### PR TITLE
fix: 修复 OpenAI 账号 5h/7d 使用限制显示错误的问题

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -879,8 +879,12 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 		// No window_minutes available: cannot reliably determine window types
 		// Fall back to legacy assumption (may be incorrect)
 		// Assume primary=7d, secondary=5h based on historical observation
-		use5hFromSecondary = snapshot.SecondaryUsedPercent != nil
-		use7dFromPrimary = snapshot.PrimaryUsedPercent != nil
+		if snapshot.SecondaryUsedPercent != nil || snapshot.SecondaryResetAfterSeconds != nil || snapshot.SecondaryWindowMinutes != nil {
+			use5hFromSecondary = true
+		}
+		if snapshot.PrimaryUsedPercent != nil || snapshot.PrimaryResetAfterSeconds != nil || snapshot.PrimaryWindowMinutes != nil {
+			use7dFromPrimary = true
+		}
 	}
 
 	// Write canonical 5h fields

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -69,21 +69,21 @@
     <!-- OpenAI OAuth accounts: show Codex usage from extra field -->
     <template v-else-if="account.platform === 'openai' && account.type === 'oauth'">
       <div v-if="hasCodexUsage" class="space-y-1">
-        <!-- 5h Window (Secondary) -->
+        <!-- 5h Window -->
         <UsageProgressBar
-          v-if="codexSecondaryUsedPercent !== null"
+          v-if="codex5hUsedPercent !== null"
           label="5h"
-          :utilization="codexSecondaryUsedPercent"
-          :resets-at="codexSecondaryResetAt"
+          :utilization="codex5hUsedPercent"
+          :resets-at="codex5hResetAt"
           color="indigo"
         />
 
-        <!-- Weekly Window (Primary) -->
+        <!-- 7d Window -->
         <UsageProgressBar
-          v-if="codexPrimaryUsedPercent !== null"
+          v-if="codex7dUsedPercent !== null"
           label="7d"
-          :utilization="codexPrimaryUsedPercent"
-          :resets-at="codexPrimaryResetAt"
+          :utilization="codex7dUsedPercent"
+          :resets-at="codex7dResetAt"
           color="emerald"
         />
       </div>
@@ -125,35 +125,123 @@ const showUsageWindows = computed(() =>
 const hasCodexUsage = computed(() => {
   const extra = props.account.extra
   return extra && (
+    // Check for new canonical fields first
+    extra.codex_5h_used_percent !== undefined ||
+    extra.codex_7d_used_percent !== undefined ||
+    // Fallback to legacy fields
     extra.codex_primary_used_percent !== undefined ||
     extra.codex_secondary_used_percent !== undefined
   )
 })
 
-const codexPrimaryUsedPercent = computed(() => {
+// 5h window usage (prefer canonical field)
+const codex5hUsedPercent = computed(() => {
   const extra = props.account.extra
-  if (!extra || extra.codex_primary_used_percent === undefined) return null
-  return extra.codex_primary_used_percent
+  if (!extra) return null
+
+  // Prefer canonical field
+  if (extra.codex_5h_used_percent !== undefined) {
+    return extra.codex_5h_used_percent
+  }
+
+  // Fallback: detect from legacy fields using window_minutes
+  if (extra.codex_primary_window_minutes !== undefined && extra.codex_primary_window_minutes <= 360) {
+    return extra.codex_primary_used_percent ?? null
+  }
+  if (extra.codex_secondary_window_minutes !== undefined && extra.codex_secondary_window_minutes <= 360) {
+    return extra.codex_secondary_used_percent ?? null
+  }
+
+  // Legacy assumption: secondary = 5h (may be incorrect)
+  return extra.codex_secondary_used_percent ?? null
 })
 
-const codexSecondaryUsedPercent = computed(() => {
+const codex5hResetAt = computed(() => {
   const extra = props.account.extra
-  if (!extra || extra.codex_secondary_used_percent === undefined) return null
-  return extra.codex_secondary_used_percent
+  if (!extra) return null
+
+  // Prefer canonical field
+  if (extra.codex_5h_reset_after_seconds !== undefined) {
+    const resetTime = new Date(Date.now() + extra.codex_5h_reset_after_seconds * 1000)
+    return resetTime.toISOString()
+  }
+
+  // Fallback: detect from legacy fields using window_minutes
+  if (extra.codex_primary_window_minutes !== undefined && extra.codex_primary_window_minutes <= 360) {
+    if (extra.codex_primary_reset_after_seconds !== undefined) {
+      const resetTime = new Date(Date.now() + extra.codex_primary_reset_after_seconds * 1000)
+      return resetTime.toISOString()
+    }
+  }
+  if (extra.codex_secondary_window_minutes !== undefined && extra.codex_secondary_window_minutes <= 360) {
+    if (extra.codex_secondary_reset_after_seconds !== undefined) {
+      const resetTime = new Date(Date.now() + extra.codex_secondary_reset_after_seconds * 1000)
+      return resetTime.toISOString()
+    }
+  }
+
+  // Legacy assumption: secondary = 5h
+  if (extra.codex_secondary_reset_after_seconds !== undefined) {
+    const resetTime = new Date(Date.now() + extra.codex_secondary_reset_after_seconds * 1000)
+    return resetTime.toISOString()
+  }
+
+  return null
 })
 
-const codexPrimaryResetAt = computed(() => {
+// 7d window usage (prefer canonical field)
+const codex7dUsedPercent = computed(() => {
   const extra = props.account.extra
-  if (!extra || extra.codex_primary_reset_after_seconds === undefined) return null
-  const resetTime = new Date(Date.now() + extra.codex_primary_reset_after_seconds * 1000)
-  return resetTime.toISOString()
+  if (!extra) return null
+
+  // Prefer canonical field
+  if (extra.codex_7d_used_percent !== undefined) {
+    return extra.codex_7d_used_percent
+  }
+
+  // Fallback: detect from legacy fields using window_minutes
+  if (extra.codex_primary_window_minutes !== undefined && extra.codex_primary_window_minutes >= 10000) {
+    return extra.codex_primary_used_percent ?? null
+  }
+  if (extra.codex_secondary_window_minutes !== undefined && extra.codex_secondary_window_minutes >= 10000) {
+    return extra.codex_secondary_used_percent ?? null
+  }
+
+  // Legacy assumption: primary = 7d (may be incorrect)
+  return extra.codex_primary_used_percent ?? null
 })
 
-const codexSecondaryResetAt = computed(() => {
+const codex7dResetAt = computed(() => {
   const extra = props.account.extra
-  if (!extra || extra.codex_secondary_reset_after_seconds === undefined) return null
-  const resetTime = new Date(Date.now() + extra.codex_secondary_reset_after_seconds * 1000)
-  return resetTime.toISOString()
+  if (!extra) return null
+
+  // Prefer canonical field
+  if (extra.codex_7d_reset_after_seconds !== undefined) {
+    const resetTime = new Date(Date.now() + extra.codex_7d_reset_after_seconds * 1000)
+    return resetTime.toISOString()
+  }
+
+  // Fallback: detect from legacy fields using window_minutes
+  if (extra.codex_primary_window_minutes !== undefined && extra.codex_primary_window_minutes >= 10000) {
+    if (extra.codex_primary_reset_after_seconds !== undefined) {
+      const resetTime = new Date(Date.now() + extra.codex_primary_reset_after_seconds * 1000)
+      return resetTime.toISOString()
+    }
+  }
+  if (extra.codex_secondary_window_minutes !== undefined && extra.codex_secondary_window_minutes >= 10000) {
+    if (extra.codex_secondary_reset_after_seconds !== undefined) {
+      const resetTime = new Date(Date.now() + extra.codex_secondary_reset_after_seconds * 1000)
+      return resetTime.toISOString()
+    }
+  }
+
+  // Legacy assumption: primary = 7d
+  if (extra.codex_primary_reset_after_seconds !== undefined) {
+    const resetTime = new Date(Date.now() + extra.codex_primary_reset_after_seconds * 1000)
+    return resetTime.toISOString()
+  }
+
+  return null
 })
 
 const loadUsage = async () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -366,13 +366,24 @@ export interface AccountUsageInfo {
 
 // OpenAI Codex usage snapshot (from response headers)
 export interface CodexUsageSnapshot {
-  codex_primary_used_percent?: number;        // Weekly limit usage percentage
-  codex_primary_reset_after_seconds?: number; // Seconds until weekly reset
-  codex_primary_window_minutes?: number;      // Weekly window in minutes
-  codex_secondary_used_percent?: number;      // 5h limit usage percentage
-  codex_secondary_reset_after_seconds?: number; // Seconds until 5h reset
-  codex_secondary_window_minutes?: number;    // 5h window in minutes
+  // Legacy fields (kept for backwards compatibility)
+  // NOTE: The naming is ambiguous - actual window type is determined by window_minutes value
+  codex_primary_used_percent?: number;        // Usage percentage (check window_minutes for actual window type)
+  codex_primary_reset_after_seconds?: number; // Seconds until reset
+  codex_primary_window_minutes?: number;      // Window in minutes
+  codex_secondary_used_percent?: number;      // Usage percentage (check window_minutes for actual window type)
+  codex_secondary_reset_after_seconds?: number; // Seconds until reset
+  codex_secondary_window_minutes?: number;    // Window in minutes
   codex_primary_over_secondary_percent?: number; // Overflow ratio
+
+  // Canonical fields (normalized by backend, use these preferentially)
+  codex_5h_used_percent?: number;             // 5-hour window usage percentage
+  codex_5h_reset_after_seconds?: number;      // Seconds until 5h window reset
+  codex_5h_window_minutes?: number;           // 5h window in minutes (should be ~300)
+  codex_7d_used_percent?: number;             // 7-day window usage percentage
+  codex_7d_reset_after_seconds?: number;      // Seconds until 7d window reset
+  codex_7d_window_minutes?: number;           // 7d window in minutes (should be ~10080)
+
   codex_usage_updated_at?: string;            // Last update timestamp
 }
 


### PR DESCRIPTION
问题描述:
- 账号管理页面中,OpenAI OAuth 账号的 5h 列显示 7 天的剩余时间
- 7d 列却显示几小时的剩余时间
- 根本原因: OpenAI 响应头中 primary/secondary 的实际含义与代码假设相反

修复方案:
1. 后端归一化 (openai_gateway_service.go):
   - 根据 window_minutes 动态判断哪个是 5h/7d 限制
   - 新增规范字段 codex_5h_* 和 codex_7d_*
   - 保留旧字段以兼容性

2. 前端适配 (AccountUsageCell.vue):
   - 优先使用新的规范字段
   - Fallback 到旧字段时基于 window_minutes 动态判断
   - 更新 computed 属性命名

3. 类型定义更新 (types/index.ts):
   - 添加新的规范字段定义
   - 更新注释说明实际语义由 window_minutes 决定

🤖 Generated with Claude Code and Codex collaboration