### PR TITLE
feat: update gemini models to support 3, 2.5, 2.0 and 1.5 series

### DIFF
--- a/backend/internal/pkg/gemini/models.go
+++ b/backend/internal/pkg/gemini/models.go
@@ -21,7 +21,7 @@ func DefaultModels() []Model {
 		{Name: "models/gemini-3-flash-preview", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-2.5-pro", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-2.5-flash", SupportedGenerationMethods: methods},
-		{Name: "models/gemini-2.0-pro-exp-02-05", SupportedGenerationMethods: methods},
+		{Name: "models/gemini-2.0-pro", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-2.0-flash", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-1.5-pro", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-1.5-flash", SupportedGenerationMethods: methods},

--- a/backend/internal/pkg/geminicli/models.go
+++ b/backend/internal/pkg/geminicli/models.go
@@ -15,7 +15,7 @@ var DefaultModels = []Model{
 	{ID: "gemini-3-flash-preview", Type: "model", DisplayName: "Gemini 3 Flash (Preview)", CreatedAt: ""},
 	{ID: "gemini-2.5-pro", Type: "model", DisplayName: "Gemini 2.5 Pro", CreatedAt: ""},
 	{ID: "gemini-2.5-flash", Type: "model", DisplayName: "Gemini 2.5 Flash", CreatedAt: ""},
-	{ID: "gemini-2.0-pro-exp-02-05", Type: "model", DisplayName: "Gemini 2.0 Pro (Exp)", CreatedAt: ""},
+	{ID: "gemini-2.0-pro", Type: "model", DisplayName: "Gemini 2.0 Pro", CreatedAt: ""},
 	{ID: "gemini-2.0-flash", Type: "model", DisplayName: "Gemini 2.0 Flash", CreatedAt: ""},
 	{ID: "gemini-1.5-pro", Type: "model", DisplayName: "Gemini 1.5 Pro", CreatedAt: ""},
 	{ID: "gemini-1.5-flash", Type: "model", DisplayName: "Gemini 1.5 Flash", CreatedAt: ""},

--- a/backend/resources/model-pricing/model_prices_and_context_window.json
+++ b/backend/resources/model-pricing/model_prices_and_context_window.json
@@ -249,30 +249,6 @@
             "/v1/images/generations"
         ]
     },
-    "aiml/google/imagen-4.0-ultra-generate-001": {
-        "litellm_provider": "aiml",
-        "metadata": {
-            "notes": "Imagen 4.0 Ultra Generate API - Photorealistic image generation with precise text rendering"
-        },
-        "mode": "image_generation",
-        "output_cost_per_image": 0.063,
-        "source": "https://docs.aimlapi.com/api-references/image-models/google/imagen-4-ultra-generate",
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ]
-    },
-    "aiml/google/nano-banana-pro": {
-        "litellm_provider": "aiml",
-        "metadata": {
-            "notes": "Gemini 3 Pro Image (Nano Banana Pro) - Advanced text-to-image generation with reasoning and 4K resolution support"
-        },
-        "mode": "image_generation",
-        "output_cost_per_image": 0.1575,
-        "source": "https://docs.aimlapi.com/api-references/image-models/google/gemini-3-pro-image-preview",
-        "supported_endpoints": [
-            "/v1/images/generations"
-        ]
-    },
     "amazon.nova-canvas-v1:0": {
         "litellm_provider": "bedrock",
         "max_input_tokens": 2600,
@@ -1380,20 +1356,6 @@
         "code_interpreter_cost_per_session": 0.03,
         "litellm_provider": "azure",
         "mode": "chat"
-    },
-    "azure_ai/gpt-oss-120b": {
-        "input_cost_per_token": 1.5e-7,
-        "output_cost_per_token": 6e-7,
-        "litellm_provider": "azure_ai",
-        "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
-        "max_tokens": 131072,
-        "mode": "chat",
-        "source": "https://azure.microsoft.com/en-us/pricing/details/cognitive-services/openai-service/",
-        "supports_function_calling": true,
-        "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
-        "supports_tool_choice": true
     },
     "azure/eu/gpt-4o-2024-08-06": {
         "deprecation_date": "2026-02-27",
@@ -3532,40 +3494,6 @@
         "supports_service_tier": true,
         "supports_vision": true
     },
-    "azure/gpt-5.2-chat": {
-        "cache_read_input_token_cost": 1.75e-07,
-        "cache_read_input_token_cost_priority": 3.5e-07,
-        "input_cost_per_token": 1.75e-06,
-        "input_cost_per_token_priority": 3.5e-06,
-        "litellm_provider": "azure",
-        "max_input_tokens": 128000,
-        "max_output_tokens": 16384,
-        "max_tokens": 16384,
-        "mode": "chat",
-        "output_cost_per_token": 1.4e-05,
-        "output_cost_per_token_priority": 2.8e-05,
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
-        ],
-        "supported_modalities": [
-            "text",
-            "image"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_function_calling": true,
-        "supports_native_streaming": true,
-        "supports_parallel_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
-    },
     "azure/gpt-5.2-chat-2025-12-11": {
         "cache_read_input_token_cost": 1.75e-07,
         "cache_read_input_token_cost_priority": 3.5e-07,
@@ -3777,32 +3705,6 @@
         "output_cost_per_pixel": 0.0,
         "supported_endpoints": [
             "/v1/images/generations"
-        ]
-    },
-    "azure/gpt-image-1.5": {
-        "cache_read_input_image_token_cost": 2e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 5e-06,
-        "input_cost_per_image_token": 8e-06,
-        "litellm_provider": "azure",
-        "mode": "image_generation",
-        "output_cost_per_image_token": 3.2e-05,
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
-        ]
-    },
-    "azure/gpt-image-1.5-2025-12-16": {
-        "cache_read_input_image_token_cost": 2e-06,
-        "cache_read_input_token_cost": 1.25e-06,
-        "input_cost_per_token": 5e-06,
-        "input_cost_per_image_token": 8e-06,
-        "litellm_provider": "azure",
-        "mode": "image_generation",
-        "output_cost_per_image_token": 3.2e-05,
-        "supported_endpoints": [
-            "/v1/images/generations",
-            "/v1/images/edits"
         ]
     },
     "azure/low/1024-x-1024/gpt-image-1-mini": {
@@ -12452,7 +12354,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
         "rpm": 100000,
@@ -12501,7 +12402,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 3e-05,
         "output_cost_per_token": 3e-05,
         "rpm": 100000,
@@ -13042,49 +12942,6 @@
         "output_cost_per_token": 1.2e-05,
         "output_cost_per_token_above_200k_tokens": 1.8e-05,
         "output_cost_per_token_batches": 6e-06,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
-        "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/completions",
-            "/v1/batch"
-        ],
-        "supported_modalities": [
-            "text",
-            "image",
-            "audio",
-            "video"
-        ],
-        "supported_output_modalities": [
-            "text"
-        ],
-        "supports_audio_input": true,
-        "supports_function_calling": true,
-        "supports_pdf_input": true,
-        "supports_prompt_caching": true,
-        "supports_reasoning": true,
-        "supports_response_schema": true,
-        "supports_system_messages": true,
-        "supports_tool_choice": true,
-        "supports_video_input": true,
-        "supports_vision": true,
-        "supports_web_search": true
-    },
-    "vertex_ai/gemini-3-flash-preview": {
-        "cache_read_input_token_cost": 5e-08,
-        "input_cost_per_token": 5e-07,
-        "input_cost_per_audio_token": 1e-06,
-        "litellm_provider": "vertex_ai",
-        "max_audio_length_hours": 8.4,
-        "max_audio_per_prompt": 1,
-        "max_images_per_prompt": 3000,
-        "max_input_tokens": 1048576,
-        "max_output_tokens": 65535,
-        "max_pdf_size_mb": 30,
-        "max_tokens": 65535,
-        "max_video_length": 1,
-        "max_videos_per_prompt": 10,
-        "mode": "chat",
-        "output_cost_per_token": 3e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -14235,7 +14092,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
         "rpm": 100000,
@@ -14284,7 +14140,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 3e-05,
         "output_cost_per_token": 3e-05,
         "rpm": 100000,
@@ -15462,34 +15317,6 @@
             "video"
         ]
     },
-    "gemini/veo-3.1-fast-generate-001": {
-        "litellm_provider": "gemini",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "gemini/veo-3.1-generate-001": {
-        "litellm_provider": "gemini",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.40,
-        "source": "https://ai.google.dev/gemini-api/docs/video",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
     "github_copilot/claude-haiku-4.5": {
         "litellm_provider": "github_copilot",
         "max_input_tokens": 128000,
@@ -15497,7 +15324,7 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15510,7 +15337,7 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15523,7 +15350,7 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_vision": true
     },
@@ -15534,7 +15361,7 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15547,7 +15374,7 @@
         "max_tokens": 16000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions"
+            "/chat/completions"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15704,8 +15531,8 @@
         "max_tokens": 128000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/chat/completions",
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15730,8 +15557,8 @@
         "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/chat/completions",
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15745,7 +15572,7 @@
         "max_tokens": 128000,
         "mode": "responses",
         "supported_endpoints": [
-            "/v1/responses"
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -15759,8 +15586,8 @@
         "max_tokens": 64000,
         "mode": "chat",
         "supported_endpoints": [
-            "/v1/chat/completions",
-            "/v1/responses"
+            "/chat/completions",
+            "/responses"
         ],
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
@@ -16962,8 +16789,7 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ],
-        "supports_vision": true,
-        "supports_pdf_input": true
+        "supports_vision": true
     },
     "gpt-image-1.5-2025-12-16": {
         "cache_read_input_image_token_cost": 2e-06,
@@ -16977,8 +16803,7 @@
         "supported_endpoints": [
             "/v1/images/generations"
         ],
-        "supports_vision": true,
-        "supports_pdf_input": true
+        "supports_vision": true
     },
     "gpt-5": {
         "cache_read_input_token_cost": 1.25e-07,
@@ -18151,6 +17976,75 @@
         "supports_response_schema": true,
         "supports_vision": true
     },
+    "groq/deepseek-r1-distill-llama-70b": {
+        "input_cost_per_token": 7.5e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 128000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "mode": "chat",
+        "output_cost_per_token": 9.9e-07,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/distil-whisper-large-v3-en": {
+        "input_cost_per_second": 5.56e-06,
+        "litellm_provider": "groq",
+        "mode": "audio_transcription",
+        "output_cost_per_second": 0.0
+    },
+    "groq/gemma-7b-it": {
+        "deprecation_date": "2024-12-18",
+        "input_cost_per_token": 7e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/gemma2-9b-it": {
+        "input_cost_per_token": 2e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 2e-07,
+        "supports_function_calling": false,
+        "supports_response_schema": false,
+        "supports_tool_choice": false
+    },
+    "groq/llama-3.1-405b-reasoning": {
+        "input_cost_per_token": 5.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.1-70b-versatile": {
+        "deprecation_date": "2025-01-24",
+        "input_cost_per_token": 5.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 7.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
     "groq/llama-3.1-8b-instant": {
         "input_cost_per_token": 5e-08,
         "litellm_provider": "groq",
@@ -18161,6 +18055,97 @@
         "output_cost_per_token": 8e-08,
         "supports_function_calling": true,
         "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-11b-text-preview": {
+        "deprecation_date": "2024-10-28",
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-11b-vision-preview": {
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 1.8e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.8e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "groq/llama-3.2-1b-preview": {
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 4e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 4e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-3b-preview": {
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 6e-08,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 6e-08,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-90b-text-preview": {
+        "deprecation_date": "2024-11-25",
+        "input_cost_per_token": 9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama-3.2-90b-vision-preview": {
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true,
+        "supports_vision": true
+    },
+    "groq/llama-3.3-70b-specdec": {
+        "deprecation_date": "2025-04-14",
+        "input_cost_per_token": 5.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 9.9e-07,
         "supports_tool_choice": true
     },
     "groq/llama-3.3-70b-versatile": {
@@ -18175,7 +18160,7 @@
         "supports_response_schema": false,
         "supports_tool_choice": true
     },
-    "groq/meta-llama/llama-guard-4-12b": {
+    "groq/llama-guard-3-8b": {
         "input_cost_per_token": 2e-07,
         "litellm_provider": "groq",
         "max_input_tokens": 8192,
@@ -18183,6 +18168,44 @@
         "max_tokens": 8192,
         "mode": "chat",
         "output_cost_per_token": 2e-07
+    },
+    "groq/llama2-70b-4096": {
+        "input_cost_per_token": 7e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 4096,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "chat",
+        "output_cost_per_token": 8e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama3-groq-70b-8192-tool-use-preview": {
+        "deprecation_date": "2025-01-06",
+        "input_cost_per_token": 8.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 8.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/llama3-groq-8b-8192-tool-use-preview": {
+        "deprecation_date": "2025-01-06",
+        "input_cost_per_token": 1.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 8192,
+        "max_output_tokens": 8192,
+        "max_tokens": 8192,
+        "mode": "chat",
+        "output_cost_per_token": 1.9e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
     },
     "groq/meta-llama/llama-4-maverick-17b-128e-instruct": {
         "input_cost_per_token": 2e-07,
@@ -18194,8 +18217,7 @@
         "output_cost_per_token": 6e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
     },
     "groq/meta-llama/llama-4-scout-17b-16e-instruct": {
         "input_cost_per_token": 1.1e-07,
@@ -18207,8 +18229,41 @@
         "output_cost_per_token": 3.4e-07,
         "supports_function_calling": true,
         "supports_response_schema": true,
-        "supports_tool_choice": true,
-        "supports_vision": true
+        "supports_tool_choice": true
+    },
+    "groq/mistral-saba-24b": {
+        "input_cost_per_token": 7.9e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 32000,
+        "max_output_tokens": 32000,
+        "max_tokens": 32000,
+        "mode": "chat",
+        "output_cost_per_token": 7.9e-07
+    },
+    "groq/mixtral-8x7b-32768": {
+        "deprecation_date": "2025-03-20",
+        "input_cost_per_token": 2.4e-07,
+        "litellm_provider": "groq",
+        "max_input_tokens": 32768,
+        "max_output_tokens": 32768,
+        "max_tokens": 32768,
+        "mode": "chat",
+        "output_cost_per_token": 2.4e-07,
+        "supports_function_calling": true,
+        "supports_response_schema": false,
+        "supports_tool_choice": true
+    },
+    "groq/moonshotai/kimi-k2-instruct": {
+        "input_cost_per_token": 1e-06,
+        "litellm_provider": "groq",
+        "max_input_tokens": 131072,
+        "max_output_tokens": 16384,
+        "max_tokens": 131072,
+        "mode": "chat",
+        "output_cost_per_token": 3e-06,
+        "supports_function_calling": true,
+        "supports_response_schema": true,
+        "supports_tool_choice": true
     },
     "groq/moonshotai/kimi-k2-instruct-0905": {
         "input_cost_per_token": 1e-06,
@@ -19447,80 +19502,6 @@
         "mode": "chat",
         "output_cost_per_token": 1.2e-06,
         "supports_system_messages": true
-    },
-    "minimax/speech-02-hd": {
-        "input_cost_per_character": 0.0001,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/speech-02-turbo": {
-        "input_cost_per_character": 0.00006,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/speech-2.6-hd": {
-        "input_cost_per_character": 0.0001,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/speech-2.6-turbo": {
-        "input_cost_per_character": 0.00006,
-        "litellm_provider": "minimax",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ]
-    },
-    "minimax/MiniMax-M2.1": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
-    "minimax/MiniMax-M2.1-lightning": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 2.4e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 1000000,
-        "max_output_tokens": 8192
-    },
-    "minimax/MiniMax-M2": {
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "cache_read_input_token_cost": 3e-08,
-        "cache_creation_input_token_cost": 3.75e-07,
-        "litellm_provider": "minimax",
-        "mode": "chat",
-        "supports_function_calling": true,
-        "supports_tool_choice": true,
-        "supports_prompt_caching": true,
-        "supports_system_messages": true,
-        "max_input_tokens": 200000,
-        "max_output_tokens": 8192
     },
     "mistral.magistral-small-2509": {
         "input_cost_per_token": 5e-07,
@@ -22363,7 +22344,7 @@
         "input_cost_per_token": 0,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
+        "max_output_tokens": null,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 0,
@@ -22391,7 +22372,7 @@
         "input_cost_per_token": 1e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 131072,
-        "max_output_tokens": 131072,
+        "max_output_tokens": null,
         "max_tokens": 131072,
         "mode": "chat",
         "output_cost_per_token": 1e-07,
@@ -22405,7 +22386,7 @@
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
+        "max_output_tokens": null,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 1.5e-07,
@@ -22419,7 +22400,7 @@
         "input_cost_per_token": 2e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
+        "max_output_tokens": null,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 2e-07,
@@ -22433,7 +22414,7 @@
         "input_cost_per_token": 5e-07,
         "litellm_provider": "openrouter",
         "max_input_tokens": 262144,
-        "max_output_tokens": 262144,
+        "max_output_tokens": null,
         "max_tokens": 262144,
         "mode": "chat",
         "output_cost_per_token": 1.5e-06,
@@ -24453,90 +24434,6 @@
         "output_cost_per_image": 0.08,
         "supported_endpoints": ["/v1/images/generations"]
     },
-    "stability/inpaint": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/outpaint": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.004,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/erase": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/search-and-replace": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/search-and-recolor": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/remove-background": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/replace-background-and-relight": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.008,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/sketch": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/structure": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/style": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.005,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/style-transfer": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.008,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/fast": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.002,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/conservative": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.04,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
-    "stability/creative": {
-        "litellm_provider": "stability",
-        "mode": "image_edit",
-        "output_cost_per_image": 0.06,
-        "supported_endpoints": ["/v1/images/edits"]
-    },
     "stability/stable-image-core": {
         "litellm_provider": "stability",
         "mode": "image_generation",
@@ -24563,84 +24460,6 @@
         "max_tokens": 77,
         "mode": "image_generation",
         "output_cost_per_image": 0.04
-    },
-    "stability.stable-conservative-upscale-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.40
-    },
-    "stability.stable-creative-upscale-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.60
-    },
-    "stability.stable-fast-upscale-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.03
-    },
-    "stability.stable-outpaint-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.06
-    },
-    "stability.stable-image-control-sketch-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-control-structure-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-erase-object-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-inpaint-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-remove-background-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-search-recolor-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-search-replace-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-image-style-guide-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.07
-    },
-    "stability.stable-style-transfer-v1:0": {
-        "litellm_provider": "bedrock",
-        "max_input_tokens": 77,
-        "mode": "image_edit",
-        "output_cost_per_image": 0.08
     },
     "stability.stable-image-core-v1:1": {
         "litellm_provider": "bedrock",
@@ -24680,16 +24499,6 @@
         "litellm_provider": "openai",
         "mode": "image_generation",
         "output_cost_per_pixel": 0.0
-    },
-    "linkup/search": {
-        "input_cost_per_query": 5.87e-03,
-        "litellm_provider": "linkup",
-        "mode": "search"
-    },
-    "linkup/search-deep": {
-        "input_cost_per_query": 58.67e-03,
-        "litellm_provider": "linkup",
-        "mode": "search"
     },
     "tavily/search": {
         "input_cost_per_query": 0.008,
@@ -25053,7 +24862,6 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen2.5-7B-Instruct-Turbo": {
@@ -25061,7 +24869,6 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Instruct-2507-tput": {
@@ -25073,7 +24880,6 @@
         "source": "https://www.together.ai/models/qwen3-235b-a22b-instruct-2507-fp8",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-Thinking-2507": {
@@ -25085,7 +24891,6 @@
         "source": "https://www.together.ai/models/qwen3-235b-a22b-thinking-2507",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
@@ -25108,7 +24913,6 @@
         "source": "https://www.together.ai/models/qwen3-coder-480b-a35b-instruct",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1": {
@@ -25121,7 +24925,6 @@
         "output_cost_per_token": 7e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-R1-0528-tput": {
@@ -25133,7 +24936,6 @@
         "source": "https://www.together.ai/models/deepseek-r1-0528-throughput",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-V3": {
@@ -25146,7 +24948,6 @@
         "output_cost_per_token": 1.25e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/deepseek-ai/DeepSeek-V3.1": {
@@ -25166,7 +24967,6 @@
         "mode": "chat",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo": {
@@ -25196,7 +24996,6 @@
         "output_cost_per_token": 8.5e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Llama-4-Scout-17B-16E-Instruct": {
@@ -25206,7 +25005,6 @@
         "output_cost_per_token": 5.9e-07,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo": {
@@ -25216,7 +25014,6 @@
         "output_cost_per_token": 3.5e-06,
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo": {
@@ -25272,7 +25069,6 @@
         "source": "https://www.together.ai/models/kimi-k2-instruct",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/openai/gpt-oss-120b": {
@@ -25284,7 +25080,6 @@
         "source": "https://www.together.ai/models/gpt-oss-120b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/openai/gpt-oss-20b": {
@@ -25296,7 +25091,6 @@
         "source": "https://www.together.ai/models/gpt-oss-20b",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/togethercomputer/CodeLlama-34b-Instruct": {
@@ -25315,7 +25109,6 @@
         "source": "https://www.together.ai/models/glm-4-5-air",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/zai-org/GLM-4.6": {
@@ -25352,7 +25145,6 @@
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-instruct",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "together_ai/Qwen/Qwen3-Next-80B-A3B-Thinking": {
@@ -25364,7 +25156,6 @@
         "source": "https://www.together.ai/models/qwen3-next-80b-a3b-thinking",
         "supports_function_calling": true,
         "supports_parallel_function_calling": true,
-        "supports_response_schema": true,
         "supports_tool_choice": true
     },
     "tts-1": {
@@ -25382,42 +25173,6 @@
         "supported_endpoints": [
             "/v1/audio/speech"
         ]
-    },
-    "aws_polly/standard": {
-        "input_cost_per_character": 4e-06,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
-    "aws_polly/neural": {
-        "input_cost_per_character": 1.6e-05,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
-    "aws_polly/long-form": {
-        "input_cost_per_character": 1e-04,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
-    },
-    "aws_polly/generative": {
-        "input_cost_per_character": 3e-05,
-        "litellm_provider": "aws_polly",
-        "mode": "audio_speech",
-        "supported_endpoints": [
-            "/v1/audio/speech"
-        ],
-        "source": "https://aws.amazon.com/polly/pricing/"
     },
     "us.amazon.nova-lite-v1:0": {
         "input_cost_per_token": 6e-08,
@@ -27479,7 +27234,6 @@
         "max_videos_per_prompt": 10,
         "mode": "image_generation",
         "output_cost_per_image": 0.039,
-        "output_cost_per_image_token": 3e-05,
         "output_cost_per_reasoning_token": 2.5e-06,
         "output_cost_per_token": 2.5e-06,
         "rpm": 100000,
@@ -27963,14 +27717,6 @@
         ],
         "source": "https://cloud.google.com/generative-ai-app-builder/pricing"
     },
-    "vertex_ai/deepseek-ai/deepseek-ocr-maas": {
-        "litellm_provider": "vertex_ai",
-        "mode": "ocr",
-        "input_cost_per_token": 3e-07,
-        "output_cost_per_token": 1.2e-06,
-        "ocr_cost_per_page": 3e-04,
-        "source": "https://cloud.google.com/vertex-ai/pricing"
-    },
     "vertex_ai/openai/gpt-oss-120b-maas": {
         "input_cost_per_token": 1.5e-07,
         "litellm_provider": "vertex_ai-openai_models",
@@ -28126,34 +27872,6 @@
         ]
     },
     "vertex_ai/veo-3.1-fast-generate-preview": {
-        "litellm_provider": "vertex_ai-video-models",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.15,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "vertex_ai/veo-3.1-generate-001": {
-        "litellm_provider": "vertex_ai-video-models",
-        "max_input_tokens": 1024,
-        "max_tokens": 1024,
-        "mode": "video_generation",
-        "output_cost_per_second": 0.4,
-        "source": "https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/veo",
-        "supported_modalities": [
-            "text"
-        ],
-        "supported_output_modalities": [
-            "video"
-        ]
-    },
-    "vertex_ai/veo-3.1-fast-generate-001": {
         "litellm_provider": "vertex_ai-video-models",
         "max_input_tokens": 1024,
         "max_tokens": 1024,
@@ -29598,8 +29316,7 @@
         "input_cost_per_token": 4.5e-07,
         "output_cost_per_token": 1.8e-06,
         "litellm_provider": "fireworks_ai",
-        "mode": "chat",
-        "supports_reasoning": true
+        "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/flux-kontext-pro": {
         "max_tokens": 4096,
@@ -31301,8 +31018,7 @@
         "input_cost_per_token": 9e-07,
         "output_cost_per_token": 9e-07,
         "litellm_provider": "fireworks_ai",
-        "mode": "chat",
-        "supports_reasoning": true
+        "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-4b": {
         "max_tokens": 40960,
@@ -31329,8 +31045,7 @@
         "input_cost_per_token": 2e-07,
         "output_cost_per_token": 2e-07,
         "litellm_provider": "fireworks_ai",
-        "mode": "chat",
-        "supports_reasoning": true
+        "mode": "chat"
     },
     "fireworks_ai/accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
         "max_tokens": 262144,


### PR DESCRIPTION
## Summary
- 更新 Gemini 模型支持，添加 3、2.5、2.0 和 1.5 系列模型
- 扩展模型映射配置，支持更多 Gemini 模型变体

## Changes
- `backend/internal/pkg/gemini/models.go`: 更新模型映射
- `backend/internal/pkg/geminicli/models.go`: 更新 CLI 模型配置

## Test plan
- [ ] 验证新模型能正确映射
- [ ] 测试 API 调用兼容性