### PR TITLE
fix: implement token invalidation on password change

### DIFF
--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -198,6 +198,7 @@ type userModel struct {
 	Concurrency   int            `gorm:"default:5;not null"`
 	Status        string         `gorm:"size:20;default:active;not null"`
 	AllowedGroups pq.Int64Array  `gorm:"type:bigint[]"`
+	TokenVersion  int64          `gorm:"default:0;not null"` // Incremented on password change
 	CreatedAt     time.Time      `gorm:"not null"`
 	UpdatedAt     time.Time      `gorm:"not null"`
 	DeletedAt     gorm.DeletedAt `gorm:"index"`
@@ -221,6 +222,7 @@ func userModelToService(m *userModel) *service.User {
 		Concurrency:   m.Concurrency,
 		Status:        m.Status,
 		AllowedGroups: []int64(m.AllowedGroups),
+		TokenVersion:  m.TokenVersion,
 		CreatedAt:     m.CreatedAt,
 		UpdatedAt:     m.UpdatedAt,
 	}
@@ -242,6 +244,7 @@ func userModelFromService(u *service.User) *userModel {
 		Concurrency:   u.Concurrency,
 		Status:        u.Status,
 		AllowedGroups: pq.Int64Array(u.AllowedGroups),
+		TokenVersion:  u.TokenVersion,
 		CreatedAt:     u.CreatedAt,
 		UpdatedAt:     u.UpdatedAt,
 	}
@@ -252,6 +255,7 @@ func applyUserModelToService(dst *service.User, src *userModel) {
 		return
 	}
 	dst.ID = src.ID
+	dst.TokenVersion = src.TokenVersion
 	dst.CreatedAt = src.CreatedAt
 	dst.UpdatedAt = src.UpdatedAt
 }

--- a/backend/internal/server/middleware/jwt_auth.go
+++ b/backend/internal/server/middleware/jwt_auth.go
@@ -61,6 +61,13 @@ func jwtAuth(authService *service.AuthService, userService *service.UserService)
 			return
 		}
 
+		// Security: Validate TokenVersion to ensure token hasn't been invalidated
+		// This check ensures tokens issued before a password change are rejected
+		if claims.TokenVersion != user.TokenVersion {
+			AbortWithError(c, 401, "TOKEN_REVOKED", "Token has been revoked (password changed)")
+			return
+		}
+
 		c.Set(string(ContextKeyUser), AuthSubject{
 			UserID:      user.ID,
 			Concurrency: user.Concurrency,

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -20,6 +20,7 @@ var (
 	ErrEmailExists         = infraerrors.Conflict("EMAIL_EXISTS", "email already exists")
 	ErrInvalidToken        = infraerrors.Unauthorized("INVALID_TOKEN", "invalid token")
 	ErrTokenExpired        = infraerrors.Unauthorized("TOKEN_EXPIRED", "token has expired")
+	ErrTokenRevoked        = infraerrors.Unauthorized("TOKEN_REVOKED", "token has been revoked")
 	ErrEmailVerifyRequired = infraerrors.BadRequest("EMAIL_VERIFY_REQUIRED", "email verification is required")
 	ErrRegDisabled         = infraerrors.Forbidden("REGISTRATION_DISABLED", "registration is currently disabled")
 	ErrServiceUnavailable  = infraerrors.ServiceUnavailable("SERVICE_UNAVAILABLE", "service temporarily unavailable")
@@ -27,9 +28,10 @@ var (
 
 // JWTClaims JWT载荷数据
 type JWTClaims struct {
-	UserID int64  `json:"user_id"`
-	Email  string `json:"email"`
-	Role   string `json:"role"`
+	UserID       int64  `json:"user_id"`
+	Email        string `json:"email"`
+	Role         string `json:"role"`
+	TokenVersion int64  `json:"token_version"` // Used to invalidate tokens on password change
 	jwt.RegisteredClaims
 }
 
@@ -311,9 +313,10 @@ func (s *AuthService) GenerateToken(user *User) (string, error) {
 	expiresAt := now.Add(time.Duration(s.cfg.JWT.ExpireHour) * time.Hour)
 
 	claims := &JWTClaims{
-		UserID: user.ID,
-		Email:  user.Email,
-		Role:   user.Role,
+		UserID:       user.ID,
+		Email:        user.Email,
+		Role:         user.Role,
+		TokenVersion: user.TokenVersion,
 		RegisteredClaims: jwt.RegisteredClaims{
 			ExpiresAt: jwt.NewNumericDate(expiresAt),
 			IssuedAt:  jwt.NewNumericDate(now),
@@ -366,6 +369,12 @@ func (s *AuthService) RefreshToken(ctx context.Context, oldTokenString string) (
 	// 检查用户状态
 	if !user.IsActive() {
 		return "", ErrUserNotActive
+	}
+
+	// Security: Check TokenVersion to prevent refreshing revoked tokens
+	// This ensures tokens issued before a password change cannot be refreshed
+	if claims.TokenVersion != user.TokenVersion {
+		return "", ErrTokenRevoked
 	}
 
 	// 生成新token

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -18,6 +18,7 @@ type User struct {
 	Concurrency   int
 	Status        string
 	AllowedGroups []int64
+	TokenVersion  int64 // Incremented on password change to invalidate existing tokens
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
 

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -116,6 +116,7 @@ func (s *UserService) UpdateProfile(ctx context.Context, userID int64, req Updat
 }
 
 // ChangePassword 修改密码
+// Security: Increments TokenVersion to invalidate all existing JWT tokens
 func (s *UserService) ChangePassword(ctx context.Context, userID int64, req ChangePasswordRequest) error {
 	user, err := s.userRepo.GetByID(ctx, userID)
 	if err != nil {
@@ -130,6 +131,10 @@ func (s *UserService) ChangePassword(ctx context.Context, userID int64, req Chan
 	if err := user.SetPassword(req.NewPassword); err != nil {
 		return fmt.Errorf("set password: %w", err)
 	}
+
+	// Increment TokenVersion to invalidate all existing tokens
+	// This ensures that any tokens issued before the password change become invalid
+	user.TokenVersion++
 
 	if err := s.userRepo.Update(ctx, user); err != nil {
 		return fmt.Errorf("update user: %w", err)


### PR DESCRIPTION
此拉取请求通过实现密码更改时的令牌失效机制，对身份验证系统进行了安全增强。核心思路是在用户模型中添加 `TokenVersion` 字段，每当用户更改密码时该字段递增。JWT 令牌现在包含此版本号，系统在每次请求和令牌刷新时都会检查该版本号，以确保密码更改前签发的令牌失效。

最重要的更改如下：

**用户模型和服务更新：**
* 在 `userModel` 和 `User` 结构体中添加了 `TokenVersion` 字段，该字段持久化存储在数据库中，并包含在服务层转换中。此字段在密码更改时递增，以使所有现有令牌失效。

**JWT 令牌处理：**
* 更新了 `JWTClaims` 结构体和令牌生成逻辑，在 JWT 中包含 `TokenVersion`，确保每个令牌都与当前用户令牌版本绑定。

**身份验证中间件和令牌刷新：**
* 修改了 JWT 身份验证中间件，如果令牌的 `TokenVersion` 与用户的当前版本不匹配，则拒绝该令牌，从而在密码更改后有效撤销令牌。
* 更新了令牌刷新逻辑，防止刷新因密码更改而失效的令牌。

**密码更改逻辑：**
* 增强了 `ChangePassword` 方法，在成功更改密码后递增用户的 `TokenVersion`，确保所有先前签发的令牌失效。

**错误处理：**
* 引入了新的 `ErrTokenRevoked` 错误，用于标准化因密码更改导致令牌失效时的错误响应。
