### PR TITLE
chore(docker): 明确 Docker Compose 项目名称为 sub2api

### DIFF
--- a/deploy/docker-compose-test.yml
+++ b/deploy/docker-compose-test.yml
@@ -12,6 +12,8 @@
 # No Setup Wizard needed - the system auto-initializes on first run.
 # =============================================================================
 
+name: sub2api
+
 services:
   # ===========================================================================
   # Sub2API Application

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,8 @@
 # No Setup Wizard needed - the system auto-initializes on first run.
 # =============================================================================
 
+name: sub2api
+
 services:
   # ===========================================================================
   # Sub2API Application


### PR DESCRIPTION
## 变更说明

在 docker-compose.yml 和 docker-compose-test.yml 中添加 `name: sub2api`，避免使用默认目录名作为项目名称。

## 修改内容

```yaml
name: sub2api

services:
  # ...
```

## 影响

- 项目名称: `deploy` → `sub2api`
- 网络名称: `deploy_sub2api-network` → `sub2api_sub2api-network`
- 卷名称: `deploy_sub2api_data` → `sub2api_sub2api_data`

## 容器命名冲突解决

首次部署或切换配置时，如遇到容器名称冲突错误：

```bash
Error: The container name "/sub2api-redis" is already in use
```

解决方法：

```bash
# 停止并删除旧容器
docker-compose -f docker-compose-test.yml down -v

# 重新启动
docker-compose -f docker-compose-test.yml up -d
```

## 测试结果

```bash
$ docker-compose -f docker-compose-test.yml ps
NAME               STATUS
sub2api            Up (healthy)
sub2api-postgres   Up (healthy)
sub2api-redis      Up (healthy)
```