### PR TITLE
fix(后端): 修复 Turnstile Secret Key 留空保留当前值不生效的问题

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -139,21 +139,18 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 			response.BadRequest(c, "Turnstile Site Key is required when enabled")
 			return
 		}
+		// 如果未提供 secret key，使用已保存的值（留空保留当前值）
 		if req.TurnstileSecretKey == "" {
-			response.BadRequest(c, "Turnstile Secret Key is required when enabled")
-			return
-		}
-
-		// 获取当前设置，检查参数是否有变化
-		currentSettings, err := h.settingService.GetAllSettings(c.Request.Context())
-		if err != nil {
-			response.ErrorFrom(c, err)
-			return
+			if previousSettings.TurnstileSecretKey == "" {
+				response.BadRequest(c, "Turnstile Secret Key is required when enabled")
+				return
+			}
+			req.TurnstileSecretKey = previousSettings.TurnstileSecretKey
 		}
 
 		// 当 site_key 或 secret_key 任一变化时验证（避免配置错误导致无法登录）
-		siteKeyChanged := currentSettings.TurnstileSiteKey != req.TurnstileSiteKey
-		secretKeyChanged := currentSettings.TurnstileSecretKey != req.TurnstileSecretKey
+		siteKeyChanged := previousSettings.TurnstileSiteKey != req.TurnstileSiteKey
+		secretKeyChanged := previousSettings.TurnstileSecretKey != req.TurnstileSecretKey
 		if siteKeyChanged || secretKeyChanged {
 			if err := h.turnstileService.ValidateSecretKey(c.Request.Context(), req.TurnstileSecretKey); err != nil {
 				response.ErrorFrom(c, err)


### PR DESCRIPTION
前端显示"密钥已配置，留空以保留当前值"，但后端验证逻辑直接
要求该字段非空，导致修改其他设置时报错。

修复方案：
- 当 TurnstileSecretKey 为空时，检查 previousSettings 是否有已保存的值
- 如果有，使用已保存的值而非返回错误
- 同时移除重复获取 currentSettings 的代码，直接复用 previousSettings

🤖 Generated with [Claude Code](https://claude.ai/code)