### PR TITLE
feat(crs-sync): Improve error messages and add private IP allowlist support

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -354,7 +354,8 @@ func (h *AccountHandler) SyncFromCRS(c *gin.Context) {
 		SyncProxies: syncProxies,
 	})
 	if err != nil {
-		response.ErrorFrom(c, err)
+		// Provide detailed error message for CRS sync failures
+		response.InternalError(c, "CRS sync failed: "+err.Error())
 		return
 	}
 

--- a/deploy/docker-compose-test.yml
+++ b/deploy/docker-compose-test.yml
@@ -32,6 +32,8 @@ services:
     volumes:
       # Data persistence (config.yaml will be auto-generated here)
       - sub2api_data:/app/data
+      # Mount custom config.yaml (optional, overrides auto-generated config)
+      - ./config.yaml:/app/data/config.yaml:ro
     environment:
       # =======================================================================
       # Auto Setup (REQUIRED for Docker deployment)
@@ -95,6 +97,12 @@ services:
       - GEMINI_OAUTH_CLIENT_SECRET=${GEMINI_OAUTH_CLIENT_SECRET:-}
       - GEMINI_OAUTH_SCOPES=${GEMINI_OAUTH_SCOPES:-}
       - GEMINI_QUOTA_POLICY=${GEMINI_QUOTA_POLICY:-}
+
+      # =======================================================================
+      # Security Configuration (URL Allowlist)
+      # =======================================================================
+      # Allow private IP addresses for CRS sync (for internal deployments)
+      - SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS=${SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS:-true}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     volumes:
       # Data persistence (config.yaml will be auto-generated here)
       - sub2api_data:/app/data
+      # Mount custom config.yaml (optional, overrides auto-generated config)
+      - ./config.yaml:/app/data/config.yaml:ro
     environment:
       # =======================================================================
       # Auto Setup (REQUIRED for Docker deployment)
@@ -93,9 +95,11 @@ services:
       - GEMINI_QUOTA_POLICY=${GEMINI_QUOTA_POLICY:-}
 
       # =======================================================================
-      # Security Configuration
+      # Security Configuration (URL Allowlist)
       # =======================================================================
       - SECURITY_URL_ALLOWLIST_UPSTREAM_HOSTS=${SECURITY_URL_ALLOWLIST_UPSTREAM_HOSTS:-}
+      # Allow private IP addresses for CRS sync (for internal deployments)
+      - SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS=${SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS:-false}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## 概述

改进 CRS（Claude Relay Service）同步功能：
1. **增强错误信息**，便于诊断问题
2. **私有 IP 白名单支持**，适配内网 CRS 部署
3. **灵活配置方式**，支持 config.yaml 和环境变量

---

## 改动说明

### 1. API 错误处理增强

**接口**: `/api/v1/admin/accounts/sync/crs`  
**文件**: `backend/internal/handler/admin/account_handler.go:358`

**改进前**:
```json
{
  "code": 500,
  "message": "internal error"
}
```

**改进后**:
```json
{
  "code": 500,
  "message": "CRS sync failed: Post \"https://****/web/auth/login\": resolved ip 10.x.x.x is not allowed"
}
```

✅ 管理员现在可以看到具体的错误原因，而不是泛泛的"内部错误"

---

### 2. 安全配置

新增环境变量 `SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS`：

**生产环境** (`docker-compose.yml`)：
- 默认值: `false`（默认安全）
- 阻止私有 IP（10.x.x.x, 192.168.x.x, 127.x.x.x）

**测试环境** (`docker-compose-test.yml`)：
- 默认值: `true`（方便内网测试）
- 允许私有 IP 访问

**使用方式**：
```bash
# 在 .env 文件中设置
SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS=true
```

---

### 3. 灵活配置支持

在生产和测试环境都添加了 `config.yaml` 挂载支持：

```yaml
volumes:
  - ./config.yaml:/app/data/config.yaml:ro
```

**配置优先级**：
```
环境变量 > config.yaml > 默认值
```

**使用场景**：
- 📝 使用 `config.yaml` 进行详细/复杂配置
- ⚡ 使用环境变量快速覆盖
- 🎛️ 混合使用以获得最大灵活性

---

## 应用场景

适用于 CRS 服务器部署在**内网/私有网络**的情况，CRS 服务器域名解析到私有 IP 地址，同时在生产环境保持默认安全设置。

**示例**：
- CRS 服务器: `internal-crs.company.local`
- 解析到: `10.144.0.3`（私有 IP）
- 解决方案: 设置 `SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS=true`