### PR TITLE
feat(前端): 用户管理页面添加 ID 列

### DIFF
--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -1474,6 +1474,7 @@ const getAttributeValue = (userId: number, attrId: number): string => {
 // All possible columns (for column settings)
 const allColumns = computed<Column[]>(() => [
   { key: 'email', label: t('admin.users.columns.user'), sortable: true },
+  { key: 'id', label: 'ID', sortable: true },
   { key: 'username', label: t('admin.users.columns.username'), sortable: true },
   { key: 'notes', label: t('admin.users.columns.notes'), sortable: false },
   // Dynamic attribute columns


### PR DESCRIPTION
在用户列表中添加可选的 ID 列，方便与其他页面（如兑换码页面）
显示的"用户 #ID"进行对照定位。

- ID 列位于用户列之后
- 支持排序
- 可在列设置中隐藏

🤖 Generated with [Claude Code](https://claude.ai/code)