### PR TITLE
fix(frontend): 修复清除代理设置无效的问题

### DIFF
--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -831,7 +831,7 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
   let credentialsChanged = false
 
   if (enableProxy.value) {
-    updates.proxy_id = proxyId.value
+    updates.proxy_id = proxyId.value ?? 0
   }
 
   if (enableConcurrency.value) {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1052,7 +1052,10 @@ const handleSubmit = async () => {
 
   submitting.value = true
   try {
-    const updatePayload: Record<string, unknown> = { ...form }
+    const updatePayload: Record<string, unknown> = {
+      ...form,
+      proxy_id: form.proxy_id ?? 0
+    }
 
     // For apikey type, handle credentials update
     if (props.account.type === 'apikey') {


### PR DESCRIPTION
## 问题

修复 #170

当用户在账号管理页面选择"无代理"并保存时，代理设置无法清除。

## 原因

- 后端逻辑：`proxy_id: 0` 清除代理，`proxy_id: null` 保持原值不变
- 前端 bug：选择"无代理"时发送 `proxy_id: null` 而非 `proxy_id: 0`

## 修复

在 `EditAccountModal.vue` 和 `BulkEditAccountModal.vue` 提交时，将 `null` 转换为 `0`：

```typescript
proxy_id: form.proxy_id ?? 0
```