### PR TITLE
fix: 修复跨时区用户日期范围查询不准确的问题

### DIFF
--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -102,8 +102,9 @@ func (h *UsageHandler) List(c *gin.Context) {
 
 	// Parse date range
 	var startTime, endTime *time.Time
+	userTZ := c.Query("timezone") // Get user's timezone from request
 	if startDateStr := c.Query("start_date"); startDateStr != "" {
-		t, err := timezone.ParseInLocation("2006-01-02", startDateStr)
+		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
 			return
@@ -112,7 +113,7 @@ func (h *UsageHandler) List(c *gin.Context) {
 	}
 
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, err := timezone.ParseInLocation("2006-01-02", endDateStr)
+		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
 			return
@@ -172,7 +173,8 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 	}
 
 	// Parse date range
-	now := timezone.Now()
+	userTZ := c.Query("timezone") // Get user's timezone from request
+	now := timezone.NowInUserLocation(userTZ)
 	var startTime, endTime time.Time
 
 	startDateStr := c.Query("start_date")
@@ -180,12 +182,12 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 
 	if startDateStr != "" && endDateStr != "" {
 		var err error
-		startTime, err = timezone.ParseInLocation("2006-01-02", startDateStr)
+		startTime, err = timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
 			return
 		}
-		endTime, err = timezone.ParseInLocation("2006-01-02", endDateStr)
+		endTime, err = timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
 			return
@@ -195,13 +197,13 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 		period := c.DefaultQuery("period", "today")
 		switch period {
 		case "today":
-			startTime = timezone.StartOfDay(now)
+			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
 		case "week":
 			startTime = now.AddDate(0, 0, -7)
 		case "month":
 			startTime = now.AddDate(0, -1, 0)
 		default:
-			startTime = timezone.StartOfDay(now)
+			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
 		}
 		endTime = now
 	}

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -122,3 +122,40 @@ func StartOfMonth(t time.Time) time.Time {
 func ParseInLocation(layout, value string) (time.Time, error) {
 	return time.ParseInLocation(layout, value, Location())
 }
+
+// ParseInUserLocation parses a time string in the user's timezone.
+// If userTZ is empty or invalid, falls back to the configured server timezone.
+func ParseInUserLocation(layout, value, userTZ string) (time.Time, error) {
+	loc := Location() // default to server timezone
+	if userTZ != "" {
+		if userLoc, err := time.LoadLocation(userTZ); err == nil {
+			loc = userLoc
+		}
+	}
+	return time.ParseInLocation(layout, value, loc)
+}
+
+// NowInUserLocation returns the current time in the user's timezone.
+// If userTZ is empty or invalid, falls back to the configured server timezone.
+func NowInUserLocation(userTZ string) time.Time {
+	if userTZ == "" {
+		return Now()
+	}
+	if userLoc, err := time.LoadLocation(userTZ); err == nil {
+		return time.Now().In(userLoc)
+	}
+	return Now()
+}
+
+// StartOfDayInUserLocation returns the start of the given day in the user's timezone.
+// If userTZ is empty or invalid, falls back to the configured server timezone.
+func StartOfDayInUserLocation(t time.Time, userTZ string) time.Time {
+	loc := Location()
+	if userTZ != "" {
+		if userLoc, err := time.LoadLocation(userTZ); err == nil {
+			loc = userLoc
+		}
+	}
+	t = t.In(loc)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,15 @@ export const apiClient: AxiosInstance = axios.create({
 
 // ==================== Request Interceptor ====================
 
+// Get user's timezone
+const getUserTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  } catch {
+    return 'UTC'
+  }
+}
+
 apiClient.interceptors.request.use(
   (config: InternalAxiosRequestConfig) => {
     // Attach token from localStorage
@@ -32,6 +41,14 @@ apiClient.interceptors.request.use(
     // Attach locale for backend translations
     if (config.headers) {
       config.headers['Accept-Language'] = getLocale()
+    }
+
+    // Attach timezone for all GET requests (backend may use it for default date ranges)
+    if (config.method === 'get') {
+      if (!config.params) {
+        config.params = {}
+      }
+      config.params.timezone = getUserTimezone()
     }
 
     return config


### PR DESCRIPTION
问题：当用户时区与服务器时区不同时，日期范围查询使用服务器时区解析，
导致用户看到的数据与预期不符。（使用记录页面）

修复方案：
- 前端：所有 GET 请求自动携带用户时区参数
- 后端：新增时区辅助函数，所有日期解析和默认日期范围计算都使用用户时区
- 当用户时区为空或无效时，自动回退到服务器时区

🤖 Generated with [Claude Code](https://claude.ai/code)