### PR TITLE
fix(i18n): use correct translation key for dashboard redeem code desc…

### DIFF
--- a/frontend/src/components/user/dashboard/UserDashboardQuickActions.vue
+++ b/frontend/src/components/user/dashboard/UserDashboardQuickActions.vue
@@ -40,7 +40,7 @@
         </div>
         <div class="min-w-0 flex-1">
           <p class="text-sm font-medium text-gray-900 dark:text-white">{{ t('dashboard.redeemCode') }}</p>
-          <p class="text-xs text-gray-500 dark:text-dark-400">{{ t('dashboard.addBalance') }}</p>
+          <p class="text-xs text-gray-500 dark:text-dark-400">{{ t('dashboard.addBalanceWithCode') }}</p>
         </div>
         <Icon
           name="chevronRight"


### PR DESCRIPTION
## 问题描述
仪表盘"快捷操作"中的"兑换码"卡片，描述文字显示为原始 key `dashboard.addBalance` 而非翻译后的文本。
<img width="1648" height="464" alt="image" src="https://github.com/user-attachments/assets/95ad1036-510d-4008-82a2-eec7ae8d7752" />
## 修复内容
将 `UserDashboardQuickActions.vue` 中的 `t('dashboard.addBalance')` 改为 `t('dashboard.addBalanceWithCode')`，使用翻译文件中已存在的正确 key。

## 修改文件
- `frontend/src/components/user/dashboard/UserDashboardQuickActions.vue`

## 修复效果
- 中文：显示"使用兑换码充值"
- 英文：显示"Add balance with a code"