### PR TITLE
fix: 修复 Go 版本、包管理器和技术栈文档

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build-backend:
 
 # 编译前端（需要已安装依赖）
 build-frontend:
-	@npm --prefix frontend run build
+	@pnpm --dir frontend run build
 
 # 运行测试（后端 + 前端）
 test: test-backend test-frontend
@@ -18,5 +18,5 @@ test-backend:
 	@$(MAKE) -C backend test
 
 test-frontend:
-	@npm --prefix frontend run lint:check
-	@npm --prefix frontend run typecheck
+	@pnpm --dir frontend run lint:check
+	@pnpm --dir frontend run typecheck

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Sub2API is an AI API gateway platform designed to distribute and manage API quot
 
 | Component | Technology |
 |-----------|------------|
-| Backend | Go 1.25.5, Gin, GORM |
+| Backend | Go 1.25.5, Gin, Ent |
 | Frontend | Vue 3.4+, Vite 5+, TailwindCSS |
 | Database | PostgreSQL 15+ |
 | Cache/Queue | Redis 7+ |

--- a/README_CN.md
+++ b/README_CN.md
@@ -44,7 +44,7 @@ Sub2API 是一个 AI API 网关平台，用于分发和管理 AI 产品订阅（
 
 | 组件 | 技术 |
 |------|------|
-| 后端 | Go 1.25.5, Gin, GORM |
+| 后端 | Go 1.25.5, Gin, Ent |
 | 前端 | Vue 3.4+, Vite 5+, TailwindCSS |
 | 数据库 | PostgreSQL 15+ |
 | 缓存/队列 | Redis 7+ |

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.25.5-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## 修复内容

- [backend/Dockerfile](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/backend/Dockerfile:0:0-0:0): Go 版本从 1.21 更新到 1.25.5（与 go.mod 一致）
- [Makefile](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/Makefile:0:0-0:0): 使用 pnpm 替代 npm（与 pnpm-lock.yaml 和 CI 一致）
- [README.md](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/README.md:0:0-0:0)/[README_CN.md](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/README_CN.md:0:0-0:0): 技术栈从 GORM 修正为 Ent