### PR TITLE
fix(auth): 修复 RefreshToken 使用过期 token 时的 nil pointer panic

### DIFF
--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -82,14 +82,18 @@ func (s *AuthService) RegisterWithVerification(ctx context.Context, email, passw
 
 	// 检查是否需要邮件验证
 	if s.settingService != nil && s.settingService.IsEmailVerifyEnabled(ctx) {
+		// 如果邮件验证已开启但邮件服务未配置，拒绝注册
+		// 这是一个配置错误，不应该允许绕过验证
+		if s.emailService == nil {
+			log.Println("[Auth] Email verification enabled but email service not configured, rejecting registration")
+			return "", nil, ErrServiceUnavailable
+		}
 		if verifyCode == "" {
 			return "", nil, ErrEmailVerifyRequired
 		}
 		// 验证邮箱验证码
-		if s.emailService != nil {
-			if err := s.emailService.VerifyCode(ctx, email, verifyCode); err != nil {
-				return "", nil, fmt.Errorf("verify code: %w", err)
-			}
+		if err := s.emailService.VerifyCode(ctx, email, verifyCode); err != nil {
+			return "", nil, fmt.Errorf("verify code: %w", err)
 		}
 	}
 


### PR DESCRIPTION
问题分析：
- RefreshToken 允许过期 token 继续流程（用于无感刷新）
- 但 ValidateToken 在 token 过期时返回 nil claims
- 导致后续访问 claims.UserID 时触发 panic

修复方案：
- 修改 ValidateToken，在检测到 ErrTokenExpired 时仍然返回 claims
- jwt-go 在解析时即使遇到过期错误，token.Claims 仍会被填充
- 这样 RefreshToken 可以正常获取用户信息并生成新 token

新增测试：
- TestAuthService_ValidateToken_ExpiredReturnsClaimsWithError
- TestAuthService_RefreshToken_ExpiredTokenNoPanic