### PR TITLE
 fix: 修复测试账号连接时复制输出的多语言缺失

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1486,6 +1486,7 @@ export default {
       testing: 'Testing...',
       retry: 'Retry',
       copyOutput: 'Copy output',
+      outputCopied: 'Output copied',
       startingTestForAccount: 'Starting test for account: {name}',
       testAccountTypeLabel: 'Account type: {type}',
       selectTestModel: 'Select Test Model',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1601,6 +1601,7 @@ export default {
       startTest: '开始测试',
       retry: '重试',
       copyOutput: '复制输出',
+      outputCopied: '输出已复制',
       startingTestForAccount: '开始测试账号：{name}',
       testAccountTypeLabel: '账号类型：{type}',
 	      selectTestModel: '选择测试模型',


### PR DESCRIPTION
修复 admin.accounts.outputCopied 国际化 key 缺失导致复制输出时显示原始 key 的问题。

<img width="1377" height="502" alt="image" src="https://github.com/user-attachments/assets/bb44395a-b82a-459e-b4d9-aa72ca4b03dd" />
