### PR TITLE
fix: 从codex请求参数中移除max_output_tokens

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -545,6 +545,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	// 2. Normalize input format for Codex API compatibility
 	if account.Type == AccountTypeOAuth {
 		reqBody["store"] = false
+		// Codex 上游不接受 max_output_tokens 参数，需要在转发前移除。
+		delete(reqBody, "max_output_tokens")
 		bodyModified = true
 
 		// Normalize input format: convert AI SDK multi-part content format to simplified format


### PR DESCRIPTION
某些客户端比如 opencode 会在请求中附加 max_output_tokens，这会导致上游返回400错误