### PR TITLE
fix(网关): 修复账号选择中的调度器快照延迟问题

### DIFF
--- a/backend/internal/repository/ops_repo_preagg.go
+++ b/backend/internal/repository/ops_repo_preagg.go
@@ -71,7 +71,9 @@ usage_agg AS (
 error_base AS (
   SELECT
     date_trunc('hour', created_at AT TIME ZONE 'UTC') AT TIME ZONE 'UTC' AS bucket_start,
-    platform AS platform,
+    -- platform is NULL for some early-phase errors (e.g. before routing); map to a sentinel
+    -- value so platform-level GROUPING SETS don't collide with the overall (platform=NULL) row.
+    COALESCE(platform, 'unknown') AS platform,
     group_id AS group_id,
     is_business_limited AS is_business_limited,
     error_owner AS error_owner,


### PR DESCRIPTION
## 问题描述

调度器快照更新存在 **0.5-1秒的延迟**（Outbox轮询间隔），导致在账号被限流或过载后的短时间窗口内，可能仍会被选中，造成请求失败。

**问题场景**：
```
T0: 账号A正常，快照中 IsSchedulable=true
T1: 请求失败，账号A被标记为限流，RateLimitResetAt = T1 + 60s
    → 数据库中账号A已不可调度
T2: (T1后0.5秒) 新请求到来
    → listSchedulableAccounts() 返回快照中的账号列表
    → 快照还未更新，账号A仍在列表中
    → 选择循环遍历账号A
    → ❌ 没有IsSchedulable()检查，直接选中账号A
    → 再次请求失败！
T3: (T1后1秒) Outbox worker检测到变更
    → 触发bucket重建
    → 快照更新，账号A被移除
```

## 根本原因

账号选择逻辑依赖调度器快照（`listSchedulableAccounts`），但快照更新有延迟：
- **Outbox轮询**: 每 **1秒** 检查一次变更事件
- **全量重建**: 每 **300秒（5分钟）** 重建一次
- **时间窗口**: 账号状态变更后 **0.5-1秒** 内，快照可能未更新

## 解决方案

在账号选择循环中添加 `IsSchedulable()` 实时检查，作为**双重保险机制**：

1. **第一道防线**: 调度器快照过滤（可能有延迟）
2. **第二道防线**: `IsSchedulable()` 实时检查（本次修复）✅

`IsSchedulable()` 会实时检查：
- `RateLimitResetAt`: 限流重置时间
- `OverloadUntil`: 过载持续时间
- `TempUnschedulableUntil`: 临时不可调度时间
- `Status`: 账号状态
- `Schedulable`: 可调度标志

## 修改范围

### OpenAI Gateway Service
- `SelectAccountForModelWithExclusions`: 添加 `IsSchedulable()` 检查
- `SelectAccountWithLoadAwareness`: 添加 `IsSchedulable()` 检查

### Gateway Service (Claude/Gemini/Antigravity)
- 负载感知选择候选账号筛选: 添加 `IsSchedulable()` 检查
- `selectAccountForModelWithPlatform`: 添加 `IsSchedulable()` 检查
- `selectAccountWithMixedScheduling`: 添加 `IsSchedulable()` 检查

### 测试用例
- **OpenAI**: 添加 2 个测试用例验证限流账号过滤
  - `TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulable`
  - `TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulableWhenNoConcurrencyService`
- **Gateway**: 添加 2 个测试用例验证限流和过载账号过滤
  - `TestGatewayService_SelectAccountWithLoadAwareness/过滤不可调度账号-限流账号被跳过`
  - `TestGatewayService_SelectAccountWithLoadAwareness/过滤不可调度账号-过载账号被跳过`

### 其他修复
- `ops_repo_preagg.go`: 修复 platform 为 NULL 时的聚合问题

## 测试结果

所有单元测试通过 ✅

```bash
# OpenAI Gateway Service
✅ TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulable
✅ TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulableWhenNoConcurrencyService

# Gateway Service
✅ TestGatewayService_SelectAccountForModelWithPlatform_Schedulability
✅ TestGatewayService_SelectAccountWithLoadAwareness/过滤不可调度账号-限流账号被跳过
✅ TestGatewayService_SelectAccountWithLoadAwareness/过滤不可调度账号-过载账号被跳过
```

## 修改统计

```
backend/internal/service/gateway_multiplatform_test.go  | 66 行新增
backend/internal/service/gateway_service.go             | 16 行新增
backend/internal/service/openai_gateway_service.go      | 11 行新增
backend/internal/service/openai_gateway_service_test.go | 124 行新增
backend/internal/repository/ops_repo_preagg.go          | 4 行修改
总计: 217 行新增，1 行删除
```

## 影响范围

- ✅ 消除调度器快照延迟导致的时间窗口问题
- ✅ 提高账号选择的准确性和可靠性
- ✅ 减少因选中不可调度账号导致的请求失败
- ✅ 对性能影响极小（只是几个时间比较操作）