### PR TITLE
feat: add proxy geo location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,8 @@ temp/
 *.log
 *.bak
 .cache/
+.dev/
+.serena/
 
 # ===================
 # 构建产物

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -218,6 +218,11 @@ func ProxyWithAccountCountFromService(p *service.ProxyWithAccountCount) *ProxyWi
 		LatencyMs:      p.LatencyMs,
 		LatencyStatus:  p.LatencyStatus,
 		LatencyMessage: p.LatencyMessage,
+		IPAddress:      p.IPAddress,
+		Country:        p.Country,
+		CountryCode:    p.CountryCode,
+		Region:         p.Region,
+		City:           p.City,
 	}
 }
 

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -134,6 +134,11 @@ type ProxyWithAccountCount struct {
 	LatencyMs      *int64 `json:"latency_ms,omitempty"`
 	LatencyStatus  string `json:"latency_status,omitempty"`
 	LatencyMessage string `json:"latency_message,omitempty"`
+	IPAddress      string `json:"ip_address,omitempty"`
+	Country        string `json:"country,omitempty"`
+	CountryCode    string `json:"country_code,omitempty"`
+	Region         string `json:"region,omitempty"`
+	City           string `json:"city,omitempty"`
 }
 
 type ProxyAccountSummary struct {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -236,21 +236,23 @@ type ProxyBatchDeleteSkipped struct {
 
 // ProxyTestResult represents the result of testing a proxy
 type ProxyTestResult struct {
-	Success   bool   `json:"success"`
-	Message   string `json:"message"`
-	LatencyMs int64  `json:"latency_ms,omitempty"`
-	IPAddress string `json:"ip_address,omitempty"`
-	City      string `json:"city,omitempty"`
-	Region    string `json:"region,omitempty"`
-	Country   string `json:"country,omitempty"`
+	Success     bool   `json:"success"`
+	Message     string `json:"message"`
+	LatencyMs   int64  `json:"latency_ms,omitempty"`
+	IPAddress   string `json:"ip_address,omitempty"`
+	City        string `json:"city,omitempty"`
+	Region      string `json:"region,omitempty"`
+	Country     string `json:"country,omitempty"`
+	CountryCode string `json:"country_code,omitempty"`
 }
 
-// ProxyExitInfo represents proxy exit information from ipinfo.io
+// ProxyExitInfo represents proxy exit information from ip-api.com
 type ProxyExitInfo struct {
-	IP      string
-	City    string
-	Region  string
-	Country string
+	IP          string
+	City        string
+	Region      string
+	Country     string
+	CountryCode string
 }
 
 // ProxyExitInfoProber tests proxy connectivity and retrieves exit information
@@ -1340,19 +1342,25 @@ func (s *adminServiceImpl) TestProxy(ctx context.Context, id int64) (*ProxyTestR
 
 	latency := latencyMs
 	s.saveProxyLatency(ctx, id, &ProxyLatencyInfo{
-		Success:   true,
-		LatencyMs: &latency,
-		Message:   "Proxy is accessible",
-		UpdatedAt: time.Now(),
+		Success:     true,
+		LatencyMs:   &latency,
+		Message:     "Proxy is accessible",
+		IPAddress:   exitInfo.IP,
+		Country:     exitInfo.Country,
+		CountryCode: exitInfo.CountryCode,
+		Region:      exitInfo.Region,
+		City:        exitInfo.City,
+		UpdatedAt:   time.Now(),
 	})
 	return &ProxyTestResult{
-		Success:   true,
-		Message:   "Proxy is accessible",
-		LatencyMs: latencyMs,
-		IPAddress: exitInfo.IP,
-		City:      exitInfo.City,
-		Region:    exitInfo.Region,
-		Country:   exitInfo.Country,
+		Success:     true,
+		Message:     "Proxy is accessible",
+		LatencyMs:   latencyMs,
+		IPAddress:   exitInfo.IP,
+		City:        exitInfo.City,
+		Region:      exitInfo.Region,
+		Country:     exitInfo.Country,
+		CountryCode: exitInfo.CountryCode,
 	}, nil
 }
 
@@ -1360,7 +1368,7 @@ func (s *adminServiceImpl) probeProxyLatency(ctx context.Context, proxy *Proxy) 
 	if s.proxyProber == nil || proxy == nil {
 		return
 	}
-	_, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxy.URL())
+	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxy.URL())
 	if err != nil {
 		s.saveProxyLatency(ctx, proxy.ID, &ProxyLatencyInfo{
 			Success:   false,
@@ -1372,10 +1380,15 @@ func (s *adminServiceImpl) probeProxyLatency(ctx context.Context, proxy *Proxy) 
 
 	latency := latencyMs
 	s.saveProxyLatency(ctx, proxy.ID, &ProxyLatencyInfo{
-		Success:   true,
-		LatencyMs: &latency,
-		Message:   "Proxy is accessible",
-		UpdatedAt: time.Now(),
+		Success:     true,
+		LatencyMs:   &latency,
+		Message:     "Proxy is accessible",
+		IPAddress:   exitInfo.IP,
+		Country:     exitInfo.Country,
+		CountryCode: exitInfo.CountryCode,
+		Region:      exitInfo.Region,
+		City:        exitInfo.City,
+		UpdatedAt:   time.Now(),
 	})
 }
 
@@ -1456,6 +1469,11 @@ func (s *adminServiceImpl) attachProxyLatency(ctx context.Context, proxies []Pro
 			proxies[i].LatencyStatus = "failed"
 		}
 		proxies[i].LatencyMessage = info.Message
+		proxies[i].IPAddress = info.IPAddress
+		proxies[i].Country = info.Country
+		proxies[i].CountryCode = info.CountryCode
+		proxies[i].Region = info.Region
+		proxies[i].City = info.City
 	}
 }
 

--- a/backend/internal/service/proxy.go
+++ b/backend/internal/service/proxy.go
@@ -35,6 +35,11 @@ type ProxyWithAccountCount struct {
 	LatencyMs      *int64
 	LatencyStatus  string
 	LatencyMessage string
+	IPAddress      string
+	Country        string
+	CountryCode    string
+	Region         string
+	City           string
 }
 
 type ProxyAccountSummary struct {

--- a/backend/internal/service/proxy_latency_cache.go
+++ b/backend/internal/service/proxy_latency_cache.go
@@ -6,10 +6,15 @@ import (
 )
 
 type ProxyLatencyInfo struct {
-	Success   bool      `json:"success"`
-	LatencyMs *int64    `json:"latency_ms,omitempty"`
-	Message   string    `json:"message,omitempty"`
-	UpdatedAt time.Time `json:"updated_at"`
+	Success     bool      `json:"success"`
+	LatencyMs   *int64    `json:"latency_ms,omitempty"`
+	Message     string    `json:"message,omitempty"`
+	IPAddress   string    `json:"ip_address,omitempty"`
+	Country     string    `json:"country,omitempty"`
+	CountryCode string    `json:"country_code,omitempty"`
+	Region      string    `json:"region,omitempty"`
+	City        string    `json:"city,omitempty"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 type ProxyLatencyCache interface {

--- a/frontend/src/api/admin/proxies.ts
+++ b/frontend/src/api/admin/proxies.ts
@@ -126,6 +126,7 @@ export async function testProxy(id: number): Promise<{
   city?: string
   region?: string
   country?: string
+  country_code?: string
 }> {
   const { data } = await apiClient.post<{
     success: boolean
@@ -135,6 +136,7 @@ export async function testProxy(id: number): Promise<{
     city?: string
     region?: string
     country?: string
+    country_code?: string
   }>(`/admin/proxies/${id}/test`)
   return data
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1634,6 +1634,7 @@ export default {
         name: 'Name',
         protocol: 'Protocol',
         address: 'Address',
+        location: 'Location',
         status: 'Status',
         accounts: 'Accounts',
         latency: 'Latency',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1719,6 +1719,7 @@ export default {
         name: '名称',
         protocol: '协议',
         address: '地址',
+        location: '地理位置',
         status: '状态',
         accounts: '账号数',
         latency: '延迟',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -367,6 +367,11 @@ export interface Proxy {
   latency_ms?: number
   latency_status?: 'success' | 'failed'
   latency_message?: string
+  ip_address?: string
+  country?: string
+  country_code?: string
+  region?: string
+  city?: string
   created_at: string
   updated_at: string
 }


### PR DESCRIPTION
新增 IP 地理位置展示：
  - 测试连接时请求 `http://ip-api.com/json/?lang=zh-CN` 获取国家/城市/国家码
  - 前端代理列表新增“地理位置”列，展示国旗（unpkg）+ 国家/城市