### PR TITLE
feat(oauth): persist usage snapshots and window cooldown

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -69,6 +69,7 @@ func provideCleanup(
 	opsScheduledReport *service.OpsScheduledReportService,
 	schedulerSnapshot *service.SchedulerSnapshotService,
 	tokenRefresh *service.TokenRefreshService,
+	oauthProbe *service.OAuthProbeService,
 	accountExpiry *service.AccountExpiryService,
 	usageCleanup *service.UsageCleanupService,
 	pricing *service.PricingService,
@@ -132,6 +133,12 @@ func provideCleanup(
 			}},
 			{"TokenRefreshService", func() error {
 				tokenRefresh.Stop()
+				return nil
+			}},
+			{"OAuthProbeService", func() error {
+				if oauthProbe != nil {
+					oauthProbe.Stop()
+				}
 				return nil
 			}},
 			{"AccountExpiryService", func() error {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -182,6 +182,7 @@ type AccountUsageService struct {
 	antigravityQuotaFetcher *AntigravityQuotaFetcher
 	cache                   *UsageCache
 	identityCache           IdentityCache
+	usageSnapshotSyncCache  sync.Map // accountID -> time.Time (best-effort throttle)
 }
 
 // NewAccountUsageService 创建AccountUsageService实例

--- a/backend/internal/service/account_usage_snapshot_sync.go
+++ b/backend/internal/service/account_usage_snapshot_sync.go
@@ -1,0 +1,162 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	claudeUsageSnapshotKey     = "claude_usage_snapshot"
+	claudeUsageUpdatedAtKey    = "claude_usage_updated_at"
+	claudeUsageSnapshotSource  = "claude_usage_source"
+	geminiUsageSnapshotKey     = "gemini_usage_snapshot"
+	geminiUsageUpdatedAtKey    = "gemini_usage_updated_at"
+	geminiUsageSnapshotSource  = "gemini_usage_source"
+	usageSnapshotSourceGateway = "gateway"
+	usageSnapshotSourceTest    = "test"
+	usageSnapshotSourceProbe   = "probe"
+)
+
+func (s *AccountUsageService) SyncUsageSnapshotToExtra(ctx context.Context, account *Account, source string) error {
+	if s == nil || s.accountRepo == nil || account == nil || account.ID <= 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	if strings.TrimSpace(source) == "" {
+		source = usageSnapshotSourceGateway
+	}
+
+	switch account.Platform {
+	case PlatformAnthropic:
+		usage, err := s.computeClaudeUsageSnapshot(ctx, account, now)
+		if err != nil {
+			return err
+		}
+		if usage == nil {
+			return nil
+		}
+		if usage.UpdatedAt == nil {
+			usage.UpdatedAt = &now
+		}
+
+		updates := map[string]any{
+			claudeUsageSnapshotKey:    usage,
+			claudeUsageUpdatedAtKey:   now.Format(time.RFC3339),
+			claudeUsageSnapshotSource: source,
+		}
+		if err := s.accountRepo.UpdateExtra(ctx, account.ID, updates); err != nil {
+			return err
+		}
+
+		// If the quota is already full, persist a real reset window to account.rate_limit_reset_at
+		// so the scheduler can skip the account until the window ends.
+		if resetAt := claudeRateLimitResetAt(usage); resetAt != nil && resetAt.After(time.Now()) {
+			_ = s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt)
+		}
+
+		return nil
+
+	case PlatformGemini:
+		usage, err := s.computeGeminiUsageSnapshot(ctx, account, now)
+		if err != nil {
+			return err
+		}
+		if usage == nil {
+			return nil
+		}
+		if usage.UpdatedAt == nil {
+			usage.UpdatedAt = &now
+		}
+
+		updates := map[string]any{
+			geminiUsageSnapshotKey:    usage,
+			geminiUsageUpdatedAtKey:   now.Format(time.RFC3339),
+			geminiUsageSnapshotSource: source,
+		}
+		return s.accountRepo.UpdateExtra(ctx, account.ID, updates)
+	default:
+		return nil
+	}
+}
+
+// MaybeSyncUsageSnapshotToExtra performs a best-effort sync with an in-memory throttle.
+// NOTE: This is per-process only; multi-instance deployments still sync independently.
+func (s *AccountUsageService) MaybeSyncUsageSnapshotToExtra(ctx context.Context, account *Account, source string, minInterval time.Duration) error {
+	if s == nil || account == nil || account.ID <= 0 {
+		return nil
+	}
+	if minInterval <= 0 {
+		return s.SyncUsageSnapshotToExtra(ctx, account, source)
+	}
+
+	now := time.Now()
+	if v, ok := s.usageSnapshotSyncCache.Load(account.ID); ok {
+		if last, ok := v.(time.Time); ok && now.Sub(last) < minInterval {
+			return nil
+		}
+	}
+	s.usageSnapshotSyncCache.Store(account.ID, now)
+	return s.SyncUsageSnapshotToExtra(ctx, account, source)
+}
+
+func (s *AccountUsageService) computeClaudeUsageSnapshot(ctx context.Context, account *Account, now time.Time) (*UsageInfo, error) {
+	if account == nil || account.Platform != PlatformAnthropic {
+		return nil, nil
+	}
+	// API Key accounts do not support Claude OAuth usage API.
+	if account.Type == AccountTypeAPIKey {
+		return nil, nil
+	}
+
+	// OAuth accounts: call Anthropic OAuth usage API.
+	if account.CanGetUsage() {
+		apiResp, err := s.fetchOAuthUsageRaw(ctx, account)
+		if err != nil {
+			return nil, err
+		}
+		usage := s.buildUsageInfo(apiResp, &now)
+		s.addWindowStats(ctx, account, usage)
+		return usage, nil
+	}
+
+	// Setup Token accounts: estimate 5h window from session_window fields.
+	if account.Type == AccountTypeSetupToken {
+		usage := s.estimateSetupTokenUsage(account)
+		usage.UpdatedAt = &now
+		s.addWindowStats(ctx, account, usage)
+		return usage, nil
+	}
+
+	return nil, fmt.Errorf("unsupported anthropic account type: %s", account.Type)
+}
+
+func (s *AccountUsageService) computeGeminiUsageSnapshot(ctx context.Context, account *Account, now time.Time) (*UsageInfo, error) {
+	if account == nil || account.Platform != PlatformGemini {
+		return nil, nil
+	}
+
+	usage, err := s.getGeminiUsage(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	if usage != nil && usage.UpdatedAt == nil {
+		usage.UpdatedAt = &now
+	}
+	return usage, nil
+}
+
+func claudeRateLimitResetAt(usage *UsageInfo) *time.Time {
+	if usage == nil {
+		return nil
+	}
+	if usage.SevenDay != nil && usage.SevenDay.ResetsAt != nil && usage.SevenDay.Utilization >= 100 {
+		return usage.SevenDay.ResetsAt
+	}
+	if usage.FiveHour != nil && usage.FiveHour.ResetsAt != nil && usage.FiveHour.Utilization >= 100 {
+		return usage.FiveHour.ResetsAt
+	}
+	return nil
+}

--- a/backend/internal/service/oauth_probe_service.go
+++ b/backend/internal/service/oauth_probe_service.go
@@ -1,0 +1,547 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
+)
+
+// OAuthProbeService periodically probes OAuth/Setup-Token accounts to:
+// - keep OAuth account availability observable even when not scheduled,
+// - refresh upstream quota snapshots (e.g. OpenAI Codex 5h/7d windows),
+// - reduce stale/expired quota display issues on the account page.
+//
+// NOTE: This service is disabled by default because each probe may consume real quota.
+type OAuthProbeService struct {
+	accountRepo         AccountRepository
+	httpUpstream        HTTPUpstream
+	openAITokenProvider *OpenAITokenProvider
+	geminiTokenProvider *GeminiTokenProvider
+	claudeTokenProvider *ClaudeTokenProvider
+	accountUsageService *AccountUsageService
+	cfg                 *config.OAuthProbeConfig
+	securityCfg         *config.SecurityConfig
+
+	stopCh chan struct{}
+	wg     sync.WaitGroup
+}
+
+func NewOAuthProbeService(
+	accountRepo AccountRepository,
+	httpUpstream HTTPUpstream,
+	openAITokenProvider *OpenAITokenProvider,
+	geminiTokenProvider *GeminiTokenProvider,
+	claudeTokenProvider *ClaudeTokenProvider,
+	accountUsageService *AccountUsageService,
+	cfg *config.Config,
+) *OAuthProbeService {
+	if cfg == nil {
+		cfg = &config.Config{}
+	}
+	return &OAuthProbeService{
+		accountRepo:         accountRepo,
+		httpUpstream:        httpUpstream,
+		openAITokenProvider: openAITokenProvider,
+		geminiTokenProvider: geminiTokenProvider,
+		claudeTokenProvider: claudeTokenProvider,
+		accountUsageService: accountUsageService,
+		cfg:                 &cfg.OAuthProbe,
+		securityCfg:         &cfg.Security,
+		stopCh:              make(chan struct{}),
+	}
+}
+
+func (s *OAuthProbeService) Start() {
+	if s.cfg == nil || !s.cfg.Enabled {
+		log.Println("[OAuthProbe] Service disabled by configuration")
+		return
+	}
+
+	s.wg.Add(1)
+	go s.probeLoop()
+
+	log.Printf("[OAuthProbe] Service started (check every %d minutes, idle_threshold=%d minutes, timeout=%ds, concurrency=%d, max_accounts_per_cycle=%d)",
+		s.cfg.CheckIntervalMinutes,
+		s.cfg.IdleThresholdMinutes,
+		s.cfg.RequestTimeoutSeconds,
+		s.cfg.MaxConcurrency,
+		s.cfg.MaxAccountsPerCycle,
+	)
+}
+
+func (s *OAuthProbeService) Stop() {
+	if s == nil {
+		return
+	}
+	close(s.stopCh)
+	s.wg.Wait()
+	log.Println("[OAuthProbe] Service stopped")
+}
+
+func (s *OAuthProbeService) probeLoop() {
+	defer s.wg.Done()
+
+	interval := time.Duration(s.cfg.CheckIntervalMinutes) * time.Minute
+	if interval < time.Minute {
+		interval = 5 * time.Minute
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	// Run once on startup to populate usage windows quickly.
+	s.processProbeCycle()
+
+	for {
+		select {
+		case <-ticker.C:
+			s.processProbeCycle()
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *OAuthProbeService) processProbeCycle() {
+	if s == nil || s.accountRepo == nil {
+		return
+	}
+	ctx := context.Background()
+
+	accounts, err := s.accountRepo.ListActive(ctx)
+	if err != nil {
+		log.Printf("[OAuthProbe] Failed to list accounts: %v", err)
+		return
+	}
+
+	// Filter to OAuth/Setup-Token accounts on OpenAI/Gemini/Claude only.
+	targets := make([]Account, 0, len(accounts))
+	idleThreshold := time.Duration(s.cfg.IdleThresholdMinutes) * time.Minute
+	if idleThreshold < 0 {
+		idleThreshold = 0
+	}
+	for _, a := range accounts {
+		if !a.IsOAuth() {
+			continue
+		}
+		switch a.Platform {
+		case PlatformOpenAI, PlatformGemini, PlatformAnthropic:
+			// Only probe idle accounts as a "fallback" mechanism.
+			// If the account was used recently, skip to avoid consuming extra quota.
+			if idleThreshold > 0 && a.LastUsedAt != nil && time.Since(*a.LastUsedAt) < idleThreshold {
+				continue
+			}
+			targets = append(targets, a)
+		}
+	}
+
+	if len(targets) == 0 {
+		log.Printf("[OAuthProbe] Cycle complete: total=%d, targets=0", len(accounts))
+		return
+	}
+
+	maxPerCycle := s.cfg.MaxAccountsPerCycle
+	if maxPerCycle > 0 && len(targets) > maxPerCycle {
+		targets = targets[:maxPerCycle]
+	}
+
+	concurrency := s.cfg.MaxConcurrency
+	if concurrency <= 0 {
+		concurrency = 1
+	}
+
+	var (
+		mu          sync.Mutex
+		okCount     int
+		failCount   int
+		openaiCount int
+		geminiCount int
+		claudeCount int
+		openaiOK    int
+		geminiOK    int
+		claudeOK    int
+	)
+
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for i := range targets {
+		account := targets[i]
+		wg.Add(1)
+		sem <- struct{}{}
+
+		go func(a Account) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			probeOK := false
+			switch a.Platform {
+			case PlatformOpenAI:
+				mu.Lock()
+				openaiCount++
+				mu.Unlock()
+				if err := s.probeOpenAIOAuth(ctx, &a); err == nil {
+					probeOK = true
+					mu.Lock()
+					openaiOK++
+					mu.Unlock()
+				}
+			case PlatformGemini:
+				mu.Lock()
+				geminiCount++
+				mu.Unlock()
+				if err := s.probeGeminiOAuth(ctx, &a); err == nil {
+					probeOK = true
+					mu.Lock()
+					geminiOK++
+					mu.Unlock()
+				}
+			case PlatformAnthropic:
+				mu.Lock()
+				claudeCount++
+				mu.Unlock()
+				if err := s.probeClaudeOAuth(ctx, &a); err == nil {
+					probeOK = true
+					mu.Lock()
+					claudeOK++
+					mu.Unlock()
+				}
+			}
+
+			mu.Lock()
+			if probeOK {
+				okCount++
+			} else {
+				failCount++
+			}
+			mu.Unlock()
+		}(account)
+	}
+
+	wg.Wait()
+	log.Printf("[OAuthProbe] Cycle complete: total=%d, targets=%d, ok=%d, failed=%d (openai=%d ok=%d, gemini=%d ok=%d, claude=%d ok=%d)",
+		len(accounts), len(targets), okCount, failCount,
+		openaiCount, openaiOK, geminiCount, geminiOK, claudeCount, claudeOK,
+	)
+}
+
+func (s *OAuthProbeService) probeOpenAIOAuth(parent context.Context, account *Account) error {
+	if account == nil || account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth {
+		return nil
+	}
+	if s.httpUpstream == nil {
+		return fmt.Errorf("http upstream not configured")
+	}
+
+	timeout := time.Duration(s.cfg.RequestTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	token := strings.TrimSpace(account.GetOpenAIAccessToken())
+	if s.openAITokenProvider != nil {
+		if t, err := s.openAITokenProvider.GetAccessToken(ctx, account); err == nil && strings.TrimSpace(t) != "" {
+			token = t
+		}
+	}
+	if token == "" {
+		return fmt.Errorf("missing access token")
+	}
+
+	nonce, _ := randomHexString(8)
+	payload := createOpenAITestPayload(openai.DefaultTestModel, true, nonce)
+	body, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, chatgptCodexAPIURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Host = "chatgpt.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("accept", "text/event-stream")
+	req.Header.Set("OpenAI-Beta", "responses=experimental")
+	if chatgptAccountID := account.GetChatGPTAccountID(); chatgptAccountID != "" {
+		req.Header.Set("chatgpt-account-id", chatgptAccountID)
+	}
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, account.IsTLSFingerprintEnabled())
+	if err != nil {
+		s.saveProbeResult(context.Background(), account.ID, false, 0, err)
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Persist Codex quota snapshot (headers only).
+	s.persistOpenAICodexSnapshot(ctx, account.ID, resp.Header)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		err := fmt.Errorf("openai oauth probe status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		s.saveProbeResult(context.Background(), account.ID, false, resp.StatusCode, err)
+		return err
+	}
+
+	s.saveProbeResult(context.Background(), account.ID, true, resp.StatusCode, nil)
+	return nil
+}
+
+func (s *OAuthProbeService) persistOpenAICodexSnapshot(ctx context.Context, accountID int64, headers http.Header) {
+	if s == nil || s.accountRepo == nil {
+		return
+	}
+	if snapshot := extractCodexUsageHeaders(headers); snapshot != nil {
+		derived := deriveCodexUsageSnapshot(snapshot)
+		if derived == nil || len(derived.updates) == 0 {
+			return
+		}
+		_ = s.accountRepo.UpdateExtra(ctx, accountID, derived.updates)
+		if resetAt := codexRateLimitResetAt(derived); resetAt != nil && resetAt.After(time.Now()) {
+			_ = s.accountRepo.SetRateLimited(ctx, accountID, *resetAt)
+		}
+	}
+}
+
+func (s *OAuthProbeService) probeGeminiOAuth(parent context.Context, account *Account) error {
+	if account == nil || account.Platform != PlatformGemini || account.Type != AccountTypeOAuth {
+		return nil
+	}
+	if s.httpUpstream == nil {
+		return fmt.Errorf("http upstream not configured")
+	}
+	if s.geminiTokenProvider == nil {
+		return fmt.Errorf("gemini token provider not configured")
+	}
+
+	timeout := time.Duration(s.cfg.RequestTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	accessToken, err := s.geminiTokenProvider.GetAccessToken(ctx, account)
+	if err != nil {
+		s.saveProbeResult(context.Background(), account.ID, false, 0, err)
+		return err
+	}
+
+	nonce, _ := randomHexString(8)
+	payload := createGeminiTestPayload(nonce)
+
+	projectID := strings.TrimSpace(account.GetCredential("project_id"))
+	modelID := geminicli.DefaultTestModel
+
+	var req *http.Request
+	if projectID == "" {
+		baseURL := account.GetCredential("base_url")
+		if strings.TrimSpace(baseURL) == "" {
+			baseURL = geminicli.AIStudioBaseURL
+		}
+		normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+		if err != nil {
+			return err
+		}
+		fullURL := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse", strings.TrimRight(normalizedBaseURL, "/"), modelID)
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+	} else {
+		var inner map[string]any
+		if err := json.Unmarshal(payload, &inner); err != nil {
+			return err
+		}
+		wrapped := map[string]any{
+			"model":   modelID,
+			"project": projectID,
+			"request": inner,
+		}
+		wrappedBytes, _ := json.Marshal(wrapped)
+
+		normalizedBaseURL, err := s.validateUpstreamBaseURL(geminicli.GeminiCliBaseURL)
+		if err != nil {
+			return err
+		}
+		fullURL := fmt.Sprintf("%s/v1internal:streamGenerateContent?alt=sse", strings.TrimRight(normalizedBaseURL, "/"))
+		req, err = http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(wrappedBytes))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+accessToken)
+		req.Header.Set("User-Agent", geminicli.GeminiCLIUserAgent)
+	}
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, account.IsTLSFingerprintEnabled())
+	if err != nil {
+		s.saveProbeResult(context.Background(), account.ID, false, 0, err)
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Persist Gemini (simulated) quota snapshot to DB extra.
+	if s.accountUsageService != nil {
+		updateCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = s.accountUsageService.SyncUsageSnapshotToExtra(updateCtx, account, usageSnapshotSourceProbe)
+		cancel()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		err := fmt.Errorf("gemini oauth probe status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		s.saveProbeResult(context.Background(), account.ID, false, resp.StatusCode, err)
+		return err
+	}
+
+	s.saveProbeResult(context.Background(), account.ID, true, resp.StatusCode, nil)
+	return nil
+}
+
+func (s *OAuthProbeService) probeClaudeOAuth(parent context.Context, account *Account) error {
+	if account == nil || account.Platform != PlatformAnthropic || !account.IsOAuth() {
+		return nil
+	}
+	if s.httpUpstream == nil {
+		return fmt.Errorf("http upstream not configured")
+	}
+
+	timeout := time.Duration(s.cfg.RequestTimeoutSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+
+	authToken := strings.TrimSpace(account.GetCredential("access_token"))
+	if account.Type == AccountTypeOAuth && s.claudeTokenProvider != nil {
+		if t, err := s.claudeTokenProvider.GetAccessToken(ctx, account); err == nil && strings.TrimSpace(t) != "" {
+			authToken = t
+		}
+	}
+	if authToken == "" {
+		return fmt.Errorf("missing access token")
+	}
+
+	nonce, _ := randomHexString(8)
+	payload, err := createTestPayload(claude.DefaultTestModel, nonce)
+	if err != nil {
+		return err
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, testClaudeAPIURL, bytes.NewReader(payloadBytes))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("anthropic-beta", claude.DefaultBetaHeader)
+	for key, value := range claude.DefaultHeaders {
+		req.Header.Set(key, value)
+	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, account.IsTLSFingerprintEnabled())
+	if err != nil {
+		s.saveProbeResult(context.Background(), account.ID, false, 0, err)
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Persist Claude quota snapshot (5h/7d windows) to DB extra.
+	// This calls Anthropic's OAuth usage API, which should not consume message quota.
+	if s.accountUsageService != nil {
+		updateCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = s.accountUsageService.SyncUsageSnapshotToExtra(updateCtx, account, usageSnapshotSourceProbe)
+		cancel()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		err := fmt.Errorf("claude oauth probe status=%d body=%s", resp.StatusCode, strings.TrimSpace(string(body)))
+		s.saveProbeResult(context.Background(), account.ID, false, resp.StatusCode, err)
+		return err
+	}
+
+	s.saveProbeResult(context.Background(), account.ID, true, resp.StatusCode, nil)
+	return nil
+}
+
+func (s *OAuthProbeService) saveProbeResult(ctx context.Context, accountID int64, ok bool, statusCode int, err error) {
+	if s == nil || s.accountRepo == nil || accountID <= 0 {
+		return
+	}
+
+	msg := ""
+	if err != nil {
+		msg = strings.TrimSpace(err.Error())
+		if len(msg) > 256 {
+			msg = msg[:256]
+		}
+	}
+
+	updates := map[string]any{
+		"oauth_probe": map[string]any{
+			"updated_at":  time.Now().UTC().Format(time.RFC3339),
+			"ok":          ok,
+			"status_code": statusCode,
+			"error":       msg,
+		},
+	}
+
+	updateCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
+}
+
+func (s *OAuthProbeService) validateUpstreamBaseURL(raw string) (string, error) {
+	if s.securityCfg == nil {
+		return urlvalidator.ValidateURLFormat(raw, true)
+	}
+	if !s.securityCfg.URLAllowlist.Enabled {
+		return urlvalidator.ValidateURLFormat(raw, s.securityCfg.URLAllowlist.AllowInsecureHTTP)
+	}
+	normalized, err := urlvalidator.ValidateHTTPSURL(raw, urlvalidator.ValidationOptions{
+		AllowedHosts:     s.securityCfg.URLAllowlist.UpstreamHosts,
+		RequireAllowlist: true,
+		AllowPrivate:     s.securityCfg.URLAllowlist.AllowPrivateHosts,
+	})
+	if err != nil {
+		return "", err
+	}
+	return normalized, nil
+}

--- a/backend/internal/service/openai_codex_usage_snapshot.go
+++ b/backend/internal/service/openai_codex_usage_snapshot.go
@@ -1,0 +1,205 @@
+package service
+
+import (
+	"time"
+)
+
+type codexDerivedUsageSnapshot struct {
+	updates map[string]any
+
+	updatedAt time.Time
+
+	fiveHourUsedPercent       *float64
+	fiveHourResetAfterSeconds *int
+	fiveHourWindowMinutes     *int
+	fiveHourResetAt           *time.Time
+
+	sevenDayUsedPercent       *float64
+	sevenDayResetAfterSeconds *int
+	sevenDayWindowMinutes     *int
+	sevenDayResetAt           *time.Time
+}
+
+func deriveCodexUsageSnapshot(snapshot *OpenAICodexUsageSnapshot) *codexDerivedUsageSnapshot {
+	if snapshot == nil {
+		return nil
+	}
+
+	updates := make(map[string]any)
+
+	if snapshot.PrimaryUsedPercent != nil {
+		updates["codex_primary_used_percent"] = *snapshot.PrimaryUsedPercent
+	}
+	if snapshot.PrimaryResetAfterSeconds != nil {
+		updates["codex_primary_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
+	}
+	if snapshot.PrimaryWindowMinutes != nil {
+		updates["codex_primary_window_minutes"] = *snapshot.PrimaryWindowMinutes
+	}
+	if snapshot.SecondaryUsedPercent != nil {
+		updates["codex_secondary_used_percent"] = *snapshot.SecondaryUsedPercent
+	}
+	if snapshot.SecondaryResetAfterSeconds != nil {
+		updates["codex_secondary_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
+	}
+	if snapshot.SecondaryWindowMinutes != nil {
+		updates["codex_secondary_window_minutes"] = *snapshot.SecondaryWindowMinutes
+	}
+	if snapshot.PrimaryOverSecondaryPercent != nil {
+		updates["codex_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
+	}
+	if snapshot.UpdatedAt != "" {
+		updates["codex_usage_updated_at"] = snapshot.UpdatedAt
+	}
+
+	updatedAt := time.Now()
+	if snapshot.UpdatedAt != "" {
+		if t, err := time.Parse(time.RFC3339, snapshot.UpdatedAt); err == nil {
+			updatedAt = t
+		}
+	}
+
+	// Normalize to canonical 5h/7d fields based on window_minutes
+	// This fixes the issue where OpenAI's primary/secondary naming is ambiguous across accounts.
+	//
+	// IMPORTANT: We can only reliably determine window type from window_minutes field.
+	// reset_after_seconds is remaining time, not window size, so it cannot be used for comparison.
+
+	var primaryWindowMins, secondaryWindowMins int
+	var hasPrimaryWindow, hasSecondaryWindow bool
+
+	if snapshot.PrimaryWindowMinutes != nil {
+		primaryWindowMins = *snapshot.PrimaryWindowMinutes
+		hasPrimaryWindow = true
+	}
+	if snapshot.SecondaryWindowMinutes != nil {
+		secondaryWindowMins = *snapshot.SecondaryWindowMinutes
+		hasSecondaryWindow = true
+	}
+
+	var use5hFromPrimary, use7dFromPrimary bool
+	var use5hFromSecondary, use7dFromSecondary bool
+
+	if hasPrimaryWindow && hasSecondaryWindow {
+		// Both window sizes known: compare and assign smaller to 5h, larger to 7d.
+		if primaryWindowMins < secondaryWindowMins {
+			use5hFromPrimary = true
+			use7dFromSecondary = true
+		} else {
+			use5hFromSecondary = true
+			use7dFromPrimary = true
+		}
+	} else if hasPrimaryWindow {
+		// Only primary window size known: classify by absolute threshold.
+		if primaryWindowMins <= 360 {
+			use5hFromPrimary = true
+		} else {
+			use7dFromPrimary = true
+		}
+	} else if hasSecondaryWindow {
+		// Only secondary window size known: classify by absolute threshold.
+		if secondaryWindowMins <= 360 {
+			use5hFromSecondary = true
+		} else {
+			use7dFromSecondary = true
+		}
+	} else {
+		// No window_minutes available: cannot reliably determine window types.
+		// Fall back to legacy assumption (may be incorrect):
+		// assume primary=7d, secondary=5h based on historical observation.
+		if snapshot.SecondaryUsedPercent != nil || snapshot.SecondaryResetAfterSeconds != nil || snapshot.SecondaryWindowMinutes != nil {
+			use5hFromSecondary = true
+		}
+		if snapshot.PrimaryUsedPercent != nil || snapshot.PrimaryResetAfterSeconds != nil || snapshot.PrimaryWindowMinutes != nil {
+			use7dFromPrimary = true
+		}
+	}
+
+	d := &codexDerivedUsageSnapshot{
+		updates:   updates,
+		updatedAt: updatedAt,
+	}
+
+	if use5hFromPrimary {
+		d.fiveHourUsedPercent = snapshot.PrimaryUsedPercent
+		d.fiveHourResetAfterSeconds = snapshot.PrimaryResetAfterSeconds
+		d.fiveHourWindowMinutes = snapshot.PrimaryWindowMinutes
+		if snapshot.PrimaryUsedPercent != nil {
+			updates["codex_5h_used_percent"] = *snapshot.PrimaryUsedPercent
+		}
+		if snapshot.PrimaryResetAfterSeconds != nil {
+			updates["codex_5h_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
+		}
+		if snapshot.PrimaryWindowMinutes != nil {
+			updates["codex_5h_window_minutes"] = *snapshot.PrimaryWindowMinutes
+		}
+	} else if use5hFromSecondary {
+		d.fiveHourUsedPercent = snapshot.SecondaryUsedPercent
+		d.fiveHourResetAfterSeconds = snapshot.SecondaryResetAfterSeconds
+		d.fiveHourWindowMinutes = snapshot.SecondaryWindowMinutes
+		if snapshot.SecondaryUsedPercent != nil {
+			updates["codex_5h_used_percent"] = *snapshot.SecondaryUsedPercent
+		}
+		if snapshot.SecondaryResetAfterSeconds != nil {
+			updates["codex_5h_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
+		}
+		if snapshot.SecondaryWindowMinutes != nil {
+			updates["codex_5h_window_minutes"] = *snapshot.SecondaryWindowMinutes
+		}
+	}
+
+	if use7dFromPrimary {
+		d.sevenDayUsedPercent = snapshot.PrimaryUsedPercent
+		d.sevenDayResetAfterSeconds = snapshot.PrimaryResetAfterSeconds
+		d.sevenDayWindowMinutes = snapshot.PrimaryWindowMinutes
+		if snapshot.PrimaryUsedPercent != nil {
+			updates["codex_7d_used_percent"] = *snapshot.PrimaryUsedPercent
+		}
+		if snapshot.PrimaryResetAfterSeconds != nil {
+			updates["codex_7d_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
+		}
+		if snapshot.PrimaryWindowMinutes != nil {
+			updates["codex_7d_window_minutes"] = *snapshot.PrimaryWindowMinutes
+		}
+	} else if use7dFromSecondary {
+		d.sevenDayUsedPercent = snapshot.SecondaryUsedPercent
+		d.sevenDayResetAfterSeconds = snapshot.SecondaryResetAfterSeconds
+		d.sevenDayWindowMinutes = snapshot.SecondaryWindowMinutes
+		if snapshot.SecondaryUsedPercent != nil {
+			updates["codex_7d_used_percent"] = *snapshot.SecondaryUsedPercent
+		}
+		if snapshot.SecondaryResetAfterSeconds != nil {
+			updates["codex_7d_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
+		}
+		if snapshot.SecondaryWindowMinutes != nil {
+			updates["codex_7d_window_minutes"] = *snapshot.SecondaryWindowMinutes
+		}
+	}
+
+	// Compute absolute reset timestamps using snapshot updated_at + reset_after_seconds.
+	if d.fiveHourResetAfterSeconds != nil {
+		resetAt := updatedAt.Add(time.Duration(*d.fiveHourResetAfterSeconds) * time.Second)
+		d.fiveHourResetAt = &resetAt
+		updates["codex_5h_reset_at"] = resetAt.UTC().Format(time.RFC3339)
+	}
+	if d.sevenDayResetAfterSeconds != nil {
+		resetAt := updatedAt.Add(time.Duration(*d.sevenDayResetAfterSeconds) * time.Second)
+		d.sevenDayResetAt = &resetAt
+		updates["codex_7d_reset_at"] = resetAt.UTC().Format(time.RFC3339)
+	}
+
+	return d
+}
+
+func codexRateLimitResetAt(derived *codexDerivedUsageSnapshot) *time.Time {
+	if derived == nil {
+		return nil
+	}
+	if derived.sevenDayUsedPercent != nil && *derived.sevenDayUsedPercent >= 100 && derived.sevenDayResetAt != nil {
+		return derived.sevenDayResetAt
+	}
+	if derived.fiveHourUsedPercent != nil && *derived.fiveHourUsedPercent >= 100 && derived.fiveHourResetAt != nil {
+		return derived.fiveHourResetAt
+	}
+	return nil
+}

--- a/backend/internal/service/openai_codex_usage_snapshot_test.go
+++ b/backend/internal/service/openai_codex_usage_snapshot_test.go
@@ -1,0 +1,142 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDeriveCodexUsageSnapshot_Assigns5hAnd7dByWindowMinutes(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := now.Format(time.RFC3339)
+
+	primaryUsed := 80.0
+	primaryReset := 100
+	primaryWindow := 10080
+
+	secondaryUsed := 50.0
+	secondaryReset := 200
+	secondaryWindow := 300
+
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         &primaryUsed,
+		PrimaryResetAfterSeconds:   &primaryReset,
+		PrimaryWindowMinutes:       &primaryWindow,
+		SecondaryUsedPercent:       &secondaryUsed,
+		SecondaryResetAfterSeconds: &secondaryReset,
+		SecondaryWindowMinutes:     &secondaryWindow,
+		UpdatedAt:                  updatedAt,
+	}
+
+	derived := deriveCodexUsageSnapshot(snapshot)
+	if derived == nil {
+		t.Fatalf("expected derived snapshot, got nil")
+	}
+
+	if derived.fiveHourUsedPercent == nil || *derived.fiveHourUsedPercent != secondaryUsed {
+		t.Fatalf("expected 5h used=%v, got=%v", secondaryUsed, derefFloat(derived.fiveHourUsedPercent))
+	}
+	if derived.sevenDayUsedPercent == nil || *derived.sevenDayUsedPercent != primaryUsed {
+		t.Fatalf("expected 7d used=%v, got=%v", primaryUsed, derefFloat(derived.sevenDayUsedPercent))
+	}
+
+	if v, ok := derived.updates["codex_5h_used_percent"].(float64); !ok || v != secondaryUsed {
+		t.Fatalf("expected updates.codex_5h_used_percent=%v, got=%v", secondaryUsed, derived.updates["codex_5h_used_percent"])
+	}
+	if v, ok := derived.updates["codex_7d_used_percent"].(float64); !ok || v != primaryUsed {
+		t.Fatalf("expected updates.codex_7d_used_percent=%v, got=%v", primaryUsed, derived.updates["codex_7d_used_percent"])
+	}
+
+	fiveHourResetAt := now.Add(time.Duration(secondaryReset) * time.Second).UTC().Format(time.RFC3339)
+	if v, ok := derived.updates["codex_5h_reset_at"].(string); !ok || v != fiveHourResetAt {
+		t.Fatalf("expected updates.codex_5h_reset_at=%q, got=%v", fiveHourResetAt, derived.updates["codex_5h_reset_at"])
+	}
+
+	sevenDayResetAt := now.Add(time.Duration(primaryReset) * time.Second).UTC().Format(time.RFC3339)
+	if v, ok := derived.updates["codex_7d_reset_at"].(string); !ok || v != sevenDayResetAt {
+		t.Fatalf("expected updates.codex_7d_reset_at=%q, got=%v", sevenDayResetAt, derived.updates["codex_7d_reset_at"])
+	}
+}
+
+func TestCodexRateLimitResetAt_Prefers7dOver5h(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := now.Format(time.RFC3339)
+
+	fiveHourUsed := 100.0
+	fiveHourReset := 60
+	fiveHourWindow := 300
+
+	sevenDayUsed := 100.0
+	sevenDayReset := 3600
+	sevenDayWindow := 10080
+
+	// Put 7d in primary, 5h in secondary.
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         &sevenDayUsed,
+		PrimaryResetAfterSeconds:   &sevenDayReset,
+		PrimaryWindowMinutes:       &sevenDayWindow,
+		SecondaryUsedPercent:       &fiveHourUsed,
+		SecondaryResetAfterSeconds: &fiveHourReset,
+		SecondaryWindowMinutes:     &fiveHourWindow,
+		UpdatedAt:                  updatedAt,
+	}
+
+	derived := deriveCodexUsageSnapshot(snapshot)
+	if derived == nil {
+		t.Fatalf("expected derived snapshot, got nil")
+	}
+
+	resetAt := codexRateLimitResetAt(derived)
+	if resetAt == nil {
+		t.Fatalf("expected resetAt, got nil")
+	}
+
+	want := now.Add(time.Duration(sevenDayReset) * time.Second)
+	if !resetAt.Equal(want) {
+		t.Fatalf("expected resetAt=%v, got=%v", want, *resetAt)
+	}
+}
+
+func TestCodexRateLimitResetAt_Uses5hWhen7dNotFull(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := now.Format(time.RFC3339)
+
+	fiveHourUsed := 100.0
+	fiveHourReset := 120
+	fiveHourWindow := 300
+
+	sevenDayUsed := 80.0
+	sevenDayReset := 3600
+	sevenDayWindow := 10080
+
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         &sevenDayUsed,
+		PrimaryResetAfterSeconds:   &sevenDayReset,
+		PrimaryWindowMinutes:       &sevenDayWindow,
+		SecondaryUsedPercent:       &fiveHourUsed,
+		SecondaryResetAfterSeconds: &fiveHourReset,
+		SecondaryWindowMinutes:     &fiveHourWindow,
+		UpdatedAt:                  updatedAt,
+	}
+
+	derived := deriveCodexUsageSnapshot(snapshot)
+	if derived == nil {
+		t.Fatalf("expected derived snapshot, got nil")
+	}
+
+	resetAt := codexRateLimitResetAt(derived)
+	if resetAt == nil {
+		t.Fatalf("expected resetAt, got nil")
+	}
+
+	want := now.Add(time.Duration(fiveHourReset) * time.Second)
+	if !resetAt.Equal(want) {
+		t.Fatalf("expected resetAt=%v, got=%v", want, *resetAt)
+	}
+}
+
+func derefFloat(v *float64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1734,145 +1734,22 @@ func extractCodexUsageHeaders(headers http.Header) *OpenAICodexUsageSnapshot {
 
 // updateCodexUsageSnapshot saves the Codex usage snapshot to account's Extra field
 func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot) {
-	if snapshot == nil {
+	derived := deriveCodexUsageSnapshot(snapshot)
+	if derived == nil || len(derived.updates) == 0 {
 		return
 	}
 
-	// Convert snapshot to map for merging into Extra
-	updates := make(map[string]any)
-	if snapshot.PrimaryUsedPercent != nil {
-		updates["codex_primary_used_percent"] = *snapshot.PrimaryUsedPercent
-	}
-	if snapshot.PrimaryResetAfterSeconds != nil {
-		updates["codex_primary_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
-	}
-	if snapshot.PrimaryWindowMinutes != nil {
-		updates["codex_primary_window_minutes"] = *snapshot.PrimaryWindowMinutes
-	}
-	if snapshot.SecondaryUsedPercent != nil {
-		updates["codex_secondary_used_percent"] = *snapshot.SecondaryUsedPercent
-	}
-	if snapshot.SecondaryResetAfterSeconds != nil {
-		updates["codex_secondary_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
-	}
-	if snapshot.SecondaryWindowMinutes != nil {
-		updates["codex_secondary_window_minutes"] = *snapshot.SecondaryWindowMinutes
-	}
-	if snapshot.PrimaryOverSecondaryPercent != nil {
-		updates["codex_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
-	}
-	updates["codex_usage_updated_at"] = snapshot.UpdatedAt
-
-	// Normalize to canonical 5h/7d fields based on window_minutes
-	// This fixes the issue where OpenAI's primary/secondary naming is reversed
-	// Strategy: Compare the two windows and assign the smaller one to 5h, larger one to 7d
-
-	// IMPORTANT: We can only reliably determine window type from window_minutes field
-	// The reset_after_seconds is remaining time, not window size, so it cannot be used for comparison
-
-	var primaryWindowMins, secondaryWindowMins int
-	var hasPrimaryWindow, hasSecondaryWindow bool
-
-	// Only use window_minutes for reliable window size comparison
-	if snapshot.PrimaryWindowMinutes != nil {
-		primaryWindowMins = *snapshot.PrimaryWindowMinutes
-		hasPrimaryWindow = true
-	}
-
-	if snapshot.SecondaryWindowMinutes != nil {
-		secondaryWindowMins = *snapshot.SecondaryWindowMinutes
-		hasSecondaryWindow = true
-	}
-
-	// Determine which is 5h and which is 7d
-	var use5hFromPrimary, use7dFromPrimary bool
-	var use5hFromSecondary, use7dFromSecondary bool
-
-	if hasPrimaryWindow && hasSecondaryWindow {
-		// Both window sizes known: compare and assign smaller to 5h, larger to 7d
-		if primaryWindowMins < secondaryWindowMins {
-			use5hFromPrimary = true
-			use7dFromSecondary = true
-		} else {
-			use5hFromSecondary = true
-			use7dFromPrimary = true
-		}
-	} else if hasPrimaryWindow {
-		// Only primary window size known: classify by absolute threshold
-		if primaryWindowMins <= 360 {
-			use5hFromPrimary = true
-		} else {
-			use7dFromPrimary = true
-		}
-	} else if hasSecondaryWindow {
-		// Only secondary window size known: classify by absolute threshold
-		if secondaryWindowMins <= 360 {
-			use5hFromSecondary = true
-		} else {
-			use7dFromSecondary = true
-		}
-	} else {
-		// No window_minutes available: cannot reliably determine window types
-		// Fall back to legacy assumption (may be incorrect)
-		// Assume primary=7d, secondary=5h based on historical observation
-		if snapshot.SecondaryUsedPercent != nil || snapshot.SecondaryResetAfterSeconds != nil || snapshot.SecondaryWindowMinutes != nil {
-			use5hFromSecondary = true
-		}
-		if snapshot.PrimaryUsedPercent != nil || snapshot.PrimaryResetAfterSeconds != nil || snapshot.PrimaryWindowMinutes != nil {
-			use7dFromPrimary = true
-		}
-	}
-
-	// Write canonical 5h fields
-	if use5hFromPrimary {
-		if snapshot.PrimaryUsedPercent != nil {
-			updates["codex_5h_used_percent"] = *snapshot.PrimaryUsedPercent
-		}
-		if snapshot.PrimaryResetAfterSeconds != nil {
-			updates["codex_5h_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
-		}
-		if snapshot.PrimaryWindowMinutes != nil {
-			updates["codex_5h_window_minutes"] = *snapshot.PrimaryWindowMinutes
-		}
-	} else if use5hFromSecondary {
-		if snapshot.SecondaryUsedPercent != nil {
-			updates["codex_5h_used_percent"] = *snapshot.SecondaryUsedPercent
-		}
-		if snapshot.SecondaryResetAfterSeconds != nil {
-			updates["codex_5h_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
-		}
-		if snapshot.SecondaryWindowMinutes != nil {
-			updates["codex_5h_window_minutes"] = *snapshot.SecondaryWindowMinutes
-		}
-	}
-
-	// Write canonical 7d fields
-	if use7dFromPrimary {
-		if snapshot.PrimaryUsedPercent != nil {
-			updates["codex_7d_used_percent"] = *snapshot.PrimaryUsedPercent
-		}
-		if snapshot.PrimaryResetAfterSeconds != nil {
-			updates["codex_7d_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
-		}
-		if snapshot.PrimaryWindowMinutes != nil {
-			updates["codex_7d_window_minutes"] = *snapshot.PrimaryWindowMinutes
-		}
-	} else if use7dFromSecondary {
-		if snapshot.SecondaryUsedPercent != nil {
-			updates["codex_7d_used_percent"] = *snapshot.SecondaryUsedPercent
-		}
-		if snapshot.SecondaryResetAfterSeconds != nil {
-			updates["codex_7d_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
-		}
-		if snapshot.SecondaryWindowMinutes != nil {
-			updates["codex_7d_window_minutes"] = *snapshot.SecondaryWindowMinutes
-		}
-	}
-
-	// Update account's Extra field asynchronously
 	go func() {
 		updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
+
+		_ = s.accountRepo.UpdateExtra(updateCtx, accountID, derived.updates)
+
+		// Persist real window-based cooldown to account.rate_limit_reset_at:
+		// - 7d>=100% => cooldown until 7d reset
+		// - else if 5h>=100% => cooldown until 5h reset
+		if resetAt := codexRateLimitResetAt(derived); resetAt != nil && resetAt.After(time.Now()) {
+			_ = s.accountRepo.SetRateLimited(updateCtx, accountID, *resetAt)
+		}
 	}()
 }

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -51,6 +51,21 @@ func ProvideTokenRefreshService(
 	return svc
 }
 
+// ProvideOAuthProbeService creates and starts OAuthProbeService.
+func ProvideOAuthProbeService(
+	accountRepo AccountRepository,
+	httpUpstream HTTPUpstream,
+	openAITokenProvider *OpenAITokenProvider,
+	geminiTokenProvider *GeminiTokenProvider,
+	claudeTokenProvider *ClaudeTokenProvider,
+	accountUsageService *AccountUsageService,
+	cfg *config.Config,
+) *OAuthProbeService {
+	svc := NewOAuthProbeService(accountRepo, httpUpstream, openAITokenProvider, geminiTokenProvider, claudeTokenProvider, accountUsageService, cfg)
+	svc.Start()
+	return svc
+}
+
 // ProvideDashboardAggregationService 创建并启动仪表盘聚合服务
 func ProvideDashboardAggregationService(repo DashboardAggregationRepository, timingWheel *TimingWheelService, cfg *config.Config) *DashboardAggregationService {
 	svc := NewDashboardAggregationService(repo, timingWheel, cfg)
@@ -255,6 +270,7 @@ var ProviderSet = wire.NewSet(
 	NewCRSSyncService,
 	ProvideUpdateService,
 	ProvideTokenRefreshService,
+	ProvideOAuthProbeService,
 	ProvideAccountExpiryService,
 	ProvideTimingWheelService,
 	ProvideDashboardAggregationService,

--- a/config.yaml
+++ b/config.yaml
@@ -525,3 +525,37 @@ gemini:
         # Cooldown time (minutes) after hitting quota
         # 达到配额后的冷却时间（分钟）
         cooldown_minutes: 5
+
+# =============================================================================
+# OAuth Probe (Optional)
+# OAuth2 探活/配额同步（可选）
+# =============================================================================
+# Periodically sends "test connection" style requests to OAuth/Setup-Token accounts to:
+# 定期对 OAuth/Setup-Token 账号执行“测试连接”式请求，用于：
+# - Sync quota/usage even when the account is not scheduled
+# - 在账号未被调度时同步用量/限额信息
+# - Refresh OpenAI OAuth Codex 5h/7d usage windows (from x-codex-* response headers)
+# - 刷新 OpenAI OAuth 的 Codex 5h/7d 窗口用量（来自响应头 x-codex-*）
+#
+# WARNING: Probing consumes real quota. Keep it disabled unless needed.
+# 注意：探活会消耗真实配额，非必要请保持关闭。
+oauth_probe:
+  # Enable periodic probing
+  # 是否启用
+  enabled: false
+  # Check interval (minutes)
+  # 检查间隔（分钟）
+  check_interval_minutes: 15
+  # Idle threshold (minutes): only probe accounts that have NOT been used within this window.
+  # 闲置阈值（分钟）：仅当账号在该时长内未被使用，才会触发探活（兜底机制）。
+  # <=0 表示不按闲置过滤（每轮都会探活符合条件的账号）。
+  idle_threshold_minutes: 15
+  # Per-request timeout (seconds)
+  # 单次请求超时（秒）
+  request_timeout_seconds: 20
+  # Max concurrent probes
+  # 最大并发探活数
+  max_concurrency: 2
+  # Max accounts to probe per cycle (0 = unlimited)
+  # 每轮最多探活账号数（0 = 不限制）
+  max_accounts_per_cycle: 0

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -453,7 +453,7 @@ export interface Account {
   platform: AccountPlatform
   type: AccountType
   credentials?: Record<string, unknown>
-  extra?: CodexUsageSnapshot & Record<string, unknown> // Extra fields including Codex usage
+  extra?: CodexUsageSnapshot & ProviderUsageSnapshotExtra & Record<string, unknown> // Extra fields including Codex usage
   proxy_id: number | null
   concurrency: number
   current_concurrency?: number // Real-time concurrency count from Redis
@@ -541,6 +541,19 @@ export interface AccountUsageInfo {
   antigravity_quota?: Record<string, AntigravityModelQuota> | null
 }
 
+// Provider usage snapshot cache persisted in Account.extra (backend writes snapshots after gateway/test/probe).
+export interface ProviderUsageSnapshotExtra {
+  // Anthropic (Claude OAuth/Setup-Token)
+  claude_usage_snapshot?: AccountUsageInfo
+  claude_usage_updated_at?: string
+  claude_usage_source?: string
+
+  // Gemini (local simulated quota)
+  gemini_usage_snapshot?: AccountUsageInfo
+  gemini_usage_updated_at?: string
+  gemini_usage_source?: string
+}
+
 // OpenAI Codex usage snapshot (from response headers)
 export interface CodexUsageSnapshot {
   // Legacy fields (kept for backwards compatibility)
@@ -557,9 +570,11 @@ export interface CodexUsageSnapshot {
   codex_5h_used_percent?: number // 5-hour window usage percentage
   codex_5h_reset_after_seconds?: number // Seconds until 5h window reset
   codex_5h_window_minutes?: number // 5h window in minutes (should be ~300)
+  codex_5h_reset_at?: string // Absolute reset time (RFC3339/ISO8601)
   codex_7d_used_percent?: number // 7-day window usage percentage
   codex_7d_reset_after_seconds?: number // Seconds until 7d window reset
   codex_7d_window_minutes?: number // 7d window in minutes (should be ~10080)
+  codex_7d_reset_at?: string // Absolute reset time (RFC3339/ISO8601)
 
   codex_usage_updated_at?: string // Last update timestamp
 }


### PR DESCRIPTION
## 背景
  - OAuth2 账号（OpenAI/Claude/Gemini）用量/限额数据在“未被调度/未调用”时更新不及时，管理页容易出现滞后或假数据。
  - OpenAI OAuth（ChatGPT Codex）实际的 5h/7d 配额信息在响应头 `x-codex-*` 中，但此前未系统化落库，也无法用“窗口结束时间”驱动持续限流。

  ## 本次改动
  ### Backend
  - OpenAI OAuth（Codex）
    - 从 `https://chatgpt.com/backend-api/codex/responses` 响应头解析 `x-codex-*`，归一化为标准 5h/7d 字段并写入 `accounts.extra`（包含 `codex_*_reset_at` 绝对时间）。
    - 当 5h 或 7d 满额时写入 `accounts.rate_limit_reset_at`，实现“持续 429 到窗口结束”（7d 优先，否则 5h）。
    - 429 场景优先用 `x-codex-*` 推导真实 resetAt，替代通用 5 分钟 fallback。
  - Claude/Gemini
    - 新增统一“用量快照落库”逻辑：写入 `accounts.extra.{claude_usage_snapshot,gemini_usage_snapshot}`，并记录 `*_usage_updated_at` 与 `*_usage_source`（`gateway/test/probe`）。
    - Claude 满额时同样写入 `accounts.rate_limit_reset_at`（基于 5h/7d 的 `resets_at`）。
  - 测试连接增强
    - OpenAI/Claude/Gemini 测试连接都会写入快照到 DB（即使非 200），并在 payload 中加入随机串（nonce）避免上游缓存。
  - 新增兜底探活（可关闭）
    - 新增 `OAuthProbeService`：默认关闭；启用后每 `check_interval_minutes` 对“闲置超过 `idle_threshold_minutes`”的 OAuth/Setup-Token 账号做最小探测并同步快照。

  ### Frontend
  - Claude/Gemini 用量展示改为直接读取 `account.extra` 快照（不再 per-row 调接口）。
  - 对 `resets_at` 已过期的快照做展示层回退：显示 0% 且不显示倒计时，减少“过期假数据”影响。

  ## 配置
  - 新增配置段 `oauth_probe`（默认 `enabled: false`），支持：
    - `check_interval_minutes`
    - `idle_threshold_minutes`（默认 15；仅闲置账号触发探活）
    - `request_timeout_seconds`
    - `max_concurrency`
    - `max_accounts_per_cycle`

  ## TLS 指纹（确认点）
  - Claude 账号若开启 TLS 指纹伪装（`extra.enable_tls_fingerprint`），在获取 OAuth usage（快照同步）时也会走同一套 TLS 指纹请求路径（`DoWithTLS`）。

  ## 测试
  - 后端（通过）：`cd backend && go test ./internal/service ./internal/repository`
  - 已知：`cd backend && go test ./...` 可能因 `internal/pkg/tlsfingerprint` 外网集成测试超时失败（与本 PR 逻辑无关）。

  ## 风险/回滚
  - `oauth_probe` 可能产生额外上游请求并消耗真实配额，因此默认关闭；如需回滚影响，保持 `oauth_probe.enabled=false` 即可。
  - #353 
