### PR TITLE
 移除 OAuth 账号不支持的参数（ droid 调用发送的参数 ） Remove unsupported parameters for…

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -806,6 +806,20 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
+	// 增加droid支持 删除droid发起的请求参数 不删除会导致openai报错
+	if account.Type == AccountTypeOAuth {
+		if retention, ok := reqBody["prompt_cache_retention"]; ok {
+			delete(reqBody, "prompt_cache_retention")
+			bodyModified = true
+			log.Printf("[OpenAI] Removed unsupported prompt_cache_retention=%v (account: %s)", retention, account.Name)
+		}
+		if identifier, ok := reqBody["safety_identifier"]; ok {
+			delete(reqBody, "safety_identifier")
+			bodyModified = true
+			log.Printf("[OpenAI] Removed unsupported safety_identifier=%v (account: %s)", identifier, account.Name)
+		}
+	}
+	
 	// Handle max_output_tokens based on platform and account type
 	if !isCodexCLI {
 		if maxOutputTokens, hasMaxOutputTokens := reqBody["max_output_tokens"]; hasMaxOutputTokens {


### PR DESCRIPTION
… OAuth accounts

从请求体中移除 OAuth 账号不支持的参数。
Remove unsupported parameters from request body for OAuth accounts.