### PR TITLE
chore: upgrade Antigravity User-Agent to 1.15.8

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -33,7 +33,7 @@ const (
 		"https://www.googleapis.com/auth/experimentsandconfigs"
 
 	// User-Agent（与 Antigravity-Manager 保持一致）
-	UserAgent = "antigravity/1.11.9 windows/amd64"
+	UserAgent = "antigravity/1.15.8 windows/amd64"
 
 	// Session 过期时间
 	SessionTTL = 30 * time.Minute


### PR DESCRIPTION
## 变更内容

将 Antigravity User-Agent 版本从 `1.11.9` 升级到 `1.15.8`，与最新的 Antigravity-Manager 保持一致。

## 修改文件

- `backend/internal/pkg/antigravity/oauth.go`