### PR TITLE
gateway: apply Claude Code default headers when TLS fingerprint simulation enabled (fix #392)

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2753,6 +2753,15 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 		s.identityService.ApplyFingerprint(req, fingerprint)
 	}
 
+	// TLS指纹启用：添加Claude Code客户端标准Headers（覆盖任何现有值）
+	// 这与TLS指纹配置一起，使服务器完全伪装成官方Claude Code客户端
+	if account.IsTLSFingerprintEnabled() {
+		// 从claude包应用Claude Code默认Headers，覆盖现有头
+		for key, value := range claude.DefaultHeaders {
+			req.Header.Set(key, value)
+		}
+	}
+
 	// 确保必要的headers存在
 	if req.Header.Get("content-type") == "" {
 		req.Header.Set("content-type", "application/json")
@@ -3792,6 +3801,14 @@ func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Con
 		fp, _ := s.identityService.GetOrCreateFingerprint(ctx, account.ID, c.Request.Header)
 		if fp != nil {
 			s.identityService.ApplyFingerprint(req, fp)
+		}
+	}
+
+	// TLS指纹启用：添加Claude Code客户端标准Headers（覆盖任何现有值）
+	// 这与TLS指纹配置一起，使服务器完全伪装成官方Claude Code客户端
+	if account.IsTLSFingerprintEnabled() {
+		for key, value := range claude.DefaultHeaders {
+			req.Header.Set(key, value)
 		}
 	}
 


### PR DESCRIPTION
🔖 PR 基本信息
分支：fix/claude-code-tls-fingerprint-headers-392
目标仓库 PR：#432

🔧 代码变更要点
文件：backend/internal/service/gateway_service.go
变更：在构建上游请求时（包括 buildUpstreamRequest 与 buildCountTokensRequest），当 account.IsTLSFingerprintEnabled() 为 true 时，遍历 claude.DefaultHeaders 并对 req.Header 调用 Set，覆盖现有同名头部（例如 User-Agent, X-Stainless-* 等）。认证头 (authorization / x-api-key) 保持存在（claude.DefaultHeaders 不包含这些键）。

（相同逻辑也已在 buildCountTokensRequest 中添加）

---

📝 PR 描述

**概要**

当账号启用"模拟 Node.js / Claude Code 客户端的 TLS 指纹"时，转发到 Anthropic（Claude / Claude Code）上游的请求会注入来自 internal/pkg/claude.DefaultHeaders 的默认头部，并覆盖请求中对应头部值，从而确保使用 Claude Code 的 OAuth/Setup Token 在上游被识别为官方客户端调用，避免上游返回：
"This credential is only authorized for use with Claude Code"。

---

**变更点（实现细节）**

修改文件：backend/internal/service/gateway_service.go
- 在 buildUpstreamRequest 与 buildCountTokensRequest 中，新增逻辑：当 account.IsTLSFingerprintEnabled() 为 true 时，遍历 claude.DefaultHeaders 并对 req.Header 调用 Set，覆盖同名头部（例如 User-Agent, X-Stainless-*, X-App 等）。
- 认证头 authorization（OAuth）或 x-api-key（API Key）仍然会被保留（DefaultHeaders 不包含这些键），因此认证信息不受影响。

---

**代码修改**

在 buildUpstreamRequest 中添加的逻辑（第 2755-2763 行）：
```go
// TLS指纹启用：添加Claude Code客户端标准Headers（覆盖任何现有值）
// 这与TLS指纹配置一起，使服务器完全伪装成官方Claude Code客户端
if account.IsTLSFingerprintEnabled() {
    // 从claude包应用Claude Code默认Headers，覆盖现有头
    for key, value := range claude.DefaultHeaders {
        req.Header.Set(key, value)
    }
}
```

在 buildCountTokensRequest 中添加的逻辑（第 3807-3814 行）：
```go
// TLS指纹启用：添加Claude Code客户端标准Headers（覆盖任何现有值）
// 这与TLS指纹配置一起，使服务器完全伪装成官方Claude Code客户端
if account.IsTLSFingerprintEnabled() {
    for key, value := range claude.DefaultHeaders {
        req.Header.Set(key, value)
    }
}
```

---

**安全性与兼容性**

覆盖行为为有意设计，仅在用户显式启用 TLS 指纹模拟时生效，不影响默认账号行为。用途是确保在上游严格基于客户端头判断调用来源时，能以官方客户端特征通过校验（例如 Claude Code 的客户端限制）。

---

**测试**

本地验证：
- 命令：`(cd backend && go test ./internal/service -v)`
- 结果：internal/service 包所有单元测试通过，包括 Claude 相关逻辑测试。

---

**关联 Issue**

Fixes #392