### PR TITLE
fix(ratelimit): implement per-model isolation and monotonic cooldowns

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -835,8 +835,12 @@ func (r *accountRepository) SetAntigravityQuotaScopeLimit(ctx context.Context, i
 	return nil
 }
 
-func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, scope string, resetAt time.Time) error {
-	if scope == "" {
+func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, key string, resetAt time.Time) error {
+	if key == "" {
+		return nil
+	}
+	if !service.IsSafeModelRateLimitKey(key) {
+		log.Printf("[SchedulerOutbox] refused unsafe model rate limit key: account=%d key=%q", id, key)
 		return nil
 	}
 	now := time.Now().UTC()
@@ -849,14 +853,26 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 		return err
 	}
 
-	path := "{model_rate_limits," + scope + "}"
 	client := clientFromContext(ctx, r.client)
 	result, err := client.ExecContext(
 		ctx,
-		"UPDATE accounts SET extra = jsonb_set(COALESCE(extra, '{}'::jsonb), $1::text[], $2::jsonb, true), updated_at = NOW() WHERE id = $3 AND deleted_at IS NULL",
-		path,
+		"UPDATE accounts\n"+
+			"SET extra = COALESCE(extra, '{}'::jsonb) || jsonb_build_object('model_rate_limits', COALESCE(extra->'model_rate_limits', '{}'::jsonb) || jsonb_build_object($1::text, $2::jsonb)), updated_at = NOW()\n"+
+			"WHERE id = $3 AND deleted_at IS NULL\n"+
+			"  AND (\n"+
+			"    GREATEST(\n"+
+			"      CASE WHEN (extra->'model_rate_limits'->($1)::text->>'rate_limit_reset_at') ~ '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}' \n"+
+			"           THEN (extra->'model_rate_limits'->($1)::text->>'rate_limit_reset_at')::timestamptz \n"+
+			"           ELSE '-infinity'::timestamptz END,\n"+
+			"      CASE WHEN (extra->'model_rate_limits'->(split_part($1, ':', 2))::text->>'rate_limit_reset_at') ~ '^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}' \n"+
+			"           THEN (extra->'model_rate_limits'->(split_part($1, ':', 2))::text->>'rate_limit_reset_at')::timestamptz \n"+
+			"           ELSE '-infinity'::timestamptz END\n"+
+			"    ) < $4::timestamptz\n"+
+			")",
+		key,
 		raw,
 		id,
+		resetAt.UTC().Format(time.RFC3339),
 	)
 	if err != nil {
 		return err
@@ -867,9 +883,21 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 		return err
 	}
 	if affected == 0 {
-		return service.ErrAccountNotFound
+		exists, err := r.client.Account.Query().
+			Where(dbaccount.IDEQ(id), dbaccount.DeletedAtIsNil()).
+			Exist(ctx)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return service.ErrAccountNotFound
+		}
+		return nil
 	}
-	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+	outboxPayload := buildSchedulerOutboxPayload(nil, map[string]any{
+		"model_rate_limit_keys": []string{key},
+	})
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, outboxPayload); err != nil {
 		log.Printf("[SchedulerOutbox] enqueue model rate limit failed: account=%d err=%v", id, err)
 	}
 	return nil
@@ -1479,10 +1507,24 @@ func mergeGroupIDs(a []int64, b []int64) []int64 {
 }
 
 func buildSchedulerGroupPayload(groupIDs []int64) map[string]any {
-	if len(groupIDs) == 0 {
+	return buildSchedulerOutboxPayload(groupIDs, nil)
+}
+
+func buildSchedulerOutboxPayload(groupIDs []int64, extras map[string]any) map[string]any {
+	if len(groupIDs) == 0 && len(extras) == 0 {
 		return nil
 	}
-	return map[string]any{"group_ids": groupIDs}
+	payload := make(map[string]any)
+	if len(groupIDs) > 0 {
+		payload["group_ids"] = groupIDs
+	}
+	for k, v := range extras {
+		if v == nil {
+			continue
+		}
+		payload[k] = v
+	}
+	return payload
 }
 
 func accountEntityToService(m *dbent.Account) *service.Account {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -155,6 +155,78 @@ func (s *AccountRepoSuite) TestDelete_WithGroupBindings() {
 	s.Require().Zero(count, "expected bindings to be removed")
 }
 
+func (s *AccountRepoSuite) TestSetModelRateLimitMonotonic() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "rl"})
+	bucketKey := "test-provider:test-bucket"
+	first := time.Now().Add(5 * time.Minute).UTC()
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, first))
+	firstReset := s.bucketResetAt(account.ID, bucketKey)
+	s.Require().Equal(first.Unix(), firstReset.Unix())
+
+	second := first.Add(-time.Minute).UTC()
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, second))
+	unchanged := s.bucketResetAt(account.ID, bucketKey)
+	s.Require().Equal(first.Unix(), unchanged.Unix())
+
+	third := first.Add(10 * time.Minute).UTC()
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, third))
+	updated := s.bucketResetAt(account.ID, bucketKey)
+	s.Require().Equal(third.Unix(), updated.Unix())
+}
+
+func (s *AccountRepoSuite) TestSetModelRateLimitOutboxMonotonic() {
+	_, _ = integrationDB.ExecContext(s.ctx, "TRUNCATE scheduler_outbox")
+
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "outbox-monotonic"})
+	bucketKey := "test-provider:test-bucket"
+	first := time.Now().Add(5 * time.Minute).UTC()
+
+	// 1. Initial write should enqueue.
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, first))
+	count := s.outboxCount()
+	s.Require().Equal(1, count, "expected 1 outbox entry after initial write")
+
+	// 2. Shorter reset (no-op) should NOT enqueue.
+	second := first.Add(-time.Minute).UTC()
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, second))
+	s.Require().Equal(count, s.outboxCount(), "outbox count should remain same after shorter reset")
+
+	// 3. Identical reset (no-op) should NOT enqueue.
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, first))
+	s.Require().Equal(count, s.outboxCount(), "outbox count should remain same after identical reset")
+
+	// 4. Longer reset (extension) should enqueue.
+	third := first.Add(10 * time.Minute).UTC()
+	s.Require().NoError(s.repo.SetModelRateLimit(s.ctx, account.ID, bucketKey, third))
+	s.Require().Equal(count+1, s.outboxCount(), "expected outbox count to increase after longer reset")
+}
+
+func (s *AccountRepoSuite) outboxCount() int {
+	rows, err := s.repo.sql.QueryContext(s.ctx, "SELECT count(*) FROM scheduler_outbox")
+	s.Require().NoError(err)
+	defer rows.Close()
+	s.Require().True(rows.Next())
+	var count int
+	s.Require().NoError(rows.Scan(&count))
+	return count
+}
+
+func (s *AccountRepoSuite) bucketResetAt(accountID int64, bucketKey string) time.Time {
+	account, err := s.repo.GetByID(s.ctx, accountID)
+	s.Require().NoError(err)
+	extra := account.Extra
+	s.Require().NotNil(extra)
+	rawLimits, ok := extra["model_rate_limits"].(map[string]any)
+	s.Require().True(ok, "model_rate_limits entry present")
+	rawLimit, ok := rawLimits[bucketKey].(map[string]any)
+	s.Require().True(ok, "bucket entry exists")
+	resetRaw, ok := rawLimit["rate_limit_reset_at"].(string)
+	s.Require().True(ok, "reset field present")
+	resetAt, err := time.Parse(time.RFC3339, resetRaw)
+	s.Require().NoError(err)
+	return resetAt.UTC()
+}
+
 // --- List / ListWithFilters ---
 
 func (s *AccountRepoSuite) TestList() {

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -758,7 +758,9 @@ func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context,
 		c:              c,
 		httpUpstream:   s.httpUpstream,
 		settingService: s.settingService,
-		handleError:    s.handleUpstreamError,
+		handleError: func(ctx context.Context, prefix string, account *Account, statusCode int, headers http.Header, body []byte, quotaScope AntigravityQuotaScope) {
+			s.handleUpstreamError(ctx, c, prefix, account, mappedModel, statusCode, headers, body, quotaScope)
+		},
 	})
 	if err != nil {
 		return nil, s.writeClaudeError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed after retries")
@@ -834,7 +836,9 @@ func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context,
 					c:              c,
 					httpUpstream:   s.httpUpstream,
 					settingService: s.settingService,
-					handleError:    s.handleUpstreamError,
+					handleError: func(ctx context.Context, prefix string, account *Account, statusCode int, headers http.Header, body []byte, quotaScope AntigravityQuotaScope) {
+						s.handleUpstreamError(ctx, c, prefix, account, mappedModel, statusCode, headers, body, quotaScope)
+					},
 				})
 				if retryErr != nil {
 					appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
@@ -910,7 +914,7 @@ func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context,
 
 		// 处理错误响应（重试后仍失败或不触发重试）
 		if resp.StatusCode >= 400 {
-			s.handleUpstreamError(ctx, prefix, account, resp.StatusCode, resp.Header, respBody, quotaScope)
+			s.handleUpstreamError(ctx, c, prefix, account, mappedModel, resp.StatusCode, resp.Header, respBody, quotaScope)
 
 			if s.shouldFailoverUpstreamError(resp.StatusCode) {
 				upstreamMsg := strings.TrimSpace(extractAntigravityErrorMessage(respBody))
@@ -1336,7 +1340,9 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 		c:              c,
 		httpUpstream:   s.httpUpstream,
 		settingService: s.settingService,
-		handleError:    s.handleUpstreamError,
+		handleError: func(ctx context.Context, prefix string, account *Account, statusCode int, headers http.Header, body []byte, quotaScope AntigravityQuotaScope) {
+			s.handleUpstreamError(ctx, c, prefix, account, mappedModel, statusCode, headers, body, quotaScope)
+		},
 	})
 	if err != nil {
 		return nil, s.writeGoogleError(c, http.StatusBadGateway, "Upstream request failed after retries")
@@ -1393,7 +1399,7 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 		if unwrapErr != nil || len(unwrappedForOps) == 0 {
 			unwrappedForOps = respBody
 		}
-		s.handleUpstreamError(ctx, prefix, account, resp.StatusCode, resp.Header, respBody, quotaScope)
+		s.handleUpstreamError(ctx, c, prefix, account, mappedModel, resp.StatusCode, resp.Header, respBody, quotaScope)
 		upstreamMsg := strings.TrimSpace(extractAntigravityErrorMessage(unwrappedForOps))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 
@@ -1533,11 +1539,13 @@ func antigravityUseScopeRateLimit() bool {
 	return v == "1" || v == "true" || v == "yes" || v == "on"
 }
 
-func (s *AntigravityGatewayService) handleUpstreamError(ctx context.Context, prefix string, account *Account, statusCode int, headers http.Header, body []byte, quotaScope AntigravityQuotaScope) {
+func (s *AntigravityGatewayService) handleUpstreamError(ctx context.Context, c *gin.Context, prefix string, account *Account, effectiveModel string, statusCode int, headers http.Header, body []byte, quotaScope AntigravityQuotaScope) {
+	var signal *RateLimitSignal
 	// 429 使用 Gemini 格式解析（从 body 解析重置时间）
 	if statusCode == 429 {
 		useScopeLimit := antigravityUseScopeRateLimit() && quotaScope != ""
 		resetAt := ParseGeminiRateLimitResetTime(body)
+		var resetTime time.Time
 		if resetAt == nil {
 			// 解析失败：使用配置的 fallback 时间，直接限流整个账户
 			fallbackMinutes := 5
@@ -1545,39 +1553,64 @@ func (s *AntigravityGatewayService) handleUpstreamError(ctx context.Context, pre
 				fallbackMinutes = s.settingService.cfg.Gateway.AntigravityFallbackCooldownMinutes
 			}
 			defaultDur := time.Duration(fallbackMinutes) * time.Minute
-			ra := time.Now().Add(defaultDur)
+			resetTime = time.Now().Add(defaultDur)
 			if useScopeLimit {
 				log.Printf("%s status=429 rate_limited scope=%s reset_in=%v (fallback)", prefix, quotaScope, defaultDur)
-				if err := s.accountRepo.SetAntigravityQuotaScopeLimit(ctx, account.ID, quotaScope, ra); err != nil {
+				if err := s.accountRepo.SetAntigravityQuotaScopeLimit(ctx, account.ID, quotaScope, resetTime); err != nil {
 					log.Printf("%s status=429 rate_limit_set_failed scope=%s error=%v", prefix, quotaScope, err)
 				}
 			} else {
-				log.Printf("%s status=429 rate_limited account=%d reset_in=%v (fallback)", prefix, account.ID, defaultDur)
-				if err := s.accountRepo.SetRateLimited(ctx, account.ID, ra); err != nil {
-					log.Printf("%s status=429 rate_limit_set_failed account=%d error=%v", prefix, account.ID, err)
+				if key, ok := ModelRateLimitKey(account.Platform, effectiveModel); ok {
+					log.Printf("%s status=429 rate_limited key=%s reset_in=%v (fallback)", prefix, key, defaultDur)
+					if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, resetTime); err != nil {
+						log.Printf("%s status=429 rate_limit_set_failed key=%s error=%v", prefix, key, err)
+					}
+				} else {
+					log.Printf("%s status=429 rate_limited account=%d reset_in=%v (fallback)", prefix, account.ID, defaultDur)
+					if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
+						log.Printf("%s status=429 rate_limit_set_failed account=%d error=%v", prefix, account.ID, err)
+					}
 				}
 			}
-			return
-		}
-		resetTime := time.Unix(*resetAt, 0)
-		if useScopeLimit {
-			log.Printf("%s status=429 rate_limited scope=%s reset_at=%v reset_in=%v", prefix, quotaScope, resetTime.Format("15:04:05"), time.Until(resetTime).Truncate(time.Second))
-			if err := s.accountRepo.SetAntigravityQuotaScopeLimit(ctx, account.ID, quotaScope, resetTime); err != nil {
-				log.Printf("%s status=429 rate_limit_set_failed scope=%s error=%v", prefix, quotaScope, err)
-			}
 		} else {
-			log.Printf("%s status=429 rate_limited account=%d reset_at=%v reset_in=%v", prefix, account.ID, resetTime.Format("15:04:05"), time.Until(resetTime).Truncate(time.Second))
-			if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
-				log.Printf("%s status=429 rate_limit_set_failed account=%d error=%v", prefix, account.ID, err)
+			resetTime = time.Unix(*resetAt, 0)
+			if useScopeLimit {
+				log.Printf("%s status=429 rate_limited scope=%s reset_at=%v reset_in=%v", prefix, quotaScope, resetTime.Format("15:04:05"), time.Until(resetTime).Truncate(time.Second))
+				if err := s.accountRepo.SetAntigravityQuotaScopeLimit(ctx, account.ID, quotaScope, resetTime); err != nil {
+					log.Printf("%s status=429 rate_limit_set_failed scope=%s error=%v", prefix, quotaScope, err)
+				}
+			} else {
+				if key, ok := ModelRateLimitKey(account.Platform, effectiveModel); ok {
+					log.Printf("%s status=429 rate_limited key=%s reset_at=%v reset_in=%v", prefix, key, resetTime.Format("15:04:05"), time.Until(resetTime).Truncate(time.Second))
+					if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, resetTime); err != nil {
+						log.Printf("%s status=429 rate_limit_set_failed key=%s error=%v", prefix, key, err)
+					}
+				} else {
+					log.Printf("%s status=429 rate_limited account=%d reset_at=%v reset_in=%v", prefix, account.ID, resetTime.Format("15:04:05"), time.Until(resetTime).Truncate(time.Second))
+					if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
+						log.Printf("%s status=429 rate_limit_set_failed account=%d error=%v", prefix, account.ID, err)
+					}
+				}
 			}
 		}
+
+		resetTime = clampResetAt(resetTime, time.Now())
+		signal = &RateLimitSignal{Scope: RateLimitScopeAccount, ResetAt: resetTime}
+		if !useScopeLimit {
+			if key, ok := ModelRateLimitKey(account.Platform, effectiveModel); ok {
+				signal.Scope = RateLimitScopeModelBucket
+				signal.Key = key
+			}
+		}
+		setRateLimitResponseHeaders(c, signal)
 		return
 	}
 	// 其他错误码继续使用 rateLimitService
 	if s.rateLimitService == nil {
 		return
 	}
-	shouldDisable := s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, headers, body)
+	shouldDisable, signal := s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, statusCode, headers, body)
+	setRateLimitResponseHeaders(c, signal)
 	if shouldDisable {
 		log.Printf("%s status=%d marked_error", prefix, statusCode)
 	}

--- a/backend/internal/service/antigravity_quota_scope.go
+++ b/backend/internal/service/antigravity_quota_scope.go
@@ -49,13 +49,14 @@ func (a *Account) IsSchedulableForModel(requestedModel string) bool {
 	if !a.IsSchedulable() {
 		return false
 	}
-	if a.isModelRateLimited(requestedModel) {
+	effectiveModel := a.GetMappedModel(requestedModel)
+	if a.isModelRateLimited(effectiveModel) {
 		return false
 	}
 	if a.Platform != PlatformAntigravity {
 		return true
 	}
-	scope, ok := resolveAntigravityQuotaScope(requestedModel)
+	scope, ok := resolveAntigravityQuotaScope(effectiveModel)
 	if !ok {
 		return true
 	}

--- a/backend/internal/service/antigravity_quota_scope_test.go
+++ b/backend/internal/service/antigravity_quota_scope_test.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSchedulableForModel_TableDriven(t *testing.T) {
+	now := time.Now()
+	future := now.Add(1 * time.Hour)
+	past := now.Add(-1 * time.Hour)
+
+	tests := []struct {
+		name           string
+		account        *Account
+		requestedModel string
+		want           bool
+	}{
+		{
+			name: "direct_bucket_limited",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"anthropic:claude-3-opus": map[string]any{
+							"rate_limit_reset_at": future.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "claude-3-opus",
+			want:           false,
+		},
+		{
+			name: "direct_bucket_eligible_different_model",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"anthropic:claude-3-opus": map[string]any{
+							"rate_limit_reset_at": future.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "claude-3-haiku",
+			want:           true,
+		},
+		{
+			name: "anthropic_family_bucket_limited",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"anthropic:claude_sonnet": map[string]any{
+							"rate_limit_reset_at": future.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "claude-3-5-sonnet",
+			want:           false,
+		},
+		{
+			name: "gemini_family_isolation_flash_limited_pro_eligible",
+			account: &Account{
+				Platform:    PlatformGemini,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"gemini:gemini-3-flash": map[string]any{
+							"rate_limit_reset_at": future.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "gemini-3-pro",
+			want:           true,
+		},
+		{
+			name: "gemini_family_flash_limited_blocks_other_flash",
+			account: &Account{
+				Platform:    PlatformGemini,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"gemini:gemini-3-flash": map[string]any{
+							"rate_limit_reset_at": future.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "gemini-3-flash-001",
+			want:           false,
+		},
+		{
+			name: "legacy_bucket_limited",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"claude_sonnet": map[string]any{
+							"rate_limit_reset_at": future.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "claude-3-sonnet-20240229",
+			want:           false,
+		},
+		{
+			name: "expired_limit_is_eligible",
+			account: &Account{
+				Platform:    PlatformAnthropic,
+				Status:      StatusActive,
+				Schedulable: true,
+				Extra: map[string]any{
+					"model_rate_limits": map[string]any{
+						"anthropic:claude-3-5-sonnet": map[string]any{
+							"rate_limit_reset_at": past.Format(time.RFC3339),
+						},
+					},
+				},
+			},
+			requestedModel: "claude-3-5-sonnet",
+			want:           true,
+		},
+		{
+			name: "global_limited_blocks_all",
+			account: &Account{
+				Platform:         PlatformAnthropic,
+				Status:           StatusActive,
+				Schedulable:      true,
+				RateLimitResetAt: &future,
+			},
+			requestedModel: "claude-3-opus",
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.IsSchedulableForModel(tt.requestedModel))
+		})
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -2556,7 +2556,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			log.Printf("[Forward] Upstream error (retry exhausted, failover): Account=%d(%s) Status=%d RequestID=%s Body=%s",
 				account.ID, account.Name, resp.StatusCode, resp.Header.Get("x-request-id"), truncateString(string(respBody), 1000))
 
-			s.handleRetryExhaustedSideEffects(ctx, resp, account)
+			s.handleRetryExhaustedSideEffects(ctx, resp, account, reqModel)
 			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 				Platform:           account.Platform,
 				AccountID:          account.ID,
@@ -2574,7 +2574,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			})
 			return nil, &UpstreamFailoverError{StatusCode: resp.StatusCode}
 		}
-		return s.handleRetryExhaustedError(ctx, resp, c, account)
+		return s.handleRetryExhaustedError(ctx, resp, c, account, reqModel)
 	}
 
 	// 处理可切换账号的错误
@@ -2587,7 +2587,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		log.Printf("[Forward] Upstream error (failover): Account=%d(%s) Status=%d RequestID=%s Body=%s",
 			account.ID, account.Name, resp.StatusCode, resp.Header.Get("x-request-id"), truncateString(string(respBody), 1000))
 
-		s.handleFailoverSideEffects(ctx, resp, account)
+		s.handleFailoverSideEffects(ctx, resp, account, reqModel)
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
 			AccountID:          account.ID,
@@ -2612,7 +2612,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 			if readErr != nil {
 				// ReadAll failed, fall back to normal error handling without consuming the stream
-				return s.handleErrorResponse(ctx, resp, c, account)
+				return s.handleErrorResponse(ctx, resp, c, account, reqModel)
 			}
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
@@ -2648,11 +2648,11 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				} else {
 					log.Printf("Account %d: 400 error, attempting failover", account.ID)
 				}
-				s.handleFailoverSideEffects(ctx, resp, account)
+				s.handleFailoverSideEffects(ctx, resp, account, reqModel)
 				return nil, &UpstreamFailoverError{StatusCode: resp.StatusCode}
 			}
 		}
-		return s.handleErrorResponse(ctx, resp, c, account)
+		return s.handleErrorResponse(ctx, resp, c, account, reqModel)
 	}
 
 	// 处理正常响应
@@ -2935,7 +2935,7 @@ func extractUpstreamErrorMessage(body []byte) string {
 	return gjson.GetBytes(body, "message").String()
 }
 
-func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account) (*ForwardResult, error) {
+func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, effectiveModel string) (*ForwardResult, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 
 	// 调试日志：打印上游错误响应
@@ -2967,9 +2967,11 @@ func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Res
 
 	// 处理上游错误，标记账号状态
 	shouldDisable := false
+	var rateLimitSignal *RateLimitSignal
 	if s.rateLimitService != nil {
-		shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		shouldDisable, rateLimitSignal = s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, resp.StatusCode, resp.Header, body)
 	}
+	setRateLimitResponseHeaders(c, rateLimitSignal)
 	if shouldDisable {
 		return nil, &UpstreamFailoverError{StatusCode: resp.StatusCode}
 	}
@@ -3042,13 +3044,15 @@ func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Res
 	return nil, fmt.Errorf("upstream error: %d message=%s", resp.StatusCode, upstreamMsg)
 }
 
-func (s *GatewayService) handleRetryExhaustedSideEffects(ctx context.Context, resp *http.Response, account *Account) {
+func (s *GatewayService) handleRetryExhaustedSideEffects(ctx context.Context, resp *http.Response, account *Account, effectiveModel string) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	statusCode := resp.StatusCode
 
 	// OAuth/Setup Token 账号的 403：标记账号异常
 	if account.IsOAuth() && statusCode == 403 {
-		s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, resp.Header, body)
+		if s.rateLimitService != nil {
+			_, _ = s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, statusCode, resp.Header, body)
+		}
 		log.Printf("Account %d: marked as error after %d retries for status %d", account.ID, maxRetryAttempts, statusCode)
 	} else {
 		// API Key 未配置错误码：不标记账号状态
@@ -3056,21 +3060,23 @@ func (s *GatewayService) handleRetryExhaustedSideEffects(ctx context.Context, re
 	}
 }
 
-func (s *GatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account) {
+func (s *GatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, effectiveModel string) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	if s.rateLimitService != nil {
+		_, _ = s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, resp.StatusCode, resp.Header, body)
+	}
 }
 
 // handleRetryExhaustedError 处理重试耗尽后的错误
 // OAuth 403：标记账号异常
 // API Key 未配置错误码：仅返回错误，不标记账号
-func (s *GatewayService) handleRetryExhaustedError(ctx context.Context, resp *http.Response, c *gin.Context, account *Account) (*ForwardResult, error) {
+func (s *GatewayService) handleRetryExhaustedError(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, effectiveModel string) (*ForwardResult, error) {
 	// Capture upstream error body before side-effects consume the stream.
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	_ = resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
-	s.handleRetryExhaustedSideEffects(ctx, resp, account)
+	s.handleRetryExhaustedSideEffects(ctx, resp, account, effectiveModel)
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -3690,7 +3696,11 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	// 处理错误响应
 	if resp.StatusCode >= 400 {
 		// 标记账号状态（429/529等）
-		s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		var rateLimitSignal *RateLimitSignal
+		if s.rateLimitService != nil {
+			_, rateLimitSignal = s.rateLimitService.HandleUpstreamError(ctx, account, reqModel, resp.StatusCode, resp.Header, respBody)
+		}
+		setRateLimitResponseHeaders(c, rateLimitSignal)
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -781,7 +781,8 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 			}
 			if resp.StatusCode == 429 {
 				// Mark as rate-limited early so concurrent requests avoid this account.
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				rateLimitSignal := s.handleGeminiUpstreamError(ctx, account, mappedModel, resp.StatusCode, resp.Header, respBody)
+				setRateLimitResponseHeaders(c, rateLimitSignal)
 			}
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
@@ -832,7 +833,8 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 		if s.rateLimitService != nil {
 			tempMatched = s.rateLimitService.HandleTempUnschedulable(ctx, account, resp.StatusCode, respBody)
 		}
-		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		rateLimitSignal := s.handleGeminiUpstreamError(ctx, account, mappedModel, resp.StatusCode, resp.Header, respBody)
+		setRateLimitResponseHeaders(c, rateLimitSignal)
 		if tempMatched {
 			upstreamReqID := resp.Header.Get(requestIDHeader)
 			if upstreamReqID == "" {
@@ -890,6 +892,9 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 		upstreamReqID := resp.Header.Get(requestIDHeader)
 		if upstreamReqID == "" {
 			upstreamReqID = resp.Header.Get("x-goog-request-id")
+		}
+		if rateLimitSignal != nil {
+			setRateLimitResponseHeaders(c, rateLimitSignal)
 		}
 		return nil, s.writeGeminiMappedError(c, account, resp.StatusCode, upstreamReqID, respBody)
 	}
@@ -1174,7 +1179,8 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				break
 			}
 			if resp.StatusCode == 429 {
-				s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				rateLimitSignal := s.handleGeminiUpstreamError(ctx, account, mappedModel, resp.StatusCode, resp.Header, respBody)
+				setRateLimitResponseHeaders(c, rateLimitSignal)
 			}
 			if attempt < geminiMaxRetries {
 				upstreamReqID := resp.Header.Get(requestIDHeader)
@@ -1247,7 +1253,8 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 		if s.rateLimitService != nil {
 			tempMatched = s.rateLimitService.HandleTempUnschedulable(ctx, account, resp.StatusCode, respBody)
 		}
-		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		rateLimitSignal := s.handleGeminiUpstreamError(ctx, account, mappedModel, resp.StatusCode, resp.Header, respBody)
+		setRateLimitResponseHeaders(c, rateLimitSignal)
 
 		// Best-effort fallback for OAuth tokens missing AI Studio scopes when calling countTokens.
 		// This avoids Gemini SDKs failing hard during preflight token counting.
@@ -2547,13 +2554,13 @@ func asInt(v any) (int, bool) {
 	}
 }
 
-func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, body []byte) {
+func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Context, account *Account, effectiveModel string, statusCode int, headers http.Header, body []byte) *RateLimitSignal {
 	if s.rateLimitService != nil && (statusCode == 401 || statusCode == 403 || statusCode == 529) {
-		s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, headers, body)
-		return
+		_, _ = s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, statusCode, headers, body)
+		return nil
 	}
 	if statusCode != 429 {
-		return
+		return nil
 	}
 
 	oauthType := account.GeminiOAuthType()
@@ -2561,38 +2568,43 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 	projectID := strings.TrimSpace(account.GetCredential("project_id"))
 	isCodeAssist := account.IsGeminiCodeAssist()
 
-	resetAt := ParseGeminiRateLimitResetTime(body)
-	if resetAt == nil {
-		// 根据账号类型使用不同的默认重置时间
-		var ra time.Time
-		if isCodeAssist {
-			// Code Assist: fallback cooldown by tier
-			cooldown := geminiCooldownForTier(tierID)
-			if s.rateLimitService != nil {
-				cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
-			}
-			ra = time.Now().Add(cooldown)
-			log.Printf("[Gemini 429] Account %d (Code Assist, tier=%s, project=%s) rate limited, cooldown=%v", account.ID, tierID, projectID, time.Until(ra).Truncate(time.Second))
-		} else {
-			// API Key / AI Studio OAuth: PST 午夜
-			if ts := nextGeminiDailyResetUnix(); ts != nil {
-				ra = time.Unix(*ts, 0)
-				log.Printf("[Gemini 429] Account %d (API Key/AI Studio, type=%s) rate limited, reset at PST midnight (%v)", account.ID, account.Type, ra)
-			} else {
-				// 兜底：5 分钟
-				ra = time.Now().Add(5 * time.Minute)
-				log.Printf("[Gemini 429] Account %d rate limited, fallback to 5min", account.ID)
-			}
+	var resetTime time.Time
+	if resetAt := ParseGeminiRateLimitResetTime(body); resetAt != nil {
+		resetTime = time.Unix(*resetAt, 0)
+	} else if isCodeAssist {
+		cooldown := geminiCooldownForTier(tierID)
+		if s.rateLimitService != nil {
+			cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
 		}
-		_ = s.accountRepo.SetRateLimited(ctx, account.ID, ra)
-		return
+		resetTime = time.Now().Add(cooldown)
+		log.Printf("[Gemini 429] Account %d (Code Assist, tier=%s, project=%s) rate limited, cooldown=%v", account.ID, tierID, projectID, time.Until(resetTime).Truncate(time.Second))
+	} else if ts := nextGeminiDailyResetUnix(); ts != nil {
+		resetTime = time.Unix(*ts, 0)
+		log.Printf("[Gemini 429] Account %d (API Key/AI Studio, type=%s) rate limited, reset at PST midnight (%v)", account.ID, account.Type, resetTime)
+	} else {
+		resetTime = time.Now().Add(5 * time.Minute)
+		log.Printf("[Gemini 429] Account %d rate limited, fallback to 5min", account.ID)
 	}
 
-	// 使用解析到的重置时间
-	resetTime := time.Unix(*resetAt, 0)
-	_ = s.accountRepo.SetRateLimited(ctx, account.ID, resetTime)
-	log.Printf("[Gemini 429] Account %d rate limited until %v (oauth_type=%s, tier=%s)",
-		account.ID, resetTime, oauthType, tierID)
+	resetTime = clampResetAt(resetTime, time.Now())
+	signal := &RateLimitSignal{Scope: RateLimitScopeAccount, ResetAt: resetTime}
+
+	if key, ok := ModelRateLimitKey(account.Platform, effectiveModel); ok {
+		signal.Scope = RateLimitScopeModelBucket
+		signal.Key = key
+		if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, resetTime); err != nil {
+			log.Printf("[Gemini 429] rate limit set failed key=%s account=%d error=%v", key, account.ID, err)
+			return signal
+		}
+	} else {
+		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
+			log.Printf("[Gemini 429] rate limit set failed account=%d error=%v", account.ID, err)
+			return signal
+		}
+	}
+
+	log.Printf("[Gemini 429] Account %d rate limited until %v (oauth_type=%s, tier=%s)", account.ID, resetTime, oauthType, tierID)
+	return signal
 }
 
 // ParseGeminiRateLimitResetTime 解析 Gemini 格式的 429 响应，返回重置时间的 Unix 时间戳

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -8,39 +8,45 @@ import (
 const modelRateLimitsKey = "model_rate_limits"
 const modelRateLimitScopeClaudeSonnet = "claude_sonnet"
 
-func resolveModelRateLimitScope(requestedModel string) (string, bool) {
-	model := strings.ToLower(strings.TrimSpace(requestedModel))
-	if model == "" {
-		return "", false
-	}
-	model = strings.TrimPrefix(model, "models/")
-	if strings.Contains(model, "sonnet") {
-		return modelRateLimitScopeClaudeSonnet, true
-	}
-	return "", false
-}
-
 func (a *Account) isModelRateLimited(requestedModel string) bool {
-	scope, ok := resolveModelRateLimitScope(requestedModel)
+	if a == nil {
+		return false
+	}
+	key, ok := ModelRateLimitKey(a.Platform, requestedModel)
+	if !ok {
+		// Fallback to legacy behavior (pre-provider bucketing).
+		legacy := normalizeModelID(requestedModel)
+		if strings.Contains(legacy, "sonnet") {
+			key = modelRateLimitScopeClaudeSonnet
+			ok = true
+		}
+	}
 	if !ok {
 		return false
 	}
-	resetAt := a.modelRateLimitResetAt(scope)
+	resetAt := a.modelRateLimitResetAt(key)
 	if resetAt == nil {
 		return false
 	}
 	return time.Now().Before(*resetAt)
 }
 
-func (a *Account) modelRateLimitResetAt(scope string) *time.Time {
-	if a == nil || a.Extra == nil || scope == "" {
+func (a *Account) modelRateLimitResetAt(key string) *time.Time {
+	if a == nil || a.Extra == nil || strings.TrimSpace(key) == "" {
 		return nil
 	}
 	rawLimits, ok := a.Extra[modelRateLimitsKey].(map[string]any)
 	if !ok {
 		return nil
 	}
-	rawLimit, ok := rawLimits[scope].(map[string]any)
+	rawLimit, ok := rawLimits[key].(map[string]any)
+	if !ok {
+		// Backward compat: if key is provider-scoped, allow reading bucket-only.
+		if idx := strings.IndexByte(key, ':'); idx > 0 {
+			bucketOnly := key[idx+1:]
+			rawLimit, ok = rawLimits[bucketOnly].(map[string]any)
+		}
+	}
 	if !ok {
 		return nil
 	}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -735,9 +735,11 @@ func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool 
 	}
 }
 
-func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account) {
+func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, effectiveModel string) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	if s.rateLimitService != nil {
+		_, _ = s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, resp.StatusCode, resp.Header, body)
+	}
 }
 
 // Forward forwards request to OpenAI API
@@ -928,10 +930,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				Detail:             upstreamDetail,
 			})
 
-			s.handleFailoverSideEffects(ctx, resp, account)
+			s.handleFailoverSideEffects(ctx, resp, account, mappedModel)
 			return nil, &UpstreamFailoverError{StatusCode: resp.StatusCode}
 		}
-		return s.handleErrorResponse(ctx, resp, c, account)
+		return s.handleErrorResponse(ctx, resp, c, account, mappedModel)
 	}
 
 	// Handle normal response
@@ -1047,7 +1049,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	return req, nil
 }
 
-func (s *OpenAIGatewayService) handleErrorResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account) (*OpenAIForwardResult, error) {
+func (s *OpenAIGatewayService) handleErrorResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, effectiveModel string) (*OpenAIForwardResult, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
@@ -1099,9 +1101,11 @@ func (s *OpenAIGatewayService) handleErrorResponse(ctx context.Context, resp *ht
 
 	// Handle upstream error (mark account status)
 	shouldDisable := false
+	var rateLimitSignal *RateLimitSignal
 	if s.rateLimitService != nil {
-		shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		shouldDisable, rateLimitSignal = s.rateLimitService.HandleUpstreamError(ctx, account, effectiveModel, resp.StatusCode, resp.Header, body)
 	}
+	setRateLimitResponseHeaders(c, rateLimitSignal)
 	kind := "http_error"
 	if shouldDisable {
 		kind = "failover"

--- a/backend/internal/service/rate_limit_bucket.go
+++ b/backend/internal/service/rate_limit_bucket.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"strings"
+)
+
+// normalizeModelID produces a stable identifier for bucketing.
+// This must match existing normalization patterns used elsewhere.
+func normalizeModelID(model string) string {
+	m := strings.ToLower(strings.TrimSpace(model))
+	if m == "" {
+		return ""
+	}
+	return strings.TrimPrefix(m, "models/")
+}
+
+// quotaBucketID returns the bucket id used for cooldown decisions.
+// In the common case, it is the exact model id, but some model families share quota.
+func quotaBucketID(providerID, exactModelID string) (string, bool) {
+	provider := strings.ToLower(strings.TrimSpace(providerID))
+	model := normalizeModelID(exactModelID)
+	if provider == "" || model == "" {
+		return "", false
+	}
+
+	switch provider {
+	case PlatformGemini:
+		// Gemini 3 families share quota within the family.
+		// Keep Flash and Pro isolated from each other.
+		if strings.HasPrefix(model, "gemini-3-flash") {
+			return "gemini-3-flash", true
+		}
+		if strings.HasPrefix(model, "gemini-3-pro") {
+			return "gemini-3-pro", true
+		}
+		return model, true
+	case PlatformAnthropic:
+		// Preserve existing scoped behavior for Sonnet as a shared bucket.
+		if strings.Contains(model, "sonnet") {
+			return modelRateLimitScopeClaudeSonnet, true
+		}
+		return model, true
+	default:
+		return model, true
+	}
+}
+
+// IsSafeModelRateLimitKey ensures the provided key can be safely used as a
+// JSONB path element (e.g. inside `jsonb_set('{model_rate_limits,<key>}', ...)`).
+//
+// It enforces a strict whitelist to keep JSON paths stable and reject
+// characters (quotes, braces, carriage returns, etc.) that might break SQL.
+func IsSafeModelRateLimitKey(s string) bool {
+	if strings.TrimSpace(s) == "" {
+		return false
+	}
+	// Prevent unbounded keys / path literal breakage.
+	// This is deliberately strict; if it fails, callers should fall back to global cooldown.
+	if len(s) > 160 {
+		return false
+	}
+	for _, r := range s {
+		if r < 0x20 || r == 0x7f {
+			return false
+		}
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			continue
+		}
+		switch r {
+		case '-', '_', '.', ':':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// ModelRateLimitKey returns a stable key used under accounts.extra.model_rate_limits.
+// Format: "<provider_id>:<quota_bucket_id>".
+func ModelRateLimitKey(providerID, exactModelID string) (string, bool) {
+	bucket, ok := quotaBucketID(providerID, exactModelID)
+	if !ok {
+		return "", false
+	}
+	key := strings.ToLower(strings.TrimSpace(providerID)) + ":" + bucket
+	if !IsSafeModelRateLimitKey(key) {
+		return "", false
+	}
+	return key, true
+}

--- a/backend/internal/service/rate_limit_bucket_test.go
+++ b/backend/internal/service/rate_limit_bucket_test.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelRateLimitKey(t *testing.T) {
+	t.Run("canonicalizes", func(t *testing.T) {
+		key, ok := ModelRateLimitKey(PlatformOpenAI, " models/GPT-4 ")
+		require.True(t, ok)
+		require.Equal(t, "openai:gpt-4", key)
+	})
+
+	t.Run("geminiFlashSharedBucket", func(t *testing.T) {
+		key, ok := ModelRateLimitKey(PlatformGemini, "Gemini-3-Flash-B001")
+		require.True(t, ok)
+		require.Equal(t, "gemini:gemini-3-flash", key)
+	})
+
+	t.Run("rejectsUnsafeCharacters", func(t *testing.T) {
+		key, ok := ModelRateLimitKey(PlatformOpenAI, "gpt-4{")
+		require.False(t, ok)
+		require.Empty(t, key)
+	})
+
+	t.Run("rejectsMissingProvider", func(t *testing.T) {
+		_, ok := ModelRateLimitKey("", "gpt-4")
+		require.False(t, ok)
+	})
+}
+
+func TestIsSafeModelRateLimitKey(t *testing.T) {
+	require.True(t, IsSafeModelRateLimitKey("openai:gpt-4"))
+	require.False(t, IsSafeModelRateLimitKey("openai:gpt-4}"))
+	require.False(t, IsSafeModelRateLimitKey(""))
+	require.False(t, IsSafeModelRateLimitKey("openai:gp t"))
+}

--- a/backend/internal/service/rate_limit_signal.go
+++ b/backend/internal/service/rate_limit_signal.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type RateLimitScope string
+
+const (
+	RateLimitScopeUnknown     RateLimitScope = "unknown"
+	RateLimitScopeAccount     RateLimitScope = "account"
+	RateLimitScopeModelBucket RateLimitScope = "model_bucket"
+)
+
+// RateLimitSignal describes the metadata emitted with a 429 response.
+type RateLimitSignal struct {
+	Scope   RateLimitScope
+	Key     string
+	ResetAt time.Time
+}
+
+// setRateLimitResponseHeaders writes the stable headers that describe the throttled bucket.
+func setRateLimitResponseHeaders(c *gin.Context, signal *RateLimitSignal) {
+	if signal == nil || signal.ResetAt.IsZero() {
+		return
+	}
+	retryAfter := int(time.Until(signal.ResetAt).Seconds())
+	if retryAfter < 1 {
+		retryAfter = 1
+	}
+	c.Header("Retry-After", strconv.Itoa(retryAfter))
+	c.Header("X-Sub2API-RateLimit-Scope", string(signal.Scope))
+	if signal.Scope == RateLimitScopeModelBucket && signal.Key != "" {
+		c.Header("X-Sub2API-RateLimit-Key", signal.Key)
+	}
+}

--- a/backend/internal/service/rate_limit_signal_test.go
+++ b/backend/internal/service/rate_limit_signal_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockAccountRepoForSignal struct {
+	AccountRepository
+	modelRateLimits map[string]time.Time
+}
+
+func (m *mockAccountRepoForSignal) SetModelRateLimit(ctx context.Context, id int64, key string, resetAt time.Time) error {
+	m.modelRateLimits[key] = resetAt
+	return nil
+}
+
+func (m *mockAccountRepoForSignal) SetRateLimited(ctx context.Context, id int64, resetAt time.Time) error {
+	return nil
+}
+
+func (m *mockAccountRepoForSignal) UpdateSessionWindow(ctx context.Context, id int64, start, end *time.Time, status string) error {
+	return nil
+}
+
+func TestRateLimitService_HandleUpstreamError_EmitsSignal(t *testing.T) {
+	repo := &mockAccountRepoForSignal{
+		modelRateLimits: make(map[string]time.Time),
+	}
+	s := &RateLimitService{
+		accountRepo: repo,
+	}
+
+	account := &Account{
+		ID:       1,
+		Platform: PlatformAnthropic,
+	}
+
+	// 429 with model should produce a model-scoped signal.
+	headers := http.Header{}
+	headers.Set("Retry-After", "60")
+	_, signal := s.HandleUpstreamError(context.Background(), account, "claude-3-opus", 429, headers, []byte("{}"))
+
+	require.NotNil(t, signal)
+	require.Equal(t, RateLimitScopeModelBucket, signal.Scope)
+	require.Equal(t, "anthropic:claude-3-opus", signal.Key)
+	require.True(t, signal.ResetAt.After(time.Now().Add(55*time.Second)))
+
+	require.Contains(t, repo.modelRateLimits, "anthropic:claude-3-opus")
+}
+
+func TestRateLimitService_HandleUpstreamError_GlobalFallback(t *testing.T) {
+	repo := &mockAccountRepoForSignal{
+		modelRateLimits: make(map[string]time.Time),
+	}
+	s := &RateLimitService{
+		accountRepo: repo,
+	}
+
+	account := &Account{
+		ID:       1,
+		Platform: PlatformOpenAI,
+	}
+
+	// 429 without model should produce an account-scoped signal.
+	headers := http.Header{}
+	headers.Set("Retry-After", "120")
+	_, signal := s.HandleUpstreamError(context.Background(), account, "", 429, headers, []byte("{}"))
+
+	require.NotNil(t, signal)
+	require.Equal(t, RateLimitScopeAccount, signal.Scope)
+	require.Empty(t, signal.Key)
+	require.True(t, signal.ResetAt.After(time.Now().Add(115*time.Second)))
+
+	require.Empty(t, repo.modelRateLimits)
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -33,7 +33,10 @@ type geminiUsageCacheEntry struct {
 	totals      GeminiUsageTotals
 }
 
-const geminiPrecheckCacheTTL = time.Minute
+const (
+	geminiPrecheckCacheTTL = time.Minute
+	rateLimitResetJitter   = 3 * time.Second
+)
 
 // NewRateLimitService 创建RateLimitService实例
 func NewRateLimitService(accountRepo AccountRepository, usageRepo UsageLogRepository, cfg *config.Config, geminiQuotaService *GeminiQuotaService, tempUnschedCache TempUnschedCache) *RateLimitService {
@@ -62,22 +65,23 @@ func (s *RateLimitService) SetTokenCacheInvalidator(invalidator TokenCacheInvali
 	s.tokenCacheInvalidator = invalidator
 }
 
-// HandleUpstreamError 处理上游错误响应，标记账号状态
-// 返回是否应该停止该账号的调度
-func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte) (shouldDisable bool) {
+// HandleUpstreamError processes upstream error responses and mutates account state.
+// effectiveModel should be the model actually sent upstream after any mapping.
+// Returns whether scheduling should disable this account and any rate-limit signal to expose to clients.
+func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, effectiveModel string, statusCode int, headers http.Header, responseBody []byte) (shouldDisable bool, signal *RateLimitSignal) {
 	// apikey 类型账号：检查自定义错误码配置
 	// 如果启用且错误码不在列表中，则不处理（不停止调度、不标记限流/过载）
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 	if !account.ShouldHandleErrorCode(statusCode) {
 		slog.Info("account_error_code_skipped", "account_id", account.ID, "status_code", statusCode)
-		return false
+		return false, nil
 	}
 
 	// 先尝试临时不可调度规则（401除外）
 	// 如果匹配成功，直接返回，不执行后续禁用逻辑
 	if statusCode != 401 {
 		if s.tryTempUnschedulable(ctx, account, statusCode, responseBody) {
-			return true
+			return true, nil
 		}
 	}
 
@@ -139,7 +143,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		s.handleAuthError(ctx, account, msg)
 		shouldDisable = true
 	case 429:
-		s.handle429(ctx, account, headers, responseBody)
+		signal = s.handle429(ctx, account, effectiveModel, headers, responseBody)
 		shouldDisable = false
 	case 529:
 		s.handle529(ctx, account)
@@ -160,7 +164,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		}
 	}
 
-	return shouldDisable
+	return shouldDisable, signal
 }
 
 // PreCheckUsage proactively checks local quota before dispatching a request.
@@ -342,110 +346,158 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
-	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, effectiveModel string, headers http.Header, responseBody []byte) *RateLimitSignal {
+	if account == nil {
+		return nil
+	}
+
+	now := time.Now()
+	var bestReset time.Time
+
+	if ra := parseRetryAfter(headers, now); ra != nil {
+		bestReset = laterFutureTime(bestReset, *ra, now)
+	}
+
 	if account.Platform == PlatformOpenAI {
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
-			if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
-				slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-				return
-			}
-			slog.Info("openai_account_rate_limited", "account_id", account.ID, "reset_at", *resetAt)
-			return
+			bestReset = laterFutureTime(bestReset, *resetAt, now)
 		}
 	}
 
-	// 2. 尝试从响应头解析重置时间（Anthropic）
-	resetTimestamp := headers.Get("anthropic-ratelimit-unified-reset")
-
-	// 3. 如果响应头没有，尝试从响应体解析（OpenAI usage_limit_reached, Gemini）
-	if resetTimestamp == "" {
-		switch account.Platform {
-		case PlatformOpenAI:
-			// 尝试解析 OpenAI 的 usage_limit_reached 错误
-			if resetAt := parseOpenAIRateLimitResetTime(responseBody); resetAt != nil {
-				resetTime := time.Unix(*resetAt, 0)
-				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
-					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-					return
-				}
-				slog.Info("account_rate_limited", "account_id", account.ID, "platform", account.Platform, "reset_at", resetTime, "reset_in", time.Until(resetTime).Truncate(time.Second))
-				return
-			}
-		case PlatformGemini, PlatformAntigravity:
-			// 尝试解析 Gemini 格式（用于其他平台）
-			if resetAt := ParseGeminiRateLimitResetTime(responseBody); resetAt != nil {
-				resetTime := time.Unix(*resetAt, 0)
-				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
-					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-					return
-				}
-				slog.Info("account_rate_limited", "account_id", account.ID, "platform", account.Platform, "reset_at", resetTime, "reset_in", time.Until(resetTime).Truncate(time.Second))
-				return
-			}
+	if v := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-reset")); v != "" {
+		if ts, err := strconv.ParseInt(v, 10, 64); err == nil {
+			bestReset = laterFutureTime(bestReset, time.Unix(ts, 0), now)
+		} else if t, err := time.Parse(time.RFC3339, v); err == nil {
+			bestReset = laterFutureTime(bestReset, t, now)
 		}
-
-		// 没有重置时间，使用默认5分钟
-		resetAt := time.Now().Add(5 * time.Minute)
-		if s.shouldScopeClaudeSonnetRateLimit(account, responseBody) {
-			if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelRateLimitScopeClaudeSonnet, resetAt); err != nil {
-				slog.Warn("model_rate_limit_set_failed", "account_id", account.ID, "scope", modelRateLimitScopeClaudeSonnet, "error", err)
-			} else {
-				slog.Info("account_model_rate_limited", "account_id", account.ID, "scope", modelRateLimitScopeClaudeSonnet, "reset_at", resetAt)
-			}
-			return
-		}
-		slog.Warn("rate_limit_no_reset_time", "account_id", account.ID, "platform", account.Platform, "using_default", "5m")
-		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
-			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-		}
-		return
 	}
 
-	// 解析Unix时间戳
-	ts, err := strconv.ParseInt(resetTimestamp, 10, 64)
-	if err != nil {
-		slog.Warn("rate_limit_reset_parse_failed", "reset_timestamp", resetTimestamp, "error", err)
-		resetAt := time.Now().Add(5 * time.Minute)
-		if s.shouldScopeClaudeSonnetRateLimit(account, responseBody) {
-			if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelRateLimitScopeClaudeSonnet, resetAt); err != nil {
-				slog.Warn("model_rate_limit_set_failed", "account_id", account.ID, "scope", modelRateLimitScopeClaudeSonnet, "error", err)
-			} else {
-				slog.Info("account_model_rate_limited", "account_id", account.ID, "scope", modelRateLimitScopeClaudeSonnet, "reset_at", resetAt)
-			}
-			return
+	switch account.Platform {
+	case PlatformOpenAI:
+		if resetAt := parseOpenAIRateLimitResetTime(responseBody); resetAt != nil {
+			bestReset = laterFutureTime(bestReset, time.Unix(*resetAt, 0), now)
 		}
-		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
-			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
+	case PlatformGemini, PlatformAntigravity:
+		if resetAt := ParseGeminiRateLimitResetTime(responseBody); resetAt != nil {
+			bestReset = laterFutureTime(bestReset, time.Unix(*resetAt, 0), now)
 		}
-		return
 	}
 
-	resetAt := time.Unix(ts, 0)
+	resetAt := bestReset
+	if resetAt.IsZero() {
+		cooldown := 5 * time.Minute
+		if account.Platform == PlatformGemini {
+			cooldown = s.GeminiCooldown(ctx, account)
+		}
+		resetAt = now.Add(cooldown)
+		slog.Warn("rate_limit_no_reset_time", "account_id", account.ID, "platform", account.Platform, "using_default", cooldown.String())
+	}
+
+	resetAt = applyResetJitter(resetAt, now)
+	resetAt = clampResetAt(resetAt, now)
+
+	if key, ok := ModelRateLimitKey(account.Platform, effectiveModel); ok {
+		signal := &RateLimitSignal{Scope: RateLimitScopeModelBucket, Key: key, ResetAt: resetAt}
+		if existing := account.modelRateLimitResetAt(key); existing != nil && !resetAt.After(*existing) {
+			signal.ResetAt = *existing
+			return signal
+		}
+		if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, resetAt); err != nil {
+			slog.Warn("model_rate_limit_set_failed", "account_id", account.ID, "key", key, "error", err)
+			return signal
+		}
+		slog.Info("account_model_rate_limited", "account_id", account.ID, "key", key, "reset_at", resetAt)
+		return signal
+	}
 
 	if s.shouldScopeClaudeSonnetRateLimit(account, responseBody) {
-		if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelRateLimitScopeClaudeSonnet, resetAt); err != nil {
-			slog.Warn("model_rate_limit_set_failed", "account_id", account.ID, "scope", modelRateLimitScopeClaudeSonnet, "error", err)
-			return
+		if key, ok := ModelRateLimitKey(PlatformAnthropic, modelRateLimitScopeClaudeSonnet); ok {
+			signal := &RateLimitSignal{Scope: RateLimitScopeModelBucket, Key: key, ResetAt: resetAt}
+			if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, resetAt); err != nil {
+				slog.Warn("model_rate_limit_set_failed", "account_id", account.ID, "key", key, "error", err)
+				return signal
+			}
+			slog.Info("account_model_rate_limited", "account_id", account.ID, "key", key, "reset_at", resetAt)
+			return signal
 		}
-		slog.Info("account_model_rate_limited", "account_id", account.ID, "scope", modelRateLimitScopeClaudeSonnet, "reset_at", resetAt)
-		return
 	}
 
-	// 标记限流状态
+	signal := &RateLimitSignal{Scope: RateLimitScopeAccount, ResetAt: resetAt}
+	if account.RateLimitResetAt != nil && !resetAt.After(*account.RateLimitResetAt) {
+		signal.ResetAt = *account.RateLimitResetAt
+		return signal
+	}
 	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
 		slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-		return
+		return signal
 	}
 
-	// 根据重置时间反推5h窗口
 	windowEnd := resetAt
 	windowStart := resetAt.Add(-5 * time.Hour)
 	if err := s.accountRepo.UpdateSessionWindow(ctx, account.ID, &windowStart, &windowEnd, "rejected"); err != nil {
 		slog.Warn("rate_limit_update_session_window_failed", "account_id", account.ID, "error", err)
+		return signal
 	}
 
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+	return signal
+}
+
+func clampResetAt(resetAt time.Time, now time.Time) time.Time {
+	// Clamp to a safe range to avoid pathological headers wedging scheduling.
+	min := now.Add(1 * time.Second)
+	max := now.Add(24 * time.Hour)
+	if resetAt.Before(min) {
+		return min
+	}
+	if resetAt.After(max) {
+		return max
+	}
+	return resetAt
+}
+
+func applyResetJitter(resetAt time.Time, now time.Time) time.Time {
+	if rateLimitResetJitter <= 0 {
+		return resetAt
+	}
+	rangeNs := int64(rateLimitResetJitter)
+	if rangeNs <= 0 {
+		return resetAt
+	}
+	offset := now.UnixNano() % rangeNs
+	if offset < 0 {
+		offset = -offset
+	}
+	return resetAt.Add(time.Duration(offset))
+}
+
+func laterFutureTime(best time.Time, candidate time.Time, now time.Time) time.Time {
+	if candidate.IsZero() || !candidate.After(now) {
+		return best
+	}
+	if best.IsZero() || candidate.After(best) {
+		return candidate
+	}
+	return best
+}
+
+// parseRetryAfter supports RFC 9110 Retry-After formats: delta-seconds or HTTP-date.
+func parseRetryAfter(headers http.Header, now time.Time) *time.Time {
+	v := strings.TrimSpace(headers.Get("Retry-After"))
+	if v == "" {
+		return nil
+	}
+	if secs, err := strconv.ParseInt(v, 10, 64); err == nil {
+		if secs <= 0 {
+			return nil
+		}
+		t := now.Add(time.Duration(secs) * time.Second)
+		return &t
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		return &t
+	}
+	return nil
 }
 
 func (s *RateLimitService) shouldScopeClaudeSonnetRateLimit(account *Account, responseBody []byte) bool {

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -73,7 +73,7 @@ func TestRateLimitService_HandleUpstreamError_OAuth401MarksError(t *testing.T) {
 				},
 			}
 
-			shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+			shouldDisable, _ := service.HandleUpstreamError(context.Background(), account, "", 401, http.Header{}, []byte("unauthorized"))
 
 			require.True(t, shouldDisable)
 			require.Equal(t, 1, repo.setErrorCalls)
@@ -95,7 +95,7 @@ func TestRateLimitService_HandleUpstreamError_OAuth401InvalidatorError(t *testin
 		Type:     AccountTypeOAuth,
 	}
 
-	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+	shouldDisable, _ := service.HandleUpstreamError(context.Background(), account, "", 401, http.Header{}, []byte("unauthorized"))
 
 	require.True(t, shouldDisable)
 	require.Equal(t, 1, repo.setErrorCalls)
@@ -113,7 +113,7 @@ func TestRateLimitService_HandleUpstreamError_NonOAuth401(t *testing.T) {
 		Type:     AccountTypeAPIKey,
 	}
 
-	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+	shouldDisable, _ := service.HandleUpstreamError(context.Background(), account, "", 401, http.Header{}, []byte("unauthorized"))
 
 	require.True(t, shouldDisable)
 	require.Equal(t, 1, repo.setErrorCalls)

--- a/backend/internal/service/ratelimit_service_retry_after_test.go
+++ b/backend/internal/service/ratelimit_service_retry_after_test.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRetryAfterSeconds(t *testing.T) {
+	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	headers := http.Header{}
+	headers.Set("Retry-After", "45")
+	result := parseRetryAfter(headers, now)
+	require.NotNil(t, result)
+	require.Equal(t, now.Add(45*time.Second), *result)
+}
+
+func TestParseRetryAfterHTTPDate(t *testing.T) {
+	now := time.Date(2026, time.February, 2, 3, 4, 5, 0, time.UTC)
+	target := now.Add(3 * time.Minute)
+	headers := http.Header{}
+	headers.Set("Retry-After", target.Format(http.TimeFormat))
+	result := parseRetryAfter(headers, now)
+	require.NotNil(t, result)
+	require.Equal(t, target, *result)
+}
+
+func TestParseRetryAfterInvalidValues(t *testing.T) {
+	now := time.Date(2026, time.March, 4, 5, 6, 7, 0, time.UTC)
+	headers := http.Header{}
+	for _, value := range []string{"-1", "0", "not-a-number"} {
+		headers.Set("Retry-After", value)
+		require.Nil(t, parseRetryAfter(headers, now), "value=%s should be ignored", value)
+	}
+}
+
+func TestClampResetAtBounds(t *testing.T) {
+	now := time.Date(2026, time.March, 3, 4, 5, 6, 0, time.UTC)
+	tooSoon := clampResetAt(now.Add(-time.Hour), now)
+	require.Equal(t, now.Add(time.Second), tooSoon)
+	tooLate := clampResetAt(now.Add(48*time.Hour), now)
+	require.Equal(t, now.Add(24*time.Hour), tooLate)
+	within := clampResetAt(now.Add(12*time.Hour), now)
+	require.Equal(t, now.Add(12*time.Hour), within)
+}
+
+func TestApplyResetJitterRange(t *testing.T) {
+	now := time.Date(2026, time.March, 3, 4, 5, 6, 0, time.UTC)
+	base := now.Add(10 * time.Minute)
+	jittered := applyResetJitter(base, now)
+	delta := jittered.Sub(base)
+	require.True(t, delta >= 0)
+	require.True(t, delta < rateLimitResetJitter)
+}

--- a/todos/001-pending-p1-jsonb-path-safety-for-model-keys.md
+++ b/todos/001-pending-p1-jsonb-path-safety-for-model-keys.md
@@ -1,0 +1,88 @@
+---
+status: done
+priority: p1
+issue_id: "001"
+tags: [code-review, security, database, rate-limiting]
+dependencies: []
+---
+
+# JSONB path safety for per-model cooldown keys
+
+## Problem Statement
+The plan proposes storing per-model cooldown state in `accounts.extra.model_rate_limits` keyed by `(provider_id, exact_model_id)`. The existing repository write primitive for `model_rate_limits` builds a `jsonb_set` path using string concatenation, and is currently safe only because keys are controlled (e.g., a fixed `claude_sonnet` scope).
+
+If we start using arbitrary model IDs as JSON keys, special characters (commas/braces/quotes) can break the Postgres array path literal, cause SQL errors, or create injection-adjacent edge cases.
+
+## Findings
+- `backend/internal/repository/account_repo.go` currently constructs JSONB path strings like `"{model_rate_limits," + scope + "}"`.
+- The current `scope` is effectively controlled (substring-derived), but the new design makes the key user-influenced via `model`.
+- The plan mentions canonicalization/validation, but it does not explicitly require “safe as jsonb_set path element” constraints.
+
+## Proposed Solutions
+### Option A: Restrict and validate key characters (Small)
+Constrain `(provider_id, exact_model_id)` to a safe character set before any DB write.
+
+Pros:
+- Minimal code change surface.
+
+Cons:
+- Still relies on fragile string-path assembly.
+- Hard to guarantee across all future changes.
+
+### Option B: Change repository write primitive to pass structured path (Medium)
+Stop using ad-hoc array-literal strings; use a safer approach to address JSON paths (or represent keys in a way that does not require embedding arbitrary strings inside a path literal).
+
+Pros:
+- Robust by construction.
+
+Cons:
+- More implementation work; must ensure ent/sql builder supports it.
+
+### Option C: Encode model key (Small/Medium)
+Encode keys (e.g., URL-safe base64) before storage, and decode at read-time.
+
+Pros:
+- Avoids unsafe characters entirely.
+
+Cons:
+- Reduces human readability in DB.
+
+## Recommended Action
+
+- Describe the `service.ModelRateLimitKey`/`service.IsSafeModelRateLimitKey` guard in the plan so reviewers know why the path is safe.
+- Enforce the guard in `SetModelRateLimit`, refuse unsafe keys, and emit scheduler outbox payloads that include the affected `model_rate_limit_keys` so downstream caches see the change.
+- Cover the helper with unit tests that exercise both good and bad characters.
+## Technical Details
+- Affected plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`
+- Affected code path: `backend/internal/repository/account_repo.go` (model_rate_limits JSONB writes)
+
+## Acceptance Criteria
+- [ ] Model/provider keys used in JSONB paths cannot break SQL or JSON path semantics.
+- [ ] Attempts to write cooldown for invalid keys are rejected safely (no partial writes).
+- [ ] Tests cover keys containing commas, braces, quotes, whitespace, and control characters.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured risk that JSONB path construction becomes unsafe with arbitrary model keys.
+
+**Learnings:**
+- Existing `SetModelRateLimit` behavior is safe today only because scope is controlled.
+
+### 2026-01-31 - Guarded per-model keys and documented flow
+
+**By:** OpenCode
+
+**Actions:**
+- Added `service.ModelRateLimitKey`/`service.IsSafeModelRateLimitKey` and wired `SetModelRateLimit` to refuse unsafe keys while emitting scheduler outbox payloads that carry `model_rate_limit_keys`.
+- Added unit tests that confirm the helper accepts canonical keys, rejects characters that would break JSON paths, and documented the safety mechanism in the main plan.
+
+**Learnings:**
+- The scheduler continues to rebuild from account changes when extra fields change, so carrying the key names in the outbox payload makes downstream observability easier.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`
+- Repo reference: `backend/internal/repository/account_repo.go`

--- a/todos/002-pending-p1-avoid-hot-row-jsonb-write-amplification.md
+++ b/todos/002-pending-p1-avoid-hot-row-jsonb-write-amplification.md
@@ -1,0 +1,75 @@
+---
+status: pending
+priority: p1
+issue_id: "002"
+tags: [code-review, performance, database, rate-limiting]
+dependencies: []
+---
+
+# Avoid hot-row JSONB write amplification on 429 storms
+
+## Problem Statement
+Per-model cooldowns are written on the error path (429), which spikes exactly when the system is under stress. If the chosen storage is `accounts.extra` JSONB, we risk turning upstream rate limiting into hot-row updates and lock contention, causing cascading latency and potentially replication/WAL pressure.
+
+## Findings
+- Option A stores cooldown state in `accounts.extra.model_rate_limits` (JSONB).
+- Under bursty 429 conditions, many workers can attempt to update the same account row.
+- JSONB updates can be TOAST-heavy and can cause row-level lock contention.
+- Plan calls out monotonic semantics but doesn’t yet specify write suppression/debouncing (beyond monotonicity).
+
+## Proposed Solutions
+### Option A: Write suppression + monotonic max-only (Small)
+Only persist cooldown when `new_reset_at` strictly extends the stored value, optionally with a small epsilon threshold.
+
+Pros:
+- High impact, low effort.
+
+Cons:
+- Still leaves hot-row contention under certain traffic patterns.
+
+### Option B: Separate table for cooldowns (Medium/Large)
+Move to a normalized table keyed by `(account_id, provider_id, exact_model_id)` with an index on `rate_limit_reset_at`.
+
+Pros:
+- Reduces JSON rewrite amplification; better queryability.
+
+Cons:
+- Requires migration + ent schema + operational rollout.
+
+### Option C: Add a short-lived external gate (Medium)
+Use a TTL store (e.g., Redis) for fast gating and reduce DB writes; persist less frequently.
+
+Pros:
+- Reduces DB hot-row writes and can smooth stampedes.
+
+Cons:
+- Adds another storage system and coherency considerations.
+
+## Recommended Action
+
+- Suppress JSONB writes in `accounts.extra.model_rate_limits` unless the incoming reset timestamp strictly extends the value currently stored for that key (with a short epsilon for clock skew). The repository layer already implements this via a conditional `jsonb_set` update that checks the existing `rate_limit_reset_at` before mutating the row, so the majority of concurrent 429s become noop reads instead of competing writes.
+- Keep the existing JSONB path for now, but monitor `cooldown_write_total` vs. DB lock wait metrics; revisit the dedicated cooldown table (Option B) if contention remains under sustained bursts.
+- Optionally, consider a short-lived cache/gate (Option C) for even faster suppression later, but ship the conditional update first because it reuses existing schema and keeps release scope small.
+
+## Technical Details
+ - Plan storage option: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`
+ - Hot row candidate: `accounts` table row per account with `extra.model_rate_limits`
+
+## Acceptance Criteria
+- [ ] Cooldown writes are suppressed when they do not extend `reset_at`.
+- [ ] System remains stable under sustained upstream 429 conditions (no runaway DB lock waits).
+- [ ] Metrics exist for `cooldown_write_total` and DB lock wait/latency signals.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured risk that JSONB-in-accounts becomes a bottleneck under throttling.
+
+**Learnings:**
+- Error-path persistence needs explicit write amplification controls.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`

--- a/todos/003-pending-p2-canonicalization-consistency-with-existing-lowercasing.md
+++ b/todos/003-pending-p2-canonicalization-consistency-with-existing-lowercasing.md
@@ -1,0 +1,69 @@
+---
+status: pending
+priority: p2
+issue_id: "003"
+tags: [code-review, quality, rate-limiting]
+dependencies: []
+---
+
+# Canonicalization consistency for model keys
+
+## Problem Statement
+The plan introduces `exact_model_id` normalization rules that differ from existing repo behavior (which lowercases model identifiers in multiple places). If canonicalization is inconsistent across reads/writes, per-model cooldown gating will be flaky and hard to debug.
+
+## Findings
+- The plan says “do not case-fold unless model ids are guaranteed case-insensitive.”
+- Existing code already lowercases in scope resolution:
+  - `backend/internal/service/antigravity_quota_scope.go`
+  - `backend/internal/service/model_rate_limit.go`
+- Divergent normalization can lead to two separate cooldown keys for the same logical model.
+
+## Proposed Solutions
+### Option A: Standardize on current behavior (Small)
+Always lowercase + trim + strip `models/` consistently across all per-model cooldown reads/writes.
+
+Pros:
+- Aligns with existing patterns.
+
+Cons:
+- Requires confidence model IDs are effectively case-insensitive in practice.
+
+### Option B: Stop lowercasing everywhere (Medium)
+Remove lowercasing from existing scope resolvers and treat model IDs as case-sensitive.
+
+Pros:
+- Strict correctness if providers are case-sensitive.
+
+Cons:
+- Likely larger refactor and higher regression risk.
+
+### Option C: Normalize only the internal bucket key (Small)
+Keep request model case for outward-facing fields, but always canonicalize the bucket key deterministically.
+
+Pros:
+- Minimizes client-visible changes.
+
+Cons:
+- Needs careful documentation.
+
+## Recommended Action
+
+## Technical Details
+- Plan definitions: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`
+- Existing code: `backend/internal/service/antigravity_quota_scope.go`, `backend/internal/service/model_rate_limit.go`
+
+## Acceptance Criteria
+- [ ] Single canonicalization function is defined for bucket keys.
+- [ ] All per-model cooldown reads and writes use that function.
+- [ ] Tests prove that casing/whitespace differences do not create distinct buckets.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Noted mismatch between plan guidance and current normalization patterns.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`

--- a/todos/004-pending-p2-add-retry-after-parsing-and-bounds.md
+++ b/todos/004-pending-p2-add-retry-after-parsing-and-bounds.md
@@ -1,0 +1,66 @@
+---
+status: resolved
+priority: p2
+issue_id: "004"
+tags: [code-review, reliability, rate-limiting]
+dependencies: []
+---
+
+# Add Retry-After parsing and bounded cooldown defaults
+
+## Problem Statement
+The plan proposes header parsing precedence starting with `Retry-After`, but the repo currently only allowlists `Retry-After` for passthrough; it does not parse it to compute cooldown state. Without explicit parsing and bounds, model cooldown timing will remain inconsistent across providers.
+
+## Findings
+- `Retry-After` is allowlisted in `backend/internal/util/responseheaders/responseheaders.go`.
+- Current upstream error handling parses provider-specific signals (OpenAI x-ratelimit / Codex headers, Anthropic reset headers, body parsing fallbacks), but does not incorporate `Retry-After` as an input.
+- The plan does not yet specify clamp rules (min/max) as acceptance criteria.
+
+## Proposed Solutions
+### Option A: Implement Retry-After parsing centrally (Small)
+Parse `Retry-After` (seconds or HTTP-date) and use it as the highest-precedence reset signal.
+
+Pros:
+- Standard, provider-agnostic.
+
+Cons:
+- Must handle invalid/negative values safely.
+
+### Option B: Keep provider-specific parsing first (Small)
+Only use `Retry-After` as a fallback when provider headers are absent.
+
+Pros:
+- Minimizes behavior change.
+
+Cons:
+- Less consistent; can miss useful standard signals.
+
+## Recommended Action
+
+## Technical Details
+- Code reference: `backend/internal/util/responseheaders/responseheaders.go`
+- Likely touchpoints: `backend/internal/service/ratelimit_service.go`, gateway error handlers
+
+## Acceptance Criteria
+- [ ] `Retry-After` seconds and HTTP-date formats are supported.
+- [ ] Cooldown is clamped to safe bounds (min/max) with small jitter to avoid stampedes.
+- [ ] Invalid `Retry-After` values do not crash or wedge cooldown state.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured missing gap between desired precedence and current implementation.
+
+### 2026-01-30 - Implemented Retry-After parsing and bounded cooldowns
+
+**By:** OpenCode
+
+**Actions:**
+- Added `parseRetryAfter`, `applyResetJitter`, and clamped cooldown logic in `backend/internal/service/ratelimit_service.go` so `Retry-After` values are honored safely.
+- Documented the parsing/jitter/bounds behavior in the per-model rate limit plan and added tests covering seconds/date parsing, clamp bounds, and jitter range.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`

--- a/todos/005-pending-p2-make-rate-limit-errors-agent-actionable.md
+++ b/todos/005-pending-p2-make-rate-limit-errors-agent-actionable.md
@@ -1,0 +1,64 @@
+---
+status: pending
+priority: p2
+issue_id: "005"
+tags: [code-review, api, agent-native, rate-limiting]
+dependencies: []
+---
+
+# Make model-scoped rate limit errors machine-actionable for agents
+
+## Problem Statement
+Per-model cooldowns are most useful when clients (including agents) can reliably detect: (1) that a request is rate-limited, (2) the scope (model vs provider/global), (3) which model key is blocked, and (4) when to retry.
+
+The plan currently treats additive fields like `error.code`, `error.model`, and `error.retry_after_seconds` as optional.
+
+## Findings
+- Agents can’t depend on provider-specific headers because headers are filtered and providers differ.
+- Without a stable scope/model/retry hint, agents may spam retries or switch models ineffectively.
+- The plan already suggests optional additions but does not commit to them as a contract.
+
+## Proposed Solutions
+### Option A: Add stable JSON fields on 429 (Small/Medium)
+Guarantee additive fields like:
+- `error.code` (e.g., `model_rate_limited`)
+- `error.scope` (`model|provider|account|unknown`)
+- `error.model` (required when scope=model)
+- `error.retry_after_seconds` (required on all 429)
+
+Pros:
+- Provider-agnostic, agent-friendly.
+
+Cons:
+- Expands public API surface (additive).
+
+### Option B: Add stable `x-sub2api-*` headers (Small/Medium)
+Provide stable headers for scope/model/reset; keep body unchanged.
+
+Pros:
+- Minimal body changes.
+
+Cons:
+- Some clients ignore headers; still filtered lists must include them.
+
+## Recommended Action
+
+## Technical Details
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`
+- Headers filter: `backend/internal/util/responseheaders/responseheaders.go`
+
+## Acceptance Criteria
+- [ ] Agents can programmatically decide whether switching models is likely to help.
+- [ ] A 429 includes retry guidance even when upstream headers are missing.
+- [ ] No sensitive internal routing/account data is leaked.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Converted agent-native review feedback into a tracked todo.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`

--- a/todos/006-pending-p2-bound-metric-cardinality-for-model-dimensions.md
+++ b/todos/006-pending-p2-bound-metric-cardinality-for-model-dimensions.md
@@ -1,0 +1,54 @@
+---
+status: pending
+priority: p2
+issue_id: "006"
+tags: [code-review, observability, performance, rate-limiting]
+dependencies: []
+---
+
+# Bound metric cardinality for model dimensions
+
+## Problem Statement
+The plan proposes metrics by `(provider, model)`. If `model` is derived from user input (even after normalization), metrics and logs can become high-cardinality and expensive, and can also become a log-injection vector.
+
+## Findings
+- Model identifiers are at least partially untrusted.
+- Under throttling, metrics/log volume spikes.
+- The plan mentions tracking distributions, but does not require cardinality controls.
+
+## Proposed Solutions
+### Option A: Use model buckets (Small)
+Track top-N known models explicitly and aggregate the long tail into `other`.
+
+Pros:
+- Predictable time series count.
+
+Cons:
+- Less granular for long-tail debugging.
+
+### Option B: Hash + sample (Medium)
+Hash model keys for debugging correlation and sample detailed events.
+
+Pros:
+- Limits cardinality while retaining some diagnosis ability.
+
+Cons:
+- Requires careful operational ergonomics.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [ ] No high-cardinality unbounded labels derived from user input.
+- [ ] Logs sanitize model strings (no newlines/control chars).
+- [ ] Rollout dashboards remain stable in series count.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured performance/ops risk: model strings in metrics can explode cardinality.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`

--- a/todos/007-pending-p3-clean-up-plan-inconsistency-for-bucket-key.md
+++ b/todos/007-pending-p3-clean-up-plan-inconsistency-for-bucket-key.md
@@ -1,0 +1,50 @@
+---
+status: resolved
+priority: p3
+issue_id: "007"
+tags: [code-review, documentation, rate-limiting]
+dependencies: []
+---
+
+# Clean up plan inconsistency: bucket key mentions without provider
+
+## Problem Statement
+The plan mostly uses `(account_id, provider_id, exact_model_id)` as the bucket key, but a few remaining sentences still reference `(account_id, exact_model_id)`.
+
+This is documentation-only, but it can cause confusion during implementation.
+
+## Findings
+- `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md` includes one lingering mention in the Proposed Solution section.
+
+## Proposed Solutions
+### Option A: Edit plan to be consistent (Small)
+Replace remaining references with the final key shape and optionally show an example key format.
+
+Pros:
+- Removes ambiguity.
+
+Cons:
+- None.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [x] Plan uses a single bucket key definition consistently.
+
+## Work Log
+### 2026-01-30 - Created from plan review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured minor documentation inconsistency.
+
+### 2026-01-31 - Clarified bucket terminology
+
+**By:** OpenCode
+
+**Actions:**
+- Clarified that the bucket key tuple `(account_id, provider_id, quota_bucket_id)` is distinct from the scope label, and updated the agent signal section to describe both clearly in `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`.
+
+## Resources
+- Plan: `docs/plans/2026-01-30-fix-per-model-rate-limit-isolation-plan.md`

--- a/todos/008-pending-p1-make-model-cooldown-updates-monotonic-in-db.md
+++ b/todos/008-pending-p1-make-model-cooldown-updates-monotonic-in-db.md
@@ -1,0 +1,75 @@
+---
+status: pending
+priority: p1
+issue_id: "008"
+tags: [code-review, database, performance, reliability, rate-limiting]
+dependencies: []
+---
+
+# Make per-model cooldown updates monotonic in the database
+
+## Problem Statement
+Per-bucket cooldowns are persisted in `accounts.extra.model_rate_limits` on upstream 429. The current implementation attempts to avoid shortening cooldowns by comparing against `account.modelRateLimitResetAt(key)` before writing.
+
+That check is not atomic and uses an in-memory snapshot of `Account.Extra`, which can be stale across concurrent requests or instances. Under concurrency, a shorter cooldown can overwrite a longer one, creating stampedes and repeated 429 storms.
+
+## Findings
+- `backend/internal/service/ratelimit_service.go` checks existing cooldown via `account.modelRateLimitResetAt(key)` before calling `SetModelRateLimit`.
+- `backend/internal/repository/account_repo.go` `SetModelRateLimit` unconditionally writes the JSON payload at the key.
+- Under concurrent 429s:
+  - cooldown can be shortened (correctness bug)
+  - repeated writes/outbox events amplify load (performance risk)
+
+## Proposed Solutions
+
+### Option A: DB-level conditional update for JSONB key (Medium)
+Update only when the new `rate_limit_reset_at` extends the existing value.
+
+Pros:
+- Preserves JSONB storage choice.
+- Prevents cooldown shortening and reduces no-op writes.
+
+Cons:
+- JSONB timestamp extraction/comparison in SQL is more complex.
+
+### Option B: Move cooldowns to a normalized table with UPSERT (Medium/Large)
+Create `account_model_rate_limits(account_id, key, rate_limit_reset_at, rate_limited_at)` and use `INSERT .. ON CONFLICT .. DO UPDATE SET rate_limit_reset_at = GREATEST(...)`.
+
+Pros:
+- Clean monotonic semantics.
+- Less JSONB rewrite pressure; better indexing and pruning.
+
+Cons:
+- Requires migration + more code changes.
+
+### Option C: Hybrid gating (Medium)
+Use Redis TTL gating to reduce DB writes and persist less frequently.
+
+Pros:
+- Reduces hot-row writes during 429 storms.
+
+Cons:
+- Adds another store and coherency complexity.
+
+## Recommended Action
+
+## Technical Details
+- Write primitive: `backend/internal/repository/account_repo.go` `SetModelRateLimit`
+- Read/check: `backend/internal/service/model_rate_limit.go`
+- Callers: `backend/internal/service/ratelimit_service.go`, `backend/internal/service/gemini_messages_compat_service.go`, `backend/internal/service/antigravity_gateway_service.go`
+
+## Acceptance Criteria
+- [ ] Cooldown can never be shortened by concurrent writes.
+- [ ] No-op writes (new reset <= existing reset) do not enqueue scheduler outbox events.
+- [ ] Stress test: concurrent 429s do not cause repeated upstream stampedes after expiry.
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured correctness/performance risk: non-atomic cooldown extension logic.
+
+## Resources
+- Branch: `fix/per-model-rate-limit-isolation`

--- a/todos/009-pending-p1-use-effective-model-for-schedulability-checks.md
+++ b/todos/009-pending-p1-use-effective-model-for-schedulability-checks.md
@@ -1,0 +1,65 @@
+---
+status: pending
+priority: p1
+issue_id: "009"
+tags: [code-review, correctness, rate-limiting]
+dependencies: []
+---
+
+# Use effective model (post-mapping) for schedulability checks
+
+## Problem Statement
+Cooldowns are written using the model actually sent upstream (`effectiveModel` / `mappedModel`). However, schedulability gating uses `Account.IsSchedulableForModel(requestedModel)` and can end up checking cooldown keys derived from the requested model instead of the mapped model.
+
+This can cause the scheduler to repeatedly select accounts that are cooled down for the effective model, increasing error rates and retry load.
+
+## Findings
+- Writes use mapped model:
+  - `backend/internal/service/openai_gateway_service.go` uses `mappedModel`.
+  - `backend/internal/service/gateway_service.go` uses `reqModel` after mapping.
+  - `backend/internal/service/gemini_messages_compat_service.go` passes `mappedModel`.
+- Scheduling gate uses requested model:
+  - `backend/internal/service/antigravity_quota_scope.go` `Account.IsSchedulableForModel(requestedModel)` calls `a.isModelRateLimited(requestedModel)`.
+- Mapping is account-dependent (`account.GetMappedModel(requestedModel)`), so the correct key for gating may require the same mapping logic.
+
+## Proposed Solutions
+
+### Option A: Apply mapping inside `IsSchedulableForModel` (Small/Medium)
+If account type/platform mapping applies, compute effective model from requested and use that for cooldown keying.
+
+Pros:
+- Single choke point used broadly.
+
+Cons:
+- Must be careful not to change behavior for accounts where mapping should not apply.
+
+### Option B: Introduce a shared helper for `effectiveModel` resolution (Medium)
+Create one function used by both (1) request forwarding and (2) schedulability checks.
+
+Pros:
+- Prevents drift between write-path and read-path.
+
+Cons:
+- Requires refactoring multiple call sites.
+
+## Recommended Action
+
+## Technical Details
+- Scheduling gate: `backend/internal/service/antigravity_quota_scope.go`
+- Model cooldown read: `backend/internal/service/model_rate_limit.go`
+- Mapping source: `backend/internal/service/account.go` (`GetMappedModel`)
+
+## Acceptance Criteria
+- [ ] If a model is mapped for upstream, the schedulability check uses the same mapped model for cooldown gating.
+- [ ] Repeated 429s on a mapped model do not result in repeated re-selection of the same account.
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured correctness bug risk: mismatched model identity between cooldown write and gating.
+
+## Resources
+- Branch: `fix/per-model-rate-limit-isolation`

--- a/todos/010-pending-p2-pass-effective-model-through-retry-exhausted-path.md
+++ b/todos/010-pending-p2-pass-effective-model-through-retry-exhausted-path.md
@@ -1,0 +1,49 @@
+---
+status: pending
+priority: p2
+issue_id: "010"
+tags: [code-review, correctness, rate-limiting]
+dependencies: []
+---
+
+# Pass effective model through retry-exhausted side effects
+
+## Problem Statement
+One code path still calls retry-exhausted side effects without an effective model, which may cause fallback to global cooldown behavior when a model-scoped cooldown is intended.
+
+## Findings
+- `backend/internal/service/gateway_service.go` has a call that passes `""` as effective model in `handleRetryExhaustedError`.
+- When `effectiveModel` is empty, `RateLimitService` cannot compute a bucket key, and the system may fall back to global `SetRateLimited`.
+
+## Proposed Solutions
+
+### Option A: Thread `reqModel` through retry-exhausted handlers (Small)
+Pass the mapped/effective request model into `handleRetryExhaustedError` and into `handleRetryExhaustedSideEffects`.
+
+Pros:
+- Minimal change.
+
+Cons:
+- Must ensure the model is available at that call site.
+
+### Option B: Use request context storage (Small/Medium)
+Store effective model in gin context keys and retrieve in retry-exhausted handlers.
+
+Pros:
+- Avoids changing function signatures.
+
+Cons:
+- More implicit coupling.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [ ] Retry-exhausted 429s can still write model-scoped cooldowns when model is known.
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured remaining path that drops effective model.

--- a/todos/011-pending-p2-revisit-reset-clamp-and-reset-source-strategy.md
+++ b/todos/011-pending-p2-revisit-reset-clamp-and-reset-source-strategy.md
@@ -1,0 +1,43 @@
+---
+status: pending
+priority: p2
+issue_id: "011"
+tags: [code-review, reliability, performance, rate-limiting]
+dependencies: []
+---
+
+# Revisit reset-time clamping and reset-source strategy
+
+## Problem Statement
+Reset time parsing now aggregates multiple sources and clamps the final reset to a maximum of 24 hours. Some providers/quota windows can legitimately exceed 24 hours (multi-day windows). Hard clamping can cause the system to retry too early, creating repeated 429 storms.
+
+## Findings
+- `backend/internal/service/ratelimit_service.go`:
+  - selects `resetAt` as the latest future time among candidates.
+  - clamps to `[now+1s, now+24h]`.
+- This is safe against pathological headers but may be incorrect for long reset windows.
+
+## Proposed Solutions
+
+### Option A: Source-aware max clamp (Small/Medium)
+Apply stricter clamps to untrusted sources (e.g., `Retry-After`, body parsing), but allow longer windows for trusted provider headers.
+
+### Option B: Increase global max clamp (Small)
+Raise max to something like 7–10 days while keeping the min clamp.
+
+### Option C: Remove max clamp and keep only min clamp (Small)
+Accept long resets, relying on key safety and provider parsing to avoid wedging.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [ ] Legitimate multi-day resets do not get reduced to 24h.
+- [ ] Pathological values still cannot wedge scheduling for weeks/months.
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured correctness/perf risk: too-aggressive 24h clamp.

--- a/todos/012-pending-p2-expose-machine-readable-model-rate-limit-signals.md
+++ b/todos/012-pending-p2-expose-machine-readable-model-rate-limit-signals.md
@@ -1,0 +1,51 @@
+---
+status: done
+priority: p2
+issue_id: "012"
+tags: [code-review, api, agent-native, rate-limiting]
+dependencies: []
+---
+
+# Expose machine-readable model-bucket rate limit signals to clients
+
+## Problem Statement
+Internal scheduling can now avoid a rate-limited model bucket and still use other buckets. However, API clients (including agents) still receive generic 429 responses with no stable indication of scope (bucket vs global) or which bucket was cooled down.
+
+## Findings
+- Error responses for 429 are generic in gateway error writers.
+- `RateLimitService` computes reset times internally (including `Retry-After` parsing), but error responses do not consistently include a retry hint.
+
+## Proposed Solutions
+
+### Option A: Add stable headers on 429 (Small/Medium)
+Always set:
+- `Retry-After` (computed if missing)
+- `X-Sub2API-RateLimit-Scope: model_bucket|account|unknown`
+- `X-Sub2API-RateLimit-Key: <provider>:<bucket>` when available
+
+### Option B: Add additive JSON fields (Medium)
+Include `error.code`, `error.scope`, `error.quota_bucket`, `error.retry_after_seconds`.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [ ] An agent can programmatically decide whether switching models/buckets is likely to work.
+- [ ] 429 responses always include retry guidance, even when upstream headers are missing.
+- [ ] No sensitive internal routing/account ids are leaked.
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured agent-native gap: internal behavior improved but external signals remain generic.
+
+### 2026-01-31 - Emit machine-readable throttling signals
+
+**By:** OpenCode
+
+**Actions:**
+- Added `RateLimitSignal` plumbing so 429 handling now returns the cooled bucket context.
+- Surface `Retry-After`, `X-Sub2API-RateLimit-Scope`, and `X-Sub2API-RateLimit-Key` in Gateway, OpenAI, and Gemini responses.
+- Documented the new header contract in `docs/reference/rate-limit-signals.md`.

--- a/todos/013-pending-p3-rename-model-rate-limit-scope-to-key.md
+++ b/todos/013-pending-p3-rename-model-rate-limit-scope-to-key.md
@@ -1,0 +1,34 @@
+---
+status: pending
+priority: p3
+issue_id: "013"
+tags: [code-review, quality, refactor, rate-limiting]
+dependencies: []
+---
+
+# Rename model rate limit "scope" to "key" for clarity
+
+## Problem Statement
+The code now stores entries under `accounts.extra.model_rate_limits` keyed by strings like `"gemini:gemini-3-pro"`. The repository method parameter is still named `scope`, which is confusing alongside Antigravity quota scopes and legacy Sonnet scope.
+
+## Findings
+- `backend/internal/repository/account_repo.go`: `SetModelRateLimit(..., scope string, ...)` now expects a storage key.
+- Several comments/constants still use “scope” terminology even though the semantics are “bucket key”.
+
+## Proposed Solutions
+
+### Option A: Rename params + constants (Small)
+Rename `scope` -> `key` in interfaces, repos, mocks, and update constant names for clarity.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [ ] No remaining confusion between Antigravity quota scopes and model cooldown keys.
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured naming cleanup for maintainability.

--- a/todos/014-pending-p3-simplify-handle429-reset-selection.md
+++ b/todos/014-pending-p3-simplify-handle429-reset-selection.md
@@ -1,0 +1,39 @@
+---
+status: pending
+priority: p3
+issue_id: "014"
+tags: [code-review, simplicity, rate-limiting]
+dependencies: []
+---
+
+# Simplify 429 reset-time selection logic
+
+## Problem Statement
+`RateLimitService.handle429` collects candidate reset times into a slice and then selects the best. This is correct but slightly more complex than needed for a hot error path.
+
+## Findings
+- `backend/internal/service/ratelimit_service.go` builds `candidates []time.Time` and then calls `latestFutureTime`.
+
+## Proposed Solutions
+
+### Option A: Compute best candidate incrementally (Small)
+Track a single best reset time as you parse sources, avoiding slice allocations.
+
+Pros:
+- Slightly lower GC pressure under 429 storms.
+
+Cons:
+- Minor change; not a functional fix.
+
+## Recommended Action
+
+## Acceptance Criteria
+- [ ] Behavior remains identical (same reset chosen for the same inputs).
+
+## Work Log
+### 2026-01-30 - Created from code review
+
+**By:** OpenCode
+
+**Actions:**
+- Captured simplification opportunity for a hot error-path function.


### PR DESCRIPTION
## Summary
Implemented per-account, per-provider, per-model (bucket) cooldowns to ensure that rate-limiting one model bucket (e.g., Gemini 3 Flash) does not block unrelated buckets (e.g., Gemini 3 Pro).

- **Monotonic Cooldown Writes**: SQL update only extends existing reset times and suppresses redundant outbox events.
- **Effective Model Gating**: Schedulability checks now use post-mapping model identity.
- **Gemini 3 Family Isolation**: Grouped models into isolated Flash and Pro buckets.
- **Stable Signals**: Exposed `Retry-After`, `X-Sub2API-RateLimit-Scope`, and `X-Sub2API-RateLimit-Key` headers.

## Testing
- Added `TestSetModelRateLimitMonotonic` and `TestSetModelRateLimitOutboxMonotonic` integration tests.
- Added table-driven `TestIsSchedulableForModel_TableDriven` unit tests.
- Verified signal generation via `TestRateLimitService_HandleUpstreamError_EmitsSignal`.
- All tests pass: `go test ./backend/internal/...`.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)