### PR TITLE
feat(gateway): Gemini API Key 账户跳过模型映射检查，直接透传

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1893,6 +1893,10 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 		// Antigravity 平台使用专门的模型支持检查
 		return IsAntigravityModelSupported(requestedModel)
 	}
+	// Gemini API Key 账户直接透传，由上游判断模型是否支持
+	if account.Platform == PlatformGemini && account.Type == AccountTypeAPIKey {
+		return true
+	}
 	// 其他平台使用账户的模型支持检查
 	return account.IsModelSupported(requestedModel)
 }


### PR DESCRIPTION
## Summary
- Gemini API Key 账户通常代理上游服务（如 clicodeplus），模型支持由上游判断
- 本地不需要预先配置模型映射，避免因缺少映射配置导致 "no available accounts" 错误

## Changes
- 在 `isModelSupportedByAccount` 函数中，对 Gemini API Key 账户直接返回 `true`，跳过模型映射检查

## Test plan
- [x] 配置 Gemini API Key 账户代理上游服务
- [x] 请求未在本地配置映射的模型（如 `gemini-3-pro-image`）
- [x] 验证请求成功转发到上游