### PR TITLE
fix(billing): 修复 Gemini 接口缓存 token 统计

### DIFF
--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2522,9 +2522,13 @@ func extractGeminiUsage(geminiResp map[string]any) *ClaudeUsage {
 	}
 	prompt, _ := asInt(usageMeta["promptTokenCount"])
 	cand, _ := asInt(usageMeta["candidatesTokenCount"])
+	cached, _ := asInt(usageMeta["cachedContentTokenCount"])
+	// 注意：Gemini 的 promptTokenCount 包含 cachedContentTokenCount，
+	// 但 Claude 的 input_tokens 不包含 cache_read_input_tokens，需要减去
 	return &ClaudeUsage{
-		InputTokens:  prompt,
-		OutputTokens: cand,
+		InputTokens:         prompt - cached,
+		OutputTokens:        cand,
+		CacheReadInputTokens: cached,
 	}
 }
 


### PR DESCRIPTION
## Summary
- 修复 Gemini 兼容接口 `extractGeminiUsage` 函数中缓存 token 统计的计算逻辑

## 问题描述
Gemini 的 `usageMetadata.promptTokenCount` **包含** `cachedContentTokenCount`，但 Claude 的 `input_tokens` **不包含** `cache_read_input_tokens`。

转换时如果不减去缓存 token，会导致重复计费：
- **错误**: InputTokens = promptTokenCount (包含缓存)
- **正确**: InputTokens = promptTokenCount - cachedContentTokenCount

## 实际 API 验证
通过多次调用 Gemini API 模拟连续会话，验证了 promptTokenCount 确实包含 cachedContentTokenCount：

| 调用 | promptTokenCount | cachedContentTokenCount | 差值 (实际输入) |
|------|-----------------|------------------------|---------------|
| 第1次 | 29061 | 0 | 29061 |
| 第2次 | 29065 | 28634 | 431 |
| 第3次 | 29069 | 28624 | 445 |

如果不减去 cached，第2次调用会按 29065 tokens 计费，而实际只输入了 431 tokens，导致约 **9x 重复计费**。

## 相关代码
此修复与 `antigravity` 包中的逻辑保持一致：
- `backend/internal/pkg/antigravity/response_transformer.go`
- `backend/internal/pkg/antigravity/stream_transformer.go`

## Test plan
- [x] 本地 API 调用验证 token 统计准确性
- [ ] CI 测试通过