### PR TITLE
feat: 支持在用户列表搜索中使用备注字段和模糊查询、支持用户名备注等搜索

### DIFF
--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -190,6 +190,7 @@ func (r *userRepository) ListWithFilters(ctx context.Context, params pagination.
 			dbuser.Or(
 				dbuser.EmailContainsFold(filters.Search),
 				dbuser.UsernameContainsFold(filters.Search),
+				dbuser.NotesContainsFold(filters.Search),
 			),
 		)
 	}


### PR DESCRIPTION

-  描述：
  ## 📋 功能：支持在用户搜索中使用备注字段

  ### 🎯 描述
  允许管理员在用户管理页面通过备注/标记字段搜索用户。

  ### 🔧 改动
  - 修改 `backend/internal/repository/user_repo.go`
  - 在搜索查询中添加 `dbuser.NotesContainsFold(filters.Search)`

  ### ✅ 测试
  - [x] 在用户管理页面测试通过
  - [x] 按邮箱搜索正常
  - [x] 按用户名搜索正常
  - [x] 按备注搜索正常（新功能）

  ### 💡 动机
  用户请求能够通过备注/标记快速查找带有特定标签或评论的用户。

- 在用户仓库的搜索过滤器中添加备注字段
- 管理员现在可以通过备注/标记搜索用户
- 使用不区分大小写的搜索(ContainsFold)

Changes:
- backend/internal/repository/user_repo.go: 添加 NotesContainsFold 到搜索条件