### PR TITLE
feat: 向用户显示管理员调整余额的备注

### DIFF
--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -321,7 +321,7 @@ func RedeemCodeFromServiceAdmin(rc *service.RedeemCode) *AdminRedeemCode {
 }
 
 func redeemCodeFromServiceBase(rc *service.RedeemCode) RedeemCode {
-	return RedeemCode{
+	out := RedeemCode{
 		ID:           rc.ID,
 		Code:         rc.Code,
 		Type:         rc.Type,
@@ -335,6 +335,14 @@ func redeemCodeFromServiceBase(rc *service.RedeemCode) RedeemCode {
 		User:         UserFromServiceShallow(rc.User),
 		Group:        GroupFromServiceShallow(rc.Group),
 	}
+
+	// For admin_balance/admin_concurrency types, include notes so users can see
+	// why they were charged or credited by admin
+	if (rc.Type == "admin_balance" || rc.Type == "admin_concurrency") && rc.Notes != "" {
+		out.Notes = &rc.Notes
+	}
+
+	return out
 }
 
 // AccountSummaryFromService returns a minimal AccountSummary for usage log display.

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -198,6 +198,10 @@ type RedeemCode struct {
 	GroupID      *int64 `json:"group_id"`
 	ValidityDays int    `json:"validity_days"`
 
+	// Notes is only populated for admin_balance/admin_concurrency types
+	// so users can see why they were charged or credited
+	Notes *string `json:"notes,omitempty"`
+
 	User  *User  `json:"user,omitempty"`
 	Group *Group `json:"group,omitempty"`
 }

--- a/frontend/src/api/redeem.ts
+++ b/frontend/src/api/redeem.ts
@@ -14,7 +14,9 @@ export interface RedeemHistoryItem {
   status: string
   used_at: string
   created_at: string
-  // 订阅类型专用字段
+  // Notes from admin for admin_balance/admin_concurrency types
+  notes?: string
+  // Subscription-specific fields
   group_id?: number
   validity_days?: number
   group?: {

--- a/frontend/src/views/user/RedeemView.vue
+++ b/frontend/src/views/user/RedeemView.vue
@@ -312,6 +312,14 @@
                 <p v-else class="text-xs text-gray-400 dark:text-dark-500">
                   {{ t('redeem.adminAdjustment') }}
                 </p>
+                <!-- Display notes for admin adjustments -->
+                <p
+                  v-if="item.notes"
+                  class="mt-1 text-xs text-gray-500 dark:text-dark-400 italic max-w-[200px] truncate"
+                  :title="item.notes"
+                >
+                  {{ item.notes }}
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- 为RedeemCode DTO添加notes字段（仅用于admin_balance/admin_concurrency类型）
- 更新mapper使其有条件地包含备注信息
- 在用户兑换历史UI中显示备注
- 备注以斜体显示，悬停时显示完整内容

用户现在可以看到管理员调整其余额的原因说明。

Changes:
- backend/internal/handler/dto/types.go: RedeemCode添加notes字段
- backend/internal/handler/dto/mappers.go: 条件性填充notes
- frontend/src/api/redeem.ts: TypeScript接口添加notes
- frontend/src/views/user/RedeemView.vue: UI显示备注信息


 描述：
  ## 📋 功能：向用户显示管理员调整余额的备注

  ### 🎯 描述
  用户现在可以在兑换历史中看到管理员调整其余额时填写的备注说明。

  ### 🔧 改动
  - `backend/internal/handler/dto/types.go`: 为RedeemCode DTO添加notes字段
  - `backend/internal/handler/dto/mappers.go`: 条件性地为admin_balance/admin_concurrency类型填充notes
  - `frontend/src/api/redeem.ts`: TypeScript接口添加notes字段
  - `frontend/src/views/user/RedeemView.vue`: UI中显示备注（斜体，悬停显示完整内容）

  ### ✅ 测试
  - [x] 管理员调整用户余额并填写备注
  - [x] 用户登录后在兑换历史中看到备注
  - [x] 备注以斜体显示，鼠标悬停显示完整内容
  - [x] 普通兑换码不显示notes（安全性）

  ### 🔒 安全性
  仅对 `admin_balance` 和 `admin_concurrency` 类型暴露notes字段，普通兑换码不会泄露内部备注。

  ### 💡 动机
  用户希望了解管理员调整余额的原因，提高透明度和信任度。