### PR TITLE
feat(gateway): 增强 /v1/usage 端点返回完整用量统计

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -173,7 +173,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	userAttributeService := service.NewUserAttributeService(userAttributeDefinitionRepository, userAttributeValueRepository)
 	userAttributeHandler := admin.NewUserAttributeHandler(userAttributeService)
 	adminHandlers := handler.ProvideAdminHandlers(dashboardHandler, adminUserHandler, groupHandler, accountHandler, adminAnnouncementHandler, oAuthHandler, openAIOAuthHandler, geminiOAuthHandler, antigravityOAuthHandler, proxyHandler, adminRedeemHandler, promoHandler, settingHandler, opsHandler, systemHandler, adminSubscriptionHandler, adminUsageHandler, userAttributeHandler)
-	gatewayHandler := handler.NewGatewayHandler(gatewayService, geminiMessagesCompatService, antigravityGatewayService, userService, concurrencyService, billingCacheService, configConfig)
+	gatewayHandler := handler.NewGatewayHandler(gatewayService, geminiMessagesCompatService, antigravityGatewayService, userService, concurrencyService, billingCacheService, usageService, configConfig)
 	openAIGatewayHandler := handler.NewOpenAIGatewayHandler(openAIGatewayService, concurrencyService, billingCacheService, configConfig)
 	handlerSettingHandler := handler.ProvideSettingHandler(settingService, buildInfo)
 	totpHandler := handler.NewTotpHandler(totpService)

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -30,6 +30,7 @@ type GatewayHandler struct {
 	antigravityGatewayService *service.AntigravityGatewayService
 	userService               *service.UserService
 	billingCacheService       *service.BillingCacheService
+	usageService              *service.UsageService
 	concurrencyHelper         *ConcurrencyHelper
 	maxAccountSwitches        int
 	maxAccountSwitchesGemini  int
@@ -43,6 +44,7 @@ func NewGatewayHandler(
 	userService *service.UserService,
 	concurrencyService *service.ConcurrencyService,
 	billingCacheService *service.BillingCacheService,
+	usageService *service.UsageService,
 	cfg *config.Config,
 ) *GatewayHandler {
 	pingInterval := time.Duration(0)
@@ -63,6 +65,7 @@ func NewGatewayHandler(
 		antigravityGatewayService: antigravityGatewayService,
 		userService:               userService,
 		billingCacheService:       billingCacheService,
+		usageService:              usageService,
 		concurrencyHelper:         NewConcurrencyHelper(concurrencyService, SSEPingFormatClaude, pingInterval),
 		maxAccountSwitches:        maxAccountSwitches,
 		maxAccountSwitchesGemini:  maxAccountSwitchesGemini,
@@ -524,7 +527,7 @@ func (h *GatewayHandler) AntigravityModels(c *gin.Context) {
 	})
 }
 
-// Usage handles getting account balance for CC Switch integration
+// Usage handles getting account balance and usage statistics for CC Switch integration
 // GET /v1/usage
 func (h *GatewayHandler) Usage(c *gin.Context) {
 	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
@@ -539,7 +542,40 @@ func (h *GatewayHandler) Usage(c *gin.Context) {
 		return
 	}
 
-	// 订阅模式：返回订阅限额信息
+	// Best-effort: 获取用量统计，失败不影响基础响应
+	var usageData gin.H
+	if h.usageService != nil {
+		dashStats, err := h.usageService.GetUserDashboardStats(c.Request.Context(), subject.UserID)
+		if err == nil && dashStats != nil {
+			usageData = gin.H{
+				"today": gin.H{
+					"requests":              dashStats.TodayRequests,
+					"input_tokens":          dashStats.TodayInputTokens,
+					"output_tokens":         dashStats.TodayOutputTokens,
+					"cache_creation_tokens": dashStats.TodayCacheCreationTokens,
+					"cache_read_tokens":     dashStats.TodayCacheReadTokens,
+					"total_tokens":          dashStats.TodayTokens,
+					"cost":                  dashStats.TodayCost,
+					"actual_cost":           dashStats.TodayActualCost,
+				},
+				"total": gin.H{
+					"requests":              dashStats.TotalRequests,
+					"input_tokens":          dashStats.TotalInputTokens,
+					"output_tokens":         dashStats.TotalOutputTokens,
+					"cache_creation_tokens": dashStats.TotalCacheCreationTokens,
+					"cache_read_tokens":     dashStats.TotalCacheReadTokens,
+					"total_tokens":          dashStats.TotalTokens,
+					"cost":                  dashStats.TotalCost,
+					"actual_cost":           dashStats.TotalActualCost,
+				},
+				"average_duration_ms": dashStats.AverageDurationMs,
+				"rpm":                 dashStats.Rpm,
+				"tpm":                 dashStats.Tpm,
+			}
+		}
+	}
+
+	// 订阅模式：返回订阅限额信息 + 用量统计
 	if apiKey.Group != nil && apiKey.Group.IsSubscriptionType() {
 		subscription, ok := middleware2.GetSubscriptionFromContext(c)
 		if !ok {
@@ -548,28 +584,46 @@ func (h *GatewayHandler) Usage(c *gin.Context) {
 		}
 
 		remaining := h.calculateSubscriptionRemaining(apiKey.Group, subscription)
-		c.JSON(http.StatusOK, gin.H{
+		resp := gin.H{
 			"isValid":   true,
 			"planName":  apiKey.Group.Name,
 			"remaining": remaining,
 			"unit":      "USD",
-		})
+			"subscription": gin.H{
+				"daily_usage_usd":   subscription.DailyUsageUSD,
+				"weekly_usage_usd":  subscription.WeeklyUsageUSD,
+				"monthly_usage_usd": subscription.MonthlyUsageUSD,
+				"daily_limit_usd":   apiKey.Group.DailyLimitUSD,
+				"weekly_limit_usd":  apiKey.Group.WeeklyLimitUSD,
+				"monthly_limit_usd": apiKey.Group.MonthlyLimitUSD,
+				"expires_at":        subscription.ExpiresAt,
+			},
+		}
+		if usageData != nil {
+			resp["usage"] = usageData
+		}
+		c.JSON(http.StatusOK, resp)
 		return
 	}
 
-	// 余额模式：返回钱包余额
+	// 余额模式：返回钱包余额 + 用量统计
 	latestUser, err := h.userService.GetByID(c.Request.Context(), subject.UserID)
 	if err != nil {
 		h.errorResponse(c, http.StatusInternalServerError, "api_error", "Failed to get user info")
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	resp := gin.H{
 		"isValid":   true,
 		"planName":  "钱包余额",
 		"remaining": latestUser.Balance,
 		"unit":      "USD",
-	})
+		"balance":   latestUser.Balance,
+	}
+	if usageData != nil {
+		resp["usage"] = usageData
+	}
+	c.JSON(http.StatusOK, resp)
 }
 
 // calculateSubscriptionRemaining 计算订阅剩余可用额度


### PR DESCRIPTION
## Summary
- 增强 `/v1/usage` 网关端点，在保持原有 4 字段 (`isValid`, `planName`, `remaining`, `unit`) 向后兼容的基础上，新增 `usage`（今日/累计 token 用量、费用、RPM/TPM）、`subscription`（订阅限额详情）、`balance`（钱包余额）字段
- 为 `GatewayHandler` 注入 `UsageService`，复用现有的 `GetUserDashboardStats` 方法获取用量数据
- 用量数据获取采用 best-effort 策略，失败不影响基础响应，确保零破坏性变更

## Motivation
当前 `/v1/usage` 端点仅返回剩余余额，cc-switch 等第三方工具无法展示已用 token 数、费用等详细信息。增强后，cc-switch 的 extractor 可以提取完整用量数据进行展示。

## Changes
- `backend/internal/handler/gateway_handler.go`：`GatewayHandler` 结构体新增 `usageService` 字段，构造函数新增参数，`Usage` 方法增强返回数据
- `backend/cmd/server/wire_gen.go`：Wire 依赖注入更新，传入已有的 `usageService` 实例

## Response Format (Balance Mode)
```json
{
  "isValid": true,
  "planName": "钱包余额",
  "remaining": 150.25,
  "unit": "USD",
  "balance": 150.25,
  "usage": {
    "today": { "requests": 42, "input_tokens": 280000, "output_tokens": 35000, ... },
    "total": { "requests": 1200, "input_tokens": 8500000, "output_tokens": 680000, ... },
    "average_duration_ms": 2450.5,
    "rpm": 8,
    "tpm": 32000
  }
}
```

## Test plan
- [ ] `go build ./...` 编译通过
- [ ] 用 API Key curl 测试 `GET /v1/usage`，确认返回新增的 `usage` 字段
- [ ] 确认原有 `isValid`/`planName`/`remaining`/`unit` 字段不变（向后兼容）
- [ ] 分别测试余额模式和订阅模式的响应格式
- [ ] 验证 cc-switch 可以正常读取新字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)