### PR TITLE
feat(ops): 将 USER_INACTIVE 错误排除在 SLA 统计之外

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -905,7 +905,7 @@ func classifyOpsIsRetryable(errType string, statusCode int) bool {
 
 func classifyOpsIsBusinessLimited(errType, phase, code string, status int, message string) bool {
 	switch strings.TrimSpace(code) {
-	case "INSUFFICIENT_BALANCE", "USAGE_LIMIT_EXCEEDED", "SUBSCRIPTION_NOT_FOUND", "SUBSCRIPTION_INVALID":
+	case "INSUFFICIENT_BALANCE", "USAGE_LIMIT_EXCEEDED", "SUBSCRIPTION_NOT_FOUND", "SUBSCRIPTION_INVALID", "USER_INACTIVE":
 		return true
 	}
 	if phase == "billing" || phase == "concurrency" {


### PR DESCRIPTION
将账户停用 (USER_INACTIVE) 导致的请求失败视为业务限制类错误，不计入 SLA 和错误率统计。

账户停用是预期内的业务结果，不应被视为系统错误或服务质量问题。此改动使错误分类更加准确，避免将预期的业务限制误报为系统故障。

修改内容：
- 在 classifyOpsIsBusinessLimited 函数中添加 USER_INACTIVE 错误码
- 该类错误不再触发错误率告警

fix #453