### PR TITLE
feat(antigravity): map all gemini-2.5 to gemini-3 series

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -273,13 +273,11 @@ func logPrefix(sessionID, accountName string) string {
 }
 
 // Antigravity 直接支持的模型（精确匹配透传）
+// 注意：gemini-2.5 系列已移除，统一映射到 gemini-3 系列
 var antigravitySupportedModels = map[string]bool{
 	"claude-opus-4-5-thinking":   true,
 	"claude-sonnet-4-5":          true,
 	"claude-sonnet-4-5-thinking": true,
-	"gemini-2.5-flash":           true,
-	"gemini-2.5-flash-lite":      true,
-	"gemini-2.5-flash-thinking":  true,
 	"gemini-3-flash":             true,
 	"gemini-3-pro-low":           true,
 	"gemini-3-pro-high":          true,
@@ -288,26 +286,32 @@ var antigravitySupportedModels = map[string]bool{
 
 // Antigravity 前缀映射表（按前缀长度降序排列，确保最长匹配优先）
 // 用于处理模型版本号变化（如 -20251111, -thinking, -preview 等后缀）
+// gemini-2.5 系列统一映射到 gemini-3 系列（Antigravity 上游不再支持 2.5）
 var antigravityPrefixMapping = []struct {
 	prefix string
 	target string
 }{
-	// 长前缀优先
+	// gemini-2.5 → gemini-3 映射（长前缀优先）
+	{"gemini-2.5-flash-thinking", "gemini-3-flash"},  // gemini-2.5-flash-thinking → gemini-3-flash
+	{"gemini-2.5-flash-image", "gemini-3-pro-image"}, // gemini-2.5-flash-image → gemini-3-pro-image
+	{"gemini-2.5-flash-lite", "gemini-3-flash"},      // gemini-2.5-flash-lite → gemini-3-flash
+	{"gemini-2.5-flash", "gemini-3-flash"},           // gemini-2.5-flash → gemini-3-flash
 	{"gemini-2.5-pro-preview", "gemini-3-pro-high"},  // gemini-2.5-pro-preview → gemini-3-pro-high
 	{"gemini-2.5-pro-exp", "gemini-3-pro-high"},      // gemini-2.5-pro-exp → gemini-3-pro-high
 	{"gemini-2.5-pro", "gemini-3-pro-high"},          // gemini-2.5-pro → gemini-3-pro-high
-	{"gemini-2.5-flash-image", "gemini-3-pro-image"}, // gemini-2.5-flash-image → 3-pro-image
-	{"gemini-3-pro-image", "gemini-3-pro-image"},     // gemini-3-pro-image-preview 等
-	{"gemini-3-flash", "gemini-3-flash"},             // gemini-3-flash-preview 等 → gemini-3-flash
-	{"claude-3-5-sonnet", "claude-sonnet-4-5"},       // 旧版 claude-3-5-sonnet-xxx
-	{"claude-sonnet-4-5", "claude-sonnet-4-5"},       // claude-sonnet-4-5-xxx
-	{"claude-haiku-4-5", "claude-sonnet-4-5"},        // claude-haiku-4-5-xxx → sonnet
+	// gemini-3 前缀映射
+	{"gemini-3-pro-image", "gemini-3-pro-image"}, // gemini-3-pro-image-preview 等
+	{"gemini-3-flash", "gemini-3-flash"},         // gemini-3-flash-preview 等 → gemini-3-flash
+	{"gemini-3-pro", "gemini-3-pro-high"},        // gemini-3-pro, gemini-3-pro-preview 等
+	// Claude 映射
+	{"claude-3-5-sonnet", "claude-sonnet-4-5"}, // 旧版 claude-3-5-sonnet-xxx
+	{"claude-sonnet-4-5", "claude-sonnet-4-5"}, // claude-sonnet-4-5-xxx
+	{"claude-haiku-4-5", "claude-sonnet-4-5"},  // claude-haiku-4-5-xxx → sonnet
 	{"claude-opus-4-5", "claude-opus-4-5-thinking"},
 	{"claude-3-haiku", "claude-sonnet-4-5"}, // 旧版 claude-3-haiku-xxx → sonnet
 	{"claude-sonnet-4", "claude-sonnet-4-5"},
 	{"claude-haiku-4", "claude-sonnet-4-5"}, // → sonnet
 	{"claude-opus-4", "claude-opus-4-5-thinking"},
-	{"gemini-3-pro", "gemini-3-pro-high"}, // gemini-3-pro, gemini-3-pro-preview 等
 }
 
 // AntigravityGatewayService 处理 Antigravity 平台的 API 转发

--- a/backend/internal/service/antigravity_model_mapping_test.go
+++ b/backend/internal/service/antigravity_model_mapping_test.go
@@ -134,12 +134,12 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-sonnet-4-5",
 		},
 
-		// 3. Gemini 透传
+		// 3. Gemini 2.5 → 3 映射
 		{
-			name:           "Gemini透传 - gemini-2.5-flash",
+			name:           "Gemini映射 - gemini-2.5-flash → gemini-3-flash",
 			requestedModel: "gemini-2.5-flash",
 			accountMapping: nil,
-			expected:       "gemini-2.5-flash",
+			expected:       "gemini-3-flash",
 		},
 		{
 			name:           "Gemini映射 - gemini-2.5-pro → gemini-3-pro-high",


### PR DESCRIPTION
## Summary
- Antigravity 上游已不再支持 gemini-2.5 系列模型
- 将所有 gemini-2.5 系列请求自动映射到对应的 gemini-3 系列

## 映射规则
| 请求模型 | 映射目标 |
|---------|---------|
| gemini-2.5-flash | gemini-3-flash |
| gemini-2.5-flash-lite | gemini-3-flash |
| gemini-2.5-flash-thinking | gemini-3-flash |
| gemini-2.5-flash-image | gemini-3-pro-image |
| gemini-2.5-pro | gemini-3-pro-high |
| gemini-2.5-pro-preview | gemini-3-pro-high |
| gemini-2.5-pro-exp | gemini-3-pro-high |

## Changes
- 从 `antigravitySupportedModels` 中移除 gemini-2.5 系列（避免透传）
- 在 `antigravityPrefixMapping` 中添加完整的 gemini-2.5 → gemini-3 映射规则
- 更新相关测试用例

## Test Plan
- [x] 单元测试通过
- [x] CI 通过
- [x] 生产环境测试验证映射正确