### PR TITLE
fix(openai): 统一 OAuth instructions 处理逻辑，修复 Codex CLI 400 错误

### DIFF
--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1,0 +1,210 @@
+package service
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyCodexOAuthTransform_StoreDefaultsFalse(t *testing.T) {
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.2",
+		"input": []any{
+			map[string]any{"type": "text", "text": "hello"},
+		},
+	}
+
+	applyCodexOAuthTransform(reqBody, false)
+
+	store, ok := reqBody["store"].(bool)
+	require.True(t, ok)
+	require.False(t, store)
+}
+
+func TestApplyCodexOAuthTransform_ExplicitStoreFalsePreserved(t *testing.T) {
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.1",
+		"store": false,
+		"input": []any{
+			map[string]any{"type": "text", "text": "hello"},
+		},
+	}
+
+	applyCodexOAuthTransform(reqBody, false)
+
+	store, ok := reqBody["store"].(bool)
+	require.True(t, ok)
+	require.False(t, store)
+}
+
+func TestApplyCodexOAuthTransform_ExplicitStoreTrueForcedFalse(t *testing.T) {
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.1",
+		"store": true,
+		"input": []any{
+			map[string]any{"type": "text", "text": "hello"},
+		},
+	}
+
+	applyCodexOAuthTransform(reqBody, false)
+
+	store, ok := reqBody["store"].(bool)
+	require.True(t, ok)
+	require.False(t, store)
+}
+
+func TestApplyCodexOAuthTransform_StripsIDs(t *testing.T) {
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.1",
+		"input": []any{
+			map[string]any{"type": "text", "id": "t1", "text": "hi"},
+		},
+	}
+
+	applyCodexOAuthTransform(reqBody, false)
+
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 1)
+	item, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	_, hasID := item["id"]
+	require.False(t, hasID)
+}
+
+func TestFilterCodexInput_RemovesItemReference(t *testing.T) {
+	input := []any{
+		map[string]any{"type": "item_reference", "id": "ref1"},
+		map[string]any{"type": "text", "id": "t1", "text": "hi"},
+	}
+
+	filtered := filterCodexInput(input)
+	require.Len(t, filtered, 1)
+	item, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "text", item["type"])
+	_, hasID := item["id"]
+	require.False(t, hasID)
+}
+
+func TestApplyCodexOAuthTransform_EmptyInput(t *testing.T) {
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.1",
+		"input": []any{},
+	}
+
+	applyCodexOAuthTransform(reqBody, false)
+
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 0)
+}
+
+func TestApplyCodexOAuthTransform_CodexCLI_PreservesExistingInstructions(t *testing.T) {
+	// Codex CLI 场景：已有 instructions 时保持不变
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model":        "gpt-5.1",
+		"instructions": "user custom instructions",
+		"input":        []any{},
+	}
+
+	result := applyCodexOAuthTransform(reqBody, true)
+
+	instructions, ok := reqBody["instructions"].(string)
+	require.True(t, ok)
+	require.Equal(t, "user custom instructions", instructions)
+	// instructions 未变，但其他字段（如 store、stream）可能被修改
+	require.True(t, result.Modified)
+}
+
+func TestApplyCodexOAuthTransform_CodexCLI_AddsInstructionsWhenEmpty(t *testing.T) {
+	// Codex CLI 场景：无 instructions 时补充 opencode 指令
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.1",
+		"input": []any{},
+	}
+
+	result := applyCodexOAuthTransform(reqBody, true)
+
+	instructions, ok := reqBody["instructions"].(string)
+	require.True(t, ok)
+	require.NotEmpty(t, instructions)
+	require.True(t, result.Modified)
+}
+
+func TestApplyCodexOAuthTransform_NonCodexCLI_UsesOpenCodeInstructions(t *testing.T) {
+	// 非 Codex CLI 场景：使用 opencode 指令（缓存中有 header）
+	setupCodexCache(t)
+
+	reqBody := map[string]any{
+		"model": "gpt-5.1",
+		"input": []any{},
+	}
+
+	result := applyCodexOAuthTransform(reqBody, false)
+
+	instructions, ok := reqBody["instructions"].(string)
+	require.True(t, ok)
+	require.Equal(t, "header", instructions) // setupCodexCache 设置的缓存内容
+	require.True(t, result.Modified)
+}
+
+func TestIsInstructionsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		reqBody  map[string]any
+		expected bool
+	}{
+		{"field not exists", map[string]any{}, true},
+		{"field is nil", map[string]any{"instructions": nil}, true},
+		{"field is empty string", map[string]any{"instructions": ""}, true},
+		{"field is whitespace", map[string]any{"instructions": "   "}, true},
+		{"field has value", map[string]any{"instructions": "hello"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isInstructionsEmpty(tt.reqBody)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func setupCodexCache(t *testing.T) {
+	t.Helper()
+
+	// 使用临时 HOME 避免触发网络拉取 header。
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	cacheDir := filepath.Join(tempDir, ".opencode", "cache")
+	require.NoError(t, os.MkdirAll(cacheDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "opencode-codex-header.txt"), []byte("header"), 0o644))
+
+	meta := map[string]any{
+		"etag":        "",
+		"lastFetch":   time.Now().UTC().Format(time.RFC3339),
+		"lastChecked": time.Now().UnixMilli(),
+	}
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(cacheDir, "opencode-codex-header-meta.json"), data, 0o644))
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -551,8 +551,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	if account.Type == AccountTypeOAuth && !isCodexCLI {
-		codexResult := applyCodexOAuthTransform(reqBody)
+	if account.Type == AccountTypeOAuth {
+		codexResult := applyCodexOAuthTransform(reqBody, isCodexCLI)
 		if codexResult.Modified {
 			bodyModified = true
 		}


### PR DESCRIPTION
## Summary
- 统一 OAuth 账号的 instructions 处理逻辑，修复 Codex CLI 请求缺少 instructions 导致的 400 错误
- 对所有 OAuth 请求统一调用 `applyCodexOAuthTransform`，根据 `isCodexCLI` 参数区分处理

## Changes
- 修改 `applyCodexOAuthTransform` 函数签名，增加 `isCodexCLI` 参数
- 移除 `&& !isCodexCLI` 条件，对所有 OAuth 请求统一处理
- 新增 `applyInstructions`、`applyCodexCLIInstructions`、`applyOpenCodeInstructions`、`isInstructionsEmpty` 辅助函数
- 添加 instructions 处理相关测试用例

## 逻辑说明
| 请求类型 | instructions 处理 |
|---------|------------------|
| Codex CLI + 有 instructions | 保持不变 |
| Codex CLI + 无 instructions | 补充 opencode 指令 |
| 非 Codex CLI | 使用 opencode 指令覆盖 |

## Test plan
- [x] 添加 Codex CLI 场景测试用例
- [x] 添加非 Codex CLI 场景测试用例
- [x] 添加 isInstructionsEmpty 测试用例
- [ ] GitHub Actions CI 通过