### PR TITLE
fix(openai): 统一 OAuth instructions 处理逻辑，修复 Codex CLI 400 错误

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -796,8 +796,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	if account.Type == AccountTypeOAuth && !isCodexCLI {
-		codexResult := applyCodexOAuthTransform(reqBody)
+	if account.Type == AccountTypeOAuth {
+		codexResult := applyCodexOAuthTransform(reqBody, isCodexCLI)
 		if codexResult.Modified {
 			bodyModified = true
 		}


### PR DESCRIPTION
## Summary
- 统一 OAuth 账号的 instructions 处理逻辑，修复 Codex CLI 请求缺少 instructions 导致的 400 错误
- 对所有 OAuth 请求统一调用 `applyCodexOAuthTransform`，根据 `isCodexCLI` 参数区分处理

## Changes
- 修改 `applyCodexOAuthTransform` 函数签名，增加 `isCodexCLI` 参数
- 移除 `&& !isCodexCLI` 条件，对所有 OAuth 请求统一处理
- 新增 `applyInstructions`、`applyCodexCLIInstructions`、`applyOpenCodeInstructions`、`isInstructionsEmpty` 辅助函数
- 添加 instructions 处理相关测试用例

## 逻辑说明
| 请求类型 | instructions 处理 |
|---------|------------------|
| Codex CLI + 有 instructions | 保持不变 |
| Codex CLI + 无 instructions | 补充 opencode 指令 |
| 非 Codex CLI | 使用 opencode 指令覆盖 |

## Test plan
- [x] 添加 Codex CLI 场景测试用例
- [x] 添加非 Codex CLI 场景测试用例
- [x] 添加 isInstructionsEmpty 测试用例
- [ ] GitHub Actions CI 通过