### PR TITLE
fix: remove unsupported safety_identifier and previous_response_id fields from upstream requests

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -846,10 +846,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 		}
 
-		// Remove prompt_cache_retention (not supported by upstream OpenAI API)
-		if _, has := reqBody["prompt_cache_retention"]; has {
-			delete(reqBody, "prompt_cache_retention")
-			bodyModified = true
+		// Remove unsupported fields (not supported by upstream OpenAI API)
+		for _, unsupportedField := range []string{"prompt_cache_retention", "safety_identifier", "previous_response_id"} {
+			if _, has := reqBody[unsupportedField]; has {
+				delete(reqBody, unsupportedField)
+				bodyModified = true
+			}
 		}
 	}
 


### PR DESCRIPTION
droid连接的时候，一直会报错，目前是droid会加一些codex不支持的参数，导致连接不成功。

```
Feb 04 15:59:56 C202601122049410 sub2api[185316]: time=2026-02-04T15:59:56.337+08:00 level=INFO msg="OpenAI upstream error 400 (account=21 platform=openai type=oauth): {\"detail\":\"Unsupported parameter: safety_identifier\"}"
```