### PR TITLE
feat(gateway): filter /v1/usage stats by API Key instead of UserID

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -616,10 +616,10 @@ func (h *GatewayHandler) Usage(c *gin.Context) {
 		return
 	}
 
-	// Best-effort: 获取用量统计，失败不影响基础响应
+	// Best-effort: 获取用量统计（按当前 API Key 过滤），失败不影响基础响应
 	var usageData gin.H
 	if h.usageService != nil {
-		dashStats, err := h.usageService.GetUserDashboardStats(c.Request.Context(), subject.UserID)
+		dashStats, err := h.usageService.GetAPIKeyDashboardStats(c.Request.Context(), apiKey.ID)
 		if err == nil && dashStats != nil {
 			usageData = gin.H{
 				"today": gin.H{

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1610,6 +1610,10 @@ func (r *stubUsageLogRepo) GetUserDashboardStats(ctx context.Context, userID int
 	return nil, errors.New("not implemented")
 }
 
+func (r *stubUsageLogRepo) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*usagestats.UserDashboardStats, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (r *stubUsageLogRepo) GetUserUsageTrendByUserID(ctx context.Context, userID int64, startTime, endTime time.Time, granularity string) ([]usagestats.TrendDataPoint, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -41,6 +41,7 @@ type UsageLogRepository interface {
 
 	// User dashboard stats
 	GetUserDashboardStats(ctx context.Context, userID int64) (*usagestats.UserDashboardStats, error)
+	GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*usagestats.UserDashboardStats, error)
 	GetUserUsageTrendByUserID(ctx context.Context, userID int64, startTime, endTime time.Time, granularity string) ([]usagestats.TrendDataPoint, error)
 	GetUserModelStats(ctx context.Context, userID int64, startTime, endTime time.Time) ([]usagestats.ModelStat, error)
 

--- a/backend/internal/service/usage_service.go
+++ b/backend/internal/service/usage_service.go
@@ -288,6 +288,15 @@ func (s *UsageService) GetUserDashboardStats(ctx context.Context, userID int64) 
 	return stats, nil
 }
 
+// GetAPIKeyDashboardStats returns dashboard summary stats filtered by API Key.
+func (s *UsageService) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*usagestats.UserDashboardStats, error) {
+	stats, err := s.usageRepo.GetAPIKeyDashboardStats(ctx, apiKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("get api key dashboard stats: %w", err)
+	}
+	return stats, nil
+}
+
 // GetUserUsageTrendByUserID returns per-user usage trend.
 func (s *UsageService) GetUserUsageTrendByUserID(ctx context.Context, userID int64, startTime, endTime time.Time, granularity string) ([]usagestats.TrendDataPoint, error) {
 	trend, err := s.usageRepo.GetUserUsageTrendByUserID(ctx, userID, startTime, endTime, granularity)


### PR DESCRIPTION
## Summary
- `/v1/usage` 端点的用量统计（today/total tokens、cost、RPM/TPM）从按 UserID 聚合改为按当前 API Key ID 过滤
- 解决同一用户有多个 API Key（如余额类型 + 订阅类型）时，用量数据混在一起无法区分的问题
- 余额/remaining 字段不受影响，仍然是用户级别的钱包余额

## Changes
- **Repository**: 新增 `GetAPIKeyDashboardStats` 和 `getPerformanceStatsByAPIKey`，SQL WHERE 条件使用 `api_key_id`
- **Service**: 新增 `GetAPIKeyDashboardStats` 方法
- **Handler**: `Usage()` 调用从 `GetUserDashboardStats(userID)` 改为 `GetAPIKeyDashboardStats(apiKey.ID)`
- **Bonus**: TPM 计算修复为包含 `cache_creation_tokens + cache_read_tokens`

## Test plan
- [ ] 使用余额类型 API Key 调用 `/v1/usage`，验证 usage.total.actual_cost 只包含该 Key 的消费
- [ ] 使用订阅类型 API Key 调用 `/v1/usage`，验证 usage 数据只包含该 Key 的消费
- [ ] 验证 remaining/balance 字段仍返回正确的用户钱包余额
- [ ] 验证 RPM/TPM 指标只统计当前 Key 的请求

🤖 Generated with [Claude Code](https://claude.com/claude-code)