### PR TITLE
fix: 修复了 codex 更新用量窗口异常的 bug

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -1089,8 +1089,9 @@ func (r *accountRepository) UpdateExtra(ctx context.Context, id int64, updates m
 	result, err := client.ExecContext(
 		ctx,
 		"UPDATE accounts SET extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb, updated_at = NOW() WHERE id = $2 AND deleted_at IS NULL",
-		payload, id,
+		string(payload), id,
 	)
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
2026/02/06 00:48:21 [UpdateAccountCodexUsage] Failed to update extra for account 2: ERROR: invalid input syntax for type json (SQLSTATE 22P02)

后端在保存 extra 字段时，直接将 JSON 字节 ([]byte) 传给了 SQL 执行器。这导致数据库驱动将其视为二进制数据 (bytea)，而 SQL 语句尝试将其转为 jsonb ($1::jsonb)，从而引发了 invalid input syntax for type json 错误。目前已经修改了 account_repo.go，将参数显式转换为字符串 (string(payload)) 再传递，这样就可以正确地被数据库解析为 JSON 了。
