### PR TITLE
fix: add claude-opus-4-6-thinking to antigravity supported models

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -304,6 +304,7 @@ func logPrefix(sessionID, accountName string) string {
 // Antigravity 直接支持的模型（精确匹配透传）
 // 注意：gemini-2.5 系列已移除，统一映射到 gemini-3 系列
 var antigravitySupportedModels = map[string]bool{
+	"claude-opus-4-6-thinking":   true,
 	"claude-opus-4-5-thinking":   true,
 	"claude-sonnet-4-5":          true,
 	"claude-sonnet-4-5-thinking": true,
@@ -336,6 +337,7 @@ var antigravityPrefixMapping = []struct {
 	{"claude-3-5-sonnet", "claude-sonnet-4-5"}, // 旧版 claude-3-5-sonnet-xxx
 	{"claude-sonnet-4-5", "claude-sonnet-4-5"}, // claude-sonnet-4-5-xxx
 	{"claude-haiku-4-5", "claude-sonnet-4-5"},  // claude-haiku-4-5-xxx → sonnet
+	{"claude-opus-4-6", "claude-opus-4-6-thinking"}, // claude-opus-4-6 → opus-4-6-thinking
 	{"claude-opus-4-5", "claude-opus-4-5-thinking"},
 	{"claude-3-haiku", "claude-sonnet-4-5"}, // 旧版 claude-3-haiku-xxx → sonnet
 	{"claude-sonnet-4", "claude-sonnet-4-5"},


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-6-thinking` to `antigravitySupportedModels` direct passthrough list
- Add `claude-opus-4-6` prefix mapping rule → `claude-opus-4-6-thinking`

## Problem
`claude-opus-4-6` was incorrectly mapped to `claude-opus-4-5-thinking` because it matched the `claude-opus-4` prefix rule in `antigravityPrefixMapping`. This caused all Opus 4.6 requests to actually use Opus 4.5 on the upstream.

## Fix
Only 2 lines added, no existing mappings changed:
1. `antigravitySupportedModels`: added `claude-opus-4-6-thinking` for direct passthrough
2. `antigravityPrefixMapping`: added `claude-opus-4-6` → `claude-opus-4-6-thinking` (placed before `claude-opus-4-5` to ensure longest-prefix-first matching)