### PR TITLE
chore: add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# 确保所有 SQL 迁移文件使用 LF 换行符
+backend/migrations/*.sql text eol=lf
+
+# Go 源代码文件
+*.go text eol=lf
+
+# Shell 脚本
+*.sh text eol=lf
+
+# YAML/YML 配置文件
+*.yaml text eol=lf
+*.yml text eol=lf
+
+# Dockerfile
+Dockerfile text eol=lf


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` to enforce LF line endings for SQL migrations, Go source, shell scripts, YAML configs, and Dockerfiles
- Fixes migration checksum mismatches on Windows where CRLF line endings cause SQL file hash differences

## Test plan
- [ ] Verify `git check-attr eol -- backend/migrations/*.sql` shows `eol: lf`
- [ ] Clone on Windows and confirm migration files use LF