### PR TITLE
fix(antigravity): reduce 429 fallback cooldown from 5min to 30s

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -2048,11 +2048,12 @@ func (s *AntigravityGatewayService) handleUpstreamError(ctx context.Context, pre
 		resetAt := ParseGeminiRateLimitResetTime(body)
 		if resetAt == nil {
 			// 解析失败：使用配置的 fallback 时间，直接限流整个账户
-			fallbackMinutes := 5
+			// 默认 30 秒，可通过配置覆盖（配置单位为分钟）
+			fallbackSeconds := 30
 			if s.settingService != nil && s.settingService.cfg != nil && s.settingService.cfg.Gateway.AntigravityFallbackCooldownMinutes > 0 {
-				fallbackMinutes = s.settingService.cfg.Gateway.AntigravityFallbackCooldownMinutes
+				fallbackSeconds = s.settingService.cfg.Gateway.AntigravityFallbackCooldownMinutes * 60
 			}
-			defaultDur := time.Duration(fallbackMinutes) * time.Minute
+			defaultDur := time.Duration(fallbackSeconds) * time.Second
 			if fallbackDur, ok := antigravityFallbackCooldownSeconds(); ok {
 				defaultDur = fallbackDur
 			}


### PR DESCRIPTION
## Summary
- Reduces the default 429 fallback cooldown from 5 minutes to 30 seconds
- When the rate limit reset time cannot be parsed from the response body, accounts were locked out for 5 minutes which is too aggressive
- Config override (`AntigravityFallbackCooldownMinutes`) still works, converted to seconds internally

## Test plan
- [ ] Trigger a 429 with unparseable reset time → account should recover after ~30s instead of 5min
- [ ] Set `AntigravityFallbackCooldownMinutes=2` in config → should cooldown for 120s