### PR TITLE
feat(frontend): show seconds in rate limit time display

### DIFF
--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -204,7 +204,7 @@ export function formatReasoningEffort(effort: string | null | undefined): string
 }
 
 /**
- * 格式化时间（只显示时分）
+ * 格式化时间（显示时分秒）
  * @param date 日期字符串或 Date 对象
  * @returns 格式化后的时间字符串
  */
@@ -212,6 +212,7 @@ export function formatTime(date: string | Date | null | undefined): string {
   return formatDate(date, {
     hour: '2-digit',
     minute: '2-digit',
+    second: '2-digit',
     hour12: false
   })
 }


### PR DESCRIPTION
## Summary
- Changes `formatTime()` to display `HH:MM:SS` instead of `HH:MM`
- Gives users more precise visibility into when rate limits will reset (especially useful for short cooldowns under 1 minute)

## Test plan
- [ ] Check account rate limit display shows seconds (e.g., `14:30:25` instead of `14:30`)