### PR TITLE
fix: pass platform prop to GroupBadge in GroupSelector

### DIFF
--- a/frontend/src/components/common/GroupSelector.vue
+++ b/frontend/src/components/common/GroupSelector.vue
@@ -22,6 +22,7 @@
         />
         <GroupBadge
           :name="group.name"
+          :platform="group.platform"
           :subscription-type="group.subscription_type"
           :rate-multiplier="group.rate_multiplier"
           class="min-w-0 flex-1"


### PR DESCRIPTION
## Summary
- `GroupBadge` in `GroupSelector.vue` was missing the `:platform` prop, causing all group badges in account edit/detail dialogs to use fallback colors (subscription=purple, balance=green) instead of platform-specific colors (Claude=orange, Gemini=blue, OpenAI=green)
- This is especially noticeable for Antigravity accounts where claude and gemini groups are mixed — without platform colors they are hard to distinguish

## Changes
- Added `:platform="group.platform"` to the `GroupBadge` component in `GroupSelector.vue`
- No other changes needed — `GroupBadge` already has the full platform color logic, and the group objects already contain the `platform` field

## Test plan
- [ ] Open account edit dialog, verify group badges show platform-specific colors
- [ ] Check Antigravity account with mixed groups (claude + gemini) — badges should have different colors
- [ ] Verify subscription groups have deeper color than balance groups