### PR TITLE
fix: support clearing model-level rate limits from action menu and temp-unsched reset

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -623,6 +623,10 @@ func (s *RateLimitService) ClearTempUnschedulable(ctx context.Context, accountID
 			slog.Warn("temp_unsched_cache_delete_failed", "account_id", accountID, "error", err)
 		}
 	}
+	// 同时清除模型级别限流
+	if err := s.accountRepo.ClearModelRateLimits(ctx, accountID); err != nil {
+		slog.Warn("clear_model_rate_limits_on_temp_unsched_reset_failed", "account_id", accountID, "error", err)
+	}
 	return nil
 }
 

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -53,7 +53,19 @@ import type { Account } from '@/types'
 const props = defineProps<{ show: boolean; account: Account | null; position: { top: number; left: number } | null }>()
 const emit = defineEmits(['close', 'test', 'stats', 'reauth', 'refresh-token', 'reset-status', 'clear-rate-limit'])
 const { t } = useI18n()
-const isRateLimited = computed(() => props.account?.rate_limit_reset_at && new Date(props.account.rate_limit_reset_at) > new Date())
+const isRateLimited = computed(() => {
+  if (props.account?.rate_limit_reset_at && new Date(props.account.rate_limit_reset_at) > new Date()) {
+    return true
+  }
+  const modelLimits = (props.account?.extra as Record<string, unknown> | undefined)?.model_rate_limits as
+    | Record<string, { rate_limit_reset_at: string }>
+    | undefined
+  if (modelLimits) {
+    const now = new Date()
+    return Object.values(modelLimits).some(info => new Date(info.rate_limit_reset_at) > now)
+  }
+  return false
+})
 const isOverloaded = computed(() => props.account?.overload_until && new Date(props.account.overload_until) > new Date())
 
 const handleKeydown = (event: KeyboardEvent) => {


### PR DESCRIPTION
## Summary

- **Frontend**: `AccountActionMenu.vue` now checks `extra.model_rate_limits` in addition to `rate_limit_reset_at` when determining whether to show the "Clear Rate Limit" button. Previously, accounts with only model-level rate limits (purple badge) but no account-level rate limit had no way to manually clear the limit.
- **Backend**: `ClearTempUnschedulable` in `ratelimit_service.go` now also clears model-level rate limits when resetting temporary unschedulable status, preventing stale model rate limit records from persisting after the account is restored to schedulable.

## Test plan

- [x] Unit tests pass: `go test -tags unit ./internal/service/... -run RateLimit`
- [x] Verified on beta: Antigravity account with only model-level rate limit shows "Clear Rate Limit" button in action menu
- [x] Verified on beta: Resetting temp-unschedulable status also clears model rate limits