### PR TITLE
feat(antigravity): 添加 onboardUser 支持，修复 project_id 缺失问题

### DIFF
--- a/backend/internal/pkg/antigravity/client_test.go
+++ b/backend/internal/pkg/antigravity/client_test.go
@@ -1,0 +1,76 @@
+package antigravity
+
+import (
+	"testing"
+)
+
+func TestExtractProjectIDFromOnboardResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		resp map[string]any
+		want string
+	}{
+		{
+			name: "nil response",
+			resp: nil,
+			want: "",
+		},
+		{
+			name: "empty response",
+			resp: map[string]any{},
+			want: "",
+		},
+		{
+			name: "project as string",
+			resp: map[string]any{
+				"cloudaicompanionProject": "my-project-123",
+			},
+			want: "my-project-123",
+		},
+		{
+			name: "project as string with spaces",
+			resp: map[string]any{
+				"cloudaicompanionProject": "  my-project-123  ",
+			},
+			want: "my-project-123",
+		},
+		{
+			name: "project as map with id",
+			resp: map[string]any{
+				"cloudaicompanionProject": map[string]any{
+					"id": "proj-from-map",
+				},
+			},
+			want: "proj-from-map",
+		},
+		{
+			name: "project as map without id",
+			resp: map[string]any{
+				"cloudaicompanionProject": map[string]any{
+					"name": "some-name",
+				},
+			},
+			want: "",
+		},
+		{
+			name: "missing cloudaicompanionProject key",
+			resp: map[string]any{
+				"otherField": "value",
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractProjectIDFromOnboardResponse(tc.resp)
+			if got != tc.want {
+				t.Fatalf("extractProjectIDFromOnboardResponse() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/antigravity_oauth_service.go
+++ b/backend/internal/service/antigravity_oauth_service.go
@@ -273,10 +273,19 @@ func (s *AntigravityOAuthService) loadProjectIDWithRetry(ctx context.Context, ac
 		}
 
 		client := antigravity.NewClient(proxyURL)
-		loadResp, _, err := client.LoadCodeAssist(ctx, accessToken)
+		loadResp, loadRaw, err := client.LoadCodeAssist(ctx, accessToken)
 
 		if err == nil && loadResp != nil && loadResp.CloudAICompanionProject != "" {
 			return loadResp.CloudAICompanionProject, nil
+		}
+
+		if err == nil {
+			if projectID, onboardErr := tryOnboardProjectID(ctx, client, accessToken, loadRaw); onboardErr == nil && projectID != "" {
+				return projectID, nil
+			} else if onboardErr != nil {
+				lastErr = onboardErr
+				continue
+			}
 		}
 
 		// 记录错误
@@ -290,6 +299,65 @@ func (s *AntigravityOAuthService) loadProjectIDWithRetry(ctx context.Context, ac
 	}
 
 	return "", fmt.Errorf("获取 project_id 失败 (重试 %d 次后): %w", maxRetries, lastErr)
+}
+
+func tryOnboardProjectID(ctx context.Context, client *antigravity.Client, accessToken string, loadRaw map[string]any) (string, error) {
+	tierID := resolveDefaultTierID(loadRaw)
+	if tierID == "" {
+		return "", fmt.Errorf("loadCodeAssist 未返回可用的默认 tier")
+	}
+
+	projectID, err := client.OnboardUser(ctx, accessToken, tierID)
+	if err != nil {
+		return "", fmt.Errorf("onboardUser 失败 (tier=%s): %w", tierID, err)
+	}
+	return projectID, nil
+}
+
+func resolveDefaultTierID(loadRaw map[string]any) string {
+	if len(loadRaw) == 0 {
+		return ""
+	}
+
+	rawTiers, ok := loadRaw["allowedTiers"]
+	if !ok {
+		return ""
+	}
+
+	tiers, ok := rawTiers.([]any)
+	if !ok {
+		return ""
+	}
+
+	for _, rawTier := range tiers {
+		tier, ok := rawTier.(map[string]any)
+		if !ok {
+			continue
+		}
+		if isDefault, _ := tier["isDefault"].(bool); !isDefault {
+			continue
+		}
+		if id, ok := tier["id"].(string); ok {
+			id = strings.TrimSpace(id)
+			if id != "" {
+				return id
+			}
+		}
+	}
+
+	return ""
+}
+
+// FillProjectID 仅获取 project_id，不刷新 OAuth token
+func (s *AntigravityOAuthService) FillProjectID(ctx context.Context, account *Account, accessToken string) (string, error) {
+	var proxyURL string
+	if account.ProxyID != nil {
+		proxy, err := s.proxyRepo.GetByID(ctx, *account.ProxyID)
+		if err == nil && proxy != nil {
+			proxyURL = proxy.URL()
+		}
+	}
+	return s.loadProjectIDWithRetry(ctx, accessToken, proxyURL, 3)
 }
 
 // BuildAccountCredentials 构建账户凭证

--- a/backend/internal/service/antigravity_oauth_service_test.go
+++ b/backend/internal/service/antigravity_oauth_service_test.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestResolveDefaultTierID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		loadRaw map[string]any
+		want    string
+	}{
+		{
+			name:    "nil loadRaw",
+			loadRaw: nil,
+			want:    "",
+		},
+		{
+			name: "missing allowedTiers",
+			loadRaw: map[string]any{
+				"paidTier": map[string]any{"id": "g1-pro-tier"},
+			},
+			want: "",
+		},
+		{
+			name:    "empty allowedTiers",
+			loadRaw: map[string]any{"allowedTiers": []any{}},
+			want:    "",
+		},
+		{
+			name: "tier missing id field",
+			loadRaw: map[string]any{
+				"allowedTiers": []any{
+					map[string]any{"isDefault": true},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "allowedTiers but no default",
+			loadRaw: map[string]any{
+				"allowedTiers": []any{
+					map[string]any{"id": "free-tier", "isDefault": false},
+					map[string]any{"id": "standard-tier", "isDefault": false},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "default tier found",
+			loadRaw: map[string]any{
+				"allowedTiers": []any{
+					map[string]any{"id": "free-tier", "isDefault": true},
+					map[string]any{"id": "standard-tier", "isDefault": false},
+				},
+			},
+			want: "free-tier",
+		},
+		{
+			name: "default tier id with spaces",
+			loadRaw: map[string]any{
+				"allowedTiers": []any{
+					map[string]any{"id": "  standard-tier  ", "isDefault": true},
+				},
+			},
+			want: "standard-tier",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveDefaultTierID(tc.loadRaw)
+			if got != tc.want {
+				t.Fatalf("resolveDefaultTierID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

部分 Antigravity 账号调用 `loadCodeAssist` 时不会立即返回 `cloudaicompanionProject`，导致后续请求报错 `"Invalid project resource name projects/"`。

本 PR 通过新增 `onboardUser` API 支持，在 `loadCodeAssist` 未返回 project_id 时自动触发账号 onboarding 完成初始化。

### 主要改动

- **新增 `OnboardUser` 客户端方法** (`client.go`)：调用 `/v1internal:onboardUser` 接口，支持 URL fallback、轮询等待 `done=true`、context 感知取消
- **`loadProjectIDWithRetry` 增加 onboard 回退** (`antigravity_oauth_service.go`)：`LoadCodeAssist` 未返回 project_id 时，自动从 `allowedTiers` 解析默认 tier 并触发 onboarding
- **新增轻量 `FillProjectID` 方法**：仅获取 project_id，不刷新 OAuth token
- **`GetAccessToken` 补齐逻辑优化** (`antigravity_token_provider.go`)：
  - 用 `FillProjectID` 替代 `RefreshAccountToken`，避免不必要的 token 刷新
  - 增加 5 分钟冷却机制，防止对始终无法获取 project_id 的账号频繁重试
  - 提取 `mergeCredentials` 辅助方法消除重复代码
- **新增单元测试**：覆盖 `extractProjectIDFromOnboardResponse` 和 `resolveDefaultTierID`

## Test plan

- [x] `go build ./...` 编译通过
- [x] `go test ./internal/pkg/antigravity/ ./internal/service/` 全部通过
- [x] `gofmt` / `golangci-lint` 无报错
- [ ] 使用无 project_id 的账号验证 onboarding 流程能自动补齐
- [ ] 验证已有 project_id 的账号不受影响