### PR TITLE
fix: 修复侧边栏 Logo 加载时的闪烁问题

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -9,8 +9,8 @@
     <!-- Logo/Brand -->
     <div class="sidebar-header">
       <!-- Custom Logo or Default Logo -->
-      <div v-if="settingsLoaded" class="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl shadow-glow">
-        <img :src="siteLogo || '/logo.png'" alt="Logo" class="h-full w-full object-contain" />
+      <div class="flex h-9 w-9 items-center justify-center overflow-hidden rounded-xl shadow-glow">
+        <img v-if="settingsLoaded" :src="siteLogo || '/logo.png'" alt="Logo" class="h-full w-full object-contain" />
       </div>
       <transition name="fade">
         <div v-if="!sidebarCollapsed" class="flex flex-col">


### PR DESCRIPTION
## Summary
- 侧边栏 Logo 在公共设置加载完成前就开始渲染，导致页面加载时出现短暂的闪烁效果
- 当自定义 Logo 尚未从 `appStore` 加载时，会先显示默认的 `/logo.png`，然后切换到自定义 Logo，造成视觉闪烁

## Changes
- `AppSidebar.vue`: 添加 `settingsLoaded` 计算属性，在 Logo 容器上添加 `v-if="settingsLoaded"` 条件渲染，确保公共设置加载完成后再显示 Logo，消除加载时的闪烁效果
