### PR TITLE
修复：StatCard 数值溢出问题

### DIFF
--- a/frontend/src/components/common/StatCard.vue
+++ b/frontend/src/components/common/StatCard.vue
@@ -6,7 +6,7 @@
     <div class="min-w-0 flex-1">
       <p class="stat-label truncate">{{ title }}</p>
       <div class="mt-1 flex items-baseline gap-2">
-        <p class="stat-value">{{ formattedValue }}</p>
+        <p class="stat-value" :title="String(formattedValue)">{{ formattedValue }}</p>
         <span v-if="change !== undefined" :class="['stat-trend', trendClass]">
           <Icon
             v-if="changeType !== 'neutral'"

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -243,7 +243,7 @@
   }
 
   .stat-value {
-    @apply text-2xl font-bold text-gray-900 dark:text-white;
+    @apply text-2xl font-bold text-gray-900 dark:text-white truncate;
   }
 
   .stat-label {


### PR DESCRIPTION
- 添加 title 属性，鼠标悬停时显示完整数值
- 添加 truncate 类防止数值溢出
- 优化长数值的显示效果
![20260213-160353](https://github.com/user-attachments/assets/7024fe5f-b245-4ec1-b83d-c1b31cc5623e)
