### PR TITLE
fix(gateway): strip context-management beta when thinking is not enabled

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3569,6 +3569,13 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 		}
 	}
 
+	// Strip context-management beta when thinking is not enabled.
+	// The context-management-2025-06-27 beta activates the clear_thinking_20251015
+	// strategy server-side, which requires thinking to be enabled or adaptive.
+	// When a client (e.g. Claude Code) sends this beta but the request doesn't
+	// have thinking enabled, the API returns a 400 error. Strip it proactively.
+	stripContextManagementBetaIfNeeded(req, body)
+
 	// Always capture a compact fingerprint line for later error diagnostics.
 	// We only print it when needed (or when the explicit debug flag is enabled).
 	if c != nil && tokenType == "oauth" {
@@ -3710,6 +3717,43 @@ func mergeAnthropicBetaDropping(required []string, incoming string, drop map[str
 		out = append(out, p)
 	}
 	return strings.Join(out, ",")
+}
+
+// stripContextManagementBetaIfNeeded removes context-management-* betas from
+// the anthropic-beta header when thinking is not enabled in the request body.
+// The context-management-2025-06-27 beta activates the clear_thinking_20251015
+// strategy on the Anthropic API, which requires thinking.type to be "enabled"
+// or "adaptive". Without this, the API returns a 400 error.
+// See: https://github.com/anthropics/claude-code/issues/11690
+func stripContextManagementBetaIfNeeded(req *http.Request, body []byte) {
+	if req == nil {
+		return
+	}
+	betaHeader := req.Header.Get("anthropic-beta")
+	if betaHeader == "" || !strings.Contains(betaHeader, "context-management") {
+		return
+	}
+
+	// Check if thinking is enabled in the request body
+	thinkingType := gjson.GetBytes(body, "thinking.type").String()
+	if strings.EqualFold(thinkingType, "enabled") || strings.EqualFold(thinkingType, "adaptive") {
+		return // thinking is enabled, context-management beta is safe
+	}
+
+	// Strip all context-management-* betas
+	var filtered []string
+	for _, part := range strings.Split(betaHeader, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" || strings.HasPrefix(part, "context-management") {
+			continue
+		}
+		filtered = append(filtered, part)
+	}
+	if len(filtered) == 0 {
+		req.Header.Del("anthropic-beta")
+	} else {
+		req.Header.Set("anthropic-beta", strings.Join(filtered, ","))
+	}
 }
 
 // applyClaudeCodeMimicHeaders forces "Claude Code-like" request headers.
@@ -5158,6 +5202,9 @@ func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Con
 			}
 		}
 	}
+
+	// Strip context-management beta when thinking is not enabled (same as messages path).
+	stripContextManagementBetaIfNeeded(req, body)
 
 	if c != nil && tokenType == "oauth" {
 		c.Set(claudeMimicDebugInfoKey, buildClaudeMimicDebugLine(req, body, account, tokenType, mimicClaudeCode))


### PR DESCRIPTION
## Summary

- Strip `context-management-*` betas from the `anthropic-beta` header when `thinking` is not enabled in the request body
- Applied to both the messages (`buildUpstreamRequest`) and count_tokens (`buildCountTokensRequest`) paths

## Problem

The `context-management-2025-06-27` beta header activates the `clear_thinking_20251015` strategy on the Anthropic API server-side. This strategy **requires** `thinking.type` to be `"enabled"` or `"adaptive"` in the request body.

When a client (e.g. Claude Code CLI) sends this beta in its `anthropic-beta` header but the request doesn't have thinking enabled (thinking disabled, absent, or using a model like Haiku), the API returns a 400 error:

```
'clear_thinking_20251015' strategy requires 'thinking' to be enabled or adaptive
```

The gateway transparently passes through the client's `anthropic-beta` header (via the allowlist), so this beta reaches the upstream API even when thinking isn't active in the request.

## Fix

Added `stripContextManagementBetaIfNeeded()` which:
1. Checks if `context-management` is present in the `anthropic-beta` header
2. Checks if `thinking.type` is `"enabled"` or `"adaptive"` in the request body
3. If thinking is NOT enabled, strips all `context-management-*` betas from the header

This prevents the Anthropic API from activating the `clear_thinking_20251015` strategy when thinking isn't configured.

## References

- https://github.com/anthropics/claude-code/issues/11690
- https://github.com/anthropics/claude-code/issues/21595
- https://github.com/anthropics/claude-code/issues/11533

## Test plan

- [ ] Verify requests with thinking enabled + context-management beta pass through unchanged
- [ ] Verify requests without thinking + context-management beta have the beta stripped
- [ ] Verify requests without context-management beta are unaffected
- [ ] Verify count_tokens path also strips the beta correctly