### PR TITLE
fix: strip unsupported parameters from Codex model requests

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -112,13 +112,19 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool) codexTran
 		result.Modified = true
 	}
 
-	if _, ok := reqBody["max_output_tokens"]; ok {
-		delete(reqBody, "max_output_tokens")
-		result.Modified = true
-	}
-	if _, ok := reqBody["max_completion_tokens"]; ok {
-		delete(reqBody, "max_completion_tokens")
-		result.Modified = true
+	// Strip parameters unsupported by codex models via the Responses API.
+	for _, key := range []string{
+		"max_output_tokens",
+		"max_completion_tokens",
+		"temperature",
+		"top_p",
+		"frequency_penalty",
+		"presence_penalty",
+	} {
+		if _, ok := reqBody[key]; ok {
+			delete(reqBody, key)
+			result.Modified = true
+		}
 	}
 
 	if normalizeCodexTools(reqBody) {


### PR DESCRIPTION
Codex models (e.g. `gpt-5.3-codex`) reject `temperature`, `top_p`, `frequency_penalty`, and `presence_penalty` when sent via the Responses API, causing 502 errors when these parameters are passed through.

This extends the existing parameter stripping in `applyCodexOAuthTransform` to also remove these unsupported parameters.