### PR TITLE
feat: add gemini-3.1-pro-preview to model lists

### DIFF
--- a/backend/internal/pkg/gemini/models.go
+++ b/backend/internal/pkg/gemini/models.go
@@ -21,6 +21,7 @@ func DefaultModels() []Model {
 		{Name: "models/gemini-2.5-pro", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-3-flash-preview", SupportedGenerationMethods: methods},
 		{Name: "models/gemini-3-pro-preview", SupportedGenerationMethods: methods},
+		{Name: "models/gemini-3.1-pro-preview", SupportedGenerationMethods: methods},
 	}
 }
 

--- a/backend/internal/pkg/geminicli/models.go
+++ b/backend/internal/pkg/geminicli/models.go
@@ -16,6 +16,7 @@ var DefaultModels = []Model{
 	{ID: "gemini-2.5-pro", Type: "model", DisplayName: "Gemini 2.5 Pro", CreatedAt: ""},
 	{ID: "gemini-3-flash-preview", Type: "model", DisplayName: "Gemini 3 Flash Preview", CreatedAt: ""},
 	{ID: "gemini-3-pro-preview", Type: "model", DisplayName: "Gemini 3 Pro Preview", CreatedAt: ""},
+	{ID: "gemini-3.1-pro-preview", Type: "model", DisplayName: "Gemini 3.1 Pro Preview", CreatedAt: ""},
 }
 
 // DefaultTestModel is the default model to preselect in test flows.


### PR DESCRIPTION
## Summary
- Add the newly released Gemini 3.1 Pro model (`gemini-3.1-pro-preview`) to the native API fallback model list and the admin UI test model dropdown

## Changes
- `backend/internal/pkg/gemini/models.go` — added `models/gemini-3.1-pro-preview` to `DefaultModels()`
- `backend/internal/pkg/geminicli/models.go` — added `gemini-3.1-pro-preview` to `DefaultModels` (admin UI test flow)

## Context
Google released Gemini 3.1 Pro on Feb 19, 2026. The API model ID is `gemini-3.1-pro-preview`, available via Google AI Studio and Vertex AI.