### PR TITLE
feat: Antigravity 将 gemini-3-pro 路由升级到 gemini-3.1-pro

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -88,12 +88,15 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"gemini-2.5-pro":            "gemini-2.5-pro",
 	// Gemini 3 白名单
 	"gemini-3-flash":     "gemini-3-flash",
-	"gemini-3-pro-high":  "gemini-3-pro-high",
-	"gemini-3-pro-low":   "gemini-3-pro-low",
+	"gemini-3-pro-high":  "gemini-3.1-pro-high",
+	"gemini-3-pro-low":   "gemini-3.1-pro-low",
 	"gemini-3-pro-image": "gemini-3-pro-image",
+	// Gemini 3.1 透传
+	"gemini-3.1-pro-high": "gemini-3.1-pro-high",
+	"gemini-3.1-pro-low":  "gemini-3.1-pro-low",
 	// Gemini 3 preview 映射
 	"gemini-3-flash-preview":     "gemini-3-flash",
-	"gemini-3-pro-preview":       "gemini-3-pro-high",
+	"gemini-3-pro-preview":       "gemini-3.1-pro-high",
 	"gemini-3-pro-image-preview": "gemini-3-pro-image",
 	// 其他官方模型
 	"gpt-oss-120b-medium":    "gpt-oss-120b-medium",

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -267,8 +267,12 @@ const antigravityPresetMappings = [
   { label: 'Sonnet→Sonnet', from: 'claude-sonnet-*', to: 'claude-sonnet-4-5', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: 'Opus→Opus', from: 'claude-opus-*', to: 'claude-opus-4-6-thinking', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Haiku→Sonnet', from: 'claude-haiku-*', to: 'claude-sonnet-4-5', color: 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400' },
+  // Gemini 3→3.1 映射
+  { label: '3-Pro-Preview→3.1-Pro-High', from: 'gemini-3-pro-preview', to: 'gemini-3.1-pro-high', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' },
+  { label: '3-Pro-High→3.1-Pro-High', from: 'gemini-3-pro-high', to: 'gemini-3.1-pro-high', color: 'bg-orange-100 text-orange-700 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400' },
+  { label: '3-Pro-Low→3.1-Pro-Low', from: 'gemini-3-pro-low', to: 'gemini-3.1-pro-low', color: 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400' },
   // Gemini 通配符映射
-  { label: 'Gemini 3→Flash', from: 'gemini-3*', to: 'gemini-3-flash', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' },
+  { label: 'Gemini 3→Flash', from: 'gemini-3*', to: 'gemini-3-flash', color: 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400' },
   { label: 'Gemini 2.5→Flash', from: 'gemini-2.5*', to: 'gemini-2.5-flash', color: 'bg-orange-100 text-orange-700 hover:bg-orange-200 dark:bg-orange-900/30 dark:text-orange-400' },
   // 精确映射
   { label: 'Sonnet 4.5', from: 'claude-sonnet-4-5', to: 'claude-sonnet-4-5', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },


### PR DESCRIPTION
## 变更说明
- 在 Antigravity 默认模型映射中，将 `gemini-3-pro-preview/high/low` 升级路由到 `gemini-3.1-pro-high/low`，覆盖已不再受支持的 Gemini 3 Pro 系列。
- 增加 `gemini-3.1-pro-high` 与 `gemini-3.1-pro-low` 的默认透传映射，确保直接使用 3.1 模型时行为稳定。
- 前端新增 Gemini 3→3.1 的快捷路由按钮，便于在界面中一键应用升级路由规则。

## 背景与目的
由于 Antigravity 已不再支持 Gemini 3 Pro 系列，本 PR 提供默认升级路径到 Gemini 3.1 Pro，同时保留 Gemini 3.1 的透传能力，并在前端提供可视化路由入口，降低用户手动配置成本。