### PR TITLE
fix: 默认补全 Antigravity 的 Gemini 3.1 Pro 透传映射

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -373,7 +373,11 @@ func (a *Account) GetModelMapping() map[string]string {
 		}
 		if len(result) > 0 {
 			if a.Platform == domain.PlatformAntigravity {
-				ensureAntigravityDefaultPassthrough(result, "gemini-3-flash")
+				ensureAntigravityDefaultPassthroughs(result, []string{
+					"gemini-3-flash",
+					"gemini-3.1-pro-high",
+					"gemini-3.1-pro-low",
+				})
 			}
 			return result
 		}
@@ -398,6 +402,12 @@ func ensureAntigravityDefaultPassthrough(mapping map[string]string, model string
 		}
 	}
 	mapping[model] = model
+}
+
+func ensureAntigravityDefaultPassthroughs(mapping map[string]string, models []string) {
+	for _, model := range models {
+		ensureAntigravityDefaultPassthrough(mapping, model)
+	}
 }
 
 // IsModelSupported 检查模型是否在 model_mapping 中（支持通配符）

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -268,7 +268,7 @@ func TestAccountGetMappedModel(t *testing.T) {
 	}
 }
 
-func TestAccountGetModelMapping_AntigravityEnsuresGemini3FlashPassthrough(t *testing.T) {
+func TestAccountGetModelMapping_AntigravityEnsuresGeminiDefaultPassthroughs(t *testing.T) {
 	account := &Account{
 		Platform: PlatformAntigravity,
 		Credentials: map[string]any{
@@ -281,6 +281,12 @@ func TestAccountGetModelMapping_AntigravityEnsuresGemini3FlashPassthrough(t *tes
 	mapping := account.GetModelMapping()
 	if mapping["gemini-3-flash"] != "gemini-3-flash" {
 		t.Fatalf("expected gemini-3-flash passthrough to be auto-filled, got: %q", mapping["gemini-3-flash"])
+	}
+	if mapping["gemini-3.1-pro-high"] != "gemini-3.1-pro-high" {
+		t.Fatalf("expected gemini-3.1-pro-high passthrough to be auto-filled, got: %q", mapping["gemini-3.1-pro-high"])
+	}
+	if mapping["gemini-3.1-pro-low"] != "gemini-3.1-pro-low" {
+		t.Fatalf("expected gemini-3.1-pro-low passthrough to be auto-filled, got: %q", mapping["gemini-3.1-pro-low"])
 	}
 }
 
@@ -297,6 +303,12 @@ func TestAccountGetModelMapping_AntigravityRespectsWildcardOverride(t *testing.T
 	mapping := account.GetModelMapping()
 	if _, exists := mapping["gemini-3-flash"]; exists {
 		t.Fatalf("did not expect explicit gemini-3-flash passthrough when wildcard already exists")
+	}
+	if _, exists := mapping["gemini-3.1-pro-high"]; exists {
+		t.Fatalf("did not expect explicit gemini-3.1-pro-high passthrough when wildcard already exists")
+	}
+	if _, exists := mapping["gemini-3.1-pro-low"]; exists {
+		t.Fatalf("did not expect explicit gemini-3.1-pro-low passthrough when wildcard already exists")
 	}
 	if mapped := account.GetMappedModel("gemini-3-flash"); mapped != "gemini-3.1-pro-high" {
 		t.Fatalf("expected wildcard mapping to stay effective, got: %q", mapped)


### PR DESCRIPTION
## 变更说明
- 在 Antigravity 自定义 `model_mapping` 存在时，默认补全以下透传映射（仅在未被显式映射或通配符覆盖时补全）：
  - `gemini-3-flash -> gemini-3-flash`
  - `gemini-3.1-pro-high -> gemini-3.1-pro-high`
  - `gemini-3.1-pro-low -> gemini-3.1-pro-low`
- 保持现有通配符优先级：若已有 `gemini-3*` 等通配符规则，则不强行写入显式透传。
- 补充并更新对应单元测试。

## 目的
- 避免批量/手动映射后遗漏关键 Gemini 模型，导致模型白名单或路由异常。
- 在“默认可用”与“自定义可控”之间保持兼容：不破坏已有通配符策略。

## 影响范围
- `backend/internal/service/account.go`
- `backend/internal/service/account_wildcard_test.go`

## 验证
- 已执行：`go test ./internal/service`（通过）
- 已执行：`go test -tags unit ./internal/service`（通过）