### PR TITLE
refactor(admin): 消除测试连接 Gemini 模型硬编码，统一由 DefaultModels 提供

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -1459,36 +1460,8 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 
 	// Handle Antigravity accounts: return Claude + Gemini models
 	if account.Platform == service.PlatformAntigravity {
-		// Antigravity 支持 Claude 和部分 Gemini 模型
-		type UnifiedModel struct {
-			ID          string `json:"id"`
-			Type        string `json:"type"`
-			DisplayName string `json:"display_name"`
-		}
-
-		var models []UnifiedModel
-
-		// 添加 Claude 模型
-		for _, m := range claude.DefaultModels {
-			models = append(models, UnifiedModel{
-				ID:          m.ID,
-				Type:        m.Type,
-				DisplayName: m.DisplayName,
-			})
-		}
-
-		// 添加 Gemini 3 系列模型用于测试
-		geminiTestModels := []UnifiedModel{
-			{ID: "gemini-3-flash", Type: "model", DisplayName: "Gemini 3 Flash"},
-			{ID: "gemini-3-pro-low", Type: "model", DisplayName: "Gemini 3 Pro Low"},
-			{ID: "gemini-3-pro-high", Type: "model", DisplayName: "Gemini 3 Pro High"},
-			{ID: "gemini-3.1-pro-low", Type: "model", DisplayName: "Gemini 3.1 Pro Low"},
-			{ID: "gemini-3.1-pro-high", Type: "model", DisplayName: "Gemini 3.1 Pro High"},
-			{ID: "gemini-3-pro-preview", Type: "model", DisplayName: "Gemini 3 Pro Preview"},
-		}
-		models = append(models, geminiTestModels...)
-
-		response.Success(c, models)
+		// 直接复用 antigravity.DefaultModels()，与 /v1/models 端点保持同步
+		response.Success(c, antigravity.DefaultModels())
 		return
 	}
 


### PR DESCRIPTION
## 问题

`GetAvailableModels` 接口在处理 Antigravity 账号时，Gemini 模型列表是硬编码在 handler 里的（`geminiTestModels`），与 `claude_types.go` 中的 `geminiModels` 完全独立维护。

每次新增 Gemini 模型都需要同时修改两个地方，容易遗漏、产生不一致。

## 解决方案

直接调用已有的 `antigravity.DefaultModels()`，该函数已经合并了 `claudeModels` 和 `geminiModels` 并以统一格式返回，也是 `/v1/models` 端点的数据来源。

测试连接弹窗与 `/v1/models` 端点现在共用**同一个唯一来源**，后续新增模型只需修改 `claude_types.go` 一处即可。

## 变更

- `account_handler.go`：删除硬编码的 `UnifiedModel` 结构体和 `geminiTestModels` 列表（约 26 行），替换为一行 `antigravity.DefaultModels()` 调用