### PR TITLE
移除 PostgreSQL 容器多余重复的 PGDATA 环境变量

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -173,7 +173,6 @@ services:
       - POSTGRES_USER=${POSTGRES_USER:-sub2api}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       - POSTGRES_DB=${POSTGRES_DB:-sub2api}
-      - PGDATA=/var/lib/postgresql/data
       - TZ=${TZ:-Asia/Shanghai}
     networks:
       - sub2api-network


### PR DESCRIPTION
移除 docker-compose.yml 文件中PostgreSQL容器环境变量中重复的PGDATA，只保留一个PGDATA环境变量