### PR TITLE
feat(i18n): 切换语言时同步更新页面标题

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -68,6 +68,14 @@ export async function setLocale(locale: string): Promise<void> {
   i18n.global.locale.value = locale
   localStorage.setItem(LOCALE_KEY, locale)
   document.documentElement.setAttribute('lang', locale)
+
+  // 同步更新浏览器页签标题，使其跟随语言切换
+  const { resolveDocumentTitle } = await import('@/router/title')
+  const { default: router } = await import('@/router')
+  const { useAppStore } = await import('@/stores/app')
+  const route = router.currentRoute.value
+  const appStore = useAppStore()
+  document.title = resolveDocumentTitle(route.meta.title, appStore.siteName, route.meta.titleKey as string)
 }
 
 export function getLocale(): LocaleCode {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -41,7 +41,8 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/auth/LoginView.vue'),
     meta: {
       requiresAuth: false,
-      title: 'Login'
+      title: 'Login',
+      titleKey: 'common.login'
     }
   },
   {
@@ -50,7 +51,8 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/auth/RegisterView.vue'),
     meta: {
       requiresAuth: false,
-      title: 'Register'
+      title: 'Register',
+      titleKey: 'auth.createAccount'
     }
   },
   {
@@ -86,7 +88,8 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/views/auth/ForgotPasswordView.vue'),
     meta: {
       requiresAuth: false,
-      title: 'Forgot Password'
+      title: 'Forgot Password',
+      titleKey: 'auth.forgotPasswordTitle'
     }
   },
   {
@@ -390,7 +393,7 @@ router.beforeEach((to, _from, next) => {
 
   // Set page title
   const appStore = useAppStore()
-  document.title = resolveDocumentTitle(to.meta.title, appStore.siteName)
+  document.title = resolveDocumentTitle(to.meta.title, appStore.siteName, to.meta.titleKey as string)
 
   // Check if route requires authentication
   const requiresAuth = to.meta.requiresAuth !== false // Default to true

--- a/frontend/src/router/title.ts
+++ b/frontend/src/router/title.ts
@@ -1,8 +1,18 @@
+import { i18n } from '@/i18n'
+
 /**
  * 统一生成页面标题，避免多处写入 document.title 产生覆盖冲突。
+ * 优先使用 titleKey 通过 i18n 翻译，fallback 到静态 routeTitle。
  */
-export function resolveDocumentTitle(routeTitle: unknown, siteName?: string): string {
+export function resolveDocumentTitle(routeTitle: unknown, siteName?: string, titleKey?: string): string {
   const normalizedSiteName = typeof siteName === 'string' && siteName.trim() ? siteName.trim() : 'Sub2API'
+
+  if (typeof titleKey === 'string' && titleKey.trim()) {
+    const translated = i18n.global.t(titleKey)
+    if (translated && translated !== titleKey) {
+      return `${translated} - ${normalizedSiteName}`
+    }
+  }
 
   if (typeof routeTitle === 'string' && routeTitle.trim()) {
     return `${routeTitle.trim()} - ${normalizedSiteName}`


### PR DESCRIPTION
## 问题

切换语言后，浏览器页签标题不会跟随更新，仍显示旧语言的标题文本。

## 解决方案

### 1. `router/title.ts` — 新增 `titleKey` 参数

`resolveDocumentTitle()` 新增可选参数 `titleKey`，优先通过 i18n 翻译生成标题，翻译失败时回退到静态 `routeTitle`。

### 2. `router/index.ts` — 传入路由 meta.titleKey

`beforeEach` 守卫调用 `resolveDocumentTitle` 时，将路由 `meta.titleKey` 一并传入，使导航时的标题即可国际化。

### 3. `i18n/index.ts` — setLocale 后同步刷新标题

`setLocale()` 完成语言切换后，读取当前路由的 `meta.titleKey` 并重新调用 `resolveDocumentTitle`，更新 `document.title`，确保页签标题与 UI 语言保持一致。

## 测试

1. 登录后进入任意页面（如「API Keys」）
2. 切换语言（英文 ↔ 中文）
3. 观察浏览器页签标题是否同步变更