### PR TITLE
fix: 添加提取站点logo功能以防止favicon闪烁

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,8 +20,20 @@ function injectPublicSettings(backendUrl: string): Plugin {
           if (response.ok) {
             const data = await response.json()
             if (data.code === 0 && data.data) {
+              // Inject config script
               const script = `<script>window.__APP_CONFIG__=${JSON.stringify(data.data)};</script>`
-              return html.replace('</head>', `${script}\n</head>`)
+              let result = html.replace('</head>', `${script}\n</head>`)
+
+              // Replace favicon with custom logo if set (prevents default logo flash)
+              const siteLogo = data.data.site_logo
+              if (siteLogo) {
+                result = result.replace(
+                  '<link rel="icon" type="image/png" href="/logo.png" />',
+                  `<link rel="icon" type="image/x-icon" href="${siteLogo}" />`
+                )
+              }
+
+              return result
             }
           }
         } catch (e) {


### PR DESCRIPTION
## 问题
页面刷新时，浏览器先加载 HTML 中的默认 /logo.png，
等待 Vue 启动后才通过 JS 替换为自定义 logo，导致闪烁。

## 解决方案
- 后端 embed_on.go: injectSettings() 现在接收 siteLogo 参数，
  在注入配置脚本前，先替换 \u003clink rel="icon"\u003e 的 href
- 前端 vite.config.ts: 开发模式插件同样替换 favicon，
  保持开发和生产行为一致

这样浏览器解析 HTML 时直接拿到正确的 favicon URL，
无需等待 JS 执行，完全消除闪烁。