### PR TITLE
fix(gateway): count_tokens 不支持时返回 404 而非伪造的 200

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6223,11 +6223,11 @@ func (s *GatewayService) forwardCountTokensAnthropicAPIKeyPassthrough(ctx contex
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 
-		// 中转站不支持 count_tokens 端点时（404），透传 404 让客户端 fallback 到本地估算。
+		// 中转站不支持 count_tokens 端点时（404），返回 404 让客户端 fallback 到本地估算。
 		// 返回 nil 避免 handler 层记录为错误，也不设置 ops 上游错误上下文。
 		if resp.StatusCode == http.StatusNotFound {
 			logger.LegacyPrintf("service.gateway",
-				"[count_tokens] Upstream does not support count_tokens (404), passing through: account=%d name=%s msg=%s",
+				"[count_tokens] Upstream does not support count_tokens (404), returning 404: account=%d name=%s msg=%s",
 				account.ID, account.Name, truncateString(upstreamMsg, 512))
 			s.countTokensError(c, http.StatusNotFound, "not_found_error", "count_tokens endpoint is not supported by upstream")
 			return nil


### PR DESCRIPTION
## 问题

PR #635 在上游不支持 `count_tokens` 端点（返回 404）时，将响应伪造为 `HTTP 200 + {"input_tokens": 0}`。这导致 Claude Code CLI 信任该零值，认为当前对话消耗 0 个 token，**自动压缩永远不会触发**，上下文窗口最终会静默溢出。

Antigravity 账户也存在同样的问题，同样返回伪造的 `{"input_tokens": 0}`。

## 根因

Claude Code CLI 仅在 `count_tokens` 返回**非 2xx** 响应时才会 fallback 到本地 tokenizer 估算。`200 + {"input_tokens": 0}` 会被视为合法的可信结果。

## 修复方案

- 返回 `404` + 标准 Anthropic 错误体，而非伪造 `200`
- 返回 `nil` error（而非 `fmt.Errorf`），handler 层不会记录为错误日志，也不设置 ops 上游错误上下文——避免平台错误率虚高
- ops 错误记录器中已有的 `IgnoreCountTokensErrors` 配置提供额外兜底

## 改动

- `gateway_service.go`：Passthrough 路径——上游 404 现在透传为 404
- `gateway_service.go`：Antigravity 路径——同样修复
- 更新测试以验证 404 透传行为