### PR TITLE
fix(frontend): add priority hint in edit account modal

### DIFF
--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -664,6 +664,7 @@
             class="input"
             data-tour="account-form-priority"
           />
+          <p class="input-hint">{{ t('admin.accounts.priorityHint') }}</p>
         </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.billingRateMultiplier') }}</label>


### PR DESCRIPTION
## 概述

在编辑账户模态框（EditAccountModal）的优先级（Priority）输入框下方，新增一行提示文案，帮助用户理解该字段的含义与取值规则。

## 改动内容

- `frontend/src/components/account/EditAccountModal.vue`：在优先级输入框后添加 `<p class="input-hint">` 提示段落，使用现有 i18n 键 `admin.accounts.priorityHint`。

## 测试

- 手动打开账户编辑模态框，确认优先级字段下方提示文案正常显示且多语言生效。