### PR TITLE
fix: add 2K image default pricing at 1.5x base price

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -543,7 +543,10 @@ func (s *BillingService) getDefaultImagePrice(model string, imageSize string) fl
 		basePrice = 0.134
 	}
 
-	// 4K 尺寸翻倍
+	// 2K 尺寸 1.5 倍，4K 尺寸翻倍
+	if imageSize == "2K" {
+		return basePrice * 1.5
+	}
 	if imageSize == "4K" {
 		return basePrice * 2
 	}

--- a/backend/internal/service/billing_service_image_test.go
+++ b/backend/internal/service/billing_service_image_test.go
@@ -12,14 +12,14 @@ import (
 func TestCalculateImageCost_DefaultPricing(t *testing.T) {
 	svc := &BillingService{} // pricingService 为 nil，使用硬编码默认值
 
-	// 2K 尺寸，默认价格 $0.134
+	// 2K 尺寸，默认价格 $0.134 * 1.5 = $0.201
 	cost := svc.CalculateImageCost("gemini-3-pro-image", "2K", 1, nil, 1.0)
-	require.InDelta(t, 0.134, cost.TotalCost, 0.0001)
-	require.InDelta(t, 0.134, cost.ActualCost, 0.0001)
+	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.201, cost.ActualCost, 0.0001)
 
 	// 多张图片
 	cost = svc.CalculateImageCost("gemini-3-pro-image", "2K", 3, nil, 1.0)
-	require.InDelta(t, 0.402, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.603, cost.TotalCost, 0.0001)
 }
 
 // TestCalculateImageCost_GroupCustomPricing 测试分组自定义价格
@@ -63,13 +63,13 @@ func TestCalculateImageCost_RateMultiplier(t *testing.T) {
 
 	// 费率倍数 1.5x
 	cost := svc.CalculateImageCost("gemini-3-pro-image", "2K", 1, nil, 1.5)
-	require.InDelta(t, 0.134, cost.TotalCost, 0.0001)  // TotalCost 不变
-	require.InDelta(t, 0.201, cost.ActualCost, 0.0001) // ActualCost = 0.134 * 1.5
+	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)  // TotalCost = 0.134 * 1.5
+	require.InDelta(t, 0.3015, cost.ActualCost, 0.0001) // ActualCost = 0.201 * 1.5
 
 	// 费率倍数 2.0x
 	cost = svc.CalculateImageCost("gemini-3-pro-image", "2K", 2, nil, 2.0)
-	require.InDelta(t, 0.268, cost.TotalCost, 0.0001)
-	require.InDelta(t, 0.536, cost.ActualCost, 0.0001)
+	require.InDelta(t, 0.402, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.804, cost.ActualCost, 0.0001)
 }
 
 // TestCalculateImageCost_ZeroCount 测试 imageCount=0
@@ -95,8 +95,8 @@ func TestCalculateImageCost_ZeroRateMultiplier(t *testing.T) {
 	svc := &BillingService{}
 
 	cost := svc.CalculateImageCost("gemini-3-pro-image", "2K", 1, nil, 0)
-	require.InDelta(t, 0.134, cost.TotalCost, 0.0001)
-	require.InDelta(t, 0.134, cost.ActualCost, 0.0001) // 0 倍率当作 1.0 处理
+	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.201, cost.ActualCost, 0.0001) // 0 倍率当作 1.0 处理
 }
 
 // TestGetImageUnitPrice_GroupPriorityOverDefault 测试分组价格优先于默认价格
@@ -127,9 +127,9 @@ func TestGetImageUnitPrice_PartialGroupConfig(t *testing.T) {
 	cost := svc.CalculateImageCost("gemini-3-pro-image", "1K", 1, groupConfig, 1.0)
 	require.InDelta(t, 0.10, cost.TotalCost, 0.0001)
 
-	// 2K 回退默认价格 $0.134
+	// 2K 回退默认价格 $0.201 (1.5倍)
 	cost = svc.CalculateImageCost("gemini-3-pro-image", "2K", 1, groupConfig, 1.0)
-	require.InDelta(t, 0.134, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)
 
 	// 4K 回退默认价格 $0.268 (翻倍)
 	cost = svc.CalculateImageCost("gemini-3-pro-image", "4K", 1, groupConfig, 1.0)
@@ -140,10 +140,10 @@ func TestGetImageUnitPrice_PartialGroupConfig(t *testing.T) {
 func TestGetDefaultImagePrice_FallbackHardcoded(t *testing.T) {
 	svc := &BillingService{} // pricingService 为 nil
 
-	// 1K 和 2K 使用相同的默认价格 $0.134
+	// 1K 默认价格 $0.134，2K 默认价格 $0.201 (1.5倍)
 	cost := svc.CalculateImageCost("gemini-3-pro-image", "1K", 1, nil, 1.0)
 	require.InDelta(t, 0.134, cost.TotalCost, 0.0001)
 
 	cost = svc.CalculateImageCost("gemini-3-pro-image", "2K", 1, nil, 1.0)
-	require.InDelta(t, 0.134, cost.TotalCost, 0.0001)
+	require.InDelta(t, 0.201, cost.TotalCost, 0.0001)
 }

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -459,7 +459,7 @@
                 step="0.001"
                 min="0"
                 class="input"
-                placeholder="0.134"
+                placeholder="0.201"
               />
             </div>
             <div>
@@ -1139,7 +1139,7 @@
                 step="0.001"
                 min="0"
                 class="input"
-                placeholder="0.134"
+                placeholder="0.201"
               />
             </div>
             <div>


### PR DESCRIPTION
## Summary
- Previously 2K images used the same base price as 1K ($0.134), now 2K uses 1.5x multiplier ($0.201), consistent with 4K using 2x ($0.268)
- Update frontend placeholder values to match new defaults
- Update unit test assertions for new 2K pricing

## Test plan
- [x] Unit tests updated and passing for all image pricing scenarios
- [ ] Verify 2K placeholder shows $0.201 in group create/edit forms