### PR TITLE
fix: 账号移出分组时清理粘性会话，修复关闭账号后仍能使用的问题

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -131,7 +131,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	geminiTokenProvider := service.NewGeminiTokenProvider(accountRepository, geminiTokenCache, geminiOAuthService)
 	gatewayCache := repository.NewGatewayCache(redisClient)
 	schedulerOutboxRepository := repository.NewSchedulerOutboxRepository(db)
-	schedulerSnapshotService := service.ProvideSchedulerSnapshotService(schedulerCache, schedulerOutboxRepository, accountRepository, groupRepository, configConfig)
+	schedulerSnapshotService := service.ProvideSchedulerSnapshotService(schedulerCache, schedulerOutboxRepository, accountRepository, groupRepository, gatewayCache, configConfig)
 	antigravityTokenProvider := service.NewAntigravityTokenProvider(accountRepository, geminiTokenCache, antigravityOAuthService)
 	antigravityGatewayService := service.NewAntigravityGatewayService(accountRepository, gatewayCache, schedulerSnapshotService, antigravityTokenProvider, rateLimitService, httpUpstream, settingService)
 	accountTestService := service.NewAccountTestService(accountRepository, geminiTokenProvider, antigravityGatewayService, httpUpstream, configConfig)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -87,6 +87,7 @@ require (
 	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/subcommands v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.18.1 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -136,6 +136,8 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=

--- a/backend/internal/handler/gateway_handler_warmup_intercept_unit_test.go
+++ b/backend/internal/handler/gateway_handler_warmup_intercept_unit_test.go
@@ -125,7 +125,7 @@ func newTestGatewayHandler(t *testing.T, group *service.Group, accounts []*servi
 	t.Helper()
 
 	schedulerCache := &fakeSchedulerCache{accounts: accounts}
-	schedulerSnapshot := service.NewSchedulerSnapshotService(schedulerCache, nil, nil, nil, nil)
+	schedulerSnapshot := service.NewSchedulerSnapshotService(schedulerCache, nil, nil, nil, nil, nil)
 
 	gwSvc := service.NewGatewayService(
 		nil, // accountRepo (not used: scheduler snapshot hit)

--- a/backend/internal/repository/gateway_cache.go
+++ b/backend/internal/repository/gateway_cache.go
@@ -10,6 +10,7 @@ import (
 )
 
 const stickySessionPrefix = "sticky_session:"
+const stickySessionIndexPrefix = "sticky_session_index:"
 
 type gatewayCache struct {
 	rdb *redis.Client
@@ -25,6 +26,12 @@ func buildSessionKey(groupID int64, sessionHash string) string {
 	return fmt.Sprintf("%s%d:%s", stickySessionPrefix, groupID, sessionHash)
 }
 
+// buildSessionIndexKey 构建反向索引 key，用于从 accountID 查找 sessionHash
+// 格式: sticky_session_index:{groupID}:{accountID}
+func buildSessionIndexKey(groupID int64, accountID int64) string {
+	return fmt.Sprintf("%s%d:%d", stickySessionIndexPrefix, groupID, accountID)
+}
+
 func (c *gatewayCache) GetSessionAccountID(ctx context.Context, groupID int64, sessionHash string) (int64, error) {
 	key := buildSessionKey(groupID, sessionHash)
 	return c.rdb.Get(ctx, key).Int64()
@@ -32,7 +39,14 @@ func (c *gatewayCache) GetSessionAccountID(ctx context.Context, groupID int64, s
 
 func (c *gatewayCache) SetSessionAccountID(ctx context.Context, groupID int64, sessionHash string, accountID int64, ttl time.Duration) error {
 	key := buildSessionKey(groupID, sessionHash)
-	return c.rdb.Set(ctx, key, accountID, ttl).Err()
+	indexKey := buildSessionIndexKey(groupID, accountID)
+
+	pipe := c.rdb.Pipeline()
+	pipe.Set(ctx, key, accountID, ttl)
+	pipe.SAdd(ctx, indexKey, sessionHash)
+	pipe.Expire(ctx, indexKey, ttl)
+	_, err := pipe.Exec(ctx)
+	return err
 }
 
 func (c *gatewayCache) RefreshSessionTTL(ctx context.Context, groupID int64, sessionHash string, ttl time.Duration) error {
@@ -49,5 +63,41 @@ func (c *gatewayCache) RefreshSessionTTL(ctx context.Context, groupID int64, ses
 // or unschedulable), allowing subsequent requests to select a new available account.
 func (c *gatewayCache) DeleteSessionAccountID(ctx context.Context, groupID int64, sessionHash string) error {
 	key := buildSessionKey(groupID, sessionHash)
+	// 注意：这里不清理反向索引，因为不知道对应的 accountID
+	// 反向索引会在 GetSessionAccountID 返回错误时由调用方清理，或在 DeleteStickySessionsByAccount 中批量清理
 	return c.rdb.Del(ctx, key).Err()
+}
+
+// DeleteStickySessionsByAccount 删除指定账号在指定分组中的所有粘性会话。
+// 当账号被移除分组时调用，确保该账号不会继续被 sticky session 使用。
+//
+// DeleteStickySessionsByAccount deletes all sticky sessions for the given account in the given group.
+// Called when account is removed from a group to ensure it won't be used by sticky sessions.
+func (c *gatewayCache) DeleteStickySessionsByAccount(ctx context.Context, groupID int64, accountID int64) error {
+	indexKey := buildSessionIndexKey(groupID, accountID)
+
+	// 获取该账号的所有 sessionHash
+	sessionHashes, err := c.rdb.SMembers(ctx, indexKey).Result()
+	if err != nil {
+		return fmt.Errorf("get session index failed: %w", err)
+	}
+
+	if len(sessionHashes) == 0 {
+		return nil
+	}
+
+	// 批量删除 sticky session
+	pipe := c.rdb.Pipeline()
+	for _, sessionHash := range sessionHashes {
+		sessionKey := buildSessionKey(groupID, sessionHash)
+		pipe.Del(ctx, sessionKey)
+	}
+	// 删除反向索引
+	pipe.Del(ctx, indexKey)
+
+	_, err = pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("delete sticky sessions failed: %w", err)
+	}
+	return nil
 }

--- a/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
+++ b/backend/internal/repository/scheduler_snapshot_outbox_integration_test.go
@@ -48,7 +48,7 @@ func TestSchedulerSnapshotOutboxReplay(t *testing.T) {
 	require.NoError(t, accountRepo.Create(ctx, account))
 	require.NoError(t, cache.SetAccount(ctx, account))
 
-	svc := service.NewSchedulerSnapshotService(cache, outboxRepo, accountRepo, nil, cfg)
+	svc := service.NewSchedulerSnapshotService(cache, outboxRepo, accountRepo, nil, nil, cfg)
 	svc.Start()
 	t.Cleanup(svc.Stop)
 

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -221,6 +221,23 @@ func (m *mockGatewayCacheForPlatform) DeleteSessionAccountID(ctx context.Context
 	return nil
 }
 
+func (m *mockGatewayCacheForPlatform) DeleteStickySessionsByAccount(ctx context.Context, groupID int64, accountID int64) error {
+	if m.sessionBindings == nil {
+		return nil
+	}
+	// 删除所有绑定到该账号的会话
+	for sessionHash, boundAccountID := range m.sessionBindings {
+		if boundAccountID == accountID {
+			delete(m.sessionBindings, sessionHash)
+			if m.deletedSessions == nil {
+				m.deletedSessions = make(map[string]int)
+			}
+			m.deletedSessions[sessionHash]++
+		}
+	}
+	return nil
+}
+
 type mockGroupRepoForGateway struct {
 	groups           map[int64]*Group
 	getByIDCalls     int

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -345,6 +345,9 @@ type GatewayCache interface {
 	// DeleteSessionAccountID 删除粘性会话绑定，用于账号不可用时主动清理
 	// Delete sticky session binding, used to proactively clean up when account becomes unavailable
 	DeleteSessionAccountID(ctx context.Context, groupID int64, sessionHash string) error
+	// DeleteStickySessionsByAccount 删除指定账号在指定分组中的所有粘性会话
+	// Delete all sticky sessions for the given account in the given group
+	DeleteStickySessionsByAccount(ctx context.Context, groupID int64, accountID int64) error
 }
 
 // derefGroupID safely dereferences *int64 to int64, returning 0 if nil
@@ -1403,7 +1406,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 				if clearSticky {
 					_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 				}
-				if !clearSticky && s.isAccountInGroup(account, groupID) &&
+				if !clearSticky && isAccountInGroup(account, groupID) &&
 					s.isAccountAllowedForPlatform(account, platform, useMixed) &&
 					(requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) &&
 					account.IsSchedulableForModelWithContext(ctx, requestedModel) &&
@@ -1857,7 +1860,7 @@ func (s *GatewayService) isAccountAllowedForPlatform(account *Account, platform 
 
 // isAccountInGroup checks if the account belongs to the specified group.
 // Returns true if groupID is nil (no group restriction) or account belongs to the group.
-func (s *GatewayService) isAccountInGroup(account *Account, groupID *int64) bool {
+func isAccountInGroup(account *Account, groupID *int64) bool {
 	if groupID == nil {
 		return true // 无分组限制
 	}
@@ -2397,7 +2400,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
-						if !clearSticky && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+						if !clearSticky && isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
 							if s.debugModelRoutingEnabled() {
 								logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] legacy routed sticky hit: group_id=%v model=%s session=%s account=%d", derefGroupID(groupID), requestedModel, shortSessionHash(sessionHash), accountID)
 							}
@@ -2497,7 +2500,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
-					if !clearSticky && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+					if !clearSticky && isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
 						return account, nil
 					}
 				}
@@ -2604,7 +2607,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
-						if !clearSticky && s.isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+						if !clearSticky && isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
 							if account.Platform == nativePlatform || (account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled()) {
 								if s.debugModelRoutingEnabled() {
 									logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] legacy mixed routed sticky hit: group_id=%v model=%s session=%s account=%d", derefGroupID(groupID), requestedModel, shortSessionHash(sessionHash), accountID)
@@ -2706,7 +2709,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
-					if !clearSticky && s.isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+					if !clearSticky && isAccountInGroup(account, groupID) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && account.IsSchedulableForModelWithContext(ctx, requestedModel) {
 						if account.Platform == nativePlatform || (account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled()) {
 							return account, nil
 						}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -207,6 +207,13 @@ func (s *GeminiMessagesCompatService) tryStickySessionHit(
 		return nil
 	}
 
+	// 检查账号是否仍在当前分组中（防御性检查：防止账号被移除分组后继续使用）
+	// Verify account still belongs to the current group
+	if !isAccountInGroup(account, groupID) {
+		_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), cacheKey)
+		return nil
+	}
+
 	// 验证账号是否可用于当前请求
 	// Verify account is usable for current request
 	if !s.isAccountUsableForRequest(ctx, account, requestedModel, platform, useMixedScheduling) {

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -274,6 +274,23 @@ func (m *mockGatewayCacheForGemini) DeleteSessionAccountID(ctx context.Context, 
 	return nil
 }
 
+func (m *mockGatewayCacheForGemini) DeleteStickySessionsByAccount(ctx context.Context, groupID int64, accountID int64) error {
+	if m.sessionBindings == nil {
+		return nil
+	}
+	// 删除所有绑定到该账号的会话
+	for sessionHash, boundAccountID := range m.sessionBindings {
+		if boundAccountID == accountID {
+			delete(m.sessionBindings, sessionHash)
+			if m.deletedSessions == nil {
+				m.deletedSessions = make(map[string]int)
+			}
+			m.deletedSessions[sessionHash]++
+		}
+	}
+	return nil
+}
+
 // TestGeminiMessagesCompatService_SelectAccountForModelWithExclusions_GeminiPlatform 测试 Gemini 单平台选择
 func TestGeminiMessagesCompatService_SelectAccountForModelWithExclusions_GeminiPlatform(t *testing.T) {
 	ctx := context.Background()

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -585,6 +585,13 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		return nil
 	}
 
+	// 检查账号是否仍在当前分组中（防御性检查：防止账号被移除分组后继续使用）
+	// Verify account still belongs to the current group
+	if !isAccountInGroup(account, groupID) {
+		_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), cacheKey)
+		return nil
+	}
+
 	// 验证账号是否可用于当前请求
 	// Verify account is usable for current request
 	if !account.IsSchedulable() || !account.IsOpenAI() {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -211,6 +211,23 @@ func (c *stubGatewayCache) DeleteSessionAccountID(ctx context.Context, groupID i
 	return nil
 }
 
+func (c *stubGatewayCache) DeleteStickySessionsByAccount(ctx context.Context, groupID int64, accountID int64) error {
+	if c.sessionBindings == nil {
+		return nil
+	}
+	// 删除所有绑定到该账号的会话
+	for sessionHash, boundAccountID := range c.sessionBindings {
+		if boundAccountID == accountID {
+			delete(c.sessionBindings, sessionHash)
+			if c.deletedSessions == nil {
+				c.deletedSessions = make(map[string]int)
+			}
+			c.deletedSessions[sessionHash]++
+		}
+	}
+	return nil
+}
+
 func TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulable(t *testing.T) {
 	now := time.Now()
 	resetAt := now.Add(10 * time.Minute)

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -25,6 +25,7 @@ type SchedulerSnapshotService struct {
 	outboxRepo    SchedulerOutboxRepository
 	accountRepo   AccountRepository
 	groupRepo     GroupRepository
+	gatewayCache  GatewayCache
 	cfg           *config.Config
 	stopCh        chan struct{}
 	stopOnce      sync.Once
@@ -39,6 +40,7 @@ func NewSchedulerSnapshotService(
 	outboxRepo SchedulerOutboxRepository,
 	accountRepo AccountRepository,
 	groupRepo GroupRepository,
+	gatewayCache GatewayCache,
 	cfg *config.Config,
 ) *SchedulerSnapshotService {
 	maxQPS := 0
@@ -50,6 +52,7 @@ func NewSchedulerSnapshotService(
 		outboxRepo:    outboxRepo,
 		accountRepo:   accountRepo,
 		groupRepo:     groupRepo,
+		gatewayCache:  gatewayCache,
 		cfg:           cfg,
 		stopCh:        make(chan struct{}),
 		fallbackLimit: newFallbackLimiter(maxQPS),
@@ -263,6 +266,18 @@ func (s *SchedulerSnapshotService) handleOutboxEvent(ctx context.Context, event 
 	case SchedulerOutboxEventAccountBulkChanged:
 		return s.handleBulkAccountEvent(ctx, event.Payload)
 	case SchedulerOutboxEventAccountGroupsChanged:
+		// 账号分组变更时，清除该账号在相关分组中的 sticky session
+		// 防止账号被移除分组后仍被 sticky session 继续使用
+		if event.AccountID != nil && s.gatewayCache != nil && event.Payload != nil {
+			if groupIDs := parseInt64Slice(event.Payload["group_ids"]); len(groupIDs) > 0 {
+				for _, groupID := range groupIDs {
+					if err := s.gatewayCache.DeleteStickySessionsByAccount(ctx, groupID, *event.AccountID); err != nil {
+						logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] clear sticky sessions failed: account=%d group=%d err=%v", *event.AccountID, groupID, err)
+						// 继续处理其他分组，不中断
+					}
+				}
+			}
+		}
 		return s.handleAccountEvent(ctx, event.AccountID, event.Payload)
 	case SchedulerOutboxEventAccountChanged:
 		return s.handleAccountEvent(ctx, event.AccountID, event.Payload)

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -116,9 +116,10 @@ func ProvideSchedulerSnapshotService(
 	outboxRepo SchedulerOutboxRepository,
 	accountRepo AccountRepository,
 	groupRepo GroupRepository,
+	gatewayCache GatewayCache,
 	cfg *config.Config,
 ) *SchedulerSnapshotService {
-	svc := NewSchedulerSnapshotService(cache, outboxRepo, accountRepo, groupRepo, cfg)
+	svc := NewSchedulerSnapshotService(cache, outboxRepo, accountRepo, groupRepo, gatewayCache, cfg)
 	svc.Start()
 	return svc
 }

--- a/backend/internal/testutil/stubs.go
+++ b/backend/internal/testutil/stubs.go
@@ -90,6 +90,9 @@ func (c StubGatewayCache) RefreshSessionTTL(_ context.Context, _ int64, _ string
 func (c StubGatewayCache) DeleteSessionAccountID(_ context.Context, _ int64, _ string) error {
 	return nil
 }
+func (c StubGatewayCache) DeleteStickySessionsByAccount(_ context.Context, _ int64, _ int64) error {
+	return nil
+}
 
 // ============================================================
 // StubSessionLimitCache — service.SessionLimitCache 的空实现


### PR DESCRIPTION
## 关联 Issue

Closes #662

## 问题描述

当账号被关闭（禁用）或从分组中移除后，之前已建立的粘性会话（sticky session）仍然持有对该账号的绑定关系，导致后续请求继续被路由到该已禁用/移除的账号，产生"关闭账号还能使用"的 bug。

## 根本原因

粘性会话以 `sticky_session:{groupID}:{sessionHash} → accountID` 的形式缓存在 Redis 中，账号状态变更或分组关系变更时未主动清理这些缓存键。

## 解决方案

### 1. 新增反向索引 + 批量清理接口

`GatewayCache` 接口新增 `DeleteStickySessionsByAccount(ctx, groupID, accountID)` 方法。  
在 `gateway_cache.go` 中，`SetSessionAccountID` 写入粘性会话时同步维护反向索引：

sticky_session_index:{groupID}:{accountID} → Set<sessionHash>


清理时通过反向索引找到该账号在该分组的所有 sessionHash，pipeline 批量删除。

### 2. 分组变更时自动触发清理

`SchedulerSnapshotService` 注入 `GatewayCache`，处理 `AccountGroupsChanged` outbox 事件时，对受影响的 groupID 逐一调用 `DeleteStickySessionsByAccount`，确保账号移出分组后粘性会话立即失效。

### 3. 防御性分组归属检查

OpenAI 和 Gemini 网关服务的 `tryStickySessionHit` 中新增 `isAccountInGroup` 检查：即使反向索引清理存在延迟，命中缓存后也会二次校验账号是否仍属于当前分组，不属于则主动清理并放弃该命中。

## 变更文件

| 文件 | 变更内容 |
|------|----------|
| `internal/repository/gateway_cache.go` | 新增反向索引及 `DeleteStickySessionsByAccount` 实现 |
| `internal/service/gateway_service.go` | `GatewayCache` 接口新增方法；`isAccountInGroup` 改为包级函数 |
| `internal/service/scheduler_snapshot_service.go` | 注入 `GatewayCache`，`AccountGroupsChanged` 事件时清理 sticky session |
| `internal/service/wire.go` | `ProvideSchedulerSnapshotService` 签名新增 `GatewayCache` 参数 |
| `internal/service/openai_gateway_service.go` | `tryStickySessionHit` 新增 `isAccountInGroup` 防御性检查 |
| `internal/service/gemini_messages_compat_service.go` | 同上 |
| `cmd/server/wire_gen.go` | 重新生成 Wire 注入代码 |
| 各测试 stub/mock 文件 | 实现新增的 `DeleteStickySessionsByAccount` 接口方法 |

## 测试

- 单元测试：`go test -tags=unit ./...` ✅
- 集成测试：`TestSchedulerSnapshotOutboxReplay` 已更新签名适配新参数