### PR TITLE
fix(admin): 修复 UpdateAccount 无法清空 credentials 和 extra 字段的问题

### DIFF
--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -1495,10 +1495,10 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	if input.Notes != nil {
 		account.Notes = normalizeAccountNotes(input.Notes)
 	}
-	if len(input.Credentials) > 0 {
+	if input.Credentials != nil {
 		account.Credentials = input.Credentials
 	}
-	if len(input.Extra) > 0 {
+	if input.Extra != nil {
 		// 保留配额用量字段，防止编辑账号时意外重置
 		for _, key := range []string{"quota_used", "quota_daily_used", "quota_daily_start", "quota_weekly_used", "quota_weekly_start"} {
 			if v, ok := account.Extra[key]; ok {


### PR DESCRIPTION
## 问题描述
在账号配置中，当用户开启自动透传（error pass-through）等功能后，再次编辑账号并尝试关闭该功能（将 `credentials` 或 `extra` 置为空）时，保存不生效，字段值始终保持原有内容，导致已开启的功能无法关闭。

**复现步骤：**
1. 编辑某账号，配置 `credentials` 或 `extra` 字段（开启自动透传等功能）并保存
2. 再次编辑该账号，将上述字段清空后保存
3. 刷新页面，发现字段内容未变，功能依然处于开启状态

## 根本原因
`UpdateAccount` 方法中使用 `len(x) > 0` 作为字段更新的判断条件，传入空切片/空 map 时长度为 0，条件不满足，字段被跳过不更新。

## 修复方案
将判断条件从` len(x) > 0` 改为 `x != nil`：
- nil：调用方未传该字段 → 保持原值不变（语义不变）
- 空切片 / 空 map：调用方明确传入空值 → 正确清空字段

