### PR TITLE
fix(ci): 修复 gosec 扫描因 ent 生成代码导致超时的问题

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   backend-security:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -32,7 +33,8 @@ jobs:
         working-directory: backend
         run: |
           go install github.com/securego/gosec/v2/cmd/gosec@latest
-          gosec -conf .gosec.json -severity high -confidence high ./...
+          # exclude ent/ — auto-generated ORM code, not subject to manual security review
+          gosec -conf .gosec.json -severity high -confidence high -exclude-dir=ent ./...
 
   frontend-security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 问题描述

`backend-security` CI job 运行约 6 小时后被 GitHub Actions 强制取消，
`Run gosec` 步骤一直挂起，最终以 `cancelled` 状态结束。

参考：https://github.com/Wei-Shaw/sub2api/actions/runs/22484785710/job/65131583668

## 根本原因

`gosec ./...` 会递归扫描所有目录，其中 `ent/` 目录包含 Ent ORM 框架自动生成的代码，
`mutation.go` 单文件就有 **24,800 行**。gosec 对每个文件做 AST 静态分析，
遇到此规模的文件时分析时间极长，最终超出 GitHub Actions 默认的 6 小时上限。

## 变更内容

`.github/workflows/security-scan.yml`

1. **`-exclude-dir=ent`** — gosec 跳过 `ent/` 目录，不再对自动生成代码做 AST 分析
2. **`timeout-minutes: 15`** — 为 `backend-security` job 增加兜底超时，避免未来类似问题再次长时间卡死

## 说明

`ent/` 目录内容全部由 Ent ORM 框架自动生成，开发者不直接编写，
不需要纳入人工安全审计范围，排除后不影响扫描对业务代码的有效性。