### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
         run: echo "owner=$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: '~> v2'
           args: release --clean --skip=validate ${{ env.SIMPLE_RELEASE == 'true' && '--config=.goreleaser.simple.yaml' || '' }}
@@ -188,7 +188,7 @@ jobs:
       # Update DockerHub description
       - name: Update DockerHub description
         if: ${{ env.SIMPLE_RELEASE != 'true' && env.DOCKERHUB_USERNAME != '' }}
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@v5
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         with:


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `goreleaser/goreleaser-action` | [`v6`](https://github.com/goreleaser/goreleaser-action/releases/tag/v6) | [`v7`](https://github.com/goreleaser/goreleaser-action/releases/tag/v7) | [Release](https://github.com/goreleaser/goreleaser-action/releases/tag/v7) | release.yml |
| `peter-evans/dockerhub-description` | [`v4`](https://github.com/peter-evans/dockerhub-description/releases/tag/v4) | [`v5`](https://github.com/peter-evans/dockerhub-description/releases/tag/v5) | [Release](https://github.com/peter-evans/dockerhub-description/releases/tag/v5) | release.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **goreleaser/goreleaser-action** (v6 → v7): Major version upgrade — review the [release notes](https://github.com/goreleaser/goreleaser-action/releases) for breaking changes
- **peter-evans/dockerhub-description** (v4 → v5): Major version upgrade — review the [release notes](https://github.com/peter-evans/dockerhub-description/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
