### PR TITLE
fix(group): clear nullable limit fields on update

### DIFF
--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -127,6 +127,38 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 		SetMcpXMLInject(groupIn.MCPXMLInject).
 		SetSoraStorageQuotaBytes(groupIn.SoraStorageQuotaBytes)
 
+	// 显式处理可空字段：nil 需要 clear，非 nil 需要 set。
+	if groupIn.DailyLimitUSD != nil {
+		builder = builder.SetDailyLimitUsd(*groupIn.DailyLimitUSD)
+	} else {
+		builder = builder.ClearDailyLimitUsd()
+	}
+	if groupIn.WeeklyLimitUSD != nil {
+		builder = builder.SetWeeklyLimitUsd(*groupIn.WeeklyLimitUSD)
+	} else {
+		builder = builder.ClearWeeklyLimitUsd()
+	}
+	if groupIn.MonthlyLimitUSD != nil {
+		builder = builder.SetMonthlyLimitUsd(*groupIn.MonthlyLimitUSD)
+	} else {
+		builder = builder.ClearMonthlyLimitUsd()
+	}
+	if groupIn.ImagePrice1K != nil {
+		builder = builder.SetImagePrice1k(*groupIn.ImagePrice1K)
+	} else {
+		builder = builder.ClearImagePrice1k()
+	}
+	if groupIn.ImagePrice2K != nil {
+		builder = builder.SetImagePrice2k(*groupIn.ImagePrice2K)
+	} else {
+		builder = builder.ClearImagePrice2k()
+	}
+	if groupIn.ImagePrice4K != nil {
+		builder = builder.SetImagePrice4k(*groupIn.ImagePrice4K)
+	} else {
+		builder = builder.ClearImagePrice4k()
+	}
+
 	// 处理 FallbackGroupID：nil 时清除，否则设置
 	if groupIn.FallbackGroupID != nil {
 		builder = builder.SetFallbackGroupID(*groupIn.FallbackGroupID)


### PR DESCRIPTION
## Summary
- Fix group update behavior for nullable pricing and limit fields.
- Ensure these fields are explicitly cleared when service layer passes nil:
  - daily_limit_usd
  - weekly_limit_usd
  - monthly_limit_usd
  - image_price_1k
  - image_price_2k
  - image_price_4k
- This makes switching a group limit from a value (for example 600) to unlimited (normalized to nil) persist correctly.

## Root Cause
- Update path relied on SetNillable methods only.
- For updates, nil values did not clear existing DB values, so previous limits could remain.

## Change
- In groupRepository.Update, explicitly Set when non-nil and Clear when nil for the six nullable fields above.

## Verification
- Local test command:
  - cd backend && go test ./internal/repository -run TestGroupRepoSuite -count=1
