### PR TITLE
fix(dashboard): sort recent usage tooltip labels by token consumption

### DIFF
--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -366,6 +366,11 @@ const lineOptions = computed(() => ({
       }
     },
     tooltip: {
+      itemSort: (a: any, b: any) => {
+        const aValue = typeof a?.raw === 'number' ? a.raw : Number(a?.parsed?.y ?? 0)
+        const bValue = typeof b?.raw === 'number' ? b.raw : Number(b?.parsed?.y ?? 0)
+        return bValue - aValue
+      },
       callbacks: {
         label: (context: any) => {
           return `${context.dataset.label}: ${formatTokens(context.raw)}`


### PR DESCRIPTION
## Summary

- sort tooltip items in Admin Dashboard `Recent Usage (Top 12)` chart by token value descending
- keep existing chart rendering and labels unchanged


## Testing

- corepack pnpm run typecheck