### PR TITLE
feat(proxy): 集中代理 URL 验证并实现全局 fail-fast

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -265,8 +265,13 @@ type CSPConfig struct {
 }
 
 type ProxyFallbackConfig struct {
-	// AllowDirectOnError 当代理初始化失败时是否允许回退直连。
-	// 默认 false：避免因代理配置错误导致 IP 泄露/关联。
+	// AllowDirectOnError 当辅助服务的代理初始化失败时是否允许回退直连。
+	// 仅影响以下非 AI 账号连接的辅助服务：
+	//   - GitHub Release 更新检查
+	//   - 定价数据拉取
+	// 不影响 AI 账号网关连接（Claude/OpenAI/Gemini/Antigravity），
+	// 这些关键路径的代理失败始终返回错误，不会回退直连。
+	// 默认 false：避免因代理配置错误导致服务器真实 IP 泄露。
 	AllowDirectOnError bool `mapstructure:"allow_direct_on_error"`
 }
 
@@ -1105,6 +1110,9 @@ func setDefaults() {
 	viper.SetDefault("security.csp.policy", DefaultCSPPolicy)
 	viper.SetDefault("security.proxy_probe.insecure_skip_verify", false)
 
+	// Security - disable direct fallback on proxy error
+	viper.SetDefault("security.proxy_fallback.allow_direct_on_error", false)
+
 	// Billing
 	viper.SetDefault("billing.circuit_breaker.enabled", true)
 	viper.SetDefault("billing.circuit_breaker.failure_threshold", 5)
@@ -1414,9 +1422,6 @@ func setDefaults() {
 	viper.SetDefault("gemini.oauth.client_secret", "")
 	viper.SetDefault("gemini.oauth.scopes", "")
 	viper.SetDefault("gemini.quota.policy", "")
-
-	// Security - proxy fallback
-	viper.SetDefault("security.proxy_fallback.allow_direct_on_error", false)
 
 	// Subscription Maintenance (bounded queue + worker pool)
 	viper.SetDefault("subscription_maintenance.worker_count", 2)

--- a/backend/internal/pkg/antigravity/client.go
+++ b/backend/internal/pkg/antigravity/client.go
@@ -14,6 +14,9 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 )
 
 // NewAPIRequestWithURL 使用指定的 base URL 创建 Antigravity API 请求（v1internal 端点）
@@ -149,22 +152,26 @@ type Client struct {
 	httpClient *http.Client
 }
 
-func NewClient(proxyURL string) *Client {
+func NewClient(proxyURL string) (*Client, error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 	}
 
-	if strings.TrimSpace(proxyURL) != "" {
-		if proxyURLParsed, err := url.Parse(proxyURL); err == nil {
-			client.Transport = &http.Transport{
-				Proxy: http.ProxyURL(proxyURLParsed),
-			}
+	_, parsed, err := proxyurl.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+	if parsed != nil {
+		transport := &http.Transport{}
+		if err := proxyutil.ConfigureTransportProxy(transport, parsed); err != nil {
+			return nil, fmt.Errorf("configure proxy: %w", err)
 		}
+		client.Transport = transport
 	}
 
 	return &Client{
 		httpClient: client,
-	}
+	}, nil
 }
 
 // isConnectionError 判断是否为连接错误（网络超时、DNS 失败、连接拒绝）

--- a/backend/internal/pkg/proxyurl/parse.go
+++ b/backend/internal/pkg/proxyurl/parse.go
@@ -1,0 +1,66 @@
+// Package proxyurl 提供代理 URL 的统一验证（fail-fast，无效代理不回退直连）
+//
+// 所有需要解析代理 URL 的地方必须通过此包的 Parse 函数。
+// 直接使用 url.Parse 处理代理 URL 是被禁止的。
+// 这确保了 fail-fast 行为：无效代理配置在创建时立即失败，
+// 而不是在运行时静默回退到直连（产生 IP 关联风险）。
+package proxyurl
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// allowedSchemes 代理协议白名单
+var allowedSchemes = map[string]bool{
+	"http":    true,
+	"https":   true,
+	"socks5":  true,
+	"socks5h": true,
+}
+
+// Parse 解析并验证代理 URL。
+//
+// 语义:
+//   - 空字符串 → ("", nil, nil)，表示直连
+//   - 非空且有效 → (trimmed, *url.URL, nil)
+//   - 非空但无效 → ("", nil, error)，fail-fast 不回退
+//
+// 验证规则:
+//   - TrimSpace 后为空视为直连
+//   - url.Parse 失败返回 error（不含原始 URL，防凭据泄露）
+//   - Host 为空返回 error（用 Redacted() 脱敏）
+//   - Scheme 必须为 http/https/socks5/socks5h
+//   - socks5:// 自动升级为 socks5h://（确保 DNS 由代理端解析，防止 DNS 泄漏）
+func Parse(raw string) (trimmed string, parsed *url.URL, err error) {
+	trimmed = strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", nil, nil
+	}
+
+	parsed, err = url.Parse(trimmed)
+	if err != nil {
+		// 不使用 %w 包装，避免 url.Parse 的底层错误消息泄漏原始 URL（可能含凭据）
+		return "", nil, fmt.Errorf("invalid proxy URL: %v", err)
+	}
+
+	if parsed.Host == "" || parsed.Hostname() == "" {
+		return "", nil, fmt.Errorf("proxy URL missing host: %s", parsed.Redacted())
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if !allowedSchemes[scheme] {
+		return "", nil, fmt.Errorf("unsupported proxy scheme %q (allowed: http, https, socks5, socks5h)", scheme)
+	}
+
+	// 自动升级 socks5 → socks5h，确保 DNS 由代理端解析，防止 DNS 泄漏。
+	// Go 的 golang.org/x/net/proxy 对 socks5:// 默认在客户端本地解析 DNS，
+	// 仅 socks5h:// 才将域名发送给代理端做远程 DNS 解析。
+	if scheme == "socks5" {
+		parsed.Scheme = "socks5h"
+		trimmed = parsed.String()
+	}
+
+	return trimmed, parsed, nil
+}

--- a/backend/internal/pkg/proxyurl/parse_test.go
+++ b/backend/internal/pkg/proxyurl/parse_test.go
@@ -1,0 +1,215 @@
+package proxyurl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParse_空字符串直连(t *testing.T) {
+	trimmed, parsed, err := Parse("")
+	if err != nil {
+		t.Fatalf("空字符串应直连: %v", err)
+	}
+	if trimmed != "" {
+		t.Errorf("trimmed 应为空: got %q", trimmed)
+	}
+	if parsed != nil {
+		t.Errorf("parsed 应为 nil: got %v", parsed)
+	}
+}
+
+func TestParse_空白字符串直连(t *testing.T) {
+	trimmed, parsed, err := Parse("   ")
+	if err != nil {
+		t.Fatalf("空白字符串应直连: %v", err)
+	}
+	if trimmed != "" {
+		t.Errorf("trimmed 应为空: got %q", trimmed)
+	}
+	if parsed != nil {
+		t.Errorf("parsed 应为 nil: got %v", parsed)
+	}
+}
+
+func TestParse_有效HTTP代理(t *testing.T) {
+	trimmed, parsed, err := Parse("http://proxy.example.com:8080")
+	if err != nil {
+		t.Fatalf("有效 HTTP 代理应成功: %v", err)
+	}
+	if trimmed != "http://proxy.example.com:8080" {
+		t.Errorf("trimmed 不匹配: got %q", trimmed)
+	}
+	if parsed == nil {
+		t.Fatal("parsed 不应为 nil")
+	}
+	if parsed.Host != "proxy.example.com:8080" {
+		t.Errorf("Host 不匹配: got %q", parsed.Host)
+	}
+}
+
+func TestParse_有效HTTPS代理(t *testing.T) {
+	_, parsed, err := Parse("https://proxy.example.com:443")
+	if err != nil {
+		t.Fatalf("有效 HTTPS 代理应成功: %v", err)
+	}
+	if parsed.Scheme != "https" {
+		t.Errorf("Scheme 不匹配: got %q", parsed.Scheme)
+	}
+}
+
+func TestParse_有效SOCKS5代理_自动升级为SOCKS5H(t *testing.T) {
+	trimmed, parsed, err := Parse("socks5://127.0.0.1:1080")
+	if err != nil {
+		t.Fatalf("有效 SOCKS5 代理应成功: %v", err)
+	}
+	// socks5 自动升级为 socks5h，确保 DNS 由代理端解析
+	if trimmed != "socks5h://127.0.0.1:1080" {
+		t.Errorf("trimmed 应升级为 socks5h: got %q", trimmed)
+	}
+	if parsed.Scheme != "socks5h" {
+		t.Errorf("Scheme 应升级为 socks5h: got %q", parsed.Scheme)
+	}
+}
+
+func TestParse_无效URL(t *testing.T) {
+	_, _, err := Parse("://invalid")
+	if err == nil {
+		t.Fatal("无效 URL 应返回错误")
+	}
+	if !strings.Contains(err.Error(), "invalid proxy URL") {
+		t.Errorf("错误信息应包含 'invalid proxy URL': got %s", err.Error())
+	}
+}
+
+func TestParse_缺少Host(t *testing.T) {
+	_, _, err := Parse("http://")
+	if err == nil {
+		t.Fatal("缺少 host 应返回错误")
+	}
+	if !strings.Contains(err.Error(), "missing host") {
+		t.Errorf("错误信息应包含 'missing host': got %s", err.Error())
+	}
+}
+
+func TestParse_不支持的Scheme(t *testing.T) {
+	_, _, err := Parse("ftp://proxy.example.com:21")
+	if err == nil {
+		t.Fatal("不支持的 scheme 应返回错误")
+	}
+	if !strings.Contains(err.Error(), "unsupported proxy scheme") {
+		t.Errorf("错误信息应包含 'unsupported proxy scheme': got %s", err.Error())
+	}
+}
+
+func TestParse_含密码URL脱敏(t *testing.T) {
+	// 场景 1: 带密码的 socks5 URL 应成功解析并升级为 socks5h
+	trimmed, parsed, err := Parse("socks5://user:secret_password@proxy.local:1080")
+	if err != nil {
+		t.Fatalf("含密码的有效 URL 应成功: %v", err)
+	}
+	if trimmed == "" || parsed == nil {
+		t.Fatal("应返回非空结果")
+	}
+	if parsed.Scheme != "socks5h" {
+		t.Errorf("Scheme 应升级为 socks5h: got %q", parsed.Scheme)
+	}
+	if !strings.HasPrefix(trimmed, "socks5h://") {
+		t.Errorf("trimmed 应以 socks5h:// 开头: got %q", trimmed)
+	}
+	if parsed.User == nil {
+		t.Error("升级后应保留 UserInfo")
+	}
+
+	// 场景 2: 带密码但缺少 host（触发 Redacted 脱敏路径）
+	_, _, err = Parse("http://user:secret_password@:0/")
+	if err == nil {
+		t.Fatal("缺少 host 应返回错误")
+	}
+	if strings.Contains(err.Error(), "secret_password") {
+		t.Error("错误信息不应包含明文密码")
+	}
+	if !strings.Contains(err.Error(), "missing host") {
+		t.Errorf("错误信息应包含 'missing host': got %s", err.Error())
+	}
+}
+
+func TestParse_带空白的有效URL(t *testing.T) {
+	trimmed, parsed, err := Parse("  http://proxy.example.com:8080  ")
+	if err != nil {
+		t.Fatalf("带空白的有效 URL 应成功: %v", err)
+	}
+	if trimmed != "http://proxy.example.com:8080" {
+		t.Errorf("trimmed 应去除空白: got %q", trimmed)
+	}
+	if parsed == nil {
+		t.Fatal("parsed 不应为 nil")
+	}
+}
+
+func TestParse_Scheme大小写不敏感(t *testing.T) {
+	// 大写 SOCKS5 应被接受并升级为 socks5h
+	trimmed, parsed, err := Parse("SOCKS5://proxy.example.com:1080")
+	if err != nil {
+		t.Fatalf("大写 SOCKS5 应被接受: %v", err)
+	}
+	if parsed.Scheme != "socks5h" {
+		t.Errorf("大写 SOCKS5 Scheme 应升级为 socks5h: got %q", parsed.Scheme)
+	}
+	if !strings.HasPrefix(trimmed, "socks5h://") {
+		t.Errorf("大写 SOCKS5 trimmed 应升级为 socks5h://: got %q", trimmed)
+	}
+
+	// 大写 HTTP 应被接受（不变）
+	_, _, err = Parse("HTTP://proxy.example.com:8080")
+	if err != nil {
+		t.Fatalf("大写 HTTP 应被接受: %v", err)
+	}
+}
+
+func TestParse_带认证的有效代理(t *testing.T) {
+	trimmed, parsed, err := Parse("http://user:pass@proxy.example.com:8080")
+	if err != nil {
+		t.Fatalf("带认证的代理 URL 应成功: %v", err)
+	}
+	if parsed.User == nil {
+		t.Error("应保留 UserInfo")
+	}
+	if trimmed != "http://user:pass@proxy.example.com:8080" {
+		t.Errorf("trimmed 不匹配: got %q", trimmed)
+	}
+}
+
+func TestParse_IPv6地址(t *testing.T) {
+	trimmed, parsed, err := Parse("http://[::1]:8080")
+	if err != nil {
+		t.Fatalf("IPv6 代理 URL 应成功: %v", err)
+	}
+	if parsed.Hostname() != "::1" {
+		t.Errorf("Hostname 不匹配: got %q", parsed.Hostname())
+	}
+	if trimmed != "http://[::1]:8080" {
+		t.Errorf("trimmed 不匹配: got %q", trimmed)
+	}
+}
+
+func TestParse_SOCKS5H保持不变(t *testing.T) {
+	trimmed, parsed, err := Parse("socks5h://proxy.local:1080")
+	if err != nil {
+		t.Fatalf("有效 SOCKS5H 代理应成功: %v", err)
+	}
+	// socks5h 不需要升级，应保持原样
+	if trimmed != "socks5h://proxy.local:1080" {
+		t.Errorf("trimmed 不应变化: got %q", trimmed)
+	}
+	if parsed.Scheme != "socks5h" {
+		t.Errorf("Scheme 应保持 socks5h: got %q", parsed.Scheme)
+	}
+}
+
+func TestParse_无Scheme裸地址(t *testing.T) {
+	// 无 scheme 的裸地址，Go url.Parse 将其视为 path，Host 为空
+	_, _, err := Parse("proxy.example.com:8080")
+	if err == nil {
+		t.Fatal("无 scheme 的裸地址应返回错误")
+	}
+}

--- a/backend/internal/pkg/proxyutil/dialer.go
+++ b/backend/internal/pkg/proxyutil/dialer.go
@@ -2,7 +2,11 @@
 //
 // 支持的代理协议：
 //   - HTTP/HTTPS: 通过 Transport.Proxy 设置
-//   - SOCKS5/SOCKS5H: 通过 Transport.DialContext 设置（服务端解析 DNS）
+//   - SOCKS5: 通过 Transport.DialContext 设置（客户端本地解析 DNS）
+//   - SOCKS5H: 通过 Transport.DialContext 设置（代理端远程解析 DNS，推荐）
+//
+// 注意：proxyurl.Parse() 会自动将 socks5:// 升级为 socks5h://，
+// 确保 DNS 也由代理端解析，防止 DNS 泄漏。
 package proxyutil
 
 import (
@@ -20,7 +24,8 @@ import (
 //
 // 支持的协议：
 //   - http/https: 设置 transport.Proxy
-//   - socks5/socks5h: 设置 transport.DialContext（由代理服务端解析 DNS）
+//   - socks5: 设置 transport.DialContext（客户端本地解析 DNS）
+//   - socks5h: 设置 transport.DialContext（代理端远程解析 DNS，推荐）
 //
 // 参数：
 //   - transport: 需要配置的 http.Transport

--- a/backend/internal/repository/claude_oauth_service.go
+++ b/backend/internal/repository/claude_oauth_service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/oauth"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
 
@@ -28,11 +29,14 @@ func NewClaudeOAuthClient() service.ClaudeOAuthClient {
 type claudeOAuthService struct {
 	baseURL       string
 	tokenURL      string
-	clientFactory func(proxyURL string) *req.Client
+	clientFactory func(proxyURL string) (*req.Client, error)
 }
 
 func (s *claudeOAuthService) GetOrganizationUUID(ctx context.Context, sessionKey, proxyURL string) (string, error) {
-	client := s.clientFactory(proxyURL)
+	client, err := s.clientFactory(proxyURL)
+	if err != nil {
+		return "", fmt.Errorf("create HTTP client: %w", err)
+	}
 
 	var orgs []struct {
 		UUID      string  `json:"uuid"`
@@ -88,7 +92,10 @@ func (s *claudeOAuthService) GetOrganizationUUID(ctx context.Context, sessionKey
 }
 
 func (s *claudeOAuthService) GetAuthorizationCode(ctx context.Context, sessionKey, orgUUID, scope, codeChallenge, state, proxyURL string) (string, error) {
-	client := s.clientFactory(proxyURL)
+	client, err := s.clientFactory(proxyURL)
+	if err != nil {
+		return "", fmt.Errorf("create HTTP client: %w", err)
+	}
 
 	authURL := fmt.Sprintf("%s/v1/oauth/%s/authorize", s.baseURL, orgUUID)
 
@@ -165,7 +172,10 @@ func (s *claudeOAuthService) GetAuthorizationCode(ctx context.Context, sessionKe
 }
 
 func (s *claudeOAuthService) ExchangeCodeForToken(ctx context.Context, code, codeVerifier, state, proxyURL string, isSetupToken bool) (*oauth.TokenResponse, error) {
-	client := s.clientFactory(proxyURL)
+	client, err := s.clientFactory(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %w", err)
+	}
 
 	// Parse code which may contain state in format "authCode#state"
 	authCode := code
@@ -223,7 +233,10 @@ func (s *claudeOAuthService) ExchangeCodeForToken(ctx context.Context, code, cod
 }
 
 func (s *claudeOAuthService) RefreshToken(ctx context.Context, refreshToken, proxyURL string) (*oauth.TokenResponse, error) {
-	client := s.clientFactory(proxyURL)
+	client, err := s.clientFactory(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %w", err)
+	}
 
 	reqBody := map[string]any{
 		"grant_type":    "refresh_token",
@@ -253,16 +266,20 @@ func (s *claudeOAuthService) RefreshToken(ctx context.Context, refreshToken, pro
 	return &tokenResp, nil
 }
 
-func createReqClient(proxyURL string) *req.Client {
+func createReqClient(proxyURL string) (*req.Client, error) {
 	// 禁用 CookieJar，确保每次授权都是干净的会话
 	client := req.C().
 		SetTimeout(60 * time.Second).
 		ImpersonateChrome().
 		SetCookieJar(nil) // 禁用 CookieJar
 
-	if strings.TrimSpace(proxyURL) != "" {
-		client.SetProxyURL(strings.TrimSpace(proxyURL))
+	trimmed, _, err := proxyurl.Parse(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+	if trimmed != "" {
+		client.SetProxyURL(trimmed)
 	}
 
-	return client
+	return client, nil
 }

--- a/backend/internal/repository/claude_oauth_service_test.go
+++ b/backend/internal/repository/claude_oauth_service_test.go
@@ -91,7 +91,7 @@ func (s *ClaudeOAuthServiceSuite) TestGetOrganizationUUID() {
 			require.True(s.T(), ok, "type assertion failed")
 			s.client = client
 			s.client.baseURL = "http://in-process"
-			s.client.clientFactory = func(string) *req.Client { return newTestReqClient(rt) }
+			s.client.clientFactory = func(string) (*req.Client, error) { return newTestReqClient(rt), nil }
 
 			got, err := s.client.GetOrganizationUUID(context.Background(), "sess", "")
 
@@ -169,7 +169,7 @@ func (s *ClaudeOAuthServiceSuite) TestGetAuthorizationCode() {
 			require.True(s.T(), ok, "type assertion failed")
 			s.client = client
 			s.client.baseURL = "http://in-process"
-			s.client.clientFactory = func(string) *req.Client { return newTestReqClient(rt) }
+			s.client.clientFactory = func(string) (*req.Client, error) { return newTestReqClient(rt), nil }
 
 			code, err := s.client.GetAuthorizationCode(context.Background(), "sess", "org-1", oauth.ScopeInference, "cc", "st", "")
 
@@ -276,7 +276,7 @@ func (s *ClaudeOAuthServiceSuite) TestExchangeCodeForToken() {
 			require.True(s.T(), ok, "type assertion failed")
 			s.client = client
 			s.client.tokenURL = "http://in-process/token"
-			s.client.clientFactory = func(string) *req.Client { return newTestReqClient(rt) }
+			s.client.clientFactory = func(string) (*req.Client, error) { return newTestReqClient(rt), nil }
 
 			resp, err := s.client.ExchangeCodeForToken(context.Background(), tt.code, "ver", "", "", tt.isSetupToken)
 
@@ -372,7 +372,7 @@ func (s *ClaudeOAuthServiceSuite) TestRefreshToken() {
 			require.True(s.T(), ok, "type assertion failed")
 			s.client = client
 			s.client.tokenURL = "http://in-process/token"
-			s.client.clientFactory = func(string) *req.Client { return newTestReqClient(rt) }
+			s.client.clientFactory = func(string) (*req.Client, error) { return newTestReqClient(rt), nil }
 
 			resp, err := s.client.RefreshToken(context.Background(), "rt", "")
 

--- a/backend/internal/repository/claude_usage_service.go
+++ b/backend/internal/repository/claude_usage_service.go
@@ -83,7 +83,7 @@ func (s *claudeUsageService) FetchUsageWithOptions(ctx context.Context, opts *se
 			AllowPrivateHosts:  s.allowPrivateHosts,
 		})
 		if err != nil {
-			client = &http.Client{Timeout: 30 * time.Second}
+			return nil, fmt.Errorf("create http client failed: %w", err)
 		}
 
 		resp, err = client.Do(req)

--- a/backend/internal/repository/claude_usage_service_test.go
+++ b/backend/internal/repository/claude_usage_service_test.go
@@ -50,7 +50,7 @@ func (s *ClaudeUsageServiceSuite) TestFetchUsage_Success() {
 		allowPrivateHosts: true,
 	}
 
-	resp, err := s.fetcher.FetchUsage(context.Background(), "at", "://bad-proxy-url")
+	resp, err := s.fetcher.FetchUsage(context.Background(), "at", "")
 	require.NoError(s.T(), err, "FetchUsage")
 	require.Equal(s.T(), 12.5, resp.FiveHour.Utilization, "FiveHour utilization mismatch")
 	require.Equal(s.T(), 34.0, resp.SevenDay.Utilization, "SevenDay utilization mismatch")
@@ -110,6 +110,17 @@ func (s *ClaudeUsageServiceSuite) TestFetchUsage_ContextCancel() {
 
 	_, err := s.fetcher.FetchUsage(ctx, "at", "")
 	require.Error(s.T(), err, "expected error for cancelled context")
+}
+
+func (s *ClaudeUsageServiceSuite) TestFetchUsage_InvalidProxyReturnsError() {
+	s.fetcher = &claudeUsageService{
+		usageURL:          "http://example.com",
+		allowPrivateHosts: true,
+	}
+
+	_, err := s.fetcher.FetchUsage(context.Background(), "at", "://bad-proxy-url")
+	require.Error(s.T(), err)
+	require.ErrorContains(s.T(), err, "create http client failed")
 }
 
 func TestClaudeUsageServiceSuite(t *testing.T) {

--- a/backend/internal/repository/gemini_oauth_client.go
+++ b/backend/internal/repository/gemini_oauth_client.go
@@ -26,7 +26,10 @@ func NewGeminiOAuthClient(cfg *config.Config) service.GeminiOAuthClient {
 }
 
 func (c *geminiOAuthClient) ExchangeCode(ctx context.Context, oauthType, code, codeVerifier, redirectURI, proxyURL string) (*geminicli.TokenResponse, error) {
-	client := createGeminiReqClient(proxyURL)
+	client, err := createGeminiReqClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %w", err)
+	}
 
 	// Use different OAuth clients based on oauthType:
 	// - code_assist: always use built-in Gemini CLI OAuth client (public)
@@ -72,7 +75,10 @@ func (c *geminiOAuthClient) ExchangeCode(ctx context.Context, oauthType, code, c
 }
 
 func (c *geminiOAuthClient) RefreshToken(ctx context.Context, oauthType, refreshToken, proxyURL string) (*geminicli.TokenResponse, error) {
-	client := createGeminiReqClient(proxyURL)
+	client, err := createGeminiReqClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %w", err)
+	}
 
 	oauthCfgInput := geminicli.OAuthConfig{
 		ClientID:     c.cfg.Gemini.OAuth.ClientID,
@@ -111,7 +117,7 @@ func (c *geminiOAuthClient) RefreshToken(ctx context.Context, oauthType, refresh
 	return &tokenResp, nil
 }
 
-func createGeminiReqClient(proxyURL string) *req.Client {
+func createGeminiReqClient(proxyURL string) (*req.Client, error) {
 	return getSharedReqClient(reqClientOptions{
 		ProxyURL: proxyURL,
 		Timeout:  60 * time.Second,

--- a/backend/internal/repository/geminicli_codeassist_client.go
+++ b/backend/internal/repository/geminicli_codeassist_client.go
@@ -26,7 +26,11 @@ func (c *geminiCliCodeAssistClient) LoadCodeAssist(ctx context.Context, accessTo
 	}
 
 	var out geminicli.LoadCodeAssistResponse
-	resp, err := createGeminiCliReqClient(proxyURL).R().
+	client, err := createGeminiCliReqClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %w", err)
+	}
+	resp, err := client.R().
 		SetContext(ctx).
 		SetHeader("Authorization", "Bearer "+accessToken).
 		SetHeader("Content-Type", "application/json").
@@ -66,7 +70,11 @@ func (c *geminiCliCodeAssistClient) OnboardUser(ctx context.Context, accessToken
 	fmt.Printf("[CodeAssist] OnboardUser request body: %+v\n", reqBody)
 
 	var out geminicli.OnboardUserResponse
-	resp, err := createGeminiCliReqClient(proxyURL).R().
+	client, err := createGeminiCliReqClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create HTTP client: %w", err)
+	}
+	resp, err := client.R().
 		SetContext(ctx).
 		SetHeader("Authorization", "Bearer "+accessToken).
 		SetHeader("Content-Type", "application/json").
@@ -98,7 +106,7 @@ func (c *geminiCliCodeAssistClient) OnboardUser(ctx context.Context, accessToken
 	return &out, nil
 }
 
-func createGeminiCliReqClient(proxyURL string) *req.Client {
+func createGeminiCliReqClient(proxyURL string) (*req.Client, error) {
 	return getSharedReqClient(reqClientOptions{
 		ProxyURL: proxyURL,
 		Timeout:  30 * time.Second,

--- a/backend/internal/repository/github_release_service.go
+++ b/backend/internal/repository/github_release_service.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
@@ -24,13 +26,19 @@ type githubReleaseClientError struct {
 
 // NewGitHubReleaseClient 创建 GitHub Release 客户端
 // proxyURL 为空时直连 GitHub，支持 http/https/socks5/socks5h 协议
+// 代理配置失败时行为由 allowDirectOnProxyError 控制：
+//   - false（默认）：返回错误占位客户端，禁止回退到直连
+//   - true：回退到直连（仅限管理员显式开启）
 func NewGitHubReleaseClient(proxyURL string, allowDirectOnProxyError bool) service.GitHubReleaseClient {
+	// 安全说明：httpclient.GetClient 的错误链（url.Parse / proxyutil）不含明文代理凭据，
+	// 但仍通过 slog 仅在服务端日志记录，不会暴露给 HTTP 响应。
 	sharedClient, err := httpclient.GetClient(httpclient.Options{
 		Timeout:  30 * time.Second,
 		ProxyURL: proxyURL,
 	})
 	if err != nil {
-		if proxyURL != "" && !allowDirectOnProxyError {
+		if strings.TrimSpace(proxyURL) != "" && !allowDirectOnProxyError {
+			slog.Warn("proxy client init failed, all requests will fail", "service", "github_release", "error", err)
 			return &githubReleaseClientError{err: fmt.Errorf("proxy client init failed and direct fallback is disabled; set security.proxy_fallback.allow_direct_on_error=true to allow fallback: %w", err)}
 		}
 		sharedClient = &http.Client{Timeout: 30 * time.Second}
@@ -42,7 +50,8 @@ func NewGitHubReleaseClient(proxyURL string, allowDirectOnProxyError bool) servi
 		ProxyURL: proxyURL,
 	})
 	if err != nil {
-		if proxyURL != "" && !allowDirectOnProxyError {
+		if strings.TrimSpace(proxyURL) != "" && !allowDirectOnProxyError {
+			slog.Warn("proxy download client init failed, all requests will fail", "service", "github_release", "error", err)
 			return &githubReleaseClientError{err: fmt.Errorf("proxy client init failed and direct fallback is disabled; set security.proxy_fallback.allow_direct_on_error=true to allow fallback: %w", err)}
 		}
 		downloadClient = &http.Client{Timeout: 10 * time.Minute}

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -235,7 +236,10 @@ func (s *httpUpstreamService) acquireClientWithTLS(proxyURL string, accountID in
 // TLS 指纹客户端使用独立的缓存键，与普通客户端隔离
 func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
 	isolation := s.getIsolationMode()
-	proxyKey, parsedProxy := normalizeProxyURL(proxyURL)
+	proxyKey, parsedProxy, err := normalizeProxyURL(proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	// TLS 指纹客户端使用独立的缓存键，加 "tls:" 前缀
 	cacheKey := "tls:" + buildCacheKey(isolation, proxyKey, accountID)
 	poolKey := s.buildPoolKey(isolation, accountConcurrency) + ":tls"
@@ -373,9 +377,8 @@ func (s *httpUpstreamService) acquireClient(proxyURL string, accountID int64, ac
 //   - proxy: 按代理地址隔离，同一代理共享客户端
 //   - account: 按账户隔离，同一账户共享客户端（代理变更时重建）
 //   - account_proxy: 按账户+代理组合隔离，最细粒度
-func (s *httpUpstreamService) getOrCreateClient(proxyURL string, accountID int64, accountConcurrency int) *upstreamClientEntry {
-	entry, _ := s.getClientEntry(proxyURL, accountID, accountConcurrency, false, false)
-	return entry
+func (s *httpUpstreamService) getOrCreateClient(proxyURL string, accountID int64, accountConcurrency int) (*upstreamClientEntry, error) {
+	return s.getClientEntry(proxyURL, accountID, accountConcurrency, false, false)
 }
 
 // getClientEntry 获取或创建客户端条目
@@ -385,7 +388,10 @@ func (s *httpUpstreamService) getClientEntry(proxyURL string, accountID int64, a
 	// 获取隔离模式
 	isolation := s.getIsolationMode()
 	// 标准化代理 URL 并解析
-	proxyKey, parsedProxy := normalizeProxyURL(proxyURL)
+	proxyKey, parsedProxy, err := normalizeProxyURL(proxyURL)
+	if err != nil {
+		return nil, err
+	}
 	// 构建缓存键（根据隔离策略不同）
 	cacheKey := buildCacheKey(isolation, proxyKey, accountID)
 	// 构建连接池配置键（用于检测配置变更）
@@ -680,17 +686,18 @@ func buildCacheKey(isolation, proxyKey string, accountID int64) string {
 //   - raw: 原始代理 URL 字符串
 //
 // 返回:
-//   - string: 标准化的代理键（空或解析失败返回 "direct"）
-//   - *url.URL: 解析后的 URL（空或解析失败返回 nil）
-func normalizeProxyURL(raw string) (string, *url.URL) {
-	proxyURL := strings.TrimSpace(raw)
-	if proxyURL == "" {
-		return directProxyKey, nil
-	}
-	parsed, err := url.Parse(proxyURL)
+//   - string: 标准化的代理键（空返回 "direct"）
+//   - *url.URL: 解析后的 URL（空返回 nil）
+//   - error: 非空代理 URL 解析失败时返回错误（禁止回退到直连）
+func normalizeProxyURL(raw string) (string, *url.URL, error) {
+	_, parsed, err := proxyurl.Parse(raw)
 	if err != nil {
-		return directProxyKey, nil
+		return "", nil, err
 	}
+	if parsed == nil {
+		return directProxyKey, nil, nil
+	}
+	// 规范化：小写 scheme/host，去除路径和查询参数
 	parsed.Scheme = strings.ToLower(parsed.Scheme)
 	parsed.Host = strings.ToLower(parsed.Host)
 	parsed.Path = ""
@@ -710,7 +717,7 @@ func normalizeProxyURL(raw string) (string, *url.URL) {
 			parsed.Host = hostname
 		}
 	}
-	return parsed.String(), parsed
+	return parsed.String(), parsed, nil
 }
 
 // defaultPoolSettings 获取默认连接池配置

--- a/backend/internal/repository/http_upstream_benchmark_test.go
+++ b/backend/internal/repository/http_upstream_benchmark_test.go
@@ -59,7 +59,10 @@ func BenchmarkHTTPUpstreamProxyClient(b *testing.B) {
 	// 模拟优化后的行为，从缓存获取客户端
 	b.Run("复用", func(b *testing.B) {
 		// 预热：确保客户端已缓存
-		entry := svc.getOrCreateClient(proxyURL, 1, 1)
+		entry, err := svc.getOrCreateClient(proxyURL, 1, 1)
+		if err != nil {
+			b.Fatalf("getOrCreateClient: %v", err)
+		}
 		client := entry.client
 		b.ResetTimer() // 重置计时器，排除预热时间
 		for i := 0; i < b.N; i++ {

--- a/backend/internal/repository/proxy_probe_service.go
+++ b/backend/internal/repository/proxy_probe_service.go
@@ -66,7 +66,6 @@ func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*s
 		ProxyURL:           proxyURL,
 		Timeout:            defaultProxyProbeTimeout,
 		InsecureSkipVerify: s.insecureSkipVerify,
-		ProxyStrict:        true,
 		ValidateResolvedIP: s.validateResolvedIP,
 		AllowPrivateHosts:  s.allowPrivateHosts,
 	})

--- a/backend/internal/repository/req_client_pool_test.go
+++ b/backend/internal/repository/req_client_pool_test.go
@@ -26,11 +26,13 @@ func TestGetSharedReqClient_ForceHTTP2SeparatesCache(t *testing.T) {
 		ProxyURL: "http://proxy.local:8080",
 		Timeout:  time.Second,
 	}
-	clientDefault := getSharedReqClient(base)
+	clientDefault, err := getSharedReqClient(base)
+	require.NoError(t, err)
 
 	force := base
 	force.ForceHTTP2 = true
-	clientForce := getSharedReqClient(force)
+	clientForce, err := getSharedReqClient(force)
+	require.NoError(t, err)
 
 	require.NotSame(t, clientDefault, clientForce)
 	require.NotEqual(t, buildReqClientKey(base), buildReqClientKey(force))
@@ -42,8 +44,10 @@ func TestGetSharedReqClient_ReuseCachedClient(t *testing.T) {
 		ProxyURL: "http://proxy.local:8080",
 		Timeout:  2 * time.Second,
 	}
-	first := getSharedReqClient(opts)
-	second := getSharedReqClient(opts)
+	first, err := getSharedReqClient(opts)
+	require.NoError(t, err)
+	second, err := getSharedReqClient(opts)
+	require.NoError(t, err)
 	require.Same(t, first, second)
 }
 
@@ -56,7 +60,8 @@ func TestGetSharedReqClient_IgnoresNonClientCache(t *testing.T) {
 	key := buildReqClientKey(opts)
 	sharedReqClients.Store(key, "invalid")
 
-	client := getSharedReqClient(opts)
+	client, err := getSharedReqClient(opts)
+	require.NoError(t, err)
 
 	require.NotNil(t, client)
 	loaded, ok := sharedReqClients.Load(key)
@@ -71,20 +76,45 @@ func TestGetSharedReqClient_ImpersonateAndProxy(t *testing.T) {
 		Timeout:     4 * time.Second,
 		Impersonate: true,
 	}
-	client := getSharedReqClient(opts)
+	client, err := getSharedReqClient(opts)
+	require.NoError(t, err)
 
 	require.NotNil(t, client)
 	require.Equal(t, "http://proxy.local:8080|4s|true|false", buildReqClientKey(opts))
 }
 
+func TestGetSharedReqClient_InvalidProxyURL(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	opts := reqClientOptions{
+		ProxyURL: "://missing-scheme",
+		Timeout:  time.Second,
+	}
+	_, err := getSharedReqClient(opts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid proxy URL")
+}
+
+func TestGetSharedReqClient_ProxyURLMissingHost(t *testing.T) {
+	sharedReqClients = sync.Map{}
+	opts := reqClientOptions{
+		ProxyURL: "http://",
+		Timeout:  time.Second,
+	}
+	_, err := getSharedReqClient(opts)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "proxy URL missing host")
+}
+
 func TestCreateOpenAIReqClient_Timeout120Seconds(t *testing.T) {
 	sharedReqClients = sync.Map{}
-	client := createOpenAIReqClient("http://proxy.local:8080")
+	client, err := createOpenAIReqClient("http://proxy.local:8080")
+	require.NoError(t, err)
 	require.Equal(t, 120*time.Second, client.GetClient().Timeout)
 }
 
 func TestCreateGeminiReqClient_ForceHTTP2Disabled(t *testing.T) {
 	sharedReqClients = sync.Map{}
-	client := createGeminiReqClient("http://proxy.local:8080")
+	client, err := createGeminiReqClient("http://proxy.local:8080")
+	require.NoError(t, err)
 	require.Equal(t, "", forceHTTPVersion(t, client))
 }

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -34,7 +34,7 @@ func ProvideGitHubReleaseClient(cfg *config.Config) service.GitHubReleaseClient 
 // ProvidePricingRemoteClient 创建定价数据远程客户端
 // 从配置中读取代理设置，支持国内服务器通过代理访问 GitHub 上的定价数据
 func ProvidePricingRemoteClient(cfg *config.Config) service.PricingRemoteClient {
-	return NewPricingRemoteClient(cfg.Update.ProxyURL)
+	return NewPricingRemoteClient(cfg.Update.ProxyURL, cfg.Security.ProxyFallback.AllowDirectOnError)
 }
 
 // ProvideSessionLimitCache 创建会话限制缓存

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2028,7 +2028,6 @@ func (s *adminServiceImpl) CheckProxyQuality(ctx context.Context, id int64) (*Pr
 		ProxyURL:              proxyURL,
 		Timeout:               proxyQualityRequestTimeout,
 		ResponseHeaderTimeout: proxyQualityResponseHeaderTimeout,
-		ProxyStrict:           true,
 	})
 	if err != nil {
 		result.Items = append(result.Items, ProxyQualityCheckItem{

--- a/backend/internal/service/antigravity_oauth_service.go
+++ b/backend/internal/service/antigravity_oauth_service.go
@@ -112,7 +112,10 @@ func (s *AntigravityOAuthService) ExchangeCode(ctx context.Context, input *Antig
 		}
 	}
 
-	client := antigravity.NewClient(proxyURL)
+	client, err := antigravity.NewClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create antigravity client failed: %w", err)
+	}
 
 	// 交换 token
 	tokenResp, err := client.ExchangeCode(ctx, input.Code, session.CodeVerifier)
@@ -167,7 +170,10 @@ func (s *AntigravityOAuthService) RefreshToken(ctx context.Context, refreshToken
 			time.Sleep(backoff)
 		}
 
-		client := antigravity.NewClient(proxyURL)
+		client, err := antigravity.NewClient(proxyURL)
+		if err != nil {
+			return nil, fmt.Errorf("create antigravity client failed: %w", err)
+		}
 		tokenResp, err := client.RefreshToken(ctx, refreshToken)
 		if err == nil {
 			now := time.Now()
@@ -209,7 +215,10 @@ func (s *AntigravityOAuthService) ValidateRefreshToken(ctx context.Context, refr
 	}
 
 	// 获取用户信息（email）
-	client := antigravity.NewClient(proxyURL)
+	client, err := antigravity.NewClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create antigravity client failed: %w", err)
+	}
 	userInfo, err := client.GetUserInfo(ctx, tokenInfo.AccessToken)
 	if err != nil {
 		fmt.Printf("[AntigravityOAuth] 警告: 获取用户信息失败: %v\n", err)
@@ -309,7 +318,10 @@ func (s *AntigravityOAuthService) loadProjectIDWithRetry(ctx context.Context, ac
 			time.Sleep(backoff)
 		}
 
-		client := antigravity.NewClient(proxyURL)
+		client, err := antigravity.NewClient(proxyURL)
+		if err != nil {
+			return "", fmt.Errorf("create antigravity client failed: %w", err)
+		}
 		loadResp, loadRaw, err := client.LoadCodeAssist(ctx, accessToken)
 
 		if err == nil && loadResp != nil && loadResp.CloudAICompanionProject != "" {

--- a/backend/internal/service/antigravity_quota_fetcher.go
+++ b/backend/internal/service/antigravity_quota_fetcher.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
@@ -31,7 +32,10 @@ func (f *AntigravityQuotaFetcher) FetchQuota(ctx context.Context, account *Accou
 	accessToken := account.GetCredential("access_token")
 	projectID := account.GetCredential("project_id")
 
-	client := antigravity.NewClient(proxyURL)
+	client, err := antigravity.NewClient(proxyURL)
+	if err != nil {
+		return nil, fmt.Errorf("create antigravity client failed: %w", err)
+	}
 
 	// 调用 API 获取配额
 	modelsResp, modelsRaw, err := client.FetchAvailableModels(ctx, accessToken, projectID)

--- a/backend/internal/service/crs_sync_service.go
+++ b/backend/internal/service/crs_sync_service.go
@@ -221,7 +221,7 @@ func (s *CRSSyncService) fetchCRSExport(ctx context.Context, baseURL, username, 
 		AllowPrivateHosts:  s.cfg.Security.URLAllowlist.AllowPrivateHosts,
 	})
 	if err != nil {
-		client = &http.Client{Timeout: 20 * time.Second}
+		return nil, fmt.Errorf("create http client failed: %w", err)
 	}
 
 	adminToken, err := crsLogin(ctx, client, normalizedURL, username, password)

--- a/backend/internal/service/gemini_oauth_service.go
+++ b/backend/internal/service/gemini_oauth_service.go
@@ -1045,7 +1045,7 @@ func fetchProjectIDFromResourceManager(ctx context.Context, accessToken, proxyUR
 		ValidateResolvedIP: true,
 	})
 	if err != nil {
-		client = &http.Client{Timeout: 30 * time.Second}
+		return "", fmt.Errorf("create http client failed: %w", err)
 	}
 
 	resp, err := client.Do(req)

--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 )
 
@@ -273,7 +273,13 @@ func (s *OpenAIOAuthService) ExchangeSoraSessionToken(ctx context.Context, sessi
 	req.Header.Set("Referer", "https://sora.chatgpt.com/")
 	req.Header.Set("User-Agent", "Sora/1.2026.007 (Android 15; 24122RKC7C; build 2600700)")
 
-	client := newOpenAIOAuthHTTPClient(proxyURL)
+	client, err := httpclient.GetClient(httpclient.Options{
+		ProxyURL: proxyURL,
+		Timeout:  120 * time.Second,
+	})
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "SORA_SESSION_CLIENT_FAILED", "create http client failed: %v", err)
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusBadGateway, "SORA_SESSION_REQUEST_FAILED", "request failed: %v", err)
@@ -528,19 +534,6 @@ func (s *OpenAIOAuthService) resolveProxyURL(ctx context.Context, proxyID *int64
 		return "", nil
 	}
 	return proxy.URL(), nil
-}
-
-func newOpenAIOAuthHTTPClient(proxyURL string) *http.Client {
-	transport := &http.Transport{}
-	if strings.TrimSpace(proxyURL) != "" {
-		if parsed, err := url.Parse(proxyURL); err == nil && parsed.Host != "" {
-			transport.Proxy = http.ProxyURL(parsed)
-		}
-	}
-	return &http.Client{
-		Timeout:   120 * time.Second,
-		Transport: transport,
-	}
 }
 
 func normalizeOpenAIOAuthPlatform(platform string) string {

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -134,6 +134,12 @@ security:
     # Allow skipping TLS verification for proxy probe (debug only)
     # 允许代理探测时跳过 TLS 证书验证（仅用于调试）
     insecure_skip_verify: false
+  proxy_fallback:
+    # Allow auxiliary services (update check, pricing data) to fallback to direct
+    # connection when proxy initialization fails. Does NOT affect AI gateway connections.
+    # 辅助服务（更新检查、定价数据拉取）代理初始化失败时是否允许回退直连。
+    # 不影响 AI 账号网关连接。默认 false：fail-fast 防止 IP 泄露。
+    allow_direct_on_error: false
 
 # =============================================================================
 # Gateway Configuration


### PR DESCRIPTION
提取 proxyurl.Parse() 公共包，将分散在 6 处的代理 URL 验证逻辑
统一收敛，确保无效代理配置在创建时立即失败，永不静默回退直连。

主要变更：
- 新增 proxyurl 包：统一 TrimSpace → url.Parse → Host 校验 → Scheme 白名单
- socks5:// 自动升级为 socks5h://，防止 DNS 泄漏（大小写不敏感）
- antigravity: http.ProxyURL → proxyutil.ConfigureTransportProxy 支持 SOCKS5
- openai_oauth: 删除 newOpenAIOAuthHTTPClient，收编至 httpclient.GetClient
- 移除未使用的 ProxyStrict 字段（fail-fast 已是全局默认行为）
- 补充 15 个 proxyurl 测试 + pricing/usage fail-fast 测试