### PR TITLE
fix(frontend): admin custom menu items not showing in sidebar

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -579,7 +579,7 @@ const customMenuItemsForUser = computed(() => {
 })
 
 const customMenuItemsForAdmin = computed(() => {
-  const items = appStore.cachedPublicSettings?.custom_menu_items ?? []
+  const items = adminSettingsStore.customMenuItems ?? []
   return items
     .filter((item) => item.visibility === 'admin')
     .sort((a, b) => a.sort_order - b.sort_order)

--- a/frontend/src/stores/adminSettings.ts
+++ b/frontend/src/stores/adminSettings.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { adminAPI } from '@/api'
+import type { CustomMenuItem } from '@/types'
 
 export const useAdminSettingsStore = defineStore('adminSettings', () => {
   const loaded = ref(false)
@@ -43,6 +44,9 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
     }
   }
 
+  // Custom menu items (all items including admin-only, loaded from admin settings API)
+  const customMenuItems = ref<CustomMenuItem[]>([])
+
   // Default open, but honor cached value to reduce UI flicker on first paint.
   const opsMonitoringEnabled = ref(readCachedBool('ops_monitoring_enabled_cached', true))
   const opsRealtimeMonitoringEnabled = ref(readCachedBool('ops_realtime_monitoring_enabled_cached', true))
@@ -63,6 +67,8 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
 
       opsQueryModeDefault.value = settings.ops_query_mode_default || 'auto'
       writeCachedString('ops_query_mode_default_cached', opsQueryModeDefault.value)
+
+      customMenuItems.value = settings.custom_menu_items ?? []
 
       loaded.value = true
     } catch (err) {
@@ -122,6 +128,7 @@ export const useAdminSettingsStore = defineStore('adminSettings', () => {
     opsMonitoringEnabled,
     opsRealtimeMonitoringEnabled,
     opsQueryModeDefault,
+    customMenuItems,
     fetch,
     setOpsMonitoringEnabledLocal,
     setOpsRealtimeMonitoringEnabledLocal,

--- a/frontend/src/views/user/CustomPageView.vue
+++ b/frontend/src/views/user/CustomPageView.vue
@@ -70,6 +70,7 @@ import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores'
 import { useAuthStore } from '@/stores/auth'
+import { useAdminSettingsStore } from '@/stores/adminSettings'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildEmbeddedUrl, detectTheme } from '@/utils/embedded-url'
@@ -78,6 +79,7 @@ const { t } = useI18n()
 const route = useRoute()
 const appStore = useAppStore()
 const authStore = useAuthStore()
+const adminSettingsStore = useAdminSettingsStore()
 
 const loading = ref(false)
 const pageTheme = ref<'light' | 'dark'>('light')
@@ -86,8 +88,15 @@ let themeObserver: MutationObserver | null = null
 const menuItemId = computed(() => route.params.id as string)
 
 const menuItem = computed(() => {
-  const items = appStore.cachedPublicSettings?.custom_menu_items ?? []
-  const found = items.find((item) => item.id === menuItemId.value) ?? null
+  const publicItems = appStore.cachedPublicSettings?.custom_menu_items ?? []
+  const adminItems = authStore.isAdmin ? (adminSettingsStore.customMenuItems ?? []) : []
+  const allItems = [...publicItems]
+  for (const item of adminItems) {
+    if (!allItems.some((existing) => existing.id === item.id)) {
+      allItems.push(item)
+    }
+  }
+  const found = allItems.find((item) => item.id === menuItemId.value) ?? null
   if (found && found.visibility === 'admin' && !authStore.isAdmin) {
     return null
   }
@@ -122,12 +131,20 @@ onMounted(async () => {
     })
   }
 
-  if (appStore.publicSettingsLoaded) return
-  loading.value = true
-  try {
-    await appStore.fetchPublicSettings()
-  } finally {
-    loading.value = false
+  const promises: Promise<unknown>[] = []
+  if (!appStore.publicSettingsLoaded) {
+    promises.push(appStore.fetchPublicSettings())
+  }
+  if (authStore.isAdmin) {
+    promises.push(adminSettingsStore.fetch())
+  }
+  if (promises.length > 0) {
+    loading.value = true
+    try {
+      await Promise.all(promises)
+    } finally {
+      loading.value = false
+    }
   }
 })
 


### PR DESCRIPTION
## 背景 / Background

自定义菜单功能（#727）合并后，公开设置 API（`/api/v1/settings/public`）在服务端过滤掉了 `visibility='admin'` 的菜单项。但前端侧边栏的管理员菜单仍然从公开 API 数据中读取，导致管理员菜单项永远为空。

After the custom menu feature (#727) was merged, the public settings API (`/api/v1/settings/public`) filters out menu items with `visibility='admin'` on the server side. However, the frontend sidebar still reads admin menu items from the public API data, causing admin menu items to never appear.

---

## 目的 / Purpose

修复管理员自定义菜单项在侧边栏中不显示的问题。管理员菜单项应从管理员设置 API 获取（该接口返回全量数据，不过滤）。

Fix admin custom menu items not showing in the sidebar. Admin menu items should be loaded from the admin settings API, which returns all items without filtering.

---

## 改动内容 / Changes

### 前端 / Frontend

- **adminSettings store**：在 `fetch` 中存储 `custom_menu_items`，并导出 `customMenuItems` 供侧边栏使用
- **AppSidebar.vue**：`customMenuItemsForAdmin` 改为从 `adminSettingsStore.customMenuItems` 读取，而非从 `cachedPublicSettings` 读取
- **CustomPageView.vue**：管理员访问自定义页面时，合并公开和管理员菜单项进行查找，确保 admin-only 页面不会 404

---

- **adminSettings store**: Store `custom_menu_items` in `fetch` and export `customMenuItems` for sidebar use
- **AppSidebar.vue**: Read `customMenuItemsForAdmin` from `adminSettingsStore.customMenuItems` instead of `cachedPublicSettings`
- **CustomPageView.vue**: Merge public and admin menu items when admin users access custom pages, preventing 404 on admin-only pages