### PR TITLE
fix(migrations): 061 迁移改为限时分批回填，避免启动阻塞导致 502

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -66,6 +66,12 @@ var migrationChecksumCompatibilityRules = map[string]migrationChecksumCompatibil
 			"182c193f3359946cf094090cd9e57d5c3fd9abaffbc1e8fc378646b8a6fa12b4": {},
 		},
 	},
+	"061_add_usage_log_request_type.sql": {
+		fileChecksum: "97bdd9a32d921986f74a0231ab90735567a9234fb7062f4d9d1baf108ba59769",
+		acceptedDBChecksum: map[string]struct{}{
+			"08a248652cbab7cfde147fc6ef8cda464f2477674e20b718312faa252e0481c0": {},
+		},
+	},
 }
 
 // ApplyMigrations 将嵌入的 SQL 迁移文件应用到指定的数据库。

--- a/backend/internal/repository/migrations_runner_checksum_test.go
+++ b/backend/internal/repository/migrations_runner_checksum_test.go
@@ -25,6 +25,15 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 		require.False(t, ok)
 	})
 
+	t.Run("061历史checksum可兼容", func(t *testing.T) {
+		ok := isMigrationChecksumCompatible(
+			"061_add_usage_log_request_type.sql",
+			"08a248652cbab7cfde147fc6ef8cda464f2477674e20b718312faa252e0481c0",
+			"97bdd9a32d921986f74a0231ab90735567a9234fb7062f4d9d1baf108ba59769",
+		)
+		require.True(t, ok)
+	})
+
 	t.Run("非白名单迁移不兼容", func(t *testing.T) {
 		ok := isMigrationChecksumCompatible(
 			"001_init.sql",

--- a/backend/migrations/061_add_usage_log_request_type.sql
+++ b/backend/migrations/061_add_usage_log_request_type.sql
@@ -19,11 +19,47 @@ $$;
 CREATE INDEX IF NOT EXISTS idx_usage_logs_request_type_created_at
     ON usage_logs (request_type, created_at);
 
--- Backfill from legacy fields. openai_ws_mode has higher priority than stream.
-UPDATE usage_logs
-SET request_type = CASE
-    WHEN openai_ws_mode = TRUE THEN 3
-    WHEN stream = TRUE THEN 2
-    ELSE 1
+-- Backfill from legacy fields in bounded batches.
+-- Why bounded:
+-- 1) Full-table UPDATE on large usage_logs can block startup for a long time.
+-- 2) request_type=0 rows remain query-compatible via legacy fallback logic
+--    (stream/openai_ws_mode) in repository filters.
+-- 3) Subsequent writes will use explicit request_type and gradually dilute
+--    historical unknown rows.
+--
+-- openai_ws_mode has higher priority than stream.
+DO $$
+DECLARE
+    v_rows         INTEGER := 0;
+    v_total_rows   INTEGER := 0;
+    v_batch_size   INTEGER := 5000;
+    v_started_at   TIMESTAMPTZ := clock_timestamp();
+    v_max_duration INTERVAL := INTERVAL '8 seconds';
+BEGIN
+    LOOP
+        WITH batch AS (
+            SELECT id
+            FROM usage_logs
+            WHERE request_type = 0
+            ORDER BY id
+            LIMIT v_batch_size
+        )
+        UPDATE usage_logs ul
+        SET request_type = CASE
+            WHEN ul.openai_ws_mode = TRUE THEN 3
+            WHEN ul.stream = TRUE THEN 2
+            ELSE 1
+        END
+        FROM batch
+        WHERE ul.id = batch.id;
+
+        GET DIAGNOSTICS v_rows = ROW_COUNT;
+        EXIT WHEN v_rows = 0;
+
+        v_total_rows := v_total_rows + v_rows;
+        EXIT WHEN clock_timestamp() - v_started_at >= v_max_duration;
+    END LOOP;
+
+    RAISE NOTICE 'usage_logs.request_type startup backfill rows=%', v_total_rows;
 END
-WHERE request_type = 0;
+$$;


### PR DESCRIPTION
## 本次问题背景
- 线上在自动更新后，启动阶段执行 61_add_usage_log_request_type.sql。
- 原 SQL 含一次性全表回填：UPDATE usage_logs ... WHERE request_type = 0。
- 在大数据量场景会长时间占用/阻塞，导致应用端口迟迟不可用，外部表现为 Nginx 502。

## 本 PR 改动
1. 将 061 迁移中的全表回填改为“限时 + 分批”回填循环。
   - 每批 LIMIT 5000
   - 单次启动最多执行约 8 秒
   - 避免启动阶段长时间阻塞
2. 保持兼容性：
   - 现有查询侧已对 
equest_type=0 做 legacy 回退（stream/openai_ws_mode），因此未回填完也不会漏查。
3. 增加 checksum 兼容规则：
   - 为 61_add_usage_log_request_type.sql 增加历史 checksum 白名单兼容，避免已部署实例在文件更新后因 checksum mismatch 启动失败。
4. 补充对应单测用例。

## 影响与收益
- 避免大表迁移在启动路径造成长时间不可用。
- 保留历史部署的 checksum 兼容性，降低升级失败风险。
- 回填改为渐进式，整体可用性优先。

## 风险说明
- equest_type=0 的历史数据不会在一次启动内全部完成回填（这是设计目标）。
- 但查询兼容逻辑已覆盖，不影响功能正确性。