### PR TITLE
perf(admin): 优化 Dashboard 大数据量加载（预聚合趋势+异步用户趋势）

### DIFF
--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -1655,6 +1655,13 @@ func (r *usageLogRepository) GetBatchAPIKeyUsageStats(ctx context.Context, apiKe
 
 // GetUsageTrendWithFilters returns usage trend data with optional filters
 func (r *usageLogRepository) GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, requestType *int16, stream *bool, billingType *int8) (results []TrendDataPoint, err error) {
+	if shouldUsePreaggregatedTrend(granularity, userID, apiKeyID, accountID, groupID, model, requestType, stream, billingType) {
+		aggregated, aggregatedErr := r.getUsageTrendFromAggregates(ctx, startTime, endTime, granularity)
+		if aggregatedErr == nil && len(aggregated) > 0 {
+			return aggregated, nil
+		}
+	}
+
 	dateFormat := safeDateFormat(granularity)
 
 	query := fmt.Sprintf(`
@@ -1706,6 +1713,78 @@ func (r *usageLogRepository) GetUsageTrendWithFilters(ctx context.Context, start
 	defer func() {
 		// 保持主错误优先；仅在无错误时回传 Close 失败。
 		// 同时清空返回值，避免误用不完整结果。
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+			results = nil
+		}
+	}()
+
+	results, err = scanTrendRows(rows)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func shouldUsePreaggregatedTrend(granularity string, userID, apiKeyID, accountID, groupID int64, model string, requestType *int16, stream *bool, billingType *int8) bool {
+	if granularity != "day" && granularity != "hour" {
+		return false
+	}
+	return userID == 0 &&
+		apiKeyID == 0 &&
+		accountID == 0 &&
+		groupID == 0 &&
+		model == "" &&
+		requestType == nil &&
+		stream == nil &&
+		billingType == nil
+}
+
+func (r *usageLogRepository) getUsageTrendFromAggregates(ctx context.Context, startTime, endTime time.Time, granularity string) (results []TrendDataPoint, err error) {
+	dateFormat := safeDateFormat(granularity)
+	query := ""
+	args := []any{startTime, endTime}
+
+	switch granularity {
+	case "hour":
+		query = fmt.Sprintf(`
+			SELECT
+				TO_CHAR(bucket_start, '%s') as date,
+				total_requests as requests,
+				input_tokens,
+				output_tokens,
+				(cache_creation_tokens + cache_read_tokens) as cache_tokens,
+				(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens) as total_tokens,
+				total_cost as cost,
+				actual_cost
+			FROM usage_dashboard_hourly
+			WHERE bucket_start >= $1 AND bucket_start < $2
+			ORDER BY bucket_start ASC
+		`, dateFormat)
+	case "day":
+		query = fmt.Sprintf(`
+			SELECT
+				TO_CHAR(bucket_date::timestamp, '%s') as date,
+				total_requests as requests,
+				input_tokens,
+				output_tokens,
+				(cache_creation_tokens + cache_read_tokens) as cache_tokens,
+				(input_tokens + output_tokens + cache_creation_tokens + cache_read_tokens) as total_tokens,
+				total_cost as cost,
+				actual_cost
+			FROM usage_dashboard_daily
+			WHERE bucket_date >= $1::date AND bucket_date < $2::date
+			ORDER BY bucket_date ASC
+		`, dateFormat)
+	default:
+		return nil, nil
+	}
+
+	rows, err := r.sql.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
 		if closeErr := rows.Close(); closeErr != nil && err == nil {
 			err = closeErr
 			results = nil

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -246,7 +246,10 @@
               {{ t('admin.dashboard.recentUsage') }} (Top 12)
             </h3>
             <div class="h-64">
-              <Line v-if="userTrendChartData" :data="userTrendChartData" :options="lineOptions" />
+              <div v-if="userTrendLoading" class="flex h-full items-center justify-center">
+                <LoadingSpinner size="md" />
+              </div>
+              <Line v-else-if="userTrendChartData" :data="userTrendChartData" :options="lineOptions" />
               <div
                 v-else
                 class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400"
@@ -306,11 +309,13 @@ const appStore = useAppStore()
 const stats = ref<DashboardStats | null>(null)
 const loading = ref(false)
 const chartsLoading = ref(false)
+const userTrendLoading = ref(false)
 
 // Chart data
 const trendData = ref<TrendDataPoint[]>([])
 const modelStats = ref<ModelStat[]>([])
 const userTrend = ref<UserUsageTrendPoint[]>([])
+let chartLoadSeq = 0
 
 // Helper function to format date in local timezone
 const formatLocalDate = (date: Date): string => {
@@ -531,7 +536,9 @@ const loadDashboardStats = async () => {
 }
 
 const loadChartData = async () => {
+  const currentSeq = ++chartLoadSeq
   chartsLoading.value = true
+  userTrendLoading.value = true
   try {
     const params = {
       start_date: startDate.value,
@@ -539,19 +546,38 @@ const loadChartData = async () => {
       granularity: granularity.value
     }
 
-    const [trendResponse, modelResponse, userResponse] = await Promise.all([
+    const [trendResponse, modelResponse] = await Promise.all([
       adminAPI.dashboard.getUsageTrend(params),
-      adminAPI.dashboard.getModelStats({ start_date: startDate.value, end_date: endDate.value }),
-      adminAPI.dashboard.getUserUsageTrend({ ...params, limit: 12 })
+      adminAPI.dashboard.getModelStats({ start_date: startDate.value, end_date: endDate.value })
     ])
 
+    if (currentSeq !== chartLoadSeq) return
     trendData.value = trendResponse.trend || []
     modelStats.value = modelResponse.models || []
-    userTrend.value = userResponse.trend || []
   } catch (error) {
+    if (currentSeq !== chartLoadSeq) return
     console.error('Error loading chart data:', error)
   } finally {
+    if (currentSeq !== chartLoadSeq) return
     chartsLoading.value = false
+  }
+
+  try {
+    const params = {
+      start_date: startDate.value,
+      end_date: endDate.value,
+      granularity: granularity.value,
+      limit: 12
+    }
+    const userResponse = await adminAPI.dashboard.getUserUsageTrend(params)
+    if (currentSeq !== chartLoadSeq) return
+    userTrend.value = userResponse.trend || []
+  } catch (error) {
+    if (currentSeq !== chartLoadSeq) return
+    console.error('Error loading user trend:', error)
+  } finally {
+    if (currentSeq !== chartLoadSeq) return
+    userTrendLoading.value = false
   }
 }
 


### PR DESCRIPTION
## 背景

线上 Admin Dashboard 在数据量上来后（当前 `usage_logs` 约 `4,299,693` 行，约 `4.3GB`）出现明显首屏卡顿。  
页面首屏会加载以下三块核心数据：

1. Token 使用趋势（`/admin/dashboard/trend`）
2. 模型分布（`/admin/dashboard/models`）
3. 最近使用 Top12 用户趋势（`/admin/dashboard/users-trend`）

在 7 天窗口下，最慢链路会拖住整页可用时间。

## 根因分析

1. `trend` 默认走 `usage_logs` 原始大表聚合，按日期分组触发大规模扫描与排序。
2. 前端使用 `Promise.all` 同步等待 3 个图表接口，任何一个慢都会阻塞首屏。
3. 当前 `usage_logs` 不是分区表，时间窗口聚合随数据量增长开销显著上升。

## 方案概述

### 后端（查询路径优化）
在“无筛选条件”的 `trend` 查询场景，优先读取预聚合表：

- `granularity=day` -> `usage_dashboard_daily`
- `granularity=hour` -> `usage_dashboard_hourly`

若预聚合读取失败或无数据，再回退原有 `usage_logs` 查询逻辑，确保兼容性与正确性。

### 前端（加载时序优化）
将 `users-trend` 从阻塞式并发中拆出，改为两阶段加载：

1. 先并发请求 `trend + models`，尽快渲染首屏主图
2. 再异步请求 `users-trend`，独立 loading 展示

并增加请求序列号保护，避免快速切换时间范围时旧请求回写覆盖新数据（竞态问题）。

## 代码变更

### Backend
- `backend/internal/repository/usage_log_repo.go`
- 新增 `shouldUsePreaggregatedTrend(...)`
- 新增 `getUsageTrendFromAggregates(...)`
- 在 `GetUsageTrendWithFilters(...)` 内接入“预聚合优先 + 回退原查询”

### Frontend
- `frontend/src/views/admin/DashboardView.vue`
- 新增 `userTrendLoading`
- `loadChartData` 改为两阶段加载
- 新增 `chartLoadSeq` 竞态保护
- 用户趋势图区域增加独立 loading 态

## 性能对比（线上实测）

数据窗口：最近 7 天

- `trend`（原始大表）`EXPLAIN ANALYZE`：约 `7.45s`
- `users-trend`：约 `2.48s`
- `models`：约 `0.93s`
- `trend`（预聚合表）`EXPLAIN ANALYZE`：约 `0.34ms`

结论：`trend` 链路从秒级降到毫秒级，首屏主图可显著提前可见。

## 兼容性说明

1. 不改 API 协议，不改响应结构。
2. 仅优化查询路径和前端加载时序。
3. 预聚合不可用时自动回退旧逻辑，不影响功能可用性。

## 验证

1. 前端类型检查通过  
   - `pnpm typecheck`
2. Go 单测通过（Docker `golang:1.25`）  
   - `go test ./internal/service -run TestDashboardService_CacheHitFresh -count=1`

## 风险与回滚

### 风险
1. 预聚合延迟可能导致趋势数据“轻微滞后”（取决于聚合作业水位）。
2. `users-trend` 后置加载后，用户趋势图会稍后出现（主图先出现）。

### 回滚
1. 回滚本 PR 两个文件即可恢复旧行为。
2. 若仅需临时回退体验，可先恢复前端并发策略。
3. 若仅需回退查询策略，可移除后端预聚合优先逻辑。