### PR TITLE
fix: add dark theme support for "open in new tab" FAB button

### DIFF
--- a/frontend/src/views/user/CustomPageView.vue
+++ b/frontend/src/views/user/CustomPageView.vue
@@ -160,7 +160,7 @@ onUnmounted(() => {
 
 .custom-open-fab {
   @apply absolute right-3 top-3 z-10;
-  @apply shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/80;
+  @apply shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/80 dark:supports-[backdrop-filter]:bg-dark-800/80;
 }
 
 .custom-embed-frame {

--- a/frontend/src/views/user/PurchaseSubscriptionView.vue
+++ b/frontend/src/views/user/PurchaseSubscriptionView.vue
@@ -143,7 +143,7 @@ onUnmounted(() => {
 
 .purchase-open-fab {
   @apply absolute right-3 top-3 z-10;
-  @apply shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/80;
+  @apply shadow-sm backdrop-blur supports-[backdrop-filter]:bg-white/80 dark:supports-[backdrop-filter]:bg-dark-800/80;
 }
 
 .purchase-embed-frame {


### PR DESCRIPTION
## 背景 / Background

iframe 嵌入页面（充值/订阅、自定义页面）右上角的"新窗口打开"悬浮按钮使用了 `supports-[backdrop-filter]:bg-white/80` 作为毛玻璃背景，但没有暗色主题适配，导致暗色主题下按钮背景仍为白色半透明，与整体深色界面不协调。

The "open in new tab" floating action button on iframe embed pages (Purchase/Subscription and Custom Page) uses `supports-[backdrop-filter]:bg-white/80` for the backdrop-blur background but lacks a dark theme variant, causing the button to appear with a white background in dark mode.

---

## 目的 / Purpose

为"新窗口打开"按钮添加暗色主题背景色适配，使其在暗色主题下与整体界面风格一致。

Add dark theme background support for the "open in new tab" FAB button so it blends properly with the dark theme.

---

## 改动内容 / Changes

### 前端 / Frontend

- **PurchaseSubscriptionView.vue**：`.purchase-open-fab` 添加 `dark:supports-[backdrop-filter]:bg-dark-800/80`
- **CustomPageView.vue**：`.custom-open-fab` 添加 `dark:supports-[backdrop-filter]:bg-dark-800/80`

---

- **PurchaseSubscriptionView.vue**: Added `dark:supports-[backdrop-filter]:bg-dark-800/80` to `.purchase-open-fab`
- **CustomPageView.vue**: Added `dark:supports-[backdrop-filter]:bg-dark-800/80` to `.custom-open-fab`