### PR TITLE
fix: extend RewriteUserID regex to match user_id containing account_uuid

### DIFF
--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -19,8 +19,10 @@ import (
 
 // 预编译正则表达式（避免每次调用重新编译）
 var (
-	// 匹配 user_id 格式: user_{64位hex}_account__session_{uuid}
-	userIDRegex = regexp.MustCompile(`^user_[a-f0-9]{64}_account__session_([a-f0-9-]{36})$`)
+	// 匹配 user_id 格式:
+	//   旧格式: user_{64位hex}_account__session_{uuid}        (account 后无 UUID)
+	//   新格式: user_{64位hex}_account_{uuid}_session_{uuid}  (account 后有 UUID)
+	userIDRegex = regexp.MustCompile(`^user_[a-f0-9]{64}_account_([a-f0-9-]*)_session_([a-f0-9-]{36})$`)
 	// 匹配 User-Agent 版本号: xxx/x.y.z
 	userAgentVersionRegex = regexp.MustCompile(`/(\d+)\.(\d+)\.(\d+)`)
 )
@@ -239,13 +241,16 @@ func (s *IdentityService) RewriteUserID(body []byte, accountID int64, accountUUI
 		return body, nil
 	}
 
-	// 匹配格式: user_{64位hex}_account__session_{uuid}
+	// 匹配格式:
+	//   旧格式: user_{64位hex}_account__session_{uuid}
+	//   新格式: user_{64位hex}_account_{uuid}_session_{uuid}
 	matches := userIDRegex.FindStringSubmatch(userID)
 	if matches == nil {
 		return body, nil
 	}
 
-	sessionTail := matches[1] // 原始session UUID
+	// matches[1] = account UUID (可能为空), matches[2] = session UUID
+	sessionTail := matches[2] // 原始session UUID
 
 	// 生成新的session hash: SHA256(accountID::sessionTail) -> UUID格式
 	seed := fmt.Sprintf("%d::%s", accountID, sessionTail)


### PR DESCRIPTION
## Summary

- `RewriteUserID` 的正则 `account__session_` 只匹配旧格式（account 后无 UUID），无法匹配含 `account_uuid` 的新格式 `account_{uuid}_session_`
- 当中间网关改写了 `User-Agent` 导致 `mimicClaudeCode = true` 时，真实 Claude Code 客户端的 `metadata.user_id`（含真实 account UUID）不会被重写，原样泄露至上游，造成 token 与 user_id 身份不匹配，触发账户封禁
- 扩展正则为 `account_([a-f0-9-]*)_session_`，同时兼容新旧两种格式，并更新捕获组索引

## Changes

仅修改 `backend/internal/service/identity_service.go`：

1. **正则扩展**：`^user_[a-f0-9]{64}_account__session_([a-f0-9-]{36})$` → `^user_[a-f0-9]{64}_account_([a-f0-9-]*)_session_([a-f0-9-]{36})$`
2. **捕获组更新**：`matches[1]`（session）→ `matches[2]`（session），`matches[1]` 现为 account UUID（可为空）

## Test plan

- [x] 正则验证：旧格式（`account__session_`）匹配 ✅，account_uuid 为空
- [x] 正则验证：新格式（`account_{uuid}_session_`）匹配 ✅，正确提取 account_uuid 和 session
- [x] 正则验证：非法格式不匹配 ✅
- [x] `go build ./...` 编译通过

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)