### PR TITLE
fix: pass through upstream HTTP status in usage API errors

### DIFF
--- a/backend/internal/repository/claude_usage_service.go
+++ b/backend/internal/repository/claude_usage_service.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -95,7 +96,8 @@ func (s *claudeUsageService) FetchUsageWithOptions(ctx context.Context, opts *se
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("API returned status %d: %s", resp.StatusCode, string(body))
+		msg := fmt.Sprintf("API returned status %d: %s", resp.StatusCode, string(body))
+		return nil, infraerrors.New(http.StatusInternalServerError, "UPSTREAM_ERROR", msg)
 	}
 
 	var usageResp service.ClaudeUsageResponse


### PR DESCRIPTION
## 背景 / Background

管理后台账号列表页面同时查询多个账号的用量信息时，Anthropic API 返回 429 Rate Limited，但系统返回给前端的是 500 Internal Error，导致用量窗口显示"错误"。

When the admin account list page queries usage for multiple accounts concurrently, the Anthropic API returns 429 Rate Limited, but the system returns 500 Internal Error to the frontend, causing usage windows to display "error".

---

## 目的 / Purpose

将上游 API 的实际 HTTP 状态码正确透传给客户端，而不是统一返回 500。

Pass through the actual upstream HTTP status code to the client instead of always returning 500.

---

## 改动内容 / Changes

### 后端 / Backend

- **错误类型修复**：`claude_usage_service.go` 中 `FetchUsageWithOptions` 收到非 200 响应时，将 `fmt.Errorf` 替换为 `infraerrors.New(resp.StatusCode, ...)`，使 `response.ErrorFrom` → `infraerrors.FromError` 能识别实际状态码

---

- **Error type fix**: In `claude_usage_service.go`, when `FetchUsageWithOptions` receives a non-200 response, replace `fmt.Errorf` with `infraerrors.New(resp.StatusCode, ...)` so that `response.ErrorFrom` → `infraerrors.FromError` can recognize the actual status code

### 根因分析 / Root Cause

`fmt.Errorf` 返回的普通错误无法被 `infraerrors.FromError`（`errors.As(*ApplicationError)`) 匹配，回退到默认的 `500 UnknownCode`：

```
FetchUsageWithOptions (fmt.Errorf "API returned status 429: ...")
  → GetUsage (透传 error)
    → response.ErrorFrom → infraerrors.ToHTTP → FromError
      → errors.As(*ApplicationError) 失败
        → fallback: New(500, UnknownReason, UnknownMessage)
```