### PR TITLE
fix: route antigravity apikey account test to native protocol

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -180,7 +180,7 @@ func (s *AccountTestService) TestAccountConnection(c *gin.Context, accountID int
 	}
 
 	if account.Platform == PlatformAntigravity {
-		return s.testAntigravityAccountConnection(c, account, modelID)
+		return s.routeAntigravityTest(c, account, modelID)
 	}
 
 	if account.Platform == PlatformSora {
@@ -1175,6 +1175,18 @@ func (s *AccountTestService) logSoraCloudflareChallenge(account *Account, proxyU
 
 func truncateSoraErrorBody(body []byte, max int) string {
 	return soraerror.TruncateBody(body, max)
+}
+
+// routeAntigravityTest 路由 Antigravity 账号的测试请求。
+// APIKey 类型走原生协议（与 gateway_handler 路由一致），OAuth/Upstream 走 CRS 中转。
+func (s *AccountTestService) routeAntigravityTest(c *gin.Context, account *Account, modelID string) error {
+	if account.Type == AccountTypeAPIKey {
+		if strings.HasPrefix(modelID, "gemini-") {
+			return s.testGeminiAccountConnection(c, account, modelID)
+		}
+		return s.testClaudeAccountConnection(c, account, modelID)
+	}
+	return s.testAntigravityAccountConnection(c, account, modelID)
 }
 
 // testAntigravityAccountConnection tests an Antigravity account's connection


### PR DESCRIPTION
## 背景 / Background

Antigravity 平台的 APIKey 类型账号在管理后台点击「测试连接」时，报错 "not an antigravity oauth account"，无法正常测试。

When testing an Antigravity APIKey account from the admin panel, it fails with "not an antigravity oauth account" error.

---

## 目的 / Purpose

修复 Antigravity APIKey 账号的测试连接功能，使其路由到正确的原生协议测试路径，与正常请求流量的路由逻辑保持一致。

Fix the test connection for Antigravity APIKey accounts by routing them to the correct native protocol test path, consistent with the normal request routing logic in gateway_handler.

---

## 改动内容 / Changes

### 后端 / Backend

- **新增 `routeAntigravityTest` 路由函数**：将 Antigravity 账号测试请求的路由决策提取为独立函数，APIKey 类型根据模型前缀分别路由到原生 Claude（`testClaudeAccountConnection`）或 Gemini（`testGeminiAccountConnection`）测试路径，OAuth/Upstream 类型保持走 CRS 中转（`testAntigravityAccountConnection`）

---

- **Add `routeAntigravityTest` routing function**: Extract Antigravity account test routing into a dedicated function. APIKey accounts are routed to native Claude or Gemini test paths based on model prefix, while OAuth/Upstream accounts continue using the CRS relay path (`testAntigravityAccountConnection`)