### PR TITLE
fix(openai): passthrough accounts bypass model mapping check

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3320,6 +3320,10 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 	if account.Platform == PlatformSora {
 		return s.isSoraModelSupportedByAccount(account, requestedModel)
 	}
+	// OpenAI 透传模式：仅替换认证，允许所有模型
+	if account.Platform == PlatformOpenAI && account.IsOpenAIPassthroughEnabled() {
+		return true
+	}
 	// OAuth/SetupToken 账号使用 Anthropic 标准映射（短ID → 长ID）
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
 		requestedModel = claude.NormalizeModelID(requestedModel)


### PR DESCRIPTION
## 背景 / Background

OpenAI 透传模式（`openai_passthrough`）的账号在调度阶段会经过 `isModelSupportedByAccount` 检查。该函数通过 `model_mapping` 判断账号是否支持请求的模型，但透传模式的核心逻辑是"仅替换认证、原样转发请求"，不应依赖 `model_mapping`。

When OpenAI passthrough accounts (`openai_passthrough`) are evaluated during scheduling, `isModelSupportedByAccount` checks the account's `model_mapping` to determine model support. However, passthrough mode only replaces authentication and forwards requests as-is — it should not depend on `model_mapping`.

---

## 目的 / Purpose

让透传模式的 OpenAI 账号在调度阶段跳过模型映射检查，允许所有模型通过。修复了新上线模型（如 `gpt-5.4`）在透传账号上返回 503 的问题。

Allow OpenAI passthrough accounts to bypass model mapping checks during scheduling, permitting all models. This fixes 503 errors for newly released models (e.g., `gpt-5.4`) when using passthrough accounts.

---

## 改动内容 / Changes

### 后端 / Backend

- **`isModelSupportedByAccount` 添加透传短路**：在 OpenAI 平台分支中，检测到 `openai_passthrough` 启用时直接返回 `true`，跳过 `model_mapping` 检查

---

- **Add passthrough short-circuit in `isModelSupportedByAccount`**: When an OpenAI account has `openai_passthrough` enabled, return `true` immediately without checking `model_mapping`