### PR TITLE
fix(openai): remove misplaced passthrough check from isModelSupportedByAccount

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3320,10 +3320,6 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 	if account.Platform == PlatformSora {
 		return s.isSoraModelSupportedByAccount(account, requestedModel)
 	}
-	// OpenAI 透传模式：仅替换认证，允许所有模型
-	if account.Platform == PlatformOpenAI && account.IsOpenAIPassthroughEnabled() {
-		return true
-	}
 	// OAuth/SetupToken 账号使用 Anthropic 标准映射（短ID → 长ID）
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
 		requestedModel = claude.NormalizeModelID(requestedModel)


### PR DESCRIPTION
## 背景 / Background

PR #806 中的第一个 commit 在 `isModelSupportedByAccount` 函数中添加了 OpenAI 透传模式的短路检查。但该函数不被 OpenAI 调度路径调用——OpenAI 的 `/responses` 和 `/chat/completions` 走的是 `openai_account_scheduler.go`，透传短路已在 #806 的第二个 commit 中正确添加到该文件。

The first commit in PR #806 added an OpenAI passthrough short-circuit in `isModelSupportedByAccount`. However, this function is not called by the OpenAI scheduling path — `/responses` and `/chat/completions` use `openai_account_scheduler.go`, where the passthrough bypass was correctly added in the second commit of #806.

---

## 目的 / Purpose

移除 `isModelSupportedByAccount` 中多余的死代码，因为 OpenAI 账号不会走到该函数的这个分支。

Remove dead code from `isModelSupportedByAccount`, as OpenAI accounts never reach this branch of the function.

---

## 改动内容 / Changes

### 后端 / Backend

- **移除 `isModelSupportedByAccount` 中的透传检查**：该检查是死代码，OpenAI 调度不经过此函数

---

- **Remove passthrough check from `isModelSupportedByAccount`**: Dead code — OpenAI scheduling does not go through this function