### PR TITLE
fix: restore usage API cache TTL to 10 minutes to prevent upstream 42…

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -88,7 +88,7 @@ type antigravityUsageCache struct {
 }
 
 const (
-	apiCacheTTL         = 3 * time.Minute
+	apiCacheTTL         = 10 * time.Minute
 	windowStatsCacheTTL = 1 * time.Minute
 )
 


### PR DESCRIPTION
The apiCacheTTL was changed from 10 minutes to 3 minutes in fac19d25 with no explanation. This causes the backend to call Anthropic's Usage API ~3.3x more frequently, triggering IP-based rate limiting when multiple OAuth accounts load concurrently on the admin accounts page.
<img width="1372" height="518" alt="截屏2026-03-06 16 22 06" src="https://github.com/user-attachments/assets/7562b0f8-6386-4eed-8d54-fcb6bd747a93" />
<img width="233" height="409" alt="截屏2026-03-06 16 22 28" src="https://github.com/user-attachments/assets/ec51ba66-ffba-4fd7-8697-7920ef4fea05" />
