### PR TITLE
fix(openai): add missing isCompact argument to applyCodexOAuthTransform call

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -67,7 +67,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
 			return nil, fmt.Errorf("unmarshal for codex transform: %w", err)
 		}
-		applyCodexOAuthTransform(reqBody, false)
+		applyCodexOAuthTransform(reqBody, false, false)
 		// OAuth codex transform forces stream=true upstream, so always use
 		// the streaming response handler regardless of what the client asked.
 		isStream = true


### PR DESCRIPTION
## Summary

PR #818 added a third `isCompact bool` parameter to `applyCodexOAuthTransform`, but the call site introduced by PR #809 in `openai_gateway_messages.go` was not updated, causing a compilation failure across the entire backend.

**Error:**
```
openai_gateway_messages.go:70:42: not enough arguments in call to applyCodexOAuthTransform
    have (map[string]any, bool)
    want (map[string]any, bool, bool)
```

**Fix:** Pass `false` as the `isCompact` argument — the messages compat path is not a compact path.

## Test plan

- [ ] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)