### PR TITLE
fix: Setup Token 账号使用真实 utilization 值替代状态估算

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strings"
@@ -666,15 +667,30 @@ func (s *AccountUsageService) estimateSetupTokenUsage(account *Account) *UsageIn
 			remaining = 0
 		}
 
-		// 根据状态估算使用率 (百分比形式，100 = 100%)
+		// 优先使用响应头中存储的真实 utilization 值（0-1 小数，转为 0-100 百分比）
 		var utilization float64
-		switch account.SessionWindowStatus {
-		case "rejected":
-			utilization = 100.0
-		case "allowed_warning":
-			utilization = 80.0
-		default:
-			utilization = 0.0
+		var found bool
+		if stored, ok := account.Extra["session_window_utilization"]; ok {
+			switch v := stored.(type) {
+			case float64:
+				utilization = v * 100
+				found = true
+			case json.Number:
+				if f, err := v.Float64(); err == nil {
+					utilization = f * 100
+					found = true
+				}
+			}
+		}
+
+		// 如果没有存储的 utilization，回退到状态估算
+		if !found {
+			switch account.SessionWindowStatus {
+			case "rejected":
+				utilization = 100.0
+			case "allowed_warning":
+				utilization = 80.0
+			}
 		}
 
 		info.FiveHour = &UsageProgress{

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -970,10 +970,25 @@ func (s *RateLimitService) UpdateSessionWindow(ctx context.Context, account *Acc
 		windowStart = &start
 		windowEnd = &end
 		slog.Info("account_session_window_initialized", "account_id", account.ID, "window_start", start, "window_end", end, "status", status)
+		// 窗口重置时清除旧的 utilization，避免残留上个窗口的数据
+		_ = s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{
+			"session_window_utilization": nil,
+		})
 	}
 
 	if err := s.accountRepo.UpdateSessionWindow(ctx, account.ID, windowStart, windowEnd, status); err != nil {
 		slog.Warn("session_window_update_failed", "account_id", account.ID, "error", err)
+	}
+
+	// 存储真实的 utilization 值（0-1 小数），供 estimateSetupTokenUsage 使用
+	if utilStr := headers.Get("anthropic-ratelimit-unified-5h-utilization"); utilStr != "" {
+		if util, err := strconv.ParseFloat(utilStr, 64); err == nil {
+			if err := s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{
+				"session_window_utilization": util,
+			}); err != nil {
+				slog.Warn("session_window_utilization_update_failed", "account_id", account.ID, "error", err)
+			}
+		}
 	}
 
 	// 如果状态为allowed且之前有限流，说明窗口已重置，清除限流状态


### PR DESCRIPTION
## Summary

- 从响应头 `anthropic-ratelimit-unified-5h-utilization` 获取并存储真实 utilization 值，解决 Setup Token 账号进度条始终显示 0% 的问题
- 优先使用 API 返回的真实值（0-1 小数转 0-100 百分比），无真实值时回退到原有状态估算逻辑（rejected=100%, allowed_warning=80%）
- 窗口重置时清除旧的 utilization 值，避免残留上个窗口的数据

## Changes

### `account_usage_service.go`
- `estimateSetupTokenUsage()`: 优先从 `account.Extra["session_window_utilization"]` 读取真实 utilization，支持 `float64` 和 `json.Number` 类型
- 保留原有状态估算作为 fallback

### `ratelimit_service.go`
- `UpdateSessionWindow()`: 窗口初始化时清除旧 utilization；从响应头读取并存储真实 utilization 值

## Test plan
- [ ] 验证 Setup Token 账号进度条显示真实使用率而非 0%
- [ ] 验证窗口重置后旧 utilization 被清除
- [ ] 验证无 utilization 响应头时回退到状态估算逻辑
- [ ] 验证非 Setup Token 账号不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)