### PR TITLE
fix(usage): 修复用量查询 429 重试风暴，增加负缓存、请求去重与随机延迟

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -98,8 +98,8 @@ type antigravityUsageCache struct {
 
 const (
 	apiCacheTTL             = 3 * time.Minute
-	apiErrorCacheTTL        = 1 * time.Minute            // 负缓存 TTL：429 等错误缓存 1 分钟，防止重试风暴
-	apiQueryMaxJitter       = 800 * time.Millisecond     // 用量查询最大随机延迟，打散并发请求避免反滥用检测
+	apiErrorCacheTTL        = 1 * time.Minute        // 负缓存 TTL：429 等错误缓存 1 分钟
+	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
 	windowStatsCacheTTL     = 1 * time.Minute
 	openAIProbeCacheTTL     = 10 * time.Minute
 	openAICodexProbeVersion = "0.104.0"
@@ -107,11 +107,11 @@ const (
 
 // UsageCache 封装账户使用量相关的缓存
 type UsageCache struct {
-	apiCache         sync.Map // accountID -> *apiUsageCache
-	windowStatsCache sync.Map // accountID -> *windowStatsCache
-	antigravityCache sync.Map // accountID -> *antigravityUsageCache
+	apiCache         sync.Map           // accountID -> *apiUsageCache
+	windowStatsCache sync.Map           // accountID -> *windowStatsCache
+	antigravityCache sync.Map           // accountID -> *antigravityUsageCache
 	apiFlight        singleflight.Group // 防止同一账号的并发请求击穿缓存
-	openAIProbeCache sync.Map // accountID -> time.Time
+	openAIProbeCache sync.Map           // accountID -> time.Time
 }
 
 // NewUsageCache 创建 UsageCache 实例
@@ -326,7 +326,7 @@ func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64) (*U
 			if flightErr != nil {
 				return nil, flightErr
 			}
-			apiResp = result.(*ClaudeUsageResponse)
+			apiResp, _ = result.(*ClaudeUsageResponse)
 		}
 
 		// 3. 构建 UsageInfo（每次都重新计算 RemainingSeconds）


### PR DESCRIPTION
## 问题现象

管理后台中，所有开启了 TLS 指纹伪装的 Anthropic 账号，用量显示突然全部变成 "error"。后端日志显示 Anthropic 用量 API（`/api/oauth/usage`）返回大量 429 rate limit 错误。

排查发现：
- **开启 TLS 指纹的账号** → 全部 429
- **未开启 TLS 指纹的账号** → 同一时间请求正常返回 200
- 每次刷新页面，所有失败的账号会**立即重试**，429 错误反复触发，形成恶性循环

## 根因分析

核心问题是 **缺少负缓存（negative caching）**：

当前实现只缓存了成功响应（3 分钟 TTL），429 等错误响应**完全没有被缓存**。这意味着：

1. 用户打开管理后台，前端为每个账号独立发起用量查询
2. 多个账号的请求几乎同时到达上游 → 触发 Anthropic 的频率限制 → 429
3. 用户刷新页面 → 由于错误没缓存，所有失败账号**再次同时请求** → 再次 429
4. 形成「请求 → 429 → 刷新 → 请求 → 429」的重试风暴

同时还存在两个加剧问题：
- **无并发去重**：同一账号被多个请求同时访问时，每个请求都独立调用上游 API（缓存击穿 / 惊群效应）
- **无请求打散**：管理后台加载时，所有账号的 `AccountUsageCell` 组件同时挂载，导致所有用量查询在同一瞬间发出。多个使用相同 TLS 指纹的请求同时到达上游，容易触发反滥用关联检测

## 修复方案

### 1. 负缓存（Error Caching）
429 等错误响应现在会被缓存 **1 分钟**。在负缓存有效期内，后续请求直接返回缓存的错误，不再重复请求上游 API。

```go
apiErrorCacheTTL = 1 * time.Minute  // 错误缓存 1 分钟
apiCacheTTL      = 3 * time.Minute  // 成功缓存 3 分钟（原有）
```

### 2. singleflight 请求去重
使用 `golang.org/x/sync/singleflight` 对同一账号的并发请求进行合并。当缓存过期后多个请求同时到来时，只有一个请求会实际调用上游 API，其余请求等待并共享结果。

### 3. 随机延迟（Jitter）
缓存未命中时，在发起上游请求前加入 **0~800ms 的随机延迟**。将原本同一瞬间的批量请求打散到一个时间窗口内，降低多账号使用相同 TLS 指纹同时请求时被上游关联检测的风险。

```go
apiQueryMaxJitter = 800 * time.Millisecond
```

## 修复前后对比

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 账号 A 返回 429，用户刷新页面 | 立即重试 → 再次 429 | 返回缓存的错误（1 分钟内不重试） |
| 10 个请求同时查询账号 A | 10 次上游 API 调用 | 1 次调用，其余共享结果 |
| 管理后台加载 20 个账号 | 20 个请求同时发出 | 20 个请求在 0~800ms 窗口内随机打散 |

## 改动文件

- `backend/internal/service/account_usage_service.go`
  - `apiUsageCache` 结构体增加 `err` 字段（支持负缓存）
  - `UsageCache` 结构体增加 `apiFlight singleflight.Group`
  - 新增常量 `apiErrorCacheTTL`、`apiQueryMaxJitter`
  - 重写 `GetUsage` 中的 API 调用逻辑：负缓存检查 → 随机延迟 → singleflight 去重 → 双重缓存检查 → 调用上游 → 缓存结果/错误

## 测试

- [x] `gofmt` 语法检查通过
- [x] 无新增依赖（`golang.org/x/sync` 已在 `go.mod` 中）
- [ ] 手动测试：触发 429 后，1 分钟内刷新页面不再重复请求上游
- [ ] 手动测试：并发请求同一账号，日志中只出现 1 次上游调用
- [ ] 手动测试：多账号刷新时，日志中请求时间呈现随机分散

> **备注**：`openai_gateway_messages.go:70` 存在一个已有的编译错误（参数数量不匹配），与本 PR 无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)