### PR TITLE
fix(ccswitch): improve import provider name and usage parsing

### DIFF
--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1647,10 +1647,12 @@ const executeCcsImport = (row: ApiKey, clientType: 'claude' | 'gemini') => {
       };
     }
   })`
+  const providerName = (publicSettings.value?.site_name || 'sub2api').trim() || 'sub2api'
+
   const params = new URLSearchParams({
     resource: 'provider',
     app: app,
-    name: 'sub2api',
+    name: providerName,
     homepage: baseUrl,
     endpoint: endpoint,
     apiKey: row.key,


### PR DESCRIPTION
## Summary

This PR improves CCSwitch import behavior in the user keys page:

1. Parse usage remaining value more robustly from `/v1/usage` response:
   - `response.remaining`
   - fallback to `response.quota.remaining`
   - fallback to legacy `response.balance`
   - unit fallback from `response.unit` -> `response.quota.unit` -> `USD`

2. Use `site_name` as the default imported provider name instead of hardcoded `sub2api`.

## Why

- Avoid `undefined USD` when response shape uses `remaining`/`quota.remaining` instead of `balance`.
- Improve white-label branding experience during CCSwitch import.

## Scope

- Frontend only
- File changed: `frontend/src/views/user/KeysView.vue`
