### PR TITLE
feat(frontend): add API Key quota progress bars to usage window

### DIFF
--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -333,6 +333,29 @@
   <div v-else>
     <!-- Gemini API Key accounts: show quota info -->
     <AccountQuotaInfo v-if="account.platform === 'gemini'" :account="account" />
+    <!-- API Key accounts with quota limits: show progress bars -->
+    <div v-else-if="hasApiKeyQuota" class="space-y-1">
+      <UsageProgressBar
+        v-if="quotaDailyBar"
+        label="1d"
+        :utilization="quotaDailyBar.utilization"
+        :resets-at="quotaDailyBar.resetsAt"
+        color="indigo"
+      />
+      <UsageProgressBar
+        v-if="quotaWeeklyBar"
+        label="7d"
+        :utilization="quotaWeeklyBar.utilization"
+        :resets-at="quotaWeeklyBar.resetsAt"
+        color="emerald"
+      />
+      <UsageProgressBar
+        v-if="quotaTotalBar"
+        label="total"
+        :utilization="quotaTotalBar.utilization"
+        color="purple"
+      />
+    </div>
     <div v-else class="text-xs text-gray-400">-</div>
   </div>
 </template>
@@ -808,6 +831,59 @@ const loadUsage = async () => {
     loading.value = false
   }
 }
+
+// ===== API Key quota progress bars =====
+
+interface QuotaBarInfo {
+  utilization: number
+  resetsAt: string | null
+}
+
+const makeQuotaBar = (
+  used: number,
+  limit: number,
+  startKey?: string
+): QuotaBarInfo => {
+  const utilization = limit > 0 ? (used / limit) * 100 : 0
+  let resetsAt: string | null = null
+  if (startKey) {
+    const extra = props.account.extra as Record<string, unknown> | undefined
+    const startStr = extra?.[startKey] as string | undefined
+    if (startStr) {
+      const startDate = new Date(startStr)
+      const periodMs = startKey.includes('daily') ? 24 * 60 * 60 * 1000 : 7 * 24 * 60 * 60 * 1000
+      resetsAt = new Date(startDate.getTime() + periodMs).toISOString()
+    }
+  }
+  return { utilization, resetsAt }
+}
+
+const hasApiKeyQuota = computed(() => {
+  if (props.account.type !== 'apikey') return false
+  return (
+    (props.account.quota_daily_limit ?? 0) > 0 ||
+    (props.account.quota_weekly_limit ?? 0) > 0 ||
+    (props.account.quota_limit ?? 0) > 0
+  )
+})
+
+const quotaDailyBar = computed((): QuotaBarInfo | null => {
+  const limit = props.account.quota_daily_limit ?? 0
+  if (limit <= 0) return null
+  return makeQuotaBar(props.account.quota_daily_used ?? 0, limit, 'quota_daily_start')
+})
+
+const quotaWeeklyBar = computed((): QuotaBarInfo | null => {
+  const limit = props.account.quota_weekly_limit ?? 0
+  if (limit <= 0) return null
+  return makeQuotaBar(props.account.quota_weekly_used ?? 0, limit, 'quota_weekly_start')
+})
+
+const quotaTotalBar = computed((): QuotaBarInfo | null => {
+  const limit = props.account.quota_limit ?? 0
+  if (limit <= 0) return null
+  return makeQuotaBar(props.account.quota_used ?? 0, limit)
+})
 
 onMounted(() => {
   if (!shouldAutoLoadUsageOnMount.value) return


### PR DESCRIPTION
## 背景 / Background

目前 API Key 账号的用量窗口列（Usage Window）仅显示 `-`（无数据），而配额使用情况只能通过容量列的 QuotaBadge 以金额形式查看（如 `$0.12/$1.00`）。管理员无法快速看到配额使用百分比和重置时间。

Currently, the usage window column for API Key accounts only shows `-` (no data). Quota utilization is only visible through QuotaBadge in the capacity column (e.g. `$0.12/$1.00`). Admins cannot quickly see quota usage percentage or reset time.

---

## 目的 / Purpose

为 API Key 账号在用量窗口列添加配额进度条，以百分比和重置倒计时的形式展示日配额、周配额和总配额的使用情况，与 OAuth/Gemini 账号的用量窗口展示风格一致。

Add quota progress bars to the usage window column for API Key accounts, displaying daily/weekly/total quota utilization as percentages with reset countdowns, consistent with the visual style of OAuth/Gemini accounts.

---

## 改动内容 / Changes

### 前端 / Frontend

- **用量窗口列新增 API Key 配额进度条**：在 `AccountUsageCell.vue` 中，为 `apikey` 类型账号新增 `v-else-if="hasApiKeyQuota"` 分支，渲染最多三条 `UsageProgressBar`
  - 日配额（`1d`，indigo）：显示 `quota_daily_used / quota_daily_limit` 百分比 + 重置倒计时
  - 周配额（`7d`，emerald）：显示 `quota_weekly_used / quota_weekly_limit` 百分比 + 重置倒计时
  - 总配额（`total`，purple）：显示 `quota_used / quota_limit` 百分比，无重置
- **重置时间计算**：通过 `account.extra` 中的 `quota_daily_start` / `quota_weekly_start` 字段推算窗口重置时间

---

- **Add API Key quota progress bars to usage window column**: Added `v-else-if="hasApiKeyQuota"` branch in `AccountUsageCell.vue` for `apikey` accounts, rendering up to three `UsageProgressBar` components
  - Daily quota (`1d`, indigo): shows `quota_daily_used / quota_daily_limit` percentage + reset countdown
  - Weekly quota (`7d`, emerald): shows `quota_weekly_used / quota_weekly_limit` percentage + reset countdown
  - Total quota (`total`, purple): shows `quota_used / quota_limit` percentage, no reset timer
- **Reset time calculation**: Computes window reset time from `quota_daily_start` / `quota_weekly_start` fields in `account.extra`