### PR TITLE
fix: recreate ops_alert_silences table dropped by goose-style migration

### DIFF
--- a/backend/migrations/071_recreate_ops_alert_silences.sql
+++ b/backend/migrations/071_recreate_ops_alert_silences.sql
@@ -1,0 +1,27 @@
+-- Recreate ops_alert_silences table.
+--
+-- Migration 037 used goose-style annotations (-- +goose Up / -- +goose Down),
+-- but the project's migration runner does not parse goose directives.
+-- It executed the entire file as plain SQL, including the Down section
+-- (DROP TABLE IF EXISTS ops_alert_silences), which immediately destroyed
+-- the table that the Up section had just created.
+--
+-- This migration recreates the table using IF NOT EXISTS for idempotency.
+
+CREATE TABLE IF NOT EXISTS ops_alert_silences (
+    id BIGSERIAL PRIMARY KEY,
+
+    rule_id BIGINT NOT NULL,
+    platform VARCHAR(64) NOT NULL,
+    group_id BIGINT,
+    region VARCHAR(64),
+
+    until TIMESTAMPTZ NOT NULL,
+    reason TEXT,
+
+    created_by BIGINT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ops_alert_silences_lookup
+    ON ops_alert_silences (rule_id, platform, group_id, region, until);


### PR DESCRIPTION
## Problem

Migration `037_ops_alert_silences.sql` uses goose-style annotations (`-- +goose Up` / `-- +goose Down`), but the project's custom migration runner (`migrations_runner.go`) does not parse goose directives — it executes the entire file content as plain SQL.

This means the Down section (`DROP TABLE IF EXISTS ops_alert_silences`) runs immediately after the Up section (`CREATE TABLE`), leaving the table missing in production.

**Impact:** The alert silence feature (`CreateAlertSilence`, `IsAlertSilenced`) is silently broken — database queries fail because the table does not exist.

Note: Two other migrations (`019`, `024`) have the same goose annotation issue but with lower severity (data-level rather than table-level).

## Fix

Add a new migration `071_recreate_ops_alert_silences.sql` that recreates the table using `IF NOT EXISTS` for idempotency.

## Root cause

The custom migration runner at `internal/repository/migrations_runner.go:230` calls `tx.ExecContext(ctx, content)` with the full file content. SQL treats `-- +goose Down` as a plain comment, so the DROP statement executes unconditionally.