### PR TITLE
feat(frontend): pass locale to iframe embedded pages via lang parameter

### DIFF
--- a/docs/ADMIN_PAYMENT_INTEGRATION_API.md
+++ b/docs/ADMIN_PAYMENT_INTEGRATION_API.md
@@ -99,16 +99,17 @@ curl -X POST "${BASE}/api/v1/admin/users/123/balance" \
   }'
 ```
 
-### 4) 购买页 URL Query 透传（iframe / 新窗口一致）
-当 Sub2API 打开 `purchase_subscription_url` 时，会统一追加：
+### 4) 购买页 / 自定义页面 URL Query 透传（iframe / 新窗口一致）
+当 Sub2API 打开 `purchase_subscription_url` 或用户侧自定义页面 iframe URL 时，会统一追加：
 - `user_id`
 - `token`
 - `theme`（`light` / `dark`）
+- `lang`（例如 `zh` / `en`，用于向嵌入页传递当前界面语言）
 - `ui_mode`（固定 `embedded`）
 
 示例：
 ```text
-https://pay.example.com/pay?user_id=123&token=<jwt>&theme=light&ui_mode=embedded
+https://pay.example.com/pay?user_id=123&token=<jwt>&theme=light&lang=zh&ui_mode=embedded
 ```
 
 ### 5) 失败处理建议
@@ -218,16 +219,17 @@ curl -X POST "${BASE}/api/v1/admin/users/123/balance" \
   }'
 ```
 
-### 4) Purchase URL query forwarding (iframe and new tab)
-When Sub2API opens `purchase_subscription_url`, it appends:
+### 4) Purchase / Custom Page URL query forwarding (iframe and new tab)
+When Sub2API opens `purchase_subscription_url` or a user-facing custom page iframe URL, it appends:
 - `user_id`
 - `token`
 - `theme` (`light` / `dark`)
+- `lang` (for example `zh` / `en`, used to pass the current UI language to the embedded page)
 - `ui_mode` (fixed: `embedded`)
 
 Example:
 ```text
-https://pay.example.com/pay?user_id=123&token=<jwt>&theme=light&ui_mode=embedded
+https://pay.example.com/pay?user_id=123&token=<jwt>&theme=light&lang=zh&ui_mode=embedded
 ```
 
 ### 5) Failure handling recommendations

--- a/frontend/src/utils/__tests__/embedded-url.spec.ts
+++ b/frontend/src/utils/__tests__/embedded-url.spec.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { buildEmbeddedUrl, detectTheme } from '../embedded-url'
+
+describe('embedded-url', () => {
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        origin: 'https://app.example.com',
+        href: 'https://app.example.com/user/purchase',
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+    document.documentElement.classList.remove('dark')
+    vi.restoreAllMocks()
+  })
+
+  it('adds embedded query parameters including locale and source context', () => {
+    const result = buildEmbeddedUrl(
+      'https://pay.example.com/checkout?plan=pro',
+      42,
+      'token-123',
+      'dark',
+      'zh-CN',
+    )
+
+    const url = new URL(result)
+    expect(url.searchParams.get('plan')).toBe('pro')
+    expect(url.searchParams.get('user_id')).toBe('42')
+    expect(url.searchParams.get('token')).toBe('token-123')
+    expect(url.searchParams.get('theme')).toBe('dark')
+    expect(url.searchParams.get('lang')).toBe('zh-CN')
+    expect(url.searchParams.get('ui_mode')).toBe('embedded')
+    expect(url.searchParams.get('src_host')).toBe('https://app.example.com')
+    expect(url.searchParams.get('src_url')).toBe('https://app.example.com/user/purchase')
+  })
+
+  it('omits optional params when they are empty', () => {
+    const result = buildEmbeddedUrl('https://pay.example.com/checkout', undefined, '', 'light')
+
+    const url = new URL(result)
+    expect(url.searchParams.get('theme')).toBe('light')
+    expect(url.searchParams.get('ui_mode')).toBe('embedded')
+    expect(url.searchParams.has('user_id')).toBe(false)
+    expect(url.searchParams.has('token')).toBe(false)
+    expect(url.searchParams.has('lang')).toBe(false)
+  })
+
+  it('returns original string for invalid url input', () => {
+    expect(buildEmbeddedUrl('not a url', 1, 'token')).toBe('not a url')
+  })
+
+  it('detects dark mode from document root class', () => {
+    document.documentElement.classList.add('dark')
+    expect(detectTheme()).toBe('dark')
+  })
+})

--- a/frontend/src/utils/embedded-url.ts
+++ b/frontend/src/utils/embedded-url.ts
@@ -1,12 +1,13 @@
 /**
  * Shared URL builder for iframe-embedded pages.
  * Used by PurchaseSubscriptionView and CustomPageView to build consistent URLs
- * with user_id, token, theme, ui_mode, src_host, and src parameters.
+ * with user_id, token, theme, lang, ui_mode, src_host, and src parameters.
  */
 
 const EMBEDDED_USER_ID_QUERY_KEY = 'user_id'
 const EMBEDDED_AUTH_TOKEN_QUERY_KEY = 'token'
 const EMBEDDED_THEME_QUERY_KEY = 'theme'
+const EMBEDDED_LANG_QUERY_KEY = 'lang'
 const EMBEDDED_UI_MODE_QUERY_KEY = 'ui_mode'
 const EMBEDDED_UI_MODE_VALUE = 'embedded'
 const EMBEDDED_SRC_HOST_QUERY_KEY = 'src_host'
@@ -17,6 +18,7 @@ export function buildEmbeddedUrl(
   userId?: number,
   authToken?: string | null,
   theme: 'light' | 'dark' = 'light',
+  lang?: string,
 ): string {
   if (!baseUrl) return baseUrl
   try {
@@ -28,6 +30,9 @@ export function buildEmbeddedUrl(
       url.searchParams.set(EMBEDDED_AUTH_TOKEN_QUERY_KEY, authToken)
     }
     url.searchParams.set(EMBEDDED_THEME_QUERY_KEY, theme)
+    if (lang) {
+      url.searchParams.set(EMBEDDED_LANG_QUERY_KEY, lang)
+    }
     url.searchParams.set(EMBEDDED_UI_MODE_QUERY_KEY, EMBEDDED_UI_MODE_VALUE)
     // Source tracking: let the embedded page know where it's being loaded from
     if (typeof window !== 'undefined') {

--- a/frontend/src/views/user/CustomPageView.vue
+++ b/frontend/src/views/user/CustomPageView.vue
@@ -75,7 +75,7 @@ import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildEmbeddedUrl, detectTheme } from '@/utils/embedded-url'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const route = useRoute()
 const appStore = useAppStore()
 const authStore = useAuthStore()
@@ -107,6 +107,7 @@ const embeddedUrl = computed(() => {
     authStore.user?.id,
     authStore.token,
     pageTheme.value,
+    locale.value,
   )
 })
 

--- a/frontend/src/views/user/PurchaseSubscriptionView.vue
+++ b/frontend/src/views/user/PurchaseSubscriptionView.vue
@@ -76,7 +76,7 @@ import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildEmbeddedUrl, detectTheme } from '@/utils/embedded-url'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const appStore = useAppStore()
 const authStore = useAuthStore()
 
@@ -90,7 +90,7 @@ const purchaseEnabled = computed(() => {
 
 const purchaseUrl = computed(() => {
   const baseUrl = (appStore.cachedPublicSettings?.purchase_subscription_url || '').trim()
-  return buildEmbeddedUrl(baseUrl, authStore.user?.id, authStore.token, purchaseTheme.value)
+  return buildEmbeddedUrl(baseUrl, authStore.user?.id, authStore.token, purchaseTheme.value, locale.value)
 })
 
 const isValidUrl = computed(() => {


### PR DESCRIPTION
## 背景 / Background

Sub2API 支持将购买页和自定义页面通过 iframe 嵌入，并通过 URL query 参数传递用户身份和主题等上下文信息。但目前缺少语言信息的传递，嵌入页面无法感知用户当前选择的界面语言，导致嵌入页面可能显示与主界面不一致的语言。

Sub2API supports embedding purchase and custom pages via iframe, passing user identity and theme context through URL query parameters. However, the current implementation does not pass language information, so embedded pages cannot detect the user's current locale, potentially showing content in a different language than the main UI.

---

## 目的 / Purpose

新增 `lang` URL 参数，将用户当前界面语言传递给 iframe 嵌入页面，使嵌入页面可以根据 `lang` 参数匹配用户语言偏好。

Add a `lang` URL parameter to pass the user's current UI locale to iframe embedded pages, allowing embedded content to match the user's language preference.

---

## 改动内容 / Changes

### 前端 / Frontend

- **`buildEmbeddedUrl` 工具函数**：新增可选参数 `lang?: string`，当提供时在 URL 上追加 `lang` query 参数
- **PurchaseSubscriptionView**：从 `useI18n()` 解构 `locale`，调用 `buildEmbeddedUrl` 时传入 `locale.value`
- **CustomPageView**：同上，传入 `locale.value`
- **单元测试**：新增 `embedded-url.spec.ts`，覆盖参数传递、可选参数省略、无效 URL 兜底、暗色模式检测等场景

---

- **`buildEmbeddedUrl` utility**: Add optional `lang?: string` parameter; when provided, appends a `lang` query param to the URL
- **PurchaseSubscriptionView**: Destructure `locale` from `useI18n()` and pass `locale.value` to `buildEmbeddedUrl`
- **CustomPageView**: Same as above, pass `locale.value`
- **Unit tests**: Add `embedded-url.spec.ts` covering parameter forwarding, optional param omission, invalid URL fallback, and dark mode detection

### 文档 / Documentation

- **ADMIN_PAYMENT_INTEGRATION_API.md**：在第 4 节"购买页 URL Query 透传"中补充 `lang` 参数说明（中英文双语）

---

- **ADMIN_PAYMENT_INTEGRATION_API.md**: Add `lang` parameter documentation to section 4 "Purchase URL query forwarding" (bilingual)