### PR TITLE
fix(frontend): stack quota badges vertically in capacity column

### DIFF
--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -73,11 +73,9 @@
     </div>
 
     <!-- API Key 账号配额限制 -->
-    <div v-if="showDailyQuota || showWeeklyQuota || showTotalQuota" class="flex items-center gap-1">
-      <QuotaBadge v-if="showDailyQuota" :used="account.quota_daily_used ?? 0" :limit="account.quota_daily_limit!" label="D" />
-      <QuotaBadge v-if="showWeeklyQuota" :used="account.quota_weekly_used ?? 0" :limit="account.quota_weekly_limit!" label="W" />
-      <QuotaBadge v-if="showTotalQuota" :used="account.quota_used ?? 0" :limit="account.quota_limit!" />
-    </div>
+    <QuotaBadge v-if="showDailyQuota" :used="account.quota_daily_used ?? 0" :limit="account.quota_daily_limit!" label="D" />
+    <QuotaBadge v-if="showWeeklyQuota" :used="account.quota_weekly_used ?? 0" :limit="account.quota_weekly_limit!" label="W" />
+    <QuotaBadge v-if="showTotalQuota" :used="account.quota_used ?? 0" :limit="account.quota_limit!" />
   </div>
 </template>
 


### PR DESCRIPTION
## 背景 / Background

在账号容量列中，API Key 的配额徽章（QuotaBadge: 日/周/总量）被包裹在一个水平 flex 容器 (`flex items-center gap-1`) 中，导致它们水平排列。而其他所有容量徽章（并发、窗口费用、会话、RPM）都直接作为外层 `flex flex-col` 的子元素，垂直排列。这导致了视觉上的不一致。

In the account capacity column, API Key quota badges (QuotaBadge: daily/weekly/total) were wrapped in a horizontal flex container (`flex items-center gap-1`), causing them to render horizontally. All other capacity badges (concurrency, window cost, sessions, RPM) are direct children of the outer `flex flex-col` container and stack vertically. This caused a visual inconsistency.

---

## 目的 / Purpose

让所有容量列中的徽章保持一致的垂直排列方式，提升视觉一致性。

Ensure all badges in the capacity column stack vertically in a consistent manner, improving visual consistency.

---

## 改动内容 / Changes

### 前端 / Frontend

- **移除 QuotaBadge 的水平包裹容器**：去掉 `<div class="flex items-center gap-1">`，让 QuotaBadge 组件直接作为外层 `flex flex-col` 容器的子元素，与其他徽章保持一致的垂直排列

---

- **Remove horizontal wrapper around QuotaBadge**: Remove the `<div class="flex items-center gap-1">` wrapper so QuotaBadge components become direct children of the outer `flex flex-col` container, aligning consistently with other badges