### PR TITLE
fix: use shared max_line_size config for OpenAI Responses SSE scanner

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -279,7 +279,11 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 	requestID := resp.Header.Get("x-request-id")
 
 	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	maxLineSize := defaultMaxLineSize
+	if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
+		maxLineSize = s.cfg.Gateway.MaxLineSize
+	}
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
 
 	var finalResponse *apicompat.ResponsesResponse
 	var usage OpenAIUsage
@@ -378,7 +382,11 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	firstChunk := true
 
 	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	maxLineSize := defaultMaxLineSize
+	if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
+		maxLineSize = s.cfg.Gateway.MaxLineSize
+	}
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
 
 	// resultWithUsage builds the final result snapshot.
 	resultWithUsage := func() *OpenAIForwardResult {


### PR DESCRIPTION
## 背景 / Background

`openai_gateway_messages.go` 中两处 SSE scanner 的最大行大小硬编码为 1MB，而项目其余所有 scanner（共 10 处）均使用 `defaultMaxLineSize`（500MB）+ 配置覆盖。当 Responses API 返回大 payload 时，这两处会因 buffer 不足而截断。

Two SSE scanners in `openai_gateway_messages.go` had their max line size hardcoded to 1MB, while all other scanners (10 locations) use `defaultMaxLineSize` (500MB) with config override. This caused Responses API streams to fail on large payloads.

---

## 目的 / Purpose

统一所有 SSE scanner 的 max line size 配置，消除不一致的硬编码值。

Unify max line size configuration across all SSE scanners, eliminating inconsistent hardcoded values.

---

## 改动内容 / Changes

### 后端 / Backend

- **`openai_gateway_messages.go`**：`handleAnthropicBufferedStreamingResponse` 和 `handleAnthropicStreamingResponse` 两处 scanner 从硬编码 `1024*1024`（1MB）改为使用 `defaultMaxLineSize` + `s.cfg.Gateway.MaxLineSize` 配置覆盖，与 `gateway_service.go`、`antigravity_gateway_service.go`、`openai_gateway_service.go`、`sora_gateway_streaming_legacy.go` 保持一致

---

- **`openai_gateway_messages.go`**: Changed two scanners in `handleAnthropicBufferedStreamingResponse` and `handleAnthropicStreamingResponse` from hardcoded `1024*1024` (1MB) to use `defaultMaxLineSize` + `s.cfg.Gateway.MaxLineSize` config override, consistent with all other scanner locations