### PR TITLE
fix: 补充缺失的组级和账户级运维告警指标

### DIFF
--- a/backend/internal/handler/admin/ops_alerts_handler.go
+++ b/backend/internal/handler/admin/ops_alerts_handler.go
@@ -23,6 +23,13 @@ var validOpsAlertMetricTypes = []string{
 	"cpu_usage_percent",
 	"memory_usage_percent",
 	"concurrency_queue_depth",
+	"group_available_accounts",
+	"group_available_ratio",
+	"group_rate_limit_ratio",
+	"account_rate_limited_count",
+	"account_error_count",
+	"account_error_ratio",
+	"overload_account_count",
 }
 
 var validOpsAlertMetricTypeSet = func() map[string]struct{} {
@@ -82,7 +89,10 @@ func isPercentOrRateMetric(metricType string) bool {
 		"error_rate",
 		"upstream_error_rate",
 		"cpu_usage_percent",
-		"memory_usage_percent":
+		"memory_usage_percent",
+		"group_available_ratio",
+		"group_rate_limit_ratio",
+		"account_error_ratio":
 		return true
 	default:
 		return false

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -506,6 +506,48 @@ func (s *OpsAlertEvaluatorService) computeRuleMetric(
 		return float64(countAccountsByCondition(availability.Accounts, func(acc *AccountAvailability) bool {
 			return acc.HasError && acc.TempUnschedulableUntil == nil
 		})), true
+	case "group_rate_limit_ratio":
+		if groupID == nil || *groupID <= 0 {
+			return 0, false
+		}
+		if s == nil || s.opsService == nil {
+			return 0, false
+		}
+		availability, err := s.opsService.GetAccountAvailability(ctx, platform, groupID)
+		if err != nil || availability == nil {
+			return 0, false
+		}
+		if availability.Group == nil || availability.Group.TotalAccounts <= 0 {
+			return 0, true
+		}
+		return (float64(availability.Group.RateLimitCount) / float64(availability.Group.TotalAccounts)) * 100, true
+	case "account_error_ratio":
+		if s == nil || s.opsService == nil {
+			return 0, false
+		}
+		availability, err := s.opsService.GetAccountAvailability(ctx, platform, groupID)
+		if err != nil || availability == nil {
+			return 0, false
+		}
+		total := int64(len(availability.Accounts))
+		if total <= 0 {
+			return 0, true
+		}
+		errorCount := countAccountsByCondition(availability.Accounts, func(acc *AccountAvailability) bool {
+			return acc.HasError && acc.TempUnschedulableUntil == nil
+		})
+		return (float64(errorCount) / float64(total)) * 100, true
+	case "overload_account_count":
+		if s == nil || s.opsService == nil {
+			return 0, false
+		}
+		availability, err := s.opsService.GetAccountAvailability(ctx, platform, groupID)
+		if err != nil || availability == nil {
+			return 0, false
+		}
+		return float64(countAccountsByCondition(availability.Accounts, func(acc *AccountAvailability) bool {
+			return acc.IsOverloaded
+		})), true
 	}
 
 	overview, err := s.opsRepo.GetDashboardOverview(ctx, &OpsDashboardFilter{


### PR DESCRIPTION
## Description

当前运维告警系统缺少对组级和账户级健康状态的监控指标，导致无法针对账户组可用性、限速、错误率等关键场景配置告警规则。本 PR 补充了这些缺失的指标。

### 新增指标

| 指标名 | 类型 | 说明 |
|---|---|---|
| `group_available_accounts` | 计数 | 组内可用账户数量 |
| `group_available_ratio` | 百分比 | 组内可用账户占比 |
| `group_rate_limit_ratio` | 百分比 | 组内被限速账户占比 |
| `account_rate_limited_count` | 计数 | 被限速的账户数量 |
| `account_error_count` | 计数 | 存在错误的账户数量 |
| `account_error_ratio` | 百分比 | 错误账户占比 |
| `overload_account_count` | 计数 | 过载账户数量 |

### 变更文件

- `backend/internal/handler/admin/ops_alerts_handler.go` — 注册新指标类型到合法列表，并将比例类指标标记为百分比类型
- `backend/internal/service/ops_alert_evaluator_service.go` — 实现 `group_rate_limit_ratio`、`account_error_ratio`、`overload_account_count` 三个指标的评估逻辑

### 测试

- [x] `go test -tags=unit ./...` 通过
- [x] `go test -tags=integration ./...` 通过