### PR TITLE
fix(openai): convert string input to array for Codex OAuth responses endpoint (fix #919)

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -146,6 +146,22 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 		input = filterCodexInput(input, needsToolContinuation)
 		reqBody["input"] = input
 		result.Modified = true
+	} else if inputStr, ok := reqBody["input"].(string); ok {
+		// ChatGPT codex endpoint requires input to be a list, not a string.
+		// Convert string input to the expected message array format.
+		trimmed := strings.TrimSpace(inputStr)
+		if trimmed != "" {
+			reqBody["input"] = []any{
+				map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": inputStr,
+				},
+			}
+		} else {
+			reqBody["input"] = []any{}
+		}
+		result.Modified = true
 	}
 
 	return result

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -249,6 +249,50 @@ func TestApplyCodexOAuthTransform_NonCodexCLI_PreservesExistingInstructions(t *t
 	require.Equal(t, "old instructions", instructions)
 }
 
+func TestApplyCodexOAuthTransform_StringInputConvertedToArray(t *testing.T) {
+	reqBody := map[string]any{"model": "gpt-5.4", "input": "Hello, world!"}
+	result := applyCodexOAuthTransform(reqBody, false, false)
+	require.True(t, result.Modified)
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 1)
+	msg, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "message", msg["type"])
+	require.Equal(t, "user", msg["role"])
+	require.Equal(t, "Hello, world!", msg["content"])
+}
+
+func TestApplyCodexOAuthTransform_EmptyStringInputBecomesEmptyArray(t *testing.T) {
+	reqBody := map[string]any{"model": "gpt-5.4", "input": ""}
+	result := applyCodexOAuthTransform(reqBody, false, false)
+	require.True(t, result.Modified)
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 0)
+}
+
+func TestApplyCodexOAuthTransform_WhitespaceStringInputBecomesEmptyArray(t *testing.T) {
+	reqBody := map[string]any{"model": "gpt-5.4", "input": "   "}
+	result := applyCodexOAuthTransform(reqBody, false, false)
+	require.True(t, result.Modified)
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 0)
+}
+
+func TestApplyCodexOAuthTransform_StringInputWithToolsField(t *testing.T) {
+	reqBody := map[string]any{
+		"model": "gpt-5.4",
+		"input": "Run the tests",
+		"tools": []any{map[string]any{"type": "function", "name": "bash"}},
+	}
+	applyCodexOAuthTransform(reqBody, false, false)
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 1)
+}
+
 func TestIsInstructionsEmpty(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## 背景 / Background

OpenClaw embedded agent 调用 `/v1/responses` 时，`input` 字段为 string 格式（符合 OpenAI 官方 Responses API spec）。sub2api 透传到 ChatGPT `backend-api/codex/responses`（OAuth 账号），该端点只接受 array 格式，返回 400 `"Input must be a list"`。

When a client calls `/v1/responses` with `input` as a plain string (valid per the OpenAI Responses API spec), sub2api forwards it as-is to ChatGPT `backend-api/codex/responses` (OAuth accounts), which only accepts array format, resulting in a 400 `"Input must be a list"` error.

---

## 目的 / Purpose

在 `applyCodexOAuthTransform` 中检测 string 类型的 `input`，自动转换为 ChatGPT backend-api 所需的 message array 格式。空字符串和纯空白字符串转为空数组，避免触发 400。

Detect string-typed `input` in `applyCodexOAuthTransform` and automatically convert it to the message array format required by the ChatGPT backend-api. Empty and whitespace-only strings are converted to an empty array to avoid triggering 400 errors.

---

## 改动内容 / Changes

### 后端 / Backend

- **`openai_codex_transform.go`**：在 `applyCodexOAuthTransform` 的 `input` 处理分支中新增 string→array 转换。使用 `strings.TrimSpace` 判断是否为空白字符串：非空字符串转为 `[{"type":"message","role":"user","content":"..."}]`，空/纯空白字符串转为 `[]`
- **`openai_codex_transform_test.go`**：新增 4 个测试用例覆盖：普通字符串转换、空字符串、纯空白字符串、带 tools 字段的字符串输入

---

- **`openai_codex_transform.go`**: Add string→array conversion in `applyCodexOAuthTransform`'s `input` handling branch. Uses `strings.TrimSpace` to detect blank strings: non-empty strings are converted to `[{"type":"message","role":"user","content":"..."}]`, empty/whitespace-only strings become `[]`
- **`openai_codex_transform_test.go`**: Add 4 test cases covering: normal string conversion, empty string, whitespace-only string, and string input with tools field

---

## 测试计划 / Test Plan

- [x] `go test ./internal/service/ -count=1` 全部通过（含 4 个新增用例，无 regression）
- [ ] `make test-integration` 通过（需 CI 环境）
- [ ] `golangci-lint v2.9` 通过（待 CI）
- [x] 已部署到生产环境验证，无 `"Input must be a list"` 错误
- [x] 端到端验证通过（旁路容器对照测试）：

### 端到端验证结果 / End-to-End Verification

在同一环境并行运行未 patch 版本（`weishaw/sub2api:latest`）和 patch 版本，使用 OAuth 账号（type=oauth，走 `applyCodexOAuthTransform` 路径）发送请求：

| 版本 | string input | array input |
|------|-------------|-------------|
| 未 patch (`weishaw/sub2api:latest`) | ❌ 上游 400: `"Input must be a list"` | ✅ 200 |
| patch 版 | ✅ 200 | ✅ 200 |

- **Bug 复现**：未 patch 版本将 string input 原样透传，触发上游 400
- **Patch 有效**：patch 版本正确转换 string→array，上游正常响应