### PR TITLE
fix: remove SSE termination marker from DefaultStopSequences

### DIFF
--- a/backend/internal/pkg/antigravity/gemini_types.go
+++ b/backend/internal/pkg/antigravity/gemini_types.go
@@ -189,6 +189,5 @@ var DefaultStopSequences = []string{
 	"<|user|>",
 	"<|endoftext|>",
 	"<|end_of_turn|>",
-	"[DONE]",
 	"\n\nHuman:",
 }


### PR DESCRIPTION
## Summary

- Remove the SSE stream termination marker string from `DefaultStopSequences` in `gemini_types.go`
- This string was being sent to Gemini as a stop sequence, causing the model to prematurely terminate output whenever its generated text happened to contain that marker
- The SSE-level protocol filtering in `stream_transformer.go:56` already handles this marker correctly at the transport layer; it should not be a content-generation stop sequence

## Root Cause

`DefaultStopSequences` is injected into Gemini requests via `request_transformer.go:608`. When Gemini encounters any of these strings in its own output text, it stops generating. The SSE termination marker is a transport-layer protocol signal, not a content boundary — including it as a stop sequence causes false-positive stream termination.

## Test Plan

- [ ] Verify that models routed through the antigravity gateway (e.g. `claude-opus-4-6`) no longer prematurely terminate when generating text that includes the SSE marker
- [ ] Verify that SSE stream termination still works correctly (handled by `stream_transformer.go:56`)