### PR TITLE
feat(billing): add fallback pricing for MiniMax M2.5, GLM-4.7/5, Kimi…

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -254,6 +254,36 @@ func (s *BillingService) initFallbackPricing() {
 		SupportsCacheBreakdown:         false,
 	}
 	s.fallbackPrices["gpt-5.3-codex"] = s.fallbackPrices["gpt-5.1-codex"]
+
+	// MiniMax M2.5
+	s.fallbackPrices["minimax-m2.5"] = &ModelPricing{
+		InputPricePerToken:  0.27e-6, // $0.27 per MTok
+		OutputPricePerToken: 0.95e-6, // $0.95 per MTok
+	}
+
+	// 智谱 GLM-4.7
+	s.fallbackPrices["glm-4.7"] = &ModelPricing{
+		InputPricePerToken:  0.38e-6, // $0.38 per MTok
+		OutputPricePerToken: 1.98e-6, // $1.98 per MTok
+	}
+
+	// 智谱 GLM-5
+	s.fallbackPrices["glm-5"] = &ModelPricing{
+		InputPricePerToken:  0.72e-6, // $0.72 per MTok
+		OutputPricePerToken: 2.30e-6, // $2.30 per MTok
+	}
+
+	// Kimi K2.5
+	s.fallbackPrices["kimi-k2.5"] = &ModelPricing{
+		InputPricePerToken:  0.45e-6, // $0.45 per MTok
+		OutputPricePerToken: 2.20e-6, // $2.20 per MTok
+	}
+
+	// Qwen 3.5 Plus
+	s.fallbackPrices["qwen3.5-plus"] = &ModelPricing{
+		InputPricePerToken:  0.26e-6, // $0.26 per MTok
+		OutputPricePerToken: 1.56e-6, // $1.56 per MTok
+	}
 }
 
 // getFallbackPricing 根据模型系列获取回退价格
@@ -306,6 +336,37 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 			return s.fallbackPrices["gpt-5.1-codex"]
 		case "gpt-5.1":
 			return s.fallbackPrices["gpt-5.1"]
+		}
+	}
+
+	// MiniMax 系列
+	if strings.Contains(modelLower, "minimax") {
+		if strings.Contains(modelLower, "m2.5") || strings.Contains(modelLower, "m2-5") {
+			return s.fallbackPrices["minimax-m2.5"]
+		}
+	}
+
+	// 智谱 GLM 系列
+	if strings.Contains(modelLower, "glm") {
+		if strings.Contains(modelLower, "5") && !strings.Contains(modelLower, "4") && !strings.Contains(modelLower, "3") {
+			return s.fallbackPrices["glm-5"]
+		}
+		if strings.Contains(modelLower, "4.7") || strings.Contains(modelLower, "4-7") {
+			return s.fallbackPrices["glm-4.7"]
+		}
+	}
+
+	// Kimi 系列
+	if strings.Contains(modelLower, "kimi") {
+		if strings.Contains(modelLower, "k2.5") || strings.Contains(modelLower, "k2-5") {
+			return s.fallbackPrices["kimi-k2.5"]
+		}
+	}
+
+	// Qwen 系列
+	if strings.Contains(modelLower, "qwen") {
+		if strings.Contains(modelLower, "3.5-plus") || strings.Contains(modelLower, "3.5_plus") || strings.Contains(modelLower, "3-5-plus") {
+			return s.fallbackPrices["qwen3.5-plus"]
 		}
 	}
 

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -214,7 +214,17 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{name: "openai gpt5.1 codex max alias", model: "gpt-5.1-codex-max", expectedInput: 1.5e-6},
 		{name: "openai codex mini latest alias", model: "codex-mini-latest", expectedInput: 1.5e-6},
 		{name: "openai unknown no fallback", model: "gpt-unknown-model", expectNilPricing: true},
-		{name: "non supported family", model: "qwen-max", expectNilPricing: true},
+		{name: "minimax m2.5", model: "minimax-m2.5", expectedInput: 0.27e-6},
+		{name: "minimax m2.5 variant", model: "MiniMax-M2.5-latest", expectedInput: 0.27e-6},
+		{name: "glm-5", model: "glm-5", expectedInput: 0.72e-6},
+		{name: "glm-5 variant", model: "GLM-5-0212", expectedInput: 0.72e-6},
+		{name: "glm-4.7", model: "glm-4.7", expectedInput: 0.38e-6},
+		{name: "glm-4.7 alt separator", model: "glm-4-7", expectedInput: 0.38e-6},
+		{name: "kimi k2.5", model: "kimi-k2.5", expectedInput: 0.45e-6},
+		{name: "kimi k2.5 variant", model: "kimi-k2-5-0215", expectedInput: 0.45e-6},
+		{name: "qwen3.5-plus", model: "qwen3.5-plus", expectedInput: 0.26e-6},
+		{name: "qwen3.5-plus variant", model: "qwen3.5-plus-0215", expectedInput: 0.26e-6},
+		{name: "non supported family", model: "llama-3-70b", expectNilPricing: true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 变更概述

为计费服务新增多个国内主流 AI 模型的兜底（fallback）定价，确保这些模型在 `model_pricing.json` 数据文件中没有精确匹配时，仍能正确计算费用。

## 新增模型及定价

| 模型 | 输入价格（$/MTok） | 输出价格（$/MTok） |
|------|------------------|--------------------|
| MiniMax M2.5 | $0.27 | $0.95 |
| 智谱 GLM-4.7 | $0.38 | $1.98 |
| 智谱 GLM-5 | $0.72 | $2.30 |
| Kimi K2.5 | $0.45 | $2.20 |
| Qwen3.5-Plus | $0.26 | $1.56 |

## 变更详情

### `billing_service.go`
- 在 `initFallbackPricing()` 中为上述 5 个模型注册兜底定价
- 在 `getFallbackPricing()` 中新增对应的模型系列匹配规则，支持大小写不敏感匹配及常见变体（如 `m2.5` / `m2-5`、`4.7` / `4-7` 等分隔符差异）

### `billing_service_test.go`
- 新增 10 个测试用例，覆盖 5 个新模型及其常见命名变体
- 将原 `qwen-max` 的 `expectNilPricing: true` 测试用例调整为 `llama-3-70b`，更准确地代表"不支持的模型系列"

## 测试

```bash
go test -tags=unit ./backend/internal/service/...
```
所有单元测试通过。

## Checklist
- [x] 单元测试通过 (go test -tags=unit github.)
- [x] 无新增 lint 问题
- [x] 新增定价均参考各厂商官方公开价格