### PR TITLE
fix: 止血 Codex/Responses 原生 input id 被误改成 fc_*

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -339,8 +339,9 @@ func filterCodexInput(input []any, preserveReferences bool) []any {
 		}
 		typ, _ := m["type"].(string)
 
-		// 修复 OpenAI 上游的最新校验："Expected an ID that begins with 'fc'"
-		fixIDPrefix := func(id string) string {
+		// 仅修正真正的 tool/function call 标识，避免误改普通 message/reasoning id；
+		// 若 item_reference 指向 legacy call_* 标识，则仅修正该引用本身。
+		fixCallIDPrefix := func(id string) string {
 			if id == "" || strings.HasPrefix(id, "fc") {
 				return id
 			}
@@ -358,8 +359,8 @@ func filterCodexInput(input []any, preserveReferences bool) []any {
 			for key, value := range m {
 				newItem[key] = value
 			}
-			if id, ok := newItem["id"].(string); ok && id != "" {
-				newItem["id"] = fixIDPrefix(id)
+			if id, ok := newItem["id"].(string); ok && strings.HasPrefix(id, "call_") {
+				newItem["id"] = fixCallIDPrefix(id)
 			}
 			filtered = append(filtered, newItem)
 			continue
@@ -390,7 +391,7 @@ func filterCodexInput(input []any, preserveReferences bool) []any {
 			}
 
 			if callID != "" {
-				fixedCallID := fixIDPrefix(callID)
+				fixedCallID := fixCallIDPrefix(callID)
 				if fixedCallID != callID {
 					ensureCopy()
 					newItem["call_id"] = fixedCallID
@@ -403,14 +404,6 @@ func filterCodexInput(input []any, preserveReferences bool) []any {
 			delete(newItem, "id")
 			if !isCodexToolCallItemType(typ) {
 				delete(newItem, "call_id")
-			}
-		} else {
-			if id, ok := newItem["id"].(string); ok && id != "" {
-				fixedID := fixIDPrefix(id)
-				if fixedID != id {
-					ensureCopy()
-					newItem["id"] = fixedID
-				}
 			}
 		}
 

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -33,12 +33,63 @@ func TestApplyCodexOAuthTransform_ToolContinuationPreservesInput(t *testing.T) {
 	first, ok := input[0].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "item_reference", first["type"])
-	require.Equal(t, "fc_ref1", first["id"])
+	require.Equal(t, "ref1", first["id"])
 
 	// 校验 input[1] 为 map，确保后续字段断言安全。
 	second, ok := input[1].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "fc_o1", second["id"])
+	require.Equal(t, "o1", second["id"])
+	require.Equal(t, "fc1", second["call_id"])
+}
+
+func TestApplyCodexOAuthTransform_ToolContinuationPreservesNativeMessageAndReasoningIDs(t *testing.T) {
+	reqBody := map[string]any{
+		"model": "gpt-5.2",
+		"input": []any{
+			map[string]any{"type": "message", "id": "msg_0", "role": "user", "content": "hi"},
+			map[string]any{"type": "item_reference", "id": "rs_123"},
+		},
+		"tool_choice": "auto",
+	}
+
+	applyCodexOAuthTransform(reqBody, false, false)
+
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 2)
+
+	first, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "msg_0", first["id"])
+
+	second, ok := input[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "rs_123", second["id"])
+}
+
+func TestApplyCodexOAuthTransform_ToolContinuationNormalizesToolReferenceIDsOnly(t *testing.T) {
+	reqBody := map[string]any{
+		"model": "gpt-5.2",
+		"input": []any{
+			map[string]any{"type": "item_reference", "id": "call_1"},
+			map[string]any{"type": "function_call_output", "call_id": "call_1", "output": "ok"},
+		},
+		"tool_choice": "auto",
+	}
+
+	applyCodexOAuthTransform(reqBody, false, false)
+
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 2)
+
+	first, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "fc1", first["id"])
+
+	second, ok := input[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "fc1", second["call_id"])
 }
 
 func TestApplyCodexOAuthTransform_ExplicitStoreFalsePreserved(t *testing.T) {


### PR DESCRIPTION
## 背景

2026-03-14 最新主线更新后，有用户反馈 Codex / Responses 相关调用出现 400：

- `Invalid 'input[i].id': 'fc_rs_...' Expected an ID that begins with 'rs'`
- `Invalid 'input[i].id': 'fc_msg_0' Expected an ID that begins with 'msg'`

排查后确认，这不是之前 PG/计费减压 PR 引入的问题，而是最新主线中 Codex transform 的一处兼容逻辑把原生 `msg_*` / `rs_*` / 普通 input item id 误改成了 `fc_*`。

## 根因

`backend/internal/service/openai_codex_transform.go` 在 tool continuation 路径里新增了统一 `fixIDPrefix` 逻辑，范围过宽：

- 会改写 `item_reference.id`
- 会改写普通保留 item 的 `id`
- 从而把本来合法的 `msg_*` / `rs_*` 一并改坏

## 本 PR 做了什么

这是一个止血版本，目标是先恢复合法请求，不继续扩大改动面：

1. **不再改写原生 Responses input id**
   - 保留 `msg_*`
   - 保留 `rs_*`
   - 保留普通 input item 的 `id`

2. **尽量保留 tool call 兼容**
   - 继续只对真正的 `call_id` 做兼容修正
   - `item_reference.id` 只有在明显是 tool call 引用（如 `call_*`）时才会一起归一化

3. **补回归测试**
   - 校验 tool continuation 下普通 `id` 不再被误改
   - 校验 `msg_*` / `rs_*` 保持原样
   - 校验 tool call 引用仍能和 `call_id` 对齐

## 影响范围

- 主要影响 Codex / Responses 的 tool continuation 兼容层
- 不涉及之前 PG 减压 / 计费解耦逻辑

## 与旧 PR 的关系

- 旧 PR：#952
- 这次 hotfix 不是对 #952 的延续修改，也不是 #952 引入的问题
- 两者处理的是不同方向：
  - `#952`：PG 减压 / 计费与 usage log 解耦
  - 本 PR：Codex / Responses 原生 input id 被误改的止血修复

## 验证

- 按要求未额外跑本地测试
- 已补充对应单元测试，交由 CI 进一步验证
