### PR TITLE
fix(ops): tune aggregation constants to prevent PG overload

### DIFF
--- a/backend/internal/service/ops_aggregation_service.go
+++ b/backend/internal/service/ops_aggregation_service.go
@@ -23,7 +23,7 @@ const (
 	opsAggDailyInterval  = 1 * time.Hour
 
 	// Keep in sync with ops retention target (vNext default 30d).
-	opsAggBackfillWindow = 30 * 24 * time.Hour
+	opsAggBackfillWindow = 1 * time.Hour
 
 	// Recompute overlap to absorb late-arriving rows near boundaries.
 	opsAggHourlyOverlap = 2 * time.Hour
@@ -36,7 +36,7 @@ const (
 	// that may still receive late inserts.
 	opsAggSafeDelay = 5 * time.Minute
 
-	opsAggMaxQueryTimeout = 3 * time.Second
+	opsAggMaxQueryTimeout = 5 * time.Second
 	opsAggHourlyTimeout   = 5 * time.Minute
 	opsAggDailyTimeout    = 2 * time.Minute
 


### PR DESCRIPTION
## 背景 / Background

OpsAggregationService 的 hourly 聚合任务在查询 `MAX(bucket_start)` 时，如果超过 3 秒超时，会退化为全量回算（30 天窗口），生成超重 SQL 导致 PG CPU/内存打满。

The hourly aggregation job in OpsAggregationService falls back to a full recomputation (30-day window) when the `MAX(bucket_start)` query exceeds its 3-second timeout, generating heavy SQL that saturates PG CPU and memory.

---

## 目的 / Purpose

通过调整两个常量，降低超时退化为全量回算时的影响：增大查询超时减少退化概率，缩小回算窗口降低退化代价。

Reduce the blast radius of timeout-induced fallbacks by increasing the query timeout (fewer fallbacks) and shrinking the backfill window (cheaper fallbacks).

---

## 改动内容 / Changes

### 后端 / Backend

- **`opsAggMaxQueryTimeout`**：3s → 5s，给 `MAX(bucket_start)` 查询更多时间，减少超时退化概率
- **`opsAggBackfillWindow`**：30 天 → 1 小时，超时退化时只回算最近 1 小时而非 30 天

---

- **`opsAggMaxQueryTimeout`**: 3s → 5s, allow more time for the `MAX(bucket_start)` query to reduce timeout-induced fallbacks
- **`opsAggBackfillWindow`**: 30 days → 1 hour, limit fallback recomputation to the last hour instead of the full retention window