### PR TITLE
fix(billing): treat nil rate limit window as expired to prevent usage accumulation

### DIFF
--- a/backend/internal/service/api_key.go
+++ b/backend/internal/service/api_key.go
@@ -22,8 +22,9 @@ const (
 )
 
 // IsWindowExpired returns true if the window starting at windowStart has exceeded the given duration.
+// A nil windowStart is treated as expired — no initialized window means any accumulated usage is stale.
 func IsWindowExpired(windowStart *time.Time, duration time.Duration) bool {
-	return windowStart != nil && time.Since(*windowStart) >= duration
+	return windowStart == nil || time.Since(*windowStart) >= duration
 }
 
 type APIKey struct {

--- a/backend/internal/service/api_key_rate_limit_test.go
+++ b/backend/internal/service/api_key_rate_limit_test.go
@@ -15,10 +15,10 @@ func TestIsWindowExpired(t *testing.T) {
 		want     bool
 	}{
 		{
-			name:     "nil window start",
+			name:     "nil window start (treated as expired)",
 			start:    nil,
 			duration: RateLimitWindow5h,
-			want:     false,
+			want:     true,
 		},
 		{
 			name:     "active window (started 1h ago, 5h window)",
@@ -113,7 +113,7 @@ func TestAPIKey_EffectiveUsage(t *testing.T) {
 			want7d: 0,
 		},
 		{
-			name: "nil window starts return raw usage",
+			name: "nil window starts return 0 (stale usage reset)",
 			key: APIKey{
 				Usage5h:       5.0,
 				Usage1d:       10.0,
@@ -122,9 +122,9 @@ func TestAPIKey_EffectiveUsage(t *testing.T) {
 				Window1dStart: nil,
 				Window7dStart: nil,
 			},
-			want5h: 5.0,
-			want1d: 10.0,
-			want7d: 50.0,
+			want5h: 0,
+			want1d: 0,
+			want7d: 0,
 		},
 		{
 			name: "mixed: 5h expired, 1d active, 7d nil",
@@ -138,7 +138,7 @@ func TestAPIKey_EffectiveUsage(t *testing.T) {
 			},
 			want5h: 0,
 			want1d: 10.0,
-			want7d: 50.0,
+			want7d: 0,
 		},
 		{
 			name: "zero usage with active windows",
@@ -210,7 +210,7 @@ func TestAPIKeyRateLimitData_EffectiveUsage(t *testing.T) {
 			want7d: 0,
 		},
 		{
-			name: "nil window starts return raw usage",
+			name: "nil window starts return 0 (stale usage reset)",
 			data: APIKeyRateLimitData{
 				Usage5h:       3.0,
 				Usage1d:       8.0,
@@ -219,9 +219,9 @@ func TestAPIKeyRateLimitData_EffectiveUsage(t *testing.T) {
 				Window1dStart: nil,
 				Window7dStart: nil,
 			},
-			want5h: 3.0,
-			want1d: 8.0,
-			want7d: 40.0,
+			want5h: 0,
+			want1d: 0,
+			want7d: 0,
 		},
 	}
 


### PR DESCRIPTION
## 背景 / Background

标准余额模式下，API Key 设置了速率限制（如日限额）后，当累计总用量超过日限额时，即使当天实际用量远未达标，也会报 `api key 日限额已用完` 错误。

In standard balance mode, after setting rate limits (e.g., daily limit) on an API key, once the cumulative total usage exceeds the daily limit, the system reports "daily limit exceeded" even though actual daily usage is well below the limit.

---

## 目的 / Purpose

修复 `IsWindowExpired(nil, ...)` 返回 `false` 导致 Redis 缓存中 `usage_1d` 跨天不重置、持续累积的问题。

Fix `IsWindowExpired(nil, ...)` returning `false`, which causes `usage_1d` in Redis cache to never reset across days and accumulate indefinitely.

---

## 改动内容 / Changes

### 后端 / Backend

- **`IsWindowExpired` 语义修正**：将 `nil` 窗口视为"已过期"而非"未过期"。`nil` 表示窗口从未初始化，任何累积的 usage 都是过时的，应被重置为 0
- **测试用例更新**：同步更新 3 个 nil 窗口相关的测试用例，期望值从"返回原始 usage"改为"返回 0"

---

- **`IsWindowExpired` semantics fix**: Treat `nil` window as "expired" instead of "not expired". A nil window means the window was never initialized — any accumulated usage is stale and should be reset to 0
- **Test cases updated**: Updated 3 nil-window test cases to expect 0 instead of raw usage values

---

## 根因分析 / Root Cause

1. Redis 缓存首次从 DB 加载时，若 `window_1d_start` 为 NULL，则 Redis 中 `window_1d = 0`
2. Redis Lua 增量脚本只执行 `HINCRBYFLOAT usage_1d, cost`，**不更新 window 时间戳**
3. Go 端 `IsWindowExpired(nil, 24h)` 返回 `false`（视为"窗口未过期"），不触发 usage 重置
4. 结果：`usage_1d` 跨天持续累积，效果等同于总用量，超过 `rate_limit_1d` 即误报限速

Fixes #1022