### PR TITLE
fix(billing): allow clearing group quota limits and treat 0 as zero-limit

### DIFF
--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -832,7 +832,7 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 		subscriptionType = SubscriptionTypeStandard
 	}
 
-	// 限额字段：0 和 nil 都表示"无限制"
+	// 限额字段：nil/负数 表示"无限制"，0 表示"不允许用量"，正数表示具体限额
 	dailyLimit := normalizeLimit(input.DailyLimitUSD)
 	weeklyLimit := normalizeLimit(input.WeeklyLimitUSD)
 	monthlyLimit := normalizeLimit(input.MonthlyLimitUSD)
@@ -944,9 +944,9 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 	return group, nil
 }
 
-// normalizeLimit 将 0 或负数转换为 nil（表示无限制）
+// normalizeLimit 将负数转换为 nil（表示无限制），0 保留（表示限额为零）
 func normalizeLimit(limit *float64) *float64 {
-	if limit == nil || *limit <= 0 {
+	if limit == nil || *limit < 0 {
 		return nil
 	}
 	return limit
@@ -1058,16 +1058,11 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	if input.SubscriptionType != "" {
 		group.SubscriptionType = input.SubscriptionType
 	}
-	// 限额字段：0 和 nil 都表示"无限制"，正数表示具体限额
-	if input.DailyLimitUSD != nil {
-		group.DailyLimitUSD = normalizeLimit(input.DailyLimitUSD)
-	}
-	if input.WeeklyLimitUSD != nil {
-		group.WeeklyLimitUSD = normalizeLimit(input.WeeklyLimitUSD)
-	}
-	if input.MonthlyLimitUSD != nil {
-		group.MonthlyLimitUSD = normalizeLimit(input.MonthlyLimitUSD)
-	}
+	// 限额字段：nil/负数 表示"无限制"，0 表示"不允许用量"，正数表示具体限额
+	// 前端始终发送这三个字段，无需 nil 守卫
+	group.DailyLimitUSD = normalizeLimit(input.DailyLimitUSD)
+	group.WeeklyLimitUSD = normalizeLimit(input.WeeklyLimitUSD)
+	group.MonthlyLimitUSD = normalizeLimit(input.MonthlyLimitUSD)
 	// 图片生成计费配置：负数表示清除（使用默认价格）
 	if input.ImagePrice1K != nil {
 		group.ImagePrice1K = normalizePrice(input.ImagePrice1K)

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -2382,6 +2382,11 @@ const handleCreateGroup = async () => {
       sora_storage_quota_bytes: createQuotaGb ? Math.round(createQuotaGb * 1024 * 1024 * 1024) : 0,
       model_routing: convertRoutingRulesToApiFormat(createModelRoutingRules.value)
     }
+    // v-model.number 清空输入框时产生 ""，转为 null 让后端设为无限制
+    const emptyToNull = (v: any) => v === '' ? null : v
+    requestData.daily_limit_usd = emptyToNull(requestData.daily_limit_usd)
+    requestData.weekly_limit_usd = emptyToNull(requestData.weekly_limit_usd)
+    requestData.monthly_limit_usd = emptyToNull(requestData.monthly_limit_usd)
     await adminAPI.groups.create(requestData)
     appStore.showSuccess(t('admin.groups.groupCreated'))
     closeCreateModal()
@@ -2465,6 +2470,11 @@ const handleUpdateGroup = async () => {
           : editForm.fallback_group_id_on_invalid_request,
       model_routing: convertRoutingRulesToApiFormat(editModelRoutingRules.value)
     }
+    // v-model.number 清空输入框时产生 ""，转为 null 让后端设为无限制
+    const emptyToNull = (v: any) => v === '' ? null : v
+    payload.daily_limit_usd = emptyToNull(payload.daily_limit_usd)
+    payload.weekly_limit_usd = emptyToNull(payload.weekly_limit_usd)
+    payload.monthly_limit_usd = emptyToNull(payload.monthly_limit_usd)
     await adminAPI.groups.update(editingGroup.value.id, payload)
     appStore.showSuccess(t('admin.groups.groupUpdated'))
     closeEditModal()


### PR DESCRIPTION
## 背景 / Background

编辑订阅分组时，如果之前设置了日/周/月限额（如 daily=40, weekly=250, monthly=1000），想要清空某个限额（改为无限制），操作 100% 失败。原因是 Vue 3 的 `v-model.number` 在输入框被清空时绑定值变成空字符串 `""`，Go 的 JSON 解码器无法将 `""` 解析为 `*float64`，导致 `ShouldBindJSON` 返回 400 错误。

When editing a subscription group that has quota limits set (e.g., daily=40, weekly=250, monthly=1000), attempting to clear any limit (set to unlimited) always fails. Vue 3's `v-model.number` produces an empty string `""` when the input is cleared, and Go's JSON decoder cannot parse `""` into `*float64`, causing `ShouldBindJSON` to return a 400 error.

---

## 目的 / Purpose

1. 修复清空限额输入框导致 400 错误的 bug
2. 修正 `normalizeLimit` 的语义：`0` 应表示"限额为零（不允许用量）"，而非"无限制"

1. Fix the bug where clearing a quota limit input causes a 400 error
2. Correct `normalizeLimit` semantics: `0` should mean "zero quota (no usage allowed)", not "unlimited"

---

## 改动内容 / Changes

### 后端 / Backend

- **`normalizeLimit`**：`*limit <= 0` 改为 `*limit < 0`，保留 `0` 作为有效限额值（限额为零 = 不允许用量），仅将负数转为 `nil`（无限制）
- **`UpdateGroup`**：移除三个限额字段的 `if input != nil` 守卫，前端始终发送这些字段，`null` 表示清除限额（无限制）

---

- **`normalizeLimit`**: Changed `*limit <= 0` to `*limit < 0` — `0` is now preserved as a valid limit (zero quota = no usage allowed), only negative values are converted to `nil` (unlimited)
- **`UpdateGroup`**: Removed `if input != nil` guards for the three limit fields — frontend always sends these fields, `null` means clear the limit (unlimited)

### 前端 / Frontend

- **`handleUpdateGroup` / `handleCreateGroup`**：`v-model.number` 清空输入框产生的 `""` 转为 `null`，让后端正确清除限额

---

- **`handleUpdateGroup` / `handleCreateGroup`**: Convert `""` (produced by `v-model.number` when input is cleared) to `null`, so the backend correctly clears the limit

---

## 语义对照 / Semantics

| 用户操作 / Action | 前端值 / Frontend | JSON | 后端 / Backend | 数据库 / DB | 含义 / Meaning |
|---|---|---|---|---|---|
| 清空输入框 / Clear input | `""` → `null` | `null` | `nil` | `NULL` | 无限制 / Unlimited |
| 输入 0 / Enter 0 | `0` | `0` | `ptr(0)` | `0` | 不允许用量 / No usage |
| 输入 42 / Enter 42 | `42` | `42` | `ptr(42)` | `42` | 限额 42 / Limit 42 |
| 不修改 / No change | 原值 / original | 原值 | 原值 | 不变 / Unchanged | 保持不变 / No change |

Closes #1021