### PR TITLE
fix(ratelimit): handle upstream 401 account deactivation

### DIFF
--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -230,6 +231,113 @@ func (h *OpenAIOAuthHandler) RefreshAccountToken(c *gin.Context) {
 	}
 
 	response.Success(c, dto.AccountFromService(updatedAccount))
+}
+
+type OpenAICreateAccountFromAccessTokenRequest struct {
+	AccessToken      string  `json:"access_token"`
+	AT               string  `json:"at"`
+	RefreshToken     string  `json:"refresh_token"`
+	ClientID         string  `json:"client_id"`
+	Email            string  `json:"email"`
+	ChatGPTAccountID string  `json:"chatgpt_account_id"`
+	ChatGPTUserID    string  `json:"chatgpt_user_id"`
+	OrganizationID   string  `json:"organization_id"`
+	PlanType         string  `json:"plan_type"`
+	IDToken          string  `json:"id_token"`
+	ExpiresAt        *int64  `json:"expires_at"`
+	ExpiresIn        *int64  `json:"expires_in"`
+	ProxyID          *int64  `json:"proxy_id"`
+	Name             string  `json:"name"`
+	Concurrency      int     `json:"concurrency"`
+	Priority         int     `json:"priority"`
+	GroupIDs         []int64 `json:"group_ids"`
+}
+
+// CreateAccountFromAccessToken creates a new OpenAI/Sora OAuth account directly from access token.
+// POST /api/v1/admin/openai/create-from-access-token
+// POST /api/v1/admin/sora/create-from-access-token
+func (h *OpenAIOAuthHandler) CreateAccountFromAccessToken(c *gin.Context) {
+	var req OpenAICreateAccountFromAccessTokenRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+
+	accessToken := strings.TrimSpace(req.AccessToken)
+	if accessToken == "" {
+		accessToken = strings.TrimSpace(req.AT)
+	}
+	if accessToken == "" {
+		response.BadRequest(c, "access_token is required")
+		return
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(time.Hour).Unix()
+	if req.ExpiresAt != nil && *req.ExpiresAt > 0 {
+		expiresAt = *req.ExpiresAt
+	} else if req.ExpiresIn != nil {
+		expiresAt = now.Add(time.Duration(*req.ExpiresIn) * time.Second).Unix()
+	}
+	if expiresAt < now.Unix() {
+		response.BadRequest(c, "expires_at must be in the future")
+		return
+	}
+
+	platform := oauthPlatformFromPath(c)
+	clientID := strings.TrimSpace(req.ClientID)
+	if clientID == "" {
+		clientID, _ = openai.OAuthClientConfigByPlatform(platform)
+	}
+
+	tokenInfo := &service.OpenAITokenInfo{
+		AccessToken:      accessToken,
+		RefreshToken:     strings.TrimSpace(req.RefreshToken),
+		IDToken:          strings.TrimSpace(req.IDToken),
+		ExpiresIn:        expiresAt - now.Unix(),
+		ExpiresAt:        expiresAt,
+		ClientID:         clientID,
+		Email:            strings.TrimSpace(req.Email),
+		ChatGPTAccountID: strings.TrimSpace(req.ChatGPTAccountID),
+		ChatGPTUserID:    strings.TrimSpace(req.ChatGPTUserID),
+		OrganizationID:   strings.TrimSpace(req.OrganizationID),
+		PlanType:         strings.TrimSpace(req.PlanType),
+	}
+	if tokenInfo.ExpiresIn < 0 {
+		tokenInfo.ExpiresIn = 0
+	}
+
+	credentials := h.openaiOAuthService.BuildAccountCredentials(tokenInfo)
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" && tokenInfo.Email != "" {
+		name = tokenInfo.Email
+	}
+	if name == "" {
+		if platform == service.PlatformSora {
+			name = "Sora Access Token Account"
+		} else {
+			name = "OpenAI Access Token Account"
+		}
+	}
+
+	account, err := h.adminService.CreateAccount(c.Request.Context(), &service.CreateAccountInput{
+		Name:        name,
+		Platform:    platform,
+		Type:        service.AccountTypeOAuth,
+		Credentials: credentials,
+		Extra:       nil,
+		ProxyID:     req.ProxyID,
+		Concurrency: req.Concurrency,
+		Priority:    req.Priority,
+		GroupIDs:    req.GroupIDs,
+	})
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.AccountFromService(account))
 }
 
 // CreateAccountFromOAuth creates a new OpenAI/Sora OAuth account from token info

--- a/backend/internal/handler/admin/openai_oauth_handler_test.go
+++ b/backend/internal/handler/admin/openai_oauth_handler_test.go
@@ -1,0 +1,114 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	openaipkg "github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIOAuthHandlerCreateAccountFromAccessToken_OpenAI(t *testing.T) {
+	adminSvc := newStubAdminService()
+	handler := NewOpenAIOAuthHandler(service.NewOpenAIOAuthService(nil, nil), adminSvc)
+
+	router := gin.New()
+	route := "/api/v1/admin/openai/create-from-access-token"
+	router.POST(route, handler.CreateAccountFromAccessToken)
+
+	payload, err := json.Marshal(map[string]any{
+		"access_token": "at-openai-123",
+		"email":        "openai@example.com",
+		"concurrency":  2,
+		"priority":     3,
+		"group_ids":    []int64{11, 12},
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, route, bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, adminSvc.createdAccounts, 1)
+
+	input := adminSvc.createdAccounts[0]
+	require.Equal(t, "openai@example.com", input.Name)
+	require.Equal(t, service.PlatformOpenAI, input.Platform)
+	require.Equal(t, service.AccountTypeOAuth, input.Type)
+	require.Equal(t, 2, input.Concurrency)
+	require.Equal(t, 3, input.Priority)
+	require.Equal(t, []int64{11, 12}, input.GroupIDs)
+	require.Equal(t, "at-openai-123", input.Credentials["access_token"])
+	require.Equal(t, openaipkg.ClientID, input.Credentials["client_id"])
+	_, hasRefreshToken := input.Credentials["refresh_token"]
+	require.False(t, hasRefreshToken)
+
+	expiresAtRaw, ok := input.Credentials["expires_at"].(string)
+	require.True(t, ok)
+	expiresAt, err := time.Parse(time.RFC3339, expiresAtRaw)
+	require.NoError(t, err)
+	require.WithinDuration(t, time.Now().Add(time.Hour), expiresAt, 5*time.Second)
+}
+
+func TestOpenAIOAuthHandlerCreateAccountFromAccessToken_SoraAcceptsAliasAndExplicitExpiry(t *testing.T) {
+	adminSvc := newStubAdminService()
+	handler := NewOpenAIOAuthHandler(service.NewOpenAIOAuthService(nil, nil), adminSvc)
+
+	router := gin.New()
+	route := "/api/v1/admin/sora/create-from-access-token"
+	router.POST(route, handler.CreateAccountFromAccessToken)
+
+	expiresAtUnix := time.Now().Add(2 * time.Hour).Unix()
+	payload, err := json.Marshal(map[string]any{
+		"at":         "at-sora-456",
+		"name":       "sora-direct-account",
+		"expires_at": expiresAtUnix,
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, route, bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, adminSvc.createdAccounts, 1)
+
+	input := adminSvc.createdAccounts[0]
+	require.Equal(t, "sora-direct-account", input.Name)
+	require.Equal(t, service.PlatformSora, input.Platform)
+	require.Equal(t, service.AccountTypeOAuth, input.Type)
+	require.Equal(t, "at-sora-456", input.Credentials["access_token"])
+	require.Equal(t, time.Unix(expiresAtUnix, 0).Format(time.RFC3339), input.Credentials["expires_at"])
+}
+
+func TestOpenAIOAuthHandlerCreateAccountFromAccessToken_RejectsPastExpiry(t *testing.T) {
+	adminSvc := newStubAdminService()
+	handler := NewOpenAIOAuthHandler(service.NewOpenAIOAuthService(nil, nil), adminSvc)
+
+	router := gin.New()
+	route := "/api/v1/admin/openai/create-from-access-token"
+	router.POST(route, handler.CreateAccountFromAccessToken)
+
+	payload, err := json.Marshal(map[string]any{
+		"access_token": "at-openai-123",
+		"expires_at":   time.Now().Add(-time.Minute).Unix(),
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, route, bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Empty(t, adminSvc.createdAccounts)
+}

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -307,6 +307,7 @@ func registerOpenAIOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		openai.POST("/refresh-token", h.Admin.OpenAIOAuth.RefreshToken)
 		openai.POST("/accounts/:id/refresh", h.Admin.OpenAIOAuth.RefreshAccountToken)
 		openai.POST("/create-from-oauth", h.Admin.OpenAIOAuth.CreateAccountFromOAuth)
+		openai.POST("/create-from-access-token", h.Admin.OpenAIOAuth.CreateAccountFromAccessToken)
 	}
 }
 
@@ -320,6 +321,7 @@ func registerSoraOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		sora.POST("/rt2at", h.Admin.OpenAIOAuth.RefreshToken)
 		sora.POST("/accounts/:id/refresh", h.Admin.OpenAIOAuth.RefreshAccountToken)
 		sora.POST("/create-from-oauth", h.Admin.OpenAIOAuth.CreateAccountFromOAuth)
+		sora.POST("/create-from-access-token", h.Admin.OpenAIOAuth.CreateAccountFromAccessToken)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -165,7 +165,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	var result *OpenAIForwardResult
 	var handleErr error
 	if clientStream {
-		result, handleErr = s.handleChatStreamingResponse(resp, c, originalModel, mappedModel, includeUsage, startTime)
+		result, handleErr = s.handleChatStreamingResponse(resp, c, account, originalModel, mappedModel, includeUsage, startTime)
 	} else {
 		result, handleErr = s.handleChatBufferedStreamingResponse(resp, c, originalModel, mappedModel, startTime)
 	}
@@ -291,6 +291,7 @@ func (s *OpenAIGatewayService) handleChatBufferedStreamingResponse(
 func (s *OpenAIGatewayService) handleChatStreamingResponse(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 	includeUsage bool,
@@ -305,7 +306,6 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.Header().Set("Connection", "keep-alive")
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
-	c.Writer.WriteHeader(http.StatusOK)
 
 	state := apicompat.NewResponsesEventToChatState()
 	state.Model = originalModel
@@ -314,6 +314,7 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 	var usage OpenAIUsage
 	var firstTokenMs *int
 	firstChunk := true
+	streamCommitted := false
 
 	scanner := bufio.NewScanner(resp.Body)
 	maxLineSize := defaultMaxLineSize
@@ -334,7 +335,20 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 		}
 	}
 
-	processDataLine := func(payload string) bool {
+	commitStream := func() {
+		if streamCommitted {
+			return
+		}
+		c.Writer.WriteHeader(http.StatusOK)
+		streamCommitted = true
+	}
+
+	processDataLine := func(payload string) (bool, *UpstreamFailoverError) {
+		if !streamCommitted {
+			if failoverErr, ok := s.buildOpenAIStreamingFailoverError(c.Request.Context(), c, resp, account, []byte(payload)); ok {
+				return false, failoverErr
+			}
+		}
 		if firstChunk {
 			firstChunk = false
 			ms := int(time.Since(startTime).Milliseconds())
@@ -347,7 +361,7 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 				zap.Error(err),
 				zap.String("request_id", requestID),
 			)
-			return false
+			return false, nil
 		}
 
 		// Extract usage from completion events
@@ -364,6 +378,7 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 
 		chunks := apicompat.ResponsesEventToChatChunks(&event, state)
 		for _, chunk := range chunks {
+			commitStream()
 			sse, err := apicompat.ChatChunkToSSE(chunk)
 			if err != nil {
 				logger.L().Warn("openai chat_completions stream: failed to marshal chunk",
@@ -376,16 +391,17 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 				logger.L().Info("openai chat_completions stream: client disconnected",
 					zap.String("request_id", requestID),
 				)
-				return true
+				return true, nil
 			}
 		}
 		if len(chunks) > 0 {
 			c.Writer.Flush()
 		}
-		return false
+		return false, nil
 	}
 
 	finalizeStream := func() (*OpenAIForwardResult, error) {
+		commitStream()
 		if finalChunks := apicompat.FinalizeResponsesChatStream(state); len(finalChunks) > 0 {
 			for _, chunk := range finalChunks {
 				sse, err := apicompat.ChatChunkToSSE(chunk)
@@ -423,7 +439,11 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 			if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
 				continue
 			}
-			if processDataLine(line[6:]) {
+			clientDisconnected, failoverErr := processDataLine(line[6:])
+			if failoverErr != nil {
+				return resultWithUsage(), failoverErr
+			}
+			if clientDisconnected {
 				return resultWithUsage(), nil
 			}
 		}
@@ -478,11 +498,18 @@ func (s *OpenAIGatewayService) handleChatStreamingResponse(
 			if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
 				continue
 			}
-			if processDataLine(line[6:]) {
+			clientDisconnected, failoverErr := processDataLine(line[6:])
+			if failoverErr != nil {
+				return resultWithUsage(), failoverErr
+			}
+			if clientDisconnected {
 				return resultWithUsage(), nil
 			}
 
 		case <-keepaliveTicker.C:
+			if !streamCommitted {
+				continue
+			}
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -180,7 +180,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	var result *OpenAIForwardResult
 	var handleErr error
 	if clientStream {
-		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, originalModel, mappedModel, startTime)
+		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, mappedModel, startTime)
 	} else {
 		// Client wants JSON: buffer the streaming response and assemble a JSON reply.
 		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, originalModel, mappedModel, startTime)
@@ -315,6 +315,7 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 	startTime time.Time,
@@ -328,13 +329,13 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.Header().Set("Connection", "keep-alive")
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
-	c.Writer.WriteHeader(http.StatusOK)
 
 	state := apicompat.NewResponsesEventToAnthropicState()
 	state.Model = originalModel
 	var usage OpenAIUsage
 	var firstTokenMs *int
 	firstChunk := true
+	streamCommitted := false
 
 	scanner := bufio.NewScanner(resp.Body)
 	maxLineSize := defaultMaxLineSize
@@ -358,7 +359,20 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 
 	// processDataLine handles a single "data: ..." SSE line from upstream.
 	// Returns (clientDisconnected bool).
-	processDataLine := func(payload string) bool {
+	commitStream := func() {
+		if streamCommitted {
+			return
+		}
+		c.Writer.WriteHeader(http.StatusOK)
+		streamCommitted = true
+	}
+
+	processDataLine := func(payload string) (bool, *UpstreamFailoverError) {
+		if !streamCommitted {
+			if failoverErr, ok := s.buildOpenAIStreamingFailoverError(c.Request.Context(), c, resp, account, []byte(payload)); ok {
+				return false, failoverErr
+			}
+		}
 		if firstChunk {
 			firstChunk = false
 			ms := int(time.Since(startTime).Milliseconds())
@@ -371,7 +385,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 				zap.Error(err),
 				zap.String("request_id", requestID),
 			)
-			return false
+			return false, nil
 		}
 
 		// Extract usage from completion events
@@ -389,6 +403,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 		// Convert to Anthropic events
 		events := apicompat.ResponsesEventToAnthropicEvents(&event, state)
 		for _, evt := range events {
+			commitStream()
 			sse, err := apicompat.ResponsesAnthropicEventToSSE(evt)
 			if err != nil {
 				logger.L().Warn("openai messages stream: failed to marshal event",
@@ -401,18 +416,19 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 				logger.L().Info("openai messages stream: client disconnected",
 					zap.String("request_id", requestID),
 				)
-				return true
+				return true, nil
 			}
 		}
 		if len(events) > 0 {
 			c.Writer.Flush()
 		}
-		return false
+		return false, nil
 	}
 
 	// finalizeStream sends any remaining Anthropic events and returns the result.
 	finalizeStream := func() (*OpenAIForwardResult, error) {
 		if finalEvents := apicompat.FinalizeResponsesAnthropicStream(state); len(finalEvents) > 0 {
+			commitStream()
 			for _, evt := range finalEvents {
 				sse, err := apicompat.ResponsesAnthropicEventToSSE(evt)
 				if err != nil {
@@ -448,7 +464,11 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
 				continue
 			}
-			if processDataLine(line[6:]) {
+			clientDisconnected, failoverErr := processDataLine(line[6:])
+			if failoverErr != nil {
+				return resultWithUsage(), failoverErr
+			}
+			if clientDisconnected {
 				return resultWithUsage(), nil
 			}
 		}
@@ -504,11 +524,18 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			if !strings.HasPrefix(line, "data: ") || line == "data: [DONE]" {
 				continue
 			}
-			if processDataLine(line[6:]) {
+			clientDisconnected, failoverErr := processDataLine(line[6:])
+			if failoverErr != nil {
+				return resultWithUsage(), failoverErr
+			}
+			if clientDisconnected {
 				return resultWithUsage(), nil
 			}
 
 		case <-keepaliveTicker.C:
+			if !streamCommitted {
+				continue
+			}
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2669,6 +2669,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	usage := &OpenAIUsage{}
 	var firstTokenMs *int
 	clientDisconnected := false
+	downstreamStarted := false
 	sawDone := false
 	sawTerminalEvent := false
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
@@ -2685,6 +2686,11 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	for scanner.Scan() {
 		line := scanner.Text()
 		if data, ok := extractOpenAISSEDataLine(line); ok {
+			if !downstreamStarted {
+				if failoverErr, ok := s.buildOpenAIStreamingFailoverError(ctx, c, resp, account, []byte(data)); ok {
+					return &openaiStreamingResultPassthrough{usage: usage, firstTokenMs: firstTokenMs}, failoverErr
+				}
+			}
 			dataBytes := []byte(data)
 			trimmedData := strings.TrimSpace(data)
 			if trimmedData == "[DONE]" {
@@ -2706,6 +2712,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
 			} else {
 				flusher.Flush()
+				downstreamStarted = true
 			}
 		}
 	}
@@ -3272,6 +3279,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	errorEventSent := false
 	clientDisconnected := false // 客户端断开后继续 drain 上游以收集 usage
 	sawTerminalEvent := false
+	downstreamStarted := false
 	sendErrorEvent := func(reason string) {
 		if errorEventSent || clientDisconnected {
 			return
@@ -3288,7 +3296,9 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 		}
 		if err := flushBuffered(); err != nil {
 			clientDisconnected = true
+			return
 		}
+		downstreamStarted = true
 	}
 
 	needModelReplace := originalModel != mappedModel
@@ -3373,6 +3383,8 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 					if err := flushBuffered(); err != nil {
 						clientDisconnected = true
 						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+					} else {
+						downstreamStarted = true
 					}
 				}
 			}
@@ -3398,6 +3410,8 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 				if err := flushBuffered(); err != nil {
 					clientDisconnected = true
 					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+				} else {
+					downstreamStarted = true
 				}
 			}
 		}
@@ -3407,6 +3421,11 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	if streamInterval <= 0 && keepaliveInterval <= 0 {
 		defer putSSEScannerBuf64K(scanBuf)
 		for scanner.Scan() {
+			if !downstreamStarted {
+				if failoverErr, ok := s.buildOpenAIStreamingFailoverError(ctx, c, resp, account, []byte(extractDataLineForFailover(scanner.Text()))); ok {
+					return resultWithUsage(), failoverErr
+				}
+			}
 			processSSELine(scanner.Text(), true)
 		}
 		if result, err, done := handleScanErr(scanner.Err()); done {
@@ -3456,6 +3475,11 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			if result, err, done := handleScanErr(ev.err); done {
 				return result, err
 			}
+			if !downstreamStarted {
+				if failoverErr, ok := s.buildOpenAIStreamingFailoverError(ctx, c, resp, account, []byte(extractDataLineForFailover(ev.line))); ok {
+					return resultWithUsage(), failoverErr
+				}
+			}
 			processSSELine(ev.line, len(events) == 0)
 
 		case <-intervalCh:
@@ -3475,6 +3499,9 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			return resultWithUsage(), fmt.Errorf("stream data interval timeout")
 
 		case <-keepaliveCh:
+			if !downstreamStarted {
+				continue
+			}
 			if clientDisconnected {
 				continue
 			}
@@ -3489,7 +3516,9 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			if err := flushBuffered(); err != nil {
 				clientDisconnected = true
 				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during keepalive flush, continuing to drain upstream for billing")
+				continue
 			}
+			downstreamStarted = true
 		}
 	}
 
@@ -3509,6 +3538,14 @@ func extractOpenAISSEDataLine(line string) (string, bool) {
 		start++
 	}
 	return line[start:], true
+}
+
+func extractDataLineForFailover(line string) string {
+	data, ok := extractOpenAISSEDataLine(line)
+	if !ok {
+		return ""
+	}
+	return data
 }
 
 func (s *OpenAIGatewayService) replaceModelInSSELine(line, fromModel, toModel string) string {
@@ -3717,6 +3754,102 @@ func extractOpenAISSEErrorMessage(payload []byte) string {
 		}
 	}
 	return sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(payload)))
+}
+
+func parseOpenAISSEErrorFields(payload []byte) (code string, errType string, errMessage string) {
+	if len(payload) == 0 {
+		return "", "", ""
+	}
+
+	values := gjson.GetManyBytes(
+		payload,
+		"error.code",
+		"error.type",
+		"error.message",
+		"response.error.code",
+		"response.error.type",
+		"response.error.message",
+	)
+
+	code = strings.TrimSpace(values[0].String())
+	if code == "" {
+		code = strings.TrimSpace(values[3].String())
+	}
+	errType = strings.TrimSpace(values[1].String())
+	if errType == "" {
+		errType = strings.TrimSpace(values[4].String())
+	}
+	errMessage = strings.TrimSpace(values[2].String())
+	if errMessage == "" {
+		errMessage = strings.TrimSpace(values[5].String())
+	}
+	if errMessage == "" {
+		errMessage = extractOpenAISSEErrorMessage(payload)
+	}
+	return code, errType, errMessage
+}
+
+func (s *OpenAIGatewayService) buildOpenAIStreamingFailoverError(
+	ctx context.Context,
+	c *gin.Context,
+	resp *http.Response,
+	account *Account,
+	payload []byte,
+) (*UpstreamFailoverError, bool) {
+	if len(payload) == 0 || account == nil {
+		return nil, false
+	}
+
+	eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	switch eventType {
+	case "error", "response.failed":
+	default:
+		return nil, false
+	}
+
+	codeRaw, errTypeRaw, upstreamMsg := parseOpenAISSEErrorFields(payload)
+	upstreamMsg = sanitizeUpstreamErrorMessage(strings.TrimSpace(upstreamMsg))
+
+	statusCode := openAIWSErrorHTTPStatusFromRaw(codeRaw, errTypeRaw)
+	if statusCode == http.StatusBadGateway && isOpenAITransientProcessingError(http.StatusBadRequest, upstreamMsg, payload) {
+		statusCode = http.StatusBadRequest
+	}
+	if !s.shouldFailoverOpenAIUpstreamResponse(statusCode, upstreamMsg, payload) {
+		return nil, false
+	}
+
+	if upstreamMsg == "" {
+		upstreamMsg = "Upstream request failed"
+	}
+
+	upstreamDetail := ""
+	if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+		maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+		if maxBytes <= 0 {
+			maxBytes = 2048
+		}
+		upstreamDetail = truncateString(string(payload), maxBytes)
+	}
+	setOpsUpstreamError(c, statusCode, upstreamMsg, upstreamDetail)
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: statusCode,
+		UpstreamRequestID:  resp.Header.Get("x-request-id"),
+		Kind:               "failover",
+		Message:            upstreamMsg,
+		Detail:             upstreamDetail,
+	})
+	if s.rateLimitService != nil {
+		s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, resp.Header, payload)
+	}
+
+	return &UpstreamFailoverError{
+		StatusCode:             statusCode,
+		ResponseBody:           append([]byte(nil), payload...),
+		RetryableOnSameAccount: account.IsPoolMode() && (isPoolModeRetryableStatus(statusCode) || isOpenAITransientProcessingError(statusCode, upstreamMsg, payload)),
+	}, true
 }
 
 func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string) error {

--- a/backend/internal/service/openai_stream_failover_test.go
+++ b/backend/internal/service/openai_stream_failover_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newOpenAIStreamingFailoverTestService() *OpenAIGatewayService {
+	return &OpenAIGatewayService{
+		cfg: &config.Config{
+			Gateway: config.GatewayConfig{
+				StreamDataIntervalTimeout: 0,
+				StreamKeepaliveInterval:   0,
+				MaxLineSize:               defaultMaxLineSize,
+			},
+		},
+	}
+}
+
+func newOpenAIStreamingFailoverTestAccount() *Account {
+	return &Account{
+		ID:             101,
+		Name:           "pool-openai",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeAPIKey,
+		Schedulable:    true,
+		Status:         StatusActive,
+		RateMultiplier: f64p(1),
+		Credentials: map[string]any{
+			"pool_mode":             true,
+			"pool_mode_retry_count": 3,
+		},
+	}
+}
+
+func newOpenAITransientErrorStreamResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+			"x-request-id": []string{"rid-stream-error"},
+		},
+		Body: ioNopCloserFromString(strings.Join([]string{
+			`data: {"type":"error","error":{"type":"invalid_request_error","message":"An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID req_123 in your message."}}`,
+			"",
+		}, "\n")),
+	}
+}
+
+func ioNopCloserFromString(body string) *readCloserFromString {
+	return &readCloserFromString{Reader: strings.NewReader(body)}
+}
+
+type readCloserFromString struct {
+	*strings.Reader
+}
+
+func (r *readCloserFromString) Close() error { return nil }
+
+func TestOpenAIStreamingErrorEventTriggersFailoverBeforeClientWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newOpenAIStreamingFailoverTestService()
+	account := newOpenAIStreamingFailoverTestAccount()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	result, err := svc.handleStreamingResponse(c.Request.Context(), newOpenAITransientErrorStreamResponse(), c, account, time.Now(), "gpt-5.4", "gpt-5.4")
+	require.NotNil(t, result)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.Empty(t, rec.Body.String())
+	require.Equal(t, -1, c.Writer.Size())
+}
+
+func TestOpenAIStreamingPassthroughErrorEventTriggersFailoverBeforeClientWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newOpenAIStreamingFailoverTestService()
+	account := newOpenAIStreamingFailoverTestAccount()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	result, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), newOpenAITransientErrorStreamResponse(), c, account, time.Now())
+	require.NotNil(t, result)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.Empty(t, rec.Body.String())
+	require.Equal(t, -1, c.Writer.Size())
+}
+
+func TestChatStreamingErrorEventTriggersFailoverBeforeClientWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newOpenAIStreamingFailoverTestService()
+	account := newOpenAIStreamingFailoverTestAccount()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	result, err := svc.handleChatStreamingResponse(newOpenAITransientErrorStreamResponse(), c, account, "gpt-5.4", "gpt-5.4", false, time.Now())
+	require.NotNil(t, result)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.Empty(t, rec.Body.String())
+	require.Equal(t, -1, c.Writer.Size())
+}
+
+func TestAnthropicStreamingErrorEventTriggersFailoverBeforeClientWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newOpenAIStreamingFailoverTestService()
+	account := newOpenAIStreamingFailoverTestAccount()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	result, err := svc.handleAnthropicStreamingResponse(newOpenAITransientErrorStreamResponse(), c, account, "gpt-5.4", "gpt-5.4", time.Now())
+	require.NotNil(t, result)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
+	require.Empty(t, rec.Body.String())
+	require.Equal(t, -1, c.Writer.Size())
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -149,26 +149,24 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		}
 		// 其他 400 错误（如参数问题）不处理，不禁用账号
 	case 401:
-		// OAuth 账号在 401 错误时临时不可调度（给 token 刷新窗口）；非 OAuth 账号保持原有 SetError 行为。
-		// Antigravity 除外：其 401 由 applyErrorPolicy 的 temp_unschedulable_rules 自行控制。
-		if account.Type == AccountTypeOAuth && account.Platform != PlatformAntigravity {
-			// 1. 失效缓存
+		lowerBody := strings.ToLower(string(responseBody))
+		if strings.Contains(lowerBody, "account_deactivated") {
+			// 账号已停用：无论 OAuth 还是 APIKey，直接标记 error 状态，不再尝试刷新
+			msg := "Account deactivated (401): " + upstreamMsg
+			if account.Type == AccountTypeOAuth && s.tokenCacheInvalidator != nil {
+				if err := s.tokenCacheInvalidator.InvalidateToken(ctx, account); err != nil {
+					slog.Warn("oauth_401_invalidate_cache_failed", "account_id", account.ID, "error", err)
+				}
+			}
+			s.handleAuthError(ctx, account, msg)
+			shouldDisable = true
+		} else if account.Type == AccountTypeOAuth {
+			// 非停用的 OAuth 401：失效缓存 + 临时冷却，等待自然刷新
 			if s.tokenCacheInvalidator != nil {
 				if err := s.tokenCacheInvalidator.InvalidateToken(ctx, account); err != nil {
 					slog.Warn("oauth_401_invalidate_cache_failed", "account_id", account.ID, "error", err)
 				}
 			}
-			// 2. 设置 expires_at 为当前时间，强制下次请求刷新 token
-			if account.Credentials == nil {
-				account.Credentials = make(map[string]any)
-			}
-			account.Credentials["expires_at"] = time.Now().Format(time.RFC3339)
-			if err := s.accountRepo.Update(ctx, account); err != nil {
-				slog.Warn("oauth_401_force_refresh_update_failed", "account_id", account.ID, "error", err)
-			} else {
-				slog.Info("oauth_401_force_refresh_set", "account_id", account.ID, "platform", account.Platform)
-			}
-			// 3. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
 			msg := "Authentication failed (401): invalid or expired credentials"
 			if upstreamMsg != "" {
 				msg = "OAuth 401: " + upstreamMsg
@@ -183,7 +181,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			}
 			shouldDisable = true
 		} else {
-			// 非 OAuth / Antigravity OAuth：保持 SetError 行为
+			// 非 OAuth 账号（APIKey）：保持原有 SetError 行为
 			msg := "Authentication failed (401): invalid or expired credentials"
 			if upstreamMsg != "" {
 				msg = "Authentication failed (401): " + upstreamMsg


### PR DESCRIPTION
## Summary
- detect 401 bodies containing account_deactivated and mark the account as error for both OAuth and API key types
- keep non-deactivated OAuth 401s in a cooldown path that invalidates cached tokens and schedules a temporary unschedulable window instead of forcing expires_at
- leave API key handling unchanged aside from the clearer error messaging so we avoid spurious retries

## Testing
- not run (not requested)
