### PR TITLE
fix(billing): add window expiration check to Redis rate limit Lua script

### DIFF
--- a/backend/internal/repository/billing_cache.go
+++ b/backend/internal/repository/billing_cache.go
@@ -20,6 +20,11 @@ const (
 	billingCacheTTL           = 5 * time.Minute
 	billingCacheJitter        = 30 * time.Second
 	rateLimitCacheTTL         = 7 * 24 * time.Hour // 7 days matches the longest window
+
+	// Rate limit window durations — must match service.RateLimitWindow* constants.
+	rateLimitWindow5h = 5 * time.Hour
+	rateLimitWindow1d = 24 * time.Hour
+	rateLimitWindow7d = 7 * 24 * time.Hour
 )
 
 // jitteredTTL 返回带随机抖动的 TTL，防止缓存雪崩
@@ -90,17 +95,40 @@ var (
 		return 1
 	`)
 
-	// updateRateLimitUsageScript atomically increments all three rate limit usage counters.
-	// Returns 0 if the key doesn't exist (cache miss), 1 on success.
+	// updateRateLimitUsageScript atomically increments all three rate limit usage counters
+	// with window expiration checking. If a window has expired, its usage is reset to cost
+	// (instead of accumulated) and the window timestamp is updated, matching the DB-side
+	// IncrementRateLimitUsage semantics.
+	//
+	// ARGV: [1]=cost, [2]=ttl_seconds, [3]=now_unix, [4]=window_5h_seconds, [5]=window_1d_seconds, [6]=window_7d_seconds
 	updateRateLimitUsageScript = redis.NewScript(`
 		local exists = redis.call('EXISTS', KEYS[1])
 		if exists == 0 then
 			return 0
 		end
 		local cost = tonumber(ARGV[1])
-		redis.call('HINCRBYFLOAT', KEYS[1], 'usage_5h', cost)
-		redis.call('HINCRBYFLOAT', KEYS[1], 'usage_1d', cost)
-		redis.call('HINCRBYFLOAT', KEYS[1], 'usage_7d', cost)
+		local now = tonumber(ARGV[3])
+		local win5h = tonumber(ARGV[4])
+		local win1d = tonumber(ARGV[5])
+		local win7d = tonumber(ARGV[6])
+
+		-- Helper: check if window is expired and update usage + window accordingly
+		-- Returns nothing, modifies the hash in-place.
+		local function update_window(usage_field, window_field, window_duration)
+			local w = tonumber(redis.call('HGET', KEYS[1], window_field) or 0)
+			if w == 0 or (now - w) >= window_duration then
+				-- Window expired or never started: reset usage to cost, start new window
+				redis.call('HSET', KEYS[1], usage_field, tostring(cost))
+				redis.call('HSET', KEYS[1], window_field, tostring(now))
+			else
+				-- Window still valid: accumulate
+				redis.call('HINCRBYFLOAT', KEYS[1], usage_field, cost)
+			end
+		end
+
+		update_window('usage_5h', 'window_5h', win5h)
+		update_window('usage_1d', 'window_1d', win1d)
+		update_window('usage_7d', 'window_7d', win7d)
 		redis.call('EXPIRE', KEYS[1], ARGV[2])
 		return 1
 	`)
@@ -280,7 +308,15 @@ func (c *billingCache) SetAPIKeyRateLimit(ctx context.Context, keyID int64, data
 
 func (c *billingCache) UpdateAPIKeyRateLimitUsage(ctx context.Context, keyID int64, cost float64) error {
 	key := billingRateLimitKey(keyID)
-	_, err := updateRateLimitUsageScript.Run(ctx, c.rdb, []string{key}, cost, int(rateLimitCacheTTL.Seconds())).Result()
+	now := time.Now().Unix()
+	_, err := updateRateLimitUsageScript.Run(ctx, c.rdb, []string{key},
+		cost,
+		int(rateLimitCacheTTL.Seconds()),
+		now,
+		int(rateLimitWindow5h.Seconds()),
+		int(rateLimitWindow1d.Seconds()),
+		int(rateLimitWindow7d.Seconds()),
+	).Result()
 	if err != nil && !errors.Is(err, redis.Nil) {
 		log.Printf("Warning: update rate limit usage cache failed for api key %d: %v", keyID, err)
 		return err


### PR DESCRIPTION
## 背景 / Background

API Key 的限速（`rate_limit_5h` / `rate_limit_1d` / `rate_limit_7d`）在窗口边界（如跨天）后，Redis 缓存中的 `usage_*` 未被重置，旧窗口的用量被累加到新窗口，导致用户请求被错误拦截返回 429。429 一旦触发会持续锁死最长 24 小时，无法自我修复。

The API Key rate limit (`rate_limit_5h` / `rate_limit_1d` / `rate_limit_7d`) usage counters in Redis cache were not reset when windows expired. Old window usage was accumulated into new windows, causing incorrect 429 rate limiting that could persist for up to 24 hours with no self-healing.

---

## 目的 / Purpose

修复 Redis Lua 脚本在窗口过期后仍然无条件累加 usage 的 bug，使 Redis 端与 DB 端 (`IncrementRateLimitUsage`) 保持相同的窗口重置语义。同时消除异步 worker 队列竞态导致缓存污染的问题。

Fix the Redis Lua script to check window expiration before incrementing usage, matching the DB-side `IncrementRateLimitUsage` semantics. This also eliminates the async worker queue race condition that could pollute a freshly rebuilt cache.

---

## 改动内容 / Changes

### 后端 / Backend

- **Lua 脚本增加窗口过期检查**：`updateRateLimitUsageScript` 现在对每个窗口（5h/1d/7d）先读取 `window_*` 时间戳，判断是否过期。过期时将 `usage_*` 重置为当前 cost 并更新窗口时间戳；有效时正常累加
- **传入窗口参数**：`UpdateAPIKeyRateLimitUsage` 方法现在向 Lua 脚本传入当前 Unix 时间戳和三个窗口时长，供脚本进行过期判断
- **新增窗口常量**：在 repository 层定义 `rateLimitWindow5h/1d/7d` 常量，与 service 层 `RateLimitWindow*` 保持一致

---

- **Lua script window expiration check**: `updateRateLimitUsageScript` now reads `window_*` timestamps for each window (5h/1d/7d) before incrementing. If expired, resets `usage_*` to current cost and updates the window timestamp; if valid, accumulates normally
- **Pass window parameters**: `UpdateAPIKeyRateLimitUsage` now passes the current Unix timestamp and three window durations to the Lua script for expiration checks
- **Window duration constants**: Added `rateLimitWindow5h/1d/7d` constants in the repository layer, matching service-layer `RateLimitWindow*` values

Closes #1049