### PR TITLE
chore(antigravity): bump default User-Agent version to 1.20.5

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -49,8 +49,8 @@ const (
 	antigravityDailyBaseURL = "https://daily-cloudcode-pa.sandbox.googleapis.com"
 )
 
-// defaultUserAgentVersion 可通过环境变量 ANTIGRAVITY_USER_AGENT_VERSION 配置，默认 1.20.4
-var defaultUserAgentVersion = "1.20.4"
+// defaultUserAgentVersion 可通过环境变量 ANTIGRAVITY_USER_AGENT_VERSION 配置，默认 1.20.5
+var defaultUserAgentVersion = "1.20.5"
 
 // defaultClientSecret 可通过环境变量 ANTIGRAVITY_OAUTH_CLIENT_SECRET 配置
 var defaultClientSecret = "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"

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -690,7 +690,7 @@ func TestConstants_值正确(t *testing.T) {
 	if RedirectURI != "http://localhost:8085/callback" {
 		t.Errorf("RedirectURI 不匹配: got %s", RedirectURI)
 	}
-	if GetUserAgent() != "antigravity/1.20.4 windows/amd64" {
+	if GetUserAgent() != "antigravity/1.20.5 windows/amd64" {
 		t.Errorf("UserAgent 不匹配: got %s", GetUserAgent())
 	}
 	if SessionTTL != 30*time.Minute {


### PR DESCRIPTION
## 背景 / Background

Antigravity 客户端已发布 1.20.5 版本，默认 User-Agent 版本需要同步更新。

Antigravity client has released version 1.20.5, the default User-Agent version needs to be updated accordingly.

---

## 目的 / Purpose

将默认 User-Agent 版本从 `1.20.4` 升级到 `1.20.5`，使请求头与最新客户端版本保持一致。

Bump the default User-Agent version from `1.20.4` to `1.20.5` to match the latest client release.

---

## 改动内容 / Changes

### 后端 / Backend

- **更新默认版本号**：`defaultUserAgentVersion` 从 `1.20.4` → `1.20.5`（`oauth.go`）
- **同步测试断言**：更新 `TestConstants_值正确` 中的预期值（`oauth_test.go`）

---

- **Update default version**: `defaultUserAgentVersion` from `1.20.4` → `1.20.5` (`oauth.go`)
- **Sync test assertion**: Update expected value in `TestConstants_值正确` (`oauth_test.go`)