### PR TITLE
fix(i18n): correct usage label from "Total" to "Last 30d"

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -574,7 +574,7 @@ export default {
     groupRequired: 'Please select a group',
     usage: 'Usage',
     today: 'Today',
-    total: 'Total',
+    total: 'Last 30d',
     quota: 'Quota',
     lastUsedAt: 'Last Used',
     useKey: 'Use Key',
@@ -1308,7 +1308,7 @@ export default {
         actions: 'Actions'
       },
       today: 'Today',
-      total: 'Total',
+      total: 'Last 30d',
       noSubscription: 'No subscription',
       daysRemaining: '{days}d',
       expired: 'Expired',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -574,7 +574,7 @@ export default {
     groupRequired: '请选择分组',
     usage: '用量',
     today: '今日',
-    total: '累计',
+    total: '近30天',
     quota: '额度',
     lastUsedAt: '上次使用时间',
     useKey: '使用密钥',
@@ -1335,7 +1335,7 @@ export default {
         actions: '操作'
       },
       today: '今日',
-      total: '累计',
+      total: '近30天',
       noSubscription: '暂无订阅',
       daysRemaining: '{days}天',
       expired: '已过期',


### PR DESCRIPTION
## 背景 / Background

管理后台用户管理页面和 API Key 页面的用量统计列显示"累计"（Total），但后端 `GetBatchUserUsageStats` 实际查询的是最近 30 天的滚动窗口数据，导致标签与实际数据语义不一致。

The usage stats column in the admin Users page and API Keys page displays "Total", but the backend `GetBatchUserUsageStats` actually queries a rolling 30-day window, making the label semantically incorrect.

---

## 目的 / Purpose

将前端标签从"累计"/"Total"修正为"近30天"/"Last 30d"，使展示与实际查询语义一致。

Correct the frontend label from "累计"/"Total" to "近30天"/"Last 30d" so it accurately reflects the underlying 30-day rolling window query.

---

## 改动内容 / Changes

### 前端 / Frontend

- **i18n 标签修正**：将 `keys.total` 和 `admin.users.total` 从"累计"/"Total"改为"近30天"/"Last 30d"
- **涉及文件**：`frontend/src/i18n/locales/zh.ts`、`frontend/src/i18n/locales/en.ts`

---

- **i18n label fix**: Changed `keys.total` and `admin.users.total` from "累计"/"Total" to "近30天"/"Last 30d"
- **Files**: `frontend/src/i18n/locales/zh.ts`, `frontend/src/i18n/locales/en.ts`

Closes #1060