### PR TITLE
fix(auto setup): 修复初始测试连接硬编码问题导致使用自定义数据库测试失败无法执行 auto setup流程

### DIFF
--- a/backend/internal/setup/setup.go
+++ b/backend/internal/setup/setup.go
@@ -164,8 +164,8 @@ func NeedsSetup() bool {
 func TestDatabaseConnection(cfg *DatabaseConfig) error {
 	// First, connect to the default 'postgres' database to check/create target database
 	defaultDSN := fmt.Sprintf(
-		"host=%s port=%d user=%s password=%s dbname=postgres sslmode=%s",
-		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.SSLMode,
+		"host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.DBName, cfg.SSLMode,
 	)
 
 	db, err := sql.Open("postgres", defaultDSN)


### PR DESCRIPTION
 ## 背景

  在 Docker `AUTO_SETUP=true` 场景下，系统启动时会先做数据库连通性探测。
  部分第三方云数据库（如托管 PostgreSQL）并不提供可访问的 `postgres` 默认库，导致初始化阶段报错并中断：

  ```log
  Auto setup failed: database connection failed: ping failed: pq: database "postgres" does not exist
  ```

 ```full-log
  sub2api        | 2026-03-17T06:21:33.030+0800   INFO      stdlog    Auto setup mode enabled...    {"service": "sub2api", "env": "bootstrap", "legacy_stdlog": true}
  sub2api        | 2026-03-17T06:21:33.030+0800   INFO      Auto setup enabled, configuring from environment variables...{"service": "sub2api", "env": "bootstrap", "component": "setup", "legacy_printf": true}
  sub2api        | 2026-03-17T06:21:33.031+0800   INFO      Data directory: /app/data     {"service": "sub2api", "env": "bootstrap", "component": "setup", "legacy_printf": true}
  sub2api        | 2026-03-17T06:21:33.031+0800   INFO      Testing database connection... {"service": "sub2api", "env": "bootstrap", "component": "setup", "legacy_printf": true}
  sub2api        | 2026-03-17T06:21:33.059+0800   ERROR     stdlog    Auto setup failed: database connection failed: ping failed: pq: database "postgres" does not exist  {"service": "sub2api", "env": "bootstrap", "legacy_stdlog": true}
  sub2api        | runtime.main
  sub2api        |  /opt/hostedtoolcache/go/1.26.1/x64/src/runtime/proc.go:290
  ```

  问题原因

  自动初始化流程中的数据库探测逻辑对默认库存在硬依赖（dbname=postgres）。
  当目标环境不包含该库时，即使业务库配置正确，也会在 ping 阶段提前失败，无法继续 auto setup。

  修复内容

  - 移除/规避对 postgres 默认库的硬编码依赖。
  - 数据库连通性探测改为基于用户实际配置的目标数据库信息进行校验。
  - 保证在第三方云数据库（无 postgres 默认库）场景下，auto setup 可正常继续执行。

  影响范围

  - 受益场景：使用托管 PostgreSQL 且无 postgres 默认库的部署环境。
  - 兼容性：已有包含 postgres 默认库的环境行为不受影响。
  - 结果：避免初始化阶段因默认库不存在而失败，提升 Docker 一键部署成功率。

  验证

  - 在无 postgres 默认库的第三方云数据库环境复现并验证：
    - AUTO_SETUP 不再因 pq: database "postgres" does not exist 中断
    - 初始化流程可继续完成
    - 服务可正常启动并通过健康检查