### PR TITLE
fix(proxy): encode special chars in proxy credentials

### DIFF
--- a/backend/internal/service/proxy.go
+++ b/backend/internal/service/proxy.go
@@ -1,7 +1,9 @@
 package service
 
 import (
-	"fmt"
+	"net"
+	"net/url"
+	"strconv"
 	"time"
 )
 
@@ -23,10 +25,14 @@ func (p *Proxy) IsActive() bool {
 }
 
 func (p *Proxy) URL() string {
-	if p.Username != "" && p.Password != "" {
-		return fmt.Sprintf("%s://%s:%s@%s:%d", p.Protocol, p.Username, p.Password, p.Host, p.Port)
+	u := &url.URL{
+		Scheme: p.Protocol,
+		Host:   net.JoinHostPort(p.Host, strconv.Itoa(p.Port)),
 	}
-	return fmt.Sprintf("%s://%s:%d", p.Protocol, p.Host, p.Port)
+	if p.Username != "" && p.Password != "" {
+		u.User = url.UserPassword(p.Username, p.Password)
+	}
+	return u.String()
 }
 
 type ProxyWithAccountCount struct {

--- a/backend/internal/service/proxy_test.go
+++ b/backend/internal/service/proxy_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestProxyURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		proxy Proxy
+		want  string
+	}{
+		{
+			name: "without auth",
+			proxy: Proxy{
+				Protocol: "http",
+				Host:     "proxy.example.com",
+				Port:     8080,
+			},
+			want: "http://proxy.example.com:8080",
+		},
+		{
+			name: "with auth",
+			proxy: Proxy{
+				Protocol: "socks5",
+				Host:     "socks.example.com",
+				Port:     1080,
+				Username: "user",
+				Password: "pass",
+			},
+			want: "socks5://user:pass@socks.example.com:1080",
+		},
+		{
+			name: "username only keeps no auth for compatibility",
+			proxy: Proxy{
+				Protocol: "http",
+				Host:     "proxy.example.com",
+				Port:     8080,
+				Username: "user-only",
+			},
+			want: "http://proxy.example.com:8080",
+		},
+		{
+			name: "with special characters in credentials",
+			proxy: Proxy{
+				Protocol: "http",
+				Host:     "proxy.example.com",
+				Port:     3128,
+				Username: "first last@corp",
+				Password: "p@ ss:#word",
+			},
+			want: "http://first%20last%40corp:p%40%20ss%3A%23word@proxy.example.com:3128",
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := tc.proxy.URL(); got != tc.want {
+				t.Fatalf("Proxy.URL() mismatch: got=%q want=%q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProxyURL_SpecialCharactersRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	proxy := Proxy{
+		Protocol: "http",
+		Host:     "proxy.example.com",
+		Port:     3128,
+		Username: "first last@corp",
+		Password: "p@ ss:#word",
+	}
+
+	parsed, err := url.Parse(proxy.URL())
+	if err != nil {
+		t.Fatalf("parse proxy URL failed: %v", err)
+	}
+	if got := parsed.User.Username(); got != proxy.Username {
+		t.Fatalf("username mismatch after parse: got=%q want=%q", got, proxy.Username)
+	}
+	pass, ok := parsed.User.Password()
+	if !ok {
+		t.Fatal("password missing after parse")
+	}
+	if pass != proxy.Password {
+		t.Fatalf("password mismatch after parse: got=%q want=%q", pass, proxy.Password)
+	}
+}


### PR DESCRIPTION
## 背景
当代理配置的用户名或密码包含特殊字符（如空格、`@`、`:`、`#`）时，代理认证会失败。

根因是代理 URL 通过字符串拼接生成，凭据未进行 URL 编码。

## 变更内容
1. 重构 `Proxy.URL()` 的构造方式：
- 使用 `net/url` 构建 URL
- 使用 `url.UserPassword(...)` 自动编码用户名/密码
- 保持兼容：仅在用户名和密码都存在时注入认证信息

2. 新增单元测试 `proxy_test.go`，覆盖：
- 无认证代理 URL
- 普通认证代理 URL
- 仅用户名（兼容旧行为）
- 含特殊字符的用户名/密码
- round-trip 校验（生成后再解析，凭据一致）

## 验证
已通过以下测试：
- `go test ./internal/service -run 'TestProxyURL|TestOAuthService_RefreshAccountToken_WithProxy' -tags unit -count=1`
- `go test ./internal/service -run TestProxyURL -count=1`

## 影响范围
所有依赖 `Proxy.URL()` 的代理请求链路（OAuth、网关上游请求、代理探测等）都会受益于该修复。

## 风险评估
低风险。变更集中在 URL 组装逻辑，且有回归测试覆盖兼容场景与特殊字符场景。