### PR TITLE
feat: 个人资料弹窗 GitHub 链接仅对管理员可见

### DIFF
--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -123,6 +123,7 @@
                 </router-link>
 
                 <a
+                  v-if="authStore.isAdmin"
                   href="https://github.com/Wei-Shaw/sub2api"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -138,6 +139,7 @@
                   </svg>
                   {{ t('nav.github') }}
                 </a>
+
               </div>
 
               <!-- Contact Support (only show if configured) -->


### PR DESCRIPTION
感谢大佬的项目，目前大佬 repo 已有商业站信息，面向管理可提供赞助渠道，面向普通用户请大佬考虑提供信息隐藏措施。