### PR TITLE
fix(setup): align install validation and expose backend errors

### DIFF
--- a/backend/internal/setup/handler.go
+++ b/backend/internal/setup/handler.go
@@ -247,6 +247,12 @@ func install(c *gin.Context) {
 		return
 	}
 
+	req.Admin.Email = strings.TrimSpace(req.Admin.Email)
+	req.Database.Host = strings.TrimSpace(req.Database.Host)
+	req.Database.User = strings.TrimSpace(req.Database.User)
+	req.Database.DBName = strings.TrimSpace(req.Database.DBName)
+	req.Redis.Host = strings.TrimSpace(req.Redis.Host)
+
 	// ========== COMPREHENSIVE INPUT VALIDATION ==========
 	// Database validation
 	if !validateHostname(req.Database.Host) {
@@ -318,13 +324,6 @@ func install(c *gin.Context) {
 		response.Error(c, http.StatusBadRequest, "Invalid server mode (must be 'release' or 'debug')")
 		return
 	}
-
-	// Trim whitespace from string inputs
-	req.Admin.Email = strings.TrimSpace(req.Admin.Email)
-	req.Database.Host = strings.TrimSpace(req.Database.Host)
-	req.Database.User = strings.TrimSpace(req.Database.User)
-	req.Database.DBName = strings.TrimSpace(req.Database.DBName)
-	req.Redis.Host = strings.TrimSpace(req.Redis.Host)
 
 	cfg := &SetupConfig{
 		Database: req.Database,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -218,7 +218,7 @@ export default {
       email: 'Email',
       password: 'Password',
       confirmPassword: 'Confirm Password',
-      passwordPlaceholder: 'Min 6 characters',
+      passwordPlaceholder: 'Min 8 characters',
       confirmPasswordPlaceholder: 'Confirm password',
       passwordMismatch: 'Passwords do not match'
     },

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -218,7 +218,7 @@ export default {
       email: '邮箱',
       password: '密码',
       confirmPassword: '确认密码',
-      passwordPlaceholder: '至少 6 个字符',
+      passwordPlaceholder: '至少 8 个字符',
       confirmPasswordPlaceholder: '确认密码',
       passwordMismatch: '密码不匹配'
     },

--- a/frontend/src/views/setup/SetupWizardView.vue
+++ b/frontend/src/views/setup/SetupWizardView.vue
@@ -565,7 +565,7 @@ const canProceed = computed(() => {
     case 2:
       return (
         formData.admin.email &&
-        formData.admin.password.length >= 6 &&
+        formData.admin.password.length >= 8 &&
         formData.admin.password === confirmPassword.value
       )
     default:
@@ -582,8 +582,9 @@ async function testDatabaseConnection() {
     await testDatabase(formData.database)
     dbConnected.value = true
   } catch (error: unknown) {
-    const err = error as { response?: { data?: { detail?: string } }; message?: string }
-    errorMessage.value = err.response?.data?.detail || err.message || 'Connection failed'
+    const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string }
+    errorMessage.value =
+      err.response?.data?.detail || err.response?.data?.message || err.message || 'Connection failed'
   } finally {
     testingDb.value = false
   }
@@ -598,8 +599,9 @@ async function testRedisConnection() {
     await testRedis(formData.redis)
     redisConnected.value = true
   } catch (error: unknown) {
-    const err = error as { response?: { data?: { detail?: string } }; message?: string }
-    errorMessage.value = err.response?.data?.detail || err.message || 'Connection failed'
+    const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string }
+    errorMessage.value =
+      err.response?.data?.detail || err.response?.data?.message || err.message || 'Connection failed'
   } finally {
     testingRedis.value = false
   }
@@ -622,8 +624,9 @@ async function performInstall() {
     // Start polling for service restart
     waitForServiceRestart()
   } catch (error: unknown) {
-    const err = error as { response?: { data?: { detail?: string } }; message?: string }
-    errorMessage.value = err.response?.data?.detail || err.message || 'Installation failed'
+    const err = error as { response?: { data?: { detail?: string; message?: string } }; message?: string }
+    errorMessage.value =
+      err.response?.data?.detail || err.response?.data?.message || err.message || 'Installation failed'
   } finally {
     installing.value = false
   }


### PR DESCRIPTION
## Summary
- Align setup admin password validation with backend rule by changing frontend minimum length from 6 to 8.
- Surface backend error envelope message (`message`) in setup failure UI instead of only showing generic axios 400 text.
- Trim setup request string fields (including admin email) before backend validation to avoid false invalid-email errors caused by surrounding whitespace.
## Why
- Users saw inconsistent password requirements between setup UI and install API, causing avoidable 400 errors.
- Install failures were hard to diagnose because UI only displayed `Request failed with status code 400`.
- Email values with leading/trailing spaces could fail format validation even when the actual email was valid.
## Changes
- `frontend/src/views/setup/SetupWizardView.vue`
  - password gate: `>= 6` -> `>= 8`
  - error extraction: `detail || message || err.message`
- `frontend/src/i18n/locales/zh.ts`
  - setup password placeholder: `至少 6 个字符` -> `至少 8 个字符`
- `frontend/src/i18n/locales/en.ts`
  - setup password placeholder: `Min 6 characters` -> `Min 8 characters`
- `backend/internal/setup/handler.go`
  - move input trim to run immediately after JSON bind and before validation
## Verification
- `go test ./internal/setup` ✅
- `go build ./cmd/server` ✅
- `pnpm run typecheck` ✅
- `pnpm run build` ✅