### PR TITLE
Fix docker-compose Redis command interpolation and startup behavior

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -204,7 +204,7 @@ services:
           --save 60 1
           --appendonly yes
           --appendfsync everysec
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+          $${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)


### PR DESCRIPTION
## Summary

This PR fixes an issue where Docker Compose fails to parse the `command` for the Redis service because Bash parameter expansion was interpreted as Compose interpolation. The change ensures the Redis startup command is passed to the container shell unchanged, and that the optional `--requirepass` flag is applied only when `REDIS_PASSWORD` is provided.

## What I changed

- Prevent Compose from interpreting shell parameter expansion by escaping dollar signs where needed (so the container shell handles the expansion).

## Why

The original `command` used Bash's `${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}` syntax. Docker Compose attempts to evaluate `$`-style interpolations itself and fails on this construct, leading to the error:

```
ERROR: Invalid interpolation format for "command" option in service "redis": "sh -c '\n  redis-server\n  --save 60 1\n  --appendonly yes\n  --appendfsync everysec\n  ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'\n"
```

## Verification
before:
```
ubuntu@instance-20220205-1135:~/sub2api-deploy$ sudo docker-compose up -d
ERROR: Invalid interpolation format for "command" option in service "redis": "sh -c '
  redis-server
  --save 60 1
  --appendonly yes
  --appendfsync everysec
  ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
"
```
after:
```
ubuntu@instance-20220205-1135:~/sub2api-deploy$ sudo docker-compose up -d
Creating network "sub2api-deploy_sub2api-network" with driver "bridge"
Pulling postgres (postgres:18-alpine)...
18-alpine: Pulling from library/postgres
d8ad8cd72600: Pull complete
79adb56125dd: Pull complete
916f1ad40c12: Pull complete
77bde3e4517b: Pull complete
ad1dd238ebba: Pull complete
44d5fa65b2d7: Pull complete
fd3bad6f36e8: Pull complete
e12398e1ef39: Pull complete
94110c662082: Pull complete
```

## Related issues

- Closes https://github.com/Wei-Shaw/sub2api/issues/291
- Closes https://github.com/Wei-Shaw/sub2api/issues/691
