### PR TITLE
fix(openai): normalize OAuth passthrough /responses for OpenClaw clients

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4569,7 +4569,42 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		}
 	}
 
+	instructions := gjson.GetBytes(normalized, "instructions")
+	if !instructions.Exists() || instructions.Type != gjson.String || strings.TrimSpace(instructions.String()) == "" {
+		next, err := sjson.SetBytes(normalized, "instructions", defaultOpenAIPassthroughInstructions())
+		if err != nil {
+			return body, false, fmt.Errorf("normalize passthrough body instructions: %w", err)
+		}
+		normalized = next
+		changed = true
+	}
+
+	if maxOutputTokens := gjson.GetBytes(normalized, "max_output_tokens"); maxOutputTokens.Exists() {
+		next, err := sjson.DeleteBytes(normalized, "max_output_tokens")
+		if err != nil {
+			return body, false, fmt.Errorf("normalize passthrough body delete max_output_tokens: %w", err)
+		}
+		normalized = next
+		changed = true
+	}
+
+	if maxCompletionTokens := gjson.GetBytes(normalized, "max_completion_tokens"); maxCompletionTokens.Exists() {
+		next, err := sjson.DeleteBytes(normalized, "max_completion_tokens")
+		if err != nil {
+			return body, false, fmt.Errorf("normalize passthrough body delete max_completion_tokens: %w", err)
+		}
+		normalized = next
+		changed = true
+	}
+
 	return normalized, changed, nil
+}
+
+func defaultOpenAIPassthroughInstructions() string {
+	if value := strings.TrimSpace(openai.DefaultInstructions); value != "" {
+		return value
+	}
+	return "You are a helpful coding assistant."
 }
 
 func detectOpenAIPassthroughInstructionsRejectReason(reqModel string, body []byte) string {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -487,6 +488,94 @@ func TestOpenAIGatewayService_OAuthPassthrough_ResponseHeadersAllowXCodex(t *tes
 
 	require.Equal(t, "12", rec.Header().Get("x-codex-primary-used-percent"))
 	require.Equal(t, "34", rec.Header().Get("x-codex-secondary-used-percent"))
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_InsertsDefaultInstructionsForNonCodexWhenMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "OpenAI/JS 6.26.0")
+
+	originalBody := []byte(`{"model":"gpt-5.4","stream":false,"input":[{"type":"text","text":"hi"}]}`)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, false, gjson.GetBytes(upstream.lastBody, "store").Bool())
+	require.Equal(t, true, gjson.GetBytes(upstream.lastBody, "stream").Bool())
+	require.Equal(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "hi", gjson.GetBytes(upstream.lastBody, "input.0.text").String())
+	require.Equal(t, defaultOpenAIPassthroughInstructions(), strings.TrimSpace(gjson.GetBytes(upstream.lastBody, "instructions").String()))
+	require.NotEmpty(t, strings.TrimSpace(openai.DefaultInstructions))
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_RemovesUnsupportedMaxTokenFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "OpenAI/JS 6.26.0")
+
+	originalBody := []byte(`{"model":"gpt-5.4","stream":false,"max_output_tokens":128,"max_completion_tokens":64,"input":[{"type":"text","text":"hi"}]}`)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "max_output_tokens").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Exists())
+	require.Equal(t, defaultOpenAIPassthroughInstructions(), strings.TrimSpace(gjson.GetBytes(upstream.lastBody, "instructions").String()))
 }
 
 func TestOpenAIGatewayService_OAuthPassthrough_UpstreamErrorIncludesPassthroughFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix OpenAI OAuth passthrough `/responses` normalization for OpenClaw-style clients.

This PR addresses two compatibility gaps in `normalizeOpenAIPassthroughOAuthBody()`:

- inject default `instructions` when a non-Codex passthrough request omits it
- strip `max_output_tokens` / `max_completion_tokens` before forwarding to the ChatGPT OAuth upstream

## Problem

When OpenClaw is configured to use Sub2API as a local OpenAI-compatible proxy, requests can reach the OpenAI OAuth passthrough path with:

- `model: gpt-5.4`
- no top-level `instructions`
- `max_output_tokens` / `max_completion_tokens` present

This caused upstream failures such as:

- `Instructions are required`
- `Unsupported parameter: max_output_tokens`

## Root Cause

The non-passthrough path already normalizes some of these fields, but the OAuth passthrough normalization only handled `store` and `stream`. As a result, OpenClaw-style `/responses` payloads were forwarded without the extra compatibility cleanup they need for the ChatGPT OAuth upstream.

## Changes

- add default instructions injection in `normalizeOpenAIPassthroughOAuthBody()`
- prefer `openai.DefaultInstructions`, with the existing coding-assistant fallback if empty
- remove `max_output_tokens`
- remove `max_completion_tokens`
- add regression tests for both behaviors

## Verification

Targeted tests:

```bash
go test ./internal/service -run 'TestOpenAIGatewayService_OAuthPassthrough_(InsertsDefaultInstructionsForNonCodexWhenMissing|RemovesUnsupportedMaxTokenFields)'
```

I also validated the fix against a local Sub2API deployment used as an OpenClaw proxy. After rebuilding the service, a real OpenClaw request that previously failed completed successfully and returned the expected text response.
