### PR TITLE
feat: map claude-haiku-4-5 variants to claude-sonnet-4-6

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -82,8 +82,8 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"claude-opus-4-5-20251101":   "claude-opus-4-6-thinking", // 迁移旧模型
 	"claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
 	// Claude Haiku → Sonnet（无 Haiku 支持）
-	"claude-haiku-4-5":          "claude-sonnet-4-5",
-	"claude-haiku-4-5-20251001": "claude-sonnet-4-5",
+	"claude-haiku-4-5":          "claude-sonnet-4-6",
+	"claude-haiku-4-5-20251001": "claude-sonnet-4-6",
 	// Gemini 2.5 白名单
 	"gemini-2.5-flash":               "gemini-2.5-flash",
 	"gemini-2.5-flash-image":         "gemini-2.5-flash-image",

--- a/backend/internal/service/antigravity_model_mapping_test.go
+++ b/backend/internal/service/antigravity_model_mapping_test.go
@@ -57,16 +57,16 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-opus-4-6-thinking",
 		},
 		{
-			name:           "默认映射 - claude-haiku-4-5 → claude-sonnet-4-5",
+			name:           "默认映射 - claude-haiku-4-5 → claude-sonnet-4-6",
 			requestedModel: "claude-haiku-4-5",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-5",
+			expected:       "claude-sonnet-4-6",
 		},
 		{
-			name:           "默认映射 - claude-haiku-4-5-20251001 → claude-sonnet-4-5",
+			name:           "默认映射 - claude-haiku-4-5-20251001 → claude-sonnet-4-6",
 			requestedModel: "claude-haiku-4-5-20251001",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-5",
+			expected:       "claude-sonnet-4-6",
 		},
 		{
 			name:           "默认映射 - claude-sonnet-4-5-20250929 → claude-sonnet-4-5",

--- a/backend/migrations/075_map_haiku45_to_sonnet46.sql
+++ b/backend/migrations/075_map_haiku45_to_sonnet46.sql
@@ -1,0 +1,17 @@
+-- Map claude-haiku-4-5 variants target from claude-sonnet-4-5 to claude-sonnet-4-6
+--
+-- Only updates when the current target is exactly claude-sonnet-4-5.
+
+-- 1. claude-haiku-4-5
+UPDATE accounts
+SET credentials = jsonb_set(credentials, '{model_mapping,claude-haiku-4-5}', '"claude-sonnet-4-6"')
+WHERE platform = 'antigravity'
+  AND deleted_at IS NULL
+  AND credentials->'model_mapping'->>'claude-haiku-4-5' = 'claude-sonnet-4-5';
+
+-- 2. claude-haiku-4-5-20251001
+UPDATE accounts
+SET credentials = jsonb_set(credentials, '{model_mapping,claude-haiku-4-5-20251001}', '"claude-sonnet-4-6"')
+WHERE platform = 'antigravity'
+  AND deleted_at IS NULL
+  AND credentials->'model_mapping'->>'claude-haiku-4-5-20251001' = 'claude-sonnet-4-5';


### PR DESCRIPTION
## 背景 / Background

当前 Antigravity 平台的模型映射中，`claude-haiku-4-5` 和 `claude-haiku-4-5-20251001` 的目标模型为 `claude-sonnet-4-5`。随着 `claude-sonnet-4-6` 的发布，需要将这两个映射的目标更新为更新的模型。

The current Antigravity model mapping routes `claude-haiku-4-5` and `claude-haiku-4-5-20251001` to `claude-sonnet-4-5`. With the release of `claude-sonnet-4-6`, these mappings should be updated to target the newer model.

---

## 目的 / Purpose

将 `claude-haiku-4-5` 和 `claude-haiku-4-5-20251001` 的目标模型从 `claude-sonnet-4-5` 更新为 `claude-sonnet-4-6`。

Update the target model for `claude-haiku-4-5` and `claude-haiku-4-5-20251001` from `claude-sonnet-4-5` to `claude-sonnet-4-6`.

---

## 改动内容 / Changes

### 后端 / Backend

- **默认映射更新**：`constants.go` 中 `DefaultAntigravityModelMapping` 的两条 haiku 映射目标改为 `claude-sonnet-4-6`
- **数据库迁移**：新增 `075_map_haiku45_to_sonnet46.sql`，仅在目标为 `claude-sonnet-4-5` 时才替换为 `claude-sonnet-4-6`
- **测试同步**：更新 `antigravity_model_mapping_test.go` 中对应的测试用例

---

- **Default mapping update**: Updated two haiku entries in `DefaultAntigravityModelMapping` in `constants.go` to target `claude-sonnet-4-6`
- **Database migration**: Added `075_map_haiku45_to_sonnet46.sql` that only updates when the current target is exactly `claude-sonnet-4-5`
- **Test sync**: Updated corresponding test cases in `antigravity_model_mapping_test.go`