### PR TITLE
feat(openai): split codex spark rate limiting from codex

### DIFF
--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -55,7 +55,12 @@ func TestAccountTestService_OpenAISuccessPersistsSnapshotFromHeaders(t *testing.
 		Platform:    PlatformOpenAI,
 		Type:        AccountTypeOAuth,
 		Concurrency: 1,
-		Credentials: map[string]any{"access_token": "test-token"},
+		Credentials: map[string]any{
+			"access_token": "test-token",
+			"model_mapping": map[string]any{
+				"gpt-5.4": "gpt-5.4",
+			},
+		},
 	}
 
 	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4")
@@ -86,7 +91,12 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimit(t *testing.T) 
 		Platform:    PlatformOpenAI,
 		Type:        AccountTypeOAuth,
 		Concurrency: 1,
-		Credentials: map[string]any{"access_token": "test-token"},
+		Credentials: map[string]any{
+			"access_token": "test-token",
+			"model_mapping": map[string]any{
+				"gpt-5.4": "gpt-5.4",
+			},
+		},
 	}
 
 	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4")

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -989,6 +989,10 @@ func windowStatsFromAccountStats(stats *usagestats.AccountStats) *WindowStats {
 }
 
 func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now time.Time) *UsageProgress {
+	return buildCodexUsageProgressFromExtraWithScope(extra, window, now, openAICodexQuotaScopeCodex)
+}
+
+func buildCodexUsageProgressFromExtraWithScope(extra map[string]any, window string, now time.Time, scope openAICodexQuotaScope) *UsageProgress {
 	if len(extra) == 0 {
 		return nil
 	}
@@ -999,15 +1003,19 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 		resetAtKey     string
 	)
 
+	key := func(suffix string) string {
+		return codexScopeExtraKey(scope, suffix)
+	}
+
 	switch window {
 	case "5h":
-		usedPercentKey = "codex_5h_used_percent"
-		resetAfterKey = "codex_5h_reset_after_seconds"
-		resetAtKey = "codex_5h_reset_at"
+		usedPercentKey = key("5h_used_percent")
+		resetAfterKey = key("5h_reset_after_seconds")
+		resetAtKey = key("5h_reset_at")
 	case "7d":
-		usedPercentKey = "codex_7d_used_percent"
-		resetAfterKey = "codex_7d_reset_after_seconds"
-		resetAtKey = "codex_7d_reset_at"
+		usedPercentKey = key("7d_used_percent")
+		resetAfterKey = key("7d_reset_after_seconds")
+		resetAtKey = key("7d_reset_at")
 	default:
 		return nil
 	}
@@ -1030,7 +1038,7 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	if progress.ResetsAt == nil {
 		if resetAfterSeconds := parseExtraInt(extra[resetAfterKey]); resetAfterSeconds > 0 {
 			base := now
-			if updatedAtRaw, ok := extra["codex_usage_updated_at"]; ok {
+			if updatedAtRaw, ok := extra[key("usage_updated_at")]; ok {
 				if updatedAt, err := parseTime(fmt.Sprint(updatedAtRaw)); err == nil {
 					base = updatedAt
 				}

--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -76,7 +76,7 @@ func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	}
 	account := &Account{ID: 12, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil, "")
 	require.Error(t, err)
 	assert.Equal(t, http.StatusBadGateway, rec.Code)
 
@@ -157,7 +157,7 @@ func TestOpenAIHandleErrorResponse_AppliesRuleFor422(t *testing.T) {
 	}
 	account := &Account{ID: 2, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil, "")
 	require.Error(t, err)
 	assert.Equal(t, http.StatusTeapot, rec.Code)
 

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -32,7 +32,13 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 		return false
 	}
 
-	modelKey := a.GetMappedModel(requestedModel)
+	mappedModel := a.GetMappedModel(requestedModel)
+	modelKey := mappedModel
+	if a.Platform == PlatformOpenAI {
+		if scopedKey := resolveOpenAICodexModelRateLimitKey(requestedModel, mappedModel); scopedKey != "" {
+			modelKey = scopedKey
+		}
+	}
 	if a.Platform == PlatformAntigravity {
 		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
 	}
@@ -54,7 +60,13 @@ func (a *Account) GetModelRateLimitRemainingTimeWithContext(ctx context.Context,
 		return 0
 	}
 
-	modelKey := a.GetMappedModel(requestedModel)
+	mappedModel := a.GetMappedModel(requestedModel)
+	modelKey := mappedModel
+	if a.Platform == PlatformOpenAI {
+		if scopedKey := resolveOpenAICodexModelRateLimitKey(requestedModel, mappedModel); scopedKey != "" {
+			modelKey = scopedKey
+		}
+	}
 	if a.Platform == PlatformAntigravity {
 		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
 	}

--- a/backend/internal/service/openai_codex_quota_scope.go
+++ b/backend/internal/service/openai_codex_quota_scope.go
@@ -1,0 +1,103 @@
+package service
+
+import "strings"
+
+type openAICodexQuotaScope string
+
+const (
+	openAICodexQuotaScopeCodex openAICodexQuotaScope = "codex"
+	openAICodexQuotaScopeSpark openAICodexQuotaScope = "spark"
+
+	openAICodexModelRateLimitKeyCodex = "openai_codex"
+	openAICodexModelRateLimitKeySpark = "openai_codex_spark"
+
+	openAICodexModelIDCodex = "gpt-5.3-codex"
+	openAICodexModelIDSpark = "gpt-5.3-codex-spark"
+)
+
+func normalizeOpenAIModelID(model string) string {
+	value := strings.TrimSpace(strings.ToLower(model))
+	if value == "" {
+		return ""
+	}
+	if strings.Contains(value, "/") {
+		parts := strings.Split(value, "/")
+		value = strings.TrimSpace(parts[len(parts)-1])
+	}
+	value = strings.NewReplacer("_", "-", " ", "-").Replace(value)
+	return value
+}
+
+func isOpenAICodexQuotaModel(model string) bool {
+	normalized := normalizeOpenAIModelID(model)
+	if normalized == "" {
+		return false
+	}
+	if strings.Contains(normalized, "codex") {
+		return true
+	}
+	// OpenAI OAuth Codex path主要使用 gpt-5 系列。
+	return strings.HasPrefix(normalized, "gpt-5")
+}
+
+func classifyOpenAICodexQuotaScope(model string) openAICodexQuotaScope {
+	normalized := normalizeOpenAIModelID(model)
+	if normalized == "" {
+		return openAICodexQuotaScopeCodex
+	}
+	if strings.Contains(normalized, "gpt-5.3-codex-spark") {
+		return openAICodexQuotaScopeSpark
+	}
+	if strings.Contains(normalized, "codex") && strings.Contains(normalized, "spark") {
+		return openAICodexQuotaScopeSpark
+	}
+	return openAICodexQuotaScopeCodex
+}
+
+func codexQuotaScopeFromModels(requestedModel, mappedModel string) openAICodexQuotaScope {
+	if classifyOpenAICodexQuotaScope(requestedModel) == openAICodexQuotaScopeSpark {
+		return openAICodexQuotaScopeSpark
+	}
+	if classifyOpenAICodexQuotaScope(mappedModel) == openAICodexQuotaScopeSpark {
+		return openAICodexQuotaScopeSpark
+	}
+	return openAICodexQuotaScopeCodex
+}
+
+func codexScopeExtraPrefix(scope openAICodexQuotaScope) string {
+	if scope == openAICodexQuotaScopeSpark {
+		return "codex_spark"
+	}
+	return "codex"
+}
+
+func codexScopeExtraKey(scope openAICodexQuotaScope, suffix string) string {
+	return codexScopeExtraPrefix(scope) + "_" + suffix
+}
+
+func codexScopeModelRateLimitKey(scope openAICodexQuotaScope) string {
+	if scope == openAICodexQuotaScopeSpark {
+		return openAICodexModelRateLimitKeySpark
+	}
+	return openAICodexModelRateLimitKeyCodex
+}
+
+func resolveOpenAICodexModelRateLimitKey(requestedModel, mappedModel string) string {
+	if !isOpenAICodexQuotaModel(requestedModel) && !isOpenAICodexQuotaModel(mappedModel) {
+		return ""
+	}
+	scope := codexQuotaScopeFromModels(requestedModel, mappedModel)
+	return codexScopeModelRateLimitKey(scope)
+}
+
+func isOpenAICodexScopeSupported(account *Account, scope openAICodexQuotaScope) bool {
+	if account == nil || !account.IsOpenAI() {
+		return false
+	}
+	switch scope {
+	case openAICodexQuotaScopeSpark:
+		return account.IsModelSupported(openAICodexModelIDSpark)
+	default:
+		return account.IsModelSupported(openAICodexModelIDCodex)
+	}
+}

--- a/backend/internal/service/openai_codex_quota_scope_test.go
+++ b/backend/internal/service/openai_codex_quota_scope_test.go
@@ -1,0 +1,96 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveOpenAICodexModelRateLimitKey(t *testing.T) {
+	require.Equal(t,
+		openAICodexModelRateLimitKeySpark,
+		resolveOpenAICodexModelRateLimitKey("gpt-5.3-codex-spark", "gpt-5.3-codex"),
+	)
+	require.Equal(t,
+		openAICodexModelRateLimitKeySpark,
+		resolveOpenAICodexModelRateLimitKey("gpt-5.3-codex-spark-high", "gpt-5.3-codex"),
+	)
+	require.Equal(t,
+		openAICodexModelRateLimitKeyCodex,
+		resolveOpenAICodexModelRateLimitKey("gpt-5.3-codex", "gpt-5.3-codex"),
+	)
+	require.Equal(t,
+		openAICodexModelRateLimitKeyCodex,
+		resolveOpenAICodexModelRateLimitKey("gpt-5.4", "gpt-5.4"),
+	)
+	require.Equal(t,
+		"",
+		resolveOpenAICodexModelRateLimitKey("text-embedding-3-large", "text-embedding-3-large"),
+	)
+}
+
+func TestOpenAICodexGlobalRateLimitResetAtFromExtra(t *testing.T) {
+	now := time.Now().UTC()
+	codexReset := now.Add(2 * time.Hour).UTC()
+	sparkReset := now.Add(1 * time.Hour).UTC()
+
+	t.Run("both_supported_only_codex_exhausted_returns_nil", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"gpt-5.3-codex":       "gpt-5.3-codex",
+					"gpt-5.3-codex-spark": "gpt-5.3-codex",
+				},
+			},
+			Extra: map[string]any{
+				"codex_7d_used_percent": 100.0,
+				"codex_7d_reset_at":     codexReset.Format(time.RFC3339),
+			},
+		}
+		require.Nil(t, openAICodexGlobalRateLimitResetAtFromExtra(account, now))
+	})
+
+	t.Run("both_supported_both_exhausted_returns_earliest_reset", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"gpt-5.3-codex":       "gpt-5.3-codex",
+					"gpt-5.3-codex-spark": "gpt-5.3-codex",
+				},
+			},
+			Extra: map[string]any{
+				"codex_7d_used_percent":       100.0,
+				"codex_7d_reset_at":           codexReset.Format(time.RFC3339),
+				"codex_spark_7d_used_percent": 100.0,
+				"codex_spark_7d_reset_at":     sparkReset.Format(time.RFC3339),
+			},
+		}
+		resetAt := openAICodexGlobalRateLimitResetAtFromExtra(account, now)
+		require.NotNil(t, resetAt)
+		require.WithinDuration(t, sparkReset, *resetAt, time.Second)
+	})
+
+	t.Run("codex_only_account_uses_codex_snapshot", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"gpt-5.3-codex": "gpt-5.3-codex",
+				},
+			},
+			Extra: map[string]any{
+				"codex_7d_used_percent": 100.0,
+				"codex_7d_reset_at":     codexReset.Format(time.RFC3339),
+			},
+		}
+		resetAt := openAICodexGlobalRateLimitResetAtFromExtra(account, now)
+		require.NotNil(t, resetAt)
+		require.WithinDuration(t, codexReset, *resetAt, time.Second)
+	})
+}
+

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -150,7 +150,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 				Detail:             upstreamDetail,
 			})
 			if s.rateLimitService != nil {
-				s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.rateLimitService.HandleUpstreamErrorWithModel(ctx, account, resp.StatusCode, resp.Header, respBody, originalModel)
 			}
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
@@ -158,7 +158,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 				RetryableOnSameAccount: account.IsPoolMode() && (isPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
 			}
 		}
-		return s.handleChatCompletionsErrorResponse(resp, c, account)
+		return s.handleChatCompletionsErrorResponse(resp, c, account, originalModel)
 	}
 
 	// 9. Handle normal response
@@ -185,7 +185,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	// Extract and save Codex usage snapshot from response headers (for OAuth accounts)
 	if handleErr == nil && account.Type == AccountTypeOAuth {
 		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+			s.updateCodexUsageSnapshotWithModel(ctx, account.ID, snapshot, originalModel, false)
 		}
 	}
 
@@ -198,8 +198,9 @@ func (s *OpenAIGatewayService) handleChatCompletionsErrorResponse(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
+	requestedModel string,
 ) (*OpenAIForwardResult, error) {
-	return s.handleCompatErrorResponse(resp, c, account, writeChatCompletionsError)
+	return s.handleCompatErrorResponse(resp, c, account, requestedModel, writeChatCompletionsError)
 }
 
 // handleChatBufferedStreamingResponse reads all Responses SSE events from the

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -164,7 +164,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 				Detail:             upstreamDetail,
 			})
 			if s.rateLimitService != nil {
-				s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.rateLimitService.HandleUpstreamErrorWithModel(ctx, account, resp.StatusCode, resp.Header, respBody, originalModel)
 			}
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
@@ -173,7 +173,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			}
 		}
 		// Non-failover error: return Anthropic-formatted error to client
-		return s.handleAnthropicErrorResponse(resp, c, account)
+		return s.handleAnthropicErrorResponse(resp, c, account, originalModel)
 	}
 
 	// 9. Handle normal response
@@ -202,7 +202,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// Extract and save Codex usage snapshot from response headers (for OAuth accounts)
 	if handleErr == nil && account.Type == AccountTypeOAuth {
 		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+			s.updateCodexUsageSnapshotWithModel(ctx, account.ID, snapshot, originalModel, false)
 		}
 	}
 
@@ -215,8 +215,9 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
+	requestedModel string,
 ) (*OpenAIForwardResult, error) {
-	return s.handleCompatErrorResponse(resp, c, account, writeAnthropicError)
+	return s.handleCompatErrorResponse(resp, c, account, requestedModel, writeAnthropicError)
 }
 
 // handleAnthropicBufferedStreamingResponse reads all Responses SSE events from

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1557,6 +1557,9 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.
 	if requestedModel != "" && !fresh.IsModelSupported(requestedModel) {
 		return nil
 	}
+	if requestedModel != "" && fresh.isModelRateLimitedWithContext(ctx, requestedModel) {
+		return nil
+	}
 	return fresh
 }
 
@@ -1636,9 +1639,9 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
 }
 
-func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account) {
+func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, requestedModel string) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	s.rateLimitService.HandleUpstreamErrorWithModel(ctx, account, resp.StatusCode, resp.Header, body, requestedModel)
 }
 
 // Forward forwards request to OpenAI API
@@ -2221,14 +2224,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 					Detail:             upstreamDetail,
 				})
 
-				s.handleFailoverSideEffects(ctx, resp, account)
+				s.handleFailoverSideEffects(ctx, resp, account, originalModel)
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
 					RetryableOnSameAccount: account.IsPoolMode() && (isPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
 				}
 			}
-			return s.handleErrorResponse(ctx, resp, c, account, body)
+			return s.handleErrorResponse(ctx, resp, c, account, body, originalModel)
 		}
 		defer func() { _ = resp.Body.Close() }()
 
@@ -2252,7 +2255,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		// Extract and save Codex usage snapshot from response headers (for OAuth accounts)
 		if account.Type == AccountTypeOAuth {
 			if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-				s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+				s.updateCodexUsageSnapshotWithModel(ctx, account.ID, snapshot, originalModel, false)
 			}
 		}
 
@@ -2415,7 +2418,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 
 	if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-		s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+		s.updateCodexUsageSnapshotWithModel(ctx, account.ID, snapshot, reqModel, false)
 	}
 
 	if usage == nil {
@@ -2966,6 +2969,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	c *gin.Context,
 	account *Account,
 	requestBody []byte,
+	requestedModel string,
 ) (*OpenAIForwardResult, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 
@@ -3043,8 +3047,11 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 
 	// Handle upstream error (mark account status)
 	shouldDisable := false
+	if requestedModel == "" {
+		requestedModel, _, _ = extractOpenAIRequestMetaFromBody(requestBody)
+	}
 	if s.rateLimitService != nil {
-		shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		shouldDisable = s.rateLimitService.HandleUpstreamErrorWithModel(ctx, account, resp.StatusCode, resp.Header, body, requestedModel)
 	}
 	kind := "http_error"
 	if shouldDisable {
@@ -3121,6 +3128,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
+	requestedModel string,
 	writeError compatErrorWriter,
 ) (*OpenAIForwardResult, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
@@ -3179,8 +3187,8 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	// Track rate limits and decide whether to trigger secondary failover.
 	shouldDisable := false
 	if s.rateLimitService != nil {
-		shouldDisable = s.rateLimitService.HandleUpstreamError(
-			c.Request.Context(), account, resp.StatusCode, resp.Header, body,
+		shouldDisable = s.rateLimitService.HandleUpstreamErrorWithModel(
+			c.Request.Context(), account, resp.StatusCode, resp.Header, body, requestedModel,
 		)
 	}
 	kind := "http_error"
@@ -4306,62 +4314,69 @@ func codexResetAtRFC3339(base time.Time, resetAfterSeconds *int) *string {
 }
 
 func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow time.Time) map[string]any {
+	return buildCodexUsageExtraUpdatesWithScope(snapshot, fallbackNow, openAICodexQuotaScopeCodex)
+}
+
+func buildCodexUsageExtraUpdatesWithScope(snapshot *OpenAICodexUsageSnapshot, fallbackNow time.Time, scope openAICodexQuotaScope) map[string]any {
 	if snapshot == nil {
 		return nil
 	}
 
 	baseTime := codexSnapshotBaseTime(snapshot, fallbackNow)
 	updates := make(map[string]any)
+	key := func(suffix string) string {
+		return codexScopeExtraKey(scope, suffix)
+	}
 
 	// 保存原始 primary/secondary 字段，便于排查问题
 	if snapshot.PrimaryUsedPercent != nil {
-		updates["codex_primary_used_percent"] = *snapshot.PrimaryUsedPercent
+		updates[key("primary_used_percent")] = *snapshot.PrimaryUsedPercent
 	}
 	if snapshot.PrimaryResetAfterSeconds != nil {
-		updates["codex_primary_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
+		updates[key("primary_reset_after_seconds")] = *snapshot.PrimaryResetAfterSeconds
 	}
 	if snapshot.PrimaryWindowMinutes != nil {
-		updates["codex_primary_window_minutes"] = *snapshot.PrimaryWindowMinutes
+		updates[key("primary_window_minutes")] = *snapshot.PrimaryWindowMinutes
 	}
 	if snapshot.SecondaryUsedPercent != nil {
-		updates["codex_secondary_used_percent"] = *snapshot.SecondaryUsedPercent
+		updates[key("secondary_used_percent")] = *snapshot.SecondaryUsedPercent
 	}
 	if snapshot.SecondaryResetAfterSeconds != nil {
-		updates["codex_secondary_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
+		updates[key("secondary_reset_after_seconds")] = *snapshot.SecondaryResetAfterSeconds
 	}
 	if snapshot.SecondaryWindowMinutes != nil {
-		updates["codex_secondary_window_minutes"] = *snapshot.SecondaryWindowMinutes
+		updates[key("secondary_window_minutes")] = *snapshot.SecondaryWindowMinutes
 	}
 	if snapshot.PrimaryOverSecondaryPercent != nil {
-		updates["codex_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
+		updates[key("primary_over_secondary_percent")] = *snapshot.PrimaryOverSecondaryPercent
 	}
-	updates["codex_usage_updated_at"] = baseTime.Format(time.RFC3339)
+	updates[key("usage_updated_at")] = baseTime.Format(time.RFC3339)
 
 	// 归一化到 5h/7d 规范字段
 	if normalized := snapshot.Normalize(); normalized != nil {
 		if normalized.Used5hPercent != nil {
-			updates["codex_5h_used_percent"] = *normalized.Used5hPercent
+			updates[key("5h_used_percent")] = *normalized.Used5hPercent
 		}
 		if normalized.Reset5hSeconds != nil {
-			updates["codex_5h_reset_after_seconds"] = *normalized.Reset5hSeconds
+			updates[key("5h_reset_after_seconds")] = *normalized.Reset5hSeconds
 		}
 		if normalized.Window5hMinutes != nil {
-			updates["codex_5h_window_minutes"] = *normalized.Window5hMinutes
+			updates[key("5h_window_minutes")] = *normalized.Window5hMinutes
 		}
 		if normalized.Used7dPercent != nil {
-			updates["codex_7d_used_percent"] = *normalized.Used7dPercent
+			updates[key("7d_used_percent")] = *normalized.Used7dPercent
 		}
 		if normalized.Reset7dSeconds != nil {
-			updates["codex_7d_reset_after_seconds"] = *normalized.Reset7dSeconds
+			updates[key("7d_reset_after_seconds")] = *normalized.Reset7dSeconds
 		}
 		if normalized.Window7dMinutes != nil {
-			updates["codex_7d_window_minutes"] = *normalized.Window7dMinutes
+			updates[key("7d_window_minutes")] = *normalized.Window7dMinutes
 		}
 		if reset5hAt := codexResetAtRFC3339(baseTime, normalized.Reset5hSeconds); reset5hAt != nil {
-			updates["codex_5h_reset_at"] = *reset5hAt
+			updates[key("5h_reset_at")] = *reset5hAt
 		}
 		if reset7dAt := codexResetAtRFC3339(baseTime, normalized.Reset7dSeconds); reset7dAt != nil {
-			updates["codex_7d_reset_at"] = *reset7dAt
+			updates[key("7d_reset_at")] = *reset7dAt
 		}
 	}
 
@@ -4393,25 +4408,60 @@ func codexRateLimitResetAtFromSnapshot(snapshot *OpenAICodexUsageSnapshot, fallb
 }
 
 func codexRateLimitResetAtFromExtra(extra map[string]any, now time.Time) *time.Time {
+	return codexRateLimitResetAtFromExtraWithScope(extra, now, openAICodexQuotaScopeCodex)
+}
+
+func codexRateLimitResetAtFromExtraWithScope(extra map[string]any, now time.Time, scope openAICodexQuotaScope) *time.Time {
 	if len(extra) == 0 {
 		return nil
 	}
-	if progress := buildCodexUsageProgressFromExtra(extra, "7d", now); progress != nil && codexUsagePercentExhausted(&progress.Utilization) && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
+	if progress := buildCodexUsageProgressFromExtraWithScope(extra, "7d", now, scope); progress != nil && codexUsagePercentExhausted(&progress.Utilization) && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
 		resetAt := progress.ResetsAt.UTC()
 		return &resetAt
 	}
-	if progress := buildCodexUsageProgressFromExtra(extra, "5h", now); progress != nil && codexUsagePercentExhausted(&progress.Utilization) && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
+	if progress := buildCodexUsageProgressFromExtraWithScope(extra, "5h", now, scope); progress != nil && codexUsagePercentExhausted(&progress.Utilization) && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
 		resetAt := progress.ResetsAt.UTC()
 		return &resetAt
 	}
 	return nil
 }
 
+func openAICodexGlobalRateLimitResetAtFromExtra(account *Account, now time.Time) *time.Time {
+	if account == nil || len(account.Extra) == 0 {
+		return nil
+	}
+
+	supportCodex := isOpenAICodexScopeSupported(account, openAICodexQuotaScopeCodex)
+	supportSpark := isOpenAICodexScopeSupported(account, openAICodexQuotaScopeSpark)
+	if !supportCodex && !supportSpark {
+		return codexRateLimitResetAtFromExtra(account.Extra, now)
+	}
+
+	candidate := (*time.Time)(nil)
+	if supportCodex {
+		reset := codexRateLimitResetAtFromExtraWithScope(account.Extra, now, openAICodexQuotaScopeCodex)
+		if reset == nil {
+			return nil
+		}
+		candidate = reset
+	}
+	if supportSpark {
+		reset := codexRateLimitResetAtFromExtraWithScope(account.Extra, now, openAICodexQuotaScopeSpark)
+		if reset == nil {
+			return nil
+		}
+		if candidate == nil || reset.Before(*candidate) {
+			candidate = reset
+		}
+	}
+	return candidate
+}
+
 func applyOpenAICodexRateLimitFromExtra(account *Account, now time.Time) (*time.Time, bool) {
 	if account == nil || !account.IsOpenAI() {
 		return nil, false
 	}
-	resetAt := codexRateLimitResetAtFromExtra(account.Extra, now)
+	resetAt := openAICodexGlobalRateLimitResetAtFromExtra(account, now)
 	if resetAt == nil {
 		return nil, false
 	}
@@ -4433,6 +4483,10 @@ func syncOpenAICodexRateLimitFromExtra(ctx context.Context, repo AccountReposito
 
 // updateCodexUsageSnapshot saves the Codex usage snapshot to account's Extra field
 func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot) {
+	s.updateCodexUsageSnapshotWithModel(ctx, accountID, snapshot, "", true)
+}
+
+func (s *OpenAIGatewayService) updateCodexUsageSnapshotWithModel(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot, requestedModel string, persistGlobalRateLimit bool) {
 	if snapshot == nil {
 		return
 	}
@@ -4440,8 +4494,9 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 		return
 	}
 
+	scope := classifyOpenAICodexQuotaScope(requestedModel)
 	now := time.Now()
-	updates := buildCodexUsageExtraUpdates(snapshot, now)
+	updates := buildCodexUsageExtraUpdatesWithScope(snapshot, now, scope)
 	resetAt := codexRateLimitResetAtFromSnapshot(snapshot, now)
 	if len(updates) == 0 && resetAt == nil {
 		return
@@ -4457,7 +4512,15 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 		if shouldPersistUpdates {
 			_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
 		}
-		if resetAt != nil {
+		shouldPersistScopeRateLimit := resetAt != nil || shouldPersistUpdates
+		if key := codexScopeModelRateLimitKey(scope); key != "" && shouldPersistScopeRateLimit {
+			resetAtForScope := now
+			if resetAt != nil {
+				resetAtForScope = *resetAt
+			}
+			_ = s.accountRepo.SetModelRateLimit(updateCtx, accountID, key, resetAtForScope)
+		}
+		if persistGlobalRateLimit && resetAt != nil {
 			_ = s.accountRepo.SetRateLimited(updateCtx, accountID, *resetAt)
 		}
 	}()
@@ -4468,7 +4531,7 @@ func (s *OpenAIGatewayService) UpdateCodexUsageSnapshotFromHeaders(ctx context.C
 		return
 	}
 	if snapshot := ParseCodexRateLimitHeaders(headers); snapshot != nil {
-		s.updateCodexUsageSnapshot(ctx, accountID, snapshot)
+		s.updateCodexUsageSnapshotWithModel(ctx, accountID, snapshot, "", true)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -78,6 +78,14 @@ func (r stubOpenAIAccountRepo) ListSchedulableUngroupedByPlatform(ctx context.Co
 	return r.ListSchedulableByPlatform(ctx, platform)
 }
 
+func (r stubOpenAIAccountRepo) SetRateLimited(ctx context.Context, id int64, resetAt time.Time) error {
+	return nil
+}
+
+func (r stubOpenAIAccountRepo) SetModelRateLimit(ctx context.Context, id int64, scope string, resetAt time.Time) error {
+	return nil
+}
+
 type stubConcurrencyCache struct {
 	ConcurrencyCache
 	loadBatchErr    error

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1866,7 +1866,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		)
 		var dialErr *openAIWSDialError
 		if errors.As(err, &dialErr) && dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
-			s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(err.Error()))
+			s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(err.Error()), originalModel)
 		}
 		return nil, wrapOpenAIWSFallback(classifyOpenAIWSAcquireError(err), err)
 	}
@@ -1949,6 +1949,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		account,
 		stateStore,
 		groupID,
+		originalModel,
 	); err != nil {
 		return nil, err
 	}
@@ -2160,7 +2161,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 
 		if eventType == "error" {
 			errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(message)
-			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw)
+			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw, originalModel)
 			errMsg := strings.TrimSpace(errMsgRaw)
 			if errMsg == "" {
 				errMsg = "Upstream websocket error"
@@ -2668,7 +2669,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			)
 			var dialErr *openAIWSDialError
 			if errors.As(acquireErr, &dialErr) && dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
-				s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(acquireErr.Error()))
+				s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(acquireErr.Error()), firstPayload.originalModel)
 			}
 			if errors.Is(acquireErr, errOpenAIWSPreferredConnUnavailable) {
 				return nil, NewOpenAIWSClientCloseError(
@@ -2808,7 +2809,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 			if eventType == "error" {
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(upstreamMessage)
-				s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), upstreamMessage, errCodeRaw, errTypeRaw, errMsgRaw)
+				s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), upstreamMessage, errCodeRaw, errTypeRaw, errMsgRaw, originalModel)
 				fallbackReason, _ := classifyOpenAIWSErrorEventFromRaw(errCodeRaw, errTypeRaw, errMsgRaw)
 				errCode, errType, errMessage := summarizeOpenAIWSErrorEventFieldsFromRaw(errCodeRaw, errTypeRaw, errMsgRaw)
 				recoverablePrevNotFound := fallbackReason == openAIWSIngressStagePreviousResponseNotFound &&
@@ -3541,6 +3542,7 @@ func (s *OpenAIGatewayService) performOpenAIWSGeneratePrewarm(
 	account *Account,
 	stateStore OpenAIWSStateStore,
 	groupID int64,
+	requestedModel string,
 ) error {
 	if s == nil {
 		return nil
@@ -3642,7 +3644,7 @@ func (s *OpenAIGatewayService) performOpenAIWSGeneratePrewarm(
 
 		if eventType == "error" {
 			errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(message)
-			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw)
+			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw, requestedModel)
 			errMsg := strings.TrimSpace(errMsgRaw)
 			if errMsg == "" {
 				errMsg = "OpenAI websocket prewarm error"
@@ -3926,14 +3928,14 @@ func isOpenAIWSRateLimitError(codeRaw, errTypeRaw, msgRaw string) bool {
 	return false
 }
 
-func (s *OpenAIGatewayService) persistOpenAIWSRateLimitSignal(ctx context.Context, account *Account, headers http.Header, responseBody []byte, codeRaw, errTypeRaw, msgRaw string) {
+func (s *OpenAIGatewayService) persistOpenAIWSRateLimitSignal(ctx context.Context, account *Account, headers http.Header, responseBody []byte, codeRaw, errTypeRaw, msgRaw, requestedModel string) {
 	if s == nil || s.rateLimitService == nil || account == nil || account.Platform != PlatformOpenAI {
 		return
 	}
 	if !isOpenAIWSRateLimitError(codeRaw, errTypeRaw, msgRaw) {
 		return
 	}
-	s.rateLimitService.HandleUpstreamError(ctx, account, http.StatusTooManyRequests, headers, responseBody)
+	s.rateLimitService.HandleUpstreamErrorWithModel(ctx, account, http.StatusTooManyRequests, headers, responseBody, requestedModel)
 }
 
 func classifyOpenAIWSErrorEventFromRaw(codeRaw, errTypeRaw, msgRaw string) (string, bool) {

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -897,6 +897,7 @@ func TestOpenAIGatewayService_PrewarmReadHonorsParentContext(t *testing.T) {
 		account,
 		nil,
 		0,
+		"gpt-5.1",
 	)
 	elapsed := time.Since(start)
 	require.Error(t, err)

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -39,6 +39,10 @@ func (r *openAIWSRateLimitSignalRepo) SetRateLimited(_ context.Context, _ int64,
 	return nil
 }
 
+func (r *openAIWSRateLimitSignalRepo) SetModelRateLimit(_ context.Context, _ int64, _ string, _ time.Time) error {
+	return nil
+}
+
 func (r *openAIWSRateLimitSignalRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
 	copied := make(map[string]any, len(updates))
 	for k, v := range updates {
@@ -52,6 +56,10 @@ func (r *openAICodexSnapshotAsyncRepo) SetRateLimited(_ context.Context, _ int64
 	if r.rateLimitCh != nil {
 		r.rateLimitCh <- resetAt
 	}
+	return nil
+}
+
+func (r *openAICodexSnapshotAsyncRepo) SetModelRateLimit(_ context.Context, _ int64, _ string, _ time.Time) error {
 	return nil
 }
 
@@ -70,6 +78,10 @@ func (r *openAICodexExtraListRepo) SetRateLimited(_ context.Context, _ int64, re
 	if r.rateLimitCh != nil {
 		r.rateLimitCh <- resetAt
 	}
+	return nil
+}
+
+func (r *openAICodexExtraListRepo) SetModelRateLimit(_ context.Context, _ int64, _ string, _ time.Time) error {
 	return nil
 }
 
@@ -140,6 +152,9 @@ func TestOpenAIGatewayService_Forward_WSv2ErrorEventUsageLimitPersistsRateLimit(
 		Credentials: map[string]any{
 			"api_key":  "sk-test",
 			"base_url": wsServer.URL,
+			"model_mapping": map[string]any{
+				"gpt-5.1": "gpt-5.1",
+			},
 		},
 		Extra: map[string]any{
 			"responses_websockets_v2_enabled": true,
@@ -210,6 +225,9 @@ func TestOpenAIGatewayService_Forward_WSv2Handshake429PersistsRateLimit(t *testi
 		Credentials: map[string]any{
 			"api_key":  "sk-test",
 			"base_url": server.URL,
+			"model_mapping": map[string]any{
+				"gpt-5.1": "gpt-5.1",
+			},
 		},
 		Extra: map[string]any{
 			"responses_websockets_v2_enabled": true,
@@ -273,6 +291,9 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_ErrorEventUsageL
 		Concurrency: 1,
 		Credentials: map[string]any{
 			"api_key": "sk-test",
+			"model_mapping": map[string]any{
+				"gpt-5.1": "gpt-5.1",
+			},
 		},
 		Extra: map[string]any{
 			"responses_websockets_v2_enabled": true,
@@ -451,6 +472,11 @@ func TestOpenAIGatewayService_GetSchedulableAccount_ExhaustedCodexExtraSetsRateL
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gpt-5.3-codex": "gpt-5.3-codex",
+			},
+		},
 		Extra: map[string]any{
 			"codex_7d_used_percent": 100.0,
 			"codex_7d_reset_at":     resetAt.UTC().Format(time.RFC3339),
@@ -482,6 +508,11 @@ func TestAdminService_ListAccounts_ExhaustedCodexExtraReturnsRateLimitedAccount(
 			Status:      StatusActive,
 			Schedulable: true,
 			Concurrency: 1,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"gpt-5.3-codex": "gpt-5.3-codex",
+				},
+			},
 			Extra: map[string]any{
 				"codex_7d_used_percent": 100.0,
 				"codex_7d_reset_at":     resetAt.UTC().Format(time.RFC3339),

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -110,6 +110,15 @@ func (s *RateLimitService) CheckErrorPolicy(ctx context.Context, account *Accoun
 // HandleUpstreamError 处理上游错误响应，标记账号状态
 // 返回是否应该停止该账号的调度
 func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte) (shouldDisable bool) {
+	return s.HandleUpstreamErrorWithModel(ctx, account, statusCode, headers, responseBody, "")
+}
+
+// HandleUpstreamErrorWithModel is the model-aware variant used by OpenAI paths
+// where the requested model is available.
+func (s *RateLimitService) HandleUpstreamErrorWithModel(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel string) (shouldDisable bool) {
+	if account == nil {
+		return false
+	}
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
 	// 池模式默认不标记本地账号状态；仅当用户显式配置自定义错误码时按本地策略处理。
@@ -213,7 +222,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		)
 		shouldDisable = s.handle403(ctx, account, upstreamMsg, responseBody)
 	case 429:
-		s.handle429(ctx, account, headers, responseBody)
+		s.handle429(ctx, account, headers, responseBody, requestedModel)
 		shouldDisable = false
 	case 529:
 		s.handle529(ctx, account)
@@ -684,16 +693,24 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel string) {
 	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
 	if account.Platform == PlatformOpenAI {
-		s.persistOpenAICodexSnapshot(ctx, account, headers)
+		scope := classifyOpenAICodexQuotaScope(requestedModel)
+		s.persistOpenAICodexSnapshot(ctx, account, headers, requestedModel)
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
-			if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
-				slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-				return
+			if key := codexScopeModelRateLimitKey(scope); key != "" {
+				if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, *resetAt); err != nil {
+					slog.Warn("model_rate_limit_set_failed", "account_id", account.ID, "scope", string(scope), "error", err)
+				}
 			}
-			slog.Info("openai_account_rate_limited", "account_id", account.ID, "reset_at", *resetAt)
+			if shouldSetOpenAIGlobalRateLimit(account, scope) {
+				if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
+					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
+					return
+				}
+				slog.Info("openai_account_rate_limited", "account_id", account.ID, "scope", string(scope), "reset_at", *resetAt)
+			}
 			return
 		}
 	}
@@ -795,6 +812,16 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+}
+
+func shouldSetOpenAIGlobalRateLimit(account *Account, scope openAICodexQuotaScope) bool {
+	if account == nil || account.Platform != PlatformOpenAI {
+		return true
+	}
+	if scope == openAICodexQuotaScopeSpark {
+		return !isOpenAICodexScopeSupported(account, openAICodexQuotaScopeCodex)
+	}
+	return !isOpenAICodexScopeSupported(account, openAICodexQuotaScopeSpark)
 }
 
 // calculateOpenAI429ResetTime 从 OpenAI 429 响应头计算正确的重置时间
@@ -951,7 +978,7 @@ func pickSooner(a, b *time.Time) *time.Time {
 	}
 }
 
-func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, account *Account, headers http.Header) {
+func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, account *Account, headers http.Header, requestedModel string) {
 	if s == nil || s.accountRepo == nil || account == nil || headers == nil {
 		return
 	}
@@ -959,12 +986,23 @@ func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, accou
 	if snapshot == nil {
 		return
 	}
-	updates := buildCodexUsageExtraUpdates(snapshot, time.Now())
+	scope := classifyOpenAICodexQuotaScope(requestedModel)
+	now := time.Now()
+	updates := buildCodexUsageExtraUpdatesWithScope(snapshot, now, scope)
 	if len(updates) == 0 {
 		return
 	}
 	if err := s.accountRepo.UpdateExtra(ctx, account.ID, updates); err != nil {
 		slog.Warn("openai_codex_snapshot_persist_failed", "account_id", account.ID, "error", err)
+	}
+	if key := codexScopeModelRateLimitKey(scope); key != "" {
+		resetAt := now
+		if scopeResetAt := codexRateLimitResetAtFromSnapshot(snapshot, now); scopeResetAt != nil {
+			resetAt = *scopeResetAt
+		}
+		if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, key, resetAt); err != nil {
+			slog.Warn("openai_model_rate_limit_persist_failed", "account_id", account.ID, "scope", string(scope), "error", err)
+		}
 	}
 }
 

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -163,7 +163,16 @@ func (r *openAI429SnapshotRepo) UpdateExtra(_ context.Context, _ int64, updates 
 func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	repo := &openAI429SnapshotRepo{}
 	svc := NewRateLimitService(repo, nil, nil, nil, nil)
-	account := &Account{ID: 123, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	account := &Account{
+		ID:       123,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"gpt-5.3-codex": "gpt-5.3-codex",
+			},
+		},
+	}
 
 	headers := http.Header{}
 	headers.Set("x-codex-primary-used-percent", "100")
@@ -173,7 +182,7 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
-	svc.handle429(context.Background(), account, headers, nil)
+	svc.handle429(context.Background(), account, headers, nil, "gpt-5.3-codex")
 
 	if repo.rateLimitedID != account.ID {
 		t.Fatalf("rateLimitedID = %d, want %d", repo.rateLimitedID, account.ID)


### PR DESCRIPTION
## Summary
- split OpenAI Codex quota/rate-limit state into two scopes: codex and spark
- route OpenAI model rate-limit checks by requested model scope
- avoid marking account globally rate-limited unless all supported codex scopes are exhausted

## Why
When codex quota is exhausted but spark is still available, account status should not be globally blocked.

## Commit
- a4990611