### PR TITLE
fix: skip invalid X-Forwarded-For entries in client IP detection

### DIFF
--- a/backend/internal/pkg/ip/ip.go
+++ b/backend/internal/pkg/ip/ip.go
@@ -28,15 +28,22 @@ func GetClientIP(c *gin.Context) string {
 	// 3. X-Forwarded-For (多个 IP 时取第一个公网 IP)
 	if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
 		ips := strings.Split(xff, ",")
+		firstValidIP := ""
 		for _, ip := range ips {
-			ip = strings.TrimSpace(ip)
-			if ip != "" && !isPrivateIP(ip) {
-				return normalizeIP(ip)
+			normalizedIP := normalizeIP(ip)
+			if normalizedIP == "" || net.ParseIP(normalizedIP) == nil {
+				continue
+			}
+			if firstValidIP == "" {
+				firstValidIP = normalizedIP
+			}
+			if !isPrivateIP(normalizedIP) {
+				return normalizedIP
 			}
 		}
-		// 如果都是私有 IP，返回第一个
-		if len(ips) > 0 {
-			return normalizeIP(strings.TrimSpace(ips[0]))
+		// 如果没有公网 IP，返回第一个有效的私有 IP。
+		if firstValidIP != "" {
+			return firstValidIP
 		}
 	}
 

--- a/backend/internal/pkg/ip/ip_test.go
+++ b/backend/internal/pkg/ip/ip_test.go
@@ -74,6 +74,66 @@ func TestGetTrustedClientIPUsesGinClientIP(t *testing.T) {
 	require.Equal(t, "9.9.9.9", w.Body.String())
 }
 
+func TestGetClientIPSkipsInvalidXFFEntriesBeforeValidPublicIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	require.NoError(t, r.SetTrustedProxies(nil))
+
+	r.GET("/t", func(c *gin.Context) {
+		c.String(200, GetClientIP(c))
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/t", nil)
+	req.RemoteAddr = "9.9.9.9:12345"
+	req.Header.Set("X-Forwarded-For", "unknown, 8.8.8.8")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, 200, w.Code)
+	require.Equal(t, "8.8.8.8", w.Body.String())
+}
+
+func TestGetClientIPFallsBackToGinClientIPWhenXFFHasNoValidIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	require.NoError(t, r.SetTrustedProxies(nil))
+
+	r.GET("/t", func(c *gin.Context) {
+		c.String(200, GetClientIP(c))
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/t", nil)
+	req.RemoteAddr = "9.9.9.9:12345"
+	req.Header.Set("X-Forwarded-For", "unknown, invalid-entry")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, 200, w.Code)
+	require.Equal(t, "9.9.9.9", w.Body.String())
+}
+
+func TestGetClientIPReturnsFirstValidPrivateXFFWhenNoPublicIPExists(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	r := gin.New()
+	require.NoError(t, r.SetTrustedProxies(nil))
+
+	r.GET("/t", func(c *gin.Context) {
+		c.String(200, GetClientIP(c))
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/t", nil)
+	req.RemoteAddr = "9.9.9.9:12345"
+	req.Header.Set("X-Forwarded-For", "unknown, 10.0.0.2, 192.168.1.10")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, 200, w.Code)
+	require.Equal(t, "10.0.0.2", w.Body.String())
+}
+
 func TestCheckIPRestrictionWithCompiledRules(t *testing.T) {
 	whitelist := CompileIPRules([]string{"10.0.0.0/8", "192.168.1.2"})
 	blacklist := CompileIPRules([]string{"10.1.1.1"})


### PR DESCRIPTION
## Summary
- skip invalid `X-Forwarded-For` entries like `unknown` before selecting a client IP
- fall back to Gin `ClientIP()` when the header contains no valid IPs
- keep the existing behavior of returning the first valid private IP when no public IP is present

## Testing
- go test -tags=unit ./internal/pkg/ip
- go test -tags=unit ./...