### PR TITLE
fix: trim whitespace before validating IP patterns

### DIFF
--- a/backend/internal/pkg/ip/ip.go
+++ b/backend/internal/pkg/ip/ip.go
@@ -231,6 +231,10 @@ func CheckIPRestrictionWithCompiledRules(clientIP string, whitelist, blacklist *
 
 // ValidateIPPattern 验证 IP 或 CIDR 格式是否有效。
 func ValidateIPPattern(pattern string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return false
+	}
 	if strings.Contains(pattern, "/") {
 		_, _, err := net.ParseCIDR(pattern)
 		return err == nil

--- a/backend/internal/pkg/ip/ip_test.go
+++ b/backend/internal/pkg/ip/ip_test.go
@@ -94,3 +94,22 @@ func TestCheckIPRestrictionWithCompiledRules_InvalidWhitelistStillDenies(t *test
 	require.False(t, allowed)
 	require.Equal(t, "access denied", reason)
 }
+
+func TestValidateIPPatternTrimsWhitespace(t *testing.T) {
+	require.True(t, ValidateIPPattern(" 1.2.3.4 "))
+	require.True(t, ValidateIPPattern(" 10.0.0.0/8 "))
+	require.True(t, ValidateIPPattern("\t2001:db8::1\n"))
+	require.False(t, ValidateIPPattern("   "))
+	require.False(t, ValidateIPPattern(" not-an-ip "))
+}
+
+func TestValidateIPPatternsPreservesOriginalInvalidInputs(t *testing.T) {
+	invalid := ValidateIPPatterns([]string{
+		" 1.2.3.4 ",
+		" invalid ",
+		" 10.0.0.0/8 ",
+		" bad-cidr/999 ",
+	})
+
+	require.Equal(t, []string{" invalid ", " bad-cidr/999 "}, invalid)
+}


### PR DESCRIPTION
## Summary
- trim surrounding whitespace before validating IP and CIDR patterns
- keep blank values invalid after trimming
- add unit coverage for trimmed single IP, CIDR, and batch validation behavior

## Testing
- go test -tags=unit ./internal/pkg/ip
- go test -tags=unit ./...