### PR TITLE
fix: reset clipboard copied timer on repeated copy

### DIFF
--- a/frontend/src/composables/__tests__/useClipboard.spec.ts
+++ b/frontend/src/composables/__tests__/useClipboard.spec.ts
@@ -69,6 +69,22 @@ describe('useClipboard', () => {
     expect(copied.value).toBe(false)
   })
 
+  it('重复复制时应以最后一次复制的定时器为准', async () => {
+    const { copied, copyToClipboard } = useClipboard()
+
+    await copyToClipboard('first')
+    vi.advanceTimersByTime(1500)
+
+    await copyToClipboard('second')
+    expect(copied.value).toBe(true)
+
+    vi.advanceTimersByTime(600)
+    expect(copied.value).toBe(true)
+
+    vi.advanceTimersByTime(1400)
+    expect(copied.value).toBe(false)
+  })
+
   it('复制成功时调用 showSuccess', async () => {
     const { copyToClipboard } = useClipboard()
 

--- a/frontend/src/composables/useClipboard.ts
+++ b/frontend/src/composables/useClipboard.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { getCurrentInstance, onUnmounted, ref } from 'vue'
 import { useAppStore } from '@/stores/app'
 import { i18n } from '@/i18n'
 
@@ -31,6 +31,14 @@ function fallbackCopy(text: string): boolean {
 export function useClipboard() {
   const appStore = useAppStore()
   const copied = ref(false)
+  let copiedResetTimer: ReturnType<typeof setTimeout> | null = null
+
+  const clearCopiedResetTimer = () => {
+    if (copiedResetTimer !== null) {
+      clearTimeout(copiedResetTimer)
+      copiedResetTimer = null
+    }
+  }
 
   const copyToClipboard = async (
     text: string,
@@ -54,14 +62,22 @@ export function useClipboard() {
     if (success) {
       copied.value = true
       appStore.showSuccess(successMessage || t('common.copiedToClipboard'))
-      setTimeout(() => {
+      clearCopiedResetTimer()
+      copiedResetTimer = setTimeout(() => {
         copied.value = false
+        copiedResetTimer = null
       }, 2000)
     } else {
       appStore.showError(t('common.copyFailed'))
     }
 
     return success
+  }
+
+  if (getCurrentInstance()) {
+    onUnmounted(() => {
+      clearCopiedResetTimer()
+    })
   }
 
   return { copied, copyToClipboard }


### PR DESCRIPTION
## Summary
- clear the previous clipboard reset timer before starting a new one
- keep the copied state aligned with the most recent successful copy
- clean up the pending timer on component unmount when the composable is used inside a component

## Testing
- pnpm exec vitest run src/composables/__tests__/useClipboard.spec.ts
- pnpm run typecheck
- pnpm exec eslint src/composables/useClipboard.ts src/composables/__tests__/useClipboard.spec.ts