### PR TITLE
fix: cancel pending table reload on unmount

### DIFF
--- a/frontend/src/composables/__tests__/useTableLoader.spec.ts
+++ b/frontend/src/composables/__tests__/useTableLoader.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { onUnmounted } from 'vue'
 import { useTableLoader } from '@/composables/useTableLoader'
 
 // Mock @vueuse/core 的 useDebounceFn
@@ -186,6 +187,23 @@ describe('useTableLoader', () => {
       await reload()
 
       expect(pagination.page).toBe(1)
+    })
+
+    it('组件卸载时取消待执行的 debouncedReload', async () => {
+      const fetchFn = createMockFetchFn()
+      const { debouncedReload } = useTableLoader({ fetchFn })
+
+      debouncedReload()
+      expect(fetchFn).not.toHaveBeenCalled()
+
+      const unmountHandler = vi.mocked(onUnmounted).mock.calls.at(-1)?.[0]
+      expect(unmountHandler).toBeTypeOf('function')
+
+      unmountHandler?.()
+      vi.advanceTimersByTime(300)
+      await vi.runAllTimersAsync()
+
+      expect(fetchFn).not.toHaveBeenCalled()
     })
   })
 

--- a/frontend/src/composables/useTableLoader.ts
+++ b/frontend/src/composables/useTableLoader.ts
@@ -16,6 +16,10 @@ interface TableLoaderOptions<T, P> {
   debounceMs?: number
 }
 
+type CancelableReload = ReturnType<typeof useDebounceFn> & {
+  cancel?: () => void
+}
+
 /**
  * 通用表格数据加载 Composable
  * 统一处理分页、筛选、搜索防抖和请求取消
@@ -75,7 +79,7 @@ export function useTableLoader<T, P extends Record<string, any>>(options: TableL
     return load()
   }
 
-  const debouncedReload = useDebounceFn(reload, debounceMs)
+  const debouncedReload = useDebounceFn(reload, debounceMs) as CancelableReload
 
   const handlePageChange = (page: number) => {
     // 确保页码在有效范围内
@@ -91,6 +95,7 @@ export function useTableLoader<T, P extends Record<string, any>>(options: TableL
   }
 
   onUnmounted(() => {
+    debouncedReload.cancel?.()
     abortController?.abort()
   })
 


### PR DESCRIPTION
## Summary
- cancel any pending debounced table reload when the composable is disposed
- keep the existing abort behavior for in-flight requests on unmount
- add unit coverage to ensure delayed reloads do not fire after teardown

## Testing
- pnpm exec vitest run src/composables/__tests__/useTableLoader.spec.ts
- pnpm run typecheck
- pnpm exec eslint src/composables/useTableLoader.ts src/composables/__tests__/useTableLoader.spec.ts