### PR TITLE
ci: release 后回写 VERSION 到默认分支

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,3 +271,36 @@ jobs:
                 parse_mode: "Markdown",
                 disable_web_page_preview: true
               }')"
+
+  sync-version-file:
+    needs: [release]
+    if: ${{ needs.release.result == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout default branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Sync VERSION file to released tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION=${{ github.event.inputs.tag }}
+            VERSION=${VERSION#v}
+          else
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
+
+          CURRENT_VERSION=$(tr -d '\r\n' < backend/cmd/server/VERSION || true)
+          if [ "$CURRENT_VERSION" = "$VERSION" ]; then
+            echo "VERSION file already matches $VERSION"
+            exit 0
+          fi
+
+          echo "$VERSION" > backend/cmd/server/VERSION
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add backend/cmd/server/VERSION
+          git commit -m "chore: sync VERSION to ${VERSION} [skip ci]"
+          git push origin HEAD:${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## 摘要
- 在 release 成功后新增一个 workflow job，把 tag 对应版本回写到默认分支的 `backend/cmd/server/VERSION`
- 保持仓库源码中的版本文件与已发布 tag 一致
- 避免 release 产物版本正确、但后续源码编译仍读取旧版本号的情况再次出现

## 关联
- Closes #1150

## 验证
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml_ok"'`
- `git diff --check`
- 确认该分支只修改 `.github/workflows/release.yml`
