### PR TITLE
Fix admin login after setup

### DIFF
--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -23,6 +23,10 @@ type userRepository struct {
 	sql    sqlExecutor
 }
 
+func normalizeUserEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
 func NewUserRepository(client *dbent.Client, sqlDB *sql.DB) service.UserRepository {
 	return newUserRepositoryWithSQL(client, sqlDB)
 }
@@ -35,6 +39,7 @@ func (r *userRepository) Create(ctx context.Context, userIn *service.User) error
 	if userIn == nil {
 		return nil
 	}
+	userIn.Email = normalizeUserEmail(userIn.Email)
 
 	// 统一使用 ent 的事务：保证用户与允许分组的更新原子化，
 	// 并避免基于 *sql.Tx 手动构造 ent client 导致的 ExecQuerier 断言错误。
@@ -99,7 +104,7 @@ func (r *userRepository) GetByID(ctx context.Context, id int64) (*service.User, 
 }
 
 func (r *userRepository) GetByEmail(ctx context.Context, email string) (*service.User, error) {
-	m, err := r.client.User.Query().Where(dbuser.EmailEQ(email)).Only(ctx)
+	m, err := r.client.User.Query().Where(dbuser.EmailEqualFold(normalizeUserEmail(email))).Only(ctx)
 	if err != nil {
 		return nil, translatePersistenceError(err, service.ErrUserNotFound, nil)
 	}
@@ -119,6 +124,7 @@ func (r *userRepository) Update(ctx context.Context, userIn *service.User) error
 	if userIn == nil {
 		return nil
 	}
+	userIn.Email = normalizeUserEmail(userIn.Email)
 
 	// 使用 ent 事务包裹用户更新与 allowed_groups 同步，避免跨层事务不一致。
 	tx, err := r.client.Tx(ctx)
@@ -429,7 +435,7 @@ func (r *userRepository) ReleaseSoraStorageUsageAtomic(ctx context.Context, user
 }
 
 func (r *userRepository) ExistsByEmail(ctx context.Context, email string) (bool, error) {
-	return r.client.User.Query().Where(dbuser.EmailEQ(email)).Exist(ctx)
+	return r.client.User.Query().Where(dbuser.EmailEqualFold(normalizeUserEmail(email))).Exist(ctx)
 }
 
 func (r *userRepository) AddGroupToAllowedGroups(ctx context.Context, userID int64, groupID int64) error {

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -401,6 +401,8 @@ func (s *AuthService) IsEmailVerifyEnabled(ctx context.Context) bool {
 
 // Login 用户登录，返回JWT token
 func (s *AuthService) Login(ctx context.Context, email, password string) (string, *User, error) {
+	email = normalizeEmail(email)
+
 	// 查找用户
 	user, err := s.userRepo.GetByEmail(ctx, email)
 	if err != nil {
@@ -438,7 +440,7 @@ func (s *AuthService) Login(ctx context.Context, email, password string) (string
 // 注意：该函数用于 LinuxDo OAuth 登录场景（不同于上游账号的 OAuth，例如 Claude/OpenAI/Gemini）。
 // 为了满足现有数据库约束（需要密码哈希），新用户会生成随机密码并进行哈希保存。
 func (s *AuthService) LoginOrRegisterOAuth(ctx context.Context, email, username string) (string, *User, error) {
-	email = strings.TrimSpace(email)
+	email = normalizeEmail(email)
 	if email == "" || len(email) > 255 {
 		return "", nil, infraerrors.BadRequest("INVALID_EMAIL", "invalid email")
 	}
@@ -537,7 +539,7 @@ func (s *AuthService) LoginOrRegisterOAuthWithTokenPair(ctx context.Context, ema
 		return nil, nil, errors.New("refresh token cache not configured")
 	}
 
-	email = strings.TrimSpace(email)
+	email = normalizeEmail(email)
 	if email == "" || len(email) > 255 {
 		return nil, nil, infraerrors.BadRequest("INVALID_EMAIL", "invalid email")
 	}
@@ -831,9 +833,12 @@ func randomHexString(byteLength int) (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
 func isReservedEmail(email string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(email))
-	return strings.HasSuffix(normalized, LinuxDoConnectSyntheticEmailDomain)
+	return strings.HasSuffix(normalizeEmail(email), LinuxDoConnectSyntheticEmailDomain)
 }
 
 // GenerateToken 生成JWT access token
@@ -943,6 +948,8 @@ func (s *AuthService) IsPasswordResetEnabled(ctx context.Context) bool {
 // Returns (siteName, resetURL, shouldProceed)
 // shouldProceed is false when we should silently return success (to prevent enumeration)
 func (s *AuthService) preparePasswordReset(ctx context.Context, email, frontendBaseURL string) (string, string, bool) {
+	email = normalizeEmail(email)
+
 	// Check if user exists (but don't reveal this to the caller)
 	user, err := s.userRepo.GetByEmail(ctx, email)
 	if err != nil {

--- a/backend/internal/service/auth_service_login_test.go
+++ b/backend/internal/service/auth_service_login_test.go
@@ -1,0 +1,45 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type loginUserRepoStub struct {
+	userRepoStub
+	expectedEmail string
+	requestedEmail string
+}
+
+func (s *loginUserRepoStub) GetByEmail(_ context.Context, email string) (*User, error) {
+	s.requestedEmail = email
+	if email != s.expectedEmail || s.user == nil {
+		return nil, ErrUserNotFound
+	}
+	return s.user, nil
+}
+
+func TestAuthService_Login_NormalizesEmailBeforeLookup(t *testing.T) {
+	repo := &loginUserRepoStub{expectedEmail: "admin@example.com"}
+	user := &User{
+		ID:     1,
+		Email:  "admin@example.com",
+		Role:   RoleAdmin,
+		Status: StatusActive,
+	}
+	require.NoError(t, user.SetPassword("secret123"))
+	repo.user = user
+
+	service := newAuthService(&repo.userRepoStub, nil, nil)
+	service.userRepo = repo
+
+	token, gotUser, err := service.Login(context.Background(), " Admin@Example.com ", "secret123")
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+	require.Equal(t, user, gotUser)
+	require.Equal(t, "admin@example.com", repo.requestedEmail)
+}

--- a/backend/internal/setup/setup.go
+++ b/backend/internal/setup/setup.go
@@ -396,7 +396,7 @@ func createAdminUser(cfg *SetupConfig) (bool, string, error) {
 	}
 
 	admin := &service.User{
-		Email:       cfg.Admin.Email,
+		Email:       strings.ToLower(strings.TrimSpace(cfg.Admin.Email)),
 		Role:        service.RoleAdmin,
 		Status:      service.StatusActive,
 		Balance:     0,


### PR DESCRIPTION
## Summary
- normalize user emails on create, update, lookup, and existence checks
- normalize setup-created admin email so setup and login use the same canonical value
- normalize auth login and password-reset email flows consistently
- add a regression test covering login with mixed-case and padded email input

## Bug
After completing the initial setup wizard, the newly created admin could fail to log in if the email used during login differed in case or had leading/trailing spaces from the email entered during setup.

## Verification
- `go test -tags unit ./internal/service ./internal/setup ./internal/repository`
