### PR TITLE
fix: 透传账号绕过模型限制与映射校验

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -501,8 +501,12 @@ func ensureAntigravityDefaultPassthroughs(mapping map[string]string, models []st
 }
 
 // IsModelSupported 检查模型是否在 model_mapping 中（支持通配符）
-// 如果未配置 mapping，返回 true（允许所有模型）
+// 如果未配置 mapping，返回 true（允许所有模型）。
+// 自动透传账号会绕过模型白名单/映射限制。
 func (a *Account) IsModelSupported(requestedModel string) bool {
+	if a.ShouldBypassModelRestrictions() {
+		return true
+	}
 	mapping := a.GetModelMapping()
 	if len(mapping) == 0 {
 		return true // 无映射 = 允许所有
@@ -521,7 +525,8 @@ func (a *Account) IsModelSupported(requestedModel string) bool {
 }
 
 // GetMappedModel 获取映射后的模型名（支持通配符，最长优先匹配）
-// 如果未配置 mapping，返回原始模型名
+// 如果未配置 mapping，返回原始模型名。
+// 自动透传账号会绕过模型映射。
 func (a *Account) GetMappedModel(requestedModel string) string {
 	mappedModel, _ := a.ResolveMappedModel(requestedModel)
 	return mappedModel
@@ -530,6 +535,9 @@ func (a *Account) GetMappedModel(requestedModel string) string {
 // ResolveMappedModel 获取映射后的模型名，并返回是否命中了账号级映射。
 // matched=true 表示命中了精确映射或通配符映射，即使映射结果与原模型名相同。
 func (a *Account) ResolveMappedModel(requestedModel string) (mappedModel string, matched bool) {
+	if a.ShouldBypassModelRestrictions() {
+		return requestedModel, false
+	}
 	mapping := a.GetModelMapping()
 	if len(mapping) == 0 {
 		return requestedModel, false
@@ -1104,6 +1112,15 @@ func (a *Account) IsOpenAIWSAllowStoreRecoveryEnabled() bool {
 // IsOpenAIOAuthPassthroughEnabled 兼容旧接口，等价于 OAuth 账号的 IsOpenAIPassthroughEnabled。
 func (a *Account) IsOpenAIOAuthPassthroughEnabled() bool {
 	return a != nil && a.IsOpenAIOAuth() && a.IsOpenAIPassthroughEnabled()
+}
+
+// ShouldBypassModelRestrictions 返回账号是否应绕过模型白名单/映射限制。
+// 当前仅自动透传账号需要绕过该限制，保持“仅替换认证”的语义一致。
+func (a *Account) ShouldBypassModelRestrictions() bool {
+	if a == nil {
+		return false
+	}
+	return a.IsOpenAIPassthroughEnabled() || a.IsAnthropicAPIKeyPassthroughEnabled()
 }
 
 // IsAnthropicAPIKeyPassthroughEnabled 返回 Anthropic API Key 账号是否启用“自动透传（仅替换认证）”。

--- a/backend/internal/service/account_anthropic_passthrough_test.go
+++ b/backend/internal/service/account_anthropic_passthrough_test.go
@@ -60,3 +60,24 @@ func TestAccount_IsAnthropicAPIKeyPassthroughEnabled(t *testing.T) {
 		require.False(t, openai.IsAnthropicAPIKeyPassthroughEnabled())
 	})
 }
+
+func TestAccount_ShouldBypassModelRestrictions_AnthropicAPIKey(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAnthropic,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"claude-sonnet-4-5": "claude-sonnet-4-5",
+			},
+		},
+		Extra: map[string]any{
+			"anthropic_passthrough": true,
+		},
+	}
+
+	require.True(t, account.ShouldBypassModelRestrictions())
+	require.True(t, account.IsModelSupported("claude-opus-4-6"))
+	mapped, matched := account.ResolveMappedModel("claude-opus-4-6")
+	require.Equal(t, "claude-opus-4-6", mapped)
+	require.False(t, matched)
+}

--- a/backend/internal/service/account_openai_passthrough_test.go
+++ b/backend/internal/service/account_openai_passthrough_test.go
@@ -71,6 +71,28 @@ func TestAccount_IsOpenAIOAuthPassthroughEnabled(t *testing.T) {
 	})
 }
 
+func TestAccount_ShouldBypassModelRestrictions_OpenAI(t *testing.T) {
+	t.Run("OpenAI passthrough bypasses model restrictions", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeAPIKey,
+			Credentials: map[string]any{
+				"model_mapping": map[string]any{
+					"gpt-4o-mini": "gpt-4o-mini",
+				},
+			},
+			Extra: map[string]any{
+				"openai_passthrough": true,
+			},
+		}
+		require.True(t, account.ShouldBypassModelRestrictions())
+		require.True(t, account.IsModelSupported("gpt-5.4"))
+		mapped, matched := account.ResolveMappedModel("gpt-5.4")
+		require.Equal(t, "gpt-5.4", mapped)
+		require.False(t, matched)
+	})
+}
+
 func TestAccount_IsCodexCLIOnlyEnabled(t *testing.T) {
 	t.Run("OpenAI OAuth 开启", func(t *testing.T) {
 		account := &Account{

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -173,7 +173,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardStreamPreservesBodyAnd
 	require.NotNil(t, result)
 	require.True(t, result.Stream)
 
-	require.Equal(t, "claude-3-haiku-20240307", gjson.GetBytes(upstream.lastBody, "model").String(), "透传模式应应用账号级模型映射")
+	require.Equal(t, "claude-3-7-sonnet-20250219", gjson.GetBytes(upstream.lastBody, "model").String(), "透传模式应保留客户端原始模型")
 
 	require.Equal(t, "upstream-anthropic-key", upstream.lastReq.Header.Get("x-api-key"))
 	require.Empty(t, upstream.lastReq.Header.Get("authorization"))
@@ -191,7 +191,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardStreamPreservesBodyAnd
 	require.True(t, ok)
 	bodyBytes, ok := rawBody.([]byte)
 	require.True(t, ok, "应以 []byte 形式缓存上游请求体，避免重复 string 拷贝")
-	require.Equal(t, "claude-3-haiku-20240307", gjson.GetBytes(bodyBytes, "model").String(), "缓存的上游请求体应包含映射后的模型")
+	require.Equal(t, "claude-3-7-sonnet-20250219", gjson.GetBytes(bodyBytes, "model").String(), "缓存的上游请求体应保留原始模型")
 }
 
 func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardCountTokensPreservesBody(t *testing.T) {
@@ -256,7 +256,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardCountTokensPreservesBo
 	err := svc.ForwardCountTokens(context.Background(), c, account, parsed)
 	require.NoError(t, err)
 
-	require.Equal(t, "claude-3-opus-20240229", gjson.GetBytes(upstream.lastBody, "model").String(), "count_tokens 透传模式应应用账号级模型映射")
+	require.Equal(t, "claude-3-5-sonnet-latest", gjson.GetBytes(upstream.lastBody, "model").String(), "count_tokens 透传模式应保留客户端原始模型")
 	require.Equal(t, "upstream-anthropic-key", upstream.lastReq.Header.Get("x-api-key"))
 	require.Empty(t, upstream.lastReq.Header.Get("authorization"))
 	require.Empty(t, upstream.lastReq.Header.Get("cookie"))
@@ -265,8 +265,8 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardCountTokensPreservesBo
 	require.Empty(t, rec.Header().Get("Set-Cookie"))
 }
 
-// TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingEdgeCases 覆盖透传模式下模型映射的各种边界情况
-func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingEdgeCases(t *testing.T) {
+// TestGatewayService_AnthropicAPIKeyPassthrough_ModelRestrictionsBypassed 覆盖透传模式下模型白名单/映射被绕过的情况。
+func TestGatewayService_AnthropicAPIKeyPassthrough_ModelRestrictionsBypassed(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
@@ -277,66 +277,66 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingEdgeCases(t *test
 		endpoint      string // "messages" or "count_tokens"
 	}{
 		{
-			name:          "Forward: 无映射配置时不改写模型",
+			name:          "Forward: 无映射配置时保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  nil,
 			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "messages",
 		},
 		{
-			name:          "Forward: 空映射配置时不改写模型",
+			name:          "Forward: 空映射配置时保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{},
 			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "messages",
 		},
 		{
-			name:          "Forward: 模型不在映射表中时不改写",
+			name:          "Forward: 模型不在映射表中时保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{"claude-3-haiku-20240307": "claude-3-opus-20240229"},
 			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "messages",
 		},
 		{
-			name:          "Forward: 精确匹配映射应改写模型",
+			name:          "Forward: 精确匹配映射时仍保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{"claude-sonnet-4-20250514": "claude-sonnet-4-5-20241022"},
-			expectedModel: "claude-sonnet-4-5-20241022",
+			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "messages",
 		},
 		{
-			name:          "Forward: 通配符映射应改写模型",
+			name:          "Forward: 通配符映射时仍保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{"claude-sonnet-4-*": "claude-sonnet-4-5-20241022"},
-			expectedModel: "claude-sonnet-4-5-20241022",
+			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "messages",
 		},
 		{
-			name:          "CountTokens: 无映射配置时不改写模型",
+			name:          "CountTokens: 无映射配置时保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  nil,
 			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "count_tokens",
 		},
 		{
-			name:          "CountTokens: 模型不在映射表中时不改写",
+			name:          "CountTokens: 模型不在映射表中时保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{"claude-3-haiku-20240307": "claude-3-opus-20240229"},
 			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "count_tokens",
 		},
 		{
-			name:          "CountTokens: 精确匹配映射应改写模型",
+			name:          "CountTokens: 精确匹配映射时仍保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{"claude-sonnet-4-20250514": "claude-sonnet-4-5-20241022"},
-			expectedModel: "claude-sonnet-4-5-20241022",
+			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "count_tokens",
 		},
 		{
-			name:          "CountTokens: 通配符映射应改写模型",
+			name:          "CountTokens: 通配符映射时仍保留原始模型",
 			model:         "claude-sonnet-4-20250514",
 			modelMapping:  map[string]any{"claude-sonnet-4-*": "claude-sonnet-4-5-20241022"},
-			expectedModel: "claude-sonnet-4-5-20241022",
+			expectedModel: "claude-sonnet-4-20250514",
 			endpoint:      "count_tokens",
 		},
 	}
@@ -421,9 +421,9 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingEdgeCases(t *test
 	}
 }
 
-// TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingPreservesOtherFields
-// 确保模型映射只替换 model 字段，不影响请求体中的其他字段
-func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingPreservesOtherFields(t *testing.T) {
+// TestGatewayService_AnthropicAPIKeyPassthrough_PreservesOtherFields
+// 确保透传模式不会改写 model 字段，也不会影响请求体中的其他字段。
+func TestGatewayService_AnthropicAPIKeyPassthrough_PreservesOtherFields(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	rec := httptest.NewRecorder()
@@ -472,7 +472,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingPreservesOtherFie
 	require.NoError(t, err)
 
 	sentBody := upstream.lastBody
-	require.Equal(t, "claude-sonnet-4-5-20241022", gjson.GetBytes(sentBody, "model").String(), "model 应被映射")
+	require.Equal(t, "claude-sonnet-4-20250514", gjson.GetBytes(sentBody, "model").String(), "model 应保留客户端原始值")
 	require.Equal(t, "You are a helpful assistant.", gjson.GetBytes(sentBody, "system.0.text").String(), "system 字段不应被修改")
 	require.Equal(t, "hello world", gjson.GetBytes(sentBody, "messages.0.content.0.text").String(), "messages 字段不应被修改")
 	require.Equal(t, "enabled", gjson.GetBytes(sentBody, "thinking.type").String(), "thinking 字段不应被修改")

--- a/backend/internal/service/gateway_passthrough_model_support_test.go
+++ b/backend/internal/service/gateway_passthrough_model_support_test.go
@@ -1,0 +1,73 @@
+package service
+
+import "testing"
+
+func TestGatewayService_isModelSupportedByAccount_PassthroughBypassesRestrictions(t *testing.T) {
+	svc := &GatewayService{}
+
+	tests := []struct {
+		name    string
+		account *Account
+		model   string
+		want    bool
+	}{
+		{
+			name: "OpenAI passthrough bypasses account model mapping",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gpt-3.5-turbo": "gpt-3.5-turbo"},
+				},
+				Extra: map[string]any{"openai_passthrough": true},
+			},
+			model: "gpt-5.4",
+			want:  true,
+		},
+		{
+			name: "Anthropic passthrough bypasses account model mapping",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"claude-3-5-sonnet-20241022": "claude-3-5-sonnet-20241022"},
+				},
+				Extra: map[string]any{"anthropic_passthrough": true},
+			},
+			model: "claude-opus-4-6",
+			want:  true,
+		},
+		{
+			name: "OpenAI non-passthrough still respects mapping allowlist",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"gpt-3.5-turbo": "gpt-3.5-turbo"},
+				},
+			},
+			model: "gpt-5.4",
+			want:  false,
+		},
+		{
+			name: "Anthropic non-passthrough still respects mapping allowlist",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{"claude-3-5-sonnet-20241022": "claude-3-5-sonnet-20241022"},
+				},
+			},
+			model: "claude-opus-4-6",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := svc.isModelSupportedByAccount(tt.account, tt.model); got != tt.want {
+				t.Fatalf("isModelSupportedByAccount(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -472,6 +472,34 @@ func TestOpenAISelectAccountForModelWithExclusions_NoModelSupport(t *testing.T) 
 	}
 }
 
+func TestOpenAISelectAccountForModelWithExclusions_PassthroughBypassesModelRestrictions(t *testing.T) {
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:          1,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Credentials: map[string]any{"model_mapping": map[string]any{"gpt-3.5-turbo": "gpt-3.5-turbo"}},
+				Extra:       map[string]any{"openai_passthrough": true},
+			},
+		},
+	}
+	cache := &stubGatewayCache{}
+
+	svc := &OpenAIGatewayService{
+		accountRepo: repo,
+		cache:       cache,
+	}
+
+	acc, err := svc.SelectAccountForModelWithExclusions(context.Background(), nil, "", "gpt-5.4", nil)
+	require.NoError(t, err)
+	require.NotNil(t, acc)
+	require.Equal(t, int64(1), acc.ID)
+}
+
 func TestOpenAISelectAccountWithLoadAwareness_LoadBatchErrorFallback(t *testing.T) {
 	groupID := int64(1)
 	repo := stubOpenAIAccountRepo{

--- a/backend/internal/service/openai_model_mapping.go
+++ b/backend/internal/service/openai_model_mapping.go
@@ -10,6 +10,9 @@ func resolveOpenAIForwardModel(account *Account, requestedModel, defaultMappedMo
 		}
 		return requestedModel
 	}
+	if account.ShouldBypassModelRestrictions() {
+		return requestedModel
+	}
 
 	mappedModel, matched := account.ResolveMappedModel(requestedModel)
 	if !matched && defaultMappedModel != "" {

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -58,6 +58,24 @@ func TestResolveOpenAIForwardModel(t *testing.T) {
 			defaultMappedModel: "gpt-4o-mini",
 			expectedModel:      "gpt-5.4",
 		},
+		{
+			name: "passthrough bypasses both account and group default mappings",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{
+						"gpt-5.4": "gpt-4o-mini",
+					},
+				},
+				Extra: map[string]any{
+					"openai_passthrough": true,
+				},
+			},
+			requestedModel:     "gpt-5.4",
+			defaultMappedModel: "gpt-4o-mini",
+			expectedModel:      "gpt-5.4",
+		},
 	}
 
 	for _, tt := range tests {

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -977,11 +977,11 @@
           <label class="input-label">{{ t('admin.accounts.modelRestriction') }}</label>
 
           <div
-            v-if="isOpenAIModelRestrictionDisabled"
+            v-if="isModelRestrictionDisabledByPassthrough"
             class="mb-3 rounded-lg bg-amber-50 p-3 dark:bg-amber-900/20"
           >
             <p class="text-xs text-amber-700 dark:text-amber-400">
-              {{ t('admin.accounts.openai.modelRestrictionDisabledByPassthrough') }}
+              {{ t('admin.accounts.modelRestrictionDisabledByPassthrough') }}
             </p>
           </div>
 
@@ -1594,11 +1594,11 @@
         <label class="input-label">{{ t('admin.accounts.modelRestriction') }}</label>
 
         <div
-          v-if="isOpenAIModelRestrictionDisabled"
+          v-if="isModelRestrictionDisabledByPassthrough"
           class="mb-3 rounded-lg bg-amber-50 p-3 dark:bg-amber-900/20"
         >
           <p class="text-xs text-amber-700 dark:text-amber-400">
-            {{ t('admin.accounts.openai.modelRestrictionDisabledByPassthrough') }}
+            {{ t('admin.accounts.modelRestrictionDisabledByPassthrough') }}
           </p>
         </div>
 
@@ -3129,8 +3129,9 @@ const openAIWSModeConcurrencyHintKey = computed(() =>
   resolveOpenAIWSModeConcurrencyHintKey(openaiResponsesWebSocketV2Mode.value)
 )
 
-const isOpenAIModelRestrictionDisabled = computed(() =>
-  form.platform === 'openai' && openaiPassthroughEnabled.value
+const isModelRestrictionDisabledByPassthrough = computed(() =>
+  (form.platform === 'openai' && openaiPassthroughEnabled.value) ||
+  (form.platform === 'anthropic' && accountCategory.value === 'apikey' && anthropicPassthroughEnabled.value)
 )
 
 const mixedChannelWarningMessageText = computed(() => {
@@ -4039,7 +4040,7 @@ const handleSubmit = async () => {
   }
 
   // Add model mapping if configured（OpenAI 开启自动透传时不应用）
-  if (!isOpenAIModelRestrictionDisabled.value) {
+  if (!isModelRestrictionDisabledByPassthrough.value) {
     const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
     if (modelMapping) {
       credentials.model_mapping = modelMapping
@@ -4285,7 +4286,7 @@ const handleOpenAIExchange = async (authCode: string) => {
     const shouldCreateSora = form.platform === 'sora'
 
     // Add model mapping for OpenAI OAuth accounts（透传模式下不应用）
-    if (shouldCreateOpenAI && !isOpenAIModelRestrictionDisabled.value) {
+    if (shouldCreateOpenAI && !isModelRestrictionDisabledByPassthrough.value) {
       const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
       if (modelMapping) {
         credentials.model_mapping = modelMapping
@@ -4403,7 +4404,7 @@ const handleOpenAIValidateRT = async (refreshTokenInput: string) => {
         const extra = buildOpenAIExtra(oauthExtra)
 
         // Add model mapping for OpenAI OAuth accounts（透传模式下不应用）
-        if (shouldCreateOpenAI && !isOpenAIModelRestrictionDisabled.value) {
+        if (shouldCreateOpenAI && !isModelRestrictionDisabledByPassthrough.value) {
           const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
           if (modelMapping) {
             credentials.model_mapping = modelMapping

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -70,11 +70,11 @@
           <label class="input-label">{{ t('admin.accounts.modelRestriction') }}</label>
 
           <div
-            v-if="isOpenAIModelRestrictionDisabled"
+            v-if="isModelRestrictionDisabledByPassthrough"
             class="mb-3 rounded-lg bg-amber-50 p-3 dark:bg-amber-900/20"
           >
             <p class="text-xs text-amber-700 dark:text-amber-400">
-              {{ t('admin.accounts.openai.modelRestrictionDisabledByPassthrough') }}
+              {{ t('admin.accounts.modelRestrictionDisabledByPassthrough') }}
             </p>
           </div>
 
@@ -411,11 +411,11 @@
         <label class="input-label">{{ t('admin.accounts.modelRestriction') }}</label>
 
         <div
-          v-if="isOpenAIModelRestrictionDisabled"
+          v-if="isModelRestrictionDisabledByPassthrough"
           class="mb-3 rounded-lg bg-amber-50 p-3 dark:bg-amber-900/20"
         >
           <p class="text-xs text-amber-700 dark:text-amber-400">
-            {{ t('admin.accounts.openai.modelRestrictionDisabledByPassthrough') }}
+            {{ t('admin.accounts.modelRestrictionDisabledByPassthrough') }}
           </p>
         </div>
 
@@ -1884,8 +1884,9 @@ const openaiResponsesWebSocketV2Mode = computed({
 const openAIWSModeConcurrencyHintKey = computed(() =>
   resolveOpenAIWSModeConcurrencyHintKey(openaiResponsesWebSocketV2Mode.value)
 )
-const isOpenAIModelRestrictionDisabled = computed(() =>
-  props.account?.platform === 'openai' && openaiPassthroughEnabled.value
+const isModelRestrictionDisabledByPassthrough = computed(() =>
+  (props.account?.platform === 'openai' && openaiPassthroughEnabled.value) ||
+  (props.account?.platform === 'anthropic' && props.account?.type === 'apikey' && anthropicPassthroughEnabled.value)
 )
 
 // Computed: current preset mappings based on platform
@@ -2679,7 +2680,7 @@ const handleSubmit = async () => {
     if (props.account.type === 'apikey') {
       const currentCredentials = (props.account.credentials as Record<string, unknown>) || {}
       const newBaseUrl = editBaseUrl.value.trim() || defaultBaseUrl.value
-      const shouldApplyModelMapping = !(props.account.platform === 'openai' && openaiPassthroughEnabled.value)
+      const shouldApplyModelMapping = !isModelRestrictionDisabledByPassthrough.value
 
       // Always update credentials for apikey type to handle model mapping changes
       const newCredentials: Record<string, unknown> = {
@@ -2822,7 +2823,7 @@ const handleSubmit = async () => {
       const currentCredentials = (updatePayload.credentials as Record<string, unknown>) ||
         ((props.account.credentials as Record<string, unknown>) || {})
       const newCredentials: Record<string, unknown> = { ...currentCredentials }
-      const shouldApplyModelMapping = !openaiPassthroughEnabled.value
+      const shouldApplyModelMapping = !isModelRestrictionDisabledByPassthrough.value
 
       if (shouldApplyModelMapping) {
         const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2167,7 +2167,6 @@ export default {
         codexCLIOnly: 'Codex official clients only',
         codexCLIOnlyDesc:
           'Only applies to OpenAI OAuth. When enabled, only Codex official client families are allowed; when disabled, the gateway bypasses this restriction and keeps existing behavior.',
-        modelRestrictionDisabledByPassthrough: 'Automatic passthrough is enabled: model whitelist/mapping will not take effect.',
         enableSora: 'Enable Sora simultaneously',
         enableSoraHint: 'Sora uses the same OpenAI account. Enable to create Sora account simultaneously.'
       },
@@ -2176,6 +2175,7 @@ export default {
         apiKeyPassthroughDesc:
           'Only applies to Anthropic API Key accounts. When enabled, messages/count_tokens are forwarded in passthrough mode with auth replacement only, while billing/concurrency/audit and safety filtering are preserved. Disable to roll back immediately.'
       },
+      modelRestrictionDisabledByPassthrough: 'Automatic passthrough is enabled: model whitelist/mapping will not take effect.',
       modelRestriction: 'Model Restriction (Optional)',
       modelWhitelist: 'Model Whitelist',
       modelMapping: 'Model Mapping',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2313,7 +2313,6 @@ export default {
         responsesWebsocketsV2PassthroughHint: '当前已开启自动透传：仅影响 HTTP 透传链路，不影响 WS mode。',
         codexCLIOnly: '仅允许 Codex 官方客户端',
         codexCLIOnlyDesc: '仅对 OpenAI OAuth 生效。开启后仅允许 Codex 官方客户端家族访问；关闭后完全绕过并保持原逻辑。',
-        modelRestrictionDisabledByPassthrough: '已开启自动透传：模型白名单/映射不会生效。',
         enableSora: '同时启用 Sora',
         enableSoraHint: 'Sora 使用相同的 OpenAI 账号，开启后将同时创建 Sora 平台账号'
       },
@@ -2322,6 +2321,7 @@ export default {
         apiKeyPassthroughDesc:
           '仅对 Anthropic API Key 生效。开启后，messages/count_tokens 请求将透传上游并仅替换认证，保留计费/并发/审计及必要安全过滤；关闭即可回滚到现有兼容链路。'
       },
+      modelRestrictionDisabledByPassthrough: '已开启自动透传：模型白名单/映射不会生效。',
       modelRestriction: '模型限制（可选）',
       modelWhitelist: '模型白名单',
       modelMapping: '模型映射',


### PR DESCRIPTION
## 变更背景

当前透传模式的语义是“仅替换认证信息，模型请求尽量原样透传到上游”。

但现状里，账号级 `model_mapping` / 模型白名单仍然会影响透传账号，导致这类场景出现误拦截：

- OpenAI passthrough 账号请求新模型时，因为账号未配置对应 `model_mapping`，调度阶段可能直接判定为不支持
- Anthropic API Key passthrough 账号也存在同类问题
- 部分路径即使账号已被选中，后续模型映射阶段仍可能继续改写模型名，不符合 passthrough 语义

## 本次改动

本 PR 将“透传账号绕过模型限制”的行为统一收敛到账号层判断，并补齐相关调用链：

- 新增 `ShouldBypassModelRestrictions()`
- 透传账号在 `IsModelSupported()` 中直接放行
- 透传账号在 `ResolveMappedModel()` / `GetMappedModel()` 中不再应用账号级模型映射
- OpenAI 转发模型解析时，透传账号不再继续套用账号映射或默认映射
- 前端创建/编辑账号时：
  - OpenAI passthrough
  - Anthropic API Key passthrough

  开启后统一提示“模型限制已失效”，不再编辑新的模型限制配置

## 影响范围

本次改动影响以下场景：

- OpenAI API Key passthrough
- OpenAI OAuth passthrough
- Anthropic API Key passthrough

不影响未开启 passthrough 的普通账号，原有模型白名单 / 模型映射逻辑保持不变。

## 与历史改动的关系

这次改动与之前的 #806 / #807 属于同一问题域，但不是重复提交。

区别是：

- `#806/#807` 主要处理 OpenAI passthrough 在调度阶段的模型支持判断
- 本 PR 进一步把相同语义扩展到 Anthropic API Key passthrough
- 同时把绕过逻辑补齐到模型映射解析链路，避免只在部分路径生效

## 测试

已补充并验证相关测试：

- passthrough 账号绕过模型支持判断
- Anthropic passthrough 绕过账号级模型限制
- OpenAI passthrough 在账号选择与 forward model 解析阶段保持原模型透传
