### PR TITLE
fix: clear stale codex rate limit state

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -415,8 +415,14 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 
 	if isOAuth && s.accountRepo != nil {
 		if updates, err := extractOpenAICodexProbeUpdates(resp); err == nil && len(updates) > 0 {
+			clearStaleRateLimit := shouldClearOpenAICodexRateLimit(account, updates, nil)
 			_ = s.accountRepo.UpdateExtra(ctx, account.ID, updates)
 			mergeAccountExtra(account, updates)
+			if clearStaleRateLimit {
+				_ = s.accountRepo.ClearRateLimit(ctx, account.ID)
+				account.RateLimitResetAt = nil
+				account.RateLimitedAt = nil
+			}
 		}
 		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
 			if resetAt := codexRateLimitResetAtFromSnapshot(snapshot, time.Now()); resetAt != nil {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -538,11 +538,23 @@ func (s *AccountUsageService) persistOpenAICodexProbeSnapshot(accountID int64, u
 	go func() {
 		updateCtx, updateCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer updateCancel()
+
+		var accountBefore *Account
+		if len(updates) > 0 && resetAt == nil {
+			if existing, err := s.accountRepo.GetByID(updateCtx, accountID); err == nil {
+				accountBefore = existing
+			}
+		}
+
 		if len(updates) > 0 {
 			_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
 		}
 		if resetAt != nil {
 			_ = s.accountRepo.SetRateLimited(updateCtx, accountID, *resetAt)
+			return
+		}
+		if shouldClearOpenAICodexRateLimit(accountBefore, updates, resetAt) {
+			_ = s.accountRepo.ClearRateLimit(updateCtx, accountID)
 		}
 	}()
 }

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -9,8 +9,9 @@ import (
 
 type accountUsageCodexProbeRepo struct {
 	stubOpenAIAccountRepo
-	updateExtraCh chan map[string]any
-	rateLimitCh   chan time.Time
+	updateExtraCh    chan map[string]any
+	rateLimitCh      chan time.Time
+	clearRateLimitCh chan int64
 }
 
 func (r *accountUsageCodexProbeRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
@@ -27,6 +28,13 @@ func (r *accountUsageCodexProbeRepo) UpdateExtra(_ context.Context, _ int64, upd
 func (r *accountUsageCodexProbeRepo) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
 	if r.rateLimitCh != nil {
 		r.rateLimitCh <- resetAt
+	}
+	return nil
+}
+
+func (r *accountUsageCodexProbeRepo) ClearRateLimit(_ context.Context, id int64) error {
+	if r.clearRateLimitCh != nil {
+		r.clearRateLimitCh <- id
 	}
 	return nil
 }
@@ -126,8 +134,9 @@ func TestAccountUsageService_PersistOpenAICodexProbeSnapshotSetsRateLimit(t *tes
 	resetAt := time.Now().Add(2 * time.Hour).UTC().Truncate(time.Second)
 
 	svc.persistOpenAICodexProbeSnapshot(321, map[string]any{
-		"codex_7d_used_percent": 100.0,
-		"codex_7d_reset_at":     resetAt.Format(time.RFC3339),
+		"codex_7d_used_percent":      100.0,
+		"codex_7d_reset_at":          resetAt.Format(time.RFC3339),
+		codexRateLimitActiveExtraKey: true,
 	}, &resetAt)
 
 	select {
@@ -146,5 +155,46 @@ func TestAccountUsageService_PersistOpenAICodexProbeSnapshotSetsRateLimit(t *tes
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("waiting for codex probe rate limit persistence timed out")
+	}
+}
+
+func TestAccountUsageService_PersistOpenAICodexProbeSnapshotClearsStaleRateLimit(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := &accountUsageCodexProbeRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{{
+			ID:               322,
+			Platform:         PlatformOpenAI,
+			Type:             AccountTypeOAuth,
+			RateLimitResetAt: &now,
+			Extra: map[string]any{
+				codexRateLimitActiveExtraKey: true,
+			},
+		}}},
+		updateExtraCh:    make(chan map[string]any, 1),
+		clearRateLimitCh: make(chan int64, 1),
+	}
+	svc := &AccountUsageService{accountRepo: repo}
+
+	svc.persistOpenAICodexProbeSnapshot(322, map[string]any{
+		"codex_5h_used_percent":      0.0,
+		"codex_7d_used_percent":      0.0,
+		codexRateLimitActiveExtraKey: false,
+	}, nil)
+
+	select {
+	case <-repo.updateExtraCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiting for codex probe extra persistence timed out")
+	}
+
+	select {
+	case gotID := <-repo.clearRateLimitCh:
+		if gotID != 322 {
+			t.Fatalf("clear rate limit account id = %d, want 322", gotID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiting for stale codex rate limit clear timed out")
 	}
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -54,6 +54,8 @@ const (
 	codexCLIVersion                    = "0.104.0"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
+	codexRateLimitActiveExtraKey          = "codex_rate_limit_active"
+	codexRateLimitResetAtExtraKey         = "codex_rate_limit_reset_at"
 )
 
 // OpenAI allowed headers whitelist (for non-passthrough).
@@ -4114,6 +4116,14 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 	}
 	updates["codex_usage_updated_at"] = baseTime.Format(time.RFC3339)
 
+	resetAt := codexRateLimitResetAtFromSnapshot(snapshot, baseTime)
+	updates[codexRateLimitActiveExtraKey] = resetAt != nil
+	if resetAt != nil {
+		updates[codexRateLimitResetAtExtraKey] = resetAt.UTC().Format(time.RFC3339)
+	} else {
+		updates[codexRateLimitResetAtExtraKey] = nil
+	}
+
 	// 归一化到 5h/7d 规范字段
 	if normalized := snapshot.Normalize(); normalized != nil {
 		if normalized.Used5hPercent != nil {
@@ -4184,6 +4194,52 @@ func codexRateLimitResetAtFromExtra(extra map[string]any, now time.Time) *time.T
 	return nil
 }
 
+func codexRateLimitActiveFromExtra(extra map[string]any) bool {
+	if len(extra) == 0 {
+		return false
+	}
+	value, ok := extra[codexRateLimitActiveExtraKey]
+	if !ok {
+		return false
+	}
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		parsed, err := strconv.ParseBool(strings.TrimSpace(v))
+		return err == nil && parsed
+	case int:
+		return v != 0
+	case int64:
+		return v != 0
+	case float64:
+		return v != 0
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return i != 0
+		}
+	}
+	return false
+}
+
+func shouldClearOpenAICodexRateLimit(account *Account, updates map[string]any, resetAt *time.Time) bool {
+	if account == nil || !account.IsOpenAI() || len(updates) == 0 || resetAt != nil {
+		return false
+	}
+	if account.RateLimitResetAt == nil {
+		return false
+	}
+	if !codexRateLimitActiveFromExtra(account.Extra) {
+		return false
+	}
+	value, ok := updates[codexRateLimitActiveExtraKey]
+	if !ok {
+		return false
+	}
+	active, ok := value.(bool)
+	return ok && !active
+}
+
 func applyOpenAICodexRateLimitFromExtra(account *Account, now time.Time) (*time.Time, bool) {
 	if account == nil || !account.IsOpenAI() {
 		return nil, false
@@ -4231,11 +4287,23 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 	go func() {
 		updateCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
+		var accountBefore *Account
+		if shouldPersistUpdates && resetAt == nil {
+			if existing, err := s.accountRepo.GetByID(updateCtx, accountID); err == nil {
+				accountBefore = existing
+			}
+		}
+
 		if shouldPersistUpdates {
 			_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
 		}
 		if resetAt != nil {
 			_ = s.accountRepo.SetRateLimited(updateCtx, accountID, *resetAt)
+			return
+		}
+		if shouldClearOpenAICodexRateLimit(accountBefore, updates, resetAt) {
+			_ = s.accountRepo.ClearRateLimit(updateCtx, accountID)
 		}
 	}()
 }

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -25,8 +25,9 @@ type openAIWSRateLimitSignalRepo struct {
 
 type openAICodexSnapshotAsyncRepo struct {
 	stubOpenAIAccountRepo
-	updateExtraCh chan map[string]any
-	rateLimitCh   chan time.Time
+	updateExtraCh    chan map[string]any
+	rateLimitCh      chan time.Time
+	clearRateLimitCh chan int64
 }
 
 type openAICodexExtraListRepo struct {
@@ -62,6 +63,13 @@ func (r *openAICodexSnapshotAsyncRepo) UpdateExtra(_ context.Context, _ int64, u
 			copied[k] = v
 		}
 		r.updateExtraCh <- copied
+	}
+	return nil
+}
+
+func (r *openAICodexSnapshotAsyncRepo) ClearRateLimit(_ context.Context, id int64) error {
+	if r.clearRateLimitCh != nil {
+		r.clearRateLimitCh <- id
 	}
 	return nil
 }
@@ -402,6 +410,46 @@ func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_NonExhaustedSnapshotDoesN
 	case resetAt := <-repo.rateLimitCh:
 		t.Fatalf("unexpected rate limit reset at: %v", resetAt)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ClearsStaleRateLimitWhenSnapshotRecovers(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := &openAICodexSnapshotAsyncRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{{
+			ID:               603,
+			Platform:         PlatformOpenAI,
+			Type:             AccountTypeOAuth,
+			RateLimitResetAt: &now,
+			Extra: map[string]any{
+				codexRateLimitActiveExtraKey: true,
+			},
+		}}},
+		updateExtraCh:    make(chan map[string]any, 1),
+		clearRateLimitCh: make(chan int64, 1),
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         ptrFloat64WS(12),
+		PrimaryResetAfterSeconds:   ptrIntWS(3600),
+		PrimaryWindowMinutes:       ptrIntWS(10080),
+		SecondaryUsedPercent:       ptrFloat64WS(0),
+		SecondaryResetAfterSeconds: ptrIntWS(1200),
+		SecondaryWindowMinutes:     ptrIntWS(300),
+	}
+	svc.updateCodexUsageSnapshot(context.Background(), 603, snapshot)
+
+	select {
+	case <-repo.updateExtraCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("等待 codex 快照落库超时")
+	}
+
+	select {
+	case gotID := <-repo.clearRateLimitCh:
+		require.Equal(t, int64(603), gotID)
+	case <-time.After(2 * time.Second):
+		t.Fatal("等待 stale codex 限流自动清理超时")
 	}
 }
 


### PR DESCRIPTION
## Summary
- persist an explicit codex rate-limit active marker in extra snapshots
- clear stale account-level rate-limit state when a fresh codex snapshot is no longer exhausted
- cover the stale-clear path in account usage and gateway snapshot tests

## Validation
- docker run --rm -v "$PWD/backend":/src -w /src golang:1.26.1 bash -lc "/usr/local/go/bin/go test ./internal/service -run "Test(AccountUsageService_PersistOpenAICodexProbeSnapshot(ClearsStaleRateLimit|SetsRateLimit)|OpenAIGatewayService_UpdateCodexUsageSnapshot_(ClearsStaleRateLimitWhenSnapshotRecovers|ExhaustedSnapshotSetsRateLimit|NonExhaustedSnapshotDoesNotSetRateLimit)|RateLimitService_RecoverAccountAfterSuccessfulTest_ClearsErrorAndRateLimitRelatedState)""