### PR TITLE
fix(antigravity): correctly mark credits exhausted on "Resource has been exhausted" 429

### DIFF
--- a/backend/internal/service/antigravity_credits_overages.go
+++ b/backend/internal/service/antigravity_credits_overages.go
@@ -45,6 +45,7 @@ var (
 		"minimumcreditamountforusage",
 		"minimum credit amount for usage",
 		"minimum credit",
+		"resource has been exhausted",
 	}
 )
 
@@ -147,9 +148,9 @@ func shouldMarkCreditsExhausted(resp *http.Response, respBody []byte, reqErr err
 	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusRequestTimeout {
 		return false
 	}
-	if isURLLevelRateLimit(respBody) {
-		return false
-	}
+	// 注意：不再检查 isURLLevelRateLimit。此函数仅在积分重试失败后调用，
+	// 如果注入 enabledCreditTypes 后仍返回 "Resource has been exhausted"，
+	// 说明积分也已耗尽，应该标记。clearCreditsExhausted 会在后续成功时自动清除。
 	if info := parseAntigravitySmartRetryInfo(respBody); info != nil {
 		return false
 	}

--- a/backend/internal/service/antigravity_credits_overages_test.go
+++ b/backend/internal/service/antigravity_credits_overages_test.go
@@ -406,10 +406,16 @@ func TestShouldMarkCreditsExhausted(t *testing.T) {
 		require.False(t, shouldMarkCreditsExhausted(resp, []byte(`{"error":"Insufficient credits"}`), nil))
 	})
 
-	t.Run("URL 级限流不标记", func(t *testing.T) {
+	t.Run("Resource has been exhausted 应标记为积分耗尽", func(t *testing.T) {
 		resp := &http.Response{StatusCode: http.StatusTooManyRequests}
 		body := []byte(`{"error":{"message":"Resource has been exhausted"}}`)
-		require.False(t, shouldMarkCreditsExhausted(resp, body, nil))
+		require.True(t, shouldMarkCreditsExhausted(resp, body, nil))
+	})
+
+	t.Run("Resource has been exhausted (check quota) 完整格式应标记", func(t *testing.T) {
+		resp := &http.Response{StatusCode: http.StatusTooManyRequests}
+		body := []byte(`{"error":{"code":429,"message":"Resource has been exhausted (e.g. check quota).","status":"RESOURCE_EXHAUSTED"}}`)
+		require.True(t, shouldMarkCreditsExhausted(resp, body, nil))
 	})
 
 	t.Run("结构化限流不标记", func(t *testing.T) {


### PR DESCRIPTION
## 背景 / Background

当 credit overages 重试返回 `"Resource has been exhausted (e.g. check quota)."` 时，`shouldMarkCreditsExhausted` 被 `isURLLevelRateLimit` 检查阻断，导致积分耗尽状态永远无法被标记。

When credit overages retry returns `"Resource has been exhausted (e.g. check quota)."`, `shouldMarkCreditsExhausted` was blocked by `isURLLevelRateLimit` check, preventing credits from ever being marked as exhausted.

---

## 目的 / Purpose

修复积分耗尽无法正确标记的 bug，避免无限循环（每次请求注入 credits → 绕过模型限流 → 再次失败 → 重复）。

Fix the bug where credits exhaustion was never marked, preventing an infinite loop (inject credits → bypass model rate limit → fail again → repeat).

---

## 改动内容 / Changes

### 后端 / Backend

- **移除 `isURLLevelRateLimit` 前置检查**：`shouldMarkCreditsExhausted` 仅在 credit retry 响应中调用，credits 重试失败即应标记耗尽
- **新增关键词**：`"resource has been exhausted"` 加入 `creditsExhaustedKeywords`
- **更新测试**：验证 `"Resource has been exhausted"` 响应能正确触发积分耗尽标记

---

- **Remove `isURLLevelRateLimit` guard**: `shouldMarkCreditsExhausted` is only called for credit retry responses — if credits retry fails, mark exhausted
- **Add keyword**: `"resource has been exhausted"` to `creditsExhaustedKeywords`
- **Update tests**: Verify `"Resource has been exhausted"` response correctly triggers credits exhausted marking