### PR TITLE
fix: quota display shows stale cumulative usage after daily/weekly reset

### DIFF
--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -276,11 +276,17 @@ func AccountFromServiceShallow(a *service.Account) *Account {
 		if limit := a.GetQuotaDailyLimit(); limit > 0 {
 			out.QuotaDailyLimit = &limit
 			used := a.GetQuotaDailyUsed()
+			if a.IsDailyQuotaPeriodExpired() {
+				used = 0
+			}
 			out.QuotaDailyUsed = &used
 		}
 		if limit := a.GetQuotaWeeklyLimit(); limit > 0 {
 			out.QuotaWeeklyLimit = &limit
 			used := a.GetQuotaWeeklyUsed()
+			if a.IsWeeklyQuotaPeriodExpired() {
+				used = 0
+			}
 			out.QuotaWeeklyUsed = &used
 		}
 		// 固定时间重置配置

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1543,6 +1543,24 @@ func isPeriodExpired(periodStart time.Time, dur time.Duration) bool {
 	return time.Since(periodStart) >= dur
 }
 
+// IsDailyQuotaPeriodExpired 检查日配额周期是否已过期（用于显示层判断是否需要将 used 归零）
+func (a *Account) IsDailyQuotaPeriodExpired() bool {
+	start := a.getExtraTime("quota_daily_start")
+	if a.GetQuotaDailyResetMode() == "fixed" {
+		return a.isFixedDailyPeriodExpired(start)
+	}
+	return isPeriodExpired(start, 24*time.Hour)
+}
+
+// IsWeeklyQuotaPeriodExpired 检查周配额周期是否已过期（用于显示层判断是否需要将 used 归零）
+func (a *Account) IsWeeklyQuotaPeriodExpired() bool {
+	start := a.getExtraTime("quota_weekly_start")
+	if a.GetQuotaWeeklyResetMode() == "fixed" {
+		return a.isFixedWeeklyPeriodExpired(start)
+	}
+	return isPeriodExpired(start, 7*24*time.Hour)
+}
+
 // IsQuotaExceeded 检查 API Key 账号配额是否已超限（任一维度超限即返回 true）
 func (a *Account) IsQuotaExceeded() bool {
 	// 总额度


### PR DESCRIPTION
## Summary

修复账号管理页面中，配置了每日/每周配额重置的账号，在重置周期到达后页面显示的已用额度未归零、持续累加的问题。

## 问题描述

配额重置机制采用**惰性重置（lazy reset）**设计：数据库中的 `quota_daily_used` / `quota_weekly_used` 仅在下一次 `IncrementQuotaUsed`（即有新请求产生费用时）才会被重置为 0。

调度层 `IsQuotaExceeded` 在判断是否超限时**正确检查了周期过期**，因此账号功能上可以正常使用。但 API 响应的 mapper 层直接读取数据库原值返回给前端，**未判断周期是否过期**，导致前端显示累加的旧值（如已用 $93.42 / 限额 $85.00 = 110%）。

## 修复方案

- 在 `Account` 上新增 `IsDailyQuotaPeriodExpired()` / `IsWeeklyQuotaPeriodExpired()` 方法，复用已有的 rolling/fixed 两种模式的过期判断逻辑
- 在 `AccountFromServiceShallow` mapper 中，当周期已过期时返回 `used = 0`，使前端正确显示归零后的额度

## 改动文件

- `backend/internal/service/account.go` — 新增两个导出方法
- `backend/internal/handler/dto/mappers.go` — mapper 中增加过期判断

## Test plan

- [x] `go test -tags=unit ./...` 通过
- [x] 配置一个账号设置每日配额重置（rolling 或 fixed 模式），等待周期过期后刷新页面，确认已用额度显示为 0
- [x] 在新周期内产生请求后，确认额度从 0 开始正常累加