### PR TITLE
fix: 修复 OpenAI 转发路径未应用分组默认模型映射

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -181,7 +181,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		forwardStart := time.Now()
 
-		defaultMappedModel := c.GetString("openai_chat_completions_fallback_model")
+		defaultMappedModel := resolveOpenAIForwardDefaultMappedModel(apiKey, c.GetString("openai_chat_completions_fallback_model"))
 		result, err := h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, body, promptCacheKey, defaultMappedModel)
 
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -37,6 +37,16 @@ type OpenAIGatewayHandler struct {
 	cfg                     *config.Config
 }
 
+func resolveOpenAIForwardDefaultMappedModel(apiKey *service.APIKey, fallbackModel string) string {
+	if fallbackModel = strings.TrimSpace(fallbackModel); fallbackModel != "" {
+		return fallbackModel
+	}
+	if apiKey == nil || apiKey.Group == nil {
+		return ""
+	}
+	return strings.TrimSpace(apiKey.Group.DefaultMappedModel)
+}
+
 // NewOpenAIGatewayHandler creates a new OpenAIGatewayHandler
 func NewOpenAIGatewayHandler(
 	gatewayService *service.OpenAIGatewayService,
@@ -657,9 +667,9 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		forwardStart := time.Now()
 
-		// 仅在调度时实际触发了降级（原模型无可用账号、改用默认模型重试成功）时，
-		// 才将降级模型传给 Forward 层做模型替换；否则保持用户请求的原始模型。
-		defaultMappedModel := c.GetString("openai_messages_fallback_model")
+		// Forward 层需要始终拿到 group 默认映射模型，这样未命中账号级映射的
+		// Claude 兼容模型才不会在后续 Codex 规范化中意外退化到 gpt-5.1。
+		defaultMappedModel := resolveOpenAIForwardDefaultMappedModel(apiKey, c.GetString("openai_messages_fallback_model"))
 		result, err := h.gatewayService.ForwardAsAnthropic(c.Request.Context(), c, account, body, promptCacheKey, defaultMappedModel)
 
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -352,6 +352,30 @@ func TestOpenAIEnsureResponsesDependencies(t *testing.T) {
 	})
 }
 
+func TestResolveOpenAIForwardDefaultMappedModel(t *testing.T) {
+	t.Run("prefers_explicit_fallback_model", func(t *testing.T) {
+		apiKey := &service.APIKey{
+			Group: &service.Group{DefaultMappedModel: "gpt-5.4"},
+		}
+		require.Equal(t, "gpt-5.2", resolveOpenAIForwardDefaultMappedModel(apiKey, " gpt-5.2 "))
+	})
+
+	t.Run("uses_group_default_on_normal_path", func(t *testing.T) {
+		apiKey := &service.APIKey{
+			Group: &service.Group{DefaultMappedModel: "gpt-5.4"},
+		}
+		require.Equal(t, "gpt-5.4", resolveOpenAIForwardDefaultMappedModel(apiKey, ""))
+	})
+
+	t.Run("returns_empty_without_group_default", func(t *testing.T) {
+		require.Empty(t, resolveOpenAIForwardDefaultMappedModel(nil, ""))
+		require.Empty(t, resolveOpenAIForwardDefaultMappedModel(&service.APIKey{}, ""))
+		require.Empty(t, resolveOpenAIForwardDefaultMappedModel(&service.APIKey{
+			Group: &service.Group{},
+		}, ""))
+	})
+}
+
 func TestOpenAIResponses_MissingDependencies_ReturnsServiceUnavailable(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -68,3 +68,19 @@ func TestResolveOpenAIForwardModel(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveOpenAIForwardModel_PreventsClaudeModelFromFallingBackToGpt51(t *testing.T) {
+	account := &Account{
+		Credentials: map[string]any{},
+	}
+
+	withoutDefault := resolveOpenAIForwardModel(account, "claude-opus-4-6", "")
+	if got := normalizeCodexModel(withoutDefault); got != "gpt-5.1" {
+		t.Fatalf("normalizeCodexModel(%q) = %q, want %q", withoutDefault, got, "gpt-5.1")
+	}
+
+	withDefault := resolveOpenAIForwardModel(account, "claude-opus-4-6", "gpt-5.4")
+	if got := normalizeCodexModel(withDefault); got != "gpt-5.4" {
+		t.Fatalf("normalizeCodexModel(%q) = %q, want %q", withDefault, got, "gpt-5.4")
+	}
+}


### PR DESCRIPTION
## 变更摘要
- 在正常转发路径下也向 OpenAI forwarder 传递分组的默认模型映射
- 当调度器确实发生 fallback 重试时，仍然优先使用显式 fallback 模型
- 增加测试，覆盖 `claude-*` 模型因未映射而被错误规范化为 `gpt-5.1` 的根因链路

## 根因
在 Claude 兼容请求转发到 OpenAI 的正常路径中，`openai_messages_fallback_model` / `openai_chat_completions_fallback_model` 这两个 context 值只有在调度失败后、使用 fallback 模型重试成功时才会被写入；正常路径下它们一直是空字符串。

这会导致 `resolveOpenAIForwardModel()` 在正常路径拿不到分组的 `default_mapped_model`。当原始请求模型仍然是 `claude-opus-4-6` 这类 Claude 模型名时，后续 Codex 模型规范化会把它当作未知模型，并静默兜底成 `gpt-5.1`。如果请求里同时带了 `xhigh`，上游最终就会以 `gpt-5.1` 不支持 `xhigh` 的组合报 400。

## 方案
新增一个统一的默认模型解析逻辑：
- 优先使用调度阶段显式写入的 fallback 模型
- 如果没有显式 fallback，则回退到分组配置的 `default_mapped_model`

这样即使在正常路径下，也能先应用分组默认映射，避免 Claude 模型名漏到后续 `normalizeCodexModel()` 中被错误降级为 `gpt-5.1`。

## 验证
- `go test ./internal/handler -run "TestResolveOpenAIForwardDefaultMappedModel|TestOpenAIEnsureResponsesDependencies|TestOpenAIResponses_MissingDependencies_ReturnsServiceUnavailable"`
- `go test ./internal/service -run "TestResolveOpenAIForwardModel|TestResolveOpenAIForwardModel_PreventsClaudeModelFromFallingBackToGpt51|TestNormalizeCodexModel_Gpt53"`