### PR TITLE
fix: show 401 badge for oauth refresh failures

### DIFF
--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -279,6 +279,19 @@ const isTempUnschedulable = computed(() => {
   return new Date(props.account.temp_unschedulable_until) > new Date()
 })
 
+const tempUnschedReason = computed(() => (props.account.temp_unschedulable_reason || '').toLowerCase())
+
+const isAuth401 = computed(() => {
+  if (!isTempUnschedulable.value) return false
+  return [
+    'status 401',
+    'authentication failed (401)',
+    'oauth 401',
+    'refresh_token_reused',
+    'token refresh retry exhausted'
+  ].some((marker) => tempUnschedReason.value.includes(marker))
+})
+
 // Computed: has error status
 const hasError = computed(() => {
   return props.account.status === 'error'
@@ -304,6 +317,9 @@ const statusClass = computed(() => {
   if (hasError.value) {
     return 'badge-danger'
   }
+  if (isAuth401.value) {
+    return 'badge-danger'
+  }
   if (isTempUnschedulable.value) {
     return 'badge-warning'
   }
@@ -326,6 +342,9 @@ const statusClass = computed(() => {
 const statusText = computed(() => {
   if (hasError.value) {
     return t('admin.accounts.status.error')
+  }
+  if (isAuth401.value) {
+    return '401'
   }
   if (isTempUnschedulable.value) {
     return t('admin.accounts.status.tempUnschedulable')

--- a/frontend/src/components/account/__tests__/AccountStatusIndicator.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountStatusIndicator.spec.ts
@@ -98,6 +98,29 @@ describe('AccountStatusIndicator', () => {
     expect(wrapper.text()).not.toContain('⚡')
   })
 
+  it('OAuth 401 temp unschedulable → 显示 401 badge', () => {
+    const wrapper = mount(AccountStatusIndicator, {
+      props: {
+        account: makeAccount({
+          id: 99,
+          platform: 'openai',
+          type: 'oauth',
+          temp_unschedulable_until: '2099-03-15T00:00:00Z',
+          temp_unschedulable_reason:
+            'token refresh retry exhausted: error: code=502 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 401, body: {\"error\":{\"code\":\"refresh_token_reused\"}}"'
+        })
+      },
+      global: {
+        stubs: {
+          Icon: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('401')
+    expect(wrapper.classes().join(' ')).not.toContain('badge-warning')
+  })
+
   it('AICredits key 生效 → 显示积分已用尽 (credits_exhausted)', () => {
     const wrapper = mount(AccountStatusIndicator, {
       props: {
@@ -122,7 +145,7 @@ describe('AccountStatusIndicator', () => {
       }
     })
 
-    expect(wrapper.text()).toContain('account.creditsExhausted')
+    expect(wrapper.text()).toContain('admin.accounts.status.creditsExhausted')
   })
 
   it('模型限流 + overages 启用 + AICredits key 生效 → 普通限流样式（积分耗尽，无 ⚡）', () => {
@@ -157,6 +180,6 @@ describe('AccountStatusIndicator', () => {
     expect(wrapper.text()).toContain('CSon45')
     expect(wrapper.text()).not.toContain('⚡')
     // AICredits 积分耗尽状态应显示
-    expect(wrapper.text()).toContain('account.creditsExhausted')
+    expect(wrapper.text()).toContain('admin.accounts.status.creditsExhausted')
   })
 })


### PR DESCRIPTION
## Summary\n- show a clear 401 badge for OAuth accounts that are temporarily unschedulable due to refresh-token 401 failures\n- preserve existing backend behavior (status remains active so refresh flows can continue)\n- add a focused frontend test for refresh_token_reused / token refresh retry exhausted cases\n\n## Why\nSub2API already detects these failures and stores them in temp_unschedulable_reason, but the admin panel still renders them as a generic temporary unschedulable state. This makes 401-invalid accounts hard to distinguish in the panel.\n\n## Scope\nFrontend-only display improvement; no backend status-machine change.