### PR TITLE
fix: correct log levels for thinking block signature retry flow

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4197,7 +4197,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						resp.Body = io.NopCloser(bytes.NewReader(respBody))
 						break
 					}
-					logger.LegacyPrintf("service.gateway", "Account %d: detected thinking block signature error, retrying with filtered thinking blocks", account.ID)
+					logger.LegacyPrintf("service.gateway", "[warn] Account %d: thinking blocks have invalid signature, retrying with filtered blocks", account.ID)
 
 					// Conservative two-stage fallback:
 					// 1) Disable thinking + thinking->text (preserve content)
@@ -4212,7 +4212,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, account.IsTLSFingerprintEnabled())
 						if retryErr == nil {
 							if retryResp.StatusCode < 400 {
-								logger.LegacyPrintf("service.gateway", "Account %d: signature error retry succeeded (thinking downgraded)", account.ID)
+								logger.LegacyPrintf("service.gateway", "Account %d: thinking block retry succeeded (blocks downgraded)", account.ID)
 								resp = retryResp
 								break
 							}
@@ -6102,13 +6102,9 @@ func (s *GatewayService) isThinkingBlockSignatureError(respBody []byte) bool {
 		return false
 	}
 
-	// Log for debugging
-	logger.LegacyPrintf("service.gateway", "[SignatureCheck] Checking error message: %s", msg)
-
 	// 检测signature相关的错误（更宽松的匹配）
 	// 例如: "Invalid `signature` in `thinking` block", "***.signature" 等
 	if strings.Contains(msg, "signature") {
-		logger.LegacyPrintf("service.gateway", "[SignatureCheck] Detected signature error")
 		return true
 	}
 


### PR DESCRIPTION
## 问题

`LegacyPrintf` 通过 `inferStdLogLevel()` 从消息文本推断日志级别，凡消息含 `"error"` 单词即判为 ERROR 级别。thinking block 签名整流（自动重试）流程中的日志消息均含 "error"，导致一次**正常自动恢复**的操作产生了 4 条 ERROR 日志，造成告警噪音。

## 根本原因

`inferStdLogLevel` 规则（`logger.go:467`）：
```go
if strings.Contains(lower, "error") { return LevelError }
```

触发 ERROR 的消息：
| 位置 | 消息（含 "error"） | 实际语义 |
|------|-------------------|---------|
| `isThinkingBlockSignatureError:6106` | `[SignatureCheck] Checking error message: ...` | 调试日志 |
| `isThinkingBlockSignatureError:6111` | `[SignatureCheck] Detected signature error` | 调试日志 |
| `Forward:4200` | `detected thinking block signature error, retrying...` | 警告（开始重试）|
| `Forward:4215` | `signature error retry succeeded (thinking downgraded)` | 成功（INFO）|

## 修复

- 删除 `isThinkingBlockSignatureError` 内的两条调试日志（每次请求均触发，生产环境无价值）
- 重试开始日志：改用 `[warn]` 前缀，使 `inferStdLogLevel` 正确归类为 WARN
- 重试成功日志：消息中去掉 "error" 关键字，正确归类为 INFO

## 测试

用包含旧版 thinking block（签名来自不同 API key）的请求触发整流流程，确认：
- 不再产生 ERROR 日志
- 重试开始 → WARN，重试成功 → INFO
- 功能行为不变（自动重试仍正常工作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)