### PR TITLE
fix: prevent silent save failure in admin settings form

### DIFF
--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -7,7 +7,7 @@
       </div>
 
       <!-- Settings Form -->
-      <form v-else @submit.prevent="saveSettings" class="space-y-6">
+      <form v-else @submit.prevent="saveSettings" class="space-y-6" novalidate>
         <!-- Tab Navigation -->
         <div class="sticky top-0 z-10 overflow-x-auto settings-tabs-scroll">
           <nav class="settings-tabs">
@@ -2196,6 +2196,35 @@ async function saveSettings() {
         })
       )
       return
+    }
+
+    // Validate URL fields — novalidate disables browser-native checks, so we validate here
+    const isValidHttpUrl = (url: string): boolean => {
+      if (!url) return true
+      try {
+        const u = new URL(url)
+        return u.protocol === 'http:' || u.protocol === 'https:'
+      } catch {
+        return false
+      }
+    }
+    // Optional URL fields: auto-clear invalid values so they don't cause backend 400 errors
+    if (!isValidHttpUrl(form.frontend_url)) form.frontend_url = ''
+    if (!isValidHttpUrl(form.doc_url)) form.doc_url = ''
+    // Purchase URL: required when enabled; auto-clear when disabled to avoid backend rejection
+    if (form.purchase_subscription_enabled) {
+      if (!form.purchase_subscription_url) {
+        appStore.showError(t('admin.settings.purchase.url') + ': URL is required when purchase is enabled')
+        saving.value = false
+        return
+      }
+      if (!isValidHttpUrl(form.purchase_subscription_url)) {
+        appStore.showError(t('admin.settings.purchase.url') + ': must be an absolute http(s) URL (e.g. https://example.com)')
+        saving.value = false
+        return
+      }
+    } else if (!isValidHttpUrl(form.purchase_subscription_url)) {
+      form.purchase_subscription_url = ''
     }
 
     const payload: UpdateSettingsRequest = {


### PR DESCRIPTION
## Problem

Clicking **Save Settings** in the admin panel has no response and no network request is triggered. A second symptom: even after the form submits, a backend `400` error appears:

```
Purchase Subscription URL must be an absolute http(s) URL
```

## Root Cause

The settings form contains multiple `<input type="url">` fields **without a `name` attribute**. When the browser runs HTML5 form validation on submit, it finds an invalid/empty URL field but cannot focus it (no `name` attribute), so it silently blocks submission with no network request and no visible error.

Console error:
```
An invalid form control with name='' is not focusable.
```

The backend `400` is a secondary issue: if a previously-stored `purchase_subscription_url` value is not a valid absolute URL, re-saving any setting triggers the rejection even when purchase is disabled.

## Fix

1. Add `novalidate` to the `<form>` element to disable browser-native URL validation (which was silently blocking submission)
2. Add an `isValidHttpUrl()` helper in `saveSettings()` to replicate the backend URL checks in the frontend:
   - **Optional fields** (`frontend_url`, `doc_url`): auto-clear invalid values instead of blocking the save
   - **`purchase_subscription_url`**: show a clear error when purchase is enabled and URL is invalid; auto-clear when purchase is disabled to prevent the backend `400`