### PR TITLE
fix: append /v1 to base_url in UseKey config for OpenAI and Gemini groups

### DIFF
--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -418,11 +418,11 @@ const currentFiles = computed((): FileConfig[] => {
         return generateAnthropicFiles(baseUrl, apiKey)
       }
       if (activeClientTab.value === 'codex-ws') {
-        return generateOpenAIWsFiles(baseUrl, apiKey)
+        return generateOpenAIWsFiles(apiBase, apiKey)
       }
-      return generateOpenAIFiles(baseUrl, apiKey)
+      return generateOpenAIFiles(apiBase, apiKey)
     case 'gemini':
-      return [generateGeminiCliContent(baseUrl, apiKey)]
+      return [generateGeminiCliContent(apiBase, apiKey)]
     case 'antigravity':
       if (activeClientTab.value === 'gemini') {
         return [generateGeminiCliContent(`${baseUrl}/antigravity`, apiKey)]


### PR DESCRIPTION
## Summary

- Fix `generateOpenAIFiles` and `generateOpenAIWsFiles` to use `apiBase` (with `/v1` suffix) instead of raw `baseUrl` for Codex CLI `config.toml`
- Fix `generateGeminiCliContent` to use `apiBase` (with `/v1` suffix) instead of raw `baseUrl` for Gemini CLI env config

## Problem

When clicking "Use Key" for OpenAI (GPT) or Gemini groups, the generated `base_url` in `~/.codex/config.toml` and `GOOGLE_GEMINI_BASE_URL` was missing the required `/v1` suffix, causing clients to hit the wrong endpoint.

**Before:**
```toml
base_url = "https://example.com"
```

**After:**
```toml
base_url = "https://example.com/v1"
```

## Test plan

- [ ] Open "Use Key" modal for an OpenAI (GPT) group → verify `base_url` in `config.toml` ends with `/v1`
- [ ] Open "Use Key" modal for a Gemini group → verify `GOOGLE_GEMINI_BASE_URL` ends with `/v1`
- [ ] Claude / Antigravity groups remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)