### PR TITLE
feat: add support for OpenAI-compatible providers using Chat Completions API

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -935,6 +935,22 @@ func (a *Account) IsOpenAIPassthroughEnabled() bool {
 	return false
 }
 
+
+// IsOpenAIChatCompletionsMode 返回 OpenAI 账号是否使用标准 Chat Completions API。
+// 某些 OpenAI 兼容的第三方 API（如 Alibaba Coding Plan）不支持 Responses API，
+// 需要使用标准的 /v1/chat/completions 端点。
+//
+// 字段：accounts.extra.openai_chat_completions_mode。
+// 字段缺失或类型不正确时，按 false（使用 Responses API）处理。
+func (a *Account) IsOpenAIChatCompletionsMode() bool {
+	if a == nil || !a.IsOpenAI() || a.Extra == nil {
+		return false
+	}
+	if enabled, ok := a.Extra["openai_chat_completions_mode"].(bool); ok {
+		return enabled
+	}
+	return false
+}
 // IsOpenAIResponsesWebSocketV2Enabled 返回 OpenAI 账号是否开启 Responses WebSocket v2。
 //
 // 分类型新字段：

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -477,7 +477,12 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
 		}
-		apiURL = strings.TrimSuffix(normalizedBaseURL, "/") + "/responses"
+		// Use Chat Completions API for OpenAI-compatible providers that do not support Responses API
+		if account.IsOpenAIChatCompletionsMode() {
+			apiURL = strings.TrimSuffix(normalizedBaseURL, "/") + "/chat/completions"
+		} else {
+			apiURL = strings.TrimSuffix(normalizedBaseURL, "/") + "/responses"
+		}
 	} else {
 		return s.sendErrorAndEnd(c, fmt.Sprintf("Unsupported account type: %s", account.Type))
 	}
@@ -489,8 +494,13 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
 	c.Writer.Flush()
 
-	// Create OpenAI Responses API payload
-	payload := createOpenAITestPayload(testModelID, isOAuth)
+	// Create test payload based on API mode
+	var payload map[string]any
+	if account.IsOpenAIChatCompletionsMode() {
+		payload = createOpenAIChatCompletionsTestPayload(testModelID)
+	} else {
+		payload = createOpenAITestPayload(testModelID, isOAuth)
+	}
 	payloadBytes, _ := json.Marshal(payload)
 
 	// Send test_start event
@@ -550,7 +560,10 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
-	// Process SSE stream
+	// Process SSE stream based on API mode
+	if account.IsOpenAIChatCompletionsMode() {
+		return s.processOpenAIChatCompletionsStream(c, resp.Body)
+	}
 	return s.processOpenAIStream(c, resp.Body)
 }
 
@@ -1632,6 +1645,22 @@ func createOpenAITestPayload(modelID string, isOAuth bool) map[string]any {
 	return payload
 }
 
+// createOpenAIChatCompletionsTestPayload creates a test payload for OpenAI Chat Completions API.
+// Used for OpenAI-compatible providers that do not support Responses API.
+func createOpenAIChatCompletionsTestPayload(modelID string) map[string]any {
+	return map[string]any{
+		"model": modelID,
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": "hi",
+			},
+		},
+		"max_tokens": 10,
+		"stream":     true,
+	}
+}
+
 // processClaudeStream processes the SSE stream from Claude API
 func (s *AccountTestService) processClaudeStream(c *gin.Context, body io.Reader) error {
 	reader := bufio.NewReader(body)
@@ -1735,6 +1764,62 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 				}
 			}
 			return s.sendErrorAndEnd(c, errorMsg)
+		}
+	}
+}
+
+// processOpenAIChatCompletionsStream processes the SSE stream from OpenAI Chat Completions API.
+// Used for OpenAI-compatible providers that do not support Responses API.
+func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, body io.Reader) error {
+	reader := bufio.NewReader(body)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+				return nil
+			}
+			return s.sendErrorAndEnd(c, fmt.Sprintf("Stream read error: %s", err.Error()))
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" || !sseDataPrefix.MatchString(line) {
+			continue
+		}
+
+		jsonStr := sseDataPrefix.ReplaceAllString(line, "")
+		if jsonStr == "[DONE]" {
+			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+			return nil
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+			continue
+		}
+
+		// Chat Completions format: choices[0].delta.content
+		if choices, ok := data["choices"].([]any); ok && len(choices) > 0 {
+			if choice, ok := choices[0].(map[string]any); ok {
+				if delta, ok := choice["delta"].(map[string]any); ok {
+					if content, ok := delta["content"].(string); ok && content != "" {
+						s.sendEvent(c, TestEvent{Type: "content", Text: content})
+					}
+				}
+				// Check for finish_reason
+				if finishReason, ok := choice["finish_reason"].(string); ok && finishReason != "" {
+					s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+					return nil
+				}
+			}
+		}
+
+		// Check for error
+		if errData, ok := data["error"].(map[string]any); ok {
+			if msg, ok := errData["message"].(string); ok {
+				return s.sendErrorAndEnd(c, msg)
+			}
 		}
 	}
 }

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -34,6 +34,11 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 ) (*OpenAIForwardResult, error) {
 	startTime := time.Now()
 
+	// For OpenAI-compatible providers that use Chat Completions API directly
+	if account.IsOpenAIChatCompletionsMode() {
+		return s.forwardOpenAIChatCompletionsDirect(ctx, c, account, body, promptCacheKey, defaultMappedModel, startTime)
+	}
+
 	// 1. Parse Chat Completions request
 	var chatReq apicompat.ChatCompletionsRequest
 	if err := json.Unmarshal(body, &chatReq); err != nil {
@@ -523,4 +528,237 @@ func writeChatCompletionsError(c *gin.Context, statusCode int, errType, message 
 			"message": message,
 		},
 	})
+}
+
+// forwardOpenAIChatCompletionsDirect forwards Chat Completions requests directly to
+// OpenAI-compatible providers that do not support Responses API (e.g., Alibaba Coding Plan).
+// It bypasses the Responses API conversion and sends/receives Chat Completions format directly.
+func (s *OpenAIGatewayService) forwardOpenAIChatCompletionsDirect(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	promptCacheKey string,
+	defaultMappedModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	// Parse and apply model mapping
+	var chatReq map[string]any
+	if err := json.Unmarshal(body, &chatReq); err != nil {
+		return nil, fmt.Errorf("parse chat completions request: %w", err)
+	}
+
+	originalModel, _ := chatReq["model"].(string)
+	clientStream := false
+	if stream, ok := chatReq["stream"].(bool); ok {
+		clientStream = stream
+	}
+
+	mappedModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
+	if mappedModel != originalModel {
+		chatReq["model"] = mappedModel
+	}
+
+	// Marshal the request body
+	forwardBody, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal chat completions request: %w", err)
+	}
+
+	// Get access token
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	// Build upstream request - use Chat Completions URL
+	baseURL := account.GetOpenAIBaseURL()
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("validate base URL: %w", err)
+	}
+	targetURL := buildOpenAIChatCompletionsURL(validatedURL)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(forwardBody))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	// Get proxy URL
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		writeChatCompletionsError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Handle error response
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+
+		if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody) {
+			return nil, &UpstreamFailoverError{
+				StatusCode:   resp.StatusCode,
+				ResponseBody: respBody,
+			}
+		}
+
+		writeChatCompletionsError(c, resp.StatusCode, "api_error", upstreamMsg)
+		return nil, fmt.Errorf("upstream error %d: %s", resp.StatusCode, upstreamMsg)
+	}
+
+	// Handle streaming response
+	if clientStream {
+		return s.handleChatCompletionsDirectStream(resp, c, originalModel, mappedModel, startTime)
+	}
+
+	// Handle non-streaming response
+	return s.handleChatCompletionsDirectNonStream(resp, c, originalModel, mappedModel, startTime)
+}
+
+// handleChatCompletionsDirectStream handles streaming response from Chat Completions API.
+func (s *OpenAIGatewayService) handleChatCompletionsDirectStream(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	mappedModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	requestID := resp.Header.Get("x-request-id")
+	var usage OpenAIUsage
+	var firstTokenMs *int
+	firstChunk := true
+
+	scanner := bufio.NewScanner(resp.Body)
+	maxLineSize := defaultMaxLineSize
+	if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
+		maxLineSize = s.cfg.Gateway.MaxLineSize
+	}
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+
+		if line == "data: [DONE]" {
+			fmt.Fprint(c.Writer, "data: [DONE]\n\n")
+			c.Writer.Flush()
+			break
+		}
+
+		if firstChunk {
+			firstChunk = false
+			ms := int(time.Since(startTime).Milliseconds())
+			firstTokenMs = &ms
+		}
+
+		// Forward the chunk directly
+		fmt.Fprintf(c.Writer, "%s\n\n", line)
+		c.Writer.Flush()
+
+		// Try to extract usage from the final chunk
+		jsonStr := strings.TrimPrefix(line, "data: ")
+		var chunk map[string]any
+		if err := json.Unmarshal([]byte(jsonStr), &chunk); err == nil {
+			if usageData, ok := chunk["usage"].(map[string]any); ok {
+				if pt, ok := usageData["prompt_tokens"].(float64); ok {
+					usage.InputTokens = int(pt)
+				}
+				if ct, ok := usageData["completion_tokens"].(float64); ok {
+					usage.OutputTokens = int(ct)
+				}
+			}
+		}
+	}
+
+	if err := scanner.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		logger.L().Warn("openai chat_completions direct stream: read error", zap.Error(err))
+	}
+
+	return &OpenAIForwardResult{
+		RequestID:     requestID,
+		Usage:         usage,
+		Model:         originalModel,
+		BillingModel:  mappedModel,
+		UpstreamModel: mappedModel,
+		Stream:        true,
+		Duration:      time.Since(startTime),
+		FirstTokenMs:  firstTokenMs,
+	}, nil
+}
+
+// handleChatCompletionsDirectNonStream handles non-streaming response from Chat Completions API.
+func (s *OpenAIGatewayService) handleChatCompletionsDirectNonStream(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	mappedModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		writeChatCompletionsError(c, http.StatusBadGateway, "api_error", "Failed to read response")
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	c.Writer.Header().Set("Content-Type", "application/json")
+	c.Writer.Write(body)
+
+	// Extract usage
+	var usage OpenAIUsage
+	var respData map[string]any
+	if err := json.Unmarshal(body, &respData); err == nil {
+		if usageData, ok := respData["usage"].(map[string]any); ok {
+			if pt, ok := usageData["prompt_tokens"].(float64); ok {
+				usage.InputTokens = int(pt)
+			}
+			if ct, ok := usageData["completion_tokens"].(float64); ok {
+				usage.OutputTokens = int(ct)
+			}
+		}
+	}
+
+	return &OpenAIForwardResult{
+		RequestID:     requestID,
+		Usage:         usage,
+		Model:         originalModel,
+		BillingModel:  mappedModel,
+		UpstreamModel: mappedModel,
+		Stream:        false,
+		Duration:      time.Since(startTime),
+	}, nil
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2484,10 +2484,18 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 			if err != nil {
 				return nil, err
 			}
-			targetURL = buildOpenAIResponsesURL(validatedURL)
+			// Use Chat Completions URL for OpenAI-compatible providers
+			if account.IsOpenAIChatCompletionsMode() {
+				targetURL = buildOpenAIChatCompletionsURL(validatedURL)
+			} else {
+				targetURL = buildOpenAIResponsesURL(validatedURL)
+			}
 		}
 	}
-	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
+	// Only append Responses path suffix for non-Chat-Completions mode
+	if !account.IsOpenAIChatCompletionsMode() {
+		targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
@@ -2880,12 +2888,20 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 			if err != nil {
 				return nil, err
 			}
-			targetURL = buildOpenAIResponsesURL(validatedURL)
+			// Use Chat Completions URL for OpenAI-compatible providers
+			if account.IsOpenAIChatCompletionsMode() {
+				targetURL = buildOpenAIChatCompletionsURL(validatedURL)
+			} else {
+				targetURL = buildOpenAIResponsesURL(validatedURL)
+			}
 		}
 	default:
 		targetURL = openaiPlatformAPIURL
 	}
-	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
+	// Only append Responses path suffix for non-Chat-Completions mode
+	if !account.IsOpenAIChatCompletionsMode() {
+		targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
+	}
 
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {
@@ -3849,6 +3865,22 @@ func buildOpenAIResponsesURL(base string) string {
 		return normalized + "/responses"
 	}
 	return normalized + "/v1/responses"
+}
+
+// buildOpenAIChatCompletionsURL 组装 OpenAI Chat Completions 端点。
+// 用于不支持 Responses API 的 OpenAI 兼容提供商（如 Alibaba Coding Plan）。
+// - base 以 /v1 结尾：追加 /chat/completions
+// - base 已是 /chat/completions：原样返回
+// - 其他情况：追加 /v1/chat/completions
+func buildOpenAIChatCompletionsURL(base string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
+	if strings.HasSuffix(normalized, "/chat/completions") {
+		return normalized
+	}
+	if strings.HasSuffix(normalized, "/v1") {
+		return normalized + "/chat/completions"
+	}
+	return normalized + "/v1/chat/completions"
 }
 
 func trimOpenAIEncryptedReasoningItems(reqBody map[string]any) bool {


### PR DESCRIPTION
## Summary

Adds support for OpenAI-compatible API providers that use the standard Chat Completions API (`/v1/chat/completions`) instead of the OpenAI Responses API (`/v1/responses`).

This enables Sub2API to work with providers like **Alibaba Coding Plan** which only support the Chat Completions endpoint.

## Changes

- Add `IsOpenAIChatCompletionsMode()` method to Account struct
- Add `openai_chat_completions_mode` field in account's `extra` configuration  
- Modify account test service to use `/chat/completions` endpoint when enabled
- Modify gateway service to build correct URL for Chat Completions mode
- Add direct forwarding function for Chat Completions API without Responses conversion

## Usage

Set `openai_chat_completions_mode: true` in the account's `extra` field to enable Chat Completions mode.

**Example account configuration:**
```json
{
  "platform": "openai",
  "type": "apikey",
  "credentials": {
    "base_url": "https://coding-intl.dashscope.aliyuncs.com/v1",
    "api_key": "sk-sp-xxx"
  },
  "extra": {
    "openai_chat_completions_mode": true
  }
}
```

## Use Cases

- Alibaba Coding Plan (`coding-intl.dashscope.aliyuncs.com`)
- Other OpenAI-compatible providers that don't support the Responses API

## Testing

Tested with Alibaba Coding Plan endpoint:
- Account connection test works correctly
- Chat Completions requests are forwarded properly
- Both streaming and non-streaming responses handled correctly