### PR TITLE
Fix OpenAI passthrough failover and normalization

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2308,7 +2308,11 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 			return nil, fmt.Errorf("openai passthrough rejected before upstream: %s", rejectReason)
 		}
 
-		normalizedBody, normalized, err := normalizeOpenAIPassthroughOAuthBody(body, isOpenAIResponsesCompactPath(c))
+		normalizedBody, normalized, err := normalizeOpenAIPassthroughOAuthBody(
+			body,
+			isOpenAIResponsesCompactPath(c),
+			openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator")),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -2736,7 +2740,56 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	var firstTokenMs *int
 	clientDisconnected := false
 	sawDone := false
+	streamCommitted := false
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
+	pendingLines := make([]string, 0, 8)
+
+	flushPendingLines := func() error {
+		if len(pendingLines) == 0 {
+			streamCommitted = true
+			return nil
+		}
+		for _, line := range pendingLines {
+			if _, err := fmt.Fprintln(w, line); err != nil {
+				return err
+			}
+		}
+		flusher.Flush()
+		pendingLines = pendingLines[:0]
+		streamCommitted = true
+		return nil
+	}
+	buildPreCommitFailover := func(reason string, cause error) error {
+		msg := strings.TrimSpace(reason)
+		if msg == "" {
+			msg = "OpenAI passthrough upstream stream ended before first data event"
+		}
+		setOpsUpstreamError(c, http.StatusBadGateway, msg, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: http.StatusBadGateway,
+			UpstreamRequestID:  upstreamRequestID,
+			Passthrough:        true,
+			Kind:               "failover",
+			Message:            msg,
+		})
+		logFields := []zap.Field{
+			zap.String("component", "service.openai_gateway"),
+			zap.Int64("account_id", account.ID),
+			zap.String("upstream_request_id", upstreamRequestID),
+		}
+		if cause != nil {
+			logFields = append(logFields, zap.Error(cause))
+		}
+		logger.FromContext(ctx).With(logFields...).Warn("OpenAI passthrough 首个数据包前断流，触发 failover")
+		return &UpstreamFailoverError{
+			StatusCode:      http.StatusBadGateway,
+			ResponseBody:    []byte(msg),
+			ResponseHeaders: resp.Header.Clone(),
+		}
+	}
 
 	scanner := bufio.NewScanner(resp.Body)
 	maxLineSize := defaultMaxLineSize
@@ -2749,11 +2802,15 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 
 	for scanner.Scan() {
 		line := scanner.Text()
+		shouldCommit := false
 		if data, ok := extractOpenAISSEDataLine(line); ok {
 			dataBytes := []byte(data)
 			trimmedData := strings.TrimSpace(data)
 			if trimmedData == "[DONE]" {
 				sawDone = true
+			}
+			if trimmedData != "" {
+				shouldCommit = true
 			}
 			if firstTokenMs == nil && trimmedData != "" && trimmedData != "[DONE]" {
 				ms := int(time.Since(startTime).Milliseconds())
@@ -2763,6 +2820,16 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		}
 
 		if !clientDisconnected {
+			if !streamCommitted {
+				pendingLines = append(pendingLines, line)
+				if shouldCommit {
+					if err := flushPendingLines(); err != nil {
+						clientDisconnected = true
+						logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+					}
+				}
+				continue
+			}
 			if _, err := fmt.Fprintln(w, line); err != nil {
 				clientDisconnected = true
 				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
@@ -2784,6 +2851,9 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				err,
 				ctx.Err(),
 			)
+			if !streamCommitted && ctx.Err() == nil {
+				return nil, buildPreCommitFailover("OpenAI passthrough upstream stream canceled before first data event", err)
+			}
 			return &openaiStreamingResultPassthrough{usage: usage, firstTokenMs: firstTokenMs}, nil
 		}
 		if errors.Is(err, bufio.ErrTooLong) {
@@ -2796,9 +2866,15 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			upstreamRequestID,
 			err,
 		)
+		if !streamCommitted {
+			return nil, buildPreCommitFailover("OpenAI passthrough upstream stream read failed before first data event", err)
+		}
 		return &openaiStreamingResultPassthrough{usage: usage, firstTokenMs: firstTokenMs}, fmt.Errorf("stream read error: %w", err)
 	}
 	if !clientDisconnected && !sawDone && ctx.Err() == nil {
+		if !streamCommitted {
+			return nil, buildPreCommitFailover("OpenAI passthrough upstream stream ended before first data event", nil)
+		}
 		logger.FromContext(ctx).With(
 			zap.String("component", "service.openai_gateway"),
 			zap.Int64("account_id", account.ID),
@@ -4441,14 +4517,37 @@ func extractOpenAIRequestMetaFromBody(body []byte) (model string, stream bool, p
 }
 
 // normalizeOpenAIPassthroughOAuthBody 将透传 OAuth 请求体收敛为旧链路关键行为：
-// 1) store=false 2) 非 compact 保持 stream=true；compact 强制 stream=false
-func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, bool, error) {
+// 1) 非官方 Codex 客户端缺失 instructions 时注入默认值
+// 2) store=false
+// 3) 非 compact 保持 stream=true；compact 强制 stream=false
+func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool, codexOfficialClient bool) ([]byte, bool, error) {
 	if len(body) == 0 {
 		return body, false, nil
 	}
 
 	normalized := body
 	changed := false
+
+	if !codexOfficialClient {
+		if instructionsReason := detectMissingOpenAIInstructionsReason(normalized); instructionsReason != "" {
+			next, err := sjson.SetBytes(normalized, "instructions", "You are a helpful coding assistant.")
+			if err != nil {
+				return body, false, fmt.Errorf("normalize passthrough body instructions default: %w", err)
+			}
+			normalized = next
+			changed = true
+		}
+		for _, field := range []string{"max_output_tokens", "max_completion_tokens"} {
+			if value := gjson.GetBytes(normalized, field); value.Exists() {
+				next, err := sjson.DeleteBytes(normalized, field)
+				if err != nil {
+					return body, false, fmt.Errorf("normalize passthrough body delete %s: %w", field, err)
+				}
+				normalized = next
+				changed = true
+			}
+		}
+	}
 
 	if compact {
 		if store := gjson.GetBytes(normalized, "store"); store.Exists() {
@@ -4495,6 +4594,20 @@ func detectOpenAIPassthroughInstructionsRejectReason(reqModel string, body []byt
 		return ""
 	}
 
+	instructions := gjson.GetBytes(body, "instructions")
+	if !instructions.Exists() {
+		return "instructions_missing"
+	}
+	if instructions.Type != gjson.String {
+		return "instructions_not_string"
+	}
+	if strings.TrimSpace(instructions.String()) == "" {
+		return "instructions_empty"
+	}
+	return ""
+}
+
+func detectMissingOpenAIInstructionsReason(body []byte) string {
 	instructions := gjson.GetBytes(body, "instructions")
 	if !instructions.Exists() {
 		return "instructions_missing"

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -1611,6 +1612,87 @@ func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, re
 	s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
 }
 
+func (s *OpenAIGatewayService) shouldFailoverOpenAIPassthroughResponse(statusCode int, upstreamMsg string, responseBody []byte) bool {
+	switch statusCode {
+	case http.StatusTooManyRequests:
+		return isOpenAIWSRateLimitError(
+			gjson.GetBytes(responseBody, "error.code").String(),
+			gjson.GetBytes(responseBody, "error.type").String(),
+			upstreamMsg,
+		)
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, 529:
+		return true
+	default:
+		return isOpenAITransientProcessingError(statusCode, upstreamMsg, responseBody)
+	}
+}
+
+func (s *OpenAIGatewayService) shouldFailoverOpenAIPassthroughRequestError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, net.ErrClosed) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := strings.ToLower(strings.TrimSpace(err.Error()))
+	switch {
+	case strings.Contains(msg, "timeout"),
+		strings.Contains(msg, "timed out"),
+		strings.Contains(msg, "deadline exceeded"),
+		strings.Contains(msg, "unexpected eof"),
+		strings.Contains(msg, "connection reset"),
+		strings.Contains(msg, "broken pipe"),
+		strings.Contains(msg, "stream disconnected"):
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *OpenAIGatewayService) markOpenAIPassthroughTransientOverload(ctx context.Context, account *Account, trigger string) {
+	if s == nil || s.accountRepo == nil || account == nil {
+		return
+	}
+	cooldownMinutes := 5
+	if s.cfg != nil && s.cfg.RateLimit.OverloadCooldownMinutes > 0 {
+		cooldownMinutes = s.cfg.RateLimit.OverloadCooldownMinutes
+	}
+	until := time.Now().Add(time.Duration(cooldownMinutes) * time.Minute)
+	if err := s.accountRepo.SetOverloaded(ctx, account.ID, until); err != nil {
+		logger.FromContext(ctx).With(
+			zap.String("component", "service.openai_gateway"),
+			zap.Int64("account_id", account.ID),
+			zap.String("trigger", strings.TrimSpace(trigger)),
+			zap.Error(err),
+		).Warn("OpenAI passthrough 瞬态错误冷却写库失败")
+		return
+	}
+	logger.FromContext(ctx).With(
+		zap.String("component", "service.openai_gateway"),
+		zap.Int64("account_id", account.ID),
+		zap.String("trigger", strings.TrimSpace(trigger)),
+		zap.Time("until", until),
+	).Warn("OpenAI passthrough 瞬态错误触发账号冷却")
+}
+
+func (s *OpenAIGatewayService) applyOpenAIPassthroughFailoverSideEffects(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, trigger string) {
+	if account == nil {
+		return
+	}
+	switch statusCode {
+	case http.StatusTooManyRequests, 529:
+		if s.rateLimitService != nil {
+			s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, headers, responseBody)
+		}
+	case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		s.markOpenAIPassthroughTransientOverload(ctx, account, trigger)
+	}
+}
+
 // Forward forwards request to OpenAI API
 func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
 	startTime := time.Now()
@@ -2285,6 +2367,23 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 	if err != nil {
 		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		if s.shouldFailoverOpenAIPassthroughRequestError(err) {
+			setOpsUpstreamError(c, http.StatusBadGateway, safeErr, "")
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: http.StatusBadGateway,
+				Passthrough:        true,
+				Kind:               "failover",
+				Message:            safeErr,
+			})
+			s.markOpenAIPassthroughTransientOverload(ctx, account, safeErr)
+			return nil, &UpstreamFailoverError{
+				StatusCode:   http.StatusBadGateway,
+				ResponseBody: []byte(safeErr),
+			}
+		}
 		setOpsUpstreamError(c, 0, safeErr, "")
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
@@ -2306,7 +2405,42 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		// 透传模式不做 failover（避免改变原始上游语义），按上游原样返回错误响应。
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(responseBody))
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(responseBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+		upstreamDetail := ""
+		if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+			maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+			if maxBytes <= 0 {
+				maxBytes = 2048
+			}
+			upstreamDetail = truncateString(string(responseBody), maxBytes)
+		}
+		if s.shouldFailoverOpenAIPassthroughResponse(resp.StatusCode, upstreamMsg, responseBody) {
+			setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:             account.Platform,
+				AccountID:            account.ID,
+				AccountName:          account.Name,
+				UpstreamStatusCode:   resp.StatusCode,
+				UpstreamRequestID:    resp.Header.Get("x-request-id"),
+				Passthrough:          true,
+				Kind:                 "failover",
+				Message:              upstreamMsg,
+				Detail:               upstreamDetail,
+				UpstreamResponseBody: upstreamDetail,
+			})
+			s.applyOpenAIPassthroughFailoverSideEffects(ctx, account, resp.StatusCode, resp.Header, responseBody, upstreamMsg)
+			return nil, &UpstreamFailoverError{
+				StatusCode:             resp.StatusCode,
+				ResponseBody:           responseBody,
+				ResponseHeaders:        resp.Header.Clone(),
+				RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
+			}
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(responseBody))
 		return nil, s.handleErrorResponsePassthrough(ctx, resp, c, account, body)
 	}
 

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -370,6 +370,52 @@ func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedB
 	require.True(t, logSink.ContainsFieldValue("reject_reason", "instructions_missing"))
 }
 
+func TestOpenAIGatewayService_OAuthPassthrough_NonOfficialClientGetsDefaultInstructions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "OpenAI/JS 6.26.0")
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	originalBody := []byte(`{"model":"gpt-5.4","stream":true,"max_output_tokens":32000,"input":[{"role":"user","content":[{"type":"input_text","text":"hi"}]}]}`)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+
+	account := &Account{
+		ID:             124,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, string(upstream.lastBody), `"instructions":"You are a helpful coding assistant."`)
+	require.Contains(t, string(upstream.lastBody), `"store":false`)
+	require.Contains(t, string(upstream.lastBody), `"stream":true`)
+	require.NotContains(t, string(upstream.lastBody), `"max_output_tokens"`)
+}
+
 func TestOpenAIGatewayService_OAuthPassthrough_DisabledUsesLegacyTransform(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -926,6 +972,46 @@ func TestOpenAIGatewayService_OAuthPassthrough_InfoWhenStreamEndsWithoutDone(t *
 	require.True(t, logSink.ContainsMessage("上游流在未收到 [DONE] 时结束，疑似断流"))
 	require.True(t, logSink.ContainsMessageAtLevel("上游流在未收到 [DONE] 时结束，疑似断流", "info"))
 	require.True(t, logSink.ContainsFieldValue("upstream_request_id", "rid-truncate"))
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_StreamEndsBeforeFirstDataTriggersFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid-precommit"}},
+		Body:       io.NopCloser(strings.NewReader("event: response.created\n\n")),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:             655,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, "rid-precommit", failoverErr.ResponseHeaders.Get("X-Request-Id"))
+	require.Empty(t, rec.Body.String(), "pre-commit failover must not write partial SSE to client")
 }
 
 func TestOpenAIGatewayService_OAuthPassthrough_DefaultFiltersTimeoutHeaders(t *testing.T) {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -45,6 +46,32 @@ func (u *httpUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID 
 
 func (u *httpUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, enableTLSFingerprint bool) (*http.Response, error) {
 	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+type openAIPassthroughFailoverRepo struct {
+	stubOpenAIAccountRepo
+	rateLimitCalls []time.Time
+	overloadCalls  []time.Time
+	updateExtra    []map[string]any
+}
+
+func (r *openAIPassthroughFailoverRepo) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
+	r.rateLimitCalls = append(r.rateLimitCalls, resetAt)
+	return nil
+}
+
+func (r *openAIPassthroughFailoverRepo) SetOverloaded(_ context.Context, _ int64, until time.Time) error {
+	r.overloadCalls = append(r.overloadCalls, until)
+	return nil
+}
+
+func (r *openAIPassthroughFailoverRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
+	copied := make(map[string]any, len(updates))
+	for k, v := range updates {
+		copied[k] = v
+	}
+	r.updateExtra = append(r.updateExtra, copied)
+	return nil
 }
 
 var structuredLogCaptureMu sync.Mutex
@@ -984,4 +1011,191 @@ func TestOpenAIGatewayService_OAuthPassthrough_AllowTimeoutHeadersWhenConfigured
 	require.NotNil(t, upstream.lastReq)
 	require.Equal(t, "120000", upstream.lastReq.Header.Get("x-stainless-timeout"))
 	require.Empty(t, upstream.lastReq.Header.Get("X-Test"))
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_429UsageLimitTriggersFailoverAndRateLimitPersistence(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	requestBody := []byte(`{"model":"gpt-5.4","stream":true,"instructions":"x","input":[{"type":"text","text":"hi"}]}`)
+	headers := http.Header{
+		"Content-Type":                          []string{"application/json"},
+		"X-Request-Id":                          []string{"rid-429"},
+		"X-Codex-Primary-Used-Percent":          []string{"100"},
+		"X-Codex-Primary-Reset-After-Seconds":   []string{"7200"},
+		"X-Codex-Primary-Window-Minutes":        []string{"10080"},
+		"X-Codex-Secondary-Used-Percent":        []string{"20"},
+		"X-Codex-Secondary-Reset-After-Seconds": []string{"1800"},
+		"X-Codex-Secondary-Window-Minutes":      []string{"300"},
+	}
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     headers,
+			Body: io.NopCloser(strings.NewReader(
+				`{"error":{"type":"usage_limit_reached","code":"rate_limit_exceeded","message":"The usage limit has been reached"}}`,
+			)),
+		},
+	}
+	repo := &openAIPassthroughFailoverRepo{}
+	svc := &OpenAIGatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream:     upstream,
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	account := &Account{
+		ID:             301,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, requestBody)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusTooManyRequests, failoverErr.StatusCode)
+	require.Len(t, repo.rateLimitCalls, 1)
+	require.NotEmpty(t, repo.updateExtra)
+	require.Empty(t, rec.Body.String())
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_429NonRateLimitStaysPassthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	requestBody := []byte(`{"model":"gpt-5.4","stream":false,"instructions":"x","input":[{"type":"text","text":"hi"}]}`)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-429-pass"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"bad upstream request"}}`)),
+		},
+	}
+	repo := &openAIPassthroughFailoverRepo{}
+	svc := &OpenAIGatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream:     upstream,
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	account := &Account{
+		ID:             302,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, requestBody)
+	require.Nil(t, result)
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Contains(t, rec.Body.String(), "bad upstream request")
+	require.Empty(t, repo.rateLimitCalls)
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_503TriggersFailoverAndCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	requestBody := []byte(`{"model":"gpt-5.4","stream":false,"instructions":"x","input":[{"type":"text","text":"hi"}]}`)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-503"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"server_error","message":"upstream unavailable"}}`)),
+		},
+	}
+	repo := &openAIPassthroughFailoverRepo{}
+	svc := &OpenAIGatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream:     upstream,
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, &config.Config{}, nil, nil),
+	}
+	account := &Account{
+		ID:             303,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, requestBody)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusServiceUnavailable, failoverErr.StatusCode)
+	require.Len(t, repo.overloadCalls, 1)
+	require.Empty(t, rec.Body.String())
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_RequestTimeoutTriggersFailoverAndCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	requestBody := []byte(`{"model":"gpt-5.4","stream":false,"instructions":"x","input":[{"type":"text","text":"hi"}]}`)
+	upstream := &httpUpstreamRecorder{err: context.DeadlineExceeded}
+	repo := &openAIPassthroughFailoverRepo{}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+		accountRepo:  repo,
+	}
+	account := &Account{
+		ID:             304,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, requestBody)
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Len(t, repo.overloadCalls, 1)
+	require.Empty(t, rec.Body.String())
 }


### PR DESCRIPTION
## Summary
- add selective failover for OpenAI OAuth passthrough on usage-limit 429s and transient upstream failures
- preserve passthrough behavior for non-rate-limit 429 responses
- harden passthrough request normalization for non-official clients by defaulting `instructions` and removing incompatible max-token fields
- fail over when the upstream stream dies before the first committed SSE payload

## Notes
- targeted tests were added for the new failover and normalization behavior
- local formatting and diff checks passed
- repeated `go test` retries in this environment were blocked by upstream Go module download timeouts (`github.com/klauspost/compress`), not by assertion failures
