### PR TITLE
Preserve group isolation in simple mode

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1846,11 +1846,11 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 
 	var accounts []Account
 	var err error
-	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
-		accounts, err = s.accountRepo.ListSchedulableByPlatform(ctx, platform)
-	} else if groupID != nil {
+	if groupID != nil {
 		accounts, err = s.accountRepo.ListSchedulableByGroupIDAndPlatform(ctx, *groupID, platform)
-		// 分组内无账号则返回空列表，由上层处理错误，不再回退到全平台查询
+		// Group-specific keys stay pinned to their own accounts even in simple mode.
+	} else if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		accounts, err = s.accountRepo.ListSchedulableByPlatform(ctx, platform)
 	} else {
 		accounts, err = s.accountRepo.ListSchedulableUngroupedByPlatform(ctx, platform)
 	}
@@ -1882,9 +1882,7 @@ func (s *GatewayService) listSoraSchedulableAccounts(ctx context.Context, groupI
 
 	var accounts []Account
 	var err error
-	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
-		accounts, err = s.accountRepo.ListByPlatform(ctx, PlatformSora)
-	} else if groupID != nil {
+	if groupID != nil {
 		accounts, err = s.accountRepo.ListByGroup(ctx, *groupID)
 	} else {
 		accounts, err = s.accountRepo.ListByPlatform(ctx, PlatformSora)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1487,10 +1487,10 @@ func (s *OpenAIGatewayService) listSchedulableAccounts(ctx context.Context, grou
 	}
 	var accounts []Account
 	var err error
-	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
-		accounts, err = s.accountRepo.ListSchedulableByPlatform(ctx, PlatformOpenAI)
-	} else if groupID != nil {
+	if groupID != nil {
 		accounts, err = s.accountRepo.ListSchedulableByGroupIDAndPlatform(ctx, *groupID, PlatformOpenAI)
+	} else if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		accounts, err = s.accountRepo.ListSchedulableByPlatform(ctx, PlatformOpenAI)
 	} else {
 		accounts, err = s.accountRepo.ListSchedulableUngroupedByPlatform(ctx, PlatformOpenAI)
 	}

--- a/backend/internal/service/scheduler_snapshot_group_isolation_test.go
+++ b/backend/internal/service/scheduler_snapshot_group_isolation_test.go
@@ -1,0 +1,42 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerSnapshot_SimpleMode_ExplicitGroupUsesGroupBucketForGeminiMixed(t *testing.T) {
+	ctx := context.Background()
+
+	groupID := int64(100)
+	accounts := []Account{
+		{
+			ID: 1, Platform: PlatformGemini, Priority: 1, Status: StatusActive, Schedulable: true,
+			AccountGroups: []AccountGroup{{GroupID: groupID}},
+		},
+		{
+			ID: 2, Platform: PlatformGemini, Priority: 1, Status: StatusActive, Schedulable: true,
+			AccountGroups: []AccountGroup{{GroupID: 200}},
+		},
+	}
+
+	repo := newGroupAwareMockRepo(accounts)
+	svc := &SchedulerSnapshotService{
+		accountRepo: repo,
+		cfg:         &config.Config{RunMode: config.RunModeSimple},
+	}
+
+	got, err := svc.loadAccountsFromDB(ctx, SchedulerBucket{
+		GroupID:  groupID,
+		Platform: PlatformGemini,
+		Mode:     SchedulerModeMixed,
+	}, true)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, int64(1), got[0].ID)
+}

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -595,9 +595,6 @@ func (s *SchedulerSnapshotService) loadAccountsFromDB(ctx context.Context, bucke
 		return nil, ErrSchedulerCacheNotReady
 	}
 	groupID := bucket.GroupID
-	if s.isRunModeSimple() {
-		groupID = 0
-	}
 
 	if useMixed {
 		platforms := []string{bucket.Platform, PlatformAntigravity}
@@ -641,9 +638,6 @@ func (s *SchedulerSnapshotService) bucketFor(groupID *int64, platform string, mo
 }
 
 func (s *SchedulerSnapshotService) normalizeGroupID(groupID *int64) int64 {
-	if s.isRunModeSimple() {
-		return 0
-	}
 	if groupID == nil || *groupID <= 0 {
 		return 0
 	}
@@ -651,9 +645,6 @@ func (s *SchedulerSnapshotService) normalizeGroupID(groupID *int64) int64 {
 }
 
 func (s *SchedulerSnapshotService) normalizeGroupIDs(groupIDs []int64) []int64 {
-	if s.isRunModeSimple() {
-		return []int64{0}
-	}
 	if len(groupIDs) == 0 {
 		return []int64{0}
 	}
@@ -749,7 +740,7 @@ func (s *SchedulerSnapshotService) defaultBuckets(ctx context.Context) ([]Schedu
 		}
 	}
 
-	if s.isRunModeSimple() || s.groupRepo == nil {
+	if s.groupRepo == nil {
 		return dedupeBuckets(buckets), nil
 	}
 


### PR DESCRIPTION
## Summary
- keep explicit group scheduling isolated even when `RunModeSimple` is enabled
- stop collapsing explicit group buckets to group `0` inside scheduler snapshot loading
- add a unit test covering mixed Gemini scheduling with an explicit group in simple mode

## Notes
- local formatting and diff checks passed
- test execution in this environment was intermittently blocked by external Go module download timeouts
