### PR TITLE
Set Gemini default test model to 3 flash preview

### DIFF
--- a/backend/internal/pkg/geminicli/models.go
+++ b/backend/internal/pkg/geminicli/models.go
@@ -22,4 +22,4 @@ var DefaultModels = []Model{
 }
 
 // DefaultTestModel is the default model to preselect in test flows.
-const DefaultTestModel = "gemini-2.0-flash"
+const DefaultTestModel = "gemini-3-flash-preview"


### PR DESCRIPTION
## Summary
- change the Gemini CLI default test model from `gemini-2.0-flash` to `gemini-3-flash-preview`
- align the admin account-test default with the model that currently works in this environment
