### PR TITLE
Ignore deploy runtime data in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -61,6 +61,9 @@ temp/
 deploy/install.sh
 deploy/sub2api.service
 deploy/sub2api-sudoers
+deploy/data/
+deploy/postgres_data/
+deploy/redis_data/
 
 # GoReleaser
 .goreleaser.yaml


### PR DESCRIPTION
## Summary
- exclude `deploy/data`, `deploy/postgres_data`, and `deploy/redis_data` from Docker build context
- prevent local runtime data directories from bloating or breaking image builds
