### PR TITLE
fix(ops): prevent runtime log controls UI overflow

### DIFF
--- a/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
+++ b/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
@@ -344,7 +344,7 @@ onMounted(async () => {
         <div class="text-xs font-semibold text-gray-700 dark:text-gray-200">运行时日志配置（实时生效）</div>
         <span v-if="runtimeLoading" class="text-xs text-gray-500">加载中...</span>
       </div>
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-6">
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-6">
         <label class="text-xs text-gray-600 dark:text-gray-300">
           级别
           <select v-model="runtimeConfig.level" class="input mt-1">
@@ -374,21 +374,27 @@ onMounted(async () => {
           保留天数
           <input v-model.number="runtimeConfig.retention_days" type="number" min="1" max="3650" class="input mt-1" />
         </label>
-        <div class="flex items-end gap-2">
-          <label class="inline-flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
-            <input v-model="runtimeConfig.caller" type="checkbox" />
-            caller
-          </label>
-          <label class="inline-flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
-            <input v-model="runtimeConfig.enable_sampling" type="checkbox" />
-            sampling
-          </label>
-          <button type="button" class="btn btn-primary btn-sm" :disabled="runtimeSaving" @click="saveRuntimeConfig">
-            {{ runtimeSaving ? '保存中...' : '保存并生效' }}
-          </button>
-          <button type="button" class="btn btn-secondary btn-sm" :disabled="runtimeSaving" @click="resetRuntimeConfig">
-            回滚默认值
-          </button>
+        <div class="md:col-span-2 xl:col-span-6">
+          <div class="grid gap-3 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
+            <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
+              <label class="inline-flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                <input v-model="runtimeConfig.caller" type="checkbox" />
+                caller
+              </label>
+              <label class="inline-flex items-center gap-2 text-xs text-gray-600 dark:text-gray-300">
+                <input v-model="runtimeConfig.enable_sampling" type="checkbox" />
+                sampling
+              </label>
+            </div>
+            <div class="flex flex-wrap items-center gap-2 lg:justify-end">
+              <button type="button" class="btn btn-primary btn-sm" :disabled="runtimeSaving" @click="saveRuntimeConfig">
+                {{ runtimeSaving ? '保存中...' : '保存并生效' }}
+              </button>
+              <button type="button" class="btn btn-secondary btn-sm" :disabled="runtimeSaving" @click="resetRuntimeConfig">
+                回滚默认值
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <p v-if="health.last_error" class="mt-2 text-xs text-red-600 dark:text-red-400">最近写入错误：{{ health.last_error }}</p>


### PR DESCRIPTION
## Summary

修复运维面板按钮错位，防止布局溢出

错位组件位置：运维监控-系统日志-运行时日志配置（实时生效）

修复前：
<img width="1656" height="254" alt="image" src="https://github.com/user-attachments/assets/8ce46da9-13a3-4f2f-ae25-b5c573b269eb" />


修复后：
<img width="1606" height="272" alt="image" src="https://github.com/user-attachments/assets/9c79f9e1-ce22-4937-8f2f-698960e26ff1" />


## Changes

* 移动 `caller`, `sampling` 单选框到正确的位置
* 移动 `保存并生效`, `回滚默认值` 按钮到正确的位置

## Verification

* `pnpm run typecheck`
* `pnpm run build`

## Notes

* scope is intentionally limited to the runtime logging config layout in `frontend/src/views/admin/ops/components/OpsSystemLogTable.vue`