### PR TITLE
fix(openai): persist passthrough 429 rate limits

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2598,6 +2598,12 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 	}
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
+	if s.rateLimitService != nil {
+		// Passthrough mode preserves the raw upstream error response, but runtime
+		// account state still needs to be updated so sticky routing can stop
+		// reusing a freshly rate-limited account.
+		_ = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	}
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:             account.Platform,
 		AccountID:            account.ID,

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -536,6 +536,55 @@ func TestOpenAIGatewayService_OAuthPassthrough_UpstreamErrorIncludesPassthroughF
 	require.True(t, arr[len(arr)-1].Passthrough)
 }
 
+func TestOpenAIGatewayService_OAuthPassthrough_429PersistsRateLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	originalBody := []byte(`{"model":"gpt-5.2","stream":false,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
+	resetAt := time.Now().Add(7 * 24 * time.Hour).Unix()
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"x-request-id": []string{"rid-rate-limit"},
+		},
+		Body: io.NopCloser(strings.NewReader(fmt.Sprintf(`{"error":{"message":"The usage limit has been reached","type":"usage_limit_reached","resets_at":%d}}`, resetAt))),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+	repo := &openAIWSRateLimitSignalRepo{}
+	rateSvc := &RateLimitService{accountRepo: repo}
+
+	svc := &OpenAIGatewayService{
+		cfg:              &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream:     upstream,
+		rateLimitService: rateSvc,
+	}
+
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.Error(t, err)
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Contains(t, rec.Body.String(), "usage_limit_reached")
+	require.Len(t, repo.rateLimitCalls, 1)
+	require.WithinDuration(t, time.Unix(resetAt, 0), repo.rateLimitCalls[0], 2*time.Second)
+}
+
 func TestOpenAIGatewayService_OAuthPassthrough_NonCodexUAFallbackToCodexUA(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## 摘要

这个 PR 修复了一个日常使用中遇到的一个影响较大的 OpenAI passthrough 账号调度问题。

当开启了 passthrough 的 OpenAI 账号触发上游 429 时，系统没有把返回的 429 rate-limit 状态持久化。导致调度器仍然会认为这个账号可调度，而 `previous_response_id` 的设定又会持续把同一个用户路由到同一个账号。

这个问题在账号容量处于 98%、99% 这类场景下尤其明显。从调度器视角看，这个账号仍然“可用”，但只要下一次请求稍大，就会立刻再次触发上游 429。一旦进入这个状态，同一个用户就会持续、连续地命中 429，这名用户之后的SLA会降低到0%，API 调用完全不可用，除非管理员在后台手动关闭这个账号的调度。

这个修复让 passthrough 路径下的 429 也能像非 passthrough 路径一样正确持久化限流状态，从而临时将该账号移出调度，前端也能看到正确的 reset 时间，并且 sticky routing 不会再持续把流量打回同一个已限流账号。

## 测试

- 添加了 passthrough 429 持久化的回归测试

---

## Summary

This fixes a high-impact scheduling bug for OpenAI accounts with passthrough enabled.

When an OpenAI passthrough account hits an upstream 429, the runtime rate-limit state was not persisted. As a result, the scheduler still considered that account schedulable and `previous_response_id` kept routing the same user back to the same account.

This is especially problematic when the account is already at 98% or 99% usage rather than a hard 100%. In that state, the account still looks "available" to the scheduler, but a slightly larger follow-up request can immediately trigger another upstream 429. Once that happens, the same user can get stuck in a continuous 429 loop, making API calls effectively unusable until an admin manually disables scheduling for that account in the admin panel.

This change persists passthrough 429 rate-limit state the same way as the non-passthrough path, so the account is temporarily removed from scheduling, the reset time is visible in the console, and sticky routing stops sending traffic back to the same rate-limited account.

## Testing

- Added a regression test covering passthrough 429 persistence
