### PR TITLE
feat(gateway): simulate prompt cache usage for messages

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -1448,6 +1448,69 @@ func (h *SettingHandler) TestSoraS3Connection(c *gin.Context) {
 	response.Success(c, gin.H{"message": "S3 连接成功"})
 }
 
+// GetPromptCacheSimulationSettings 获取 Prompt Cache Simulation 配置
+// GET /api/v1/admin/settings/prompt-cache-simulation
+func (h *SettingHandler) GetPromptCacheSimulationSettings(c *gin.Context) {
+	settings, err := h.settingService.GetPromptCacheSimulationSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.PromptCacheSimulationSettings{
+		Enabled:            settings.Enabled,
+		SemanticFirst:      settings.SemanticFirst,
+		FallbackReadRatio:  settings.FallbackReadRatio,
+		FallbackWriteRatio: settings.FallbackWriteRatio,
+		TTLSeconds:         settings.TTLSeconds,
+	})
+}
+
+// UpdatePromptCacheSimulationSettingsRequest 更新 Prompt Cache Simulation 配置请求
+type UpdatePromptCacheSimulationSettingsRequest struct {
+	Enabled            bool    `json:"enabled"`
+	SemanticFirst      bool    `json:"semantic_first"`
+	FallbackReadRatio  float64 `json:"fallback_read_ratio"`
+	FallbackWriteRatio float64 `json:"fallback_write_ratio"`
+	TTLSeconds         int     `json:"ttl_seconds"`
+}
+
+// UpdatePromptCacheSimulationSettings 更新 Prompt Cache Simulation 配置
+// PUT /api/v1/admin/settings/prompt-cache-simulation
+func (h *SettingHandler) UpdatePromptCacheSimulationSettings(c *gin.Context) {
+	var req UpdatePromptCacheSimulationSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+
+	settings := &service.PromptCacheSimulationSettings{
+		Enabled:            req.Enabled,
+		SemanticFirst:      req.SemanticFirst,
+		FallbackReadRatio:  req.FallbackReadRatio,
+		FallbackWriteRatio: req.FallbackWriteRatio,
+		TTLSeconds:         req.TTLSeconds,
+	}
+	if err := h.settingService.SetPromptCacheSimulationSettings(c.Request.Context(), settings); err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+
+	updatedSettings, err := h.settingService.GetPromptCacheSimulationSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.PromptCacheSimulationSettings{
+		Enabled:            updatedSettings.Enabled,
+		SemanticFirst:      updatedSettings.SemanticFirst,
+		FallbackReadRatio:  updatedSettings.FallbackReadRatio,
+		FallbackWriteRatio: updatedSettings.FallbackWriteRatio,
+		TTLSeconds:         updatedSettings.TTLSeconds,
+	})
+}
+
 // GetRectifierSettings 获取请求整流器配置
 // GET /api/v1/admin/settings/rectifier
 func (h *SettingHandler) GetRectifierSettings(c *gin.Context) {

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -164,6 +164,15 @@ type OverloadCooldownSettings struct {
 	CooldownMinutes int  `json:"cooldown_minutes"`
 }
 
+// PromptCacheSimulationSettings Prompt Cache Simulation 配置 DTO
+type PromptCacheSimulationSettings struct {
+	Enabled            bool    `json:"enabled"`
+	SemanticFirst      bool    `json:"semantic_first"`
+	FallbackReadRatio  float64 `json:"fallback_read_ratio"`
+	FallbackWriteRatio float64 `json:"fallback_write_ratio"`
+	TTLSeconds         int     `json:"ttl_seconds"`
+}
+
 // StreamTimeoutSettings 流超时处理配置 DTO
 type StreamTimeoutSettings struct {
 	Enabled                bool   `json:"enabled"`

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -406,6 +406,9 @@ func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		// 529过载冷却配置
 		adminSettings.GET("/overload-cooldown", h.Admin.Setting.GetOverloadCooldownSettings)
 		adminSettings.PUT("/overload-cooldown", h.Admin.Setting.UpdateOverloadCooldownSettings)
+		// Prompt Cache Simulation 配置
+		adminSettings.GET("/prompt-cache-simulation", h.Admin.Setting.GetPromptCacheSimulationSettings)
+		adminSettings.PUT("/prompt-cache-simulation", h.Admin.Setting.UpdatePromptCacheSimulationSettings)
 		// 流超时处理配置
 		adminSettings.GET("/stream-timeout", h.Admin.Setting.GetStreamTimeoutSettings)
 		adminSettings.PUT("/stream-timeout", h.Admin.Setting.UpdateStreamTimeoutSettings)

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -178,6 +178,13 @@ const (
 	SettingKeyOverloadCooldownSettings = "overload_cooldown_settings"
 
 	// =========================
+	// Prompt Cache Simulation
+	// =========================
+
+	// SettingKeyPromptCacheSimulationSettings stores JSON config for Anthropic-style prompt cache usage simulation.
+	SettingKeyPromptCacheSimulationSettings = "prompt_cache_simulation_settings"
+
+	// =========================
 	// Stream Timeout Handling
 	// =========================
 

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1053,11 +1053,113 @@ func TestParseClaudeUsageFromResponseBody(t *testing.T) {
 		require.Equal(t, 8, got.CacheCreation1hTokens)
 	})
 
-	t.Run("keep explicit aggregate values", func(t *testing.T) {
-		body := []byte(`{"usage":{"input_tokens":1,"output_tokens":2,"cache_creation_input_tokens":9,"cache_read_input_tokens":7,"cached_tokens":99,"cache_creation":{"ephemeral_5m_input_tokens":4,"ephemeral_1h_input_tokens":5}}}`)
-		got := parseClaudeUsageFromResponseBody(body)
-		require.Equal(t, 9, got.CacheCreationInputTokens, "已显式提供聚合字段时不应被明细覆盖")
-		require.Equal(t, 7, got.CacheReadInputTokens, "已显式提供 cache_read_input_tokens 时不应回退 cached_tokens")
+	t.Run("simulate missing cache fields when eligible", func(t *testing.T) {
+		repo := newMockSettingRepo()
+		data, err := json.Marshal(PromptCacheSimulationSettings{
+			Enabled:            true,
+			SemanticFirst:      true,
+			FallbackReadRatio:  0.7,
+			FallbackWriteRatio: 0.2,
+			TTLSeconds:         300,
+		})
+		require.NoError(t, err)
+		repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+		cfg := &config.Config{}
+		svc := NewGatewayService(
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			&RateLimitService{},
+			nil,
+			cfg,
+			nil,
+			nil,
+			NewBillingService(cfg, nil),
+			nil,
+			&BillingCacheService{},
+			nil,
+			nil,
+			&DeferredService{},
+			nil,
+			nil,
+			nil,
+			NewSettingService(repo, cfg),
+			nil,
+		)
+
+		parsed, err := ParseGatewayRequest([]byte(`{
+			"model":"claude-sonnet-4",
+			"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+			"metadata":{"user_id":"user-1"}
+		}`), PlatformAnthropic)
+		require.NoError(t, err)
+
+		usage := &ClaudeUsage{InputTokens: 21}
+		require.True(t, svc.applyPromptCacheSimulationToUsage(context.Background(), "/v1/messages", parsed, "claude-sonnet-4", usage))
+		require.Zero(t, usage.InputTokens)
+		require.Equal(t, 21, usage.CacheCreationInputTokens)
+		require.Equal(t, 21, usage.CacheCreation5mTokens)
+		require.Zero(t, usage.CacheReadInputTokens)
+	})
+
+	t.Run("preserve explicit upstream cache fields", func(t *testing.T) {
+		repo := newMockSettingRepo()
+		data, err := json.Marshal(PromptCacheSimulationSettings{
+			Enabled:            true,
+			SemanticFirst:      true,
+			FallbackReadRatio:  0.7,
+			FallbackWriteRatio: 0.2,
+			TTLSeconds:         300,
+		})
+		require.NoError(t, err)
+		repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+		cfg := &config.Config{}
+		svc := NewGatewayService(
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			&RateLimitService{},
+			nil,
+			cfg,
+			nil,
+			nil,
+			NewBillingService(cfg, nil),
+			nil,
+			&BillingCacheService{},
+			nil,
+			nil,
+			&DeferredService{},
+			nil,
+			nil,
+			nil,
+			NewSettingService(repo, cfg),
+			nil,
+		)
+
+		parsed, err := ParseGatewayRequest([]byte(`{
+			"model":"claude-sonnet-4",
+			"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+			"metadata":{"user_id":"user-1"}
+		}`), PlatformAnthropic)
+		require.NoError(t, err)
+
+		usage := &ClaudeUsage{InputTokens: 21, CacheReadInputTokens: 7}
+		require.False(t, svc.applyPromptCacheSimulationToUsage(context.Background(), "/v1/messages", parsed, "claude-sonnet-4", usage))
+		require.Equal(t, 21, usage.InputTokens)
+		require.Equal(t, 7, usage.CacheReadInputTokens)
+		require.Zero(t, usage.CacheCreationInputTokens)
 	})
 }
 

--- a/backend/internal/service/gateway_cached_tokens_test.go
+++ b/backend/internal/service/gateway_cached_tokens_test.go
@@ -1,9 +1,16 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -256,6 +263,247 @@ func TestNonStreamingReconcile_NativeClaude(t *testing.T) {
 	assert.Equal(t, 30, response.Usage.CacheReadInputTokens)
 }
 
+func TestPromptCacheSimulationService_SemanticFirstFullPromptCreatesThenReads(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	settingSvc := NewSettingService(repo, nil)
+	simSvc := NewPromptCacheSimulationService(settingSvc)
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral"}}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"tools":[{"name":"lookup","input_schema":{"type":"object"},"cache_control":{"type":"ephemeral"}}]
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+	parsed.MetadataUserID = "user-1"
+
+	first, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-1", "claude-sonnet-4", 100)
+	require.True(t, ok)
+	require.Zero(t, first.InputTokens)
+	require.Equal(t, 100, first.CacheCreationInputTokens)
+	require.Equal(t, 100, first.CacheCreation5mTokens)
+	require.Zero(t, first.CacheReadInputTokens)
+
+	second, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-1", "claude-sonnet-4", 100)
+	require.True(t, ok)
+	require.Zero(t, second.InputTokens)
+	require.Zero(t, second.CacheCreationInputTokens)
+	require.Equal(t, 100, second.CacheReadInputTokens)
+}
+
+func TestPromptCacheSimulationService_FallbackUsesRatiosWhenSemanticUnavailable(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	settingSvc := NewSettingService(repo, nil)
+	simSvc := NewPromptCacheSimulationService(settingSvc)
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"system":[{"type":"text","text":"uncached system"}],
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}},{"type":"text","text":"tail"}]}]
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+	parsed.MetadataUserID = "user-1"
+
+	first, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-1", "claude-sonnet-4", 100)
+	require.True(t, ok)
+	require.Equal(t, 80, first.InputTokens)
+	require.Equal(t, 20, first.CacheCreationInputTokens)
+	require.Equal(t, 20, first.CacheCreation5mTokens)
+	require.Zero(t, first.CacheReadInputTokens)
+
+	second, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-1", "claude-sonnet-4", 100)
+	require.True(t, ok)
+	require.Equal(t, 30, second.InputTokens)
+	require.Zero(t, second.CacheCreationInputTokens)
+	require.Zero(t, second.CacheCreation5mTokens)
+	require.Equal(t, 70, second.CacheReadInputTokens)
+}
+
+func TestPromptCacheSimulationService_IsolatedBySessionAndModel(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	settingSvc := NewSettingService(repo, nil)
+	simSvc := NewPromptCacheSimulationService(settingSvc)
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}]
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+	parsedOtherModel, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-opus-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}]
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+
+	first, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-a", "claude-sonnet-4", 50)
+	require.True(t, ok)
+	require.Zero(t, first.InputTokens)
+	require.Equal(t, 50, first.CacheCreationInputTokens)
+
+	otherSession, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-b", "claude-sonnet-4", 50)
+	require.True(t, ok)
+	require.Zero(t, otherSession.InputTokens)
+	require.Equal(t, 50, otherSession.CacheCreationInputTokens)
+
+	otherModel, ok := simSvc.Simulate(context.Background(), "/v1/messages", parsedOtherModel, "metadata:user-a", "claude-opus-4", 50)
+	require.True(t, ok)
+	require.Zero(t, otherModel.InputTokens)
+	require.Equal(t, 50, otherModel.CacheCreationInputTokens)
+}
+
+func TestPromptCacheSimulationService_PreservesUpstreamUsageAndFallsBackToSessionContext(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	settingSvc := NewSettingService(repo, &config.Config{})
+	svc := NewGatewayService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&RateLimitService{},
+		nil,
+		&config.Config{},
+		nil,
+		nil,
+		NewBillingService(&config.Config{}, nil),
+		nil,
+		&BillingCacheService{},
+		nil,
+		nil,
+		&DeferredService{},
+		nil,
+		nil,
+		nil,
+		settingSvc,
+		nil,
+	)
+
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}]
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+	parsed.SessionContext = &SessionContext{ClientIP: "10.0.0.1", UserAgent: "ua-test", APIKeyID: 42}
+
+	upstreamUsage := &ClaudeUsage{InputTokens: 100, CacheReadInputTokens: 9}
+	require.False(t, svc.applyPromptCacheSimulationToUsage(context.Background(), "/v1/messages", parsed, "claude-sonnet-4", upstreamUsage))
+	require.Equal(t, 100, upstreamUsage.InputTokens)
+	require.Equal(t, 9, upstreamUsage.CacheReadInputTokens)
+	require.Zero(t, upstreamUsage.CacheCreationInputTokens)
+
+	first := &ClaudeUsage{InputTokens: 100}
+	require.True(t, svc.applyPromptCacheSimulationToUsage(context.Background(), "/v1/messages", parsed, "claude-sonnet-4", first))
+	require.Zero(t, first.InputTokens)
+	require.Equal(t, 100, first.CacheCreationInputTokens)
+	require.Equal(t, 100, first.CacheCreation5mTokens)
+	require.Zero(t, first.CacheReadInputTokens)
+
+	second := &ClaudeUsage{InputTokens: 100}
+	require.True(t, svc.applyPromptCacheSimulationToUsage(context.Background(), "/v1/messages", parsed, "claude-sonnet-4", second))
+	require.Zero(t, second.InputTokens)
+	require.Equal(t, 100, second.CacheReadInputTokens)
+	require.Zero(t, second.CacheCreationInputTokens)
+}
+
+func TestPromptCacheSimulationService_DisabledForNonAnthropicUsageShapes(t *testing.T) {
+	service := &PromptCacheSimulationService{}
+	decision, ok := service.Simulate(context.Background(), "/v1/messages", nil, "metadata:user-1", "claude-sonnet-4", 100)
+	require.False(t, ok)
+	require.Nil(t, decision)
+}
+
+func TestPromptCacheSimulationService_DoesNotSimulateOutsideMessagesPath(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	settingSvc := NewSettingService(repo, nil)
+	service := NewPromptCacheSimulationService(settingSvc)
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"metadata":{"user_id":"user-1"}
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+
+	decision, ok := service.Simulate(context.Background(), "/v1/complete", parsed, "metadata:user-1", "claude-sonnet-4", 100)
+	require.False(t, ok)
+	require.Nil(t, decision)
+}
+
+func TestPromptCacheSimulationService_DoesNotSimulateForModelMismatch(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	settingSvc := NewSettingService(repo, nil)
+	service := NewPromptCacheSimulationService(settingSvc)
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"metadata":{"user_id":"user-1"}
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+
+	decision, ok := service.Simulate(context.Background(), "/v1/messages", parsed, "metadata:user-1", "claude-opus-4", 100)
+	require.False(t, ok)
+	require.Nil(t, decision)
+}
+
 func TestNonStreamingReconcile_NoCachedTokens(t *testing.T) {
 	// 没有 cached_tokens 字段
 	body := []byte(`{
@@ -286,3 +534,156 @@ func TestNonStreamingReconcile_NoCachedTokens(t *testing.T) {
 	assert.Equal(t, 0, response.Usage.CacheReadInputTokens)
 	assert.Equal(t, int64(0), gjson.GetBytes(body, "usage.cache_read_input_tokens").Int())
 }
+
+func TestHandleNonStreamingResponse_PromptCacheSimulationPatchesBodyAndUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	cfg := &config.Config{}
+	svc := NewGatewayService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&RateLimitService{},
+		nil,
+		cfg,
+		nil,
+		nil,
+		NewBillingService(cfg, nil),
+		nil,
+		&BillingCacheService{},
+		nil,
+		nil,
+		&DeferredService{},
+		nil,
+		nil,
+		nil,
+		NewSettingService(repo, cfg),
+		nil,
+	)
+
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"metadata":{"user_id":"user-1"}
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body: io.NopCloser(strings.NewReader(`{
+			"type":"message",
+			"model":"claude-sonnet-4",
+			"usage":{"input_tokens":10,"output_tokens":3,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}
+		}`)),
+	}
+
+	usage, err := svc.handleNonStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, "claude-sonnet-4", "claude-sonnet-4", parsed)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Zero(t, usage.InputTokens)
+	require.Equal(t, 10, usage.CacheCreationInputTokens)
+	require.Equal(t, 10, usage.CacheCreation5mTokens)
+	require.Zero(t, usage.CacheReadInputTokens)
+	require.Equal(t, int64(0), gjson.Get(rec.Body.String(), "usage.input_tokens").Int())
+	require.Equal(t, int64(10), gjson.Get(rec.Body.String(), "usage.cache_creation_input_tokens").Int())
+	require.Equal(t, int64(10), gjson.Get(rec.Body.String(), "usage.cache_creation.ephemeral_5m_input_tokens").Int())
+}
+
+func TestHandleNonStreamingResponse_PreservesAuthoritativeUpstreamCacheFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	cfg := &config.Config{}
+	svc := NewGatewayService(
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		&RateLimitService{},
+		nil,
+		cfg,
+		nil,
+		nil,
+		NewBillingService(cfg, nil),
+		nil,
+		&BillingCacheService{},
+		nil,
+		nil,
+		&DeferredService{},
+		nil,
+		nil,
+		nil,
+		NewSettingService(repo, cfg),
+		nil,
+	)
+
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"claude-sonnet-4",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"metadata":{"user_id":"user-1"}
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body: io.NopCloser(strings.NewReader(`{
+			"type":"message",
+			"model":"claude-sonnet-4",
+			"usage":{
+				"input_tokens":10,
+				"output_tokens":3,
+				"cache_creation_input_tokens":0,
+				"cache_read_input_tokens":0,
+				"cache_creation":{"ephemeral_5m_input_tokens":4}
+			}
+		}`)),
+	}
+
+	usage, err := svc.handleNonStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, "claude-sonnet-4", "claude-sonnet-4", parsed)
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Zero(t, usage.CacheCreationInputTokens)
+	require.Equal(t, 4, usage.CacheCreation5mTokens)
+	require.Zero(t, usage.CacheReadInputTokens)
+	require.Equal(t, int64(0), gjson.Get(rec.Body.String(), "usage.cache_creation_input_tokens").Int())
+	require.Equal(t, int64(4), gjson.Get(rec.Body.String(), "usage.cache_creation.ephemeral_5m_input_tokens").Int())
+}
+

--- a/backend/internal/service/gateway_record_usage_test.go
+++ b/backend/internal/service/gateway_record_usage_test.go
@@ -423,6 +423,68 @@ func TestGatewayServiceRecordUsage_ReasoningEffortPersisted(t *testing.T) {
 	require.Equal(t, "max", *usageRepo.lastLog.ReasoningEffort)
 }
 
+func TestGatewayServiceRecordUsage_PersistsSimulatedPromptCacheUsage(t *testing.T) {
+	usageRepo := &openAIRecordUsageBestEffortLogRepoStub{}
+	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})
+
+	err := svc.RecordUsage(context.Background(), &RecordUsageInput{
+		Result: &ForwardResult{
+			RequestID: "gateway_simulated_prompt_cache",
+			Usage: ClaudeUsage{
+				InputTokens:              10,
+				OutputTokens:             6,
+				CacheCreationInputTokens: 8,
+				CacheReadInputTokens:     2,
+				CacheCreation5mTokens:    8,
+			},
+			Model:    "claude-sonnet-4",
+			Duration: time.Second,
+		},
+		APIKey:  &APIKey{ID: 509, Quota: 100},
+		User:    &User{ID: 609},
+		Account: &Account{ID: 709},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, 8, usageRepo.lastLog.CacheCreationTokens)
+	require.Equal(t, 2, usageRepo.lastLog.CacheReadTokens)
+	require.Equal(t, 8, usageRepo.lastLog.CacheCreation5mTokens)
+	require.Zero(t, usageRepo.lastLog.CacheCreation1hTokens)
+}
+
+func TestGatewayServiceRecordUsageWithLongContext_PersistsSimulatedPromptCacheUsage(t *testing.T) {
+	usageRepo := &openAIRecordUsageBestEffortLogRepoStub{}
+	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})
+
+	err := svc.RecordUsageWithLongContext(context.Background(), &RecordUsageLongContextInput{
+		Result: &ForwardResult{
+			RequestID: "gateway_long_context_simulated_prompt_cache",
+			Usage: ClaudeUsage{
+				InputTokens:              12,
+				OutputTokens:             8,
+				CacheCreationInputTokens: 5,
+				CacheReadInputTokens:     3,
+				CacheCreation5mTokens:    5,
+			},
+			Model:    "claude-sonnet-4",
+			Duration: time.Second,
+		},
+		APIKey:                &APIKey{ID: 510, Quota: 100},
+		User:                  &User{ID: 610},
+		Account:               &Account{ID: 710},
+		LongContextThreshold:  200000,
+		LongContextMultiplier: 2,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, 5, usageRepo.lastLog.CacheCreationTokens)
+	require.Equal(t, 3, usageRepo.lastLog.CacheReadTokens)
+	require.Equal(t, 5, usageRepo.lastLog.CacheCreation5mTokens)
+	require.Zero(t, usageRepo.lastLog.CacheCreation1hTokens)
+}
+
 func TestGatewayServiceRecordUsage_ReasoningEffortNil(t *testing.T) {
 	usageRepo := &openAIRecordUsageBestEffortLogRepoStub{}
 	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -559,9 +559,10 @@ type GatewayService struct {
 	userGroupRateSF       singleflight.Group
 	modelsListCache       *gocache.Cache
 	modelsListCacheTTL    time.Duration
-	settingService        *SettingService
-	responseHeaderFilter  *responseheaders.CompiledHeaderFilter
-	debugModelRouting     atomic.Bool
+	settingService               *SettingService
+	promptCacheSimulationService *PromptCacheSimulationService
+	responseHeaderFilter         *responseheaders.CompiledHeaderFilter
+	debugModelRouting            atomic.Bool
 	debugClaudeMimic      atomic.Bool
 }
 
@@ -614,12 +615,13 @@ func NewGatewayService(
 		deferredService:      deferredService,
 		claudeTokenProvider:  claudeTokenProvider,
 		sessionLimitCache:    sessionLimitCache,
-		rpmCache:             rpmCache,
-		userGroupRateCache:   gocache.New(userGroupRateTTL, time.Minute),
-		settingService:       settingService,
-		modelsListCache:      gocache.New(modelsListTTL, time.Minute),
-		modelsListCacheTTL:   modelsListTTL,
-		responseHeaderFilter: compileResponseHeaderFilter(cfg),
+		rpmCache:                    rpmCache,
+		userGroupRateCache:          gocache.New(userGroupRateTTL, time.Minute),
+		settingService:              settingService,
+		promptCacheSimulationService: NewPromptCacheSimulationService(settingService),
+		modelsListCache:             gocache.New(modelsListTTL, time.Minute),
+		modelsListCacheTTL:          modelsListTTL,
+		responseHeaderFilter:        compileResponseHeaderFilter(cfg),
 	}
 	svc.userGroupRateResolver = newUserGroupRateResolver(
 		userGroupRateRepo,
@@ -634,6 +636,129 @@ func NewGatewayService(
 }
 
 // GenerateSessionHash 从预解析请求计算粘性会话 hash
+func (s *GatewayService) derivePromptCacheSimulationSessionIdentity(parsed *ParsedRequest) string {
+	if parsed == nil {
+		return ""
+	}
+	if parsed.MetadataUserID != "" {
+		return "metadata:" + strings.TrimSpace(parsed.MetadataUserID)
+	}
+	if parsed.SessionContext != nil {
+		return strings.Join([]string{
+			"session",
+			strings.TrimSpace(parsed.SessionContext.ClientIP),
+			strings.TrimSpace(parsed.SessionContext.UserAgent),
+			strconv.FormatInt(parsed.SessionContext.APIKeyID, 10),
+		}, "|")
+	}
+	if len(parsed.Body) > 0 {
+		return "body:" + promptCacheSimulationHashBytes(parsed.Body)
+	}
+	return ""
+}
+
+func (s *GatewayService) promptCacheSimulationRequestPath(c *gin.Context) string {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.Request.URL.Path)
+}
+
+func (s *GatewayService) applyPromptCacheSimulationToUsage(ctx context.Context, requestPath string, parsed *ParsedRequest, model string, usage *ClaudeUsage) bool {
+	if s == nil || s.promptCacheSimulationService == nil || usage == nil || parsed == nil {
+		return false
+	}
+	if usage.CacheReadInputTokens > 0 || usage.CacheCreationInputTokens > 0 || usage.CacheCreation5mTokens > 0 || usage.CacheCreation1hTokens > 0 {
+		return false
+	}
+	decision, ok := s.promptCacheSimulationService.Simulate(ctx, requestPath, parsed, s.derivePromptCacheSimulationSessionIdentity(parsed), model, usage.InputTokens)
+	if !ok || decision == nil || !decision.HasSimulation() {
+		return false
+	}
+	usage.InputTokens = decision.InputTokens
+	if decision.CacheCreationInputTokens > 0 {
+		usage.CacheCreationInputTokens = decision.CacheCreationInputTokens
+		usage.CacheCreation5mTokens = decision.CacheCreation5mTokens
+		usage.CacheCreation1hTokens = 0
+	}
+	if decision.CacheReadInputTokens > 0 {
+		usage.CacheReadInputTokens = decision.CacheReadInputTokens
+	}
+	return true
+}
+
+func (s *GatewayService) applyPromptCacheSimulationToUsageJSON(ctx context.Context, requestPath string, parsed *ParsedRequest, model string, usageObj map[string]any, usage *ClaudeUsage) bool {
+	if usageObj == nil || usage == nil {
+		return false
+	}
+	if !s.applyPromptCacheSimulationToUsage(ctx, requestPath, parsed, model, usage) {
+		return false
+	}
+	usageObj["input_tokens"] = float64(usage.InputTokens)
+	if usage.CacheCreationInputTokens > 0 {
+		usageObj["cache_creation_input_tokens"] = float64(usage.CacheCreationInputTokens)
+		usageObj["cache_creation"] = map[string]any{
+			"ephemeral_5m_input_tokens": float64(usage.CacheCreation5mTokens),
+		}
+	}
+	if usage.CacheReadInputTokens > 0 {
+		usageObj["cache_read_input_tokens"] = float64(usage.CacheReadInputTokens)
+	}
+	return true
+}
+
+func (s *GatewayService) applyPromptCacheSimulationToSSEEvent(ctx context.Context, requestPath string, parsed *ParsedRequest, model string, event map[string]any, currentUsage *ClaudeUsage) bool {
+	if event == nil || parsed == nil || currentUsage == nil {
+		return false
+	}
+	eventType, _ := event["type"].(string)
+	if eventType != "message_start" {
+		return false
+	}
+	msg, _ := event["message"].(map[string]any)
+	usageObj, _ := msg["usage"].(map[string]any)
+	if usageObj == nil {
+		return false
+	}
+
+	eventUsage := *currentUsage
+	if v, ok := parseSSEUsageInt(usageObj["input_tokens"]); ok {
+		eventUsage.InputTokens = v
+	}
+	if v, ok := parseSSEUsageInt(usageObj["cache_creation_input_tokens"]); ok {
+		eventUsage.CacheCreationInputTokens = v
+	}
+	if v, ok := parseSSEUsageInt(usageObj["cache_read_input_tokens"]); ok {
+		eventUsage.CacheReadInputTokens = v
+	}
+	if cc, ok := usageObj["cache_creation"].(map[string]any); ok {
+		if v, ok := parseSSEUsageInt(cc["ephemeral_5m_input_tokens"]); ok {
+			eventUsage.CacheCreation5mTokens = v
+		}
+		if v, ok := parseSSEUsageInt(cc["ephemeral_1h_input_tokens"]); ok {
+			eventUsage.CacheCreation1hTokens = v
+		}
+	}
+
+	changed := s.applyPromptCacheSimulationToUsageJSON(ctx, requestPath, parsed, model, usageObj, &eventUsage)
+	if changed {
+		*currentUsage = eventUsage
+	}
+	return changed
+}
+
+func (s *GatewayService) parsePromptCacheSimulationUsageMap(body []byte) map[string]any {
+	if len(body) == 0 {
+		return nil
+	}
+	var response map[string]any
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil
+	}
+	usageObj, _ := response["usage"].(map[string]any)
+	return usageObj
+}
+
 func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 	if parsed == nil {
 		return ""
@@ -4520,7 +4645,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	var firstTokenMs *int
 	var clientDisconnect bool
 	if reqStream {
-		streamResult, err := s.handleStreamingResponse(ctx, resp, c, account, startTime, originalModel, reqModel, shouldMimicClaudeCode)
+		streamResult, err := s.handleStreamingResponse(ctx, resp, c, account, startTime, originalModel, reqModel, shouldMimicClaudeCode, parsed)
 		if err != nil {
 			if err.Error() == "have error in stream" {
 				return nil, &UpstreamFailoverError{
@@ -4533,7 +4658,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		firstTokenMs = streamResult.firstTokenMs
 		clientDisconnect = streamResult.clientDisconnect
 	} else {
-		usage, err = s.handleNonStreamingResponse(ctx, resp, c, account, originalModel, reqModel)
+		usage, err = s.handleNonStreamingResponse(ctx, resp, c, account, originalModel, reqModel, parsed)
 		if err != nil {
 			return nil, err
 		}
@@ -6501,7 +6626,7 @@ type streamingResult struct {
 	clientDisconnect bool // 客户端是否在流式传输过程中断开
 }
 
-func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel string, mimicClaudeCode bool) (*streamingResult, error) {
+func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel string, mimicClaudeCode bool, parsed *ParsedRequest) (*streamingResult, error) {
 	// 更新5h窗口状态
 	s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 
@@ -6683,6 +6808,8 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 				eventChanged = reconcileCachedTokens(u) || eventChanged
 			}
 		}
+
+		eventChanged = s.applyPromptCacheSimulationToSSEEvent(ctx, s.promptCacheSimulationRequestPath(c), parsed, originalModel, event, usage) || eventChanged
 
 		// Cache TTL Override: 重写 SSE 事件中的 cache_creation 分类
 		if account.IsCacheTTLOverrideEnabled() {
@@ -7070,7 +7197,7 @@ func rewriteCacheCreationJSON(usageObj map[string]any, target string) bool {
 	return true
 }
 
-func (s *GatewayService) handleNonStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, originalModel, mappedModel string) (*ClaudeUsage, error) {
+func (s *GatewayService) handleNonStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, originalModel, mappedModel string, parsed *ParsedRequest) (*ClaudeUsage, error) {
 	// 更新5h窗口状态
 	s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 
@@ -7113,6 +7240,18 @@ func (s *GatewayService) handleNonStreamingResponse(ctx context.Context, resp *h
 			response.Usage.CacheReadInputTokens = int(cachedTokens)
 			if newBody, err := sjson.SetBytes(body, "usage.cache_read_input_tokens", cachedTokens); err == nil {
 				body = newBody
+			}
+		}
+	}
+
+	if usageObj := s.parsePromptCacheSimulationUsageMap(body); usageObj != nil {
+		if s.applyPromptCacheSimulationToUsageJSON(ctx, s.promptCacheSimulationRequestPath(c), parsed, originalModel, usageObj, &response.Usage) {
+			var responseMap map[string]any
+			if err := json.Unmarshal(body, &responseMap); err == nil {
+				responseMap["usage"] = usageObj
+				if replacedBody, err := json.Marshal(responseMap); err == nil {
+					body = replacedBody
+				}
 			}
 		}
 	}

--- a/backend/internal/service/gateway_service_streaming_test.go
+++ b/backend/internal/service/gateway_service_streaming_test.go
@@ -42,7 +42,7 @@ func TestGatewayService_StreamingReusesScannerBufferAndStillParsesUsage(t *testi
 		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
 	}()
 
-	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false)
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false, nil)
 	_ = pr.Close()
 	require.NoError(t, err)
 	require.NotNil(t, result)

--- a/backend/internal/service/gateway_streaming_test.go
+++ b/backend/internal/service/gateway_streaming_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -152,7 +153,7 @@ func TestHandleStreamingResponse_CacheTokens(t *testing.T) {
 		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
 	}()
 
-	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false)
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false, nil)
 	_ = pr.Close()
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -179,16 +180,36 @@ func TestHandleStreamingResponse_EmptyStream(t *testing.T) {
 		_ = pw.Close()
 	}()
 
-	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false)
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false, nil)
 	_ = pr.Close()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing terminal event")
 	require.NotNil(t, result)
 }
 
-func TestHandleStreamingResponse_SpecialCharactersInJSON(t *testing.T) {
+func TestHandleStreamingResponse_PromptCacheSimulationPatchesMessageStartAndUsage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
 	svc := newMinimalGatewayService()
+	svc.settingService = NewSettingService(repo, nil)
+	svc.promptCacheSimulationService = NewPromptCacheSimulationService(svc.settingService)
+
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"model",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"metadata":{"user_id":"user-1"}
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -199,22 +220,73 @@ func TestHandleStreamingResponse_SpecialCharactersInJSON(t *testing.T) {
 
 	go func() {
 		defer func() { _ = pw.Close() }()
-		// 包含特殊字符的 content_block_delta（引号、换行、Unicode）
-		_, _ = pw.Write([]byte("data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello \\\"world\\\"\\n你好\"}}\n\n"))
-		_, _ = pw.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":5}}}\n\n"))
+		_, _ = pw.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0}}}\n\n"))
 		_, _ = pw.Write([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":3}}\n\n"))
 		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
 	}()
 
-	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false)
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false, parsed)
 	_ = pr.Close()
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotNil(t, result.usage)
-	require.Equal(t, 5, result.usage.InputTokens)
-	require.Equal(t, 3, result.usage.OutputTokens)
-
-	// 验证响应中包含转发的数据
-	body := rec.Body.String()
-	require.Contains(t, body, "content_block_delta", "响应应包含转发的 SSE 事件")
+	require.Zero(t, result.usage.InputTokens)
+	require.Equal(t, 10, result.usage.CacheCreationInputTokens)
+	require.Equal(t, 10, result.usage.CacheCreation5mTokens)
+	require.Zero(t, result.usage.CacheReadInputTokens)
+	require.Contains(t, rec.Body.String(), `"input_tokens":0`)
+	require.Contains(t, rec.Body.String(), `"cache_creation_input_tokens":10`)
+	require.Contains(t, rec.Body.String(), `"ephemeral_5m_input_tokens":10`)
 }
+
+func TestHandleStreamingResponse_PromptCacheSimulationPreservesUpstreamFieldsOnMessageStart(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := newMockSettingRepo()
+	data, err := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+
+	svc := newMinimalGatewayService()
+	svc.settingService = NewSettingService(repo, nil)
+	svc.promptCacheSimulationService = NewPromptCacheSimulationService(svc.settingService)
+
+	parsed, err := ParseGatewayRequest([]byte(`{
+		"model":"model",
+		"messages":[{"role":"user","content":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}]}],
+		"metadata":{"user_id":"user-1"}
+	}`), PlatformAnthropic)
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: pr}
+
+	go func() {
+		defer func() { _ = pw.Close() }()
+		_, _ = pw.Write([]byte("data: {\"type\":\"message_start\",\"message\":{\"usage\":{\"input_tokens\":10,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":2,\"cache_creation\":{\"ephemeral_5m_input_tokens\":4}}}}\n\n"))
+		_, _ = pw.Write([]byte("data: {\"type\":\"message_delta\",\"usage\":{\"output_tokens\":3}}\n\n"))
+		_, _ = pw.Write([]byte("data: [DONE]\n\n"))
+	}()
+
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false, parsed)
+	_ = pr.Close()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.usage)
+	require.Equal(t, 2, result.usage.CacheReadInputTokens)
+	require.Zero(t, result.usage.CacheCreationInputTokens)
+	require.Equal(t, 4, result.usage.CacheCreation5mTokens)
+	require.Contains(t, rec.Body.String(), `"cache_read_input_tokens":2`)
+	require.Contains(t, rec.Body.String(), `"ephemeral_5m_input_tokens":4`)
+	require.NotContains(t, rec.Body.String(), `"cache_creation_input_tokens":10`)
+}
+

--- a/backend/internal/service/prompt_cache_simulation.go
+++ b/backend/internal/service/prompt_cache_simulation.go
@@ -1,0 +1,320 @@
+package service
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cespare/xxhash/v2"
+	gocache "github.com/patrickmn/go-cache"
+	"github.com/tidwall/gjson"
+)
+
+type PromptCacheSimulationDecision struct {
+	InputTokens              int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+	CacheCreation5mTokens    int
+}
+
+func (d *PromptCacheSimulationDecision) HasSimulation() bool {
+	if d == nil {
+		return false
+	}
+	return d.CacheCreationInputTokens > 0 || d.CacheReadInputTokens > 0 || d.CacheCreation5mTokens > 0
+}
+
+type PromptCacheSimulationService struct {
+	settingService *SettingService
+	cache          *gocache.Cache
+}
+
+func NewPromptCacheSimulationService(settingService *SettingService) *PromptCacheSimulationService {
+	return &PromptCacheSimulationService{
+		settingService: settingService,
+		cache:          gocache.New(5*time.Minute, time.Minute),
+	}
+}
+
+func (s *PromptCacheSimulationService) Simulate(ctx context.Context, requestPath string, parsed *ParsedRequest, sessionIdentity, model string, inputTokens int) (*PromptCacheSimulationDecision, bool) {
+	if s == nil || s.settingService == nil || parsed == nil || inputTokens <= 0 {
+		return nil, false
+	}
+	if strings.TrimSpace(requestPath) != "/v1/messages" {
+		return nil, false
+	}
+	if !strings.EqualFold(strings.TrimSpace(parsed.Model), strings.TrimSpace(model)) {
+		return nil, false
+	}
+
+	settings, err := s.settingService.GetPromptCacheSimulationSettings(ctx)
+	if err != nil || settings == nil || !settings.Enabled {
+		return nil, false
+	}
+
+	scopeKey := buildPromptCacheSimulationScopeKey(sessionIdentity, model, parsed)
+	if scopeKey == "" {
+		return nil, false
+	}
+	decisionTTL := time.Duration(settings.TTLSeconds) * time.Second
+
+	if settings.SemanticFirst {
+		if semanticKey, ok := buildPromptCacheSimulationSemanticKey(parsed); ok {
+			cacheKey := "semantic|" + scopeKey + "|" + semanticKey
+			if _, hit := s.cache.Get(cacheKey); hit {
+				s.cache.Set(cacheKey, true, decisionTTL)
+				return &PromptCacheSimulationDecision{
+					InputTokens:          0,
+					CacheReadInputTokens: inputTokens,
+				}, true
+			}
+			s.cache.Set(cacheKey, true, decisionTTL)
+			return &PromptCacheSimulationDecision{
+				InputTokens:              0,
+				CacheCreationInputTokens: inputTokens,
+				CacheCreation5mTokens:    inputTokens,
+			}, true
+		}
+	}
+
+	fallbackKey := buildPromptCacheSimulationFallbackKey(parsed)
+	if fallbackKey == "" {
+		return nil, false
+	}
+	cacheKey := "fallback|" + scopeKey + "|" + fallbackKey
+	if _, hit := s.cache.Get(cacheKey); hit {
+		readTokens := promptCacheSimulationRatioTokens(inputTokens, settings.FallbackReadRatio)
+		if readTokens <= 0 {
+			return nil, false
+		}
+		remainingInputTokens := inputTokens - readTokens
+		if remainingInputTokens < 0 {
+			remainingInputTokens = 0
+		}
+		s.cache.Set(cacheKey, true, decisionTTL)
+		return &PromptCacheSimulationDecision{
+			InputTokens:          remainingInputTokens,
+			CacheReadInputTokens: readTokens,
+		}, true
+	}
+
+	createTokens := promptCacheSimulationRatioTokens(inputTokens, settings.FallbackWriteRatio)
+	if createTokens <= 0 {
+		return nil, false
+	}
+	remainingInputTokens := inputTokens - createTokens
+	if remainingInputTokens < 0 {
+		remainingInputTokens = 0
+	}
+	s.cache.Set(cacheKey, true, decisionTTL)
+	return &PromptCacheSimulationDecision{
+		InputTokens:              remainingInputTokens,
+		CacheCreationInputTokens: createTokens,
+		CacheCreation5mTokens:    createTokens,
+	}, true
+}
+
+func buildPromptCacheSimulationScopeKey(sessionIdentity, model string, parsed *ParsedRequest) string {
+	sessionIdentity = strings.TrimSpace(sessionIdentity)
+	model = strings.TrimSpace(model)
+	if sessionIdentity == "" && parsed != nil {
+		sessionIdentity = derivePromptCacheSimulationSessionIdentity(parsed)
+	}
+	if sessionIdentity == "" {
+		return ""
+	}
+	return sessionIdentity + "|model:" + model
+}
+
+func derivePromptCacheSimulationSessionIdentity(parsed *ParsedRequest) string {
+	if parsed == nil {
+		return ""
+	}
+	if parsed.MetadataUserID != "" {
+		return "metadata:" + strings.TrimSpace(parsed.MetadataUserID)
+	}
+	if parsed.SessionContext != nil {
+		return strings.Join([]string{
+			"session",
+			strings.TrimSpace(parsed.SessionContext.ClientIP),
+			strings.TrimSpace(parsed.SessionContext.UserAgent),
+			strconv.FormatInt(parsed.SessionContext.APIKeyID, 10),
+		}, "|")
+	}
+	if len(parsed.Body) > 0 {
+		return "body:" + promptCacheSimulationHashBytes(parsed.Body)
+	}
+	return ""
+}
+
+func buildPromptCacheSimulationFallbackKey(parsed *ParsedRequest) string {
+	cacheable := strings.TrimSpace(extractPromptCacheSimulationCacheableText(parsed))
+	if cacheable == "" {
+		return ""
+	}
+	return promptCacheSimulationHashString(cacheable)
+}
+
+func buildPromptCacheSimulationSemanticKey(parsed *ParsedRequest) (string, bool) {
+	full := strings.TrimSpace(extractPromptCacheSimulationFullText(parsed))
+	cacheable := strings.TrimSpace(extractPromptCacheSimulationCacheableText(parsed))
+	if full == "" || cacheable == "" || full != cacheable {
+		return "", false
+	}
+	return promptCacheSimulationHashString(full), true
+}
+
+func extractPromptCacheSimulationFullText(parsed *ParsedRequest) string {
+	if parsed == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	appendPromptCacheSimulationTools(&builder, parsed.Body, false)
+	appendPromptCacheSimulationSystem(&builder, parsed.System, false)
+	appendPromptCacheSimulationMessages(&builder, parsed.Messages, false)
+	return builder.String()
+}
+
+func extractPromptCacheSimulationCacheableText(parsed *ParsedRequest) string {
+	if parsed == nil {
+		return ""
+	}
+
+	var builder strings.Builder
+	appendPromptCacheSimulationTools(&builder, parsed.Body, true)
+	appendPromptCacheSimulationSystem(&builder, parsed.System, true)
+	appendPromptCacheSimulationMessages(&builder, parsed.Messages, true)
+	return builder.String()
+}
+
+func appendPromptCacheSimulationTools(builder *strings.Builder, body []byte, cacheableOnly bool) {
+	if builder == nil || len(body) == 0 {
+		return
+	}
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.Exists() || !tools.IsArray() {
+		return
+	}
+	tools.ForEach(func(_, value gjson.Result) bool {
+		if cacheableOnly && value.Get("cache_control.type").String() != "ephemeral" {
+			return true
+		}
+		builder.WriteString(value.Raw)
+		builder.WriteString("\n")
+		return true
+	})
+}
+
+func appendPromptCacheSimulationSystem(builder *strings.Builder, system any, cacheableOnly bool) {
+	if builder == nil || system == nil {
+		return
+	}
+	if !cacheableOnly {
+		builder.WriteString(extractPromptCacheSimulationTextValue(system))
+		return
+	}
+	parts, ok := system.([]any)
+	if !ok {
+		return
+	}
+	for _, part := range parts {
+		partMap, ok := part.(map[string]any)
+		if !ok {
+			continue
+		}
+		cc, ok := partMap["cache_control"].(map[string]any)
+		if !ok || cc["type"] != "ephemeral" {
+			continue
+		}
+		if text, _ := partMap["text"].(string); text != "" {
+			builder.WriteString(text)
+		}
+	}
+}
+
+func appendPromptCacheSimulationMessages(builder *strings.Builder, messages []any, cacheableOnly bool) {
+	if builder == nil {
+		return
+	}
+	for _, msg := range messages {
+		msgMap, ok := msg.(map[string]any)
+		if !ok {
+			continue
+		}
+		content, exists := msgMap["content"]
+		if !exists {
+			continue
+		}
+		if !cacheableOnly {
+			builder.WriteString(extractPromptCacheSimulationTextValue(content))
+			continue
+		}
+		parts, ok := content.([]any)
+		if !ok {
+			continue
+		}
+		for _, part := range parts {
+			partMap, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			cc, ok := partMap["cache_control"].(map[string]any)
+			if !ok || cc["type"] != "ephemeral" {
+				continue
+			}
+			if partMap["type"] == "text" {
+				if text, _ := partMap["text"].(string); text != "" {
+					builder.WriteString(text)
+				}
+			}
+		}
+	}
+}
+
+func extractPromptCacheSimulationTextValue(value any) string {
+	switch v := value.(type) {
+	case string:
+		return v
+	case []any:
+		var builder strings.Builder
+		for _, part := range v {
+			partMap, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			if partMap["type"] == "text" {
+				if text, _ := partMap["text"].(string); text != "" {
+					builder.WriteString(text)
+				}
+			}
+		}
+		return builder.String()
+	default:
+		return ""
+	}
+}
+
+func promptCacheSimulationRatioTokens(inputTokens int, ratio float64) int {
+	if inputTokens <= 0 || ratio <= 0 {
+		return 0
+	}
+	value := int(math.Round(float64(inputTokens) * ratio))
+	if value < 0 {
+		return 0
+	}
+	if value > inputTokens {
+		return inputTokens
+	}
+	return value
+}
+
+func promptCacheSimulationHashString(value string) string {
+	return promptCacheSimulationHashBytes([]byte(value))
+}
+
+func promptCacheSimulationHashBytes(value []byte) string {
+	return strconv.FormatUint(xxhash.Sum64(value), 36)
+}

--- a/backend/internal/service/prompt_cache_simulation_settings_test.go
+++ b/backend/internal/service/prompt_cache_simulation_settings_test.go
@@ -1,0 +1,207 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPromptCacheSimulationSettings_DefaultsWhenNotSet(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetPromptCacheSimulationSettings(context.Background())
+	require.NoError(t, err)
+	require.False(t, settings.Enabled)
+	require.True(t, settings.SemanticFirst)
+	require.InDelta(t, 0.7, settings.FallbackReadRatio, 0.000001)
+	require.InDelta(t, 0.2, settings.FallbackWriteRatio, 0.000001)
+	require.Equal(t, 300, settings.TTLSeconds)
+}
+
+func TestGetPromptCacheSimulationSettings_ReadsFromDB(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, _ := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      false,
+		FallbackReadRatio:  0.55,
+		FallbackWriteRatio: 0.15,
+		TTLSeconds:         600,
+	})
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetPromptCacheSimulationSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, settings.Enabled)
+	require.False(t, settings.SemanticFirst)
+	require.InDelta(t, 0.55, settings.FallbackReadRatio, 0.000001)
+	require.InDelta(t, 0.15, settings.FallbackWriteRatio, 0.000001)
+	require.Equal(t, 600, settings.TTLSeconds)
+}
+
+func TestGetPromptCacheSimulationSettings_NormalizesInvalidStoredValues(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, _ := json.Marshal(PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  1.4,
+		FallbackWriteRatio: 0.6,
+		TTLSeconds:         0,
+	})
+	repo.data[SettingKeyPromptCacheSimulationSettings] = string(data)
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetPromptCacheSimulationSettings(context.Background())
+	require.NoError(t, err)
+	require.InDelta(t, 1.0, settings.FallbackReadRatio, 0.000001)
+	require.InDelta(t, 0.0, settings.FallbackWriteRatio, 0.000001)
+	require.Equal(t, 60, settings.TTLSeconds)
+}
+
+func TestGetPromptCacheSimulationSettings_InvalidJSON_ReturnsDefaults(t *testing.T) {
+	repo := newMockSettingRepo()
+	repo.data[SettingKeyPromptCacheSimulationSettings] = "not-json"
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetPromptCacheSimulationSettings(context.Background())
+	require.NoError(t, err)
+	require.False(t, settings.Enabled)
+	require.True(t, settings.SemanticFirst)
+	require.InDelta(t, 0.7, settings.FallbackReadRatio, 0.000001)
+	require.InDelta(t, 0.2, settings.FallbackWriteRatio, 0.000001)
+	require.Equal(t, 300, settings.TTLSeconds)
+}
+
+func TestSetPromptCacheSimulationSettings_Success(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := NewSettingService(repo, &config.Config{})
+
+	err := svc.SetPromptCacheSimulationSettings(context.Background(), &PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.6,
+		FallbackWriteRatio: 0.25,
+		TTLSeconds:         300,
+	})
+	require.NoError(t, err)
+
+	settings, err := svc.GetPromptCacheSimulationSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, settings.Enabled)
+	require.True(t, settings.SemanticFirst)
+	require.InDelta(t, 0.6, settings.FallbackReadRatio, 0.000001)
+	require.InDelta(t, 0.25, settings.FallbackWriteRatio, 0.000001)
+	require.Equal(t, 300, settings.TTLSeconds)
+}
+
+func TestSetPromptCacheSimulationSettings_RejectsNil(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+	err := svc.SetPromptCacheSimulationSettings(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestSetPromptCacheSimulationSettings_RejectsOutOfRangeReadRatio(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	for _, ratio := range []float64{-0.1, 1.1} {
+		err := svc.SetPromptCacheSimulationSettings(context.Background(), &PromptCacheSimulationSettings{
+			Enabled:            true,
+			SemanticFirst:      true,
+			FallbackReadRatio:  ratio,
+			FallbackWriteRatio: 0.2,
+			TTLSeconds:         300,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fallback_read_ratio must be between 0-1")
+	}
+}
+
+func TestSetPromptCacheSimulationSettings_RejectsOutOfRangeWriteRatio(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	for _, ratio := range []float64{-0.1, 1.1} {
+		err := svc.SetPromptCacheSimulationSettings(context.Background(), &PromptCacheSimulationSettings{
+			Enabled:            true,
+			SemanticFirst:      true,
+			FallbackReadRatio:  0.5,
+			FallbackWriteRatio: ratio,
+			TTLSeconds:         300,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "fallback_write_ratio must be between 0-1")
+	}
+}
+
+func TestSetPromptCacheSimulationSettings_RejectsCombinedRatiosAboveOne(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	err := svc.SetPromptCacheSimulationSettings(context.Background(), &PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.8,
+		FallbackWriteRatio: 0.4,
+		TTLSeconds:         300,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "fallback ratios must sum to 1 or less")
+}
+
+func TestSetPromptCacheSimulationSettings_RejectsTTLSecondsOutOfRange(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	for _, ttlSeconds := range []int{0, 59, 3601} {
+		err := svc.SetPromptCacheSimulationSettings(context.Background(), &PromptCacheSimulationSettings{
+			Enabled:            true,
+			SemanticFirst:      true,
+			FallbackReadRatio:  0.5,
+			FallbackWriteRatio: 0.2,
+			TTLSeconds:         ttlSeconds,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "ttl_seconds must be between 60-3600")
+	}
+}
+
+func TestDefaultPromptCacheSimulationSettings(t *testing.T) {
+	settings := DefaultPromptCacheSimulationSettings()
+	require.False(t, settings.Enabled)
+	require.True(t, settings.SemanticFirst)
+	require.InDelta(t, 0.7, settings.FallbackReadRatio, 0.000001)
+	require.InDelta(t, 0.2, settings.FallbackWriteRatio, 0.000001)
+	require.Equal(t, 300, settings.TTLSeconds)
+}
+
+func TestPromptCacheSimulationSettings_JSONRoundTrip(t *testing.T) {
+	original := PromptCacheSimulationSettings{
+		Enabled:            true,
+		SemanticFirst:      false,
+		FallbackReadRatio:  0.45,
+		FallbackWriteRatio: 0.35,
+		TTLSeconds:         900,
+	}
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var decoded PromptCacheSimulationSettings
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	require.Equal(t, original, decoded)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	_, hasEnabled := raw["enabled"]
+	_, hasSemanticFirst := raw["semantic_first"]
+	_, hasReadRatio := raw["fallback_read_ratio"]
+	_, hasWriteRatio := raw["fallback_write_ratio"]
+	_, hasTTLSeconds := raw["ttl_seconds"]
+	require.True(t, hasEnabled)
+	require.True(t, hasSemanticFirst)
+	require.True(t, hasReadRatio)
+	require.True(t, hasWriteRatio)
+	require.True(t, hasTTLSeconds)
+}

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -1343,6 +1343,76 @@ func (s *SettingService) GetClaudeCodeVersionBounds(ctx context.Context) (min, m
 	return b.min, b.max
 }
 
+func (s *SettingService) GetPromptCacheSimulationSettings(ctx context.Context) (*PromptCacheSimulationSettings, error) {
+	value, err := s.settingRepo.GetValue(ctx, SettingKeyPromptCacheSimulationSettings)
+	if err != nil {
+		if errors.Is(err, ErrSettingNotFound) {
+			return DefaultPromptCacheSimulationSettings(), nil
+		}
+		return nil, fmt.Errorf("get prompt cache simulation settings: %w", err)
+	}
+	if value == "" {
+		return DefaultPromptCacheSimulationSettings(), nil
+	}
+
+	var settings PromptCacheSimulationSettings
+	if err := json.Unmarshal([]byte(value), &settings); err != nil {
+		return DefaultPromptCacheSimulationSettings(), nil
+	}
+
+	if settings.FallbackReadRatio < 0 {
+		settings.FallbackReadRatio = 0
+	}
+	if settings.FallbackReadRatio > 1 {
+		settings.FallbackReadRatio = 1
+	}
+	if settings.FallbackWriteRatio < 0 {
+		settings.FallbackWriteRatio = 0
+	}
+	if settings.FallbackWriteRatio > 1 {
+		settings.FallbackWriteRatio = 1
+	}
+	if settings.FallbackReadRatio+settings.FallbackWriteRatio > 1 {
+		settings.FallbackWriteRatio = 1 - settings.FallbackReadRatio
+		if settings.FallbackWriteRatio < 0 {
+			settings.FallbackWriteRatio = 0
+		}
+	}
+	if settings.TTLSeconds < 60 {
+		settings.TTLSeconds = 60
+	}
+	if settings.TTLSeconds > 3600 {
+		settings.TTLSeconds = 3600
+	}
+
+	return &settings, nil
+}
+
+func (s *SettingService) SetPromptCacheSimulationSettings(ctx context.Context, settings *PromptCacheSimulationSettings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+	if settings.FallbackReadRatio < 0 || settings.FallbackReadRatio > 1 {
+		return fmt.Errorf("fallback_read_ratio must be between 0-1")
+	}
+	if settings.FallbackWriteRatio < 0 || settings.FallbackWriteRatio > 1 {
+		return fmt.Errorf("fallback_write_ratio must be between 0-1")
+	}
+	if settings.FallbackReadRatio+settings.FallbackWriteRatio > 1 {
+		return fmt.Errorf("fallback ratios must sum to 1 or less")
+	}
+	if settings.TTLSeconds < 60 || settings.TTLSeconds > 3600 {
+		return fmt.Errorf("ttl_seconds must be between 60-3600")
+	}
+
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("marshal prompt cache simulation settings: %w", err)
+	}
+
+	return s.settingRepo.Set(ctx, SettingKeyPromptCacheSimulationSettings, string(data))
+}
+
 // GetRectifierSettings 获取请求整流器配置
 func (s *SettingService) GetRectifierSettings(ctx context.Context) (*RectifierSettings, error) {
 	value, err := s.settingRepo.GetValue(ctx, SettingKeyRectifierSettings)

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -239,6 +239,27 @@ func DefaultOverloadCooldownSettings() *OverloadCooldownSettings {
 	}
 }
 
+// PromptCacheSimulationSettings Prompt Caching 模拟配置
+// 仅用于 /v1/messages 的 Anthropic 风格缓存 usage 模拟。
+type PromptCacheSimulationSettings struct {
+	Enabled            bool    `json:"enabled"`
+	SemanticFirst      bool    `json:"semantic_first"`
+	FallbackReadRatio  float64 `json:"fallback_read_ratio"`
+	FallbackWriteRatio float64 `json:"fallback_write_ratio"`
+	TTLSeconds         int     `json:"ttl_seconds"`
+}
+
+// DefaultPromptCacheSimulationSettings 返回默认的 Prompt Caching 模拟配置。
+func DefaultPromptCacheSimulationSettings() *PromptCacheSimulationSettings {
+	return &PromptCacheSimulationSettings{
+		Enabled:            false,
+		SemanticFirst:      true,
+		FallbackReadRatio:  0.7,
+		FallbackWriteRatio: 0.2,
+		TTLSeconds:         300,
+	}
+}
+
 // DefaultBetaPolicySettings 返回默认的 Beta 策略配置
 func DefaultBetaPolicySettings() *BetaPolicySettings {
 	return &BetaPolicySettings{

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -20,6 +20,21 @@ SERVER_PORT=8080
 # Server mode: release or debug
 SERVER_MODE=release
 
+# ----------------------------------------------------------------------------
+# Application Image / Local Source Build
+# ----------------------------------------------------------------------------
+# Default runtime image. Leave unchanged to use the published image.
+# When using docker-compose.build.yml, this will default to sub2api:local.
+SUB2API_IMAGE=weishaw/sub2api:latest
+# Optional metadata for local docker builds
+SUB2API_VERSION=
+SUB2API_COMMIT=
+SUB2API_BUILD_DATE=
+
+# Optional Go module mirrors for docker local builds
+GOPROXY=https://goproxy.cn,direct
+GOSUMDB=sum.golang.google.cn
+
 # -----------------------------------------------------------------------------
 # Logging Configuration
 # 日志配置

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -65,6 +65,34 @@ docker compose -f docker-compose.local.yml logs sub2api | grep "admin password"
 # http://localhost:8080
 ```
 
+### Method 1.5: Build And Deploy Current Local Source
+
+If you need the running container to include your current unmerged local changes, build from the current repository source instead of pulling `weishaw/sub2api:latest`.
+
+```bash
+# From repository root
+cd deploy
+
+# Optional: create .env first
+cp .env.example .env
+
+# Build current source and start with local data directories
+docker compose -f docker-compose.local.yml -f docker-compose.build.yml up -d --build
+```
+
+This mode:
+- builds Go and frontend **inside Docker**,
+- does **not** require Go on the host,
+- tags the local image as `sub2api:local` by default,
+- then starts the same deployment stack against that locally built image.
+
+You can also prebuild explicitly:
+
+```bash
+./build_image.sh
+SUB2API_IMAGE=sub2api:local docker compose -f docker-compose.local.yml up -d
+```
+
 ### Method 2: Manual Deployment
 
 If you prefer manual control:

--- a/deploy/build_image.sh
+++ b/deploy/build_image.sh
@@ -5,9 +5,19 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-sub2api:local}"
 
-docker build -t sub2api:latest \
-    --build-arg GOPROXY=https://goproxy.cn,direct \
-    --build-arg GOSUMDB=sum.golang.google.cn \
+BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+COMMIT_VALUE="${COMMIT_VALUE:-$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || printf 'docker-local')}"
+VERSION_VALUE="${VERSION_VALUE:-}"
+
+DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1} docker build -t "${IMAGE_TAG}" \
+    --build-arg GOPROXY="${GOPROXY:-https://goproxy.cn,direct}" \
+    --build-arg GOSUMDB="${GOSUMDB:-sum.golang.google.cn}" \
+    --build-arg COMMIT="${COMMIT_VALUE}" \
+    --build-arg DATE="${BUILD_DATE}" \
+    --build-arg VERSION="${VERSION_VALUE}" \
     -f "${REPO_ROOT}/Dockerfile" \
     "${REPO_ROOT}"
+
+printf 'Built image: %s\n' "${IMAGE_TAG}"

--- a/deploy/docker-compose.build.yml
+++ b/deploy/docker-compose.build.yml
@@ -1,0 +1,25 @@
+# =============================================================================
+# Sub2API Docker Compose - Local Source Build Override
+# =============================================================================
+# Use this file together with docker-compose.local.yml / docker-compose.yml /
+# docker-compose.standalone.yml to build the application image from the current
+# repository source code instead of pulling a prebuilt remote image.
+#
+# Examples:
+#   docker compose -f docker-compose.local.yml -f docker-compose.build.yml up -d --build
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml up -d --build
+#   docker compose -f docker-compose.standalone.yml -f docker-compose.build.yml up -d --build
+# =============================================================================
+
+services:
+  sub2api:
+    image: ${SUB2API_IMAGE:-sub2api:local}
+    build:
+      context: ..
+      dockerfile: Dockerfile
+      args:
+        GOPROXY: ${GOPROXY:-https://goproxy.cn,direct}
+        GOSUMDB: ${GOSUMDB:-sum.golang.google.cn}
+        VERSION: ${SUB2API_VERSION:-}
+        COMMIT: ${SUB2API_COMMIT:-docker-local}
+        DATE: ${SUB2API_BUILD_DATE:-}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -24,7 +24,7 @@ services:
   # Sub2API Application
   # ===========================================================================
   sub2api:
-    image: weishaw/sub2api:latest
+    image: ${SUB2API_IMAGE:-weishaw/sub2api:latest}
     container_name: sub2api
     restart: unless-stopped
     ulimits:

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -12,7 +12,7 @@
 
 services:
   sub2api:
-    image: weishaw/sub2api:latest
+    image: ${SUB2API_IMAGE:-weishaw/sub2api:latest}
     container_name: sub2api
     restart: unless-stopped
     ulimits:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   # Sub2API Application
   # ===========================================================================
   sub2api:
-    image: weishaw/sub2api:latest
+    image: ${SUB2API_IMAGE:-weishaw/sub2api:latest}
     container_name: sub2api
     restart: unless-stopped
     ulimits:

--- a/frontend/src/api/admin/__tests__/settings.spec.ts
+++ b/frontend/src/api/admin/__tests__/settings.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { mockGet, mockPut } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPut: vi.fn()
+}))
+
+vi.mock('../../client', () => ({
+  apiClient: {
+    get: mockGet,
+    put: mockPut
+  }
+}))
+
+import settingsAPI, * as settingsModule from '../settings'
+
+describe('admin settings prompt cache simulation api', () => {
+  beforeEach(() => {
+    mockGet.mockReset()
+    mockPut.mockReset()
+  })
+
+  it('gets prompt cache simulation settings from the dedicated endpoint', async () => {
+    const expected = {
+      enabled: true,
+      semantic_first: true,
+      fallback_read_ratio: 0.7,
+      fallback_write_ratio: 0.2,
+      ttl_seconds: 300
+    }
+    mockGet.mockResolvedValue({ data: expected })
+
+    const getPromptCacheSimulationSettings = (settingsModule as Record<string, any>).getPromptCacheSimulationSettings
+
+    expect(getPromptCacheSimulationSettings).toBeTypeOf('function')
+    await expect(getPromptCacheSimulationSettings()).resolves.toEqual(expected)
+    expect(mockGet).toHaveBeenCalledWith('/admin/settings/prompt-cache-simulation')
+    expect((settingsAPI as Record<string, any>).getPromptCacheSimulationSettings).toBe(getPromptCacheSimulationSettings)
+  })
+
+  it('updates prompt cache simulation settings through the dedicated endpoint', async () => {
+    const payload = {
+      enabled: true,
+      semantic_first: false,
+      fallback_read_ratio: 0.5,
+      fallback_write_ratio: 0.25,
+      ttl_seconds: 600
+    }
+    mockPut.mockResolvedValue({ data: payload })
+
+    const updatePromptCacheSimulationSettings = (settingsModule as Record<string, any>).updatePromptCacheSimulationSettings
+
+    expect(updatePromptCacheSimulationSettings).toBeTypeOf('function')
+    await expect(updatePromptCacheSimulationSettings(payload)).resolves.toEqual(payload)
+    expect(mockPut).toHaveBeenCalledWith('/admin/settings/prompt-cache-simulation', payload)
+    expect((settingsAPI as Record<string, any>).updatePromptCacheSimulationSettings).toBe(updatePromptCacheSimulationSettings)
+  })
+})

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -306,6 +306,31 @@ export async function updateStreamTimeoutSettings(
   return data
 }
 
+// ==================== Prompt Cache Simulation Settings ====================
+
+export interface PromptCacheSimulationSettings {
+  enabled: boolean
+  semantic_first: boolean
+  fallback_read_ratio: number
+  fallback_write_ratio: number
+  ttl_seconds: number
+}
+
+export async function getPromptCacheSimulationSettings(): Promise<PromptCacheSimulationSettings> {
+  const { data } = await apiClient.get<PromptCacheSimulationSettings>('/admin/settings/prompt-cache-simulation')
+  return data
+}
+
+export async function updatePromptCacheSimulationSettings(
+  settings: PromptCacheSimulationSettings
+): Promise<PromptCacheSimulationSettings> {
+  const { data } = await apiClient.put<PromptCacheSimulationSettings>(
+    '/admin/settings/prompt-cache-simulation',
+    settings
+  )
+  return data
+}
+
 // ==================== Rectifier Settings ====================
 
 /**
@@ -532,6 +557,8 @@ export const settingsAPI = {
   updateOverloadCooldownSettings,
   getStreamTimeoutSettings,
   updateStreamTimeoutSettings,
+  getPromptCacheSimulationSettings,
+  updatePromptCacheSimulationSettings,
   getRectifierSettings,
   updateRectifierSettings,
   getBetaPolicySettings,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4415,6 +4415,22 @@ export default {
         saved: 'Stream timeout settings saved',
         saveFailed: 'Failed to save stream timeout settings'
       },
+      promptCacheSimulation: {
+        title: 'Prompt Cache Simulation',
+        description: 'Simulate Anthropic-style prompt caching usage for /v1/messages when upstream does not provide authoritative cache fields.',
+        enabled: 'Enable Prompt Cache Simulation',
+        enabledHint: 'Applies semantic-first simulation with ratio fallback on the Anthropic-compatible messages endpoint.',
+        semanticFirst: 'Prefer Semantic Simulation',
+        semanticFirstHint: 'Use semantic matching first, then fall back to configured ratios only when semantic simulation is unavailable.',
+        fallbackReadRatio: 'Fallback Read Ratio',
+        fallbackReadRatioHint: 'Ratio used for cache_read_input_tokens on fallback cache hits.',
+        fallbackWriteRatio: 'Fallback Write Ratio',
+        fallbackWriteRatioHint: 'Ratio used for cache_creation_input_tokens on fallback cache writes.',
+        ttlSeconds: 'Cache TTL (seconds)',
+        ttlSecondsHint: 'TTL for simulated prompt cache entries.',
+        saved: 'Prompt cache simulation settings saved',
+        saveFailed: 'Failed to save prompt cache simulation settings'
+      },
       rectifier: {
         title: 'Request Rectifier',
         description: 'Automatically fix request parameters and retry when upstream returns specific errors',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4579,6 +4579,22 @@ export default {
         saved: '流超时设置保存成功',
         saveFailed: '保存流超时设置失败'
       },
+      promptCacheSimulation: {
+        title: '缓存模拟',
+        description: '当上游未返回权威缓存字段时，为 /v1/messages 模拟 Anthropic 风格的 Prompt Caching 用量字段。',
+        enabled: '启用缓存模拟',
+        enabledHint: '仅作用于 Anthropic 兼容的 messages 接口，优先走语义模拟，失败时再回退到比例模拟。',
+        semanticFirst: '优先语义模拟',
+        semanticFirstHint: '先尝试按语义匹配缓存命中，只有无法可靠模拟时才使用回退比例。',
+        fallbackReadRatio: '回退读取比例',
+        fallbackReadRatioHint: '回退命中时用于 cache_read_input_tokens 的比例。',
+        fallbackWriteRatio: '回退写入比例',
+        fallbackWriteRatioHint: '回退写入时用于 cache_creation_input_tokens 的比例。',
+        ttlSeconds: '缓存 TTL（秒）',
+        ttlSecondsHint: '模拟缓存条目的生存时间。',
+        saved: '缓存模拟设置保存成功',
+        saveFailed: '保存缓存模拟设置失败'
+      },
       rectifier: {
         title: '请求整流器',
         description: '当上游返回特定错误时，自动修正请求参数并重试，提高请求成功率',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -393,6 +393,135 @@
           </div>
         </div>
 
+        <!-- Prompt Cache Simulation Settings -->
+        <div class="card">
+          <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+              {{ t('admin.settings.promptCacheSimulation.title') }}
+            </h2>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {{ t('admin.settings.promptCacheSimulation.description') }}
+            </p>
+          </div>
+          <div class="space-y-5 p-6">
+            <div v-if="promptCacheSimulationLoading" class="flex items-center gap-2 text-gray-500">
+              <div class="h-4 w-4 animate-spin rounded-full border-b-2 border-primary-600"></div>
+              {{ t('common.loading') }}
+            </div>
+
+            <template v-else>
+              <div class="flex items-center justify-between">
+                <div>
+                  <label class="font-medium text-gray-900 dark:text-white">{{
+                    t('admin.settings.promptCacheSimulation.enabled')
+                  }}</label>
+                  <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ t('admin.settings.promptCacheSimulation.enabledHint') }}
+                  </p>
+                </div>
+                <Toggle v-model="promptCacheSimulationForm.enabled" />
+              </div>
+
+              <div
+                v-if="promptCacheSimulationForm.enabled"
+                class="space-y-4 border-t border-gray-100 pt-4 dark:border-dark-700"
+              >
+                <div class="flex items-center justify-between">
+                  <div>
+                    <label class="text-sm font-medium text-gray-700 dark:text-gray-300">{{
+                      t('admin.settings.promptCacheSimulation.semanticFirst')
+                    }}</label>
+                    <p class="text-xs text-gray-500 dark:text-gray-400">
+                      {{ t('admin.settings.promptCacheSimulation.semanticFirstHint') }}
+                    </p>
+                  </div>
+                  <Toggle v-model="promptCacheSimulationForm.semantic_first" />
+                </div>
+
+                <div>
+                  <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ t('admin.settings.promptCacheSimulation.fallbackReadRatio') }}
+                  </label>
+                  <input
+                    v-model.number="promptCacheSimulationForm.fallback_read_ratio"
+                    type="number"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    class="input w-40"
+                  />
+                  <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{ t('admin.settings.promptCacheSimulation.fallbackReadRatioHint') }}
+                  </p>
+                </div>
+
+                <div>
+                  <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ t('admin.settings.promptCacheSimulation.fallbackWriteRatio') }}
+                  </label>
+                  <input
+                    v-model.number="promptCacheSimulationForm.fallback_write_ratio"
+                    type="number"
+                    min="0"
+                    max="1"
+                    step="0.01"
+                    class="input w-40"
+                  />
+                  <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{ t('admin.settings.promptCacheSimulation.fallbackWriteRatioHint') }}
+                  </p>
+                </div>
+
+                <div>
+                  <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {{ t('admin.settings.promptCacheSimulation.ttlSeconds') }}
+                  </label>
+                  <input
+                    v-model.number="promptCacheSimulationForm.ttl_seconds"
+                    type="number"
+                    min="1"
+                    class="input w-40"
+                  />
+                  <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{ t('admin.settings.promptCacheSimulation.ttlSecondsHint') }}
+                  </p>
+                </div>
+              </div>
+
+              <div class="flex justify-end border-t border-gray-100 pt-4 dark:border-dark-700">
+                <button
+                  type="button"
+                  @click="savePromptCacheSimulationSettings"
+                  :disabled="promptCacheSimulationSaving"
+                  class="btn btn-primary btn-sm"
+                >
+                  <svg
+                    v-if="promptCacheSimulationSaving"
+                    class="mr-1 h-4 w-4 animate-spin"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      class="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      stroke-width="4"
+                    ></circle>
+                    <path
+                      class="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    ></path>
+                  </svg>
+                  {{ promptCacheSimulationSaving ? t('common.saving') : t('common.save') }}
+                </button>
+              </div>
+            </template>
+          </div>
+        </div>
+
         <!-- Request Rectifier Settings -->
         <div class="card">
           <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
@@ -1883,6 +2012,17 @@ const streamTimeoutForm = reactive({
   threshold_window_minutes: 10
 })
 
+// Prompt Cache Simulation 状态
+const promptCacheSimulationLoading = ref(true)
+const promptCacheSimulationSaving = ref(false)
+const promptCacheSimulationForm = reactive({
+  enabled: true,
+  semantic_first: true,
+  fallback_read_ratio: 0.7,
+  fallback_write_ratio: 0.2,
+  ttl_seconds: 300
+})
+
 // Rectifier 状态
 const rectifierLoading = ref(true)
 const rectifierSaving = ref(false)
@@ -2477,6 +2617,39 @@ async function saveStreamTimeoutSettings() {
   }
 }
 
+async function loadPromptCacheSimulationSettings() {
+  promptCacheSimulationLoading.value = true
+  try {
+    const settings = await adminAPI.settings.getPromptCacheSimulationSettings()
+    Object.assign(promptCacheSimulationForm, settings)
+  } catch (error: any) {
+    console.error('Failed to load prompt cache simulation settings:', error)
+  } finally {
+    promptCacheSimulationLoading.value = false
+  }
+}
+
+async function savePromptCacheSimulationSettings() {
+  promptCacheSimulationSaving.value = true
+  try {
+    const updated = await adminAPI.settings.updatePromptCacheSimulationSettings({
+      enabled: promptCacheSimulationForm.enabled,
+      semantic_first: promptCacheSimulationForm.semantic_first,
+      fallback_read_ratio: promptCacheSimulationForm.fallback_read_ratio,
+      fallback_write_ratio: promptCacheSimulationForm.fallback_write_ratio,
+      ttl_seconds: promptCacheSimulationForm.ttl_seconds
+    })
+    Object.assign(promptCacheSimulationForm, updated)
+    appStore.showSuccess(t('admin.settings.promptCacheSimulation.saved'))
+  } catch (error: any) {
+    appStore.showError(
+      t('admin.settings.promptCacheSimulation.saveFailed') + ': ' + (error.message || t('common.unknownError'))
+    )
+  } finally {
+    promptCacheSimulationSaving.value = false
+  }
+}
+
 // Rectifier 方法
 async function loadRectifierSettings() {
   rectifierLoading.value = true
@@ -2567,6 +2740,7 @@ onMounted(() => {
   loadAdminApiKey()
   loadOverloadCooldownSettings()
   loadStreamTimeoutSettings()
+  loadPromptCacheSimulationSettings()
   loadRectifierSettings()
   loadBetaPolicySettings()
 })

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import SettingsView from '../SettingsView.vue'
+
+const {
+  getSettings,
+  updateSettings,
+  getAdminApiKey,
+  deleteAdminApiKey,
+  regenerateAdminApiKey,
+  testSmtpConnection,
+  sendTestEmail,
+  getOverloadCooldownSettings,
+  updateOverloadCooldownSettings,
+  getStreamTimeoutSettings,
+  updateStreamTimeoutSettings,
+  getPromptCacheSimulationSettings,
+  updatePromptCacheSimulationSettings,
+  getRectifierSettings,
+  updateRectifierSettings,
+  getBetaPolicySettings,
+  updateBetaPolicySettings,
+  getGroups,
+  fetchPublicSettings,
+  fetchAdminSettings,
+  showSuccess,
+  showError,
+  copyToClipboard
+} = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  updateSettings: vi.fn(),
+  getAdminApiKey: vi.fn(),
+  deleteAdminApiKey: vi.fn(),
+  regenerateAdminApiKey: vi.fn(),
+  testSmtpConnection: vi.fn(),
+  sendTestEmail: vi.fn(),
+  getOverloadCooldownSettings: vi.fn(),
+  updateOverloadCooldownSettings: vi.fn(),
+  getStreamTimeoutSettings: vi.fn(),
+  updateStreamTimeoutSettings: vi.fn(),
+  getPromptCacheSimulationSettings: vi.fn(),
+  updatePromptCacheSimulationSettings: vi.fn(),
+  getRectifierSettings: vi.fn(),
+  updateRectifierSettings: vi.fn(),
+  getBetaPolicySettings: vi.fn(),
+  updateBetaPolicySettings: vi.fn(),
+  getGroups: vi.fn(),
+  fetchPublicSettings: vi.fn(),
+  fetchAdminSettings: vi.fn(),
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  copyToClipboard: vi.fn()
+}))
+
+vi.mock('@/api', () => ({
+  adminAPI: {
+    settings: {
+      getSettings,
+      updateSettings,
+      getAdminApiKey,
+      deleteAdminApiKey,
+      regenerateAdminApiKey,
+      testSmtpConnection,
+      sendTestEmail,
+      getOverloadCooldownSettings,
+      updateOverloadCooldownSettings,
+      getStreamTimeoutSettings,
+      updateStreamTimeoutSettings,
+      getPromptCacheSimulationSettings,
+      updatePromptCacheSimulationSettings,
+      getRectifierSettings,
+      updateRectifierSettings,
+      getBetaPolicySettings,
+      updateBetaPolicySettings
+    },
+    groups: {
+      getAll: getGroups
+    }
+  }
+}))
+
+vi.mock('@/stores', () => ({
+  useAppStore: () => ({
+    showSuccess,
+    showError,
+    fetchPublicSettings
+  })
+}))
+
+vi.mock('@/stores/adminSettings', () => ({
+  useAdminSettingsStore: () => ({
+    fetch: fetchAdminSettings
+  })
+}))
+
+vi.mock('@/composables/useClipboard', () => ({
+  useClipboard: () => ({
+    copyToClipboard
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+const createSettingsResponse = () => ({
+  registration_enabled: true,
+  email_verify_enabled: false,
+  registration_email_suffix_whitelist: [],
+  promo_code_enabled: true,
+  password_reset_enabled: false,
+  frontend_url: '',
+  invitation_code_enabled: false,
+  totp_enabled: false,
+  totp_encryption_key_configured: false,
+  smtp_host: '',
+  smtp_port: 587,
+  smtp_username: '',
+  smtp_password_configured: false,
+  smtp_from_email: '',
+  smtp_from_name: '',
+  smtp_use_tls: true,
+  turnstile_enabled: false,
+  turnstile_site_key: '',
+  turnstile_secret_key_configured: false,
+  linuxdo_connect_enabled: false,
+  linuxdo_connect_client_id: '',
+  linuxdo_connect_client_secret_configured: false,
+  linuxdo_connect_redirect_url: '',
+  site_name: 'Sub2API',
+  site_logo: '',
+  site_subtitle: '',
+  api_base_url: '',
+  contact_info: '',
+  doc_url: '',
+  home_content: '',
+  hide_ccs_import_button: false,
+  purchase_subscription_enabled: false,
+  purchase_subscription_url: '',
+  sora_client_enabled: false,
+  custom_menu_items: [],
+  default_concurrency: 1,
+  default_balance: 0,
+  default_subscriptions: [],
+  enable_model_fallback: false,
+  fallback_model_anthropic: '',
+  fallback_model_openai: '',
+  fallback_model_gemini: '',
+  fallback_model_antigravity: '',
+  enable_identity_patch: false,
+  identity_patch_prompt: '',
+  ops_monitoring_enabled: false,
+  ops_realtime_monitoring_enabled: false,
+  ops_query_mode_default: 'auto',
+  ops_metrics_interval_seconds: 60,
+  min_claude_code_version: '',
+  max_claude_code_version: '',
+  allow_ungrouped_key_scheduling: false,
+  backend_mode_enabled: false
+})
+
+const AppLayoutStub = { template: '<div><slot /></div>' }
+const BackupSettingsStub = { template: '<div />' }
+const DataManagementSettingsStub = { template: '<div />' }
+const IconStub = { template: '<span />' }
+const GroupBadgeStub = { template: '<span />' }
+const GroupOptionItemStub = { template: '<span />' }
+const ImageUploadStub = { template: '<div />' }
+const SelectStub = {
+  props: ['modelValue', 'options'],
+  emits: ['update:modelValue'],
+  template: '<select />'
+}
+const ToggleStub = {
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template: '<button type="button" @click="$emit(\'update:modelValue\', !modelValue)">{{ modelValue }}</button>'
+}
+
+function mountView() {
+  return mount(SettingsView, {
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        BackupSettings: BackupSettingsStub,
+        DataManagementSettings: DataManagementSettingsStub,
+        Icon: IconStub,
+        GroupBadge: GroupBadgeStub,
+        GroupOptionItem: GroupOptionItemStub,
+        ImageUpload: ImageUploadStub,
+        Select: SelectStub,
+        Toggle: ToggleStub
+      }
+    }
+  })
+}
+
+describe('admin SettingsView prompt cache simulation card', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    getSettings.mockResolvedValue(createSettingsResponse())
+    getGroups.mockResolvedValue([])
+    getAdminApiKey.mockResolvedValue({ exists: false, masked_key: '' })
+    getOverloadCooldownSettings.mockResolvedValue({ enabled: true, cooldown_minutes: 10 })
+    getStreamTimeoutSettings.mockResolvedValue({
+      enabled: true,
+      action: 'temp_unsched',
+      temp_unsched_minutes: 5,
+      threshold_count: 3,
+      threshold_window_minutes: 10
+    })
+    getRectifierSettings.mockResolvedValue({
+      enabled: true,
+      thinking_signature_enabled: true,
+      thinking_budget_enabled: true
+    })
+    getBetaPolicySettings.mockResolvedValue({ rules: [] })
+    getPromptCacheSimulationSettings.mockResolvedValue({
+      enabled: true,
+      semantic_first: true,
+      fallback_read_ratio: 0.7,
+      fallback_write_ratio: 0.2,
+      ttl_seconds: 300
+    })
+    updatePromptCacheSimulationSettings.mockImplementation(async (payload) => payload)
+  })
+
+  it('loads dedicated prompt cache simulation settings on mount', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(getPromptCacheSimulationSettings).toHaveBeenCalledTimes(1)
+
+    await wrapper.findAll('button').find((button) => button.text().includes('admin.settings.tabs.gateway'))?.trigger('click')
+    await flushPromises()
+
+    const promptCacheCard = wrapper.findAll('.card').find((card) =>
+      card.text().includes('admin.settings.promptCacheSimulation.title')
+    )
+
+    expect(promptCacheCard?.exists()).toBe(true)
+    expect(promptCacheCard?.findAll('input[type="number"]')).toHaveLength(3)
+  })
+
+  it('saves dedicated prompt cache simulation settings without using the main form submit', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    await wrapper.findAll('button').find((button) => button.text().includes('admin.settings.tabs.gateway'))?.trigger('click')
+    await flushPromises()
+
+    const promptCacheCard = wrapper.findAll('.card').find((card) =>
+      card.text().includes('admin.settings.promptCacheSimulation.title')
+    )
+
+    expect(promptCacheCard?.exists()).toBe(true)
+
+    const numberInputs = promptCacheCard!.findAll('input[type="number"]')
+    await numberInputs[0].setValue('0.55')
+    await numberInputs[1].setValue('0.25')
+    await numberInputs[2].setValue('600')
+
+    await promptCacheCard!.findAll('button').find((button) => button.text().includes('common.save'))?.trigger('click')
+    await flushPromises()
+
+    expect(updatePromptCacheSimulationSettings).toHaveBeenCalledWith({
+      enabled: true,
+      semantic_first: true,
+      fallback_read_ratio: 0.55,
+      fallback_write_ratio: 0.25,
+      ttl_seconds: 600
+    })
+    expect(updateSettings).not.toHaveBeenCalled()
+    expect(showSuccess).toHaveBeenCalledWith('admin.settings.promptCacheSimulation.saved')
+  })
+})


### PR DESCRIPTION
Normalize /v1/messages cache usage when upstream gateways omit Anthropic prompt caching fields so client responses, usage logs, and billing stay aligned. Add admin controls and Docker source-build deployment support so the feature can be tuned and validated without a local Go toolchain.