### PR TITLE
fix(perf): cut admin account and group overhead for large pools

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -250,6 +250,26 @@ func (h *AccountHandler) List(c *gin.Context) {
 		return
 	}
 
+	if lite {
+		items := make([]*dto.Account, len(accounts))
+		for i := range accounts {
+			items[i] = dto.AccountFromService(&accounts[i])
+		}
+
+		etag := buildAccountsListETag(items, total, page, pageSize, platform, accountType, status, search, true)
+		if etag != "" {
+			c.Header("ETag", etag)
+			c.Header("Vary", "If-None-Match")
+			if ifNoneMatchMatched(c.GetHeader("If-None-Match"), etag) {
+				c.Status(http.StatusNotModified)
+				return
+			}
+		}
+
+		response.Paginated(c, items, total, page, pageSize)
+		return
+	}
+
 	// Get current concurrency counts for all accounts
 	accountIDs := make([]int64, len(accounts))
 	for i, acc := range accounts {
@@ -380,22 +400,22 @@ func (h *AccountHandler) List(c *gin.Context) {
 }
 
 func buildAccountsListETag(
-	items []AccountWithConcurrency,
+	items any,
 	total int64,
 	page, pageSize int,
 	platform, accountType, status, search string,
 	lite bool,
 ) string {
 	payload := struct {
-		Total       int64                    `json:"total"`
-		Page        int                      `json:"page"`
-		PageSize    int                      `json:"page_size"`
-		Platform    string                   `json:"platform"`
-		AccountType string                   `json:"type"`
-		Status      string                   `json:"status"`
-		Search      string                   `json:"search"`
-		Lite        bool                     `json:"lite"`
-		Items       []AccountWithConcurrency `json:"items"`
+		Total       int64  `json:"total"`
+		Page        int    `json:"page"`
+		PageSize    int    `json:"page_size"`
+		Platform    string `json:"platform"`
+		AccountType string `json:"type"`
+		Status      string `json:"status"`
+		Search      string `json:"search"`
+		Lite        bool   `json:"lite"`
+		Items       any    `json:"items"`
 	}{
 		Total:       total,
 		Page:        page,

--- a/backend/internal/handler/admin/account_handler_list_lite_test.go
+++ b/backend/internal/handler/admin/account_handler_list_lite_test.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func setupAccountListRouter(adminSvc *stubAdminService) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(gin.Recovery())
+	handler := NewAccountHandler(adminSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	router.GET("/api/v1/admin/accounts", handler.List)
+	return router
+}
+
+func TestAccountHandlerList_LiteSkipsHeavyRuntimeMetrics(t *testing.T) {
+	now := time.Now().UTC()
+	adminSvc := newStubAdminService()
+	adminSvc.accounts = []service.Account{{
+		ID:          9,
+		Name:        "heavy-account",
+		Platform:    service.PlatformAnthropic,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 8,
+		Extra: map[string]any{
+			"window_cost_limit":            25.0,
+			"max_sessions":                 4,
+			"session_idle_timeout_minutes": 15,
+			"base_rpm":                     30,
+		},
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}
+
+	router := setupAccountListRouter(adminSvc)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts?lite=1", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body struct {
+		Code int `json:"code"`
+		Data struct {
+			Items []map[string]any `json:"items"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, 0, body.Code)
+	require.Len(t, body.Data.Items, 1)
+	require.NotContains(t, body.Data.Items[0], "current_concurrency")
+	require.NotContains(t, body.Data.Items[0], "current_window_cost")
+	require.NotContains(t, body.Data.Items[0], "active_sessions")
+	require.NotContains(t, body.Data.Items[0], "current_rpm")
+}

--- a/backend/internal/pkg/logger/logger.go
+++ b/backend/internal/pkg/logger/logger.go
@@ -47,6 +47,7 @@ var (
 	sugar         atomic.Pointer[zap.SugaredLogger]
 	atomicLevel   zap.AtomicLevel
 	initOptions   InitOptions
+	activeClosers []io.Closer
 	currentSink   atomic.Value // sinkState
 	stdLogUndo    func()
 	bootstrapOnce sync.Once
@@ -72,16 +73,18 @@ func Init(options InitOptions) error {
 
 func initLocked(options InitOptions) error {
 	normalized := options.normalized()
-	zl, al, err := buildLogger(normalized)
+	zl, al, closers, err := buildLogger(normalized)
 	if err != nil {
 		return err
 	}
 
 	prev := global.Load()
+	prevClosers := activeClosers
 	global.Store(zl)
 	sugar.Store(zl.Sugar())
 	atomicLevel = al
 	initOptions = normalized
+	activeClosers = closers
 
 	bridgeSlogLocked()
 	bridgeStdLogLocked()
@@ -89,6 +92,7 @@ func initLocked(options InitOptions) error {
 	if prev != nil {
 		_ = prev.Sync()
 	}
+	closeClosers(prevClosers)
 	return nil
 }
 
@@ -205,6 +209,19 @@ func Sync() {
 	}
 }
 
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if l := global.Load(); l != nil {
+		_ = l.Sync()
+	}
+	closeClosers(activeClosers)
+	activeClosers = nil
+	global.Store(nil)
+	sugar.Store(nil)
+}
+
 func bridgeStdLogLocked() {
 	if stdLogUndo != nil {
 		stdLogUndo()
@@ -238,7 +255,7 @@ func bridgeSlogLocked() {
 	slog.SetDefault(slog.New(newSlogZapHandler(base.Named("slog"))))
 }
 
-func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
+func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, []io.Closer, error) {
 	level, _ := parseLevel(options.Level)
 	atomic := zap.NewAtomicLevelAt(level)
 
@@ -265,6 +282,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 
 	sinkCore := newSinkCore()
 	cores := make([]zapcore.Core, 0, 3)
+	closers := make([]io.Closer, 0, 1)
 
 	if options.Output.ToStdout {
 		infoPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
@@ -278,7 +296,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 	}
 
 	if options.Output.ToFile {
-		fileCore, filePath, fileErr := buildFileCore(enc, atomic, options)
+		fileCore, fileCloser, filePath, fileErr := buildFileCore(enc, atomic, options)
 		if fileErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "time=%s level=WARN msg=\"日志文件输出初始化失败，降级为仅标准输出\" path=%s err=%v\n",
 				time.Now().Format(time.RFC3339Nano),
@@ -287,6 +305,9 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 			)
 		} else {
 			cores = append(cores, fileCore)
+			if fileCloser != nil {
+				closers = append(closers, fileCloser)
+			}
 		}
 	}
 
@@ -313,10 +334,10 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 		zap.String("service", options.ServiceName),
 		zap.String("env", options.Environment),
 	)
-	return logger, atomic, nil
+	return logger, atomic, closers, nil
 }
 
-func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, string, error) {
+func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, io.Closer, string, error) {
 	filePath := options.Output.FilePath
 	if strings.TrimSpace(filePath) == "" {
 		filePath = resolveLogFilePath("")
@@ -324,7 +345,7 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, filePath, err
+		return nil, nil, filePath, err
 	}
 	lj := &lumberjack.Logger{
 		Filename:   filePath,
@@ -334,7 +355,16 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 		Compress:   options.Rotation.Compress,
 		LocalTime:  options.Rotation.LocalTime,
 	}
-	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), filePath, nil
+	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), lj, filePath, nil
+}
+
+func closeClosers(closers []io.Closer) {
+	for _, closer := range closers {
+		if closer == nil {
+			continue
+		}
+		_ = closer.Close()
+	}
 }
 
 type sinkCore struct {

--- a/backend/internal/pkg/logger/logger_test.go
+++ b/backend/internal/pkg/logger/logger_test.go
@@ -5,9 +5,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func syncTestLogger() {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	Sync()
+}
 
 func TestInit_DualOutput(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -54,10 +62,11 @@ func TestInit_DualOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("dual-output-info")
 	L().Warn("dual-output-warn")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -121,6 +130,7 @@ func TestInit_FileOutputFailureDowngrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() should downgrade instead of failing, got: %v", err)
 	}
+	t.Cleanup(Close)
 
 	_ = stderrW.Close()
 	stderrBytes, _ := io.ReadAll(stderrR)
@@ -164,9 +174,10 @@ func TestInit_CallerShouldPointToCallsite(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("caller-check")
-	Sync()
+	syncTestLogger()
 	_ = stdoutW.Close()
 	logBytes, _ := io.ReadAll(stdoutR)
 

--- a/backend/internal/pkg/logger/options_test.go
+++ b/backend/internal/pkg/logger/options_test.go
@@ -95,7 +95,7 @@ func TestBuildFileCore_InvalidPathFallback(t *testing.T) {
 		EncodeLevel: zapcore.CapitalLevelEncoder,
 	}
 	encoder := zapcore.NewJSONEncoder(encoderCfg)
-	_, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
+	_, _, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
 	if err == nil {
 		t.Fatalf("buildFileCore() expected error for invalid path")
 	}

--- a/backend/internal/pkg/logger/stdlog_bridge_test.go
+++ b/backend/internal/pkg/logger/stdlog_bridge_test.go
@@ -73,11 +73,12 @@ func TestStdLogBridgeRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	log.Printf("service started")
 	log.Printf("Warning: queue full")
 	log.Printf("Forward request failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -135,11 +136,12 @@ func TestLegacyPrintfRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	LegacyPrintf("service.test", "request started")
 	LegacyPrintf("service.test", "Warning: queue full")
 	LegacyPrintf("service.test", "forward failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -160,6 +160,23 @@ func (r *accountRepository) GetByID(ctx context.Context, id int64) (*service.Acc
 	return &accounts[0], nil
 }
 
+func (r *accountRepository) GetByIDForUsage(ctx context.Context, id int64) (*service.Account, error) {
+	m, err := r.client.Account.Query().Where(dbaccount.IDEQ(id)).WithProxy().Only(ctx)
+	if err != nil {
+		return nil, translatePersistenceError(err, service.ErrAccountNotFound, nil)
+	}
+
+	account := accountEntityToService(m)
+	if account == nil {
+		return nil, service.ErrAccountNotFound
+	}
+	if m.Edges.Proxy != nil {
+		account.Proxy = proxyEntityToService(m.Edges.Proxy)
+	}
+
+	return account, nil
+}
+
 func (r *accountRepository) GetByIDs(ctx context.Context, ids []int64) ([]*service.Account, error) {
 	if len(ids) == 0 {
 		return []*service.Account{}, nil

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -82,6 +82,10 @@ type accountWindowStatsBatchReader interface {
 	GetAccountWindowStatsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error)
 }
 
+type accountUsageAccountReader interface {
+	GetByIDForUsage(ctx context.Context, id int64) (*Account, error)
+}
+
 // apiUsageCache 缓存从 Anthropic API 获取的使用率数据（utilization, resets_at）
 // 同时支持缓存错误响应（负缓存），防止 429 等错误导致的重试风暴
 type apiUsageCache struct {
@@ -292,7 +296,7 @@ func NewAccountUsageService(
 // Setup Token账号: 根据session_window推算5h窗口，7d数据不可用（没有profile scope）
 // API Key账号: 不支持usage查询
 func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64) (*UsageInfo, error) {
-	account, err := s.accountRepo.GetByID(ctx, accountID)
+	account, err := s.getAccountForUsage(ctx, accountID)
 	if err != nil {
 		return nil, fmt.Errorf("get account failed: %w", err)
 	}
@@ -413,10 +417,17 @@ func (s *AccountUsageService) GetUsage(ctx context.Context, accountID int64) (*U
 	return nil, fmt.Errorf("account type %s does not support usage query", account.Type)
 }
 
+func (s *AccountUsageService) getAccountForUsage(ctx context.Context, accountID int64) (*Account, error) {
+	if reader, ok := s.accountRepo.(accountUsageAccountReader); ok {
+		return reader.GetByIDForUsage(ctx, accountID)
+	}
+	return s.accountRepo.GetByID(ctx, accountID)
+}
+
 // GetPassiveUsage 从 Account.Extra 中的被动采样数据构建 UsageInfo，不调用外部 API。
 // 仅适用于 Anthropic OAuth / SetupToken 账号。
 func (s *AccountUsageService) GetPassiveUsage(ctx context.Context, accountID int64) (*UsageInfo, error) {
-	account, err := s.accountRepo.GetByID(ctx, accountID)
+	account, err := s.getAccountForUsage(ctx, accountID)
 	if err != nil {
 		return nil, fmt.Errorf("get account failed: %w", err)
 	}

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -199,3 +199,57 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 	})
 }
+
+type accountUsageLiteReaderRepo struct {
+	stubOpenAIAccountRepo
+	getByIDCalls         int
+	getByIDForUsageCalls int
+}
+
+func (r *accountUsageLiteReaderRepo) GetByID(ctx context.Context, id int64) (*Account, error) {
+	r.getByIDCalls++
+	return r.stubOpenAIAccountRepo.GetByID(ctx, id)
+}
+
+func (r *accountUsageLiteReaderRepo) GetByIDForUsage(ctx context.Context, id int64) (*Account, error) {
+	r.getByIDForUsageCalls++
+	return r.stubOpenAIAccountRepo.GetByID(ctx, id)
+}
+
+func TestAccountUsageService_GetUsage_PrefersUsageSpecificAccountReaderForOpenAI(t *testing.T) {
+	t.Parallel()
+
+	resetAt5h := time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
+	resetAt7d := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	repo := &accountUsageLiteReaderRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{
+			accounts: []Account{{
+				ID:       101,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+				Status:   StatusActive,
+				Extra: map[string]any{
+					"codex_5h_used_percent": 12.0,
+					"codex_5h_reset_at":     resetAt5h,
+					"codex_7d_used_percent": 34.0,
+					"codex_7d_reset_at":     resetAt7d,
+				},
+			}},
+		},
+	}
+	svc := &AccountUsageService{accountRepo: repo}
+
+	usage, err := svc.GetUsage(context.Background(), 101)
+	if err != nil {
+		t.Fatalf("GetUsage() error = %v", err)
+	}
+	if usage == nil || usage.FiveHour == nil || usage.SevenDay == nil {
+		t.Fatalf("expected cached OpenAI usage windows, got %#v", usage)
+	}
+	if repo.getByIDCalls != 0 {
+		t.Fatalf("expected GetByID to be skipped, got %d calls", repo.getByIDCalls)
+	}
+	if repo.getByIDForUsageCalls != 1 {
+		t.Fatalf("expected GetByIDForUsage to be used once, got %d calls", repo.getByIDForUsageCalls)
+	}
+}

--- a/backend/internal/service/group_capacity_service.go
+++ b/backend/internal/service/group_capacity_service.go
@@ -49,40 +49,71 @@ func (s *GroupCapacityService) GetAllGroupCapacity(ctx context.Context) ([]Group
 		return nil, err
 	}
 
-	results := make([]GroupCapacitySummary, 0, len(groups))
+	results := make([]GroupCapacitySummary, len(groups))
+	groupIndex := make(map[int64]int, len(groups))
 	for i := range groups {
-		cap, err := s.getGroupCapacity(ctx, groups[i].ID)
-		if err != nil {
-			// Skip groups with errors, return partial results
-			continue
-		}
-		cap.GroupID = groups[i].ID
-		results = append(results, cap)
+		results[i] = GroupCapacitySummary{GroupID: groups[i].ID}
+		groupIndex[groups[i].ID] = i
 	}
-	return results, nil
-}
 
-func (s *GroupCapacityService) getGroupCapacity(ctx context.Context, groupID int64) (GroupCapacitySummary, error) {
-	accounts, err := s.accountRepo.ListSchedulableByGroupID(ctx, groupID)
+	accounts, err := s.accountRepo.ListSchedulable(ctx)
 	if err != nil {
-		return GroupCapacitySummary{}, err
+		return nil, err
 	}
 	if len(accounts) == 0 {
-		return GroupCapacitySummary{}, nil
+		return results, nil
 	}
 
-	// Collect account IDs and config values
 	accountIDs := make([]int64, 0, len(accounts))
 	sessionTimeouts := make(map[int64]time.Duration)
-	var concurrencyMax, sessionsMax, rpmMax int
 
 	for i := range accounts {
 		acc := &accounts[i]
 		accountIDs = append(accountIDs, acc.ID)
-		concurrencyMax += acc.Concurrency
+		applyAccountCapacityToGroups(acc, groupIndex, results, sessionTimeouts)
+	}
+
+	concurrencyMap := make(map[int64]int, len(accountIDs))
+	if s.concurrencyService != nil {
+		concurrencyMap, _ = s.concurrencyService.GetAccountConcurrencyBatch(ctx, accountIDs)
+		if concurrencyMap == nil {
+			concurrencyMap = make(map[int64]int, len(accountIDs))
+		}
+	}
+
+	var sessionsMap map[int64]int
+	if len(sessionTimeouts) > 0 && s.sessionLimitCache != nil {
+		sessionsMap, _ = s.sessionLimitCache.GetActiveSessionCountBatch(ctx, accountIDs, sessionTimeouts)
+	}
+
+	var rpmMap map[int64]int
+	if s.rpmCache != nil {
+		rpmMap, _ = s.rpmCache.GetRPMBatch(ctx, accountIDs)
+	}
+
+	for i := range accounts {
+		acc := &accounts[i]
+		applyAccountRuntimeToGroups(acc, groupIndex, results, concurrencyMap[acc.ID], sessionsMap, rpmMap)
+	}
+
+	return results, nil
+}
+
+func applyAccountCapacityToGroups(
+	acc *Account,
+	groupIndex map[int64]int,
+	results []GroupCapacitySummary,
+	sessionTimeouts map[int64]time.Duration,
+) {
+	for _, groupID := range acc.GroupIDs {
+		idx, ok := groupIndex[groupID]
+		if !ok {
+			continue
+		}
+		results[idx].ConcurrencyMax += acc.Concurrency
 
 		if ms := acc.GetMaxSessions(); ms > 0 {
-			sessionsMax += ms
+			results[idx].SessionsMax += ms
 			timeout := time.Duration(acc.GetSessionIdleTimeoutMinutes()) * time.Minute
 			if timeout <= 0 {
 				timeout = 5 * time.Minute
@@ -91,41 +122,35 @@ func (s *GroupCapacityService) getGroupCapacity(ctx context.Context, groupID int
 		}
 
 		if rpm := acc.GetBaseRPM(); rpm > 0 {
-			rpmMax += rpm
+			results[idx].RPMMax += rpm
 		}
 	}
+}
 
-	// Batch query runtime data from Redis
-	concurrencyMap, _ := s.concurrencyService.GetAccountConcurrencyBatch(ctx, accountIDs)
-
-	var sessionsMap map[int64]int
-	if sessionsMax > 0 && s.sessionLimitCache != nil {
-		sessionsMap, _ = s.sessionLimitCache.GetActiveSessionCountBatch(ctx, accountIDs, sessionTimeouts)
+func applyAccountRuntimeToGroups(
+	acc *Account,
+	groupIndex map[int64]int,
+	results []GroupCapacitySummary,
+	concurrencyUsed int,
+	sessionsMap map[int64]int,
+	rpmMap map[int64]int,
+) {
+	sessionsUsed := 0
+	rpmUsed := 0
+	if sessionsMap != nil {
+		sessionsUsed = sessionsMap[acc.ID]
+	}
+	if rpmMap != nil {
+		rpmUsed = rpmMap[acc.ID]
 	}
 
-	var rpmMap map[int64]int
-	if rpmMax > 0 && s.rpmCache != nil {
-		rpmMap, _ = s.rpmCache.GetRPMBatch(ctx, accountIDs)
-	}
-
-	// Aggregate
-	var concurrencyUsed, sessionsUsed, rpmUsed int
-	for _, id := range accountIDs {
-		concurrencyUsed += concurrencyMap[id]
-		if sessionsMap != nil {
-			sessionsUsed += sessionsMap[id]
+	for _, groupID := range acc.GroupIDs {
+		idx, ok := groupIndex[groupID]
+		if !ok {
+			continue
 		}
-		if rpmMap != nil {
-			rpmUsed += rpmMap[id]
-		}
+		results[idx].ConcurrencyUsed += concurrencyUsed
+		results[idx].SessionsUsed += sessionsUsed
+		results[idx].RPMUsed += rpmUsed
 	}
-
-	return GroupCapacitySummary{
-		ConcurrencyUsed: concurrencyUsed,
-		ConcurrencyMax:  concurrencyMax,
-		SessionsUsed:    sessionsUsed,
-		SessionsMax:     sessionsMax,
-		RPMUsed:         rpmUsed,
-		RPMMax:          rpmMax,
-	}, nil
 }

--- a/backend/internal/service/group_capacity_service_test.go
+++ b/backend/internal/service/group_capacity_service_test.go
@@ -1,0 +1,279 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+type groupCapacityAccountRepo struct {
+	stubOpenAIAccountRepo
+	listSchedulableCalls        int
+	listSchedulableByGroupCalls int
+}
+
+func (r *groupCapacityAccountRepo) ListSchedulable(ctx context.Context) ([]Account, error) {
+	r.listSchedulableCalls++
+	return append([]Account(nil), r.accounts...), nil
+}
+
+func (r *groupCapacityAccountRepo) ListSchedulableByGroupID(ctx context.Context, groupID int64) ([]Account, error) {
+	r.listSchedulableByGroupCalls++
+	return nil, nil
+}
+
+type groupCapacityGroupRepo struct {
+	active []Group
+}
+
+func (r *groupCapacityGroupRepo) ListActive(context.Context) ([]Group, error) {
+	return append([]Group(nil), r.active...), nil
+}
+
+type groupCapacitySessionCache struct {
+	counts map[int64]int
+}
+
+func (c *groupCapacitySessionCache) RegisterSession(context.Context, int64, string, int, time.Duration) (bool, error) {
+	return true, nil
+}
+func (c *groupCapacitySessionCache) RefreshSession(context.Context, int64, string, time.Duration) error {
+	return nil
+}
+func (c *groupCapacitySessionCache) GetActiveSessionCount(context.Context, int64) (int, error) {
+	return 0, nil
+}
+func (c *groupCapacitySessionCache) GetActiveSessionCountBatch(context.Context, []int64, map[int64]time.Duration) (map[int64]int, error) {
+	return c.counts, nil
+}
+func (c *groupCapacitySessionCache) IsSessionActive(context.Context, int64, string) (bool, error) {
+	return false, nil
+}
+func (c *groupCapacitySessionCache) GetWindowCost(context.Context, int64) (float64, bool, error) {
+	return 0, false, nil
+}
+func (c *groupCapacitySessionCache) SetWindowCost(context.Context, int64, float64) error {
+	return nil
+}
+func (c *groupCapacitySessionCache) GetWindowCostBatch(context.Context, []int64) (map[int64]float64, error) {
+	return nil, nil
+}
+
+type groupCapacityRPMCache struct {
+	counts map[int64]int
+}
+
+func (c *groupCapacityRPMCache) IncrementRPM(context.Context, int64) (int, error) {
+	return 0, nil
+}
+func (c *groupCapacityRPMCache) GetRPM(context.Context, int64) (int, error) {
+	return 0, nil
+}
+func (c *groupCapacityRPMCache) GetRPMBatch(context.Context, []int64) (map[int64]int, error) {
+	return c.counts, nil
+}
+
+func TestGroupCapacityService_GetAllGroupCapacity_AggregatesSchedulableAccountsOnce(t *testing.T) {
+	t.Parallel()
+
+	groupRepo := &groupCapacityGroupRepo{
+		active: []Group{
+			{ID: 1, Name: "g1"},
+			{ID: 2, Name: "g2"},
+			{ID: 3, Name: "g3"},
+		},
+	}
+	accountRepo := &groupCapacityAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{
+			accounts: []Account{
+				{
+					ID:          10,
+					Platform:    PlatformAnthropic,
+					Type:        AccountTypeOAuth,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 2,
+					GroupIDs:    []int64{1},
+					Extra: map[string]any{
+						"max_sessions":                 3,
+						"session_idle_timeout_minutes": 10,
+						"base_rpm":                     5,
+					},
+				},
+				{
+					ID:          11,
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeOAuth,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 4,
+					GroupIDs:    []int64{1, 2},
+					Extra: map[string]any{
+						"base_rpm": 7,
+					},
+				},
+				{
+					ID:          12,
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeOAuth,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					GroupIDs:    []int64{99},
+				},
+			},
+		},
+	}
+	concurrencySvc := NewConcurrencyService(&groupCapacityConcurrencyCache{
+		counts: map[int64]int{
+			10: 1,
+			11: 2,
+			12: 9,
+		},
+	})
+	sessionCache := &groupCapacitySessionCache{counts: map[int64]int{10: 2}}
+	rpmCache := &groupCapacityRPMCache{counts: map[int64]int{10: 4, 11: 6, 12: 8}}
+
+	svc := NewGroupCapacityService(accountRepo, groupRepo, concurrencySvc, sessionCache, rpmCache)
+
+	results, err := svc.GetAllGroupCapacity(context.Background())
+	require.NoError(t, err)
+	require.Len(t, results, 3)
+	require.Equal(t, 1, accountRepo.listSchedulableCalls)
+	require.Zero(t, accountRepo.listSchedulableByGroupCalls)
+
+	require.Equal(t, GroupCapacitySummary{
+		GroupID:         1,
+		ConcurrencyUsed: 3,
+		ConcurrencyMax:  6,
+		SessionsUsed:    2,
+		SessionsMax:     3,
+		RPMUsed:         10,
+		RPMMax:          12,
+	}, results[0])
+	require.Equal(t, GroupCapacitySummary{
+		GroupID:         2,
+		ConcurrencyUsed: 2,
+		ConcurrencyMax:  4,
+		SessionsUsed:    0,
+		SessionsMax:     0,
+		RPMUsed:         6,
+		RPMMax:          7,
+	}, results[1])
+	require.Equal(t, GroupCapacitySummary{
+		GroupID:         3,
+		ConcurrencyUsed: 0,
+		ConcurrencyMax:  0,
+		SessionsUsed:    0,
+		SessionsMax:     0,
+		RPMUsed:         0,
+		RPMMax:          0,
+	}, results[2])
+}
+
+type groupCapacityConcurrencyCache struct {
+	counts map[int64]int
+}
+
+func (c *groupCapacityConcurrencyCache) AcquireAccountSlot(context.Context, int64, int, string) (bool, error) {
+	return true, nil
+}
+func (c *groupCapacityConcurrencyCache) ReleaseAccountSlot(context.Context, int64, string) error {
+	return nil
+}
+func (c *groupCapacityConcurrencyCache) GetAccountConcurrency(context.Context, int64) (int, error) {
+	return 0, nil
+}
+func (c *groupCapacityConcurrencyCache) GetAccountConcurrencyBatch(_ context.Context, accountIDs []int64) (map[int64]int, error) {
+	result := make(map[int64]int, len(accountIDs))
+	for _, accountID := range accountIDs {
+		result[accountID] = c.counts[accountID]
+	}
+	return result, nil
+}
+func (c *groupCapacityConcurrencyCache) IncrementAccountWaitCount(context.Context, int64, int) (bool, error) {
+	return true, nil
+}
+func (c *groupCapacityConcurrencyCache) DecrementAccountWaitCount(context.Context, int64) error {
+	return nil
+}
+func (c *groupCapacityConcurrencyCache) GetAccountWaitingCount(context.Context, int64) (int, error) {
+	return 0, nil
+}
+func (c *groupCapacityConcurrencyCache) AcquireUserSlot(context.Context, int64, int, string) (bool, error) {
+	return true, nil
+}
+func (c *groupCapacityConcurrencyCache) ReleaseUserSlot(context.Context, int64, string) error {
+	return nil
+}
+func (c *groupCapacityConcurrencyCache) GetUserConcurrency(context.Context, int64) (int, error) {
+	return 0, nil
+}
+func (c *groupCapacityConcurrencyCache) IncrementWaitCount(context.Context, int64, int) (bool, error) {
+	return true, nil
+}
+func (c *groupCapacityConcurrencyCache) DecrementWaitCount(context.Context, int64) error {
+	return nil
+}
+func (c *groupCapacityConcurrencyCache) GetAccountsLoadBatch(context.Context, []AccountWithConcurrency) (map[int64]*AccountLoadInfo, error) {
+	return nil, nil
+}
+func (c *groupCapacityConcurrencyCache) GetUsersLoadBatch(context.Context, []UserWithConcurrency) (map[int64]*UserLoadInfo, error) {
+	return nil, nil
+}
+func (c *groupCapacityConcurrencyCache) CleanupExpiredAccountSlots(context.Context, int64) error {
+	return nil
+}
+func (c *groupCapacityConcurrencyCache) CleanupStaleProcessSlots(context.Context, string) error {
+	return nil
+}
+
+var _ GroupRepository = (*groupCapacityGroupRepo)(nil)
+var _ AccountRepository = (*groupCapacityAccountRepo)(nil)
+var _ SessionLimitCache = (*groupCapacitySessionCache)(nil)
+var _ RPMCache = (*groupCapacityRPMCache)(nil)
+var _ ConcurrencyCache = (*groupCapacityConcurrencyCache)(nil)
+
+func (r *groupCapacityGroupRepo) List(context.Context, pagination.PaginationParams) ([]Group, *pagination.PaginationResult, error) {
+	return nil, nil, nil
+}
+
+func (r *groupCapacityGroupRepo) Create(context.Context, *Group) error { return nil }
+func (r *groupCapacityGroupRepo) GetByID(context.Context, int64) (*Group, error) {
+	return nil, nil
+}
+func (r *groupCapacityGroupRepo) GetByIDLite(context.Context, int64) (*Group, error) {
+	return nil, nil
+}
+func (r *groupCapacityGroupRepo) Update(context.Context, *Group) error { return nil }
+func (r *groupCapacityGroupRepo) Delete(context.Context, int64) error  { return nil }
+func (r *groupCapacityGroupRepo) DeleteCascade(context.Context, int64) ([]int64, error) {
+	return nil, nil
+}
+func (r *groupCapacityGroupRepo) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, *bool) ([]Group, *pagination.PaginationResult, error) {
+	return nil, nil, nil
+}
+func (r *groupCapacityGroupRepo) ListActiveByPlatform(context.Context, string) ([]Group, error) {
+	return nil, nil
+}
+func (r *groupCapacityGroupRepo) ExistsByName(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (r *groupCapacityGroupRepo) GetAccountCount(context.Context, int64) (int64, int64, error) {
+	return 0, 0, nil
+}
+func (r *groupCapacityGroupRepo) DeleteAccountGroupsByGroupID(context.Context, int64) (int64, error) {
+	return 0, nil
+}
+func (r *groupCapacityGroupRepo) GetAccountIDsByGroupIDs(context.Context, []int64) ([]int64, error) {
+	return nil, nil
+}
+func (r *groupCapacityGroupRepo) BindAccountsToGroup(context.Context, int64, []int64) error {
+	return nil
+}
+func (r *groupCapacityGroupRepo) UpdateSortOrders(context.Context, []GroupSortOrderUpdate) error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- honor the existing \\lite=1\\ admin account list path so the first-load accounts page skips runtime concurrency/session/RPM/window-cost enrichment
- add a usage-specific account reader for \\/admin/accounts/:id/usage\\ so usage fetches do not hydrate the full account graph
- rewrite group capacity aggregation to scan schedulable accounts once and aggregate in memory instead of issuing one query per active group
- close logger file sinks on reconfigure/test cleanup so Windows can run the backend suite without stale file-handle failures

## Why
Large admin deployments were still doing too much work on control-plane reads:
- the frontend already sends \\lite=1\\ on first account-page load, but the backend ignored it and still computed per-row runtime metrics
- account usage reads loaded a heavier account shape than needed
- group capacity summary used a per-group query pattern, which scales poorly when many accounts share large groups
- on Windows, logger tests could leave file handles open or hang on \\Sync()\\, making local full-suite verification unreliable

In large pools, especially with many OpenAI accounts in one group, these extra reads and aggregations amplify CPU cost and memory pressure in the admin plane.

## Testing
- \\go test ./...\\
- \\go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./...\\

## Notes
This PR is intentionally scoped to admin/control-plane overhead reduction and test-suite reliability. It does not change request-path scheduling semantics for production traffic.