### PR TITLE
fix(gemini): honor google_one cooldown on 429

### DIFF
--- a/backend/internal/pkg/logger/logger.go
+++ b/backend/internal/pkg/logger/logger.go
@@ -47,6 +47,7 @@ var (
 	sugar         atomic.Pointer[zap.SugaredLogger]
 	atomicLevel   zap.AtomicLevel
 	initOptions   InitOptions
+	activeClosers []io.Closer
 	currentSink   atomic.Value // sinkState
 	stdLogUndo    func()
 	bootstrapOnce sync.Once
@@ -72,16 +73,18 @@ func Init(options InitOptions) error {
 
 func initLocked(options InitOptions) error {
 	normalized := options.normalized()
-	zl, al, err := buildLogger(normalized)
+	zl, al, closers, err := buildLogger(normalized)
 	if err != nil {
 		return err
 	}
 
 	prev := global.Load()
+	prevClosers := activeClosers
 	global.Store(zl)
 	sugar.Store(zl.Sugar())
 	atomicLevel = al
 	initOptions = normalized
+	activeClosers = closers
 
 	bridgeSlogLocked()
 	bridgeStdLogLocked()
@@ -89,6 +92,7 @@ func initLocked(options InitOptions) error {
 	if prev != nil {
 		_ = prev.Sync()
 	}
+	closeClosers(prevClosers)
 	return nil
 }
 
@@ -205,6 +209,19 @@ func Sync() {
 	}
 }
 
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if l := global.Load(); l != nil {
+		_ = l.Sync()
+	}
+	closeClosers(activeClosers)
+	activeClosers = nil
+	global.Store(nil)
+	sugar.Store(nil)
+}
+
 func bridgeStdLogLocked() {
 	if stdLogUndo != nil {
 		stdLogUndo()
@@ -238,7 +255,7 @@ func bridgeSlogLocked() {
 	slog.SetDefault(slog.New(newSlogZapHandler(base.Named("slog"))))
 }
 
-func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
+func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, []io.Closer, error) {
 	level, _ := parseLevel(options.Level)
 	atomic := zap.NewAtomicLevelAt(level)
 
@@ -265,6 +282,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 
 	sinkCore := newSinkCore()
 	cores := make([]zapcore.Core, 0, 3)
+	closers := make([]io.Closer, 0, 1)
 
 	if options.Output.ToStdout {
 		infoPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
@@ -278,7 +296,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 	}
 
 	if options.Output.ToFile {
-		fileCore, filePath, fileErr := buildFileCore(enc, atomic, options)
+		fileCore, fileCloser, filePath, fileErr := buildFileCore(enc, atomic, options)
 		if fileErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "time=%s level=WARN msg=\"日志文件输出初始化失败，降级为仅标准输出\" path=%s err=%v\n",
 				time.Now().Format(time.RFC3339Nano),
@@ -287,6 +305,9 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 			)
 		} else {
 			cores = append(cores, fileCore)
+			if fileCloser != nil {
+				closers = append(closers, fileCloser)
+			}
 		}
 	}
 
@@ -313,10 +334,10 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 		zap.String("service", options.ServiceName),
 		zap.String("env", options.Environment),
 	)
-	return logger, atomic, nil
+	return logger, atomic, closers, nil
 }
 
-func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, string, error) {
+func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, io.Closer, string, error) {
 	filePath := options.Output.FilePath
 	if strings.TrimSpace(filePath) == "" {
 		filePath = resolveLogFilePath("")
@@ -324,7 +345,7 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, filePath, err
+		return nil, nil, filePath, err
 	}
 	lj := &lumberjack.Logger{
 		Filename:   filePath,
@@ -334,7 +355,16 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 		Compress:   options.Rotation.Compress,
 		LocalTime:  options.Rotation.LocalTime,
 	}
-	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), filePath, nil
+	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), lj, filePath, nil
+}
+
+func closeClosers(closers []io.Closer) {
+	for _, closer := range closers {
+		if closer == nil {
+			continue
+		}
+		_ = closer.Close()
+	}
 }
 
 type sinkCore struct {

--- a/backend/internal/pkg/logger/logger_test.go
+++ b/backend/internal/pkg/logger/logger_test.go
@@ -5,9 +5,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func syncTestLogger() {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	Sync()
+}
 
 func TestInit_DualOutput(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -54,10 +62,11 @@ func TestInit_DualOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("dual-output-info")
 	L().Warn("dual-output-warn")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -121,6 +130,7 @@ func TestInit_FileOutputFailureDowngrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() should downgrade instead of failing, got: %v", err)
 	}
+	t.Cleanup(Close)
 
 	_ = stderrW.Close()
 	stderrBytes, _ := io.ReadAll(stderrR)
@@ -164,9 +174,10 @@ func TestInit_CallerShouldPointToCallsite(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("caller-check")
-	Sync()
+	syncTestLogger()
 	_ = stdoutW.Close()
 	logBytes, _ := io.ReadAll(stdoutR)
 

--- a/backend/internal/pkg/logger/options_test.go
+++ b/backend/internal/pkg/logger/options_test.go
@@ -95,7 +95,7 @@ func TestBuildFileCore_InvalidPathFallback(t *testing.T) {
 		EncodeLevel: zapcore.CapitalLevelEncoder,
 	}
 	encoder := zapcore.NewJSONEncoder(encoderCfg)
-	_, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
+	_, _, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
 	if err == nil {
 		t.Fatalf("buildFileCore() expected error for invalid path")
 	}

--- a/backend/internal/pkg/logger/stdlog_bridge_test.go
+++ b/backend/internal/pkg/logger/stdlog_bridge_test.go
@@ -73,11 +73,12 @@ func TestStdLogBridgeRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	log.Printf("service started")
 	log.Printf("Warning: queue full")
 	log.Printf("Forward request failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -135,11 +136,12 @@ func TestLegacyPrintfRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	LegacyPrintf("service.test", "request started")
 	LegacyPrintf("service.test", "Warning: queue full")
 	LegacyPrintf("service.test", "forward failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()

--- a/backend/internal/service/gemini_messages_compat_rate_limit_test.go
+++ b/backend/internal/service/gemini_messages_compat_rate_limit_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type geminiRateLimitRepo struct {
+	stubOpenAIAccountRepo
+	rateLimitedAccountID int64
+	rateLimitedUntil     *time.Time
+}
+
+func (r *geminiRateLimitRepo) SetRateLimited(_ context.Context, id int64, resetAt time.Time) error {
+	r.rateLimitedAccountID = id
+	t := resetAt
+	r.rateLimitedUntil = &t
+	return nil
+}
+
+func TestHandleGeminiUpstreamError_GoogleOne429UsesTierCooldown(t *testing.T) {
+	t.Parallel()
+
+	repo := &geminiRateLimitRepo{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo: repo,
+	}
+	account := &Account{
+		ID:       41,
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"oauth_type": "google_one",
+			"tier_id":    GeminiTierGoogleOneFree,
+		},
+	}
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, 429, nil, []byte(`{"error":{"code":429,"message":"rate limited"}}`))
+	after := time.Now()
+
+	require.Equal(t, account.ID, repo.rateLimitedAccountID)
+	require.NotNil(t, repo.rateLimitedUntil)
+
+	cooldown := geminiCooldownForTier(GeminiTierGoogleOneFree)
+	lowerBound := before.Add(cooldown - 2*time.Second)
+	upperBound := after.Add(cooldown + 2*time.Second)
+	require.False(t, repo.rateLimitedUntil.Before(lowerBound), "google_one cooldown should use tier-based fallback")
+	require.False(t, repo.rateLimitedUntil.After(upperBound), "google_one cooldown should not jump to daily reset")
+}
+
+func TestHandleGeminiUpstreamError_AIStudio429FallsBackToDailyReset(t *testing.T) {
+	t.Parallel()
+
+	repo := &geminiRateLimitRepo{}
+	svc := &GeminiMessagesCompatService{
+		accountRepo: repo,
+	}
+	account := &Account{
+		ID:       42,
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"oauth_type": "ai_studio",
+			"tier_id":    GeminiTierAIStudioFree,
+		},
+	}
+
+	expectedResetUnix := nextGeminiDailyResetUnix()
+	require.NotNil(t, expectedResetUnix)
+
+	svc.handleGeminiUpstreamError(context.Background(), account, 429, nil, []byte(`{"error":{"code":429,"message":"rate limited"}}`))
+
+	require.Equal(t, account.ID, repo.rateLimitedAccountID)
+	require.NotNil(t, repo.rateLimitedUntil)
+	require.Equal(t, *expectedResetUnix, repo.rateLimitedUntil.Unix())
+}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2733,23 +2733,28 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 		return
 	}
 
-	oauthType := account.GeminiOAuthType()
+	oauthType := strings.ToLower(strings.TrimSpace(account.GeminiOAuthType()))
 	tierID := account.GeminiTierID()
 	projectID := strings.TrimSpace(account.GetCredential("project_id"))
 	isCodeAssist := account.IsGeminiCodeAssist()
+	isGoogleOne := oauthType == "google_one"
 
 	resetAt := ParseGeminiRateLimitResetTime(body)
 	if resetAt == nil {
 		// 根据账号类型使用不同的默认重置时间
 		var ra time.Time
-		if isCodeAssist {
-			// Code Assist: fallback cooldown by tier
+		if isCodeAssist || isGoogleOne {
+			// Gemini CLI OAuth accounts (Code Assist / Google One): fallback cooldown by tier.
 			cooldown := geminiCooldownForTier(tierID)
 			if s.rateLimitService != nil {
 				cooldown = s.rateLimitService.GeminiCooldown(ctx, account)
 			}
 			ra = time.Now().Add(cooldown)
-			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Code Assist, tier=%s, project=%s) rate limited, cooldown=%v", account.ID, tierID, projectID, time.Until(ra).Truncate(time.Second))
+			if isCodeAssist {
+				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Code Assist, tier=%s, project=%s) rate limited, cooldown=%v", account.ID, tierID, projectID, time.Until(ra).Truncate(time.Second))
+			} else {
+				logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Account %d (Gemini CLI / Google One, tier=%s) rate limited, cooldown=%v", account.ID, tierID, time.Until(ra).Truncate(time.Second))
+			}
 		} else {
 			// API Key / AI Studio OAuth: PST 午夜
 			if ts := nextGeminiDailyResetUnix(); ts != nil {


### PR DESCRIPTION
## Summary
- treat Gemini \\google_one\\ OAuth accounts like other Gemini CLI OAuth accounts when a 429 response has no explicit reset hint
- use tier cooldown fallback for \\google_one\\ instead of forcing the account into the PST-midnight branch reserved for AI Studio / API key style daily limits
- add default backend regression tests that lock the difference between \\google_one\\ and \\i_studio\\ fallback behavior
- include the same Windows logger handle cleanup used for reliable local full-suite verification

## Why
This fixes #641.

Today, \\google_one\\ Gemini CLI OAuth accounts fall through the AI Studio/API key 429 fallback branch in \\handleGeminiUpstreamError\\. That can mark the account rate-limited until PST midnight even when the configured tier cooldown is much shorter.

Result: short upstream 429s get amplified into long local 503 windows because the scheduler keeps the account disabled far longer than necessary.

## Behavior After This Change
- \\code_assist\\: tier cooldown fallback
- \\google_one\\: tier cooldown fallback
- \\i_studio\\ and API-key-like daily quota behavior: PST-midnight fallback remains unchanged

## Testing
- \\go test -p 1 ./...\\
- \\go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./...\\

## Notes
I ran the backend suite with \\-p 1\\ on Windows because parallel compilation/linking on this machine can hit paging-file limits; the tests and lint still pass cleanly.

There is intentional overlap with the Windows logger test-handle cleanup already proposed elsewhere. If that lands first, this PR should shrink cleanly after rebase.