### PR TITLE
fix(simple): ignore group filter in mixed scheduling

### DIFF
--- a/backend/internal/pkg/logger/logger.go
+++ b/backend/internal/pkg/logger/logger.go
@@ -47,6 +47,7 @@ var (
 	sugar         atomic.Pointer[zap.SugaredLogger]
 	atomicLevel   zap.AtomicLevel
 	initOptions   InitOptions
+	activeClosers []io.Closer
 	currentSink   atomic.Value // sinkState
 	stdLogUndo    func()
 	bootstrapOnce sync.Once
@@ -72,16 +73,18 @@ func Init(options InitOptions) error {
 
 func initLocked(options InitOptions) error {
 	normalized := options.normalized()
-	zl, al, err := buildLogger(normalized)
+	zl, al, closers, err := buildLogger(normalized)
 	if err != nil {
 		return err
 	}
 
 	prev := global.Load()
+	prevClosers := activeClosers
 	global.Store(zl)
 	sugar.Store(zl.Sugar())
 	atomicLevel = al
 	initOptions = normalized
+	activeClosers = closers
 
 	bridgeSlogLocked()
 	bridgeStdLogLocked()
@@ -89,6 +92,7 @@ func initLocked(options InitOptions) error {
 	if prev != nil {
 		_ = prev.Sync()
 	}
+	closeClosers(prevClosers)
 	return nil
 }
 
@@ -205,6 +209,19 @@ func Sync() {
 	}
 }
 
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if l := global.Load(); l != nil {
+		_ = l.Sync()
+	}
+	closeClosers(activeClosers)
+	activeClosers = nil
+	global.Store(nil)
+	sugar.Store(nil)
+}
+
 func bridgeStdLogLocked() {
 	if stdLogUndo != nil {
 		stdLogUndo()
@@ -238,7 +255,7 @@ func bridgeSlogLocked() {
 	slog.SetDefault(slog.New(newSlogZapHandler(base.Named("slog"))))
 }
 
-func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
+func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, []io.Closer, error) {
 	level, _ := parseLevel(options.Level)
 	atomic := zap.NewAtomicLevelAt(level)
 
@@ -265,6 +282,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 
 	sinkCore := newSinkCore()
 	cores := make([]zapcore.Core, 0, 3)
+	closers := make([]io.Closer, 0, 1)
 
 	if options.Output.ToStdout {
 		infoPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
@@ -278,7 +296,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 	}
 
 	if options.Output.ToFile {
-		fileCore, filePath, fileErr := buildFileCore(enc, atomic, options)
+		fileCore, fileCloser, filePath, fileErr := buildFileCore(enc, atomic, options)
 		if fileErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "time=%s level=WARN msg=\"日志文件输出初始化失败，降级为仅标准输出\" path=%s err=%v\n",
 				time.Now().Format(time.RFC3339Nano),
@@ -287,6 +305,9 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 			)
 		} else {
 			cores = append(cores, fileCore)
+			if fileCloser != nil {
+				closers = append(closers, fileCloser)
+			}
 		}
 	}
 
@@ -313,10 +334,10 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 		zap.String("service", options.ServiceName),
 		zap.String("env", options.Environment),
 	)
-	return logger, atomic, nil
+	return logger, atomic, closers, nil
 }
 
-func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, string, error) {
+func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, io.Closer, string, error) {
 	filePath := options.Output.FilePath
 	if strings.TrimSpace(filePath) == "" {
 		filePath = resolveLogFilePath("")
@@ -324,7 +345,7 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, filePath, err
+		return nil, nil, filePath, err
 	}
 	lj := &lumberjack.Logger{
 		Filename:   filePath,
@@ -334,7 +355,16 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 		Compress:   options.Rotation.Compress,
 		LocalTime:  options.Rotation.LocalTime,
 	}
-	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), filePath, nil
+	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), lj, filePath, nil
+}
+
+func closeClosers(closers []io.Closer) {
+	for _, closer := range closers {
+		if closer == nil {
+			continue
+		}
+		_ = closer.Close()
+	}
 }
 
 type sinkCore struct {

--- a/backend/internal/pkg/logger/logger_test.go
+++ b/backend/internal/pkg/logger/logger_test.go
@@ -5,9 +5,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func syncTestLogger() {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	Sync()
+}
 
 func TestInit_DualOutput(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -54,10 +62,11 @@ func TestInit_DualOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("dual-output-info")
 	L().Warn("dual-output-warn")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -121,6 +130,7 @@ func TestInit_FileOutputFailureDowngrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() should downgrade instead of failing, got: %v", err)
 	}
+	t.Cleanup(Close)
 
 	_ = stderrW.Close()
 	stderrBytes, _ := io.ReadAll(stderrR)
@@ -164,9 +174,10 @@ func TestInit_CallerShouldPointToCallsite(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("caller-check")
-	Sync()
+	syncTestLogger()
 	_ = stdoutW.Close()
 	logBytes, _ := io.ReadAll(stdoutR)
 

--- a/backend/internal/pkg/logger/options_test.go
+++ b/backend/internal/pkg/logger/options_test.go
@@ -95,7 +95,7 @@ func TestBuildFileCore_InvalidPathFallback(t *testing.T) {
 		EncodeLevel: zapcore.CapitalLevelEncoder,
 	}
 	encoder := zapcore.NewJSONEncoder(encoderCfg)
-	_, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
+	_, _, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
 	if err == nil {
 		t.Fatalf("buildFileCore() expected error for invalid path")
 	}

--- a/backend/internal/pkg/logger/stdlog_bridge_test.go
+++ b/backend/internal/pkg/logger/stdlog_bridge_test.go
@@ -73,11 +73,12 @@ func TestStdLogBridgeRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	log.Printf("service started")
 	log.Printf("Warning: queue full")
 	log.Printf("Forward request failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -135,11 +136,12 @@ func TestLegacyPrintfRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	LegacyPrintf("service.test", "request started")
 	LegacyPrintf("service.test", "Warning: queue full")
 	LegacyPrintf("service.test", "forward failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1936,10 +1936,10 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 		platforms := []string{platform, PlatformAntigravity}
 		var accounts []Account
 		var err error
-		if groupID != nil {
-			accounts, err = s.accountRepo.ListSchedulableByGroupIDAndPlatforms(ctx, *groupID, platforms)
-		} else if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
 			accounts, err = s.accountRepo.ListSchedulableByPlatforms(ctx, platforms)
+		} else if groupID != nil {
+			accounts, err = s.accountRepo.ListSchedulableByGroupIDAndPlatforms(ctx, *groupID, platforms)
 		} else {
 			accounts, err = s.accountRepo.ListSchedulableUngroupedByPlatforms(ctx, platforms)
 		}

--- a/backend/internal/service/gateway_simple_mode_regression_test.go
+++ b/backend/internal/service/gateway_simple_mode_regression_test.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type simpleModeMixedGroupAwareRepo struct {
+	stubOpenAIAccountRepo
+	groupedCalls  int
+	platformCalls int
+}
+
+func (r *simpleModeMixedGroupAwareRepo) ListSchedulableByPlatforms(_ context.Context, platforms []string) ([]Account, error) {
+	r.platformCalls++
+	platformSet := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		platformSet[platform] = struct{}{}
+	}
+	result := make([]Account, 0, len(r.accounts))
+	for _, acc := range r.accounts {
+		if _, ok := platformSet[acc.Platform]; ok && acc.IsSchedulable() {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
+}
+
+func (r *simpleModeMixedGroupAwareRepo) ListSchedulableByGroupIDAndPlatforms(_ context.Context, groupID int64, platforms []string) ([]Account, error) {
+	r.groupedCalls++
+	platformSet := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		platformSet[platform] = struct{}{}
+	}
+	result := make([]Account, 0, len(r.accounts))
+	for _, acc := range r.accounts {
+		if _, ok := platformSet[acc.Platform]; !ok || !acc.IsSchedulable() {
+			continue
+		}
+		for _, ag := range acc.AccountGroups {
+			if ag.GroupID == groupID {
+				result = append(result, acc)
+				break
+			}
+		}
+	}
+	return result, nil
+}
+
+func TestGatewayService_SelectAccountWithMixedScheduling_SimpleModeIgnoresGroupFilter(t *testing.T) {
+	t.Parallel()
+
+	groupID := int64(100)
+	repo := &simpleModeMixedGroupAwareRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{
+			accounts: []Account{
+				{
+					ID:          1,
+					Platform:    PlatformAnthropic,
+					Priority:    1,
+					Status:      StatusActive,
+					Schedulable: true,
+				},
+				{
+					ID:          2,
+					Platform:    PlatformAntigravity,
+					Priority:    2,
+					Status:      StatusActive,
+					Schedulable: true,
+					Extra: map[string]any{
+						"mixed_scheduling": true,
+					},
+				},
+			},
+		},
+	}
+
+	svc := &GatewayService{
+		accountRepo: repo,
+		cache:       &stubGatewayCache{},
+		cfg:         &config.Config{RunMode: config.RunModeSimple},
+	}
+
+	account, err := svc.selectAccountWithMixedScheduling(context.Background(), &groupID, "", "", nil, PlatformAnthropic)
+	require.NoError(t, err)
+	require.NotNil(t, account)
+	require.Equal(t, int64(1), account.ID)
+	require.Equal(t, 1, repo.platformCalls)
+	require.Zero(t, repo.groupedCalls)
+}


### PR DESCRIPTION
## Summary
- make mixed scheduling respect RUN_MODE=simple by skipping group-bound account filtering even when the API key still carries a group id
- add a regression test that proves ungrouped accounts remain schedulable in simple mode through the mixed scheduling path
- include the Windows logger-handle cleanup used for reliable local backend verification

## Why
This fixes #245.

The single-platform path already bypassed group isolation in simple mode, but the mixed scheduling path still prioritized ListSchedulableByGroupIDAndPlatforms(...) whenever groupID != nil. In simple mode, accounts are often intentionally left ungrouped, so that stale group filter caused false 503 No available accounts errors.

## Testing
- go test -p 1 ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./...

## Notes
This PR intentionally includes the same Windows logger test-handle cleanup already proposed in another PR, because otherwise the local backend full suite cannot complete reliably on this machine. If that lands first, this PR should shrink cleanly after rebase.