### PR TITLE
fix(deploy): escape redis requirepass interpolation

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -87,7 +87,7 @@ services:
           --save 60 1
           --appendonly yes
           --appendfsync everysec
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+          $${REDIS_PASSWORD:+--requirepass "$$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - REDISCLI_AUTH=${REDIS_PASSWORD:-}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -211,7 +211,7 @@ services:
           --save 60 1
           --appendonly yes
           --appendfsync everysec
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+          $${REDIS_PASSWORD:+--requirepass "$$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -204,7 +204,7 @@ services:
           --save 60 1
           --appendonly yes
           --appendfsync everysec
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+          $${REDIS_PASSWORD:+--requirepass "$$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)


### PR DESCRIPTION
## Summary
- escape the Redis shell parameter expansion in the deploy compose files
- apply the same fix to the default, dev, and local compose variants
- validate them with docker compose config

## Why
This fixes #291.

## Testing
- docker compose -f deploy/docker-compose.yml config
- docker compose -f deploy/docker-compose.dev.yml config
- docker compose -f deploy/docker-compose.local.yml config