### PR TITLE
feat(antigravity): migrate Sonnet 4.5 default mapping to Sonnet 4.6

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -76,11 +76,11 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"claude-opus-4-6":            "claude-opus-4-6-thinking", // 简称映射
 	"claude-opus-4-5-thinking":   "claude-opus-4-6-thinking", // 迁移旧模型
 	"claude-sonnet-4-6":          "claude-sonnet-4-6",
-	"claude-sonnet-4-5":          "claude-sonnet-4-6",          // Sonnet 4.5 → 4.6
-	"claude-sonnet-4-5-thinking": "claude-sonnet-4-6",          // Sonnet 4.5 → 4.6
+	"claude-sonnet-4-5":          "claude-sonnet-4-6", // Sonnet 4.5 → 4.6
+	"claude-sonnet-4-5-thinking": "claude-sonnet-4-6", // Sonnet 4.5 → 4.6
 	// Claude 详细版本 ID 映射
 	"claude-opus-4-5-20251101":   "claude-opus-4-6-thinking", // 迁移旧模型
-	"claude-sonnet-4-5-20250929": "claude-sonnet-4-6",          // Sonnet 4.5 → 4.6
+	"claude-sonnet-4-5-20250929": "claude-sonnet-4-6",        // Sonnet 4.5 → 4.6
 	// Claude Haiku → Sonnet（无 Haiku 支持）
 	"claude-haiku-4-5":          "claude-sonnet-4-6",
 	"claude-haiku-4-5-20251001": "claude-sonnet-4-6",

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -76,11 +76,11 @@ var DefaultAntigravityModelMapping = map[string]string{
 	"claude-opus-4-6":            "claude-opus-4-6-thinking", // 简称映射
 	"claude-opus-4-5-thinking":   "claude-opus-4-6-thinking", // 迁移旧模型
 	"claude-sonnet-4-6":          "claude-sonnet-4-6",
-	"claude-sonnet-4-5":          "claude-sonnet-4-5",
-	"claude-sonnet-4-5-thinking": "claude-sonnet-4-5-thinking",
+	"claude-sonnet-4-5":          "claude-sonnet-4-6",          // Sonnet 4.5 → 4.6
+	"claude-sonnet-4-5-thinking": "claude-sonnet-4-6",          // Sonnet 4.5 → 4.6
 	// Claude 详细版本 ID 映射
 	"claude-opus-4-5-20251101":   "claude-opus-4-6-thinking", // 迁移旧模型
-	"claude-sonnet-4-5-20250929": "claude-sonnet-4-5",
+	"claude-sonnet-4-5-20250929": "claude-sonnet-4-6",          // Sonnet 4.5 → 4.6
 	// Claude Haiku → Sonnet（无 Haiku 支持）
 	"claude-haiku-4-5":          "claude-sonnet-4-6",
 	"claude-haiku-4-5-20251001": "claude-sonnet-4-6",

--- a/backend/internal/service/antigravity_credits_overages_test.go
+++ b/backend/internal/service/antigravity_credits_overages_test.go
@@ -239,7 +239,7 @@ func TestAntigravityRetryLoop_ModelRateLimited_InjectsCredits(t *testing.T) {
 		Extra: map[string]any{
 			"allow_overages": true,
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limited_at":     time.Now().UTC().Format(time.RFC3339),
 					"rate_limit_reset_at": time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339),
 				},
@@ -290,7 +290,7 @@ func TestAntigravityRetryLoop_CreditsExhausted_DoesNotInject(t *testing.T) {
 		Extra: map[string]any{
 			"allow_overages": true,
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limited_at":     time.Now().UTC().Format(time.RFC3339),
 					"rate_limit_reset_at": time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339),
 				},
@@ -355,7 +355,7 @@ func TestAntigravityRetryLoop_CreditErrorMarksExhausted(t *testing.T) {
 		Extra: map[string]any{
 			"allow_overages": true,
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limited_at":     time.Now().UTC().Format(time.RFC3339),
 					"rate_limit_reset_at": time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339),
 				},
@@ -503,7 +503,7 @@ func TestClearCreditsExhausted(t *testing.T) {
 			ID: 1,
 			Extra: map[string]any{
 				modelRateLimitsKey: map[string]any{
-					"claude-sonnet-4-5": map[string]any{
+					"claude-sonnet-4-6": map[string]any{
 						"rate_limited_at":     "2026-03-15T00:00:00Z",
 						"rate_limit_reset_at": "2099-03-15T00:00:00Z",
 					},
@@ -520,7 +520,7 @@ func TestClearCreditsExhausted(t *testing.T) {
 			ID: 1,
 			Extra: map[string]any{
 				modelRateLimitsKey: map[string]any{
-					"claude-sonnet-4-5": map[string]any{
+					"claude-sonnet-4-6": map[string]any{
 						"rate_limited_at":     "2026-03-15T00:00:00Z",
 						"rate_limit_reset_at": "2099-03-15T00:00:00Z",
 					},
@@ -538,7 +538,7 @@ func TestClearCreditsExhausted(t *testing.T) {
 		_, exists := rawLimits[creditsExhaustedKey]
 		require.False(t, exists, "AICredits key 应被删除")
 		// 普通模型限流应保留
-		_, exists = rawLimits["claude-sonnet-4-5"]
+		_, exists = rawLimits["claude-sonnet-4-6"]
 		require.True(t, exists, "普通模型限流应保留")
 	})
 }

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -980,14 +980,8 @@ func (s *AntigravityGatewayService) getMappedModel(account *Account, requestedMo
 }
 
 // applyThinkingModelSuffix 根据 thinking 配置调整模型名
-// 当映射结果是 claude-sonnet-4-5 且请求开启了 thinking 时，改为 claude-sonnet-4-5-thinking
+// Sonnet 4.5 已统一映射到 4.6，此函数保留为扩展点
 func applyThinkingModelSuffix(mappedModel string, thinkingEnabled bool) string {
-	if !thinkingEnabled {
-		return mappedModel
-	}
-	if mappedModel == "claude-sonnet-4-5" {
-		return "claude-sonnet-4-5-thinking"
-	}
 	return mappedModel
 }
 

--- a/backend/internal/service/antigravity_model_mapping_test.go
+++ b/backend/internal/service/antigravity_model_mapping_test.go
@@ -69,10 +69,10 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-sonnet-4-6",
 		},
 		{
-			name:           "默认映射 - claude-sonnet-4-5-20250929 → claude-sonnet-4-5",
+			name:           "默认映射 - claude-sonnet-4-5-20250929 → claude-sonnet-4-6",
 			requestedModel: "claude-sonnet-4-5-20250929",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-5",
+			expected:       "claude-sonnet-4-6",
 		},
 
 		// 3. 默认映射中的透传（映射到自己）
@@ -83,10 +83,10 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-sonnet-4-6",
 		},
 		{
-			name:           "默认映射透传 - claude-sonnet-4-5",
+			name:           "默认映射 - claude-sonnet-4-5 → claude-sonnet-4-6",
 			requestedModel: "claude-sonnet-4-5",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-5",
+			expected:       "claude-sonnet-4-6",
 		},
 		{
 			name:           "默认映射透传 - claude-opus-4-6-thinking",
@@ -95,10 +95,10 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-opus-4-6-thinking",
 		},
 		{
-			name:           "默认映射透传 - claude-sonnet-4-5-thinking",
+			name:           "默认映射 - claude-sonnet-4-5-thinking → claude-sonnet-4-6",
 			requestedModel: "claude-sonnet-4-5-thinking",
 			accountMapping: nil,
-			expected:       "claude-sonnet-4-5-thinking",
+			expected:       "claude-sonnet-4-6",
 		},
 		{
 			name:           "默认映射透传 - gemini-2.5-flash",

--- a/backend/internal/service/antigravity_rate_limit_test.go
+++ b/backend/internal/service/antigravity_rate_limit_test.go
@@ -205,7 +205,7 @@ func TestHandleUpstreamError_429_NonModelRateLimit(t *testing.T) {
 	// 但 429 兜底逻辑会使用 requestedModel 设置模型级限流
 	require.Nil(t, result)
 	require.Len(t, repo.modelRateLimitCalls, 1)
-	require.Equal(t, "claude-sonnet-4-5", repo.modelRateLimitCalls[0].modelKey)
+	require.Equal(t, "claude-sonnet-4-6", repo.modelRateLimitCalls[0].modelKey)
 }
 
 // TestHandleUpstreamError_429_NonModelRateLimit_UsesMappedModelKey 测试 429 非模型限流场景
@@ -831,7 +831,7 @@ func TestAntigravityRetryLoop_PreCheck_SwitchesWhenRateLimited(t *testing.T) {
 		Concurrency: 1,
 		Extra: map[string]any{
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limit_reset_at": time.Now().Add(2 * time.Second).Format(time.RFC3339),
 				},
 			},
@@ -874,7 +874,7 @@ func TestAntigravityRetryLoop_PreCheck_SwitchesWhenRemainingLong(t *testing.T) {
 		Concurrency: 1,
 		Extra: map[string]any{
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limit_reset_at": time.Now().Add(11 * time.Second).Format(time.RFC3339),
 				},
 			},

--- a/backend/internal/service/antigravity_single_account_retry_test.go
+++ b/backend/internal/service/antigravity_single_account_retry_test.go
@@ -689,7 +689,7 @@ func TestAntigravityRetryLoop_PreCheck_SingleAccountRetry_SkipsRateLimit(t *test
 		Concurrency: 1,
 		Extra: map[string]any{
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limit_reset_at": time.Now().Add(30 * time.Second).Format(time.RFC3339),
 				},
 			},
@@ -733,7 +733,7 @@ func TestAntigravityRetryLoop_PreCheck_NoSingleAccountRetry_SwitchesOnRateLimit(
 		Concurrency: 1,
 		Extra: map[string]any{
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limit_reset_at": time.Now().Add(30 * time.Second).Format(time.RFC3339),
 				},
 			},

--- a/backend/internal/service/antigravity_thinking_test.go
+++ b/backend/internal/service/antigravity_thinking_test.go
@@ -27,12 +27,12 @@ func TestApplyThinkingModelSuffix(t *testing.T) {
 			expected:        "claude-opus-4-6-thinking",
 		},
 
-		// Thinking 开启 + claude-sonnet-4-5：自动添加后缀
+		// Thinking 开启 + claude-sonnet-4-5：Sonnet 4.5 已统一映射到 4.6，不再特殊处理
 		{
-			name:            "thinking enabled - claude-sonnet-4-5 becomes thinking version",
+			name:            "thinking enabled - claude-sonnet-4-5 unchanged (mapped to 4.6 elsewhere)",
 			mappedModel:     "claude-sonnet-4-5",
 			thinkingEnabled: true,
-			expected:        "claude-sonnet-4-5-thinking",
+			expected:        "claude-sonnet-4-5",
 		},
 
 		// Thinking 开启 + 其他模型：保持原样

--- a/backend/internal/service/gateway_service_antigravity_whitelist_test.go
+++ b/backend/internal/service/gateway_service_antigravity_whitelist_test.go
@@ -103,7 +103,8 @@ func TestGatewayService_isModelSupportedByAccountWithContext_ThinkingMode(t *tes
 			expected:        false,
 		},
 		// 场景 3: 配置 claude-sonnet-4-5（非 thinking），请求 claude-sonnet-4-5 + thinking=true
-		// 最终模型名 = claude-sonnet-4-5-thinking，不在 mapping 中，应该不匹配
+		// applyThinkingModelSuffix 已简化为直通，不再添加 -thinking 后缀
+		// 最终模型名仍为 claude-sonnet-4-5，在 mapping 中 → 返回 true
 		{
 			name: "thinking_enabled_no_match_non_thinking_mapping",
 			modelMapping: map[string]any{
@@ -111,7 +112,7 @@ func TestGatewayService_isModelSupportedByAccountWithContext_ThinkingMode(t *tes
 			},
 			requestedModel:  "claude-sonnet-4-5",
 			thinkingEnabled: true,
-			expected:        false,
+			expected:        true,
 		},
 		// 场景 4: 配置两种模型，请求 claude-sonnet-4-5 + thinking=true，应该匹配 thinking 版本
 		{

--- a/backend/internal/service/model_rate_limit_test.go
+++ b/backend/internal/service/model_rate_limit_test.go
@@ -181,11 +181,12 @@ func TestIsModelRateLimited_Antigravity_ThinkingAffectsModelKey(t *testing.T) {
 	now := time.Now()
 	future := now.Add(10 * time.Minute).Format(time.RFC3339)
 
+	// Sonnet 4.5 now maps to Sonnet 4.6, so rate limit key is claude-sonnet-4-6
 	account := &Account{
 		Platform: PlatformAntigravity,
 		Extra: map[string]any{
 			modelRateLimitsKey: map[string]any{
-				"claude-sonnet-4-5-thinking": map[string]any{
+				"claude-sonnet-4-6": map[string]any{
 					"rate_limit_reset_at": future,
 				},
 			},
@@ -343,7 +344,7 @@ func TestGetRateLimitRemainingTime(t *testing.T) {
 				Platform: PlatformAntigravity,
 				Extra: map[string]any{
 					modelRateLimitsKey: map[string]any{
-						"claude-sonnet-4-5": map[string]any{
+						"claude-sonnet-4-6": map[string]any{
 							"rate_limit_reset_at": future15m,
 						},
 					},
@@ -359,7 +360,7 @@ func TestGetRateLimitRemainingTime(t *testing.T) {
 				Platform: PlatformAntigravity,
 				Extra: map[string]any{
 					modelRateLimitsKey: map[string]any{
-						"claude-sonnet-4-5": map[string]any{
+						"claude-sonnet-4-6": map[string]any{
 							"rate_limit_reset_at": future5m,
 						},
 					},

--- a/backend/migrations/080_migrate_sonnet45_to_sonnet46.sql
+++ b/backend/migrations/080_migrate_sonnet45_to_sonnet46.sql
@@ -1,0 +1,16 @@
+-- 080: Migrate Sonnet 4.5 → Sonnet 4.6 for all antigravity accounts
+-- Sonnet 4.5 is no longer reliable on upstream, redirect to 4.6
+
+UPDATE accounts
+SET credentials = jsonb_set(
+    credentials, '{model_mapping}',
+    (credentials->'model_mapping')
+        || '{"claude-sonnet-4-5": "claude-sonnet-4-6"}'::jsonb
+        || '{"claude-sonnet-4-5-thinking": "claude-sonnet-4-6"}'::jsonb
+        || '{"claude-sonnet-4-5-20250929": "claude-sonnet-4-6"}'::jsonb
+        || '{"claude-haiku-4-5": "claude-sonnet-4-6"}'::jsonb
+        || '{"claude-haiku-4-5-20251001": "claude-sonnet-4-6"}'::jsonb
+)
+WHERE platform = 'antigravity'
+  AND deleted_at IS NULL
+  AND credentials->'model_mapping' IS NOT NULL;

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -302,10 +302,10 @@ const geminiPresetMappings = [
 // Antigravity 预设映射（支持通配符）
 const antigravityPresetMappings = [
   // Claude 通配符映射
-  { label: 'Claude→Sonnet', from: 'claude-*', to: 'claude-sonnet-4-5', color: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400' },
-  { label: 'Sonnet→Sonnet', from: 'claude-sonnet-*', to: 'claude-sonnet-4-5', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
+  { label: 'Claude→Sonnet4.6', from: 'claude-*', to: 'claude-sonnet-4-6', color: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400' },
+  { label: 'Sonnet→4.6', from: 'claude-sonnet-*', to: 'claude-sonnet-4-6', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: 'Opus→Opus', from: 'claude-opus-*', to: 'claude-opus-4-6-thinking', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
-  { label: 'Haiku→Sonnet', from: 'claude-haiku-*', to: 'claude-sonnet-4-5', color: 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400' },
+  { label: 'Haiku→Sonnet4.6', from: 'claude-haiku-*', to: 'claude-sonnet-4-6', color: 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400' },
   { label: 'Sonnet4→4.6', from: 'claude-sonnet-4-20250514', to: 'claude-sonnet-4-6', color: 'bg-sky-100 text-sky-700 hover:bg-sky-200 dark:bg-sky-900/30 dark:text-sky-400' },
   { label: 'Sonnet4.5→4.6', from: 'claude-sonnet-4-5-20250929', to: 'claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
   { label: 'Sonnet3.5→4.6', from: 'claude-3-5-sonnet-20241022', to: 'claude-sonnet-4-6', color: 'bg-teal-100 text-teal-700 hover:bg-teal-200 dark:bg-teal-900/30 dark:text-teal-400' },
@@ -326,7 +326,7 @@ const antigravityPresetMappings = [
   { label: '2.5-Flash-Lite透传', from: 'gemini-2.5-flash-lite', to: 'gemini-2.5-flash-lite', color: 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400' },
   // 精确映射
   { label: 'Sonnet 4.6', from: 'claude-sonnet-4-6', to: 'claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
-  { label: 'Sonnet 4.5', from: 'claude-sonnet-4-5', to: 'claude-sonnet-4-5', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'Sonnet 4.5→4.6', from: 'claude-sonnet-4-5', to: 'claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'claude-opus-4-6-thinking', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.6-thinking', from: 'claude-opus-4-6-thinking', to: 'claude-opus-4-6-thinking', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' }
 ]


### PR DESCRIPTION
## 背景 / Background

Sonnet 4.5 在上游已不再稳定可用，需要将所有 Sonnet 4.5 变体统一重定向到 Sonnet 4.6。

Sonnet 4.5 is no longer reliable on upstream and needs to be redirected to Sonnet 4.6.

---

## 目的 / Purpose

将默认模型映射、DB 存量数据和前端预设中的 Sonnet 4.5 全部迁移到 Sonnet 4.6，确保用户请求 Sonnet 4.5 时自动使用 4.6。

Migrate all Sonnet 4.5 references (default mapping, DB records, frontend presets) to Sonnet 4.6, so that requests for Sonnet 4.5 are automatically served by 4.6.

---

## 改动内容 / Changes

### 后端 / Backend

- **默认映射更新**：`constants.go` 中 `claude-sonnet-4-5`、`claude-sonnet-4-5-thinking`、`claude-sonnet-4-5-20250929` 全部映射到 `claude-sonnet-4-6`
- **简化 thinking 后缀逻辑**：`applyThinkingModelSuffix` 不再需要特殊处理 Sonnet 4.5（已统一映射到 4.6）
- **DB 迁移脚本**：`080_migrate_sonnet45_to_sonnet46.sql` 更新所有 antigravity 账号的 `model_mapping`
- **测试同步**：`model_rate_limit_test.go` 中的 rate limit key 跟随映射更新

---

- **Default mapping update**: `constants.go` — `claude-sonnet-4-5`, `claude-sonnet-4-5-thinking`, `claude-sonnet-4-5-20250929` all map to `claude-sonnet-4-6`
- **Simplify thinking suffix logic**: `applyThinkingModelSuffix` no longer needs Sonnet 4.5 special handling (all mapped to 4.6)
- **DB migration**: `080_migrate_sonnet45_to_sonnet46.sql` updates all antigravity accounts' `model_mapping`
- **Test sync**: `model_rate_limit_test.go` rate limit keys updated accordingly

### 前端 / Frontend

- **预设映射标签更新**：通配符映射和精确映射的 label 和 target 从 `sonnet-4-5` 更新到 `sonnet-4-6`

---

- **Preset mapping labels updated**: wildcard and exact mapping labels and targets changed from `sonnet-4-5` to `sonnet-4-6`