### PR TITLE
fix(handler): distinguish concurrency timeout diagnostics

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -205,7 +205,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		// On error, allow request to proceed
 	} else if !canWait {
 		reqLog.Info("gateway.user_wait_queue_full", zap.Int("max_wait", maxWait))
-		h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", "Too many pending requests, please retry later")
+		h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", tooManyPendingRequestsMessage)
 		return
 	}
 	if err == nil && canWait {
@@ -349,7 +349,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Int64("account_id", account.ID),
 						zap.Int("max_waiting", selection.WaitPlan.MaxWaiting),
 					)
-					h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error", "Too many pending requests, please retry later", streamStarted)
+					h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error", tooManyPendingRequestsMessage, streamStarted)
 					return
 				}
 				if err == nil && canWait {
@@ -558,7 +558,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 						zap.Int64("account_id", account.ID),
 						zap.Int("max_waiting", selection.WaitPlan.MaxWaiting),
 					)
-					h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error", "Too many pending requests, please retry later", streamStarted)
+					h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error", tooManyPendingRequestsMessage, streamStarted)
 					return
 				}
 				if err == nil && canWait {
@@ -1188,7 +1188,7 @@ func (h *GatewayHandler) calculateSubscriptionRemaining(group *service.Group, su
 // handleConcurrencyError handles concurrency-related errors with proper 429 response
 func (h *GatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
-		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+		formatConcurrencyErrorMessage(err, slotType), streamStarted)
 }
 
 func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, platform string, streamStarted bool) {

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -125,6 +126,8 @@ const (
 	backoffMultiplier = 1.5
 	// maxBackoff 最大退避时间
 	maxBackoff = 2 * time.Second
+
+	tooManyPendingRequestsMessage = "Too many pending requests, please retry later"
 )
 
 // SSEPingFormat defines the format of SSE ping events for different platforms
@@ -150,6 +153,29 @@ func (e *ConcurrencyError) Error() string {
 		return fmt.Sprintf("timeout waiting for %s concurrency slot", e.SlotType)
 	}
 	return fmt.Sprintf("%s concurrency limit reached", e.SlotType)
+}
+
+func formatConcurrencyErrorMessage(err error, slotType string) string {
+	var concurrencyErr *ConcurrencyError
+	if errors.As(err, &concurrencyErr) && concurrencyErr.IsTimeout {
+		switch slotType {
+		case "account":
+			return "Timed out waiting for an available account slot, please retry later"
+		case "user":
+			return "Timed out waiting for an available user slot, please retry later"
+		default:
+			return fmt.Sprintf("Timed out waiting for an available %s slot, please retry later", slotType)
+		}
+	}
+
+	switch slotType {
+	case "account":
+		return "Account concurrency limit reached, please retry later"
+	case "user":
+		return "User concurrency limit reached, please retry later"
+	default:
+		return fmt.Sprintf("%s concurrency limit reached, please retry later", slotType)
+	}
 }
 
 // ConcurrencyHelper provides common concurrency slot management for gateway handlers

--- a/backend/internal/handler/gateway_helper_test.go
+++ b/backend/internal/handler/gateway_helper_test.go
@@ -139,3 +139,36 @@ func BenchmarkWrapReleaseOnDone(b *testing.B) {
 		release()
 	}
 }
+
+func TestFormatConcurrencyErrorMessage(t *testing.T) {
+	t.Run("account timeout", func(t *testing.T) {
+		err := &ConcurrencyError{SlotType: "account", IsTimeout: true}
+		got := formatConcurrencyErrorMessage(err, "account")
+		if got != "Timed out waiting for an available account slot, please retry later" {
+			t.Fatalf("unexpected message: %q", got)
+		}
+	})
+
+	t.Run("user timeout", func(t *testing.T) {
+		err := &ConcurrencyError{SlotType: "user", IsTimeout: true}
+		got := formatConcurrencyErrorMessage(err, "user")
+		if got != "Timed out waiting for an available user slot, please retry later" {
+			t.Fatalf("unexpected message: %q", got)
+		}
+	})
+
+	t.Run("account limit", func(t *testing.T) {
+		err := &ConcurrencyError{SlotType: "account", IsTimeout: false}
+		got := formatConcurrencyErrorMessage(err, "account")
+		if got != "Account concurrency limit reached, please retry later" {
+			t.Fatalf("unexpected message: %q", got)
+		}
+	})
+
+	t.Run("fallback non-concurrency error", func(t *testing.T) {
+		got := formatConcurrencyErrorMessage(context.DeadlineExceeded, "user")
+		if got != "User concurrency limit reached, please retry later" {
+			t.Fatalf("unexpected message: %q", got)
+		}
+	})
+}

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -197,7 +197,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		reqLog.Warn("gemini.user_wait_counter_increment_failed", zap.Error(err))
 	} else if !canWait {
 		reqLog.Info("gemini.user_wait_queue_full", zap.Int("max_wait", maxWait))
-		googleError(c, http.StatusTooManyRequests, "Too many pending requests, please retry later")
+		googleError(c, http.StatusTooManyRequests, tooManyPendingRequestsMessage)
 		return
 	}
 	if err == nil && canWait {
@@ -217,7 +217,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 	userReleaseFunc, err := geminiConcurrency.AcquireUserSlotWithWait(c, authSubject.UserID, authSubject.Concurrency, stream, &streamStarted)
 	if err != nil {
 		reqLog.Warn("gemini.user_slot_acquire_failed", zap.Error(err))
-		googleError(c, http.StatusTooManyRequests, err.Error())
+		googleError(c, http.StatusTooManyRequests, formatConcurrencyErrorMessage(err, "user"))
 		return
 	}
 	if waitCounted {
@@ -414,7 +414,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 					zap.Int64("account_id", account.ID),
 					zap.Int("max_waiting", selection.WaitPlan.MaxWaiting),
 				)
-				googleError(c, http.StatusTooManyRequests, "Too many pending requests, please retry later")
+				googleError(c, http.StatusTooManyRequests, tooManyPendingRequestsMessage)
 				return
 			}
 			if err == nil && canWait {
@@ -436,7 +436,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 			)
 			if err != nil {
 				reqLog.Warn("gemini.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
-				googleError(c, http.StatusTooManyRequests, err.Error())
+				googleError(c, http.StatusTooManyRequests, formatConcurrencyErrorMessage(err, "account"))
 				return
 			}
 			if accountWaitCounted {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1414,7 +1414,7 @@ func (h *OpenAIGatewayHandler) submitUsageRecordTask(task service.UsageRecordTas
 // handleConcurrencyError handles concurrency-related errors with proper 429 response
 func (h *OpenAIGatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
-		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+		formatConcurrencyErrorMessage(err, slotType), streamStarted)
 }
 
 func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {

--- a/backend/internal/handler/sora_gateway_handler.go
+++ b/backend/internal/handler/sora_gateway_handler.go
@@ -181,7 +181,7 @@ func (h *SoraGatewayHandler) ChatCompletions(c *gin.Context) {
 		reqLog.Warn("sora.user_wait_counter_increment_failed", zap.Error(err))
 	} else if !canWait {
 		reqLog.Info("sora.user_wait_queue_full", zap.Int("max_wait", maxWait))
-		h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", "Too many pending requests, please retry later")
+		h.errorResponse(c, http.StatusTooManyRequests, "rate_limit_error", tooManyPendingRequestsMessage)
 		return
 	}
 	if err == nil && canWait {
@@ -285,7 +285,7 @@ func (h *SoraGatewayHandler) ChatCompletions(c *gin.Context) {
 					zap.Bool("tls_fingerprint_enabled", tlsFingerprintEnabled),
 					zap.Int("max_waiting", selection.WaitPlan.MaxWaiting),
 				)
-				h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error", "Too many pending requests, please retry later", streamStarted)
+				h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error", tooManyPendingRequestsMessage, streamStarted)
 				return
 			}
 			if err == nil && canWait {
@@ -480,7 +480,7 @@ func (h *SoraGatewayHandler) submitUsageRecordTask(task service.UsageRecordTask)
 
 func (h *SoraGatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
-		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+		formatConcurrencyErrorMessage(err, slotType), streamStarted)
 }
 
 func (h *SoraGatewayHandler) handleFailoverExhausted(c *gin.Context, statusCode int, responseHeaders http.Header, responseBody []byte, streamStarted bool) {

--- a/backend/internal/pkg/logger/logger.go
+++ b/backend/internal/pkg/logger/logger.go
@@ -47,6 +47,7 @@ var (
 	sugar         atomic.Pointer[zap.SugaredLogger]
 	atomicLevel   zap.AtomicLevel
 	initOptions   InitOptions
+	activeClosers []io.Closer
 	currentSink   atomic.Value // sinkState
 	stdLogUndo    func()
 	bootstrapOnce sync.Once
@@ -72,16 +73,18 @@ func Init(options InitOptions) error {
 
 func initLocked(options InitOptions) error {
 	normalized := options.normalized()
-	zl, al, err := buildLogger(normalized)
+	zl, al, closers, err := buildLogger(normalized)
 	if err != nil {
 		return err
 	}
 
 	prev := global.Load()
+	prevClosers := activeClosers
 	global.Store(zl)
 	sugar.Store(zl.Sugar())
 	atomicLevel = al
 	initOptions = normalized
+	activeClosers = closers
 
 	bridgeSlogLocked()
 	bridgeStdLogLocked()
@@ -89,6 +92,7 @@ func initLocked(options InitOptions) error {
 	if prev != nil {
 		_ = prev.Sync()
 	}
+	closeClosers(prevClosers)
 	return nil
 }
 
@@ -205,6 +209,19 @@ func Sync() {
 	}
 }
 
+func Close() {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if l := global.Load(); l != nil {
+		_ = l.Sync()
+	}
+	closeClosers(activeClosers)
+	activeClosers = nil
+	global.Store(nil)
+	sugar.Store(nil)
+}
+
 func bridgeStdLogLocked() {
 	if stdLogUndo != nil {
 		stdLogUndo()
@@ -238,7 +255,7 @@ func bridgeSlogLocked() {
 	slog.SetDefault(slog.New(newSlogZapHandler(base.Named("slog"))))
 }
 
-func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
+func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, []io.Closer, error) {
 	level, _ := parseLevel(options.Level)
 	atomic := zap.NewAtomicLevelAt(level)
 
@@ -265,6 +282,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 
 	sinkCore := newSinkCore()
 	cores := make([]zapcore.Core, 0, 3)
+	closers := make([]io.Closer, 0, 1)
 
 	if options.Output.ToStdout {
 		infoPriority := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
@@ -278,7 +296,7 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 	}
 
 	if options.Output.ToFile {
-		fileCore, filePath, fileErr := buildFileCore(enc, atomic, options)
+		fileCore, fileCloser, filePath, fileErr := buildFileCore(enc, atomic, options)
 		if fileErr != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "time=%s level=WARN msg=\"日志文件输出初始化失败，降级为仅标准输出\" path=%s err=%v\n",
 				time.Now().Format(time.RFC3339Nano),
@@ -287,6 +305,9 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 			)
 		} else {
 			cores = append(cores, fileCore)
+			if fileCloser != nil {
+				closers = append(closers, fileCloser)
+			}
 		}
 	}
 
@@ -313,10 +334,10 @@ func buildLogger(options InitOptions) (*zap.Logger, zap.AtomicLevel, error) {
 		zap.String("service", options.ServiceName),
 		zap.String("env", options.Environment),
 	)
-	return logger, atomic, nil
+	return logger, atomic, closers, nil
 }
 
-func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, string, error) {
+func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOptions) (zapcore.Core, io.Closer, string, error) {
 	filePath := options.Output.FilePath
 	if strings.TrimSpace(filePath) == "" {
 		filePath = resolveLogFilePath("")
@@ -324,7 +345,7 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 
 	dir := filepath.Dir(filePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, filePath, err
+		return nil, nil, filePath, err
 	}
 	lj := &lumberjack.Logger{
 		Filename:   filePath,
@@ -334,7 +355,16 @@ func buildFileCore(enc zapcore.Encoder, atomic zap.AtomicLevel, options InitOpti
 		Compress:   options.Rotation.Compress,
 		LocalTime:  options.Rotation.LocalTime,
 	}
-	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), filePath, nil
+	return zapcore.NewCore(enc, zapcore.AddSync(lj), atomic), lj, filePath, nil
+}
+
+func closeClosers(closers []io.Closer) {
+	for _, closer := range closers {
+		if closer == nil {
+			continue
+		}
+		_ = closer.Close()
+	}
 }
 
 type sinkCore struct {

--- a/backend/internal/pkg/logger/logger_test.go
+++ b/backend/internal/pkg/logger/logger_test.go
@@ -5,9 +5,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
+
+func syncTestLogger() {
+	if runtime.GOOS == "windows" {
+		return
+	}
+	Sync()
+}
 
 func TestInit_DualOutput(t *testing.T) {
 	tmpDir := t.TempDir()
@@ -54,10 +62,11 @@ func TestInit_DualOutput(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("dual-output-info")
 	L().Warn("dual-output-warn")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -121,6 +130,7 @@ func TestInit_FileOutputFailureDowngrade(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Init() should downgrade instead of failing, got: %v", err)
 	}
+	t.Cleanup(Close)
 
 	_ = stderrW.Close()
 	stderrBytes, _ := io.ReadAll(stderrR)
@@ -164,9 +174,10 @@ func TestInit_CallerShouldPointToCallsite(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	L().Info("caller-check")
-	Sync()
+	syncTestLogger()
 	_ = stdoutW.Close()
 	logBytes, _ := io.ReadAll(stdoutR)
 

--- a/backend/internal/pkg/logger/options_test.go
+++ b/backend/internal/pkg/logger/options_test.go
@@ -95,7 +95,7 @@ func TestBuildFileCore_InvalidPathFallback(t *testing.T) {
 		EncodeLevel: zapcore.CapitalLevelEncoder,
 	}
 	encoder := zapcore.NewJSONEncoder(encoderCfg)
-	_, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
+	_, _, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
 	if err == nil {
 		t.Fatalf("buildFileCore() expected error for invalid path")
 	}

--- a/backend/internal/pkg/logger/stdlog_bridge_test.go
+++ b/backend/internal/pkg/logger/stdlog_bridge_test.go
@@ -73,11 +73,12 @@ func TestStdLogBridgeRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	log.Printf("service started")
 	log.Printf("Warning: queue full")
 	log.Printf("Forward request failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()
@@ -135,11 +136,12 @@ func TestLegacyPrintfRoutesLevels(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Init() error: %v", err)
 	}
+	t.Cleanup(Close)
 
 	LegacyPrintf("service.test", "request started")
 	LegacyPrintf("service.test", "Warning: queue full")
 	LegacyPrintf("service.test", "forward failed: timeout")
-	Sync()
+	syncTestLogger()
 
 	_ = stdoutW.Close()
 	_ = stderrW.Close()


### PR DESCRIPTION
## Summary
- distinguish account/user slot wait timeout messages from generic concurrency saturation messages
- keep wait-queue-full responses on the existing \Too many pending requests\ wording while making slot timeout diagnostics explicit
- apply the same concurrency error formatting to Claude-compatible, OpenAI, Gemini native, and Sora handlers
- include the Windows logger handle cleanup required for reliable local full-suite verification

## Why
This addresses the current ambiguity behind messages like Concurrency limit exceeded for account, please retry later.

Today, account/user slot wait timeouts and actual concurrency saturation are both surfaced with nearly the same wording. In practice this makes it hard to tell whether a user truly exceeded configured concurrency or simply waited too long for a long-lived slot to free up.

After this change:
- wait queue full => Too many pending requests, please retry later
- account slot wait timeout => Timed out waiting for an available account slot, please retry later
- user slot wait timeout => Timed out waiting for an available user slot, please retry later
- non-timeout concurrency rejection keeps an explicit account/user concurrency limit message

## Testing
- go test -p 1 ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run ./...

## Notes
This PR keeps scheduling behavior unchanged. It only improves diagnostics and operator visibility so concurrency incidents are easier to classify and debug.