### PR TITLE
fix: align Alpine version to 3.21 in deploy/Dockerfile

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -8,7 +8,7 @@
 
 ARG NODE_IMAGE=node:24-alpine
 ARG GOLANG_IMAGE=golang:1.26.1-alpine
-ARG ALPINE_IMAGE=alpine:3.20
+ARG ALPINE_IMAGE=alpine:3.21
 ARG GOPROXY=https://goproxy.cn,direct
 ARG GOSUMDB=sum.golang.google.cn
 


### PR DESCRIPTION
## Summary
- Updated `deploy/Dockerfile` to use `alpine:3.21` instead of `alpine:3.20`, matching the root `Dockerfile` and `Dockerfile.goreleaser` for consistency across all build configurations.

## Test plan
- [ ] Verify `docker build -f deploy/Dockerfile .` succeeds with alpine:3.21