### PR TITLE
fix: add timeout-minutes to backend CI workflow jobs

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -29,6 +30,7 @@ jobs:
 
   golangci-lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 30` to the `test` job (unit + integration tests)
- Add `timeout-minutes: 15` to the `golangci-lint` job

Prevents jobs from running up to the default 6-hour GitHub Actions timeout, saving CI minutes if a job hangs.

## Test plan
- [x] YAML syntax validated locally
- [ ] CI passes on this PR