### PR TITLE
fix: standardize healthcheck to use curl across all Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ LABEL org.opencontainers.image.source="https://github.com/Wei-Shaw/sub2api"
 RUN apk add --no-cache \
     ca-certificates \
     tzdata \
+    curl \
     su-exec \
     libpq \
     zstd-libs \
@@ -130,7 +131,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD wget -q -T 5 -O /dev/null http://localhost:${SERVER_PORT:-8080}/health || exit 1
+    CMD curl -f -s --max-time 5 http://localhost:${SERVER_PORT:-8080}/health || exit 1
 
 # Run the application (entrypoint fixes /app/data ownership then execs as sub2api)
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -55,7 +55,7 @@ RUN chmod +x /app/docker-entrypoint.sh
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:${SERVER_PORT:-8080}/health || exit 1
+    CMD curl -f -s --max-time 5 http://localhost:${SERVER_PORT:-8080}/health || exit 1
 
 # Run the application (entrypoint fixes /app/data ownership then execs as sub2api)
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -107,7 +107,7 @@ EXPOSE 8080
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD wget -q -T 5 -O /dev/null http://localhost:${SERVER_PORT:-8080}/health || exit 1
+    CMD curl -f -s --max-time 5 http://localhost:${SERVER_PORT:-8080}/health || exit 1
 
 # Run the application (entrypoint fixes /app/data ownership then execs as sub2api)
 ENTRYPOINT ["/app/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Replaced `wget`-based healthchecks with `curl` in root `Dockerfile` and `deploy/Dockerfile`
- Added consistent flags (`-f -s --max-time 5`) to the existing `curl` healthcheck in `Dockerfile.goreleaser`
- Added `curl` to the root `Dockerfile`'s `apk install` list (already present in the other two Dockerfiles)

All three Dockerfiles now use the identical healthcheck command:
```
curl -f -s --max-time 5 http://localhost:${SERVER_PORT:-8080}/health || exit 1
```

## Test plan
- [ ] Build root Dockerfile and verify healthcheck passes
- [ ] Build deploy/Dockerfile and verify healthcheck passes
- [ ] Verify Dockerfile.goreleaser builds correctly with GoReleaser