### PR TITLE
feat: add frontend CI workflow for typecheck, lint, and tests

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,34 @@
+name: Frontend CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: Install dependencies
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+      - name: Type check
+        working-directory: frontend
+        run: pnpm run typecheck
+      - name: Lint
+        working-directory: frontend
+        run: pnpm run lint:check
+      - name: Unit tests
+        working-directory: frontend
+        run: pnpm run test:run


### PR DESCRIPTION
## Summary
- Add `.github/workflows/frontend-ci.yml` GitHub Actions workflow
- Runs on push and pull_request events, matching the backend CI style
- Steps: pnpm install (frozen lockfile), vue-tsc type check, ESLint lint, Vitest unit tests

## Test plan
- [ ] Verify workflow triggers on push and PR
- [ ] Confirm pnpm cache works with `cache-dependency-path`
- [ ] Validate typecheck, lint, and test steps pass on a clean checkout