### PR TITLE
feat: implement proxy connection test logic

### DIFF
--- a/backend/internal/service/proxy_service.go
+++ b/backend/internal/service/proxy_service.go
@@ -3,9 +3,13 @@ package service
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 )
 
 var (
@@ -171,14 +175,38 @@ func (s *ProxyService) Delete(ctx context.Context, id int64) error {
 
 // TestConnection 测试代理连接（需要实现具体测试逻辑）
 func (s *ProxyService) TestConnection(ctx context.Context, id int64) error {
-	proxy, err := s.proxyRepo.GetByID(ctx, id)
+	p, err := s.proxyRepo.GetByID(ctx, id)
 	if err != nil {
 		return fmt.Errorf("get proxy: %w", err)
 	}
 
-	// TODO: 实现代理连接测试逻辑
-	// 可以尝试通过代理发送测试请求
-	_ = proxy
+	_, parsedURL, err := proxyurl.Parse(p.URL())
+	if err != nil {
+		return fmt.Errorf("parse proxy URL: %w", err)
+	}
+
+	transport := &http.Transport{}
+	if err := proxyutil.ConfigureTransportProxy(transport, parsedURL); err != nil {
+		return fmt.Errorf("configure proxy transport: %w", err)
+	}
+
+	const testTimeout = 10 * time.Second
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   testTimeout,
+	}
+	defer client.CloseIdleConnections()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, "https://httpbin.org/get", nil)
+	if err != nil {
+		return fmt.Errorf("create test request: %w", err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("proxy connection test failed: %w", err)
+	}
+	defer resp.Body.Close()
 
 	return nil
 }


### PR DESCRIPTION
Implement the TODO in proxy_service.go for testing proxy connectivity. Reuses existing proxyutil and proxyurl packages for consistent proxy handling.