### PR TITLE
fix: remove console.log from VersionBadge.vue restart handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![Go](https://img.shields.io/badge/Go-1.25.7-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.1-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-[![Go](https://img.shields.io/badge/Go-1.25.7-00ADD8.svg)](https://golang.org/)
+[![Go](https://img.shields.io/badge/Go-1.26.1-00ADD8.svg)](https://golang.org/)
 [![Vue](https://img.shields.io/badge/Vue-3.4+-4FC08D.svg)](https://vuejs.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-15+-336791.svg)](https://www.postgresql.org/)
 [![Redis](https://img.shields.io/badge/Redis-7+-DC382D.svg)](https://redis.io/)

--- a/frontend/src/components/common/VersionBadge.vue
+++ b/frontend/src/components/common/VersionBadge.vue
@@ -469,9 +469,8 @@ async function handleRestart() {
   try {
     await restartService()
     // Service will restart, page will reload automatically or show disconnected
-  } catch (error) {
+  } catch {
     // Expected - connection will be lost during restart
-    console.log('Service restarting...')
   }
 
   // Start countdown


### PR DESCRIPTION
## Summary
- Remove unnecessary `console.log('Service restarting...')` from the catch block in the restart handler
- The catch block already has a descriptive comment explaining the expected behavior (connection loss during restart), making the console.log redundant
- Also removed the unused `error` parameter from the catch clause

## Test plan
- [ ] Verify the restart functionality still works correctly without the console.log
- [ ] Confirm no other console.log statements were accidentally affected