### PR TITLE
fix: remove console.debug from useRoutePrefetch.ts

### DIFF
--- a/frontend/src/composables/useRoutePrefetch.ts
+++ b/frontend/src/composables/useRoutePrefetch.ts
@@ -106,11 +106,8 @@ export function useRoutePrefetch(router?: Router) {
   const prefetchComponent = async (importFn: ComponentImportFn): Promise<void> => {
     try {
       await importFn()
-    } catch (error) {
-      // 静默处理预加载错误
-      if (import.meta.env.DEV) {
-        console.debug('[Prefetch] Failed to prefetch component:', error)
-      }
+    } catch {
+      // 静默处理预加载错误 (silently handle prefetch errors)
     }
   }
 


### PR DESCRIPTION
## Summary
- Remove `console.debug('[Prefetch] Failed to prefetch component:', error)` from the prefetch error handler
- Remove the surrounding `import.meta.env.DEV` guard block since it only contained the console.debug call
- Prefetch failures are expected and non-critical; silent handling with the existing comment is sufficient

## Test plan
- [ ] Verify route prefetching still works correctly
- [ ] Confirm no runtime errors when prefetch fails silently