### PR TITLE
fix: update Go version reference to 1.26.1 in DEV_GUIDE.md

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -53,7 +53,7 @@ npm install -g pnpm
 
 ### CI 要求
 
-- Go 版本必须是 **1.25.7**
+- Go 版本必须是 **1.26.1**
 - 前端使用 `pnpm install --frozen-lockfile`，必须提交 `pnpm-lock.yaml`
 
 ### 本地测试命令


### PR DESCRIPTION
## Summary
- Update Go version requirement from 1.25.7 to 1.26.1 in DEV_GUIDE.md CI requirements section (line 56)

## Test plan
- [x] Verify the version string is correctly updated