### PR TITLE
fix: improve TypeScript type safety in SelectOption interface

### DIFF
--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,7 +7,8 @@
 export interface SelectOption {
   value: string | number | boolean | null
   label: string
-  [key: string]: any // Support extra properties for custom templates
+  disabled?: boolean
+  [key: string]: string | number | boolean | null | undefined
 }
 
 export interface BasePaginationResponse<T> {


### PR DESCRIPTION
## Summary
- Replace `[key: string]: any` index signature in `SelectOption` interface with a specific union type `string | number | boolean | null | undefined`
- Add optional `disabled` property to align with the `Select.vue` component's `SelectOption` interface

## Test plan
- [x] `npm run typecheck` passes with no errors