### PR TITLE
fix: add account and proxy details to forward_failed log

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -422,11 +422,24 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					}
 				}
 				wroteFallback := h.ensureForwardErrorResponse(c, streamStarted)
-				reqLog.Error("gateway.forward_failed",
+				forwardFailedFields := []zap.Field{
 					zap.Int64("account_id", account.ID),
+					zap.String("account_name", account.Name),
+					zap.String("account_platform", account.Platform),
 					zap.Bool("fallback_error_response_written", wroteFallback),
 					zap.Error(err),
-				)
+				}
+				if account.Proxy != nil {
+					forwardFailedFields = append(forwardFailedFields,
+						zap.Int64("proxy_id", account.Proxy.ID),
+						zap.String("proxy_name", account.Proxy.Name),
+						zap.String("proxy_host", account.Proxy.Host),
+						zap.Int("proxy_port", account.Proxy.Port),
+					)
+				} else if account.ProxyID != nil {
+					forwardFailedFields = append(forwardFailedFields, zap.Int64p("proxy_id", account.ProxyID))
+				}
+				reqLog.Error("gateway.forward_failed", forwardFailedFields...)
 				return
 			}
 
@@ -741,11 +754,24 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					}
 				}
 				wroteFallback := h.ensureForwardErrorResponse(c, streamStarted)
-				reqLog.Error("gateway.forward_failed",
+				forwardFailedFields := []zap.Field{
 					zap.Int64("account_id", account.ID),
+					zap.String("account_name", account.Name),
+					zap.String("account_platform", account.Platform),
 					zap.Bool("fallback_error_response_written", wroteFallback),
 					zap.Error(err),
-				)
+				}
+				if account.Proxy != nil {
+					forwardFailedFields = append(forwardFailedFields,
+						zap.Int64("proxy_id", account.Proxy.ID),
+						zap.String("proxy_name", account.Proxy.Name),
+						zap.String("proxy_host", account.Proxy.Host),
+						zap.Int("proxy_port", account.Proxy.Port),
+					)
+				} else if account.ProxyID != nil {
+					forwardFailedFields = append(forwardFailedFields, zap.Int64p("proxy_id", account.ProxyID))
+				}
+				reqLog.Error("gateway.forward_failed", forwardFailedFields...)
 				return
 			}
 


### PR DESCRIPTION
## Summary
- `gateway.forward_failed` 日志之前只有 `account_id`，排查时需要查库才能知道是哪个账号、哪个代理出了问题
- 新增 `account_name`、`account_platform` 字段，以及代理详情（`proxy_id`、`proxy_name`、`proxy_host`、`proxy_port`）
- 修复了两处 `gateway.forward_failed` 日志（OpenAI 和 Anthropic 转发路径）

## Test plan
- [ ] 触发转发失败场景，验证日志中包含账号名称和代理信息
- [ ] 验证无代理账号的转发失败日志不包含代理字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)