### PR TITLE
fix(identity): 统一 metadata.user_id 的 device_id 来源，消除身份不一致

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -139,7 +139,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	schedulerSnapshotService := service.ProvideSchedulerSnapshotService(schedulerCache, schedulerOutboxRepository, accountRepository, groupRepository, configConfig)
 	antigravityTokenProvider := service.ProvideAntigravityTokenProvider(accountRepository, geminiTokenCache, antigravityOAuthService, oauthRefreshAPI, tempUnschedCache)
 	antigravityGatewayService := service.NewAntigravityGatewayService(accountRepository, gatewayCache, schedulerSnapshotService, antigravityTokenProvider, rateLimitService, httpUpstream, settingService)
-	accountTestService := service.NewAccountTestService(accountRepository, geminiTokenProvider, antigravityGatewayService, httpUpstream, configConfig)
+	identityService := service.NewIdentityService(identityCache)
+	accountTestService := service.NewAccountTestService(accountRepository, identityService, geminiTokenProvider, antigravityGatewayService, httpUpstream, configConfig)
 	crsSyncService := service.NewCRSSyncService(accountRepository, proxyRepository, oAuthService, openAIOAuthService, geminiOAuthService, configConfig)
 	sessionLimitCache := repository.ProvideSessionLimitCache(redisClient, configConfig)
 	rpmCache := repository.NewRPMCache(redisClient)
@@ -167,7 +168,6 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 		return nil, err
 	}
 	billingService := service.NewBillingService(configConfig, pricingService)
-	identityService := service.NewIdentityService(identityCache)
 	deferredService := service.ProvideDeferredService(accountRepository, timingWheelService)
 	claudeTokenProvider := service.ProvideClaudeTokenProvider(accountRepository, geminiTokenCache, oAuthService, oauthRefreshAPI)
 	digestSessionStore := service.NewDigestSessionStore()

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -778,6 +778,7 @@ func (h *AccountHandler) refreshSingleAccount(ctx context.Context, account *serv
 	}
 
 	var newCredentials map[string]any
+	var newExtra map[string]any
 
 	if account.IsOpenAI() {
 		tokenInfo, err := h.openaiOAuthService.RefreshAccountToken(ctx, account)
@@ -865,11 +866,31 @@ func (h *AccountHandler) refreshSingleAccount(ctx context.Context, account *serv
 		if strings.TrimSpace(tokenInfo.Scope) != "" {
 			newCredentials["scope"] = tokenInfo.Scope
 		}
+
+		// Persist account_uuid / org_uuid to Extra if returned by upstream
+		if tokenInfo.AccountUUID != "" || tokenInfo.OrgUUID != "" {
+			if newExtra == nil {
+				newExtra = make(map[string]any)
+				for k, v := range account.Extra {
+					newExtra[k] = v
+				}
+			}
+			if tokenInfo.AccountUUID != "" {
+				newExtra["account_uuid"] = tokenInfo.AccountUUID
+			}
+			if tokenInfo.OrgUUID != "" {
+				newExtra["org_uuid"] = tokenInfo.OrgUUID
+			}
+		}
 	}
 
-	updatedAccount, err := h.adminService.UpdateAccount(ctx, account.ID, &service.UpdateAccountInput{
+	updateInput := &service.UpdateAccountInput{
 		Credentials: newCredentials,
-	})
+	}
+	if newExtra != nil {
+		updateInput.Extra = newExtra
+	}
+	updatedAccount, err := h.adminService.UpdateAccount(ctx, account.ID, updateInput)
 	if err != nil {
 		return nil, "", err
 	}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -4,8 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -65,6 +63,7 @@ const (
 // AccountTestService handles account testing operations
 type AccountTestService struct {
 	accountRepo               AccountRepository
+	identityService           *IdentityService
 	geminiTokenProvider       *GeminiTokenProvider
 	antigravityGatewayService *AntigravityGatewayService
 	httpUpstream              HTTPUpstream
@@ -79,6 +78,7 @@ const defaultSoraTestCooldown = 10 * time.Second
 // NewAccountTestService creates a new AccountTestService
 func NewAccountTestService(
 	accountRepo AccountRepository,
+	identityService *IdentityService,
 	geminiTokenProvider *GeminiTokenProvider,
 	antigravityGatewayService *AntigravityGatewayService,
 	httpUpstream HTTPUpstream,
@@ -86,6 +86,7 @@ func NewAccountTestService(
 ) *AccountTestService {
 	return &AccountTestService{
 		accountRepo:               accountRepo,
+		identityService:           identityService,
 		geminiTokenProvider:       geminiTokenProvider,
 		antigravityGatewayService: antigravityGatewayService,
 		httpUpstream:              httpUpstream,
@@ -114,25 +115,19 @@ func (s *AccountTestService) validateUpstreamBaseURL(raw string) (string, error)
 }
 
 // generateSessionString generates a Claude Code style session string.
-// The output format is determined by the UA version in claude.DefaultHeaders,
-// ensuring consistency between the user_id format and the UA sent to upstream.
-func generateSessionString() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", err
-	}
-	hex64 := hex.EncodeToString(b)
+// clientID 和 accountUUID 应来自账号的 fingerprint 缓存和 Extra，
+// 保证同一账号在所有出口使用相同的 device_id 和 account_uuid。
+// 输出格式根据 DefaultHeaders 的 UA 版本自动选择（旧拼接 or 新 JSON）。
+func generateSessionString(clientID, accountUUID string) string {
 	sessionUUID := uuid.New().String()
 	uaVersion := ExtractCLIVersion(claude.DefaultHeaders["User-Agent"])
-	return FormatMetadataUserID(hex64, "", sessionUUID, uaVersion), nil
+	return FormatMetadataUserID(clientID, accountUUID, sessionUUID, uaVersion)
 }
 
-// createTestPayload creates a Claude Code style test request payload
-func createTestPayload(modelID string) (map[string]any, error) {
-	sessionID, err := generateSessionString()
-	if err != nil {
-		return nil, err
-	}
+// createTestPayload creates a Claude Code style test request payload.
+// clientID 和 accountUUID 用于构建稳定的 metadata.user_id。
+func createTestPayload(modelID, clientID, accountUUID string) map[string]any {
+	sessionID := generateSessionString(clientID, accountUUID)
 
 	return map[string]any{
 		"model": modelID,
@@ -165,7 +160,7 @@ func createTestPayload(modelID string) (map[string]any, error) {
 		"max_tokens":  1024,
 		"temperature": 1,
 		"stream":      true,
-	}, nil
+	}
 }
 
 // TestAccountConnection tests an account's connection by sending a test request
@@ -261,11 +256,21 @@ func (s *AccountTestService) testClaudeAccountConnection(c *gin.Context, account
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
 	c.Writer.Flush()
 
-	// Create Claude Code style payload (same for all account types)
-	payload, err := createTestPayload(testModelID)
-	if err != nil {
-		return s.sendErrorAndEnd(c, "Failed to create test payload")
+	// 获取账号的 fingerprint，保证 device_id 与正常请求一致
+	clientID := ""
+	accountUUID := account.GetExtraString("account_uuid")
+	if s.identityService != nil {
+		fp, err := s.identityService.GetOrCreateFingerprint(ctx, account.ID, c.Request.Header)
+		if err == nil && fp != nil {
+			clientID = fp.ClientID
+		}
 	}
+	if clientID == "" {
+		return s.sendErrorAndEnd(c, "Failed to get fingerprint: clientID unavailable")
+	}
+
+	// Create Claude Code style payload (same for all account types)
+	payload := createTestPayload(testModelID, clientID, accountUUID)
 	payloadBytes, _ := json.Marshal(payload)
 
 	// Send test_start event

--- a/backend/internal/service/gateway_oauth_metadata_test.go
+++ b/backend/internal/service/gateway_oauth_metadata_test.go
@@ -53,7 +53,9 @@ func TestBuildOAuthMetadataUserID_UsesAccountUUIDWhenPresent(t *testing.T) {
 		},
 	}
 
-	got := svc.buildOAuthMetadataUserID(parsed, account, nil)
+	fp := &Fingerprint{ClientID: "clientid123"}
+
+	got := svc.buildOAuthMetadataUserID(parsed, account, fp)
 	require.NotEmpty(t, got)
 
 	// New format: user_{client}_account_{account_uuid}_session_{uuid}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1101,14 +1101,16 @@ func (s *GatewayService) buildOAuthMetadataUserID(parsed *ParsedRequest, account
 		return ""
 	}
 
-	userID := strings.TrimSpace(account.GetClaudeUserID())
-	if userID == "" && fp != nil {
+	// device_id 统一使用 fp.ClientID（与 RewriteUserIDWithMasking 一致），
+	// 不使用 GetClaudeUserID()，避免同一账号在不同出口产生不同的 device_id。
+	var userID string
+	if fp != nil {
 		userID = fp.ClientID
 	}
 	if userID == "" {
-		// Fall back to a random, well-formed client id so we can still satisfy
-		// Claude Code OAuth requirements when account metadata is incomplete.
-		userID = generateClientID()
+		// fp 为 nil 或 fp.ClientID 为空均不应发生（GetOrCreateFingerprint 保证），
+		// 此处仅做防御性保护，不生成随机值以避免 device_id 不稳定。
+		return ""
 	}
 
 	sessionHash := s.GenerateSessionHash(parsed)

--- a/backend/internal/service/identity_service.go
+++ b/backend/internal/service/identity_service.go
@@ -80,6 +80,13 @@ func (s *IdentityService) GetOrCreateFingerprint(ctx context.Context, accountID 
 	if err == nil && cached != nil {
 		needWrite := false
 
+		// 修复缓存中 ClientID 为空的异常（旧数据或缓存损坏）
+		if cached.ClientID == "" {
+			cached.ClientID = generateClientID()
+			needWrite = true
+			logger.LegacyPrintf("service.identity", "Repaired empty ClientID for account %d: %s", accountID, cached.ClientID)
+		}
+
 		// 检查客户端的user-agent是否是更新版本
 		clientUA := headers.Get("User-Agent")
 		if clientUA != "" && isNewerVersion(clientUA, cached.UserAgent) {

--- a/backend/internal/service/oauth_service.go
+++ b/backend/internal/service/oauth_service.go
@@ -275,14 +275,30 @@ func (s *OAuthService) RefreshToken(ctx context.Context, refreshToken string, pr
 		return nil, err
 	}
 
-	return &TokenInfo{
+	tokenInfo := &TokenInfo{
 		AccessToken:  tokenResp.AccessToken,
 		TokenType:    tokenResp.TokenType,
 		ExpiresIn:    tokenResp.ExpiresIn,
 		ExpiresAt:    time.Now().Unix() + tokenResp.ExpiresIn,
 		RefreshToken: tokenResp.RefreshToken,
 		Scope:        tokenResp.Scope,
-	}, nil
+	}
+
+	if tokenResp.Organization != nil && tokenResp.Organization.UUID != "" {
+		tokenInfo.OrgUUID = tokenResp.Organization.UUID
+		log.Printf("[OAuth] RefreshToken: got org_uuid")
+	}
+	if tokenResp.Account != nil {
+		if tokenResp.Account.UUID != "" {
+			tokenInfo.AccountUUID = tokenResp.Account.UUID
+			log.Printf("[OAuth] RefreshToken: got account_uuid")
+		}
+		if tokenResp.Account.EmailAddress != "" {
+			tokenInfo.EmailAddress = tokenResp.Account.EmailAddress
+		}
+	}
+
+	return tokenInfo, nil
 }
 
 // RefreshAccountToken refreshes token for an account

--- a/backend/internal/service/token_refresher.go
+++ b/backend/internal/service/token_refresher.go
@@ -57,6 +57,9 @@ func (r *ClaudeTokenRefresher) NeedsRefresh(account *Account, refreshWindow time
 
 // Refresh 执行token刷新
 // 保留原有credentials中的所有字段，只更新token相关字段
+// Refresh 执行token刷新，返回更新后的credentials。
+// 同时将上游返回的 account_uuid / org_uuid 持久化到 account.Extra，
+// 供 metadata.user_id 重写使用。
 func (r *ClaudeTokenRefresher) Refresh(ctx context.Context, account *Account) (map[string]any, error) {
 	tokenInfo, err := r.oauthService.RefreshAccountToken(ctx, account)
 	if err != nil {
@@ -65,6 +68,19 @@ func (r *ClaudeTokenRefresher) Refresh(ctx context.Context, account *Account) (m
 
 	newCredentials := BuildClaudeAccountCredentials(tokenInfo)
 	newCredentials = MergeCredentials(account.Credentials, newCredentials)
+
+	// Persist account_uuid / org_uuid to Extra (saved by accountRepo.Update in caller)
+	if tokenInfo.AccountUUID != "" || tokenInfo.OrgUUID != "" {
+		if account.Extra == nil {
+			account.Extra = make(map[string]any)
+		}
+		if tokenInfo.AccountUUID != "" {
+			account.Extra["account_uuid"] = tokenInfo.AccountUUID
+		}
+		if tokenInfo.OrgUUID != "" {
+			account.Extra["org_uuid"] = tokenInfo.OrgUUID
+		}
+	}
 
 	return newCredentials, nil
 }


### PR DESCRIPTION
问题：同一账号在不同代码路径（buildOAuthMetadataUserID、测试请求、
token 刷新）使用不同的 device_id 来源（GetClaudeUserID / 随机生成 / fingerprint 缓存），导致上游看到同一账号发出的请求带有不同身份标识。

修复：
- buildOAuthMetadataUserID: 统一使用 fp.ClientID 作为 device_id， 移除 GetClaudeUserID() 和 generateClientID() 随机 fallback
- generateSessionString: 改为接收确定性参数 (clientID, accountUUID)， 不再随机生成 device_id
- AccountTestService: 注入 IdentityService，测试请求复用 fingerprint 缓存中的 ClientID，与正常请求保持一致
- GetOrCreateFingerprint: 修复缓存中 ClientID 为空的异常（旧数据兼容）
- RefreshToken: 从上游响应中提取 account_uuid / org_uuid
- ClaudeTokenRefresher: 自动刷新时将 UUID 持久化到 account.Extra
- refreshSingleAccount: 手动刷新时将 UUID 写入 Extra 并持久化