### PR TITLE
fix(gateway): preserve thinking block signature in StripEmptyTextBlocks

### DIFF
--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -254,6 +254,7 @@ func sliceRawFromBody(body []byte, r gjson.Result) []byte {
 }
 
 // stripEmptyTextBlocksFromSlice removes empty text blocks from a content slice (including nested tool_result content).
+// Used by FilterThinkingBlocksForRetry which already does full deserialization for retry purposes.
 // Returns (cleaned slice, true) if any blocks were removed, or (original, false) if unchanged.
 func stripEmptyTextBlocksFromSlice(blocks []any) ([]any, bool) {
 	var result []any
@@ -310,8 +311,60 @@ func stripEmptyTextBlocksFromSlice(blocks []any) ([]any, bool) {
 	return result, true
 }
 
+// isEmptyTextBlock checks if a gjson.Result represents an empty text block: {"type":"text","text":""}
+func isEmptyTextBlock(item gjson.Result) bool {
+	return item.Get("type").String() == "text" && item.Get("text").String() == ""
+}
+
+// collectEmptyTextBlockPathsInContent recursively collects sjson paths of empty text blocks
+// in a content array, including nested tool_result content.
+func collectEmptyTextBlockPathsInContent(content gjson.Result, basePath string, paths *[]string) {
+	if !content.IsArray() {
+		return
+	}
+	idx := 0
+	content.ForEach(func(_, item gjson.Result) bool {
+		itemPath := fmt.Sprintf("%s.%d", basePath, idx)
+		if isEmptyTextBlock(item) {
+			*paths = append(*paths, itemPath)
+		} else if item.Get("type").String() == "tool_result" {
+			nested := item.Get("content")
+			if nested.IsArray() {
+				collectEmptyTextBlockPathsInContent(nested, itemPath+".content", paths)
+			}
+		}
+		idx++
+		return true
+	})
+}
+
+// collectEmptyTextBlockPaths collects sjson paths of empty text blocks in messages,
+// including those nested inside tool_result content arrays (recursively).
+// Uses gjson for read-only traversal — never deserializes/re-serializes the body.
+func collectEmptyTextBlockPaths(body []byte) []string {
+	var paths []string
+
+	jsonStr := *(*string)(unsafe.Pointer(&body))
+	messages := gjson.Get(jsonStr, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return nil
+	}
+
+	msgIdx := 0
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		collectEmptyTextBlockPathsInContent(content, fmt.Sprintf("messages.%d.content", msgIdx), &paths)
+		msgIdx++
+		return true
+	})
+
+	return paths
+}
+
 // StripEmptyTextBlocks removes empty text blocks from the request body (including nested tool_result content).
 // This is a lightweight pre-filter for the initial request path to prevent upstream 400 errors.
+// Uses gjson/sjson path-based operations to avoid full deserialization/re-serialization,
+// which would corrupt thinking block signatures (see issue #1175).
 // Returns the original body unchanged if no empty text blocks are found.
 func StripEmptyTextBlocks(body []byte) []byte {
 	// Fast path: check if body contains empty text patterns
@@ -323,45 +376,23 @@ func StripEmptyTextBlocks(body []byte) []byte {
 		return body
 	}
 
-	jsonStr := *(*string)(unsafe.Pointer(&body))
-	msgsRes := gjson.Get(jsonStr, "messages")
-	if !msgsRes.Exists() || !msgsRes.IsArray() {
+	paths := collectEmptyTextBlockPaths(body)
+	if len(paths) == 0 {
 		return body
 	}
 
-	var messages []any
-	if err := json.Unmarshal(sliceRawFromBody(body, msgsRes), &messages); err != nil {
-		return body
-	}
+	// Delete from back to front to keep earlier indices valid.
+	sort.Sort(sort.Reverse(sort.StringSlice(paths)))
 
-	modified := false
-	for _, msg := range messages {
-		msgMap, ok := msg.(map[string]any)
-		if !ok {
+	out := body
+	for _, path := range paths {
+		next, err := sjson.DeleteBytes(out, path)
+		if err != nil {
 			continue
 		}
-		content, ok := msgMap["content"].([]any)
-		if !ok {
-			continue
-		}
-		if cleaned, changed := stripEmptyTextBlocksFromSlice(content); changed {
-			modified = true
-			msgMap["content"] = cleaned
-		}
+		out = next
 	}
 
-	if !modified {
-		return body
-	}
-
-	msgsBytes, err := json.Marshal(messages)
-	if err != nil {
-		return body
-	}
-	out, err := sjson.SetRawBytes(body, "messages", msgsBytes)
-	if err != nil {
-		return body
-	}
 	return out
 }
 

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestParseGatewayRequest(t *testing.T) {
@@ -549,6 +550,36 @@ func TestStripEmptyTextBlocks(t *testing.T) {
 		require.Len(t, deepContent, 1)
 		require.Equal(t, "deep", deepContent[0].(map[string]any)["text"])
 	})
+}
+
+func TestStripEmptyTextBlocks_PreservesThinkingBlockSignature(t *testing.T) {
+	// The body contains both a thinking block with a cryptographic signature
+	// AND an empty text block. StripEmptyTextBlocks must remove the empty text
+	// block while preserving the thinking block bytes exactly (issue #1175).
+	thinkingSig := "ErUBCkYIAxgCIkDJr+e70s8tJkfFfSO3jLCa3dP/N0dPxqKHG5MIhFSBc0rrMU4B09sDOb0m59YVc5g6VA83KjxB8eXSOCjGJkkSDAi98uK8BhC27avJBRoMCN7y4rwGEKz0wpwDIjCqVH3jjhWkHspCi+NqZpULi2r/8e0Vu2YnEWl36nkKVANkf8jI7DJQM4S0Ywik7Jw="
+	input := []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"Let me analyze this.","signature":"` + thinkingSig + `"},{"type":"text","text":"Hello!"}]},{"role":"user","content":[{"type":"text","text":"continue"},{"type":"text","text":""}]}]}`)
+
+	out := StripEmptyTextBlocks(input)
+
+	// The empty text block in the user message should be removed
+	require.NotEqual(t, input, out, "should have removed the empty text block")
+
+	// The thinking block signature must be byte-for-byte identical
+	thinkingBlock := gjson.GetBytes(out, "messages.0.content.0")
+	require.Equal(t, "thinking", thinkingBlock.Get("type").String())
+	require.Equal(t, "Let me analyze this.", thinkingBlock.Get("thinking").String())
+	require.Equal(t, thinkingSig, thinkingBlock.Get("signature").String())
+
+	// Verify the raw JSON bytes of the thinking block are unchanged
+	originalThinking := gjson.GetBytes(input, "messages.0.content.0").Raw
+	outputThinking := thinkingBlock.Raw
+	require.Equal(t, originalThinking, outputThinking, "thinking block raw bytes must be identical")
+
+	// The user message should only have 1 content block now
+	userContent := gjson.GetBytes(out, "messages.1.content")
+	require.True(t, userContent.IsArray())
+	require.Equal(t, 1, len(userContent.Array()))
+	require.Equal(t, "continue", userContent.Array()[0].Get("text").String())
 }
 
 func TestFilterThinkingBlocksForRetry_PreservesNonEmptyTextBlocks(t *testing.T) {


### PR DESCRIPTION
## 问题描述

`StripEmptyTextBlocks` 函数在处理包含 thinking block 的请求时，会破坏 thinking block 的 `signature` 字段，导致 Anthropic API 返回 400 错误：

```
messages.1.content.16: Invalid `signature` in `thinking` block
```

这在 Claude Code 等客户端的**多轮对话**中必然触发，因为 Claude Code 会将上一轮包含 thinking block（含 signature）的 assistant message 原样带入下一轮请求。

## 根因

`StripEmptyTextBlocks` 的慢路径（当 body 中检测到 `"text":""` 模式时触发）对 `messages` 数组做了**全量反序列化 → 重序列化**：

```go
// 旧实现
var messages []any
json.Unmarshal(sliceRawFromBody(body, msgsRes), &messages)  // 全量反序列化
// ... 遍历删除空 text block ...
msgsBytes, _ := json.Marshal(messages)                     // 全量重序列化 ← 破坏 signature
```

`json.Unmarshal` + `json.Marshal` 会重新编码所有字段，thinking block 的 `signature`（Anthropic 服务端生成的密码学签名）经过 Go 的 JSON 序列化后字节表示可能发生变化，导致签名校验失败。

## 影响

Claude Code 真实请求中工具调用结果（`tool_result`）经常包含空 text block（`"text":""`），会触发慢路径，使得**每一轮多轮对话**都触发 400 错误。虽然签名整流器会自动重试，但：

- thinking 上下文被完全剥离（thinking downgraded）
- 每次多 ~3 秒延迟
- 某些客户端不容忍 thinking downgrade，会持续报错导致功能不可用

## 修复方案

改用 **gjson 只读遍历 + sjson 路径级删除**，与 `enforceCacheControlLimit` 保持一致的模式，thinking block 的原始字节完全不被触碰：

```go
// 新实现
paths := collectEmptyTextBlockPaths(body)  // gjson 只读遍历，收集路径
// 从后往前按路径精确删除
for _, path := range paths {
    out, _ = sjson.DeleteBytes(out, path)  // 字节级精确操作，不触碰其他字段
}
```

`collectEmptyTextBlockPaths` 递归处理 `tool_result` 嵌套内容，功能与原实现完全等价。

## 测试

新增 `TestStripEmptyTextBlocks_PreservesThinkingBlockSignature` 测试用例：构造包含 thinking block（带 signature）+ 空 text block 的请求体，验证经过 `StripEmptyTextBlocks` 后 thinking block 的原始字节**完全不变**。

所有现有 `TestStripEmptyTextBlocks` 子测试通过。

## 关联

Fixes #1175
