### PR TITLE
feat(admin): add proxy name prefix to batch import

### DIFF
--- a/backend/internal/handler/admin/admin_basic_handlers_test.go
+++ b/backend/internal/handler/admin/admin_basic_handlers_test.go
@@ -43,6 +43,7 @@ func setupAdminRouter() (*gin.Engine, *stubAdminService) {
 	router.GET("/api/v1/admin/proxies/all", proxyHandler.GetAll)
 	router.GET("/api/v1/admin/proxies/:id", proxyHandler.GetByID)
 	router.POST("/api/v1/admin/proxies", proxyHandler.Create)
+	router.POST("/api/v1/admin/proxies/batch", proxyHandler.BatchCreate)
 	router.PUT("/api/v1/admin/proxies/:id", proxyHandler.Update)
 	router.DELETE("/api/v1/admin/proxies/:id", proxyHandler.Delete)
 	router.POST("/api/v1/admin/proxies/batch-delete", proxyHandler.BatchDelete)
@@ -200,6 +201,18 @@ func TestProxyHandlerEndpoints(t *testing.T) {
 
 	rec = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/batch-delete", bytes.NewBufferString(`{"ids":[1,2]}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	body, _ = json.Marshal(map[string]any{
+		"name_prefix": "tokyo",
+		"proxies": []map[string]any{
+			{"protocol": "http", "host": "10.0.0.1", "port": 8080},
+		},
+	})
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/batch", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -22,6 +23,7 @@ type stubAdminService struct {
 	updatedProxyIDs      []int64
 	updatedProxies       []*service.UpdateProxyInput
 	testedProxyIDs       []int64
+	existingProxyKeys    map[string]bool
 	createAccountErr     error
 	updateAccountErr     error
 	bulkUpdateAccountErr error
@@ -89,13 +91,14 @@ func newStubAdminService() *stubAdminService {
 		CreatedAt: now,
 	}
 	return &stubAdminService{
-		users:       []service.User{user},
-		apiKeys:     []service.APIKey{apiKey},
-		groups:      []service.Group{group},
-		accounts:    []service.Account{account},
-		proxies:     []service.Proxy{proxy},
-		proxyCounts: []service.ProxyWithAccountCount{{Proxy: proxy, AccountCount: 1}},
-		redeems:     []service.RedeemCode{redeem},
+		users:             []service.User{user},
+		apiKeys:           []service.APIKey{apiKey},
+		groups:            []service.Group{group},
+		accounts:          []service.Account{account},
+		proxies:           []service.Proxy{proxy},
+		proxyCounts:       []service.ProxyWithAccountCount{{Proxy: proxy, AccountCount: 1}},
+		redeems:           []service.RedeemCode{redeem},
+		existingProxyKeys: map[string]bool{},
 	}
 }
 
@@ -354,7 +357,10 @@ func (s *stubAdminService) GetProxyAccounts(ctx context.Context, proxyID int64) 
 }
 
 func (s *stubAdminService) CheckProxyExists(ctx context.Context, host string, port int, username, password string) (bool, error) {
-	return false, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := strings.Join([]string{host, strconv.Itoa(port), username, password}, "|")
+	return s.existingProxyKeys[key], nil
 }
 
 func (s *stubAdminService) TestProxy(ctx context.Context, id int64) (*service.ProxyTestResult, error) {

--- a/backend/internal/handler/admin/proxy_handler.go
+++ b/backend/internal/handler/admin/proxy_handler.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -308,7 +309,8 @@ type BatchCreateProxyItem struct {
 
 // BatchCreateRequest represents batch create proxies request
 type BatchCreateRequest struct {
-	Proxies []BatchCreateProxyItem `json:"proxies" binding:"required,min=1"`
+	NamePrefix string                 `json:"name_prefix"`
+	Proxies    []BatchCreateProxyItem `json:"proxies" binding:"required,min=1"`
 }
 
 // BatchCreate handles batch creating proxies
@@ -322,6 +324,7 @@ func (h *ProxyHandler) BatchCreate(c *gin.Context) {
 
 	created := 0
 	skipped := 0
+	namePrefix := strings.TrimSpace(req.NamePrefix)
 
 	for _, item := range req.Proxies {
 		// Trim all string fields
@@ -342,9 +345,13 @@ func (h *ProxyHandler) BatchCreate(c *gin.Context) {
 			continue
 		}
 
-		// Create proxy with default name
+		name := "default"
+		if namePrefix != "" {
+			name = fmt.Sprintf("%s-%03d", namePrefix, created+1)
+		}
+
 		_, err = h.adminService.CreateProxy(c.Request.Context(), &service.CreateProxyInput{
-			Name:     "default",
+			Name:     name,
 			Protocol: protocol,
 			Host:     host,
 			Port:     item.Port,

--- a/backend/internal/handler/admin/proxy_handler_batch_test.go
+++ b/backend/internal/handler/admin/proxy_handler_batch_test.go
@@ -1,0 +1,85 @@
+package admin
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyHandlerBatchCreateUsesNamePrefix(t *testing.T) {
+	router, adminSvc := setupAdminRouter()
+
+	body, _ := json.Marshal(map[string]any{
+		"name_prefix": "tokyo",
+		"proxies": []map[string]any{
+			{"protocol": "http", "host": "10.0.0.1", "port": 8080},
+			{"protocol": "https", "host": "10.0.0.2", "port": 443},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	adminSvc.mu.Lock()
+	defer adminSvc.mu.Unlock()
+	require.Len(t, adminSvc.createdProxies, 2)
+	require.Equal(t, "tokyo-001", adminSvc.createdProxies[0].Name)
+	require.Equal(t, "tokyo-002", adminSvc.createdProxies[1].Name)
+}
+
+func TestProxyHandlerBatchCreateFallsBackWithoutNamePrefix(t *testing.T) {
+	router, adminSvc := setupAdminRouter()
+
+	body, _ := json.Marshal(map[string]any{
+		"proxies": []map[string]any{
+			{"protocol": "http", "host": "10.0.0.1", "port": 8080},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	adminSvc.mu.Lock()
+	defer adminSvc.mu.Unlock()
+	require.Len(t, adminSvc.createdProxies, 1)
+	require.Equal(t, "default", adminSvc.createdProxies[0].Name)
+}
+
+func TestProxyHandlerBatchCreateKeepsNamesSequentialForCreatedItems(t *testing.T) {
+	router, adminSvc := setupAdminRouter()
+
+	adminSvc.mu.Lock()
+	adminSvc.existingProxyKeys["10.0.0.1|8080||"] = true
+	adminSvc.mu.Unlock()
+
+	body, _ := json.Marshal(map[string]any{
+		"name_prefix": "tokyo",
+		"proxies": []map[string]any{
+			{"protocol": "http", "host": "10.0.0.1", "port": 8080},
+			{"protocol": "http", "host": "10.0.0.2", "port": 8080},
+			{"protocol": "http", "host": "10.0.0.3", "port": 8080},
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/batch", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	adminSvc.mu.Lock()
+	defer adminSvc.mu.Unlock()
+	require.Len(t, adminSvc.createdProxies, 2)
+	require.Equal(t, "tokyo-001", adminSvc.createdProxies[0].Name)
+	require.Equal(t, "tokyo-002", adminSvc.createdProxies[1].Name)
+}

--- a/frontend/src/api/admin/proxies.ts
+++ b/frontend/src/api/admin/proxies.ts
@@ -192,13 +192,16 @@ export async function getProxyAccounts(id: number): Promise<ProxyAccountSummary[
  * @returns Creation result with count of created and skipped
  */
 export async function batchCreate(
-  proxies: Array<{
-    protocol: string
-    host: string
-    port: number
-    username?: string
-    password?: string
-  }>
+  payload: {
+    name_prefix?: string
+    proxies: Array<{
+      protocol: string
+      host: string
+      port: number
+      username?: string
+      password?: string
+    }>
+  }
 ): Promise<{
   created: number
   skipped: number
@@ -206,7 +209,7 @@ export async function batchCreate(
   const { data } = await apiClient.post<{
     created: number
     skipped: number
-  }>('/admin/proxies/batch', { proxies })
+  }>('/admin/proxies/batch', payload)
   return data
 }
 

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2950,6 +2950,9 @@ export default {
       // Batch import
       standardAdd: 'Standard Add',
       batchAdd: 'Quick Add',
+      batchNamePrefix: 'Name Prefix',
+      batchNamePrefixPlaceholder: 'Example: tokyo-proxy',
+      batchNamePrefixHint: 'New proxies will be named like tokyo-proxy-001, tokyo-proxy-002.',
       batchInput: 'Proxy List',
       batchInputPlaceholder:
         "Enter one proxy per line in the following formats:\nsocks5://user:pass{'@'}192.168.1.1:1080\nhttp://192.168.1.1:8080\nhttps://user:pass{'@'}proxy.example.com:443",
@@ -3000,6 +3003,7 @@ export default {
       failedToUpdate: 'Failed to update proxy',
       failedToDelete: 'Failed to delete proxy',
       failedToTest: 'Failed to test proxy',
+      batchNamePrefixRequired: 'Please enter a name prefix for batch import',
       nameRequired: 'Please enter proxy name',
       hostRequired: 'Please enter host address',
       portInvalid: 'Port must be between 1-65535',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3071,6 +3071,9 @@ export default {
       // Batch import
       standardAdd: '标准添加',
       batchAdd: '快捷添加',
+      batchNamePrefix: '名称前缀',
+      batchNamePrefixPlaceholder: '例如：tokyo-proxy',
+      batchNamePrefixHint: '新建代理将按 tokyo-proxy-001、tokyo-proxy-002 的格式自动命名。',
       batchInput: '代理列表',
       batchInputPlaceholder:
         "每行输入一个代理，支持以下格式：\nsocks5://user:pass{'@'}192.168.1.1:1080\nhttp://192.168.1.1:8080\nhttps://user:pass{'@'}proxy.example.com:443",
@@ -3128,6 +3131,7 @@ export default {
       failedToCreate: '创建代理失败',
       failedToUpdate: '更新代理失败',
       failedToTest: '测试代理失败',
+      batchNamePrefixRequired: '请输入批量导入名称前缀',
       nameRequired: '请输入代理名称',
       hostRequired: '请输入主机地址',
       portInvalid: '端口必须在 1-65535 之间',

--- a/frontend/src/views/admin/ProxiesView.vue
+++ b/frontend/src/views/admin/ProxiesView.vue
@@ -468,6 +468,19 @@
       <!-- Batch Add Form -->
       <div v-else class="space-y-5">
         <div>
+          <label class="input-label">{{ t('admin.proxies.batchNamePrefix') }}</label>
+          <input
+            v-model="batchNamePrefix"
+            type="text"
+            class="input"
+            :placeholder="t('admin.proxies.batchNamePrefixPlaceholder')"
+          />
+          <p class="input-hint mt-2">
+            {{ t('admin.proxies.batchNamePrefixHint') }}
+          </p>
+        </div>
+
+        <div>
           <label class="input-label">{{ t('admin.proxies.batchInput') }}</label>
           <textarea
             v-model="batchInput"
@@ -994,6 +1007,7 @@ const qualityReport = ref<ProxyQualityCheckResult | null>(null)
 
 // Batch import state
 const createMode = ref<'standard' | 'batch'>('standard')
+const batchNamePrefix = ref('')
 const batchInput = ref('')
 const batchParseResult = reactive({
   total: 0,
@@ -1113,6 +1127,7 @@ const closeCreateModal = () => {
   createForm.username = ''
   createForm.password = ''
   createPasswordVisible.value = false
+  batchNamePrefix.value = ''
   batchInput.value = ''
   batchParseResult.total = 0
   batchParseResult.valid = 0
@@ -1192,10 +1207,18 @@ const parseBatchInput = () => {
 
 const handleBatchCreate = async () => {
   if (batchParseResult.valid === 0) return
+  const trimmedNamePrefix = batchNamePrefix.value.trim()
+  if (!trimmedNamePrefix) {
+    appStore.showError(t('admin.proxies.batchNamePrefixRequired'))
+    return
+  }
 
   submitting.value = true
   try {
-    const result = await adminAPI.proxies.batchCreate(batchParseResult.proxies)
+    const result = await adminAPI.proxies.batchCreate({
+      name_prefix: trimmedNamePrefix,
+      proxies: batchParseResult.proxies
+    })
     const created = result.created || 0
     const skipped = result.skipped || 0
 

--- a/frontend/src/views/admin/__tests__/ProxiesView.spec.ts
+++ b/frontend/src/views/admin/__tests__/ProxiesView.spec.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const { list, batchCreate } = vi.hoisted(() => {
+  vi.stubGlobal('localStorage', {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(),
+    removeItem: vi.fn()
+  })
+
+  return {
+    list: vi.fn(),
+    batchCreate: vi.fn()
+  }
+})
+
+import ProxiesView from '../ProxiesView.vue'
+
+const showError = vi.fn()
+const showSuccess = vi.fn()
+const showInfo = vi.fn()
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    proxies: {
+      list,
+      batchCreate,
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      batchDelete: vi.fn(),
+      testProxy: vi.fn(),
+      checkProxyQuality: vi.fn(),
+      exportData: vi.fn(),
+      getProxyAccounts: vi.fn()
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError,
+    showSuccess,
+    showInfo,
+    showWarning: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useClipboard', () => ({
+  useClipboard: () => ({
+    copyToClipboard: vi.fn()
+  })
+}))
+
+vi.mock('@/composables/useSwipeSelect', () => ({
+  useSwipeSelect: vi.fn()
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+const globalStubs = {
+  AppLayout: { template: '<div><slot /></div>' },
+  TablePageLayout: { template: '<div><slot name="filters" /><slot name="table" /></div>' },
+  DataTable: { template: '<div />' },
+  BaseDialog: { template: '<div><slot /><slot name="footer" /></div>' },
+  Select: { template: '<div />' },
+  Icon: true,
+  ConfirmDialog: true,
+  ProxyExportDialog: true,
+  ImportDataModal: true,
+  Pagination: true,
+  PlatformTypeBadge: true
+}
+
+describe('admin ProxiesView batch add', () => {
+  beforeEach(() => {
+    list.mockReset()
+    batchCreate.mockReset()
+    showError.mockReset()
+    showSuccess.mockReset()
+    showInfo.mockReset()
+
+    list.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0
+    })
+    batchCreate.mockResolvedValue({
+      created: 1,
+      skipped: 0
+    })
+  })
+
+  it('requires a batch name prefix before importing proxies', async () => {
+    const wrapper = mount(ProxiesView, {
+      global: {
+        stubs: globalStubs
+      }
+    })
+
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    await buttons.find((button) => button.text().includes('admin.proxies.batchAdd'))?.trigger('click')
+    const textarea = wrapper.find('textarea')
+    await textarea.setValue('http://10.0.0.1:8080')
+    await wrapper.findAll('button').find((button) => button.text().includes('admin.proxies.importProxies'))?.trigger('click')
+
+    expect(showError).toHaveBeenCalledWith('admin.proxies.batchNamePrefixRequired')
+    expect(batchCreate).not.toHaveBeenCalled()
+  })
+
+  it('sends name_prefix in batch create payload', async () => {
+    const wrapper = mount(ProxiesView, {
+      global: {
+        stubs: globalStubs
+      }
+    })
+
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    await buttons.find((button) => button.text().includes('admin.proxies.batchAdd'))?.trigger('click')
+
+    const inputs = wrapper.findAll('input[type="text"]')
+    const prefixInput = inputs.find((input) => input.attributes('placeholder') === 'admin.proxies.batchNamePrefixPlaceholder')
+    expect(prefixInput).toBeTruthy()
+    await prefixInput!.setValue('tokyo')
+
+    const textarea = wrapper.find('textarea')
+    await textarea.setValue('http://10.0.0.1:8080')
+
+    await wrapper.findAll('button').find((button) => button.text().includes('admin.proxies.importProxies'))?.trigger('click')
+    await flushPromises()
+
+    expect(batchCreate).toHaveBeenCalledWith({
+      name_prefix: 'tokyo',
+      proxies: [
+        {
+          protocol: 'http',
+          host: '10.0.0.1',
+          port: 8080,
+          username: '',
+          password: ''
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Adds a name-prefix option to proxy batch import in admin proxy management.

## Behavior
When batch-creating proxies, admins can enter a shared name prefix and new proxies will be named sequentially, for example `tokyo-proxy-001`, `tokyo-proxy-002`.

## Notes
- applies only to proxy quick-add batch import
- JSON proxy data import behavior is unchanged
