### PR TITLE
fix(openai-compat): 修复 OpenAI 兼容格式 token 用量无法统计的问题

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3643,13 +3643,25 @@ func (s *OpenAIGatewayService) parseSSEUsageBytes(data []byte, usage *OpenAIUsag
 		return
 	}
 	eventType := gjson.GetBytes(data, "type").String()
-	if eventType != "response.completed" && eventType != "response.done" {
+	if eventType == "response.completed" || eventType == "response.done" {
+		// OpenAI Responses API (/v1/responses) streaming format
+		usage.InputTokens = int(gjson.GetBytes(data, "response.usage.input_tokens").Int())
+		usage.OutputTokens = int(gjson.GetBytes(data, "response.usage.output_tokens").Int())
+		usage.CacheReadInputTokens = int(gjson.GetBytes(data, "response.usage.input_tokens_details.cached_tokens").Int())
 		return
 	}
 
-	usage.InputTokens = int(gjson.GetBytes(data, "response.usage.input_tokens").Int())
-	usage.OutputTokens = int(gjson.GetBytes(data, "response.usage.output_tokens").Int())
-	usage.CacheReadInputTokens = int(gjson.GetBytes(data, "response.usage.input_tokens_details.cached_tokens").Int())
+	// Standard OpenAI chat completions (/v1/chat/completions) streaming format:
+	// the last chunk may carry usage with prompt_tokens/completion_tokens.
+	if gjson.GetBytes(data, "object").String() == "chat.completion.chunk" {
+		promptTokens := gjson.GetBytes(data, "usage.prompt_tokens").Int()
+		completionTokens := gjson.GetBytes(data, "usage.completion_tokens").Int()
+		if promptTokens > 0 || completionTokens > 0 {
+			usage.InputTokens = int(promptTokens)
+			usage.OutputTokens = int(completionTokens)
+			usage.CacheReadInputTokens = int(gjson.GetBytes(data, "usage.prompt_tokens_details.cached_tokens").Int())
+		}
+	}
 }
 
 func extractOpenAIUsageFromJSONBytes(body []byte) (OpenAIUsage, bool) {
@@ -3661,11 +3673,27 @@ func extractOpenAIUsageFromJSONBytes(body []byte) (OpenAIUsage, bool) {
 		"usage.input_tokens",
 		"usage.output_tokens",
 		"usage.input_tokens_details.cached_tokens",
+		"usage.prompt_tokens",
+		"usage.completion_tokens",
+		"usage.prompt_tokens_details.cached_tokens",
 	)
+	inputTokens := int(values[0].Int())
+	outputTokens := int(values[1].Int())
+	cachedTokens := int(values[2].Int())
+	// Fall back to standard OpenAI chat completions field names
+	if inputTokens == 0 {
+		inputTokens = int(values[3].Int())
+	}
+	if outputTokens == 0 {
+		outputTokens = int(values[4].Int())
+	}
+	if cachedTokens == 0 {
+		cachedTokens = int(values[5].Int())
+	}
 	return OpenAIUsage{
-		InputTokens:          int(values[0].Int()),
-		OutputTokens:         int(values[1].Int()),
-		CacheReadInputTokens: int(values[2].Int()),
+		InputTokens:          inputTokens,
+		OutputTokens:         outputTokens,
+		CacheReadInputTokens: cachedTokens,
 	}, true
 }
 

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1876,12 +1876,12 @@ func TestHandleOAuthSSEToJSON_ResponseFailedReturnsProtocolError(t *testing.T) {
 
 func TestExtractOpenAIUsageFromJSONBytes(t *testing.T) {
 	tests := []struct {
-		name             string
-		body             string
-		wantInput        int
-		wantOutput       int
-		wantCacheRead    int
-		wantOK           bool
+		name          string
+		body          string
+		wantInput     int
+		wantOutput    int
+		wantCacheRead int
+		wantOK        bool
 	}{
 		{
 			name:      "Anthropic/Responses API format (input_tokens/output_tokens)",
@@ -1933,10 +1933,10 @@ func TestParseSSEUsageBytesStandardChatCompletions(t *testing.T) {
 		wantCacheRead int
 	}{
 		{
-			name:       "OpenAI Responses API terminal event",
-			data:       `{"type":"response.completed","response":{"usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":10}}}}`,
-			wantInput:  100,
-			wantOutput: 50,
+			name:          "OpenAI Responses API terminal event",
+			data:          `{"type":"response.completed","response":{"usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":10}}}}`,
+			wantInput:     100,
+			wantOutput:    50,
 			wantCacheRead: 10,
 		},
 		{
@@ -1946,10 +1946,10 @@ func TestParseSSEUsageBytesStandardChatCompletions(t *testing.T) {
 			wantOutput: 80,
 		},
 		{
-			name:       "Standard chat completions chunk with cached tokens",
-			data:       `{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":300,"completion_tokens":60,"prompt_tokens_details":{"cached_tokens":20}}}`,
-			wantInput:  300,
-			wantOutput: 60,
+			name:          "Standard chat completions chunk with cached tokens",
+			data:          `{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":300,"completion_tokens":60,"prompt_tokens_details":{"cached_tokens":20}}}`,
+			wantInput:     300,
+			wantOutput:    60,
 			wantCacheRead: 20,
 		},
 		{

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1873,3 +1873,99 @@ func TestHandleOAuthSSEToJSON_ResponseFailedReturnsProtocolError(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "upstream rejected request")
 	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
 }
+
+func TestExtractOpenAIUsageFromJSONBytes(t *testing.T) {
+	tests := []struct {
+		name             string
+		body             string
+		wantInput        int
+		wantOutput       int
+		wantCacheRead    int
+		wantOK           bool
+	}{
+		{
+			name:      "Anthropic/Responses API format (input_tokens/output_tokens)",
+			body:      `{"usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":10}}}`,
+			wantInput: 100, wantOutput: 50, wantCacheRead: 10, wantOK: true,
+		},
+		{
+			name:      "Standard OpenAI chat completions format (prompt_tokens/completion_tokens)",
+			body:      `{"usage":{"prompt_tokens":200,"completion_tokens":80,"total_tokens":280}}`,
+			wantInput: 200, wantOutput: 80, wantCacheRead: 0, wantOK: true,
+		},
+		{
+			name:      "Standard OpenAI format with cached tokens",
+			body:      `{"usage":{"prompt_tokens":300,"completion_tokens":60,"prompt_tokens_details":{"cached_tokens":20}}}`,
+			wantInput: 300, wantOutput: 60, wantCacheRead: 20, wantOK: true,
+		},
+		{
+			name:      "Anthropic format takes precedence over OpenAI format when both present",
+			body:      `{"usage":{"input_tokens":10,"output_tokens":5,"prompt_tokens":200,"completion_tokens":80}}`,
+			wantInput: 10, wantOutput: 5, wantCacheRead: 0, wantOK: true,
+		},
+		{
+			name: "empty body", body: "", wantOK: false,
+		},
+		{
+			name: "invalid json", body: "{not json}", wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := extractOpenAIUsageFromJSONBytes([]byte(tt.body))
+			require.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				require.Equal(t, tt.wantInput, got.InputTokens)
+				require.Equal(t, tt.wantOutput, got.OutputTokens)
+				require.Equal(t, tt.wantCacheRead, got.CacheReadInputTokens)
+			}
+		})
+	}
+}
+
+func TestParseSSEUsageBytesStandardChatCompletions(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	tests := []struct {
+		name          string
+		data          string
+		wantInput     int
+		wantOutput    int
+		wantCacheRead int
+	}{
+		{
+			name:       "OpenAI Responses API terminal event",
+			data:       `{"type":"response.completed","response":{"usage":{"input_tokens":100,"output_tokens":50,"input_tokens_details":{"cached_tokens":10}}}}`,
+			wantInput:  100,
+			wantOutput: 50,
+			wantCacheRead: 10,
+		},
+		{
+			name:       "Standard chat completions last chunk with prompt_tokens/completion_tokens",
+			data:       `{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":200,"completion_tokens":80,"total_tokens":280}}`,
+			wantInput:  200,
+			wantOutput: 80,
+		},
+		{
+			name:       "Standard chat completions chunk with cached tokens",
+			data:       `{"object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":300,"completion_tokens":60,"prompt_tokens_details":{"cached_tokens":20}}}`,
+			wantInput:  300,
+			wantOutput: 60,
+			wantCacheRead: 20,
+		},
+		{
+			name:       "Non-terminal chunk (no usage) should not update",
+			data:       `{"object":"chat.completion.chunk","choices":[{"delta":{"content":"hello"}}]}`,
+			wantInput:  0,
+			wantOutput: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := &OpenAIUsage{}
+			svc.parseSSEUsageBytes([]byte(tt.data), usage)
+			require.Equal(t, tt.wantInput, usage.InputTokens)
+			require.Equal(t, tt.wantOutput, usage.OutputTokens)
+			require.Equal(t, tt.wantCacheRead, usage.CacheReadInputTokens)
+		})
+	}
+}


### PR DESCRIPTION
## 问题描述

使用第三方 OpenAI 兼容服务（如 MiniMax 等自部署服务）时，界面无法显示 token 消耗统计，始终为 0。相关 issue: #891

## 根因分析

`openai_gateway_service.go` 中有两个解析 token 用量的函数，只处理了 Anthropic/OpenAI Responses API 格式的字段名（`input_tokens` / `output_tokens`），但标准 OpenAI Chat Completions API（以及所有兼容它的第三方服务）返回的是 `prompt_tokens` / `completion_tokens`，导致 token 用量始终解析为 0。

受影响的函数：
- `extractOpenAIUsageFromJSONBytes`（非流式响应）
- `parseSSEUsageBytes`（流式 SSE 响应）

## 修复方案

**`extractOpenAIUsageFromJSONBytes`**：新增对 `prompt_tokens` / `completion_tokens` / `prompt_tokens_details.cached_tokens` 的 fallback 读取——当 `input_tokens` 为 0 时自动回落到标准 OpenAI 字段。

**`parseSSEUsageBytes`**：
- 保留原有 Responses API（`type: "response.completed"`）处理逻辑
- 新增对标准 Chat Completions 流式末尾 chunk（`object: "chat.completion.chunk"` 含 usage 字段）的处理

## 测试

新增单元测试 `TestExtractOpenAIUsageFromJSONBytes` 和 `TestParseSSEUsageBytesStandardChatCompletions`，覆盖：
- Anthropic/Responses API 格式
- 标准 OpenAI Chat Completions 格式（含 cached tokens）
- 两种格式同时存在时 Anthropic 格式优先
- 非 usage chunk 不更新

全部已有测试通过（`go test ./internal/service/... -count=1`）。