### PR TITLE
fix(api-key):软删除apikey后key没有被释放后续无法再自定义相同的key

### DIFF
--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
@@ -257,9 +258,12 @@ func (r *apiKeyRepository) Update(ctx context.Context, key *service.APIKey) erro
 }
 
 func (r *apiKeyRepository) Delete(ctx context.Context, id int64) error {
+	// 存在唯一键约束 生成tombstone key 用来释放原key，长度远小于 128，满足 schema 限制
+	tombstoneKey := fmt.Sprintf("__deleted__%d__%d", id, time.Now().UnixNano())
 	// 显式软删除：避免依赖 Hook 行为，确保 deleted_at 一定被设置。
 	affected, err := r.client.APIKey.Update().
 		Where(apikey.IDEQ(id), apikey.DeletedAtIsNil()).
+		SetKey(tombstoneKey).
 		SetDeletedAt(time.Now()).
 		Save(ctx)
 	if err != nil {

--- a/backend/internal/repository/api_key_repo_integration_test.go
+++ b/backend/internal/repository/api_key_repo_integration_test.go
@@ -151,6 +151,31 @@ func (s *APIKeyRepoSuite) TestDelete() {
 	s.Require().Error(err, "expected error after delete")
 }
 
+func (s *APIKeyRepoSuite) TestCreate_AfterSoftDelete_AllowsSameKey() {
+	user := s.mustCreateUser("recreate-after-soft-delete@test.com")
+	const reusedKey = "sk-reuse-after-soft-delete"
+
+	first := &service.APIKey{
+		UserID: user.ID,
+		Key:    reusedKey,
+		Name:   "First Key",
+		Status: service.StatusActive,
+	}
+	s.Require().NoError(s.repo.Create(s.ctx, first), "create first key")
+
+	s.Require().NoError(s.repo.Delete(s.ctx, first.ID), "soft delete first key")
+
+	second := &service.APIKey{
+		UserID: user.ID,
+		Key:    reusedKey,
+		Name:   "Second Key",
+		Status: service.StatusActive,
+	}
+	s.Require().NoError(s.repo.Create(s.ctx, second), "create second key with same key")
+	s.Require().NotZero(second.ID)
+	s.Require().NotEqual(first.ID, second.ID, "recreated key should be a new row")
+}
+
 // --- ListByUserID / CountByUserID ---
 
 func (s *APIKeyRepoSuite) TestListByUserID() {


### PR DESCRIPTION
#1333 

# 修复 API Key 软删除后因唯一约束无法复用同名 key 的问题

## 问题概述

在 API Key 管理场景中，删除操作采用软删除（仅设置 `deleted_at`），但 `api_keys.key` 字段存在全局唯一约束。  
因此，当某个 key 被软删除后，数据库中该行仍保留原始 `key` 值，后续再次创建同名 key 会触发唯一冲突，导致创建失败。

## 问题原因

当前实现中：

- 删除逻辑只更新 `deleted_at`，不修改 `key`
-  `key` 字段声明了 `Unique()`

这意味着“历史软删除记录”仍占用唯一键空间，和“允许复用已删除 key”的业务预期冲突。

## 修复方案

修改位置：`internal/repository/api_key_repo.go` 的 `Delete` 方法。

在软删除时，除了设置 `deleted_at`，同时将原始 `key` 改写为 tombstone 值（墓碑 key），释放原 key 的唯一约束占用。  
建议 tombstone 规则：

- 前缀固定：`__deleted__`
- 拼接 `id` 与高精度时间戳（如 `UnixNano`）
- 保证长度不超过 schema 的 `MaxLen(128)`

示例格式：

- `__deleted__{id}__{unix_nano}`

这样可确保：

1. 原 key 可被后续重新创建
2. 不需要改动数据库索引结构

## 修复效果

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 删除后重建同名 key | 触发唯一冲突，创建失败 | 可正常创建 |
| 历史删除记录保留 | 保留 | 保留 |
| 数据库索引调整 | 不涉及 | 不涉及 |

## 兼容性与风险说明

- 该方案会改变被删除记录的 `key` 值，不再保留原始明文 key。
- 若有依赖“删除后仍可用原 key 精确检索历史记录”的逻辑，需要改为按 `id` 或审计字段追踪。
- 建议在日志/审计层补充记录“删除前原 key（脱敏）”用于排障。

## 测试说明

在 `internal/repository/api_key_repo_integration_test.go` 增加以下用例：

| 用例名 | 校验点 |
|---|---|
| `TestCreate_AfterSoftDelete_AllowsSameKey` | 删除 key A 后，再创建 key A 成功 |


### 运行命令

```bash
# 运行 API Key repository 集成测试（可按实际用例名调整 -run）
go test -tags=integration -v ./internal/repository/...
```


