### PR TITLE
fix(i18n): 修复 Sora 存储配置页面表格列头「存储桶」翻译缺失

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4378,6 +4378,7 @@ export default {
           provider: 'Type',
           active: 'Active',
           endpoint: 'Endpoint',
+          bucket: 'Bucket',
           storagePath: 'Storage Path',
           capacityUsage: 'Capacity / Used',
           capacityUnlimited: 'Unlimited',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4542,6 +4542,7 @@ export default {
           provider: '存储类型',
           active: '生效状态',
           endpoint: '端点',
+          bucket: '存储桶',
           storagePath: '存储路径',
           capacityUsage: '容量 / 已用',
           capacityUnlimited: '无限制',


### PR DESCRIPTION
## 问题描述

在管理后台「系统设置 → Sora 存储」页面中，表格的「存储桶」列头未被翻译，直接显示了原始 i18n key。

<img width="1345" height="488" alt="image" src="https://github.com/user-attachments/assets/ec41f241-0da3-4d95-be68-9af35630440c" />

## 原因

[frontend/src/i18n/locales/en.ts](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/frontend/src/i18n/locales/en.ts:0:0-0:0) 和 [zh.ts](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/frontend/src/i18n/locales/zh.ts:0:0-0:0) 的 `soraS3.columns` 中缺少 `bucket` 条目，而 [frontend/src/views/admin/DataManagementView.vue](cci:7://file:///e:/CodeAI/github/sub2api/sub2api/frontend/src/views/admin/DataManagementView.vue:0:0-0:0) 中已引用了该 key。

## 修复方式

在中英文语言文件的 `soraS3.columns` 中补充 `bucket`：

- **en.ts**: `bucket: 'Bucket'`
- **zh.ts**: `bucket: '存储桶'`
