### PR TITLE
fix(gateway): 在转发前预过滤缺少 signature 的 thinking 块

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4255,6 +4255,14 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		account.ID, account.Name, account.Platform, account.Type, tlsProfile, proxyURL)
 	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
 	body = StripEmptyTextBlocks(body)
+	// Pre-filter: remove thinking blocks with missing/invalid signatures before forwarding.
+	// Clients (e.g. Claude Code) sometimes send multi-turn conversations where a historical
+	// assistant message contains a thinking block that is missing the required "signature" field,
+	// causing upstream to reject the request with 400 "thinking.signature: Field required".
+	// FilterThinkingBlocks removes only the invalid blocks; thinking blocks with valid signatures
+	// are preserved. This avoids relying solely on the post-error retry path, which can time out
+	// (maxRetryElapsed = 10s) for long conversations before the retry budget is exhausted.
+	body = FilterThinkingBlocks(body)
 
 	// 重试间复用同一请求体，避免每次 string(body) 产生额外分配。
 	setOpsUpstreamRequestBody(c, body)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4497,6 +4497,14 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		account.ID, account.Name, account.Platform, account.Type, tlsProfile, proxyURL)
 	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
 	body = StripEmptyTextBlocks(body)
+	// Pre-filter: remove thinking blocks with missing/invalid signatures before forwarding.
+	// Clients (e.g. Claude Code) sometimes send multi-turn conversations where a historical
+	// assistant message contains a thinking block that is missing the required "signature" field,
+	// causing upstream to reject the request with 400 "thinking.signature: Field required".
+	// FilterThinkingBlocks removes only the invalid blocks; thinking blocks with valid signatures
+	// are preserved. This avoids relying solely on the post-error retry path, which can time out
+	// (maxRetryElapsed = 10s) for long conversations before the retry budget is exhausted.
+	body = FilterThinkingBlocks(body)
 
 	// 重试间复用同一请求体，避免每次 string(body) 产生额外分配。
 	setOpsUpstreamRequestBody(c, body)


### PR DESCRIPTION
## 问题

客户端（如 Claude Code）在多轮对话中，有时会发送历史 assistant 消息里包含**缺少 `signature` 字段**的 thinking 块，导致上游直接拒绝请求：

```
400 "messages.N.content.0.thinking.signature: Field required"
```

线上实际观察到该问题在超长对话（250+ 条消息）中反复出现。

## 根本原因

网关已有一条「400 响应后重试」路径（`FilterThinkingBlocksForRetry`）来处理此类错误。但对于超长对话，**第一次上游请求本身耗时可能超过 `maxRetryElapsed`（10 s）**，导致重试预算在重试触发前就已耗尽。预算耗尽时的代码路径：

```go
if time.Since(retryStart) >= maxRetryElapsed {
    resp.Body = io.NopCloser(bytes.NewReader(respBody)) // 恢复原始错误体
    break
}
```

客户端最终收到原始的 400 错误，没有任何恢复。

## 修复

在现有的 `StripEmptyTextBlocks` 调用之后，将 `FilterThinkingBlocks` 作为**预过滤步骤**加入，在请求转发上游之前执行：

```go
body = StripEmptyTextBlocks(body)
body = FilterThinkingBlocks(body)  // ← 新增
```

`FilterThinkingBlocks` 的行为：
- 顶层 `thinking` 为 **enabled/adaptive** 时：仅移除缺少或无效 signature 的 thinking 块，**有效 signature 的 thinking 块完整保留**。
- 顶层 `thinking` 不存在或已禁用时：移除所有 thinking 相关块。
- 有 fast-path：请求体不含 thinking 相关字节时直接返回，**常规请求零开销**。

原有的重试路径（`FilterThinkingBlocksForRetry`）保留，作为第二道防线。

## 测试

所有现有的 `TestFilterThinkingBlocks` 和 `TestStripEmptyTextBlocks` 单元测试通过，`go build ./cmd/server/` 构建验证无误。

🤖 Generated with [Claude Code](https://claude.com/claude-code)