### PR TITLE
fix(billing): 计费始终使用用户请求的原始模型，而非映射后的上游模型

### DIFF
--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -895,14 +895,16 @@ func TestOpenAIGatewayServiceRecordUsage_UsesRequestedModelAndUpstreamModelMetad
 	require.Equal(t, 1, userRepo.deductCalls)
 }
 
-func TestOpenAIGatewayServiceRecordUsage_BillsMappedRequestsUsingUpstreamModelFallback(t *testing.T) {
+func TestOpenAIGatewayServiceRecordUsage_BillsMappedRequestsUsingRequestedModel(t *testing.T) {
 	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
 	userRepo := &openAIRecordUsageUserRepoStub{}
 	subRepo := &openAIRecordUsageSubRepoStub{}
 	svc := newOpenAIRecordUsageServiceForTest(usageRepo, userRepo, subRepo, nil)
 	usage := OpenAIUsage{InputTokens: 20, OutputTokens: 10}
 
-	expectedCost, err := svc.billingService.CalculateCost("gpt-5.1-codex", UsageTokens{
+	// Billing should use the requested model ("gpt-5.1"), not the upstream mapped model ("gpt-5.1-codex").
+	// This ensures pricing is always based on the model the user requested.
+	expectedCost, err := svc.billingService.CalculateCost("gpt-5.1", UsageTokens{
 		InputTokens:  20,
 		OutputTokens: 10,
 	}, 1.1)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4153,9 +4153,6 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	}
 
 	billingModel := forwardResultBillingModel(result.Model, result.UpstreamModel)
-	if result.BillingModel != "" {
-		billingModel = strings.TrimSpace(result.BillingModel)
-	}
 	serviceTier := ""
 	if result.ServiceTier != nil {
 		serviceTier = strings.TrimSpace(*result.ServiceTier)

--- a/backend/internal/service/usage_log_helpers.go
+++ b/backend/internal/service/usage_log_helpers.go
@@ -21,8 +21,8 @@ func optionalNonEqualStringPtr(value, compare string) *string {
 }
 
 func forwardResultBillingModel(requestedModel, upstreamModel string) string {
-	if trimmedUpstream := strings.TrimSpace(upstreamModel); trimmedUpstream != "" {
-		return trimmedUpstream
+	if trimmed := strings.TrimSpace(requestedModel); trimmed != "" {
+		return trimmed
 	}
-	return strings.TrimSpace(requestedModel)
+	return strings.TrimSpace(upstreamModel)
 }


### PR DESCRIPTION
## Summary

- 修复账号配置模型映射后（如 `claude-sonnet-4-6` → `glm-5.0`），计费使用映射后的上游模型名计算费用，因该模型无价格配置导致金额被置为 0 的问题
- 改为始终使用用户请求的原始模型名计费，映射只影响发给上游的实际模型名
- 同步更新相关单元测试

## Root Cause

`forwardResultBillingModel` 优先返回 `upstreamModel`（映射后的模型），而映射目标模型（如 `glm-5.0`）在 pricing 系统中没有价格配置 → `CalculateCost` 返回 error → 被静默降级为 `ActualCost: 0` → 用户不扣费。

同时 OpenAI 兼容路径中 `result.BillingModel` 字段（总是被设为 `mappedModel`）会覆盖 `forwardResultBillingModel` 的结果，进一步确保了计费使用的是上游模型。

## Changes

- `forwardResultBillingModel` 改为优先返回 `requestedModel`，仅在请求模型为空时回退到 `upstreamModel`
- 移除 `openai_gateway_service.go` 中 `BillingModel` 字段对计费模型的覆盖逻辑
- 更新单元测试 `TestOpenAIGatewayServiceRecordUsage_BillsMappedRequestsUsingRequestedModel`

## Test Plan

- [x] `go test -tags=unit ./internal/service/...` 全部通过
- [x] 验证配置了模型映射的账号请求后 usage log 中 `actual_cost` 不再为 0
- [x] 验证未配置映射的账号行为不变