### PR TITLE
feat(gateway): 添加客户端断开时取消上游流式请求的配置开关

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -412,6 +412,11 @@ type GatewayConfig struct {
 	StreamKeepaliveInterval int `mapstructure:"stream_keepalive_interval"`
 	// MaxLineSize: 上游 SSE 单行最大字节数（0使用默认值）
 	MaxLineSize int `mapstructure:"max_line_size"`
+	// CancelStreamOnClientDisconnect: 客户端断开时是否立即取消上游流式请求
+	// 启用后，客户端断开将直接终止上游请求，不再继续 drain 上游以收集用量数据
+	// 适用于自用部署场景，可减少不必要的上游资源消耗
+	// 注意：启用后将无法获取完整的 token 用量数据，影响计费准确性
+	CancelStreamOnClientDisconnect bool `mapstructure:"cancel_stream_on_client_disconnect"`
 
 	// 是否记录上游错误响应体摘要（避免输出请求内容）
 	LogUpstreamErrorBody bool `mapstructure:"log_upstream_error_body"`
@@ -1421,6 +1426,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.stream_data_interval_timeout", 180)
 	viper.SetDefault("gateway.stream_keepalive_interval", 10)
 	viper.SetDefault("gateway.max_line_size", 500*1024*1024)
+	viper.SetDefault("gateway.cancel_stream_on_client_disconnect", false)
 	viper.SetDefault("gateway.scheduling.sticky_session_max_waiting", 3)
 	viper.SetDefault("gateway.scheduling.sticky_session_wait_timeout", 120*time.Second)
 	viper.SetDefault("gateway.scheduling.fallback_wait_timeout", 30*time.Second)

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -903,6 +903,10 @@ func (s *AntigravityGatewayService) getLogConfig() (logBody bool, maxBytes int) 
 	return cfg.LogUpstreamErrorBody, maxBytes
 }
 
+func (s *AntigravityGatewayService) cancelStreamOnDisconnect() bool {
+	return s != nil && s.settingService != nil && s.settingService.cfg != nil && s.settingService.cfg.Gateway.CancelStreamOnClientDisconnect
+}
+
 // getUpstreamErrorDetail 获取上游错误详情（用于日志记录）
 func (s *AntigravityGatewayService) getUpstreamErrorDetail(body []byte) string {
 	logBody, maxBytes := s.getLogConfig()
@@ -2960,10 +2964,11 @@ type antigravityClientWriter struct {
 	flusher      http.Flusher
 	disconnected bool
 	prefix       string // 日志前缀，标识来源方法
+	cancelStream bool
 }
 
-func newAntigravityClientWriter(w gin.ResponseWriter, flusher http.Flusher, prefix string) *antigravityClientWriter {
-	return &antigravityClientWriter{w: w, flusher: flusher, prefix: prefix}
+func newAntigravityClientWriter(w gin.ResponseWriter, flusher http.Flusher, prefix string, cancelStream bool) *antigravityClientWriter {
+	return &antigravityClientWriter{w: w, flusher: flusher, prefix: prefix, cancelStream: cancelStream}
 }
 
 // Write 写入数据到客户端，写入失败时标记断开并返回 false
@@ -2996,6 +3001,10 @@ func (cw *antigravityClientWriter) Disconnected() bool { return cw.disconnected 
 
 func (cw *antigravityClientWriter) markDisconnected() {
 	cw.disconnected = true
+	if cw.cancelStream {
+		logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected, canceling upstream stream (%s)", cw.prefix)
+		return
+	}
 	logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected during streaming (%s), continuing to drain upstream for billing", cw.prefix)
 }
 
@@ -3014,6 +3023,8 @@ func handleStreamReadError(err error, clientDisconnected bool, prefix string) (d
 }
 
 func (s *AntigravityGatewayService) handleGeminiStreamingResponse(c *gin.Context, resp *http.Response, startTime time.Time) (*antigravityStreamResult, error) {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	c.Status(resp.StatusCode)
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
@@ -3104,7 +3115,7 @@ func (s *AntigravityGatewayService) handleGeminiStreamingResponse(c *gin.Context
 	}
 	lastDataAt := time.Now()
 
-	cw := newAntigravityClientWriter(c.Writer, flusher, "antigravity gemini")
+	cw := newAntigravityClientWriter(c.Writer, flusher, "antigravity gemini", cancelOnDisconnect)
 
 	// 仅发送一次错误事件，避免多次写入导致协议混乱
 	errorEventSent := false
@@ -3144,6 +3155,9 @@ func (s *AntigravityGatewayService) handleGeminiStreamingResponse(c *gin.Context
 				payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data:"))
 				if payload == "" || payload == "[DONE]" {
 					cw.Fprintf("%s\n", line)
+					if cancelOnDisconnect && cw.Disconnected() {
+						return &antigravityStreamResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+					}
 					continue
 				}
 
@@ -3180,10 +3194,16 @@ func (s *AntigravityGatewayService) handleGeminiStreamingResponse(c *gin.Context
 				}
 
 				cw.Fprintf("data: %s\n\n", payload)
+				if cancelOnDisconnect && cw.Disconnected() {
+					return &antigravityStreamResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+				}
 				continue
 			}
 
 			cw.Fprintf("%s\n", line)
+			if cancelOnDisconnect && cw.Disconnected() {
+				return &antigravityStreamResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+			}
 
 		case <-intervalCh:
 			lastRead := time.Unix(0, atomic.LoadInt64(&lastReadAt))
@@ -3207,6 +3227,10 @@ func (s *AntigravityGatewayService) handleGeminiStreamingResponse(c *gin.Context
 			}
 			// SSE ping/keepalive：保持连接活跃防止 Cloudflare Tunnel 等代理断开
 			if !cw.Fprintf(":\n\n") {
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected, canceling upstream stream (antigravity gemini)")
+					return &antigravityStreamResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+				}
 				logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected during keepalive ping (antigravity gemini), continuing to drain upstream for billing")
 				continue
 			}
@@ -3854,6 +3878,8 @@ returnResponse:
 
 // handleClaudeStreamingResponse 处理 Claude 流式响应（Gemini SSE → Claude SSE 转换）
 func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context, resp *http.Response, startTime time.Time, originalModel string) (*antigravityStreamResult, error) {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
@@ -3951,7 +3977,7 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 	}
 	lastDataAt := time.Now()
 
-	cw := newAntigravityClientWriter(c.Writer, flusher, "antigravity claude")
+	cw := newAntigravityClientWriter(c.Writer, flusher, "antigravity claude", cancelOnDisconnect)
 
 	// 仅发送一次错误事件，避免多次写入导致协议混乱
 	errorEventSent := false
@@ -4013,6 +4039,9 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 					firstTokenMs = &ms
 				}
 				cw.Write(claudeEvents)
+				if cancelOnDisconnect && cw.Disconnected() {
+					return &antigravityStreamResult{usage: finishUsage(), firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+				}
 			}
 
 		case <-intervalCh:
@@ -4038,6 +4067,10 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 			// SSE ping 事件：Anthropic 原生格式，客户端会正确处理，
 			// 同时保持连接活跃防止 Cloudflare Tunnel 等代理断开
 			if !cw.Fprintf("event: ping\ndata: {\"type\": \"ping\"}\n\n") {
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected, canceling upstream stream (antigravity claude)")
+					return &antigravityStreamResult{usage: finishUsage(), firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+				}
 				logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected during keepalive ping (antigravity claude), continuing to drain upstream for billing")
 				continue
 			}
@@ -4317,6 +4350,8 @@ func (s *AntigravityGatewayService) ForwardUpstream(ctx context.Context, c *gin.
 
 // streamUpstreamResponse 透传上游 SSE 流并提取 Claude usage
 func (s *AntigravityGatewayService) streamUpstreamResponse(c *gin.Context, resp *http.Response, startTime time.Time) *antigravityStreamResult {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	usage := &ClaudeUsage{}
 	var firstTokenMs *int
 
@@ -4388,7 +4423,7 @@ func (s *AntigravityGatewayService) streamUpstreamResponse(c *gin.Context, resp 
 	lastDataAt := time.Now()
 
 	flusher, _ := c.Writer.(http.Flusher)
-	cw := newAntigravityClientWriter(c.Writer, flusher, "antigravity upstream")
+	cw := newAntigravityClientWriter(c.Writer, flusher, "antigravity upstream", cancelOnDisconnect)
 
 	for {
 		select {
@@ -4419,6 +4454,9 @@ func (s *AntigravityGatewayService) streamUpstreamResponse(c *gin.Context, resp 
 
 			// 透传行
 			cw.Fprintf("%s\n", line)
+			if cancelOnDisconnect && cw.Disconnected() {
+				return &antigravityStreamResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}
+			}
 
 		case <-intervalCh:
 			lastRead := time.Unix(0, atomic.LoadInt64(&lastReadAt))
@@ -4442,6 +4480,10 @@ func (s *AntigravityGatewayService) streamUpstreamResponse(c *gin.Context, resp 
 			// SSE ping 事件：Anthropic 原生格式，客户端会正确处理，
 			// 同时保持连接活跃防止 Cloudflare Tunnel 等代理断开
 			if !cw.Fprintf("event: ping\ndata: {\"type\": \"ping\"}\n\n") {
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected, canceling upstream stream (antigravity upstream)")
+					return &antigravityStreamResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}
+				}
 				logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected during keepalive ping (antigravity upstream), continuing to drain upstream for billing")
 				continue
 			}

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -1318,7 +1318,7 @@ func TestAntigravityClientWriter(t *testing.T) {
 		rec := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(rec)
 		flusher, _ := c.Writer.(http.Flusher)
-		cw := newAntigravityClientWriter(c.Writer, flusher, "test")
+		cw := newAntigravityClientWriter(c.Writer, flusher, "test", false)
 
 		ok := cw.Write([]byte("hello"))
 		require.True(t, ok)
@@ -1332,7 +1332,7 @@ func TestAntigravityClientWriter(t *testing.T) {
 		c, _ := gin.CreateTestContext(rec)
 		fw := &antigravityFailingWriter{ResponseWriter: c.Writer, failAfter: 0}
 		flusher, _ := c.Writer.(http.Flusher)
-		cw := newAntigravityClientWriter(fw, flusher, "test")
+		cw := newAntigravityClientWriter(fw, flusher, "test", false)
 
 		ok := cw.Write([]byte("hello"))
 		require.False(t, ok)
@@ -1345,7 +1345,7 @@ func TestAntigravityClientWriter(t *testing.T) {
 		c, _ := gin.CreateTestContext(rec)
 		fw := &antigravityFailingWriter{ResponseWriter: c.Writer, failAfter: 0}
 		flusher, _ := c.Writer.(http.Flusher)
-		cw := newAntigravityClientWriter(fw, flusher, "test")
+		cw := newAntigravityClientWriter(fw, flusher, "test", false)
 
 		cw.Write([]byte("first"))
 		ok := cw.Fprintf("second %d", 2)

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -112,7 +112,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 	}
 
 	// 10. Build upstream request
-	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
+	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
 	releaseUpstreamCtx()
 	if err != nil {

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -109,7 +109,7 @@ func (s *GatewayService) ForwardAsResponses(
 	}
 
 	// 10. Build upstream request
-	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
+	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
 	releaseUpstreamCtx()
 	if err != nil {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4173,7 +4173,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	retryStart := time.Now()
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		// 构建上游请求（每次重试需要重新构建，因为请求体需要重新读取）
-		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
+		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 		releaseUpstreamCtx()
 		if err != nil {
@@ -4255,7 +4255,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					//    also downgrade tool_use/tool_result blocks to text.
 
 					filteredBody := FilterThinkingBlocksForRetry(body)
-					retryCtx, releaseRetryCtx := detachStreamUpstreamContext(ctx, reqStream)
+					retryCtx, releaseRetryCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 					retryReq, buildErr := s.buildUpstreamRequest(retryCtx, c, account, filteredBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 					releaseRetryCtx()
 					if buildErr == nil {
@@ -4290,7 +4290,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 								if looksLikeToolSignatureError(msg2) && time.Since(retryStart) < maxRetryElapsed {
 									logger.LegacyPrintf("service.gateway", "Account %d: signature retry still failing and looks tool-related, retrying with tool blocks downgraded", account.ID)
 									filteredBody2 := FilterSignatureSensitiveBlocksForRetry(body)
-									retryCtx2, releaseRetryCtx2 := detachStreamUpstreamContext(ctx, reqStream)
+									retryCtx2, releaseRetryCtx2 := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 									retryReq2, buildErr2 := s.buildUpstreamRequest(retryCtx2, c, account, filteredBody2, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 									releaseRetryCtx2()
 									if buildErr2 == nil {
@@ -4361,7 +4361,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					rectifiedBody, applied := RectifyThinkingBudget(body)
 					if applied && time.Since(retryStart) < maxRetryElapsed {
 						logger.LegacyPrintf("service.gateway", "Account %d: detected budget_tokens constraint error, retrying with rectified budget (budget_tokens=%d, max_tokens=%d)", account.ID, BudgetRectifyBudgetTokens, BudgetRectifyMaxTokens)
-						budgetRetryCtx, releaseBudgetRetryCtx := detachStreamUpstreamContext(ctx, reqStream)
+						budgetRetryCtx, releaseBudgetRetryCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 						budgetRetryReq, buildErr := s.buildUpstreamRequest(budgetRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseBudgetRetryCtx()
 						if buildErr == nil {
@@ -4664,7 +4664,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	var resp *http.Response
 	retryStart := time.Now()
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
-		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
+		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, input.RequestStream, s.cancelStreamOnDisconnect())
 		upstreamReq, err := s.buildUpstreamRequestAnthropicAPIKeyPassthrough(upstreamCtx, c, account, input.Body, token)
 		releaseUpstreamCtx()
 		if err != nil {
@@ -4915,6 +4915,8 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 	startTime time.Time,
 	model string,
 ) (*streamingResult, error) {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	if s.rateLimitService != nil {
 		s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 	}
@@ -5052,9 +5054,17 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 			if !clientDisconnected {
 				if _, err := io.WriteString(w, line); err != nil {
 					clientDisconnected = true
+					if cancelOnDisconnect {
+						logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected, canceling upstream stream: account=%d", account.ID)
+						return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+					}
 					logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
 				} else if _, err := io.WriteString(w, "\n"); err != nil {
 					clientDisconnected = true
+					if cancelOnDisconnect {
+						logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected, canceling upstream stream: account=%d", account.ID)
+						return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+					}
 					logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
 				} else if line == "" {
 					// 按 SSE 事件边界刷出，减少每行 flush 带来的 syscall 开销。
@@ -6630,6 +6640,8 @@ type streamingResult struct {
 }
 
 func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel string, mimicClaudeCode bool) (*streamingResult, error) {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	// 更新5h窗口状态
 	s.rateLimitService.UpdateSessionWindow(ctx, account, resp.Header)
 
@@ -6922,6 +6934,10 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 					if !clientDisconnected {
 						if _, werr := fmt.Fprint(w, block); werr != nil {
 							clientDisconnected = true
+							if cancelOnDisconnect {
+								logger.LegacyPrintf("service.gateway", "Client disconnected, canceling upstream stream")
+								return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+							}
 							logger.LegacyPrintf("service.gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
 							break
 						}
@@ -6970,6 +6986,10 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 			// 同时保持连接活跃防止 Cloudflare Tunnel 等代理断开
 			if _, werr := fmt.Fprint(w, "event: ping\ndata: {\"type\": \"ping\"}\n\n"); werr != nil {
 				clientDisconnected = true
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.gateway", "Client disconnected, canceling upstream stream")
+					return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: true}, nil
+				}
 				logger.LegacyPrintf("service.gateway", "Client disconnected during keepalive ping, continuing to drain upstream for billing")
 				continue
 			}
@@ -7553,12 +7573,19 @@ func detachedBillingContext(ctx context.Context) (context.Context, context.Cance
 	return context.WithTimeout(base, postUsageBillingTimeout)
 }
 
-func detachStreamUpstreamContext(ctx context.Context, stream bool) (context.Context, context.CancelFunc) {
+func (s *GatewayService) cancelStreamOnDisconnect() bool {
+	return s != nil && s.cfg != nil && s.cfg.Gateway.CancelStreamOnClientDisconnect
+}
+
+func detachStreamUpstreamContext(ctx context.Context, stream bool, cancelOnDisconnect bool) (context.Context, context.CancelFunc) {
 	if !stream {
 		return ctx, func() {}
 	}
 	if ctx == nil {
 		return context.Background(), func() {}
+	}
+	if cancelOnDisconnect {
+		return ctx, func() {}
 	}
 	return context.WithoutCancel(ctx), func() {}
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2177,7 +2177,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	httpInvalidEncryptedContentRetryTried := false
 	for {
 		// Build upstream request
-		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
+		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, reqStream, promptCacheKey, isCodexCLI)
 		releaseUpstreamCtx()
 		if err != nil {
@@ -2387,7 +2387,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		return nil, err
 	}
 
-	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
+	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream, s.cancelStreamOnDisconnect())
 	upstreamReq, err := s.buildUpstreamRequestOpenAIPassthrough(upstreamCtx, c, account, body, token)
 	releaseUpstreamCtx()
 	if err != nil {
@@ -2689,6 +2689,10 @@ func (s *OpenAIGatewayService) isOpenAIPassthroughTimeoutHeadersAllowed() bool {
 	return s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIPassthroughAllowTimeoutHeaders
 }
 
+func (s *OpenAIGatewayService) cancelStreamOnDisconnect() bool {
+	return s != nil && s.cfg != nil && s.cfg.Gateway.CancelStreamOnClientDisconnect
+}
+
 func collectOpenAIPassthroughTimeoutHeaders(h http.Header) []string {
 	if h == nil {
 		return nil
@@ -2720,6 +2724,8 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	account *Account,
 	startTime time.Time,
 ) (*openaiStreamingResultPassthrough, error) {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 
 	// SSE headers
@@ -2774,6 +2780,10 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		if !clientDisconnected {
 			if _, err := fmt.Fprintln(w, line); err != nil {
 				clientDisconnected = true
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected, canceling upstream stream: account=%d", account.ID)
+					return &openaiStreamingResultPassthrough{usage: usage, firstTokenMs: firstTokenMs}, nil
+				}
 				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
 			} else {
 				flusher.Flush()
@@ -3271,6 +3281,8 @@ type openaiStreamingResult struct {
 }
 
 func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, startTime time.Time, originalModel, mappedModel string) (*openaiStreamingResult, error) {
+	cancelOnDisconnect := s.cancelStreamOnDisconnect()
+
 	if s.responseHeaderFilter != nil {
 		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	}
@@ -3348,6 +3360,9 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	errorEventSent := false
 	clientDisconnected := false // 客户端断开后继续 drain 上游以收集 usage
 	sawTerminalEvent := false
+	shouldCancelOnDisconnect := func() bool {
+		return cancelOnDisconnect && clientDisconnected
+	}
 	sendErrorEvent := func(reason string) {
 		if errorEventSent || clientDisconnected {
 			return
@@ -3441,14 +3456,26 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 				}
 				if _, err := bufferedWriter.WriteString(line); err != nil {
 					clientDisconnected = true
-					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					if cancelOnDisconnect {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+					} else {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					}
 				} else if _, err := bufferedWriter.WriteString("\n"); err != nil {
 					clientDisconnected = true
-					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					if cancelOnDisconnect {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+					} else {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					}
 				} else if shouldFlush {
 					if err := flushBuffered(); err != nil {
 						clientDisconnected = true
-						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+						if cancelOnDisconnect {
+							logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+						} else {
+							logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+						}
 					}
 				}
 			}
@@ -3466,14 +3493,26 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 		if !clientDisconnected {
 			if _, err := bufferedWriter.WriteString(line); err != nil {
 				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+				} else {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				}
 			} else if _, err := bufferedWriter.WriteString("\n"); err != nil {
 				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+				} else {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				}
 			} else if queueDrained {
 				if err := flushBuffered(); err != nil {
 					clientDisconnected = true
-					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+					if cancelOnDisconnect {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+					} else {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+					}
 				}
 			}
 		}
@@ -3484,6 +3523,9 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 		defer putSSEScannerBuf64K(scanBuf)
 		for scanner.Scan() {
 			processSSELine(scanner.Text(), true)
+			if shouldCancelOnDisconnect() {
+				return resultWithUsage(), nil
+			}
 		}
 		if result, err, done := handleScanErr(scanner.Err()); done {
 			return result, err
@@ -3533,6 +3575,9 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 				return result, err
 			}
 			processSSELine(ev.line, len(events) == 0)
+			if shouldCancelOnDisconnect() {
+				return resultWithUsage(), nil
+			}
 
 		case <-intervalCh:
 			lastRead := time.Unix(0, atomic.LoadInt64(&lastReadAt))
@@ -3559,11 +3604,19 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			}
 			if _, err := bufferedWriter.WriteString(":\n\n"); err != nil {
 				clientDisconnected = true
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+					return resultWithUsage(), nil
+				}
 				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
 				continue
 			}
 			if err := flushBuffered(); err != nil {
 				clientDisconnected = true
+				if cancelOnDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected, canceling upstream stream")
+					return resultWithUsage(), nil
+				}
 				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during keepalive flush, continuing to drain upstream for billing")
 			}
 		}


### PR DESCRIPTION
## Summary

新增 `gateway.cancel_stream_on_client_disconnect` 配置项（默认 `false`），启用后客户端断开将立即终止上游流式请求，不再继续 drain 上游收集用量数据。

### 背景

当前行为：客户端断开后，网关会继续读取上游流式响应直到自然结束，以确保收集完整的 token 用量数据用于计费。这对于多用户共享部署是合理的。

但对于**自用部署**场景，这意味着用户取消请求后上游仍在持续消耗配额（尤其是长输出的 AI 响应可能持续数十秒），造成不必要的开销。

### 改动

- **config**: 新增 `CancelStreamOnClientDisconnect` 布尔配置字段
- **detachStreamUpstreamContext**: 启用时保留原始 context（客户端断开可取消上游 HTTP 请求）
- **所有流式 relay 循环**: 启用时检测到客户端断开后立即返回，不再 drain
  - `GatewayService.handleStreamingResponse`
  - `GatewayService.handleStreamingResponseAnthropicAPIKeyPassthrough`
  - `OpenAIGatewayService.handleStreamingResponse`（同步 + 异步路径）
  - `OpenAIGatewayService.handleStreamingResponsePassthrough`
  - `AntigravityGatewayService.handleGeminiStreamingResponse`
  - `AntigravityGatewayService.handleClaudeStreamingResponse`（通过 `antigravityClientWriter`）
  - `AntigravityGatewayService.streamUpstreamResponse`

### 使用方式

```yaml
gateway:
  cancel_stream_on_client_disconnect: true
```

### 注意事项

- 默认 `false`，**不改变现有行为**
- 启用后将无法获取完整的 token 用量数据，影响计费准确性
- 建议仅在自用部署、不依赖精确计费的场景下启用

### 测试

- `go build ./...` ✅
- `go test -tags=unit ./internal/service/` ✅（82s，全部通过）