### PR TITLE
fix: skip pool mode codex extra rate-limit sync

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4454,6 +4454,9 @@ func applyOpenAICodexRateLimitFromExtra(account *Account, now time.Time) (*time.
 	if account == nil || !account.IsOpenAI() {
 		return nil, false
 	}
+	if account.IsPoolMode() {
+		return nil, false
+	}
 	resetAt := codexRateLimitResetAtFromExtra(account.Extra, now)
 	if resetAt == nil {
 		return nil, false

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -473,6 +473,38 @@ func TestOpenAIGatewayService_GetSchedulableAccount_ExhaustedCodexExtraSetsRateL
 	}
 }
 
+func TestOpenAIGatewayService_GetSchedulableAccount_PoolModeExhaustedCodexExtraDoesNotSetRateLimit(t *testing.T) {
+	resetAt := time.Now().Add(6 * 24 * time.Hour)
+	account := Account{
+		ID:          711,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":   "sk-test",
+			"pool_mode": true,
+		},
+		Extra: map[string]any{
+			"codex_7d_used_percent": 100.0,
+			"codex_7d_reset_at":     resetAt.UTC().Format(time.RFC3339),
+		},
+	}
+	repo := &openAICodexExtraListRepo{stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}}, rateLimitCh: make(chan time.Time, 1)}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+
+	fresh, err := svc.getSchedulableAccount(context.Background(), account.ID)
+	require.NoError(t, err)
+	require.NotNil(t, fresh)
+	require.Nil(t, fresh.RateLimitResetAt)
+	select {
+	case persisted := <-repo.rateLimitCh:
+		t.Fatalf("unexpected synced rate limit reset at: %v", persisted)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestAdminService_ListAccounts_ExhaustedCodexExtraReturnsRateLimitedAccount(t *testing.T) {
 	resetAt := time.Now().Add(4 * 24 * time.Hour)
 	repo := &openAICodexExtraListRepo{
@@ -503,6 +535,41 @@ func TestAdminService_ListAccounts_ExhaustedCodexExtraReturnsRateLimitedAccount(
 		require.WithinDuration(t, resetAt.UTC(), persisted, time.Second)
 	case <-time.After(2 * time.Second):
 		t.Fatal("等待列表补写限流状态超时")
+	}
+}
+
+func TestAdminService_ListAccounts_PoolModeExhaustedCodexExtraDoesNotSetRateLimit(t *testing.T) {
+	resetAt := time.Now().Add(4 * 24 * time.Hour)
+	repo := &openAICodexExtraListRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{{
+			ID:          712,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Credentials: map[string]any{
+				"api_key":   "sk-test",
+				"pool_mode": true,
+			},
+			Extra: map[string]any{
+				"codex_7d_used_percent": 100.0,
+				"codex_7d_reset_at":     resetAt.UTC().Format(time.RFC3339),
+			},
+		}}},
+		rateLimitCh: make(chan time.Time, 1),
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeAPIKey, "", "", 0, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), total)
+	require.Len(t, accounts, 1)
+	require.Nil(t, accounts[0].RateLimitResetAt)
+	select {
+	case persisted := <-repo.rateLimitCh:
+		t.Fatalf("unexpected synced rate limit reset at: %v", persisted)
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 


### PR DESCRIPTION
## Summary
- skip syncing `codex_*` usage snapshots from `extra` into local rate-limit state for pool mode API key accounts
- keep the existing exhausted snapshot behavior for non-pool-mode OpenAI accounts
- add regression tests for schedulable-account reloads and admin account listing

## Reproduction
1. Configure an OpenAI API key account with `credentials.pool_mode=true` and passthrough/WS enabled.
2. Let `extra` retain an exhausted Codex snapshot such as `codex_7d_used_percent=100` plus a future `codex_7d_reset_at`.
3. Manually reset the local account status.
4. Fetch the account again through scheduling or admin list.

Before this change, the stale `codex_*` snapshot was synced back into local `RateLimitResetAt`, so the local account state became rate-limited again after reset.

## Testing
- `env GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go test ./internal/service -run 'Test(OpenAIGatewayService_GetSchedulableAccount_(ExhaustedCodexExtraSetsRateLimit|PoolModeExhaustedCodexExtraDoesNotSetRateLimit)|AdminService_ListAccounts_(ExhaustedCodexExtraReturnsRateLimitedAccount|PoolModeExhaustedCodexExtraDoesNotSetRateLimit))$'`
- `env GOPATH=/tmp/go GOMODCACHE=/tmp/go/pkg/mod GOCACHE=/tmp/go-build go test ./internal/service -run 'Test(OpenAIGatewayService_(OAuthPassthrough_429PersistsRateLimit|Forward_WSv2ErrorEventUsageLimitPersistsRateLimit|Forward_WSv2Handshake429PersistsRateLimit|ProxyResponsesWebSocketFromClient_ErrorEventUsageLimitPersistsRateLimit))$'`
