### PR TITLE
fix(gateway): reject unsupported responses subpaths for OAuth accounts

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2510,8 +2510,15 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	token string,
 ) (*http.Request, error) {
 	targetURL := openaiPlatformAPIURL
+	suffix := openAIResponsesRequestPathSuffix(c)
 	switch account.Type {
 	case AccountTypeOAuth:
+		// ChatGPT Codex internal API only supports /responses and /responses/compact,
+		// reject unsupported subpaths (e.g. /input_tokens) to avoid 403 from Cloudflare
+		// which would trigger account circuit-breaking.
+		if suffix != "" && !isOpenAIResponsesCompactPath(c) {
+			return nil, fmt.Errorf("OAuth account does not support responses subpath %q", suffix)
+		}
 		targetURL = chatgptCodexURL
 	case AccountTypeAPIKey:
 		baseURL := account.GetOpenAIBaseURL()
@@ -2523,7 +2530,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 			targetURL = buildOpenAIResponsesURL(validatedURL)
 		}
 	}
-	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
+	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, suffix)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
@@ -2908,8 +2915,15 @@ func writeOpenAIPassthroughResponseHeaders(dst http.Header, src http.Header, fil
 func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string, isStream bool, promptCacheKey string, isCodexCLI bool) (*http.Request, error) {
 	// Determine target URL based on account type
 	var targetURL string
+	suffix := openAIResponsesRequestPathSuffix(c)
 	switch account.Type {
 	case AccountTypeOAuth:
+		// ChatGPT Codex internal API only supports /responses and /responses/compact,
+		// reject unsupported subpaths (e.g. /input_tokens) to avoid 403 from Cloudflare
+		// which would trigger account circuit-breaking.
+		if suffix != "" && !isOpenAIResponsesCompactPath(c) {
+			return nil, fmt.Errorf("OAuth account does not support responses subpath %q", suffix)
+		}
 		// OAuth accounts use ChatGPT internal API
 		targetURL = chatgptCodexURL
 	case AccountTypeAPIKey:
@@ -2927,7 +2941,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	default:
 		targetURL = openaiPlatformAPIURL
 	}
-	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
+	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, suffix)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {


### PR DESCRIPTION
## Problem

OAuth accounts route to `chatgpt.com/backend-api/codex/responses`. Sub-path requests like `/v1/responses/input_tokens` return 403 from Cloudflare, which the circuit breaker treats as auth failure and **disables the entire account**.

Triggered by LiteLLM's `OpenAITokenCounter` calling `/v1/responses/input_tokens` during Claude Code context compaction (`/compact`).

## Fix

Validate responses API sub-path for OAuth accounts before forwarding:
- `/compact` and `/compact/*` → allowed
- Any other sub-path → reject immediately (fast 502, no upstream call)

Applied in both `buildUpstreamRequestOpenAIPassthrough` and `buildUpstreamRequest`.

## Verification

5 consecutive `/input_tokens` calls → 502 each (~5ms, no upstream hit), account NOT disabled, `/v1/responses` continues returning 200.