### PR TITLE
fix: plan_type never updates after subscription change

### DIFF
--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -610,7 +610,10 @@ func enrichCredentialsFromIDToken(item *DataAccount) {
 	}
 
 	setIfMissing("email", userInfo.Email)
-	setIfMissing("plan_type", userInfo.PlanType)
+	// plan_type 是可变的（如 free → plus），始终用最新值覆盖
+	if userInfo.PlanType != "" {
+		item.Credentials["plan_type"] = userInfo.PlanType
+	}
 	setIfMissing("chatgpt_account_id", userInfo.ChatGPTAccountID)
 	setIfMissing("chatgpt_user_id", userInfo.ChatGPTUserID)
 	setIfMissing("organization_id", userInfo.OrganizationID)

--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -259,8 +259,9 @@ func (s *OpenAIOAuthService) RefreshTokenWithClientID(ctx context.Context, refre
 		tokenInfo.PlanType = userInfo.PlanType
 	}
 
-	// id_token 中缺少 plan_type 时（如 Mobile RT），尝试通过 ChatGPT backend-api 补全
-	if tokenInfo.PlanType == "" && tokenInfo.AccessToken != "" && s.privacyClientFactory != nil {
+	// 通过 ChatGPT backend-api 获取实时 plan_type，因为 id_token 中的 chatgpt_plan_type 可能是缓存的旧值
+	// （例如：账号从 free 升级到 plus 后，id_token 仍返回 "free"）
+	if tokenInfo.AccessToken != "" && s.privacyClientFactory != nil {
 		// 从 access_token JWT 中提取 orgID（poid），用于匹配正确的账号
 		orgID := tokenInfo.OrganizationID
 		if orgID == "" {
@@ -269,7 +270,8 @@ func (s *OpenAIOAuthService) RefreshTokenWithClientID(ctx context.Context, refre
 			}
 		}
 		if info := fetchChatGPTAccountInfo(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, orgID); info != nil {
-			if tokenInfo.PlanType == "" && info.PlanType != "" {
+			// 优先使用 accounts/check 的实时结果，而非 id_token 中可能过期的值
+			if info.PlanType != "" {
 				tokenInfo.PlanType = info.PlanType
 			}
 			if tokenInfo.Email == "" && info.Email != "" {


### PR DESCRIPTION
## Summary

- Fix `plan_type` staying stale (e.g. `"free"`) after an OpenAI subscription upgrade (free → plus)
- OpenAI's `id_token` JWT caches `chatgpt_plan_type`, so the `accounts/check` API (real-time) should always be preferred

## Changes

### 1. `openai_oauth_service.go` — Always fetch real-time plan_type

**Before:** `fetchChatGPTAccountInfo()` was only called when `tokenInfo.PlanType == ""`. Since `id_token` always includes `chatgpt_plan_type` (even stale), this condition was never true, and the stale value persisted.

**After:** Always call `fetchChatGPTAccountInfo()` and prefer its real-time `plan_type` over the id_token's potentially cached value.

### 2. `account_data.go` — Always update plan_type on import

**Before:** `setIfMissing("plan_type", ...)` never overwrites an existing value, so re-importing an upgraded account keeps the old `"free"`.

**After:** Always overwrite `plan_type` since it's mutable (unlike email or account ID).

## Test plan

- [ ] Import a free account, upgrade to plus on OpenAI, trigger token refresh → verify `plan_type` updates to `"plus"`
- [ ] Import a plus account → verify `plan_type` remains `"plus"`
- [ ] Account without `id_token` (Mobile RT) still falls back to `accounts/check` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)