### PR TITLE
fix: localize shared GroupOptionItem rate label

### DIFF
--- a/frontend/src/components/common/GroupOptionItem.vue
+++ b/frontend/src/components/common/GroupOptionItem.vue
@@ -31,7 +31,7 @@
           <span class="font-bold">{{ userRateMultiplier }}x</span>
         </template>
         <template v-else>
-          {{ rateMultiplier }}x 倍率
+          {{ rateMultiplier }}x {{ t('usage.rate') }}
         </template>
       </span>
       <!-- Checkmark -->
@@ -51,6 +51,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import GroupBadge from './GroupBadge.vue'
 import type { SubscriptionType, GroupPlatform } from '@/types'
 
@@ -71,6 +72,8 @@ const props = withDefaults(defineProps<Props>(), {
   showCheckmark: true,
   userRateMultiplier: null
 })
+
+const { t } = useI18n()
 
 // Whether user has a custom rate different from default
 const hasCustomRate = computed(() => {

--- a/frontend/src/components/common/__tests__/GroupOptionItem.spec.ts
+++ b/frontend/src/components/common/__tests__/GroupOptionItem.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import GroupOptionItem from '../GroupOptionItem.vue'
+
+const localeMessages = {
+  en: {
+    'usage.rate': 'Rate'
+  },
+  zh: {
+    'usage.rate': '倍率'
+  }
+} as const
+
+let currentLocale: keyof typeof localeMessages = 'en'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: keyof (typeof localeMessages)[typeof currentLocale]) => localeMessages[currentLocale][key] ?? key
+  })
+}))
+
+const createWrapper = () => mount(GroupOptionItem, {
+  props: {
+    name: 'Test Group',
+    platform: 'openai',
+    rateMultiplier: 1
+  },
+  global: {
+    stubs: {
+      GroupBadge: {
+        template: '<div class="group-badge-stub" />'
+      }
+    }
+  }
+})
+
+describe('GroupOptionItem', () => {
+  it('renders the rate label in English without hardcoded Chinese text', () => {
+    currentLocale = 'en'
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('1x Rate')
+    expect(wrapper.text()).not.toContain('倍率')
+  })
+
+  it('renders the rate label in Chinese for zh locale', () => {
+    currentLocale = 'zh'
+
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('1x 倍率')
+  })
+})


### PR DESCRIPTION
## Summary
- fixes #1205, where the English Keys page showed the Chinese `倍率` label
- replaces the hardcoded `{{ rateMultiplier }}x 倍率` branch in shared `GroupOptionItem.vue` with `{{ rateMultiplier }}x {{ t('usage.rate') }}` via `useI18n()`
- adds focused regression coverage proving English renders `1x Rate` and not `倍率`, while Chinese still renders `1x 倍率`

## Root cause
Issue #1205 surfaced on the Keys page, but the source was the shared `frontend/src/components/common/GroupOptionItem.vue` component. Its non-custom-rate branch rendered a hardcoded Chinese suffix instead of using the existing locale key, so English consumers leaked `倍率`.

## Changes
- import `useI18n()` in `frontend/src/components/common/GroupOptionItem.vue`
- replace `{{ rateMultiplier }}x 倍率` with `{{ rateMultiplier }}x {{ t('usage.rate') }}`
- cover the affected branch in `frontend/src/components/common/__tests__/GroupOptionItem.spec.ts` so English renders `1x Rate` and not `倍率`, while Chinese renders `1x 倍率`
- leave locale files unchanged because `usage.rate` already exists in `frontend/src/i18n/locales/en.ts` and `frontend/src/i18n/locales/zh.ts`

## Verification
- `pnpm --dir frontend run test:run src/components/common/__tests__/GroupOptionItem.spec.ts`
- `pnpm --dir frontend run lint:check`
- `pnpm --dir frontend run typecheck`
- `pnpm --dir frontend run build`

## Impact
- fixes the English locale leak reported in #1205
- applies at the shared component boundary, so KeysView and other group-selection UIs using `GroupOptionItem` get the corrected locale behavior
- frontend-only and low risk: no backend/API/data-model changes, no new locale keys, and Chinese output remains unchanged

Fixes #1205