### PR TITLE
Fix: 修正运维监控错误日志表格列名显示

### DIFF
--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3656,6 +3656,7 @@ export default {
         group: '分组',
         user: '用户',
         userId: '用户 ID',
+        userOrAccount: '用户/账号',
         account: '账号',
         accountId: '账号 ID',
         status: '状态码',

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
@@ -252,6 +252,7 @@ watch(
             :loading="loading"
             :page="page"
             :page-size="pageSize"
+            :error-type="errorType"
             @openErrorDetail="emit('openErrorDetail', $event)"
 
             @update:page="page = $event"

--- a/frontend/src/views/admin/ops/components/OpsErrorLogTable.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorLogTable.vue
@@ -30,7 +30,7 @@
                 {{ t('admin.ops.errorLog.group') }}
               </th>
               <th class="border-b border-gray-200 px-4 py-2.5 text-left text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:border-dark-700 dark:text-dark-400">
-                {{ t('admin.ops.errorLog.user') }}
+                {{ props.errorType === 'upstream' ? t('admin.ops.errorLog.account') : t('admin.ops.errorLog.userOrAccount') }}
               </th>
               <th class="border-b border-gray-200 px-4 py-2.5 text-left text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:border-dark-700 dark:text-dark-400">
                 {{ t('admin.ops.errorLog.status') }}
@@ -293,6 +293,7 @@ interface Props {
   loading: boolean
   page: number
   pageSize: number
+  errorType?: 'request' | 'upstream'
 }
 
 interface Emits {
@@ -301,7 +302,7 @@ interface Emits {
   (e: 'update:pageSize', value: number): void
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
 const emit = defineEmits<Emits>()
 
 function getStatusClass(code: number): string {


### PR DESCRIPTION
## 修正运维监控错误日志表格列名显示

### 问题描述

在运维监控页面中，请求错误和上游错误的明细表格都有一个"用户"列，但实际数据内容不一致：
- **请求错误明细**：该列混合显示用户邮箱（user_email）和账号名（account_name）
- **上游错误明细**：该列仅显示账号名（account_name）

列名固定显示"用户"，但实际数据可能是账号，语义不符。

### 解决方案

1. **OpsErrorLogTable.vue**
   - 添加 `errorType` prop（`'request' | 'upstream'`）
   - 列头根据 `errorType` 动态显示：
     - `errorType === 'upstream'` → 显示"账号"
     - 其他情况 → 显示"用户/账号"（因为请求错误明细中混合了两种数据）

2. **OpsErrorDetailsModal.vue**
   - 透传 `errorType` prop 给 `OpsErrorLogTable` 组件

3. **i18n (zh.ts)**
   - 添加翻译键 `userOrAccount: '用户/账号'`

### 修改文件

- `frontend/src/views/admin/ops/components/OpsErrorLogTable.vue`
- `frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue`
- `frontend/src/i18n/locales/zh.ts`

### 测试

- [x] 上游错误明细：列头显示"账号"
- [x] 请求错误明细：列头显示"用户/账号"
- [x] 数据单元格根据行类型正确显示用户邮箱或账号名
