### PR TITLE
fix(apicompat): support array-format content in streaming chat completions

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -181,6 +181,26 @@ func TestChatCompletionsToResponses_ImageURL(t *testing.T) {
 	assert.Equal(t, "data:image/png;base64,abc123", parts[1].ImageURL)
 }
 
+func TestChatCompletionsToResponses_TextOnlyArrayContentFlattensToString(t *testing.T) {
+	req := &ChatCompletionsRequest{
+		Model: "gpt-4o",
+		Messages: []ChatMessage{
+			{Role: "user", Content: json.RawMessage(`[{"type":"text","text":"hello"},{"type":"text","text":" world"}]`)},
+		},
+	}
+
+	resp, err := ChatCompletionsToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 1)
+
+	var content string
+	require.NoError(t, json.Unmarshal(items[0].Content, &content))
+	assert.Equal(t, "hello world", content)
+}
+
 func TestChatCompletionsToResponses_SystemArrayContent(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model: "gpt-4o",
@@ -197,11 +217,9 @@ func TestChatCompletionsToResponses_SystemArrayContent(t *testing.T) {
 	require.NoError(t, json.Unmarshal(resp.Input, &items))
 	require.Len(t, items, 2)
 
-	var systemParts []ResponsesContentPart
-	require.NoError(t, json.Unmarshal(items[0].Content, &systemParts))
-	require.Len(t, systemParts, 1)
-	assert.Equal(t, "input_text", systemParts[0].Type)
-	assert.Equal(t, "You are a careful visual assistant.", systemParts[0].Text)
+	var systemContent string
+	require.NoError(t, json.Unmarshal(items[0].Content, &systemContent))
+	assert.Equal(t, "You are a careful visual assistant.", systemContent)
 
 	var userParts []ResponsesContentPart
 	require.NoError(t, json.Unmarshal(items[1].Content, &userParts))

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -324,7 +324,19 @@ func marshalChatInputContent(content chatMessageContent) (json.RawMessage, error
 	if content.Text != nil {
 		return json.Marshal(*content.Text)
 	}
+	if hasOnlyTextChatContentParts(content.Parts) {
+		return json.Marshal(flattenChatContentParts(content.Parts))
+	}
 	return json.Marshal(convertChatContentPartsToResponses(content.Parts))
+}
+
+func hasOnlyTextChatContentParts(parts []ChatContentPart) bool {
+	for _, p := range parts {
+		if p.Type != "text" {
+			return false
+		}
+	}
+	return true
 }
 
 func convertChatContentPartsToResponses(parts []ChatContentPart) []ResponsesContentPart {

--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -3,6 +3,8 @@
 package service
 
 import (
+	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -106,4 +110,56 @@ func TestHandleCCStreamingFromAnthropic_PreservesMessageStartCacheUsageAndReason
 	require.NotNil(t, result.ReasoningEffort)
 	require.Equal(t, "medium", *result.ReasoningEffort)
 	require.Contains(t, rec.Body.String(), `[DONE]`)
+}
+
+func TestOpenAIGatewayService_ForwardAsChatCompletions_StreamTextArrayContent(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"x-request-id": []string{"rid_openai_cc_stream"}},
+			Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+				`data: {"type":"response.created","response":{"id":"resp_1"}}`,
+				``,
+				`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","status":"completed","model":"gpt-4o","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello back"}],"status":"completed"}],"usage":{"input_tokens":3,"output_tokens":2,"total_tokens":5}}}`,
+				``,
+				`data: [DONE]`,
+				``,
+			}, "\n"))),
+		},
+	}
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-key",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test"},
+	}
+	body := []byte(`{"model":"gpt-4o","stream":true,"messages":[{"role":"user","content":[{"type":"text","text":"hello"},{"type":"text","text":" world"}]}]}`)
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Stream)
+	require.Contains(t, rec.Body.String(), `[DONE]`)
+
+	var upstreamReq apicompat.ResponsesRequest
+	require.NoError(t, json.Unmarshal(upstream.lastBody, &upstreamReq))
+
+	var items []apicompat.ResponsesInputItem
+	require.NoError(t, json.Unmarshal(upstreamReq.Input, &items))
+	require.Len(t, items, 1)
+
+	var content string
+	require.NoError(t, json.Unmarshal(items[0].Content, &content))
+	require.Equal(t, "hello world", content)
 }


### PR DESCRIPTION
## Summary
- normalize text-only `messages[].content` arrays into a plain string in the chat-completions → responses compatibility path
- preserve multimodal arrays as structured content so image inputs continue to pass through correctly
- add regression coverage for both the compat converter and the streaming OpenAI chat-completions forwarding path

## Problem
- OpenAI-compatible clients such as Cursor can send chat-completions `messages[].content` as an array instead of a string
- streaming `/v1/chat/completions` requests could fail on that payload shape and return `502 upstream_error`
- plain string content and non-streaming requests were not affected

## Fix
- flatten pure text content arrays into a single string during `ChatCompletionsToResponses`
- keep mixed or multimodal arrays in structured Responses API part form instead of collapsing them
- add a service-level streaming regression test that verifies the forwarded upstream payload for Cursor-style requests

## Verification
- `go test ./internal/pkg/apicompat`
- `go test -tags unit ./internal/service -run 'TestExtractCCReasoningEffortFromBody|TestHandleCCBufferedFromAnthropic_PreservesMessageStartCacheUsageAndReasoning|TestHandleCCStreamingFromAnthropic_PreservesMessageStartCacheUsageAndReasoning|TestOpenAIGatewayService_ForwardAsChatCompletions_StreamTextArrayContent'`
- `go test ./...`
- `go build ./cmd/server`
- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `golangci-lint run ./...` *(not available in this environment: `command not found`)*

Closes #1247