### PR TITLE
fix(oauth): 每次刷新都通过 backend-api 获取最新 plan_type

### DIFF
--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -259,8 +259,9 @@ func (s *OpenAIOAuthService) RefreshTokenWithClientID(ctx context.Context, refre
 		tokenInfo.PlanType = userInfo.PlanType
 	}
 
-	// id_token 中缺少 plan_type 时（如 Mobile RT），尝试通过 ChatGPT backend-api 补全
-	if tokenInfo.PlanType == "" && tokenInfo.AccessToken != "" && s.privacyClientFactory != nil {
+	// 每次刷新都通过 ChatGPT backend-api 获取最新的 plan_type，
+	// 因为账号订阅类型可能每月变化，id_token 中的值是签发时的快照，不一定反映当前状态。
+	if tokenInfo.AccessToken != "" && s.privacyClientFactory != nil {
 		// 从 access_token JWT 中提取 orgID（poid），用于匹配正确的账号
 		orgID := tokenInfo.OrganizationID
 		if orgID == "" {
@@ -269,7 +270,7 @@ func (s *OpenAIOAuthService) RefreshTokenWithClientID(ctx context.Context, refre
 			}
 		}
 		if info := fetchChatGPTAccountInfo(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, orgID); info != nil {
-			if tokenInfo.PlanType == "" && info.PlanType != "" {
+			if info.PlanType != "" {
 				tokenInfo.PlanType = info.PlanType
 			}
 			if tokenInfo.Email == "" && info.Email != "" {


### PR DESCRIPTION
账号订阅类型可能每月变化，id_token 中的 plan_type 是签发时的快照，
不一定反映当前状态。移除 plan_type == "" 前置条件，确保每次刷新都
调用 ChatGPT backend-api 获取实时订阅类型并覆盖旧值。