### PR TITLE
fix(antigravity): 修复批量刷新令牌不设置隐私模式的问题

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -839,6 +839,7 @@ func (h *AccountHandler) refreshSingleAccount(ctx context.Context, account *serv
 			if updateErr != nil {
 				return nil, "", fmt.Errorf("failed to update credentials: %w", updateErr)
 			}
+			h.adminService.EnsureAntigravityPrivacy(ctx, updatedAccount)
 			return updatedAccount, "missing_project_id_temporary", nil
 		}
 

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2783,16 +2783,14 @@ func (s *adminServiceImpl) ForceOpenAIPrivacy(ctx context.Context, account *Acco
 }
 
 // EnsureAntigravityPrivacy 检查 Antigravity OAuth 账号隐私状态。
-// 如果 Extra["privacy_mode"] 已存在（无论成功或失败），直接跳过。
-// 仅对从未设置过隐私的账号执行 setUserSettings + fetchUserInfo 流程。
-// 用户可通过前端 ForceAntigravityPrivacy（SetPrivacy 按钮）强制重新设置。
+// 仅当 privacy_mode 已成功设置（"privacy_set"）时跳过；
+// 未设置或之前失败（"privacy_set_failed"）均会重试。
 func (s *adminServiceImpl) EnsureAntigravityPrivacy(ctx context.Context, account *Account) string {
 	if account.Platform != PlatformAntigravity || account.Type != AccountTypeOAuth {
 		return ""
 	}
-	// 已设置过则跳过（无论成功或失败），用户可通过 Force 手动重试
 	if account.Extra != nil {
-		if existing, ok := account.Extra["privacy_mode"].(string); ok && existing != "" {
+		if existing, ok := account.Extra["privacy_mode"].(string); ok && existing == AntigravityPrivacySet {
 			return existing
 		}
 	}

--- a/backend/internal/service/antigravity_oauth_service.go
+++ b/backend/internal/service/antigravity_oauth_service.go
@@ -91,6 +91,7 @@ type AntigravityTokenInfo struct {
 	ProjectID        string `json:"project_id,omitempty"`
 	ProjectIDMissing bool   `json:"-"`
 	PlanType         string `json:"-"`
+	PrivacyMode      string `json:"-"`
 }
 
 // ExchangeCode 用 authorization code 交换 token
@@ -158,6 +159,9 @@ func (s *AntigravityOAuthService) ExchangeCode(ctx context.Context, input *Antig
 			result.PlanType = loadResult.Subscription.PlanType
 		}
 	}
+
+	// 令牌刚获取，立即设置隐私（不依赖后续账号创建流程）
+	result.PrivacyMode = setAntigravityPrivacy(ctx, result.AccessToken, result.ProjectID, proxyURL)
 
 	return result, nil
 }
@@ -247,6 +251,9 @@ func (s *AntigravityOAuthService) ValidateRefreshToken(ctx context.Context, refr
 			tokenInfo.PlanType = loadResult.Subscription.PlanType
 		}
 	}
+
+	// 令牌刚获取，立即设置隐私
+	tokenInfo.PrivacyMode = setAntigravityPrivacy(ctx, tokenInfo.AccessToken, tokenInfo.ProjectID, proxyURL)
 
 	return tokenInfo, nil
 }

--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -489,15 +489,14 @@ func (s *TokenRefreshService) ensureOpenAIPrivacy(ctx context.Context, account *
 }
 
 // ensureAntigravityPrivacy 后台刷新中检查 Antigravity OAuth 账号隐私状态。
-// 仅做 Extra["privacy_mode"] 存在性检查，不发起 HTTP 请求，避免每轮循环产生额外网络开销。
-// 用户可通过前端 SetPrivacy 按钮强制重新设置。
+// 仅当 privacy_mode 已成功设置（"privacy_set"）时跳过；
+// 未设置或之前失败（"privacy_set_failed"）均会重试。
 func (s *TokenRefreshService) ensureAntigravityPrivacy(ctx context.Context, account *Account) {
 	if account.Platform != PlatformAntigravity || account.Type != AccountTypeOAuth {
 		return
 	}
-	// 已设置过（无论成功或失败）则跳过，不发 HTTP
 	if account.Extra != nil {
-		if _, ok := account.Extra["privacy_mode"]; ok {
+		if mode, ok := account.Extra["privacy_mode"].(string); ok && mode == AntigravityPrivacySet {
 			return
 		}
 	}


### PR DESCRIPTION
- refreshSingleAccount ProjectIDMissing 提前返回前补上 EnsureAntigravityPrivacy 调用
- EnsureAntigravityPrivacy 跳过条件从"有任何值"改为"仅 privacy_set 成功时跳过"， privacy_set_failed 允许重试，对齐 OpenAI shouldSkipOpenAIPrivacyEnsure 的行为
- 后台 TokenRefreshService.ensureAntigravityPrivacy 同步修改
- ExchangeCode/ValidateRefreshToken 获得令牌后立即调用 setAntigravityPrivacy， 不依赖后续账号创建流程

Made-with: Cursor