### PR TITLE
fix: embed IANA timezone database to fix startup failure on Windows

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	_ "time/tzdata" // embed IANA timezone database for platforms without system tzdata (e.g. Windows)
 
 	_ "github.com/Wei-Shaw/sub2api/ent/runtime"
 	"github.com/Wei-Shaw/sub2api/internal/config"


### PR DESCRIPTION
Fixes #1398

## Problem

On platforms without a system-level timezone database (notably Windows), `time.LoadLocation()` fails with `unknown time zone Asia/Shanghai`, causing the server to exit at startup:

```
Failed to initialize application: invalid timezone "Asia/Shanghai": unknown time zone Asia/Shanghai
```

Go's `time.LoadLocation` relies on the OS timezone data (`/usr/share/zoneinfo` on Linux/macOS), which is not available on Windows.

## Solution

Add a blank import of `time/tzdata` in `backend/cmd/server/main.go`. This embeds the complete IANA timezone database directly into the compiled binary (~450 KB overhead), making all `time.LoadLocation` calls work on every platform without requiring OS timezone data.

```go
import _ "time/tzdata" // embed IANA timezone database for platforms without system tzdata (e.g. Windows)
```

## Testing

- Root cause confirmed by tracing `timezone.Init()` in `internal/pkg/timezone/timezone.go` through `internal/repository/ent.go`
- This is the standard, well-documented Go solution: https://pkg.go.dev/time/tzdata