### PR TITLE
fix: stabilize pagination nav width to prevent layout shift on page change

### DIFF
--- a/frontend/src/components/common/Pagination.vue
+++ b/frontend/src/components/common/Pagination.vue
@@ -171,37 +171,39 @@ const jumpPage = ref('')
 
 const visiblePages = computed(() => {
   const pages: (number | string)[] = []
-  const maxVisible = 7
   const total = totalPages.value
 
-  if (total <= maxVisible) {
-    // Show all pages if total is small
+  if (total <= 7) {
+    // Show all pages when there are 7 or fewer total
     for (let i = 1; i <= total; i++) {
       pages.push(i)
     }
-  } else {
-    // Always show first page
-    pages.push(1)
+    return pages
+  }
 
-    const start = Math.max(2, props.page - 2)
-    const end = Math.min(total - 1, props.page + 2)
-
-    // Add ellipsis before if needed
-    if (start > 2) {
-      pages.push('...')
-    }
-
-    // Add middle pages
-    for (let i = start; i <= end; i++) {
+  // Always produce exactly 7 items to keep the nav width stable:
+  //   [1, 2, 3, 4, 5, '...', total]          — near start (page ≤ 4)
+  //   [1, '...', p-1, p, p+1, '...', total]  — middle
+  //   [1, '...', total-4, …, total]           — near end (page ≥ total-3)
+  if (props.page <= 4) {
+    for (let i = 1; i <= 5; i++) {
       pages.push(i)
     }
-
-    // Add ellipsis after if needed
-    if (end < total - 1) {
-      pages.push('...')
+    pages.push('...')
+    pages.push(total)
+  } else if (props.page >= total - 3) {
+    pages.push(1)
+    pages.push('...')
+    for (let i = total - 4; i <= total; i++) {
+      pages.push(i)
     }
-
-    // Always show last page
+  } else {
+    pages.push(1)
+    pages.push('...')
+    pages.push(props.page - 1)
+    pages.push(props.page)
+    pages.push(props.page + 1)
+    pages.push('...')
     pages.push(total)
   }
 


### PR DESCRIPTION
Fixes #1363

## Problem

The pagination component's `<nav>` element changes width when navigating between pages, causing a visible layout "jump". This happens because the number of rendered page buttons is variable:

- Page 1 of 23: `« 1 2 3 … 23 »` → 5 page items
- Page 6 of 23: `« 1 … 4 5 6 7 8 … 23 »` → 9 page items

The old `visiblePages` algorithm used `page ± 2` as a sliding window, producing between 5 and 9 items depending on the current page, causing the nav to grow and shift other layout elements.

## Solution

Replace the variable-width algorithm with one that always returns exactly **7 items** when `totalPages > 7`:

| Condition | Result (7 items) |
|-----------|-----------------|
| `page ≤ 4` | `1 2 3 4 5 … total` |
| `page ≥ total - 3` | `1 … t-4 t-3 t-2 t-1 t` |
| middle | `1 … p-1 p p+1 … total` |

This ensures the `<nav>` maintains a constant width regardless of which page the user is on, eliminating the layout shift.

## Testing

Verified the output length of `visiblePages` is stable across all pages for a 23-page dataset by manually tracing the algorithm:
- Page 1: `[1,2,3,4,5,'...',23]` → 7 items ✓
- Page 5: `[1,'...',4,5,6,'...',23]` → 7 items ✓
- Page 12: `[1,'...',11,12,13,'...',23]` → 7 items ✓
- Page 20: `[1,'...',19,20,21,22,23]` → 7 items ✓
- Page 23: `[1,'...',19,20,21,22,23]` → 7 items ✓