### PR TITLE
fix: show upstream model in user usage records when model mapping is applied

### DIFF
--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -577,6 +577,7 @@ func usageLogFromServiceUser(l *service.UsageLog) UsageLog {
 		MediaType:             l.MediaType,
 		UserAgent:             l.UserAgent,
 		CacheTTLOverridden:    l.CacheTTLOverridden,
+		UpstreamModel:         l.UpstreamModel,
 		CreatedAt:             l.CreatedAt,
 		User:                  UserFromServiceShallow(l.User),
 		APIKey:                APIKeyFromService(l.APIKey),
@@ -603,7 +604,6 @@ func UsageLogFromServiceAdmin(l *service.UsageLog) *AdminUsageLog {
 	}
 	return &AdminUsageLog{
 		UsageLog:              usageLogFromServiceUser(l),
-		UpstreamModel:         l.UpstreamModel,
 		AccountRateMultiplier: l.AccountRateMultiplier,
 		IPAddress:             l.IPAddress,
 		Account:               AccountSummaryFromService(l.Account),

--- a/backend/internal/handler/dto/mappers_usage_test.go
+++ b/backend/internal/handler/dto/mappers_usage_test.go
@@ -107,7 +107,7 @@ func TestUsageLogFromService_IncludesServiceTierForUserAndAdmin(t *testing.T) {
 	require.InDelta(t, 1.5, *adminDTO.AccountRateMultiplier, 1e-12)
 }
 
-func TestUsageLogFromService_UsesRequestedModelAndKeepsUpstreamAdminOnly(t *testing.T) {
+func TestUsageLogFromService_UsesRequestedModelAndIncludesUpstreamModel(t *testing.T) {
 	t.Parallel()
 
 	upstreamModel := "claude-sonnet-4-20250514"
@@ -126,7 +126,7 @@ func TestUsageLogFromService_UsesRequestedModelAndKeepsUpstreamAdminOnly(t *test
 
 	userJSON, err := json.Marshal(userDTO)
 	require.NoError(t, err)
-	require.NotContains(t, string(userJSON), "upstream_model")
+	require.Contains(t, string(userJSON), `"upstream_model":"claude-sonnet-4-20250514"`)
 
 	adminJSON, err := json.Marshal(adminDTO)
 	require.NoError(t, err)

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -390,6 +390,10 @@ type UsageLog struct {
 	// Cache TTL Override 标记
 	CacheTTLOverridden bool `json:"cache_ttl_overridden"`
 
+	// UpstreamModel is the actual model sent to the upstream provider after mapping.
+	// Omitted when no mapping was applied (requested model was used as-is).
+	UpstreamModel *string `json:"upstream_model,omitempty"`
+
 	CreatedAt time.Time `json:"created_at"`
 
 	User         *User             `json:"user,omitempty"`
@@ -401,10 +405,6 @@ type UsageLog struct {
 // AdminUsageLog 是管理员接口使用的 usage log DTO（包含管理员字段）。
 type AdminUsageLog struct {
 	UsageLog
-
-	// UpstreamModel is the actual model sent to the upstream provider after mapping.
-	// Omitted when no mapping was applied (requested model was used as-is).
-	UpstreamModel *string `json:"upstream_model,omitempty"`
 
 	// AccountRateMultiplier 账号计费倍率快照（nil 表示按 1.0 处理）
 	AccountRateMultiplier *float64 `json:"account_rate_multiplier"`

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -984,3 +984,72 @@ func TestOpenAIGatewayServiceRecordUsage_SimpleModeSkipsBillingAfterPersist(t *t
 	require.Equal(t, 0, userRepo.deductCalls)
 	require.Equal(t, 0, subRepo.incrementCalls)
 }
+
+// TestOpenAIGatewayServiceRecordUsage_UnknownBillingModelFallsBackToUpstream verifies that
+// when the billing model has no configured pricing (e.g. "gpt" without version), RecordUsage
+// falls back to the upstream model's pricing rather than silently billing zero.
+func TestOpenAIGatewayServiceRecordUsage_UnknownBillingModelFallsBackToUpstream(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	userRepo := &openAIRecordUsageUserRepoStub{}
+	subRepo := &openAIRecordUsageSubRepoStub{}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, userRepo, subRepo, nil)
+
+	usage := OpenAIUsage{InputTokens: 10, OutputTokens: 5}
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:     "resp_unknown_billing_model",
+			Usage:         usage,
+			Model:         "gpt",     // no pricing for bare "gpt"
+			BillingModel:  "gpt",     // same non-standard name
+			UpstreamModel: "gpt-5.1", // normalized model with known pricing
+			Duration:      time.Second,
+		},
+		APIKey:  &APIKey{ID: 1001, Group: &Group{RateMultiplier: 1}},
+		User:    &User{ID: 2001},
+		Account: &Account{ID: 3001},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	// Cost must be non-zero: upstream model fallback should have been used.
+	require.Greater(t, usageRepo.lastLog.ActualCost, 0.0, "expected non-zero cost after upstream model fallback")
+	require.Greater(t, userRepo.lastAmount, 0.0, "expected non-zero deduction after upstream model fallback")
+}
+
+// TestOpenAIGatewayServiceRecordUsage_BillingModelPreferredOverRequestedModel verifies that
+// when BillingModel is explicitly set (Messages/Anthropic compat path), it is used for billing
+// instead of the client-visible model name.
+func TestOpenAIGatewayServiceRecordUsage_BillingModelPreferredOverRequestedModel(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	userRepo := &openAIRecordUsageUserRepoStub{}
+	subRepo := &openAIRecordUsageSubRepoStub{}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, userRepo, subRepo, nil)
+
+	usage := OpenAIUsage{InputTokens: 20, OutputTokens: 8}
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:     "resp_billing_model_preferred",
+			Usage:         usage,
+			Model:         "claude-opus-4-6", // client-visible Claude model (no GPT pricing)
+			BillingModel:  "gpt-5.1-codex",   // actual billing model set by Messages compat path
+			UpstreamModel: "gpt-5.1-codex",
+			Duration:      time.Second,
+		},
+		APIKey:  &APIKey{ID: 1002, Group: &Group{RateMultiplier: 1}},
+		User:    &User{ID: 2002},
+		Account: &Account{ID: 3002},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+
+	// Cost should use gpt-5.1-codex pricing, not claude-opus pricing.
+	expectedCost, calcErr := svc.billingService.CalculateCost("gpt-5.1-codex", UsageTokens{
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
+	}, 1.0)
+	require.NoError(t, calcErr)
+	require.InDelta(t, expectedCost.ActualCost, usageRepo.lastLog.ActualCost, 1e-12)
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4152,12 +4152,23 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		multiplier = resolver.Resolve(ctx, user.ID, *apiKey.GroupID, apiKey.Group.RateMultiplier)
 	}
 
-	billingModel := forwardResultBillingModel(result.Model, result.UpstreamModel)
+	// Prefer BillingModel when explicitly set (e.g., Anthropic Messages compat path where
+	// the requested model is a Claude model but billing should use the mapped GPT model).
+	billingModel := result.BillingModel
+	if billingModel == "" {
+		billingModel = forwardResultBillingModel(result.Model, result.UpstreamModel)
+	}
 	serviceTier := ""
 	if result.ServiceTier != nil {
 		serviceTier = strings.TrimSpace(*result.ServiceTier)
 	}
 	cost, err := s.billingService.CalculateCostWithServiceTier(billingModel, tokens, multiplier, serviceTier)
+	if err != nil && result.UpstreamModel != "" && result.UpstreamModel != billingModel {
+		// Fallback: try upstream model pricing when billing model has no configured price.
+		// This handles cases where billingModel is a non-standard name (e.g. "gpt" without
+		// version) while upstreamModel is always normalized to a known model (e.g. "gpt-5.1").
+		cost, err = s.billingService.CalculateCostWithServiceTier(result.UpstreamModel, tokens, multiplier, serviceTier)
+	}
 	if err != nil {
 		cost = &CostBreakdown{ActualCost: 0}
 	}

--- a/frontend/src/components/user/dashboard/UserDashboardRecentUsage.vue
+++ b/frontend/src/components/user/dashboard/UserDashboardRecentUsage.vue
@@ -19,6 +19,7 @@
             </div>
             <div>
               <p class="text-sm font-medium text-gray-900 dark:text-white">{{ log.model }}</p>
+              <p v-if="log.upstream_model && log.upstream_model !== log.model" class="text-xs text-gray-500 dark:text-dark-400">↳ {{ log.upstream_model }}</p>
               <p class="text-xs text-gray-500 dark:text-dark-400">{{ formatDateTime(log.created_at) }}</p>
             </div>
           </div>

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -156,8 +156,14 @@
             }}</span>
           </template>
 
-          <template #cell-model="{ value }">
-            <span class="font-medium text-gray-900 dark:text-white">{{ value }}</span>
+          <template #cell-model="{ value, row }">
+            <div v-if="row.upstream_model && row.upstream_model !== value" class="space-y-0.5">
+              <span class="font-medium text-gray-900 dark:text-white">{{ value }}</span>
+              <div class="text-xs text-gray-500 dark:text-gray-400">
+                <span class="mr-0.5">↳</span>{{ row.upstream_model }}
+              </div>
+            </div>
+            <span v-else class="font-medium text-gray-900 dark:text-white">{{ value }}</span>
           </template>
 
           <template #cell-reasoning_effort="{ row }">


### PR DESCRIPTION
Fixes #1444

## Problem

When a model mapping is configured (e.g., GPT-5.3-codex → GPT-5.4-mini), the usage records shown to regular users only display the originally requested model name (GPT-5.3-codex), making it impossible to see which model was actually used. The `upstream_model` field was available in the database and shown in admin views, but excluded from user-facing API responses.

## Solution

- Added `upstream_model` field to the user-facing `UsageLog` DTO (previously it was admin-only)
- Populated `UpstreamModel` in `usageLogFromServiceUser()` from the service layer
- Updated `UsageView.vue` to display the mapped model below the requested model with an arrow indicator (↳) when a mapping was applied
- Updated `UserDashboardRecentUsage.vue` to also show the mapped model in the dashboard recent usage list
- Moved `UpstreamModel` from `AdminUsageLog` into the base `UsageLog` struct since it's now shared
- Updated the test to reflect the new behavior

## Testing

- Unit test `TestUsageLogFromService_UsesRequestedModelAndIncludesUpstreamModel` updated to verify `upstream_model` is now included in both user and admin JSON responses
- When no mapping is applied, `upstream_model` is omitted (omitempty), so the display is unchanged for unmapped requests