### PR TITLE
fix: add content-based session hash fallback for OpenAI compat clients

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1120,6 +1120,9 @@ func (s *OpenAIGatewayService) ExtractSessionID(c *gin.Context, body []byte) str
 //  1. Header: session_id
 //  2. Header: conversation_id
 //  3. Body:   prompt_cache_key (opencode)
+//  4. Content-based fallback: model + system messages + first user message + auth header
+//     Used for clients that do not send explicit session signals (e.g. standard OpenAI-compat clients).
+//     Hashes only the stable request prefix so routing stays sticky across conversation rounds.
 func (s *OpenAIGatewayService) GenerateSessionHash(c *gin.Context, body []byte) string {
 	if c == nil {
 		return ""
@@ -1132,13 +1135,66 @@ func (s *OpenAIGatewayService) GenerateSessionHash(c *gin.Context, body []byte) 
 	if sessionID == "" && len(body) > 0 {
 		sessionID = strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
 	}
-	if sessionID == "" {
-		return ""
+	if sessionID != "" {
+		currentHash, legacyHash := deriveOpenAISessionHashes(sessionID)
+		attachOpenAILegacySessionHashToGin(c, legacyHash)
+		return currentHash
 	}
 
-	currentHash, legacyHash := deriveOpenAISessionHashes(sessionID)
-	attachOpenAILegacySessionHashToGin(c, legacyHash)
-	return currentHash
+	// Content-based fallback: derive a stable hash from the request prefix.
+	// This ensures non-Codex clients without explicit session signals are routed
+	// to the same upstream account for a given conversation, enabling prompt caching.
+	if len(body) > 0 {
+		if seed := deriveOpenAIContentBasedSessionSeed(c, body); seed != "" {
+			return DeriveSessionHashFromSeed(seed)
+		}
+	}
+
+	return ""
+}
+
+// deriveOpenAIContentBasedSessionSeed builds a stable seed from the Authorization
+// header (to differentiate users) and the stable prefix of the request body
+// (model + all system messages + first user message). Including only the stable
+// prefix means the hash does not change as the conversation grows, keeping
+// sticky-session routing consistent across turns.
+func deriveOpenAIContentBasedSessionSeed(c *gin.Context, body []byte) string {
+	var parts []string
+
+	// Mix in the Authorization header so two different users with identical prompts
+	// are routed independently. The raw value is hashed before use.
+	authHeader := strings.TrimSpace(c.GetHeader("Authorization"))
+	if authHeader != "" {
+		parts = append(parts, "auth="+hashSensitiveValueForLog(authHeader))
+	}
+
+	model := strings.TrimSpace(gjson.GetBytes(body, "model").String())
+	if model != "" {
+		parts = append(parts, "model="+model)
+	}
+
+	firstUserCaptured := false
+	for _, msg := range gjson.GetBytes(body, "messages").Array() {
+		role := strings.TrimSpace(msg.Get("role").String())
+		switch role {
+		case "system":
+			if content := strings.TrimSpace(msg.Get("content").String()); content != "" {
+				parts = append(parts, "system="+content)
+			}
+		case "user":
+			if !firstUserCaptured {
+				if content := strings.TrimSpace(msg.Get("content").String()); content != "" {
+					parts = append(parts, "first_user="+content)
+					firstUserCaptured = true
+				}
+			}
+		}
+	}
+
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "|")
 }
 
 // GenerateSessionHashWithFallback 先按常规信号生成会话哈希；

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -182,11 +182,63 @@ func TestOpenAIGatewayService_GenerateSessionHash_Priority(t *testing.T) {
 		t.Fatalf("expected different hashes for different keys")
 	}
 
-	// 4) empty when no signals
+	// 4) empty when no signals (no auth header, empty body)
 	h4 := svc.GenerateSessionHash(c, []byte(`{}`))
 	if h4 != "" {
 		t.Fatalf("expected empty hash when no signals")
 	}
+}
+
+func TestOpenAIGatewayService_GenerateSessionHash_ContentBasedFallback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{}
+
+	makeCtx := func(authHeader string) *gin.Context {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions", nil)
+		if authHeader != "" {
+			c.Request.Header.Set("Authorization", authHeader)
+		}
+		return c
+	}
+
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hello"}]}`)
+
+	// Content-based fallback produces a non-empty hash when Authorization + content are present
+	c1 := makeCtx("Bearer key-abc")
+	h1 := svc.GenerateSessionHash(c1, body)
+	if h1 == "" {
+		t.Fatalf("expected non-empty content-based hash")
+	}
+
+	// Same content + same auth → same hash (stable across retries)
+	c2 := makeCtx("Bearer key-abc")
+	h2 := svc.GenerateSessionHash(c2, body)
+	require.Equal(t, h1, h2, "same content + same auth should produce identical hash")
+
+	// Different auth header → different hash (different users isolated)
+	c3 := makeCtx("Bearer key-xyz")
+	h3 := svc.GenerateSessionHash(c3, body)
+	require.NotEqual(t, h1, h3, "different auth headers should produce different hashes")
+
+	// Adding more messages should NOT change the hash (stable prefix only)
+	bodyWithMore := []byte(`{"model":"gpt-5.4","messages":[{"role":"system","content":"You are a helpful assistant."},{"role":"user","content":"Hello"},{"role":"assistant","content":"Hi!"},{"role":"user","content":"How are you?"}]}`)
+	c4 := makeCtx("Bearer key-abc")
+	h4 := svc.GenerateSessionHash(c4, bodyWithMore)
+	require.Equal(t, h1, h4, "content-based hash should be stable as conversation grows (only stable prefix is hashed)")
+
+	// No auth header + no meaningful content → empty hash
+	c5 := makeCtx("")
+	h5 := svc.GenerateSessionHash(c5, []byte(`{}`))
+	require.Equal(t, "", h5, "empty body with no auth should return empty hash")
+
+	// Explicit session_id header takes priority over content-based fallback
+	c6 := makeCtx("Bearer key-abc")
+	c6.Request.Header.Set("session_id", "explicit-session")
+	h6 := svc.GenerateSessionHash(c6, body)
+	want := fmt.Sprintf("%016x", xxhash.Sum64String("explicit-session"))
+	require.Equal(t, want, h6, "explicit session_id should take priority over content-based fallback")
 }
 
 func TestOpenAIGatewayService_GenerateSessionHash_UsesXXHash64(t *testing.T) {


### PR DESCRIPTION
Fixes #1421

## Problem

`OpenAIGatewayService.GenerateSessionHash` only checks three explicit session signals (headers `session_id`/`conversation_id`, body field `prompt_cache_key`). When none are present — which is the case for standard OpenAI-compatible clients such as Claude Code IDE extensions, custom scripts, and most non-Codex CLI tools — the function returns an empty string.

An empty session hash means `SelectAccountWithScheduler` picks a random upstream account on every request, preventing prompt caching entirely. Successive turns of the same conversation land on different accounts, so the upstream cache is never reused.

## Solution

Add a **content-based fallback (priority 4)** that builds a stable seed from:

- `Authorization` header (SHA-256 hashed before use, so different API keys route independently)
- `model` field
- All system messages  
- First user message only

Using only the stable request prefix — rather than the full growing message list — ensures the hash remains constant across conversation turns. This gives sticky-session routing for the lifetime of a conversation without breaking when new messages are appended.

Clients that already provide explicit session signals (priorities 1-3) are completely unaffected.

## Testing

- Added `TestOpenAIGatewayService_GenerateSessionHash_ContentBasedFallback` covering:
  - Content-based hash is non-empty when `Authorization` + content are present
  - Same content + same auth → identical hash (retry stability)
  - Different auth header → different hash (user isolation)
  - Growing conversation (more messages) → same hash (stable prefix)
  - Empty body + no auth → empty hash (no change to existing no-signal behaviour)
  - Explicit `session_id` header still takes priority over content-based fallback