### PR TITLE
fix(ops): 将错误日志请求体存储限制从 10KB 提升至 256KB

### DIFF
--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -16,7 +16,7 @@ import (
 var ErrOpsDisabled = infraerrors.NotFound("OPS_DISABLED", "Ops monitoring is disabled")
 
 const (
-	opsMaxStoredRequestBodyBytes = 10 * 1024
+	opsMaxStoredRequestBodyBytes = 256 * 1024
 	opsMaxStoredErrorBodyBytes   = 20 * 1024
 )
 


### PR DESCRIPTION
## 问题

当前错误日志中 `request_body` 的存储限制为 10KB，但现代 LLM API 请求的对话上下文经常超过 1MB（例如 100k token 的上下文序列化后约 2MB）。这导致错误日志中的请求体被极度裁剪，仅剩下 model 和最后一条消息等最小化信息，无法有效调试上游故障。

## 修改内容

- 将 `opsMaxStoredRequestBodyBytes` 从 `10 * 1024`（10KB）提升至 `256 * 1024`（256KB）
- 现有的多级裁剪逻辑（消息数组前向裁剪 → 核心字段保留 → 占位符兜底）保持不变，只是裁剪阈值提高

## 影响分析

- **数据库兼容性**：`request_body` 字段类型为 `JSONB`（上限 ~1GB），无需变更 schema
- **存储影响**：错误日志属于低频数据，每条增加的存储可忽略
- **功能影响**：仅影响错误日志的请求体存储，不影响正常请求处理流程

## 测试

- 单元测试通过（`TestPrepareOpsRequestBodyForQueue` 系列）
- CI 全部通过（test + golangci-lint）