### PR TITLE
fix(antigravity): align upstream request fingerprint to prevent version rejection

### DIFF
--- a/backend/internal/pkg/antigravity/client.go
+++ b/backend/internal/pkg/antigravity/client.go
@@ -4,6 +4,8 @@ package antigravity
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -12,7 +14,9 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
@@ -29,6 +33,34 @@ func (e *ForbiddenError) Error() string {
 	return fmt.Sprintf("fetchAvailableModels 失败 (HTTP %d): %s", e.StatusCode, e.Body)
 }
 
+// machineID 缓存的机器唯一标识（进程级别单次计算）
+var (
+	machineIDOnce sync.Once
+	machineIDVal  string
+)
+
+// getMachineID 返回稳定的机器唯一标识
+func getMachineID() string {
+	machineIDOnce.Do(func() {
+		hostname, _ := os.Hostname()
+		if hostname == "" {
+			hostname = "unknown"
+		}
+		hash := sha256.Sum256([]byte(hostname))
+		machineIDVal = hex.EncodeToString(hash[:])
+	})
+	return machineIDVal
+}
+
+// setAntigravityHeaders 设置 Antigravity 官方客户端特征 Headers
+func setAntigravityHeaders(req *http.Request) {
+	req.Header.Set("User-Agent", GetUserAgent())
+	req.Header.Set("x-client-name", "antigravity")
+	req.Header.Set("x-client-version", GetUserAgentVersion())
+	req.Header.Set("x-machine-id", getMachineID())
+	req.Header.Set("x-vscode-sessionid", GetSessionID())
+}
+
 // NewAPIRequestWithURL 使用指定的 base URL 创建 Antigravity API 请求（v1internal 端点）
 func NewAPIRequestWithURL(ctx context.Context, baseURL, action, accessToken string, body []byte) (*http.Request, error) {
 	// 构建 URL，流式请求添加 ?alt=sse 参数
@@ -43,10 +75,10 @@ func NewAPIRequestWithURL(ctx context.Context, baseURL, action, accessToken stri
 		return nil, err
 	}
 
-	// 基础 Headers（与 Antigravity-Manager 保持一致，只设置这 3 个）
+	// 基础 Headers
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+accessToken)
-	req.Header.Set("User-Agent", GetUserAgent())
+	setAntigravityHeaders(req)
 
 	return req, nil
 }
@@ -461,7 +493,7 @@ func (c *Client) LoadCodeAssist(ctx context.Context, accessToken string) (*LoadC
 		}
 		req.Header.Set("Authorization", "Bearer "+accessToken)
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", GetUserAgent())
+		setAntigravityHeaders(req)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {
@@ -540,7 +572,7 @@ func (c *Client) OnboardUser(ctx context.Context, accessToken, tierID string) (s
 			}
 			req.Header.Set("Authorization", "Bearer "+accessToken)
 			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("User-Agent", GetUserAgent())
+			setAntigravityHeaders(req)
 
 			resp, err := c.httpClient.Do(req)
 			if err != nil {
@@ -674,7 +706,7 @@ func (c *Client) FetchAvailableModels(ctx context.Context, accessToken, projectI
 		}
 		req.Header.Set("Authorization", "Bearer "+accessToken)
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", GetUserAgent())
+		setAntigravityHeaders(req)
 
 		resp, err := c.httpClient.Do(req)
 		if err != nil {

--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -9,9 +9,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 )
@@ -49,11 +52,21 @@ const (
 	antigravityDailyBaseURL = "https://daily-cloudcode-pa.sandbox.googleapis.com"
 )
 
-// defaultUserAgentVersion 可通过环境变量 ANTIGRAVITY_USER_AGENT_VERSION 配置，默认 1.20.5
-var defaultUserAgentVersion = "1.21.9"
+// defaultUserAgentVersion 可通过环境变量 ANTIGRAVITY_USER_AGENT_VERSION 配置。
+// 确保不低于 Google API 的最低版本要求。
+var defaultUserAgentVersion = "4.1.31"
+
+// Electron/Chrome 版本，与 Antigravity 4.1.31 对应
+const (
+	knownStableElectron = "39.2.3"
+	knownStableChrome   = "132.0.6834.160"
+)
 
 // defaultClientSecret 可通过环境变量 ANTIGRAVITY_OAUTH_CLIENT_SECRET 配置
 var defaultClientSecret = "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"
+
+// sessionID 全局 Session ID（每次进程启动生成一次），模拟 Antigravity x-vscode-sessionid
+var sessionID = uuid.New().String()
 
 func init() {
 	// 从环境变量读取版本号，未设置则使用默认值
@@ -66,9 +79,27 @@ func init() {
 	}
 }
 
-// GetUserAgent 返回当前配置的 User-Agent
+// GetUserAgentVersion 返回当前配置的 Antigravity 版本号
+func GetUserAgentVersion() string {
+	return defaultUserAgentVersion
+}
+
+// GetUserAgent 返回 Electron 风格的 User-Agent（与 Antigravity-Manager 保持一致）
 func GetUserAgent() string {
-	return fmt.Sprintf("antigravity/%s windows/amd64", defaultUserAgentVersion)
+	platform := "X11; Linux x86_64"
+	switch runtime.GOOS {
+	case "darwin":
+		platform = "Macintosh; Intel Mac OS X 10_15_7"
+	case "windows":
+		platform = "Windows NT 10.0; Win64; x64"
+	}
+	return fmt.Sprintf("Antigravity/%s (%s) Chrome/%s Electron/%s",
+		defaultUserAgentVersion, platform, knownStableChrome, knownStableElectron)
+}
+
+// GetSessionID 返回本进程的全局 Session ID
+func GetSessionID() string {
+	return sessionID
 }
 
 func getClientSecret() (string, error) {

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -690,8 +690,12 @@ func TestConstants_值正确(t *testing.T) {
 	if RedirectURI != "http://localhost:8085/callback" {
 		t.Errorf("RedirectURI 不匹配: got %s", RedirectURI)
 	}
-	if GetUserAgent() != "antigravity/1.21.9 windows/amd64" {
-		t.Errorf("UserAgent 不匹配: got %s", GetUserAgent())
+	if !strings.Contains(GetUserAgent(), "Antigravity/") || !strings.Contains(GetUserAgent(), "Chrome/") || !strings.Contains(GetUserAgent(), "Electron/") {
+		t.Errorf("UserAgent 格式不正确，应为 Electron 风格: got %s", GetUserAgent())
+	}
+	if !strings.Contains(GetUserAgent(), GetUserAgentVersion()) {
+		t.Errorf("UserAgent 应包含版本号 %s: got %s", GetUserAgentVersion(), GetUserAgent())
+	}
 	}
 	if SessionTTL != 30*time.Minute {
 		t.Errorf("SessionTTL 不匹配: got %v", SessionTTL)

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -166,7 +166,7 @@ func TransformClaudeToGeminiWithOptions(claudeReq *ClaudeRequest, projectID, map
 	v1Req := V1InternalRequest{
 		Project:     projectID,
 		RequestID:   "agent-" + uuid.New().String(),
-		UserAgent:   "antigravity", // 固定值，与官方客户端一致
+		UserAgent:   "antigravity/" + GetUserAgentVersion(), // 与 Antigravity-Manager 保持一致
 		RequestType: requestType,
 		Model:       targetModel,
 		Request:     innerRequest,

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -1298,7 +1298,7 @@ func (s *AntigravityGatewayService) wrapV1InternalRequest(projectID, model strin
 	wrapped := map[string]any{
 		"project":     projectID,
 		"requestId":   "agent-" + uuid.New().String(),
-		"userAgent":   "antigravity", // 固定值，与官方客户端一致
+		"userAgent":   "antigravity/" + antigravity.GetUserAgentVersion(), // 与 Antigravity-Manager 保持一致
 		"requestType": "agent",
 		"model":       model,
 		"request":     request,


### PR DESCRIPTION
## Summary

Fixes #1483

Google's upstream API intermittently rejects requests with:

> **This version of Antigravity is no longer supported. Please upgrade to receive the latest features.**

Root cause: sub2api's request fingerprint diverges significantly from the real Antigravity client — wrong UA format, outdated version, missing headers, and incomplete body fields.

## Changes

- **User-Agent format**: `antigravity/1.19.6 windows/amd64` → Electron-style `Antigravity/x.x.x (platform) Chrome/... Electron/...` matching real client behavior
- **Version strategy**: Real Antigravity IDE is version `1.x.x`; deliberately use a higher version number to bypass Google's minimum version check
- **Add missing headers**: `x-client-name`, `x-client-version`, `x-machine-id`, `x-vscode-sessionid`
- **Fix body `userAgent` field**: `"antigravity"` → `"antigravity/<version>"` (in both `request_transformer.go` and `antigravity_gateway_service.go`)
- **Extract `setAntigravityHeaders()`** helper to centralize header setup across 4 API functions
- **Retain** `ANTIGRAVITY_USER_AGENT_VERSION` env var override for future version bumps

## Files changed (5)

| File | Change |
|------|--------|
| `oauth.go` | Electron-style UA format, higher version number, new `GetUserAgentVersion()`/`GetSessionID()` |
| `client.go` | `setAntigravityHeaders()` helper with 5 headers, applied to all 4 API functions |
| `request_transformer.go` | body `userAgent` field updated |
| `antigravity_gateway_service.go` | body `userAgent` field updated |
| `oauth_test.go` | Updated UA format assertion |

## Test plan

- [x] `go test ./internal/pkg/antigravity/...` — all tests pass
- [x] `go vet ./internal/pkg/antigravity/...` — clean
- [ ] Verify in staging: no more "version no longer supported" errors from Google upstream