### PR TITLE
fix: support STARTTLS for SMTP on port 587

### DIFF
--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net"
 	"net/smtp"
 	"net/url"
 	"strconv"
@@ -160,14 +161,18 @@ func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body
 	auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
 
 	if config.UseTLS {
-		return s.sendMailTLS(addr, auth, config.From, to, []byte(msg), config.Host)
+		// Port 465 uses implicit TLS (SMTPS); other ports (e.g. 587) use STARTTLS.
+		if config.Port == 465 {
+			return s.sendMailImplicitTLS(addr, auth, config.From, to, []byte(msg), config.Host)
+		}
+		return s.sendMailSTARTTLS(addr, auth, config.From, to, []byte(msg), config.Host)
 	}
 
 	return smtp.SendMail(addr, auth, config.From, []string{to}, []byte(msg))
 }
 
-// sendMailTLS 使用TLS发送邮件
-func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from, to string, msg []byte, host string) error {
+// sendMailImplicitTLS sends email over an implicit TLS connection (port 465 / SMTPS).
+func (s *EmailService) sendMailImplicitTLS(addr string, auth smtp.Auth, from, to string, msg []byte, host string) error {
 	tlsConfig := &tls.Config{
 		ServerName: host,
 		// 强制 TLS 1.2+，避免协议降级导致的弱加密风险。
@@ -180,6 +185,64 @@ func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from, to string,
 	}
 	defer func() { _ = conn.Close() }()
 
+	return s.sendMailOverConn(conn, auth, from, to, msg, host)
+}
+
+// sendMailSTARTTLS sends email using STARTTLS (plain TCP that upgrades to TLS, e.g. port 587).
+func (s *EmailService) sendMailSTARTTLS(addr string, auth smtp.Auth, from, to string, msg []byte, host string) error {
+	tlsConfig := &tls.Config{
+		ServerName: host,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("tcp dial: %w", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	client, err := smtp.NewClient(conn, host)
+	if err != nil {
+		return fmt.Errorf("new smtp client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	if err = client.StartTLS(tlsConfig); err != nil {
+		return fmt.Errorf("starttls: %w", err)
+	}
+
+	if err = client.Auth(auth); err != nil {
+		return fmt.Errorf("smtp auth: %w", err)
+	}
+
+	if err = client.Mail(from); err != nil {
+		return fmt.Errorf("smtp mail: %w", err)
+	}
+
+	if err = client.Rcpt(to); err != nil {
+		return fmt.Errorf("smtp rcpt: %w", err)
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("smtp data: %w", err)
+	}
+
+	if _, err = w.Write(msg); err != nil {
+		return fmt.Errorf("write msg: %w", err)
+	}
+
+	if err = w.Close(); err != nil {
+		return fmt.Errorf("close writer: %w", err)
+	}
+
+	// Email is sent successfully after w.Close(), ignore Quit errors.
+	_ = client.Quit()
+	return nil
+}
+
+// sendMailOverConn sends email over an already-established net.Conn (used by implicit TLS path).
+func (s *EmailService) sendMailOverConn(conn net.Conn, auth smtp.Auth, from, to string, msg []byte, host string) error {
 	client, err := smtp.NewClient(conn, host)
 	if err != nil {
 		return fmt.Errorf("new smtp client: %w", err)
@@ -203,17 +266,15 @@ func (s *EmailService) sendMailTLS(addr string, auth smtp.Auth, from, to string,
 		return fmt.Errorf("smtp data: %w", err)
 	}
 
-	_, err = w.Write(msg)
-	if err != nil {
+	if _, err = w.Write(msg); err != nil {
 		return fmt.Errorf("write msg: %w", err)
 	}
 
-	err = w.Close()
-	if err != nil {
+	if err = w.Close(); err != nil {
 		return fmt.Errorf("close writer: %w", err)
 	}
 
-	// Email is sent successfully after w.Close(), ignore Quit errors
+	// Email is sent successfully after w.Close(), ignore Quit errors.
 	// Some SMTP servers return non-standard responses on QUIT
 	_ = client.Quit()
 	return nil


### PR DESCRIPTION
Fixes #1470

## Problem

When **Enable TLS encryption for SMTP connection** is turned on, Sub2API called `tls.Dial` to establish an implicit TLS connection. This works correctly for port 465 (SMTPS), but port 587 — used by providers like MailerSend — expects **STARTTLS**: a plain TCP connection that is subsequently upgraded to TLS via the `STARTTLS` SMTP command.

As a result, users who configured port 587 + TLS received:
```
tls dial: tls: first record does not look like a TLS handshake
```

## Solution

Split the TLS send path into two functions based on the configured port:

- **Port 465** → `sendMailImplicitTLS`: connects directly via `tls.Dial` (existing behaviour, unchanged).
- **All other ports (e.g. 587)** → `sendMailSTARTTLS`: opens a plain TCP connection, then calls `client.StartTLS()` to negotiate TLS before authentication.

Both paths enforce TLS 1.2+ and use the same TLS config (`ServerName` set to the SMTP host).

No configuration changes are needed — existing users are unaffected because the routing is automatic based on the port number.

## Testing

- Port 587 + STARTTLS (e.g. MailerSend, Gmail relay): connection now upgrades via STARTTLS correctly.
- Port 465 + implicit TLS: existing path unchanged, continues to work as before.
- TLS disabled (`UseTLS = false`): unchanged, falls through to `smtp.SendMail`.