### PR TITLE
fix: return 404 model_not_found instead of 503 when no accounts support the model

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1452,7 +1452,7 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 	account, err := h.gatewayService.SelectAccountForModel(c.Request.Context(), apiKey.GroupID, sessionHash, parsedReq.Model)
 	if err != nil {
 		reqLog.Warn("gateway.count_tokens_select_account_failed", zap.Error(err))
-		h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable")
+		h.errorResponse(c, http.StatusNotFound, "invalid_request_error", "The model '"+parsedReq.Model+"' does not exist or you do not have access to it.")
 		return
 	}
 	setOpsSelectedAccount(c, account.ID, account.Platform)

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -155,7 +155,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 					}
 				}
 				if err != nil {
-					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+					h.handleStreamingAwareError(c, http.StatusNotFound, "invalid_request_error", "The model '"+reqModel+"' does not exist or you do not have access to it.", streamStarted)
 					return
 				}
 			} else {
@@ -168,7 +168,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			}
 		}
 		if selection == nil || selection.Account == nil {
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.handleStreamingAwareError(c, http.StatusNotFound, "invalid_request_error", "The model '"+reqModel+"' does not exist or you do not have access to it.", streamStarted)
 			return
 		}
 		account := selection.Account

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -248,7 +248,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if len(failedAccountIDs) == 0 {
-				h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				h.handleStreamingAwareError(c, http.StatusNotFound, "invalid_request_error", "The model '"+reqModel+"' does not exist or you do not have access to it.", streamStarted)
 				return
 			}
 			if lastFailoverErr != nil {
@@ -259,7 +259,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			return
 		}
 		if selection == nil || selection.Account == nil {
-			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.handleStreamingAwareError(c, http.StatusNotFound, "invalid_request_error", "The model '"+reqModel+"' does not exist or you do not have access to it.", streamStarted)
 			return
 		}
 		if previousResponseID != "" && selection != nil && selection.Account != nil {
@@ -652,7 +652,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 					}
 				}
 				if err != nil {
-					h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+					h.anthropicStreamingAwareError(c, http.StatusNotFound, "invalid_request_error", "The model '"+routingModel+"' does not exist or you do not have access to it.", streamStarted)
 					return
 				}
 			} else {
@@ -665,7 +665,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			}
 		}
 		if selection == nil || selection.Account == nil {
-			h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts", streamStarted)
+			h.anthropicStreamingAwareError(c, http.StatusNotFound, "invalid_request_error", "The model '"+routingModel+"' does not exist or you do not have access to it.", streamStarted)
 			return
 		}
 		account := selection.Account


### PR DESCRIPTION
Fixes #1475

## Problem

When a request arrives for a model that has no accounts configured (or no accounts available), all gateway endpoints returned:

```
HTTP 503 Service Unavailable
{"error":{"type":"api_error","message":"Service temporarily unavailable"}}
```

This is misleading because:
- **503** implies a transient server-side failure, prompting retries that will never succeed.
- The message gives no indication of the actual root cause.

The OpenAI API returns **HTTP 404** with `"type": "invalid_request_error"` and a descriptive message when a model is not found or inaccessible.

## Solution

Changed the "no accounts available for the requested model" code path to return:

```
HTTP 404 Not Found
{"error":{"type":"invalid_request_error","message":"The model 'gpt-X' does not exist or you do not have access to it."}}
```

Only the early-exit paths are changed (when `failedAccountIDs` is empty and/or `selection` is nil — meaning **no accounts were tried at all**). The failover-exhausted paths that already tried one or more accounts and failed remain 502/503 since those represent genuine upstream failures.

### Files changed

| File | Change |
|------|--------|
| `openai_gateway_handler.go` | `Responses` and `Messages` endpoints |
| `openai_chat_completions.go` | `ChatCompletions` endpoint |
| `gateway_handler.go` | `CountTokens` endpoint |

## Testing

Request with a model name that has no configured accounts:
- **Before**: `503 Service temporarily unavailable`
- **After**: `404 The model 'xyz' does not exist or you do not have access to it.`