### PR TITLE
fix(openai): skip normalizeCodexModel for custom base_url accounts

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -865,6 +865,21 @@ func (a *Account) GetOpenAIBaseURL() string {
 	return "https://api.openai.com"
 }
 
+// HasCustomOpenAIBaseURL returns true when the account uses a non-default
+// OpenAI-compatible base URL (i.e. a third-party provider such as Azure,
+// CommonStack, etc.).  Callers use this to skip OpenAI-specific model name
+// normalisation that would strip provider prefixes or rewrite model IDs.
+func (a *Account) HasCustomOpenAIBaseURL() bool {
+	if a == nil || !a.IsOpenAI() || a.Type != AccountTypeAPIKey {
+		return false
+	}
+	baseURL := strings.TrimSpace(a.GetCredential("base_url"))
+	if baseURL == "" {
+		return false
+	}
+	return !strings.HasPrefix(baseURL, "https://api.openai.com")
+}
+
 func (a *Account) GetOpenAIAccessToken() string {
 	if !a.IsOpenAI() {
 		return ""

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -46,7 +46,10 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	// 2. Resolve model mapping early so compat prompt_cache_key injection can
 	// derive a stable seed from the final upstream model family.
 	billingModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
-	upstreamModel := normalizeCodexModel(billingModel)
+	upstreamModel := billingModel
+	if !account.HasCustomOpenAIBaseURL() {
+		upstreamModel = normalizeCodexModel(billingModel)
+	}
 
 	promptCacheKey = strings.TrimSpace(promptCacheKey)
 	compatPromptCacheInjected := false

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -62,7 +62,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 
 	// 3. Model mapping
 	billingModel := resolveOpenAIForwardModel(account, normalizedModel, defaultMappedModel)
-	upstreamModel := normalizeCodexModel(billingModel)
+	upstreamModel := billingModel
+	if !account.HasCustomOpenAIBaseURL() {
+		upstreamModel = normalizeCodexModel(billingModel)
+	}
 	responsesReq.Model = upstreamModel
 
 	logger.L().Debug("openai messages: model mapping applied",

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1937,8 +1937,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	}
 	upstreamModel := billingModel
 
-	// 针对所有 OpenAI 账号执行 Codex 模型名规范化，确保上游识别一致。
-	if model, ok := reqBody["model"].(string); ok {
+	// 针对 OpenAI 官方账号执行 Codex 模型名规范化，确保上游识别一致。
+	// 自定义 base_url 的第三方 provider 保留 model_mapping 后的原始名称。
+	if model, ok := reqBody["model"].(string); ok && !account.HasCustomOpenAIBaseURL() {
 		upstreamModel = normalizeCodexModel(model)
 		if upstreamModel != "" && upstreamModel != model {
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Upstream model resolved: %s -> %s (account: %s, type: %s, isCodexCLI: %v)",

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -2515,7 +2515,11 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 			normalized = next
 		}
-		upstreamModel := normalizeCodexModel(account.GetMappedModel(originalModel))
+		mappedModel := account.GetMappedModel(originalModel)
+		upstreamModel := mappedModel
+		if !account.HasCustomOpenAIBaseURL() {
+			upstreamModel = normalizeCodexModel(mappedModel)
+		}
 		if upstreamModel != originalModel {
 			next, setErr := applyPayloadMutation(normalized, "model", upstreamModel)
 			if setErr != nil {
@@ -2773,7 +2777,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		mappedModel := ""
 		var mappedModelBytes []byte
 		if originalModel != "" {
-			mappedModel = normalizeCodexModel(account.GetMappedModel(originalModel))
+			mappedModel = account.GetMappedModel(originalModel)
+			if !account.HasCustomOpenAIBaseURL() {
+				mappedModel = normalizeCodexModel(mappedModel)
+			}
 			needModelReplace = mappedModel != "" && mappedModel != originalModel
 			if needModelReplace {
 				mappedModelBytes = []byte(mappedModel)


### PR DESCRIPTION
## Problem

When an OpenAI-platform account uses a custom `base_url` (e.g. CommonStack), the `model_mapping` result is overwritten by `normalizeCodexModel`. This function strips provider prefixes like `openai/` and rewrites model IDs to OpenAI-native names, causing **404 errors** on third-party providers that require the full model identifier.

Example:
```
User requests: gpt-5.4
→ model_mapping: openai/gpt-5.4-nano-2026-03-17  ← correct for CommonStack
→ normalizeCodexModel: gpt-5.4-nano               ← wrong, CommonStack returns 404
```

## Solution

Add `Account.HasCustomOpenAIBaseURL()` method and skip `normalizeCodexModel` when the account uses a non-`api.openai.com` base URL.

### Files changed
- `account.go` — add `HasCustomOpenAIBaseURL()` method
- `openai_gateway_chat_completions.go` — gate normalize
- `openai_gateway_service.go` — gate normalize
- `openai_gateway_messages.go` — gate normalize
- `openai_ws_forwarder.go` — gate normalize (both WS paths)

## Test

- All existing tests pass (`go test ./internal/service/ -run "TestNormalizeCodexModel|TestResolveOpenAIForwardModel|TestAccountResolveMappedModel"`)
- Verified with CommonStack provider: mapping `gpt-5.4` → `openai/gpt-5.4-nano-2026-03-17` now correctly reaches upstream