### PR TITLE
fix: normalize function_call item id to fc prefix in tool continuation

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -484,6 +484,13 @@ func filterCodexInput(input []any, preserveReferences bool) []any {
 					newItem["call_id"] = fixedCallID
 				}
 			}
+
+			// The Responses API requires function_call item ids to start with 'fc'.
+			// Fix any 'call_'-prefixed id so OpenAI does not reject the request.
+			if id, ok := m["id"].(string); ok && strings.HasPrefix(id, "call_") {
+				ensureCopy()
+				newItem["id"] = fixCallIDPrefix(id)
+			}
 		}
 
 		if !preserveReferences {

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -67,6 +67,37 @@ func TestApplyCodexOAuthTransform_ToolContinuationPreservesNativeMessageAndReaso
 	require.Equal(t, "rs_123", second["id"])
 }
 
+func TestApplyCodexOAuthTransform_ToolContinuationFixesFunctionCallItemID(t *testing.T) {
+	// function_call items with id starting with 'call_' must be fixed to 'fc' prefix
+	// so that OpenAI does not reject with "Expected an ID that begins with 'fc'".
+	reqBody := map[string]any{
+		"model": "gpt-5.2",
+		"input": []any{
+			map[string]any{"type": "function_call", "id": "call_U7Zpb", "call_id": "call_U7Zpb", "name": "bash", "arguments": "{}"},
+			map[string]any{"type": "function_call_output", "call_id": "call_U7Zpb", "output": "ok"},
+		},
+		"tool_choice": "auto",
+	}
+
+	applyCodexOAuthTransform(reqBody, false, false)
+
+	input, ok := reqBody["input"].([]any)
+	require.True(t, ok)
+	require.Len(t, input, 2)
+
+	first, ok := input[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "function_call", first["type"])
+	// id must be fixed to fc prefix
+	require.Equal(t, "fcU7Zpb", first["id"])
+	// call_id must also be fixed
+	require.Equal(t, "fcU7Zpb", first["call_id"])
+
+	second, ok := input[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "fcU7Zpb", second["call_id"])
+}
+
 func TestApplyCodexOAuthTransform_ToolContinuationNormalizesToolReferenceIDsOnly(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.2",


### PR DESCRIPTION
Fixes #954

## Problem

When a Responses API request (e.g., from OpenCode using OpenAI OAuth) contains `function_call` items whose `id` field starts with `call_` instead of `fc`, OpenAI rejects the request with:

```
Invalid 'input[3].id': 'call_U7ZpbozYfIAQ0tyiqZ97HB65'. Expected an ID that begins with 'fc'.
```

This happens in tool continuation scenarios when a client replays previous `function_call` output items that have `call_`-prefixed ids (either because the upstream returned them that way, or because the client generated them using the chat completions tool call id format).

## Solution

In `filterCodexInput`, apply the same `fixCallIDPrefix` normalization to `function_call` item `id` fields that is already applied to `call_id` and `item_reference.id`. This converts `call_xxx` ids to `fcxxx` before forwarding to the OpenAI Responses API.

## Testing

Added a new unit test `TestApplyCodexOAuthTransform_ToolContinuationFixesFunctionCallItemID` that verifies `function_call` items with `call_`-prefixed `id` fields are correctly normalized in tool continuation requests. All existing tests continue to pass.
