### PR TITLE
Fix negative available account counts in groups

### DIFF
--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -378,7 +378,7 @@ func (r *groupRepository) GetAccountCount(ctx context.Context, groupID int64) (t
 	err = scanSingleRow(ctx, r.sql,
 		`SELECT COUNT(*),
 			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true),
-			COUNT(*) FILTER (WHERE a.status = 'active' AND (
+			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true AND (
 				a.rate_limit_reset_at > NOW() OR
 				a.overload_until > NOW() OR
 				a.temp_unschedulable_until > NOW()
@@ -529,7 +529,7 @@ func (r *groupRepository) loadAccountCounts(ctx context.Context, groupIDs []int6
 		`SELECT ag.group_id,
 			COUNT(*) AS total,
 			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true) AS active,
-			COUNT(*) FILTER (WHERE a.status = 'active' AND (
+			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true AND (
 				a.rate_limit_reset_at > NOW() OR
 				a.overload_until > NOW() OR
 				a.temp_unschedulable_until > NOW()

--- a/backend/internal/repository/group_repo_integration_test.go
+++ b/backend/internal/repository/group_repo_integration_test.go
@@ -624,6 +624,53 @@ func (s *GroupRepoSuite) TestGetAccountCount_Empty() {
 	s.Require().Zero(count)
 }
 
+func (s *GroupRepoSuite) TestListWithFilters_GroupRateLimitedCountOnlyIncludesSchedulableAccounts() {
+	group := &service.Group{
+		Name:             "g-rate-limit-scope",
+		Platform:         service.PlatformAnthropic,
+		RateMultiplier:   1.0,
+		IsExclusive:      false,
+		Status:           service.StatusActive,
+		SubscriptionType: service.SubscriptionTypeStandard,
+	}
+	s.Require().NoError(s.repo.Create(s.ctx, group))
+
+	insertAccount := func(name string, schedulable bool, rateLimited bool) int64 {
+		var id int64
+		query := "INSERT INTO accounts (name, platform, type, status, schedulable) VALUES ($1, $2, $3, $4, $5) RETURNING id"
+		args := []any{name, service.PlatformAnthropic, service.AccountTypeOAuth, service.StatusActive, schedulable}
+		if rateLimited {
+			query = "INSERT INTO accounts (name, platform, type, status, schedulable, rate_limit_reset_at) VALUES ($1, $2, $3, $4, $5, NOW() + INTERVAL '10 minutes') RETURNING id"
+		}
+		s.Require().NoError(scanSingleRow(s.ctx, s.tx, query, args, &id))
+		return id
+	}
+
+	availableID := insertAccount("available", true, false)
+	schedulableLimitedID := insertAccount("schedulable-limited", true, true)
+	unschedulableLimitedID := insertAccount("unschedulable-limited", false, true)
+
+	for idx, accountID := range []int64{availableID, schedulableLimitedID, unschedulableLimitedID} {
+		_, err := s.tx.ExecContext(
+			s.ctx,
+			"INSERT INTO account_groups (account_id, group_id, priority, created_at) VALUES ($1, $2, $3, NOW())",
+			accountID,
+			group.ID,
+			idx+1,
+		)
+		s.Require().NoError(err)
+	}
+
+	groups, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", "", group.Name, nil)
+	s.Require().NoError(err)
+	s.Require().Len(groups, 1)
+
+	got := groups[0]
+	s.Require().Equal(int64(3), got.AccountCount)
+	s.Require().Equal(int64(2), got.ActiveAccountCount)
+	s.Require().Equal(int64(1), got.RateLimitedAccountCount)
+}
+
 // --- DeleteAccountGroupsByGroupID ---
 
 func (s *GroupRepoSuite) TestDeleteAccountGroupsByGroupID() {

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -162,7 +162,7 @@
             <div class="space-y-0.5 text-xs">
               <div>
                 <span class="text-gray-500 dark:text-gray-400">{{ t('admin.groups.accountsAvailable') }}</span>
-                <span class="ml-1 font-medium text-emerald-600 dark:text-emerald-400">{{ (row.active_account_count || 0) - (row.rate_limited_account_count || 0) }}</span>
+                <span class="ml-1 font-medium text-emerald-600 dark:text-emerald-400">{{ Math.max(0, (row.active_account_count || 0) - (row.rate_limited_account_count || 0)) }}</span>
                 <span class="ml-1 inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 font-medium text-gray-800 dark:bg-dark-600 dark:text-gray-300">{{ t('admin.groups.accountsUnit') }}</span>
               </div>
               <div v-if="row.rate_limited_account_count">


### PR DESCRIPTION
## Summary
- count rate-limited accounts in group summaries only when the account is still schedulable
- add a regression test covering unschedulable accounts that remain inside a rate-limit window
- clamp the frontend available-account display to zero as a defensive fallback

## Problem
The group list currently computes available accounts as:

`active_account_count - rate_limited_account_count`

But the backend counts these two fields with different scopes:
- `active_account_count` only includes `status = active AND schedulable = true`
- `rate_limited_account_count` includes all active accounts inside a rate-limit/overload/temp-unschedulable window, even if `schedulable = false`

That mismatch can make `rate_limited_account_count` larger than `active_account_count`, which leads to negative values in the UI.

## Fix
- align backend group summary queries so `rate_limited_account_count` only counts accounts that are still schedulable
- add an integration regression test for the case where an unschedulable account is still inside a rate-limit window
- clamp the frontend display to `0` as a defensive guard

## Testing
- `go test -tags integration ./internal/repository -run 'TestGroupRepoSuite' -count=1`
- `corepack pnpm typecheck`
