### PR TITLE
feat(home): expose key-usage page entry in header nav

### DIFF
--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -51,6 +51,15 @@
           <!-- Language Switcher -->
           <LocaleSwitcher />
 
+          <!-- Key Usage Link -->
+          <router-link
+            to="/key-usage"
+            class="rounded-lg p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-dark-400 dark:hover:bg-dark-800 dark:hover:text-white"
+            :title="t('keyUsage.title')"
+          >
+            <Icon name="chart" size="md" />
+          </router-link>
+
           <!-- Doc Link -->
           <a
             v-if="docUrl"


### PR DESCRIPTION
## Summary
- Add a chart-icon `router-link` to `/key-usage` in the `HomeView` header so unauthenticated visitors can discover the API key usage query page without having to know the URL.
- The existing `/key-usage` route is already public (`requiresAuth: false`) but had no UI entry point — this is a pure wiring fix, no behavior change elsewhere.

## Test plan
- [x] Visit `/` while logged out — new chart icon appears in the header between the language switcher and the doc link
- [x] Click the chart icon — navigates to `/key-usage`
- [x] Hover shows the `keyUsage.title` tooltip in both zh and en locales
- [x] Dark-mode styling matches the sibling header icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)