### PR TITLE
fix: correct group account status logic for active and rate-limited counts

### DIFF
--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -380,7 +380,7 @@ func (r *groupRepository) GetAccountCount(ctx context.Context, groupID int64) (t
 	err = scanSingleRow(ctx, r.sql,
 		`SELECT COUNT(*),
 			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true),
-			COUNT(*) FILTER (WHERE a.status = 'active' AND (
+			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true AND (
 				a.rate_limit_reset_at > NOW() OR
 				a.overload_until > NOW() OR
 				a.temp_unschedulable_until > NOW()
@@ -531,7 +531,7 @@ func (r *groupRepository) loadAccountCounts(ctx context.Context, groupIDs []int6
 		`SELECT ag.group_id,
 			COUNT(*) AS total,
 			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true) AS active,
-			COUNT(*) FILTER (WHERE a.status = 'active' AND (
+			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true AND (
 				a.rate_limit_reset_at > NOW() OR
 				a.overload_until > NOW() OR
 				a.temp_unschedulable_until > NOW()


### PR DESCRIPTION
### Problem
Previously, the `rate_limited_account_count` in the group repository included accounts that were `active` but not `schedulable`. This caused a calculation error in the frontend (Available = Active - Limited), potentially resulting in negative numbers if deactivated accounts were still in a rate-limited state.

### Solution
Updated the SQL filter in `group_repo.go` to ensure `rate_limited` counts only include accounts that are both `status = 'active'` and `schedulable = true`. This ensures the rate-limited count is always a subset of the active count, preventing negative availability results.