### PR TITLE
fix: ensure text/thinking fields always present in content_block_start

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -535,6 +535,74 @@ func TestResponsesAnthropicEventToSSE(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// AnthropicContentBlock JSON serialization tests
+// ---------------------------------------------------------------------------
+
+// TestAnthropicContentBlock_TextAlwaysPresent verifies that text-type content
+// blocks always include the "text" field in JSON, even when the value is "".
+// The Anthropic API spec requires this: without it the Python SDK initializes
+// content.text as None and the subsequent += accumulation raises a TypeError.
+func TestAnthropicContentBlock_TextAlwaysPresent(t *testing.T) {
+	block := AnthropicContentBlock{Type: "text", Text: ""}
+	data, err := json.Marshal(block)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"text":""`,
+		"text field must be present even when empty")
+}
+
+// TestAnthropicContentBlock_ThinkingAlwaysPresent verifies that thinking-type
+// content blocks always include the "thinking" field in JSON, even when empty.
+func TestAnthropicContentBlock_ThinkingAlwaysPresent(t *testing.T) {
+	block := AnthropicContentBlock{Type: "thinking", Thinking: ""}
+	data, err := json.Marshal(block)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"thinking":""`,
+		"thinking field must be present even when empty")
+}
+
+// TestAnthropicContentBlock_ToolUseOmitsTextAndThinking verifies that tool_use
+// blocks do NOT include "text" or "thinking" fields (they would pollute the output).
+func TestAnthropicContentBlock_ToolUseOmitsTextAndThinking(t *testing.T) {
+	block := AnthropicContentBlock{
+		Type:  "tool_use",
+		ID:    "tool_1",
+		Name:  "get_weather",
+		Input: json.RawMessage(`{}`),
+	}
+	data, err := json.Marshal(block)
+	require.NoError(t, err)
+	s := string(data)
+	assert.NotContains(t, s, `"text"`, "tool_use block must not include text field")
+	assert.NotContains(t, s, `"thinking"`, "tool_use block must not include thinking field")
+	assert.Contains(t, s, `"id":"tool_1"`)
+	assert.Contains(t, s, `"name":"get_weather"`)
+}
+
+// TestStreamingContentBlockStartTextJSON verifies that the SSE JSON for a
+// content_block_start event includes "text":"" for text-type blocks.
+func TestStreamingContentBlockStartTextJSON(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_x", Model: "gpt-5.4"},
+	}, state)
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:  "response.output_text.delta",
+		Delta: "ok",
+	}, state)
+	require.GreaterOrEqual(t, len(events), 1)
+	blockStart := events[0]
+	require.Equal(t, "content_block_start", blockStart.Type)
+
+	sse, err := ResponsesAnthropicEventToSSE(blockStart)
+	require.NoError(t, err)
+	assert.Contains(t, sse, `"text":""`,
+		"content_block_start SSE must include \"text\":\"\" for text-type blocks")
+}
+
+// ---------------------------------------------------------------------------
 // response.failed tests
 // ---------------------------------------------------------------------------
 

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -67,6 +67,32 @@ type AnthropicContentBlock struct {
 	IsError   bool            `json:"is_error,omitempty"`
 }
 
+// MarshalJSON implements json.Marshaler for AnthropicContentBlock.
+// It ensures that text-type blocks always include the "text" field and
+// thinking-type blocks always include the "thinking" field, even when the
+// value is an empty string. The Anthropic API spec requires these fields to
+// be present in content_block_start events; omitting them causes the
+// Anthropic Python SDK to initialize content.text as None rather than "",
+// which triggers a TypeError on the subsequent "+=" accumulation.
+func (b AnthropicContentBlock) MarshalJSON() ([]byte, error) {
+	// Use a type alias to avoid infinite recursion when delegating to json.Marshal.
+	type Alias AnthropicContentBlock
+	switch b.Type {
+	case "text":
+		return json.Marshal(struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		}{Type: b.Type, Text: b.Text})
+	case "thinking":
+		return json.Marshal(struct {
+			Type     string `json:"type"`
+			Thinking string `json:"thinking"`
+		}{Type: b.Type, Thinking: b.Thinking})
+	default:
+		return json.Marshal(Alias(b))
+	}
+}
+
 // AnthropicImageSource describes the source data for an image content block.
 type AnthropicImageSource struct {
 	Type      string `json:"type"` // "base64"


### PR DESCRIPTION
Fixes #1528

## Problem

`AnthropicContentBlock.Text` and `.Thinking` fields have `omitempty` JSON tags. When a `content_block_start` event is emitted for a text-type block, the initial content block is `AnthropicContentBlock{Type: "text", Text: ""}`. Because `Text` is an empty string and has `omitempty`, the JSON serializer drops the field, producing:

```json
{"type":"content_block_start","index":0,"content_block":{"type":"text"}}
```

instead of the spec-required:

```json
{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
```

The Anthropic Python SDK's accumulator initializes `content.text` to `None` (pydantic missing-field default) instead of `""`, causing a `TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'` on the next delta. The same issue affects thinking-type blocks (`"thinking"` field missing) and non-streaming responses where the fallback empty text block is similarly malformed.

## Solution

Add a `MarshalJSON` method to `AnthropicContentBlock` that ensures:
- Text-type blocks always include `"text"` even when the value is `""`
- Thinking-type blocks always include `"thinking"` even when the value is `""`
- All other block types (tool_use, image, tool_result, server_tool_use, web_search_tool_result) use the standard struct marshaling via a type alias (avoiding infinite recursion) — their existing `omitempty` behavior is preserved

## Testing

Added four unit tests in `anthropic_responses_test.go`:
- `TestAnthropicContentBlock_TextAlwaysPresent`: verifies `"text":""` is present for text blocks
- `TestAnthropicContentBlock_ThinkingAlwaysPresent`: verifies `"thinking":""` is present for thinking blocks
- `TestAnthropicContentBlock_ToolUseOmitsTextAndThinking`: verifies tool_use blocks do not include spurious `text`/`thinking` fields
- `TestStreamingContentBlockStartTextJSON`: end-to-end SSE test verifying that `content_block_start` events for text blocks include `"text":""`