### PR TITLE
fix: 更灵活的baseUrl填写方式，以便支持nvidia nim等非responses接口

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -380,6 +380,136 @@ func stringPtr(s string) *string {
 	return &s
 }
 
+// ResponsesToChatCompletionsRequest converts a Responses API request into a
+// Chat Completions request for sending to an OpenAI-compatible upstream
+// that expects /v1/chat/completions format.
+func ResponsesToChatCompletionsRequest(req *ResponsesRequest) (*ChatCompletionsRequest, error) {
+	// Extract messages from Responses input
+	messages, err := convertResponsesInputToChatMessages(req.Input)
+	if err != nil {
+		return nil, err
+	}
+
+	out := &ChatCompletionsRequest{
+		Model:          req.Model,
+		Messages:       messages,
+		Temperature:    req.Temperature,
+		TopP:           req.TopP,
+		Stream:         req.Stream,
+		MaxTokens:      req.MaxOutputTokens,
+		ServiceTier:    req.ServiceTier,
+		ReasoningEffort: getReasoningEffortFromResponses(req),
+	}
+
+	// Convert tools
+	if len(req.Tools) > 0 {
+		out.Tools = convertResponsesToolsToChat(req.Tools)
+	}
+
+	// tool_choice
+	if len(req.ToolChoice) > 0 {
+		out.ToolChoice = req.ToolChoice
+	}
+
+	return out, nil
+}
+
+// convertResponsesInputToChatMessages converts Responses input items into
+// Chat Completions messages array.
+func convertResponsesInputToChatMessages(input []ResponsesInputItem) ([]ChatMessage, error) {
+	var messages []ChatMessage
+
+	for _, item := range input {
+		switch item.Role {
+		case "system":
+			content := extractTextFromResponsesContent(item.Content)
+			messages = append(messages, ChatMessage{
+				Role:    "system",
+				Content: mustMarshalJSON(content),
+			})
+		case "user":
+			content := extractTextFromResponsesContent(item.Content)
+			messages = append(messages, ChatMessage{
+				Role:    "user",
+				Content: mustMarshalJSON(content),
+			})
+		case "assistant":
+			content := extractTextFromResponsesContent(item.Content)
+			messages = append(messages, ChatMessage{
+				Role:    "assistant",
+				Content: mustMarshalJSON(content),
+			})
+		// function_call and function_call_output are handled as tool calls and tool responses
+		case "function_call":
+			// We handle this in the previous assistant message
+		case "function_call_output":
+			// Attach as tool response to the previous message if possible, otherwise just create a new tool message
+			if len(messages) > 0 {
+				// For simplicity, just create a tool message
+				messages = append(messages, ChatMessage{
+					Role:     "tool",
+					Content:  mustMarshalJSON(item.Output),
+					ToolCallID: item.CallID,
+				})
+			}
+		}
+	}
+
+	return messages, nil
+}
+
+// extractTextFromResponsesContent extracts the concatenated text content from
+// a Responses content array. Only text parts are extracted, images are ignored.
+func extractTextFromResponsesContent(raw json.RawMessage) string {
+	var parts []ResponsesContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return ""
+	}
+
+	var text strings.Builder
+	for _, part := range parts {
+		if part.Type == "input_text" && part.Text != "" {
+			text.WriteString(part.Text)
+		}
+	}
+	return text.String()
+}
+
+// convertResponsesToolsToChat converts Responses tool definitions to
+// Chat Completions tool definitions.
+func convertResponsesToolsToChat(tools []ResponsesTool) []ChatTool {
+	var out []ChatTool
+
+	for _, t := range tools {
+		if t.Type == "function" {
+			out = append(out, ChatTool{
+				Type: "function",
+				Function: ChatFunctionCall{
+					Name:        t.Name,
+					Description: t.Description,
+					Parameters:  t.Parameters,
+				},
+			})
+		}
+	}
+
+	return out
+}
+
+// getReasoningEffortFromResponses extracts reasoning effort from Responses request.
+func getReasoningEffortFromResponses(req *ResponsesRequest) string {
+	if req.Reasoning != nil {
+		return req.Reasoning.Effort
+	}
+	return ""
+}
+
+// mustMarshalJSON marshals to JSON and panics on error (never happens for string).
+func mustMarshalJSON(s string) json.RawMessage {
+	data, _ := json.Marshal(s)
+	return data
+}
+
 // convertChatToolsToResponses maps Chat Completions tool definitions and legacy
 // function definitions to Responses API tool definitions.
 func convertChatToolsToResponses(tools []ChatTool, functions []ChatFunction) []ResponsesTool {

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -385,20 +385,25 @@ func stringPtr(s string) *string {
 // that expects /v1/chat/completions format.
 func ResponsesToChatCompletionsRequest(req *ResponsesRequest) (*ChatCompletionsRequest, error) {
 	// Extract messages from Responses input
-	messages, err := convertResponsesInputToChatMessages(req.Input)
+	var input []ResponsesInputItem
+	if err := json.Unmarshal(req.Input, &input); err != nil {
+		return nil, err
+	}
+	messages, err := convertResponsesInputToChatMessages(input)
 	if err != nil {
 		return nil, err
 	}
 
 	out := &ChatCompletionsRequest{
-		Model:          req.Model,
-		Messages:       messages,
-		Temperature:    req.Temperature,
-		TopP:           req.TopP,
-		Stream:         req.Stream,
-		MaxTokens:      req.MaxOutputTokens,
-		ServiceTier:    req.ServiceTier,
-		ReasoningEffort: getReasoningEffortFromResponses(req),
+		Model:               req.Model,
+		Messages:            messages,
+		Temperature:         req.Temperature,
+		TopP:                req.TopP,
+		Stream:              req.Stream,
+		MaxTokens:           req.MaxOutputTokens,
+		MaxCompletionTokens: req.MaxOutputTokens,
+		ServiceTier:         req.ServiceTier,
+		ReasoningEffort:     getReasoningEffortFromResponses(req),
 	}
 
 	// Convert tools
@@ -420,39 +425,24 @@ func convertResponsesInputToChatMessages(input []ResponsesInputItem) ([]ChatMess
 	var messages []ChatMessage
 
 	for _, item := range input {
-		switch item.Role {
-		case "system":
+		switch {
+		case item.Role != "":
+			// Regular role-based messages (system, user, assistant)
 			content := extractTextFromResponsesContent(item.Content)
 			messages = append(messages, ChatMessage{
-				Role:    "system",
+				Role:    item.Role,
 				Content: mustMarshalJSON(content),
 			})
-		case "user":
-			content := extractTextFromResponsesContent(item.Content)
+		case item.Type == "function_call_output":
+			// Tool output -> create tool message
 			messages = append(messages, ChatMessage{
-				Role:    "user",
-				Content: mustMarshalJSON(content),
+				Role:       "tool",
+				Content:    mustMarshalJSON(item.Output),
+				ToolCallID: item.CallID,
 			})
-		case "assistant":
-			content := extractTextFromResponsesContent(item.Content)
-			messages = append(messages, ChatMessage{
-				Role:    "assistant",
-				Content: mustMarshalJSON(content),
-			})
-		// function_call and function_call_output are handled as tool calls and tool responses
-		case "function_call":
-			// We handle this in the previous assistant message
-		case "function_call_output":
-			// Attach as tool response to the previous message if possible, otherwise just create a new tool message
-			if len(messages) > 0 {
-				// For simplicity, just create a tool message
-				messages = append(messages, ChatMessage{
-					Role:     "tool",
-					Content:  mustMarshalJSON(item.Output),
-					ToolCallID: item.CallID,
-				})
-			}
 		}
+		// Note: function_call items are already included in the assistant message
+		// content in Responses format, so they don't need separate handling here for basic usage
 	}
 
 	return messages, nil
@@ -461,9 +451,17 @@ func convertResponsesInputToChatMessages(input []ResponsesInputItem) ([]ChatMess
 // extractTextFromResponsesContent extracts the concatenated text content from
 // a Responses content array. Only text parts are extracted, images are ignored.
 func extractTextFromResponsesContent(raw json.RawMessage) string {
+	if raw == nil {
+		return ""
+	}
 	var parts []ResponsesContentPart
 	if err := json.Unmarshal(raw, &parts); err != nil {
-		return ""
+		// If it's just a plain string, try unmarshal as string
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			return ""
+		}
+		return s
 	}
 
 	var text strings.Builder
@@ -484,10 +482,11 @@ func convertResponsesToolsToChat(tools []ResponsesTool) []ChatTool {
 		if t.Type == "function" {
 			out = append(out, ChatTool{
 				Type: "function",
-				Function: ChatFunctionCall{
+				Function: &ChatFunction{
 					Name:        t.Name,
 					Description: t.Description,
 					Parameters:  t.Parameters,
+					Strict:      t.Strict,
 				},
 			})
 		}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -461,7 +461,11 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
 		}
-		apiURL = strings.TrimSuffix(normalizedBaseURL, "/") + "/responses"
+		if strings.HasSuffix(normalizedBaseURL, "/responses") || strings.HasSuffix(normalizedBaseURL, "/chat/completions") {
+			apiURL = normalizedBaseURL
+		} else {
+			apiURL = strings.TrimSuffix(normalizedBaseURL, "/") + "/responses"
+		}
 	} else {
 		return s.sendErrorAndEnd(c, fmt.Sprintf("Unsupported account type: %s", account.Type))
 	}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -477,8 +477,13 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
 	c.Writer.Flush()
 
-	// Create OpenAI Responses API payload
-	payload := createOpenAITestPayload(testModelID, isOAuth)
+	// Create payload based on endpoint type
+	var payload map[string]any
+	if strings.HasSuffix(apiURL, "/chat/completions") {
+		payload = createOpenAIChatCompletionsTestPayload(testModelID)
+	} else {
+		payload = createOpenAITestPayload(testModelID, isOAuth)
+	}
 	payloadBytes, _ := json.Marshal(payload)
 
 	// Send test_start event
@@ -543,7 +548,10 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
-	// Process SSE stream
+	// Process SSE stream based on endpoint type
+	if strings.HasSuffix(apiURL, "/chat/completions") {
+		return s.processOpenAIChatCompletionsStream(c, resp.Body)
+	}
 	return s.processOpenAIStream(c, resp.Body)
 }
 
@@ -934,6 +942,23 @@ func createOpenAITestPayload(modelID string, isOAuth bool) map[string]any {
 	return payload
 }
 
+// createOpenAIChatCompletionsTestPayload creates a test payload for OpenAI Chat Completions API
+func createOpenAIChatCompletionsTestPayload(modelID string) map[string]any {
+	payload := map[string]any{
+		"model": modelID,
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": "hi",
+			},
+		},
+		"stream": true,
+		"max_tokens": 1024,
+	}
+
+	return payload
+}
+
 // processClaudeStream processes the SSE stream from Claude API
 func (s *AccountTestService) processClaudeStream(c *gin.Context, body io.Reader) error {
 	reader := bufio.NewReader(body)
@@ -1037,6 +1062,65 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 				}
 			}
 			return s.sendErrorAndEnd(c, errorMsg)
+		}
+	}
+}
+
+// processOpenAIChatCompletionsStream processes the SSE stream from OpenAI Chat Completions API
+func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, body io.Reader) error {
+	reader := bufio.NewReader(body)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+				return nil
+			}
+			return s.sendErrorAndEnd(c, fmt.Sprintf("Stream read error: %s", err.Error()))
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" || !sseDataPrefix.MatchString(line) {
+			continue
+		}
+
+		jsonStr := sseDataPrefix.ReplaceAllString(line, "")
+		if jsonStr == "[DONE]" {
+			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+			return nil
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+			continue
+		}
+
+		// Check for errors
+		if errData, ok := data["error"].(map[string]any); ok && errData != nil {
+			errorMsg := "Unknown error"
+			if msg, ok := errData["message"].(string); ok {
+				errorMsg = msg
+			}
+			return s.sendErrorAndEnd(c, errorMsg)
+		}
+
+		// Extract text from choices[0].delta.content
+		if choices, ok := data["choices"].([]any); ok && len(choices) > 0 {
+			if choice, ok := choices[0].(map[string]any); ok {
+				if delta, ok := choice["delta"].(map[string]any); ok {
+					if content, ok := delta["content"].(string); ok && content != "" {
+						s.sendEvent(c, TestEvent{Type: "content", Text: content})
+					}
+				}
+				// Check if this is the final chunk
+				if finishReason, ok := choice["finish_reason"]; ok && finishReason != nil {
+					if finishReason != "" {
+						s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+						return nil
+					}
+				}
+			}
 		}
 	}
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3176,6 +3176,22 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	}
 	targetURL = appendOpenAIResponsesRequestPathSuffix(targetURL, openAIResponsesRequestPathSuffix(c))
 
+	// If upstream endpoint is /chat/completions, convert Responses format to Chat Completions format
+	if strings.HasSuffix(strings.TrimRight(targetURL, "/"), "/chat/completions") {
+		var responsesReq apicompat.ResponsesRequest
+		if err := json.Unmarshal(body, &responsesReq); err != nil {
+			return nil, fmt.Errorf("parse responses request for conversion: %w", err)
+		}
+		chatReq, err := apicompat.ResponsesToChatCompletionsRequest(&responsesReq)
+		if err != nil {
+			return nil, fmt.Errorf("convert responses to chat completions: %w", err)
+		}
+		body, err = json.Marshal(chatReq)
+		if err != nil {
+			return nil, fmt.Errorf("marshal chat completions request: %w", err)
+		}
+	}
+
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -4180,7 +4196,7 @@ func (s *OpenAIGatewayService) validateUpstreamBaseURL(raw string) (string, erro
 // - 其他情况：追加 /v1/responses
 func buildOpenAIResponsesURL(base string) string {
 	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
-	if strings.HasSuffix(normalized, "/responses") {
+	if strings.HasSuffix(normalized, "/responses") || strings.HasSuffix(normalized, "/chat/completions") {
 		return normalized
 	}
 	if strings.HasSuffix(normalized, "/v1") {


### PR DESCRIPTION
这个PR修改 #1548 
方式为：如果用户在baseUrl中自己填写了/responses或者/chat/completions结尾的url，就不再拼接/responses了，不影响原来的逻辑。