### PR TITLE
[codex] Fix account list refresh after test

### DIFF
--- a/frontend/src/components/admin/account/AccountTableActions.vue
+++ b/frontend/src/components/admin/account/AccountTableActions.vue
@@ -1,8 +1,9 @@
 <template>
   <div class="flex flex-wrap items-center gap-3">
     <slot name="before"></slot>
-    <button @click="$emit('refresh')" :disabled="loading" class="btn btn-secondary">
-      <Icon name="refresh" size="md" :class="[loading ? 'animate-spin' : '']" />
+    <button @click="$emit('refresh')" :disabled="loading" class="btn btn-secondary" :title="t('common.refresh')">
+      <Icon name="refresh" size="md" :class="[loading ? 'animate-spin' : '', 'md:mr-1.5']" />
+      <span class="hidden md:inline">{{ t('common.refresh') }}</span>
     </button>
     <slot name="after"></slot>
     <button @click="$emit('sync')" class="btn btn-secondary">{{ t('admin.accounts.syncFromCrs') }}</button>

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -238,6 +238,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'close'): void
+  (e: 'tested', payload: { accountId: number; success: boolean }): void
 }>()
 
 const terminalRef = ref<HTMLElement | null>(null)
@@ -344,6 +345,8 @@ const closeEventSource = () => {
   }
 }
 
+const isSuccessStatus = (value: string) => value === 'success'
+
 const addLine = (text: string, className: string = 'text-gray-300') => {
   outputLines.value.push({ text, class: className })
   scrollToBottom()
@@ -366,6 +369,9 @@ const startTest = async () => {
   addLine('', 'text-gray-300')
 
   closeEventSource()
+
+  let shouldEmitTested = false
+  let testSucceeded = false
 
   try {
     // Create EventSource for SSE
@@ -418,10 +424,22 @@ const startTest = async () => {
         }
       }
     }
+
+    shouldEmitTested = true
+    testSucceeded = isSuccessStatus(status.value)
   } catch (error: any) {
     status.value = 'error'
     errorMessage.value = error.message || 'Unknown error'
     addLine(`Error: ${errorMessage.value}`, 'text-red-400')
+    shouldEmitTested = true
+    testSucceeded = false
+  } finally {
+    if (shouldEmitTested && props.account) {
+      emit('tested', {
+        accountId: props.account.id,
+        success: testSucceeded
+      })
+    }
   }
 }
 

--- a/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
@@ -143,5 +143,9 @@ describe('AccountTestModal', () => {
     const preview = wrapper.find('img[alt="gemini-test-image-1"]')
     expect(preview.exists()).toBe(true)
     expect(preview.attributes('src')).toBe('data:image/png;base64,QUJD')
+
+    expect(wrapper.emitted('tested')).toEqual([
+      [{ accountId: 42, success: true }]
+    ])
   })
 })

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -283,7 +283,7 @@
     <CreateAccountModal :show="showCreate" :proxies="proxies" :groups="groups" @close="showCreate = false" @created="reload" />
     <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
     <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
-    <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
+    <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" @tested="handleAccountTested" />
     <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />
     <ScheduledTestsPanel :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
     <AccountActionMenu :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" />
@@ -725,8 +725,11 @@ const shouldReplaceAutoRefreshRow = (current: Account, next: Account) => {
 const syncAccountRefs = (nextAccount: Account) => {
   if (edAcc.value?.id === nextAccount.id) edAcc.value = nextAccount
   if (reAuthAcc.value?.id === nextAccount.id) reAuthAcc.value = nextAccount
+  if (testingAcc.value?.id === nextAccount.id) testingAcc.value = nextAccount
   if (tempUnschedAcc.value?.id === nextAccount.id) tempUnschedAcc.value = nextAccount
   if (deletingAcc.value?.id === nextAccount.id) deletingAcc.value = nextAccount
+  if (scheduleAcc.value?.id === nextAccount.id) scheduleAcc.value = nextAccount
+  if (statsAcc.value?.id === nextAccount.id) statsAcc.value = nextAccount
   if (menu.acc?.id === nextAccount.id) menu.acc = nextAccount
 }
 
@@ -1210,6 +1213,17 @@ const closeTestModal = () => { showTest.value = false; testingAcc.value = null }
 const closeStatsModal = () => { showStats.value = false; statsAcc.value = null }
 const closeReAuthModal = () => { showReAuth.value = false; reAuthAcc.value = null }
 const handleTest = (a: Account) => { testingAcc.value = a; showTest.value = true }
+const handleAccountTested = async ({ accountId }: { accountId: number; success: boolean }) => {
+  try {
+    const updated = await adminAPI.accounts.getById(accountId)
+    patchAccountInList(updated)
+  } catch (error) {
+    console.error('Failed to sync account after test:', error)
+    await load()
+  } finally {
+    enterAutoRefreshSilentWindow()
+  }
+}
 const handleViewStats = (a: Account) => { statsAcc.value = a; showStats.value = true }
 const handleSchedule = async (a: Account) => {
   scheduleAcc.value = a


### PR DESCRIPTION
## Summary
- sync the account row after the account test modal finishes so recovered status is reflected immediately
- make the accounts toolbar refresh action more explicit with a visible label
- cover the new post-test sync signal with a frontend unit test

## Root Cause
The accounts page pauses auto-refresh while the test modal is open. After a successful test, the modal previously closed without reloading the affected row, so stale `error` state could remain visible until the user manually refreshed the page.

## Impact
Admins can now validate an account and see the recovered status immediately in the list without a full page refresh.

## Validation
- `pnpm --dir frontend test:run src/components/admin/account/__tests__/AccountTestModal.spec.ts`
- `pnpm --dir frontend typecheck`
