### PR TITLE
fix: correct cache hit rate formula to work across all API backends

### DIFF
--- a/frontend/src/components/charts/TokenUsageTrend.vue
+++ b/frontend/src/components/charts/TokenUsageTrend.vue
@@ -109,7 +109,7 @@ const chartData = computed(() => {
       {
         label: 'Cache Hit Rate',
         data: props.trendData.map((d) => {
-          const total = d.cache_read_tokens + d.cache_creation_tokens
+          const total = d.input_tokens + d.cache_creation_tokens + d.cache_read_tokens
           return total > 0 ? (d.cache_read_tokens / total) * 100 : 0
         }),
         borderColor: chartColors.value.cacheHitRate,


### PR DESCRIPTION
The previous formula `cache_read / (cache_read + cache_creation)` only worked for Claude API. For OpenAI (where cache_creation is always 0), it degrades to 0% or 100%. The new formula uses
`cache_read / (input + cache_creation + cache_read)` which equals total input tokens across all backends.