### PR TITLE
fix: billing quota increment ignores fixed-window reset mode

### DIFF
--- a/backend/internal/repository/usage_billing_repo.go
+++ b/backend/internal/repository/usage_billing_repo.go
@@ -248,30 +248,32 @@ func incrementUsageBillingAccountQuota(ctx context.Context, tx *sql.Tx, accountI
 			|| CASE WHEN COALESCE((extra->>'quota_daily_limit')::numeric, 0) > 0 THEN
 				jsonb_build_object(
 					'quota_daily_used',
-					CASE WHEN COALESCE((extra->>'quota_daily_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '24 hours'::interval <= NOW()
+					CASE WHEN `+dailyExpiredExpr+`
 					THEN $1
 					ELSE COALESCE((extra->>'quota_daily_used')::numeric, 0) + $1 END,
 					'quota_daily_start',
-					CASE WHEN COALESCE((extra->>'quota_daily_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '24 hours'::interval <= NOW()
+					CASE WHEN `+dailyExpiredExpr+`
 					THEN `+nowUTC+`
 					ELSE COALESCE(extra->>'quota_daily_start', `+nowUTC+`) END
 				)
+				|| CASE WHEN `+dailyExpiredExpr+` AND `+nextDailyResetAtExpr+` IS NOT NULL
+				   THEN jsonb_build_object('quota_daily_reset_at', `+nextDailyResetAtExpr+`)
+				   ELSE '{}'::jsonb END
 			ELSE '{}'::jsonb END
 			|| CASE WHEN COALESCE((extra->>'quota_weekly_limit')::numeric, 0) > 0 THEN
 				jsonb_build_object(
 					'quota_weekly_used',
-					CASE WHEN COALESCE((extra->>'quota_weekly_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '168 hours'::interval <= NOW()
+					CASE WHEN `+weeklyExpiredExpr+`
 					THEN $1
 					ELSE COALESCE((extra->>'quota_weekly_used')::numeric, 0) + $1 END,
 					'quota_weekly_start',
-					CASE WHEN COALESCE((extra->>'quota_weekly_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '168 hours'::interval <= NOW()
+					CASE WHEN `+weeklyExpiredExpr+`
 					THEN `+nowUTC+`
 					ELSE COALESCE(extra->>'quota_weekly_start', `+nowUTC+`) END
 				)
+				|| CASE WHEN `+weeklyExpiredExpr+` AND `+nextWeeklyResetAtExpr+` IS NOT NULL
+				   THEN jsonb_build_object('quota_weekly_reset_at', `+nextWeeklyResetAtExpr+`)
+				   ELSE '{}'::jsonb END
 			ELSE '{}'::jsonb END
 		), updated_at = NOW()
 		WHERE id = $2 AND deleted_at IS NULL


### PR DESCRIPTION
Fixes #1534

## Problem

`incrementUsageBillingAccountQuota` in `usage_billing_repo.go` used hardcoded rolling-window expressions for daily and weekly quota period checks:

```sql
CASE WHEN COALESCE((extra->>'quota_daily_start')::timestamptz, '1970-01-01'::timestamptz)
    + '24 hours'::interval <= NOW()
```

This completely ignores `quota_daily_reset_mode` and `quota_weekly_reset_mode` settings. Even when an account is configured with `fixed` reset mode (e.g. reset at midnight in Asia/Shanghai), the billing path would still reset the quota counter only after 24 rolling hours from the first request of each period — not at the configured fixed wall-clock time.

The result: an account created or first used at 3pm would see its daily quota window run from 3pm to 3pm the next day in the billing path, even though the UI and the `IsQuotaExceeded` check expect a midnight reset.

## Solution

Replace the hardcoded `+ '24 hours'::interval` and `+ '168 hours'::interval` checks with the shared `dailyExpiredExpr` and `weeklyExpiredExpr` constants already defined in `account_repo.go` (same `repository` package). These constants correctly branch on `quota_daily_reset_mode`/`quota_weekly_reset_mode`:

- **rolling** mode: same 24h/168h rolling window as before
- **fixed** mode: compares `NOW()` against the pre-computed `quota_daily_reset_at`/`quota_weekly_reset_at` timestamp

Also add the `quota_daily_reset_at`/`quota_weekly_reset_at` updates (via `nextDailyResetAtExpr`/`nextWeeklyResetAtExpr`) on reset in fixed mode, keeping the billing path fully consistent with `IncrementQuotaUsed` in `account_repo.go`.

## Testing

- Accounts with rolling reset mode: behavior unchanged (same 24h/168h window logic)
- Accounts with fixed reset mode: daily quota now resets at the configured wall-clock time (e.g. midnight in the configured timezone) rather than 24 hours after the first request of each period