### PR TITLE
fix: normalize gemini image sizes for billing

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -4067,17 +4067,14 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 func (s *AntigravityGatewayService) extractImageSize(body []byte) string {
 	var req antigravity.GeminiRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return "2K" // 默认 2K
+		return geminiImageSizeDefault
 	}
 
 	if req.GenerationConfig != nil && req.GenerationConfig.ImageConfig != nil {
-		size := strings.ToUpper(strings.TrimSpace(req.GenerationConfig.ImageConfig.ImageSize))
-		if size == "1K" || size == "2K" || size == "4K" {
-			return size
-		}
+		return normalizeGeminiImageSizeOrDefault(req.GenerationConfig.ImageConfig.ImageSize)
 	}
 
-	return "2K" // 默认 2K
+	return geminiImageSizeDefault
 }
 
 // isImageGenerationModel 判断模型是否为图片生成模型

--- a/backend/internal/service/antigravity_image_test.go
+++ b/backend/internal/service/antigravity_image_test.go
@@ -68,56 +68,73 @@ func TestExtractImageSize_CaseInsensitive(t *testing.T) {
 	require.Equal(t, "4K", svc.extractImageSize(body))
 }
 
-// TestExtractImageSize_Default 测试无 imageConfig 返回默认 2K
+// TestExtractImageSize_Default 测试缺少 imageSize 时回落到官方默认 1K
 func TestExtractImageSize_Default(t *testing.T) {
 	svc := &AntigravityGatewayService{}
 
 	// 无 generationConfig
 	body := []byte(`{"contents":[]}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 
 	// 有 generationConfig 但无 imageConfig
 	body = []byte(`{"generationConfig":{"temperature":0.7}}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 
 	// 有 imageConfig 但无 imageSize
 	body = []byte(`{"generationConfig":{"imageConfig":{}}}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 }
 
-// TestExtractImageSize_InvalidJSON 测试非法 JSON 返回默认 2K
+// TestExtractImageSize_InvalidJSON 测试非法 JSON 返回默认 1K
 func TestExtractImageSize_InvalidJSON(t *testing.T) {
 	svc := &AntigravityGatewayService{}
 
 	body := []byte(`not valid json`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 
 	body = []byte(`{"broken":`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 }
 
-// TestExtractImageSize_EmptySize 测试空 imageSize 返回默认 2K
+// TestExtractImageSize_EmptySize 测试空 imageSize 返回默认 1K
 func TestExtractImageSize_EmptySize(t *testing.T) {
 	svc := &AntigravityGatewayService{}
 
 	body := []byte(`{"generationConfig":{"imageConfig":{"imageSize":""}}}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 
 	// 空格
 	body = []byte(`{"generationConfig":{"imageConfig":{"imageSize":"   "}}}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 }
 
-// TestExtractImageSize_InvalidSize 测试无效尺寸返回默认 2K
+// TestExtractImageSize_InvalidSize 测试无效尺寸返回默认 1K
 func TestExtractImageSize_InvalidSize(t *testing.T) {
 	svc := &AntigravityGatewayService{}
 
 	body := []byte(`{"generationConfig":{"imageConfig":{"imageSize":"3K"}}}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 
 	body = []byte(`{"generationConfig":{"imageConfig":{"imageSize":"8K"}}}`)
-	require.Equal(t, "2K", svc.extractImageSize(body))
+	require.Equal(t, "1K", svc.extractImageSize(body))
 
 	body = []byte(`{"generationConfig":{"imageConfig":{"imageSize":"invalid"}}}`)
+	require.Equal(t, "1K", svc.extractImageSize(body))
+}
+
+// TestExtractImageSize_Resolutions 测试新分辨率会回落到既有计费档位
+func TestExtractImageSize_Resolutions(t *testing.T) {
+	svc := &AntigravityGatewayService{}
+
+	body := []byte(`{"generationConfig":{"imageConfig":{"imageSize":"512"}}}`)
+	require.Equal(t, "1K", svc.extractImageSize(body))
+
+	body = []byte(`{"generationConfig":{"imageConfig":{"imageSize":"1584x672"}}}`)
+	require.Equal(t, "1K", svc.extractImageSize(body))
+
+	body = []byte(`{"generationConfig":{"imageConfig":{"imageSize":"3168x1344"}}}`)
 	require.Equal(t, "2K", svc.extractImageSize(body))
+
+	body = []byte(`{"generationConfig":{"imageConfig":{"imageSize":"6336x2688"}}}`)
+	require.Equal(t, "4K", svc.extractImageSize(body))
 }

--- a/backend/internal/service/gemini_image_size.go
+++ b/backend/internal/service/gemini_image_size.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	geminiImageSize1K      = "1K"
+	geminiImageSize2K      = "2K"
+	geminiImageSize4K      = "4K"
+	geminiImageSizeDefault = geminiImageSize1K
+)
+
+// normalizeGeminiImageSize 统一 Gemini 图片尺寸到现有计费档位。
+//
+// 优先保留官方 imageSize 语义：
+// - 512 / 1K / 2K / 4K
+// - 某些客户端若传具体分辨率（如 1584x672、3168x1344），按等效像素面积映射回 1K/2K/4K。
+//
+// 这样可以继续沿用现有 1K/2K/4K 计费配置，而不需要为每个长宽比单独建价目表。
+func normalizeGeminiImageSize(raw string) string {
+	normalized := strings.ToUpper(strings.TrimSpace(raw))
+	switch normalized {
+	case "":
+		return ""
+	case "512", "0.5K":
+		return geminiImageSize1K
+	case geminiImageSize1K, geminiImageSize2K, geminiImageSize4K:
+		return normalized
+	}
+
+	if side, err := strconv.Atoi(normalized); err == nil && side > 0 {
+		return classifyGeminiImageSizeByEquivalentSide(side)
+	}
+
+	width, height, ok := parseGeminiImageResolution(normalized)
+	if !ok {
+		return ""
+	}
+	return classifyGeminiImageSizeByPixels(width * height)
+}
+
+func normalizeGeminiImageSizeOrDefault(raw string) string {
+	if normalized := normalizeGeminiImageSize(raw); normalized != "" {
+		return normalized
+	}
+	return geminiImageSizeDefault
+}
+
+func parseGeminiImageResolution(raw string) (int, int, bool) {
+	for idx, r := range raw {
+		if r != 'X' && r != '×' {
+			continue
+		}
+
+		nextIdx := idx + utf8.RuneLen(r)
+		if idx <= 0 || nextIdx >= len(raw) {
+			return 0, 0, false
+		}
+
+		left := strings.TrimSpace(raw[:idx])
+		right := strings.TrimSpace(raw[nextIdx:])
+		width, err := strconv.Atoi(left)
+		if err != nil || width <= 0 {
+			return 0, 0, false
+		}
+		height, err := strconv.Atoi(right)
+		if err != nil || height <= 0 {
+			return 0, 0, false
+		}
+		return width, height, true
+	}
+	return 0, 0, false
+}
+
+func classifyGeminiImageSizeByEquivalentSide(side int) string {
+	switch {
+	case side <= 1536:
+		return geminiImageSize1K
+	case side <= 3072:
+		return geminiImageSize2K
+	default:
+		return geminiImageSize4K
+	}
+}
+
+func classifyGeminiImageSizeByPixels(pixels int) string {
+	switch {
+	// 1536^2: 兼容 512 和所有官方 1K 长宽比分辨率。
+	case pixels <= 2359296:
+		return geminiImageSize1K
+	// 3072^2: 兼容所有官方 2K 长宽比分辨率。
+	case pixels <= 9437184:
+		return geminiImageSize2K
+	default:
+		return geminiImageSize4K
+	}
+}

--- a/backend/internal/service/gemini_image_size_test.go
+++ b/backend/internal/service/gemini_image_size_test.go
@@ -1,0 +1,59 @@
+//go:build unit
+
+package service
+
+import "testing"
+
+import "github.com/stretchr/testify/require"
+
+func TestNormalizeGeminiImageSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty", raw: "", want: ""},
+		{name: "512 literal", raw: "512", want: "1K"},
+		{name: "1k literal", raw: "1k", want: "1K"},
+		{name: "2k literal", raw: "2K", want: "2K"},
+		{name: "4k literal", raw: "4k", want: "4K"},
+		{name: "21:9 1k resolution", raw: "1584x672", want: "1K"},
+		{name: "21:9 2k resolution", raw: "3168x1344", want: "2K"},
+		{name: "21:9 4k resolution", raw: "6336x2688", want: "4K"},
+		{name: "1:8 1k resolution", raw: "384x3072", want: "1K"},
+		{name: "4:1 1k resolution", raw: "2048x512", want: "1K"},
+		{name: "unicode separator", raw: "1792×2400", want: "2K"},
+		{name: "invalid", raw: "panorama", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, normalizeGeminiImageSize(tt.raw))
+		})
+	}
+}
+
+func TestNormalizeGeminiImageSizeOrDefault(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "1K", normalizeGeminiImageSizeOrDefault(""))
+	require.Equal(t, "1K", normalizeGeminiImageSizeOrDefault("invalid"))
+	require.Equal(t, "1K", normalizeGeminiImageSizeOrDefault("512"))
+	require.Equal(t, "2K", normalizeGeminiImageSizeOrDefault("3168x1344"))
+}
+
+func TestGeminiImageSizeExtraction_UsesNormalizedBillingTier(t *testing.T) {
+	t.Parallel()
+
+	antigravitySvc := &AntigravityGatewayService{}
+	compatSvc := &GeminiMessagesCompatService{}
+
+	require.Equal(t, "1K", antigravitySvc.extractImageSize([]byte(`{"generationConfig":{"imageConfig":{"imageSize":"512"}}}`)))
+	require.Equal(t, "1K", compatSvc.extractImageSize([]byte(`{"generationConfig":{"imageConfig":{"imageSize":"1584x672"}}}`)))
+	require.Equal(t, "2K", antigravitySvc.extractImageSize([]byte(`{"generationConfig":{"imageConfig":{"imageSize":"3168x1344"}}}`)))
+	require.Equal(t, "4K", compatSvc.extractImageSize([]byte(`{"generationConfig":{"imageConfig":{"imageSize":"6336x2688"}}}`)))
+	require.Equal(t, "1K", antigravitySvc.extractImageSize([]byte(`{"generationConfig":{"imageConfig":{"aspectRatio":"21:9"}}}`)))
+	require.Equal(t, "1K", compatSvc.extractImageSize([]byte(`{"contents":[]}`)))
+}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -3391,15 +3391,12 @@ func (s *GeminiMessagesCompatService) extractImageSize(body []byte) string {
 		} `json:"generationConfig"`
 	}
 	if err := json.Unmarshal(body, &req); err != nil {
-		return "2K"
+		return geminiImageSizeDefault
 	}
 
 	if req.GenerationConfig != nil && req.GenerationConfig.ImageConfig != nil {
-		size := strings.ToUpper(strings.TrimSpace(req.GenerationConfig.ImageConfig.ImageSize))
-		if size == "1K" || size == "2K" || size == "4K" {
-			return size
-		}
+		return normalizeGeminiImageSizeOrDefault(req.GenerationConfig.ImageConfig.ImageSize)
 	}
 
-	return "2K"
+	return geminiImageSizeDefault
 }


### PR DESCRIPTION
## Summary\n- normalize Gemini image sizes to the existing 1K/2K/4K billing tiers\n- map explicit resolutions like 1584x672 and 3168x1344 back to billing sizes\n- default missing or invalid Gemini image sizes to 1K and add focused unit tests\n\n## Testing\n- go test ./internal/service -tags=unit -run 'TestNormalizeGeminiImageSize|TestNormalizeGeminiImageSizeOrDefault|TestGeminiImageSizeExtraction_UsesNormalizedBillingTier|TestExtractImageSize_'