### PR TITLE
feat(admin): add account plan type filters

### DIFF
--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -377,7 +377,7 @@ func (h *AccountHandler) listAccountsFiltered(ctx context.Context, platform, acc
 	pageSize := dataPageCap
 	var out []service.Account
 	for {
-		items, total, err := h.adminService.ListAccounts(ctx, page, pageSize, platform, accountType, status, search, 0, "")
+		items, total, err := h.adminService.ListAccounts(ctx, page, pageSize, platform, accountType, status, search, 0, "", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -168,6 +168,35 @@ type AccountWithConcurrency struct {
 
 const accountListGroupUngroupedQueryValue = "ungrouped"
 
+func parseAccountPlanTypesQuery(c *gin.Context) []string {
+	rawValues := append([]string{}, c.QueryArray("plan_types")...)
+	rawValues = append(rawValues, c.QueryArray("plan_types[]")...)
+	if raw := strings.TrimSpace(c.Query("plan_types")); raw != "" && len(rawValues) == 0 {
+		rawValues = append(rawValues, raw)
+	}
+
+	planTypes := make([]string, 0)
+	seen := make(map[string]struct{})
+	for _, raw := range rawValues {
+		for _, item := range strings.Split(raw, ",") {
+			trimmed := strings.TrimSpace(item)
+			if trimmed == "" {
+				continue
+			}
+			normalized := service.NormalizeAccountPlanTypeFilterValue(trimmed)
+			if normalized == "" {
+				continue
+			}
+			if _, ok := seen[normalized]; ok {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			planTypes = append(planTypes, normalized)
+		}
+	}
+	return planTypes
+}
+
 func (h *AccountHandler) buildAccountResponseWithRuntime(ctx context.Context, account *service.Account) AccountWithConcurrency {
 	item := AccountWithConcurrency{
 		Account:            dto.AccountFromService(account),
@@ -221,6 +250,7 @@ func (h *AccountHandler) List(c *gin.Context) {
 	status := c.Query("status")
 	search := c.Query("search")
 	privacyMode := strings.TrimSpace(c.Query("privacy_mode"))
+	planTypes := parseAccountPlanTypesQuery(c)
 	// 标准化和验证 search 参数
 	search = strings.TrimSpace(search)
 	if len(search) > 100 {
@@ -246,7 +276,7 @@ func (h *AccountHandler) List(c *gin.Context) {
 		}
 	}
 
-	accounts, total, err := h.adminService.ListAccounts(c.Request.Context(), page, pageSize, platform, accountType, status, search, groupID, privacyMode)
+	accounts, total, err := h.adminService.ListAccounts(c.Request.Context(), page, pageSize, platform, accountType, status, search, groupID, privacyMode, planTypes)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
@@ -368,7 +398,7 @@ func (h *AccountHandler) List(c *gin.Context) {
 		result[i] = item
 	}
 
-	etag := buildAccountsListETag(result, total, page, pageSize, platform, accountType, status, search, lite)
+	etag := buildAccountsListETag(result, total, page, pageSize, platform, accountType, status, search, c.Query("group"), privacyMode, strings.Join(planTypes, ","), lite)
 	if etag != "" {
 		c.Header("ETag", etag)
 		c.Header("Vary", "If-None-Match")
@@ -385,7 +415,7 @@ func buildAccountsListETag(
 	items []AccountWithConcurrency,
 	total int64,
 	page, pageSize int,
-	platform, accountType, status, search string,
+	platform, accountType, status, search, groupFilter, privacyMode, planTypes string,
 	lite bool,
 ) string {
 	payload := struct {
@@ -396,6 +426,9 @@ func buildAccountsListETag(
 		AccountType string                   `json:"type"`
 		Status      string                   `json:"status"`
 		Search      string                   `json:"search"`
+		GroupFilter string                   `json:"group"`
+		PrivacyMode string                   `json:"privacy_mode"`
+		PlanTypes   string                   `json:"plan_types"`
 		Lite        bool                     `json:"lite"`
 		Items       []AccountWithConcurrency `json:"items"`
 	}{
@@ -406,6 +439,9 @@ func buildAccountsListETag(
 		AccountType: accountType,
 		Status:      status,
 		Search:      search,
+		GroupFilter: groupFilter,
+		PrivacyMode: privacyMode,
+		PlanTypes:   planTypes,
 		Lite:        lite,
 		Items:       items,
 	}
@@ -2029,7 +2065,7 @@ func (h *AccountHandler) BatchRefreshTier(c *gin.Context) {
 	accounts := make([]*service.Account, 0)
 
 	if len(req.AccountIDs) == 0 {
-		allAccounts, _, err := h.adminService.ListAccounts(ctx, 1, 10000, "gemini", "oauth", "", "", 0, "")
+		allAccounts, _, err := h.adminService.ListAccounts(ctx, 1, 10000, "gemini", "oauth", "", "", 0, "", nil)
 		if err != nil {
 			response.ErrorFrom(c, err)
 			return

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -187,7 +187,7 @@ func (s *stubAdminService) BatchSetGroupRateMultipliers(_ context.Context, _ int
 	return nil
 }
 
-func (s *stubAdminService) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string) ([]service.Account, int64, error) {
+func (s *stubAdminService) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]service.Account, int64, error) {
 	return s.accounts, int64(len(s.accounts)), nil
 }
 

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -486,14 +486,31 @@ func accountPlanTypePredicate(planTypes []string) dbpredicate.Account {
 			return
 		}
 
-		rawPlanExpr := "LOWER(COALESCE(" + s.C(dbaccount.FieldCredentials) + "->>'plan_type', ''))"
-		normalizedPlanExpr := "CASE WHEN " + rawPlanExpr + " = 'chatgptpro' THEN 'pro' ELSE " + rawPlanExpr + " END"
+		path := sqljson.Path("plan_type")
 		predicates := make([]*entsql.Predicate, 0, len(normalizedPlanTypes)+1)
 		for _, planType := range normalizedPlanTypes {
-			predicates = append(predicates, entsql.ExprP(normalizedPlanExpr+" = ?", planType))
+			switch planType {
+			case "pro":
+				predicates = append(predicates, entsql.Or(
+					sqljson.ValueEQ(dbaccount.FieldCredentials, "pro", path),
+					sqljson.ValueEQ(dbaccount.FieldCredentials, "chatgptpro", path),
+				))
+			default:
+				predicates = append(predicates, sqljson.ValueEQ(dbaccount.FieldCredentials, planType, path))
+			}
 		}
 		if includeUnknown {
-			predicates = append(predicates, entsql.ExprP(normalizedPlanExpr+" NOT IN (?, ?, ?, ?)", service.AccountRecognizedPlanTypes[0], service.AccountRecognizedPlanTypes[1], service.AccountRecognizedPlanTypes[2], service.AccountRecognizedPlanTypes[3]))
+			predicates = append(predicates, entsql.And(
+				entsql.Or(
+					entsql.Not(sqljson.HasKey(dbaccount.FieldCredentials, path)),
+					sqljson.ValueIsNull(dbaccount.FieldCredentials, path),
+					sqljson.ValueEQ(dbaccount.FieldCredentials, "", path),
+					entsql.And(
+						entsql.Not(sqljson.ValueIn(dbaccount.FieldCredentials, []any{"free", "team", "plus", "pro", "chatgptpro"}, path)),
+						entsql.Not(sqljson.ValueIsNull(dbaccount.FieldCredentials, path)),
+					),
+				),
+			))
 		}
 
 		switch len(predicates) {

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -486,13 +486,14 @@ func accountPlanTypePredicate(planTypes []string) dbpredicate.Account {
 			return
 		}
 
-		planExpr := "LOWER(COALESCE(" + s.C(dbaccount.FieldCredentials) + "->>'plan_type', ''))"
-		predicates := make([]*entsql.Predicate, 0, 2)
-		if len(normalizedPlanTypes) > 0 {
-			predicates = append(predicates, entsql.ExprP(planExpr+" = ANY(?)", pq.Array(normalizedPlanTypes)))
+		rawPlanExpr := "LOWER(COALESCE(" + s.C(dbaccount.FieldCredentials) + "->>'plan_type', ''))"
+		normalizedPlanExpr := "CASE WHEN " + rawPlanExpr + " = 'chatgptpro' THEN 'pro' ELSE " + rawPlanExpr + " END"
+		predicates := make([]*entsql.Predicate, 0, len(normalizedPlanTypes)+1)
+		for _, planType := range normalizedPlanTypes {
+			predicates = append(predicates, entsql.ExprP(normalizedPlanExpr+" = ?", planType))
 		}
 		if includeUnknown {
-			predicates = append(predicates, entsql.ExprP("NOT ("+planExpr+" = ANY(?))", pq.Array(service.AccountRecognizedPlanTypes)))
+			predicates = append(predicates, entsql.ExprP(normalizedPlanExpr+" NOT IN (?, ?, ?, ?)", service.AccountRecognizedPlanTypes[0], service.AccountRecognizedPlanTypes[1], service.AccountRecognizedPlanTypes[2], service.AccountRecognizedPlanTypes[3]))
 		}
 
 		switch len(predicates) {

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -454,10 +454,59 @@ func (r *accountRepository) Delete(ctx context.Context, id int64) error {
 }
 
 func (r *accountRepository) List(ctx context.Context, params pagination.PaginationParams) ([]service.Account, *pagination.PaginationResult, error) {
-	return r.ListWithFilters(ctx, params, "", "", "", "", 0, "")
+	return r.ListWithFilters(ctx, params, "", "", "", "", 0, "", nil)
 }
 
-func (r *accountRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]service.Account, *pagination.PaginationResult, error) {
+func normalizeAccountPlanTypeFilters(planTypes []string) ([]string, bool) {
+	normalized := make([]string, 0, len(planTypes))
+	seen := make(map[string]struct{}, len(planTypes))
+	includeUnknown := false
+	for _, planType := range planTypes {
+		normalizedValue := service.NormalizeAccountPlanTypeFilterValue(planType)
+		if normalizedValue == "" {
+			continue
+		}
+		if normalizedValue == service.AccountPlanTypeUnknownFilter {
+			includeUnknown = true
+			continue
+		}
+		if _, ok := seen[normalizedValue]; ok {
+			continue
+		}
+		seen[normalizedValue] = struct{}{}
+		normalized = append(normalized, normalizedValue)
+	}
+	return normalized, includeUnknown
+}
+
+func accountPlanTypePredicate(planTypes []string) dbpredicate.Account {
+	return dbpredicate.Account(func(s *entsql.Selector) {
+		normalizedPlanTypes, includeUnknown := normalizeAccountPlanTypeFilters(planTypes)
+		if len(normalizedPlanTypes) == 0 && !includeUnknown {
+			return
+		}
+
+		planExpr := "LOWER(COALESCE(" + s.C(dbaccount.FieldCredentials) + "->>'plan_type', ''))"
+		predicates := make([]*entsql.Predicate, 0, 2)
+		if len(normalizedPlanTypes) > 0 {
+			predicates = append(predicates, entsql.ExprP(planExpr+" = ANY(?)", pq.Array(normalizedPlanTypes)))
+		}
+		if includeUnknown {
+			predicates = append(predicates, entsql.ExprP("NOT ("+planExpr+" = ANY(?))", pq.Array(service.AccountRecognizedPlanTypes)))
+		}
+
+		switch len(predicates) {
+		case 0:
+			return
+		case 1:
+			s.Where(predicates[0])
+		default:
+			s.Where(entsql.Or(predicates...))
+		}
+	})
+}
+
+func (r *accountRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]service.Account, *pagination.PaginationResult, error) {
 	q := r.client.Account.Query()
 
 	if platform != "" {
@@ -511,6 +560,9 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 				s.Where(sqljson.ValueEQ(dbaccount.FieldExtra, privacyMode, path))
 			}
 		}))
+	}
+	if len(planTypes) > 0 {
+		q = q.Where(accountPlanTypePredicate(planTypes))
 	}
 
 	total, err := q.Count(ctx)

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -989,7 +989,7 @@ func (s *stubAccountRepo) List(ctx context.Context, params pagination.Pagination
 	return nil, nil, errors.New("not implemented")
 }
 
-func (s *stubAccountRepo) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]service.Account, *pagination.PaginationResult, error) {
+func (s *stubAccountRepo) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]service.Account, *pagination.PaginationResult, error) {
 	return nil, nil, errors.New("not implemented")
 }
 

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
@@ -16,6 +17,21 @@ var (
 
 const AccountListGroupUngrouped int64 = -1
 const AccountPrivacyModeUnsetFilter = "__unset__"
+const AccountPlanTypeUnknownFilter = "unknown"
+
+var AccountRecognizedPlanTypes = []string{"free", "team", "plus", "pro"}
+
+func NormalizeAccountPlanTypeFilterValue(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	switch normalized {
+	case "", "__unset__", "unset", "unknown", "unrecognized", "unrecognised", "null", "none", "empty":
+		return AccountPlanTypeUnknownFilter
+	case "chatgptpro":
+		return "pro"
+	default:
+		return normalized
+	}
+}
 
 type AccountRepository interface {
 	Create(ctx context.Context, account *Account) error
@@ -37,7 +53,7 @@ type AccountRepository interface {
 	Delete(ctx context.Context, id int64) error
 
 	List(ctx context.Context, params pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error)
-	ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error)
+	ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, *pagination.PaginationResult, error)
 	ListByGroup(ctx context.Context, groupID int64) ([]Account, error)
 	ListActive(ctx context.Context) ([]Account, error)
 	ListByPlatform(ctx context.Context, platform string) ([]Account, error)

--- a/backend/internal/service/account_service_delete_test.go
+++ b/backend/internal/service/account_service_delete_test.go
@@ -79,7 +79,7 @@ func (s *accountRepoStub) List(ctx context.Context, params pagination.Pagination
 	panic("unexpected List call")
 }
 
-func (s *accountRepoStub) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (s *accountRepoStub) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, *pagination.PaginationResult, error) {
 	panic("unexpected ListWithFilters call")
 }
 

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -55,7 +55,7 @@ type AdminService interface {
 	ReplaceUserGroup(ctx context.Context, userID, oldGroupID, newGroupID int64) (*ReplaceUserGroupResult, error)
 
 	// Account management
-	ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, int64, error)
+	ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, int64, error)
 	GetAccount(ctx context.Context, id int64) (*Account, error)
 	GetAccountsByIDs(ctx context.Context, ids []int64) ([]*Account, error)
 	CreateAccount(ctx context.Context, input *CreateAccountInput) (*Account, error)
@@ -1456,9 +1456,9 @@ func (s *adminServiceImpl) ReplaceUserGroup(ctx context.Context, userID, oldGrou
 }
 
 // Account management implementations
-func (s *adminServiceImpl) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, int64, error) {
+func (s *adminServiceImpl) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, int64, error) {
 	params := pagination.PaginationParams{Page: page, PageSize: pageSize}
-	accounts, result, err := s.accountRepo.ListWithFilters(ctx, params, platform, accountType, status, search, groupID, privacyMode)
+	accounts, result, err := s.accountRepo.ListWithFilters(ctx, params, platform, accountType, status, search, groupID, privacyMode, planTypes)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/internal/service/admin_service_search_test.go
+++ b/backend/internal/service/admin_service_search_test.go
@@ -13,19 +13,20 @@ import (
 type accountRepoStubForAdminList struct {
 	accountRepoStub
 
-	listWithFiltersCalls    int
-	listWithFiltersParams   pagination.PaginationParams
-	listWithFiltersPlatform string
-	listWithFiltersType     string
-	listWithFiltersStatus   string
-	listWithFiltersSearch   string
-	listWithFiltersPrivacy  string
-	listWithFiltersAccounts []Account
-	listWithFiltersResult   *pagination.PaginationResult
-	listWithFiltersErr      error
+	listWithFiltersCalls     int
+	listWithFiltersParams    pagination.PaginationParams
+	listWithFiltersPlatform  string
+	listWithFiltersType      string
+	listWithFiltersStatus    string
+	listWithFiltersSearch    string
+	listWithFiltersPrivacy   string
+	listWithFiltersPlanTypes []string
+	listWithFiltersAccounts  []Account
+	listWithFiltersResult    *pagination.PaginationResult
+	listWithFiltersErr       error
 }
 
-func (s *accountRepoStubForAdminList) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (s *accountRepoStubForAdminList) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, *pagination.PaginationResult, error) {
 	s.listWithFiltersCalls++
 	s.listWithFiltersParams = params
 	s.listWithFiltersPlatform = platform
@@ -33,6 +34,7 @@ func (s *accountRepoStubForAdminList) ListWithFilters(_ context.Context, params 
 	s.listWithFiltersStatus = status
 	s.listWithFiltersSearch = search
 	s.listWithFiltersPrivacy = privacyMode
+	s.listWithFiltersPlanTypes = append([]string(nil), planTypes...)
 
 	if s.listWithFiltersErr != nil {
 		return nil, nil, s.listWithFiltersErr
@@ -170,7 +172,7 @@ func TestAdminService_ListAccounts_WithSearch(t *testing.T) {
 		}
 		svc := &adminServiceImpl{accountRepo: repo}
 
-		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformGemini, AccountTypeOAuth, StatusActive, "acc", 0, "")
+		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformGemini, AccountTypeOAuth, StatusActive, "acc", 0, "", nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(10), total)
 		require.Equal(t, []Account{{ID: 1, Name: "acc"}}, accounts)
@@ -192,11 +194,27 @@ func TestAdminService_ListAccounts_WithPrivacyMode(t *testing.T) {
 		}
 		svc := &adminServiceImpl{accountRepo: repo}
 
-		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, StatusActive, "acc2", 0, PrivacyModeCFBlocked)
+		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, StatusActive, "acc2", 0, PrivacyModeCFBlocked, nil)
 		require.NoError(t, err)
 		require.Equal(t, int64(1), total)
 		require.Equal(t, []Account{{ID: 2, Name: "acc2"}}, accounts)
 		require.Equal(t, PrivacyModeCFBlocked, repo.listWithFiltersPrivacy)
+	})
+}
+
+func TestAdminService_ListAccounts_WithPlanTypes(t *testing.T) {
+	t.Run("plan_types 参数正常传递到 repository 层", func(t *testing.T) {
+		repo := &accountRepoStubForAdminList{
+			listWithFiltersAccounts: []Account{{ID: 3, Name: "acc3"}},
+			listWithFiltersResult:   &pagination.PaginationResult{Total: 1},
+		}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, StatusActive, "", 0, "", []string{"free", "team", AccountPlanTypeUnknownFilter})
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		require.Equal(t, []Account{{ID: 3, Name: "acc3"}}, accounts)
+		require.Equal(t, []string{"free", "team", AccountPlanTypeUnknownFilter}, repo.listWithFiltersPlanTypes)
 	})
 }
 

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -92,7 +92,7 @@ func (m *mockAccountRepoForPlatform) Delete(ctx context.Context, id int64) error
 func (m *mockAccountRepoForPlatform) List(ctx context.Context, params pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
-func (m *mockAccountRepoForPlatform) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (m *mockAccountRepoForPlatform) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
 func (m *mockAccountRepoForPlatform) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -79,7 +79,7 @@ func (m *mockAccountRepoForGemini) Delete(ctx context.Context, id int64) error  
 func (m *mockAccountRepoForGemini) List(ctx context.Context, params pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
-func (m *mockAccountRepoForGemini) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (m *mockAccountRepoForGemini) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
 func (m *mockAccountRepoForGemini) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -73,7 +73,7 @@ func (r *openAICodexExtraListRepo) SetRateLimited(_ context.Context, _ int64, re
 	return nil
 }
 
-func (r *openAICodexExtraListRepo) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (r *openAICodexExtraListRepo) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planTypes []string) ([]Account, *pagination.PaginationResult, error) {
 	_ = platform
 	_ = accountType
 	_ = status
@@ -492,7 +492,7 @@ func TestAdminService_ListAccounts_ExhaustedCodexExtraReturnsRateLimitedAccount(
 	}
 	svc := &adminServiceImpl{accountRepo: repo}
 
-	accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, "", "", 0, "")
+	accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, "", "", 0, "", nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total)
 	require.Len(t, accounts, 1)

--- a/backend/internal/service/ops_concurrency.go
+++ b/backend/internal/service/ops_concurrency.go
@@ -24,7 +24,7 @@ func (s *OpsService) listAllAccountsForOps(ctx context.Context, platformFilter s
 		accounts, pageInfo, err := s.accountRepo.ListWithFilters(ctx, pagination.PaginationParams{
 			Page:     page,
 			PageSize: opsAccountsPageSize,
-		}, platformFilter, "", "", "", 0, "")
+		}, platformFilter, "", "", "", 0, "", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -81,7 +81,7 @@ func (m *sessionWindowMockRepo) Delete(context.Context, int64) error    { panic(
 func (m *sessionWindowMockRepo) List(context.Context, pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
 	panic("unexpected")
 }
-func (m *sessionWindowMockRepo) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, string, int64, string) ([]Account, *pagination.PaginationResult, error) {
+func (m *sessionWindowMockRepo) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, string, int64, string, []string) ([]Account, *pagination.PaginationResult, error) {
 	panic("unexpected")
 }
 func (m *sessionWindowMockRepo) ListByGroup(context.Context, int64) ([]Account, error) {

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -27,28 +27,36 @@ import type {
  * @param filters - Optional filters
  * @returns Paginated list of accounts
  */
+type AccountListFilters = {
+  platform?: string
+  type?: string
+  status?: string
+  group?: string
+  search?: string
+  privacy_mode?: string
+  plan_types?: string[]
+  lite?: string
+}
+
+function buildAccountListParams(page: number, pageSize: number, filters?: AccountListFilters) {
+  return {
+    page,
+    page_size: pageSize,
+    ...filters,
+    plan_types: filters?.plan_types?.length ? filters.plan_types.join(',') : undefined
+  }
+}
+
 export async function list(
   page: number = 1,
   pageSize: number = 20,
-  filters?: {
-    platform?: string
-    type?: string
-    status?: string
-    group?: string
-    search?: string
-    privacy_mode?: string
-    lite?: string
-  },
+  filters?: AccountListFilters,
   options?: {
     signal?: AbortSignal
   }
 ): Promise<PaginatedResponse<Account>> {
   const { data } = await apiClient.get<PaginatedResponse<Account>>('/admin/accounts', {
-    params: {
-      page,
-      page_size: pageSize,
-      ...filters
-    },
+    params: buildAccountListParams(page, pageSize, filters),
     signal: options?.signal
   })
   return data
@@ -63,15 +71,7 @@ export interface AccountListWithEtagResult {
 export async function listWithEtag(
   page: number = 1,
   pageSize: number = 20,
-  filters?: {
-    platform?: string
-    type?: string
-    status?: string
-    group?: string
-    search?: string
-    privacy_mode?: string
-    lite?: string
-  },
+  filters?: AccountListFilters,
   options?: {
     signal?: AbortSignal
     etag?: string | null
@@ -83,11 +83,7 @@ export async function listWithEtag(
   }
 
   const response = await apiClient.get<PaginatedResponse<Account>>('/admin/accounts', {
-    params: {
-      page,
-      page_size: pageSize,
-      ...filters
-    },
+    params: buildAccountListParams(page, pageSize, filters),
     headers,
     signal: options?.signal,
     validateStatus: (status) => (status >= 200 && status < 300) || status === 304

--- a/frontend/src/components/admin/account/AccountTableFilters.vue
+++ b/frontend/src/components/admin/account/AccountTableFilters.vue
@@ -7,27 +7,216 @@
       @update:model-value="$emit('update:searchQuery', $event)"
       @search="$emit('change')"
     />
-    <Select :model-value="filters.platform" class="w-40" :options="pOpts" @update:model-value="updatePlatform" @change="$emit('change')" />
-    <Select :model-value="filters.type" class="w-40" :options="tOpts" @update:model-value="updateType" @change="$emit('change')" />
-    <Select :model-value="filters.status" class="w-40" :options="sOpts" @update:model-value="updateStatus" @change="$emit('change')" />
-    <Select :model-value="filters.privacy_mode" class="w-40" :options="privacyOpts" @update:model-value="updatePrivacyMode" @change="$emit('change')" />
-    <Select :model-value="filters.group" class="w-40" :options="gOpts" @update:model-value="updateGroup" @change="$emit('change')" />
+    <Select
+      :model-value="filters.platform"
+      class="w-40"
+      :options="pOpts"
+      @update:model-value="updatePlatform"
+      @change="$emit('change')"
+    />
+    <Select
+      :model-value="filters.type"
+      class="w-40"
+      :options="tOpts"
+      @update:model-value="updateType"
+      @change="$emit('change')"
+    />
+    <Select
+      :model-value="filters.status"
+      class="w-40"
+      :options="sOpts"
+      @update:model-value="updateStatus"
+      @change="$emit('change')"
+    />
+
+    <div class="relative" ref="planTypeDropdownRef">
+      <button
+        type="button"
+        data-testid="account-plan-types-trigger"
+        class="flex w-44 items-center justify-between gap-2 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm text-gray-900 transition-all duration-200 hover:border-gray-300 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500/30 dark:border-dark-600 dark:bg-dark-800 dark:text-gray-100 dark:hover:border-dark-500"
+        :class="planTypeDropdownOpen && 'border-primary-500 ring-2 ring-primary-500/30'"
+        :title="planTypeButtonTitle"
+        @click="togglePlanTypeDropdown"
+      >
+        <span class="truncate">{{ planTypeButtonLabel }}</span>
+        <svg
+          class="h-4 w-4 flex-shrink-0 text-gray-400 transition-transform duration-200"
+          :class="planTypeDropdownOpen && 'rotate-180'"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25L12 15.75 4.5 8.25" />
+        </svg>
+      </button>
+
+      <div
+        v-if="planTypeDropdownOpen"
+        class="absolute left-0 z-50 mt-2 w-56 rounded-xl border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+      >
+        <div class="max-h-64 overflow-y-auto p-2">
+          <label
+            v-for="option in planTypeOpts"
+            :key="String(option.value)"
+            :data-testid="`account-plan-types-option-${String(option.value)}`"
+            class="flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            <input
+              type="checkbox"
+              class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              :checked="selectedPlanTypes.includes(String(option.value))"
+              @change="togglePlanType(String(option.value))"
+            />
+            <span>{{ option.label }}</span>
+          </label>
+        </div>
+        <div class="flex items-center justify-between border-t border-gray-100 px-3 py-2 dark:border-gray-700">
+          <button
+            type="button"
+            data-testid="account-plan-types-reset"
+            class="text-xs font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+            @click="clearPlanTypes"
+          >
+            {{ t('common.reset') }}
+          </button>
+          <span class="text-xs text-gray-500 dark:text-gray-400">
+            {{ selectedPlanTypes.length ? t('admin.accounts.planTypesSelected', { count: selectedPlanTypes.length }) : t('common.all') }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <Select
+      :model-value="filters.privacy_mode"
+      class="w-40"
+      :options="privacyOpts"
+      @update:model-value="updatePrivacyMode"
+      @change="$emit('change')"
+    />
+    <Select
+      :model-value="filters.group"
+      class="w-40"
+      :options="gOpts"
+      @update:model-value="updateGroup"
+      @change="$emit('change')"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'; import { useI18n } from 'vue-i18n'; import Select from '@/components/common/Select.vue'; import SearchInput from '@/components/common/SearchInput.vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Select from '@/components/common/Select.vue'
+import SearchInput from '@/components/common/SearchInput.vue'
 import type { AdminGroup } from '@/types'
+
 const props = defineProps<{ searchQuery: string; filters: Record<string, any>; groups?: AdminGroup[] }>()
-const emit = defineEmits(['update:searchQuery', 'update:filters', 'change']); const { t } = useI18n()
-const updatePlatform = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, platform: value }) }
-const updateType = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, type: value }) }
-const updateStatus = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, status: value }) }
-const updatePrivacyMode = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, privacy_mode: value }) }
-const updateGroup = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, group: value }) }
-const pOpts = computed(() => [{ value: '', label: t('admin.accounts.allPlatforms') }, { value: 'anthropic', label: 'Anthropic' }, { value: 'openai', label: 'OpenAI' }, { value: 'gemini', label: 'Gemini' }, { value: 'antigravity', label: 'Antigravity' }])
-const tOpts = computed(() => [{ value: '', label: t('admin.accounts.allTypes') }, { value: 'oauth', label: t('admin.accounts.oauthType') }, { value: 'setup-token', label: t('admin.accounts.setupToken') }, { value: 'apikey', label: t('admin.accounts.apiKey') }, { value: 'bedrock', label: 'AWS Bedrock' }])
-const sOpts = computed(() => [{ value: '', label: t('admin.accounts.allStatus') }, { value: 'active', label: t('admin.accounts.status.active') }, { value: 'inactive', label: t('admin.accounts.status.inactive') }, { value: 'error', label: t('admin.accounts.status.error') }, { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') }, { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') }])
+const emit = defineEmits(['update:searchQuery', 'update:filters', 'change'])
+const { t } = useI18n()
+
+const planTypeDropdownRef = ref<HTMLElement | null>(null)
+const planTypeDropdownOpen = ref(false)
+
+const normalizePlanTypes = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item).trim()).filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map(item => item.trim())
+      .filter(Boolean)
+  }
+  return []
+}
+
+const selectedPlanTypes = computed<string[]>(() => normalizePlanTypes(props.filters.plan_types))
+
+const updatePlatform = (value: string | number | boolean | null) => {
+  emit('update:filters', { ...props.filters, platform: value })
+}
+const updateType = (value: string | number | boolean | null) => {
+  emit('update:filters', { ...props.filters, type: value })
+}
+const updateStatus = (value: string | number | boolean | null) => {
+  emit('update:filters', { ...props.filters, status: value })
+}
+const updatePrivacyMode = (value: string | number | boolean | null) => {
+  emit('update:filters', { ...props.filters, privacy_mode: value })
+}
+const updateGroup = (value: string | number | boolean | null) => {
+  emit('update:filters', { ...props.filters, group: value })
+}
+const updatePlanTypes = (planTypes: string[]) => {
+  emit('update:filters', { ...props.filters, plan_types: planTypes })
+  emit('change')
+}
+
+const togglePlanTypeDropdown = () => {
+  planTypeDropdownOpen.value = !planTypeDropdownOpen.value
+}
+
+const togglePlanType = (value: string) => {
+  const nextPlanTypes = selectedPlanTypes.value.includes(value)
+    ? selectedPlanTypes.value.filter(item => item !== value)
+    : [...selectedPlanTypes.value, value]
+  updatePlanTypes(nextPlanTypes)
+}
+
+const clearPlanTypes = () => {
+  if (selectedPlanTypes.value.length === 0) {
+    planTypeDropdownOpen.value = false
+    return
+  }
+  updatePlanTypes([])
+}
+
+const handleClickOutside = (event: MouseEvent) => {
+  if (!planTypeDropdownRef.value) return
+  const target = event.target as Node | null
+  if (target && !planTypeDropdownRef.value.contains(target)) {
+    planTypeDropdownOpen.value = false
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+})
+
+const pOpts = computed(() => [
+  { value: '', label: t('admin.accounts.allPlatforms') },
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'antigravity', label: 'Antigravity' }
+])
+const tOpts = computed(() => [
+  { value: '', label: t('admin.accounts.allTypes') },
+  { value: 'oauth', label: t('admin.accounts.oauthType') },
+  { value: 'setup-token', label: t('admin.accounts.setupToken') },
+  { value: 'apikey', label: t('admin.accounts.apiKey') },
+  { value: 'bedrock', label: 'AWS Bedrock' }
+])
+const sOpts = computed(() => [
+  { value: '', label: t('admin.accounts.allStatus') },
+  { value: 'active', label: t('admin.accounts.status.active') },
+  { value: 'inactive', label: t('admin.accounts.status.inactive') },
+  { value: 'error', label: t('admin.accounts.status.error') },
+  { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') },
+  { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') }
+])
+const planTypeOpts = computed(() => [
+  { value: 'free', label: t('admin.accounts.planType.free') },
+  { value: 'team', label: t('admin.accounts.planType.team') },
+  { value: 'plus', label: t('admin.accounts.planType.plus') },
+  { value: 'pro', label: t('admin.accounts.planType.pro') },
+  { value: 'unknown', label: t('admin.accounts.planType.unknown') }
+])
 const privacyOpts = computed(() => [
   { value: '', label: t('admin.accounts.allPrivacyModes') },
   { value: '__unset__', label: t('admin.accounts.privacyUnset') },
@@ -40,4 +229,26 @@ const gOpts = computed(() => [
   { value: 'ungrouped', label: t('admin.accounts.ungroupedGroup') },
   ...(props.groups || []).map(g => ({ value: String(g.id), label: g.name }))
 ])
+
+const selectedPlanTypeLabels = computed(() => {
+  const labelMap = new Map(planTypeOpts.value.map(option => [String(option.value), option.label]))
+  return selectedPlanTypes.value.map(value => labelMap.get(value) || value)
+})
+
+const planTypeButtonLabel = computed(() => {
+  if (selectedPlanTypeLabels.value.length === 0) {
+    return t('admin.accounts.allPlanTypes')
+  }
+  if (selectedPlanTypeLabels.value.length <= 2) {
+    return selectedPlanTypeLabels.value.join(' / ')
+  }
+  return t('admin.accounts.planTypesSelected', { count: selectedPlanTypeLabels.value.length })
+})
+
+const planTypeButtonTitle = computed(() => {
+  if (selectedPlanTypeLabels.value.length === 0) {
+    return t('admin.accounts.allPlanTypes')
+  }
+  return selectedPlanTypeLabels.value.join(', ')
+})
 </script>

--- a/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
@@ -8,7 +8,12 @@ vi.mock('vue-i18n', async () => {
   return {
     ...actual,
     useI18n: () => ({
-      t: (key: string) => key
+      t: (key: string, params?: Record<string, unknown>) => {
+        if (key === 'admin.accounts.planTypesSelected' && params?.count !== undefined) {
+          return `${key}:${params.count}`
+        }
+        return key
+      }
     })
   }
 })
@@ -23,7 +28,8 @@ describe('AccountTableFilters', () => {
           type: '',
           status: '',
           group: '',
-          privacy_mode: ''
+          privacy_mode: '',
+          plan_types: []
         },
         groups: []
       },
@@ -52,5 +58,45 @@ describe('AccountTableFilters', () => {
       { value: 'training_set_cf_blocked', label: 'CF' },
       { value: 'training_set_failed', label: 'Fail' }
     ])
+  })
+
+  it('supports multi-select plan type filters', async () => {
+    const wrapper = mount(AccountTableFilters, {
+      props: {
+        searchQuery: '',
+        filters: {
+          platform: '',
+          type: '',
+          status: '',
+          group: '',
+          privacy_mode: '',
+          plan_types: []
+        },
+        groups: []
+      },
+      global: {
+        stubs: {
+          SearchInput: {
+            template: '<div />'
+          },
+          Select: {
+            props: ['modelValue', 'options'],
+            emits: ['update:modelValue', 'change'],
+            template: '<div class="select-stub" />'
+          }
+        }
+      }
+    })
+
+    await wrapper.get('[data-testid="account-plan-types-trigger"]').trigger('click')
+    await wrapper.get('[data-testid="account-plan-types-option-team"] input').setValue(true)
+
+    const filterEvents = wrapper.emitted('update:filters')
+    expect(filterEvents).toBeTruthy()
+    expect(filterEvents?.at(-1)?.[0]).toMatchObject({ plan_types: ['team'] })
+
+    const changeEvents = wrapper.emitted('change')
+    expect(changeEvents).toBeTruthy()
+    expect(changeEvents?.length).toBeGreaterThan(0)
   })
 })

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1997,8 +1997,17 @@ export default {
       allTypes: 'All Types',
       allStatus: 'All Status',
       allGroups: 'All Groups',
+      allPlanTypes: 'All Plan Types',
+      planTypesSelected: '{count} selected',
       ungroupedGroup: 'Ungrouped',
       oauthType: 'OAuth',
+      planType: {
+        free: 'Free',
+        team: 'Team',
+        plus: 'Plus',
+        pro: 'Pro',
+        unknown: 'Unknown'
+      },
       setupToken: 'Setup Token',
       apiKey: 'API Key',
       // Schedulable toggle

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2079,8 +2079,17 @@ export default {
       allTypes: '全部类型',
       allStatus: '全部状态',
       allGroups: '全部分组',
+      allPlanTypes: '全部订阅类型',
+      planTypesSelected: '已选 {count} 项',
       ungroupedGroup: '未分配分组',
       oauthType: 'OAuth',
+      planType: {
+        free: 'Free',
+        team: 'Team',
+        plus: 'Plus',
+        pro: 'Pro',
+        unknown: '未识别'
+      },
       // Schedulable toggle
       schedulable: '参与调度',
       schedulableHint: '开启后账号参与API请求调度',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -594,7 +594,7 @@ const {
   handlePageSizeChange: baseHandlePageSizeChange
 } = useTableLoader<Account, any>({
   fetchFn: adminAPI.accounts.list,
-  initialParams: { platform: '', type: '', status: '', privacy_mode: '', group: '', search: '' }
+  initialParams: { platform: '', type: '', status: '', privacy_mode: '', group: '', search: '', plan_types: [] }
 })
 
 const {
@@ -774,7 +774,7 @@ const refreshAccountsIncrementally = async () => {
         privacy_mode?: string
         group?: string
         search?: string
-
+        plan_types?: string[]
       },
       { etag: autoRefreshETag.value }
     )
@@ -1103,6 +1103,31 @@ const handleBulkToggleSchedulable = async (schedulable: boolean) => {
 }
 const handleBulkUpdated = () => { showBulkEdit.value = false; clearSelection(); reload() }
 const handleDataImported = () => { showImportData.value = false; reload() }
+
+const normalizePlanTypeFilterValues = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item).trim().toLowerCase()).filter(Boolean)
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map(item => item.trim().toLowerCase())
+      .filter(Boolean)
+  }
+  return []
+}
+
+const normalizeAccountPlanTypeForFilter = (account: Account): string => {
+  const rawPlanType = typeof account.credentials?.plan_type === 'string'
+    ? account.credentials.plan_type.trim().toLowerCase()
+    : ''
+
+  if (!rawPlanType) return 'unknown'
+  if (rawPlanType === 'chatgptpro') return 'pro'
+  if (['free', 'team', 'plus', 'pro'].includes(rawPlanType)) return rawPlanType
+  return 'unknown'
+}
+
 const accountMatchesCurrentFilters = (account: Account) => {
   if (params.platform && account.platform !== params.platform) return false
   if (params.type && account.type !== params.type) return false
@@ -1111,9 +1136,38 @@ const accountMatchesCurrentFilters = (account: Account) => {
       if (!account.rate_limit_reset_at) return false
       const resetAt = new Date(account.rate_limit_reset_at).getTime()
       if (!Number.isFinite(resetAt) || resetAt <= Date.now()) return false
+    } else if (params.status === 'temp_unschedulable') {
+      if (!account.temp_unschedulable_until) return false
+      const tempUnschedUntil = new Date(account.temp_unschedulable_until).getTime()
+      if (!Number.isFinite(tempUnschedUntil) || tempUnschedUntil <= Date.now()) return false
     } else if (account.status !== params.status) {
       return false
     }
+  }
+  if (params.privacy_mode) {
+    const privacyMode = typeof account.extra?.privacy_mode === 'string' ? account.extra.privacy_mode : ''
+    if (params.privacy_mode === '__unset__') {
+      if (privacyMode) return false
+    } else if (privacyMode !== params.privacy_mode) {
+      return false
+    }
+  }
+  if (params.group) {
+    const groupIds = Array.isArray(account.group_ids)
+      ? account.group_ids.map(id => String(id))
+      : Array.isArray(account.groups)
+        ? account.groups.map(group => String(group.id))
+        : []
+    if (params.group === 'ungrouped') {
+      if (groupIds.length > 0) return false
+    } else if (!groupIds.includes(String(params.group))) {
+      return false
+    }
+  }
+  const selectedPlanTypes = normalizePlanTypeFilterValues(params.plan_types)
+  if (selectedPlanTypes.length > 0) {
+    const accountPlanType = normalizeAccountPlanTypeForFilter(account)
+    if (!selectedPlanTypes.includes(accountPlanType)) return false
   }
   const search = String(params.search || '').trim().toLowerCase()
   if (search && !account.name.toLowerCase().includes(search)) return false


### PR DESCRIPTION
## 变更摘要
- 为管理后台账号列表新增基于 `credentials.plan_type` 的订阅类型筛选
- 账号管理页支持 `Free / Team / Plus / Pro / 未识别` 多选筛选
- 将空值、缺失值和未识别值统一归类为 `unknown`
- 过滤时将 `chatgptpro` 归一为 `pro`

## 实现说明
- 后端新增 `plan_types` 查询参数，并贯通 `handler -> adminService -> repository`
- repository 层改为使用安全的 `sqljson` 谓词组合过滤 `plan_type`
- 前端账号页新增订阅类型多选筛选器
- 补充中英文文案与筛选组件测试

## 验证
- `npm test -- --run src/components/admin/account/__tests__/AccountTableFilters.spec.ts`
- `npm run build`
- `go test -tags unit ./internal/service -run '^TestAdminService_ListAccounts_WithPlanTypes$' -count=1 -vet=off -v`
- `go test -tags unit ./internal/handler/admin ./internal/server ./internal/repository -run '^$' -count=1 -vet=off`

## Live 验收
- `GET /api/v1/admin/accounts?plan_types=team` -> `total=11`
- `GET /api/v1/admin/accounts?plan_types=free` -> `total=33`
- `GET /api/v1/admin/accounts?plan_types=plus` -> `total=4`
- `GET /api/v1/admin/accounts?plan_types=unknown` -> `total=28`
- `GET /api/v1/admin/accounts?plan_types=team,plus` -> `total=15`