### PR TITLE
fix(service): 修正 WS 续链连接保护

### DIFF
--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -426,6 +426,13 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"window_cost_sticky_reserve",
 		"max_sessions",
 		"session_idle_timeout_minutes",
+		"openai_oauth_responses_websockets_v2_enabled",
+		"openai_oauth_responses_websockets_v2_mode",
+		"openai_apikey_responses_websockets_v2_enabled",
+		"openai_apikey_responses_websockets_v2_mode",
+		"responses_websockets_v2_enabled",
+		"openai_ws_enabled",
+		"openai_ws_force_http",
 	}
 	filtered := make(map[string]any)
 	for _, key := range keys {

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -12,50 +12,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T) {
+func TestSchedulerCacheSnapshotKeepsOpenAIWSMetadataFields(t *testing.T) {
 	ctx := context.Background()
 	rdb := testRedis(t)
 	cache := NewSchedulerCache(rdb)
 
-	bucket := service.SchedulerBucket{GroupID: 2, Platform: service.PlatformGemini, Mode: service.SchedulerModeSingle}
-	now := time.Now().UTC().Truncate(time.Second)
-	limitReset := now.Add(10 * time.Minute)
-	overloadUntil := now.Add(2 * time.Minute)
-	tempUnschedUntil := now.Add(3 * time.Minute)
-	windowEnd := now.Add(5 * time.Hour)
-
+	bucket := service.SchedulerBucket{GroupID: 5, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
 	account := service.Account{
-		ID:          101,
-		Name:        "gemini-heavy",
-		Platform:    service.PlatformGemini,
+		ID:          201,
+		Name:        "openai-ws-oauth",
+		Platform:    service.PlatformOpenAI,
 		Type:        service.AccountTypeOAuth,
 		Status:      service.StatusActive,
 		Schedulable: true,
-		Concurrency: 3,
-		Priority:    7,
-		LastUsedAt:  &now,
-		Credentials: map[string]any{
-			"api_key":       "gemini-api-key",
-			"access_token":  "secret-access-token",
-			"project_id":    "proj-1",
-			"oauth_type":    "ai_studio",
-			"model_mapping": map[string]any{"gemini-2.5-pro": "gemini-2.5-pro"},
-			"huge_blob":     strings.Repeat("x", 4096),
-		},
+		Concurrency: 1,
+		Priority:    1,
 		Extra: map[string]any{
-			"mixed_scheduling":             true,
-			"window_cost_limit":            12.5,
-			"window_cost_sticky_reserve":   8.0,
-			"max_sessions":                 4,
-			"session_idle_timeout_minutes": 11,
-			"unused_large_field":           strings.Repeat("y", 4096),
+			"openai_oauth_responses_websockets_v2_enabled": true,
+			"openai_oauth_responses_websockets_v2_mode":    "passthrough",
+			"openai_ws_force_http":                         false,
+			"privacy_mode":                                 "training_off",
+			"unused_large_field":                           strings.Repeat("z", 4096),
 		},
-		RateLimitResetAt:       &limitReset,
-		OverloadUntil:          &overloadUntil,
-		TempUnschedulableUntil: &tempUnschedUntil,
-		SessionWindowStart:     &now,
-		SessionWindowEnd:       &windowEnd,
-		SessionWindowStatus:    "active",
 	}
 
 	require.NoError(t, cache.SetSnapshot(ctx, bucket, []service.Account{account}))
@@ -67,22 +45,9 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 
 	got := snapshot[0]
 	require.NotNil(t, got)
-	require.Equal(t, "gemini-api-key", got.GetCredential("api_key"))
-	require.Equal(t, "proj-1", got.GetCredential("project_id"))
-	require.Equal(t, "ai_studio", got.GetCredential("oauth_type"))
-	require.NotEmpty(t, got.GetModelMapping())
-	require.Empty(t, got.GetCredential("access_token"))
-	require.Empty(t, got.GetCredential("huge_blob"))
-	require.Equal(t, true, got.Extra["mixed_scheduling"])
-	require.Equal(t, 12.5, got.GetWindowCostLimit())
-	require.Equal(t, 8.0, got.GetWindowCostStickyReserve())
-	require.Equal(t, 4, got.GetMaxSessions())
-	require.Equal(t, 11, got.GetSessionIdleTimeoutMinutes())
+	require.Equal(t, true, got.Extra["openai_oauth_responses_websockets_v2_enabled"])
+	require.Equal(t, "passthrough", got.Extra["openai_oauth_responses_websockets_v2_mode"])
+	require.Equal(t, false, got.Extra["openai_ws_force_http"])
+	require.Nil(t, got.Extra["privacy_mode"])
 	require.Nil(t, got.Extra["unused_large_field"])
-
-	full, err := cache.GetAccount(ctx, account.ID)
-	require.NoError(t, err)
-	require.NotNil(t, full)
-	require.Equal(t, "secret-access-token", full.GetCredential("access_token"))
-	require.Equal(t, strings.Repeat("x", 4096), full.GetCredential("huge_blob"))
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"log/slog"
 	"math"
 	"sort"
 	"strconv"
@@ -584,26 +585,56 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 
 	filtered := make([]*Account, 0, len(accounts))
 	loadReq := make([]AccountWithConcurrency, 0, len(accounts))
+	excludedCount := 0
+	unschedulableCount := 0
+	nonOpenAICount := 0
+	privacyRejectedCount := 0
+	modelRejectedCount := 0
+	transportRejectedCount := 0
 	for i := range accounts {
 		account := &accounts[i]
 		if req.ExcludedIDs != nil {
 			if _, excluded := req.ExcludedIDs[account.ID]; excluded {
+				excludedCount++
 				continue
 			}
 		}
-		if !account.IsSchedulable() || !account.IsOpenAI() {
+		if !account.IsSchedulable() {
+			unschedulableCount++
+			continue
+		}
+		if !account.IsOpenAI() {
+			nonOpenAICount++
 			continue
 		}
 		// require_privacy_set: 跳过 privacy 未设置的账号并标记异常
 		if schedGroup != nil && schedGroup.RequirePrivacySet && !account.IsPrivacySet() {
+			privacyRejectedCount++
 			_ = s.service.accountRepo.SetError(ctx, account.ID,
 				fmt.Sprintf("Privacy not set, required by group [%s]", schedGroup.Name))
 			continue
 		}
 		if req.RequestedModel != "" && !account.IsModelSupported(req.RequestedModel) {
+			modelRejectedCount++
 			continue
 		}
 		if !s.isAccountTransportCompatible(account, req.RequiredTransport) {
+			transportRejectedCount++
+			if req.RequiredTransport == OpenAIUpstreamTransportResponsesWebsocketV2 {
+				wsDecision := s.service.getOpenAIWSProtocolResolver().Resolve(account)
+				slog.Info("openai_ws_scheduler_transport_rejected_account",
+					"group_id", derefGroupID(req.GroupID),
+					"requested_model", req.RequestedModel,
+					"account_id", account.ID,
+					"account_name", account.Name,
+					"account_type", account.Type,
+					"resolved_transport", string(wsDecision.Transport),
+					"transport_reason", wsDecision.Reason,
+					"responses_ws_v2_enabled", account.IsOpenAIResponsesWebSocketV2Enabled(),
+					"resolved_ws_v2_mode", account.ResolveOpenAIResponsesWebSocketV2Mode(OpenAIWSIngressModeCtxPool),
+					"openai_ws_force_http", account.IsOpenAIWSForceHTTPEnabled(),
+				)
+			}
 			continue
 		}
 		filtered = append(filtered, account)
@@ -611,6 +642,21 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 			ID:             account.ID,
 			MaxConcurrency: account.EffectiveLoadFactor(),
 		})
+	}
+	if req.RequiredTransport == OpenAIUpstreamTransportResponsesWebsocketV2 || len(filtered) == 0 {
+		slog.Info("openai_ws_scheduler_filter_summary",
+			"group_id", derefGroupID(req.GroupID),
+			"requested_model", req.RequestedModel,
+			"required_transport", string(req.RequiredTransport),
+			"input_count", len(accounts),
+			"excluded_count", excludedCount,
+			"unschedulable_count", unschedulableCount,
+			"non_openai_count", nonOpenAICount,
+			"privacy_rejected_count", privacyRejectedCount,
+			"model_rejected_count", modelRejectedCount,
+			"transport_rejected_count", transportRejectedCount,
+			"filtered_count", len(filtered),
+		)
 	}
 	if len(filtered) == 0 {
 		return nil, 0, 0, 0, errors.New("no available OpenAI accounts")
@@ -703,14 +749,29 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	rankedCandidates := selectTopKOpenAICandidates(candidates, topK)
 	selectionOrder := buildOpenAIWeightedSelectionOrder(rankedCandidates, req)
 
+	freshRejectedCount := 0
+	freshTransportRejectedCount := 0
+	recheckRejectedCount := 0
+	recheckTransportRejectedCount := 0
+	acquireBusyCount := 0
 	for i := 0; i < len(selectionOrder); i++ {
 		candidate := selectionOrder[i]
 		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.RequestedModel)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) {
+		if fresh == nil {
+			freshRejectedCount++
+			continue
+		}
+		if !s.isAccountTransportCompatible(fresh, req.RequiredTransport) {
+			freshTransportRejectedCount++
 			continue
 		}
 		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.RequestedModel)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) {
+		if fresh == nil {
+			recheckRejectedCount++
+			continue
+		}
+		if !s.isAccountTransportCompatible(fresh, req.RequiredTransport) {
+			recheckTransportRejectedCount++
 			continue
 		}
 		result, acquireErr := s.service.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
@@ -727,13 +788,21 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 				ReleaseFunc: result.ReleaseFunc,
 			}, len(candidates), topK, loadSkew, nil
 		}
+		acquireBusyCount++
 	}
 
 	cfg := s.service.schedulingConfig()
 	// WaitPlan.MaxConcurrency 使用 Concurrency（非 EffectiveLoadFactor），因为 WaitPlan 控制的是 Redis 实际并发槽位等待。
+	waitPlanFreshRejectedCount := 0
+	waitPlanTransportRejectedCount := 0
 	for _, candidate := range selectionOrder {
 		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.RequestedModel)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) {
+		if fresh == nil {
+			waitPlanFreshRejectedCount++
+			continue
+		}
+		if !s.isAccountTransportCompatible(fresh, req.RequiredTransport) {
+			waitPlanTransportRejectedCount++
 			continue
 		}
 		return &AccountSelectionResult{
@@ -746,6 +815,21 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 			},
 		}, len(candidates), topK, loadSkew, nil
 	}
+
+	slog.Warn("openai_ws_scheduler_no_available_account",
+		"group_id", derefGroupID(req.GroupID),
+		"requested_model", req.RequestedModel,
+		"required_transport", string(req.RequiredTransport),
+		"candidate_count", len(candidates),
+		"top_k", topK,
+		"fresh_rejected_count", freshRejectedCount,
+		"fresh_transport_rejected_count", freshTransportRejectedCount,
+		"recheck_rejected_count", recheckRejectedCount,
+		"recheck_transport_rejected_count", recheckTransportRejectedCount,
+		"acquire_busy_count", acquireBusyCount,
+		"waitplan_fresh_rejected_count", waitPlanFreshRejectedCount,
+		"waitplan_transport_rejected_count", waitPlanTransportRejectedCount,
+	)
 
 	return nil, len(candidates), topK, loadSkew, ErrNoAvailableAccounts
 }

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2098,6 +2098,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 		}
 		_, hasPreviousResponseID := wsReqBody["previous_response_id"]
+		explicitPreviousResponseID := hasPreviousResponseID && strings.TrimSpace(openAIWSPayloadString(wsReqBody, "previous_response_id")) != ""
 		logOpenAIWSModeDebug(
 			"forward_start account_id=%d account_type=%s model=%s stream=%v has_previous_response_id=%v",
 			account.ID,
@@ -2114,6 +2115,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		wsPrevResponseRecoveryTried := false
 		wsInvalidEncryptedContentRecoveryTried := false
 		recoverPrevResponseNotFound := func(attempt int) bool {
+			if explicitPreviousResponseID {
+				return false
+			}
 			if wsPrevResponseRecoveryTried {
 				return false
 			}

--- a/backend/internal/service/openai_ws_client.go
+++ b/backend/internal/service/openai_ws_client.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -97,16 +99,37 @@ func (d *coderOpenAIWSClientDialer) Dial(
 			status = resp.StatusCode
 			respHeaders = cloneHeader(resp.Header)
 		}
+		logOpenAIWSHandshakeHeaders(targetURL, status, respHeaders)
 		return nil, status, respHeaders, err
 	}
 	// coder/websocket 默认单消息读取上限为 32KB，Codex WS 事件（如 rate_limits/大 delta）
 	// 可能超过该阈值，需显式提高上限，避免本地 read_fail(message too big)。
 	conn.SetReadLimit(openAIWSMessageReadLimitBytes)
 	respHeaders := http.Header(nil)
+	status := 0
 	if resp != nil {
+		status = resp.StatusCode
 		respHeaders = cloneHeader(resp.Header)
 	}
+	logOpenAIWSHandshakeHeaders(targetURL, status, respHeaders)
 	return &coderOpenAIWSClientConn{conn: conn}, 0, respHeaders, nil
+}
+
+func logOpenAIWSHandshakeHeaders(targetURL string, status int, headers http.Header) {
+	keys := make([]string, 0, len(headers))
+	for key := range headers {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	log.Printf(
+		"[openai_ws_client] raw_handshake_response status=%d target=%s x_codex_turn_state=%q session_id=%q conversation_id=%q header_keys=%v",
+		status,
+		targetURL,
+		headers.Get("x-codex-turn-state"),
+		headers.Get("session_id"),
+		headers.Get("conversation_id"),
+		keys,
+	)
 }
 
 func (d *coderOpenAIWSClientDialer) proxyHTTPClient(proxy string) (*http.Client, error) {

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -894,13 +894,58 @@ func sortedKeys(m map[string]any) []string {
 	return keys
 }
 
+func (s *OpenAIGatewayService) attachOpenAIWSConnClosedHook(pool *openAIWSConnPool) {
+	if s == nil || pool == nil {
+		return
+	}
+	pool.setConnClosedHook(func(connID string) {
+		store := s.getOpenAIWSStateStore()
+		if store == nil {
+			return
+		}
+		responseIDs, sessionKeys := store.DeleteConnBindings(connID)
+		if len(responseIDs) == 0 && len(sessionKeys) == 0 {
+			return
+		}
+		logOpenAIWSModeInfo(
+			"pool_conn_binding_cleanup conn_id=%s response_bindings=%d session_bindings=%d",
+			truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+			len(responseIDs),
+			len(sessionKeys),
+		)
+	})
+}
+
+func (s *OpenAIGatewayService) cleanupOpenAIWSConnBindings(connID string, reason string) (responseBindingCount int, sessionBindingCount int) {
+	if s == nil {
+		return 0, 0
+	}
+	store := s.getOpenAIWSStateStore()
+	if store == nil {
+		return 0, 0
+	}
+	responseIDs, sessionKeys := store.DeleteConnBindings(connID)
+	if len(responseIDs) > 0 || len(sessionKeys) > 0 {
+		logOpenAIWSModeInfo(
+			"stale_conn_binding_cleanup reason=%s conn_id=%s response_bindings=%d session_bindings=%d",
+			normalizeOpenAIWSLogValue(reason),
+			truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+			len(responseIDs),
+			len(sessionKeys),
+		)
+	}
+	return len(responseIDs), len(sessionKeys)
+}
+
 func (s *OpenAIGatewayService) getOpenAIWSConnPool() *openAIWSConnPool {
 	if s == nil {
 		return nil
 	}
 	s.openaiWSPoolOnce.Do(func() {
 		if s.openaiWSPool == nil {
-			s.openaiWSPool = newOpenAIWSConnPool(s.cfg)
+			pool := newOpenAIWSConnPool(s.cfg)
+			s.attachOpenAIWSConnClosedHook(pool)
+			s.openaiWSPool = pool
 		}
 	})
 	return s.openaiWSPool
@@ -954,6 +999,9 @@ func (s *OpenAIGatewayService) getOpenAIWSStateStore() OpenAIWSStateStore {
 			s.openaiWSStateStore = NewOpenAIWSStateStore(s.cache)
 		}
 	})
+	if pool := s.openaiWSPool; pool != nil {
+		s.attachOpenAIWSConnClosedHook(pool)
+	}
 	return s.openaiWSStateStore
 }
 
@@ -1449,7 +1497,7 @@ func normalizeOpenAIWSJSONForCompareOrRaw(raw []byte) []byte {
 	return normalized
 }
 
-func normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(payload []byte) ([]byte, error) {
+func normalizeOpenAIWSPayloadForStrictCompare(payload []byte, dropGenerate bool) ([]byte, error) {
 	if len(payload) == 0 {
 		return nil, errors.New("payload is empty")
 	}
@@ -1459,7 +1507,38 @@ func normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(payload []byte) (
 	}
 	delete(decoded, "input")
 	delete(decoded, "previous_response_id")
+	if dropGenerate {
+		delete(decoded, "generate")
+	}
 	return json.Marshal(decoded)
+}
+
+func normalizeOpenAIWSPayloadWithoutInputAndPreviousResponseID(payload []byte) ([]byte, error) {
+	return normalizeOpenAIWSPayloadForStrictCompare(payload, false)
+}
+
+func normalizeOpenAIWSPayloadWithoutInputPreviousResponseIDAndGenerate(payload []byte) ([]byte, error) {
+	return normalizeOpenAIWSPayloadForStrictCompare(payload, true)
+}
+
+func isOpenAIWSGenerateFalsePrewarmSeed(payload []byte) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	if strings.TrimSpace(openAIWSPayloadStringFromRaw(payload, "previous_response_id")) != "" {
+		return false
+	}
+	if generateValue := gjson.GetBytes(payload, "generate"); !generateValue.Exists() || generateValue.Type != gjson.False {
+		return false
+	}
+	inputItems, inputExists, err := openAIWSExtractNormalizedInputSequence(payload)
+	if err != nil {
+		return false
+	}
+	if !inputExists {
+		return true
+	}
+	return len(inputItems) == 0
 }
 
 func openAIWSExtractNormalizedInputSequence(payload []byte) ([]json.RawMessage, bool, error) {
@@ -1618,13 +1697,28 @@ func shouldKeepIngressPreviousResponseID(
 		return false, "non_input_compare_error", currentComparableErr
 	}
 	if !bytes.Equal(previousComparable, currentComparable) {
+		if isOpenAIWSGenerateFalsePrewarmSeed(previousPayload) {
+			previousPrewarmComparable, previousPrewarmErr := normalizeOpenAIWSPayloadWithoutInputPreviousResponseIDAndGenerate(previousPayload)
+			if previousPrewarmErr != nil {
+				return false, "non_input_compare_error", previousPrewarmErr
+			}
+			currentPrewarmComparable, currentPrewarmErr := normalizeOpenAIWSPayloadWithoutInputPreviousResponseIDAndGenerate(currentPayload)
+			if currentPrewarmErr != nil {
+				return false, "non_input_compare_error", currentPrewarmErr
+			}
+			if bytes.Equal(previousPrewarmComparable, currentPrewarmComparable) {
+				return true, "prewarm_business_ok", nil
+			}
+		}
 		return false, "non_input_changed", nil
 	}
 	return true, "strict_incremental_ok", nil
 }
 
 type openAIWSIngressPreviousTurnStrictState struct {
-	nonInputComparable []byte
+	nonInputComparable      []byte
+	prewarmSeedComparable   []byte
+	allowGenerateTransition bool
 }
 
 func buildOpenAIWSIngressPreviousTurnStrictState(payload []byte) (*openAIWSIngressPreviousTurnStrictState, error) {
@@ -1635,9 +1729,18 @@ func buildOpenAIWSIngressPreviousTurnStrictState(payload []byte) (*openAIWSIngre
 	if nonInputErr != nil {
 		return nil, nonInputErr
 	}
-	return &openAIWSIngressPreviousTurnStrictState{
+	state := &openAIWSIngressPreviousTurnStrictState{
 		nonInputComparable: nonInputComparable,
-	}, nil
+	}
+	if isOpenAIWSGenerateFalsePrewarmSeed(payload) {
+		prewarmComparable, prewarmErr := normalizeOpenAIWSPayloadWithoutInputPreviousResponseIDAndGenerate(payload)
+		if prewarmErr != nil {
+			return nil, prewarmErr
+		}
+		state.prewarmSeedComparable = prewarmComparable
+		state.allowGenerateTransition = true
+	}
+	return state, nil
 }
 
 func shouldKeepIngressPreviousResponseIDWithStrictState(
@@ -1669,6 +1772,15 @@ func shouldKeepIngressPreviousResponseIDWithStrictState(
 		return false, "non_input_compare_error", currentComparableErr
 	}
 	if !bytes.Equal(previousState.nonInputComparable, currentComparable) {
+		if previousState.allowGenerateTransition {
+			currentPrewarmComparable, currentPrewarmErr := normalizeOpenAIWSPayloadWithoutInputPreviousResponseIDAndGenerate(currentPayload)
+			if currentPrewarmErr != nil {
+				return false, "non_input_compare_error", currentPrewarmErr
+			}
+			if bytes.Equal(previousState.prewarmSeedComparable, currentPrewarmComparable) {
+				return true, "prewarm_business_ok", nil
+			}
+		}
 		return false, "non_input_changed", nil
 	}
 	return true, "strict_incremental_ok", nil
@@ -1923,12 +2035,25 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	}
 
 	handshakeTurnState := strings.TrimSpace(lease.HandshakeHeader(openAIWSTurnStateHeader))
-	logOpenAIWSModeDebug(
-		"handshake account_id=%d conn_id=%s has_turn_state=%v turn_state_len=%d",
+	handshakeSessionID := strings.TrimSpace(lease.HandshakeHeader("session_id"))
+	handshakeConversationID := strings.TrimSpace(lease.HandshakeHeader("conversation_id"))
+	logOpenAIWSModeInfo(
+		"handshake_diag account_id=%d conn_id=%s has_turn_state=%v turn_state_len=%d handshake_session_id=%s handshake_conversation_id=%s",
 		account.ID,
 		connID,
 		handshakeTurnState != "",
 		len(handshakeTurnState),
+		openAIWSHeaderValueForLog(lease.HandshakeHeaders(), "session_id"),
+		openAIWSHeaderValueForLog(lease.HandshakeHeaders(), "conversation_id"),
+	)
+	logOpenAIWSModeDebug(
+		"handshake account_id=%d conn_id=%s has_turn_state=%v turn_state_len=%d handshake_session_id=%s handshake_conversation_id=%s",
+		account.ID,
+		connID,
+		handshakeTurnState != "",
+		len(handshakeTurnState),
+		truncateOpenAIWSLogValue(handshakeSessionID, openAIWSHeaderValueMaxLen),
+		truncateOpenAIWSLogValue(handshakeConversationID, openAIWSHeaderValueMaxLen),
 	)
 	if handshakeTurnState != "" {
 		if stateStore != nil && sessionHash != "" {
@@ -2420,13 +2545,22 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 	debugEnabled := isOpenAIWSModeDebugEnabled()
 
+	type openAIWSPreviousResponseIDSource string
+
+	const (
+		openAIWSPreviousResponseIDSourceNone     openAIWSPreviousResponseIDSource = "none"
+		openAIWSPreviousResponseIDSourceExplicit openAIWSPreviousResponseIDSource = "explicit"
+		openAIWSPreviousResponseIDSourceInferred openAIWSPreviousResponseIDSource = "inferred"
+	)
+
 	type openAIWSClientPayload struct {
-		payloadRaw         []byte
-		rawForHash         []byte
-		promptCacheKey     string
-		previousResponseID string
-		originalModel      string
-		payloadBytes       int
+		payloadRaw               []byte
+		rawForHash               []byte
+		promptCacheKey           string
+		previousResponseID       string
+		previousResponseIDSource openAIWSPreviousResponseIDSource
+		originalModel            string
+		payloadBytes             int
 	}
 
 	applyPayloadMutation := func(current []byte, path string, value any) ([]byte, error) {
@@ -2500,6 +2634,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		}
 		promptCacheKey := strings.TrimSpace(values[2].String())
 		previousResponseID := strings.TrimSpace(values[3].String())
+		previousResponseIDSource := openAIWSPreviousResponseIDSourceNone
+		if previousResponseID != "" {
+			previousResponseIDSource = openAIWSPreviousResponseIDSourceExplicit
+		}
 		previousResponseIDKind := ClassifyOpenAIPreviousResponseIDKind(previousResponseID)
 		if previousResponseID != "" && previousResponseIDKind == OpenAIPreviousResponseIDKindMessageID {
 			return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(
@@ -2525,12 +2663,13 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		}
 
 		return openAIWSClientPayload{
-			payloadRaw:         normalized,
-			rawForHash:         trimmed,
-			promptCacheKey:     promptCacheKey,
-			previousResponseID: previousResponseID,
-			originalModel:      originalModel,
-			payloadBytes:       len(normalized),
+			payloadRaw:               normalized,
+			rawForHash:               trimmed,
+			promptCacheKey:           promptCacheKey,
+			previousResponseID:       previousResponseID,
+			previousResponseIDSource: previousResponseIDSource,
+			originalModel:            originalModel,
+			payloadBytes:             len(normalized),
 		}, nil
 	}
 
@@ -2550,17 +2689,27 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 
 	preferredConnID := ""
+	preferredConnSource := "none"
+	responseConnHit := false
+	sessionConnHit := false
+	storeDisabled := s.isOpenAIWSStoreDisabledInRequestRaw(firstPayload.payloadRaw, account)
+	storeDisabledConnMode := s.openAIWSStoreDisabledConnMode()
 	if stateStore != nil && firstPayload.previousResponseID != "" {
 		if connID, ok := stateStore.GetResponseConn(firstPayload.previousResponseID); ok {
 			preferredConnID = connID
+			preferredConnSource = "response_conn"
+			responseConnHit = true
 		}
 	}
-
-	storeDisabled := s.isOpenAIWSStoreDisabledInRequestRaw(firstPayload.payloadRaw, account)
-	storeDisabledConnMode := s.openAIWSStoreDisabledConnMode()
-	if stateStore != nil && storeDisabled && firstPayload.previousResponseID == "" && sessionHash != "" {
+	if preferredConnID == "" && stateStore != nil && storeDisabled && sessionHash != "" {
 		if connID, ok := stateStore.GetSessionConn(groupID, sessionHash); ok {
 			preferredConnID = connID
+			if firstPayload.previousResponseID != "" {
+				preferredConnSource = "session_conn_fallback"
+			} else {
+				preferredConnSource = "session_conn"
+			}
+			sessionConnHit = true
 		}
 	}
 
@@ -2612,12 +2761,15 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	if firstPayload.previousResponseID != "" {
 		firstPreviousResponseIDKind := ClassifyOpenAIPreviousResponseIDKind(firstPayload.previousResponseID)
 		logOpenAIWSModeInfo(
-			"ingress_ws_continuation_probe account_id=%d turn=%d previous_response_id=%s previous_response_id_kind=%s preferred_conn_id=%s session_hash=%s header_session_id=%s header_conversation_id=%s has_turn_state=%v turn_state_len=%d has_prompt_cache_key=%v store_disabled=%v",
+			"ingress_ws_continuation_probe account_id=%d turn=%d previous_response_id=%s previous_response_id_kind=%s preferred_conn_id=%s preferred_conn_source=%s response_conn_hit=%v session_conn_hit=%v session_hash=%s header_session_id=%s header_conversation_id=%s has_turn_state=%v turn_state_len=%d has_prompt_cache_key=%v store_disabled=%v",
 			account.ID,
 			1,
 			truncateOpenAIWSLogValue(firstPayload.previousResponseID, openAIWSIDValueMaxLen),
 			normalizeOpenAIWSLogValue(firstPreviousResponseIDKind),
 			truncateOpenAIWSLogValue(preferredConnID, openAIWSIDValueMaxLen),
+			normalizeOpenAIWSLogValue(preferredConnSource),
+			responseConnHit,
+			sessionConnHit,
 			truncateOpenAIWSLogValue(sessionHash, 12),
 			openAIWSHeaderValueForLog(baseAcquireReq.Headers, "session_id"),
 			openAIWSHeaderValueForLog(baseAcquireReq.Headers, "conversation_id"),
@@ -2669,6 +2821,16 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(acquireErr.Error()))
 			}
 			if errors.Is(acquireErr, errOpenAIWSPreferredConnUnavailable) {
+				responseBindingCount, sessionBindingCount := s.cleanupOpenAIWSConnBindings(preferred, "preferred_conn_unavailable")
+				logOpenAIWSModeInfo(
+					"ingress_ws_preferred_conn_unavailable_diag account_id=%d turn=%d preferred_conn_id=%s response_bindings_cleared=%d session_bindings_cleared=%d force_preferred_conn=%v",
+					account.ID,
+					turn,
+					truncateOpenAIWSLogValue(preferred, openAIWSIDValueMaxLen),
+					responseBindingCount,
+					sessionBindingCount,
+					forcePreferredConn,
+				)
 				return nil, NewOpenAIWSClientCloseError(
 					coderws.StatusPolicyViolation,
 					"upstream continuation connection is unavailable; please restart the conversation",
@@ -2685,7 +2847,19 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			return nil, acquireErr
 		}
 		connID := strings.TrimSpace(lease.ConnID())
-		if handshakeTurnState := strings.TrimSpace(lease.HandshakeHeader(openAIWSTurnStateHeader)); handshakeTurnState != "" {
+		handshakeTurnState := strings.TrimSpace(lease.HandshakeHeader(openAIWSTurnStateHeader))
+		logOpenAIWSModeInfo(
+			"ingress_ws_handshake_diag account_id=%d turn=%d conn_id=%s has_turn_state=%v turn_state_len=%d handshake_session_id=%s handshake_conversation_id=%s preferred_conn_id=%s",
+			account.ID,
+			turn,
+			truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+			handshakeTurnState != "",
+			len(handshakeTurnState),
+			openAIWSHeaderValueForLog(lease.HandshakeHeaders(), "session_id"),
+			openAIWSHeaderValueForLog(lease.HandshakeHeaders(), "conversation_id"),
+			truncateOpenAIWSLogValue(preferred, openAIWSIDValueMaxLen),
+		)
+		if handshakeTurnState != "" {
 			turnState = handshakeTurnState
 			if stateStore != nil && sessionHash != "" {
 				stateStore.BindSessionTurnState(groupID, sessionHash, handshakeTurnState, s.openAIWSSessionStickyTTL())
@@ -2731,7 +2905,14 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		return payload, nil
 	}
 
-	sendAndRelay := func(turn int, lease *openAIWSConnLease, payload []byte, payloadBytes int, originalModel string) (*OpenAIForwardResult, error) {
+	sendAndRelay := func(
+		turn int,
+		lease *openAIWSConnLease,
+		payload []byte,
+		payloadBytes int,
+		originalModel string,
+		previousResponseIDSource openAIWSPreviousResponseIDSource,
+	) (*OpenAIForwardResult, error) {
 		if lease == nil {
 			return nil, errors.New("upstream websocket lease is nil")
 		}
@@ -2808,6 +2989,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				errCode, errType, errMessage := summarizeOpenAIWSErrorEventFieldsFromRaw(errCodeRaw, errTypeRaw, errMsgRaw)
 				recoverablePrevNotFound := fallbackReason == openAIWSIngressStagePreviousResponseNotFound &&
 					turnPreviousResponseID != "" &&
+					previousResponseIDSource != openAIWSPreviousResponseIDSourceExplicit &&
 					!turnHasFunctionCallOutput &&
 					s.openAIWSIngressPreviousResponseRecoveryEnabled() &&
 					!wroteDownstream
@@ -2844,6 +3026,44 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 						normalizeOpenAIWSLogValue(turnPreviousResponseIDKind),
 						truncateOpenAIWSLogValue(responseID, openAIWSIDValueMaxLen),
 						turnStoreDisabled,
+						turnPromptCacheKey != "",
+					)
+				}
+				if fallbackReason == openAIWSIngressStagePreviousResponseNotFound {
+					responseConnDiag := ""
+					responseConnHit := false
+					sessionConnDiag := ""
+					sessionConnHit := false
+					if stateStore != nil && turnPreviousResponseID != "" {
+						if stickyConnID, ok := stateStore.GetResponseConn(turnPreviousResponseID); ok {
+							responseConnDiag = stickyConnID
+							responseConnHit = true
+						}
+					}
+					if stateStore != nil && turnStoreDisabled && sessionHash != "" {
+						if stickyConnID, ok := stateStore.GetSessionConn(groupID, sessionHash); ok {
+							sessionConnDiag = stickyConnID
+							sessionConnHit = true
+						}
+					}
+					logOpenAIWSModeInfo(
+						"ingress_ws_prev_response_not_found_diag account_id=%d turn=%d conn_id=%s previous_response_id=%s previous_response_id_kind=%s preferred_conn_id=%s response_conn_hit=%v response_conn_id=%s session_conn_hit=%v session_conn_id=%s session_hash=%s store_disabled=%v has_turn_state=%v turn_state_len=%d header_session_id=%s header_conversation_id=%s has_prompt_cache_key=%v",
+						account.ID,
+						turn,
+						truncateOpenAIWSLogValue(lease.ConnID(), openAIWSIDValueMaxLen),
+						truncateOpenAIWSLogValue(turnPreviousResponseID, openAIWSIDValueMaxLen),
+						normalizeOpenAIWSLogValue(turnPreviousResponseIDKind),
+						truncateOpenAIWSLogValue(preferredConnID, openAIWSIDValueMaxLen),
+						responseConnHit,
+						truncateOpenAIWSLogValue(responseConnDiag, openAIWSIDValueMaxLen),
+						sessionConnHit,
+						truncateOpenAIWSLogValue(sessionConnDiag, openAIWSIDValueMaxLen),
+						truncateOpenAIWSLogValue(sessionHash, 12),
+						turnStoreDisabled,
+						turnState != "",
+						len(turnState),
+						openAIWSHeaderValueForLog(baseAcquireReq.Headers, "session_id"),
+						openAIWSHeaderValueForLog(baseAcquireReq.Headers, "conversation_id"),
 						turnPromptCacheKey != "",
 					)
 				}
@@ -2955,7 +3175,12 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 
 	currentPayload := firstPayload.payloadRaw
 	currentOriginalModel := firstPayload.originalModel
+	currentPreviousResponseIDSource := firstPayload.previousResponseIDSource
 	currentPayloadBytes := firstPayload.payloadBytes
+	explicitContinuationTurn := func() bool {
+		return currentPreviousResponseIDSource == openAIWSPreviousResponseIDSourceExplicit &&
+			strings.TrimSpace(openAIWSPayloadStringFromRaw(currentPayload, "previous_response_id")) != ""
+	}
 	isStrictAffinityTurn := func(payload []byte) bool {
 		if !storeDisabled {
 			return false
@@ -3038,6 +3263,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 	recoverIngressPrevResponseNotFound := func(relayErr error, turn int, connID string) bool {
 		if !isOpenAIWSIngressPreviousResponseNotFound(relayErr) {
+			return false
+		}
+		if explicitContinuationTurn() {
 			return false
 		}
 		if turnPrevRecoveryTried || !s.openAIWSIngressPreviousResponseRecoveryEnabled() {
@@ -3156,6 +3384,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				currentPayload = updatedPayload
 				currentPayloadBytes = len(updatedPayload)
 				currentPreviousResponseID = expectedPrev
+				currentPreviousResponseIDSource = openAIWSPreviousResponseIDSourceInferred
 				logOpenAIWSModeInfo(
 					"ingress_ws_function_call_output_prev_infer account_id=%d turn=%d conn_id=%s action=set_previous_response_id previous_response_id=%s",
 					account.ID,
@@ -3217,6 +3446,13 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					hasFunctionCallOutput,
 				)
 			} else if !shouldKeepPreviousResponseID {
+				if explicitContinuationTurn() {
+					return NewOpenAIWSClientCloseError(
+						coderws.StatusPolicyViolation,
+						"upstream continuation context is unavailable; please restart the conversation",
+						nil,
+					)
+				}
 				updatedPayload, removed, dropErr := dropPreviousResponseIDFromRawPayload(currentPayload)
 				if dropErr != nil || !removed {
 					dropReason := "not_removed"
@@ -3270,7 +3506,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				}
 			}
 		}
-		forcePreferredConn := isStrictAffinityTurn(currentPayload)
+		forcePreferredConn := isStrictAffinityTurn(currentPayload) && strings.TrimSpace(preferredConnID) != ""
 		if sessionLease == nil {
 			acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn)
 			if acquireErr != nil {
@@ -3292,14 +3528,25 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		}
 		if shouldPreflightPing {
 			if pingErr := sessionLease.PingWithTimeout(openAIWSConnHealthCheckTO); pingErr != nil {
+				responseBindingCount, sessionBindingCount := s.cleanupOpenAIWSConnBindings(sessionConnID, "preflight_ping_fail")
 				logOpenAIWSModeInfo(
-					"ingress_ws_upstream_preflight_ping_fail account_id=%d turn=%d conn_id=%s cause=%s",
+					"ingress_ws_upstream_preflight_ping_fail account_id=%d turn=%d conn_id=%s cause=%s response_bindings_cleared=%d session_bindings_cleared=%d",
 					account.ID,
 					turn,
 					truncateOpenAIWSLogValue(sessionConnID, openAIWSIDValueMaxLen),
 					truncateOpenAIWSLogValue(pingErr.Error(), openAIWSLogValueMaxLen),
+					responseBindingCount,
+					sessionBindingCount,
 				)
 				if forcePreferredConn {
+					if explicitContinuationTurn() {
+						resetSessionLease(true)
+						return NewOpenAIWSClientCloseError(
+							coderws.StatusPolicyViolation,
+							"upstream continuation connection is unavailable; please restart the conversation",
+							pingErr,
+						)
+					}
 					if !turnPrevRecoveryTried && currentPreviousResponseID != "" {
 						updatedPayload, removed, dropErr := dropPreviousResponseIDFromRawPayload(currentPayload)
 						if dropErr != nil || !removed {
@@ -3390,7 +3637,14 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			)
 		}
 
-		result, relayErr := sendAndRelay(turn, sessionLease, currentPayload, currentPayloadBytes, currentOriginalModel)
+		result, relayErr := sendAndRelay(
+			turn,
+			sessionLease,
+			currentPayload,
+			currentPayloadBytes,
+			currentOriginalModel,
+			currentPreviousResponseIDSource,
+		)
 		if relayErr != nil {
 			lastTurnClean = false
 			if recoverIngressPrevResponseNotFound(relayErr, turn, connID) {
@@ -3446,6 +3700,34 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if stateStore != nil && storeDisabled && sessionHash != "" {
 			stateStore.BindSessionConn(groupID, sessionHash, connID, s.openAIWSSessionStickyTTL())
 		}
+		responseConnCommitted := false
+		sessionConnCommitted := false
+		if stateStore != nil && responseID != "" {
+			if committedConnID, ok := stateStore.GetResponseConn(responseID); ok && strings.TrimSpace(committedConnID) == strings.TrimSpace(connID) {
+				responseConnCommitted = true
+			}
+		}
+		if stateStore != nil && storeDisabled && sessionHash != "" {
+			if committedConnID, ok := stateStore.GetSessionConn(groupID, sessionHash); ok && strings.TrimSpace(committedConnID) == strings.TrimSpace(connID) {
+				sessionConnCommitted = true
+			}
+		}
+		logOpenAIWSModeInfo(
+			"ingress_ws_continuation_commit account_id=%d turn=%d conn_id=%s response_id=%s session_hash=%s store_disabled=%v response_conn_committed=%v session_conn_committed=%v has_turn_state=%v turn_state_len=%d header_session_id=%s header_conversation_id=%s has_prompt_cache_key=%v",
+			account.ID,
+			turn,
+			truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+			truncateOpenAIWSLogValue(responseID, openAIWSIDValueMaxLen),
+			truncateOpenAIWSLogValue(sessionHash, 12),
+			storeDisabled,
+			responseConnCommitted,
+			sessionConnCommitted,
+			turnState != "",
+			len(turnState),
+			openAIWSHeaderValueForLog(baseAcquireReq.Headers, "session_id"),
+			openAIWSHeaderValueForLog(baseAcquireReq.Headers, "conversation_id"),
+			openAIWSPayloadStringFromRaw(currentPayload, "prompt_cache_key") != "",
+		)
 		if connID != "" {
 			preferredConnID = connID
 		}
@@ -3512,6 +3794,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		}
 		currentPayload = nextPayload.payloadRaw
 		currentOriginalModel = nextPayload.originalModel
+		currentPreviousResponseIDSource = nextPayload.previousResponseIDSource
 		currentPayloadBytes = nextPayload.payloadBytes
 		storeDisabled = s.isOpenAIWSStoreDisabledInRequestRaw(currentPayload, account)
 		if !storeDisabled {

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -532,7 +532,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_ModeOffReturnsPo
 	}
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPrevResponseStrictDropToFullCreate(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPrevResponseStrictFailsClosedForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := &config.Config{}
@@ -553,7 +553,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 	captureConn := &openAIWSCaptureConn{
 		events: [][]byte{
 			[]byte(`{"type":"response.completed","response":{"id":"resp_preflight_rewrite_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
-			[]byte(`{"type":"response.completed","response":{"id":"resp_preflight_rewrite_2","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+			[]byte(`{"type":"error","error":{"type":"invalid_request_error","code":"previous_response_not_found","message":"strict continuation unavailable"}}`),
 		},
 	}
 	captureDialer := &openAIWSCaptureDialer{conn: captureConn}
@@ -648,10 +648,183 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 	require.Equal(t, "resp_preflight_rewrite_1", gjson.GetBytes(firstTurn, "response.id").String())
 
 	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"previous_response_id":"resp_stale_external","input":[{"type":"input_text","text":"world"}]}`)
-	secondTurn := readMessage()
-	require.Equal(t, "resp_preflight_rewrite_2", gjson.GetBytes(secondTurn, "response.id").String())
+	readCtx2, cancel2 := context.WithTimeout(context.Background(), 3*time.Second)
+	_, _, readErr2 := clientConn.Read(readCtx2)
+	cancel2()
+	require.Error(t, readErr2)
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
+	select {
+	case serverErr := <-serverErrCh:
+		require.Error(t, serverErr)
+		var closeErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, serverErr, &closeErr)
+		require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
+		require.Contains(t, closeErr.Reason(), "continuation context is unavailable")
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待 ingress websocket 结束超时")
+	}
+
+	require.Equal(t, 1, captureDialer.DialCount(), "显式 strict continuation 失败时不应在同一连接内降级为 full create")
+	require.Len(t, captureConn.writes, 1, "strict eval 失败应在发送第二轮前直接 fail-close")
+}
+
+func TestShouldKeepIngressPreviousResponseIDWithStrictState_AllowsGenerateFalsePrewarmBusinessContinuation(t *testing.T) {
+	previousPayload := []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"pk_prewarm","generate":false,"input":[]}`)
+	currentPayload := []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"pk_prewarm","previous_response_id":"resp_prewarm_seed_1","input":[{"type":"input_text","text":"hello"}]}`)
+
+	strictState, err := buildOpenAIWSIngressPreviousTurnStrictState(previousPayload)
+	require.NoError(t, err)
+
+	keep, reason, err := shouldKeepIngressPreviousResponseIDWithStrictState(
+		strictState,
+		currentPayload,
+		"resp_prewarm_seed_1",
+		false,
+	)
+	require.NoError(t, err)
+	require.True(t, keep)
+	require.Equal(t, "prewarm_business_ok", reason)
+}
+
+func TestShouldKeepIngressPreviousResponseIDWithStrictState_RejectsChangedModelAfterPrewarm(t *testing.T) {
+	previousPayload := []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"pk_prewarm","generate":false,"input":[]}`)
+	currentPayload := []byte(`{"type":"response.create","model":"gpt-5.2","stream":false,"store":false,"prompt_cache_key":"pk_prewarm","previous_response_id":"resp_prewarm_seed_1","input":[{"type":"input_text","text":"hello"}]}`)
+
+	strictState, err := buildOpenAIWSIngressPreviousTurnStrictState(previousPayload)
+	require.NoError(t, err)
+
+	keep, reason, err := shouldKeepIngressPreviousResponseIDWithStrictState(
+		strictState,
+		currentPayload,
+		"resp_prewarm_seed_1",
+		false,
+	)
+	require.NoError(t, err)
+	require.False(t, keep)
+	require.Equal(t, "non_input_changed", reason)
+}
+
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledGenerateFalsePrewarmAllowsBusinessContinuation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	captureConn := &openAIWSCaptureConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.completed","response":{"id":"resp_prewarm_seed_1","model":"gpt-5.1","usage":{"input_tokens":0,"output_tokens":0}}}`),
+			[]byte(`{"type":"response.completed","response":{"id":"resp_business_turn_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		},
+	}
+	captureDialer := &openAIWSCaptureDialer{conn: captureConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(captureDialer)
+
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+
+	account := &Account{
+		ID:          141,
+		Name:        "openai-ingress-packet-prewarm-business",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-test",
+		},
+		Extra: map[string]any{
+			"responses_websockets_v2_enabled": true,
+		},
+	}
+
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{
+			CompressionMode: coderws.CompressionContextTakeover,
+		})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.CloseNow()
+		}()
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		req := r.Clone(r.Context())
+		req.Header = req.Header.Clone()
+		req.Header.Set("User-Agent", "unit-test-agent/1.0")
+		ginCtx.Request = req
+
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErrCh <- errors.New("unsupported websocket client message type")
+			return
+		}
+
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, nil)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() {
+		_ = clientConn.CloseNow()
+	}()
+
+	writeMessage := func(payload string) {
+		writeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(payload)))
+	}
+	readMessage := func() []byte {
+		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		msgType, message, readErr := clientConn.Read(readCtx)
+		require.NoError(t, readErr)
+		require.Equal(t, coderws.MessageText, msgType)
+		return message
+	}
+
+	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"pk_prewarm","generate":false,"input":[]}`)
+	firstTurn := readMessage()
+	require.Equal(t, "resp_prewarm_seed_1", gjson.GetBytes(firstTurn, "response.id").String())
+
+	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"pk_prewarm","previous_response_id":"resp_prewarm_seed_1","input":[{"type":"input_text","text":"hello"}]}`)
+	secondTurn := readMessage()
+	require.Equal(t, "resp_business_turn_1", gjson.GetBytes(secondTurn, "response.id").String())
+
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -659,16 +832,15 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 		t.Fatal("等待 ingress websocket 结束超时")
 	}
 
-	require.Equal(t, 1, captureDialer.DialCount(), "严格增量不成立时应在同一连接内降级为 full create")
-	require.Len(t, captureConn.writes, 2)
-	secondWrite := requestToJSONString(captureConn.writes[1])
-	require.False(t, gjson.Get(secondWrite, "previous_response_id").Exists(), "严格增量不成立时应移除 previous_response_id，改为 full create")
-	require.Equal(t, 2, len(gjson.Get(secondWrite, "input").Array()), "严格降级为 full create 时应重放完整 input 上下文")
-	require.Equal(t, "hello", gjson.Get(secondWrite, "input.0.text").String())
-	require.Equal(t, "world", gjson.Get(secondWrite, "input.1.text").String())
+	require.Equal(t, 1, captureDialer.DialCount(), "官方 prewarm->business 应复用同一连接")
+	require.Len(t, captureConn.writes, 2, "第二轮 business continuation 应真正写到上游")
+	require.Equal(t, false, gjson.Get(requestToJSONString(captureConn.writes[0]), "generate").Bool())
+	require.False(t, gjson.Get(requestToJSONString(captureConn.writes[0]), "previous_response_id").Exists())
+	require.Equal(t, "resp_prewarm_seed_1", gjson.Get(requestToJSONString(captureConn.writes[1]), "previous_response_id").String())
+	require.False(t, gjson.Get(requestToJSONString(captureConn.writes[1]), "generate").Exists(), "business create 不应被强制保留 generate=false")
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPrevResponseStrictDropBeforePreflightPingFailReconnects(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPrevResponseStrictPreflightPingFailFailsClosedForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	prevPreflightPingIdle := openAIWSIngressPreflightPingIdle
 	openAIWSIngressPreflightPingIdle = 0
@@ -795,29 +967,28 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 	require.Equal(t, "resp_turn_ping_drop_1", gjson.GetBytes(firstTurn, "response.id").String())
 
 	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"previous_response_id":"resp_stale_external","input":[{"type":"input_text","text":"world"}]}`)
-	secondTurn := readMessage()
-	require.Equal(t, "resp_turn_ping_drop_2", gjson.GetBytes(secondTurn, "response.id").String())
+	readCtx2, cancel2 := context.WithTimeout(context.Background(), 3*time.Second)
+	_, _, readErr2 := clientConn.Read(readCtx2)
+	cancel2()
+	require.Error(t, readErr2)
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
-		require.NoError(t, serverErr)
+		require.Error(t, serverErr)
+		var closeErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, serverErr, &closeErr)
+		require.Equal(t, coderws.StatusPolicyViolation, closeErr.StatusCode())
+		require.Contains(t, closeErr.Reason(), "continuation")
 	case <-time.After(5 * time.Second):
-		t.Fatal("等待 ingress websocket 严格降级后预检换连超时")
+		t.Fatal("等待 ingress websocket 结束超时")
 	}
 
-	require.Equal(t, 2, dialer.DialCount(), "严格降级为 full create 后，预检 ping 失败应允许换连")
-	require.Equal(t, 1, firstConn.WriteCount(), "首连接在预检失败后不应继续发送第二轮")
-	require.GreaterOrEqual(t, firstConn.PingCount(), 1, "第二轮前应执行 preflight ping")
+	require.Equal(t, 1, dialer.DialCount(), "显式 strict continuation 失败时不应在同一连接内降级为 full create")
 	secondConn.mu.Lock()
 	secondWrites := append([]map[string]any(nil), secondConn.writes...)
 	secondConn.mu.Unlock()
-	require.Len(t, secondWrites, 1)
-	secondWrite := requestToJSONString(secondWrites[0])
-	require.False(t, gjson.Get(secondWrite, "previous_response_id").Exists(), "严格降级后重试应移除 previous_response_id")
-	require.Equal(t, 2, len(gjson.Get(secondWrite, "input").Array()))
-	require.Equal(t, "hello", gjson.Get(secondWrite, "input.0.text").String())
-	require.Equal(t, "world", gjson.Get(secondWrite, "input.1.text").String())
+	require.Len(t, secondWrites, 0, "显式 continuation 失败时不应在第二个连接发送恢复请求")
 }
 
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreEnabledSkipsStrictPrevResponseEval(t *testing.T) {
@@ -939,7 +1110,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreEnabledSkip
 	secondTurn := readMessage()
 	require.Equal(t, "resp_store_enabled_2", gjson.GetBytes(secondTurn, "response.id").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -1071,7 +1242,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 	secondTurn := readMessage()
 	require.Equal(t, "resp_preflight_skip_2", gjson.GetBytes(secondTurn, "response.id").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -1082,6 +1253,126 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledPre
 	require.Equal(t, 1, captureDialer.DialCount())
 	require.Len(t, captureConn.writes, 2)
 	require.Equal(t, "resp_stale_external", gjson.Get(requestToJSONString(captureConn.writes[1]), "previous_response_id").String(), "function_call_output 场景不应预改写 previous_response_id")
+}
+
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledExplicitPrevResponseWithoutPreferredConnFallsBackToFreshConn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	captureConn := &openAIWSCaptureConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.completed","response":{"id":"resp_missing_pref_ok","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		},
+	}
+	captureDialer := &openAIWSCaptureDialer{conn: captureConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(captureDialer)
+
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+
+	account := &Account{
+		ID:          142,
+		Name:        "openai-ingress-prev-without-preferred-conn",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-test",
+		},
+		Extra: map[string]any{
+			"responses_websockets_v2_enabled": true,
+		},
+	}
+
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{
+			CompressionMode: coderws.CompressionContextTakeover,
+		})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.CloseNow()
+		}()
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		req := r.Clone(r.Context())
+		req.Header = req.Header.Clone()
+		req.Header.Set("User-Agent", "unit-test-agent/1.0")
+		ginCtx.Request = req
+
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErrCh <- errors.New("unsupported websocket client message type")
+			return
+		}
+
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, nil)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() {
+		_ = clientConn.CloseNow()
+	}()
+
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"previous_response_id":"resp_missing_pref_external","input":[{"type":"input_text","text":"hello"}]}`)))
+	cancelWrite()
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	msgType, message, readErr := clientConn.Read(readCtx)
+	cancelRead()
+	require.NoError(t, readErr)
+	require.Equal(t, coderws.MessageText, msgType)
+	require.Equal(t, "resp_missing_pref_ok", gjson.GetBytes(message, "response.id").String())
+
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
+	select {
+	case serverErr := <-serverErrCh:
+		require.NoError(t, serverErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待显式 previous_response_id 无 preferred_conn 场景结束超时")
+	}
+
+	require.Equal(t, 1, captureDialer.DialCount())
+	require.Len(t, captureConn.writes, 1)
+	require.Equal(t, "resp_missing_pref_external", gjson.Get(requestToJSONString(captureConn.writes[0]), "previous_response_id").String(), "缺少 preferred_conn 绑定时不应在发上游前直接 fail-close")
 }
 
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledFunctionCallOutputAutoAttachPreviousResponseID(t *testing.T) {
@@ -1203,7 +1494,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledFun
 	secondTurn := readMessage()
 	require.Equal(t, "resp_auto_prev_2", gjson.GetBytes(secondTurn, "response.id").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -1336,7 +1627,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledFun
 	secondTurn := readMessage()
 	require.Equal(t, "resp_auto_prev_skip_2", gjson.GetBytes(secondTurn, "response.id").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -1479,7 +1770,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreflightPingFai
 	secondTurn := readMessage()
 	require.Equal(t, "resp_turn_ping_2", gjson.GetBytes(secondTurn, "response.id").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -1491,7 +1782,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreflightPingFai
 	require.GreaterOrEqual(t, firstConn.PingCount(), 1, "第二轮前应对旧连接执行 preflight ping")
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStrictAffinityPreflightPingFailAutoRecoveryReconnects(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStrictAffinityPreflightPingFailFailsClosedForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	prevPreflightPingIdle := openAIWSIngressPreflightPingIdle
 	openAIWSIngressPreflightPingIdle = 0
@@ -1618,29 +1909,27 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStr
 	require.Equal(t, "resp_turn_ping_strict_1", gjson.GetBytes(firstTurn, "response.id").String())
 
 	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"previous_response_id":"resp_turn_ping_strict_1","input":[{"type":"input_text","text":"world"}]}`)
-	secondTurn := readMessage()
-	require.Equal(t, "resp_turn_ping_strict_2", gjson.GetBytes(secondTurn, "response.id").String())
+	readCtx2, cancel2 := context.WithTimeout(context.Background(), 3*time.Second)
+	_, _, readErr2 := clientConn.Read(readCtx2)
+	cancel2()
+	require.Error(t, readErr2)
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
-		require.NoError(t, serverErr)
+		require.Error(t, serverErr)
+		require.Contains(t, strings.ToLower(serverErr.Error()), "continuation connection is unavailable")
 	case <-time.After(5 * time.Second):
-		t.Fatal("等待 ingress websocket 严格亲和自动恢复后结束超时")
+		t.Fatal("等待 ingress websocket 严格亲和失败结束超时")
 	}
 
-	require.Equal(t, 2, dialer.DialCount(), "严格亲和 preflight ping 失败后应自动降级并换连重放")
+	require.Equal(t, 1, dialer.DialCount(), "显式 strict continuation preflight ping 失败时不应自动换连恢复")
 	require.Equal(t, 1, firstConn.WriteCount(), "preflight ping 失败后不应继续在旧连接写第二轮")
 	require.GreaterOrEqual(t, firstConn.PingCount(), 1, "第二轮前应执行 preflight ping")
 	secondConn.mu.Lock()
 	secondWrites := append([]map[string]any(nil), secondConn.writes...)
 	secondConn.mu.Unlock()
-	require.Len(t, secondWrites, 1)
-	secondWrite := requestToJSONString(secondWrites[0])
-	require.False(t, gjson.Get(secondWrite, "previous_response_id").Exists(), "自动恢复重放应移除 previous_response_id")
-	require.Equal(t, 2, len(gjson.Get(secondWrite, "input").Array()), "自动恢复重放应使用完整 input 上下文")
-	require.Equal(t, "hello", gjson.Get(secondWrite, "input.0.text").String())
-	require.Equal(t, "world", gjson.Get(secondWrite, "input.1.text").String())
+	require.Len(t, secondWrites, 0, "显式 strict continuation preflight ping 失败时不应发送恢复重试请求")
 }
 
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeDownstreamRetriesOnce(t *testing.T) {
@@ -1784,7 +2073,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeD
 	secondTurn := readMessage()
 	require.Equal(t, "resp_turn_write_retry_2", gjson.GetBytes(secondTurn, "response.id").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
 		require.NoError(t, serverErr)
@@ -1804,7 +2093,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_WriteFailBeforeD
 	require.Equal(t, 1, afterTurn2, "第二轮 turn AfterTurn 应执行一次")
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponseNotFoundRecoversByDroppingPrevID(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponseNotFoundFailsClosedForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := &config.Config{}
@@ -1929,18 +2218,19 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponse
 
 	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"previous_response_id":"resp_turn_prev_recover_1"}`)
 	secondTurn := readMessage()
-	require.Equal(t, "response.completed", gjson.GetBytes(secondTurn, "type").String())
-	require.Equal(t, "resp_turn_prev_recover_2", gjson.GetBytes(secondTurn, "response.id").String())
+	require.Equal(t, "error", gjson.GetBytes(secondTurn, "type").String())
+	require.Equal(t, "previous_response_not_found", gjson.GetBytes(secondTurn, "error.code").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
-		require.NoError(t, serverErr)
+		require.Error(t, serverErr)
+		require.Contains(t, strings.ToLower(serverErr.Error()), "eof")
 	case <-time.After(5 * time.Second):
 		t.Fatal("等待 ingress websocket 结束超时")
 	}
 
-	require.Equal(t, 2, dialer.DialCount(), "previous_response_not_found 恢复应触发换连重试")
+	require.Equal(t, 1, dialer.DialCount(), "显式 previous_response_id 命中 previous_response_not_found 时不应自动换连恢复")
 
 	firstConn.mu.Lock()
 	firstWrites := append([]map[string]any(nil), firstConn.writes...)
@@ -1951,11 +2241,10 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponse
 	secondConn.mu.Lock()
 	secondWrites := append([]map[string]any(nil), secondConn.writes...)
 	secondConn.mu.Unlock()
-	require.Len(t, secondWrites, 1, "恢复重试应在第二个连接发送一次请求")
-	require.False(t, gjson.Get(requestToJSONString(secondWrites[0]), "previous_response_id").Exists(), "恢复重试应移除 previous_response_id")
+	require.Len(t, secondWrites, 0, "显式 continuation 失败时不应发送去锚点恢复请求")
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStrictAffinityPreviousResponseNotFoundLayer2Recovery(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStrictAffinityPreviousResponseNotFoundFailsClosedForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := &config.Config{}
@@ -2080,17 +2369,19 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStr
 
 	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"pk_strict_layer2","previous_response_id":"resp_turn_prev_strict_recover_1","input":[{"type":"input_text","text":"world"}]}`)
 	secondTurn := readMessage()
-	require.Equal(t, "resp_turn_prev_strict_recover_2", gjson.GetBytes(secondTurn, "response.id").String())
+	require.Equal(t, "error", gjson.GetBytes(secondTurn, "type").String())
+	require.Equal(t, "previous_response_not_found", gjson.GetBytes(secondTurn, "error.code").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
-		require.NoError(t, serverErr)
+		require.Error(t, serverErr)
+		require.Contains(t, strings.ToLower(serverErr.Error()), "eof")
 	case <-time.After(5 * time.Second):
-		t.Fatal("等待 ingress websocket 严格亲和 Layer2 恢复结束超时")
+		t.Fatal("等待 ingress websocket 严格亲和失败结束超时")
 	}
 
-	require.Equal(t, 2, dialer.DialCount(), "严格亲和链路命中 previous_response_not_found 应触发 Layer2 恢复重试")
+	require.Equal(t, 1, dialer.DialCount(), "显式 strict continuation 命中 previous_response_not_found 时不应触发 Layer2 恢复重试")
 
 	firstConn.mu.Lock()
 	firstWrites := append([]map[string]any(nil), firstConn.writes...)
@@ -2101,17 +2392,10 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_StoreDisabledStr
 	secondConn.mu.Lock()
 	secondWrites := append([]map[string]any(nil), secondConn.writes...)
 	secondConn.mu.Unlock()
-	require.Len(t, secondWrites, 1, "Layer2 恢复应仅重放一次")
-	secondWrite := requestToJSONString(secondWrites[0])
-	require.False(t, gjson.Get(secondWrite, "previous_response_id").Exists(), "Layer2 恢复重放应移除 previous_response_id")
-	require.True(t, gjson.Get(secondWrite, "store").Exists(), "Layer2 恢复不应改变 store 标志")
-	require.False(t, gjson.Get(secondWrite, "store").Bool())
-	require.Equal(t, 2, len(gjson.Get(secondWrite, "input").Array()), "Layer2 恢复应重放完整 input 上下文")
-	require.Equal(t, "hello", gjson.Get(secondWrite, "input.0.text").String())
-	require.Equal(t, "world", gjson.Get(secondWrite, "input.1.text").String())
+	require.Len(t, secondWrites, 0, "显式 strict continuation 失败时不应发送 Layer2 去锚点恢复请求")
 }
 
-func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponseNotFoundRecoveryRemovesDuplicatePrevID(t *testing.T) {
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponseNotFoundDuplicatePrevIDFailsClosedForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	cfg := &config.Config{}
@@ -2234,20 +2518,22 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponse
 	firstTurn := readMessage()
 	require.Equal(t, "resp_turn_prev_once_1", gjson.GetBytes(firstTurn, "response.id").String())
 
-	// duplicate previous_response_id: 恢复重试时应删除所有重复键，避免再次 previous_response_not_found。
+	// duplicate previous_response_id: 显式 continuation 失败时应 fail-close，不再进入恢复重试。
 	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"previous_response_id":"resp_turn_prev_once_1","input":[],"previous_response_id":"resp_turn_prev_duplicate"}`)
 	secondTurn := readMessage()
-	require.Equal(t, "resp_turn_prev_once_2", gjson.GetBytes(secondTurn, "response.id").String())
+	require.Equal(t, "error", gjson.GetBytes(secondTurn, "type").String())
+	require.Equal(t, "previous_response_not_found", gjson.GetBytes(secondTurn, "error.code").String())
 
-	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
 	select {
 	case serverErr := <-serverErrCh:
-		require.NoError(t, serverErr)
+		require.Error(t, serverErr)
+		require.Contains(t, strings.ToLower(serverErr.Error()), "eof")
 	case <-time.After(5 * time.Second):
 		t.Fatal("等待 ingress websocket 结束超时")
 	}
 
-	require.Equal(t, 2, dialer.DialCount(), "previous_response_not_found 恢复应只重试一次")
+	require.Equal(t, 1, dialer.DialCount(), "显式 previous_response_not_found 失败时不应触发恢复重试")
 
 	firstConn.mu.Lock()
 	firstWrites := append([]map[string]any(nil), firstConn.writes...)
@@ -2258,8 +2544,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PreviousResponse
 	secondConn.mu.Lock()
 	secondWrites := append([]map[string]any(nil), secondConn.writes...)
 	secondConn.mu.Unlock()
-	require.Len(t, secondWrites, 1)
-	require.False(t, gjson.Get(requestToJSONString(secondWrites[0]), "previous_response_id").Exists(), "重复键场景恢复重试后不应保留 previous_response_id")
+	require.Len(t, secondWrites, 0, "显式 duplicate prev 失败时不应发送恢复重试请求")
 }
 
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_RejectsMessageIDAsPreviousResponseID(t *testing.T) {

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -559,6 +559,9 @@ type openAIWSConnPool struct {
 
 	metrics openAIWSPoolMetrics
 
+	connClosedHookMu sync.RWMutex
+	connClosedHook   func(connID string)
+
 	workerStopCh chan struct{}
 	workerWg     sync.WaitGroup
 	closeOnce    sync.Once
@@ -608,6 +611,44 @@ func (p *openAIWSConnPool) setClientDialerForTest(dialer openAIWSClientDialer) {
 	p.clientDialer = dialer
 }
 
+func (p *openAIWSConnPool) setConnClosedHook(hook func(connID string)) {
+	if p == nil || hook == nil {
+		return
+	}
+	p.connClosedHookMu.Lock()
+	p.connClosedHook = hook
+	p.connClosedHookMu.Unlock()
+}
+
+func (p *openAIWSConnPool) getConnClosedHook() func(connID string) {
+	if p == nil {
+		return nil
+	}
+	p.connClosedHookMu.RLock()
+	defer p.connClosedHookMu.RUnlock()
+	return p.connClosedHook
+}
+
+func (p *openAIWSConnPool) closeConn(conn *openAIWSConn) {
+	if conn == nil {
+		return
+	}
+	connID := stringsTrim(conn.id)
+	conn.close()
+	if hook := p.getConnClosedHook(); hook != nil && connID != "" {
+		hook(connID)
+	}
+}
+
+func (p *openAIWSConnPool) closeConns(conns []*openAIWSConn) {
+	if p == nil || len(conns) == 0 {
+		return
+	}
+	for _, conn := range conns {
+		p.closeConn(conn)
+	}
+}
+
 // Close 停止后台 worker 并关闭所有空闲连接，应在优雅关闭时调用。
 func (p *openAIWSConnPool) Close() {
 	if p == nil {
@@ -627,7 +668,7 @@ func (p *openAIWSConnPool) Close() {
 			ap.mu.Lock()
 			for _, conn := range ap.conns {
 				if conn != nil && !conn.isLeased() {
-					conn.close()
+					p.closeConn(conn)
 				}
 			}
 			ap.mu.Unlock()
@@ -767,7 +808,7 @@ func (p *openAIWSConnPool) runBackgroundCleanupSweep(now time.Time) {
 		return true
 	})
 	for _, result := range results {
-		closeOpenAIWSConns(result.evicted)
+		p.closeConns(result.evicted)
 	}
 }
 
@@ -810,21 +851,21 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 			if preferredConnID == "" {
 				p.recordConnPickDuration(time.Since(pickStartedAt))
 				ap.mu.Unlock()
-				closeOpenAIWSConns(evicted)
+				p.closeConns(evicted)
 				return nil, errOpenAIWSPreferredConnUnavailable
 			}
 			preferredConn, ok := ap.conns[preferredConnID]
 			if !ok || preferredConn == nil {
 				p.recordConnPickDuration(time.Since(pickStartedAt))
 				ap.mu.Unlock()
-				closeOpenAIWSConns(evicted)
+				p.closeConns(evicted)
 				return nil, errOpenAIWSPreferredConnUnavailable
 			}
 			if preferredConn.tryAcquire() {
 				connPick := time.Since(pickStartedAt)
 				p.recordConnPickDuration(connPick)
 				ap.mu.Unlock()
-				closeOpenAIWSConns(evicted)
+				p.closeConns(evicted)
 				if p.shouldHealthCheckConn(preferredConn) {
 					if err := preferredConn.pingWithTimeout(openAIWSConnHealthCheckTO); err != nil {
 						preferredConn.close()
@@ -851,12 +892,12 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 			p.recordConnPickDuration(connPick)
 			if int(preferredConn.waiters.Load()) >= p.queueLimitPerConn() {
 				ap.mu.Unlock()
-				closeOpenAIWSConns(evicted)
+				p.closeConns(evicted)
 				return nil, errOpenAIWSConnQueueFull
 			}
 			preferredConn.waiters.Add(1)
 			ap.mu.Unlock()
-			closeOpenAIWSConns(evicted)
+			p.closeConns(evicted)
 			defer preferredConn.waiters.Add(-1)
 			waitStart := time.Now()
 			p.metrics.acquireQueueWaitTotal.Add(1)
@@ -899,7 +940,7 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 				connPick := time.Since(pickStartedAt)
 				p.recordConnPickDuration(connPick)
 				ap.mu.Unlock()
-				closeOpenAIWSConns(evicted)
+				p.closeConns(evicted)
 				if p.shouldHealthCheckConn(conn) {
 					if err := conn.pingWithTimeout(openAIWSConnHealthCheckTO); err != nil {
 						conn.close()
@@ -922,7 +963,7 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 			connPick := time.Since(pickStartedAt)
 			p.recordConnPickDuration(connPick)
 			ap.mu.Unlock()
-			closeOpenAIWSConns(evicted)
+			p.closeConns(evicted)
 			if p.shouldHealthCheckConn(best) {
 				if err := best.pingWithTimeout(openAIWSConnHealthCheckTO); err != nil {
 					best.close()
@@ -946,7 +987,7 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 				connPick := time.Since(pickStartedAt)
 				p.recordConnPickDuration(connPick)
 				ap.mu.Unlock()
-				closeOpenAIWSConns(evicted)
+				p.closeConns(evicted)
 				if p.shouldHealthCheckConn(conn) {
 					if err := conn.pingWithTimeout(openAIWSConnHealthCheckTO); err != nil {
 						conn.close()
@@ -978,7 +1019,7 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 		p.recordConnPickDuration(connPick)
 		ap.creating++
 		ap.mu.Unlock()
-		closeOpenAIWSConns(evicted)
+		p.closeConns(evicted)
 
 		conn, dialErr := p.dialConn(ctx, req)
 
@@ -1012,7 +1053,7 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 	if req.ForceNewConn {
 		p.recordConnPickDuration(time.Since(pickStartedAt))
 		ap.mu.Unlock()
-		closeOpenAIWSConns(evicted)
+		p.closeConns(evicted)
 		return nil, errOpenAIWSConnQueueFull
 	}
 
@@ -1021,17 +1062,17 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 	p.recordConnPickDuration(connPick)
 	if target == nil {
 		ap.mu.Unlock()
-		closeOpenAIWSConns(evicted)
+		p.closeConns(evicted)
 		return nil, errOpenAIWSConnClosed
 	}
 	if int(target.waiters.Load()) >= p.queueLimitPerConn() {
 		ap.mu.Unlock()
-		closeOpenAIWSConns(evicted)
+		p.closeConns(evicted)
 		return nil, errOpenAIWSConnQueueFull
 	}
 	target.waiters.Add(1)
 	ap.mu.Unlock()
-	closeOpenAIWSConns(evicted)
+	p.closeConns(evicted)
 	defer target.waiters.Add(-1)
 	waitStart := time.Now()
 	p.metrics.acquireQueueWaitTotal.Add(1)
@@ -1384,7 +1425,7 @@ func (p *openAIWSConnPool) prewarmConns(accountID int64, req openAIWSAcquireRequ
 		ap, ok := p.getAccountPool(accountID)
 		if !ok || ap == nil {
 			if conn != nil {
-				conn.close()
+				p.closeConn(conn)
 			}
 			return
 		}
@@ -1400,7 +1441,7 @@ func (p *openAIWSConnPool) prewarmConns(accountID int64, req openAIWSAcquireRequ
 		}
 		if len(ap.conns) >= p.effectiveMaxConnsByAccount(req.Account) {
 			ap.mu.Unlock()
-			conn.close()
+			p.closeConn(conn)
 			continue
 		}
 		ap.conns[conn.id] = conn
@@ -1428,7 +1469,7 @@ func (p *openAIWSConnPool) evictConn(accountID int64, connID string) {
 		ap.mu.Unlock()
 	}
 	if conn != nil {
-		conn.close()
+		p.closeConn(conn)
 	}
 }
 

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -842,6 +842,33 @@ func TestOpenAIWSConnPool_QueueLimitPerConn_DefaultAndConfigured(t *testing.T) {
 	require.Equal(t, 9, pool.queueLimitPerConn())
 }
 
+func TestOpenAIWSConnPool_CloseConnHookCleansBindings(t *testing.T) {
+	cfg := &config.Config{}
+	pool := newOpenAIWSConnPool(cfg)
+	store := NewOpenAIWSStateStore(nil)
+	pool.setConnClosedHook(func(connID string) {
+		store.DeleteConnBindings(connID)
+	})
+
+	accountID := int64(401)
+	conn := newOpenAIWSConn("conn_cleanup_hook", accountID, &openAIWSFakeConn{}, nil)
+	ap := pool.getOrCreateAccountPool(accountID)
+	ap.mu.Lock()
+	ap.conns[conn.id] = conn
+	ap.mu.Unlock()
+
+	store.BindResponseConn("resp_cleanup_hook", conn.id, time.Minute)
+	store.BindSessionConn(9, "session_cleanup_hook", conn.id, time.Minute)
+	require.True(t, store.HasConnBindings(conn.id))
+
+	pool.evictConn(accountID, conn.id)
+	require.False(t, store.HasConnBindings(conn.id), "连接关闭后应同步清理 stale conn bindings")
+	_, ok := store.GetResponseConn("resp_cleanup_hook")
+	require.False(t, ok)
+	_, ok = store.GetSessionConn(9, "session_cleanup_hook")
+	require.False(t, ok)
+}
+
 func TestOpenAIWSConnPool_Close(t *testing.T) {
 	cfg := &config.Config{}
 	pool := newOpenAIWSConnPool(cfg)

--- a/backend/internal/service/openai_ws_protocol_forward_test.go
+++ b/backend/internal/service/openai_ws_protocol_forward_test.go
@@ -1024,7 +1024,7 @@ func TestOpenAIGatewayService_Forward_WSv2ConnectionLimitReachedRetryThenFallbac
 	require.Equal(t, int32(openAIWSReconnectRetryLimit+1), wsAttempts.Load())
 }
 
-func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundRecoversByDroppingPreviousResponseID(t *testing.T) {
+func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundFailsForExplicitPrevID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var wsAttempts atomic.Int32
@@ -1125,20 +1125,18 @@ func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundRecoversByDrop
 
 	body := []byte(`{"model":"gpt-5.3-codex","stream":false,"previous_response_id":"resp_prev_missing","input":[{"type":"input_text","text":"hello"}]}`)
 	result, err := svc.Forward(context.Background(), c, account, body)
-	require.NoError(t, err)
-	require.NotNil(t, result)
-	require.Equal(t, "resp_ws_prev_recover_ok", result.RequestID)
+	require.Error(t, err)
+	require.Nil(t, result)
 	require.Nil(t, upstream.lastReq, "previous_response_not_found 不应回退 HTTP")
-	require.Equal(t, int32(2), wsAttempts.Load(), "previous_response_not_found 应触发一次去掉 previous_response_id 的恢复重试")
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.Equal(t, "resp_ws_prev_recover_ok", gjson.Get(rec.Body.String(), "id").String())
+	require.Equal(t, int32(1), wsAttempts.Load(), "显式 previous_response_id 命中 previous_response_not_found 时不应触发自动恢复重试")
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Contains(t, strings.ToLower(rec.Body.String()), "previous response not found")
 
 	wsRequestMu.Lock()
 	requests := append([][]byte(nil), wsRequestPayloads...)
 	wsRequestMu.Unlock()
-	require.Len(t, requests, 2)
+	require.Len(t, requests, 1)
 	require.True(t, gjson.GetBytes(requests[0], "previous_response_id").Exists(), "首轮请求应保留 previous_response_id")
-	require.False(t, gjson.GetBytes(requests[1], "previous_response_id").Exists(), "恢复重试应移除 previous_response_id")
 }
 
 func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundSkipsRecoveryForFunctionCallOutput(t *testing.T) {
@@ -1336,7 +1334,7 @@ func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundSkipsRecoveryW
 	require.False(t, gjson.GetBytes(requests[0], "previous_response_id").Exists())
 }
 
-func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundOnlyRecoversOnce(t *testing.T) {
+func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundFailsForExplicitPrevID_NoAutoRecovery(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var wsAttempts atomic.Int32
@@ -1423,15 +1421,14 @@ func TestOpenAIGatewayService_Forward_WSv2PreviousResponseNotFoundOnlyRecoversOn
 	require.Error(t, err)
 	require.Nil(t, result)
 	require.Nil(t, upstream.lastReq, "WS 模式下 previous_response_not_found 不应回退 HTTP")
-	require.Equal(t, int32(2), wsAttempts.Load(), "应只允许一次自动恢复重试")
+	require.Equal(t, int32(1), wsAttempts.Load(), "显式 previous_response_id 命中 previous_response_not_found 时不应自动恢复重试")
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 
 	wsRequestMu.Lock()
 	requests := append([][]byte(nil), wsRequestPayloads...)
 	wsRequestMu.Unlock()
-	require.Len(t, requests, 2)
+	require.Len(t, requests, 1)
 	require.True(t, gjson.GetBytes(requests[0], "previous_response_id").Exists(), "首轮请求应包含 previous_response_id")
-	require.False(t, gjson.GetBytes(requests[1], "previous_response_id").Exists(), "恢复重试应移除 previous_response_id")
 }
 
 func TestOpenAIGatewayService_Forward_WSv2InvalidEncryptedContentRecoversOnce(t *testing.T) {

--- a/backend/internal/service/openai_ws_state_store.go
+++ b/backend/internal/service/openai_ws_state_store.go
@@ -53,6 +53,8 @@ type OpenAIWSStateStore interface {
 	BindResponseConn(responseID, connID string, ttl time.Duration)
 	GetResponseConn(responseID string) (string, bool)
 	DeleteResponseConn(responseID string)
+	DeleteConnBindings(connID string) (responseIDs []string, sessionKeys []string)
+	HasConnBindings(connID string) bool
 
 	BindSessionTurnState(groupID int64, sessionHash, turnState string, ttl time.Duration)
 	GetSessionTurnState(groupID int64, sessionHash string) (string, bool)
@@ -207,6 +209,78 @@ func (s *defaultOpenAIWSStateStore) DeleteResponseConn(responseID string) {
 	s.responseToConnMu.Lock()
 	delete(s.responseToConn, id)
 	s.responseToConnMu.Unlock()
+}
+
+func (s *defaultOpenAIWSStateStore) DeleteConnBindings(connID string) (responseIDs []string, sessionKeys []string) {
+	connID = strings.TrimSpace(connID)
+	if s == nil || connID == "" {
+		return nil, nil
+	}
+	s.maybeCleanup()
+	now := time.Now()
+
+	s.responseToConnMu.Lock()
+	for responseID, binding := range s.responseToConn {
+		if now.After(binding.expiresAt) || strings.TrimSpace(binding.connID) == "" {
+			delete(s.responseToConn, responseID)
+			continue
+		}
+		if strings.TrimSpace(binding.connID) != connID {
+			continue
+		}
+		delete(s.responseToConn, responseID)
+		responseIDs = append(responseIDs, responseID)
+	}
+	s.responseToConnMu.Unlock()
+
+	s.sessionToConnMu.Lock()
+	for sessionKey, binding := range s.sessionToConn {
+		if now.After(binding.expiresAt) || strings.TrimSpace(binding.connID) == "" {
+			delete(s.sessionToConn, sessionKey)
+			continue
+		}
+		if strings.TrimSpace(binding.connID) != connID {
+			continue
+		}
+		delete(s.sessionToConn, sessionKey)
+		sessionKeys = append(sessionKeys, sessionKey)
+	}
+	s.sessionToConnMu.Unlock()
+	return responseIDs, sessionKeys
+}
+
+func (s *defaultOpenAIWSStateStore) HasConnBindings(connID string) bool {
+	connID = strings.TrimSpace(connID)
+	if s == nil || connID == "" {
+		return false
+	}
+	s.maybeCleanup()
+	now := time.Now()
+
+	s.responseToConnMu.RLock()
+	for _, binding := range s.responseToConn {
+		if now.After(binding.expiresAt) || strings.TrimSpace(binding.connID) == "" {
+			continue
+		}
+		if strings.TrimSpace(binding.connID) == connID {
+			s.responseToConnMu.RUnlock()
+			return true
+		}
+	}
+	s.responseToConnMu.RUnlock()
+
+	s.sessionToConnMu.RLock()
+	for _, binding := range s.sessionToConn {
+		if now.After(binding.expiresAt) || strings.TrimSpace(binding.connID) == "" {
+			continue
+		}
+		if strings.TrimSpace(binding.connID) == connID {
+			s.sessionToConnMu.RUnlock()
+			return true
+		}
+	}
+	s.sessionToConnMu.RUnlock()
+	return false
 }
 
 func (s *defaultOpenAIWSStateStore) BindSessionTurnState(groupID int64, sessionHash, turnState string, ttl time.Duration) {

--- a/backend/internal/service/openai_ws_state_store_test.go
+++ b/backend/internal/service/openai_ws_state_store_test.go
@@ -75,6 +75,32 @@ func TestOpenAIWSStateStore_SessionConnTTL(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestOpenAIWSStateStore_DeleteConnBindings(t *testing.T) {
+	store := NewOpenAIWSStateStore(nil)
+	store.BindResponseConn("resp_a", "conn_dead", time.Minute)
+	store.BindResponseConn("resp_b", "conn_live", time.Minute)
+	store.BindSessionConn(9, "session_a", "conn_dead", time.Minute)
+	store.BindSessionConn(9, "session_b", "conn_live", time.Minute)
+
+	require.True(t, store.HasConnBindings("conn_dead"))
+	responseIDs, sessionKeys := store.DeleteConnBindings("conn_dead")
+	require.ElementsMatch(t, []string{"resp_a"}, responseIDs)
+	require.ElementsMatch(t, []string{"9:session_a"}, sessionKeys)
+	require.False(t, store.HasConnBindings("conn_dead"))
+
+	_, ok := store.GetResponseConn("resp_a")
+	require.False(t, ok)
+	_, ok = store.GetSessionConn(9, "session_a")
+	require.False(t, ok)
+
+	connID, ok := store.GetResponseConn("resp_b")
+	require.True(t, ok)
+	require.Equal(t, "conn_live", connID)
+	connID, ok = store.GetSessionConn(9, "session_b")
+	require.True(t, ok)
+	require.Equal(t, "conn_live", connID)
+}
+
 func TestOpenAIWSStateStore_GetResponseAccount_NoStaleAfterCacheMiss(t *testing.T) {
 	cache := &stubGatewayCache{sessionBindings: map[string]int64{}}
 	store := NewOpenAIWSStateStore(cache)


### PR DESCRIPTION
## 问题现象
- 长任务或连续 `继续` 时，`previous_response_id` 续链偶发失效。
- 连接池在 recent-anchor 窗口内提前清理连接，会触发 `previous_response_not_found`，主链路被迫 full replay。

## 下游真实行为来源
- `source/codex/`
- 与 `gpt2claude-proxy` 的真实联调日志

## 上游真实行为来源
- `chatgpt.com/backend-api/codex/responses` 的 WSv2 行为
- `sub2api` 本地运行日志与连接池/forwarder 调试日志

## 当前差异
- 连接保护只依赖 pin/binding，不足以覆盖 recent-anchor 的短窗口续链。
- cleanup/idle evict 会在错误时机回收仍应保留的连接。

## 修复策略
- 把 recent-anchor 保护挂到 WS pool cleanup 判定里。
- 扩展 forwarder 的 recent-anchor conn 引用计数与保护 hook。
- 补充 ingress/session 与 pool 层测试，覆盖 cleanup 不应误回收的场景。

## 验证结果
- `go test ./internal/service/...` 通过。
- `go test ./...` 未全绿，但失败点在未改动的 `internal/config TestLoadForcedCodexInstructionsTemplate`，与本次 WS 续链改动无关。
- 实机联调确认：最新主链路已出现成功的 `response_conn_hit=true` 与 `bridge_runtime_fallback_count=0`。