### PR TITLE
fix(gateway): 兼容 Cursor /v1/chat/completions 的 Responses API body

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -124,6 +124,14 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 		"top_p",
 		"frequency_penalty",
 		"presence_penalty",
+		// prompt_cache_retention is a newer Responses API parameter (cache TTL).
+		// The ChatGPT internal Codex endpoint rejects it with
+		// "Unsupported parameter: prompt_cache_retention". Defense-in-depth
+		// for any OAuth path that reaches this transform — the Cursor
+		// Responses-shape short-circuit in ForwardAsChatCompletions strips
+		// it earlier too, but we keep this line so other OAuth callers are
+		// equally protected.
+		"prompt_cache_retention",
 	} {
 		if _, ok := reqBody[key]; ok {
 			delete(reqBody, key)

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -481,6 +481,26 @@ func TestExtractSystemMessagesFromInput(t *testing.T) {
 	})
 }
 
+// TestApplyCodexOAuthTransform_StripsPromptCacheRetention is a regression
+// test: some clients (e.g. Cursor cloud via the Responses-shape compat path)
+// send prompt_cache_retention, but the ChatGPT internal Codex endpoint
+// rejects it with "Unsupported parameter: prompt_cache_retention".
+func TestApplyCodexOAuthTransform_StripsPromptCacheRetention(t *testing.T) {
+	reqBody := map[string]any{
+		"model":                  "gpt-5.1",
+		"prompt_cache_retention": "24h",
+		"input": []any{
+			map[string]any{"role": "user", "content": "hi"},
+		},
+	}
+
+	applyCodexOAuthTransform(reqBody, false, false)
+
+	_, stillThere := reqBody["prompt_cache_retention"]
+	require.False(t, stillThere,
+		"prompt_cache_retention must be stripped before forwarding to Codex upstream")
+}
+
 func TestApplyCodexOAuthTransform_ExtractsSystemMessages(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.1",

--- a/backend/internal/service/openai_cursor_warmup_pipeline_test.go
+++ b/backend/internal/service/openai_cursor_warmup_pipeline_test.go
@@ -1,0 +1,155 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// TestCursorMixedShapeDetection covers the core invariant of the Cursor
+// compatibility fix in ForwardAsChatCompletions: when a client POSTs a
+// Responses-shaped body (has `input`, no `messages`) to /v1/chat/completions,
+// the request must be forwarded as-is with only the `model` field rewritten.
+// The raw `input` array (including Cursor's 80KB system prompt) must not be
+// discarded or reshaped.
+//
+// Context:
+//
+//	Before the fix, the handler unmarshaled the body into ChatCompletionsRequest,
+//	which has no Input field, silently dropping Cursor's input. The subsequent
+//	conversion produced `input: null`, which Codex upstreams reject with
+//	"Invalid type for 'input': expected a string, but got an object".
+func TestCursorMixedShapeDetection(t *testing.T) {
+	// Representative Cursor cloud body — shape is what matters, content is
+	// abridged. Notice: `input` is a Responses-API array, there is no
+	// `messages` field at all, and `user`/`stream` are at the top level.
+	cursorBody := []byte(`{
+		"user": "85df22e7463ab6c2",
+		"model": "gpt-5.4",
+		"stream": true,
+		"input": [
+			{"role":"system","content":"You are GPT-5.4 running as a coding agent."},
+			{"role":"user","content":"hello"}
+		],
+		"service_tier": "auto",
+		"reasoning": {"effort": "high"}
+	}`)
+
+	// --- Step 1: Shape detection (mirrors ForwardAsChatCompletions) ---
+	hasMessages := gjson.GetBytes(cursorBody, "messages").Exists()
+	hasInput := gjson.GetBytes(cursorBody, "input").Exists()
+	isResponsesShape := !hasMessages && hasInput
+
+	require.True(t, isResponsesShape,
+		"Cursor body must be detected as Responses-shape (has input, no messages)")
+
+	// --- Step 2: Model rewrite (mirrors the sjson.SetBytes branch) ---
+	const upstreamModel = "gpt-5.1-codex"
+	rewritten, err := sjson.SetBytes(cursorBody, "model", upstreamModel)
+	require.NoError(t, err)
+
+	// --- Step 3: Invariants of the rewritten body ---
+
+	// 3a. model must be rewritten to the upstream target.
+	assert.Equal(t, upstreamModel, gjson.GetBytes(rewritten, "model").String())
+
+	// 3b. input array must be preserved verbatim — no reshaping, no nulling.
+	inputResult := gjson.GetBytes(rewritten, "input")
+	require.True(t, inputResult.Exists(), "input field must still exist after rewrite")
+	require.True(t, inputResult.IsArray(), "input must still be an array (not null, not object)")
+
+	items := inputResult.Array()
+	require.Len(t, items, 2, "both input items must be preserved")
+	assert.Equal(t, "system", items[0].Get("role").String())
+	assert.Equal(t, "You are GPT-5.4 running as a coding agent.",
+		items[0].Get("content").String())
+	assert.Equal(t, "user", items[1].Get("role").String())
+	assert.Equal(t, "hello", items[1].Get("content").String())
+
+	// 3c. ALL other top-level fields must survive intact.
+	assert.Equal(t, "85df22e7463ab6c2", gjson.GetBytes(rewritten, "user").String())
+	assert.Equal(t, true, gjson.GetBytes(rewritten, "stream").Bool())
+	assert.Equal(t, "auto", gjson.GetBytes(rewritten, "service_tier").String())
+	assert.Equal(t, "high", gjson.GetBytes(rewritten, "reasoning.effort").String())
+
+	// 3d. Final upstream body must NOT contain the old "input":null pattern.
+	assert.NotContains(t, string(rewritten), `"input":null`,
+		"rewritten body must not collapse input to null")
+}
+
+// TestCursorMixedShapeDetection_NormalChatCompletionsUnaffected guards that
+// the shape detection does NOT misfire on a standard Chat Completions request
+// (one that has a `messages` array). Such requests must fall through to the
+// existing ChatCompletionsToResponses conversion path.
+func TestCursorMixedShapeDetection_NormalChatCompletionsUnaffected(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [{"role":"user","content":"hi"}],
+		"stream": true
+	}`)
+
+	hasMessages := gjson.GetBytes(body, "messages").Exists()
+	hasInput := gjson.GetBytes(body, "input").Exists()
+	isResponsesShape := !hasMessages && hasInput
+
+	assert.False(t, isResponsesShape,
+		"standard Chat Completions body must NOT be detected as Responses-shape")
+}
+
+// TestCursorMixedShapeDetection_BothFieldsPrefersMessages guards the
+// ambiguous case where a client sends both `messages` and `input`. We fall
+// through to the normal conversion path (messages wins), since mixing the
+// two is almost certainly a client bug and messages is the documented
+// Chat Completions contract.
+func TestCursorMixedShapeDetection_BothFieldsPrefersMessages(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-4o",
+		"messages": [{"role":"user","content":"hi"}],
+		"input": [{"role":"user","content":"other"}]
+	}`)
+
+	hasMessages := gjson.GetBytes(body, "messages").Exists()
+	hasInput := gjson.GetBytes(body, "input").Exists()
+	isResponsesShape := !hasMessages && hasInput
+
+	assert.False(t, isResponsesShape,
+		"when both messages and input are present, must not take the Cursor shortcut")
+}
+
+// TestCursorMixedShapeDetection_EmptyBody ensures a body with neither
+// messages nor input is NOT taken as Cursor-shape (would hit the normal
+// conversion and fail on its own with a clearer error).
+func TestCursorMixedShapeDetection_EmptyBody(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","stream":true}`)
+
+	hasMessages := gjson.GetBytes(body, "messages").Exists()
+	hasInput := gjson.GetBytes(body, "input").Exists()
+	isResponsesShape := !hasMessages && hasInput
+
+	assert.False(t, isResponsesShape,
+		"body with neither messages nor input must not be taken as Cursor shape")
+}
+
+// TestCursorMixedShape_JSONRoundtrip ensures the rewritten body is still
+// valid JSON and parseable back into a map without surprises — catches
+// any encoding drift from sjson.
+func TestCursorMixedShape_JSONRoundtrip(t *testing.T) {
+	cursorBody := []byte(`{"model":"gpt-5.4","stream":true,"input":[{"role":"user","content":"hi"}]}`)
+
+	rewritten, err := sjson.SetBytes(cursorBody, "model", "gpt-5.1-codex")
+	require.NoError(t, err)
+
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(rewritten, &parsed))
+
+	assert.Equal(t, "gpt-5.1-codex", parsed["model"])
+	assert.Equal(t, true, parsed["stream"])
+
+	inputArr, ok := parsed["input"].([]any)
+	require.True(t, ok, "input must decode to a Go []any after round-trip")
+	require.Len(t, inputArr, 1)
+}

--- a/backend/internal/service/openai_cursor_warmup_pipeline_test.go
+++ b/backend/internal/service/openai_cursor_warmup_pipeline_test.go
@@ -153,3 +153,47 @@ func TestCursorMixedShape_JSONRoundtrip(t *testing.T) {
 	require.True(t, ok, "input must decode to a Go []any after round-trip")
 	require.Len(t, inputArr, 1)
 }
+
+// TestCursorMixedShape_StripsUnsupportedFields mirrors the strip loop in
+// ForwardAsChatCompletions (isResponsesShape branch). Cursor cloud sends
+// prompt_cache_retention, safety_identifier, metadata and stream_options
+// as top-level Responses API parameters, which Codex upstreams reject with
+// "Unsupported parameter: ...". The fix must remove them from the raw body
+// before it is forwarded, for BOTH OAuth and API Key account types.
+func TestCursorMixedShape_StripsUnsupportedFields(t *testing.T) {
+	cursorBody := []byte(`{
+		"model": "gpt-5.4",
+		"stream": true,
+		"prompt_cache_retention": "24h",
+		"safety_identifier": "cursor-user-xyz",
+		"metadata": {"trace_id":"abc","caller":"cursor"},
+		"stream_options": {"include_usage": true},
+		"input": [{"role":"user","content":"hi"}]
+	}`)
+
+	// Sanity: the test fixture contains every field the production code strips.
+	for _, field := range cursorResponsesUnsupportedFields {
+		require.True(t, gjson.GetBytes(cursorBody, field).Exists(),
+			"test fixture must contain %s", field)
+	}
+
+	// Run the exact same loop as the production code.
+	result := cursorBody
+	for _, field := range cursorResponsesUnsupportedFields {
+		if stripped, err := sjson.DeleteBytes(result, field); err == nil {
+			result = stripped
+		}
+	}
+
+	// All unsupported fields must be gone.
+	for _, field := range cursorResponsesUnsupportedFields {
+		assert.False(t, gjson.GetBytes(result, field).Exists(),
+			"%s must be stripped", field)
+	}
+
+	// Everything else must survive intact.
+	assert.Equal(t, "gpt-5.4", gjson.GetBytes(result, "model").String())
+	assert.Equal(t, true, gjson.GetBytes(result, "stream").Bool())
+	assert.True(t, gjson.GetBytes(result, "input").IsArray())
+	assert.Equal(t, "user", gjson.GetBytes(result, "input.0.role").String())
+}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -16,6 +16,8 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 	"go.uber.org/zap"
 )
 
@@ -55,13 +57,52 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		compatPromptCacheInjected = promptCacheKey != ""
 	}
 
-	// 3. Convert to Responses and forward
-	// ChatCompletionsToResponses always sets Stream=true (upstream always streams).
-	responsesReq, err := apicompat.ChatCompletionsToResponses(&chatReq)
-	if err != nil {
-		return nil, fmt.Errorf("convert chat completions to responses: %w", err)
+	// 3. Build the upstream (Responses API) body.
+	//
+	// Cursor compatibility: some clients (notably Cursor cloud) send Responses
+	// API shaped bodies — `input: [...]` with no `messages` field — to the
+	// /v1/chat/completions URL. Running those through ChatCompletionsToResponses
+	// would silently drop Cursor's `input` array (the struct has no Input field)
+	// and produce `input: null`, which Codex upstreams reject with
+	// "Invalid type for 'input': expected a string, but got an object".
+	//
+	// Detect that shape and forward the raw body as-is, only rewriting `model`
+	// to the resolved upstream model. The downstream codex OAuth transform will
+	// still normalize store/stream/instructions/etc.
+	isResponsesShape := !gjson.GetBytes(body, "messages").Exists() && gjson.GetBytes(body, "input").Exists()
+
+	var (
+		responsesReq  *apicompat.ResponsesRequest
+		responsesBody []byte
+		err           error
+	)
+	if isResponsesShape {
+		responsesBody, err = sjson.SetBytes(body, "model", upstreamModel)
+		if err != nil {
+			return nil, fmt.Errorf("rewrite model in responses-shape body: %w", err)
+		}
+		// Minimal stub populated from the raw body so downstream billing
+		// propagation (ServiceTier, ReasoningEffort) keeps working.
+		responsesReq = &apicompat.ResponsesRequest{
+			Model:       upstreamModel,
+			ServiceTier: gjson.GetBytes(responsesBody, "service_tier").String(),
+		}
+		if effort := gjson.GetBytes(responsesBody, "reasoning.effort").String(); effort != "" {
+			responsesReq.Reasoning = &apicompat.ResponsesReasoning{Effort: effort}
+		}
+	} else {
+		// Normal path: convert Chat Completions → Responses.
+		// ChatCompletionsToResponses always sets Stream=true (upstream always streams).
+		responsesReq, err = apicompat.ChatCompletionsToResponses(&chatReq)
+		if err != nil {
+			return nil, fmt.Errorf("convert chat completions to responses: %w", err)
+		}
+		responsesReq.Model = upstreamModel
+		responsesBody, err = json.Marshal(responsesReq)
+		if err != nil {
+			return nil, fmt.Errorf("marshal responses request: %w", err)
+		}
 	}
-	responsesReq.Model = upstreamModel
 
 	logFields := []zap.Field{
 		zap.Int64("account_id", account.ID),
@@ -69,6 +110,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		zap.String("billing_model", billingModel),
 		zap.String("upstream_model", upstreamModel),
 		zap.Bool("stream", clientStream),
+		zap.Bool("responses_shape", isResponsesShape),
 	}
 	if compatPromptCacheInjected {
 		logFields = append(logFields,
@@ -77,12 +119,6 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		)
 	}
 	logger.L().Debug("openai chat_completions: model mapping applied", logFields...)
-
-	// 4. Marshal Responses request body, then apply OAuth codex transform
-	responsesBody, err := json.Marshal(responsesReq)
-	if err != nil {
-		return nil, fmt.Errorf("marshal responses request: %w", err)
-	}
 
 	if account.Type == AccountTypeOAuth {
 		var reqBody map[string]any

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -21,6 +21,22 @@ import (
 	"go.uber.org/zap"
 )
 
+// cursorResponsesUnsupportedFields are top-level Responses API parameters that
+// Codex upstreams reject with "Unsupported parameter: ...". They must be
+// stripped when forwarding a raw client body through the Responses-shape
+// short-circuit in ForwardAsChatCompletions (see isResponsesShape branch).
+// The normal Chat Completions → Responses conversion path is unaffected
+// because ChatCompletionsRequest has no fields for these parameters — unknown
+// fields are dropped naturally by json.Unmarshal. Kept semantically in sync
+// with the list in openai_gateway_service.go:2034 used by the /v1/responses
+// passthrough path.
+var cursorResponsesUnsupportedFields = []string{
+	"prompt_cache_retention",
+	"safety_identifier",
+	"metadata",
+	"stream_options",
+}
+
 // ForwardAsChatCompletions accepts a Chat Completions request body, converts it
 // to OpenAI Responses API format, forwards to the OpenAI upstream, and converts
 // the response back to Chat Completions format. All account types (OAuth and API
@@ -80,6 +96,16 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		responsesBody, err = sjson.SetBytes(body, "model", upstreamModel)
 		if err != nil {
 			return nil, fmt.Errorf("rewrite model in responses-shape body: %w", err)
+		}
+		// Strip Responses API parameters that no Codex upstream accepts.
+		// Because this branch forwards the raw body (the normal path rebuilds
+		// it from ChatCompletionsRequest and drops unknown fields naturally),
+		// we must filter these fields explicitly here — otherwise the upstream
+		// rejects the request with "Unsupported parameter: ...".
+		for _, field := range cursorResponsesUnsupportedFields {
+			if stripped, derr := sjson.DeleteBytes(responsesBody, field); derr == nil {
+				responsesBody = stripped
+			}
 		}
 		// Minimal stub populated from the raw body so downstream billing
 		// propagation (ServiceTier, ReasoningEffort) keeps working.


### PR DESCRIPTION
## Summary

修复 Cursor 云端发往 `/v1/chat/completions` 的请求被 Codex 上游拒绝的 bug。Cursor 使用 "Chat Completions URL + Responses API body shape" 的混合格式(`input: [...]` 没有 `messages`),现有代码在 `ChatCompletionsRequest` 反序列化时会**静默丢弃 `input` 字段**,转换后发出 `input: null`,触发上游报错:

```
Invalid type for 'input': expected a string, but got an object
```

## Root Cause

1. Cursor 云端(User-Agent: `Go-http-client/2.0`, AWS 段 IP)发往 `/v1/chat/completions` 的 body 长这样:
   ```json
   {
     "user": "...",
     "model": "gpt-5.4",
     "stream": true,
     "input": [{"role":"system","content":"You are GPT-5.4..."}]
   }
   ```
2. `ForwardAsChatCompletions` 用 `ChatCompletionsRequest` 反序列化,该结构体没有 `Input` 字段 → Cursor 的 `input` 数组被 Go 的 `json.Unmarshal` 静默丢弃
3. `chatReq.Messages` 为 nil → `convertChatMessagesToResponsesInput(nil)` 返回 nil 切片 → `json.Marshal(nil slice)` 输出 `"null"`
4. `ResponsesRequest.Input = json.RawMessage("null")` → 最终发给上游的 body 是 `{"input": null, ...}`
5. Codex 上游(例如 JZYZ-hyy-codex 这类中转)的校验器在 JS 语义下 `typeof null === "object"`,报出 `expected a string, but got an object`

Codex CLI 不受影响,因为它直接打 `/v1/responses` 走 passthrough 路径,不经过 `ChatCompletionsToResponses` 转换。

## Fix

在 `ForwardAsChatCompletions` 里新增一条**短路分支**:用 `gjson` 检测 body shape,当 `input` 字段存在且 `messages` 字段缺失时,判定为 Responses-shape,跳过 Chat→Responses 转换,用 `sjson` 仅改写 `model` 字段后**原样透传** body:

```go
isResponsesShape := !gjson.GetBytes(body, "messages").Exists() &&
                     gjson.GetBytes(body, "input").Exists()

if isResponsesShape {
    responsesBody, err = sjson.SetBytes(body, "model", upstreamModel)
    responsesReq = &apicompat.ResponsesRequest{
        Model:       upstreamModel,
        ServiceTier: gjson.GetBytes(responsesBody, "service_tier").String(),
    }
    if effort := gjson.GetBytes(responsesBody, "reasoning.effort").String(); effort != "" {
        responsesReq.Reasoning = &apicompat.ResponsesReasoning{Effort: effort}
    }
} else {
    // 原路径:Chat Completions → Responses 转换(未改动)
}
```

设计要点:
- **不动 `ChatCompletionsToResponses`** —— 避免改动被多处复用的纯函数
- **不动 `ChatCompletionsRequest` 结构** —— 不引入"一个字段既可能是 Chat 又可能是 Responses"的歧义
- **sjson 仅改写 `model`** —— Cursor 发的所有其他字段(`user`/`service_tier`/`reasoning`/`tools` 等)原样透传
- **billing 的 `ServiceTier` / `Reasoning.Effort`** 用 gjson 从 raw body 提取,下游代码不变
- **`codex OAuth transform` 不受影响** —— 它在 `map[string]any` 层工作,不关心上游来自哪条分支
- debug 日志新增 `responses_shape` 字段,便于观察新分支命中率

## 影响面

| 场景 | 旧行为 | 新行为 |
|---|---|---|
| 标准 Chat Completions 请求(有 `messages`) | 走 Chat→Responses 转换 | **不变** |
| Cursor 混合请求(有 `input`,无 `messages`) | `input: null` 上游 400 | 原样透传,正常返回 |
| 两个字段都在(罕见/客户端 bug) | 走 Chat→Responses 转换 | **不变**(messages 优先) |
| Codex CLI → `/v1/responses` passthrough | 不经过这个函数 | **不变** |

## Test Plan

- [x] 新增 `openai_cursor_warmup_pipeline_test.go`,5 个 shape 检测用例
  - [x] `TestCursorMixedShapeDetection` — 正向:Cursor body 被检测 + model 改写 + input 数组/user/stream/service_tier/reasoning.effort 全部保留
  - [x] `TestCursorMixedShapeDetection_NormalChatCompletionsUnaffected` — 反向:标准 Chat Completions 请求不误伤
  - [x] `TestCursorMixedShapeDetection_BothFieldsPrefersMessages` — 边界:两字段共存时不走 Cursor 分支
  - [x] `TestCursorMixedShapeDetection_EmptyBody` — 边界:两字段都没有时不走 Cursor 分支
  - [x] `TestCursorMixedShape_JSONRoundtrip` — sjson 改写后 body 仍是合法 JSON
- [x] `go test ./internal/service/...` (含 `openai_ws_v2`) 全量通过
- [x] `go test ./internal/pkg/apicompat/...` 全量通过
- [x] `go vet ./internal/service/... ./internal/pkg/apicompat/...` 通过
- [x] `gofmt -l` 无格式问题
- [x] `go build ./...` 编译通过
- [ ] 部署后观察 `ops_error_logs` 里 `Invalid type for 'input'` 错误是否消失
- [ ] Cursor 端实际对话验证

## Diagnostic Trail

定位过程(供 reviewer 复核):
1. nginx 日志:`POST /v1/chat/completions` 返回 400,User-Agent `Go-http-client/2.0`,Client IP `3.209.66.12`(AWS 段,Cursor 云端)
2. `ops_error_logs` 中 `upstream_errors[0]` 精确指向:`"param":"input","code":"invalid_type","message":"Invalid type for 'input': expected a string, but got an object instead."`,上游账号 `JZYZ-hyy-codex`
3. tcpdump 在 NPM → sub2api backend 的内网 HTTP 链路上抓到 Cursor 原始 body(Content-Length 85837),确认 `input` 字段存在但无 `messages`
4. 代码路径确认:`openai_gateway_chat_completions.go:39` 的 `json.Unmarshal(body, &chatReq)` 会丢弃 `input` 字段;`chatcompletions_to_responses.go:19` 的 `convertChatMessagesToResponsesInput(nil)` 返回 nil 切片;`json.Marshal(nil slice)` 输出 `"null"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)