### PR TITLE
fix(openai): honor x-session-affinity in session hash and upstream session injection for better OpenCode request sticky and higher cache hit rate

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1099,20 +1099,33 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 	return match(string(upstreamBody))
 }
 
+func extractOpenAISessionSignal(c *gin.Context, body []byte, includeContentFallback bool) string {
+	if c != nil {
+		if sessionID := strings.TrimSpace(c.GetHeader("session_id")); sessionID != "" {
+			return sessionID
+		}
+		if conversationID := strings.TrimSpace(c.GetHeader("conversation_id")); conversationID != "" {
+			return conversationID
+		}
+		if sessionAffinity := strings.TrimSpace(c.GetHeader("x-session-affinity")); sessionAffinity != "" {
+			return sessionAffinity
+		}
+	}
+	if len(body) == 0 {
+		return ""
+	}
+	if promptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String()); promptCacheKey != "" {
+		return promptCacheKey
+	}
+	if includeContentFallback {
+		return deriveOpenAIContentSessionSeed(body)
+	}
+	return ""
+}
 // ExtractSessionID extracts the raw session ID from headers or body without hashing.
 // Used by ForwardAsAnthropic to pass as prompt_cache_key for upstream cache.
 func (s *OpenAIGatewayService) ExtractSessionID(c *gin.Context, body []byte) string {
-	if c == nil {
-		return ""
-	}
-	sessionID := strings.TrimSpace(c.GetHeader("session_id"))
-	if sessionID == "" {
-		sessionID = strings.TrimSpace(c.GetHeader("conversation_id"))
-	}
-	if sessionID == "" && len(body) > 0 {
-		sessionID = strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
-	}
-	return sessionID
+	return extractOpenAISessionSignal(c, body, false)
 }
 
 // GenerateSessionHash generates a sticky-session hash for OpenAI requests.
@@ -1120,23 +1133,15 @@ func (s *OpenAIGatewayService) ExtractSessionID(c *gin.Context, body []byte) str
 // Priority:
 //  1. Header: session_id
 //  2. Header: conversation_id
-//  3. Body:   prompt_cache_key (opencode)
-//  4. Body:   content-based fallback (model + system + tools + first user message)
+//  3. Header: x-session-affinity
+//  4. Body:   prompt_cache_key (opencode)
+//  5. Body:   content-based fallback (model + system + tools + first user message)
 func (s *OpenAIGatewayService) GenerateSessionHash(c *gin.Context, body []byte) string {
 	if c == nil {
 		return ""
 	}
 
-	sessionID := strings.TrimSpace(c.GetHeader("session_id"))
-	if sessionID == "" {
-		sessionID = strings.TrimSpace(c.GetHeader("conversation_id"))
-	}
-	if sessionID == "" && len(body) > 0 {
-		sessionID = strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
-	}
-	if sessionID == "" && len(body) > 0 {
-		sessionID = deriveOpenAIContentSessionSeed(body)
-	}
+	sessionID := extractOpenAISessionSignal(c, body, true)
 	if sessionID == "" {
 		return ""
 	}
@@ -1147,7 +1152,7 @@ func (s *OpenAIGatewayService) GenerateSessionHash(c *gin.Context, body []byte) 
 }
 
 // GenerateSessionHashWithFallback 先按常规信号生成会话哈希；
-// 当未携带 session_id/conversation_id/prompt_cache_key 时，使用 fallbackSeed 生成稳定哈希。
+// 当未携带 session_id/conversation_id/x-session-affinity/prompt_cache_key 时，使用 fallbackSeed 生成稳定哈希。
 // 该方法用于 WS ingress，避免会话信号缺失时发生跨账号漂移。
 func (s *OpenAIGatewayService) GenerateSessionHashWithFallback(c *gin.Context, body []byte, fallbackSeed string) string {
 	sessionHash := s.GenerateSessionHash(c, body)
@@ -2689,7 +2694,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 
 	// OAuth 透传到 ChatGPT internal API 时补齐必要头。
 	if account.Type == AccountTypeOAuth {
-		promptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
+		sessionSignal := extractOpenAISessionSignal(c, body, false)
 		req.Host = "chatgpt.com"
 		if chatgptAccountID := account.GetChatGPTAccountID(); chatgptAccountID != "" {
 			req.Header.Set("chatgpt-account-id", chatgptAccountID)
@@ -2698,13 +2703,19 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 		// 先保存客户端原始值，再做 compact 补充，避免后续统一隔离时读到已处理的值。
 		clientSessionID := strings.TrimSpace(req.Header.Get("session_id"))
 		clientConversationID := strings.TrimSpace(req.Header.Get("conversation_id"))
+		if clientSessionID == "" {
+			clientSessionID = sessionSignal
+		}
+		if clientConversationID == "" {
+			clientConversationID = sessionSignal
+		}
 		if isOpenAIResponsesCompactPath(c) {
 			req.Header.Set("accept", "application/json")
 			if req.Header.Get("version") == "" {
 				req.Header.Set("version", codexCLIVersion)
 			}
 			if clientSessionID == "" {
-				clientSessionID = resolveOpenAICompactSessionID(c)
+				clientSessionID = resolveOpenAICompactSessionID(c, body)
 			}
 		} else if req.Header.Get("accept") == "" {
 			req.Header.Set("accept", "text/event-stream")
@@ -2716,12 +2727,6 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 			req.Header.Set("originator", "codex_cli_rs")
 		}
 		// 用隔离后的 session 标识符覆盖客户端透传值，防止跨用户会话碰撞。
-		if clientSessionID == "" {
-			clientSessionID = promptCacheKey
-		}
-		if clientConversationID == "" {
-			clientConversationID = promptCacheKey
-		}
 		if clientSessionID != "" {
 			req.Header.Set("session_id", isolateOpenAISessionID(apiKeyID, clientSessionID))
 		}
@@ -3180,6 +3185,13 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	if err != nil {
 		return nil, err
 	}
+	sessionSignal := ""
+	if account.Type == AccountTypeOAuth {
+		sessionSignal = extractOpenAISessionSignal(c, body, false)
+		if sessionSignal == "" {
+			sessionSignal = strings.TrimSpace(promptCacheKey)
+		}
+	}
 
 	// Set authentication header
 	req.Header.Set("authorization", "Bearer "+token)
@@ -3212,20 +3224,24 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		req.Header.Set("OpenAI-Beta", "responses=experimental")
 		req.Header.Set("originator", resolveOpenAIUpstreamOriginator(c, isCodexCLI))
 		apiKeyID := getAPIKeyIDFromContext(c)
+		clientSessionID := sessionSignal
+		clientConversationID := sessionSignal
 		if isOpenAIResponsesCompactPath(c) {
 			req.Header.Set("accept", "application/json")
 			if req.Header.Get("version") == "" {
 				req.Header.Set("version", codexCLIVersion)
 			}
-			compactSession := resolveOpenAICompactSessionID(c)
-			req.Header.Set("session_id", isolateOpenAISessionID(apiKeyID, compactSession))
+			if clientSessionID == "" {
+				clientSessionID = resolveOpenAICompactSessionID(c, body)
+			}
 		} else {
 			req.Header.Set("accept", "text/event-stream")
 		}
-		if promptCacheKey != "" {
-			isolated := isolateOpenAISessionID(apiKeyID, promptCacheKey)
-			req.Header.Set("conversation_id", isolated)
-			req.Header.Set("session_id", isolated)
+		if clientSessionID != "" {
+			req.Header.Set("session_id", isolateOpenAISessionID(apiKeyID, clientSessionID))
+		}
+		if clientConversationID != "" {
+			req.Header.Set("conversation_id", isolateOpenAISessionID(apiKeyID, clientConversationID))
 		}
 	}
 
@@ -4333,14 +4349,11 @@ func normalizeOpenAICompactRequestBody(body []byte) ([]byte, bool, error) {
 	return normalized, true, nil
 }
 
-func resolveOpenAICompactSessionID(c *gin.Context) string {
+func resolveOpenAICompactSessionID(c *gin.Context, body []byte) string {
+	if sessionID := extractOpenAISessionSignal(c, body, false); sessionID != "" {
+		return sessionID
+	}
 	if c != nil {
-		if sessionID := strings.TrimSpace(c.GetHeader("session_id")); sessionID != "" {
-			return sessionID
-		}
-		if conversationID := strings.TrimSpace(c.GetHeader("conversation_id")); conversationID != "" {
-			return conversationID
-		}
 		if seed, ok := c.Get(openAICompactSessionSeedKey); ok {
 			if seedStr, ok := seed.(string); ok && strings.TrimSpace(seedStr) != "" {
 				return strings.TrimSpace(seedStr)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -189,6 +189,36 @@ func TestOpenAIGatewayService_GenerateSessionHash_Priority(t *testing.T) {
 	}
 }
 
+func TestOpenAIGatewayService_GenerateSessionHash_UsesXSessionAffinityBeforePromptCacheKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("x-session-affinity", "affinity-123")
+
+	svc := &OpenAIGatewayService{}
+
+	h1 := svc.GenerateSessionHash(c, []byte(`{"prompt_cache_key":"cache-key-1"}`))
+	h2 := svc.GenerateSessionHash(c, []byte(`{"prompt_cache_key":"cache-key-2"}`))
+
+	require.NotEmpty(t, h1)
+	require.Equal(t, h1, h2)
+	require.Equal(t, fmt.Sprintf("%016x", xxhash.Sum64String("affinity-123")), h1)
+}
+
+func TestOpenAIGatewayService_ExtractSessionID_PrefersXSessionAffinityOverPromptCacheKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Request.Header.Set("x-session-affinity", "affinity-456")
+
+	svc := &OpenAIGatewayService{}
+	got := svc.ExtractSessionID(c, []byte(`{"prompt_cache_key":"cache-key-body"}`))
+
+	require.Equal(t, "affinity-456", got)
+}
+
 func TestOpenAIGatewayService_GenerateSessionHash_UsesXXHash64(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -1568,6 +1598,47 @@ func TestOpenAIBuildUpstreamRequestOAuthOfficialClientOriginatorCompatibility(t 
 	}
 }
 
+func TestOpenAIGatewayService_BuildUpstreamRequest_UsesXSessionAffinityOverPromptCacheKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader([]byte(`{"model":"gpt-5","prompt_cache_key":"body-cache"}`)))
+	c.Request.Header.Set("x-session-affinity", "affinity-upstream")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "chatgpt-acc"},
+	}
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, []byte(`{"model":"gpt-5","prompt_cache_key":"body-cache"}`), "token", true, "body-cache", false)
+	require.NoError(t, err)
+
+	expected := isolateOpenAISessionID(0, "affinity-upstream")
+	require.Equal(t, expected, req.Header.Get("Session_Id"))
+	require.Equal(t, expected, req.Header.Get("Conversation_Id"))
+}
+
+func TestOpenAIGatewayService_BuildUpstreamRequest_UsesXSessionAffinityOverPromptCacheKey_Passthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader([]byte(`{"model":"gpt-5","prompt_cache_key":"body-cache"}`)))
+	c.Request.Header.Set("x-session-affinity", "affinity-passthrough")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "chatgpt-acc"},
+	}
+
+	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, []byte(`{"model":"gpt-5","prompt_cache_key":"body-cache"}`), "token")
+	require.NoError(t, err)
+
+	expected := isolateOpenAISessionID(0, "affinity-passthrough")
+	require.Equal(t, expected, req.Header.Get("Session_Id"))
+	require.Equal(t, expected, req.Header.Get("Conversation_Id"))
+}
 // ==================== P1-08 修复：model 替换性能优化测试 ====================
 
 // ==================== P1-08 修复：model 替换性能优化测试 =============


### PR DESCRIPTION
x-session-affinity 是 OpenCode 使用的 session 标记请求头。

本项目中将 OpenCode 作为和 Codex CLI 并列的客户端推荐，应当支持 OpenCode 使用的标记请求头。进行此变更后在我自己的实例上可以将 OpenCode相关请求的缓存命中率从 1x%提高到 90%+。（顺带一提，现在的缓存命中率计算也是错误的）

## Summary
- honor `x-session-affinity` between `conversation_id` and `prompt_cache_key` when extracting the effective OpenAI session signal
- use the same priority for sticky-session hash generation and OAuth upstream `session_id` / `conversation_id` injection
- add focused regression tests for session-hash priority and upstream request building

## Testing
- `go test ./internal/service -run "GenerateSessionHash_UsesXSessionAffinity|ExtractSessionID_PrefersXSessionAffinity|BuildUpstreamRequest_UsesXSessionAffinity" -count=1`