### PR TITLE
fix(messages): fall back to group DefaultMappedModel in ResolveMessagesDispatchModel

### DIFF
--- a/backend/internal/repository/usage_billing_repo.go
+++ b/backend/internal/repository/usage_billing_repo.go
@@ -248,30 +248,32 @@ func incrementUsageBillingAccountQuota(ctx context.Context, tx *sql.Tx, accountI
 			|| CASE WHEN COALESCE((extra->>'quota_daily_limit')::numeric, 0) > 0 THEN
 				jsonb_build_object(
 					'quota_daily_used',
-					CASE WHEN COALESCE((extra->>'quota_daily_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '24 hours'::interval <= NOW()
+					CASE WHEN `+dailyExpiredExpr+`
 					THEN $1
 					ELSE COALESCE((extra->>'quota_daily_used')::numeric, 0) + $1 END,
 					'quota_daily_start',
-					CASE WHEN COALESCE((extra->>'quota_daily_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '24 hours'::interval <= NOW()
+					CASE WHEN `+dailyExpiredExpr+`
 					THEN `+nowUTC+`
 					ELSE COALESCE(extra->>'quota_daily_start', `+nowUTC+`) END
 				)
+				|| CASE WHEN `+dailyExpiredExpr+` AND `+nextDailyResetAtExpr+` IS NOT NULL
+				   THEN jsonb_build_object('quota_daily_reset_at', `+nextDailyResetAtExpr+`)
+				   ELSE '{}'::jsonb END
 			ELSE '{}'::jsonb END
 			|| CASE WHEN COALESCE((extra->>'quota_weekly_limit')::numeric, 0) > 0 THEN
 				jsonb_build_object(
 					'quota_weekly_used',
-					CASE WHEN COALESCE((extra->>'quota_weekly_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '168 hours'::interval <= NOW()
+					CASE WHEN `+weeklyExpiredExpr+`
 					THEN $1
 					ELSE COALESCE((extra->>'quota_weekly_used')::numeric, 0) + $1 END,
 					'quota_weekly_start',
-					CASE WHEN COALESCE((extra->>'quota_weekly_start')::timestamptz, '1970-01-01'::timestamptz)
-						+ '168 hours'::interval <= NOW()
+					CASE WHEN `+weeklyExpiredExpr+`
 					THEN `+nowUTC+`
 					ELSE COALESCE(extra->>'quota_weekly_start', `+nowUTC+`) END
 				)
+				|| CASE WHEN `+weeklyExpiredExpr+` AND `+nextWeeklyResetAtExpr+` IS NOT NULL
+				   THEN jsonb_build_object('quota_weekly_reset_at', `+nextWeeklyResetAtExpr+`)
+				   ELSE '{}'::jsonb END
 			ELSE '{}'::jsonb END
 		), updated_at = NOW()
 		WHERE id = $2 AND deleted_at IS NULL

--- a/backend/internal/service/openai_messages_dispatch.go
+++ b/backend/internal/service/openai_messages_dispatch.go
@@ -69,20 +69,35 @@ func (g *Group) ResolveMessagesDispatchModel(requestedModel string) string {
 		return mappedModel
 	}
 
+	// Fall back to the group-level default mapped model when no family-specific
+	// mapping is explicitly configured. This preserves backward-compatible
+	// behavior for groups that relied on DefaultMappedModel as a catch-all before
+	// per-family MessagesDispatchModelConfig was introduced.
+	groupDefault := strings.TrimSpace(g.DefaultMappedModel)
+
 	switch claudeMessagesDispatchFamily(requestedModel) {
 	case "opus":
 		if mappedModel := strings.TrimSpace(cfg.OpusMappedModel); mappedModel != "" {
 			return mappedModel
+		}
+		if groupDefault != "" {
+			return groupDefault
 		}
 		return defaultOpenAIMessagesDispatchOpusMappedModel
 	case "sonnet":
 		if mappedModel := strings.TrimSpace(cfg.SonnetMappedModel); mappedModel != "" {
 			return mappedModel
 		}
+		if groupDefault != "" {
+			return groupDefault
+		}
 		return defaultOpenAIMessagesDispatchSonnetMappedModel
 	case "haiku":
 		if mappedModel := strings.TrimSpace(cfg.HaikuMappedModel); mappedModel != "" {
 			return mappedModel
+		}
+		if groupDefault != "" {
+			return groupDefault
 		}
 		return defaultOpenAIMessagesDispatchHaikuMappedModel
 	default:

--- a/backend/internal/service/openai_messages_dispatch_test.go
+++ b/backend/internal/service/openai_messages_dispatch_test.go
@@ -1,8 +1,94 @@
 package service
 
-import "testing"
+import (
+	"testing"
 
-import "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveMessagesDispatchModel_DefaultMappedModelFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		group          *Group
+		requestedModel string
+		want           string
+	}{
+		{
+			name: "opus with no config uses hardcoded default",
+			group: &Group{
+				MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{},
+			},
+			requestedModel: "claude-opus-4-5",
+			want:           defaultOpenAIMessagesDispatchOpusMappedModel,
+		},
+		{
+			name: "opus with DefaultMappedModel uses group default as fallback",
+			group: &Group{
+				DefaultMappedModel:          "gpt-5.3-codex",
+				MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{},
+			},
+			requestedModel: "claude-opus-4-5",
+			want:           "gpt-5.3-codex",
+		},
+		{
+			name: "opus with explicit OpusMappedModel ignores DefaultMappedModel",
+			group: &Group{
+				DefaultMappedModel: "gpt-5.3-codex",
+				MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
+					OpusMappedModel: "gpt-5.4",
+				},
+			},
+			requestedModel: "claude-opus-4-5",
+			want:           "gpt-5.4",
+		},
+		{
+			name: "sonnet with DefaultMappedModel uses group default as fallback",
+			group: &Group{
+				DefaultMappedModel:          "gpt-5.3-codex",
+				MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{},
+			},
+			requestedModel: "claude-sonnet-4-5",
+			want:           "gpt-5.3-codex",
+		},
+		{
+			name: "haiku with DefaultMappedModel uses group default as fallback",
+			group: &Group{
+				DefaultMappedModel:          "gpt-5.3-codex",
+				MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{},
+			},
+			requestedModel: "claude-haiku-3-5",
+			want:           "gpt-5.3-codex",
+		},
+		{
+			name: "exact model mapping takes precedence over DefaultMappedModel",
+			group: &Group{
+				DefaultMappedModel: "gpt-5.3-codex",
+				MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
+					ExactModelMappings: map[string]string{
+						"claude-opus-4-5": "gpt-5.2",
+					},
+				},
+			},
+			requestedModel: "claude-opus-4-5",
+			want:           "gpt-5.2",
+		},
+		{
+			name:           "nil group returns empty",
+			group:          nil,
+			requestedModel: "claude-opus-4-5",
+			want:           "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.group.ResolveMessagesDispatchModel(tt.requestedModel)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
 
 func TestNormalizeOpenAIMessagesDispatchModelConfig(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #1582

## Problem

After the introduction of per-family `MessagesDispatchModelConfig` (opus/sonnet/haiku mappings), the `ResolveMessagesDispatchModel` function stopped honoring the group's `DefaultMappedModel` setting when no family-specific mapping was explicitly configured.

Previously, the handler used `resolveOpenAIForwardDefaultMappedModel` to get the group's `DefaultMappedModel` as a fallback for all Claude model families. After commit `4de4823a`, this was replaced by `effectiveMappedModel` which comes directly from `ResolveMessagesDispatchModel`, which falls through to hardcoded defaults (gpt-5.4 for opus, gpt-5.3-codex for sonnet, gpt-5.4-mini for haiku).

This broke existing groups that had `DefaultMappedModel` configured as a catch-all for all Claude model families — their claude-opus requests now always map to gpt-5.4 regardless of what `DefaultMappedModel` is set to.

## Solution

Add a `groupDefault` fallback in `ResolveMessagesDispatchModel` between the family-specific mapping and the hardcoded defaults.

New priority order:
1. `ExactModelMappings` (highest, unchanged)
2. Family-specific mapping (`OpusMappedModel` / `SonnetMappedModel` / `HaikuMappedModel`)
3. **Group `DefaultMappedModel`** (new — preserves backward-compatible behavior)
4. Hardcoded family defaults (`gpt-5.4` / `gpt-5.3-codex` / `gpt-5.4-mini`)

## Testing

Added `TestResolveMessagesDispatchModel_DefaultMappedModelFallback` covering:
- No config → hardcoded default
- `DefaultMappedModel` set with empty `MessagesDispatchModelConfig` → group default used for opus, sonnet, haiku
- Explicit family mapping present → family mapping takes precedence over `DefaultMappedModel`
- Exact model mapping present → exact mapping takes precedence over `DefaultMappedModel`
- Nil group → empty string returned