### PR TITLE
fix: handle Anthropic credit balance exhausted (400) as account error

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -142,9 +142,14 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 
 	switch statusCode {
 	case 400:
-		// 只有当错误信息包含 "organization has been disabled" 时才禁用
+		// "organization has been disabled" → 永久禁用
 		if strings.Contains(strings.ToLower(upstreamMsg), "organization has been disabled") {
 			msg := "Organization disabled (400): " + upstreamMsg
+			s.handleAuthError(ctx, account, msg)
+			shouldDisable = true
+		} else if account.Platform == PlatformAnthropic && strings.Contains(strings.ToLower(upstreamMsg), "credit balance") {
+			// Anthropic API key 余额不足（语义等同 402），停止调度
+			msg := "Credit balance exhausted (400): " + upstreamMsg
 			s.handleAuthError(ctx, account, msg)
 			shouldDisable = true
 		}


### PR DESCRIPTION
## Summary

- Anthropic API key 余额耗尽时返回 HTTP 400 + `"credit balance is too low"`，当前 `HandleUpstreamError` 的 `case 400:` 未匹配该错误，导致账号持续被调度、反复失败
- 新增 `"credit balance"` 关键词检测（仅限 `PlatformAnthropic`），走 `handleAuthError` → `SetError` 路径，与 402 Payment Required 行为一致

Closes #1586

## 错误示例

```json
{
  "error": {
    "message": "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
    "type": "invalid_request_error"
  },
  "request_id": "req_xxx",
  "type": "error"
}
```

## 改动

`backend/internal/service/ratelimit_service.go` — `HandleUpstreamError` `case 400:` 分支增加一个 `else if`：

```go
} else if account.Platform == PlatformAnthropic && strings.Contains(strings.ToLower(upstreamMsg), "credit balance") {
    msg := "Credit balance exhausted (400): " + upstreamMsg
    s.handleAuthError(ctx, account, msg)
    shouldDisable = true
}
```

## Test plan

- [ ] 添加余额为 0 的 Anthropic API key，发送请求，确认账号被标记为 `error` 状态
- [ ] 确认 error message 包含 `"Credit balance exhausted (400):"`
- [ ] 确认其他 400 错误（如参数错误）不受影响
- [ ] 确认非 Anthropic 平台的 400 不受影响