### PR TITLE
Fix IPv6-only proxy probing

### DIFF
--- a/backend/internal/repository/proxy_probe_service.go
+++ b/backend/internal/repository/proxy_probe_service.go
@@ -44,14 +44,14 @@ const (
 	defaultProxyProbeResponseMaxBytes = int64(1024 * 1024)
 )
 
-// probeURLs 按优先级排列的探测 URL 列表
-// 某些 AI API 专用代理只允许访问特定域名，因此需要多个备选
+// probeURLs 按优先级排列的探测 URL 列表。
+// 这里必须选择同时支持 HTTPS 和 IPv6 的站点，否则 IPv6-only 代理会被误判为不可用。
 var probeURLs = []struct {
 	url    string
-	parser string // "ip-api" or "httpbin"
+	parser string // "ifconfig" or "ipify"
 }{
-	{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
-	{"http://httpbin.org/ip", "httpbin"},
+	{"https://ifconfig.co/json", "ifconfig"},
+	{"https://api64.ipify.org?format=json", "ipify"},
 }
 
 type proxyProbeService struct {
@@ -87,10 +87,11 @@ func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*s
 
 func (s *proxyProbeService) probeWithURL(ctx context.Context, client *http.Client, url string, parser string) (*service.ProxyExitInfo, int64, error) {
 	startTime := time.Now()
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to create request: %w", err)
 	}
+	req.Header.Set("Accept", "application/json")
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -117,25 +118,23 @@ func (s *proxyProbeService) probeWithURL(ctx context.Context, client *http.Clien
 	}
 
 	switch parser {
-	case "ip-api":
-		return s.parseIPAPI(body, latencyMs)
-	case "httpbin":
-		return s.parseHTTPBin(body, latencyMs)
+	case "ifconfig":
+		return s.parseIfconfig(body, latencyMs)
+	case "ipify":
+		return s.parseIPify(body, latencyMs)
 	default:
 		return nil, latencyMs, fmt.Errorf("unknown parser: %s", parser)
 	}
 }
 
-func (s *proxyProbeService) parseIPAPI(body []byte, latencyMs int64) (*service.ProxyExitInfo, int64, error) {
+func (s *proxyProbeService) parseIfconfig(body []byte, latencyMs int64) (*service.ProxyExitInfo, int64, error) {
 	var ipInfo struct {
-		Status      string `json:"status"`
-		Message     string `json:"message"`
-		Query       string `json:"query"`
-		City        string `json:"city"`
-		Region      string `json:"region"`
-		RegionName  string `json:"regionName"`
-		Country     string `json:"country"`
-		CountryCode string `json:"countryCode"`
+		IP         string `json:"ip"`
+		City       string `json:"city"`
+		RegionName string `json:"region_name"`
+		RegionCode string `json:"region_code"`
+		Country    string `json:"country"`
+		CountryISO string `json:"country_iso"`
 	}
 
 	if err := json.Unmarshal(body, &ipInfo); err != nil {
@@ -145,38 +144,34 @@ func (s *proxyProbeService) parseIPAPI(body []byte, latencyMs int64) (*service.P
 		}
 		return nil, latencyMs, fmt.Errorf("failed to parse response: %w (body: %s)", err, preview)
 	}
-	if strings.ToLower(ipInfo.Status) != "success" {
-		if ipInfo.Message == "" {
-			ipInfo.Message = "ip-api request failed"
-		}
-		return nil, latencyMs, fmt.Errorf("ip-api request failed: %s", ipInfo.Message)
+	if strings.TrimSpace(ipInfo.IP) == "" {
+		return nil, latencyMs, fmt.Errorf("ifconfig: no IP found in response")
 	}
 
 	region := ipInfo.RegionName
 	if region == "" {
-		region = ipInfo.Region
+		region = ipInfo.RegionCode
 	}
 	return &service.ProxyExitInfo{
-		IP:          ipInfo.Query,
+		IP:          ipInfo.IP,
 		City:        ipInfo.City,
 		Region:      region,
 		Country:     ipInfo.Country,
-		CountryCode: ipInfo.CountryCode,
+		CountryCode: ipInfo.CountryISO,
 	}, latencyMs, nil
 }
 
-func (s *proxyProbeService) parseHTTPBin(body []byte, latencyMs int64) (*service.ProxyExitInfo, int64, error) {
-	// httpbin.org/ip 返回格式: {"origin": "1.2.3.4"}
+func (s *proxyProbeService) parseIPify(body []byte, latencyMs int64) (*service.ProxyExitInfo, int64, error) {
 	var result struct {
-		Origin string `json:"origin"`
+		IP string `json:"ip"`
 	}
 	if err := json.Unmarshal(body, &result); err != nil {
-		return nil, latencyMs, fmt.Errorf("failed to parse httpbin response: %w", err)
+		return nil, latencyMs, fmt.Errorf("failed to parse ipify response: %w", err)
 	}
-	if result.Origin == "" {
-		return nil, latencyMs, fmt.Errorf("httpbin: no IP found in response")
+	if strings.TrimSpace(result.IP) == "" {
+		return nil, latencyMs, fmt.Errorf("ipify: no IP found in response")
 	}
 	return &service.ProxyExitInfo{
-		IP: result.Origin,
+		IP: result.IP,
 	}, latencyMs, nil
 }

--- a/backend/internal/repository/proxy_probe_service_test.go
+++ b/backend/internal/repository/proxy_probe_service_test.go
@@ -49,20 +49,18 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_UnsupportedProxyScheme() {
 	require.ErrorContains(s.T(), err, "failed to create proxy client")
 }
 
-func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPAPI() {
+func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_Ifconfig() {
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// 检查是否是 ip-api 请求
-		if strings.Contains(r.RequestURI, "ip-api.com") {
+		if strings.Contains(r.RequestURI, "ifconfig.co") {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"status":"success","query":"1.2.3.4","city":"c","regionName":"r","country":"cc","countryCode":"CC"}`)
+			_, _ = io.WriteString(w, `{"ip":"1.2.3.4","city":"c","region_name":"r","country":"cc","country_iso":"CC"}`)
 			return
 		}
-		// 其他请求返回错误
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 
 	info, latencyMs, err := s.prober.ProbeProxy(s.ctx, s.proxySrv.URL)
-	require.NoError(s.T(), err, "ProbeProxy")
+	require.NoError(s.T(), err)
 	require.GreaterOrEqual(s.T(), latencyMs, int64(0), "unexpected latency")
 	require.Equal(s.T(), "1.2.3.4", info.IP)
 	require.Equal(s.T(), "c", info.City)
@@ -71,24 +69,22 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPAPI() {
 	require.Equal(s.T(), "CC", info.CountryCode)
 }
 
-func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_HTTPBinFallback() {
+func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPifyFallback() {
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// ip-api 失败
-		if strings.Contains(r.RequestURI, "ip-api.com") {
+		if strings.Contains(r.RequestURI, "ifconfig.co") {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
-		// httpbin 成功
-		if strings.Contains(r.RequestURI, "httpbin.org") {
+		if strings.Contains(r.RequestURI, "api64.ipify.org") {
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = io.WriteString(w, `{"origin": "5.6.7.8"}`)
+			_, _ = io.WriteString(w, `{"ip": "5.6.7.8"}`)
 			return
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 
 	info, latencyMs, err := s.prober.ProbeProxy(s.ctx, s.proxySrv.URL)
-	require.NoError(s.T(), err, "ProbeProxy should fallback to httpbin")
+	require.NoError(s.T(), err, "ProbeProxy should fallback to ipify")
 	require.GreaterOrEqual(s.T(), latencyMs, int64(0), "unexpected latency")
 	require.Equal(s.T(), "5.6.7.8", info.IP)
 }
@@ -105,13 +101,12 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_AllFailed() {
 
 func (s *ProxyProbeServiceSuite) TestProbeProxy_InvalidJSON() {
 	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.RequestURI, "ip-api.com") {
+		if strings.Contains(r.RequestURI, "ifconfig.co") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, "not-json")
 			return
 		}
-		// httpbin 也返回无效响应
-		if strings.Contains(r.RequestURI, "httpbin.org") {
+		if strings.Contains(r.RequestURI, "api64.ipify.org") {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = io.WriteString(w, "not-json")
 			return
@@ -132,9 +127,9 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_ProxyServerClosed() {
 	require.Error(s.T(), err, "expected error when proxy server is closed")
 }
 
-func (s *ProxyProbeServiceSuite) TestParseIPAPI_Success() {
-	body := []byte(`{"status":"success","query":"1.2.3.4","city":"Beijing","regionName":"Beijing","country":"China","countryCode":"CN"}`)
-	info, latencyMs, err := s.prober.parseIPAPI(body, 100)
+func (s *ProxyProbeServiceSuite) TestParseIfconfig_Success() {
+	body := []byte(`{"ip":"1.2.3.4","city":"Beijing","region_name":"Beijing","country":"China","country_iso":"CN"}`)
+	info, latencyMs, err := s.prober.parseIfconfig(body, 100)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), int64(100), latencyMs)
 	require.Equal(s.T(), "1.2.3.4", info.IP)
@@ -144,24 +139,24 @@ func (s *ProxyProbeServiceSuite) TestParseIPAPI_Success() {
 	require.Equal(s.T(), "CN", info.CountryCode)
 }
 
-func (s *ProxyProbeServiceSuite) TestParseIPAPI_Failure() {
-	body := []byte(`{"status":"fail","message":"rate limited"}`)
-	_, _, err := s.prober.parseIPAPI(body, 100)
+func (s *ProxyProbeServiceSuite) TestParseIfconfig_NoIP() {
+	body := []byte(`{"ip":""}`)
+	_, _, err := s.prober.parseIfconfig(body, 100)
 	require.Error(s.T(), err)
-	require.ErrorContains(s.T(), err, "rate limited")
+	require.ErrorContains(s.T(), err, "no IP found")
 }
 
-func (s *ProxyProbeServiceSuite) TestParseHTTPBin_Success() {
-	body := []byte(`{"origin": "9.8.7.6"}`)
-	info, latencyMs, err := s.prober.parseHTTPBin(body, 50)
+func (s *ProxyProbeServiceSuite) TestParseIPify_Success() {
+	body := []byte(`{"ip":"9.8.7.6"}`)
+	info, latencyMs, err := s.prober.parseIPify(body, 50)
 	require.NoError(s.T(), err)
 	require.Equal(s.T(), int64(50), latencyMs)
 	require.Equal(s.T(), "9.8.7.6", info.IP)
 }
 
-func (s *ProxyProbeServiceSuite) TestParseHTTPBin_NoIP() {
-	body := []byte(`{"origin": ""}`)
-	_, _, err := s.prober.parseHTTPBin(body, 50)
+func (s *ProxyProbeServiceSuite) TestParseIPify_NoIP() {
+	body := []byte(`{"ip":""}`)
+	_, _, err := s.prober.parseIPify(body, 50)
 	require.Error(s.T(), err)
 	require.ErrorContains(s.T(), err, "no IP found")
 }


### PR DESCRIPTION
## Summary
- replace the proxy probe URLs with HTTPS endpoints that are reachable from IPv6-only proxies
- parse `ifconfig.co` and `api64.ipify.org` responses instead of `ip-api` / `httpbin`
- update the repository tests to cover the new probe sources

## Context
The admin proxy test / quality check currently probes `ip-api.com` and `httpbin.org`. In production we hit a socks5 proxy with an IPv6-only exit: account traffic worked through the proxy, but IP management always marked it unavailable because those probe endpoints failed while IPv6-capable HTTPS endpoints succeeded.

## Verification
- validated on a live IPv6-only socks5 proxy that `https://ifconfig.co/json` and `https://api64.ipify.org?format=json` return the exit IPv6
- updated the unit tests for the new probe parsers and fallback order
