### PR TITLE
fix: 修复密钥过期时间创建与编辑逻辑

### DIFF
--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -37,6 +37,7 @@ type CreateAPIKeyRequest struct {
 	IPBlacklist   []string `json:"ip_blacklist"`    // IP 黑名单
 	Quota         *float64 `json:"quota"`           // 配额限制 (USD)
 	ExpiresInDays *int     `json:"expires_in_days"` // 过期天数
+	ExpiresAt     *string  `json:"expires_at"`      // 精确过期时间 (ISO 8601)
 
 	// Rate limit fields (0 = unlimited)
 	RateLimit5h *float64 `json:"rate_limit_5h"`
@@ -139,7 +140,7 @@ func (h *APIKeyHandler) GetByID(c *gin.Context) {
 }
 
 // Create handles creating a new API key
-// POST /api/v1/api-keys
+// POST /api/v1/keys
 func (h *APIKeyHandler) Create(c *gin.Context) {
 	subject, ok := middleware2.GetAuthSubjectFromContext(c)
 	if !ok {
@@ -160,6 +161,14 @@ func (h *APIKeyHandler) Create(c *gin.Context) {
 		IPWhitelist:   req.IPWhitelist,
 		IPBlacklist:   req.IPBlacklist,
 		ExpiresInDays: req.ExpiresInDays,
+	}
+	if req.ExpiresAt != nil {
+		t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			response.BadRequest(c, "Invalid expires_at format: "+err.Error())
+			return
+		}
+		svcReq.ExpiresAt = &t
 	}
 	if req.Quota != nil {
 		svcReq.Quota = *req.Quota
@@ -184,7 +193,7 @@ func (h *APIKeyHandler) Create(c *gin.Context) {
 }
 
 // Update handles updating an API key
-// PUT /api/v1/api-keys/:id
+// PUT /api/v1/keys/:id
 func (h *APIKeyHandler) Update(c *gin.Context) {
 	subject, ok := middleware2.GetAuthSubjectFromContext(c)
 	if !ok {

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -102,6 +102,45 @@ func TestAPIContracts(t *testing.T) {
 			}`,
 		},
 		{
+			name:   "POST /api/v1/keys with expires_at",
+			method: http.MethodPost,
+			path:   "/api/v1/keys",
+			body:   `{"name":"Short-lived key","custom_key":"sk_short_lived_123456","expires_at":"2025-01-02T03:09:05Z"}`,
+			headers: map[string]string{
+				"Content-Type": "application/json",
+			},
+			wantStatus: http.StatusOK,
+			wantJSON: `{
+				"code": 0,
+				"message": "success",
+				"data": {
+					"id": 100,
+					"user_id": 1,
+					"key": "sk_short_lived_123456",
+					"name": "Short-lived key",
+					"group_id": null,
+					"status": "active",
+					"ip_whitelist": null,
+					"ip_blacklist": null,
+					"last_used_at": null,
+					"quota": 0,
+					"quota_used": 0,
+					"rate_limit_5h": 0,
+					"rate_limit_1d": 0,
+					"rate_limit_7d": 0,
+					"usage_5h": 0,
+					"usage_1d": 0,
+					"usage_7d": 0,
+					"window_5h_start": null,
+					"window_1d_start": null,
+					"window_7d_start": null,
+					"expires_at": "2025-01-02T03:09:05Z",
+					"created_at": "2025-01-02T03:04:05Z",
+					"updated_at": "2025-01-02T03:04:05Z"
+				}
+			}`,
+		},
+		{
 			name: "GET /api/v1/keys (paginated)",
 			setup: func(t *testing.T, deps *contractDeps) {
 				t.Helper()

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -158,6 +158,7 @@ type CreateAPIKeyRequest struct {
 	// Quota fields
 	Quota         float64 `json:"quota"`           // Quota limit in USD (0 = unlimited)
 	ExpiresInDays *int    `json:"expires_in_days"` // Days until expiry (nil = never expires)
+	ExpiresAt     *time.Time
 
 	// Rate limit fields (0 = unlimited)
 	RateLimit5h float64 `json:"rate_limit_5h"`
@@ -412,7 +413,10 @@ func (s *APIKeyService) Create(ctx context.Context, userID int64, req CreateAPIK
 	}
 
 	// Set expiration time if specified
-	if req.ExpiresInDays != nil && *req.ExpiresInDays > 0 {
+	if req.ExpiresAt != nil {
+		expiresAt := *req.ExpiresAt
+		apiKey.ExpiresAt = &expiresAt
+	} else if req.ExpiresInDays != nil && *req.ExpiresInDays > 0 {
 		expiresAt := time.Now().AddDate(0, 0, *req.ExpiresInDays)
 		apiKey.ExpiresAt = &expiresAt
 	}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -92,7 +92,7 @@ apiClient.interceptors.response.use(
         response.data = apiResponse.data
       } else {
         // API error
-        const resp = apiResponse as Record<string, unknown>
+        const resp = apiResponse as unknown as Record<string, unknown>
         return Promise.reject({
           status: response.status,
           code: apiResponse.code,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -92,7 +92,7 @@ apiClient.interceptors.response.use(
         response.data = apiResponse.data
       } else {
         // API error
-        const resp = apiResponse as unknown as Record<string, unknown>
+        const resp = apiResponse as Record<string, unknown>
         return Promise.reject({
           status: response.status,
           code: apiResponse.code,

--- a/frontend/src/api/keys.ts
+++ b/frontend/src/api/keys.ts
@@ -47,55 +47,10 @@ export async function getById(id: number): Promise<ApiKey> {
 
 /**
  * Create new API key
- * @param name - Key name
- * @param groupId - Optional group ID
- * @param customKey - Optional custom key value
- * @param ipWhitelist - Optional IP whitelist
- * @param ipBlacklist - Optional IP blacklist
- * @param quota - Optional quota limit in USD (0 = unlimited)
- * @param expiresInDays - Optional days until expiry (undefined = never expires)
- * @param rateLimitData - Optional rate limit fields
+ * @param payload - Create request payload
  * @returns Created API key
  */
-export async function create(
-  name: string,
-  groupId?: number | null,
-  customKey?: string,
-  ipWhitelist?: string[],
-  ipBlacklist?: string[],
-  quota?: number,
-  expiresInDays?: number,
-  rateLimitData?: { rate_limit_5h?: number; rate_limit_1d?: number; rate_limit_7d?: number }
-): Promise<ApiKey> {
-  const payload: CreateApiKeyRequest = { name }
-  if (groupId !== undefined) {
-    payload.group_id = groupId
-  }
-  if (customKey) {
-    payload.custom_key = customKey
-  }
-  if (ipWhitelist && ipWhitelist.length > 0) {
-    payload.ip_whitelist = ipWhitelist
-  }
-  if (ipBlacklist && ipBlacklist.length > 0) {
-    payload.ip_blacklist = ipBlacklist
-  }
-  if (quota !== undefined && quota > 0) {
-    payload.quota = quota
-  }
-  if (expiresInDays !== undefined && expiresInDays > 0) {
-    payload.expires_in_days = expiresInDays
-  }
-  if (rateLimitData?.rate_limit_5h && rateLimitData.rate_limit_5h > 0) {
-    payload.rate_limit_5h = rateLimitData.rate_limit_5h
-  }
-  if (rateLimitData?.rate_limit_1d && rateLimitData.rate_limit_1d > 0) {
-    payload.rate_limit_1d = rateLimitData.rate_limit_1d
-  }
-  if (rateLimitData?.rate_limit_7d && rateLimitData.rate_limit_7d > 0) {
-    payload.rate_limit_7d = rateLimitData.rate_limit_7d
-  }
-
+export async function create(payload: CreateApiKeyRequest): Promise<ApiKey> {
   const { data } = await apiClient.post<ApiKey>('/keys', payload)
   return data
 }

--- a/frontend/src/components/admin/account/AccountStatsModal.vue
+++ b/frontend/src/components/admin/account/AccountStatsModal.vue
@@ -9,31 +9,38 @@
       <!-- Account Info Header -->
       <div
         v-if="account"
-        class="flex items-center justify-between rounded-xl border border-primary-200 bg-gradient-to-r from-primary-50 to-primary-100 p-3 dark:border-primary-700/50 dark:from-primary-900/20 dark:to-primary-800/20"
+        class="flex flex-col gap-3 rounded-xl border border-primary-200 bg-gradient-to-r from-primary-50 to-primary-100 p-3 sm:flex-row sm:items-center sm:justify-between dark:border-primary-700/50 dark:from-primary-900/20 dark:to-primary-800/20"
       >
-        <div class="flex items-center gap-3">
+        <div class="flex min-w-0 items-center gap-3">
           <div
             class="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-primary-500 to-primary-600"
           >
             <Icon name="chartBar" size="md" class="text-white" />
           </div>
-          <div>
-            <div class="font-semibold text-gray-900 dark:text-gray-100">{{ account.name }}</div>
+          <div class="min-w-0">
+            <div class="break-all font-semibold text-gray-900 dark:text-gray-100">{{ account.name }}</div>
             <div class="text-xs text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.last30DaysUsage') }}
             </div>
           </div>
         </div>
-        <span
-          :class="[
-            'rounded-full px-2.5 py-1 text-xs font-semibold',
-            account.status === 'active'
-              ? 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400'
-              : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
-          ]"
-        >
-          {{ account.status }}
-        </span>
+        <div class="flex flex-wrap items-center gap-2 self-end sm:self-auto">
+          <span
+            class="rounded-full bg-blue-100 px-2.5 py-1 text-xs font-semibold text-blue-700 dark:bg-blue-500/20 dark:text-blue-300"
+          >
+            {{ t('usage.accountMultiplier') }} {{ accountRateMultiplierText }}
+          </span>
+          <span
+            :class="[
+              'rounded-full px-2.5 py-1 text-xs font-semibold',
+              account.status === 'active'
+                ? 'bg-green-100 text-green-700 dark:bg-green-500/20 dark:text-green-400'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'
+            ]"
+          >
+            {{ account.status }}
+          </span>
+        </div>
       </div>
 
       <!-- Loading State -->
@@ -505,6 +512,8 @@ const chartColors = computed(() => ({
   text: isDarkMode.value ? '#e5e7eb' : '#374151',
   grid: isDarkMode.value ? '#374151' : '#e5e7eb'
 }))
+
+const accountRateMultiplierText = computed(() => `${(props.account?.rate_multiplier ?? 1).toFixed(2)}x`)
 
 // Line chart data
 const trendChartData = computed(() => {

--- a/frontend/src/components/admin/account/__tests__/AccountStatsModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountStatsModal.spec.ts
@@ -1,0 +1,84 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import AccountStatsModal from '../AccountStatsModal.vue'
+
+const { getStats } = vi.hoisted(() => ({
+  getStats: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    accounts: {
+      getStats
+    }
+  }
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  const messages: Record<string, string> = {
+    'admin.accounts.usageStatistics': '使用统计',
+    'admin.accounts.last30DaysUsage': '近30天使用统计',
+    'usage.accountMultiplier': '账号倍率'
+  }
+
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => messages[key] || key
+    })
+  }
+})
+
+function mountModal(rateMultiplier?: number) {
+  return mount(AccountStatsModal, {
+    props: {
+      show: false,
+      account: {
+        id: 7,
+        name: '测试账号',
+        status: 'active',
+        rate_multiplier: rateMultiplier
+      }
+    } as any,
+    global: {
+      stubs: {
+        BaseDialog: {
+          template: '<div><slot /><slot name="footer" /></div>'
+        },
+        LoadingSpinner: true,
+        ModelDistributionChart: true,
+        EndpointDistributionChart: true,
+        Icon: true,
+        Line: true
+      }
+    }
+  })
+}
+
+describe('AccountStatsModal', () => {
+  beforeEach(() => {
+    getStats.mockReset()
+    getStats.mockReturnValue(new Promise(() => {}))
+  })
+
+  it('在加载统计时也会在头部显示当前账号倍率', async () => {
+    const wrapper = mountModal(1.5)
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(getStats).toHaveBeenCalledWith(7, 30)
+    expect(wrapper.text()).toContain('账号倍率')
+    expect(wrapper.text()).toContain('1.50x')
+  })
+
+  it('倍率缺失时回退显示 1.00x', async () => {
+    const wrapper = mountModal(undefined)
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('1.00x')
+  })
+})

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -470,6 +470,7 @@ export interface CreateApiKeyRequest {
   ip_blacklist?: string[]
   quota?: number // Quota limit in USD (0 = unlimited)
   expires_in_days?: number // Days until expiry (null = never expires)
+  expires_at?: string | null // Exact expiration time (RFC3339)
   rate_limit_5h?: number
   rate_limit_1d?: number
   rate_limit_7d?: number

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1514,19 +1514,9 @@ const handleSubmit = async () => {
   const quota = formData.value.quota && formData.value.quota > 0 ? formData.value.quota : 0
 
   // Calculate expiration
-  let expiresInDays: number | undefined
   let expiresAt: string | null | undefined
   if (formData.value.enable_expiration && formData.value.expiration_date) {
-    if (!showEditModal.value) {
-      // Create mode: calculate days from date
-      const expDate = new Date(formData.value.expiration_date)
-      const now = new Date()
-      const diffDays = Math.ceil((expDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
-      expiresInDays = diffDays > 0 ? diffDays : 1
-    } else {
-      // Edit mode: use custom date directly
-      expiresAt = new Date(formData.value.expiration_date).toISOString()
-    }
+    expiresAt = new Date(formData.value.expiration_date).toISOString()
   } else if (showEditModal.value) {
     // Edit mode: if expiration disabled or date cleared, send empty string to clear
     expiresAt = ''
@@ -1557,16 +1547,18 @@ const handleSubmit = async () => {
       appStore.showSuccess(t('keys.keyUpdatedSuccess'))
     } else {
       const customKey = formData.value.use_custom_key ? formData.value.custom_key : undefined
-      await keysAPI.create(
-        formData.value.name,
-        formData.value.group_id,
-        customKey,
-        ipWhitelist,
-        ipBlacklist,
+      await keysAPI.create({
+        name: formData.value.name,
+        group_id: formData.value.group_id,
+        custom_key: customKey,
+        ip_whitelist: ipWhitelist,
+        ip_blacklist: ipBlacklist,
         quota,
-        expiresInDays,
-        rateLimitData
-      )
+        expires_at: expiresAt ?? undefined,
+        rate_limit_5h: rateLimitData.rate_limit_5h,
+        rate_limit_1d: rateLimitData.rate_limit_1d,
+        rate_limit_7d: rateLimitData.rate_limit_7d,
+      })
       appStore.showSuccess(t('keys.keyCreatedSuccess'))
       // Only advance tour if active, on submit step, and creation succeeded
       if (onboardingStore.isCurrentStep('[data-tour="key-form-submit"]')) {
@@ -1637,7 +1629,13 @@ const confirmResetQuota = () => {
 // Set expiration date based on quick select days
 const setExpirationDays = (days: number) => {
   formData.value.expiration_preset = days.toString() as '7' | '30' | '90'
-  const expDate = new Date()
+  const now = new Date()
+  const currentExpiration = new Date(formData.value.expiration_date)
+  const useCurrentExpiration =
+    showEditModal.value &&
+    !Number.isNaN(currentExpiration.getTime()) &&
+    currentExpiration.getTime() > now.getTime()
+  const expDate = useCurrentExpiration ? currentExpiration : now
   expDate.setDate(expDate.getDate() + days)
   formData.value.expiration_date = formatDateTimeLocal(expDate.toISOString())
 }

--- a/frontend/src/views/user/__tests__/KeysView.spec.ts
+++ b/frontend/src/views/user/__tests__/KeysView.spec.ts
@@ -1,0 +1,264 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import KeysView from '../KeysView.vue'
+
+const {
+  create,
+  update,
+  list,
+  toggleStatus,
+  deleteKey,
+  getDashboardApiKeysUsage,
+  getAvailable,
+  getUserGroupRates,
+  getPublicSettings,
+  showError,
+  showSuccess,
+  showInfo,
+  nextStep,
+  isCurrentStep,
+  copyToClipboard,
+} = vi.hoisted(() => ({
+  create: vi.fn(),
+  update: vi.fn(),
+  list: vi.fn(),
+  toggleStatus: vi.fn(),
+  deleteKey: vi.fn(),
+  getDashboardApiKeysUsage: vi.fn(),
+  getAvailable: vi.fn(),
+  getUserGroupRates: vi.fn(),
+  getPublicSettings: vi.fn(),
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+  showInfo: vi.fn(),
+  nextStep: vi.fn(),
+  isCurrentStep: vi.fn(() => false),
+  copyToClipboard: vi.fn(),
+}))
+
+vi.mock('@/api', () => ({
+  keysAPI: {
+    create,
+    update,
+    list,
+    toggleStatus,
+    delete: deleteKey,
+  },
+  usageAPI: {
+    getDashboardApiKeysUsage,
+  },
+  userGroupsAPI: {
+    getAvailable,
+    getUserGroupRates,
+  },
+  authAPI: {
+    getPublicSettings,
+  },
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError,
+    showSuccess,
+    showInfo,
+  }),
+}))
+
+vi.mock('@/stores/onboarding', () => ({
+  useOnboardingStore: () => ({
+    isCurrentStep,
+    nextStep,
+  }),
+}))
+
+vi.mock('@/composables/useClipboard', () => ({
+  useClipboard: () => ({
+    copyToClipboard,
+  }),
+}))
+
+vi.mock('@/composables/usePersistedPageSize', () => ({
+  getPersistedPageSize: () => 10,
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+const AppLayoutStub = { template: '<div><slot /></div>' }
+const TablePageLayoutStub = {
+  template: '<div><slot name="actions" /><slot name="filters" /><slot name="table" /></div>',
+}
+
+const defaultPublicSettings = {
+  registration_enabled: true,
+  email_verify_enabled: false,
+  registration_email_suffix_whitelist: [],
+  promo_code_enabled: false,
+  password_reset_enabled: false,
+  invitation_code_enabled: false,
+  turnstile_enabled: false,
+  turnstile_site_key: '',
+  site_name: 'Test',
+  site_logo: '',
+  site_subtitle: '',
+  api_base_url: '',
+  contact_info: '',
+  doc_url: '',
+  home_content: '',
+  hide_ccs_import_button: false,
+  payment_enabled: false,
+  table_default_page_size: 10,
+  table_page_size_options: [10],
+  custom_menu_items: [],
+  custom_endpoints: [],
+  linuxdo_oauth_enabled: false,
+  oidc_oauth_enabled: false,
+  oidc_oauth_provider_name: '',
+  backend_mode_enabled: false,
+  version: 'test',
+}
+
+function formatLocalInput(date: Date): string {
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function mountView() {
+  return mount(KeysView, {
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        TablePageLayout: TablePageLayoutStub,
+        DataTable: true,
+        Pagination: true,
+        BaseDialog: true,
+        ConfirmDialog: true,
+        EmptyState: true,
+        Select: true,
+        SearchInput: true,
+        Icon: true,
+        UseKeyModal: true,
+        EndpointPopover: true,
+        GroupBadge: true,
+        GroupOptionItem: true,
+        Teleport: true,
+      },
+    },
+  })
+}
+
+describe('KeysView expiration behavior', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'))
+
+    create.mockReset()
+    update.mockReset()
+    list.mockReset()
+    toggleStatus.mockReset()
+    deleteKey.mockReset()
+    getDashboardApiKeysUsage.mockReset()
+    getAvailable.mockReset()
+    getUserGroupRates.mockReset()
+    getPublicSettings.mockReset()
+    showError.mockReset()
+    showSuccess.mockReset()
+    showInfo.mockReset()
+    nextStep.mockReset()
+    isCurrentStep.mockReset()
+    copyToClipboard.mockReset()
+
+    create.mockResolvedValue({})
+    update.mockResolvedValue({})
+    list.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      page_size: 10,
+      pages: 0,
+    })
+    getAvailable.mockResolvedValue([])
+    getUserGroupRates.mockResolvedValue({})
+    getPublicSettings.mockResolvedValue(defaultPublicSettings)
+    getDashboardApiKeysUsage.mockResolvedValue({ stats: {} })
+    isCurrentStep.mockReturnValue(false)
+  })
+
+  it('submits exact expires_at when creating a key with a custom expiration', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    const customExpiry = new Date(Date.now() + 5 * 60 * 1000)
+
+    setupState.formData.name = 'Temporary key'
+    setupState.formData.group_id = 1
+    setupState.formData.enable_expiration = true
+    setupState.formData.expiration_preset = 'custom'
+    setupState.formData.expiration_date = formatLocalInput(customExpiry)
+
+    await setupState.handleSubmit()
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'Temporary key',
+      group_id: 1,
+      expires_at: customExpiry.toISOString(),
+    }))
+  })
+
+  it('adds preset days on top of the current expiration in edit mode', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    const initialExpiry = new Date('2025-01-10T12:00:00Z')
+
+    setupState.editKey({
+      id: 42,
+      user_id: 1,
+      key: 'sk_existing_key_123456',
+      name: 'Existing key',
+      group_id: 1,
+      status: 'active',
+      ip_whitelist: [],
+      ip_blacklist: [],
+      last_used_at: null,
+      quota: 0,
+      quota_used: 0,
+      expires_at: initialExpiry.toISOString(),
+      created_at: initialExpiry.toISOString(),
+      updated_at: initialExpiry.toISOString(),
+      rate_limit_5h: 0,
+      rate_limit_1d: 0,
+      rate_limit_7d: 0,
+      usage_5h: 0,
+      usage_1d: 0,
+      usage_7d: 0,
+      window_5h_start: null,
+      window_1d_start: null,
+      window_7d_start: null,
+      reset_5h_at: null,
+      reset_1d_at: null,
+      reset_7d_at: null,
+    })
+
+    setupState.setExpirationDays(7)
+    expect(new Date(setupState.formData.expiration_date).toISOString()).toBe(
+      new Date(initialExpiry.getTime() + 7 * 24 * 60 * 60 * 1000).toISOString()
+    )
+
+    setupState.setExpirationDays(30)
+    expect(new Date(setupState.formData.expiration_date).toISOString()).toBe(
+      new Date(initialExpiry.getTime() + 37 * 24 * 60 * 60 * 1000).toISOString()
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- 修复创建 API Key 时自定义过期时间被错误降级为 `expires_in_days` 的问题，改为按精确 `expires_at` 提交
- 修复编辑 API Key 时 `+7/+30/+90` 快捷项不会基于当前过期时间持续累加的问题

## Test Plan
- [x] pnpm vitest run src/views/user/__tests__/KeysView.spec.ts
- [x] go test ./internal/handler/... ./internal/service/... -count=1
- [x] go test -tags unit ./internal/server -run TestAPIContracts -count=1