### PR TITLE
fix(payment): register Alipay/Wxpay providers for base payment types

### DIFF
--- a/backend/internal/payment/load_balancer.go
+++ b/backend/internal/payment/load_balancer.go
@@ -94,17 +94,21 @@ func (lb *DefaultLoadBalancer) SelectInstance(
 	return lb.buildSelection(selected.inst)
 }
 
-// queryEnabledInstances returns enabled instances for providerKey that support paymentType.
+// queryEnabledInstances returns enabled instances that support paymentType.
+// When providerKey is non-empty, only instances with that provider key are considered.
+// When providerKey is empty, instances across all providers are considered,
+// enabling cross-provider load balancing (e.g. EasyPay + Alipay direct for "alipay").
 func (lb *DefaultLoadBalancer) queryEnabledInstances(
 	ctx context.Context,
 	providerKey string,
 	paymentType PaymentType,
 ) ([]*dbent.PaymentProviderInstance, error) {
-	instances, err := lb.db.PaymentProviderInstance.Query().
-		Where(
-			paymentproviderinstance.ProviderKey(providerKey),
-			paymentproviderinstance.Enabled(true),
-		).
+	query := lb.db.PaymentProviderInstance.Query().
+		Where(paymentproviderinstance.Enabled(true))
+	if providerKey != "" {
+		query = query.Where(paymentproviderinstance.ProviderKey(providerKey))
+	}
+	instances, err := query.
 		Order(dbent.Asc(paymentproviderinstance.FieldSortOrder)).
 		All(ctx)
 	if err != nil {
@@ -113,12 +117,12 @@ func (lb *DefaultLoadBalancer) queryEnabledInstances(
 
 	var matched []*dbent.PaymentProviderInstance
 	for _, inst := range instances {
-		if paymentType == providerKey || InstanceSupportsType(inst.SupportedTypes, paymentType) {
+		if InstanceSupportsType(inst.SupportedTypes, paymentType) {
 			matched = append(matched, inst)
 		}
 	}
 	if len(matched) == 0 {
-		return nil, fmt.Errorf("no enabled instance for provider %s type %s", providerKey, paymentType)
+		return nil, fmt.Errorf("no enabled instance for payment type %s", paymentType)
 	}
 	return matched, nil
 }
@@ -258,6 +262,7 @@ func (lb *DefaultLoadBalancer) buildSelection(selected *dbent.PaymentProviderIns
 
 	return &InstanceSelection{
 		InstanceID:     fmt.Sprintf("%d", selected.ID),
+		ProviderKey:    selected.ProviderKey,
 		Config:         config,
 		SupportedTypes: selected.SupportedTypes,
 		PaymentMode:    selected.PaymentMode,

--- a/backend/internal/payment/provider/alipay.go
+++ b/backend/internal/payment/provider/alipay.go
@@ -76,7 +76,7 @@ func (a *Alipay) getClient() (*alipay.Client, error) {
 func (a *Alipay) Name() string        { return "Alipay" }
 func (a *Alipay) ProviderKey() string { return payment.TypeAlipay }
 func (a *Alipay) SupportedTypes() []payment.PaymentType {
-	return []payment.PaymentType{payment.TypeAlipayDirect}
+	return []payment.PaymentType{payment.TypeAlipay}
 }
 
 // CreatePayment creates an Alipay payment page URL.

--- a/backend/internal/payment/provider/wxpay.go
+++ b/backend/internal/payment/provider/wxpay.go
@@ -72,7 +72,7 @@ func NewWxpay(instanceID string, config map[string]string) (*Wxpay, error) {
 func (w *Wxpay) Name() string        { return "Wxpay" }
 func (w *Wxpay) ProviderKey() string { return payment.TypeWxpay }
 func (w *Wxpay) SupportedTypes() []payment.PaymentType {
-	return []payment.PaymentType{payment.TypeWxpayDirect}
+	return []payment.PaymentType{payment.TypeWxpay}
 }
 
 func formatPEM(key, keyType string) string {

--- a/backend/internal/payment/types.go
+++ b/backend/internal/payment/types.go
@@ -148,6 +148,7 @@ type RefundResponse struct {
 // InstanceSelection holds the selected provider instance and its decrypted config.
 type InstanceSelection struct {
 	InstanceID     string
+	ProviderKey    string // Provider key of the selected instance (e.g. "alipay", "easypay")
 	Config         map[string]string
 	SupportedTypes string // Comma-separated list of supported payment types from the instance
 	PaymentMode    string // Payment display mode: "qrcode", "redirect", "popup"

--- a/backend/internal/service/payment_order.go
+++ b/backend/internal/service/payment_order.go
@@ -189,19 +189,16 @@ func (s *PaymentService) checkDailyLimit(ctx context.Context, tx *dbent.Tx, user
 }
 
 func (s *PaymentService) invokeProvider(ctx context.Context, order *dbent.PaymentOrder, req CreateOrderRequest, cfg *PaymentConfig, payAmountStr string, payAmount float64, plan *dbent.SubscriptionPlan) (*CreateOrderResponse, error) {
-	s.EnsureProviders(ctx)
-	providerKey := s.registry.GetProviderKey(req.PaymentType)
-	if providerKey == "" {
-		return nil, infraerrors.ServiceUnavailable("PAYMENT_GATEWAY_ERROR", fmt.Sprintf("payment method (%s) is not configured", req.PaymentType))
-	}
-	sel, err := s.loadBalancer.SelectInstance(ctx, providerKey, req.PaymentType, payment.Strategy(cfg.LoadBalanceStrategy), payAmount)
+	// Select an instance across all providers that support the requested payment type.
+	// This enables cross-provider load balancing (e.g. EasyPay + Alipay direct for "alipay").
+	sel, err := s.loadBalancer.SelectInstance(ctx, "", req.PaymentType, payment.Strategy(cfg.LoadBalanceStrategy), payAmount)
 	if err != nil {
-		return nil, fmt.Errorf("select provider instance: %w", err)
+		return nil, infraerrors.ServiceUnavailable("PAYMENT_GATEWAY_ERROR", fmt.Sprintf("payment method (%s) is not configured", req.PaymentType))
 	}
 	if sel == nil {
 		return nil, infraerrors.TooManyRequests("NO_AVAILABLE_INSTANCE", "no available payment instance")
 	}
-	prov, err := provider.CreateProvider(providerKey, sel.InstanceID, sel.Config)
+	prov, err := provider.CreateProvider(sel.ProviderKey, sel.InstanceID, sel.Config)
 	if err != nil {
 		return nil, infraerrors.ServiceUnavailable("PAYMENT_GATEWAY_ERROR", "payment method is temporarily unavailable")
 	}
@@ -209,7 +206,7 @@ func (s *PaymentService) invokeProvider(ctx context.Context, order *dbent.Paymen
 	outTradeNo := order.OutTradeNo
 	pr, err := prov.CreatePayment(ctx, payment.CreatePaymentRequest{OrderID: outTradeNo, Amount: payAmountStr, PaymentType: req.PaymentType, Subject: subject, ClientIP: req.ClientIP, IsMobile: req.IsMobile, InstanceSubMethods: sel.SupportedTypes})
 	if err != nil {
-		slog.Error("[PaymentService] CreatePayment failed", "provider", providerKey, "instance", sel.InstanceID, "error", err)
+		slog.Error("[PaymentService] CreatePayment failed", "provider", sel.ProviderKey, "instance", sel.InstanceID, "error", err)
 		return nil, infraerrors.ServiceUnavailable("PAYMENT_GATEWAY_ERROR", fmt.Sprintf("payment gateway error: %s", err.Error()))
 	}
 	_, err = s.entClient.PaymentOrder.UpdateOneID(order.ID).SetNillablePaymentTradeNo(psNilIfEmpty(pr.TradeNo)).SetNillablePayURL(psNilIfEmpty(pr.PayURL)).SetNillableQrCode(psNilIfEmpty(pr.QRCode)).SetNillableProviderInstanceID(psNilIfEmpty(sel.InstanceID)).Save(ctx)


### PR DESCRIPTION
## 背景 / Background

支付宝官方直连和微信支付官方直连存在两个问题：

1. Provider 的 `SupportedTypes()` 返回 `alipay_direct` / `wxpay_direct`，但前端下单时发送的是 `alipay` / `wxpay`，导致 registry 查找失败，所有直连支付报 503
2. 当多个 provider 支持同一支付方式（如 EasyPay 和支付宝直连都支持 `alipay`）时，load balancer 只查询 registry 中最后注册的那个 provider 的实例，另一个 provider 的实例完全不可达，无法跨 provider 负载均衡

Two issues with Alipay/Wxpay direct providers:

1. `SupportedTypes()` returned `alipay_direct`/`wxpay_direct`, but the frontend sends `payment_type=alipay`/`wxpay`. Registry lookup failed, returning 503 for all direct payments.
2. When multiple providers support the same payment type (e.g. EasyPay and Alipay direct both handle `alipay`), the load balancer only queried instances from the last-registered provider, making the other provider's instances unreachable.

---

## 目的 / Purpose

1. 修复直连支付的类型映射，使其正确注册基础支付类型
2. 支持跨 provider 负载均衡：同一支付方式的所有 provider 实例参与选择

1. Fix direct payment type mapping to register base payment types
2. Enable cross-provider load balancing: all provider instances supporting a payment type participate in selection

---

## 改动内容 / Changes

### 后端 / Backend

- **`provider/alipay.go`**：`SupportedTypes()` 从 `[TypeAlipayDirect]` 改为 `[TypeAlipay]`
- **`provider/wxpay.go`**：`SupportedTypes()` 从 `[TypeWxpayDirect]` 改为 `[TypeWxpay]`
- **`types.go`**：`InstanceSelection` 新增 `ProviderKey` 字段
- **`load_balancer.go`**：`queryEnabledInstances` 支持 `providerKey` 为空时跨所有 provider 查询实例
- **`payment_order.go`**：`invokeProvider` 绕过 registry，直接由 load balancer 跨 provider 选实例，用选中实例的 `ProviderKey` 创建 provider

---

- **`provider/alipay.go`**: Change `SupportedTypes()` from `[TypeAlipayDirect]` to `[TypeAlipay]`
- **`provider/wxpay.go`**: Change `SupportedTypes()` from `[TypeWxpayDirect]` to `[TypeWxpay]`
- **`types.go`**: Add `ProviderKey` field to `InstanceSelection`
- **`load_balancer.go`**: `queryEnabledInstances` supports empty `providerKey` to query instances across all providers
- **`payment_order.go`**: `invokeProvider` bypasses registry, lets load balancer select across providers, uses selected instance's `ProviderKey` to create the correct provider

Closes #1592