### PR TITLE
fix(frontend): lower QR code error correction level to reduce density

### DIFF
--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -154,7 +154,7 @@ async function renderQR() {
   await QRCode.toCanvas(qrCanvas.value, qrUrl.value, {
     width: 220,
     margin: 2,
-    errorCorrectionLevel: logoSrc ? 'H' : 'M',
+    errorCorrectionLevel: logoSrc ? 'M' : 'L',
   })
   if (!logoSrc) return
   const canvas = qrCanvas.value

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -199,7 +199,7 @@ async function renderQR() {
   if (!qrCanvas.value || !qrUrl.value) return
   await QRCode.toCanvas(qrCanvas.value, qrUrl.value, {
     width: 220, margin: 2,
-    errorCorrectionLevel: 'H',
+    errorCorrectionLevel: 'M',
   })
 }
 

--- a/frontend/src/views/user/PaymentQRCodeView.vue
+++ b/frontend/src/views/user/PaymentQRCodeView.vue
@@ -94,12 +94,12 @@ async function renderQR() {
   await nextTick()
   if (!qrCanvas.value || !qrUrl.value) return
 
-  // Use high error correction to support logo overlay
+  // Use medium error correction to support logo overlay while keeping QR code scannable
   const logoSrc = getLogoForType()
   await QRCode.toCanvas(qrCanvas.value, qrUrl.value, {
     width: 256,
     margin: 2,
-    errorCorrectionLevel: logoSrc ? 'H' : 'M',
+    errorCorrectionLevel: logoSrc ? 'M' : 'L',
   })
 
   if (!logoSrc) return


### PR DESCRIPTION
## 背景 / Background

支付二维码使用了 `H` 级容错率（30% 冗余），生成的二维码模块非常密集，部分手机相机难以扫描识别。

Payment QR codes used error correction level `H` (30% redundancy), generating very dense QR modules that some phone cameras struggle to scan.

---

## 目的 / Purpose

降低容错率以减少二维码密度，改善扫码体验。

Lower the error correction level to reduce QR code density and improve scanning reliability.

---

## 改动内容 / Changes

### 前端 / Frontend

- **`PaymentQRCodeView.vue`**：有 logo 时 `H` → `M`（15%），无 logo 时 `M` → `L`（7%）
- **`PaymentStatusPanel.vue`**：`H` → `M`
- **`PaymentQRDialog.vue`**：有 logo 时 `H` → `M`，无 logo 时 `M` → `L`

---

- **`PaymentQRCodeView.vue`**: With logo `H` → `M` (15%), without logo `M` → `L` (7%)
- **`PaymentStatusPanel.vue`**: `H` → `M`
- **`PaymentQRDialog.vue`**: With logo `H` → `M`, without logo `M` → `L`

Closes #1607