### PR TITLE
feat(gemini): add vertex api key support

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1158,6 +1158,7 @@ func setDefaults() {
 		"open.bigmodel.cn",
 		"api.minimaxi.com",
 		"generativelanguage.googleapis.com",
+		"aiplatform.googleapis.com",
 		"cloudcode-pa.googleapis.com",
 		"*.openai.azure.com",
 	})

--- a/backend/internal/pkg/geminicli/constants.go
+++ b/backend/internal/pkg/geminicli/constants.go
@@ -4,8 +4,9 @@ package geminicli
 import "time"
 
 const (
-	AIStudioBaseURL  = "https://generativelanguage.googleapis.com"
-	GeminiCliBaseURL = "https://cloudcode-pa.googleapis.com"
+	AIStudioBaseURL      = "https://generativelanguage.googleapis.com"
+	VertexExpressBaseURL = "https://aiplatform.googleapis.com"
+	GeminiCliBaseURL     = "https://cloudcode-pa.googleapis.com"
 
 	AuthorizeURL = "https://accounts.google.com/o/oauth2/v2/auth"
 	TokenURL     = "https://oauth2.googleapis.com/token"

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -160,6 +160,27 @@ func (a *Account) IsGemini() bool {
 	return a.Platform == PlatformGemini
 }
 
+const (
+	GeminiAPIModeAIStudio = "ai_studio"
+	GeminiAPIModeVertex   = "vertex"
+)
+
+func (a *Account) GeminiAPIMode() string {
+	if a.Platform != PlatformGemini || a.Type != AccountTypeAPIKey {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(a.GetCredential("api_mode"))) {
+	case GeminiAPIModeVertex:
+		return GeminiAPIModeVertex
+	default:
+		return GeminiAPIModeAIStudio
+	}
+}
+
+func (a *Account) IsGeminiVertexAPIKey() bool {
+	return a.GeminiAPIMode() == GeminiAPIModeVertex
+}
+
 func (a *Account) GeminiOAuthType() string {
 	if a.Platform != PlatformGemini || a.Type != AccountTypeOAuth {
 		return ""

--- a/backend/internal/service/account_base_url_test.go
+++ b/backend/internal/service/account_base_url_test.go
@@ -158,3 +158,54 @@ func TestGetGeminiBaseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGeminiAPIMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		account  Account
+		expected string
+		vertex   bool
+	}{
+		{
+			name: "gemini apikey defaults to ai studio",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{},
+			},
+			expected: GeminiAPIModeAIStudio,
+			vertex:   false,
+		},
+		{
+			name: "gemini apikey vertex mode",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			expected: GeminiAPIModeVertex,
+			vertex:   true,
+		},
+		{
+			name: "non gemini account returns empty mode",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			expected: "",
+			vertex:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.account.GeminiAPIMode(); got != tt.expected {
+				t.Fatalf("GeminiAPIMode() = %q, want %q", got, tt.expected)
+			}
+			if got := tt.account.IsGeminiVertexAPIKey(); got != tt.vertex {
+				t.Fatalf("IsGeminiVertexAPIKey() = %v, want %v", got, tt.vertex)
+			}
+		})
+	}
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -672,19 +672,10 @@ func (s *AccountTestService) buildGeminiAPIKeyRequest(ctx context.Context, accou
 	if strings.TrimSpace(apiKey) == "" {
 		return nil, fmt.Errorf("no API key available")
 	}
-
-	baseURL := account.GetCredential("base_url")
-	if baseURL == "" {
-		baseURL = geminicli.AIStudioBaseURL
-	}
-	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+	fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, modelID, "streamGenerateContent", true)
 	if err != nil {
 		return nil, err
 	}
-
-	// Use streamGenerateContent for real-time feedback
-	fullURL := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse",
-		strings.TrimRight(normalizedBaseURL, "/"), modelID)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewReader(payload))
 	if err != nil {

--- a/backend/internal/service/gemini_api_key_upstream.go
+++ b/backend/internal/service/gemini_api_key_upstream.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gemini"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
+)
+
+func geminiAPIKeyDefaultBaseURL(account *Account) string {
+	if account != nil && account.IsGeminiVertexAPIKey() {
+		return geminicli.VertexExpressBaseURL
+	}
+	return geminicli.AIStudioBaseURL
+}
+
+func buildGeminiAPIKeyUpstreamURL(
+	account *Account,
+	validateBaseURL func(string) (string, error),
+	model string,
+	action string,
+	stream bool,
+) (string, error) {
+	if account == nil {
+		return "", fmt.Errorf("account is nil")
+	}
+	baseURL := account.GetGeminiBaseURL(geminiAPIKeyDefaultBaseURL(account))
+	normalizedBaseURL, err := validateBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	trimmedBaseURL := strings.TrimRight(normalizedBaseURL, "/")
+	trimmedModel := strings.TrimSpace(model)
+	if trimmedModel == "" {
+		return "", fmt.Errorf("missing model")
+	}
+
+	var fullURL string
+	if account.IsGeminiVertexAPIKey() {
+		resource := geminiVertexModelResource(trimmedModel)
+		fullURL = fmt.Sprintf("%s/v1beta1/%s:%s", trimmedBaseURL, resource, action)
+	} else {
+		fullURL = fmt.Sprintf("%s/v1beta/models/%s:%s", trimmedBaseURL, trimmedModel, action)
+	}
+
+	if stream {
+		fullURL += "?alt=sse"
+	}
+	return fullURL, nil
+}
+
+func geminiVertexModelResource(model string) string {
+	trimmed := strings.Trim(strings.TrimSpace(model), "/")
+	switch {
+	case strings.HasPrefix(trimmed, "publishers/"):
+		return trimmed
+	case strings.HasPrefix(trimmed, "models/"):
+		trimmed = strings.TrimPrefix(trimmed, "models/")
+	}
+	return "publishers/google/models/" + trimmed
+}
+
+func buildGeminiVertexModelsFallback(path string) (*UpstreamHTTPResult, bool, error) {
+	trimmedPath := strings.TrimSpace(path)
+	headers := http.Header{"Content-Type": []string{"application/json; charset=utf-8"}}
+
+	switch {
+	case trimmedPath == "/v1beta/models":
+		body, err := json.Marshal(gemini.FallbackModelsList())
+		if err != nil {
+			return nil, true, err
+		}
+		return &UpstreamHTTPResult{
+			StatusCode: http.StatusOK,
+			Headers:    headers,
+			Body:       body,
+		}, true, nil
+	case strings.HasPrefix(trimmedPath, "/v1beta/models/"):
+		modelName := strings.TrimSpace(strings.TrimPrefix(trimmedPath, "/v1beta/models/"))
+		if modelName == "" {
+			return nil, true, fmt.Errorf("invalid path")
+		}
+		body, err := json.Marshal(gemini.FallbackModel(modelName))
+		if err != nil {
+			return nil, true, err
+		}
+		return &UpstreamHTTPResult{
+			StatusCode: http.StatusOK,
+			Headers:    headers,
+			Body:       body,
+		}, true, nil
+	default:
+		return nil, false, nil
+	}
+}

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -486,7 +486,8 @@ func (s *GeminiMessagesCompatService) HasAntigravityAccounts(ctx context.Context
 // 1) API key accounts (AI Studio)
 // 2) OAuth accounts without project_id (AI Studio OAuth)
 // 3) OAuth accounts explicitly marked as ai_studio
-// 4) Any remaining Gemini accounts (fallback)
+// 4) API key accounts (Vertex API key; GET models falls back to local metadata)
+// 5) Any remaining Gemini accounts (fallback)
 func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx context.Context, groupID *int64) (*Account, error) {
 	accounts, err := s.listSchedulableAccountsOnce(ctx, groupID, PlatformGemini, true)
 	if err != nil {
@@ -503,6 +504,9 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 		switch a.Type {
 		case AccountTypeAPIKey:
 			if strings.TrimSpace(a.GetCredential("api_key")) != "" {
+				if a.IsGeminiVertexAPIKey() {
+					return 3
+				}
 				return 0
 			}
 			return 9
@@ -514,7 +518,7 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 				return 2
 			}
 			// Code Assist OAuth tokens often lack AI Studio scopes for models listing.
-			return 3
+			return 4
 		default:
 			return 10
 		}
@@ -611,19 +615,13 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
-			if err != nil {
-				return nil, "", err
-			}
-
 			action := "generateContent"
 			if req.Stream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
-			if req.Stream {
-				fullURL += "?alt=sse"
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, action, req.Stream)
+			if err != nil {
+				return nil, "", err
 			}
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)
@@ -1122,16 +1120,9 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 			if strings.TrimSpace(apiKey) == "" {
 				return nil, "", errors.New("gemini api_key not configured")
 			}
-
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, upstreamAction, useUpstreamStream)
 			if err != nil {
 				return nil, "", err
-			}
-
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, upstreamAction)
-			if useUpstreamStream {
-				fullURL += "?alt=sse"
 			}
 
 			upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(body))
@@ -2566,6 +2557,11 @@ func (s *GeminiMessagesCompatService) ForwardAIStudioGET(ctx context.Context, ac
 	path = strings.TrimSpace(path)
 	if path == "" || !strings.HasPrefix(path, "/") {
 		return nil, errors.New("invalid path")
+	}
+	if account.IsGeminiVertexAPIKey() {
+		if fallbackRes, handled, err := buildGeminiVertexModelsFallback(path); handled || err != nil {
+			return fallbackRes, err
+		}
 	}
 
 	baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -308,6 +308,44 @@ func TestGeminiMessagesCompatServiceForward_NormalizesWebSearchToolForAIStudio(t
 	require.False(t, hasFuncDecl)
 }
 
+func TestBuildGeminiAPIKeyUpstreamURL_VertexExpressMode(t *testing.T) {
+	account := &Account{
+		Type:     AccountTypeAPIKey,
+		Platform: PlatformGemini,
+		Credentials: map[string]any{
+			"api_key":  "test-key",
+			"api_mode": "vertex",
+		},
+	}
+
+	fullURL, err := buildGeminiAPIKeyUpstreamURL(
+		account,
+		func(raw string) (string, error) { return raw, nil },
+		"gemini-2.5-flash",
+		"streamGenerateContent",
+		true,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"https://aiplatform.googleapis.com/v1beta1/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+		fullURL,
+	)
+}
+
+func TestBuildGeminiVertexModelsFallback(t *testing.T) {
+	res, handled, err := buildGeminiVertexModelsFallback("/v1beta/models")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, string(res.Body), "\"models\"")
+
+	res, handled, err = buildGeminiVertexModelsFallback("/v1beta/models/gemini-2.5-flash")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, string(res.Body), "\"models/gemini-2.5-flash\"")
+}
 func TestConvertClaudeMessagesToGeminiGenerateContent_AddsThoughtSignatureForToolUse(t *testing.T) {
 	claudeReq := map[string]any{
 		"model":      "claude-haiku-4-5-20251001",

--- a/backend/internal/service/gemini_quota.go
+++ b/backend/internal/service/gemini_quota.go
@@ -373,6 +373,12 @@ func geminiQuotaTierKeyForAccount(account *Account) string {
 	if account == nil || account.Platform != PlatformGemini {
 		return ""
 	}
+	if account.Type == AccountTypeAPIKey && account.IsGeminiVertexAPIKey() {
+		if tierID := normalizeGeminiTierID(account.GeminiTierID()); tierID != "" {
+			return tierID
+		}
+		return GeminiTierGCPStandard
+	}
 
 	// Note: GeminiOAuthType() already defaults legacy (project_id present) to code_assist.
 	oauthType := strings.ToLower(strings.TrimSpace(account.GeminiOAuthType()))

--- a/frontend/src/components/account/AccountQuotaInfo.vue
+++ b/frontend/src/components/account/AccountQuotaInfo.vue
@@ -55,6 +55,11 @@ const isGoogleOne = computed(() => {
   return creds?.oauth_type === 'google_one'
 })
 
+const geminiApiMode = computed(() => {
+  const creds = props.account.credentials as GeminiCredentials | undefined
+  return (creds?.api_mode || '').toString().trim().toLowerCase() || 'ai_studio'
+})
+
 // 是否应该显示配额信息
 const shouldShowQuota = computed(() => {
   return props.account.platform === 'gemini'
@@ -88,8 +93,14 @@ const tierLabel = computed(() => {
     return 'Google One'
   }
 
-  // API Key: 显示 AI Studio
   const tier = (creds?.tier_id || '').toString().trim().toLowerCase()
+  if (props.account.type === 'apikey' && geminiApiMode.value === 'vertex') {
+    if (tier === 'gcp_enterprise') return 'Vertex AI Enterprise'
+    if (tier === 'gcp_standard') return 'Vertex AI Standard'
+    return 'Vertex AI'
+  }
+
+  // API Key: 显示 AI Studio
   if (tier === 'aistudio_paid') return 'AI Studio Pay-as-you-go'
   if (tier === 'aistudio_free') return 'AI Studio Free Tier'
   return 'AI Studio'
@@ -121,8 +132,13 @@ const tierBadgeClass = computed(() => {
     return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
   }
 
-  // AI Studio 默认样式：蓝色
   const tier = (creds?.tier_id || '').toString().trim().toLowerCase()
+  if (props.account.type === 'apikey' && geminiApiMode.value === 'vertex') {
+    if (tier === 'gcp_enterprise') return 'bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-300'
+    return 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300'
+  }
+
+  // AI Studio 默认样式：蓝色
   if (tier === 'aistudio_paid') return 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300'
   if (tier === 'aistudio_free') return 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300'
   return 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300'

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -627,6 +627,12 @@ const geminiOAuthType = computed(() => {
   return (creds?.oauth_type || '').trim() || null
 })
 
+const geminiApiMode = computed(() => {
+  if (props.account.platform !== 'gemini') return null
+  const creds = props.account.credentials as GeminiCredentials | undefined
+  return (creds?.api_mode || '').trim() || 'ai_studio'
+})
+
 // Gemini 是否为 Code Assist OAuth
 const isGeminiCodeAssist = computed(() => {
   if (props.account.platform !== 'gemini') return false
@@ -634,11 +640,12 @@ const isGeminiCodeAssist = computed(() => {
   return creds?.oauth_type === 'code_assist' || (!creds?.oauth_type && !!creds?.project_id)
 })
 
-const geminiChannelShort = computed((): 'ai studio' | 'gcp' | 'google one' | 'client' | null => {
+const geminiChannelShort = computed((): 'ai studio' | 'vertex' | 'gcp' | 'google one' | 'client' | null => {
   if (props.account.platform !== 'gemini') return null
 
-  // API Key accounts are AI Studio.
-  if (props.account.type === 'apikey') return 'ai studio'
+  if (props.account.type === 'apikey') {
+    return geminiApiMode.value === 'vertex' ? 'vertex' : 'ai studio'
+  }
 
   if (geminiOAuthType.value === 'google_one') return 'google one'
   if (isGeminiCodeAssist.value) return 'gcp'
@@ -679,6 +686,13 @@ const geminiUserLevel = computed((): string | null => {
     return 'standard'
   }
 
+  if (props.account.type === 'apikey' && geminiApiMode.value === 'vertex') {
+    if (tierLower === 'gcp_enterprise') return 'enterprise'
+    if (tierLower === 'gcp_standard') return 'standard'
+    if (tierUpper.includes('ULTRA') || tierUpper.includes('ENTERPRISE')) return 'enterprise'
+    return 'standard'
+  }
+
   // AI Studio (API Key) and Client OAuth: free / paid
   if (props.account.type === 'apikey' || geminiOAuthType.value === 'ai_studio') {
     if (tierLower === 'aistudio_paid') return 'paid'
@@ -711,6 +725,11 @@ const geminiTierClass = computed(() => {
     return 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300'
   }
 
+  if (channel === 'vertex') {
+    if (level === 'enterprise') return 'bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-300'
+    return 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300'
+  }
+
   if (channel === 'google one') {
     if (level === 'ultra') return 'bg-purple-100 text-purple-600 dark:bg-purple-900/40 dark:text-purple-300'
     if (level === 'pro') return 'bg-blue-100 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300'
@@ -732,6 +751,9 @@ const geminiQuotaPolicyChannel = computed(() => {
   }
   if (isGeminiCodeAssist.value) {
     return t('admin.accounts.gemini.quotaPolicy.rows.gcp.channel')
+  }
+  if (props.account.type === 'apikey' && geminiApiMode.value === 'vertex') {
+    return t('admin.accounts.gemini.quotaPolicy.rows.vertex.channel')
   }
   return t('admin.accounts.gemini.quotaPolicy.rows.aiStudio.channel')
 })
@@ -755,6 +777,12 @@ const geminiQuotaPolicyLimits = computed(() => {
     }
     return t('admin.accounts.gemini.quotaPolicy.rows.gcp.limitsStandard')
   }
+  if (props.account.type === 'apikey' && geminiApiMode.value === 'vertex') {
+    if (tierLower === 'gcp_enterprise' || geminiUserLevel.value === 'enterprise') {
+      return t('admin.accounts.gemini.quotaPolicy.rows.vertex.limitsEnterprise')
+    }
+    return t('admin.accounts.gemini.quotaPolicy.rows.vertex.limitsStandard')
+  }
 
   // AI Studio (API Key / custom OAuth)
   if (tierLower === 'aistudio_paid' || geminiUserLevel.value === 'paid') {
@@ -766,6 +794,9 @@ const geminiQuotaPolicyLimits = computed(() => {
 const geminiQuotaPolicyDocsUrl = computed(() => {
   if (geminiOAuthType.value === 'google_one' || isGeminiCodeAssist.value) {
     return 'https://developers.google.com/gemini-code-assist/resources/quotas'
+  }
+  if (props.account.type === 'apikey' && geminiApiMode.value === 'vertex') {
+    return 'https://cloud.google.com/vertex-ai/generative-ai/docs/quotas'
   }
   return 'https://ai.google.dev/pricing'
 })

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -849,6 +849,14 @@
 
       <!-- API Key input (only for apikey type, excluding Antigravity which has its own fields) -->
       <div v-if="form.type === 'apikey' && form.platform !== 'antigravity'" class="space-y-4">
+        <div v-if="form.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.apiModeLabel') }}</label>
+          <select v-model="geminiApiMode" class="input">
+            <option value="ai_studio">{{ t('admin.accounts.gemini.apiMode.aiStudio') }}</option>
+            <option value="vertex">{{ t('admin.accounts.gemini.apiMode.vertex') }}</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.gemini.apiModeHint') }}</p>
+        </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
           <input
@@ -859,7 +867,9 @@
               form.platform === 'openai'
                 ? 'https://api.openai.com'
                 : form.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
+                  ? geminiApiMode === 'vertex'
+                    ? 'https://aiplatform.googleapis.com'
+                    : 'https://generativelanguage.googleapis.com'
                   : 'https://api.anthropic.com'
             "
           />
@@ -876,7 +886,9 @@
               form.platform === 'openai'
                 ? 'sk-proj-...'
                 : form.platform === 'gemini'
-                  ? 'AIza...'
+                  ? geminiApiMode === 'vertex'
+                    ? 'AQ...'
+                    : 'AIza...'
                   : 'sk-ant-...'
             "
           />
@@ -886,11 +898,21 @@
         <!-- Gemini API Key tier selection -->
         <div v-if="form.platform === 'gemini'">
           <label class="input-label">{{ t('admin.accounts.gemini.tier.label') }}</label>
-          <select v-model="geminiTierAIStudio" class="input">
+          <select v-if="geminiApiMode === 'vertex'" v-model="geminiTierVertex" class="input">
+            <option value="gcp_standard">{{ t('admin.accounts.gemini.tier.vertex.standard') }}</option>
+            <option value="gcp_enterprise">{{ t('admin.accounts.gemini.tier.vertex.enterprise') }}</option>
+          </select>
+          <select v-else v-model="geminiTierAIStudio" class="input">
             <option value="aistudio_free">{{ t('admin.accounts.gemini.tier.aiStudio.free') }}</option>
             <option value="aistudio_paid">{{ t('admin.accounts.gemini.tier.aiStudio.paid') }}</option>
           </select>
-          <p class="input-hint">{{ t('admin.accounts.gemini.tier.aiStudioHint') }}</p>
+          <p class="input-hint">
+            {{
+              geminiApiMode === 'vertex'
+                ? t('admin.accounts.gemini.tier.vertexHint')
+                : t('admin.accounts.gemini.tier.aiStudioHint')
+            }}
+          </p>
         </div>
 
         <!-- Model Restriction Section (Antigravity 已在上层条件排除) -->
@@ -2872,13 +2894,21 @@ const oauthStepTitle = computed(() => {
 // Platform-specific hints for API Key type
 const baseUrlHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === 'gemini') {
+    return geminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.baseUrlHintVertex')
+      : t('admin.accounts.gemini.baseUrlHint')
+  }
   return t('admin.accounts.baseUrlHint')
 })
 
 const apiKeyHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.apiKeyHint')
-  if (form.platform === 'gemini') return t('admin.accounts.gemini.apiKeyHint')
+  if (form.platform === 'gemini') {
+    return geminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.apiKeyHintVertex')
+      : t('admin.accounts.gemini.apiKeyHint')
+  }
   return t('admin.accounts.apiKeyHint')
 })
 
@@ -3006,6 +3036,7 @@ const getAntigravityModelMappingKey = createStableObjectKeyResolver<ModelMapping
 const getTempUnschedRuleKey = createStableObjectKeyResolver<TempUnschedRuleForm>('create-temp-unsched-rule')
 const geminiOAuthType = ref<'code_assist' | 'google_one' | 'ai_studio'>('google_one')
 const geminiAIStudioOAuthEnabled = ref(false)
+const geminiApiMode = ref<'ai_studio' | 'vertex'>('ai_studio')
 
 function buildAntigravityExtra(): Record<string, unknown> | undefined {
   const extra: Record<string, unknown> = {}
@@ -3054,10 +3085,13 @@ const customBaseUrl = ref('')
 const geminiTierGoogleOne = ref<'google_one_free' | 'google_ai_pro' | 'google_ai_ultra'>('google_one_free')
 const geminiTierGcp = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
 const geminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free')
+const geminiTierVertex = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
 
 const geminiSelectedTier = computed(() => {
   if (form.platform !== 'gemini') return ''
-  if (accountCategory.value === 'apikey') return geminiTierAIStudio.value
+  if (accountCategory.value === 'apikey') {
+    return geminiApiMode.value === 'vertex' ? geminiTierVertex.value : geminiTierAIStudio.value
+  }
   switch (geminiOAuthType.value) {
     case 'google_one':
       return geminiTierGoogleOne.value
@@ -3267,7 +3301,9 @@ watch(
       (newPlatform === 'openai')
         ? 'https://api.openai.com'
         : newPlatform === 'gemini'
-          ? 'https://generativelanguage.googleapis.com'
+          ? (geminiApiMode.value === 'vertex'
+              ? 'https://aiplatform.googleapis.com'
+              : 'https://generativelanguage.googleapis.com')
           : 'https://api.anthropic.com'
     // Clear model-related settings
     allowedModels.value = []
@@ -3314,6 +3350,19 @@ watch(
 
     geminiOAuth.resetState()
     antigravityOAuth.resetState()
+  }
+)
+
+watch(
+  geminiApiMode,
+  (newMode) => {
+    if (form.platform !== 'gemini' || accountCategory.value !== 'apikey') return
+    const aiStudioURL = 'https://generativelanguage.googleapis.com'
+    const vertexURL = 'https://aiplatform.googleapis.com'
+    const current = apiKeyBaseUrl.value.trim()
+    if (!current || current === aiStudioURL || current === vertexURL) {
+      apiKeyBaseUrl.value = newMode === 'vertex' ? vertexURL : aiStudioURL
+    }
   }
 )
 
@@ -3719,6 +3768,8 @@ const resetForm = () => {
   geminiTierGoogleOne.value = 'google_one_free'
   geminiTierGcp.value = 'gcp_standard'
   geminiTierAIStudio.value = 'aistudio_free'
+  geminiApiMode.value = 'ai_studio'
+  geminiTierVertex.value = 'gcp_standard'
   oauth.resetState()
   openaiOAuth.resetState()
   geminiOAuth.resetState()
@@ -3950,7 +4001,9 @@ const handleSubmit = async () => {
     form.platform === 'openai'
       ? 'https://api.openai.com'
       : form.platform === 'gemini'
-        ? 'https://generativelanguage.googleapis.com'
+        ? geminiApiMode.value === 'vertex'
+          ? 'https://aiplatform.googleapis.com'
+          : 'https://generativelanguage.googleapis.com'
         : 'https://api.anthropic.com'
 
   // Build credentials with optional model mapping
@@ -3959,7 +4012,8 @@ const handleSubmit = async () => {
     api_key: apiKeyValue.value.trim()
   }
   if (form.platform === 'gemini') {
-    credentials.tier_id = geminiTierAIStudio.value
+    credentials.api_mode = geminiApiMode.value
+    credentials.tier_id = geminiApiMode.value === 'vertex' ? geminiTierVertex.value : geminiTierAIStudio.value
   }
 
   // Add model mapping if configured（OpenAI 开启自动透传时不应用）

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -28,6 +28,14 @@
 
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
+        <div v-if="account.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.apiModeLabel') }}</label>
+          <select v-model="editGeminiApiMode" class="input">
+            <option value="ai_studio">{{ t('admin.accounts.gemini.apiMode.aiStudio') }}</option>
+            <option value="vertex">{{ t('admin.accounts.gemini.apiMode.vertex') }}</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.gemini.apiModeHint') }}</p>
+        </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
           <input
@@ -38,7 +46,9 @@
               account.platform === 'openai'
                 ? 'https://api.openai.com'
                 : account.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
+                  ? editGeminiApiMode === 'vertex'
+                    ? 'https://aiplatform.googleapis.com'
+                    : 'https://generativelanguage.googleapis.com'
                   : account.platform === 'antigravity'
                     ? 'https://cloudcode-pa.googleapis.com'
                     : 'https://api.anthropic.com'
@@ -56,13 +66,33 @@
               account.platform === 'openai'
                 ? 'sk-proj-...'
                 : account.platform === 'gemini'
-                  ? 'AIza...'
+                  ? editGeminiApiMode === 'vertex'
+                    ? 'AQ...'
+                    : 'AIza...'
                   : account.platform === 'antigravity'
                     ? 'sk-...'
                     : 'sk-ant-...'
             "
           />
           <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
+        </div>
+        <div v-if="account.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.tier.label') }}</label>
+          <select v-if="editGeminiApiMode === 'vertex'" v-model="editGeminiTierVertex" class="input">
+            <option value="gcp_standard">{{ t('admin.accounts.gemini.tier.vertex.standard') }}</option>
+            <option value="gcp_enterprise">{{ t('admin.accounts.gemini.tier.vertex.enterprise') }}</option>
+          </select>
+          <select v-else v-model="editGeminiTierAIStudio" class="input">
+            <option value="aistudio_free">{{ t('admin.accounts.gemini.tier.aiStudio.free') }}</option>
+            <option value="aistudio_paid">{{ t('admin.accounts.gemini.tier.aiStudio.paid') }}</option>
+          </select>
+          <p class="input-hint">
+            {{
+              editGeminiApiMode === 'vertex'
+                ? t('admin.accounts.gemini.tier.vertexHint')
+                : t('admin.accounts.gemini.tier.aiStudioHint')
+            }}
+          </p>
         </div>
 
         <!-- Model Restriction Section (不适用于 Antigravity) -->
@@ -1800,7 +1830,11 @@ const authStore = useAuthStore()
 const baseUrlHint = computed(() => {
   if (!props.account) return t('admin.accounts.baseUrlHint')
   if (props.account.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (props.account.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (props.account.platform === 'gemini') {
+    return editGeminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.baseUrlHintVertex')
+      : t('admin.accounts.gemini.baseUrlHint')
+  }
   return t('admin.accounts.baseUrlHint')
 })
 
@@ -1824,6 +1858,9 @@ interface TempUnschedRuleForm {
 const submitting = ref(false)
 const editBaseUrl = ref('https://api.anthropic.com')
 const editApiKey = ref('')
+const editGeminiApiMode = ref<'ai_studio' | 'vertex'>('ai_studio')
+const editGeminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free')
+const editGeminiTierVertex = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
 // Bedrock credentials
 const editBedrockAccessKeyId = ref('')
 const editBedrockSecretAccessKey = ref('')
@@ -1970,7 +2007,11 @@ const tempUnschedPresets = computed(() => [
 // Computed: default base URL based on platform
 const defaultBaseUrl = computed(() => {
   if (props.account?.platform === 'openai') return 'https://api.openai.com'
-  if (props.account?.platform === 'gemini') return 'https://generativelanguage.googleapis.com'
+  if (props.account?.platform === 'gemini') {
+    return editGeminiApiMode.value === 'vertex'
+      ? 'https://aiplatform.googleapis.com'
+      : 'https://generativelanguage.googleapis.com'
+  }
   return 'https://api.anthropic.com'
 })
 
@@ -1980,6 +2021,19 @@ const mixedChannelWarningMessageText = computed(() => {
   }
   return mixedChannelWarningRawMessage.value
 })
+
+watch(
+  editGeminiApiMode,
+  (newMode) => {
+    if (props.account?.platform !== 'gemini' || props.account?.type !== 'apikey') return
+    const aiStudioURL = 'https://generativelanguage.googleapis.com'
+    const vertexURL = 'https://aiplatform.googleapis.com'
+    const current = editBaseUrl.value.trim()
+    if (!current || current === aiStudioURL || current === vertexURL) {
+      editBaseUrl.value = newMode === 'vertex' ? vertexURL : aiStudioURL
+    }
+  }
+)
 
 const form = reactive({
   name: '',
@@ -2156,11 +2210,24 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Initialize API Key fields for apikey type
   if (newAccount.type === 'apikey' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
+    if (newAccount.platform === 'gemini') {
+      editGeminiApiMode.value = credentials.api_mode === 'vertex' ? 'vertex' : 'ai_studio'
+      editGeminiTierAIStudio.value =
+        credentials.tier_id === 'aistudio_paid' ? 'aistudio_paid' : 'aistudio_free'
+      editGeminiTierVertex.value =
+        credentials.tier_id === 'gcp_enterprise' ? 'gcp_enterprise' : 'gcp_standard'
+    } else {
+      editGeminiApiMode.value = 'ai_studio'
+      editGeminiTierAIStudio.value = 'aistudio_free'
+      editGeminiTierVertex.value = 'gcp_standard'
+    }
     const platformDefaultUrl =
       newAccount.platform === 'openai'
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
-          ? 'https://generativelanguage.googleapis.com'
+          ? editGeminiApiMode.value === 'vertex'
+            ? 'https://aiplatform.googleapis.com'
+            : 'https://generativelanguage.googleapis.com'
           : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
 
@@ -2764,6 +2831,11 @@ const handleSubmit = async () => {
       } else {
         appStore.showError(t('admin.accounts.apiKeyIsRequired'))
         return
+      }
+      if (props.account.platform === 'gemini') {
+        newCredentials.api_mode = editGeminiApiMode.value
+        newCredentials.tier_id =
+          editGeminiApiMode.value === 'vertex' ? editGeminiTierVertex.value : editGeminiTierAIStudio.value
       }
 
       // Add model mapping if configured（OpenAI 开启自动透传时保留现有映射，不再编辑）

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2682,11 +2682,22 @@ export default {
           'All model requests are forwarded directly to the Gemini API without model restrictions or mappings.',
         baseUrlHint: 'Leave default for official Gemini API',
         apiKeyHint: 'Your Gemini API Key (starts with AIza)',
+        baseUrlHintVertex: 'Leave default for the official Vertex AI express mode endpoint',
+        apiKeyHintVertex: 'Your Vertex AI API Key (usually starts with AQ)',
+        apiModeLabel: 'API Mode',
+        apiModeHint:
+          'AI Studio stays the default. When switched to Vertex AI, sub2api will call Vertex directly instead of using an upstream compatibility relay.',
+        apiMode: {
+          aiStudio: 'AI Studio',
+          vertex: 'Vertex AI'
+        },
         tier: {
           label: 'Account Tier',
           hint: 'Tip: The system will try to auto-detect the tier first; if auto-detection is unavailable or fails, your selected tier is used as a fallback (simulated quota).',
           aiStudioHint:
             'AI Studio quotas are per-model (Pro/Flash are limited independently). If billing is enabled, choose Pay-as-you-go.',
+          vertexHint:
+            'Vertex API keys use Vertex AI Express Mode. This tier is only used for local scheduling heuristics and does not change Google-side quota.',
           googleOne: {
             free: 'Google One Free',
             pro: 'Google One Pro',
@@ -2699,15 +2710,19 @@ export default {
           aiStudio: {
             free: 'Google AI Free',
             paid: 'Google AI Pay-as-you-go'
+          },
+          vertex: {
+            standard: 'Vertex AI Standard',
+            enterprise: 'Vertex AI Enterprise'
           }
         },
         accountType: {
           oauthTitle: 'OAuth (Gemini)',
           oauthDesc: 'Authorize with your Google account and choose an OAuth type.',
-          apiKeyTitle: 'API Key (AI Studio)',
-          apiKeyDesc: 'Fastest setup. Use an AIza API key.',
+          apiKeyTitle: 'API Key (AI Studio / Vertex AI)',
+          apiKeyDesc: 'Supports both AI Studio API keys and Vertex AI API keys.',
           apiKeyNote:
-            'Best for light testing. Free tier has strict rate limits and data may be used for training.',
+            'Choose AI Studio or Vertex AI when creating the account. The default remains AI Studio.',
           apiKeyLink: 'Get API Key',
           quotaLink: 'Quota guide'
         },
@@ -2790,6 +2805,11 @@ export default {
               paid: 'Billing enabled (pay-as-you-go)',
               limitsFree: 'RPD 50; RPM 2 (Pro) / 15 (Flash)',
               limitsPaid: 'RPD unlimited; RPM 1000 (Pro) / 2000 (Flash) (per model)'
+            },
+            vertex: {
+              channel: 'Vertex AI API Key (Express Mode)',
+              limitsStandard: 'Shared pool: follows Vertex project quota; local scheduler defaults to Standard',
+              limitsEnterprise: 'Shared pool: follows Vertex project quota; local scheduler defaults to Enterprise'
             },
             customOAuth: {
               channel: 'Custom OAuth Client (GCP)',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2815,11 +2815,21 @@ export default {
         modelPassthroughDesc: '所有模型请求将直接转发至 Gemini API，不进行模型限制或映射。',
         baseUrlHint: '留空使用官方 Gemini API',
         apiKeyHint: '您的 Gemini API Key（以 AIza 开头）',
+        baseUrlHintVertex: '留空使用官方 Vertex AI Express Mode 地址',
+        apiKeyHintVertex: '您的 Vertex AI API Key（通常以 AQ 开头）',
+        apiModeLabel: '接口类型',
+        apiModeHint: '默认使用 AI Studio。切到 Vertex AI 后，sub2api 会直接请求 Vertex，不经过上游兼容模式。',
+        apiMode: {
+          aiStudio: 'AI Studio',
+          vertex: 'Vertex AI'
+        },
         tier: {
           label: '账号等级',
           hint: '提示：系统会优先尝试自动识别账号等级；若自动识别不可用或失败，则使用你选择的等级作为回退（本地模拟配额）。',
           aiStudioHint:
             'AI Studio 的配额是按模型分别限流（Pro/Flash 独立）。若已绑卡（按量付费），请选 Pay-as-you-go。',
+          vertexHint:
+            'Vertex API key 走的是 Vertex AI Express Mode。这里的等级仅用于本地调度参考，不会改变 Google 侧真实额度。',
           googleOne: {
             free: 'Google One Free',
             pro: 'Google One Pro',
@@ -2832,14 +2842,18 @@ export default {
           aiStudio: {
             free: 'Google AI Free',
             paid: 'Google AI Pay-as-you-go'
+          },
+          vertex: {
+            standard: 'Vertex AI Standard',
+            enterprise: 'Vertex AI Enterprise'
           }
         },
         accountType: {
           oauthTitle: 'OAuth 授权（Gemini）',
           oauthDesc: '使用 Google 账号授权，并选择 OAuth 子类型。',
-          apiKeyTitle: 'API 密钥（AI Studio）',
-          apiKeyDesc: '最快接入方式，使用 AIza API Key。',
-          apiKeyNote: '适合轻量测试。免费层限流严格，数据可能用于训练。',
+          apiKeyTitle: 'API 密钥（AI Studio / Vertex AI）',
+          apiKeyDesc: '支持 AI Studio API Key，也支持 Vertex AI API Key。',
+          apiKeyNote: '创建时可再选择 AI Studio 或 Vertex AI。默认仍是 AI Studio。',
           apiKeyLink: '获取 API Key',
           quotaLink: '配额说明'
         },
@@ -2922,6 +2936,11 @@ export default {
               paid: '已绑卡（按量付费）',
               limitsFree: 'RPD 50；RPM 2（Pro）/ 15（Flash）',
               limitsPaid: 'RPD 不限；RPM 1000（Pro）/ 2000（Flash）（按模型配额）'
+            },
+            vertex: {
+              channel: 'Vertex AI API Key（Express Mode）',
+              limitsStandard: '共享池：按 Vertex 项目配额生效；默认按 Standard 级别做本地调度',
+              limitsEnterprise: '共享池：按 Vertex 项目配额生效；默认按 Enterprise 级别做本地调度'
             },
             customOAuth: {
               channel: 'Custom OAuth Client（GCP）',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -620,6 +620,7 @@ export interface ProxyQualityCheckResult {
 export interface GeminiCredentials {
   // API Key authentication
   api_key?: string
+  api_mode?: 'ai_studio' | 'vertex' | string
 
   // OAuth authentication
   access_token?: string


### PR DESCRIPTION
## Summary\n- add Gemini Vertex API Key upstream support\n- expose Vertex mode in Gemini account create/edit flows\n- show Vertex-specific labels and quota docs in account list cells\n\n## Testing\n- go test ./internal/service -run 'TestBuildGeminiAPIKeyUpstreamURL_VertexExpressMode|TestBuildGeminiVertexModelsFallback|TestAccountGeminiAPIMode|TestGeminiMessagesCompatServiceForward_NormalizesWebSearchToolForAIStudio'\n- npm run typecheck\n\n## Notes\n- This PR supersedes #1581 with a clean branch that excludes unrelated local history.