### PR TITLE
fix: anthropic 非流式路径丢失 delta 内容（镜像 b2e379cf）

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -270,6 +270,7 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 
 	var finalResponse *apicompat.ResponsesResponse
 	var usage OpenAIUsage
+	acc := apicompat.NewBufferedResponseAccumulator()
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -288,8 +289,12 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 			continue
 		}
 
+		// Accumulate delta content for fallback when terminal output is empty.
+		acc.ProcessEvent(&event)
+
 		// Terminal events carry the complete ResponsesResponse with output + usage.
-		if (event.Type == "response.completed" || event.Type == "response.incomplete" || event.Type == "response.failed") &&
+		if (event.Type == "response.completed" || event.Type == "response.done" ||
+			event.Type == "response.incomplete" || event.Type == "response.failed") &&
 			event.Response != nil {
 			finalResponse = event.Response
 			if event.Response.Usage != nil {
@@ -317,6 +322,10 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 		writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream stream ended without a terminal response event")
 		return nil, fmt.Errorf("upstream stream ended without terminal event")
 	}
+
+	// When the terminal event has an empty output array, reconstruct from
+	// accumulated delta events so the client receives the full content.
+	acc.SupplementResponseOutput(finalResponse)
 
 	anthropicResp := apicompat.ResponsesToAnthropic(finalResponse, originalModel)
 


### PR DESCRIPTION
## 背景

`b2e379cf` 引入的 `BufferedResponseAccumulator` 已修复了 **chat_completions 非流式路径**和 **responses OAuth 非流式路径**在上游 `response.completed` 终态事件 `output` 为空时返回空响应的问题，但遗漏了 **Anthropic `/v1/messages` 非流式路径** (`handleAnthropicBufferedStreamingResponse`)。

## 复现

客户端：
- 请求 `POST /v1/messages`，使用 Anthropic 协议
- `stream=false`
- 目标模型为开启 thinking 的 Claude 系列

表现：响应 `content` 为 `[{"type":"text"}]`，`text` 字段为空字符串（或缺失）。

## 根因

`handleAnthropicBufferedStreamingResponse` 在扫描上游 SSE 时只读终态事件 (`response.completed` / `response.incomplete` / `response.failed`) 的 `event.Response`，忽略所有 `response.output_text.delta` / `response.reasoning_summary_text.delta` / `response.function_call_arguments.delta` 等增量事件。

上游 API 更新后，终态事件的 `output` 字段在开启 thinking 等场景下可能为空，实际内容仅通过 delta 事件下发。旧代码将空 output 直接转成 Anthropic 响应，客户端收到的 `content` 为空。

## 修复

将 `b2e379cf` 的相同修复模式镜像到 Anthropic 路径：

1. 在 SSE 扫描循环前建 `BufferedResponseAccumulator`
2. 每个事件 `acc.ProcessEvent(&event)` 累积 delta 内容
3. 终态之后、`apicompat.ResponsesToAnthropic` 之前 `acc.SupplementResponseOutput(finalResponse)`（终态 output 非空时为 no-op，完全向后兼容）

## 附带修复

同时补上 `response.done` 作为终态事件类型，与 `handleChatBufferedStreamingResponse` 保持一致。之前 Anthropic 路径只识别 `response.completed / .incomplete / .failed` 三种，若上游发送 `response.done`，handler 会认不出终态事件，`finalResponse` 保持 `nil`，最终走到兜底分支返 502 `Upstream stream ended without a terminal response event`。这是与 chat 路径对齐的潜在问题防护，改动仅一个 `||` 分支。

## 测试

- `BufferedResponseAccumulator` 已在 `chatcompletions_responses_test.go` 有完整单元测试覆盖（`TextOnly` / `ToolCalls` / `Reasoning` / `Mixed` / `SupplementEmptyOutput` / `NoSupplementWhenOutputExists` / `EmptyDeltas` / `IgnoresNonFunctionCallItems`）。本 PR 复用同一个累加器，无需新增测试。
- 本地 `go build ./...` 和 `go test ./internal/pkg/apicompat/... ./internal/service/...` 全部通过。

## 改动规模

单文件，`backend/internal/service/openai_gateway_messages.go`，+10/-1。