### PR TITLE
fix(sidebar): prevent version update dropdown clipping

### DIFF
--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from 'vitest'
 
 const componentPath = resolve(dirname(fileURLToPath(import.meta.url)), '../AppSidebar.vue')
 const componentSource = readFileSync(componentPath, 'utf8')
+const stylePath = resolve(dirname(fileURLToPath(import.meta.url)), '../../../style.css')
+const styleSource = readFileSync(stylePath, 'utf8')
 
 describe('AppSidebar custom SVG styles', () => {
   it('does not override uploaded SVG fill or stroke colors', () => {
@@ -14,5 +16,14 @@ describe('AppSidebar custom SVG styles', () => {
     expect(componentSource).toContain('display: block;')
     expect(componentSource).not.toContain('stroke: currentColor;')
     expect(componentSource).not.toContain('fill: none;')
+  })
+})
+
+describe('AppSidebar header styles', () => {
+  it('does not clip the version badge dropdown', () => {
+    const sidebarHeaderBlockMatch = styleSource.match(/\.sidebar-header\s*\{[\s\S]*?\n  \}/)
+
+    expect(sidebarHeaderBlockMatch).not.toBeNull()
+    expect(sidebarHeaderBlockMatch?.[0]).not.toContain('@apply overflow-hidden;')
   })
 })

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -529,7 +529,6 @@
   .sidebar-header {
     @apply h-16 px-6;
     @apply flex items-center gap-3;
-    @apply overflow-hidden;
     @apply border-b border-gray-100 dark:border-dark-800;
     transition:
       padding 0.2s ease,


### PR DESCRIPTION
## Summary
- remove `overflow-hidden` from `.sidebar-header` so the version badge dropdown is no longer clipped
- add a regression test to prevent the sidebar header from reintroducing the clipping style

## Root Cause
Issue #1613 is caused by a frontend style regression introduced in `fix(sidebar): smooth collapse transitions`.
The version badge dropdown is rendered inside the sidebar header, and `.sidebar-header` had `overflow-hidden`, which clipped the absolute-positioned update menu and made its actions effectively unclickable.

## Validation
- `cd frontend && pnpm test:run src/components/layout/__tests__/AppSidebar.spec.ts`
- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm build`

Fixes #1613
