### PR TITLE
fix(apicompat): flatten tool_choice for Responses API

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -832,12 +832,13 @@ func TestAnthropicToResponses_ToolChoiceSpecific(t *testing.T) {
 	resp, err := AnthropicToResponses(req)
 	require.NoError(t, err)
 
+	// Responses API uses flat {"type":"function","name":"X"}, not nested.
 	var tc map[string]any
 	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
 	assert.Equal(t, "function", tc["type"])
-	fn, ok := tc["function"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "get_weather", fn["name"])
+	assert.Equal(t, "get_weather", tc["name"])
+	_, hasNested := tc["function"]
+	assert.False(t, hasNested, "Responses API rejects nested 'function' field in tool_choice")
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -75,7 +75,7 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 //	{"type":"auto"}            → "auto"
 //	{"type":"any"}             → "required"
 //	{"type":"none"}            → "none"
-//	{"type":"tool","name":"X"} → {"type":"function","function":{"name":"X"}}
+//	{"type":"tool","name":"X"} → {"type":"function","name":"X"}
 func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage, error) {
 	var tc struct {
 		Type string `json:"type"`
@@ -93,9 +93,9 @@ func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage
 	case "none":
 		return json.Marshal("none")
 	case "tool":
-		return json.Marshal(map[string]any{
-			"type":     "function",
-			"function": map[string]string{"name": tc.Name},
+		return json.Marshal(map[string]string{
+			"type": "function",
+			"name": tc.Name,
 		})
 	default:
 		// Pass through unknown types as-is

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -276,11 +276,89 @@ func TestChatCompletionsToResponses_LegacyFunctions(t *testing.T) {
 	assert.Equal(t, "function", resp.Tools[0].Type)
 	assert.Equal(t, "get_weather", resp.Tools[0].Name)
 
-	// tool_choice should be converted
+	// tool_choice should be converted to Responses flat format
 	require.NotNil(t, resp.ToolChoice)
 	var tc map[string]any
 	require.NoError(t, json.Unmarshal(resp.ToolChoice, &tc))
 	assert.Equal(t, "function", tc["type"])
+	assert.Equal(t, "get_weather", tc["name"])
+	_, hasNested := tc["function"]
+	assert.False(t, hasNested, "Responses API rejects nested 'function' field in tool_choice")
+}
+
+// TestChatCompletionsToResponses_ToolChoice_NestedObject guards against regression
+// of the production bug where Chat Completions nested tool_choice
+// ({"type":"function","function":{"name":"X"}}) was passed through unchanged and
+// triggered upstream 400 'Unknown parameter: tool_choice.function'.
+func TestChatCompletionsToResponses_ToolChoice_NestedObject(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		wantType string
+		wantName string
+		wantFlat bool // true: object with flat {type,name}; false: raw string pass-through
+		wantStr  string
+	}{
+		{
+			name:     "nested function form flattens",
+			input:    `{"type":"function","function":{"name":"SummaryInfo"}}`,
+			wantType: "function",
+			wantName: "SummaryInfo",
+			wantFlat: true,
+		},
+		{
+			name:     "already flat form is idempotent",
+			input:    `{"type":"function","name":"SummaryInfo"}`,
+			wantType: "function",
+			wantName: "SummaryInfo",
+			wantFlat: true,
+		},
+		{
+			name:    "auto string passes through",
+			input:   `"auto"`,
+			wantStr: "auto",
+		},
+		{
+			name:    "required string passes through",
+			input:   `"required"`,
+			wantStr: "required",
+		},
+		{
+			// Defensive: even if a client sends both top-level name and nested function,
+			// we must not leak the nested 'function' field to Responses API.
+			name:     "mixed shape strips nested function",
+			input:    `{"type":"function","name":"Y","function":{"name":"X"}}`,
+			wantType: "function",
+			wantName: "Y",
+			wantFlat: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &ChatCompletionsRequest{
+				Model:      "gpt-5.2",
+				Messages:   []ChatMessage{{Role: "user", Content: json.RawMessage(`"Hi"`)}},
+				ToolChoice: json.RawMessage(tc.input),
+			}
+			resp, err := ChatCompletionsToResponses(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp.ToolChoice)
+
+			if tc.wantFlat {
+				var got map[string]any
+				require.NoError(t, json.Unmarshal(resp.ToolChoice, &got))
+				assert.Equal(t, tc.wantType, got["type"])
+				assert.Equal(t, tc.wantName, got["name"])
+				_, hasNested := got["function"]
+				assert.False(t, hasNested, "must not contain nested 'function' field")
+			} else {
+				var got string
+				require.NoError(t, json.Unmarshal(resp.ToolChoice, &got))
+				assert.Equal(t, tc.wantStr, got)
+			}
+		})
+	}
 }
 
 func TestChatCompletionsToResponses_ServiceTier(t *testing.T) {

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -1,6 +1,7 @@
 package apicompat
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -68,10 +69,15 @@ func ChatCompletionsToResponses(req *ChatCompletionsRequest) (*ResponsesRequest,
 		out.Tools = convertChatToolsToResponses(req.Tools, req.Functions)
 	}
 
-	// tool_choice: already compatible format — pass through directly.
-	// Legacy function_call needs mapping.
+	// tool_choice: Chat Completions uses nested {"type":"function","function":{"name":"X"}},
+	// Responses API uses flat {"type":"function","name":"X"}. Strings (auto/none/required)
+	// and already-flat objects pass through.
 	if len(req.ToolChoice) > 0 {
-		out.ToolChoice = req.ToolChoice
+		tc, err := remapChatToolChoiceToResponses(req.ToolChoice)
+		if err != nil {
+			return nil, fmt.Errorf("convert tool_choice: %w", err)
+		}
+		out.ToolChoice = tc
 	} else if len(req.FunctionCall) > 0 {
 		tc, err := convertChatFunctionCallToToolChoice(req.FunctionCall)
 		if err != nil {
@@ -415,11 +421,11 @@ func convertChatToolsToResponses(tools []ChatTool, functions []ChatFunction) []R
 }
 
 // convertChatFunctionCallToToolChoice maps the legacy function_call field to a
-// Responses API tool_choice value.
+// Responses API tool_choice value (flat format).
 //
 //	"auto" → "auto"
 //	"none" → "none"
-//	{"name":"X"} → {"type":"function","function":{"name":"X"}}
+//	{"name":"X"} → {"type":"function","name":"X"}
 func convertChatFunctionCallToToolChoice(raw json.RawMessage) (json.RawMessage, error) {
 	// Try string first ("auto", "none", etc.) — pass through as-is.
 	var s string
@@ -434,8 +440,49 @@ func convertChatFunctionCallToToolChoice(raw json.RawMessage) (json.RawMessage, 
 	if err := json.Unmarshal(raw, &obj); err != nil {
 		return nil, err
 	}
-	return json.Marshal(map[string]any{
-		"type":     "function",
-		"function": map[string]string{"name": obj.Name},
+	return json.Marshal(map[string]string{
+		"type": "function",
+		"name": obj.Name,
 	})
+}
+
+// remapChatToolChoiceToResponses converts Chat Completions tool_choice into the
+// Responses API flat format. Chat Completions wraps the function name in a
+// nested object ({"type":"function","function":{"name":"X"}}), whereas the
+// Responses API expects it flattened ({"type":"function","name":"X"}).
+// Strings ("auto","none","required") and already-flat objects are returned
+// unchanged. Unknown shapes are preserved to avoid breaking future tool types.
+func remapChatToolChoiceToResponses(raw json.RawMessage) (json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		// Not an object (string / null / unexpected) — pass through.
+		return raw, nil
+	}
+
+	var probe struct {
+		Type     string `json:"type"`
+		Name     string `json:"name"`
+		Function *struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, err
+	}
+
+	// Function tool choice: always strip nested "function" field to guarantee Responses
+	// API compliance. Prefer explicit top-level name, fall back to nested function.name.
+	if probe.Type == "function" && (probe.Function != nil || probe.Name != "") {
+		name := probe.Name
+		if name == "" && probe.Function != nil {
+			name = probe.Function.Name
+		}
+		return json.Marshal(map[string]string{
+			"type": "function",
+			"name": name,
+		})
+	}
+
+	// Other tool types (e.g. allowed_tools, file_search) — pass through.
+	return raw, nil
 }

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -425,10 +425,11 @@ func normalizeAnthropicInputSchema(schema json.RawMessage) json.RawMessage {
 // convertResponsesToAnthropicToolChoice maps Responses tool_choice to Anthropic format.
 // Reverse of convertAnthropicToolChoiceToResponses.
 //
-//	"auto"                                     → {"type":"auto"}
-//	"required"                                 → {"type":"any"}
-//	"none"                                     → {"type":"none"}
-//	{"type":"function","function":{"name":"X"}} → {"type":"tool","name":"X"}
+//	"auto"                               → {"type":"auto"}
+//	"required"                           → {"type":"any"}
+//	"none"                               → {"type":"none"}
+//	{"type":"function","name":"X"}       → {"type":"tool","name":"X"}   (Responses native)
+//	{"type":"function","function":{...}} → {"type":"tool","name":"X"}   (legacy nested, defensive)
 func convertResponsesToAnthropicToolChoice(raw json.RawMessage) (json.RawMessage, error) {
 	// Try as string first
 	var s string
@@ -445,18 +446,25 @@ func convertResponsesToAnthropicToolChoice(raw json.RawMessage) (json.RawMessage
 		}
 	}
 
-	// Try as object with type=function
+	// Try as object. Accept both flat (Responses native) and nested (legacy) shapes.
 	var tc struct {
 		Type     string `json:"type"`
-		Function struct {
+		Name     string `json:"name"`
+		Function *struct {
 			Name string `json:"name"`
 		} `json:"function"`
 	}
-	if err := json.Unmarshal(raw, &tc); err == nil && tc.Type == "function" && tc.Function.Name != "" {
-		return json.Marshal(map[string]string{
-			"type": "tool",
-			"name": tc.Function.Name,
-		})
+	if err := json.Unmarshal(raw, &tc); err == nil && tc.Type == "function" {
+		name := tc.Name
+		if name == "" && tc.Function != nil {
+			name = tc.Function.Name
+		}
+		if name != "" {
+			return json.Marshal(map[string]string{
+				"type": "tool",
+				"name": name,
+			})
+		}
 	}
 
 	// Pass through unknown

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_tool_choice_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_tool_choice_test.go
@@ -1,0 +1,42 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConvertResponsesToAnthropicToolChoice guards the reverse path that was
+// silently broken when the forward Anthropic→Responses mapping switched from
+// nested Chat format to the flat Responses format. The reverse converter must
+// accept both shapes and always emit Anthropic's {"type":"tool","name":"X"}.
+func TestConvertResponsesToAnthropicToolChoice(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"auto string", `"auto"`, `{"type":"auto"}`},
+		{"required string", `"required"`, `{"type":"any"}`},
+		{"none string", `"none"`, `{"type":"none"}`},
+		{
+			name:  "flat responses format",
+			input: `{"type":"function","name":"get_weather"}`,
+			want:  `{"name":"get_weather","type":"tool"}`,
+		},
+		{
+			name:  "legacy nested format (defensive)",
+			input: `{"type":"function","function":{"name":"get_weather"}}`,
+			want:  `{"name":"get_weather","type":"tool"}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := convertResponsesToAnthropicToolChoice(json.RawMessage(tc.input))
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(got))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Chat Completions requests with a forced function tool choice fail with upstream HTTP 400 when the gateway converts them to the Responses API:

```
{"error":{"message":"Unknown parameter: 'tool_choice.function'.","type":"invalid_request_error"}}
```

The Chat Completions API wraps the function name in a nested object:

```json
{"type":"function","function":{"name":"X"}}
```

The Responses API expects it flat:

```json
{"type":"function","name":"X"}
```

`ChatCompletionsToResponses` was passing `req.ToolChoice` through unchanged (the inline comment said "already compatible format — pass through directly"), so the nested shape leaked upstream and was rejected.

## Changes

- `chatcompletions_to_responses.go`
  - Add `remapChatToolChoiceToResponses` that flattens any `type=function` tool_choice, tolerating mixed shapes (e.g. both top-level `name` and nested `function.name`). Strings (`auto`/`none`/`required`) and other tool types pass through unchanged.
  - `convertChatFunctionCallToToolChoice` now emits the flat Responses shape for the legacy `function_call` field.
- `anthropic_to_responses.go`
  - `convertAnthropicToolChoiceToResponses` emits the flat shape for the `tool` branch (Anthropic → Responses forced tool choice).
- `responses_to_anthropic_request.go`
  - `convertResponsesToAnthropicToolChoice` accepts both the flat and legacy nested shapes, avoiding a reverse-path regression after the forward converters switched to flat.

## Tests

- `TestChatCompletionsToResponses_ToolChoice_NestedObject` — covers nested → flat, already flat (idempotent), `auto`/`required` strings, mixed shapes.
- `TestConvertResponsesToAnthropicToolChoice` (new file) — covers `auto`/`none`/`required` strings, flat Responses format, and legacy nested format.
- Existing `TestChatCompletionsToResponses_LegacyFunctions` and `TestAnthropicToResponses_ToolChoiceSpecific` were strengthened to explicitly assert the flat layout (no nested `function` field).

All `./internal/pkg/apicompat/...` tests pass.

## Reference

OpenAI API reference (Realtime / Responses) defines the forced function tool choice as:

```python
tool_choice = {"type": "function", "name": "get_weather"}
```

## Test plan
- [x] Unit tests in `backend/internal/pkg/apicompat/` all pass
- [x] Verified end-to-end against production traffic (`gpt-5.2` + forced `SummaryInfo`): 200 streaming SSE with valid `tool_calls` delta instead of upstream 400