### PR TITLE
fix(sidebar): prevent version dropdown clipping in expanded brand

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -807,7 +807,6 @@ onMounted(() => {
 .sidebar-brand {
   min-width: 0;
   flex: 1 1 auto;
-  overflow: hidden;
   white-space: nowrap;
   transition:
     max-width 0.22s ease,
@@ -818,6 +817,7 @@ onMounted(() => {
 
 .sidebar-brand-collapsed {
   max-width: 0;
+  overflow: hidden;
   opacity: 0;
   transform: translateX(-4px);
   pointer-events: none;

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -22,8 +22,11 @@ describe('AppSidebar custom SVG styles', () => {
 describe('AppSidebar header styles', () => {
   it('does not clip the version badge dropdown', () => {
     const sidebarHeaderBlockMatch = styleSource.match(/\.sidebar-header\s*\{[\s\S]*?\n  \}/)
+    const sidebarBrandBlockMatch = componentSource.match(/\.sidebar-brand\s*\{[\s\S]*?\n\}/)
 
     expect(sidebarHeaderBlockMatch).not.toBeNull()
+    expect(sidebarBrandBlockMatch).not.toBeNull()
     expect(sidebarHeaderBlockMatch?.[0]).not.toContain('@apply overflow-hidden;')
+    expect(sidebarBrandBlockMatch?.[0]).not.toContain('overflow: hidden;')
   })
 })


### PR DESCRIPTION
## Summary
- fix the remaining clipping issue for the version dropdown in the expanded sidebar brand area
- keep overflow clipping only when the sidebar brand is collapsed
- extend the regression test to cover both sidebar header and sidebar brand clipping

## Root Cause
The previous fix removed clipping from `.sidebar-header`, but the dropdown was still nested inside `.sidebar-brand`, which still had `overflow: hidden;`. Clicking the version badge opened the dropdown, but the parent container clipped it so it looked like nothing happened.

## Validation
- pnpm --dir frontend test:run src/components/layout/__tests__/AppSidebar.spec.ts
- pnpm --dir frontend typecheck
- manual local verification with Docker backend + admin login
