### PR TITLE
feat(accounts): enable searchable model selector in test modal

### DIFF
--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -52,6 +52,7 @@
           value-key="id"
           label-key="display_name"
           :placeholder="loadingModels ? t('common.loading') + '...' : t('admin.accounts.selectTestModel')"
+          searchable
         />
       </div>
 


### PR DESCRIPTION
Add `searchable` to the model selector in AccountTestModal, so users can filter models by typing instead of scrolling through the full list.

<img width="510" height="493" alt="image" src="https://github.com/user-attachments/assets/f622f73a-c7c3-4645-aa2b-d4a7095a5054" />
