### PR TITLE
feat(group): codex 分组新增强制 fast 模式开关（绕过客户端 anthropic-beta 限制）

### DIFF
--- a/backend/ent/group.go
+++ b/backend/ent/group.go
@@ -79,6 +79,8 @@ type Group struct {
 	DefaultMappedModel string `json:"default_mapped_model,omitempty"`
 	// OpenAI Messages 调度模型配置：按 Claude 系列/精确模型映射到目标 GPT 模型
 	MessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config,omitempty"`
+	// 仅 openai 分组：强制所有请求走 codex fast (service_tier=priority)，忽略客户端传入的 service_tier 和 anthropic-beta 头
+	ForceFastMode bool `json:"force_fast_mode,omitempty"`
 	// Edges holds the relations/edges for other nodes in the graph.
 	// The values are being populated by the GroupQuery when eager-loading is set.
 	Edges        GroupEdges `json:"edges"`
@@ -187,7 +189,7 @@ func (*Group) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case group.FieldModelRouting, group.FieldSupportedModelScopes, group.FieldMessagesDispatchModelConfig:
 			values[i] = new([]byte)
-		case group.FieldIsExclusive, group.FieldClaudeCodeOnly, group.FieldModelRoutingEnabled, group.FieldMcpXMLInject, group.FieldAllowMessagesDispatch, group.FieldRequireOauthOnly, group.FieldRequirePrivacySet:
+		case group.FieldIsExclusive, group.FieldClaudeCodeOnly, group.FieldModelRoutingEnabled, group.FieldMcpXMLInject, group.FieldAllowMessagesDispatch, group.FieldRequireOauthOnly, group.FieldRequirePrivacySet, group.FieldForceFastMode:
 			values[i] = new(sql.NullBool)
 		case group.FieldRateMultiplier, group.FieldDailyLimitUsd, group.FieldWeeklyLimitUsd, group.FieldMonthlyLimitUsd, group.FieldImagePrice1k, group.FieldImagePrice2k, group.FieldImagePrice4k:
 			values[i] = new(sql.NullFloat64)
@@ -414,6 +416,12 @@ func (_m *Group) assignValues(columns []string, values []any) error {
 					return fmt.Errorf("unmarshal field messages_dispatch_model_config: %w", err)
 				}
 			}
+		case group.FieldForceFastMode:
+			if value, ok := values[i].(*sql.NullBool); !ok {
+				return fmt.Errorf("unexpected type %T for field force_fast_mode", values[i])
+			} else if value.Valid {
+				_m.ForceFastMode = value.Bool
+			}
 		default:
 			_m.selectValues.Set(columns[i], values[i])
 		}
@@ -599,6 +607,9 @@ func (_m *Group) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("messages_dispatch_model_config=")
 	builder.WriteString(fmt.Sprintf("%v", _m.MessagesDispatchModelConfig))
+	builder.WriteString(", ")
+	builder.WriteString("force_fast_mode=")
+	builder.WriteString(fmt.Sprintf("%v", _m.ForceFastMode))
 	builder.WriteByte(')')
 	return builder.String()
 }

--- a/backend/ent/group/group.go
+++ b/backend/ent/group/group.go
@@ -76,6 +76,8 @@ const (
 	FieldDefaultMappedModel = "default_mapped_model"
 	// FieldMessagesDispatchModelConfig holds the string denoting the messages_dispatch_model_config field in the database.
 	FieldMessagesDispatchModelConfig = "messages_dispatch_model_config"
+	// FieldForceFastMode holds the string denoting the force_fast_mode field in the database.
+	FieldForceFastMode = "force_fast_mode"
 	// EdgeAPIKeys holds the string denoting the api_keys edge name in mutations.
 	EdgeAPIKeys = "api_keys"
 	// EdgeRedeemCodes holds the string denoting the redeem_codes edge name in mutations.
@@ -181,6 +183,7 @@ var Columns = []string{
 	FieldRequirePrivacySet,
 	FieldDefaultMappedModel,
 	FieldMessagesDispatchModelConfig,
+	FieldForceFastMode,
 }
 
 var (
@@ -258,6 +261,8 @@ var (
 	DefaultMappedModelValidator func(string) error
 	// DefaultMessagesDispatchModelConfig holds the default value on creation for the "messages_dispatch_model_config" field.
 	DefaultMessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig
+	// DefaultForceFastMode holds the default value on creation for the "force_fast_mode" field.
+	DefaultForceFastMode bool
 )
 
 // OrderOption defines the ordering options for the Group queries.
@@ -401,6 +406,11 @@ func ByRequirePrivacySet(opts ...sql.OrderTermOption) OrderOption {
 // ByDefaultMappedModel orders the results by the default_mapped_model field.
 func ByDefaultMappedModel(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDefaultMappedModel, opts...).ToFunc()
+}
+
+// ByForceFastMode orders the results by the force_fast_mode field.
+func ByForceFastMode(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldForceFastMode, opts...).ToFunc()
 }
 
 // ByAPIKeysCount orders the results by api_keys count.

--- a/backend/ent/group/where.go
+++ b/backend/ent/group/where.go
@@ -190,6 +190,11 @@ func DefaultMappedModel(v string) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldDefaultMappedModel, v))
 }
 
+// ForceFastMode applies equality check predicate on the "force_fast_mode" field. It's identical to ForceFastModeEQ.
+func ForceFastMode(v bool) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldForceFastMode, v))
+}
+
 // CreatedAtEQ applies the EQ predicate on the "created_at" field.
 func CreatedAtEQ(v time.Time) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldCreatedAt, v))
@@ -1318,6 +1323,16 @@ func DefaultMappedModelEqualFold(v string) predicate.Group {
 // DefaultMappedModelContainsFold applies the ContainsFold predicate on the "default_mapped_model" field.
 func DefaultMappedModelContainsFold(v string) predicate.Group {
 	return predicate.Group(sql.FieldContainsFold(FieldDefaultMappedModel, v))
+}
+
+// ForceFastModeEQ applies the EQ predicate on the "force_fast_mode" field.
+func ForceFastModeEQ(v bool) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldForceFastMode, v))
+}
+
+// ForceFastModeNEQ applies the NEQ predicate on the "force_fast_mode" field.
+func ForceFastModeNEQ(v bool) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldForceFastMode, v))
 }
 
 // HasAPIKeys applies the HasEdge predicate on the "api_keys" edge.

--- a/backend/ent/group_create.go
+++ b/backend/ent/group_create.go
@@ -425,6 +425,20 @@ func (_c *GroupCreate) SetNillableMessagesDispatchModelConfig(v *domain.OpenAIMe
 	return _c
 }
 
+// SetForceFastMode sets the "force_fast_mode" field.
+func (_c *GroupCreate) SetForceFastMode(v bool) *GroupCreate {
+	_c.mutation.SetForceFastMode(v)
+	return _c
+}
+
+// SetNillableForceFastMode sets the "force_fast_mode" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableForceFastMode(v *bool) *GroupCreate {
+	if v != nil {
+		_c.SetForceFastMode(*v)
+	}
+	return _c
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_c *GroupCreate) AddAPIKeyIDs(ids ...int64) *GroupCreate {
 	_c.mutation.AddAPIKeyIDs(ids...)
@@ -630,6 +644,10 @@ func (_c *GroupCreate) defaults() error {
 		v := group.DefaultMessagesDispatchModelConfig
 		_c.mutation.SetMessagesDispatchModelConfig(v)
 	}
+	if _, ok := _c.mutation.ForceFastMode(); !ok {
+		v := group.DefaultForceFastMode
+		_c.mutation.SetForceFastMode(v)
+	}
 	return nil
 }
 
@@ -716,6 +734,9 @@ func (_c *GroupCreate) check() error {
 	}
 	if _, ok := _c.mutation.MessagesDispatchModelConfig(); !ok {
 		return &ValidationError{Name: "messages_dispatch_model_config", err: errors.New(`ent: missing required field "Group.messages_dispatch_model_config"`)}
+	}
+	if _, ok := _c.mutation.ForceFastMode(); !ok {
+		return &ValidationError{Name: "force_fast_mode", err: errors.New(`ent: missing required field "Group.force_fast_mode"`)}
 	}
 	return nil
 }
@@ -863,6 +884,10 @@ func (_c *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.MessagesDispatchModelConfig(); ok {
 		_spec.SetField(group.FieldMessagesDispatchModelConfig, field.TypeJSON, value)
 		_node.MessagesDispatchModelConfig = value
+	}
+	if value, ok := _c.mutation.ForceFastMode(); ok {
+		_spec.SetField(group.FieldForceFastMode, field.TypeBool, value)
+		_node.ForceFastMode = value
 	}
 	if nodes := _c.mutation.APIKeysIDs(); len(nodes) > 0 {
 		edge := &sqlgraph.EdgeSpec{
@@ -1500,6 +1525,18 @@ func (u *GroupUpsert) UpdateMessagesDispatchModelConfig() *GroupUpsert {
 	return u
 }
 
+// SetForceFastMode sets the "force_fast_mode" field.
+func (u *GroupUpsert) SetForceFastMode(v bool) *GroupUpsert {
+	u.Set(group.FieldForceFastMode, v)
+	return u
+}
+
+// UpdateForceFastMode sets the "force_fast_mode" field to the value that was provided on create.
+func (u *GroupUpsert) UpdateForceFastMode() *GroupUpsert {
+	u.SetExcluded(group.FieldForceFastMode)
+	return u
+}
+
 // UpdateNewValues updates the mutable fields using the new values that were set on create.
 // Using this option is equivalent to using:
 //
@@ -2102,6 +2139,20 @@ func (u *GroupUpsertOne) SetMessagesDispatchModelConfig(v domain.OpenAIMessagesD
 func (u *GroupUpsertOne) UpdateMessagesDispatchModelConfig() *GroupUpsertOne {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateMessagesDispatchModelConfig()
+	})
+}
+
+// SetForceFastMode sets the "force_fast_mode" field.
+func (u *GroupUpsertOne) SetForceFastMode(v bool) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetForceFastMode(v)
+	})
+}
+
+// UpdateForceFastMode sets the "force_fast_mode" field to the value that was provided on create.
+func (u *GroupUpsertOne) UpdateForceFastMode() *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateForceFastMode()
 	})
 }
 
@@ -2873,6 +2924,20 @@ func (u *GroupUpsertBulk) SetMessagesDispatchModelConfig(v domain.OpenAIMessages
 func (u *GroupUpsertBulk) UpdateMessagesDispatchModelConfig() *GroupUpsertBulk {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateMessagesDispatchModelConfig()
+	})
+}
+
+// SetForceFastMode sets the "force_fast_mode" field.
+func (u *GroupUpsertBulk) SetForceFastMode(v bool) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetForceFastMode(v)
+	})
+}
+
+// UpdateForceFastMode sets the "force_fast_mode" field to the value that was provided on create.
+func (u *GroupUpsertBulk) UpdateForceFastMode() *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateForceFastMode()
 	})
 }
 

--- a/backend/ent/group_update.go
+++ b/backend/ent/group_update.go
@@ -567,6 +567,20 @@ func (_u *GroupUpdate) SetNillableMessagesDispatchModelConfig(v *domain.OpenAIMe
 	return _u
 }
 
+// SetForceFastMode sets the "force_fast_mode" field.
+func (_u *GroupUpdate) SetForceFastMode(v bool) *GroupUpdate {
+	_u.mutation.SetForceFastMode(v)
+	return _u
+}
+
+// SetNillableForceFastMode sets the "force_fast_mode" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableForceFastMode(v *bool) *GroupUpdate {
+	if v != nil {
+		_u.SetForceFastMode(*v)
+	}
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdate) AddAPIKeyIDs(ids ...int64) *GroupUpdate {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -1029,6 +1043,9 @@ func (_u *GroupUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.MessagesDispatchModelConfig(); ok {
 		_spec.SetField(group.FieldMessagesDispatchModelConfig, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.ForceFastMode(); ok {
+		_spec.SetField(group.FieldForceFastMode, field.TypeBool, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{
@@ -1875,6 +1892,20 @@ func (_u *GroupUpdateOne) SetNillableMessagesDispatchModelConfig(v *domain.OpenA
 	return _u
 }
 
+// SetForceFastMode sets the "force_fast_mode" field.
+func (_u *GroupUpdateOne) SetForceFastMode(v bool) *GroupUpdateOne {
+	_u.mutation.SetForceFastMode(v)
+	return _u
+}
+
+// SetNillableForceFastMode sets the "force_fast_mode" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableForceFastMode(v *bool) *GroupUpdateOne {
+	if v != nil {
+		_u.SetForceFastMode(*v)
+	}
+	return _u
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by IDs.
 func (_u *GroupUpdateOne) AddAPIKeyIDs(ids ...int64) *GroupUpdateOne {
 	_u.mutation.AddAPIKeyIDs(ids...)
@@ -2367,6 +2398,9 @@ func (_u *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error)
 	}
 	if value, ok := _u.mutation.MessagesDispatchModelConfig(); ok {
 		_spec.SetField(group.FieldMessagesDispatchModelConfig, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.ForceFastMode(); ok {
+		_spec.SetField(group.FieldForceFastMode, field.TypeBool, value)
 	}
 	if _u.mutation.APIKeysCleared() {
 		edge := &sqlgraph.EdgeSpec{

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -408,6 +408,7 @@ var (
 		{Name: "require_privacy_set", Type: field.TypeBool, Default: false},
 		{Name: "default_mapped_model", Type: field.TypeString, Size: 100, Default: ""},
 		{Name: "messages_dispatch_model_config", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "force_fast_mode", Type: field.TypeBool, Default: false},
 	}
 	// GroupsTable holds the schema information for the "groups" table.
 	GroupsTable = &schema.Table{

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -8255,6 +8255,7 @@ type GroupMutation struct {
 	require_privacy_set                     *bool
 	default_mapped_model                    *string
 	messages_dispatch_model_config          *domain.OpenAIMessagesDispatchModelConfig
+	force_fast_mode                         *bool
 	clearedFields                           map[string]struct{}
 	api_keys                                map[int64]struct{}
 	removedapi_keys                         map[int64]struct{}
@@ -9843,6 +9844,42 @@ func (m *GroupMutation) ResetMessagesDispatchModelConfig() {
 	m.messages_dispatch_model_config = nil
 }
 
+// SetForceFastMode sets the "force_fast_mode" field.
+func (m *GroupMutation) SetForceFastMode(b bool) {
+	m.force_fast_mode = &b
+}
+
+// ForceFastMode returns the value of the "force_fast_mode" field in the mutation.
+func (m *GroupMutation) ForceFastMode() (r bool, exists bool) {
+	v := m.force_fast_mode
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldForceFastMode returns the old "force_fast_mode" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldForceFastMode(ctx context.Context) (v bool, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldForceFastMode is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldForceFastMode requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldForceFastMode: %w", err)
+	}
+	return oldValue.ForceFastMode, nil
+}
+
+// ResetForceFastMode resets all changes to the "force_fast_mode" field.
+func (m *GroupMutation) ResetForceFastMode() {
+	m.force_fast_mode = nil
+}
+
 // AddAPIKeyIDs adds the "api_keys" edge to the APIKey entity by ids.
 func (m *GroupMutation) AddAPIKeyIDs(ids ...int64) {
 	if m.api_keys == nil {
@@ -10201,7 +10238,7 @@ func (m *GroupMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GroupMutation) Fields() []string {
-	fields := make([]string, 0, 30)
+	fields := make([]string, 0, 31)
 	if m.created_at != nil {
 		fields = append(fields, group.FieldCreatedAt)
 	}
@@ -10292,6 +10329,9 @@ func (m *GroupMutation) Fields() []string {
 	if m.messages_dispatch_model_config != nil {
 		fields = append(fields, group.FieldMessagesDispatchModelConfig)
 	}
+	if m.force_fast_mode != nil {
+		fields = append(fields, group.FieldForceFastMode)
+	}
 	return fields
 }
 
@@ -10360,6 +10400,8 @@ func (m *GroupMutation) Field(name string) (ent.Value, bool) {
 		return m.DefaultMappedModel()
 	case group.FieldMessagesDispatchModelConfig:
 		return m.MessagesDispatchModelConfig()
+	case group.FieldForceFastMode:
+		return m.ForceFastMode()
 	}
 	return nil, false
 }
@@ -10429,6 +10471,8 @@ func (m *GroupMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldDefaultMappedModel(ctx)
 	case group.FieldMessagesDispatchModelConfig:
 		return m.OldMessagesDispatchModelConfig(ctx)
+	case group.FieldForceFastMode:
+		return m.OldForceFastMode(ctx)
 	}
 	return nil, fmt.Errorf("unknown Group field %s", name)
 }
@@ -10647,6 +10691,13 @@ func (m *GroupMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetMessagesDispatchModelConfig(v)
+		return nil
+	case group.FieldForceFastMode:
+		v, ok := value.(bool)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetForceFastMode(v)
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)
@@ -10990,6 +11041,9 @@ func (m *GroupMutation) ResetField(name string) error {
 		return nil
 	case group.FieldMessagesDispatchModelConfig:
 		m.ResetMessagesDispatchModelConfig()
+		return nil
+	case group.FieldForceFastMode:
+		m.ResetForceFastMode()
 		return nil
 	}
 	return fmt.Errorf("unknown Group field %s", name)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -477,6 +477,10 @@ func init() {
 	groupDescMessagesDispatchModelConfig := groupFields[26].Descriptor()
 	// group.DefaultMessagesDispatchModelConfig holds the default value on creation for the messages_dispatch_model_config field.
 	group.DefaultMessagesDispatchModelConfig = groupDescMessagesDispatchModelConfig.Default.(domain.OpenAIMessagesDispatchModelConfig)
+	// groupDescForceFastMode is the schema descriptor for force_fast_mode field.
+	groupDescForceFastMode := groupFields[27].Descriptor()
+	// group.DefaultForceFastMode holds the default value on creation for the force_fast_mode field.
+	group.DefaultForceFastMode = groupDescForceFastMode.Default.(bool)
 	idempotencyrecordMixin := schema.IdempotencyRecord{}.Mixin()
 	idempotencyrecordMixinFields0 := idempotencyrecordMixin[0].Fields()
 	_ = idempotencyrecordMixinFields0

--- a/backend/ent/schema/group.go
+++ b/backend/ent/schema/group.go
@@ -145,6 +145,11 @@ func (Group) Fields() []ent.Field {
 			Default(domain.OpenAIMessagesDispatchModelConfig{}).
 			SchemaType(map[string]string{dialect.Postgres: "jsonb"}).
 			Comment("OpenAI Messages 调度模型配置：按 Claude 系列/精确模型映射到目标 GPT 模型"),
+
+		// 强制 fast 模式开关 (added by migration 103)
+		field.Bool("force_fast_mode").
+			Default(false).
+			Comment("仅 openai 分组：强制所有请求走 codex fast (service_tier=priority)，忽略客户端传入的 service_tier 和 anthropic-beta 头"),
 	}
 }
 

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -110,6 +110,8 @@ type CreateGroupRequest struct {
 	RequirePrivacySet           bool                                      `json:"require_privacy_set"`
 	DefaultMappedModel          string                                    `json:"default_mapped_model"`
 	MessagesDispatchModelConfig service.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
+	// 强制 fast 模式（仅 openai 平台使用）
+	ForceFastMode bool `json:"force_fast_mode"`
 	// 从指定分组复制账号（创建后自动绑定）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -145,6 +147,8 @@ type UpdateGroupRequest struct {
 	RequirePrivacySet           *bool                                      `json:"require_privacy_set"`
 	DefaultMappedModel          *string                                    `json:"default_mapped_model"`
 	MessagesDispatchModelConfig *service.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
+	// 强制 fast 模式（仅 openai 平台使用）
+	ForceFastMode *bool `json:"force_fast_mode"`
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64 `json:"copy_accounts_from_group_ids"`
 }
@@ -262,6 +266,7 @@ func (h *GroupHandler) Create(c *gin.Context) {
 		RequirePrivacySet:               req.RequirePrivacySet,
 		DefaultMappedModel:              req.DefaultMappedModel,
 		MessagesDispatchModelConfig:     req.MessagesDispatchModelConfig,
+		ForceFastMode:                   req.ForceFastMode,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {
@@ -313,6 +318,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 		RequirePrivacySet:               req.RequirePrivacySet,
 		DefaultMappedModel:              req.DefaultMappedModel,
 		MessagesDispatchModelConfig:     req.MessagesDispatchModelConfig,
+		ForceFastMode:                   req.ForceFastMode,
 		CopyAccountsFromGroupIDs:        req.CopyAccountsFromGroupIDs,
 	})
 	if err != nil {

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -144,6 +144,7 @@ func GroupFromServiceAdmin(g *service.Group) *AdminGroup {
 		MCPXMLInject:                g.MCPXMLInject,
 		DefaultMappedModel:          g.DefaultMappedModel,
 		MessagesDispatchModelConfig: g.MessagesDispatchModelConfig,
+		ForceFastMode:               g.ForceFastMode,
 		SupportedModelScopes:        g.SupportedModelScopes,
 		AccountCount:                g.AccountCount,
 		ActiveAccountCount:          g.ActiveAccountCount,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -126,6 +126,9 @@ type AdminGroup struct {
 	DefaultMappedModel          string                                   `json:"default_mapped_model"`
 	MessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
 
+	// 强制 fast 模式（仅 openai 平台使用）
+	ForceFastMode bool `json:"force_fast_mode"`
+
 	// 支持的模型系列（仅 antigravity 平台使用）
 	SupportedModelScopes    []string       `json:"supported_model_scopes"`
 	AccountGroups           []AccountGroup `json:"account_groups,omitempty"`

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -175,6 +175,7 @@ func (r *apiKeyRepository) GetByKeyForAuth(ctx context.Context, key string) (*se
 				group.FieldAllowMessagesDispatch,
 				group.FieldDefaultMappedModel,
 				group.FieldMessagesDispatchModelConfig,
+				group.FieldForceFastMode,
 			)
 		}).
 		Only(ctx)
@@ -707,6 +708,7 @@ func groupEntityToService(g *dbent.Group) *service.Group {
 		RequirePrivacySet:               g.RequirePrivacySet,
 		DefaultMappedModel:              g.DefaultMappedModel,
 		MessagesDispatchModelConfig:     g.MessagesDispatchModelConfig,
+		ForceFastMode:                   g.ForceFastMode,
 		CreatedAt:                       g.CreatedAt,
 		UpdatedAt:                       g.UpdatedAt,
 	}

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -63,7 +63,8 @@ func (r *groupRepository) Create(ctx context.Context, groupIn *service.Group) er
 		SetRequireOauthOnly(groupIn.RequireOAuthOnly).
 		SetRequirePrivacySet(groupIn.RequirePrivacySet).
 		SetDefaultMappedModel(groupIn.DefaultMappedModel).
-		SetMessagesDispatchModelConfig(groupIn.MessagesDispatchModelConfig)
+		SetMessagesDispatchModelConfig(groupIn.MessagesDispatchModelConfig).
+		SetForceFastMode(groupIn.ForceFastMode)
 
 	// 设置模型路由配置
 	if groupIn.ModelRouting != nil {
@@ -130,7 +131,8 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 		SetRequireOauthOnly(groupIn.RequireOAuthOnly).
 		SetRequirePrivacySet(groupIn.RequirePrivacySet).
 		SetDefaultMappedModel(groupIn.DefaultMappedModel).
-		SetMessagesDispatchModelConfig(groupIn.MessagesDispatchModelConfig)
+		SetMessagesDispatchModelConfig(groupIn.MessagesDispatchModelConfig).
+		SetForceFastMode(groupIn.ForceFastMode)
 
 	// 显式处理可空字段：nil 需要 clear，非 nil 需要 set。
 	if groupIn.DailyLimitUSD != nil {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -157,6 +157,8 @@ type CreateGroupInput struct {
 	RequireOAuthOnly            bool
 	RequirePrivacySet           bool
 	MessagesDispatchModelConfig OpenAIMessagesDispatchModelConfig
+	// 强制 fast 模式（仅 openai 平台使用）
+	ForceFastMode bool
 	// 从指定分组复制账号（创建分组后在同一事务内绑定）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -192,6 +194,8 @@ type UpdateGroupInput struct {
 	RequireOAuthOnly            *bool
 	RequirePrivacySet           *bool
 	MessagesDispatchModelConfig *OpenAIMessagesDispatchModelConfig
+	// 强制 fast 模式（仅 openai 平台使用）
+	ForceFastMode *bool
 	// 从指定分组复制账号（同步操作：先清空当前分组的账号绑定，再绑定源分组的账号）
 	CopyAccountsFromGroupIDs []int64
 }
@@ -911,6 +915,7 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 		RequirePrivacySet:               input.RequirePrivacySet,
 		DefaultMappedModel:              input.DefaultMappedModel,
 		MessagesDispatchModelConfig:     normalizeOpenAIMessagesDispatchModelConfig(input.MessagesDispatchModelConfig),
+		ForceFastMode:                   input.ForceFastMode,
 	}
 	sanitizeGroupMessagesDispatchFields(group)
 	if err := s.groupRepo.Create(ctx, group); err != nil {
@@ -1141,6 +1146,9 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	}
 	if input.MessagesDispatchModelConfig != nil {
 		group.MessagesDispatchModelConfig = normalizeOpenAIMessagesDispatchModelConfig(*input.MessagesDispatchModelConfig)
+	}
+	if input.ForceFastMode != nil {
+		group.ForceFastMode = *input.ForceFastMode
 	}
 	sanitizeGroupMessagesDispatchFields(group)
 

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -76,6 +76,9 @@ type APIKeyAuthGroupSnapshot struct {
 	AllowMessagesDispatch       bool                              `json:"allow_messages_dispatch"`
 	DefaultMappedModel          string                            `json:"default_mapped_model,omitempty"`
 	MessagesDispatchModelConfig OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config,omitempty"`
+
+	// 强制 fast 模式（仅 openai 平台使用）
+	ForceFastMode bool `json:"force_fast_mode,omitempty"`
 }
 
 // APIKeyAuthCacheEntry 缓存条目，支持负缓存

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -258,6 +258,7 @@ func (s *APIKeyService) snapshotFromAPIKey(apiKey *APIKey) *APIKeyAuthSnapshot {
 			AllowMessagesDispatch:           apiKey.Group.AllowMessagesDispatch,
 			DefaultMappedModel:              apiKey.Group.DefaultMappedModel,
 			MessagesDispatchModelConfig:     apiKey.Group.MessagesDispatchModelConfig,
+			ForceFastMode:                   apiKey.Group.ForceFastMode,
 		}
 	}
 	return snapshot
@@ -321,6 +322,7 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			AllowMessagesDispatch:           snapshot.Group.AllowMessagesDispatch,
 			DefaultMappedModel:              snapshot.Group.DefaultMappedModel,
 			MessagesDispatchModelConfig:     snapshot.Group.MessagesDispatchModelConfig,
+			ForceFastMode:                   snapshot.Group.ForceFastMode,
 		}
 	}
 	s.compileAPIKeyIPRules(apiKey)

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -59,6 +59,11 @@ type Group struct {
 	DefaultMappedModel          string
 	MessagesDispatchModelConfig OpenAIMessagesDispatchModelConfig
 
+	// 强制 fast 模式（仅 openai 分组使用）
+	// 启用后，所有转发给上游的请求都会被强制设置 service_tier="priority"，
+	// 忽略客户端传入的 service_tier 和 anthropic-beta: fast-mode 头。
+	ForceFastMode bool
+
 	CreatedAt time.Time
 	UpdatedAt time.Time
 

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -166,6 +166,15 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		}
 	}
 
+	// 分组级"强制 fast 模式"：无条件覆盖客户端显式传入的 service_tier。
+	// 同时更新 responsesBody（实际发送给上游的 bytes）和 responsesReq（下游 billing 传播源）。
+	if getForceFastModeFromContext(c) {
+		if patched, perr := sjson.SetBytes(responsesBody, "service_tier", "priority"); perr == nil {
+			responsesBody = patched
+		}
+		responsesReq.ServiceTier = "priority"
+	}
+
 	// 5. Get access token
 	token, _, err := s.GetAccessToken(ctx, account)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -55,8 +55,11 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	responsesReq.Stream = true
 	isStream := true
 
-	// 2b. Handle BetaFastMode → service_tier: "priority"
-	if containsBetaToken(c.GetHeader("anthropic-beta"), claude.BetaFastMode) {
+	// 2b. Handle fast mode: group-level ForceFastMode wins over client header.
+	// When a codex group has force_fast_mode enabled, unconditionally override
+	// service_tier regardless of the client's anthropic-beta header.
+	if getForceFastModeFromContext(c) ||
+		containsBetaToken(c.GetHeader("anthropic-beta"), claude.BetaFastMode) {
 		responsesReq.ServiceTier = "priority"
 	}
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -872,6 +872,25 @@ func getAPIKeyIDFromContext(c *gin.Context) int64 {
 	return apiKey.ID
 }
 
+// getForceFastModeFromContext 返回当前请求是否命中一个开启了"强制 fast 模式"的 openai 分组。
+// 启用后，所有转发给上游的 codex 请求都会被强制写入 service_tier="priority"，
+// 无条件覆盖客户端传入的 service_tier 和 anthropic-beta: fast-mode 头。
+// 该字段仅对 platform=openai 的分组有意义。
+func getForceFastModeFromContext(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	v, exists := c.Get("api_key")
+	if !exists {
+		return false
+	}
+	apiKey, ok := v.(*APIKey)
+	if !ok || apiKey == nil || apiKey.Group == nil {
+		return false
+	}
+	return apiKey.Group.Platform == PlatformOpenAI && apiKey.Group.ForceFastMode
+}
+
 // isolateOpenAISessionID 将 apiKeyID 混入 session 标识符，
 // 确保不同 API Key 的用户即使使用相同的原始 session_id/conversation_id，
 // 到达上游的标识符也不同，防止跨用户会话碰撞。
@@ -1856,6 +1875,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if passthroughEnabled {
 		// 透传分支只需要轻量提取字段，避免热路径全量 Unmarshal。
 		reasoningEffort := extractOpenAIReasoningEffortFromBody(body, reqModel)
+		// 分组级"强制 fast 模式"：即使走透传也要覆盖客户端的 service_tier。
+		if getForceFastModeFromContext(c) {
+			if patched, err := sjson.SetBytes(originalBody, "service_tier", "priority"); err == nil {
+				originalBody = patched
+			}
+		}
 		return s.forwardOpenAIPassthrough(ctx, c, account, originalBody, reqModel, reasoningEffort, reqStream, startTime)
 	}
 
@@ -1989,6 +2014,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		if codexResult.PromptCacheKey != "" {
 			promptCacheKey = codexResult.PromptCacheKey
 		}
+	}
+
+	// 分组级"强制 fast 模式"：无条件覆盖客户端显式传入的 service_tier。
+	// 放在 codex transform 之后，确保后者不会丢掉这次注入。
+	if getForceFastModeFromContext(c) {
+		reqBody["service_tier"] = "priority"
+		bodyModified = true
+		disablePatch()
 	}
 
 	// Handle max_output_tokens based on platform and account type

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -103,6 +103,79 @@ func TestLogCodexCLIOnlyDetection_NilSafety(t *testing.T) {
 	})
 }
 
+func TestGetForceFastModeFromContext(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newCtx := func() *gin.Context {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		return c
+	}
+
+	t.Run("context 为 nil", func(t *testing.T) {
+		require.False(t, getForceFastModeFromContext(nil))
+	})
+
+	t.Run("上下文没有 api_key", func(t *testing.T) {
+		require.False(t, getForceFastModeFromContext(newCtx()))
+	})
+
+	t.Run("api_key 类型错误", func(t *testing.T) {
+		c := newCtx()
+		c.Set("api_key", "not-api-key")
+		require.False(t, getForceFastModeFromContext(c))
+	})
+
+	t.Run("api_key 为 nil 指针", func(t *testing.T) {
+		c := newCtx()
+		var k *APIKey
+		c.Set("api_key", k)
+		require.False(t, getForceFastModeFromContext(c))
+	})
+
+	t.Run("group 为 nil", func(t *testing.T) {
+		c := newCtx()
+		c.Set("api_key", &APIKey{ID: 1, Group: nil})
+		require.False(t, getForceFastModeFromContext(c))
+	})
+
+	t.Run("group 未启用 force_fast_mode", func(t *testing.T) {
+		c := newCtx()
+		c.Set("api_key", &APIKey{
+			ID: 1,
+			Group: &Group{
+				Platform:      PlatformOpenAI,
+				ForceFastMode: false,
+			},
+		})
+		require.False(t, getForceFastModeFromContext(c))
+	})
+
+	t.Run("非 openai 平台分组即使启用也不生效", func(t *testing.T) {
+		c := newCtx()
+		c.Set("api_key", &APIKey{
+			ID: 1,
+			Group: &Group{
+				Platform:      PlatformAnthropic,
+				ForceFastMode: true,
+			},
+		})
+		require.False(t, getForceFastModeFromContext(c))
+	})
+
+	t.Run("openai 分组启用 force_fast_mode", func(t *testing.T) {
+		c := newCtx()
+		c.Set("api_key", &APIKey{
+			ID: 1,
+			Group: &Group{
+				Platform:      PlatformOpenAI,
+				ForceFastMode: true,
+			},
+		})
+		require.True(t, getForceFastModeFromContext(c))
+	})
+}
+
 func TestLogCodexCLIOnlyDetection_OnlyLogsRejected(t *testing.T) {
 	logSink, restore := captureStructuredLog(t)
 	defer restore()

--- a/backend/migrations/107_add_group_force_fast_mode.sql
+++ b/backend/migrations/107_add_group_force_fast_mode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups ADD COLUMN force_fast_mode BOOLEAN NOT NULL DEFAULT false;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1706,6 +1706,8 @@ export default {
         title: 'OpenAI Messages Dispatch',
         allowDispatch: 'Allow /v1/messages dispatch',
         allowDispatchHint: 'When enabled, API keys in this OpenAI group can dispatch requests through /v1/messages endpoint',
+        forceFastMode: 'Force Fast Mode',
+        forceFastModeHint: 'When enabled, all requests (/v1/responses, /v1/chat/completions, /v1/messages) handled by this group are forced to codex fast tier, overriding any service_tier or anthropic-beta header from the client. Note: fast tier is billed at priority pricing, roughly 2× the standard rate.',
         familyMappingTitle: 'Family Default Mapping',
         familyMappingHint: 'Requests that match the Opus, Sonnet, or Haiku families will prefer the target model configured here.',
         opusModel: 'Opus Target Model',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1792,6 +1792,8 @@ export default {
         title: 'OpenAI Messages 调度配置',
         allowDispatch: '允许 /v1/messages 调度',
         allowDispatchHint: '启用后，此 OpenAI 分组的 API Key 可以通过 /v1/messages 端点调度请求',
+        forceFastMode: '强制 fast 模式',
+        forceFastModeHint: '启用后，此分组处理的所有请求（/v1/responses、/v1/chat/completions、/v1/messages）都会强制走 codex fast，忽略客户端传入的 service_tier 和 anthropic-beta 头。注意：fast 档按 priority 档位计费，约为普通档的 2 倍。',
         familyMappingTitle: '系列默认映射',
         familyMappingHint: '当请求命中 Opus、Sonnet、Haiku 系列时，会优先使用这里配置的目标模型。',
         opusModel: 'Opus 映射模型',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -416,6 +416,8 @@ export interface Group {
   allow_messages_dispatch?: boolean
   default_mapped_model?: string
   messages_dispatch_model_config?: OpenAIMessagesDispatchModelConfig
+  // 强制 fast 模式（仅 openai 分组使用）
+  force_fast_mode?: boolean
   require_oauth_only: boolean
   require_privacy_set: boolean
   created_at: string
@@ -524,6 +526,8 @@ export interface CreateGroupRequest {
   supported_model_scopes?: string[]
   require_oauth_only?: boolean
   require_privacy_set?: boolean
+  // 强制 fast 模式（仅 openai 分组）
+  force_fast_mode?: boolean
   // 从指定分组复制账号
   copy_accounts_from_group_ids?: number[]
 }
@@ -549,6 +553,8 @@ export interface UpdateGroupRequest {
   supported_model_scopes?: string[]
   require_oauth_only?: boolean
   require_privacy_set?: boolean
+  // 强制 fast 模式（仅 openai 分组）
+  force_fast_mode?: boolean
   copy_accounts_from_group_ids?: number[]
 }
 

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -929,6 +929,37 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
+          <!-- 强制 fast 模式开关 -->
+          <div class="flex items-center justify-between mt-4">
+            <label class="text-sm text-gray-600 dark:text-gray-400">{{
+              t("admin.groups.openaiMessages.forceFastMode")
+            }}</label>
+            <button
+              type="button"
+              @click="
+                createForm.force_fast_mode = !createForm.force_fast_mode
+              "
+              class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
+              :class="
+                createForm.force_fast_mode
+                  ? 'bg-primary-500'
+                  : 'bg-gray-300 dark:bg-dark-600'
+              "
+            >
+              <span
+                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                :class="
+                  createForm.force_fast_mode
+                    ? 'translate-x-6'
+                    : 'translate-x-1'
+                "
+              />
+            </button>
+          </div>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            {{ t("admin.groups.openaiMessages.forceFastModeHint") }}
+          </p>
+
           <div v-if="createForm.allow_messages_dispatch" class="mt-3">
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
@@ -2047,6 +2078,35 @@
             {{ t("admin.groups.openaiMessages.allowDispatchHint") }}
           </p>
 
+          <!-- 强制 fast 模式开关 -->
+          <div class="flex items-center justify-between mt-4">
+            <label class="text-sm text-gray-600 dark:text-gray-400">{{
+              t("admin.groups.openaiMessages.forceFastMode")
+            }}</label>
+            <button
+              type="button"
+              @click="editForm.force_fast_mode = !editForm.force_fast_mode"
+              class="relative inline-flex h-6 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none"
+              :class="
+                editForm.force_fast_mode
+                  ? 'bg-primary-500'
+                  : 'bg-gray-300 dark:bg-dark-600'
+              "
+            >
+              <span
+                class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out"
+                :class="
+                  editForm.force_fast_mode
+                    ? 'translate-x-6'
+                    : 'translate-x-1'
+                "
+              />
+            </button>
+          </div>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+            {{ t("admin.groups.openaiMessages.forceFastModeHint") }}
+          </p>
+
           <div v-if="editForm.allow_messages_dispatch" class="mt-3">
             <div
               class="relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-dark-600 dark:bg-dark-800"
@@ -2973,6 +3033,8 @@ const createForm = reactive({
   fallback_group_id_on_invalid_request: null as number | null,
   // OpenAI Messages 调度配置（仅 openai 平台使用）
   allow_messages_dispatch: false,
+  // 强制 fast 模式（仅 openai 平台使用）
+  force_fast_mode: false,
   opus_mapped_model: createMessagesDispatchDefaults.opus_mapped_model,
   sonnet_mapped_model: createMessagesDispatchDefaults.sonnet_mapped_model,
   haiku_mapped_model: createMessagesDispatchDefaults.haiku_mapped_model,
@@ -3254,6 +3316,8 @@ const editForm = reactive({
   // OpenAI Messages 调度配置（仅 openai 平台使用）
   allow_messages_dispatch: false,
   default_mapped_model: '',
+  // 强制 fast 模式（仅 openai 平台使用）
+  force_fast_mode: false,
   opus_mapped_model: editMessagesDispatchDefaults.opus_mapped_model,
   sonnet_mapped_model: editMessagesDispatchDefaults.sonnet_mapped_model,
   haiku_mapped_model: editMessagesDispatchDefaults.haiku_mapped_model,
@@ -3545,6 +3609,7 @@ const handleEdit = async (group: AdminGroup) => {
   editForm.allow_messages_dispatch =
     group.allow_messages_dispatch ||
     messagesDispatchFormState.allow_messages_dispatch;
+  editForm.force_fast_mode = group.force_fast_mode ?? false;
   editForm.opus_mapped_model = messagesDispatchFormState.opus_mapped_model;
   editForm.sonnet_mapped_model = messagesDispatchFormState.sonnet_mapped_model;
   editForm.haiku_mapped_model = messagesDispatchFormState.haiku_mapped_model;


### PR DESCRIPTION
## 背景

项目已经支持 Claude 协议 → Codex Fast 的自动映射：当 Claude Code 客户端通过 `/v1/messages` 发送请求并携带 `anthropic-beta: fast-mode-2026-02-01` header 时，`ForwardAsAnthropic` 会把 `responsesReq.ServiceTier` 设为 `"priority"`（`openai_gateway_messages.go:58-61`）。

但实际用户遇到的问题是:

- **Claude Code 官方客户端**目前没有开启 fast-mode beta 的入口,用户无法让客户端携带这个 header
- **Claude Code 的 codex 插件**同样无法传入 fast-mode header

结果就是:即使用户愿意使用 fast 档(priority 档位),现有链路也**触发不了** —— 整个"Claude → Codex Fast"的功能在实际场景中派不上用场。

## 方案

在 openai 类型分组上新增一个 admin 级开关 `force_fast_mode`。开启后,此分组处理的**所有**请求(不论来自 `/v1/responses`、`/v1/chat/completions` 还是 `/v1/messages`)都会被强制写入 `service_tier="priority"`,**无条件覆盖**客户端传入的 `service_tier` 和 `anthropic-beta: fast-mode-*` header。

这是一个分组级的"override 兜底":管理员配置一次,该分组下所有 API Key 的请求都自动走 fast 档,不依赖客户端能不能传 header。

## 设计要点

### 单一注入入口,不改函数签名

三条 forward 路径(`Forward` / `ForwardAsAnthropic` / `ForwardAsChatCompletions`)都在 OAuth 分支调用 `applyCodexOAuthTransform`。为避免改动 `applyCodexOAuthTransform` 签名(会牵扯到 20+ 个已有测试桩),新增一个 helper:

```go
// openai_gateway_service.go
func getForceFastModeFromContext(c *gin.Context) bool {
    // 从 c.Get("api_key") 读 apiKey.Group.ForceFastMode
    // 仅对 platform=openai 的分组生效
}
```

这个 helper 复用了中间件已 eager-load 到 context 的 `apiKey.Group`,handler 层**完全不需要改动**。

### 三处单点注入

- `openai_gateway_service.go` `Forward`(`/v1/responses`,含 passthrough 和 WSv2 分支):在 `applyCodexOAuthTransform` 之后设置 `reqBody["service_tier"] = "priority"`
- `openai_gateway_messages.go` `ForwardAsAnthropic`(Claude `/v1/messages`):扩展原有 `BetaFastMode` 判断为 `force_fast_mode || beta`
- `openai_gateway_chat_completions.go` `ForwardAsChatCompletions`(`/v1/chat/completions`):在 `responsesBody` 最终 marshal 前同时设置 `responsesReq.ServiceTier` 和 body bytes

### 计费自动跟随

不需要碰 billing 代码。`extractOpenAIServiceTier(reqBody)` 已经会从最终 body 读 `service_tier`,`CalculateCostWithServiceTier` 会按 priority 档计费(`billing_service_test.go:503` 已覆盖)。

### api_key_auth_cache 同步更新

`APIKeyAuthGroupSnapshot`(`api_key_auth_cache.go`)需要同步序列化新字段,否则 cache 里读回来的 Group 永远是默认 false。字段用 `omitempty`,老版本读到缺失字段时默认 false,向后兼容。

### api_key_repo Select 白名单

`api_key_repo.go` 的 `GetByKeyForAuth` 用了显式 `q.Select(...)` 字段白名单,必须把 `group.FieldForceFastMode` 加进去,否则 ent 不会 SELECT 这一列,读出来的结构体字段是 false(已踩过这个坑)。

## 向后兼容性

- **DB schema**:`migration 107` 加列 `force_fast_mode BOOLEAN NOT NULL DEFAULT false`。老代码读到这一列不会崩,只是不读。
- **Redis cache**:`APIKeyAuthGroupSnapshot` JSON 字段用 `omitempty`。新老版本混部(共享同一个 Redis)时,双向读写都安全。
- **已有 fast-mode header 客户端**:行为**不变**(`force_fast_mode` 关闭时原链路完全保留)。开启时会覆盖客户端显式值,这是预期行为。

## 测试

- 新增 8 个 subtest:`TestGetForceFastModeFromContext` 覆盖 nil context、缺 api_key、类型错、nil APIKey、nil Group、关闭、非 openai 平台、openai+开启 所有分支
- `go test -tags=unit ./internal/service/... ./internal/handler/... ./internal/repository/...` 全部通过
- `golangci-lint run ./... --new-from-rev=upstream/main` 0 issues
- `pnpm run typecheck` 通过

## Checklist

- [x] `go test -tags=unit ./...` 通过
- [ ] `go test -tags=integration ./...` —— 本地未启动 postgres/redis,依赖 CI 跑(改动对集成测试零影响:只加了一个字段 + 对应白名单更新,没有改任何既有接口)
- [x] `golangci-lint run ./...` 无新增问题
- [x] `pnpm-lock.yaml` 同步(未改 package.json)
- [x] 无 interface 改动,不需要补 stub
- [x] Ent 生成代码已提交

## 使用方式

在 admin UI 编辑一个 openai 平台分组,可以看到"强制 fast 模式"开关(位于"允许 /v1/messages 调度"下方)。开启后**立即对所有该分组的 API Key 生效**(auth cache 会在下次请求时重新加载或自动失效)。

用户如果同时使用 `force_fast_mode=true` 和客户端 `anthropic-beta: fast-mode` header,行为一致(都走 priority);如果 `force_fast_mode=false` + 客户端传 header,按原有链路走 priority;`force_fast_mode=false` + 客户端不传 header,走默认档。
