### PR TITLE
fix(ui): allow closing test dialog during active SSE stream

### DIFF
--- a/frontend/src/components/account/AccountTestModal.vue
+++ b/frontend/src/components/account/AccountTestModal.vue
@@ -165,7 +165,6 @@
         <button
           @click="handleClose"
           class="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-dark-600 dark:text-gray-300 dark:hover:bg-dark-500"
-          :disabled="status === 'connecting'"
         >
           {{ t('common.close') }}
         </button>
@@ -249,7 +248,7 @@ const availableModels = ref<ClaudeModel[]>([])
 const selectedModelId = ref('')
 const testPrompt = ref('')
 const loadingModels = ref(false)
-let eventSource: EventSource | null = null
+let abortController: AbortController | null = null
 const generatedImages = ref<PreviewImage[]>([])
 const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
 const supportsGeminiImageTest = computed(() => {
@@ -279,7 +278,7 @@ watch(
       resetState()
       await loadAvailableModels()
     } else {
-      closeEventSource()
+      abortStream()
     }
   }
 )
@@ -329,18 +328,14 @@ const resetState = () => {
 }
 
 const handleClose = () => {
-  // 防止在连接测试进行中关闭对话框
-  if (status.value === 'connecting') {
-    return
-  }
-  closeEventSource()
+  abortStream()
   emit('close')
 }
 
-const closeEventSource = () => {
-  if (eventSource) {
-    eventSource.close()
-    eventSource = null
+const abortStream = () => {
+  if (abortController) {
+    abortController.abort()
+    abortController = null
   }
 }
 
@@ -365,7 +360,9 @@ const startTest = async () => {
   addLine(t('admin.accounts.testAccountTypeLabel', { type: props.account.type }), 'text-gray-400')
   addLine('', 'text-gray-300')
 
-  closeEventSource()
+  abortStream()
+
+  abortController = new AbortController()
 
   try {
     // Create EventSource for SSE
@@ -381,7 +378,8 @@ const startTest = async () => {
       body: JSON.stringify({
               model_id: selectedModelId.value,
               prompt: supportsGeminiImageTest.value ? testPrompt.value.trim() : ''
-            })
+            }),
+      signal: abortController.signal
     })
 
     if (!response.ok) {
@@ -418,10 +416,15 @@ const startTest = async () => {
         }
       }
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      status.value = 'idle'
+      return
+    }
     status.value = 'error'
-    errorMessage.value = error.message || 'Unknown error'
-    addLine(`Error: ${errorMessage.value}`, 'text-red-400')
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    errorMessage.value = msg
+    addLine(`Error: ${msg}`, 'text-red-400')
   }
 }
 

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -165,7 +165,6 @@
         <button
           @click="handleClose"
           class="rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-200 dark:bg-dark-600 dark:text-gray-300 dark:hover:bg-dark-500"
-          :disabled="status === 'connecting'"
         >
           {{ t('common.close') }}
         </button>
@@ -249,7 +248,7 @@ const availableModels = ref<ClaudeModel[]>([])
 const selectedModelId = ref('')
 const testPrompt = ref('')
 const loadingModels = ref(false)
-let eventSource: EventSource | null = null
+let abortController: AbortController | null = null
 const generatedImages = ref<PreviewImage[]>([])
 const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
 const supportsGeminiImageTest = computed(() => {
@@ -279,7 +278,7 @@ watch(
       resetState()
       await loadAvailableModels()
     } else {
-      closeEventSource()
+      abortStream()
     }
   }
 )
@@ -329,18 +328,14 @@ const resetState = () => {
 }
 
 const handleClose = () => {
-  // 防止在连接测试进行中关闭对话框
-  if (status.value === 'connecting') {
-    return
-  }
-  closeEventSource()
+  abortStream()
   emit('close')
 }
 
-const closeEventSource = () => {
-  if (eventSource) {
-    eventSource.close()
-    eventSource = null
+const abortStream = () => {
+  if (abortController) {
+    abortController.abort()
+    abortController = null
   }
 }
 
@@ -365,7 +360,9 @@ const startTest = async () => {
   addLine(t('admin.accounts.testAccountTypeLabel', { type: props.account.type }), 'text-gray-400')
   addLine('', 'text-gray-300')
 
-  closeEventSource()
+  abortStream()
+
+  abortController = new AbortController()
 
   try {
     // Create EventSource for SSE
@@ -381,7 +378,8 @@ const startTest = async () => {
       body: JSON.stringify({
               model_id: selectedModelId.value,
               prompt: supportsGeminiImageTest.value ? testPrompt.value.trim() : ''
-            })
+            }),
+      signal: abortController.signal
     })
 
     if (!response.ok) {
@@ -418,10 +416,15 @@ const startTest = async () => {
         }
       }
     }
-  } catch (error: any) {
+  } catch (error: unknown) {
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      status.value = 'idle'
+      return
+    }
     status.value = 'error'
-    errorMessage.value = error.message || 'Unknown error'
-    addLine(`Error: ${errorMessage.value}`, 'text-red-400')
+    const msg = error instanceof Error ? error.message : 'Unknown error'
+    errorMessage.value = msg
+    addLine(`Error: ${msg}`, 'text-red-400')
   }
 }
 


### PR DESCRIPTION
## 背景 / Background

账号测试对话框在 SSE 流式请求进行中时，关闭按钮被禁用，`handleClose()` 直接 return，Escape 键也无效。如果后端响应缓慢或无响应，用户无法关闭对话框，整个 UI 处于卡死状态。

The account test dialog disables the close button and blocks `handleClose()` with an early return while SSE streaming is in progress. If the backend is slow or unresponsive, the user cannot dismiss the dialog, effectively freezing the UI.

---

## 目的 / Purpose

允许用户在测试进行中随时关闭对话框，同时正确取消正在进行的 fetch 流式请求。

Allow users to close the test dialog at any time during an active test, while properly cancelling the in-flight fetch stream.

---

## 改动内容 / Changes

### 前端 / Frontend

- **替换无效的 EventSource 为 AbortController**：原代码声明了 `let eventSource: EventSource` 但从未赋值（实际使用 fetch + getReader），导致 `closeEventSource()` 为空操作。改为 `AbortController`，并将 `signal` 传入 fetch 请求
- **移除关闭阻断逻辑**：`handleClose()` 不再在 `connecting` 状态时 return，而是调用 `abortStream()` 取消请求后正常关闭
- **移除关闭按钮 disabled**：关闭按钮不再在测试期间被禁用
- **正确处理取消错误**：catch 块识别 `AbortError`，用户主动取消时静默处理，不显示错误信息
- **修复 TypeScript 类型**：`catch (error: any)` → `catch (error: unknown)`

---

- **Replace dead EventSource with AbortController**: The original code declared `let eventSource: EventSource` but never assigned it (fetch + getReader is used instead), making `closeEventSource()` a no-op. Replaced with `AbortController` and pass its `signal` to the fetch call
- **Remove close-blocking logic**: `handleClose()` no longer returns early during `connecting` status; it calls `abortStream()` to cancel the request and closes normally
- **Remove close button disabled state**: The close button is no longer disabled during testing
- **Handle cancellation errors properly**: The catch block recognizes `AbortError` and silently handles user-initiated cancellation without showing error messages
- **Fix TypeScript typing**: `catch (error: any)` → `catch (error: unknown)`