### PR TITLE
fix：修复上游账号为OpenAI API key时Claude Code调用缓存率低的问题

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -121,6 +121,28 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		}
 	}
 
+	// For API key accounts (including OpenAI-compatible upstream gateways),
+	// ensure promptCacheKey is also propagated via the request body so that
+	// upstreams using the Responses API can derive a stable session identifier
+	// from prompt_cache_key. This makes our Anthropic /v1/messages compatibility
+	// path behave more like a native Responses client.
+	if account.Type == AccountTypeAPIKey {
+		if trimmedKey := strings.TrimSpace(promptCacheKey); trimmedKey != "" {
+			var reqBody map[string]any
+			if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
+				return nil, fmt.Errorf("unmarshal for prompt cache key injection: %w", err)
+			}
+			if existing, ok := reqBody["prompt_cache_key"].(string); !ok || strings.TrimSpace(existing) == "" {
+				reqBody["prompt_cache_key"] = trimmedKey
+				updated, err := json.Marshal(reqBody)
+				if err != nil {
+					return nil, fmt.Errorf("remarshal after prompt cache key injection: %w", err)
+				}
+				responsesBody = updated
+			}
+		}
+	}
+
 	// 5. Get access token
 	token, _, err := s.GetAccessToken(ctx, account)
 	if err != nil {


### PR DESCRIPTION
# Summary
通过在 `responsesBody ` 里写入 `prompt_cache_key`，可以显著改善当上游账号为 OpenAI API Key 类型，在 Claude Code 客户端中调用时缓存率低的问题。

# 效果

未加入 `prompt_cache_key` 时，缓存很不稳定：
<img width="738" height="834" alt="image" src="https://github.com/user-attachments/assets/28560345-dc8c-43a0-bd4d-facd52cf810e" />

加入 `prompt_cache_key` 后：
<img width="716" height="762" alt="image" src="https://github.com/user-attachments/assets/6e2eea0a-472d-4cc7-bf85-ed517acff2c8" />

