### PR TITLE
fix(usage): support searchable API key filter on /usage page

### DIFF
--- a/frontend/src/components/common/Select.vue
+++ b/frontend/src/components/common/Select.vue
@@ -140,6 +140,7 @@ interface Props {
 interface Emits {
   (e: 'update:modelValue', value: string | number | boolean | null): void
   (e: 'change', value: string | number | boolean | null, option: SelectOption | null): void
+  (e: 'search', query: string): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -329,6 +330,7 @@ watch(isOpen, (open) => {
     }
 
     if (props.searchable) {
+      emit('search', searchQuery.value)
       nextTick(() => searchInputRef.value?.focus())
     }
     // Add scroll listener to update position
@@ -340,6 +342,11 @@ watch(isOpen, (open) => {
     window.removeEventListener('scroll', updateTriggerRect, { capture: true })
     window.removeEventListener('resize', calculateDropdownPosition)
   }
+})
+
+watch(searchQuery, (query) => {
+  if (!props.searchable || !isOpen.value) return
+  emit('search', query)
 })
 
 const selectOption = (option: any) => {

--- a/frontend/src/components/common/__tests__/Select.spec.ts
+++ b/frontend/src/components/common/__tests__/Select.spec.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { ref } from 'vue'
+
+import Select from '../Select.vue'
+
+const messages: Record<string, string> = {
+  'common.selectOption': 'Select option',
+  'common.searchPlaceholder': 'Search...',
+  'common.noOptionsFound': 'No options found'
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => messages[key] ?? key,
+    locale: ref('en')
+  })
+}))
+
+describe('Select', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('emits search when opened and when the query changes', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        modelValue: null,
+        searchable: true,
+        options: [
+          { value: 1, label: 'Alpha' },
+          { value: 2, label: 'Beta' }
+        ]
+      },
+      global: {
+        stubs: {
+          Icon: true,
+          Teleport: true
+        }
+      }
+    })
+
+    await wrapper.get('button[aria-haspopup="true"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('search')).toEqual([['']])
+
+    const searchInput = wrapper.find('.select-search-input')
+    expect(searchInput.exists()).toBe(true)
+
+    await searchInput.setValue('abc')
+    await flushPromises()
+
+    expect(wrapper.emitted('search')).toEqual([[''], ['abc']])
+  })
+
+  it('does not emit search when searchable is disabled', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        modelValue: null,
+        options: [
+          { value: 1, label: 'Alpha' },
+          { value: 2, label: 'Beta' }
+        ]
+      },
+      global: {
+        stubs: {
+          Icon: true,
+          Teleport: true
+        }
+      }
+    })
+
+    await wrapper.get('button[aria-haspopup="true"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('search')).toBeUndefined()
+  })
+
+  it('keeps change and update:modelValue behavior unchanged', async () => {
+    const wrapper = mount(Select, {
+      attachTo: document.body,
+      props: {
+        modelValue: null,
+        options: [
+          { value: 1, label: 'Alpha' },
+          { value: 2, label: 'Beta' }
+        ]
+      },
+      global: {
+        stubs: {
+          Icon: true,
+          Teleport: true
+        }
+      }
+    })
+
+    await wrapper.get('button[aria-haspopup="true"]').trigger('click')
+    await flushPromises()
+
+    const options = wrapper.findAll('.select-option')
+    expect(options).toHaveLength(2)
+
+    await options[1].trigger('click')
+    await flushPromises()
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[2]])
+    expect(wrapper.emitted('change')).toEqual([[2, { value: 2, label: 'Beta' }]])
+  })
+})

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -97,7 +97,11 @@
                 v-model="filters.api_key_id"
                 :options="apiKeyOptions"
                 :placeholder="t('usage.allApiKeys')"
-                @change="applyFilters"
+                :empty-text="apiKeyOptionsLoading ? t('common.loading') : t('common.noOptionsFound')"
+                searchable
+                :search-placeholder="t('keys.searchPlaceholder')"
+                @change="onApiKeyChange"
+                @search="searchApiKeys"
               />
             </div>
 
@@ -504,7 +508,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, reactive, onMounted } from 'vue'
+import { ref, computed, reactive, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { usageAPI, keysAPI } from '@/api'
@@ -516,7 +520,7 @@ import EmptyState from '@/components/common/EmptyState.vue'
 import Select from '@/components/common/Select.vue'
 import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import Icon from '@/components/icons/Icon.vue'
-import type { UsageLog, ApiKey, UsageQueryParams, UsageStatsResponse } from '@/types'
+import type { UsageLog, UsageQueryParams, UsageStatsResponse } from '@/types'
 import type { Column } from '@/components/common/types'
 import { formatDateTime, formatReasoningEffort } from '@/utils/format'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
@@ -559,19 +563,41 @@ const columns = computed<Column[]>(() => [
   { key: 'user_agent', label: t('usage.userAgent'), sortable: false }
 ])
 
+type ApiKeyOption = {
+  value: number | null
+  label: string
+}
+
+const getDefaultApiKeyOption = (): ApiKeyOption => ({
+  value: null,
+  label: t('usage.allApiKeys')
+})
+
 const usageLogs = ref<UsageLog[]>([])
-const apiKeys = ref<ApiKey[]>([])
+const apiKeyOptionsState = ref<ApiKeyOption[]>([])
+const selectedApiKeyOption = ref<ApiKeyOption | null>(null)
 const loading = ref(false)
 const exporting = ref(false)
+const apiKeyOptionsLoading = ref(false)
+let apiKeySearchAbortController: AbortController | null = null
+let apiKeySearchTimer: ReturnType<typeof setTimeout> | null = null
 
 const apiKeyOptions = computed(() => {
-  return [
-    { value: null, label: t('usage.allApiKeys') },
-    ...apiKeys.value.map((key) => ({
-      value: key.id,
-      label: key.name
-    }))
+  const defaultOption = getDefaultApiKeyOption()
+  const options = [defaultOption]
+  const seenValues = new Set<number | null>([defaultOption.value])
+  const candidateOptions = [
+    ...(selectedApiKeyOption.value ? [selectedApiKeyOption.value] : []),
+    ...apiKeyOptionsState.value
   ]
+
+  for (const option of candidateOptions) {
+    if (seenValues.has(option.value)) continue
+    options.push(option)
+    seenValues.add(option.value)
+  }
+
+  return options
 })
 
 // Helper function to format date in local timezone
@@ -718,13 +744,77 @@ const loadUsageLogs = async () => {
   }
 }
 
-const loadApiKeys = async () => {
-  try {
-    const response = await keysAPI.list(1, 100)
-    apiKeys.value = response.items
-  } catch (error) {
-    console.error('Failed to load API keys:', error)
+const buildApiKeySearchFilters = (query: string) => {
+  const trimmedQuery = query.trim()
+  if (trimmedQuery) {
+    return {
+      search: trimmedQuery,
+      sort_by: 'name',
+      sort_order: 'asc' as const
+    }
   }
+
+  return {
+    sort_by: 'created_at',
+    sort_order: 'desc' as const
+  }
+}
+
+const fetchApiKeyOptions = async (query: string) => {
+  apiKeySearchAbortController?.abort()
+  const controller = new AbortController()
+  apiKeySearchAbortController = controller
+  const { signal } = controller
+  apiKeyOptionsLoading.value = true
+
+  try {
+    const response = await keysAPI.list(1, 20, buildApiKeySearchFilters(query), { signal })
+    if (signal.aborted) {
+      return
+    }
+
+    apiKeyOptionsState.value = response.items.map((key) => ({
+      value: key.id,
+      label: key.name
+    }))
+  } catch (error) {
+    if (signal.aborted) {
+      return
+    }
+    apiKeyOptionsState.value = []
+    console.error('Failed to search API keys:', error)
+  } finally {
+    if (apiKeySearchAbortController === controller) {
+      apiKeyOptionsLoading.value = false
+    }
+  }
+}
+
+const searchApiKeys = (query: string) => {
+  if (apiKeySearchTimer) {
+    clearTimeout(apiKeySearchTimer)
+  }
+
+  apiKeySearchTimer = setTimeout(() => {
+    apiKeySearchTimer = null
+    fetchApiKeyOptions(query)
+  }, 300)
+}
+
+const onApiKeyChange = (
+  value: string | number | boolean | null,
+  option: { value?: string | number | boolean | null; label?: string } | null
+) => {
+  if (value == null) {
+    selectedApiKeyOption.value = null
+  } else if (typeof value === 'number' && option && typeof option.label === 'string') {
+    selectedApiKeyOption.value = {
+      value,
+      label: option.label
+    }
+  }
+
+  applyFilters()
 }
 
 const loadUsageStats = async () => {
@@ -748,6 +838,11 @@ const applyFilters = () => {
 }
 
 const resetFilters = () => {
+  apiKeySearchAbortController?.abort()
+  if (apiKeySearchTimer) {
+    clearTimeout(apiKeySearchTimer)
+    apiKeySearchTimer = null
+  }
   filters.value = {
     api_key_id: undefined,
     start_date: undefined,
@@ -761,6 +856,8 @@ const resetFilters = () => {
   endDate.value = formatLocalDate(now)
   filters.value.start_date = startDate.value
   filters.value.end_date = endDate.value
+  selectedApiKeyOption.value = null
+  apiKeyOptionsState.value = []
   pagination.page = 1
   loadUsageLogs()
   loadUsageStats()
@@ -925,8 +1022,16 @@ const hideTokenTooltip = () => {
 }
 
 onMounted(() => {
-  loadApiKeys()
   loadUsageLogs()
   loadUsageStats()
+})
+
+onUnmounted(() => {
+  abortController?.abort()
+  apiKeySearchAbortController?.abort()
+  if (apiKeySearchTimer) {
+    clearTimeout(apiKeySearchTimer)
+    apiKeySearchTimer = null
+  }
 })
 </script>

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 
 import UsageView from '../UsageView.vue'
+import Select from '@/components/common/Select.vue'
 
 const { query, getStatsByDateRange, list, showError, showWarning, showSuccess, showInfo } = vi.hoisted(() => ({
   query: vi.fn(),
@@ -32,6 +33,7 @@ const messages: Record<string, string> = {
   'usage.billed': 'Billed',
   'usage.allApiKeys': 'All API Keys',
   'usage.apiKeyFilter': 'API Key',
+  'keys.searchPlaceholder': 'Search name or key...',
   'usage.model': 'Model',
   'usage.reasoningEffort': 'Reasoning Effort',
   'usage.type': 'Type',
@@ -41,6 +43,8 @@ const messages: Record<string, string> = {
   'usage.duration': 'Duration',
   'usage.time': 'Time',
   'usage.userAgent': 'User Agent',
+  'common.loading': 'Loading...',
+  'common.noOptionsFound': 'No options found'
 }
 
 vi.mock('@/api', () => ({
@@ -72,6 +76,24 @@ const TablePageLayoutStub = {
   template: '<div><slot name="actions" /><slot name="filters" /><slot /></div>',
 }
 
+const mountUsageView = (useRealSelect: boolean = false) => {
+  return mount(UsageView, {
+    attachTo: document.body,
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        TablePageLayout: TablePageLayoutStub,
+        Pagination: true,
+        EmptyState: true,
+        Select: useRealSelect ? Select : true,
+        DateRangePicker: true,
+        Icon: true,
+        Teleport: true,
+      },
+    },
+  })
+}
+
 describe('user UsageView tooltip', () => {
   beforeEach(() => {
     query.mockReset()
@@ -98,6 +120,11 @@ describe('user UsageView tooltip', () => {
       observe() {}
       disconnect() {}
     }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    document.body.innerHTML = ''
   })
 
   it('shows fast service tier and unit prices in user tooltip', async () => {
@@ -137,20 +164,7 @@ describe('user UsageView tooltip', () => {
     })
     list.mockResolvedValue({ items: [] })
 
-    const wrapper = mount(UsageView, {
-      global: {
-        stubs: {
-          AppLayout: AppLayoutStub,
-          TablePageLayout: TablePageLayoutStub,
-          Pagination: true,
-          EmptyState: true,
-          Select: true,
-          DateRangePicker: true,
-          Icon: true,
-          Teleport: true,
-        },
-      },
-    })
+    const wrapper = mountUsageView()
 
     await flushPromises()
     await nextTick()
@@ -235,20 +249,7 @@ describe('user UsageView tooltip', () => {
     window.URL.revokeObjectURL = vi.fn(() => {}) as typeof window.URL.revokeObjectURL
     const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
 
-    const wrapper = mount(UsageView, {
-      global: {
-        stubs: {
-          AppLayout: AppLayoutStub,
-          TablePageLayout: TablePageLayoutStub,
-          Pagination: true,
-          EmptyState: true,
-          Select: true,
-          DateRangePicker: true,
-          Icon: true,
-          Teleport: true,
-        },
-      },
-    })
+    const wrapper = mountUsageView()
 
     await flushPromises()
 
@@ -273,5 +274,113 @@ describe('user UsageView tooltip', () => {
     window.URL.createObjectURL = originalCreateObjectURL
     window.URL.revokeObjectURL = originalRevokeObjectURL
     clickSpy.mockRestore()
+  })
+
+  it('loads default API key options on select open instead of preloading 100 keys', async () => {
+    vi.useFakeTimers()
+    query.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0,
+    })
+    getStatsByDateRange.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      avg_duration_ms: 0,
+    })
+    list.mockResolvedValue({ items: [{ id: 11, name: 'Newest Key' }], total: 1, pages: 1 })
+
+    const wrapper = mountUsageView(true)
+
+    await flushPromises()
+    expect(list).not.toHaveBeenCalled()
+
+    await wrapper.get('button[aria-haspopup="true"]').trigger('click')
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    expect(list).toHaveBeenCalledWith(
+      1,
+      20,
+      { sort_by: 'created_at', sort_order: 'desc' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+  })
+
+  it('searches API keys by keyword and keeps selected label after options change', async () => {
+    vi.useFakeTimers()
+    query.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0,
+    })
+    getStatsByDateRange.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      avg_duration_ms: 0,
+    })
+    list
+      .mockResolvedValueOnce({ items: [{ id: 11, name: 'Newest Key' }], total: 1, pages: 1 })
+      .mockResolvedValueOnce({ items: [{ id: 42, name: 'Alice Key' }], total: 1, pages: 1 })
+
+    const wrapper = mountUsageView(true)
+    await flushPromises()
+
+    await wrapper.get('button[aria-haspopup="true"]').trigger('click')
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    const searchInput = wrapper.find('.select-search-input')
+    expect(searchInput.exists()).toBe(true)
+
+    await searchInput.setValue('alice')
+    vi.advanceTimersByTime(300)
+    await flushPromises()
+
+    expect(list).toHaveBeenLastCalledWith(
+      1,
+      20,
+      { search: 'alice', sort_by: 'name', sort_order: 'asc' },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    setupState.filters.api_key_id = 42
+    setupState.onApiKeyChange(42, { value: 42, label: 'Alice Key' })
+    setupState.apiKeyOptionsState = [{ value: 7, label: 'Beta Key' }]
+    await nextTick()
+
+    expect(wrapper.get('button[aria-haspopup="true"]').text()).toContain('Alice Key')
+  })
+
+  it('resets API key filter back to all API keys', async () => {
+    query.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0,
+    })
+    getStatsByDateRange.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      avg_duration_ms: 0,
+    })
+    list.mockResolvedValue({ items: [], total: 0, pages: 0 })
+
+    const wrapper = mountUsageView(true)
+    await flushPromises()
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    setupState.filters.api_key_id = 42
+    setupState.onApiKeyChange(42, { value: 42, label: 'Alice Key' })
+    await nextTick()
+    expect(wrapper.get('button[aria-haspopup="true"]').text()).toContain('Alice Key')
+
+    setupState.resetFilters()
+    await nextTick()
+
+    expect(wrapper.get('button[aria-haspopup="true"]').text()).toContain('All API Keys')
   })
 })


### PR DESCRIPTION
## Summary
- keep the existing `/usage` API key filter UI as a `Select`, but make it searchable
- stop preloading only the first 100 API keys and load matching candidates on demand through the existing `/keys` API
- add regression coverage for the new `Select` search event and the user usage page filter flow

## Problem
The user usage page could only filter API keys from a preloaded list, which made the control effectively unsearchable and also meant keys beyond the first 100 entries were hard to reach.

## Solution
- add an optional `search` event to the shared `Select` component
- update the user usage page to debounce remote key lookup and keep the selected key label stable across result refreshes
- preserve existing usage query, stats, pagination, sorting, and CSV export behavior

## Testing
- `docker run --rm -v "$PWD/frontend:/app" -w /app node:24-alpine sh -lc 'corepack enable && corepack prepare pnpm@10.33.0 --activate && pnpm install --frozen-lockfile && pnpm exec vitest run src/components/common/__tests__/Select.spec.ts src/views/user/__tests__/UsageView.spec.ts && pnpm run typecheck'`
- `cd deploy && POSTGRES_PASSWORD=testpass JWT_SECRET=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef TOTP_ENCRYPTION_KEY=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789 ADMIN_PASSWORD=admin123 docker compose -f docker-compose.dev.yml build sub2api`
- manual browser verification completed locally by the reporter

## Demo

screen recording


https://github.com/user-attachments/assets/a6cbe22f-ee27-424f-b3d2-ec98264f64c4


