### PR TITLE
fix: use gpt-5.4 for openai oauth probes

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -416,7 +416,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	// Default to openai.DefaultTestModel for OpenAI testing
 	testModelID := modelID
 	if testModelID == "" {
-		testModelID = openai.DefaultTestModel
+		testModelID = defaultOpenAITestModelForAccount(account)
 	}
 
 	// For API Key accounts with model mapping, map the model

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -144,4 +145,33 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimit(t *testing.T) 
 	if account.RateLimitResetAt != nil && repo.rateLimitedAt != nil {
 		require.WithinDuration(t, *repo.rateLimitedAt, *account.RateLimitResetAt, time.Second)
 	}
+}
+
+func TestAccountTestService_OpenAIOAuthEmptyModelUsesSafeDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusOK, "")
+	resp.Body = io.NopCloser(strings.NewReader("data: {\"type\":\"response.completed\"}\n\n"))
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream}
+	account := &Account{
+		ID:          91,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "test-token", "chatgpt_account_id": "acct_123"},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "")
+	require.NoError(t, err)
+	require.Len(t, upstream.requests, 1)
+
+	var payload map[string]any
+	body, readErr := io.ReadAll(upstream.requests[0].Body)
+	require.NoError(t, readErr)
+	require.NoError(t, json.Unmarshal(body, &payload))
+	require.Equal(t, openAIOAuthDefaultTestModel, payload["model"])
 }

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	httppool "github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
-	openaipkg "github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
@@ -602,7 +601,7 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	if accessToken == "" {
 		return nil, nil, fmt.Errorf("no access token available")
 	}
-	modelID := openaipkg.DefaultTestModel
+	modelID := defaultOpenAITestModelForAccount(account)
 	payload := createOpenAITestPayload(modelID, true)
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/backend/internal/service/openai_test_model.go
+++ b/backend/internal/service/openai_test_model.go
@@ -1,0 +1,15 @@
+package service
+
+import openaipkg "github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+
+const openAIOAuthDefaultTestModel = "gpt-5.4"
+
+// defaultOpenAITestModelForAccount chooses a safe probe model for the account.
+// ChatGPT OAuth accounts on chatgpt.com/backend-api/codex/responses reject
+// gpt-5.1-codex and gpt-5.1, but accept gpt-5.4 in the live runtime.
+func defaultOpenAITestModelForAccount(account *Account) string {
+	if account != nil && account.IsOpenAIOAuth() {
+		return openAIOAuthDefaultTestModel
+	}
+	return openaipkg.DefaultTestModel
+}

--- a/backend/internal/service/openai_test_model_test.go
+++ b/backend/internal/service/openai_test_model_test.go
@@ -1,0 +1,58 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	openaipkg "github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+)
+
+func TestDefaultOpenAITestModelForAccount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		account *Account
+		want    string
+	}{
+		{
+			name: "nil account falls back to package default",
+			want: openaipkg.DefaultTestModel,
+		},
+		{
+			name: "openai oauth uses safe default",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeOAuth,
+			},
+			want: openAIOAuthDefaultTestModel,
+		},
+		{
+			name: "openai apikey keeps package default",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+			},
+			want: openaipkg.DefaultTestModel,
+		},
+		{
+			name: "non openai oauth keeps package default",
+			account: &Account{
+				Platform: PlatformAnthropic,
+				Type:     AccountTypeOAuth,
+			},
+			want: openaipkg.DefaultTestModel,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := defaultOpenAITestModelForAccount(tt.account); got != tt.want {
+				t.Fatalf("defaultOpenAITestModelForAccount() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared helper to choose a probe-safe OpenAI test model by account type
- use `gpt-5.4` for ChatGPT OAuth probe/test flows while keeping the package default for other account types
- add unit coverage for the helper and for empty-model OpenAI OAuth account tests

## Test Plan
- `cd backend && go test ./internal/service -run 'Test(DefaultOpenAITestModelForAccount|AccountTestService_OpenAIOAuthEmptyModelUsesSafeDefault|AccountTestService_OpenAISuccessPersistsSnapshotFromHeaders|AccountTestService_OpenAI429PersistsSnapshotAndRateLimit)' -tags unit`
