### PR TITLE
fix(前端): 修复侧边栏收起状态刷新后失效

### DIFF
--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -16,7 +16,8 @@ import { getPublicSettings as fetchPublicSettingsAPI } from '@/api/auth'
 export const useAppStore = defineStore('app', () => {
   // ==================== State ====================
 
-  const sidebarCollapsed = ref<boolean>(false)
+  const SIDEBAR_COLLAPSED_KEY = 'sidebar_collapsed'
+  const sidebarCollapsed = ref<boolean>(localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true')
   const mobileOpen = ref<boolean>(false)
   const loading = ref<boolean>(false)
   const toasts = ref<Toast[]>([])
@@ -58,6 +59,7 @@ export const useAppStore = defineStore('app', () => {
    */
   function toggleSidebar(): void {
     sidebarCollapsed.value = !sidebarCollapsed.value
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(sidebarCollapsed.value))
   }
 
   /**
@@ -66,6 +68,7 @@ export const useAppStore = defineStore('app', () => {
    */
   function setSidebarCollapsed(collapsed: boolean): void {
     sidebarCollapsed.value = collapsed
+    localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(collapsed))
   }
 
   /**
@@ -226,6 +229,7 @@ export const useAppStore = defineStore('app', () => {
     loading.value = false
     loadingCount.value = 0
     toasts.value = []
+    localStorage.removeItem(SIDEBAR_COLLAPSED_KEY)
   }
 
   // ==================== Version Management ====================


### PR DESCRIPTION
## 问题描述

侧边栏收起后刷新页面，状态会重置为展开，用户体验不佳。

## 根本原因

`stores/app.ts` 中 `sidebarCollapsed` 仅保存在内存（Pinia store），页面刷新后状态丢失。

## 修复方案

将侧边栏折叠状态持久化到 `localStorage`：

- 初始化时从 `localStorage` 读取上次状态
- `toggleSidebar()` / `setSidebarCollapsed()` 变更时同步写入 `localStorage`
- `reset()` 时同步清除 `localStorage`，保证状态一致

## 测试

- [x] 收起侧边栏 → 刷新页面 → 侧边栏保持收起状态
- [x] 展开侧边栏 → 刷新页面 → 侧边栏保持展开状态
- [x] 现有单元测试通过（`beforeEach` 已清理 localStorage，不受影响）
