### PR TITLE
fix(前端): 修复英文界面引导弹窗底部按钮被遮挡

### DIFF
--- a/frontend/src/styles/onboarding.css
+++ b/frontend/src/styles/onboarding.css
@@ -104,6 +104,8 @@
   display: flex !important;
   align-items: center !important;
   justify-content: space-between !important; /* Push Left and Right apart */
+  flex-wrap: wrap !important; /* Wrap to next line when content overflows (e.g. English) */
+  gap: 8px 0 !important;
   padding: 16px 24px !important;
   background-color: #f9fafb !important;
   border-top: 1px solid #f3f4f6 !important;
@@ -126,6 +128,7 @@
   display: flex !important;
   align-items: center !important;
   gap: 8px !important;
+  margin-left: auto !important; /* Stay right-aligned when wrapped to next line */
 }
 
 /* Progress */


### PR DESCRIPTION
## 问题描述

英文界面下，新手引导弹窗（onboarding tour）底部的「Start Setup」按钮被弹窗边框裁切，无法完整显示。

## 根本原因

弹窗宽度上限为 `min(440px, 90vw)`，且设有 `overflow: hidden`。英文文本（「Flip Page」「Exit」「Start Setup」）比中文（「翻页」「退出」「开始配置」）更长，footer 内容总宽度约 467px，超出容器上限，右侧按钮被裁切。

## 修复方案

在 `onboarding.css` 的 footer 中添加 `flex-wrap: wrap`，并对按钮区域（`.footer-right`）设置 `margin-left: auto`：

- 空间充足时（中文）：左右内容保持单行，布局不变
- 空间不足时（英文）：按钮区域自动换到下一行，并靠右对齐，按钮完整显示

## 影响范围

仅修改 `frontend/src/styles/onboarding.css`，不影响中文或其他语言的显示效果。

<img width="300" height="320" alt="image" src="https://github.com/user-attachments/assets/59558dd3-e6ca-4f1c-93c3-16df6d1fa043" />
<img width="300" height="320" alt="image" src="https://github.com/user-attachments/assets/b476f8e6-c8de-4527-9d1c-db804f5fd229" />
