### PR TITLE
fix: change SSE keepalive from event to comment format

### DIFF
--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -131,8 +131,9 @@ const (
 type SSEPingFormat string
 
 const (
-	// SSEPingFormatClaude is the Claude/Anthropic SSE ping format
-	SSEPingFormatClaude SSEPingFormat = "data: {\"type\": \"ping\"}\n\n"
+	// SSEPingFormatClaude uses SSE comment format: keeps HTTP connection alive without
+	// being yielded by Anthropic SDK, so client idle watchdogs work correctly.
+	SSEPingFormatClaude SSEPingFormat = ": keepalive\n\n"
 	// SSEPingFormatNone indicates no ping should be sent (e.g., OpenAI has no ping spec)
 	SSEPingFormatNone SSEPingFormat = ""
 	// SSEPingFormatComment is an SSE comment ping for OpenAI/Codex CLI clients

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -4053,9 +4053,8 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}
-			// SSE ping 事件：Anthropic 原生格式，客户端会正确处理，
-			// 同时保持连接活跃防止 Cloudflare Tunnel 等代理断开
-			if !cw.Fprintf("event: ping\ndata: {\"type\": \"ping\"}\n\n") {
+			// SSE 注释格式 keepalive：在 HTTP 层保持连接活跃，不干扰客户端 idle watchdog。
+			if !cw.Fprintf(": keepalive\n\n") {
 				logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected during keepalive ping (antigravity claude), continuing to drain upstream for billing")
 				continue
 			}
@@ -4457,9 +4456,8 @@ func (s *AntigravityGatewayService) streamUpstreamResponse(c *gin.Context, resp 
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}
-			// SSE ping 事件：Anthropic 原生格式，客户端会正确处理，
-			// 同时保持连接活跃防止 Cloudflare Tunnel 等代理断开
-			if !cw.Fprintf("event: ping\ndata: {\"type\": \"ping\"}\n\n") {
+			// SSE 注释格式 keepalive：在 HTTP 层保持连接活跃，不干扰客户端 idle watchdog。
+			if !cw.Fprintf(": keepalive\n\n") {
 				logger.LegacyPrintf("service.antigravity_gateway", "Client disconnected during keepalive ping (antigravity upstream), continuing to drain upstream for billing")
 				continue
 			}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6939,9 +6939,9 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}
-			// SSE ping 事件：Anthropic 原生格式，客户端会正确处理，
-			// 同时保持连接活跃防止 Cloudflare Tunnel 等代理断开
-			if _, werr := fmt.Fprint(w, "event: ping\ndata: {\"type\": \"ping\"}\n\n"); werr != nil {
+			// SSE 注释格式 keepalive：在 HTTP 层保持连接活跃（防止 Cloudflare Tunnel 等代理因空闲断开），
+			// 但不会被 Anthropic SDK yield 给消费者，不干扰客户端（如 Claude Code）的 idle watchdog。
+			if _, werr := fmt.Fprint(w, ": keepalive\n\n"); werr != nil {
 				clientDisconnected = true
 				logger.LegacyPrintf("service.gateway", "Client disconnected during keepalive ping, continuing to drain upstream for billing")
 				continue

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -552,8 +552,8 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}
-			// Send Anthropic-format ping event
-			if _, err := fmt.Fprint(c.Writer, "event: ping\ndata: {\"type\":\"ping\"}\n\n"); err != nil {
+			// SSE 注释格式 keepalive：在 HTTP 层保持连接活跃，不干扰客户端 idle watchdog。
+			if _, err := fmt.Fprint(c.Writer, ": keepalive\n\n"); err != nil {
 				// Client disconnected
 				logger.L().Info("openai messages stream: client disconnected during keepalive",
 					zap.String("request_id", requestID),


### PR DESCRIPTION
## Summary

- Change SSE keepalive ping from `event: ping\ndata: {"type": "ping"}\n\n` (SSE event) to `: keepalive\n\n` (SSE comment) across all streaming handlers
- SSE comments keep the HTTP connection alive (preventing proxy idle timeouts) but are **not** yielded by the Anthropic SDK to consumers, so client-side idle watchdogs (e.g. Claude Code's 90s timeout) continue counting down correctly
- This fixes a bug where Claude Code hangs indefinitely during extended thinking: the upstream connection dies silently, sub2api's keepalive pings reset the client watchdog, and the client never retries

## Problem

When using Claude Code through sub2api with extended thinking enabled, the client occasionally hangs (time keeps ticking but no tokens arrive). Root cause:

1. Upstream connection (sub2api → Anthropic) dies during long thinking pauses
2. sub2api's `bufio.Scanner.Scan()` blocks forever (Go's `http.Transport` has no read timeout on response body)
3. sub2api sends keepalive pings as SSE events → Anthropic SDK yields them → Claude Code's idle watchdog resets
4. Result: client never detects the stall, hangs indefinitely

## Fix

Replace SSE event pings with SSE comments in all 4 streaming paths:
- `gateway_service.go` — main Claude streaming handler
- `antigravity_gateway_service.go` — two Antigravity streaming handlers  
- `openai_gateway_messages.go` — OpenAI-compat Anthropic streaming handler
- `gateway_helper.go` — `SSEPingFormatClaude` constant

SSE comments (`:<space>text\n\n`) are valid SSE frames that keep HTTP connections alive but are silently discarded by spec-compliant SSE parsers, including the Anthropic SDK.

## Test plan

- [ ] Verify streaming responses work normally (no regression in keepalive behavior)
- [ ] Test extended thinking scenario through a proxy with idle timeout < keepalive interval
- [ ] Confirm Claude Code's watchdog triggers correctly when upstream connection dies

🤖 Generated with [Claude Code](https://claude.com/claude-code)