### PR TITLE
修复滚动最近 24 小时用量范围

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -46,6 +46,41 @@ func TestParseTimeRangeLast24Hours(t *testing.T) {
 	require.Equal(t, 24*time.Hour, end.Sub(start))
 }
 
+func TestTimeRangeResponseMetadataLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=24h&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseTimeRange(c)
+	after := time.Now().UTC()
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "last24hours", metadata.Period)
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, start.Format(time.RFC3339), metadata.StartTime)
+	require.Equal(t, end.Format(time.RFC3339), metadata.EndTime)
+	require.Equal(t, end.Format("2006-01-02"), metadata.EndDate)
+}
+
+func TestTimeRangeResponseMetadataDateRange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
+
+	start, end := parseTimeRange(c)
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "2024-01-01", metadata.StartDate)
+	require.Equal(t, "2024-01-02", metadata.EndDate)
+	require.Empty(t, metadata.Period)
+	require.Equal(t, "2024-01-01T00:00:00Z", metadata.StartTime)
+	require.Equal(t, "2024-01-03T00:00:00Z", metadata.EndTime)
+}
+
 func TestParseOpsViewParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -31,6 +31,21 @@ func TestParseTimeRange(t *testing.T) {
 	require.False(t, end.IsZero())
 }
 
+func TestParseTimeRangeLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=last24hours&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseTimeRange(c)
+	after := time.Now().UTC()
+
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, 24*time.Hour, end.Sub(start))
+}
+
 func TestParseOpsViewParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -47,6 +47,41 @@ func TestParseTimeRangeLast24Hours(t *testing.T) {
 	require.Equal(t, 24*time.Hour, end.Sub(start))
 }
 
+func TestTimeRangeResponseMetadataLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=24h&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseTimeRange(c)
+	after := time.Now().UTC()
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "last24hours", metadata.Period)
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, start.Format(time.RFC3339), metadata.StartTime)
+	require.Equal(t, end.Format(time.RFC3339), metadata.EndTime)
+	require.Equal(t, end.Format("2006-01-02"), metadata.EndDate)
+}
+
+func TestTimeRangeResponseMetadataDateRange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
+
+	start, end := parseTimeRange(c)
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "2024-01-01", metadata.StartDate)
+	require.Equal(t, "2024-01-02", metadata.EndDate)
+	require.Empty(t, metadata.Period)
+	require.Equal(t, "2024-01-01T00:00:00Z", metadata.StartTime)
+	require.Equal(t, "2024-01-03T00:00:00Z", metadata.EndTime)
+}
+
 func TestParseOpsViewParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -32,6 +32,21 @@ func TestParseTimeRange(t *testing.T) {
 	require.False(t, end.IsZero())
 }
 
+func TestParseTimeRangeLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=last24hours&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseTimeRange(c)
+	after := time.Now().UTC()
+
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, 24*time.Hour, end.Sub(start))
+}
+
 func TestParseOpsViewParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -262,12 +262,10 @@ func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // GetModelStats handles getting model usage statistics
@@ -343,11 +341,9 @@ func (h *DashboardHandler) GetModelStats(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
-		"models":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"models": stats,
+	}, c, startTime, endTime))
 }
 
 // GetGroupStats handles getting group usage statistics
@@ -414,11 +410,9 @@ func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
-		"groups":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"groups": stats,
+	}, c, startTime, endTime))
 }
 
 // GetAPIKeyUsageTrend handles getting API key usage trend data
@@ -440,12 +434,10 @@ func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // GetUserUsageTrend handles getting user usage trend data
@@ -467,12 +459,10 @@ func (h *DashboardHandler) GetUserUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // BatchUsersUsageRequest represents the request body for batch user usage stats
@@ -523,14 +513,12 @@ func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
 		return
 	}
 
-	payload := gin.H{
+	payload := addTimeRangeResponseMetadata(gin.H{
 		"ranking":           ranking.Ranking,
 		"total_actual_cost": ranking.TotalActualCost,
 		"total_requests":    ranking.TotalRequests,
 		"total_tokens":      ranking.TotalTokens,
-		"start_date":        startTime.Format("2006-01-02"),
-		"end_date":          endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	}
+	}, c, startTime, endTime)
 	dashboardUsersRankingCache.Set(cacheKey, payload)
 	c.Header("X-Snapshot-Cache", "miss")
 	response.Success(c, payload)
@@ -690,9 +678,7 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
-		"users":      stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"users": stats,
+	}, c, startTime, endTime))
 }

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -38,8 +38,13 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")
 	endDate := c.Query("end_date")
+	period := c.Query("period")
 
 	var startTime, endTime time.Time
+
+	if startDate == "" && endDate == "" && timezone.IsLast24HoursPeriod(period) {
+		return timezone.Last24HoursInUserLocation(userTZ)
+	}
 
 	if startDate != "" {
 		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
@@ -53,7 +58,7 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 
 	if endDate != "" {
 		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
-			endTime = t.Add(24 * time.Hour) // Include the end date
+			endTime = t.AddDate(0, 0, 1) // Include the end date
 		} else {
 			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 		}

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -262,12 +262,10 @@ func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // GetModelStats handles getting model usage statistics
@@ -343,11 +341,9 @@ func (h *DashboardHandler) GetModelStats(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
-		"models":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"models": stats,
+	}, c, startTime, endTime))
 }
 
 // GetGroupStats handles getting group usage statistics
@@ -414,11 +410,9 @@ func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
-		"groups":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"groups": stats,
+	}, c, startTime, endTime))
 }
 
 // GetAPIKeyUsageTrend handles getting API key usage trend data
@@ -440,12 +434,10 @@ func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // GetUserUsageTrend handles getting user usage trend data
@@ -467,12 +459,10 @@ func (h *DashboardHandler) GetUserUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // BatchUsersUsageRequest represents the request body for batch user usage stats
@@ -523,14 +513,12 @@ func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
 		return
 	}
 
-	payload := gin.H{
+	payload := addTimeRangeResponseMetadata(gin.H{
 		"ranking":           ranking.Ranking,
 		"total_actual_cost": ranking.TotalActualCost,
 		"total_requests":    ranking.TotalRequests,
 		"total_tokens":      ranking.TotalTokens,
-		"start_date":        startTime.Format("2006-01-02"),
-		"end_date":          endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	}
+	}, c, startTime, endTime)
 	dashboardUsersRankingCache.Set(cacheKey, payload)
 	c.Header("X-Snapshot-Cache", "miss")
 	response.Success(c, payload)
@@ -701,9 +689,7 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
-		"users":      stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"users": stats,
+	}, c, startTime, endTime))
 }

--- a/backend/internal/handler/admin/dashboard_handler_request_type_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_request_type_test.go
@@ -89,6 +89,8 @@ func TestDashboardTrendRequestTypePriority(t *testing.T) {
 	require.NotNil(t, repo.trendRequestType)
 	require.Equal(t, int16(service.RequestTypeWSV2), *repo.trendRequestType)
 	require.Nil(t, repo.trendStream)
+	require.Contains(t, rec.Body.String(), "\"start_time\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\"")
 }
 
 func TestDashboardTrendInvalidRequestType(t *testing.T) {
@@ -190,6 +192,8 @@ func TestDashboardUsersRankingLimitAndCache(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "\"total_actual_cost\":88.8")
 	require.Contains(t, rec.Body.String(), "\"total_requests\":44")
 	require.Contains(t, rec.Body.String(), "\"total_tokens\":1234")
+	require.Contains(t, rec.Body.String(), "\"start_time\":\"2025-01-01T00:00:00")
+	require.Contains(t, rec.Body.String(), "\"end_time\":\"2025-01-03T00:00:00")
 	require.Equal(t, "miss", rec.Header().Get("X-Snapshot-Cache"))
 
 	req2 := httptest.NewRequest(http.MethodGet, "/admin/dashboard/users-ranking?limit=100&start_date=2025-01-01&end_date=2025-01-02", nil)

--- a/backend/internal/handler/admin/dashboard_snapshot_v2_handler.go
+++ b/backend/internal/handler/admin/dashboard_snapshot_v2_handler.go
@@ -25,8 +25,7 @@ type dashboardSnapshotV2Stats struct {
 type dashboardSnapshotV2Response struct {
 	GeneratedAt string `json:"generated_at"`
 
-	StartDate   string `json:"start_date"`
-	EndDate     string `json:"end_date"`
+	timeRangeResponseMetadata
 	Granularity string `json:"granularity"`
 
 	Stats      *dashboardSnapshotV2Stats        `json:"stats,omitempty"`
@@ -115,6 +114,7 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 
 	cached, hit, err := dashboardSnapshotV2Cache.GetOrLoad(cacheKey, func() (any, error) {
 		return h.buildSnapshotV2Response(
+			c,
 			c.Request.Context(),
 			startTime,
 			endTime,
@@ -145,6 +145,7 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 }
 
 func (h *DashboardHandler) buildSnapshotV2Response(
+	c *gin.Context,
 	ctx context.Context,
 	startTime, endTime time.Time,
 	granularity string,
@@ -153,10 +154,9 @@ func (h *DashboardHandler) buildSnapshotV2Response(
 	usersTrendLimit int,
 ) (*dashboardSnapshotV2Response, error) {
 	resp := &dashboardSnapshotV2Response{
-		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-		StartDate:   startTime.Format("2006-01-02"),
-		EndDate:     endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-		Granularity: granularity,
+		GeneratedAt:               time.Now().UTC().Format(time.RFC3339),
+		timeRangeResponseMetadata: newTimeRangeResponseMetadata(c, startTime, endTime),
+		Granularity:               granularity,
 	}
 
 	if includeStats {

--- a/backend/internal/handler/admin/time_range_response.go
+++ b/backend/internal/handler/admin/time_range_response.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/gin-gonic/gin"
+)
+
+type timeRangeResponseMetadata struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	StartTime string `json:"start_time,omitempty"`
+	EndTime   string `json:"end_time,omitempty"`
+	Period    string `json:"period,omitempty"`
+}
+
+func newTimeRangeResponseMetadata(c *gin.Context, startTime, endTime time.Time) timeRangeResponseMetadata {
+	metadata := timeRangeResponseMetadata{
+		StartDate: startTime.Format("2006-01-02"),
+		EndDate:   formatResponseEndDate(c, endTime),
+		StartTime: startTime.Format(time.RFC3339),
+		EndTime:   endTime.Format(time.RFC3339),
+	}
+
+	if period := normalizeResponsePeriod(c); period != "" {
+		metadata.Period = period
+	}
+
+	return metadata
+}
+
+func addTimeRangeResponseMetadata(payload gin.H, c *gin.Context, startTime, endTime time.Time) gin.H {
+	metadata := newTimeRangeResponseMetadata(c, startTime, endTime)
+	payload["start_date"] = metadata.StartDate
+	payload["end_date"] = metadata.EndDate
+	payload["start_time"] = metadata.StartTime
+	payload["end_time"] = metadata.EndTime
+	if metadata.Period != "" {
+		payload["period"] = metadata.Period
+	}
+	return payload
+}
+
+func formatResponseEndDate(c *gin.Context, endTime time.Time) string {
+	if c != nil && c.Query("start_date") == "" && c.Query("end_date") == "" && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		return endTime.Format("2006-01-02")
+	}
+	return endTime.Add(-time.Nanosecond).Format("2006-01-02")
+}
+
+func normalizeResponsePeriod(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	period := strings.ToLower(strings.TrimSpace(c.Query("period")))
+	if period == "" {
+		return ""
+	}
+	if timezone.IsLast24HoursPeriod(period) {
+		return "last24hours"
+	}
+	return period
+}

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -165,6 +165,12 @@ func (h *UsageHandler) List(c *gin.Context) {
 		endTime = &t
 	}
 
+	if startTime == nil && endTime == nil && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		start, end := timezone.Last24HoursInUserLocation(userTZ)
+		startTime = &start
+		endTime = &end
+	}
+
 	params := pagination.PaginationParams{
 		Page:      page,
 		PageSize:  pageSize,
@@ -297,17 +303,22 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 		endTime = endTime.AddDate(0, 0, 1)
 	} else {
 		period := c.DefaultQuery("period", "today")
-		switch period {
-		case "today":
+		switch {
+		case timezone.IsLast24HoursPeriod(period):
+			startTime, endTime = timezone.Last24HoursInUserLocation(userTZ)
+		case period == "today":
 			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
-		case "week":
+			endTime = now
+		case period == "week":
 			startTime = now.AddDate(0, 0, -7)
-		case "month":
+			endTime = now
+		case period == "month":
 			startTime = now.AddDate(0, -1, 0)
+			endTime = now
 		default:
 			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			endTime = now
 		}
-		endTime = now
 	}
 
 	// Build filters and call GetStatsWithFilters

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -164,9 +164,10 @@ func (h *UsageHandler) List(c *gin.Context) {
 		t = t.AddDate(0, 0, 1)
 		endTime = &t
 	}
-
 	if startTime == nil && endTime == nil && timezone.IsLast24HoursPeriod(c.Query("period")) {
-		start, end := timezone.Last24HoursInUserLocation(userTZ)
+		now := timezone.NowInUserLocation(userTZ)
+		start := now.Add(-24 * time.Hour)
+		end := now
 		startTime = &start
 		endTime = &end
 	}
@@ -305,20 +306,20 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 		period := c.DefaultQuery("period", "today")
 		switch {
 		case timezone.IsLast24HoursPeriod(period):
-			startTime, endTime = timezone.Last24HoursInUserLocation(userTZ)
-		case period == "today":
-			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
-			endTime = now
-		case period == "week":
-			startTime = now.AddDate(0, 0, -7)
-			endTime = now
-		case period == "month":
-			startTime = now.AddDate(0, -1, 0)
-			endTime = now
+			startTime = now.Add(-24 * time.Hour)
 		default:
-			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
-			endTime = now
+			switch period {
+			case "today":
+				startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			case "week":
+				startTime = now.AddDate(0, 0, -7)
+			case "month":
+				startTime = now.AddDate(0, -1, 0)
+			default:
+				startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			}
 		}
+		endTime = now
 	}
 
 	// Build filters and call GetStatsWithFilters

--- a/backend/internal/handler/admin/usage_handler_request_type_test.go
+++ b/backend/internal/handler/admin/usage_handler_request_type_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
@@ -105,6 +106,24 @@ func TestAdminUsageListInvalidExactTotal(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestAdminUsageListLast24HoursPeriod(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.listFilters.StartTime)
+	require.NotNil(t, repo.listFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.listFilters.EndTime.Sub(*repo.listFilters.StartTime))
+}
+
 func TestAdminUsageStatsRequestTypePriority(t *testing.T) {
 	repo := &adminUsageRepoCapture{}
 	router := newAdminUsageRequestTypeTestRouter(repo)
@@ -139,4 +158,22 @@ func TestAdminUsageStatsInvalidStream(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAdminUsageStatsLast24HoursPeriod(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage/stats?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.statsFilters.StartTime)
+	require.NotNil(t, repo.statsFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.statsFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.statsFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.statsFilters.EndTime.Sub(*repo.statsFilters.StartTime))
 }

--- a/backend/internal/handler/admin/usage_handler_request_type_test.go
+++ b/backend/internal/handler/admin/usage_handler_request_type_test.go
@@ -106,24 +106,6 @@ func TestAdminUsageListInvalidExactTotal(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
-func TestAdminUsageListLast24HoursPeriod(t *testing.T) {
-	repo := &adminUsageRepoCapture{}
-	router := newAdminUsageRequestTypeTestRouter(repo)
-
-	before := time.Now().UTC()
-	req := httptest.NewRequest(http.MethodGet, "/admin/usage?period=last24hours&timezone=UTC", nil)
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
-	after := time.Now().UTC()
-
-	require.Equal(t, http.StatusOK, rec.Code)
-	require.NotNil(t, repo.listFilters.StartTime)
-	require.NotNil(t, repo.listFilters.EndTime)
-	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
-	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
-	require.Equal(t, 24*time.Hour, repo.listFilters.EndTime.Sub(*repo.listFilters.StartTime))
-}
-
 func TestAdminUsageStatsRequestTypePriority(t *testing.T) {
 	repo := &adminUsageRepoCapture{}
 	router := newAdminUsageRequestTypeTestRouter(repo)
@@ -160,12 +142,30 @@ func TestAdminUsageStatsInvalidStream(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestAdminUsageListLast24HoursPeriod(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.listFilters.StartTime)
+	require.NotNil(t, repo.listFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
+	require.WithinDuration(t, *repo.listFilters.StartTime, repo.listFilters.EndTime.Add(-24*time.Hour), 2*time.Second)
+}
+
 func TestAdminUsageStatsLast24HoursPeriod(t *testing.T) {
 	repo := &adminUsageRepoCapture{}
 	router := newAdminUsageRequestTypeTestRouter(repo)
 
 	before := time.Now().UTC()
-	req := httptest.NewRequest(http.MethodGet, "/admin/usage/stats?period=last24hours&timezone=UTC", nil)
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage/stats?period=24h&timezone=UTC", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	after := time.Now().UTC()
@@ -175,5 +175,5 @@ func TestAdminUsageStatsLast24HoursPeriod(t *testing.T) {
 	require.NotNil(t, repo.statsFilters.EndTime)
 	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.statsFilters.StartTime, 2*time.Second)
 	require.WithinDuration(t, after, *repo.statsFilters.EndTime, 2*time.Second)
-	require.Equal(t, 24*time.Hour, repo.statsFilters.EndTime.Sub(*repo.statsFilters.StartTime))
+	require.WithinDuration(t, *repo.statsFilters.StartTime, repo.statsFilters.EndTime.Add(-24*time.Hour), 2*time.Second)
 }

--- a/backend/internal/handler/time_range_response.go
+++ b/backend/internal/handler/time_range_response.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/gin-gonic/gin"
+)
+
+type timeRangeResponseMetadata struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	StartTime string `json:"start_time,omitempty"`
+	EndTime   string `json:"end_time,omitempty"`
+	Period    string `json:"period,omitempty"`
+}
+
+func newTimeRangeResponseMetadata(c *gin.Context, startTime, endTime time.Time) timeRangeResponseMetadata {
+	metadata := timeRangeResponseMetadata{
+		StartDate: startTime.Format("2006-01-02"),
+		EndDate:   formatResponseEndDate(c, endTime),
+		StartTime: startTime.Format(time.RFC3339),
+		EndTime:   endTime.Format(time.RFC3339),
+	}
+
+	if period := normalizeResponsePeriod(c); period != "" {
+		metadata.Period = period
+	}
+
+	return metadata
+}
+
+func addTimeRangeResponseMetadata(payload gin.H, c *gin.Context, startTime, endTime time.Time) gin.H {
+	metadata := newTimeRangeResponseMetadata(c, startTime, endTime)
+	payload["start_date"] = metadata.StartDate
+	payload["end_date"] = metadata.EndDate
+	payload["start_time"] = metadata.StartTime
+	payload["end_time"] = metadata.EndTime
+	if metadata.Period != "" {
+		payload["period"] = metadata.Period
+	}
+	return payload
+}
+
+func formatResponseEndDate(c *gin.Context, endTime time.Time) string {
+	if c != nil && c.Query("start_date") == "" && c.Query("end_date") == "" && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		return endTime.Format("2006-01-02")
+	}
+	return endTime.Add(-time.Nanosecond).Format("2006-01-02")
+}
+
+func normalizeResponsePeriod(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	period := strings.ToLower(strings.TrimSpace(c.Query("period")))
+	if period == "" {
+		return ""
+	}
+	if timezone.IsLast24HoursPeriod(period) {
+		return "last24hours"
+	}
+	return period
+}

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -350,12 +350,10 @@ func (h *UsageHandler) DashboardTrend(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // DashboardModels handles getting user model usage statistics
@@ -375,11 +373,9 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
-		"models":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"models": stats,
+	}, c, startTime, endTime))
 }
 
 // BatchAPIKeysUsageRequest represents the request for batch API keys usage

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -119,6 +119,12 @@ func (h *UsageHandler) List(c *gin.Context) {
 		endTime = &t
 	}
 
+	if startTime == nil && endTime == nil && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		start, end := timezone.Last24HoursInUserLocation(userTZ)
+		startTime = &start
+		endTime = &end
+	}
+
 	params := pagination.PaginationParams{
 		Page:      page,
 		PageSize:  pageSize,
@@ -237,17 +243,22 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 	} else {
 		// 使用 period 参数
 		period := c.DefaultQuery("period", "today")
-		switch period {
-		case "today":
+		switch {
+		case timezone.IsLast24HoursPeriod(period):
+			startTime, endTime = timezone.Last24HoursInUserLocation(userTZ)
+		case period == "today":
 			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
-		case "week":
+			endTime = now
+		case period == "week":
 			startTime = now.AddDate(0, 0, -7)
-		case "month":
+			endTime = now
+		case period == "month":
 			startTime = now.AddDate(0, -1, 0)
+			endTime = now
 		default:
 			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			endTime = now
 		}
-		endTime = now
 	}
 
 	var stats *service.UsageStats
@@ -272,8 +283,13 @@ func parseUserTimeRange(c *gin.Context) (time.Time, time.Time) {
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")
 	endDate := c.Query("end_date")
+	period := c.Query("period")
 
 	var startTime, endTime time.Time
+
+	if startDate == "" && endDate == "" && timezone.IsLast24HoursPeriod(period) {
+		return timezone.Last24HoursInUserLocation(userTZ)
+	}
 
 	if startDate != "" {
 		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
@@ -287,7 +303,7 @@ func parseUserTimeRange(c *gin.Context) (time.Time, time.Time) {
 
 	if endDate != "" {
 		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
-			endTime = t.Add(24 * time.Hour) // Include the end date
+			endTime = t.AddDate(0, 0, 1) // Include the end date
 		} else {
 			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 		}

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -521,12 +521,10 @@ func (h *UsageHandler) DashboardTrend(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  parsed.StartTime.Format("2006-01-02"),
-		"end_date":    parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, parsed.StartTime, parsed.EndTime))
 }
 
 // DashboardModels handles getting user model usage statistics
@@ -549,11 +547,9 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
-		"models":     userModelStatsFromUsageStats(stats),
-		"start_date": parsed.StartTime.Format("2006-01-02"),
-		"end_date":   parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"models": userModelStatsFromUsageStats(stats),
+	}, c, parsed.StartTime, parsed.EndTime))
 }
 
 // DashboardSnapshotV2 returns usage-page chart data scoped to the current user.

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -169,6 +169,12 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 		endPtr = &endTime
 	}
 
+	if startPtr == nil && endPtr == nil && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		startTime, endTime = timezone.Last24HoursInUserLocation(userTZ)
+		startPtr = &startTime
+		endPtr = &endTime
+	}
+
 	if requireRange {
 		if startPtr == nil {
 			switch c.DefaultQuery("period", "") {
@@ -432,6 +438,53 @@ func apiKeyDailyUsageRange(days int, userTZ string) (time.Time, time.Time) {
 	now := timezone.NowInUserLocation(userTZ)
 	startTime := timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -(days-1)), userTZ)
 	endTime := timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+	return startTime, endTime
+}
+
+func parseUserTimeRange(c *gin.Context) (time.Time, time.Time) {
+	userTZ := c.Query("timezone")
+	now := timezone.NowInUserLocation(userTZ)
+	startDate := strings.TrimSpace(c.Query("start_date"))
+	endDate := strings.TrimSpace(c.Query("end_date"))
+	period := strings.TrimSpace(c.Query("period"))
+
+	if startDate == "" && endDate == "" && timezone.IsLast24HoursPeriod(period) {
+		return timezone.Last24HoursInUserLocation(userTZ)
+	}
+
+	var startTime, endTime time.Time
+
+	if startDate != "" {
+		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
+			startTime = t
+		} else {
+			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
+		}
+	} else {
+		switch period {
+		case "today":
+			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+		case "week":
+			startTime = now.AddDate(0, 0, -7)
+		case "month":
+			startTime = now.AddDate(0, -1, 0)
+		default:
+			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
+		}
+	}
+
+	if endDate != "" {
+		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
+			endTime = t.AddDate(0, 0, 1)
+		} else {
+			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+		}
+	} else if period != "" {
+		endTime = now
+	} else {
+		endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+	}
+
 	return startTime, endTime
 }
 

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -17,11 +17,18 @@ import (
 
 type userUsageRepoCapture struct {
 	service.UsageLogRepository
-	listParams  pagination.PaginationParams
-	listFilters usagestats.UsageLogFilters
-	statsUserID int64
-	statsStart  time.Time
-	statsEnd    time.Time
+	listParams                pagination.PaginationParams
+	listFilters               usagestats.UsageLogFilters
+	statsUserID               int64
+	statsStart                time.Time
+	statsEnd                  time.Time
+	dashboardTrendUserID      int64
+	dashboardTrendStart       time.Time
+	dashboardTrendEnd         time.Time
+	dashboardTrendGranularity string
+	dashboardModelsUserID     int64
+	dashboardModelsStart      time.Time
+	dashboardModelsEnd        time.Time
 }
 
 func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters usagestats.UsageLogFilters) ([]service.UsageLog, *pagination.PaginationResult, error) {
@@ -42,6 +49,21 @@ func (s *userUsageRepoCapture) GetUserStatsAggregated(ctx context.Context, userI
 	return &usagestats.UsageStats{}, nil
 }
 
+func (s *userUsageRepoCapture) GetUserUsageTrendByUserID(ctx context.Context, userID int64, startTime, endTime time.Time, granularity string) ([]usagestats.TrendDataPoint, error) {
+	s.dashboardTrendUserID = userID
+	s.dashboardTrendStart = startTime
+	s.dashboardTrendEnd = endTime
+	s.dashboardTrendGranularity = granularity
+	return []usagestats.TrendDataPoint{}, nil
+}
+
+func (s *userUsageRepoCapture) GetUserModelStats(ctx context.Context, userID int64, startTime, endTime time.Time) ([]usagestats.ModelStat, error) {
+	s.dashboardModelsUserID = userID
+	s.dashboardModelsStart = startTime
+	s.dashboardModelsEnd = endTime
+	return []usagestats.ModelStat{}, nil
+}
+
 func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	usageSvc := service.NewUsageService(repo, nil, nil, nil)
@@ -53,6 +75,8 @@ func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	})
 	router.GET("/usage", handler.List)
 	router.GET("/usage/stats", handler.Stats)
+	router.GET("/usage/dashboard/trend", handler.DashboardTrend)
+	router.GET("/usage/dashboard/models", handler.DashboardModels)
 	return router
 }
 
@@ -126,4 +150,38 @@ func TestUserUsageStatsLast24HoursPeriod(t *testing.T) {
 	require.WithinDuration(t, before.Add(-24*time.Hour), repo.statsStart, 2*time.Second)
 	require.WithinDuration(t, after, repo.statsEnd, 2*time.Second)
 	require.Equal(t, 24*time.Hour, repo.statsEnd.Sub(repo.statsStart))
+}
+
+func TestUserDashboardTrendLast24HoursResponseMetadata(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/trend?period=24h&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(42), repo.dashboardTrendUserID)
+	require.Equal(t, "day", repo.dashboardTrendGranularity)
+	require.Contains(t, rec.Body.String(), "\"period\":\"last24hours\"")
+	require.Contains(t, rec.Body.String(), "\"start_time\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\"")
+}
+
+func TestUserDashboardModelsDateRangeResponseMetadata(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/models?start_date=2025-01-01&end_date=2025-01-02&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(42), repo.dashboardModelsUserID)
+	require.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), repo.dashboardModelsStart)
+	require.Equal(t, time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), repo.dashboardModelsEnd)
+	require.Contains(t, rec.Body.String(), "\"start_date\":\"2025-01-01\"")
+	require.Contains(t, rec.Body.String(), "\"end_date\":\"2025-01-02\"")
+	require.Contains(t, rec.Body.String(), "\"start_time\":\"2025-01-01T00:00:00Z\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\":\"2025-01-03T00:00:00Z\"")
 }

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
@@ -18,6 +19,9 @@ type userUsageRepoCapture struct {
 	service.UsageLogRepository
 	listParams  pagination.PaginationParams
 	listFilters usagestats.UsageLogFilters
+	statsUserID int64
+	statsStart  time.Time
+	statsEnd    time.Time
 }
 
 func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters usagestats.UsageLogFilters) ([]service.UsageLog, *pagination.PaginationResult, error) {
@@ -31,6 +35,13 @@ func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagin
 	}, nil
 }
 
+func (s *userUsageRepoCapture) GetUserStatsAggregated(ctx context.Context, userID int64, startTime, endTime time.Time) (*usagestats.UsageStats, error) {
+	s.statsUserID = userID
+	s.statsStart = startTime
+	s.statsEnd = endTime
+	return &usagestats.UsageStats{}, nil
+}
+
 func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	usageSvc := service.NewUsageService(repo, nil, nil, nil)
@@ -41,6 +52,7 @@ func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 		c.Next()
 	})
 	router.GET("/usage", handler.List)
+	router.GET("/usage/stats", handler.Stats)
 	return router
 }
 
@@ -79,4 +91,39 @@ func TestUserUsageListInvalidStream(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserUsageListLast24HoursPeriod(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/usage?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.listFilters.StartTime)
+	require.NotNil(t, repo.listFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.listFilters.EndTime.Sub(*repo.listFilters.StartTime))
+}
+
+func TestUserUsageStatsLast24HoursPeriod(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/usage/stats?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(42), repo.statsUserID)
+	require.WithinDuration(t, before.Add(-24*time.Hour), repo.statsStart, 2*time.Second)
+	require.WithinDuration(t, after, repo.statsEnd, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.statsEnd.Sub(repo.statsStart))
 }

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -89,6 +89,7 @@ func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	})
 	router.GET("/usage", handler.List)
 	router.GET("/usage/stats", handler.Stats)
+	router.GET("/usage/dashboard/trend", handler.DashboardTrend)
 	router.GET("/usage/dashboard/models", handler.DashboardModels)
 	router.GET("/usage/dashboard/snapshot-v2", handler.DashboardSnapshotV2)
 	return router
@@ -129,6 +130,24 @@ func TestUserUsageListInvalidStream(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserUsageListLast24HoursPeriod(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/usage?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.listFilters.StartTime)
+	require.NotNil(t, repo.listFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.listFilters.EndTime.Sub(*repo.listFilters.StartTime))
 }
 
 func TestUserUsageListAdvancedFilters(t *testing.T) {
@@ -262,6 +281,24 @@ func TestUserUsageStatsUsesScopedFilters(t *testing.T) {
 	require.NotContains(t, rec.Body.String(), "total_account_cost")
 	require.NotContains(t, rec.Body.String(), "upstream_endpoints")
 	require.NotContains(t, rec.Body.String(), "endpoint_paths")
+}
+
+func TestUserUsageStatsLast24HoursPeriod(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/usage/stats?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.statsFilters.StartTime)
+	require.NotNil(t, repo.statsFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.statsFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.statsFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.statsFilters.EndTime.Sub(*repo.statsFilters.StartTime))
 }
 
 func TestUserUsageDashboardModelsOmitsAccountCost(t *testing.T) {

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -17,15 +17,20 @@ import (
 
 type userUsageRepoCapture struct {
 	service.UsageLogRepository
-	listParams   pagination.PaginationParams
-	listFilters  usagestats.UsageLogFilters
-	statsFilters usagestats.UsageLogFilters
-	trendFilters usagestats.UsageLogFilters
-	groupFilters usagestats.UsageLogFilters
-	listRows     []service.UsageLog
-	stats        *usagestats.UsageStats
-	modelStats   []usagestats.ModelStat
-	groupStats   []usagestats.GroupStat
+	listParams       pagination.PaginationParams
+	listFilters      usagestats.UsageLogFilters
+	statsFilters     usagestats.UsageLogFilters
+	trendFilters     usagestats.UsageLogFilters
+	trendStart       time.Time
+	trendEnd         time.Time
+	trendGranularity string
+	modelStart       time.Time
+	modelEnd         time.Time
+	groupFilters     usagestats.UsageLogFilters
+	listRows         []service.UsageLog
+	stats            *usagestats.UsageStats
+	modelStats       []usagestats.ModelStat
+	groupStats       []usagestats.GroupStat
 }
 
 func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters usagestats.UsageLogFilters) ([]service.UsageLog, *pagination.PaginationResult, error) {
@@ -48,6 +53,9 @@ func (s *userUsageRepoCapture) GetStatsWithFilters(ctx context.Context, filters 
 }
 
 func (s *userUsageRepoCapture) GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, requestType *int16, stream *bool, billingType *int8) ([]usagestats.TrendDataPoint, error) {
+	s.trendStart = startTime
+	s.trendEnd = endTime
+	s.trendGranularity = granularity
 	s.trendFilters = usagestats.UsageLogFilters{
 		UserID:      userID,
 		APIKeyID:    apiKeyID,
@@ -62,6 +70,8 @@ func (s *userUsageRepoCapture) GetUsageTrendWithFilters(ctx context.Context, sta
 }
 
 func (s *userUsageRepoCapture) GetModelStatsWithFilters(ctx context.Context, startTime, endTime time.Time, userID, apiKeyID, accountID, groupID int64, requestType *int16, stream *bool, billingType *int8) ([]usagestats.ModelStat, error) {
+	s.modelStart = startTime
+	s.modelEnd = endTime
 	return s.modelStats, nil
 }
 
@@ -301,6 +311,22 @@ func TestUserUsageStatsLast24HoursPeriod(t *testing.T) {
 	require.Equal(t, 24*time.Hour, repo.statsFilters.EndTime.Sub(*repo.statsFilters.StartTime))
 }
 
+func TestUserDashboardTrendLast24HoursResponseMetadata(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/trend?period=24h&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(42), repo.trendFilters.UserID)
+	require.Equal(t, "day", repo.trendGranularity)
+	require.Contains(t, rec.Body.String(), "\"period\":\"last24hours\"")
+	require.Contains(t, rec.Body.String(), "\"start_time\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\"")
+}
+
 func TestUserUsageDashboardModelsOmitsAccountCost(t *testing.T) {
 	repo := &userUsageRepoCapture{
 		modelStats: []usagestats.ModelStat{{
@@ -323,6 +349,23 @@ func TestUserUsageDashboardModelsOmitsAccountCost(t *testing.T) {
 	require.Contains(t, body, `"cost":0.1`)
 	require.Contains(t, body, `"actual_cost":0.08`)
 	require.NotContains(t, body, "account_cost")
+}
+
+func TestUserDashboardModelsDateRangeResponseMetadata(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/models?start_date=2025-01-01&end_date=2025-01-02&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), repo.modelStart)
+	require.Equal(t, time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), repo.modelEnd)
+	require.Contains(t, rec.Body.String(), "\"start_date\":\"2025-01-01\"")
+	require.Contains(t, rec.Body.String(), "\"end_date\":\"2025-01-02\"")
+	require.Contains(t, rec.Body.String(), "\"start_time\":\"2025-01-01T00:00:00Z\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\":\"2025-01-03T00:00:00Z\"")
 }
 
 func TestUserUsageDashboardModelsRejectsAdminModelSources(t *testing.T) {

--- a/backend/internal/handler/usage_handler_time_range_test.go
+++ b/backend/internal/handler/usage_handler_time_range_test.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUserTimeRangeLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=last24hours&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseUserTimeRange(c)
+	after := time.Now().UTC()
+
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, 24*time.Hour, end.Sub(start))
+}

--- a/backend/internal/handler/usage_handler_time_range_test.go
+++ b/backend/internal/handler/usage_handler_time_range_test.go
@@ -24,3 +24,38 @@ func TestParseUserTimeRangeLast24Hours(t *testing.T) {
 	require.WithinDuration(t, after, end, 2*time.Second)
 	require.Equal(t, 24*time.Hour, end.Sub(start))
 }
+
+func TestUserTimeRangeResponseMetadataLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=24h&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseUserTimeRange(c)
+	after := time.Now().UTC()
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "last24hours", metadata.Period)
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, start.Format(time.RFC3339), metadata.StartTime)
+	require.Equal(t, end.Format(time.RFC3339), metadata.EndTime)
+	require.Equal(t, end.Format("2006-01-02"), metadata.EndDate)
+}
+
+func TestUserTimeRangeResponseMetadataDateRange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
+
+	start, end := parseUserTimeRange(c)
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "2024-01-01", metadata.StartDate)
+	require.Equal(t, "2024-01-02", metadata.EndDate)
+	require.Empty(t, metadata.Period)
+	require.Equal(t, "2024-01-01T00:00:00Z", metadata.StartTime)
+	require.Equal(t, "2024-01-03T00:00:00Z", metadata.EndTime)
+}

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -6,6 +6,7 @@ package timezone
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -158,4 +159,22 @@ func StartOfDayInUserLocation(t time.Time, userTZ string) time.Time {
 	}
 	t = t.In(loc)
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+}
+
+// IsLast24HoursPeriod reports whether the caller requested a rolling last-24-hours window.
+func IsLast24HoursPeriod(period string) bool {
+	switch strings.ToLower(strings.TrimSpace(period)) {
+	case "last24hours", "last24h", "24h":
+		return true
+	default:
+		return false
+	}
+}
+
+// Last24HoursInUserLocation returns a rolling [now-24h, now) window in the user's timezone.
+// The returned values represent the same instants regardless of timezone, but are expressed
+// in the resolved user/server location to keep downstream formatting consistent.
+func Last24HoursInUserLocation(userTZ string) (time.Time, time.Time) {
+	end := NowInUserLocation(userTZ)
+	return end.Add(-24 * time.Hour), end
 }

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -6,6 +6,7 @@ package timezone
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -163,4 +164,22 @@ func StartOfDayInUserLocation(t time.Time, userTZ string) time.Time {
 	}
 	t = t.In(loc)
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+}
+
+// IsLast24HoursPeriod reports whether the caller requested a rolling last-24-hours window.
+func IsLast24HoursPeriod(period string) bool {
+	switch strings.ToLower(strings.TrimSpace(period)) {
+	case "last24hours", "last24h", "24h":
+		return true
+	default:
+		return false
+	}
+}
+
+// Last24HoursInUserLocation returns a rolling [now-24h, now) window in the user's timezone.
+// The returned values represent the same instants regardless of timezone, but are expressed
+// in the resolved user/server location to keep downstream formatting consistent.
+func Last24HoursInUserLocation(userTZ string) (time.Time, time.Time) {
+	end := NowInUserLocation(userTZ)
+	return end.Add(-24 * time.Hour), end
 }

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -135,3 +135,45 @@ func TestDSTAwareness(t *testing.T) {
 	_ = Now()
 	_ = StartOfDay(Now())
 }
+
+func TestIsLast24HoursPeriod(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "last24hours", want: true},
+		{input: "LAST24H", want: true},
+		{input: "24h", want: true},
+		{input: "today", want: false},
+		{input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := IsLast24HoursPeriod(tt.input); got != tt.want {
+			t.Fatalf("IsLast24HoursPeriod(%q)=%v want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLast24HoursInUserLocation(t *testing.T) {
+	if err := Init("UTC"); err != nil {
+		t.Fatalf("Init failed with UTC: %v", err)
+	}
+
+	before := time.Now().UTC()
+	start, end := Last24HoursInUserLocation("UTC")
+	after := time.Now().UTC()
+
+	if !start.Before(end) {
+		t.Fatalf("expected start before end, got start=%v end=%v", start, end)
+	}
+	if diff := end.Sub(start); diff != 24*time.Hour {
+		t.Fatalf("expected exact 24h window, got %v", diff)
+	}
+	if start.Before(before.Add(-24*time.Hour-time.Second)) || start.After(after.Add(-24*time.Hour+time.Second)) {
+		t.Fatalf("unexpected start time: %v", start)
+	}
+	if end.Before(before.Add(-time.Second)) || end.After(after.Add(time.Second)) {
+		t.Fatalf("unexpected end time: %v", end)
+	}
+}

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -161,3 +161,45 @@ func TestStartOfWeek_Boundaries(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLast24HoursPeriod(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "last24hours", want: true},
+		{input: "LAST24H", want: true},
+		{input: "24h", want: true},
+		{input: "today", want: false},
+		{input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := IsLast24HoursPeriod(tt.input); got != tt.want {
+			t.Fatalf("IsLast24HoursPeriod(%q)=%v want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLast24HoursInUserLocation(t *testing.T) {
+	if err := Init("UTC"); err != nil {
+		t.Fatalf("Init failed with UTC: %v", err)
+	}
+
+	before := time.Now().UTC()
+	start, end := Last24HoursInUserLocation("UTC")
+	after := time.Now().UTC()
+
+	if !start.Before(end) {
+		t.Fatalf("expected start before end, got start=%v end=%v", start, end)
+	}
+	if diff := end.Sub(start); diff != 24*time.Hour {
+		t.Fatalf("expected exact 24h window, got %v", diff)
+	}
+	if start.Before(before.Add(-24*time.Hour-time.Second)) || start.After(after.Add(-24*time.Hour+time.Second)) {
+		t.Fatalf("unexpected start time: %v", start)
+	}
+	if end.Before(before.Add(-time.Second)) || end.After(after.Add(time.Second)) {
+		t.Fatalf("unexpected end time: %v", end)
+	}
+}

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -13,6 +13,7 @@ import type {
   UserUsageTrendPoint,
   UserSpendingRankingResponse,
   UserBreakdownItem,
+  TimeRangeMetadata,
   UsageRequestType
 } from '@/types'
 
@@ -59,10 +60,8 @@ export interface TrendParams {
   billing_type?: number | null
 }
 
-export interface TrendResponse {
+export interface TrendResponse extends TimeRangeMetadata {
   trend: TrendDataPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
@@ -91,10 +90,8 @@ export interface ModelStatsParams {
   billing_type?: number | null
 }
 
-export interface ModelStatsResponse {
+export interface ModelStatsResponse extends TimeRangeMetadata {
   models: ModelStat[]
-  start_date: string
-  end_date: string
 }
 
 /**
@@ -120,10 +117,8 @@ export interface GroupStatsParams {
   billing_type?: number | null
 }
 
-export interface GroupStatsResponse {
+export interface GroupStatsResponse extends TimeRangeMetadata {
   groups: GroupStat[]
-  start_date: string
-  end_date: string
 }
 
 export interface DashboardSnapshotV2Params extends TrendParams {
@@ -139,10 +134,8 @@ export interface DashboardSnapshotV2Stats extends DashboardStats {
   uptime: number
 }
 
-export interface DashboardSnapshotV2Response {
+export interface DashboardSnapshotV2Response extends TimeRangeMetadata {
   generated_at: string
-  start_date: string
-  end_date: string
   granularity: string
   stats?: DashboardSnapshotV2Stats
   trend?: TrendDataPoint[]
@@ -180,10 +173,8 @@ export interface UserBreakdownParams {
   billing_type?: number | null
 }
 
-export interface UserBreakdownResponse {
+export interface UserBreakdownResponse extends TimeRangeMetadata {
   users: UserBreakdownItem[]
-  start_date: string
-  end_date: string
 }
 
 export async function getUserBreakdown(params: UserBreakdownParams): Promise<UserBreakdownResponse> {
@@ -207,10 +198,8 @@ export interface ApiKeyTrendParams extends TrendParams {
   limit?: number
 }
 
-export interface ApiKeyTrendResponse {
+export interface ApiKeyTrendResponse extends TimeRangeMetadata {
   trend: ApiKeyUsageTrendPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
@@ -232,10 +221,8 @@ export interface UserTrendParams extends TrendParams {
   limit?: number
 }
 
-export interface UserTrendResponse {
+export interface UserTrendResponse extends TimeRangeMetadata {
   trend: UserUsageTrendPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -45,6 +45,7 @@ export async function getRealtimeMetrics(): Promise<{
 }
 
 export interface TrendParams {
+  period?: string
   start_date?: string
   end_date?: string
   granularity?: 'day' | 'hour'
@@ -76,6 +77,7 @@ export async function getUsageTrend(params?: TrendParams): Promise<TrendResponse
 }
 
 export interface ModelStatsParams {
+  period?: string
   start_date?: string
   end_date?: string
   user_id?: number
@@ -106,6 +108,7 @@ export async function getModelStats(params?: ModelStatsParams): Promise<ModelSta
 }
 
 export interface GroupStatsParams {
+  period?: string
   start_date?: string
   end_date?: string
   user_id?: number
@@ -159,6 +162,7 @@ export async function getGroupStats(params?: GroupStatsParams): Promise<GroupSta
 }
 
 export interface UserBreakdownParams {
+  period?: string
   start_date?: string
   end_date?: string
   group_id?: number
@@ -236,7 +240,7 @@ export interface UserTrendResponse {
 }
 
 export interface UserSpendingRankingParams
-  extends Pick<TrendParams, 'start_date' | 'end_date'> {
+  extends Pick<TrendParams, 'period' | 'start_date' | 'end_date'> {
   limit?: number
 }
 

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -45,6 +45,7 @@ export async function getRealtimeMetrics(): Promise<{
 }
 
 export interface TrendParams {
+  period?: string
   start_date?: string
   end_date?: string
   granularity?: 'day' | 'hour'
@@ -76,6 +77,7 @@ export async function getUsageTrend(params?: TrendParams): Promise<TrendResponse
 }
 
 export interface ModelStatsParams {
+  period?: string
   start_date?: string
   end_date?: string
   user_id?: number
@@ -106,6 +108,7 @@ export async function getModelStats(params?: ModelStatsParams): Promise<ModelSta
 }
 
 export interface GroupStatsParams {
+  period?: string
   start_date?: string
   end_date?: string
   user_id?: number
@@ -159,6 +162,7 @@ export async function getGroupStats(params?: GroupStatsParams): Promise<GroupSta
 }
 
 export interface UserBreakdownParams {
+  period?: string
   start_date?: string
   end_date?: string
   group_id?: number
@@ -238,7 +242,7 @@ export interface UserTrendResponse {
 }
 
 export interface UserSpendingRankingParams
-  extends Pick<TrendParams, 'start_date' | 'end_date'> {
+  extends Pick<TrendParams, 'period' | 'start_date' | 'end_date'> {
   limit?: number
 }
 

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -13,6 +13,7 @@ import type {
   UserUsageTrendPoint,
   UserSpendingRankingResponse,
   UserBreakdownItem,
+  TimeRangeMetadata,
   UsageRequestType
 } from '@/types'
 
@@ -59,10 +60,8 @@ export interface TrendParams {
   billing_type?: number | null
 }
 
-export interface TrendResponse {
+export interface TrendResponse extends TimeRangeMetadata {
   trend: TrendDataPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
@@ -91,10 +90,8 @@ export interface ModelStatsParams {
   billing_type?: number | null
 }
 
-export interface ModelStatsResponse {
+export interface ModelStatsResponse extends TimeRangeMetadata {
   models: ModelStat[]
-  start_date: string
-  end_date: string
 }
 
 /**
@@ -120,10 +117,8 @@ export interface GroupStatsParams {
   billing_type?: number | null
 }
 
-export interface GroupStatsResponse {
+export interface GroupStatsResponse extends TimeRangeMetadata {
   groups: GroupStat[]
-  start_date: string
-  end_date: string
 }
 
 export interface DashboardSnapshotV2Params extends TrendParams {
@@ -139,10 +134,8 @@ export interface DashboardSnapshotV2Stats extends DashboardStats {
   uptime: number
 }
 
-export interface DashboardSnapshotV2Response {
+export interface DashboardSnapshotV2Response extends TimeRangeMetadata {
   generated_at: string
-  start_date: string
-  end_date: string
   granularity: string
   stats?: DashboardSnapshotV2Stats
   trend?: TrendDataPoint[]
@@ -182,10 +175,8 @@ export interface UserBreakdownParams {
   billing_type?: number | null
 }
 
-export interface UserBreakdownResponse {
+export interface UserBreakdownResponse extends TimeRangeMetadata {
   users: UserBreakdownItem[]
-  start_date: string
-  end_date: string
 }
 
 export async function getUserBreakdown(params: UserBreakdownParams): Promise<UserBreakdownResponse> {
@@ -209,10 +200,8 @@ export interface ApiKeyTrendParams extends TrendParams {
   limit?: number
 }
 
-export interface ApiKeyTrendResponse {
+export interface ApiKeyTrendResponse extends TimeRangeMetadata {
   trend: ApiKeyUsageTrendPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
@@ -234,10 +223,8 @@ export interface UserTrendParams extends TrendParams {
   limit?: number
 }
 
-export interface UserTrendResponse {
+export interface UserTrendResponse extends TimeRangeMetadata {
   trend: UserUsageTrendPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -10,7 +10,8 @@ import type {
   UsageStatsResponse,
   PaginatedResponse,
   TrendDataPoint,
-  ModelStat
+  ModelStat,
+  TimeRangeMetadata
 } from '@/types'
 
 // ==================== Dashboard Types ====================
@@ -46,17 +47,13 @@ export interface TrendParams {
   granularity?: 'day' | 'hour'
 }
 
-export interface TrendResponse {
+export interface TrendResponse extends TimeRangeMetadata {
   trend: TrendDataPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
-export interface ModelStatsResponse {
+export interface ModelStatsResponse extends TimeRangeMetadata {
   models: ModelStat[]
-  start_date: string
-  end_date: string
 }
 
 /**

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -40,6 +40,7 @@ export interface UserDashboardStats {
 }
 
 export interface TrendParams {
+  period?: string
   start_date?: string
   end_date?: string
   granularity?: 'day' | 'hour'
@@ -216,6 +217,7 @@ export async function getDashboardTrend(params?: TrendParams): Promise<TrendResp
  * @returns Model usage statistics for current user
  */
 export async function getDashboardModels(params?: {
+  period?: string
   start_date?: string
   end_date?: string
 }): Promise<ModelStatsResponse> {

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -56,6 +56,7 @@ export interface UserDashboardStats {
 }
 
 export interface TrendParams {
+  period?: string
   start_date?: string
   end_date?: string
   granularity?: 'day' | 'hour'
@@ -277,6 +278,7 @@ export async function getDashboardTrend(params?: TrendParams): Promise<TrendResp
  * @returns Model usage statistics for current user
  */
 export async function getDashboardModels(params?: {
+  period?: string
   start_date?: string
   end_date?: string
   api_key_id?: number

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -15,6 +15,7 @@ import type {
   UsageRequestType,
   UserErrorRequest,
   UserErrorRequestDetail,
+  TimeRangeMetadata,
   UserErrorListParams
 } from '@/types'
 
@@ -70,17 +71,13 @@ export interface TrendParams {
   timezone?: string
 }
 
-export interface TrendResponse {
+export interface TrendResponse extends TimeRangeMetadata {
   trend: TrendDataPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
-export interface ModelStatsResponse {
+export interface ModelStatsResponse extends TimeRangeMetadata {
   models: ModelStat[]
-  start_date: string
-  end_date: string
 }
 
 export interface ApiKeyDailyUsagePoint {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1371,6 +1371,7 @@ export interface ExtendSubscriptionRequest {
 export interface UsageQueryParams {
   page?: number
   page_size?: number
+  period?: string
   api_key_id?: number
   user_id?: number
   account_id?: number

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1267,13 +1267,19 @@ export interface UserSpendingRankingItem {
   tokens: number
 }
 
-export interface UserSpendingRankingResponse {
+export interface TimeRangeMetadata {
+  start_date: string
+  end_date: string
+  start_time?: string
+  end_time?: string
+  period?: string
+}
+
+export interface UserSpendingRankingResponse extends TimeRangeMetadata {
   ranking: UserSpendingRankingItem[]
   total_actual_cost: number
   total_requests: number
   total_tokens: number
-  start_date: string
-  end_date: string
 }
 
 export interface ApiKeyUsageTrendPoint {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1766,6 +1766,7 @@ export interface UserErrorListParams {
 export interface UsageQueryParams {
   page?: number
   page_size?: number
+  period?: string
   api_key_id?: number
   user_id?: number
   account_id?: number

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1622,13 +1622,19 @@ export interface UserSpendingRankingItem {
   tokens: number
 }
 
-export interface UserSpendingRankingResponse {
+export interface TimeRangeMetadata {
+  start_date: string
+  end_date: string
+  start_time?: string
+  end_time?: string
+  period?: string
+}
+
+export interface UserSpendingRankingResponse extends TimeRangeMetadata {
   ranking: UserSpendingRankingItem[]
   total_actual_cost: number
   total_requests: number
   total_tokens: number
-  start_date: string
-  end_date: string
 }
 
 export interface ApiKeyUsageTrendPoint {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1772,7 +1772,6 @@ export interface UserErrorListParams {
 export interface UsageQueryParams {
   page?: number
   page_size?: number
-  period?: string
   api_key_id?: number
   user_id?: number
   account_id?: number
@@ -1782,6 +1781,7 @@ export interface UsageQueryParams {
   stream?: boolean
   billing_type?: number | null
   billing_mode?: string | null
+  period?: string
   start_date?: string
   end_date?: string
   timezone?: string

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -340,6 +340,7 @@ ChartJS.register(
 
 const appStore = useAppStore()
 const router = useRouter()
+type DateRangePreset = 'last24Hours' | null
 const stats = ref<DashboardStats | null>(null)
 const loading = ref(false)
 const chartsLoading = ref(false)
@@ -379,6 +380,25 @@ const granularity = ref<'day' | 'hour'>('hour')
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
+
+const buildRangeParams = (): { period?: string; start_date?: string; end_date?: string } => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
 
 // Granularity options for Select component
 const granularityOptions = computed(() => [
@@ -556,12 +576,14 @@ const formatDuration = (ms: number): string => {
 }
 
 const goToUserUsage = (item: UserSpendingRankingItem) => {
+  const rangeParams = buildRangeParams()
   void router.push({
     path: '/admin/usage',
     query: {
       user_id: String(item.user_id),
-      start_date: startDate.value,
-      end_date: endDate.value
+      ...(rangeParams.period
+        ? { period: rangeParams.period }
+        : { start_date: startDate.value, end_date: endDate.value })
     }
   })
 }
@@ -572,6 +594,9 @@ const onDateRangeChange = (range: {
   endDate: string
   preset: string | null
 }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
   // Auto-select granularity based on date range
   const start = new Date(range.startDate)
   const end = new Date(range.endDate)
@@ -596,8 +621,7 @@ const loadDashboardSnapshot = async (includeStats: boolean) => {
   chartsLoading.value = true
   try {
     const response = await adminAPI.dashboard.getSnapshotV2({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       include_stats: includeStats,
       include_trend: true,
@@ -628,8 +652,7 @@ const loadUsersTrend = async () => {
   userTrendLoading.value = true
   try {
     const response = await adminAPI.dashboard.getUserUsageTrend({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       limit: 12
     })
@@ -652,8 +675,7 @@ const loadUserSpendingRanking = async () => {
   rankingError.value = false
   try {
     const response = await adminAPI.dashboard.getUserSpendingRanking({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       limit: rankingLimit
     })
     if (currentSeq !== rankingLoadSeq) return

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -390,6 +390,7 @@ ChartJS.register(
 const appStore = useAppStore()
 const router = useRouter()
 const { canUseBatchImage, refreshBatchImageAccess } = useBatchImageAccess()
+type DateRangePreset = 'last24Hours' | null
 const stats = ref<DashboardStats | null>(null)
 const loading = ref(false)
 const chartsLoading = ref(false)
@@ -429,6 +430,25 @@ const granularity = ref<'day' | 'hour'>('hour')
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
+
+const buildRangeParams = (): { period?: string; start_date?: string; end_date?: string } => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
 
 // Granularity options for Select component
 const granularityOptions = computed(() => [
@@ -612,12 +632,14 @@ const formatDuration = (ms: number): string => {
 }
 
 const goToUserUsage = (item: UserSpendingRankingItem) => {
+  const rangeParams = buildRangeParams()
   void router.push({
     path: '/admin/usage',
     query: {
       user_id: String(item.user_id),
-      start_date: startDate.value,
-      end_date: endDate.value
+      ...(rangeParams.period
+        ? { period: rangeParams.period }
+        : { start_date: startDate.value, end_date: endDate.value })
     }
   })
 }
@@ -628,6 +650,9 @@ const onDateRangeChange = (range: {
   endDate: string
   preset: string | null
 }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
   // Auto-select granularity based on date range
   const start = new Date(range.startDate)
   const end = new Date(range.endDate)
@@ -652,8 +677,7 @@ const loadDashboardSnapshot = async (includeStats: boolean) => {
   chartsLoading.value = true
   try {
     const response = await adminAPI.dashboard.getSnapshotV2({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       include_stats: includeStats,
       include_trend: true,
@@ -684,8 +708,7 @@ const loadUsersTrend = async () => {
   userTrendLoading.value = true
   try {
     const response = await adminAPI.dashboard.getUserUsageTrend({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       limit: 12
     })
@@ -708,8 +731,7 @@ const loadUserSpendingRanking = async () => {
   rankingError.value = false
   try {
     const response = await adminAPI.dashboard.getUserSpendingRanking({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       limit: rankingLimit
     })
     if (currentSeq !== rankingLoadSeq) return

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -154,6 +154,7 @@ const appStore = useAppStore()
 type DistributionMetric = 'tokens' | 'actual_cost'
 type EndpointSource = 'inbound' | 'upstream' | 'path'
 type ModelDistributionSource = 'requested' | 'upstream' | 'mapping'
+type DateRangePreset = 'last24Hours' | null
 const route = useRoute()
 const usageStats = ref<AdminUsageStatsResponse | null>(null); const usageLogs = ref<AdminUsageLog[]>([]); const loading = ref(false); const exporting = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const requestedModelStats = ref<ModelStat[]>([]); const upstreamModelStats = ref<ModelStat[]>([]); const mappingModelStats = ref<ModelStat[]>([]); const groupStats = ref<GroupStat[]>([]); const chartsLoading = ref(false); const modelStatsLoading = ref(false); const granularity = ref<'day' | 'hour'>('hour')
@@ -226,6 +227,7 @@ const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
 }
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
 const pagination = reactive({ page: 1, page_size: getPersistedPageSize(), total: 0 })
 const sortState = reactive({
@@ -249,6 +251,16 @@ const applyRouteQueryFilters = () => {
   const queryStartDate = getSingleQueryValue(route.query.start_date)
   const queryEndDate = getSingleQueryValue(route.query.end_date)
   const queryUserId = getNumericQueryValue(route.query.user_id)
+  const queryPeriod = getSingleQueryValue(route.query.period)
+
+  if (queryStartDate || queryEndDate) {
+    activeDatePreset.value = null
+  } else if (queryPeriod === 'last24hours') {
+    activeDatePreset.value = 'last24Hours'
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+  }
 
   if (queryStartDate) {
     startDate.value = queryStartDate
@@ -260,17 +272,44 @@ const applyRouteQueryFilters = () => {
   filters.value = {
     ...filters.value,
     user_id: queryUserId,
+    period: activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined,
     start_date: startDate.value,
     end_date: endDate.value
   }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
 }
 
+const buildRangeParams = (): Pick<AdminUsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+    filters.value = {
+      ...filters.value,
+      period: 'last24hours',
+      start_date: range.start,
+      end_date: range.end
+    }
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
+
 const onDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
   startDate.value = range.startDate
   endDate.value = range.endDate
   filters.value = {
     ...filters.value,
+    period: activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined,
     start_date: range.startDate,
     end_date: range.endDate
   }
@@ -290,6 +329,7 @@ const buildUsageListParams = (
     page_size: pageSize,
     exact_total: exactTotal,
     ...filters.value,
+    ...buildRangeParams(),
     stream: legacyStream === null ? undefined : legacyStream,
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order
@@ -312,7 +352,11 @@ const loadStats = async () => {
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
-    const s = await adminAPI.usage.getStats({ ...filters.value, stream: legacyStream === null ? undefined : legacyStream })
+    const s = await adminAPI.usage.getStats({
+      ...filters.value,
+      ...buildRangeParams(),
+      stream: legacyStream === null ? undefined : legacyStream
+    })
     if (seq !== statsReqSeq) return
     usageStats.value = s
     inboundEndpointStats.value = s.endpoints || []
@@ -349,8 +393,7 @@ const loadModelStats = async (source: ModelDistributionSource, force = false) =>
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
     const baseParams = {
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
+      ...buildRangeParams(),
       user_id: filters.value.user_id,
       model: filters.value.model,
       api_key_id: filters.value.api_key_id,
@@ -397,8 +440,7 @@ const loadChartData = async () => {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
     const snapshot = await adminAPI.dashboard.getSnapshotV2({
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       user_id: filters.value.user_id,
       model: filters.value.model,
@@ -436,9 +478,17 @@ const refreshData = () => {
 }
 const resetFilters = () => {
   const range = getLast24HoursRangeDates()
+  activeDatePreset.value = 'last24Hours'
   startDate.value = range.start
   endDate.value = range.end
-  filters.value = { start_date: startDate.value, end_date: endDate.value, request_type: undefined, billing_type: null, billing_mode: undefined }
+  filters.value = {
+    period: 'last24hours',
+    start_date: startDate.value,
+    end_date: endDate.value,
+    request_type: undefined,
+    billing_type: null,
+    billing_mode: undefined
+  }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
   applyFilters()
 }

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -210,6 +210,7 @@ const appStore = useAppStore()
 type DistributionMetric = 'tokens' | 'actual_cost'
 type EndpointSource = 'inbound' | 'upstream' | 'path'
 type ModelDistributionSource = 'requested' | 'upstream' | 'mapping'
+type DateRangePreset = 'last24Hours' | null
 const route = useRoute()
 const usageStats = ref<AdminUsageStatsResponse | null>(null); const usageLogs = ref<AdminUsageLog[]>([]); const loading = ref(false); const exporting = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const requestedModelStats = ref<ModelStat[]>([]); const upstreamModelStats = ref<ModelStat[]>([]); const mappingModelStats = ref<ModelStat[]>([]); const groupStats = ref<GroupStat[]>([]); const chartsLoading = ref(false); const modelStatsLoading = ref(false); const granularity = ref<'day' | 'hour'>('hour')
@@ -295,6 +296,7 @@ const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
 }
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
 const pagination = reactive({ page: 1, page_size: getPersistedPageSize(), total: 0 })
 const sortState = reactive({
@@ -318,6 +320,16 @@ const applyRouteQueryFilters = () => {
   const queryStartDate = getSingleQueryValue(route.query.start_date)
   const queryEndDate = getSingleQueryValue(route.query.end_date)
   const queryUserId = getNumericQueryValue(route.query.user_id)
+  const queryPeriod = getSingleQueryValue(route.query.period)
+
+  if (queryStartDate || queryEndDate) {
+    activeDatePreset.value = null
+  } else if (queryPeriod === 'last24hours') {
+    activeDatePreset.value = 'last24Hours'
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+  }
 
   if (queryStartDate) {
     startDate.value = queryStartDate
@@ -329,17 +341,44 @@ const applyRouteQueryFilters = () => {
   filters.value = {
     ...filters.value,
     user_id: queryUserId,
+    period: activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined,
     start_date: startDate.value,
     end_date: endDate.value
   }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
 }
 
+const buildRangeParams = (): Pick<AdminUsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+    filters.value = {
+      ...filters.value,
+      period: 'last24hours',
+      start_date: range.start,
+      end_date: range.end
+    }
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
+
 const onDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
   startDate.value = range.startDate
   endDate.value = range.endDate
   filters.value = {
     ...filters.value,
+    period: activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined,
     start_date: range.startDate,
     end_date: range.endDate
   }
@@ -359,6 +398,7 @@ const buildUsageListParams = (
     page_size: pageSize,
     exact_total: exactTotal,
     ...filters.value,
+    ...buildRangeParams(),
     stream: legacyStream === null ? undefined : legacyStream,
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order
@@ -383,6 +423,7 @@ const loadStats = async (force = false) => {
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
     const s = await adminAPI.usage.getStats({
       ...filters.value,
+      ...buildRangeParams(),
       stream: legacyStream === null ? undefined : legacyStream,
       ...(force ? { nocache: 1 } : {}),
     })
@@ -420,8 +461,7 @@ const loadModelStats = async (source: ModelDistributionSource, force = false) =>
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
     const baseParams = {
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
+      ...buildRangeParams(),
       user_id: filters.value.user_id,
       model: filters.value.model,
       api_key_id: filters.value.api_key_id,
@@ -468,8 +508,7 @@ const loadChartData = async () => {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
     const snapshot = await adminAPI.dashboard.getSnapshotV2({
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       user_id: filters.value.user_id,
       model: filters.value.model,
@@ -515,9 +554,17 @@ const refreshData = () => {
 }
 const resetFilters = () => {
   const range = getLast24HoursRangeDates()
+  activeDatePreset.value = 'last24Hours'
   startDate.value = range.start
   endDate.value = range.end
-  filters.value = { start_date: startDate.value, end_date: endDate.value, request_type: undefined, billing_type: null, billing_mode: undefined }
+  filters.value = {
+    period: 'last24hours',
+    start_date: startDate.value,
+    end_date: endDate.value,
+    request_type: undefined,
+    billing_type: null,
+    billing_mode: undefined
+  }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
   applyFilters()
 }

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -210,7 +210,6 @@ const appStore = useAppStore()
 type DistributionMetric = 'tokens' | 'actual_cost'
 type EndpointSource = 'inbound' | 'upstream' | 'path'
 type ModelDistributionSource = 'requested' | 'upstream' | 'mapping'
-type DateRangePreset = 'last24Hours' | null
 const route = useRoute()
 const usageStats = ref<AdminUsageStatsResponse | null>(null); const usageLogs = ref<AdminUsageLog[]>([]); const loading = ref(false); const exporting = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const requestedModelStats = ref<ModelStat[]>([]); const upstreamModelStats = ref<ModelStat[]>([]); const mappingModelStats = ref<ModelStat[]>([]); const groupStats = ref<GroupStat[]>([]); const chartsLoading = ref(false); const modelStatsLoading = ref(false); const granularity = ref<'day' | 'hour'>('hour')
@@ -296,7 +295,6 @@ const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
 }
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
-const activeDatePreset = ref<DateRangePreset>('last24Hours')
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
 const pagination = reactive({ page: 1, page_size: getPersistedPageSize(), total: 0 })
 const sortState = reactive({
@@ -319,18 +317,10 @@ const getNumericQueryValue = (value: string | null | Array<string | null> | unde
 const applyRouteQueryFilters = () => {
   const queryStartDate = getSingleQueryValue(route.query.start_date)
   const queryEndDate = getSingleQueryValue(route.query.end_date)
-  const queryUserId = getNumericQueryValue(route.query.user_id)
   const queryPeriod = getSingleQueryValue(route.query.period)
+  const queryUserId = getNumericQueryValue(route.query.user_id)
 
-  if (queryStartDate || queryEndDate) {
-    activeDatePreset.value = null
-  } else if (queryPeriod === 'last24hours') {
-    activeDatePreset.value = 'last24Hours'
-    const range = getLast24HoursRangeDates()
-    startDate.value = range.start
-    endDate.value = range.end
-  }
-
+  const useLast24Hours = queryPeriod === '24h' || queryPeriod === 'last24hours'
   if (queryStartDate) {
     startDate.value = queryStartDate
   }
@@ -341,46 +331,22 @@ const applyRouteQueryFilters = () => {
   filters.value = {
     ...filters.value,
     user_id: queryUserId,
-    period: activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined,
-    start_date: startDate.value,
-    end_date: endDate.value
+    period: useLast24Hours ? 'last24hours' : undefined,
+    start_date: useLast24Hours ? undefined : startDate.value,
+    end_date: useLast24Hours ? undefined : endDate.value
   }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
 }
 
-const buildRangeParams = (): Pick<AdminUsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
-  if (activeDatePreset.value === 'last24Hours') {
-    const range = getLast24HoursRangeDates()
-    startDate.value = range.start
-    endDate.value = range.end
-    filters.value = {
-      ...filters.value,
-      period: 'last24hours',
-      start_date: range.start,
-      end_date: range.end
-    }
-    return {
-      period: 'last24hours',
-      start_date: undefined,
-      end_date: undefined
-    }
-  }
-  return {
-    period: undefined,
-    start_date: startDate.value,
-    end_date: endDate.value
-  }
-}
-
 const onDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
-  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  const isLast24Hours = range.preset === 'last24Hours'
   startDate.value = range.startDate
   endDate.value = range.endDate
   filters.value = {
     ...filters.value,
-    period: activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined,
-    start_date: range.startDate,
-    end_date: range.endDate
+    period: isLast24Hours ? 'last24hours' : undefined,
+    start_date: isLast24Hours ? undefined : range.startDate,
+    end_date: isLast24Hours ? undefined : range.endDate
   }
   granularity.value = getGranularityForRange(range.startDate, range.endDate)
   applyFilters()
@@ -393,12 +359,14 @@ const buildUsageListParams = (
 ): AdminUsageQueryParams => {
   const requestType = filters.value.request_type
   const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+  const isLast24Hours = filters.value.period === 'last24hours'
   return {
     page,
     page_size: pageSize,
     exact_total: exactTotal,
     ...filters.value,
-    ...buildRangeParams(),
+    start_date: isLast24Hours ? undefined : filters.value.start_date,
+    end_date: isLast24Hours ? undefined : filters.value.end_date,
     stream: legacyStream === null ? undefined : legacyStream,
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order
@@ -421,9 +389,11 @@ const loadStats = async (force = false) => {
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const isLast24Hours = filters.value.period === 'last24hours'
     const s = await adminAPI.usage.getStats({
       ...filters.value,
-      ...buildRangeParams(),
+      start_date: isLast24Hours ? undefined : filters.value.start_date,
+      end_date: isLast24Hours ? undefined : filters.value.end_date,
       stream: legacyStream === null ? undefined : legacyStream,
       ...(force ? { nocache: 1 } : {}),
     })
@@ -460,8 +430,11 @@ const loadModelStats = async (source: ModelDistributionSource, force = false) =>
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const isLast24Hours = filters.value.period === 'last24hours'
     const baseParams = {
-      ...buildRangeParams(),
+      start_date: isLast24Hours ? undefined : (filters.value.start_date || startDate.value),
+      end_date: isLast24Hours ? undefined : (filters.value.end_date || endDate.value),
+      period: isLast24Hours ? 'last24hours' : undefined,
       user_id: filters.value.user_id,
       model: filters.value.model,
       api_key_id: filters.value.api_key_id,
@@ -507,8 +480,11 @@ const loadChartData = async () => {
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const isLast24Hours = filters.value.period === 'last24hours'
     const snapshot = await adminAPI.dashboard.getSnapshotV2({
-      ...buildRangeParams(),
+      start_date: isLast24Hours ? undefined : (filters.value.start_date || startDate.value),
+      end_date: isLast24Hours ? undefined : (filters.value.end_date || endDate.value),
+      period: isLast24Hours ? 'last24hours' : undefined,
       granularity: granularity.value,
       user_id: filters.value.user_id,
       model: filters.value.model,
@@ -554,17 +530,9 @@ const refreshData = () => {
 }
 const resetFilters = () => {
   const range = getLast24HoursRangeDates()
-  activeDatePreset.value = 'last24Hours'
   startDate.value = range.start
   endDate.value = range.end
-  filters.value = {
-    period: 'last24hours',
-    start_date: startDate.value,
-    end_date: endDate.value,
-    request_type: undefined,
-    billing_type: null,
-    billing_mode: undefined
-  }
+  filters.value = { period: 'last24hours', request_type: undefined, billing_type: null, billing_mode: undefined }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
   applyFilters()
 }
@@ -868,6 +836,9 @@ const handleColumnClickOutside = (event: MouseEvent) => {
 
 onMounted(() => {
   applyRouteQueryFilters()
+  if (!filters.value.period) {
+    filters.value = { ...filters.value, period: 'last24hours', start_date: undefined, end_date: undefined }
+  }
   loadLogs()
   loadStats()
   loadModelStats(modelDistributionSource.value, true)

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -42,13 +42,6 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 const createDashboardStats = (): DashboardStats => ({
   total_users: 0,
   today_new_users: 0,
@@ -71,6 +64,7 @@ const createDashboardStats = (): DashboardStats => ({
   total_tokens: 0,
   total_cost: 0,
   total_actual_cost: 0,
+  total_account_cost: 0,
   today_requests: 0,
   today_input_tokens: 0,
   today_output_tokens: 0,
@@ -79,6 +73,7 @@ const createDashboardStats = (): DashboardStats => ({
   today_tokens: 0,
   today_cost: 0,
   today_actual_cost: 0,
+  today_account_cost: 0,
   average_duration_ms: 0,
   uptime: 0,
   rpm: 0,
@@ -130,13 +125,11 @@ describe('admin DashboardView', () => {
 
     await flushPromises()
 
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
       granularity: 'hour'
     }))
   })

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -43,13 +43,6 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 const createDashboardStats = (): DashboardStats => ({
   total_users: 0,
   today_new_users: 0,
@@ -72,6 +65,7 @@ const createDashboardStats = (): DashboardStats => ({
   total_tokens: 0,
   total_cost: 0,
   total_actual_cost: 0,
+  total_account_cost: 0,
   today_requests: 0,
   today_input_tokens: 0,
   today_output_tokens: 0,
@@ -80,6 +74,7 @@ const createDashboardStats = (): DashboardStats => ({
   today_tokens: 0,
   today_cost: 0,
   today_actual_cost: 0,
+  today_account_cost: 0,
   average_duration_ms: 0,
   uptime: 0,
   rpm: 0,
@@ -133,13 +128,11 @@ describe('admin DashboardView', () => {
 
     await flushPromises()
 
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
       granularity: 'hour'
     }))
   })

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -3,7 +3,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 
 import UsageView from '../UsageView.vue'
 
-const { list, getStats, getSnapshotV2, getById } = vi.hoisted(() => {
+const { list, getStats, getSnapshotV2, getModelStats, getById } = vi.hoisted(() => {
   vi.stubGlobal('localStorage', {
     getItem: vi.fn(() => null),
     setItem: vi.fn(),
@@ -14,6 +14,7 @@ const { list, getStats, getSnapshotV2, getById } = vi.hoisted(() => {
     list: vi.fn(),
     getStats: vi.fn(),
     getSnapshotV2: vi.fn(),
+    getModelStats: vi.fn(),
     getById: vi.fn(),
   }
 })
@@ -25,13 +26,6 @@ const messages: Record<string, string> = {
   'admin.usage.failedToLoadUser': 'Failed to load user',
 }
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 vi.mock('@/api/admin', () => ({
   adminAPI: {
     usage: {
@@ -40,6 +34,7 @@ vi.mock('@/api/admin', () => ({
     },
     dashboard: {
       getSnapshotV2,
+      getModelStats,
     },
     users: {
       getById,
@@ -111,6 +106,7 @@ describe('admin UsageView distribution metric toggles', () => {
     list.mockReset()
     getStats.mockReset()
     getSnapshotV2.mockReset()
+    getModelStats.mockReset()
     getById.mockReset()
 
     list.mockResolvedValue({
@@ -132,6 +128,11 @@ describe('admin UsageView distribution metric toggles', () => {
       trend: [],
       models: [],
       groups: [],
+    })
+    getModelStats.mockResolvedValue({
+      models: [],
+      start_date: '',
+      end_date: '',
     })
   })
 
@@ -165,11 +166,10 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
 
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
       granularity: 'hour'
     }))
 

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -27,13 +27,6 @@ const messages: Record<string, string> = {
   'admin.usage.failedToLoadUser': 'Failed to load user',
 }
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 vi.mock('@/api/admin', () => ({
   adminAPI: {
     usage: {
@@ -157,7 +150,6 @@ describe('admin UsageView distribution metric toggles', () => {
   })
 
   it('keeps previous model stats visible during refresh until new data arrives', async () => {
-    // 首次加载返回 A
     getModelStats.mockResolvedValueOnce({ models: [{ model: 'A', total_tokens: 10 }] })
 
     const wrapper = mount(UsageView, {
@@ -174,14 +166,12 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'A', total_tokens: 10 }])
 
-    // 刷新:让第二次 getModelStats 处于 pending,断言旧数据 A 仍在(不被清空成 [])
     let resolveSecond: (v: any) => void = () => {}
     getModelStats.mockReturnValueOnce(new Promise((res) => { resolveSecond = res }))
     ;(wrapper.vm as any).refreshData()
     await flushPromises()
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'A', total_tokens: 10 }])
 
-    // 新数据到达后替换为 B
     resolveSecond({ models: [{ model: 'B', total_tokens: 20 }] })
     await flushPromises()
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'B', total_tokens: 20 }])
@@ -214,11 +204,10 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
 
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
       granularity: 'hour'
     }))
 
@@ -338,7 +327,6 @@ describe('admin UsageView errors tab filter forwarding', () => {
     vi.advanceTimersByTime(120)
     await flushPromises()
 
-    // 模拟用户在过滤器里选择了模型/账户/分组
     const vm = wrapper.vm as any
     vm.filters.model = 'gpt-5.3-codex'
     vm.filters.account_id = 7

--- a/frontend/src/views/user/DashboardView.vue
+++ b/frontend/src/views/user/DashboardView.vue
@@ -4,7 +4,7 @@
       <div v-if="loading" class="flex items-center justify-center py-12"><LoadingSpinner /></div>
       <template v-else-if="stats">
         <UserDashboardStats :stats="stats" :balance="user?.balance || 0" :is-simple="authStore.isSimpleMode" />
-        <UserDashboardCharts v-model:startDate="startDate" v-model:endDate="endDate" v-model:granularity="granularity" :loading="loadingCharts" :trend="trendData" :models="modelStats" @dateRangeChange="loadCharts" @granularityChange="loadCharts" @refresh="refreshAll" />
+        <UserDashboardCharts v-model:startDate="startDate" v-model:endDate="endDate" v-model:granularity="granularity" :loading="loadingCharts" :trend="trendData" :models="modelStats" @dateRangeChange="handleDateRangeChange" @granularityChange="loadCharts" @refresh="refreshAll" />
         <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <div class="lg:col-span-2"><UserDashboardRecentUsage :data="recentUsage" :loading="loadingUsage" /></div>
           <div class="lg:col-span-1"><UserDashboardQuickActions /></div>
@@ -19,18 +19,50 @@ import { ref, computed, onMounted } from 'vue'; import { useAuthStore } from '@/
 import AppLayout from '@/components/layout/AppLayout.vue'; import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserDashboardStats from '@/components/user/dashboard/UserDashboardStats.vue'; import UserDashboardCharts from '@/components/user/dashboard/UserDashboardCharts.vue'
 import UserDashboardRecentUsage from '@/components/user/dashboard/UserDashboardRecentUsage.vue'; import UserDashboardQuickActions from '@/components/user/dashboard/UserDashboardQuickActions.vue'
-import type { UsageLog, TrendDataPoint, ModelStat } from '@/types'
+import type { UsageLog, TrendDataPoint, ModelStat, UsageQueryParams } from '@/types'
 
 const authStore = useAuthStore(); const user = computed(() => authStore.user)
 const stats = ref<UserStatsType | null>(null); const loading = ref(false); const loadingUsage = ref(false); const loadingCharts = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const modelStats = ref<ModelStat[]>([]); const recentUsage = ref<UsageLog[]>([])
+type DateRangePreset = 'last24Hours' | null
 
 const formatLD = (d: Date) => d.toISOString().split('T')[0]
 const startDate = ref(formatLD(new Date(Date.now() - 6 * 86400000))); const endDate = ref(formatLD(new Date())); const granularity = ref('day')
+const activeDatePreset = ref<DateRangePreset>(null)
+
+const buildRangeParams = (): Pick<UsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const end = new Date()
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+    startDate.value = formatLD(start)
+    endDate.value = formatLD(end)
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
 
 const loadStats = async () => { loading.value = true; try { await authStore.refreshUser(); stats.value = await usageAPI.getDashboardStats() } catch (error) { console.error('Failed to load dashboard stats:', error) } finally { loading.value = false } }
-const loadCharts = async () => { loadingCharts.value = true; try { const res = await Promise.all([usageAPI.getDashboardTrend({ start_date: startDate.value, end_date: endDate.value, granularity: granularity.value as any }), usageAPI.getDashboardModels({ start_date: startDate.value, end_date: endDate.value })]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
-const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.getByDateRange(startDate.value, endDate.value); recentUsage.value = res.items.slice(0, 5) } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
+const loadCharts = async () => { loadingCharts.value = true; try { const rangeParams = buildRangeParams(); const res = await Promise.all([usageAPI.getDashboardTrend({ ...rangeParams, granularity: granularity.value as any }), usageAPI.getDashboardModels(rangeParams)]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
+const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.query({ page: 1, page_size: 5, sort_by: 'created_at', sort_order: 'desc', ...buildRangeParams() }); recentUsage.value = res.items } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
+const handleDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
+  const start = new Date(range.startDate)
+  const end = new Date(range.endDate)
+  const daysDiff = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
+  granularity.value = daysDiff <= 1 ? 'hour' : 'day'
+  loadCharts()
+  loadRecent()
+}
 const refreshAll = () => { loadStats(); loadCharts(); loadRecent() }
 
 onMounted(() => { refreshAll() })

--- a/frontend/src/views/user/DashboardView.vue
+++ b/frontend/src/views/user/DashboardView.vue
@@ -4,7 +4,7 @@
       <div v-if="loading" class="flex items-center justify-center py-12"><LoadingSpinner /></div>
       <template v-else-if="stats">
         <UserDashboardStats :stats="stats" :balance="user?.balance || 0" :is-simple="authStore.isSimpleMode" :platform-quotas="platformQuotas" />
-        <UserDashboardCharts v-model:startDate="startDate" v-model:endDate="endDate" v-model:granularity="granularity" :loading="loadingCharts" :trend="trendData" :models="modelStats" @dateRangeChange="loadCharts" @granularityChange="loadCharts" @refresh="refreshAll" />
+        <UserDashboardCharts v-model:startDate="startDate" v-model:endDate="endDate" v-model:granularity="granularity" :loading="loadingCharts" :trend="trendData" :models="modelStats" @dateRangeChange="handleDateRangeChange" @granularityChange="loadCharts" @refresh="refreshAll" />
         <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <div class="lg:col-span-2"><UserDashboardRecentUsage :data="recentUsage" :loading="loadingUsage" /></div>
           <div class="lg:col-span-1"><UserDashboardQuickActions /></div>
@@ -19,21 +19,53 @@ import { ref, computed, onMounted } from 'vue'; import { useAuthStore } from '@/
 import AppLayout from '@/components/layout/AppLayout.vue'; import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserDashboardStats from '@/components/user/dashboard/UserDashboardStats.vue'; import UserDashboardCharts from '@/components/user/dashboard/UserDashboardCharts.vue'
 import UserDashboardRecentUsage from '@/components/user/dashboard/UserDashboardRecentUsage.vue'; import UserDashboardQuickActions from '@/components/user/dashboard/UserDashboardQuickActions.vue'
-import type { UsageLog, TrendDataPoint, ModelStat, PlatformQuotaItem } from '@/types'
+import type { UsageLog, TrendDataPoint, ModelStat, PlatformQuotaItem, UsageQueryParams } from '@/types'
 import { getMyPlatformQuotas } from '@/api/user'
 
 const authStore = useAuthStore(); const user = computed(() => authStore.user)
 const stats = ref<UserStatsType | null>(null); const loading = ref(false); const loadingUsage = ref(false); const loadingCharts = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const modelStats = ref<ModelStat[]>([]); const recentUsage = ref<UsageLog[]>([])
 const platformQuotas = ref<PlatformQuotaItem[] | null>(null)
+type DateRangePreset = 'last24Hours' | null
 
 const formatLD = (d: Date) => d.toISOString().split('T')[0]
 const startDate = ref(formatLD(new Date(Date.now() - 6 * 86400000))); const endDate = ref(formatLD(new Date())); const granularity = ref('day')
+const activeDatePreset = ref<DateRangePreset>(null)
+
+const buildRangeParams = (): Pick<UsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const end = new Date()
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+    startDate.value = formatLD(start)
+    endDate.value = formatLD(end)
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
 
 const loadStats = async () => { loading.value = true; try { await authStore.refreshUser(); stats.value = await usageAPI.getDashboardStats() } catch (error) { console.error('Failed to load dashboard stats:', error) } finally { loading.value = false } }
-const loadCharts = async () => { loadingCharts.value = true; try { const res = await Promise.all([usageAPI.getDashboardTrend({ start_date: startDate.value, end_date: endDate.value, granularity: granularity.value as any }), usageAPI.getDashboardModels({ start_date: startDate.value, end_date: endDate.value })]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
-const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.getByDateRange(startDate.value, endDate.value); recentUsage.value = res.items.slice(0, 5) } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
+const loadCharts = async () => { loadingCharts.value = true; try { const rangeParams = buildRangeParams(); const res = await Promise.all([usageAPI.getDashboardTrend({ ...rangeParams, granularity: granularity.value as any }), usageAPI.getDashboardModels(rangeParams)]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
+const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.query({ page: 1, page_size: 5, sort_by: 'created_at', sort_order: 'desc', ...buildRangeParams() }); recentUsage.value = res.items } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
 const loadPlatformQuotas = async () => { try { const data = await getMyPlatformQuotas(); platformQuotas.value = data.platform_quotas ?? [] } catch (error) { console.warn('Failed to load platform quotas:', error); platformQuotas.value = [] } }
+const handleDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
+  const start = new Date(range.startDate)
+  const end = new Date(range.endDate)
+  const daysDiff = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
+  granularity.value = daysDiff <= 1 ? 'hour' : 'day'
+  loadCharts()
+  loadRecent()
+}
 const refreshAll = () => { loadStats(); loadCharts(); loadRecent(); loadPlatformQuotas() }
 
 onMounted(() => { refreshAll() })

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -528,6 +528,7 @@ import { getBillingModeLabel, getBillingModeBadgeClass } from '@/utils/billingMo
 
 const { t } = useI18n()
 const appStore = useAppStore()
+type DateRangePreset = 'last24Hours' | null
 
 let abortController: AbortController | null = null
 
@@ -587,9 +588,11 @@ weekAgo.setDate(weekAgo.getDate() - 6)
 // Date range state
 const startDate = ref(formatLocalDate(weekAgo))
 const endDate = ref(formatLocalDate(now))
+const activeDatePreset = ref<DateRangePreset>(null)
 
 const filters = ref<UsageQueryParams>({
   api_key_id: undefined,
+  period: undefined,
   start_date: undefined,
   end_date: undefined
 })
@@ -598,12 +601,40 @@ const filters = ref<UsageQueryParams>({
 filters.value.start_date = startDate.value
 filters.value.end_date = endDate.value
 
+const buildRangeParams = (): Pick<UsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const end = new Date()
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+    const nextStartDate = formatLocalDate(start)
+    const nextEndDate = formatLocalDate(end)
+    startDate.value = nextStartDate
+    endDate.value = nextEndDate
+    filters.value.period = 'last24hours'
+    filters.value.start_date = nextStartDate
+    filters.value.end_date = nextEndDate
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
+
 // Handle date range change from DateRangePicker
 const onDateRangeChange = (range: {
   startDate: string
   endDate: string
   preset: string | null
 }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
+  filters.value.period = activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined
   filters.value.start_date = range.startDate
   filters.value.end_date = range.endDate
   applyFilters()
@@ -679,6 +710,7 @@ const buildUsageQueryParams = (page: number, pageSize: number): UsageTableQueryP
   page,
   page_size: pageSize,
   ...filters.value,
+  ...buildRangeParams(),
   sort_by: sortState.sort_by,
   sort_order: sortState.sort_order
 })
@@ -730,11 +762,13 @@ const loadApiKeys = async () => {
 const loadUsageStats = async () => {
   try {
     const apiKeyId = filters.value.api_key_id ? Number(filters.value.api_key_id) : undefined
-    const stats = await usageAPI.getStatsByDateRange(
-      filters.value.start_date || startDate.value,
-      filters.value.end_date || endDate.value,
-      apiKeyId
-    )
+    const stats = activeDatePreset.value === 'last24Hours'
+      ? await usageAPI.getStats('last24hours', apiKeyId)
+      : await usageAPI.getStatsByDateRange(
+          filters.value.start_date || startDate.value,
+          filters.value.end_date || endDate.value,
+          apiKeyId
+        )
     usageStats.value = stats
   } catch (error) {
     console.error('Failed to load usage stats:', error)
@@ -748,8 +782,10 @@ const applyFilters = () => {
 }
 
 const resetFilters = () => {
+  activeDatePreset.value = null
   filters.value = {
     api_key_id: undefined,
+    period: undefined,
     start_date: undefined,
     end_date: undefined
   }

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -250,6 +250,7 @@ import { COMMON_ERROR_STATUS_CODES } from '@/utils/errorBadges'
 
 const { t } = useI18n()
 const appStore = useAppStore()
+type DateRangePreset = 'last24Hours' | null
 
 type DistributionMetric = 'tokens' | 'actual_cost'
 type EndpointSource = 'inbound' | 'upstream' | 'path'
@@ -342,6 +343,7 @@ const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
 const granularity = ref<'day' | 'hour'>(getGranularityForRange(startDate.value, endDate.value))
 
 const modelDistributionMetric = ref<DistributionMetric>('tokens')
@@ -352,6 +354,7 @@ const activeTab = ref<'usage' | 'errors'>('usage')
 const errorViewEnabled = computed(() => appStore.cachedPublicSettings?.allow_user_view_error_requests ?? false)
 
 const filters = ref<UsageQueryParams>({
+  period: 'last24hours',
   start_date: startDate.value,
   end_date: endDate.value,
   request_type: undefined,
@@ -359,6 +362,20 @@ const filters = ref<UsageQueryParams>({
   billing_mode: null,
 })
 
+const buildRangeParams = (): Pick<UsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value,
+  }
+}
 const pagination = reactive({
   page: 1,
   page_size: getPersistedPageSize(),
@@ -414,8 +431,7 @@ const normalizedFilters = computed<UsageQueryParams>(() => {
   const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
   return {
     ...filters.value,
-    start_date: startDate.value,
-    end_date: endDate.value,
+    ...buildRangeParams(),
     stream: legacyStream === null ? undefined : legacyStream,
   }
 })
@@ -544,9 +560,11 @@ const refreshData = () => {
 
 const resetFilters = () => {
   const range = getLast24HoursRangeDates()
+  activeDatePreset.value = 'last24Hours'
   startDate.value = range.start
   endDate.value = range.end
   filters.value = {
+    period: 'last24hours',
     start_date: range.start,
     end_date: range.end,
     request_type: undefined,
@@ -562,8 +580,10 @@ const resetFilters = () => {
 }
 
 const onDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
   startDate.value = range.startDate
   endDate.value = range.endDate
+  filters.value.period = activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined
   filters.value.start_date = range.startDate
   filters.value.end_date = range.endDate
   granularity.value = getGranularityForRange(range.startDate, range.endDate)

--- a/frontend/src/views/user/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/user/__tests__/DashboardView.spec.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import DashboardView from '../DashboardView.vue'
+
+const { refreshUser, getDashboardStats, getDashboardTrend, getDashboardModels, query } = vi.hoisted(() => ({
+  refreshUser: vi.fn(),
+  getDashboardStats: vi.fn(),
+  getDashboardTrend: vi.fn(),
+  getDashboardModels: vi.fn(),
+  query: vi.fn(),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { balance: 0 },
+    isSimpleMode: false,
+    refreshUser,
+  }),
+}))
+
+vi.mock('@/api/usage', () => ({
+  usageAPI: {
+    getDashboardStats,
+    getDashboardTrend,
+    getDashboardModels,
+    query,
+  },
+}))
+
+const UserDashboardChartsStub = {
+  template: '<button data-test="last24hours" @click="emitPreset">last24hours</button>',
+  methods: {
+    emitPreset() {
+      this.$emit('update:startDate', '2026-03-07')
+      this.$emit('update:endDate', '2026-03-08')
+      this.$emit('dateRangeChange', {
+        startDate: '2026-03-07',
+        endDate: '2026-03-08',
+        preset: 'last24Hours'
+      })
+    }
+  }
+}
+
+describe('user DashboardView', () => {
+  beforeEach(() => {
+    refreshUser.mockReset()
+    getDashboardStats.mockReset()
+    getDashboardTrend.mockReset()
+    getDashboardModels.mockReset()
+    query.mockReset()
+
+    refreshUser.mockResolvedValue(undefined)
+    getDashboardStats.mockResolvedValue({})
+    getDashboardTrend.mockResolvedValue({ trend: [], start_date: '', end_date: '', granularity: 'day' })
+    getDashboardModels.mockResolvedValue({ models: [], start_date: '', end_date: '' })
+    query.mockResolvedValue({ items: [], total: 0, pages: 0 })
+  })
+
+  it('uses rolling last24hours period for charts and recent usage when selected', async () => {
+    const wrapper = mount(DashboardView, {
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          LoadingSpinner: true,
+          UserDashboardStats: true,
+          UserDashboardCharts: UserDashboardChartsStub,
+          UserDashboardRecentUsage: true,
+          UserDashboardQuickActions: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    getDashboardTrend.mockClear()
+    getDashboardModels.mockClear()
+    query.mockClear()
+
+    await wrapper.get('[data-test="last24hours"]').trigger('click')
+    await flushPromises()
+
+    expect(getDashboardTrend).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      granularity: 'hour'
+    }))
+    expect(getDashboardModels).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      page_size: 5
+    }))
+  })
+})
+

--- a/frontend/src/views/user/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/user/__tests__/DashboardView.spec.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import DashboardView from '../DashboardView.vue'
+
+const { refreshUser, getDashboardStats, getDashboardTrend, getDashboardModels, query, getMyPlatformQuotas } = vi.hoisted(() => ({
+  refreshUser: vi.fn(),
+  getDashboardStats: vi.fn(),
+  getDashboardTrend: vi.fn(),
+  getDashboardModels: vi.fn(),
+  query: vi.fn(),
+  getMyPlatformQuotas: vi.fn(),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { balance: 0 },
+    isSimpleMode: false,
+    refreshUser,
+  }),
+}))
+
+vi.mock('@/api/usage', () => ({
+  usageAPI: {
+    getDashboardStats,
+    getDashboardTrend,
+    getDashboardModels,
+    query,
+  },
+}))
+
+vi.mock('@/api/user', () => ({
+  getMyPlatformQuotas,
+}))
+
+const UserDashboardChartsStub = {
+  template: '<button data-test="last24hours" @click="emitPreset">last24hours</button>',
+  methods: {
+    emitPreset() {
+      this.$emit('update:startDate', '2026-03-07')
+      this.$emit('update:endDate', '2026-03-08')
+      this.$emit('dateRangeChange', {
+        startDate: '2026-03-07',
+        endDate: '2026-03-08',
+        preset: 'last24Hours'
+      })
+    }
+  }
+}
+
+describe('user DashboardView', () => {
+  beforeEach(() => {
+    refreshUser.mockReset()
+    getDashboardStats.mockReset()
+    getDashboardTrend.mockReset()
+    getDashboardModels.mockReset()
+    query.mockReset()
+    getMyPlatformQuotas.mockReset()
+
+    refreshUser.mockResolvedValue(undefined)
+    getDashboardStats.mockResolvedValue({})
+    getDashboardTrend.mockResolvedValue({ trend: [], start_date: '', end_date: '', granularity: 'day' })
+    getDashboardModels.mockResolvedValue({ models: [], start_date: '', end_date: '' })
+    query.mockResolvedValue({ items: [], total: 0, pages: 0 })
+    getMyPlatformQuotas.mockResolvedValue({ platform_quotas: [] })
+  })
+
+  it('uses rolling last24hours period for charts and recent usage when selected', async () => {
+    const wrapper = mount(DashboardView, {
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          LoadingSpinner: true,
+          UserDashboardStats: true,
+          UserDashboardCharts: UserDashboardChartsStub,
+          UserDashboardRecentUsage: true,
+          UserDashboardQuickActions: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    getDashboardTrend.mockClear()
+    getDashboardModels.mockClear()
+    query.mockClear()
+
+    await wrapper.get('[data-test="last24hours"]').trigger('click')
+    await flushPromises()
+
+    expect(getDashboardTrend).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      granularity: 'hour'
+    }))
+    expect(getDashboardModels).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      page_size: 5
+    }))
+  })
+})

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -4,8 +4,9 @@ import { nextTick } from 'vue'
 
 import UsageView from '../UsageView.vue'
 
-const { query, getStatsByDateRange, list, showError, showWarning, showSuccess, showInfo } = vi.hoisted(() => ({
+const { query, getStats, getStatsByDateRange, list, showError, showWarning, showSuccess, showInfo } = vi.hoisted(() => ({
   query: vi.fn(),
+  getStats: vi.fn(),
   getStatsByDateRange: vi.fn(),
   list: vi.fn(),
   showError: vi.fn(),
@@ -46,6 +47,7 @@ const messages: Record<string, string> = {
 vi.mock('@/api', () => ({
   usageAPI: {
     query,
+    getStats,
     getStatsByDateRange,
   },
   keysAPI: {
@@ -75,6 +77,7 @@ const TablePageLayoutStub = {
 describe('user UsageView tooltip', () => {
   beforeEach(() => {
     query.mockReset()
+    getStats.mockReset()
     getStatsByDateRange.mockReset()
     list.mockReset()
     showError.mockReset()
@@ -181,6 +184,75 @@ describe('user UsageView tooltip', () => {
     expect(text).toContain('$0.092883')
     expect(text).toContain('$5.0000 / 1M tokens')
     expect(text).toContain('$30.0000 / 1M tokens')
+  })
+
+  it('uses rolling last24hours period when the date picker preset is selected', async () => {
+    query.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0,
+    })
+    getStats.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      total_actual_cost: 0,
+      average_duration_ms: 0,
+    })
+    getStatsByDateRange.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      total_actual_cost: 0,
+      average_duration_ms: 0,
+    })
+    list.mockResolvedValue({ items: [] })
+
+    const DateRangePickerStub = {
+      template: '<button data-test="last24hours" @click="emitPreset">last24hours</button>',
+      methods: {
+        emitPreset() {
+          this.$emit('update:startDate', '2026-03-07')
+          this.$emit('update:endDate', '2026-03-08')
+          this.$emit('change', {
+            startDate: '2026-03-07',
+            endDate: '2026-03-08',
+            preset: 'last24Hours'
+          })
+        }
+      }
+    }
+
+    const wrapper = mount(UsageView, {
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          TablePageLayout: TablePageLayoutStub,
+          Pagination: true,
+          EmptyState: true,
+          Select: true,
+          DateRangePicker: DateRangePickerStub,
+          Icon: true,
+          Teleport: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    query.mockClear()
+    getStats.mockClear()
+    getStatsByDateRange.mockClear()
+
+    await wrapper.get('[data-test="last24hours"]').trigger('click')
+    await flushPromises()
+
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }), expect.anything())
+    expect(getStats).toHaveBeenCalledWith('last24hours', undefined)
+    expect(getStatsByDateRange).not.toHaveBeenCalled()
   })
 
   it('exports csv with input and output unit price columns', async () => {

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -127,7 +127,7 @@ const usageLog = {
   stream: false,
 }
 
-function mountUsageView() {
+function mountUsageView(overrides: Record<string, any> = {}) {
   return mount(UsageView, {
     global: {
       stubs: {
@@ -142,6 +142,7 @@ function mountUsageView() {
         GroupDistributionChart: chartStub,
         EndpointDistributionChart: chartStub,
         TokenUsageTrend: chartStub,
+        ...overrides,
       },
     },
   })
@@ -205,6 +206,56 @@ describe('user UsageView', () => {
     }))
     expect(list).toHaveBeenCalledWith(1, 100)
     expect(getAvailable).toHaveBeenCalled()
+  })
+
+  it('uses rolling last24hours period when the date picker preset is selected', async () => {
+    const DateRangePickerStub = {
+      template: '<button data-test="last24hours" @click="emitPreset">last24hours</button>',
+      methods: {
+        emitPreset() {
+          this.$emit('update:startDate', '2026-03-07')
+          this.$emit('update:endDate', '2026-03-08')
+          this.$emit('change', {
+            startDate: '2026-03-07',
+            endDate: '2026-03-08',
+            preset: 'last24Hours',
+          })
+        },
+      },
+    }
+
+    const wrapper = mountUsageView({ DateRangePicker: DateRangePickerStub })
+    await flushPromises()
+
+    query.mockClear()
+    getStats.mockClear()
+    getDashboardModels.mockClear()
+    getDashboardSnapshotV2.mockClear()
+
+    await wrapper.get('[data-test="last24hours"]').trigger('click')
+    await flushPromises()
+
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }), expect.anything())
+    expect(getStats).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
+    expect(getDashboardModels).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      model_source: 'requested',
+    }))
+    expect(getDashboardSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
   })
 
   it('exports csv with current filters and without admin-only fields', async () => {


### PR DESCRIPTION
## 说明
- 修复 admin/user usage 与 dashboard 的滚动 `last24hours` 时间窗口问题
- 24 小时预设改为统一使用 `period=last24hours`，不再用仅按日期的 `start_date/end_date` 近似表示
- 补充后端与前端回归测试，覆盖滚动 24 小时窗口和时间范围响应元数据

## 验证
- GitHub Actions 已通过：`test`、`golangci-lint`、`frontend`、`backend-security`、`frontend-security`、`cla-check`
- 本地验证：
  - `go test ./internal/handler ./internal/handler/admin ./internal/pkg/timezone`
  - `pnpm exec vitest run src/views/user/__tests__/UsageView.spec.ts src/views/admin/__tests__/UsageView.spec.ts src/views/user/__tests__/DashboardView.spec.ts src/views/admin/__tests__/DashboardView.spec.ts`
