### PR TITLE
fix(payment): alipay redirect-only flow + redact provider secrets in admin API

### DIFF
--- a/backend/internal/handler/payment_handler.go
+++ b/backend/internal/handler/payment_handler.go
@@ -206,6 +206,10 @@ type CreateOrderRequest struct {
 	PaymentType string  `json:"payment_type" binding:"required"`
 	OrderType   string  `json:"order_type"`
 	PlanID      int64   `json:"plan_id"`
+	// IsMobile lets the frontend declare its mobile status directly. When
+	// nil we fall back to User-Agent heuristics (which miss iPadOS / some
+	// embedded browsers that strip the "Mobile" keyword).
+	IsMobile *bool `json:"is_mobile,omitempty"`
 }
 
 // CreateOrder creates a new payment order.
@@ -222,12 +226,16 @@ func (h *PaymentHandler) CreateOrder(c *gin.Context) {
 		return
 	}
 
+	mobile := isMobile(c)
+	if req.IsMobile != nil {
+		mobile = *req.IsMobile
+	}
 	result, err := h.paymentService.CreateOrder(c.Request.Context(), service.CreateOrderRequest{
 		UserID:      subject.UserID,
 		Amount:      req.Amount,
 		PaymentType: req.PaymentType,
 		ClientIP:    c.ClientIP(),
-		IsMobile:    isMobile(c),
+		IsMobile:    mobile,
 		SrcHost:     c.Request.Host,
 		SrcURL:      c.Request.Referer(),
 		OrderType:   req.OrderType,

--- a/backend/internal/payment/provider/alipay.go
+++ b/backend/internal/payment/provider/alipay.go
@@ -15,8 +15,8 @@ import (
 
 // Alipay product codes.
 const (
-	alipayProductCodePagePay = "FAST_INSTANT_TRADE_PAY"
 	alipayProductCodeWapPay  = "QUICK_WAP_WAY"
+	alipayProductCodePagePay = "FAST_INSTANT_TRADE_PAY"
 )
 
 // Alipay response constants.
@@ -79,7 +79,12 @@ func (a *Alipay) SupportedTypes() []payment.PaymentType {
 	return []payment.PaymentType{payment.TypeAlipay}
 }
 
-// CreatePayment creates an Alipay payment page URL.
+// CreatePayment creates an Alipay payment using redirect-only flow:
+//   - Mobile (H5): alipay.trade.wap.pay — returns a URL the browser jumps to.
+//   - PC: alipay.trade.page.pay — returns a gateway URL the browser opens in a
+//     new window; Alipay's own page then shows login/QR. We intentionally do
+//     NOT encode the URL into a QR on the client (it isn't a scannable payload
+//     and would produce an invalid scan result).
 func (a *Alipay) CreatePayment(_ context.Context, req payment.CreatePaymentRequest) (*payment.CreatePaymentResponse, error) {
 	client, err := a.getClient()
 	if err != nil {
@@ -96,31 +101,31 @@ func (a *Alipay) CreatePayment(_ context.Context, req payment.CreatePaymentReque
 	}
 
 	if req.IsMobile {
-		return a.createTrade(client, req, notifyURL, returnURL, true)
+		return a.createWapTrade(client, req, notifyURL, returnURL)
 	}
-	return a.createTrade(client, req, notifyURL, returnURL, false)
+	return a.createPagePayTrade(client, req, notifyURL, returnURL)
 }
 
-func (a *Alipay) createTrade(client *alipay.Client, req payment.CreatePaymentRequest, notifyURL, returnURL string, isMobile bool) (*payment.CreatePaymentResponse, error) {
-	if isMobile {
-		param := alipay.TradeWapPay{}
-		param.OutTradeNo = req.OrderID
-		param.TotalAmount = req.Amount
-		param.Subject = req.Subject
-		param.ProductCode = alipayProductCodeWapPay
-		param.NotifyURL = notifyURL
-		param.ReturnURL = returnURL
+func (a *Alipay) createWapTrade(client *alipay.Client, req payment.CreatePaymentRequest, notifyURL, returnURL string) (*payment.CreatePaymentResponse, error) {
+	param := alipay.TradeWapPay{}
+	param.OutTradeNo = req.OrderID
+	param.TotalAmount = req.Amount
+	param.Subject = req.Subject
+	param.ProductCode = alipayProductCodeWapPay
+	param.NotifyURL = notifyURL
+	param.ReturnURL = returnURL
 
-		payURL, err := client.TradeWapPay(param)
-		if err != nil {
-			return nil, fmt.Errorf("alipay TradeWapPay: %w", err)
-		}
-		return &payment.CreatePaymentResponse{
-			TradeNo: req.OrderID,
-			PayURL:  payURL.String(),
-		}, nil
+	payURL, err := client.TradeWapPay(param)
+	if err != nil {
+		return nil, fmt.Errorf("alipay TradeWapPay: %w", err)
 	}
+	return &payment.CreatePaymentResponse{
+		TradeNo: req.OrderID,
+		PayURL:  payURL.String(),
+	}, nil
+}
 
+func (a *Alipay) createPagePayTrade(client *alipay.Client, req payment.CreatePaymentRequest, notifyURL, returnURL string) (*payment.CreatePaymentResponse, error) {
 	param := alipay.TradePagePay{}
 	param.OutTradeNo = req.OrderID
 	param.TotalAmount = req.Amount
@@ -136,7 +141,6 @@ func (a *Alipay) createTrade(client *alipay.Client, req payment.CreatePaymentReq
 	return &payment.CreatePaymentResponse{
 		TradeNo: req.OrderID,
 		PayURL:  payURL.String(),
-		QRCode:  payURL.String(),
 	}, nil
 }
 

--- a/backend/internal/service/payment_config_providers.go
+++ b/backend/internal/service/payment_config_providers.go
@@ -51,7 +51,7 @@ func (s *PaymentConfigService) ListProviderInstancesWithConfig(ctx context.Conte
 			AllowUserRefund: inst.AllowUserRefund,
 			SortOrder:       inst.SortOrder, PaymentMode: inst.PaymentMode,
 		}
-		resp.Config, err = s.decryptAndMaskConfig(inst.Config)
+		resp.Config, err = s.decryptAndMaskConfig(inst.ProviderKey, inst.Config)
 		if err != nil {
 			return nil, fmt.Errorf("decrypt config for instance %d: %w", inst.ID, err)
 		}
@@ -60,8 +60,26 @@ func (s *PaymentConfigService) ListProviderInstancesWithConfig(ctx context.Conte
 	return result, nil
 }
 
-func (s *PaymentConfigService) decryptAndMaskConfig(encrypted string) (map[string]string, error) {
-	return s.decryptConfig(encrypted)
+// decryptAndMaskConfig returns the stored config with sensitive fields omitted.
+// Admin UIs display masked placeholders for these; the raw values never leave
+// the server. Callers that need the full config (e.g. payment runtime) must
+// use decryptConfig directly.
+func (s *PaymentConfigService) decryptAndMaskConfig(providerKey, encrypted string) (map[string]string, error) {
+	cfg, err := s.decryptConfig(encrypted)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+	masked := make(map[string]string, len(cfg))
+	for k, v := range cfg {
+		if isSensitiveProviderConfigField(providerKey, k) {
+			continue
+		}
+		masked[k] = v
+	}
+	return masked, nil
 }
 
 // pendingOrderStatuses are order statuses considered "in progress".
@@ -71,16 +89,27 @@ var pendingOrderStatuses = []string{
 	payment.OrderStatusRecharging,
 }
 
-var sensitiveConfigPatterns = []string{"key", "pkey", "secret", "private", "password"}
+// providerSensitiveConfigFields is the authoritative list of config keys that
+// are treated as secrets per provider. Must stay in sync with the frontend
+// definition at frontend/src/components/payment/providerConfig.ts
+// (PROVIDER_CONFIG_FIELDS, fields with sensitive: true).
+//
+// Key matching is case-insensitive. Non-listed keys (e.g. appId, notifyUrl,
+// stripe publishableKey) are returned in plaintext by the admin GET API.
+var providerSensitiveConfigFields = map[string]map[string]struct{}{
+	payment.TypeEasyPay: {"pkey": {}},
+	payment.TypeAlipay:  {"privatekey": {}, "publickey": {}, "alipaypublickey": {}},
+	payment.TypeWxpay:   {"privatekey": {}, "apiv3key": {}, "publickey": {}},
+	payment.TypeStripe:  {"secretkey": {}, "webhooksecret": {}},
+}
 
-func isSensitiveConfigField(fieldName string) bool {
-	lower := strings.ToLower(fieldName)
-	for _, p := range sensitiveConfigPatterns {
-		if strings.Contains(lower, p) {
-			return true
-		}
+func isSensitiveProviderConfigField(providerKey, fieldName string) bool {
+	fields, ok := providerSensitiveConfigFields[providerKey]
+	if !ok {
+		return false
 	}
-	return false
+	_, found := fields[strings.ToLower(fieldName)]
+	return found
 }
 
 func (s *PaymentConfigService) countPendingOrders(ctx context.Context, providerInstanceID int64) (int, error) {
@@ -136,10 +165,26 @@ func validateProviderRequest(providerKey, name, supportedTypes string) error {
 // NOTE: This function exceeds 30 lines due to per-field nil-check patch update
 // boilerplate and pending-order safety checks.
 func (s *PaymentConfigService) UpdateProviderInstance(ctx context.Context, id int64, req UpdateProviderInstanceRequest) (*dbent.PaymentProviderInstance, error) {
+	var cachedInst *dbent.PaymentProviderInstance
+	loadInst := func() (*dbent.PaymentProviderInstance, error) {
+		if cachedInst != nil {
+			return cachedInst, nil
+		}
+		inst, err := s.entClient.PaymentProviderInstance.Get(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("load provider instance: %w", err)
+		}
+		cachedInst = inst
+		return inst, nil
+	}
 	if req.Config != nil {
+		inst, err := loadInst()
+		if err != nil {
+			return nil, err
+		}
 		hasSensitive := false
-		for k := range req.Config {
-			if isSensitiveConfigField(k) && req.Config[k] != "" {
+		for k, v := range req.Config {
+			if v != "" && isSensitiveProviderConfigField(inst.ProviderKey, k) {
 				hasSensitive = true
 				break
 			}
@@ -282,9 +327,14 @@ func (s *PaymentConfigService) mergeConfig(ctx context.Context, id int64, newCon
 		return nil, fmt.Errorf("decrypt existing config for instance %d: %w", id, err)
 	}
 	if existing == nil {
-		return newConfig, nil
+		existing = map[string]string{}
 	}
 	for k, v := range newConfig {
+		// Preserve existing secrets when the client submits an empty value
+		// (admin UI omits the value to indicate "leave unchanged").
+		if v == "" && isSensitiveProviderConfigField(inst.ProviderKey, k) {
+			continue
+		}
 		existing[k] = v
 	}
 	return existing, nil

--- a/backend/internal/service/payment_config_providers_test.go
+++ b/backend/internal/service/payment_config_providers_test.go
@@ -97,41 +97,52 @@ func TestValidateProviderRequest(t *testing.T) {
 	}
 }
 
-func TestIsSensitiveConfigField(t *testing.T) {
+func TestIsSensitiveProviderConfigField(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		field   string
-		wantSen bool
+		providerKey string
+		field       string
+		wantSen     bool
 	}{
-		// Sensitive fields (contain key/secret/private/password/pkey patterns)
-		{"secretKey", true},
-		{"apiSecret", true},
-		{"pkey", true},
-		{"privateKey", true},
-		{"apiPassword", true},
-		{"appKey", true},
-		{"SECRET_TOKEN", true},
-		{"PrivateData", true},
-		{"PASSWORD", true},
-		{"mySecretValue", true},
+		// Stripe: publishableKey is public, only secretKey/webhookSecret are secrets
+		{"stripe", "secretKey", true},
+		{"stripe", "webhookSecret", true},
+		{"stripe", "SecretKey", true}, // case-insensitive
+		{"stripe", "publishableKey", false},
+		{"stripe", "appId", false},
 
-		// Non-sensitive fields
-		{"appId", false},
-		{"mchId", false},
-		{"apiBase", false},
-		{"endpoint", false},
-		{"merchantNo", false},
-		{"paymentMode", false},
-		{"notifyUrl", false},
+		// Alipay
+		{"alipay", "privateKey", true},
+		{"alipay", "publicKey", true},
+		{"alipay", "alipayPublicKey", true},
+		{"alipay", "appId", false},
+		{"alipay", "notifyUrl", false},
+
+		// Wxpay
+		{"wxpay", "privateKey", true},
+		{"wxpay", "apiV3Key", true},
+		{"wxpay", "publicKey", true},
+		{"wxpay", "publicKeyId", false},
+		{"wxpay", "certSerial", false},
+		{"wxpay", "mchId", false},
+
+		// EasyPay
+		{"easypay", "pkey", true},
+		{"easypay", "pid", false},
+		{"easypay", "apiBase", false},
+
+		// Unknown provider: never sensitive
+		{"unknown", "secretKey", false},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.field, func(t *testing.T) {
+		tc := tc
+		t.Run(tc.providerKey+"/"+tc.field, func(t *testing.T) {
 			t.Parallel()
 
-			got := isSensitiveConfigField(tc.field)
-			assert.Equal(t, tc.wantSen, got, "isSensitiveConfigField(%q)", tc.field)
+			got := isSensitiveProviderConfigField(tc.providerKey, tc.field)
+			assert.Equal(t, tc.wantSen, got, "isSensitiveProviderConfigField(%q, %q)", tc.providerKey, tc.field)
 		})
 	}
 }

--- a/frontend/src/components/payment/PaymentProviderDialog.vue
+++ b/frontend/src/components/payment/PaymentProviderDialog.vue
@@ -88,13 +88,24 @@
               v-model="config[field.key]"
               rows="3"
               class="input font-mono text-xs"
+              autocomplete="new-password"
+              data-1p-ignore
+              data-lpignore="true"
+              data-bwignore="true"
+              spellcheck="false"
+              :placeholder="editing ? t('admin.accounts.leaveEmptyToKeep') : ''"
             />
             <div v-else-if="field.sensitive" class="relative">
               <input
                 :type="visibleFields[field.key] ? 'text' : 'password'"
                 v-model="config[field.key]"
                 class="input pr-10"
-                :placeholder="field.defaultValue || ''"
+                autocomplete="new-password"
+                data-1p-ignore
+                data-lpignore="true"
+                data-bwignore="true"
+                spellcheck="false"
+                :placeholder="editing ? t('admin.accounts.leaveEmptyToKeep') : (field.defaultValue || '')"
               />
               <button
                 type="button"
@@ -398,9 +409,12 @@ function handleSave() {
     emitValidationError(t('admin.settings.payment.validationNameRequired'))
     return
   }
-  // Validate required config fields — all non-optional fields must be filled
+  // Validate required config fields — all non-optional fields must be filled.
+  // In edit mode, sensitive fields may be left blank to preserve the stored
+  // value (backend merges blanks by preserving the existing secret).
   for (const f of PROVIDER_CONFIG_FIELDS[form.provider_key] || []) {
     if (f.optional) continue
+    if (props.editing && f.sensitive) continue
     const val = (config[f.key] || '').trim()
     if (!val) {
       const label = f.label || t(`admin.settings.payment.field_${f.key}`)
@@ -412,8 +426,6 @@ function handleSave() {
   const filteredConfig: Record<string, string> = {}
   for (const [k, v] of Object.entries(config)) {
     if (!v || !v.trim()) continue
-    // Skip masked values — backend keeps existing credentials
-    if (v === '••••••••') continue
     filteredConfig[k] = v
   }
 
@@ -470,7 +482,8 @@ function loadProvider(provider: ProviderInstance) {
   form.refund_enabled = provider.refund_enabled
   form.allow_user_refund = provider.allow_user_refund
   clearConfig()
-  // Pre-fill config from API response (non-sensitive in cleartext, sensitive masked as ••••••••)
+  // Pre-fill config from API response. Backend omits sensitive fields entirely,
+  // so those inputs stay blank — submitting blank preserves the stored secret.
   if (provider.config) {
     for (const [k, v] of Object.entries(provider.config)) {
       // Skip notifyUrl/returnUrl — they are derived from callbackBaseUrl

--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -79,7 +79,7 @@ import { usePaymentStore } from '@/stores/payment'
 import { useAppStore } from '@/stores'
 import { paymentAPI } from '@/api/payment'
 import { extractApiErrorMessage } from '@/utils/apiError'
-import { POPUP_WINDOW_FEATURES } from '@/components/payment/providerConfig'
+import { getPaymentPopupFeatures } from '@/components/payment/providerConfig'
 import type { PaymentOrder } from '@/types/payment'
 import QRCode from 'qrcode'
 import alipayIcon from '@/assets/icons/alipay.svg'
@@ -147,7 +147,7 @@ function getLogoForType(): string | null {
 
 function reopenPopup() {
   if (props.payUrl) {
-    window.open(props.payUrl, 'paymentPopup', POPUP_WINDOW_FEATURES)
+    window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
   }
 }
 

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -125,7 +125,7 @@ import { usePaymentStore } from '@/stores/payment'
 import { useAppStore } from '@/stores'
 import { paymentAPI } from '@/api/payment'
 import { extractApiErrorMessage } from '@/utils/apiError'
-import { POPUP_WINDOW_FEATURES } from '@/components/payment/providerConfig'
+import { getPaymentPopupFeatures } from '@/components/payment/providerConfig'
 import type { PaymentOrder } from '@/types/payment'
 import Icon from '@/components/icons/Icon.vue'
 import QRCode from 'qrcode'
@@ -194,7 +194,7 @@ const countdownDisplay = computed(() => {
 
 function reopenPopup() {
   if (props.payUrl) {
-    window.open(props.payUrl, 'paymentPopup', POPUP_WINDOW_FEATURES)
+    window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
   }
 }
 

--- a/frontend/src/components/payment/StripePaymentInline.vue
+++ b/frontend/src/components/payment/StripePaymentInline.vue
@@ -70,7 +70,7 @@ import { useRouter } from 'vue-router'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { paymentAPI } from '@/api/payment'
 import { useAppStore } from '@/stores'
-import { STRIPE_POPUP_WINDOW_FEATURES } from '@/components/payment/providerConfig'
+import { getPaymentPopupFeatures } from '@/components/payment/providerConfig'
 import type { Stripe, StripeElements } from '@stripe/stripe-js'
 import Icon from '@/components/icons/Icon.vue'
 
@@ -151,7 +151,7 @@ async function handlePay() {
         amount: String(props.payAmount),
       },
     }).href
-    const popup = window.open(popupUrl, 'paymentPopup', STRIPE_POPUP_WINDOW_FEATURES)
+    const popup = window.open(popupUrl, 'paymentPopup', getPaymentPopupFeatures())
 
     const onReady = (event: MessageEvent) => {
       if (event.source !== popup || event.data?.type !== 'STRIPE_POPUP_READY') return

--- a/frontend/src/components/payment/providerConfig.ts
+++ b/frontend/src/components/payment/providerConfig.ts
@@ -43,11 +43,24 @@ export const METHOD_ORDER = ['alipay', 'alipay_direct', 'wxpay', 'wxpay_direct',
 export const PAYMENT_MODE_QRCODE = 'qrcode'
 export const PAYMENT_MODE_POPUP = 'popup'
 
-/** Window features for payment popup windows */
-export const POPUP_WINDOW_FEATURES = 'width=1000,height=750,left=100,top=80,scrollbars=yes,resizable=yes'
+/** Preferred popup size for payment gateways. Alipay's standard checkout
+ * (QR + account login panel) needs ~1200×900 to render without any scrolling. */
+const PAYMENT_POPUP_PREFERRED_WIDTH = 1250
+const PAYMENT_POPUP_PREFERRED_HEIGHT = 900
 
-/** Wider popup for Stripe redirect methods (Alipay checkout page needs ~1200px) */
-export const STRIPE_POPUP_WINDOW_FEATURES = 'width=1250,height=780,left=80,top=60,scrollbars=yes,resizable=yes'
+/** Build a window.open features string sized to fit within the current screen
+ * while preferring the above dimensions. Centers the popup on the available
+ * work area so nothing is clipped on smaller laptop displays. */
+export function getPaymentPopupFeatures(): string {
+  const screen = typeof window !== 'undefined' ? window.screen : null
+  const availW = screen?.availWidth ?? PAYMENT_POPUP_PREFERRED_WIDTH
+  const availH = screen?.availHeight ?? PAYMENT_POPUP_PREFERRED_HEIGHT
+  const width = Math.min(PAYMENT_POPUP_PREFERRED_WIDTH, availW - 40)
+  const height = Math.min(PAYMENT_POPUP_PREFERRED_HEIGHT, availH - 40)
+  const left = Math.max(0, Math.floor((availW - width) / 2))
+  const top = Math.max(0, Math.floor((availH - height) / 2))
+  return `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+}
 
 /** Webhook paths for each provider (relative to origin). */
 export const WEBHOOK_PATHS: Record<string, string> = {

--- a/frontend/src/types/payment.ts
+++ b/frontend/src/types/payment.ts
@@ -154,6 +154,7 @@ export interface CreateOrderRequest {
   payment_type: string
   order_type: string
   plan_id?: number
+  is_mobile?: boolean
 }
 
 export interface CreateOrderResult {

--- a/frontend/src/views/user/PaymentView.vue
+++ b/frontend/src/views/user/PaymentView.vue
@@ -277,7 +277,7 @@ import type { SubscriptionPlan, CheckoutInfoResponse, OrderType } from '@/types/
 import AppLayout from '@/components/layout/AppLayout.vue'
 import AmountInput from '@/components/payment/AmountInput.vue'
 import PaymentMethodSelector from '@/components/payment/PaymentMethodSelector.vue'
-import { METHOD_ORDER, POPUP_WINDOW_FEATURES } from '@/components/payment/providerConfig'
+import { METHOD_ORDER, getPaymentPopupFeatures } from '@/components/payment/providerConfig'
 import { platformAccentBarClass, platformBadgeLightClass, platformBadgeClass, platformTextClass, platformLabel } from '@/utils/platformColors'
 import SubscriptionPlanCard from '@/components/payment/SubscriptionPlanCard.vue'
 import PaymentStatusPanel from '@/components/payment/PaymentStatusPanel.vue'
@@ -551,9 +551,10 @@ async function createOrder(orderAmount: number, orderType: OrderType, planId?: n
       payment_type: selectedMethod.value,
       order_type: orderType,
       plan_id: planId,
+      is_mobile: isMobileDevice(),
     })
     const openWindow = (url: string) => {
-      const win = window.open(url, 'paymentPopup', POPUP_WINDOW_FEATURES)
+      const win = window.open(url, 'paymentPopup', getPaymentPopupFeatures())
       if (!win || win.closed) {
         window.location.href = url
       }


### PR DESCRIPTION
## 背景 / Background

本地 Alipay provider 之前把支付页 URL 塞进二维码展示，但该 URL 不是可扫描载荷，二维码扫出来无效；同时部分嵌入浏览器和 iPadOS 13+ 的 UA 嗅探会误判，把 H5 场景路由到 PC 流，popup 窗口也装不下 Alipay 标准收银台（二维码 + 右侧账号登录），用户需要横纵向滚动。另外 `GET /api/v1/admin/payment/providers` 把 `privateKey` / `apiV3Key` / `secretKey` 等敏感字段全量明文返回给 admin UI，admin 端一旦 XSS，所有生产支付凭证会被一次性拿走。

The native Alipay provider embedded the gateway URL into a client-side QR code, but that URL is not a scannable payload — the QR never worked. UA sniffing also missed iPadOS 13+ and some embedded browsers, routing mobile users to the PC flow, and the popup window was too small for Alipay's standard checkout layout (QR + side login panel), forcing horizontal and vertical scrolling. Separately, `GET /api/v1/admin/payment/providers` returned every config value — including `privateKey` / `apiV3Key` / `secretKey` — verbatim, so any XSS on the admin UI would hand attackers the full set of production payment credentials.

---

## 目的 / Purpose

让 Alipay 走原生跳转流（PC page-pay、H5 wap-pay），客户端不再渲染二维码；popup 尺寸按 Alipay 收银台实际占位确定并按屏幕夹紧居中；admin 配置接口脱敏所有敏感字段，编辑态把"空值 = 保持不变"，这样操作员可以只改非敏感设置而无需重输凭证。

Switch Alipay to its native redirect flows (PC page-pay, H5 wap-pay) so the client never renders a QR itself; size the popup to Alipay's real checkout footprint, clamped and centered against the available screen. Redact sensitive fields from the admin config API, and treat empty values as "leave unchanged" in edit mode so operators can tweak non-sensitive settings without re-entering credentials.

---

## 改动内容 / Changes

### 后端 / Backend

- **`backend/internal/payment/provider/alipay.go`**：去掉 QR-on-URL 路径，PC 用 `alipay.trade.page.pay`，H5 用 `alipay.trade.wap.pay`，都返回网关 URL 让浏览器新窗口打开或跳转
- **`backend/internal/handler/payment_handler.go`**：`CreateOrderRequest` 新增可选 `is_mobile`，允许前端显式声明设备；缺省时仍回退到 UA 嗅探
- **`backend/internal/service/payment_config_providers.go`**：新增按 provider 列举的敏感字段注册表（alipay: `privateKey`/`publicKey`/`alipayPublicKey`；wxpay: `privateKey`/`apiV3Key`/`publicKey`；stripe: `secretKey`/`webhookSecret`；easypay: `pkey`），`decryptAndMaskConfig` 在 admin GET 响应中脱敏这些字段，`mergeConfig` 将空值视为"保持不变"；支付运行时仍走 `decryptConfig` 读全量，gateway 行为不变
- **`backend/internal/service/payment_config_providers_test.go`**：单测改名 `TestIsSensitiveProviderConfigField`，覆盖 provider 注册表并断言 Stripe `publishableKey` 不被当作 secret

---

- **`backend/internal/payment/provider/alipay.go`**: Drop the QR-on-URL path. Use `alipay.trade.page.pay` for PC and `alipay.trade.wap.pay` for H5 — both return a gateway URL the browser opens in a new window or navigates to.
- **`backend/internal/handler/payment_handler.go`**: Add optional `is_mobile` to `CreateOrderRequest` so the frontend can declare the device explicitly; server still falls back to UA sniffing when absent.
- **`backend/internal/service/payment_config_providers.go`**: Add a per-provider registry of sensitive fields (alipay: `privateKey`/`publicKey`/`alipayPublicKey`; wxpay: `privateKey`/`apiV3Key`/`publicKey`; stripe: `secretKey`/`webhookSecret`; easypay: `pkey`). `decryptAndMaskConfig` strips them from the admin GET response; `mergeConfig` treats an empty value on these keys as "leave unchanged". Payment runtime still reads the full config via `decryptConfig` — gateway behavior unchanged.
- **`backend/internal/service/payment_config_providers_test.go`**: Renamed to `TestIsSensitiveProviderConfigField`; covers the provider registry and explicitly asserts Stripe `publishableKey` is NOT treated as a secret.

### 前端 / Frontend

- **`frontend/src/types/payment.ts` / `views/user/PaymentView.vue`**：`CreateOrderRequest` 新增 `is_mobile` 字段，下单时传 `isMobileDevice()` 计算值
- **`frontend/src/components/payment/providerConfig.ts`**：用 `getPaymentPopupFeatures()` 替换两个固定 `POPUP_WINDOW_FEATURES` 常量，优先 1250×900（Alipay 收银台尺寸），按 `window.screen.avail*` 夹紧并居中
- **`frontend/src/components/payment/PaymentQRDialog.vue` / `PaymentStatusPanel.vue` / `StripePaymentInline.vue` / `PaymentView.vue`**：所有 popup 调用点统一走新 helper
- **`frontend/src/components/payment/PaymentProviderDialog.vue`**：secret 输入框加 `autocomplete="new-password"` / `data-1p-ignore` / `data-lpignore` / `data-bwignore`，避免密码管理器保存；编辑态必填校验跳过敏感字段（空=保留原值），占位符显示"留空保持不变"；新建态仍要求所有非可选字段

---

- **`frontend/src/types/payment.ts` / `views/user/PaymentView.vue`**: Add `is_mobile` to `CreateOrderRequest`; pass the computed `isMobileDevice()` value when creating orders.
- **`frontend/src/components/payment/providerConfig.ts`**: Replace the two fixed `POPUP_WINDOW_FEATURES` constants with `getPaymentPopupFeatures()` — prefers 1250×900 (Alipay checkout footprint), clamps to `window.screen.avail*`, and centers the popup so it never overflows small laptops.
- **`frontend/src/components/payment/PaymentQRDialog.vue` / `PaymentStatusPanel.vue` / `StripePaymentInline.vue` / `PaymentView.vue`**: Use the new helper at all popup call sites.
- **`frontend/src/components/payment/PaymentProviderDialog.vue`**: Secret inputs get `autocomplete="new-password"` / `data-1p-ignore` / `data-lpignore` / `data-bwignore` so password managers do not offer to save provider credentials. In edit mode the required-field check skips sensitive fields (empty = keep existing) and the placeholder shows "leave empty to keep"; create mode still requires every non-optional field.
