### PR TITLE
fix(account): 修复上游账号超出设置限额后仍继续调度问题

### DIFF
--- a/backend/internal/handler/dto/account_mapper_schedulable_test.go
+++ b/backend/internal/handler/dto/account_mapper_schedulable_test.go
@@ -1,0 +1,51 @@
+package dto
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountFromServiceShallow_UsesRuntimeSchedulableWhenQuotaExceeded(t *testing.T) {
+	account := &service.Account{
+		ID:          1,
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeAPIKey,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{
+			"quota_daily_limit": 10.0,
+			"quota_daily_used":  10.0,
+			"quota_daily_start": time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	got := AccountFromServiceShallow(account)
+	require.NotNil(t, got)
+	require.False(t, got.Schedulable)
+	require.NotNil(t, got.QuotaDailyUsed)
+	require.Equal(t, 10.0, *got.QuotaDailyUsed)
+}
+
+func TestAccountFromServiceShallow_ExpiredQuotaPeriodRestoresSchedulableAndZeroesUsed(t *testing.T) {
+	account := &service.Account{
+		ID:          2,
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeAPIKey,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{
+			"quota_weekly_limit": 10.0,
+			"quota_weekly_used":  10.0,
+			"quota_weekly_start": time.Now().Add(-8 * 24 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	got := AccountFromServiceShallow(account)
+	require.NotNil(t, got)
+	require.True(t, got.Schedulable)
+	require.NotNil(t, got.QuotaWeeklyUsed)
+	require.Equal(t, 0.0, *got.QuotaWeeklyUsed)
+}

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -211,7 +211,7 @@ func AccountFromServiceShallow(a *service.Account) *Account {
 		AutoPauseOnExpired:      a.AutoPauseOnExpired,
 		CreatedAt:               a.CreatedAt,
 		UpdatedAt:               a.UpdatedAt,
-		Schedulable:             a.Schedulable,
+		Schedulable:             a.IsSchedulable(),
 		RateLimitedAt:           a.RateLimitedAt,
 		RateLimitResetAt:        a.RateLimitResetAt,
 		OverloadUntil:           a.OverloadUntil,

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -121,6 +121,9 @@ func (a *Account) IsSchedulable() bool {
 	if a.TempUnschedulableUntil != nil && now.Before(*a.TempUnschedulableUntil) {
 		return false
 	}
+	if a.IsAPIKeyOrBedrock() && a.IsQuotaExceeded() {
+		return false
+	}
 	return true
 }
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -435,14 +435,15 @@ func prefetchedStickyAccountIDFromContext(ctx context.Context, groupID *int64) i
 }
 
 // shouldClearStickySession 检查账号是否处于不可调度状态，需要清理粘性会话绑定。
-// 当账号状态为错误、禁用、不可调度、处于临时不可调度期间，
+// 当账号状态为错误/禁用、手动不可调度、处于临时不可调度期间、配额超限，
 // 或请求的模型处于限流状态时，返回 true。
 // 这确保后续请求不会继续使用不可用的账号。
 //
 // shouldClearStickySession checks if an account is in an unschedulable state
 // and the sticky session binding should be cleared.
 // Returns true when account status is error/disabled, schedulable is false,
-// within temporary unschedulable period, or the requested model is rate-limited.
+// within temporary unschedulable period, quota is exceeded, or the requested
+// model is rate-limited.
 // This ensures subsequent requests won't continue using unavailable accounts.
 func shouldClearStickySession(account *Account, requestedModel string) bool {
 	if account == nil {
@@ -452,6 +453,9 @@ func shouldClearStickySession(account *Account, requestedModel string) bool {
 		return true
 	}
 	if account.TempUnschedulableUntil != nil && time.Now().Before(*account.TempUnschedulableUntil) {
+		return true
+	}
+	if account.IsAPIKeyOrBedrock() && account.IsQuotaExceeded() {
 		return true
 	}
 	// 检查模型限流和 scope 限流，有限流即清除粘性会话

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -114,6 +114,49 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyDBRuntimeR
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 }
 
+func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyQuotaExceededFallsBackToFreshCandidate(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(10105)
+	staleSticky := &Account{ID: 33101, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0}
+	staleBackup := &Account{ID: 33102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5}
+	dbSticky := Account{
+		ID:          33101,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		Extra: map[string]any{
+			"quota_daily_limit": 10.0,
+			"quota_daily_used":  10.0,
+			"quota_daily_start": time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+	dbBackup := Account{ID: 33102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5}
+	cache := &stubGatewayCache{sessionBindings: map[string]int64{"openai:session_hash_quota_runtime_recheck": 33101}}
+	snapshotCache := &openAISnapshotCacheStub{
+		snapshotAccounts: []*Account{staleSticky, staleBackup},
+		accountsByID:     map[int64]*Account{33101: staleSticky, 33102: staleBackup},
+	}
+	snapshotService := &SchedulerSnapshotService{cache: snapshotCache}
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{dbSticky, dbBackup}},
+		cache:              cache,
+		cfg:                &config.Config{},
+		schedulerSnapshot:  snapshotService,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "session_hash_quota_runtime_recheck", "gpt-5.1", nil, OpenAIUpstreamTransportAny)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(33102), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.Equal(t, 1, cache.deletedSessions["openai:session_hash_quota_runtime_recheck"])
+}
+
 func TestOpenAIGatewayService_SelectAccountForModelWithExclusions_DBRuntimeRecheckSkipsStaleCachedCandidate(t *testing.T) {
 	ctx := context.Background()
 	groupID := int64(10104)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -426,6 +426,22 @@ func TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulableWhenNoConcurre
 	}
 }
 
+func TestAccountIsSchedulable_QuotaExceededForAPIKey(t *testing.T) {
+	account := &Account{
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Extra: map[string]any{
+			"quota_daily_limit": 10.0,
+			"quota_daily_used":  10.0,
+			"quota_daily_start": time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	require.False(t, account.IsSchedulable())
+}
+
 func TestOpenAISelectAccountForModelWithExclusions_StickyUnschedulableClearsSession(t *testing.T) {
 	sessionHash := "session-1"
 	repo := stubOpenAIAccountRepo{
@@ -456,6 +472,43 @@ func TestOpenAISelectAccountForModelWithExclusions_StickyUnschedulableClearsSess
 	if cache.sessionBindings["openai:"+sessionHash] != 2 {
 		t.Fatalf("expected sticky session to bind to account 2")
 	}
+}
+
+func TestOpenAISelectAccountForModelWithExclusions_StickyQuotaExceededClearsSession(t *testing.T) {
+	sessionHash := "session-quota-no-concurrency"
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:          1,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			{ID: 2, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1},
+		},
+	}
+	cache := &stubGatewayCache{
+		sessionBindings: map[string]int64{"openai:" + sessionHash: 1},
+	}
+
+	svc := &OpenAIGatewayService{
+		accountRepo: repo,
+		cache:       cache,
+	}
+
+	acc, err := svc.SelectAccountForModelWithExclusions(context.Background(), nil, sessionHash, "gpt-4", nil)
+	require.NoError(t, err)
+	require.NotNil(t, acc)
+	require.Equal(t, int64(2), acc.ID)
+	require.Equal(t, 1, cache.deletedSessions["openai:"+sessionHash])
+	require.Equal(t, int64(2), cache.sessionBindings["openai:"+sessionHash])
 }
 
 func TestOpenAISelectAccountWithLoadAwareness_StickyUnschedulableClearsSession(t *testing.T) {
@@ -490,6 +543,49 @@ func TestOpenAISelectAccountWithLoadAwareness_StickyUnschedulableClearsSession(t
 	if cache.sessionBindings["openai:"+sessionHash] != 2 {
 		t.Fatalf("expected sticky session to bind to account 2")
 	}
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAISelectAccountWithLoadAwareness_StickyQuotaExceededClearsSession(t *testing.T) {
+	sessionHash := "session-quota-load-aware"
+	groupID := int64(1)
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:          1,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			{ID: 2, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1},
+		},
+	}
+	cache := &stubGatewayCache{
+		sessionBindings: map[string]int64{"openai:" + sessionHash: 1},
+	}
+
+	svc := &OpenAIGatewayService{
+		accountRepo:        repo,
+		cache:              cache,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, sessionHash, "gpt-4", nil)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(2), selection.Account.ID)
+	require.Equal(t, 1, cache.deletedSessions["openai:"+sessionHash])
+	require.Equal(t, int64(2), cache.sessionBindings["openai:"+sessionHash])
 	if selection.ReleaseFunc != nil {
 		selection.ReleaseFunc()
 	}

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -217,6 +217,18 @@ const activeModelStatuses = computed<AccountModelStatusItem[]>(() => {
   return items
 })
 
+const isQuotaExceeded = computed(() => {
+  const exceedsQuota = (used?: number | null, limit?: number | null) => {
+    return typeof limit === 'number' && limit > 0 && typeof used === 'number' && used >= limit
+  }
+
+  return (
+    exceedsQuota(props.account.quota_used, props.account.quota_limit) ||
+    exceedsQuota(props.account.quota_daily_used, props.account.quota_daily_limit) ||
+    exceedsQuota(props.account.quota_weekly_used, props.account.quota_weekly_limit)
+  )
+})
+
 const formatScopeName = (scope: string): string => {
   const aliases: Record<string, string> = {
     // Claude 系列
@@ -307,19 +319,23 @@ const statusClass = computed(() => {
   if (isTempUnschedulable.value) {
     return 'badge-warning'
   }
+  if (props.account.status !== 'active') {
+    switch (props.account.status) {
+      case 'inactive':
+        return 'badge-gray'
+      case 'error':
+        return 'badge-danger'
+      default:
+        return 'badge-gray'
+    }
+  }
+  if (isQuotaExceeded.value) {
+    return 'badge-warning'
+  }
   if (!props.account.schedulable) {
     return 'badge-gray'
   }
-  switch (props.account.status) {
-    case 'active':
-      return 'badge-success'
-    case 'inactive':
-      return 'badge-gray'
-    case 'error':
-      return 'badge-danger'
-    default:
-      return 'badge-gray'
-  }
+  return 'badge-success'
 })
 
 // Computed: status text
@@ -329,6 +345,12 @@ const statusText = computed(() => {
   }
   if (isTempUnschedulable.value) {
     return t('admin.accounts.status.tempUnschedulable')
+  }
+  if (props.account.status !== 'active') {
+    return t(`admin.accounts.status.${props.account.status}`)
+  }
+  if (isQuotaExceeded.value) {
+    return t('admin.accounts.status.quotaExceeded')
   }
   if (!props.account.schedulable) {
     return t('admin.accounts.status.paused')

--- a/frontend/src/components/account/__tests__/AccountStatusIndicator.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountStatusIndicator.spec.ts
@@ -122,7 +122,7 @@ describe('AccountStatusIndicator', () => {
       }
     })
 
-    expect(wrapper.text()).toContain('account.creditsExhausted')
+    expect(wrapper.text()).toContain('admin.accounts.status.creditsExhausted')
   })
 
   it('模型限流 + overages 启用 + AICredits key 生效 → 普通限流样式（积分耗尽，无 ⚡）', () => {
@@ -157,6 +157,65 @@ describe('AccountStatusIndicator', () => {
     expect(wrapper.text()).toContain('CSon45')
     expect(wrapper.text()).not.toContain('⚡')
     // AICredits 积分耗尽状态应显示
-    expect(wrapper.text()).toContain('account.creditsExhausted')
+    expect(wrapper.text()).toContain('admin.accounts.status.creditsExhausted')
+  })
+
+  it('quota 超限时优先显示 quota exceeded，而不是 paused', () => {
+    const wrapper = mount(AccountStatusIndicator, {
+      props: {
+        account: makeAccount({
+          schedulable: false,
+          quota_daily_limit: 10,
+          quota_daily_used: 10,
+        })
+      },
+      global: {
+        stubs: {
+          Icon: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('admin.accounts.status.quotaExceeded')
+    expect(wrapper.text()).not.toContain('admin.accounts.status.paused')
+  })
+
+  it('非 quota 原因的不可调度继续显示 paused', () => {
+    const wrapper = mount(AccountStatusIndicator, {
+      props: {
+        account: makeAccount({
+          schedulable: false,
+          quota_daily_limit: 10,
+          quota_daily_used: 0,
+        })
+      },
+      global: {
+        stubs: {
+          Icon: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('admin.accounts.status.paused')
+    expect(wrapper.text()).not.toContain('admin.accounts.status.quotaExceeded')
+  })
+
+  it('inactive 账号保持显示 inactive，而不是 paused', () => {
+    const wrapper = mount(AccountStatusIndicator, {
+      props: {
+        account: makeAccount({
+          status: 'inactive',
+          schedulable: false,
+        })
+      },
+      global: {
+        stubs: {
+          Icon: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('admin.accounts.status.inactive')
+    expect(wrapper.text()).not.toContain('admin.accounts.status.paused')
   })
 })

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2126,6 +2126,7 @@ export default {
         rateLimited: 'Rate Limited',
         overloaded: 'Overloaded',
         tempUnschedulable: 'Temp Unschedulable',
+        quotaExceeded: 'Quota Exceeded',
         unschedulable: 'Unschedulable',
         rateLimitedUntil: 'Rate limited and removed from scheduling. Auto resumes at {time}',
         rateLimitedAutoResume: 'Auto resumes in {time}',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2315,6 +2315,7 @@ export default {
         rateLimited: '限流中',
         overloaded: '过载中',
         tempUnschedulable: '临时不可调度',
+        quotaExceeded: '配额超限',
         unschedulable: '不可调度',
         rateLimitedUntil: '限流中，当前不参与调度，预计 {time} 自动恢复',
         rateLimitedAutoResume: '{time} 自动恢复',


### PR DESCRIPTION
This pull request enhances how account quota exceedance is handled and displayed throughout both backend and frontend. The main improvements ensure that accounts exceeding their quota are marked as unschedulable in the backend and that this state is clearly surfaced in the UI, with new tests added to cover these scenarios.

**Backend: Quota Exceedance Handling**

- Accounts are now considered unschedulable if they are API key or Bedrock accounts and have exceeded their quota, by updating the `IsSchedulable` method and its usage in account mapping and session logic. [[1]](diffhunk://#diff-b2852a407acd66f46b98b64f86f8db31356a8b2c5f61fdeff689b4ed7093bc66R124-R126) [[2]](diffhunk://#diff-187e4346a2d1c5b321a1c6da2136aa077e3ebab42f380a551495a1ab10e18386L214-R214) [[3]](diffhunk://#diff-bcd1c56a1e66062537c0479e0cfafdd1a805e2ec91693e2629f12fcd956c7516R458-R460)
- The sticky session logic now clears sessions if an account has exceeded its quota, ensuring requests do not continue to use unavailable accounts.
- New and updated tests verify that quota-exceeded accounts are handled correctly in account selection and session stickiness. [[1]](diffhunk://#diff-8eea7782434144f86a33b282f963d101f0031673b3acdb5e820026e52fa8b35fR1-R51) [[2]](diffhunk://#diff-18be0d87936b6271990caadd172a067794dcc4f44ca71fb048a9067e591eb288R117-R159) [[3]](diffhunk://#diff-860ae049876892f0a8bacc0455b137234044e4a1aaac6dd1e88a7bd895e0cec3R429-R444) [[4]](diffhunk://#diff-860ae049876892f0a8bacc0455b137234044e4a1aaac6dd1e88a7bd895e0cec3R477-R513) [[5]](diffhunk://#diff-860ae049876892f0a8bacc0455b137234044e4a1aaac6dd1e88a7bd895e0cec3R551-R593)

**Frontend: UI and Localization Updates**

- The account status indicator now detects quota-exceeded states and displays a specific "Quota Exceeded" badge and status, with priority over the generic "paused" state. [[1]](diffhunk://#diff-4ef9552ec19b904a684313ee4a94a8272e25eab482002c659d96dab51b8d6590R220-R231) [[2]](diffhunk://#diff-4ef9552ec19b904a684313ee4a94a8272e25eab482002c659d96dab51b8d6590L310-R338) [[3]](diffhunk://#diff-4ef9552ec19b904a684313ee4a94a8272e25eab482002c659d96dab51b8d6590R349-R354)
- Localization strings for "Quota Exceeded" have been added in both English and Chinese. [[1]](diffhunk://#diff-382b563bbde3e617c465540df9742be0f40e3839bb8d80f566a02500659a17a4R2129) [[2]](diffhunk://#diff-ef5bd00de3107c0411b462dbf0eb41d621e803533bc9e7487f75fff2b1ed9097R2318)
- Unit tests have been added to ensure the UI displays the correct status for quota-exceeded and other unschedulable scenarios. [[1]](diffhunk://#diff-52cf19e52cad5c07530060fa8196966b95bfd0270c7665f19f263b922bfe59bdL125-R125) [[2]](diffhunk://#diff-52cf19e52cad5c07530060fa8196966b95bfd0270c7665f19f263b922bfe59bdL160-R219)

These changes collectively improve the accuracy and clarity of account status handling, especially around quota limits, for both backend logic and end-user visibility.