### PR TITLE
fix: support xhigh reasoning effort in usage records

### DIFF
--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -962,7 +962,7 @@ func NormalizeClaudeOutputEffort(raw string) *string {
 		return nil
 	}
 	switch value {
-	case "low", "medium", "high", "max":
+	case "low", "medium", "high", "xhigh", "max":
 		return &value
 	default:
 		return nil

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -1150,6 +1150,11 @@ func TestParseGatewayRequest_OutputEffort(t *testing.T) {
 			wantEffort: "max",
 		},
 		{
+			name:       "output_config.effort xhigh",
+			body:       `{"model":"claude-opus-4-7","output_config":{"effort":"xhigh"},"messages":[]}`,
+			wantEffort: "xhigh",
+		},
+		{
 			name:       "output_config without effort",
 			body:       `{"model":"claude-opus-4-6","output_config":{},"messages":[]}`,
 			wantEffort: "",
@@ -1186,9 +1191,10 @@ func TestNormalizeClaudeOutputEffort(t *testing.T) {
 		{"LOW", strPtr("low")},
 		{"Max", strPtr("max")},
 		{" medium ", strPtr("medium")},
+		{"xhigh", strPtr("xhigh")},
+		{"XHIGH", strPtr("xhigh")},
 		{"", nil},
 		{"unknown", nil},
-		{"xhigh", nil},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -193,7 +193,9 @@ export function formatReasoningEffort(effort: string | null | undefined): string
       return 'High'
     case 'xhigh':
     case 'extrahigh':
-      return 'Xhigh'
+      return 'XHigh'
+    case 'max':
+      return 'Max'
     case 'none':
     case 'minimal':
       return '-'


### PR DESCRIPTION
## 背景 / Background

Claude Opus 4.7 新增了 `xhigh` 作为 `output_config.effort` 的合法值（位于 `high` 和 `max` 之间），但 `NormalizeClaudeOutputEffort` 不认识该值，导致通过 `/v1/messages` 发送 `output_config.effort = "xhigh"` 时，使用记录中推理强度显示为 "-"。

Claude Opus 4.7 introduced `xhigh` as a valid `output_config.effort` value (between `high` and `max`), but `NormalizeClaudeOutputEffort` did not recognize it. When sending `output_config.effort = "xhigh"` via `/v1/messages`, the reasoning effort in usage records showed "-".

---

## 目的 / Purpose

让使用记录正确显示 Claude `xhigh` 推理强度。

Display Claude `xhigh` reasoning effort correctly in usage records.

Closes #1732

---

## 改动内容 / Changes

### 后端 / Backend

- **`NormalizeClaudeOutputEffort`**：在合法值列表中新增 `"xhigh"`，使 `/v1/messages` 路径能正确识别并存储该推理强度

---

- **`NormalizeClaudeOutputEffort`**: Added `"xhigh"` to the recognized effort levels so the `/v1/messages` path correctly stores it in usage logs

### 前端 / Frontend

- **`formatReasoningEffort`**：新增 `"xhigh"` → `"XHigh"` 和 `"max"` → `"Max"` 的显式映射，确保使用记录列表正确展示

---

- **`formatReasoningEffort`**: Added explicit mappings for `"xhigh"` → `"XHigh"` and `"max"` → `"Max"` for proper display in usage records