### PR TITLE
fix(account): prevent quota-exceeded API key/Bedrock accounts from being scheduled

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -121,6 +121,9 @@ func (a *Account) IsSchedulable() bool {
 	if a.TempUnschedulableUntil != nil && now.Before(*a.TempUnschedulableUntil) {
 		return false
 	}
+	if a.IsAPIKeyOrBedrock() && a.IsQuotaExceeded() {
+		return false
+	}
 	return true
 }
 

--- a/backend/internal/service/account_quota_schedulable_test.go
+++ b/backend/internal/service/account_quota_schedulable_test.go
@@ -1,0 +1,123 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccountIsSchedulable_QuotaExceeded(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name: "apikey daily quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "apikey weekly quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_weekly_limit": 50.0,
+					"quota_weekly_used":  50.0,
+					"quota_weekly_start": now.Add(-2 * 24 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "apikey total quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_limit": 100.0,
+					"quota_used":  100.0,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "apikey quota not exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  5.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "apikey expired daily period restores schedulable",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-25 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "oauth ignores quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeOAuth,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "bedrock quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeBedrock,
+				Extra: map[string]any{
+					"quota_limit": 200.0,
+					"quota_used":  200.0,
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.IsSchedulable())
+		})
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -435,26 +435,19 @@ func prefetchedStickyAccountIDFromContext(ctx context.Context, groupID *int64) i
 }
 
 // shouldClearStickySession 检查账号是否处于不可调度状态，需要清理粘性会话绑定。
-// 当账号状态为错误、禁用、不可调度、处于临时不可调度期间，
-// 或请求的模型处于限流状态时，返回 true。
-// 这确保后续请求不会继续使用不可用的账号。
+// 委托 IsSchedulable() 判断账号级可调度性（状态、配额、过载、限流等），
+// 额外检查模型级限流。
 //
 // shouldClearStickySession checks if an account is in an unschedulable state
 // and the sticky session binding should be cleared.
-// Returns true when account status is error/disabled, schedulable is false,
-// within temporary unschedulable period, or the requested model is rate-limited.
-// This ensures subsequent requests won't continue using unavailable accounts.
+// Delegates to IsSchedulable() for account-level checks, plus model-level rate limiting.
 func shouldClearStickySession(account *Account, requestedModel string) bool {
 	if account == nil {
 		return false
 	}
-	if account.Status == StatusError || account.Status == StatusDisabled || !account.Schedulable {
+	if !account.IsSchedulable() {
 		return true
 	}
-	if account.TempUnschedulableUntil != nil && time.Now().Before(*account.TempUnschedulableUntil) {
-		return true
-	}
-	// 检查模型限流和 scope 限流，有限流即清除粘性会话
 	if remaining := account.GetRateLimitRemainingTimeWithContext(context.Background(), requestedModel); remaining > 0 {
 		return true
 	}

--- a/backend/internal/service/sticky_session_test.go
+++ b/backend/internal/service/sticky_session_test.go
@@ -15,20 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestShouldClearStickySession 测试粘性会话清理判断逻辑。
-// 验证在以下情况下是否正确判断需要清理粘性会话：
-//   - nil 账号：不清理（返回 false）
-//   - 状态为错误或禁用：清理
-//   - 不可调度：清理
-//   - 临时不可调度且未过期：清理
-//   - 临时不可调度已过期：不清理
-//   - 正常可调度状态：不清理
-//   - 模型限流（任意时长）：清理
-//
-// TestShouldClearStickySession tests the sticky session clearing logic.
-// Verifies correct behavior for various account states including:
-// nil account, error/disabled status, unschedulable, temporary unschedulable,
-// and model rate limiting scenarios.
+// TestShouldClearStickySession tests sticky session clearing via IsSchedulable() delegation
+// plus model-level rate limiting.
 func TestShouldClearStickySession(t *testing.T) {
 	now := time.Now()
 	future := now.Add(1 * time.Hour)
@@ -100,6 +88,56 @@ func TestShouldClearStickySession(t *testing.T) {
 			},
 			requestedModel: "claude-opus-4", // 请求不同模型
 			want:           false,           // 不同模型不受影响
+		},
+		{
+			name: "apikey quota exceeded",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeAPIKey,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			requestedModel: "",
+			want:           true,
+		},
+		{
+			name: "oauth quota exceeded not cleared",
+			account: &Account{
+				Status:      StatusActive,
+				Schedulable: true,
+				Type:        AccountTypeOAuth,
+				Extra: map[string]any{
+					"quota_daily_limit": 10.0,
+					"quota_daily_used":  10.0,
+					"quota_daily_start": now.Add(-1 * time.Hour).Format(time.RFC3339),
+				},
+			},
+			requestedModel: "",
+			want:           false,
+		},
+		{
+			name: "overloaded account",
+			account: &Account{
+				Status:       StatusActive,
+				Schedulable:  true,
+				OverloadUntil: &future,
+			},
+			requestedModel: "",
+			want:           true,
+		},
+		{
+			name: "account-level rate limited",
+			account: &Account{
+				Status:           StatusActive,
+				Schedulable:      true,
+				RateLimitResetAt: &future,
+			},
+			requestedModel: "",
+			want:           true,
 		},
 	}
 

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -284,6 +284,16 @@ const hasError = computed(() => {
   return props.account.status === 'error'
 })
 
+const isQuotaExceeded = computed(() => {
+  const exceeded = (used?: number | null, limit?: number | null) =>
+    typeof limit === 'number' && limit > 0 && typeof used === 'number' && used >= limit
+  return (
+    exceeded(props.account.quota_used, props.account.quota_limit) ||
+    exceeded(props.account.quota_daily_used, props.account.quota_daily_limit) ||
+    exceeded(props.account.quota_weekly_used, props.account.quota_weekly_limit)
+  )
+})
+
 // Computed: countdown text for rate limit (429)
 const rateLimitCountdown = computed(() => {
   return formatCountdown(props.account.rate_limit_reset_at)
@@ -307,19 +317,16 @@ const statusClass = computed(() => {
   if (isTempUnschedulable.value) {
     return 'badge-warning'
   }
+  if (props.account.status !== 'active') {
+    return props.account.status === 'error' ? 'badge-danger' : 'badge-gray'
+  }
+  if (isQuotaExceeded.value) {
+    return 'badge-warning'
+  }
   if (!props.account.schedulable) {
     return 'badge-gray'
   }
-  switch (props.account.status) {
-    case 'active':
-      return 'badge-success'
-    case 'inactive':
-      return 'badge-gray'
-    case 'error':
-      return 'badge-danger'
-    default:
-      return 'badge-gray'
-  }
+  return 'badge-success'
 })
 
 // Computed: status text
@@ -329,6 +336,12 @@ const statusText = computed(() => {
   }
   if (isTempUnschedulable.value) {
     return t('admin.accounts.status.tempUnschedulable')
+  }
+  if (props.account.status !== 'active') {
+    return t(`admin.accounts.status.${props.account.status}`)
+  }
+  if (isQuotaExceeded.value) {
+    return t('admin.accounts.status.quotaExceeded')
   }
   if (!props.account.schedulable) {
     return t('admin.accounts.status.paused')

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2126,6 +2126,7 @@ export default {
         rateLimited: 'Rate Limited',
         overloaded: 'Overloaded',
         tempUnschedulable: 'Temp Unschedulable',
+        quotaExceeded: 'Quota Exceeded',
         unschedulable: 'Unschedulable',
         rateLimitedUntil: 'Rate limited and removed from scheduling. Auto resumes at {time}',
         rateLimitedAutoResume: 'Auto resumes in {time}',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2315,6 +2315,7 @@ export default {
         rateLimited: '限流中',
         overloaded: '过载中',
         tempUnschedulable: '临时不可调度',
+        quotaExceeded: '配额超限',
         unschedulable: '不可调度',
         rateLimitedUntil: '限流中，当前不参与调度，预计 {time} 自动恢复',
         rateLimitedAutoResume: '{time} 自动恢复',


### PR DESCRIPTION
## 背景 / Background

当 API Key 或 Bedrock 类型的上游账号超出配置的额度限制（日/周/总）后，`IsSchedulable()` 仍返回 true，导致这些账号继续参与调度。此外 `shouldClearStickySession()` 手动复制了 `IsSchedulable()` 的部分条件，遗漏了过载、账号级限流、过期自动暂停等场景的粘性会话清理。

When API Key or Bedrock upstream accounts exceed their configured quota limits (daily/weekly/total), `IsSchedulable()` still returns true, causing these accounts to continue being scheduled. Additionally, `shouldClearStickySession()` manually duplicated a subset of `IsSchedulable()` conditions, missing sticky session clearing for overload, account-level rate limiting, and auto-pause-on-expired scenarios.

---

## 目的 / Purpose

修复配额超限的 API Key/Bedrock 账号仍被调度的问题，同时重构 `shouldClearStickySession()` 消除与 `IsSchedulable()` 的逻辑重复，并在前端展示配额超限状态。

Fix quota-exceeded API Key/Bedrock accounts still being scheduled, refactor `shouldClearStickySession()` to eliminate logic duplication with `IsSchedulable()`, and display quota exceeded status in the frontend.

---

## 改动内容 / Changes

### 后端 / Backend

- **`IsSchedulable()` 新增配额检查**：对 API Key/Bedrock 类型账号，调用 `IsQuotaExceeded()` 判断日/周/总额度是否超限，超限则返回不可调度。所有平台（OpenAI/Gemini/Antigravity）自动获得覆盖
- **`shouldClearStickySession()` 重构**：从手动复制 5 个条件改为委托 `!account.IsSchedulable()`，仅额外保留模型级限流检查。消除重复逻辑，同时修复了之前遗漏的过载、账号级限流、过期自动暂停不清除粘性会话的问题
- **新增单元测试**：`account_quota_schedulable_test.go`（7 个用例覆盖日/周/总额度、过期重置、OAuth 豁免、Bedrock）；`sticky_session_test.go` 扩展 4 个用例（quota exceeded、OAuth 豁免、过载、账号级限流）

---

- **`IsSchedulable()` quota check**: For API Key/Bedrock accounts, calls `IsQuotaExceeded()` to check daily/weekly/total quota limits. All platforms (OpenAI/Gemini/Antigravity) are automatically covered
- **`shouldClearStickySession()` refactor**: Replaced 5 manually duplicated conditions with `!account.IsSchedulable()`, keeping only the model-level rate limit check. Eliminates duplication and fixes previously missed overload, account-level rate limit, and auto-pause-on-expired sticky session clearing
- **Unit tests**: `account_quota_schedulable_test.go` (7 cases covering daily/weekly/total quota, expired period reset, OAuth exemption, Bedrock); `sticky_session_test.go` extended with 4 new cases (quota exceeded, OAuth exemption, overload, account-level rate limit)

### 前端 / Frontend

- **配额超限状态展示**：`AccountStatusIndicator.vue` 新增 `isQuotaExceeded` 计算属性，通过已有的 quota 字段独立判断（不依赖 `schedulable` 字段），在状态优先级链中插入于 `!schedulable` 之前，显示黄色 "配额超限" badge
- **i18n**：新增 `quotaExceeded` 翻译（EN: "Quota Exceeded" / ZH: "配额超限"）

---

- **Quota exceeded status display**: `AccountStatusIndicator.vue` adds `isQuotaExceeded` computed property, calculated independently from quota fields (not relying on `schedulable`), inserted before `!schedulable` in the status priority chain, showing a warning "Quota Exceeded" badge
- **i18n**: Added `quotaExceeded` translations (EN: "Quota Exceeded" / ZH: "配额超限")
