### PR TITLE
fix: delete scheduled test plans when account is deleted

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -438,6 +438,9 @@ func (r *accountRepository) Delete(ctx context.Context, id int64) error {
 	if _, err := txClient.AccountGroup.Delete().Where(dbaccountgroup.AccountIDEQ(id)).Exec(ctx); err != nil {
 		return err
 	}
+	if _, err := txClient.ExecContext(ctx, "DELETE FROM scheduled_test_plans WHERE account_id = $1", id); err != nil {
+		return err
+	}
 	if _, err := txClient.Account.Delete().Where(dbaccount.IDEQ(id)).Exec(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
## 背景 / Background

账号使用软删除（设置 `deleted_at`），因此 PostgreSQL 的 `ON DELETE CASCADE` 约束不会触发。删除账号后，关联的定时测试计划仍然保留在数据库中，`enabled = true`，cron runner 每分钟仍会尝试执行这些孤儿计划。同时，由于账号已删除，前端界面无法管理这些定时任务。

Accounts use soft-delete (setting `deleted_at`), so PostgreSQL's `ON DELETE CASCADE` on `scheduled_test_plans.account_id` never fires. After an account is deleted, its scheduled test plans remain in the database with `enabled = true`, and the cron runner continues to execute them every minute. Since the account no longer exists, these orphaned plans cannot be managed from the frontend.

---

## 目的 / Purpose

删除账号时，在同一个事务内同步清理该账号关联的所有定时测试计划（及其级联的测试结果），确保操作的原子性。

When an account is deleted, clean up all associated scheduled test plans (and their cascaded test results) within the same transaction to ensure atomicity.

Closes #1728

---

## 改动内容 / Changes

### 后端 / Backend

- **`accountRepository.Delete` 事务内新增 plan 清理**：在 `account_groups` 删除和 `account` 软删除之间，增加 `DELETE FROM scheduled_test_plans WHERE account_id = $1`，利用现有 Ent 事务保证三步操作的原子性。测试结果通过数据库级联 (`ON DELETE CASCADE`) 自动清理。

---

- **Added plan cleanup inside `accountRepository.Delete` transaction**: Between the `account_groups` deletion and `account` soft-delete, added `DELETE FROM scheduled_test_plans WHERE account_id = $1`, leveraging the existing Ent transaction to ensure atomicity of all three operations. Test results are automatically cleaned up via database-level cascade (`ON DELETE CASCADE`).