### PR TITLE
fix(gateway): 返回明确的模型选择错误

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -303,6 +303,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		for {
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, "", int64(0)) // Gemini 不使用会话限制
 			if err != nil {
+				if len(fs.FailedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+					return
+				}
 				if len(fs.FailedAccountIDs) == 0 {
 					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error(), streamStarted)
 					return
@@ -527,6 +530,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 选择支持该模型的账号
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), currentAPIKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, parsedReq.MetadataUserID, subject.UserID)
 			if err != nil {
+				if len(fs.FailedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+					return
+				}
 				if len(fs.FailedAccountIDs) == 0 {
 					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error(), streamStarted)
 					return
@@ -1232,6 +1238,20 @@ func (h *GatewayHandler) calculateSubscriptionRemaining(group *service.Group, su
 func (h *GatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
 		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+}
+
+func (h *GatewayHandler) handleSelectionError(c *gin.Context, err error, streamStarted bool) bool {
+	var unsupportedErr *service.UnsupportedRequestedModelError
+	if errors.As(err, &unsupportedErr) {
+		h.handleStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error(), streamStarted)
+		return true
+	}
+	var deniedErr *service.ModelAccessDeniedError
+	if errors.As(err, &deniedErr) {
+		h.handleStreamingAwareError(c, http.StatusForbidden, "permission_error", deniedErr.Error(), streamStarted)
+		return true
+	}
+	return false
 }
 
 func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, platform string, streamStarted bool) {

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -324,6 +324,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		for {
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, "", int64(0)) // Gemini 不使用会话限制
 			if err != nil {
+				if len(fs.FailedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+					return
+				}
 				if len(fs.FailedAccountIDs) == 0 {
 					reqLog.Warn("gateway.select_account_no_available",
 						zap.String("model", reqModel),
@@ -565,6 +568,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			)
 			selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), currentAPIKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, parsedReq.MetadataUserID, subject.UserID)
 			if err != nil {
+				if len(fs.FailedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+					return
+				}
 				if len(fs.FailedAccountIDs) == 0 {
 					reqLog.Warn("gateway.select_account_no_available",
 						zap.String("model", reqModel),
@@ -1307,6 +1313,20 @@ func (h *GatewayHandler) calculateSubscriptionRemaining(group *service.Group, su
 func (h *GatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
 		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+}
+
+func (h *GatewayHandler) handleSelectionError(c *gin.Context, err error, streamStarted bool) bool {
+	var unsupportedErr *service.UnsupportedRequestedModelError
+	if errors.As(err, &unsupportedErr) {
+		h.handleStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error(), streamStarted)
+		return true
+	}
+	var deniedErr *service.ModelAccessDeniedError
+	if errors.As(err, &deniedErr) {
+		h.handleStreamingAwareError(c, http.StatusForbidden, "permission_error", deniedErr.Error(), streamStarted)
+		return true
+	}
+	return false
 }
 
 func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, platform string, streamStarted bool) {

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -163,6 +163,9 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	for {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
+			if len(fs.FailedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+				return
+			}
 			if len(fs.FailedAccountIDs) == 0 {
 				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
 				return

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -168,6 +168,9 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	for {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
+			if len(fs.FailedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+				return
+			}
 			if len(fs.FailedAccountIDs) == 0 {
 				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
 				return

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -169,6 +169,18 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
+				var unsupportedErr *service.UnsupportedRequestedModelError
+				if errors.As(err, &unsupportedErr) {
+					h.responsesErrorResponse(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error())
+					return
+				}
+				var deniedErr *service.ModelAccessDeniedError
+				if errors.As(err, &deniedErr) {
+					h.responsesErrorResponse(c, http.StatusForbidden, "permission_error", deniedErr.Error())
+					return
+				}
+			}
+			if len(fs.FailedAccountIDs) == 0 {
 				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
 				return
 			}

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -174,6 +174,18 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionHash, reqModel, fs.FailedAccountIDs, "", int64(0))
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
+				var unsupportedErr *service.UnsupportedRequestedModelError
+				if errors.As(err, &unsupportedErr) {
+					h.responsesErrorResponse(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error())
+					return
+				}
+				var deniedErr *service.ModelAccessDeniedError
+				if errors.As(err, &deniedErr) {
+					h.responsesErrorResponse(c, http.StatusForbidden, "permission_error", deniedErr.Error())
+					return
+				}
+			}
+			if len(fs.FailedAccountIDs) == 0 {
 				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
 				return
 			}

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -367,6 +367,18 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, modelName, fs.FailedAccountIDs, "", int64(0)) // Gemini 不使用会话限制
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
+				var unsupportedErr *service.UnsupportedRequestedModelError
+				if errors.As(err, &unsupportedErr) {
+					googleError(c, http.StatusBadRequest, unsupportedErr.Error())
+					return
+				}
+				var deniedErr *service.ModelAccessDeniedError
+				if errors.As(err, &deniedErr) {
+					googleError(c, http.StatusForbidden, deniedErr.Error())
+					return
+				}
+			}
+			if len(fs.FailedAccountIDs) == 0 {
 				googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
 				return
 			}

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -372,6 +372,18 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, modelName, fs.FailedAccountIDs, "", int64(0)) // Gemini 不使用会话限制
 		if err != nil {
 			if len(fs.FailedAccountIDs) == 0 {
+				var unsupportedErr *service.UnsupportedRequestedModelError
+				if errors.As(err, &unsupportedErr) {
+					googleError(c, http.StatusBadRequest, unsupportedErr.Error())
+					return
+				}
+				var deniedErr *service.ModelAccessDeniedError
+				if errors.As(err, &deniedErr) {
+					googleError(c, http.StatusForbidden, deniedErr.Error())
+					return
+				}
+			}
+			if len(fs.FailedAccountIDs) == 0 {
 				googleError(c, http.StatusServiceUnavailable, "No available Gemini accounts: "+err.Error())
 				return
 			}

--- a/backend/internal/handler/model_selection_error_test.go
+++ b/backend/internal/handler/model_selection_error_test.go
@@ -1,0 +1,67 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewayHandlerHandleSelectionError_UnsupportedModelReturns400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	h := &GatewayHandler{}
+	require.True(t, h.handleSelectionError(c, &service.UnsupportedRequestedModelError{Model: "gpt-5"}, false))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "invalid_request_error", errObj["type"])
+	require.Contains(t, errObj["message"], "gpt-5")
+}
+
+func TestOpenAIGatewayHandlerHandleSelectionError_ModelAccessDeniedReturns403(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	h := &OpenAIGatewayHandler{}
+	require.True(t, h.handleSelectionError(c, &service.ModelAccessDeniedError{Model: "gpt-4.1", Reason: "channel pricing restriction"}, false))
+	require.Equal(t, http.StatusForbidden, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "permission_error", errObj["type"])
+	require.Contains(t, errObj["message"], "channel pricing restriction")
+}
+
+func TestOpenAIGatewayHandlerHandleSelectionErrorAnthropic_UnsupportedModelReturnsAnthropicShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	h := &OpenAIGatewayHandler{}
+	require.True(t, h.handleSelectionErrorAnthropic(c, &service.UnsupportedRequestedModelError{Model: "gpt-5"}, false))
+	require.Equal(t, http.StatusBadRequest, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, "error", body["type"])
+	errObj, ok := body["error"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "invalid_request_error", errObj["type"])
+	require.Contains(t, errObj["message"], "gpt-5")
+}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -137,6 +137,9 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if len(failedAccountIDs) == 0 {
+				if h.handleSelectionError(c, err, streamStarted) {
+					return
+				}
 				defaultModel := ""
 				if apiKey.Group != nil {
 					defaultModel = apiKey.Group.DefaultMappedModel
@@ -159,6 +162,9 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 					}
 				}
 				if err != nil {
+					if h.handleSelectionError(c, err, streamStarted) {
+						return
+					}
 					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
 					return
 				}

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -126,6 +126,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 	var lastFailoverErr *service.UpstreamFailoverError
 
 	for {
+		c.Set("openai_chat_completions_fallback_model", "")
 		reqLog.Debug("openai_chat_completions.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
 		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithScheduler(
 			c.Request.Context(),
@@ -143,8 +144,38 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if len(failedAccountIDs) == 0 {
-				h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
-				return
+				if h.handleSelectionError(c, err, streamStarted) {
+					return
+				}
+				defaultModel := ""
+				if apiKey.Group != nil {
+					defaultModel = apiKey.Group.DefaultMappedModel
+				}
+				if defaultModel != "" && defaultModel != reqModel {
+					reqLog.Info("openai_chat_completions.fallback_to_default_model",
+						zap.String("default_mapped_model", defaultModel),
+					)
+					selection, scheduleDecision, err = h.gatewayService.SelectAccountWithScheduler(
+						c.Request.Context(),
+						apiKey.GroupID,
+						"",
+						sessionHash,
+						defaultModel,
+						failedAccountIDs,
+						service.OpenAIUpstreamTransportAny,
+						false,
+					)
+					if err == nil && selection != nil {
+						c.Set("openai_chat_completions_fallback_model", defaultModel)
+					}
+				}
+				if err != nil {
+					if h.handleSelectionError(c, err, streamStarted) {
+						return
+					}
+					h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+					return
+				}
 			} else {
 				if lastFailoverErr != nil {
 					h.handleFailoverExhausted(c, lastFailoverErr, streamStarted)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -258,6 +258,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			service.OpenAIUpstreamTransportAny,
 		)
 		if err != nil {
+			if len(failedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+				return
+			}
 			reqLog.Warn("openai.account_select_failed",
 				zap.Error(err),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
@@ -651,10 +654,11 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if len(failedAccountIDs) == 0 {
-				if err != nil {
-					h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				if h.handleSelectionErrorAnthropic(c, err, streamStarted) {
 					return
 				}
+				h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				return
 			} else {
 				if lastFailoverErr != nil {
 					h.handleAnthropicFailoverExhausted(c, lastFailoverErr, streamStarted)
@@ -1445,6 +1449,34 @@ func (h *OpenAIGatewayHandler) submitUsageRecordTask(task service.UsageRecordTas
 func (h *OpenAIGatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
 		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+}
+
+func (h *OpenAIGatewayHandler) handleSelectionError(c *gin.Context, err error, streamStarted bool) bool {
+	var unsupportedErr *service.UnsupportedRequestedModelError
+	if errors.As(err, &unsupportedErr) {
+		h.handleStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error(), streamStarted)
+		return true
+	}
+	var deniedErr *service.ModelAccessDeniedError
+	if errors.As(err, &deniedErr) {
+		h.handleStreamingAwareError(c, http.StatusForbidden, "permission_error", deniedErr.Error(), streamStarted)
+		return true
+	}
+	return false
+}
+
+func (h *OpenAIGatewayHandler) handleSelectionErrorAnthropic(c *gin.Context, err error, streamStarted bool) bool {
+	var unsupportedErr *service.UnsupportedRequestedModelError
+	if errors.As(err, &unsupportedErr) {
+		h.anthropicStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error(), streamStarted)
+		return true
+	}
+	var deniedErr *service.ModelAccessDeniedError
+	if errors.As(err, &deniedErr) {
+		h.anthropicStreamingAwareError(c, http.StatusForbidden, "permission_error", deniedErr.Error(), streamStarted)
+		return true
+	}
+	return false
 }
 
 func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -277,6 +277,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			requireCompact,
 		)
 		if err != nil {
+			if len(failedAccountIDs) == 0 && h.handleSelectionError(c, err, streamStarted) {
+				return
+			}
 			reqLog.Warn("openai.account_select_failed",
 				zap.Error(err),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
@@ -676,10 +679,11 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if len(failedAccountIDs) == 0 {
-				if err != nil {
-					h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				if h.handleSelectionErrorAnthropic(c, err, streamStarted) {
 					return
 				}
+				h.anthropicStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable", streamStarted)
+				return
 			} else {
 				if lastFailoverErr != nil {
 					h.handleAnthropicFailoverExhausted(c, lastFailoverErr, streamStarted)
@@ -1593,6 +1597,34 @@ func (h *OpenAIGatewayHandler) acquireImageGenerationSlot(c *gin.Context, stream
 func (h *OpenAIGatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
 		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+}
+
+func (h *OpenAIGatewayHandler) handleSelectionError(c *gin.Context, err error, streamStarted bool) bool {
+	var unsupportedErr *service.UnsupportedRequestedModelError
+	if errors.As(err, &unsupportedErr) {
+		h.handleStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error(), streamStarted)
+		return true
+	}
+	var deniedErr *service.ModelAccessDeniedError
+	if errors.As(err, &deniedErr) {
+		h.handleStreamingAwareError(c, http.StatusForbidden, "permission_error", deniedErr.Error(), streamStarted)
+		return true
+	}
+	return false
+}
+
+func (h *OpenAIGatewayHandler) handleSelectionErrorAnthropic(c *gin.Context, err error, streamStarted bool) bool {
+	var unsupportedErr *service.UnsupportedRequestedModelError
+	if errors.As(err, &unsupportedErr) {
+		h.anthropicStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", unsupportedErr.Error(), streamStarted)
+		return true
+	}
+	var deniedErr *service.ModelAccessDeniedError
+	if errors.As(err, &deniedErr) {
+		h.anthropicStreamingAwareError(c, http.StatusForbidden, "permission_error", deniedErr.Error(), streamStarted)
+		return true
+	}
+	return false
 }
 
 func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -1766,7 +1766,8 @@ func TestGatewayService_selectAccountWithMixedScheduling(t *testing.T) {
 		acc, err := svc.selectAccountWithMixedScheduling(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
 		require.Error(t, err)
 		require.Nil(t, acc)
-		require.Contains(t, err.Error(), "supporting model")
+		var unsupportedErr *UnsupportedRequestedModelError
+		require.ErrorAs(t, err, &unsupportedErr)
 	})
 
 	t.Run("混合调度-优先未使用账号", func(t *testing.T) {

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -878,7 +878,8 @@ func TestGatewayService_SelectAccountForModelWithPlatform_NoModelSupport(t *test
 	acc, err := svc.selectAccountForModelWithPlatform(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
 	require.Error(t, err)
 	require.Nil(t, acc)
-	require.Contains(t, err.Error(), "supporting model")
+	var unsupportedErr *UnsupportedRequestedModelError
+	require.ErrorAs(t, err, &unsupportedErr)
 }
 
 func TestGatewayService_SelectAccountForModelWithPlatform_GeminiPreferOAuth(t *testing.T) {
@@ -955,7 +956,8 @@ func TestGatewayService_SelectAccountForModelWithPlatform_GeminiAPIKeyModelMappi
 	acc, err = svc.selectAccountForModelWithPlatform(ctx, nil, "", "gemini-3-pro-preview", nil, PlatformGemini)
 	require.Error(t, err)
 	require.Nil(t, acc)
-	require.Contains(t, err.Error(), "supporting model")
+	var unsupportedErr *UnsupportedRequestedModelError
+	require.ErrorAs(t, err, &unsupportedErr)
 }
 
 func TestGatewayService_SelectAccountForModelWithPlatform_StickyInGroup(t *testing.T) {
@@ -1766,7 +1768,8 @@ func TestGatewayService_selectAccountWithMixedScheduling(t *testing.T) {
 		acc, err := svc.selectAccountWithMixedScheduling(ctx, nil, "", "claude-3-5-sonnet-20241022", nil, PlatformAnthropic)
 		require.Error(t, err)
 		require.Nil(t, acc)
-		require.Contains(t, err.Error(), "supporting model")
+		var unsupportedErr *UnsupportedRequestedModelError
+		require.ErrorAs(t, err, &unsupportedErr)
 	})
 
 	t.Run("混合调度-优先未使用账号", func(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -345,6 +345,34 @@ var (
 // ErrNoAvailableAccounts 表示没有可用的账号
 var ErrNoAvailableAccounts = errors.New("no available accounts")
 
+type UnsupportedRequestedModelError struct{ Model string }
+
+func (e *UnsupportedRequestedModelError) Error() string {
+	model := strings.TrimSpace(e.Model)
+	if model == "" {
+		return "requested model is not supported by this endpoint/account pool"
+	}
+	return fmt.Sprintf("requested model %q is not supported by this endpoint/account pool", model)
+}
+
+type ModelAccessDeniedError struct {
+	Model  string
+	Reason string
+}
+
+func (e *ModelAccessDeniedError) Error() string {
+	model := strings.TrimSpace(e.Model)
+	reason := strings.TrimSpace(e.Reason)
+	msg := "requested model is not allowed for this endpoint/account"
+	if model != "" {
+		msg = fmt.Sprintf("requested model %q is not allowed for this endpoint/account", model)
+	}
+	if reason != "" {
+		return msg + ": " + reason
+	}
+	return msg
+}
+
 // ErrClaudeCodeOnly 表示分组仅允许 Claude Code 客户端访问
 var ErrClaudeCodeOnly = errors.New("this group only allows Claude Code clients")
 
@@ -1181,7 +1209,7 @@ func (s *GatewayService) SelectAccountForModelWithExclusions(ctx context.Context
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	// anthropic/gemini 分组支持混合调度（包含启用了 mixed_scheduling 的 antigravity 账户）
@@ -1234,7 +1262,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	var stickyAccountID int64
@@ -2939,10 +2967,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, platform, accounts, excludedIDs, false)
-		if requestedModel != "" {
-			return nil, fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
-		}
-		return nil, ErrNoAvailableAccounts
+		return nil, classifySelectionFailureError(requestedModel, stats)
 	}
 
 	// 4. 建立粘性绑定
@@ -3200,10 +3225,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, nativePlatform, accounts, excludedIDs, true)
-		if requestedModel != "" {
-			return nil, fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
-		}
-		return nil, ErrNoAvailableAccounts
+		return nil, classifySelectionFailureError(requestedModel, stats)
 	}
 
 	// 4. 建立粘性绑定
@@ -3386,6 +3408,24 @@ func summarizeSelectionFailureStats(stats selectionFailureStats) string {
 		stats.ModelUnsupported,
 		stats.ModelRateLimited,
 	)
+}
+
+func unsupportedRequestedModelError(model string) error {
+	return &UnsupportedRequestedModelError{Model: strings.TrimSpace(model)}
+}
+
+func modelAccessDeniedError(model, reason string) error {
+	return &ModelAccessDeniedError{Model: strings.TrimSpace(model), Reason: strings.TrimSpace(reason)}
+}
+
+func classifySelectionFailureError(requestedModel string, stats selectionFailureStats) error {
+	if strings.TrimSpace(requestedModel) == "" {
+		return ErrNoAvailableAccounts
+	}
+	if stats.Total > 0 && stats.Excluded == 0 && stats.ModelUnsupported == stats.Total && stats.Eligible == 0 && stats.Unschedulable == 0 && stats.PlatformFiltered == 0 && stats.ModelRateLimited == 0 {
+		return unsupportedRequestedModelError(requestedModel)
+	}
+	return fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
 }
 
 // isModelSupportedByAccountWithContext 根据账户平台检查模型支持（带 context）

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -352,6 +352,34 @@ var (
 // ErrNoAvailableAccounts 表示没有可用的账号
 var ErrNoAvailableAccounts = errors.New("no available accounts")
 
+type UnsupportedRequestedModelError struct{ Model string }
+
+func (e *UnsupportedRequestedModelError) Error() string {
+	model := strings.TrimSpace(e.Model)
+	if model == "" {
+		return "requested model is not supported by this endpoint/account pool"
+	}
+	return fmt.Sprintf("requested model %q is not supported by this endpoint/account pool", model)
+}
+
+type ModelAccessDeniedError struct {
+	Model  string
+	Reason string
+}
+
+func (e *ModelAccessDeniedError) Error() string {
+	model := strings.TrimSpace(e.Model)
+	reason := strings.TrimSpace(e.Reason)
+	msg := "requested model is not allowed for this endpoint/account"
+	if model != "" {
+		msg = fmt.Sprintf("requested model %q is not allowed for this endpoint/account", model)
+	}
+	if reason != "" {
+		return msg + ": " + reason
+	}
+	return msg
+}
+
 // ErrClaudeCodeOnly 表示分组仅允许 Claude Code 客户端访问
 var ErrClaudeCodeOnly = errors.New("this group only allows Claude Code clients")
 
@@ -1376,7 +1404,7 @@ func (s *GatewayService) SelectAccountForModelWithExclusions(ctx context.Context
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	// anthropic/gemini 分组支持混合调度（包含启用了 mixed_scheduling 的 antigravity 账户）
@@ -1429,7 +1457,7 @@ func (s *GatewayService) SelectAccountWithLoadAwareness(ctx context.Context, gro
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	var stickyAccountID int64
@@ -3234,10 +3262,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, platform, accounts, excludedIDs, false)
-		if requestedModel != "" {
-			return nil, fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
-		}
-		return nil, ErrNoAvailableAccounts
+		return nil, classifySelectionFailureError(requestedModel, stats)
 	}
 
 	// 4. 建立粘性绑定
@@ -3495,10 +3520,7 @@ func (s *GatewayService) selectAccountWithMixedScheduling(ctx context.Context, g
 
 	if selected == nil {
 		stats := s.logDetailedSelectionFailure(ctx, groupID, sessionHash, requestedModel, nativePlatform, accounts, excludedIDs, true)
-		if requestedModel != "" {
-			return nil, fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
-		}
-		return nil, ErrNoAvailableAccounts
+		return nil, classifySelectionFailureError(requestedModel, stats)
 	}
 
 	// 4. 建立粘性绑定
@@ -3681,6 +3703,24 @@ func summarizeSelectionFailureStats(stats selectionFailureStats) string {
 		stats.ModelUnsupported,
 		stats.ModelRateLimited,
 	)
+}
+
+func unsupportedRequestedModelError(model string) error {
+	return &UnsupportedRequestedModelError{Model: strings.TrimSpace(model)}
+}
+
+func modelAccessDeniedError(model, reason string) error {
+	return &ModelAccessDeniedError{Model: strings.TrimSpace(model), Reason: strings.TrimSpace(reason)}
+}
+
+func classifySelectionFailureError(requestedModel string, stats selectionFailureStats) error {
+	if strings.TrimSpace(requestedModel) == "" {
+		return ErrNoAvailableAccounts
+	}
+	if stats.Total > 0 && stats.Excluded == 0 && stats.ModelUnsupported == stats.Total && stats.Eligible == 0 && stats.Unschedulable == 0 && stats.PlatformFiltered == 0 && stats.ModelRateLimited == 0 {
+		return unsupportedRequestedModelError(requestedModel)
+	}
+	return fmt.Errorf("%w supporting model: %s (%s)", ErrNoAvailableAccounts, requestedModel, summarizeSelectionFailureStats(stats))
 }
 
 // isModelSupportedByAccountWithContext 根据账户平台检查模型支持（带 context）

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -388,7 +388,8 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_Require
 		OpenAIUpstreamTransportResponsesWebsocketV2,
 		false,
 	)
-	require.ErrorContains(t, err, "no available OpenAI accounts")
+	var unsupportedErr *UnsupportedRequestedModelError
+	require.ErrorAs(t, err, &unsupportedErr)
 	require.Nil(t, selection)
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 }

--- a/backend/internal/service/openai_channel_restriction_test.go
+++ b/backend/internal/service/openai_channel_restriction_test.go
@@ -35,7 +35,8 @@ func TestOpenAISelectAccountForModelWithExclusions_ChannelMappedRestrictionRejec
 
 	groupID := int64(10)
 	_, err := svc.SelectAccountForModelWithExclusions(context.Background(), &groupID, "", "gpt-4.1", nil)
-	require.ErrorIs(t, err, ErrNoAvailableAccounts)
+	var deniedErr *ModelAccessDeniedError
+	require.ErrorAs(t, err, &deniedErr)
 	require.Contains(t, err.Error(), "channel pricing restriction")
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1216,7 +1216,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	// 1. 尝试粘性会话命中
@@ -1238,7 +1238,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 
 	if selected == nil {
 		if requestedModel != "" {
-			return nil, fmt.Errorf("no available OpenAI accounts supporting model: %s", requestedModel)
+			return nil, unsupportedRequestedModelError(requestedModel)
 		}
 		return nil, errors.New("no available OpenAI accounts")
 	}
@@ -1396,7 +1396,7 @@ func (s *OpenAIGatewayService) SelectAccountWithLoadAwareness(ctx context.Contex
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	cfg := s.schedulingConfig()

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1266,7 +1266,7 @@ func noAvailableOpenAISelectionError(requestedModel string, compactBlocked bool)
 		return ErrNoAvailableCompactAccounts
 	}
 	if requestedModel != "" {
-		return fmt.Errorf("no available OpenAI accounts supporting model: %s", requestedModel)
+		return unsupportedRequestedModelError(requestedModel)
 	}
 	return errors.New("no available OpenAI accounts")
 }
@@ -1348,7 +1348,7 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	// 1. 尝试粘性会话命中
@@ -1549,7 +1549,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		slog.Warn("channel pricing restriction blocked request",
 			"group_id", derefGroupID(groupID),
 			"model", requestedModel)
-		return nil, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, requestedModel)
+		return nil, modelAccessDeniedError(requestedModel, "channel pricing restriction")
 	}
 
 	cfg := s.schedulingConfig()

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -521,8 +521,9 @@ func TestOpenAISelectAccountForModelWithExclusions_NoModelSupport(t *testing.T) 
 	if acc != nil {
 		t.Fatalf("expected nil account for unsupported model")
 	}
-	if !strings.Contains(err.Error(), "supporting model") {
-		t.Fatalf("unexpected error: %v", err)
+	var unsupportedErr *UnsupportedRequestedModelError
+	if !errors.As(err, &unsupportedErr) {
+		t.Fatalf("expected UnsupportedRequestedModelError, got %v", err)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -564,8 +564,9 @@ func TestOpenAISelectAccountForModelWithExclusions_NoModelSupport(t *testing.T) 
 	if acc != nil {
 		t.Fatalf("expected nil account for unsupported model")
 	}
-	if !strings.Contains(err.Error(), "supporting model") {
-		t.Fatalf("unexpected error: %v", err)
+	var unsupportedErr *UnsupportedRequestedModelError
+	if !errors.As(err, &unsupportedErr) {
+		t.Fatalf("expected UnsupportedRequestedModelError, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## 说明

修复客户端请求了当前 endpoint / account pool 不支持的模型时，网关多数只返回 `503 No available accounts`，导致用户误以为是临时容量问题，而不是模型本身不支持或被策略拒绝的问题。

本次改动将模型选择失败细分为更明确的错误类型，并在各协议 handler 中返回更合适的状态码与错误信息。

## 改动内容

- 在调度层新增 typed error：
  - `UnsupportedRequestedModelError`
  - `ModelAccessDeniedError`
- 当请求模型在当前 endpoint / account pool 中明确不受支持时，返回 `400`
- 当请求模型被显式策略拒绝（如 channel pricing restriction）时，返回 `403`
- 真实的“没有可用账号”场景仍保持返回 `503`
- 覆盖以下主链路的错误映射：
  - Anthropic `/v1/messages`
  - OpenAI `/v1/chat/completions`
  - OpenAI `/v1/responses`
  - Gemini `/v1beta`

## 返回语义

### 400
适用于：
- 请求模型不受当前 endpoint / account pool 支持

示例语义：
- `requested model "xxx" is not supported by this endpoint/account pool`

### 403
适用于：
- 请求模型被显式策略拒绝

示例语义：
- `requested model "xxx" is not allowed for this endpoint/account: channel pricing restriction`

### 503
仍适用于：
- 真实没有可用账号
- 容量/调度耗尽类问题

## 验证

### 编译检查
- `go test -run '^$' ./internal/service ./internal/handler`

### 定向测试
- `go test ./internal/service -run 'TestOpenAISelectAccountForModelWithExclusions_NoModelSupport|TestOpenAISelectAccountForModelWithExclusions_ChannelMappedRestrictionRejectsEarly|TestResolveOpenAIForwardModel_PreventsClaudeModelFromFallingBackToGpt54'`
- `go test ./internal/handler -run 'TestGatewayHandlerHandleSelectionError_UnsupportedModelReturns400|TestOpenAIGatewayHandlerHandleSelectionError_ModelAccessDeniedReturns403'`

## 影响范围

- 网关调度错误分类
- OpenAI / Anthropic / Gemini 协议错误映射
- 客户端在模型不支持场景下的可读性与可操作性