### PR TITLE
fix(profile): 修正邮箱重复显示问题并添加国际化语言支持

### DIFF
--- a/backend/internal/handler/user_handler_test.go
+++ b/backend/internal/handler/user_handler_test.go
@@ -323,6 +323,11 @@ func TestUserHandlerGetProfileReturnsLegacyCompatibilityFields(t *testing.T) {
 	emailBinding, ok := identityBindings["email"].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, true, emailBinding["bound"])
+	require.Equal(t, "profile.authBindings.notes.emailManagedFromProfile", emailBinding["note_key"])
+
+	linuxdoCompatBinding, ok := identityBindings["linuxdo"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "profile.authBindings.notes.canUnbind", linuxdoCompatBinding["note_key"])
 
 	profileSources, ok := resp.Data["profile_sources"].(map[string]any)
 	require.True(t, ok)

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -77,6 +77,7 @@ func TestAPIContracts(t *testing.T) {
 							"can_unbind": false,
 							"display_name": "alice@example.com",
 							"subject_hint": "a***e@example.com",
+							"note_key": "profile.authBindings.notes.emailManagedFromProfile",
 							"note": "Primary account email is managed from the profile form."
 						},
 						"linuxdo": {
@@ -114,6 +115,7 @@ func TestAPIContracts(t *testing.T) {
 							"can_unbind": false,
 							"display_name": "alice@example.com",
 							"subject_hint": "a***e@example.com",
+							"note_key": "profile.authBindings.notes.emailManagedFromProfile",
 							"note": "Primary account email is managed from the profile form."
 						},
 						"linuxdo": {
@@ -151,6 +153,7 @@ func TestAPIContracts(t *testing.T) {
 							"can_unbind": false,
 							"display_name": "alice@example.com",
 							"subject_hint": "a***e@example.com",
+							"note_key": "profile.authBindings.notes.emailManagedFromProfile",
 							"note": "Primary account email is managed from the profile form."
 						},
 						"linuxdo": {

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -134,6 +134,7 @@ type UserIdentitySummary struct {
 	BindStartPath string     `json:"bind_start_path,omitempty"`
 	CanBind       bool       `json:"can_bind"`
 	CanUnbind     bool       `json:"can_unbind"`
+	NoteKey       string     `json:"note_key,omitempty"`
 	Note          string     `json:"note,omitempty"`
 }
 
@@ -155,6 +156,12 @@ type StartUserIdentityBindingResult struct {
 	Method             string `json:"method"`
 	UseBrowserRedirect bool   `json:"use_browser_redirect"`
 }
+
+const (
+	userIdentityNoteEmailManagedFromProfile = "profile.authBindings.notes.emailManagedFromProfile"
+	userIdentityNoteCanUnbind               = "profile.authBindings.notes.canUnbind"
+	userIdentityNoteBindAnotherBeforeUnbind = "profile.authBindings.notes.bindAnotherBeforeUnbind"
+)
 
 // UpdateProfileRequest 更新用户资料请求
 type UpdateProfileRequest struct {
@@ -601,6 +608,7 @@ func (s *UserService) buildEmailIdentitySummary(user *User, records []UserAuthId
 		Provider:  "email",
 		CanBind:   false,
 		CanUnbind: false,
+		NoteKey:   userIdentityNoteEmailManagedFromProfile,
 		Note:      "Primary account email is managed from the profile form.",
 	}
 	if user == nil {
@@ -668,8 +676,10 @@ func (s *UserService) buildProviderIdentitySummary(provider string, user *User, 
 	summary.VerifiedAt = primary.VerifiedAt
 	summary.CanUnbind = s.canUnbindProvider(provider, user, records)
 	if summary.CanUnbind {
+		summary.NoteKey = userIdentityNoteCanUnbind
 		summary.Note = "You can unbind this sign-in method."
 	} else {
+		summary.NoteKey = userIdentityNoteBindAnotherBeforeUnbind
 		summary.Note = "Bind another sign-in method before unbinding."
 	}
 	return summary

--- a/frontend/src/components/user/profile/ProfileIdentityBindingsSection.vue
+++ b/frontend/src/components/user/profile/ProfileIdentityBindingsSection.vue
@@ -67,23 +67,23 @@
               </p>
 
               <div
-                v-if="item.details && (item.details.display_name || item.details.subject_hint || bindingCountLabel(item.details) || item.details.note)"
+                v-if="hasBindingDetails(item.provider, item.details)"
                 class="grid gap-1 text-sm text-gray-500 dark:text-gray-400"
               >
                 <p
-                  v-if="item.details.display_name"
+                  v-if="item.provider !== 'email' && item.details?.display_name"
                   class="font-medium text-gray-700 dark:text-gray-200"
                 >
                   {{ item.details.display_name }}
                 </p>
-                <p v-if="item.details.subject_hint">
+                <p v-if="item.provider !== 'email' && item.details?.subject_hint">
                   {{ item.details.subject_hint }}
                 </p>
                 <p v-if="bindingCountLabel(item.details)">
                   {{ bindingCountLabel(item.details) }}
                 </p>
-                <p v-if="item.details.note">
-                  {{ item.details.note }}
+                <p v-if="bindingNote(item.details)">
+                  {{ bindingNote(item.details) }}
                 </p>
               </div>
 
@@ -298,6 +298,13 @@ const emailSubmitActionLabel = computed(() =>
     ? t('profile.authBindings.confirmEmailReplaceAction')
     : t('profile.authBindings.confirmEmailBindAction')
 )
+const legacyBindingNoteKeys: Record<string, string> = {
+  'Primary account email is managed from the profile form.':
+    'profile.authBindings.notes.emailManagedFromProfile',
+  'You can unbind this sign-in method.': 'profile.authBindings.notes.canUnbind',
+  'Bind another sign-in method before unbinding.':
+    'profile.authBindings.notes.bindAnotherBeforeUnbind',
+}
 
 function resolveLegacyCompatibleWeChatSettings(
   settings: WeChatOAuthPublicSettings | null | undefined
@@ -487,6 +494,36 @@ function bindingCountLabel(details: UserAuthBindingStatus | null): string {
     return ''
   }
   return t('profile.authBindings.boundCount', { count: details.bound_count })
+}
+
+function bindingNote(details: UserAuthBindingStatus | null): string {
+  if (!details) {
+    return ''
+  }
+
+  const noteKey = details.note_key?.trim() || legacyBindingNoteKeys[details.note?.trim() || ''] || ''
+  if (noteKey) {
+    const translated = t(noteKey)
+    if (translated !== noteKey) {
+      return translated
+    }
+  }
+
+  return details.note?.trim() || ''
+}
+
+function hasBindingDetails(
+  provider: UserAuthProvider,
+  details: UserAuthBindingStatus | null
+): boolean {
+  if (!details) {
+    return false
+  }
+
+  const showsProviderIdentityDetails =
+    provider !== 'email' && Boolean(details.display_name || details.subject_hint)
+
+  return Boolean(showsProviderIdentityDetails || bindingCountLabel(details) || bindingNote(details))
 }
 
 function toggleEmailForm(): void {

--- a/frontend/src/components/user/profile/__tests__/ProfileIdentityBindingsSection.spec.ts
+++ b/frontend/src/components/user/profile/__tests__/ProfileIdentityBindingsSection.spec.ts
@@ -64,6 +64,12 @@ vi.mock('vue-i18n', async (importOriginal) => {
         if (key === 'profile.authBindings.codeSentTo') return `Code sent to ${params?.email || ''}`.trim()
         if (key === 'profile.authBindings.bindSuccess') return 'Bind success'
         if (key === 'profile.authBindings.replaceSuccess') return 'Primary email updated'
+        if (key === 'profile.authBindings.notes.emailManagedFromProfile')
+          return 'Primary email is managed in the profile form'
+        if (key === 'profile.authBindings.notes.canUnbind')
+          return 'You can unbind this sign-in method'
+        if (key === 'profile.authBindings.notes.bindAnotherBeforeUnbind')
+          return 'Bind another sign-in method before unbinding'
         return key
       },
     }),
@@ -164,7 +170,7 @@ describe('ProfileIdentityBindingsSection', () => {
 
     await wrapper.get('[data-testid="profile-binding-wechat-action"]').trigger('click')
 
-    expect(locationState.current.href).toContain('/api/v1/auth/oauth/wechat/start?')
+    expect(locationState.current.href).toContain('/api/v1/auth/oauth/wechat/bind/start?')
     expect(locationState.current.href).toContain('mode=open')
     expect(locationState.current.href).toContain('intent=bind_current_user')
     expect(locationState.current.href).toContain('redirect=%2Fprofile')
@@ -219,7 +225,7 @@ describe('ProfileIdentityBindingsSection', () => {
 
     await wrapper.get('[data-testid="profile-binding-wechat-action"]').trigger('click')
 
-    expect(locationState.current.href).toContain('/api/v1/auth/oauth/wechat/start?')
+    expect(locationState.current.href).toContain('/api/v1/auth/oauth/wechat/bind/start?')
     expect(locationState.current.href).toContain('mode=open')
     expect(locationState.current.href).toContain('intent=bind_current_user')
     expect(locationState.current.href).toContain('redirect=%2Fprofile')
@@ -401,6 +407,36 @@ describe('ProfileIdentityBindingsSection', () => {
     expect(wrapper.get('[data-testid="profile-binding-email-status"]').text()).toBe('Not bound')
   })
 
+  it('shows the bound email only once and localizes the email management note', () => {
+    const wrapper = mount(ProfileIdentityBindingsSection, {
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        user: createUser({
+          email: 'alice@example.com',
+          email_bound: true,
+          auth_bindings: {
+            email: {
+              bound: true,
+              display_name: 'alice@example.com',
+              subject_hint: 'a***e@example.com',
+              note_key: 'profile.authBindings.notes.emailManagedFromProfile',
+              note: 'Primary account email is managed from the profile form.',
+            } as any,
+          },
+        }),
+        linuxdoEnabled: false,
+        oidcEnabled: false,
+        wechatEnabled: false,
+      },
+    })
+
+    expect(wrapper.text().match(/alice@example\.com/g)).toHaveLength(1)
+    expect(wrapper.text()).not.toContain('a***e@example.com')
+    expect(wrapper.text()).toContain('Primary email is managed in the profile form')
+  })
+
   it('keeps the email form available for replacing a bound primary email', async () => {
     userApiMocks.sendEmailBindingCode.mockResolvedValue(undefined)
     userApiMocks.bindEmailIdentity.mockResolvedValue(
@@ -539,6 +575,36 @@ describe('ProfileIdentityBindingsSection', () => {
 
     expect(userApiMocks.unbindAuthIdentity).toHaveBeenCalledWith('linuxdo')
     expect(wrapper.get('[data-testid="profile-binding-linuxdo-status"]').text()).toBe('Not bound')
+  })
+
+  it('localizes third-party unbind guidance from note_key', () => {
+    const wrapper = mount(ProfileIdentityBindingsSection, {
+      global: {
+        plugins: [pinia],
+      },
+      props: {
+        user: createUser({
+          email_bound: true,
+          linuxdo_bound: true,
+          auth_bindings: {
+            email: { bound: true },
+            linuxdo: {
+              bound: true,
+              display_name: 'linuxdo-handle',
+              note_key: 'profile.authBindings.notes.canUnbind',
+              note: 'You can unbind this sign-in method.',
+              can_unbind: true,
+            } as any,
+          },
+        }),
+        linuxdoEnabled: true,
+        oidcEnabled: false,
+        wechatEnabled: false,
+      },
+    })
+
+    expect(wrapper.text()).toContain('You can unbind this sign-in method')
+    expect(wrapper.text()).not.toContain('You can unbind this sign-in method.')
   })
 
   it('hides bind actions when provider details say bindable but the provider is disabled', () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1042,6 +1042,11 @@ export default {
         oidc: '{providerName}',
         wechat: 'WeChat',
       },
+      notes: {
+        emailManagedFromProfile: 'Primary email is managed in the profile form',
+        canUnbind: 'You can unbind this sign-in method',
+        bindAnotherBeforeUnbind: 'Bind another sign-in method before unbinding',
+      },
       source: {
         avatar: 'Avatar is currently synced from {providerName}',
         username: 'Nickname is currently synced from {providerName}',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1046,6 +1046,11 @@ export default {
         oidc: '{providerName}',
         wechat: '微信',
       },
+      notes: {
+        emailManagedFromProfile: '主邮箱在资料表单中管理',
+        canUnbind: '你可以解绑这个登录方式。',
+        bindAnotherBeforeUnbind: '请先绑定其他登录方式，再解除当前绑定。',
+      },
       source: {
         avatar: '头像当前来自 {providerName}',
         username: '昵称当前来自 {providerName}',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -51,6 +51,7 @@ export interface UserAuthBindingStatus {
   bind_start_path?: string | null
   can_bind?: boolean
   can_unbind?: boolean
+  note_key?: string | null
   note?: string | null
   metadata?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary
本 PR 包含两个改进：
1. **修正邮箱重复显示问题**：邮箱绑定状态不再重复显示邮箱地址和提示信息
2. **添加国际化支持**：为身份绑定提示信息添加 i18n 支持，提升多语言用户体验

## Changes

### 1. 修正邮箱重复显示
**Frontend**
- 优化 `hasBindingDetails()` 函数，对 `email` 类型的绑定跳过 `display_name` 和 `subject_hint` 的显示
- 避免在绑定详情区域重复显示已在标题区域展示的邮箱地址

### 2. 添加国际化支持
**Backend**
- 在 `UserIdentitySummary` 结构体中添加 `note_key` 字段
- 定义三个提示信息常量：
  - `emailManagedFromProfile`: 主邮箱在资料表单中管理
  - `canUnbind`: 可以解绑此登录方式
  - `bindAnotherBeforeUnbind`: 需先绑定其他方式才能解绑
- 更新相关测试用例验证 `note_key` 字段

**Frontend**
- 实现 `bindingNote()` 函数，优先使用 `note_key` 进行国际化翻译
- 添加向后兼容逻辑（`legacyBindingNoteKeys`），支持旧的硬编码 `note` 文本
- 在 `en.ts` 和 `zh.ts` 中添加对应的翻译文本
- 更新测试用例验证国际化功能

## Test plan
- ✅ 后端单元测试通过
- ✅ 前端组件测试通过
- ✅ API 契约测试通过
- ✅ 验证邮箱不再重复显示
- ✅ 验证中英文提示信息正确显示