### PR TITLE
fix: use site name as TOTP issuer instead of hardcoded Sub2API

### DIFF
--- a/backend/internal/service/totp_service.go
+++ b/backend/internal/service/totp_service.go
@@ -85,11 +85,11 @@ type TotpSetupResponse struct {
 }
 
 const (
-	totpSetupTTL    = 5 * time.Minute
-	totpLoginTTL    = 5 * time.Minute
-	totpAttemptsTTL = 15 * time.Minute
-	maxTotpAttempts = 5
-	totpIssuer      = "Sub2API"
+	totpSetupTTL       = 5 * time.Minute
+	totpLoginTTL       = 5 * time.Minute
+	totpAttemptsTTL    = 15 * time.Minute
+	maxTotpAttempts    = 5
+	totpIssuerFallback = "Sub2API"
 )
 
 // TotpService handles TOTP operations
@@ -175,8 +175,12 @@ func (s *TotpService) InitiateSetup(ctx context.Context, userID int64, emailCode
 	}
 
 	// Generate a new TOTP key
+	issuer := s.settingService.GetSiteName(ctx)
+	if issuer == "" {
+		issuer = totpIssuerFallback
+	}
 	key, err := totp.Generate(totp.GenerateOpts{
-		Issuer:      totpIssuer,
+		Issuer:      issuer,
 		AccountName: user.Email,
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #1782

## Problem

The TOTP issuer was hardcoded to `"Sub2API"` in `totp_service.go`, causing authenticator apps (Google Authenticator, 1Password, etc.) to always display `Sub2API: user@example.com` regardless of the site name configured in system settings.

## Solution

Replace the hardcoded `totpIssuer` constant with a dynamic lookup via `s.settingService.GetSiteName(ctx)` when generating the TOTP key in `InitiateSetup`. Falls back to `"Sub2API"` when no site name is configured, preserving backward-compatible behavior.

The `GetSiteName` method already exists on `SettingService` and is already used elsewhere in the same file (e.g., `SendVerifyCode`).

## Testing

- With site name set to e.g. `"MyApp"` in admin settings: new TOTP QR codes will produce issuer `MyApp`, showing `MyApp: user@email.com` in authenticator apps.
- With site name empty/unset: falls back to `Sub2API` as before.
- Existing TOTP secrets are unaffected (verification uses the stored secret, not the issuer).