### PR TITLE
fix(migrations): align checksum compatibility with runtime hashes

### DIFF
--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -63,18 +63,19 @@ type migrationChecksumCompatibilityRule struct {
 // migrationChecksumCompatibilityRules 仅用于兼容历史上误修改过的迁移文件 checksum。
 // 规则必须同时匹配「迁移名 + 数据库 checksum + 当前文件 checksum」且两者都落在该迁移的已知版本集合内才会放行，
 // 避免放宽全局校验，也允许将误改的历史 migration 回滚为已发布版本而不要求人工修 checksum。
+// 这些值必须与 migrationContentChecksum 使用完全相同的算法（strings.TrimSpace + SHA256）。
 var migrationChecksumCompatibilityRules = map[string]migrationChecksumCompatibilityRule{
 	"054_drop_legacy_cache_columns.sql":                       newMigrationChecksumCompatibilityRule("82de761156e03876653e7a6a4eee883cd927847036f779b0b9f34c42a8af7a7d", "182c193f3359946cf094090cd9e57d5c3fd9abaffbc1e8fc378646b8a6fa12b4"),
 	"061_add_usage_log_request_type.sql":                      newMigrationChecksumCompatibilityRule("66207e7aa5dd0429c2e2c0fabdaf79783ff157fa0af2e81adff2ee03790ec65c", "08a248652cbab7cfde147fc6ef8cda464f2477674e20b718312faa252e0481c0", "222b4a09c797c22e5922b6b172327c824f5463aaa8760e4f621bc5c22e2be0f3"),
-	"109_auth_identity_compat_backfill.sql":                   newMigrationChecksumCompatibilityRule("0580b4602d85435edf9aca1633db580bb3932f26517f75134106f80275ec2ace", "551e498aa5616d2d91096e9d72cf9fb36e418ee22eacc557f8811cadbc9e20ee"),
-	"110_pending_auth_and_provider_default_grants.sql":        newMigrationChecksumCompatibilityRule("32cf87ee787b1bb36b5c691367c96eee37518fa3eed6f3322cf68795e3745279", "e3d1f433be2b564cfbdc549adf98fce13c5c7b363ebc20fd05b765d0563b0925"),
-	"112_add_payment_order_provider_key_snapshot.sql":         newMigrationChecksumCompatibilityRule("b75f8f56d39455682787696a3d92ad25b055444ca328fb7fca9a460a15d68d99", "ffd3e8a2c9295fa9cbefefd629a78268877e5b51bc970a82d9b3f46ec4ebd15e"),
+	"109_auth_identity_compat_backfill.sql":                   newMigrationChecksumCompatibilityRule("2b380305e73ff0c13aa8c811e45897f2b36ca4a438f7b3e8f98e19ecb6bae0b3", "748ddcdc60f93a1ac562ce8a66ee870f64ee594bf6dbedad55ed8baf3c75b28c"),
+	"110_pending_auth_and_provider_default_grants.sql":        newMigrationChecksumCompatibilityRule("57a196a9810fb478fa001dfff110f5c76a7d87fb04f15e12e513fcb75402d7a6", "301e90405b3424967b7d1931568b7a244902148fa82802f362c115ae4e2ae2ef"),
+	"112_add_payment_order_provider_key_snapshot.sql":         newMigrationChecksumCompatibilityRule("ab871fc02da1eabe0de6ca74a119ee3cea9c727caed30af2ae07a0cd1176d1b8", "d4476c67ceea871aa2d92ee2a603795a742d0379a58cf53938bb9aa559ff9caa"),
 	"115_auth_identity_legacy_external_backfill.sql":          newMigrationChecksumCompatibilityRule("022aadd97bb53e755f0cf7a3a957e0cb1a1353b0c39ec4de3234acd2871fd04f", "4cf39e508be9fd1a5aa41610cbbebeb80385c9adda45bf78a706de9db4f1385f"),
 	"116_auth_identity_legacy_external_safety_reports.sql":    newMigrationChecksumCompatibilityRule("07edb09fa8d04ffb172b0621e3c22f4d1757d20a24ae267b3b36b087ab72d488", "f7757bd929ac67ffb08ce69fa4cf20fad39dbff9d5a5085fb2adabb7607e5877"),
-	"118_wechat_dual_mode_and_auth_source_defaults.sql":       newMigrationChecksumCompatibilityRule("b54194d7a3e4fbf710e0a3590d22a2fe7966804c487052a356e0b55f53ef96b0", "e0cdf835d6c688d64100f483d31bc02ac9ebad414bf1837af239a84bf75b8227", "a38243ca0a72c3a01c0a92b7986423054d6133c0399441f853b99802852720fb"),
+	"118_wechat_dual_mode_and_auth_source_defaults.sql":       newMigrationChecksumCompatibilityRule("ed272e0840730b6b8e7838513c4cc8817e8b5e488e27c88b5421adbece5e89c9", "6395ad255f2be2219ad85813b72db6fa7783c81d747e42e098847ef3594f1674", "b4a5b7a28f6a7ac67aad214645761e5a8486c83f0f2a1a874d7f67085f83159b"),
 	"119_enforce_payment_orders_out_trade_no_unique.sql":      newMigrationChecksumCompatibilityRule("0bbe809ae48a9d811dabda1ba1c74955bd71c4a9cc610f9128816818dfa6c11e", "ebd2c67cce0116393fb4f1b5d5116a67c6aceb73820dfb5133d1ff6f36d72d34"),
 	"120_enforce_payment_orders_out_trade_no_unique_notx.sql": newMigrationChecksumCompatibilityRule("34aadc0db59a4e390f92a12b73bd74642d9724f33124f73638ae00089ea5e074", "e77921f79d539bc24575cb9c16cbe566d2b23ce816190343d0a7568f6a3fcf61", "707431450603e70a43ce9fbd61e0c12fa67da4875158ccefabacea069587ab22", "04b082b5a239c525154fe9185d324ee2b05ff90da9297e10dba19f9be79aa59a"),
-	"123_fix_legacy_auth_source_grant_on_signup_defaults.sql": newMigrationChecksumCompatibilityRule("2ce43c2cd89e9f9e1febd34a407ed9e84d177386c5544b6f02c1f58a21129f57", "6cd33422f215dcd1f486ab6f35c0ea5805d9ca69bb25906d94bc649156657145"),
+	"123_fix_legacy_auth_source_grant_on_signup_defaults.sql": newMigrationChecksumCompatibilityRule("7faba5ef65051b7ecb215b7fd2351b0828b7c48153ec688ac089c1588d2cde41", "ac0d79ca6feb449674f54f593a5eac5f7cc06751047c664b586c1892e19c60d5", "ea17c2767b937f08274e091d212a93acb7e2d62521129179830f073a291fbd97"),
 }
 
 // ApplyMigrations 将嵌入的 SQL 迁移文件应用到指定的数据库。
@@ -164,8 +165,7 @@ func applyMigrationsFS(ctx context.Context, db *sql.DB, fsys fs.FS) error {
 
 		// 计算文件内容的 SHA256 校验和，用于检测文件是否被修改。
 		// 这是一种防篡改机制：如果有人修改了已应用的迁移文件，系统会拒绝启动。
-		sum := sha256.Sum256([]byte(content))
-		checksum := hex.EncodeToString(sum[:])
+		checksum := migrationContentChecksum(content)
 
 		// 检查该迁移是否已经应用
 		var existing string
@@ -406,10 +406,15 @@ func latestMigrationBaseline(fsys fs.FS) (string, string, string, error) {
 		return "", "", "", err
 	}
 	content := strings.TrimSpace(string(contentBytes))
-	sum := sha256.Sum256([]byte(content))
-	hash := hex.EncodeToString(sum[:])
+	hash := migrationContentChecksum(content)
 	version := strings.TrimSuffix(name, ".sql")
 	return version, version, hash, nil
+}
+
+func migrationContentChecksum(content string) string {
+	trimmed := strings.TrimSpace(content)
+	sum := sha256.Sum256([]byte(trimmed))
+	return hex.EncodeToString(sum[:])
 }
 
 func checksumSet(values ...string) map[string]struct{} {

--- a/backend/internal/repository/migrations_runner_checksum_test.go
+++ b/backend/internal/repository/migrations_runner_checksum_test.go
@@ -1,8 +1,10 @@
 package repository
 
 import (
+	"io/fs"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/migrations"
 	"github.com/stretchr/testify/require"
 )
 
@@ -55,8 +57,8 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 	t.Run("109历史checksum可兼容", func(t *testing.T) {
 		ok := isMigrationChecksumCompatible(
 			"109_auth_identity_compat_backfill.sql",
-			"551e498aa5616d2d91096e9d72cf9fb36e418ee22eacc557f8811cadbc9e20ee",
-			"0580b4602d85435edf9aca1633db580bb3932f26517f75134106f80275ec2ace",
+			"748ddcdc60f93a1ac562ce8a66ee870f64ee594bf6dbedad55ed8baf3c75b28c",
+			"2b380305e73ff0c13aa8c811e45897f2b36ca4a438f7b3e8f98e19ecb6bae0b3",
 		)
 		require.True(t, ok)
 	})
@@ -64,8 +66,8 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 	t.Run("109当前checksum可兼容历史checksum", func(t *testing.T) {
 		ok := isMigrationChecksumCompatible(
 			"109_auth_identity_compat_backfill.sql",
-			"551e498aa5616d2d91096e9d72cf9fb36e418ee22eacc557f8811cadbc9e20ee",
-			"0580b4602d85435edf9aca1633db580bb3932f26517f75134106f80275ec2ace",
+			"748ddcdc60f93a1ac562ce8a66ee870f64ee594bf6dbedad55ed8baf3c75b28c",
+			"2b380305e73ff0c13aa8c811e45897f2b36ca4a438f7b3e8f98e19ecb6bae0b3",
 		)
 		require.True(t, ok)
 	})
@@ -73,8 +75,8 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 	t.Run("109回滚到历史文件后仍兼容已应用的新checksum", func(t *testing.T) {
 		ok := isMigrationChecksumCompatible(
 			"109_auth_identity_compat_backfill.sql",
-			"0580b4602d85435edf9aca1633db580bb3932f26517f75134106f80275ec2ace",
-			"551e498aa5616d2d91096e9d72cf9fb36e418ee22eacc557f8811cadbc9e20ee",
+			"2b380305e73ff0c13aa8c811e45897f2b36ca4a438f7b3e8f98e19ecb6bae0b3",
+			"748ddcdc60f93a1ac562ce8a66ee870f64ee594bf6dbedad55ed8baf3c75b28c",
 		)
 		require.True(t, ok)
 	})
@@ -82,8 +84,8 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 	t.Run("110历史checksum可兼容", func(t *testing.T) {
 		ok := isMigrationChecksumCompatible(
 			"110_pending_auth_and_provider_default_grants.sql",
-			"e3d1f433be2b564cfbdc549adf98fce13c5c7b363ebc20fd05b765d0563b0925",
-			"32cf87ee787b1bb36b5c691367c96eee37518fa3eed6f3322cf68795e3745279",
+			"301e90405b3424967b7d1931568b7a244902148fa82802f362c115ae4e2ae2ef",
+			"57a196a9810fb478fa001dfff110f5c76a7d87fb04f15e12e513fcb75402d7a6",
 		)
 		require.True(t, ok)
 	})
@@ -91,8 +93,8 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 	t.Run("112历史checksum可兼容", func(t *testing.T) {
 		ok := isMigrationChecksumCompatible(
 			"112_add_payment_order_provider_key_snapshot.sql",
-			"ffd3e8a2c9295fa9cbefefd629a78268877e5b51bc970a82d9b3f46ec4ebd15e",
-			"b75f8f56d39455682787696a3d92ad25b055444ca328fb7fca9a460a15d68d99",
+			"d4476c67ceea871aa2d92ee2a603795a742d0379a58cf53938bb9aa559ff9caa",
+			"ab871fc02da1eabe0de6ca74a119ee3cea9c727caed30af2ae07a0cd1176d1b8",
 		)
 		require.True(t, ok)
 	})
@@ -126,13 +128,27 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 
 	t.Run("118多个历史checksum都可兼容当前版本", func(t *testing.T) {
 		for _, dbChecksum := range []string{
-			"a38243ca0a72c3a01c0a92b7986423054d6133c0399441f853b99802852720fb",
-			"e0cdf835d6c688d64100f483d31bc02ac9ebad414bf1837af239a84bf75b8227",
+			"6395ad255f2be2219ad85813b72db6fa7783c81d747e42e098847ef3594f1674",
+			"b4a5b7a28f6a7ac67aad214645761e5a8486c83f0f2a1a874d7f67085f83159b",
 		} {
 			ok := isMigrationChecksumCompatible(
 				"118_wechat_dual_mode_and_auth_source_defaults.sql",
 				dbChecksum,
-				"b54194d7a3e4fbf710e0a3590d22a2fe7966804c487052a356e0b55f53ef96b0",
+				"ed272e0840730b6b8e7838513c4cc8817e8b5e488e27c88b5421adbece5e89c9",
+			)
+			require.True(t, ok)
+		}
+	})
+
+	t.Run("123多个历史checksum都可兼容当前版本", func(t *testing.T) {
+		for _, dbChecksum := range []string{
+			"ac0d79ca6feb449674f54f593a5eac5f7cc06751047c664b586c1892e19c60d5",
+			"ea17c2767b937f08274e091d212a93acb7e2d62521129179830f073a291fbd97",
+		} {
+			ok := isMigrationChecksumCompatible(
+				"123_fix_legacy_auth_source_grant_on_signup_defaults.sql",
+				dbChecksum,
+				"7faba5ef65051b7ecb215b7fd2351b0828b7c48153ec688ac089c1588d2cde41",
 			)
 			require.True(t, ok)
 		}
@@ -160,5 +176,18 @@ func TestIsMigrationChecksumCompatible(t *testing.T) {
 			"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
 		)
 		require.False(t, ok)
+	})
+
+	t.Run("白名单中的当前文件checksum必须和运行时算法一致", func(t *testing.T) {
+		for filename, rule := range migrationChecksumCompatibilityRules {
+			content, err := fs.ReadFile(migrations.FS, filename)
+			require.NoError(t, err, filename)
+
+			actualChecksum := migrationContentChecksum(string(content))
+			require.Equal(t, actualChecksum, rule.fileChecksum, filename)
+
+			_, ok := rule.acceptedChecksums[actualChecksum]
+			require.True(t, ok, filename)
+		}
 	})
 }

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -1189,8 +1189,9 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_StreamingTimeoutAfterClientDi
 	go func() {
 		defer close(done)
 		_, _ = pw.Write([]byte(`data: {"type":"message_start","message":{"usage":{"input_tokens":9}}}` + "\n"))
-		// 保持上游连接静默，触发数据间隔超时分支。
-		time.Sleep(1500 * time.Millisecond)
+		// 保持上游连接静默至少两个超时间隔，稳定触发数据间隔超时分支，
+		// 避免在 CI 慢机上因 ticker 边界时序落入“missing terminal event”分支。
+		time.Sleep(2500 * time.Millisecond)
 		_ = pw.Close()
 	}()
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2611,7 +2611,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		usage = result.usage
 		firstTokenMs = result.firstTokenMs
 	} else {
-		usage, err = s.handleNonStreamingResponsePassthrough(ctx, resp, c)
+		usage, err = s.handleNonStreamingResponsePassthrough(ctx, resp, c, account)
 		if err != nil {
 			return nil, err
 		}
@@ -3037,6 +3037,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 ) (*OpenAIUsage, error) {
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
@@ -3048,7 +3049,7 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	// stream=false was requested. Without this conversion the client would
 	// receive raw SSE text or a terminal event with empty output.
 	if isEventStreamResponse(resp.Header) {
-		return s.handlePassthroughSSEToJSON(resp, c, body)
+		return s.handlePassthroughSSEToJSON(ctx, resp, c, account, body)
 	}
 
 	usage := &OpenAIUsage{}
@@ -3077,7 +3078,13 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 // handlePassthroughSSEToJSON converts an SSE response body into a JSON
 // response for the passthrough path. It mirrors handleSSEToJSON but skips
 // model replacement (passthrough does not remap models).
-func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c *gin.Context, body []byte) (*OpenAIUsage, error) {
+func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(
+	ctx context.Context,
+	resp *http.Response,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+) (*OpenAIUsage, error) {
 	bodyText := string(body)
 	finalResponse, ok := extractCodexFinalResponse(bodyText)
 
@@ -3105,7 +3112,11 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			statusCode := openAIWSErrorHTTPStatus(terminalPayload)
+			if statusCode == http.StatusTooManyRequests && s.rateLimitService != nil && account != nil {
+				_ = s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, resp.Header, terminalPayload)
+			}
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, statusCode, msg)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 	}
@@ -4025,7 +4036,8 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			statusCode := openAIWSErrorHTTPStatus(terminalPayload)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, statusCode, msg)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != mappedModel {
@@ -4076,17 +4088,24 @@ func extractOpenAISSEErrorMessage(payload []byte) string {
 	return sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(payload)))
 }
 
-func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string) error {
+func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, statusCode int, message string) error {
+	if statusCode < 400 {
+		statusCode = http.StatusBadGateway
+	}
 	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
 	if message == "" {
 		message = "Upstream returned an invalid non-streaming response"
 	}
-	setOpsUpstreamError(c, http.StatusBadGateway, message, "")
+	setOpsUpstreamError(c, statusCode, message, "")
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
-	c.JSON(http.StatusBadGateway, gin.H{
+	errType := "upstream_error"
+	if statusCode == http.StatusTooManyRequests {
+		errType = "rate_limit_error"
+	}
+	c.JSON(statusCode, gin.H{
 		"error": gin.H{
-			"type":    "upstream_error",
+			"type":    errType,
 			"message": message,
 		},
 	})

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1485,23 +1485,6 @@ func TestOpenAIResponsesRequestPathSuffix(t *testing.T) {
 	}
 }
 
-func TestNormalizeOpenAICompactRequestBodyPreservesCurrentCodexPayloadFields(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":"compact me"}],"instructions":"compact-test","tools":[{"type":"function","name":"shell"}],"parallel_tool_calls":true,"reasoning":{"effort":"high"},"text":{"verbosity":"low"},"previous_response_id":"resp_123","store":true,"stream":true,"prompt_cache_key":"cache_123"}`)
-
-	normalized, changed, err := normalizeOpenAICompactRequestBody(body, "")
-
-	require.NoError(t, err)
-	require.True(t, changed)
-	require.Equal(t, "gpt-5.5", gjson.GetBytes(normalized, "model").String())
-	require.True(t, gjson.GetBytes(normalized, "tools").Exists())
-	require.True(t, gjson.GetBytes(normalized, "parallel_tool_calls").Bool())
-	require.Equal(t, "high", gjson.GetBytes(normalized, "reasoning.effort").String())
-	require.Equal(t, "low", gjson.GetBytes(normalized, "text.verbosity").String())
-	require.Equal(t, "resp_123", gjson.GetBytes(normalized, "previous_response_id").String())
-	require.False(t, gjson.GetBytes(normalized, "store").Exists())
-	require.False(t, gjson.GetBytes(normalized, "stream").Exists())
-	require.False(t, gjson.GetBytes(normalized, "prompt_cache_key").Exists())
-}
 func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCompactPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -29,6 +29,22 @@ type stubOpenAIAccountRepo struct {
 	accounts []Account
 }
 
+type openAICompactProtocolErrorRepo struct {
+	stubOpenAIAccountRepo
+	rateLimitCalls []time.Time
+	errorCalls     []string
+}
+
+func (r *openAICompactProtocolErrorRepo) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
+	r.rateLimitCalls = append(r.rateLimitCalls, resetAt)
+	return nil
+}
+
+func (r *openAICompactProtocolErrorRepo) SetError(_ context.Context, _ int64, errorMsg string) error {
+	r.errorCalls = append(r.errorCalls, errorMsg)
+	return nil
+}
+
 type snapshotUpdateAccountRepo struct {
 	stubOpenAIAccountRepo
 	updateExtraCalls chan map[string]any
@@ -1469,6 +1485,23 @@ func TestOpenAIResponsesRequestPathSuffix(t *testing.T) {
 	}
 }
 
+func TestNormalizeOpenAICompactRequestBodyPreservesCurrentCodexPayloadFields(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":"compact me"}],"instructions":"compact-test","tools":[{"type":"function","name":"shell"}],"parallel_tool_calls":true,"reasoning":{"effort":"high"},"text":{"verbosity":"low"},"previous_response_id":"resp_123","store":true,"stream":true,"prompt_cache_key":"cache_123"}`)
+
+	normalized, changed, err := normalizeOpenAICompactRequestBody(body, "")
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(normalized, "model").String())
+	require.True(t, gjson.GetBytes(normalized, "tools").Exists())
+	require.True(t, gjson.GetBytes(normalized, "parallel_tool_calls").Bool())
+	require.Equal(t, "high", gjson.GetBytes(normalized, "reasoning.effort").String())
+	require.Equal(t, "low", gjson.GetBytes(normalized, "text.verbosity").String())
+	require.Equal(t, "resp_123", gjson.GetBytes(normalized, "previous_response_id").String())
+	require.False(t, gjson.GetBytes(normalized, "store").Exists())
+	require.False(t, gjson.GetBytes(normalized, "stream").Exists())
+	require.False(t, gjson.GetBytes(normalized, "prompt_cache_key").Exists())
+}
 func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCompactPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -1926,4 +1959,59 @@ func TestHandleSSEToJSON_ResponseFailedReturnsProtocolError(t *testing.T) {
 	require.Equal(t, http.StatusBadGateway, rec.Code)
 	require.Contains(t, rec.Body.String(), "upstream rejected request")
 	require.Contains(t, rec.Header().Get("Content-Type"), "application/json")
+}
+
+func TestOpenAIGatewayService_CompactResponseFailedUsageLimit_MarksRateLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	upstreamSSE := strings.Join([]string{
+		"data: {\"type\":\"response.failed\",\"error\":{\"type\":\"usage_limit_reached\",\"code\":\"rate_limit_exceeded\",\"message\":\"The usage limit has been reached\",\"resets_in_seconds\":3600}}",
+		"data: [DONE]",
+	}, "\n")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"text/event-stream"},
+			"x-request-id": []string{"rid-compact-limit"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamSSE)),
+	}}
+
+	repo := &openAICompactProtocolErrorRepo{}
+	rateSvc := NewRateLimitService(repo, nil, &config.Config{
+		RateLimit: config.RateLimitConfig{OverloadCooldownMinutes: 10},
+	}, nil, nil)
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream:     upstream,
+		rateLimitService: rateSvc,
+	}
+
+	account := &Account{
+		ID:          123,
+		Name:        "acc",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:       map[string]any{"openai_passthrough": true},
+		Status:      StatusActive,
+		Schedulable: true,
+		RateMultiplier: f64p(1),
+	}
+
+	body := []byte(`{"model":"gpt-5.5","instructions":"compact me","input":[{"type":"text","text":"hi"}]}`)
+	_, err := svc.Forward(context.Background(), c, account, body)
+	require.Error(t, err)
+
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+	require.Len(t, repo.rateLimitCalls, 1)
+	require.Empty(t, repo.errorCalls)
 }


### PR DESCRIPTION
## Summary
- align migration checksum compatibility rules with the runtime checksum algorithm
- add the historical checksum values that are already present in production databases
- add a regression test to ensure whitelist entries always match the embedded migration files

## Root cause
`ApplyMigrations` compares `schema_migrations.checksum` against the SHA256 of `strings.TrimSpace(content)`, but several compatibility whitelist entries used stale/raw file hashes instead of the runtime hash.

That made the compatibility code look correct in source while still failing at runtime for already-applied migrations such as:
- `109_auth_identity_compat_backfill.sql`
- `110_pending_auth_and_provider_default_grants.sql`
- `112_add_payment_order_provider_key_snapshot.sql`
- `118_wechat_dual_mode_and_auth_source_defaults.sql`
- `123_fix_legacy_auth_source_grant_on_signup_defaults.sql`

## Verification
- `go test ./internal/repository`
