### PR TITLE
fix: 修复账户配额跨越时调度快照入队逻辑

### DIFF
--- a/backend/internal/repository/usage_billing_repo.go
+++ b/backend/internal/repository/usage_billing_repo.go
@@ -290,7 +290,6 @@ func incrementUsageBillingAccountQuota(ctx context.Context, tx *sql.Tx, accountI
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = rows.Close() }()
 
 	var state service.AccountQuotaState
 	if rows.Next() {
@@ -299,18 +298,36 @@ func incrementUsageBillingAccountQuota(ctx context.Context, tx *sql.Tx, accountI
 			&state.DailyUsed, &state.DailyLimit,
 			&state.WeeklyUsed, &state.WeeklyLimit,
 		); err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
 	} else {
 		if err := rows.Err(); err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
+		_ = rows.Close()
 		return nil, service.ErrAccountNotFound
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
 		return nil, err
 	}
-	if state.TotalLimit > 0 && state.TotalUsed >= state.TotalLimit && (state.TotalUsed-amount) < state.TotalLimit {
+	// 必须在执行下一条 SQL 前显式关闭 rows：pq 驱动在同一连接上
+	// 不允许前一条查询的结果集未耗尽时启动新查询，否则会返回
+	// "unexpected Parse response" 错误。
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	// 任意维度额度在本次递增中从"未超"跨越到"已超"时，必须刷新调度快照，
+	// 否则 Redis 中缓存的 Account 仍显示旧的 used 值，后续请求会继续选中本账号，
+	// 最终观察到 daily_used / weekly_used 大幅超过配置的 limit。
+	// 对于日/周额度，即使本次触发了周期重置（pre=0、post=amount），
+	// 判定式 (post-amount) < limit 同样成立，逻辑与总额度保持一致。
+	crossedTotal := state.TotalLimit > 0 && state.TotalUsed >= state.TotalLimit && (state.TotalUsed-amount) < state.TotalLimit
+	crossedDaily := state.DailyLimit > 0 && state.DailyUsed >= state.DailyLimit && (state.DailyUsed-amount) < state.DailyLimit
+	crossedWeekly := state.WeeklyLimit > 0 && state.WeeklyUsed >= state.WeeklyLimit && (state.WeeklyUsed-amount) < state.WeeklyLimit
+	if crossedTotal || crossedDaily || crossedWeekly {
 		if err := enqueueSchedulerOutbox(ctx, tx, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil); err != nil {
 			logger.LegacyPrintf("repository.usage_billing", "[SchedulerOutbox] enqueue quota exceeded failed: account=%d err=%v", accountID, err)
 			return nil, err

--- a/backend/internal/repository/usage_billing_repo_integration_test.go
+++ b/backend/internal/repository/usage_billing_repo_integration_test.go
@@ -199,6 +199,94 @@ func TestUsageBillingRepositoryApply_UpdatesAccountQuota(t *testing.T) {
 	require.InDelta(t, 3.5, quotaUsed, 0.000001)
 }
 
+func TestUsageBillingRepositoryApply_EnqueuesSchedulerOutboxOnQuotaCrossing(t *testing.T) {
+	ctx := context.Background()
+	client := testEntClient(t)
+	repo := NewUsageBillingRepository(client, integrationDB)
+
+	newFixture := func(t *testing.T, extra map[string]any) (int64, int64) {
+		t.Helper()
+		user := mustCreateUser(t, client, &service.User{
+			Email:        fmt.Sprintf("usage-billing-outbox-user-%d-%s@example.com", time.Now().UnixNano(), uuid.NewString()),
+			PasswordHash: "hash",
+		})
+		apiKey := mustCreateApiKey(t, client, &service.APIKey{
+			UserID: user.ID,
+			Key:    "sk-usage-billing-outbox-" + uuid.NewString(),
+			Name:   "billing-outbox",
+		})
+		account := mustCreateAccount(t, client, &service.Account{
+			Name:  "usage-billing-outbox-" + uuid.NewString(),
+			Type:  service.AccountTypeAPIKey,
+			Extra: extra,
+		})
+		return apiKey.ID, account.ID
+	}
+
+	outboxCountFor := func(t *testing.T, accountID int64) int {
+		t.Helper()
+		var count int
+		require.NoError(t, integrationDB.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1 AND account_id = $2",
+			service.SchedulerOutboxEventAccountChanged, accountID,
+		).Scan(&count))
+		return count
+	}
+
+	t.Run("daily_first_crossing_enqueues", func(t *testing.T) {
+		apiKeyID, accountID := newFixture(t, map[string]any{
+			"quota_daily_limit": 10.0,
+		})
+		// 第一次低于日限额：不应入队 outbox
+		_, err := repo.Apply(ctx, &service.UsageBillingCommand{
+			RequestID:        uuid.NewString(),
+			APIKeyID:         apiKeyID,
+			AccountID:        accountID,
+			AccountType:      service.AccountTypeAPIKey,
+			AccountQuotaCost: 4,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 0, outboxCountFor(t, accountID), "below limit should not enqueue")
+
+		// 第二次跨越日限额：应入队一次 outbox
+		_, err = repo.Apply(ctx, &service.UsageBillingCommand{
+			RequestID:        uuid.NewString(),
+			APIKeyID:         apiKeyID,
+			AccountID:        accountID,
+			AccountType:      service.AccountTypeAPIKey,
+			AccountQuotaCost: 8,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, outboxCountFor(t, accountID), "crossing daily limit should enqueue once")
+
+		// 再次递增（已超）：不应重复入队
+		_, err = repo.Apply(ctx, &service.UsageBillingCommand{
+			RequestID:        uuid.NewString(),
+			APIKeyID:         apiKeyID,
+			AccountID:        accountID,
+			AccountType:      service.AccountTypeAPIKey,
+			AccountQuotaCost: 2,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, outboxCountFor(t, accountID), "subsequent increments beyond limit should not re-enqueue")
+	})
+
+	t.Run("weekly_first_crossing_enqueues", func(t *testing.T) {
+		apiKeyID, accountID := newFixture(t, map[string]any{
+			"quota_weekly_limit": 10.0,
+		})
+		_, err := repo.Apply(ctx, &service.UsageBillingCommand{
+			RequestID:        uuid.NewString(),
+			APIKeyID:         apiKeyID,
+			AccountID:        accountID,
+			AccountType:      service.AccountTypeAPIKey,
+			AccountQuotaCost: 15, // 单次即跨越
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, outboxCountFor(t, accountID), "single-shot crossing weekly limit should enqueue once")
+	})
+}
+
 func TestDashboardAggregationRepositoryCleanupUsageBillingDedup_BatchDeletesOldRows(t *testing.T) {
 	ctx := context.Background()
 	repo := newDashboardAggregationRepositoryWithSQL(integrationDB)


### PR DESCRIPTION
## Summary
- 修复账号"日/周限额"在 Redis 调度快照中未被及时失效、导致账号超限后仍被选中的 bug
- `incrementUsageBillingAccountQuota` 现会在日/周额度首次跨越限额时入队 `scheduler_outbox` 事件（此前仅总额度跨越才入队）
- 顺带修了同函数在 pq 驱动下 `rows` 未关闭即下一条查询的隐患，此前只有 total 跨越才触发，现 daily/weekly 也走 enqueue 必须先关闭 rows

## 背景
`GatewayService.SelectAccount*` 的候选账号来自 `schedulerSnapshot.ListSchedulableAccounts`，读取 Redis 缓存中的 `Account.extra`。每次计费后 DB 里的 `quota_daily_used` / `quota_weekly_used` 已更新，但只有"总额度首次跨越"才会通过 `scheduler_outbox` 通知调度服务重建快照：

- [usage_billing_repo.go:313](backend/internal/repository/usage_billing_repo.go#L313)（修改前）只判定 `TotalLimit`

结果：日/周额度超限不触发任何失效事件，缓存里的 `daily_used`/`weekly_used` 停留在旧值 → `IsQuotaExceeded()` 读缓存返回 `false` → 账号持续被调度命中，直到下次周期性全量重建（`runFullRebuildWorker`）才恢复。可观测到的症状是日用量累积到远高于配置的 `quota_daily_limit`。

## 修复
在 `incrementUsageBillingAccountQuota` 返回的 `AccountQuotaState` 上，把"本次首次跨越限额"的判定扩展到 total / daily / weekly 三维度，任一维度跨越即入队一次 `SchedulerOutboxEventAccountChanged`。

判定式：`post >= limit && (post - amount) < limit`
- 正常跨越（pre < limit，post ≥ limit）：入队
- 周期刚过重置为 `amount`、单次即超限（pre 视为 0）：入队
- 已超后的后续递增（pre ≥ limit）：不重复入队

## 附带修复
同函数内原有 `defer rows.Close()`，但在 rows 未耗尽的状态下调用 `enqueueSchedulerOutbox` 会在同一 `tx` 上发起新查询，pq 驱动会返回 `unexpected Parse response 'C'`。集成测试把这条路径跑起来后复现了该错误。改为在执行 enqueue 前显式 `rows.Close()`。

## Test plan
- [x] `go test -tags=unit ./...`
- [x] `go test -tags=integration ./internal/repository/...`
- [x] 新增集成测试 `TestUsageBillingRepositoryApply_EnqueuesSchedulerOutboxOnQuotaCrossing`，覆盖：低于限额不入队 / daily 首次跨越入队一次 / 已超后不重复入队 / weekly 单次跨越入队
- [x] 部署后观察有日/周限额配置的账号，确认超限后请求立刻被调度排除