### PR TITLE
fix: compatible with non-standard SSE format (no space after colon) from some Anthropic-compatible upstreams

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -230,7 +230,8 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseCCeventLine(line)
+		if !ok {
 			continue
 		}
 
@@ -238,15 +239,16 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseCCdataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			continue
 		}
+		event.Type = eventType
 
 		// message_start carries the initial response structure and cache usage
 		if event.Type == "message_start" && event.Message != nil {
@@ -421,7 +423,8 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseCCeventLine(line)
+		if !ok {
 			continue
 		}
 
@@ -429,15 +432,16 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseCCdataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			continue
 		}
+		event.Type = eventType
 
 		if processAnthropicEvent(&event) {
 			return resultWithUsage(), nil
@@ -482,4 +486,28 @@ func writeGatewayCCError(c *gin.Context, statusCode int, errType, message string
 			"message": message,
 		},
 	})
+}
+
+// parseCCeventLine extracts the event name from an SSE "event:" line.
+// Compatible with both "event: name" (with space) and "event:name" (without space).
+func parseCCeventLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "event: ") {
+		return strings.TrimSpace(line[7:]), true
+	}
+	if strings.HasPrefix(line, "event:") {
+		return strings.TrimSpace(line[6:]), true
+	}
+	return "", false
+}
+
+// parseCCdataLine extracts the data payload from an SSE "data:" line.
+// Compatible with both "data: {...}" (with space) and "data:{...}" (without space).
+func parseCCdataLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "data: ") {
+		return line[6:], true
+	}
+	if strings.HasPrefix(line, "data:") {
+		return line[5:], true
+	}
+	return "", false
 }

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -240,20 +240,20 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseRespEventLine(line)
+		if !ok {
 			continue
 		}
-		eventType := strings.TrimPrefix(line, "event: ")
 
 		// Read the data line
 		if !scanner.Scan() {
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseRespDataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -263,6 +263,9 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 				zap.String("event_type", eventType),
 			)
 			continue
+		}
+		if event.Type == "" {
+			event.Type = eventType
 		}
 
 		// message_start carries the initial response structure
@@ -449,20 +452,20 @@ func (s *GatewayService) handleResponsesStreamingResponse(
 	// Read Anthropic SSE events
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseRespEventLine(line)
+		if !ok {
 			continue
 		}
-		eventType := strings.TrimPrefix(line, "event: ")
 
 		// Read data line
 		if !scanner.Scan() {
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseRespDataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -472,6 +475,9 @@ func (s *GatewayService) handleResponsesStreamingResponse(
 				zap.String("event_type", eventType),
 			)
 			continue
+		}
+		if event.Type == "" {
+			event.Type = eventType
 		}
 
 		if processEvent(&event) {
@@ -515,4 +521,28 @@ func mapUpstreamStatusCode(code int) int {
 		return http.StatusBadGateway
 	}
 	return code
+}
+
+// parseRespEventLine extracts the event name from an SSE "event:" line.
+// Compatible with both "event: name" (with space) and "event:name" (without space).
+func parseRespEventLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "event: ") {
+		return strings.TrimSpace(line[7:]), true
+	}
+	if strings.HasPrefix(line, "event:") {
+		return strings.TrimSpace(line[6:]), true
+	}
+	return "", false
+}
+
+// parseRespDataLine extracts the data payload from an SSE "data:" line.
+// Compatible with both "data: {...}" (with space) and "data:{...}" (without space).
+func parseRespDataLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "data: ") {
+		return line[6:], true
+	}
+	if strings.HasPrefix(line, "data:") {
+		return line[5:], true
+	}
+	return "", false
 }


### PR DESCRIPTION
## What this PR does

Fixes SSE parsing compatibility for upstreams that return `event:name` / `data:{...}` format without a space after the colon, while maintaining full compatibility with the standard `event: name` / `data: {...}` format.

## Problem

Some Anthropic-compatible API providers (e.g. Alibaba Cloud DashScope / 百炼) return SSE events without a space after the colon:

```
event:message_start
data:{"message":{"usage":{"input_tokens":2,"output_tokens":0}},"type":"message_start"}
```

The existing SSE parsers in `handleCCBufferedFromAnthropic`, `handleCCStreamingFromAnthropic`, `handleResponsesBufferedStreamingResponse`, and `handleResponsesStreamingResponse` use `strings.HasPrefix(line, "event: ")` which requires a space after the colon. This causes **all SSE events to be silently skipped**, resulting in:

- `ForwardResult.Usage` stays at zero values
- Token counts (input/output/cache) are all recorded as 0
- Billing fails silently — users make requests but no usage is recorded or charged

## Solution

Added helper functions (`parseCCeventLine`/`parseCCdataLine` and `parseRespEventLine`/`parseRespDataLine`) that accept both formats:
- `event: name` (standard, with space) ← checked first
- `event:name` (non-standard, without space) ← fallback

Also added `event.Type = eventType` fallback to ensure the event type is always populated even when the JSON payload doesn't contain a `type` field.

## Files changed

| File | Changes |
|------|---------|
| `backend/internal/service/gateway_forward_as_chat_completions.go` | 2 functions modified + 2 helpers added |
| `backend/internal/service/gateway_forward_as_responses.go` | 2 functions modified + 2 helpers added |

## Scope

- 4 SSE parsing locations updated
- Fully backward compatible — standard format is checked first
- No changes to business logic, only SSE line prefix parsing

## Tested

Verified with Alibaba Cloud DashScope (`coding.dashscope.aliyuncs.com/apps/anthropic`) using `qwen3.6-plus` model:
- Before fix: `input_tokens=0, output_tokens=0` in `usage_logs`
- After fix: `input_tokens=33893, output_tokens=257` correctly recorded