### PR TITLE
fix: resolve unaligned 64-bit atomic operation on 32-bit architectures

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -66,11 +66,11 @@ type poolSettings struct {
 // upstreamClientEntry 上游客户端缓存条目
 // 记录客户端实例及其元数据，用于连接池管理和淘汰策略
 type upstreamClientEntry struct {
+	lastUsed int64        // 最后使用时间戳（纳秒），用于 LRU 淘汰
+	inFlight int64        // 当前进行中的请求数，>0 时不可淘汰
 	client   *http.Client // HTTP 客户端实例
 	proxyKey string       // 代理标识（用于检测代理变更）
 	poolKey  string       // 连接池配置标识（用于检测配置变更）
-	lastUsed int64        // 最后使用时间戳（纳秒），用于 LRU 淘汰
-	inFlight int64        // 当前进行中的请求数，>0 时不可淘汰
 }
 
 // httpUpstreamService 通用 HTTP 上游服务


### PR DESCRIPTION
This PR fixes a critical panic caused by unaligned 64-bit atomic operations on 32-bit architectures (like x86).

Reordered `upstreamClientEntry` fields to place `int64` variables at the top of the struct, ensuring the 8-byte alignment required by `sync/atomic` on 32-bit systems.