### PR TITLE
fix(gemini): apply model_mapping to oauth accounts

### DIFF
--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -579,7 +579,9 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 
 	originalModel := req.Model
 	mappedModel := req.Model
-	if account.Type == AccountTypeAPIKey {
+	if account.Credentials != nil {
+		// OAuth Gemini accounts can also rely on model_mapping, especially when
+		// bridging client-requested Gemini models onto Code Assist-supported ones.
 		mappedModel = account.GetMappedModel(req.Model)
 	}
 
@@ -1094,7 +1096,9 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 	body = ensureGeminiFunctionCallThoughtSignatures(body)
 
 	mappedModel := originalModel
-	if account.Type == AccountTypeAPIKey {
+	if account.Credentials != nil {
+		// OAuth Gemini accounts can also rely on model_mapping, especially when
+		// bridging client-requested Gemini models onto Code Assist-supported ones.
 		mappedModel = account.GetMappedModel(originalModel)
 	}
 


### PR DESCRIPTION
## Summary
- apply Gemini `model_mapping` for OAuth accounts in both compat and native forwarding paths
- keep the existing API key mapping behavior unchanged
- fix OAuth-backed Gemini upstreams such as Code Assist where a client-facing model alias should be remapped before the upstream request is built

## Testing
- `docker compose build sub2api`
- manual `POST /v1beta/models/gemini-2.0-flash:generateContent` against a local deploy with an OAuth-backed Gemini account
- manual `POST /v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse` against the same deploy
