### PR TITLE
feat: add 429 cooldown settings

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1093,8 +1093,9 @@ type DefaultConfig struct {
 }
 
 type RateLimitConfig struct {
-	OverloadCooldownMinutes int `mapstructure:"overload_cooldown_minutes"`  // 529过载冷却时间(分钟)
-	OAuth401CooldownMinutes int `mapstructure:"oauth_401_cooldown_minutes"` // OAuth 401临时不可调度冷却(分钟)
+	OverloadCooldownMinutes  int `mapstructure:"overload_cooldown_minutes"`   // 529过载冷却时间(分钟)
+	RateLimitCooldownMinutes int `mapstructure:"rate_limit_cooldown_minutes"` // 429限流兜底冷却时间(分钟)
+	OAuth401CooldownMinutes  int `mapstructure:"oauth_401_cooldown_minutes"`  // OAuth 401临时不可调度冷却(分钟)
 }
 
 // APIKeyAuthCacheConfig API Key 认证缓存配置
@@ -1554,6 +1555,7 @@ func setDefaults() {
 
 	// RateLimit
 	viper.SetDefault("rate_limit.overload_cooldown_minutes", 10)
+	viper.SetDefault("rate_limit.rate_limit_cooldown_minutes", 5)
 	viper.SetDefault("rate_limit.oauth_401_cooldown_minutes", 10)
 
 	// Pricing - 从 model-price-repo 同步模型定价和上下文窗口数据（固定到 commit，避免分支漂移）

--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -2328,6 +2328,58 @@ func (h *SettingHandler) UpdateOverloadCooldownSettings(c *gin.Context) {
 	})
 }
 
+// GetRateLimitCooldownSettings 获取429限流冷却配置
+// GET /api/v1/admin/settings/rate-limit-cooldown
+func (h *SettingHandler) GetRateLimitCooldownSettings(c *gin.Context) {
+	settings, err := h.settingService.GetRateLimitCooldownSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.RateLimitCooldownSettings{
+		Enabled:         settings.Enabled,
+		CooldownMinutes: settings.CooldownMinutes,
+	})
+}
+
+// UpdateRateLimitCooldownSettingsRequest 更新429限流冷却配置请求
+type UpdateRateLimitCooldownSettingsRequest struct {
+	Enabled         bool `json:"enabled"`
+	CooldownMinutes int  `json:"cooldown_minutes"`
+}
+
+// UpdateRateLimitCooldownSettings 更新429限流冷却配置
+// PUT /api/v1/admin/settings/rate-limit-cooldown
+func (h *SettingHandler) UpdateRateLimitCooldownSettings(c *gin.Context) {
+	var req UpdateRateLimitCooldownSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+
+	settings := &service.RateLimitCooldownSettings{
+		Enabled:         req.Enabled,
+		CooldownMinutes: req.CooldownMinutes,
+	}
+
+	if err := h.settingService.SetRateLimitCooldownSettings(c.Request.Context(), settings); err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+
+	updatedSettings, err := h.settingService.GetRateLimitCooldownSettings(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, dto.RateLimitCooldownSettings{
+		Enabled:         updatedSettings.Enabled,
+		CooldownMinutes: updatedSettings.CooldownMinutes,
+	})
+}
+
 // GetStreamTimeoutSettings 获取流超时处理配置
 // GET /api/v1/admin/settings/stream-timeout
 func (h *SettingHandler) GetStreamTimeoutSettings(c *gin.Context) {

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -252,6 +252,12 @@ type OverloadCooldownSettings struct {
 	CooldownMinutes int  `json:"cooldown_minutes"`
 }
 
+// RateLimitCooldownSettings 429限流冷却配置 DTO
+type RateLimitCooldownSettings struct {
+	Enabled         bool `json:"enabled"`
+	CooldownMinutes int  `json:"cooldown_minutes"`
+}
+
 // StreamTimeoutSettings 流超时处理配置 DTO
 type StreamTimeoutSettings struct {
 	Enabled                bool   `json:"enabled"`

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -405,6 +405,9 @@ func registerSettingsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		// 529过载冷却配置
 		adminSettings.GET("/overload-cooldown", h.Admin.Setting.GetOverloadCooldownSettings)
 		adminSettings.PUT("/overload-cooldown", h.Admin.Setting.UpdateOverloadCooldownSettings)
+		// 429限流冷却配置
+		adminSettings.GET("/rate-limit-cooldown", h.Admin.Setting.GetRateLimitCooldownSettings)
+		adminSettings.PUT("/rate-limit-cooldown", h.Admin.Setting.UpdateRateLimitCooldownSettings)
 		// 流超时处理配置
 		adminSettings.GET("/stream-timeout", h.Admin.Setting.GetStreamTimeoutSettings)
 		adminSettings.PUT("/stream-timeout", h.Admin.Setting.UpdateStreamTimeoutSettings)

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -275,6 +275,9 @@ const (
 	// SettingKeyOverloadCooldownSettings stores JSON config for 529 overload cooldown handling.
 	SettingKeyOverloadCooldownSettings = "overload_cooldown_settings"
 
+	// SettingKeyRateLimitCooldownSettings stores JSON config for 429 rate-limit cooldown handling.
+	SettingKeyRateLimitCooldownSettings = "rate_limit_cooldown_settings"
+
 	// =========================
 	// Stream Timeout Handling
 	// =========================

--- a/backend/internal/service/overload_cooldown_test.go
+++ b/backend/internal/service/overload_cooldown_test.go
@@ -184,6 +184,55 @@ func TestSetOverloadCooldownSettings_AcceptsBoundaries(t *testing.T) {
 	}
 }
 
+func TestGetRateLimitCooldownSettings_DefaultsWhenNotSet(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetRateLimitCooldownSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, settings.Enabled)
+	require.Equal(t, 5, settings.CooldownMinutes)
+}
+
+func TestGetRateLimitCooldownSettings_ReadsFromDB(t *testing.T) {
+	repo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimitCooldownSettings{Enabled: false, CooldownMinutes: 30})
+	repo.data[SettingKeyRateLimitCooldownSettings] = string(data)
+	svc := NewSettingService(repo, &config.Config{})
+
+	settings, err := svc.GetRateLimitCooldownSettings(context.Background())
+	require.NoError(t, err)
+	require.False(t, settings.Enabled)
+	require.Equal(t, 30, settings.CooldownMinutes)
+}
+
+func TestSetRateLimitCooldownSettings_EnabledRejectsOutOfRange(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	for _, minutes := range []int{0, -1, 121, 999} {
+		err := svc.SetRateLimitCooldownSettings(context.Background(), &RateLimitCooldownSettings{
+			Enabled: true, CooldownMinutes: minutes,
+		})
+		require.Error(t, err, "should reject enabled=true + cooldown_minutes=%d", minutes)
+		require.Contains(t, err.Error(), "cooldown_minutes must be between 1-120")
+	}
+}
+
+func TestSetRateLimitCooldownSettings_DisabledNormalizesOutOfRange(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := NewSettingService(repo, &config.Config{})
+
+	err := svc.SetRateLimitCooldownSettings(context.Background(), &RateLimitCooldownSettings{
+		Enabled: false, CooldownMinutes: 0,
+	})
+	require.NoError(t, err)
+
+	settings, err := svc.GetRateLimitCooldownSettings(context.Background())
+	require.NoError(t, err)
+	require.False(t, settings.Enabled)
+	require.Equal(t, 5, settings.CooldownMinutes)
+}
+
 // ===========================================================================
 // RateLimitService: handle529 behaviour
 // ===========================================================================

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -817,6 +817,12 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
 func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+	settings := s.rateLimitCooldownSettings(ctx, account)
+	if !settings.Enabled {
+		slog.Info("account_429_ignored", "account_id", account.ID, "reason", "rate_limit_cooldown_disabled")
+		return
+	}
+
 	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
 	if account.Platform == PlatformOpenAI {
 		s.persistOpenAICodexSnapshot(ctx, account, headers)
@@ -891,9 +897,9 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 			return
 		}
 
-		// 其他平台：没有重置时间，使用默认5分钟
-		resetAt := time.Now().Add(5 * time.Minute)
-		slog.Warn("rate_limit_no_reset_time", "account_id", account.ID, "platform", account.Platform, "using_default", "5m")
+		// 其他平台：没有重置时间，使用配置的兜底冷却时间
+		resetAt := time.Now().Add(time.Duration(settings.CooldownMinutes) * time.Minute)
+		slog.Warn("rate_limit_no_reset_time", "account_id", account.ID, "platform", account.Platform, "using_default_minutes", settings.CooldownMinutes)
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 		}
@@ -904,7 +910,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	ts, err := strconv.ParseInt(resetTimestamp, 10, 64)
 	if err != nil {
 		slog.Warn("rate_limit_reset_parse_failed", "reset_timestamp", resetTimestamp, "error", err)
-		resetAt := time.Now().Add(5 * time.Minute)
+		resetAt := time.Now().Add(time.Duration(settings.CooldownMinutes) * time.Minute)
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 		}
@@ -927,6 +933,29 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+}
+
+func (s *RateLimitService) rateLimitCooldownSettings(ctx context.Context, account *Account) *RateLimitCooldownSettings {
+	var settings *RateLimitCooldownSettings
+	if s.settingService != nil {
+		var err error
+		settings, err = s.settingService.GetRateLimitCooldownSettings(ctx)
+		if err != nil {
+			slog.Warn("rate_limit_settings_read_failed", "account_id", account.ID, "error", err)
+			settings = nil
+		}
+	}
+	if settings == nil {
+		cooldown := 5
+		if s.cfg != nil && s.cfg.RateLimit.RateLimitCooldownMinutes > 0 {
+			cooldown = s.cfg.RateLimit.RateLimitCooldownMinutes
+		}
+		settings = &RateLimitCooldownSettings{Enabled: true, CooldownMinutes: cooldown}
+	}
+	if settings.CooldownMinutes <= 0 {
+		settings.CooldownMinutes = 5
+	}
+	return settings
 }
 
 // calculateOpenAI429ResetTime 从 OpenAI 429 响应头计算正确的重置时间

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
@@ -150,11 +151,13 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 type openAI429SnapshotRepo struct {
 	mockAccountRepoForGemini
 	rateLimitedID int64
+	rateLimitedAt *time.Time
 	updatedExtra  map[string]any
 }
 
-func (r *openAI429SnapshotRepo) SetRateLimited(_ context.Context, id int64, _ time.Time) error {
+func (r *openAI429SnapshotRepo) SetRateLimited(_ context.Context, id int64, resetAt time.Time) error {
 	r.rateLimitedID = id
+	r.rateLimitedAt = &resetAt
 	return nil
 }
 
@@ -190,6 +193,51 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	if got := repo.updatedExtra["codex_7d_used_percent"]; got != 100.0 {
 		t.Fatalf("codex_7d_used_percent = %v, want 100", got)
 	}
+}
+
+func TestHandle429_OpenAIDisabledFromDB_SkipsRateLimit(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimitCooldownSettings{Enabled: false, CooldownMinutes: 5})
+	settingRepo.data[SettingKeyRateLimitCooldownSettings] = string(data)
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetSettingService(settingSvc)
+
+	account := &Account{ID: 124, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "100")
+	headers.Set("x-codex-primary-reset-after-seconds", "300")
+	headers.Set("x-codex-primary-window-minutes", "300")
+
+	svc.handle429(context.Background(), account, headers, nil)
+
+	require.Zero(t, repo.rateLimitedID)
+	require.Nil(t, repo.rateLimitedAt)
+	require.Empty(t, repo.updatedExtra)
+}
+
+func TestHandle429_OpenAINoResetUsesConfiguredFallback(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimitCooldownSettings{Enabled: true, CooldownMinutes: 3})
+	settingRepo.data[SettingKeyRateLimitCooldownSettings] = string(data)
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc.SetSettingService(settingSvc)
+
+	account := &Account{ID: 125, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "100")
+
+	before := time.Now()
+	svc.handle429(context.Background(), account, headers, nil)
+
+	require.Equal(t, account.ID, repo.rateLimitedID)
+	require.NotNil(t, repo.rateLimitedAt)
+	require.WithinDuration(t, before.Add(3*time.Minute), *repo.rateLimitedAt, 2*time.Second)
 }
 
 func TestNormalizedCodexLimits(t *testing.T) {

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -2626,6 +2626,55 @@ func (s *SettingService) SetOverloadCooldownSettings(ctx context.Context, settin
 	return s.settingRepo.Set(ctx, SettingKeyOverloadCooldownSettings, string(data))
 }
 
+// GetRateLimitCooldownSettings 获取429限流冷却配置
+func (s *SettingService) GetRateLimitCooldownSettings(ctx context.Context) (*RateLimitCooldownSettings, error) {
+	value, err := s.settingRepo.GetValue(ctx, SettingKeyRateLimitCooldownSettings)
+	if err != nil {
+		if errors.Is(err, ErrSettingNotFound) {
+			return DefaultRateLimitCooldownSettings(), nil
+		}
+		return nil, fmt.Errorf("get rate limit cooldown settings: %w", err)
+	}
+	if value == "" {
+		return DefaultRateLimitCooldownSettings(), nil
+	}
+
+	var settings RateLimitCooldownSettings
+	if err := json.Unmarshal([]byte(value), &settings); err != nil {
+		return DefaultRateLimitCooldownSettings(), nil
+	}
+
+	if settings.CooldownMinutes < 1 {
+		settings.CooldownMinutes = 1
+	}
+	if settings.CooldownMinutes > 120 {
+		settings.CooldownMinutes = 120
+	}
+
+	return &settings, nil
+}
+
+// SetRateLimitCooldownSettings 设置429限流冷却配置
+func (s *SettingService) SetRateLimitCooldownSettings(ctx context.Context, settings *RateLimitCooldownSettings) error {
+	if settings == nil {
+		return fmt.Errorf("settings cannot be nil")
+	}
+
+	if settings.CooldownMinutes < 1 || settings.CooldownMinutes > 120 {
+		if settings.Enabled {
+			return fmt.Errorf("cooldown_minutes must be between 1-120")
+		}
+		settings.CooldownMinutes = 5
+	}
+
+	data, err := json.Marshal(settings)
+	if err != nil {
+		return fmt.Errorf("marshal rate limit cooldown settings: %w", err)
+	}
+
+	return s.settingRepo.Set(ctx, SettingKeyRateLimitCooldownSettings, string(data))
+}
+
 // GetOIDCConnectOAuthConfig 返回用于登录的“最终生效” OIDC 配置。
 //
 // 优先级：

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -381,6 +381,22 @@ func DefaultOverloadCooldownSettings() *OverloadCooldownSettings {
 	}
 }
 
+// RateLimitCooldownSettings 429限流冷却配置
+type RateLimitCooldownSettings struct {
+	// Enabled 是否在收到429时暂停账号调度
+	Enabled bool `json:"enabled"`
+	// CooldownMinutes 无法从上游解析恢复时间时的兜底冷却时长（分钟）
+	CooldownMinutes int `json:"cooldown_minutes"`
+}
+
+// DefaultRateLimitCooldownSettings 返回默认的429限流冷却配置（启用，5分钟）
+func DefaultRateLimitCooldownSettings() *RateLimitCooldownSettings {
+	return &RateLimitCooldownSettings{
+		Enabled:         true,
+		CooldownMinutes: 5,
+	}
+}
+
 // DefaultBetaPolicySettings 返回默认的 Beta 策略配置
 func DefaultBetaPolicySettings() *BetaPolicySettings {
 	return &BetaPolicySettings{

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -785,6 +785,33 @@ export async function updateOverloadCooldownSettings(
   return data;
 }
 
+// ==================== Rate Limit Cooldown Settings ====================
+
+/**
+ * Rate limit cooldown settings interface (429 handling)
+ */
+export interface RateLimitCooldownSettings {
+  enabled: boolean;
+  cooldown_minutes: number;
+}
+
+export async function getRateLimitCooldownSettings(): Promise<RateLimitCooldownSettings> {
+  const { data } = await apiClient.get<RateLimitCooldownSettings>(
+    "/admin/settings/rate-limit-cooldown",
+  );
+  return data;
+}
+
+export async function updateRateLimitCooldownSettings(
+  settings: RateLimitCooldownSettings,
+): Promise<RateLimitCooldownSettings> {
+  const { data } = await apiClient.put<RateLimitCooldownSettings>(
+    "/admin/settings/rate-limit-cooldown",
+    settings,
+  );
+  return data;
+}
+
 // ==================== Stream Timeout Settings ====================
 
 /**
@@ -981,6 +1008,8 @@ export const settingsAPI = {
   deleteAdminApiKey,
   getOverloadCooldownSettings,
   updateOverloadCooldownSettings,
+  getRateLimitCooldownSettings,
+  updateRateLimitCooldownSettings,
   getStreamTimeoutSettings,
   updateStreamTimeoutSettings,
   getRectifierSettings,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5387,6 +5387,16 @@ export default {
         saved: 'Overload cooldown settings saved',
         saveFailed: 'Failed to save overload cooldown settings'
       },
+      rateLimitCooldown: {
+        title: '429 Rate Limit Cooldown',
+        description: 'Configure account scheduling pause strategy when upstream returns 429 (rate limited)',
+        enabled: 'Enable Rate Limit Cooldown',
+        enabledHint: 'Pause account scheduling on 429 errors, auto-recover after the reset time or fallback cooldown',
+        cooldownMinutes: 'Fallback Cooldown Duration (minutes)',
+        cooldownMinutesHint: 'Used when upstream does not provide a reset time (1-120 minutes)',
+        saved: 'Rate limit cooldown settings saved',
+        saveFailed: 'Failed to save rate limit cooldown settings'
+      },
       streamTimeout: {
         title: 'Stream Timeout Handling',
         description: 'Configure account handling strategy when upstream response times out',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5547,6 +5547,16 @@ export default {
         saved: '过载冷却设置保存成功',
         saveFailed: '保存过载冷却设置失败'
       },
+      rateLimitCooldown: {
+        title: '429 限流冷却',
+        description: '配置上游返回 429（限流）时的账号调度暂停策略',
+        enabled: '启用限流冷却',
+        enabledHint: '收到 429 错误时暂停该账号的调度，按上游重置时间或兜底冷却后自动恢复',
+        cooldownMinutes: '兜底冷却时长（分钟）',
+        cooldownMinutesHint: '当上游没有提供重置时间时使用（1-120 分钟）',
+        saved: '限流冷却设置保存成功',
+        saveFailed: '保存限流冷却设置失败'
+      },
       streamTimeout: {
         title: '流超时处理',
         description: '配置上游响应超时时的账户处理策略，避免问题账户持续被选中',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -291,6 +291,107 @@
             </div>
           </div>
 
+          <!-- Rate Limit Cooldown (429) Settings -->
+          <div class="card">
+            <div
+              class="border-b border-gray-100 px-6 py-4 dark:border-dark-700"
+            >
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ t("admin.settings.rateLimitCooldown.title") }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ t("admin.settings.rateLimitCooldown.description") }}
+              </p>
+            </div>
+            <div class="space-y-5 p-6">
+              <div
+                v-if="rateLimitCooldownLoading"
+                class="flex items-center gap-2 text-gray-500"
+              >
+                <div
+                  class="h-4 w-4 animate-spin rounded-full border-b-2 border-primary-600"
+                ></div>
+                {{ t("common.loading") }}
+              </div>
+
+              <template v-else>
+                <div class="flex items-center justify-between">
+                  <div>
+                    <label class="font-medium text-gray-900 dark:text-white">{{
+                      t("admin.settings.rateLimitCooldown.enabled")
+                    }}</label>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.rateLimitCooldown.enabledHint") }}
+                    </p>
+                  </div>
+                  <Toggle v-model="rateLimitCooldownForm.enabled" />
+                </div>
+
+                <div
+                  v-if="rateLimitCooldownForm.enabled"
+                  class="space-y-4 border-t border-gray-100 pt-4 dark:border-dark-700"
+                >
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{ t("admin.settings.rateLimitCooldown.cooldownMinutes") }}
+                    </label>
+                    <input
+                      v-model.number="rateLimitCooldownForm.cooldown_minutes"
+                      type="number"
+                      min="1"
+                      max="120"
+                      class="input w-32"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{
+                        t("admin.settings.rateLimitCooldown.cooldownMinutesHint")
+                      }}
+                    </p>
+                  </div>
+                </div>
+
+                <div
+                  class="flex justify-end border-t border-gray-100 pt-4 dark:border-dark-700"
+                >
+                  <button
+                    type="button"
+                    @click="saveRateLimitCooldownSettings"
+                    :disabled="rateLimitCooldownSaving"
+                    class="btn btn-primary btn-sm"
+                  >
+                    <svg
+                      v-if="rateLimitCooldownSaving"
+                      class="mr-1 h-4 w-4 animate-spin"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        class="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        stroke-width="4"
+                      ></circle>
+                      <path
+                        class="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      ></path>
+                    </svg>
+                    {{
+                      rateLimitCooldownSaving
+                        ? t("common.saving")
+                        : t("common.save")
+                    }}
+                  </button>
+                </div>
+              </template>
+            </div>
+          </div>
+
           <!-- Stream Timeout Settings -->
           <div class="card">
             <div
@@ -4915,6 +5016,14 @@ const overloadCooldownForm = reactive({
   cooldown_minutes: 10,
 });
 
+// Rate Limit Cooldown (429) 状态
+const rateLimitCooldownLoading = ref(true);
+const rateLimitCooldownSaving = ref(false);
+const rateLimitCooldownForm = reactive({
+  enabled: true,
+  cooldown_minutes: 5,
+});
+
 // Stream Timeout 状态
 const streamTimeoutLoading = ref(true);
 const streamTimeoutSaving = ref(false);
@@ -6283,6 +6392,40 @@ async function saveOverloadCooldownSettings() {
   }
 }
 
+// Rate Limit Cooldown 方法
+async function loadRateLimitCooldownSettings() {
+  rateLimitCooldownLoading.value = true;
+  try {
+    const settings = await adminAPI.settings.getRateLimitCooldownSettings();
+    Object.assign(rateLimitCooldownForm, settings);
+  } catch (_error: unknown) {
+    // Silent fail - settings will use defaults
+  } finally {
+    rateLimitCooldownLoading.value = false;
+  }
+}
+
+async function saveRateLimitCooldownSettings() {
+  rateLimitCooldownSaving.value = true;
+  try {
+    const updated = await adminAPI.settings.updateRateLimitCooldownSettings({
+      enabled: rateLimitCooldownForm.enabled,
+      cooldown_minutes: rateLimitCooldownForm.cooldown_minutes,
+    });
+    Object.assign(rateLimitCooldownForm, updated);
+    appStore.showSuccess(t("admin.settings.rateLimitCooldown.saved"));
+  } catch (error: unknown) {
+    appStore.showError(
+      extractApiErrorMessage(
+        error,
+        t("admin.settings.rateLimitCooldown.saveFailed"),
+      ),
+    );
+  } finally {
+    rateLimitCooldownSaving.value = false;
+  }
+}
+
 // Stream Timeout 方法
 async function loadStreamTimeoutSettings() {
   streamTimeoutLoading.value = true;
@@ -6839,6 +6982,7 @@ onMounted(() => {
   loadSubscriptionGroups();
   loadAdminApiKey();
   loadOverloadCooldownSettings();
+  loadRateLimitCooldownSettings();
   loadStreamTimeoutSettings();
   loadRectifierSettings();
   loadBetaPolicySettings();


### PR DESCRIPTION
  ## Summary
  - Add configurable 429 rate-limit cooldown settings, aligned with existing 529 overload cooldown behavior.
  - Add admin settings API and Gateway settings UI for enabling/disabling 429 cooldown.
  - Use configurable fallback cooldown minutes when upstream 429 does not provide a reset time.

  ## Tests
  - go test -tags unit ./internal/service -run 'Test(Get|Set)(Overload|RateLimit)CooldownSettings|TestHandle529|
  TestHandle429_OpenAI'
  - go test ./internal/handler/admin ./internal/server/routes