### PR TITLE
fix(apicompat): recognize web_search_20250305 / google_search in Responses→Anthropic tool conversion

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -390,7 +390,7 @@ func convertResponsesToAnthropicTools(tools []ResponsesTool) []AnthropicTool {
 	var out []AnthropicTool
 	for _, t := range tools {
 		switch t.Type {
-		case "web_search":
+		case "web_search", "google_search", "web_search_20250305":
 			out = append(out, AnthropicTool{
 				Type: "web_search_20250305",
 				Name: "web_search",


### PR DESCRIPTION
Fixes #1919

## 背景

`convertResponsesToAnthropicTools`（`backend/internal/pkg/apicompat/responses_to_anthropic_request.go`）只匹配窄字面 `type: "web_search"`，当 Responses API 客户端声明 `"web_search_20250305"` 或 `"google_search"` 时会落入 `default` 分支被作为未知工具原样透传，web_search 能力在 Responses → Anthropic 链路上被静默丢失。

## 一致性理由

同仓库另外两处语义等价的工具类型识别早已覆盖这三个别名，本 PR 仅将第三处与它们对齐，不引入新行为：

- `backend/internal/pkg/antigravity/request_transformer.go:672`
  ```go
  case "web_search", "google_search", "web_search_20250305":
  ```
- `backend/internal/service/gemini_messages_compat_service.go:3312`
  ```go
  case "web_search", "google_search", "web_search_20250305":
  ```

## 改动

```diff
-		case "web_search":
+		case "web_search", "google_search", "web_search_20250305":
 			out = append(out, AnthropicTool{
 				Type: "web_search_20250305",
 				Name: "web_search",
 			})
```

## 影响 / 兼容性

- 原有走字面 `"web_search"` 的客户端行为不变（case 仍匹配）
- 新增两个别名合并进同一分支，输出仍为 `AnthropicTool{Type: "web_search_20250305", Name: "web_search"}`，与既有约定一致
- 无新增依赖、无配置、无数据库变更