### PR TITLE
feat: universal platform support for cross-platform model routing

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine
+FROM golang:1.26-alpine
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN go mod download
 COPY . .
 
 # 构建应用
-RUN go build -o main ./cmd/server/
+RUN go build -tags embed -o main ./cmd/server/
 
 # 暴露端口
 EXPOSE 8080

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -225,7 +225,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	usageRecordWorkerPool := service.NewUsageRecordWorkerPool(configConfig)
 	userMsgQueueCache := repository.NewUserMsgQueueCache(redisClient)
 	userMessageQueueService := service.ProvideUserMessageQueueService(userMsgQueueCache, rpmCache, configConfig)
-	gatewayHandler := handler.NewGatewayHandler(gatewayService, geminiMessagesCompatService, antigravityGatewayService, userService, concurrencyService, billingCacheService, usageService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, userMessageQueueService, configConfig, settingService)
+	gatewayHandler := handler.NewGatewayHandler(gatewayService, geminiMessagesCompatService, antigravityGatewayService, openAIGatewayService, userService, concurrencyService, billingCacheService, usageService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, userMessageQueueService, configConfig, settingService)
 	openAIGatewayHandler := handler.NewOpenAIGatewayHandler(openAIGatewayService, concurrencyService, billingCacheService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, configConfig)
 	handlerSettingHandler := handler.ProvideSettingHandler(settingService, buildInfo)
 	totpHandler := handler.NewTotpHandler(totpService)

--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -22,6 +22,7 @@ const (
 	PlatformOpenAI      = "openai"
 	PlatformGemini      = "gemini"
 	PlatformAntigravity = "antigravity"
+	PlatformUniversal   = "universal" // 跨平台组：允许组内包含任意平台的账号，按模型名自动路由
 )
 
 // Account type constants

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -84,7 +84,7 @@ func NewGroupHandler(adminService service.AdminService, dashboardService *servic
 type CreateGroupRequest struct {
 	Name             string             `json:"name" binding:"required"`
 	Description      string             `json:"description"`
-	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity"`
+	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity universal"`
 	RateMultiplier   float64            `json:"rate_multiplier"`
 	IsExclusive      bool               `json:"is_exclusive"`
 	SubscriptionType string             `json:"subscription_type" binding:"omitempty,oneof=standard subscription"`
@@ -98,7 +98,7 @@ type CreateGroupRequest struct {
 	ClaudeCodeOnly                  bool     `json:"claude_code_only"`
 	FallbackGroupID                 *int64   `json:"fallback_group_id"`
 	FallbackGroupIDOnInvalidRequest *int64   `json:"fallback_group_id_on_invalid_request"`
-	// 模型路由配置（仅 anthropic 平台使用）
+	// 模型路由配置（anthropic / universal 平台使用）
 	ModelRouting        map[string][]int64 `json:"model_routing"`
 	ModelRoutingEnabled bool               `json:"model_routing_enabled"`
 	MCPXMLInject        *bool              `json:"mcp_xml_inject"`
@@ -118,7 +118,7 @@ type CreateGroupRequest struct {
 type UpdateGroupRequest struct {
 	Name             string             `json:"name"`
 	Description      string             `json:"description"`
-	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity"`
+	Platform         string             `json:"platform" binding:"omitempty,oneof=anthropic openai gemini antigravity universal"`
 	RateMultiplier   *float64           `json:"rate_multiplier"`
 	IsExclusive      *bool              `json:"is_exclusive"`
 	Status           string             `json:"status" binding:"omitempty,oneof=active inactive"`
@@ -133,7 +133,7 @@ type UpdateGroupRequest struct {
 	ClaudeCodeOnly                  *bool    `json:"claude_code_only"`
 	FallbackGroupID                 *int64   `json:"fallback_group_id"`
 	FallbackGroupIDOnInvalidRequest *int64   `json:"fallback_group_id_on_invalid_request"`
-	// 模型路由配置（仅 anthropic 平台使用）
+	// 模型路由配置（anthropic / universal 平台使用）
 	ModelRouting        map[string][]int64 `json:"model_routing"`
 	ModelRoutingEnabled *bool              `json:"model_routing_enabled"`
 	MCPXMLInject        *bool              `json:"mcp_xml_inject"`

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -39,6 +39,7 @@ type GatewayHandler struct {
 	gatewayService            *service.GatewayService
 	geminiCompatService       *service.GeminiMessagesCompatService
 	antigravityGatewayService *service.AntigravityGatewayService
+	openAIMessages            *service.OpenAIGatewayService
 	userService               *service.UserService
 	billingCacheService       *service.BillingCacheService
 	usageService              *service.UsageService
@@ -58,6 +59,7 @@ func NewGatewayHandler(
 	gatewayService *service.GatewayService,
 	geminiCompatService *service.GeminiMessagesCompatService,
 	antigravityGatewayService *service.AntigravityGatewayService,
+	openAIMessages *service.OpenAIGatewayService,
 	userService *service.UserService,
 	concurrencyService *service.ConcurrencyService,
 	billingCacheService *service.BillingCacheService,
@@ -92,6 +94,7 @@ func NewGatewayHandler(
 		gatewayService:            gatewayService,
 		geminiCompatService:       geminiCompatService,
 		antigravityGatewayService: antigravityGatewayService,
+		openAIMessages:            openAIMessages,
 		userService:               userService,
 		billingCacheService:       billingCacheService,
 		usageService:              usageService,
@@ -104,6 +107,25 @@ func NewGatewayHandler(
 		maxAccountSwitchesGemini:  maxAccountSwitchesGemini,
 		cfg:                       cfg,
 		settingService:            settingService,
+	}
+}
+
+// convertOpenAIForwardResult converts OpenAIForwardResult to ForwardResult for unified usage recording.
+func convertOpenAIForwardResult(o *service.OpenAIForwardResult) *service.ForwardResult {
+	if o == nil {
+		return nil
+	}
+	return &service.ForwardResult{
+		RequestID:       o.RequestID,
+		Usage:           service.ClaudeUsage{InputTokens: o.Usage.InputTokens, OutputTokens: o.Usage.OutputTokens, CacheCreationInputTokens: o.Usage.CacheCreationInputTokens, CacheReadInputTokens: o.Usage.CacheReadInputTokens, ImageOutputTokens: o.Usage.ImageOutputTokens},
+		Model:           o.Model,
+		UpstreamModel:   o.UpstreamModel,
+		Stream:          o.Stream,
+		Duration:        o.Duration,
+		FirstTokenMs:    o.FirstTokenMs,
+		ReasoningEffort: o.ReasoningEffort,
+		ImageCount:      o.ImageCount,
+		ImageSize:       o.ImageSize,
 	}
 }
 
@@ -686,6 +708,21 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			writerSizeBeforeForward := c.Writer.Size()
 			if account.Platform == service.PlatformAntigravity && account.Type != service.AccountTypeAPIKey {
 				result, err = h.antigravityGatewayService.Forward(requestCtx, c, account, body, hasBoundSession)
+			} else if account.Platform == service.PlatformOpenAI {
+				// Universal group may schedule OpenAI accounts; forward via OpenAI chain
+				// (Anthropic→OpenAI conversion)
+				promptCacheKey := sessionKey
+				var mappedModel string
+				if channelMapping.Mapped {
+					mappedModel = channelMapping.MappedModel
+				}
+				openaiResult, openaiErr := h.openAIMessages.ForwardAsAnthropic(requestCtx, c, account, body, promptCacheKey, mappedModel)
+				if openaiErr != nil {
+					err = openaiErr
+					result = nil
+				} else if openaiResult != nil {
+					result = convertOpenAIForwardResult(openaiResult)
+				}
 			} else {
 				result, err = h.gatewayService.Forward(requestCtx, c, account, parsedReq)
 			}

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -205,12 +205,14 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		accountReleaseFunc = wrapReleaseOnDone(c.Request.Context(), accountReleaseFunc)
 
 		// 5. Forward request
+		// Use ForwardUniversalChatCompletions to support OpenAI accounts in universal groups;
+		// for non-universal groups the internal dispatch falls through to ForwardAsChatCompletions.
 		writerSizeBeforeForward := c.Writer.Size()
 		forwardBody := body
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
 		}
-		result, err := h.gatewayService.ForwardAsChatCompletions(c.Request.Context(), c, account, forwardBody, parsedReq)
+		result, err := h.gatewayService.ForwardUniversalChatCompletions(c.Request.Context(), c, account, forwardBody, parsedReq)
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -210,12 +210,14 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		accountReleaseFunc = wrapReleaseOnDone(c.Request.Context(), accountReleaseFunc)
 
 		// 5. Forward request
+		// Use ForwardUniversalResponses to support OpenAI accounts in universal groups;
+		// for non-universal groups the internal dispatch falls through to ForwardAsResponses.
 		writerSizeBeforeForward := c.Writer.Size()
 		forwardBody := body
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
 		}
-		result, err := h.gatewayService.ForwardAsResponses(c.Request.Context(), c, account, forwardBody, parsedReq)
+		result, err := h.gatewayService.ForwardUniversalResponses(c.Request.Context(), c, account, forwardBody, parsedReq)
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()

--- a/backend/internal/pkg/tlsfingerprint/dialer.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer.go
@@ -11,10 +11,17 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 
 	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/proxy"
 )
+
+// Shared IPv4-only dialer to avoid IPv6 timeout when the host cannot reach IPv6 networks.
+var ipv4Dialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+}
 
 // Profile contains TLS fingerprint configuration.
 // All slice fields use built-in defaults when empty.
@@ -118,10 +125,10 @@ var (
 
 // NewDialer creates a new TLS fingerprint dialer.
 // baseDialer is used for TCP connection establishment (supports proxy scenarios).
-// If baseDialer is nil, direct TCP dial is used.
+// If baseDialer is nil, IPv4-only direct TCP dial is used.
 func NewDialer(profile *Profile, baseDialer func(ctx context.Context, network, addr string) (net.Conn, error)) *Dialer {
 	if baseDialer == nil {
-		baseDialer = (&net.Dialer{}).DialContext
+		baseDialer = ipv4Dialer.DialContext
 	}
 	return &Dialer{profile: profile, baseDialer: baseDialer}
 }
@@ -197,8 +204,7 @@ func (d *HTTPProxyDialer) DialTLSContext(ctx context.Context, network, addr stri
 		}
 	}
 
-	dialer := &net.Dialer{}
-	conn, err := dialer.DialContext(ctx, "tcp", proxyAddr)
+	conn, err := ipv4Dialer.DialContext(ctx, "tcp4", proxyAddr)
 	if err != nil {
 		slog.Debug("tls_fingerprint_http_proxy_connect_failed", "error", err)
 		return nil, fmt.Errorf("connect to proxy: %w", err)

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"compress/flate"
 	"compress/gzip"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -52,6 +53,36 @@ const (
 )
 
 var errUpstreamClientLimitReached = errors.New("upstream client cache limit reached")
+
+// ipv4DialContext forces IPv4-only connections with custom DNS resolver
+// to avoid DNS poisoning (e.g., Clash proxy returning wrong IPs for chatgpt.com).
+var customResolver = &net.Resolver{
+	PreferGo: true,
+	Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+		d := &net.Dialer{Timeout: 5 * time.Second}
+		return d.DialContext(ctx, "udp", "8.8.8.8:53")
+	},
+}
+
+var ipv4Dialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+}
+
+func ipv4DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+		port = "443"
+	}
+	// Resolve using Google DNS to avoid DNS poisoning
+	addrs, err := customResolver.LookupIP(ctx, "ip4", host)
+	if err != nil || len(addrs) == 0 {
+		return nil, &net.OpError{Op: "dial", Net: "tcp4", Source: nil, Addr: nil, Err: fmt.Errorf("DNS lookup failed for %s: %w", host, err)}
+	}
+	target := net.JoinHostPort(addrs[0].String(), port)
+	return ipv4Dialer.DialContext(ctx, "tcp4", target)
+}
 
 // poolSettings 连接池配置参数
 // 封装 Transport 所需的各项连接池参数
@@ -766,6 +797,7 @@ func buildUpstreamTransport(settings poolSettings, proxyURL *url.URL) (*http.Tra
 		MaxConnsPerHost:       settings.maxConnsPerHost,
 		IdleConnTimeout:       settings.idleConnTimeout,
 		ResponseHeaderTimeout: settings.responseHeaderTimeout,
+		DialContext:           ipv4DialContext,
 	}
 	if err := proxyutil.ConfigureTransportProxy(transport, proxyURL); err != nil {
 		return nil, err

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -24,6 +24,7 @@ const (
 	PlatformOpenAI      = domain.PlatformOpenAI
 	PlatformGemini      = domain.PlatformGemini
 	PlatformAntigravity = domain.PlatformAntigravity
+	PlatformUniversal   = domain.PlatformUniversal
 )
 
 // Account type constants

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -230,7 +230,8 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseCCeventLine(line)
+		if !ok {
 			continue
 		}
 
@@ -238,15 +239,16 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseCCdataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			continue
 		}
+		event.Type = eventType
 
 		// message_start carries the initial response structure and cache usage
 		if event.Type == "message_start" && event.Message != nil {
@@ -421,7 +423,8 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseCCeventLine(line)
+		if !ok {
 			continue
 		}
 
@@ -429,15 +432,16 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseCCdataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
 			continue
 		}
+		event.Type = eventType
 
 		if processAnthropicEvent(&event) {
 			return resultWithUsage(), nil
@@ -482,4 +486,28 @@ func writeGatewayCCError(c *gin.Context, statusCode int, errType, message string
 			"message": message,
 		},
 	})
+}
+
+// parseCCeventLine extracts the event name from an SSE "event:" line.
+// Compatible with both "event: name" (with space) and "event:name" (without space).
+func parseCCeventLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "event: ") {
+		return strings.TrimSpace(line[7:]), true
+	}
+	if strings.HasPrefix(line, "event:") {
+		return strings.TrimSpace(line[6:]), true
+	}
+	return "", false
+}
+
+// parseCCdataLine extracts the data payload from an SSE "data:" line.
+// Compatible with both "data: {...}" (with space) and "data:{...}" (without space).
+func parseCCdataLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "data: ") {
+		return line[6:], true
+	}
+	if strings.HasPrefix(line, "data:") {
+		return line[5:], true
+	}
+	return "", false
 }

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -240,20 +240,20 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseRespEventLine(line)
+		if !ok {
 			continue
 		}
-		eventType := strings.TrimPrefix(line, "event: ")
 
 		// Read the data line
 		if !scanner.Scan() {
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseRespDataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -263,6 +263,9 @@ func (s *GatewayService) handleResponsesBufferedStreamingResponse(
 				zap.String("event_type", eventType),
 			)
 			continue
+		}
+		if event.Type == "" {
+			event.Type = eventType
 		}
 
 		// message_start carries the initial response structure
@@ -449,20 +452,20 @@ func (s *GatewayService) handleResponsesStreamingResponse(
 	// Read Anthropic SSE events
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		eventType, ok := parseRespEventLine(line)
+		if !ok {
 			continue
 		}
-		eventType := strings.TrimPrefix(line, "event: ")
 
 		// Read data line
 		if !scanner.Scan() {
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := parseRespDataLine(dataLine)
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -472,6 +475,9 @@ func (s *GatewayService) handleResponsesStreamingResponse(
 				zap.String("event_type", eventType),
 			)
 			continue
+		}
+		if event.Type == "" {
+			event.Type = eventType
 		}
 
 		if processEvent(&event) {
@@ -515,4 +521,28 @@ func mapUpstreamStatusCode(code int) int {
 		return http.StatusBadGateway
 	}
 	return code
+}
+
+// parseRespEventLine extracts the event name from an SSE "event:" line.
+// Compatible with both "event: name" (with space) and "event:name" (without space).
+func parseRespEventLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "event: ") {
+		return strings.TrimSpace(line[7:]), true
+	}
+	if strings.HasPrefix(line, "event:") {
+		return strings.TrimSpace(line[6:]), true
+	}
+	return "", false
+}
+
+// parseRespDataLine extracts the data payload from an SSE "data:" line.
+// Compatible with both "data: {...}" (with space) and "data:{...}" (without space).
+func parseRespDataLine(line string) (string, bool) {
+	if strings.HasPrefix(line, "data: ") {
+		return line[6:], true
+	}
+	if strings.HasPrefix(line, "data:") {
+		return line[5:], true
+	}
+	return "", false
 }

--- a/backend/internal/service/gateway_forward_universal.go
+++ b/backend/internal/service/gateway_forward_universal.go
@@ -1,0 +1,689 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+// ForwardUniversalChatCompletions dispatches to the appropriate upstream based
+// on the selected account's platform. For OpenAI accounts it does a direct
+// CC→OpenAI passthrough (no format conversion). For Anthropic/Antigravity/Gemini
+// accounts it delegates to the existing Anthropic conversion chain.
+func (s *GatewayService) ForwardUniversalChatCompletions(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	parsed *ParsedRequest,
+) (*ForwardResult, error) {
+	switch account.Platform {
+	case PlatformOpenAI:
+		return s.forwardAsChatCompletionsOpenAI(ctx, c, account, body, parsed)
+	default:
+		// anthropic, antigravity, gemini → existing Anthropic chain
+		return s.ForwardAsChatCompletions(ctx, c, account, body, parsed)
+	}
+}
+
+// ForwardUniversalResponses dispatches to the appropriate upstream based
+// on the selected account's platform. For OpenAI accounts it does a direct
+// Responses→OpenAI passthrough. For Anthropic/Antigravity/Gemini accounts
+// it delegates to the existing ForwardAsResponses.
+func (s *GatewayService) ForwardUniversalResponses(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	parsed *ParsedRequest,
+) (*ForwardResult, error) {
+	switch account.Platform {
+	case PlatformOpenAI:
+		return s.forwardAsResponsesOpenAI(ctx, c, account, body, parsed)
+	default:
+		return s.ForwardAsResponses(ctx, c, account, body, parsed)
+	}
+}
+
+// forwardAsChatCompletionsOpenAI forwards a Chat Completions request directly
+// to an OpenAI-compatible upstream (no format conversion, CC body is already
+// in OpenAI format). The response is streamed back to the client as-is.
+func (s *GatewayService) forwardAsChatCompletionsOpenAI(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	parsed *ParsedRequest,
+) (*ForwardResult, error) {
+	startTime := time.Now()
+
+	originalModel := gjson.GetBytes(body, "model").String()
+	clientStream := gjson.GetBytes(body, "stream").Bool()
+	includeUsage := gjson.GetBytes(body, "stream_options.include_usage").Bool()
+
+	// Model mapping for API Key accounts
+	mappedModel := originalModel
+	if account.Type == AccountTypeAPIKey {
+		if m := account.GetMappedModel(originalModel); m != "" {
+			mappedModel = m
+		}
+	}
+	if mappedModel != originalModel {
+		body = replaceModelInBody(body, mappedModel)
+	}
+
+	// For OAuth accounts, convert Chat Completions body to Responses format
+	// since the upstream endpoint is chatgpt.com/backend-api/codex/responses
+	if account.Type == AccountTypeOAuth {
+		var chatReq apicompat.ChatCompletionsRequest
+		if err := json.Unmarshal(body, &chatReq); err == nil {
+			if responsesReq, err := apicompat.ChatCompletionsToResponses(&chatReq); err == nil {
+				if converted, err := json.Marshal(responsesReq); err == nil {
+					body = converted
+				}
+			}
+		}
+		// Apply Codex OAuth transform (sets instructions, model normalization, etc.)
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err == nil {
+			applyCodexOAuthTransform(reqBody, false, false)
+			// Responses API requires instructions field
+			if _, ok := reqBody["instructions"]; !ok {
+				reqBody["instructions"] = ""
+			}
+			if transformed, err := json.Marshal(reqBody); err == nil {
+				body = transformed
+			}
+		}
+	}
+
+	logger.L().Debug("universal forward openai: model mapping",
+		zap.Int64("account_id", account.ID),
+		zap.String("original_model", originalModel),
+		zap.String("mapped_model", mappedModel),
+	)
+
+	// Get access token
+	token, tokenType, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	// Get proxy URL
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	// Build upstream request for OpenAI
+	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, clientStream)
+	upstreamReq, err := s.buildOpenAIUpstreamRequest(upstreamCtx, c, account, body, token, tokenType, mappedModel, clientStream)
+	releaseUpstreamCtx()
+	if err != nil {
+		return nil, fmt.Errorf("build openai upstream request: %w", err)
+	}
+
+	// Send request
+	// OpenAI OAuth accounts go through ChatGPT internal API (chatgpt.com) which is
+	// protected by Cloudflare WAF. TLS fingerprint emulation triggers WAF detection,
+	// so we use plain Do() for OAuth accounts.
+	var resp *http.Response
+	if account.Type == AccountTypeOAuth {
+		resp, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	} else {
+		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	}
+	if err != nil {
+		if resp != nil && resp.Body != nil {
+			_ = resp.Body.Close()
+		}
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: 0,
+			Kind:               "request_error",
+			Message:            safeErr,
+		})
+		writeGatewayCCError(c, http.StatusBadGateway, "server_error", "Upstream request failed")
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Handle error response
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+
+		if s.shouldFailoverUpstreamError(resp.StatusCode) {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: resp.StatusCode,
+				UpstreamRequestID:  resp.Header.Get("x-request-id"),
+				Kind:               "failover",
+				Message:            upstreamMsg,
+			})
+			if s.rateLimitService != nil {
+				s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+			}
+			return nil, &UpstreamFailoverError{
+				StatusCode:   resp.StatusCode,
+				ResponseBody: respBody,
+			}
+		}
+
+		writeGatewayCCError(c, mapUpstreamStatusCode(resp.StatusCode), "server_error", upstreamMsg)
+		return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
+	}
+
+	// Forward response to client
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+
+	var result *ForwardResult
+	var handleErr error
+	if clientStream {
+		result, handleErr = s.forwardOpenAIStreamingResponse(resp, c, originalModel, mappedModel, startTime, includeUsage)
+	} else {
+		result, handleErr = s.forwardOpenAIBufferedResponse(resp, c, originalModel, mappedModel, startTime)
+	}
+	return result, handleErr
+}
+
+// forwardAsResponsesOpenAI forwards a Responses API request directly
+// to an OpenAI-compatible upstream (no format conversion, Responses body is
+// already in OpenAI-compatible format). The response is streamed back as-is.
+func (s *GatewayService) forwardAsResponsesOpenAI(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	parsed *ParsedRequest,
+) (*ForwardResult, error) {
+	startTime := time.Now()
+
+	originalModel := gjson.GetBytes(body, "model").String()
+	clientStream := gjson.GetBytes(body, "stream").Bool()
+
+	// Model mapping for API Key accounts
+	mappedModel := originalModel
+	if account.Type == AccountTypeAPIKey {
+		if m := account.GetMappedModel(originalModel); m != "" {
+			mappedModel = m
+		}
+	}
+	if mappedModel != originalModel {
+		body = replaceModelInBody(body, mappedModel)
+	}
+
+	logger.L().Debug("universal forward openai responses: model mapping",
+		zap.Int64("account_id", account.ID),
+		zap.String("original_model", originalModel),
+		zap.String("mapped_model", mappedModel),
+	)
+
+	// Get access token
+	token, tokenType, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	// Get proxy URL
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	// Build upstream request for OpenAI
+	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, clientStream)
+	upstreamReq, err := s.buildOpenAIUpstreamRequest(upstreamCtx, c, account, body, token, tokenType, mappedModel, clientStream)
+	releaseUpstreamCtx()
+	if err != nil {
+		return nil, fmt.Errorf("build openai upstream request: %w", err)
+	}
+
+	// Send request
+	// OpenAI OAuth accounts go through ChatGPT internal API (chatgpt.com) which is
+	// protected by Cloudflare WAF. TLS fingerprint emulation triggers WAF detection,
+	// so we use plain Do() for OAuth accounts.
+	var resp2 *http.Response
+	if account.Type == AccountTypeOAuth {
+		resp2, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	} else {
+		resp2, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	}
+	if err != nil {
+		if resp2 != nil && resp2.Body != nil {
+			_ = resp2.Body.Close()
+		}
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: 0,
+			Kind:               "request_error",
+			Message:            safeErr,
+		})
+		writeResponsesError(c, http.StatusBadGateway, "server_error", "Upstream request failed")
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+
+	// Handle error response
+	if resp2.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp2.Body, 2<<20))
+		_ = resp2.Body.Close()
+		resp2.Body = io.NopCloser(bytes.NewReader(respBody))
+
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+
+		if s.shouldFailoverUpstreamError(resp2.StatusCode) {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: resp2.StatusCode,
+				UpstreamRequestID:  resp2.Header.Get("x-request-id"),
+				Kind:               "failover",
+				Message:            upstreamMsg,
+			})
+			if s.rateLimitService != nil {
+				s.rateLimitService.HandleUpstreamError(ctx, account, resp2.StatusCode, resp2.Header, respBody)
+			}
+			return nil, &UpstreamFailoverError{
+				StatusCode:   resp2.StatusCode,
+				ResponseBody: respBody,
+			}
+		}
+
+		writeResponsesError(c, mapUpstreamStatusCode(resp2.StatusCode), "server_error", upstreamMsg)
+		return nil, fmt.Errorf("upstream error: %d %s", resp2.StatusCode, upstreamMsg)
+	}
+
+	// Forward response to client
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp2.Header, s.responseHeaderFilter)
+	}
+
+	var result *ForwardResult
+	var handleErr error
+	if clientStream {
+		result, handleErr = s.forwardOpenAIStreamingResponse(resp2, c, originalModel, mappedModel, startTime, false)
+	} else {
+		result, handleErr = s.forwardOpenAIBufferedResponse(resp2, c, originalModel, mappedModel, startTime)
+	}
+	return result, handleErr
+}
+func (s *GatewayService) buildOpenAIUpstreamRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token, tokenType, model string,
+	stream bool,
+) (*http.Request, error) {
+	var url string
+	if account.Type == AccountTypeOAuth {
+		// OAuth accounts use ChatGPT internal API, not api.openai.com.
+		// Do NOT use GetOpenAIBaseURL() — it returns api.openai.com for all
+		// OpenAI accounts, which sends the request to the wrong host.
+		url = "https://chatgpt.com/backend-api/codex/responses"
+	} else {
+		// API Key accounts: use OpenAI Platform API or custom base URL
+		customBase := account.GetOpenAIBaseURL()
+		if customBase == "" {
+			customBase = "https://api.openai.com"
+		}
+		url = customBase + "/v1/chat/completions"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("content-type", "application/json")
+	req.Header.Set("accept", "text/event-stream")
+
+	// Auth — OpenAI always uses Bearer
+	if token != "" {
+		req.Header.Set("authorization", "Bearer "+token)
+	}
+
+	// OAuth: set ChatGPT required headers
+	if account.Type == AccountTypeOAuth {
+		req.Host = "chatgpt.com"
+		if chatgptAccountID := account.GetChatGPTAccountID(); chatgptAccountID != "" {
+			req.Header.Set("chatgpt-account-id", chatgptAccountID)
+		}
+		req.Header.Set("OpenAI-Beta", "responses=experimental")
+		req.Header.Set("originator", "codex_cli_rs")
+		req.Header.Set("version", "0.104.0")
+		req.Header.Set("accept", "text/event-stream")
+		if deviceID := account.GetOpenAIDeviceID(); deviceID != "" {
+			req.Header.Set("oai-device-id", deviceID)
+			req.Header.Set("Cookie", "oai-did="+deviceID)
+		}
+		if sessionID := account.GetOpenAISessionID(); sessionID != "" {
+			req.Header.Set("oai-session-id", sessionID)
+		}
+		// Apply custom User-Agent if configured
+		if ua := account.GetOpenAIUserAgent(); ua != "" {
+			req.Header.Set("user-agent", ua)
+		}
+		// OAuth safety: default to Codex CLI UA if no custom UA set
+		if req.Header.Get("user-agent") == "" {
+			req.Header.Set("user-agent", "codex_cli_rs/0.104.0")
+		}
+	}
+
+	// Copy relevant headers from the original request
+	for _, h := range []string{"X-Request-ID", "Traceparent"} {
+		if v := c.GetHeader(h); v != "" {
+			req.Header.Set(h, v)
+		}
+	}
+	// Only copy User-Agent if not already set by OAuth branch
+	if account.Type != AccountTypeOAuth || req.Header.Get("user-agent") == "" {
+		if v := c.GetHeader("User-Agent"); v != "" {
+			req.Header.Set("user-agent", v)
+		}
+	}
+
+	return req, nil
+}
+
+// forwardOpenAIStreamingResponse streams the OpenAI SSE response to the client,
+// converting Responses API SSE events to Chat Completions SSE format.
+func (s *GatewayService) forwardOpenAIStreamingResponse(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	mappedModel string,
+	startTime time.Time,
+	includeUsage bool,
+) (*ForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	var usage ClaudeUsage
+	var firstTokenMs *int
+	firstChunk := true
+	created := time.Now().Unix()
+	chunkIndex := 0
+	sawTerminal := false
+
+	scanner := bufio.NewScanner(resp.Body)
+	maxLineSize := defaultMaxLineSize
+	if s.cfg != nil && s.cfg.Gateway.MaxLineSize > 0 {
+		maxLineSize = s.cfg.Gateway.MaxLineSize
+	}
+	scanner.Buffer(make([]byte, 0, 64*1024), maxLineSize)
+
+	resultWithUsage := func() *ForwardResult {
+		return &ForwardResult{
+			RequestID:     requestID,
+			Usage:         usage,
+			Model:         originalModel,
+			UpstreamModel: mappedModel,
+			Stream:        true,
+			Duration:      time.Since(startTime),
+			FirstTokenMs:  firstTokenMs,
+		}
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+
+		data := strings.TrimPrefix(strings.TrimPrefix(line, "data: "), "data:")
+		if data == "[DONE]" {
+			sawTerminal = true
+			break
+		}
+
+		eventType := gjson.Get(data, "type").String()
+
+		switch eventType {
+		case "response.output_text.delta":
+			if firstChunk {
+				firstChunk = false
+				ms := int(time.Since(startTime).Milliseconds())
+				firstTokenMs = &ms
+			}
+			delta := gjson.Get(data, "delta").String()
+			chunk := buildChatCompletionsChunk(delta, originalModel, created, chunkIndex)
+			fmt.Fprint(c.Writer, chunk)
+			chunkIndex++
+			c.Writer.Flush()
+
+		case "response.done", "response.completed":
+			sawTerminal = true
+			if pt := gjson.Get(data, "response.usage.input_tokens"); pt.Exists() {
+				usage.InputTokens = int(pt.Int())
+			}
+			if ct := gjson.Get(data, "response.usage.output_tokens"); ct.Exists() {
+				usage.OutputTokens = int(ct.Int())
+			}
+			if includeUsage {
+				usageSSE := buildCCUsageSSE(usage, originalModel)
+				fmt.Fprint(c.Writer, usageSSE) //nolint:errcheck
+			}
+			fmt.Fprint(c.Writer, "data: [DONE]\n\n") //nolint:errcheck
+			c.Writer.Flush()
+			return resultWithUsage(), nil
+
+		case "error":
+			errMsg := gjson.Get(data, "error.message").String()
+			if errMsg == "" {
+				errMsg = "Upstream error"
+			}
+			logger.L().Warn("openai streaming error",
+				zap.String("request_id", requestID),
+				zap.String("error", errMsg),
+			)
+			fmt.Fprint(c.Writer, "data: [DONE]\n\n") //nolint:errcheck
+			c.Writer.Flush()
+			return resultWithUsage(), nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			logger.L().Warn("forward openai stream: read error",
+				zap.Error(err),
+				zap.String("request_id", requestID),
+			)
+		}
+	}
+
+	if !sawTerminal {
+		if includeUsage {
+			usageSSE := buildCCUsageSSE(usage, originalModel)
+			fmt.Fprint(c.Writer, usageSSE) //nolint:errcheck
+		}
+		fmt.Fprint(c.Writer, "data: [DONE]\n\n") //nolint:errcheck
+	}
+	c.Writer.Flush()
+
+	return resultWithUsage(), nil
+}
+
+// forwardOpenAIBufferedResponse reads the full OpenAI response and writes it to the client.
+// If the upstream returns Responses API format, it converts to Chat Completions format.
+func (s *GatewayService) forwardOpenAIBufferedResponse(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	mappedModel string,
+	startTime time.Time,
+) (*ForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		writeGatewayCCError(c, http.StatusBadGateway, "server_error", "Failed to read upstream response")
+		return nil, fmt.Errorf("read upstream response: %w", err)
+	}
+
+	// Check if this is a Responses API format response and convert if needed
+	if isResponsesAPIFormat(respBody) {
+		respBody = convertResponsesToChatCompletions(respBody, originalModel, mappedModel)
+	} else if originalModel != mappedModel {
+		// Already Chat Completions format, just replace model name
+		respBody = bytes.ReplaceAll(respBody, []byte(`"model":"`+mappedModel+`"`), []byte(`"model":"`+originalModel+`"`))
+	}
+
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	c.Data(http.StatusOK, "application/json; charset=utf-8", respBody)
+
+	// Extract usage
+	var usage ClaudeUsage
+	usageData := gjson.GetBytes(respBody, "usage")
+	if usageData.Exists() {
+		if pt := usageData.Get("prompt_tokens"); pt.Exists() {
+			usage.InputTokens = int(pt.Int())
+		}
+		if ct := usageData.Get("completion_tokens"); ct.Exists() {
+			usage.OutputTokens = int(ct.Int())
+		}
+	}
+
+	// Also check Responses API usage format if not already captured
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 {
+		if pt := gjson.GetBytes(respBody, "response.usage.input_tokens"); pt.Exists() {
+			usage.InputTokens = int(pt.Int())
+		}
+		if ct := gjson.GetBytes(respBody, "response.usage.output_tokens"); ct.Exists() {
+			usage.OutputTokens = int(ct.Int())
+		}
+	}
+
+	return &ForwardResult{
+		RequestID:     requestID,
+		Usage:         usage,
+		Model:         originalModel,
+		UpstreamModel: mappedModel,
+		Stream:        false,
+		Duration:      time.Since(startTime),
+	}, nil
+}
+
+// replaceModelInBody replaces the "model" field in a JSON body.
+func replaceModelInBody(body []byte, model string) []byte {
+	old := gjson.GetBytes(body, "model").String()
+	if old == "" || old == model {
+		return body
+	}
+	return bytes.ReplaceAll(body,
+		[]byte(`"model":"`+old+`"`),
+		[]byte(`"model":"`+model+`"`),
+	)
+}
+
+// buildCCUsageSSE builds a Chat Completions usage-only SSE chunk.
+func buildCCUsageSSE(usage ClaudeUsage, model string) string {
+	return fmt.Sprintf(`data: {"id":"usage","object":"chat.completion.chunk","created":0,"model":"%s","choices":[],"usage":{"prompt_tokens":%d,"completion_tokens":%d,"total_tokens":%d}}
+
+`, model, usage.InputTokens, usage.OutputTokens, usage.InputTokens+usage.OutputTokens)
+}
+
+// buildChatCompletionsChunk builds a Chat Completions SSE chunk from text delta.
+func buildChatCompletionsChunk(delta string, model string, created int64, index int) string {
+	escaped, _ := json.Marshal(delta)
+	return fmt.Sprintf(`data: {"id":"chatcmpl-universal-%d-%d","object":"chat.completion.chunk","created":%d,"model":"%s","choices":[{"index":%d,"delta":{"content":%s}}]}
+
+`, index, index, created, model, index, string(escaped))
+}
+
+// isResponsesAPIFormat checks if a JSON body is in Responses API format.
+func isResponsesAPIFormat(body []byte) bool {
+	if t := gjson.GetBytes(body, "type"); t.Exists() && t.Str == "response.completed" {
+		return true
+	}
+	if out := gjson.GetBytes(body, "response.output"); out.Exists() {
+		return true
+	}
+	return false
+}
+
+// convertResponsesToChatCompletions converts a Responses API JSON response to Chat Completions format.
+func convertResponsesToChatCompletions(body []byte, originalModel, mappedModel string) []byte {
+	var textContent string
+	outputItems := gjson.GetBytes(body, "response.output")
+	if outputItems.Exists() && outputItems.IsArray() {
+		for _, item := range outputItems.Array() {
+			for _, content := range item.Get("content").Array() {
+				if t := content.Get("text"); t.Exists() {
+					textContent += t.String()
+				}
+			}
+		}
+	}
+
+	respModel := originalModel
+
+	inputTokens := int(gjson.GetBytes(body, "response.usage.input_tokens").Int())
+	outputTokens := int(gjson.GetBytes(body, "response.usage.output_tokens").Int())
+	totalTokens := inputTokens + outputTokens
+
+	result := map[string]any{
+		"id":      gjson.GetBytes(body, "response.id").String(),
+		"object":  "chat.completion",
+		"created": gjson.GetBytes(body, "response.created_at").Int(),
+		"model":   respModel,
+		"choices": []map[string]any{
+			{
+				"index": 0,
+				"message": map[string]any{
+					"role":    "assistant",
+					"content": textContent,
+				},
+				"finish_reason": "stop",
+			},
+		},
+		"usage": map[string]any{
+			"prompt_tokens":     inputTokens,
+			"completion_tokens": outputTokens,
+			"total_tokens":      totalTokens,
+		},
+	}
+
+	b, _ := json.Marshal(result)
+	return b
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1834,7 +1834,11 @@ func (s *GatewayService) ResolveGroupByID(ctx context.Context, groupID int64) (*
 }
 
 func (s *GatewayService) routingAccountIDsForRequest(ctx context.Context, groupID *int64, requestedModel string, platform string) []int64 {
-	if groupID == nil || requestedModel == "" || platform != PlatformAnthropic {
+	if groupID == nil || requestedModel == "" {
+		return nil
+	}
+	// Model routing 仅适用于 anthropic 和 universal 组
+	if platform != PlatformAnthropic && platform != PlatformUniversal {
 		return nil
 	}
 	group, err := s.resolveGroupByID(ctx, *groupID)
@@ -1844,10 +1848,10 @@ func (s *GatewayService) routingAccountIDsForRequest(ctx context.Context, groupI
 		}
 		return nil
 	}
-	// Preserve existing behavior: model routing only applies to anthropic groups.
-	if group.Platform != PlatformAnthropic {
+	// universal 组允许任意平台路由；anthropic 组保持原有校验
+	if group.Platform != PlatformAnthropic && group.Platform != PlatformUniversal {
 		if s.debugModelRoutingEnabled() {
-			logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] skip: non-anthropic group platform: group_id=%d group_platform=%s model=%s", group.ID, group.Platform, requestedModel)
+			logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] skip: unsupported group platform: group_id=%d group_platform=%s model=%s", group.ID, group.Platform, requestedModel)
 		}
 		return nil
 	}
@@ -1992,6 +1996,42 @@ func (s *GatewayService) listSchedulableAccounts(ctx context.Context, groupID *i
 		return filtered, useMixed, nil
 	}
 
+	// universal 平台：不限平台，返回分组内所有可调度账号
+	if platform == PlatformUniversal {
+		var accounts []Account
+		var err error
+		if groupID != nil {
+			accounts, err = s.accountRepo.ListSchedulableByGroupID(ctx, *groupID)
+		} else if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+			accounts, err = s.accountRepo.ListSchedulable(ctx)
+		} else {
+			// 无分组 universal 模式：查询所有平台的可调度账号
+			allPlatforms := []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity}
+			accounts, err = s.accountRepo.ListSchedulableByPlatforms(ctx, allPlatforms)
+		}
+		if err != nil {
+			slog.Debug("account_scheduling_list_failed",
+				"group_id", derefGroupID(groupID),
+				"platform", platform,
+				"error", err)
+			return nil, false, err
+		}
+		slog.Debug("account_scheduling_list_universal",
+			"group_id", derefGroupID(groupID),
+			"platform", platform,
+			"count", len(accounts))
+		for _, acc := range accounts {
+			slog.Debug("account_scheduling_account_detail",
+				"account_id", acc.ID,
+				"name", acc.Name,
+				"platform", acc.Platform,
+				"type", acc.Type,
+				"status", acc.Status,
+				"tls_fingerprint", acc.IsTLSFingerprintEnabled())
+		}
+		return accounts, false, nil
+	}
+
 	var accounts []Account
 	var err error
 	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
@@ -2039,6 +2079,9 @@ func (s *GatewayService) IsSingleAntigravityAccountGroup(ctx context.Context, gr
 func (s *GatewayService) isAccountAllowedForPlatform(account *Account, platform string, useMixed bool) bool {
 	if account == nil {
 		return false
+	}
+	if platform == PlatformUniversal {
+		return true // universal 组允许任意平台账号
 	}
 	if useMixed {
 		if account.Platform == platform {
@@ -2730,7 +2773,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 						if clearSticky {
 							_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 						}
-						if !clearSticky && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) && !s.isStickyAccountUpstreamRestricted(ctx, groupID, account, requestedModel) {
+						if !clearSticky && s.isAccountInGroup(account, groupID) && (account.Platform == platform || platform == PlatformUniversal) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) && !s.isStickyAccountUpstreamRestricted(ctx, groupID, account, requestedModel) {
 							if s.debugModelRoutingEnabled() {
 								logger.LegacyPrintf("service.gateway", "[ModelRoutingDebug] legacy routed sticky hit: group_id=%v model=%s session=%s account=%d", derefGroupID(groupID), requestedModel, shortSessionHash(sessionHash), accountID)
 							}
@@ -2849,7 +2892,7 @@ func (s *GatewayService) selectAccountForModelWithPlatform(ctx context.Context, 
 					if clearSticky {
 						_ = s.cache.DeleteSessionAccountID(ctx, derefGroupID(groupID), sessionHash)
 					}
-					if !clearSticky && s.isAccountInGroup(account, groupID) && account.Platform == platform && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) {
+					if !clearSticky && s.isAccountInGroup(account, groupID) && (account.Platform == platform || platform == PlatformUniversal) && (requestedModel == "" || s.isModelSupportedByAccountWithContext(ctx, account, requestedModel)) && s.isAccountSchedulableForModelSelection(ctx, account, requestedModel) && s.isAccountSchedulableForQuota(account) && s.isAccountSchedulableForWindowCost(ctx, account, true) && s.isAccountSchedulableForRPM(ctx, account, true) {
 						return account, nil
 					}
 				}
@@ -3429,6 +3472,15 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 	if account.Platform == PlatformOpenAI && account.IsOpenAIPassthroughEnabled() {
 		return true
 	}
+	// OpenAI API Key 但使用自定义 base_url（如 DashScope 兼容接口），
+	// 不认为它支持 OpenAI 原生模型（如 gpt-*），除非配置了显式映射。
+	if account.Platform == PlatformOpenAI && account.Type == AccountTypeAPIKey {
+		baseURL := account.GetOpenAIBaseURL()
+		if baseURL != "" && !strings.Contains(baseURL, "api.openai.com") {
+			// 自定义 upstream，需要显式模型映射
+			return account.IsModelSupported(requestedModel)
+		}
+	}
 	// OAuth/SetupToken 账号使用 Anthropic 标准映射（短ID → 长ID）
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
 		requestedModel = claude.NormalizeModelID(requestedModel)
@@ -3502,7 +3554,7 @@ func (s *GatewayService) shouldRetryUpstreamError(account *Account, statusCode i
 // shouldFailoverUpstreamError determines whether an upstream error should trigger account failover.
 func (s *GatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
-	case 401, 403, 429, 529:
+	case 401, 403, 404, 429, 529:
 		return true
 	default:
 		return statusCode >= 500
@@ -8740,8 +8792,8 @@ func (s *GatewayService) GetAvailableModels(ctx context.Context, groupID *int64,
 		return nil
 	}
 
-	// Filter by platform if specified
-	if platform != "" {
+	// Filter by platform if specified (universal platform skips filtering)
+	if platform != "" && platform != PlatformUniversal {
 		filtered := make([]Account, 0)
 		for _, acc := range accounts {
 			if acc.Platform == platform {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1780,7 +1780,7 @@ func (s *OpenAIGatewayService) GetAccessToken(ctx context.Context, account *Acco
 
 func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
-	case 401, 402, 403, 429, 529:
+	case 401, 402, 403, 404, 429, 529:
 		return true
 	default:
 		return statusCode >= 500

--- a/backend/internal/service/scheduler_cache.go
+++ b/backend/internal/service/scheduler_cache.go
@@ -9,9 +9,10 @@ import (
 )
 
 const (
-	SchedulerModeSingle = "single"
-	SchedulerModeMixed  = "mixed"
-	SchedulerModeForced = "forced"
+	SchedulerModeSingle    = "single"
+	SchedulerModeMixed     = "mixed"
+	SchedulerModeForced    = "forced"
+	SchedulerModeUniversal = "universal"
 )
 
 type SchedulerBucket struct {

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -473,6 +473,10 @@ func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account
 			firstErr = err
 		}
 	}
+	// 账号变更可能影响 universal 组的调度快照，需要同步重建
+	if err := s.rebuildBucketsForPlatform(ctx, PlatformUniversal, groupIDs, reason, seen); err != nil && firstErr == nil {
+		firstErr = err
+	}
 	return firstErr
 }
 
@@ -481,7 +485,7 @@ func (s *SchedulerSnapshotService) rebuildByGroupIDs(ctx context.Context, groupI
 	if len(groupIDs) == 0 {
 		return nil
 	}
-	platforms := []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity}
+	platforms := []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformUniversal}
 	var firstErr error
 	for _, platform := range platforms {
 		if err := s.rebuildBucketsForPlatform(ctx, platform, groupIDs, reason, seen); err != nil && firstErr == nil {
@@ -516,6 +520,11 @@ func (s *SchedulerSnapshotService) rebuildBucketsForPlatform(ctx context.Context
 		}
 		if platform == PlatformAnthropic || platform == PlatformGemini {
 			if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeMixed}, reason); err != nil && firstErr == nil {
+				firstErr = err
+			}
+		}
+		if platform == PlatformUniversal {
+			if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeUniversal}, reason); err != nil && firstErr == nil {
 				firstErr = err
 			}
 		}
@@ -663,6 +672,18 @@ func (s *SchedulerSnapshotService) loadAccountsFromDB(ctx context.Context, bucke
 		return filtered, nil
 	}
 
+	// universal 模式：不限平台
+	if bucket.Mode == SchedulerModeUniversal {
+		if groupID > 0 {
+			return s.accountRepo.ListSchedulableByGroupID(ctx, groupID)
+		}
+		if s.isRunModeSimple() {
+			return s.accountRepo.ListSchedulable(ctx)
+		}
+		allPlatforms := []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity}
+		return s.accountRepo.ListSchedulableByPlatforms(ctx, allPlatforms)
+	}
+
 	if groupID > 0 {
 		return s.accountRepo.ListSchedulableByGroupIDAndPlatform(ctx, groupID, bucket.Platform)
 	}
@@ -718,6 +739,9 @@ func (s *SchedulerSnapshotService) normalizeGroupIDs(groupIDs []int64) []int64 {
 func (s *SchedulerSnapshotService) resolveMode(platform string, hasForcePlatform bool) string {
 	if hasForcePlatform {
 		return SchedulerModeForced
+	}
+	if platform == PlatformUniversal {
+		return SchedulerModeUniversal
 	}
 	if platform == PlatformAnthropic || platform == PlatformGemini {
 		return SchedulerModeMixed
@@ -805,6 +829,9 @@ func (s *SchedulerSnapshotService) defaultBuckets(ctx context.Context) ([]Schedu
 		buckets = append(buckets, SchedulerBucket{GroupID: group.ID, Platform: group.Platform, Mode: SchedulerModeForced})
 		if group.Platform == PlatformAnthropic || group.Platform == PlatformGemini {
 			buckets = append(buckets, SchedulerBucket{GroupID: group.ID, Platform: group.Platform, Mode: SchedulerModeMixed})
+		}
+		if group.Platform == PlatformUniversal {
+			buckets = append(buckets, SchedulerBucket{GroupID: group.ID, Platform: group.Platform, Mode: SchedulerModeUniversal})
 		}
 	}
 	return dedupeBuckets(buckets), nil

--- a/frontend/src/components/common/GroupSelector.vue
+++ b/frontend/src/components/common/GroupSelector.vue
@@ -70,8 +70,8 @@ const filteredGroups = computed(() => {
       (g) => g.platform === 'antigravity' || g.platform === 'anthropic' || g.platform === 'gemini'
     )
   }
-  // 默认：只能选择同 platform 的分组
-  return props.groups.filter((g) => g.platform === props.platform)
+  // 默认：可选择同 platform 或 universal 分组（universal 分组允许任何平台账号加入）
+  return props.groups.filter((g) => g.platform === props.platform || g.platform === 'universal')
 })
 
 const handleChange = (groupId: number, checked: boolean) => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -436,7 +436,7 @@ export interface PaginationConfig {
 
 // ==================== API Key & Group Types ====================
 
-export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity'
+export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'universal'
 
 export type SubscriptionType = 'standard' | 'subscription'
 

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -1225,8 +1225,8 @@
           </p>
         </div>
 
-        <!-- 模型路由配置（仅 anthropic 平台） -->
-        <div v-if="createForm.platform === 'anthropic'" class="border-t pt-4">
+        <!-- 模型路由配置（anthropic / universal 平台） -->
+        <div v-if="createForm.platform === 'anthropic' || createForm.platform === 'universal'" class="border-t pt-4">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.modelRouting.title") }}
@@ -2344,8 +2344,8 @@
           </p>
         </div>
 
-        <!-- 模型路由配置（仅 anthropic 平台） -->
-        <div v-if="editForm.platform === 'anthropic'" class="border-t pt-4">
+        <!-- 模型路由配置（anthropic / universal 平台） -->
+        <div v-if="editForm.platform === 'anthropic' || editForm.platform === 'universal'" class="border-t pt-4">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.modelRouting.title") }}
@@ -2783,6 +2783,7 @@ const platformOptions = computed(() => [
   { value: "openai", label: "OpenAI" },
   { value: "gemini", label: "Gemini" },
   { value: "antigravity", label: "Antigravity" },
+  { value: "universal", label: "Universal（跨平台）" },
 ]);
 
 const platformFilterOptions = computed(() => [
@@ -2791,6 +2792,7 @@ const platformFilterOptions = computed(() => [
   { value: "openai", label: "OpenAI" },
   { value: "gemini", label: "Gemini" },
   { value: "antigravity", label: "Antigravity" },
+  { value: "universal", label: "Universal（跨平台）" },
 ]);
 
 const editStatusOptions = computed(() => [


### PR DESCRIPTION
## Summary

- Add `universal` platform type that allows a single API key to access models across all platforms (Anthropic, OpenAI, etc.) with automatic account-level routing
- Implement SSE format conversion for OpenAI OAuth (Responses API events → Chat Completions SSE) so clients like Claude Code and openclaw can parse responses correctly
- Add 404 to OpenAIGatewayService failover conditions to handle custom upstream accounts (e.g. DashScope) that don't support gpt-* models
- Add TLS fingerprint dialer support for OpenAI API Key accounts
- Admin UI: universal platform option in group selector

## Key Changes

### New `universal` Platform
- `PlatformUniversal` constant and `SchedulerModeUniversal` scheduler mode
- Universal group dispatches to all accounts regardless of their platform
- Automatic routing: when an OpenAI account is selected, it uses direct OpenAI passthrough; Anthropic/Gemini accounts use existing conversion chains

### OpenAI OAuth Response Format Conversion
- `forwardOpenAIStreamingResponse`: Converts Responses API SSE events (`response.output_text.delta`) to Chat Completions SSE chunks in real-time
- `forwardOpenAIBufferedResponse`: Detects Responses API JSON and converts to Chat Completions format
- Fixes issue where Claude Code / openclaw couldn't parse Responses API format responses

### 404 Failover
- Added 404 to `OpenAIGatewayService.shouldFailoverUpstreamError` failover conditions
- Prevents universal groups from being stuck on custom upstream accounts that don't support certain models

### TLS Fingerprint Dialer
- Support for TLS fingerprint emulation on OpenAI API Key accounts (not just OAuth)

## Testing

- Universal group with both Anthropic account (DashScope → qwen) and OpenAI OAuth account (ChatGPT → gpt)
- Single API key successfully accesses both qwen3.6-plus and gpt-5.4-mini
- SSE streaming works correctly with openclaw and Claude Code clients
- 404 from DashScope correctly triggers failover to OpenAI OAuth account
- Admin UI supports creating universal groups

## Files Changed

- `backend/internal/service/gateway_forward_universal.go` (new) — Core OpenAI passthrough with SSE conversion
- `backend/internal/service/gateway_service.go` — Universal scheduling logic
- `backend/internal/service/openai_gateway_service.go` — 404 failover fix
- `backend/internal/service/scheduler_snapshot_service.go` — Universal scheduler mode
- `backend/internal/handler/gateway_handler.go` — Forward dispatch by account platform
- `backend/internal/handler/gateway_handler_chat_completions.go` — Universal routing
- `backend/internal/handler/gateway_handler_responses.go` — Universal routing
- `backend/internal/pkg/tlsfingerprint/dialer.go` — TLS fingerprint support
- `backend/internal/repository/http_upstream.go` — Upstream request enhancements
- Admin frontend files — universal platform option