### PR TITLE
fix(openai): bump codex CLI version from 0.104.0 to 0.125.0

### DIFF
--- a/backend/internal/handler/openai_gateway_compact_log_test.go
+++ b/backend/internal/handler/openai_gateway_compact_log_test.go
@@ -116,7 +116,7 @@ func TestLogOpenAIRemoteCompactOutcome_Succeeded(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
-	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.104.0")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
 	c.Set(opsModelKey, "gpt-5.3-codex")
 	c.Set(opsAccountIDKey, int64(123))
 	c.Header("x-request-id", "rid-compact-ok")
@@ -142,7 +142,7 @@ func TestLogOpenAIRemoteCompactOutcome_Failed(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/responses/compact", nil)
-	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.104.0")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
 	c.Status(http.StatusBadGateway)
 
 	h := &OpenAIGatewayHandler{}
@@ -180,7 +180,7 @@ func TestOpenAIResponses_CompactUnauthorizedLogsFailed(t *testing.T) {
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", strings.NewReader(`{"model":"gpt-5.3-codex"}`))
 	c.Request.Header.Set("Content-Type", "application/json")
-	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.104.0")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
 
 	h := &OpenAIGatewayHandler{}
 	h.Responses(c)

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -110,7 +110,7 @@ const (
 	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
 	windowStatsCacheTTL     = 1 * time.Minute
 	openAIProbeCacheTTL     = 10 * time.Minute
-	openAICodexProbeVersion = "0.104.0"
+	openAICodexProbeVersion = "0.125.0"
 )
 
 // UsageCache 封装账户使用量相关的缓存

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -40,7 +40,7 @@ const (
 	// OpenAI Platform API for API Key accounts (fallback)
 	openaiPlatformAPIURL   = "https://api.openai.com/v1/responses"
 	openaiStickySessionTTL = time.Hour // 粘性会话TTL
-	codexCLIUserAgent      = "codex_cli_rs/0.104.0"
+	codexCLIUserAgent      = "codex_cli_rs/0.125.0"
 	// codex_cli_only 拒绝时单个请求头日志长度上限（字符）
 	codexCLIOnlyHeaderValueMaxBytes = 256
 
@@ -54,7 +54,7 @@ const (
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
-	codexCLIVersion                    = "0.104.0"
+	codexCLIVersion                    = "0.125.0"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 )

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -734,7 +734,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_NonCodexUAFallbackToCodexUA(t *te
 	require.NoError(t, err)
 	require.Equal(t, false, gjson.GetBytes(upstream.lastBody, "store").Bool())
 	require.Equal(t, true, gjson.GetBytes(upstream.lastBody, "stream").Bool())
-	require.Equal(t, "codex_cli_rs/0.104.0", upstream.lastReq.Header.Get("User-Agent"))
+	require.Equal(t, "codex_cli_rs/0.125.0", upstream.lastReq.Header.Get("User-Agent"))
 }
 
 func TestOpenAIGatewayService_CodexCLIOnly_RejectsNonCodexClient(t *testing.T) {


### PR DESCRIPTION
## Summary

- Bump `codexCLIVersion` and `codexCLIUserAgent` from `0.104.0` to `0.125.0` in `openai_gateway_service.go`
- Bump `openAICodexProbeVersion` from `0.104.0` to `0.125.0` in `account_usage_service.go`
- Sync hardcoded version strings in related test files

## Problem

The hardcoded Codex CLI version `0.104.0` is outdated. When using gpt-5.5 via OAuth + `/responses/compact`, the upstream server rejects requests from this old version with 400, which the gateway wraps as 502:

```
Error running remote compact task: unexpected status 502 Bad Gateway: Upstream request failed
```

This affects any user whose client does not explicitly set the `version` header, as the fallback value `0.104.0` is used instead.

## Changes

| File | Change |
|------|--------|
| `backend/internal/service/openai_gateway_service.go` | `codexCLIUserAgent`: `codex_cli_rs/0.104.0` → `codex_cli_rs/0.125.0`; `codexCLIVersion`: `0.104.0` → `0.125.0` |
| `backend/internal/service/account_usage_service.go` | `openAICodexProbeVersion`: `0.104.0` → `0.125.0` |
| `backend/internal/handler/openai_gateway_compact_log_test.go` | Update test UA strings |
| `backend/internal/service/openai_oauth_passthrough_test.go` | Update test UA string |

## Related Issues

Fixes #1933, #1887, #1865
Related: #1609, #1298, #849

## Test plan

- [x] Verify `go build ./...` passes
- [x] Verify `go test ./backend/internal/service/... ./backend/internal/handler/...` passes
- [ ] Confirm gpt-5.5 compact requests no longer return 502 in staging