### PR TITLE
feat(claude): expose Claude Design (seven_day_omelette) usage window

### DIFF
--- a/backend/internal/repository/claude_usage_service_test.go
+++ b/backend/internal/repository/claude_usage_service_test.go
@@ -41,7 +41,8 @@ func (s *ClaudeUsageServiceSuite) TestFetchUsage_Success() {
 		_, _ = io.WriteString(w, `{
   "five_hour": {"utilization": 12.5, "resets_at": "2025-01-01T00:00:00Z"},
   "seven_day": {"utilization": 34.0, "resets_at": "2025-01-08T00:00:00Z"},
-  "seven_day_sonnet": {"utilization": 56.0, "resets_at": "2025-01-08T00:00:00Z"}
+  "seven_day_sonnet": {"utilization": 56.0, "resets_at": "2025-01-08T00:00:00Z"},
+  "seven_day_omelette": {"utilization": 78.0, "resets_at": "2025-01-08T00:00:00Z"}
 }`)
 	}))
 
@@ -55,6 +56,7 @@ func (s *ClaudeUsageServiceSuite) TestFetchUsage_Success() {
 	require.Equal(s.T(), 12.5, resp.FiveHour.Utilization, "FiveHour utilization mismatch")
 	require.Equal(s.T(), 34.0, resp.SevenDay.Utilization, "SevenDay utilization mismatch")
 	require.Equal(s.T(), 56.0, resp.SevenDaySonnet.Utilization, "SevenDaySonnet utilization mismatch")
+	require.Equal(s.T(), 78.0, resp.SevenDayOmelette.Utilization, "SevenDayOmelette utilization mismatch")
 
 	// Assertions on captured request data
 	require.Equal(s.T(), "Bearer at", captured.authorization, "Authorization header mismatch")

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -183,6 +183,7 @@ type UsageInfo struct {
 	FiveHour           *UsageProgress `json:"five_hour"`                      // 5小时窗口
 	SevenDay           *UsageProgress `json:"seven_day,omitempty"`            // 7天窗口
 	SevenDaySonnet     *UsageProgress `json:"seven_day_sonnet,omitempty"`     // 7天Sonnet窗口
+	SevenDayOmelette   *UsageProgress `json:"seven_day_omelette,omitempty"`   // 7天 Claude Design 窗口
 	GeminiSharedDaily  *UsageProgress `json:"gemini_shared_daily,omitempty"`  // Gemini shared pool RPD (Google One / Code Assist)
 	GeminiProDaily     *UsageProgress `json:"gemini_pro_daily,omitempty"`     // Gemini Pro 日配额
 	GeminiFlashDaily   *UsageProgress `json:"gemini_flash_daily,omitempty"`   // Gemini Flash 日配额
@@ -238,6 +239,10 @@ type ClaudeUsageResponse struct {
 		Utilization float64 `json:"utilization"`
 		ResetsAt    string  `json:"resets_at"`
 	} `json:"seven_day_sonnet"`
+	SevenDayOmelette struct {
+		Utilization float64 `json:"utilization"`
+		ResetsAt    string  `json:"resets_at"`
+	} `json:"seven_day_omelette"`
 }
 
 // ClaudeUsageFetchOptions 包含获取 Claude 用量数据所需的所有选项
@@ -918,8 +923,8 @@ func enrichUsageWithAccountError(info *UsageInfo, account *Account) {
 // 使用独立缓存（1 分钟），与 API 缓存分离
 func (s *AccountUsageService) addWindowStats(ctx context.Context, account *Account, usage *UsageInfo) {
 	// 修复：即使 FiveHour 为 nil，也要尝试获取统计数据
-	// 因为 SevenDay/SevenDaySonnet 可能需要
-	if usage.FiveHour == nil && usage.SevenDay == nil && usage.SevenDaySonnet == nil {
+	// 因为 SevenDay/SevenDaySonnet/SevenDayOmelette 可能需要
+	if usage.FiveHour == nil && usage.SevenDay == nil && usage.SevenDaySonnet == nil && usage.SevenDayOmelette == nil {
 		return
 	}
 
@@ -1244,6 +1249,22 @@ func (s *AccountUsageService) buildUsageInfo(resp *ClaudeUsageResponse, updatedA
 			log.Printf("Failed to parse SevenDaySonnet.ResetsAt: %s, error: %v", resp.SevenDaySonnet.ResetsAt, err)
 			info.SevenDaySonnet = &UsageProgress{
 				Utilization: resp.SevenDaySonnet.Utilization,
+			}
+		}
+	}
+
+	// 7天 Claude Design 窗口（Anthropic 内部代号 omelette）
+	if resp.SevenDayOmelette.ResetsAt != "" {
+		if omeletteReset, err := parseTime(resp.SevenDayOmelette.ResetsAt); err == nil {
+			info.SevenDayOmelette = &UsageProgress{
+				Utilization:      resp.SevenDayOmelette.Utilization,
+				ResetsAt:         &omeletteReset,
+				RemainingSeconds: int(time.Until(omeletteReset).Seconds()),
+			}
+		} else {
+			log.Printf("Failed to parse SevenDayOmelette.ResetsAt: %s, error: %v", resp.SevenDayOmelette.ResetsAt, err)
+			info.SevenDayOmelette = &UsageProgress{
+				Utilization: resp.SevenDayOmelette.Utilization,
 			}
 		}
 	}

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -68,6 +68,15 @@
           color="purple"
         />
 
+        <!-- 7d Claude Design Window (OAuth only) -->
+        <UsageProgressBar
+          v-if="usageInfo.seven_day_omelette"
+          label="7d D"
+          :utilization="usageInfo.seven_day_omelette.utilization"
+          :resets-at="usageInfo.seven_day_omelette.resets_at"
+          color="amber"
+        />
+
         <!-- Passive sampling label + active query button -->
         <div class="flex items-center gap-1.5 mt-0.5">
           <span

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -886,6 +886,7 @@ export interface AccountUsageInfo {
   five_hour: UsageProgress | null
   seven_day: UsageProgress | null
   seven_day_sonnet: UsageProgress | null
+  seven_day_omelette: UsageProgress | null
   gemini_shared_daily?: UsageProgress | null
   gemini_pro_daily?: UsageProgress | null
   gemini_flash_daily?: UsageProgress | null


### PR DESCRIPTION
## Summary

Anthropic's `/api/oauth/usage` endpoint now returns a `seven_day_omelette` window for Max plans, tracking the **Claude Design** (Imagine with Claude) feature quota separately from the general 7-day window. This PR plumbs that field through to the admin account usage card, mirroring the existing `seven_day_sonnet` (`7d S`) treatment.

Visible on https://claude.ai/settings/usage as the "Claude Design" weekly limit; for accounts that have used the feature the bar can sit at significantly different utilization than the general 7d window.

## Changes

* **Backend**
  * `ClaudeUsageResponse` / `UsageInfo`: add `seven_day_omelette` field
  * `buildUsageInfo`: parse `resets_at` and populate `SevenDayOmelette`
  * `addWindowStats` nil-guard: also pass through when only omelette is present
  * Test fixture in `claude_usage_service_test.go` updated with the new field + assertion
* **Frontend**
  * `AccountUsageInfo` TS type gains `seven_day_omelette`
  * `AccountUsageCell.vue` renders an additional progress bar labelled `7d D` (amber), mirroring the `7d S` bar pattern

## Test plan

- [x] Backend unit test (`TestFetchUsage_OK`) covers the new field
- [x] Verified end-to-end against a real Max account: `claude.ai/settings/usage` showed `Claude Design 81% used`, and the admin card now reports the same percentage on the new bar
- [x] Accounts without the field (no Max / no Claude Design usage) still render unchanged — the bar is `v-if`-gated

## Notes

`omelette` is the upstream JSON key Anthropic uses for this window; keeping the Go field name in sync (`SevenDayOmelette`) avoids special-casing the JSON tag.