### PR TITLE
fix(apicompat): ensure thinking/text content blocks always include their field in JSON

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -308,6 +308,13 @@ func TestStreamingTextOnly(t *testing.T) {
 	require.Len(t, events, 2) // content_block_start + content_block_delta
 	assert.Equal(t, "content_block_start", events[0].Type)
 	assert.Equal(t, "text", events[0].ContentBlock.Type)
+
+	// text block 序列化后必须包含 "text" 字段（即使为空字符串）
+	blockJSON, err := json.Marshal(events[0].ContentBlock)
+	require.NoError(t, err)
+	assert.Contains(t, string(blockJSON), `"text":""`)
+	assert.NotContains(t, string(blockJSON), `"thinking"`)
+
 	assert.Equal(t, "content_block_delta", events[1].Type)
 	assert.Equal(t, "text_delta", events[1].Delta.Type)
 	assert.Equal(t, "Hello", events[1].Delta.Text)
@@ -410,6 +417,13 @@ func TestStreamingReasoning(t *testing.T) {
 	require.Len(t, events, 1)
 	assert.Equal(t, "content_block_start", events[0].Type)
 	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
+
+	// content_block_start 序列化后必须包含 "thinking" 字段（即使为空字符串），
+	// 否则下游 schema 校验会报 "expected string, received undefined"
+	blockJSON, err := json.Marshal(events[0].ContentBlock)
+	require.NoError(t, err)
+	assert.Contains(t, string(blockJSON), `"thinking":""`)
+	assert.NotContains(t, string(blockJSON), `"text"`)
 
 	// reasoning text delta
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -73,6 +73,35 @@ type AnthropicContentBlock struct {
 	IsError   bool            `json:"is_error,omitempty"`
 }
 
+// MarshalJSON ensures thinking/text content blocks always include their
+// corresponding field, even when empty (omitempty would drop it, causing
+// downstream schema validation to fail with "expected string, received undefined").
+func (b AnthropicContentBlock) MarshalJSON() ([]byte, error) {
+	type Alias AnthropicContentBlock
+	data, err := json.Marshal(Alias(b))
+	if err != nil {
+		return nil, err
+	}
+
+	needsPatch := (b.Type == "thinking" && b.Thinking == "") ||
+		(b.Type == "text" && b.Text == "")
+	if !needsPatch {
+		return data, nil
+	}
+
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	switch b.Type {
+	case "thinking":
+		m["thinking"] = json.RawMessage(`""`)
+	case "text":
+		m["text"] = json.RawMessage(`""`)
+	}
+	return json.Marshal(m)
+}
+
 // AnthropicImageSource describes the source data for an image content block.
 type AnthropicImageSource struct {
 	Type      string `json:"type"` // "base64"


### PR DESCRIPTION
## Summary

Fixes a bug where `content_block_start` events for `thinking` type blocks are serialized without the `thinking` field, causing downstream schema validation errors:

```
Type validation failed: Value: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}.
Error message: [{"expected":"string","code":"invalid_type","path":["content_block","thinking"],"message":"Invalid input: expected string, received undefined"}]
```

## Root Cause

`AnthropicContentBlock.Thinking` (and `.Text`) use `json:",omitempty"` tags. When a `thinking` content block is created with `Thinking: ""` (as in streaming `content_block_start`), Go's `json.Marshal` omits the field entirely. Clients validating against the Anthropic API schema expect a string value and fail with "expected string, received undefined".

## Fix

Add a custom `MarshalJSON` on `AnthropicContentBlock` that ensures:
- `type=thinking` blocks always include `"thinking"` (even if empty string)
- `type=text` blocks always include `"text"` (even if empty string)
- All other block types are unaffected

## Testing

- Added serialization assertions to existing `TestStreamingReasoning` and `TestStreamingTextOnly` tests
- All existing tests pass with no regressions