### PR TITLE
fix(affiliate): cast rebate audit SQL params

### DIFF
--- a/backend/internal/service/payment_fulfillment.go
+++ b/backend/internal/service/payment_fulfillment.go
@@ -444,11 +444,11 @@ func (s *PaymentService) tryClaimAffiliateRebateAudit(ctx context.Context, clien
 	})
 	rows, err := client.QueryContext(ctx, `
 INSERT INTO payment_audit_logs (order_id, action, detail, operator, created_at)
-SELECT $1, 'AFFILIATE_REBATE_APPLIED', $2, 'system', NOW()
+SELECT $1::varchar(64), 'AFFILIATE_REBATE_APPLIED', $2::text, 'system', NOW()
 WHERE NOT EXISTS (
 	SELECT 1
 	FROM payment_audit_logs
-	WHERE order_id = $1
+	WHERE order_id = $1::varchar(64)
 	  AND action IN ('AFFILIATE_REBATE_APPLIED', 'AFFILIATE_REBATE_SKIPPED')
 )
 ON CONFLICT (order_id, action) DO NOTHING


### PR DESCRIPTION
## Summary

Fix affiliate rebate processing on PostgreSQL 18 by explicitly casting SQL parameters in the rebate audit claim query.

## Problem

When an invited user completes a balance recharge order, affiliate rebate processing can fail with PostgreSQL 18:

```text
pq: inconsistent types deduced for parameter $1
```

The order is completed, but the inviter does not receive affiliate quota because the rebate audit claim query fails before accrual.

## Root Cause

`payment_audit_logs.order_id` is `varchar(64)`, but `tryClaimAffiliateRebateAudit` reused `$1` in both the insert select-list and the `WHERE order_id = $1` predicate without an explicit type:

```sql
SELECT $1, 'AFFILIATE_REBATE_APPLIED', $2, 'system', NOW()
...
WHERE order_id = $1
```

PostgreSQL 18 can infer conflicting parameter types (`text` vs `character varying`).

## Fix

Explicitly cast the parameters to the target column types:

- `$1::varchar(64)` for `order_id`
- `$2::text` for `detail`

The existing idempotency behavior remains unchanged.

## Validation

Verified against PostgreSQL 18.3 that the updated statement can be prepared successfully:

```sql
PREPARE aff_claim_cast AS
INSERT INTO payment_audit_logs (order_id, action, detail, operator, created_at)
SELECT $1::varchar(64), 'AFFILIATE_REBATE_APPLIED', $2::text, 'system', NOW()
WHERE NOT EXISTS (
  SELECT 1 FROM payment_audit_logs
  WHERE order_id = $1::varchar(64)
    AND action IN ('AFFILIATE_REBATE_APPLIED', 'AFFILIATE_REBATE_SKIPPED')
)
ON CONFLICT (order_id, action) DO NOTHING
RETURNING id;
```

Go tests were not run in this environment because the local machine does not have the Go toolchain installed.
