### PR TITLE
feat(payment): show exact amount warning on pay page

### DIFF
--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -74,6 +74,13 @@
       <div class="card p-6">
         <div class="flex flex-col items-center space-y-4">
           <p class="text-lg font-semibold text-gray-900 dark:text-white">{{ scanTitle }}</p>
+          <div v-if="displayPayAmount" class="rounded-2xl bg-primary-50 px-5 py-3 text-center dark:bg-primary-900/20">
+            <p class="text-xs font-medium uppercase tracking-wide text-primary-500 dark:text-primary-300">{{ t('payment.qr.amountDue') }}</p>
+            <p class="mt-1 text-3xl font-bold tabular-nums text-primary-600 dark:text-primary-300">¥{{ displayPayAmount }}</p>
+            <p class="mt-3 rounded-lg bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+              {{ t('payment.qr.exactAmountWarning') }}
+            </p>
+          </div>
           <div :class="['relative rounded-lg border-2 p-4', qrBorderClass]">
             <canvas ref="qrCanvas" class="mx-auto"></canvas>
             <!-- Brand logo overlay -->
@@ -104,6 +111,13 @@
       <div class="card p-6">
         <div class="flex flex-col items-center space-y-4 py-4">
           <div class="h-10 w-10 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
+          <div v-if="displayPayAmount" class="rounded-2xl bg-primary-50 px-5 py-3 text-center dark:bg-primary-900/20">
+            <p class="text-xs font-medium uppercase tracking-wide text-primary-500 dark:text-primary-300">{{ t('payment.qr.amountDue') }}</p>
+            <p class="mt-1 text-3xl font-bold tabular-nums text-primary-600 dark:text-primary-300">¥{{ displayPayAmount }}</p>
+            <p class="mt-3 rounded-lg bg-amber-100 px-3 py-2 text-sm font-semibold text-amber-800 dark:bg-amber-500/15 dark:text-amber-200">
+              {{ t('payment.qr.exactAmountWarning') }}
+            </p>
+          </div>
           <p class="text-sm text-gray-500 dark:text-gray-400">{{ t('payment.qr.payInNewWindowHint') }}</p>
           <button v-if="payUrl" class="btn btn-secondary text-sm" @click="reopenPopup">
             {{ t('payment.qr.openPayWindow') }}
@@ -142,6 +156,7 @@ const props = defineProps<{
   paymentType: string
   payUrl?: string
   orderType?: string
+  payAmount?: number
 }>()
 
 type PaymentOutcome = 'success' | 'cancelled' | 'expired'
@@ -166,6 +181,10 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const displayPayAmount = computed(() => {
+  const amount = Number(props.payAmount || 0)
+  return amount > 0 ? amount.toFixed(2) : ''
+})
 
 const qrBorderClass = computed(() => {
   if (isAlipay.value) return 'border-[#00AEEF] bg-blue-50 dark:border-[#00AEEF]/70 dark:bg-blue-950/20'

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5992,6 +5992,8 @@ export default {
       payInNewWindowHint: 'The payment page has opened in a new window. Please complete the payment there and return to this page.',
       openPayWindow: 'Reopen Payment Page',
       expiresIn: 'Expires in',
+      amountDue: 'Amount Due',
+      exactAmountWarning: 'Pay the exact amount or it cannot be credited automatically',
       expired: 'Order Expired',
       expiredDesc: 'This order has expired. Please create a new one.',
       cancelled: 'Order Cancelled',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6177,6 +6177,8 @@ export default {
       payInNewWindowHint: '支付页面已在新窗口打开，请在新窗口中完成支付后返回此页面',
       openPayWindow: '重新打开支付页面',
       expiresIn: '剩余支付时间',
+      amountDue: '应付金额',
+      exactAmountWarning: '务必支付准确金额，否则无法自动到账',
       expired: '订单已过期',
       expiredDesc: '订单已超时，请重新创建订单',
       cancelled: '订单已取消',

--- a/frontend/src/views/user/PaymentView.vue
+++ b/frontend/src/views/user/PaymentView.vue
@@ -21,6 +21,7 @@
             :payment-type="paymentState.paymentType"
             :pay-url="paymentState.payUrl"
             :order-type="paymentState.orderType"
+            :pay-amount="paymentState.payAmount"
             @done="onPaymentDone"
             @success="onPaymentSuccess"
             @settled="onPaymentSettled"


### PR DESCRIPTION
## Summary

Show the actual payable amount on the payment waiting page and warn users to pay the exact amount.

This helps avoid cases where a user pays a different amount than the generated order amount, causing automatic crediting to fail or require manual handling.

## Changes

- Pass `paymentState.payAmount` into `PaymentStatusPanel`.
- Add `payAmount` support in `PaymentStatusPanel`.
- Display an `Amount Due` block in both active payment waiting modes:
  - QR code scan mode
  - popup/redirect waiting mode
- Add a stronger warning:
  - zh: `务必支付准确金额，否则无法自动到账`
  - en: `Pay the exact amount or it cannot be credited automatically`

## Validation

Not run locally because this environment does not have frontend dependencies installed in the clean PR worktree.

The change is limited to Vue template/props/i18n text and preserves the existing payment flow.
