### PR TITLE
Fix affiliate rebate accrual

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -74,7 +74,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	authService := service.NewAuthService(client, userRepository, redeemCodeRepository, refreshTokenCache, configConfig, settingService, emailService, turnstileService, emailQueueService, promoService, subscriptionService, affiliateService)
 	userService := service.NewUserService(userRepository, settingRepository, apiKeyAuthCacheInvalidator, billingCache)
 	redeemCache := repository.NewRedeemCache(redisClient)
-	redeemService := service.NewRedeemService(redeemCodeRepository, userRepository, subscriptionService, redeemCache, billingCacheService, client, apiKeyAuthCacheInvalidator)
+	redeemService := service.NewRedeemService(redeemCodeRepository, userRepository, subscriptionService, redeemCache, billingCacheService, client, apiKeyAuthCacheInvalidator, affiliateService)
 	secretEncryptor, err := repository.NewAESEncryptor(configConfig)
 	if err != nil {
 		return nil, err

--- a/backend/internal/handler/admin/redeem_handler.go
+++ b/backend/internal/handler/admin/redeem_handler.go
@@ -185,7 +185,7 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 			return nil, createErr
 		}
 
-		redeemed, redeemErr := h.redeemService.Redeem(ctx, req.UserID, req.Code)
+		redeemed, redeemErr := h.redeemService.RedeemRecharge(ctx, req.UserID, req.Code)
 		if redeemErr != nil {
 			return nil, redeemErr
 		}
@@ -200,7 +200,7 @@ func (h *RedeemHandler) resolveCreateAndRedeemExisting(ctx context.Context, exis
 
 	// If previous run created the code but crashed before redeem, redeem it now.
 	if existing.CanUse() {
-		redeemed, err := h.redeemService.Redeem(ctx, userID, existing.Code)
+		redeemed, err := h.redeemService.RedeemRecharge(ctx, userID, existing.Code)
 		if err == nil {
 			return gin.H{"redeem_code": dto.RedeemCodeFromServiceAdmin(redeemed)}, nil
 		}

--- a/backend/internal/handler/auth_linuxdo_oauth.go
+++ b/backend/internal/handler/auth_linuxdo_oauth.go
@@ -435,6 +435,7 @@ func (h *AuthHandler) createLinuxDoOAuthChoicePendingSession(
 
 type completeLinuxDoOAuthRequest struct {
 	InvitationCode   string `json:"invitation_code" binding:"required"`
+	AffCode          string `json:"aff_code,omitempty"`
 	AdoptDisplayName *bool  `json:"adopt_display_name,omitempty"`
 	AdoptAvatar      *bool  `json:"adopt_avatar,omitempty"`
 }
@@ -518,7 +519,7 @@ func (h *AuthHandler) CompleteLinuxDoOAuthRegistration(c *gin.Context) {
 		response.ErrorFrom(c, err)
 		return
 	}
-	tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPair(c.Request.Context(), email, username, req.InvitationCode)
+	tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPair(c.Request.Context(), email, username, req.InvitationCode, req.AffCode)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return

--- a/backend/internal/handler/auth_oauth_pending_flow.go
+++ b/backend/internal/handler/auth_oauth_pending_flow.go
@@ -67,6 +67,7 @@ type createPendingOAuthAccountRequest struct {
 	VerifyCode       string `json:"verify_code,omitempty"`
 	Password         string `json:"password" binding:"required,min=6"`
 	InvitationCode   string `json:"invitation_code,omitempty"`
+	AffCode          string `json:"aff_code,omitempty"`
 	AdoptDisplayName *bool  `json:"adopt_display_name,omitempty"`
 	AdoptAvatar      *bool  `json:"adopt_avatar,omitempty"`
 }
@@ -1678,6 +1679,7 @@ func (h *AuthHandler) createPendingOAuthAccount(c *gin.Context, provider string)
 		strings.TrimSpace(req.VerifyCode),
 		strings.TrimSpace(req.InvitationCode),
 		strings.TrimSpace(session.ProviderType),
+		strings.TrimSpace(req.AffCode),
 	)
 	if err != nil {
 		if errors.Is(err, service.ErrEmailExists) {
@@ -1751,6 +1753,7 @@ func (h *AuthHandler) createPendingOAuthAccount(c *gin.Context, provider string)
 		user,
 		strings.TrimSpace(req.InvitationCode),
 		strings.TrimSpace(session.ProviderType),
+		strings.TrimSpace(req.AffCode),
 	); err != nil {
 		_ = tx.Rollback()
 		if rollbackCreatedUser(err) {

--- a/backend/internal/handler/auth_oidc_oauth.go
+++ b/backend/internal/handler/auth_oidc_oauth.go
@@ -582,6 +582,7 @@ func (h *AuthHandler) createOIDCOAuthChoicePendingSession(
 
 type completeOIDCOAuthRequest struct {
 	InvitationCode   string `json:"invitation_code" binding:"required"`
+	AffCode          string `json:"aff_code,omitempty"`
 	AdoptDisplayName *bool  `json:"adopt_display_name,omitempty"`
 	AdoptAvatar      *bool  `json:"adopt_avatar,omitempty"`
 }
@@ -665,7 +666,7 @@ func (h *AuthHandler) CompleteOIDCOAuthRegistration(c *gin.Context) {
 		response.ErrorFrom(c, err)
 		return
 	}
-	tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPair(c.Request.Context(), email, username, req.InvitationCode)
+	tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPair(c.Request.Context(), email, username, req.InvitationCode, req.AffCode)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return

--- a/backend/internal/handler/auth_wechat_oauth.go
+++ b/backend/internal/handler/auth_wechat_oauth.go
@@ -481,6 +481,7 @@ func (h *AuthHandler) wechatPaymentResumeService() *service.PaymentResumeService
 
 type completeWeChatOAuthRequest struct {
 	InvitationCode   string `json:"invitation_code" binding:"required"`
+	AffCode          string `json:"aff_code,omitempty"`
 	AdoptDisplayName *bool  `json:"adopt_display_name,omitempty"`
 	AdoptAvatar      *bool  `json:"adopt_avatar,omitempty"`
 }
@@ -547,7 +548,7 @@ func (h *AuthHandler) CompleteWeChatOAuthRegistration(c *gin.Context) {
 		return
 	}
 
-	tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPair(c.Request.Context(), email, username, req.InvitationCode)
+	tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPair(c.Request.Context(), email, username, req.InvitationCode, req.AffCode)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1092,7 +1092,7 @@ func newContractDeps(t *testing.T) *contractDeps {
 	subscriptionService := service.NewSubscriptionService(groupRepo, userSubRepo, nil, nil, cfg)
 	subscriptionHandler := handler.NewSubscriptionHandler(subscriptionService)
 
-	redeemService := service.NewRedeemService(redeemRepo, userRepo, subscriptionService, nil, nil, nil, nil)
+	redeemService := service.NewRedeemService(redeemRepo, userRepo, subscriptionService, nil, nil, nil, nil, nil)
 	redeemHandler := handler.NewRedeemHandler(redeemService)
 
 	settingRepo := newStubSettingRepo()

--- a/backend/internal/service/auth_oauth_email_flow.go
+++ b/backend/internal/service/auth_oauth_email_flow.go
@@ -104,6 +104,7 @@ func (s *AuthService) RegisterOAuthEmailAccount(
 	verifyCode string,
 	invitationCode string,
 	signupSource string,
+	affiliateCode ...string,
 ) (*TokenPair, *User, error) {
 	if s == nil {
 		return nil, nil, ErrServiceUnavailable
@@ -175,6 +176,7 @@ func (s *AuthService) FinalizeOAuthEmailAccount(
 	user *User,
 	invitationCode string,
 	signupSource string,
+	affiliateCode ...string,
 ) error {
 	if s == nil || user == nil || user.ID <= 0 {
 		return ErrServiceUnavailable
@@ -192,6 +194,7 @@ func (s *AuthService) FinalizeOAuthEmailAccount(
 	}
 
 	s.updateOAuthSignupSource(ctx, user.ID, signupSource)
+	s.bootstrapAffiliateForNewUser(ctx, user.ID, firstOptionalString(affiliateCode))
 	grantPlan := s.resolveSignupGrantPlan(ctx, signupSource)
 	s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 	return nil

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -226,17 +226,7 @@ func (s *AuthService) RegisterWithVerification(ctx context.Context, email, passw
 	}
 	s.postAuthUserBootstrap(ctx, user, "email", true)
 	s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
-	if s.affiliateService != nil {
-		if _, err := s.affiliateService.EnsureUserAffiliate(ctx, user.ID); err != nil {
-			logger.LegacyPrintf("service.auth", "[Auth] Failed to initialize affiliate profile for user %d: %v", user.ID, err)
-		}
-		if code := strings.TrimSpace(affiliateCode); code != "" {
-			if err := s.affiliateService.BindInviterByCode(ctx, user.ID, code); err != nil {
-				// 邀请返利码绑定失败不影响注册，只记录日志
-				logger.LegacyPrintf("service.auth", "[Auth] Failed to bind affiliate inviter for user %d: %v", user.ID, err)
-			}
-		}
-	}
+	s.bootstrapAffiliateForNewUser(ctx, user.ID, affiliateCode)
 
 	// 标记邀请码为已使用（如果使用了邀请码）
 	if invitationRedeemCode != nil {
@@ -563,7 +553,7 @@ func (s *AuthService) LoginOrRegisterOAuth(ctx context.Context, email, username 
 // LoginOrRegisterOAuthWithTokenPair 用于第三方 OAuth/SSO 登录，返回完整的 TokenPair。
 // 与 LoginOrRegisterOAuth 功能相同，但返回 TokenPair 而非单个 token。
 // invitationCode 仅在邀请码注册模式下新用户注册时使用；已有账号登录时忽略。
-func (s *AuthService) LoginOrRegisterOAuthWithTokenPair(ctx context.Context, email, username, invitationCode string) (*TokenPair, *User, error) {
+func (s *AuthService) LoginOrRegisterOAuthWithTokenPair(ctx context.Context, email, username, invitationCode string, affiliateCode ...string) (*TokenPair, *User, error) {
 	// 检查 refreshTokenCache 是否可用
 	if s.refreshTokenCache == nil {
 		return nil, nil, errors.New("refresh token cache not configured")
@@ -664,6 +654,7 @@ func (s *AuthService) LoginOrRegisterOAuthWithTokenPair(ctx context.Context, ema
 						return nil, nil, ErrServiceUnavailable
 					}
 					user = newUser
+					s.bootstrapAffiliateForNewUser(ctx, user.ID, firstOptionalString(affiliateCode))
 					s.postAuthUserBootstrap(ctx, user, signupSource, false)
 					s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 				}
@@ -681,6 +672,7 @@ func (s *AuthService) LoginOrRegisterOAuthWithTokenPair(ctx context.Context, ema
 					}
 				} else {
 					user = newUser
+					s.bootstrapAffiliateForNewUser(ctx, user.ID, firstOptionalString(affiliateCode))
 					s.postAuthUserBootstrap(ctx, user, signupSource, false)
 					s.assignSubscriptions(ctx, user.ID, grantPlan.Subscriptions, "auto assigned by signup defaults")
 					if invitationRedeemCode != nil {
@@ -725,6 +717,28 @@ func (s *AuthService) assignSubscriptions(ctx context.Context, userID int64, ite
 			Notes:        notes,
 		}); err != nil {
 			logger.LegacyPrintf("service.auth", "[Auth] Failed to assign default subscription: user_id=%d group_id=%d err=%v", userID, item.GroupID, err)
+		}
+	}
+}
+
+func firstOptionalString(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+func (s *AuthService) bootstrapAffiliateForNewUser(ctx context.Context, userID int64, affiliateCode string) {
+	if s == nil || s.affiliateService == nil || userID <= 0 {
+		return
+	}
+	if _, err := s.affiliateService.EnsureUserAffiliate(ctx, userID); err != nil {
+		logger.LegacyPrintf("service.auth", "[Auth] Failed to initialize affiliate profile for user %d: %v", userID, err)
+	}
+	if code := strings.TrimSpace(affiliateCode); code != "" {
+		if err := s.affiliateService.BindInviterByCode(ctx, userID, code); err != nil {
+			// 邀请返利码绑定失败不影响注册，只记录日志
+			logger.LegacyPrintf("service.auth", "[Auth] Failed to bind affiliate inviter for user %d: %v", userID, err)
 		}
 	}
 }

--- a/backend/internal/service/auth_service_register_test.go
+++ b/backend/internal/service/auth_service_register_test.go
@@ -216,6 +216,86 @@ func newAuthService(repo *userRepoStub, settings map[string]string, emailCache E
 	)
 }
 
+type affiliateRepoStub struct {
+	summaries    map[int64]*AffiliateSummary
+	codeSummary  *AffiliateSummary
+	bindCalls    [][2]int64
+	ensureCalls  []int64
+	getCodeCalls []string
+	accrueCalls  []struct {
+		inviterID     int64
+		inviteeUserID int64
+		amount        float64
+	}
+	accrueErr error
+}
+
+func (s *affiliateRepoStub) EnsureUserAffiliate(_ context.Context, userID int64) (*AffiliateSummary, error) {
+	s.ensureCalls = append(s.ensureCalls, userID)
+	if s.summaries == nil {
+		s.summaries = make(map[int64]*AffiliateSummary)
+	}
+	if summary, ok := s.summaries[userID]; ok {
+		return summary, nil
+	}
+	summary := &AffiliateSummary{UserID: userID, AffCode: "AUTOAFF"}
+	s.summaries[userID] = summary
+	return summary, nil
+}
+
+func (s *affiliateRepoStub) GetAffiliateByCode(_ context.Context, code string) (*AffiliateSummary, error) {
+	s.getCodeCalls = append(s.getCodeCalls, code)
+	if s.codeSummary == nil {
+		return nil, ErrAffiliateProfileNotFound
+	}
+	return s.codeSummary, nil
+}
+
+func (s *affiliateRepoStub) BindInviter(_ context.Context, userID, inviterID int64) (bool, error) {
+	s.bindCalls = append(s.bindCalls, [2]int64{userID, inviterID})
+	return true, nil
+}
+
+func (s *affiliateRepoStub) AccrueQuota(_ context.Context, inviterID, inviteeUserID int64, amount float64) (bool, error) {
+	s.accrueCalls = append(s.accrueCalls, struct {
+		inviterID     int64
+		inviteeUserID int64
+		amount        float64
+	}{inviterID: inviterID, inviteeUserID: inviteeUserID, amount: amount})
+	if s.accrueErr != nil {
+		return false, s.accrueErr
+	}
+	return true, nil
+}
+
+func (s *affiliateRepoStub) TransferQuotaToBalance(context.Context, int64) (float64, float64, error) {
+	panic("unexpected TransferQuotaToBalance call")
+}
+
+func (s *affiliateRepoStub) ListInvitees(context.Context, int64, int) ([]AffiliateInvitee, error) {
+	panic("unexpected ListInvitees call")
+}
+
+func (s *affiliateRepoStub) UpdateUserAffCode(context.Context, int64, string) error {
+	panic("unexpected UpdateUserAffCode call")
+}
+
+func (s *affiliateRepoStub) ResetUserAffCode(context.Context, int64) (string, error) {
+	panic("unexpected ResetUserAffCode call")
+}
+
+func (s *affiliateRepoStub) SetUserRebateRate(context.Context, int64, *float64) error {
+	panic("unexpected SetUserRebateRate call")
+}
+
+func (s *affiliateRepoStub) BatchSetUserRebateRate(context.Context, []int64, *float64) error {
+	panic("unexpected BatchSetUserRebateRate call")
+}
+
+func (s *affiliateRepoStub) ListUsersWithCustomSettings(context.Context, AffiliateAdminFilter) ([]AffiliateAdminEntry, int64, error) {
+	panic("unexpected ListUsersWithCustomSettings call")
+}
+
 func TestAuthService_Register_Disabled(t *testing.T) {
 	repo := &userRepoStub{}
 	service := newAuthService(repo, map[string]string{
@@ -633,6 +713,26 @@ func TestAuthService_LoginOrRegisterOAuthWithTokenPair_UsesLinuxDoAuthSourceDefa
 	require.Len(t, assigner.calls, 1)
 	require.Equal(t, int64(22), assigner.calls[0].GroupID)
 	require.Equal(t, 14, assigner.calls[0].ValidityDays)
+}
+
+func TestAuthService_LoginOrRegisterOAuthWithTokenPair_BindsAffiliateCodeOnSignup(t *testing.T) {
+	repo := &userRepoStub{nextID: 62}
+	affiliateRepo := &affiliateRepoStub{
+		codeSummary: &AffiliateSummary{UserID: 41, AffCode: "INVITER42"},
+	}
+	service := newAuthService(repo, map[string]string{
+		SettingKeyRegistrationEnabled: "true",
+		SettingKeyAffiliateEnabled:    "true",
+	}, nil)
+	service.refreshTokenCache = &refreshTokenCacheStub{}
+	service.affiliateService = NewAffiliateService(affiliateRepo, service.settingService, nil, nil)
+
+	tokenPair, user, err := service.LoginOrRegisterOAuthWithTokenPair(context.Background(), "linuxdo-aff@linuxdo-connect.invalid", "linuxdo_aff", "", "INVITER42")
+	require.NoError(t, err)
+	require.NotNil(t, tokenPair)
+	require.NotNil(t, user)
+	require.Equal(t, int64(62), user.ID)
+	require.Equal(t, [][2]int64{{62, 41}}, affiliateRepo.bindCalls)
 }
 
 func TestAuthService_LoginOrRegisterOAuthWithTokenPair_ExistingUserDoesNotGrantAgain(t *testing.T) {

--- a/backend/internal/service/payment_fulfillment.go
+++ b/backend/internal/service/payment_fulfillment.go
@@ -444,14 +444,14 @@ func (s *PaymentService) tryClaimAffiliateRebateAudit(ctx context.Context, clien
 	})
 	rows, err := client.QueryContext(ctx, `
 INSERT INTO payment_audit_logs (order_id, action, detail, operator, created_at)
-SELECT $1, 'AFFILIATE_REBATE_APPLIED', $2, 'system', NOW()
+SELECT CAST($1 AS TEXT), 'AFFILIATE_REBATE_APPLIED', $2, 'system', CURRENT_TIMESTAMP
 WHERE NOT EXISTS (
 	SELECT 1
 	FROM payment_audit_logs
-	WHERE order_id = $1
+	WHERE order_id = CAST($1 AS TEXT)
 	  AND action IN ('AFFILIATE_REBATE_APPLIED', 'AFFILIATE_REBATE_SKIPPED')
 )
-ON CONFLICT (order_id, action) DO NOTHING
+ON CONFLICT DO NOTHING
 RETURNING id`, oid, string(detail))
 	if err != nil {
 		return false, err

--- a/backend/internal/service/payment_fulfillment_test.go
+++ b/backend/internal/service/payment_fulfillment_test.go
@@ -6,11 +6,15 @@ import (
 	"context"
 	"errors"
 	"math"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type paymentFulfillmentTestProvider struct {
@@ -331,6 +335,78 @@ func TestIsValidProviderAmount(t *testing.T) {
 	assert.False(t, isValidProviderAmount(-1))
 	assert.False(t, isValidProviderAmount(math.NaN()))
 	assert.False(t, isValidProviderAmount(math.Inf(1)))
+}
+
+func TestApplyAffiliateRebateForOrderAccruesQuotaWithoutAuditUniqueIndex(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentOrderLifecycleTestClient(t)
+
+	inviter, err := client.User.Create().
+		SetEmail("affiliate-inviter@example.com").
+		SetPasswordHash("hash").
+		SetUsername("affiliate-inviter").
+		Save(ctx)
+	require.NoError(t, err)
+	invitee, err := client.User.Create().
+		SetEmail("affiliate-invitee@example.com").
+		SetPasswordHash("hash").
+		SetUsername("affiliate-invitee").
+		Save(ctx)
+	require.NoError(t, err)
+
+	order, err := client.PaymentOrder.Create().
+		SetUserID(invitee.ID).
+		SetUserEmail(invitee.Email).
+		SetUserName(invitee.Username).
+		SetAmount(100).
+		SetPayAmount(100).
+		SetFeeRate(0).
+		SetRechargeCode("AFFILIATE-REBATE-ORDER").
+		SetOutTradeNo("sub2_affiliate_rebate_order").
+		SetPaymentType(payment.TypeAlipay).
+		SetPaymentTradeNo("affiliate-rebate-trade").
+		SetOrderType(payment.OrderTypeBalance).
+		SetStatus(OrderStatusRecharging).
+		SetPaidAt(time.Now()).
+		SetExpiresAt(time.Now().Add(time.Hour)).
+		SetClientIP("127.0.0.1").
+		SetSrcHost("api.example.com").
+		Save(ctx)
+	require.NoError(t, err)
+
+	inviterID := inviter.ID
+	affiliateRepo := &affiliateRepoStub{
+		summaries: map[int64]*AffiliateSummary{
+			invitee.ID: {UserID: invitee.ID, InviterID: &inviterID},
+			inviter.ID: {UserID: inviter.ID, AffCode: "INVITER"},
+		},
+	}
+	settingSvc := NewSettingService(&settingRepoStub{values: map[string]string{
+		SettingKeyAffiliateEnabled:    "true",
+		SettingKeyAffiliateRebateRate: "20",
+	}}, nil)
+
+	svc := &PaymentService{
+		entClient:        client,
+		affiliateService: NewAffiliateService(affiliateRepo, settingSvc, nil, nil),
+	}
+
+	svc.applyAffiliateRebateForOrder(ctx, order)
+
+	require.Len(t, affiliateRepo.accrueCalls, 1)
+	require.Equal(t, inviter.ID, affiliateRepo.accrueCalls[0].inviterID)
+	require.Equal(t, invitee.ID, affiliateRepo.accrueCalls[0].inviteeUserID)
+	require.InDelta(t, 20.0, affiliateRepo.accrueCalls[0].amount, 1e-9)
+}
+
+func TestAffiliateRebateClaimSQLCastsOrderIDParameterForPostgres(t *testing.T) {
+	src, err := os.ReadFile("payment_fulfillment.go")
+	require.NoError(t, err)
+
+	sql := string(src)
+	require.Contains(t, sql, "SELECT CAST($1 AS TEXT), 'AFFILIATE_REBATE_APPLIED'")
+	require.Contains(t, sql, "WHERE order_id = CAST($1 AS TEXT)")
+	require.False(t, strings.Contains(sql, "WHERE order_id = $1\n"), "Postgres infers conflicting parameter types without an explicit text cast")
 }
 
 func TestValidateProviderNotificationMetadataRejectsAlipaySnapshotMismatch(t *testing.T) {

--- a/backend/internal/service/payment_order_lifecycle_test.go
+++ b/backend/internal/service/payment_order_lifecycle_test.go
@@ -208,6 +208,7 @@ func TestVerifyOrderByOutTradeNoBackfillsTradeNoFromPaidQuery(t *testing.T) {
 		nil,
 		client,
 		nil,
+		nil,
 	)
 	registry := payment.NewRegistry()
 	provider := &paymentOrderLifecycleQueryProvider{
@@ -308,6 +309,7 @@ func TestVerifyOrderByOutTradeNoRetriesZeroAmountPaidQueryOnce(t *testing.T) {
 		nil,
 		client,
 		nil,
+		nil,
 	)
 	registry := payment.NewRegistry()
 	provider := &paymentOrderLifecycleQueryProvider{
@@ -397,6 +399,7 @@ func TestVerifyOrderByOutTradeNoRejectsPaidQueryWithZeroAmount(t *testing.T) {
 		nil,
 		nil,
 		client,
+		nil,
 		nil,
 	)
 	registry := payment.NewRegistry()
@@ -495,6 +498,7 @@ func TestVerifyOrderByOutTradeNoUsesOutTradeNoWhenPaymentTradeNoAlreadyExistsFor
 		nil,
 		nil,
 		client,
+		nil,
 		nil,
 	)
 	registry := payment.NewRegistry()

--- a/backend/internal/service/redeem_service.go
+++ b/backend/internal/service/redeem_service.go
@@ -80,6 +80,7 @@ type RedeemService struct {
 	billingCacheService  *BillingCacheService
 	entClient            *dbent.Client
 	authCacheInvalidator APIKeyAuthCacheInvalidator
+	affiliateService     *AffiliateService
 }
 
 // NewRedeemService 创建兑换码服务实例
@@ -91,6 +92,7 @@ func NewRedeemService(
 	billingCacheService *BillingCacheService,
 	entClient *dbent.Client,
 	authCacheInvalidator APIKeyAuthCacheInvalidator,
+	affiliateService *AffiliateService,
 ) *RedeemService {
 	return &RedeemService{
 		redeemRepo:           redeemRepo,
@@ -100,6 +102,7 @@ func NewRedeemService(
 		billingCacheService:  billingCacheService,
 		entClient:            entClient,
 		authCacheInvalidator: authCacheInvalidator,
+		affiliateService:     affiliateService,
 	}
 }
 
@@ -255,6 +258,17 @@ func (s *RedeemService) releaseRedeemLock(ctx context.Context, code string) {
 
 // Redeem 使用兑换码
 func (s *RedeemService) Redeem(ctx context.Context, userID int64, code string) (*RedeemCode, error) {
+	return s.redeem(ctx, userID, code, false)
+}
+
+// RedeemRecharge redeems a balance code that represents a completed recharge.
+// It is intentionally separate from Redeem: ordinary user-entered redeem codes
+// must not trigger invite rebates.
+func (s *RedeemService) RedeemRecharge(ctx context.Context, userID int64, code string) (*RedeemCode, error) {
+	return s.redeem(ctx, userID, code, true)
+}
+
+func (s *RedeemService) redeem(ctx context.Context, userID int64, code string, applyRechargeRebate bool) (*RedeemCode, error) {
 	// 检查限流
 	if err := s.checkRedeemRateLimit(ctx, userID); err != nil {
 		return nil, err
@@ -322,6 +336,11 @@ func (s *RedeemService) Redeem(ctx context.Context, userID int64, code string) (
 		}
 		if err := s.userRepo.UpdateBalance(txCtx, userID, amount); err != nil {
 			return nil, fmt.Errorf("update user balance: %w", err)
+		}
+		if applyRechargeRebate && amount > 0 && s.affiliateService != nil {
+			if _, err := s.affiliateService.AccrueInviteRebate(txCtx, userID, amount); err != nil {
+				return nil, fmt.Errorf("accrue affiliate rebate: %w", err)
+			}
 		}
 
 	case RedeemTypeConcurrency:

--- a/backend/internal/service/redeem_service_recharge_test.go
+++ b/backend/internal/service/redeem_service_recharge_test.go
@@ -1,0 +1,107 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedeemRecharge_AccruesAffiliateRebateForPositiveBalanceCode(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentOrderLifecycleTestClient(t)
+
+	inviteeID := int64(2)
+	inviterID := int64(1)
+	userRepo := &mockUserRepo{
+		getByIDUser: &User{ID: inviteeID, Balance: 0},
+	}
+	userRepo.updateBalanceFn = func(_ context.Context, id int64, amount float64) error {
+		require.Equal(t, inviteeID, id)
+		require.Equal(t, 100.0, amount)
+		userRepo.getByIDUser.Balance += amount
+		return nil
+	}
+
+	redeemRepo := &paymentOrderLifecycleRedeemRepo{
+		codesByCode: map[string]*RedeemCode{
+			"recharge-code-1": {
+				ID:     10,
+				Code:   "recharge-code-1",
+				Type:   RedeemTypeBalance,
+				Value:  100,
+				Status: StatusUnused,
+			},
+		},
+	}
+	affiliateRepo := &affiliateRepoStub{
+		summaries: map[int64]*AffiliateSummary{
+			inviteeID: {UserID: inviteeID, InviterID: &inviterID},
+			inviterID: {UserID: inviterID, AffCode: "INVITER"},
+		},
+	}
+	settingSvc := NewSettingService(&settingRepoStub{values: map[string]string{
+		SettingKeyAffiliateEnabled:    "true",
+		SettingKeyAffiliateRebateRate: "20",
+	}}, nil)
+	affiliateSvc := NewAffiliateService(affiliateRepo, settingSvc, nil, nil)
+	redeemSvc := NewRedeemService(redeemRepo, userRepo, nil, nil, nil, client, nil, affiliateSvc)
+
+	redeemed, err := redeemSvc.RedeemRecharge(ctx, inviteeID, "recharge-code-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusUsed, redeemed.Status)
+	require.Equal(t, 100.0, userRepo.getByIDUser.Balance)
+	require.Len(t, affiliateRepo.accrueCalls, 1)
+	require.Equal(t, inviterID, affiliateRepo.accrueCalls[0].inviterID)
+	require.Equal(t, inviteeID, affiliateRepo.accrueCalls[0].inviteeUserID)
+	require.InDelta(t, 20.0, affiliateRepo.accrueCalls[0].amount, 1e-9)
+}
+
+func TestRedeem_DoesNotAccrueAffiliateRebateForManualRedeem(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentOrderLifecycleTestClient(t)
+
+	inviteeID := int64(2)
+	inviterID := int64(1)
+	userRepo := &mockUserRepo{
+		getByIDUser: &User{ID: inviteeID, Balance: 0},
+	}
+	userRepo.updateBalanceFn = func(_ context.Context, id int64, amount float64) error {
+		require.Equal(t, inviteeID, id)
+		require.Equal(t, 100.0, amount)
+		userRepo.getByIDUser.Balance += amount
+		return nil
+	}
+
+	redeemRepo := &paymentOrderLifecycleRedeemRepo{
+		codesByCode: map[string]*RedeemCode{
+			"manual-code-1": {
+				ID:     11,
+				Code:   "manual-code-1",
+				Type:   RedeemTypeBalance,
+				Value:  100,
+				Status: StatusUnused,
+			},
+		},
+	}
+	affiliateRepo := &affiliateRepoStub{
+		summaries: map[int64]*AffiliateSummary{
+			inviteeID: {UserID: inviteeID, InviterID: &inviterID},
+			inviterID: {UserID: inviterID, AffCode: "INVITER"},
+		},
+	}
+	settingSvc := NewSettingService(&settingRepoStub{values: map[string]string{
+		SettingKeyAffiliateEnabled:    "true",
+		SettingKeyAffiliateRebateRate: "20",
+	}}, nil)
+	affiliateSvc := NewAffiliateService(affiliateRepo, settingSvc, nil, nil)
+	redeemSvc := NewRedeemService(redeemRepo, userRepo, nil, nil, nil, client, nil, affiliateSvc)
+
+	redeemed, err := redeemSvc.Redeem(ctx, inviteeID, "manual-code-1")
+	require.NoError(t, err)
+	require.Equal(t, StatusUsed, redeemed.Status)
+	require.Equal(t, 100.0, userRepo.getByIDUser.Balance)
+	require.Empty(t, affiliateRepo.accrueCalls)
+}

--- a/backend/migrations/132_backfill_failed_affiliate_rebates.sql
+++ b/backend/migrations/132_backfill_failed_affiliate_rebates.sql
@@ -1,0 +1,165 @@
+-- Backfill balance-order affiliate rebates that failed during the initial
+-- audit-claim rollout because Postgres could not infer the shared $1 type.
+-- Idempotency gate: only orders with a matching FAILED audit and without an
+-- APPLIED/SKIPPED rebate audit are eligible.
+
+WITH cfg AS (
+    SELECT
+        COALESCE((SELECT value = 'true' FROM settings WHERE key = 'affiliate_enabled'), false) AS enabled,
+        COALESCE((
+            SELECT value::numeric
+            FROM settings
+            WHERE key = 'affiliate_rebate_rate'
+              AND value ~ '^-?[0-9]+(\.[0-9]+)?$'
+        ), 20) AS global_rate
+),
+eligible AS (
+    SELECT
+        po.id::text AS order_id,
+        po.user_id AS invitee_user_id,
+        invitee_aff.inviter_id AS inviter_id,
+        po.amount::numeric AS base_amount,
+        ROUND((po.amount::numeric * COALESCE(inviter_aff.aff_rebate_rate_percent, cfg.global_rate) / 100), 8) AS rebate_amount
+    FROM payment_orders po
+    JOIN user_affiliates invitee_aff
+      ON invitee_aff.user_id = po.user_id
+     AND invitee_aff.inviter_id IS NOT NULL
+    JOIN user_affiliates inviter_aff
+      ON inviter_aff.user_id = invitee_aff.inviter_id
+    CROSS JOIN cfg
+    WHERE cfg.enabled
+      AND po.order_type = 'balance'
+      AND po.status = 'COMPLETED'
+      AND po.amount > 0
+      AND EXISTS (
+          SELECT 1
+          FROM payment_audit_logs failed
+          WHERE failed.order_id = po.id::text
+            AND failed.action = 'AFFILIATE_REBATE_FAILED'
+            AND failed.detail LIKE '%inconsistent types deduced for parameter%'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM payment_audit_logs done
+          WHERE done.order_id = po.id::text
+            AND done.action IN ('AFFILIATE_REBATE_APPLIED', 'AFFILIATE_REBATE_SKIPPED')
+      )
+),
+filtered AS (
+    SELECT *
+    FROM eligible
+    WHERE rebate_amount > 0
+),
+aggregated AS (
+    SELECT inviter_id, SUM(rebate_amount) AS total_rebate
+    FROM filtered
+    GROUP BY inviter_id
+)
+UPDATE user_affiliates ua
+SET aff_quota = ua.aff_quota + aggregated.total_rebate,
+    aff_history_quota = ua.aff_history_quota + aggregated.total_rebate,
+    updated_at = NOW()
+FROM aggregated
+WHERE ua.user_id = aggregated.inviter_id;
+
+WITH cfg AS (
+    SELECT
+        COALESCE((SELECT value = 'true' FROM settings WHERE key = 'affiliate_enabled'), false) AS enabled,
+        COALESCE((
+            SELECT value::numeric
+            FROM settings
+            WHERE key = 'affiliate_rebate_rate'
+              AND value ~ '^-?[0-9]+(\.[0-9]+)?$'
+        ), 20) AS global_rate
+),
+eligible AS (
+    SELECT
+        po.id::text AS order_id,
+        po.user_id AS invitee_user_id,
+        invitee_aff.inviter_id AS inviter_id,
+        po.amount::numeric AS base_amount,
+        ROUND((po.amount::numeric * COALESCE(inviter_aff.aff_rebate_rate_percent, cfg.global_rate) / 100), 8) AS rebate_amount
+    FROM payment_orders po
+    JOIN user_affiliates invitee_aff
+      ON invitee_aff.user_id = po.user_id
+     AND invitee_aff.inviter_id IS NOT NULL
+    JOIN user_affiliates inviter_aff
+      ON inviter_aff.user_id = invitee_aff.inviter_id
+    CROSS JOIN cfg
+    WHERE cfg.enabled
+      AND po.order_type = 'balance'
+      AND po.status = 'COMPLETED'
+      AND po.amount > 0
+      AND EXISTS (
+          SELECT 1
+          FROM payment_audit_logs failed
+          WHERE failed.order_id = po.id::text
+            AND failed.action = 'AFFILIATE_REBATE_FAILED'
+            AND failed.detail LIKE '%inconsistent types deduced for parameter%'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM payment_audit_logs done
+          WHERE done.order_id = po.id::text
+            AND done.action IN ('AFFILIATE_REBATE_APPLIED', 'AFFILIATE_REBATE_SKIPPED')
+      )
+)
+INSERT INTO user_affiliate_ledger (user_id, action, amount, source_user_id, created_at, updated_at)
+SELECT inviter_id, 'accrue', rebate_amount, invitee_user_id, NOW(), NOW()
+FROM eligible
+WHERE rebate_amount > 0;
+
+WITH cfg AS (
+    SELECT
+        COALESCE((SELECT value = 'true' FROM settings WHERE key = 'affiliate_enabled'), false) AS enabled,
+        COALESCE((
+            SELECT value::numeric
+            FROM settings
+            WHERE key = 'affiliate_rebate_rate'
+              AND value ~ '^-?[0-9]+(\.[0-9]+)?$'
+        ), 20) AS global_rate
+),
+eligible AS (
+    SELECT
+        po.id::text AS order_id,
+        po.amount::numeric AS base_amount,
+        ROUND((po.amount::numeric * COALESCE(inviter_aff.aff_rebate_rate_percent, cfg.global_rate) / 100), 8) AS rebate_amount
+    FROM payment_orders po
+    JOIN user_affiliates invitee_aff
+      ON invitee_aff.user_id = po.user_id
+     AND invitee_aff.inviter_id IS NOT NULL
+    JOIN user_affiliates inviter_aff
+      ON inviter_aff.user_id = invitee_aff.inviter_id
+    CROSS JOIN cfg
+    WHERE cfg.enabled
+      AND po.order_type = 'balance'
+      AND po.status = 'COMPLETED'
+      AND po.amount > 0
+      AND EXISTS (
+          SELECT 1
+          FROM payment_audit_logs failed
+          WHERE failed.order_id = po.id::text
+            AND failed.action = 'AFFILIATE_REBATE_FAILED'
+            AND failed.detail LIKE '%inconsistent types deduced for parameter%'
+      )
+      AND NOT EXISTS (
+          SELECT 1
+          FROM payment_audit_logs done
+          WHERE done.order_id = po.id::text
+            AND done.action IN ('AFFILIATE_REBATE_APPLIED', 'AFFILIATE_REBATE_SKIPPED')
+      )
+)
+INSERT INTO payment_audit_logs (order_id, action, detail, operator, created_at)
+SELECT
+    order_id,
+    'AFFILIATE_REBATE_APPLIED',
+    json_build_object(
+        'baseAmount', base_amount,
+        'rebateAmount', rebate_amount,
+        'reason', 'backfill failed affiliate rebate claim'
+    )::text,
+    'system',
+    NOW()
+FROM eligible
+WHERE rebate_amount > 0
+ON CONFLICT (order_id, action) DO NOTHING;

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -564,9 +564,10 @@ export async function resetPassword(request: ResetPasswordRequest): Promise<Rese
  */
 export async function completeLinuxDoOAuthRegistration(
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<OAuthTokenResponse> {
-  return createPendingLinuxDoOAuthAccount(invitationCode, decision)
+  return createPendingLinuxDoOAuthAccount(invitationCode, decision, affiliateCode)
 }
 
 /**
@@ -576,27 +577,31 @@ export async function completeLinuxDoOAuthRegistration(
  */
 export async function completeOIDCOAuthRegistration(
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<OAuthTokenResponse> {
-  return createPendingOIDCOAuthAccount(invitationCode, decision)
+  return createPendingOIDCOAuthAccount(invitationCode, decision, affiliateCode)
 }
 
 export async function completeWeChatOAuthRegistration(
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<OAuthTokenResponse> {
-  return createPendingWeChatOAuthAccount(invitationCode, decision)
+  return createPendingWeChatOAuthAccount(invitationCode, decision, affiliateCode)
 }
 
 async function createPendingOAuthAccount(
   provider: 'linuxdo' | 'oidc' | 'wechat',
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<PendingOAuthCreateAccountResponse> {
   const { data } = await apiClient.post<PendingOAuthCreateAccountResponse>(
     `/auth/oauth/${provider}/complete-registration`,
     {
       invitation_code: invitationCode,
+      ...(affiliateCode?.trim() ? { aff_code: affiliateCode.trim() } : {}),
       ...serializeOAuthAdoptionDecision(decision)
     }
   )
@@ -605,23 +610,26 @@ async function createPendingOAuthAccount(
 
 export async function createPendingLinuxDoOAuthAccount(
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<PendingOAuthCreateAccountResponse> {
-  return createPendingOAuthAccount('linuxdo', invitationCode, decision)
+  return createPendingOAuthAccount('linuxdo', invitationCode, decision, affiliateCode)
 }
 
 export async function createPendingOIDCOAuthAccount(
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<PendingOAuthCreateAccountResponse> {
-  return createPendingOAuthAccount('oidc', invitationCode, decision)
+  return createPendingOAuthAccount('oidc', invitationCode, decision, affiliateCode)
 }
 
 export async function createPendingWeChatOAuthAccount(
   invitationCode: string,
-  decision?: OAuthAdoptionDecision
+  decision?: OAuthAdoptionDecision,
+  affiliateCode?: string
 ): Promise<PendingOAuthCreateAccountResponse> {
-  return createPendingOAuthAccount('wechat', invitationCode, decision)
+  return createPendingOAuthAccount('wechat', invitationCode, decision, affiliateCode)
 }
 
 export async function completePendingOAuthBindLogin(

--- a/frontend/src/components/auth/LinuxDoOAuthSection.vue
+++ b/frontend/src/components/auth/LinuxDoOAuthSection.vue
@@ -54,6 +54,10 @@ const route = useRoute()
 const { t } = useI18n()
 
 function startLogin(): void {
+  const affCode = ((route.query.aff as string) || (route.query.aff_code as string) || '').trim()
+  if (affCode) {
+    sessionStorage.setItem('affiliate_code', affCode)
+  }
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')

--- a/frontend/src/components/auth/OidcOAuthSection.vue
+++ b/frontend/src/components/auth/OidcOAuthSection.vue
@@ -44,6 +44,10 @@ const normalizedProviderName = computed(() => {
 const providerInitial = computed(() => normalizedProviderName.value.charAt(0).toUpperCase() || 'O')
 
 function startLogin(): void {
+  const affCode = ((route.query.aff as string) || (route.query.aff_code as string) || '').trim()
+  if (affCode) {
+    sessionStorage.setItem('affiliate_code', affCode)
+  }
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')

--- a/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
+++ b/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
@@ -99,6 +99,7 @@ export type PendingOAuthCreateAccountPayload = {
   password: string
   verifyCode: string
   invitationCode?: string
+  affiliateCode?: string
 }
 
 const props = defineProps<{

--- a/frontend/src/components/auth/WechatOAuthSection.vue
+++ b/frontend/src/components/auth/WechatOAuthSection.vue
@@ -83,6 +83,10 @@ function startLogin(): void {
   if (buttonDisabled.value || !resolvedStart.value.mode) {
     return
   }
+  const affCode = ((route.query.aff as string) || (route.query.aff_code as string) || '').trim()
+  if (affCode) {
+    sessionStorage.setItem('affiliate_code', affCode)
+  }
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')

--- a/frontend/src/views/auth/LinuxDoCallbackView.vue
+++ b/frontend/src/views/auth/LinuxDoCallbackView.vue
@@ -288,6 +288,10 @@ const canReturnToCreateAccount = ref(false)
 const bindSuccessMessage = t('profile.authBindings.bindSuccess')
 const needsTotpChallenge = ref(false)
 const totpTempToken = ref('')
+
+function getAffiliateCode(): string {
+  return sessionStorage.getItem('affiliate_code')?.trim() || ''
+}
 const totpCode = ref('')
 const totpError = ref('')
 const totpUserEmailMasked = ref('')
@@ -632,12 +636,14 @@ async function handleSubmitInvitation() {
           await apiClient.post<LinuxDoPendingActionResponse>('/auth/oauth/linuxdo/complete-registration', {
             pending_oauth_token: legacyPendingOAuthToken.value,
             invitation_code: invitationCode.value.trim(),
+            ...(getAffiliateCode() ? { aff_code: getAffiliateCode() } : {}),
             ...serializeAdoptionDecision(currentAdoptionDecision())
           })
         ).data
       : await completeLinuxDoOAuthRegistration(
           invitationCode.value.trim(),
-          currentAdoptionDecision()
+          currentAdoptionDecision(),
+          ...(getAffiliateCode() ? [getAffiliateCode()] : [])
         )
     await finalizePendingAccountResponse(completion)
   } catch (e: unknown) {
@@ -673,6 +679,7 @@ async function handleCreateAccount(payload: PendingOAuthCreateAccountPayload) {
       password: payload.password,
       verify_code: payload.verifyCode || undefined,
       invitation_code: payload.invitationCode || undefined,
+      ...(getAffiliateCode() ? { aff_code: getAffiliateCode() } : {}),
       ...serializeAdoptionDecision(currentAdoptionDecision())
     })
     await finalizePendingAccountResponse(data)

--- a/frontend/src/views/auth/OidcCallbackView.vue
+++ b/frontend/src/views/auth/OidcCallbackView.vue
@@ -283,6 +283,10 @@ const providerName = ref('OIDC')
 const adoptionRequired = ref(false)
 const suggestedDisplayName = ref('')
 const suggestedAvatarUrl = ref('')
+
+function getAffiliateCode(): string {
+  return sessionStorage.getItem('affiliate_code')?.trim() || ''
+}
 const adoptDisplayName = ref(true)
 const adoptAvatar = ref(true)
 const needsAdoptionConfirmation = ref(false)
@@ -654,12 +658,14 @@ async function handleSubmitInvitation() {
           await apiClient.post<PendingOidcCompletion>('/auth/oauth/oidc/complete-registration', {
             pending_oauth_token: legacyPendingOAuthToken.value,
             invitation_code: invitationCode.value.trim(),
+            ...(getAffiliateCode() ? { aff_code: getAffiliateCode() } : {}),
             ...serializeAdoptionDecision(currentAdoptionDecision())
           })
         ).data
       : await completeOIDCOAuthRegistration(
           invitationCode.value.trim(),
-          currentAdoptionDecision()
+          currentAdoptionDecision(),
+          ...(getAffiliateCode() ? [getAffiliateCode()] : [])
         )
     await finalizePendingAccountResponse(completion)
   } catch (e: unknown) {
@@ -695,6 +701,7 @@ async function handleCreateAccount(payload: PendingOAuthCreateAccountPayload) {
       password: payload.password,
       verify_code: payload.verifyCode || undefined,
       invitation_code: payload.invitationCode || undefined,
+      ...(getAffiliateCode() ? { aff_code: getAffiliateCode() } : {}),
       ...serializeAdoptionDecision(currentAdoptionDecision())
     })
     await finalizePendingAccountResponse(data)

--- a/frontend/src/views/auth/WechatCallbackView.vue
+++ b/frontend/src/views/auth/WechatCallbackView.vue
@@ -360,6 +360,10 @@ const adoptionRequired = ref(false)
 const suggestedDisplayName = ref('')
 const suggestedAvatarUrl = ref('')
 const existingAccountEmail = ref('')
+
+function getAffiliateCode(): string {
+  return sessionStorage.getItem('affiliate_code')?.trim() || ''
+}
 const adoptDisplayName = ref(true)
 const adoptAvatar = ref(true)
 const needsAdoptionConfirmation = ref(false)
@@ -866,12 +870,14 @@ async function handleSubmitInvitation() {
           await apiClient.post<PendingWeChatCompletion>('/auth/oauth/wechat/complete-registration', {
             pending_oauth_token: legacyPendingOAuthToken.value,
             invitation_code: invitationCode.value.trim(),
+            ...(getAffiliateCode() ? { aff_code: getAffiliateCode() } : {}),
             ...serializeAdoptionDecision(currentAdoptionDecision())
           })
         ).data
       : await completeWeChatOAuthRegistration(
           invitationCode.value.trim(),
-          currentAdoptionDecision()
+          currentAdoptionDecision(),
+          ...(getAffiliateCode() ? [getAffiliateCode()] : [])
         )
     await finalizePendingAccountResponse(completion)
   } catch (e: unknown) {
@@ -907,6 +913,7 @@ async function handleCreateAccount(payload: PendingOAuthCreateAccountPayload) {
       password: payload.password,
       verify_code: payload.verifyCode || undefined,
       invitation_code: payload.invitationCode || undefined,
+      ...(getAffiliateCode() ? { aff_code: getAffiliateCode() } : {}),
       ...serializeAdoptionDecision(currentAdoptionDecision())
     })
     await finalizePendingAccountResponse(data)


### PR DESCRIPTION
## Summary
- Pass affiliate codes through email and pending OAuth registration flows so invite relationships are bound for new users.
- Treat admin/integration create-and-redeem balance codes as recharge events while keeping manual redeem codes from generating rebates.
- Fix affiliate rebate audit claiming on Postgres by casting order IDs consistently, and add a backfill migration for failed rebate claims.

## Verification
- go test -tags unit ./internal/service -count=1
- go test -tags unit ./internal/handler/admin -count=1
- go test -tags unit ./internal/server -count=1
- go test -tags embed ./internal/web -run TestHasEmbeddedFrontend -count=1
- go build -tags embed -o sub2api ./cmd/server
