### PR TITLE
fix(gateway): SSE parsing compatibility for Dashscope no-space format

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -231,7 +231,7 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		if !strings.HasPrefix(line, "event:") {
 			continue
 		}
 
@@ -239,10 +239,10 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		if !strings.HasPrefix(dataLine, "data:") {
 			continue
 		}
-		payload := dataLine[6:]
+		payload := strings.TrimSpace(dataLine[5:])
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -432,7 +432,7 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		if !strings.HasPrefix(line, "event:") {
 			continue
 		}
 
@@ -440,10 +440,10 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 			break
 		}
 		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		if !strings.HasPrefix(dataLine, "data:") {
 			continue
 		}
-		payload := dataLine[6:]
+		payload := strings.TrimSpace(dataLine[5:])
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {


### PR DESCRIPTION
# fix(gateway): SSE parsing compatibility for Dashscope no-space format

## 故障时间线

**现象**: 通过 `/v1/chat/completions` 端点向 Anthropic 平台账户（如 Dashscope）发起请求，流式和非流式响应均返回空内容 `{"delta":{"content":""},"finish_reason":"stop"}`，无错误提示。

**触发时间**: 2026-04-26 凌晨

**影响范围**: 所有通过 `/v1/chat/completions` 路径转发到 Anthropic 上游的请求（openclaw-tui 等客户端）

---

## 故障根因

`gateway_forward_as_chat_completions.go` 中的 SSE 解析器使用严格的格式匹配：

```go
if !strings.HasPrefix(line, "event: ") { ... }   // 冒号后必须有空格
if !strings.HasPrefix(dataLine, "data: ") { ... } // 冒号后必须有空格
```

但 Dashscope（coding.dashscope.aliyuncs.com）的 SSE 序列化格式变为**紧凑格式**——冒号后无空格：

```
event:message_start      ← Dashscope 实际返回（无空格）
data:{"message":{...}}   ← Dashscope 实际返回（无空格）
```

SSE 规范 (EventSource) 允许冒号后有无空格两种格式。但我们的解析器只认有空格版本，导致所有 SSE 事件被静默跳过，`finalResp == nil`，最终只输出一个空内容的 finish chunk。

**为什么之前没出问题？**
- Dashscope 上游之前返回的是标准格式 `event: message_start`（有空格），今天可能部署了新版本改为紧凑格式
- 此文件（`gateway_forward_as_chat_completions.go`）自 4321adab 引入以来，SSE 解析逻辑从未修改过

---

## 修复方案

将严格的 `event: ` / `data: ` 前缀匹配改为 `event:` / `data:`，并用 `strings.TrimSpace` 处理 payload：

| 修改前 | 修改后 |
|--------|--------|
| `HasPrefix(line, "event: ")` | `HasPrefix(line, "event:")` |
| `HasPrefix(dataLine, "data: ")` | `HasPrefix(dataLine, "data:")` |
| `payload := dataLine[6:]` | `payload := strings.TrimSpace(dataLine[5:])` |

**修复影响两个路径：**
1. `handleCCStreamingFromAnthropic` — 流式路径（line 234, 435）
2. `handleCCBufferedFromAnthropic` — 非流式路径（line 234, 435）

修复后同时兼容有空格和无空格两种格式。

---

## 测试验证

**流式响应（修复前）：**
```json
{"delta":{"content":""},"finish_reason":"stop"}
```

**流式响应（修复后）：**
```json
{"delta":{"reasoning_content":"Here's a thinking process..."}}
{"delta":{"reasoning_content":"...analyzing user input..."}}
{"delta":{"content":"你好！有什么我可以帮你的吗？"}}
```

**非流式响应（修复前）：** HTTP 502 `Upstream stream ended without a response`

**非流式响应（修复后）：** 完整 JSON 响应含 content、reasoning_content 和 usage

---

## 变更文件

- `backend/internal/service/gateway_forward_as_chat_completions.go` — 6 insertions, 6 deletions