### PR TITLE
feat: add configurable prompt keyword filter

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -237,7 +237,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	userMsgQueueCache := repository.NewUserMsgQueueCache(redisClient)
 	userMessageQueueService := service.ProvideUserMessageQueueService(userMsgQueueCache, rpmCache, configConfig)
 	gatewayHandler := handler.NewGatewayHandler(gatewayService, geminiMessagesCompatService, antigravityGatewayService, userService, concurrencyService, billingCacheService, usageService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, userMessageQueueService, configConfig, settingService)
-	openAIGatewayHandler := handler.NewOpenAIGatewayHandler(openAIGatewayService, concurrencyService, billingCacheService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, configConfig)
+	openAIGatewayHandler := handler.NewOpenAIGatewayHandler(openAIGatewayService, concurrencyService, billingCacheService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, settingService, configConfig)
 	handlerSettingHandler := handler.ProvideSettingHandler(settingService, buildInfo)
 	totpHandler := handler.NewTotpHandler(totpService)
 	handlerPaymentHandler := handler.NewPaymentHandler(paymentService, paymentConfigService, channelService)

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1435,6 +1435,7 @@ var (
 		{Name: "balance", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
 		{Name: "concurrency", Type: field.TypeInt, Default: 5},
 		{Name: "status", Type: field.TypeString, Size: 20, Default: "active"},
+		{Name: "prompt_violation_count", Type: field.TypeInt, Default: 0},
 		{Name: "username", Type: field.TypeString, Size: 100, Default: ""},
 		{Name: "notes", Type: field.TypeString, Default: "", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "totp_secret_encrypted", Type: field.TypeString, Nullable: true, SchemaType: map[string]string{"postgres": "text"}},

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -37438,6 +37438,8 @@ type UserMutation struct {
 	concurrency                   *int
 	addconcurrency                *int
 	status                        *string
+	prompt_violation_count        *int
+	addprompt_violation_count     *int
 	username                      *string
 	notes                         *string
 	totp_secret_encrypted         *string
@@ -37970,6 +37972,62 @@ func (m *UserMutation) OldStatus(ctx context.Context) (v string, err error) {
 // ResetStatus resets all changes to the "status" field.
 func (m *UserMutation) ResetStatus() {
 	m.status = nil
+}
+
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (m *UserMutation) SetPromptViolationCount(i int) {
+	m.prompt_violation_count = &i
+	m.addprompt_violation_count = nil
+}
+
+// PromptViolationCount returns the value of the "prompt_violation_count" field in the mutation.
+func (m *UserMutation) PromptViolationCount() (r int, exists bool) {
+	v := m.prompt_violation_count
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPromptViolationCount returns the old "prompt_violation_count" field's value of the User entity.
+// If the User object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserMutation) OldPromptViolationCount(ctx context.Context) (v int, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPromptViolationCount is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPromptViolationCount requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPromptViolationCount: %w", err)
+	}
+	return oldValue.PromptViolationCount, nil
+}
+
+// AddPromptViolationCount adds i to the "prompt_violation_count" field.
+func (m *UserMutation) AddPromptViolationCount(i int) {
+	if m.addprompt_violation_count != nil {
+		*m.addprompt_violation_count += i
+	} else {
+		m.addprompt_violation_count = &i
+	}
+}
+
+// AddedPromptViolationCount returns the value that was added to the "prompt_violation_count" field in this mutation.
+func (m *UserMutation) AddedPromptViolationCount() (r int, exists bool) {
+	v := m.addprompt_violation_count
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ResetPromptViolationCount resets all changes to the "prompt_violation_count" field.
+func (m *UserMutation) ResetPromptViolationCount() {
+	m.prompt_violation_count = nil
+	m.addprompt_violation_count = nil
 }
 
 // SetUsername sets the "username" field.
@@ -39284,7 +39342,7 @@ func (m *UserMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserMutation) Fields() []string {
-	fields := make([]string, 0, 23)
+	fields := make([]string, 0, 24)
 	if m.created_at != nil {
 		fields = append(fields, user.FieldCreatedAt)
 	}
@@ -39311,6 +39369,9 @@ func (m *UserMutation) Fields() []string {
 	}
 	if m.status != nil {
 		fields = append(fields, user.FieldStatus)
+	}
+	if m.prompt_violation_count != nil {
+		fields = append(fields, user.FieldPromptViolationCount)
 	}
 	if m.username != nil {
 		fields = append(fields, user.FieldUsername)
@@ -39380,6 +39441,8 @@ func (m *UserMutation) Field(name string) (ent.Value, bool) {
 		return m.Concurrency()
 	case user.FieldStatus:
 		return m.Status()
+	case user.FieldPromptViolationCount:
+		return m.PromptViolationCount()
 	case user.FieldUsername:
 		return m.Username()
 	case user.FieldNotes:
@@ -39435,6 +39498,8 @@ func (m *UserMutation) OldField(ctx context.Context, name string) (ent.Value, er
 		return m.OldConcurrency(ctx)
 	case user.FieldStatus:
 		return m.OldStatus(ctx)
+	case user.FieldPromptViolationCount:
+		return m.OldPromptViolationCount(ctx)
 	case user.FieldUsername:
 		return m.OldUsername(ctx)
 	case user.FieldNotes:
@@ -39534,6 +39599,13 @@ func (m *UserMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetStatus(v)
+		return nil
+	case user.FieldPromptViolationCount:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPromptViolationCount(v)
 		return nil
 	case user.FieldUsername:
 		v, ok := value.(string)
@@ -39647,6 +39719,9 @@ func (m *UserMutation) AddedFields() []string {
 	if m.addconcurrency != nil {
 		fields = append(fields, user.FieldConcurrency)
 	}
+	if m.addprompt_violation_count != nil {
+		fields = append(fields, user.FieldPromptViolationCount)
+	}
 	if m.addbalance_notify_threshold != nil {
 		fields = append(fields, user.FieldBalanceNotifyThreshold)
 	}
@@ -39668,6 +39743,8 @@ func (m *UserMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedBalance()
 	case user.FieldConcurrency:
 		return m.AddedConcurrency()
+	case user.FieldPromptViolationCount:
+		return m.AddedPromptViolationCount()
 	case user.FieldBalanceNotifyThreshold:
 		return m.AddedBalanceNotifyThreshold()
 	case user.FieldTotalRecharged:
@@ -39696,6 +39773,13 @@ func (m *UserMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddConcurrency(v)
+		return nil
+	case user.FieldPromptViolationCount:
+		v, ok := value.(int)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddPromptViolationCount(v)
 		return nil
 	case user.FieldBalanceNotifyThreshold:
 		v, ok := value.(float64)
@@ -39810,6 +39894,9 @@ func (m *UserMutation) ResetField(name string) error {
 		return nil
 	case user.FieldStatus:
 		m.ResetStatus()
+		return nil
+	case user.FieldPromptViolationCount:
+		m.ResetPromptViolationCount()
 		return nil
 	case user.FieldUsername:
 		m.ResetUsername()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -1793,44 +1793,48 @@ func init() {
 	user.DefaultStatus = userDescStatus.Default.(string)
 	// user.StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	user.StatusValidator = userDescStatus.Validators[0].(func(string) error)
+	// userDescPromptViolationCount is the schema descriptor for prompt_violation_count field.
+	userDescPromptViolationCount := userFields[6].Descriptor()
+	// user.DefaultPromptViolationCount holds the default value on creation for the prompt_violation_count field.
+	user.DefaultPromptViolationCount = userDescPromptViolationCount.Default.(int)
 	// userDescUsername is the schema descriptor for username field.
-	userDescUsername := userFields[6].Descriptor()
+	userDescUsername := userFields[7].Descriptor()
 	// user.DefaultUsername holds the default value on creation for the username field.
 	user.DefaultUsername = userDescUsername.Default.(string)
 	// user.UsernameValidator is a validator for the "username" field. It is called by the builders before save.
 	user.UsernameValidator = userDescUsername.Validators[0].(func(string) error)
 	// userDescNotes is the schema descriptor for notes field.
-	userDescNotes := userFields[7].Descriptor()
+	userDescNotes := userFields[8].Descriptor()
 	// user.DefaultNotes holds the default value on creation for the notes field.
 	user.DefaultNotes = userDescNotes.Default.(string)
 	// userDescTotpEnabled is the schema descriptor for totp_enabled field.
-	userDescTotpEnabled := userFields[9].Descriptor()
+	userDescTotpEnabled := userFields[10].Descriptor()
 	// user.DefaultTotpEnabled holds the default value on creation for the totp_enabled field.
 	user.DefaultTotpEnabled = userDescTotpEnabled.Default.(bool)
 	// userDescSignupSource is the schema descriptor for signup_source field.
-	userDescSignupSource := userFields[11].Descriptor()
+	userDescSignupSource := userFields[12].Descriptor()
 	// user.DefaultSignupSource holds the default value on creation for the signup_source field.
 	user.DefaultSignupSource = userDescSignupSource.Default.(string)
 	// user.SignupSourceValidator is a validator for the "signup_source" field. It is called by the builders before save.
 	user.SignupSourceValidator = userDescSignupSource.Validators[0].(func(string) error)
 	// userDescBalanceNotifyEnabled is the schema descriptor for balance_notify_enabled field.
-	userDescBalanceNotifyEnabled := userFields[14].Descriptor()
+	userDescBalanceNotifyEnabled := userFields[15].Descriptor()
 	// user.DefaultBalanceNotifyEnabled holds the default value on creation for the balance_notify_enabled field.
 	user.DefaultBalanceNotifyEnabled = userDescBalanceNotifyEnabled.Default.(bool)
 	// userDescBalanceNotifyThresholdType is the schema descriptor for balance_notify_threshold_type field.
-	userDescBalanceNotifyThresholdType := userFields[15].Descriptor()
+	userDescBalanceNotifyThresholdType := userFields[16].Descriptor()
 	// user.DefaultBalanceNotifyThresholdType holds the default value on creation for the balance_notify_threshold_type field.
 	user.DefaultBalanceNotifyThresholdType = userDescBalanceNotifyThresholdType.Default.(string)
 	// userDescBalanceNotifyExtraEmails is the schema descriptor for balance_notify_extra_emails field.
-	userDescBalanceNotifyExtraEmails := userFields[17].Descriptor()
+	userDescBalanceNotifyExtraEmails := userFields[18].Descriptor()
 	// user.DefaultBalanceNotifyExtraEmails holds the default value on creation for the balance_notify_extra_emails field.
 	user.DefaultBalanceNotifyExtraEmails = userDescBalanceNotifyExtraEmails.Default.(string)
 	// userDescTotalRecharged is the schema descriptor for total_recharged field.
-	userDescTotalRecharged := userFields[18].Descriptor()
+	userDescTotalRecharged := userFields[19].Descriptor()
 	// user.DefaultTotalRecharged holds the default value on creation for the total_recharged field.
 	user.DefaultTotalRecharged = userDescTotalRecharged.Default.(float64)
 	// userDescRpmLimit is the schema descriptor for rpm_limit field.
-	userDescRpmLimit := userFields[19].Descriptor()
+	userDescRpmLimit := userFields[20].Descriptor()
 	// user.DefaultRpmLimit holds the default value on creation for the rpm_limit field.
 	user.DefaultRpmLimit = userDescRpmLimit.Default.(int)
 	userallowedgroupFields := schema.UserAllowedGroup{}.Fields()

--- a/backend/ent/schema/user.go
+++ b/backend/ent/schema/user.go
@@ -54,6 +54,8 @@ func (User) Fields() []ent.Field {
 		field.String("status").
 			MaxLen(20).
 			Default(domain.StatusActive),
+		field.Int("prompt_violation_count").
+			Default(0),
 
 		// Optional profile fields (added later; default '' in DB migration)
 		field.String("username").

--- a/backend/ent/user.go
+++ b/backend/ent/user.go
@@ -35,6 +35,8 @@ type User struct {
 	Concurrency int `json:"concurrency,omitempty"`
 	// Status holds the value of the "status" field.
 	Status string `json:"status,omitempty"`
+	// PromptViolationCount holds the value of the "prompt_violation_count" field.
+	PromptViolationCount int `json:"prompt_violation_count,omitempty"`
 	// Username holds the value of the "username" field.
 	Username string `json:"username,omitempty"`
 	// Notes holds the value of the "notes" field.
@@ -228,7 +230,7 @@ func (*User) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case user.FieldBalance, user.FieldBalanceNotifyThreshold, user.FieldTotalRecharged:
 			values[i] = new(sql.NullFloat64)
-		case user.FieldID, user.FieldConcurrency, user.FieldRpmLimit:
+		case user.FieldID, user.FieldConcurrency, user.FieldPromptViolationCount, user.FieldRpmLimit:
 			values[i] = new(sql.NullInt64)
 		case user.FieldEmail, user.FieldPasswordHash, user.FieldRole, user.FieldStatus, user.FieldUsername, user.FieldNotes, user.FieldTotpSecretEncrypted, user.FieldSignupSource, user.FieldBalanceNotifyThresholdType, user.FieldBalanceNotifyExtraEmails:
 			values[i] = new(sql.NullString)
@@ -309,6 +311,12 @@ func (_m *User) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field status", values[i])
 			} else if value.Valid {
 				_m.Status = value.String
+			}
+		case user.FieldPromptViolationCount:
+			if value, ok := values[i].(*sql.NullInt64); !ok {
+				return fmt.Errorf("unexpected type %T for field prompt_violation_count", values[i])
+			} else if value.Valid {
+				_m.PromptViolationCount = int(value.Int64)
 			}
 		case user.FieldUsername:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -528,6 +536,9 @@ func (_m *User) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("status=")
 	builder.WriteString(_m.Status)
+	builder.WriteString(", ")
+	builder.WriteString("prompt_violation_count=")
+	builder.WriteString(fmt.Sprintf("%v", _m.PromptViolationCount))
 	builder.WriteString(", ")
 	builder.WriteString("username=")
 	builder.WriteString(_m.Username)

--- a/backend/ent/user/user.go
+++ b/backend/ent/user/user.go
@@ -33,6 +33,8 @@ const (
 	FieldConcurrency = "concurrency"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
+	// FieldPromptViolationCount holds the string denoting the prompt_violation_count field in the database.
+	FieldPromptViolationCount = "prompt_violation_count"
 	// FieldUsername holds the string denoting the username field in the database.
 	FieldUsername = "username"
 	// FieldNotes holds the string denoting the notes field in the database.
@@ -192,6 +194,7 @@ var Columns = []string{
 	FieldBalance,
 	FieldConcurrency,
 	FieldStatus,
+	FieldPromptViolationCount,
 	FieldUsername,
 	FieldNotes,
 	FieldTotpSecretEncrypted,
@@ -254,6 +257,8 @@ var (
 	DefaultStatus string
 	// StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	StatusValidator func(string) error
+	// DefaultPromptViolationCount holds the default value on creation for the "prompt_violation_count" field.
+	DefaultPromptViolationCount int
 	// DefaultUsername holds the default value on creation for the "username" field.
 	DefaultUsername string
 	// UsernameValidator is a validator for the "username" field. It is called by the builders before save.
@@ -329,6 +334,11 @@ func ByConcurrency(opts ...sql.OrderTermOption) OrderOption {
 // ByStatus orders the results by the status field.
 func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
+}
+
+// ByPromptViolationCount orders the results by the prompt_violation_count field.
+func ByPromptViolationCount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPromptViolationCount, opts...).ToFunc()
 }
 
 // ByUsername orders the results by the username field.

--- a/backend/ent/user/where.go
+++ b/backend/ent/user/where.go
@@ -100,6 +100,11 @@ func Status(v string) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldStatus, v))
 }
 
+// PromptViolationCount applies equality check predicate on the "prompt_violation_count" field. It's identical to PromptViolationCountEQ.
+func PromptViolationCount(v int) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldPromptViolationCount, v))
+}
+
 // Username applies equality check predicate on the "username" field. It's identical to UsernameEQ.
 func Username(v string) predicate.User {
 	return predicate.User(sql.FieldEQ(FieldUsername, v))
@@ -638,6 +643,46 @@ func StatusEqualFold(v string) predicate.User {
 // StatusContainsFold applies the ContainsFold predicate on the "status" field.
 func StatusContainsFold(v string) predicate.User {
 	return predicate.User(sql.FieldContainsFold(FieldStatus, v))
+}
+
+// PromptViolationCountEQ applies the EQ predicate on the "prompt_violation_count" field.
+func PromptViolationCountEQ(v int) predicate.User {
+	return predicate.User(sql.FieldEQ(FieldPromptViolationCount, v))
+}
+
+// PromptViolationCountNEQ applies the NEQ predicate on the "prompt_violation_count" field.
+func PromptViolationCountNEQ(v int) predicate.User {
+	return predicate.User(sql.FieldNEQ(FieldPromptViolationCount, v))
+}
+
+// PromptViolationCountIn applies the In predicate on the "prompt_violation_count" field.
+func PromptViolationCountIn(vs ...int) predicate.User {
+	return predicate.User(sql.FieldIn(FieldPromptViolationCount, vs...))
+}
+
+// PromptViolationCountNotIn applies the NotIn predicate on the "prompt_violation_count" field.
+func PromptViolationCountNotIn(vs ...int) predicate.User {
+	return predicate.User(sql.FieldNotIn(FieldPromptViolationCount, vs...))
+}
+
+// PromptViolationCountGT applies the GT predicate on the "prompt_violation_count" field.
+func PromptViolationCountGT(v int) predicate.User {
+	return predicate.User(sql.FieldGT(FieldPromptViolationCount, v))
+}
+
+// PromptViolationCountGTE applies the GTE predicate on the "prompt_violation_count" field.
+func PromptViolationCountGTE(v int) predicate.User {
+	return predicate.User(sql.FieldGTE(FieldPromptViolationCount, v))
+}
+
+// PromptViolationCountLT applies the LT predicate on the "prompt_violation_count" field.
+func PromptViolationCountLT(v int) predicate.User {
+	return predicate.User(sql.FieldLT(FieldPromptViolationCount, v))
+}
+
+// PromptViolationCountLTE applies the LTE predicate on the "prompt_violation_count" field.
+func PromptViolationCountLTE(v int) predicate.User {
+	return predicate.User(sql.FieldLTE(FieldPromptViolationCount, v))
 }
 
 // UsernameEQ applies the EQ predicate on the "username" field.

--- a/backend/ent/user_create.go
+++ b/backend/ent/user_create.go
@@ -143,6 +143,20 @@ func (_c *UserCreate) SetNillableStatus(v *string) *UserCreate {
 	return _c
 }
 
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (_c *UserCreate) SetPromptViolationCount(v int) *UserCreate {
+	_c.mutation.SetPromptViolationCount(v)
+	return _c
+}
+
+// SetNillablePromptViolationCount sets the "prompt_violation_count" field if the given value is not nil.
+func (_c *UserCreate) SetNillablePromptViolationCount(v *int) *UserCreate {
+	if v != nil {
+		_c.SetPromptViolationCount(*v)
+	}
+	return _c
+}
+
 // SetUsername sets the "username" field.
 func (_c *UserCreate) SetUsername(v string) *UserCreate {
 	_c.mutation.SetUsername(v)
@@ -586,6 +600,10 @@ func (_c *UserCreate) defaults() error {
 		v := user.DefaultStatus
 		_c.mutation.SetStatus(v)
 	}
+	if _, ok := _c.mutation.PromptViolationCount(); !ok {
+		v := user.DefaultPromptViolationCount
+		_c.mutation.SetPromptViolationCount(v)
+	}
 	if _, ok := _c.mutation.Username(); !ok {
 		v := user.DefaultUsername
 		_c.mutation.SetUsername(v)
@@ -670,6 +688,9 @@ func (_c *UserCreate) check() error {
 		if err := user.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "User.status": %w`, err)}
 		}
+	}
+	if _, ok := _c.mutation.PromptViolationCount(); !ok {
+		return &ValidationError{Name: "prompt_violation_count", err: errors.New(`ent: missing required field "User.prompt_violation_count"`)}
 	}
 	if _, ok := _c.mutation.Username(); !ok {
 		return &ValidationError{Name: "username", err: errors.New(`ent: missing required field "User.username"`)}
@@ -770,6 +791,10 @@ func (_c *UserCreate) createSpec() (*User, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Status(); ok {
 		_spec.SetField(user.FieldStatus, field.TypeString, value)
 		_node.Status = value
+	}
+	if value, ok := _c.mutation.PromptViolationCount(); ok {
+		_spec.SetField(user.FieldPromptViolationCount, field.TypeInt, value)
+		_node.PromptViolationCount = value
 	}
 	if value, ok := _c.mutation.Username(); ok {
 		_spec.SetField(user.FieldUsername, field.TypeString, value)
@@ -1189,6 +1214,24 @@ func (u *UserUpsert) UpdateStatus() *UserUpsert {
 	return u
 }
 
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (u *UserUpsert) SetPromptViolationCount(v int) *UserUpsert {
+	u.Set(user.FieldPromptViolationCount, v)
+	return u
+}
+
+// UpdatePromptViolationCount sets the "prompt_violation_count" field to the value that was provided on create.
+func (u *UserUpsert) UpdatePromptViolationCount() *UserUpsert {
+	u.SetExcluded(user.FieldPromptViolationCount)
+	return u
+}
+
+// AddPromptViolationCount adds v to the "prompt_violation_count" field.
+func (u *UserUpsert) AddPromptViolationCount(v int) *UserUpsert {
+	u.Add(user.FieldPromptViolationCount, v)
+	return u
+}
+
 // SetUsername sets the "username" field.
 func (u *UserUpsert) SetUsername(v string) *UserUpsert {
 	u.Set(user.FieldUsername, v)
@@ -1580,6 +1623,27 @@ func (u *UserUpsertOne) SetStatus(v string) *UserUpsertOne {
 func (u *UserUpsertOne) UpdateStatus() *UserUpsertOne {
 	return u.Update(func(s *UserUpsert) {
 		s.UpdateStatus()
+	})
+}
+
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (u *UserUpsertOne) SetPromptViolationCount(v int) *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.SetPromptViolationCount(v)
+	})
+}
+
+// AddPromptViolationCount adds v to the "prompt_violation_count" field.
+func (u *UserUpsertOne) AddPromptViolationCount(v int) *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.AddPromptViolationCount(v)
+	})
+}
+
+// UpdatePromptViolationCount sets the "prompt_violation_count" field to the value that was provided on create.
+func (u *UserUpsertOne) UpdatePromptViolationCount() *UserUpsertOne {
+	return u.Update(func(s *UserUpsert) {
+		s.UpdatePromptViolationCount()
 	})
 }
 
@@ -2176,6 +2240,27 @@ func (u *UserUpsertBulk) SetStatus(v string) *UserUpsertBulk {
 func (u *UserUpsertBulk) UpdateStatus() *UserUpsertBulk {
 	return u.Update(func(s *UserUpsert) {
 		s.UpdateStatus()
+	})
+}
+
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (u *UserUpsertBulk) SetPromptViolationCount(v int) *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.SetPromptViolationCount(v)
+	})
+}
+
+// AddPromptViolationCount adds v to the "prompt_violation_count" field.
+func (u *UserUpsertBulk) AddPromptViolationCount(v int) *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.AddPromptViolationCount(v)
+	})
+}
+
+// UpdatePromptViolationCount sets the "prompt_violation_count" field to the value that was provided on create.
+func (u *UserUpsertBulk) UpdatePromptViolationCount() *UserUpsertBulk {
+	return u.Update(func(s *UserUpsert) {
+		s.UpdatePromptViolationCount()
 	})
 }
 

--- a/backend/ent/user_update.go
+++ b/backend/ent/user_update.go
@@ -163,6 +163,27 @@ func (_u *UserUpdate) SetNillableStatus(v *string) *UserUpdate {
 	return _u
 }
 
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (_u *UserUpdate) SetPromptViolationCount(v int) *UserUpdate {
+	_u.mutation.ResetPromptViolationCount()
+	_u.mutation.SetPromptViolationCount(v)
+	return _u
+}
+
+// SetNillablePromptViolationCount sets the "prompt_violation_count" field if the given value is not nil.
+func (_u *UserUpdate) SetNillablePromptViolationCount(v *int) *UserUpdate {
+	if v != nil {
+		_u.SetPromptViolationCount(*v)
+	}
+	return _u
+}
+
+// AddPromptViolationCount adds value to the "prompt_violation_count" field.
+func (_u *UserUpdate) AddPromptViolationCount(v int) *UserUpdate {
+	_u.mutation.AddPromptViolationCount(v)
+	return _u
+}
+
 // SetUsername sets the "username" field.
 func (_u *UserUpdate) SetUsername(v string) *UserUpdate {
 	_u.mutation.SetUsername(v)
@@ -969,6 +990,12 @@ func (_u *UserUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(user.FieldStatus, field.TypeString, value)
 	}
+	if value, ok := _u.mutation.PromptViolationCount(); ok {
+		_spec.SetField(user.FieldPromptViolationCount, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedPromptViolationCount(); ok {
+		_spec.AddField(user.FieldPromptViolationCount, field.TypeInt, value)
+	}
 	if value, ok := _u.mutation.Username(); ok {
 		_spec.SetField(user.FieldUsername, field.TypeString, value)
 	}
@@ -1728,6 +1755,27 @@ func (_u *UserUpdateOne) SetNillableStatus(v *string) *UserUpdateOne {
 	if v != nil {
 		_u.SetStatus(*v)
 	}
+	return _u
+}
+
+// SetPromptViolationCount sets the "prompt_violation_count" field.
+func (_u *UserUpdateOne) SetPromptViolationCount(v int) *UserUpdateOne {
+	_u.mutation.ResetPromptViolationCount()
+	_u.mutation.SetPromptViolationCount(v)
+	return _u
+}
+
+// SetNillablePromptViolationCount sets the "prompt_violation_count" field if the given value is not nil.
+func (_u *UserUpdateOne) SetNillablePromptViolationCount(v *int) *UserUpdateOne {
+	if v != nil {
+		_u.SetPromptViolationCount(*v)
+	}
+	return _u
+}
+
+// AddPromptViolationCount adds value to the "prompt_violation_count" field.
+func (_u *UserUpdateOne) AddPromptViolationCount(v int) *UserUpdateOne {
+	_u.mutation.AddPromptViolationCount(v)
 	return _u
 }
 
@@ -2566,6 +2614,12 @@ func (_u *UserUpdateOne) sqlSave(ctx context.Context) (_node *User, err error) {
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(user.FieldStatus, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.PromptViolationCount(); ok {
+		_spec.SetField(user.FieldPromptViolationCount, field.TypeInt, value)
+	}
+	if value, ok := _u.mutation.AddedPromptViolationCount(); ok {
+		_spec.AddField(user.FieldPromptViolationCount, field.TypeInt, value)
 	}
 	if value, ok := _u.mutation.Username(); ok {
 		_spec.SetField(user.FieldUsername, field.TypeString, value)

--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -195,6 +195,11 @@ func (h *SettingHandler) GetSettings(c *gin.Context) {
 		FallbackModelAntigravity:               settings.FallbackModelAntigravity,
 		EnableIdentityPatch:                    settings.EnableIdentityPatch,
 		IdentityPatchPrompt:                    settings.IdentityPatchPrompt,
+		PromptFilterEnabled:                    settings.PromptFilterEnabled,
+		PromptFilterKeywords:                   settings.PromptFilterKeywords,
+		PromptFilterViolationLimit:             settings.PromptFilterViolationLimit,
+		PromptFilterWarningMessage:             settings.PromptFilterWarningMessage,
+		PromptFilterBanMessage:                 settings.PromptFilterBanMessage,
 		OpsMonitoringEnabled:                   opsEnabled && settings.OpsMonitoringEnabled,
 		OpsRealtimeMonitoringEnabled:           settings.OpsRealtimeMonitoringEnabled,
 		OpsQueryModeDefault:                    settings.OpsQueryModeDefault,
@@ -376,6 +381,13 @@ type UpdateSettingsRequest struct {
 	// Identity patch configuration (Claude -> Gemini)
 	EnableIdentityPatch bool   `json:"enable_identity_patch"`
 	IdentityPatchPrompt string `json:"identity_patch_prompt"`
+
+	// Prompt keyword filter
+	PromptFilterEnabled        *bool     `json:"prompt_filter_enabled"`
+	PromptFilterKeywords       *[]string `json:"prompt_filter_keywords"`
+	PromptFilterViolationLimit *int      `json:"prompt_filter_violation_limit"`
+	PromptFilterWarningMessage *string   `json:"prompt_filter_warning_message"`
+	PromptFilterBanMessage     *string   `json:"prompt_filter_ban_message"`
 
 	// Ops monitoring (vNext)
 	OpsMonitoringEnabled         *bool   `json:"ops_monitoring_enabled"`
@@ -1146,6 +1158,11 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		FallbackModelAntigravity:         req.FallbackModelAntigravity,
 		EnableIdentityPatch:              req.EnableIdentityPatch,
 		IdentityPatchPrompt:              req.IdentityPatchPrompt,
+		PromptFilterEnabled:              boolValueOrDefault(req.PromptFilterEnabled, previousSettings.PromptFilterEnabled),
+		PromptFilterKeywords:             stringSliceValueOrDefault(req.PromptFilterKeywords, previousSettings.PromptFilterKeywords),
+		PromptFilterViolationLimit:       intValueOrDefault(req.PromptFilterViolationLimit, previousSettings.PromptFilterViolationLimit),
+		PromptFilterWarningMessage:       stringValueOrDefault(req.PromptFilterWarningMessage, previousSettings.PromptFilterWarningMessage),
+		PromptFilterBanMessage:           stringValueOrDefault(req.PromptFilterBanMessage, previousSettings.PromptFilterBanMessage),
 		MinClaudeCodeVersion:             req.MinClaudeCodeVersion,
 		MaxClaudeCodeVersion:             req.MaxClaudeCodeVersion,
 		AllowUngroupedKeyScheduling:      req.AllowUngroupedKeyScheduling,
@@ -1467,6 +1484,11 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		FallbackModelAntigravity:               updatedSettings.FallbackModelAntigravity,
 		EnableIdentityPatch:                    updatedSettings.EnableIdentityPatch,
 		IdentityPatchPrompt:                    updatedSettings.IdentityPatchPrompt,
+		PromptFilterEnabled:                    updatedSettings.PromptFilterEnabled,
+		PromptFilterKeywords:                   updatedSettings.PromptFilterKeywords,
+		PromptFilterViolationLimit:             updatedSettings.PromptFilterViolationLimit,
+		PromptFilterWarningMessage:             updatedSettings.PromptFilterWarningMessage,
+		PromptFilterBanMessage:                 updatedSettings.PromptFilterBanMessage,
 		OpsMonitoringEnabled:                   updatedSettings.OpsMonitoringEnabled,
 		OpsRealtimeMonitoringEnabled:           updatedSettings.OpsRealtimeMonitoringEnabled,
 		OpsQueryModeDefault:                    updatedSettings.OpsQueryModeDefault,
@@ -1792,6 +1814,21 @@ func diffSettings(before *service.SystemSettings, after *service.SystemSettings,
 	if before.IdentityPatchPrompt != after.IdentityPatchPrompt {
 		changed = append(changed, "identity_patch_prompt")
 	}
+	if before.PromptFilterEnabled != after.PromptFilterEnabled {
+		changed = append(changed, "prompt_filter_enabled")
+	}
+	if !equalStringSlice(before.PromptFilterKeywords, after.PromptFilterKeywords) {
+		changed = append(changed, "prompt_filter_keywords")
+	}
+	if before.PromptFilterViolationLimit != after.PromptFilterViolationLimit {
+		changed = append(changed, "prompt_filter_violation_limit")
+	}
+	if before.PromptFilterWarningMessage != after.PromptFilterWarningMessage {
+		changed = append(changed, "prompt_filter_warning_message")
+	}
+	if before.PromptFilterBanMessage != after.PromptFilterBanMessage {
+		changed = append(changed, "prompt_filter_ban_message")
+	}
 	if before.OpsMonitoringEnabled != after.OpsMonitoringEnabled {
 		changed = append(changed, "ops_monitoring_enabled")
 	}
@@ -1973,6 +2010,20 @@ func intValueOrDefault(value *int, fallback int) int {
 }
 
 func boolValueOrDefault(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func stringValueOrDefault(value *string, fallback string) string {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func stringSliceValueOrDefault(value *[]string, fallback []string) []string {
 	if value == nil {
 		return fallback
 	}

--- a/backend/internal/handler/auth_oauth_pending_flow_test.go
+++ b/backend/internal/handler/auth_oauth_pending_flow_test.go
@@ -2811,6 +2811,10 @@ func (r *oauthPendingFlowUserRepo) ExistsByEmail(ctx context.Context, email stri
 	return count > 0, err
 }
 
+func (r *oauthPendingFlowUserRepo) IncrementPromptViolationCount(context.Context, int64, int) (int, bool, error) {
+	panic("unexpected IncrementPromptViolationCount call")
+}
+
 func (r *oauthPendingFlowUserRepo) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {
 	panic("unexpected RemoveGroupFromAllowedGroups call")
 }

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -123,6 +123,13 @@ type SystemSettings struct {
 	EnableIdentityPatch bool   `json:"enable_identity_patch"`
 	IdentityPatchPrompt string `json:"identity_patch_prompt"`
 
+	// Prompt keyword filter
+	PromptFilterEnabled        bool     `json:"prompt_filter_enabled"`
+	PromptFilterKeywords       []string `json:"prompt_filter_keywords"`
+	PromptFilterViolationLimit int      `json:"prompt_filter_violation_limit"`
+	PromptFilterWarningMessage string   `json:"prompt_filter_warning_message"`
+	PromptFilterBanMessage     string   `json:"prompt_filter_ban_message"`
+
 	// Ops monitoring (vNext)
 	OpsMonitoringEnabled         bool   `json:"ops_monitoring_enabled"`
 	OpsRealtimeMonitoringEnabled bool   `json:"ops_realtime_monitoring_enabled"`

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -158,6 +158,12 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	reqStream := parsedReq.Stream
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
 
+	if h.enforcePromptFilter(c, body, "", func(status int, errorType string, message string) {
+		h.errorResponse(c, status, errorType, message)
+	}) {
+		return
+	}
+
 	// 解析渠道级模型映射
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
 

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -78,6 +78,12 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	reqStream := gjson.GetBytes(body, "stream").Bool()
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
 
+	if h.enforcePromptFilter(c, body, "", func(status int, errorType string, message string) {
+		h.chatCompletionsErrorResponse(c, status, errorType, message)
+	}) {
+		return
+	}
+
 	setOpsRequestContext(c, reqModel, reqStream, body)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
 

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -182,6 +182,12 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		return
 	}
 
+	if h.enforcePromptFilter(c, body, "", func(status int, _ string, message string) {
+		googleError(c, status, message)
+	}) {
+		return
+	}
+
 	setOpsRequestContext(c, modelName, stream, body)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(stream, false)))
 

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -35,6 +35,7 @@ type OpenAIGatewayHandler struct {
 	concurrencyHelper       *ConcurrencyHelper
 	maxAccountSwitches      int
 	cfg                     *config.Config
+	settingService          *service.SettingService
 }
 
 func resolveOpenAIForwardDefaultMappedModel(apiKey *service.APIKey, fallbackModel string) string {
@@ -62,6 +63,7 @@ func NewOpenAIGatewayHandler(
 	apiKeyService *service.APIKeyService,
 	usageRecordWorkerPool *service.UsageRecordWorkerPool,
 	errorPassthroughService *service.ErrorPassthroughService,
+	settingService *service.SettingService,
 	cfg *config.Config,
 ) *OpenAIGatewayHandler {
 	pingInterval := time.Duration(0)
@@ -81,6 +83,7 @@ func NewOpenAIGatewayHandler(
 		concurrencyHelper:       NewConcurrencyHelper(concurrencyService, SSEPingFormatComment, pingInterval),
 		maxAccountSwitches:      maxAccountSwitches,
 		cfg:                     cfg,
+		settingService:          settingService,
 	}
 }
 
@@ -154,6 +157,12 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 校验请求体 JSON 合法性
 	if !gjson.ValidBytes(body) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+		return
+	}
+
+	if h.enforcePromptFilter(c, body, "", func(status int, errorType string, message string) {
+		h.errorResponse(c, status, errorType, message)
+	}) {
 		return
 	}
 
@@ -562,6 +571,12 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 
 	if !gjson.ValidBytes(body) {
 		h.anthropicErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+		return
+	}
+
+	if h.enforcePromptFilter(c, body, "", func(status int, errorType string, message string) {
+		h.anthropicErrorResponse(c, status, errorType, message)
+	}) {
 		return
 	}
 

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -81,6 +81,12 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		zap.String("capability", string(parsed.RequiredCapability)),
 	)
 
+	if h.enforcePromptFilter(c, nil, parsed.Prompt, func(status int, errorType string, message string) {
+		h.errorResponse(c, status, errorType, message)
+	}) {
+		return
+	}
+
 	if parsed.Multipart {
 		setOpsRequestContext(c, parsed.Model, parsed.Stream, nil)
 	} else {

--- a/backend/internal/handler/prompt_filter.go
+++ b/backend/internal/handler/prompt_filter.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+type promptFilterErrorWriter func(status int, errorType string, message string)
+
+func (h *GatewayHandler) enforcePromptFilter(c *gin.Context, body []byte, explicitPrompt string, writeError promptFilterErrorWriter) bool {
+	if h == nil {
+		return false
+	}
+	return enforcePromptFilter(c, h.settingService, h.apiKeyService, body, explicitPrompt, writeError)
+}
+
+func (h *OpenAIGatewayHandler) enforcePromptFilter(c *gin.Context, body []byte, explicitPrompt string, writeError promptFilterErrorWriter) bool {
+	if h == nil {
+		return false
+	}
+	return enforcePromptFilter(c, h.settingService, h.apiKeyService, body, explicitPrompt, writeError)
+}
+
+func enforcePromptFilter(c *gin.Context, settingService *service.SettingService, apiKeyService *service.APIKeyService, body []byte, explicitPrompt string, writeError promptFilterErrorWriter) bool {
+	if c == nil || settingService == nil || writeError == nil {
+		return false
+	}
+
+	runtime := settingService.GetPromptFilterRuntime(c.Request.Context())
+	if !runtime.Enabled || len(runtime.Keywords) == 0 {
+		return false
+	}
+
+	var parts []string
+	if prompt := strings.TrimSpace(explicitPrompt); prompt != "" {
+		parts = append(parts, prompt)
+	}
+	if len(body) > 0 {
+		if prompt := service.PromptTextFromJSON(body); strings.TrimSpace(prompt) != "" {
+			parts = append(parts, prompt)
+		}
+	}
+	if !service.PromptFilterContainsKeyword(strings.Join(parts, "\n"), runtime.Keywords) {
+		return false
+	}
+
+	userID := int64(0)
+	if subject, ok := middleware.GetAuthSubjectFromContext(c); ok {
+		userID = subject.UserID
+	}
+	count := 0
+	disabled := false
+	if apiKeyService != nil && userID > 0 {
+		var err error
+		count, disabled, err = apiKeyService.RecordPromptViolation(c.Request.Context(), userID, runtime.ViolationLimit)
+		if err != nil {
+			slog.Warn("failed to record prompt filter violation", "user_id", userID, "error", err)
+		}
+	}
+
+	message := runtime.WarningMessage
+	if disabled {
+		message = runtime.BanMessage
+	}
+	if strings.TrimSpace(message) == "" {
+		if disabled {
+			message = service.DefaultPromptFilterBanMessage
+		} else {
+			message = service.DefaultPromptFilterWarningMessage
+		}
+	}
+
+	slog.Warn("prompt filter violation blocked", "user_id", userID, "violation_count", count, "disabled", disabled)
+	writeError(http.StatusForbidden, "policy_violation", message)
+	return true
+}

--- a/backend/internal/handler/user_handler_test.go
+++ b/backend/internal/handler/user_handler_test.go
@@ -88,6 +88,9 @@ func (s *userHandlerRepoStub) UpdateBalance(context.Context, int64, float64) err
 func (s *userHandlerRepoStub) DeductBalance(context.Context, int64, float64) error { return nil }
 func (s *userHandlerRepoStub) UpdateConcurrency(context.Context, int64, int) error { return nil }
 func (s *userHandlerRepoStub) ExistsByEmail(context.Context, string) (bool, error) { return false, nil }
+func (s *userHandlerRepoStub) IncrementPromptViolationCount(context.Context, int64, int) (int, bool, error) {
+	return 0, false, nil
+}
 func (s *userHandlerRepoStub) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {
 	return 0, nil
 }
@@ -270,19 +273,19 @@ func TestUserHandlerGetProfileReturnsLegacyCompatibilityFields(t *testing.T) {
 			AvatarURL:    "https://cdn.example.com/linuxdo.png",
 			AvatarSource: "remote_url",
 		},
-			identities: []service.UserAuthIdentityRecord{
-				{
-					ProviderType:    "linuxdo",
-					ProviderKey:     "linuxdo",
-					ProviderSubject: "linuxdo-subject-21",
-					VerifiedAt:      &verifiedAt,
-					Metadata: map[string]any{
-						"username":   "linuxdo-handle",
-						"avatar_url": "https://cdn.example.com/linuxdo.png",
-					},
+		identities: []service.UserAuthIdentityRecord{
+			{
+				ProviderType:    "linuxdo",
+				ProviderKey:     "linuxdo",
+				ProviderSubject: "linuxdo-subject-21",
+				VerifiedAt:      &verifiedAt,
+				Metadata: map[string]any{
+					"username":   "linuxdo-handle",
+					"avatar_url": "https://cdn.example.com/linuxdo.png",
 				},
 			},
-		}
+		},
+	}
 	handler := NewUserHandler(service.NewUserService(repo, nil, nil, nil), nil, nil, nil, nil)
 
 	recorder := httptest.NewRecorder()

--- a/backend/internal/repository/user_repo.go
+++ b/backend/internal/repository/user_repo.go
@@ -256,6 +256,41 @@ func (r *userRepository) Update(ctx context.Context, userIn *service.User) error
 	return nil
 }
 
+func (r *userRepository) IncrementPromptViolationCount(ctx context.Context, userID int64, limit int) (int, bool, error) {
+	if userID <= 0 {
+		return 0, false, service.ErrUserNotFound
+	}
+	if limit <= 0 {
+		limit = service.DefaultPromptFilterViolationLimit
+	}
+	exec := txAwareSQLExecutor(ctx, r.sql, r.client)
+	if exec == nil {
+		return 0, false, fmt.Errorf("sql executor is not configured")
+	}
+
+	var count int
+	var disabled bool
+	err := scanSingleRow(ctx, exec, `
+UPDATE users
+SET prompt_violation_count = prompt_violation_count + 1,
+    status = CASE
+        WHEN prompt_violation_count + 1 >= $2 THEN $3
+        ELSE status
+    END,
+    updated_at = NOW()
+WHERE id = $1
+  AND deleted_at IS NULL
+RETURNING prompt_violation_count, status = $3
+`, []any{userID, limit, service.StatusDisabled}, &count, &disabled)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, service.ErrUserNotFound
+		}
+		return 0, false, err
+	}
+	return count, disabled, nil
+}
+
 func ensureEmailAuthIdentityWithClient(ctx context.Context, client *dbent.Client, userID int64, email string, source string) error {
 	client = clientFromContext(ctx, client)
 	if client == nil || userID <= 0 {

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -642,6 +642,11 @@ func TestAPIContracts(t *testing.T) {
 					"email_verify_enabled": false,
 					"registration_email_suffix_whitelist": [],
 					"promo_code_enabled": true,
+					"prompt_filter_enabled": false,
+					"prompt_filter_keywords": [],
+					"prompt_filter_violation_limit": 10,
+					"prompt_filter_warning_message": "请求包含违规关键词，已被拦截。",
+					"prompt_filter_ban_message": "账号因多次提交违规内容已被禁用。",
 					"password_reset_enabled": false,
 					"frontend_url": "",
 					"totp_enabled": false,
@@ -840,6 +845,11 @@ func TestAPIContracts(t *testing.T) {
 					"email_verify_enabled": false,
 					"registration_email_suffix_whitelist": [],
 					"promo_code_enabled": true,
+					"prompt_filter_enabled": false,
+					"prompt_filter_keywords": [],
+					"prompt_filter_violation_limit": 10,
+					"prompt_filter_warning_message": "请求包含违规关键词，已被拦截。",
+					"prompt_filter_ban_message": "账号因多次提交违规内容已被禁用。",
 					"password_reset_enabled": false,
 					"frontend_url": "",
 					"invitation_code_enabled": false,
@@ -1265,6 +1275,10 @@ func (r *stubUserRepo) UpdateConcurrency(ctx context.Context, id int64, amount i
 
 func (r *stubUserRepo) ExistsByEmail(ctx context.Context, email string) (bool, error) {
 	return false, errors.New("not implemented")
+}
+
+func (r *stubUserRepo) IncrementPromptViolationCount(ctx context.Context, userID int64, limit int) (int, bool, error) {
+	return 0, false, errors.New("not implemented")
 }
 
 func (r *stubUserRepo) RemoveGroupFromAllowedGroups(ctx context.Context, groupID int64) (int64, error) {

--- a/backend/internal/server/middleware/admin_auth_test.go
+++ b/backend/internal/server/middleware/admin_auth_test.go
@@ -202,6 +202,10 @@ func (s *stubUserRepo) ExistsByEmail(ctx context.Context, email string) (bool, e
 	panic("unexpected ExistsByEmail call")
 }
 
+func (s *stubUserRepo) IncrementPromptViolationCount(ctx context.Context, userID int64, limit int) (int, bool, error) {
+	panic("unexpected IncrementPromptViolationCount call")
+}
+
 func (s *stubUserRepo) RemoveGroupFromAllowedGroups(ctx context.Context, groupID int64) (int64, error) {
 	panic("unexpected RemoveGroupFromAllowedGroups call")
 }

--- a/backend/internal/service/admin_service_apikey_test.go
+++ b/backend/internal/service/admin_service_apikey_test.go
@@ -71,6 +71,9 @@ func (s *userRepoStubForGroupUpdate) UpdateConcurrency(context.Context, int64, i
 func (s *userRepoStubForGroupUpdate) ExistsByEmail(context.Context, string) (bool, error) {
 	panic("unexpected")
 }
+func (s *userRepoStubForGroupUpdate) IncrementPromptViolationCount(context.Context, int64, int) (int, bool, error) {
+	panic("unexpected")
+}
 func (s *userRepoStubForGroupUpdate) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {
 	panic("unexpected")
 }

--- a/backend/internal/service/admin_service_delete_test.go
+++ b/backend/internal/service/admin_service_delete_test.go
@@ -138,6 +138,10 @@ func (s *userRepoStub) ExistsByEmail(ctx context.Context, email string) (bool, e
 	return s.exists, nil
 }
 
+func (s *userRepoStub) IncrementPromptViolationCount(ctx context.Context, userID int64, limit int) (int, bool, error) {
+	panic("unexpected IncrementPromptViolationCount call")
+}
+
 func (s *userRepoStub) RemoveGroupFromAllowedGroups(ctx context.Context, groupID int64) (int64, error) {
 	panic("unexpected RemoveGroupFromAllowedGroups call")
 }

--- a/backend/internal/service/admin_service_email_identity_sync_test.go
+++ b/backend/internal/service/admin_service_email_identity_sync_test.go
@@ -109,6 +109,10 @@ func (s *emailSyncRepoStub) UpdateConcurrency(context.Context, int64, int) error
 
 func (s *emailSyncRepoStub) ExistsByEmail(context.Context, string) (bool, error) { return false, nil }
 
+func (s *emailSyncRepoStub) IncrementPromptViolationCount(context.Context, int64, int) (int, bool, error) {
+	return 0, false, fmt.Errorf("unexpected IncrementPromptViolationCount call")
+}
+
 func (s *emailSyncRepoStub) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {
 	return 0, nil
 }

--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -237,6 +237,26 @@ func (s *APIKeyService) SetRateLimitCacheInvalidator(inv RateLimitCacheInvalidat
 	s.rateLimitCacheInvalid = inv
 }
 
+func (s *APIKeyService) RecordPromptViolation(ctx context.Context, userID int64, limit int) (int, bool, error) {
+	if s == nil || s.userRepo == nil {
+		return 0, false, nil
+	}
+	if userID <= 0 {
+		return 0, false, nil
+	}
+	if limit <= 0 {
+		limit = DefaultPromptFilterViolationLimit
+	}
+	count, disabled, err := s.userRepo.IncrementPromptViolationCount(ctx, userID, limit)
+	if err != nil {
+		return count, disabled, err
+	}
+	if disabled {
+		s.InvalidateAuthCacheByUserID(ctx, userID)
+	}
+	return count, disabled, nil
+}
+
 func (s *APIKeyService) compileAPIKeyIPRules(apiKey *APIKey) {
 	if apiKey == nil {
 		return

--- a/backend/internal/service/auth_service_email_bind_test.go
+++ b/backend/internal/service/auth_service_email_bind_test.go
@@ -810,14 +810,18 @@ func (s *emailBindUserRepoStub) UpdateUserLastActiveAt(context.Context, int64, t
 }
 
 func (s *emailBindUserRepoStub) UpdateBalance(context.Context, int64, float64) error { return nil }
-func (s *emailBindUserRepoStub) DeductBalance(context.Context, int64, float64) error  { return nil }
-func (s *emailBindUserRepoStub) UpdateConcurrency(context.Context, int64, int) error   { return nil }
+func (s *emailBindUserRepoStub) DeductBalance(context.Context, int64, float64) error { return nil }
+func (s *emailBindUserRepoStub) UpdateConcurrency(context.Context, int64, int) error { return nil }
 
 func (s *emailBindUserRepoStub) ExistsByEmail(_ context.Context, email string) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	_, ok := s.usersByEmail[email]
 	return ok, nil
+}
+
+func (s *emailBindUserRepoStub) IncrementPromptViolationCount(context.Context, int64, int) (int, bool, error) {
+	return 0, false, nil
 }
 
 func (s *emailBindUserRepoStub) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -225,6 +225,13 @@ const (
 	SettingKeyEnableIdentityPatch = "enable_identity_patch"
 	SettingKeyIdentityPatchPrompt = "identity_patch_prompt"
 
+	// Prompt keyword filter
+	SettingKeyPromptFilterEnabled        = "prompt_filter_enabled"
+	SettingKeyPromptFilterKeywords       = "prompt_filter_keywords"
+	SettingKeyPromptFilterViolationLimit = "prompt_filter_violation_limit"
+	SettingKeyPromptFilterWarningMessage = "prompt_filter_warning_message"
+	SettingKeyPromptFilterBanMessage     = "prompt_filter_ban_message"
+
 	// =========================
 	// Ops Monitoring (vNext)
 	// =========================

--- a/backend/internal/service/prompt_filter.go
+++ b/backend/internal/service/prompt_filter.go
@@ -1,0 +1,230 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	DefaultPromptFilterViolationLimit = 10
+	DefaultPromptFilterWarningMessage = "请求包含违规关键词，已被拦截。"
+	DefaultPromptFilterBanMessage     = "账号因多次提交违规内容已被禁用。"
+
+	promptFilterCacheTTL   = 60 * time.Second
+	promptFilterErrorTTL   = 5 * time.Second
+	promptFilterDBTimeout  = 5 * time.Second
+	promptFilterCacheKey   = "prompt_filter"
+	promptFilterMaxTextLen = 1 << 20
+)
+
+type PromptFilterRuntime struct {
+	Enabled        bool
+	Keywords       []string
+	ViolationLimit int
+	WarningMessage string
+	BanMessage     string
+}
+
+type cachedPromptFilterRuntime struct {
+	runtime   PromptFilterRuntime
+	expiresAt int64
+}
+
+var promptFilterRuntimeCache atomic.Value // *cachedPromptFilterRuntime
+var promptFilterRuntimeSF singleflight.Group
+
+func DefaultPromptFilterRuntime() PromptFilterRuntime {
+	return PromptFilterRuntime{
+		Enabled:        false,
+		Keywords:       []string{},
+		ViolationLimit: DefaultPromptFilterViolationLimit,
+		WarningMessage: DefaultPromptFilterWarningMessage,
+		BanMessage:     DefaultPromptFilterBanMessage,
+	}
+}
+
+func ParsePromptFilterRuntime(settings map[string]string) PromptFilterRuntime {
+	runtime := DefaultPromptFilterRuntime()
+	if settings == nil {
+		return runtime
+	}
+	runtime.Enabled = settings[SettingKeyPromptFilterEnabled] == "true"
+	runtime.Keywords = parsePromptFilterKeywords(settings[SettingKeyPromptFilterKeywords])
+	runtime.ViolationLimit = parsePromptFilterViolationLimit(settings[SettingKeyPromptFilterViolationLimit])
+	if message := strings.TrimSpace(settings[SettingKeyPromptFilterWarningMessage]); message != "" {
+		runtime.WarningMessage = message
+	}
+	if message := strings.TrimSpace(settings[SettingKeyPromptFilterBanMessage]); message != "" {
+		runtime.BanMessage = message
+	}
+	return runtime
+}
+
+func NormalizePromptFilterKeywords(input []string) []string {
+	if len(input) == 0 {
+		return []string{}
+	}
+	seen := make(map[string]struct{}, len(input))
+	out := make([]string, 0, len(input))
+	for _, keyword := range input {
+		keyword = strings.TrimSpace(keyword)
+		if keyword == "" {
+			continue
+		}
+		key := strings.ToLower(keyword)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, keyword)
+	}
+	return out
+}
+
+func parsePromptFilterKeywords(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return []string{}
+	}
+	var items []string
+	if err := json.Unmarshal([]byte(raw), &items); err == nil {
+		return NormalizePromptFilterKeywords(items)
+	}
+	items = strings.FieldsFunc(raw, func(r rune) bool {
+		return r == '\n' || r == '\r' || r == ',' || r == '，' || r == ';' || r == '；'
+	})
+	return NormalizePromptFilterKeywords(items)
+}
+
+func parsePromptFilterViolationLimit(raw string) int {
+	v, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || v <= 0 {
+		return DefaultPromptFilterViolationLimit
+	}
+	return v
+}
+
+func (s *SettingService) GetPromptFilterRuntime(ctx context.Context) PromptFilterRuntime {
+	if s == nil || s.settingRepo == nil {
+		return DefaultPromptFilterRuntime()
+	}
+	if cached, ok := promptFilterRuntimeCache.Load().(*cachedPromptFilterRuntime); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.runtime
+		}
+	}
+	result, _, _ := promptFilterRuntimeSF.Do(promptFilterCacheKey, func() (any, error) {
+		if cached, ok := promptFilterRuntimeCache.Load().(*cachedPromptFilterRuntime); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.runtime, nil
+			}
+		}
+		dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), promptFilterDBTimeout)
+		defer cancel()
+		settings, err := s.settingRepo.GetMultiple(dbCtx, []string{
+			SettingKeyPromptFilterEnabled,
+			SettingKeyPromptFilterKeywords,
+			SettingKeyPromptFilterViolationLimit,
+			SettingKeyPromptFilterWarningMessage,
+			SettingKeyPromptFilterBanMessage,
+		})
+		if err != nil {
+			runtime := DefaultPromptFilterRuntime()
+			if !errors.Is(err, ErrSettingNotFound) {
+				slog.Warn("failed to get prompt filter settings", "error", err)
+			}
+			promptFilterRuntimeCache.Store(&cachedPromptFilterRuntime{
+				runtime:   runtime,
+				expiresAt: time.Now().Add(promptFilterErrorTTL).UnixNano(),
+			})
+			return runtime, nil
+		}
+		runtime := ParsePromptFilterRuntime(settings)
+		promptFilterRuntimeCache.Store(&cachedPromptFilterRuntime{
+			runtime:   runtime,
+			expiresAt: time.Now().Add(promptFilterCacheTTL).UnixNano(),
+		})
+		return runtime, nil
+	})
+	if runtime, ok := result.(PromptFilterRuntime); ok {
+		return runtime
+	}
+	return DefaultPromptFilterRuntime()
+}
+
+func RefreshPromptFilterRuntimeCache(runtime PromptFilterRuntime) {
+	promptFilterRuntimeSF.Forget(promptFilterCacheKey)
+	promptFilterRuntimeCache.Store(&cachedPromptFilterRuntime{
+		runtime:   runtime,
+		expiresAt: time.Now().Add(promptFilterCacheTTL).UnixNano(),
+	})
+}
+
+func PromptFilterContainsKeyword(text string, keywords []string) bool {
+	text = strings.TrimSpace(text)
+	if text == "" || len(keywords) == 0 {
+		return false
+	}
+	if len(text) > promptFilterMaxTextLen {
+		text = text[:promptFilterMaxTextLen]
+	}
+	lowerText := strings.ToLower(text)
+	for _, keyword := range NormalizePromptFilterKeywords(keywords) {
+		if strings.Contains(lowerText, strings.ToLower(keyword)) {
+			return true
+		}
+	}
+	return false
+}
+
+func PromptTextFromJSON(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	var payload any
+	if err := decoder.Decode(&payload); err != nil {
+		return ""
+	}
+	parts := make([]string, 0, 8)
+	collectPromptText(payload, "", &parts)
+	return strings.Join(parts, "\n")
+}
+
+func collectPromptText(value any, key string, parts *[]string) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for childKey, child := range typed {
+			collectPromptText(child, strings.ToLower(strings.TrimSpace(childKey)), parts)
+		}
+	case []any:
+		for _, child := range typed {
+			collectPromptText(child, key, parts)
+		}
+	case string:
+		if isPromptTextKey(key) {
+			if text := strings.TrimSpace(typed); text != "" {
+				*parts = append(*parts, text)
+			}
+		}
+	}
+}
+
+func isPromptTextKey(key string) bool {
+	switch key {
+	case "prompt", "input", "instructions", "system", "content", "text":
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/prompt_filter_test.go
+++ b/backend/internal/service/prompt_filter_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptTextFromJSONExtractsCommonPromptShapes(t *testing.T) {
+	body := []byte(`{
+		"instructions": "system note",
+		"messages": [
+			{"role": "user", "content": "hello forbidden"},
+			{"role": "user", "content": [{"type": "text", "text": "gemini text"}]}
+		],
+		"contents": [{"parts": [{"text": "native gemini"}]}]
+	}`)
+
+	text := PromptTextFromJSON(body)
+	require.Contains(t, text, "system note")
+	require.Contains(t, text, "hello forbidden")
+	require.Contains(t, text, "gemini text")
+	require.Contains(t, text, "native gemini")
+}
+
+func TestPromptFilterContainsKeywordIsCaseInsensitive(t *testing.T) {
+	require.True(t, PromptFilterContainsKeyword("please BLOCK this", []string{"block"}))
+	require.True(t, PromptFilterContainsKeyword("请拦截这个词", []string{"拦截"}))
+	require.False(t, PromptFilterContainsKeyword("clean prompt", []string{"blocked"}))
+}
+
+func TestParsePromptFilterRuntimeDefaults(t *testing.T) {
+	runtime := ParsePromptFilterRuntime(map[string]string{
+		SettingKeyPromptFilterEnabled:        "true",
+		SettingKeyPromptFilterKeywords:       `[" One ","one","Two"]`,
+		SettingKeyPromptFilterViolationLimit: "0",
+	})
+
+	require.True(t, runtime.Enabled)
+	require.Equal(t, []string{"One", "Two"}, runtime.Keywords)
+	require.Equal(t, DefaultPromptFilterViolationLimit, runtime.ViolationLimit)
+	require.Equal(t, DefaultPromptFilterWarningMessage, runtime.WarningMessage)
+	require.Equal(t, DefaultPromptFilterBanMessage, runtime.BanMessage)
+}

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -1051,6 +1051,18 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	if settings.WeChatConnectFrontendRedirectURL == "" {
 		settings.WeChatConnectFrontendRedirectURL = defaultWeChatConnectFrontend
 	}
+	settings.PromptFilterKeywords = NormalizePromptFilterKeywords(settings.PromptFilterKeywords)
+	if settings.PromptFilterViolationLimit <= 0 {
+		settings.PromptFilterViolationLimit = DefaultPromptFilterViolationLimit
+	}
+	settings.PromptFilterWarningMessage = strings.TrimSpace(settings.PromptFilterWarningMessage)
+	if settings.PromptFilterWarningMessage == "" {
+		settings.PromptFilterWarningMessage = DefaultPromptFilterWarningMessage
+	}
+	settings.PromptFilterBanMessage = strings.TrimSpace(settings.PromptFilterBanMessage)
+	if settings.PromptFilterBanMessage == "" {
+		settings.PromptFilterBanMessage = DefaultPromptFilterBanMessage
+	}
 
 	updates := make(map[string]string)
 
@@ -1193,6 +1205,17 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	updates[SettingKeyEnableIdentityPatch] = strconv.FormatBool(settings.EnableIdentityPatch)
 	updates[SettingKeyIdentityPatchPrompt] = settings.IdentityPatchPrompt
 
+	// Prompt keyword filter
+	promptFilterKeywordsJSON, err := json.Marshal(settings.PromptFilterKeywords)
+	if err != nil {
+		return nil, fmt.Errorf("marshal prompt filter keywords: %w", err)
+	}
+	updates[SettingKeyPromptFilterEnabled] = strconv.FormatBool(settings.PromptFilterEnabled)
+	updates[SettingKeyPromptFilterKeywords] = string(promptFilterKeywordsJSON)
+	updates[SettingKeyPromptFilterViolationLimit] = strconv.Itoa(settings.PromptFilterViolationLimit)
+	updates[SettingKeyPromptFilterWarningMessage] = settings.PromptFilterWarningMessage
+	updates[SettingKeyPromptFilterBanMessage] = settings.PromptFilterBanMessage
+
 	// Ops monitoring (vNext)
 	updates[SettingKeyOpsMonitoringEnabled] = strconv.FormatBool(settings.OpsMonitoringEnabled)
 	updates[SettingKeyOpsRealtimeMonitoringEnabled] = strconv.FormatBool(settings.OpsRealtimeMonitoringEnabled)
@@ -1291,6 +1314,13 @@ func (s *SettingService) refreshCachedSettings(settings *SystemSettings) {
 		metadataPassthrough:    settings.EnableMetadataPassthrough,
 		cchSigning:             settings.EnableCCHSigning,
 		expiresAt:              time.Now().Add(gatewayForwardingCacheTTL).UnixNano(),
+	})
+	RefreshPromptFilterRuntimeCache(PromptFilterRuntime{
+		Enabled:        settings.PromptFilterEnabled,
+		Keywords:       NormalizePromptFilterKeywords(settings.PromptFilterKeywords),
+		ViolationLimit: parsePromptFilterViolationLimit(strconv.Itoa(settings.PromptFilterViolationLimit)),
+		WarningMessage: strings.TrimSpace(firstNonEmpty(settings.PromptFilterWarningMessage, DefaultPromptFilterWarningMessage)),
+		BanMessage:     strings.TrimSpace(firstNonEmpty(settings.PromptFilterBanMessage, DefaultPromptFilterBanMessage)),
 	})
 	openAIAdvancedSchedulerSettingSF.Forget(openAIAdvancedSchedulerSettingKey)
 	openAIAdvancedSchedulerSettingCache.Store(&cachedOpenAIAdvancedSchedulerSetting{
@@ -1790,6 +1820,13 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		SettingKeyEnableIdentityPatch: "true",
 		SettingKeyIdentityPatchPrompt: "",
 
+		// Prompt keyword filter defaults
+		SettingKeyPromptFilterEnabled:        "false",
+		SettingKeyPromptFilterKeywords:       "[]",
+		SettingKeyPromptFilterViolationLimit: strconv.Itoa(DefaultPromptFilterViolationLimit),
+		SettingKeyPromptFilterWarningMessage: DefaultPromptFilterWarningMessage,
+		SettingKeyPromptFilterBanMessage:     DefaultPromptFilterBanMessage,
+
 		// Ops monitoring defaults (vNext)
 		SettingKeyOpsMonitoringEnabled:         "true",
 		SettingKeyOpsRealtimeMonitoringEnabled: "true",
@@ -2099,6 +2136,14 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 		result.EnableIdentityPatch = true
 	}
 	result.IdentityPatchPrompt = settings[SettingKeyIdentityPatchPrompt]
+
+	// Prompt keyword filter
+	promptFilterRuntime := ParsePromptFilterRuntime(settings)
+	result.PromptFilterEnabled = promptFilterRuntime.Enabled
+	result.PromptFilterKeywords = promptFilterRuntime.Keywords
+	result.PromptFilterViolationLimit = promptFilterRuntime.ViolationLimit
+	result.PromptFilterWarningMessage = promptFilterRuntime.WarningMessage
+	result.PromptFilterBanMessage = promptFilterRuntime.BanMessage
 
 	// Ops monitoring settings (default: enabled, fail-open)
 	result.OpsMonitoringEnabled = !isFalseSettingValue(settings[SettingKeyOpsMonitoringEnabled])

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -122,6 +122,13 @@ type SystemSettings struct {
 	EnableIdentityPatch bool   `json:"enable_identity_patch"`
 	IdentityPatchPrompt string `json:"identity_patch_prompt"`
 
+	// Prompt keyword filter
+	PromptFilterEnabled        bool
+	PromptFilterKeywords       []string
+	PromptFilterViolationLimit int
+	PromptFilterWarningMessage string
+	PromptFilterBanMessage     string
+
 	// Ops monitoring (vNext)
 	OpsMonitoringEnabled         bool
 	OpsRealtimeMonitoringEnabled bool

--- a/backend/internal/service/user_service.go
+++ b/backend/internal/service/user_service.go
@@ -97,6 +97,7 @@ type UserRepository interface {
 	DeductBalance(ctx context.Context, id int64, amount float64) error
 	UpdateConcurrency(ctx context.Context, id int64, amount int) error
 	ExistsByEmail(ctx context.Context, email string) (bool, error)
+	IncrementPromptViolationCount(ctx context.Context, userID int64, limit int) (count int, disabled bool, err error)
 	RemoveGroupFromAllowedGroups(ctx context.Context, groupID int64) (int64, error)
 	// AddGroupToAllowedGroups 将指定分组增量添加到用户的 allowed_groups（幂等，冲突忽略）
 	AddGroupToAllowedGroups(ctx context.Context, userID int64, groupID int64) error

--- a/backend/internal/service/user_service_test.go
+++ b/backend/internal/service/user_service_test.go
@@ -196,6 +196,9 @@ func (m *mockUserRepo) UpdateUserLastActiveAt(_ context.Context, userID int64, a
 func (m *mockUserRepo) DeductBalance(context.Context, int64, float64) error { return nil }
 func (m *mockUserRepo) UpdateConcurrency(context.Context, int64, int) error { return nil }
 func (m *mockUserRepo) ExistsByEmail(context.Context, string) (bool, error) { return false, nil }
+func (m *mockUserRepo) IncrementPromptViolationCount(context.Context, int64, int) (int, bool, error) {
+	return 0, false, nil
+}
 func (m *mockUserRepo) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {
 	return 0, nil
 }

--- a/backend/migrations/133_add_prompt_violation_count.sql
+++ b/backend/migrations/133_add_prompt_violation_count.sql
@@ -1,0 +1,6 @@
+-- Track keyword-filter prompt violations per user. The gateway increments this
+-- counter atomically and disables the user once the configured limit is reached.
+
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS prompt_violation_count INTEGER NOT NULL DEFAULT 0;
+

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -419,6 +419,13 @@ export interface SystemSettings {
   enable_identity_patch: boolean;
   identity_patch_prompt: string;
 
+  // Prompt keyword filter
+  prompt_filter_enabled: boolean;
+  prompt_filter_keywords: string[];
+  prompt_filter_violation_limit: number;
+  prompt_filter_warning_message: string;
+  prompt_filter_ban_message: string;
+
   // Ops Monitoring (vNext)
   ops_monitoring_enabled: boolean;
   ops_realtime_monitoring_enabled: boolean;
@@ -590,6 +597,11 @@ export interface UpdateSettingsRequest {
   fallback_model_antigravity?: string;
   enable_identity_patch?: boolean;
   identity_patch_prompt?: string;
+  prompt_filter_enabled?: boolean;
+  prompt_filter_keywords?: string[];
+  prompt_filter_violation_limit?: number;
+  prompt_filter_warning_message?: string;
+  prompt_filter_ban_message?: string;
   ops_monitoring_enabled?: boolean;
   ops_realtime_monitoring_enabled?: boolean;
   ops_query_mode_default?: "auto" | "raw" | "preagg" | string;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -4980,6 +4980,21 @@ export default {
         allowUngroupedKey: 'Allow Ungrouped Key Scheduling',
         allowUngroupedKeyHint: 'When disabled, API Keys not assigned to any group cannot make requests (403 Forbidden). Keep disabled to ensure all Keys belong to a specific group.'
       },
+      promptFilter: {
+        title: 'Prompt Keyword Filter',
+        description: 'Block user prompts containing banned keywords and disable the account after repeated violations.',
+        enabled: 'Enable Keyword Filter',
+        enabledHint: 'When enabled, matching requests return a policy warning before scheduling or billing.',
+        keywords: 'Banned Keywords',
+        keywordsPlaceholder: 'One keyword per line',
+        keywordsHint: 'Separate keywords by lines, commas, or Chinese commas. Matching is case-insensitive.',
+        violationLimit: 'Ban Threshold',
+        violationLimitHint: 'The user is disabled when cumulative violations reach this number.',
+        warningMessage: 'Violation Message',
+        warningMessageHint: 'Returned when a keyword matches before the ban threshold is reached.',
+        banMessage: 'Ban Message',
+        banMessageHint: 'Returned when the threshold is reached and the account is disabled.',
+      },
       gatewayForwarding: {
         title: 'Request Forwarding',
         description: 'Control how requests are forwarded to upstream OAuth accounts',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5139,6 +5139,21 @@ export default {
         allowUngroupedKey: '允许未分组 Key 调度',
         allowUngroupedKeyHint: '关闭后，未分配到任何分组的 API Key 将无法发起请求（返回 403）。建议保持关闭以确保所有 Key 都归属明确的分组。'
       },
+      promptFilter: {
+        title: 'Prompt 关键词过滤',
+        description: '拦截包含违禁关键词的用户 Prompt，并在多次违规后自动禁用账号。',
+        enabled: '启用关键词过滤',
+        enabledHint: '开启后，命中的请求会在进入调度和计费前直接返回违规提醒。',
+        keywords: '违禁关键词',
+        keywordsPlaceholder: '每行一个关键词',
+        keywordsHint: '支持按行、英文逗号或中文逗号分隔；匹配不区分大小写。',
+        violationLimit: '封号阈值',
+        violationLimitHint: '同一用户累计达到该次数后自动禁用账号。',
+        warningMessage: '违规提醒文案',
+        warningMessageHint: '命中关键词但未达到封号阈值时返回。',
+        banMessage: '封号提醒文案',
+        banMessageHint: '达到阈值并禁用账号时返回。',
+      },
       gatewayForwarding: {
         title: '请求转发行为',
         description: '控制请求转发到上游 OAuth 账号时的行为',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -2707,6 +2707,108 @@
             </div>
           </div>
 
+          <!-- Prompt Keyword Filter -->
+          <div class="card">
+            <div
+              class="border-b border-gray-100 px-6 py-4 dark:border-dark-700"
+            >
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ t("admin.settings.promptFilter.title") }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ t("admin.settings.promptFilter.description") }}
+              </p>
+            </div>
+            <div class="space-y-5 p-6">
+              <div class="flex items-center justify-between gap-4">
+                <div>
+                  <label
+                    class="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {{ t("admin.settings.promptFilter.enabled") }}
+                  </label>
+                  <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{ t("admin.settings.promptFilter.enabledHint") }}
+                  </p>
+                </div>
+                <Toggle v-model="form.prompt_filter_enabled" />
+              </div>
+
+              <div
+                v-if="form.prompt_filter_enabled"
+                class="space-y-4 border-t border-gray-100 pt-4 dark:border-dark-700"
+              >
+                <div>
+                  <label
+                    class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {{ t("admin.settings.promptFilter.keywords") }}
+                  </label>
+                  <textarea
+                    v-model="promptFilterKeywordsInput"
+                    rows="6"
+                    class="input min-h-[140px] font-mono text-sm"
+                    :placeholder="
+                      t('admin.settings.promptFilter.keywordsPlaceholder')
+                    "
+                  ></textarea>
+                  <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{ t("admin.settings.promptFilter.keywordsHint") }}
+                  </p>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-3">
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{ t("admin.settings.promptFilter.violationLimit") }}
+                    </label>
+                    <input
+                      v-model.number="form.prompt_filter_violation_limit"
+                      type="number"
+                      min="1"
+                      class="input w-full"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.promptFilter.violationLimitHint") }}
+                    </p>
+                  </div>
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{ t("admin.settings.promptFilter.warningMessage") }}
+                    </label>
+                    <input
+                      v-model="form.prompt_filter_warning_message"
+                      type="text"
+                      class="input w-full"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.promptFilter.warningMessageHint") }}
+                    </p>
+                  </div>
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{ t("admin.settings.promptFilter.banMessage") }}
+                    </label>
+                    <input
+                      v-model="form.prompt_filter_ban_message"
+                      type="text"
+                      class="input w-full"
+                    />
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.promptFilter.banMessageHint") }}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <!-- Gateway Forwarding Behavior -->
           <div class="card">
             <div
@@ -5233,6 +5335,7 @@ const testEmailAddress = ref("");
 const registrationEmailSuffixWhitelistTags = ref<string[]>([]);
 const registrationEmailSuffixWhitelistDraft = ref("");
 const tablePageSizeOptionsInput = ref("10, 20, 50, 100");
+const promptFilterKeywordsInput = ref("");
 
 // Admin API Key 状态
 const adminApiKeyLoading = ref(true);
@@ -5454,6 +5557,12 @@ const form = reactive<SettingsForm>({
   // Identity patch (Claude -> Gemini)
   enable_identity_patch: true,
   identity_patch_prompt: "",
+  // Prompt keyword filter
+  prompt_filter_enabled: false,
+  prompt_filter_keywords: [] as string[],
+  prompt_filter_violation_limit: 10,
+  prompt_filter_warning_message: "请求包含违规关键词，已被拦截。",
+  prompt_filter_ban_message: "账号因多次提交违规内容已被禁用。",
   // Ops monitoring (vNext)
   ops_monitoring_enabled: true,
   ops_realtime_monitoring_enabled: true,
@@ -5974,6 +6083,24 @@ function parseTablePageSizeOptionsInput(raw: string): number[] | null {
   return deduped;
 }
 
+function formatPromptFilterKeywords(keywords: string[] | undefined): string {
+  return Array.isArray(keywords) ? keywords.join("\n") : "";
+}
+
+function parsePromptFilterKeywordsInput(raw: string): string[] {
+  const seen = new Set<string>();
+  const keywords: string[] = [];
+  for (const token of raw.split(/[\n\r,，;；]+/)) {
+    const keyword = token.trim();
+    if (!keyword) continue;
+    const key = keyword.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keywords.push(keyword);
+  }
+  return keywords;
+}
+
 async function loadSettings() {
   loading.value = true;
   loadFailed.value = false;
@@ -6000,6 +6127,9 @@ async function loadSettings() {
       Array.isArray(settings.table_page_size_options)
         ? settings.table_page_size_options
         : [10, 20, 50, 100],
+    );
+    promptFilterKeywordsInput.value = formatPromptFilterKeywords(
+      settings.prompt_filter_keywords,
     );
     registrationEmailSuffixWhitelistDraft.value = "";
     form.smtp_password = "";
@@ -6178,6 +6308,19 @@ async function saveSettings() {
 
     form.table_default_page_size = normalizedTableDefaultPageSize;
     form.table_page_size_options = normalizedTablePageSizeOptions;
+    form.prompt_filter_keywords = parsePromptFilterKeywordsInput(
+      promptFilterKeywordsInput.value,
+    );
+    form.prompt_filter_violation_limit = Math.max(
+      1,
+      Math.floor(Number(form.prompt_filter_violation_limit) || 10),
+    );
+    form.prompt_filter_warning_message =
+      form.prompt_filter_warning_message.trim() ||
+      "请求包含违规关键词，已被拦截。";
+    form.prompt_filter_ban_message =
+      form.prompt_filter_ban_message.trim() ||
+      "账号因多次提交违规内容已被禁用。";
 
     const normalizedDefaultSubscriptions = normalizeDefaultSubscriptionSettings(
       form.default_subscriptions,
@@ -6351,6 +6494,11 @@ async function saveSettings() {
       fallback_model_antigravity: form.fallback_model_antigravity,
       enable_identity_patch: form.enable_identity_patch,
       identity_patch_prompt: form.identity_patch_prompt,
+      prompt_filter_enabled: form.prompt_filter_enabled,
+      prompt_filter_keywords: form.prompt_filter_keywords,
+      prompt_filter_violation_limit: form.prompt_filter_violation_limit,
+      prompt_filter_warning_message: form.prompt_filter_warning_message,
+      prompt_filter_ban_message: form.prompt_filter_ban_message,
       min_claude_code_version: form.min_claude_code_version,
       max_claude_code_version: form.max_claude_code_version,
       allow_ungrouped_key_scheduling: form.allow_ungrouped_key_scheduling,
@@ -6421,6 +6569,9 @@ async function saveSettings() {
       Array.isArray(updated.table_page_size_options)
         ? updated.table_page_size_options
         : [10, 20, 50, 100],
+    );
+    promptFilterKeywordsInput.value = formatPromptFilterKeywords(
+      updated.prompt_filter_keywords,
     );
     registrationEmailSuffixWhitelistDraft.value = "";
     form.smtp_password = "";


### PR DESCRIPTION
## Summary
- Add configurable prompt keyword filtering settings for admins, including enable switch, keyword list, violation threshold, warning message, and ban message.
- Block matching gateway requests before scheduling/billing and return a `policy_violation` response.
- Track per-user prompt violations and disable the account once the configured threshold is reached.
- Add frontend settings UI, i18n strings, user violation-count migration, and focused tests.

## Validation
- `go test ./internal/service ./internal/handler ./internal/repository ./internal/server/middleware`
- `go test -tags unit ./internal/service ./internal/handler ./internal/server ./internal/server/middleware`
- `pnpm run typecheck`
- `git diff --check`