### PR TITLE
feat(account): enhance test model selection with search and memory

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -66,11 +66,11 @@ type poolSettings struct {
 // upstreamClientEntry 上游客户端缓存条目
 // 记录客户端实例及其元数据，用于连接池管理和淘汰策略
 type upstreamClientEntry struct {
+	lastUsed int64        // 最后使用时间戳（纳秒），用于 LRU 淘汰
+	inFlight int64        // 当前进行中的请求数，>0 时不可淘汰
 	client   *http.Client // HTTP 客户端实例
 	proxyKey string       // 代理标识（用于检测代理变更）
 	poolKey  string       // 连接池配置标识（用于检测配置变更）
-	lastUsed int64        // 最后使用时间戳（纳秒），用于 LRU 淘汰
-	inFlight int64        // 当前进行中的请求数，>0 时不可淘汰
 }
 
 // httpUpstreamService 通用 HTTP 上游服务

--- a/frontend/src/components/account/AccountTestModal.vue
+++ b/frontend/src/components/account/AccountTestModal.vue
@@ -52,6 +52,7 @@
           value-key="id"
           label-key="display_name"
           :placeholder="loadingModels ? t('common.loading') + '...' : t('admin.accounts.selectTestModel')"
+          searchable
         />
       </div>
 
@@ -334,7 +335,10 @@ watch(
   }
 )
 
-watch(selectedModelId, () => {
+watch(selectedModelId, (newVal) => {
+  if (newVal) {
+    localStorage.setItem('last_test_model_id', newVal)
+  }
   if (supportsImageTest.value && !testPrompt.value.trim()) {
     testPrompt.value = t('admin.accounts.imagePromptDefault')
   }
@@ -352,7 +356,10 @@ const loadAvailableModels = async () => {
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini') {
+      const lastUsed = localStorage.getItem('last_test_model_id')
+      if (lastUsed && availableModels.value.some((m) => m.id === lastUsed)) {
+        selectedModelId.value = lastUsed
+      } else if (props.account.platform === 'gemini') {
         selectedModelId.value = availableModels.value[0].id
       } else {
         // Try to select Sonnet as default, otherwise use first model

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -52,6 +52,7 @@
           value-key="id"
           label-key="display_name"
           :placeholder="loadingModels ? t('common.loading') + '...' : t('admin.accounts.selectTestModel')"
+          searchable
         />
       </div>
 
@@ -316,7 +317,10 @@ watch(
   }
 )
 
-watch(selectedModelId, () => {
+watch(selectedModelId, (newVal) => {
+  if (newVal) {
+    localStorage.setItem('last_test_model_id', newVal)
+  }
   if (supportsImageTest.value && !testPrompt.value.trim()) {
     testPrompt.value = t('admin.accounts.imagePromptDefault')
   }
@@ -334,7 +338,10 @@ const loadAvailableModels = async () => {
       : models
     // Default selection by platform
     if (availableModels.value.length > 0) {
-      if (props.account.platform === 'gemini') {
+      const lastUsed = localStorage.getItem('last_test_model_id')
+      if (lastUsed && availableModels.value.some((m) => m.id === lastUsed)) {
+        selectedModelId.value = lastUsed
+      } else if (props.account.platform === 'gemini') {
         selectedModelId.value = availableModels.value[0].id
       } else {
         // Try to select Sonnet as default, otherwise use first model


### PR DESCRIPTION
This PR adds search capability to the test model selection dropdown in account test modals, allowing users to quickly find specific models. It also remembers the last tested model using local storage and automatically selects it on subsequent tests.