### PR TITLE
fix(openai): fail over unsupported account models

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -331,8 +331,18 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			var failoverErr *service.UpstreamFailoverError
 			if errors.As(err, &failoverErr) {
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
+				if failoverErr.ModelUnsupported {
+					h.gatewayService.HandleOpenAIModelUnsupportedFailover(
+						c.Request.Context(),
+						apiKey.GroupID,
+						sessionHash,
+						account,
+						reqModel,
+						failoverErr.ModelUnsupportedKey,
+					)
+				}
 				// 池模式：同账号重试
-				if failoverErr.RetryableOnSameAccount {
+				if failoverErr.RetryableOnSameAccount && !failoverErr.ModelUnsupported {
 					retryLimit := account.GetPoolModeRetryCount()
 					if sameAccountRetryCount[account.ID] < retryLimit {
 						sameAccountRetryCount[account.ID]++

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -505,6 +505,8 @@ type UpstreamFailoverError struct {
 	ResponseHeaders        http.Header // 上游响应头，用于透传 cf-ray/cf-mitigated/content-type 等诊断信息
 	ForceCacheBilling      bool        // Antigravity 粘性会话切换时设为 true
 	RetryableOnSameAccount bool        // 临时性错误（如 Google 间歇性 400、空响应），应在同一账号上重试 N 次再切换
+	ModelUnsupported       bool        // 上游明确表示当前账号不支持该模型，应切换账号
+	ModelUnsupportedKey    string      // 需要临时屏蔽的上游模型 key
 }
 
 func (e *UpstreamFailoverError) Error() string {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -55,6 +55,7 @@ const (
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
 	codexCLIVersion                    = "0.125.0"
+	openAIModelUnsupportedCooldown     = 6 * time.Hour
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 )
@@ -1252,6 +1253,9 @@ func isOpenAIAccountEligibleForRequest(account *Account, requestedModel string, 
 	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
 		return false
 	}
+	if requestedModel != "" && account.GetModelRateLimitRemainingTime(requestedModel) > 0 {
+		return false
+	}
 	if requireCompact && openAICompactSupportTier(account) == 0 {
 		return false
 	}
@@ -1938,12 +1942,100 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	if s.shouldFailoverUpstreamError(statusCode) {
 		return true
 	}
+	if isOpenAIAccountModelUnsupportedResponse(statusCode, upstreamMsg, upstreamBody) {
+		return true
+	}
 	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
+}
+
+func isOpenAIAccountModelUnsupportedResponse(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	combined := strings.ToLower(strings.TrimSpace(strings.Join([]string{
+		upstreamMsg,
+		gjson.GetBytes(upstreamBody, "detail").String(),
+		gjson.GetBytes(upstreamBody, "error.message").String(),
+		gjson.GetBytes(upstreamBody, "response.error.message").String(),
+		gjson.GetBytes(upstreamBody, "error.code").String(),
+		gjson.GetBytes(upstreamBody, "response.error.code").String(),
+	}, " ")))
+	if combined == "" {
+		return false
+	}
+	if strings.Contains(combined, "model is not supported when using codex with a chatgpt account") {
+		return true
+	}
+	return strings.Contains(combined, "model_not_supported") && strings.Contains(combined, "chatgpt account")
+}
+
+func openAIModelUnsupportedKey(account *Account, requestedModel, upstreamModel string) string {
+	if key := strings.TrimSpace(upstreamModel); key != "" {
+		return key
+	}
+	if account != nil {
+		if key := strings.TrimSpace(account.GetMappedModel(requestedModel)); key != "" {
+			return key
+		}
+	}
+	return strings.TrimSpace(requestedModel)
+}
+
+func newOpenAIModelUnsupportedFailoverError(statusCode int, body []byte, account *Account, requestedModel, upstreamModel string) *UpstreamFailoverError {
+	return &UpstreamFailoverError{
+		StatusCode:          statusCode,
+		ResponseBody:        body,
+		ModelUnsupported:    true,
+		ModelUnsupportedKey: openAIModelUnsupportedKey(account, requestedModel, upstreamModel),
+	}
+}
+
+func (s *OpenAIGatewayService) HandleOpenAIModelUnsupportedFailover(ctx context.Context, groupID *int64, sessionHash string, account *Account, requestedModel, modelKey string) {
+	if s == nil || account == nil {
+		return
+	}
+	resolvedModelKey := openAIModelUnsupportedKey(account, requestedModel, modelKey)
+	resetAt := time.Now().Add(openAIModelUnsupportedCooldown)
+	if resolvedModelKey != "" && s.accountRepo != nil {
+		if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, resolvedModelKey, resetAt); err != nil {
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] model_not_supported mark failed account=%d model=%s err=%v", account.ID, resolvedModelKey, err)
+		} else {
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] model_not_supported marked account=%d model=%s reset_in=%v", account.ID, resolvedModelKey, time.Until(resetAt).Truncate(time.Second))
+		}
+	}
+	s.updateOpenAIModelRateLimitInCache(ctx, account, resolvedModelKey, resetAt)
+	if sessionHash != "" {
+		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
+	}
+}
+
+func (s *OpenAIGatewayService) updateOpenAIModelRateLimitInCache(ctx context.Context, account *Account, modelKey string, resetAt time.Time) {
+	if s == nil || s.schedulerSnapshot == nil || account == nil || strings.TrimSpace(modelKey) == "" {
+		return
+	}
+	if account.Extra == nil {
+		account.Extra = make(map[string]any)
+	}
+	limits, _ := account.Extra[modelRateLimitsKey].(map[string]any)
+	if limits == nil {
+		limits = make(map[string]any)
+		account.Extra[modelRateLimitsKey] = limits
+	}
+	now := time.Now().UTC()
+	limits[modelKey] = map[string]any{
+		"rate_limited_at":     now.Format(time.RFC3339),
+		"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
+	}
+	if err := s.schedulerSnapshot.SetAccount(ctx, account); err != nil {
+		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] model_not_supported cache update failed account=%d model=%s err=%v", account.ID, modelKey, err)
+	}
 }
 
 func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	if s.rateLimitService != nil {
+		s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	}
 }
 
 // Forward forwards request to OpenAI API
@@ -2614,6 +2706,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				})
 
 				s.handleFailoverSideEffects(ctx, resp, account)
+				if isOpenAIAccountModelUnsupportedResponse(resp.StatusCode, upstreamMsg, respBody) {
+					return nil, newOpenAIModelUnsupportedFailoverError(resp.StatusCode, respBody, account, reqModel, upstreamModel)
+				}
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
@@ -3702,6 +3797,21 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 			account.Type,
 			truncateForLog(body, s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes),
 		)
+	}
+
+	if isOpenAIAccountModelUnsupportedResponse(resp.StatusCode, upstreamMsg, body) {
+		requestedModel, _, _ := extractOpenAIRequestMetaFromBody(requestBody)
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  resp.Header.Get("x-request-id"),
+			Kind:               "failover",
+			Message:            upstreamMsg,
+			Detail:             upstreamDetail,
+		})
+		return nil, newOpenAIModelUnsupportedFailoverError(resp.StatusCode, body, account, requestedModel, "")
 	}
 
 	if status, errType, errMsg, matched := applyErrorPassthroughRule(

--- a/backend/internal/service/openai_model_not_supported_failover_test.go
+++ b/backend/internal/service/openai_model_not_supported_failover_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type openAIModelUnsupportedRepoStub struct {
+	AccountRepository
+	calls []openAIModelUnsupportedRepoCall
+}
+
+type openAIModelUnsupportedRepoCall struct {
+	accountID int64
+	modelKey  string
+	resetAt   time.Time
+}
+
+func (r *openAIModelUnsupportedRepoStub) SetModelRateLimit(ctx context.Context, id int64, scope string, resetAt time.Time) error {
+	r.calls = append(r.calls, openAIModelUnsupportedRepoCall{accountID: id, modelKey: scope, resetAt: resetAt})
+	return nil
+}
+
+func TestOpenAIModelUnsupportedResponseTriggersFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-5.5"}`))
+
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+		Body:       ioNopCloser(`{"detail":"The 'gpt-5.5' model is not supported when using Codex with a ChatGPT account."}`),
+	}
+	account := &Account{ID: 213, Name: "free", Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	_, err := svc.handleErrorResponse(c.Request.Context(), resp, c, account, []byte(`{"model":"gpt-5.5"}`))
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.True(t, failoverErr.ModelUnsupported)
+	require.Equal(t, "gpt-5.5", failoverErr.ModelUnsupportedKey)
+	require.False(t, c.Writer.Written(), "failover path must not write the final client error before account switch")
+}
+
+func TestOpenAIAccountEligibilitySkipsModelRateLimitedAccount(t *testing.T) {
+	resetAt := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	account := &Account{
+		ID:          1,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"}},
+		Extra: map[string]any{
+			"model_rate_limits": map[string]any{
+				"gpt-5.5": map[string]any{"rate_limit_reset_at": resetAt},
+			},
+		},
+	}
+
+	require.False(t, isOpenAIAccountEligibleForRequest(account, "gpt-5.5", false))
+}
+
+func TestOpenAIModelUnsupportedFailoverMarksModelAndClearsSticky(t *testing.T) {
+	repo := &openAIModelUnsupportedRepoStub{}
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{}}
+	svc := &OpenAIGatewayService{accountRepo: repo, cache: cache}
+	groupID := int64(2)
+	sessionHash := "session-abc"
+	account := &Account{
+		ID:          213,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Credentials: map[string]any{"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"}},
+	}
+	require.NoError(t, svc.setStickySessionAccountID(context.Background(), &groupID, sessionHash, account.ID, time.Hour))
+
+	svc.HandleOpenAIModelUnsupportedFailover(context.Background(), &groupID, sessionHash, account, "gpt-5.5", "gpt-5.5")
+
+	require.Len(t, repo.calls, 1)
+	require.Equal(t, int64(213), repo.calls[0].accountID)
+	require.Equal(t, "gpt-5.5", repo.calls[0].modelKey)
+	require.Greater(t, time.Until(repo.calls[0].resetAt), time.Minute)
+	require.NotContains(t, cache.sessionBindings, svc.openAISessionCacheKey(sessionHash))
+	require.GreaterOrEqual(t, cache.deletedSessions[svc.openAISessionCacheKey(sessionHash)], 1)
+}
+
+func ioNopCloser(body string) *nopReadCloser {
+	return &nopReadCloser{Reader: strings.NewReader(body)}
+}
+
+type nopReadCloser struct {
+	*strings.Reader
+}
+
+func (n *nopReadCloser) Close() error { return nil }


### PR DESCRIPTION
## Summary
- Detect OpenAI OAuth `model_not_supported` responses for ChatGPT account/model mismatches and turn them into account failover instead of a final 502.
- Mark the failed account/model pair with a temporary model-level cooldown and clear sticky session bindings before retrying another account.
- Skip OpenAI accounts with active model-level cooldowns during selection and add regression coverage for failover, cooldown filtering, and sticky cleanup.

## Test Plan
- [ ] `go test ./internal/service -run "TestOpenAIModelUnsupported" -count=1`
- [ ] `go test ./internal/service ./internal/handler`

## Notes
- Related reports: #1852, #1877, #1891.
- Not run on the production VM to avoid CPU/memory pressure; intended for CI validation.
