### PR TITLE
fix: support gpt-5.3-codex-spark compatibility

### DIFF
--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -373,12 +373,12 @@ func (h *AccountHandler) listAllProxies(ctx context.Context) ([]service.Proxy, e
 	return out, nil
 }
 
-func (h *AccountHandler) listAccountsFiltered(ctx context.Context, platform, accountType, status, search string, groupID int64, privacyMode, sortBy, sortOrder string) ([]service.Account, error) {
+func (h *AccountHandler) listAccountsFiltered(ctx context.Context, platform, accountType, status, search string, groupID int64, privacyMode, planType, sortBy, sortOrder string) ([]service.Account, error) {
 	page := 1
 	pageSize := dataPageCap
 	var out []service.Account
 	for {
-		items, total, err := h.adminService.ListAccounts(ctx, page, pageSize, platform, accountType, status, search, groupID, privacyMode, sortBy, sortOrder)
+		items, total, err := h.adminService.ListAccounts(ctx, page, pageSize, platform, accountType, status, search, groupID, privacyMode, planType, sortBy, sortOrder)
 		if err != nil {
 			return nil, err
 		}
@@ -411,6 +411,7 @@ func (h *AccountHandler) resolveExportAccounts(ctx context.Context, ids []int64,
 	accountType := c.Query("type")
 	status := c.Query("status")
 	privacyMode := strings.TrimSpace(c.Query("privacy_mode"))
+	planType := strings.TrimSpace(c.Query("plan_type"))
 	search := strings.TrimSpace(c.Query("search"))
 	sortBy := c.DefaultQuery("sort_by", "name")
 	sortOrder := c.DefaultQuery("sort_order", "asc")
@@ -431,7 +432,7 @@ func (h *AccountHandler) resolveExportAccounts(ctx context.Context, ids []int64,
 		}
 	}
 
-	return h.listAccountsFiltered(ctx, platform, accountType, status, search, groupID, privacyMode, sortBy, sortOrder)
+	return h.listAccountsFiltered(ctx, platform, accountType, status, search, groupID, privacyMode, planType, sortBy, sortOrder)
 }
 
 func (h *AccountHandler) resolveExportProxies(ctx context.Context, accounts []service.Account) ([]service.Proxy, error) {

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -134,30 +134,19 @@ type UpdateAccountRequest struct {
 
 // BulkUpdateAccountsRequest represents the payload for bulk editing accounts
 type BulkUpdateAccountsRequest struct {
-	AccountIDs              []int64                   `json:"account_ids"`
-	Filters                 *BulkUpdateAccountFilters `json:"filters"`
-	Name                    string                    `json:"name"`
-	ProxyID                 *int64                    `json:"proxy_id"`
-	Concurrency             *int                      `json:"concurrency"`
-	Priority                *int                      `json:"priority"`
-	RateMultiplier          *float64                  `json:"rate_multiplier"`
-	LoadFactor              *int                      `json:"load_factor"`
-	Status                  string                    `json:"status" binding:"omitempty,oneof=active inactive error"`
-	Schedulable             *bool                     `json:"schedulable"`
-	GroupIDs                *[]int64                  `json:"group_ids"`
-	Credentials             map[string]any            `json:"credentials"`
-	Extra                   map[string]any            `json:"extra"`
-	ConfirmMixedChannelRisk *bool                     `json:"confirm_mixed_channel_risk"` // 用户确认混合渠道风险
-}
-
-type BulkUpdateAccountFilters struct {
-	Platform    string `json:"platform"`
-	Type        string `json:"type"`
-	Status      string `json:"status"`
-	Group       string `json:"group"`
-	Search      string `json:"search"`
-	PrivacyMode string `json:"privacy_mode"`
-	PlanType    string `json:"plan_type"`
+	AccountIDs              []int64        `json:"account_ids"`
+	Name                    string         `json:"name"`
+	ProxyID                 *int64         `json:"proxy_id"`
+	Concurrency             *int           `json:"concurrency"`
+	Priority                *int           `json:"priority"`
+	RateMultiplier          *float64       `json:"rate_multiplier"`
+	LoadFactor              *int           `json:"load_factor"`
+	Status                  string         `json:"status" binding:"omitempty,oneof=active inactive error"`
+	Schedulable             *bool          `json:"schedulable"`
+	GroupIDs                *[]int64       `json:"group_ids"`
+	Credentials             map[string]any `json:"credentials"`
+	Extra                   map[string]any `json:"extra"`
+	ConfirmMixedChannelRisk *bool          `json:"confirm_mixed_channel_risk"` // 用户确认混合渠道风险
 }
 
 // CheckMixedChannelRequest represents check mixed channel risk request
@@ -1381,8 +1370,8 @@ func (h *AccountHandler) BulkUpdate(c *gin.Context) {
 		response.BadRequest(c, "rate_multiplier must be >= 0")
 		return
 	}
-	if len(req.AccountIDs) == 0 && req.Filters == nil {
-		response.BadRequest(c, "account_ids or filters is required")
+	if len(req.AccountIDs) == 0 {
+		response.BadRequest(c, "account_ids is required")
 		return
 	}
 	// base_rpm 输入校验：负值归零，超过 10000 截断
@@ -1410,7 +1399,6 @@ func (h *AccountHandler) BulkUpdate(c *gin.Context) {
 
 	result, err := h.adminService.BulkUpdateAccounts(c.Request.Context(), &service.BulkUpdateAccountsInput{
 		AccountIDs:            req.AccountIDs,
-		Filters:               toServiceBulkUpdateAccountFilters(req.Filters),
 		Name:                  req.Name,
 		ProxyID:               req.ProxyID,
 		Concurrency:           req.Concurrency,
@@ -1444,21 +1432,6 @@ func (h *AccountHandler) BulkUpdate(c *gin.Context) {
 	}
 
 	response.Success(c, result)
-}
-
-func toServiceBulkUpdateAccountFilters(filters *BulkUpdateAccountFilters) *service.BulkUpdateAccountFilters {
-	if filters == nil {
-		return nil
-	}
-	return &service.BulkUpdateAccountFilters{
-		Platform:    filters.Platform,
-		Type:        filters.Type,
-		Status:      filters.Status,
-		Group:       filters.Group,
-		Search:      filters.Search,
-		PrivacyMode: filters.PrivacyMode,
-		PlanType:    filters.PlanType,
-	}
 }
 
 // ========== OAuth Handlers ==========

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -231,6 +231,7 @@ func (h *AccountHandler) List(c *gin.Context) {
 	status := c.Query("status")
 	search := c.Query("search")
 	privacyMode := strings.TrimSpace(c.Query("privacy_mode"))
+	planType := strings.TrimSpace(c.Query("plan_type"))
 	sortBy := c.DefaultQuery("sort_by", "name")
 	sortOrder := c.DefaultQuery("sort_order", "asc")
 	// 标准化和验证 search 参数
@@ -258,7 +259,7 @@ func (h *AccountHandler) List(c *gin.Context) {
 		}
 	}
 
-	accounts, total, err := h.adminService.ListAccounts(c.Request.Context(), page, pageSize, platform, accountType, status, search, groupID, privacyMode, sortBy, sortOrder)
+	accounts, total, err := h.adminService.ListAccounts(c.Request.Context(), page, pageSize, platform, accountType, status, search, groupID, privacyMode, planType, sortBy, sortOrder)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
@@ -2067,7 +2068,7 @@ func (h *AccountHandler) BatchRefreshTier(c *gin.Context) {
 	accounts := make([]*service.Account, 0)
 
 	if len(req.AccountIDs) == 0 {
-		allAccounts, _, err := h.adminService.ListAccounts(ctx, 1, 10000, "gemini", "oauth", "", "", 0, "", "name", "asc")
+		allAccounts, _, err := h.adminService.ListAccounts(ctx, 1, 10000, "gemini", "oauth", "", "", 0, "", "", "name", "asc")
 		if err != nil {
 			response.ErrorFrom(c, err)
 			return

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -157,6 +157,7 @@ type BulkUpdateAccountFilters struct {
 	Group       string `json:"group"`
 	Search      string `json:"search"`
 	PrivacyMode string `json:"privacy_mode"`
+	PlanType    string `json:"plan_type"`
 }
 
 // CheckMixedChannelRequest represents check mixed channel risk request
@@ -1456,6 +1457,7 @@ func toServiceBulkUpdateAccountFilters(filters *BulkUpdateAccountFilters) *servi
 		Group:       filters.Group,
 		Search:      filters.Search,
 		PrivacyMode: filters.PrivacyMode,
+		PlanType:    filters.PlanType,
 	}
 }
 

--- a/backend/internal/handler/admin/account_handler_mixed_channel_test.go
+++ b/backend/internal/handler/admin/account_handler_mixed_channel_test.go
@@ -197,7 +197,7 @@ func TestAccountHandlerBulkUpdateMixedChannelConfirmSkips(t *testing.T) {
 	require.Equal(t, float64(0), data["failed"])
 }
 
-func TestBulkUpdateAcceptsFilterTargetRequest(t *testing.T) {
+func TestBulkUpdateRejectsFilterTargetRequest(t *testing.T) {
 	adminSvc := newStubAdminService()
 	router := setupAccountMixedChannelRouter(adminSvc)
 
@@ -217,8 +217,9 @@ func TestBulkUpdateAcceptsFilterTargetRequest(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(rec, req)
 
-	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
-	require.Equal(t, float64(0), resp["code"])
+	require.Contains(t, rec.Body.String(), "account_ids is required")
+	require.Equal(t, 0, adminSvc.bulkUpdateCalls)
 }

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -295,7 +295,7 @@ func (s *stubAdminService) BatchSetGroupRPMOverrides(_ context.Context, _ int64,
 	return nil
 }
 
-func (s *stubAdminService) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, sortBy, sortOrder string) ([]service.Account, int64, error) {
+func (s *stubAdminService) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, planType string, sortBy, sortOrder string) ([]service.Account, int64, error) {
 	s.lastListAccounts.platform = platform
 	s.lastListAccounts.accountType = accountType
 	s.lastListAccounts.status = status

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -27,6 +27,7 @@ type stubAdminService struct {
 	createAccountErr     error
 	updateAccountErr     error
 	bulkUpdateAccountErr error
+	bulkUpdateCalls      int
 	checkMixedErr        error
 	lastMixedCheck       struct {
 		accountID int64
@@ -365,6 +366,7 @@ func (s *stubAdminService) SetAccountSchedulable(ctx context.Context, id int64, 
 }
 
 func (s *stubAdminService) BulkUpdateAccounts(ctx context.Context, input *service.BulkUpdateAccountsInput) (*service.BulkUpdateAccountsResult, error) {
+	s.bulkUpdateCalls++
 	if s.bulkUpdateAccountErr != nil {
 		return nil, s.bulkUpdateAccountErr
 	}

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -457,10 +457,10 @@ func (r *accountRepository) Delete(ctx context.Context, id int64) error {
 }
 
 func (r *accountRepository) List(ctx context.Context, params pagination.PaginationParams) ([]service.Account, *pagination.PaginationResult, error) {
-	return r.ListWithFilters(ctx, params, "", "", "", "", 0, "")
+	return r.ListWithFilters(ctx, params, "", "", "", "", 0, "", "")
 }
 
-func (r *accountRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]service.Account, *pagination.PaginationResult, error) {
+func (r *accountRepository) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]service.Account, *pagination.PaginationResult, error) {
 	q := r.client.Account.Query()
 
 	if platform != "" {
@@ -549,6 +549,20 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 				))
 			default:
 				s.Where(sqljson.ValueEQ(dbaccount.FieldExtra, privacyMode, path))
+			}
+		}))
+	}
+	if planType != "" {
+		q = q.Where(dbpredicate.Account(func(s *entsql.Selector) {
+			path := sqljson.Path("plan_type")
+			switch planType {
+			case service.AccountPlanTypeUnsetFilter:
+				s.Where(entsql.Or(
+					entsql.Not(sqljson.HasKey(dbaccount.FieldCredentials, path)),
+					sqljson.ValueEQ(dbaccount.FieldCredentials, "", path),
+				))
+			default:
+				s.Where(sqljson.ValueEQ(dbaccount.FieldCredentials, planType, path))
 			}
 		}))
 	}

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -469,65 +469,24 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 	if accountType != "" {
 		q = q.Where(dbaccount.TypeEQ(accountType))
 	}
-	if status != "" {
-		switch status {
-		case service.StatusActive:
-			q = q.Where(
-				dbaccount.StatusEQ(status),
-				dbaccount.SchedulableEQ(true),
-				dbaccount.Or(
-					dbaccount.RateLimitResetAtIsNil(),
-					dbaccount.RateLimitResetAtLTE(time.Now()),
-				),
-				dbpredicate.Account(func(s *entsql.Selector) {
-					col := s.C("temp_unschedulable_until")
-					s.Where(entsql.Or(
-						entsql.IsNull(col),
-						entsql.LTE(col, entsql.Expr("NOW()")),
-					))
-				}),
-			)
-		case "rate_limited":
-			q = q.Where(
-				dbaccount.StatusEQ(service.StatusActive),
-				dbaccount.RateLimitResetAtGT(time.Now()),
-				dbpredicate.Account(func(s *entsql.Selector) {
-					col := s.C("temp_unschedulable_until")
-					s.Where(entsql.Or(
-						entsql.IsNull(col),
-						entsql.LTE(col, entsql.Expr("NOW()")),
-					))
-				}),
-			)
-		case "temp_unschedulable":
-			q = q.Where(
-				dbaccount.StatusEQ(service.StatusActive),
-				dbpredicate.Account(func(s *entsql.Selector) {
-					col := s.C("temp_unschedulable_until")
-					s.Where(entsql.And(
-						entsql.Not(entsql.IsNull(col)),
-						entsql.GT(col, entsql.Expr("NOW()")),
-					))
-				}),
-			)
-		case "unschedulable":
-			q = q.Where(
-				dbaccount.StatusEQ(service.StatusActive),
-				dbaccount.SchedulableEQ(false),
-				dbaccount.Or(
-					dbaccount.RateLimitResetAtIsNil(),
-					dbaccount.RateLimitResetAtLTE(time.Now()),
-				),
-				dbpredicate.Account(func(s *entsql.Selector) {
-					col := s.C("temp_unschedulable_until")
-					s.Where(entsql.Or(
-						entsql.IsNull(col),
-						entsql.LTE(col, entsql.Expr("NOW()")),
-					))
-				}),
-			)
-		default:
-			q = q.Where(dbaccount.StatusEQ(status))
+	if statusValues := splitAccountFilterValues(status); len(statusValues) > 0 {
+		now := time.Now()
+		statusPredicates := make([]dbpredicate.Account, 0, len(statusValues))
+		excludeRateLimited := false
+		for _, statusValue := range statusValues {
+			if statusValue == "not_rate_limited" {
+				excludeRateLimited = true
+				continue
+			}
+			statusPredicates = append(statusPredicates, accountStatusFilterPredicate(statusValue, now))
+		}
+		if len(statusPredicates) == 1 {
+			q = q.Where(statusPredicates[0])
+		} else if len(statusPredicates) > 1 {
+			q = q.Where(dbaccount.Or(statusPredicates...))
+		}
+		if excludeRateLimited {
+			q = q.Where(accountNotRateLimitedPredicate(now))
 		}
 	}
 	if search != "" {
@@ -552,19 +511,16 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 			}
 		}))
 	}
-	if planType != "" {
-		q = q.Where(dbpredicate.Account(func(s *entsql.Selector) {
-			path := sqljson.Path("plan_type")
-			switch planType {
-			case service.AccountPlanTypeUnsetFilter:
-				s.Where(entsql.Or(
-					entsql.Not(sqljson.HasKey(dbaccount.FieldCredentials, path)),
-					sqljson.ValueEQ(dbaccount.FieldCredentials, "", path),
-				))
-			default:
-				s.Where(sqljson.ValueEQ(dbaccount.FieldCredentials, planType, path))
-			}
-		}))
+	if planTypes := splitAccountFilterValues(planType); len(planTypes) > 0 {
+		planPredicates := make([]dbpredicate.Account, 0, len(planTypes))
+		for _, value := range planTypes {
+			planPredicates = append(planPredicates, accountPlanTypeFilterPredicate(value))
+		}
+		if len(planPredicates) == 1 {
+			q = q.Where(planPredicates[0])
+		} else {
+			q = q.Where(dbaccount.Or(planPredicates...))
+		}
 	}
 
 	total, err := q.Count(ctx)
@@ -589,6 +545,101 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 		return nil, nil, err
 	}
 	return outAccounts, paginationResultFromTotal(int64(total), params), nil
+}
+
+func splitAccountFilterValues(raw string) []string {
+	seen := make(map[string]struct{})
+	values := make([]string, 0)
+	for _, part := range strings.Split(raw, ",") {
+		value := strings.TrimSpace(part)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
+}
+
+func accountStatusFilterPredicate(status string, now time.Time) dbpredicate.Account {
+	switch status {
+	case service.StatusActive:
+		return dbaccount.And(
+			dbaccount.StatusEQ(status),
+			dbaccount.SchedulableEQ(true),
+			accountNotRateLimitedPredicate(now),
+			dbpredicate.Account(func(s *entsql.Selector) {
+				col := s.C("temp_unschedulable_until")
+				s.Where(entsql.Or(
+					entsql.IsNull(col),
+					entsql.LTE(col, entsql.Expr("NOW()")),
+				))
+			}),
+		)
+	case "rate_limited":
+		return dbaccount.And(
+			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.RateLimitResetAtGT(now),
+			dbpredicate.Account(func(s *entsql.Selector) {
+				col := s.C("temp_unschedulable_until")
+				s.Where(entsql.Or(
+					entsql.IsNull(col),
+					entsql.LTE(col, entsql.Expr("NOW()")),
+				))
+			}),
+		)
+	case "temp_unschedulable":
+		return dbaccount.And(
+			dbaccount.StatusEQ(service.StatusActive),
+			dbpredicate.Account(func(s *entsql.Selector) {
+				col := s.C("temp_unschedulable_until")
+				s.Where(entsql.And(
+					entsql.Not(entsql.IsNull(col)),
+					entsql.GT(col, entsql.Expr("NOW()")),
+				))
+			}),
+		)
+	case "unschedulable":
+		return dbaccount.And(
+			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.SchedulableEQ(false),
+			accountNotRateLimitedPredicate(now),
+			dbpredicate.Account(func(s *entsql.Selector) {
+				col := s.C("temp_unschedulable_until")
+				s.Where(entsql.Or(
+					entsql.IsNull(col),
+					entsql.LTE(col, entsql.Expr("NOW()")),
+				))
+			}),
+		)
+	default:
+		return dbaccount.StatusEQ(status)
+	}
+}
+
+func accountNotRateLimitedPredicate(now time.Time) dbpredicate.Account {
+	return dbaccount.Or(
+		dbaccount.RateLimitResetAtIsNil(),
+		dbaccount.RateLimitResetAtLTE(now),
+	)
+}
+
+func accountPlanTypeFilterPredicate(planType string) dbpredicate.Account {
+	return dbpredicate.Account(func(s *entsql.Selector) {
+		path := sqljson.Path("plan_type")
+		switch planType {
+		case service.AccountPlanTypeUnsetFilter:
+			s.Where(entsql.Or(
+				entsql.Not(sqljson.HasKey(dbaccount.FieldCredentials, path)),
+				sqljson.ValueEQ(dbaccount.FieldCredentials, "", path),
+			))
+		default:
+			s.Where(sqljson.ValueEQ(dbaccount.FieldCredentials, planType, path))
+		}
+	})
 }
 
 func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selector) {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -419,7 +419,7 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 
 			tt.setup(client)
 
-			accounts, _, err := repo.ListWithFilters(ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, tt.platform, tt.accType, tt.status, tt.search, tt.groupID, tt.privacyMode)
+			accounts, _, err := repo.ListWithFilters(ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, tt.platform, tt.accType, tt.status, tt.search, tt.groupID, tt.privacyMode, "")
 			s.Require().NoError(err)
 			s.Require().Len(accounts, tt.wantCount)
 			if tt.validate != nil {
@@ -486,7 +486,7 @@ func (s *AccountRepoSuite) TestPreload_And_VirtualFields() {
 	s.Require().Len(got.Groups, 1, "expected Groups to be populated")
 	s.Require().Equal(group.ID, got.Groups[0].ID)
 
-	accounts, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", "", "", "acc", 0, "")
+	accounts, page, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, "", "", "", "acc", 0, "", "")
 	s.Require().NoError(err, "ListWithFilters")
 	s.Require().Equal(int64(1), page.Total)
 	s.Require().Len(accounts, 1)

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -220,6 +220,7 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 		search      string
 		groupID     int64
 		privacyMode string
+		planType    string
 		wantCount   int
 		validate    func(accounts []service.Account)
 	}{
@@ -407,6 +408,26 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 				s.ElementsMatch([]string{"privacy-unset", "privacy-empty"}, names)
 			},
 		},
+		{
+			name: "filter_by_multi_plan_and_not_rate_limited",
+			setup: func(client *dbent.Client) {
+				mustCreateAccount(s.T(), client, &service.Account{Name: "plus-ok", Credentials: map[string]any{"plan_type": "plus"}})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "team-ok", Credentials: map[string]any{"plan_type": "team"}})
+				rateLimited := mustCreateAccount(s.T(), client, &service.Account{Name: "pro-limited", Credentials: map[string]any{"plan_type": "pro"}})
+				err := client.Account.UpdateOneID(rateLimited.ID).
+					SetRateLimitResetAt(time.Now().Add(10 * time.Minute)).
+					Exec(context.Background())
+				s.Require().NoError(err)
+				mustCreateAccount(s.T(), client, &service.Account{Name: "free-ok", Credentials: map[string]any{"plan_type": "free"}})
+			},
+			status:    "not_rate_limited",
+			planType:  "plus,team,pro",
+			wantCount: 2,
+			validate: func(accounts []service.Account) {
+				names := []string{accounts[0].Name, accounts[1].Name}
+				s.ElementsMatch([]string{"plus-ok", "team-ok"}, names)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -419,7 +440,7 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 
 			tt.setup(client)
 
-			accounts, _, err := repo.ListWithFilters(ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, tt.platform, tt.accType, tt.status, tt.search, tt.groupID, tt.privacyMode, "")
+			accounts, _, err := repo.ListWithFilters(ctx, pagination.PaginationParams{Page: 1, PageSize: 10}, tt.platform, tt.accType, tt.status, tt.search, tt.groupID, tt.privacyMode, tt.planType)
 			s.Require().NoError(err)
 			s.Require().Len(accounts, tt.wantCount)
 			if tt.validate != nil {

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1498,7 +1498,7 @@ func (s *stubAccountRepo) List(ctx context.Context, params pagination.Pagination
 	return nil, nil, errors.New("not implemented")
 }
 
-func (s *stubAccountRepo) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]service.Account, *pagination.PaginationResult, error) {
+func (s *stubAccountRepo) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]service.Account, *pagination.PaginationResult, error) {
 	return nil, nil, errors.New("not implemented")
 }
 

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -16,6 +16,7 @@ var (
 
 const AccountListGroupUngrouped int64 = -1
 const AccountPrivacyModeUnsetFilter = "__unset__"
+const AccountPlanTypeUnsetFilter = "__unset__"
 
 type AccountRepository interface {
 	Create(ctx context.Context, account *Account) error
@@ -37,7 +38,7 @@ type AccountRepository interface {
 	Delete(ctx context.Context, id int64) error
 
 	List(ctx context.Context, params pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error)
-	ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error)
+	ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error)
 	ListByGroup(ctx context.Context, groupID int64) ([]Account, error)
 	ListActive(ctx context.Context) ([]Account, error)
 	ListByPlatform(ctx context.Context, platform string) ([]Account, error)

--- a/backend/internal/service/account_service_delete_test.go
+++ b/backend/internal/service/account_service_delete_test.go
@@ -79,7 +79,7 @@ func (s *accountRepoStub) List(ctx context.Context, params pagination.Pagination
 	panic("unexpected List call")
 }
 
-func (s *accountRepoStub) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (s *accountRepoStub) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error) {
 	panic("unexpected ListWithFilters call")
 }
 

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -319,6 +319,7 @@ type BulkUpdateAccountFilters struct {
 	Group       string
 	Search      string
 	PrivacyMode string
+	PlanType    string
 }
 
 // BulkUpdateAccountResult captures the result for a single account update.
@@ -2816,6 +2817,7 @@ func (s *adminServiceImpl) resolveBulkUpdateTargetIDs(ctx context.Context, filte
 			filters.Search,
 			groupID,
 			filters.PrivacyMode,
+			filters.PlanType,
 			"",
 			"",
 		)

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -295,7 +294,6 @@ type UpdateAccountInput struct {
 // BulkUpdateAccountsInput describes the payload for bulk updating accounts.
 type BulkUpdateAccountsInput struct {
 	AccountIDs     []int64
-	Filters        *BulkUpdateAccountFilters
 	Name           string
 	ProxyID        *int64
 	Concurrency    *int
@@ -310,16 +308,6 @@ type BulkUpdateAccountsInput struct {
 	// SkipMixedChannelCheck skips the mixed channel risk check when binding groups.
 	// This should only be set when the caller has explicitly confirmed the risk.
 	SkipMixedChannelCheck bool
-}
-
-type BulkUpdateAccountFilters struct {
-	Platform    string
-	Type        string
-	Status      string
-	Group       string
-	Search      string
-	PrivacyMode string
-	PlanType    string
 }
 
 // BulkUpdateAccountResult captures the result for a single account update.
@@ -2661,14 +2649,6 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 // BulkUpdateAccounts updates multiple accounts in one request.
 // It merges credentials/extra keys instead of overwriting the whole object.
 func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUpdateAccountsInput) (*BulkUpdateAccountsResult, error) {
-	if len(input.AccountIDs) == 0 && input.Filters != nil {
-		accountIDs, err := s.resolveBulkUpdateTargetIDs(ctx, input.Filters)
-		if err != nil {
-			return nil, err
-		}
-		input.AccountIDs = accountIDs
-	}
-
 	result := &BulkUpdateAccountsResult{
 		SuccessIDs: make([]int64, 0, len(input.AccountIDs)),
 		FailedIDs:  make([]int64, 0, len(input.AccountIDs)),
@@ -2782,56 +2762,6 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 	}
 
 	return result, nil
-}
-
-func (s *adminServiceImpl) resolveBulkUpdateTargetIDs(ctx context.Context, filters *BulkUpdateAccountFilters) ([]int64, error) {
-	if filters == nil {
-		return nil, nil
-	}
-
-	groupID := int64(0)
-	switch strings.TrimSpace(filters.Group) {
-	case "":
-	case "ungrouped":
-		groupID = AccountListGroupUngrouped
-	default:
-		parsedGroupID, err := strconv.ParseInt(strings.TrimSpace(filters.Group), 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("invalid group filter: %w", err)
-		}
-		groupID = parsedGroupID
-	}
-
-	const pageSize = 500
-	page := 1
-	accountIDs := make([]int64, 0, pageSize)
-
-	for {
-		accounts, total, err := s.ListAccounts(
-			ctx,
-			page,
-			pageSize,
-			filters.Platform,
-			filters.Type,
-			filters.Status,
-			filters.Search,
-			groupID,
-			filters.PrivacyMode,
-			filters.PlanType,
-			"",
-			"",
-		)
-		if err != nil {
-			return nil, err
-		}
-		for _, account := range accounts {
-			accountIDs = append(accountIDs, account.ID)
-		}
-		if int64(len(accountIDs)) >= total || len(accounts) == 0 {
-			return accountIDs, nil
-		}
-		page++
-	}
 }
 
 func (s *adminServiceImpl) DeleteAccount(ctx context.Context, id int64) error {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -19,6 +20,7 @@ import (
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/util/httputil"
 )
@@ -65,7 +67,7 @@ type AdminService interface {
 	ReplaceUserGroup(ctx context.Context, userID, oldGroupID, newGroupID int64) (*ReplaceUserGroupResult, error)
 
 	// Account management
-	ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, sortBy, sortOrder string) ([]Account, int64, error)
+	ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, planType string, sortBy, sortOrder string) ([]Account, int64, error)
 	GetAccount(ctx context.Context, id int64) (*Account, error)
 	GetAccountsByIDs(ctx context.Context, ids []int64) ([]*Account, error)
 	CreateAccount(ctx context.Context, input *CreateAccountInput) (*Account, error)
@@ -548,7 +550,7 @@ func NewAdminService(
 	userSubRepo UserSubscriptionRepository,
 	privacyClientFactory PrivacyClientFactory,
 ) AdminService {
-	return &adminServiceImpl{
+	svc := &adminServiceImpl{
 		userRepo:             userRepo,
 		groupRepo:            groupRepo,
 		accountRepo:          accountRepo,
@@ -567,6 +569,8 @@ func NewAdminService(
 		userSubRepo:          userSubRepo,
 		privacyClientFactory: privacyClientFactory,
 	}
+	svc.StartOpenAIPlanModelCatalogWorker(context.Background(), 24*time.Hour)
+	return svc
 }
 
 // User management implementations
@@ -2063,13 +2067,334 @@ func (s *adminServiceImpl) ReplaceUserGroup(ctx context.Context, userID, oldGrou
 }
 
 // Account management implementations
-func (s *adminServiceImpl) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, sortBy, sortOrder string) ([]Account, int64, error) {
+func (s *adminServiceImpl) ListAccounts(ctx context.Context, page, pageSize int, platform, accountType, status, search string, groupID int64, privacyMode string, planType string, sortBy, sortOrder string) ([]Account, int64, error) {
 	params := pagination.PaginationParams{Page: page, PageSize: pageSize, SortBy: sortBy, SortOrder: sortOrder}
-	accounts, result, err := s.accountRepo.ListWithFilters(ctx, params, platform, accountType, status, search, groupID, privacyMode)
+	accounts, result, err := s.accountRepo.ListWithFilters(ctx, params, platform, accountType, status, search, groupID, privacyMode, planType)
 	if err != nil {
 		return nil, 0, err
 	}
 	return accounts, result.Total, nil
+}
+
+type openAIPlanModelCatalogEntry struct {
+	Models          []string `json:"models"`
+	SampledAt       string   `json:"sampled_at,omitempty"`
+	SourceAccountID int64    `json:"source_account_id,omitempty"`
+	Status          string   `json:"status,omitempty"`
+	Error           string   `json:"error,omitempty"`
+}
+
+type openAIPlanModelCatalog struct {
+	Plans map[string]openAIPlanModelCatalogEntry `json:"plans,omitempty"`
+	Free  openAIPlanModelCatalogEntry            `json:"free,omitempty"`
+	Plus  openAIPlanModelCatalogEntry            `json:"plus,omitempty"`
+	Team  openAIPlanModelCatalogEntry            `json:"team,omitempty"`
+	Pro   openAIPlanModelCatalogEntry            `json:"pro,omitempty"`
+}
+
+var openAIPlanCatalogPlans = []string{"free", "plus", "team", "pro"}
+
+func hasExplicitModelMapping(credentials map[string]any) bool {
+	if credentials == nil {
+		return false
+	}
+	raw, ok := credentials["model_mapping"]
+	if !ok || raw == nil {
+		return false
+	}
+	switch v := raw.(type) {
+	case map[string]any:
+		return len(v) > 0
+	case map[string]string:
+		return len(v) > 0
+	case string:
+		return strings.TrimSpace(v) != ""
+	default:
+		return true
+	}
+}
+
+func normalizeOpenAIPlanType(value any) string {
+	var raw string
+	switch v := value.(type) {
+	case string:
+		raw = v
+	case fmt.Stringer:
+		raw = v.String()
+	default:
+		raw = fmt.Sprint(v)
+	}
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	switch raw {
+	case "free", "plus", "team", "pro":
+		return raw
+	default:
+		return "unknown"
+	}
+}
+
+func defaultOpenAIPlanModels(planType string) []string {
+	switch normalizeOpenAIPlanType(planType) {
+	case "free":
+		return []string{"gpt-5.3-codex"}
+	case "plus":
+		return []string{"gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini"}
+	case "team":
+		return []string{"gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"}
+	case "pro":
+		return openai.DefaultModelIDs()
+	default:
+		return []string{"gpt-5.3-codex", "gpt-5.4", "gpt-5.4-mini"}
+	}
+}
+
+func identityModelMapping(models []string) map[string]any {
+	if len(models) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(models))
+	for _, model := range models {
+		model = strings.TrimSpace(model)
+		if model == "" {
+			continue
+		}
+		out[model] = model
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (s *adminServiceImpl) openAIPlanModelMapping(ctx context.Context, planType string) map[string]any {
+	plan := normalizeOpenAIPlanType(planType)
+	models := s.openAIPlanModelsFromCatalog(ctx, plan)
+	if len(models) == 0 {
+		models = defaultOpenAIPlanModels(plan)
+	}
+	return identityModelMapping(models)
+}
+
+func (s *adminServiceImpl) openAIPlanModelsFromCatalog(ctx context.Context, plan string) []string {
+	if s == nil || s.settingService == nil || s.settingService.settingRepo == nil {
+		return nil
+	}
+	raw, err := s.settingService.settingRepo.GetValue(ctx, SettingKeyOpenAIPlanModelCatalog)
+	if err != nil || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	var catalog openAIPlanModelCatalog
+	if err := json.Unmarshal([]byte(raw), &catalog); err != nil {
+		slog.Warn("openai_plan_model_catalog_parse_failed", "error", err)
+		return nil
+	}
+	if catalog.Plans != nil {
+		if entry, ok := catalog.Plans[plan]; ok && len(entry.Models) > 0 {
+			return entry.Models
+		}
+	}
+	switch plan {
+	case "free":
+		return catalog.Free.Models
+	case "plus":
+		return catalog.Plus.Models
+	case "team":
+		return catalog.Team.Models
+	case "pro":
+		return catalog.Pro.Models
+	default:
+		return nil
+	}
+}
+
+func (s *adminServiceImpl) StartOpenAIPlanModelCatalogWorker(ctx context.Context, interval time.Duration) {
+	if s == nil || s.accountRepo == nil || s.settingService == nil || s.settingService.settingRepo == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = 24 * time.Hour
+	}
+	go func() {
+		timer := time.NewTimer(5 * time.Minute)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			refreshCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			if err := s.RefreshOpenAIPlanModelCatalog(refreshCtx); err != nil {
+				slog.Warn("openai_plan_model_catalog_refresh_failed", "error", err)
+			}
+			cancel()
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+			}
+		}
+	}()
+}
+
+func (s *adminServiceImpl) RefreshOpenAIPlanModelCatalog(ctx context.Context) error {
+	if s == nil || s.accountRepo == nil || s.settingService == nil || s.settingService.settingRepo == nil {
+		return nil
+	}
+	catalog := s.readOpenAIPlanModelCatalog(ctx)
+	if catalog.Plans == nil {
+		catalog.Plans = map[string]openAIPlanModelCatalogEntry{}
+	}
+	for _, plan := range openAIPlanCatalogPlans {
+		catalog.Plans[plan] = s.sampleOpenAIPlanCatalogEntry(ctx, plan, catalog.Plans[plan])
+	}
+	payload, err := json.Marshal(catalog)
+	if err != nil {
+		return err
+	}
+	return s.settingService.settingRepo.Set(ctx, SettingKeyOpenAIPlanModelCatalog, string(payload))
+}
+
+func (s *adminServiceImpl) readOpenAIPlanModelCatalog(ctx context.Context) openAIPlanModelCatalog {
+	if s == nil || s.settingService == nil || s.settingService.settingRepo == nil {
+		return openAIPlanModelCatalog{}
+	}
+	raw, err := s.settingService.settingRepo.GetValue(ctx, SettingKeyOpenAIPlanModelCatalog)
+	if err != nil || strings.TrimSpace(raw) == "" {
+		return openAIPlanModelCatalog{}
+	}
+	var catalog openAIPlanModelCatalog
+	if err := json.Unmarshal([]byte(raw), &catalog); err != nil {
+		slog.Warn("openai_plan_model_catalog_parse_failed", "error", err)
+		return openAIPlanModelCatalog{}
+	}
+	if catalog.Plans == nil {
+		catalog.Plans = map[string]openAIPlanModelCatalogEntry{}
+	}
+	for _, plan := range openAIPlanCatalogPlans {
+		if _, ok := catalog.Plans[plan]; ok {
+			continue
+		}
+		switch plan {
+		case "free":
+			catalog.Plans[plan] = catalog.Free
+		case "plus":
+			catalog.Plans[plan] = catalog.Plus
+		case "team":
+			catalog.Plans[plan] = catalog.Team
+		case "pro":
+			catalog.Plans[plan] = catalog.Pro
+		}
+	}
+	return catalog
+}
+
+func (s *adminServiceImpl) sampleOpenAIPlanCatalogEntry(ctx context.Context, plan string, previous openAIPlanModelCatalogEntry) openAIPlanModelCatalogEntry {
+	account, err := s.pickOpenAIPlanSampleAccount(ctx, plan)
+	if err != nil {
+		previous.Status = "error"
+		previous.Error = err.Error()
+		return previous
+	}
+	if account == nil {
+		previous.Status = "no_account"
+		previous.Error = "no usable OpenAI OAuth account for plan"
+		return previous
+	}
+
+	candidates := previous.Models
+	if len(candidates) == 0 {
+		candidates = defaultOpenAIPlanModels(plan)
+	}
+	nextModels := make([]string, 0, len(candidates))
+	temporaryErr := ""
+	for _, model := range candidates {
+		supported, unsupported, err := probeOpenAIPlanModel(ctx, account, model)
+		if supported {
+			nextModels = append(nextModels, model)
+			continue
+		}
+		if unsupported {
+			continue
+		}
+		if err != nil && temporaryErr == "" {
+			temporaryErr = err.Error()
+		}
+		nextModels = append(nextModels, model)
+	}
+	if temporaryErr != "" {
+		previous.Status = "error"
+		previous.Error = temporaryErr
+		return previous
+	}
+	return openAIPlanModelCatalogEntry{
+		Models:          nextModels,
+		SampledAt:       time.Now().UTC().Format(time.RFC3339),
+		SourceAccountID: account.ID,
+		Status:          "ok",
+	}
+}
+
+func (s *adminServiceImpl) pickOpenAIPlanSampleAccount(ctx context.Context, plan string) (*Account, error) {
+	accounts, _, err := s.accountRepo.ListWithFilters(ctx, pagination.PaginationParams{Page: 1, PageSize: 20}, PlatformOpenAI, AccountTypeOAuth, StatusActive, "", 0, "", plan)
+	if err != nil {
+		return nil, err
+	}
+	for i := range accounts {
+		token, _ := accounts[i].Credentials["access_token"].(string)
+		if strings.TrimSpace(token) == "" {
+			continue
+		}
+		return &accounts[i], nil
+	}
+	return nil, nil
+}
+
+func probeOpenAIPlanModel(ctx context.Context, account *Account, model string) (supported bool, unsupported bool, err error) {
+	token, _ := account.Credentials["access_token"].(string)
+	if strings.TrimSpace(token) == "" {
+		return false, false, errors.New("missing access_token")
+	}
+	body, err := json.Marshal(map[string]any{
+		"model":             model,
+		"input":             "ping",
+		"store":             false,
+		"stream":            false,
+		"max_output_tokens": 1,
+	})
+	if err != nil {
+		return false, false, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, chatgptCodexURL, bytes.NewReader(body))
+	if err != nil {
+		return false, false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, false, err
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return true, false, nil
+	}
+	lowerBody := strings.ToLower(string(respBody))
+	if strings.Contains(lowerBody, "model_not_found") ||
+		strings.Contains(lowerBody, "unsupported model") ||
+		strings.Contains(lowerBody, "model is not supported") ||
+		strings.Contains(lowerBody, "does not exist") {
+		return false, true, nil
+	}
+	return false, false, fmt.Errorf("sample model %s failed with status %d", model, resp.StatusCode)
 }
 
 func (s *adminServiceImpl) GetAccount(ctx context.Context, id int64) (*Account, error) {
@@ -2110,6 +2435,19 @@ func (s *adminServiceImpl) CreateAccount(ctx context.Context, input *CreateAccou
 	if len(groupIDs) > 0 && !input.SkipMixedChannelCheck {
 		if err := s.checkMixedChannelRisk(ctx, 0, input.Platform, groupIDs); err != nil {
 			return nil, err
+		}
+	}
+
+	if input.Platform == PlatformOpenAI && input.Type == AccountTypeOAuth && !hasExplicitModelMapping(input.Credentials) {
+		if input.Credentials == nil {
+			input.Credentials = map[string]any{}
+		}
+		planType := normalizeOpenAIPlanType(input.Credentials["plan_type"])
+		if planType == "unknown" {
+			planType = normalizeOpenAIPlanType(input.Credentials["chatgpt_plan_type"])
+		}
+		if mapping := s.openAIPlanModelMapping(ctx, planType); len(mapping) > 0 {
+			input.Credentials["model_mapping"] = mapping
 		}
 	}
 

--- a/backend/internal/service/admin_service_bulk_update_test.go
+++ b/backend/internal/service/admin_service_bulk_update_test.go
@@ -5,7 +5,6 @@ package service
 import (
 	"context"
 	"errors"
-	"reflect"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
@@ -32,14 +31,6 @@ type accountRepoStubForBulkUpdate struct {
 	listErr          error
 	listCalled       bool
 	lastListParams   pagination.PaginationParams
-	lastListFilters  struct {
-		platform    string
-		accountType string
-		status      string
-		search      string
-		groupID     int64
-		privacyMode string
-	}
 }
 
 func (s *accountRepoStubForBulkUpdate) BulkUpdate(_ context.Context, ids []int64, _ AccountBulkUpdate) (int64, error) {
@@ -88,15 +79,9 @@ func (s *accountRepoStubForBulkUpdate) ListByGroup(_ context.Context, groupID in
 	return nil, nil
 }
 
-func (s *accountRepoStubForBulkUpdate) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (s *accountRepoStubForBulkUpdate) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error) {
 	s.listCalled = true
 	s.lastListParams = params
-	s.lastListFilters.platform = platform
-	s.lastListFilters.accountType = accountType
-	s.lastListFilters.status = status
-	s.lastListFilters.search = search
-	s.lastListFilters.groupID = groupID
-	s.lastListFilters.privacyMode = privacyMode
 	if s.listErr != nil {
 		return nil, nil, s.listErr
 	}
@@ -204,7 +189,7 @@ func TestAdminService_BulkUpdateAccounts_MixedChannelPreCheckBlocksOnExistingCon
 	require.Empty(t, repo.bindGroupsCalls)
 }
 
-func TestAdminServiceBulkUpdateAccounts_ResolvesIDsFromFilters(t *testing.T) {
+func TestAdminServiceBulkUpdateAccounts_RequiresSelectedAccountIDs(t *testing.T) {
 	repo := &accountRepoStubForBulkUpdate{
 		listData: []Account{
 			{ID: 7},
@@ -219,30 +204,12 @@ func TestAdminServiceBulkUpdateAccounts_ResolvesIDsFromFilters(t *testing.T) {
 		Schedulable: &schedulable,
 	}
 
-	filtersField := reflect.ValueOf(input).Elem().FieldByName("Filters")
-	require.True(t, filtersField.IsValid(), "BulkUpdateAccountsInput should expose Filters for filter-target bulk update")
-	require.Equal(t, reflect.Ptr, filtersField.Kind(), "BulkUpdateAccountsInput.Filters should be a pointer field")
-
-	filtersValue := reflect.New(filtersField.Type().Elem())
-	filtersValue.Elem().FieldByName("Platform").SetString(PlatformOpenAI)
-	filtersValue.Elem().FieldByName("Type").SetString(AccountTypeOAuth)
-	filtersValue.Elem().FieldByName("Status").SetString(StatusActive)
-	filtersValue.Elem().FieldByName("Group").SetString("12")
-	filtersValue.Elem().FieldByName("PrivacyMode").SetString(PrivacyModeCFBlocked)
-	filtersValue.Elem().FieldByName("Search").SetString("bulk-target")
-	filtersField.Set(filtersValue)
-
 	result, err := svc.BulkUpdateAccounts(context.Background(), input)
 	require.NoError(t, err)
-	require.True(t, repo.listCalled, "expected filter-target bulk update to resolve matching IDs via account list filters")
-	require.Equal(t, PlatformOpenAI, repo.lastListFilters.platform)
-	require.Equal(t, AccountTypeOAuth, repo.lastListFilters.accountType)
-	require.Equal(t, StatusActive, repo.lastListFilters.status)
-	require.Equal(t, "bulk-target", repo.lastListFilters.search)
-	require.Equal(t, int64(12), repo.lastListFilters.groupID)
-	require.Equal(t, PrivacyModeCFBlocked, repo.lastListFilters.privacyMode)
-	require.Equal(t, []int64{7, 11}, repo.bulkUpdateIDs)
-	require.Equal(t, 2, result.Success)
+	require.False(t, repo.listCalled, "bulk update must not resolve targets from list filters")
+	require.Empty(t, repo.bulkUpdateIDs)
+	require.Equal(t, 0, result.Success)
 	require.Equal(t, 0, result.Failed)
-	require.Equal(t, []int64{7, 11}, result.SuccessIDs)
+	require.Empty(t, result.SuccessIDs)
+	require.Empty(t, result.FailedIDs)
 }

--- a/backend/internal/service/admin_service_openai_plan_mapping_test.go
+++ b/backend/internal/service/admin_service_openai_plan_mapping_test.go
@@ -1,0 +1,133 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+type accountRepoStubForCreateOpenAIPlan struct {
+	accountRepoStub
+	created *Account
+}
+
+func (s *accountRepoStubForCreateOpenAIPlan) Create(_ context.Context, account *Account) error {
+	copiedCredentials := map[string]any{}
+	for key, value := range account.Credentials {
+		copiedCredentials[key] = value
+	}
+	copied := *account
+	copied.Credentials = copiedCredentials
+	s.created = &copied
+	return nil
+}
+
+type accountRepoStubForOpenAIPlanCatalog struct {
+	accountRepoStub
+}
+
+func (s *accountRepoStubForOpenAIPlanCatalog) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, string, int64, string, string) ([]Account, *pagination.PaginationResult, error) {
+	return []Account{}, &pagination.PaginationResult{Total: 0}, nil
+}
+
+type settingRepoStubForOpenAIPlanCatalog struct {
+	settingRepoStub
+}
+
+func (s *settingRepoStubForOpenAIPlanCatalog) Set(_ context.Context, key, value string) error {
+	if s.values == nil {
+		s.values = map[string]string{}
+	}
+	s.values[key] = value
+	return nil
+}
+
+func TestAdminService_CreateAccount_OpenAIOAuthPlanModelMapping(t *testing.T) {
+	t.Run("无手动 model_mapping 时按 plan_type 写入默认映射", func(t *testing.T) {
+		repo := &accountRepoStubForCreateOpenAIPlan{}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		account, err := svc.CreateAccount(context.Background(), &CreateAccountInput{
+			Name:                 "openai-plus",
+			Platform:             PlatformOpenAI,
+			Type:                 AccountTypeOAuth,
+			Credentials:          map[string]any{"plan_type": "plus"},
+			Concurrency:          1,
+			Priority:             1,
+			SkipDefaultGroupBind: true,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, account)
+		require.NotNil(t, repo.created)
+		mapping, ok := repo.created.Credentials["model_mapping"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "gpt-5.3-codex", mapping["gpt-5.3-codex"])
+		require.Equal(t, "gpt-5.4", mapping["gpt-5.4"])
+	})
+
+	t.Run("已有 model_mapping 时不覆盖", func(t *testing.T) {
+		repo := &accountRepoStubForCreateOpenAIPlan{}
+		svc := &adminServiceImpl{accountRepo: repo}
+		manualMapping := map[string]any{"custom": "upstream-custom"}
+
+		account, err := svc.CreateAccount(context.Background(), &CreateAccountInput{
+			Name:                 "openai-manual",
+			Platform:             PlatformOpenAI,
+			Type:                 AccountTypeOAuth,
+			Credentials:          map[string]any{"plan_type": "pro", "model_mapping": manualMapping},
+			Concurrency:          1,
+			Priority:             1,
+			SkipDefaultGroupBind: true,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, account)
+		require.Equal(t, manualMapping, repo.created.Credentials["model_mapping"])
+	})
+
+	t.Run("缓存目录存在时优先使用缓存模型", func(t *testing.T) {
+		repo := &accountRepoStubForCreateOpenAIPlan{}
+		settingSvc := NewSettingService(&settingRepoStub{values: map[string]string{
+			SettingKeyOpenAIPlanModelCatalog: `{"plans":{"team":{"models":["cached-team-model"],"status":"ok"}}}`,
+		}}, &config.Config{})
+		svc := &adminServiceImpl{accountRepo: repo, settingService: settingSvc}
+
+		_, err := svc.CreateAccount(context.Background(), &CreateAccountInput{
+			Name:                 "openai-team",
+			Platform:             PlatformOpenAI,
+			Type:                 AccountTypeOAuth,
+			Credentials:          map[string]any{"plan_type": "team"},
+			Concurrency:          1,
+			Priority:             1,
+			SkipDefaultGroupBind: true,
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, map[string]any{"cached-team-model": "cached-team-model"}, repo.created.Credentials["model_mapping"])
+	})
+}
+
+func TestAdminService_RefreshOpenAIPlanModelCatalog_NoAccountKeepsCachedModels(t *testing.T) {
+	settingRepo := &settingRepoStubForOpenAIPlanCatalog{settingRepoStub: settingRepoStub{values: map[string]string{
+		SettingKeyOpenAIPlanModelCatalog: `{"plans":{"plus":{"models":["cached-plus-model"],"status":"ok"}}}`,
+	}}}
+	svc := &adminServiceImpl{
+		accountRepo:    &accountRepoStubForOpenAIPlanCatalog{},
+		settingService: NewSettingService(settingRepo, &config.Config{}),
+	}
+
+	err := svc.RefreshOpenAIPlanModelCatalog(context.Background())
+
+	require.NoError(t, err)
+	var catalog openAIPlanModelCatalog
+	require.NoError(t, json.Unmarshal([]byte(settingRepo.values[SettingKeyOpenAIPlanModelCatalog]), &catalog))
+	require.Equal(t, []string{"cached-plus-model"}, catalog.Plans["plus"].Models)
+	require.Equal(t, "no_account", catalog.Plans["plus"].Status)
+}

--- a/backend/internal/service/admin_service_search_test.go
+++ b/backend/internal/service/admin_service_search_test.go
@@ -20,12 +20,13 @@ type accountRepoStubForAdminList struct {
 	listWithFiltersStatus   string
 	listWithFiltersSearch   string
 	listWithFiltersPrivacy  string
+	listWithFiltersPlanType string
 	listWithFiltersAccounts []Account
 	listWithFiltersResult   *pagination.PaginationResult
 	listWithFiltersErr      error
 }
 
-func (s *accountRepoStubForAdminList) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (s *accountRepoStubForAdminList) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error) {
 	s.listWithFiltersCalls++
 	s.listWithFiltersParams = params
 	s.listWithFiltersPlatform = platform
@@ -33,6 +34,7 @@ func (s *accountRepoStubForAdminList) ListWithFilters(_ context.Context, params 
 	s.listWithFiltersStatus = status
 	s.listWithFiltersSearch = search
 	s.listWithFiltersPrivacy = privacyMode
+	s.listWithFiltersPlanType = planType
 
 	if s.listWithFiltersErr != nil {
 		return nil, nil, s.listWithFiltersErr
@@ -170,7 +172,7 @@ func TestAdminService_ListAccounts_WithSearch(t *testing.T) {
 		}
 		svc := &adminServiceImpl{accountRepo: repo}
 
-		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformGemini, AccountTypeOAuth, StatusActive, "acc", 0, "", "name", "ASC")
+		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformGemini, AccountTypeOAuth, StatusActive, "acc", 0, "", "", "name", "ASC")
 		require.NoError(t, err)
 		require.Equal(t, int64(10), total)
 		require.Equal(t, []Account{{ID: 1, Name: "acc"}}, accounts)
@@ -192,11 +194,27 @@ func TestAdminService_ListAccounts_WithPrivacyMode(t *testing.T) {
 		}
 		svc := &adminServiceImpl{accountRepo: repo}
 
-		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, StatusActive, "acc2", 0, PrivacyModeCFBlocked, "", "")
+		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, StatusActive, "acc2", 0, PrivacyModeCFBlocked, "", "", "")
 		require.NoError(t, err)
 		require.Equal(t, int64(1), total)
 		require.Equal(t, []Account{{ID: 2, Name: "acc2"}}, accounts)
 		require.Equal(t, PrivacyModeCFBlocked, repo.listWithFiltersPrivacy)
+	})
+}
+
+func TestAdminService_ListAccounts_WithPlanType(t *testing.T) {
+	t.Run("plan_type 参数正常传递到 repository 层", func(t *testing.T) {
+		repo := &accountRepoStubForAdminList{
+			listWithFiltersAccounts: []Account{{ID: 3, Name: "acc3"}},
+			listWithFiltersResult:   &pagination.PaginationResult{Total: 1},
+		}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, StatusActive, "acc3", 0, "", "plus", "", "")
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		require.Equal(t, []Account{{ID: 3, Name: "acc3"}}, accounts)
+		require.Equal(t, "plus", repo.listWithFiltersPlanType)
 	})
 }
 

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -224,6 +224,7 @@ const (
 	SettingKeyGeminiQuotaPolicy = "gemini_quota_policy"
 
 	// Model fallback settings
+	SettingKeyOpenAIPlanModelCatalog   = "openai_plan_model_catalog"
 	SettingKeyEnableModelFallback      = "enable_model_fallback"
 	SettingKeyFallbackModelAnthropic   = "fallback_model_anthropic"
 	SettingKeyFallbackModelOpenAI      = "fallback_model_openai"

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -92,7 +92,7 @@ func (m *mockAccountRepoForPlatform) Delete(ctx context.Context, id int64) error
 func (m *mockAccountRepoForPlatform) List(ctx context.Context, params pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
-func (m *mockAccountRepoForPlatform) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (m *mockAccountRepoForPlatform) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
 func (m *mockAccountRepoForPlatform) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -79,7 +79,7 @@ func (m *mockAccountRepoForGemini) Delete(ctx context.Context, id int64) error  
 func (m *mockAccountRepoForGemini) List(ctx context.Context, params pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
-func (m *mockAccountRepoForGemini) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (m *mockAccountRepoForGemini) ListWithFilters(ctx context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error) {
 	return nil, nil, nil
 }
 func (m *mockAccountRepoForGemini) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -44,6 +44,7 @@ type codexTransformResult struct {
 	Modified        bool
 	NormalizedModel string
 	PromptCacheKey  string
+	ForceCodexCLI   bool
 }
 
 const (
@@ -80,6 +81,7 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 		model = v
 	}
 	normalizedModel := strings.TrimSpace(model)
+	requestedCodexModel := normalizeCodexModel(normalizedModel)
 	if normalizedModel != "" {
 		if model != normalizedModel {
 			reqBody["model"] = normalizedModel
@@ -88,6 +90,14 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 		result.NormalizedModel = normalizedModel
 	}
 	if normalizeCodexReasoningEffortForModel(reqBody, normalizedModel) {
+		result.Modified = true
+	}
+	if isCodexSparkModel(normalizedModel) {
+		result.ForceCodexCLI = true
+	}
+	if upstreamModel := normalizeChatGPTCodexModelForUpstream(normalizedModel); upstreamModel != "" && upstreamModel != normalizedModel {
+		reqBody["model"] = upstreamModel
+		result.NormalizedModel = upstreamModel
 		result.Modified = true
 	}
 
@@ -174,7 +184,7 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 	if applyInstructions(reqBody, isCodexCLI) {
 		result.Modified = true
 	}
-	if isCodexSparkModel(normalizedModel) && applyCodexSparkImageUnsupportedInstructions(reqBody) {
+	if requestedCodexModel == "gpt-5.3-codex-spark" && applyCodexSparkImageUnsupportedInstructions(reqBody) {
 		result.Modified = true
 	}
 
@@ -499,6 +509,15 @@ func normalizeCodexModel(model string) string {
 
 func isCodexSparkModel(model string) bool {
 	return normalizeCodexModel(model) == "gpt-5.3-codex-spark"
+}
+
+func normalizeChatGPTCodexModelForUpstream(model string) string {
+	switch normalizeCodexModel(model) {
+	case "gpt-5.3-codex-spark":
+		return "gpt-5.3-codex"
+	default:
+		return strings.TrimSpace(model)
+	}
 }
 
 func defaultCodexReasoningEffort(model string) string {

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -87,6 +87,9 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 		}
 		result.NormalizedModel = normalizedModel
 	}
+	if normalizeCodexReasoningEffortForModel(reqBody, normalizedModel) {
+		result.Modified = true
+	}
 
 	if isCompact {
 		if _, ok := reqBody["store"]; ok {
@@ -496,6 +499,83 @@ func normalizeCodexModel(model string) string {
 
 func isCodexSparkModel(model string) bool {
 	return normalizeCodexModel(model) == "gpt-5.3-codex-spark"
+}
+
+func defaultCodexReasoningEffort(model string) string {
+	switch normalizeCodexModel(model) {
+	case "gpt-5.3-codex", "gpt-5.3-codex-spark":
+		return "medium"
+	default:
+		return ""
+	}
+}
+
+func normalizeCodexReasoningEffortForModel(reqBody map[string]any, model string) bool {
+	if len(reqBody) == 0 {
+		return false
+	}
+	fallback := defaultCodexReasoningEffort(model)
+	if fallback == "" {
+		return false
+	}
+
+	nextEffort := fallback
+	if rawEffort, ok := readOpenAIReasoningEffortRaw(reqBody); ok {
+		normalized, known := normalizeCodexReasoningEffortValue(rawEffort, fallback)
+		if !known {
+			return false
+		}
+		nextEffort = normalized
+	} else if derivedEffort := deriveOpenAIReasoningEffortFromModel(model); derivedEffort != "" {
+		nextEffort = derivedEffort
+	}
+
+	modified := false
+	reasoning, _ := reqBody["reasoning"].(map[string]any)
+	if reasoning == nil {
+		reasoning = map[string]any{}
+		reqBody["reasoning"] = reasoning
+		modified = true
+	}
+	if effort, _ := reasoning["effort"].(string); effort != nextEffort {
+		reasoning["effort"] = nextEffort
+		modified = true
+	}
+	if _, ok := reqBody["reasoning_effort"]; ok {
+		delete(reqBody, "reasoning_effort")
+		modified = true
+	}
+	return modified
+}
+
+func readOpenAIReasoningEffortRaw(reqBody map[string]any) (string, bool) {
+	if reasoning, ok := reqBody["reasoning"].(map[string]any); ok {
+		if effort, ok := reasoning["effort"].(string); ok {
+			return effort, true
+		}
+	}
+	if effort, ok := reqBody["reasoning_effort"].(string); ok {
+		return effort, true
+	}
+	return "", false
+}
+
+func normalizeCodexReasoningEffortValue(raw string, fallback string) (string, bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return fallback, true
+	}
+	value = strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
+	switch value {
+	case "none", "minimal":
+		return fallback, true
+	case "low", "medium", "high":
+		return value, true
+	case "xhigh", "extrahigh":
+		return "xhigh", true
+	default:
+		return "", false
+	}
 }
 
 func hasOpenAIImageGenerationTool(reqBody map[string]any) bool {

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -953,6 +953,14 @@ func TestApplyCodexOAuthTransform_NormalizesCodexReasoningEffort(t *testing.T) {
 			wantEffort: "high",
 		},
 		{
+			name: "model suffix none uses default",
+			reqBody: map[string]any{
+				"model": "gpt-5.3-codex-spark-none",
+				"input": []any{},
+			},
+			wantEffort: "medium",
+		},
+		{
 			name: "invalid effort stays untouched",
 			reqBody: map[string]any{
 				"model":            "gpt-5.3-codex-spark",

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -844,7 +844,7 @@ func TestNormalizeCodexModel_RemovedModelsFallbackToSupportedTargets(t *testing.
 	}
 }
 
-func TestApplyCodexOAuthTransform_PreservesBareSparkModel(t *testing.T) {
+func TestApplyCodexOAuthTransform_RewritesBareSparkModelForChatGPTCodex(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.3-codex-spark",
 		"input": []any{},
@@ -852,8 +852,9 @@ func TestApplyCodexOAuthTransform_PreservesBareSparkModel(t *testing.T) {
 
 	result := applyCodexOAuthTransform(reqBody, false, false)
 
-	require.Equal(t, "gpt-5.3-codex-spark", reqBody["model"])
-	require.Equal(t, "gpt-5.3-codex-spark", result.NormalizedModel)
+	require.Equal(t, "gpt-5.3-codex", reqBody["model"])
+	require.Equal(t, "gpt-5.3-codex", result.NormalizedModel)
+	require.True(t, result.ForceCodexCLI)
 	store, ok := reqBody["store"].(bool)
 	require.True(t, ok)
 	require.False(t, store)
@@ -862,7 +863,7 @@ func TestApplyCodexOAuthTransform_PreservesBareSparkModel(t *testing.T) {
 	require.Equal(t, "medium", reasoning["effort"])
 }
 
-func TestApplyCodexOAuthTransform_TrimmedModelWithoutPolicyRewrite(t *testing.T) {
+func TestApplyCodexOAuthTransform_TrimmedSparkModelRewritesForChatGPTCodex(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "  gpt-5.3-codex-spark  ",
 		"input": []any{},
@@ -870,8 +871,9 @@ func TestApplyCodexOAuthTransform_TrimmedModelWithoutPolicyRewrite(t *testing.T)
 
 	result := applyCodexOAuthTransform(reqBody, false, false)
 
-	require.Equal(t, "gpt-5.3-codex-spark", reqBody["model"])
-	require.Equal(t, "gpt-5.3-codex-spark", result.NormalizedModel)
+	require.Equal(t, "gpt-5.3-codex", reqBody["model"])
+	require.Equal(t, "gpt-5.3-codex", result.NormalizedModel)
+	require.True(t, result.ForceCodexCLI)
 	require.True(t, result.Modified)
 }
 

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -857,6 +857,9 @@ func TestApplyCodexOAuthTransform_PreservesBareSparkModel(t *testing.T) {
 	store, ok := reqBody["store"].(bool)
 	require.True(t, ok)
 	require.False(t, store)
+	reasoning, ok := reqBody["reasoning"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "medium", reasoning["effort"])
 }
 
 func TestApplyCodexOAuthTransform_TrimmedModelWithoutPolicyRewrite(t *testing.T) {
@@ -870,6 +873,113 @@ func TestApplyCodexOAuthTransform_TrimmedModelWithoutPolicyRewrite(t *testing.T)
 	require.Equal(t, "gpt-5.3-codex-spark", reqBody["model"])
 	require.Equal(t, "gpt-5.3-codex-spark", result.NormalizedModel)
 	require.True(t, result.Modified)
+}
+
+func TestApplyCodexOAuthTransform_DefaultsCodexReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+	}{
+		{name: "codex", model: "gpt-5.3-codex"},
+		{name: "spark", model: "gpt-5.3-codex-spark"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqBody := map[string]any{
+				"model": tt.model,
+				"input": []any{},
+			}
+
+			result := applyCodexOAuthTransform(reqBody, false, false)
+
+			require.True(t, result.Modified)
+			reasoning, ok := reqBody["reasoning"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, "medium", reasoning["effort"])
+		})
+	}
+}
+
+func TestApplyCodexOAuthTransform_NormalizesCodexReasoningEffort(t *testing.T) {
+	tests := []struct {
+		name        string
+		reqBody     map[string]any
+		wantEffort  string
+		wantFlatKey bool
+	}{
+		{
+			name: "spark none uses default",
+			reqBody: map[string]any{
+				"model":     "gpt-5.3-codex-spark",
+				"input":     []any{},
+				"reasoning": map[string]any{"effort": "none"},
+			},
+			wantEffort: "medium",
+		},
+		{
+			name: "spark minimal uses default",
+			reqBody: map[string]any{
+				"model":     "gpt-5.3-codex-spark",
+				"input":     []any{},
+				"reasoning": map[string]any{"effort": "minimal"},
+			},
+			wantEffort: "medium",
+		},
+		{
+			name: "spark keeps supported effort",
+			reqBody: map[string]any{
+				"model":     "gpt-5.3-codex-spark",
+				"input":     []any{},
+				"reasoning": map[string]any{"effort": "x-high"},
+			},
+			wantEffort: "xhigh",
+		},
+		{
+			name: "flat effort moves to reasoning",
+			reqBody: map[string]any{
+				"model":            "gpt-5.3-codex-spark",
+				"input":            []any{},
+				"reasoning_effort": "low",
+			},
+			wantEffort: "low",
+		},
+		{
+			name: "model suffix supplies effort",
+			reqBody: map[string]any{
+				"model": "gpt-5.3-codex-spark-high",
+				"input": []any{},
+			},
+			wantEffort: "high",
+		},
+		{
+			name: "invalid effort stays untouched",
+			reqBody: map[string]any{
+				"model":            "gpt-5.3-codex-spark",
+				"input":            []any{},
+				"reasoning_effort": "turbo",
+			},
+			wantFlatKey: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyCodexOAuthTransform(tt.reqBody, false, false)
+
+			if tt.wantFlatKey {
+				require.Equal(t, "turbo", tt.reqBody["reasoning_effort"])
+				_, ok := tt.reqBody["reasoning"]
+				require.False(t, ok)
+				return
+			}
+
+			reasoning, ok := tt.reqBody["reasoning"].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tt.wantEffort, reasoning["effort"])
+			require.NotContains(t, tt.reqBody, "reasoning_effort")
+		})
+	}
 }
 
 func TestApplyCodexOAuthTransform_CodexCLI_PreservesExistingInstructions(t *testing.T) {

--- a/backend/internal/service/openai_compat_model.go
+++ b/backend/internal/service/openai_compat_model.go
@@ -65,6 +65,20 @@ func splitOpenAICompatReasoningModel(model string) (normalizedModel string, reas
 		return trimmed, "", false
 	}
 
+	if strings.HasSuffix(strings.TrimSpace(modelID), ")") {
+		openParen := strings.LastIndex(modelID, "(")
+		if openParen > 0 {
+			suffix := strings.TrimSpace(strings.TrimSuffix(modelID[openParen+1:], ")"))
+			if effort, valid := normalizeOpenAICompatReasoningSuffix(suffix); valid {
+				baseModel := strings.TrimSpace(modelID[:openParen])
+				if baseModel == "" {
+					return trimmed, "", false
+				}
+				return normalizeCodexModel(baseModel), effort, true
+			}
+		}
+	}
+
 	parts := strings.FieldsFunc(strings.ToLower(modelID), func(r rune) bool {
 		switch r {
 		case '-', '_', ' ':
@@ -78,17 +92,31 @@ func splitOpenAICompatReasoningModel(model string) (normalizedModel string, reas
 	}
 
 	last := strings.NewReplacer("-", "", "_", "", " ", "").Replace(parts[len(parts)-1])
-	switch last {
-	case "none", "minimal":
-	case "low", "medium", "high":
-		reasoningEffort = last
-	case "xhigh", "extrahigh":
-		reasoningEffort = "xhigh"
-	default:
+	reasoningEffort, ok = normalizeOpenAICompatReasoningSuffix(last)
+	if !ok {
 		return trimmed, "", false
 	}
 
 	return normalizeCodexModel(modelID), reasoningEffort, true
+}
+
+func normalizeOpenAICompatReasoningSuffix(raw string) (reasoningEffort string, ok bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return "", false
+	}
+	value = strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
+
+	switch value {
+	case "none", "minimal":
+	case "low", "medium", "high":
+		return value, true
+	case "xhigh", "extrahigh":
+		return "xhigh", true
+	default:
+		return "", false
+	}
+	return "", true
 }
 
 func openAIReasoningEffortToClaudeOutputEffort(effort string) string {

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -27,6 +27,8 @@ func TestNormalizeOpenAICompatRequestedModel(t *testing.T) {
 		want  string
 	}{
 		{name: "gpt reasoning alias strips xhigh", input: "gpt-5.4-xhigh", want: "gpt-5.4"},
+		{name: "gpt parenthesized reasoning alias strips xhigh", input: "gpt-5.5(xhigh)", want: "gpt-5.5"},
+		{name: "gpt spaced parenthesized reasoning alias strips xhigh", input: "gpt-5.5 (x-high)", want: "gpt-5.5"},
 		{name: "gpt reasoning alias strips none", input: "gpt-5.4-none", want: "gpt-5.4"},
 		{name: "codex max model stays intact", input: "gpt-5.1-codex-max", want: "gpt-5.1-codex-max"},
 		{name: "non openai model unchanged", input: "claude-opus-4-6", want: "claude-opus-4-6"},
@@ -48,6 +50,16 @@ func TestApplyOpenAICompatModelNormalization(t *testing.T) {
 		applyOpenAICompatModelNormalization(req)
 
 		require.Equal(t, "gpt-5.4", req.Model)
+		require.NotNil(t, req.OutputConfig)
+		require.Equal(t, "max", req.OutputConfig.Effort)
+	})
+
+	t.Run("derives xhigh from parenthesized model suffix when output config missing", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{Model: "gpt-5.5(xhigh)"}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "gpt-5.5", req.Model)
 		require.NotNil(t, req.OutputConfig)
 		require.Equal(t, "max", req.OutputConfig.Effort)
 	})
@@ -129,6 +141,60 @@ func TestForwardAsAnthropic_NormalizesRoutingAndEffortForGpt54XHigh(t *testing.T
 	require.Equal(t, "ok", gjson.GetBytes(rec.Body.Bytes(), "content.0.text").String())
 	t.Logf("upstream body: %s", string(upstream.lastBody))
 	t.Logf("response body: %s", rec.Body.String())
+}
+
+func TestForwardAsAnthropic_NormalizesParenthesizedRoutingAndEffortForGpt55XHigh(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5(xhigh)","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_compat"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.5",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.1")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gpt-5.5(xhigh)", result.Model)
+	require.Equal(t, "gpt-5.5", result.UpstreamModel)
+	require.Equal(t, "gpt-5.5", result.BillingModel)
+	require.NotNil(t, result.ReasoningEffort)
+	require.Equal(t, "xhigh", *result.ReasoningEffort)
+
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "xhigh", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "gpt-5.5(xhigh)", gjson.GetBytes(rec.Body.Bytes(), "model").String())
+	require.Equal(t, "ok", gjson.GetBytes(rec.Body.Bytes(), "content.0.text").String())
 }
 
 func TestForwardAsAnthropic_ForcedCodexInstructionsTemplatePrependsRenderedInstructions(t *testing.T) {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -156,7 +156,8 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
 			return nil, fmt.Errorf("unmarshal for codex transform: %w", err)
 		}
-		codexResult := applyCodexOAuthTransform(reqBody, false, false)
+		upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
+		codexResult := applyCodexOAuthTransform(reqBody, upstreamIsCodexCLI, false)
 		if codexResult.NormalizedModel != "" {
 			upstreamModel = codexResult.NormalizedModel
 		}
@@ -189,7 +190,8 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	}
 
 	// 6. Build upstream request
-	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, responsesBody, token, true, promptCacheKey, false)
+	upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
+	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, responsesBody, token, true, promptCacheKey, upstreamIsCodexCLI)
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)
 	}

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -151,13 +151,16 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	}
 	logger.L().Debug("openai chat_completions: model mapping applied", logFields...)
 
+	upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 	if account.Type == AccountTypeOAuth {
 		var reqBody map[string]any
 		if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
 			return nil, fmt.Errorf("unmarshal for codex transform: %w", err)
 		}
-		upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 		codexResult := applyCodexOAuthTransform(reqBody, upstreamIsCodexCLI, false)
+		if codexResult.ForceCodexCLI {
+			upstreamIsCodexCLI = true
+		}
 		if codexResult.NormalizedModel != "" {
 			upstreamModel = codexResult.NormalizedModel
 		}
@@ -165,6 +168,12 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 			promptCacheKey = codexResult.PromptCacheKey
 		} else if promptCacheKey != "" {
 			reqBody["prompt_cache_key"] = promptCacheKey
+		}
+		if normalizeOpenAICodexInternalServiceTier(reqBody) {
+			responsesReq.ServiceTier = ""
+			if tier := extractOpenAIServiceTier(reqBody); tier != nil {
+				responsesReq.ServiceTier = *tier
+			}
 		}
 		responsesBody, err = json.Marshal(reqBody)
 		if err != nil {
@@ -190,7 +199,6 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	}
 
 	// 6. Build upstream request
-	upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, responsesBody, token, true, promptCacheKey, upstreamIsCodexCLI)
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -85,7 +85,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
 			return nil, fmt.Errorf("unmarshal for codex transform: %w", err)
 		}
-		codexResult := applyCodexOAuthTransform(reqBody, false, false)
+		upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
+		codexResult := applyCodexOAuthTransform(reqBody, upstreamIsCodexCLI, false)
 		forcedTemplateText := ""
 		if s.cfg != nil {
 			forcedTemplateText = s.cfg.Gateway.ForcedCodexInstructionsTemplate
@@ -163,7 +164,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	// 6. Build upstream request
-	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, responsesBody, token, isStream, promptCacheKey, false)
+	upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
+	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, responsesBody, token, isStream, promptCacheKey, upstreamIsCodexCLI)
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)
 	}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -80,13 +80,16 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		return nil, fmt.Errorf("marshal responses request: %w", err)
 	}
 
+	upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 	if account.Type == AccountTypeOAuth {
 		var reqBody map[string]any
 		if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
 			return nil, fmt.Errorf("unmarshal for codex transform: %w", err)
 		}
-		upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 		codexResult := applyCodexOAuthTransform(reqBody, upstreamIsCodexCLI, false)
+		if codexResult.ForceCodexCLI {
+			upstreamIsCodexCLI = true
+		}
 		forcedTemplateText := ""
 		if s.cfg != nil {
 			forcedTemplateText = s.cfg.Gateway.ForcedCodexInstructionsTemplate
@@ -112,6 +115,12 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			promptCacheKey = codexResult.PromptCacheKey
 		} else if promptCacheKey != "" {
 			reqBody["prompt_cache_key"] = promptCacheKey
+		}
+		if normalizeOpenAICodexInternalServiceTier(reqBody) {
+			responsesReq.ServiceTier = ""
+			if tier := extractOpenAIServiceTier(reqBody); tier != nil {
+				responsesReq.ServiceTier = *tier
+			}
 		}
 		// OAuth codex transform forces stream=true upstream, so always use
 		// the streaming response handler regardless of what the client asked.
@@ -164,7 +173,6 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	// 6. Build upstream request
-	upstreamIsCodexCLI := requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, responsesBody, token, isStream, promptCacheKey, upstreamIsCodexCLI)
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -5537,6 +5537,10 @@ func deriveOpenAIReasoningEffortFromModel(model string) string {
 		return ""
 	}
 
+	if _, effort, ok := splitOpenAICompatReasoningModel(model); ok {
+		return effort
+	}
+
 	modelID := strings.TrimSpace(model)
 	if strings.Contains(modelID, "/") {
 		parts := strings.Split(modelID, "/")
@@ -5622,6 +5626,22 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 			next, err := sjson.SetBytes(normalized, "stream", true)
 			if err != nil {
 				return body, false, fmt.Errorf("normalize passthrough body stream=true: %w", err)
+			}
+			normalized = next
+			changed = true
+		}
+	}
+
+	model := strings.TrimSpace(gjson.GetBytes(normalized, "model").String())
+	if defaultCodexReasoningEffort(model) != "" {
+		reqBody := make(map[string]any)
+		if err := json.Unmarshal(normalized, &reqBody); err != nil {
+			return body, false, fmt.Errorf("normalize passthrough body reasoning: %w", err)
+		}
+		if normalizeCodexReasoningEffortForModel(reqBody, model) {
+			next, err := json.Marshal(reqBody)
+			if err != nil {
+				return body, false, fmt.Errorf("serialize passthrough body reasoning: %w", err)
 			}
 			normalized = next
 			changed = true

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2234,17 +2234,25 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
+	forceCodexCLIHeaders := false
 	if account.Type == AccountTypeOAuth {
 		codexResult := applyCodexOAuthTransform(reqBody, isCodexCLI, isCompactRequest)
 		if codexResult.Modified {
 			bodyModified = true
 			disablePatch()
 		}
+		if codexResult.ForceCodexCLI {
+			forceCodexCLIHeaders = true
+		}
 		if codexResult.NormalizedModel != "" {
 			upstreamModel = codexResult.NormalizedModel
 		}
 		if codexResult.PromptCacheKey != "" {
 			promptCacheKey = codexResult.PromptCacheKey
+		}
+		if normalizeOpenAICodexInternalServiceTier(reqBody) {
+			bodyModified = true
+			disablePatch()
 		}
 	}
 
@@ -2491,7 +2499,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				wsReqBody,
 				token,
 				wsDecision,
-				isCodexCLI,
+				isCodexCLI || forceCodexCLIHeaders,
 				reqStream,
 				originalModel,
 				upstreamModel,
@@ -2606,7 +2614,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	for {
 		// Build upstream request
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-		upstreamIsCodexCLI := isCodexCLI || requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
+		upstreamIsCodexCLI := isCodexCLI || forceCodexCLIHeaders || requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
 		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, reqStream, promptCacheKey, upstreamIsCodexCLI)
 		releaseUpstreamCtx()
 		if err != nil {
@@ -2790,12 +2798,16 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 			return nil, fmt.Errorf("openai passthrough rejected before upstream: %s", rejectReason)
 		}
 
+		forceCodexCLIHeaders := requiresCodexCLIHeadersForOAuthModel(account, gjson.GetBytes(body, "model").String())
 		normalizedBody, normalized, err := normalizeOpenAIPassthroughOAuthBody(body, isOpenAIResponsesCompactPath(c))
 		if err != nil {
 			return nil, err
 		}
 		if normalized {
 			body = normalizedBody
+		}
+		if forceCodexCLIHeaders && c != nil {
+			c.Set("openai_passthrough_force_codex_cli_headers", true)
 		}
 		reqStream = gjson.GetBytes(body, "stream").Bool()
 	}
@@ -2858,7 +2870,13 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 
 	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-	upstreamReq, err := s.buildUpstreamRequestOpenAIPassthrough(upstreamCtx, c, account, body, token)
+	forceCodexCLIHeaders := false
+	if c != nil {
+		if v, ok := c.Get("openai_passthrough_force_codex_cli_headers"); ok {
+			forceCodexCLIHeaders = v == true
+		}
+	}
+	upstreamReq, err := s.buildUpstreamRequestOpenAIPassthrough(upstreamCtx, c, account, body, token, forceCodexCLIHeaders)
 	releaseUpstreamCtx()
 	if err != nil {
 		return nil, err
@@ -2983,6 +3001,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	account *Account,
 	body []byte,
 	token string,
+	forceCodexCLIHeaders bool,
 ) (*http.Request, error) {
 	targetURL := openaiPlatformAPIURL
 	switch account.Type {
@@ -3028,7 +3047,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	// OAuth 透传到 ChatGPT internal API 时补齐必要头。
 	if account.Type == AccountTypeOAuth {
 		promptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
-		forceCodexCLIHeaders := requiresCodexCLIHeadersForOAuthModel(account, gjson.GetBytes(body, "model").String())
+		forceCodexCLIHeaders = forceCodexCLIHeaders || requiresCodexCLIHeadersForOAuthModel(account, gjson.GetBytes(body, "model").String())
 		req.Host = "chatgpt.com"
 		if chatgptAccountID := account.GetChatGPTAccountID(); chatgptAccountID != "" {
 			req.Header.Set("chatgpt-account-id", chatgptAccountID)
@@ -5632,6 +5651,13 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		}
 	}
 
+	if next, ok, err := normalizeOpenAICodexInternalServiceTierBody(normalized); err != nil {
+		return body, false, fmt.Errorf("normalize passthrough body service_tier: %w", err)
+	} else if ok {
+		normalized = next
+		changed = true
+	}
+
 	model := strings.TrimSpace(gjson.GetBytes(normalized, "model").String())
 	if defaultCodexReasoningEffort(model) != "" {
 		reqBody := make(map[string]any)
@@ -5646,6 +5672,14 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 			normalized = next
 			changed = true
 		}
+	}
+	if upstreamModel := normalizeChatGPTCodexModelForUpstream(model); upstreamModel != "" && upstreamModel != model {
+		next, err := sjson.SetBytes(normalized, "model", upstreamModel)
+		if err != nil {
+			return body, false, fmt.Errorf("normalize passthrough body model: %w", err)
+		}
+		normalized = next
+		changed = true
 	}
 
 	return normalized, changed, nil
@@ -5726,6 +5760,72 @@ func normalizeOpenAIServiceTier(raw string) *string {
 	default:
 		return nil
 	}
+}
+
+// normalizeOpenAICodexInternalServiceTier removes service_tier values that are
+// valid for the public OpenAI API but rejected by ChatGPT's internal Codex
+// endpoint. API key accounts do not use this helper.
+func normalizeOpenAICodexInternalServiceTier(reqBody map[string]any) bool {
+	if reqBody == nil {
+		return false
+	}
+	raw, exists := reqBody["service_tier"]
+	if !exists {
+		return false
+	}
+	rawString, ok := raw.(string)
+	if !ok {
+		delete(reqBody, "service_tier")
+		return true
+	}
+	normalized, keep := normalizeOpenAICodexInternalServiceTierValue(rawString)
+	if !keep {
+		delete(reqBody, "service_tier")
+		return true
+	}
+	if rawString != normalized {
+		reqBody["service_tier"] = normalized
+		return true
+	}
+	return false
+}
+
+func normalizeOpenAICodexInternalServiceTierBody(body []byte) ([]byte, bool, error) {
+	if len(body) == 0 {
+		return body, false, nil
+	}
+	value := gjson.GetBytes(body, "service_tier")
+	if !value.Exists() {
+		return body, false, nil
+	}
+	if value.Type != gjson.String {
+		next, err := sjson.DeleteBytes(body, "service_tier")
+		return next, true, err
+	}
+	normalized, keep := normalizeOpenAICodexInternalServiceTierValue(value.String())
+	if !keep {
+		next, err := sjson.DeleteBytes(body, "service_tier")
+		return next, true, err
+	}
+	if value.String() == normalized {
+		return body, false, nil
+	}
+	next, err := sjson.SetBytes(body, "service_tier", normalized)
+	return next, true, err
+}
+
+func normalizeOpenAICodexInternalServiceTierValue(raw string) (string, bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return "", false
+	}
+	if value == "fast" {
+		value = "priority"
+	}
+	if value == "priority" {
+		return value, true
+	}
+	return "", false
 }
 
 // OpenAIFastBlockedError indicates a request was rejected by the OpenAI fast

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1213,6 +1213,10 @@ func resolveOpenAIUpstreamOriginator(c *gin.Context, isOfficialClient bool) stri
 	return "opencode"
 }
 
+func requiresCodexCLIHeadersForOAuthModel(account *Account, model string) bool {
+	return account != nil && account.Type == AccountTypeOAuth && isCodexSparkModel(model)
+}
+
 // BindStickySession sets session -> account binding with standard TTL.
 func (s *OpenAIGatewayService) BindStickySession(ctx context.Context, groupID *int64, sessionHash string, accountID int64) error {
 	if sessionHash == "" || accountID <= 0 {
@@ -2602,7 +2606,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	for {
 		// Build upstream request
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, reqStream, promptCacheKey, isCodexCLI)
+		upstreamIsCodexCLI := isCodexCLI || requiresCodexCLIHeadersForOAuthModel(account, upstreamModel)
+		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, reqStream, promptCacheKey, upstreamIsCodexCLI)
 		releaseUpstreamCtx()
 		if err != nil {
 			return nil, err
@@ -3023,6 +3028,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	// OAuth 透传到 ChatGPT internal API 时补齐必要头。
 	if account.Type == AccountTypeOAuth {
 		promptCacheKey := strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
+		forceCodexCLIHeaders := requiresCodexCLIHeadersForOAuthModel(account, gjson.GetBytes(body, "model").String())
 		req.Host = "chatgpt.com"
 		if chatgptAccountID := account.GetChatGPTAccountID(); chatgptAccountID != "" {
 			req.Header.Set("chatgpt-account-id", chatgptAccountID)
@@ -3045,8 +3051,13 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 		if req.Header.Get("OpenAI-Beta") == "" {
 			req.Header.Set("OpenAI-Beta", "responses=experimental")
 		}
-		if req.Header.Get("originator") == "" {
+		if forceCodexCLIHeaders {
 			req.Header.Set("originator", "codex_cli_rs")
+		} else if req.Header.Get("originator") == "" {
+			req.Header.Set("originator", "codex_cli_rs")
+		}
+		if req.Header.Get("version") == "" {
+			req.Header.Set("version", codexCLIVersion)
 		}
 		// 用隔离后的 session 标识符覆盖客户端透传值，防止跨用户会话碰撞。
 		if clientSessionID == "" {
@@ -3732,6 +3743,9 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		} else {
 			req.Header.Set("accept", "text/event-stream")
 		}
+		if req.Header.Get("version") == "" {
+			req.Header.Set("version", codexCLIVersion)
+		}
 		if promptCacheKey != "" {
 			isolated := isolateOpenAISessionID(apiKeyID, promptCacheKey)
 			req.Header.Set("conversation_id", isolated)
@@ -3748,6 +3762,9 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	// 若开启 ForceCodexCLI，则强制将上游 User-Agent 伪装为 Codex CLI。
 	// 用于网关未透传/改写 User-Agent 时，仍能命中 Codex 侧识别逻辑。
 	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		req.Header.Set("user-agent", codexCLIUserAgent)
+	}
+	if account.Type == AccountTypeOAuth && !openai.IsCodexCLIRequest(req.Header.Get("user-agent")) {
 		req.Header.Set("user-agent", codexCLIUserAgent)
 	}
 

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -86,6 +86,13 @@ func TestExtractOpenAIReasoningEffortFromBody(t *testing.T) {
 			wantValue: "high",
 		},
 		{
+			name:      "缺失字段时从括号模型后缀推导",
+			body:      []byte(`{"input":"hi"}`),
+			model:     "gpt-5.5(xhigh)",
+			wantNil:   false,
+			wantValue: "xhigh",
+		},
+		{
 			name:    "未知后缀不返回",
 			body:    []byte(`{"input":"hi"}`),
 			model:   "gpt-5-unknown",

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1794,7 +1794,7 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCompactPath(t *test
 	svc := &OpenAIGatewayService{}
 	account := &Account{Type: AccountTypeOAuth}
 
-	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token")
+	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token", false)
 	require.NoError(t, err)
 	require.Equal(t, chatgptCodexURL+"/compact", req.URL.String())
 	require.Equal(t, "application/json", req.Header.Get("Accept"))

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -1209,3 +1209,37 @@ func TestOpenAIGatewayService_OAuthPassthrough_AllowTimeoutHeadersWhenConfigured
 	require.Equal(t, "120000", upstream.lastReq.Header.Get("x-stainless-timeout"))
 	require.Empty(t, upstream.lastReq.Header.Get("X-Test"))
 }
+
+func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesSparkReasoning(t *testing.T) {
+	t.Run("explicit none uses default", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex-spark","stream":false,"reasoning":{"effort":"none"},"input":[]}`)
+
+		got, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
+		require.True(t, gjson.GetBytes(got, "stream").Bool())
+		require.False(t, gjson.GetBytes(got, "store").Bool())
+	})
+
+	t.Run("missing effort uses default", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex-spark","input":[]}`)
+
+		got, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
+	})
+
+	t.Run("supported effort is preserved", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex-spark","reasoning":{"effort":"x-high"},"input":[]}`)
+
+		got, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.Equal(t, "xhigh", gjson.GetBytes(got, "reasoning.effort").String())
+	})
+}

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -448,6 +448,55 @@ func TestOpenAIGatewayService_OAuthLegacy_CompositeCodexUAUsesCodexOriginator(t 
 	require.NotEqual(t, "opencode", upstream.lastReq.Header.Get("originator"))
 }
 
+func TestOpenAIGatewayService_ForwardAsAnthropic_SparkUsesCodexCLIIdentityForAnyUserAgent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "claude-cli/2.1.92 (external, cli)")
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	inputBody := []byte(`{"model":"gpt-5.3-codex-spark","max_tokens":16,"messages":[{"role":"user","content":"hi"}],"stream":true}`)
+
+	upstreamSSE := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.3-codex-spark","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"spark-ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_spark"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, inputBody, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "codex_cli_rs", upstream.lastReq.Header.Get("originator"))
+	require.Equal(t, codexCLIVersion, upstream.lastReq.Header.Get("version"))
+	require.Equal(t, codexCLIUserAgent, upstream.lastReq.Header.Get("User-Agent"))
+}
+
 func TestOpenAIGatewayService_OAuthPassthrough_ResponseHeadersAllowXCodex(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -491,7 +491,7 @@ func TestOpenAIGatewayService_ForwardAsAnthropic_SparkUsesCodexCLIIdentityForAny
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.NotNil(t, upstream.lastReq)
-	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, "codex_cli_rs", upstream.lastReq.Header.Get("originator"))
 	require.Equal(t, codexCLIVersion, upstream.lastReq.Header.Get("version"))
 	require.Equal(t, codexCLIUserAgent, upstream.lastReq.Header.Get("User-Agent"))
@@ -929,6 +929,98 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamingSetsFirstTokenMs(t *test
 	require.Equal(t, "priority", *result.ServiceTier)
 }
 
+func TestOpenAIGatewayService_OAuthLegacy_DropsFlexServiceTierBeforeCodexUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	originalBody := []byte(`{"model":"gpt-5.3-codex","stream":true,"service_tier":"flex","instructions":"local-test-instructions","input":[{"type":"input_text","text":"hi"}]}`)
+	upstreamSSE := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"h"}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, originalBody)
+
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "service_tier").Exists())
+	require.Nil(t, result.ServiceTier)
+	require.Equal(t, "https://chatgpt.com/backend-api/codex/responses", upstream.lastReq.URL.String())
+}
+
+func TestOpenAIGatewayService_OAuthLegacy_MapsFastServiceTierToPriorityForCodexUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	originalBody := []byte(`{"model":"gpt-5.3-codex","stream":true,"service_tier":"fast","instructions":"local-test-instructions","input":[{"type":"input_text","text":"hi"}]}`)
+	upstreamSSE := strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"h"}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, originalBody)
+
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "priority", gjson.GetBytes(upstream.lastBody, "service_tier").String())
+	require.NotNil(t, result.ServiceTier)
+	require.Equal(t, "priority", *result.ServiceTier)
+}
+
 func TestOpenAIGatewayService_OAuthPassthrough_StreamClientDisconnectStillCollectsUsage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -1218,6 +1310,7 @@ func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesSparkReasoning(t *testing
 
 		require.NoError(t, err)
 		require.True(t, changed)
+		require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(got, "model").String())
 		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
 		require.True(t, gjson.GetBytes(got, "stream").Bool())
 		require.False(t, gjson.GetBytes(got, "store").Bool())
@@ -1230,6 +1323,7 @@ func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesSparkReasoning(t *testing
 
 		require.NoError(t, err)
 		require.True(t, changed)
+		require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(got, "model").String())
 		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
 	})
 
@@ -1240,6 +1334,30 @@ func TestNormalizeOpenAIPassthroughOAuthBody_NormalizesSparkReasoning(t *testing
 
 		require.NoError(t, err)
 		require.True(t, changed)
+		require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(got, "model").String())
 		require.Equal(t, "xhigh", gjson.GetBytes(got, "reasoning.effort").String())
+	})
+}
+
+func TestNormalizeOpenAIPassthroughOAuthBody_ServiceTierForCodexInternal(t *testing.T) {
+	t.Run("flex is removed", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex","stream":true,"service_tier":"flex","input":[]}`)
+
+		got, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.False(t, gjson.GetBytes(got, "service_tier").Exists())
+		require.True(t, gjson.GetBytes(got, "stream").Bool())
+	})
+
+	t.Run("fast maps to priority", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex","stream":true,"service_tier":"fast","input":[]}`)
+
+		got, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.Equal(t, "priority", gjson.GetBytes(got, "service_tier").String())
 	})
 }

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1835,7 +1835,8 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	storeDisabledConnMode := s.openAIWSStoreDisabledConnMode()
 	forceNewConnByPolicy := shouldForceNewConnOnStoreDisabled(storeDisabledConnMode, lastFailureReason)
 	forceNewConn := forceNewConnByPolicy && storeDisabled && previousResponseID == "" && sessionHash != "" && preferredConnID == ""
-	wsHeaders, sessionResolution := s.buildOpenAIWSHeaders(c, account, token, decision, isCodexCLI, turnState, turnMetadata, promptCacheKey)
+	headerIsCodexCLI := isCodexCLI || requiresCodexCLIHeadersForOAuthModel(account, openAIWSPayloadString(payload, "model"))
+	wsHeaders, sessionResolution := s.buildOpenAIWSHeaders(c, account, token, decision, headerIsCodexCLI, turnState, turnMetadata, promptCacheKey)
 	logOpenAIWSModeDebug(
 		"acquire_start account_id=%d account_type=%s transport=%s preferred_conn_id=%s has_previous_response_id=%v session_hash=%s has_turn_state=%v turn_state_len=%d has_turn_metadata=%v turn_metadata_len=%d store_disabled=%v store_disabled_conn_mode=%s retry_last_reason=%s force_new_conn=%v header_user_agent=%s header_openai_beta=%s header_originator=%s header_accept_language=%s header_session_id=%s header_conversation_id=%s session_id_source=%s conversation_id_source=%s has_prompt_cache_key=%v has_chatgpt_account_id=%v has_authorization=%v has_session_id=%v has_conversation_id=%v proxy_enabled=%v",
 		account.ID,
@@ -2478,6 +2479,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		promptCacheKey     string
 		previousResponseID string
 		originalModel      string
+		upstreamModel      string
 		payloadBytes       int
 	}
 
@@ -2625,6 +2627,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			promptCacheKey:     promptCacheKey,
 			previousResponseID: previousResponseID,
 			originalModel:      originalModel,
+			upstreamModel:      upstreamModel,
 			payloadBytes:       len(normalized),
 		}, nil
 	}
@@ -2659,7 +2662,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		}
 	}
 
-	isCodexCLI := openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator")) || (s.cfg != nil && s.cfg.Gateway.ForceCodexCLI)
+	isCodexCLI := openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator")) ||
+		(s.cfg != nil && s.cfg.Gateway.ForceCodexCLI) ||
+		requiresCodexCLIHeadersForOAuthModel(account, firstPayload.upstreamModel)
 	wsHeaders, _ := s.buildOpenAIWSHeaders(c, account, token, wsDecision, isCodexCLI, turnState, strings.TrimSpace(c.GetHeader(openAIWSTurnMetadataHeader)), firstPayload.promptCacheKey)
 	baseAcquireReq := openAIWSAcquireRequest{
 		Account: account,
@@ -3577,7 +3582,8 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if nextPayload.promptCacheKey != "" {
 			// ingress 会话在整个客户端 WS 生命周期内复用同一上游连接；
 			// prompt_cache_key 对握手头的更新仅在未来需要重新建连时生效。
-			updatedHeaders, _ := s.buildOpenAIWSHeaders(c, account, token, wsDecision, isCodexCLI, turnState, strings.TrimSpace(c.GetHeader(openAIWSTurnMetadataHeader)), nextPayload.promptCacheKey)
+			nextIsCodexCLI := isCodexCLI || requiresCodexCLIHeadersForOAuthModel(account, nextPayload.upstreamModel)
+			updatedHeaders, _ := s.buildOpenAIWSHeaders(c, account, token, wsDecision, nextIsCodexCLI, turnState, strings.TrimSpace(c.GetHeader(openAIWSTurnMetadataHeader)), nextPayload.promptCacheKey)
 			baseAcquireReq.Headers = updatedHeaders
 		}
 		if nextPayload.previousResponseID != "" {

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1201,6 +1201,9 @@ func (s *OpenAIGatewayService) buildOpenAIWSCreatePayload(reqBody map[string]any
 		payload["store"] = false
 	}
 	normalizeOpenAIWSCodexReasoningPayload(payload, account)
+	if account != nil && account.Type == AccountTypeOAuth {
+		normalizeOpenAICodexInternalServiceTier(payload)
+	}
 	return payload
 }
 
@@ -1209,7 +1212,12 @@ func normalizeOpenAIWSCodexReasoningPayload(payload map[string]any, account *Acc
 		return false
 	}
 	model, _ := payload["model"].(string)
-	return normalizeCodexReasoningEffortForModel(payload, model)
+	modified := normalizeCodexReasoningEffortForModel(payload, model)
+	if upstreamModel := normalizeChatGPTCodexModelForUpstream(model); upstreamModel != "" && upstreamModel != strings.TrimSpace(model) {
+		payload["model"] = upstreamModel
+		modified = true
+	}
+	return modified
 }
 
 func normalizeOpenAIWSCodexReasoningPayloadRaw(payload []byte, model string, account *Account) ([]byte, bool, error) {
@@ -1227,7 +1235,12 @@ func normalizeOpenAIWSCodexReasoningPayloadRaw(payload []byte, model string, acc
 	if strings.TrimSpace(model) != "" {
 		decoded["model"] = model
 	}
-	if !normalizeCodexReasoningEffortForModel(decoded, model) {
+	modified := normalizeCodexReasoningEffortForModel(decoded, model)
+	if upstreamModel := normalizeChatGPTCodexModelForUpstream(model); upstreamModel != "" && upstreamModel != strings.TrimSpace(model) {
+		decoded["model"] = upstreamModel
+		modified = true
+	}
+	if !modified {
 		return payload, false, nil
 	}
 	rebuilt, err := json.Marshal(decoded)

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1200,7 +1200,41 @@ func (s *OpenAIGatewayService) buildOpenAIWSCreatePayload(reqBody map[string]any
 	if account != nil && account.Type == AccountTypeOAuth && !s.isOpenAIWSStoreRecoveryAllowed(account) {
 		payload["store"] = false
 	}
+	normalizeOpenAIWSCodexReasoningPayload(payload, account)
 	return payload
+}
+
+func normalizeOpenAIWSCodexReasoningPayload(payload map[string]any, account *Account) bool {
+	if len(payload) == 0 || account == nil || account.Type != AccountTypeOAuth {
+		return false
+	}
+	model, _ := payload["model"].(string)
+	return normalizeCodexReasoningEffortForModel(payload, model)
+}
+
+func normalizeOpenAIWSCodexReasoningPayloadRaw(payload []byte, model string, account *Account) ([]byte, bool, error) {
+	if len(payload) == 0 || account == nil || account.Type != AccountTypeOAuth {
+		return payload, false, nil
+	}
+	if defaultCodexReasoningEffort(model) == "" {
+		return payload, false, nil
+	}
+
+	decoded := make(map[string]any)
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return payload, false, err
+	}
+	if strings.TrimSpace(model) != "" {
+		decoded["model"] = model
+	}
+	if !normalizeCodexReasoningEffortForModel(decoded, model) {
+		return payload, false, nil
+	}
+	rebuilt, err := json.Marshal(decoded)
+	if err != nil {
+		return payload, false, err
+	}
+	return rebuilt, true, nil
 }
 
 func setOpenAIWSTurnMetadata(payload map[string]any, turnMetadata string) {
@@ -2539,6 +2573,11 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			if setErr != nil {
 				return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", setErr)
 			}
+			normalized = next
+		}
+		if next, modified, normalizeErr := normalizeOpenAIWSCodexReasoningPayloadRaw(normalized, upstreamModel, account); normalizeErr != nil {
+			return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", normalizeErr)
+		} else if modified {
 			normalized = next
 		}
 

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -518,11 +519,13 @@ func TestOpenAIGatewayService_Forward_WSv2_OAuthOriginatorCompatibility(t *testi
 		name           string
 		userAgent      string
 		originator     string
+		requestModel   string
 		wantOriginator string
 	}{
 		{name: "desktop originator preserved", originator: "Codex Desktop", wantOriginator: "Codex Desktop"},
 		{name: "vscode originator preserved", originator: "codex_vscode", wantOriginator: "codex_vscode"},
 		{name: "official ua fallback to codex_cli_rs", userAgent: "Codex Desktop/1.2.3", wantOriginator: "codex_cli_rs"},
+		{name: "spark forces codex cli originator", userAgent: "claude-cli/2.1.92 (external, cli)", requestModel: "gpt-5.3-codex-spark", wantOriginator: "codex_cli_rs"},
 	}
 
 	for _, tt := range tests {
@@ -582,11 +585,19 @@ func TestOpenAIGatewayService_Forward_WSv2_OAuthOriginatorCompatibility(t *testi
 				},
 			}
 
-			body := []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"input_text","text":"hello"}]}`)
+			requestModel := tt.requestModel
+			if requestModel == "" {
+				requestModel = "gpt-5.1"
+			}
+			body := []byte(fmt.Sprintf(`{"model":%q,"stream":false,"input":[{"type":"input_text","text":"hello"}]}`, requestModel))
 			result, err := svc.Forward(context.Background(), c, account, body)
 			require.NoError(t, err)
 			require.NotNil(t, result)
 			require.Equal(t, tt.wantOriginator, captureDialer.lastHeaders.Get("originator"))
+			if requestModel == "gpt-5.3-codex-spark" {
+				require.Equal(t, codexCLIUserAgent, captureDialer.lastHeaders.Get("user-agent"))
+				require.Equal(t, "gpt-5.3-codex-spark", captureConn.lastWrite["model"])
+			}
 		})
 	}
 }

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -219,6 +219,7 @@ func TestNormalizeOpenAIWSCodexReasoningPayloadRaw_OAuthSpark(t *testing.T) {
 
 		require.NoError(t, err)
 		require.True(t, modified)
+		require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(got, "model").String())
 		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
 	})
 
@@ -229,6 +230,7 @@ func TestNormalizeOpenAIWSCodexReasoningPayloadRaw_OAuthSpark(t *testing.T) {
 
 		require.NoError(t, err)
 		require.True(t, modified)
+		require.Equal(t, "gpt-5.3-codex", gjson.GetBytes(got, "model").String())
 		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
 	})
 }
@@ -596,7 +598,7 @@ func TestOpenAIGatewayService_Forward_WSv2_OAuthOriginatorCompatibility(t *testi
 			require.Equal(t, tt.wantOriginator, captureDialer.lastHeaders.Get("originator"))
 			if requestModel == "gpt-5.3-codex-spark" {
 				require.Equal(t, codexCLIUserAgent, captureDialer.lastHeaders.Get("user-agent"))
-				require.Equal(t, "gpt-5.3-codex-spark", captureConn.lastWrite["model"])
+				require.Equal(t, "gpt-5.3-codex", captureConn.lastWrite["model"])
 			}
 		})
 	}

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -182,6 +182,56 @@ func requestToJSONString(payload map[string]any) string {
 	return string(b)
 }
 
+func TestBuildOpenAIWSCreatePayload_OAuthSparkReasoningDefault(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := &Account{ID: 170, Type: AccountTypeOAuth}
+
+	t.Run("explicit none uses spark default", func(t *testing.T) {
+		payload := svc.buildOpenAIWSCreatePayload(map[string]any{
+			"model":     "gpt-5.3-codex-spark",
+			"stream":    false,
+			"input":     []any{},
+			"reasoning": map[string]any{"effort": "none"},
+		}, account)
+
+		require.Equal(t, "medium", gjson.Get(requestToJSONString(payload), "reasoning.effort").String())
+	})
+
+	t.Run("missing effort uses spark default", func(t *testing.T) {
+		payload := svc.buildOpenAIWSCreatePayload(map[string]any{
+			"model":  "gpt-5.3-codex-spark",
+			"stream": false,
+			"input":  []any{},
+		}, account)
+
+		require.Equal(t, "medium", gjson.Get(requestToJSONString(payload), "reasoning.effort").String())
+	})
+}
+
+func TestNormalizeOpenAIWSCodexReasoningPayloadRaw_OAuthSpark(t *testing.T) {
+	account := &Account{ID: 170, Type: AccountTypeOAuth}
+
+	t.Run("direct ws none uses spark default", func(t *testing.T) {
+		payload := []byte(`{"type":"response.create","model":"gpt-5.3-codex-spark","reasoning":{"effort":"none"},"input":[]}`)
+
+		got, modified, err := normalizeOpenAIWSCodexReasoningPayloadRaw(payload, "gpt-5.3-codex-spark", account)
+
+		require.NoError(t, err)
+		require.True(t, modified)
+		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
+	})
+
+	t.Run("direct ws missing effort uses spark default", func(t *testing.T) {
+		payload := []byte(`{"type":"response.create","model":"gpt-5.3-codex-spark","input":[]}`)
+
+		got, modified, err := normalizeOpenAIWSCodexReasoningPayloadRaw(payload, "gpt-5.3-codex-spark", account)
+
+		require.NoError(t, err)
+		require.True(t, modified)
+		require.Equal(t, "medium", gjson.GetBytes(got, "reasoning.effort").String())
+	})
+}
+
 func TestLogOpenAIWSBindResponseAccountWarn(t *testing.T) {
 	require.NotPanics(t, func() {
 		logOpenAIWSBindResponseAccountWarn(1, 2, "resp_ok", nil)

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -73,7 +73,7 @@ func (r *openAICodexExtraListRepo) SetRateLimited(_ context.Context, _ int64, re
 	return nil
 }
 
-func (r *openAICodexExtraListRepo) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string) ([]Account, *pagination.PaginationResult, error) {
+func (r *openAICodexExtraListRepo) ListWithFilters(_ context.Context, params pagination.PaginationParams, platform, accountType, status, search string, groupID int64, privacyMode string, planType string) ([]Account, *pagination.PaginationResult, error) {
 	_ = platform
 	_ = accountType
 	_ = status
@@ -487,7 +487,7 @@ func TestAdminService_ListAccounts_ExhaustedCodexExtraDoesNotSetRateLimit(t *tes
 	}
 	svc := &adminServiceImpl{accountRepo: repo}
 
-	accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, "", "", 0, "", "", "")
+	accounts, total, err := svc.ListAccounts(context.Background(), 1, 20, PlatformOpenAI, AccountTypeOAuth, "", "", 0, "", "", "", "")
 	require.NoError(t, err)
 	require.Equal(t, int64(1), total)
 	require.Len(t, accounts, 1)

--- a/backend/internal/service/ops_concurrency.go
+++ b/backend/internal/service/ops_concurrency.go
@@ -24,7 +24,7 @@ func (s *OpsService) listAllAccountsForOps(ctx context.Context, platformFilter s
 		accounts, pageInfo, err := s.accountRepo.ListWithFilters(ctx, pagination.PaginationParams{
 			Page:     page,
 			PageSize: opsAccountsPageSize,
-		}, platformFilter, "", "", "", 0, "")
+		}, platformFilter, "", "", "", 0, "", "")
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -81,7 +81,7 @@ func (m *sessionWindowMockRepo) Delete(context.Context, int64) error    { panic(
 func (m *sessionWindowMockRepo) List(context.Context, pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
 	panic("unexpected")
 }
-func (m *sessionWindowMockRepo) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, string, int64, string) ([]Account, *pagination.PaginationResult, error) {
+func (m *sessionWindowMockRepo) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, string, int64, string, string) ([]Account, *pagination.PaginationResult, error) {
 	panic("unexpected")
 }
 func (m *sessionWindowMockRepo) ListByGroup(context.Context, int64) ([]Account, error) {

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -372,8 +372,8 @@ export async function batchUpdateCredentials(request: {
  * @returns Success confirmation
  */
 export async function bulkUpdate(
-  accountIdsOrPayload: number[] | Record<string, unknown>,
-  updates?: Record<string, unknown>
+  accountIds: number[],
+  updates: Record<string, unknown>
 ): Promise<{
   success: number
   failed: number
@@ -381,12 +381,10 @@ export async function bulkUpdate(
   failed_ids?: number[]
   results: Array<{ account_id: number; success: boolean; error?: string }>
   }> {
-  const payload = Array.isArray(accountIdsOrPayload)
-    ? {
-        account_ids: accountIdsOrPayload,
-        ...(updates ?? {})
-      }
-    : accountIdsOrPayload
+  const payload = {
+    account_ids: accountIds,
+    ...updates
+  }
   const { data } = await apiClient.post<{
     success: number
     failed: number

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -37,6 +37,7 @@ export async function list(
     group?: string
     search?: string
     privacy_mode?: string
+    plan_type?: string
     lite?: string
     sort_by?: string
     sort_order?: 'asc' | 'desc'
@@ -72,6 +73,7 @@ export async function listWithEtag(
     group?: string
     search?: string
     privacy_mode?: string
+    plan_type?: string
     lite?: string
     sort_by?: string
     sort_order?: 'asc' | 'desc'
@@ -509,6 +511,7 @@ export async function exportData(options?: {
     status?: string
     group?: string
     privacy_mode?: string
+    plan_type?: string
     search?: string
     sort_by?: string
     sort_order?: 'asc' | 'desc'
@@ -519,12 +522,13 @@ export async function exportData(options?: {
   if (options?.ids && options.ids.length > 0) {
     params.ids = options.ids.join(',')
   } else if (options?.filters) {
-    const { platform, type, status, group, privacy_mode, search, sort_by, sort_order } = options.filters
+    const { platform, type, status, group, privacy_mode, plan_type, search, sort_by, sort_order } = options.filters
     if (platform) params.platform = platform
     if (type) params.type = type
     if (status) params.status = status
     if (group) params.group = group
     if (privacy_mode) params.privacy_mode = privacy_mode
+    if (plan_type) params.plan_type = plan_type
     if (search) params.search = search
     if (sort_by) params.sort_by = sort_by
     if (sort_order) params.sort_order = sort_order

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -17,7 +17,7 @@
               d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
             />
           </svg>
-          {{ t('admin.accounts.bulkEdit.selectionInfo', { count: targetMode === 'filtered' ? targetPreviewCount : accountIds.length }) }}
+          {{ t('admin.accounts.bulkEdit.selectionInfo', { count: accountIds.length }) }}
         </p>
       </div>
 
@@ -1014,13 +1014,6 @@ interface Props {
   accountIds: number[]
   selectedPlatforms: AccountPlatform[]
   selectedTypes: AccountType[]
-  target?: {
-    mode: 'selected' | 'filtered'
-    filters?: Record<string, unknown>
-    previewCount?: number
-    selectedPlatforms?: AccountPlatform[]
-    selectedTypes?: AccountType[]
-  }
   proxies: ProxyConfig[]
   groups: AdminGroup[]
 }
@@ -1035,10 +1028,8 @@ const { t } = useI18n()
 const appStore = useAppStore()
 
 // Platform awareness
-const targetMode = computed(() => props.target?.mode ?? 'selected')
-const targetPreviewCount = computed(() => props.target?.previewCount ?? props.accountIds.length)
-const targetSelectedPlatforms = computed(() => props.target?.selectedPlatforms ?? props.selectedPlatforms)
-const targetSelectedTypes = computed(() => props.target?.selectedTypes ?? props.selectedTypes)
+const targetSelectedPlatforms = computed(() => props.selectedPlatforms)
+const targetSelectedTypes = computed(() => props.selectedTypes)
 const isMixedPlatform = computed(() => targetSelectedPlatforms.value.length > 1)
 
 const allOpenAIPassthroughCapable = computed(() => {
@@ -1446,7 +1437,7 @@ const preCheckMixedChannelRisk = async (built: Record<string, unknown>): Promise
 }
 
 const handleSubmit = async () => {
-  if (targetMode.value === 'selected' && props.accountIds.length === 0) {
+  if (props.accountIds.length === 0) {
     appStore.showError(t('admin.accounts.bulkEdit.noSelection'))
     return
   }
@@ -1496,12 +1487,7 @@ const submitBulkUpdate = async (baseUpdates: Record<string, unknown>) => {
   submitting.value = true
 
   try {
-    const res = targetMode.value === 'filtered' && props.target?.filters
-      ? await adminAPI.accounts.bulkUpdate({
-        filters: props.target.filters,
-        ...updates
-      })
-      : await adminAPI.accounts.bulkUpdate(props.accountIds, updates)
+    const res = await adminAPI.accounts.bulkUpdate(props.accountIds, updates)
     const success = res.success || 0
     const failed = res.failed || 0
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3427,6 +3427,19 @@ const isOpenAIModelRestrictionDisabled = computed(() =>
   form.platform === 'openai' && openaiPassthroughEnabled.value
 )
 
+const isOpenAIOAuthSelection = computed(() =>
+  form.platform === 'openai' && accountCategory.value === 'oauth-based'
+)
+
+const buildOpenAIOAuthManualModelMapping = () => {
+  if (isOpenAIModelRestrictionDisabled.value) return null
+  if (modelRestrictionMode.value === 'mapping') {
+    return buildModelMappingObject('mapping', [], modelMappings.value)
+  }
+  if (allowedModels.value.length === 0) return null
+  return buildModelMappingObject('whitelist', allowedModels.value, [])
+}
+
 const mixedChannelWarningMessageText = computed(() => {
   if (mixedChannelWarningDetails.value) {
     return t('admin.accounts.mixedChannelWarning', mixedChannelWarningDetails.value)
@@ -3543,8 +3556,8 @@ watch(
       adminAPI.tlsFingerprintProfiles.list()
         .then(profiles => { tlsFingerprintProfiles.value = profiles.map(p => ({ id: p.id, name: p.name })) })
         .catch(() => { tlsFingerprintProfiles.value = [] })
-      // Modal opened - fill related models
-      allowedModels.value = [...getModelsByPlatform(form.platform)]
+      // Modal opened - fill related models unless OpenAI OAuth should wait for plan_type.
+      allowedModels.value = isOpenAIOAuthSelection.value ? [] : [...getModelsByPlatform(form.platform)]
       // Antigravity: 默认使用映射模式并填充默认映射
       if (form.platform === 'antigravity') {
         antigravityModelRestrictionMode.value = 'mapping'
@@ -3698,8 +3711,12 @@ const handleSelectGeminiOAuthType = (oauthType: 'code_assist' | 'google_one' | '
 
 // Auto-fill related models when switching to whitelist mode or changing platform
 watch(
-  [modelRestrictionMode, () => form.platform],
+  [modelRestrictionMode, () => form.platform, accountCategory],
   ([newMode]) => {
+    if (isOpenAIOAuthSelection.value) {
+      allowedModels.value = []
+      return
+    }
     if (newMode === 'whitelist') {
       allowedModels.value = [...getModelsByPlatform(form.platform)]
     }
@@ -4578,9 +4595,9 @@ const handleOpenAIExchange = async (authCode: string) => {
     const extra = buildOpenAIExtra(oauthExtra)
     const shouldCreateOpenAI = form.platform === 'openai'
 
-    // Add model mapping for OpenAI OAuth accounts（透传模式下不应用）
-    if (shouldCreateOpenAI && !isOpenAIModelRestrictionDisabled.value) {
-      const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
+    // OpenAI OAuth 默认交给后端按 plan_type 写入模型映射；这里仅提交用户手动配置。
+    if (shouldCreateOpenAI) {
+      const modelMapping = buildOpenAIOAuthManualModelMapping()
       if (modelMapping) {
         credentials.model_mapping = modelMapping
       }
@@ -4676,9 +4693,9 @@ const handleOpenAIBatchRT = async (refreshTokenInput: string, clientId?: string)
         const oauthExtra = oauthClient.buildExtraInfo(tokenInfo) as Record<string, unknown> | undefined
         const extra = buildOpenAIExtra(oauthExtra)
 
-        // Add model mapping for OpenAI OAuth accounts（透传模式下不应用）
-        if (shouldCreateOpenAI && !isOpenAIModelRestrictionDisabled.value) {
-          const modelMapping = buildModelMappingObject(modelRestrictionMode.value, allowedModels.value, modelMappings.value)
+        // OpenAI OAuth 默认交给后端按 plan_type 写入模型映射；这里仅提交用户手动配置。
+        if (shouldCreateOpenAI) {
+          const modelMapping = buildOpenAIOAuthManualModelMapping()
           if (modelMapping) {
             credentials.model_mapping = modelMapping
           }

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -257,23 +257,11 @@ describe('BulkEditAccountModal', () => {
     expect(wrapper.text()).toContain('admin.accounts.openai.modelRestrictionDisabledByPassthrough')
   })
 
-  it('filtered-results 模式下应提交 filters 而不是 account_ids', async () => {
+  it('批量编辑只提交已选择账号 ID，不提交筛选条件', async () => {
     const wrapper = mountModal({
-      accountIds: [],
-      target: {
-        mode: 'filtered',
-        filters: {
-          platform: 'openai',
-          type: 'oauth',
-          status: 'active',
-          group: '12',
-          search: 'bulk-target',
-          privacy_mode: 'training_set_cf_blocked'
-        },
-        previewCount: 5,
-        selectedPlatforms: ['openai'],
-        selectedTypes: ['oauth']
-      }
+      accountIds: [9, 10],
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
     })
 
     await wrapper.get('#bulk-edit-status-enabled').setValue(true)
@@ -281,15 +269,7 @@ describe('BulkEditAccountModal', () => {
     await flushPromises()
 
     expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
-    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith({
-      filters: {
-        platform: 'openai',
-        type: 'oauth',
-        status: 'active',
-        group: '12',
-        search: 'bulk-target',
-        privacy_mode: 'training_set_cf_blocked'
-      },
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([9, 10], {
       status: 'active'
     })
   })

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -32,14 +32,11 @@
         <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
         <button @click="$emit('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
       </template>
-      <button @click="$emit('edit-filtered')" class="btn btn-primary btn-sm">
-        {{ t('admin.accounts.bulkEdit.submit') }}
-      </button>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-defineProps(['selectedIds']); defineEmits(['delete', 'edit-selected', 'edit-filtered', 'clear', 'select-page', 'toggle-schedulable', 'reset-status', 'refresh-token']); const { t } = useI18n()
+defineProps(['selectedIds']); defineEmits(['delete', 'edit-selected', 'clear', 'select-page', 'toggle-schedulable', 'reset-status', 'refresh-token']); const { t } = useI18n()
 </script>

--- a/frontend/src/components/admin/account/AccountTableFilters.vue
+++ b/frontend/src/components/admin/account/AccountTableFilters.vue
@@ -11,11 +11,14 @@
     <div ref="filterDropdownRef" class="relative">
       <button
         type="button"
-        class="btn btn-secondary px-3"
-        @click="showFilterMenu = !showFilterMenu"
+        class="btn btn-secondary px-2.5 md:px-3"
+        :aria-expanded="showFilterMenu"
+        aria-haspopup="menu"
+        @click="toggleFilterMenu"
+        @keydown.escape.stop.prevent="closeFilterMenu"
       >
         <Icon name="filter" size="sm" class="mr-1.5" />
-        <span>筛选</span>
+        <span>{{ t('admin.accounts.filters.title') }}</span>
         <span
           v-if="activeFilterCount > 0"
           class="ml-1.5 rounded-full bg-primary-100 px-1.5 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-300"
@@ -26,11 +29,15 @@
 
       <div
         v-if="showFilterMenu"
-        class="absolute left-0 z-50 mt-2 w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-dark-600 dark:bg-dark-800"
+        class="absolute left-0 z-50 mt-2 w-[min(20rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-2 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+        role="menu"
+        @keydown.escape.stop.prevent="closeFilterMenu"
       >
         <div class="space-y-3">
           <div>
-            <div class="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-dark-400">账号</div>
+            <div class="mb-2 px-1 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.filters.account') }}
+            </div>
             <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
               <Select :model-value="filters.platform" :options="platformOptions" @update:model-value="updateFilter('platform', $event)" @change="$emit('change')" />
               <Select :model-value="filters.type" :options="typeOptions" @update:model-value="updateFilter('type', $event)" @change="$emit('change')" />
@@ -40,12 +47,16 @@
           </div>
 
           <div>
-            <div class="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-dark-400">状态</div>
+            <div class="mb-2 px-1 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.filters.status') }}
+            </div>
             <Select :model-value="filters.status" :options="statusOptions" @update:model-value="updateFilter('status', $event)" @change="$emit('change')" />
           </div>
 
           <div>
-            <div class="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-dark-400">Plan</div>
+            <div class="mb-2 px-1 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.filters.plan') }}
+            </div>
             <Select :model-value="filters.plan_type" :options="planOptions" @update:model-value="updateFilter('plan_type', $event)" @change="$emit('change')" />
           </div>
         </div>
@@ -68,7 +79,7 @@
         class="px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-dark-400 dark:hover:text-dark-200"
         @click="clearAllFilters"
       >
-        全部清除
+        {{ t('admin.accounts.filters.clearAll') }}
       </button>
     </div>
   </div>
@@ -135,12 +146,12 @@ const groupOptions = computed(() => [
 ])
 
 const planOptions = computed(() => [
-  { value: '', label: '全部 Plan' },
+  { value: '', label: t('admin.accounts.filters.allPlans') },
   { value: 'free', label: 'Free' },
   { value: 'plus', label: 'Plus' },
   { value: 'team', label: 'Team' },
   { value: 'pro', label: 'Pro' },
-  { value: '__unset__', label: '未识别' }
+  { value: '__unset__', label: t('admin.accounts.filters.unrecognizedPlan') }
 ])
 
 const optionGroups = computed<Record<string, Array<{ value: string | number | boolean | null; label: string }>>>(() => ({
@@ -152,14 +163,14 @@ const optionGroups = computed<Record<string, Array<{ value: string | number | bo
   plan_type: planOptions.value
 }))
 
-const filterNames: Record<string, string> = {
-  platform: '平台',
-  type: '类型',
-  status: '状态',
-  privacy_mode: '隐私',
-  group: '分组',
-  plan_type: 'Plan'
-}
+const filterNames = computed<Record<string, string>>(() => ({
+  platform: t('admin.accounts.filters.platform'),
+  type: t('admin.accounts.filters.type'),
+  status: t('admin.accounts.filters.status'),
+  privacy_mode: t('admin.accounts.filters.privacy'),
+  group: t('admin.accounts.filters.group'),
+  plan_type: t('admin.accounts.filters.plan')
+}))
 
 const filterKeys = ['platform', 'type', 'status', 'privacy_mode', 'group', 'plan_type']
 
@@ -170,7 +181,7 @@ const activeTags = computed(() => filterKeys
     const option = optionGroups.value[key]?.find((item) => String(item.value) === String(value))
     return {
       key,
-      label: `${filterNames[key]}: ${option?.label ?? value}`
+      label: `${filterNames.value[key]}: ${option?.label ?? value}`
     }
   })
   .filter(Boolean) as Array<{ key: string; label: string }>)
@@ -195,13 +206,33 @@ const clearAllFilters = () => {
   emit('change')
 }
 
+const toggleFilterMenu = () => {
+  showFilterMenu.value = !showFilterMenu.value
+}
+
+const closeFilterMenu = () => {
+  showFilterMenu.value = false
+}
+
 const handleClickOutside = (event: MouseEvent) => {
   const target = event.target as Node
   if (filterDropdownRef.value && !filterDropdownRef.value.contains(target)) {
-    showFilterMenu.value = false
+    closeFilterMenu()
   }
 }
 
-onMounted(() => document.addEventListener('click', handleClickOutside))
-onUnmounted(() => document.removeEventListener('click', handleClickOutside))
+const handleKeydown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    closeFilterMenu()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('click', handleClickOutside)
+  document.addEventListener('keydown', handleKeydown)
+})
+onUnmounted(() => {
+  document.removeEventListener('click', handleClickOutside)
+  document.removeEventListener('keydown', handleKeydown)
+})
 </script>

--- a/frontend/src/components/admin/account/AccountTableFilters.vue
+++ b/frontend/src/components/admin/account/AccountTableFilters.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-wrap items-center gap-3">
+  <div class="flex flex-1 flex-wrap items-center gap-2">
     <SearchInput
       :model-value="searchQuery"
       :placeholder="t('admin.accounts.searchAccounts')"
@@ -7,37 +7,201 @@
       @update:model-value="$emit('update:searchQuery', $event)"
       @search="$emit('change')"
     />
-    <Select :model-value="filters.platform" class="w-40" :options="pOpts" @update:model-value="updatePlatform" @change="$emit('change')" />
-    <Select :model-value="filters.type" class="w-40" :options="tOpts" @update:model-value="updateType" @change="$emit('change')" />
-    <Select :model-value="filters.status" class="w-40" :options="sOpts" @update:model-value="updateStatus" @change="$emit('change')" />
-    <Select :model-value="filters.privacy_mode" class="w-40" :options="privacyOpts" @update:model-value="updatePrivacyMode" @change="$emit('change')" />
-    <Select :model-value="filters.group" class="w-40" :options="gOpts" @update:model-value="updateGroup" @change="$emit('change')" />
+
+    <div ref="filterDropdownRef" class="relative">
+      <button
+        type="button"
+        class="btn btn-secondary px-3"
+        @click="showFilterMenu = !showFilterMenu"
+      >
+        <Icon name="filter" size="sm" class="mr-1.5" />
+        <span>筛选</span>
+        <span
+          v-if="activeFilterCount > 0"
+          class="ml-1.5 rounded-full bg-primary-100 px-1.5 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-300"
+        >
+          {{ activeFilterCount }}
+        </span>
+      </button>
+
+      <div
+        v-if="showFilterMenu"
+        class="absolute left-0 z-50 mt-2 w-[min(22rem,calc(100vw-2rem))] rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-dark-600 dark:bg-dark-800"
+      >
+        <div class="space-y-3">
+          <div>
+            <div class="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-dark-400">账号</div>
+            <div class="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              <Select :model-value="filters.platform" :options="platformOptions" @update:model-value="updateFilter('platform', $event)" @change="$emit('change')" />
+              <Select :model-value="filters.type" :options="typeOptions" @update:model-value="updateFilter('type', $event)" @change="$emit('change')" />
+              <Select :model-value="filters.privacy_mode" :options="privacyOptions" @update:model-value="updateFilter('privacy_mode', $event)" @change="$emit('change')" />
+              <Select :model-value="filters.group" :options="groupOptions" @update:model-value="updateFilter('group', $event)" @change="$emit('change')" />
+            </div>
+          </div>
+
+          <div>
+            <div class="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-dark-400">状态</div>
+            <Select :model-value="filters.status" :options="statusOptions" @update:model-value="updateFilter('status', $event)" @change="$emit('change')" />
+          </div>
+
+          <div>
+            <div class="mb-2 text-xs font-semibold uppercase text-gray-500 dark:text-dark-400">Plan</div>
+            <Select :model-value="filters.plan_type" :options="planOptions" @update:model-value="updateFilter('plan_type', $event)" @change="$emit('change')" />
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div v-if="activeTags.length > 0" class="flex flex-wrap items-center gap-1.5">
+      <button
+        v-for="tag in activeTags"
+        :key="tag.key"
+        type="button"
+        class="inline-flex max-w-[14rem] items-center gap-1 rounded-md bg-gray-100 px-2 py-1 text-xs text-gray-700 hover:bg-gray-200 dark:bg-dark-700 dark:text-gray-200 dark:hover:bg-dark-600"
+        @click="clearFilter(tag.key)"
+      >
+        <span class="truncate">{{ tag.label }}</span>
+        <Icon name="x" size="xs" />
+      </button>
+      <button
+        type="button"
+        class="px-2 py-1 text-xs text-gray-500 hover:text-gray-700 dark:text-dark-400 dark:hover:text-dark-200"
+        @click="clearAllFilters"
+      >
+        全部清除
+      </button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'; import { useI18n } from 'vue-i18n'; import Select from '@/components/common/Select.vue'; import SearchInput from '@/components/common/SearchInput.vue'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import Select from '@/components/common/Select.vue'
+import SearchInput from '@/components/common/SearchInput.vue'
+import Icon from '@/components/icons/Icon.vue'
 import type { AdminGroup } from '@/types'
-const props = defineProps<{ searchQuery: string; filters: Record<string, any>; groups?: AdminGroup[] }>()
-const emit = defineEmits(['update:searchQuery', 'update:filters', 'change']); const { t } = useI18n()
-const updatePlatform = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, platform: value }) }
-const updateType = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, type: value }) }
-const updateStatus = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, status: value }) }
-const updatePrivacyMode = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, privacy_mode: value }) }
-const updateGroup = (value: string | number | boolean | null) => { emit('update:filters', { ...props.filters, group: value }) }
-const pOpts = computed(() => [{ value: '', label: t('admin.accounts.allPlatforms') }, { value: 'anthropic', label: 'Anthropic' }, { value: 'openai', label: 'OpenAI' }, { value: 'gemini', label: 'Gemini' }, { value: 'antigravity', label: 'Antigravity' }])
-const tOpts = computed(() => [{ value: '', label: t('admin.accounts.allTypes') }, { value: 'oauth', label: t('admin.accounts.oauthType') }, { value: 'setup-token', label: t('admin.accounts.setupToken') }, { value: 'apikey', label: t('admin.accounts.apiKey') }, { value: 'bedrock', label: 'AWS Bedrock' }])
-const sOpts = computed(() => [{ value: '', label: t('admin.accounts.allStatus') }, { value: 'active', label: t('admin.accounts.status.active') }, { value: 'inactive', label: t('admin.accounts.status.inactive') }, { value: 'error', label: t('admin.accounts.status.error') }, { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') }, { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') }, { value: 'unschedulable', label: t('admin.accounts.status.unschedulable') }])
-const privacyOpts = computed(() => [
+
+const props = defineProps<{
+  searchQuery: string
+  filters: Record<string, any>
+  groups?: AdminGroup[]
+}>()
+
+const emit = defineEmits(['update:searchQuery', 'update:filters', 'change'])
+const { t } = useI18n()
+
+const showFilterMenu = ref(false)
+const filterDropdownRef = ref<HTMLElement | null>(null)
+
+const platformOptions = computed(() => [
+  { value: '', label: t('admin.accounts.allPlatforms') },
+  { value: 'anthropic', label: 'Anthropic' },
+  { value: 'openai', label: 'OpenAI' },
+  { value: 'gemini', label: 'Gemini' },
+  { value: 'antigravity', label: 'Antigravity' }
+])
+
+const typeOptions = computed(() => [
+  { value: '', label: t('admin.accounts.allTypes') },
+  { value: 'oauth', label: t('admin.accounts.oauthType') },
+  { value: 'setup-token', label: t('admin.accounts.setupToken') },
+  { value: 'apikey', label: t('admin.accounts.apiKey') },
+  { value: 'bedrock', label: 'AWS Bedrock' }
+])
+
+const statusOptions = computed(() => [
+  { value: '', label: t('admin.accounts.allStatus') },
+  { value: 'active', label: t('admin.accounts.status.active') },
+  { value: 'inactive', label: t('admin.accounts.status.inactive') },
+  { value: 'error', label: t('admin.accounts.status.error') },
+  { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') },
+  { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') },
+  { value: 'unschedulable', label: t('admin.accounts.status.unschedulable') }
+])
+
+const privacyOptions = computed(() => [
   { value: '', label: t('admin.accounts.allPrivacyModes') },
   { value: '__unset__', label: t('admin.accounts.privacyUnset') },
   { value: 'training_off', label: 'Privacy' },
   { value: 'training_set_cf_blocked', label: 'CF' },
   { value: 'training_set_failed', label: 'Fail' }
 ])
-const gOpts = computed(() => [
+
+const groupOptions = computed(() => [
   { value: '', label: t('admin.accounts.allGroups') },
   { value: 'ungrouped', label: t('admin.accounts.ungroupedGroup') },
-  ...(props.groups || []).map(g => ({ value: String(g.id), label: g.name }))
+  ...(props.groups || []).map((group) => ({ value: String(group.id), label: group.name }))
 ])
+
+const planOptions = computed(() => [
+  { value: '', label: '全部 Plan' },
+  { value: 'free', label: 'Free' },
+  { value: 'plus', label: 'Plus' },
+  { value: 'team', label: 'Team' },
+  { value: 'pro', label: 'Pro' },
+  { value: '__unset__', label: '未识别' }
+])
+
+const optionGroups = computed<Record<string, Array<{ value: string | number | boolean | null; label: string }>>>(() => ({
+  platform: platformOptions.value,
+  type: typeOptions.value,
+  status: statusOptions.value,
+  privacy_mode: privacyOptions.value,
+  group: groupOptions.value,
+  plan_type: planOptions.value
+}))
+
+const filterNames: Record<string, string> = {
+  platform: '平台',
+  type: '类型',
+  status: '状态',
+  privacy_mode: '隐私',
+  group: '分组',
+  plan_type: 'Plan'
+}
+
+const filterKeys = ['platform', 'type', 'status', 'privacy_mode', 'group', 'plan_type']
+
+const activeTags = computed(() => filterKeys
+  .map((key) => {
+    const value = props.filters[key]
+    if (value === '' || value === null || value === undefined) return null
+    const option = optionGroups.value[key]?.find((item) => String(item.value) === String(value))
+    return {
+      key,
+      label: `${filterNames[key]}: ${option?.label ?? value}`
+    }
+  })
+  .filter(Boolean) as Array<{ key: string; label: string }>)
+
+const activeFilterCount = computed(() => activeTags.value.length)
+
+const updateFilter = (key: string, value: string | number | boolean | null) => {
+  emit('update:filters', { ...props.filters, [key]: value ?? '' })
+}
+
+const clearFilter = (key: string) => {
+  emit('update:filters', { ...props.filters, [key]: '' })
+  emit('change')
+}
+
+const clearAllFilters = () => {
+  const next = { ...props.filters }
+  for (const key of filterKeys) {
+    next[key] = ''
+  }
+  emit('update:filters', next)
+  emit('change')
+}
+
+const handleClickOutside = (event: MouseEvent) => {
+  const target = event.target as Node
+  if (filterDropdownRef.value && !filterDropdownRef.value.contains(target)) {
+    showFilterMenu.value = false
+  }
+}
+
+onMounted(() => document.addEventListener('click', handleClickOutside))
+onUnmounted(() => document.removeEventListener('click', handleClickOutside))
 </script>

--- a/frontend/src/components/admin/account/AccountTableFilters.vue
+++ b/frontend/src/components/admin/account/AccountTableFilters.vue
@@ -50,14 +50,46 @@
             <div class="mb-2 px-1 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.filters.status') }}
             </div>
-            <Select :model-value="filters.status" :options="statusOptions" @update:model-value="updateFilter('status', $event)" @change="$emit('change')" />
+            <div class="grid grid-cols-1 gap-1 sm:grid-cols-2">
+              <button
+                v-for="option in statusMultiOptions"
+                :key="String(option.value)"
+                type="button"
+                class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                @click="toggleMultiFilter('status', String(option.value))"
+              >
+                <span
+                  class="flex h-4 w-4 items-center justify-center rounded border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-900"
+                  :class="isMultiFilterSelected('status', String(option.value)) && 'border-primary-500 bg-primary-500 text-white'"
+                >
+                  <Icon v-if="isMultiFilterSelected('status', String(option.value))" name="check" size="xs" />
+                </span>
+                <span class="truncate">{{ option.label }}</span>
+              </button>
+            </div>
           </div>
 
           <div>
             <div class="mb-2 px-1 text-xs font-semibold uppercase text-gray-500 dark:text-gray-400">
               {{ t('admin.accounts.filters.plan') }}
             </div>
-            <Select :model-value="filters.plan_type" :options="planOptions" @update:model-value="updateFilter('plan_type', $event)" @change="$emit('change')" />
+            <div class="grid grid-cols-2 gap-1">
+              <button
+                v-for="option in planMultiOptions"
+                :key="String(option.value)"
+                type="button"
+                class="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                @click="toggleMultiFilter('plan_type', String(option.value))"
+              >
+                <span
+                  class="flex h-4 w-4 items-center justify-center rounded border border-gray-300 bg-white dark:border-gray-600 dark:bg-gray-900"
+                  :class="isMultiFilterSelected('plan_type', String(option.value)) && 'border-primary-500 bg-primary-500 text-white'"
+                >
+                  <Icon v-if="isMultiFilterSelected('plan_type', String(option.value))" name="check" size="xs" />
+                </span>
+                <span class="truncate">{{ option.label }}</span>
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -127,6 +159,7 @@ const statusOptions = computed(() => [
   { value: 'inactive', label: t('admin.accounts.status.inactive') },
   { value: 'error', label: t('admin.accounts.status.error') },
   { value: 'rate_limited', label: t('admin.accounts.status.rateLimited') },
+  { value: 'not_rate_limited', label: t('admin.accounts.status.notRateLimited') },
   { value: 'temp_unschedulable', label: t('admin.accounts.status.tempUnschedulable') },
   { value: 'unschedulable', label: t('admin.accounts.status.unschedulable') }
 ])
@@ -154,6 +187,9 @@ const planOptions = computed(() => [
   { value: '__unset__', label: t('admin.accounts.filters.unrecognizedPlan') }
 ])
 
+const statusMultiOptions = computed(() => statusOptions.value.filter((option) => option.value !== ''))
+const planMultiOptions = computed(() => planOptions.value.filter((option) => option.value !== ''))
+
 const optionGroups = computed<Record<string, Array<{ value: string | number | boolean | null; label: string }>>>(() => ({
   platform: platformOptions.value,
   type: typeOptions.value,
@@ -178,10 +214,14 @@ const activeTags = computed(() => filterKeys
   .map((key) => {
     const value = props.filters[key]
     if (value === '' || value === null || value === undefined) return null
-    const option = optionGroups.value[key]?.find((item) => String(item.value) === String(value))
+    const selectedValues = splitMultiFilterValue(value)
+    const labels = selectedValues.map((selectedValue) => {
+      const option = optionGroups.value[key]?.find((item) => String(item.value) === selectedValue)
+      return option?.label ?? selectedValue
+    })
     return {
       key,
-      label: `${filterNames.value[key]}: ${option?.label ?? value}`
+      label: `${filterNames.value[key]}: ${labels.join(', ')}`
     }
   })
   .filter(Boolean) as Array<{ key: string; label: string }>)
@@ -190,6 +230,25 @@ const activeFilterCount = computed(() => activeTags.value.length)
 
 const updateFilter = (key: string, value: string | number | boolean | null) => {
   emit('update:filters', { ...props.filters, [key]: value ?? '' })
+}
+
+const splitMultiFilterValue = (value: unknown) => String(value ?? '')
+  .split(',')
+  .map((item) => item.trim())
+  .filter(Boolean)
+
+const joinMultiFilterValue = (values: string[]) => Array.from(new Set(values)).join(',')
+
+const isMultiFilterSelected = (key: string, value: string) =>
+  splitMultiFilterValue(props.filters[key]).includes(value)
+
+const toggleMultiFilter = (key: string, value: string) => {
+  const current = splitMultiFilterValue(props.filters[key])
+  const next = current.includes(value)
+    ? current.filter((item) => item !== value)
+    : [...current, value]
+  emit('update:filters', { ...props.filters, [key]: joinMultiFilterValue(next) })
+  emit('change')
 }
 
 const clearFilter = (key: string) => {

--- a/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
@@ -1,0 +1,144 @@
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import AccountTableFilters from '../AccountTableFilters.vue'
+
+const messages: Record<string, string> = {
+  'admin.accounts.searchAccounts': 'Search accounts...',
+  'admin.accounts.filters.title': 'Filters',
+  'admin.accounts.filters.account': 'Account',
+  'admin.accounts.filters.status': 'Status',
+  'admin.accounts.filters.plan': 'Plan',
+  'admin.accounts.filters.platform': 'Platform',
+  'admin.accounts.filters.type': 'Type',
+  'admin.accounts.filters.privacy': 'Privacy',
+  'admin.accounts.filters.group': 'Group',
+  'admin.accounts.filters.clearAll': 'Clear all',
+  'admin.accounts.filters.allPlans': 'All Plans',
+  'admin.accounts.filters.unrecognizedPlan': 'Unrecognized',
+  'admin.accounts.allPlatforms': 'All Platforms',
+  'admin.accounts.allTypes': 'All Types',
+  'admin.accounts.allStatus': 'All Status',
+  'admin.accounts.allGroups': 'All Groups',
+  'admin.accounts.allPrivacyModes': 'All Privacy States',
+  'admin.accounts.privacyUnset': 'Unset',
+  'admin.accounts.ungroupedGroup': 'Ungrouped',
+  'admin.accounts.oauthType': 'OAuth',
+  'admin.accounts.setupToken': 'Setup Token',
+  'admin.accounts.apiKey': 'API Key',
+  'admin.accounts.status.active': 'Active',
+  'admin.accounts.status.inactive': 'Inactive',
+  'admin.accounts.status.error': 'Error',
+  'admin.accounts.status.rateLimited': 'Rate Limited',
+  'admin.accounts.status.tempUnschedulable': 'Temp Unschedulable',
+  'admin.accounts.status.unschedulable': 'Unschedulable'
+}
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => messages[key] ?? key
+  })
+}))
+
+const SelectStub = defineComponent({
+  name: 'Select',
+  props: {
+    modelValue: [String, Number, Boolean],
+    options: {
+      type: Array,
+      default: () => []
+    }
+  },
+  emits: ['update:modelValue', 'change'],
+  methods: {
+    onChange(event: Event) {
+      this.$emit('update:modelValue', (event.target as HTMLSelectElement).value)
+      this.$emit('change')
+    }
+  },
+  template: `
+    <select
+      data-test="filter-select"
+      :value="modelValue"
+      @change="onChange"
+    >
+      <option v-for="option in options" :key="String(option.value)" :value="option.value">
+        {{ option.label }}
+      </option>
+    </select>
+  `
+})
+
+const SearchInputStub = defineComponent({
+  name: 'SearchInput',
+  props: {
+    modelValue: String,
+    placeholder: String
+  },
+  emits: ['update:modelValue', 'search'],
+  template: '<input data-test="search" :placeholder="placeholder" :value="modelValue" />'
+})
+
+const mountFilters = () => mount(AccountTableFilters, {
+  attachTo: document.body,
+  props: {
+    searchQuery: '',
+    filters: {
+      platform: 'openai',
+      type: '',
+      status: '',
+      privacy_mode: '',
+      group: '',
+      plan_type: '__unset__'
+    },
+    groups: []
+  },
+  global: {
+    stubs: {
+      Select: SelectStub,
+      SearchInput: SearchInputStub,
+      Icon: true
+    }
+  }
+})
+
+describe('AccountTableFilters', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('uses localized labels for active tags and menu text', async () => {
+    const wrapper = mountFilters()
+
+    expect(wrapper.text()).toContain('Platform: OpenAI')
+    expect(wrapper.text()).toContain('Plan: Unrecognized')
+    expect(wrapper.text()).not.toContain('平台:')
+    expect(wrapper.text()).not.toContain('未识别')
+
+    await wrapper.get('button[aria-haspopup="menu"]').trigger('click')
+
+    expect(wrapper.text()).toContain('Account')
+    expect(wrapper.text()).toContain('All Plans')
+    expect(wrapper.text()).toContain('Clear all')
+  })
+
+  it('exposes menu state and closes with Escape or outside click', async () => {
+    const wrapper = mountFilters()
+    const trigger = wrapper.get('button[aria-haspopup="menu"]')
+
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    await nextTick()
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+
+    await trigger.trigger('click')
+    expect(trigger.attributes('aria-expanded')).toBe('true')
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+    expect(trigger.attributes('aria-expanded')).toBe('false')
+  })
+})

--- a/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTableFilters.spec.ts
@@ -31,6 +31,7 @@ const messages: Record<string, string> = {
   'admin.accounts.status.inactive': 'Inactive',
   'admin.accounts.status.error': 'Error',
   'admin.accounts.status.rateLimited': 'Rate Limited',
+  'admin.accounts.status.notRateLimited': 'Not rate limited',
   'admin.accounts.status.tempUnschedulable': 'Temp Unschedulable',
   'admin.accounts.status.unschedulable': 'Unschedulable'
 }
@@ -119,7 +120,8 @@ describe('AccountTableFilters', () => {
     await wrapper.get('button[aria-haspopup="menu"]').trigger('click')
 
     expect(wrapper.text()).toContain('Account')
-    expect(wrapper.text()).toContain('All Plans')
+    expect(wrapper.text()).toContain('Plan')
+    expect(wrapper.text()).toContain('Unrecognized')
     expect(wrapper.text()).toContain('Clear all')
   })
 
@@ -140,5 +142,21 @@ describe('AccountTableFilters', () => {
     document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
     expect(trigger.attributes('aria-expanded')).toBe('false')
+  })
+
+  it('emits comma-separated values for status and plan selections', async () => {
+    const wrapper = mountFilters()
+
+    await wrapper.get('button[aria-haspopup="menu"]').trigger('click')
+    await wrapper.findAll('button').find((button) => button.text().includes('Plus'))!.trigger('click')
+    await wrapper.findAll('button').find((button) => button.text().includes('Team'))!.trigger('click')
+    await wrapper.findAll('button').find((button) => button.text().includes('Not rate limited'))!.trigger('click')
+
+    const updates = wrapper.emitted('update:filters') as Array<[Record<string, string>]>
+
+    expect(updates[0][0]).toMatchObject({ plan_type: '__unset__,plus' })
+    expect(updates[1][0]).toMatchObject({ plan_type: '__unset__,team' })
+    expect(updates[2][0]).toMatchObject({ status: 'not_rate_limited' })
+    expect(wrapper.emitted('change')).toHaveLength(3)
   })
 })

--- a/frontend/src/components/common/DataTable.vue
+++ b/frontend/src/components/common/DataTable.vue
@@ -64,12 +64,20 @@
     v-else
     ref="tableWrapperRef"
     class="table-wrapper"
+    :style="tableWrapperStyle"
     :class="{
       'actions-expanded': actionsExpanded,
       'is-scrollable': isScrollable
     }"
   >
     <table class="w-full min-w-max divide-y divide-gray-200 dark:divide-dark-700">
+      <colgroup>
+        <col
+          v-for="column in columns"
+          :key="column.key"
+          :style="getColumnStyle(column)"
+        />
+      </colgroup>
       <thead class="table-header bg-gray-50 dark:bg-dark-800">
         <tr>
           <th
@@ -80,9 +88,11 @@
               'sticky-header-cell py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-dark-400',
               getAdaptivePaddingClass(),
               { 'cursor-pointer hover:bg-gray-100 dark:hover:bg-dark-700': column.sortable },
+              { 'is-resizing': resizingColumnKey === column.key },
               getStickyColumnClass(column, index),
               column.class
             ]"
+            :style="getColumnStyle(column)"
             @click="column.sortable && handleSort(column.key)"
           >
             <slot
@@ -115,6 +125,11 @@
                 </span>
               </div>
             </slot>
+            <span
+              v-if="isColumnResizable(column)"
+              class="column-resize-handle"
+              @mousedown.stop.prevent="startColumnResize(column, $event)"
+            ></span>
           </th>
         </tr>
       </thead>
@@ -173,6 +188,7 @@
                 getStickyColumnClass(column, colIndex),
                 column.class
               ]"
+              :style="getColumnStyle(column)"
             >
               <slot :name="`cell-${column.key}`"
                     :row="sortedData[virtualRow.index]"
@@ -306,6 +322,7 @@ const attachDesktopTableTracking = () => {
 }
 
 onMounted(() => {
+  columnWidths.value = readPersistedColumnWidths()
   if (typeof window !== 'undefined') {
     desktopViewportMediaQuery = window.matchMedia(desktopViewportQuery)
     isDesktopViewport.value = desktopViewportMediaQuery.matches
@@ -361,6 +378,8 @@ interface Props {
   estimateRowHeight?: number
   /** Number of rows to render beyond the visible area (default 5) */
   overscan?: number
+  /** Persist resized desktop column widths to localStorage using this key. */
+  columnWidthStorageKey?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -375,10 +394,132 @@ const props = withDefaults(defineProps<Props>(), {
 const sortKey = ref<string>('')
 const sortOrder = ref<'asc' | 'desc'>('asc')
 const actionsExpanded = ref(false)
+const columnWidths = ref<Record<string, number>>({})
+const resizingColumnKey = ref<string | null>(null)
+
+type ColumnWidthState = Record<string, number>
 
 type PersistedSortState = {
   key: string
   order: 'asc' | 'desc'
+}
+
+const parseColumnWidth = (value: number | string | undefined): number | null => {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null
+  if (typeof value !== 'string') return null
+  const match = value.trim().match(/^(\d+(?:\.\d+)?)px$/)
+  if (!match) return null
+  const parsed = Number(match[1])
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+const clampColumnWidth = (column: Column, width: number): number => {
+  const min = column.minWidth ?? 56
+  const max = column.maxWidth ?? 640
+  return Math.min(max, Math.max(min, Math.round(width)))
+}
+
+const getColumnWidth = (column: Column): number | null => {
+  const persisted = columnWidths.value[column.key]
+  if (Number.isFinite(persisted)) return clampColumnWidth(column, persisted)
+  return parseColumnWidth(column.width)
+}
+
+const getColumnStyle = (column: Column) => {
+  const width = getColumnWidth(column)
+  const style: Record<string, string> = {}
+  if (width !== null) {
+    style.width = `${width}px`
+    style.minWidth = `${column.minWidth ?? width}px`
+    if (column.maxWidth) style.maxWidth = `${column.maxWidth}px`
+  } else {
+    if (column.minWidth) style.minWidth = `${column.minWidth}px`
+    if (column.maxWidth) style.maxWidth = `${column.maxWidth}px`
+  }
+  return style
+}
+
+const isColumnResizable = (column: Column) =>
+  !!props.columnWidthStorageKey && column.resizable === true
+
+const readPersistedColumnWidths = (): ColumnWidthState => {
+  if (!props.columnWidthStorageKey || typeof localStorage === 'undefined') return {}
+  try {
+    const raw = localStorage.getItem(props.columnWidthStorageKey)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw) as Record<string, unknown>
+    const next: ColumnWidthState = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        next[key] = value
+      }
+    }
+    return next
+  } catch (e) {
+    console.error('[DataTable] Failed to read persisted column widths:', e)
+    return {}
+  }
+}
+
+const writePersistedColumnWidths = (widths: ColumnWidthState) => {
+  if (!props.columnWidthStorageKey || typeof localStorage === 'undefined') return
+  try {
+    localStorage.setItem(props.columnWidthStorageKey, JSON.stringify(widths))
+  } catch (e) {
+    console.error('[DataTable] Failed to persist column widths:', e)
+  }
+}
+
+const resetColumnWidths = () => {
+  columnWidths.value = {}
+  if (props.columnWidthStorageKey && typeof localStorage !== 'undefined') {
+    localStorage.removeItem(props.columnWidthStorageKey)
+  }
+  nextTick(() => {
+    checkScrollable()
+    checkActionsColumnWidth()
+  })
+}
+
+const tableWrapperStyle = computed(() => {
+  const firstColumn = props.columns[0]
+  const selectWidth = firstColumn?.key === 'select' ? (getColumnWidth(firstColumn) ?? 52) : 52
+  return {
+    '--select-col-width': `${selectWidth}px`
+  }
+})
+
+const startColumnResize = (column: Column, event: MouseEvent) => {
+  if (!isColumnResizable(column)) return
+  const startX = event.clientX
+  const startWidth = (event.currentTarget as HTMLElement).parentElement?.getBoundingClientRect().width
+    ?? getColumnWidth(column)
+    ?? parseColumnWidth(column.width)
+    ?? column.minWidth
+    ?? 120
+
+  resizingColumnKey.value = column.key
+  document.body.classList.add('select-none')
+
+  const onMove = (moveEvent: MouseEvent) => {
+    const nextWidth = clampColumnWidth(column, startWidth + moveEvent.clientX - startX)
+    columnWidths.value = { ...columnWidths.value, [column.key]: nextWidth }
+  }
+
+  const onUp = () => {
+    document.removeEventListener('mousemove', onMove)
+    document.removeEventListener('mouseup', onUp)
+    document.body.classList.remove('select-none')
+    resizingColumnKey.value = null
+    writePersistedColumnWidths(columnWidths.value)
+    nextTick(() => {
+      checkScrollable()
+      checkActionsColumnWidth()
+    })
+  }
+
+  document.addEventListener('mousemove', onMove)
+  document.addEventListener('mouseup', onUp)
 }
 
 const collator = new Intl.Collator(undefined, {
@@ -701,6 +842,7 @@ defineExpose({
   sortedData,
   resolveRowKey,
   tableWrapperEl: tableWrapperRef,
+  resetColumnWidths,
 })
 </script>
 
@@ -740,6 +882,32 @@ defineExpose({
   top: 0;
   z-index: 210; /* 必须高于所有表体内容 */
   background-color: rgb(249 250 251);
+}
+
+.column-resize-handle {
+  position: absolute;
+  top: 0;
+  right: -3px;
+  bottom: 0;
+  z-index: 5;
+  width: 8px;
+  cursor: col-resize;
+  touch-action: none;
+}
+
+.column-resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 25%;
+  right: 3px;
+  bottom: 25%;
+  width: 1px;
+  background-color: transparent;
+}
+
+.column-resize-handle:hover::after,
+.sticky-header-cell.is-resizing .column-resize-handle::after {
+  background-color: rgb(59 130 246);
 }
 
 .dark .sticky-header-cell {

--- a/frontend/src/components/common/DataTable.vue
+++ b/frontend/src/components/common/DataTable.vue
@@ -128,6 +128,7 @@
             <span
               v-if="isColumnResizable(column)"
               class="column-resize-handle"
+              @click.stop.prevent
               @mousedown.stop.prevent="startColumnResize(column, $event)"
             ></span>
           </th>
@@ -489,14 +490,21 @@ const tableWrapperStyle = computed(() => {
   }
 })
 
-const startColumnResize = (column: Column, event: MouseEvent) => {
-  if (!isColumnResizable(column)) return
-  const startX = event.clientX
-  const startWidth = (event.currentTarget as HTMLElement).parentElement?.getBoundingClientRect().width
-    ?? getColumnWidth(column)
+const getResizeStartWidth = (column: Column, event: MouseEvent) => {
+  const parentWidth = (event.currentTarget as HTMLElement).parentElement?.getBoundingClientRect().width
+  if (parentWidth && Number.isFinite(parentWidth) && parentWidth > 0) {
+    return parentWidth
+  }
+  return getColumnWidth(column)
     ?? parseColumnWidth(column.width)
     ?? column.minWidth
     ?? 120
+}
+
+const startColumnResize = (column: Column, event: MouseEvent) => {
+  if (!isColumnResizable(column)) return
+  const startX = event.clientX
+  const startWidth = getResizeStartWidth(column, event)
 
   resizingColumnKey.value = column.key
   document.body.classList.add('select-none')

--- a/frontend/src/components/common/DataTable.vue
+++ b/frontend/src/components/common/DataTable.vue
@@ -70,7 +70,7 @@
       'is-scrollable': isScrollable
     }"
   >
-    <table class="w-full min-w-max divide-y divide-gray-200 dark:divide-dark-700">
+    <table class="w-full table-fixed divide-y divide-gray-200 dark:divide-dark-700" :style="desktopTableStyle">
       <colgroup>
         <col
           v-for="column in columns"
@@ -101,8 +101,8 @@
               :sort-key="sortKey"
               :sort-order="sortOrder"
             >
-              <div class="flex items-center space-x-1">
-                <span>{{ column.label }}</span>
+              <div class="flex min-w-0 items-center space-x-1">
+                <span class="min-w-0 truncate">{{ column.label }}</span>
                 <span v-if="column.sortable" class="text-gray-400 dark:text-dark-500">
                   <svg
                     v-if="sortKey === column.key"
@@ -184,7 +184,7 @@
               v-for="(column, colIndex) in columns"
               :key="column.key"
               :class="[
-                'whitespace-nowrap py-4 text-sm text-gray-900 dark:text-gray-100',
+                'overflow-hidden whitespace-nowrap py-4 text-sm text-gray-900 dark:text-gray-100',
                 getAdaptivePaddingClass(),
                 getStickyColumnClass(column, colIndex),
                 column.class
@@ -488,6 +488,14 @@ const tableWrapperStyle = computed(() => {
   return {
     '--select-col-width': `${selectWidth}px`
   }
+})
+
+const desktopTableStyle = computed(() => {
+  const totalWidth = props.columns.reduce((sum, column) => {
+    const width = getColumnWidth(column) ?? column.minWidth ?? 120
+    return sum + width
+  }, 0)
+  return totalWidth > 0 ? { minWidth: `${totalWidth}px` } : {}
 })
 
 const getResizeStartWidth = (column: Column, event: MouseEvent) => {
@@ -888,8 +896,14 @@ defineExpose({
 .sticky-header-cell {
   position: sticky;
   top: 0;
+  overflow: hidden;
   z-index: 210; /* 必须高于所有表体内容 */
   background-color: rgb(249 250 251);
+}
+
+.table-wrapper th,
+.table-wrapper td {
+  overflow: hidden;
 }
 
 .column-resize-handle {

--- a/frontend/src/components/common/README.md
+++ b/frontend/src/components/common/README.md
@@ -16,6 +16,7 @@ A generic data table component with sorting, loading states, and custom cell ren
 - `defaultSortKey?: string` - Default sort key (only used if no persisted sort state)
 - `defaultSortOrder?: 'asc' | 'desc'` - Default sort order (default: `asc`)
 - `sortStorageKey?: string` - Persist sort state (key + order) to localStorage
+- `columnWidthStorageKey?: string` - Persist desktop column widths to localStorage. Column resizing is only enabled when this prop is set and a column has `resizable: true`.
 - `rowKey?: string | (row: any) => string | number` - Row key field or resolver (defaults to `row.id`, falls back to index)
 
 **Slots:**

--- a/frontend/src/components/common/README.md
+++ b/frontend/src/components/common/README.md
@@ -19,6 +19,8 @@ A generic data table component with sorting, loading states, and custom cell ren
 - `columnWidthStorageKey?: string` - Persist desktop column widths to localStorage. Column resizing is only enabled when this prop is set and a column has `resizable: true`.
 - `rowKey?: string | (row: any) => string | number` - Row key field or resolver (defaults to `row.id`, falls back to index)
 
+Column resizing uses `width`, `minWidth`, and `maxWidth` from each column. Desktop tables use fixed layout when widths are configured, so long cell text is clipped instead of forcing the column wider than its configured limits.
+
 **Slots:**
 
 - `empty` - Custom empty state content

--- a/frontend/src/components/common/__tests__/DataTableColumnWidths.spec.ts
+++ b/frontend/src/components/common/__tests__/DataTableColumnWidths.spec.ts
@@ -1,0 +1,77 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import DataTable from '../DataTable.vue'
+import type { Column } from '../types'
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+const columns: Column[] = [
+  { key: 'name', label: 'Name', sortable: true, width: 120, minWidth: 80, maxWidth: 240, resizable: true },
+  { key: 'status', label: 'Status', sortable: true, width: 100, minWidth: 80, maxWidth: 160, resizable: true }
+]
+
+const data = [
+  { id: 1, name: 'alpha', status: 'active' },
+  { id: 2, name: 'beta', status: 'inactive' }
+]
+
+const mountTable = () => mount(DataTable, {
+  attachTo: document.body,
+  props: {
+    columns,
+    data,
+    serverSideSort: true,
+    columnWidthStorageKey: 'test-column-widths',
+    estimateRowHeight: 56
+  },
+  global: {
+    stubs: {
+      Icon: true
+    }
+  }
+})
+
+describe('DataTable column widths', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.body.innerHTML = ''
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    }))
+  })
+
+  it('does not sort when the resize handle is clicked', async () => {
+    const wrapper = mountTable()
+
+    await wrapper.get('.column-resize-handle').trigger('click')
+
+    expect(wrapper.emitted('sort')).toBeUndefined()
+  })
+
+  it('persists resized widths and exposes reset for the owning table', async () => {
+    const wrapper = mountTable()
+    const handle = wrapper.get('.column-resize-handle')
+
+    await handle.trigger('mousedown', { clientX: 100 })
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 180, bubbles: true }))
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }))
+
+    expect(JSON.parse(localStorage.getItem('test-column-widths') ?? '{}')).toEqual({ name: 200 })
+
+    ;(wrapper.vm as unknown as { resetColumnWidths: () => void }).resetColumnWidths()
+
+    expect(localStorage.getItem('test-column-widths')).toBeNull()
+  })
+})

--- a/frontend/src/components/common/__tests__/DataTableColumnWidths.spec.ts
+++ b/frontend/src/components/common/__tests__/DataTableColumnWidths.spec.ts
@@ -74,4 +74,14 @@ describe('DataTable column widths', () => {
 
     expect(localStorage.getItem('test-column-widths')).toBeNull()
   })
+
+  it('uses fixed table layout so text content does not force resized width', () => {
+    const wrapper = mountTable()
+    const table = wrapper.get('table')
+    const headerLabel = wrapper.get('thead th span.truncate')
+
+    expect(table.classes()).toContain('table-fixed')
+    expect(table.attributes('style')).toContain('min-width: 220px')
+    expect(headerLabel.classes()).toContain('truncate')
+  })
 })

--- a/frontend/src/components/common/types.ts
+++ b/frontend/src/components/common/types.ts
@@ -7,5 +7,9 @@ export interface Column {
   label: string
   sortable?: boolean
   class?: string
+  width?: number | string
+  minWidth?: number
+  maxWidth?: number
+  resizable?: boolean
   formatter?: (value: any, row: any) => string
 }

--- a/frontend/src/composables/__tests__/useOpenAIOAuth.spec.ts
+++ b/frontend/src/composables/__tests__/useOpenAIOAuth.spec.ts
@@ -39,10 +39,14 @@ describe('useOpenAIOAuth.buildCredentials', () => {
       access_token: 'at',
       refresh_token: 'rt',
       client_id: 'app_test_client',
+      plan_type: 'plus',
+      subscription_expires_at: '2026-05-01T00:00:00Z',
       expires_at: 1700000000
     })
 
     expect(creds.client_id).toBe('app_test_client')
+    expect(creds.plan_type).toBe('plus')
+    expect(creds.subscription_expires_at).toBe('2026-05-01T00:00:00Z')
     expect(creds.access_token).toBe('at')
     expect(creds.refresh_token).toBe('rt')
   })

--- a/frontend/src/composables/useOpenAIOAuth.ts
+++ b/frontend/src/composables/useOpenAIOAuth.ts
@@ -16,6 +16,7 @@ export interface OpenAITokenInfo {
   email?: string
   name?: string
   plan_type?: string
+  subscription_expires_at?: string
   privacy_mode?: string
   // OpenAI specific IDs (extracted from ID Token)
   chatgpt_account_id?: string
@@ -196,6 +197,9 @@ export function useOpenAIOAuth() {
     }
     if (tokenInfo.plan_type) {
       creds.plan_type = tokenInfo.plan_type
+    }
+    if (tokenInfo.subscription_expires_at) {
+      creds.subscription_expires_at = tokenInfo.subscription_expires_at
     }
     if (tokenInfo.client_id) {
       creds.client_id = tokenInfo.client_id

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2627,7 +2627,21 @@ export default {
         proxy: 'Proxy',
         lastUsed: 'Last Used',
         expiresAt: 'Expires At',
-        actions: 'Actions'
+        actions: 'Actions',
+        resetWidths: 'Reset column widths'
+      },
+      filters: {
+        title: 'Filters',
+        account: 'Account',
+        status: 'Status',
+        plan: 'Plan',
+        platform: 'Platform',
+        type: 'Type',
+        privacy: 'Privacy',
+        group: 'Group',
+        clearAll: 'Clear all',
+        allPlans: 'All Plans',
+        unrecognizedPlan: 'Unrecognized'
       },
       allPrivacyModes: 'All Privacy States',
       privacyUnset: 'Unset',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2596,6 +2596,7 @@ export default {
         paused: 'Paused',
         limited: 'Limited',
         rateLimited: 'Rate Limited',
+        notRateLimited: 'Not rate limited',
         overloaded: 'Overloaded',
         tempUnschedulable: 'Temp Unschedulable',
         quotaExceeded: 'Quota Exceeded',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2665,7 +2665,8 @@ export default {
         proxy: '代理',
         lastUsed: '最近使用',
         expiresAt: '过期时间',
-        actions: '操作'
+        actions: '操作',
+        resetWidths: '重置列宽'
       },
       allPrivacyModes: '全部Privacy状态',
       privacyUnset: '未设置',
@@ -2888,12 +2889,20 @@ export default {
         statusLabel: '状态'
       },
       filters: {
+        title: '筛选',
+        account: '账号',
         platform: '平台',
         allPlatforms: '全部平台',
         type: '类型',
         allTypes: '全部类型',
+        privacy: '隐私',
+        group: '分组',
         status: '状态',
-        allStatuses: '全部状态'
+        allStatuses: '全部状态',
+        plan: 'Plan',
+        clearAll: '全部清除',
+        allPlans: '全部 Plan',
+        unrecognizedPlan: '未识别'
       },
       saving: '保存中...',
       refreshing: '刷新中...',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2784,6 +2784,7 @@ export default {
         paused: '暂停',
         limited: '限流',
         rateLimited: '限流中',
+        notRateLimited: '非限流',
         overloaded: '过载中',
         tempUnschedulable: '临时不可调度',
         quotaExceeded: '配额超限',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -118,7 +118,7 @@
                       @click="resetTableColumnWidths"
                       class="flex w-full items-center justify-between rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
                     >
-                      <span>重置列宽</span>
+                      <span>{{ t('admin.accounts.columns.resetWidths') }}</span>
                       <Icon name="refresh" size="sm" class="text-gray-400" />
                     </button>
                   </div>

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -113,6 +113,14 @@
                       <span>{{ col.label }}</span>
                       <Icon v-if="isColumnVisible(col.key)" name="check" size="sm" class="text-primary-500" />
                     </button>
+                    <div class="my-1 border-t border-gray-100 dark:border-gray-700"></div>
+                    <button
+                      @click="resetTableColumnWidths"
+                      class="flex w-full items-center justify-between rounded-md px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+                    >
+                      <span>重置列宽</span>
+                      <Icon name="refresh" size="sm" class="text-gray-400" />
+                    </button>
                   </div>
                 </div>
               </div>
@@ -164,6 +172,7 @@
           default-sort-key="name"
           default-sort-order="asc"
           :sort-storage-key="ACCOUNT_SORT_STORAGE_KEY"
+          column-width-storage-key="account-table-column-widths"
           :estimate-row-height="72"
           :overscan="5"
         >
@@ -670,6 +679,11 @@ const toggleColumn = (key: string) => {
   }
 }
 
+const resetTableColumnWidths = () => {
+  (dataTableRef.value as any)?.resetColumnWidths?.()
+  showColumnDropdown.value = false
+}
+
 const isColumnVisible = (key: string) => !hiddenColumns.has(key)
 
 const {
@@ -689,6 +703,7 @@ const {
     type: '',
     status: '',
     privacy_mode: '',
+    plan_type: '',
     group: '',
     search: '',
     sort_by: sortState.sort_by,
@@ -892,6 +907,7 @@ const refreshAccountsIncrementally = async () => {
         type?: string
         status?: string
         privacy_mode?: string
+        plan_type?: string
         group?: string
         search?: string
         sort_by?: string
@@ -1033,26 +1049,26 @@ function getAntigravityTierClass(row: any): string {
 // All available columns
 const allColumns = computed(() => {
   const c = [
-    { key: 'select', label: '', sortable: false },
-    { key: 'name', label: t('admin.accounts.columns.name'), sortable: true },
-    { key: 'platform_type', label: t('admin.accounts.columns.platformType'), sortable: false },
-    { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false },
-    { key: 'status', label: t('admin.accounts.columns.status'), sortable: true },
-    { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true },
-    { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false }
+    { key: 'select', label: '', sortable: false, width: 52, minWidth: 52, maxWidth: 52, resizable: false },
+    { key: 'name', label: t('admin.accounts.columns.name'), sortable: true, width: 220, minWidth: 160, maxWidth: 420, resizable: true },
+    { key: 'platform_type', label: t('admin.accounts.columns.platformType'), sortable: false, width: 180, minWidth: 140, maxWidth: 300, resizable: true },
+    { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false, width: 170, minWidth: 140, maxWidth: 260, resizable: true },
+    { key: 'status', label: t('admin.accounts.columns.status'), sortable: true, width: 150, minWidth: 120, maxWidth: 240, resizable: true },
+    { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true, width: 110, minWidth: 96, maxWidth: 150, resizable: true },
+    { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false, width: 180, minWidth: 150, maxWidth: 260, resizable: true }
   ]
   if (!authStore.isSimpleMode) {
-    c.push({ key: 'groups', label: t('admin.accounts.columns.groups'), sortable: false })
+    c.push({ key: 'groups', label: t('admin.accounts.columns.groups'), sortable: false, width: 180, minWidth: 130, maxWidth: 280, resizable: true })
   }
   c.push(
-    { key: 'usage', label: t('admin.accounts.columns.usageWindows'), sortable: false },
-    { key: 'proxy', label: t('admin.accounts.columns.proxy'), sortable: false },
-    { key: 'priority', label: t('admin.accounts.columns.priority'), sortable: true },
-    { key: 'rate_multiplier', label: t('admin.accounts.columns.billingRateMultiplier'), sortable: true },
-    { key: 'last_used_at', label: t('admin.accounts.columns.lastUsed'), sortable: true },
-    { key: 'expires_at', label: t('admin.accounts.columns.expiresAt'), sortable: true },
-    { key: 'notes', label: t('admin.accounts.columns.notes'), sortable: false },
-    { key: 'actions', label: t('admin.accounts.columns.actions'), sortable: false }
+    { key: 'usage', label: t('admin.accounts.columns.usageWindows'), sortable: false, width: 220, minWidth: 180, maxWidth: 360, resizable: true },
+    { key: 'proxy', label: t('admin.accounts.columns.proxy'), sortable: false, width: 170, minWidth: 130, maxWidth: 280, resizable: true },
+    { key: 'priority', label: t('admin.accounts.columns.priority'), sortable: true, width: 100, minWidth: 80, maxWidth: 140, resizable: true },
+    { key: 'rate_multiplier', label: t('admin.accounts.columns.billingRateMultiplier'), sortable: true, width: 130, minWidth: 110, maxWidth: 180, resizable: true },
+    { key: 'last_used_at', label: t('admin.accounts.columns.lastUsed'), sortable: true, width: 150, minWidth: 130, maxWidth: 220, resizable: true },
+    { key: 'expires_at', label: t('admin.accounts.columns.expiresAt'), sortable: true, width: 180, minWidth: 140, maxWidth: 260, resizable: true },
+    { key: 'notes', label: t('admin.accounts.columns.notes'), sortable: false, width: 220, minWidth: 150, maxWidth: 360, resizable: true },
+    { key: 'actions', label: t('admin.accounts.columns.actions'), sortable: false, width: 140, minWidth: 120, maxWidth: 220, resizable: true }
   )
   return c
 })
@@ -1314,12 +1330,14 @@ const handleBulkUpdated = () => {
 const handleDataImported = () => { showImportData.value = false; reload() }
 const ACCOUNT_UNGROUPED_GROUP_QUERY_VALUE = 'ungrouped'
 const ACCOUNT_PRIVACY_MODE_UNSET_QUERY_VALUE = '__unset__'
+const ACCOUNT_PLAN_TYPE_UNSET_QUERY_VALUE = '__unset__'
 const buildAccountQueryFilters = () => ({
   platform: params.platform || '',
   type: params.type || '',
   status: params.status || '',
   group: params.group || '',
   privacy_mode: params.privacy_mode || '',
+  plan_type: params.plan_type || '',
   search: params.search || '',
   sort_by: sortState.sort_by,
   sort_order: sortState.sort_order
@@ -1360,6 +1378,14 @@ const accountMatchesCurrentFilters = (account: Account) => {
     if (filters.privacy_mode === ACCOUNT_PRIVACY_MODE_UNSET_QUERY_VALUE) {
       if (privacyMode.trim() !== '') return false
     } else if (privacyMode !== filters.privacy_mode) {
+      return false
+    }
+  }
+  const planType = typeof account.credentials?.plan_type === 'string' ? account.credentials.plan_type : ''
+  if (filters.plan_type) {
+    if (filters.plan_type === ACCOUNT_PLAN_TYPE_UNSET_QUERY_VALUE) {
+      if (planType.trim() !== '') return false
+    } else if (planType !== filters.plan_type) {
       return false
     }
   }

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1342,27 +1342,43 @@ const buildAccountQueryFilters = () => ({
   sort_by: sortState.sort_by,
   sort_order: sortState.sort_order
 })
+const splitAccountFilterValues = (value: unknown) => String(value ?? '')
+  .split(',')
+  .map((item) => item.trim())
+  .filter(Boolean)
+
 const accountMatchesCurrentFilters = (account: Account) => {
   const filters = buildAccountQueryFilters()
   if (filters.platform && account.platform !== filters.platform) return false
   if (filters.type && account.type !== filters.type) return false
-  if (filters.status) {
+  const statusValues = splitAccountFilterValues(filters.status)
+  if (statusValues.length > 0) {
     const now = Date.now()
     const rateLimitResetAt = account.rate_limit_reset_at ? new Date(account.rate_limit_reset_at).getTime() : Number.NaN
     const isRateLimited = Number.isFinite(rateLimitResetAt) && rateLimitResetAt > now
     const tempUnschedUntil = account.temp_unschedulable_until ? new Date(account.temp_unschedulable_until).getTime() : Number.NaN
     const isTempUnschedulable = Number.isFinite(tempUnschedUntil) && tempUnschedUntil > now
+    const excludeRateLimited = statusValues.includes('not_rate_limited')
+    const concreteStatusValues = statusValues.filter((status) => status !== 'not_rate_limited')
 
-    if (filters.status === 'active') {
-      if (account.status !== 'active' || isRateLimited || isTempUnschedulable || !account.schedulable) return false
-    } else if (filters.status === 'rate_limited') {
-      if (account.status !== 'active' || !isRateLimited || isTempUnschedulable) return false
-    } else if (filters.status === 'temp_unschedulable') {
-      if (account.status !== 'active' || !isTempUnschedulable) return false
-    } else if (filters.status === 'unschedulable') {
-      if (account.status !== 'active' || account.schedulable || isRateLimited || isTempUnschedulable) return false
-    } else if (account.status !== filters.status) {
-      return false
+    if (excludeRateLimited && isRateLimited) return false
+    if (concreteStatusValues.length > 0) {
+      const matchesStatus = concreteStatusValues.some((status) => {
+        if (status === 'active') {
+          return account.status === 'active' && !isRateLimited && !isTempUnschedulable && account.schedulable
+        }
+        if (status === 'rate_limited') {
+          return account.status === 'active' && isRateLimited && !isTempUnschedulable
+        }
+        if (status === 'temp_unschedulable') {
+          return account.status === 'active' && isTempUnschedulable
+        }
+        if (status === 'unschedulable') {
+          return account.status === 'active' && !account.schedulable && !isRateLimited && !isTempUnschedulable
+        }
+        return account.status === status
+      })
+      if (!matchesStatus) return false
     }
   }
   if (filters.group) {
@@ -1382,12 +1398,15 @@ const accountMatchesCurrentFilters = (account: Account) => {
     }
   }
   const planType = typeof account.credentials?.plan_type === 'string' ? account.credentials.plan_type : ''
-  if (filters.plan_type) {
-    if (filters.plan_type === ACCOUNT_PLAN_TYPE_UNSET_QUERY_VALUE) {
-      if (planType.trim() !== '') return false
-    } else if (planType !== filters.plan_type) {
-      return false
-    }
+  const planTypeValues = splitAccountFilterValues(filters.plan_type)
+  if (planTypeValues.length > 0) {
+    const matchesPlanType = planTypeValues.some((value) => {
+      if (value === ACCOUNT_PLAN_TYPE_UNSET_QUERY_VALUE) {
+        return planType.trim() === ''
+      }
+      return planType === value
+    })
+    if (!matchesPlanType) return false
   }
   const search = String(filters.search || '').trim().toLowerCase()
   if (search && !account.name.toLowerCase().includes(search)) return false

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -155,7 +155,6 @@
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
           @edit-selected="openBulkEditSelected"
-          @edit-filtered="openBulkEditFiltered"
           @clear="clearSelection"
           @select-page="selectPage"
           @toggle-schedulable="handleBulkToggleSchedulable"
@@ -327,7 +326,6 @@
       :account-ids="selIds"
       :selected-platforms="selPlatforms"
       :selected-types="selTypes"
-      :target="bulkEditTarget ?? undefined"
       :proxies="proxies"
       :groups="groups"
       @close="showBulkEdit = false"
@@ -393,29 +391,6 @@ const proxies = ref<AccountProxy[]>([])
 const groups = ref<AdminGroup[]>([])
 const accountTableRef = ref<HTMLElement | null>(null)
 const dataTableRef = ref<InstanceType<typeof DataTable> | null>(null)
-type AccountBulkEditTarget =
-  | {
-      mode: 'selected'
-      accountIds: number[]
-      selectedPlatforms: AccountPlatform[]
-      selectedTypes: AccountType[]
-    }
-  | {
-      mode: 'filtered'
-      filters: {
-        platform?: string
-        type?: string
-        status?: string
-        group?: string
-        search?: string
-        privacy_mode?: string
-        sort_by?: string
-        sort_order?: AccountSortOrder
-      }
-      previewCount: number
-      selectedPlatforms: AccountPlatform[]
-      selectedTypes: AccountType[]
-    }
 const selPlatforms = computed<AccountPlatform[]>(() => {
   const platforms = new Set(
     accounts.value
@@ -439,7 +414,6 @@ const showImportData = ref(false)
 const showExportDataDialog = ref(false)
 const includeProxyOnExport = ref(true)
 const showBulkEdit = ref(false)
-const bulkEditTarget = ref<AccountBulkEditTarget | null>(null)
 const showTempUnsched = ref(false)
 const showDeleteDialog = ref(false)
 const showReAuth = ref(false)
@@ -1276,54 +1250,12 @@ const handleBulkToggleSchedulable = async (schedulable: boolean) => {
     appStore.showError(t('common.error'))
   }
 }
-const buildBulkEditFilterSnapshot = () => {
-  const rawParams = toRaw(params) as Record<string, unknown>
-  const sortOrder: AccountSortOrder = rawParams.sort_order === 'desc' ? 'desc' : 'asc'
-  return {
-    platform: typeof rawParams.platform === 'string' ? rawParams.platform : '',
-    type: typeof rawParams.type === 'string' ? rawParams.type : '',
-    status: typeof rawParams.status === 'string' ? rawParams.status : '',
-    group: typeof rawParams.group === 'string' ? rawParams.group : '',
-    search: typeof rawParams.search === 'string' ? rawParams.search : '',
-    privacy_mode: typeof rawParams.privacy_mode === 'string' ? rawParams.privacy_mode : '',
-    sort_by: typeof rawParams.sort_by === 'string' ? rawParams.sort_by : '',
-    sort_order: sortOrder
-  }
-}
-
-const collectSelectionMetadata = (rows: Account[]) => {
-  const selectedPlatforms = Array.from(new Set(rows.map(account => account.platform)))
-  const selectedTypes = Array.from(new Set(rows.map(account => account.type)))
-  return { selectedPlatforms, selectedTypes }
-}
-
 const openBulkEditSelected = () => {
-  bulkEditTarget.value = {
-    mode: 'selected',
-    accountIds: [...selIds.value],
-    selectedPlatforms: [...selPlatforms.value],
-    selectedTypes: [...selTypes.value]
-  }
-  showBulkEdit.value = true
-}
-
-const openBulkEditFiltered = async () => {
-  const filters = buildBulkEditFilterSnapshot()
-  const preview = await adminAPI.accounts.list(1, 100, filters)
-  const { selectedPlatforms, selectedTypes } = collectSelectionMetadata(preview.items)
-  bulkEditTarget.value = {
-    mode: 'filtered',
-    filters,
-    previewCount: preview.total,
-    selectedPlatforms,
-    selectedTypes
-  }
   showBulkEdit.value = true
 }
 
 const handleBulkUpdated = () => {
   showBulkEdit.value = false
-  bulkEditTarget.value = null
   clearSelection()
   reload()
 }

--- a/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
@@ -68,13 +68,13 @@ const DataTableStub = {
 
 const AccountBulkActionsBarStub = {
   props: ['selectedIds'],
-  emits: ['edit-filtered'],
-  template: '<button data-test="edit-filtered" @click="$emit(\'edit-filtered\')">edit filtered</button>'
+  emits: ['edit-selected'],
+  template: '<button data-test="edit-selected" @click="$emit(\'edit-selected\')">edit selected</button>'
 }
 
 const BulkEditAccountModalStub = {
-  props: ['show', 'target'],
-  template: '<div data-test="bulk-edit-modal" :data-show="String(show)" :data-target-mode="target?.mode ?? \'\'"></div>'
+  props: ['show', 'accountIds'],
+  template: '<div data-test="bulk-edit-modal" :data-show="String(show)" :data-account-ids="(accountIds || []).join(\',\')"></div>'
 }
 
 describe('admin AccountsView bulk edit scope', () => {
@@ -104,7 +104,7 @@ describe('admin AccountsView bulk edit scope', () => {
     getAllGroups.mockResolvedValue([])
   })
 
-  it('opens bulk edit in filtered-results mode from the bulk actions dropdown', async () => {
+  it('opens bulk edit for selected accounts from the bulk actions dropdown', async () => {
     const wrapper = mount(AccountsView, {
       global: {
         stubs: {
@@ -143,10 +143,10 @@ describe('admin AccountsView bulk edit scope', () => {
     })
 
     await flushPromises()
-    await wrapper.get('[data-test="edit-filtered"]').trigger('click')
+    await wrapper.get('[data-test="edit-selected"]').trigger('click')
     await flushPromises()
 
     expect(wrapper.get('[data-test="bulk-edit-modal"]').attributes('data-show')).toBe('true')
-    expect(wrapper.get('[data-test="bulk-edit-modal"]').attributes('data-target-mode')).toBe('filtered')
+    expect(wrapper.get('[data-test="bulk-edit-modal"]').attributes('data-account-ids')).toBe('')
   })
 })


### PR DESCRIPTION
## Summary
- default gpt-5.3-codex and gpt-5.3-codex-spark reasoning effort to medium when missing or set to none/minimal
- send gpt-5.3-codex-spark OAuth requests with Codex CLI identity across Responses, Messages, Chat Completions, WebSocket, and passthrough paths
- cover passthrough and WebSocket routes so CherryStudio/Codex-compatible clients do not leak reasoning.effort=none upstream

## Tests
- go test ./internal/service -run "TestApplyCodexOAuthTransform_NormalizesCodexReasoningEffort|TestBuildOpenAIWSCreatePayload_OAuthSparkReasoningDefault|TestNormalizeOpenAIWSCodexReasoningPayloadRaw_OAuthSpark|TestOpenAIGatewayService_Forward_WSv2_SuccessAndBindSticky"
- go test ./internal/service -run "TestNormalizeOpenAIPassthroughOAuthBody_NormalizesSparkReasoning|TestOpenAIGatewayService_OAuthPassthrough"
- go test ./internal/service