### PR TITLE
fix(groups): prevent negative available account counts

### DIFF
--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -150,6 +150,7 @@ func GroupFromServiceAdmin(g *service.Group) *AdminGroup {
 		SupportedModelScopes:        g.SupportedModelScopes,
 		AccountCount:                g.AccountCount,
 		ActiveAccountCount:          g.ActiveAccountCount,
+		AvailableAccountCount:       g.AvailableAccountCount,
 		RateLimitedAccountCount:     g.RateLimitedAccountCount,
 		SortOrder:                   g.SortOrder,
 	}

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -139,6 +139,7 @@ type AdminGroup struct {
 	AccountGroups           []AccountGroup `json:"account_groups,omitempty"`
 	AccountCount            int64          `json:"account_count,omitempty"`
 	ActiveAccountCount      int64          `json:"active_account_count,omitempty"`
+	AvailableAccountCount   int64          `json:"available_account_count"`
 	RateLimitedAccountCount int64          `json:"rate_limited_account_count,omitempty"`
 
 	// 分组排序

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -91,9 +91,14 @@ func (r *groupRepository) GetByID(ctx context.Context, id int64) (*service.Group
 	if err != nil {
 		return nil, err
 	}
-	total, active, _ := r.GetAccountCount(ctx, out.ID)
-	out.AccountCount = total
-	out.ActiveAccountCount = active
+	counts, countErr := r.loadAccountCounts(ctx, []int64{out.ID})
+	if countErr == nil {
+		c := counts[out.ID]
+		out.AccountCount = c.Total
+		out.ActiveAccountCount = c.Active
+		out.AvailableAccountCount = c.Available
+		out.RateLimitedAccountCount = c.RateLimited
+	}
 	return out, nil
 }
 
@@ -269,6 +274,7 @@ func (r *groupRepository) ListWithFilters(ctx context.Context, params pagination
 			c := counts[outGroups[i].ID]
 			outGroups[i].AccountCount = c.Total
 			outGroups[i].ActiveAccountCount = c.Active
+			outGroups[i].AvailableAccountCount = c.Available
 			outGroups[i].RateLimitedAccountCount = c.RateLimited
 		}
 	}
@@ -300,6 +306,7 @@ func (r *groupRepository) listWithAccountCountSort(ctx context.Context, q *dbent
 		c := counts[outGroups[i].ID]
 		outGroups[i].AccountCount = c.Total
 		outGroups[i].ActiveAccountCount = c.Active
+		outGroups[i].AvailableAccountCount = c.Available
 		outGroups[i].RateLimitedAccountCount = c.RateLimited
 	}
 
@@ -397,6 +404,7 @@ func (r *groupRepository) ListActive(ctx context.Context) ([]service.Group, erro
 			c := counts[outGroups[i].ID]
 			outGroups[i].AccountCount = c.Total
 			outGroups[i].ActiveAccountCount = c.Active
+			outGroups[i].AvailableAccountCount = c.Available
 			outGroups[i].RateLimitedAccountCount = c.RateLimited
 		}
 	}
@@ -427,6 +435,7 @@ func (r *groupRepository) ListActiveByPlatform(ctx context.Context, platform str
 			c := counts[outGroups[i].ID]
 			outGroups[i].AccountCount = c.Total
 			outGroups[i].ActiveAccountCount = c.Active
+			outGroups[i].AvailableAccountCount = c.Available
 			outGroups[i].RateLimitedAccountCount = c.RateLimited
 		}
 	}
@@ -492,9 +501,9 @@ func (r *groupRepository) GetAccountCount(ctx context.Context, groupID int64) (t
 		`SELECT COUNT(*),
 			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true),
 			COUNT(*) FILTER (WHERE a.status = 'active' AND (
-				a.rate_limit_reset_at > NOW() OR
-				a.overload_until > NOW() OR
-				a.temp_unschedulable_until > NOW()
+					a.rate_limit_reset_at > NOW() OR
+					a.overload_until > NOW() OR
+					a.temp_unschedulable_until > NOW()
 			))
 		FROM account_groups ag JOIN accounts a ON a.id = ag.account_id
 		WHERE ag.group_id = $1`,
@@ -628,6 +637,7 @@ func (r *groupRepository) DeleteCascade(ctx context.Context, id int64) ([]int64,
 type groupAccountCounts struct {
 	Total       int64
 	Active      int64
+	Available   int64
 	RateLimited int64
 }
 
@@ -642,10 +652,18 @@ func (r *groupRepository) loadAccountCounts(ctx context.Context, groupIDs []int6
 		`SELECT ag.group_id,
 			COUNT(*) AS total,
 			COUNT(*) FILTER (WHERE a.status = 'active' AND a.schedulable = true) AS active,
+			COUNT(*) FILTER (WHERE a.status = 'active'
+				AND a.deleted_at IS NULL
+				AND a.schedulable = true
+				AND (a.expires_at IS NULL OR a.expires_at > NOW() OR a.auto_pause_on_expired = false)
+				AND (a.rate_limit_reset_at IS NULL OR a.rate_limit_reset_at <= NOW())
+				AND (a.overload_until IS NULL OR a.overload_until <= NOW())
+				AND (a.temp_unschedulable_until IS NULL OR a.temp_unschedulable_until <= NOW())
+			) AS available,
 			COUNT(*) FILTER (WHERE a.status = 'active' AND (
-				a.rate_limit_reset_at > NOW() OR
-				a.overload_until > NOW() OR
-				a.temp_unschedulable_until > NOW()
+					a.rate_limit_reset_at > NOW() OR
+					a.overload_until > NOW() OR
+					a.temp_unschedulable_until > NOW()
 			)) AS rate_limited
 		FROM account_groups ag
 		JOIN accounts a ON a.id = ag.account_id
@@ -666,7 +684,7 @@ func (r *groupRepository) loadAccountCounts(ctx context.Context, groupIDs []int6
 	for rows.Next() {
 		var groupID int64
 		var c groupAccountCounts
-		if err = rows.Scan(&groupID, &c.Total, &c.Active, &c.RateLimited); err != nil {
+		if err = rows.Scan(&groupID, &c.Total, &c.Active, &c.Available, &c.RateLimited); err != nil {
 			return nil, err
 		}
 		counts[groupID] = c

--- a/backend/internal/repository/group_repo_integration_test.go
+++ b/backend/internal/repository/group_repo_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"testing"
+	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
@@ -649,6 +650,59 @@ func (s *GroupRepoSuite) TestGetAccountCount_Empty() {
 	count, _, err := s.repo.GetAccountCount(s.ctx, group.ID)
 	s.Require().NoError(err)
 	s.Require().Zero(count)
+}
+
+func (s *GroupRepoSuite) TestLoadAccountCounts_UsesSchedulablePoolSemantics() {
+	group := mustCreateGroup(s.T(), s.tx.Client(), &service.Group{
+		Name:             "g-pool-counts",
+		Platform:         service.PlatformAnthropic,
+		RateMultiplier:   1.0,
+		IsExclusive:      false,
+		Status:           service.StatusActive,
+		SubscriptionType: service.SubscriptionTypeStandard,
+	})
+
+	now := time.Now()
+
+	available := mustCreateAccount(s.T(), s.tx.Client(), &service.Account{Name: "available"})
+	rateLimited := mustCreateAccount(s.T(), s.tx.Client(), &service.Account{Name: "rate-limited"})
+	manualUnsched := mustCreateAccount(s.T(), s.tx.Client(), &service.Account{Name: "manual-unsched"})
+	expired := mustCreateAccount(s.T(), s.tx.Client(), &service.Account{Name: "expired"})
+	deleted := mustCreateAccount(s.T(), s.tx.Client(), &service.Account{Name: "deleted"})
+
+	s.Require().NoError(s.tx.Client().Account.UpdateOneID(rateLimited.ID).
+		SetRateLimitResetAt(now.Add(10 * time.Minute)).
+		Exec(s.ctx))
+	s.Require().NoError(s.tx.Client().Account.UpdateOneID(manualUnsched.ID).
+		SetSchedulable(false).
+		SetRateLimitResetAt(now.Add(10 * time.Minute)).
+		Exec(s.ctx))
+	s.Require().NoError(s.tx.Client().Account.UpdateOneID(expired.ID).
+		SetExpiresAt(now.Add(-10 * time.Minute)).
+		SetAutoPauseOnExpired(true).
+		Exec(s.ctx))
+	_, err := s.tx.ExecContext(s.ctx, "UPDATE accounts SET deleted_at = NOW() WHERE id = $1", deleted.ID)
+	s.Require().NoError(err)
+
+	for i, accountID := range []int64{available.ID, rateLimited.ID, manualUnsched.ID, expired.ID, deleted.ID} {
+		_, err = s.tx.ExecContext(
+			s.ctx,
+			"INSERT INTO account_groups (account_id, group_id, priority, created_at) VALUES ($1, $2, $3, NOW())",
+			accountID,
+			group.ID,
+			i+1,
+		)
+		s.Require().NoError(err)
+	}
+
+	counts, err := s.repo.loadAccountCounts(s.ctx, []int64{group.ID})
+	s.Require().NoError(err)
+
+	got := counts[group.ID]
+	s.Require().Equal(int64(5), got.Total)
+	s.Require().Equal(int64(4), got.Active, "active count should preserve the legacy status+manual-schedulable semantics")
+	s.Require().Equal(int64(2), got.RateLimited, "rate-limited count should preserve the legacy group visibility semantics")
+	s.Require().Equal(int64(1), got.Available, "available count should only include accounts currently selectable by the scheduler")
 }
 
 // --- DeleteAccountGroupsByGroupID ---

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -69,6 +69,7 @@ type Group struct {
 	AccountGroups           []AccountGroup
 	AccountCount            int64
 	ActiveAccountCount      int64
+	AvailableAccountCount   int64
 	RateLimitedAccountCount int64
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -524,6 +524,7 @@ export interface AdminGroup extends Group {
   // 分组下账号数量（仅管理员可见）
   account_count?: number
   active_account_count?: number
+  available_account_count?: number
   rate_limited_account_count?: number
 
   // OpenAI Messages 调度配置（仅 openai 平台使用）

--- a/frontend/src/utils/__tests__/groupAccountStats.spec.ts
+++ b/frontend/src/utils/__tests__/groupAccountStats.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAvailableGroupAccountCount } from '@/utils/groupAccountStats'
+
+describe('groupAccountStats utils', () => {
+  it('prefers the explicit available count from the backend', () => {
+    expect(getAvailableGroupAccountCount({
+      available_account_count: 3,
+      active_account_count: 5,
+      rate_limited_account_count: 9,
+    })).toBe(3)
+  })
+
+  it('never displays a negative explicit available count', () => {
+    expect(getAvailableGroupAccountCount({
+      available_account_count: -1,
+    })).toBe(0)
+  })
+
+  it('falls back to a non-negative active-minus-limited calculation for older payloads', () => {
+    expect(getAvailableGroupAccountCount({
+      active_account_count: 0,
+      rate_limited_account_count: 8,
+    })).toBe(0)
+
+    expect(getAvailableGroupAccountCount({
+      active_account_count: 2,
+      rate_limited_account_count: 8,
+    })).toBe(0)
+  })
+
+  it('falls back to zero when the count is missing', () => {
+    expect(getAvailableGroupAccountCount()).toBe(0)
+    expect(getAvailableGroupAccountCount({})).toBe(0)
+  })
+})

--- a/frontend/src/utils/groupAccountStats.ts
+++ b/frontend/src/utils/groupAccountStats.ts
@@ -1,0 +1,12 @@
+type GroupAccountCounts = {
+  available_account_count?: number | null
+  active_account_count?: number | null
+  rate_limited_account_count?: number | null
+}
+
+export function getAvailableGroupAccountCount(group?: GroupAccountCounts | null): number {
+  if (group?.available_account_count != null) {
+    return Math.max(0, group.available_account_count)
+  }
+  return Math.max(0, (group?.active_account_count ?? 0) - (group?.rate_limited_account_count ?? 0))
+}

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -201,10 +201,7 @@
                 }}</span>
                 <span
                   class="ml-1 font-medium text-emerald-600 dark:text-emerald-400"
-                  >{{
-                    (row.active_account_count || 0) -
-                    (row.rate_limited_account_count || 0)
-                  }}</span
+                  >{{ getAvailableGroupAccountCount(row) }}</span
                 >
                 <span
                   class="ml-1 inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 font-medium text-gray-800 dark:bg-dark-600 dark:text-gray-300"
@@ -2755,6 +2752,7 @@ import GroupRateMultipliersModal from "@/components/admin/group/GroupRateMultipl
 import GroupRPMOverridesModal from "@/components/admin/group/GroupRPMOverridesModal.vue";
 import GroupCapacityBadge from "@/components/common/GroupCapacityBadge.vue";
 import { VueDraggable } from "vue-draggable-plus";
+import { getAvailableGroupAccountCount } from "@/utils/groupAccountStats";
 import { createStableObjectKeyResolver } from "@/utils/stableObjectKey";
 import { useKeyedDebouncedSearch } from "@/composables/useKeyedDebouncedSearch";
 import { getPersistedPageSize } from "@/composables/usePersistedPageSize";


### PR DESCRIPTION
## 问题概览
分组管理页面里的"可用账号数"之前是在前端用 `active_account_count - rate_limited_account_count` 计算出来的。

这会导致当限流的账号被手动关闭调度时，出现可用账号数为负的情况：

<img width="1146" height="230" alt="33b8e31e254f0eeab0a126efbe1b25ab" src="https://github.com/user-attachments/assets/d97cb7f4-8f88-4a00-9c82-1b14914e293d" />
<img width="1130" height="230" alt="064f6e03448ccf3ee451925c124b6754" src="https://github.com/user-attachments/assets/9c2cdf9d-40b4-4789-ab50-d2ca4f86da98" />

此问题长期存在于过去的版本中，直到最新版`v0.1.119`依旧可复现

### 问题分析

`active_account_count` 和 `rate_limited_account_count` 并不是同一个统计口径：`active_account_count` 只统计 active 且开启调度的账号，而 `rate_limited_account_count` 可以统计 active 但处于运行时限流/过载/临时不可调度窗口内的账号，即使这个账号已经被手动关闭调度。这样在多个账号同时“限流 + 关闭调度”时，页面就可能显示负的可用账号数。

### 修复
- 后端为分组管理页面的响应新增 `available_account_count` 字段，通过后端计算可用账号数，不再依赖前端简单相减。
- 分组管理表格优先展示后端返回的真实可用账号数；如果对接旧后端 payload，则保留非负 fallback。
- 增加后端 integration test 和前端 unit test，覆盖可用账号数显示为负数的回归场景。

### 测试
- `pnpm test:run src/utils/__tests__/groupAccountStats.spec.ts`
- `go test -tags integration ./internal/repository -run TestGroupRepoSuite/TestLoadAccountCounts_UsesSchedulablePoolSemantics -count=1 -timeout=2m`
- `git diff --check`