### PR TITLE
fix(openai): preserve structured upstream errors

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1289,8 +1289,15 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 	upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
 	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
 
-	// 使用默认的错误映射
+	// 使用默认状态/类型映射，但优先把可解析的上游错误消息返回给下游，
+	// 避免用户只看到“Upstream service temporarily unavailable”这类通用文案。
 	status, errType, errMsg := h.mapUpstreamError(statusCode)
+	if upstreamType := service.ExtractUpstreamErrorType(responseBody); upstreamType != "" {
+		errType = upstreamType
+	}
+	if upstreamMsg != "" {
+		errMsg = upstreamMsg
+	}
 	h.handleStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }
 

--- a/backend/internal/handler/gateway_handler_stream_failover_test.go
+++ b/backend/internal/handler/gateway_handler_stream_failover_test.go
@@ -120,3 +120,21 @@ func TestStreamWrittenGuard_NoByteWritten_GuardNotTriggered(t *testing.T) {
 	require.False(t, guardTriggered,
 		"未写入任何字节时，守卫条件必须为 false，应允许正常 failover 继续")
 }
+
+func TestGatewayFailoverExhausted_ReturnsUpstreamMessageByDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	failoverErr := &service.UpstreamFailoverError{
+		StatusCode:   http.StatusBadGateway,
+		ResponseBody: []byte(`{"error":{"type":"invalid_request_error","message":"upstream validation failed"}}`),
+	}
+
+	h := &GatewayHandler{}
+	h.handleFailoverExhausted(c, failoverErr, service.PlatformAnthropic, false)
+
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	require.JSONEq(t, `{"type":"error","error":{"type":"invalid_request_error","message":"upstream validation failed"}}`, w.Body.String())
+}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1478,7 +1478,11 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 				c.Set(service.OpsSkipPassthroughKey, true)
 			}
 
-			h.handleStreamingAwareError(c, respCode, "upstream_error", msg, streamStarted)
+			errType := "upstream_error"
+			if upstreamType := service.ExtractUpstreamErrorType(responseBody); upstreamType != "" {
+				errType = upstreamType
+			}
+			h.handleStreamingAwareOpenAIError(c, respCode, errType, msg, responseBody, streamStarted)
 			return
 		}
 	}
@@ -1487,9 +1491,19 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 	upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
 	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
 
-	// 使用默认的错误映射
+	// 使用默认状态/类型映射，但优先把可解析的上游错误消息返回给下游，
+	// 避免用户只看到“Upstream service temporarily unavailable”这类通用文案。
 	status, errType, errMsg := h.mapUpstreamError(statusCode)
-	h.handleStreamingAwareError(c, status, errType, errMsg, streamStarted)
+	if upstreamType := service.ExtractUpstreamErrorType(responseBody); upstreamType != "" {
+		errType = upstreamType
+		if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError && statusCode != http.StatusUnauthorized && statusCode != http.StatusForbidden && statusCode != http.StatusTooManyRequests {
+			status = statusCode
+		}
+	}
+	if upstreamMsg != "" {
+		errMsg = upstreamMsg
+	}
+	h.handleStreamingAwareOpenAIError(c, status, errType, errMsg, responseBody, streamStarted)
 }
 
 // handleFailoverExhaustedSimple 简化版本，用于没有响应体的情况
@@ -1517,6 +1531,33 @@ func (h *OpenAIGatewayHandler) mapUpstreamError(statusCode int) (int, string, st
 }
 
 // handleStreamingAwareError handles errors that may occur after streaming has started
+func (h *OpenAIGatewayHandler) handleStreamingAwareOpenAIError(c *gin.Context, status int, errType, message string, responseBody []byte, streamStarted bool) {
+	errorObj := gin.H{
+		"type":    errType,
+		"message": message,
+	}
+	if code, ok := service.ExtractUpstreamErrorCode(responseBody); ok {
+		errorObj["code"] = code
+	}
+	if param, ok := service.ExtractUpstreamErrorParam(responseBody); ok {
+		errorObj["param"] = param
+	}
+
+	if streamStarted {
+		flusher, ok := c.Writer.(http.Flusher)
+		if ok {
+			payload, _ := json.Marshal(gin.H{"error": errorObj})
+			if _, err := fmt.Fprintf(c.Writer, "event: error\ndata: %s\n\n", payload); err != nil {
+				_ = c.Error(err)
+			}
+			flusher.Flush()
+		}
+		return
+	}
+
+	c.JSON(status, gin.H{"error": errorObj})
+}
+
 func (h *OpenAIGatewayHandler) handleStreamingAwareError(c *gin.Context, status int, errType, message string, streamStarted bool) {
 	if streamStarted {
 		// Stream already started, send error as SSE event then close

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -796,3 +796,39 @@ func newOpenAIWSHandlerTestServer(t *testing.T, h *OpenAIGatewayHandler, subject
 	router.GET("/openai/v1/responses", h.ResponsesWebSocket)
 	return httptest.NewServer(router)
 }
+
+func TestOpenAIFailoverExhausted_ReturnsUpstreamMessageByDefault(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	failoverErr := &service.UpstreamFailoverError{
+		StatusCode:   http.StatusServiceUnavailable,
+		ResponseBody: []byte(`{"error":{"code":"invalid_value","type":"server_error","message":"upstream model overloaded: retry after 30s","param":"tools"}}`),
+	}
+
+	h := &OpenAIGatewayHandler{}
+	h.handleFailoverExhausted(c, failoverErr, false)
+
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	require.JSONEq(t, `{"error":{"code":"invalid_value","type":"server_error","message":"upstream model overloaded: retry after 30s","param":"tools"}}`, w.Body.String())
+}
+
+func TestOpenAIFailoverExhausted_PreservesNullCodeAndParam(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	failoverErr := &service.UpstreamFailoverError{
+		StatusCode:   http.StatusBadRequest,
+		ResponseBody: []byte(`{"error":{"code":null,"message":"No tool call found for function call output with call_id fcaa415ff5cd0c.","param":"input","type":"invalid_request_error"}}`),
+	}
+
+	h := &OpenAIGatewayHandler{}
+	h.handleFailoverExhausted(c, failoverErr, false)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.JSONEq(t, `{"error":{"code":null,"message":"No tool call found for function call output with call_id fcaa415ff5cd0c.","param":"input","type":"invalid_request_error"}}`, w.Body.String())
+}

--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -62,13 +62,13 @@ func TestGatewayHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	assert.Equal(t, "Upstream request failed", errField["message"])
 }
 
-func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
+func TestOpenAIHandleErrorResponse_PreservesStructuredUserError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 
 	svc := &OpenAIGatewayService{}
-	respBody := []byte(`{"error":{"message":"Invalid schema for field messages"}}`)
+	respBody := []byte(`{"error":{"code":null,"message":"Item with id 'rs_0c6a545ab19f86ee0169edb4bc4fac8193a6ebafee677d84a2' not found. Items are not persisted when ` + "`" + `store` + "`" + ` is set to false. Try again with ` + "`" + `store` + "`" + ` set to true, or remove this item from your input.","param":"input","type":"invalid_request_error"}}`)
 	resp := &http.Response{
 		StatusCode: http.StatusUnprocessableEntity,
 		Body:       io.NopCloser(bytes.NewReader(respBody)),
@@ -78,14 +78,16 @@ func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 
 	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
 	require.Error(t, err)
-	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Equal(t, http.StatusUnprocessableEntity, rec.Code)
 
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
 	errField, ok := payload["error"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "upstream_error", errField["type"])
-	assert.Equal(t, "Upstream request failed", errField["message"])
+	assert.Equal(t, "invalid_request_error", errField["type"])
+	assert.Equal(t, nil, errField["code"])
+	assert.Equal(t, "input", errField["param"])
+	assert.Contains(t, errField["message"], "Items are not persisted")
 }
 
 func TestGeminiWriteGeminiMappedError_NoRuleKeepsDefault(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6440,6 +6440,21 @@ func ExtractUpstreamErrorMessage(body []byte) string {
 	return extractUpstreamErrorMessage(body)
 }
 
+// ExtractUpstreamErrorType extracts structured upstream error type when present.
+func ExtractUpstreamErrorType(body []byte) string {
+	return extractUpstreamErrorType(body)
+}
+
+// ExtractUpstreamErrorCode extracts structured upstream error code when present.
+func ExtractUpstreamErrorCode(body []byte) (any, bool) {
+	return extractUpstreamErrorField(body, "code")
+}
+
+// ExtractUpstreamErrorParam extracts structured upstream error param when present.
+func ExtractUpstreamErrorParam(body []byte) (any, bool) {
+	return extractUpstreamErrorField(body, "param")
+}
+
 func extractUpstreamErrorMessage(body []byte) string {
 	// Claude 风格：{"type":"error","error":{"type":"...","message":"..."}}
 	if m := gjson.GetBytes(body, "error.message").String(); strings.TrimSpace(m) != "" {
@@ -6460,6 +6475,70 @@ func extractUpstreamErrorMessage(body []byte) string {
 
 	// 兜底：尝试顶层 message
 	return gjson.GetBytes(body, "message").String()
+}
+
+func extractUpstreamErrorField(body []byte, field string) (any, bool) {
+	path := "error." + field
+	if v := gjson.GetBytes(body, path); v.Exists() {
+		return gjsonResultValue(v), true
+	}
+
+	inner := strings.TrimSpace(gjson.GetBytes(body, "error.message").String())
+	if !strings.HasPrefix(inner, "{") {
+		return nil, false
+	}
+
+	if v := gjson.Get(inner, path); v.Exists() {
+		return gjsonResultValue(v), true
+	}
+
+	if lastBrace := strings.LastIndex(inner, "}"); lastBrace >= 0 {
+		if v := gjson.Get(inner[:lastBrace+1], path); v.Exists() {
+			return gjsonResultValue(v), true
+		}
+	}
+
+	return nil, false
+}
+
+func gjsonResultValue(v gjson.Result) any {
+	switch v.Type {
+	case gjson.Null:
+		return nil
+	case gjson.True:
+		return true
+	case gjson.False:
+		return false
+	case gjson.Number:
+		return v.Value()
+	case gjson.JSON:
+		return v.Value()
+	default:
+		return v.String()
+	}
+}
+
+func extractUpstreamErrorType(body []byte) string {
+	if errType := strings.TrimSpace(gjson.GetBytes(body, "error.type").String()); errType != "" {
+		return errType
+	}
+
+	inner := strings.TrimSpace(gjson.GetBytes(body, "error.message").String())
+	if !strings.HasPrefix(inner, "{") {
+		return ""
+	}
+
+	if errType := strings.TrimSpace(gjson.Get(inner, "error.type").String()); errType != "" {
+		return errType
+	}
+
+	if lastBrace := strings.LastIndex(inner, "}"); lastBrace >= 0 {
+		if errType := strings.TrimSpace(gjson.Get(inner[:lastBrace+1], "error.type").String()); errType != "" {
+			return errType
+		}
+	}
+
+	return ""
 }
 
 func extractUpstreamErrorCode(body []byte) string {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -689,6 +689,20 @@ func resolveOpenAIWSFallbackErrorResponse(err error) (statusCode int, errType st
 	return statusCode, errType, clientMessage, upstreamMessage, true
 }
 
+func writeOpenAIErrorResponse(c *gin.Context, statusCode int, errType, message string, responseBody []byte) {
+	errorObj := gin.H{
+		"type":    errType,
+		"message": message,
+	}
+	if code, ok := ExtractUpstreamErrorCode(responseBody); ok {
+		errorObj["code"] = code
+	}
+	if param, ok := ExtractUpstreamErrorParam(responseBody); ok {
+		errorObj["param"] = param
+	}
+	c.JSON(statusCode, gin.H{"error": errorObj})
+}
+
 func (s *OpenAIGatewayService) writeOpenAIWSFallbackErrorResponse(c *gin.Context, account *Account, wsErr error) bool {
 	if c == nil || c.Writer == nil || c.Writer.Written() {
 		return false
@@ -3713,12 +3727,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		"upstream_error",
 		"Upstream request failed",
 	); matched {
-		c.JSON(status, gin.H{
-			"error": gin.H{
-				"type":    errType,
-				"message": errMsg,
-			},
-		})
+		writeOpenAIErrorResponse(c, status, errType, errMsg, body)
 		if upstreamMsg == "" {
 			upstreamMsg = errMsg
 		}
@@ -3779,7 +3788,8 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		}
 	}
 
-	// Return appropriate error response
+	// Return appropriate error response. Preserve structured upstream user errors so clients
+	// can see invalid_request_error/code/param instead of a generic upstream_error wrapper.
 	var errType, errMsg string
 	var statusCode int
 
@@ -3805,13 +3815,17 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		errType = "upstream_error"
 		errMsg = "Upstream request failed"
 	}
+	if upstreamType := ExtractUpstreamErrorType(body); upstreamType != "" {
+		errType = upstreamType
+		if resp.StatusCode >= http.StatusBadRequest && resp.StatusCode < http.StatusInternalServerError && resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+			statusCode = resp.StatusCode
+		}
+	}
+	if upstreamMsg != "" {
+		errMsg = upstreamMsg
+	}
 
-	c.JSON(statusCode, gin.H{
-		"error": gin.H{
-			"type":    errType,
-			"message": errMsg,
-		},
-	})
+	writeOpenAIErrorResponse(c, statusCode, errType, errMsg, body)
 
 	if upstreamMsg == "" {
 		return nil, fmt.Errorf("upstream error: %d", resp.StatusCode)

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -274,7 +274,8 @@ func TestOpenAIGatewayService_Forward_LogsInstructionsRequiredDetails(t *testing
 
 	_, err := svc.Forward(context.Background(), c, account, body)
 	require.Error(t, err)
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.JSONEq(t, `{"error":{"message":"Missing required parameter: 'instructions'","type":"invalid_request_error","param":"instructions","code":"missing_required_parameter"}}`, rec.Body.String())
 	require.Contains(t, err.Error(), "upstream error: 400")
 
 	require.True(t, logSink.ContainsMessageAtLevel("OpenAI 上游返回 Instructions are required，已记录请求详情用于排查", "warn"))

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -483,6 +483,11 @@ func openAIImagesStreamPrefix(parsed *OpenAIImagesRequest) string {
 	return "image_generation"
 }
 
+type openAIImagesResponsesError struct {
+	Message       string
+	StreamPayload []byte
+}
+
 func buildOpenAIImagesStreamErrorBody(message string) []byte {
 	body := []byte(`{"type":"error","error":{"type":"upstream_error","message":""}}`)
 	if strings.TrimSpace(message) == "" {
@@ -490,6 +495,133 @@ func buildOpenAIImagesStreamErrorBody(message string) []byte {
 	}
 	body, _ = sjson.SetBytes(body, "error.message", message)
 	return body
+}
+
+func buildOpenAIImagesStructuredErrorPayload(errorObject []byte, message string) []byte {
+	body := []byte(`{"type":"error","error":{"type":"upstream_error","message":""}}`)
+	if raw := bytes.TrimSpace(errorObject); len(raw) > 0 && raw[0] == '{' && gjson.ValidBytes(raw) {
+		body, _ = sjson.SetRawBytes(body, "error", raw)
+	}
+	if strings.TrimSpace(gjson.GetBytes(body, "error.type").String()) == "" {
+		body, _ = sjson.SetBytes(body, "error.type", "upstream_error")
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "upstream request failed"
+	}
+	if strings.TrimSpace(gjson.GetBytes(body, "error.message").String()) == "" {
+		body, _ = sjson.SetBytes(body, "error.message", message)
+	}
+	return body
+}
+
+func normalizeOpenAIImagesStreamErrorPayload(payload []byte, errorObject []byte, message string) []byte {
+	if len(payload) > 0 && gjson.ValidBytes(payload) && strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "error" {
+		body := bytes.TrimSpace(payload)
+		if strings.TrimSpace(gjson.GetBytes(body, "error.type").String()) == "" {
+			body, _ = sjson.SetBytes(body, "error.type", "upstream_error")
+		}
+		if strings.TrimSpace(message) == "" {
+			message = "upstream request failed"
+		}
+		if strings.TrimSpace(gjson.GetBytes(body, "error.message").String()) == "" {
+			body, _ = sjson.SetBytes(body, "error.message", message)
+		}
+		return body
+	}
+	return buildOpenAIImagesStructuredErrorPayload(errorObject, message)
+}
+
+func extractOpenAIImagesResponsesErrorObject(payload []byte) []byte {
+	for _, path := range []string{"response.error", "error"} {
+		result := gjson.GetBytes(payload, path)
+		raw := strings.TrimSpace(result.Raw)
+		if result.Type == gjson.JSON && strings.HasPrefix(raw, "{") {
+			return []byte(raw)
+		}
+	}
+	return nil
+}
+
+func buildOpenAIImagesNonStreamingErrorBody(streamPayload []byte, message string) []byte {
+	errorObject := extractOpenAIImagesResponsesErrorObject(streamPayload)
+	if len(errorObject) == 0 {
+		errorObject = []byte(gjson.GetBytes(buildOpenAIImagesStreamErrorBody(message), "error").Raw)
+	}
+	body := []byte(`{"error":{"type":"upstream_error","message":"upstream request failed"}}`)
+	if raw := bytes.TrimSpace(errorObject); len(raw) > 0 && raw[0] == '{' && gjson.ValidBytes(raw) {
+		body, _ = sjson.SetRawBytes(body, "error", raw)
+	}
+	if strings.TrimSpace(gjson.GetBytes(body, "error.type").String()) == "" {
+		body, _ = sjson.SetBytes(body, "error.type", "upstream_error")
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "upstream request failed"
+	}
+	if strings.TrimSpace(gjson.GetBytes(body, "error.message").String()) == "" {
+		body, _ = sjson.SetBytes(body, "error.message", message)
+	}
+	return body
+}
+
+func extractOpenAIImagesResponsesError(payload []byte) (openAIImagesResponsesError, bool) {
+	if len(payload) == 0 || !gjson.ValidBytes(payload) {
+		return openAIImagesResponsesError{}, false
+	}
+	eventType := strings.TrimSpace(gjson.GetBytes(payload, "type").String())
+	switch eventType {
+	case "error", "response.failed":
+		msg := extractOpenAISSEErrorMessage(payload)
+		if msg == "" {
+			msg = "upstream image generation failed"
+		}
+		errorObject := extractOpenAIImagesResponsesErrorObject(payload)
+		return openAIImagesResponsesError{
+			Message:       msg,
+			StreamPayload: normalizeOpenAIImagesStreamErrorPayload(payload, errorObject, msg),
+		}, true
+	case "response.incomplete":
+		if msg := extractOpenAISSEErrorMessage(payload); msg != "" {
+			errorObject := extractOpenAIImagesResponsesErrorObject(payload)
+			return openAIImagesResponsesError{
+				Message:       msg,
+				StreamPayload: normalizeOpenAIImagesStreamErrorPayload(payload, errorObject, msg),
+			}, true
+		}
+	}
+	return openAIImagesResponsesError{}, false
+}
+
+func (s *OpenAIGatewayService) recordOpenAIImagesResponsesError(
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	payload []byte,
+	message string,
+	kind string,
+) {
+	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
+	if message == "" {
+		message = "upstream image generation failed"
+	}
+	detail := strings.TrimSpace(string(payload))
+	setOpsUpstreamError(c, http.StatusBadGateway, message, detail)
+
+	event := OpsUpstreamErrorEvent{
+		UpstreamStatusCode:   http.StatusBadGateway,
+		Kind:                 kind,
+		Message:              message,
+		Detail:               detail,
+		UpstreamResponseBody: detail,
+	}
+	if resp != nil {
+		event.UpstreamRequestID = resp.Header.Get("x-request-id")
+	}
+	if account != nil {
+		event.Platform = account.Platform
+		event.AccountID = account.ID
+		event.AccountName = account.Name
+	}
+	appendOpsUpstreamError(c, event)
 }
 
 func (s *OpenAIGatewayService) writeOpenAIImagesStreamEvent(c *gin.Context, flusher http.Flusher, eventName string, payload []byte) error {
@@ -506,8 +638,10 @@ func (s *OpenAIGatewayService) writeOpenAIImagesStreamEvent(c *gin.Context, flus
 }
 
 func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
+	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	responseFormat string,
 	fallbackModel string,
 ) (OpenAIUsage, int, error) {
@@ -525,6 +659,12 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 		}
 		dataBytes := []byte(data)
 		s.parseSSEUsageBytes(dataBytes, &usage)
+		if upstreamErr, ok := extractOpenAIImagesResponsesError(dataBytes); ok {
+			s.recordOpenAIImagesResponsesError(c, account, resp, dataBytes, upstreamErr.Message, "stream_error_event")
+			responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+			c.Data(http.StatusBadGateway, "application/json; charset=utf-8", buildOpenAIImagesNonStreamingErrorBody(upstreamErr.StreamPayload, upstreamErr.Message))
+			return OpenAIUsage{}, 0, fmt.Errorf("upstream image generation failed: %s", upstreamErr.Message)
+		}
 	}
 	results, createdAt, usageRaw, firstMeta, _, err := collectOpenAIImagesFromResponsesBody(body)
 	if err != nil {
@@ -547,8 +687,10 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 }
 
 func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
+	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	startTime time.Time,
 	responseFormat string,
 	streamPrefix string,
@@ -593,6 +735,11 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 				dataBytes := []byte(data)
 				s.parseSSEUsageBytes(dataBytes, &usage)
 				if gjson.ValidBytes(dataBytes) {
+					if upstreamErr, ok := extractOpenAIImagesResponsesError(dataBytes); ok {
+						s.recordOpenAIImagesResponsesError(c, account, resp, dataBytes, upstreamErr.Message, "stream_error_event")
+						_ = s.writeOpenAIImagesStreamEvent(c, flusher, "error", upstreamErr.StreamPayload)
+						return OpenAIUsage{}, imageCount, firstTokenMs, fmt.Errorf("upstream image generation failed: %s", upstreamErr.Message)
+					}
 					if meta, eventCreatedAt, ok := extractOpenAIResponsesImageMetaFromLifecycleEvent(dataBytes); ok {
 						mergeOpenAIResponsesImageMeta(&streamMeta, meta)
 						if eventCreatedAt > 0 {
@@ -825,12 +972,12 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 		firstTokenMs *int
 	)
 	if parsed.Stream {
-		usage, imageCount, firstTokenMs, err = s.handleOpenAIImagesOAuthStreamingResponse(resp, c, startTime, parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), requestModel)
+		usage, imageCount, firstTokenMs, err = s.handleOpenAIImagesOAuthStreamingResponse(ctx, resp, c, account, startTime, parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), requestModel)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		usage, imageCount, err = s.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, parsed.ResponseFormat, requestModel)
+		usage, imageCount, err = s.handleOpenAIImagesOAuthNonStreamingResponse(ctx, resp, c, account, parsed.ResponseFormat, requestModel)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -445,6 +445,131 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingTransformsEvents(t *tes
 	require.False(t, gjson.Get(completed.Data, "revised_prompt").Exists())
 }
 
+func TestOpenAIGatewayServiceForwardImages_OAuthStreamingRecordsResponseFailed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+				"X-Request-Id": []string{"req_img_failed"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				`data: {"type":"response.failed","response":{"error":{"type":"server_error","message":"image worker failed"}}}` + "\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+	svc.httpUpstream = upstream
+
+	account := &Account{ID: 2, Name: "openai-oauth", Platform: PlatformOpenAI, Type: AccountTypeOAuth, Credentials: map[string]any{"access_token": "token-123"}}
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, err.Error(), "image worker failed")
+	require.Equal(t, http.StatusBadGateway, c.GetInt(OpsUpstreamStatusCodeKey))
+	msg, _ := c.Get(OpsUpstreamErrorMessageKey)
+	require.Equal(t, "image worker failed", msg)
+	detail, _ := c.Get(OpsUpstreamErrorDetailKey)
+	require.Contains(t, detail, "response.failed")
+	require.Contains(t, rec.Body.String(), "image worker failed")
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthStreamingPreservesStructuredErrorEvent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+				"X-Request-Id": []string{"req_img_moderation"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				`data: {"error":{"code":"moderation_blocked","message":"Your request was rejected by the safety system.","param":null,"type":"image_generation_user_error"},"sequence_number":11,"type":"error"}` + "\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+	svc.httpUpstream = upstream
+
+	account := &Account{ID: 2, Name: "openai-oauth", Platform: PlatformOpenAI, Type: AccountTypeOAuth, Credentials: map[string]any{"access_token": "token-123"}}
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	events := parseOpenAIImageTestSSEEvents(rec.Body.String())
+	errorEvent, ok := findOpenAIImageTestSSEEvent(events, "error")
+	require.True(t, ok)
+	require.Equal(t, "error", gjson.Get(errorEvent.Data, "type").String())
+	require.Equal(t, int64(11), gjson.Get(errorEvent.Data, "sequence_number").Int())
+	require.Equal(t, "image_generation_user_error", gjson.Get(errorEvent.Data, "error.type").String())
+	require.Equal(t, "moderation_blocked", gjson.Get(errorEvent.Data, "error.code").String())
+	require.Equal(t, gjson.Null, gjson.Get(errorEvent.Data, "error.param").Type)
+	require.Contains(t, gjson.Get(errorEvent.Data, "error.message").String(), "rejected by the safety system")
+	require.NotEqual(t, "upstream_error", gjson.Get(errorEvent.Data, "error.type").String())
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthNonStreamingPreservesStructuredImageError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(
+				`data: {"type":"response.failed","response":{"error":{"code":"invalid_value","message":"Transparent background is not supported for this model.","param":"tools","type":"image_generation_user_error"}}}` + "\n\n",
+			)),
+		},
+	}
+	svc.httpUpstream = upstream
+
+	account := &Account{ID: 2, Name: "openai-oauth", Platform: PlatformOpenAI, Type: AccountTypeOAuth, Credentials: map[string]any{"access_token": "token-123"}}
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, "image_generation_user_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Equal(t, "invalid_value", gjson.Get(rec.Body.String(), "error.code").String())
+	require.Equal(t, "tools", gjson.Get(rec.Body.String(), "error.param").String())
+	require.Equal(t, "Transparent background is not supported for this model.", gjson.Get(rec.Body.String(), "error.message").String())
+}
+
 func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION

OpenAI 上游返回结构化错误时，下游目前可能只看到通用的 `upstream_error` / `Upstream request failed`，导致调用方无法直接判断真实原因。例如：

- `invalid_request_error` 被包装成通用上游错误
- `code` / `param` 字段丢失，包括 `code: null`、`param: "input"`
- `/v1/images` 通过 Responses SSE 返回 `type: error` 或 `response.failed` 时，没有稳定透传给下游

这些错误本身不是网关错误，应该尽量保留上游原始结构，方便客户端和用户直接看到真实原因。

### 变更

- 增加结构化上游错误字段提取：`type` / `code` / `param`。
- OpenAI failover exhausted 路径保留上游 `error.type`、`error.message`、`error.code`、`error.param`。
- OpenAI 非 failover 错误路径对 4xx 用户错误保留原始错误类型和 HTTP 状态。
- `/v1/images` OAuth Responses 转换路径识别 SSE `type: error`、`response.failed`、带 message 的 `response.incomplete`。
- 图片流式错误保持 SSE error event；非流式错误返回 OpenAI 风格 JSON error。
- Anthropic/Gateway failover exhausted 路径也优先展示上游可解析错误消息，避免只返回通用文案。

### 不包含

- 不改账号调度策略。
- 不引入图片单独额度。
- 不修改 Codex 会话粘性。

### 验证

```bash
go test ./internal/service -run 'OpenAI.*Image|Passthrough|Error' -count=1
go test ./internal/handler ./internal/handler/admin -run 'OpenAI|Failover|Passthrough|Error' -count=1
```
