### PR TITLE
[codex] Fix cache_control limit enforcement

### DIFF
--- a/backend/internal/service/gateway_body_order_test.go
+++ b/backend/internal/service/gateway_body_order_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func assertJSONTokenOrder(t *testing.T, body string, tokens ...string) {
@@ -70,4 +71,32 @@ func TestEnforceCacheControlLimit_PreservesTopLevelFieldOrder(t *testing.T) {
 
 	assertJSONTokenOrder(t, resultStr, `"alpha"`, `"system"`, `"messages"`, `"omega"`)
 	require.Equal(t, 4, strings.Count(resultStr, `"cache_control"`))
+}
+
+func TestEnforceCacheControlLimit_CountsTopLevelAndToolCacheControl(t *testing.T) {
+	body := []byte(`{"cache_control":{"type":"ephemeral"},"system":[{"type":"text","text":"s","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"m1","cache_control":{"type":"ephemeral"}}]},{"role":"assistant","content":[{"type":"text","text":"m2","cache_control":{"type":"ephemeral"}}]}],"tools":[{"name":"t","input_schema":{},"cache_control":{"type":"ephemeral"}}]}`)
+
+	result := enforceCacheControlLimit(body)
+	resultStr := string(result)
+
+	require.Equal(t, 4, strings.Count(resultStr, `"cache_control"`))
+	require.False(t, gjson.GetBytes(result, "cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "messages.0.content.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "messages.1.content.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "tools.0.cache_control").Exists())
+}
+
+func TestEnforceCacheControlLimit_TrimsMessagesBeforeToolsAndSystem(t *testing.T) {
+	body := []byte(`{"system":[{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}},{"type":"text","text":"s2","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"m1","cache_control":{"type":"ephemeral"}}]},{"role":"assistant","content":[{"type":"text","text":"m2","cache_control":{"type":"ephemeral"}}]}],"tools":[{"name":"t","input_schema":{},"cache_control":{"type":"ephemeral"}}]}`)
+
+	result := enforceCacheControlLimit(body)
+	resultStr := string(result)
+
+	require.Equal(t, 4, strings.Count(resultStr, `"cache_control"`))
+	require.False(t, gjson.GetBytes(result, "messages.0.content.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "messages.1.content.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "tools.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.1.cache_control").Exists())
 }

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3963,7 +3963,11 @@ type cacheControlPath struct {
 	log  string
 }
 
-func collectCacheControlPaths(body []byte) (invalidThinking []cacheControlPath, messagePaths []string, systemPaths []string) {
+func collectCacheControlPaths(body []byte) (invalidThinking []cacheControlPath, rootPaths []string, messagePaths []string, toolPaths []string, systemPaths []string) {
+	if gjson.GetBytes(body, "cache_control").Exists() {
+		rootPaths = append(rootPaths, "cache_control")
+	}
+
 	system := gjson.GetBytes(body, "system")
 	if system.IsArray() {
 		sysIndex := 0
@@ -4012,17 +4016,29 @@ func collectCacheControlPaths(body []byte) (invalidThinking []cacheControlPath, 
 		})
 	}
 
-	return invalidThinking, messagePaths, systemPaths
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		toolIndex := 0
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if tool.Get("cache_control").Exists() {
+				toolPaths = append(toolPaths, fmt.Sprintf("tools.%d.cache_control", toolIndex))
+			}
+			toolIndex++
+			return true
+		})
+	}
+
+	return invalidThinking, rootPaths, messagePaths, toolPaths, systemPaths
 }
 
 // enforceCacheControlLimit 强制执行 cache_control 块数量限制（最多 4 个）
-// 超限时优先从 messages 中移除 cache_control，保护 system 中的缓存控制
+// 超限时优先移除顶层 cache_control，再从 messages 中移除，保护 tools 和 system 中的缓存控制
 func enforceCacheControlLimit(body []byte) []byte {
 	if len(body) == 0 {
 		return body
 	}
 
-	invalidThinking, messagePaths, systemPaths := collectCacheControlPaths(body)
+	invalidThinking, rootPaths, messagePaths, toolPaths, systemPaths := collectCacheControlPaths(body)
 	out := body
 	modified := false
 
@@ -4040,7 +4056,7 @@ func enforceCacheControlLimit(body []byte) []byte {
 		logger.LegacyPrintf("service.gateway", "%s", item.log)
 	}
 
-	count := len(messagePaths) + len(systemPaths)
+	count := len(rootPaths) + len(messagePaths) + len(toolPaths) + len(systemPaths)
 	if count <= maxCacheControlBlocks {
 		if modified {
 			return out
@@ -4048,9 +4064,41 @@ func enforceCacheControlLimit(body []byte) []byte {
 		return body
 	}
 
-	// 超限：优先从 messages 中移除，再从 system 中移除
+	// 超限：优先从顶层和 messages 中移除，再从 tools、system 中移除
 	remaining := count - maxCacheControlBlocks
+	for _, path := range rootPaths {
+		if remaining <= 0 {
+			break
+		}
+		if !gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		next, ok := deleteJSONPathBytes(out, path)
+		if !ok {
+			continue
+		}
+		out = next
+		modified = true
+		remaining--
+	}
+
 	for _, path := range messagePaths {
+		if remaining <= 0 {
+			break
+		}
+		if !gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		next, ok := deleteJSONPathBytes(out, path)
+		if !ok {
+			continue
+		}
+		out = next
+		modified = true
+		remaining--
+	}
+
+	for _, path := range toolPaths {
 		if remaining <= 0 {
 			break
 		}


### PR DESCRIPTION
## Summary
- Count top-level `cache_control` and `tools[*].cache_control` when enforcing Anthropic's 4-block cache_control limit.
- Prefer trimming top-level client cache_control first, then message cache controls, while preserving tool and system cache breakpoints when possible.
- Add regression coverage for top-level + tool cache controls and trim priority.

## Root Cause
The gateway adds stable message and tool cache breakpoints, but the limit enforcement only counted system and message cache controls. Requests that already contained top-level cache_control could therefore pass through with five cache_control entries and be rejected by Anthropic.

## Validation
- `GOPROXY=https://goproxy.cn,direct go test ./internal/service -run 'Test(EnforceCacheControlLimit|ApplyToolsLastCacheBreakpoint|StripMessageCacheControl|AddMessageCacheBreakpoints)'`\n- `git diff --check`