### PR TITLE
feat(openai): pass through SSE comment keepalives during reasoning stalls

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3375,6 +3375,20 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		}
 
 		if !clientDisconnected {
+			// SSE comment lines (":...") are no-ops per spec but reset idle
+			// timers on intermediaries (e.g. Cloudflare's ~100s limit). Pass
+			// them through immediately, even before client output has started,
+			// so upstream keepalives during long reasoning stalls actually
+			// reach the client without polluting the pending buffer.
+			if isSSECommentLine(line) {
+				if _, err := fmt.Fprintln(w, line); err != nil {
+					clientDisconnected = true
+					logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				} else {
+					flusher.Flush()
+				}
+				continue
+			}
 			if !clientOutputStarted && !lineStartsClientOutput {
 				pendingLines = append(pendingLines, line)
 				continue
@@ -4331,6 +4345,14 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 
 // extractOpenAISSEDataLine 低开销提取 SSE `data:` 行内容。
 // 兼容 `data: xxx` 与 `data:xxx` 两种格式。
+// isSSECommentLine reports whether line is an SSE comment line (begins with
+// ':' after optional whitespace) per the EventSource spec. Comment lines are
+// ignored by clients but useful as keepalives across idle proxies.
+func isSSECommentLine(line string) bool {
+	trimmed := strings.TrimLeft(line, " \t")
+	return strings.HasPrefix(trimmed, ":")
+}
+
 func extractOpenAISSEDataLine(line string) (string, bool) {
 	if !strings.HasPrefix(line, "data:") {
 		return "", false

--- a/backend/internal/service/openai_gateway_service_sse_comment_test.go
+++ b/backend/internal/service/openai_gateway_service_sse_comment_test.go
@@ -1,0 +1,25 @@
+package service
+
+import "testing"
+
+func TestIsSSECommentLine(t *testing.T) {
+	cases := []struct {
+		line string
+		want bool
+	}{
+		{":", true},
+		{": keepalive", true},
+		{":heartbeat", true},
+		{"  : leading space", true},
+		{"\t: leading tab", true},
+		{"data: {\"foo\":1}", false},
+		{"event: response.created", false},
+		{"", false},
+		{"  ", false},
+	}
+	for _, c := range cases {
+		if got := isSSECommentLine(c.line); got != c.want {
+			t.Errorf("isSSECommentLine(%q) = %v, want %v", c.line, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Background

`forwardOpenAIPassthrough` collects all upstream SSE lines in a `pendingLines`
slice until it sees the first \"client output\" event. This is by design — it
hides intermediate non-output events from clients until something visible
arrives.

It also has an unintended side effect: SSE **comment lines** (lines beginning
with \`:\`) emitted by upstreams as keepalive heartbeats end up in the same
buffer and never leave the gateway during the reasoning window.

## Symptom

GPT-5 / o1-class models with high reasoning effort can spend 60–120 s on a
single reasoning step before producing the first \`response.output_text.delta\`.
During that window the upstream connection is alive and the upstream sends
\`: ping\` / \`: keepalive\` lines, but the gateway holds them in the buffer.

Any intermediary with an idle-timeout shorter than the reasoning step closes
the SSE connection. The most common one is Cloudflare's ~100 s origin idle
limit. The user-visible error is:

```
Stream disconnected before completion: stream closed before response.completed
```

The gateway logs show no error — from its perspective the upstream is still
streaming, the client just \"disconnected\" silently a minute or two in.

## Change

Bypass the pending buffer for SSE comment lines. When a line begins with
\`:\` (after optional whitespace, per the
[EventSource spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream)),
write it directly and \`flusher.Flush()\` immediately, without setting
\`clientOutputStarted\` or contributing to first-token timing.

Comment lines are explicitly defined as no-ops by the spec, so this is safe
for any compliant SSE client. But every byte that hits the wire resets idle
timers on Cloudflare, nginx, AWS ALB, and similar middleboxes.

## Tests

New unit test \`TestIsSSECommentLine\` covers the helper across spaces, tabs,
empty input, and non-comment lines.

```
$ go test -run TestIsSSECommentLine ./internal/service/...
ok  	github.com/Wei-Shaw/sub2api/internal/service
$ go build ./...
(clean)
```

## Risk / Compatibility

- No change for streams that don't contain comment lines (the new branch is
  guarded by a single \`HasPrefix\` check).
- No change to \`firstTokenMs\` accounting — comment lines are explicitly
  excluded from \"client output\" detection.
- No change to failure semantics. \`response.failed\`, \`[DONE]\`, terminal-event
  detection, and \`pendingLines\` flushing on first real output are untouched.
- Memory: removes lines from the buffer immediately, so peak buffer size only
  decreases.

Happy to adjust the helper name or split the test if preferred.