### PR TITLE
fix(openai): scope 429 rate limits by request type

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -1106,6 +1106,7 @@ func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, sco
 	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue model rate limit failed: account=%d err=%v", id, err)
 	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
 	return nil
 }
 

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -539,7 +539,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		if resp.StatusCode == http.StatusTooManyRequests {
-			s.reconcileOpenAI429State(ctx, account, resp.Header, body)
+			s.reconcileOpenAI429State(ctx, account, resp.Header, body, testModelID)
 		}
 		// 401 Unauthorized: 标记账号为永久错误
 		if resp.StatusCode == http.StatusUnauthorized && s.accountRepo != nil {
@@ -651,7 +651,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 		}
 		// 探测如返回 429,主动同步限流状态,避免后续短时间内继续选中。
 		if resp.StatusCode == http.StatusTooManyRequests {
-			s.reconcileOpenAI429State(ctx, account, resp.Header, body)
+			s.reconcileOpenAI429State(ctx, account, resp.Header, body, testModelID)
 		}
 	}
 
@@ -668,36 +668,77 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 	return nil
 }
 
-func (s *AccountTestService) reconcileOpenAI429State(ctx context.Context, account *Account, headers http.Header, body []byte) {
+func (s *AccountTestService) reconcileOpenAI429State(ctx context.Context, account *Account, headers http.Header, body []byte, requestedModel string) {
 	if s == nil || s.accountRepo == nil || account == nil {
+		return
+	}
+
+	resetUnix, scopeGlobal, recognized := parseOpenAIRateLimitResetTime(body)
+	if recognized && scopeGlobal {
+		s.reconcileOpenAIAccountRateLimitState(ctx, account, openAIUsageLimitResetTime(resetUnix))
 		return
 	}
 
 	var resetAt *time.Time
 	if calculated := calculateOpenAI429ResetTime(headers); calculated != nil {
 		resetAt = calculated
-	} else if unixTs := parseOpenAIRateLimitResetTime(body); unixTs != nil {
-		t := time.Unix(*unixTs, 0)
-		resetAt = &t
+	} else if recognized {
+		if resetUnix != nil {
+			resetTime := time.Unix(*resetUnix, 0)
+			resetAt = &resetTime
+		} else {
+			resetTime := time.Now().Add(rateLimitFallbackCooldown)
+			resetAt = &resetTime
+		}
 	}
 	if resetAt == nil {
 		return
 	}
 
-	if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
+	scope := openAIRateLimitScopeForModel(requestedModel)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scope, *resetAt); err != nil {
 		return
 	}
+	mergeAccountModelRateLimit(account, scope, *resetAt)
+	s.clearOpenAIStaleErrorAfterRateLimitReconcile(ctx, account)
+}
 
+func (s *AccountTestService) reconcileOpenAIAccountRateLimitState(ctx context.Context, account *Account, resetAt time.Time) {
+	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
+		return
+	}
 	now := time.Now()
 	account.RateLimitedAt = &now
-	account.RateLimitResetAt = resetAt
+	account.RateLimitResetAt = &resetAt
+	s.clearOpenAIStaleErrorAfterRateLimitReconcile(ctx, account)
+}
 
+func (s *AccountTestService) clearOpenAIStaleErrorAfterRateLimitReconcile(ctx context.Context, account *Account) {
 	if account.Status == StatusError {
 		if err := s.accountRepo.ClearError(ctx, account.ID); err != nil {
 			return
 		}
 		account.Status = StatusActive
 		account.ErrorMessage = ""
+	}
+}
+
+func mergeAccountModelRateLimit(account *Account, scope string, resetAt time.Time) {
+	if account == nil || strings.TrimSpace(scope) == "" {
+		return
+	}
+	if account.Extra == nil {
+		account.Extra = make(map[string]any)
+	}
+	limits, _ := account.Extra[modelRateLimitsKey].(map[string]any)
+	if limits == nil {
+		limits = make(map[string]any)
+		account.Extra[modelRateLimitsKey] = limits
+	}
+	now := time.Now().UTC()
+	limits[scope] = map[string]any{
+		"rate_limited_at":     now.Format(time.RFC3339),
+		"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
 	}
 }
 
@@ -1270,6 +1311,9 @@ func (s *AccountTestService) testOpenAIImageAPIKey(c *gin.Context, ctx context.C
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			s.reconcileOpenAI429State(ctx, account, resp.Header, body, modelID)
+		}
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
@@ -1368,6 +1412,9 @@ func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Co
 	}()
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		if resp.StatusCode == http.StatusTooManyRequests {
+			s.reconcileOpenAI429State(ctx, account, resp.Header, body, modelID)
+		}
 		message := strings.TrimSpace(extractUpstreamErrorMessage(body))
 		if message == "" {
 			message = fmt.Sprintf("Responses API returned %d", resp.StatusCode)

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -61,12 +61,15 @@ func newTestContext() (*gin.Context, *httptest.ResponseRecorder) {
 
 type openAIAccountTestRepo struct {
 	mockAccountRepoForGemini
-	updatedExtra   map[string]any
-	rateLimitedID  int64
-	rateLimitedAt  *time.Time
-	clearedErrorID int64
-	setErrorID     int64
-	setErrorMsg    string
+	updatedExtra        map[string]any
+	rateLimitedID       int64
+	rateLimitedAt       *time.Time
+	modelRateLimitedID  int64
+	modelRateLimitScope string
+	modelRateLimitAt    *time.Time
+	clearedErrorID      int64
+	setErrorID          int64
+	setErrorMsg         string
 }
 
 func (r *openAIAccountTestRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
@@ -77,6 +80,13 @@ func (r *openAIAccountTestRepo) UpdateExtra(_ context.Context, _ int64, updates 
 func (r *openAIAccountTestRepo) SetRateLimited(_ context.Context, id int64, resetAt time.Time) error {
 	r.rateLimitedID = id
 	r.rateLimitedAt = &resetAt
+	return nil
+}
+
+func (r *openAIAccountTestRepo) SetModelRateLimit(_ context.Context, id int64, scope string, resetAt time.Time) error {
+	r.modelRateLimitedID = id
+	r.modelRateLimitScope = scope
+	r.modelRateLimitAt = &resetAt
 	return nil
 }
 
@@ -180,6 +190,8 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimitState(t *testin
 	require.Equal(t, 100.0, repo.updatedExtra["codex_5h_used_percent"])
 	require.Equal(t, account.ID, repo.rateLimitedID)
 	require.NotNil(t, repo.rateLimitedAt)
+	require.Zero(t, repo.modelRateLimitedID)
+	require.Empty(t, repo.modelRateLimitScope)
 	require.Equal(t, account.ID, repo.clearedErrorID)
 	require.Equal(t, StatusActive, account.Status)
 	require.Empty(t, account.ErrorMessage)
@@ -243,7 +255,7 @@ func TestAccountTestService_OpenAI429ActiveAccountDoesNotClearError(t *testing.T
 	require.NotNil(t, account.RateLimitResetAt)
 }
 
-func TestAccountTestService_OpenAI429WithoutResetSignalDoesNotMutateRuntimeState(t *testing.T) {
+func TestAccountTestService_OpenAIUsageLimitWithoutResetUsesAccountFallback(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := newTestContext()
 
@@ -264,12 +276,108 @@ func TestAccountTestService_OpenAI429WithoutResetSignalDoesNotMutateRuntimeState
 
 	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4", "", "")
 	require.Error(t, err)
+	require.Equal(t, account.ID, repo.rateLimitedID)
+	require.NotNil(t, repo.rateLimitedAt)
+	require.Zero(t, repo.modelRateLimitedID)
+	require.Equal(t, account.ID, repo.clearedErrorID)
+	require.Equal(t, StatusActive, account.Status)
+	require.Empty(t, account.ErrorMessage)
+	require.NotNil(t, account.RateLimitResetAt)
+	require.WithinDuration(t, time.Now().Add(openAIUsageLimitFallbackCooldown), *repo.rateLimitedAt, 5*time.Second)
+}
+
+func TestAccountTestService_OpenAI429RateLimitExceededUsesModelScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resetAt := time.Now().Add(30 * time.Second).Unix()
+	resp := newJSONResponse(http.StatusTooManyRequests, fmt.Sprintf(`{"error":{"type":"rate_limit_exceeded","message":"slow down","resets_at":"%d"}}`, resetAt))
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream}
+	account := &Account{
+		ID:           81,
+		Platform:     PlatformOpenAI,
+		Type:         AccountTypeOAuth,
+		Status:       StatusError,
+		ErrorMessage: "stale 403",
+		Concurrency:  1,
+		Credentials:  map[string]any{"access_token": "test-token"},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4", "", "")
+	require.Error(t, err)
 	require.Zero(t, repo.rateLimitedID)
 	require.Nil(t, repo.rateLimitedAt)
-	require.Zero(t, repo.clearedErrorID)
-	require.Equal(t, StatusError, account.Status)
-	require.Equal(t, "stale 403", account.ErrorMessage)
+	require.Equal(t, account.ID, repo.modelRateLimitedID)
+	require.Equal(t, openAIRateLimitScopeCode, repo.modelRateLimitScope)
+	require.NotNil(t, repo.modelRateLimitAt)
+	require.Equal(t, account.ID, repo.clearedErrorID)
+	require.Equal(t, StatusActive, account.Status)
+	require.Empty(t, account.ErrorMessage)
 	require.Nil(t, account.RateLimitResetAt)
+	require.True(t, account.isModelRateLimitedWithContext(context.Background(), "gpt-5.4"))
+}
+
+func TestAccountTestService_OpenAI429HeaderOnlyUsesModelScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusTooManyRequests, `{"error":{"type":"rate_limit_exceeded","message":"slow down"}}`)
+	resp.Header.Set("x-codex-primary-used-percent", "100")
+	resp.Header.Set("x-codex-primary-reset-after-seconds", "604800")
+	resp.Header.Set("x-codex-primary-window-minutes", "10080")
+	resp.Header.Set("x-codex-secondary-used-percent", "100")
+	resp.Header.Set("x-codex-secondary-reset-after-seconds", "18000")
+	resp.Header.Set("x-codex-secondary-window-minutes", "300")
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream}
+	account := &Account{
+		ID:          82,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "test-token"},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4", "", "")
+	require.Error(t, err)
+	require.Zero(t, repo.rateLimitedID)
+	require.Nil(t, repo.rateLimitedAt)
+	require.Equal(t, account.ID, repo.modelRateLimitedID)
+	require.Equal(t, openAIRateLimitScopeCode, repo.modelRateLimitScope)
+	require.NotNil(t, repo.modelRateLimitAt)
+	require.Nil(t, account.RateLimitResetAt)
+	require.True(t, account.isModelRateLimitedWithContext(context.Background(), "gpt-5.4"))
+}
+
+func TestAccountTestService_OpenAI429ImageModelUsesImageScope(t *testing.T) {
+	repo := &openAIAccountTestRepo{}
+	svc := &AccountTestService{accountRepo: repo}
+	account := &Account{
+		ID:          83,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Concurrency: 1,
+	}
+
+	resetAt := time.Now().Add(30 * time.Second).Unix()
+	body := []byte(fmt.Sprintf(`{"error":{"type":"rate_limit_exceeded","message":"slow down","resets_at":%d}}`, resetAt))
+	svc.reconcileOpenAI429State(context.Background(), account, http.Header{}, body, "gpt-image-2")
+
+	require.Zero(t, repo.rateLimitedID)
+	require.Nil(t, repo.rateLimitedAt)
+	require.Equal(t, account.ID, repo.modelRateLimitedID)
+	require.Equal(t, openAIRateLimitScopeImage, repo.modelRateLimitScope)
+	require.NotNil(t, repo.modelRateLimitAt)
+	require.Nil(t, account.RateLimitResetAt)
+	require.True(t, account.isModelRateLimitedWithContext(context.Background(), "gpt-image-2"))
+	require.False(t, account.isModelRateLimitedWithContext(context.Background(), "gpt-5.4"))
 }
 
 func TestAccountTestService_OpenAI401SetsPermanentErrorOnly(t *testing.T) {

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -8,6 +8,18 @@ import (
 
 const modelRateLimitsKey = "model_rate_limits"
 
+const (
+	openAIRateLimitScopeCode  = "openai:code"
+	openAIRateLimitScopeImage = "openai:image"
+)
+
+func openAIRateLimitScopeForModel(model string) string {
+	if isOpenAIImageGenerationModel(model) {
+		return openAIRateLimitScopeImage
+	}
+	return openAIRateLimitScopeCode
+}
+
 // isRateLimitActiveForKey 检查指定 key 的限流是否生效
 func (a *Account) isRateLimitActiveForKey(key string) bool {
 	resetAt := a.modelRateLimitResetAt(key)
@@ -37,6 +49,11 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
 	}
 	modelKey = strings.TrimSpace(modelKey)
+	if a.Platform == PlatformOpenAI {
+		if a.isRateLimitActiveForKey(openAIRateLimitScopeForModel(requestedModel)) {
+			return true
+		}
+	}
 	if modelKey == "" {
 		return false
 	}
@@ -59,10 +76,18 @@ func (a *Account) GetModelRateLimitRemainingTimeWithContext(ctx context.Context,
 		modelKey = resolveFinalAntigravityModelKey(ctx, a, requestedModel)
 	}
 	modelKey = strings.TrimSpace(modelKey)
-	if modelKey == "" {
-		return 0
+	var remaining time.Duration
+	if a.Platform == PlatformOpenAI {
+		remaining = a.getRateLimitRemainingForKey(openAIRateLimitScopeForModel(requestedModel))
 	}
-	return a.getRateLimitRemainingForKey(modelKey)
+	if modelKey == "" {
+		return remaining
+	}
+	modelRemaining := a.getRateLimitRemainingForKey(modelKey)
+	if modelRemaining > remaining {
+		return modelRemaining
+	}
+	return remaining
 }
 
 func resolveFinalAntigravityModelKey(ctx context.Context, account *Account, requestedModel string) string {

--- a/backend/internal/service/model_rate_limit_test.go
+++ b/backend/internal/service/model_rate_limit_test.go
@@ -165,6 +165,66 @@ func TestIsModelRateLimited(t *testing.T) {
 			requestedModel: "claude-3-5-sonnet-20241022",
 			expected:       false,
 		},
+		{
+			name: "openai code scope blocks coding model",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Extra: map[string]any{
+					modelRateLimitsKey: map[string]any{
+						openAIRateLimitScopeCode: map[string]any{
+							"rate_limit_reset_at": future,
+						},
+					},
+				},
+			},
+			requestedModel: "gpt-5.5",
+			expected:       true,
+		},
+		{
+			name: "openai code scope does not block image model",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Extra: map[string]any{
+					modelRateLimitsKey: map[string]any{
+						openAIRateLimitScopeCode: map[string]any{
+							"rate_limit_reset_at": future,
+						},
+					},
+				},
+			},
+			requestedModel: "gpt-image-2",
+			expected:       false,
+		},
+		{
+			name: "openai image scope blocks image model",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Extra: map[string]any{
+					modelRateLimitsKey: map[string]any{
+						openAIRateLimitScopeImage: map[string]any{
+							"rate_limit_reset_at": future,
+						},
+					},
+				},
+			},
+			requestedModel: "gpt-image-2",
+			expected:       true,
+		},
+		{
+			name: "openai image scope does not block coding model",
+			account: &Account{
+				Platform: PlatformOpenAI,
+				Extra: map[string]any{
+					modelRateLimitsKey: map[string]any{
+						openAIRateLimitScopeImage: map[string]any{
+							"rate_limit_reset_at": future,
+						},
+					},
+				},
+			},
+			requestedModel: "gpt-5.5",
+			expected:       false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -895,6 +895,9 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatible(account *Acco
 	if req.RequestedModel != "" && !account.IsModelSupported(req.RequestedModel) {
 		return false
 	}
+	if !account.IsSchedulableForModel(req.RequestedModel) {
+		return false
+	}
 	return account.SupportsOpenAIImageCapability(req.RequiredImageCapability)
 }
 

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -24,6 +24,16 @@ type schedulerTestOpenAIAccountRepo struct {
 	accounts []Account
 }
 
+func openAITestModelRateLimitExtra(scope string, resetAt time.Time) map[string]any {
+	return map[string]any{
+		modelRateLimitsKey: map[string]any{
+			scope: map[string]any{
+				"rate_limit_reset_at": resetAt.UTC().Format(time.RFC3339),
+			},
+		},
+	}
+}
+
 func (r schedulerTestOpenAIAccountRepo) GetByID(ctx context.Context, id int64) (*Account, error) {
 	for i := range r.accounts {
 		if r.accounts[i].ID == id {
@@ -496,6 +506,57 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyRateLimite
 	require.NotNil(t, selection.Account)
 	require.Equal(t, int64(31002), selection.Account.ID)
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_SessionStickyModelRateLimitedAccountFallsBackToFreshCandidate(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(10105)
+	modelLimitedUntil := time.Now().Add(30 * time.Minute)
+	staleSticky := &Account{ID: 35001, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: openAITestModelRateLimitExtra(openAIRateLimitScopeCode, modelLimitedUntil)}
+	freshBackup := &Account{ID: 35002, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5}
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{"openai:session_hash_model_rate_limited": 35001}}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: []Account{*staleSticky, *freshBackup}},
+		cache:              cache,
+		cfg:                &config.Config{},
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "session_hash_model_rate_limited", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(35002), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.Equal(t, 1, cache.deletedSessions["openai:session_hash_model_rate_limited"])
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_LoadBalanceSkipsModelRateLimitedTopCandidate(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(10106)
+	modelLimitedUntil := time.Now().Add(30 * time.Minute)
+	accounts := []Account{
+		{ID: 36001, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: openAITestModelRateLimitExtra(openAIRateLimitScopeCode, modelLimitedUntil)},
+		{ID: 36002, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 5},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 1
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(36002), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.Equal(t, 1, decision.CandidateCount)
 }
 
 func TestOpenAIGatewayService_SelectAccountForModelWithExclusions_SkipsFreshlyRateLimitedSnapshotCandidate(t *testing.T) {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -237,7 +237,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 				Detail:             upstreamDetail,
 			})
 			if s.rateLimitService != nil {
-				s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, resp.StatusCode, resp.Header, respBody, originalModel)
 			}
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
@@ -245,7 +245,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 				RetryableOnSameAccount: account.IsPoolMode() && (isPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
 			}
 		}
-		return s.handleChatCompletionsErrorResponse(resp, c, account)
+		return s.handleChatCompletionsErrorResponse(resp, c, account, originalModel)
 	}
 
 	// 9. Handle normal response
@@ -320,8 +320,9 @@ func (s *OpenAIGatewayService) handleChatCompletionsErrorResponse(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
+	requestedModel string,
 ) (*OpenAIForwardResult, error) {
-	return s.handleCompatErrorResponse(resp, c, account, writeChatCompletionsError)
+	return s.handleCompatErrorResponse(resp, c, account, requestedModel, writeChatCompletionsError)
 }
 
 // handleChatBufferedStreamingResponse reads all Responses SSE events from the

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -212,7 +212,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 				Detail:             upstreamDetail,
 			})
 			if s.rateLimitService != nil {
-				s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+				s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, resp.StatusCode, resp.Header, respBody, originalModel)
 			}
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
@@ -221,7 +221,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			}
 		}
 		// Non-failover error: return Anthropic-formatted error to client
-		return s.handleAnthropicErrorResponse(resp, c, account)
+		return s.handleAnthropicErrorResponse(resp, c, account, originalModel)
 	}
 
 	// 9. Handle normal response
@@ -263,8 +263,9 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
+	requestedModel string,
 ) (*OpenAIForwardResult, error) {
-	return s.handleCompatErrorResponse(resp, c, account, writeAnthropicError)
+	return s.handleCompatErrorResponse(resp, c, account, requestedModel, writeAnthropicError)
 }
 
 // handleAnthropicBufferedStreamingResponse reads all Responses SSE events from

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1275,6 +1275,9 @@ func isOpenAIAccountEligibleForRequest(account *Account, requestedModel string, 
 	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
 		return false
 	}
+	if account.isModelRateLimitedWithContext(context.Background(), requestedModel) {
+		return false
+	}
 	if requireCompact && openAICompactSupportTier(account) == 0 {
 		return false
 	}
@@ -1638,6 +1641,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		if requestedModel != "" && !acc.IsModelSupported(requestedModel) {
 			continue
 		}
+		if !acc.IsSchedulableForModelWithContext(ctx, requestedModel) {
+			continue
+		}
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
 			continue
 		}
@@ -1964,9 +1970,9 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
 }
 
-func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account) {
+func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, requestedModel string) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
-	s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+	s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, resp.StatusCode, resp.Header, body, requestedModel)
 }
 
 // Forward forwards request to OpenAI API
@@ -2636,14 +2642,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 					Detail:             upstreamDetail,
 				})
 
-				s.handleFailoverSideEffects(ctx, resp, account)
+				s.handleFailoverSideEffects(ctx, resp, account, originalModel)
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
 					RetryableOnSameAccount: account.IsPoolMode() && (isPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
 				}
 			}
-			return s.handleErrorResponse(ctx, resp, c, account, body)
+			return s.handleErrorResponse(ctx, resp, c, account, body, originalModel)
 		}
 		defer func() { _ = resp.Body.Close() }()
 
@@ -3049,7 +3055,8 @@ func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
 	if s.rateLimitService != nil {
-		_ = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		requestedModel, _, _ := extractOpenAIRequestMetaFromBody(requestBody)
+		_ = s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, resp.StatusCode, resp.Header, body, requestedModel)
 	}
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:             account.Platform,
@@ -3095,7 +3102,8 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 		// Passthrough mode preserves the raw upstream error response, but runtime
 		// account state still needs to be updated so sticky routing can stop
 		// reusing a freshly rate-limited account.
-		_ = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		requestedModel, _, _ := extractOpenAIRequestMetaFromBody(requestBody)
+		_ = s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, resp.StatusCode, resp.Header, body, requestedModel)
 	}
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:             account.Platform,
@@ -3700,8 +3708,13 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	c *gin.Context,
 	account *Account,
 	requestBody []byte,
+	requestedModel ...string,
 ) (*OpenAIForwardResult, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	requestModel := ""
+	if len(requestedModel) > 0 {
+		requestModel = requestedModel[0]
+	}
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
 	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -3778,7 +3791,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	// Handle upstream error (mark account status)
 	shouldDisable := false
 	if s.rateLimitService != nil {
-		shouldDisable = s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		shouldDisable = s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, resp.StatusCode, resp.Header, body, requestModel)
 	}
 	kind := "http_error"
 	if shouldDisable {
@@ -3855,6 +3868,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
+	requestedModel string,
 	writeError compatErrorWriter,
 ) (*OpenAIForwardResult, error) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
@@ -3913,9 +3927,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	// Track rate limits and decide whether to trigger secondary failover.
 	shouldDisable := false
 	if s.rateLimitService != nil {
-		shouldDisable = s.rateLimitService.HandleUpstreamError(
-			c.Request.Context(), account, resp.StatusCode, resp.Header, body,
-		)
+		shouldDisable = s.rateLimitService.HandleUpstreamErrorForModel(c.Request.Context(), account, resp.StatusCode, resp.Header, body, requestedModel)
 	}
 	kind := "http_error"
 	if shouldDisable {

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -582,14 +582,14 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 				Kind:               "failover",
 				Message:            upstreamMsg,
 			})
-			s.handleFailoverSideEffects(ctx, resp, account)
+			s.handleFailoverSideEffects(ctx, resp, account, requestModel)
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
 				RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
 			}
 		}
-		return s.handleErrorResponse(ctx, resp, c, account, forwardBody)
+		return s.handleErrorResponse(ctx, resp, c, account, forwardBody, requestModel)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -808,14 +808,14 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 				Kind:               "failover",
 				Message:            upstreamMsg,
 			})
-			s.handleFailoverSideEffects(ctx, resp, account)
+			s.handleFailoverSideEffects(ctx, resp, account, requestModel)
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
 				RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
 			}
 		}
-		return s.handleErrorResponse(ctx, resp, c, account, responsesBody)
+		return s.handleErrorResponse(ctx, resp, c, account, responsesBody, requestModel)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -50,12 +50,24 @@ func (u *httpUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, acc
 
 type openAIPassthroughFailoverRepo struct {
 	stubOpenAIAccountRepo
-	rateLimitCalls []time.Time
-	overloadCalls  []time.Time
+	rateLimitCalls      []time.Time
+	modelRateLimitCalls []struct {
+		scope   string
+		resetAt time.Time
+	}
+	overloadCalls []time.Time
 }
 
 func (r *openAIPassthroughFailoverRepo) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
 	r.rateLimitCalls = append(r.rateLimitCalls, resetAt)
+	return nil
+}
+
+func (r *openAIPassthroughFailoverRepo) SetModelRateLimit(_ context.Context, _ int64, scope string, resetAt time.Time) error {
+	r.modelRateLimitCalls = append(r.modelRateLimitCalls, struct {
+		scope   string
+		resetAt time.Time
+	}{scope: scope, resetAt: resetAt})
 	return nil
 }
 
@@ -598,6 +610,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 			}(),
 			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, _ time.Time) {
 				require.Len(t, repo.rateLimitCalls, 1)
+				require.Empty(t, repo.modelRateLimitCalls)
 				require.Empty(t, repo.overloadCalls)
 				require.True(t, time.Until(repo.rateLimitCalls[0]) > 24*time.Hour)
 			},
@@ -609,6 +622,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 			body:        `{"error":{"message":"server overloaded","type":"server_error"}}`,
 			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time) {
 				require.Empty(t, repo.rateLimitCalls)
+				require.Empty(t, repo.modelRateLimitCalls)
 				require.Len(t, repo.overloadCalls, 1)
 				require.WithinDuration(t, start.Add(10*time.Minute), repo.overloadCalls[0], 5*time.Second)
 			},
@@ -623,6 +637,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 			}(),
 			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, _ time.Time) {
 				require.Len(t, repo.rateLimitCalls, 1)
+				require.Empty(t, repo.modelRateLimitCalls)
 				require.Empty(t, repo.overloadCalls)
 				require.True(t, time.Until(repo.rateLimitCalls[0]) > 24*time.Hour)
 			},
@@ -634,6 +649,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 			body:        `{"error":{"message":"server overloaded","type":"server_error"}}`,
 			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time) {
 				require.Empty(t, repo.rateLimitCalls)
+				require.Empty(t, repo.modelRateLimitCalls)
 				require.Len(t, repo.overloadCalls, 1)
 				require.WithinDuration(t, start.Add(10*time.Minute), repo.overloadCalls[0], 5*time.Second)
 			},

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1866,7 +1866,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		)
 		var dialErr *openAIWSDialError
 		if errors.As(err, &dialErr) && dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
-			s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(err.Error()))
+			s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, originalModel, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(err.Error()))
 		}
 		return nil, wrapOpenAIWSFallback(classifyOpenAIWSAcquireError(err), err)
 	}
@@ -2160,7 +2160,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 
 		if eventType == "error" {
 			errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(message)
-			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw)
+			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, originalModel, errCodeRaw, errTypeRaw, errMsgRaw)
 			errMsg := strings.TrimSpace(errMsgRaw)
 			if errMsg == "" {
 				errMsg = "Upstream websocket error"
@@ -2633,7 +2633,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		acquireTimeout = 30 * time.Second
 	}
 
-	acquireTurnLease := func(turn int, preferred string, forcePreferredConn bool) (*openAIWSConnLease, error) {
+	acquireTurnLease := func(turn int, preferred string, forcePreferredConn bool, requestedModel string) (*openAIWSConnLease, error) {
 		req := cloneOpenAIWSAcquireRequest(baseAcquireReq)
 		req.PreferredConnID = strings.TrimSpace(preferred)
 		req.ForcePreferredConn = forcePreferredConn
@@ -2666,7 +2666,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			)
 			var dialErr *openAIWSDialError
 			if errors.As(acquireErr, &dialErr) && dialErr != nil && dialErr.StatusCode == http.StatusTooManyRequests {
-				s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(acquireErr.Error()))
+				s.persistOpenAIWSRateLimitSignal(ctx, account, dialErr.ResponseHeaders, nil, requestedModel, "rate_limit_exceeded", "rate_limit_error", strings.TrimSpace(acquireErr.Error()))
 			}
 			if errors.Is(acquireErr, errOpenAIWSPreferredConnUnavailable) {
 				return nil, NewOpenAIWSClientCloseError(
@@ -2803,7 +2803,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 			if eventType == "error" {
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(upstreamMessage)
-				s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), upstreamMessage, errCodeRaw, errTypeRaw, errMsgRaw)
+				s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), upstreamMessage, originalModel, errCodeRaw, errTypeRaw, errMsgRaw)
 				fallbackReason, _ := classifyOpenAIWSErrorEventFromRaw(errCodeRaw, errTypeRaw, errMsgRaw)
 				errCode, errType, errMessage := summarizeOpenAIWSErrorEventFieldsFromRaw(errCodeRaw, errTypeRaw, errMsgRaw)
 				recoverablePrevNotFound := fallbackReason == openAIWSIngressStagePreviousResponseNotFound &&
@@ -3272,7 +3272,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		}
 		forcePreferredConn := isStrictAffinityTurn(currentPayload)
 		if sessionLease == nil {
-			acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn)
+			acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn, currentOriginalModel)
 			if acquireErr != nil {
 				return fmt.Errorf("acquire upstream websocket: %w", acquireErr)
 			}
@@ -3356,7 +3356,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				}
 				resetSessionLease(true)
 
-				acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn)
+				acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn, currentOriginalModel)
 				if acquireErr != nil {
 					return fmt.Errorf("acquire upstream websocket after preflight ping fail: %w", acquireErr)
 				}
@@ -3638,7 +3638,8 @@ func (s *OpenAIGatewayService) performOpenAIWSGeneratePrewarm(
 
 		if eventType == "error" {
 			errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(message)
-			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, errCodeRaw, errTypeRaw, errMsgRaw)
+			requestedModel, _ := reqBody["model"].(string)
+			s.persistOpenAIWSRateLimitSignal(ctx, account, lease.HandshakeHeaders(), message, requestedModel, errCodeRaw, errTypeRaw, errMsgRaw)
 			errMsg := strings.TrimSpace(errMsgRaw)
 			if errMsg == "" {
 				errMsg = "OpenAI websocket prewarm error"
@@ -3933,14 +3934,14 @@ func isOpenAIWSRateLimitError(codeRaw, errTypeRaw, msgRaw string) bool {
 	return false
 }
 
-func (s *OpenAIGatewayService) persistOpenAIWSRateLimitSignal(ctx context.Context, account *Account, headers http.Header, responseBody []byte, codeRaw, errTypeRaw, msgRaw string) {
+func (s *OpenAIGatewayService) persistOpenAIWSRateLimitSignal(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel string, codeRaw, errTypeRaw, msgRaw string) {
 	if s == nil || s.rateLimitService == nil || account == nil || account.Platform != PlatformOpenAI {
 		return
 	}
 	if !isOpenAIWSRateLimitError(codeRaw, errTypeRaw, msgRaw) {
 		return
 	}
-	s.rateLimitService.HandleUpstreamError(ctx, account, http.StatusTooManyRequests, headers, responseBody)
+	s.rateLimitService.HandleUpstreamErrorForModel(ctx, account, http.StatusTooManyRequests, headers, responseBody, requestedModel)
 }
 
 func classifyOpenAIWSErrorEventFromRaw(codeRaw, errTypeRaw, msgRaw string) (string, bool) {

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -19,8 +19,12 @@ import (
 
 type openAIWSRateLimitSignalRepo struct {
 	stubOpenAIAccountRepo
-	rateLimitCalls []time.Time
-	updateExtra    []map[string]any
+	rateLimitCalls      []time.Time
+	modelRateLimitCalls []struct {
+		scope   string
+		resetAt time.Time
+	}
+	updateExtra []map[string]any
 }
 
 type openAICodexSnapshotAsyncRepo struct {
@@ -36,6 +40,14 @@ type openAICodexExtraListRepo struct {
 
 func (r *openAIWSRateLimitSignalRepo) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
 	r.rateLimitCalls = append(r.rateLimitCalls, resetAt)
+	return nil
+}
+
+func (r *openAIWSRateLimitSignalRepo) SetModelRateLimit(_ context.Context, _ int64, scope string, resetAt time.Time) error {
+	r.modelRateLimitCalls = append(r.modelRateLimitCalls, struct {
+		scope   string
+		resetAt time.Time
+	}{scope: scope, resetAt: resetAt})
 	return nil
 }
 
@@ -165,6 +177,7 @@ func TestOpenAIGatewayService_Forward_WSv2ErrorEventUsageLimitPersistsRateLimit(
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 	require.Nil(t, upstream.lastReq, "WS 限流 error event 不应回退到同账号 HTTP")
 	require.Len(t, repo.rateLimitCalls, 1)
+	require.Empty(t, repo.modelRateLimitCalls)
 	require.WithinDuration(t, time.Unix(resetAt, 0), repo.rateLimitCalls[0], 2*time.Second)
 }
 
@@ -234,7 +247,9 @@ func TestOpenAIGatewayService_Forward_WSv2Handshake429PersistsRateLimit(t *testi
 	require.Nil(t, result)
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 	require.Nil(t, upstream.lastReq, "WS 握手 429 不应回退到同账号 HTTP")
-	require.Len(t, repo.rateLimitCalls, 1)
+	require.Empty(t, repo.rateLimitCalls)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, openAIRateLimitScopeCode, repo.modelRateLimitCalls[0].scope)
 	require.NotEmpty(t, repo.updateExtra, "握手 429 的 x-codex 头应立即落库")
 	require.Contains(t, repo.updateExtra[0], "codex_usage_updated_at")
 }
@@ -339,6 +354,7 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_ErrorEventUsageL
 	case serverErr := <-serverErrCh:
 		require.Error(t, serverErr)
 		require.Len(t, repo.rateLimitCalls, 1)
+		require.Empty(t, repo.modelRateLimitCalls)
 		require.WithinDuration(t, time.Unix(resetAt, 0), repo.rateLimitCalls[0], 2*time.Second)
 	case <-time.After(5 * time.Second):
 		t.Fatal("等待 ingress websocket 结束超时")

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -54,6 +54,8 @@ type geminiUsageTotalsBatchProvider interface {
 }
 
 const geminiPrecheckCacheTTL = time.Minute
+const rateLimitFallbackCooldown = 5 * time.Second
+const openAIUsageLimitFallbackCooldown = 5 * time.Minute
 
 const (
 	openAI403CooldownMinutesDefault = 10
@@ -125,6 +127,12 @@ func (s *RateLimitService) CheckErrorPolicy(ctx context.Context, account *Accoun
 // HandleUpstreamError 处理上游错误响应，标记账号状态
 // 返回是否应该停止该账号的调度
 func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte) (shouldDisable bool) {
+	return s.HandleUpstreamErrorForModel(ctx, account, statusCode, headers, responseBody, "")
+}
+
+// HandleUpstreamErrorForModel 处理带请求模型上下文的上游错误响应。
+// OpenAI usage_limit_reached/insufficient_quota 写账号级限流；rate_limit_exceeded 写 code/image 请求类型级限流。
+func (s *RateLimitService) HandleUpstreamErrorForModel(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel string) (shouldDisable bool) {
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
 	// 池模式默认不标记本地账号状态；仅当用户显式配置自定义错误码时按本地策略处理。
@@ -266,7 +274,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		)
 		shouldDisable = s.handle403(ctx, account, upstreamMsg, responseBody)
 	case 429:
-		s.handle429(ctx, account, headers, responseBody)
+		s.handle429(ctx, account, headers, responseBody, requestedModel)
 		shouldDisable = false
 	case 529:
 		s.handle529(ctx, account)
@@ -816,16 +824,16 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel string) {
 	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
 	if account.Platform == PlatformOpenAI {
 		s.persistOpenAICodexSnapshot(ctx, account, headers)
+		if resetUnix, scopeGlobal, recognized := parseOpenAIRateLimitResetTime(responseBody); recognized && scopeGlobal {
+			s.setAccountRateLimit(ctx, account, openAIUsageLimitResetTime(resetUnix))
+			return
+		}
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
-			if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
-				slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
-				return
-			}
-			slog.Info("openai_account_rate_limited", "account_id", account.ID, "reset_at", *resetAt)
+			s.setOpenAI429RateLimit(ctx, account, requestedModel, *resetAt)
 			return
 		}
 	}
@@ -858,15 +866,17 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	if resetTimestamp == "" {
 		switch account.Platform {
 		case PlatformOpenAI:
-			// 尝试解析 OpenAI 的 usage_limit_reached 错误
-			if resetAt := parseOpenAIRateLimitResetTime(responseBody); resetAt != nil {
-				resetTime := time.Unix(*resetAt, 0)
-				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
-					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
+			// OpenAI usage_limit_reached/insufficient_quota 表示账号级配额耗尽，必须写入账号级限流。
+			// rate_limit_exceeded 才是请求类型/模型级短期限流，避免覆盖全局配额状态。
+			if resetAt, scopeGlobal, recognized := parseOpenAIRateLimitResetTime(responseBody); recognized {
+				if scopeGlobal {
+					s.setAccountRateLimit(ctx, account, openAIUsageLimitResetTime(resetAt))
 					return
 				}
-				slog.Info("account_rate_limited", "account_id", account.ID, "platform", account.Platform, "reset_at", resetTime, "reset_in", time.Until(resetTime).Truncate(time.Second))
-				return
+				if resetAt != nil {
+					s.setOpenAI429RateLimit(ctx, account, requestedModel, time.Unix(*resetAt, 0))
+					return
+				}
 			}
 		case PlatformGemini, PlatformAntigravity:
 			// 尝试解析 Gemini 格式（用于其他平台）
@@ -891,9 +901,13 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 			return
 		}
 
-		// 其他平台：没有重置时间，使用默认5分钟
-		resetAt := time.Now().Add(5 * time.Minute)
-		slog.Warn("rate_limit_no_reset_time", "account_id", account.ID, "platform", account.Platform, "using_default", "5m")
+		// 其他平台：没有重置时间，使用短暂兜底，避免误伤长时间不可调度。
+		resetAt := time.Now().Add(rateLimitFallbackCooldown)
+		slog.Warn("rate_limit_no_reset_time", "account_id", account.ID, "platform", account.Platform, "using_default", rateLimitFallbackCooldown.String())
+		if account.Platform == PlatformOpenAI {
+			s.setOpenAI429RateLimit(ctx, account, requestedModel, resetAt)
+			return
+		}
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 		}
@@ -904,7 +918,11 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	ts, err := strconv.ParseInt(resetTimestamp, 10, 64)
 	if err != nil {
 		slog.Warn("rate_limit_reset_parse_failed", "reset_timestamp", resetTimestamp, "error", err)
-		resetAt := time.Now().Add(5 * time.Minute)
+		resetAt := time.Now().Add(rateLimitFallbackCooldown)
+		if account.Platform == PlatformOpenAI {
+			s.setOpenAI429RateLimit(ctx, account, requestedModel, resetAt)
+			return
+		}
 		if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
 			slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
 		}
@@ -912,6 +930,11 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	resetAt := time.Unix(ts, 0)
+
+	if account.Platform == PlatformOpenAI {
+		s.setOpenAI429RateLimit(ctx, account, requestedModel, resetAt)
+		return
+	}
 
 	// 标记限流状态
 	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
@@ -927,6 +950,30 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
+}
+
+func (s *RateLimitService) setAccountRateLimit(ctx context.Context, account *Account, resetAt time.Time) {
+	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {
+		slog.Warn("rate_limit_set_failed", "account_id", account.ID, "platform", account.Platform, "error", err)
+		return
+	}
+	slog.Info("account_rate_limited", "account_id", account.ID, "platform", account.Platform, "reset_at", resetAt, "reset_in", time.Until(resetAt).Truncate(time.Second))
+}
+
+func (s *RateLimitService) setOpenAI429RateLimit(ctx context.Context, account *Account, requestedModel string, resetAt time.Time) {
+	scope := openAIRateLimitScopeForModel(requestedModel)
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, scope, resetAt); err != nil {
+		slog.Warn("openai_scoped_rate_limit_set_failed", "account_id", account.ID, "scope", scope, "error", err)
+		return
+	}
+	slog.Info("openai_account_scoped_rate_limited", "account_id", account.ID, "scope", scope, "requested_model", requestedModel, "reset_at", resetAt, "reset_in", time.Until(resetAt).Truncate(time.Second))
+}
+
+func openAIUsageLimitResetTime(resetUnix *int64) time.Time {
+	if resetUnix != nil {
+		return time.Unix(*resetUnix, 0)
+	}
+	return time.Now().Add(openAIUsageLimitFallbackCooldown)
 }
 
 // calculateOpenAI429ResetTime 从 OpenAI 429 响应头计算正确的重置时间
@@ -1104,7 +1151,7 @@ func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, accou
 	}
 }
 
-// parseOpenAIRateLimitResetTime 解析 OpenAI 格式的 429 响应，返回重置时间的 Unix 时间戳
+// parseOpenAIRateLimitResetTime 解析 OpenAI 格式的 429 响应，返回重置时间的 Unix 时间戳、是否账号级、是否识别。
 // OpenAI 的 usage_limit_reached 错误格式：
 //
 //	{
@@ -1115,47 +1162,55 @@ func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, accou
 //	    "resets_in_seconds": 133107
 //	  }
 //	}
-func parseOpenAIRateLimitResetTime(body []byte) *int64 {
+func parseOpenAIRateLimitResetTime(body []byte) (*int64, bool, bool) {
 	var parsed map[string]any
 	if err := json.Unmarshal(body, &parsed); err != nil {
-		return nil
+		return nil, false, false
 	}
 
 	errObj, ok := parsed["error"].(map[string]any)
 	if !ok {
-		return nil
+		return nil, false, false
 	}
 
-	// 检查是否为 usage_limit_reached 或 rate_limit_exceeded 类型
-	errType, _ := errObj["type"].(string)
-	if errType != "usage_limit_reached" && errType != "rate_limit_exceeded" {
-		return nil
+	// 检查是否为账号级配额耗尽或请求类型级限流；不同上游会放在 type 或 code。
+	errTypeRaw, _ := errObj["type"].(string)
+	errCodeRaw, _ := errObj["code"].(string)
+	errType := strings.ToLower(strings.TrimSpace(errTypeRaw))
+	errCode := strings.ToLower(strings.TrimSpace(errCodeRaw))
+	scopeGlobal := errType == "usage_limit_reached" ||
+		errType == "insufficient_quota" ||
+		errCode == "usage_limit_reached" ||
+		errCode == "insufficient_quota"
+	scopeRateLimited := errType == "rate_limit_exceeded" || errCode == "rate_limit_exceeded"
+	if !scopeGlobal && !scopeRateLimited {
+		return nil, false, false
 	}
 
 	// 优先使用 resets_at（Unix 时间戳）
 	if resetsAt, ok := errObj["resets_at"].(float64); ok {
 		ts := int64(resetsAt)
-		return &ts
+		return &ts, scopeGlobal, true
 	}
 	if resetsAt, ok := errObj["resets_at"].(string); ok {
 		if ts, err := strconv.ParseInt(resetsAt, 10, 64); err == nil {
-			return &ts
+			return &ts, scopeGlobal, true
 		}
 	}
 
 	// 如果没有 resets_at，尝试使用 resets_in_seconds
 	if resetsInSeconds, ok := errObj["resets_in_seconds"].(float64); ok {
 		ts := time.Now().Unix() + int64(resetsInSeconds)
-		return &ts
+		return &ts, scopeGlobal, true
 	}
 	if resetsInSeconds, ok := errObj["resets_in_seconds"].(string); ok {
 		if sec, err := strconv.ParseInt(resetsInSeconds, 10, 64); err == nil {
 			ts := time.Now().Unix() + sec
-			return &ts
+			return &ts, scopeGlobal, true
 		}
 	}
 
-	return nil
+	return nil, scopeGlobal, true
 }
 
 // handle529 处理529过载错误

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -149,12 +150,24 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 type openAI429SnapshotRepo struct {
 	mockAccountRepoForGemini
-	rateLimitedID int64
-	updatedExtra  map[string]any
+	rateLimitedID       int64
+	rateLimitReset      time.Time
+	modelRateLimitID    int64
+	modelRateLimitScope string
+	modelRateLimitReset time.Time
+	updatedExtra        map[string]any
 }
 
-func (r *openAI429SnapshotRepo) SetRateLimited(_ context.Context, id int64, _ time.Time) error {
+func (r *openAI429SnapshotRepo) SetRateLimited(_ context.Context, id int64, resetAt time.Time) error {
 	r.rateLimitedID = id
+	r.rateLimitReset = resetAt
+	return nil
+}
+
+func (r *openAI429SnapshotRepo) SetModelRateLimit(_ context.Context, id int64, scope string, resetAt time.Time) error {
+	r.modelRateLimitID = id
+	r.modelRateLimitScope = scope
+	r.modelRateLimitReset = resetAt
 	return nil
 }
 
@@ -176,10 +189,16 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
-	svc.handle429(context.Background(), account, headers, nil)
+	svc.handle429(context.Background(), account, headers, nil, "gpt-5.5")
 
-	if repo.rateLimitedID != account.ID {
-		t.Fatalf("rateLimitedID = %d, want %d", repo.rateLimitedID, account.ID)
+	if repo.rateLimitedID != 0 {
+		t.Fatalf("rateLimitedID = %d, want 0", repo.rateLimitedID)
+	}
+	if repo.modelRateLimitID != account.ID {
+		t.Fatalf("modelRateLimitID = %d, want %d", repo.modelRateLimitID, account.ID)
+	}
+	if repo.modelRateLimitScope != openAIRateLimitScopeCode {
+		t.Fatalf("modelRateLimitScope = %s, want %s", repo.modelRateLimitScope, openAIRateLimitScopeCode)
 	}
 	if len(repo.updatedExtra) == 0 {
 		t.Fatal("expected codex snapshot to be persisted on 429")
@@ -190,6 +209,104 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	if got := repo.updatedExtra["codex_7d_used_percent"]; got != 100.0 {
 		t.Fatalf("codex_7d_used_percent = %v, want 100", got)
 	}
+}
+
+func TestHandle429_OpenAIImageUsesImageScope(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 124, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(30 * time.Second).Unix()
+	body := []byte(`{"error":{"type":"rate_limit_exceeded","resets_at":` + strconv.FormatInt(resetAt, 10) + `}}`)
+
+	svc.handle429(context.Background(), account, http.Header{}, body, "gpt-image-2")
+
+	require.Zero(t, repo.rateLimitedID)
+	require.Equal(t, account.ID, repo.modelRateLimitID)
+	require.Equal(t, openAIRateLimitScopeImage, repo.modelRateLimitScope)
+	require.WithinDuration(t, time.Unix(resetAt, 0), repo.modelRateLimitReset, time.Second)
+}
+
+func TestHandle429_OpenAIUsageLimitReachedUsesAccountScope(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 126, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(7 * 24 * time.Hour).Unix()
+	body := []byte(`{"error":{"type":"usage_limit_reached","message":"The usage limit has been reached","resets_at":` + strconv.FormatInt(resetAt, 10) + `}}`)
+
+	svc.handle429(context.Background(), account, http.Header{}, body, "gpt-5.5")
+
+	require.Equal(t, account.ID, repo.rateLimitedID)
+	require.WithinDuration(t, time.Unix(resetAt, 0), repo.rateLimitReset, time.Second)
+	require.Zero(t, repo.modelRateLimitID)
+	require.Empty(t, repo.modelRateLimitScope)
+}
+
+func TestHandle429_OpenAIUsageLimitReachedWithoutResetUsesAccountFallback(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 127, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	before := time.Now()
+	body := []byte(`{"error":{"message":"The usage limit has been reached","type":"usage_limit_reached"}}`)
+	svc.handle429(context.Background(), account, http.Header{}, body, "gpt-5.5")
+	after := time.Now()
+
+	require.Equal(t, account.ID, repo.rateLimitedID)
+	require.Zero(t, repo.modelRateLimitID)
+	require.Empty(t, repo.modelRateLimitScope)
+	require.True(t, !repo.rateLimitReset.Before(before.Add(openAIUsageLimitFallbackCooldown)) && !repo.rateLimitReset.After(after.Add(openAIUsageLimitFallbackCooldown)),
+		"fallback reset %v must be within [%v, %v]", repo.rateLimitReset, before.Add(openAIUsageLimitFallbackCooldown), after.Add(openAIUsageLimitFallbackCooldown))
+}
+
+func TestHandle429_OpenAIInsufficientQuotaUsesAccountScope(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 128, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	before := time.Now()
+	body := []byte(`{"error":{"message":"You exceeded your current quota","type":"insufficient_quota","code":"insufficient_quota"}}`)
+	svc.handle429(context.Background(), account, http.Header{}, body, "gpt-5.5")
+	after := time.Now()
+
+	require.Equal(t, account.ID, repo.rateLimitedID)
+	require.Zero(t, repo.modelRateLimitID)
+	require.Empty(t, repo.modelRateLimitScope)
+	require.True(t, !repo.rateLimitReset.Before(before.Add(openAIUsageLimitFallbackCooldown)) && !repo.rateLimitReset.After(after.Add(openAIUsageLimitFallbackCooldown)),
+		"fallback reset %v must be within [%v, %v]", repo.rateLimitReset, before.Add(openAIUsageLimitFallbackCooldown), after.Add(openAIUsageLimitFallbackCooldown))
+}
+
+func TestHandle429_OpenAIRateLimitExceededCodeUsesModelScope(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 129, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	resetAt := time.Now().Add(45 * time.Second).Unix()
+	body := []byte(`{"error":{"type":"rate_limit_error","code":"rate_limit_exceeded","resets_at":` + strconv.FormatInt(resetAt, 10) + `}}`)
+
+	svc.handle429(context.Background(), account, http.Header{}, body, "gpt-5.5")
+
+	require.Zero(t, repo.rateLimitedID)
+	require.Equal(t, account.ID, repo.modelRateLimitID)
+	require.Equal(t, openAIRateLimitScopeCode, repo.modelRateLimitScope)
+	require.WithinDuration(t, time.Unix(resetAt, 0), repo.modelRateLimitReset, time.Second)
+}
+
+func TestHandle429_OpenAINoResetFallbackFiveSeconds(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 125, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	before := time.Now()
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`), "gpt-5.5")
+	after := time.Now()
+
+	require.Zero(t, repo.rateLimitedID)
+	require.Equal(t, account.ID, repo.modelRateLimitID)
+	require.Equal(t, openAIRateLimitScopeCode, repo.modelRateLimitScope)
+	require.True(t, !repo.modelRateLimitReset.Before(before.Add(rateLimitFallbackCooldown)) && !repo.modelRateLimitReset.After(after.Add(rateLimitFallbackCooldown)),
+		"fallback reset %v must be within [%v, %v]", repo.modelRateLimitReset, before.Add(rateLimitFallbackCooldown), after.Add(rateLimitFallbackCooldown))
 }
 
 func TestNormalizedCodexLimits(t *testing.T) {


### PR DESCRIPTION

## 背景

OpenAI 上游返回 429 时，当前逻辑会把账号写入全局限流状态，并且在缺少 reset 时间时默认限流 5 分钟。这会导致两个问题：

- 图片请求触发 429 后，普通 coding / responses 请求也会被误判为不可调度。(暂不清楚这两个429是不是一起的，所以需要分开处理)
- 没有明确 reset 时间的 429 会造成 5 分钟不可调度，误伤过重。

## 修改内容

- 新增 OpenAI 429 限流 scope：
  - `openai:code`
  - `openai:image`
- OpenAI 429 不再写账号级 `SetRateLimited`，改写模型级 `SetModelRateLimit`。
- 根据请求模型判断限流 scope：
  - 图像模型写入 `openai:image`
  - 其他模型写入 `openai:code`
- OpenAI HTTP / passthrough / chat completions / messages / images / websocket 路径都传入请求模型上下文。
- 缺少 reset 时间或 reset 解析失败时，429 兜底限流从 5 分钟缩短为 5 秒。
- `SetModelRateLimit` 后同步 scheduler account snapshot，避免调度缓存滞后。

## 行为变化

- 图片 429 只影响图片请求调度，不再阻断普通 coding 请求。
- coding 429 只影响普通 coding 请求，不再阻断图片请求。
- 429 无 reset 时间时只短暂避让 5 秒，不再粗暴打入 5 分钟限流。
- 非 OpenAI 平台仍沿用账号级限流逻辑。

## 测试

- `cd backend && go test ./internal/service -run 'TestHandle429|TestIsModelRateLimited|TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover|TestOpenAIGatewayService_Forward_WSv2|TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient'`
- `cd backend && go test ./...`
