### PR TITLE
 fix(anthropic): map system prompt to responses instructions

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -45,11 +45,12 @@ func TestAnthropicToResponses_SystemPrompt(t *testing.T) {
 		}
 		resp, err := AnthropicToResponses(req)
 		require.NoError(t, err)
+		assert.Equal(t, "You are helpful.", resp.Instructions)
 
 		var items []ResponsesInputItem
 		require.NoError(t, json.Unmarshal(resp.Input, &items))
-		require.Len(t, items, 2)
-		assert.Equal(t, "system", items[0].Role)
+		require.Len(t, items, 1)
+		assert.Equal(t, "user", items[0].Role)
 	})
 
 	t.Run("array", func(t *testing.T) {
@@ -61,15 +62,12 @@ func TestAnthropicToResponses_SystemPrompt(t *testing.T) {
 		}
 		resp, err := AnthropicToResponses(req)
 		require.NoError(t, err)
+		assert.Equal(t, "Part 1\n\nPart 2", resp.Instructions)
 
 		var items []ResponsesInputItem
 		require.NoError(t, json.Unmarshal(resp.Input, &items))
-		require.Len(t, items, 2)
-		assert.Equal(t, "system", items[0].Role)
-		// System text should be joined with double newline.
-		var text string
-		require.NoError(t, json.Unmarshal(items[0].Content, &text))
-		assert.Equal(t, "Part 1\n\nPart 2", text)
+		require.Len(t, items, 1)
+		assert.Equal(t, "user", items[0].Role)
 	})
 }
 

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -11,7 +11,16 @@ import (
 // Chat Completions intermediary round-trip (e.g. thinking, cache_control,
 // structured system prompts).
 func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
-	input, err := convertAnthropicToResponsesInput(req.System, req.Messages)
+	instructions := ""
+	if len(req.System) > 0 {
+		systemText, err := parseAnthropicSystemPrompt(req.System)
+		if err != nil {
+			return nil, err
+		}
+		instructions = systemText
+	}
+
+	input, err := convertAnthropicToResponsesInput(req.Messages)
 	if err != nil {
 		return nil, err
 	}
@@ -22,12 +31,13 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 	}
 
 	out := &ResponsesRequest{
-		Model:       req.Model,
-		Input:       inputJSON,
-		Temperature: req.Temperature,
-		TopP:        req.TopP,
-		Stream:      req.Stream,
-		Include:     []string{"reasoning.encrypted_content"},
+		Model:        req.Model,
+		Instructions: instructions,
+		Input:        inputJSON,
+		Temperature:  req.Temperature,
+		TopP:         req.TopP,
+		Stream:       req.Stream,
+		Include:      []string{"reasoning.encrypted_content"},
 	}
 
 	storeFalse := false
@@ -104,24 +114,10 @@ func convertAnthropicToolChoiceToResponses(raw json.RawMessage) (json.RawMessage
 }
 
 // convertAnthropicToResponsesInput builds the Responses API input items array
-// from the Anthropic system field and message list.
-func convertAnthropicToResponsesInput(system json.RawMessage, msgs []AnthropicMessage) ([]ResponsesInputItem, error) {
+// from the Anthropic message list. The Anthropic system field maps to top-level
+// Responses instructions and is handled by AnthropicToResponses.
+func convertAnthropicToResponsesInput(msgs []AnthropicMessage) ([]ResponsesInputItem, error) {
 	var out []ResponsesInputItem
-
-	// System prompt → system role input item.
-	if len(system) > 0 {
-		sysText, err := parseAnthropicSystemPrompt(system)
-		if err != nil {
-			return nil, err
-		}
-		if sysText != "" {
-			content, _ := json.Marshal(sysText)
-			out = append(out, ResponsesInputItem{
-				Role:    "system",
-				Content: content,
-			})
-		}
-	}
 
 	for _, m := range msgs {
 		items, err := anthropicMsgToResponsesItems(m)

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -64,6 +64,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	billingModel := resolveOpenAIForwardModel(account, normalizedModel, defaultMappedModel)
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	responsesReq.Model = upstreamModel
+	if strings.TrimSpace(responsesReq.Instructions) == "" {
+		responsesReq.Instructions = "You are a helpful coding assistant."
+	}
 
 	logger.L().Debug("openai messages: model mapping applied",
 		zap.Int64("account_id", account.ID),


### PR DESCRIPTION
  ## Summary

  - Map Anthropic system prompts to the Responses API top-level `instructions` field instead of injecting them as input items
  - Keep Responses input items limited to user/assistant message content
  - Add a default coding-assistant instruction when forwarding OpenAI messages without explicit instructions

  ## Test plan

  - Updated Anthropic-to-Responses system prompt tests
  - Not run locally