### PR TITLE
fix: normalize parenthesized OpenAI reasoning models

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -526,6 +526,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		return
 	}
 	reqModel := modelResult.String()
+	routingModel := service.NormalizeOpenAICompatRequestedModel(reqModel)
 	reqStream := gjson.GetBytes(body, "stream").Bool()
 
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
@@ -590,7 +591,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			apiKey.GroupID,
 			"", // no previous_response_id
 			sessionHash,
-			reqModel,
+			routingModel,
 			failedAccountIDs,
 			service.OpenAIUpstreamTransportAny,
 		)
@@ -605,7 +606,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 				if apiKey.Group != nil {
 					defaultModel = apiKey.Group.DefaultMappedModel
 				}
-				if defaultModel != "" && defaultModel != reqModel {
+				if defaultModel != "" && defaultModel != routingModel {
 					reqLog.Info("openai_messages.fallback_to_default_model",
 						zap.String("default_mapped_model", defaultModel),
 					)

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -388,7 +388,7 @@ func mapAnthropicEffortToResponses(effort string) string {
 	switch effort {
 	case "medium":
 		return "high"
-	case "high":
+	case "high", "max":
 		return "xhigh"
 	default:
 		return effort // "low" and any unknown values pass through unchanged

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -6,6 +6,7 @@ import (
 )
 
 var codexModelMap = map[string]string{
+	"gpt-5.5":                    "gpt-5.5",
 	"gpt-5.4":                    "gpt-5.4",
 	"gpt-5.4-none":               "gpt-5.4",
 	"gpt-5.4-low":                "gpt-5.4",
@@ -185,6 +186,9 @@ func normalizeCodexModel(model string) string {
 
 	normalized := strings.ToLower(modelID)
 
+	if strings.Contains(normalized, "gpt-5.5") || strings.Contains(normalized, "gpt 5.5") {
+		return "gpt-5.5"
+	}
 	if strings.Contains(normalized, "gpt-5.4") || strings.Contains(normalized, "gpt 5.4") {
 		return "gpt-5.4"
 	}

--- a/backend/internal/service/openai_compat_model.go
+++ b/backend/internal/service/openai_compat_model.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+)
+
+func NormalizeOpenAICompatRequestedModel(model string) string {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" {
+		return ""
+	}
+
+	normalized, _, ok := splitOpenAICompatReasoningModel(trimmed)
+	if !ok || normalized == "" {
+		return trimmed
+	}
+	return normalized
+}
+
+func applyOpenAICompatModelNormalization(req *apicompat.AnthropicRequest) {
+	if req == nil {
+		return
+	}
+
+	originalModel := strings.TrimSpace(req.Model)
+	if originalModel == "" {
+		return
+	}
+
+	normalizedModel, derivedEffort, hasReasoningSuffix := splitOpenAICompatReasoningModel(originalModel)
+	if hasReasoningSuffix && normalizedModel != "" {
+		req.Model = normalizedModel
+	}
+
+	if req.OutputConfig != nil && strings.TrimSpace(req.OutputConfig.Effort) != "" {
+		return
+	}
+
+	claudeEffort := openAIReasoningEffortToClaudeOutputEffort(derivedEffort)
+	if claudeEffort == "" {
+		return
+	}
+
+	if req.OutputConfig == nil {
+		req.OutputConfig = &apicompat.AnthropicOutputConfig{}
+	}
+	req.OutputConfig.Effort = claudeEffort
+}
+
+func splitOpenAICompatReasoningModel(model string) (normalizedModel string, reasoningEffort string, ok bool) {
+	trimmed := strings.TrimSpace(model)
+	if trimmed == "" {
+		return "", "", false
+	}
+
+	modelID := trimmed
+	if strings.Contains(modelID, "/") {
+		parts := strings.Split(modelID, "/")
+		modelID = parts[len(parts)-1]
+	}
+	modelID = strings.TrimSpace(modelID)
+	if !strings.HasPrefix(strings.ToLower(modelID), "gpt-") {
+		return trimmed, "", false
+	}
+
+	if strings.HasSuffix(strings.TrimSpace(modelID), ")") {
+		openParen := strings.LastIndex(modelID, "(")
+		if openParen > 0 {
+			suffix := strings.TrimSpace(strings.TrimSuffix(modelID[openParen+1:], ")"))
+			if effort, valid := normalizeOpenAICompatReasoningSuffix(suffix); valid {
+				baseModel := strings.TrimSpace(modelID[:openParen])
+				if baseModel == "" {
+					return trimmed, "", false
+				}
+				return normalizeCodexModel(baseModel), effort, true
+			}
+		}
+	}
+
+	parts := strings.FieldsFunc(strings.ToLower(modelID), func(r rune) bool {
+		switch r {
+		case '-', '_', ' ':
+			return true
+		default:
+			return false
+		}
+	})
+	if len(parts) == 0 {
+		return trimmed, "", false
+	}
+
+	last := strings.NewReplacer("-", "", "_", "", " ", "").Replace(parts[len(parts)-1])
+	reasoningEffort, ok = normalizeOpenAICompatReasoningSuffix(last)
+	if !ok {
+		return trimmed, "", false
+	}
+
+	return normalizeCodexModel(modelID), reasoningEffort, true
+}
+
+func normalizeOpenAICompatReasoningSuffix(raw string) (reasoningEffort string, ok bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return "", false
+	}
+	value = strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
+
+	switch value {
+	case "none", "minimal":
+	case "low", "medium", "high":
+		return value, true
+	case "xhigh", "extrahigh":
+		return "xhigh", true
+	default:
+		return "", false
+	}
+	return "", true
+}
+
+func openAIReasoningEffortToClaudeOutputEffort(effort string) string {
+	switch strings.TrimSpace(effort) {
+	case "low", "medium", "high":
+		return effort
+	case "xhigh":
+		return "max"
+	default:
+		return ""
+	}
+}

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeOpenAICompatRequestedModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "gpt reasoning alias strips xhigh", input: "gpt-5.4-xhigh", want: "gpt-5.4"},
+		{name: "gpt parenthesized reasoning alias strips xhigh", input: "gpt-5.5(xhigh)", want: "gpt-5.5"},
+		{name: "gpt spaced parenthesized reasoning alias strips xhigh", input: "gpt-5.5 (x-high)", want: "gpt-5.5"},
+		{name: "gpt reasoning alias strips none", input: "gpt-5.4-none", want: "gpt-5.4"},
+		{name: "codex max model stays intact", input: "gpt-5.1-codex-max", want: "gpt-5.1-codex-max"},
+		{name: "non openai model unchanged", input: "claude-opus-4-6", want: "claude-opus-4-6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, NormalizeOpenAICompatRequestedModel(tt.input))
+		})
+	}
+}
+
+func TestApplyOpenAICompatModelNormalization(t *testing.T) {
+	t.Parallel()
+
+	t.Run("derives xhigh from model suffix when output config missing", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{Model: "gpt-5.4-xhigh"}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "gpt-5.4", req.Model)
+		require.NotNil(t, req.OutputConfig)
+		require.Equal(t, "max", req.OutputConfig.Effort)
+	})
+
+	t.Run("derives xhigh from parenthesized model suffix when output config missing", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{Model: "gpt-5.5(xhigh)"}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "gpt-5.5", req.Model)
+		require.NotNil(t, req.OutputConfig)
+		require.Equal(t, "max", req.OutputConfig.Effort)
+	})
+
+	t.Run("explicit output config wins over model suffix", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{
+			Model:        "gpt-5.4-xhigh",
+			OutputConfig: &apicompat.AnthropicOutputConfig{Effort: "low"},
+		}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "gpt-5.4", req.Model)
+		require.NotNil(t, req.OutputConfig)
+		require.Equal(t, "low", req.OutputConfig.Effort)
+	})
+
+	t.Run("non openai model is untouched", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{Model: "claude-opus-4-6"}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "claude-opus-4-6", req.Model)
+		require.Nil(t, req.OutputConfig)
+	})
+}
+
+func TestForwardAsAnthropic_NormalizesParenthesizedRoutingAndEffortForGpt55XHigh(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5(xhigh)","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_compat"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.5",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.1")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gpt-5.5(xhigh)", result.Model)
+	require.Equal(t, "gpt-5.5", result.BillingModel)
+	require.NotNil(t, result.ReasoningEffort)
+	require.Equal(t, "xhigh", *result.ReasoningEffort)
+
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "xhigh", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "gpt-5.5(xhigh)", gjson.GetBytes(rec.Body.Bytes(), "model").String())
+	require.Equal(t, "ok", gjson.GetBytes(rec.Body.Bytes(), "content.0.text").String())
+}

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -40,6 +40,8 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		return nil, fmt.Errorf("parse anthropic request: %w", err)
 	}
 	originalModel := anthropicReq.Model
+	applyOpenAICompatModelNormalization(&anthropicReq)
+	normalizedModel := anthropicReq.Model
 	clientStream := anthropicReq.Stream // client's original stream preference
 
 	// 2. Convert Anthropic → Responses
@@ -59,16 +61,13 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	// 3. Model mapping
-	mappedModel := account.GetMappedModel(originalModel)
-	// 分组级降级：账号未映射时使用分组默认映射模型
-	if mappedModel == originalModel && defaultMappedModel != "" {
-		mappedModel = defaultMappedModel
-	}
+	mappedModel := resolveOpenAIForwardModel(account, normalizedModel, defaultMappedModel)
 	responsesReq.Model = mappedModel
 
 	logger.L().Debug("openai messages: model mapping applied",
 		zap.Int64("account_id", account.ID),
 		zap.String("original_model", originalModel),
+		zap.String("normalized_model", normalizedModel),
 		zap.String("mapped_model", mappedModel),
 		zap.Bool("stream", isStream),
 	)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4274,6 +4274,10 @@ func deriveOpenAIReasoningEffortFromModel(model string) string {
 		return ""
 	}
 
+	if _, effort, ok := splitOpenAICompatReasoningModel(model); ok {
+		return effort
+	}
+
 	modelID := strings.TrimSpace(model)
 	if strings.Contains(modelID, "/") {
 		parts := strings.Split(modelID, "/")

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -85,6 +85,13 @@ func TestExtractOpenAIReasoningEffortFromBody(t *testing.T) {
 			wantValue: "high",
 		},
 		{
+			name:      "缺失字段时从括号模型后缀推导",
+			body:      []byte(`{"input":"hi"}`),
+			model:     "gpt-5.5(xhigh)",
+			wantNil:   false,
+			wantValue: "xhigh",
+		},
+		{
 			name:    "未知后缀不返回",
 			body:    []byte(`{"input":"hi"}`),
 			model:   "gpt-5-unknown",

--- a/backend/internal/service/openai_model_mapping.go
+++ b/backend/internal/service/openai_model_mapping.go
@@ -1,0 +1,49 @@
+package service
+
+import "strings"
+
+func resolveOpenAIForwardModel(account *Account, requestedModel, defaultMappedModel string) string {
+	if account == nil {
+		if defaultMappedModel != "" {
+			return defaultMappedModel
+		}
+		return requestedModel
+	}
+
+	mapping := account.GetModelMapping()
+	if len(mapping) > 0 {
+		if mappedModel, exists := mapping[requestedModel]; exists {
+			return mappedModel
+		}
+		for pattern := range mapping {
+			if matchWildcard(pattern, requestedModel) {
+				return matchWildcardMapping(mapping, requestedModel)
+			}
+		}
+	}
+
+	if defaultMappedModel != "" && !isExplicitCodexModel(requestedModel) {
+		return defaultMappedModel
+	}
+	return requestedModel
+}
+
+func isExplicitCodexModel(model string) bool {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return false
+	}
+	if strings.Contains(model, "/") {
+		parts := strings.Split(model, "/")
+		model = parts[len(parts)-1]
+	}
+	model = strings.ToLower(strings.TrimSpace(model))
+	if getNormalizedCodexModel(model) != "" {
+		return true
+	}
+	if strings.HasSuffix(model, "-openai-compact") {
+		base := strings.TrimSuffix(model, "-openai-compact")
+		return getNormalizedCodexModel(base) != ""
+	}
+	return false
+}

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -1,0 +1,53 @@
+package service
+
+import "testing"
+
+func TestResolveOpenAIForwardModel(t *testing.T) {
+	tests := []struct {
+		name               string
+		account            *Account
+		requestedModel     string
+		defaultMappedModel string
+		expectedModel      string
+	}{
+		{
+			name: "falls back to group default when account has no mapping",
+			account: &Account{
+				Credentials: map[string]any{},
+			},
+			requestedModel:     "claude-opus-4-6",
+			defaultMappedModel: "gpt-5.1",
+			expectedModel:      "gpt-5.1",
+		},
+		{
+			name: "preserves gpt-5.5 instead of group default",
+			account: &Account{
+				Credentials: map[string]any{},
+			},
+			requestedModel:     "gpt-5.5",
+			defaultMappedModel: "gpt-5.1",
+			expectedModel:      "gpt-5.5",
+		},
+		{
+			name: "preserves exact passthrough mapping instead of group default",
+			account: &Account{
+				Credentials: map[string]any{
+					"model_mapping": map[string]any{
+						"gpt-5.5": "gpt-5.5",
+					},
+				},
+			},
+			requestedModel:     "gpt-5.5",
+			defaultMappedModel: "gpt-5.1",
+			expectedModel:      "gpt-5.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveOpenAIForwardModel(tt.account, tt.requestedModel, tt.defaultMappedModel); got != tt.expectedModel {
+				t.Fatalf("resolveOpenAIForwardModel(...) = %q, want %q", got, tt.expectedModel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- normalize parenthesized OpenAI reasoning model aliases such as gpt-5.5(xhigh) before /v1/messages account selection
- preserve the derived xhigh value into reasoning.effort for upstream Responses requests
- keep explicit Codex/OpenAI model requests from being replaced by a group default model

## Tests
- go test ./internal/service -run "TestNormalizeOpenAICompatRequestedModel|TestApplyOpenAICompatModelNormalization|TestForwardAsAnthropic_NormalizesParenthesizedRoutingAndEffortForGpt55XHigh|TestExtractOpenAIReasoningEffortFromBody|TestResolveOpenAIForwardModel"
- go test ./internal/service ./internal/handler ./internal/pkg/apicompat
