### PR TITLE
fix: normalize parenthesized OpenAI reasoning models

### DIFF
--- a/backend/internal/service/openai_compat_model.go
+++ b/backend/internal/service/openai_compat_model.go
@@ -65,6 +65,20 @@ func splitOpenAICompatReasoningModel(model string) (normalizedModel string, reas
 		return trimmed, "", false
 	}
 
+	if strings.HasSuffix(strings.TrimSpace(modelID), ")") {
+		openParen := strings.LastIndex(modelID, "(")
+		if openParen > 0 {
+			suffix := strings.TrimSpace(strings.TrimSuffix(modelID[openParen+1:], ")"))
+			if effort, valid := normalizeOpenAICompatReasoningSuffix(suffix); valid {
+				baseModel := strings.TrimSpace(modelID[:openParen])
+				if baseModel == "" {
+					return trimmed, "", false
+				}
+				return normalizeCodexModel(baseModel), effort, true
+			}
+		}
+	}
+
 	parts := strings.FieldsFunc(strings.ToLower(modelID), func(r rune) bool {
 		switch r {
 		case '-', '_', ' ':
@@ -78,17 +92,31 @@ func splitOpenAICompatReasoningModel(model string) (normalizedModel string, reas
 	}
 
 	last := strings.NewReplacer("-", "", "_", "", " ", "").Replace(parts[len(parts)-1])
-	switch last {
-	case "none", "minimal":
-	case "low", "medium", "high":
-		reasoningEffort = last
-	case "xhigh", "extrahigh":
-		reasoningEffort = "xhigh"
-	default:
+	reasoningEffort, ok = normalizeOpenAICompatReasoningSuffix(last)
+	if !ok {
 		return trimmed, "", false
 	}
 
 	return normalizeCodexModel(modelID), reasoningEffort, true
+}
+
+func normalizeOpenAICompatReasoningSuffix(raw string) (reasoningEffort string, ok bool) {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return "", false
+	}
+	value = strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
+
+	switch value {
+	case "none", "minimal":
+	case "low", "medium", "high":
+		return value, true
+	case "xhigh", "extrahigh":
+		return "xhigh", true
+	default:
+		return "", false
+	}
+	return "", true
 }
 
 func openAIReasoningEffortToClaudeOutputEffort(effort string) string {

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -27,6 +27,8 @@ func TestNormalizeOpenAICompatRequestedModel(t *testing.T) {
 		want  string
 	}{
 		{name: "gpt reasoning alias strips xhigh", input: "gpt-5.4-xhigh", want: "gpt-5.4"},
+		{name: "gpt parenthesized reasoning alias strips xhigh", input: "gpt-5.5(xhigh)", want: "gpt-5.5"},
+		{name: "gpt spaced parenthesized reasoning alias strips xhigh", input: "gpt-5.5 (x-high)", want: "gpt-5.5"},
 		{name: "gpt reasoning alias strips none", input: "gpt-5.4-none", want: "gpt-5.4"},
 		{name: "codex max model stays intact", input: "gpt-5.1-codex-max", want: "gpt-5.1-codex-max"},
 		{name: "non openai model unchanged", input: "claude-opus-4-6", want: "claude-opus-4-6"},
@@ -48,6 +50,16 @@ func TestApplyOpenAICompatModelNormalization(t *testing.T) {
 		applyOpenAICompatModelNormalization(req)
 
 		require.Equal(t, "gpt-5.4", req.Model)
+		require.NotNil(t, req.OutputConfig)
+		require.Equal(t, "max", req.OutputConfig.Effort)
+	})
+
+	t.Run("derives xhigh from parenthesized model suffix when output config missing", func(t *testing.T) {
+		req := &apicompat.AnthropicRequest{Model: "gpt-5.5(xhigh)"}
+
+		applyOpenAICompatModelNormalization(req)
+
+		require.Equal(t, "gpt-5.5", req.Model)
 		require.NotNil(t, req.OutputConfig)
 		require.Equal(t, "max", req.OutputConfig.Effort)
 	})
@@ -129,6 +141,60 @@ func TestForwardAsAnthropic_NormalizesRoutingAndEffortForGpt54XHigh(t *testing.T
 	require.Equal(t, "ok", gjson.GetBytes(rec.Body.Bytes(), "content.0.text").String())
 	t.Logf("upstream body: %s", string(upstream.lastBody))
 	t.Logf("response body: %s", rec.Body.String())
+}
+
+func TestForwardAsAnthropic_NormalizesParenthesizedRoutingAndEffortForGpt55XHigh(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5(xhigh)","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_1","object":"response","model":"gpt-5.5","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_compat"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.5",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.1")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gpt-5.5(xhigh)", result.Model)
+	require.Equal(t, "gpt-5.5", result.UpstreamModel)
+	require.Equal(t, "gpt-5.5", result.BillingModel)
+	require.NotNil(t, result.ReasoningEffort)
+	require.Equal(t, "xhigh", *result.ReasoningEffort)
+
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "xhigh", gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "gpt-5.5(xhigh)", gjson.GetBytes(rec.Body.Bytes(), "model").String())
+	require.Equal(t, "ok", gjson.GetBytes(rec.Body.Bytes(), "content.0.text").String())
 }
 
 func TestForwardAsAnthropic_ForcedCodexInstructionsTemplatePrependsRenderedInstructions(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -5509,6 +5509,10 @@ func deriveOpenAIReasoningEffortFromModel(model string) string {
 		return ""
 	}
 
+	if _, effort, ok := splitOpenAICompatReasoningModel(model); ok {
+		return effort
+	}
+
 	modelID := strings.TrimSpace(model)
 	if strings.Contains(modelID, "/") {
 		parts := strings.Split(modelID, "/")

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -86,6 +86,13 @@ func TestExtractOpenAIReasoningEffortFromBody(t *testing.T) {
 			wantValue: "high",
 		},
 		{
+			name:      "缺失字段时从括号模型后缀推导",
+			body:      []byte(`{"input":"hi"}`),
+			model:     "gpt-5.5(xhigh)",
+			wantNil:   false,
+			wantValue: "xhigh",
+		},
+		{
 			name:    "未知后缀不返回",
 			body:    []byte(`{"input":"hi"}`),
 			model:   "gpt-5-unknown",


### PR DESCRIPTION
## Summary
- normalize parenthesized OpenAI reasoning model aliases such as gpt-5.5(xhigh) before account selection
- preserve the derived xhigh value into reasoning.effort for upstream Responses requests
- add regression coverage for routing, upstream model, and usage reasoning effort

## Scope
- This is the clean small OpenAI/Codex fix left after reviewing the conflicted #1896 branch.
- It does not include affiliate, settings, auth, frontend, or local runtime-file changes.
- It does not remove or change reasoning.summary handling.

## Tests
- go.exe test ./internal/service -run "TestAdminService_CreateAccount_OpenAIOAuthPlanModelMapping|TestAdminService_RefreshOpenAIPlanModelCatalog_NoAccountKeepsCachedModels|TestNormalizeOpenAICompatRequestedModel|TestApplyOpenAICompatModelNormalization|TestForwardAsAnthropic_NormalizesRoutingAndEffortForGpt54XHigh|TestForwardAsAnthropic_NormalizesParenthesizedRoutingAndEffortForGpt55XHigh|TestForwardAsAnthropic_ForcedCodexInstructionsTemplatePrependsRenderedInstructions|TestForwardAsAnthropic_ForcedCodexInstructionsTemplateUsesCachedTemplateContent|TestExtractOpenAIRequestMetaFromBody|TestExtractOpenAIReasoningEffortFromBody|TestGetOpenAIRequestBodyMap_UsesContextCache|TestGetOpenAIRequestBodyMap_ParseErrorWithoutCache|TestGetOpenAIRequestBodyMap_WriteBackContextCache|TestSanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap|TestSanitizeEmptyBase64InputImagesInOpenAIBody"