### PR TITLE
fix(openai): keep non-streaming image requests alive

### DIFF
--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -167,6 +168,75 @@ func TestOpenAIEnsureForwardErrorResponse_DoesNotOverrideWrittenResponse(t *test
 	require.False(t, wrote)
 	require.Equal(t, http.StatusTeapot, w.Code)
 	assert.Equal(t, "already written", w.Body.String())
+}
+
+type openAIHandlerInformationalRecorder struct {
+	header        http.Header
+	body          bytes.Buffer
+	informational []int
+	status        int
+	wroteFinal    bool
+}
+
+func newOpenAIHandlerInformationalRecorder() *openAIHandlerInformationalRecorder {
+	return &openAIHandlerInformationalRecorder{
+		header: make(http.Header),
+	}
+}
+
+func (r *openAIHandlerInformationalRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *openAIHandlerInformationalRecorder) WriteHeader(code int) {
+	if code >= 100 && code < 200 {
+		r.informational = append(r.informational, code)
+		return
+	}
+	if r.wroteFinal {
+		return
+	}
+	r.status = code
+	r.wroteFinal = true
+}
+
+func (r *openAIHandlerInformationalRecorder) Write(data []byte) (int, error) {
+	if !r.wroteFinal {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.body.Write(data)
+}
+
+func (r *openAIHandlerInformationalRecorder) Flush() {}
+
+func TestOpenAIEnsureForwardErrorResponse_WritesAfterImageJSONKeepalive(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := newOpenAIHandlerInformationalRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	keepalive := service.StartOpenAIImagesJSONKeepalive(c, time.Millisecond, time.Millisecond)
+	require.NotNil(t, keepalive)
+	require.Eventually(t, func() bool {
+		return service.OpenAIImagesJSONKeepaliveWasWritten(c)
+	}, 100*time.Millisecond, time.Millisecond)
+	keepalive.Stop()
+	require.False(t, c.Writer.Written())
+	require.Equal(t, []int{http.StatusProcessing}, w.informational[:1])
+
+	h := &OpenAIGatewayHandler{}
+	wrote := h.ensureForwardErrorResponse(c, false)
+
+	require.True(t, wrote)
+	require.Equal(t, http.StatusBadGateway, w.status)
+
+	var parsed map[string]any
+	err := json.Unmarshal(bytes.TrimSpace(w.body.Bytes()), &parsed)
+	require.NoError(t, err)
+	errorObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "upstream_error", errorObj["type"])
+	assert.Equal(t, "Upstream request failed", errorObj["message"])
 }
 
 func TestShouldLogOpenAIForwardFailureAsWarn(t *testing.T) {

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -80,6 +80,16 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		zap.Bool("multipart", parsed.Multipart),
 		zap.String("capability", string(parsed.RequiredCapability)),
 	)
+	if !parsed.Stream {
+		jsonKeepalive := service.StartOpenAIImagesJSONKeepalive(
+			c,
+			service.OpenAIImagesJSONKeepaliveInitialDelay,
+			service.OpenAIImagesJSONKeepaliveInterval,
+		)
+		if jsonKeepalive != nil {
+			defer jsonKeepalive.Stop()
+		}
+	}
 
 	if parsed.Multipart {
 		setOpsRequestContext(c, parsed.Model, parsed.Stream, nil)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3736,6 +3736,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		"upstream_error",
 		"Upstream request failed",
 	); matched {
+		FinishOpenAIImagesJSONKeepalive(c)
 		c.JSON(status, gin.H{
 			"error": gin.H{
 				"type":    errType,
@@ -3763,6 +3764,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 			Message:            upstreamMsg,
 			Detail:             upstreamDetail,
 		})
+		FinishOpenAIImagesJSONKeepalive(c)
 		c.JSON(http.StatusInternalServerError, gin.H{
 			"error": gin.H{
 				"type":    "upstream_error",
@@ -3829,6 +3831,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		errMsg = "Upstream request failed"
 	}
 
+	FinishOpenAIImagesJSONKeepalive(c)
 	c.JSON(statusCode, gin.H{
 		"error": gin.H{
 			"type":    errType,

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -774,8 +774,10 @@ func cloneMultipartHeader(src textproto.MIMEHeader) textproto.MIMEHeader {
 func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponse(resp *http.Response, c *gin.Context) (OpenAIUsage, int, error) {
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
+		StopOpenAIImagesJSONKeepalive(c)
 		return OpenAIUsage{}, 0, err
 	}
+	FinishOpenAIImagesJSONKeepalive(c)
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	contentType := "application/json"
 	if s.cfg != nil && !s.cfg.Security.ResponseHeaders.Enabled {

--- a/backend/internal/service/openai_images_json_keepalive.go
+++ b/backend/internal/service/openai_images_json_keepalive.go
@@ -1,0 +1,157 @@
+package service
+
+import (
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	// Cloudflare can close idle HTTP requests after ~120s. Use 1xx informational
+	// responses so keepalive does not commit the final HTTP status.
+	OpenAIImagesJSONKeepaliveInitialDelay = 75 * time.Second
+	OpenAIImagesJSONKeepaliveInterval     = 25 * time.Second
+
+	openAIImagesJSONKeepaliveContextKey = "openai_images_json_keepalive"
+)
+
+type OpenAIImagesJSONKeepalive struct {
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+	stopOnce sync.Once
+
+	written  atomic.Bool
+	terminal atomic.Bool
+}
+
+func StartOpenAIImagesJSONKeepalive(c *gin.Context, initialDelay, interval time.Duration) *OpenAIImagesJSONKeepalive {
+	if c == nil || c.Request == nil || c.Writer == nil || initialDelay <= 0 || interval <= 0 {
+		return nil
+	}
+	if existing := getOpenAIImagesJSONKeepalive(c); existing != nil {
+		return existing
+	}
+
+	c.Header("Content-Type", "application/json; charset=utf-8")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("X-Accel-Buffering", "no")
+
+	keepalive := &OpenAIImagesJSONKeepalive{
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+	}
+	c.Set(openAIImagesJSONKeepaliveContextKey, keepalive)
+
+	go keepalive.run(c, initialDelay, interval)
+	return keepalive
+}
+
+func FinishOpenAIImagesJSONKeepalive(c *gin.Context) {
+	keepalive := getOpenAIImagesJSONKeepalive(c)
+	if keepalive == nil {
+		return
+	}
+	keepalive.terminal.Store(true)
+	keepalive.Stop()
+}
+
+func StopOpenAIImagesJSONKeepalive(c *gin.Context) {
+	keepalive := getOpenAIImagesJSONKeepalive(c)
+	if keepalive == nil {
+		return
+	}
+	keepalive.Stop()
+}
+
+func OpenAIImagesJSONKeepaliveWasWritten(c *gin.Context) bool {
+	keepalive := getOpenAIImagesJSONKeepalive(c)
+	return keepalive != nil && keepalive.written.Load()
+}
+
+func (k *OpenAIImagesJSONKeepalive) Stop() {
+	if k == nil {
+		return
+	}
+	k.stopOnce.Do(func() {
+		close(k.stopCh)
+		<-k.doneCh
+	})
+}
+
+func (k *OpenAIImagesJSONKeepalive) run(c *gin.Context, initialDelay, interval time.Duration) {
+	defer close(k.doneCh)
+
+	timer := time.NewTimer(initialDelay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+	case <-c.Request.Context().Done():
+		return
+	case <-k.stopCh:
+		return
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if !k.write(c) {
+			return
+		}
+
+		select {
+		case <-ticker.C:
+		case <-c.Request.Context().Done():
+			return
+		case <-k.stopCh:
+			return
+		}
+	}
+}
+
+func (k *OpenAIImagesJSONKeepalive) write(c *gin.Context) bool {
+	if k.terminal.Load() || c == nil || c.Writer == nil {
+		return false
+	}
+
+	writer := openAIImagesKeepaliveResponseWriter(c)
+	if writer == nil {
+		return false
+	}
+
+	writer.WriteHeader(http.StatusProcessing)
+	k.written.Store(true)
+	if flusher, ok := writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	return true
+}
+
+func openAIImagesKeepaliveResponseWriter(c *gin.Context) http.ResponseWriter {
+	type responseWriterUnwrapper interface {
+		Unwrap() http.ResponseWriter
+	}
+	if c == nil || c.Writer == nil {
+		return nil
+	}
+	if unwrapper, ok := c.Writer.(responseWriterUnwrapper); ok {
+		return unwrapper.Unwrap()
+	}
+	return nil
+}
+
+func getOpenAIImagesJSONKeepalive(c *gin.Context) *OpenAIImagesJSONKeepalive {
+	if c == nil {
+		return nil
+	}
+	value, ok := c.Get(openAIImagesJSONKeepaliveContextKey)
+	if !ok {
+		return nil
+	}
+	keepalive, _ := value.(*OpenAIImagesJSONKeepalive)
+	return keepalive
+}

--- a/backend/internal/service/openai_images_json_keepalive_test.go
+++ b/backend/internal/service/openai_images_json_keepalive_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type openAIImagesInformationalRecorder struct {
+	header        http.Header
+	body          bytes.Buffer
+	informational []int
+	status        int
+	wroteFinal    bool
+}
+
+func newOpenAIImagesInformationalRecorder() *openAIImagesInformationalRecorder {
+	return &openAIImagesInformationalRecorder{
+		header: make(http.Header),
+	}
+}
+
+func (r *openAIImagesInformationalRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *openAIImagesInformationalRecorder) WriteHeader(code int) {
+	if code >= 100 && code < 200 {
+		r.informational = append(r.informational, code)
+		return
+	}
+	if r.wroteFinal {
+		return
+	}
+	r.status = code
+	r.wroteFinal = true
+}
+
+func (r *openAIImagesInformationalRecorder) Write(data []byte) (int, error) {
+	if !r.wroteFinal {
+		r.WriteHeader(http.StatusOK)
+	}
+	return r.body.Write(data)
+}
+
+func (r *openAIImagesInformationalRecorder) Flush() {}
+
+func TestOpenAIImagesJSONKeepaliveSendsInformationalStatusAndStops(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := newOpenAIImagesInformationalRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	keepalive := StartOpenAIImagesJSONKeepalive(c, time.Millisecond, time.Millisecond)
+	require.NotNil(t, keepalive)
+	defer keepalive.Stop()
+
+	require.Eventually(t, func() bool {
+		return OpenAIImagesJSONKeepaliveWasWritten(c) && len(rec.informational) > 0
+	}, 100*time.Millisecond, time.Millisecond)
+	require.Equal(t, http.StatusProcessing, rec.informational[0])
+	require.False(t, c.Writer.Written())
+	require.Empty(t, rec.body.String())
+	require.Equal(t, "application/json; charset=utf-8", rec.Header().Get("Content-Type"))
+	require.Equal(t, "no-cache", rec.Header().Get("Cache-Control"))
+
+	keepalive.Stop()
+	writtenCount := len(rec.informational)
+	time.Sleep(5 * time.Millisecond)
+	require.Equal(t, writtenCount, len(rec.informational))
+}
+
+func TestOpenAIImagesJSONKeepalivePreservesFinalJSONStatus(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := newOpenAIImagesInformationalRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	keepalive := StartOpenAIImagesJSONKeepalive(c, time.Millisecond, time.Millisecond)
+	require.NotNil(t, keepalive)
+	require.Eventually(t, func() bool {
+		return OpenAIImagesJSONKeepaliveWasWritten(c)
+	}, 100*time.Millisecond, time.Millisecond)
+
+	FinishOpenAIImagesJSONKeepalive(c)
+	c.JSON(http.StatusOK, gin.H{"ok": true})
+
+	var payload map[string]bool
+	require.NoError(t, json.Unmarshal(bytes.TrimSpace(rec.body.Bytes()), &payload))
+	require.True(t, payload["ok"])
+	require.Equal(t, http.StatusOK, rec.status)
+}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -513,6 +513,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 ) (OpenAIUsage, int, error) {
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
+		StopOpenAIImagesJSONKeepalive(c)
 		return OpenAIUsage{}, 0, err
 	}
 
@@ -528,9 +529,11 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	}
 	results, createdAt, usageRaw, firstMeta, _, err := collectOpenAIImagesFromResponsesBody(body)
 	if err != nil {
+		StopOpenAIImagesJSONKeepalive(c)
 		return OpenAIUsage{}, 0, err
 	}
 	if len(results) == 0 {
+		StopOpenAIImagesJSONKeepalive(c)
 		return OpenAIUsage{}, 0, fmt.Errorf("upstream did not return image output")
 	}
 	if strings.TrimSpace(firstMeta.Model) == "" {
@@ -539,8 +542,10 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 
 	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
 	if err != nil {
+		StopOpenAIImagesJSONKeepalive(c)
 		return OpenAIUsage{}, 0, err
 	}
+	FinishOpenAIImagesJSONKeepalive(c)
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
 	return usage, len(results), nil

--- a/backend/internal/service/upstream_response_limit.go
+++ b/backend/internal/service/upstream_response_limit.go
@@ -74,6 +74,7 @@ func anthropicTooLargeError(c *gin.Context) {
 
 // openAITooLargeError 以 OpenAI / Gemini 格式写入超限错误。
 func openAITooLargeError(c *gin.Context) {
+	FinishOpenAIImagesJSONKeepalive(c)
 	c.JSON(http.StatusBadGateway, gin.H{
 		"error": gin.H{
 			"type":    "upstream_error",


### PR DESCRIPTION

## 关联 Issue

Fixes #2031

## 背景

Issue #2031 反馈：当用户服务器经过 Cloudflare 代理时，非流式生图请求如果生成耗时超过 Cloudflare 约 120 秒的空闲超时，客户端会在图片返回前被断开，最终拿不到生成结果。

这个问题主要发生在 `/v1/images/generations`、`/v1/images/edits` 的非流式请求上：上游可能长时间不返回最终 JSON，下游连接期间没有任何可见数据，容易被中间代理按 idle timeout 关闭。

## 改动内容

- 为 OpenAI Images 非流式请求增加延迟保活机制：
  - 请求开始后 75 秒仍未结束时发送一次 `102 Processing`。
  - 之后每 25 秒继续发送 `102 Processing`，直到请求完成或客户端断开。
- 使用 HTTP 1xx informational response 做保活，而不是向 body 写空白字符：
  - 不提交最终 HTTP 状态码。
  - 后续仍可正常返回 `200`、`4xx`、`5xx`。
  - 不污染最终 JSON body，避免严格客户端解析失败。
- 在最终成功响应、上游错误、响应体超限等路径写响应前停止保活 goroutine，避免终态响应期间并发写入。
- 补充测试覆盖：
  - 保活会发送 `102 Processing`。
  - 保活不会让 Gin 标记最终响应已写出。
  - 保活后仍能保留最终 JSON 状态码。
  - Forward fallback 错误仍能返回正确的 `502`。

## 设计说明

没有采用 issue 中提到的异步回调/轮询方案，因为这会改变 Images API 的同步调用语义，并要求客户端配合新协议。

本 PR 选择保持现有同步 API 行为，仅在长时间无响应时用 HTTP 标准 1xx 临时响应刷新链路。这样对现有 OpenAI 兼容客户端影响最小，同时可以规避 Cloudflare 等代理的空闲超时。

## 验证

已执行：

```bash
go test ./internal/service -run 'TestOpenAIImagesJSONKeepalive|TestOpenAIGatewayServiceForwardImages_OAuthUsesResponsesAPI' -count=1
go test ./internal/handler -run 'TestOpenAIEnsureForwardErrorResponse' -count=1
```