### PR TITLE
fix(openai): preserve current Codex compact payload fields

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -4864,7 +4864,18 @@ func normalizeOpenAICompactRequestBody(body []byte) ([]byte, bool, error) {
 	}
 
 	normalized := []byte(`{}`)
-	for _, field := range []string{"model", "input", "instructions", "previous_response_id"} {
+	// Keep the current Codex /compact schema while still dropping request-scoped
+	// fields such as prompt_cache_key, store, and stream.
+	for _, field := range []string{
+		"model",
+		"input",
+		"instructions",
+		"tools",
+		"parallel_tool_calls",
+		"reasoning",
+		"text",
+		"previous_response_id",
+	} {
 		value := gjson.GetBytes(body, field)
 		if !value.Exists() {
 			continue

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1767,6 +1767,24 @@ func TestOpenAIResponsesRequestPathSuffix(t *testing.T) {
 	}
 }
 
+func TestNormalizeOpenAICompactRequestBodyPreservesCurrentCodexPayloadFields(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":"compact me"}],"instructions":"compact-test","tools":[{"type":"function","name":"shell"}],"parallel_tool_calls":true,"reasoning":{"effort":"high"},"text":{"verbosity":"low"},"previous_response_id":"resp_123","store":true,"stream":true,"prompt_cache_key":"cache_123"}`)
+
+	normalized, changed, err := normalizeOpenAICompactRequestBody(body)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(normalized, "model").String())
+	require.True(t, gjson.GetBytes(normalized, "tools").Exists())
+	require.True(t, gjson.GetBytes(normalized, "parallel_tool_calls").Bool())
+	require.Equal(t, "high", gjson.GetBytes(normalized, "reasoning.effort").String())
+	require.Equal(t, "low", gjson.GetBytes(normalized, "text.verbosity").String())
+	require.Equal(t, "resp_123", gjson.GetBytes(normalized, "previous_response_id").String())
+	require.False(t, gjson.GetBytes(normalized, "store").Exists())
+	require.False(t, gjson.GetBytes(normalized, "stream").Exists())
+	require.False(t, gjson.GetBytes(normalized, "prompt_cache_key").Exists())
+}
+
 func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCompactPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- 在 `/responses/compact` 请求体归一化时保留当前 Codex remote compact 会发送的字段：`tools`、`parallel_tool_calls`、`reasoning`、`text`
- 仍保持 compact 归一化的保守行为，继续移除 `store`、`stream`、`prompt_cache_key` 这类请求态字段
- 增加回归测试，避免新版 Codex compact payload 字段再次被裁剪

## Context
#1865 里讨论的 compact 失败问题看起来已经通过最近的 Codex version/header 更新解决了。这个 PR 处理的是另一个兼容性细节：当前代码仍然按旧 compact schema 重建请求体，只保留 `model`、`input`、`instructions`、`previous_response_id`，会把当前 Codex remote compact 已经发送的字段裁掉。

当前 Codex 的 remote compact payload 来自 `CompactionInput`，实际包含 `model`、`input`、`instructions`、`tools`、`parallel_tool_calls`、`reasoning`、`text`。其中 `tools` 和 `parallel_tool_calls` 是固定序列化字段，`reasoning` 和 `text` 按模型能力/配置条件序列化。

参考源码：
- `codex-api/src/common.rs`: `CompactionInput`
- `codex-rs/core/src/client.rs`: 构造 `ApiCompactionInput`
- `codex-rs/core/src/compact/compact_remote.rs`: remote compact prompt/options 构造

这个改动只是让 sub2api 的 compact body 白名单跟当前 Codex compact payload 对齐，并没有放开所有未知字段透传。

Related to #1865.


## Tests
- `go test ./internal/service -run TestNormalizeOpenAICompactRequestBodyPreservesCurrentCodexPayloadFields`
