### PR TITLE
fix: normalize oauth codex service tier

### DIFF
--- a/backend/internal/service/openai_fast_policy_test.go
+++ b/backend/internal/service/openai_fast_policy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 type openAIFastPolicyRepoStub struct {
@@ -165,7 +166,7 @@ func TestApplyOpenAIFastPolicyToBody_OfficialTiersBypassDefaultRule(t *testing.T
 	svc := newOpenAIGatewayServiceWithSettings(t, DefaultOpenAIFastPolicySettings())
 	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
 
-	for _, tier := range []string{"auto", "default", "scale"} {
+	for _, tier := range []string{"flex", "auto", "default", "scale"} {
 		body := []byte(`{"model":"gpt-5.5","service_tier":"` + tier + `"}`)
 		updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
 		require.NoError(t, err, "tier %q should pass without error", tier)
@@ -174,10 +175,48 @@ func TestApplyOpenAIFastPolicyToBody_OfficialTiersBypassDefaultRule(t *testing.T
 	}
 
 	// evaluate 层也应判定为 pass（默认规则 ServiceTier=priority 与 auto/default/scale 不匹配）
-	for _, tier := range []string{"auto", "default", "scale"} {
+	for _, tier := range []string{"flex", "auto", "default", "scale"} {
 		action, _ := svc.evaluateOpenAIFastPolicy(context.Background(), account, "gpt-5.5", tier)
 		require.Equal(t, BetaPolicyActionPass, action, "tier %q should evaluate to pass", tier)
 	}
+}
+
+func TestApplyOpenAIFastPolicyToBody_OAuthCodexInternalDefaultsUnsupportedTiers(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{})
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	for _, tier := range []string{"flex", "auto", "default", "scale", "unknown"} {
+		body := []byte(`{"model":"gpt-5.5","service_tier":"` + tier + `"}`)
+		updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+		require.NoError(t, err)
+		require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(updated, "service_tier").String(),
+			"tier %q should be sent as default for OAuth Codex internal upstream", tier)
+	}
+
+	body := []byte(`{"model":"gpt-5.5","service_tier":{"mode":"flex"}}`)
+	updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(updated, "service_tier").String())
+
+	body = []byte(`{"model":"gpt-5.5"}`)
+	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestApplyOpenAIFastPolicyToBody_OAuthCodexInternalKeepsPriority(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, &OpenAIFastPolicySettings{})
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	body := []byte(`{"model":"gpt-5.5","service_tier":"priority"}`)
+	updated, err := svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.Equal(t, "priority", gjson.GetBytes(updated, "service_tier").String())
+
+	body = []byte(`{"model":"gpt-5.5","service_tier":"fast"}`)
+	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
+	require.NoError(t, err)
+	require.Equal(t, "priority", gjson.GetBytes(updated, "service_tier").String())
 }
 
 // TestApplyOpenAIFastPolicyToBody_AllRuleStripsOfficialTiers 验证管理员显式配置

--- a/backend/internal/service/openai_fast_policy_ws_test.go
+++ b/backend/internal/service/openai_fast_policy_ws_test.go
@@ -68,6 +68,29 @@ func TestWSResponseCreate_FlexPassThrough(t *testing.T) {
 	require.Equal(t, "flex", gjson.GetBytes(updated, "service_tier").String(), "flex frames must reach upstream untouched under default policy")
 }
 
+func TestWSResponseCreate_OAuthCodexInternalDefaultsUnsupportedServiceTier(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithSettings(t, nil)
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	frame := []byte(`{"type":"response.create","model":"gpt-5.5","service_tier":"flex"}`)
+	updated, blocked, err := svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, "gpt-5.5", frame)
+	require.NoError(t, err)
+	require.Nil(t, blocked)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(updated, "service_tier").String())
+
+	frame = []byte(`{"type":"response.create","model":"gpt-5.5","service_tier":{"mode":"flex"}}`)
+	updated, blocked, err = svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, "gpt-5.5", frame)
+	require.NoError(t, err)
+	require.Nil(t, blocked)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(updated, "service_tier").String())
+
+	frame = []byte(`{"type":"response.create","model":"gpt-5.5"}`)
+	updated, blocked, err = svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, "gpt-5.5", frame)
+	require.NoError(t, err)
+	require.Nil(t, blocked)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(updated, "service_tier").String())
+}
+
 func TestWSResponseCreate_BlockReturnsTypedError(t *testing.T) {
 	settings := &OpenAIFastPolicySettings{
 		Rules: []OpenAIFastPolicyRule{{

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2327,8 +2327,19 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	//      否则 native /responses 入口透传 "fast" 给上游会被拒。chat-
 	//      completions 入口由 normalizeResponsesBodyServiceTier 完成同一
 	//      行为，这里手工实现等效逻辑。
-	if rawTier, ok := reqBody["service_tier"].(string); ok {
-		if normTier := normalizedOpenAIServiceTierValue(rawTier); normTier != "" {
+	if tierValue, hasTier := reqBody["service_tier"]; hasTier {
+		rawTier, ok := tierValue.(string)
+		normTier := ""
+		if ok {
+			normTier = normalizedOpenAIServiceTierValue(rawTier)
+		}
+		if !ok || normTier == "" || !openAICodexInternalFastPolicyEligible(account, normTier) {
+			if isOpenAICodexInternalAccount(account) {
+				reqBody["service_tier"] = OpenAICodexInternalDefaultServiceTier
+				bodyModified = true
+				disablePatch()
+			}
+		} else {
 			action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, upstreamModel, normTier)
 			switch action {
 			case BetaPolicyActionBlock:
@@ -2353,6 +2364,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				}
 			}
 		}
+	} else if isOpenAICodexInternalAccount(account) {
+		reqBody["service_tier"] = OpenAICodexInternalDefaultServiceTier
+		bodyModified = true
+		disablePatch()
 	}
 
 	// Re-serialize body only if modified
@@ -5667,6 +5682,27 @@ func normalizeOpenAIServiceTier(raw string) *string {
 	}
 }
 
+func isOpenAICodexInternalAccount(account *Account) bool {
+	return account != nil && account.Platform == PlatformOpenAI && account.Type == AccountTypeOAuth
+}
+
+const OpenAICodexInternalDefaultServiceTier = "default"
+
+func openAICodexInternalFastPolicyEligible(account *Account, tier string) bool {
+	if !isOpenAICodexInternalAccount(account) {
+		return true
+	}
+	return tier == OpenAIFastTierPriority
+}
+
+func setOpenAICodexInternalDefaultServiceTier(body []byte) ([]byte, error) {
+	updated, err := sjson.SetBytes(body, "service_tier", OpenAICodexInternalDefaultServiceTier)
+	if err != nil {
+		return body, err
+	}
+	return updated, nil
+}
+
 // OpenAIFastBlockedError indicates a request was rejected by the OpenAI fast
 // policy (action=block). Mirrors BetaBlockedError on the Claude side.
 type OpenAIFastBlockedError struct {
@@ -5788,12 +5824,40 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToBody(ctx context.Context, 
 	if len(body) == 0 {
 		return body, nil
 	}
-	rawTier := gjson.GetBytes(body, "service_tier").String()
-	if rawTier == "" {
+	tierResult := gjson.GetBytes(body, "service_tier")
+	if !tierResult.Exists() {
+		if isOpenAICodexInternalAccount(account) {
+			updated, err := setOpenAICodexInternalDefaultServiceTier(body)
+			if err != nil {
+				return body, fmt.Errorf("set default service_tier on body: %w", err)
+			}
+			return updated, nil
+		}
 		return body, nil
 	}
+	if tierResult.Type != gjson.String {
+		if !isOpenAICodexInternalAccount(account) {
+			return body, nil
+		}
+		updated, err := setOpenAICodexInternalDefaultServiceTier(body)
+		if err != nil {
+			return body, fmt.Errorf("set default service_tier on body: %w", err)
+		}
+		return updated, nil
+	}
+	rawTier := tierResult.String()
 	normTier := normalizedOpenAIServiceTierValue(rawTier)
-	if normTier == "" {
+	if normTier == "" || !openAICodexInternalFastPolicyEligible(account, normTier) {
+		if !isOpenAICodexInternalAccount(account) {
+			return body, nil
+		}
+		updated, err := setOpenAICodexInternalDefaultServiceTier(body)
+		if err != nil {
+			return body, fmt.Errorf("set default service_tier on body: %w", err)
+		}
+		return updated, nil
+	}
+	if rawTier == "" {
 		return body, nil
 	}
 	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
@@ -5884,12 +5948,40 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToWSResponseCreate(
 	if frameType != "response.create" {
 		return frame, nil, nil
 	}
-	rawTier := gjson.GetBytes(frame, "service_tier").String()
-	if rawTier == "" {
+	tierResult := gjson.GetBytes(frame, "service_tier")
+	if !tierResult.Exists() {
+		if isOpenAICodexInternalAccount(account) {
+			updated, err := setOpenAICodexInternalDefaultServiceTier(frame)
+			if err != nil {
+				return frame, nil, fmt.Errorf("set default service_tier on ws frame: %w", err)
+			}
+			return updated, nil, nil
+		}
 		return frame, nil, nil
 	}
+	if tierResult.Type != gjson.String {
+		if !isOpenAICodexInternalAccount(account) {
+			return frame, nil, nil
+		}
+		updated, err := setOpenAICodexInternalDefaultServiceTier(frame)
+		if err != nil {
+			return frame, nil, fmt.Errorf("set default service_tier on ws frame: %w", err)
+		}
+		return updated, nil, nil
+	}
+	rawTier := tierResult.String()
 	normTier := normalizedOpenAIServiceTierValue(rawTier)
-	if normTier == "" {
+	if normTier == "" || !openAICodexInternalFastPolicyEligible(account, normTier) {
+		if !isOpenAICodexInternalAccount(account) {
+			return frame, nil, nil
+		}
+		updated, err := setOpenAICodexInternalDefaultServiceTier(frame)
+		if err != nil {
+			return frame, nil, fmt.Errorf("set default service_tier on ws frame: %w", err)
+		}
+		return updated, nil, nil
+	}
+	if rawTier == "" {
 		return frame, nil, nil
 	}
 	action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, model, normTier)
@@ -5907,6 +5999,13 @@ func (s *OpenAIGatewayService) applyOpenAIFastPolicyToWSResponseCreate(
 		}
 		return trimmed, nil, nil
 	default:
+		if normTier != rawTier {
+			updated, err := sjson.SetBytes(frame, "service_tier", normTier)
+			if err != nil {
+				return frame, nil, fmt.Errorf("normalize service_tier on ws frame: %w", err)
+			}
+			return updated, nil, nil
+		}
 		return frame, nil, nil
 	}
 }

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -405,6 +405,51 @@ func TestOpenAIGatewayService_OAuthPassthrough_DisabledUsesLegacyTransform(t *te
 	require.Contains(t, string(upstream.lastBody), `"stream":true`)
 }
 
+func TestOpenAIGatewayService_OAuthLegacy_DefaultsFlexServiceTierBeforeCodexUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	inputBody := []byte(`{"model":"gpt-5.5","stream":true,"store":false,"service_tier":"flex","input":[{"type":"text","text":"hi"}]}`)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}
+	upstream := &httpUpstreamRecorder{resp: resp}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": false},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, inputBody)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, result.ServiceTier)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, *result.ServiceTier)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, OpenAICodexInternalDefaultServiceTier, gjson.GetBytes(upstream.lastBody, "service_tier").String())
+	require.Equal(t, "https://chatgpt.com/backend-api/codex/responses", upstream.lastReq.URL.String())
+}
+
 func TestOpenAIGatewayService_OAuthLegacy_CompositeCodexUAUsesCodexOriginator(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary
- Normalize OpenAI OAuth Codex internal requests so only service_tier=priority remains eligible for fast handling.
- For OAuth Codex internal upstream, send service_tier=default when the client omits service_tier or sends non-priority values such as flex/auto/default/scale/unknown.
- Keep public OpenAI API / API Key passthrough behavior unchanged, including service_tier=flex.
- Cover HTTP body, legacy OAuth /responses, and response.create WebSocket policy handling.

## Why
OpenAI public API defaults service_tier to auto, which can follow project-level Priority settings. The ChatGPT Codex internal upstream also rejects service_tier=flex. To avoid accidental Priority usage and upstream 400 errors, OAuth Codex internal requests now explicitly use default unless the client requested priority.

## Tests
- go test ./internal/service -run "TestApplyOpenAIFastPolicy|TestWSResponseCreate|TestOpenAIGatewayService_OAuthLegacy_DefaultsFlexServiceTierBeforeCodexUpstream|TestOpenAIGatewayService_APIKeyPassthrough_PreservesBodyAndUsesResponsesEndpoint"
- go test ./internal/service