### PR TITLE
fix(openai): drop reasoning items from /v1/responses input on OAuth path

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -853,6 +853,14 @@ func filterCodexInput(input []any, preserveReferences bool) []any {
 		}
 		typ, _ := m["type"].(string)
 
+		// chatgpt.com codex backend (OAuth path) does not persist reasoning
+		// items because applyCodexOAuthTransform forces store=false. Any rs_*
+		// reference replayed in input is guaranteed to 404 upstream
+		// ("Item with id 'rs_...' not found"). Drop reasoning items entirely.
+		if typ == "reasoning" {
+			continue
+		}
+
 		// 仅修正真正的 tool/function call 标识，避免误改普通 message/reasoning id；
 		// 若 item_reference 指向 legacy call_* 标识，则仅修正该引用本身。
 		fixCallIDPrefix := func(id string) string {

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -1091,6 +1093,57 @@ func TestIsInstructionsEmpty(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := isInstructionsEmpty(tt.reqBody)
 			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFilterCodexInput_DropsReasoningItemsRegardlessOfPreserveReferences(t *testing.T) {
+	// Reasoning items in input[] reference rs_* IDs that were emitted by
+	// chatgpt.com under store=false (forced by applyCodexOAuthTransform).
+	// They are never persisted upstream, so forwarding them produces a
+	// guaranteed 404 ("Item with id 'rs_...' not found"). Drop them
+	// regardless of preserveReferences. See: Wei-Shaw/sub2api issue #1957.
+
+	build := func() []any {
+		return []any{
+			map[string]any{"type": "message", "id": "msg_0", "role": "user", "content": "hi"},
+			map[string]any{
+				"type":    "reasoning",
+				"id":      "rs_0672f12450da0b9c0169f07220a6c08198b68c2455ced99344",
+				"summary": []any{},
+			},
+			map[string]any{"type": "function_call", "id": "fc_1", "call_id": "call_1", "name": "tool"},
+			map[string]any{"type": "function_call_output", "call_id": "call_1", "output": "{}"},
+		}
+	}
+
+	for _, preserve := range []bool{true, false} {
+		preserve := preserve
+		t.Run(fmt.Sprintf("preserveReferences=%v", preserve), func(t *testing.T) {
+			filtered := filterCodexInput(build(), preserve)
+
+			for _, raw := range filtered {
+				item, ok := raw.(map[string]any)
+				require.True(t, ok)
+				require.NotEqual(t, "reasoning", item["type"],
+					"reasoning items must be dropped from input on the OAuth path")
+				if id, ok := item["id"].(string); ok {
+					require.False(t, strings.HasPrefix(id, "rs_"),
+						"no item carrying an rs_* id should survive the filter")
+				}
+			}
+
+			// Sanity check: the non-reasoning items should still be present.
+			gotTypes := make(map[string]int)
+			for _, raw := range filtered {
+				item, ok := raw.(map[string]any)
+				require.True(t, ok)
+				gotTypes[item["type"].(string)]++
+			}
+			require.Equal(t, 1, gotTypes["message"])
+			require.Equal(t, 1, gotTypes["function_call"])
+			require.Equal(t, 1, gotTypes["function_call_output"])
+			require.Equal(t, 0, gotTypes["reasoning"])
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Drops items with `type == "reasoning"` from `input[]` in `filterCodexInput`. The OAuth path forces `store: false` upstream, which means `rs_*` IDs are never persisted and replaying them in subsequent turns guarantees a 404 → 502.

Closes #2067
Refs #1957

## What changes

| File | Lines | Purpose |
|---|---|---|
| `backend/internal/service/openai_codex_transform.go` | +8 (5 code, 4 doc) | Drop `type == "reasoning"` items at the top of `filterCodexInput`'s loop |
| `backend/internal/service/openai_codex_transform_test.go` | +53 | Regression test covering both `preserveReferences=true` and `preserveReferences=false` |

Total: +61 / -0 across 2 files.

## Why this is safe

The change is gated by the existing `applyCodexOAuthTransform` call site (`openai_gateway_service.go:2233-2245`), which only fires for `account.Type == AccountTypeOAuth`. Other paths are unaffected:

- **API-key OpenAI accounts** (going to `api.openai.com/v1/responses`): not affected — `store: true` works there and `rs_*` references must be preserved.
- **Anthropic / Gemini platform groups**: different transform pipeline, not touched.
- **`/v1/chat/completions`**: no concept of reasoning items, not touched.
- **`item_reference` items**: different `type`, not touched. Only `type == "reasoning"` is dropped.

## Why dropping is a no-op for the model

Reasoning items in `input[]` carry semantic value to the upstream model only via `encrypted_content` (the opaque OpenAI reasoning state). Under `store: false`, `chatgpt.com`'s codex backend does not emit `encrypted_content`, so the items being dropped have no model-visible payload — only the `rs_*` ID, which the upstream then fails to look up. Codex CLI, the reference client for this path, also never replays reasoning items.

## Verification

Tests run on a clean checkout of the branch:

- `go test ./internal/service/ -run "Codex|Tool|OAuth"` — full pre-existing suite passes
- New test `TestFilterCodexInput_DropsReasoningItemsRegardlessOfPreserveReferences` (with both sub-tests) passes
- End-to-end: built `weishaw/sub2api:0.1.119-patch1`, swapped into a real deployment, ran a 30-line Python reproducer:
  - Pre-patch: `gpt-5.5` turn-2-with-tools → 502 (with the exact `rs_*` ID surfacing in `request-errors`)
  - Post-patch: same reproducer → 200, three-turn deep-loop variant also 200
  - `gpt-5.4` multi-turn unchanged
  - `/v1/chat/completions` unchanged
- Patched image has been running in production for several hours under real OpenClaw load with no regressions observed

## 概述

在 `filterCodexInput` 中把 `type == "reasoning"` 的 `input[]` items 整个 drop 掉。OAuth 路径下 `store: false` 是强制的，意味着 `rs_*` ID 永远不会在上游持久化，客户端在后续轮次回放它们必然导致上游 404 → 网关 502。

Closes #2067
Refs #1957

## 改了什么

| 文件 | 行数 | 用途 |
|---|---|---|
| `backend/internal/service/openai_codex_transform.go` | +8（5 行代码 + 4 行注释）| 在 `filterCodexInput` 循环顶部 drop `type == "reasoning"` items |
| `backend/internal/service/openai_codex_transform_test.go` | +53 | 回归测试，覆盖 `preserveReferences=true` 和 `preserveReferences=false` 两条路径 |

合计 +61 / -0，2 个文件。

## 为什么是安全的

变更被现有的 `applyCodexOAuthTransform` 调用位置（`openai_gateway_service.go:2233-2245`）天然门控——只有 `account.Type == AccountTypeOAuth` 才会进。其他路径不受影响：

- **API-key OpenAI 账号**（走 `api.openai.com/v1/responses`）：不受影响——那条路 `store: true` 真生效，`rs_*` 引用必须保留
- **Anthropic / Gemini 平台账号**：走不同的 transform 流水线，未触碰
- **`/v1/chat/completions`**：没有 reasoning item 概念，未触碰
- **`item_reference` items**：`type` 不同，未触碰。仅 `type == "reasoning"` 被 drop

## 为什么 drop 对模型是 no-op

`input[]` 里的 reasoning item 对上游模型有语义价值的载体只有 `encrypted_content`（OpenAI 的 opaque reasoning state）。但在 `store: false` 下，`chatgpt.com` 的 codex 后端**不下发** `encrypted_content`，所以被 drop 的这些 items 实际上对模型没有可见 payload——只剩一个 `rs_*` ID，而上游必然查找失败。

Codex CLI（这条路径上 OpenAI 自家的参考客户端）本身也从不回放 reasoning items，进一步印证了这是上游协议层面的设计共识。

## 验证

在干净的 branch checkout 上跑了：

- `go test ./internal/service/ -run "Codex|Tool|OAuth"`：全套既有测试通过
- 新增测试 `TestFilterCodexInput_DropsReasoningItemsRegardlessOfPreserveReferences`（含两个 sub-test）通过
- 端到端验证：构建 `weishaw/sub2api:0.1.119-patch1`，部署到真实环境，跑 30 行 Python reproducer：
  - patch 前：`gpt-5.5` 双轮带 tools → 502（`request-errors` 里的 `rs_*` ID 跟客户端 turn1 收到的字符级一致）
  - patch 后：同 reproducer → 200，三轮深度循环变体也 200
  - `gpt-5.4` 多轮请求行为不变
  - `/v1/chat/completions` 行为不变
- 打 patch 的镜像已经在生产环境真实 OpenClaw 负载下跑了数小时，未观察到任何 regression
