### PR TITLE
fix: 修复了当账号为apikey模式时的 池模式与临时不可调度规则冲突 的问题

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -151,7 +151,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	antigravityTokenProvider := service.ProvideAntigravityTokenProvider(accountRepository, geminiTokenCache, antigravityOAuthService, oAuthRefreshAPI, tempUnschedCache)
 	internal500CounterCache := repository.NewInternal500CounterCache(redisClient)
 	antigravityGatewayService := service.NewAntigravityGatewayService(accountRepository, gatewayCache, schedulerSnapshotService, antigravityTokenProvider, rateLimitService, httpUpstream, settingService, internal500CounterCache)
-	accountTestService := service.NewAccountTestService(accountRepository, geminiTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService)
+	accountTestService := service.NewAccountTestService(accountRepository, geminiTokenProvider, antigravityGatewayService, httpUpstream, configConfig, tlsFingerprintProfileService, rateLimitService)
 	crsSyncService := service.NewCRSSyncService(accountRepository, proxyRepository, oAuthService, openAIOAuthService, geminiOAuthService, configConfig)
 	accountHandler := admin.NewAccountHandler(adminService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, rateLimitService, accountUsageService, accountTestService, concurrencyService, crsSyncService, sessionLimitCache, rpmCache, compositeTokenCacheInvalidator)
 	adminAnnouncementHandler := admin.NewAnnouncementHandler(announcementService)

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -68,6 +68,7 @@ type AccountTestService struct {
 	httpUpstream              HTTPUpstream
 	cfg                       *config.Config
 	tlsFPProfileService       *TLSFingerprintProfileService
+	rateLimitService          *RateLimitService
 }
 
 // NewAccountTestService creates a new AccountTestService
@@ -78,6 +79,7 @@ func NewAccountTestService(
 	httpUpstream HTTPUpstream,
 	cfg *config.Config,
 	tlsFPProfileService *TLSFingerprintProfileService,
+	rateLimitService *RateLimitService,
 ) *AccountTestService {
 	return &AccountTestService{
 		accountRepo:               accountRepo,
@@ -86,6 +88,7 @@ func NewAccountTestService(
 		httpUpstream:              httpUpstream,
 		cfg:                       cfg,
 		tlsFPProfileService:       tlsFPProfileService,
+		rateLimitService:          rateLimitService,
 	}
 }
 
@@ -301,6 +304,10 @@ func (s *AccountTestService) testClaudeAccountConnection(c *gin.Context, account
 		body, _ := io.ReadAll(resp.Body)
 		errMsg := fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body))
 
+		if s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body) {
+			return s.sendErrorAndEnd(c, errMsg)
+		}
+
 		// 403 表示账号被上游封禁，标记为 error 状态
 		if resp.StatusCode == http.StatusForbidden {
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
@@ -390,6 +397,9 @@ func (s *AccountTestService) testBedrockAccountConnection(c *gin.Context, ctx co
 	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
+		if s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body) {
+			return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		}
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
@@ -541,6 +551,9 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if resp.StatusCode == http.StatusTooManyRequests {
 			s.reconcileOpenAI429State(ctx, account, resp.Header, body)
 		}
+		if s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body) {
+			return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		}
 		// 401 Unauthorized: 标记账号为永久错误
 		if resp.StatusCode == http.StatusUnauthorized && s.accountRepo != nil {
 			errMsg := fmt.Sprintf("Authentication failed (401): %s", string(body))
@@ -656,6 +669,9 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body) {
+			return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		}
 		if resp.StatusCode == http.StatusUnauthorized && s.accountRepo != nil {
 			errMsg := fmt.Sprintf("Authentication failed (401): %s", string(body))
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
@@ -765,6 +781,9 @@ func (s *AccountTestService) testGeminiAccountConnection(c *gin.Context, account
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
+		if s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body) {
+			return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		}
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
@@ -1270,6 +1289,9 @@ func (s *AccountTestService) testOpenAIImageAPIKey(c *gin.Context, ctx context.C
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		if s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body) {
+			return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		}
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
@@ -1368,6 +1390,7 @@ func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Co
 	}()
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		s.markTempUnschedulableOnHTTPError(ctx, account, resp.StatusCode, resp.Header, body)
 		message := strings.TrimSpace(extractUpstreamErrorMessage(body))
 		if message == "" {
 			message = fmt.Sprintf("Responses API returned %d", resp.StatusCode)
@@ -1418,6 +1441,19 @@ func (s *AccountTestService) sendErrorAndEnd(c *gin.Context, errorMsg string) er
 	log.Printf("Account test error: %s", errorMsg)
 	s.sendEvent(c, TestEvent{Type: "error", Error: errorMsg})
 	return fmt.Errorf("%s", errorMsg)
+}
+
+func (s *AccountTestService) markTempUnschedulableOnHTTPError(ctx context.Context, account *Account, statusCode int, headers http.Header, body []byte) bool {
+	if s == nil || s.rateLimitService == nil || account == nil {
+		return false
+	}
+	if statusCode == http.StatusUnauthorized && account.Type == AccountTypeOAuth && account.Platform != PlatformAntigravity {
+		return s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, headers, body)
+	}
+	if statusCode == http.StatusUnauthorized {
+		return false
+	}
+	return s.rateLimitService.HandleTempUnschedulable(ctx, account, statusCode, body)
 }
 
 // RunTestBackground executes an account test in-memory (no real HTTP client),

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 )
 
@@ -61,12 +62,17 @@ func newTestContext() (*gin.Context, *httptest.ResponseRecorder) {
 
 type openAIAccountTestRepo struct {
 	mockAccountRepoForGemini
-	updatedExtra   map[string]any
-	rateLimitedID  int64
-	rateLimitedAt  *time.Time
-	clearedErrorID int64
-	setErrorID     int64
-	setErrorMsg    string
+	updatedExtra           map[string]any
+	rateLimitedID          int64
+	rateLimitedAt          *time.Time
+	clearedErrorID         int64
+	setErrorID             int64
+	setErrorMsg            string
+	tempUnschedID          int64
+	tempUnschedUntil       *time.Time
+	tempUnschedReason      string
+	updateCredentialsCalls int
+	lastCredentials        map[string]any
 }
 
 func (r *openAIAccountTestRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
@@ -88,6 +94,19 @@ func (r *openAIAccountTestRepo) ClearError(_ context.Context, id int64) error {
 func (r *openAIAccountTestRepo) SetError(_ context.Context, id int64, errorMsg string) error {
 	r.setErrorID = id
 	r.setErrorMsg = errorMsg
+	return nil
+}
+
+func (r *openAIAccountTestRepo) SetTempUnschedulable(_ context.Context, id int64, until time.Time, reason string) error {
+	r.tempUnschedID = id
+	r.tempUnschedUntil = &until
+	r.tempUnschedReason = reason
+	return nil
+}
+
+func (r *openAIAccountTestRepo) UpdateCredentials(_ context.Context, _ int64, credentials map[string]any) error {
+	r.updateCredentialsCalls++
+	r.lastCredentials = cloneCredentials(credentials)
 	return nil
 }
 
@@ -186,6 +205,104 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimitState(t *testin
 	require.NotNil(t, account.RateLimitResetAt)
 }
 
+func TestAccountTestService_OpenAIAPIKey502MarksTempUnschedulable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, recorder := newTestContext()
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{
+		responses: []*http.Response{
+			newJSONResponse(http.StatusBadGateway, `{"error":{"message":"Upstream service temporarily unavailable","type":"upstream_error"}}`),
+		},
+	}
+	rateLimitSvc := &RateLimitService{accountRepo: repo}
+	svc := &AccountTestService{
+		accountRepo:      repo,
+		httpUpstream:     upstream,
+		cfg:              &config.Config{},
+		rateLimitService: rateLimitSvc,
+	}
+	account := &Account{
+		ID:          91,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":                    "test-key",
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []any{
+				map[string]any{
+					"error_code":       502,
+					"duration_minutes": 30,
+					"keywords":         []any{"bad gateway", "upstream", "gateway"},
+					"description":      "网关错误，临时停止调度",
+				},
+			},
+		},
+	}
+	repo.accountsByID = map[int64]*Account{
+		account.ID: account,
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.3-codex", "", "")
+	require.Error(t, err)
+	require.Equal(t, account.ID, repo.tempUnschedID)
+	require.NotNil(t, repo.tempUnschedUntil)
+	require.Contains(t, repo.tempUnschedReason, `"status_code":502`)
+	require.Contains(t, repo.tempUnschedReason, `"matched_keyword":"upstream"`)
+	require.Contains(t, recorder.Body.String(), `API returned 502`)
+	require.Zero(t, repo.setErrorID)
+}
+
+func TestAccountTestService_OpenAI429WithTempUnschedRuleAlsoPersistsRateLimitState(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusTooManyRequests, `{"error":{"type":"usage_limit_reached","message":"limit reached","resets_at":"1777283883"}}`)
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	rateLimitSvc := &RateLimitService{accountRepo: repo}
+	svc := &AccountTestService{
+		accountRepo:      repo,
+		httpUpstream:     upstream,
+		cfg:              &config.Config{},
+		rateLimitService: rateLimitSvc,
+	}
+	account := &Account{
+		ID:           92,
+		Platform:     PlatformOpenAI,
+		Type:         AccountTypeAPIKey,
+		Status:       StatusError,
+		ErrorMessage: "stale 403",
+		Concurrency:  1,
+		Credentials: map[string]any{
+			"api_key":                    "test-key",
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []any{
+				map[string]any{
+					"error_code":       429,
+					"duration_minutes": 30,
+					"keywords":         []any{"limit reached", "usage_limit_reached"},
+					"description":      "限流，临时停止调度",
+				},
+			},
+		},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.3-codex", "", "")
+	require.Error(t, err)
+	require.Equal(t, account.ID, repo.tempUnschedID)
+	require.NotNil(t, repo.tempUnschedUntil)
+	require.Equal(t, account.ID, repo.rateLimitedID)
+	require.NotNil(t, repo.rateLimitedAt)
+	require.Equal(t, account.ID, repo.clearedErrorID)
+	require.Equal(t, StatusActive, account.Status)
+	require.Empty(t, account.ErrorMessage)
+	require.NotNil(t, account.RateLimitResetAt)
+	require.Zero(t, repo.setErrorID)
+}
+
 func TestAccountTestService_OpenAI429BodyOnlyPersistsRateLimitAndClearsStaleError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := newTestContext()
@@ -272,7 +389,7 @@ func TestAccountTestService_OpenAI429WithoutResetSignalDoesNotMutateRuntimeState
 	require.Nil(t, account.RateLimitResetAt)
 }
 
-func TestAccountTestService_OpenAI401SetsPermanentErrorOnly(t *testing.T) {
+func TestAccountTestService_OpenAIOAuth401SetsTempUnschedulableAndForcesRefresh(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := newTestContext()
 
@@ -280,7 +397,10 @@ func TestAccountTestService_OpenAI401SetsPermanentErrorOnly(t *testing.T) {
 
 	repo := &openAIAccountTestRepo{}
 	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
-	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream}
+	rateLimitSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	invalidator := &tokenCacheInvalidatorRecorder{}
+	rateLimitSvc.SetTokenCacheInvalidator(invalidator)
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream, rateLimitService: rateLimitSvc}
 	account := &Account{
 		ID:          80,
 		Platform:    PlatformOpenAI,
@@ -292,8 +412,41 @@ func TestAccountTestService_OpenAI401SetsPermanentErrorOnly(t *testing.T) {
 
 	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4", "", "")
 	require.Error(t, err)
+	require.Equal(t, account.ID, repo.tempUnschedID)
+	require.NotNil(t, repo.tempUnschedUntil)
+	require.Zero(t, repo.setErrorID)
+	require.Equal(t, 1, repo.updateCredentialsCalls)
+	require.NotEmpty(t, repo.lastCredentials["expires_at"])
+	require.Len(t, invalidator.accounts, 1)
+	require.Same(t, account, invalidator.accounts[0])
+	require.Zero(t, repo.rateLimitedID)
+	require.Zero(t, repo.clearedErrorID)
+	require.Nil(t, account.RateLimitResetAt)
+}
+
+func TestAccountTestService_OpenAIAPIKey401SetsPermanentErrorOnly(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusUnauthorized, `{"error":"bad key"}`)
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream, cfg: &config.Config{}}
+	account := &Account{
+		ID:          81,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "test-key"},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "gpt-5.4", "", "")
+	require.Error(t, err)
 	require.Equal(t, account.ID, repo.setErrorID)
 	require.Contains(t, repo.setErrorMsg, "Authentication failed (401)")
+	require.Zero(t, repo.tempUnschedID)
 	require.Zero(t, repo.rateLimitedID)
 	require.Zero(t, repo.clearedErrorID)
 	require.Nil(t, account.RateLimitResetAt)

--- a/backend/internal/service/error_policy_test.go
+++ b/backend/internal/service/error_policy_test.go
@@ -242,6 +242,39 @@ func TestHandleUpstreamError_PoolModeCustomErrorCodesOverride(t *testing.T) {
 		require.Equal(t, 0, repo.tempCalls)
 	})
 
+	t.Run("pool_mode_without_custom_error_codes_still_applies_temp_unsched_rules", func(t *testing.T) {
+		repo := &errorPolicyRepoStub{}
+		svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		account := &Account{
+			ID:       32,
+			Type:     AccountTypeAPIKey,
+			Platform: PlatformOpenAI,
+			Credentials: map[string]any{
+				"pool_mode":                  true,
+				"temp_unschedulable_enabled": true,
+				"temp_unschedulable_rules": []any{
+					map[string]any{
+						"error_code":       float64(502),
+						"keywords":         []any{"temporarily unavailable"},
+						"duration_minutes": float64(10),
+					},
+				},
+			},
+		}
+
+		shouldDisable := svc.HandleUpstreamError(
+			context.Background(),
+			account,
+			http.StatusBadGateway,
+			http.Header{},
+			[]byte(`{"error":{"message":"Upstream service temporarily unavailable"}}`),
+		)
+
+		require.True(t, shouldDisable)
+		require.Equal(t, 0, repo.setErrCalls)
+		require.Equal(t, 1, repo.tempCalls)
+	})
+
 	t.Run("pool_mode_with_custom_error_codes_uses_local_error_policy", func(t *testing.T) {
 		repo := &errorPolicyRepoStub{}
 		svc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -128,7 +128,11 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
 	// 池模式默认不标记本地账号状态；仅当用户显式配置自定义错误码时按本地策略处理。
+	// 但临时不可调度规则属于显式熔断配置，应在池模式早退前先尝试匹配。
 	if account.IsPoolMode() && !customErrorCodesEnabled {
+		if s.tryTempUnschedulable(ctx, account, statusCode, responseBody) {
+			return true
+		}
 		slog.Info("pool_mode_error_skipped", "account_id", account.ID, "status_code", statusCode)
 		return false
 	}

--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -261,6 +261,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'close'): void
+  (e: 'updated', account: Account): void
 }>()
 
 const terminalRef = ref<HTMLElement | null>(null)
@@ -361,6 +362,15 @@ const resetState = () => {
   previewImageUrl.value = ''
 }
 
+const syncLatestAccountState = async (accountId: number) => {
+  try {
+    const latestAccount = await adminAPI.accounts.getById(accountId)
+    emit('updated', latestAccount)
+  } catch (error) {
+    console.error('Failed to sync latest account state after test:', error)
+  }
+}
+
 const handleClose = () => {
   abortStream()
   emit('close')
@@ -387,6 +397,7 @@ const scrollToBottom = async () => {
 
 const startTest = async () => {
   if (!props.account || !selectedModelId.value) return
+  const testedAccountId = props.account.id
 
   resetState()
   status.value = 'connecting'
@@ -397,10 +408,11 @@ const startTest = async () => {
   abortStream()
 
   abortController = new AbortController()
+  let shouldSyncLatestState = false
 
   try {
     // Create EventSource for SSE
-    const url = `/api/v1/admin/accounts/${props.account.id}/test`
+    const url = `/api/v1/admin/accounts/${testedAccountId}/test`
 
     // Use fetch with streaming for SSE since EventSource doesn't support POST
     const response = await fetch(url, {
@@ -450,6 +462,7 @@ const startTest = async () => {
         }
       }
     }
+    shouldSyncLatestState = true
   } catch (error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
       status.value = 'idle'
@@ -459,6 +472,12 @@ const startTest = async () => {
     const msg = error instanceof Error ? error.message : 'Unknown error'
     errorMessage.value = msg
     addLine(`Error: ${msg}`, 'text-red-400')
+    shouldSyncLatestState = true
+  } finally {
+    abortController = null
+    if (shouldSyncLatestState) {
+      await syncLatestAccountState(testedAccountId)
+    }
   }
 }
 

--- a/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
@@ -2,15 +2,17 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import AccountTestModal from '../AccountTestModal.vue'
 
-const { getAvailableModels, copyToClipboard } = vi.hoisted(() => ({
+const { getAvailableModels, getById, copyToClipboard } = vi.hoisted(() => ({
   getAvailableModels: vi.fn(),
+  getById: vi.fn(),
   copyToClipboard: vi.fn()
 }))
 
 vi.mock('@/api/admin', () => ({
   adminAPI: {
     accounts: {
-      getAvailableModels
+      getAvailableModels,
+      getById
     }
   }
 }))
@@ -59,6 +61,26 @@ function createStreamResponse(lines: string[]) {
   } as Response
 }
 
+function createDeferredStreamResponse() {
+  let resolveRead: ((value: { done: boolean, value?: Uint8Array }) => void) | null = null
+
+  return {
+    response: {
+      ok: true,
+      body: {
+        getReader: () => ({
+          read: vi.fn().mockImplementation(() => new Promise((resolve) => {
+            resolveRead = resolve
+          }))
+        })
+      }
+    } as Response,
+    finish() {
+      resolveRead?.({ done: true, value: undefined })
+    }
+  }
+}
+
 function mountModal() {
   return mount(AccountTestModal, {
     props: {
@@ -93,6 +115,13 @@ describe('AccountTestModal', () => {
       { id: 'gemini-2.5-flash-image', display_name: 'Gemini 2.5 Flash Image' },
       { id: 'gemini-3.1-flash-image', display_name: 'Gemini 3.1 Flash Image' }
     ])
+    getById.mockResolvedValue({
+      id: 42,
+      name: 'Gemini Image Test',
+      platform: 'gemini',
+      type: 'apikey',
+      status: 'active'
+    })
     copyToClipboard.mockReset()
     Object.defineProperty(globalThis, 'localStorage', {
       value: {
@@ -143,5 +172,66 @@ describe('AccountTestModal', () => {
     const preview = wrapper.find('img[alt="test-image-1"]')
     expect(preview.exists()).toBe(true)
     expect(preview.attributes('src')).toBe('data:image/png;base64,QUJD')
+  })
+
+  it('测试结束后会回传最新账号状态', async () => {
+    const updatedAccount = {
+      id: 42,
+      name: 'Gemini Image Test',
+      platform: 'gemini',
+      type: 'apikey',
+      status: 'active',
+      temp_unschedulable_until: '2026-04-29T12:00:00Z'
+    }
+    getById.mockResolvedValue(updatedAccount)
+
+    const wrapper = mountModal()
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const startButton = buttons.find((button) => button.text().includes('admin.accounts.startTest'))
+    expect(startButton).toBeTruthy()
+
+    await startButton!.trigger('click')
+    await flushPromises()
+    await flushPromises()
+
+    expect(getById).toHaveBeenCalledWith(42)
+    expect(wrapper.emitted('updated')?.[0]).toEqual([updatedAccount])
+  })
+
+  it('测试过程中切换账号后仍会同步原始测试账号状态', async () => {
+    const deferred = createDeferredStreamResponse()
+    ;(global.fetch as any).mockResolvedValueOnce(deferred.response)
+
+    const wrapper = mountModal()
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    const buttons = wrapper.findAll('button')
+    const startButton = buttons.find((button) => button.text().includes('admin.accounts.startTest'))
+    expect(startButton).toBeTruthy()
+
+    const clickPromise = startButton!.trigger('click')
+    await flushPromises()
+
+    await wrapper.setProps({
+      account: {
+        id: 99,
+        name: 'Other Account',
+        platform: 'gemini',
+        type: 'apikey',
+        status: 'active'
+      } as any
+    })
+
+    deferred.finish()
+    await clickPromise
+    await flushPromises()
+    await flushPromises()
+
+    expect(getById).toHaveBeenCalledWith(42)
+    expect(getById).not.toHaveBeenCalledWith(99)
   })
 })

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -297,7 +297,7 @@
     <CreateAccountModal :show="showCreate" :proxies="proxies" :groups="groups" @close="showCreate = false" @created="reload" />
     <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
     <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
-    <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
+    <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" @updated="handleAccountUpdated" />
     <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />
     <ScheduledTestsPanel :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
     <AccountActionMenu :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" />
@@ -801,6 +801,7 @@ const shouldReplaceAutoRefreshRow = (current: Account, next: Account) => {
 const syncAccountRefs = (nextAccount: Account) => {
   if (edAcc.value?.id === nextAccount.id) edAcc.value = nextAccount
   if (reAuthAcc.value?.id === nextAccount.id) reAuthAcc.value = nextAccount
+  if (testingAcc.value?.id === nextAccount.id) testingAcc.value = nextAccount
   if (tempUnschedAcc.value?.id === nextAccount.id) tempUnschedAcc.value = nextAccount
   if (deletingAcc.value?.id === nextAccount.id) deletingAcc.value = nextAccount
   if (menu.acc?.id === nextAccount.id) menu.acc = nextAccount


### PR DESCRIPTION
## 背景概述

- 在使用中转站套娃中转站的时候发现：中转站在 池模式+临时不可调度规则 设置下，会出现返回 502 但是不进入临时不可调度的问题。
- 使用账号测试连接也不会更新相关状态
- 了解后发现是池模式判断覆盖了临时不可调度规则，导致其不再被命中。调用会先走池模式早退分支，旧行为会直接打出 pool_mode_error_skipped，导致 502 根本来不及匹配临时不可调度规则。

## 变更概述

这个 PR 修复了账号测试与调度相关的 3 个问题：

1. 在 rate limit 的池模式调度中，改为先判断临时不可调度规则，避免临时不可调度规则不生效。
2. 同步账号测试的错误状态处理逻辑。
3. 管理端执行账号测试后，立即刷新被测试账号状态，保证弹窗和列表展示的是最新结果。

## 具体改动

### 后端
- 调整账号相关测试流程的错误状态处理。
- 修复池模式下 rate limit 调度未正确处理临时不可调度规则的问题。
- 根据后端注入变更更新 `wire_gen.go`。
- 补充/更新账号测试与错误策略相关测试。

### 前端
- 管理端账号测试完成后，立即刷新对应账号状态。
- 更新管理端账号测试相关前端测试。

## 涉及文件

- `backend/internal/service/account_test_service.go`
- `backend/internal/service/account_test_service_openai_test.go`
- `backend/internal/service/error_policy_test.go`
- `backend/internal/service/ratelimit_service.go`
- `backend/cmd/server/wire_gen.go`
- `frontend/src/components/admin/account/AccountTestModal.vue`
- `frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts`
- `frontend/src/views/admin/AccountsView.vue`

## 本地验证情况

已通过：
- `pnpm install --frozen-lockfile`
- `pnpm run lint:check`
- `pnpm run typecheck`
- workflow 中的前端 critical vitest 用例
- `pnpm exec vitest run src/components/admin/account/__tests__/AccountTestModal.spec.ts`
- `golangci-lint run ./...`
- `govulncheck ./...`
- `python tools/check_pnpm_audit_exceptions.py --audit frontend/audit.json --exceptions .github/audit-exceptions.yml`

本地存在的非本次改动引入失败：
- `go test -tags=unit ./...`
- `go test -tags=integration ./...`

当前失败点主要位于：
- `backend/internal/config` 相关测试
- integration 路径已有的 `go.sum` / testcontainers 依赖问题

这些失败与本 PR 修改文件无直接关系。

## 说明

- 本次未修改 `package.json` 和 `pnpm-lock.yaml`
- 本次未涉及 Ent schema 变更
