### PR TITLE
fix: support compressed request bodies in body reader

### DIFF
--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -120,6 +122,26 @@ func TestReadRequestBodyWithPrealloc(t *testing.T) {
 	body, err := pkghttputil.ReadRequestBodyWithPrealloc(req)
 	require.NoError(t, err)
 	require.Equal(t, payload, string(body))
+}
+
+func TestReadRequestBodyWithPrealloc_Zstd(t *testing.T) {
+	payload := `{"model":"gpt-5","input":"hello"}`
+	var compressed bytes.Buffer
+	encoder, err := zstd.NewWriter(&compressed)
+	require.NoError(t, err)
+	_, err = encoder.Write([]byte(payload))
+	require.NoError(t, err)
+	require.NoError(t, encoder.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", &compressed)
+	req.Header.Set("Content-Encoding", "zstd")
+	req.ContentLength = int64(compressed.Len())
+
+	body, err := pkghttputil.ReadRequestBodyWithPrealloc(req)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(body))
+	require.Empty(t, req.Header.Get("Content-Encoding"))
+	require.Equal(t, int64(-1), req.ContentLength)
 }
 
 func TestReadRequestBodyWithPrealloc_MaxBytesError(t *testing.T) {

--- a/backend/internal/pkg/httputil/body.go
+++ b/backend/internal/pkg/httputil/body.go
@@ -2,8 +2,13 @@ package httputil
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"net/http"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 )
 
 const (
@@ -15,6 +20,19 @@ const (
 func ReadRequestBodyWithPrealloc(req *http.Request) ([]byte, error) {
 	if req == nil || req.Body == nil {
 		return nil, nil
+	}
+
+	bodyReader := req.Body
+	contentEncoding := strings.ToLower(strings.TrimSpace(req.Header.Get("Content-Encoding")))
+	if contentEncoding != "" && contentEncoding != "identity" {
+		var err error
+		bodyReader, err = decodeRequestBodyReader(req.Body, contentEncoding)
+		if err != nil {
+			return nil, err
+		}
+		defer bodyReader.Close()
+		req.Header.Del("Content-Encoding")
+		req.ContentLength = -1
 	}
 
 	capHint := requestBodyReadInitCap
@@ -30,8 +48,34 @@ func ReadRequestBodyWithPrealloc(req *http.Request) ([]byte, error) {
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, capHint))
-	if _, err := io.Copy(buf, req.Body); err != nil {
+	if _, err := io.Copy(buf, bodyReader); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func decodeRequestBodyReader(body io.ReadCloser, contentEncoding string) (io.ReadCloser, error) {
+	switch contentEncoding {
+	case "gzip":
+		return gzip.NewReader(body)
+	case "br":
+		return io.NopCloser(brotli.NewReader(body)), nil
+	case "zstd":
+		reader, err := zstd.NewReader(body)
+		if err != nil {
+			return nil, err
+		}
+		return &zstdReadCloser{Decoder: reader}, nil
+	default:
+		return body, nil
+	}
+}
+
+type zstdReadCloser struct {
+	*zstd.Decoder
+}
+
+func (r *zstdReadCloser) Close() error {
+	r.Decoder.Close()
+	return nil
 }


### PR DESCRIPTION
## Summary
- decode compressed request bodies before JSON validation
- support gzip, br and zstd in the shared body reader
- add regression coverage for zstd-compressed /v1/responses requests

## 背景
在 OpenAI 兼容接口场景下，部分客户端会对请求体添加 `Content-Encoding: zstd`。
当前实现里，请求在进入 JSON 校验前会直接读取原始 `Request.Body`，没有先按 `Content-Encoding` 解压，因此压缩后的二进制内容会被直接当成 JSON 校验，最终返回类似 `Failed to parse request body` 的错误。

这个问题在 `/v1/responses` 路由上比较容易复现，因为该链路会较早读取请求体并做 JSON 有效性检查。

## 变更说明
- 在共享的 request body 读取工具中统一处理压缩请求体，而不是只在单一路由做特判
- 新增对以下编码的解压支持：
  - `gzip`
  - `br`
  - `zstd`
- 解压后会清理 `Content-Encoding` 请求头，并将 `Content-Length` 重置为 `-1`，避免后续逻辑继续按压缩态处理
- 补充 zstd 回归测试，覆盖压缩后的 `/v1/responses` 请求体读取场景

## 为什么这样改
把解压逻辑放在共享 body reader 里，能覆盖所有复用该读取入口的 handler，避免只修 `/v1/responses` 后，其他需要先读 body 的接口再次踩到同类问题。

## Testing
- go test ./internal/handler -run TestReadRequestBodyWithPrealloc -count=1 -v
