### PR TITLE
feat(deploy): add Helm Kubernetes deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ docs/*
 frontend/coverage/
 aicodex
 output/
+
+# Helm dependency archives are fetched from Chart.lock during deploy.
+deploy/helm/sub2api/charts/

--- a/deploy/.gitignore
+++ b/deploy/.gitignore
@@ -9,6 +9,9 @@ redis_data/
 
 # Environment configuration (contains sensitive information)
 .env
+helm-values.yaml
+helm-values.*.yaml
+!helm-values.simple.yaml
 
 # Backup files
 *.backup

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,12 +1,13 @@
 # Sub2API Deployment Files
 
-This directory contains files for deploying Sub2API on Linux servers.
+This directory contains files for deploying Sub2API on Linux servers and Kubernetes clusters.
 
 ## Deployment Methods
 
 | Method | Best For | Setup Wizard |
 |--------|----------|--------------|
 | **Docker Compose** | Quick setup, all-in-one | Not needed (auto-setup) |
+| **Helm / Kubernetes** | Kubernetes clusters | Not needed (auto-setup) |
 | **Binary Install** | Production servers, systemd | Web-based wizard |
 
 ## Files
@@ -16,6 +17,9 @@ This directory contains files for deploying Sub2API on Linux servers.
 | `docker-compose.yml` | Docker Compose configuration (named volumes) |
 | `docker-compose.local.yml` | Docker Compose configuration (local directories, easy migration) |
 | `docker-deploy.sh` | **One-click Docker deployment script (recommended)** |
+| `helm/sub2api/` | Helm chart for Kubernetes deployment |
+| `helm-values.simple.yaml` | Simple Helm values override file |
+| `helm-deploy.sh` | Simple Helm deployment script |
 | `.env.example` | Docker environment variables template |
 | `DOCKER.md` | Docker Hub documentation |
 | `install.sh` | One-click binary installation script |
@@ -246,6 +250,377 @@ docker compose -f docker-compose.local.yml up -d
 ```
 
 Your entire deployment (configuration + data) is migrated!
+
+---
+
+## Helm / Kubernetes Deployment
+
+Use the first-party Helm chart when deploying Sub2API to Kubernetes. The chart defaults mirror the Docker Compose setup:
+
+- Sub2API image: `weishaw/sub2api:latest`
+- Bundled PostgreSQL: Bitnami PostgreSQL subchart, rendered as a StatefulSet
+- Bundled Redis: Bitnami Redis subchart, rendered as a StatefulSet
+- `AUTO_SETUP=true`
+- Persistent volumes for Sub2API data, PostgreSQL data, and Redis data
+- `/health` probes for the application
+
+The `postgresql:` and `redis:` values are native upstream Bitnami chart values, so operators can extend them for replication, Redis Sentinel, metrics, resources, scheduling, or other Bitnami-supported options. The Sub2API chart only adds small `connection` override blocks for cases where the application must connect to a non-default service or secret.
+
+When bundled PostgreSQL or Redis are enabled, Sub2API connects through Kubernetes Service DNS such as `sub2api-postgresql.sub2api.svc.cluster.local`. Startup also includes an init container that waits for PostgreSQL and Redis ports before the Sub2API container starts, avoiding first-boot crashes while the dependency StatefulSets are still becoming ready.
+
+For non-default dependency topologies, keep the upstream options under the same keys:
+
+```yaml
+postgresql:
+  architecture: replication
+  readReplicas:
+    replicaCount: 2
+
+redis:
+  architecture: replication
+  replica:
+    replicaCount: 2
+```
+
+If a topology exposes a different service or secret than the chart defaults, set `postgresql.connection.*` or `redis.connection.*` so the Sub2API application uses the correct endpoint. For Redis Sentinel, Bitnami requires `redis.architecture=replication` and can optionally expose a master-only service with `redis.sentinel.masterService.enabled=true` plus its documented RBAC/serviceAccount settings.
+
+Dependency waiting can be tuned or disabled:
+
+```yaml
+waitForDependencies:
+  enabled: true
+  timeoutSeconds: 300
+  intervalSeconds: 2
+  image:
+    repository: busybox
+    tag: "1.36"
+```
+
+### Install
+
+Use the helper script to start Sub2API with the simple Helm values file:
+
+```bash
+cd deploy
+chmod +x helm-deploy.sh
+./helm-deploy.sh
+```
+
+It runs:
+
+```bash
+helm upgrade --install sub2api ./helm/sub2api \
+  --dependency-update \
+  --namespace sub2api \
+  --create-namespace \
+  -f ./helm-values.simple.yaml
+```
+
+Manual install is also supported:
+
+```bash
+# From the repository root
+helm upgrade --install sub2api deploy/helm/sub2api \
+  --namespace sub2api --create-namespace \
+  --dependency-update \
+  -f deploy/helm-values.simple.yaml
+
+# Local access without ingress
+kubectl -n sub2api port-forward svc/sub2api 8080:8080
+```
+
+Open `http://127.0.0.1:8080`.
+
+The chart creates stable secrets by default. To read the generated admin password:
+
+```bash
+kubectl -n sub2api get secret sub2api-app \
+  -o jsonpath='{.data.admin-password}' | base64 -d
+```
+
+### Recommended Production Values
+
+Use `deploy/helm-values.simple.yaml` as a small override file instead of editing the full chart `values.yaml`. For production, copy it to a private values file and set fixed credentials before first install:
+
+```yaml
+global:
+  imageRegistry: "registry.example.com/mirror"
+  defaultStorageClass: "fast-storage"
+  security:
+    allowInsecureImages: true
+
+secrets:
+  app:
+    jwtSecret: "replace-with-output-of-openssl-rand-hex-32"
+    totpEncryptionKey: "replace-with-output-of-openssl-rand-hex-32"
+    adminPassword: "replace-with-a-strong-password"
+postgresql:
+  auth:
+    password: "replace-with-a-strong-postgres-password"
+redis:
+  auth:
+    password: "replace-with-a-strong-redis-password"
+```
+
+If you keep PostgreSQL or Redis PVCs across `helm uninstall` and reinstall, these fixed passwords are required. Bitnami stores database/cache credentials in the retained data directories; a new random password generated during reinstall will not match the existing data.
+
+`global.imageRegistry` is passed to the Bitnami PostgreSQL/Redis subcharts and is also used by the Sub2API image unless `image.registry` is set. Bitnami charts block unrecognized mirrored images unless `global.security.allowInsecureImages=true` is set. If your mirror rewrites image names, set the upstream image fields directly:
+
+```yaml
+image:
+  registry: crpi-dgkl9khr1943eg60.cn-hangzhou.personal.cr.aliyuncs.com
+  repository: hq-docker-mirror/weishaw-sub2api
+
+postgresql:
+  image:
+    registry: crpi-dgkl9khr1943eg60.cn-hangzhou.personal.cr.aliyuncs.com
+    repository: hq-docker-mirror/bitnami-postgresql
+    tag: latest
+
+redis:
+  image:
+    registry: crpi-dgkl9khr1943eg60.cn-hangzhou.personal.cr.aliyuncs.com
+    repository: hq-docker-mirror/bitnami-redis
+    tag: latest
+```
+
+Then install or upgrade with:
+
+```bash
+helm upgrade --install sub2api deploy/helm/sub2api \
+  --namespace sub2api --create-namespace \
+  -f deploy/helm-values.production.yaml
+```
+
+### Existing Secrets
+
+If your platform manages secrets separately, point the chart at existing Kubernetes secrets:
+
+```yaml
+secrets:
+  app:
+    existingSecret: sub2api-app-secret
+postgresql:
+  auth:
+    existingSecret: sub2api-postgres-secret
+    secretKeys:
+      userPasswordKey: password
+      adminPasswordKey: postgres-password
+redis:
+  auth:
+    existingSecret: sub2api-redis-secret
+    existingSecretPasswordKey: redis-password
+```
+
+For bundled Bitnami PostgreSQL/Redis, do not put these two secrets under
+`secrets.postgresql.existingSecret` or `secrets.redis.existingSecret`. Those
+legacy keys are only for external PostgreSQL/Redis fallback secrets when the
+bundled dependency is disabled.
+
+Create the secrets before installing the chart:
+
+```bash
+kubectl create namespace sub2api --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl -n sub2api create secret generic sub2api-app-secret \
+  --from-literal=jwt-secret="$(openssl rand -hex 32)" \
+  --from-literal=totp-encryption-key="$(openssl rand -hex 32)" \
+  --from-literal=admin-password='replace-with-a-strong-admin-password'
+
+kubectl -n sub2api create secret generic sub2api-postgres-secret \
+  --from-literal=password='replace-with-a-strong-postgres-password' \
+  --from-literal=postgres-password='replace-with-a-strong-postgres-admin-password'
+
+kubectl -n sub2api create secret generic sub2api-redis-secret \
+  --from-literal=redis-password='replace-with-a-strong-redis-password'
+```
+
+The manually created secrets are not owned by the Helm release, so `helm uninstall`
+will not delete them. This is the recommended production pattern when PVCs are
+retained across uninstall/reinstall, because the retained PostgreSQL/Redis data
+must keep using the same passwords.
+
+Required keys:
+
+| Secret | Required Keys |
+|--------|---------------|
+| `secrets.app.existingSecret` | `jwt-secret`, `totp-encryption-key`, `admin-password` |
+| `postgresql.auth.existingSecret` | `password` by default, or `postgresql.auth.secretKeys.userPasswordKey` |
+| `redis.auth.existingSecret` | `redis-password` by default, or `redis.auth.existingSecretPasswordKey` |
+
+For external PostgreSQL or Redis, the legacy `secrets.postgresql.existingSecret` and `secrets.redis.existingSecret` keys are still supported as fallback secrets.
+
+For bundled PostgreSQL/Redis, prefer either fixed `postgresql.auth.password` / `redis.auth.password` values or upstream Bitnami `existingSecret` settings before the first production install.
+
+If you use `postgresql.auth.existingSecret` or `redis.auth.existingSecret`, keep those secrets when retaining PVCs.
+
+### Mihomo Sidecar Proxy
+
+For clusters that need outbound proxy access, the chart can run a mihomo
+sidecar in the same Pod as Sub2API. This recommended mode does not use TUN and
+does not inject `HTTP_PROXY` or `HTTPS_PROXY`.
+
+Create a Kubernetes Secret that contains `config.yaml`:
+
+```bash
+kubectl -n sub2api create secret generic sub2api-mihomo-config \
+  --from-file=config.yaml=./mihomo-config.yaml
+```
+
+Recommended mihomo listener settings:
+
+```yaml
+mixed-port: 7890
+allow-lan: false
+bind-address: 127.0.0.1
+external-controller: 127.0.0.1:9090
+```
+
+Enable the sidecar:
+
+```yaml
+mihomo:
+  enabled: true
+  config:
+    existingSecret: sub2api-mihomo-config
+    key: config.yaml
+```
+
+For Sub2API's built-in external downloads, set `app.update.proxyURL` to the
+local mihomo listener. This is used by GitHub release checks and remote pricing
+data downloads, including the model pricing list fetched from GitHub:
+
+```yaml
+app:
+  update:
+    proxyURL: http://127.0.0.1:7890
+```
+
+For provider/account traffic, add a proxy in the Sub2API admin UI and assign it
+to the accounts or providers that need overseas access:
+
+```text
+protocol: http
+host: 127.0.0.1
+port: 7890
+```
+
+If using SOCKS mode, use `socks5h` in Sub2API so DNS is resolved through the
+proxy. Keep mihomo subscription URLs and node credentials in the Secret, not in
+Helm values.
+
+TUN mode is usually unnecessary for this deployment. If you enable TUN in a
+custom mihomo config, the Pod also needs cluster-specific permissions and
+devices such as `/dev/net/tun` and `NET_ADMIN`; without them mihomo can start
+the mixed proxy but fail the TUN listener.
+
+### External PostgreSQL and Redis
+
+Disable bundled services when using managed databases or shared cluster services:
+
+```yaml
+postgresql:
+  enabled: false
+externalPostgresql:
+  host: postgres.example.internal
+  port: 5432
+  username: sub2api
+  password: "replace-with-postgres-password"
+  database: sub2api
+  sslMode: require
+
+redis:
+  enabled: false
+externalRedis:
+  host: redis.example.internal
+  port: 6379
+  password: "replace-with-redis-password"
+```
+
+### Ingress
+
+Ingress is disabled by default and does not assume a specific controller:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: sub2api.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: sub2api-tls
+      hosts:
+        - sub2api.example.com
+```
+
+### Persistence
+
+PVCs are enabled by default:
+
+```yaml
+global:
+  defaultStorageClass: fast-storage
+persistence:
+  size: 10Gi
+postgresql:
+  primary:
+    persistence:
+      size: 20Gi
+redis:
+  master:
+    persistence:
+      size: 8Gi
+```
+
+To use an existing claim:
+
+```yaml
+persistence:
+  existingClaim: sub2api-data
+```
+
+To run with ephemeral storage for testing only:
+
+```yaml
+persistence:
+  enabled: false
+postgresql:
+  primary:
+    persistence:
+      enabled: false
+redis:
+  master:
+    persistence:
+      enabled: false
+```
+
+> Warning: disabling persistence uses `emptyDir`; data will not survive pod rescheduling.
+
+### Upgrade and Uninstall
+
+```bash
+# Upgrade
+helm upgrade sub2api deploy/helm/sub2api -n sub2api --dependency-update -f deploy/helm-values.simple.yaml
+
+# Uninstall release
+helm uninstall sub2api -n sub2api
+
+# Remove PVCs only if you intentionally want to delete stored data
+kubectl -n sub2api delete pvc -l app.kubernetes.io/instance=sub2api
+```
+
+If you uninstall but keep PVCs, reinstall with the same `postgresql.auth.password` and `redis.auth.password` values. If an older release used random generated passwords and the Bitnami secrets were deleted, you must recover the original passwords or reset them inside the retained PostgreSQL/Redis data before reinstalling.
+
+### Helm Validation
+
+```bash
+helm dependency update deploy/helm/sub2api
+helm lint deploy/helm/sub2api
+helm template sub2api deploy/helm/sub2api
+```
 
 ---
 

--- a/deploy/helm-deploy.sh
+++ b/deploy/helm-deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+helm upgrade --install sub2api "${SCRIPT_DIR}/helm/sub2api" \
+  --dependency-update \
+  --namespace sub2api \
+  --create-namespace \
+  -f "${SCRIPT_DIR}/helm-values.simple.yaml"

--- a/deploy/helm-values.simple.yaml
+++ b/deploy/helm-values.simple.yaml
@@ -1,0 +1,61 @@
+# Simple values for deploy/helm/sub2api.
+# This file is intentionally small. Full defaults live in
+# deploy/helm/sub2api/values.yaml.
+
+global:
+  imageRegistry: ""
+  defaultStorageClass: ""
+  security:
+    allowInsecureImages: false
+
+image:
+  repository: weishaw/sub2api
+  tag: latest
+
+waitForDependencies:
+  enabled: true
+  timeoutSeconds: 300
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: false
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+app:
+  runMode: standard
+  timezone: Asia/Shanghai
+  adminEmail: admin@sub2api.local
+  update:
+    # Set to http://127.0.0.1:7890 when mihomo sidecar is enabled and the
+    # cluster needs proxy access for GitHub release checks or pricing downloads.
+    proxyURL: ""
+
+postgresql:
+  enabled: true
+  primary:
+    persistence:
+      enabled: true
+      size: 20Gi
+
+redis:
+  enabled: true
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+
+# Optional mihomo sidecar. It exposes a local proxy inside the Sub2API Pod.
+# For Sub2API's built-in GitHub/pricing downloads, also set:
+# app.update.proxyURL: http://127.0.0.1:7890
+# For provider/account traffic, configure Sub2API's in-app proxy after install.
+mihomo:
+  enabled: false
+  config:
+    existingSecret: ""
+    key: config.yaml

--- a/deploy/helm/sub2api/Chart.lock
+++ b/deploy/helm/sub2api/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 18.6.2
+- name: redis
+  repository: https://charts.bitnami.com/bitnami
+  version: 25.4.1
+digest: sha256:2592638572492855b1a8438d5fb0da7b8b9417dbc00c6dcb75716b670905659d
+generated: "2026-04-29T14:01:04.7458986+08:00"

--- a/deploy/helm/sub2api/Chart.yaml
+++ b/deploy/helm/sub2api/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: sub2api
+description: A Helm chart for deploying Sub2API on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+dependencies:
+  - name: postgresql
+    version: 18.6.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: postgresql.enabled
+  - name: redis
+    version: 25.4.1
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+home: https://github.com/Wei-Shaw/sub2api
+sources:
+  - https://github.com/Wei-Shaw/sub2api
+maintainers:
+  - name: Wei-Shaw
+    url: https://github.com/Wei-Shaw

--- a/deploy/helm/sub2api/templates/NOTES.txt
+++ b/deploy/helm/sub2api/templates/NOTES.txt
@@ -1,0 +1,34 @@
+Sub2API has been deployed.
+
+Service:
+  {{ include "sub2api.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+{{- if .Values.ingress.enabled }}
+Ingress:
+{{- range .Values.ingress.hosts }}
+{{- $host := .host }}
+{{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ .path }}
+{{- end }}
+{{- end }}
+{{- else }}
+Port-forward for local access:
+  kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "sub2api.fullname" . }} 8080:{{ .Values.service.port }}
+
+Then open:
+  http://127.0.0.1:8080
+{{- end }}
+
+Admin credentials:
+  Email: {{ .Values.app.adminEmail }}
+{{- if .Values.secrets.app.existingSecret }}
+  Password: read the admin-password key from existing secret {{ .Values.secrets.app.existingSecret }}.
+{{- else if .Values.secrets.app.generateAdminPassword }}
+  Password: kubectl -n {{ .Release.Namespace }} get secret {{ include "sub2api.appSecretName" . }} -o jsonpath='{.data.admin-password}' | base64 -d
+{{- else }}
+  Password: check startup logs if ADMIN_PASSWORD was intentionally left empty:
+    kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "sub2api.fullname" . }} | grep "admin password"
+{{- end }}
+
+Upgrade:
+  helm upgrade {{ .Release.Name }} {{ .Chart.Name }} -n {{ .Release.Namespace }} -f values.yaml

--- a/deploy/helm/sub2api/templates/_helpers.tpl
+++ b/deploy/helm/sub2api/templates/_helpers.tpl
@@ -1,0 +1,264 @@
+{{/*
+Expand the chart name.
+*/}}
+{{- define "sub2api.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "sub2api.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "sub2api.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "sub2api.labels" -}}
+helm.sh/chart: {{ include "sub2api.chart" . }}
+{{ include "sub2api.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "sub2api.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "sub2api.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Application ServiceAccount name.
+*/}}
+{{- define "sub2api.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "sub2api.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.appSecretName" -}}
+{{- if .Values.secrets.app.existingSecret -}}
+{{- .Values.secrets.app.existingSecret -}}
+{{- else -}}
+{{- printf "%s-app" (include "sub2api.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.image" -}}
+{{- $registry := coalesce .Values.image.registry .Values.global.imageRegistry -}}
+{{- $repository := .Values.image.repository -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" (trimSuffix "/" $registry) (trimPrefix "/" $repository) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.waitImage" -}}
+{{- $registry := coalesce .Values.waitForDependencies.image.registry .Values.global.imageRegistry -}}
+{{- $repository := .Values.waitForDependencies.image.repository -}}
+{{- $tag := .Values.waitForDependencies.image.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" (trimSuffix "/" $registry) (trimPrefix "/" $repository) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.mihomoImage" -}}
+{{- $registry := coalesce .Values.mihomo.image.registry .Values.global.imageRegistry -}}
+{{- $repository := .Values.mihomo.image.repository -}}
+{{- $tag := .Values.mihomo.image.tag -}}
+{{- if $registry -}}
+{{- printf "%s/%s:%s" (trimSuffix "/" $registry) (trimPrefix "/" $repository) $tag -}}
+{{- else -}}
+{{- printf "%s:%s" $repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.storageClass" -}}
+{{- coalesce .Values.persistence.storageClass .Values.global.defaultStorageClass .Values.global.storageClass -}}
+{{- end -}}
+
+{{- define "sub2api.serviceFQDN" -}}
+{{- printf "%s.%s.svc.cluster.local" .name .namespace -}}
+{{- end -}}
+
+{{- define "sub2api.postgresql.fullname" -}}
+{{- printf "%s-postgresql" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "sub2api.postgresql.secretName" -}}
+{{- if .Values.postgresql.connection.secretName -}}
+{{- .Values.postgresql.connection.secretName -}}
+{{- else if .Values.postgresql.auth.existingSecret -}}
+{{- .Values.postgresql.auth.existingSecret -}}
+{{- else if and (not .Values.postgresql.enabled) .Values.secrets.postgresql.existingSecret -}}
+{{- .Values.secrets.postgresql.existingSecret -}}
+{{- else -}}
+{{- printf "%s-postgresql" (include "sub2api.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.postgresql.passwordKey" -}}
+{{- if .Values.postgresql.connection.passwordKey -}}
+{{- .Values.postgresql.connection.passwordKey -}}
+{{- else if and (not .Values.postgresql.enabled) .Values.secrets.postgresql.existingSecret (not .Values.postgresql.auth.existingSecret) -}}
+postgres-password
+{{- else -}}
+{{- default "password" .Values.postgresql.auth.secretKeys.userPasswordKey -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.postgresql.host" -}}
+{{- if .Values.postgresql.connection.host -}}
+{{- .Values.postgresql.connection.host -}}
+{{- else if not .Values.postgresql.enabled -}}
+{{- .Values.externalPostgresql.host -}}
+{{- else if eq (default "standalone" .Values.postgresql.architecture) "replication" -}}
+{{- include "sub2api.serviceFQDN" (dict "name" (printf "%s-primary" (include "sub2api.postgresql.fullname" .)) "namespace" .Release.Namespace) -}}
+{{- else -}}
+{{- include "sub2api.serviceFQDN" (dict "name" (include "sub2api.postgresql.fullname" .) "namespace" .Release.Namespace) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.postgresql.port" -}}
+{{- if .Values.postgresql.connection.port -}}
+{{- .Values.postgresql.connection.port -}}
+{{- else if not .Values.postgresql.enabled -}}
+{{- .Values.externalPostgresql.port -}}
+{{- else -}}
+{{- default 5432 .Values.postgresql.primary.service.ports.postgresql -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.redis.fullname" -}}
+{{- printf "%s-redis" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "sub2api.redis.secretName" -}}
+{{- if .Values.redis.connection.secretName -}}
+{{- .Values.redis.connection.secretName -}}
+{{- else if .Values.redis.auth.existingSecret -}}
+{{- .Values.redis.auth.existingSecret -}}
+{{- else if and (not .Values.redis.enabled) .Values.secrets.redis.existingSecret -}}
+{{- .Values.secrets.redis.existingSecret -}}
+{{- else -}}
+{{- printf "%s-redis" (include "sub2api.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.redis.passwordKey" -}}
+{{- if .Values.redis.connection.passwordKey -}}
+{{- .Values.redis.connection.passwordKey -}}
+{{- else -}}
+{{- default "redis-password" .Values.redis.auth.existingSecretPasswordKey -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.redis.host" -}}
+{{- if .Values.redis.connection.host -}}
+{{- .Values.redis.connection.host -}}
+{{- else if not .Values.redis.enabled -}}
+{{- .Values.externalRedis.host -}}
+{{- else if .Values.redis.sentinel.enabled -}}
+{{- if .Values.redis.sentinel.masterService.enabled -}}
+{{- include "sub2api.serviceFQDN" (dict "name" (printf "%s-master" (include "sub2api.redis.fullname" .)) "namespace" .Release.Namespace) -}}
+{{- else -}}
+{{- include "sub2api.serviceFQDN" (dict "name" (include "sub2api.redis.fullname" .) "namespace" .Release.Namespace) -}}
+{{- end -}}
+{{- else -}}
+{{- include "sub2api.serviceFQDN" (dict "name" (printf "%s-master" (include "sub2api.redis.fullname" .)) "namespace" .Release.Namespace) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.redis.port" -}}
+{{- if .Values.redis.connection.port -}}
+{{- .Values.redis.connection.port -}}
+{{- else if not .Values.redis.enabled -}}
+{{- .Values.externalRedis.port -}}
+{{- else -}}
+{{- default 6379 .Values.redis.master.service.ports.redis -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate user-facing chart values that would otherwise be silently ignored by
+Bitnami dependency charts.
+*/}}
+{{- define "sub2api.validateSecretName" -}}
+{{- $name := default "" .name -}}
+{{- if and $name (ne $name (trim $name)) -}}
+{{- fail (printf "%s must not contain leading or trailing whitespace" .path) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sub2api.validateValues" -}}
+{{- include "sub2api.validateSecretName" (dict "path" "secrets.app.existingSecret" "name" .Values.secrets.app.existingSecret) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "secrets.postgresql.existingSecret" "name" .Values.secrets.postgresql.existingSecret) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "secrets.redis.existingSecret" "name" .Values.secrets.redis.existingSecret) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "postgresql.auth.existingSecret" "name" .Values.postgresql.auth.existingSecret) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "postgresql.connection.secretName" "name" .Values.postgresql.connection.secretName) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "redis.auth.existingSecret" "name" .Values.redis.auth.existingSecret) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "redis.connection.secretName" "name" .Values.redis.connection.secretName) -}}
+{{- include "sub2api.validateSecretName" (dict "path" "mihomo.config.existingSecret" "name" .Values.mihomo.config.existingSecret) -}}
+{{- if and .Values.postgresql.enabled .Values.secrets.postgresql.existingSecret -}}
+{{- fail "secrets.postgresql.existingSecret is only used when postgresql.enabled=false. For bundled Bitnami PostgreSQL, set postgresql.auth.existingSecret instead." -}}
+{{- end -}}
+{{- if and .Values.redis.enabled .Values.secrets.redis.existingSecret -}}
+{{- fail "secrets.redis.existingSecret is only used when redis.enabled=false. For bundled Bitnami Redis, set redis.auth.existingSecret instead." -}}
+{{- end -}}
+{{- if and .Values.mihomo.enabled (not .Values.mihomo.config.existingSecret) -}}
+{{- fail "mihomo.config.existingSecret is required when mihomo.enabled=true" -}}
+{{- end -}}
+{{- if and .Values.mihomo.enabled (not .Values.mihomo.config.key) -}}
+{{- fail "mihomo.config.key is required when mihomo.enabled=true" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return a base64-encoded Secret data value. When upgrading an existing release,
+reuse the existing key unless the user provided a new explicit value.
+*/}}
+{{- define "sub2api.secretData" -}}
+{{- $root := .root -}}
+{{- $secretName := .secretName -}}
+{{- $key := .key -}}
+{{- $value := default "" .value -}}
+{{- $generated := default "" .generated -}}
+{{- $existing := lookup "v1" "Secret" $root.Release.Namespace $secretName -}}
+{{- if ne $value "" -}}
+{{- $value | b64enc | quote -}}
+{{- else if and $existing (hasKey $existing.data $key) -}}
+{{- index $existing.data $key | quote -}}
+{{- else -}}
+{{- $generated | b64enc | quote -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/sub2api/templates/deployment.yaml
+++ b/deploy/helm/sub2api/templates/deployment.yaml
@@ -1,0 +1,309 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "sub2api.fullname" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "sub2api.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        {{- include "sub2api.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: app
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "sub2api.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- if .Values.waitForDependencies.enabled }}
+      initContainers:
+        - name: wait-for-dependencies
+          image: {{ include "sub2api.waitImage" . | quote }}
+          imagePullPolicy: {{ .Values.waitForDependencies.image.pullPolicy }}
+          {{- with .Values.waitForDependencies.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - sh
+            - -ec
+            - |
+              deadline=$(( $(date +%s) + {{ .Values.waitForDependencies.timeoutSeconds }} ))
+              wait_for() {
+                name="$1"
+                host="$2"
+                port="$3"
+                until nc -z "$host" "$port"; do
+                  if [ "$(date +%s)" -ge "$deadline" ]; then
+                    echo "Timed out waiting for ${name} at ${host}:${port}" >&2
+                    exit 1
+                  fi
+                  echo "Waiting for ${name} at ${host}:${port}..."
+                  sleep {{ .Values.waitForDependencies.intervalSeconds }}
+                done
+              }
+              wait_for postgresql "{{ include "sub2api.postgresql.host" . }}" "{{ include "sub2api.postgresql.port" . }}"
+              wait_for redis "{{ include "sub2api.redis.host" . }}" "{{ include "sub2api.redis.port" . }}"
+          {{- with .Values.waitForDependencies.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- end }}
+      containers:
+        - name: sub2api
+          image: {{ include "sub2api.image" . | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.app.server.port }}
+              protocol: TCP
+          env:
+            - name: AUTO_SETUP
+              value: {{ .Values.app.autoSetup | quote }}
+            - name: SERVER_HOST
+              value: {{ .Values.app.server.host | quote }}
+            - name: SERVER_PORT
+              value: {{ .Values.app.server.port | quote }}
+            - name: SERVER_MODE
+              value: {{ .Values.app.server.mode | quote }}
+            - name: RUN_MODE
+              value: {{ .Values.app.runMode | quote }}
+            - name: TZ
+              value: {{ .Values.app.timezone | quote }}
+            - name: DATABASE_HOST
+              value: {{ include "sub2api.postgresql.host" . | quote }}
+            - name: DATABASE_PORT
+              value: {{ include "sub2api.postgresql.port" . | quote }}
+            - name: DATABASE_USER
+              value: {{ ternary .Values.postgresql.auth.username .Values.externalPostgresql.username .Values.postgresql.enabled | quote }}
+            - name: DATABASE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sub2api.postgresql.secretName" . }}
+                  key: {{ include "sub2api.postgresql.passwordKey" . }}
+            - name: DATABASE_DBNAME
+              value: {{ ternary .Values.postgresql.auth.database .Values.externalPostgresql.database .Values.postgresql.enabled | quote }}
+            - name: DATABASE_SSLMODE
+              value: {{ ternary .Values.app.database.sslMode .Values.externalPostgresql.sslMode .Values.postgresql.enabled | quote }}
+            - name: DATABASE_MAX_OPEN_CONNS
+              value: {{ .Values.app.database.maxOpenConns | quote }}
+            - name: DATABASE_MAX_IDLE_CONNS
+              value: {{ .Values.app.database.maxIdleConns | quote }}
+            - name: DATABASE_CONN_MAX_LIFETIME_MINUTES
+              value: {{ .Values.app.database.connMaxLifetimeMinutes | quote }}
+            - name: DATABASE_CONN_MAX_IDLE_TIME_MINUTES
+              value: {{ .Values.app.database.connMaxIdleTimeMinutes | quote }}
+            - name: REDIS_HOST
+              value: {{ include "sub2api.redis.host" . | quote }}
+            - name: REDIS_PORT
+              value: {{ include "sub2api.redis.port" . | quote }}
+            {{- if and .Values.redis.enabled (not .Values.redis.auth.enabled) }}
+            - name: REDIS_PASSWORD
+              value: ""
+            {{- else }}
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sub2api.redis.secretName" . }}
+                  key: {{ include "sub2api.redis.passwordKey" . }}
+            {{- end }}
+            - name: REDIS_DB
+              value: {{ .Values.app.redis.db | quote }}
+            - name: REDIS_POOL_SIZE
+              value: {{ .Values.app.redis.poolSize | quote }}
+            - name: REDIS_MIN_IDLE_CONNS
+              value: {{ .Values.app.redis.minIdleConns | quote }}
+            - name: REDIS_ENABLE_TLS
+              value: {{ .Values.app.redis.enableTLS | quote }}
+            - name: ADMIN_EMAIL
+              value: {{ .Values.app.adminEmail | quote }}
+            - name: ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sub2api.appSecretName" . }}
+                  key: admin-password
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sub2api.appSecretName" . }}
+                  key: jwt-secret
+            - name: JWT_EXPIRE_HOUR
+              value: {{ .Values.app.jwtExpireHour | quote }}
+            - name: TOTP_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "sub2api.appSecretName" . }}
+                  key: totp-encryption-key
+            - name: GEMINI_OAUTH_CLIENT_ID
+              value: {{ .Values.app.gemini.oauthClientId | quote }}
+            - name: GEMINI_OAUTH_CLIENT_SECRET
+              value: {{ .Values.app.gemini.oauthClientSecret | quote }}
+            - name: GEMINI_OAUTH_SCOPES
+              value: {{ .Values.app.gemini.oauthScopes | quote }}
+            - name: GEMINI_QUOTA_POLICY
+              value: {{ .Values.app.gemini.quotaPolicy | quote }}
+            - name: GEMINI_CLI_OAUTH_CLIENT_SECRET
+              value: {{ .Values.app.gemini.cliOauthClientSecret | quote }}
+            - name: ANTIGRAVITY_OAUTH_CLIENT_SECRET
+              value: {{ .Values.app.gemini.antigravityOauthClientSecret | quote }}
+            - name: SECURITY_URL_ALLOWLIST_ENABLED
+              value: {{ .Values.app.security.urlAllowlist.enabled | quote }}
+            - name: SECURITY_URL_ALLOWLIST_ALLOW_INSECURE_HTTP
+              value: {{ .Values.app.security.urlAllowlist.allowInsecureHTTP | quote }}
+            - name: SECURITY_URL_ALLOWLIST_ALLOW_PRIVATE_HOSTS
+              value: {{ .Values.app.security.urlAllowlist.allowPrivateHosts | quote }}
+            - name: SECURITY_URL_ALLOWLIST_UPSTREAM_HOSTS
+              value: {{ .Values.app.security.urlAllowlist.upstreamHosts | quote }}
+            - name: UPDATE_PROXY_URL
+              value: {{ .Values.app.update.proxyURL | quote }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+          {{- if .Values.probes.liveness.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.readiness.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- if .Values.mihomo.enabled }}
+        - name: mihomo
+          image: {{ include "sub2api.mihomoImage" . | quote }}
+          imagePullPolicy: {{ .Values.mihomo.image.pullPolicy }}
+          {{- with .Values.mihomo.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.mihomo.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.mihomo.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: mixed
+              containerPort: {{ .Values.mihomo.mixedPort }}
+              protocol: TCP
+            - name: controller
+              containerPort: {{ .Values.mihomo.controllerPort }}
+              protocol: TCP
+          {{- with .Values.mihomo.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: mihomo-config
+              mountPath: {{ .Values.mihomo.config.mountPath | quote }}
+              readOnly: true
+          {{- if .Values.mihomo.probes.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: mixed
+            initialDelaySeconds: {{ .Values.mihomo.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.mihomo.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.mihomo.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.mihomo.probes.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.mihomo.probes.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: mixed
+            initialDelaySeconds: {{ .Values.mihomo.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.mihomo.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.mihomo.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.mihomo.probes.readiness.failureThreshold }}
+          {{- end }}
+          {{- with .Values.mihomo.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-data" (include "sub2api.fullname" .)) .Values.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        {{- if .Values.mihomo.enabled }}
+        - name: mihomo-config
+          secret:
+            secretName: {{ .Values.mihomo.config.existingSecret }}
+            items:
+              - key: {{ .Values.mihomo.config.key }}
+                path: config.yaml
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/sub2api/templates/ingress.yaml
+++ b/deploy/helm/sub2api/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "sub2api.fullname" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path | quote }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "sub2api.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/sub2api/templates/pvc.yaml
+++ b/deploy/helm/sub2api/templates/pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sub2api.fullname" . }}-data
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- $storageClass := include "sub2api.storageClass" . }}
+  {{- if $storageClass }}
+  storageClassName: {{ $storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/sub2api/templates/secret.yaml
+++ b/deploy/helm/sub2api/templates/secret.yaml
@@ -1,0 +1,39 @@
+{{- if not .Values.secrets.app.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sub2api.appSecretName" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+type: Opaque
+data:
+  jwt-secret: {{ include "sub2api.secretData" (dict "root" . "secretName" (include "sub2api.appSecretName" .) "key" "jwt-secret" "value" .Values.secrets.app.jwtSecret "generated" (randAlphaNum 64)) }}
+  totp-encryption-key: {{ include "sub2api.secretData" (dict "root" . "secretName" (include "sub2api.appSecretName" .) "key" "totp-encryption-key" "value" .Values.secrets.app.totpEncryptionKey "generated" (randAlphaNum 64 | sha256sum)) }}
+  admin-password: {{ include "sub2api.secretData" (dict "root" . "secretName" (include "sub2api.appSecretName" .) "key" "admin-password" "value" .Values.secrets.app.adminPassword "generated" (ternary (randAlphaNum 24) "" .Values.secrets.app.generateAdminPassword)) }}
+{{- end }}
+{{- if and (not .Values.postgresql.enabled) (not .Values.postgresql.connection.secretName) (not .Values.postgresql.auth.existingSecret) (not .Values.secrets.postgresql.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sub2api.postgresql.secretName" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgresql
+type: Opaque
+data:
+  {{ include "sub2api.postgresql.passwordKey" . }}: {{ include "sub2api.secretData" (dict "root" . "secretName" (include "sub2api.postgresql.secretName" .) "key" (include "sub2api.postgresql.passwordKey" .) "value" (coalesce .Values.secrets.postgresql.password .Values.externalPostgresql.password) "generated" (randAlphaNum 32)) }}
+{{- end }}
+{{- if and (not .Values.redis.enabled) (not .Values.redis.connection.secretName) (not .Values.redis.auth.existingSecret) (not .Values.secrets.redis.existingSecret) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "sub2api.redis.secretName" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+type: Opaque
+data:
+  {{ include "sub2api.redis.passwordKey" . }}: {{ include "sub2api.secretData" (dict "root" . "secretName" (include "sub2api.redis.secretName" .) "key" (include "sub2api.redis.passwordKey" .) "value" (coalesce .Values.secrets.redis.password .Values.externalRedis.password) "generated" (ternary (randAlphaNum 32) "" .Values.secrets.redis.generatePassword)) }}
+{{- end }}

--- a/deploy/helm/sub2api/templates/service.yaml
+++ b/deploy/helm/sub2api/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "sub2api.fullname" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "sub2api.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: app

--- a/deploy/helm/sub2api/templates/serviceaccount.yaml
+++ b/deploy/helm/sub2api/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "sub2api.serviceAccountName" . }}
+  labels:
+    {{- include "sub2api.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+{{- end }}

--- a/deploy/helm/sub2api/templates/validations.yaml
+++ b/deploy/helm/sub2api/templates/validations.yaml
@@ -1,0 +1,1 @@
+{{- include "sub2api.validateValues" . -}}

--- a/deploy/helm/sub2api/values.yaml
+++ b/deploy/helm/sub2api/values.yaml
@@ -1,0 +1,320 @@
+# Default values for the Sub2API Helm chart.
+# This chart mirrors the Docker Compose deployment defaults while exposing
+# Kubernetes-native service, persistence, secret, and ingress settings.
+
+replicaCount: 1
+
+global:
+  # Shared Docker registry for Sub2API and Bitnami dependency images.
+  # Example: registry.example.com/mirror
+  imageRegistry: ""
+  # Shared image pull secrets for Bitnami dependencies. For the Sub2API app,
+  # use imagePullSecrets below when Kubernetes object-form secrets are needed.
+  imagePullSecrets: []
+  # Shared StorageClass for Sub2API, PostgreSQL, and Redis PVCs.
+  defaultStorageClass: ""
+  # Deprecated Bitnami compatibility alias. Prefer defaultStorageClass.
+  storageClass: ""
+  security:
+    # Bitnami charts verify image names. Set true when using a private mirror
+    # or rewritten repository names for Bitnami dependency images.
+    allowInsecureImages: false
+
+image:
+  registry: ""
+  repository: weishaw/sub2api
+  pullPolicy: IfNotPresent
+  tag: latest
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+waitForDependencies:
+  enabled: true
+  image:
+    registry: ""
+    repository: busybox
+    tag: "1.36"
+    pullPolicy: IfNotPresent
+  intervalSeconds: 2
+  timeoutSeconds: 300
+  resources: {}
+  securityContext: {}
+
+commonLabels: {}
+podLabels: {}
+podAnnotations: {}
+
+serviceAccount:
+  create: false
+  annotations: {}
+  name: ""
+  automountServiceAccountToken: false
+
+podSecurityContext: {}
+securityContext: {}
+
+resources: {}
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+priorityClassName: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    []
+    # - host: sub2api.example.com
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
+  tls: []
+
+persistence:
+  enabled: true
+  existingClaim: ""
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 10Gi
+  annotations: {}
+
+app:
+  autoSetup: true
+  runMode: standard
+  timezone: Asia/Shanghai
+  adminEmail: admin@sub2api.local
+  jwtExpireHour: 24
+  server:
+    host: 0.0.0.0
+    port: 8080
+    mode: release
+  database:
+    sslMode: disable
+    maxOpenConns: 50
+    maxIdleConns: 10
+    connMaxLifetimeMinutes: 30
+    connMaxIdleTimeMinutes: 5
+  redis:
+    db: 0
+    poolSize: 1024
+    minIdleConns: 10
+    enableTLS: false
+  gemini:
+    oauthClientId: ""
+    oauthClientSecret: ""
+    oauthScopes: ""
+    quotaPolicy: ""
+    cliOauthClientSecret: ""
+    antigravityOauthClientSecret: ""
+  security:
+    urlAllowlist:
+      enabled: false
+      allowInsecureHTTP: false
+      allowPrivateHosts: false
+      upstreamHosts: ""
+  update:
+    # Proxy used by Sub2API built-in update/download clients, including
+    # GitHub release checks and remote pricing data downloads.
+    # Example with mihomo sidecar: http://127.0.0.1:7890
+    proxyURL: ""
+
+# Append additional environment variables to the Sub2API container.
+extraEnv: []
+  # - name: LOG_LEVEL
+  #   value: info
+
+envFrom: []
+  # - secretRef:
+  #     name: sub2api-extra-env
+
+mihomo:
+  enabled: false
+  image:
+    registry: ""
+    repository: metacubex/mihomo
+    tag: latest
+    pullPolicy: IfNotPresent
+  # Mount an existing Secret that contains mihomo config.yaml. Keep node,
+  # subscription, and credential data out of Helm values.
+  config:
+    existingSecret: ""
+    key: config.yaml
+    mountPath: /etc/mihomo
+  # The sidecar does not inject HTTP_PROXY/HTTPS_PROXY into Sub2API. Set
+  # app.update.proxyURL for built-in GitHub/pricing downloads, and configure
+  # Sub2API's in-app proxy for provider/account traffic after deployment.
+  mixedPort: 7890
+  controllerPort: 9090
+  command: []
+  args:
+    - -f
+    - /etc/mihomo/config.yaml
+  env: []
+  resources: {}
+  securityContext: {}
+  probes:
+    liveness:
+      # Keep disabled when mihomo binds to 127.0.0.1 only. Kubernetes TCP
+      # probes target the Pod IP and may fail against loopback-only listeners.
+      enabled: false
+      initialDelaySeconds: 10
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readiness:
+      enabled: false
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 3
+      failureThreshold: 3
+
+secrets:
+  app:
+    # Existing secret must contain keys: jwt-secret, totp-encryption-key,
+    # and admin-password.
+    existingSecret: ""
+    # jwtSecret must be at least 32 bytes. totpEncryptionKey must be
+    # 64 hex characters, for example: openssl rand -hex 32.
+    jwtSecret: ""
+    totpEncryptionKey: ""
+    adminPassword: ""
+    generateAdminPassword: true
+  postgresql:
+    # External PostgreSQL fallback only. When bundled PostgreSQL is enabled,
+    # use postgresql.auth.existingSecret because Bitnami reads that key.
+    existingSecret: ""
+    password: ""
+  redis:
+    # External Redis fallback only. When bundled Redis is enabled, use
+    # redis.auth.existingSecret because Bitnami reads that key.
+    existingSecret: ""
+    password: ""
+    generatePassword: false
+
+postgresql:
+  enabled: true
+  # Native Bitnami PostgreSQL chart values. Extend this section with upstream
+  # options such as architecture=replication, readReplicas, metrics, initdb,
+  # image, resources, node selectors, tolerations, and affinity.
+  architecture: standalone
+  image:
+    registry: registry-1.docker.io
+    repository: bitnami/postgresql
+    tag: latest
+  auth:
+    username: sub2api
+    # Set a fixed password before the first production install if PostgreSQL
+    # PVCs may be retained across uninstall/reinstall.
+    password: ""
+    database: sub2api
+    # Existing secret for bundled Bitnami PostgreSQL. This is the correct
+    # production secret entry when postgresql.enabled=true.
+    existingSecret: ""
+    secretKeys:
+      adminPasswordKey: postgres-password
+      userPasswordKey: password
+  primary:
+    persistence:
+      enabled: true
+      existingClaim: ""
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 20Gi
+      annotations: {}
+    service:
+      ports:
+        postgresql: 5432
+  connection:
+    # Override only when Sub2API must connect to a non-default PostgreSQL
+    # service or secret. Empty values use Bitnami chart defaults.
+    host: ""
+    port: ""
+    secretName: ""
+    passwordKey: ""
+
+externalPostgresql:
+  host: ""
+  port: 5432
+  username: sub2api
+  password: ""
+  database: sub2api
+  sslMode: disable
+
+redis:
+  enabled: true
+  # Native Bitnami Redis chart values. Extend this section with upstream
+  # options such as architecture=replication, replica counts, sentinel,
+  # image, metrics, resources, node selectors, tolerations, and affinity.
+  architecture: standalone
+  image:
+    registry: registry-1.docker.io
+    repository: bitnami/redis
+    tag: latest
+  auth:
+    enabled: true
+    # Set a fixed password before the first production install if Redis PVCs
+    # may be retained across uninstall/reinstall.
+    password: ""
+    # Existing secret for bundled Bitnami Redis. This is the correct
+    # production secret entry when redis.enabled=true.
+    existingSecret: ""
+    existingSecretPasswordKey: redis-password
+  master:
+    persistence:
+      enabled: true
+      existingClaim: ""
+      storageClass: ""
+      accessModes:
+        - ReadWriteOnce
+      size: 8Gi
+      annotations: {}
+    service:
+      ports:
+        redis: 6379
+  replica:
+    replicaCount: 1
+  sentinel:
+    enabled: false
+  connection:
+    # Override only when Sub2API must connect to a non-default Redis service
+    # or secret. Empty values use Bitnami chart defaults.
+    host: ""
+    port: ""
+    secretName: ""
+    passwordKey: ""
+
+externalRedis:
+  host: ""
+  port: 6379
+  password: ""
+
+probes:
+  liveness:
+    enabled: true
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 10
+    failureThreshold: 3
+  readiness:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
+  startup:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30


### PR DESCRIPTION
## Summary
- add a Helm chart for Sub2API Kubernetes deployment
- use Bitnami PostgreSQL/Redis chart dependencies with configurable persistence, registry, storage class, secrets, ingress, and image pull secrets
- add simple values and deploy helper, plus deployment docs for dependency build, retained PVC secrets, and optional mihomo sidecar proxy

## Validation
- helm dependency build deploy/helm/sub2api
- helm lint deploy/helm/sub2api -f deploy/helm-values.simple.yaml
- helm template sub2api deploy/helm/sub2api --namespace sub2api -f deploy/helm-values.simple.yaml

## Scope
Only Helm/deploy-related files are included.