### PR TITLE
perf(frontend): improve modal scroll performance

### DIFF
--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -370,7 +370,7 @@
   /* ============ 模态框 ============ */
   .modal-overlay {
     @apply fixed inset-0 z-50;
-    @apply bg-black/50 backdrop-blur-sm;
+    @apply bg-black/50;
     @apply flex items-center justify-center p-2 sm:p-4;
   }
 


### PR DESCRIPTION
## Summary

移除弹窗全屏遮罩上的 `backdrop-blur-sm`，保留原有的 `bg-black/50` 暗色遮罩。

这个 `backdrop-blur-sm` 会生成全屏 `backdrop-filter`，在账号编辑这类内容较多、需要滚动的弹窗中，可能带来明显的滚动卡顿，尤其是在低性能设备、集显、远程桌面或浏览器硬件加速受限的环境下。

移除后弹窗仍然有遮罩和视觉聚焦效果，只是不再对背景做实时模糊处理。

## Testing

- `npm run typecheck`
