### PR TITLE
fix(apicompat): normalize Responses content blocks for Anthropic upst…

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1027,6 +1027,102 @@ func TestResponsesToAnthropicRequest_ToolChoiceLegacyFunctionName(t *testing.T) 
 	assert.Equal(t, "get_weather", tc["name"])
 }
 
+func TestResponsesToAnthropicRequest_TopLevelInputTextItem(t *testing.T) {
+	req := &ResponsesRequest{
+		Model: "gpt-5.2",
+		Input: json.RawMessage(`[
+			{"type":"input_text","text":"Hello from Responses"}
+		]`),
+	}
+
+	resp, err := ResponsesToAnthropicRequest(req)
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, 1)
+	assert.Equal(t, "user", resp.Messages[0].Role)
+
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Messages[0].Content, &blocks))
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "text", blocks[0]["type"])
+	assert.Equal(t, "Hello from Responses", blocks[0]["text"])
+	assert.NotContains(t, string(resp.Messages[0].Content), "input_text")
+}
+
+func TestResponsesToAnthropicRequest_NormalizesResponsesContentParts(t *testing.T) {
+	req := &ResponsesRequest{
+		Model: "gpt-5.2",
+		Input: json.RawMessage(`[
+			{
+				"role":"user",
+				"content":[
+					{"type":"input_text","text":"Describe this","cache_control":{"type":"ephemeral"}},
+					{"type":"input_image","image_url":"data:image/png;base64,iVBOR"},
+					{"type":"image_url","image_url":{"url":"data:image/jpeg;base64,/9j/4AAQ"}}
+				]
+			}
+		]`),
+	}
+
+	resp, err := ResponsesToAnthropicRequest(req)
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, 1)
+
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Messages[0].Content, &blocks))
+	require.Len(t, blocks, 3)
+	assert.Equal(t, "text", blocks[0]["type"])
+	assert.Equal(t, "Describe this", blocks[0]["text"])
+	assert.Equal(t, map[string]any{"type": "ephemeral"}, blocks[0]["cache_control"])
+	assert.Equal(t, "image", blocks[1]["type"])
+	assert.Equal(t, "image", blocks[2]["type"])
+	assert.NotContains(t, string(resp.Messages[0].Content), "input_text")
+	assert.NotContains(t, string(resp.Messages[0].Content), "input_image")
+	assert.NotContains(t, string(resp.Messages[0].Content), "image_url")
+}
+
+func TestResponsesToAnthropicRequest_NormalizesFallbackMessageContent(t *testing.T) {
+	req := &ResponsesRequest{
+		Model: "gpt-5.2",
+		Input: json.RawMessage(`[
+			{
+				"type":"message",
+				"content":[
+					{"type":"input_text","text":"Fallback path should still normalize"}
+				]
+			}
+		]`),
+	}
+
+	resp, err := ResponsesToAnthropicRequest(req)
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, 1)
+	assert.Equal(t, "user", resp.Messages[0].Role)
+
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Messages[0].Content, &blocks))
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "text", blocks[0]["type"])
+	assert.Equal(t, "Fallback path should still normalize", blocks[0]["text"])
+	assert.NotContains(t, string(resp.Messages[0].Content), "input_text")
+}
+
+func TestResponsesToAnthropicRequest_SingleObjectInput(t *testing.T) {
+	req := &ResponsesRequest{
+		Model: "gpt-5.2",
+		Input: json.RawMessage(`{"type":"input_text","text":"Single object input"}`),
+	}
+
+	resp, err := ResponsesToAnthropicRequest(req)
+	require.NoError(t, err)
+	require.Len(t, resp.Messages, 1)
+
+	var blocks []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Messages[0].Content, &blocks))
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "text", blocks[0]["type"])
+	assert.Equal(t, "Single object input", blocks[0]["text"])
+}
+
 // ---------------------------------------------------------------------------
 // Image content block conversion tests
 // ---------------------------------------------------------------------------

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -1,6 +1,7 @@
 package apicompat
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -108,21 +109,56 @@ func convertResponsesInputToAnthropic(inputRaw json.RawMessage) (json.RawMessage
 		return nil, []AnthropicMessage{{Role: "user", Content: content}}, nil
 	}
 
-	var items []ResponsesInputItem
-	if err := json.Unmarshal(inputRaw, &items); err != nil {
-		return nil, nil, fmt.Errorf("parse responses input: %w", err)
+	var rawItems []json.RawMessage
+	trimmedInput := bytes.TrimSpace(inputRaw)
+	switch {
+	case len(trimmedInput) == 0:
+		return nil, nil, fmt.Errorf("parse responses input: empty input")
+	case trimmedInput[0] == '[':
+		if err := json.Unmarshal(trimmedInput, &rawItems); err != nil {
+			return nil, nil, fmt.Errorf("parse responses input: %w", err)
+		}
+	case trimmedInput[0] == '{':
+		rawItems = []json.RawMessage{trimmedInput}
+	default:
+		return nil, nil, fmt.Errorf("parse responses input: expected string, object, or array")
 	}
 
 	var system json.RawMessage
 	var messages []AnthropicMessage
 
-	for _, item := range items {
+	for _, rawItem := range rawItems {
+		var item ResponsesInputItem
+		if err := json.Unmarshal(rawItem, &item); err != nil {
+			return nil, nil, fmt.Errorf("parse responses input item: %w", err)
+		}
+
 		switch {
 		case item.Role == "system":
 			// System prompt → Anthropic system field
 			text := extractTextFromContent(item.Content)
 			if text != "" {
 				system, _ = json.Marshal(text)
+			}
+
+		case item.Type == "input_text" || item.Type == "text":
+			blocks := convertResponsesContentPartToAnthropicRawBlocks(rawItem, false)
+			if len(blocks) > 0 {
+				content, _ := marshalAnthropicRawBlocks(blocks...)
+				messages = append(messages, AnthropicMessage{
+					Role:    "user",
+					Content: content,
+				})
+			}
+
+		case item.Type == "input_image" || item.Type == "image_url":
+			blocks := convertResponsesContentPartToAnthropicRawBlocks(rawItem, false)
+			if len(blocks) > 0 {
+				content, _ := marshalAnthropicRawBlocks(blocks...)
+				messages = append(messages, AnthropicMessage{
+					Role:    "user",
+					Content: content,
+				})
 			}
 
 		case item.Type == "function_call":
@@ -184,9 +220,13 @@ func convertResponsesInputToAnthropic(inputRaw json.RawMessage) (json.RawMessage
 		default:
 			// Unknown role/type — attempt as user message
 			if item.Content != nil {
+				content, err := convertResponsesUserToAnthropicContent(item.Content)
+				if err != nil {
+					return nil, nil, err
+				}
 				messages = append(messages, AnthropicMessage{
 					Role:    "user",
-					Content: item.Content,
+					Content: content,
 				})
 			}
 		}
@@ -234,38 +274,12 @@ func convertResponsesUserToAnthropicContent(raw json.RawMessage) (json.RawMessag
 		return json.Marshal(s)
 	}
 
-	// Array of content parts → Anthropic content blocks.
-	var parts []ResponsesContentPart
-	if err := json.Unmarshal(raw, &parts); err != nil {
-		// Pass through as-is if we can't parse
-		return raw, nil
-	}
-
-	var blocks []AnthropicContentBlock
-	for _, p := range parts {
-		switch p.Type {
-		case "input_text", "text":
-			if p.Text != "" {
-				blocks = append(blocks, AnthropicContentBlock{
-					Type: "text",
-					Text: p.Text,
-				})
-			}
-		case "input_image":
-			src := dataURIToAnthropicImageSource(p.ImageURL)
-			if src != nil {
-				blocks = append(blocks, AnthropicContentBlock{
-					Type:   "image",
-					Source: src,
-				})
-			}
-		}
-	}
+	blocks := convertResponsesContentToAnthropicRawBlocks(raw, false)
 
 	if len(blocks) == 0 {
 		return json.Marshal("")
 	}
-	return json.Marshal(blocks)
+	return marshalAnthropicRawBlocks(blocks...)
 }
 
 // convertResponsesAssistantToAnthropicContent converts a Responses assistant
@@ -281,29 +295,161 @@ func convertResponsesAssistantToAnthropicContent(raw json.RawMessage) (json.RawM
 		return json.Marshal([]AnthropicContentBlock{{Type: "text", Text: s}})
 	}
 
-	// Array of content parts → Anthropic content blocks.
-	var parts []ResponsesContentPart
-	if err := json.Unmarshal(raw, &parts); err != nil {
-		return raw, nil
+	blocks := convertResponsesContentToAnthropicRawBlocks(raw, true)
+
+	if len(blocks) == 0 {
+		blocks = append(blocks, makeAnthropicTextRawBlock("", nil))
+	}
+	return marshalAnthropicRawBlocks(blocks...)
+}
+
+func convertResponsesContentToAnthropicRawBlocks(raw json.RawMessage, assistant bool) []json.RawMessage {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil
 	}
 
-	var blocks []AnthropicContentBlock
-	for _, p := range parts {
-		switch p.Type {
-		case "output_text", "text":
-			if p.Text != "" {
-				blocks = append(blocks, AnthropicContentBlock{
-					Type: "text",
-					Text: p.Text,
-				})
-			}
+	var parts []json.RawMessage
+	switch trimmed[0] {
+	case '[':
+		if err := json.Unmarshal(trimmed, &parts); err != nil {
+			return nil
+		}
+	case '{':
+		parts = []json.RawMessage{trimmed}
+	default:
+		var s string
+		if err := json.Unmarshal(trimmed, &s); err == nil {
+			return []json.RawMessage{makeAnthropicTextRawBlock(s, nil)}
+		}
+		return nil
+	}
+
+	var blocks []json.RawMessage
+	for _, part := range parts {
+		blocks = append(blocks, convertResponsesContentPartToAnthropicRawBlocks(part, assistant)...)
+	}
+	return blocks
+}
+
+func convertResponsesContentPartToAnthropicRawBlocks(raw json.RawMessage, assistant bool) []json.RawMessage {
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return []json.RawMessage{makeAnthropicTextRawBlock(s, nil)}
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+
+	partType := rawJSONFieldString(obj, "type")
+	switch partType {
+	case "input_text", "output_text", "text":
+		if text := rawJSONFieldString(obj, "text"); text != "" {
+			return []json.RawMessage{makeAnthropicTextRawBlock(text, obj["cache_control"])}
+		}
+	case "input_image", "image_url":
+		if source := responsesImageSourceFromObject(obj); source != nil {
+			return []json.RawMessage{makeAnthropicImageRawBlock(source, obj["cache_control"])}
+		}
+	case "image":
+		if _, ok := obj["source"]; ok {
+			return []json.RawMessage{raw}
+		}
+		if source := responsesImageSourceFromObject(obj); source != nil {
+			return []json.RawMessage{makeAnthropicImageRawBlock(source, obj["cache_control"])}
+		}
+	case "tool_use":
+		if assistant {
+			return []json.RawMessage{raw}
+		}
+	case "tool_result":
+		if !assistant {
+			return []json.RawMessage{raw}
+		}
+	case "thinking":
+		if assistant {
+			return []json.RawMessage{raw}
+		}
+	case "document", "server_tool_use", "tool_reference", "web_search_tool_result":
+		return []json.RawMessage{raw}
+	}
+
+	if text := rawJSONFieldString(obj, "text"); text != "" {
+		return []json.RawMessage{makeAnthropicTextRawBlock(text, obj["cache_control"])}
+	}
+	return nil
+}
+
+func marshalAnthropicRawBlocks(blocks ...json.RawMessage) (json.RawMessage, error) {
+	return json.Marshal(blocks)
+}
+
+func makeAnthropicTextRawBlock(text string, cacheControl json.RawMessage) json.RawMessage {
+	obj := map[string]json.RawMessage{
+		"type": json.RawMessage(`"text"`),
+		"text": mustMarshalRaw(text),
+	}
+	if len(cacheControl) > 0 {
+		obj["cache_control"] = cacheControl
+	}
+	raw, _ := json.Marshal(obj)
+	return raw
+}
+
+func makeAnthropicImageRawBlock(source *AnthropicImageSource, cacheControl json.RawMessage) json.RawMessage {
+	obj := map[string]json.RawMessage{
+		"type":   json.RawMessage(`"image"`),
+		"source": mustMarshalRaw(source),
+	}
+	if len(cacheControl) > 0 {
+		obj["cache_control"] = cacheControl
+	}
+	raw, _ := json.Marshal(obj)
+	return raw
+}
+
+func responsesImageSourceFromObject(obj map[string]json.RawMessage) *AnthropicImageSource {
+	if rawSource, ok := obj["source"]; ok {
+		var source AnthropicImageSource
+		if err := json.Unmarshal(rawSource, &source); err == nil && source.Type != "" {
+			return &source
 		}
 	}
 
-	if len(blocks) == 0 {
-		blocks = append(blocks, AnthropicContentBlock{Type: "text", Text: ""})
+	if url := rawJSONFieldString(obj, "image_url"); url != "" {
+		return dataURIToAnthropicImageSource(url)
 	}
-	return json.Marshal(blocks)
+
+	var imageURLObj map[string]json.RawMessage
+	if rawImageURL, ok := obj["image_url"]; ok && json.Unmarshal(rawImageURL, &imageURLObj) == nil {
+		if url := rawJSONFieldString(imageURLObj, "url"); url != "" {
+			return dataURIToAnthropicImageSource(url)
+		}
+	}
+
+	if url := rawJSONFieldString(obj, "url"); url != "" {
+		return dataURIToAnthropicImageSource(url)
+	}
+	return nil
+}
+
+func rawJSONFieldString(obj map[string]json.RawMessage, key string) string {
+	raw, ok := obj[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+func mustMarshalRaw(v any) json.RawMessage {
+	raw, _ := json.Marshal(v)
+	return raw
 }
 
 // fromResponsesCallIDToAnthropic converts an OpenAI function call ID back to


### PR DESCRIPTION
## Summary

修复 `Responses -> Anthropic Messages` 转换时，OpenAI Responses 专用 content block 类型可能原样透传到 Anthropic 上游的问题。

之前 `ResponsesToAnthropicRequest` 在部分路径下会把 `input_text` / `input_image` / `image_url` 这类 Responses/Chat Completions content block 原样放进 Anthropic `messages[].content`。对于 Anthropic 兼容上游，这会导致类似下面的错误：

```text
messages[0].content: unknown variant `input_text`, expected one of `text`, ...
```

这个 PR 做了几件事：

- 支持顶层 `input_text` / `input_image` Responses input item 转换
- 将 `input_text` / `output_text` / `text` 统一转换为 Anthropic `text`
- 将 Responses/Chat Completions 风格图片块转换为 Anthropic `image`
- 避免 fallback 分支继续把 Responses content 原样透传给 Anthropic 上游
- 保留 Anthropic 原生块，例如 `tool_use` / `tool_result` / `thinking` / `document`
- 支持单对象 `input`，避免只接受数组形式

## Related

可能与 #2036 相关：该 issue 中也出现了 `/responses` 入站转 Anthropic/DeepSeek 上游时的兼容问题。本 PR 只修复 content block 归一化，不声明完整解决该 issue。

This is also related to the general protocol-conversion direction discussed in #1331.

It is narrower than #2101: this PR only fixes content block normalization for `Responses -> Anthropic`.


## Testing

- `cd backend && go test ./internal/pkg/apicompat -count=1`
- `cd backend && go test ./internal/service -run "^$" -count=1`
