### PR TITLE
[codex] support OpenAI responses on DeepSeek upstream

### DIFF
--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
+	"github.com/klauspost/compress/zstd"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -120,6 +122,26 @@ func TestReadRequestBodyWithPrealloc(t *testing.T) {
 	body, err := pkghttputil.ReadRequestBodyWithPrealloc(req)
 	require.NoError(t, err)
 	require.Equal(t, payload, string(body))
+}
+
+func TestReadRequestBodyWithPrealloc_Zstd(t *testing.T) {
+	payload := `{"model":"gpt-5","input":"hello"}`
+	var compressed bytes.Buffer
+	encoder, err := zstd.NewWriter(&compressed)
+	require.NoError(t, err)
+	_, err = encoder.Write([]byte(payload))
+	require.NoError(t, err)
+	require.NoError(t, encoder.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", &compressed)
+	req.Header.Set("Content-Encoding", "zstd")
+	req.ContentLength = int64(compressed.Len())
+
+	body, err := pkghttputil.ReadRequestBodyWithPrealloc(req)
+	require.NoError(t, err)
+	require.Equal(t, payload, string(body))
+	require.Empty(t, req.Header.Get("Content-Encoding"))
+	require.Equal(t, int64(-1), req.ContentLength)
 }
 
 func TestReadRequestBodyWithPrealloc_MaxBytesError(t *testing.T) {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -283,6 +283,91 @@ func TestChatCompletionsToResponses_LegacyFunctions(t *testing.T) {
 	assert.Equal(t, "function", tc["type"])
 }
 
+func TestResponsesToChatCompletionsRequest_BasicTextAndTools(t *testing.T) {
+	req := &ResponsesRequest{
+		Model:        "deepseek-chat",
+		Instructions: "You are helpful.",
+		Input: json.RawMessage(`[
+			{"role":"user","content":[{"type":"input_text","text":"hello"}]},
+			{"type":"function_call","call_id":"call_1","name":"weather","arguments":"{\"city\":\"Tokyo\"}"},
+			{"type":"function_call_output","call_id":"call_1","output":"sunny"}
+		]`),
+		MaxOutputTokens: intPtr(256),
+		Stream:          true,
+		Reasoning:       &ResponsesReasoning{Effort: "high"},
+		Tools: []ResponsesTool{{
+			Type:        "function",
+			Name:        "weather",
+			Description: "Get weather",
+			Parameters:  json.RawMessage(`{"type":"object"}`),
+		}},
+	}
+
+	out, err := ResponsesToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 4)
+	assert.Equal(t, "system", out.Messages[0].Role)
+	assert.Equal(t, "user", out.Messages[1].Role)
+	assert.Equal(t, "assistant", out.Messages[2].Role)
+	assert.Equal(t, "tool", out.Messages[3].Role)
+	require.NotNil(t, out.MaxTokens)
+	assert.Equal(t, 256, *out.MaxTokens)
+	assert.Equal(t, "high", out.ReasoningEffort)
+	require.Len(t, out.Tools, 1)
+	assert.Equal(t, "weather", out.Tools[0].Function.Name)
+}
+
+func TestChatCompletionsToResponsesResponse(t *testing.T) {
+	resp := &ChatCompletionsResponse{
+		ID:      "chatcmpl_1",
+		Object:  "chat.completion",
+		Created: 1,
+		Model:   "deepseek-chat",
+		Choices: []ChatChoice{{
+			Index: 0,
+			Message: ChatMessage{
+				Role:             "assistant",
+				Content:          json.RawMessage(`"ok"`),
+				ReasoningContent: "thinking",
+				ToolCalls: []ChatToolCall{{
+					ID:   "call_1",
+					Type: "function",
+					Function: ChatFunctionCall{
+						Name:      "weather",
+						Arguments: `{"city":"Tokyo"}`,
+					},
+				}},
+			},
+			FinishReason: "stop",
+		}},
+		Usage: &ChatUsage{
+			PromptTokens:     10,
+			CompletionTokens: 3,
+			TotalTokens:      13,
+			PromptTokensDetails: &ChatTokenDetails{
+				CachedTokens: 2,
+			},
+		},
+	}
+
+	out := ChatCompletionsToResponsesResponse(resp, "gpt-5.4-mini")
+	require.Equal(t, "response", out.Object)
+	require.Equal(t, "gpt-5.4-mini", out.Model)
+	require.Len(t, out.Output, 3)
+	assert.Equal(t, "reasoning", out.Output[0].Type)
+	assert.Equal(t, "message", out.Output[1].Type)
+	assert.Equal(t, "function_call", out.Output[2].Type)
+	require.NotNil(t, out.Usage)
+	assert.Equal(t, 10, out.Usage.InputTokens)
+	assert.Equal(t, 3, out.Usage.OutputTokens)
+	require.NotNil(t, out.Usage.InputTokensDetails)
+	assert.Equal(t, 2, out.Usage.InputTokensDetails.CachedTokens)
+}
+
+func intPtr(v int) *int {
+	return &v
+}
+
 func TestChatCompletionsToResponses_ServiceTier(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model:       "gpt-4o",

--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions_request.go
@@ -1,0 +1,290 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// ResponsesToChatCompletionsRequest converts an OpenAI Responses request into a
+// Chat Completions request so OpenAI-compatible upstreams that only expose
+// /chat/completions can still serve /v1/responses callers.
+func ResponsesToChatCompletionsRequest(req *ResponsesRequest) (*ChatCompletionsRequest, error) {
+	if req == nil {
+		return nil, fmt.Errorf("responses request is nil")
+	}
+
+	out := &ChatCompletionsRequest{
+		Model:       req.Model,
+		Temperature: req.Temperature,
+		TopP:        req.TopP,
+		Stream:      req.Stream,
+		ToolChoice:  req.ToolChoice,
+		ServiceTier: req.ServiceTier,
+	}
+
+	if req.MaxOutputTokens != nil {
+		v := *req.MaxOutputTokens
+		out.MaxTokens = &v
+	}
+	if req.Reasoning != nil {
+		out.ReasoningEffort = req.Reasoning.Effort
+	}
+	if len(req.Tools) > 0 {
+		out.Tools = convertResponsesToolsToChat(req.Tools)
+	}
+	if req.Instructions != "" {
+		content, _ := json.Marshal(req.Instructions)
+		out.Messages = append(out.Messages, ChatMessage{
+			Role:    "system",
+			Content: content,
+		})
+	}
+
+	if len(req.Input) == 0 {
+		return out, nil
+	}
+
+	var inputString string
+	if err := json.Unmarshal(req.Input, &inputString); err == nil {
+		content, _ := json.Marshal(inputString)
+		out.Messages = append(out.Messages, ChatMessage{
+			Role:    "user",
+			Content: content,
+		})
+		return out, nil
+	}
+
+	var inputItems []ResponsesInputItem
+	if err := json.Unmarshal(req.Input, &inputItems); err != nil {
+		return nil, fmt.Errorf("parse responses input: %w", err)
+	}
+
+	for _, item := range inputItems {
+		msg, err := responsesInputItemToChatMessages(item)
+		if err != nil {
+			return nil, err
+		}
+		out.Messages = append(out.Messages, msg...)
+	}
+
+	return out, nil
+}
+
+func convertResponsesToolsToChat(tools []ResponsesTool) []ChatTool {
+	out := make([]ChatTool, 0, len(tools))
+	for _, tool := range tools {
+		if tool.Type != "function" {
+			continue
+		}
+		out = append(out, ChatTool{
+			Type: "function",
+			Function: &ChatFunction{
+				Name:        tool.Name,
+				Description: tool.Description,
+				Parameters:  tool.Parameters,
+				Strict:      tool.Strict,
+			},
+		})
+	}
+	return out
+}
+
+func responsesInputItemToChatMessages(item ResponsesInputItem) ([]ChatMessage, error) {
+	switch item.Type {
+	case "function_call":
+		return []ChatMessage{{
+			Role: "assistant",
+			ToolCalls: []ChatToolCall{{
+				ID:   item.CallID,
+				Type: "function",
+				Function: ChatFunctionCall{
+					Name:      item.Name,
+					Arguments: defaultJSONObjectString(item.Arguments),
+				},
+			}},
+		}}, nil
+	case "function_call_output":
+		outputContent, _ := json.Marshal(item.Output)
+		return []ChatMessage{{
+			Role:       "tool",
+			ToolCallID: item.CallID,
+			Content:    outputContent,
+		}}, nil
+	}
+
+	role := item.Role
+	if role == "" {
+		role = "user"
+	}
+	content, err := responsesMessageContentToChat(item.Content)
+	if err != nil {
+		return nil, fmt.Errorf("convert responses item content: %w", err)
+	}
+	return []ChatMessage{{
+		Role:    role,
+		Content: content,
+	}}, nil
+}
+
+func responsesMessageContentToChat(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return json.RawMessage(`""`), nil
+	}
+
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		return json.Marshal(plain)
+	}
+
+	var parts []ResponsesContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return nil, err
+	}
+
+	chatParts := make([]ChatContentPart, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case "input_text", "output_text", "text":
+			chatParts = append(chatParts, ChatContentPart{
+				Type: "text",
+				Text: part.Text,
+			})
+		case "input_image":
+			chatParts = append(chatParts, ChatContentPart{
+				Type: "image_url",
+				ImageURL: &ChatImageURL{
+					URL: part.ImageURL,
+				},
+			})
+		}
+	}
+
+	return json.Marshal(chatParts)
+}
+
+func defaultJSONObjectString(raw string) string {
+	if raw == "" {
+		return "{}"
+	}
+	return raw
+}
+
+// ChatCompletionsToResponsesResponse converts a Chat Completions response into
+// a Responses response for OpenAI-compatible upstreams that only speak
+// /chat/completions.
+func ChatCompletionsToResponsesResponse(resp *ChatCompletionsResponse, model string) *ResponsesResponse {
+	if resp == nil {
+		return &ResponsesResponse{
+			Object: "response",
+			Model:  model,
+			Status: "completed",
+			Output: []ResponsesOutput{{
+				Type:    "message",
+				Role:    "assistant",
+				Status:  "completed",
+				Content: []ResponsesContentPart{{Type: "output_text", Text: ""}},
+			}},
+		}
+	}
+
+	out := &ResponsesResponse{
+		ID:     resp.ID,
+		Object: "response",
+		Model:  model,
+		Status: "completed",
+	}
+
+	if len(resp.Choices) == 0 {
+		out.Output = []ResponsesOutput{{
+			Type:    "message",
+			Role:    "assistant",
+			Status:  "completed",
+			Content: []ResponsesContentPart{{Type: "output_text", Text: ""}},
+		}}
+		return out
+	}
+
+	choice := resp.Choices[0]
+	var outputs []ResponsesOutput
+
+	if choice.Message.ReasoningContent != "" {
+		outputs = append(outputs, ResponsesOutput{
+			Type: "reasoning",
+			Summary: []ResponsesSummary{{
+				Type: "summary_text",
+				Text: choice.Message.ReasoningContent,
+			}},
+		})
+	}
+
+	if text := extractChatMessageText(choice.Message.Content); text != "" || len(choice.Message.ToolCalls) == 0 {
+		outputs = append(outputs, ResponsesOutput{
+			Type:   "message",
+			Role:   "assistant",
+			Status: "completed",
+			Content: []ResponsesContentPart{{
+				Type: "output_text",
+				Text: text,
+			}},
+		})
+	}
+
+	for _, toolCall := range choice.Message.ToolCalls {
+		outputs = append(outputs, ResponsesOutput{
+			Type:      "function_call",
+			ID:        toolCall.ID,
+			CallID:    toolCall.ID,
+			Name:      toolCall.Function.Name,
+			Arguments: defaultJSONObjectString(toolCall.Function.Arguments),
+			Status:    "completed",
+		})
+	}
+
+	out.Output = outputs
+	switch choice.FinishReason {
+	case "length":
+		out.Status = "incomplete"
+		out.IncompleteDetails = &ResponsesIncompleteDetails{Reason: "max_output_tokens"}
+	default:
+		out.Status = "completed"
+	}
+
+	if resp.Usage != nil {
+		out.Usage = &ResponsesUsage{
+			InputTokens:  resp.Usage.PromptTokens,
+			OutputTokens: resp.Usage.CompletionTokens,
+			TotalTokens:  resp.Usage.TotalTokens,
+		}
+		if resp.Usage.PromptTokensDetails != nil && resp.Usage.PromptTokensDetails.CachedTokens > 0 {
+			out.Usage.InputTokensDetails = &ResponsesInputTokensDetails{
+				CachedTokens: resp.Usage.PromptTokensDetails.CachedTokens,
+			}
+		}
+	}
+
+	return out
+}
+
+func extractChatMessageText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		return plain
+	}
+
+	var parts []ChatContentPart
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return ""
+	}
+
+	var text string
+	for _, part := range parts {
+		if part.Type == "text" {
+			text += part.Text
+		}
+	}
+	return text
+}

--- a/backend/internal/pkg/httputil/body.go
+++ b/backend/internal/pkg/httputil/body.go
@@ -2,8 +2,13 @@ package httputil
 
 import (
 	"bytes"
+	"compress/gzip"
 	"io"
 	"net/http"
+	"strings"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 )
 
 const (
@@ -15,6 +20,19 @@ const (
 func ReadRequestBodyWithPrealloc(req *http.Request) ([]byte, error) {
 	if req == nil || req.Body == nil {
 		return nil, nil
+	}
+
+	bodyReader := req.Body
+	contentEncoding := strings.ToLower(strings.TrimSpace(req.Header.Get("Content-Encoding")))
+	if contentEncoding != "" && contentEncoding != "identity" {
+		var err error
+		bodyReader, err = decodeRequestBodyReader(req.Body, contentEncoding)
+		if err != nil {
+			return nil, err
+		}
+		defer bodyReader.Close()
+		req.Header.Del("Content-Encoding")
+		req.ContentLength = -1
 	}
 
 	capHint := requestBodyReadInitCap
@@ -30,8 +48,34 @@ func ReadRequestBodyWithPrealloc(req *http.Request) ([]byte, error) {
 	}
 
 	buf := bytes.NewBuffer(make([]byte, 0, capHint))
-	if _, err := io.Copy(buf, req.Body); err != nil {
+	if _, err := io.Copy(buf, bodyReader); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil
+}
+
+func decodeRequestBodyReader(body io.ReadCloser, contentEncoding string) (io.ReadCloser, error) {
+	switch contentEncoding {
+	case "gzip":
+		return gzip.NewReader(body)
+	case "br":
+		return io.NopCloser(brotli.NewReader(body)), nil
+	case "zstd":
+		reader, err := zstd.NewReader(body)
+		if err != nil {
+			return nil, err
+		}
+		return &zstdReadCloser{Decoder: reader}, nil
+	default:
+		return body, nil
+	}
+}
+
+type zstdReadCloser struct {
+	*zstd.Decoder
+}
+
+func (r *zstdReadCloser) Close() error {
+	r.Decoder.Close()
+	return nil
 }

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -90,11 +89,12 @@ func NewAccountTestService(
 }
 
 func (s *AccountTestService) validateUpstreamBaseURL(raw string) (string, error) {
-	if s.cfg == nil {
-		return "", errors.New("config is not available")
+	allowInsecureHTTP := false
+	if s.cfg != nil {
+		allowInsecureHTTP = s.cfg.Security.URLAllowlist.AllowInsecureHTTP
 	}
-	if !s.cfg.Security.URLAllowlist.Enabled {
-		return urlvalidator.ValidateURLFormat(raw, s.cfg.Security.URLAllowlist.AllowInsecureHTTP)
+	if s.cfg == nil || !s.cfg.Security.URLAllowlist.Enabled {
+		return urlvalidator.ValidateURLFormat(raw, allowInsecureHTTP)
 	}
 	normalized, err := urlvalidator.ValidateHTTPSURL(raw, urlvalidator.ValidationOptions{
 		AllowedHosts:     s.cfg.Security.URLAllowlist.UpstreamHosts,
@@ -453,6 +453,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	var apiURL string
 	var isOAuth bool
 	var chatgptAccountID string
+	var useChatCompletionsAPI bool
 
 	if account.IsOAuth() {
 		isOAuth = true
@@ -480,7 +481,12 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
 		}
-		apiURL = strings.TrimSuffix(normalizedBaseURL, "/") + "/responses"
+		if isDeepSeekBaseURL(normalizedBaseURL) {
+			useChatCompletionsAPI = true
+			apiURL = buildOpenAIChatCompletionsURL(normalizedBaseURL)
+		} else {
+			apiURL = buildOpenAIResponsesURL(normalizedBaseURL)
+		}
 	} else {
 		return s.sendErrorAndEnd(c, fmt.Sprintf("Unsupported account type: %s", account.Type))
 	}
@@ -492,8 +498,15 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
 	c.Writer.Flush()
 
-	// Create OpenAI Responses API payload
-	payload := createOpenAITestPayload(testModelID, isOAuth)
+	// Create OpenAI test payload.
+	// DeepSeek's official OpenAI-compatible API is centered on /chat/completions,
+	// so its connectivity probe must avoid the Responses-only shape.
+	var payload map[string]any
+	if useChatCompletionsAPI {
+		payload = createOpenAIChatCompletionsTestPayload(testModelID)
+	} else {
+		payload = createOpenAITestPayload(testModelID, isOAuth)
+	}
 	payloadBytes, _ := json.Marshal(payload)
 
 	// Send test_start event
@@ -507,6 +520,9 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	// Set common headers
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+authToken)
+	if useChatCompletionsAPI {
+		req.Header.Set("accept", "text/event-stream")
+	}
 
 	// Set OAuth-specific headers for ChatGPT internal API
 	if isOAuth {
@@ -549,7 +565,10 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
-	// Process SSE stream
+	// Process SSE stream.
+	if useChatCompletionsAPI {
+		return s.processOpenAIChatCompletionsStream(c, resp.Body)
+	}
 	return s.processOpenAIStream(c, resp.Body)
 }
 
@@ -1088,6 +1107,19 @@ func createOpenAITestPayload(modelID string, isOAuth bool) map[string]any {
 	return payload
 }
 
+func createOpenAIChatCompletionsTestPayload(modelID string) map[string]any {
+	return map[string]any{
+		"model": modelID,
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": "hi",
+			},
+		},
+		"stream": true,
+	}
+}
+
 // processClaudeStream processes the SSE stream from Claude API
 func (s *AccountTestService) processClaudeStream(c *gin.Context, body io.Reader) error {
 	reader := bufio.NewReader(body)
@@ -1208,6 +1240,84 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 				}
 			}
 			return s.sendErrorAndEnd(c, errorMsg)
+		}
+	}
+}
+
+// processOpenAIChatCompletionsStream processes the SSE stream from
+// OpenAI-compatible /chat/completions providers such as DeepSeek.
+func (s *AccountTestService) processOpenAIChatCompletionsStream(c *gin.Context, body io.Reader) error {
+	reader := bufio.NewReader(body)
+	seenTerminal := false
+	seenContent := false
+
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err == io.EOF {
+				if seenTerminal || seenContent {
+					s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+					return nil
+				}
+				return s.sendErrorAndEnd(c, "Stream ended before completion")
+			}
+			return s.sendErrorAndEnd(c, fmt.Sprintf("Stream read error: %s", err.Error()))
+		}
+
+		line = strings.TrimSpace(line)
+		if line == "" || !sseDataPrefix.MatchString(line) {
+			continue
+		}
+
+		jsonStr := sseDataPrefix.ReplaceAllString(line, "")
+		if jsonStr == "[DONE]" {
+			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+			return nil
+		}
+
+		var data map[string]any
+		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+			continue
+		}
+
+		if errData, ok := data["error"].(map[string]any); ok {
+			errorMsg := "Unknown error"
+			if msg, ok := errData["message"].(string); ok && msg != "" {
+				errorMsg = msg
+			}
+			return s.sendErrorAndEnd(c, errorMsg)
+		}
+
+		choices, ok := data["choices"].([]any)
+		if !ok {
+			continue
+		}
+
+		for _, rawChoice := range choices {
+			choice, ok := rawChoice.(map[string]any)
+			if !ok {
+				continue
+			}
+			if delta, ok := choice["delta"].(map[string]any); ok {
+				if text, ok := delta["content"].(string); ok && text != "" {
+					seenContent = true
+					s.sendEvent(c, TestEvent{Type: "content", Text: text})
+				}
+			}
+			if msg, ok := choice["message"].(map[string]any); ok {
+				if text, ok := msg["content"].(string); ok && text != "" {
+					seenContent = true
+					s.sendEvent(c, TestEvent{Type: "content", Text: text})
+				}
+			}
+			if finishReason, exists := choice["finish_reason"]; exists && finishReason != nil {
+				seenTerminal = true
+			}
+		}
+
+		if seenTerminal {
+			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+			return nil
 		}
 	}
 }

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -150,6 +150,39 @@ func TestAccountTestService_OpenAIStreamEOFBeforeCompletedFails(t *testing.T) {
 	require.NotContains(t, recorder.Body.String(), `"success":true`)
 }
 
+func TestAccountTestService_OpenAIDeepSeekAPIKeyUsesChatCompletionsPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, recorder := newTestContext()
+
+	resp := newJSONResponse(http.StatusOK, "")
+	resp.Body = io.NopCloser(strings.NewReader(`data: {"choices":[{"delta":{"content":"ok"},"finish_reason":null}]}
+
+data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+`))
+
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{httpUpstream: upstream}
+	account := &Account{
+		ID:          91,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "test-token",
+			"base_url": "https://api.deepseek.com",
+		},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "deepseek-chat", "", "")
+	require.NoError(t, err)
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "https://api.deepseek.com/chat/completions", upstream.requests[0].URL.String())
+	require.Contains(t, recorder.Body.String(), "test_complete")
+}
+
 func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimitState(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, _ := newTestContext()

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -73,6 +73,19 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		compatPromptCacheInjected = promptCacheKey != ""
 	}
 
+	if shouldUseDirectOpenAIChatCompletionsUpstream(account) {
+		return s.forwardDirectChatCompletionsUpstream(
+			ctx,
+			c,
+			account,
+			&chatReq,
+			originalModel,
+			billingModel,
+			upstreamModel,
+			startTime,
+		)
+	}
+
 	// 3. Build the upstream (Responses API) body.
 	//
 	// Cursor compatibility: some clients (notably Cursor cloud) send Responses
@@ -288,6 +301,211 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	}
 
 	return result, handleErr
+}
+
+func (s *OpenAIGatewayService) forwardDirectChatCompletionsUpstream(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	chatReq *apicompat.ChatCompletionsRequest,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	if chatReq == nil {
+		return nil, fmt.Errorf("chat completions request is nil")
+	}
+
+	baseURL := account.GetOpenAIBaseURL()
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = "https://api.openai.com"
+	}
+	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	targetURL := buildOpenAIChatCompletionsURL(validatedURL)
+
+	chatReq.Model = upstreamModel
+	upstreamBody, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal chat completions request: %w", err)
+	}
+
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(upstreamBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("authorization", "Bearer "+token)
+
+	for key, values := range c.Request.Header {
+		lowerKey := strings.ToLower(key)
+		if openaiAllowedHeaders[lowerKey] {
+			for _, v := range values {
+				req.Header.Add(key, v)
+			}
+		}
+	}
+
+	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+		req.Header.Set("user-agent", customUA)
+	}
+	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		req.Header.Set("user-agent", codexCLIUserAgent)
+	}
+	if req.Header.Get("content-type") == "" {
+		req.Header.Set("content-type", "application/json")
+	}
+	if chatReq.Stream {
+		req.Header.Set("accept", "text/event-stream")
+	} else {
+		req.Header.Set("accept", "application/json")
+	}
+
+	proxyURL := ""
+	if account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		writeChatCompletionsError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+		if upstreamMsg == "" {
+			upstreamMsg = string(respBody)
+		}
+		writeChatCompletionsError(c, mapUpstreamStatusCode(resp.StatusCode), "server_error", upstreamMsg)
+		return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
+	}
+
+	if chatReq.Stream {
+		return s.handleDirectChatCompletionsStream(resp, c, originalModel, billingModel, upstreamModel, startTime)
+	}
+	return s.handleDirectChatCompletionsJSON(resp, c, originalModel, billingModel, upstreamModel, startTime)
+}
+
+func (s *OpenAIGatewayService) handleDirectChatCompletionsJSON(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	usage := OpenAIUsage{}
+	usage.InputTokens = int(gjson.GetBytes(body, "usage.prompt_tokens").Int())
+	usage.OutputTokens = int(gjson.GetBytes(body, "usage.completion_tokens").Int())
+	usage.CacheReadInputTokens = int(gjson.GetBytes(body, "usage.prompt_tokens_details.cached_tokens").Int())
+
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json; charset=utf-8"
+	}
+	c.Data(resp.StatusCode, contentType, body)
+
+	return &OpenAIForwardResult{
+		RequestID:       resp.Header.Get("x-request-id"),
+		Usage:           usage,
+		Model:           originalModel,
+		BillingModel:    billingModel,
+		UpstreamModel:   upstreamModel,
+		Stream:          false,
+		ResponseHeaders: resp.Header.Clone(),
+		Duration:        time.Since(startTime),
+	}, nil
+}
+
+func (s *OpenAIGatewayService) handleDirectChatCompletionsStream(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	reader := bufio.NewReader(resp.Body)
+	usage := OpenAIUsage{}
+	var firstTokenMs *int
+
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			trimmed := strings.TrimRight(line, "\r\n")
+			if strings.HasPrefix(trimmed, "data: ") {
+				payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data: "))
+				if payload != "" && payload != "[DONE]" {
+					if firstTokenMs == nil {
+						ms := int(time.Since(startTime).Milliseconds())
+						firstTokenMs = &ms
+					}
+					usage.InputTokens = int(gjson.Get(payload, "usage.prompt_tokens").Int())
+					usage.OutputTokens = int(gjson.Get(payload, "usage.completion_tokens").Int())
+					usage.CacheReadInputTokens = int(gjson.Get(payload, "usage.prompt_tokens_details.cached_tokens").Int())
+				}
+			}
+
+			if _, writeErr := io.WriteString(c.Writer, line); writeErr != nil {
+				return &OpenAIForwardResult{
+					RequestID:     requestID,
+					Usage:         usage,
+					Model:         originalModel,
+					BillingModel:  billingModel,
+					UpstreamModel: upstreamModel,
+					Stream:        true,
+					FirstTokenMs:  firstTokenMs,
+					Duration:      time.Since(startTime),
+				}, nil
+			}
+			c.Writer.Flush()
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				return &OpenAIForwardResult{
+					RequestID:       requestID,
+					Usage:           usage,
+					Model:           originalModel,
+					BillingModel:    billingModel,
+					UpstreamModel:   upstreamModel,
+					Stream:          true,
+					ResponseHeaders: resp.Header.Clone(),
+					FirstTokenMs:    firstTokenMs,
+					Duration:        time.Since(startTime),
+				}, nil
+			}
+			return nil, err
+		}
+	}
 }
 
 func normalizeResponsesRequestServiceTier(req *apicompat.ResponsesRequest) {

--- a/backend/internal/service/openai_gateway_chat_completions_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_test.go
@@ -1,9 +1,16 @@
 package service
 
 import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -72,4 +79,156 @@ func TestNormalizeResponsesBodyServiceTier(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, tier)
 	require.False(t, gjson.GetBytes(body, "service_tier").Exists())
+}
+
+func TestIsDeepSeekBaseURL(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isDeepSeekBaseURL("https://api.deepseek.com"))
+	require.True(t, isDeepSeekBaseURL("https://api.deepseek.com/v1"))
+	require.False(t, isDeepSeekBaseURL("https://api.openai.com"))
+}
+
+func TestBuildOpenAIChatCompletionsURL(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "https://api.deepseek.com/chat/completions", buildOpenAIChatCompletionsURL("https://api.deepseek.com"))
+	require.Equal(t, "https://api.deepseek.com/v1/chat/completions", buildOpenAIChatCompletionsURL("https://api.deepseek.com/v1"))
+	require.Equal(t, "https://api.deepseek.com/chat/completions", buildOpenAIChatCompletionsURL("https://api.deepseek.com/chat/completions"))
+}
+
+func TestOpenAIGatewayService_ForwardAsChatCompletions_DeepSeekUsesDirectChatPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.3","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1}}`,
+		"",
+		`data: [DONE]`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_deepseek"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "deepseek",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://api.deepseek.com",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.deepseek.com/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "gpt-5.3", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Contains(t, rec.Body.String(), "chat.completion.chunk")
+	require.Contains(t, rec.Body.String(), "[DONE]")
+}
+
+func TestOpenAIGatewayService_Forward_DeepSeekUsesDirectResponsesJSONPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.4-mini","input":"hello","stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_deepseek_resp"}},
+		Body: io.NopCloser(strings.NewReader(`{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1,
+			"model":"deepseek-chat",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":4,"completion_tokens":2,"total_tokens":6}
+		}`)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "deepseek",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://api.deepseek.com",
+		},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "https://api.deepseek.com/chat/completions", upstream.lastReq.URL.String())
+	require.Equal(t, "gpt-5.4-mini", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "system", gjson.GetBytes(upstream.lastBody, "messages.0.role").String())
+	require.Equal(t, "hello", gjson.GetBytes(upstream.lastBody, "messages.1.content").String())
+	require.Equal(t, "response", gjson.GetBytes(rec.Body.Bytes(), "object").String())
+	require.Equal(t, "ok", gjson.Get(rec.Body.String(), "output.0.content.0.text").String())
+}
+
+func TestOpenAIGatewayService_Forward_DeepSeekUsesDirectResponsesStreamPath(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.4-mini","input":"hello","stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}`,
+		"",
+		`data: [DONE]`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_deepseek_stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "deepseek",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://api.deepseek.com",
+		},
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), "event: response.created")
+	require.Contains(t, rec.Body.String(), "event: response.output_text.delta")
+	require.Contains(t, rec.Body.String(), "event: response.completed")
+	require.Contains(t, rec.Body.String(), "data: [DONE]")
 }

--- a/backend/internal/service/openai_gateway_responses_direct.go
+++ b/backend/internal/service/openai_gateway_responses_direct.go
@@ -1,0 +1,504 @@
+package service
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+type directResponsesStreamToolState struct {
+	OutputIndex int
+	ItemID      string
+	CallID      string
+	Name        string
+}
+
+type directResponsesStreamState struct {
+	ResponseID       string
+	Model            string
+	CreatedUnix      int64
+	CreatedSent      bool
+	MessageItemID    string
+	MessageStarted   bool
+	ReasoningItemID  string
+	ReasoningStarted bool
+	ToolStates       map[int]*directResponsesStreamToolState
+	Accumulator      *apicompat.BufferedResponseAccumulator
+	Usage            OpenAIUsage
+}
+
+func newDirectResponsesStreamState(model string) *directResponsesStreamState {
+	return &directResponsesStreamState{
+		Model:       model,
+		CreatedUnix: time.Now().Unix(),
+		ToolStates:  make(map[int]*directResponsesStreamToolState),
+		Accumulator: apicompat.NewBufferedResponseAccumulator(),
+	}
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIResponsesViaChatCompletions(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	var responsesReq apicompat.ResponsesRequest
+	if err := json.Unmarshal(body, &responsesReq); err != nil {
+		return nil, fmt.Errorf("parse responses request: %w", err)
+	}
+	chatReq, err := apicompat.ResponsesToChatCompletionsRequest(&responsesReq)
+	if err != nil {
+		return nil, fmt.Errorf("convert responses request to chat completions: %w", err)
+	}
+	chatReq.Model = upstreamModel
+
+	baseURL := account.GetOpenAIBaseURL()
+	if strings.TrimSpace(baseURL) == "" {
+		baseURL = "https://api.openai.com"
+	}
+	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	targetURL := buildOpenAIChatCompletionsURL(validatedURL)
+
+	upstreamBody, err := json.Marshal(chatReq)
+	if err != nil {
+		return nil, fmt.Errorf("marshal chat completions request: %w", err)
+	}
+	setOpsUpstreamRequestBody(c, upstreamBody)
+
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("get access token: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(upstreamBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("authorization", "Bearer "+token)
+	for key, values := range c.Request.Header {
+		lowerKey := strings.ToLower(key)
+		if openaiAllowedHeaders[lowerKey] {
+			for _, v := range values {
+				req.Header.Add(key, v)
+			}
+		}
+	}
+	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+		req.Header.Set("user-agent", customUA)
+	}
+	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		req.Header.Set("user-agent", codexCLIUserAgent)
+	}
+	if req.Header.Get("content-type") == "" {
+		req.Header.Set("content-type", "application/json")
+	}
+	if chatReq.Stream {
+		req.Header.Set("accept", "text/event-stream")
+	} else {
+		req.Header.Set("accept", "application/json")
+	}
+
+	proxyURL := ""
+	if account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		c.JSON(http.StatusBadGateway, gin.H{
+			"error": gin.H{
+				"type":    "upstream_error",
+				"message": "Upstream request failed",
+			},
+		})
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+		if upstreamMsg == "" {
+			upstreamMsg = string(respBody)
+		}
+		setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, "")
+		c.JSON(mapUpstreamStatusCode(resp.StatusCode), gin.H{
+			"error": gin.H{
+				"type":    "upstream_error",
+				"message": upstreamMsg,
+			},
+		})
+		return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
+	}
+
+	if chatReq.Stream {
+		return s.handleDirectResponsesStream(resp, c, originalModel, billingModel, upstreamModel, startTime)
+	}
+	return s.handleDirectResponsesJSON(resp, c, originalModel, billingModel, upstreamModel, startTime)
+}
+
+func (s *OpenAIGatewayService) handleDirectResponsesJSON(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var chatResp apicompat.ChatCompletionsResponse
+	if err := json.Unmarshal(body, &chatResp); err != nil {
+		return nil, s.writeOpenAINonStreamingProtocolError(resp, c, "Failed to parse chat completions response")
+	}
+
+	responsesResp := apicompat.ChatCompletionsToResponsesResponse(&chatResp, originalModel)
+	respBody, err := json.Marshal(responsesResp)
+	if err != nil {
+		return nil, err
+	}
+
+	usage := OpenAIUsage{
+		InputTokens:              int(gjson.GetBytes(body, "usage.prompt_tokens").Int()),
+		OutputTokens:             int(gjson.GetBytes(body, "usage.completion_tokens").Int()),
+		CacheReadInputTokens:     int(gjson.GetBytes(body, "usage.prompt_tokens_details.cached_tokens").Int()),
+		CacheCreationInputTokens: 0,
+	}
+
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	c.Data(http.StatusOK, "application/json; charset=utf-8", respBody)
+
+	return &OpenAIForwardResult{
+		RequestID:       resp.Header.Get("x-request-id"),
+		Usage:           usage,
+		Model:           originalModel,
+		BillingModel:    billingModel,
+		UpstreamModel:   upstreamModel,
+		Stream:          false,
+		ResponseHeaders: resp.Header.Clone(),
+		Duration:        time.Since(startTime),
+	}, nil
+}
+
+func (s *OpenAIGatewayService) handleDirectResponsesStream(
+	resp *http.Response,
+	c *gin.Context,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+	if s.responseHeaderFilter != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	}
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+
+	state := newDirectResponsesStreamState(originalModel)
+	reader := bufio.NewReader(resp.Body)
+	var firstTokenMs *int
+	completed := false
+
+	emit := func(evt apicompat.ResponsesStreamEvent) error {
+		switch evt.Type {
+		case "response.output_item.added", "response.output_text.delta", "response.reasoning_summary_text.delta", "response.function_call_arguments.delta":
+			state.Accumulator.ProcessEvent(&evt)
+		case "response.completed", "response.incomplete":
+			completed = true
+		}
+		formatted, err := apicompat.ResponsesEventToSSE(evt)
+		if err != nil {
+			return err
+		}
+		_, err = io.WriteString(c.Writer, formatted)
+		if err == nil {
+			c.Writer.Flush()
+		}
+		return err
+	}
+
+	for {
+		line, err := reader.ReadString('\n')
+		if line != "" {
+			trimmed := strings.TrimRight(line, "\r\n")
+			if strings.HasPrefix(trimmed, "data: ") {
+				payload := strings.TrimSpace(strings.TrimPrefix(trimmed, "data: "))
+				if payload != "" && payload != "[DONE]" {
+					if firstTokenMs == nil {
+						ms := int(time.Since(startTime).Milliseconds())
+						firstTokenMs = &ms
+					}
+					var chunk apicompat.ChatCompletionsChunk
+					if json.Unmarshal([]byte(payload), &chunk) == nil {
+						events := directResponsesEventsFromChatChunk(state, &chunk)
+						for _, evt := range events {
+							if writeErr := emit(evt); writeErr != nil {
+								return buildDirectResponsesStreamResult(requestID, state, originalModel, billingModel, upstreamModel, resp, startTime, firstTokenMs), nil
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if err != nil {
+			if err == io.EOF {
+				if !completed {
+					for _, evt := range finalizeDirectResponsesEvents(state) {
+						if writeErr := emit(evt); writeErr != nil {
+							break
+						}
+					}
+				}
+				_, _ = io.WriteString(c.Writer, "data: [DONE]\n\n")
+				c.Writer.Flush()
+				return buildDirectResponsesStreamResult(requestID, state, originalModel, billingModel, upstreamModel, resp, startTime, firstTokenMs), nil
+			}
+			return nil, err
+		}
+	}
+}
+
+func buildDirectResponsesStreamResult(
+	requestID string,
+	state *directResponsesStreamState,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	resp *http.Response,
+	startTime time.Time,
+	firstTokenMs *int,
+) *OpenAIForwardResult {
+	return &OpenAIForwardResult{
+		RequestID:       requestID,
+		Usage:           state.Usage,
+		Model:           originalModel,
+		BillingModel:    billingModel,
+		UpstreamModel:   upstreamModel,
+		Stream:          true,
+		ResponseHeaders: resp.Header.Clone(),
+		FirstTokenMs:    firstTokenMs,
+		Duration:        time.Since(startTime),
+	}
+}
+
+func directResponsesEventsFromChatChunk(state *directResponsesStreamState, chunk *apicompat.ChatCompletionsChunk) []apicompat.ResponsesStreamEvent {
+	if chunk == nil {
+		return nil
+	}
+	if chunk.ID != "" {
+		state.ResponseID = chunk.ID
+	}
+	if chunk.Model != "" {
+		state.Model = chunk.Model
+	}
+	if chunk.Usage != nil {
+		state.Usage.InputTokens = chunk.Usage.PromptTokens
+		state.Usage.OutputTokens = chunk.Usage.CompletionTokens
+		if chunk.Usage.PromptTokensDetails != nil {
+			state.Usage.CacheReadInputTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+		}
+	}
+
+	var events []apicompat.ResponsesStreamEvent
+	if !state.CreatedSent {
+		state.CreatedSent = true
+		events = append(events, apicompat.ResponsesStreamEvent{
+			Type: "response.created",
+			Response: &apicompat.ResponsesResponse{
+				ID:     state.responseID(),
+				Object: "response",
+				Model:  state.Model,
+				Status: "in_progress",
+			},
+		})
+	}
+
+	for _, choice := range chunk.Choices {
+		if delta := choice.Delta.ReasoningContent; delta != nil && *delta != "" {
+			if !state.ReasoningStarted {
+				state.ReasoningStarted = true
+				state.ReasoningItemID = fmt.Sprintf("%s_reasoning", state.responseID())
+				events = append(events, apicompat.ResponsesStreamEvent{
+					Type:        "response.output_item.added",
+					OutputIndex: 1,
+					Item: &apicompat.ResponsesOutput{
+						Type:   "reasoning",
+						ID:     state.ReasoningItemID,
+						Status: "in_progress",
+					},
+				})
+			}
+			events = append(events, apicompat.ResponsesStreamEvent{
+				Type:         "response.reasoning_summary_text.delta",
+				OutputIndex:  1,
+				SummaryIndex: 0,
+				ItemID:       state.ReasoningItemID,
+				Delta:        *delta,
+			})
+		}
+
+		if delta := choice.Delta.Content; delta != nil && *delta != "" {
+			if !state.MessageStarted {
+				state.MessageStarted = true
+				state.MessageItemID = fmt.Sprintf("%s_message", state.responseID())
+				events = append(events, apicompat.ResponsesStreamEvent{
+					Type:        "response.output_item.added",
+					OutputIndex: 0,
+					Item: &apicompat.ResponsesOutput{
+						Type:   "message",
+						ID:     state.MessageItemID,
+						Role:   "assistant",
+						Status: "in_progress",
+					},
+				})
+			}
+			events = append(events, apicompat.ResponsesStreamEvent{
+				Type:         "response.output_text.delta",
+				OutputIndex:  0,
+				ContentIndex: 0,
+				ItemID:       state.MessageItemID,
+				Delta:        *delta,
+			})
+		}
+
+		for idx, toolCall := range choice.Delta.ToolCalls {
+			toolIndex := idx
+			if toolCall.Index != nil {
+				toolIndex = *toolCall.Index
+			}
+			toolState, exists := state.ToolStates[toolIndex]
+			if !exists {
+				callID := toolCall.ID
+				if callID == "" {
+					callID = fmt.Sprintf("%s_call_%d", state.responseID(), toolIndex)
+				}
+				toolState = &directResponsesStreamToolState{
+					OutputIndex: 2 + toolIndex,
+					ItemID:      fmt.Sprintf("%s_tool_%d", state.responseID(), toolIndex),
+					CallID:      callID,
+					Name:        toolCall.Function.Name,
+				}
+				state.ToolStates[toolIndex] = toolState
+				events = append(events, apicompat.ResponsesStreamEvent{
+					Type:        "response.output_item.added",
+					OutputIndex: toolState.OutputIndex,
+					Item: &apicompat.ResponsesOutput{
+						Type:   "function_call",
+						ID:     toolState.ItemID,
+						CallID: toolState.CallID,
+						Name:   toolState.Name,
+						Status: "in_progress",
+					},
+				})
+			} else {
+				if toolState.CallID == "" && toolCall.ID != "" {
+					toolState.CallID = toolCall.ID
+				}
+				if toolState.Name == "" && toolCall.Function.Name != "" {
+					toolState.Name = toolCall.Function.Name
+				}
+			}
+			if toolCall.Function.Arguments != "" {
+				events = append(events, apicompat.ResponsesStreamEvent{
+					Type:        "response.function_call_arguments.delta",
+					OutputIndex: toolState.OutputIndex,
+					ItemID:      toolState.ItemID,
+					CallID:      toolState.CallID,
+					Name:        toolState.Name,
+					Delta:       toolCall.Function.Arguments,
+				})
+			}
+		}
+
+		if choice.FinishReason != nil {
+			status := "completed"
+			if *choice.FinishReason == "length" {
+				status = "incomplete"
+			}
+			events = append(events, buildDirectResponsesTerminalEvent(state, status))
+		}
+	}
+
+	return events
+}
+
+func finalizeDirectResponsesEvents(state *directResponsesStreamState) []apicompat.ResponsesStreamEvent {
+	return []apicompat.ResponsesStreamEvent{buildDirectResponsesTerminalEvent(state, "completed")}
+}
+
+func buildDirectResponsesTerminalEvent(state *directResponsesStreamState, status string) apicompat.ResponsesStreamEvent {
+	response := &apicompat.ResponsesResponse{
+		ID:     state.responseID(),
+		Object: "response",
+		Model:  state.Model,
+		Status: status,
+		Output: state.Accumulator.BuildOutput(),
+	}
+	if len(response.Output) == 0 {
+		response.Output = []apicompat.ResponsesOutput{{
+			Type:   "message",
+			Role:   "assistant",
+			Status: "completed",
+			Content: []apicompat.ResponsesContentPart{{
+				Type: "output_text",
+				Text: "",
+			}},
+		}}
+	}
+	response.Usage = &apicompat.ResponsesUsage{
+		InputTokens:  state.Usage.InputTokens,
+		OutputTokens: state.Usage.OutputTokens,
+		TotalTokens:  state.Usage.InputTokens + state.Usage.OutputTokens,
+	}
+	if state.Usage.CacheReadInputTokens > 0 {
+		response.Usage.InputTokensDetails = &apicompat.ResponsesInputTokensDetails{
+			CachedTokens: state.Usage.CacheReadInputTokens,
+		}
+	}
+	if status == "incomplete" {
+		response.IncompleteDetails = &apicompat.ResponsesIncompleteDetails{
+			Reason: "max_output_tokens",
+		}
+	}
+	return apicompat.ResponsesStreamEvent{
+		Type:     "response." + status,
+		Response: response,
+	}
+}
+
+func (s *directResponsesStreamState) responseID() string {
+	if s.ResponseID != "" {
+		return s.ResponseID
+	}
+	s.ResponseID = fmt.Sprintf("resp_%d", time.Now().UnixNano())
+	return s.ResponseID
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2378,6 +2378,19 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
+	if shouldUseDirectOpenAIChatCompletionsUpstream(account) {
+		return s.forwardOpenAIResponsesViaChatCompletions(
+			ctx,
+			c,
+			account,
+			body,
+			originalModel,
+			billingModel,
+			upstreamModel,
+			startTime,
+		)
+	}
+
 	// Get access token
 	token, _, err := s.GetAccessToken(ctx, account)
 	if err != nil {
@@ -4770,8 +4783,12 @@ func (s *OpenAIGatewayService) replaceModelInSSEBody(body, fromModel, toModel st
 }
 
 func (s *OpenAIGatewayService) validateUpstreamBaseURL(raw string) (string, error) {
-	if s.cfg != nil && !s.cfg.Security.URLAllowlist.Enabled {
-		normalized, err := urlvalidator.ValidateURLFormat(raw, s.cfg.Security.URLAllowlist.AllowInsecureHTTP)
+	allowInsecureHTTP := false
+	if s.cfg != nil {
+		allowInsecureHTTP = s.cfg.Security.URLAllowlist.AllowInsecureHTTP
+	}
+	if s.cfg == nil || !s.cfg.Security.URLAllowlist.Enabled {
+		normalized, err := urlvalidator.ValidateURLFormat(raw, allowInsecureHTTP)
 		if err != nil {
 			return "", fmt.Errorf("invalid base_url: %w", err)
 		}

--- a/backend/internal/service/openai_upstream_provider.go
+++ b/backend/internal/service/openai_upstream_provider.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"net/url"
+	"strings"
+)
+
+func isDeepSeekBaseURL(base string) bool {
+	normalized := strings.TrimSpace(base)
+	if normalized == "" {
+		return false
+	}
+
+	if parsed, err := url.Parse(normalized); err == nil && parsed != nil {
+		host := strings.ToLower(strings.TrimSpace(parsed.Hostname()))
+		return host == "api.deepseek.com" || strings.HasSuffix(host, ".deepseek.com")
+	}
+
+	lower := strings.ToLower(normalized)
+	return strings.Contains(lower, "api.deepseek.com")
+}
+
+func buildOpenAIChatCompletionsURL(base string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(base), "/")
+	if strings.HasSuffix(normalized, "/chat/completions") {
+		return normalized
+	}
+	if strings.HasSuffix(normalized, "/v1") {
+		return normalized + "/chat/completions"
+	}
+	return normalized + "/chat/completions"
+}
+
+func shouldUseDirectOpenAIChatCompletionsUpstream(account *Account) bool {
+	if account == nil || account.Type != AccountTypeAPIKey {
+		return false
+	}
+	return isDeepSeekBaseURL(account.GetOpenAIBaseURL())
+}


### PR DESCRIPTION
## 变更内容
- 为 OpenAI DeepSeek API Key 上游补充 `/v1/responses -> /chat/completions` 直连兼容
- 新增 Responses 请求到 Chat Completions 请求的转换，以及 Chat Completions 响应回转为 Responses 响应的适配
- 补充 DeepSeek `/v1/chat/completions` 与 `/v1/responses` 的 JSON / 流式测试
- 保持后台账号测试与现有 DeepSeek 直连路径一致

## 变更原因
DeepSeek OpenAI 兼容接口不提供 `/v1/responses`，而 sub2api 的 OpenAI API Key 路径此前默认按 Responses 协议上游转发，导致配置 DeepSeek 为 OpenAI 上游时，请求 `/v1/responses` 会失败或返回 404。

## 影响
- OpenAI 兼容客户端现在可以通过 sub2api 正常把 `/v1/responses` 请求转发到 DeepSeek 上游
- 已有 DeepSeek `/v1/chat/completions` 兼容路径继续保留
- 后台 DeepSeek 账号测试继续可用

## 根因
sub2api 之前只兼容了 DeepSeek 的 `/chat/completions` 测试与聊天入口，但没有补齐 OpenAI `/v1/responses` 到 DeepSeek `/chat/completions` 的协议映射层。

## 验证
- `go test ./internal/pkg/apicompat ./internal/service -run 'Test(ResponsesToChatCompletionsRequest_BasicTextAndTools|ChatCompletionsToResponsesResponse|OpenAIGatewayService_Forward_DeepSeekUsesDirectResponsesJSONPath|OpenAIGatewayService_Forward_DeepSeekUsesDirectResponsesStreamPath|OpenAIGatewayService_ForwardAsChatCompletions_DeepSeekUsesDirectChatPath|IsDeepSeekBaseURL|BuildOpenAIChatCompletionsURL|NormalizeResponsesRequestServiceTier|NormalizeResponsesBodyServiceTier)' -count=1`
- `go test -tags unit ./internal/service -run 'TestAccountTestService_OpenAIDeepSeekAPIKeyUsesChatCompletionsPath' -count=1`
- 已编译并部署到 223 服务器，确认服务 `sub2api` 为 `active`
