### PR TITLE
fix(gateway): enforce cache control limit across request blocks

### DIFF
--- a/backend/internal/service/gateway_body_order_test.go
+++ b/backend/internal/service/gateway_body_order_test.go
@@ -150,6 +150,34 @@ func TestEnforceCacheControlLimit_PreservesTopLevelFieldOrder(t *testing.T) {
 	require.Equal(t, 4, strings.Count(resultStr, `"cache_control"`))
 }
 
+func TestEnforceCacheControlLimit_CountsTopLevelAndTools(t *testing.T) {
+	body := []byte(`{"alpha":1,"cache_control":{"type":"ephemeral"},"system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral"}}],"messages":[{"role":"user","content":[{"type":"text","text":"m1","cache_control":{"type":"ephemeral"}}]},{"role":"assistant","content":[{"type":"text","text":"a1"}]},{"role":"user","content":[{"type":"text","text":"m2","cache_control":{"type":"ephemeral"}}]}],"tools":[{"name":"a","input_schema":{},"cache_control":{"type":"ephemeral"}}],"omega":2}`)
+
+	result := enforceCacheControlLimit(body)
+	resultStr := string(result)
+
+	assertJSONTokenOrder(t, resultStr, `"alpha"`, `"cache_control"`, `"system"`, `"messages"`, `"tools"`, `"omega"`)
+	require.Equal(t, 4, strings.Count(resultStr, `"cache_control"`))
+	require.False(t, gjson.GetBytes(result, "messages.0.content.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "messages.2.content.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "tools.0.cache_control").Exists())
+}
+
+func TestEnforceCacheControlLimit_RemovesTopLevelBeforeStableBlocks(t *testing.T) {
+	body := []byte(`{"cache_control":{"type":"ephemeral"},"system":[{"type":"text","text":"s1","cache_control":{"type":"ephemeral"}},{"type":"text","text":"s2","cache_control":{"type":"ephemeral"}},{"type":"text","text":"s3","cache_control":{"type":"ephemeral"}}],"tools":[{"name":"a","input_schema":{},"cache_control":{"type":"ephemeral"}}]}`)
+
+	result := enforceCacheControlLimit(body)
+
+	require.Equal(t, 4, strings.Count(string(result), `"cache_control"`))
+	require.False(t, gjson.GetBytes(result, "cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "tools.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.0.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.1.cache_control").Exists())
+	require.True(t, gjson.GetBytes(result, "system.2.cache_control").Exists())
+}
+
 func TestInjectAnthropicCacheControlTTL1h_OnlyUpdatesExistingEphemeralCacheControl(t *testing.T) {
 	body := []byte(`{"alpha":1,"cache_control":{"type":"ephemeral"},"system":[{"type":"text","text":"sys","cache_control":{"type":"ephemeral","ttl":"5m"}},{"type":"text","text":"plain"}],"messages":[{"role":"user","content":[{"type":"text","text":"hi","cache_control":{"type":"ephemeral"}},{"type":"text","text":"non","cache_control":{"type":"persistent","ttl":"5m"}}]}],"tools":[{"name":"a","input_schema":{},"cache_control":{"type":"ephemeral"}}],"omega":2}`)
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4108,7 +4108,11 @@ type cacheControlPath struct {
 	log  string
 }
 
-func collectCacheControlPaths(body []byte) (invalidThinking []cacheControlPath, messagePaths []string, systemPaths []string) {
+func collectCacheControlPaths(body []byte) (invalidThinking []cacheControlPath, topLevelPaths []string, messagePaths []string, systemPaths []string, toolPaths []string) {
+	if gjson.GetBytes(body, "cache_control").Exists() {
+		topLevelPaths = append(topLevelPaths, "cache_control")
+	}
+
 	system := gjson.GetBytes(body, "system")
 	if system.IsArray() {
 		sysIndex := 0
@@ -4157,17 +4161,29 @@ func collectCacheControlPaths(body []byte) (invalidThinking []cacheControlPath, 
 		})
 	}
 
-	return invalidThinking, messagePaths, systemPaths
+	tools := gjson.GetBytes(body, "tools")
+	if tools.IsArray() {
+		toolIndex := 0
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if tool.Get("cache_control").Exists() {
+				toolPaths = append(toolPaths, fmt.Sprintf("tools.%d.cache_control", toolIndex))
+			}
+			toolIndex++
+			return true
+		})
+	}
+
+	return invalidThinking, topLevelPaths, messagePaths, systemPaths, toolPaths
 }
 
 // enforceCacheControlLimit 强制执行 cache_control 块数量限制（最多 4 个）
-// 超限时优先从 messages 中移除 cache_control，保护 system 中的缓存控制
+// 超限时优先移除代理/客户端动态断点，尽量保护 system/tools 中的稳定缓存控制。
 func enforceCacheControlLimit(body []byte) []byte {
 	if len(body) == 0 {
 		return body
 	}
 
-	invalidThinking, messagePaths, systemPaths := collectCacheControlPaths(body)
+	invalidThinking, topLevelPaths, messagePaths, systemPaths, toolPaths := collectCacheControlPaths(body)
 	out := body
 	modified := false
 
@@ -4185,7 +4201,7 @@ func enforceCacheControlLimit(body []byte) []byte {
 		logger.LegacyPrintf("service.gateway", "%s", item.log)
 	}
 
-	count := len(messagePaths) + len(systemPaths)
+	count := len(topLevelPaths) + len(messagePaths) + len(systemPaths) + len(toolPaths)
 	if count <= maxCacheControlBlocks {
 		if modified {
 			return out
@@ -4193,12 +4209,42 @@ func enforceCacheControlLimit(body []byte) []byte {
 		return body
 	}
 
-	// 超限：优先从 messages 中移除，再从 system 中移除
+	// 超限：先移除 messages，再移除顶层自动断点，之后才动 tools/system。
 	remaining := count - maxCacheControlBlocks
 	for _, path := range messagePaths {
 		if remaining <= 0 {
 			break
 		}
+		if !gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		next, ok := deleteJSONPathBytes(out, path)
+		if !ok {
+			continue
+		}
+		out = next
+		modified = true
+		remaining--
+	}
+
+	for _, path := range topLevelPaths {
+		if remaining <= 0 {
+			break
+		}
+		if !gjson.GetBytes(out, path).Exists() {
+			continue
+		}
+		next, ok := deleteJSONPathBytes(out, path)
+		if !ok {
+			continue
+		}
+		out = next
+		modified = true
+		remaining--
+	}
+
+	for i := len(toolPaths) - 1; i >= 0 && remaining > 0; i-- {
+		path := toolPaths[i]
 		if !gjson.GetBytes(out, path).Exists() {
 			continue
 		}
@@ -4990,6 +5036,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	}
 	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
 	input.Body = StripEmptyTextBlocks(input.Body)
+	input.Body = enforceCacheControlLimit(input.Body)
 
 	// 重试间复用同一请求体，避免每次 string(body) 产生额外分配。
 	setOpsUpstreamRequestBody(c, input.Body)


### PR DESCRIPTION
## Summary
- Count top-level and tool `cache_control` blocks when enforcing Anthropic's 4-block limit.
- Prefer removing dynamic message breakpoints, then top-level automatic cache control, before touching tool/system cache controls.
- Apply the same limit enforcement in Anthropic API key passthrough before forwarding upstream.

## Tests
- `go test ./internal/service -run 'TestEnforceCacheControlLimit|TestGatewayService_AnthropicAPIKeyPassthrough_ForwardStreamPreservesBodyAndAuthReplacement'`
- `go test ./internal/service`