### PR TITLE
feat: ops 错误详情弹窗支持自定义时间区间

### DIFF
--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -114,6 +114,8 @@
         <OpsErrorDetailsModal
           :show="showErrorDetails"
           :time-range="timeRange"
+          :custom-start-time="customStartTime"
+          :custom-end-time="customEndTime"
           :platform="platform"
           :group-id="groupId"
           :error-type="errorDetailsType"

--- a/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
+++ b/frontend/src/views/admin/ops/components/OpsErrorDetailsModal.vue
@@ -9,6 +9,8 @@ import { opsAPI, type OpsErrorLog } from '@/api/admin/ops'
 interface Props {
   show: boolean
   timeRange: string
+  customStartTime?: string | null
+  customEndTime?: string | null
   platform?: string
   groupId?: number | null
   errorType: 'request' | 'upstream'
@@ -96,6 +98,17 @@ async function fetchErrorLogs() {
       view: viewMode.value
     }
 
+    if (props.timeRange === 'custom') {
+      if (props.customStartTime && props.customEndTime) {
+        params.start_time = props.customStartTime
+        params.end_time = props.customEndTime
+        delete params.time_range
+      } else {
+        // Safety fallback: avoid sending time_range=custom (backend doesn't support it)
+        params.time_range = '1h'
+      }
+    }
+
     const platform = String(props.platform || '').trim()
     if (platform) params.platform = platform
     if (typeof props.groupId === 'number' && props.groupId > 0) params.group_id = props.groupId
@@ -147,7 +160,7 @@ watch(
 )
 
 watch(
-  () => [props.timeRange, props.platform, props.groupId] as const,
+  () => [props.timeRange, props.customStartTime, props.customEndTime, props.platform, props.groupId] as const,
   () => {
     if (!props.show) return
     page.value = 1


### PR DESCRIPTION
    当前错误详情弹窗当查询时段为自定义时间时, 由于没有传递自定义时间的开始时间和结束时间, 会回退为近1小时而与实际查询时段不一致
    PR增加了自定义的开始时间和结束时间参数传递, 以支持正确的时段查询

示例, 选择自定义时间4月20号 至 5月1号
修改前:
<img width="3828" height="1414" alt="image" src="https://github.com/user-attachments/assets/c3527112-d30c-41e9-9147-30ee8c5ac74a" />

修改后:
<img width="3528" height="1794" alt="image" src="https://github.com/user-attachments/assets/8b28247e-349d-4a64-9c9a-b9764f5184fa" />

