### PR TITLE
fix(gateway): normalizeOpenAIReasoningEffort 识别 DeepSeek 的 reasoning_effort 'max'

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -29,6 +29,12 @@ func TestExtractCCReasoningEffortFromBody(t *testing.T) {
 		require.Equal(t, "xhigh", *got)
 	})
 
+	t.Run("DeepSeek max", func(t *testing.T) {
+		got := extractCCReasoningEffortFromBody([]byte(`{"reasoning_effort":"Max"}`))
+		require.NotNil(t, got)
+		require.Equal(t, "xhigh", *got)
+	})
+
 	t.Run("missing effort", func(t *testing.T) {
 		require.Nil(t, extractCCReasoningEffortFromBody([]byte(`{"model":"gpt-5"}`)))
 	})

--- a/backend/internal/service/gateway_forward_as_responses_test.go
+++ b/backend/internal/service/gateway_forward_as_responses_test.go
@@ -21,6 +21,10 @@ func TestExtractResponsesReasoningEffortFromBody(t *testing.T) {
 	require.NotNil(t, got)
 	require.Equal(t, "high", *got)
 
+	maxGot := ExtractResponsesReasoningEffortFromBody([]byte(`{"model":"deepseek-v4-pro","reasoning":{"effort":"max"}}`))
+	require.NotNil(t, maxGot)
+	require.Equal(t, "xhigh", *maxGot)
+
 	require.Nil(t, ExtractResponsesReasoningEffortFromBody([]byte(`{"model":"claude-sonnet-4.5"}`)))
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -7159,7 +7159,7 @@ func normalizeOpenAIReasoningEffort(raw string) string {
 		return ""
 	case "low", "medium", "high":
 		return value
-	case "xhigh", "extrahigh":
+	case "xhigh", "extrahigh", "max":
 		return "xhigh"
 	default:
 		// Only store known effort levels for now to keep UI consistent.

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -596,6 +596,13 @@ func TestExtractOpenAIReasoningEffortFromBody(t *testing.T) {
 			wantValue: "xhigh",
 		},
 		{
+			name:      "DeepSeek max 归一化为 xhigh",
+			body:      []byte(`{"reasoning_effort":"max"}`),
+			model:     "deepseek-v4-pro",
+			wantNil:   false,
+			wantValue: "xhigh",
+		},
+		{
 			name:    "minimal 归一化为空",
 			body:    []byte(`{"reasoning":{"effort":"minimal"}}`),
 			model:   "gpt-5-high",


### PR DESCRIPTION
## 问题

pi 将 `defaultThinkingLevel: "xhigh"` 映射为 `reasoning_effort: "max"` 发送给 deepseek-v4-pro，但 `normalizeOpenAIReasoningEffort` 不识别 `"max"`，导致 Chat Completions 路径上的推理强度被静默丢弃。

## 根因

`normalizeOpenAIReasoningEffort` 只识别 OpenAI 原生推理强度（`low`/`medium`/`high`/`xhigh`），但 DeepSeek 和 pi 使用 `"max"` 表示最高推理级别。

| 路径 | 字段 | 值 | 归一化函数 | 修复前 | 修复后 |
|------|-------|-------|------------|--------|-------|
| Claude `/v1/messages` | `output_config.effort` | `max` | `NormalizeClaudeOutputEffort` | ✅ | ✅ |
| DeepSeek `/v1/chat/completions` | `reasoning_effort` | `max` | `normalizeOpenAIReasoningEffort` | ❌ | ✅ |

## 修复

在 `normalizeOpenAIReasoningEffort` 中增加 `"max"` → `"xhigh"` 映射，与 `NormalizeClaudeOutputEffort` 对同值的处理保持一致。