### PR TITLE
feat(billing): 添加 DeepSeek V4 Pro / Flash 回退定价

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -297,18 +297,18 @@ func (s *BillingService) initFallbackPricing() {
 	// DeepSeek V4 Pro
 	// Source: https://api-docs.deepseek.com/quick_start/pricing
 	s.fallbackPrices["deepseek-v4-pro"] = &ModelPricing{
-		InputPricePerToken:     4.35e-7,   // $0.435 per MTok
-		OutputPricePerToken:    8.7e-7,    // $0.87 per MTok
-		CacheReadPricePerToken: 3.625e-9,  // $0.003625 per MTok
+		InputPricePerToken:     4.35e-7,  // $0.435 per MTok
+		OutputPricePerToken:    8.7e-7,   // $0.87 per MTok
+		CacheReadPricePerToken: 3.625e-9, // $0.003625 per MTok
 		SupportsCacheBreakdown: false,
 	}
 
 	// DeepSeek V4 Flash
 	// Source: https://api-docs.deepseek.com/quick_start/pricing
 	s.fallbackPrices["deepseek-v4-flash"] = &ModelPricing{
-		InputPricePerToken:     1.4e-7,   // $0.14 per MTok
-		OutputPricePerToken:    2.8e-7,   // $0.28 per MTok
-		CacheReadPricePerToken: 2.8e-9,   // $0.0028 per MTok
+		InputPricePerToken:     1.4e-7, // $0.14 per MTok
+		OutputPricePerToken:    2.8e-7, // $0.28 per MTok
+		CacheReadPricePerToken: 2.8e-9, // $0.0028 per MTok
 		SupportsCacheBreakdown: false,
 	}
 

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -294,6 +294,24 @@ func (s *BillingService) initFallbackPricing() {
 		CacheReadPricePerTokenPriority: 0.35e-6,
 		SupportsCacheBreakdown:         false,
 	}
+	// DeepSeek V4 Pro
+	// Source: https://api-docs.deepseek.com/quick_start/pricing
+	s.fallbackPrices["deepseek-v4-pro"] = &ModelPricing{
+		InputPricePerToken:     4.35e-7,   // $0.435 per MTok
+		OutputPricePerToken:    8.7e-7,    // $0.87 per MTok
+		CacheReadPricePerToken: 3.625e-9,  // $0.003625 per MTok
+		SupportsCacheBreakdown: false,
+	}
+
+	// DeepSeek V4 Flash
+	// Source: https://api-docs.deepseek.com/quick_start/pricing
+	s.fallbackPrices["deepseek-v4-flash"] = &ModelPricing{
+		InputPricePerToken:     1.4e-7,   // $0.14 per MTok
+		OutputPricePerToken:    2.8e-7,   // $0.28 per MTok
+		CacheReadPricePerToken: 2.8e-9,   // $0.0028 per MTok
+		SupportsCacheBreakdown: false,
+	}
+
 	// Codex 族兜底统一按 GPT-5.3 Codex 价格计费
 	s.fallbackPrices["gpt-5.3-codex"] = &ModelPricing{
 		InputPricePerToken:             1.5e-6, // $1.5 per MTok
@@ -342,6 +360,18 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	}
 	if strings.Contains(modelLower, "gemini-3.1-pro") || strings.Contains(modelLower, "gemini-3-1-pro") {
 		return s.fallbackPrices["gemini-3.1-pro"]
+	}
+
+	// DeepSeek V4 系列
+	if strings.Contains(modelLower, "deepseek-v4-flash") {
+		return s.fallbackPrices["deepseek-v4-flash"]
+	}
+	if strings.Contains(modelLower, "deepseek-v4-pro") {
+		return s.fallbackPrices["deepseek-v4-pro"]
+	}
+	// deepseek-chat / deepseek-reasoner → V4 Flash（官方兼容别名）
+	if strings.Contains(modelLower, "deepseek-chat") || strings.Contains(modelLower, "deepseek-reasoner") {
+		return s.fallbackPrices["deepseek-v4-flash"]
 	}
 
 	// OpenAI 仅匹配已知 GPT-5/Codex 族，避免未知 OpenAI 型号误计价。

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -362,19 +362,19 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 		return s.fallbackPrices["gemini-3.1-pro"]
 	}
 
-	// DeepSeek V4 系列
+	// DeepSeek V4 系列：仅匹配已知 V4 Pro/Flash 与官方兼容别名
+	// （deepseek-chat / deepseek-reasoner → V4 Flash），未知 deepseek-* 型号不回退，避免误计价。
 	if strings.Contains(modelLower, "deepseek-v4-flash") {
 		return s.fallbackPrices["deepseek-v4-flash"]
 	}
 	if strings.Contains(modelLower, "deepseek-v4-pro") {
 		return s.fallbackPrices["deepseek-v4-pro"]
 	}
-	// deepseek-chat / deepseek-reasoner → V4 Flash（官方兼容别名）
 	if strings.Contains(modelLower, "deepseek-chat") || strings.Contains(modelLower, "deepseek-reasoner") {
 		return s.fallbackPrices["deepseek-v4-flash"]
 	}
 
-	// OpenAI 仅匹配已知 GPT-5/Codex 族，避免未知 OpenAI 型号误计价。
+	// OpenAI（GPT-5 / Codex 族）：仅匹配已知型号，避免未知 OpenAI 型号误计价。
 	if normalized := normalizeKnownOpenAICodexModel(modelLower); normalized != "" {
 		switch normalized {
 		case "gpt-5.5":

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -352,6 +352,10 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{name: "openai legacy gpt5.1 codex falls back to gpt5.3 codex", model: "gpt-5.1-codex", expectedInput: 1.5e-6},
 		{name: "openai legacy codex mini latest falls back to gpt5.3 codex", model: "codex-mini-latest", expectedInput: 1.5e-6},
 		{name: "openai unknown no fallback", model: "gpt-unknown-model", expectNilPricing: true},
+		{name: "deepseek v4 pro", model: "deepseek-v4-pro", expectedInput: 4.35e-7},
+		{name: "deepseek v4 flash", model: "deepseek-v4-flash", expectedInput: 1.4e-7},
+		{name: "deepseek chat alias → flash", model: "deepseek-chat", expectedInput: 1.4e-7},
+		{name: "deepseek reasoner alias → flash", model: "deepseek-reasoner", expectedInput: 1.4e-7},
 		{name: "non supported family", model: "qwen-max", expectNilPricing: true},
 	}
 

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -332,11 +332,14 @@ func TestCalculateCost_LongContextAppliesMultiplierToCacheCreation5mAnd1h(t *tes
 func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 	svc := newTestBillingService()
 
+	// expectedOutput / expectedCacheRead 为 0 时跳过该字段断言（保持与原有用例兼容）。
 	tests := []struct {
-		name             string
-		model            string
-		expectedInput    float64
-		expectNilPricing bool
+		name              string
+		model             string
+		expectedInput     float64
+		expectedOutput    float64
+		expectedCacheRead float64
+		expectNilPricing  bool
 	}{
 		{name: "empty model", model: "   ", expectNilPricing: true},
 		{name: "claude opus 4.6", model: "claude-opus-4.6-20260201", expectedInput: 5e-6},
@@ -352,10 +355,34 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{name: "openai legacy gpt5.1 codex falls back to gpt5.3 codex", model: "gpt-5.1-codex", expectedInput: 1.5e-6},
 		{name: "openai legacy codex mini latest falls back to gpt5.3 codex", model: "codex-mini-latest", expectedInput: 1.5e-6},
 		{name: "openai unknown no fallback", model: "gpt-unknown-model", expectNilPricing: true},
-		{name: "deepseek v4 pro", model: "deepseek-v4-pro", expectedInput: 4.35e-7},
-		{name: "deepseek v4 flash", model: "deepseek-v4-flash", expectedInput: 1.4e-7},
-		{name: "deepseek chat alias → flash", model: "deepseek-chat", expectedInput: 1.4e-7},
-		{name: "deepseek reasoner alias → flash", model: "deepseek-reasoner", expectedInput: 1.4e-7},
+		{
+			name:              "deepseek v4 pro",
+			model:             "deepseek-v4-pro",
+			expectedInput:     4.35e-7,
+			expectedOutput:    8.7e-7,
+			expectedCacheRead: 3.625e-9,
+		},
+		{
+			name:              "deepseek v4 flash",
+			model:             "deepseek-v4-flash",
+			expectedInput:     1.4e-7,
+			expectedOutput:    2.8e-7,
+			expectedCacheRead: 2.8e-9,
+		},
+		{
+			name:              "deepseek chat alias → flash",
+			model:             "deepseek-chat",
+			expectedInput:     1.4e-7,
+			expectedOutput:    2.8e-7,
+			expectedCacheRead: 2.8e-9,
+		},
+		{
+			name:              "deepseek reasoner alias → flash",
+			model:             "deepseek-reasoner",
+			expectedInput:     1.4e-7,
+			expectedOutput:    2.8e-7,
+			expectedCacheRead: 2.8e-9,
+		},
 		{name: "non supported family", model: "qwen-max", expectNilPricing: true},
 	}
 
@@ -368,6 +395,14 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 			}
 			require.NotNil(t, pricing)
 			require.InDelta(t, tt.expectedInput, pricing.InputPricePerToken, 1e-12)
+			if tt.expectedOutput != 0 {
+				require.InDelta(t, tt.expectedOutput, pricing.OutputPricePerToken, 1e-12,
+					"OutputPricePerToken mismatch for %s", tt.model)
+			}
+			if tt.expectedCacheRead != 0 {
+				require.InDelta(t, tt.expectedCacheRead, pricing.CacheReadPricePerToken, 1e-14,
+					"CacheReadPricePerToken mismatch for %s", tt.model)
+			}
 		})
 	}
 }

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -258,7 +258,7 @@ func TestOpenAIGatewayServiceRecordUsage_MissingPricingRecordsZeroCostUsageLog(t
 				InputTokens:  1200,
 				OutputTokens: 300,
 			},
-			Model:    "deepseek-v4-flash",
+			Model:    "pricing-missing-test-model",
 			Duration: time.Second,
 		},
 		APIKey:        &APIKey{ID: 1002, Quota: 100, Group: &Group{RateMultiplier: 1}},
@@ -277,8 +277,8 @@ func TestOpenAIGatewayServiceRecordUsage_MissingPricingRecordsZeroCostUsageLog(t
 
 	require.NotNil(t, usageRepo.lastLog)
 	require.Equal(t, "resp_missing_pricing", usageRepo.lastLog.RequestID)
-	require.Equal(t, "deepseek-v4-flash", usageRepo.lastLog.Model)
-	require.Equal(t, "deepseek-v4-flash", usageRepo.lastLog.RequestedModel)
+	require.Equal(t, "pricing-missing-test-model", usageRepo.lastLog.Model)
+	require.Equal(t, "pricing-missing-test-model", usageRepo.lastLog.RequestedModel)
 	require.Equal(t, 1200, usageRepo.lastLog.InputTokens)
 	require.Equal(t, 300, usageRepo.lastLog.OutputTokens)
 	require.Zero(t, usageRepo.lastLog.TotalCost)


### PR DESCRIPTION
## 问题

DeepSeek 模型（V4 Pro / V4 Flash）在 LiteLLM 动态定价中暂无数据，也没有 fallback 硬编码定价，导致所有请求的 input_cost / output_cost / total_cost 均为 0。

## 修复

在 `initFallbackPricing()` 中添加 DeepSeek V4 系列的回退定价，来源为[官方文档](https://api-docs.deepseek.com/quick_start/pricing)：

| 模型 | Input | Output | Cache Read |
|------|-------|--------|------------|
| `deepseek-v4-pro` | $0.435/M | $0.87/M | $0.003625/M |
| `deepseek-v4-flash` | $0.14/M | $0.28/M | $0.0028/M |

同时将官方兼容别名 `deepseek-chat` / `deepseek-reasoner` 映射到 `deepseek-v4-flash`。

## 测试

在 `TestGetFallbackPricing_FamilyMatching` 中新增 4 个 DeepSeek 测试用例，全部通过。