### PR TITLE
fix(gateway): always obfuscate tool names regardless of count (fixes "out of extra usage" 400 with <=5 tools)

### DIFF
--- a/backend/internal/service/gateway_tool_rewrite.go
+++ b/backend/internal/service/gateway_tool_rewrite.go
@@ -32,9 +32,24 @@ var fakeToolNamePrefixes = []string{
 	"review_", "search_", "transform_", "handle_", "invoke_", "notify_",
 }
 
-// dynamicToolMapThreshold 与 Parrot 一致：tools 数量超过 5 才启用动态映射。
-// 少量工具不需要混淆（一般是 Claude Code 自己的核心工具 bash/edit/read 等）。
-const dynamicToolMapThreshold = 5
+// dynamicToolMapThreshold 是触发动态混淆的最小 tools 数量。设为 0 → 只要有
+// 可混淆的工具就做映射（emptyToolNames 仍由 buildDynamicToolMap 顶部短路返回 nil）。
+//
+// Parrot 原值是 5，假设是「工具少时往往是 Claude Code 自带的核心工具
+// bash/edit/read 等，Anthropic 接受原名」。但对接 sub2api 的客户端不一定如此：
+// 比如 hermes-agent / opencode 的 delegate 子 agent 只带 2–5 个工具，其中
+// `delegate_task` / `skill_manage` / `session_search` 等名字不在 Anthropic 的
+// 核心工具白名单里，会触发上游 validator 误分类，返回:
+//
+//	{"type":"invalid_request_error",
+//	 "message":"You're out of extra usage. Add more at claude.ai/settings/usage..."}
+//
+// 哪怕账号额度充裕。复现：tools.length=5 中含 `skill_manage`/`delegate_task`
+// → 400；同样 body 加一个 dummy tool 凑到 6 → 200（threshold 之上 → 触发混淆 → 通过）。
+//
+// 0 的代价：响应侧每个 SSE chunk 多 N 次 bytes.Replace（N=tools 数）；请求侧
+// 多构造一个 map。换来的好处：任何工具组合都不会把"非 CLI 指纹"漏给上游。
+const dynamicToolMapThreshold = 0
 
 // ToolNameRewrite 是单次请求内的工具名混淆映射。
 //   - Forward: real → fake，请求阶段在 body 上应用。
@@ -51,8 +66,11 @@ type ToolNameRewrite struct {
 
 // buildDynamicToolMap 构造 tools 的动态假名映射。
 //
-// 与 Parrot _build_dynamic_tool_map 语义等价：
-//   - tools 数量 ≤ dynamicToolMapThreshold 时返回 nil（不做动态映射，走静态 fallback）
+// 与 Parrot _build_dynamic_tool_map 大体一致，唯一差异是 dynamicToolMapThreshold
+// 默认 0（Parrot 是 5）。差异原因见 dynamicToolMapThreshold 的注释。
+//
+// 不变量：
+//   - 空 toolNames 返回 nil（无东西可映射）
 //   - 同一组 tool_names 在同进程内映射稳定（保证 cache 命中）
 //
 // Parrot 用 `random.Random(hash(tuple(tool_names)))` 作 seed + shuffle 前缀池；

--- a/backend/internal/service/gateway_tool_rewrite_test.go
+++ b/backend/internal/service/gateway_tool_rewrite_test.go
@@ -8,10 +8,28 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestBuildDynamicToolMap_BelowThreshold(t *testing.T) {
-	// Parrot 行为：tools 数量 ≤ 5 时不做动态映射。
-	names := []string{"bash", "edit", "read", "write", "search"}
-	require.Nil(t, buildDynamicToolMap(names))
+func TestBuildDynamicToolMap_EmptyReturnsNil(t *testing.T) {
+	// 空输入：没有可混淆的工具，直接返回 nil。
+	require.Nil(t, buildDynamicToolMap(nil))
+	require.Nil(t, buildDynamicToolMap([]string{}))
+}
+
+func TestBuildDynamicToolMap_AlwaysObfuscatesNonEmpty(t *testing.T) {
+	// 偏离 Parrot：threshold = 0，任何 tools.length >= 1 都做动态映射。
+	// 见 dynamicToolMapThreshold 注释里的 "out of extra usage" 复现。
+	for _, names := range [][]string{
+		{"bash"},
+		{"bash", "edit"},
+		{"bash", "edit", "read", "write", "search"}, // 5 个，旧版 Parrot/sub2api 会跳过
+	} {
+		m := buildDynamicToolMap(names)
+		require.NotNil(t, m, "tools=%v should produce dynamic mapping", names)
+		require.Len(t, m, len(names))
+		for _, n := range names {
+			require.Contains(t, m, n)
+			require.NotEqual(t, n, m[n], "real name %q should be remapped", n)
+		}
+	}
 }
 
 func TestBuildDynamicToolMap_AboveThresholdIsStable(t *testing.T) {
@@ -74,13 +92,19 @@ func TestApplyToolNameRewriteToBody_RenamesToolsAndToolChoice(t *testing.T) {
 
 	out := applyToolNameRewriteToBody(body, rw)
 
-	// tools[0].name and tools[1].name rewritten; tools[2].name untouched
-	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "tools.0.name").String())
-	require.Equal(t, "cc_ses_get", gjson.GetBytes(out, "tools.1.name").String())
+	// dynamic 映射启用（threshold = 0），具体假名形如 "modify_ses00"，
+	// 不同前缀池组合会变；这里只验证 (a) 两个工具被重写、(b) 与 Forward 一致、
+	// (c) server tool 不动、(d) tool_choice.name 与 tools[0].name 一致。
+	fakeList := rw.Forward["sessions_list"]
+	fakeGet := rw.Forward["session_get"]
+	require.NotEqual(t, "sessions_list", fakeList)
+	require.NotEqual(t, "session_get", fakeGet)
+	require.Equal(t, fakeList, gjson.GetBytes(out, "tools.0.name").String())
+	require.Equal(t, fakeGet, gjson.GetBytes(out, "tools.1.name").String())
 	require.Equal(t, "web_search", gjson.GetBytes(out, "tools.2.name").String())
 
-	// tool_choice.name rewritten
-	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "tool_choice.name").String())
+	// tool_choice.name rewritten consistently with the matching tool
+	require.Equal(t, fakeList, gjson.GetBytes(out, "tool_choice.name").String())
 	require.Equal(t, "tool", gjson.GetBytes(out, "tool_choice.type").String())
 }
 


### PR DESCRIPTION
## Problem

When a non-CLI client (hermes-agent, opencode sub-agent, ...) sends a request to `/v1/messages` through sub2api with `tools.length <= 5` and the tool list contains names that are **not** on Anthropic's core whitelist (`delegate_task`, `skill_manage`, `skill_view`, `skills_list`, `session_search`, ...), the upstream returns:

```http
HTTP/1.1 400 Bad Request

{
  "type": "error",
  "error": {
    "type": "invalid_request_error",
    "message": "You're out of extra usage. Add more at claude.ai/settings/usage and keep going."
  },
  "request_id": "req_011Cad..."
}
```

The error has nothing to do with quota. `accounts.extra.session_window_utilization` is e.g. `0.15`, and `ops_error_logs.is_business_limited = false`. The same OAuth credential called via the official Claude Code CLI never produces this error.

## Root cause

`dynamicToolMapThreshold` in [`backend/internal/service/gateway_tool_rewrite.go`](https://github.com/Wei-Shaw/sub2api/blob/main/backend/internal/service/gateway_tool_rewrite.go) defaulted to `5`, mirroring [Parrot's `_build_dynamic_tool_map` threshold](https://github.com/coffeegrind123/parrot). The implicit assumption was *"requests with few tools come from clients that ship known-safe core tool names (`bash`/`edit`/`read`/etc.) which Anthropic accepts raw"*.

That assumption holds for the official Claude Code CLI, but **not** for non-CLI clients routed through sub2api. A delegate sub-agent or batch request frequently carries only 2–5 tools whose names are arbitrary (`delegate_task`, `skill_manage`, ...). With `<= 5` tools, `buildDynamicToolMap` returns `nil` and the names go upstream unmodified, triggering Anthropic's server-side validator which mis-classifies the request as third-party.

## Reproduction (deterministic)

```bash
# Body: 5 tools = [skill_manage, skill_view, skills_list, delegate_task, session_search]
curl -X POST http://sub2api/v1/messages \
  -H 'x-api-key: …' -H 'anthropic-version: 2023-06-01' \
  --data-binary @repro_5tools.json
# → 400 "You're out of extra usage…"

# Same body + 1 dummy tool (6 total) → threshold crossed → obfuscation kicks in
curl -X POST http://sub2api/v1/messages \
  -H 'x-api-key: …' -H 'anthropic-version: 2023-06-01' \
  --data-binary @repro_6tools.json
# → 200 OK
```

The diff between the two `UPSTREAM_FORWARD` snapshots (with `SUB2API_DEBUG_GATEWAY_BODY=1`) is exactly: 5-tool case sends `"name": "skill_manage"`, 6-tool case sends e.g. `"name": "manage_ski00"`. Headers, billing block, beta list — all identical.

## Fix

Lower `dynamicToolMapThreshold` from `5` to `0`. Empty `tools` array still short-circuits to `nil` at the top of `buildDynamicToolMap` (nothing to map).

```go
// before
const dynamicToolMapThreshold = 5

// after
const dynamicToolMapThreshold = 0
```

The full comment block in the patched file explains the rationale and the cost trade-off.

### Cost

- Response side: `N` extra `bytes.Replace` passes per SSE chunk (`N` = `tools` count), already paid for the common >5-tool case.
- Request side: one extra map construction.

### Benefit

No tool-count edge case can leak the "non-CLI fingerprint" to Anthropic's validator.

## Tests

- `TestBuildDynamicToolMap_BelowThreshold` retired (the contract it asserted is the bug).
- New `TestBuildDynamicToolMap_EmptyReturnsNil` + `TestBuildDynamicToolMap_AlwaysObfuscatesNonEmpty` cover the new behavior.
- `TestApplyToolNameRewriteToBody_RenamesToolsAndToolChoice` updated to assert dynamic-mapping consistency (`tool_choice.name` stays in sync with `tools[0]`), since dynamic now wins over the static prefix map for the same name set.
- Full `internal/service` suite: 1973 passed locally with `go test ./internal/service/ -count=1`.

## Verification

Built `linux/arm64` binary from this branch, hot-swapped into a running `weishaw/sub2api:latest` container (v0.1.121). Both 5-tool and 6-tool repros now return 200; the 5-tool `UPSTREAM_FORWARD` body now shows obfuscated names, identical in shape to what the 6-tool case already produced.

## Related

- Issue #1894 — `@nxxxsooo` reports *"opencode 主 agent 没问题了，子 agent delegate 给 haiku 还报错"*. The sub-agent has fewer tools than the main agent, falls below the threshold, and hits this bug. (Other tool-count-dependent reports likely have the same root cause.)
- PR #1914 (merged) put the full Claude Code mimicry in place but kept the Parrot threshold; this PR is a follow-up that closes the remaining edge case.