### PR TITLE
第三方兼容上游账号测试支持 /v1/chat/completions 路径

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -276,14 +276,16 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 }
 
 // resolveRawCCUpstreamEndpoint returns the actual upstream endpoint for
-// OpenAI Chat Completions requests. For APIKey accounts whose upstream
-// has been probed to not support the Responses API, the request is
-// forwarded directly to /v1/chat/completions — not through the default
-// CC→Responses conversion path.
+// OpenAI Chat Completions requests. For APIKey accounts whose base_url
+// is not https://api.openai.com (third-party compatible upstreams like
+// DeepSeek/Kimi/GLM/Qwen), the request is forwarded directly to
+// /v1/chat/completions — not through the default CC→Responses conversion path.
 func resolveRawCCUpstreamEndpoint(c *gin.Context, account *service.Account) string {
-	if account != nil && account.Type == service.AccountTypeAPIKey &&
-		!openai_compat.ShouldUseResponsesAPI(account.Extra) {
-		return "/v1/chat/completions"
+	if account != nil && account.Type == service.AccountTypeAPIKey {
+		baseURL := strings.TrimSpace(account.GetOpenAIBaseURL())
+		if !strings.HasPrefix(baseURL, "https://api.openai.com") {
+			return "/v1/chat/completions"
+		}
 	}
 	return GetUpstreamEndpoint(c, account.Platform)
 }

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -21,7 +21,6 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -527,6 +526,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	var authToken string
 	var apiURL string
 	var isOAuth bool
+	var isOfficialOpenAI bool
 	var chatgptAccountID string
 
 	if account.IsOAuth() {
@@ -555,16 +555,15 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
 		}
-		// 账号已被探测为不支持 Responses（如 DeepSeek/Kimi 等）时，丢出明确提示。
-		// 账号本身可用（网关会走 CC 直转），仅测试入口需要补齐 CC SSE 处理逻辑。
-		// TODO：实现 CC 格式的账号测试路径（需专门的 CC SSE handler）。
-		if !openai_compat.ShouldUseResponsesAPI(account.Extra) {
-			return s.sendErrorAndEnd(c,
-				"账号已被探测为不支持 OpenAI Responses API（如 DeepSeek/Kimi 等三方兼容上游），"+
-					"账号本身可正常使用，但当前测试接口仅支持 Responses API 路径。请直接通过实际 API 调用验证。",
-			)
+		// 判断是否为官方 OpenAI 还是第三方兼容上游
+		isOfficialOpenAI = strings.TrimSpace(baseURL) == "https://api.openai.com"
+		if isOfficialOpenAI {
+			// 官方 OpenAI 走 Responses API 路径
+			apiURL = buildOpenAIResponsesURL(normalizedBaseURL)
+		} else {
+			// 第三方兼容上游（DeepSeek/Kimi 等）走 /v1/chat/completions 直转路径
+			apiURL = buildOpenAIChatCompletionsURL(normalizedBaseURL)
 		}
-		apiURL = buildOpenAIResponsesURL(normalizedBaseURL)
 	} else {
 		return s.sendErrorAndEnd(c, fmt.Sprintf("Unsupported account type: %s", account.Type))
 	}
@@ -576,9 +575,17 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
 	c.Writer.Flush()
 
-	// Create OpenAI Responses API payload
-	payload := createOpenAITestPayload(testModelID, isOAuth)
-	payloadBytes, _ := json.Marshal(payload)
+	// 根据 API 路径选择对应的 payload 格式
+	var payloadBytes []byte
+	if isOfficialOpenAI || isOAuth {
+		// 官方 OpenAI 和 OAuth 使用 Responses API 格式
+		payload := createOpenAITestPayload(testModelID, isOAuth)
+		payloadBytes, _ = json.Marshal(payload)
+	} else {
+		// 第三方兼容上游使用 Chat Completions 格式
+		payload := createOpenAIChatCompletionsTestPayload(testModelID)
+		payloadBytes, _ = json.Marshal(payload)
+	}
 
 	// Send test_start event
 	s.sendEvent(c, TestEvent{Type: "test_start", Model: testModelID})
@@ -591,6 +598,11 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	// Set common headers
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+authToken)
+
+	// 第三方兼容上游使用流式响应
+	if !isOfficialOpenAI && !isOAuth {
+		req.Header.Set("Accept", "text/event-stream")
+	}
 
 	// Set OAuth-specific headers for ChatGPT internal API
 	if isOAuth {
@@ -1195,6 +1207,24 @@ func createOpenAITestPayload(modelID string, isOAuth bool) map[string]any {
 	return payload
 }
 
+// createOpenAIChatCompletionsTestPayload creates a test payload for OpenAI Chat Completions API
+// 用于第三方兼容上游（DeepSeek/Kimi/GLM/Qwen 等）的测试
+func createOpenAIChatCompletionsTestPayload(modelID string) map[string]any {
+	return map[string]any{
+		"model": modelID,
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": "hi",
+			},
+		},
+		"stream": true,
+		"stream_options": map[string]any{
+			"include_usage": true,
+		},
+	}
+}
+
 // processClaudeStream processes the SSE stream from Claude API
 func (s *AccountTestService) processClaudeStream(c *gin.Context, body io.Reader) error {
 	reader := bufio.NewReader(body)
@@ -1249,16 +1279,20 @@ func (s *AccountTestService) processClaudeStream(c *gin.Context, body io.Reader)
 	}
 }
 
-// processOpenAIStream processes the SSE stream from OpenAI Responses API
+// processOpenAIStream processes the SSE stream from OpenAI Responses API 或 Chat Completions API
+// 支持两种格式：
+// 1. Responses API（官方 OpenAI / OAuth）：type="response.output_text.delta", type="response.completed"
+// 2. Chat Completions（第三方兼容上游）：choices=[{delta:{content:"..."}}], [DONE]
 func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader) error {
 	reader := bufio.NewReader(body)
 	seenCompleted := false
+	hasReceivedContent := false
 
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
-				if seenCompleted {
+				if seenCompleted || hasReceivedContent {
 					s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 					return nil
 				}
@@ -1274,11 +1308,9 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 
 		jsonStr := sseDataPrefix.ReplaceAllString(line, "")
 		if jsonStr == "[DONE]" {
-			if seenCompleted {
-				s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
-				return nil
-			}
-			return s.sendErrorAndEnd(c, "Stream ended before response.completed")
+			// Chat Completions 格式：[DONE] 表示流结束
+			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+			return nil
 		}
 
 		var data map[string]any
@@ -1288,11 +1320,29 @@ func (s *AccountTestService) processOpenAIStream(c *gin.Context, body io.Reader)
 
 		eventType, _ := data["type"].(string)
 
+		// 检查是否为 Chat Completions 格式（有 choices 字段）
+		if choices, ok := data["choices"].([]any); ok && len(choices) > 0 {
+			if choice, ok := choices[0].(map[string]any); ok {
+				if delta, ok := choice["delta"].(map[string]any); ok {
+					if content, ok := delta["content"].(string); ok && content != "" {
+						s.sendEvent(c, TestEvent{Type: "content", Text: content})
+						hasReceivedContent = true
+					}
+				}
+				if finishReason, ok := choice["finish_reason"].(string); ok && finishReason != "" {
+					s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+					return nil
+				}
+			}
+			continue
+		}
+
+		// Responses API 格式
 		switch eventType {
 		case "response.output_text.delta":
-			// OpenAI Responses API uses "delta" field for text content
 			if delta, ok := data["delta"].(string); ok && delta != "" {
 				s.sendEvent(c, TestEvent{Type: "content", Text: delta})
+				hasReceivedContent = true
 			}
 		case "response.completed", "response.done":
 			s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -48,11 +47,11 @@ var cursorResponsesUnsupportedFields = []string{
 // 正确的，但 sub2api 接入 DeepSeek/Kimi/GLM 等第三方 OpenAI 兼容上游后假设破裂：
 // 这些上游普遍只支持 /v1/chat/completions，无 /v1/responses 端点。
 //
-// 当前路由策略（基于账号探测标记，详见 openai_compat.ShouldUseResponsesAPI）：
-//   - APIKey 账号 + 探测确认不支持 Responses → 走 forwardAsRawChatCompletions
+// 当前路由策略（基于 base_url 判断）：
+//   - APIKey 账号 + base_url 非 https://api.openai.com → 走 forwardAsRawChatCompletions
 //     直转上游 /v1/chat/completions，不做协议转换
-//   - 其他所有情况（OAuth、APIKey 探测确认支持、未探测）→ 走原有 CC→Responses
-//     转换路径（保留旧行为，存量未探测账号零兼容破坏）
+//   - 其他所有情况（OAuth、官方 APIKey）→ 走原有 CC→Responses
+//     转换路径
 func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	ctx context.Context,
 	c *gin.Context,
@@ -61,9 +60,13 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	promptCacheKey string,
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
-	// 入口分流：APIKey 账号 + 已探测且确认上游不支持 Responses，走 CC 直转。
-	// 标记缺失（未探测）按"现状即证据"原则继续走下方原 Responses 转换路径。
-	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+	// 入口分流：仅 OpenAI 官方 APIKey 和 OAuth 账号走 Responses 路径
+	// 其他所有第三方兼容上游（DeepSeek/Kimi/GLM/Qwen 等）走 CC 直转路径
+	isOfficialOpenAI := account.Type == AccountTypeAPIKey &&
+		strings.HasPrefix(strings.TrimSpace(account.GetOpenAIBaseURL()), "https://api.openai.com")
+	isOAuth := account.Type == AccountTypeOAuth
+
+	if !isOfficialOpenAI && !isOAuth {
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
 

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -43,8 +43,8 @@ var openaiCCRawAllowedHeaders = map[string]bool{
 // forwardAsRawChatCompletions 直转客户端的 Chat Completions 请求到上游
 // `{base_url}/v1/chat/completions`，**不**做 CC↔Responses 协议转换。
 //
-// 适用场景：account.platform=openai && account.type=apikey && 上游已被探测确认
-// 不支持 /v1/responses 端点（如 DeepSeek/Kimi/GLM/Qwen 等第三方 OpenAI 兼容上游）。
+// 适用场景：account.platform=openai && account.type=apikey && 非官方 OpenAI 上游
+// （如 DeepSeek/Kimi/GLM/Qwen 等第三方 OpenAI 兼容上游）。
 //
 // 与 ForwardAsChatCompletions 的关键差异：
 //
@@ -56,7 +56,7 @@ var openaiCCRawAllowedHeaders = map[string]bool{
 //   - 不注入 prompt_cache_key（OAuth 专属机制）
 //
 // 调用入口：openai_gateway_chat_completions.go::ForwardAsChatCompletions
-// 在函数顶部按 openai_compat.ShouldUseResponsesAPI 分流。
+// 在函数顶部按 base_url 是否为 https://api.openai.com 分流。
 func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	ctx context.Context,
 	c *gin.Context,


### PR DESCRIPTION
## 问题描述

### 修复前

第三方 OpenAI 兼容上游（DeepSeek、Kimi、Qwen 等）在账号测试时存在两个问题：

**问题 1：测试入口直接拒绝**

当账号被探测为不支持 Responses API 时，测试接口直接返回错误，无法进行测试：

<img width="574" height="626" alt="屏幕截图 2026-05-05 012805" src="https://github.com/user-attachments/assets/f4e34f76-8637-43ab-b1fd-a376c14a1d06" />


> 账号已被探测为不支持 OpenAI Responses API（如 DeepSeek/Kimi 等三方兼容上游），账号本身可正常使用，但当前测试接口仅支持 Responses API 路径。

**问题 2：SSE 流解析失败**

即使绕过检测，由于测试接口使用 Responses API 格式的 payload 和 SSE 解析逻辑，而第三方上游返回的是 Chat Completions 格式（`choices[].delta.content` + `[DONE]`），导致流解析失败：

<img width="579" height="649" alt="屏幕截图 2026-05-05 012822" src="https://github.com/user-attachments/assets/09ec4f83-7c60-42f1-95f5-dbe9594ae122" />


> Stream ended before response.completed

---

### 修复后

第三方兼容上游账号测试完全正常：

<img width="578" height="672" alt="屏幕截图 2026-05-05 015355" src="https://github.com/user-attachments/assets/39e412ea-41a4-4fab-9dab-3e3cef4be127" />


> 测试完成！

<img width="584" height="671" alt="屏幕截图 2026-05-05 021228" src="https://github.com/user-attachments/assets/db9ca2ef-67a2-4a5c-9add-c96c6265fc79" />

> 测试完成！

---

## 修改内容

### 核心变更：路由策略从"能力探测"改为"base_url 检测"

| 账号类型 | base_url | 路由路径 |
|---------|----------|---------|
| OpenAI 官方 APIKey | `https://api.openai.com` | `/v1/responses` (Responses API) |
| ChatGPT OAuth | N/A | `/v1/responses` (Responses API) |
| 第三方兼容上游 APIKey | 非 `https://api.openai.com` | `/v1/chat/completions` (Chat Completions) |

### 修改文件

#### 1. `internal/service/openai_gateway_chat_completions.go`
- `ForwardAsChatCompletions` 入口分流逻辑从 `openai_compat.ShouldUseResponsesAPI(account.Extra)` 改为 `base_url` 前缀检测
- 非官方 OpenAI 的 APIKey 账号 + 非 OAuth 账号 → 走 `forwardAsRawChatCompletions` 直转路径

#### 2. `internal/handler/openai_chat_completions.go`
- `resolveRawCCUpstreamEndpoint` 从能力探测改为 `base_url` 前缀检查
- 移除 `openai_compat` 导入，添加 `strings` 导入

#### 3. `internal/service/account_test_service.go`
- **路由逻辑**：APIKey 测试不再报错，根据 `base_url` 自动选择 Responses API 或 `/v1/chat/completions` 路径
- **Payload 适配**：新增 `createOpenAIChatCompletionsTestPayload` 函数，第三方上游使用 `messages` 格式而非 `input` 格式
- **SSE 流处理**：`processOpenAIStream` 同时支持两种 SSE 格式：
  - Responses API：`response.output_text.delta` + `response.completed`
  - Chat Completions：`choices[].delta.content` + `[DONE]` / `finish_reason`

#### 4. `internal/service/openai_gateway_chat_completions_raw.go`
- 更新函数注释，反映新的路由策略

---

## 技术细节

### Responses API vs Chat Completions 格式差异

| 特性 | Responses API | Chat Completions |
|------|--------------|------------------|
| 端点 | `/v1/responses` | `/v1/chat/completions` |
| 请求格式 | `input: [{role, content: [{type, text}]}]` | `messages: [{role, content}]` |
| 流式事件 | `response.output_text.delta` | `choices: [{delta: {content}}]` |
| 结束标志 | `response.completed` | `[DONE]` 或 `finish_reason` |
| 额外参数 | `instructions`, `store` | `stream_options.include_usage` |

---

## 测试验证

| 账号 | 类型 | base_url | 修复前 | 修复后 |
|------|------|----------|--------|--------|
| 月之暗面 (Kimi) | APIKey | 第三方 | ❌ 直接拒绝 | ✅ 测试通过 |
| 阿里云百炼 (Qwen) | APIKey | 第三方 | ❌ 流解析失败 | ✅ 测试通过 |
| OpenAI 官方 | APIKey | api.openai.com | ✅ 正常 | ✅ 正常 |
| ChatGPT OAuth | OAuth | N/A | ✅ 正常 | ✅ 正常 |

---