### PR TITLE
fix: preflight ping 恢复时跳过携带 function_call_output 的请求

### DIFF
--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -3104,6 +3104,12 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if turnPrevRecoveryTried || !s.openAIWSIngressPreviousResponseRecoveryEnabled() {
 			return false
 		}
+		// 携带 function_call_output 的请求不能丢弃 previous_response_id：
+		// 上游 API 需要 response chain 来匹配 tool_result 与之前的 tool_use，
+		// 丢弃后会导致 "No tool call found for function call output" 400 错误。
+		if gjson.GetBytes(currentPayload, `input.#(type=="function_call_output")`).Exists() {
+			return false
+		}
 		if isStrictAffinityTurn(currentPayload) {
 			// Layer 2：严格亲和链路命中 previous_response_not_found 时，降级为“去掉 previous_response_id 后重放一次”。
 			// 该错误说明续链锚点已失效，继续 strict fail-close 只会直接中断本轮请求。
@@ -3370,7 +3376,11 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					truncateOpenAIWSLogValue(pingErr.Error(), openAIWSLogValueMaxLen),
 				)
 				if forcePreferredConn {
-					if !turnPrevRecoveryTried && currentPreviousResponseID != "" {
+					// 携带 function_call_output 的请求不能丢弃 previous_response_id：
+					// 上游 API 需要 response chain 来匹配 tool_result 与之前的 tool_use，
+					// 丢弃后会导致 "No tool call found for function call output" 400 错误。
+					hasFCOutput := gjson.GetBytes(currentPayload, `input.#(type=="function_call_output")`).Exists()
+					if !turnPrevRecoveryTried && currentPreviousResponseID != "" && !hasFCOutput {
 						updatedPayload, removed, dropErr := dropPreviousResponseIDFromRawPayload(currentPayload)
 						if dropErr != nil || !removed {
 							reason := "not_removed"


### PR DESCRIPTION
## 问题

Fixes #2195

在 OpenAI WebSocket 模式下，当 preflight ping 失败或 `previous_response_not_found` 时，sub2api 会尝试丢弃 `previous_response_id` 并重放请求。但如果请求的 `input` 中包含 `function_call_output`（即 tool result），丢弃 response chain 会导致上游 API 无法找到对应的 `tool_use`，返回 400：

```
No tool call found for function call output with call_id call_xxxxx.
```

## 根因

已有代码在 `sendAndRelay` 内部的 `recoverablePrevNotFound` 判断中正确检查了 `turnHasFunctionCallOutput`（line 2872），但有两条恢复路径遗漏了这个检查：

1. **preflight ping 失败恢复**（`forcePreferredConn` 路径，line ~3378）：直接丢弃 `previous_response_id` 重试，没有检查 payload 是否携带 `function_call_output`
2. **`recoverIngressPrevResponseNotFound`**（line ~3100）：`previous_response_not_found` 错误的恢复函数，同样没有检查

## 修复

在两条恢复路径中添加 `function_call_output` 检测，当 payload 的 `input` 中包含 `type=="function_call_output"` 的条目时，跳过丢弃 `previous_response_id` 的恢复逻辑，让错误直接返回客户端。客户端拥有完整的对话上下文，可以自行处理重试。

## 测试

- [ ] 需要确认在携带 `function_call_output` 的场景下，preflight ping 失败时不再尝试丢弃 `previous_response_id`
- [ ] 需要确认不携带 `function_call_output` 的普通请求，恢复逻辑仍然正常工作