### PR TITLE
fix(openai): trigger account failover on passthrough 403 forbidden_error

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3199,7 +3199,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 
 func shouldFailoverOpenAIPassthroughResponse(statusCode int) bool {
 	switch statusCode {
-	case http.StatusTooManyRequests, 529:
+	case http.StatusForbidden, http.StatusTooManyRequests, 529:
 		return true
 	default:
 		return false

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -147,8 +147,12 @@ func TestOpenAIGatewayService_OAuthMessagesBridgeDoesNotInjectDefaultInstruction
 
 type openAIPassthroughFailoverRepo struct {
 	stubOpenAIAccountRepo
-	rateLimitCalls []time.Time
-	overloadCalls  []time.Time
+	rateLimitCalls       []time.Time
+	overloadCalls        []time.Time
+	tempUnschedulableIDs []int64
+	tempUnschedulableAt  []time.Time
+	tempUnschedulableWhy []string
+	setErrorCalls        []string
 }
 
 func (r *openAIPassthroughFailoverRepo) SetRateLimited(_ context.Context, _ int64, resetAt time.Time) error {
@@ -158,6 +162,35 @@ func (r *openAIPassthroughFailoverRepo) SetRateLimited(_ context.Context, _ int6
 
 func (r *openAIPassthroughFailoverRepo) SetOverloaded(_ context.Context, _ int64, until time.Time) error {
 	r.overloadCalls = append(r.overloadCalls, until)
+	return nil
+}
+
+func (r *openAIPassthroughFailoverRepo) SetTempUnschedulable(_ context.Context, id int64, until time.Time, reason string) error {
+	r.tempUnschedulableIDs = append(r.tempUnschedulableIDs, id)
+	r.tempUnschedulableAt = append(r.tempUnschedulableAt, until)
+	r.tempUnschedulableWhy = append(r.tempUnschedulableWhy, reason)
+	return nil
+}
+
+func (r *openAIPassthroughFailoverRepo) SetError(_ context.Context, _ int64, errorMsg string) error {
+	r.setErrorCalls = append(r.setErrorCalls, errorMsg)
+	return nil
+}
+
+type openAIPassthrough403CounterStub struct {
+	counts []int64
+}
+
+func (s *openAIPassthrough403CounterStub) IncrementOpenAI403Count(context.Context, int64, int) (int64, error) {
+	if len(s.counts) == 0 {
+		return 1, nil
+	}
+	count := s.counts[0]
+	s.counts = s.counts[1:]
+	return count, nil
+}
+
+func (s *openAIPassthrough403CounterStub) ResetOpenAI403Count(context.Context, int64) error {
 	return nil
 }
 
@@ -745,7 +778,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_UpstreamErrorIncludesPassthroughF
 	require.Equal(t, "http_error", arr[len(arr)-1].Kind)
 }
 
-func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *testing.T) {
+func TestOpenAIGatewayService_OpenAIPassthrough_FailoverStatusesTriggerAccountSwitch(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	originalBody := []byte(`{"model":"gpt-5.2","stream":false,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
@@ -777,6 +810,20 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 		body        string
 		assertRepo  func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time)
 	}{
+		{
+			name:        "oauth_403_temp_unschedulable",
+			accountType: AccountTypeOAuth,
+			statusCode:  http.StatusForbidden,
+			body:        `{"error":{"message":"usage limit reached","type":"forbidden_error"}}`,
+			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, _ time.Time) {
+				require.Empty(t, repo.rateLimitCalls)
+				require.Empty(t, repo.overloadCalls)
+				require.Equal(t, []int64{123}, repo.tempUnschedulableIDs)
+				require.Len(t, repo.tempUnschedulableAt, 1)
+				require.True(t, time.Until(repo.tempUnschedulableAt[0]) > 9*time.Minute)
+				require.Contains(t, repo.tempUnschedulableWhy[0], "OpenAI 403 temporary cooldown")
+			},
+		},
 		{
 			name:        "oauth_429_rate_limit",
 			accountType: AccountTypeOAuth,
@@ -852,6 +899,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_429And529TriggerFailover(t *test
 					RateLimit: config.RateLimitConfig{OverloadCooldownMinutes: 10},
 				},
 			}
+			rateSvc.SetOpenAI403CounterCache(&openAIPassthrough403CounterStub{counts: []int64{1}})
 
 			svc := &OpenAIGatewayService{
 				cfg:              &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},


### PR DESCRIPTION
## 问题

OpenAI passthrough 模式(走 OAuth 桥接的 Codex / ChatGPT 订阅账号)的失败转移决策函数 `shouldFailoverOpenAIPassthroughResponse` 当前只把 `429` 和 `529` 当作可 failover 状态码:

```go
// backend/internal/service/openai_gateway_service.go:3086
func shouldFailoverOpenAIPassthroughResponse(statusCode int) bool {
    switch statusCode {
    case http.StatusTooManyRequests, 529:
        return true
    default:
        return false
    }
}
```

但 Codex / ChatGPT 订阅账号的"用量配额耗尽"信号实际是 **`403 forbidden_error`** (例如 `{"error": {"message": "usage limit reached", "type": "forbidden_error"}}`),不是 429。这意味着:

- 客户 API key 在 group 内绑定多个 OAuth 账号
- 当前账号配额跑完返回 403
- vanilla 不 failover,把 403 原样透回客户端
- 用户体验:**单账号跑完后 key 直接断开,即使同 group 还有健康账号**

跟 `shouldFailoverUpstreamError`(用于非 passthrough 的标准模式)对比,后者已经包含 `case 401, 402, 403, 429, 529` — passthrough 路径漏掉了 403。

## 改动

`shouldFailoverOpenAIPassthroughResponse` 增加 `http.StatusForbidden`,让 passthrough 模式也能在 403 时触发 `handler.FailoverState` 循环。

复用现有的 cooldown 状态机(`SetTempUnschedulable` + `IncrementOpenAI403Count`),不引入新状态:
- 单次 403:账号进入 10 分钟临时冷却("OpenAI 403 temporary cooldown"),group 内调度器立即跳过它
- 累计 3 次 403:升级为永久判坏号(走 `SetError` 路径)

## 测试

`TestOpenAIGatewayService_OpenAIPassthrough_FailoverStatusesTriggerAccountSwitch` 增加 `oauth_403_temp_unschedulable` case,验证:
- `repo.tempUnschedulableIDs == [123]`
- `until` 在 9 分钟之后(=10 分钟 cooldown)
- `repo.tempUnschedulableWhy[0]` 包含 `"OpenAI 403 temporary cooldown"`

本地 `go test ./internal/service -run TestOpenAIGatewayService_OpenAIPassthrough_FailoverStatusesTriggerAccountSwitch -count=1 -v` 全部通过(5 个 subcase)。

## 兼容性

- 非 passthrough 路径不受影响(那条路 vanilla 已经处理 403)
- 单次 403 不会立刻判坏账号 — 临时冷却 10 分钟,符合 sub2api 现有的"先临时冷却,再根据连续次数决定是否判坏号"逻辑(commit `11cf23da` 提过同样思路)
