### PR TITLE
fix: Bedrock routing for OpenAI-compatible endpoints

### DIFF
--- a/backend/internal/service/gateway_compat_bedrock.go
+++ b/backend/internal/service/gateway_compat_bedrock.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type compatErrorWriter func(c *gin.Context, statusCode int, code, message string)
+type bedrockCompatErrorWriter func(c *gin.Context, statusCode int, code, message string)
 
 func (s *GatewayService) forwardCompatBedrockAnthropicStream(
 	ctx context.Context,
@@ -21,7 +21,7 @@ func (s *GatewayService) forwardCompatBedrockAnthropicStream(
 	anthropicBody []byte,
 	model string,
 	stream bool,
-	writeError compatErrorWriter,
+	writeError bedrockCompatErrorWriter,
 ) (*http.Response, string, error) {
 	region := bedrockRuntimeRegion(account)
 	mappedModel, ok := ResolveBedrockModelID(account, model)
@@ -85,7 +85,7 @@ func (s *GatewayService) handleCompatBedrockError(
 	resp *http.Response,
 	c *gin.Context,
 	account *Account,
-	writeError compatErrorWriter,
+	writeError bedrockCompatErrorWriter,
 ) (*http.Response, error) {
 	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	_ = resp.Body.Close()

--- a/backend/internal/service/gateway_compat_bedrock.go
+++ b/backend/internal/service/gateway_compat_bedrock.go
@@ -1,0 +1,222 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type compatErrorWriter func(c *gin.Context, statusCode int, code, message string)
+
+func (s *GatewayService) forwardCompatBedrockAnthropicStream(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	anthropicBody []byte,
+	model string,
+	stream bool,
+	writeError compatErrorWriter,
+) (*http.Response, string, error) {
+	region := bedrockRuntimeRegion(account)
+	mappedModel, ok := ResolveBedrockModelID(account, model)
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported bedrock model: %s", model)
+	}
+
+	betaHeader := ""
+	if c != nil && c.Request != nil {
+		betaHeader = c.GetHeader("anthropic-beta")
+	}
+	betaTokens, err := s.resolveBedrockBetaTokensForRequest(ctx, account, betaHeader, anthropicBody, mappedModel)
+	if err != nil {
+		return nil, "", err
+	}
+	bedrockBody, err := PrepareBedrockRequestBodyWithTokens(anthropicBody, mappedModel, betaTokens)
+	if err != nil {
+		return nil, "", fmt.Errorf("prepare bedrock request body: %w", err)
+	}
+
+	var signer *BedrockSigner
+	var bedrockAPIKey string
+	if account.IsBedrockAPIKey() {
+		bedrockAPIKey = account.GetCredential("api_key")
+		if bedrockAPIKey == "" {
+			return nil, "", fmt.Errorf("api_key not found in bedrock credentials")
+		}
+	} else {
+		signer, err = NewBedrockSignerFromAccount(account)
+		if err != nil {
+			return nil, "", fmt.Errorf("create bedrock signer: %w", err)
+		}
+	}
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.executeBedrockUpstream(ctx, c, account, bedrockBody, mappedModel, region, stream, signer, bedrockAPIKey, proxyURL)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if awsReqID := resp.Header.Get("x-amzn-requestid"); awsReqID != "" && resp.Header.Get("x-request-id") == "" {
+		resp.Header.Set("x-request-id", awsReqID)
+	}
+
+	if resp.StatusCode >= 400 {
+		errResp, err := s.handleCompatBedrockError(ctx, resp, c, account, writeError)
+		return errResp, mappedModel, err
+	}
+
+	if stream {
+		resp.Body = newBedrockAnthropicSSEReadCloser(resp.Body)
+	}
+	return resp, mappedModel, nil
+}
+
+func (s *GatewayService) handleCompatBedrockError(
+	ctx context.Context,
+	resp *http.Response,
+	c *gin.Context,
+	account *Account,
+	writeError compatErrorWriter,
+) (*http.Response, error) {
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+
+	if s.shouldFailoverUpstreamError(resp.StatusCode) {
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  resp.Header.Get("x-request-id"),
+			Kind:               "failover",
+			Message:            upstreamMsg,
+		})
+		if s.rateLimitService != nil {
+			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		}
+		return nil, &UpstreamFailoverError{
+			StatusCode:             resp.StatusCode,
+			ResponseBody:           respBody,
+			RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
+		}
+	}
+
+	writeError(c, mapUpstreamStatusCode(resp.StatusCode), "server_error", upstreamMsg)
+	return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
+}
+
+type bedrockAnthropicSSEReadCloser struct {
+	source  io.Closer
+	events  chan bedrockCompatEvent
+	done    chan struct{}
+	buf     bytes.Buffer
+	closed  bool
+	readErr error
+}
+
+type bedrockCompatEvent struct {
+	payload []byte
+	err     error
+}
+
+func newBedrockAnthropicSSEReadCloser(source io.ReadCloser) io.ReadCloser {
+	rc := &bedrockAnthropicSSEReadCloser{
+		source: source,
+		events: make(chan bedrockCompatEvent, 16),
+		done:   make(chan struct{}),
+	}
+	decoder := newBedrockEventStreamDecoder(source)
+	send := func(ev bedrockCompatEvent) bool {
+		select {
+		case rc.events <- ev:
+			return true
+		case <-rc.done:
+			return false
+		}
+	}
+	go func() {
+		defer close(rc.events)
+		for {
+			payload, err := decoder.Decode()
+			if err != nil {
+				if err != io.EOF {
+					_ = send(bedrockCompatEvent{err: err})
+				}
+				return
+			}
+			if !send(bedrockCompatEvent{payload: payload}) {
+				return
+			}
+		}
+	}()
+	return rc
+}
+
+func (r *bedrockAnthropicSSEReadCloser) Read(p []byte) (int, error) {
+	for r.buf.Len() == 0 {
+		if r.readErr != nil {
+			return 0, r.readErr
+		}
+		if r.closed {
+			return 0, io.EOF
+		}
+
+		ev, ok := <-r.events
+		if !ok {
+			r.closed = true
+			return 0, io.EOF
+		}
+		if ev.err != nil {
+			r.readErr = fmt.Errorf("bedrock stream read error: %w", ev.err)
+			return 0, r.readErr
+		}
+
+		sseData := extractBedrockChunkData(ev.payload)
+		if sseData == nil {
+			continue
+		}
+		sseData = transformBedrockInvocationMetrics(sseData)
+		eventType := strings.TrimSpace(jsonEventType(sseData))
+		if eventType != "" {
+			fmt.Fprintf(&r.buf, "event: %s\ndata: %s\n\n", eventType, sseData)
+		} else {
+			fmt.Fprintf(&r.buf, "data: %s\n\n", sseData)
+		}
+	}
+	return r.buf.Read(p)
+}
+
+func (r *bedrockAnthropicSSEReadCloser) Close() error {
+	select {
+	case <-r.done:
+	default:
+		close(r.done)
+	}
+	if r.source == nil {
+		return nil
+	}
+	return r.source.Close()
+}
+
+func jsonEventType(data []byte) string {
+	var payload struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return ""
+	}
+	return payload.Type
+}

--- a/backend/internal/service/gateway_compat_bedrock_test.go
+++ b/backend/internal/service/gateway_compat_bedrock_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type bedrockCompatHTTPUpstreamRecorder struct {
+	lastReq  *http.Request
+	lastBody []byte
+	resp     *http.Response
+}
+
+func (u *bedrockCompatHTTPUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	u.lastReq = req
+	if req != nil && req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		u.lastBody = b
+		_ = req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(b))
+	}
+	return u.resp, nil
+}
+
+func (u *bedrockCompatHTTPUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func TestGatewayService_ForwardAsChatCompletions_BedrockAPIKeyUsesBedrockRuntime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &bedrockCompatHTTPUpstreamRecorder{
+		resp: newBedrockEventStreamResponse(
+			`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"us.anthropic.claude-sonnet-4-6","stop_reason":"","usage":{"input_tokens":3,"output_tokens":0}}}`,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+			`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+			`{"type":"message_stop"}`,
+		),
+	}
+	svc := &GatewayService{httpUpstream: upstream}
+	account := newBedrockAPIKeyCompatAccountForTest()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"max_tokens":128}`)
+	result, err := svc.ForwardAsChatCompletions(c.Request.Context(), c, account, body, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, upstream.lastReq.URL.String(), "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/invoke-with-response-stream")
+	require.Equal(t, "Bearer bedrock-test-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-api-key"))
+	require.Equal(t, "claude-sonnet-4-6", gjson.Get(rec.Body.String(), "model").String())
+	require.Equal(t, "assistant", gjson.Get(rec.Body.String(), "choices.0.message.role").String())
+	require.Equal(t, "hello", gjson.Get(rec.Body.String(), "choices.0.message.content").String())
+	require.Equal(t, int64(3), gjson.Get(rec.Body.String(), "usage.prompt_tokens").Int())
+	require.Equal(t, int64(1), gjson.Get(rec.Body.String(), "usage.completion_tokens").Int())
+}
+
+func TestGatewayService_ForwardAsResponses_BedrockAPIKeyUsesBedrockRuntime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &bedrockCompatHTTPUpstreamRecorder{
+		resp: newBedrockEventStreamResponse(
+			`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"us.anthropic.claude-sonnet-4-6","stop_reason":"","usage":{"input_tokens":3,"output_tokens":0}}}`,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+			`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+			`{"type":"message_stop"}`,
+		),
+	}
+	svc := &GatewayService{httpUpstream: upstream}
+	account := newBedrockAPIKeyCompatAccountForTest()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","input":"hi","max_output_tokens":128}`)
+	result, err := svc.ForwardAsResponses(c.Request.Context(), c, account, body, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, upstream.lastReq.URL.String(), "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/invoke-with-response-stream")
+	require.Equal(t, "Bearer bedrock-test-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-api-key"))
+	require.Contains(t, rec.Body.String(), `"model":"claude-sonnet-4-6"`)
+	require.Contains(t, rec.Body.String(), `"text":"hello"`)
+}
+
+func newBedrockAPIKeyCompatAccountForTest() *Account {
+	return &Account{
+		ID:          301,
+		Name:        "bedrock-compat-test",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeBedrock,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"auth_mode":  "apikey",
+			"api_key":    "bedrock-test-key",
+			"aws_region": "us-east-1",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func newBedrockEventStreamResponse(events ...string) *http.Response {
+	var body bytes.Buffer
+	for _, event := range events {
+		chunkPayload := `{"bytes":"` + base64.StdEncoding.EncodeToString([]byte(event)) + `"}`
+		_, _ = body.Write(buildBedrockEventStreamFrameForCompatTest("chunk", []byte(chunkPayload)))
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"x-amzn-requestid": []string{"bedrock-request-id"},
+		},
+		Body: io.NopCloser(bytes.NewReader(body.Bytes())),
+	}
+}
+
+func buildBedrockEventStreamFrameForCompatTest(eventType string, payload []byte) []byte {
+	crc32IeeeTab := crc32.MakeTable(crc32.IEEE)
+	var headersBuf bytes.Buffer
+	_ = headersBuf.WriteByte(byte(len(":event-type")))
+	_, _ = headersBuf.WriteString(":event-type")
+	_ = headersBuf.WriteByte(7)
+	_ = binary.Write(&headersBuf, binary.BigEndian, uint16(len(eventType)))
+	_, _ = headersBuf.WriteString(eventType)
+	_ = headersBuf.WriteByte(byte(len(":message-type")))
+	_, _ = headersBuf.WriteString(":message-type")
+	_ = headersBuf.WriteByte(7)
+	_ = binary.Write(&headersBuf, binary.BigEndian, uint16(len("event")))
+	_, _ = headersBuf.WriteString("event")
+
+	headers := headersBuf.Bytes()
+	headersLen := uint32(len(headers))
+	totalLen := uint32(12 + len(headers) + len(payload) + 4)
+
+	var preludeBuf bytes.Buffer
+	_ = binary.Write(&preludeBuf, binary.BigEndian, totalLen)
+	_ = binary.Write(&preludeBuf, binary.BigEndian, headersLen)
+	preludeBytes := preludeBuf.Bytes()
+	preludeCRC := crc32.Checksum(preludeBytes, crc32IeeeTab)
+
+	var frame bytes.Buffer
+	_, _ = frame.Write(preludeBytes)
+	_ = binary.Write(&frame, binary.BigEndian, preludeCRC)
+	_, _ = frame.Write(headers)
+	_, _ = frame.Write(payload)
+	messageCRC := crc32.Checksum(frame.Bytes(), crc32IeeeTab)
+	_ = binary.Write(&frame, binary.BigEndian, messageCRC)
+	return frame.Bytes()
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -104,6 +104,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+	reasoningEffort := extractCCReasoningEffortFromBody(body)
 
 	if account.IsBedrock() {
 		resp, bedrockModel, err := s.forwardCompatBedrockAnthropicStream(ctx, c, account, anthropicBody, mappedModel, reqStream, writeGatewayCCError)
@@ -190,9 +191,6 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		writeGatewayCCError(c, mapUpstreamStatusCode(resp.StatusCode), "server_error", upstreamMsg)
 		return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
 	}
-
-	// 13. Extract reasoning effort from CC request body
-	reasoningEffort := extractCCReasoningEffortFromBody(body)
 
 	// 14. Handle normal response
 	// Read Anthropic SSE → convert to Responses events → convert to CC format

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -69,7 +69,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		if normalized != originalModel {
 			mappedModel = normalized
 		}
-	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
+	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey && !account.IsBedrock() {
 		normalized := claude.NormalizeModelID(originalModel)
 		if normalized != originalModel {
 			mappedModel = normalized
@@ -104,6 +104,19 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+
+	if account.IsBedrock() {
+		resp, bedrockModel, err := s.forwardCompatBedrockAnthropicStream(ctx, c, account, anthropicBody, mappedModel, reqStream, writeGatewayCCError)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if clientStream {
+			return s.handleCCStreamingFromAnthropic(resp, c, originalModel, bedrockModel, reasoningEffort, startTime, includeUsage)
+		}
+		return s.handleCCBufferedFromAnthropic(resp, c, originalModel, bedrockModel, reasoningEffort, startTime)
+	}
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -66,7 +66,7 @@ func (s *GatewayService) ForwardAsResponses(
 		if normalized != originalModel {
 			mappedModel = normalized
 		}
-	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
+	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey && !account.IsBedrock() {
 		normalized := claude.NormalizeModelID(originalModel)
 		if normalized != originalModel {
 			mappedModel = normalized
@@ -101,6 +101,19 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+
+	if account.IsBedrock() {
+		resp, bedrockModel, err := s.forwardCompatBedrockAnthropicStream(ctx, c, account, anthropicBody, mappedModel, reqStream, writeResponsesError)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if clientStream {
+			return s.handleResponsesStreamingResponse(resp, c, originalModel, bedrockModel, reasoningEffort, startTime)
+		}
+		return s.handleResponsesBufferedStreamingResponse(resp, c, originalModel, bedrockModel, reasoningEffort, startTime)
+	}
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)


### PR DESCRIPTION
## Problem
Bedrock accounts can be selected for Anthropic-platform groups, but OpenAI-compatible routes such as `/v1/chat/completions` and `/v1/responses` were forwarding through the generic Anthropic upstream builder.

That path does not use Bedrock Runtime signing or API-key handling. When a Bedrock account is selected on `/v1/chat/completions`, the request can be sent as if it were a normal Anthropic API request, causing upstream authentication failures such as:

```text
Authentication failed (401): x-api-key header is required
```

This is especially visible after the platform-based routing split for `/v1/chat/completions`, where non-OpenAI groups route to `GatewayHandler.ChatCompletions` and can schedule Bedrock accounts.

## Fix
- Detect `account.IsBedrock()` inside `GatewayService.ForwardAsChatCompletions` and `GatewayService.ForwardAsResponses`.
- Route converted Anthropic request bodies through Bedrock Runtime request construction instead of the generic Anthropic upstream request builder.
- Preserve Bedrock SigV4 and Bedrock API Key modes:
  - SigV4 accounts use `NewBedrockSignerFromAccount`.
  - Bedrock API Key accounts use `Authorization: Bearer <api_key>`.
- Adapt Bedrock EventStream chunks back into Anthropic SSE so the existing Responses and Chat Completions conversion code can be reused.
- Skip normal Anthropic model normalization for Bedrock accounts and let the Bedrock resolver produce the AWS model id.

## Tests
- Added coverage for Bedrock API Key accounts through `/v1/chat/completions` and `/v1/responses`, asserting requests go to `bedrock-runtime` with `Authorization: Bearer` and no `x-api-key`.
- Not run locally in this sandbox: no `go`/`gofmt` binary is available, and Docker daemon access is denied.