### PR TITLE
feat(easypay): add per-channel payment type override

### DIFF
--- a/backend/internal/payment/provider/easypay.go
+++ b/backend/internal/payment/provider/easypay.go
@@ -125,7 +125,7 @@ func (e *EasyPay) CreatePayment(ctx context.Context, req payment.CreatePaymentRe
 func (e *EasyPay) createRedirectPayment(req payment.CreatePaymentRequest) (*payment.CreatePaymentResponse, error) {
 	notifyURL, returnURL := e.resolveURLs(req)
 	params := map[string]string{
-		"pid": e.config["pid"], "type": req.PaymentType,
+		"pid": e.config["pid"], "type": e.resolveType(req.PaymentType),
 		"out_trade_no": req.OrderID, "notify_url": notifyURL,
 		"return_url": returnURL, "name": req.Subject,
 		"money": req.Amount,
@@ -151,7 +151,7 @@ func (e *EasyPay) createRedirectPayment(req payment.CreatePaymentRequest) (*paym
 func (e *EasyPay) createAPIPayment(ctx context.Context, req payment.CreatePaymentRequest) (*payment.CreatePaymentResponse, error) {
 	notifyURL, returnURL := e.resolveURLs(req)
 	params := map[string]string{
-		"pid": e.config["pid"], "type": req.PaymentType,
+		"pid": e.config["pid"], "type": e.resolveType(req.PaymentType),
 		"out_trade_no": req.OrderID, "notify_url": notifyURL,
 		"return_url": returnURL, "name": req.Subject,
 		"money": req.Amount, "clientip": req.ClientIP,
@@ -396,17 +396,23 @@ func summarizeEasyPayResponse(body []byte) string {
 	return summary
 }
 
-func (e *EasyPay) resolveCID(paymentType string) string {
-	if strings.HasPrefix(paymentType, "alipay") {
-		if v := e.config["cidAlipay"]; v != "" {
-			return v
-		}
-		return e.config["cid"]
+func (e *EasyPay) resolveByChannel(paymentType, alipayKey, wxpayKey, fallback string) string {
+	key := wxpayKey
+	if strings.HasPrefix(paymentType, string(payment.TypeAlipay)) {
+		key = alipayKey
 	}
-	if v := e.config["cidWxpay"]; v != "" {
+	if v := e.config[key]; v != "" {
 		return v
 	}
-	return e.config["cid"]
+	return fallback
+}
+
+func (e *EasyPay) resolveCID(paymentType string) string {
+	return e.resolveByChannel(paymentType, "cidAlipay", "cidWxpay", e.config["cid"])
+}
+
+func (e *EasyPay) resolveType(paymentType string) string {
+	return e.resolveByChannel(paymentType, "typeAlipay", "typeWxpay", paymentType)
 }
 
 func (e *EasyPay) post(ctx context.Context, endpoint string, params map[string]string) ([]byte, error) {

--- a/backend/internal/payment/provider/easypay_resolve_test.go
+++ b/backend/internal/payment/provider/easypay_resolve_test.go
@@ -1,0 +1,145 @@
+package provider
+
+import "testing"
+
+func TestEasyPayResolveType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      map[string]string
+		paymentType string
+		want        string
+	}{
+		{
+			name:        "alipay with override",
+			config:      map[string]string{"typeAlipay": "alipay_h5"},
+			paymentType: "alipay",
+			want:        "alipay_h5",
+		},
+		{
+			name:        "alipay_direct with override",
+			config:      map[string]string{"typeAlipay": "alipay_h5"},
+			paymentType: "alipay_direct",
+			want:        "alipay_h5",
+		},
+		{
+			name:        "alipay no override",
+			config:      map[string]string{},
+			paymentType: "alipay",
+			want:        "alipay",
+		},
+		{
+			name:        "wxpay with override",
+			config:      map[string]string{"typeWxpay": "wxpay_h5"},
+			paymentType: "wxpay",
+			want:        "wxpay_h5",
+		},
+		{
+			name:        "wxpay_direct with override",
+			config:      map[string]string{"typeWxpay": "wxpay_h5"},
+			paymentType: "wxpay_direct",
+			want:        "wxpay_h5",
+		},
+		{
+			name:        "wxpay no override",
+			config:      map[string]string{},
+			paymentType: "wxpay",
+			want:        "wxpay",
+		},
+		{
+			name:        "both configured alipay input",
+			config:      map[string]string{"typeAlipay": "alipay_h5", "typeWxpay": "wxpay_h5"},
+			paymentType: "alipay",
+			want:        "alipay_h5",
+		},
+		{
+			name:        "both configured wxpay input",
+			config:      map[string]string{"typeAlipay": "alipay_h5", "typeWxpay": "wxpay_h5"},
+			paymentType: "wxpay",
+			want:        "wxpay_h5",
+		},
+		{
+			name:        "empty override ignored for alipay",
+			config:      map[string]string{"typeAlipay": ""},
+			paymentType: "alipay",
+			want:        "alipay",
+		},
+		{
+			name:        "empty override ignored for wxpay",
+			config:      map[string]string{"typeWxpay": ""},
+			paymentType: "wxpay",
+			want:        "wxpay",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &EasyPay{config: tt.config}
+			got := e.resolveType(tt.paymentType)
+			if got != tt.want {
+				t.Errorf("resolveType(%q) = %q, want %q", tt.paymentType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEasyPayResolveCID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      map[string]string
+		paymentType string
+		want        string
+	}{
+		{
+			name:        "alipay with override",
+			config:      map[string]string{"cid": "default", "cidAlipay": "ali_cid"},
+			paymentType: "alipay",
+			want:        "ali_cid",
+		},
+		{
+			name:        "alipay no override falls back to cid",
+			config:      map[string]string{"cid": "default"},
+			paymentType: "alipay",
+			want:        "default",
+		},
+		{
+			name:        "wxpay with override",
+			config:      map[string]string{"cid": "default", "cidWxpay": "wx_cid"},
+			paymentType: "wxpay",
+			want:        "wx_cid",
+		},
+		{
+			name:        "wxpay no override falls back to cid",
+			config:      map[string]string{"cid": "default"},
+			paymentType: "wxpay",
+			want:        "default",
+		},
+		{
+			name:        "empty override ignored for alipay",
+			config:      map[string]string{"cid": "default", "cidAlipay": ""},
+			paymentType: "alipay",
+			want:        "default",
+		},
+		{
+			name:        "empty override ignored for wxpay",
+			config:      map[string]string{"cid": "default", "cidWxpay": ""},
+			paymentType: "wxpay",
+			want:        "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := &EasyPay{config: tt.config}
+			got := e.resolveCID(tt.paymentType)
+			if got != tt.want {
+				t.Errorf("resolveCID(%q) = %q, want %q", tt.paymentType, got, tt.want)
+			}
+		})
+	}
+}

--- a/frontend/src/components/payment/PaymentProviderDialog.vue
+++ b/frontend/src/components/payment/PaymentProviderDialog.vue
@@ -547,7 +547,8 @@ function handleSave() {
   // Validate required config fields — all non-optional fields must be filled.
   // In edit mode, sensitive fields may be left blank to preserve the stored
   // value (backend merges blanks by preserving the existing secret).
-  for (const f of PROVIDER_CONFIG_FIELDS[form.provider_key] || []) {
+  const fieldDefs = PROVIDER_CONFIG_FIELDS[form.provider_key] || []
+  for (const f of fieldDefs) {
     if (f.optional) continue
     if (props.editing && f.sensitive) continue
     const val = (config[f.key] || '').trim()
@@ -563,15 +564,18 @@ function handleSave() {
       .filter(field => field.clearable)
       .map(field => field.key),
   )
+  const sensitiveKeys = new Set(fieldDefs.filter(f => f.sensitive).map(f => f.key))
   const filteredConfig: Record<string, string> = {}
-  for (const [k, v] of Object.entries(config)) {
-    if (!v || !v.trim()) {
+  for (const [k, v] of Object.entries(config) as [string, string][]) {
+    const val = v.trim()
+    if (!val) {
+      if (sensitiveKeys.has(k)) continue
       if (clearableConfigKeys.has(k)) {
         filteredConfig[k] = ''
       }
       continue
     }
-    filteredConfig[k] = v
+    filteredConfig[k] = val
   }
 
   // Inject computed callback URLs (each URL = independent base + fixed path)

--- a/frontend/src/components/payment/providerConfig.ts
+++ b/frontend/src/components/payment/providerConfig.ts
@@ -112,6 +112,8 @@ export const PROVIDER_CONFIG_FIELDS: Record<string, ConfigFieldDef[]> = {
     { key: 'apiBase', label: '', sensitive: false },
     { key: 'cidAlipay', label: '', sensitive: false, optional: true },
     { key: 'cidWxpay', label: '', sensitive: false, optional: true },
+    { key: 'typeAlipay', label: '', sensitive: false, optional: true },
+    { key: 'typeWxpay', label: '', sensitive: false, optional: true },
   ],
   alipay: [
     { key: 'appId', label: 'App ID', sensitive: false },

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5559,6 +5559,8 @@ export default {
         field_cid: 'Channel ID',
         field_cidAlipay: 'Alipay Channel ID',
         field_cidWxpay: 'WeChat Channel ID',
+        field_typeAlipay: 'Alipay Type Override',
+        field_typeWxpay: 'WeChat Type Override',
         stripeWebhookHint: 'Configure the following URL as a Webhook endpoint in Stripe Dashboard:',
         stripeWebhookApiVersionHint: 'Set this Webhook endpoint API version to match the integrated Stripe SDK. Recommended: {version}. A mismatch can cause webhook parsing errors.',
         airwallexWebhookHint: 'Configure the following URL as a Webhook endpoint in Airwallex. Select at least Payment Intent -> Succeeded (payment_intent.succeeded), preferably also Payment Intent -> Cancelled (payment_intent.cancelled). Use the account default or latest stable API version.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5720,6 +5720,8 @@ export default {
         field_cid: '支付渠道 ID',
         field_cidAlipay: '支付宝渠道 ID',
         field_cidWxpay: '微信渠道 ID',
+        field_typeAlipay: '支付宝类型覆盖',
+        field_typeWxpay: '微信类型覆盖',
         stripeWebhookHint: '请在 Stripe Dashboard 中将以下地址配置为 Webhook 端点：',
         stripeWebhookApiVersionHint: 'Webhook 端点的 API 版本请与当前集成的 Stripe SDK 对齐，建议选择 {version}；版本不一致可能导致回调事件解析失败。',
         airwallexWebhookHint: '请在 Airwallex 后台将以下地址配置为 Webhook 端点；事件至少选择 Payment Intent -> Succeeded（payment_intent.succeeded），建议同时选择 Payment Intent -> Cancelled（payment_intent.cancelled）；API version 选择账户默认或最新稳定版本。',


### PR DESCRIPTION
## Summary
- Add `typeAlipay` / `typeWxpay` optional config keys to EasyPay, allowing
  per-channel payment type overrides (e.g. mapping `alipay` → `alipay_h5`)
- Extract `resolveByChannel` helper to consolidate the channel-specific
  config lookup pattern (previously only in `resolveCID`, now shared with `resolveType`)
- Frontend: allow clearing optional non-sensitive overrides by preserving
  empty values on save; only drop empty sensitive fields to let the backend
  keep stored secrets
