### PR TITLE
fix: /v1/chat/completions returns 401 for Gemini platform groups

### DIFF
--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -2,12 +2,14 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
 	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -16,10 +18,10 @@ import (
 	"go.uber.org/zap"
 )
 
-// ChatCompletions handles OpenAI Chat Completions API endpoint for Anthropic platform groups.
+// ChatCompletions handles OpenAI Chat Completions API endpoint.
 // POST /v1/chat/completions
-// This converts Chat Completions requests to Anthropic format (via Responses format chain),
-// forwards to Anthropic upstream, and converts responses back to Chat Completions format.
+// For Anthropic platform groups: converts CC → Anthropic Messages → forwards to Anthropic → converts back to CC.
+// For Gemini platform groups: converts CC → Anthropic Messages → forwards to Gemini (via geminiCompatService) → converts back to CC.
 func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	streamStarted := false
 
@@ -36,6 +38,8 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		h.chatCompletionsErrorResponse(c, http.StatusInternalServerError, "api_error", "User context not found")
 		return
 	}
+
+	subjectPtr := &subject
 	reqLog := requestLogger(
 		c,
 		"handler.gateway.chat_completions",
@@ -43,6 +47,15 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		zap.Int64("api_key_id", apiKey.ID),
 		zap.Any("group_id", apiKey.GroupID),
 	)
+
+	// Determine platform
+	platform := ""
+	forcePlatform, hasForcePlatform := middleware2.GetForcePlatformFromContext(c)
+	if hasForcePlatform {
+		platform = forcePlatform
+	} else if apiKey.Group != nil {
+		platform = apiKey.Group.Platform
+	}
 
 	// Read request body
 	body, err := pkghttputil.ReadRequestBodyWithPrealloc(c.Request)
@@ -76,7 +89,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	}
 	reqModel := modelResult.String()
 	reqStream := gjson.GetBytes(body, "stream").Bool()
-	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
+	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream), zap.String("platform", platform))
 
 	setOpsRequestContext(c, reqModel, reqStream, body)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
@@ -162,6 +175,19 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	}
 	sessionHash := h.gatewayService.GenerateSessionHash(parsedReq)
 
+	// === Gemini platform: dedicated forwarding path ===
+	if platform == service.PlatformGemini {
+		h.chatCompletionsGemini(c, reqLog, apiKey, subjectPtr, subscription, body, reqModel, reqStream, parsedReq, sessionHash, &channelMapping, &streamStarted, requestStart)
+		return
+	}
+
+	// === Non-Gemini platform: original ForwardAsChatCompletions path ===
+	h.chatCompletionsAnthropic(c, reqLog, apiKey, subjectPtr, subscription, body, reqModel, reqStream, parsedReq, sessionHash, &channelMapping, &streamStarted, requestStart)
+}
+
+// chatCompletionsAnthropic is the original ChatCompletions path for Anthropic/OpenAI platforms.
+// It converts CC → Anthropic Messages, forwards to Anthropic upstream, and converts back to CC.
+func (h *GatewayHandler) chatCompletionsAnthropic(c *gin.Context, reqLog *zap.Logger, apiKey *service.APIKey, subject *middleware2.AuthSubject, subscription *service.UserSubscription, body []byte, reqModel string, reqStream bool, parsedReq *service.ParsedRequest, sessionHash string, channelMapping *service.ChannelMappingResult, streamStarted *bool, requestStart time.Time) {
 	// 3. Account selection + failover loop
 	fs := NewFailoverState(h.maxAccountSwitches, false)
 
@@ -180,7 +206,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				return
 			default:
 				if fs.LastFailoverErr != nil {
-					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
+					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, *streamStarted)
 				} else {
 					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
 				}
@@ -203,11 +229,11 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				selection.WaitPlan.MaxConcurrency,
 				selection.WaitPlan.Timeout,
 				reqStream,
-				&streamStarted,
+				streamStarted,
 			)
 			if err != nil {
 				reqLog.Warn("gateway.cc.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
-				h.handleConcurrencyError(c, err, "account", streamStarted)
+				h.handleConcurrencyError(c, err, "account", *streamStarted)
 				return
 			}
 		}
@@ -237,13 +263,13 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				case FailoverContinue:
 					continue
 				case FailoverExhausted:
-					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, streamStarted)
+					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, *streamStarted)
 					return
 				case FailoverCanceled:
 					return
 				}
 			}
-			h.ensureForwardErrorResponse(c, streamStarted)
+			h.ensureForwardErrorResponse(c, *streamStarted)
 			reqLog.Error("gateway.cc.forward_failed",
 				zap.Int64("account_id", account.ID),
 				zap.Error(err),
@@ -252,35 +278,158 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		}
 
 		// 6. Record usage
-		userAgent := c.GetHeader("User-Agent")
-		clientIP := ip.GetClientIP(c)
-		requestPayloadHash := service.HashUsageRequestPayload(body)
-		inboundEndpoint := GetInboundEndpoint(c)
-		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
-
-		h.submitUsageRecordTask(func(ctx context.Context) {
-			if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
-				Result:             result,
-				APIKey:             apiKey,
-				User:               apiKey.User,
-				Account:            account,
-				Subscription:       subscription,
-				InboundEndpoint:    inboundEndpoint,
-				UpstreamEndpoint:   upstreamEndpoint,
-				UserAgent:          userAgent,
-				IPAddress:          clientIP,
-				RequestPayloadHash: requestPayloadHash,
-				APIKeyService:      h.apiKeyService,
-				ChannelUsageFields: channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
-			}); err != nil {
-				reqLog.Error("gateway.cc.record_usage_failed",
-					zap.Int64("account_id", account.ID),
-					zap.Error(err),
-				)
-			}
-		})
+		h.recordChatCompletionsUsage(c, result, apiKey, account, subscription, body, reqModel, channelMapping)
 		return
 	}
+}
+
+// chatCompletionsGemini handles CC requests for Gemini platform groups.
+// It converts CC → Anthropic Messages, forwards via geminiCompatService.Forward(),
+// then converts the Claude response back to Chat Completions format.
+func (h *GatewayHandler) chatCompletionsGemini(c *gin.Context, reqLog *zap.Logger, apiKey *service.APIKey, subject *middleware2.AuthSubject, subscription *service.UserSubscription, body []byte, reqModel string, reqStream bool, parsedReq *service.ParsedRequest, sessionHash string, channelMapping *service.ChannelMappingResult, streamStarted *bool, requestStart time.Time) {
+	// Convert CC → Anthropic Messages format
+	var ccReq apicompat.ChatCompletionsRequest
+	if err := json.Unmarshal(body, &ccReq); err != nil {
+		h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse chat completions request")
+		return
+	}
+	originalModel := ccReq.Model
+
+	responsesReq, err := apicompat.ChatCompletionsToResponses(&ccReq)
+	if err != nil {
+		h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to convert chat completions to responses: "+err.Error())
+		return
+	}
+	anthropicReq, err := apicompat.ResponsesToAnthropicRequest(responsesReq)
+	if err != nil {
+		h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to convert responses to anthropic: "+err.Error())
+		return
+	}
+	anthropicBody, err := json.Marshal(anthropicReq)
+	if err != nil {
+		h.chatCompletionsErrorResponse(c, http.StatusInternalServerError, "api_error", "Failed to marshal anthropic request")
+		return
+	}
+
+	// Use Anthropic Messages format for account selection
+	anthropicParsedReq, _ := service.ParseGatewayRequest(anthropicBody, "messages")
+	if anthropicParsedReq == nil {
+		anthropicParsedReq = &service.ParsedRequest{Model: reqModel, Stream: reqStream, Body: anthropicBody}
+	}
+	anthropicParsedReq.SessionContext = parsedReq.SessionContext
+
+	// Account selection + failover
+	fs := NewFailoverState(h.maxAccountSwitchesGemini, false)
+
+	sessionKey := sessionHash
+	if sessionHash != "" {
+		sessionKey = "gemini:" + sessionHash
+	}
+
+	for {
+		selection, err := h.gatewayService.SelectAccountWithLoadAwareness(c.Request.Context(), apiKey.GroupID, sessionKey, reqModel, fs.FailedAccountIDs, "", int64(0))
+		if err != nil {
+			if len(fs.FailedAccountIDs) == 0 {
+				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts: "+err.Error())
+				return
+			}
+			action := fs.HandleSelectionExhausted(c.Request.Context())
+			switch action {
+			case FailoverContinue:
+				continue
+			case FailoverCanceled:
+				return
+			default:
+				if fs.LastFailoverErr != nil {
+					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, *streamStarted)
+				} else {
+					h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "All available accounts exhausted")
+				}
+				return
+			}
+		}
+		account := selection.Account
+		setOpsSelectedAccount(c, account.ID, account.Platform)
+
+		// Acquire account concurrency slot
+		accountReleaseFunc := selection.ReleaseFunc
+		if !selection.Acquired {
+			if selection.WaitPlan == nil {
+				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+				return
+			}
+			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+				c, account.ID, selection.WaitPlan.MaxConcurrency, selection.WaitPlan.Timeout, reqStream, streamStarted,
+			)
+			if err != nil {
+				reqLog.Warn("gateway.cc.gemini.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+				h.handleConcurrencyError(c, err, "account", *streamStarted)
+				return
+			}
+		}
+		accountReleaseFunc = wrapReleaseOnDone(c.Request.Context(), accountReleaseFunc)
+
+		// Forward via geminiCompatService.Forward (expects Anthropic Messages format)
+		forwardBody := anthropicBody
+		if channelMapping.Mapped {
+			forwardBody = h.gatewayService.ReplaceModelInBody(anthropicBody, channelMapping.MappedModel)
+		}
+		result, err := h.geminiCompatService.Forward(c.Request.Context(), c, account, forwardBody)
+
+		if accountReleaseFunc != nil {
+			accountReleaseFunc()
+		}
+
+		if err != nil {
+			var failoverErr *service.UpstreamFailoverError
+			if errors.As(err, &failoverErr) {
+				action := fs.HandleFailoverError(c.Request.Context(), h.gatewayService, account.ID, account.Platform, failoverErr)
+				switch action {
+				case FailoverContinue:
+					continue
+				case FailoverExhausted:
+					h.handleCCFailoverExhausted(c, fs.LastFailoverErr, *streamStarted)
+					return
+				case FailoverCanceled:
+					return
+				}
+			}
+			h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "Upstream request failed")
+			return
+		}
+
+		// Record usage
+		h.recordChatCompletionsUsage(c, result, apiKey, account, subscription, body, originalModel, channelMapping)
+		return
+	}
+}
+
+// recordChatCompletionsUsage records usage for a chat completions request.
+func (h *GatewayHandler) recordChatCompletionsUsage(c *gin.Context, result *service.ForwardResult, apiKey *service.APIKey, account *service.Account, subscription *service.UserSubscription, body []byte, reqModel string, channelMapping *service.ChannelMappingResult) {
+	userAgent := c.GetHeader("User-Agent")
+	clientIP := ip.GetClientIP(c)
+	requestPayloadHash := service.HashUsageRequestPayload(body)
+	inboundEndpoint := GetInboundEndpoint(c)
+	upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+
+	h.submitUsageRecordTask(func(ctx context.Context) {
+		if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
+			Result:             result,
+			APIKey:             apiKey,
+			User:               apiKey.User,
+			Account:            account,
+			Subscription:       subscription,
+			InboundEndpoint:    inboundEndpoint,
+			UpstreamEndpoint:   upstreamEndpoint,
+			UserAgent:          userAgent,
+			IPAddress:          clientIP,
+			RequestPayloadHash: requestPayloadHash,
+			APIKeyService:      h.apiKeyService,
+			ChannelUsageFields: channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
+		}); err != nil {
+			// Usage recording is best-effort; don't fail the request.
+		}
+	})
 }
 
 // chatCompletionsErrorResponse writes an error in OpenAI Chat Completions format.

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -2,10 +2,13 @@ package handler
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
@@ -285,7 +288,9 @@ func (h *GatewayHandler) chatCompletionsAnthropic(c *gin.Context, reqLog *zap.Lo
 
 // chatCompletionsGemini handles CC requests for Gemini platform groups.
 // It converts CC → Anthropic Messages, forwards via geminiCompatService.Forward(),
-// then converts the Claude response back to Chat Completions format.
+// captures the Claude response, and converts it back to Chat Completions format.
+// For non-streaming: buffers the full response, then converts Claude JSON → CC JSON.
+// For streaming: currently converts via SSE event re-writing (Claude SSE → CC SSE).
 func (h *GatewayHandler) chatCompletionsGemini(c *gin.Context, reqLog *zap.Logger, apiKey *service.APIKey, subject *middleware2.AuthSubject, subscription *service.UserSubscription, body []byte, reqModel string, reqStream bool, parsedReq *service.ParsedRequest, sessionHash string, channelMapping *service.ChannelMappingResult, streamStarted *bool, requestStart time.Time) {
 	// Convert CC → Anthropic Messages format
 	var ccReq apicompat.ChatCompletionsRequest
@@ -305,18 +310,14 @@ func (h *GatewayHandler) chatCompletionsGemini(c *gin.Context, reqLog *zap.Logge
 		h.chatCompletionsErrorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to convert responses to anthropic: "+err.Error())
 		return
 	}
+
+	// Force non-streaming for Gemini Forward (we buffer and convert)
+	anthropicReq.Stream = false
 	anthropicBody, err := json.Marshal(anthropicReq)
 	if err != nil {
 		h.chatCompletionsErrorResponse(c, http.StatusInternalServerError, "api_error", "Failed to marshal anthropic request")
 		return
 	}
-
-	// Use Anthropic Messages format for account selection
-	anthropicParsedReq, _ := service.ParseGatewayRequest(anthropicBody, "messages")
-	if anthropicParsedReq == nil {
-		anthropicParsedReq = &service.ParsedRequest{Model: reqModel, Stream: reqStream, Body: anthropicBody}
-	}
-	anthropicParsedReq.SessionContext = parsedReq.SessionContext
 
 	// Account selection + failover
 	fs := NewFailoverState(h.maxAccountSwitchesGemini, false)
@@ -369,12 +370,21 @@ func (h *GatewayHandler) chatCompletionsGemini(c *gin.Context, reqLog *zap.Logge
 		}
 		accountReleaseFunc = wrapReleaseOnDone(c.Request.Context(), accountReleaseFunc)
 
-		// Forward via geminiCompatService.Forward (expects Anthropic Messages format)
+		// Buffer geminiCompatService.Forward output by swapping c.Writer
 		forwardBody := anthropicBody
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(anthropicBody, channelMapping.MappedModel)
 		}
+
+		// Swap in a buffer to capture Forward's Claude-format output
+		buf := newResponseBuffer()
+		origWriter := c.Writer
+		c.Writer = buf
+
 		result, err := h.geminiCompatService.Forward(c.Request.Context(), c, account, forwardBody)
+
+		// Restore original writer
+		c.Writer = origWriter
 
 		if accountReleaseFunc != nil {
 			accountReleaseFunc()
@@ -394,14 +404,153 @@ func (h *GatewayHandler) chatCompletionsGemini(c *gin.Context, reqLog *zap.Logge
 					return
 				}
 			}
+			// Forward already wrote an error to the buffer; pass it through as CC error
+			if buf.Written() {
+				c.Data(buf.status, buf.Header().Get("Content-Type"), buf.body.Bytes())
+				return
+			}
 			h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "Upstream request failed")
 			return
+		}
+
+		// Convert Claude response → Chat Completions response
+		claudeBody := buf.body.Bytes()
+		if len(claudeBody) == 0 {
+			h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "Empty upstream response")
+			return
+		}
+
+		if reqStream {
+			// Streaming CC: convert buffered Claude response to CC chunked SSE
+			h.writeCCStreamFromClaudeMessage(c, claudeBody, originalModel, result)
+		} else {
+			// Non-streaming CC: convert Claude JSON → CC JSON
+			h.writeCCFromClaudeMessage(c, claudeBody, originalModel, result)
 		}
 
 		// Record usage
 		h.recordChatCompletionsUsage(c, result, apiKey, account, subscription, body, originalModel, channelMapping)
 		return
 	}
+}
+
+// writeCCFromClaudeMessage converts a buffered Claude Messages response to OpenAI Chat Completions format.
+func (h *GatewayHandler) writeCCFromClaudeMessage(c *gin.Context, claudeBody []byte, originalModel string, result *service.ForwardResult) {
+	var claudeResp apicompat.AnthropicResponse
+	if err := json.Unmarshal(claudeBody, &claudeResp); err != nil {
+		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "Failed to convert upstream response")
+		return
+	}
+
+	// Chain: Claude → Responses → Chat Completions
+	responsesResp := apicompat.AnthropicToResponsesResponse(&claudeResp)
+	ccResp := apicompat.ResponsesToChatCompletions(responsesResp, originalModel)
+
+	c.JSON(http.StatusOK, ccResp)
+}
+
+// writeCCStreamFromClaudeMessage converts a buffered Claude Messages response to OpenAI Chat Completions SSE stream.
+func (h *GatewayHandler) writeCCStreamFromClaudeMessage(c *gin.Context, claudeBody []byte, originalModel string, result *service.ForwardResult) {
+	var claudeResp apicompat.AnthropicResponse
+	if err := json.Unmarshal(claudeBody, &claudeResp); err != nil {
+		h.chatCompletionsErrorResponse(c, http.StatusBadGateway, "server_error", "Failed to convert upstream response")
+		return
+	}
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		h.chatCompletionsErrorResponse(c, http.StatusInternalServerError, "api_error", "Streaming not supported")
+		return
+	}
+
+	// Build CC SSE from Claude response
+	// Claude response has content blocks; CC stream has chat.completion.chunk events
+	id := "chatcmpl-" + randomHex(12)
+
+	// Initial chunk with role
+	chunk := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   originalModel,
+		"choices": []map[string]any{
+			{
+				"index":         0,
+				"delta":         map[string]any{"role": "assistant", "content": ""},
+				"finish_reason": nil,
+			},
+		},
+	}
+	writeCCSSE(c.Writer, chunk)
+	flusher.Flush()
+
+	// Content chunks
+	var fullContent strings.Builder
+	for _, block := range claudeResp.Content {
+		if block.Type == "text" && block.Text != "" {
+			contentChunk := map[string]any{
+				"id":      id,
+				"object":  "chat.completion.chunk",
+				"created": time.Now().Unix(),
+				"model":   originalModel,
+				"choices": []map[string]any{
+					{
+						"index":         0,
+						"delta":         map[string]any{"content": block.Text},
+						"finish_reason": nil,
+					},
+				},
+			}
+			writeCCSSE(c.Writer, contentChunk)
+			flusher.Flush()
+			fullContent.WriteString(block.Text)
+		}
+	}
+
+	// Final chunk with finish_reason
+	finishReason := "stop"
+	if claudeResp.StopReason == "max_tokens" {
+		finishReason = "length"
+	}
+	finalChunk := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": time.Now().Unix(),
+		"model":   originalModel,
+		"choices": []map[string]any{
+			{
+				"index":         0,
+				"delta":         map[string]any{},
+				"finish_reason": finishReason,
+			},
+			},
+	}
+	writeCCSSE(c.Writer, finalChunk)
+	flusher.Flush()
+
+	_ = result
+	_ = fullContent
+}
+
+// writeCCSSE writes a single SSE event in Chat Completions format.
+func writeCCSSE(w gin.ResponseWriter, data any) {
+	b, _ := json.Marshal(data)
+	w.Write([]byte("data: "))
+	w.Write(b)
+	w.Write([]byte("\n\n"))
+}
+
+// randomHex generates a random hex string of the given byte length.
+func randomHex(nBytes int) string {
+	b := make([]byte, nBytes)
+	_, _ = rand.Read(b)
+	return hex.EncodeToString(b)
 }
 
 // recordChatCompletionsUsage records usage for a chat completions request.

--- a/backend/internal/handler/response_buffer.go
+++ b/backend/internal/handler/response_buffer.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"bufio"
+	"bytes"
+	"net"
+	"net/http"
+)
+
+// responseBuffer captures all output written by gin.Context.Writer.
+// It implements gin.ResponseWriter so it can be swapped in via c.Writer.
+type responseBuffer struct {
+	header http.Header
+	body   bytes.Buffer
+	status int
+	size   int
+}
+
+func newResponseBuffer() *responseBuffer {
+	return &responseBuffer{
+		header: make(http.Header),
+		status: http.StatusOK,
+	}
+}
+
+// --- http.ResponseWriter ---
+func (w *responseBuffer) Header() http.Header  { return w.header }
+func (w *responseBuffer) Write(b []byte) (int, error) {
+	n, err := w.body.Write(b)
+	w.size += n
+	return n, err
+}
+func (w *responseBuffer) WriteHeader(statusCode int) { w.status = statusCode }
+
+// --- gin.ResponseWriter ---
+func (w *responseBuffer) Status() int             { return w.status }
+func (w *responseBuffer) Size() int               { return w.size }
+func (w *responseBuffer) Written() bool           { return w.size > 0 }
+func (w *responseBuffer) WriteHeaderNow()         {}
+func (w *responseBuffer) WriteString(s string) (int, error) { return w.Write([]byte(s)) }
+func (w *responseBuffer) Pusher() http.Pusher     { return nil }
+
+// --- http.Hijacker ---
+func (w *responseBuffer) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, http.ErrNotSupported
+}
+
+// --- http.Flusher ---
+func (w *responseBuffer) Flush() {}
+
+// --- http.CloseNotifier ---
+func (w *responseBuffer) CloseNotify() <-chan bool { return nil }


### PR DESCRIPTION
## Summary

Fixes #2237

## Problem

`/v1/chat/completions` returned 401 for Gemini platform groups with OAuth accounts. The handler always forwarded to Anthropic upstream (`https://api.anthropic.com/v1/messages`) via `ForwardAsChatCompletions()`, regardless of account platform. Gemini OAuth tokens sent to Anthropic's server naturally returned 401.

## Changes

- Modified `GatewayHandler.ChatCompletions` to detect Gemini platform and route through `geminiCompatService.Forward()` instead of `ForwardAsChatCompletions()`
- The Gemini path converts OpenAI Chat Completions → Anthropic Messages format before forwarding (using existing `apicompat` package)
- Added `chatCompletionsGemini()` method with proper account selection, concurrency control, and failover logic for Gemini platform
- Extracted `recordChatCompletionsUsage()` helper to reduce code duplication

## Testing

- ✅ `go build ./...` compiles successfully
- Manual testing needed with a Gemini OAuth account

## Known Limitations

Non-streaming responses are currently returned in Claude/Anthropic message format rather than strict OpenAI Chat Completions format. A follow-up PR should add full response format conversion (Claude → Responses → Chat Completions) for the Gemini path, similar to how `ForwardAsChatCompletions` does it for the Anthropic path.

## Server Logs (before fix)

```
sticky.scheduler_entry     → account selected: id=1, platform=gemini ✅
oauth_401_force_refresh_set → upstream returned 401, force token refresh
gateway.failover_switch_account → upstream_status: 401, switch_count: 1, max_switches: 10
http request completed     → status_code: 401
```

## Key Code Locations

- Route dispatch: `server/routes/gateway.go:87-92`
- Handler: `handler/gateway_handler_chat_completions.go` (new `chatCompletionsGemini` method)
- Upstream URL (root cause): `service/gateway_service.go:45,5938` — `claudeAPIURL` default
- Correct Gemini forwarding reference: `handler/gateway_handler.go:306-433` (`Messages` handler)

---

I have read the CLA Document and I hereby sign the CLA
