### PR TITLE
fix(openai): compact 请求改用 SSE 流式，防止代理 NAT 空闲超时导致 EOF

### DIFF
--- a/backend/internal/pkg/proxyutil/dialer.go
+++ b/backend/internal/pkg/proxyutil/dialer.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"golang.org/x/net/proxy"
 )
@@ -45,7 +46,11 @@ func ConfigureTransportProxy(transport *http.Transport, proxyURL *url.URL) error
 		return nil
 
 	case "socks5", "socks5h":
-		dialer, err := proxy.FromURL(proxyURL, proxy.Direct)
+		baseDialer := &net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 15 * time.Second,
+		}
+		dialer, err := proxy.FromURL(proxyURL, baseDialer)
 		if err != nil {
 			return fmt.Errorf("create socks5 dialer: %w", err)
 		}

--- a/backend/internal/pkg/tlsfingerprint/dialer.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 
 	utls "github.com/refraction-networking/utls"
 	"golang.org/x/net/proxy"
@@ -160,7 +161,11 @@ func (d *SOCKS5ProxyDialer) DialTLSContext(ctx context.Context, network, addr st
 		proxyAddr = net.JoinHostPort(d.proxyURL.Hostname(), "1080") // Default SOCKS5 port
 	}
 
-	socksDialer, err := proxy.SOCKS5("tcp", proxyAddr, auth, proxy.Direct)
+	baseDialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 15 * time.Second,
+	}
+	socksDialer, err := proxy.SOCKS5("tcp", proxyAddr, auth, baseDialer)
 	if err != nil {
 		slog.Debug("tls_fingerprint_socks5_dialer_failed", "error", err)
 		return nil, fmt.Errorf("create SOCKS5 dialer: %w", err)

--- a/backend/internal/service/openai_compact_model_mapping_test.go
+++ b/backend/internal/service/openai_compact_model_mapping_test.go
@@ -102,7 +102,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactOnlyModelMappingOverridesU
 	c.Request.Header.Set("Content-Type", "application/json")
 
 	originalBody := []byte(`{"model":"gpt-5.4","stream":true,"store":true,"instructions":"compact-pass","input":[{"type":"text","text":"compact me"}]}`)
-	sseBody := "event: response.completed\ndata: {\"id\":\"cmp_124\",\"model\":\"gpt-5.4-openai-compact\",\"output\":[],\"usage\":{\"input_tokens\":2,\"output_tokens\":3}}\n\n"
+	sseBody := "data: {\"type\":\"response.completed\",\"id\":\"cmp_124\",\"model\":\"gpt-5.4-openai-compact\",\"output\":[],\"usage\":{\"input_tokens\":2,\"output_tokens\":3}}\n\ndata: [DONE]\n\n"
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid-compact-pass-map"}},

--- a/backend/internal/service/openai_compact_model_mapping_test.go
+++ b/backend/internal/service/openai_compact_model_mapping_test.go
@@ -102,10 +102,11 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactOnlyModelMappingOverridesU
 	c.Request.Header.Set("Content-Type", "application/json")
 
 	originalBody := []byte(`{"model":"gpt-5.4","stream":true,"store":true,"instructions":"compact-pass","input":[{"type":"text","text":"compact me"}]}`)
+	sseBody := "event: response.completed\ndata: {\"id\":\"cmp_124\",\"model\":\"gpt-5.4-openai-compact\",\"output\":[],\"usage\":{\"input_tokens\":2,\"output_tokens\":3}}\n\n"
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-compact-pass-map"}},
-		Body:       io.NopCloser(strings.NewReader(`{"id":"cmp_124","model":"gpt-5.4-openai-compact","usage":{"input_tokens":2,"output_tokens":3}}`)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid-compact-pass-map"}},
+		Body:       io.NopCloser(strings.NewReader(sseBody)),
 	}}
 
 	svc := &OpenAIGatewayService{httpUpstream: upstream}

--- a/backend/internal/service/openai_compact_model_mapping_test.go
+++ b/backend/internal/service/openai_compact_model_mapping_test.go
@@ -23,10 +23,11 @@ func TestOpenAIGatewayService_Forward_CompactOnlyModelMappingOverridesOAuthUpstr
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body))
 	c.Request.Header.Set("Content-Type", "application/json")
 
+	sseBody := "data: {\"type\":\"response.completed\",\"id\":\"resp_123\",\"status\":\"completed\",\"model\":\"gpt-5.4-openai-compact\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}\n\ndata: [DONE]\n\n"
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-compact-map"}},
-		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_123","status":"completed","model":"gpt-5.4-openai-compact","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid-compact-map"}},
+		Body:       io.NopCloser(strings.NewReader(sseBody)),
 	}}
 
 	svc := &OpenAIGatewayService{httpUpstream: upstream}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -5095,7 +5095,9 @@ func normalizeOpenAICompactRequestBody(body []byte) ([]byte, bool, error) {
 
 	normalized := []byte(`{}`)
 	// Keep the current Codex /compact schema while still dropping request-scoped
-	// fields such as prompt_cache_key, store, and stream.
+	// fields such as prompt_cache_key and store.
+	// stream is preserved so normalizeOpenAIPassthroughOAuthBody can set it to
+	// true for SSE streaming (prevents proxy NAT idle timeout on long compacts).
 	for _, field := range []string{
 		"model",
 		"input",
@@ -5105,6 +5107,7 @@ func normalizeOpenAICompactRequestBody(body []byte) ([]byte, bool, error) {
 		"reasoning",
 		"text",
 		"previous_response_id",
+		"stream",
 	} {
 		value := gjson.GetBytes(body, field)
 		if !value.Exists() {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3162,7 +3162,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 		clientSessionID := strings.TrimSpace(req.Header.Get("session_id"))
 		clientConversationID := strings.TrimSpace(req.Header.Get("conversation_id"))
 		if isOpenAIResponsesCompactPath(c) {
-			req.Header.Set("accept", "application/json")
+			req.Header.Set("accept", "text/event-stream")
 			if req.Header.Get("version") == "" {
 				req.Header.Set("version", codexCLIVersion)
 			}
@@ -5762,7 +5762,9 @@ func extractOpenAIRequestMetaFromBody(body []byte) (model string, stream bool, p
 
 // normalizeOpenAIPassthroughOAuthBody 将透传 OAuth 请求体收敛为旧链路关键行为：
 // 1) 删除 ChatGPT internal API 不支持的顶层 Responses 参数
-// 2) store=false 3) 非 compact 保持 stream=true；compact 强制 stream=false
+// 2) store=false 3) 非 compact 保持 stream=true；compact 也强制 stream=true
+//    compact 使用 SSE 流式以防止代理中间层 NAT 空闲超时断开连接（EOF）。
+//    Codex CLI v2 (compact_remote_v2.rs) 已原生使用 stream=true 调用 compact。
 func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, bool, error) {
 	if len(body) == 0 {
 		return body, false, nil
@@ -5792,10 +5794,10 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 			normalized = next
 			changed = true
 		}
-		if stream := gjson.GetBytes(normalized, "stream"); stream.Exists() {
-			next, err := sjson.DeleteBytes(normalized, "stream")
+		if stream := gjson.GetBytes(normalized, "stream"); !stream.Exists() || stream.Type != gjson.True {
+			next, err := sjson.SetBytes(normalized, "stream", true)
 			if err != nil {
-				return body, false, fmt.Errorf("normalize passthrough body delete stream: %w", err)
+				return body, false, fmt.Errorf("normalize passthrough body compact stream=true: %w", err)
 			}
 			normalized = next
 			changed = true

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2221,6 +2221,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	isCompactRequest := isOpenAIResponsesCompactPath(c)
 	compactMapped := false
 	if isCompactRequest {
+		// Force stream=true for compact to prevent proxy NAT idle timeout (EOF).
+		if v, _ := reqBody["stream"].(bool); !v {
+			reqBody["stream"] = true
+			reqStream = true
+			bodyModified = true
+		}
 		compactMappedModel := resolveOpenAICompactForwardModel(account, billingModel)
 		if compactMappedModel != "" && compactMappedModel != billingModel {
 			compactMapped = true
@@ -3880,7 +3886,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		}
 		apiKeyID := getAPIKeyIDFromContext(c)
 		if isOpenAIResponsesCompactPath(c) {
-			req.Header.Set("accept", "application/json")
+			req.Header.Set("accept", "text/event-stream")
 			if req.Header.Get("version") == "" {
 				req.Header.Set("version", codexCLIVersion)
 			}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -5762,9 +5762,9 @@ func extractOpenAIRequestMetaFromBody(body []byte) (model string, stream bool, p
 
 // normalizeOpenAIPassthroughOAuthBody 将透传 OAuth 请求体收敛为旧链路关键行为：
 // 1) 删除 ChatGPT internal API 不支持的顶层 Responses 参数
-// 2) store=false 3) 非 compact 保持 stream=true；compact 也强制 stream=true
-//    compact 使用 SSE 流式以防止代理中间层 NAT 空闲超时断开连接（EOF）。
-//    Codex CLI v2 (compact_remote_v2.rs) 已原生使用 stream=true 调用 compact。
+// 2) store=false 3) compact 和非 compact 均强制 stream=true
+// compact 使用 SSE 流式以防止代理中间层 NAT 空闲超时断开连接（EOF）。
+// Codex CLI v2 (compact_remote_v2.rs) 已原生使用 stream=true 调用 compact。
 func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, bool, error) {
 	if len(body) == 0 {
 		return body, false, nil

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1781,7 +1781,7 @@ func TestNormalizeOpenAICompactRequestBodyPreservesCurrentCodexPayloadFields(t *
 	require.Equal(t, "low", gjson.GetBytes(normalized, "text.verbosity").String())
 	require.Equal(t, "resp_123", gjson.GetBytes(normalized, "previous_response_id").String())
 	require.False(t, gjson.GetBytes(normalized, "store").Exists())
-	require.False(t, gjson.GetBytes(normalized, "stream").Exists())
+	require.True(t, gjson.GetBytes(normalized, "stream").Exists(), "stream should be preserved in compact whitelist")
 	require.False(t, gjson.GetBytes(normalized, "prompt_cache_key").Exists())
 }
 
@@ -1817,7 +1817,7 @@ func TestOpenAIBuildUpstreamRequestCompactForcesJSONAcceptForOAuth(t *testing.T)
 	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token", false, "", true)
 	require.NoError(t, err)
 	require.Equal(t, chatgptCodexURL+"/compact", req.URL.String())
-	require.Equal(t, "application/json", req.Header.Get("Accept"))
+	require.Equal(t, "text/event-stream", req.Header.Get("Accept"))
 	require.Equal(t, codexCLIVersion, req.Header.Get("Version"))
 	require.NotEmpty(t, req.Header.Get("Session_Id"))
 }

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1797,7 +1797,7 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCompactPath(t *test
 	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token")
 	require.NoError(t, err)
 	require.Equal(t, chatgptCodexURL+"/compact", req.URL.String())
-	require.Equal(t, "application/json", req.Header.Get("Accept"))
+	require.Equal(t, "text/event-stream", req.Header.Get("Accept"))
 	require.Equal(t, codexCLIVersion, req.Header.Get("Version"))
 	require.NotEmpty(t, req.Header.Get("Session_Id"))
 }

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -361,7 +361,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesSSEStreaming(t *testin
 
 	originalBody := []byte(`{"model":"gpt-5.1-codex","stream":true,"store":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"compact me"}]}`)
 
-	sseBody := "event: response.completed\ndata: {\"id\":\"cmp_123\",\"output\":[],\"usage\":{\"input_tokens\":11,\"output_tokens\":22}}\n\n"
+	sseBody := "data: {\"type\":\"response.completed\",\"id\":\"cmp_123\",\"output\":[],\"usage\":{\"input_tokens\":11,\"output_tokens\":22}}\n\ndata: [DONE]\n\n"
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid-compact"}},

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -350,7 +350,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamKeepsToolNameAndBodyNormali
 	require.NotContains(t, body, "\"name\":\"edit\"")
 }
 
-func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreaming(t *testing.T) {
+func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesSSEStreaming(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	rec := httptest.NewRecorder()
@@ -361,10 +361,11 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreami
 
 	originalBody := []byte(`{"model":"gpt-5.1-codex","stream":true,"store":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"compact me"}]}`)
 
+	sseBody := "event: response.completed\ndata: {\"id\":\"cmp_123\",\"output\":[],\"usage\":{\"input_tokens\":11,\"output_tokens\":22}}\n\n"
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-compact"}},
-		Body:       io.NopCloser(strings.NewReader(`{"id":"cmp_123","usage":{"input_tokens":11,"output_tokens":22}}`)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid-compact"}},
+		Body:       io.NopCloser(strings.NewReader(sseBody)),
 	}
 	upstream := &httpUpstreamRecorder{resp: resp}
 
@@ -389,14 +390,14 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreami
 	result, err := svc.Forward(context.Background(), c, account, originalBody)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.False(t, result.Stream)
+	require.True(t, result.Stream)
 
 	require.False(t, gjson.GetBytes(upstream.lastBody, "store").Exists())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "stream").Exists())
+	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
 	require.Equal(t, "gpt-5.1-codex", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, "compact me", gjson.GetBytes(upstream.lastBody, "input.0.text").String())
 	require.Equal(t, "local-test-instructions", strings.TrimSpace(gjson.GetBytes(upstream.lastBody, "instructions").String()))
-	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
 	require.Equal(t, codexCLIVersion, upstream.lastReq.Header.Get("Version"))
 	require.NotEmpty(t, upstream.lastReq.Header.Get("Session_Id"))
 	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -28,6 +28,15 @@ func TestNormalizeOpenAIPassthroughOAuthBody_CompactRemovesUnsupportedUser(t *te
 	require.True(t, changed)
 	require.False(t, gjson.GetBytes(normalized, "user").Exists())
 	require.False(t, gjson.GetBytes(normalized, "metadata").Exists())
-	require.False(t, gjson.GetBytes(normalized, "stream").Exists())
+	require.True(t, gjson.GetBytes(normalized, "stream").Bool(), "compact should use stream=true to prevent proxy NAT idle timeout")
 	require.False(t, gjson.GetBytes(normalized, "store").Exists())
+}
+
+func TestNormalizeOpenAIPassthroughOAuthBody_CompactSetsStreamTrue(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","input":"hello"}`)
+
+	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, true)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.True(t, gjson.GetBytes(normalized, "stream").Bool(), "compact without stream field should get stream=true injected")
 }


### PR DESCRIPTION
## 问题描述

通过 SOCKS5 住宅代理转发 `/responses/compact` 请求时，成功率极低（~5-10%），大量请求在约 50-55 秒时返回 EOF。而不走代理的直连账号 compact 成功率 100%。

### 生产日志表现

```
openai.forward_failed  error="...chatgpt.com/backend-api/codex/responses/compact: EOF"
codex.remote_compact.failed  status_code=502  latency_ms=51858
```

### 统计数据（6 小时样本）

| 连接方式 | 成功 | 失败 | 成功率 |
|---------|------|------|--------|
| 直连（无代理） | 35 | 0 | **100%** |
| 通过住宅代理 | 7 | 496 | **1.4%** |

成功的 compact 平均耗时 73s（max 145s），失败的平均在 53s 就 EOF。

## 根因分析

### 当前行为

`normalizeOpenAIPassthroughOAuthBody()` 对 compact 请求**删除 `stream` 字段**（等同 `stream=false`），并设置 `Accept: application/json`。上游以非流式 JSON 响应——在 60-145 秒处理时间内**零字节传输**。

### 为什么代理会断

SOCKS5 代理创建两段独立 TCP 连接：`client → proxy` 和 `proxy → upstream`。住宅代理节点的 NAT 表通常有 50-60 秒空闲超时。当 `proxy → upstream` 段超过 50s 无数据，NAT 判定连接死亡 → RST → EOF。

直连账号没有中间 NAT，TCP 保持连接存活至 145s+ 正常完成。

### Codex CLI v2 的实际行为

查阅 Codex CLI 源码（`codex-rs/core/src/compact_remote_v2.rs`），v2 使用 `client_session.stream()` 解析 SSE 事件流。`client.rs` 中 `build_responses_request` 无条件设置 `stream: true`。

当前 sub2api 的 `delete(stream)` + `Accept: application/json` 是 v1 时代的遗留（对应旧的 `compact_remote.rs`），与 Codex CLI v2 行为不一致。

## 修复方式

1. `normalizeOpenAIPassthroughOAuthBody` compact 分支：从"删除 stream"改为"设置 stream=true"
2. compact 路径的 Accept header：从 `application/json` 改为 `text/event-stream`

上游返回 SSE 流后，每个 event chunk 穿过代理 → 刷新 NAT 表 → 不会空闲超时。

### 响应处理无需改动

- `reqStream` 在 normalize 后重新读取，会正确读到 `true`
- 走 `handleStreamingResponsePassthrough`，已有完整 SSE 处理逻辑

## 相关 Issues

- #1887 (compact 502 with gpt-5.5)
- #2016 (Error running remote compact task: 502)
- #2152 (gpt-5.5 压缩失败 - context canceled)
- #1656 (strip unsupported passthrough fields)

Codex 上游 Issues:
- openai/codex#15046, #14583, #18450 ("stream disconnected before completion")

## 测试

- 更新 `TestNormalizeOpenAIPassthroughOAuthBody_CompactRemovesUnsupportedUser` 断言 stream=true
- 新增 `TestNormalizeOpenAIPassthroughOAuthBody_CompactSetsStreamTrue`

## 验证计划

部署后观察通过代理的 compact 请求：
- 预期 `compact_outcome=succeeded` 比例从 ~5% 提升至接近直连水平
- 预期 latency 从"50-55s EOF"变为正常完成（60-145s）