### PR TITLE
fix(admin/settings): 修复标签栏溢出时背景色未覆盖「数据备份」

### DIFF
--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -8918,12 +8918,6 @@ watch(
     0 1px 2px rgb(0 0 0 / 0.02);
 }
 
-@media (min-width: 640px) {
-  .settings-tabs {
-    @apply flex;
-  }
-}
-
 .settings-tab {
   @apply relative flex flex-1 items-center justify-center gap-1.5
          whitespace-nowrap rounded-xl px-2.5 py-2


### PR DESCRIPTION
## 问题

`/admin/settings` 页面 settings-tabs 标签栏中，最后一个标签「数据备份」缺失背景色——`bg-white/80` 的圆角胶囊背景在它身上断掉了。

## 复现

1. 在中等宽度视窗（约 1024–1280px，例如带侧栏的笔记本屏幕）打开 `/admin/settings`
2. 查看标签栏最右侧的「数据备份」
3. 它会落在容器背景色之外（不论是否选中）

## 根因

`frontend/src/views/admin/SettingsView.vue` 中样式定义如下：

```css
.settings-tabs {
  @apply inline-flex min-w-full gap-0.5 rounded-2xl
         border border-gray-100 bg-white/80 p-1 backdrop-blur-sm
         dark:border-dark-700/50 dark:bg-dark-800/80;
  ...
}

@media (min-width: 640px) {
  .settings-tabs {
    @apply flex;
  }
}
```

主规则是 `inline-flex min-w-full`，但 ≥640px 时被覆盖成 `flex`。两者关键差别：

- `inline-flex`：inline 级别，宽度跟随内容；`min-width: 100%` 保证至少撑满父容器，内容更宽时容器一起撑大。
- `flex`：block 级别，宽度默认等于父容器（即 100%），不会随内容增长。

`#e872cba`（feat: 添加登录注册条款确认）新增 `agreement` 后，标签数量从 8 变为 9。在中等宽度视窗下，9 个 `whitespace-nowrap` + `flex-1` 的标签 min-content 总和会超过容器 100% 宽度——但因为媒体查询把容器锁在 `flex`（block 级），容器宽度仍是 100%，子项溢出到容器外。`bg-white/80` 只画在容器实际宽度内，溢出部分（最后的「数据备份」）落在背景色之外。

父级 `.settings-tabs-scroll` 是 `overflow-x-auto`，所以溢出可滚动看到，但底色丢失的问题就此暴露。

## 修复

删除 ≥640px 的媒体查询。主规则 `inline-flex min-w-full` 已经能正确处理两种情形：

- 内容塞得下：`min-width: 100%` 让容器至少 100% 宽，子项 `flex-1` 平均分配 — 与之前视觉完全一致。
- 内容溢出：`inline-flex` 让容器随内容撑大，背景覆盖到所有子项 — 修好。

```diff
- @media (min-width: 640px) {
-   .settings-tabs {
-     @apply flex;
-   }
- }
```

## 影响面

- `.settings-tabs` class 仅在 `SettingsView.vue` 使用一处（`<nav class="settings-tabs">`），样式定义也只在本文件，无其他引用。
- 父容器只包含这一个 `<nav>`，没有 inline 兄弟元素，`inline-flex` 不会引入空白或基线问题。

## 测试

- 中等宽度视窗：标签栏整体一个胶囊形圆角背景，「数据备份」落在背景色内（修复前在背景色外）。
- 宽屏：所有标签等宽分布，视觉无变化。
- 窄屏（移动端）：行为不变，仍可横向滚动。