### PR TITLE
fix(openai): avoid long Codex burst cooldown

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1369,6 +1369,12 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 	selected, compactBlocked := s.selectBestAccount(ctx, groupID, accounts, requestedModel, excludedIDs, requireCompact)
 
 	if selected == nil {
+		if recovered := s.tryRecoverOpenAIRateLimitedAccountForProbe(ctx, groupID, requestedModel, excludedIDs, requireCompact); recovered != nil {
+			if sessionHash != "" {
+				_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, recovered.ID, openaiStickySessionTTL)
+			}
+			return recovered, nil
+		}
 		return nil, noAvailableOpenAISelectionError(requestedModel, compactBlocked)
 	}
 
@@ -1593,6 +1599,21 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		return nil, err
 	}
 	if len(accounts) == 0 {
+		if recovered := s.tryRecoverOpenAIRateLimitedAccountForProbe(ctx, groupID, requestedModel, excludedIDs, requireCompact); recovered != nil {
+			result, err := s.tryAcquireAccountSlot(ctx, recovered.ID, recovered.Concurrency)
+			if err == nil && result.Acquired {
+				if sessionHash != "" {
+					_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, recovered.ID, openaiStickySessionTTL)
+				}
+				return newOpenAISelectionResult(recovered, true, result.ReleaseFunc, nil), nil
+			}
+			return newOpenAISelectionResult(recovered, false, nil, &AccountWaitPlan{
+				AccountID:      recovered.ID,
+				MaxConcurrency: recovered.Concurrency,
+				Timeout:        cfg.FallbackWaitTimeout,
+				MaxWaiting:     cfg.FallbackMaxWaiting,
+			}), nil
+		}
 		return nil, ErrNoAvailableAccounts
 	}
 
@@ -1667,6 +1688,21 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	}
 
 	if len(candidates) == 0 {
+		if recovered := s.tryRecoverOpenAIRateLimitedAccountForProbe(ctx, groupID, requestedModel, excludedIDs, requireCompact); recovered != nil {
+			result, err := s.tryAcquireAccountSlot(ctx, recovered.ID, recovered.Concurrency)
+			if err == nil && result.Acquired {
+				if sessionHash != "" {
+					_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, recovered.ID, openaiStickySessionTTL)
+				}
+				return newOpenAISelectionResult(recovered, true, result.ReleaseFunc, nil), nil
+			}
+			return newOpenAISelectionResult(recovered, false, nil, &AccountWaitPlan{
+				AccountID:      recovered.ID,
+				MaxConcurrency: recovered.Concurrency,
+				Timeout:        cfg.FallbackWaitTimeout,
+				MaxWaiting:     cfg.FallbackMaxWaiting,
+			}), nil
+		}
 		return nil, ErrNoAvailableAccounts
 	}
 
@@ -1812,7 +1848,155 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	if requireCompact && baseCandidateCount > 0 {
 		return nil, ErrNoAvailableCompactAccounts
 	}
+	if recovered := s.tryRecoverOpenAIRateLimitedAccountForProbe(ctx, groupID, requestedModel, excludedIDs, requireCompact); recovered != nil {
+		result, err := s.tryAcquireAccountSlot(ctx, recovered.ID, recovered.Concurrency)
+		if err == nil && result.Acquired {
+			if sessionHash != "" {
+				_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, recovered.ID, openaiStickySessionTTL)
+			}
+			return newOpenAISelectionResult(recovered, true, result.ReleaseFunc, nil), nil
+		}
+		return newOpenAISelectionResult(recovered, false, nil, &AccountWaitPlan{
+			AccountID:      recovered.ID,
+			MaxConcurrency: recovered.Concurrency,
+			Timeout:        cfg.FallbackWaitTimeout,
+			MaxWaiting:     cfg.FallbackMaxWaiting,
+		}), nil
+	}
 	return nil, ErrNoAvailableAccounts
+}
+
+func (s *OpenAIGatewayService) tryRecoverOpenAIRateLimitedAccountForProbe(ctx context.Context, groupID *int64, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool) *Account {
+	if s == nil || s.accountRepo == nil || s.rateLimitService == nil {
+		return nil
+	}
+
+	accounts, err := s.listActiveOpenAIAccountsForRateLimitProbe(ctx, groupID)
+	if err != nil {
+		slog.Warn("openai_rate_limit_probe_list_failed", "group_id", derefGroupID(groupID), "error", err)
+		return nil
+	}
+
+	var candidate *Account
+	for i := range accounts {
+		acc := &accounts[i]
+		if _, excluded := excludedIDs[acc.ID]; excluded {
+			continue
+		}
+		if !isOpenAIAccountProbeRecoveryCandidate(acc, requestedModel, requireCompact) {
+			continue
+		}
+		if groupID != nil && s.needsUpstreamChannelRestrictionCheck(ctx, groupID) &&
+			s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
+			continue
+		}
+		if candidate == nil || openAIRateLimitProbeCandidateLess(acc, candidate) {
+			candidate = acc
+		}
+	}
+	if candidate == nil {
+		return nil
+	}
+
+	if err := s.rateLimitService.ClearRateLimit(ctx, candidate.ID); err != nil {
+		slog.Warn("openai_rate_limit_probe_clear_failed", "account_id", candidate.ID, "error", err)
+		return nil
+	}
+
+	recovered, err := s.accountRepo.GetByID(ctx, candidate.ID)
+	if err != nil || recovered == nil {
+		slog.Warn("openai_rate_limit_probe_get_recovered_failed", "account_id", candidate.ID, "error", err)
+		return nil
+	}
+	if !isOpenAIAccountEligibleForRequest(recovered, requestedModel, requireCompact) {
+		return nil
+	}
+	slog.Info("openai_rate_limit_probe_account_recovered", "account_id", recovered.ID, "group_id", derefGroupID(groupID))
+	return recovered
+}
+
+func (s *OpenAIGatewayService) listActiveOpenAIAccountsForRateLimitProbe(ctx context.Context, groupID *int64) ([]Account, error) {
+	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		return s.accountRepo.ListByPlatform(ctx, PlatformOpenAI)
+	}
+	if groupID != nil {
+		accounts, err := s.accountRepo.ListByGroup(ctx, *groupID)
+		if err != nil {
+			return nil, err
+		}
+		filtered := accounts[:0]
+		for _, acc := range accounts {
+			if acc.Platform == PlatformOpenAI {
+				filtered = append(filtered, acc)
+			}
+		}
+		return filtered, nil
+	}
+	accounts, err := s.accountRepo.ListByPlatform(ctx, PlatformOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	filtered := accounts[:0]
+	for _, acc := range accounts {
+		if len(acc.AccountGroups) == 0 && len(acc.GroupIDs) == 0 {
+			filtered = append(filtered, acc)
+		}
+	}
+	return filtered, nil
+}
+
+func isOpenAIAccountProbeRecoveryCandidate(account *Account, requestedModel string, requireCompact bool) bool {
+	if account == nil || account.Platform != PlatformOpenAI || account.Status != StatusActive || !account.Schedulable {
+		return false
+	}
+	now := time.Now()
+	if account.AutoPauseOnExpired && account.ExpiresAt != nil && !now.Before(*account.ExpiresAt) {
+		return false
+	}
+	if account.IsAPIKeyOrBedrock() && account.IsQuotaExceeded() {
+		return false
+	}
+	if account.OverloadUntil != nil && now.Before(*account.OverloadUntil) {
+		return false
+	}
+	if account.TempUnschedulableUntil != nil && now.Before(*account.TempUnschedulableUntil) {
+		return false
+	}
+	if account.RateLimitResetAt == nil || !now.Before(*account.RateLimitResetAt) {
+		return false
+	}
+	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
+		return false
+	}
+	if requireCompact && openAICompactSupportTier(account) == 0 {
+		return false
+	}
+	if remaining := account.GetRateLimitRemainingTimeWithContext(context.Background(), requestedModel); remaining > 0 {
+		return false
+	}
+	return true
+}
+
+func openAIRateLimitProbeCandidateLess(candidate, current *Account) bool {
+	if candidate.RateLimitResetAt != nil && current.RateLimitResetAt != nil && !candidate.RateLimitResetAt.Equal(*current.RateLimitResetAt) {
+		return candidate.RateLimitResetAt.Before(*current.RateLimitResetAt)
+	}
+	if candidate.Priority != current.Priority {
+		return candidate.Priority < current.Priority
+	}
+	switch {
+	case candidate.LastUsedAt == nil && current.LastUsedAt != nil:
+		return true
+	case candidate.LastUsedAt != nil && current.LastUsedAt == nil:
+		return false
+	case candidate.LastUsedAt == nil && current.LastUsedAt == nil:
+		return candidate.ID < current.ID
+	default:
+		if !candidate.LastUsedAt.Equal(*current.LastUsedAt) {
+			return candidate.LastUsedAt.Before(*current.LastUsedAt)
+		}
+		return candidate.ID < current.ID
+	}
 }
 
 func (s *OpenAIGatewayService) listSchedulableAccounts(ctx context.Context, groupID *int64) ([]Account, error) {
@@ -1918,12 +2102,16 @@ func (s *OpenAIGatewayService) newSelectionResult(ctx context.Context, account *
 	if err != nil {
 		return nil, err
 	}
+	return newOpenAISelectionResult(hydrated, acquired, release, waitPlan), nil
+}
+
+func newOpenAISelectionResult(account *Account, acquired bool, release func(), waitPlan *AccountWaitPlan) *AccountSelectionResult {
 	return &AccountSelectionResult{
-		Account:     hydrated,
+		Account:     account,
 		Acquired:    acquired,
 		ReleaseFunc: release,
 		WaitPlan:    waitPlan,
-	}, nil
+	}
 }
 
 func (s *OpenAIGatewayService) schedulingConfig() config.GatewaySchedulingConfig {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -58,7 +58,7 @@ func (r stubOpenAIAccountRepo) GetByID(ctx context.Context, id int64) (*Account,
 func (r stubOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]Account, error) {
 	var result []Account
 	for _, acc := range r.accounts {
-		if acc.Platform == platform {
+		if acc.Platform == platform && acc.IsSchedulable() {
 			result = append(result, acc)
 		}
 	}
@@ -68,7 +68,7 @@ func (r stubOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.C
 func (r stubOpenAIAccountRepo) ListSchedulableByPlatform(ctx context.Context, platform string) ([]Account, error) {
 	var result []Account
 	for _, acc := range r.accounts {
-		if acc.Platform == platform {
+		if acc.Platform == platform && acc.IsSchedulable() {
 			result = append(result, acc)
 		}
 	}
@@ -77,6 +77,68 @@ func (r stubOpenAIAccountRepo) ListSchedulableByPlatform(ctx context.Context, pl
 
 func (r stubOpenAIAccountRepo) ListSchedulableUngroupedByPlatform(ctx context.Context, platform string) ([]Account, error) {
 	return r.ListSchedulableByPlatform(ctx, platform)
+}
+
+func (r stubOpenAIAccountRepo) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {
+	var result []Account
+	for _, acc := range r.accounts {
+		if acc.Status != StatusActive {
+			continue
+		}
+		matched := len(acc.AccountGroups) == 0 && len(acc.GroupIDs) == 0
+		for _, ag := range acc.AccountGroups {
+			if ag.GroupID == groupID {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			for _, gid := range acc.GroupIDs {
+				if gid == groupID {
+					matched = true
+					break
+				}
+			}
+		}
+		if matched {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
+}
+
+func (r stubOpenAIAccountRepo) ListByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	var result []Account
+	for _, acc := range r.accounts {
+		if acc.Platform == platform && acc.Status == StatusActive {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
+}
+
+func (r stubOpenAIAccountRepo) ClearRateLimit(ctx context.Context, id int64) error {
+	for i := range r.accounts {
+		if r.accounts[i].ID == id {
+			r.accounts[i].RateLimitedAt = nil
+			r.accounts[i].RateLimitResetAt = nil
+			r.accounts[i].OverloadUntil = nil
+			return nil
+		}
+	}
+	return errors.New("account not found")
+}
+
+func (r stubOpenAIAccountRepo) ClearAntigravityQuotaScopes(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (r stubOpenAIAccountRepo) ClearModelRateLimits(ctx context.Context, id int64) error {
+	return nil
+}
+
+func (r stubOpenAIAccountRepo) ClearTempUnschedulable(ctx context.Context, id int64) error {
+	return nil
 }
 
 type stubConcurrencyCache struct {
@@ -807,6 +869,35 @@ func TestOpenAISelectAccountForModelWithExclusions_NoAccounts(t *testing.T) {
 	}
 }
 
+func TestOpenAISelectAccountForModelWithExclusions_RecoversRateLimitedProbeAccount(t *testing.T) {
+	groupID := int64(42)
+	resetAt := time.Now().Add(30 * time.Minute)
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{ID: 9, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 1, RateLimitResetAt: &resetAt, AccountGroups: []AccountGroup{{GroupID: groupID}}},
+		},
+	}
+	cache := &stubGatewayCache{}
+	rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	svc := &OpenAIGatewayService{
+		accountRepo:      repo,
+		cache:            cache,
+		rateLimitService: rateLimitService,
+	}
+
+	acc, err := svc.SelectAccountForModelWithExclusions(context.Background(), &groupID, "recover-session", "gpt-4", nil)
+	if err != nil {
+		t.Fatalf("SelectAccountForModelWithExclusions error: %v", err)
+	}
+	if acc == nil || acc.ID != 9 {
+		t.Fatalf("expected recovered account 9, got %#v", acc)
+	}
+	if acc.RateLimitResetAt != nil {
+		t.Fatalf("expected rate limit to be cleared")
+	}
+}
+
 func TestOpenAISelectAccountWithLoadAwareness_NoCandidates(t *testing.T) {
 	groupID := int64(1)
 	resetAt := time.Now().Add(1 * time.Hour)
@@ -830,6 +921,42 @@ func TestOpenAISelectAccountWithLoadAwareness_NoCandidates(t *testing.T) {
 	}
 	if selection != nil {
 		t.Fatalf("expected nil selection")
+	}
+}
+
+func TestOpenAISelectAccountWithLoadAwareness_RecoversRateLimitedProbeAccount(t *testing.T) {
+	groupID := int64(1)
+	soon := time.Now().Add(5 * time.Minute)
+	later := time.Now().Add(1 * time.Hour)
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{ID: 1, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 2, RateLimitResetAt: &later, AccountGroups: []AccountGroup{{GroupID: groupID}}},
+			{ID: 2, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 1, RateLimitResetAt: &soon, AccountGroups: []AccountGroup{{GroupID: groupID}}},
+		},
+	}
+	cache := &stubGatewayCache{}
+	concurrencyCache := stubConcurrencyCache{}
+	rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	svc := &OpenAIGatewayService{
+		accountRepo:        repo,
+		cache:              cache,
+		concurrencyService: NewConcurrencyService(concurrencyCache),
+		rateLimitService:   rateLimitService,
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gpt-4", nil)
+	if err != nil {
+		t.Fatalf("SelectAccountWithLoadAwareness error: %v", err)
+	}
+	if selection == nil || selection.Account == nil || selection.Account.ID != 2 {
+		t.Fatalf("expected recovered account 2, got %#v", selection)
+	}
+	if selection.Account.RateLimitResetAt != nil {
+		t.Fatalf("expected recovered account rate limit to be cleared")
+	}
+	if !selection.Acquired {
+		t.Fatalf("expected recovered account slot to be acquired")
 	}
 }
 

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1000,20 +1000,10 @@ func calculateOpenAI429ResetTime(headers http.Header) *time.Time {
 		return &resetAt
 	}
 
-	// 都未达到100%但收到429，使用较长的重置时间
-	var maxResetSecs int
-	if normalized.Reset7dSeconds != nil && *normalized.Reset7dSeconds > maxResetSecs {
-		maxResetSecs = *normalized.Reset7dSeconds
-	}
-	if normalized.Reset5hSeconds != nil && *normalized.Reset5hSeconds > maxResetSecs {
-		maxResetSecs = *normalized.Reset5hSeconds
-	}
-	if maxResetSecs > 0 {
-		resetAt := now.Add(time.Duration(maxResetSecs) * time.Second)
-		slog.Info("openai_429_using_max_reset", "max_reset_seconds", maxResetSecs, "reset_at", resetAt)
-		return &resetAt
-	}
-
+	// 两个用量窗口都未耗尽时，429 通常来自短暂 RPM/TPM 突发限制。
+	// x-codex-*-reset-after-seconds 表示用量窗口重置时间，不应当被当作本次
+	// 突发限流的冷却时间；返回 nil 让调用方使用短 fallback cooldown。
+	slog.Info("openai_429_codex_windows_not_exhausted_using_fallback")
 	return nil
 }
 

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -73,10 +73,11 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 	}
 }
 
-func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
+func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesFallback(t *testing.T) {
 	svc := &RateLimitService{}
 
-	// Neither limit at 100%, should use the longer reset time
+	// Neither usage window is exhausted. The reset headers describe the usage
+	// windows, not a transient 429 burst cooldown, so callers should fall back.
 	headers := http.Header{}
 	headers.Set("x-codex-primary-used-percent", "80")
 	headers.Set("x-codex-primary-reset-after-seconds", "100000")
@@ -85,22 +86,8 @@ func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
 	headers.Set("x-codex-secondary-reset-after-seconds", "5000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
-	before := time.Now()
 	resetAt := svc.calculateOpenAI429ResetTime(headers)
-	after := time.Now()
-
-	if resetAt == nil {
-		t.Fatal("expected non-nil resetAt")
-	}
-
-	// Should use the max (100000 seconds from 7d window)
-	expectedDuration := 100000 * time.Second
-	minExpected := before.Add(expectedDuration)
-	maxExpected := after.Add(expectedDuration)
-
-	if resetAt.Before(minExpected) || resetAt.After(maxExpected) {
-		t.Errorf("resetAt %v not in expected range [%v, %v]", resetAt, minExpected, maxExpected)
-	}
+	require.Nil(t, resetAt)
 }
 
 func TestCalculateOpenAI429ResetTime_NoCodexHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

- Avoid writing Codex 429 5h/7d reset windows as long local cooldowns when those windows are not exhausted.
- Add an OpenAI rate-limit probe recovery path so accounts hidden by `rate_limit_reset_at` can be retried when the normal scheduler has no viable account.
- Add regression coverage for the fallback cooldown behavior and both normal/load-aware OpenAI selection paths.

## Root Cause

Codex 429 responses can include long reset windows even when the corresponding `used_percent` values are below 100. The previous fallback selected the maximum reset value anyway, which could turn a short burst/RPM cooldown into a multi-hour account block. Once persisted, the main scheduler filtered those accounts before requests could reach the success-header cleanup path.

## Validation

- `cd backend && go test -tags=unit ./internal/service -run "TestCalculateOpenAI429ResetTime|TestOpenAISelectAccount"`
