### PR TITLE
fix: 修复 OpenAI 账号 429 冷却时间误判，增加限流账号恢复机制

### DIFF
--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -57,6 +57,24 @@ func (r schedulerTestOpenAIAccountRepo) ListSchedulableUngroupedByPlatform(ctx c
 	return r.ListSchedulableByPlatform(ctx, platform)
 }
 
+func (r schedulerTestOpenAIAccountRepo) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {
+	return r.accounts, nil
+}
+
+func (r schedulerTestOpenAIAccountRepo) ListByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	var result []Account
+	for _, acc := range r.accounts {
+		if acc.Platform == platform {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
+}
+
+func (r schedulerTestOpenAIAccountRepo) ClearRateLimit(ctx context.Context, id int64) error {
+	return nil
+}
+
 type schedulerTestConcurrencyCache struct {
 	ConcurrencyCache
 	loadBatchErr    error

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -57,6 +57,7 @@ const (
 	codexCLIVersion                    = "0.125.0"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
+	openAICodexRecoverySnapshotMaxSkew    = 2 * time.Minute
 )
 
 // OpenAI allowed headers whitelist (for non-passthrough).
@@ -1369,6 +1370,12 @@ func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.C
 	selected, compactBlocked := s.selectBestAccount(ctx, groupID, accounts, requestedModel, excludedIDs, requireCompact)
 
 	if selected == nil {
+		if recovered := s.recoverOpenAIRateLimitedAccountBeforeNoAvailable(ctx, groupID, requestedModel, excludedIDs, requireCompact); recovered != nil {
+			if sessionHash != "" {
+				_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, recovered.ID, openaiStickySessionTTL)
+			}
+			return recovered, nil
+		}
 		return nil, noAvailableOpenAISelectionError(requestedModel, compactBlocked)
 	}
 
@@ -1506,6 +1513,199 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 	return selected, compactBlocked
 }
 
+func (s *OpenAIGatewayService) recoverOpenAIRateLimitedAccountBeforeNoAvailable(ctx context.Context, groupID *int64, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool) *Account {
+	if s == nil || s.accountRepo == nil {
+		return nil
+	}
+
+	accounts, err := s.listOpenAIAccountsForRateLimitRecovery(ctx, groupID)
+	if err != nil {
+		slog.Warn("openai_rate_limit_recovery_list_failed", "group_id", derefGroupID(groupID), "error", err)
+		return nil
+	}
+	if len(accounts) == 0 {
+		return nil
+	}
+
+	needsUpstreamCheck := s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
+	candidates := make([]*Account, 0, len(accounts))
+	for i := range accounts {
+		acc := &accounts[i]
+		if _, excluded := excludedIDs[acc.ID]; excluded {
+			continue
+		}
+		if !isRecoverableOpenAIRateLimitedAccount(acc, requestedModel, requireCompact) {
+			continue
+		}
+		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
+			continue
+		}
+		candidates = append(candidates, acc)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	sortAccountsByPriorityAndLastUsed(candidates, false)
+	for _, candidate := range candidates {
+		if err := s.clearOpenAIRateLimitForRecovery(ctx, candidate.ID); err != nil {
+			slog.Warn("openai_rate_limit_recovery_clear_failed", "account_id", candidate.ID, "error", err)
+			continue
+		}
+
+		fresh, err := s.accountRepo.GetByID(ctx, candidate.ID)
+		if err != nil || fresh == nil {
+			slog.Warn("openai_rate_limit_recovery_hydrate_failed", "account_id", candidate.ID, "error", err)
+			continue
+		}
+		if !isOpenAIAccountEligibleForRequest(fresh, requestedModel, requireCompact) {
+			continue
+		}
+		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+			continue
+		}
+
+		slog.Info("openai_rate_limit_recovery_selected", "account_id", fresh.ID, "group_id", derefGroupID(groupID), "model", requestedModel)
+		return fresh
+	}
+
+	return nil
+}
+
+func (s *OpenAIGatewayService) recoverOpenAIRateLimitedSelectionBeforeNoAvailable(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, cfg config.GatewaySchedulingConfig) (*AccountSelectionResult, bool) {
+	account := s.recoverOpenAIRateLimitedAccountBeforeNoAvailable(ctx, groupID, requestedModel, excludedIDs, requireCompact)
+	if account == nil {
+		return nil, false
+	}
+	if sessionHash != "" {
+		_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, account.ID, openaiStickySessionTTL)
+	}
+
+	result, err := s.tryAcquireAccountSlot(ctx, account.ID, account.Concurrency)
+	if err == nil && result != nil && result.Acquired {
+		return &AccountSelectionResult{
+			Account:     account,
+			Acquired:    true,
+			ReleaseFunc: result.ReleaseFunc,
+		}, true
+	}
+
+	return &AccountSelectionResult{
+		Account: account,
+		WaitPlan: &AccountWaitPlan{
+			AccountID:      account.ID,
+			MaxConcurrency: account.Concurrency,
+			Timeout:        cfg.FallbackWaitTimeout,
+			MaxWaiting:     cfg.FallbackMaxWaiting,
+		},
+	}, true
+}
+
+func (s *OpenAIGatewayService) listOpenAIAccountsForRateLimitRecovery(ctx context.Context, groupID *int64) ([]Account, error) {
+	if s == nil || s.accountRepo == nil {
+		return nil, nil
+	}
+	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		return s.accountRepo.ListByPlatform(ctx, PlatformOpenAI)
+	}
+	if groupID != nil {
+		accounts, err := s.accountRepo.ListByGroup(ctx, *groupID)
+		if err != nil {
+			return nil, err
+		}
+		return filterOpenAIAccounts(accounts), nil
+	}
+
+	accounts, err := s.accountRepo.ListByPlatform(ctx, PlatformOpenAI)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Account, 0, len(accounts))
+	for _, acc := range accounts {
+		if len(acc.AccountGroups) == 0 {
+			out = append(out, acc)
+		}
+	}
+	return out, nil
+}
+
+func filterOpenAIAccounts(accounts []Account) []Account {
+	out := make([]Account, 0, len(accounts))
+	for _, acc := range accounts {
+		if acc.IsOpenAI() {
+			out = append(out, acc)
+		}
+	}
+	return out
+}
+
+func (s *OpenAIGatewayService) clearOpenAIRateLimitForRecovery(ctx context.Context, accountID int64) error {
+	if s != nil && s.accountRepo != nil {
+		return s.accountRepo.ClearRateLimit(ctx, accountID)
+	}
+	return nil
+}
+
+func isRecoverableOpenAIRateLimitedAccount(account *Account, requestedModel string, requireCompact bool) bool {
+	if account == nil || !account.IsOpenAI() || !account.IsActive() || !account.Schedulable {
+		return false
+	}
+	now := time.Now()
+	if account.RateLimitResetAt == nil || !now.Before(*account.RateLimitResetAt) {
+		return false
+	}
+	if account.AutoPauseOnExpired && account.ExpiresAt != nil && !now.Before(*account.ExpiresAt) {
+		return false
+	}
+	if account.OverloadUntil != nil && now.Before(*account.OverloadUntil) {
+		return false
+	}
+	if account.TempUnschedulableUntil != nil && now.Before(*account.TempUnschedulableUntil) {
+		return false
+	}
+	if account.IsAPIKeyOrBedrock() && account.IsQuotaExceeded() {
+		return false
+	}
+	if requestedModel != "" && !account.IsModelSupported(requestedModel) {
+		return false
+	}
+	if requireCompact && openAICompactSupportTier(account) == 0 {
+		return false
+	}
+	return openAICodexSnapshotShowsNonExhaustedWindows(account)
+}
+
+func openAICodexSnapshotShowsNonExhaustedWindows(account *Account) bool {
+	used5h, ok5h := accountExtraFloat64(account, "codex_5h_used_percent")
+	used7d, ok7d := accountExtraFloat64(account, "codex_7d_used_percent")
+	if !ok5h || !ok7d || used5h >= 100 || used7d >= 100 {
+		return false
+	}
+	if account.RateLimitedAt == nil {
+		return false
+	}
+	sampledAt := account.getExtraTime("codex_usage_updated_at")
+	if sampledAt.IsZero() {
+		return false
+	}
+	diff := sampledAt.Sub(*account.RateLimitedAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= openAICodexRecoverySnapshotMaxSkew
+}
+
+func accountExtraFloat64(account *Account, key string) (float64, bool) {
+	if account == nil || account.Extra == nil {
+		return 0, false
+	}
+	value, ok := account.Extra[key]
+	if !ok {
+		return 0, false
+	}
+	return parseExtraFloat64(value), true
+}
+
 // isBetterAccount 判断 candidate 是否比 current 更优。
 // 规则：优先级更高（数值更小）优先；同优先级时，未使用过的优先，其次是最久未使用的。
 //
@@ -1593,6 +1793,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		return nil, err
 	}
 	if len(accounts) == 0 {
+		if recovered, ok := s.recoverOpenAIRateLimitedSelectionBeforeNoAvailable(ctx, groupID, sessionHash, requestedModel, excludedIDs, requireCompact, cfg); ok {
+			return recovered, nil
+		}
 		return nil, ErrNoAvailableAccounts
 	}
 
@@ -1667,6 +1870,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	}
 
 	if len(candidates) == 0 {
+		if recovered, ok := s.recoverOpenAIRateLimitedSelectionBeforeNoAvailable(ctx, groupID, sessionHash, requestedModel, excludedIDs, requireCompact, cfg); ok {
+			return recovered, nil
+		}
 		return nil, ErrNoAvailableAccounts
 	}
 
@@ -1809,6 +2015,9 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		})
 	}
 
+	if recovered, ok := s.recoverOpenAIRateLimitedSelectionBeforeNoAvailable(ctx, groupID, sessionHash, requestedModel, excludedIDs, requireCompact, cfg); ok {
+		return recovered, nil
+	}
 	if requireCompact && baseCandidateCount > 0 {
 		return nil, ErrNoAvailableCompactAccounts
 	}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -35,6 +35,11 @@ type snapshotUpdateAccountRepo struct {
 	updateExtraCalls chan map[string]any
 }
 
+type recoverableOpenAIAccountRepo struct {
+	stubOpenAIAccountRepo
+	clearRateLimitCalls int
+}
+
 func (r *snapshotUpdateAccountRepo) UpdateExtra(ctx context.Context, id int64, updates map[string]any) error {
 	if r.updateExtraCalls != nil {
 		copied := make(map[string]any, len(updates))
@@ -42,6 +47,18 @@ func (r *snapshotUpdateAccountRepo) UpdateExtra(ctx context.Context, id int64, u
 			copied[k] = v
 		}
 		r.updateExtraCalls <- copied
+	}
+	return nil
+}
+
+func (r *recoverableOpenAIAccountRepo) ClearRateLimit(ctx context.Context, id int64) error {
+	r.clearRateLimitCalls++
+	for i := range r.accounts {
+		if r.accounts[i].ID == id {
+			r.accounts[i].RateLimitedAt = nil
+			r.accounts[i].RateLimitResetAt = nil
+			return nil
+		}
 	}
 	return nil
 }
@@ -65,6 +82,26 @@ func (r stubOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.C
 	return result, nil
 }
 
+func (r stubOpenAIAccountRepo) ListByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	var result []Account
+	for _, acc := range r.accounts {
+		if acc.Platform == platform && acc.Status == StatusActive {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
+}
+
+func (r stubOpenAIAccountRepo) ListByGroup(ctx context.Context, groupID int64) ([]Account, error) {
+	var result []Account
+	for _, acc := range r.accounts {
+		if acc.Status == StatusActive {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
+}
+
 func (r stubOpenAIAccountRepo) ListSchedulableByPlatform(ctx context.Context, platform string) ([]Account, error) {
 	var result []Account
 	for _, acc := range r.accounts {
@@ -77,6 +114,10 @@ func (r stubOpenAIAccountRepo) ListSchedulableByPlatform(ctx context.Context, pl
 
 func (r stubOpenAIAccountRepo) ListSchedulableUngroupedByPlatform(ctx context.Context, platform string) ([]Account, error) {
 	return r.ListSchedulableByPlatform(ctx, platform)
+}
+
+func (r stubOpenAIAccountRepo) ClearRateLimit(ctx context.Context, id int64) error {
+	return nil
 }
 
 type stubConcurrencyCache struct {
@@ -467,6 +508,108 @@ func TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulableWhenNoConcurre
 	if selection.ReleaseFunc != nil {
 		selection.ReleaseFunc()
 	}
+}
+
+func TestOpenAISelectAccountForModelWithExclusions_RecoversNonExhaustedCodexRateLimit(t *testing.T) {
+	now := time.Now()
+	rateLimitedAt := now.Add(-30 * time.Second)
+	resetAt := now.Add(5 * time.Hour)
+	account := Account{
+		ID:               9,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		Status:           StatusActive,
+		Schedulable:      true,
+		Concurrency:      1,
+		Priority:         0,
+		RateLimitedAt:    &rateLimitedAt,
+		RateLimitResetAt: &resetAt,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  31.0,
+			"codex_7d_used_percent":  42.0,
+			"codex_usage_updated_at": rateLimitedAt.Format(time.RFC3339),
+		},
+	}
+	repo := &recoverableOpenAIAccountRepo{stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}}}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+
+	selected, err := svc.SelectAccountForModelWithExclusions(context.Background(), nil, "", "gpt-5.2", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, selected)
+	require.Equal(t, account.ID, selected.ID)
+	require.Equal(t, 1, repo.clearRateLimitCalls)
+	require.Nil(t, selected.RateLimitResetAt)
+}
+
+func TestOpenAISelectAccountWithLoadAwareness_RecoversNonExhaustedCodexRateLimit(t *testing.T) {
+	now := time.Now()
+	rateLimitedAt := now.Add(-30 * time.Second)
+	resetAt := now.Add(5 * time.Hour)
+	account := Account{
+		ID:               10,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		Status:           StatusActive,
+		Schedulable:      true,
+		Concurrency:      1,
+		Priority:         0,
+		RateLimitedAt:    &rateLimitedAt,
+		RateLimitResetAt: &resetAt,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  31.0,
+			"codex_7d_used_percent":  42.0,
+			"codex_usage_updated_at": rateLimitedAt.Format(time.RFC3339),
+		},
+	}
+	repo := &recoverableOpenAIAccountRepo{stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}}}
+	svc := &OpenAIGatewayService{
+		accountRepo:        repo,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+	}
+
+	selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), nil, "", "gpt-5.2", nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, account.ID, selection.Account.ID)
+	require.Equal(t, 1, repo.clearRateLimitCalls)
+	require.True(t, selection.Acquired)
+	require.Nil(t, selection.Account.RateLimitResetAt)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAISelectAccountForModelWithExclusions_DoesNotRecoverExhaustedCodexRateLimit(t *testing.T) {
+	now := time.Now()
+	rateLimitedAt := now.Add(-30 * time.Second)
+	resetAt := now.Add(5 * time.Hour)
+	account := Account{
+		ID:               11,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		Status:           StatusActive,
+		Schedulable:      true,
+		Concurrency:      1,
+		Priority:         0,
+		RateLimitedAt:    &rateLimitedAt,
+		RateLimitResetAt: &resetAt,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  12.0,
+			"codex_7d_used_percent":  100.0,
+			"codex_usage_updated_at": rateLimitedAt.Format(time.RFC3339),
+		},
+	}
+	repo := &recoverableOpenAIAccountRepo{stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{account}}}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+
+	selected, err := svc.SelectAccountForModelWithExclusions(context.Background(), nil, "", "gpt-5.2", nil)
+
+	require.Error(t, err)
+	require.Nil(t, selected)
+	require.Equal(t, 0, repo.clearRateLimitCalls)
 }
 
 func TestOpenAISelectAccountForModelWithExclusions_StickyUnschedulableClearsSession(t *testing.T) {

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1000,20 +1000,8 @@ func calculateOpenAI429ResetTime(headers http.Header) *time.Time {
 		return &resetAt
 	}
 
-	// 都未达到100%但收到429，使用较长的重置时间
-	var maxResetSecs int
-	if normalized.Reset7dSeconds != nil && *normalized.Reset7dSeconds > maxResetSecs {
-		maxResetSecs = *normalized.Reset7dSeconds
-	}
-	if normalized.Reset5hSeconds != nil && *normalized.Reset5hSeconds > maxResetSecs {
-		maxResetSecs = *normalized.Reset5hSeconds
-	}
-	if maxResetSecs > 0 {
-		resetAt := now.Add(time.Duration(maxResetSecs) * time.Second)
-		slog.Info("openai_429_using_max_reset", "max_reset_seconds", maxResetSecs, "reset_at", resetAt)
-		return &resetAt
-	}
-
+	// Neither Codex usage window is exhausted. Treat this as a burst 429 and
+	// let the caller apply the short fallback cooldown.
 	return nil
 }
 
@@ -1156,6 +1144,10 @@ func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, accou
 //	  }
 //	}
 func parseOpenAIRateLimitResetTime(body []byte) *int64 {
+	return parseOpenAIRateLimitResetTimeAt(body, time.Now())
+}
+
+func parseOpenAIRateLimitResetTimeAt(body []byte, now time.Time) *int64 {
 	var parsed map[string]any
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil
@@ -1174,28 +1166,42 @@ func parseOpenAIRateLimitResetTime(body []byte) *int64 {
 
 	// 优先使用 resets_at（Unix 时间戳）
 	if resetsAt, ok := errObj["resets_at"].(float64); ok {
-		ts := int64(resetsAt)
+		ts := clampOpenAIRateLimitExceededReset(errType, int64(resetsAt), now)
 		return &ts
 	}
 	if resetsAt, ok := errObj["resets_at"].(string); ok {
 		if ts, err := strconv.ParseInt(resetsAt, 10, 64); err == nil {
+			ts = clampOpenAIRateLimitExceededReset(errType, ts, now)
 			return &ts
 		}
 	}
 
 	// 如果没有 resets_at，尝试使用 resets_in_seconds
 	if resetsInSeconds, ok := errObj["resets_in_seconds"].(float64); ok {
-		ts := time.Now().Unix() + int64(resetsInSeconds)
+		ts := now.Unix() + int64(resetsInSeconds)
+		ts = clampOpenAIRateLimitExceededReset(errType, ts, now)
 		return &ts
 	}
 	if resetsInSeconds, ok := errObj["resets_in_seconds"].(string); ok {
 		if sec, err := strconv.ParseInt(resetsInSeconds, 10, 64); err == nil {
-			ts := time.Now().Unix() + sec
+			ts := now.Unix() + sec
+			ts = clampOpenAIRateLimitExceededReset(errType, ts, now)
 			return &ts
 		}
 	}
 
 	return nil
+}
+
+func clampOpenAIRateLimitExceededReset(errType string, ts int64, now time.Time) int64 {
+	if errType != "rate_limit_exceeded" {
+		return ts
+	}
+	maxResetAt := now.Add(time.Duration(maxRateLimit429CooldownSeconds) * time.Second).Unix()
+	if ts > maxResetAt {
+		return maxResetAt
+	}
+	return ts
 }
 
 // handle529 处理529过载错误

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -73,10 +74,11 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 	}
 }
 
-func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
+func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesFallback(t *testing.T) {
 	svc := &RateLimitService{}
 
-	// Neither limit at 100%, should use the longer reset time
+	// Neither limit is exhausted. The reset headers describe usage windows, not
+	// the transient burst limit that caused the 429.
 	headers := http.Header{}
 	headers.Set("x-codex-primary-used-percent", "80")
 	headers.Set("x-codex-primary-reset-after-seconds", "100000")
@@ -85,22 +87,9 @@ func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
 	headers.Set("x-codex-secondary-reset-after-seconds", "5000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
-	before := time.Now()
 	resetAt := svc.calculateOpenAI429ResetTime(headers)
-	after := time.Now()
 
-	if resetAt == nil {
-		t.Fatal("expected non-nil resetAt")
-	}
-
-	// Should use the max (100000 seconds from 7d window)
-	expectedDuration := 100000 * time.Second
-	minExpected := before.Add(expectedDuration)
-	maxExpected := after.Add(expectedDuration)
-
-	if resetAt.Before(minExpected) || resetAt.After(maxExpected) {
-		t.Errorf("resetAt %v not in expected range [%v, %v]", resetAt, minExpected, maxExpected)
-	}
+	require.Nil(t, resetAt)
 }
 
 func TestCalculateOpenAI429ResetTime_NoCodexHeaders(t *testing.T) {
@@ -459,4 +448,29 @@ func TestCalculateOpenAI429ResetTime_5MinFallbackWhenNoReset(t *testing.T) {
 	if resetAt != nil {
 		t.Errorf("expected nil when no reset_after_seconds, got %v", resetAt)
 	}
+}
+
+func TestParseOpenAIRateLimitResetTime_RateLimitExceededClampsLongReset(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+
+	got := parseOpenAIRateLimitResetTimeAt(
+		[]byte(`{"error":{"type":"rate_limit_exceeded","message":"slow down","resets_in_seconds":432000}}`),
+		now,
+	)
+
+	require.NotNil(t, got)
+	require.Equal(t, now.Add(time.Duration(maxRateLimit429CooldownSeconds)*time.Second).Unix(), *got)
+}
+
+func TestParseOpenAIRateLimitResetTime_UsageLimitReachedKeepsLongReset(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	resetAt := now.Add(5 * 24 * time.Hour).Unix()
+
+	got := parseOpenAIRateLimitResetTimeAt(
+		[]byte(fmt.Sprintf(`{"error":{"type":"usage_limit_reached","message":"limit reached","resets_at":%d}}`, resetAt)),
+		now,
+	)
+
+	require.NotNil(t, got)
+	require.Equal(t, resetAt, *got)
 }


### PR DESCRIPTION
Closes #2258

---

## 问题背景

OpenAI Codex 账号在收到 429 响应时，系统会读取响应头中的 Codex 用量窗口信息（5h/7d）来设置冷却时间。但当两个窗口均**未耗尽**（`used_percent < 100%`）时，之前的逻辑会错误地取两个窗口 `reset-after-seconds` 中的较大值作为冷却时长：

- 7d 窗口还剩 5 天时，冷却时间会被设为 ~432000 秒（5 天）
- 实际上这只是一次瞬时 RPM 突发限流，几秒就会恢复
- 导致账号被误判为长时间限流，系统持续返回 503

此外，`parseOpenAIRateLimitResetTime` 对 `rate_limit_exceeded` 类型的错误缺乏上限保护，响应体中的 `resets_at` 值完全由 OpenAI 控制，也可能导致数小时甚至数天的冷却。

---

## 本次修复内容

### 1. 修复冷却时间误判（`ratelimit_service.go`）

**`calculateOpenAI429ResetTime`**：当两个 Codex 用量窗口均未耗尽时，原兜底分支取最大 `reset-after-seconds`，改为直接返回 `nil`，让调用方走到 `apply429FallbackRateLimit`（默认 5 秒短冷却，上限 2h），而非错误地使用用量窗口的重置时间。

**`parseOpenAIRateLimitResetTime` 加 clamp 保护**：新增 `clampOpenAIRateLimitExceededReset` 函数，区分错误类型：
- `rate_limit_exceeded`（突发限流）：对解析到的 `resets_at` 施加上限（`maxRateLimit429CooldownSeconds`），避免过长冷却
- `usage_limit_reached`（真正用量耗尽）：保持上游返回值不变

同时将 `parseOpenAIRateLimitResetTime` 重构为可注入时间的 `parseOpenAIRateLimitResetTimeAt`，提升测试覆盖能力。

### 2. 增加限流账号恢复机制（`openai_gateway_service.go`）

由于 OpenAI 平台缺少"成功响应自愈"路径（不同于 Anthropic），当即将返回 503/无可用账号时，新增以下恢复逻辑：

- `recoverOpenAIRateLimitedAccountBeforeNoAvailable`：在 `selectBestAccount` 返回 nil 时，遍历仅因限流被阻塞的账号，验证其 Codex 用量快照（5h/7d 均未耗尽），清除限流状态后重新投入调度。安全性：若账号实际仍在限流，上游会再次返回 429 并重新标记。
- `recoverOpenAIRateLimitedSelectionBeforeNoAvailable`：在 `selectAccountWithLoadAwareness` 的三处"无可用账号"出口处均接入上述恢复逻辑。
- `openAICodexSnapshotShowsNonExhaustedWindows`：通过账号 Extra 字段中的 `codex_5h_used_percent`、`codex_7d_used_percent` 及快照时间 `codex_usage_updated_at` 判断快照是否有效（快照时间与限流时间差不超过 2 分钟），避免使用过期快照误判。
- 新增常量 `openAICodexRecoverySnapshotMaxSkew = 2 * time.Minute`。

---

## 测试覆盖

新增/修改测试（`openai_gateway_service_test.go`、`ratelimit_service_openai_test.go`）：

- `TestOpenAISelectAccountForModelWithExclusions_RecoversNonExhaustedCodexRateLimit`：验证用量未耗尽的限流账号被正确恢复
- `TestOpenAISelectAccountWithLoadAwareness_RecoversNonExhaustedCodexRateLimit`：验证负载感知调度路径的恢复逻辑
- `TestOpenAISelectAccountForModelWithExclusions_DoesNotRecoverExhaustedCodexRateLimit`：验证 7d 用量已达 100% 时不触发恢复
- `TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesFallback`：验证两个窗口均未耗尽时返回 nil
- `TestParseOpenAIRateLimitResetTime_RateLimitExceededClampsLongReset`：验证 `rate_limit_exceeded` 长重置时间被 clamp
- `TestParseOpenAIRateLimitResetTime_UsageLimitReachedKeepsLongReset`：验证 `usage_limit_reached` 重置时间不受 clamp 影响

---

## 变更文件

- `backend/internal/service/openai_gateway_service.go`
- `backend/internal/service/openai_gateway_service_test.go`
- `backend/internal/service/ratelimit_service.go`
- `backend/internal/service/ratelimit_service_openai_test.go`