### PR TITLE
fix(antigravity): drop .sandbox subdomain on daily-cloudcode-pa base URL

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -46,7 +46,7 @@ const (
 
 	// Antigravity API 端点
 	antigravityProdBaseURL  = "https://cloudcode-pa.googleapis.com"
-	antigravityDailyBaseURL = "https://daily-cloudcode-pa.sandbox.googleapis.com"
+	antigravityDailyBaseURL = "https://daily-cloudcode-pa.googleapis.com"
 )
 
 // defaultUserAgentVersion 可通过环境变量 ANTIGRAVITY_USER_AGENT_VERSION 配置，默认 1.20.5


### PR DESCRIPTION
Fixes #2164: chat completion requests through Antigravity OAuth accounts return the stub "This version of Antigravity is no longer supported" with zero token usage, regardless of client version metadata.

Root cause: ForwardBaseURLs() rotates daily first, and the daily host was set to daily-cloudcode-pa.sandbox.googleapis.com, which is no longer the production daily endpoint and returns the version-gating stub for any request. The actual Antigravity client uses daily-cloudcode-pa.googleapis.com (no .sandbox subdomain).

Verified: claude-opus-4-6, claude-sonnet-4-6, gpt-oss-120b-medium all return real inference (non-zero token usage) after the fix.