### PR TITLE
fix(frontend): correct cache hit rate denominator

### DIFF
--- a/frontend/src/components/charts/TokenUsageTrend.vue
+++ b/frontend/src/components/charts/TokenUsageTrend.vue
@@ -109,8 +109,8 @@ const chartData = computed(() => {
       {
         label: 'Cache Hit Rate',
         data: props.trendData.map((d) => {
-          const total = d.cache_read_tokens + d.cache_creation_tokens
-          return total > 0 ? (d.cache_read_tokens / total) * 100 : 0
+          const totalPromptTokens = d.input_tokens + d.cache_read_tokens + d.cache_creation_tokens
+          return totalPromptTokens > 0 ? (d.cache_read_tokens / totalPromptTokens) * 100 : 0
         }),
         borderColor: chartColors.value.cacheHitRate,
         backgroundColor: `${chartColors.value.cacheHitRate}20`,

--- a/frontend/src/components/charts/__tests__/TokenUsageTrend.spec.ts
+++ b/frontend/src/components/charts/__tests__/TokenUsageTrend.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import TokenUsageTrend from '../TokenUsageTrend.vue'
+
+const messages: Record<string, string> = {
+  'admin.dashboard.tokenUsageTrend': 'Token Usage Trend',
+  'admin.dashboard.noDataAvailable': 'No data available',
+}
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => messages[key] ?? key,
+    }),
+  }
+})
+
+vi.mock('vue-chartjs', () => ({
+  Line: {
+    props: ['data', 'options'],
+    template: '<div class="chart-data">{{ JSON.stringify(data) }}</div>',
+  },
+}))
+
+describe('TokenUsageTrend', () => {
+  it('calculates cache hit rate against all prompt tokens', () => {
+    const wrapper = mount(TokenUsageTrend, {
+      props: {
+        trendData: [
+          {
+            date: '2026-05-08',
+            requests: 1,
+            input_tokens: 1000,
+            output_tokens: 200,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 250,
+            total_tokens: 1450,
+            cost: 0.01,
+            actual_cost: 0.01,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          LoadingSpinner: true,
+        },
+      },
+    })
+
+    const chartData = JSON.parse(wrapper.find('.chart-data').text())
+    const hitRateDataset = chartData.datasets.find(
+      (dataset: { label: string }) => dataset.label === 'Cache Hit Rate'
+    )
+
+    expect(hitRateDataset.data).toEqual([20])
+  })
+})


### PR DESCRIPTION
## Summary
- Fix the token usage trend Cache Hit Rate denominator to use all prompt tokens: `input_tokens + cache_read_tokens + cache_creation_tokens`.
- Add a regression test covering the OpenAI OAuth stats case where cache reads were displayed as 100% when cache creation was zero.

Fixes #2291

## Tests
- `pnpm test:run src/components/charts/__tests__/TokenUsageTrend.spec.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/components/charts/TokenUsageTrend.vue src/components/charts/__tests__/TokenUsageTrend.spec.ts`
- `git diff --check`