### PR TITLE
fix(auth-cache): invalidate legacy image auth snapshots

### DIFF
--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/dgraph-io/ristretto"
 )
 
-const apiKeyAuthSnapshotVersion = 9 // v9: added API Key name for audit logs
+const apiKeyAuthSnapshotVersion = 10 // v10: invalidate legacy auth snapshots missing image-generation fields
 
 type apiKeyAuthCacheConfig struct {
 	l1Size        int

--- a/backend/internal/service/api_key_service_cache_test.go
+++ b/backend/internal/service/api_key_service_cache_test.go
@@ -251,6 +251,9 @@ func TestAPIKeyService_SnapshotRoundTrip_PreservesMessagesDispatchModelConfig(t 
 			Status:                StatusActive,
 			SubscriptionType:      SubscriptionTypeStandard,
 			RateMultiplier:        1,
+			AllowImageGeneration:  true,
+			ImageRateIndependent:  true,
+			ImageRateMultiplier:   1.75,
 			AllowMessagesDispatch: true,
 			DefaultMappedModel:    "gpt-5.4",
 			MessagesDispatchModelConfig: OpenAIMessagesDispatchModelConfig{
@@ -270,6 +273,9 @@ func TestAPIKeyService_SnapshotRoundTrip_PreservesMessagesDispatchModelConfig(t 
 	require.NotNil(t, roundTrip)
 	require.Equal(t, apiKey.Name, roundTrip.Name)
 	require.NotNil(t, roundTrip.Group)
+	require.True(t, roundTrip.Group.AllowImageGeneration)
+	require.True(t, roundTrip.Group.ImageRateIndependent)
+	require.Equal(t, 1.75, roundTrip.Group.ImageRateMultiplier)
 	require.Equal(t, apiKey.Group.MessagesDispatchModelConfig, roundTrip.Group.MessagesDispatchModelConfig)
 }
 
@@ -320,6 +326,7 @@ func TestAPIKeyService_GetByKey_IgnoresLegacyAuthCacheSnapshotWithoutMessagesDis
 	cache.getAuthCache = func(ctx context.Context, key string) (*APIKeyAuthCacheEntry, error) {
 		return &APIKeyAuthCacheEntry{
 			Snapshot: &APIKeyAuthSnapshot{
+				Version:  apiKeyAuthSnapshotVersion - 1,
 				APIKeyID: 1,
 				UserID:   2,
 				GroupID:  &groupID,


### PR DESCRIPTION
## Summary
- bump the auth snapshot version so legacy cache entries missing image generation fields are reloaded from the database
- extend auth cache regression coverage to assert image permission and rate fields survive snapshot round-trip
- verify version-mismatched cache snapshots fall back to the repository path instead of reusing stale auth data

## Test plan
- [x] `go test ./internal/service -tags unit -run 'TestAPIKeyService_(SnapshotRoundTrip_PreservesMessagesDispatchModelConfig|GetByKey_IgnoresLegacyAuthCacheSnapshotWithoutMessagesDispatchConfig)' -count=1`