### PR TITLE
fix: preserve existing settings during default init

### DIFF
--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -2190,14 +2190,9 @@ func (s *SettingService) UpdateAuthSourceDefaultSettings(ctx context.Context, se
 
 // InitializeDefaultSettings 初始化默认设置
 func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
-	// 检查是否已有设置
-	_, err := s.settingRepo.GetValue(ctx, SettingKeyRegistrationEnabled)
-	if err == nil {
-		// 已有设置，不需要初始化
-		return nil
-	}
-	if !errors.Is(err, ErrSettingNotFound) {
-		return fmt.Errorf("check existing settings: %w", err)
+	existing, err := s.settingRepo.GetAll(ctx)
+	if err != nil {
+		return fmt.Errorf("load existing settings: %w", err)
 	}
 
 	oidcUsePKCEDefault := true
@@ -2365,7 +2360,16 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		openAIAdvancedSchedulerSettingKey:            "false",
 	}
 
-	return s.settingRepo.SetMultiple(ctx, defaults)
+	missing := make(map[string]string, len(defaults))
+	for key, value := range defaults {
+		if _, ok := existing[key]; !ok {
+			missing[key] = value
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	return s.settingRepo.SetMultiple(ctx, missing)
 }
 
 // parseSettings 解析设置到结构体

--- a/backend/internal/service/setting_service_initialize_test.go
+++ b/backend/internal/service/setting_service_initialize_test.go
@@ -1,0 +1,91 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type settingInitRepoStub struct {
+	values  map[string]string
+	updates map[string]string
+}
+
+func (s *settingInitRepoStub) Get(context.Context, string) (*Setting, error) {
+	panic("unexpected Get call")
+}
+
+func (s *settingInitRepoStub) GetValue(context.Context, string) (string, error) {
+	panic("unexpected GetValue call")
+}
+
+func (s *settingInitRepoStub) Set(context.Context, string, string) error {
+	panic("unexpected Set call")
+}
+
+func (s *settingInitRepoStub) GetMultiple(context.Context, []string) (map[string]string, error) {
+	panic("unexpected GetMultiple call")
+}
+
+func (s *settingInitRepoStub) SetMultiple(_ context.Context, settings map[string]string) error {
+	s.updates = make(map[string]string, len(settings))
+	for key, value := range settings {
+		s.updates[key] = value
+		s.values[key] = value
+	}
+	return nil
+}
+
+func (s *settingInitRepoStub) GetAll(context.Context) (map[string]string, error) {
+	result := make(map[string]string, len(s.values))
+	for key, value := range s.values {
+		result[key] = value
+	}
+	return result, nil
+}
+
+func (s *settingInitRepoStub) Delete(context.Context, string) error {
+	panic("unexpected Delete call")
+}
+
+func TestSettingService_InitializeDefaultSettings_BackfillsWithoutOverwriting(t *testing.T) {
+	repo := &settingInitRepoStub{
+		values: map[string]string{
+			SettingKeyRegistrationEnabled: "false",
+			SettingKeySiteName:            "Custom Site",
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.NoError(t, svc.InitializeDefaultSettings(context.Background()))
+
+	require.NotContains(t, repo.updates, SettingKeyRegistrationEnabled)
+	require.NotContains(t, repo.updates, SettingKeySiteName)
+	require.Equal(t, "false", repo.values[SettingKeyRegistrationEnabled])
+	require.Equal(t, "Custom Site", repo.values[SettingKeySiteName])
+	require.Contains(t, repo.updates, SettingKeyPromoCodeEnabled)
+	require.Contains(t, repo.updates, SettingKeyTableDefaultPageSize)
+}
+
+func TestSettingService_InitializeDefaultSettings_PreservesExistingDefaultKeys(t *testing.T) {
+	repo := &settingInitRepoStub{
+		values: map[string]string{
+			SettingKeyRegistrationEnabled:  "false",
+			SettingKeyPromoCodeEnabled:     "false",
+			SettingKeyTableDefaultPageSize: "50",
+		},
+	}
+	svc := NewSettingService(repo, &config.Config{})
+
+	require.NoError(t, svc.InitializeDefaultSettings(context.Background()))
+
+	require.NotContains(t, repo.updates, SettingKeyRegistrationEnabled)
+	require.NotContains(t, repo.updates, SettingKeyPromoCodeEnabled)
+	require.NotContains(t, repo.updates, SettingKeyTableDefaultPageSize)
+	require.Equal(t, "false", repo.values[SettingKeyPromoCodeEnabled])
+	require.Equal(t, "50", repo.values[SettingKeyTableDefaultPageSize])
+}


### PR DESCRIPTION
## Summary
- backfill missing default settings instead of using a single sentinel key
- preserve existing database-backed settings during startup/default initialization
- add unit coverage for partial settings backfills and existing value preservation

## Tests
- go test -tags=unit ./internal/service -run 'TestSettingService_InitializeDefaultSettings'
- go test -tags=unit ./internal/service
- git diff --check