### PR TITLE
fix(mimic): rewrite tool_use names in messages to match renamed tools

### DIFF
--- a/backend/internal/service/gateway_tool_rewrite.go
+++ b/backend/internal/service/gateway_tool_rewrite.go
@@ -168,13 +168,13 @@ func buildToolNameRewriteFromBody(body []byte) *ToolNameRewrite {
 }
 
 // applyToolNameRewriteToBody 把已构造的 ToolNameRewrite 应用到 body 上：
-//   - 改写 $.tools[*].name（仅对 shouldMimicToolName 通过的 tool）
-//   - 在 $.tools[last].cache_control 上打 ephemeral 缓存断点（Parrot 行为对齐，
-//     ttl 客户端已有则透传，否则默认 claude.DefaultCacheControlTTL）
-//   - 改写 $.tool_choice.name（仅当 $.tool_choice.type == "tool"）
 //
-// 历史 $.messages[*].content[*].name（tool_use）不在请求侧改写——这与 Parrot 一致；
-// 响应侧 bytes.Replace 会连带还原它们。
+//	- 改写 $.tools[*].name（仅对 shouldMimicToolName 通过的 tool）
+//	- 改写 $.tool_choice.name（仅当 $.tool_choice.type == "tool"）
+//	- 改写 $.messages[*].content[*].name（仅当 type == "tool_use"）
+//	- 在 $.tools[last].cache_control 上打 ephemeral 缓存断点
+//
+// 响应侧 bytes.Replace 会连带还原假名 → 真名。
 func applyToolNameRewriteToBody(body []byte, rw *ToolNameRewrite) []byte {
 	if rw == nil || len(rw.Forward) == 0 {
 		body = applyToolsLastCacheBreakpoint(body)
@@ -211,6 +211,38 @@ func applyToolNameRewriteToBody(body []byte, rw *ToolNameRewrite) []byte {
 				body = next
 			}
 		}
+	}
+
+	// Rewrite tool_use names in messages to match the renamed tools.
+	// Without this, Anthropic rejects requests where messages reference tools
+	// by their original name but tools[] declares the renamed (fake) name.
+	messages := gjson.GetBytes(body, "messages")
+	if messages.IsArray() {
+		messages.ForEach(func(msgKey, msg gjson.Result) bool {
+			msgIdx := int(msgKey.Num)
+			content := msg.Get("content")
+			if !content.IsArray() {
+				return true
+			}
+			content.ForEach(func(blkKey, blk gjson.Result) bool {
+				blkIdx := int(blkKey.Num)
+				if blk.Get("type").String() != "tool_use" {
+					return true
+				}
+				name := blk.Get("name").String()
+				if name == "" {
+					return true
+				}
+				if fake, ok := rw.Forward[name]; ok {
+					path := fmt.Sprintf("messages.%d.content.%d.name", msgIdx, blkIdx)
+					if next, err := sjson.SetBytes(body, path, fake); err == nil {
+						body = next
+					}
+				}
+				return true
+			})
+			return true
+		})
 	}
 
 	body = applyToolsLastCacheBreakpoint(body)

--- a/backend/internal/service/gateway_tool_rewrite_test.go
+++ b/backend/internal/service/gateway_tool_rewrite_test.go
@@ -84,6 +84,30 @@ func TestApplyToolNameRewriteToBody_RenamesToolsAndToolChoice(t *testing.T) {
 	require.Equal(t, "tool", gjson.GetBytes(out, "tool_choice.type").String())
 }
 
+
+func TestApplyToolNameRewriteToBody_RenamesToolUseInMessages(t *testing.T) {
+	// sessions_list -> cc_sess_list (static prefix: sessions_ -> sessions_)
+	// web_search is a server tool (type != ""), not rewritten
+	// messages tool_use names must be rewritten to match tools[]
+	body := []byte(`{"tools":[{"name":"sessions_list","input_schema":{}},{"name":"web_search","type":"web_search_20250305"}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]},{"role":"assistant","content":[{"type":"tool_use","id":"tu_01","name":"sessions_list","input":{}},{"type":"text","text":"thinking"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_01","content":"ok"}]}]}`)
+	rw := buildToolNameRewriteFromBody(body)
+	require.NotNil(t, rw)
+	require.Equal(t, "cc_sess_list", rw.Forward["sessions_list"])
+
+	out := applyToolNameRewriteToBody(body, rw)
+
+	// tools[0].name rewritten
+	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "tools.0.name").String())
+	// tools[1].name untouched (server tool)
+	require.Equal(t, "web_search", gjson.GetBytes(out, "tools.1.name").String())
+	// messages[1].content[0].name (tool_use) also rewritten to match tools
+	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "messages.1.content.0.name").String())
+	// messages[1].content[1] (text) untouched
+	require.Equal(t, "thinking", gjson.GetBytes(out, "messages.1.content.1.text").String())
+	// messages[2].content[0] (tool_result) untouched — no name field in tool_result
+	require.Equal(t, "ok", gjson.GetBytes(out, "messages.2.content.0.content").String())
+}
+
 func TestApplyToolsLastCacheBreakpoint_InjectsDefault(t *testing.T) {
 	body := []byte(`{"tools":[{"name":"a","input_schema":{}},{"name":"b","input_schema":{}}]}`)
 	out := applyToolsLastCacheBreakpoint(body)


### PR DESCRIPTION
## Summary

When `claude_code_mimic` rewrites tool names in `tools[]` and `tool_choice`, it currently leaves `messages[].content[].name` blocks (`type == "tool_use"`) with their **original** names. Anthropic validates that every tool referenced by a `tool_use` block is declared in `tools[]`, so the mismatch produces an error like:

```
messages.N.content.M: Input tag 'original_name' not found in tools
```

surfaced as HTTP 400 directly, or wrapped as 424 by upstream proxies (e.g. Bedrock gateways).

## Reproduction

1. An account with `extra.claude_code_mimic = true`
2. A client that sends tools **beyond** the Claude Code built-in set (e.g. `web_search`, or any user-defined tool whose name gets rewritten)
3. A multi-turn request where the assistant has previously invoked one of those tools, so the history contains `tool_use` blocks referencing the original name

The rewrite renames `tools[*].name`, but the older `tool_use` blocks in `messages` still point at the old name → Anthropic rejects the request.

## Why Parrot didn't need this

The existing code comment referenced Parrot's behavior:

> 历史 `$.messages[*].content[*].name`（tool_use）不在请求侧改写——这与 Parrot 一致；响应侧 bytes.Replace 会连带还原它们。

Parrot only mimics Claude Code's built-in tool set, so by construction `messages[].name` and `tools[].name` use the same set of names, and there is no cross-turn mismatch. sub2api is more permissive — clients may send any `tools[]` — so the assumption no longer holds for historical `tool_use` blocks, which were named back when the rewrite hadn't been applied yet.

## Fix

Apply the same `ToolNameRewrite.Forward` map to `messages[].content[]` entries where `type == "tool_use"`, keeping `tools[]`, `tool_choice` and `messages` self-consistent before the request hits Anthropic.

- `tool_result` blocks reference tools via `tool_use_id`, not `name`, so they don't need changes.
- Server tools (e.g. `web_search_20250305` with non-empty `type`) are still skipped by `shouldMimicToolName`, so they aren't touched.
- Response-side `bytes.Replace` still restores the original names in the final output, so the client sees no difference.

## Testing

Added `TestApplyToolNameRewriteToBody_RenamesToolUseInMessages` to `gateway_tool_rewrite_test.go`, covering:

- `tools[*].name` rewritten
- `tool_choice.name` rewritten
- `messages[*].content[*].name` (`type == "tool_use"`) rewritten
- Server tools (`type != ""`) untouched
- Text blocks untouched
- `tool_result` blocks untouched (no `name` field)

```
$ go test ./internal/service/ -run TestApplyToolNameRewriteToBody -v
=== RUN   TestApplyToolNameRewriteToBody_RenamesToolsAndToolChoice
--- PASS: TestApplyToolNameRewriteToBody_RenamesToolsAndToolChoice (0.00s)
=== RUN   TestApplyToolNameRewriteToBody_RenamesToolUseInMessages
--- PASS: TestApplyToolNameRewriteToBody_RenamesToolUseInMessages (0.00s)
PASS
```

Validated in production: previously the affected account hit 424 on every multi-turn request containing `web_search` tool_use history; after this fix those requests succeed.
