### PR TITLE
fix(openai): prime Images streams before upstream first byte

### DIFF
--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -103,6 +104,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		setOpsRequestContext(c, parsed.Model, parsed.Stream, body)
 	}
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(parsed.Stream, false)))
+	var stopImageStreamPrimer func()
 
 	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, parsed.Model)
 
@@ -129,6 +131,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		if retryAfter > 0 {
 			c.Header("Retry-After", strconv.Itoa(retryAfter))
 		}
+		stopOpenAIImagesStreamPrimerForHandlerError(c, stopImageStreamPrimer)
 		h.handleStreamingAwareError(c, status, code, message, streamStarted)
 		return
 	}
@@ -157,9 +160,11 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
 			if len(failedAccountIDs) == 0 {
+				stopOpenAIImagesStreamPrimerForHandlerError(c, stopImageStreamPrimer)
 				h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available compatible accounts", streamStarted)
 				return
 			}
+			stopOpenAIImagesStreamPrimerForHandlerError(c, stopImageStreamPrimer)
 			if lastFailoverErr != nil {
 				h.handleFailoverExhausted(c, lastFailoverErr, streamStarted)
 			} else {
@@ -168,6 +173,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			return
 		}
 		if selection == nil || selection.Account == nil {
+			stopOpenAIImagesStreamPrimerForHandlerError(c, stopImageStreamPrimer)
 			h.handleStreamingAwareError(c, http.StatusServiceUnavailable, "api_error", "No available compatible accounts", streamStarted)
 			return
 		}
@@ -192,6 +198,17 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		}
 
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+		if stopImageStreamPrimer == nil && parsed.Stream {
+			keepaliveInterval := time.Duration(0)
+			if h != nil && h.cfg != nil && h.cfg.Gateway.ImageStreamKeepaliveInterval > 0 {
+				keepaliveInterval = time.Duration(h.cfg.Gateway.ImageStreamKeepaliveInterval) * time.Second
+			}
+			if stop, started := startOpenAIImagesStreamPrimer(c, &streamStarted, keepaliveInterval); started {
+				stopImageStreamPrimer = stop
+				service.BindOpenAIImagesStreamPrimerStopper(c, stop)
+				defer stopImageStreamPrimer()
+			}
+		}
 		forwardStart := time.Now()
 		result, err := h.gatewayService.ForwardImages(c.Request.Context(), c, account, body, parsed, channelMapping.MappedModel)
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
@@ -240,6 +257,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 					failedAccountIDs[account.ID] = struct{}{}
 					lastFailoverErr = failoverErr
 					if switchCount >= maxAccountSwitches {
+						stopOpenAIImagesStreamPrimerForHandlerError(c, stopImageStreamPrimer)
 						h.handleFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}
@@ -253,6 +271,15 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 					continue
 				}
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
+				if streamStarted && c.Writer.Written() {
+					wroteFallback := shouldWriteOpenAIImagesStreamPrimerForwardError(c) && handleOpenAIImagesStreamPrimerForwardError(c, stopImageStreamPrimer)
+					reqLog.Warn("openai.images.forward_failed",
+						zap.Int64("account_id", account.ID),
+						zap.Bool("fallback_error_response_written", wroteFallback),
+						zap.Error(err),
+					)
+					return
+				}
 				wroteFallback := h.ensureForwardErrorResponse(c, streamStarted)
 				fields := []zap.Field{
 					zap.Int64("account_id", account.ID),
@@ -321,6 +348,103 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		)
 		return
 	}
+}
+
+func startOpenAIImagesStreamPrimer(c *gin.Context, streamStarted *bool, keepaliveInterval time.Duration) (func(), bool) {
+	if c == nil || c.Writer == nil || streamStarted == nil || *streamStarted {
+		return nil, false
+	}
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return nil, false
+	}
+
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Writer.WriteHeader(http.StatusOK)
+	*streamStarted = true
+
+	if _, err := io.WriteString(c.Writer, ":\n\n"); err != nil {
+		flusher.Flush()
+		return func() {}, true
+	}
+	flusher.Flush()
+
+	if keepaliveInterval <= 0 {
+		return func() {}, true
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(keepaliveInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if _, err := io.WriteString(c.Writer, ":\n\n"); err != nil {
+					return
+				}
+				flusher.Flush()
+			case <-stop:
+				return
+			case <-c.Request.Context().Done():
+				return
+			}
+		}
+	}()
+
+	return func() {
+		select {
+		case <-stopped:
+			return
+		default:
+			close(stopped)
+			close(stop)
+			<-done
+		}
+	}, true
+}
+
+func handleOpenAIImagesStreamPrimerForwardError(c *gin.Context, stop func()) bool {
+	if c == nil || c.Writer == nil || !c.Writer.Written() {
+		return false
+	}
+	if stop != nil {
+		stop()
+	}
+	service.StopOpenAIImagesStreamPrimer(c)
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return false
+	}
+	errorEvent := "event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"upstream_error\",\"message\":\"Upstream request failed\"}}\n\n"
+	if _, err := io.WriteString(c.Writer, errorEvent); err != nil {
+		_ = c.Error(err)
+		return false
+	}
+	flusher.Flush()
+	service.MarkOpenAIImagesStreamResponseWritten(c)
+	return true
+}
+
+func shouldWriteOpenAIImagesStreamPrimerForwardError(c *gin.Context) bool {
+	if c == nil || c.Writer == nil || !c.Writer.Written() {
+		return false
+	}
+	return !service.HasOpenAIImagesStreamResponseWritten(c)
+}
+
+func stopOpenAIImagesStreamPrimerForHandlerError(c *gin.Context, stop func()) {
+	if stop != nil {
+		stop()
+	}
+	service.StopOpenAIImagesStreamPrimer(c)
 }
 
 func isMultipartImagesContentType(contentType string) bool {

--- a/backend/internal/handler/openai_images_stream_primer_test.go
+++ b/backend/internal/handler/openai_images_stream_primer_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIImagesStreamPrimerWritesInitialComment(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"stream":true}`))
+
+	streamStarted := false
+	stop, started := startOpenAIImagesStreamPrimer(c, &streamStarted, 10*time.Second)
+	require.True(t, started)
+	require.True(t, streamStarted)
+	require.NotNil(t, stop)
+	stop()
+	stop()
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "text/event-stream", w.Header().Get("Content-Type"))
+	require.Equal(t, "no-cache", w.Header().Get("Cache-Control"))
+	require.Equal(t, "keep-alive", w.Header().Get("Connection"))
+	require.Equal(t, "no", w.Header().Get("X-Accel-Buffering"))
+	require.Contains(t, w.Body.String(), ":\n\n")
+}
+
+func TestOpenAIImagesStreamPrimerNoopsWhenAlreadyStarted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	streamStarted := true
+	stop, started := startOpenAIImagesStreamPrimer(c, &streamStarted, 10*time.Second)
+	require.False(t, started)
+	require.Nil(t, stop)
+	require.Empty(t, w.Body.String())
+}
+
+func TestOpenAIImagesStreamPrimerWritesPeriodicComments(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	streamStarted := false
+	stop, started := startOpenAIImagesStreamPrimer(c, &streamStarted, 10*time.Millisecond)
+	require.True(t, started)
+	require.NotNil(t, stop)
+	require.Eventually(t, func() bool {
+		return strings.Count(w.Body.String(), ":\n\n") >= 2
+	}, 200*time.Millisecond, 10*time.Millisecond)
+	stop()
+	stop()
+}
+
+func TestHandleOpenAIImagesStreamPrimerForwardErrorWritesSSEErrorAndStops(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	c.Writer.WriteHeader(http.StatusOK)
+	_, _ = c.Writer.Write([]byte(":\n\n"))
+
+	stopCalls := 0
+	wrote := handleOpenAIImagesStreamPrimerForwardError(c, func() { stopCalls++ })
+
+	require.True(t, wrote)
+	require.Equal(t, 1, stopCalls)
+	require.Contains(t, w.Body.String(), "event: error")
+	require.Contains(t, w.Body.String(), "Upstream request failed")
+}
+
+func TestShouldWriteOpenAIImagesStreamPrimerForwardErrorIgnoresPrimerComments(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	streamStarted := false
+	stop, started := startOpenAIImagesStreamPrimer(c, &streamStarted, 10*time.Millisecond)
+	require.True(t, started)
+	t.Cleanup(stop)
+
+	require.Eventually(t, func() bool {
+		return strings.Count(w.Body.String(), ":\n\n") >= 2
+	}, 200*time.Millisecond, 10*time.Millisecond)
+	require.True(t, shouldWriteOpenAIImagesStreamPrimerForwardError(c))
+
+	service.MarkOpenAIImagesStreamResponseWritten(c)
+	require.False(t, shouldWriteOpenAIImagesStreamPrimerForwardError(c))
+}

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -582,6 +582,61 @@ func classifyUnknownOpenAIImageSizeTier(width int, height int) string {
 	return "2K"
 }
 
+const (
+	openAIImagesStreamPrimerStopperKey = "openai_images_stream_primer_stopper"
+	openAIImagesStreamWrittenKey       = "openai_images_stream_written"
+)
+
+// BindOpenAIImagesStreamPrimerStopper registers a handler-owned stream primer
+// stopper. ForwardImages stops it immediately before service code writes to the
+// downstream response, so the primer cannot race with upstream forwarding.
+func BindOpenAIImagesStreamPrimerStopper(c *gin.Context, stop func()) {
+	if c == nil || stop == nil {
+		return
+	}
+	c.Set(openAIImagesStreamPrimerStopperKey, stop)
+	c.Set(openAIImagesStreamWrittenKey, false)
+}
+
+func StopOpenAIImagesStreamPrimer(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	value, ok := c.Get(openAIImagesStreamPrimerStopperKey)
+	if !ok {
+		return
+	}
+	stop, ok := value.(func())
+	if !ok || stop == nil {
+		return
+	}
+	c.Set(openAIImagesStreamPrimerStopperKey, func() {})
+	stop()
+}
+
+// MarkOpenAIImagesStreamResponseWritten records that service code has written
+// a downstream Images stream event/body after the handler primer. Handler-level
+// fallback errors use this marker so primer keepalive comments do not suppress
+// the final SSE error, while service-written errors are not duplicated.
+func MarkOpenAIImagesStreamResponseWritten(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(openAIImagesStreamWrittenKey, true)
+}
+
+func HasOpenAIImagesStreamResponseWritten(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	value, ok := c.Get(openAIImagesStreamWrittenKey)
+	if !ok {
+		return false
+	}
+	written, ok := value.(bool)
+	return ok && written
+}
+
 func (s *OpenAIGatewayService) ForwardImages(
 	ctx context.Context,
 	c *gin.Context,
@@ -672,6 +727,9 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 		})
 		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
 	}
+	if resp.StatusCode < 400 {
+		StopOpenAIImagesStreamPrimer(c)
+	}
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 		_ = resp.Body.Close()
@@ -695,6 +753,10 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 				ResponseBody:           respBody,
 				RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
 			}
+		}
+		StopOpenAIImagesStreamPrimer(c)
+		if parsed.Stream && c.Writer.Written() {
+			return nil, s.writeOpenAIImagesStreamError(c, upstreamMsg)
 		}
 		return s.handleErrorResponse(upstreamCtx, resp, c, account, forwardBody)
 	}
@@ -726,6 +788,9 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 		imageCount = streamCount
 		firstTokenMs = ttft
 	} else {
+		if parsed.Stream && c.Writer.Written() {
+			return nil, s.writeOpenAIImagesStreamError(c, "upstream image stream did not return text/event-stream")
+		}
 		nonStreamUsage, nonStreamCount, err := s.handleOpenAIImagesNonStreamingResponse(resp, c)
 		if err != nil {
 			return nil, err
@@ -905,6 +970,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponse(resp *http
 		}
 	}
 	c.Data(resp.StatusCode, contentType, body)
+	MarkOpenAIImagesStreamResponseWritten(c)
 
 	usage, _ := extractOpenAIUsageFromJSONBytes(body)
 	return usage, extractOpenAIImageCountFromJSONBytes(body), nil
@@ -920,8 +986,17 @@ func (s *OpenAIGatewayService) handleOpenAIImagesStreamingResponse(
 	if contentType == "" {
 		contentType = "text/event-stream"
 	}
-	c.Status(resp.StatusCode)
+	if !c.Writer.Written() {
+		c.Status(resp.StatusCode)
+	}
 	c.Header("Content-Type", contentType)
+	if c.Writer.Header().Get("Cache-Control") == "" {
+		c.Header("Cache-Control", "no-cache")
+	}
+	if c.Writer.Header().Get("Connection") == "" {
+		c.Header("Connection", "keep-alive")
+	}
+	c.Header("X-Accel-Buffering", "no")
 
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
@@ -965,6 +1040,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesStreamingResponse(
 				clientDisconnected = true
 				logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Images stream client disconnected, continue draining upstream for billing")
 			} else {
+				MarkOpenAIImagesStreamResponseWritten(c)
 				flusher.Flush()
 				lastDownstreamWriteAt = time.Now()
 			}
@@ -1098,6 +1174,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesStreamingResponse(
 				return usage, imageCounter.Count(), firstTokenMs, fmt.Errorf("image stream incomplete after timeout")
 			}
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Images stream data interval timeout: interval=%s", streamInterval)
+			MarkOpenAIImagesStreamResponseWritten(c)
 			_ = s.writeOpenAIImagesStreamEvent(c, flusher, "error", buildOpenAIImagesStreamErrorBody(fmt.Sprintf("upstream image stream idle for %s", streamInterval)))
 			return usage, imageCounter.Count(), firstTokenMs, fmt.Errorf("image stream data interval timeout")
 		case <-keepaliveCh:

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -505,6 +505,18 @@ func buildOpenAIImagesStreamErrorBody(message string) []byte {
 	return body
 }
 
+func (s *OpenAIGatewayService) writeOpenAIImagesStreamError(c *gin.Context, message string) error {
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return fmt.Errorf("streaming is not supported by response writer")
+	}
+	if strings.TrimSpace(message) == "" {
+		message = "upstream request failed"
+	}
+	_ = s.writeOpenAIImagesStreamEvent(c, flusher, "error", buildOpenAIImagesStreamErrorBody(message))
+	return fmt.Errorf("upstream image stream error: %s", message)
+}
+
 func (s *OpenAIGatewayService) writeOpenAIImagesStreamEvent(c *gin.Context, flusher http.Flusher, eventName string, payload []byte) error {
 	if strings.TrimSpace(eventName) != "" {
 		if _, err := fmt.Fprintf(c.Writer, "event: %s\n", eventName); err != nil {
@@ -514,6 +526,7 @@ func (s *OpenAIGatewayService) writeOpenAIImagesStreamEvent(c *gin.Context, flus
 	if _, err := fmt.Fprintf(c.Writer, "data: %s\n\n", payload); err != nil {
 		return err
 	}
+	MarkOpenAIImagesStreamResponseWritten(c)
 	flusher.Flush()
 	return nil
 }
@@ -574,6 +587,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	}
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
+	MarkOpenAIImagesStreamResponseWritten(c)
 	return usage, len(results), nil
 }
 
@@ -589,7 +603,10 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Status(resp.StatusCode)
+	c.Header("X-Accel-Buffering", "no")
+	if !c.Writer.Written() {
+		c.Status(resp.StatusCode)
+	}
 
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
@@ -990,6 +1007,9 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 		})
 		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
 	}
+	if resp.StatusCode < 400 {
+		StopOpenAIImagesStreamPrimer(c)
+	}
 	if resp.StatusCode >= 400 {
 		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 		_ = resp.Body.Close()
@@ -1013,6 +1033,10 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 				ResponseBody:           respBody,
 				RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
 			}
+		}
+		StopOpenAIImagesStreamPrimer(c)
+		if parsed.Stream && c.Writer.Written() {
+			return nil, s.writeOpenAIImagesStreamError(c, upstreamMsg)
 		}
 		return s.handleErrorResponse(upstreamCtx, resp, c, account, responsesBody)
 	}

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -649,6 +649,87 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyStreamJSONResponseBillsImage(t 
 	require.Equal(t, "aGVsbG8=", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
 }
 
+func TestOpenAIGatewayServiceForwardImages_APIKeyStreamJSONAfterPrimerWritesSSEError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"b64_json"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	c.Header("Content-Type", "text/event-stream")
+	c.Writer.WriteHeader(http.StatusOK)
+	_, _ = c.Writer.Write([]byte(":\n\n"))
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{},
+		httpUpstream: &httpUpstreamRecorder{
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"created":1710000008,"data":[{"b64_json":"aGVsbG8="}]}`)),
+			},
+		},
+	}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	account := &Account{
+		ID:          8,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "test-api-key"},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, rec.Body.String(), "event: error")
+	require.NotContains(t, rec.Body.String(), `"data":[{"b64_json"`)
+}
+
+func TestOpenAIGatewayServiceForwardImages_APIKeyStreamHTTPErrorAfterPrimerWritesSSEError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"b64_json"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	c.Header("Content-Type", "text/event-stream")
+	c.Writer.WriteHeader(http.StatusOK)
+	_, _ = c.Writer.Write([]byte(":\n\n"))
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{},
+		httpUpstream: &httpUpstreamRecorder{
+			resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad image request"}}`)),
+			},
+		},
+	}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	account := &Account{
+		ID:          9,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "test-api-key"},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, rec.Body.String(), "event: error")
+	require.Contains(t, rec.Body.String(), "bad image request")
+	require.NotContains(t, rec.Body.String(), `{"error":{"message":"bad image request"}}`)
+}
+
 func TestOpenAIGatewayServiceForwardImages_APIKeyStreamRawJSONEventStreamFallbackBillsImage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"b64_json"}`)
@@ -738,6 +819,8 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyStreamMultilineSSEDataBillsImag
 		},
 	}
 
+	stopCalls := 0
+	BindOpenAIImagesStreamPrimerStopper(c, func() { stopCalls++ })
 	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -746,6 +829,8 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyStreamMultilineSSEDataBillsImag
 	require.Equal(t, 10, result.Usage.InputTokens)
 	require.Equal(t, 18, result.Usage.OutputTokens)
 	require.Equal(t, 8, result.Usage.ImageOutputTokens)
+	require.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"))
+	require.Equal(t, 1, stopCalls)
 }
 
 func TestExtractOpenAIImagesBillableCountFromJSONBytes_CompletedEvent(t *testing.T) {
@@ -858,6 +943,8 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingTransformsEvents(t *tes
 		},
 	}
 
+	stopCalls := 0
+	BindOpenAIImagesStreamPrimerStopper(c, func() { stopCalls++ })
 	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -888,7 +975,51 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingTransformsEvents(t *tes
 	require.Equal(t, "1024x1024", gjson.Get(completed.Data, "size").String())
 	require.Equal(t, "auto", gjson.Get(completed.Data, "background").String())
 	require.JSONEq(t, `{"images":1}`, gjson.Get(completed.Data, "usage").Raw)
+	require.Equal(t, "no", rec.Header().Get("X-Accel-Buffering"))
+
+	require.Equal(t, 1, stopCalls)
 	require.False(t, gjson.Get(completed.Data, "revised_prompt").Exists())
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthStreamHTTPErrorAfterPrimerWritesSSEError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"url"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	c.Header("Content-Type", "text/event-stream")
+	c.Writer.WriteHeader(http.StatusOK)
+	_, _ = c.Writer.Write([]byte(":\n\n"))
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+	svc.httpUpstream = &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"bad responses image request"}}`)),
+		},
+	}
+	account := &Account{
+		ID:       3,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Contains(t, rec.Body.String(), "event: error")
+	require.Contains(t, rec.Body.String(), "bad responses image request")
+	require.NotContains(t, rec.Body.String(), `{"error":{"message":"bad responses image request"}}`)
 }
 
 func TestOpenAIGatewayServiceForwardImages_APIKeyStreamingDrainsAfterClientDisconnect(t *testing.T) {


### PR DESCRIPTION
## Summary

- Prime OpenAI Images `stream=true` responses after local validation/routing and before waiting for the upstream response header.
- Send an initial SSE comment and pre-upstream keepalive comments using `gateway.image_stream_keepalive_interval`.
- Stop the primer before service-level response writes, and use SSE error events for post-primer upstream errors/fallbacks.

## Motivation

Images stream requests can spend a long time waiting for the upstream response header before any downstream byte is written. Reverse proxies/CDNs with first-byte or idle timeouts may close the client connection before the existing stream keepalive loop starts.

This change moves the downstream SSE opening point earlier for Images `stream=true` requests without changing non-streaming behavior.

## Behavior

- `stream=false` is unchanged.
- `stream=true` Images requests receive SSE headers and an initial `:` comment before upstream headers arrive.
- Once the SSE response has been opened, later upstream HTTP errors or non-SSE fallbacks are written as SSE `event: error` events instead of JSON responses.
- The primer is stopped before service forwarding writes to the same response writer.

## Tests

- `C:/Users/34404/Documents/GitHub/workbench/toolchains/go/bin/go.exe test -tags unit ./internal/handler ./internal/service -run 'TestOpenAIImagesStreamPrimer|TestHandleOpenAIImagesStreamPrimerForwardError|TestShouldWriteOpenAIImagesStreamPrimerForwardErrorIgnoresPrimerComments|TestOpenAIGatewayServiceForwardImages_(APIKeyStream|OAuthStreaming|APIKeyStreamJSONAfterPrimer|APIKeyStreamHTTPErrorAfterPrimer|OAuthStreamHTTPErrorAfterPrimer)' -count=1 -timeout=120s`
- `C:/Users/34404/Documents/GitHub/workbench/toolchains/go/bin/go.exe test -tags unit ./internal/handler ./internal/service -count=1 -timeout=180s`
- `git diff --check origin/main...HEAD`

Refs #2031