### PR TITLE
feat(account): add streaming batch account connectivity test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+.gitattributes text eol=lf
+deploy/.env.example text eol=lf
+
 # 确保所有 SQL 迁移文件使用 LF 换行符
 backend/migrations/*.sql text eol=lf
 

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -19,6 +19,13 @@ const (
 	RunModeSimple   = "simple"
 )
 
+const (
+	BatchAccountTestDefaultConcurrency       = 5
+	BatchAccountTestMaxConcurrency           = 10
+	BatchAccountTestMaxAccounts              = 500
+	BatchAccountTestPerAccountTimeoutSeconds = 30
+)
+
 // 使用量记录队列溢出策略
 const (
 	UsageRecordOverflowPolicyDrop   = "drop"
@@ -75,6 +82,7 @@ type Config struct {
 	GitHubOAuth             EmailOAuthProviderConfig      `mapstructure:"github_oauth"`
 	GoogleOAuth             EmailOAuthProviderConfig      `mapstructure:"google_oauth"`
 	Default                 DefaultConfig                 `mapstructure:"default"`
+	BatchAccountTest        BatchAccountTestConfig        `mapstructure:"batch_account_test"`
 	RateLimit               RateLimitConfig               `mapstructure:"rate_limit"`
 	Pricing                 PricingConfig                 `mapstructure:"pricing"`
 	Gateway                 GatewayConfig                 `mapstructure:"gateway"`
@@ -1134,6 +1142,22 @@ type DefaultConfig struct {
 	RateMultiplier  float64 `mapstructure:"rate_multiplier"`
 }
 
+type BatchAccountTestConfig struct {
+	DefaultConcurrency       int `mapstructure:"default_concurrency"`
+	MaxConcurrency           int `mapstructure:"max_concurrency"`
+	MaxAccounts              int `mapstructure:"max_accounts"`
+	PerAccountTimeoutSeconds int `mapstructure:"per_account_timeout_seconds"`
+}
+
+func DefaultBatchAccountTestConfig() BatchAccountTestConfig {
+	return BatchAccountTestConfig{
+		DefaultConcurrency:       BatchAccountTestDefaultConcurrency,
+		MaxConcurrency:           BatchAccountTestMaxConcurrency,
+		MaxAccounts:              BatchAccountTestMaxAccounts,
+		PerAccountTimeoutSeconds: BatchAccountTestPerAccountTimeoutSeconds,
+	}
+}
+
 type RateLimitConfig struct {
 	OverloadCooldownMinutes int `mapstructure:"overload_cooldown_minutes"`  // 529过载冷却时间(分钟)
 	OAuth401CooldownMinutes int `mapstructure:"oauth_401_cooldown_minutes"` // OAuth 401临时不可调度冷却(分钟)
@@ -1594,6 +1618,12 @@ func setDefaults() {
 	viper.SetDefault("default.api_key_prefix", "sk-")
 	viper.SetDefault("default.rate_multiplier", 1.0)
 
+	// Batch account test
+	viper.SetDefault("batch_account_test.default_concurrency", BatchAccountTestDefaultConcurrency)
+	viper.SetDefault("batch_account_test.max_concurrency", BatchAccountTestMaxConcurrency)
+	viper.SetDefault("batch_account_test.max_accounts", BatchAccountTestMaxAccounts)
+	viper.SetDefault("batch_account_test.per_account_timeout_seconds", BatchAccountTestPerAccountTimeoutSeconds)
+
 	// RateLimit
 	viper.SetDefault("rate_limit.overload_cooldown_minutes", 10)
 	viper.SetDefault("rate_limit.oauth_401_cooldown_minutes", 10)
@@ -1871,6 +1901,21 @@ func (c *Config) Validate() error {
 	}
 	if c.SubscriptionMaintenance.QueueSize < 0 {
 		return fmt.Errorf("subscription_maintenance.queue_size must be non-negative")
+	}
+	if c.BatchAccountTest.DefaultConcurrency <= 0 {
+		return fmt.Errorf("batch_account_test.default_concurrency must be positive")
+	}
+	if c.BatchAccountTest.MaxConcurrency <= 0 {
+		return fmt.Errorf("batch_account_test.max_concurrency must be positive")
+	}
+	if c.BatchAccountTest.MaxConcurrency < c.BatchAccountTest.DefaultConcurrency {
+		return fmt.Errorf("batch_account_test.max_concurrency must be >= default_concurrency")
+	}
+	if c.BatchAccountTest.MaxAccounts <= 0 {
+		return fmt.Errorf("batch_account_test.max_accounts must be positive")
+	}
+	if c.BatchAccountTest.PerAccountTimeoutSeconds <= 0 {
+		return fmt.Errorf("batch_account_test.per_account_timeout_seconds must be positive")
 	}
 
 	// Gemini OAuth 配置校验：client_id 与 client_secret 必须同时设置或同时留空。

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -666,6 +666,56 @@ func TestLoadDefaultUsageCleanupConfig(t *testing.T) {
 	}
 }
 
+func TestLoadDefaultBatchAccountTestConfig(t *testing.T) {
+	resetViperWithJWTSecret(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.BatchAccountTest.DefaultConcurrency != BatchAccountTestDefaultConcurrency {
+		t.Fatalf("BatchAccountTest.DefaultConcurrency = %d, want %d", cfg.BatchAccountTest.DefaultConcurrency, BatchAccountTestDefaultConcurrency)
+	}
+	if cfg.BatchAccountTest.MaxConcurrency != BatchAccountTestMaxConcurrency {
+		t.Fatalf("BatchAccountTest.MaxConcurrency = %d, want %d", cfg.BatchAccountTest.MaxConcurrency, BatchAccountTestMaxConcurrency)
+	}
+	if cfg.BatchAccountTest.MaxAccounts != BatchAccountTestMaxAccounts {
+		t.Fatalf("BatchAccountTest.MaxAccounts = %d, want %d", cfg.BatchAccountTest.MaxAccounts, BatchAccountTestMaxAccounts)
+	}
+	if cfg.BatchAccountTest.PerAccountTimeoutSeconds != BatchAccountTestPerAccountTimeoutSeconds {
+		t.Fatalf("BatchAccountTest.PerAccountTimeoutSeconds = %d, want %d", cfg.BatchAccountTest.PerAccountTimeoutSeconds, BatchAccountTestPerAccountTimeoutSeconds)
+	}
+}
+
+func TestValidateBatchAccountTestConfig(t *testing.T) {
+	resetViperWithJWTSecret(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	cfg.BatchAccountTest.MaxConcurrency = cfg.BatchAccountTest.DefaultConcurrency - 1
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatalf("Validate() expected error for batch_account_test.max_concurrency, got nil")
+	}
+	if !strings.Contains(err.Error(), "batch_account_test.max_concurrency") {
+		t.Fatalf("Validate() expected max_concurrency error, got: %v", err)
+	}
+
+	cfg.BatchAccountTest.MaxConcurrency = cfg.BatchAccountTest.DefaultConcurrency
+	cfg.BatchAccountTest.PerAccountTimeoutSeconds = 0
+	err = cfg.Validate()
+	if err == nil {
+		t.Fatalf("Validate() expected error for batch_account_test.per_account_timeout_seconds, got nil")
+	}
+	if !strings.Contains(err.Error(), "batch_account_test.per_account_timeout_seconds") {
+		t.Fatalf("Validate() expected per_account_timeout_seconds error, got: %v", err)
+	}
+}
+
 func TestValidateUsageCleanupConfigEnabled(t *testing.T) {
 	resetViperWithJWTSecret(t)
 

--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -703,6 +703,27 @@ type TestAccountRequest struct {
 	Mode    string `json:"mode"`
 }
 
+const (
+	batchAccountTestStreamEventStart    = "start"
+	batchAccountTestStreamEventResult   = "result"
+	batchAccountTestStreamEventComplete = "complete"
+	batchAccountTestStreamEventError    = "error"
+)
+
+type BatchAccountTestStreamEvent struct {
+	Type           string                           `json:"type"`
+	Total          int                              `json:"total,omitempty"`
+	Completed      int                              `json:"completed,omitempty"`
+	Success        int                              `json:"success,omitempty"`
+	Failed         int                              `json:"failed,omitempty"`
+	Unauthorized   int                              `json:"unauthorized,omitempty"`
+	Concurrency    int                              `json:"concurrency,omitempty"`
+	TimeoutSeconds int                              `json:"timeout_seconds,omitempty"`
+	Result         *service.BatchAccountTestResult  `json:"result,omitempty"`
+	Results        []service.BatchAccountTestResult `json:"results,omitempty"`
+	Message        string                           `json:"message,omitempty"`
+}
+
 type SyncFromCRSRequest struct {
 	BaseURL            string   `json:"base_url" binding:"required"`
 	Username           string   `json:"username" binding:"required"`
@@ -741,6 +762,95 @@ func (h *AccountHandler) Test(c *gin.Context) {
 			_ = c.Error(err)
 		}
 	}
+}
+
+// BatchAccountTestStream streams batch account test progress.
+// POST /api/v1/admin/accounts/batch-account-test/stream
+func (h *AccountHandler) BatchAccountTestStream(c *gin.Context) {
+	var req service.BatchAccountTestRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	if len(req.AccountIDs) == 0 {
+		response.BadRequest(c, "account_ids is required")
+		return
+	}
+	if h.accountTestService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "Account test service unavailable")
+		return
+	}
+	batchTestConfig := h.accountTestService.BatchAccountTestConfig()
+	if len(req.AccountIDs) > batchTestConfig.MaxAccounts {
+		response.BadRequest(c, fmt.Sprintf("account_ids cannot exceed %d", batchTestConfig.MaxAccounts))
+		return
+	}
+
+	concurrency := service.ResolveBatchAccountTestConcurrency(req.Concurrency, len(req.AccountIDs), batchTestConfig)
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.Flush()
+
+	h.sendBatchAccountTestStreamEvent(c, BatchAccountTestStreamEvent{
+		Type:           batchAccountTestStreamEventStart,
+		Total:          len(req.AccountIDs),
+		Concurrency:    concurrency,
+		TimeoutSeconds: batchTestConfig.PerAccountTimeoutSeconds,
+	})
+
+	var streamMu sync.Mutex
+	results, progress, err := h.accountTestService.RunBatchAccountTest(c.Request.Context(), req, func(result service.BatchAccountTestResult, progress service.BatchAccountTestProgress) {
+		if result.Success && h.rateLimitService != nil {
+			if _, err := h.rateLimitService.RecoverAccountAfterSuccessfulTest(c.Request.Context(), result.AccountID); err != nil {
+				log.Printf("[WARN] Failed to recover account %d after batch test: %v", result.AccountID, err)
+			}
+		}
+
+		streamMu.Lock()
+		defer streamMu.Unlock()
+		h.sendBatchAccountTestStreamEvent(c, BatchAccountTestStreamEvent{
+			Type:         batchAccountTestStreamEventResult,
+			Total:        len(req.AccountIDs),
+			Completed:    progress.Completed,
+			Success:      progress.Success,
+			Failed:       progress.Failed,
+			Unauthorized: progress.Unauthorized,
+			Result:       &result,
+		})
+	})
+	if err != nil {
+		streamMu.Lock()
+		defer streamMu.Unlock()
+		h.sendBatchAccountTestStreamEvent(c, BatchAccountTestStreamEvent{
+			Type:    batchAccountTestStreamEventError,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	streamMu.Lock()
+	defer streamMu.Unlock()
+	h.sendBatchAccountTestStreamEvent(c, BatchAccountTestStreamEvent{
+		Type:         batchAccountTestStreamEventComplete,
+		Total:        len(results),
+		Completed:    progress.Completed,
+		Success:      progress.Success,
+		Failed:       progress.Failed,
+		Unauthorized: progress.Unauthorized,
+		Results:      results,
+	})
+}
+
+func (h *AccountHandler) sendBatchAccountTestStreamEvent(c *gin.Context, event BatchAccountTestStreamEvent) {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		log.Printf("[WARN] Failed to marshal batch test stream event: %v", err)
+		return
+	}
+	fmt.Fprintf(c.Writer, "data: %s\n\n", payload)
+	c.Writer.Flush()
 }
 
 // RecoverState handles unified recovery of recoverable account runtime state.

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -311,6 +311,7 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		accounts.POST("/bulk-update", h.Admin.Account.BulkUpdate)
 		accounts.POST("/batch-clear-error", h.Admin.Account.BatchClearError)
 		accounts.POST("/batch-refresh", h.Admin.Account.BatchRefresh)
+		accounts.POST("/batch-account-test/stream", h.Admin.Account.BatchAccountTestStream)
 
 		// Antigravity 默认模型映射
 		accounts.GET("/antigravity/default-model-mapping", h.Admin.Account.GetAntigravityDefaultModelMapping)

--- a/backend/internal/service/account_batch_test_test.go
+++ b/backend/internal/service/account_batch_test_test.go
@@ -1,0 +1,66 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBatchAccountTestConcurrencyUsesConfig(t *testing.T) {
+	cfg := config.BatchAccountTestConfig{
+		DefaultConcurrency:       2,
+		MaxConcurrency:           3,
+		MaxAccounts:              500,
+		PerAccountTimeoutSeconds: 30,
+	}
+
+	require.Equal(t, 2, ResolveBatchAccountTestConcurrency(0, 5, cfg))
+	require.Equal(t, 3, ResolveBatchAccountTestConcurrency(10, 5, cfg))
+	require.Equal(t, 1, ResolveBatchAccountTestConcurrency(10, 1, cfg))
+}
+
+func TestBatchAccountTestProgressCountsUnauthorizedByHTTPStatus(t *testing.T) {
+	var progress BatchAccountTestProgress
+	resultItem := BatchAccountTestResult{
+		AccountID:    1,
+		Status:       batchAccountTestStatusFailed,
+		ErrorMessage: "body mentions 401 but status is forbidden",
+		HTTPStatus:   http.StatusForbidden,
+	}
+
+	updateBatchAccountTestProgress(&progress, resultItem)
+	require.Equal(t, 1, progress.Failed)
+	require.Equal(t, 0, progress.Unauthorized)
+
+	resultItem.HTTPStatus = http.StatusUnauthorized
+	updateBatchAccountTestProgress(&progress, resultItem)
+	require.Equal(t, 2, progress.Failed)
+	require.Equal(t, 1, progress.Unauthorized)
+}
+
+func TestRunTestBackgroundCapturesHTTPStatusInternally(t *testing.T) {
+	recorderErr := &accountTestHTTPStatusError{
+		statusCode: http.StatusUnauthorized,
+		message:    "API returned 401",
+	}
+
+	var httpStatusErr *accountTestHTTPStatusError
+	require.ErrorAs(t, recorderErr, &httpStatusErr)
+	require.Equal(t, http.StatusUnauthorized, httpStatusErr.statusCode)
+}
+
+func TestAntigravityTestConnectionHTTPStatusError(t *testing.T) {
+	recorderErr := &antigravityTestConnectionHTTPStatusError{
+		statusCode: http.StatusUnauthorized,
+		message:    "API returned 401",
+	}
+
+	var httpStatusErr *antigravityTestConnectionHTTPStatusError
+	require.True(t, errors.As(recorderErr, &httpStatusErr))
+	require.Equal(t, http.StatusUnauthorized, httpStatusErr.statusCode)
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -25,6 +26,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
 )
 
 // sseDataPrefix matches SSE data lines with optional whitespace after colon.
@@ -55,6 +57,51 @@ const (
 	defaultGeminiImageTestPrompt = "Generate a cute orange cat astronaut sticker on a clean pastel background."
 	defaultOpenAIImageTestPrompt = "Generate a cute orange cat astronaut sticker on a clean pastel background."
 )
+
+const (
+	batchAccountTestStatusSuccess = "success"
+	batchAccountTestStatusFailed  = "failed"
+)
+
+// BatchAccountTestRequest describes a batch connectivity test request.
+type BatchAccountTestRequest struct {
+	AccountIDs  []int64 `json:"account_ids"`
+	ModelID     string  `json:"model_id"`
+	Concurrency int     `json:"concurrency"`
+}
+
+// BatchAccountTestResult is the per-account result for a batch test.
+type BatchAccountTestResult struct {
+	AccountID    int64  `json:"account_id"`
+	Success      bool   `json:"success"`
+	Status       string `json:"status"`
+	LatencyMs    int64  `json:"latency_ms"`
+	ErrorMessage string `json:"error_message,omitempty"`
+	ResponseText string `json:"response_text,omitempty"`
+	HTTPStatus   int    `json:"-"`
+}
+
+// BatchAccountTestProgress tracks batch test completion counts.
+type BatchAccountTestProgress struct {
+	Completed    int
+	Success      int
+	Failed       int
+	Unauthorized int
+}
+
+type accountTestHTTPStatusError struct {
+	statusCode int
+	message    string
+}
+
+func (e *accountTestHTTPStatusError) Error() string {
+	return e.message
+}
+
+type accountTestBackgroundResult struct {
+	result     *ScheduledTestResult
+	httpStatus int
+}
 
 // isOpenAIImageModel checks if the model is an OpenAI image generation model (e.g. gpt-image-2).
 func isOpenAIImageModel(model string) bool {
@@ -313,7 +360,7 @@ func (s *AccountTestService) testClaudeAccountConnection(c *gin.Context, account
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
 		}
 
-		return s.sendErrorAndEnd(c, errMsg)
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, errMsg)
 	}
 
 	// Process SSE stream
@@ -382,7 +429,7 @@ func (s *AccountTestService) testClaudeVertexServiceAccountConnection(c *gin.Con
 		if resp.StatusCode == http.StatusForbidden {
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
 		}
-		return s.sendErrorAndEnd(c, errMsg)
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, errMsg)
 	}
 
 	return s.processClaudeStream(c, resp.Body)
@@ -465,7 +512,7 @@ func (s *AccountTestService) testBedrockAccountConnection(c *gin.Context, ctx co
 	body, _ := io.ReadAll(resp.Body)
 
 	if resp.StatusCode != http.StatusOK {
-		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
 	// Bedrock non-streaming response is standard Claude JSON, extract the text
@@ -630,7 +677,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 			errMsg := fmt.Sprintf("Authentication failed (401): %s", string(body))
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
 		}
-		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
 	// Process SSE stream
@@ -744,7 +791,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 			errMsg := fmt.Sprintf("Authentication failed (401): %s", string(body))
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
 		}
-		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
 	s.sendEvent(c, TestEvent{Type: "content", Text: "Compact probe succeeded"})
@@ -851,7 +898,7 @@ func (s *AccountTestService) testGeminiAccountConnection(c *gin.Context, account
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
 	// Process SSE stream
@@ -898,6 +945,10 @@ func (s *AccountTestService) testAntigravityAccountConnection(c *gin.Context, ac
 	// 调用 AntigravityGatewayService.TestConnection（复用协议转换逻辑）
 	result, err := s.antigravityGatewayService.TestConnection(ctx, account, testModelID)
 	if err != nil {
+		var httpStatusErr *antigravityTestConnectionHTTPStatusError
+		if errors.As(err, &httpStatusErr) {
+			return s.sendHTTPStatusErrorAndEnd(c, httpStatusErr.statusCode, err.Error())
+		}
 		return s.sendErrorAndEnd(c, err.Error())
 	}
 
@@ -1377,7 +1428,7 @@ func (s *AccountTestService) testOpenAIImageAPIKey(c *gin.Context, ctx context.C
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return s.sendErrorAndEnd(c, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body)))
 	}
 
 	// Parse {"data": [{"b64_json": "...", "revised_prompt": "..."}]}
@@ -1479,7 +1530,7 @@ func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Co
 		if message == "" {
 			message = fmt.Sprintf("Responses API returned %d", resp.StatusCode)
 		}
-		return s.sendErrorAndEnd(c, message)
+		return s.sendHTTPStatusErrorAndEnd(c, resp.StatusCode, message)
 	}
 
 	body, err := io.ReadAll(resp.Body)
@@ -1527,9 +1578,26 @@ func (s *AccountTestService) sendErrorAndEnd(c *gin.Context, errorMsg string) er
 	return fmt.Errorf("%s", errorMsg)
 }
 
+func (s *AccountTestService) sendHTTPStatusErrorAndEnd(c *gin.Context, statusCode int, errorMsg string) error {
+	log.Printf("Account test error: %s", errorMsg)
+	s.sendEvent(c, TestEvent{Type: "error", Error: errorMsg})
+	return &accountTestHTTPStatusError{
+		statusCode: statusCode,
+		message:    errorMsg,
+	}
+}
+
 // RunTestBackground executes an account test in-memory (no real HTTP client),
 // capturing SSE output via httptest.NewRecorder, then parses the result.
 func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID int64, modelID string) (*ScheduledTestResult, error) {
+	backgroundResult, err := s.runTestBackground(ctx, accountID, modelID)
+	if err != nil || backgroundResult == nil {
+		return nil, err
+	}
+	return backgroundResult.result, nil
+}
+
+func (s *AccountTestService) runTestBackground(ctx context.Context, accountID int64, modelID string) (*accountTestBackgroundResult, error) {
 	startedAt := time.Now()
 
 	w := httptest.NewRecorder()
@@ -1543,21 +1611,130 @@ func (s *AccountTestService) RunTestBackground(ctx context.Context, accountID in
 	responseText, errMsg := parseTestSSEOutput(body)
 
 	status := "success"
+	httpStatus := 0
 	if testErr != nil || errMsg != "" {
 		status = "failed"
 		if errMsg == "" && testErr != nil {
 			errMsg = testErr.Error()
 		}
+		var httpStatusErr *accountTestHTTPStatusError
+		if errors.As(testErr, &httpStatusErr) {
+			httpStatus = httpStatusErr.statusCode
+		}
 	}
 
-	return &ScheduledTestResult{
-		Status:       status,
-		ResponseText: responseText,
-		ErrorMessage: errMsg,
-		LatencyMs:    finishedAt.Sub(startedAt).Milliseconds(),
-		StartedAt:    startedAt,
-		FinishedAt:   finishedAt,
+	return &accountTestBackgroundResult{
+		result: &ScheduledTestResult{
+			Status:       status,
+			ResponseText: responseText,
+			ErrorMessage: errMsg,
+			LatencyMs:    finishedAt.Sub(startedAt).Milliseconds(),
+			StartedAt:    startedAt,
+			FinishedAt:   finishedAt,
+		},
+		httpStatus: httpStatus,
 	}, nil
+}
+
+// RunBatchAccountTest runs account connectivity tests concurrently and reports progress per result.
+func (s *AccountTestService) RunBatchAccountTest(
+	ctx context.Context,
+	req BatchAccountTestRequest,
+	onResult func(BatchAccountTestResult, BatchAccountTestProgress),
+) ([]BatchAccountTestResult, BatchAccountTestProgress, error) {
+	cfg := s.batchAccountTestConfig()
+	concurrency := ResolveBatchAccountTestConcurrency(req.Concurrency, len(req.AccountIDs), cfg)
+
+	results := make([]BatchAccountTestResult, len(req.AccountIDs))
+	var progress BatchAccountTestProgress
+	var progressMu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(concurrency)
+
+	for i, id := range req.AccountIDs {
+		index := i
+		accountID := id
+		g.Go(func() error {
+			resultItem := BatchAccountTestResult{
+				AccountID: accountID,
+				Status:    batchAccountTestStatusFailed,
+			}
+
+			testCtx, cancel := context.WithTimeout(gctx, time.Duration(cfg.PerAccountTimeoutSeconds)*time.Second)
+			defer cancel()
+
+			testResult, err := s.runTestBackground(testCtx, accountID, req.ModelID)
+			if err != nil {
+				resultItem.ErrorMessage = err.Error()
+			} else if testResult == nil {
+				resultItem.ErrorMessage = "empty test result"
+			} else {
+				resultItem.Status = testResult.result.Status
+				resultItem.Success = testResult.result.Status == batchAccountTestStatusSuccess
+				resultItem.LatencyMs = testResult.result.LatencyMs
+				resultItem.ErrorMessage = testResult.result.ErrorMessage
+				resultItem.ResponseText = testResult.result.ResponseText
+				resultItem.HTTPStatus = testResult.httpStatus
+			}
+
+			results[index] = resultItem
+			progressMu.Lock()
+			updateBatchAccountTestProgress(&progress, resultItem)
+			currentProgress := progress
+			progressMu.Unlock()
+
+			if onResult != nil {
+				onResult(resultItem, currentProgress)
+			}
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, BatchAccountTestProgress{}, err
+	}
+
+	return results, progress, nil
+}
+
+func updateBatchAccountTestProgress(progress *BatchAccountTestProgress, result BatchAccountTestResult) {
+	progress.Completed++
+	if result.Success {
+		progress.Success++
+		return
+	}
+	progress.Failed++
+	if result.HTTPStatus == http.StatusUnauthorized {
+		progress.Unauthorized++
+	}
+}
+
+func (s *AccountTestService) BatchAccountTestConfig() config.BatchAccountTestConfig {
+	return s.batchAccountTestConfig()
+}
+
+func (s *AccountTestService) batchAccountTestConfig() config.BatchAccountTestConfig {
+	if s.cfg != nil {
+		return s.cfg.BatchAccountTest
+	}
+	return config.DefaultBatchAccountTestConfig()
+}
+
+// ResolveBatchAccountTestConcurrency applies the configured batch test concurrency limits.
+func ResolveBatchAccountTestConcurrency(requested int, accountCount int, cfg config.BatchAccountTestConfig) int {
+	if accountCount <= 0 {
+		return 0
+	}
+	if requested <= 0 {
+		requested = cfg.DefaultConcurrency
+	}
+	if requested > cfg.MaxConcurrency {
+		requested = cfg.MaxConcurrency
+	}
+	if requested > accountCount {
+		requested = accountCount
+	}
+	return requested
 }
 
 // parseTestSSEOutput extracts response text and error message from captured SSE output.

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -1022,6 +1022,15 @@ type TestConnectionResult struct {
 	MappedModel string // 实际使用的模型
 }
 
+type antigravityTestConnectionHTTPStatusError struct {
+	statusCode int
+	message    string
+}
+
+func (e *antigravityTestConnectionHTTPStatusError) Error() string {
+	return e.message
+}
+
 // TestConnection 测试 Antigravity 账号连接。
 // 复用 antigravityRetryLoop 的完整重试 / credits overages / 智能重试逻辑，
 // 与真实调度行为一致。差异：不做账号切换（测试指定账号）、不记录 ops 错误。
@@ -1101,7 +1110,11 @@ func (s *AntigravityGatewayService) TestConnection(ctx context.Context, account 
 	}
 
 	if result.resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("API 返回 %d: %s", result.resp.StatusCode, string(respBody))
+		message := fmt.Sprintf("API 返回 %d: %s", result.resp.StatusCode, string(respBody))
+		return nil, &antigravityTestConnectionHTTPStatusError{
+			statusCode: result.resp.StatusCode,
+			message:    message,
+		}
 	}
 
 	text := extractTextFromSSEResponse(respBody)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -387,6 +387,22 @@ GEMINI_OAUTH_SCOPES=
 GEMINI_QUOTA_POLICY=
 
 # -----------------------------------------------------------------------------
+# Batch Account Test
+# -----------------------------------------------------------------------------
+# Default worker concurrency for batch account connectivity tests
+# 批量账号连通性测试的默认并发数
+BATCH_ACCOUNT_TEST_DEFAULT_CONCURRENCY=5
+# Maximum worker concurrency allowed for one batch account test request
+# 单次批量账号测试允许的最大并发数
+BATCH_ACCOUNT_TEST_MAX_CONCURRENCY=10
+# Maximum accounts allowed in one batch account test request
+# 单次批量账号测试允许的最大账号数量
+BATCH_ACCOUNT_TEST_MAX_ACCOUNTS=500
+# Per-account timeout in seconds for batch account connectivity tests
+# 批量账号连通性测试中单个账号的超时时间（秒）
+BATCH_ACCOUNT_TEST_PER_ACCOUNT_TIMEOUT_SECONDS=30
+
+# -----------------------------------------------------------------------------
 # Ops Monitoring Configuration (运维监控配置)
 # -----------------------------------------------------------------------------
 # Enable ops monitoring features (background jobs and APIs)

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -948,6 +948,24 @@ default:
   rate_multiplier: 1.0
 
 # =============================================================================
+# Batch Account Test
+# 批量账号测试
+# =============================================================================
+batch_account_test:
+  # Default worker concurrency for batch account connectivity tests
+  # 批量账号连通性测试的默认并发数
+  default_concurrency: 5
+  # Maximum worker concurrency allowed for one batch account test request
+  # 单次批量账号测试允许的最大并发数
+  max_concurrency: 10
+  # Maximum accounts allowed in one batch account test request
+  # 单次批量账号测试允许的最大账号数量
+  max_accounts: 500
+  # Per-account timeout in seconds for batch account connectivity tests
+  # 批量账号连通性测试中单个账号的超时时间（秒）
+  per_account_timeout_seconds: 30
+
+# =============================================================================
 # Rate Limiting
 # 速率限制
 # =============================================================================

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -4,6 +4,7 @@
  */
 
 import { apiClient } from '../client'
+import { getLocale } from '@/i18n'
 import type {
   Account,
   CreateAccountRequest,
@@ -19,8 +20,11 @@ import type {
   CodexSessionImportRequest,
   CodexSessionImportResult,
   CheckMixedChannelRequest,
-  CheckMixedChannelResponse
+  CheckMixedChannelResponse,
+  BatchAccountTestStreamEvent
 } from '@/types'
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1'
 
 /**
  * List all accounts with pagination
@@ -627,6 +631,74 @@ export async function batchRefresh(accountIds: number[]): Promise<BatchOperation
   return data
 }
 
+export async function streamBatchAccountTest(
+  accountIds: number[],
+  onEvent: (event: BatchAccountTestStreamEvent) => void,
+  options?: { signal?: AbortSignal }
+): Promise<void> {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Accept-Language': getLocale()
+  }
+  const token = localStorage.getItem('auth_token')
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const response = await fetch(`${API_BASE_URL}/admin/accounts/batch-account-test/stream`, {
+    method: 'POST',
+    credentials: 'include',
+    headers,
+    signal: options?.signal,
+    body: JSON.stringify({ account_ids: accountIds })
+  })
+
+  if (!response.ok) {
+    let message = `HTTP ${response.status}`
+    try {
+      const payload = await response.json()
+      message = payload?.message || payload?.error || message
+    } catch {
+      // keep HTTP status fallback
+    }
+    throw new Error(message)
+  }
+  if (!response.body) {
+    throw new Error('Batch account test stream is unavailable')
+  }
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  const consumeChunk = (chunk: string) => {
+    buffer += chunk
+    const frames = buffer.split(/\r?\n\r?\n/)
+    buffer = frames.pop() || ''
+    for (const frame of frames) {
+      const lines = frame.split(/\r?\n/)
+      const dataLines = lines
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => line.replace(/^data:\s?/, ''))
+      if (dataLines.length === 0) continue
+      const data = dataLines.join('\n')
+      if (data === '[DONE]') continue
+      const event = JSON.parse(data) as BatchAccountTestStreamEvent
+      if (event.type === 'error') {
+        throw new Error(event.message || 'Batch account test failed')
+      }
+      onEvent(event)
+    }
+  }
+
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    consumeChunk(decoder.decode(value, { stream: true }))
+  }
+  consumeChunk(decoder.decode())
+}
+
 /**
  * Set privacy for an Antigravity OAuth account
  * @param id - Account ID
@@ -674,6 +746,7 @@ export const accountsAPI = {
   getAntigravityDefaultModelMapping,
   batchClearError,
   batchRefresh,
+  streamBatchAccountTest,
   setPrivacy
 }
 

--- a/frontend/src/components/admin/account/AccountBatchTestModal.vue
+++ b/frontend/src/components/admin/account/AccountBatchTestModal.vue
@@ -1,0 +1,138 @@
+<template>
+  <BaseDialog
+    :show="show"
+    :title="t('admin.accounts.batchTestResults.title')"
+    width="wide"
+    @close="handleClose"
+  >
+    <div v-if="result" class="space-y-4">
+      <div v-if="running" class="space-y-2">
+        <div class="flex items-center justify-between text-sm text-gray-600 dark:text-gray-300">
+          <span>{{ t('admin.accounts.bulkActions.batchTesting') }}</span>
+          <span>{{ completed }} / {{ result.total }}</span>
+        </div>
+        <div class="h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-dark-700">
+          <div class="h-full bg-primary-500 transition-all" :style="{ width: `${progressPercent}%` }"></div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 dark:border-dark-600 dark:bg-dark-700">
+          <div class="text-xs text-gray-500 dark:text-gray-400">{{ t('admin.accounts.batchTestResults.total') }}</div>
+          <div class="text-xl font-semibold text-gray-900 dark:text-gray-100">{{ result.total }}</div>
+        </div>
+        <div class="rounded-lg border border-green-200 bg-green-50 p-3 dark:border-green-800 dark:bg-green-900/20">
+          <div class="text-xs text-green-700 dark:text-green-300">{{ t('admin.accounts.batchTestResults.success') }}</div>
+          <div class="text-xl font-semibold text-green-700 dark:text-green-300">{{ result.success }}</div>
+        </div>
+        <div class="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-800 dark:bg-red-900/20">
+          <div class="text-xs text-red-700 dark:text-red-300">{{ t('admin.accounts.batchTestResults.failed') }}</div>
+          <div class="text-xl font-semibold text-red-700 dark:text-red-300">{{ result.failed }}</div>
+        </div>
+        <div class="rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
+          <div class="text-xs text-amber-700 dark:text-amber-300">{{ t('admin.accounts.batchTestResults.unauthorized') }}</div>
+          <div class="text-xl font-semibold text-amber-700 dark:text-amber-300">{{ result.unauthorized }}</div>
+        </div>
+      </div>
+
+      <div class="max-h-[460px] overflow-auto rounded-lg border border-gray-200 dark:border-dark-600">
+        <table class="min-w-full divide-y divide-gray-200 text-sm dark:divide-dark-600">
+          <thead class="bg-gray-50 dark:bg-dark-700">
+            <tr>
+              <th class="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                {{ t('admin.accounts.batchTestResults.account') }}
+              </th>
+              <th class="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                {{ t('admin.accounts.batchTestResults.status') }}
+              </th>
+              <th class="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                {{ t('admin.accounts.batchTestResults.latency') }}
+              </th>
+              <th class="px-3 py-2 text-left font-medium text-gray-600 dark:text-gray-300">
+                {{ t('admin.accounts.batchTestResults.message') }}
+              </th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-gray-100 bg-white dark:divide-dark-600 dark:bg-dark-800">
+            <tr v-for="item in result.results" :key="item.account_id">
+              <td class="px-3 py-2 text-gray-900 dark:text-gray-100">
+                <div class="font-medium">{{ accountName(item.account_id) }}</div>
+                <div class="text-xs text-gray-500">#{{ item.account_id }}</div>
+              </td>
+              <td class="px-3 py-2">
+                <span
+                  :class="[
+                    'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+                    item.success
+                      ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
+                      : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+                  ]"
+                >
+                  {{ item.success ? t('admin.accounts.batchTestResults.ok') : t('admin.accounts.batchTestResults.error') }}
+                </span>
+              </td>
+              <td class="px-3 py-2 text-gray-600 dark:text-gray-300">
+                {{ item.latency_ms ? `${item.latency_ms}ms` : '-' }}
+              </td>
+              <td class="max-w-md px-3 py-2 text-gray-600 dark:text-gray-300">
+                <div class="line-clamp-3 whitespace-pre-wrap break-words">
+                  {{ item.error_message || item.response_text || '-' }}
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end gap-2">
+        <button v-if="running" class="btn btn-secondary" @click="emit('cancel')">
+          {{ t('common.cancel') }}
+        </button>
+        <button class="btn btn-primary" :disabled="running" @click="emit('close')">
+          {{ t('common.close') }}
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import BaseDialog from '@/components/common/BaseDialog.vue'
+import type { Account, BatchAccountTestResponse } from '@/types'
+
+const props = defineProps<{
+  show: boolean
+  result: BatchAccountTestResponse | null
+  accounts: Account[]
+  running?: boolean
+  completed?: number
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'cancel'): void
+}>()
+
+const { t } = useI18n()
+
+const accountMap = computed(() => new Map(props.accounts.map((account) => [account.id, account.name])))
+const accountName = (accountID: number) => accountMap.value.get(accountID) || t('admin.accounts.batchTestResults.unknownAccount')
+const completed = computed(() => props.completed ?? props.result?.results.length ?? 0)
+const progressPercent = computed(() => {
+  const total = props.result?.total ?? 0
+  if (total <= 0) return 0
+  return Math.min(100, Math.round((completed.value / total) * 100))
+})
+
+const handleClose = () => {
+  if (props.running) {
+    emit('cancel')
+    return
+  }
+  emit('close')
+}
+</script>

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -28,6 +28,9 @@
         <button @click="$emit('delete')" class="btn btn-danger btn-sm">{{ t('admin.accounts.bulkActions.delete') }}</button>
         <button @click="$emit('reset-status')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
         <button @click="$emit('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
+        <button @click="$emit('batch-test')" :disabled="batchTesting" class="btn btn-secondary btn-sm">
+          {{ batchTesting ? t('admin.accounts.bulkActions.batchTesting') : t('admin.accounts.bulkActions.batchTest') }}
+        </button>
         <button @click="$emit('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
         <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
         <button @click="$emit('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
@@ -41,5 +44,5 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-defineProps(['selectedIds']); defineEmits(['delete', 'edit-selected', 'edit-filtered', 'clear', 'select-page', 'toggle-schedulable', 'reset-status', 'refresh-token']); const { t } = useI18n()
+defineProps(['selectedIds', 'batchTesting']); defineEmits(['delete', 'edit-selected', 'edit-filtered', 'clear', 'select-page', 'toggle-schedulable', 'reset-status', 'refresh-token', 'batch-test']); const { t } = useI18n()
 </script>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3053,9 +3053,27 @@ export default {
         disableScheduling: 'Disable Scheduling',
         resetStatus: 'Reset Status',
         refreshToken: 'Refresh Token',
+        batchTest: 'Batch Account Test',
+        batchTesting: 'Testing accounts...',
         resetStatusSuccess: 'Successfully reset {count} account(s) status',
         refreshTokenSuccess: 'Successfully refreshed {count} account(s) token',
+        batchTestSuccess: 'Batch account test completed: {success} succeeded, {failed} failed, {unauthorized} unauthorized',
+        batchTestFailed: 'Batch account test failed',
         partialSuccess: 'Partially completed: {success} succeeded, {failed} failed'
+      },
+      batchTestResults: {
+        title: 'Batch Account Test Results',
+        total: 'Total',
+        success: 'Success',
+        failed: 'Failed',
+        unauthorized: '401',
+        account: 'Account',
+        status: 'Status',
+        latency: 'Latency',
+        message: 'Response / Error',
+        ok: 'OK',
+        error: 'Error',
+        unknownAccount: 'Unknown account'
       },
       bulkEdit: {
         title: 'Bulk Edit Accounts',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3200,9 +3200,27 @@ export default {
         disableScheduling: '批量停止调度',
         resetStatus: '批量重置状态',
         refreshToken: '批量刷新令牌',
+        batchTest: '批量账号测试',
+        batchTesting: '账号测试中...',
         resetStatusSuccess: '已成功重置 {count} 个账号状态',
         refreshTokenSuccess: '已成功刷新 {count} 个账号令牌',
+        batchTestSuccess: '批量账号测试完成：成功 {success} 个，失败 {failed} 个，401 {unauthorized} 个',
+        batchTestFailed: '批量账号测试失败',
         partialSuccess: '操作部分完成：{success} 成功，{failed} 失败'
+      },
+      batchTestResults: {
+        title: '批量账号测试结果',
+        total: '总数',
+        success: '成功',
+        failed: '失败',
+        unauthorized: '401',
+        account: '账号',
+        status: '状态',
+        latency: '耗时',
+        message: '响应 / 错误',
+        ok: '正常',
+        error: '异常',
+        unknownAccount: '未知账号'
       },
       bulkEdit: {
         title: '批量编辑账号',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1819,3 +1819,40 @@ export interface UpdateScheduledTestPlanRequest {
 
 // Payment types
 export type { SubscriptionPlan, PaymentOrder, CheckoutInfoResponse } from './payment'
+
+
+// ==================== Batch Account Test Types ====================
+
+
+export interface BatchAccountTestResult {
+  account_id: number
+  success: boolean
+  status: string
+  latency_ms: number
+  error_message?: string
+  response_text?: string
+}
+
+export interface BatchAccountTestResponse {
+  total: number
+  success: number
+  failed: number
+  unauthorized: number
+  results: BatchAccountTestResult[]
+}
+
+export type BatchAccountTestStreamEventType = 'start' | 'result' | 'complete' | 'error'
+
+export interface BatchAccountTestStreamEvent {
+  type: BatchAccountTestStreamEventType
+  total?: number
+  completed?: number
+  success?: number
+  failed?: number
+  unauthorized?: number
+  concurrency?: number
+  timeout_seconds?: number
+  result?: BatchAccountTestResult
+  results?: BatchAccountTestResult[]
+  message?: string
+}

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -174,6 +174,7 @@
       <template #table>
         <AccountBulkActionsBar
           :selected-ids="selIds"
+          :batch-testing="batchTesting"
           @delete="handleBulkDelete"
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
@@ -182,6 +183,7 @@
           @clear="clearSelection"
           @select-page="selectPage"
           @toggle-schedulable="handleBulkToggleSchedulable"
+          @batch-test="handleBulkTest"
         />
         <div ref="accountTableRef" class="flex min-h-0 flex-1 flex-col overflow-hidden">
         <DataTable
@@ -345,6 +347,15 @@
     <EditAccountModal :show="showEdit" :account="edAcc" :proxies="proxies" :groups="groups" @close="showEdit = false" @updated="handleAccountUpdated" />
     <ReAuthAccountModal :show="showReAuth" :account="reAuthAcc" @close="closeReAuthModal" @reauthorized="handleAccountUpdated" />
     <AccountTestModal :show="showTest" :account="testingAcc" @close="closeTestModal" />
+    <AccountBatchTestModal
+      :show="showBatchTestResults"
+      :result="batchTestResult"
+      :accounts="batchAccountTestAccounts"
+      :running="batchTesting"
+      :completed="batchTestCompleted"
+      @close="showBatchTestResults = false"
+      @cancel="cancelBatchTest"
+    />
     <AccountStatsModal :show="showStats" :account="statsAcc" @close="closeStatsModal" />
     <ScheduledTestsPanel :show="showSchedulePanel" :account-id="scheduleAcc?.id ?? null" :model-options="scheduleModelOptions" @close="closeSchedulePanel" />
     <AccountActionMenu :show="menu.show" :account="menu.acc" :position="menu.pos" @close="menu.show = false" @test="handleTest" @stats="handleViewStats" @schedule="handleSchedule" @reauth="handleReAuth" @refresh-token="handleRefresh" @recover-state="handleRecoverState" @reset-quota="handleResetQuota" @set-privacy="handleSetPrivacy" />
@@ -397,6 +408,7 @@ import AccountActionMenu from '@/components/admin/account/AccountActionMenu.vue'
 import ImportDataModal from '@/components/admin/account/ImportDataModal.vue'
 import ReAuthAccountModal from '@/components/admin/account/ReAuthAccountModal.vue'
 import AccountTestModal from '@/components/admin/account/AccountTestModal.vue'
+import AccountBatchTestModal from '@/components/admin/account/AccountBatchTestModal.vue'
 import AccountStatsModal from '@/components/admin/account/AccountStatsModal.vue'
 import ScheduledTestsPanel from '@/components/admin/account/ScheduledTestsPanel.vue'
 import type { SelectOption } from '@/components/common/Select.vue'
@@ -411,7 +423,7 @@ import ErrorPassthroughRulesModal from '@/components/admin/ErrorPassthroughRules
 import TLSFingerprintProfilesModal from '@/components/admin/TLSFingerprintProfilesModal.vue'
 import { buildOpenAIUsageRefreshKey } from '@/utils/accountUsageRefresh'
 import { formatDateTime, formatRelativeTime } from '@/utils/format'
-import type { Account, AccountPlatform, AccountType, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel } from '@/types'
+import type { Account, AccountPlatform, AccountType, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel, BatchAccountTestResponse } from '@/types'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -472,6 +484,8 @@ const showTempUnsched = ref(false)
 const showDeleteDialog = ref(false)
 const showReAuth = ref(false)
 const showTest = ref(false)
+const showBatchTestResults = ref(false)
+const batchTesting = ref(false)
 const showStats = ref(false)
 const showErrorPassthrough = ref(false)
 const showTLSFingerprintProfiles = ref(false)
@@ -480,6 +494,11 @@ const tempUnschedAcc = ref<Account | null>(null)
 const deletingAcc = ref<Account | null>(null)
 const reAuthAcc = ref<Account | null>(null)
 const testingAcc = ref<Account | null>(null)
+const batchTestResult = ref<BatchAccountTestResponse | null>(null)
+const batchAccountTestAccounts = ref<Account[]>([])
+const batchTestCompleted = ref(0)
+const batchTestAbortController = ref<AbortController | null>(null)
+const selectedAccountCache = ref<Map<number, Account>>(new Map())
 const statsAcc = ref<Account | null>(null)
 const showSchedulePanel = ref(false)
 const scheduleAcc = ref<Account | null>(null)
@@ -764,6 +783,18 @@ useSwipeSelect(accountTableRef, {
   batchUpdate
 }, swipeVirtualContext)
 
+const syncSelectedAccountCache = () => {
+  const selectedSet = new Set(selIds.value)
+  const next = new Map<number, Account>()
+  for (const [id, account] of selectedAccountCache.value) {
+    if (selectedSet.has(id)) next.set(id, account)
+  }
+  accounts.value.forEach((account) => {
+    if (selectedSet.has(account.id)) next.set(account.id, account)
+  })
+  selectedAccountCache.value = next
+}
+
 const resetAutoRefreshCache = () => {
   autoRefreshETag.value = null
 }
@@ -837,6 +868,8 @@ watch(loading, (isLoading, wasLoading) => {
   }
 })
 
+watch([selIds, accounts], syncSelectedAccountCache, { immediate: true })
+
 const isAnyModalOpen = computed(() => {
   return (
     showCreate.value ||
@@ -849,6 +882,7 @@ const isAnyModalOpen = computed(() => {
     showDeleteDialog.value ||
     showReAuth.value ||
     showTest.value ||
+    showBatchTestResults.value ||
     showStats.value ||
     showSchedulePanel.value ||
     showErrorPassthrough.value ||
@@ -1234,6 +1268,83 @@ const handleBulkRefreshToken = async () => {
     console.error('Failed to bulk refresh token:', error)
     appStore.showError(String(error))
   }
+}
+const handleBulkTest = async () => {
+  const accountIds = [...selIds.value]
+  if (accountIds.length === 0 || batchTesting.value) return
+  batchTesting.value = true
+  batchTestCompleted.value = 0
+  syncSelectedAccountCache()
+  batchAccountTestAccounts.value = accountIds
+    .map(id => selectedAccountCache.value.get(id))
+    .filter((account): account is Account => Boolean(account))
+  batchTestResult.value = {
+    total: accountIds.length,
+    success: 0,
+    failed: 0,
+    unauthorized: 0,
+    results: []
+  }
+  showBatchTestResults.value = true
+  const abortController = new AbortController()
+  batchTestAbortController.value = abortController
+  try {
+    await adminAPI.accounts.streamBatchAccountTest(accountIds, (event) => {
+      if (!batchTestResult.value) return
+      if (event.type === 'start') {
+        batchTestResult.value.total = event.total ?? accountIds.length
+        return
+      }
+      if (event.type === 'result' && event.result) {
+        const existingIndex = batchTestResult.value.results.findIndex(item => item.account_id === event.result?.account_id)
+        if (existingIndex >= 0) {
+          batchTestResult.value.results.splice(existingIndex, 1, event.result)
+        } else {
+          batchTestResult.value.results.push(event.result)
+        }
+        batchTestCompleted.value = event.completed ?? batchTestResult.value.results.length
+        batchTestResult.value.success = event.success ?? batchTestResult.value.results.filter(item => item.success).length
+        batchTestResult.value.failed = event.failed ?? batchTestResult.value.results.filter(item => !item.success).length
+        batchTestResult.value.unauthorized = event.unauthorized ?? batchTestResult.value.unauthorized
+        return
+      }
+      if (event.type === 'complete') {
+        batchTestCompleted.value = event.completed ?? event.total ?? batchTestResult.value.results.length
+        batchTestResult.value.total = event.total ?? batchTestResult.value.total
+        batchTestResult.value.success = event.success ?? batchTestResult.value.success
+        batchTestResult.value.failed = event.failed ?? batchTestResult.value.failed
+        batchTestResult.value.unauthorized = event.unauthorized ?? batchTestResult.value.unauthorized
+        if (event.results) {
+          batchTestResult.value.results = event.results
+        }
+        return
+      }
+    }, { signal: abortController.signal })
+    const result = batchTestResult.value
+    showBatchTestResults.value = true
+    appStore.showSuccess(t('admin.accounts.bulkActions.batchTestSuccess', {
+      success: result.success,
+      failed: result.failed,
+      unauthorized: result.unauthorized
+    }))
+    reload().catch((error) => {
+      console.error('Failed to refresh accounts after batch test:', error)
+    })
+  } catch (error: any) {
+    if (abortController.signal.aborted || error?.name === 'AbortError') {
+      showBatchTestResults.value = false
+      return
+    }
+    console.error('Failed to batch test accounts:', error)
+    appStore.showError(error?.message || t('admin.accounts.bulkActions.batchTestFailed'))
+  } finally {
+    batchTesting.value = false
+    batchTestAbortController.value = null
+  }
+}
+const cancelBatchTest = () => {
+  batchTestAbortController.value?.abort()
+  showBatchTestResults.value = false
 }
 const updateSchedulableInList = (accountIds: number[], schedulable: boolean) => {
   if (accountIds.length === 0) return


### PR DESCRIPTION
## Summary
- Add streaming batch connectivity testing for selected admin accounts.
- Reuse existing single-account test logic and keep successful-account recovery aligned with the existing single test flow.
- Add configurable batch account test limits and per-account timeout.

Closes #2230

## Changes
- Add `POST /api/v1/admin/accounts/batch-account-test/stream` for SSE batch test progress.
- Add the admin accounts bulk action and result modal for streaming per-account progress.
- Track unauthorized failures by captured HTTP status instead of matching `401` in error text.
- Keep batch defaults configurable through `batch_account_test`.
- Normalize line endings for `.env.example` and related project text files.

## Testing

Passed:
- `git diff --check origin/main..HEAD`
- `go test -tags=unit ./...`
- `make test-frontend`
- `golangci-lint run ./... --timeout=30m`
- Local Docker build/deploy and `/health`

Attempted:
- `go test -tags=integration ./...`

Notes:
- Integration tests reached `internal/pkg/tlsfingerprint`, but the existing capture-server test timed out connecting to `https://tls.sub2api.org:8090` from the local container.


## CLA
I have read the CLA Document and I hereby sign the CLA