### PR TITLE
feat: add distributed cluster support with static master-slave mode

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -91,6 +91,7 @@ type Config struct {
 	Gemini                  GeminiConfig                  `mapstructure:"gemini"`
 	Update                  UpdateConfig                  `mapstructure:"update"`
 	Idempotency             IdempotencyConfig             `mapstructure:"idempotency"`
+	Cluster                 ClusterConfig                 `mapstructure:"cluster"`
 }
 
 type LogConfig struct {
@@ -519,7 +520,7 @@ type ServerConfig struct {
 type H2CConfig struct {
 	Enabled                      bool   `mapstructure:"enabled"`                          // 是否启用 H2C
 	MaxConcurrentStreams         uint32 `mapstructure:"max_concurrent_streams"`           // 最大并发流数量
-	IdleTimeout                  int    `mapstructure:"idle_timeout"`                     // 空闲超时（秒）
+	IdleTimeout                  int    `mapstructure:"idle_timeout"`                     // 空��超时（秒）
 	MaxReadFrameSize             int    `mapstructure:"max_read_frame_size"`              // 最大帧大小（字节）
 	MaxUploadBufferPerConnection int    `mapstructure:"max_upload_buffer_per_connection"` // 每个连接的上传缓冲区（字节）
 	MaxUploadBufferPerStream     int    `mapstructure:"max_upload_buffer_per_stream"`     // 每个流的上传缓冲区（字节）
@@ -658,8 +659,8 @@ type GatewayConfig struct {
 	// 建议值：预估的活跃账户数 * 1.2（留有余量）
 	MaxUpstreamClients int `mapstructure:"max_upstream_clients"`
 	// ClientIdleTTLSeconds: 上游连接池客户端空闲回收阈值（秒）
-	// 超过此时间未使用的客户端会被标记为可回收
-	// 建议值：根据用户访问频率设置，一般 10-30 分钟
+	// 超过此时间��使用的客户端会被标记为可回收
+	// 建议值：根据用户访问频���设置，一般 10-30 分钟
 	ClientIdleTTLSeconds int `mapstructure:"client_idle_ttl_seconds"`
 	// ConcurrencySlotTTLMinutes: 并发槽位过期时间（分钟）
 	// 应大于最长 LLM 请求时间，防止请求完成前槽位过期
@@ -943,7 +944,7 @@ type GatewaySchedulingConfig struct {
 
 	// 负载计算
 	LoadBatchEnabled bool `mapstructure:"load_batch_enabled"`
-	// 快照桶读取时的 MGET 分块大小
+	// 快照桶���取时的 MGET 分块大小
 	SnapshotMGetChunkSize int `mapstructure:"snapshot_mget_chunk_size"`
 	// 快照重建时的缓存写入分块大小
 	SnapshotWriteChunkSize int `mapstructure:"snapshot_write_chunk_size"`
@@ -1117,7 +1118,7 @@ type TotpConfig struct {
 	// 如果为空，将自动生成一个随机密钥（仅适用于开发环境）
 	EncryptionKey string `mapstructure:"encryption_key"`
 	// EncryptionKeyConfigured 标记加密密钥是否为手动配置（非自动生成）
-	// 只有手动配置了密钥才允许在管理后台启用 TOTP 功能
+	// 只有���动配置了密钥才允许在管理后台启用 TOTP 功能
 	EncryptionKeyConfigured bool `mapstructure:"-"`
 }
 
@@ -2762,5 +2763,45 @@ func warnIfInsecureURL(field, raw string) {
 	}
 	if strings.EqualFold(u.Scheme, "http") {
 		slog.Warn("url uses http scheme; use https in production to avoid token leakage", "field", field)
+	}
+}
+
+// ClusterConfig holds configuration for distributed cluster deployment.
+// Uses a simple master-slave model where master runs background tasks
+// and slaves handle API traffic.
+type ClusterConfig struct {
+	// Enabled indicates whether cluster mode is enabled.
+	// When disabled, runs in standalone mode (single instance).
+	Enabled bool `mapstructure:"enabled"`
+
+	// Role specifies this instance's role: "master" or "slave".
+	// Master: runs background tasks, should NOT receive API traffic.
+	// Slave: handles API traffic, does NOT run background tasks.
+	// Only used when Enabled is true.
+	Role string `mapstructure:"role"`
+
+	// InstanceID is a unique identifier for this instance.
+	// If empty, a short UUID will be generated automatically.
+	InstanceID string `mapstructure:"instance_id"`
+
+	// HeartbeatIntervalSeconds is how often instances send heartbeats.
+	HeartbeatIntervalSeconds int `mapstructure:"heartbeat_interval_seconds"`
+
+	// HeartbeatTTLSeconds is the TTL for instance heartbeat records.
+	HeartbeatTTLSeconds int `mapstructure:"heartbeat_ttl_seconds"`
+
+	// InstanceRegistryKey is the Redis key prefix for instance registry.
+	InstanceRegistryKey string `mapstructure:"instance_registry_key"`
+}
+
+// DefaultClusterConfig returns the default cluster configuration.
+func DefaultClusterConfig() ClusterConfig {
+	return ClusterConfig{
+		Enabled:                  false,
+		Role:                     "",
+		InstanceID:               "",
+		HeartbeatIntervalSeconds: 5,
+		HeartbeatTTLSeconds:      15,
+		InstanceRegistryKey:      "cluster:instances",
 	}
 }

--- a/backend/internal/handler/admin/cluster_handler.go
+++ b/backend/internal/handler/admin/cluster_handler.go
@@ -1,0 +1,120 @@
+package admin
+
+import (
+	"net/http"
+
+	"github.com/Wei-Shaw/sub2api/internal/service/cluster"
+	"github.com/gin-gonic/gin"
+)
+
+// ClusterHandler handles cluster-related admin API endpoints.
+type ClusterHandler struct {
+	coordinator *cluster.Coordinator
+}
+
+// NewClusterHandler creates a new cluster handler.
+func NewClusterHandler(coordinator *cluster.Coordinator) *ClusterHandler {
+	return &ClusterHandler{
+		coordinator: coordinator,
+	}
+}
+
+// ClusterStatusResponse represents the cluster status response.
+type ClusterStatusResponse struct {
+	CurrentInstance *cluster.Instance  `json:"current_instance"`
+	Instances       []cluster.Instance `json:"instances"`
+	MasterID        string             `json:"master_id,omitempty"`
+	ClusterMode     string             `json:"cluster_mode"`
+	ClusterHealthy  bool               `json:"cluster_healthy"`
+	TotalInstances  int                `json:"total_instances"`
+	HealthyCount    int                `json:"healthy_count"`
+	MasterCount     int                `json:"master_count"`
+	SlaveCount      int                `json:"slave_count"`
+	ClusterEnabled  bool               `json:"cluster_enabled"`
+}
+
+// GetClusterStatus returns the current cluster status.
+// @Summary Get cluster status
+// @Description Returns the status of all instances in the cluster
+// @Tags Admin - Cluster
+// @Produce json
+// @Success 200 {object} ClusterStatusResponse
+// @Failure 500 {object} ErrorResponse
+// @Security BearerAuth
+// @Router /api/admin/cluster/status [get]
+func (h *ClusterHandler) GetClusterStatus(c *gin.Context) {
+	status, err := h.coordinator.GetClusterStatus()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "failed to get cluster status",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	response := ClusterStatusResponse{
+		CurrentInstance: status.CurrentInstance,
+		Instances:       status.Instances,
+		MasterID:        string(status.MasterID),
+		ClusterMode:     status.ClusterMode,
+		ClusterHealthy:  status.ClusterHealthy,
+		TotalInstances:  status.TotalInstances,
+		HealthyCount:    status.HealthyCount,
+		MasterCount:     status.MasterCount,
+		SlaveCount:      status.SlaveCount,
+		ClusterEnabled:  status.ClusterMode == "master-slave",
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+// GetCurrentInstance returns information about the current instance.
+// @Summary Get current instance info
+// @Description Returns information about this specific instance
+// @Tags Admin - Cluster
+// @Produce json
+// @Success 200 {object} cluster.Instance
+// @Security BearerAuth
+// @Router /api/admin/cluster/instance [get]
+func (h *ClusterHandler) GetCurrentInstance(c *gin.Context) {
+	status, err := h.coordinator.GetClusterStatus()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error":   "failed to get instance info",
+			"details": err.Error(),
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, status.CurrentInstance)
+}
+
+// GetMasterStatus returns whether this instance is the master.
+// @Summary Check master status
+// @Description Returns whether this instance is the master (runs background tasks)
+// @Tags Admin - Cluster
+// @Produce json
+// @Success 200 {object} map[string]interface{}
+// @Security BearerAuth
+// @Router /api/admin/cluster/master [get]
+func (h *ClusterHandler) GetMasterStatus(c *gin.Context) {
+	isMaster := h.coordinator.IsMaster()
+	instanceID := h.coordinator.InstanceID()
+	role := h.coordinator.GetRole()
+
+	c.JSON(http.StatusOK, gin.H{
+		"is_master":   isMaster,
+		"instance_id": string(instanceID),
+		"role":        string(role),
+	})
+}
+
+// RegisterRoutes registers cluster routes.
+func (h *ClusterHandler) RegisterRoutes(rg *gin.RouterGroup) {
+	clusterGroup := rg.Group("/cluster")
+	{
+		clusterGroup.GET("/status", h.GetClusterStatus)
+		clusterGroup.GET("/instance", h.GetCurrentInstance)
+		clusterGroup.GET("/master", h.GetMasterStatus)
+	}
+}

--- a/backend/internal/repository/oauth_session_cache.go
+++ b/backend/internal/repository/oauth_session_cache.go
@@ -1,0 +1,352 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// oauthSessionKeyPrefix is the Redis key prefix for OAuth sessions.
+	oauthSessionKeyPrefix = "oauth_session:"
+
+	// defaultOAuthSessionTTL is the default TTL for OAuth sessions.
+	defaultOAuthSessionTTL = 30 * time.Minute
+)
+
+// OAuthSessionCache provides Redis-based storage for OAuth sessions.
+// This enables distributed deployment where any instance can handle
+// the OAuth callback regardless of which instance initiated the flow.
+type OAuthSessionCache struct {
+	rdb *redis.Client
+	ttl time.Duration
+}
+
+// NewOAuthSessionCache creates a new OAuth session cache.
+func NewOAuthSessionCache(rdb *redis.Client) *OAuthSessionCache {
+	return &OAuthSessionCache{
+		rdb: rdb,
+		ttl: defaultOAuthSessionTTL,
+	}
+}
+
+// NewOAuthSessionCacheWithTTL creates a new OAuth session cache with custom TTL.
+func NewOAuthSessionCacheWithTTL(rdb *redis.Client, ttl time.Duration) *OAuthSessionCache {
+	return &OAuthSessionCache{
+		rdb: rdb,
+		ttl: ttl,
+	}
+}
+
+// OAuthSessionData is a generic OAuth session data structure.
+// Different OAuth providers can use this with provider-specific fields.
+type OAuthSessionData struct {
+	// Common fields
+	State        string    `json:"state"`
+	CodeVerifier string    `json:"code_verifier,omitempty"`
+	ClientID     string    `json:"client_id,omitempty"`
+	ProxyURL     string    `json:"proxy_url,omitempty"`
+	RedirectURI  string    `json:"redirect_uri,omitempty"`
+	CreatedAt    time.Time `json:"created_at"`
+
+	// Provider identifier (openai, claude, gemini, antigravity)
+	Provider string `json:"provider,omitempty"`
+
+	// Additional provider-specific data stored as JSON
+	Extra map[string]interface{} `json:"extra,omitempty"`
+}
+
+// buildKey constructs the Redis key for an OAuth session.
+func (c *OAuthSessionCache) buildKey(provider, sessionID string) string {
+	return fmt.Sprintf("%s%s:%s", oauthSessionKeyPrefix, provider, sessionID)
+}
+
+// Set stores an OAuth session in Redis.
+func (c *OAuthSessionCache) Set(ctx context.Context, provider, sessionID string, session *OAuthSessionData) error {
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = time.Now()
+	}
+	session.Provider = provider
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OAuth session: %w", err)
+	}
+
+	key := c.buildKey(provider, sessionID)
+	if err := c.rdb.Set(ctx, key, data, c.ttl).Err(); err != nil {
+		return fmt.Errorf("failed to store OAuth session: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves an OAuth session from Redis.
+// Returns nil, nil if the session doesn't exist or has expired.
+func (c *OAuthSessionCache) Get(ctx context.Context, provider, sessionID string) (*OAuthSessionData, error) {
+	key := c.buildKey(provider, sessionID)
+	data, err := c.rdb.Get(ctx, key).Bytes()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get OAuth session: %w", err)
+	}
+
+	var session OAuthSessionData
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal OAuth session: %w", err)
+	}
+
+	return &session, nil
+}
+
+// Delete removes an OAuth session from Redis.
+func (c *OAuthSessionCache) Delete(ctx context.Context, provider, sessionID string) error {
+	key := c.buildKey(provider, sessionID)
+	if err := c.rdb.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("failed to delete OAuth session: %w", err)
+	}
+	return nil
+}
+
+// GetAndDelete retrieves and removes an OAuth session atomically.
+// This is useful for one-time use sessions like OAuth callbacks.
+func (c *OAuthSessionCache) GetAndDelete(ctx context.Context, provider, sessionID string) (*OAuthSessionData, error) {
+	key := c.buildKey(provider, sessionID)
+
+	// Use GETDEL for atomic get and delete
+	data, err := c.rdb.GetDel(ctx, key).Bytes()
+	if err == redis.Nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get and delete OAuth session: %w", err)
+	}
+
+	var session OAuthSessionData
+	if err := json.Unmarshal(data, &session); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal OAuth session: %w", err)
+	}
+
+	return &session, nil
+}
+
+// Exists checks if an OAuth session exists.
+func (c *OAuthSessionCache) Exists(ctx context.Context, provider, sessionID string) (bool, error) {
+	key := c.buildKey(provider, sessionID)
+	count, err := c.rdb.Exists(ctx, key).Result()
+	if err != nil {
+		return false, fmt.Errorf("failed to check OAuth session existence: %w", err)
+	}
+	return count > 0, nil
+}
+
+// SetWithTTL stores an OAuth session with a custom TTL.
+func (c *OAuthSessionCache) SetWithTTL(ctx context.Context, provider, sessionID string, session *OAuthSessionData, ttl time.Duration) error {
+	if session.CreatedAt.IsZero() {
+		session.CreatedAt = time.Now()
+	}
+	session.Provider = provider
+
+	data, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("failed to marshal OAuth session: %w", err)
+	}
+
+	key := c.buildKey(provider, sessionID)
+	if err := c.rdb.Set(ctx, key, data, ttl).Err(); err != nil {
+		return fmt.Errorf("failed to store OAuth session: %w", err)
+	}
+
+	return nil
+}
+
+// OpenAIOAuthSessionStore adapts OAuthSessionCache to the openai.SessionStore interface.
+// This allows gradual migration from in-memory to Redis-based storage.
+type OpenAIOAuthSessionStore struct {
+	cache *OAuthSessionCache
+}
+
+// NewOpenAIOAuthSessionStore creates a new OpenAI OAuth session store backed by Redis.
+func NewOpenAIOAuthSessionStore(cache *OAuthSessionCache) *OpenAIOAuthSessionStore {
+	return &OpenAIOAuthSessionStore{cache: cache}
+}
+
+// Set stores an OpenAI OAuth session.
+func (s *OpenAIOAuthSessionStore) Set(sessionID string, state, codeVerifier, clientID, proxyURL, redirectURI string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session := &OAuthSessionData{
+		State:        state,
+		CodeVerifier: codeVerifier,
+		ClientID:     clientID,
+		ProxyURL:     proxyURL,
+		RedirectURI:  redirectURI,
+		CreatedAt:    time.Now(),
+	}
+
+	return s.cache.Set(ctx, "openai", sessionID, session)
+}
+
+// Get retrieves an OpenAI OAuth session.
+func (s *OpenAIOAuthSessionStore) Get(sessionID string) (state, codeVerifier, clientID, proxyURL, redirectURI string, found bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session, err := s.cache.Get(ctx, "openai", sessionID)
+	if err != nil || session == nil {
+		return "", "", "", "", "", false
+	}
+
+	return session.State, session.CodeVerifier, session.ClientID, session.ProxyURL, session.RedirectURI, true
+}
+
+// Delete removes an OpenAI OAuth session.
+func (s *OpenAIOAuthSessionStore) Delete(sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.cache.Delete(ctx, "openai", sessionID)
+}
+
+// ClaudeOAuthSessionStore adapts OAuthSessionCache for Claude OAuth.
+type ClaudeOAuthSessionStore struct {
+	cache *OAuthSessionCache
+}
+
+// NewClaudeOAuthSessionStore creates a new Claude OAuth session store backed by Redis.
+func NewClaudeOAuthSessionStore(cache *OAuthSessionCache) *ClaudeOAuthSessionStore {
+	return &ClaudeOAuthSessionStore{cache: cache}
+}
+
+// Set stores a Claude OAuth session.
+func (s *ClaudeOAuthSessionStore) Set(sessionID string, state, codeVerifier, proxyURL, redirectURI string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session := &OAuthSessionData{
+		State:        state,
+		CodeVerifier: codeVerifier,
+		ProxyURL:     proxyURL,
+		RedirectURI:  redirectURI,
+		CreatedAt:    time.Now(),
+	}
+
+	return s.cache.Set(ctx, "claude", sessionID, session)
+}
+
+// Get retrieves a Claude OAuth session.
+func (s *ClaudeOAuthSessionStore) Get(sessionID string) (state, codeVerifier, proxyURL, redirectURI string, found bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session, err := s.cache.Get(ctx, "claude", sessionID)
+	if err != nil || session == nil {
+		return "", "", "", "", false
+	}
+
+	return session.State, session.CodeVerifier, session.ProxyURL, session.RedirectURI, true
+}
+
+// Delete removes a Claude OAuth session.
+func (s *ClaudeOAuthSessionStore) Delete(sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.cache.Delete(ctx, "claude", sessionID)
+}
+
+// GeminiOAuthSessionStore adapts OAuthSessionCache for Gemini OAuth.
+type GeminiOAuthSessionStore struct {
+	cache *OAuthSessionCache
+}
+
+// NewGeminiOAuthSessionStore creates a new Gemini OAuth session store backed by Redis.
+func NewGeminiOAuthSessionStore(cache *OAuthSessionCache) *GeminiOAuthSessionStore {
+	return &GeminiOAuthSessionStore{cache: cache}
+}
+
+// Set stores a Gemini OAuth session.
+func (s *GeminiOAuthSessionStore) Set(sessionID string, state, codeVerifier, proxyURL, redirectURI string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session := &OAuthSessionData{
+		State:        state,
+		CodeVerifier: codeVerifier,
+		ProxyURL:     proxyURL,
+		RedirectURI:  redirectURI,
+		CreatedAt:    time.Now(),
+	}
+
+	return s.cache.Set(ctx, "gemini", sessionID, session)
+}
+
+// Get retrieves a Gemini OAuth session.
+func (s *GeminiOAuthSessionStore) Get(sessionID string) (state, codeVerifier, proxyURL, redirectURI string, found bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session, err := s.cache.Get(ctx, "gemini", sessionID)
+	if err != nil || session == nil {
+		return "", "", "", "", false
+	}
+
+	return session.State, session.CodeVerifier, session.ProxyURL, session.RedirectURI, true
+}
+
+// Delete removes a Gemini OAuth session.
+func (s *GeminiOAuthSessionStore) Delete(sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.cache.Delete(ctx, "gemini", sessionID)
+}
+
+// AntigravityOAuthSessionStore adapts OAuthSessionCache for Antigravity OAuth.
+type AntigravityOAuthSessionStore struct {
+	cache *OAuthSessionCache
+}
+
+// NewAntigravityOAuthSessionStore creates a new Antigravity OAuth session store backed by Redis.
+func NewAntigravityOAuthSessionStore(cache *OAuthSessionCache) *AntigravityOAuthSessionStore {
+	return &AntigravityOAuthSessionStore{cache: cache}
+}
+
+// Set stores an Antigravity OAuth session.
+func (s *AntigravityOAuthSessionStore) Set(sessionID string, state, codeVerifier, proxyURL, redirectURI string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session := &OAuthSessionData{
+		State:        state,
+		CodeVerifier: codeVerifier,
+		ProxyURL:     proxyURL,
+		RedirectURI:  redirectURI,
+		CreatedAt:    time.Now(),
+	}
+
+	return s.cache.Set(ctx, "antigravity", sessionID, session)
+}
+
+// Get retrieves an Antigravity OAuth session.
+func (s *AntigravityOAuthSessionStore) Get(sessionID string) (state, codeVerifier, proxyURL, redirectURI string, found bool) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	session, err := s.cache.Get(ctx, "antigravity", sessionID)
+	if err != nil || session == nil {
+		return "", "", "", "", false
+	}
+
+	return session.State, session.CodeVerifier, session.ProxyURL, session.RedirectURI, true
+}
+
+// Delete removes an Antigravity OAuth session.
+func (s *AntigravityOAuthSessionStore) Delete(sessionID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = s.cache.Delete(ctx, "antigravity", sessionID)
+}

--- a/backend/internal/service/cluster/coordinator.go
+++ b/backend/internal/service/cluster/coordinator.go
@@ -1,0 +1,194 @@
+package cluster
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// Coordinator is the main entry point for cluster coordination.
+// In master-slave mode, it manages instance registration and task scheduling based on role.
+type Coordinator struct {
+	instanceRegistry *InstanceRegistry
+	config           Config
+	logger           *slog.Logger
+
+	tasks   []TaskRunner
+	tasksMu sync.RWMutex
+
+	started  bool
+	startMu  sync.Mutex
+	stopOnce sync.Once
+}
+
+// NewCoordinator creates a new cluster coordinator.
+func NewCoordinator(registry *InstanceRegistry, cfg Config, logger *slog.Logger) *Coordinator {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Coordinator{
+		instanceRegistry: registry,
+		config:           cfg,
+		logger:           logger.With("component", "cluster_coordinator"),
+	}
+}
+
+// Start begins cluster coordination.
+func (c *Coordinator) Start() {
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+
+	if c.started {
+		return
+	}
+	c.started = true
+
+	role := c.GetRole()
+	c.logger.Info("starting cluster coordinator",
+		"enabled", c.config.Enabled,
+		"role", role,
+		"instance_id", c.config.InstanceID)
+
+	// Start instance registry for heartbeat
+	if c.instanceRegistry != nil {
+		c.instanceRegistry.Start()
+	}
+
+	// Only master or standalone runs background tasks
+	if role == RoleMaster || role == RoleStandalone {
+		c.startAllTasks()
+	}
+}
+
+// Stop gracefully stops the coordinator.
+func (c *Coordinator) Stop() {
+	c.stopOnce.Do(func() {
+		c.logger.Info("stopping cluster coordinator")
+
+		// Stop all tasks first
+		c.stopAllTasks()
+
+		// Stop instance registry
+		if c.instanceRegistry != nil {
+			c.instanceRegistry.Stop()
+		}
+	})
+}
+
+// RegisterTask registers a background task to be managed by the coordinator.
+// Tasks will only run on master or standalone instances.
+func (c *Coordinator) RegisterTask(task TaskRunner) {
+	c.tasksMu.Lock()
+	defer c.tasksMu.Unlock()
+
+	c.tasks = append(c.tasks, task)
+
+	// If already started and this is master/standalone, start the task
+	c.startMu.Lock()
+	started := c.started
+	c.startMu.Unlock()
+
+	if started && c.IsMaster() {
+		c.logger.Info("starting task on master", "task", task.Name())
+		task.Start()
+		if c.instanceRegistry != nil {
+			c.instanceRegistry.AddRunningTask(task.Name())
+		}
+	}
+}
+
+// IsMaster returns whether this instance should run background tasks.
+// Returns true for master role or standalone mode.
+func (c *Coordinator) IsMaster() bool {
+	role := c.GetRole()
+	return role == RoleMaster || role == RoleStandalone
+}
+
+// IsSlave returns whether this instance should only handle traffic.
+func (c *Coordinator) IsSlave() bool {
+	return c.GetRole() == RoleSlave
+}
+
+// GetRole returns the current instance role.
+func (c *Coordinator) GetRole() InstanceRole {
+	if !c.config.Enabled {
+		return RoleStandalone
+	}
+	return c.config.Role
+}
+
+// InstanceID returns the unique identifier for this instance.
+func (c *Coordinator) InstanceID() InstanceID {
+	if c.config.InstanceID == "" {
+		return "local"
+	}
+	return InstanceID(c.config.InstanceID)
+}
+
+// GetClusterStatus returns the current cluster status.
+func (c *Coordinator) GetClusterStatus() (*ClusterStatus, error) {
+	if c.instanceRegistry == nil {
+		// Standalone mode: return single local instance status
+		return &ClusterStatus{
+			CurrentInstance: &Instance{
+				ID:       c.InstanceID(),
+				Hostname: "local",
+				Role:     RoleStandalone,
+				Status:   InstanceStatusHealthy,
+			},
+			Instances:      []Instance{},
+			ClusterMode:    "standalone",
+			ClusterHealthy: true,
+			TotalInstances: 1,
+			HealthyCount:   1,
+			MasterCount:    1,
+			SlaveCount:     0,
+		}, nil
+	}
+	return c.instanceRegistry.GetClusterStatus()
+}
+
+// GetAllInstances returns all registered instances.
+func (c *Coordinator) GetAllInstances() ([]Instance, error) {
+	if c.instanceRegistry == nil {
+		return []Instance{}, nil
+	}
+	return c.instanceRegistry.GetAllInstances()
+}
+
+// startAllTasks starts all registered tasks.
+func (c *Coordinator) startAllTasks() {
+	c.tasksMu.RLock()
+	defer c.tasksMu.RUnlock()
+
+	for _, task := range c.tasks {
+		c.logger.Info("starting task", "task", task.Name())
+		task.Start()
+		if c.instanceRegistry != nil {
+			c.instanceRegistry.AddRunningTask(task.Name())
+		}
+	}
+}
+
+// stopAllTasks stops all registered tasks.
+func (c *Coordinator) stopAllTasks() {
+	c.tasksMu.RLock()
+	defer c.tasksMu.RUnlock()
+
+	for _, task := range c.tasks {
+		c.logger.Info("stopping task", "task", task.Name())
+		task.Stop()
+		if c.instanceRegistry != nil {
+			c.instanceRegistry.RemoveRunningTask(task.Name())
+		}
+	}
+}
+
+// MasterOnlyRunner wraps a function to only run when this instance is master.
+// It returns immediately if this is a slave instance.
+func (c *Coordinator) MasterOnlyRunner(fn func()) {
+	if !c.IsMaster() {
+		return
+	}
+	fn()
+}

--- a/backend/internal/service/cluster/instance_registry.go
+++ b/backend/internal/service/cluster/instance_registry.go
@@ -1,0 +1,272 @@
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// InstanceRegistry manages instance registration and heartbeat for cluster status display.
+// This is a simplified version without leader election - only for monitoring purposes.
+type InstanceRegistry struct {
+	rdb    *redis.Client
+	config Config
+	logger *slog.Logger
+
+	// Current instance info
+	instanceID InstanceID
+	hostname   string
+	version    string
+	startedAt  time.Time
+
+	// Running tasks tracking
+	runningTasks   []string
+	runningTasksMu sync.RWMutex
+
+	// Lifecycle
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// NewInstanceRegistry creates a new instance registry.
+func NewInstanceRegistry(rdb *redis.Client, cfg Config, version string, logger *slog.Logger) *InstanceRegistry {
+	hostname, _ := os.Hostname()
+
+	return &InstanceRegistry{
+		rdb:        rdb,
+		config:     cfg,
+		logger:     logger.With("component", "instance_registry"),
+		instanceID: InstanceID(cfg.InstanceID),
+		hostname:   hostname,
+		version:    version,
+		startedAt:  time.Now(),
+		stopCh:     make(chan struct{}),
+	}
+}
+
+// Start begins the heartbeat loop.
+func (r *InstanceRegistry) Start() {
+	r.wg.Add(1)
+	go r.heartbeatLoop()
+
+	r.logger.Info("instance registry started",
+		"instance_id", r.instanceID,
+		"role", r.config.Role,
+		"hostname", r.hostname)
+}
+
+// Stop gracefully stops the registry.
+func (r *InstanceRegistry) Stop() {
+	r.stopOnce.Do(func() {
+		close(r.stopCh)
+		r.wg.Wait()
+
+		// Remove this instance from registry
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		key := r.instanceKey()
+		if err := r.rdb.Del(ctx, key).Err(); err != nil {
+			r.logger.Warn("failed to remove instance from registry", "error", err)
+		}
+
+		r.logger.Info("instance registry stopped")
+	})
+}
+
+// AddRunningTask adds a task to the running tasks list.
+func (r *InstanceRegistry) AddRunningTask(taskName string) {
+	r.runningTasksMu.Lock()
+	defer r.runningTasksMu.Unlock()
+	r.runningTasks = append(r.runningTasks, taskName)
+}
+
+// RemoveRunningTask removes a task from the running tasks list.
+func (r *InstanceRegistry) RemoveRunningTask(taskName string) {
+	r.runningTasksMu.Lock()
+	defer r.runningTasksMu.Unlock()
+
+	for i, name := range r.runningTasks {
+		if name == taskName {
+			r.runningTasks = append(r.runningTasks[:i], r.runningTasks[i+1:]...)
+			return
+		}
+	}
+}
+
+// GetClusterStatus returns the current cluster status.
+func (r *InstanceRegistry) GetClusterStatus() (*ClusterStatus, error) {
+	instances, err := r.GetAllInstances()
+	if err != nil {
+		return nil, err
+	}
+
+	// Build current instance
+	r.runningTasksMu.RLock()
+	tasks := make([]string, len(r.runningTasks))
+	copy(tasks, r.runningTasks)
+	r.runningTasksMu.RUnlock()
+
+	currentInstance := &Instance{
+		ID:            r.instanceID,
+		Hostname:      r.hostname,
+		Role:          r.config.Role,
+		StartedAt:     r.startedAt,
+		LastHeartbeat: time.Now(),
+		Status:        InstanceStatusHealthy,
+		RunningTasks:  tasks,
+		Version:       r.version,
+	}
+
+	// Count instances by role and status
+	var masterCount, slaveCount, healthyCount int
+	var masterID InstanceID
+
+	for _, inst := range instances {
+		if inst.Status == InstanceStatusHealthy {
+			healthyCount++
+		}
+		switch inst.Role {
+		case RoleMaster:
+			masterCount++
+			masterID = inst.ID
+		case RoleSlave:
+			slaveCount++
+		}
+	}
+
+	return &ClusterStatus{
+		CurrentInstance: currentInstance,
+		Instances:       instances,
+		MasterID:        masterID,
+		ClusterMode:     "master-slave",
+		ClusterHealthy:  masterCount == 1 && healthyCount == len(instances),
+		TotalInstances:  len(instances),
+		HealthyCount:    healthyCount,
+		MasterCount:     masterCount,
+		SlaveCount:      slaveCount,
+	}, nil
+}
+
+// GetAllInstances returns all registered instances from Redis.
+func (r *InstanceRegistry) GetAllInstances() ([]Instance, error) {
+	ctx := context.Background()
+
+	// Get all instance keys
+	pattern := r.config.InstanceRegistryKey + ":*"
+	keys, err := r.rdb.Keys(ctx, pattern).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys) == 0 {
+		return []Instance{}, nil
+	}
+
+	// Get all instance data
+	pipe := r.rdb.Pipeline()
+	cmds := make([]*redis.StringCmd, len(keys))
+	for i, key := range keys {
+		cmds[i] = pipe.Get(ctx, key)
+	}
+
+	_, err = pipe.Exec(ctx)
+	if err != nil && err != redis.Nil {
+		return nil, err
+	}
+
+	instances := make([]Instance, 0, len(keys))
+	now := time.Now()
+
+	for _, cmd := range cmds {
+		data, err := cmd.Result()
+		if err == redis.Nil {
+			continue
+		}
+		if err != nil {
+			continue
+		}
+
+		var inst Instance
+		if err := json.Unmarshal([]byte(data), &inst); err != nil {
+			continue
+		}
+
+		// Check if instance is healthy (heartbeat within TTL)
+		if now.Sub(inst.LastHeartbeat) > r.config.HeartbeatTTL {
+			inst.Status = InstanceStatusUnhealthy
+		} else {
+			inst.Status = InstanceStatusHealthy
+		}
+
+		instances = append(instances, inst)
+	}
+
+	return instances, nil
+}
+
+// heartbeatLoop periodically updates this instance's heartbeat.
+func (r *InstanceRegistry) heartbeatLoop() {
+	defer r.wg.Done()
+
+	ticker := time.NewTicker(r.config.HeartbeatInterval)
+	defer ticker.Stop()
+
+	// Send initial heartbeat
+	r.sendHeartbeat()
+
+	for {
+		select {
+		case <-ticker.C:
+			r.sendHeartbeat()
+		case <-r.stopCh:
+			return
+		}
+	}
+}
+
+// sendHeartbeat updates this instance's registration in Redis.
+func (r *InstanceRegistry) sendHeartbeat() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	r.runningTasksMu.RLock()
+	tasks := make([]string, len(r.runningTasks))
+	copy(tasks, r.runningTasks)
+	r.runningTasksMu.RUnlock()
+
+	inst := Instance{
+		ID:            r.instanceID,
+		Hostname:      r.hostname,
+		Role:          r.config.Role,
+		StartedAt:     r.startedAt,
+		LastHeartbeat: time.Now(),
+		Status:        InstanceStatusHealthy,
+		RunningTasks:  tasks,
+		Version:       r.version,
+	}
+
+	data, err := json.Marshal(inst)
+	if err != nil {
+		r.logger.Warn("failed to marshal instance data", "error", err)
+		return
+	}
+
+	key := r.instanceKey()
+	ttl := r.config.HeartbeatTTL * 2 // TTL is 2x heartbeat interval for safety
+
+	if err := r.rdb.Set(ctx, key, data, ttl).Err(); err != nil {
+		r.logger.Warn("failed to send heartbeat", "error", err)
+	}
+}
+
+// instanceKey returns the Redis key for this instance.
+func (r *InstanceRegistry) instanceKey() string {
+	return r.config.InstanceRegistryKey + ":" + string(r.instanceID)
+}

--- a/backend/internal/service/cluster/types.go
+++ b/backend/internal/service/cluster/types.go
@@ -1,0 +1,108 @@
+// Package cluster provides distributed cluster coordination for multi-instance deployments.
+// It uses a simple master-slave model where the master runs background tasks
+// and slaves handle API traffic.
+package cluster
+
+import (
+	"time"
+)
+
+// InstanceID is a unique identifier for a cluster instance.
+type InstanceID string
+
+// InstanceRole represents the role of an instance in the cluster.
+type InstanceRole string
+
+const (
+	// RoleMaster indicates the instance runs background tasks, does not receive traffic.
+	RoleMaster InstanceRole = "master"
+
+	// RoleSlave indicates the instance handles API traffic, does not run background tasks.
+	RoleSlave InstanceRole = "slave"
+
+	// RoleStandalone indicates single-instance mode (runs both tasks and traffic).
+	RoleStandalone InstanceRole = "standalone"
+)
+
+// InstanceStatus represents the health status of an instance.
+type InstanceStatus string
+
+const (
+	InstanceStatusHealthy   InstanceStatus = "healthy"
+	InstanceStatusUnhealthy InstanceStatus = "unhealthy"
+	InstanceStatusUnknown   InstanceStatus = "unknown"
+)
+
+// Instance represents a single instance in the cluster.
+type Instance struct {
+	ID            InstanceID     `json:"id"`
+	Hostname      string         `json:"hostname"`
+	IP            string         `json:"ip,omitempty"`
+	Role          InstanceRole   `json:"role"`
+	StartedAt     time.Time      `json:"started_at"`
+	LastHeartbeat time.Time      `json:"last_heartbeat"`
+	Status        InstanceStatus `json:"status"`
+	RunningTasks  []string       `json:"running_tasks,omitempty"`
+	Version       string         `json:"version,omitempty"`
+}
+
+// ClusterStatus represents the overall cluster state.
+type ClusterStatus struct {
+	CurrentInstance *Instance    `json:"current_instance"`
+	Instances       []Instance   `json:"instances"`
+	MasterID        InstanceID   `json:"master_id,omitempty"`
+	ClusterMode     string       `json:"cluster_mode"` // "master-slave" or "standalone"
+	ClusterHealthy  bool         `json:"cluster_healthy"`
+	TotalInstances  int          `json:"total_instances"`
+	HealthyCount    int          `json:"healthy_count"`
+	MasterCount     int          `json:"master_count"`
+	SlaveCount      int          `json:"slave_count"`
+}
+
+// Config holds cluster configuration.
+type Config struct {
+	// Enabled indicates whether cluster mode is enabled.
+	// When false, runs in standalone mode (single instance).
+	Enabled bool
+
+	// Role specifies this instance's role: "master" or "slave".
+	// Only used when Enabled is true.
+	Role InstanceRole
+
+	// InstanceID is a unique identifier for this instance.
+	// If empty, a UUID will be generated.
+	InstanceID string
+
+	// HeartbeatInterval is how often instances send heartbeats.
+	HeartbeatInterval time.Duration
+
+	// HeartbeatTTL is the TTL for instance heartbeat records.
+	HeartbeatTTL time.Duration
+
+	// InstanceRegistryKey is the Redis key prefix for instance registry.
+	InstanceRegistryKey string
+}
+
+// DefaultConfig returns the default cluster configuration.
+func DefaultConfig() Config {
+	return Config{
+		Enabled:             false,
+		Role:                RoleStandalone,
+		InstanceID:          "",
+		HeartbeatInterval:   5 * time.Second,
+		HeartbeatTTL:        15 * time.Second,
+		InstanceRegistryKey: "cluster:instances",
+	}
+}
+
+// TaskRunner represents a background task that should only run on master.
+type TaskRunner interface {
+	// Name returns the task name for display and logging.
+	Name() string
+
+	// Start begins the task execution.
+	Start()
+
+	// Stop gracefully stops the task.
+	Stop()
+}

--- a/backend/internal/service/cluster/wire.go
+++ b/backend/internal/service/cluster/wire.go
@@ -1,0 +1,112 @@
+package cluster
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/google/uuid"
+	"github.com/google/wire"
+	"github.com/redis/go-redis/v9"
+)
+
+// ProviderSet provides cluster-related dependencies for wire.
+var ProviderSet = wire.NewSet(
+	ProvideClusterConfig,
+	ProvideCoordinator,
+)
+
+// ProvideClusterConfig converts config.ClusterConfig to cluster.Config.
+func ProvideClusterConfig(cfg *config.Config) Config {
+	if cfg == nil {
+		return DefaultConfig()
+	}
+
+	clusterCfg := cfg.Cluster
+
+	// Determine role from config
+	role := RoleStandalone
+	if clusterCfg.Enabled {
+		switch clusterCfg.Role {
+		case "master":
+			role = RoleMaster
+		case "slave":
+			role = RoleSlave
+		default:
+			role = RoleStandalone
+		}
+	}
+
+	// Generate instance ID if not provided
+	instanceID := clusterCfg.InstanceID
+	if instanceID == "" && clusterCfg.Enabled {
+		instanceID = uuid.New().String()[:8]
+	}
+
+	result := Config{
+		Enabled:             clusterCfg.Enabled,
+		Role:                role,
+		InstanceID:          instanceID,
+		InstanceRegistryKey: clusterCfg.InstanceRegistryKey,
+	}
+
+	// Apply defaults for empty values
+	if result.InstanceRegistryKey == "" {
+		result.InstanceRegistryKey = "cluster:instances"
+	}
+
+	// Convert seconds to duration
+	if clusterCfg.HeartbeatIntervalSeconds > 0 {
+		result.HeartbeatInterval = time.Duration(clusterCfg.HeartbeatIntervalSeconds) * time.Second
+	} else {
+		result.HeartbeatInterval = 5 * time.Second
+	}
+
+	if clusterCfg.HeartbeatTTLSeconds > 0 {
+		result.HeartbeatTTL = time.Duration(clusterCfg.HeartbeatTTLSeconds) * time.Second
+	} else {
+		result.HeartbeatTTL = 15 * time.Second
+	}
+
+	return result
+}
+
+// BuildInfo contains build information for cluster registration.
+type BuildInfo struct {
+	Version   string
+	BuildType string
+}
+
+// ProvideCoordinator creates and starts a cluster coordinator.
+// If cluster mode is disabled, returns a standalone coordinator.
+func ProvideCoordinator(rdb *redis.Client, cfg Config, buildInfo BuildInfo) *Coordinator {
+	logger := slog.Default()
+
+	if !cfg.Enabled {
+		logger.Info("cluster mode disabled, running in standalone mode")
+		return NewStandaloneCoordinator()
+	}
+
+	// Create instance registry for status display
+	registry := NewInstanceRegistry(rdb, cfg, buildInfo.Version, logger)
+
+	coordinator := NewCoordinator(registry, cfg, logger)
+
+	logger.Info("cluster coordinator created",
+		"role", cfg.Role,
+		"instance_id", cfg.InstanceID)
+
+	return coordinator
+}
+
+// NewStandaloneCoordinator creates a coordinator for single-instance mode.
+// All background tasks will run locally.
+func NewStandaloneCoordinator() *Coordinator {
+	return &Coordinator{
+		config: Config{
+			Enabled: false,
+			Role:    RoleStandalone,
+		},
+		logger: slog.Default().With("component", "cluster_coordinator_standalone"),
+	}
+}

--- a/backend/internal/service/gateway_tool_rewrite.go
+++ b/backend/internal/service/gateway_tool_rewrite.go
@@ -169,10 +169,10 @@ func buildToolNameRewriteFromBody(body []byte) *ToolNameRewrite {
 
 // applyToolNameRewriteToBody 把已构造的 ToolNameRewrite 应用到 body 上：
 //
-//	- 改写 $.tools[*].name（仅对 shouldMimicToolName 通过的 tool）
-//	- 改写 $.tool_choice.name（仅当 $.tool_choice.type == "tool"）
-//	- 改写 $.messages[*].content[*].name（仅当 type == "tool_use"）
-//	- 在 $.tools[last].cache_control 上打 ephemeral 缓存断点
+//   - 改写 $.tools[*].name（仅对 shouldMimicToolName 通过的 tool）
+//   - 改写 $.tool_choice.name（仅当 $.tool_choice.type == "tool"）
+//   - 改写 $.messages[*].content[*].name（仅当 type == "tool_use"）
+//   - 在 $.tools[last].cache_control 上打 ephemeral 缓存断点
 //
 // 响应侧 bytes.Replace 会连带还原假名 → 真名。
 func applyToolNameRewriteToBody(body []byte, rw *ToolNameRewrite) []byte {
@@ -213,9 +213,8 @@ func applyToolNameRewriteToBody(body []byte, rw *ToolNameRewrite) []byte {
 		}
 	}
 
-	// Rewrite tool_use names in messages to match the renamed tools.
-	// Without this, Anthropic rejects requests where messages reference tools
-	// by their original name but tools[] declares the renamed (fake) name.
+	// 同步改写历史消息中的 tool_use.name，确保它和 tools[] 中的假名一致。
+	// 否则 Anthropic 会因为 tool_use 引用了未声明的原始工具名而拒绝请求。
 	messages := gjson.GetBytes(body, "messages")
 	if messages.IsArray() {
 		messages.ForEach(func(msgKey, msg gjson.Result) bool {

--- a/backend/internal/service/gateway_tool_rewrite_test.go
+++ b/backend/internal/service/gateway_tool_rewrite_test.go
@@ -69,26 +69,25 @@ func TestApplyToolNameRewriteToBody_RenamesToolsAndToolChoice(t *testing.T) {
 	require.NotNil(t, rw)
 	require.Contains(t, rw.Forward, "sessions_list")
 	require.Contains(t, rw.Forward, "session_get")
-	// web_search is a server tool, not rewritten
+	// web_search 是 server tool，不参与工具名改写
 	require.NotContains(t, rw.Forward, "web_search")
 
 	out := applyToolNameRewriteToBody(body, rw)
 
-	// tools[0].name and tools[1].name rewritten; tools[2].name untouched
+	// tools[0].name 和 tools[1].name 被改写，tools[2].name 保持不变
 	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "tools.0.name").String())
 	require.Equal(t, "cc_ses_get", gjson.GetBytes(out, "tools.1.name").String())
 	require.Equal(t, "web_search", gjson.GetBytes(out, "tools.2.name").String())
 
-	// tool_choice.name rewritten
+	// tool_choice.name 被同步改写
 	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "tool_choice.name").String())
 	require.Equal(t, "tool", gjson.GetBytes(out, "tool_choice.type").String())
 }
 
-
 func TestApplyToolNameRewriteToBody_RenamesToolUseInMessages(t *testing.T) {
-	// sessions_list -> cc_sess_list (static prefix: sessions_ -> sessions_)
-	// web_search is a server tool (type != ""), not rewritten
-	// messages tool_use names must be rewritten to match tools[]
+	// sessions_list 通过静态前缀规则改写为 cc_sess_list
+	// web_search 是 server tool（type != ""），不参与工具名改写
+	// messages 中的 tool_use.name 必须同步改写，才能和 tools[] 保持一致
 	body := []byte(`{"tools":[{"name":"sessions_list","input_schema":{}},{"name":"web_search","type":"web_search_20250305"}],"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]},{"role":"assistant","content":[{"type":"tool_use","id":"tu_01","name":"sessions_list","input":{}},{"type":"text","text":"thinking"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_01","content":"ok"}]}]}`)
 	rw := buildToolNameRewriteFromBody(body)
 	require.NotNil(t, rw)
@@ -96,16 +95,40 @@ func TestApplyToolNameRewriteToBody_RenamesToolUseInMessages(t *testing.T) {
 
 	out := applyToolNameRewriteToBody(body, rw)
 
-	// tools[0].name rewritten
+	// tools[0].name 被改写
 	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "tools.0.name").String())
-	// tools[1].name untouched (server tool)
+	// tools[1].name 是 server tool，保持不变
 	require.Equal(t, "web_search", gjson.GetBytes(out, "tools.1.name").String())
-	// messages[1].content[0].name (tool_use) also rewritten to match tools
+	// messages[1].content[0].name 是 tool_use，必须同步改写以匹配 tools[]
 	require.Equal(t, "cc_sess_list", gjson.GetBytes(out, "messages.1.content.0.name").String())
-	// messages[1].content[1] (text) untouched
+	// messages[1].content[1] 是 text，保持不变
 	require.Equal(t, "thinking", gjson.GetBytes(out, "messages.1.content.1.text").String())
-	// messages[2].content[0] (tool_result) untouched — no name field in tool_result
+	// messages[2].content[0] 是 tool_result，不包含 name 字段，保持不变
 	require.Equal(t, "ok", gjson.GetBytes(out, "messages.2.content.0.content").String())
+}
+
+func TestApplyToolNameRewriteToBody_RenamesToolUseWithDynamicMapping(t *testing.T) {
+	body := []byte(`{"tools":[{"name":"alpha_search","input_schema":{}},{"name":"beta_lookup","input_schema":{}},{"name":"gamma_fetch","input_schema":{}},{"name":"delta_update","input_schema":{}},{"name":"epsilon_parse","input_schema":{}},{"name":"zeta_render","input_schema":{}},{"name":"web_search","type":"web_search_20250305"}],"tool_choice":{"type":"tool","name":"gamma_fetch"},"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"tu_dyn","name":"gamma_fetch","input":{}},{"type":"tool_use","id":"tu_srv","name":"web_search","input":{}},{"type":"text","text":"done"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"tu_dyn","content":"ok"}]}]}`)
+	rw := buildToolNameRewriteFromBody(body)
+	require.NotNil(t, rw)
+	require.Len(t, rw.Forward, 6)
+
+	fakeGamma := rw.Forward["gamma_fetch"]
+	require.NotEmpty(t, fakeGamma)
+	require.NotEqual(t, "gamma_fetch", fakeGamma)
+	require.NotContains(t, rw.Forward, "web_search")
+
+	out := applyToolNameRewriteToBody(body, rw)
+
+	// 动态映射会改写 tools[]、tool_choice 和历史 tool_use 中的同一个工具名
+	require.Equal(t, fakeGamma, gjson.GetBytes(out, "tools.2.name").String())
+	require.Equal(t, fakeGamma, gjson.GetBytes(out, "tool_choice.name").String())
+	require.Equal(t, fakeGamma, gjson.GetBytes(out, "messages.0.content.0.name").String())
+	// server tool 不参与动态映射，历史 tool_use 中同名引用也保持不变
+	require.Equal(t, "web_search", gjson.GetBytes(out, "tools.6.name").String())
+	require.Equal(t, "web_search", gjson.GetBytes(out, "messages.0.content.1.name").String())
+	// tool_result 依靠 tool_use_id 关联，不需要 name 字段
+	require.Equal(t, "ok", gjson.GetBytes(out, "messages.1.content.0.content").String())
 }
 
 func TestApplyToolsLastCacheBreakpoint_InjectsDefault(t *testing.T) {

--- a/frontend/src/api/admin/cluster.ts
+++ b/frontend/src/api/admin/cluster.ts
@@ -1,0 +1,72 @@
+/**
+ * Cluster API endpoints for admin operations
+ * Provides cluster status monitoring for distributed deployments
+ */
+
+import { apiClient } from '../client'
+
+export interface ClusterInstance {
+  id: string
+  hostname: string
+  ip?: string
+  role: 'master' | 'slave' | 'standalone'
+  started_at: string
+  last_heartbeat: string
+  status: 'healthy' | 'unhealthy' | 'unknown'
+  running_tasks?: string[]
+  version?: string
+}
+
+export interface ClusterStatusResponse {
+  current_instance: ClusterInstance | null
+  instances: ClusterInstance[]
+  master_id: string
+  cluster_mode: 'master-slave' | 'standalone'
+  cluster_healthy: boolean
+  total_instances: number
+  healthy_count: number
+  master_count: number
+  slave_count: number
+  cluster_enabled: boolean
+}
+
+export interface MasterStatusResponse {
+  is_master: boolean
+  instance_id: string
+  role: 'master' | 'slave' | 'standalone'
+}
+
+/**
+ * Get cluster status
+ * Returns status of all instances in the cluster
+ */
+export async function getClusterStatus(): Promise<ClusterStatusResponse> {
+  const { data } = await apiClient.get<ClusterStatusResponse>('/admin/cluster/status')
+  return data
+}
+
+/**
+ * Get current instance info
+ * Returns information about this specific instance
+ */
+export async function getCurrentInstance(): Promise<ClusterInstance> {
+  const { data } = await apiClient.get<ClusterInstance>('/admin/cluster/instance')
+  return data
+}
+
+/**
+ * Check master status
+ * Returns whether this instance is the master (runs background tasks)
+ */
+export async function getMasterStatus(): Promise<MasterStatusResponse> {
+  const { data } = await apiClient.get<MasterStatusResponse>('/admin/cluster/master')
+  return data
+}
+
+export const clusterAPI = {
+  getClusterStatus,
+  getCurrentInstance,
+  getMasterStatus
+}
+
+export default clusterAPI

--- a/frontend/src/components/admin/ClusterStatusCard.vue
+++ b/frontend/src/components/admin/ClusterStatusCard.vue
@@ -1,0 +1,322 @@
+<template>
+  <div class="card">
+    <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+      <div class="flex items-center justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+            {{ t('admin.cluster.title') }}
+          </h2>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('admin.cluster.description') }}
+          </p>
+        </div>
+        <button
+          type="button"
+          @click="refreshStatus"
+          :disabled="loading"
+          class="btn btn-secondary btn-sm"
+        >
+          <Icon
+            name="refresh"
+            size="sm"
+            :class="{ 'animate-spin': loading }"
+          />
+        </button>
+      </div>
+    </div>
+
+    <div class="p-6">
+      <!-- Loading State -->
+      <div v-if="loading && !status" class="flex items-center gap-2 text-gray-500">
+        <div class="h-4 w-4 animate-spin rounded-full border-b-2 border-primary-600"></div>
+        {{ t('common.loading') }}
+      </div>
+
+      <!-- Cluster Status -->
+      <div v-else-if="status" class="space-y-6">
+        <!-- Overview Stats -->
+        <div class="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div class="rounded-lg bg-gray-50 p-4 dark:bg-dark-700">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+              {{ t('admin.cluster.totalInstances') }}
+            </p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">
+              {{ status.total_instances }}
+            </p>
+          </div>
+          <div class="rounded-lg bg-gray-50 p-4 dark:bg-dark-700">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+              {{ t('admin.cluster.masterSlaveCount') }}
+            </p>
+            <p class="mt-1 text-2xl font-semibold text-gray-900 dark:text-white">
+              {{ status.master_count }} / {{ status.slave_count }}
+            </p>
+          </div>
+          <div class="rounded-lg bg-gray-50 p-4 dark:bg-dark-700">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+              {{ t('admin.cluster.clusterMode') }}
+            </p>
+            <p class="mt-1 text-lg font-semibold" :class="status.cluster_enabled ? 'text-green-600 dark:text-green-400' : 'text-gray-500'">
+              {{ status.cluster_enabled ? t('admin.cluster.enabled') : t('admin.cluster.disabled') }}
+            </p>
+          </div>
+          <div class="rounded-lg bg-gray-50 p-4 dark:bg-dark-700">
+            <p class="text-sm font-medium text-gray-500 dark:text-gray-400">
+              {{ t('admin.cluster.clusterHealth') }}
+            </p>
+            <div class="mt-1 flex items-center gap-2">
+              <span
+                class="h-3 w-3 rounded-full"
+                :class="status.cluster_healthy ? 'bg-green-500' : 'bg-red-500'"
+              ></span>
+              <span class="text-lg font-semibold" :class="status.cluster_healthy ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'">
+                {{ status.cluster_healthy ? t('admin.cluster.healthy') : t('admin.cluster.unhealthy') }}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Current Instance Info -->
+        <div v-if="status.current_instance" class="rounded-lg border border-primary-200 bg-primary-50 p-4 dark:border-primary-800 dark:bg-primary-900/20">
+          <div class="flex items-center gap-2">
+            <Icon name="server" size="md" class="text-primary-600 dark:text-primary-400" />
+            <span class="font-medium text-primary-700 dark:text-primary-300">
+              {{ t('admin.cluster.currentInstance') }}
+            </span>
+            <span
+              class="rounded-full px-2 py-0.5 text-xs font-medium"
+              :class="roleClass(status.current_instance.role)"
+            >
+              {{ roleLabel(status.current_instance.role) }}
+            </span>
+          </div>
+          <div class="mt-2 grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
+            <div>
+              <span class="text-gray-500 dark:text-gray-400">{{ t('admin.cluster.instanceId') }}:</span>
+              <span class="ml-1 font-mono text-gray-900 dark:text-white">{{ truncateId(status.current_instance.id) }}</span>
+            </div>
+            <div>
+              <span class="text-gray-500 dark:text-gray-400">{{ t('admin.cluster.hostname') }}:</span>
+              <span class="ml-1 text-gray-900 dark:text-white">{{ status.current_instance.hostname }}</span>
+            </div>
+            <div v-if="status.current_instance.ip">
+              <span class="text-gray-500 dark:text-gray-400">{{ t('admin.cluster.ip') }}:</span>
+              <span class="ml-1 text-gray-900 dark:text-white">{{ status.current_instance.ip }}</span>
+            </div>
+            <div v-if="status.current_instance.version">
+              <span class="text-gray-500 dark:text-gray-400">{{ t('admin.cluster.version') }}:</span>
+              <span class="ml-1 text-gray-900 dark:text-white">{{ status.current_instance.version }}</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Instance List -->
+        <div v-if="status.instances.length > 0">
+          <h3 class="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300">
+            {{ t('admin.cluster.allInstances') }}
+          </h3>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-gray-200 dark:border-dark-600">
+                  <th class="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.cluster.instanceId') }}
+                  </th>
+                  <th class="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.cluster.hostname') }}
+                  </th>
+                  <th class="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.cluster.status') }}
+                  </th>
+                  <th class="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.cluster.role') }}
+                  </th>
+                  <th class="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.cluster.lastHeartbeat') }}
+                  </th>
+                  <th class="pb-2 text-left font-medium text-gray-500 dark:text-gray-400">
+                    {{ t('admin.cluster.runningTasks') }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="instance in status.instances"
+                  :key="instance.id"
+                  class="border-b border-gray-100 dark:border-dark-700"
+                  :class="{ 'bg-primary-50/50 dark:bg-primary-900/10': instance.id === status.current_instance?.id }"
+                >
+                  <td class="py-3 font-mono text-gray-900 dark:text-white">
+                    {{ truncateId(instance.id) }}
+                  </td>
+                  <td class="py-3 text-gray-900 dark:text-white">
+                    {{ instance.hostname }}
+                  </td>
+                  <td class="py-3">
+                    <span
+                      class="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
+                      :class="statusClass(instance.status)"
+                    >
+                      <span class="h-1.5 w-1.5 rounded-full" :class="statusDotClass(instance.status)"></span>
+                      {{ instance.status }}
+                    </span>
+                  </td>
+                  <td class="py-3">
+                    <span
+                      class="rounded-full px-2 py-0.5 text-xs font-medium"
+                      :class="roleClass(instance.role)"
+                    >
+                      {{ roleLabel(instance.role) }}
+                    </span>
+                  </td>
+                  <td class="py-3 text-gray-500 dark:text-gray-400">
+                    {{ formatTime(instance.last_heartbeat) }}
+                  </td>
+                  <td class="py-3">
+                    <div v-if="instance.running_tasks?.length" class="flex flex-wrap gap-1">
+                      <span
+                        v-for="task in instance.running_tasks.slice(0, 3)"
+                        :key="task"
+                        class="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600 dark:bg-dark-600 dark:text-gray-300"
+                      >
+                        {{ task }}
+                      </span>
+                      <span
+                        v-if="instance.running_tasks.length > 3"
+                        class="text-xs text-gray-500"
+                      >
+                        +{{ instance.running_tasks.length - 3 }}
+                      </span>
+                    </div>
+                    <span v-else class="text-gray-400">-</span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <!-- No Instances (single mode) -->
+        <div v-else class="rounded-lg border border-gray-200 bg-gray-50 p-4 text-center dark:border-dark-600 dark:bg-dark-700">
+          <Icon name="server" size="lg" class="mx-auto text-gray-400" />
+          <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('admin.cluster.singleInstanceMode') }}
+          </p>
+        </div>
+      </div>
+
+      <!-- Error State -->
+      <div v-else class="text-center text-gray-500">
+        {{ t('admin.cluster.loadError') }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { clusterAPI, type ClusterStatusResponse } from '@/api/admin/cluster'
+import Icon from '@/components/icons/Icon.vue'
+
+const { t } = useI18n()
+
+const loading = ref(false)
+const status = ref<ClusterStatusResponse | null>(null)
+let refreshInterval: ReturnType<typeof setInterval> | null = null
+
+const healthyColor = computed(() => {
+  if (!status.value) return 'text-gray-500'
+  if (status.value.healthy_count === status.value.total_instances) {
+    return 'text-green-600 dark:text-green-400'
+  } else if (status.value.healthy_count > 0) {
+    return 'text-amber-600 dark:text-amber-400'
+  }
+  return 'text-red-600 dark:text-red-400'
+})
+
+function truncateId(id: string): string {
+  if (id.length <= 12) return id
+  return id.slice(0, 8) + '...'
+}
+
+function statusClass(status: string): string {
+  switch (status) {
+    case 'healthy':
+      return 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+    case 'unhealthy':
+      return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+    default:
+      return 'bg-gray-100 text-gray-700 dark:bg-dark-600 dark:text-gray-400'
+  }
+}
+
+function statusDotClass(status: string): string {
+  switch (status) {
+    case 'healthy':
+      return 'bg-green-500'
+    case 'unhealthy':
+      return 'bg-red-500'
+    default:
+      return 'bg-gray-400'
+  }
+}
+
+function roleClass(role: string): string {
+  switch (role) {
+    case 'master':
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400'
+    case 'slave':
+      return 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    default:
+      return 'bg-gray-100 text-gray-700 dark:bg-dark-600 dark:text-gray-400'
+  }
+}
+
+function roleLabel(role: string): string {
+  switch (role) {
+    case 'master':
+      return t('admin.cluster.master')
+    case 'slave':
+      return t('admin.cluster.slave')
+    default:
+      return t('admin.cluster.standalone')
+  }
+}
+
+function formatTime(isoString: string): string {
+  if (!isoString) return '-'
+  const date = new Date(isoString)
+  const now = new Date()
+  const diffMs = now.getTime() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  
+  if (diffSec < 60) return `${diffSec}s ago`
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h ago`
+  return date.toLocaleString()
+}
+
+async function refreshStatus() {
+  loading.value = true
+  try {
+    status.value = await clusterAPI.getClusterStatus()
+  } catch (error) {
+    console.error('Failed to fetch cluster status:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  refreshStatus()
+  // Auto-refresh every 10 seconds
+  refreshInterval = setInterval(refreshStatus, 10000)
+})
+
+onUnmounted(() => {
+  if (refreshInterval) {
+    clearInterval(refreshInterval)
+  }
+})
+</script>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1361,6 +1361,37 @@ export default {
       failedToLoad: 'Failed to load dashboard statistics'
     },
 
+    // Cluster
+    cluster: {
+      title: 'Cluster Status',
+      description: 'Master-slave distributed deployment monitoring',
+      totalInstances: 'Total Instances',
+      masterSlaveCount: 'Master/Slave',
+      clusterMode: 'Cluster Mode',
+      clusterHealth: 'Cluster Health',
+      enabled: 'Enabled',
+      disabled: 'Disabled',
+      healthy: 'Healthy',
+      unhealthy: 'Unhealthy',
+      currentInstance: 'Current Instance',
+      master: 'Master',
+      slave: 'Slave',
+      standalone: 'Standalone',
+      instanceId: 'Instance ID',
+      hostname: 'Hostname',
+      ip: 'IP Address',
+      version: 'Version',
+      status: 'Status',
+      role: 'Role',
+      lastHeartbeat: 'Last Heartbeat',
+      runningTasks: 'Running Tasks',
+      allInstances: 'All Instances',
+      singleInstanceMode: 'Running in single instance mode, cluster features are disabled',
+      loadError: 'Failed to load cluster status',
+      masterNote: 'Master runs background tasks and does not receive traffic',
+      slaveNote: 'Slave handles traffic and does not run background tasks'
+    },
+
     backup: {
       title: 'Database Backup',
       description: 'Full database backup to S3-compatible storage with scheduled backup and restore',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -697,7 +697,7 @@ export default {
         configTomlHint: '请确保以下内容位于 config.toml 文件的开头部分',
         note: '请确保配置目录存在。macOS/Linux 用户可运行 mkdir -p ~/.codex 创建目录。',
         noteWindows:
-          '按 Win+R，输入 %userprofile%\\.codex 打开配置目录。如目录不存在，请先手动创建。'
+          '按 Win+R，输入 %userprofile%\\.codex 打开配置目录��如目录不存在，请先手动创建。'
       },
       cliTabs: {
         claudeCode: 'Claude Code',
@@ -821,7 +821,7 @@ export default {
     timeRange: '时间范围',
     exportCsv: '导出 CSV',
     exportExcel: '导出 Excel',
-    exportingProgress: '正在导出数据...',
+    exportingProgress: '正在�����数据...',
     exportedCount: '已导出 {current}/{total} 条',
     estimatedTime: '预计剩余时间：{time}',
     cancelExport: '取消导出',
@@ -1067,7 +1067,7 @@ export default {
     balanceAddedRedeem: '余额充值（兑换）',
     balanceAddedAffiliate: '余额充值（返利转入）',
     balanceAddedAdmin: '余额充值（管理员）',
-    balanceDeductedAdmin: '余额扣除（管理员）',
+    balanceDeductedAdmin: '余额扣除（管��员）',
     concurrencyAddedRedeem: '并发增加（兑换）',
     concurrencyAddedAdmin: '并发增加（管理员）',
     concurrencyReducedAdmin: '并发减少（管理员）',
@@ -1282,7 +1282,7 @@ export default {
   errors: {
     somethingWentWrong: '出错了',
     pageNotFound: '页面未找到',
-    unauthorized: '未授权',
+    unauthorized: '未��权',
     forbidden: '禁止访问',
     serverError: '服务器错误',
     networkError: '网络错误',
@@ -1380,6 +1380,37 @@ export default {
       systemSettings: '系统设置',
       configureSystem: '配置系统设置',
       failedToLoad: '加载仪表盘数据失败'
+    },
+
+    // Cluster
+    cluster: {
+      title: '集群状态',
+      description: '主从模式分布式部署状态监控',
+      totalInstances: '实例总数',
+      masterSlaveCount: '主/从节点',
+      clusterMode: '集群模式',
+      clusterHealth: '集群健康',
+      enabled: '已启用',
+      disabled: '已禁用',
+      healthy: '健康',
+      unhealthy: '异常',
+      currentInstance: '当前实例',
+      master: '主节点',
+      slave: '从节点',
+      standalone: '单机',
+      instanceId: '实例 ID',
+      hostname: '主机名',
+      ip: 'IP 地址',
+      version: '版本',
+      status: '状态',
+      role: '角色',
+      lastHeartbeat: '最后心跳',
+      runningTasks: '运行任务',
+      allInstances: '所有实例',
+      singleInstanceMode: '单实例模式运行中，未启用集群功能',
+      loadError: '加载集群状态失败',
+      masterNote: '主节点运行后台任务，不接收流量',
+      slaveNote: '从节点接收流量，不运行后台任务'
     },
 
     backup: {
@@ -1680,7 +1711,7 @@ export default {
         loadFailed: '加载邀请返利记录失败'
       },
       records: {
-        search: '搜索',
+        search: '搜���',
         searchPlaceholder: '邮箱、用户名、用户 ID、订单号',
         startAt: '开始日期',
         endAt: '结束日期',
@@ -2138,7 +2169,7 @@ export default {
         dailyLimit: '每日限额（USD）',
         weeklyLimit: '每周限额（USD）',
         monthlyLimit: '每月限额（USD）',
-        defaultValidityDays: '默认有效期（天）',
+        defaultValidityDays: '默认有效期��天）',
         validityHint: '分配给用户时订阅的有效天数',
         noLimit: '无限制'
       },
@@ -2362,7 +2393,7 @@ export default {
         searchGroups: '搜索分组...',
         noGroupsMatch: '没有匹配的分组',
         restrictModels: '限制模型',
-        restrictModelsHint: '开启后，仅允许模型定价列表中的模型。不在列表中的模型请求将被拒绝。',
+        restrictModelsHint: '开启后，仅允许模型定价列表中的模型。不在列表���的模型请求将被拒绝。',
         defaultPerRequestPrice: '默认单次价格（未命中层级时使用）',
         defaultImagePrice: '默认图片价格（未命中层级时使用）',
         platformConfig: '平台配置',
@@ -2649,7 +2680,7 @@ export default {
         useMyKey: '使用我的 Key',
         selectKeyTitle: '选择我的 API Key',
         selectKeyHint: '仅显示当前账号下处于「启用」状态且未过期的 Key。',
-        noActiveKey: '没有可用的启用状态 Key',
+        noActiveKey: '没有可用���启用状态 Key',
         primaryModel: '主模型',
         primaryModelPlaceholder: 'gpt-4o-mini',
         extraModels: '附加模型',
@@ -2968,7 +2999,7 @@ export default {
           normal: '5h窗口费用正常'
         },
         sessions: {
-          full: '活跃会话已满，新会话需等待（空闲超时：{idle}分钟）',
+          full: '活跃会话��满，新会话需等待（空闲超时：{idle}分钟）',
           normal: '活跃会话正常（空闲超时：{idle}分钟）'
         },
         rpm: {
@@ -3181,7 +3212,7 @@ export default {
       saving: '保存中...',
       refreshing: '刷新中...',
       testing: '测试中...',
-      noAccounts: '暂无账号',
+      noAccounts: '暂无账���',
       noAccountsDescription: '添加 AI 平台账号以开始使用 API 网关。',
       accountCreatedSuccess: '账号添加成功',
       accountUpdatedSuccess: '账号更新成功',
@@ -3397,7 +3428,7 @@ export default {
           hint: '限制账号在5小时窗口内的费用使用',
           limit: '费用阈值',
           limitPlaceholder: '50',
-          limitHint: '达到阈值后不参与新请求调度',
+          limitHint: '达到阈值后不参与新请���调度',
           stickyReserve: '粘性预留额度',
           stickyReservePlaceholder: '10',
           stickyReserveHint: '为粘性会话预留的额外额度'
@@ -3463,7 +3494,7 @@ export default {
       affinityClients: '{count} 个亲和客户端：',
       affinitySection: '客户端亲和',
       affinitySectionHint: '控制客户端在账号间的分布。通过配置区域阈值来平衡负载。',
-      affinityToggle: '启用客户端亲和',
+      affinityToggle: '启用客���端亲和',
       affinityToggleHint: '新会话优先调度到该客户端之前使用过的账号',
       affinityBase: '基础限额（绿区）',
       affinityBasePlaceholder: '留空表示不限制',
@@ -3725,7 +3756,7 @@ export default {
         apiKeyHint: '您的 Gemini API Key（以 AIza 开头）',
         tier: {
           label: '账号等级',
-          hint: '提示：系统会优先尝试自动识别账号等级；若自动识别不可用或失败，则使用你选择的等级作为回退（本地模拟配额）。',
+          hint: '提示：系统会优先尝试自动识别账号等级；若自动识别不可用或失败，��使用你选择的等级作为回退（本地模拟配额）。',
           aiStudioHint:
             'AI Studio 的配额是按模型分别限流（Pro/Flash 独立）。若已绑卡（按量付费），请选 Pay-as-you-go。',
           googleOne: {
@@ -3771,7 +3802,7 @@ export default {
           title: 'Gemini 使用准备',
           checklistTitle: '准备工作',
           checklistItems: {
-            usIp: '使用美国 IP，并确保账号归属地为美国。',
+            usIp: '使用美国 IP，并确保账号归属地为美��。',
             age: '账号需满 18 岁。'
           },
           activationTitle: '服务激活',
@@ -3790,7 +3821,7 @@ export default {
           note: '注意：Gemini 官方未提供用量查询接口。此处显示的“每日配额”是由系统根据账号等级模拟计算的估算值，仅供调度参考，请以 Google 官方实际报错为准。',
           columns: {
             channel: '授权通道',
-            account: '账号状态',
+            account: '账号状��',
             limits: '限流政策',
             docs: '官方文档'
           },
@@ -3907,7 +3938,7 @@ export default {
         totalTokens: '30天总计',
         dailyAvgTokens: '日均 Token',
         performance: '性能',
-        avgResponseTime: '平均响应',
+        avgResponseTime: '平均响���',
         daysActive: '活跃天数',
         recentActivity: '最近统计',
         todayRequests: '今日请求',
@@ -4521,7 +4552,7 @@ export default {
       other: '其他',
       errorsSla: '错误（SLA范围）',
       upstreamExcl429529: '上游（排除429/529）',
-      failedToLoadData: '加载运维数据失败',
+      failedToLoadData: '加载运维���据失败',
       failedToLoadOverview: '加载概览数据失败',
       failedToLoadThroughputTrend: '加载吞吐趋势失败',
       failedToLoadSwitchTrend: '加载平均账号切换趋势失败',
@@ -4946,7 +4977,7 @@ export default {
           errorRate: '统计窗口内失败请求占比（0~100）。',
           upstreamErrorRate: '统计窗口内上游错误占比（0~100）。',
           p95: '统计窗口内 P95 请求耗时（毫秒）。',
-          p99: '统计窗口内 P99 请求耗时（毫秒）。',
+          p99: '统计窗口内 P99 请求耗时（毫��）。',
           cpu: '当前实例 CPU 使用率（0~100）。',
           memory: '当前实例内存使用率（0~100）。',
           queueDepth: '统计窗口内并发队列排队深度（等待中的请求数）。',
@@ -5225,7 +5256,7 @@ export default {
         db: '数据库连接池状态，包括活跃连接、空闲连接和等待连接数。',
         redis: 'Redis 连接池状态，显示活跃和空闲的连接数。',
         jobs: '后台任务执行状态，包括最近运行时间、成功时间和错误信息。',
-        qps: '每秒查询数（QPS）和每秒Token数（TPS），实时显示系统吞吐量。',
+        qps: '每秒查询数（QPS）和每秒Token数（TPS），实时显示系统吞吐量���',
         tokens: '当前时间窗口内处理的总Token数量。',
         sla: '服务等级协议达成率，排除业务限制（如余额不足、配额超限）的成功请求占比。',
         errors: '错误统计，包括总错误数、错误率和上游错误率。',
@@ -5717,7 +5748,7 @@ export default {
         field_cidWxpay: '微信渠道 ID',
         stripeWebhookHint: '请在 Stripe Dashboard 中将以下地址配置为 Webhook 端点：',
         stripeWebhookApiVersionHint: 'Webhook 端点的 API 版本请与当前集成的 Stripe SDK 对齐，建议选择 {version}；版本不一致可能导致回调事件解析失败。',
-        airwallexWebhookHint: '请在 Airwallex 后台将以下地址配置为 Webhook 端点；事件至少选择 Payment Intent -> Succeeded（payment_intent.succeeded），建议同时选择 Payment Intent -> Cancelled（payment_intent.cancelled）；API version 选择账户默认或最新稳定版本。',
+        airwallexWebhookHint: '请在 Airwallex 后台将以下地址配置为 Webhook 端点；事件至少选择 Payment Intent -> Succeeded（payment_intent.succeeded）��建议同时选择 Payment Intent -> Cancelled（payment_intent.cancelled）；API version 选择账户默认或最新稳定版本。',
         airwallexGuideSummary: '创建 Airwallex Scoped API 密钥时，建议只在账户级权限中为 Payment Acceptance 勾选读取和写入。',
         airwallexGuideNote: '不需要勾选 Spend、Payouts、Transfers、Funds Splits、POS 终端等与在线收款无关的权限。Webhook 事件至少选择 payment_intent.succeeded，建议同时选择 payment_intent.cancelled；API version 选择账户默认或最新稳定版本。',
         limitsTitle: '限额配置',
@@ -5831,7 +5862,7 @@ export default {
         recipientEmailPlaceholder: "test{'@'}example.com",
         sendTestEmail: '发送测试邮件',
         sending: '发送中...',
-        enterRecipientHint: '请输入收件人邮箱地址'
+        enterRecipientHint: '请��入收件人邮箱地址'
       },
       opsMonitoring: {
         title: '运维监控',
@@ -6171,7 +6202,7 @@ export default {
       editRule: '编辑规则',
       deleteRule: '删除规则',
       noRules: '暂无规则',
-      createFirstRule: '创建第一条错误透传规则',
+      createFirstRule: '创建��一条错误透传规则',
       allPlatforms: '所有平台',
       passthrough: '透传',
       custom: '自定义',
@@ -6380,7 +6411,7 @@ export default {
     total: '条公告',
     emptyDescription: '暂时没有任何系统公告',
     readStatus: '您已阅读此公告',
-    markReadHint: '点击"已读"标记此公告'
+    markReadHint: '点击"已读"���记此公告'
   },
 
   // User Subscriptions Page
@@ -6468,7 +6499,7 @@ export default {
       groupSubmit: {
         title: '✅ 保存分组',
         description:
-          '<div style="line-height: 1.7;"><p style="margin-bottom: 12px;">确认信息无误后，点击创建按钮保存分组。</p><p style="padding: 8px 12px; background: #fef3c7; border-left: 3px solid #f59e0b; border-radius: 4px; font-size: 13px; margin-bottom: 12px;"><b>⚠️ 注意：</b>分组创建后，平台类型不可修改，其他信息可以随时编辑</p><p style="padding: 8px 12px; background: #f0fdf4; border-left: 3px solid #10b981; border-radius: 4px; font-size: 13px;"><b>📌 下一步：</b>创建成功后，我们将添加上游账号到这个分组</p><p style="margin-top: 12px; color: #10b981; font-weight: 600;">👉 点击"创建"按钮</p></div>'
+          '<div style="line-height: 1.7;"><p style="margin-bottom: 12px;">确认信息无误后，点击创��按钮保存分组。</p><p style="padding: 8px 12px; background: #fef3c7; border-left: 3px solid #f59e0b; border-radius: 4px; font-size: 13px; margin-bottom: 12px;"><b>⚠️ 注意：</b>分组创建后，平台类型不可修改，其他信息可以随时编辑</p><p style="padding: 8px 12px; background: #f0fdf4; border-left: 3px solid #10b981; border-radius: 4px; font-size: 13px;"><b>📌 下一步：</b>创建成功后，我们将添加上游账号到这个分组</p><p style="margin-top: 12px; color: #10b981; font-weight: 600;">👉 点击"创建"按钮</p></div>'
       },
       accountManage: {
         title: '🔗 第二步：添加账号',
@@ -6540,7 +6571,7 @@ export default {
       keySubmit: {
         title: '🎉 生成并复制',
         description:
-          '<div style="line-height: 1.7;"><p style="margin-bottom: 12px;">点击创建后，系统会生成完整的 API Key。</p><div style="padding: 8px 12px; background: #fee2e2; border-left: 3px solid #ef4444; border-radius: 4px; font-size: 13px; margin-bottom: 12px;"><b>⚠️ 重要提醒：</b><ul style="margin: 8px 0 0 16px;"><li>密钥只显示一次，请立即复制</li><li>丢失后需要重新生成</li><li>妥善保管，不要泄露给他人</li></ul></div><div style="padding: 8px 12px; background: #f0fdf4; border-left: 3px solid #10b981; border-radius: 4px; font-size: 13px; margin-bottom: 12px;"><b>🚀 下一步：</b><ul style="margin: 8px 0 0 16px;"><li>复制生成的 sk-xxx 密钥</li><li>在支持 OpenAI 接口的客户端中使用</li><li>开始体验 AI 服务！</li></ul></div><p style="margin-top: 12px; color: #10b981; font-weight: 600;">👉 点击"创建"按钮</p></div>'
+          '<div style="line-height: 1.7;"><p style="margin-bottom: 12px;">点击创建后，系统会生成完整的 API Key。</p><div style="padding: 8px 12px; background: #fee2e2; border-left: 3px solid #ef4444; border-radius: 4px; font-size: 13px; margin-bottom: 12px;"><b>⚠️ 重要提醒：</b><ul style="margin: 8px 0 0 16px;"><li>密钥只显示一次，请立即复制</li><li>丢失��需要重新生成</li><li>妥善保管，不要泄露给他人</li></ul></div><div style="padding: 8px 12px; background: #f0fdf4; border-left: 3px solid #10b981; border-radius: 4px; font-size: 13px; margin-bottom: 12px;"><b>🚀 下一步：</b><ul style="margin: 8px 0 0 16px;"><li>复制生成的 sk-xxx 密钥</li><li>在支持 OpenAI 接口的客户端中使用</li><li>开始体验 AI 服务！</li></ul></div><p style="margin-top: 12px; color: #10b981; font-weight: 600;">👉 点击"创建"按钮</p></div>'
       }
     },
     // User tour steps
@@ -6548,7 +6579,7 @@ export default {
       welcome: {
         title: '👋 欢迎使用 Sub2API',
         description:
-          '<div style="line-height: 1.8;"><p style="margin-bottom: 16px;">您好！欢迎来到 Sub2API AI 服务平台。</p><p style="margin-bottom: 12px;"><b>🎯 快速开始：</b></p><ul style="margin-left: 20px; margin-bottom: 16px;"><li>🔑 创建 API 密钥</li><li>📋 复制密钥到您的应用</li><li>🚀 开始使用 AI 服务</li></ul><p style="color: #10b981; font-weight: 600;">只需 1 分钟，让我们开始吧 →</p></div>',
+          '<div style="line-height: 1.8;"><p style="margin-bottom: 16px;">您好！欢迎来到 Sub2API AI 服务平台。</p><p style="margin-bottom: 12px;"><b>🎯 快速开始：</b></p><ul style="margin-left: 20px; margin-bottom: 16px;"><li>🔑 创建 API 密钥</li><li>���� 复制密钥到您的应用</li><li>🚀 开始使用 AI 服务</li></ul><p style="color: #10b981; font-weight: 600;">只需 1 分钟，让我们开始吧 →</p></div>',
         nextBtn: '开始 🚀',
         prevBtn: '跳过'
       },
@@ -6662,7 +6693,7 @@ export default {
       subscriptionSuccess: '订阅成功',
       processing: '支付处理中',
       processingHint: '支付结果仍在确认中，页面会自动刷新。',
-      failed: '支付失败',
+      failed: '支付��败',
       backToRecharge: '返回充值',
       viewOrders: '查看订单',
     },


### PR DESCRIPTION
## Summary

This PR adds distributed cluster deployment support using a **static master-slave configuration model**.

## Changes

### Backend
- Add `cluster` package with coordinator, instance registry, and type definitions
- Support static master-slave configuration via config file
- Master runs background tasks, slaves handle API traffic
- Add Redis-based OAuth session storage for cross-instance consistency
- Add cluster status API endpoints

### Frontend
- Add cluster status monitoring component
- Add Chinese and English i18n support

## Architecture
┌─────────────────────────────────────┐
│          Load Balancer              │
│  - HTTP: round-robin                │
│  - WebSocket: sticky session        │
└─────────────────────────────────────┘
│                    │
┌──────────┴───┐          ┌─────┴──────────┐
│   Slave 1    │          │    Slave 2     │
│  (traffic)   │          │   (traffic)    │
└──────────────┘          └────────────────┘

┌─────────────────────────────────────┐
│             Master                  │
│  (background tasks, no traffic)     │
└─────────────────────────────────────┘

## Configuration

```yaml
# Master node
cluster:
  enabled: true
  role: master
  instance_id: "master-01"

# Slave node
cluster:
  enabled: true
  role: slave
  instance_id: "slave-01"
```
  
## Note
This is a **simple static master-slave mode** where roles are determined by configuration file. It assumes the master node will not fail.

**Future enhancement**: Can be upgraded to automatic leader election (e.g., Raft-based or Redis Redlock) for higher availability if needed.
