### PR TITLE
feat(privacy): OpenAI 账号隐私批量操作 + Ensure 内存同步修复

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -2200,6 +2200,204 @@ func (h *AccountHandler) BatchRefreshTier(c *gin.Context) {
 	response.Success(c, results)
 }
 
+// BatchSetPrivacy handles batch setting privacy for OpenAI OAuth accounts
+// POST /api/v1/admin/accounts/batch-set-privacy
+func (h *AccountHandler) BatchSetPrivacy(c *gin.Context) {
+	var req struct {
+		AccountIDs []int64 `json:"account_ids"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	if len(req.AccountIDs) == 0 {
+		response.BadRequest(c, "account_ids is required")
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	accounts, err := h.adminService.GetAccountsByIDs(ctx, req.AccountIDs)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	// 建立已获取账号的 ID 集合，检测缺失的 ID
+	foundIDs := make(map[int64]bool, len(accounts))
+	for _, acc := range accounts {
+		if acc != nil {
+			foundIDs[acc.ID] = true
+		}
+	}
+
+	const maxConcurrency = 5
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrency)
+
+	var mu sync.Mutex
+	var successCount, failedCount, skippedCount int
+	var errors []gin.H
+
+	// 将不存在的账号 ID 标记为失败
+	for _, id := range req.AccountIDs {
+		if !foundIDs[id] {
+			mu.Lock()
+			failedCount++
+			errors = append(errors, gin.H{
+				"account_id": id,
+				"error":      "账号不存在",
+			})
+			mu.Unlock()
+		}
+	}
+
+	for _, account := range accounts {
+		acc := account // 闭包捕获
+		if acc == nil {
+			continue
+		}
+		g.Go(func() error {
+			// 跳过非 OpenAI OAuth 账号
+			if acc.Platform != service.PlatformOpenAI || acc.Type != service.AccountTypeOAuth {
+				mu.Lock()
+				skippedCount++
+				errors = append(errors, gin.H{
+					"account_id": acc.ID,
+					"error":      "跳过：仅 OpenAI OAuth 账号支持设置隐私",
+				})
+				mu.Unlock()
+				return nil
+			}
+			mode := h.adminService.ForceOpenAIPrivacy(gctx, acc)
+			mu.Lock()
+			if mode == "" {
+				failedCount++
+				errors = append(errors, gin.H{
+					"account_id": acc.ID,
+					"error":      "设置隐私失败：缺少 access_token 或请求失败",
+				})
+			} else {
+				successCount++
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, gin.H{
+		"total":   len(req.AccountIDs),
+		"success": successCount,
+		"failed":  failedCount,
+		"skipped": skippedCount,
+		"errors":  errors,
+	})
+}
+
+// BatchClearPrivacy handles batch clearing privacy_mode for OpenAI OAuth accounts
+// POST /api/v1/admin/accounts/batch-clear-privacy
+func (h *AccountHandler) BatchClearPrivacy(c *gin.Context) {
+	var req struct {
+		AccountIDs []int64 `json:"account_ids"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	if len(req.AccountIDs) == 0 {
+		response.BadRequest(c, "account_ids is required")
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	accounts, err := h.adminService.GetAccountsByIDs(ctx, req.AccountIDs)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	// 建立已获取账号的 ID 集合，检测缺失的 ID
+	foundIDs := make(map[int64]bool, len(accounts))
+	for _, acc := range accounts {
+		if acc != nil {
+			foundIDs[acc.ID] = true
+		}
+	}
+
+	const maxConcurrency = 10
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrency)
+
+	var mu sync.Mutex
+	var successCount, failedCount, skippedCount int
+	var batchErrors []gin.H
+
+	// 将不存在的账号 ID 标记为失败
+	for _, id := range req.AccountIDs {
+		if !foundIDs[id] {
+			mu.Lock()
+			failedCount++
+			batchErrors = append(batchErrors, gin.H{
+				"account_id": id,
+				"error":      "账号不存在",
+			})
+			mu.Unlock()
+		}
+	}
+
+	for _, account := range accounts {
+		acc := account // 闭包捕获
+		if acc == nil {
+			continue
+		}
+		g.Go(func() error {
+			// 跳过非 OpenAI OAuth 账号
+			if acc.Platform != service.PlatformOpenAI || acc.Type != service.AccountTypeOAuth {
+				mu.Lock()
+				skippedCount++
+				batchErrors = append(batchErrors, gin.H{
+					"account_id": acc.ID,
+					"error":      "跳过：仅 OpenAI OAuth 账号支持清除隐私状态",
+				})
+				mu.Unlock()
+				return nil
+			}
+			clearErr := h.adminService.ClearAccountPrivacyMode(gctx, acc)
+			mu.Lock()
+			if clearErr != nil {
+				failedCount++
+				batchErrors = append(batchErrors, gin.H{
+					"account_id": acc.ID,
+					"error":      clearErr.Error(),
+				})
+			} else {
+				successCount++
+			}
+			mu.Unlock()
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	response.Success(c, gin.H{
+		"total":   len(req.AccountIDs),
+		"success": successCount,
+		"failed":  failedCount,
+		"skipped": skippedCount,
+		"errors":  batchErrors,
+	})
+}
+
 // GetAntigravityDefaultModelMapping 获取 Antigravity 平台的默认模型映射
 // GET /api/v1/admin/accounts/antigravity/default-model-mapping
 func (h *AccountHandler) GetAntigravityDefaultModelMapping(c *gin.Context) {

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -605,6 +605,10 @@ func (s *stubAdminService) ForceAntigravityPrivacy(ctx context.Context, account 
 	return ""
 }
 
+func (s *stubAdminService) ClearAccountPrivacyMode(ctx context.Context, account *service.Account) error {
+	return nil
+}
+
 func (s *stubAdminService) ReplaceUserGroup(ctx context.Context, userID, oldGroupID, newGroupID int64) (*service.ReplaceUserGroupResult, error) {
 	return &service.ReplaceUserGroupResult{MigratedKeys: 0}, nil
 }

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -311,6 +311,8 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		accounts.POST("/bulk-update", h.Admin.Account.BulkUpdate)
 		accounts.POST("/batch-clear-error", h.Admin.Account.BatchClearError)
 		accounts.POST("/batch-refresh", h.Admin.Account.BatchRefresh)
+		accounts.POST("/batch-set-privacy", h.Admin.Account.BatchSetPrivacy)
+		accounts.POST("/batch-clear-privacy", h.Admin.Account.BatchClearPrivacy)
 
 		// Antigravity 默认模型映射
 		accounts.GET("/antigravity/default-model-mapping", h.Admin.Account.GetAntigravityDefaultModelMapping)

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -3587,7 +3587,14 @@ func (s *adminServiceImpl) EnsureOpenAIPrivacy(ctx context.Context, account *Acc
 		return ""
 	}
 
-	_ = s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{"privacy_mode": mode})
+	if err := s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{"privacy_mode": mode}); err != nil {
+		logger.LegacyPrintf("service.admin", "update_openai_privacy_mode_failed: account_id=%d err=%v", account.ID, err)
+		return mode
+	}
+	if account.Extra == nil {
+		account.Extra = make(map[string]any)
+	}
+	account.Extra["privacy_mode"] = mode
 	return mode
 }
 

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -84,6 +84,10 @@ type AdminService interface {
 	ForceOpenAIPrivacy(ctx context.Context, account *Account) string
 	// ForceAntigravityPrivacy 强制重新设置 Antigravity OAuth 账号隐私，无论当前状态。
 	ForceAntigravityPrivacy(ctx context.Context, account *Account) string
+	// ClearAccountPrivacyMode 清除账号的 privacy_mode 字段（设置为空字符串），
+	// 使下次 EnsureOpenAIPrivacy 能重新生效。
+	// 仅对 OpenAI OAuth 账号操作，其他账号类型返回 error。
+	ClearAccountPrivacyMode(ctx context.Context, account *Account) error
 	SetAccountSchedulable(ctx context.Context, id int64, schedulable bool) (*Account, error)
 	BulkUpdateAccounts(ctx context.Context, input *BulkUpdateAccountsInput) (*BulkUpdateAccountsResult, error)
 	CheckMixedChannelRisk(ctx context.Context, currentAccountID int64, currentAccountPlatform string, groupIDs []int64) error
@@ -3695,4 +3699,22 @@ func (s *adminServiceImpl) ForceAntigravityPrivacy(ctx context.Context, account 
 	}
 	applyAntigravityPrivacyMode(account, mode)
 	return mode
+}
+
+// ClearAccountPrivacyMode 清除账号的 privacy_mode 字段（设置为空字符串），
+// 使下次 EnsureOpenAIPrivacy 能重新尝试设置。
+// 仅对 OpenAI OAuth 账号操作，其他平台或类型返回 error。
+func (s *adminServiceImpl) ClearAccountPrivacyMode(ctx context.Context, account *Account) error {
+	if account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth {
+		return errors.New("仅 OpenAI OAuth 账号支持清除隐私状态")
+	}
+	if err := s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{"privacy_mode": ""}); err != nil {
+		logger.LegacyPrintf("service.admin", "clear_openai_privacy_mode_failed: account_id=%d err=%v", account.ID, err)
+		return err
+	}
+	if account.Extra == nil {
+		account.Extra = make(map[string]any)
+	}
+	account.Extra["privacy_mode"] = ""
+	return nil
 }

--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -472,6 +472,10 @@ func (s *TokenRefreshService) ensureOpenAIPrivacy(ctx context.Context, account *
 			"account_id", account.ID,
 			"privacy_mode", mode,
 		)
+		if account.Extra == nil {
+			account.Extra = make(map[string]any)
+		}
+		account.Extra["privacy_mode"] = mode
 	}
 }
 

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -597,6 +597,7 @@ export interface BatchOperationResult {
   total: number
   success: number
   failed: number
+  skipped?: number
   errors?: Array<{ account_id: number; error: string }>
   warnings?: Array<{ account_id: number; warning: string }>
 }
@@ -637,6 +638,32 @@ export async function setPrivacy(id: number): Promise<Account> {
   return data
 }
 
+/**
+ * Batch set privacy (force training_off) for OpenAI OAuth accounts
+ * @param accountIds - Array of account IDs
+ * @returns Batch operation result
+ */
+export async function batchSetPrivacy(accountIds: number[]): Promise<BatchOperationResult> {
+  const { data } = await apiClient.post<BatchOperationResult>('/admin/accounts/batch-set-privacy', {
+    account_ids: accountIds,
+  }, {
+    timeout: 120000 // 120s，批量设置隐私可能耗时
+  })
+  return data
+}
+
+/**
+ * Batch clear privacy_mode for OpenAI OAuth accounts
+ * @param accountIds - Array of account IDs
+ * @returns Batch operation result
+ */
+export async function batchClearPrivacy(accountIds: number[]): Promise<BatchOperationResult> {
+  const { data } = await apiClient.post<BatchOperationResult>('/admin/accounts/batch-clear-privacy', {
+    account_ids: accountIds,
+  })
+  return data
+}
+
 export const accountsAPI = {
   list,
   listWithEtag,
@@ -674,7 +701,9 @@ export const accountsAPI = {
   getAntigravityDefaultModelMapping,
   batchClearError,
   batchRefresh,
-  setPrivacy
+  setPrivacy,
+  batchSetPrivacy,
+  batchClearPrivacy
 }
 
 export default accountsAPI

--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -28,6 +28,8 @@
         <button @click="$emit('delete')" class="btn btn-danger btn-sm">{{ t('admin.accounts.bulkActions.delete') }}</button>
         <button @click="$emit('reset-status')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
         <button @click="$emit('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
+        <button @click="$emit('set-privacy')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.setPrivacy') }}</button>
+        <button @click="$emit('clear-privacy')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.clearPrivacy') }}</button>
         <button @click="$emit('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
         <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
         <button @click="$emit('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
@@ -41,5 +43,5 @@
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
-defineProps(['selectedIds']); defineEmits(['delete', 'edit-selected', 'edit-filtered', 'clear', 'select-page', 'toggle-schedulable', 'reset-status', 'refresh-token']); const { t } = useI18n()
+defineProps(['selectedIds']); defineEmits(['delete', 'edit-selected', 'edit-filtered', 'clear', 'select-page', 'toggle-schedulable', 'reset-status', 'refresh-token', 'set-privacy', 'clear-privacy']); const { t } = useI18n()
 </script>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3053,9 +3053,16 @@ export default {
         disableScheduling: 'Disable Scheduling',
         resetStatus: 'Reset Status',
         refreshToken: 'Refresh Token',
+        setPrivacy: 'Set Privacy',
+        clearPrivacy: 'Clear Privacy Status',
+        confirmSetPrivacy: 'This will call the OpenAI API to force training data sharing OFF for the selected accounts. Continue?',
+        confirmClearPrivacy: 'This will clear the locally stored privacy state (no OpenAI call) so the next refresh re-checks and applies it. Continue?',
         resetStatusSuccess: 'Successfully reset {count} account(s) status',
         refreshTokenSuccess: 'Successfully refreshed {count} account(s) token',
-        partialSuccess: 'Partially completed: {success} succeeded, {failed} failed'
+        setPrivacySuccess: 'Successfully set privacy for {count} account(s)',
+        clearPrivacySuccess: 'Successfully cleared privacy status for {count} account(s)',
+        partialSuccess: 'Partially completed: {success} succeeded, {failed} failed',
+        partialSuccessWithSkipped: 'Partially completed: {success} succeeded, {failed} failed, {skipped} skipped (non-OpenAI OAuth)'
       },
       bulkEdit: {
         title: 'Bulk Edit Accounts',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3200,9 +3200,16 @@ export default {
         disableScheduling: '批量停止调度',
         resetStatus: '批量重置状态',
         refreshToken: '批量刷新令牌',
+        setPrivacy: '批量设置隐私',
+        clearPrivacy: '批量清除隐私状态',
+        confirmSetPrivacy: '将向 OpenAI 发起 API 请求，强制把所选账号的训练数据共享设为关闭。是否继续？',
+        confirmClearPrivacy: '将清空所选账号本地保存的隐私状态（不调用 OpenAI），下次刷新时会重新检查并设置。是否继续？',
         resetStatusSuccess: '已成功重置 {count} 个账号状态',
         refreshTokenSuccess: '已成功刷新 {count} 个账号令牌',
-        partialSuccess: '操作部分完成：{success} 成功，{failed} 失败'
+        setPrivacySuccess: '已成功为 {count} 个账号设置隐私',
+        clearPrivacySuccess: '已成功清除 {count} 个账号的隐私状态',
+        partialSuccess: '操作部分完成：{success} 成功，{failed} 失败',
+        partialSuccessWithSkipped: '操作部分完成：{success} 成功，{failed} 失败，{skipped} 已跳过（非 OpenAI OAuth 账号）'
       },
       bulkEdit: {
         title: '批量编辑账号',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -177,6 +177,8 @@
           @delete="handleBulkDelete"
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
+          @set-privacy="handleBulkSetPrivacy"
+          @clear-privacy="handleBulkClearPrivacy"
           @edit-selected="openBulkEditSelected"
           @edit-filtered="openBulkEditFiltered"
           @clear="clearSelection"
@@ -1232,6 +1234,40 @@ const handleBulkRefreshToken = async () => {
     reload()
   } catch (error) {
     console.error('Failed to bulk refresh token:', error)
+    appStore.showError(String(error))
+  }
+}
+const handleBulkSetPrivacy = async () => {
+  if (!confirm(t('admin.accounts.bulkActions.confirmSetPrivacy'))) return
+  try {
+    const result = await adminAPI.accounts.batchSetPrivacy(selIds.value)
+    const skipped = result.skipped ?? 0
+    if (result.failed > 0 || skipped > 0) {
+      appStore.showError(t('admin.accounts.bulkActions.partialSuccessWithSkipped', { success: result.success, failed: result.failed, skipped }))
+    } else {
+      appStore.showSuccess(t('admin.accounts.bulkActions.setPrivacySuccess', { count: result.success }))
+      clearSelection()
+    }
+    reload()
+  } catch (error) {
+    console.error('Failed to bulk set privacy:', error)
+    appStore.showError(String(error))
+  }
+}
+const handleBulkClearPrivacy = async () => {
+  if (!confirm(t('admin.accounts.bulkActions.confirmClearPrivacy'))) return
+  try {
+    const result = await adminAPI.accounts.batchClearPrivacy(selIds.value)
+    const skipped = result.skipped ?? 0
+    if (result.failed > 0 || skipped > 0) {
+      appStore.showError(t('admin.accounts.bulkActions.partialSuccessWithSkipped', { success: result.success, failed: result.failed, skipped }))
+    } else {
+      appStore.showSuccess(t('admin.accounts.bulkActions.clearPrivacySuccess', { count: result.success }))
+      clearSelection()
+    }
+    reload()
+  } catch (error) {
+    console.error('Failed to bulk clear privacy:', error)
     appStore.showError(String(error))
   }
 }


### PR DESCRIPTION
- **批量隐私操作**：新增 `/admin/accounts/batch-set-privacy` 和 `/batch-clear-privacy` 两个端点，前端账号管理页新增对应批量按钮。批量设置走 `ForceOpenAIPrivacy` 强制下发到
  ChatGPT settings API；批量清除仅清空本地 `privacy_mode`，不调外部 API。仅作用于 OpenAI OAuth 账号，非匹配账号在响应中标记 `skipped`。
  - **Ensure 内存同步修复**：`EnsureOpenAIPrivacy` / `ensureOpenAIPrivacy` 写 DB 成功后同步更新 `account.Extra["privacy_mode"]`。修复了调度器缓存中的 account 指针 stale 导致
  `shouldSkipOpenAIPrivacyEnsure` 不生效、下个刷新周期重复 PATCH ChatGPT settings API 的问题。skip guard 路径与 DB 失败路径不变。