### PR TITLE
fix: use auto tool choice for OpenAI image responses

### DIFF
--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -227,7 +227,7 @@ func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel st
 		return nil, fmt.Errorf("image input is required")
 	}
 
-	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":{"type":"image_generation"}}`)
+	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":"auto"}`)
 	req, _ = sjson.SetBytes(req, "model", openAIImagesResponsesMainModel)
 
 	input := []byte(`[{"type":"message","role":"user","content":[{"type":"input_text","text":""}]}]`)

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -1124,6 +1124,21 @@ func TestBuildOpenAIImagesResponsesRequest_DowngradesMultipleImagesToSingle(t *t
 	require.Equal(t, "draw a cat", gjson.GetBytes(body, "input.0.content.0.text").String())
 }
 
+func TestBuildOpenAIImagesResponsesRequest_UsesAutoToolChoice(t *testing.T) {
+	parsed := &OpenAIImagesRequest{
+		Endpoint: openAIImagesGenerationsEndpoint,
+		Model:    "gpt-image-1.5",
+		Prompt:   "draw a cat",
+	}
+
+	body, err := buildOpenAIImagesResponsesRequest(parsed, "gpt-image-1.5")
+	require.NoError(t, err)
+	require.NotNil(t, body)
+	require.Equal(t, "auto", gjson.GetBytes(body, "tool_choice").String())
+	require.Equal(t, "image_generation", gjson.GetBytes(body, "tools.0.type").String())
+	require.Equal(t, "gpt-image-1.5", gjson.GetBytes(body, "tools.0.model").String())
+}
+
 func TestBuildOpenAIImagesResponsesRequest_StripsInputFidelity(t *testing.T) {
 	parsed := &OpenAIImagesRequest{
 		Endpoint:      openAIImagesEditsEndpoint,


### PR DESCRIPTION
## Summary

- Change OpenAI OAuth image Responses requests to use `tool_choice: "auto"` instead of forcing `{"type":"image_generation"}`.
- Keep the `image_generation` tool attached with the requested GPT image model.
- Add a regression test for the request payload shape.

## Root Cause

ChatGPT Codex `/backend-api/codex/responses` rejects image requests with:

`Tool choice 'image_generation' not found in 'tools' parameter.`

Live probing showed the request body did include `tools: [{"type":"image_generation", ...}]`, but the Codex endpoint still rejected the forced object-form tool choice. The same request with `tool_choice: "auto"` is accepted by upstream parameter validation.

## Scope

This fixes the immediate 400 caused by the forced `tool_choice` payload shape. It does not claim that every ChatGPT account tier can actually execute the image tool; in a Free OAuth probe, upstream accepted the request but returned `tools: []` and no `image_generation_call`.

Related issue: #2111

## Tests

- `GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod go test ./internal/service -run 'OpenAIImage|BuildOpenAIImagesResponsesRequest|CollectOpenAIImagesFromResponsesBody' -count=1`
- `git diff --check`
