### PR TITLE
fix(auth): prefer OIDC compat email in pending flow

### DIFF
--- a/frontend/src/views/auth/OidcCallbackView.vue
+++ b/frontend/src/views/auth/OidcCallbackView.vue
@@ -338,6 +338,7 @@ type PendingOidcCompletion = PendingOAuthExchangeResponse & {
   pending_email?: string
   resolved_email?: string
   existing_account_email?: string
+  compat_email?: string
   email?: string
   suggested_email?: string
   provider_fallback?: string
@@ -461,6 +462,7 @@ function extractPendingAccountEmail(completion: PendingOidcCompletion): string {
   return (
     completion.pending_email ||
     completion.existing_account_email ||
+    completion.compat_email ||
     completion.resolved_email ||
     completion.email ||
     completion.suggested_email ||


### PR DESCRIPTION
## Summary
- include `compat_email` in the OIDC pending completion type
- prefer provider-compatible email before synthetic OIDC emails when pre-filling the pending account flow

## Why
OIDC pending account flow can receive a real provider email in `compat_email`, while the internal `email`/`resolved_email` may be a synthetic `@oidc-connect.invalid` address. Preferring `compat_email` avoids showing the synthetic address to users when a real email is available.

## Testing
- `pnpm --dir frontend run build`