### PR TITLE
Fix Redis self-signed TLS and Bedrock compat routing

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1051,6 +1051,8 @@ type RedisConfig struct {
 	MinIdleConns int `mapstructure:"min_idle_conns"`
 	// EnableTLS: 是否启用 TLS/SSL 连接
 	EnableTLS bool `mapstructure:"enable_tls"`
+	// TLSSkipVerify: 跳过 Redis TLS 证书校验，仅建议临时调试或私有网络兜底使用
+	TLSSkipVerify bool `mapstructure:"tls_skip_verify"`
 }
 
 func (r *RedisConfig) Address() string {
@@ -1559,6 +1561,7 @@ func setDefaults() {
 	viper.SetDefault("redis.pool_size", 1024)
 	viper.SetDefault("redis.min_idle_conns", 128)
 	viper.SetDefault("redis.enable_tls", false)
+	viper.SetDefault("redis.tls_skip_verify", true)
 
 	// Ops (vNext)
 	viper.SetDefault("ops.enabled", true)

--- a/backend/internal/repository/redis.go
+++ b/backend/internal/repository/redis.go
@@ -39,11 +39,16 @@ func buildRedisOptions(cfg *config.Config) *redis.Options {
 	}
 
 	if cfg.Redis.EnableTLS {
-		opts.TLSConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ServerName: cfg.Redis.Host,
-		}
+		opts.TLSConfig = buildRedisTLSConfig(cfg.Redis)
 	}
 
 	return opts
+}
+
+func buildRedisTLSConfig(cfg config.RedisConfig) *tls.Config {
+	return &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         cfg.Host,
+		InsecureSkipVerify: cfg.TLSSkipVerify, //nolint:gosec // explicit Redis deployment option for private/self-signed servers
+	}
 }

--- a/backend/internal/repository/redis_test.go
+++ b/backend/internal/repository/redis_test.go
@@ -37,11 +37,13 @@ func TestBuildRedisOptions(t *testing.T) {
 	// Test case with TLS enabled
 	cfgTLS := &config.Config{
 		Redis: config.RedisConfig{
-			Host:      "localhost",
-			EnableTLS: true,
+			Host:          "localhost",
+			EnableTLS:     true,
+			TLSSkipVerify: true,
 		},
 	}
 	optsTLS := buildRedisOptions(cfgTLS)
 	require.NotNil(t, optsTLS.TLSConfig)
 	require.Equal(t, "localhost", optsTLS.TLSConfig.ServerName)
+	require.True(t, optsTLS.TLSConfig.InsecureSkipVerify)
 }

--- a/backend/internal/service/gateway_compat_bedrock.go
+++ b/backend/internal/service/gateway_compat_bedrock.go
@@ -1,0 +1,222 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+type bedrockCompatErrorWriter func(c *gin.Context, statusCode int, code, message string)
+
+func (s *GatewayService) forwardCompatBedrockAnthropicStream(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	anthropicBody []byte,
+	model string,
+	stream bool,
+	writeError bedrockCompatErrorWriter,
+) (*http.Response, string, error) {
+	region := bedrockRuntimeRegion(account)
+	mappedModel, ok := ResolveBedrockModelID(account, model)
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported bedrock model: %s", model)
+	}
+
+	betaHeader := ""
+	if c != nil && c.Request != nil {
+		betaHeader = c.GetHeader("anthropic-beta")
+	}
+	betaTokens, err := s.resolveBedrockBetaTokensForRequest(ctx, account, betaHeader, anthropicBody, mappedModel)
+	if err != nil {
+		return nil, "", err
+	}
+	bedrockBody, err := PrepareBedrockRequestBodyWithTokens(anthropicBody, mappedModel, betaTokens)
+	if err != nil {
+		return nil, "", fmt.Errorf("prepare bedrock request body: %w", err)
+	}
+
+	var signer *BedrockSigner
+	var bedrockAPIKey string
+	if account.IsBedrockAPIKey() {
+		bedrockAPIKey = account.GetCredential("api_key")
+		if bedrockAPIKey == "" {
+			return nil, "", fmt.Errorf("api_key not found in bedrock credentials")
+		}
+	} else {
+		signer, err = NewBedrockSignerFromAccount(account)
+		if err != nil {
+			return nil, "", fmt.Errorf("create bedrock signer: %w", err)
+		}
+	}
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.executeBedrockUpstream(ctx, c, account, bedrockBody, mappedModel, region, stream, signer, bedrockAPIKey, proxyURL)
+	if err != nil {
+		return nil, "", err
+	}
+
+	if awsReqID := resp.Header.Get("x-amzn-requestid"); awsReqID != "" && resp.Header.Get("x-request-id") == "" {
+		resp.Header.Set("x-request-id", awsReqID)
+	}
+
+	if resp.StatusCode >= 400 {
+		errResp, err := s.handleCompatBedrockError(ctx, resp, c, account, writeError)
+		return errResp, mappedModel, err
+	}
+
+	if stream {
+		resp.Body = newBedrockAnthropicSSEReadCloser(resp.Body)
+	}
+	return resp, mappedModel, nil
+}
+
+func (s *GatewayService) handleCompatBedrockError(
+	ctx context.Context,
+	resp *http.Response,
+	c *gin.Context,
+	account *Account,
+	writeError bedrockCompatErrorWriter,
+) (*http.Response, error) {
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(respBody))
+
+	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+
+	if s.shouldFailoverUpstreamError(resp.StatusCode) {
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  resp.Header.Get("x-request-id"),
+			Kind:               "failover",
+			Message:            upstreamMsg,
+		})
+		if s.rateLimitService != nil {
+			s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
+		}
+		return nil, &UpstreamFailoverError{
+			StatusCode:             resp.StatusCode,
+			ResponseBody:           respBody,
+			RetryableOnSameAccount: account.IsPoolMode() && isPoolModeRetryableStatus(resp.StatusCode),
+		}
+	}
+
+	writeError(c, mapUpstreamStatusCode(resp.StatusCode), "server_error", upstreamMsg)
+	return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
+}
+
+type bedrockAnthropicSSEReadCloser struct {
+	source  io.Closer
+	events  chan bedrockCompatEvent
+	done    chan struct{}
+	buf     bytes.Buffer
+	closed  bool
+	readErr error
+}
+
+type bedrockCompatEvent struct {
+	payload []byte
+	err     error
+}
+
+func newBedrockAnthropicSSEReadCloser(source io.ReadCloser) io.ReadCloser {
+	rc := &bedrockAnthropicSSEReadCloser{
+		source: source,
+		events: make(chan bedrockCompatEvent, 16),
+		done:   make(chan struct{}),
+	}
+	decoder := newBedrockEventStreamDecoder(source)
+	send := func(ev bedrockCompatEvent) bool {
+		select {
+		case rc.events <- ev:
+			return true
+		case <-rc.done:
+			return false
+		}
+	}
+	go func() {
+		defer close(rc.events)
+		for {
+			payload, err := decoder.Decode()
+			if err != nil {
+				if err != io.EOF {
+					_ = send(bedrockCompatEvent{err: err})
+				}
+				return
+			}
+			if !send(bedrockCompatEvent{payload: payload}) {
+				return
+			}
+		}
+	}()
+	return rc
+}
+
+func (r *bedrockAnthropicSSEReadCloser) Read(p []byte) (int, error) {
+	for r.buf.Len() == 0 {
+		if r.readErr != nil {
+			return 0, r.readErr
+		}
+		if r.closed {
+			return 0, io.EOF
+		}
+
+		ev, ok := <-r.events
+		if !ok {
+			r.closed = true
+			return 0, io.EOF
+		}
+		if ev.err != nil {
+			r.readErr = fmt.Errorf("bedrock stream read error: %w", ev.err)
+			return 0, r.readErr
+		}
+
+		sseData := extractBedrockChunkData(ev.payload)
+		if sseData == nil {
+			continue
+		}
+		sseData = transformBedrockInvocationMetrics(sseData)
+		eventType := strings.TrimSpace(jsonEventType(sseData))
+		if eventType != "" {
+			fmt.Fprintf(&r.buf, "event: %s\ndata: %s\n\n", eventType, sseData)
+		} else {
+			fmt.Fprintf(&r.buf, "data: %s\n\n", sseData)
+		}
+	}
+	return r.buf.Read(p)
+}
+
+func (r *bedrockAnthropicSSEReadCloser) Close() error {
+	select {
+	case <-r.done:
+	default:
+		close(r.done)
+	}
+	if r.source == nil {
+		return nil
+	}
+	return r.source.Close()
+}
+
+func jsonEventType(data []byte) string {
+	var payload struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return ""
+	}
+	return payload.Type
+}

--- a/backend/internal/service/gateway_compat_bedrock_test.go
+++ b/backend/internal/service/gateway_compat_bedrock_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type bedrockCompatHTTPUpstreamRecorder struct {
+	lastReq  *http.Request
+	lastBody []byte
+	resp     *http.Response
+}
+
+func (u *bedrockCompatHTTPUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	u.lastReq = req
+	if req != nil && req.Body != nil {
+		b, _ := io.ReadAll(req.Body)
+		u.lastBody = b
+		_ = req.Body.Close()
+		req.Body = io.NopCloser(bytes.NewReader(b))
+	}
+	return u.resp, nil
+}
+
+func (u *bedrockCompatHTTPUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func TestGatewayService_ForwardAsChatCompletions_BedrockAPIKeyUsesBedrockRuntime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &bedrockCompatHTTPUpstreamRecorder{
+		resp: newBedrockEventStreamResponse(
+			`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"us.anthropic.claude-sonnet-4-6","stop_reason":"","usage":{"input_tokens":3,"output_tokens":0}}}`,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+			`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+			`{"type":"message_stop"}`,
+		),
+	}
+	svc := &GatewayService{httpUpstream: upstream}
+	account := newBedrockAPIKeyCompatAccountForTest()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":"hi"}],"max_tokens":128}`)
+	result, err := svc.ForwardAsChatCompletions(c.Request.Context(), c, account, body, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, upstream.lastReq.URL.String(), "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/invoke-with-response-stream")
+	require.Equal(t, "Bearer bedrock-test-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-api-key"))
+	require.Equal(t, "claude-sonnet-4-6", gjson.Get(rec.Body.String(), "model").String())
+	require.Equal(t, "assistant", gjson.Get(rec.Body.String(), "choices.0.message.role").String())
+	require.Equal(t, "hello", gjson.Get(rec.Body.String(), "choices.0.message.content").String())
+	require.Equal(t, int64(3), gjson.Get(rec.Body.String(), "usage.prompt_tokens").Int())
+	require.Equal(t, int64(1), gjson.Get(rec.Body.String(), "usage.completion_tokens").Int())
+}
+
+func TestGatewayService_ForwardAsResponses_BedrockAPIKeyUsesBedrockRuntime(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &bedrockCompatHTTPUpstreamRecorder{
+		resp: newBedrockEventStreamResponse(
+			`{"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","content":[],"model":"us.anthropic.claude-sonnet-4-6","stop_reason":"","usage":{"input_tokens":3,"output_tokens":0}}}`,
+			`{"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+			`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello"}}`,
+			`{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}`,
+			`{"type":"message_stop"}`,
+		),
+	}
+	svc := &GatewayService{httpUpstream: upstream}
+	account := newBedrockAPIKeyCompatAccountForTest()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	body := []byte(`{"model":"claude-sonnet-4-6","input":"hi","max_output_tokens":128}`)
+	result, err := svc.ForwardAsResponses(c.Request.Context(), c, account, body, nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Contains(t, upstream.lastReq.URL.String(), "https://bedrock-runtime.us-east-1.amazonaws.com/model/us.anthropic.claude-sonnet-4-6/invoke-with-response-stream")
+	require.Equal(t, "Bearer bedrock-test-key", upstream.lastReq.Header.Get("Authorization"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-api-key"))
+	require.Contains(t, rec.Body.String(), `"model":"claude-sonnet-4-6"`)
+	require.Contains(t, rec.Body.String(), `"text":"hello"`)
+}
+
+func newBedrockAPIKeyCompatAccountForTest() *Account {
+	return &Account{
+		ID:          301,
+		Name:        "bedrock-compat-test",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeBedrock,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"auth_mode":  "apikey",
+			"api_key":    "bedrock-test-key",
+			"aws_region": "us-east-1",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func newBedrockEventStreamResponse(events ...string) *http.Response {
+	var body bytes.Buffer
+	for _, event := range events {
+		chunkPayload := `{"bytes":"` + base64.StdEncoding.EncodeToString([]byte(event)) + `"}`
+		_, _ = body.Write(buildBedrockEventStreamFrameForCompatTest("chunk", []byte(chunkPayload)))
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"x-amzn-requestid": []string{"bedrock-request-id"},
+		},
+		Body: io.NopCloser(bytes.NewReader(body.Bytes())),
+	}
+}
+
+func buildBedrockEventStreamFrameForCompatTest(eventType string, payload []byte) []byte {
+	crc32IeeeTab := crc32.MakeTable(crc32.IEEE)
+	var headersBuf bytes.Buffer
+	_ = headersBuf.WriteByte(byte(len(":event-type")))
+	_, _ = headersBuf.WriteString(":event-type")
+	_ = headersBuf.WriteByte(7)
+	_ = binary.Write(&headersBuf, binary.BigEndian, uint16(len(eventType)))
+	_, _ = headersBuf.WriteString(eventType)
+	_ = headersBuf.WriteByte(byte(len(":message-type")))
+	_, _ = headersBuf.WriteString(":message-type")
+	_ = headersBuf.WriteByte(7)
+	_ = binary.Write(&headersBuf, binary.BigEndian, uint16(len("event")))
+	_, _ = headersBuf.WriteString("event")
+
+	headers := headersBuf.Bytes()
+	headersLen := uint32(len(headers))
+	totalLen := uint32(12 + len(headers) + len(payload) + 4)
+
+	var preludeBuf bytes.Buffer
+	_ = binary.Write(&preludeBuf, binary.BigEndian, totalLen)
+	_ = binary.Write(&preludeBuf, binary.BigEndian, headersLen)
+	preludeBytes := preludeBuf.Bytes()
+	preludeCRC := crc32.Checksum(preludeBytes, crc32IeeeTab)
+
+	var frame bytes.Buffer
+	_, _ = frame.Write(preludeBytes)
+	_ = binary.Write(&frame, binary.BigEndian, preludeCRC)
+	_, _ = frame.Write(headers)
+	_, _ = frame.Write(payload)
+	messageCRC := crc32.Checksum(frame.Bytes(), crc32IeeeTab)
+	_ = binary.Write(&frame, binary.BigEndian, messageCRC)
+	return frame.Bytes()
+}

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -69,7 +69,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		if normalized != originalModel {
 			mappedModel = normalized
 		}
-	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
+	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey && !account.IsBedrock() {
 		normalized := claude.NormalizeModelID(originalModel)
 		if normalized != originalModel {
 			mappedModel = normalized
@@ -104,6 +104,20 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+	reasoningEffort := extractCCReasoningEffortFromBody(body)
+
+	if account.IsBedrock() {
+		resp, bedrockModel, err := s.forwardCompatBedrockAnthropicStream(ctx, c, account, anthropicBody, mappedModel, reqStream, writeGatewayCCError)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if clientStream {
+			return s.handleCCStreamingFromAnthropic(resp, c, originalModel, bedrockModel, reasoningEffort, startTime, includeUsage)
+		}
+		return s.handleCCBufferedFromAnthropic(resp, c, originalModel, bedrockModel, reasoningEffort, startTime)
+	}
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)
@@ -177,9 +191,6 @@ func (s *GatewayService) ForwardAsChatCompletions(
 		writeGatewayCCError(c, mapUpstreamStatusCode(resp.StatusCode), "server_error", upstreamMsg)
 		return nil, fmt.Errorf("upstream error: %d %s", resp.StatusCode, upstreamMsg)
 	}
-
-	// 13. Extract reasoning effort from CC request body
-	reasoningEffort := extractCCReasoningEffortFromBody(body)
 
 	// 14. Handle normal response
 	// Read Anthropic SSE → convert to Responses events → convert to CC format

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -66,7 +66,7 @@ func (s *GatewayService) ForwardAsResponses(
 		if normalized != originalModel {
 			mappedModel = normalized
 		}
-	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
+	} else if mappedModel == originalModel && account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey && !account.IsBedrock() {
 		normalized := claude.NormalizeModelID(originalModel)
 		if normalized != originalModel {
 			mappedModel = normalized
@@ -101,6 +101,19 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 7. Enforce cache_control block limit
 	anthropicBody = enforceCacheControlLimit(anthropicBody)
+
+	if account.IsBedrock() {
+		resp, bedrockModel, err := s.forwardCompatBedrockAnthropicStream(ctx, c, account, anthropicBody, mappedModel, reqStream, writeResponsesError)
+		if err != nil {
+			return nil, err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		if clientStream {
+			return s.handleResponsesStreamingResponse(resp, c, originalModel, bedrockModel, reasoningEffort, startTime)
+		}
+		return s.handleResponsesBufferedStreamingResponse(resp, c, originalModel, bedrockModel, reasoningEffort, startTime)
+	}
 
 	// 8. Get access token
 	token, tokenType, err := s.GetAccessToken(ctx, account)

--- a/backend/internal/setup/handler.go
+++ b/backend/internal/setup/handler.go
@@ -176,11 +176,12 @@ func testDatabase(c *gin.Context) {
 
 // TestRedisRequest represents Redis test request
 type TestRedisRequest struct {
-	Host      string `json:"host" binding:"required"`
-	Port      int    `json:"port" binding:"required"`
-	Password  string `json:"password"`
-	DB        int    `json:"db"`
-	EnableTLS bool   `json:"enable_tls"`
+	Host          string `json:"host" binding:"required"`
+	Port          int    `json:"port" binding:"required"`
+	Password      string `json:"password"`
+	DB            int    `json:"db"`
+	EnableTLS     bool   `json:"enable_tls"`
+	TLSSkipVerify bool   `json:"tls_skip_verify"`
 }
 
 // testRedis tests Redis connection
@@ -206,11 +207,12 @@ func testRedis(c *gin.Context) {
 	}
 
 	cfg := &RedisConfig{
-		Host:      req.Host,
-		Port:      req.Port,
-		Password:  req.Password,
-		DB:        req.DB,
-		EnableTLS: req.EnableTLS,
+		Host:          req.Host,
+		Port:          req.Port,
+		Password:      req.Password,
+		DB:            req.DB,
+		EnableTLS:     req.EnableTLS,
+		TLSSkipVerify: req.TLSSkipVerify,
 	}
 
 	if err := TestRedisConnection(cfg); err != nil {

--- a/backend/internal/setup/setup.go
+++ b/backend/internal/setup/setup.go
@@ -91,11 +91,12 @@ type DatabaseConfig struct {
 }
 
 type RedisConfig struct {
-	Host      string `json:"host" yaml:"host"`
-	Port      int    `json:"port" yaml:"port"`
-	Password  string `json:"password" yaml:"password"`
-	DB        int    `json:"db" yaml:"db"`
-	EnableTLS bool   `json:"enable_tls" yaml:"enable_tls"`
+	Host          string `json:"host" yaml:"host"`
+	Port          int    `json:"port" yaml:"port"`
+	Password      string `json:"password" yaml:"password"`
+	DB            int    `json:"db" yaml:"db"`
+	EnableTLS     bool   `json:"enable_tls" yaml:"enable_tls"`
+	TLSSkipVerify bool   `json:"tls_skip_verify" yaml:"tls_skip_verify"`
 }
 
 type AdminConfig struct {
@@ -249,10 +250,7 @@ func TestRedisConnection(cfg *RedisConfig) error {
 	}
 
 	if cfg.EnableTLS {
-		opts.TLSConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ServerName: cfg.Host,
-		}
+		opts.TLSConfig = buildRedisTLSConfig(cfg)
 	}
 
 	rdb := redis.NewClient(opts)
@@ -270,6 +268,14 @@ func TestRedisConnection(cfg *RedisConfig) error {
 	}
 
 	return nil
+}
+
+func buildRedisTLSConfig(cfg *RedisConfig) *tls.Config {
+	return &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		ServerName:         cfg.Host,
+		InsecureSkipVerify: cfg.TLSSkipVerify, //nolint:gosec // explicit Redis setup option for private/self-signed servers
+	}
 }
 
 // Install performs the installation with the given configuration
@@ -554,11 +560,12 @@ func AutoSetupFromEnv() error {
 			SSLMode:  getEnvOrDefault("DATABASE_SSLMODE", "disable"),
 		},
 		Redis: RedisConfig{
-			Host:      getEnvOrDefault("REDIS_HOST", "localhost"),
-			Port:      getEnvIntOrDefault("REDIS_PORT", 6379),
-			Password:  getEnvOrDefault("REDIS_PASSWORD", ""),
-			DB:        getEnvIntOrDefault("REDIS_DB", 0),
-			EnableTLS: getEnvOrDefault("REDIS_ENABLE_TLS", "false") == "true",
+			Host:          getEnvOrDefault("REDIS_HOST", "localhost"),
+			Port:          getEnvIntOrDefault("REDIS_PORT", 6379),
+			Password:      getEnvOrDefault("REDIS_PASSWORD", ""),
+			DB:            getEnvIntOrDefault("REDIS_DB", 0),
+			EnableTLS:     getEnvOrDefault("REDIS_ENABLE_TLS", "false") == "true",
+			TLSSkipVerify: getEnvOrDefault("REDIS_TLS_SKIP_VERIFY", "true") == "true",
 		},
 		Admin: AdminConfig{
 			Email:    getEnvOrDefault("ADMIN_EMAIL", "admin@sub2api.local"),

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -170,6 +170,8 @@ REDIS_POOL_SIZE=4096
 # Redis 最小空闲连接数（默认 10）
 REDIS_MIN_IDLE_CONNS=256
 REDIS_ENABLE_TLS=false
+# 跳过 Redis TLS 证书校验，自签名 Redis TLS 默认开启
+REDIS_TLS_SKIP_VERIFY=true
 
 # -----------------------------------------------------------------------------
 # Admin Account

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -806,6 +806,9 @@ redis:
   # Enable TLS/SSL connection
   # 是否启用 TLS/SSL 连接
   enable_tls: false
+  # Skip Redis TLS certificate verification. Defaults to true for self-signed Redis TLS.
+  # 跳过 Redis TLS 证书校验，自签名 Redis TLS 默认开启
+  tls_skip_verify: true
 
 # =============================================================================
 # Ops Monitoring (Optional)

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -35,6 +35,8 @@ services:
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:-}
       - REDIS_DB=${REDIS_DB:-0}
+      - REDIS_ENABLE_TLS=${REDIS_ENABLE_TLS:-false}
+      - REDIS_TLS_SKIP_VERIFY=${REDIS_TLS_SKIP_VERIFY:-true}
       - ADMIN_EMAIL=${ADMIN_EMAIL:-admin@sub2api.local}
       - ADMIN_PASSWORD=${ADMIN_PASSWORD:-}
       - JWT_SECRET=${JWT_SECRET:-}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -77,6 +77,7 @@ services:
       - REDIS_POOL_SIZE=${REDIS_POOL_SIZE:-1024}
       - REDIS_MIN_IDLE_CONNS=${REDIS_MIN_IDLE_CONNS:-10}
       - REDIS_ENABLE_TLS=${REDIS_ENABLE_TLS:-false}
+      - REDIS_TLS_SKIP_VERIFY=${REDIS_TLS_SKIP_VERIFY:-true}
 
       # =======================================================================
       # Admin Account (auto-created on first run)

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -63,6 +63,7 @@ services:
       - REDIS_POOL_SIZE=${REDIS_POOL_SIZE:-1024}
       - REDIS_MIN_IDLE_CONNS=${REDIS_MIN_IDLE_CONNS:-10}
       - REDIS_ENABLE_TLS=${REDIS_ENABLE_TLS:-false}
+      - REDIS_TLS_SKIP_VERIFY=${REDIS_TLS_SKIP_VERIFY:-true}
 
       # =======================================================================
       # Admin Account (auto-created on first run)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - REDIS_POOL_SIZE=${REDIS_POOL_SIZE:-1024}
       - REDIS_MIN_IDLE_CONNS=${REDIS_MIN_IDLE_CONNS:-10}
       - REDIS_ENABLE_TLS=${REDIS_ENABLE_TLS:-false}
+      - REDIS_TLS_SKIP_VERIFY=${REDIS_TLS_SKIP_VERIFY:-true}
 
       # =======================================================================
       # Admin Account (auto-created on first run)

--- a/frontend/src/api/setup.ts
+++ b/frontend/src/api/setup.ts
@@ -32,6 +32,7 @@ export interface RedisConfig {
   password: string
   db: number
   enable_tls: boolean
+  tls_skip_verify: boolean
 }
 
 export interface AdminConfig {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -210,7 +210,9 @@ export default {
       database: 'Database',
       passwordPlaceholder: 'Password',
       enableTls: 'Enable TLS',
-      enableTlsHint: 'Use TLS when connecting to Redis (public CA certs)'
+      enableTlsHint: 'Use TLS when connecting to Redis',
+      tlsSkipVerify: 'Skip certificate verification',
+      tlsSkipVerifyHint: 'Enabled by default for self-signed Redis TLS'
     },
     admin: {
       title: 'Admin Account',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -210,7 +210,9 @@ export default {
       database: '数据库',
       passwordPlaceholder: '密码',
       enableTls: '启用 TLS',
-      enableTlsHint: '连接 Redis 时使用 TLS（公共 CA 证书）'
+      enableTlsHint: '连接 Redis 时使用 TLS',
+      tlsSkipVerify: '跳过证书校验',
+      tlsSkipVerifyHint: '自签名 Redis TLS 默认开启'
     },
     admin: {
       title: '管理员账户',

--- a/frontend/src/views/setup/SetupWizardView.vue
+++ b/frontend/src/views/setup/SetupWizardView.vue
@@ -91,18 +91,6 @@
             </div>
           </div>
 
-          <div class="flex items-center justify-between rounded-xl border border-gray-200 p-3 dark:border-dark-700">
-            <div>
-              <p class="text-sm font-medium text-gray-900 dark:text-white">
-                {{ t("setup.redis.enableTls") }}
-              </p>
-              <p class="text-xs text-gray-500 dark:text-dark-400">
-                {{ t("setup.redis.enableTlsHint") }}
-              </p>
-            </div>
-            <Toggle v-model="formData.redis.enable_tls" />
-          </div>
-
           <div class="grid grid-cols-2 gap-4">
             <div>
               <label class="input-label">{{ t('setup.database.username') }}</label>
@@ -247,6 +235,18 @@
               </p>
             </div>
             <Toggle v-model="formData.redis.enable_tls" />
+          </div>
+
+          <div v-if="formData.redis.enable_tls" class="flex items-center justify-between rounded-xl border border-amber-200 bg-amber-50 p-3 dark:border-amber-900/60 dark:bg-amber-950/20">
+            <div>
+              <p class="text-sm font-medium text-amber-900 dark:text-amber-100">
+                {{ t("setup.redis.tlsSkipVerify") }}
+              </p>
+              <p class="text-xs text-amber-700 dark:text-amber-300">
+                {{ t("setup.redis.tlsSkipVerifyHint") }}
+              </p>
+            </div>
+            <Toggle v-model="formData.redis.tls_skip_verify" />
           </div>
 
           <button
@@ -543,7 +543,8 @@ const formData = reactive<InstallRequest>({
     port: 6379,
     password: '',
     db: 0,
-    enable_tls: false
+    enable_tls: false,
+    tls_skip_verify: true
   },
   admin: {
     email: '',


### PR DESCRIPTION
## Summary

This PR includes two focused fixes that should be generally useful upstream:

1. Support Redis TLS deployments that use private or self-signed certificates.
2. Route Bedrock compatibility requests through the Bedrock runtime path instead of the generic Anthropic/OpenAI forwarders.

## Changes

### Redis TLS

- Add `redis.tls_skip_verify` configuration support.
- Wire the option into the Redis TLS client config.
- Expose the setting in setup and deployment examples.
- Update Redis setup/config tests for the new field.

This is useful for private deployments where Redis is served over TLS with an internal CA or a self-signed certificate.

### Bedrock compatibility routing

- Add Bedrock compatibility request handling for chat completions and responses forwarding.
- Preserve Bedrock-specific model/provider routing when requests enter through compatibility endpoints.
- Add tests covering Bedrock compat request behavior.

This prevents Bedrock accounts from being incorrectly routed through non-Bedrock upstream paths when using compat endpoints.

## Tests

```bash
go test ./internal/repository ./internal/service -run 'Test.*Redis|Test.*Bedrock|Bedrock|Redis'
git diff --check upstream/main..HEAD
```
