### PR TITLE
fix: 支付宝弹窗流程修复

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -20,7 +20,7 @@ FROM ${NODE_IMAGE} AS frontend-builder
 WORKDIR /app/frontend
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9 --activate
 
 # Install dependencies first (better caching)
 COPY frontend/package.json frontend/pnpm-lock.yaml ./

--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -117,6 +117,7 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const shouldOpenAlipayPopup = computed(() => isAlipay.value && !!props.payUrl)
 
 const dialogTitle = computed(() => {
   if (success.value) return t('payment.result.success')
@@ -147,7 +148,10 @@ function getLogoForType(): string | null {
 
 function reopenPopup() {
   if (props.payUrl) {
-    window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
+    const win = window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
+    if (!win || win.closed) {
+      window.location.href = props.payUrl
+    }
   }
 }
 
@@ -249,7 +253,7 @@ function init() {
   paidOrder.value = null
   expired.value = false
   cancelling.value = false
-  qrUrl.value = props.qrCode
+  qrUrl.value = shouldOpenAlipayPopup.value ? '' : props.qrCode
 
   let seconds = 30 * 60
   if (props.expiresAt) {
@@ -258,7 +262,11 @@ function init() {
   }
   startCountdown(seconds)
   pollTimer = setInterval(pollStatus, 3000)
-  renderQR()
+  if (shouldOpenAlipayPopup.value) {
+    reopenPopup()
+  } else {
+    renderQR()
+  }
 }
 
 // Watch for dialog open/close

--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -16,7 +16,11 @@
         <div class="flex flex-col items-center py-4">
           <div class="h-10 w-10 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
           <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{{ t('payment.qr.payInNewWindowHint') }}</p>
-          <button v-if="payUrl" class="btn btn-secondary mt-3 text-sm" @click="reopenPopup">
+          <template v-if="popupBlocked">
+            <p class="mt-2 text-xs text-amber-600 dark:text-amber-400">{{ t('payment.qr.popupBlocked') || '弹窗被浏览器阻止，请点击下方链接完成支付' }}</p>
+            <a v-if="payUrl" :href="payUrl" target="_blank" rel="noopener" class="btn btn-secondary mt-3 text-sm">{{ t('payment.qr.openPayWindow') }}</a>
+          </template>
+          <button v-else-if="payUrl" class="btn btn-secondary mt-3 text-sm" @click="reopenPopup">
             {{ t('payment.qr.openPayWindow') }}
           </button>
         </div>
@@ -146,13 +150,19 @@ function getLogoForType(): string | null {
 }
 
 
+const popupBlocked = ref(false)
+
 function reopenPopup() {
   if (props.payUrl) {
     const win = window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
     if (!win || win.closed) {
-      window.location.href = props.payUrl
+      popupBlocked.value = true
+      return false
     }
+    popupBlocked.value = false
+    return true
   }
+  return false
 }
 
 async function renderQR() {

--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -17,7 +17,7 @@
           <div class="h-10 w-10 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
           <p class="mt-4 text-sm text-gray-500 dark:text-gray-400">{{ t('payment.qr.payInNewWindowHint') }}</p>
           <template v-if="popupBlocked">
-            <p class="mt-2 text-xs text-amber-600 dark:text-amber-400">{{ t('payment.qr.popupBlocked') || '弹窗被浏览器阻止，请点击下方链接完成支付' }}</p>
+            <p class="mt-2 text-xs text-amber-600 dark:text-amber-400">{{ t('payment.qr.popupBlocked') }}</p>
             <a v-if="payUrl" :href="payUrl" target="_blank" rel="noopener" class="btn btn-secondary mt-3 text-sm">{{ t('payment.qr.openPayWindow') }}</a>
           </template>
           <button v-else-if="payUrl" class="btn btn-secondary mt-3 text-sm" @click="reopenPopup">

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -106,7 +106,7 @@
           <div class="h-10 w-10 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
           <p class="text-sm text-gray-500 dark:text-gray-400">{{ t('payment.qr.payInNewWindowHint') }}</p>
           <template v-if="popupBlocked">
-            <p class="text-xs text-amber-600 dark:text-amber-400">{{ t('payment.qr.popupBlocked') || '弹窗被浏览器阻止，请点击下方链接完成支付' }}</p>
+            <p class="text-xs text-amber-600 dark:text-amber-400">{{ t('payment.qr.popupBlocked') }}</p>
             <a v-if="payUrl" :href="payUrl" target="_blank" rel="noopener" class="btn btn-secondary text-sm">{{ t('payment.qr.openPayWindow') }}</a>
           </template>
           <button v-else-if="payUrl" class="btn btn-secondary text-sm" @click="reopenPopup">

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -105,7 +105,11 @@
         <div class="flex flex-col items-center space-y-4 py-4">
           <div class="h-10 w-10 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
           <p class="text-sm text-gray-500 dark:text-gray-400">{{ t('payment.qr.payInNewWindowHint') }}</p>
-          <button v-if="payUrl" class="btn btn-secondary text-sm" @click="reopenPopup">
+          <template v-if="popupBlocked">
+            <p class="text-xs text-amber-600 dark:text-amber-400">{{ t('payment.qr.popupBlocked') || '弹窗被浏览器阻止，请点击下方链接完成支付' }}</p>
+            <a v-if="payUrl" :href="payUrl" target="_blank" rel="noopener" class="btn btn-secondary text-sm">{{ t('payment.qr.openPayWindow') }}</a>
+          </template>
+          <button v-else-if="payUrl" class="btn btn-secondary text-sm" @click="reopenPopup">
             {{ t('payment.qr.openPayWindow') }}
           </button>
         </div>
@@ -218,13 +222,19 @@ function isSuccessStatus(status: string | null | undefined): boolean {
   return status === 'COMPLETED' || status === 'PAID' || status === 'RECHARGING'
 }
 
+const popupBlocked = ref(false)
+
 function reopenPopup() {
   if (props.payUrl) {
     const win = window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
     if (!win || win.closed) {
-      window.location.href = props.payUrl
+      popupBlocked.value = true
+      return false
     }
+    popupBlocked.value = false
+    return true
   }
+  return false
 }
 
 function setOutcome(next: PaymentOutcome) {
@@ -300,6 +310,8 @@ startCountdown(seconds)
 pollTimer = setInterval(pollStatus, 3000)
 if (!shouldOpenAlipayPopup.value) {
   renderQR()
+} else {
+  reopenPopup()
 }
 
 watch(() => qrUrl.value, () => renderQR())

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -178,6 +178,7 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const shouldOpenAlipayPopup = computed(() => isAlipay.value && !!props.payUrl)
 
 const qrBorderClass = computed(() => {
   if (isAlipay.value) return 'border-[#00AEEF] bg-blue-50 dark:border-[#00AEEF]/70 dark:bg-blue-950/20'
@@ -290,14 +291,16 @@ function cleanup() {
 }
 
 // Initialize on mount
-qrUrl.value = props.qrCode
+qrUrl.value = shouldOpenAlipayPopup.value ? '' : props.qrCode
 let seconds = 30 * 60
 if (props.expiresAt) {
   seconds = Math.floor((new Date(props.expiresAt).getTime() - Date.now()) / 1000)
 }
 startCountdown(seconds)
 pollTimer = setInterval(pollStatus, 3000)
-renderQR()
+if (!shouldOpenAlipayPopup.value) {
+  renderQR()
+}
 
 watch(() => qrUrl.value, () => renderQR())
 onUnmounted(() => cleanup())

--- a/frontend/src/components/payment/__tests__/PaymentQRDialog.spec.ts
+++ b/frontend/src/components/payment/__tests__/PaymentQRDialog.spec.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const pollOrderStatus = vi.hoisted(() => vi.fn())
+const cancelOrder = vi.hoisted(() => vi.fn())
+const showError = vi.hoisted(() => vi.fn())
+const toCanvas = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/stores/payment', () => ({
+  usePaymentStore: () => ({
+    pollOrderStatus,
+  }),
+}))
+
+vi.mock('@/stores', () => ({
+  useAppStore: () => ({
+    showError,
+  }),
+}))
+
+vi.mock('@/api/payment', () => ({
+  paymentAPI: {
+    cancelOrder,
+  },
+}))
+
+vi.mock('qrcode', () => ({
+  default: {
+    toCanvas,
+  },
+}))
+
+import PaymentQRDialog from '../PaymentQRDialog.vue'
+
+describe('PaymentQRDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    pollOrderStatus.mockReset()
+    cancelOrder.mockReset()
+    showError.mockReset()
+    toCanvas.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('opens Alipay payUrl directly instead of rendering its QR code', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({ closed: false } as Window)
+
+    const wrapper = mount(PaymentQRDialog, {
+      props: {
+        show: false,
+        orderId: 42,
+        qrCode: 'https://pay.example.com/invalid-alipay-qr',
+        payUrl: 'https://pay.example.com/session/42',
+        expiresAt: '2099-01-01T12:30:00Z',
+        paymentType: 'alipay',
+      },
+      global: {
+        stubs: {
+          BaseDialog: { template: '<div><slot /><slot name="footer" /></div>' },
+          Icon: true,
+        },
+      },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://pay.example.com/session/42',
+      'paymentPopup',
+      expect.any(String),
+    )
+    expect(toCanvas).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('payment.qr.payInNewWindowHint')
+    expect(wrapper.text()).not.toContain('payment.qr.scanAlipay')
+  })
+})

--- a/frontend/src/components/payment/__tests__/PaymentStatusPanel.spec.ts
+++ b/frontend/src/components/payment/__tests__/PaymentStatusPanel.spec.ts
@@ -67,6 +67,7 @@ describe('PaymentStatusPanel', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 
@@ -106,7 +107,7 @@ describe('PaymentStatusPanel', () => {
         qrCode: 'https://pay.example.com/qr/42',
         payUrl: 'https://pay.example.com/session/42',
         expiresAt: '2099-01-01T12:30:00Z',
-        paymentType: 'alipay',
+        paymentType: 'wxpay',
         orderType: 'balance',
       },
       global: {
@@ -127,5 +128,29 @@ describe('PaymentStatusPanel', () => {
     )
 
     openSpy.mockRestore()
+  })
+
+  it('hides Alipay QR mode when payUrl is available', async () => {
+    const wrapper = mount(PaymentStatusPanel, {
+      props: {
+        orderId: 42,
+        qrCode: 'https://pay.example.com/invalid-alipay-qr',
+        payUrl: 'https://pay.example.com/session/42',
+        expiresAt: '2099-01-01T12:30:00Z',
+        paymentType: 'alipay',
+        orderType: 'balance',
+      },
+      global: {
+        stubs: {
+          Icon: true,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(toCanvas).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('payment.qr.payInNewWindowHint')
+    expect(wrapper.text()).not.toContain('payment.qr.scanAlipay')
   })
 })

--- a/frontend/src/components/payment/__tests__/paymentFlow.spec.ts
+++ b/frontend/src/components/payment/__tests__/paymentFlow.spec.ts
@@ -148,19 +148,19 @@ describe('decidePaymentLaunch', () => {
     expect(decision.recovery.resumeToken).toBe('resume-2')
   })
 
-  it('prefers redirect on mobile when both pay_url and qr_code are present', () => {
+  it('prefers Alipay pay_url over QR when both are present', () => {
     const decision = decidePaymentLaunch(createOrderResult({
-      pay_url: 'https://pay.example.com/mobile/session',
+      pay_url: 'https://pay.example.com/alipay/session',
       qr_code: 'https://pay.example.com/qr/session',
     }), {
       visibleMethod: 'alipay',
       orderType: 'balance',
-      isMobile: true,
+      isMobile: false,
     })
 
     expect(decision.kind).toBe('redirect_waiting')
-    expect(decision.paymentState.payUrl).toBe('https://pay.example.com/mobile/session')
-    expect(decision.paymentState.qrCode).toBe('https://pay.example.com/qr/session')
+    expect(decision.paymentState.payUrl).toBe('https://pay.example.com/alipay/session')
+    expect(decision.paymentState.qrCode).toBe('')
   })
 
   it('keeps QR flow on desktop when both pay_url and qr_code are present', () => {

--- a/frontend/src/components/payment/paymentFlow.ts
+++ b/frontend/src/components/payment/paymentFlow.ts
@@ -201,6 +201,11 @@ export function decidePaymentLaunch(
     return { kind: 'redirect_waiting', paymentState: baseState, recovery: baseState }
   }
 
+  if (visibleMethod === 'alipay' && baseState.payUrl) {
+    const paymentState = { ...baseState, qrCode: '' }
+    return { kind: 'redirect_waiting', paymentState, recovery: paymentState }
+  }
+
   if (prefersRedirect && baseState.payUrl) {
     return { kind: 'redirect_waiting', paymentState: baseState, recovery: baseState }
   }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -6449,6 +6449,7 @@ export default {
       payInNewWindow: 'Complete Payment in New Window',
       payInNewWindowHint: 'The payment page has opened in a new window. Please complete the payment there and return to this page.',
       openPayWindow: 'Reopen Payment Page',
+      popupBlocked: 'Popup blocked by browser. Please click the link below to complete payment.',
       expiresIn: 'Expires in',
       expired: 'Order Expired',
       expiredDesc: 'This order has expired. Please create a new one.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6634,6 +6634,7 @@ export default {
       payInNewWindow: '请在新窗口中完成支付',
       payInNewWindowHint: '支付页面已在新窗口打开，请在新窗口中完成支付后返回此页面',
       openPayWindow: '重新打开支付页面',
+      popupBlocked: '弹窗被浏览器阻止，请点击下方链接完成支付',
       expiresIn: '剩余支付时间',
       expired: '订单已过期',
       expiredDesc: '订单已超时，请重新创建订单',


### PR DESCRIPTION
## 修复内容

### 1. 支付宝使用 payUrl 弹窗替代二维码
- 当支付宝同时返回 `pay_url` 和 `qr_code` 时，优先使用 `pay_url` 打开支付弹窗，不再显示二维码
- 弹窗被浏览器阻止时，显示替代 UI（橙色提示 + 可点击的支付链接），而非直接跳转离开页面

### 2. 弹窗被阻止时保留取消能力
- `reopenPopup()` 不再执行 `window.location.href` 跳转
- 设置 `popupBlocked` 标记，显示可点击的 `<a>` 支付链接
- 取消按钮和轮询始终保留，用户可随时取消订单

### 3. 组件行为统一
- `PaymentStatusPanel` 初始化时自动尝试打开弹窗（与 `PaymentQRDialog` 行为一致）

## 改动文件
- `PaymentQRDialog.vue` — 弹窗阻止处理 + fallback UI
- `PaymentStatusPanel.vue` — 弹窗阻止处理 + fallback UI + 初始化自动弹窗
- `paymentFlow.ts` — 支付宝优先使用 payUrl 决策逻辑
- 相关测试用例更新

Fixes #1664
Fixes #1676
Fixes #2292