### PR TITLE
fix(passthrough): 修复WSv2模式下first_token_ms测量错误

### DIFF
--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -82,6 +82,7 @@ type relayState struct {
 	terminalEventType string
 	firstTokenMs      *int
 	turnTimingByID    map[string]*relayTurnTiming
+	activeTurn *relayTurnTiming
 }
 
 type relayExitSignal struct {
@@ -550,6 +551,12 @@ func observeUpstreamMessage(
 		if ms >= 0 {
 			state.firstTokenMs = &ms
 		}
+		if state.activeTurn != nil && state.activeTurn.firstTokenMs == nil {
+			tms := int(now.Sub(state.activeTurn.startAt).Milliseconds())
+			if tms >= 0 {
+				state.activeTurn.firstTokenMs = &tms
+			}
+		}
 	}
 	parsedUsage := parseUsageAndAccumulate(state, message, eventType, onUsageParseFailure)
 	observed := observedUpstreamEvent{
@@ -622,6 +629,7 @@ func openAIWSRelayGetOrInitTurnTiming(state *relayState, responseID string, now 
 	if !ok || timing == nil || timing.startAt.IsZero() {
 		timing = &relayTurnTiming{startAt: now}
 		state.turnTimingByID[responseID] = timing
+		state.activeTurn = timing
 		return timing
 	}
 	return timing
@@ -636,6 +644,9 @@ func openAIWSRelayDeleteTurnTiming(state *relayState, responseID string) (relayT
 		return relayTurnTiming{}, false
 	}
 	delete(state.turnTimingByID, responseID)
+	if state.activeTurn == timing {
+		state.activeTurn = nil
+	}
 	return *timing, true
 }
 

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
@@ -750,3 +750,67 @@ func (c *errorOnWriteFrameConn) WriteFrame(_ context.Context, _ coderws.MessageT
 func (c *errorOnWriteFrameConn) Close() error {
 	return nil
 }
+
+func TestRelay_OnTurnComplete_RealOpenAIStream_FirstTokenMs(t *testing.T) {
+	t.Parallel()
+
+	clientConn := newPassthroughTestFrameConn(nil, false)
+	upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.created","response":{"id":"resp_real"}}`),
+		},
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.output_text.delta","delta":"He"}`),
+		},
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.output_text.delta","delta":"llo"}`),
+		},
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.output_text.delta","delta":" world"}`),
+		},
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.completed","response":{"id":"resp_real","usage":{"input_tokens":2,"output_tokens":3}}}`),
+		},
+	}, true)
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-5.3-codex","input":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	base := time.Unix(0, 0)
+	var nowTick atomic.Int64
+	nowFn := func() time.Time {
+		step := nowTick.Add(1)
+		return base.Add(time.Duration(step) * 10 * time.Millisecond)
+	}
+
+	var turn RelayTurnResult
+	result, relayExit := Relay(ctx, clientConn, upstreamConn, firstPayload, RelayOptions{
+		Now: nowFn,
+		OnTurnComplete: func(current RelayTurnResult) {
+			turn = current
+		},
+	})
+	require.Nil(t, relayExit)
+	require.Equal(t, "resp_real", turn.RequestID)
+	require.Equal(t, "response.completed", turn.TerminalEventType)
+
+	require.NotNil(t, turn.FirstTokenMs, "per-turn FirstTokenMs must be captured for real OpenAI streams")
+	require.Greater(t, turn.Duration.Milliseconds(), int64(0))
+
+	require.Less(t,
+		int64(*turn.FirstTokenMs),
+		turn.Duration.Milliseconds(),
+		"per-turn FirstTokenMs (%dms) should be strictly less than Duration (%dms); "+
+			"equality indicates the bug where first_token is mistakenly stamped on the terminal event",
+		*turn.FirstTokenMs, turn.Duration.Milliseconds(),
+	)
+
+	require.NotNil(t, result.FirstTokenMs)
+	require.Greater(t, *result.FirstTokenMs, 0)
+}


### PR DESCRIPTION
WSv2 passthrough 模式下，每个请求的 `first_token_ms` 都等于 `duration_ms` —— 在 admin UI 表现为「首 TOKEN ≈ 耗时」，并且这个错误值会通过 `AfterTurn` 回调持久化到 `usage_logs.first_token_ms`。

`ctx_pool` 模式和 HTTP `/responses` 路径不受影响。

复现
  
真实 OpenAI Responses-API 在流式响应中发送的事件序列大致是这样：

```
{"type":"response.created","response":{"id":"resp_X"}}
{"type":"response.output_text.delta","delta":"He"}
{"type":"response.output_text.delta","delta":"llo"}
{"type":"response.completed","response":{"id":"resp_X","usage":{...}}}
```
关键点：`response.output_text.delta` 事件**在任何层级都不携带 `response_id`**，只有 `response.created` / `response.completed` 才有。

根因
  
`backend/internal/service/openai_ws_v2/passthrough_relay.go` 里 `observeUpstreamMessage` 的两段逻辑：

1. **行 538-545**：`responseID` 从 `response.id` / `response_id` / 顶层 `id` 提取。delta 事件这三个字段都没有，所以 `responseID == ""`。
2. **行 560-568**：只在 `responseID != ""` 时才更新 `turnTiming.firstTokenMs`。

结果就是delta 来的时候，per-turn 的 `firstTokenMs` 永远不会被打点，一直等到 `response.completed` 这种带 `response.id` 的终结事件才进入这段逻辑 —— 此时 `now - turnTiming.startAt` 就等于整个 turn 的 duration。

另外行 781 把 `response.completed` / `response.done` 也算成了 `isTokenEvent`，让 bug 表面看起来"firstTokenMs 至少有值"，掩盖了实际错误。

`state.firstTokenMs`（全局，会写入 `RelayResult.FirstTokenMs`）是正确的，因为它在行 548 直接用 `now - startAt` 打点，不依赖 `responseID`。但 `RelayTurnResult.FirstTokenMs`（per-turn，被 `openai_ws_v2_passthrough_adapter.go` 用于日志和 DB 写入）是错的。

修复
  
在 `relayState` 加一个 `activeTurn *relayTurnTiming` 指针，指向当前 in-flight 的 turn。

- `getOrInitTurnTiming` 新建条目时，同步设置 `state.activeTurn = timing`
- `observeUpstreamMessage` 在打 `state.firstTokenMs` 的同时，如果 `state.activeTurn != nil` 且其 `firstTokenMs` 尚未设置，就用 `now - activeTurn.startAt` 直接打点 —— 不依赖事件里有没有 `responseID`
- `openAIWSRelayDeleteTurnTiming` 删除条目时，如果 `state.activeTurn` 指向被删的那个 timing，置为 nil

我用指针而不是 `responseID string`是因为WSv2 一个连接上 turn 是串行的，同一时刻只有一个 active turn，不需要 map 查找

测试

新增 `TestRelay_OnTurnComplete_RealOpenAIStream_FirstTokenMs`：模拟真实 OpenAI 事件流（`response.created` → 3 个 `response.output_text.delta`（**不带 `response_id`**）→ `response.completed`），断言 `turn.FirstTokenMs < 
turn.Duration`。

修复前的失败信息（精确复现生产症状）：

```
Error: "120" is not less than "120"
per-turn FirstTokenMs (120ms) should be strictly less than Duration (120ms);
equality indicates the bug where first_token is mistakenly stamped on the
terminal event
```
  
修复后通过。

 现有的 `TestRelay_OnTurnComplete_ProvidesTurnMetrics` 之所以没发现这个 bug，是因为它在 delta payload 里手动注入了 `"response_id":"resp_metric"` 这不是真实 OpenAI 行为。新测试不注入这个字段，反映真实流。

仅影响 passthrough 模式的 per-turn 指标（`RelayTurnResult.FirstTokenMs`）
