### PR TITLE
fix: 安装脚本提前检查 Bash 版本

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -7,6 +7,21 @@
 
 set -e
 
+# Bash 4+ is required for associative arrays used by the localized message table.
+# Keep this guard before any Bash 4-only syntax so older shells fail with a clear hint.
+if [ -z "${BASH_VERSION:-}" ]; then
+    echo "Error: This installer must be run with Bash 4.0 or later." >&2
+    echo "Please install Bash 4+ and run it with that interpreter." >&2
+    exit 1
+fi
+
+BASH_MAJOR_VERSION="${BASH_VERSION%%.*}"
+if [ "$BASH_MAJOR_VERSION" -lt 4 ]; then
+    echo "Error: Bash 4.0 or later is required. Current version: $BASH_VERSION" >&2
+    echo "Please install Bash 4+ and retry with that interpreter." >&2
+    exit 1
+fi
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
## 变更内容
- 在 install.sh 顶部新增 Bash 4+ 版本检查，确保在 declare -A 执行前给出清晰错误
- 兼容非 Bash 或 Bash 3 环境，避免安装时出现 declare: -A: invalid option

## 验证
- bash -n deploy/install.sh
- /bin/bash deploy/install.sh --help（Bash 3，确认提前提示）
- /opt/homebrew/bin/bash deploy/install.sh --help（Bash 5.3，确认帮助页正常）

Fixes #2428