### PR TITLE
fix: 修复兑换码生成后复制全部报错

### DIFF
--- a/frontend/src/views/admin/RedeemView.vue
+++ b/frontend/src/views/admin/RedeemView.vue
@@ -476,14 +476,12 @@ const closeResultDialog = () => {
 }
 
 const copyGeneratedCodes = async () => {
-  try {
-    await navigator.clipboard.writeText(generatedCodesText.value)
+  const success = await clipboardCopy(generatedCodesText.value, t('admin.redeem.copied'))
+  if (success) {
     copiedAll.value = true
     setTimeout(() => {
       copiedAll.value = false
     }, 2000)
-  } catch (error) {
-    appStore.showError(t('admin.redeem.failedToCopy'))
   }
 }
 


### PR DESCRIPTION
## 背景
- Fixes #2334
- 兑换码生成结果弹窗点击“复制全部”时，原逻辑直接调用 `navigator.clipboard.writeText`，在非安全上下文或不支持 Clipboard API 的环境会报错。

## 修改
- 将“复制全部”接入项目已有 `useClipboard` composable。
- 保留复制成功后的按钮状态反馈，并复用已有降级复制与提示逻辑。

## 测试
- `pnpm typecheck`
- `pnpm test:run src/composables/__tests__/useClipboard.spec.ts`
- `pnpm exec eslint src/views/admin/RedeemView.vue`

## 备注
- 全量 `pnpm test:run` 在当前 `main` 基础上仍有 13 个既有失败，失败集中在 `AccountUsageCell`、图表组件、`EmailVerifyView` 等，与本次改动无关。