### PR TITLE
fix(service): add FOR UPDATE lock to prevent lost update in subscription extension

### DIFF
--- a/backend/internal/repository/user_subscription_repo.go
+++ b/backend/internal/repository/user_subscription_repo.go
@@ -84,6 +84,21 @@ func (r *userSubscriptionRepository) GetByUserIDAndGroupID(ctx context.Context, 
 	return userSubscriptionEntityToService(m), nil
 }
 
+// GetByUserIDAndGroupIDForUpdate 在事务内使用 FOR UPDATE 行锁读取订阅记录，
+// 防止并发续期导致的丢失更新（lost update）。
+func (r *userSubscriptionRepository) GetByUserIDAndGroupIDForUpdate(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
+	client := clientFromContext(ctx, r.client)
+	m, err := client.UserSubscription.Query().
+		Where(usersubscription.UserIDEQ(userID), usersubscription.GroupIDEQ(groupID)).
+		WithGroup().
+		ForUpdate().
+		Only(ctx)
+	if err != nil {
+		return nil, translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+	}
+	return userSubscriptionEntityToService(m), nil
+}
+
 func (r *userSubscriptionRepository) GetActiveByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
 	client := clientFromContext(ctx, r.client)
 	m, err := client.UserSubscription.Query().

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -1851,6 +1851,9 @@ func (stubUserSubscriptionRepo) GetByID(ctx context.Context, id int64) (*service
 func (stubUserSubscriptionRepo) GetByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
 	return nil, errors.New("not implemented")
 }
+func (stubUserSubscriptionRepo) GetByUserIDAndGroupIDForUpdate(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
+	return nil, errors.New("not implemented")
+}
 func (stubUserSubscriptionRepo) GetActiveByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
 	return nil, errors.New("not implemented")
 }

--- a/backend/internal/server/middleware/api_key_auth_google_test.go
+++ b/backend/internal/server/middleware/api_key_auth_google_test.go
@@ -117,6 +117,9 @@ func (f fakeGoogleSubscriptionRepo) GetByID(ctx context.Context, id int64) (*ser
 func (f fakeGoogleSubscriptionRepo) GetByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
 	return nil, errors.New("not implemented")
 }
+func (f fakeGoogleSubscriptionRepo) GetByUserIDAndGroupIDForUpdate(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
+	return nil, errors.New("not implemented")
+}
 func (f fakeGoogleSubscriptionRepo) GetActiveByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
 	if f.getActive != nil {
 		return f.getActive(ctx, userID, groupID)

--- a/backend/internal/server/middleware/api_key_auth_test.go
+++ b/backend/internal/server/middleware/api_key_auth_test.go
@@ -623,6 +623,10 @@ func (r *stubUserSubscriptionRepo) GetByUserIDAndGroupID(ctx context.Context, us
 	return nil, errors.New("not implemented")
 }
 
+func (r *stubUserSubscriptionRepo) GetByUserIDAndGroupIDForUpdate(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
+	return nil, errors.New("not implemented")
+}
+
 func (r *stubUserSubscriptionRepo) GetActiveByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*service.UserSubscription, error) {
 	if r.getActive != nil {
 		return r.getActive(ctx, userID, groupID)

--- a/backend/internal/service/subscription_assign_idempotency_test.go
+++ b/backend/internal/service/subscription_assign_idempotency_test.go
@@ -76,6 +76,9 @@ func (userSubRepoNoop) GetByID(context.Context, int64) (*UserSubscription, error
 func (userSubRepoNoop) GetByUserIDAndGroupID(context.Context, int64, int64) (*UserSubscription, error) {
 	panic("unexpected GetByUserIDAndGroupID call")
 }
+func (userSubRepoNoop) GetByUserIDAndGroupIDForUpdate(context.Context, int64, int64) (*UserSubscription, error) {
+	panic("unexpected GetByUserIDAndGroupIDForUpdate call")
+}
 func (userSubRepoNoop) GetActiveByUserIDAndGroupID(context.Context, int64, int64) (*UserSubscription, error) {
 	panic("unexpected GetActiveByUserIDAndGroupID call")
 }

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -176,13 +176,6 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		return nil, false, ErrGroupNotSubscriptionType
 	}
 
-	// 查询是否已有订阅
-	existingSub, err := s.userSubRepo.GetByUserIDAndGroupID(ctx, input.UserID, input.GroupID)
-	if err != nil {
-		// 不存在记录是正常情况，其他错误需要返回
-		existingSub = nil
-	}
-
 	validityDays := input.ValidityDays
 	if validityDays <= 0 {
 		validityDays = 30
@@ -191,7 +184,20 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		validityDays = MaxValidityDays
 	}
 
-	// 已有订阅，执行续期（在事务中完成所有更新）
+	// 先开事务，在事务内用 FOR UPDATE 行锁读取已有订阅，防止并发续期丢失更新。
+	tx, err := s.entClient.Tx(ctx)
+	if err != nil {
+		return nil, false, fmt.Errorf("begin transaction: %w", err)
+	}
+	txCtx := dbent.NewTxContext(ctx, tx)
+
+	existingSub, err := s.userSubRepo.GetByUserIDAndGroupIDForUpdate(txCtx, input.UserID, input.GroupID)
+	if err != nil {
+		// 不存在记录是正常情况，回滚事务走创建路径；其他错误直接返回
+		existingSub = nil
+	}
+
+	// 已有订阅，在事务内执行续期（ExtendExpiry + UpdateStatus + UpdateNotes）
 	if existingSub != nil {
 		now := time.Now()
 		var newExpiresAt time.Time
@@ -208,13 +214,6 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		if newExpiresAt.After(MaxExpiresAt) {
 			newExpiresAt = MaxExpiresAt
 		}
-
-		// 开启事务：ExtendExpiry + UpdateStatus + UpdateNotes 在同一事务中完成
-		tx, err := s.entClient.Tx(ctx)
-		if err != nil {
-			return nil, false, fmt.Errorf("begin transaction: %w", err)
-		}
-		txCtx := dbent.NewTxContext(ctx, tx)
 
 		// 更新过期时间
 		if err := s.userSubRepo.ExtendExpiry(txCtx, existingSub.ID, newExpiresAt); err != nil {
@@ -263,6 +262,9 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		sub, err := s.userSubRepo.GetByID(ctx, existingSub.ID)
 		return sub, true, err // true 表示是续期
 	}
+
+	// 不存在订阅，回滚事务走创建路径
+	_ = tx.Rollback()
 
 	// 没有订阅，创建新订阅
 	sub, err := s.createSubscription(ctx, input)

--- a/backend/internal/service/user_subscription_port.go
+++ b/backend/internal/service/user_subscription_port.go
@@ -11,6 +11,7 @@ type UserSubscriptionRepository interface {
 	Create(ctx context.Context, sub *UserSubscription) error
 	GetByID(ctx context.Context, id int64) (*UserSubscription, error)
 	GetByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*UserSubscription, error)
+	GetByUserIDAndGroupIDForUpdate(ctx context.Context, userID, groupID int64) (*UserSubscription, error)
 	GetActiveByUserIDAndGroupID(ctx context.Context, userID, groupID int64) (*UserSubscription, error)
 	Update(ctx context.Context, sub *UserSubscription) error
 	Delete(ctx context.Context, id int64) error


### PR DESCRIPTION
## Summary

Fix a lost-update race condition in `AssignOrExtendSubscription`. Two concurrent subscription extension requests could read the same `expires_at`, each compute an extension based on the stale value, and overwrite each other's result.

## Changes

- Move the existing subscription read inside the transaction with `SELECT ... FOR UPDATE`
- Add `GetByUserIDAndGroupIDForUpdate` to `UserSubscriptionRepository` interface and implementation
- Follows the same pattern already used by PromoCode (`GetByCodeForUpdate` in `promo_code_repo.go`)

## Files Changed

| File | Change |
|------|--------|
| `service/user_subscription_port.go` | Add `GetByUserIDAndGroupIDForUpdate` to interface |
| `repository/user_subscription_repo.go` | Implement `ForUpdate()`-locked read |
| `service/subscription_service.go` | Restructure: start tx → lock read → update → commit |
| `server/api_contract_test.go` | Add stub method |
| `server/middleware/api_key_auth_test.go` | Add stub method |
| `server/middleware/api_key_auth_google_test.go` | Add stub method |

## Race Scenario (Before)

```
T1: Read sub (expires 6/1)
T2: Read sub (expires 6/1)
T1: Compute newExpiresAt = 7/1
T2: Compute newExpiresAt = 7/1
T1: Write 7/1 → Commit
T2: Write 7/1 → Commit
Result: Only 30 days added, 30 days lost
```

## After Fix

```
T1: tx → SELECT FOR UPDATE (locks row, reads 6/1)
T2: tx → SELECT FOR UPDATE (BLOCKS)
T1: Compute 7/1 → Write → Commit (releases lock)
T2: SELECT FOR UPDATE returns (reads 7/1)
T2: Compute 8/1 → Write → Commit
Result: 60 days correctly applied
```

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)