### PR TITLE
feat(openai): 新增仅针对 Codex 请求的账号轮询路由

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -233,6 +233,7 @@ func (h *SettingHandler) GetSettings(c *gin.Context) {
 		PaymentVisibleMethodAlipayEnabled:      settings.PaymentVisibleMethodAlipayEnabled,
 		PaymentVisibleMethodWxpayEnabled:       settings.PaymentVisibleMethodWxpayEnabled,
 		OpenAIAdvancedSchedulerEnabled:         settings.OpenAIAdvancedSchedulerEnabled,
+		OpenAIRoundRobinSchedulerEnabled:       settings.OpenAIRoundRobinSchedulerEnabled,
 		BalanceLowNotifyEnabled:                settings.BalanceLowNotifyEnabled,
 		BalanceLowNotifyThreshold:              settings.BalanceLowNotifyThreshold,
 		BalanceLowNotifyRechargeURL:            settings.BalanceLowNotifyRechargeURL,
@@ -527,7 +528,8 @@ type UpdateSettingsRequest struct {
 	PaymentVisibleMethodWxpayEnabled  *bool   `json:"payment_visible_method_wxpay_enabled"`
 
 	// OpenAI account scheduling
-	OpenAIAdvancedSchedulerEnabled *bool `json:"openai_advanced_scheduler_enabled"`
+	OpenAIAdvancedSchedulerEnabled   *bool `json:"openai_advanced_scheduler_enabled"`
+	OpenAIRoundRobinSchedulerEnabled *bool `json:"openai_round_robin_scheduler_enabled"`
 
 	// Balance low notification
 	BalanceLowNotifyEnabled     *bool                   `json:"balance_low_notify_enabled"`
@@ -1469,6 +1471,12 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 			}
 			return previousSettings.OpenAIAdvancedSchedulerEnabled
 		}(),
+		OpenAIRoundRobinSchedulerEnabled: func() bool {
+			if req.OpenAIRoundRobinSchedulerEnabled != nil {
+				return *req.OpenAIRoundRobinSchedulerEnabled
+			}
+			return previousSettings.OpenAIRoundRobinSchedulerEnabled
+		}(),
 		BalanceLowNotifyEnabled: func() bool {
 			if req.BalanceLowNotifyEnabled != nil {
 				return *req.BalanceLowNotifyEnabled
@@ -1778,6 +1786,7 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		PaymentVisibleMethodAlipayEnabled:      updatedSettings.PaymentVisibleMethodAlipayEnabled,
 		PaymentVisibleMethodWxpayEnabled:       updatedSettings.PaymentVisibleMethodWxpayEnabled,
 		OpenAIAdvancedSchedulerEnabled:         updatedSettings.OpenAIAdvancedSchedulerEnabled,
+		OpenAIRoundRobinSchedulerEnabled:       updatedSettings.OpenAIRoundRobinSchedulerEnabled,
 		BalanceLowNotifyEnabled:                updatedSettings.BalanceLowNotifyEnabled,
 		BalanceLowNotifyThreshold:              updatedSettings.BalanceLowNotifyThreshold,
 		BalanceLowNotifyRechargeURL:            updatedSettings.BalanceLowNotifyRechargeURL,
@@ -2189,6 +2198,9 @@ func diffSettings(before *service.SystemSettings, after *service.SystemSettings,
 	}
 	if before.OpenAIAdvancedSchedulerEnabled != after.OpenAIAdvancedSchedulerEnabled {
 		changed = append(changed, "openai_advanced_scheduler_enabled")
+	}
+	if before.OpenAIRoundRobinSchedulerEnabled != after.OpenAIRoundRobinSchedulerEnabled {
+		changed = append(changed, "openai_round_robin_scheduler_enabled")
 	}
 	// Balance & quota notification
 	if before.BalanceLowNotifyEnabled != after.BalanceLowNotifyEnabled {

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -175,7 +175,8 @@ type SystemSettings struct {
 	PaymentVisibleMethodWxpayEnabled  bool   `json:"payment_visible_method_wxpay_enabled"`
 
 	// OpenAI account scheduling
-	OpenAIAdvancedSchedulerEnabled bool `json:"openai_advanced_scheduler_enabled"`
+	OpenAIAdvancedSchedulerEnabled   bool `json:"openai_advanced_scheduler_enabled"`
+	OpenAIRoundRobinSchedulerEnabled bool `json:"openai_round_robin_scheduler_enabled"`
 
 	// Payment configuration
 	PaymentEnabled                   bool     `json:"payment_enabled"`

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -21,7 +21,9 @@ const (
 	openAIAccountScheduleLayerPreviousResponse = "previous_response_id"
 	openAIAccountScheduleLayerSessionSticky    = "session_hash"
 	openAIAccountScheduleLayerLoadBalance      = "load_balance"
+	openAIAccountScheduleLayerRoundRobin       = "round_robin"
 	openAIAdvancedSchedulerSettingKey          = "openai_advanced_scheduler_enabled"
+	openAIRoundRobinSchedulerSettingKey        = "openai_round_robin_scheduler_enabled"
 )
 
 const (
@@ -1012,6 +1014,7 @@ func (s *OpenAIGatewayService) getOpenAIAccountScheduler(ctx context.Context) Op
 func resetOpenAIAdvancedSchedulerSettingCacheForTest() {
 	openAIAdvancedSchedulerSettingCache = atomic.Value{}
 	openAIAdvancedSchedulerSettingSF = singleflight.Group{}
+	resetOpenAIRoundRobinSchedulerSettingCacheForTest()
 }
 
 func (s *OpenAIGatewayService) SelectAccountWithScheduler(
@@ -1060,6 +1063,19 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 	decision := OpenAIAccountScheduleDecision{}
 	scheduler := s.getOpenAIAccountScheduler(ctx)
 	if scheduler == nil {
+		if roundRobin := s.getOpenAIRoundRobinScheduler(ctx); roundRobin != nil {
+			selection, rrDecision, err := roundRobin.Select(ctx, OpenAIAccountScheduleRequest{
+				GroupID:                 groupID,
+				SessionHash:             sessionHash,
+				PreviousResponseID:      previousResponseID,
+				RequestedModel:          requestedModel,
+				RequiredTransport:       requiredTransport,
+				RequiredImageCapability: requiredImageCapability,
+				RequireCompact:          requireCompact,
+				ExcludedIDs:             excludedIDs,
+			})
+			return selection, rrDecision, err
+		}
 		decision.Layer = openAIAccountScheduleLayerLoadBalance
 		if requiredTransport == OpenAIUpstreamTransportAny || requiredTransport == OpenAIUpstreamTransportHTTPSSE {
 			effectiveExcludedIDs := cloneExcludedAccountIDs(excludedIDs)

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1063,18 +1063,20 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 	decision := OpenAIAccountScheduleDecision{}
 	scheduler := s.getOpenAIAccountScheduler(ctx)
 	if scheduler == nil {
-		if roundRobin := s.getOpenAIRoundRobinScheduler(ctx); roundRobin != nil {
-			selection, rrDecision, err := roundRobin.Select(ctx, OpenAIAccountScheduleRequest{
-				GroupID:                 groupID,
-				SessionHash:             sessionHash,
-				PreviousResponseID:      previousResponseID,
-				RequestedModel:          requestedModel,
-				RequiredTransport:       requiredTransport,
-				RequiredImageCapability: requiredImageCapability,
-				RequireCompact:          requireCompact,
-				ExcludedIDs:             excludedIDs,
-			})
-			return selection, rrDecision, err
+		if shouldUseOpenAIRoundRobinForModel(requestedModel) {
+			if roundRobin := s.getOpenAIRoundRobinScheduler(ctx); roundRobin != nil {
+				selection, rrDecision, err := roundRobin.Select(ctx, OpenAIAccountScheduleRequest{
+					GroupID:                 groupID,
+					SessionHash:             sessionHash,
+					PreviousResponseID:      previousResponseID,
+					RequestedModel:          requestedModel,
+					RequiredTransport:       requiredTransport,
+					RequiredImageCapability: requiredImageCapability,
+					RequireCompact:          requireCompact,
+					ExcludedIDs:             excludedIDs,
+				})
+				return selection, rrDecision, err
+			}
 		}
 		decision.Layer = openAIAccountScheduleLayerLoadBalance
 		if requiredTransport == OpenAIUpstreamTransportAny || requiredTransport == OpenAIUpstreamTransportHTTPSSE {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -337,7 +337,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinEnabledCycles
 
 	var got []int64
 	for i := 0; i < 5; i++ {
-		selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "ignored-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+		selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "ignored-sticky", "gpt-5.3-codex", nil, OpenAIUpstreamTransportAny, false)
 		require.NoError(t, err)
 		require.NotNil(t, selection)
 		require.NotNil(t, selection.Account)
@@ -348,6 +348,41 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinEnabledCycles
 		}
 	}
 	require.Equal(t, []int64{51001, 51002, 51003, 51001, 51002}, got)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinDisabledForNonCodexModels(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(20115)
+	accounts := []Account{
+		{ID: 51103, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 51101, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 51102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cfg:                &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		rateLimitService:   newOpenAISchedulerRateLimitService("false", "true"),
+	}
+
+	first, firstDecision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.NotNil(t, first.Account)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, firstDecision.Layer)
+	if first.ReleaseFunc != nil {
+		first.ReleaseFunc()
+	}
+
+	second, secondDecision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.NotNil(t, second.Account)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, secondDecision.Layer)
+	require.Equal(t, first.Account.ID, second.Account.ID)
+	if second.ReleaseFunc != nil {
+		second.ReleaseFunc()
+	}
 }
 
 func TestOpenAIGatewayService_SelectAccountWithScheduler_AdvancedSchedulerWinsOverRoundRobin(t *testing.T) {
@@ -397,7 +432,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinIgnoresSticky
 	require.NoError(t, svc.BindStickySession(ctx, &groupID, "rr-sticky", 53002))
 	require.NoError(t, svc.getOpenAIWSStateStore().BindResponseAccount(ctx, groupID, "resp_rr_001", 53002, time.Hour))
 
-	first, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "resp_rr_001", "rr-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	first, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "resp_rr_001", "rr-sticky", "gpt-5.3-codex", nil, OpenAIUpstreamTransportAny, false)
 	require.NoError(t, err)
 	require.NotNil(t, first)
 	require.NotNil(t, first.Account)
@@ -408,7 +443,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinIgnoresSticky
 		first.ReleaseFunc()
 	}
 
-	second, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "resp_rr_001", "rr-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	second, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "resp_rr_001", "rr-sticky", "gpt-5.3-codex", nil, OpenAIUpstreamTransportAny, false)
 	require.NoError(t, err)
 	require.NotNil(t, second)
 	require.NotNil(t, second.Account)
@@ -437,7 +472,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinSkipsExcluded
 		&groupID,
 		"",
 		"",
-		"gpt-5.1",
+		"gpt-5.3-codex",
 		map[int64]struct{}{54001: {}},
 		OpenAIUpstreamTransportAny,
 		false,
@@ -467,7 +502,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinReturnsAcquir
 		rateLimitService: newOpenAISchedulerRateLimitService("false", "true"),
 	}
 
-	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.3-codex", nil, OpenAIUpstreamTransportAny, false)
 	require.ErrorIs(t, err, acquireErr)
 	require.Nil(t, selection)
 	require.Equal(t, openAIAccountScheduleLayerRoundRobin, decision.Layer)

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -62,11 +62,15 @@ type schedulerTestConcurrencyCache struct {
 	loadBatchErr    error
 	loadMap         map[int64]*AccountLoadInfo
 	acquireResults  map[int64]bool
+	acquireErr      error
 	waitCounts      map[int64]int
 	skipDefaultLoad bool
 }
 
 func (c schedulerTestConcurrencyCache) AcquireAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
+	if c.acquireErr != nil {
+		return false, c.acquireErr
+	}
 	if c.acquireResults != nil {
 		if result, ok := c.acquireResults[accountID]; ok {
 			return result, nil
@@ -215,6 +219,22 @@ func newOpenAIAdvancedSchedulerRateLimitService(enabled string) *RateLimitServic
 	}
 }
 
+func newOpenAISchedulerRateLimitService(advancedEnabled string, roundRobinEnabled string) *RateLimitService {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	repo := &openAIAdvancedSchedulerSettingRepoStub{
+		values: map[string]string{},
+	}
+	if advancedEnabled != "" {
+		repo.values[openAIAdvancedSchedulerSettingKey] = advancedEnabled
+	}
+	if roundRobinEnabled != "" {
+		repo.values[openAIRoundRobinSchedulerSettingKey] = roundRobinEnabled
+	}
+	return &RateLimitService{
+		settingService: NewSettingService(repo, &config.Config{}),
+	}
+}
+
 func (s *openAISnapshotCacheStub) GetSnapshot(ctx context.Context, bucket SchedulerBucket) ([]*Account, bool, error) {
 	if len(s.snapshotAccounts) == 0 {
 		return nil, false, nil
@@ -297,6 +317,160 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabledUsesLega
 	require.Equal(t, int64(36002), selection.Account.ID)
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 	require.False(t, decision.StickyPreviousHit)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinEnabledCyclesAccounts(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(20101)
+	accounts := []Account{
+		{ID: 51003, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 51001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 51002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cfg:                &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		rateLimitService:   newOpenAISchedulerRateLimitService("false", "true"),
+		openaiAccountStats: newOpenAIAccountRuntimeStats(),
+	}
+
+	var got []int64
+	for i := 0; i < 5; i++ {
+		selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "ignored-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.NotNil(t, selection.Account)
+		got = append(got, selection.Account.ID)
+		require.Equal(t, openAIAccountScheduleLayerRoundRobin, decision.Layer)
+		if selection.ReleaseFunc != nil {
+			selection.ReleaseFunc()
+		}
+	}
+	require.Equal(t, []int64{51001, 51002, 51003, 51001, 51002}, got)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_AdvancedSchedulerWinsOverRoundRobin(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(20102)
+	accounts := []Account{
+		{ID: 52001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 52002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+	}
+	cache := &schedulerTestGatewayCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              cache,
+		cfg:                &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		rateLimitService:   newOpenAISchedulerRateLimitService("true", "true"),
+		openaiAccountStats: newOpenAIAccountRuntimeStats(),
+	}
+	require.NoError(t, svc.BindStickySession(ctx, &groupID, "advanced-sticky", 52002))
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "advanced-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(52002), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinIgnoresStickyAndPreviousResponse(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(20103)
+	accounts := []Account{
+		{ID: 53001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 53002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+	}
+	cache := &schedulerTestGatewayCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              cache,
+		cfg:                &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		rateLimitService:   newOpenAISchedulerRateLimitService("false", "true"),
+	}
+	require.NoError(t, svc.BindStickySession(ctx, &groupID, "rr-sticky", 53002))
+	require.NoError(t, svc.getOpenAIWSStateStore().BindResponseAccount(ctx, groupID, "resp_rr_001", 53002, time.Hour))
+
+	first, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "resp_rr_001", "rr-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.NotNil(t, first.Account)
+	require.Equal(t, int64(53001), first.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerRoundRobin, decision.Layer)
+	require.Equal(t, int64(53002), cache.sessionBindings["openai:rr-sticky"])
+	if first.ReleaseFunc != nil {
+		first.ReleaseFunc()
+	}
+
+	second, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "resp_rr_001", "rr-sticky", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.NotNil(t, second.Account)
+	require.Equal(t, int64(53002), second.Account.ID)
+	if second.ReleaseFunc != nil {
+		second.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinSkipsExcluded(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(20104)
+	accounts := []Account{
+		{ID: 54001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+		{ID: 54002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cfg:                &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		rateLimitService:   newOpenAISchedulerRateLimitService("false", "true"),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.1",
+		map[int64]struct{}{54001: {}},
+		OpenAIUpstreamTransportAny,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(54002), selection.Account.ID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobinReturnsAcquireError(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(20109)
+	acquireErr := errors.New("redis unavailable")
+	accounts := []Account{
+		{ID: 59001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0},
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cfg:         &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{
+			acquireErr: acquireErr,
+		}),
+		rateLimitService: newOpenAISchedulerRateLimitService("false", "true"),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.ErrorIs(t, err, acquireErr)
+	require.Nil(t, selection)
+	require.Equal(t, openAIAccountScheduleLayerRoundRobin, decision.Layer)
 }
 
 func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_RequiredWSV2_SkipsHTTPOnlyAccount(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -340,10 +340,12 @@ type OpenAIGatewayService struct {
 	openaiWSPoolOnce              sync.Once
 	openaiWSStateStoreOnce        sync.Once
 	openaiSchedulerOnce           sync.Once
+	openaiRoundRobinSchedulerOnce sync.Once
 	openaiWSPassthroughDialerOnce sync.Once
 	openaiWSPool                  *openAIWSConnPool
 	openaiWSStateStore            OpenAIWSStateStore
 	openaiScheduler               OpenAIAccountScheduler
+	openaiRoundRobinScheduler     *openAIRoundRobinScheduler
 	openaiWSPassthroughDialer     openAIWSClientDialer
 	openaiAccountStats            *openAIAccountRuntimeStats
 

--- a/backend/internal/service/openai_round_robin_scheduler.go
+++ b/backend/internal/service/openai_round_robin_scheduler.go
@@ -87,6 +87,11 @@ func (s *OpenAIGatewayService) getOpenAIRoundRobinScheduler(ctx context.Context)
 	return s.openaiRoundRobinScheduler
 }
 
+func shouldUseOpenAIRoundRobinForModel(requestedModel string) bool {
+	normalized := normalizeKnownOpenAICodexModel(requestedModel)
+	return normalized != "" && strings.Contains(normalized, "codex")
+}
+
 func resetOpenAIRoundRobinSchedulerSettingCacheForTest() {
 	openAIRoundRobinSchedulerSettingCache = atomic.Value{}
 	openAIRoundRobinSchedulerSettingSF = singleflight.Group{}

--- a/backend/internal/service/openai_round_robin_scheduler.go
+++ b/backend/internal/service/openai_round_robin_scheduler.go
@@ -1,0 +1,275 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	openAIRoundRobinSchedulerSettingCacheTTL  = 5 * time.Second
+	openAIRoundRobinSchedulerSettingDBTimeout = 2 * time.Second
+)
+
+type cachedOpenAIRoundRobinSchedulerSetting struct {
+	enabled   bool
+	expiresAt int64
+}
+
+var openAIRoundRobinSchedulerSettingCache atomic.Value // *cachedOpenAIRoundRobinSchedulerSetting
+var openAIRoundRobinSchedulerSettingSF singleflight.Group
+
+type openAIRoundRobinScheduler struct {
+	service *OpenAIGatewayService
+	mu      sync.Mutex
+	cursors map[string]uint64
+}
+
+func newOpenAIRoundRobinScheduler(service *OpenAIGatewayService) *openAIRoundRobinScheduler {
+	return &openAIRoundRobinScheduler{
+		service: service,
+		cursors: make(map[string]uint64),
+	}
+}
+
+func (s *OpenAIGatewayService) isOpenAIRoundRobinSchedulerEnabled(ctx context.Context) bool {
+	if cached, ok := openAIRoundRobinSchedulerSettingCache.Load().(*cachedOpenAIRoundRobinSchedulerSetting); ok && cached != nil {
+		if time.Now().UnixNano() < cached.expiresAt {
+			return cached.enabled
+		}
+	}
+
+	result, _, _ := openAIRoundRobinSchedulerSettingSF.Do(openAIRoundRobinSchedulerSettingKey, func() (any, error) {
+		if cached, ok := openAIRoundRobinSchedulerSettingCache.Load().(*cachedOpenAIRoundRobinSchedulerSetting); ok && cached != nil {
+			if time.Now().UnixNano() < cached.expiresAt {
+				return cached.enabled, nil
+			}
+		}
+
+		enabled := false
+		if repo := s.openAIAdvancedSchedulerSettingRepo(); repo != nil {
+			dbCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), openAIRoundRobinSchedulerSettingDBTimeout)
+			defer cancel()
+
+			value, err := repo.GetValue(dbCtx, openAIRoundRobinSchedulerSettingKey)
+			if err == nil {
+				enabled = strings.EqualFold(strings.TrimSpace(value), "true")
+			}
+		}
+
+		openAIRoundRobinSchedulerSettingCache.Store(&cachedOpenAIRoundRobinSchedulerSetting{
+			enabled:   enabled,
+			expiresAt: time.Now().Add(openAIRoundRobinSchedulerSettingCacheTTL).UnixNano(),
+		})
+		return enabled, nil
+	})
+
+	enabled, _ := result.(bool)
+	return enabled
+}
+
+func (s *OpenAIGatewayService) getOpenAIRoundRobinScheduler(ctx context.Context) *openAIRoundRobinScheduler {
+	if s == nil || !s.isOpenAIRoundRobinSchedulerEnabled(ctx) {
+		return nil
+	}
+	s.openaiRoundRobinSchedulerOnce.Do(func() {
+		if s.openaiRoundRobinScheduler == nil {
+			s.openaiRoundRobinScheduler = newOpenAIRoundRobinScheduler(s)
+		}
+	})
+	return s.openaiRoundRobinScheduler
+}
+
+func resetOpenAIRoundRobinSchedulerSettingCacheForTest() {
+	openAIRoundRobinSchedulerSettingCache = atomic.Value{}
+	openAIRoundRobinSchedulerSettingSF = singleflight.Group{}
+}
+
+func (r *openAIRoundRobinScheduler) Select(
+	ctx context.Context,
+	req OpenAIAccountScheduleRequest,
+) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
+	decision := OpenAIAccountScheduleDecision{
+		Layer: openAIAccountScheduleLayerRoundRobin,
+	}
+	start := time.Now()
+	defer func() {
+		decision.LatencyMs = time.Since(start).Milliseconds()
+	}()
+
+	if r == nil || r.service == nil {
+		return nil, decision, ErrNoAvailableAccounts
+	}
+	selection, candidateCount, err := r.selectByRoundRobin(ctx, req)
+	decision.CandidateCount = candidateCount
+	if err != nil {
+		return nil, decision, err
+	}
+	if selection != nil && selection.Account != nil {
+		decision.SelectedAccountID = selection.Account.ID
+		decision.SelectedAccountType = selection.Account.Type
+	}
+	return selection, decision, nil
+}
+
+func (r *openAIRoundRobinScheduler) selectByRoundRobin(
+	ctx context.Context,
+	req OpenAIAccountScheduleRequest,
+) (*AccountSelectionResult, int, error) {
+	if r.service.checkChannelPricingRestriction(ctx, req.GroupID, req.RequestedModel) {
+		return nil, 0, fmt.Errorf("%w supporting model: %s (channel pricing restriction)", ErrNoAvailableAccounts, req.RequestedModel)
+	}
+
+	accounts, err := r.service.listSchedulableAccounts(ctx, req.GroupID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	candidates, compactBlocked := r.filterCandidates(ctx, accounts, req)
+	if len(candidates) == 0 {
+		return nil, 0, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked)
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].Priority != candidates[j].Priority {
+			return candidates[i].Priority < candidates[j].Priority
+		}
+		return candidates[i].ID < candidates[j].ID
+	})
+
+	cfg := r.service.schedulingConfig()
+	key := buildOpenAIRoundRobinCursorKey(req)
+	for start := 0; start < len(candidates); {
+		end := start + 1
+		for end < len(candidates) && candidates[end].Priority == candidates[start].Priority {
+			end++
+		}
+
+		ordered := r.orderBucket(key, candidates[start:end])
+		var waitAccount *Account
+		usableBucket := false
+		for _, account := range ordered {
+			fresh := r.service.recheckSelectedOpenAIAccountFromDB(ctx, account, req.RequestedModel, false)
+			if fresh == nil {
+				continue
+			}
+			if req.RequireCompact && openAICompactSupportTier(fresh) == 0 {
+				compactBlocked = true
+				continue
+			}
+			if !isOpenAIAccountEligibleForRequest(fresh, req.RequestedModel, req.RequireCompact) ||
+				!r.service.isOpenAIAccountTransportCompatible(fresh, req.RequiredTransport) ||
+				!fresh.SupportsOpenAIImageCapability(req.RequiredImageCapability) {
+				continue
+			}
+			usableBucket = true
+			result, acquireErr := r.service.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
+			if acquireErr != nil {
+				return nil, len(candidates), acquireErr
+			}
+			if result != nil && result.Acquired {
+				selection, err := r.service.newSelectionResult(ctx, fresh, true, result.ReleaseFunc, nil)
+				return selection, len(candidates), err
+			}
+			if waitAccount == nil {
+				waitAccount = fresh
+			}
+		}
+		if waitAccount != nil {
+			selection, err := r.service.newSelectionResult(ctx, waitAccount, false, nil, &AccountWaitPlan{
+				AccountID:      waitAccount.ID,
+				MaxConcurrency: waitAccount.Concurrency,
+				Timeout:        cfg.FallbackWaitTimeout,
+				MaxWaiting:     cfg.FallbackMaxWaiting,
+			})
+			return selection, len(candidates), err
+		}
+		if usableBucket {
+			return nil, len(candidates), noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked)
+		}
+		start = end
+	}
+	return nil, len(candidates), noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked)
+}
+
+func (r *openAIRoundRobinScheduler) filterCandidates(
+	ctx context.Context,
+	accounts []Account,
+	req OpenAIAccountScheduleRequest,
+) ([]*Account, bool) {
+	needsUpstreamCheck := r.service.needsUpstreamChannelRestrictionCheck(ctx, req.GroupID)
+	candidates := make([]*Account, 0, len(accounts))
+	compactBlocked := false
+	for i := range accounts {
+		account := &accounts[i]
+		if req.ExcludedIDs != nil {
+			if _, excluded := req.ExcludedIDs[account.ID]; excluded {
+				continue
+			}
+		}
+		account = r.service.recheckSelectedOpenAIAccountFromDB(ctx, account, req.RequestedModel, false)
+		if account == nil {
+			continue
+		}
+		if !isOpenAIAccountEligibleForRequest(account, req.RequestedModel, req.RequireCompact) {
+			if req.RequireCompact && account != nil && account.IsSchedulable() && account.IsOpenAI() &&
+				(req.RequestedModel == "" || account.IsModelSupported(req.RequestedModel)) &&
+				openAICompactSupportTier(account) == 0 {
+				compactBlocked = true
+			}
+			continue
+		}
+		if needsUpstreamCheck && req.GroupID != nil && r.service.isUpstreamModelRestrictedByChannel(ctx, *req.GroupID, account, req.RequestedModel, req.RequireCompact) {
+			continue
+		}
+		if !r.service.isOpenAIAccountTransportCompatible(account, req.RequiredTransport) {
+			continue
+		}
+		if !account.SupportsOpenAIImageCapability(req.RequiredImageCapability) {
+			continue
+		}
+		candidates = append(candidates, account)
+	}
+	return candidates, compactBlocked
+}
+
+func (r *openAIRoundRobinScheduler) orderBucket(key string, bucket []*Account) []*Account {
+	if len(bucket) <= 1 {
+		return append([]*Account(nil), bucket...)
+	}
+	r.mu.Lock()
+	if r.cursors == nil {
+		r.cursors = make(map[string]uint64)
+	}
+	cursor := r.cursors[key]
+	start := int(cursor % uint64(len(bucket)))
+	r.cursors[key] = cursor + 1
+	r.mu.Unlock()
+
+	ordered := make([]*Account, 0, len(bucket))
+	for offset := 0; offset < len(bucket); offset++ {
+		ordered = append(ordered, bucket[(start+offset)%len(bucket)])
+	}
+	return ordered
+}
+
+func buildOpenAIRoundRobinCursorKey(req OpenAIAccountScheduleRequest) string {
+	groupID := int64(0)
+	if req.GroupID != nil {
+		groupID = *req.GroupID
+	}
+	return strings.Join([]string{
+		strconv.FormatInt(groupID, 10),
+		strings.TrimSpace(req.RequestedModel),
+		string(req.RequiredTransport),
+		string(req.RequiredImageCapability),
+		strconv.FormatBool(req.RequireCompact),
+	}, ":")
+}

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -1654,6 +1654,7 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	updates[SettingPaymentVisibleMethodAlipayEnabled] = strconv.FormatBool(settings.PaymentVisibleMethodAlipayEnabled)
 	updates[SettingPaymentVisibleMethodWxpayEnabled] = strconv.FormatBool(settings.PaymentVisibleMethodWxpayEnabled)
 	updates[openAIAdvancedSchedulerSettingKey] = strconv.FormatBool(settings.OpenAIAdvancedSchedulerEnabled)
+	updates[openAIRoundRobinSchedulerSettingKey] = strconv.FormatBool(settings.OpenAIRoundRobinSchedulerEnabled)
 
 	// Balance low notification
 	updates[SettingKeyBalanceLowNotifyEnabled] = strconv.FormatBool(settings.BalanceLowNotifyEnabled)
@@ -1733,6 +1734,11 @@ func (s *SettingService) refreshCachedSettings(settings *SystemSettings) {
 	openAIAdvancedSchedulerSettingCache.Store(&cachedOpenAIAdvancedSchedulerSetting{
 		enabled:   settings.OpenAIAdvancedSchedulerEnabled,
 		expiresAt: time.Now().Add(openAIAdvancedSchedulerSettingCacheTTL).UnixNano(),
+	})
+	openAIRoundRobinSchedulerSettingSF.Forget(openAIRoundRobinSchedulerSettingKey)
+	openAIRoundRobinSchedulerSettingCache.Store(&cachedOpenAIRoundRobinSchedulerSetting{
+		enabled:   settings.OpenAIRoundRobinSchedulerEnabled,
+		expiresAt: time.Now().Add(openAIRoundRobinSchedulerSettingCacheTTL).UnixNano(),
 	})
 	if s.onUpdate != nil {
 		s.onUpdate() // Invalidate cache after settings update
@@ -2464,6 +2470,7 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		SettingPaymentVisibleMethodAlipayEnabled:     "false",
 		SettingPaymentVisibleMethodWxpayEnabled:      "false",
 		openAIAdvancedSchedulerSettingKey:            "false",
+		openAIRoundRobinSchedulerSettingKey:          "false",
 	}
 
 	return s.settingRepo.SetMultiple(ctx, defaults)
@@ -2854,6 +2861,7 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 	result.PaymentVisibleMethodAlipayEnabled = settings[SettingPaymentVisibleMethodAlipayEnabled] == "true"
 	result.PaymentVisibleMethodWxpayEnabled = settings[SettingPaymentVisibleMethodWxpayEnabled] == "true"
 	result.OpenAIAdvancedSchedulerEnabled = settings[openAIAdvancedSchedulerSettingKey] == "true"
+	result.OpenAIRoundRobinSchedulerEnabled = settings[openAIRoundRobinSchedulerSettingKey] == "true"
 
 	// Balance low notification
 	result.BalanceLowNotifyEnabled = settings[SettingKeyBalanceLowNotifyEnabled] == "true"

--- a/backend/internal/service/setting_service_update_test.go
+++ b/backend/internal/service/setting_service_update_test.go
@@ -260,7 +260,7 @@ func TestSettingService_UpdateSettings_TablePreferences(t *testing.T) {
 	require.Equal(t, "[20,100]", repo.updates[SettingKeyTablePageSizeOptions])
 }
 
-func TestSettingService_UpdateSettings_PaymentVisibleMethodsAndAdvancedScheduler(t *testing.T) {
+func TestSettingService_UpdateSettings_PaymentVisibleMethodsAndOpenAISchedulers(t *testing.T) {
 	repo := &settingUpdateRepoStub{}
 	svc := NewSettingService(repo, &config.Config{})
 
@@ -270,6 +270,7 @@ func TestSettingService_UpdateSettings_PaymentVisibleMethodsAndAdvancedScheduler
 		PaymentVisibleMethodAlipayEnabled: true,
 		PaymentVisibleMethodWxpayEnabled:  false,
 		OpenAIAdvancedSchedulerEnabled:    true,
+		OpenAIRoundRobinSchedulerEnabled:  true,
 	})
 	require.NoError(t, err)
 	require.Equal(t, VisibleMethodSourceOfficialAlipay, repo.updates[SettingPaymentVisibleMethodAlipaySource])
@@ -277,6 +278,7 @@ func TestSettingService_UpdateSettings_PaymentVisibleMethodsAndAdvancedScheduler
 	require.Equal(t, "true", repo.updates[SettingPaymentVisibleMethodAlipayEnabled])
 	require.Equal(t, "false", repo.updates[SettingPaymentVisibleMethodWxpayEnabled])
 	require.Equal(t, "true", repo.updates[openAIAdvancedSchedulerSettingKey])
+	require.Equal(t, "true", repo.updates[openAIRoundRobinSchedulerSettingKey])
 }
 
 func TestSettingService_UpdateSettings_AntigravityUserAgentVersion(t *testing.T) {

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -185,7 +185,8 @@ type SystemSettings struct {
 	PaymentVisibleMethodWxpayEnabled  bool
 
 	// OpenAI account scheduling
-	OpenAIAdvancedSchedulerEnabled bool
+	OpenAIAdvancedSchedulerEnabled   bool
+	OpenAIRoundRobinSchedulerEnabled bool
 
 	// Balance low notification
 	BalanceLowNotifyEnabled     bool

--- a/backend/migrations/136_add_openai_round_robin_scheduler_setting.sql
+++ b/backend/migrations/136_add_openai_round_robin_scheduler_setting.sql
@@ -1,0 +1,4 @@
+INSERT INTO settings (key, value)
+VALUES
+    ('openai_round_robin_scheduler_enabled', 'false')
+ON CONFLICT (key) DO NOTHING;

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -508,6 +508,7 @@ export interface SystemSettings {
   payment_visible_method_alipay_enabled?: boolean;
   payment_visible_method_wxpay_enabled?: boolean;
   openai_advanced_scheduler_enabled?: boolean;
+  openai_round_robin_scheduler_enabled?: boolean;
 
   // Balance & quota notification
   balance_low_notify_enabled: boolean;
@@ -704,6 +705,7 @@ export interface UpdateSettingsRequest {
   payment_visible_method_alipay_enabled?: boolean;
   payment_visible_method_wxpay_enabled?: boolean;
   openai_advanced_scheduler_enabled?: boolean;
+  openai_round_robin_scheduler_enabled?: boolean;
   // Balance & quota notification
   balance_low_notify_enabled?: boolean;
   balance_low_notify_threshold?: number;

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5997,6 +5997,10 @@ export default {
         title: 'OpenAI experimental scheduler policy',
         description: "Disabled by default. When enabled, this only changes the gateway's experimental account-selection policy for OpenAI traffic; it does not indicate an upstream OpenAI capability."
       },
+      openaiRoundRobinScheduler: {
+        title: 'OpenAI round-robin scheduler',
+        description: 'Disabled by default. Takes effect only when the experimental scheduler is off; each request advances a cursor across eligible OpenAI accounts.'
+      },
       saveSettings: 'Save Settings',
       saving: 'Saving...',
       settingsSaved: 'Settings saved successfully',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5999,7 +5999,7 @@ export default {
       },
       openaiRoundRobinScheduler: {
         title: 'OpenAI round-robin scheduler',
-        description: 'Disabled by default. Takes effect only when the experimental scheduler is off; each request advances a cursor across eligible OpenAI accounts.'
+        description: 'Disabled by default. Takes effect only for Codex account routing when the experimental scheduler is off; each request advances a cursor across eligible accounts.'
       },
       saveSettings: 'Save Settings',
       saving: 'Saving...',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6159,7 +6159,7 @@ export default {
       },
       openaiRoundRobinScheduler: {
         title: 'OpenAI Round-Robin 轮询调度',
-        description: '默认关闭。仅在实验调度关闭时生效；每次请求都会在可用 OpenAI 账号池中推进游标。'
+        description: '默认关闭。仅在实验调度关闭时，对 Codex 账号路由生效；每次请求都会在可用账号池中推进游标。'
       },
       saveSettings: '保存设置',
       saving: '保存中...',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6157,6 +6157,10 @@ export default {
         title: 'OpenAI 实验调度策略',
         description: '默认关闭。开启后仅影响本网关在 OpenAI 账号间的实验性调度选择逻辑，不代表上游 OpenAI 官方能力。'
       },
+      openaiRoundRobinScheduler: {
+        title: 'OpenAI Round-Robin 轮询调度',
+        description: '默认关闭。仅在实验调度关闭时生效；每次请求都会在可用 OpenAI 账号池中推进游标。'
+      },
       saveSettings: '保存设置',
       saving: '保存中...',
       settingsSaved: '设置保存成功',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -3329,6 +3329,22 @@
                 </div>
                 <Toggle v-model="form.openai_advanced_scheduler_enabled" />
               </div>
+
+              <div class="flex items-center justify-between">
+                <div>
+                  <label
+                    class="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {{ t("admin.settings.openaiRoundRobinScheduler.title") }}
+                  </label>
+                  <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{
+                      t("admin.settings.openaiRoundRobinScheduler.description")
+                    }}
+                  </p>
+                </div>
+                <Toggle v-model="form.openai_round_robin_scheduler_enabled" />
+              </div>
             </div>
           </div>
 
@@ -6429,6 +6445,7 @@ type SettingsForm = Omit<
   google_oauth_client_secret: string;
   force_email_on_third_party_signup: boolean;
   openai_advanced_scheduler_enabled: boolean;
+  openai_round_robin_scheduler_enabled: boolean;
 };
 
 const form = reactive<SettingsForm>({
@@ -6595,6 +6612,7 @@ const form = reactive<SettingsForm>({
   // 分组隔离
   allow_ungrouped_key_scheduling: false,
   openai_advanced_scheduler_enabled: false,
+  openai_round_robin_scheduler_enabled: false,
   // Gateway forwarding behavior
   enable_fingerprint_unification: true,
   enable_metadata_passthrough: false,
@@ -7703,6 +7721,8 @@ async function saveSettings() {
       payment_cancel_rate_limit_window_mode:
         form.payment_cancel_rate_limit_window_mode,
       openai_advanced_scheduler_enabled: form.openai_advanced_scheduler_enabled,
+      openai_round_robin_scheduler_enabled:
+        form.openai_round_robin_scheduler_enabled,
       // Balance & quota notification
       balance_low_notify_enabled: form.balance_low_notify_enabled,
       balance_low_notify_threshold:


### PR DESCRIPTION
## 概述

新增一条仅针对 Codex 请求生效的 OpenAI 账号轮询链路，用于在多 OpenAI 账号池场景下按“每个请求推进一次”的方式循环轮询可用账号。

## 背景

现有 sticky / previous_response_id / load-aware 路径更适合强调会话连续性或优先选择局部最优账号，但在大量可互换账号组成的 Codex 账号池中，容易持续命中少数热点账号，导致单账号更早触发限流、额度耗尽或并发拥塞，而其他账号利用率不足。

对于这类账号池场景，更合适的目标不是尽量保持粘性，而是让请求在账号池中更均匀地分布。因此本次新增一条显式的 round-robin 轮询链路，使请求按“一个请求轮到下一个可用账号”的方式推进。

## 适用范围

本次新增的 round-robin 链路仅对以下场景生效：

- 账号平台为 OpenAI
- 请求模型命中 Codex 系列
- `openai_advanced_scheduler_enabled = false`
- `openai_round_robin_scheduler_enabled = true`

这意味着：

- Claude 等非 Codex 请求不会走该轮询链路
- 其他非 Codex 的 OpenAI 请求不会走该轮询链路
- 当高级调度开启时，仍然优先使用现有高级调度器

## 调度优先级

当前调度优先级为：

1. `openai_advanced_scheduler_enabled = true`
   使用现有高级调度器

2. `openai_advanced_scheduler_enabled = false`
   且 `openai_round_robin_scheduler_enabled = true`
   且请求模型命中 Codex 系列
   使用本次新增的 round-robin 轮询链路

3. 其他情况
   保持现有旧链路，即 sticky + load-aware fallback 的行为不变

## 行为说明

启用该轮询链路后：

- 不读取 sticky session 绑定
- 不优先使用 `previous_response_id`
- 每个请求推进一次账号 cursor
- 仅在当前最高可用 priority 桶内轮询
- 如果该 priority 桶内没有可立即获取的并发槽位，则返回现有 fallback wait plan

这次实现刻意保持直白和明确，不引入额外评分、冷却或粘性策略。

## 改动内容

- 新增设置项 `openai_round_robin_scheduler_enabled`，默认值为 `false`
- 新增独立的 OpenAI round-robin 调度器实现
- 将新调度器接入现有 OpenAI 账号选择入口
- 将该链路限制为仅对 Codex 请求生效
- 保持现有高级调度器与旧链路逻辑不变
- 补充后端设置项读写与缓存更新逻辑
- 补充后台设置接口字段
- 补充前端设置页开关
- 补充数据库迁移
- 补充最小回归测试，覆盖核心轮询行为

## 前端设置页

本次在后台 `Gateway` 设置页中新增了 `OpenAI Round-Robin 轮询调度` 开关，位置在现有 `OpenAI 实验调度策略` 开关下方。管理员可以直接在设置页中开启或关闭该轮询链路。

## 测试

已通过：

- `go test ./internal/service -run 'TestOpenAIGatewayService_SelectAccountWithScheduler_RoundRobin|TestSettingService_UpdateSettings_PaymentVisibleMethodsAndOpenAISchedulers'`

另外，本地还使用过 500+ 账号池做过更大规模的轮询验证，但这部分没有作为仓库测试一并提交，原因是这些验证依赖：

- 本地导出的账号文件
- 环境变量
- 真实外网请求

因此本次 PR 仅提交了稳定、可重复运行、无外部依赖的最小自动化测试。
