### PR TITLE
fix(gateway): 修复图片生成上游请求过早取消

### DIFF
--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -639,7 +639,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 		setOpsUpstreamRequestBody(c, forwardBody)
 	}
 
-	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, parsed.Stream)
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 	defer releaseUpstreamCtx()
 
 	token, _, err := s.GetAccessToken(upstreamCtx, account)

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -948,7 +948,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 		)
 	}
 
-	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, parsed.Stream)
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
 	defer releaseUpstreamCtx()
 
 	token, _, err := s.GetAccessToken(upstreamCtx, account)


### PR DESCRIPTION
## 问题

OpenAI 图片生成请求（`/v1/images/generations` 以及 Responses API 的 `image_generation` 工具调用）在生成耗时较长时，可能因为客户端提前断开或代理超时而返回 502。关联 issue 中的典型场景是复杂 prompt + high quality 图片生成需要约 30-80 秒，期间下游连接断开后，日志会出现 `context canceled`。

## 根因

`forwardOpenAIImagesOAuth` 和 `forwardOpenAIImagesAPIKey` 原先都调用了：

```go
upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, parsed.Stream)
```

但图片生成的非流式请求中 `parsed.Stream` 为 `false`，`detachStreamUpstreamContext` 会直接返回原始客户端 context：

```go
if !stream {
    return ctx, func() {}
}
```

因此，一旦客户端连接关闭，Go 会取消 `c.Request.Context()`，上游 HTTP 请求也会被中途取消，最终表现为图片生成请求失败并返回 502。

## 修复

将两处图片生成转发逻辑改为无条件脱离客户端 context：

```go
upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
```

`detachUpstreamContext` 会使用 `context.WithoutCancel(ctx)` 包装上游请求 context，让图片生成这类长耗时上游请求在客户端生命周期结束后仍可继续完成。

## 影响范围

- `backend/internal/service/openai_images.go`
  - `forwardOpenAIImagesAPIKey`
- `backend/internal/service/openai_images_responses.go`
  - `forwardOpenAIImagesOAuth`

本次变更只替换 context 脱离策略，没有改变请求体构建、鉴权、模型映射、响应转换或计费逻辑。

## 验证

- GitHub CI 已通过：后端测试、`golangci-lint`、前端检查、安全检查、CLA 检查
- 本地已通过相关服务测试：

```bash
go test ./internal/service -run 'Test(OpenAI|.*Image|.*Stream|.*Context)'
```

Fixes #2310
