### PR TITLE
Fix OpenAI image edit mask handling

### DIFF
--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"image"
+	"image/color"
+	"image/png"
 	"io"
 	"net/http"
 	"strings"
@@ -27,6 +30,23 @@ type openAIResponsesImageResult struct {
 	Background    string
 	Quality       string
 	Model         string
+}
+
+func openAIImagesRequestedLimit(requested int) int {
+	if requested <= 0 {
+		return 1
+	}
+	return requested
+}
+
+func limitOpenAIResponsesImageResults(results []openAIResponsesImageResult, requested int) []openAIResponsesImageResult {
+	limit := openAIImagesRequestedLimit(requested)
+	if len(results) <= limit {
+		return results
+	}
+	limited := make([]openAIResponsesImageResult, limit)
+	copy(limited, results[:limit])
+	return limited
 }
 
 func openAIResponsesImageResultKey(itemID string, result openAIResponsesImageResult) string {
@@ -201,6 +221,34 @@ func openAIImageUploadToDataURL(upload OpenAIImagesUpload) (string, error) {
 	return "data:" + contentType + ";base64," + base64.StdEncoding.EncodeToString(upload.Data), nil
 }
 
+func normalizeOpenAIImageMaskUpload(upload OpenAIImagesUpload) OpenAIImagesUpload {
+	img, _, err := image.Decode(bytes.NewReader(upload.Data))
+	if err != nil {
+		return upload
+	}
+	bounds := img.Bounds()
+	if bounds.Empty() {
+		return upload
+	}
+	mask := image.NewNRGBA(bounds)
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			_, _, _, alpha := img.At(x, y).RGBA()
+			mask.SetNRGBA(x, y, color.NRGBA{R: 255, G: 255, B: 255, A: uint8(alpha >> 8)})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, mask); err != nil {
+		return upload
+	}
+	upload.Data = buf.Bytes()
+	upload.ContentType = "image/png"
+	if strings.TrimSpace(upload.FileName) == "" {
+		upload.FileName = "mask.png"
+	}
+	return upload
+}
+
 func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel string) ([]byte, error) {
 	if parsed == nil {
 		return nil, fmt.Errorf("parsed images request is required")
@@ -227,6 +275,15 @@ func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel st
 		return nil, fmt.Errorf("image input is required")
 	}
 
+	maskImageURL := strings.TrimSpace(parsed.MaskImageURL)
+	if parsed.MaskUpload != nil {
+		maskUpload := normalizeOpenAIImageMaskUpload(*parsed.MaskUpload)
+		dataURL, err := openAIImageUploadToDataURL(maskUpload)
+		if err != nil {
+			return nil, err
+		}
+		maskImageURL = dataURL
+	}
 	req := []byte(`{"instructions":"","stream":true,"reasoning":{"effort":"medium","summary":"auto"},"parallel_tool_calls":true,"include":["reasoning.encrypted_content"],"model":"","store":false,"tool_choice":{"type":"image_generation"}}`)
 	req, _ = sjson.SetBytes(req, "model", openAIImagesResponsesMainModel)
 
@@ -269,14 +326,6 @@ func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel st
 		tool, _ = sjson.SetBytes(tool, "partial_images", *parsed.PartialImages)
 	}
 
-	maskImageURL := strings.TrimSpace(parsed.MaskImageURL)
-	if parsed.MaskUpload != nil {
-		dataURL, err := openAIImageUploadToDataURL(*parsed.MaskUpload)
-		if err != nil {
-			return nil, err
-		}
-		maskImageURL = dataURL
-	}
 	if maskImageURL != "" {
 		tool, _ = sjson.SetBytes(tool, "input_image_mask.image_url", maskImageURL)
 	}
@@ -547,6 +596,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	c *gin.Context,
 	responseFormat string,
 	fallbackModel string,
+	requestedCount int,
 ) (OpenAIUsage, int, error) {
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
@@ -564,6 +614,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	if len(results) == 0 {
 		return OpenAIUsage{}, 0, fmt.Errorf("upstream did not return image output")
 	}
+	results = limitOpenAIResponsesImageResults(results, requestedCount)
 	if strings.TrimSpace(firstMeta.Model) == "" {
 		firstMeta.Model = strings.TrimSpace(fallbackModel)
 	}
@@ -584,6 +635,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 	responseFormat string,
 	streamPrefix string,
 	fallbackModel string,
+	requestedCount int,
 ) (OpenAIUsage, int, *int, error) {
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Header("Content-Type", "text/event-stream")
@@ -702,6 +754,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 				processDataDone = true
 				return
 			}
+			finalResults = limitOpenAIResponsesImageResults(finalResults, requestedCount)
 			eventName := streamPrefix + ".completed"
 			for _, img := range finalResults {
 				key := openAIResponsesImageResultKey("", img)
@@ -742,7 +795,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 		}
 		if len(pendingResults) > 0 {
 			eventName := streamPrefix + ".completed"
-			for _, img := range pendingResults {
+			for _, img := range limitOpenAIResponsesImageResults(pendingResults, requestedCount) {
 				mergeOpenAIResponsesImageMeta(&img, streamMeta)
 				key := openAIResponsesImageResultKey("", img)
 				if _, exists := emitted[key]; exists {
@@ -932,11 +985,14 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 	}
 	logger.LegacyPrintf(
 		"service.openai_gateway",
-		"[OpenAI] Images request routing request_model=%s endpoint=%s account_type=%s uploads=%d",
+		"[OpenAI] Images request routing request_model=%s endpoint=%s account_type=%s uploads=%d mask_upload=%t mask_url=%t requested_n=%d",
 		requestModel,
 		parsed.Endpoint,
 		account.Type,
 		len(parsed.Uploads),
+		parsed.MaskUpload != nil,
+		strings.TrimSpace(parsed.MaskImageURL) != "",
+		parsed.N,
 	)
 	if parsed.N > 1 {
 		logger.LegacyPrintf(
@@ -1024,7 +1080,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 		firstTokenMs *int
 	)
 	if parsed.Stream {
-		usage, imageCount, firstTokenMs, err = s.handleOpenAIImagesOAuthStreamingResponse(resp, c, startTime, parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), requestModel)
+		usage, imageCount, firstTokenMs, err = s.handleOpenAIImagesOAuthStreamingResponse(resp, c, startTime, parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), requestModel, parsed.N)
 		if err != nil {
 			if imageCount > 0 {
 				return &OpenAIForwardResult{
@@ -1043,7 +1099,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 			return nil, err
 		}
 	} else {
-		usage, imageCount, err = s.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, parsed.ResponseFormat, requestModel)
+		usage, imageCount, err = s.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, parsed.ResponseFormat, requestModel, parsed.N)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"image"
+	"image/color"
+	"image/png"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -543,6 +546,52 @@ func TestOpenAIGatewayServiceForwardImages_OAuthUsesResponsesAPI(t *testing.T) {
 	require.Equal(t, "gpt-image-2", gjson.Get(rec.Body.String(), "model").String())
 	require.Equal(t, "aGVsbG8=", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
 	require.Equal(t, "draw a cat", gjson.Get(rec.Body.String(), "data.0.revised_prompt").String())
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthLimitsResponsesImagesToRequestedCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","n":1}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	svc.httpUpstream = &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+				"X-Request-Id": []string{"req_img_limit_1"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000012,\"tool_usage\":{\"image_gen\":{\"images\":1}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"Zmlyc3Q=\",\"output_format\":\"png\"},{\"type\":\"image_generation_call\",\"result\":\"c2Vjb25k\",\"output_format\":\"png\"}]}}\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+
+	account := &Account{
+		ID:       13,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, "Zmlyc3Q=", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
+	require.False(t, gjson.Get(rec.Body.String(), "data.1").Exists())
 }
 
 func TestOpenAIGatewayServiceForwardImages_APIKeyGenerationUsesConfiguredV1BaseURL(t *testing.T) {
@@ -1142,6 +1191,42 @@ func TestBuildOpenAIImagesResponsesRequest_StripsInputFidelity(t *testing.T) {
 	require.Equal(t, "edit", gjson.GetBytes(body, "tools.0.action").String())
 }
 
+func TestNormalizeOpenAIImageMaskUploadClearsTransparentRGB(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 2, 1))
+	img.SetNRGBA(0, 0, color.NRGBA{R: 0, G: 0, B: 0, A: 0})
+	img.SetNRGBA(1, 0, color.NRGBA{R: 12, G: 34, B: 56, A: 255})
+
+	var buf bytes.Buffer
+	require.NoError(t, png.Encode(&buf, img))
+
+	normalized := normalizeOpenAIImageMaskUpload(OpenAIImagesUpload{
+		FileName:    "mask.png",
+		ContentType: "image/png",
+		Data:        buf.Bytes(),
+	})
+
+	decoded, _, err := image.Decode(bytes.NewReader(normalized.Data))
+	require.NoError(t, err)
+
+	transparent := color.NRGBAModel.Convert(decoded.At(0, 0)).(color.NRGBA)
+	opaque := color.NRGBAModel.Convert(decoded.At(1, 0)).(color.NRGBA)
+	require.Equal(t, color.NRGBA{R: 255, G: 255, B: 255, A: 0}, transparent)
+	require.Equal(t, color.NRGBA{R: 255, G: 255, B: 255, A: 255}, opaque)
+	require.Equal(t, "image/png", normalized.ContentType)
+}
+
+func TestLimitOpenAIResponsesImageResultsHonorsRequestedCount(t *testing.T) {
+	results := []openAIResponsesImageResult{
+		{Result: "first"},
+		{Result: "second"},
+	}
+
+	limited := limitOpenAIResponsesImageResults(results, 1)
+	require.Len(t, limited, 1)
+	require.Equal(t, "first", limited[0].Result)
+	require.Len(t, limitOpenAIResponsesImageResults(results, 2), 2)
+}
+
 func TestCollectOpenAIImagesFromResponsesBody_FallsBackToOutputItemDone(t *testing.T) {
 	body := []byte(
 		"data: {\"type\":\"response.created\",\"response\":{\"created_at\":1710000004}}\n\n" +
@@ -1233,6 +1318,60 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingHandlesOutputItemDoneFa
 	require.Equal(t, "gpt-image-2", gjson.Get(completed.Data, "model").String())
 	require.JSONEq(t, `{"images":1}`, gjson.Get(completed.Data, "usage").Raw)
 	require.NotContains(t, rec.Body.String(), "event: error")
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthStreamingLimitsResponsesImagesToRequestedCount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"b64_json","n":1}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	svc.httpUpstream = &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+				"X-Request-Id": []string{"req_img_stream_limit_1"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000013,\"tool_usage\":{\"image_gen\":{\"images\":1}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"Zmlyc3Q=\",\"output_format\":\"png\"},{\"type\":\"image_generation_call\",\"result\":\"c2Vjb25k\",\"output_format\":\"png\"}]}}\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+
+	account := &Account{
+		ID:       14,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Stream)
+	require.Equal(t, 1, result.ImageCount)
+	events := parseOpenAIImageTestSSEEvents(rec.Body.String())
+	completedCount := 0
+	for _, event := range events {
+		if event.Name == "image_generation.completed" {
+			completedCount++
+			require.Equal(t, "Zmlyc3Q=", gjson.Get(event.Data, "b64_json").String())
+		}
+	}
+	require.Equal(t, 1, completedCount)
 }
 
 func TestOpenAIGatewayServiceForwardImages_OAuthStreamingHandlesMultilineSSE(t *testing.T) {


### PR DESCRIPTION
## Summary
- Normalize uploaded image edit masks before forwarding them through the OAuth Responses image bridge.
- Limit returned Responses image results to the caller-requested n for both streaming and non-streaming image routes.
- Add tests for mask normalization and requested image count limiting.

## Details
This keeps mask semantics based on alpha while clearing RGB values in transparent pixels, which avoids downstream/upstream layers accidentally interpreting transparent mask pixels as visible black content. It also ensures that if an upstream Responses image event returns more image outputs than requested, the gateway only returns the requested count and bills/logs the matching image count.

## Tests
- go test ./internal/service -run 'OpenAIImages|Images|NormalizeOpenAIImageMaskUpload'