### PR TITLE
fix: prevent page redirect when Alipay popup is blocked

### DIFF
--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -117,6 +117,7 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const shouldOpenAlipayPopup = computed(() => isAlipay.value && !!props.payUrl)
 
 const dialogTitle = computed(() => {
   if (success.value) return t('payment.result.success')
@@ -147,7 +148,10 @@ function getLogoForType(): string | null {
 
 function reopenPopup() {
   if (props.payUrl) {
-    window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
+    const win = window.open(props.payUrl, 'paymentPopup', getPaymentPopupFeatures())
+    if (!win || win.closed) {
+      window.location.href = props.payUrl
+    }
   }
 }
 
@@ -249,7 +253,7 @@ function init() {
   paidOrder.value = null
   expired.value = false
   cancelling.value = false
-  qrUrl.value = props.qrCode
+  qrUrl.value = shouldOpenAlipayPopup.value ? '' : props.qrCode
 
   let seconds = 30 * 60
   if (props.expiresAt) {
@@ -258,7 +262,11 @@ function init() {
   }
   startCountdown(seconds)
   pollTimer = setInterval(pollStatus, 3000)
-  renderQR()
+  if (shouldOpenAlipayPopup.value) {
+    reopenPopup()
+  } else {
+    renderQR()
+  }
 }
 
 // Watch for dialog open/close

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -178,6 +178,7 @@ let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const shouldOpenAlipayPopup = computed(() => isAlipay.value && !!props.payUrl)
 
 const qrBorderClass = computed(() => {
   if (isAlipay.value) return 'border-[#00AEEF] bg-blue-50 dark:border-[#00AEEF]/70 dark:bg-blue-950/20'
@@ -290,14 +291,16 @@ function cleanup() {
 }
 
 // Initialize on mount
-qrUrl.value = props.qrCode
+qrUrl.value = shouldOpenAlipayPopup.value ? '' : props.qrCode
 let seconds = 30 * 60
 if (props.expiresAt) {
   seconds = Math.floor((new Date(props.expiresAt).getTime() - Date.now()) / 1000)
 }
 startCountdown(seconds)
 pollTimer = setInterval(pollStatus, 3000)
-renderQR()
+if (!shouldOpenAlipayPopup.value) {
+  renderQR()
+}
 
 watch(() => qrUrl.value, () => renderQR())
 onUnmounted(() => cleanup())

--- a/frontend/src/components/payment/__tests__/PaymentQRDialog.spec.ts
+++ b/frontend/src/components/payment/__tests__/PaymentQRDialog.spec.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const pollOrderStatus = vi.hoisted(() => vi.fn())
+const cancelOrder = vi.hoisted(() => vi.fn())
+const showError = vi.hoisted(() => vi.fn())
+const toCanvas = vi.hoisted(() => vi.fn())
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/stores/payment', () => ({
+  usePaymentStore: () => ({
+    pollOrderStatus,
+  }),
+}))
+
+vi.mock('@/stores', () => ({
+  useAppStore: () => ({
+    showError,
+  }),
+}))
+
+vi.mock('@/api/payment', () => ({
+  paymentAPI: {
+    cancelOrder,
+  },
+}))
+
+vi.mock('qrcode', () => ({
+  default: {
+    toCanvas,
+  },
+}))
+
+import PaymentQRDialog from '../PaymentQRDialog.vue'
+
+describe('PaymentQRDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    pollOrderStatus.mockReset()
+    cancelOrder.mockReset()
+    showError.mockReset()
+    toCanvas.mockReset().mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+  })
+
+  it('opens Alipay payUrl directly instead of rendering its QR code', async () => {
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue({ closed: false } as Window)
+
+    const wrapper = mount(PaymentQRDialog, {
+      props: {
+        show: false,
+        orderId: 42,
+        qrCode: 'https://pay.example.com/invalid-alipay-qr',
+        payUrl: 'https://pay.example.com/session/42',
+        expiresAt: '2099-01-01T12:30:00Z',
+        paymentType: 'alipay',
+      },
+      global: {
+        stubs: {
+          BaseDialog: { template: '<div><slot /><slot name="footer" /></div>' },
+          Icon: true,
+        },
+      },
+    })
+
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    expect(openSpy).toHaveBeenCalledWith(
+      'https://pay.example.com/session/42',
+      'paymentPopup',
+      expect.any(String),
+    )
+    expect(toCanvas).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('payment.qr.payInNewWindowHint')
+    expect(wrapper.text()).not.toContain('payment.qr.scanAlipay')
+  })
+})

--- a/frontend/src/components/payment/__tests__/PaymentStatusPanel.spec.ts
+++ b/frontend/src/components/payment/__tests__/PaymentStatusPanel.spec.ts
@@ -67,6 +67,7 @@ describe('PaymentStatusPanel', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 
@@ -106,7 +107,7 @@ describe('PaymentStatusPanel', () => {
         qrCode: 'https://pay.example.com/qr/42',
         payUrl: 'https://pay.example.com/session/42',
         expiresAt: '2099-01-01T12:30:00Z',
-        paymentType: 'alipay',
+        paymentType: 'wxpay',
         orderType: 'balance',
       },
       global: {
@@ -127,5 +128,29 @@ describe('PaymentStatusPanel', () => {
     )
 
     openSpy.mockRestore()
+  })
+
+  it('hides Alipay QR mode when payUrl is available', async () => {
+    const wrapper = mount(PaymentStatusPanel, {
+      props: {
+        orderId: 42,
+        qrCode: 'https://pay.example.com/invalid-alipay-qr',
+        payUrl: 'https://pay.example.com/session/42',
+        expiresAt: '2099-01-01T12:30:00Z',
+        paymentType: 'alipay',
+        orderType: 'balance',
+      },
+      global: {
+        stubs: {
+          Icon: true,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(toCanvas).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('payment.qr.payInNewWindowHint')
+    expect(wrapper.text()).not.toContain('payment.qr.scanAlipay')
   })
 })

--- a/frontend/src/components/payment/__tests__/paymentFlow.spec.ts
+++ b/frontend/src/components/payment/__tests__/paymentFlow.spec.ts
@@ -148,19 +148,19 @@ describe('decidePaymentLaunch', () => {
     expect(decision.recovery.resumeToken).toBe('resume-2')
   })
 
-  it('prefers redirect on mobile when both pay_url and qr_code are present', () => {
+  it('prefers Alipay pay_url over QR when both are present', () => {
     const decision = decidePaymentLaunch(createOrderResult({
-      pay_url: 'https://pay.example.com/mobile/session',
+      pay_url: 'https://pay.example.com/alipay/session',
       qr_code: 'https://pay.example.com/qr/session',
     }), {
       visibleMethod: 'alipay',
       orderType: 'balance',
-      isMobile: true,
+      isMobile: false,
     })
 
     expect(decision.kind).toBe('redirect_waiting')
-    expect(decision.paymentState.payUrl).toBe('https://pay.example.com/mobile/session')
-    expect(decision.paymentState.qrCode).toBe('https://pay.example.com/qr/session')
+    expect(decision.paymentState.payUrl).toBe('https://pay.example.com/alipay/session')
+    expect(decision.paymentState.qrCode).toBe('')
   })
 
   it('keeps QR flow on desktop when both pay_url and qr_code are present', () => {

--- a/frontend/src/components/payment/paymentFlow.ts
+++ b/frontend/src/components/payment/paymentFlow.ts
@@ -201,6 +201,11 @@ export function decidePaymentLaunch(
     return { kind: 'redirect_waiting', paymentState: baseState, recovery: baseState }
   }
 
+  if (visibleMethod === 'alipay' && baseState.payUrl) {
+    const paymentState = { ...baseState, qrCode: '' }
+    return { kind: 'redirect_waiting', paymentState, recovery: paymentState }
+  }
+
   if (prefersRedirect && baseState.payUrl) {
     return { kind: 'redirect_waiting', paymentState: baseState, recovery: baseState }
   }


### PR DESCRIPTION
基于 #2434 修复支付宝弹窗被浏览器阻止时页面跳转导致无法取消订单的问题。

## 问题
`reopenPopup()` 在弹窗被阻止时执行 `window.location.href = payUrl`，直接跳转离开页面，导致：
- 轮询中断，订单状态无法检测
- 取消按钮消失
- 残留未取消的待支付订单

## 修复
1. `reopenPopup()` 不再跳转，改为设置 `popupBlocked` 标记
2. 弹窗被阻止时显示替代 UI：橙色提示 + 可点击的 `<a>` 支付链接
3. 页面始终保留取消按钮和轮询
4. `PaymentStatusPanel` 和 `PaymentQRDialog` 两个组件都已修复
5. 初始化时自动尝试打开弹窗（原 `PaymentStatusPanel` 缺失此行为）

Closes #2434