### PR TITLE
Fix admin assignment blocked by expired subscriptions

### DIFF
--- a/backend/internal/repository/user_subscription_repo_integration_test.go
+++ b/backend/internal/repository/user_subscription_repo_integration_test.go
@@ -145,6 +145,42 @@ func (s *UserSubscriptionRepoSuite) TestUpdate() {
 	s.Require().Equal("updated notes", got.Notes)
 }
 
+func (s *UserSubscriptionRepoSuite) TestUpdate_RenewalFields() {
+	user := s.mustCreateUser("update-renewal@test.com", service.RoleUser)
+	admin := s.mustCreateUser("update-renewal-admin@test.com", service.RoleAdmin)
+	group := s.mustCreateGroup("g-update-renewal")
+	oldStart := time.Now().AddDate(0, 0, -10)
+	created := s.mustCreateSubscription(user.ID, group.ID, func(c *dbent.UserSubscriptionCreate) {
+		c.SetStartsAt(oldStart)
+		c.SetExpiresAt(oldStart.AddDate(0, 0, 3))
+		c.SetStatus(service.SubscriptionStatusExpired)
+		c.SetNotes("old-note")
+	})
+
+	sub, err := s.repo.GetByID(s.ctx, created.ID)
+	s.Require().NoError(err, "GetByID")
+	newStart := time.Now().Truncate(time.Microsecond)
+	newExpiry := newStart.AddDate(0, 0, 30)
+	sub.StartsAt = newStart
+	sub.ExpiresAt = newExpiry
+	sub.Status = service.SubscriptionStatusActive
+	sub.AssignedBy = &admin.ID
+	sub.AssignedAt = newStart
+	sub.Notes = "new-note"
+
+	s.Require().NoError(s.repo.Update(s.ctx, sub), "Update renewal fields")
+
+	got, err := s.repo.GetByID(s.ctx, sub.ID)
+	s.Require().NoError(err, "GetByID after renewal update")
+	s.Require().WithinDuration(newStart, got.StartsAt, time.Microsecond)
+	s.Require().WithinDuration(newExpiry, got.ExpiresAt, time.Microsecond)
+	s.Require().Equal(service.SubscriptionStatusActive, got.Status)
+	s.Require().NotNil(got.AssignedBy)
+	s.Require().Equal(admin.ID, *got.AssignedBy)
+	s.Require().WithinDuration(newStart, got.AssignedAt, time.Microsecond)
+	s.Require().Equal("new-note", got.Notes)
+}
+
 func (s *UserSubscriptionRepoSuite) TestDelete() {
 	user := s.mustCreateUser("delete@test.com", service.RoleUser)
 	group := s.mustCreateGroup("g-delete")

--- a/backend/internal/service/subscription_assign_idempotency_test.go
+++ b/backend/internal/service/subscription_assign_idempotency_test.go
@@ -190,6 +190,19 @@ func (s *subscriptionUserSubRepoStub) Create(_ context.Context, sub *UserSubscri
 	return nil
 }
 
+func (s *subscriptionUserSubRepoStub) Update(_ context.Context, sub *UserSubscription) error {
+	if sub == nil {
+		return ErrSubscriptionNilInput
+	}
+	if s.byID[sub.ID] == nil {
+		return ErrSubscriptionNotFound
+	}
+	cp := *sub
+	s.byID[cp.ID] = &cp
+	s.byUserGroup[s.key(cp.UserID, cp.GroupID)] = &cp
+	return nil
+}
+
 func (s *subscriptionUserSubRepoStub) GetByID(_ context.Context, id int64) (*UserSubscription, error) {
 	sub := s.byID[id]
 	if sub == nil {
@@ -200,7 +213,7 @@ func (s *subscriptionUserSubRepoStub) GetByID(_ context.Context, id int64) (*Use
 }
 
 func TestAssignSubscriptionReuseWhenSemanticsMatch(t *testing.T) {
-	start := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
+	start := futureSubscriptionStart()
 	groupRepo := &subscriptionGroupRepoStub{
 		group: &Group{ID: 1, SubscriptionType: SubscriptionTypeSubscription},
 	}
@@ -226,8 +239,58 @@ func TestAssignSubscriptionReuseWhenSemanticsMatch(t *testing.T) {
 	require.Equal(t, 0, subRepo.createCalls, "reuse should not create new subscription")
 }
 
+func TestAssignSubscriptionRenewsExpiredExistingSubscription(t *testing.T) {
+	start := time.Now().AddDate(0, 0, -10)
+	expiredAt := start.AddDate(0, 0, 3)
+	groupRepo := &subscriptionGroupRepoStub{
+		group: &Group{ID: 1, SubscriptionType: SubscriptionTypeSubscription},
+	}
+	subRepo := newSubscriptionUserSubRepoStub()
+	subRepo.seed(&UserSubscription{
+		ID:        12,
+		UserID:    3001,
+		GroupID:   1,
+		StartsAt:  start,
+		ExpiresAt: expiredAt,
+		Status:    SubscriptionStatusExpired,
+		Notes:     "old-note",
+	})
+
+	svc := NewSubscriptionService(groupRepo, subRepo, nil, nil, nil)
+	before := time.Now()
+	sub, err := svc.AssignSubscription(context.Background(), &AssignSubscriptionInput{
+		UserID:       3001,
+		GroupID:      1,
+		ValidityDays: 30,
+		AssignedBy:   9,
+		Notes:        "new-note",
+	})
+	after := time.Now()
+	require.NoError(t, err)
+	require.Equal(t, int64(12), sub.ID)
+	require.Equal(t, SubscriptionStatusActive, sub.Status)
+	require.WithinDuration(t, before, sub.StartsAt, after.Sub(before)+time.Second)
+	require.WithinDuration(t, sub.StartsAt.AddDate(0, 0, 30), sub.ExpiresAt, time.Second)
+	require.Equal(t, "new-note", sub.Notes)
+	require.NotNil(t, sub.AssignedBy)
+	require.Equal(t, int64(9), *sub.AssignedBy)
+	require.WithinDuration(t, sub.StartsAt, sub.AssignedAt, time.Second)
+	require.Equal(t, 0, subRepo.createCalls, "expired existing subscription should be renewed in place")
+
+	reused, err := svc.AssignSubscription(context.Background(), &AssignSubscriptionInput{
+		UserID:       3001,
+		GroupID:      1,
+		ValidityDays: 30,
+		AssignedBy:   9,
+		Notes:        "new-note",
+	})
+	require.NoError(t, err)
+	require.Equal(t, sub.ID, reused.ID)
+	require.Equal(t, 0, subRepo.createCalls, "repeat assign after renewal should remain idempotent")
+}
+
 func TestAssignSubscriptionConflictWhenSemanticsMismatch(t *testing.T) {
-	start := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
+	start := futureSubscriptionStart()
 	groupRepo := &subscriptionGroupRepoStub{
 		group: &Group{ID: 1, SubscriptionType: SubscriptionTypeSubscription},
 	}
@@ -254,7 +317,7 @@ func TestAssignSubscriptionConflictWhenSemanticsMismatch(t *testing.T) {
 }
 
 func TestBulkAssignSubscriptionCreatedReusedAndConflict(t *testing.T) {
-	start := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
+	start := futureSubscriptionStart()
 	groupRepo := &subscriptionGroupRepoStub{
 		group: &Group{ID: 1, SubscriptionType: SubscriptionTypeSubscription},
 	}
@@ -327,7 +390,7 @@ func TestNormalizeAssignValidityDays(t *testing.T) {
 }
 
 func TestDetectAssignSemanticConflictCases(t *testing.T) {
-	start := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
+	start := futureSubscriptionStart()
 	base := &UserSubscription{
 		UserID:    1,
 		GroupID:   1,
@@ -386,4 +449,8 @@ func strconvFormatInt(v int64) string {
 
 func infraerrorsReason(err error) string {
 	return infraerrors.Reason(err)
+}
+
+func futureSubscriptionStart() time.Time {
+	return time.Now().UTC().AddDate(0, 0, 30).Truncate(time.Second)
 }

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -400,6 +400,10 @@ func (s *SubscriptionService) assignSubscriptionWithReuse(ctx context.Context, i
 		if getErr != nil {
 			return nil, false, getErr
 		}
+		if isAssignableExistingSubscriptionExpired(sub) {
+			renewedSub, renewErr := s.renewExpiredAssignedSubscription(ctx, sub, input)
+			return renewedSub, true, renewErr
+		}
 		if conflictReason, conflict := detectAssignSemanticConflict(sub, input); conflict {
 			return nil, false, ErrSubscriptionAssignConflict.WithMetadata(map[string]string{
 				"conflict_reason": conflictReason,
@@ -425,6 +429,54 @@ func (s *SubscriptionService) assignSubscriptionWithReuse(ctx context.Context, i
 	}
 
 	return sub, false, nil
+}
+
+func isAssignableExistingSubscriptionExpired(sub *UserSubscription) bool {
+	if sub == nil {
+		return false
+	}
+	return sub.Status == SubscriptionStatusExpired || !sub.ExpiresAt.After(time.Now())
+}
+
+func (s *SubscriptionService) renewExpiredAssignedSubscription(ctx context.Context, existing *UserSubscription, input *AssignSubscriptionInput) (*UserSubscription, error) {
+	if existing == nil {
+		return nil, ErrSubscriptionNotFound
+	}
+	validityDays := normalizeAssignValidityDays(input.ValidityDays)
+	now := time.Now()
+	expiresAt := now.AddDate(0, 0, validityDays)
+	if expiresAt.After(MaxExpiresAt) {
+		expiresAt = MaxExpiresAt
+	}
+
+	updated := *existing
+	updated.StartsAt = now
+	updated.ExpiresAt = expiresAt
+	updated.Status = SubscriptionStatusActive
+	updated.AssignedAt = now
+	updated.Notes = input.Notes
+	if input.AssignedBy > 0 {
+		updated.AssignedBy = &input.AssignedBy
+	} else {
+		updated.AssignedBy = nil
+	}
+	updated.UpdatedAt = now
+
+	if err := s.userSubRepo.Update(ctx, &updated); err != nil {
+		return nil, err
+	}
+
+	s.InvalidateSubCache(input.UserID, input.GroupID)
+	if s.billingCacheService != nil {
+		userID, groupID := input.UserID, input.GroupID
+		go func() {
+			cacheCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = s.billingCacheService.InvalidateSubscription(cacheCtx, userID, groupID)
+		}()
+	}
+
+	return s.userSubRepo.GetByID(ctx, updated.ID)
 }
 
 func detectAssignSemanticConflict(existing *UserSubscription, input *AssignSubscriptionInput) (string, bool) {


### PR DESCRIPTION
## Summary
- Fixes admin subscription assignment when an existing non-soft-deleted subscription for the same user/group is already expired.
- Renews expired existing subscriptions in place before semantic conflict detection, resetting starts_at/expires_at/status/assignment metadata from the new admin request.
- Keeps active subscription idempotency/conflict behavior unchanged and adds regression coverage for repeat assignment after renewal.

## Root Cause
The admin assign path checked only whether a non-soft-deleted (user_id, group_id) subscription existed. Expired rows are not soft-deleted by the expiry job, so they still occupy the partial unique index scope. The assign path then compared the old starts_at/expires_at window against the new validity_days and returned SUBSCRIPTION_ASSIGN_CONFLICT with conflict_reason=validity_days_mismatch.

## Fix
When AssignSubscription finds an existing row, it now first treats status=expired or expires_at <= now() as a renewal case. The existing row is updated to active with a fresh starts_at, expires_at, assigned_at, assigned_by, and notes. Only non-expired existing rows continue to use the existing semantic conflict checks.

## Test Plan
- [x] go test ./internal/service -count=1
- [x] go test -tags=integration ./internal/repository -run 'TestUserSubscriptionRepoSuite/TestUpdate_RenewalFields' -count=1
- [x] git diff --check

Fixes #2478