### PR TITLE
fix: preserve Codex Responses headers

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -38,9 +38,10 @@ const (
 	// ChatGPT internal API for OAuth accounts
 	chatgptCodexURL = "https://chatgpt.com/backend-api/codex/responses"
 	// OpenAI Platform API for API Key accounts (fallback)
-	openaiPlatformAPIURL   = "https://api.openai.com/v1/responses"
-	openaiStickySessionTTL = time.Hour // 粘性会话TTL
-	codexCLIUserAgent      = "codex_cli_rs/0.125.0"
+	openaiPlatformAPIURL           = "https://api.openai.com/v1/responses"
+	openaiStickySessionTTL         = time.Hour // 粘性会话TTL
+	codexCLIUserAgent              = "codex_cli_rs/0.125.0"
+	codexRemoteCompactionV2Feature = "remote_compaction_v2"
 	// codex_cli_only 拒绝时单个请求头日志长度上限（字符）
 	codexCLIOnlyHeaderValueMaxBytes = 256
 
@@ -114,6 +115,58 @@ var codexCLIOnlyDebugHeaderWhitelist = []string{
 	"X-Client-Request-ID",
 	"X-Forwarded-For",
 	"X-Real-IP",
+}
+
+func ensureCodexContextCompactionBetaHeader(header http.Header, body []byte) {
+	if !openAIRequestBodyHasContextCompaction(body) {
+		return
+	}
+
+	existing := strings.TrimSpace(header.Get("X-Codex-Beta-Features"))
+	if existing == "" {
+		header.Set("X-Codex-Beta-Features", codexRemoteCompactionV2Feature)
+		return
+	}
+
+	for _, token := range strings.Split(existing, ",") {
+		if strings.TrimSpace(token) == codexRemoteCompactionV2Feature {
+			return
+		}
+	}
+	header.Set("X-Codex-Beta-Features", existing+","+codexRemoteCompactionV2Feature)
+}
+
+func openAIRequestBodyHasContextCompaction(body []byte) bool {
+	if !bytes.Contains(body, []byte("context_compaction")) {
+		return false
+	}
+
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+	return jsonValueHasType(payload, "context_compaction")
+}
+
+func jsonValueHasType(value any, itemType string) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		if actual, ok := typed["type"].(string); ok && actual == itemType {
+			return true
+		}
+		for _, child := range typed {
+			if jsonValueHasType(child, itemType) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range typed {
+			if jsonValueHasType(child, itemType) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // OpenAICodexUsageSnapshot represents Codex API usage limits from response headers
@@ -3163,6 +3216,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	req.Header.Del("x-api-key")
 	req.Header.Del("x-goog-api-key")
 	req.Header.Set("authorization", "Bearer "+token)
+	ensureCodexContextCompactionBetaHeader(req.Header, body)
 
 	// OAuth 透传到 ChatGPT internal API 时补齐必要头。
 	if account.Type == AccountTypeOAuth {
@@ -3879,6 +3933,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 			}
 		}
 	}
+	ensureCodexContextCompactionBetaHeader(req.Header, body)
 	if account.Type == AccountTypeOAuth {
 		compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
 		// 清除客户端透传的 session 头，后续用隔离后的值重新设置，防止跨用户会话碰撞。

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -67,6 +67,7 @@ var openaiAllowedHeaders = map[string]bool{
 	"user-agent":            true,
 	"originator":            true,
 	"session_id":            true,
+	"x-codex-beta-features": true,
 	"x-codex-turn-state":    true,
 	"x-codex-turn-metadata": true,
 }
@@ -82,6 +83,7 @@ var openaiPassthroughAllowedHeaders = map[string]bool{
 	"user-agent":            true,
 	"originator":            true,
 	"session_id":            true,
+	"x-codex-beta-features": true,
 	"x-codex-turn-state":    true,
 	"x-codex-turn-metadata": true,
 }
@@ -96,6 +98,7 @@ var codexCLIOnlyDebugHeaderWhitelist = []string{
 	"Originator",
 	"Session_ID",
 	"Conversation_ID",
+	"X-Codex-Beta-Features",
 	"X-Request-ID",
 	"X-Client-Request-ID",
 	"X-Forwarded-For",

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -66,6 +66,7 @@ var openaiAllowedHeaders = map[string]bool{
 	"content-type":             true,
 	"conversation_id":          true,
 	"user-agent":               true,
+	"version":                  true,
 	"originator":               true,
 	"session_id":               true,
 	"x-codex-beta-features":    true,
@@ -85,6 +86,7 @@ var openaiPassthroughAllowedHeaders = map[string]bool{
 	"conversation_id":          true,
 	"openai-beta":              true,
 	"user-agent":               true,
+	"version":                  true,
 	"originator":               true,
 	"session_id":               true,
 	"x-codex-beta-features":    true,
@@ -3246,6 +3248,9 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 		if req.Header.Get("originator") == "" {
 			req.Header.Set("originator", "codex_cli_rs")
 		}
+		if req.Header.Get("version") == "" {
+			req.Header.Set("version", codexCLIVersion)
+		}
 		// 用隔离后的 session 标识符覆盖客户端透传值，防止跨用户会话碰撞。
 		if clientSessionID == "" {
 			clientSessionID = promptCacheKey
@@ -3951,13 +3956,13 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 		apiKeyID := getAPIKeyIDFromContext(c)
 		if isOpenAIResponsesCompactPath(c) {
 			req.Header.Set("accept", "application/json")
-			if req.Header.Get("version") == "" {
-				req.Header.Set("version", codexCLIVersion)
-			}
 			compactSession := resolveOpenAICompactSessionID(c)
 			req.Header.Set("session_id", isolateOpenAISessionID(apiKeyID, compactSession))
 		} else {
 			req.Header.Set("accept", "text/event-stream")
+		}
+		if req.Header.Get("version") == "" {
+			req.Header.Set("version", codexCLIVersion)
 		}
 		if promptCacheKey != "" {
 			isolated := isolateOpenAISessionID(apiKeyID, promptCacheKey)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -61,31 +61,37 @@ const (
 
 // OpenAI allowed headers whitelist (for non-passthrough).
 var openaiAllowedHeaders = map[string]bool{
-	"accept-language":       true,
-	"content-type":          true,
-	"conversation_id":       true,
-	"user-agent":            true,
-	"originator":            true,
-	"session_id":            true,
-	"x-codex-beta-features": true,
-	"x-codex-turn-state":    true,
-	"x-codex-turn-metadata": true,
+	"accept-language":          true,
+	"content-type":             true,
+	"conversation_id":          true,
+	"user-agent":               true,
+	"originator":               true,
+	"session_id":               true,
+	"x-codex-beta-features":    true,
+	"x-codex-installation-id":  true,
+	"x-codex-parent-thread-id": true,
+	"x-codex-turn-state":       true,
+	"x-codex-turn-metadata":    true,
+	"x-codex-window-id":        true,
 }
 
 // OpenAI passthrough allowed headers whitelist.
 // 透传模式下仅放行这些低风险请求头，避免将非标准/环境噪声头传给上游触发风控。
 var openaiPassthroughAllowedHeaders = map[string]bool{
-	"accept":                true,
-	"accept-language":       true,
-	"content-type":          true,
-	"conversation_id":       true,
-	"openai-beta":           true,
-	"user-agent":            true,
-	"originator":            true,
-	"session_id":            true,
-	"x-codex-beta-features": true,
-	"x-codex-turn-state":    true,
-	"x-codex-turn-metadata": true,
+	"accept":                   true,
+	"accept-language":          true,
+	"content-type":             true,
+	"conversation_id":          true,
+	"openai-beta":              true,
+	"user-agent":               true,
+	"originator":               true,
+	"session_id":               true,
+	"x-codex-beta-features":    true,
+	"x-codex-installation-id":  true,
+	"x-codex-parent-thread-id": true,
+	"x-codex-turn-state":       true,
+	"x-codex-turn-metadata":    true,
+	"x-codex-window-id":        true,
 }
 
 // codex_cli_only 拒绝时记录的请求头白名单（仅用于诊断日志，不参与上游透传）
@@ -99,6 +105,11 @@ var codexCLIOnlyDebugHeaderWhitelist = []string{
 	"Session_ID",
 	"Conversation_ID",
 	"X-Codex-Beta-Features",
+	"X-Codex-Installation-Id",
+	"X-Codex-Parent-Thread-Id",
+	"X-Codex-Turn-State",
+	"X-Codex-Turn-Metadata",
+	"X-Codex-Window-Id",
 	"X-Request-ID",
 	"X-Client-Request-ID",
 	"X-Forwarded-For",
@@ -3802,6 +3813,7 @@ func writeOpenAIPassthroughResponseHeaders(dst http.Header, src http.Header, fil
 		"x-codex-secondary-reset-after-seconds",
 		"x-codex-secondary-window-minutes",
 		"x-codex-primary-over-secondary-limit-percent",
+		"x-codex-turn-state",
 	} {
 		vals := getCaseInsensitiveValues(src, rawKey)
 		if len(vals) == 0 {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1873,6 +1873,7 @@ func TestOpenAIBuildUpstreamRequestPreservesCodexBetaFeatures(t *testing.T) {
 	c.Request.Header.Set("X-Codex-Parent-Thread-Id", "parent-123")
 	c.Request.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"turn-123"}`)
 	c.Request.Header.Set("X-Codex-Window-Id", "window-123")
+	c.Request.Header.Set("Version", "0.999.0")
 
 	svc := &OpenAIGatewayService{}
 	account := &Account{
@@ -1888,6 +1889,7 @@ func TestOpenAIBuildUpstreamRequestPreservesCodexBetaFeatures(t *testing.T) {
 	require.Equal(t, "parent-123", req.Header.Get("X-Codex-Parent-Thread-Id"))
 	require.Equal(t, `{"turn_id":"turn-123"}`, req.Header.Get("X-Codex-Turn-Metadata"))
 	require.Equal(t, "window-123", req.Header.Get("X-Codex-Window-Id"))
+	require.Equal(t, "0.999.0", req.Header.Get("Version"))
 }
 
 func TestOpenAIBuildUpstreamRequestInfersCodexBetaFeaturesForContextCompaction(t *testing.T) {
@@ -1904,6 +1906,7 @@ func TestOpenAIBuildUpstreamRequestInfersCodexBetaFeaturesForContextCompaction(t
 
 	require.NoError(t, err)
 	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+	require.Equal(t, codexCLIVersion, req.Header.Get("Version"))
 }
 
 func TestOpenAIBuildUpstreamRequestAppendsCodexBetaFeaturesForContextCompaction(t *testing.T) {
@@ -1934,6 +1937,7 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t
 	c.Request.Header.Set("X-Codex-Parent-Thread-Id", "parent-123")
 	c.Request.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"turn-123"}`)
 	c.Request.Header.Set("X-Codex-Window-Id", "window-123")
+	c.Request.Header.Set("Version", "0.999.0")
 
 	svc := &OpenAIGatewayService{}
 	account := &Account{
@@ -1949,6 +1953,7 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t
 	require.Equal(t, "parent-123", req.Header.Get("X-Codex-Parent-Thread-Id"))
 	require.Equal(t, `{"turn_id":"turn-123"}`, req.Header.Get("X-Codex-Turn-Metadata"))
 	require.Equal(t, "window-123", req.Header.Get("X-Codex-Window-Id"))
+	require.Equal(t, "0.999.0", req.Header.Get("Version"))
 }
 
 func TestOpenAIBuildUpstreamRequestOpenAIPassthroughInfersCodexBetaFeaturesForContextCompaction(t *testing.T) {
@@ -1965,6 +1970,7 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughInfersCodexBetaFeaturesForCo
 
 	require.NoError(t, err)
 	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+	require.Equal(t, codexCLIVersion, req.Header.Get("Version"))
 }
 
 func TestOpenAIBuildUpstreamRequestOAuthMessagesBridgeUsesSessionOnly(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1822,6 +1822,46 @@ func TestOpenAIBuildUpstreamRequestCompactForcesJSONAcceptForOAuth(t *testing.T)
 	require.NotEmpty(t, req.Header.Get("Session_Id"))
 }
 
+func TestOpenAIBuildUpstreamRequestPreservesCodexBetaFeatures(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"context_compaction"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("X-Codex-Beta-Features", "remote_compaction_v2")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "chatgpt-acc"},
+	}
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", false, "", true)
+
+	require.NoError(t, err)
+	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+}
+
+func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"context_compaction"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("X-Codex-Beta-Features", "remote_compaction_v2")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "chatgpt-acc"},
+	}
+
+	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "token")
+
+	require.NoError(t, err)
+	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+}
+
 func TestOpenAIBuildUpstreamRequestOAuthMessagesBridgeUsesSessionOnly(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1890,6 +1890,39 @@ func TestOpenAIBuildUpstreamRequestPreservesCodexBetaFeatures(t *testing.T) {
 	require.Equal(t, "window-123", req.Header.Get("X-Codex-Window-Id"))
 }
 
+func TestOpenAIBuildUpstreamRequestInfersCodexBetaFeaturesForContextCompaction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"message","content":"hi"},{"type":"context_compaction"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{Type: AccountTypeOAuth}
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", true, "", true)
+
+	require.NoError(t, err)
+	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+}
+
+func TestOpenAIBuildUpstreamRequestAppendsCodexBetaFeaturesForContextCompaction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"context_compaction"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("X-Codex-Beta-Features", "some_other_feature")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{Type: AccountTypeOAuth}
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", true, "", true)
+
+	require.NoError(t, err)
+	require.Equal(t, "some_other_feature,remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+}
+
 func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
@@ -1916,6 +1949,22 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t
 	require.Equal(t, "parent-123", req.Header.Get("X-Codex-Parent-Thread-Id"))
 	require.Equal(t, `{"turn_id":"turn-123"}`, req.Header.Get("X-Codex-Turn-Metadata"))
 	require.Equal(t, "window-123", req.Header.Get("X-Codex-Window-Id"))
+}
+
+func TestOpenAIBuildUpstreamRequestOpenAIPassthroughInfersCodexBetaFeaturesForContextCompaction(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","input":[{"type":"context_compaction"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{Type: AccountTypeOAuth}
+
+	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "token")
+
+	require.NoError(t, err)
+	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
 }
 
 func TestOpenAIBuildUpstreamRequestOAuthMessagesBridgeUsesSessionOnly(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1558,7 +1558,7 @@ func TestOpenAIStreamingHeadersOverride(t *testing.T) {
 			MaxLineSize:               defaultMaxLineSize,
 		},
 	}
-	svc := &OpenAIGatewayService{cfg: cfg}
+	svc := &OpenAIGatewayService{cfg: cfg, responseHeaderFilter: compileResponseHeaderFilter(cfg)}
 
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -1569,9 +1569,10 @@ func TestOpenAIStreamingHeadersOverride(t *testing.T) {
 		StatusCode: http.StatusOK,
 		Body:       pr,
 		Header: http.Header{
-			"Cache-Control": []string{"upstream"},
-			"X-Request-Id":  []string{"req-123"},
-			"Content-Type":  []string{"application/custom"},
+			"Cache-Control":      []string{"upstream"},
+			"X-Request-Id":       []string{"req-123"},
+			"X-Codex-Turn-State": []string{"turn-state-123"},
+			"Content-Type":       []string{"application/custom"},
 		},
 	}
 
@@ -1595,6 +1596,45 @@ func TestOpenAIStreamingHeadersOverride(t *testing.T) {
 	if rec.Header().Get("X-Request-Id") != "req-123" {
 		t.Fatalf("expected X-Request-Id passthrough, got %q", rec.Header().Get("X-Request-Id"))
 	}
+	if rec.Header().Get("X-Codex-Turn-State") != "turn-state-123" {
+		t.Fatalf("expected X-Codex-Turn-State passthrough, got %q", rec.Header().Get("X-Codex-Turn-State"))
+	}
+}
+
+func TestOpenAIStreamingPreservesContextCompactionItem(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       pr,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+
+	go func() {
+		defer func() { _ = pw.Close() }()
+		_, _ = pw.Write([]byte("data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"context_compaction\",\"encrypted_content\":\"enc-123\"}}\n\n"))
+		_, _ = pw.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"input_tokens\":3,\"output_tokens\":1}}}\n\n"))
+	}()
+
+	result, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1}, time.Now(), "model", "model")
+	_ = pr.Close()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), `"type":"context_compaction"`)
+	require.Contains(t, rec.Body.String(), `"encrypted_content":"enc-123"`)
 }
 
 func TestOpenAIStreamingReuseScannerBufferAndStillWorks(t *testing.T) {
@@ -1829,6 +1869,10 @@ func TestOpenAIBuildUpstreamRequestPreservesCodexBetaFeatures(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.5","input":[{"type":"context_compaction"}]}`)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
 	c.Request.Header.Set("X-Codex-Beta-Features", "remote_compaction_v2")
+	c.Request.Header.Set("X-Codex-Installation-Id", "install-123")
+	c.Request.Header.Set("X-Codex-Parent-Thread-Id", "parent-123")
+	c.Request.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"turn-123"}`)
+	c.Request.Header.Set("X-Codex-Window-Id", "window-123")
 
 	svc := &OpenAIGatewayService{}
 	account := &Account{
@@ -1840,6 +1884,10 @@ func TestOpenAIBuildUpstreamRequestPreservesCodexBetaFeatures(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+	require.Equal(t, "install-123", req.Header.Get("X-Codex-Installation-Id"))
+	require.Equal(t, "parent-123", req.Header.Get("X-Codex-Parent-Thread-Id"))
+	require.Equal(t, `{"turn_id":"turn-123"}`, req.Header.Get("X-Codex-Turn-Metadata"))
+	require.Equal(t, "window-123", req.Header.Get("X-Codex-Window-Id"))
 }
 
 func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t *testing.T) {
@@ -1849,6 +1897,10 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t
 	body := []byte(`{"model":"gpt-5.5","input":[{"type":"context_compaction"}]}`)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
 	c.Request.Header.Set("X-Codex-Beta-Features", "remote_compaction_v2")
+	c.Request.Header.Set("X-Codex-Installation-Id", "install-123")
+	c.Request.Header.Set("X-Codex-Parent-Thread-Id", "parent-123")
+	c.Request.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"turn-123"}`)
+	c.Request.Header.Set("X-Codex-Window-Id", "window-123")
 
 	svc := &OpenAIGatewayService{}
 	account := &Account{
@@ -1860,6 +1912,10 @@ func TestOpenAIBuildUpstreamRequestOpenAIPassthroughPreservesCodexBetaFeatures(t
 
 	require.NoError(t, err)
 	require.Equal(t, "remote_compaction_v2", req.Header.Get("X-Codex-Beta-Features"))
+	require.Equal(t, "install-123", req.Header.Get("X-Codex-Installation-Id"))
+	require.Equal(t, "parent-123", req.Header.Get("X-Codex-Parent-Thread-Id"))
+	require.Equal(t, `{"turn_id":"turn-123"}`, req.Header.Get("X-Codex-Turn-Metadata"))
+	require.Equal(t, "window-123", req.Header.Get("X-Codex-Window-Id"))
 }
 
 func TestOpenAIBuildUpstreamRequestOAuthMessagesBridgeUsesSessionOnly(t *testing.T) {

--- a/backend/internal/util/responseheaders/responseheaders.go
+++ b/backend/internal/util/responseheaders/responseheaders.go
@@ -32,6 +32,7 @@ var defaultAllowed = map[string]struct{}{
 	"retry-after":                    {},
 	"location":                       {},
 	"www-authenticate":               {},
+	"x-codex-turn-state":             {},
 }
 
 // hopByHopHeaders 是跳过的 hop-by-hop 头部，这些头部由 HTTP 库自动处理

--- a/backend/internal/util/responseheaders/responseheaders_test.go
+++ b/backend/internal/util/responseheaders/responseheaders_test.go
@@ -11,6 +11,7 @@ func TestFilterHeadersDisabledUsesDefaultAllowlist(t *testing.T) {
 	src := http.Header{}
 	src.Add("Content-Type", "application/json")
 	src.Add("X-Request-Id", "req-123")
+	src.Add("X-Codex-Turn-State", "turn-state-123")
 	src.Add("X-Test", "ok")
 	src.Add("Connection", "keep-alive")
 	src.Add("Content-Length", "123")
@@ -26,6 +27,9 @@ func TestFilterHeadersDisabledUsesDefaultAllowlist(t *testing.T) {
 	}
 	if filtered.Get("X-Request-Id") != "req-123" {
 		t.Fatalf("expected X-Request-Id allowed, got %q", filtered.Get("X-Request-Id"))
+	}
+	if filtered.Get("X-Codex-Turn-State") != "turn-state-123" {
+		t.Fatalf("expected X-Codex-Turn-State allowed, got %q", filtered.Get("X-Codex-Turn-State"))
 	}
 	if filtered.Get("X-Test") != "" {
 		t.Fatalf("expected X-Test removed, got %q", filtered.Get("X-Test"))


### PR DESCRIPTION
## What

- Preserve Codex-specific Responses headers, including `X-Codex-Beta-Features`, `Version`, turn metadata/state, window id, parent thread id, and installation id.
- Infer `x-codex-beta-features: remote_compaction_v2` when a Codex `context_compaction` item is present but an intermediate client/proxy omitted the header.
- Pass `X-Codex-Turn-State` response headers back to Codex clients so later requests in the same turn can replay the sticky-routing token.
- Add streaming coverage to ensure `context_compaction` SSE output items pass through unchanged.
- Add coverage for both normal OpenAI forwarding and OpenAI passthrough forwarding.

## Why

Recent Codex remote compaction v2 requests send `context_compaction` items through `/v1/responses` and advertise the protocol with `x-codex-beta-features: remote_compaction_v2`. Official Codex also sends a `version` header on Responses requests. If sub2api filters these headers, ChatGPT Codex backend can validate the request as a normal/older Responses payload and reject `context_compaction` as an invalid item type.

The v2 flow is streaming. Codex also captures `x-codex-turn-state` from the stream response headers and replays it on subsequent requests in the same turn. Preserving that response header keeps the v2 streaming contract intact.

## Related issues

- Directly related: #2490
- Similar remote compact / compact compatibility reports that may share the same header/schema mismatch symptom: #1609, #2016, #2152, #1887, #1865, #1900, #1927, #1933

Some of the older reports also mention model mapping, fixed Codex version headers, or timeout/context-canceled behavior, so this PR intentionally references them as related rather than claiming to close all of them.

## Test

- `go test ./internal/service`
- `go test ./internal/util/responseheaders`

## Risk

Low. This extends existing Codex-specific allowlists and preserves the upstream SSE body shape; it does not rewrite request or response bodies.
