### PR TITLE
fix(openai): implement rollback mechanism for missing instructions in passthrough mode

### DIFF
--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -79,14 +79,14 @@ type ContentBlock struct {
 	ToolUseID string          `json:"tool_use_id,omitempty"`
 	Content   json.RawMessage `json:"content,omitempty"`
 	IsError   bool            `json:"is_error,omitempty"`
-	// image
+	// image/document/file
 	Source *ImageSource `json:"source,omitempty"`
 }
 
-// ImageSource Claude 图片来源
+// ImageSource Claude 图片/文件来源
 type ImageSource struct {
 	Type      string `json:"type"`       // "base64"
-	MediaType string `json:"media_type"` // "image/png", "image/jpeg" 等
+	MediaType string `json:"media_type"` // "image/png", "image/jpeg", "application/pdf" 等
 	Data      string `json:"data"`
 }
 

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -464,7 +464,7 @@ func buildParts(content json.RawMessage, toolIDToName map[string]string, allowDu
 			}
 			parts = append(parts, part)
 
-		case "image":
+		case "image", "document", "file":
 			if block.Source != nil && block.Source.Type == "base64" {
 				parts = append(parts, GeminiPart{
 					InlineData: &GeminiInlineData{

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -150,6 +150,21 @@ func TestBuildParts_ToolUseSignatureHandling(t *testing.T) {
 	})
 }
 
+func TestBuildParts_DocumentBase64PreservedAsInlineData(t *testing.T) {
+	content := `[
+		{"type":"text","text":"这可以看得出是谁购买的吗?"},
+		{"type":"document","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0xLjQ="},"title":"receipt.pdf"}
+	]`
+
+	parts, _, err := buildParts(json.RawMessage(content), map[string]string{}, true)
+	require.NoError(t, err)
+	require.Len(t, parts, 2)
+	require.Equal(t, "这可以看得出是谁购买的吗?", parts[0].Text)
+	require.NotNil(t, parts[1].InlineData)
+	require.Equal(t, "application/pdf", parts[1].InlineData.MimeType)
+	require.Equal(t, "JVBERi0xLjQ=", parts[1].InlineData.Data)
+}
+
 // TestBuildTools_CustomTypeTools 测试custom类型工具转换
 func TestBuildTools_CustomTypeTools(t *testing.T) {
 	tests := []struct {

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1314,6 +1314,63 @@ func TestAnthropicToResponses_ImageOnlyUserMessage(t *testing.T) {
 	assert.Equal(t, "data:image/jpeg;base64,/9j/4AAQ", parts[0].ImageURL)
 }
 
+func TestAnthropicToResponses_UserDocumentBlock(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`[
+				{"type":"text","text":"Summarize this file"},
+				{"type":"document","title":"example-report.pdf","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0x"}}
+			]`)},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 1)
+
+	var parts []ResponsesContentPart
+	require.NoError(t, json.Unmarshal(items[0].Content, &parts))
+	require.Len(t, parts, 2)
+	assert.Equal(t, "input_text", parts[0].Type)
+	assert.Equal(t, "Summarize this file", parts[0].Text)
+	assert.Equal(t, "input_file", parts[1].Type)
+	assert.Equal(t, "example-report.pdf", parts[1].Filename)
+	assert.Equal(t, "data:application/pdf;base64,JVBERi0x", parts[1].FileData)
+	assert.Empty(t, parts[1].FileURL)
+}
+
+func TestAnthropicToResponses_UserDocumentURLBlock(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`[
+				{"type":"document","title":"report.pdf","source":{"type":"url","url":"https://example.com/report.pdf"}}
+			]`)},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 1)
+
+	var parts []ResponsesContentPart
+	require.NoError(t, json.Unmarshal(items[0].Content, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "input_file", parts[0].Type)
+	assert.Equal(t, "report.pdf", parts[0].Filename)
+	assert.Equal(t, "https://example.com/report.pdf", parts[0].FileURL)
+	assert.Empty(t, parts[0].FileData)
+}
+
 func TestAnthropicToResponses_ToolResultWithImage(t *testing.T) {
 	req := &AnthropicRequest{
 		Model:     "gpt-5.2",

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1371,6 +1371,79 @@ func TestAnthropicToResponses_UserDocumentURLBlock(t *testing.T) {
 	assert.Empty(t, parts[0].FileData)
 }
 
+func TestAnthropicToResponses_UserFileBlock(t *testing.T) {
+	req := &AnthropicRequest{
+		Model:     "gpt-5.2",
+		MaxTokens: 1024,
+		Messages: []AnthropicMessage{
+			{Role: "user", Content: json.RawMessage(`[
+				{"type":"file","title":"example-report.pdf","source":{"type":"base64","media_type":"application/pdf","data":"JVBERi0x"}}
+			]`)},
+		},
+	}
+
+	resp, err := AnthropicToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 1)
+
+	var parts []ResponsesContentPart
+	require.NoError(t, json.Unmarshal(items[0].Content, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "input_file", parts[0].Type)
+	assert.Equal(t, "example-report.pdf", parts[0].Filename)
+	assert.Equal(t, "data:application/pdf;base64,JVBERi0x", parts[0].FileData)
+}
+
+func TestResponsesToAnthropicRequest_InputFileDataBecomesDocument(t *testing.T) {
+	input := json.RawMessage(`[
+		{"role":"user","content":[
+			{"type":"input_text","text":"Analyze this"},
+			{"type":"input_file","filename":"receipt.pdf","file_data":"data:application/pdf;base64,JVBERi0x"}
+		]}
+	]`)
+	req := &ResponsesRequest{Model: "claude-sonnet-4-6", Input: input}
+
+	out, err := ResponsesToAnthropicRequest(req)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+
+	var blocks []AnthropicContentBlock
+	require.NoError(t, json.Unmarshal(out.Messages[0].Content, &blocks))
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "text", blocks[0].Type)
+	assert.Equal(t, "document", blocks[1].Type)
+	assert.Equal(t, "receipt.pdf", blocks[1].Title)
+	require.NotNil(t, blocks[1].Source)
+	assert.Equal(t, "base64", blocks[1].Source.Type)
+	assert.Equal(t, "application/pdf", blocks[1].Source.MediaType)
+	assert.Equal(t, "JVBERi0x", blocks[1].Source.Data)
+}
+
+func TestResponsesToAnthropicRequest_InputFileURLBecomesDocument(t *testing.T) {
+	input := json.RawMessage(`[
+		{"role":"user","content":[
+			{"type":"input_file","filename":"receipt.pdf","file_url":"https://example.com/receipt.pdf"}
+		]}
+	]`)
+	req := &ResponsesRequest{Model: "claude-sonnet-4-6", Input: input}
+
+	out, err := ResponsesToAnthropicRequest(req)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 1)
+
+	var blocks []AnthropicContentBlock
+	require.NoError(t, json.Unmarshal(out.Messages[0].Content, &blocks))
+	require.Len(t, blocks, 1)
+	assert.Equal(t, "document", blocks[0].Type)
+	assert.Equal(t, "receipt.pdf", blocks[0].Title)
+	require.NotNil(t, blocks[0].Source)
+	assert.Equal(t, "url", blocks[0].Source.Type)
+	assert.Equal(t, "https://example.com/receipt.pdf", blocks[0].Source.URL)
+}
+
 func TestAnthropicToResponses_ToolResultWithImage(t *testing.T) {
 	req := &AnthropicRequest{
 		Model:     "gpt-5.2",

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -226,7 +226,7 @@ func anthropicUserToResponses(raw json.RawMessage) ([]ResponsesInputItem, error)
 		toolResultImageParts = append(toolResultImageParts, imageParts...)
 	}
 
-	// Remaining text + image blocks → user message with content parts.
+	// Remaining text + image/file blocks → user message with content parts.
 	// Also include images extracted from tool_results so the model can see them.
 	var parts []ResponsesContentPart
 	for _, b := range blocks {
@@ -238,6 +238,10 @@ func anthropicUserToResponses(raw json.RawMessage) ([]ResponsesInputItem, error)
 		case "image":
 			if uri := anthropicImageToDataURI(b.Source); uri != "" {
 				parts = append(parts, ResponsesContentPart{Type: "input_image", ImageURL: uri})
+			}
+		case "document", "file":
+			if part := anthropicFileToResponsesPart(b); part != nil {
+				parts = append(parts, *part)
 			}
 		}
 	}
@@ -339,6 +343,30 @@ func anthropicImageToDataURI(src *AnthropicImageSource) string {
 		mediaType = "image/png"
 	}
 	return "data:" + mediaType + ";base64," + src.Data
+}
+
+func anthropicFileToResponsesPart(block AnthropicContentBlock) *ResponsesContentPart {
+	if block.Source == nil {
+		return nil
+	}
+	part := ResponsesContentPart{Type: "input_file", Filename: block.Title}
+	switch block.Source.Type {
+	case "url":
+		part.FileURL = block.Source.URL
+	default:
+		if block.Source.Data == "" {
+			return nil
+		}
+		mediaType := block.Source.MediaType
+		if mediaType == "" {
+			mediaType = "application/octet-stream"
+		}
+		part.FileData = "data:" + mediaType + ";base64," + block.Source.Data
+	}
+	if part.FileData == "" && part.FileURL == "" {
+		return nil
+	}
+	return &part
 }
 
 // convertToolResultOutput extracts text and image content from a tool_result

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -121,7 +121,7 @@ func responsesInputToChatMessages(instructions string, inputRaw json.RawMessage)
 			content, _ := json.Marshal(rawString(item["text"]))
 			messages = append(messages, ChatMessage{Role: "user", Content: content})
 			continue
-		case "input_image":
+		case "input_image", "input_file":
 			content, err := chatContentFromSingleResponsesPart(itemType, item)
 			if err != nil {
 				return nil, err
@@ -217,6 +217,31 @@ func responsesContentPartsToChatContent(rawParts []json.RawMessage, role string)
 				Type:     "image_url",
 				ImageURL: &ChatImageURL{URL: imageURL},
 			})
+		case "input_file", "file":
+			fileData := rawString(part["file_data"])
+			fileURL := rawString(part["file_url"])
+			filename := rawString(part["filename"])
+			if fileData == "" {
+				fileData = rawNestedString(part["file"], "file_data")
+			}
+			if fileURL == "" {
+				fileURL = rawNestedString(part["file"], "file_url")
+			}
+			if filename == "" {
+				filename = rawNestedString(part["file"], "filename")
+			}
+			if fileData == "" && fileURL == "" {
+				continue
+			}
+			hasNonText = true
+			chatParts = append(chatParts, ChatContentPart{
+				Type: "file",
+				File: &ChatFile{
+					Filename: filename,
+					FileData: fileData,
+					FileURL:  fileURL,
+				},
+			})
 		}
 	}
 
@@ -245,6 +270,27 @@ func chatContentFromSingleResponsesPart(partType string, part map[string]json.Ra
 		return json.Marshal([]ChatContentPart{{
 			Type:     "image_url",
 			ImageURL: &ChatImageURL{URL: imageURL},
+		}})
+	case "input_file", "file":
+		fileData := rawString(part["file_data"])
+		fileURL := rawString(part["file_url"])
+		filename := rawString(part["filename"])
+		if fileData == "" {
+			fileData = rawNestedString(part["file"], "file_data")
+		}
+		if fileURL == "" {
+			fileURL = rawNestedString(part["file"], "file_url")
+		}
+		if filename == "" {
+			filename = rawNestedString(part["file"], "filename")
+		}
+		return json.Marshal([]ChatContentPart{{
+			Type: "file",
+			File: &ChatFile{
+				Filename: filename,
+				FileData: fileData,
+				FileURL:  fileURL,
+			},
 		}})
 	default:
 		return json.Marshal(rawString(part["text"]))

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -260,6 +260,56 @@ func TestChatCompletionsToResponses_EmptyContentNeverNull(t *testing.T) {
 	}
 }
 
+func TestChatCompletionsToResponses_FileData(t *testing.T) {
+	content := `[{"type":"text","text":"Analyze this file"},{"type":"file","file":{"filename":"example-report.pdf","file_data":"data:application/pdf;base64,abc123"}}]`
+	req := &ChatCompletionsRequest{
+		Model: "gpt-4o",
+		Messages: []ChatMessage{
+			{Role: "user", Content: json.RawMessage(content)},
+		},
+	}
+	resp, err := ChatCompletionsToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 1)
+
+	var parts []ResponsesContentPart
+	require.NoError(t, json.Unmarshal(items[0].Content, &parts))
+	require.Len(t, parts, 2)
+	assert.Equal(t, "input_text", parts[0].Type)
+	assert.Equal(t, "Analyze this file", parts[0].Text)
+	assert.Equal(t, "input_file", parts[1].Type)
+	assert.Equal(t, "example-report.pdf", parts[1].Filename)
+	assert.Equal(t, "data:application/pdf;base64,abc123", parts[1].FileData)
+	assert.Empty(t, parts[1].FileURL)
+}
+
+func TestChatCompletionsToResponses_FileURL(t *testing.T) {
+	content := `[{"type":"file","file":{"filename":"report.pdf","file_url":"https://example.com/report.pdf"}}]`
+	req := &ChatCompletionsRequest{
+		Model: "gpt-4o",
+		Messages: []ChatMessage{
+			{Role: "user", Content: json.RawMessage(content)},
+		},
+	}
+	resp, err := ChatCompletionsToResponses(req)
+	require.NoError(t, err)
+
+	var items []ResponsesInputItem
+	require.NoError(t, json.Unmarshal(resp.Input, &items))
+	require.Len(t, items, 1)
+
+	var parts []ResponsesContentPart
+	require.NoError(t, json.Unmarshal(items[0].Content, &parts))
+	require.Len(t, parts, 1)
+	assert.Equal(t, "input_file", parts[0].Type)
+	assert.Equal(t, "report.pdf", parts[0].Filename)
+	assert.Equal(t, "https://example.com/report.pdf", parts[0].FileURL)
+	assert.Empty(t, parts[0].FileData)
+}
+
 func TestChatCompletionsToResponses_SystemArrayContent(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model: "gpt-4o",

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -667,6 +667,49 @@ func TestChatCompletionsToResponses_ToolArrayContent(t *testing.T) {
 	assert.Equal(t, "image width: 100; image height: 200", items[2].Output)
 }
 
+func TestResponsesToChatCompletionsRequest_InputFile(t *testing.T) {
+	input := json.RawMessage(`[
+		{"role":"user","content":[
+			{"type":"input_text","text":"Analyze this"},
+			{"type":"input_file","filename":"receipt.pdf","file_data":"data:application/pdf;base64,JVBERi0x"}
+		]}
+	]`)
+	req := &ResponsesRequest{Model: "gpt-4o", Input: input}
+
+	chatReq, err := ResponsesToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.Len(t, chatReq.Messages, 1)
+
+	var parts []ChatContentPart
+	require.NoError(t, json.Unmarshal(chatReq.Messages[0].Content, &parts))
+	require.Len(t, parts, 2)
+	assert.Equal(t, "text", parts[0].Type)
+	assert.Equal(t, "Analyze this", parts[0].Text)
+	require.NotNil(t, parts[1].File)
+	assert.Equal(t, "file", parts[1].Type)
+	assert.Equal(t, "receipt.pdf", parts[1].File.Filename)
+	assert.Equal(t, "data:application/pdf;base64,JVBERi0x", parts[1].File.FileData)
+}
+
+func TestResponsesToChatCompletionsRequest_TopLevelInputFile(t *testing.T) {
+	input := json.RawMessage(`[
+		{"type":"input_file","filename":"receipt.pdf","file_url":"https://example.com/receipt.pdf"}
+	]`)
+	req := &ResponsesRequest{Model: "gpt-4o", Input: input}
+
+	chatReq, err := ResponsesToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.Len(t, chatReq.Messages, 1)
+
+	var parts []ChatContentPart
+	require.NoError(t, json.Unmarshal(chatReq.Messages[0].Content, &parts))
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].File)
+	assert.Equal(t, "file", parts[0].Type)
+	assert.Equal(t, "receipt.pdf", parts[0].File.Filename)
+	assert.Equal(t, "https://example.com/receipt.pdf", parts[0].File.FileURL)
+}
+
 func TestResponsesToChatCompletions_Incomplete(t *testing.T) {
 	resp := &ResponsesResponse{
 		ID:                "resp_inc",

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -370,6 +370,29 @@ func convertChatContentPartsToResponses(parts []ChatContentPart) []ResponsesCont
 					ImageURL: p.ImageURL.URL,
 				})
 			}
+		case "file":
+			fileData := p.FileData
+			fileURL := p.FileURL
+			filename := p.Filename
+			if p.File != nil {
+				if fileData == "" {
+					fileData = p.File.FileData
+				}
+				if fileURL == "" {
+					fileURL = p.File.FileURL
+				}
+				if filename == "" {
+					filename = p.File.Filename
+				}
+			}
+			if fileData != "" || fileURL != "" {
+				responseParts = append(responseParts, ResponsesContentPart{
+					Type:     "input_file",
+					FileData: fileData,
+					FileURL:  fileURL,
+					Filename: filename,
+				})
+			}
 		}
 	}
 	return responseParts

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -259,6 +259,10 @@ func convertResponsesUserToAnthropicContent(raw json.RawMessage) (json.RawMessag
 					Source: src,
 				})
 			}
+		case "input_file":
+			if block := responsesFileToAnthropicBlock(p); block != nil {
+				blocks = append(blocks, *block)
+			}
 		}
 	}
 
@@ -324,6 +328,10 @@ func fromResponsesCallIDToAnthropic(id string) string {
 
 // dataURIToAnthropicImageSource parses a data URI into an AnthropicImageSource.
 func dataURIToAnthropicImageSource(dataURI string) *AnthropicImageSource {
+	return dataURIToAnthropicSource(dataURI)
+}
+
+func dataURIToAnthropicSource(dataURI string) *AnthropicImageSource {
 	if !strings.HasPrefix(dataURI, "data:") {
 		return nil
 	}
@@ -344,6 +352,23 @@ func dataURIToAnthropicImageSource(dataURI string) *AnthropicImageSource {
 		MediaType: mediaType,
 		Data:      data,
 	}
+}
+
+func responsesFileToAnthropicBlock(part ResponsesContentPart) *AnthropicContentBlock {
+	block := AnthropicContentBlock{Type: "document", Title: part.Filename}
+	switch {
+	case part.FileData != "":
+		src := dataURIToAnthropicSource(part.FileData)
+		if src == nil {
+			return nil
+		}
+		block.Source = src
+	case part.FileURL != "":
+		block.Source = &AnthropicImageSource{Type: "url", URL: part.FileURL}
+	default:
+		return nil
+	}
+	return &block
 }
 
 // mergeConsecutiveMessages merges consecutive messages with the same role

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -63,6 +63,7 @@ type AnthropicContentBlock struct {
 
 	// type=image
 	Source *AnthropicImageSource `json:"source,omitempty"`
+	Title  string                `json:"title,omitempty"`
 
 	// type=tool_use
 	ID    string          `json:"id,omitempty"`
@@ -102,6 +103,7 @@ type AnthropicImageSource struct {
 	Type      string `json:"type"` // "base64"
 	MediaType string `json:"media_type"`
 	Data      string `json:"data"`
+	URL       string `json:"url,omitempty"`
 }
 
 // AnthropicTool describes a tool available to the model.

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -241,9 +241,12 @@ type ResponsesInputItem struct {
 
 // ResponsesContentPart is a typed content part in a Responses message.
 type ResponsesContentPart struct {
-	Type     string `json:"type"` // "input_text" | "output_text" | "input_image"
+	Type     string `json:"type"` // "input_text" | "output_text" | "input_image" | "input_file"
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // data URI for input_image
+	FileData string `json:"file_data,omitempty"` // data URI for input_file
+	FileURL  string `json:"file_url,omitempty"`  // URL for input_file
+	Filename string `json:"filename,omitempty"`  // original filename for input_file
 }
 
 // ResponsesTool describes a tool in the Responses API.
@@ -460,15 +463,28 @@ type ChatMessage struct {
 
 // ChatContentPart is a typed content part in a multi-modal message.
 type ChatContentPart struct {
-	Type     string        `json:"type"` // "text" | "image_url"
+	Type     string        `json:"type"` // "text" | "image_url" | "file"
 	Text     string        `json:"text,omitempty"`
 	ImageURL *ChatImageURL `json:"image_url,omitempty"`
+	File     *ChatFile     `json:"file,omitempty"`
+
+	// Optional flat file fields for compatibility with different client payloads.
+	FileData string `json:"file_data,omitempty"`
+	FileURL  string `json:"file_url,omitempty"`
+	Filename string `json:"filename,omitempty"`
 }
 
 // ChatImageURL contains the URL for an image content part.
 type ChatImageURL struct {
 	URL    string `json:"url"`
 	Detail string `json:"detail,omitempty"` // "auto" | "low" | "high"
+}
+
+// ChatFile contains file metadata and source for a file content part.
+type ChatFile struct {
+	Filename string `json:"filename,omitempty"`
+	FileData string `json:"file_data,omitempty"`
+	FileURL  string `json:"file_url,omitempty"`
 }
 
 // ChatTool describes a tool available to the model.

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -528,14 +528,14 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-5*time.Hour)); err == nil {
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStart(account.Extra, "5h", now)); err == nil {
 		if usage.FiveHour == nil {
 			usage.FiveHour = &UsageProgress{Utilization: 0}
 		}
 		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-7*24*time.Hour)); err == nil {
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStart(account.Extra, "7d", now)); err == nil {
 		if usage.SevenDay == nil {
 			usage.SevenDay = &UsageProgress{Utilization: 0}
 		}
@@ -1118,6 +1118,43 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	return progress
+}
+
+func codexWindowStart(extra map[string]any, window string, now time.Time) time.Time {
+	var (
+		resetAtKey      string
+		windowMinuteKey string
+		fallback        time.Time
+	)
+
+	switch window {
+	case "5h":
+		resetAtKey = "codex_5h_reset_at"
+		windowMinuteKey = "codex_5h_window_minutes"
+		fallback = now.Add(-5 * time.Hour)
+	case "7d":
+		resetAtKey = "codex_7d_reset_at"
+		windowMinuteKey = "codex_7d_window_minutes"
+		fallback = now.Add(-7 * 24 * time.Hour)
+	default:
+		return now
+	}
+
+	resetAtRaw, hasResetAt := extra[resetAtKey]
+	windowMinutes := parseExtraInt(extra[windowMinuteKey])
+	if !hasResetAt || windowMinutes <= 0 {
+		return fallback
+	}
+
+	resetAt, err := parseTime(fmt.Sprint(resetAtRaw))
+	if err != nil {
+		return fallback
+	}
+	if !now.Before(resetAt) {
+		return fallback
+	}
+
+	return resetAt.Add(-time.Duration(windowMinutes) * time.Minute)
 }
 
 func (s *AccountUsageService) GetAccountUsageStats(ctx context.Context, accountID int64, startTime, endTime time.Time) (*usagestats.AccountUsageStatsResponse, error) {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -97,6 +97,11 @@ type windowStatsCache struct {
 	timestamp time.Time
 }
 
+type windowStatsCacheKey struct {
+	accountID     int64
+	startUnixNano int64
+}
+
 // antigravityUsageCache 缓存 Antigravity 额度数据
 type antigravityUsageCache struct {
 	usageInfo *UsageInfo
@@ -116,7 +121,7 @@ const (
 // UsageCache 封装账户使用量相关的缓存
 type UsageCache struct {
 	apiCache          sync.Map           // accountID -> *apiUsageCache
-	windowStatsCache  sync.Map           // accountID -> *windowStatsCache
+	windowStatsCache  sync.Map           // windowStatsCacheKey -> *windowStatsCache
 	antigravityCache  sync.Map           // accountID -> *antigravityUsageCache
 	apiFlight         singleflight.Group // 防止同一账号的并发请求击穿缓存（Anthropic）
 	antigravityFlight singleflight.Group // 防止同一 Antigravity 账号的并发请求击穿缓存
@@ -928,44 +933,65 @@ func (s *AccountUsageService) addWindowStats(ctx context.Context, account *Accou
 		return
 	}
 
-	// 检查窗口统计缓存（1 分钟）
-	var windowStats *WindowStats
-	if cached, ok := s.cache.windowStatsCache.Load(account.ID); ok {
-		if cache, ok := cached.(*windowStatsCache); ok && time.Since(cache.timestamp) < windowStatsCacheTTL {
-			windowStats = cache.stats
-		}
-	}
-
-	// 如果没有缓存，从数据库查询
-	if windowStats == nil {
-		// 使用统一的窗口开始时间计算逻辑（考虑窗口过期情况）
-		startTime := account.GetCurrentWindowStartTime()
-
-		stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, startTime)
-		if err != nil {
-			log.Printf("Failed to get window stats for account %d: %v", account.ID, err)
-			return
-		}
-
-		windowStats = &WindowStats{
-			Requests:     stats.Requests,
-			Tokens:       stats.Tokens,
-			Cost:         stats.Cost,
-			StandardCost: stats.StandardCost,
-			UserCost:     stats.UserCost,
-		}
-
-		// 缓存窗口统计（1 分钟）
-		s.cache.windowStatsCache.Store(account.ID, &windowStatsCache{
-			stats:     windowStats,
-			timestamp: time.Now(),
-		})
-	}
-
 	// 为 FiveHour 添加 WindowStats（5h 窗口统计）
 	if usage.FiveHour != nil {
-		usage.FiveHour.WindowStats = windowStats
+		if windowStats, err := s.accountWindowStats(ctx, account.ID, account.GetCurrentWindowStartTime()); err == nil {
+			usage.FiveHour.WindowStats = windowStats
+		} else {
+			log.Printf("Failed to get 5h window stats for account %d: %v", account.ID, err)
+		}
 	}
+
+	if usage.SevenDay != nil {
+		if startTime, ok := usageWindowStartFromReset(usage.SevenDay, 7*24*time.Hour); ok {
+			if windowStats, err := s.accountWindowStats(ctx, account.ID, startTime); err == nil {
+				usage.SevenDay.WindowStats = windowStats
+			} else {
+				log.Printf("Failed to get 7d window stats for account %d: %v", account.ID, err)
+			}
+		}
+	}
+
+	if usage.SevenDaySonnet != nil {
+		if startTime, ok := usageWindowStartFromReset(usage.SevenDaySonnet, 7*24*time.Hour); ok {
+			if windowStats, err := s.accountWindowStats(ctx, account.ID, startTime); err == nil {
+				usage.SevenDaySonnet.WindowStats = windowStats
+			} else {
+				log.Printf("Failed to get 7d Sonnet window stats for account %d: %v", account.ID, err)
+			}
+		}
+	}
+}
+
+func (s *AccountUsageService) accountWindowStats(ctx context.Context, accountID int64, startTime time.Time) (*WindowStats, error) {
+	key := windowStatsCacheKey{accountID: accountID, startUnixNano: startTime.UnixNano()}
+	if cached, ok := s.cache.windowStatsCache.Load(key); ok {
+		if cache, ok := cached.(*windowStatsCache); ok && time.Since(cache.timestamp) < windowStatsCacheTTL {
+			return cache.stats, nil
+		}
+	}
+
+	stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, accountID, startTime)
+	if err != nil {
+		return nil, err
+	}
+
+	windowStats := windowStatsFromAccountStats(stats)
+	s.cache.windowStatsCache.Store(key, &windowStatsCache{
+		stats:     windowStats,
+		timestamp: time.Now(),
+	})
+	return windowStats, nil
+}
+
+func usageWindowStartFromReset(progress *UsageProgress, duration time.Duration) (time.Time, bool) {
+	if progress == nil || progress.ResetsAt == nil || duration <= 0 {
+		return time.Time{}, false
+	}
+	if !progress.ResetsAt.After(time.Now()) {
+		return time.Time{}, false
+	}
+	return progress.ResetsAt.Add(-duration), true
 }
 
 // GetTodayStats 获取账号今日统计

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -5,7 +5,23 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 )
+
+type accountUsageWindowStatsRepo struct {
+	UsageLogRepository
+	statsByStart map[int64]*usagestats.AccountStats
+	calls        []time.Time
+}
+
+func (r *accountUsageWindowStatsRepo) GetAccountWindowStats(_ context.Context, _ int64, startTime time.Time) (*usagestats.AccountStats, error) {
+	r.calls = append(r.calls, startTime)
+	if stats, ok := r.statsByStart[startTime.UnixNano()]; ok {
+		return stats, nil
+	}
+	return &usagestats.AccountStats{}, nil
+}
 
 type accountUsageCodexProbeRepo struct {
 	stubOpenAIAccountRepo
@@ -63,6 +79,50 @@ func TestShouldRefreshOpenAICodexSnapshot(t *testing.T) {
 		},
 	}, usage, now) {
 		t.Fatal("expected stale ws snapshot to trigger refresh")
+	}
+}
+
+func TestAccountUsageService_AddWindowStatsAttachesAnthropicSevenDay(t *testing.T) {
+	now := time.Now().UTC()
+	fiveHourStart := now.Add(-2 * time.Hour).Truncate(time.Second)
+	fiveHourEnd := now.Add(3 * time.Hour).Truncate(time.Second)
+	sevenDayReset := now.Add(48 * time.Hour).Truncate(time.Second)
+	sevenDayStart := sevenDayReset.Add(-7 * 24 * time.Hour)
+
+	repo := &accountUsageWindowStatsRepo{statsByStart: map[int64]*usagestats.AccountStats{
+		fiveHourStart.UnixNano(): {
+			Requests:     5,
+			Tokens:       50,
+			StandardCost: 0.5,
+		},
+		sevenDayStart.UnixNano(): {
+			Requests:     70,
+			Tokens:       700,
+			StandardCost: 7,
+		},
+	}}
+	svc := &AccountUsageService{usageLogRepo: repo, cache: NewUsageCache()}
+	usage := &UsageInfo{
+		FiveHour: &UsageProgress{Utilization: 10},
+		SevenDay: &UsageProgress{Utilization: 20, ResetsAt: &sevenDayReset},
+	}
+	account := &Account{ID: 42, SessionWindowStart: &fiveHourStart, SessionWindowEnd: &fiveHourEnd}
+
+	svc.addWindowStats(context.Background(), account, usage)
+
+	if usage.FiveHour.WindowStats == nil || usage.FiveHour.WindowStats.Requests != 5 {
+		t.Fatalf("FiveHour.WindowStats = %#v, want requests=5", usage.FiveHour.WindowStats)
+	}
+	if usage.SevenDay.WindowStats == nil || usage.SevenDay.WindowStats.Requests != 70 {
+		t.Fatalf("SevenDay.WindowStats = %#v, want requests=70", usage.SevenDay.WindowStats)
+	}
+	if len(repo.calls) != 2 {
+		t.Fatalf("GetAccountWindowStats calls = %d, want 2", len(repo.calls))
+	}
+
+	svc.addWindowStats(context.Background(), account, usage)
+	if len(repo.calls) != 2 {
+		t.Fatalf("GetAccountWindowStats calls after cache hit = %d, want 2", len(repo.calls))
 	}
 }
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -207,3 +207,53 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 	})
 }
+
+func TestCodexWindowStart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+
+	t.Run("uses reset minus 5h window length", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_5h_reset_at":       "2026-03-16T15:30:00Z",
+			"codex_5h_window_minutes": 300,
+		}
+		got := codexWindowStart(extra, "5h", now)
+		want := time.Date(2026, 3, 16, 10, 30, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("uses reset minus 7d window length", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_7d_reset_at":       "2026-03-20T00:00:00Z",
+			"codex_7d_window_minutes": 10080,
+		}
+		got := codexWindowStart(extra, "7d", now)
+		want := time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls back to rolling window when metadata is missing", func(t *testing.T) {
+		got := codexWindowStart(map[string]any{}, "5h", now)
+		want := now.Add(-5 * time.Hour)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls back to rolling window when reset is expired", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_5h_reset_at":       "2026-03-16T10:00:00Z",
+			"codex_5h_window_minutes": 300,
+		}
+		got := codexWindowStart(extra, "5h", now)
+		want := now.Add(-5 * time.Hour)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -104,6 +104,17 @@ var codexCLIOnlyDebugHeaderWhitelist = []string{
 	"X-Real-IP",
 }
 
+type openAIPassthroughRollbackError struct {
+	Reason string
+}
+
+func (e *openAIPassthroughRollbackError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("openai passthrough rollback: %s", strings.TrimSpace(e.Reason))
+}
+
 // OpenAICodexUsageSnapshot represents Codex API usage limits from response headers
 type OpenAICodexUsageSnapshot struct {
 	PrimaryUsedPercent          *float64 `json:"primary_used_percent,omitempty"`
@@ -2359,7 +2370,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if passthroughEnabled {
 		// 透传分支只需要轻量提取字段，避免热路径全量 Unmarshal。
 		reasoningEffort := extractOpenAIReasoningEffortFromBody(body, reqModel)
-		return s.forwardOpenAIPassthrough(ctx, c, account, originalBody, reqModel, reasoningEffort, reqStream, startTime)
+		result, err := s.forwardOpenAIPassthrough(ctx, c, account, originalBody, reqModel, reasoningEffort, reqStream, startTime)
+		if err == nil {
+			return result, nil
+		}
+		var rollbackErr *openAIPassthroughRollbackError
+		if !errors.As(err, &rollbackErr) {
+			return nil, err
+		}
 	}
 
 	reqBody, err := getOpenAIRequestBodyMap(c, body)
@@ -3171,16 +3189,8 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 
 	if account != nil && account.Type == AccountTypeOAuth {
 		if rejectReason := detectOpenAIPassthroughInstructionsRejectReason(reqModel, body); rejectReason != "" {
-			rejectMsg := "OpenAI codex passthrough requires a non-empty instructions field"
-			MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
 			logOpenAIPassthroughInstructionsRejected(ctx, c, account, reqModel, rejectReason, body)
-			c.JSON(http.StatusForbidden, gin.H{
-				"error": gin.H{
-					"type":    "forbidden_error",
-					"message": rejectMsg,
-				},
-			})
-			return nil, fmt.Errorf("openai passthrough rejected before upstream: %s", rejectReason)
+			return nil, &openAIPassthroughRollbackError{Reason: rejectReason}
 		}
 
 		normalizedBody, normalized, err := normalizeOpenAIPassthroughOAuthBody(body, isOpenAIResponsesCompactPath(c))
@@ -6314,10 +6324,7 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 }
 
 func detectOpenAIPassthroughInstructionsRejectReason(reqModel string, body []byte) string {
-	model := strings.ToLower(strings.TrimSpace(reqModel))
-	if !strings.Contains(model, "codex") {
-		return ""
-	}
+	_ = reqModel
 
 	instructions := gjson.GetBytes(body, "instructions")
 	if !instructions.Exists() {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -450,7 +450,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_UpstreamRequestIgnoresClientCance
 	require.NoError(t, upstream.lastReq.Context().Err())
 }
 
-func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedBeforeUpstream(t *testing.T) {
+func TestOpenAIGatewayService_OAuthPassthrough_MissingInstructionsRejectedBeforeUpstream(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logSink, restore := captureStructuredLog(t)
 	defer restore()
@@ -462,14 +462,14 @@ func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedB
 	c.Request.Header.Set("Content-Type", "application/json")
 	c.Request.Header.Set("OpenAI-Beta", "responses=experimental")
 
-	// Codex 模型且缺少 instructions，应在本地直接 403 拒绝，不触达上游。
-	originalBody := []byte(`{"model":"gpt-5.1-codex-max","stream":false,"store":true,"input":[{"type":"text","text":"hi"}]}`)
+	// OAuth 可用模型缺少 instructions，透传路径记录告警后回退到非透传路径。
+	originalBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"input":[{"type":"text","text":"hi"}]}`)
 
 	upstream := &httpUpstreamRecorder{
 		resp: &http.Response{
 			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid"}},
-			Body:       io.NopCloser(strings.NewReader(`{"output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+			Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
 		},
 	}
 
@@ -491,16 +491,58 @@ func TestOpenAIGatewayService_OAuthPassthrough_CodexMissingInstructionsRejectedB
 		RateMultiplier: f64p(1),
 	}
 
-	result, err := svc.Forward(context.Background(), c, account, originalBody)
-	require.Error(t, err)
-	require.Nil(t, result)
-	require.Equal(t, http.StatusForbidden, rec.Code)
-	require.Contains(t, rec.Body.String(), "requires a non-empty instructions field")
-	require.Nil(t, upstream.lastReq)
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.NotEqual(t, http.StatusForbidden, rec.Code)
 
 	require.True(t, logSink.ContainsMessage("OpenAI passthrough 本地拦截：Codex 请求缺少有效 instructions"))
-	require.True(t, logSink.ContainsFieldValue("request_user_agent", "codex_cli_rs/0.98.0 (Windows 10.0.19045; x86_64) unknown"))
 	require.True(t, logSink.ContainsFieldValue("reject_reason", "instructions_missing"))
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_MissingInstructionsRollbackToNonPassthrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	originalBody := []byte(`{"model":"gpt-5.5","stream":false,"store":true,"input":[{"type":"text","text":"hello"}]}`)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_rollback"}},
+			Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+		},
+	}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.NotEqual(t, originalBody, upstream.lastBody)
+	require.Contains(t, string(upstream.lastBody), `"stream":true`)
+	require.NotEqual(t, http.StatusForbidden, rec.Code)
 }
 
 func TestOpenAIGatewayService_OAuthPassthrough_DisabledUsesLegacyTransform(t *testing.T) {
@@ -645,7 +687,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_ResponseHeadersAllowXCodex(t *tes
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 	headers := make(http.Header)
 	headers.Set("Content-Type", "application/json")
@@ -703,7 +745,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_UpstreamErrorIncludesPassthroughF
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":false,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":false,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 	resp := &http.Response{
 		StatusCode: http.StatusBadRequest,
@@ -892,7 +934,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_NonCodexUAFallbackToCodexUA(t *te
 	// Non-Codex UA
 	c.Request.Header.Set("User-Agent", "curl/8.0")
 
-	inputBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"input":[{"type":"text","text":"hi"}]}`)
+	inputBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -934,7 +976,7 @@ func TestOpenAIGatewayService_CodexCLIOnly_RejectsNonCodexClient(t *testing.T) {
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
 	c.Request.Header.Set("User-Agent", "curl/8.0")
 
-	inputBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"input":[{"type":"text","text":"hi"}]}`)
+	inputBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 	svc := &OpenAIGatewayService{
 		cfg: &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
@@ -983,7 +1025,7 @@ func TestOpenAIGatewayService_CodexCLIOnly_AllowOfficialClientFamilies(t *testin
 				c.Request.Header.Set("originator", tt.originator)
 			}
 
-			inputBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"input":[{"type":"text","text":"hi"}]}`)
+			inputBody := []byte(`{"model":"gpt-5.2","stream":false,"store":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 			resp := &http.Response{
 				StatusCode: http.StatusOK,
@@ -1025,7 +1067,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamingSetsFirstTokenMs(t *test
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"service_tier":"fast","input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"service_tier":"fast","instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 	upstreamSSE := strings.Join([]string{
 		`data: {"type":"response.output_text.delta","delta":"h"}`,
@@ -1079,7 +1121,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_StreamClientDisconnectStillCollec
 	// 首次写入成功，后续写入失败，模拟客户端中途断开。
 	c.Writer = &failingGinWriter{ResponseWriter: c.Writer, failAfter: 1}
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 
 	upstreamSSE := strings.Join([]string{
 		`data: {"type":"response.output_text.delta","delta":"h"}`,
@@ -1183,7 +1225,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_WarnOnTimeoutHeadersForStream(t *
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
 	c.Request.Header.Set("x-stainless-timeout", "10000")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid-timeout"}},
@@ -1223,7 +1265,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_InfoWhenStreamEndsWithoutDone(t *
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 	// 注意：刻意不发送 [DONE]，模拟上游中途断流。
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
@@ -1265,7 +1307,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_DefaultFiltersTimeoutHeaders(t *t
 	c.Request.Header.Set("x-stainless-timeout", "120000")
 	c.Request.Header.Set("X-Test", "keep")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid-filter-default"}},
@@ -1311,7 +1353,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_AllowTimeoutHeadersWhenConfigured
 	c.Request.Header.Set("x-stainless-timeout", "120000")
 	c.Request.Header.Set("X-Test", "keep")
 
-	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"input":[{"type":"text","text":"hi"}]}`)
+	originalBody := []byte(`{"model":"gpt-5.2","stream":true,"instructions":"local-test-instructions","input":[{"type":"text","text":"hi"}]}`)
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "X-Request-Id": []string{"rid-filter-allow"}},

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -56,6 +56,7 @@
           label="7d"
           :utilization="usageInfo.seven_day.utilization"
           :resets-at="usageInfo.seven_day.resets_at"
+          :window-stats="usageInfo.seven_day.window_stats"
           color="emerald"
         />
 
@@ -65,6 +66,7 @@
           label="7d S"
           :utilization="usageInfo.seven_day_sonnet.utilization"
           :resets-at="usageInfo.seven_day_sonnet.resets_at"
+          :window-stats="usageInfo.seven_day_sonnet.window_stats"
           color="purple"
         />
 

--- a/frontend/src/components/account/UsageProgressBar.vue
+++ b/frontend/src/components/account/UsageProgressBar.vue
@@ -185,7 +185,7 @@ const formatTokens = computed(() => {
 
 const formatAccountCost = computed(() => {
   if (!props.windowStats) return '0.00'
-  return props.windowStats.cost.toFixed(2)
+  return (props.windowStats.standard_cost ?? props.windowStats.cost).toFixed(2)
 })
 
 const formatUserCost = computed(() => {

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -211,6 +211,74 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('7d|77|300')
   })
 
+  it('Anthropic OAuth 会把 5h/7d/7d Sonnet 各自 window_stats 传给窗口条', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: {
+        utilization: 10,
+        resets_at: '2026-03-08T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 5,
+          tokens: 500,
+          cost: 0.5,
+          standard_cost: 0.55,
+          user_cost: 0.25
+        }
+      },
+      seven_day: {
+        utilization: 20,
+        resets_at: '2026-03-13T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 70,
+          tokens: 7000,
+          cost: 7,
+          standard_cost: 7.7,
+          user_cost: 3.5
+        }
+      },
+      seven_day_sonnet: {
+        utilization: 30,
+        resets_at: '2026-03-13T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 17,
+          tokens: 1700,
+          cost: 1.7,
+          standard_cost: 1.87,
+          user_cost: 0.85
+        }
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2100,
+          platform: 'anthropic',
+          type: 'oauth',
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.requests }}|{{ windowStats?.tokens }}|{{ windowStats?.standard_cost }}|{{ windowStats?.user_cost }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2100)
+    expect(wrapper.text()).toContain('5h|10|5|500|0.55|0.25')
+    expect(wrapper.text()).toContain('7d|20|70|7000|7.7|3.5')
+    expect(wrapper.text()).toContain('7d S|30|17|1700|1.87|0.85')
+  })
+
   it('OpenAI OAuth 有 codex 快照时仍然使用 /usage API 数据渲染', async () => {
     getUsage.mockResolvedValue({
       five_hour: {

--- a/frontend/src/components/account/__tests__/UsageProgressBar.spec.ts
+++ b/frontend/src/components/account/__tests__/UsageProgressBar.spec.ts
@@ -66,4 +66,27 @@ describe('UsageProgressBar', () => {
     expect(wrapper.text()).toContain('2h 30m')
     expect(wrapper.text()).not.toContain('现在')
   })
+
+  it('窗口统计展示 req、Token、A-USD 标准成本和 U-USD 用户成本', () => {
+    const wrapper = mount(UsageProgressBar, {
+      props: {
+        label: '7d',
+        utilization: 12,
+        resetsAt: '2026-03-17T02:30:00Z',
+        color: 'emerald',
+        windowStats: {
+          requests: 12,
+          tokens: 3456,
+          cost: 9.99,
+          standard_cost: 1.23,
+          user_cost: 4.56
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('12 req')
+    expect(wrapper.text()).toContain('3.5K')
+    expect(wrapper.text()).toContain('A $1.23')
+    expect(wrapper.text()).toContain('U $4.56')
+  })
 })


### PR DESCRIPTION
## Summary / 摘要

### 中文
本 PR 修复 OpenAI OAuth 透传路径在请求缺少 `instructions` 字段时的处理逻辑。

此前透传路径会在本地直接返回 403，导致请求无法继续通过非透传路径进行完整转换。现在当检测到缺失 `instructions` 时，透传路径会记录告警并回退到非透传路径，由完整转换逻辑重新打包请求体后继续转发到上游。

同时，`instructions` 缺失检测不再仅限于 Codex 模型，而是适用于 OAuth 可用模型的透传场景，以匹配上游对 `instructions` 字段的实际要求。现在已经测试gpt-5.5 gpt-5.4 gpt-5.4-mini gpt-5.2 现在都要求instructions ( 上游返回 Instructions are required ）, 而不是仅有codex要求instructions。

### English
This PR fixes OpenAI OAuth passthrough behavior when the request body is missing the `instructions` field.

Previously, the passthrough path rejected such requests locally with a 403 response, preventing the request from continuing through the non-passthrough full transform path. With this change, missing `instructions` now triggers a passthrough rollback: the gateway logs the warning, falls back to the non-passthrough path, repacks the request body, and forwards it upstream.

The missing `instructions` detection is also expanded beyond Codex-only models to OAuth-supported passthrough requests, aligning local gateway behavior with upstream requirements. Now gpt-5.5 gpt-5.4 gpt-5.4-mini gpt-5.2 all need instructions, upstream returns Instructions are required for all models not only codex models.

## Changes / 变更内容

### 中文
- 新增 `openAIPassthroughRollbackError`，用于在透传路径尚未写入响应时通知上层回退。
- 在 `Forward` 中捕获透传回退错误，并继续执行非透传完整转换路径。
- 将缺失 `instructions` 的处理从本地 403 拒绝改为记录告警后回退。
- 扩展 `instructions` 缺失检测范围，不再只判断 Codex 模型。
- 更新 OAuth passthrough 测试，覆盖回退到非透传路径、请求体重写、以及正常透传测试请求显式携带 `instructions` 的场景。

### English
- Added `openAIPassthroughRollbackError` to signal rollback before any response is written.
- Updated `Forward` to catch passthrough rollback errors and continue through the non-passthrough full transform path.
- Changed missing `instructions` handling from local 403 rejection to warning + rollback.
- Expanded missing `instructions` detection beyond Codex-only model checks.
- Updated OAuth passthrough tests to cover rollback to non-passthrough, request body rewriting, and explicit `instructions` in normal passthrough test cases.

## Changed Files / 影响文件

- [backend/internal/service/openai_gateway_service.go](backend/internal/service/openai_gateway_service.go)
- [backend/internal/service/openai_oauth_passthrough_test.go](backend/internal/service/openai_oauth_passthrough_test.go)

## Commits / 相关提交

- `c63f429407cd78a90ecbf502cdae8dc3736f2abe`  
  `fix(openai): implement rollback mechanism for missing instructions in passthrough`

- `a038fffec3ba0efb1bdebcf2780e4741953e02ee`  
  `fix(openai): reflect changes in instruction handling for OAuth upstream`

## Testing / 测试

### 中文
已运行 OpenAI passthrough 相关 Go 测试：