### PR TITLE
fix(codex-transform): preserve underscore when rewriting `call_*` tool-call ids

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1030,7 +1030,7 @@ func filterCodexInputWithOptions(input []any, opts codexInputFilterOptions) []an
 				return id
 			}
 			if strings.HasPrefix(id, "call_") {
-				return "fc" + strings.TrimPrefix(id, "call_")
+				return "fc_" + strings.TrimPrefix(id, "call_")
 			}
 			return "fc_" + id
 		}


### PR DESCRIPTION
## Summary

`fixCallIDPrefix` in `openai_codex_transform.go` rewrites
`call_<nanoid>` → `fc<nanoid>` (missing underscore). The codex backend
then rejects the malformed id with `400 Invalid 'input[N].id'` and
sub2api surfaces it as `502 Bad Gateway` to the client.

```go
// before (line 1032-1034)
if strings.HasPrefix(id, "call_") {
    return "fc" + strings.TrimPrefix(id, "call_")  // ← missing "_"
}
return "fc_" + id  // ← other branch has it
```

## Repro

Client uses the OpenAI SDK against an OAuth/codex-mode sub2api account.
The model emits a function_call with the standard `call_<nanoid>` id;
the client replays it on the next hop as an `item_reference` whose id
mirrors the call_id. `fixCallIDPrefix` then produces e.g.
`fcYYen1qxDejd2myJwcTCf7Nyp` (instead of `fc_YYen1qxDejd2myJwcTCf7Nyp`),
which the upstream codex /responses endpoint rejects:

```text
400 Invalid 'input[N].id': 'fcYYen1qxDejd2myJwcTCf7Nyp'.
    Expected an ID that contains letters, numbers, underscores, or
    dashes, but this value contained additional characters.
```

Sub2api wraps that into `502 upstream request failed`.

## Fix

One character — add the missing underscore on the `call_` branch so it
matches the fallback branch directly below it.

```go
if strings.HasPrefix(id, "call_") {
    return "fc_" + strings.TrimPrefix(id, "call_")  // ← now matches fallback
}
return "fc_" + id
```

## Impact

- **Affects** `platform=openai type=oauth` accounts whose clients use
  the official OpenAI SDK / Responses-API id conventions
  (`call_<nanoid>` prefix). Every multi-hop turn after the first tool
  call surfaces as 502 from sub2api.
- **Does not affect** API-key accounts (they don't go through
  `applyCodexOAuthTransform`) or clients that already emit `fc_` ids
  directly.

## Test plan

- [x] Codex OAuth account, OpenAI SDK client, multi-hop turn with
      function calls — previously 502 on hop 2+, expected 200 with fix.
- [ ] Confirm no regression for clients sending non-`call_`-prefixed
      ids (the fallback branch still handles them with `fc_` prefix).