### PR TITLE
fix: avoid ops deep link initialization error

### DIFF
--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -310,8 +310,6 @@ const applyRouteQueryToState = () => {
   }
 }
 
-applyRouteQueryToState()
-
 const buildQueryFromState = () => {
   const next: Record<string, any> = { ...route.query }
 
@@ -379,6 +377,8 @@ const requestDetailsPreset = ref<OpsRequestDetailsPreset>({
 
 const showSettingsDialog = ref(false)
 const showAlertRulesCard = ref(false)
+
+applyRouteQueryToState()
 
 // Auto refresh settings
 const showAlertEvents = ref(true)


### PR DESCRIPTION
﻿## Summary

Fixes a runtime error when opening the ops dashboard through a deep link that includes `open_error_details=1`.

The initial `applyRouteQueryToState()` call could access ops modal refs before those refs were initialized. In production builds this can surface as a temporal dead zone error with a minified variable name:

```text
ReferenceError: Cannot access '<minified variable>' before initialization
```

## Changes

- Move the initial `applyRouteQueryToState()` call after the related ops modal state refs are initialized.

## Verification

- `corepack pnpm run typecheck`
- `corepack pnpm run build`
