### PR TITLE
fix(admin/settings): make tab shell readable in dark mode

### DIFF
--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -9012,14 +9012,6 @@ watch(
     0 1px 0 rgb(255 255 255 / 0.9) inset;
 }
 
-:global(.dark) .settings-tabs-shell {
-  border-color: rgb(51 65 85 / 0.65);
-  background: rgb(15 23 42 / 0.86);
-  box-shadow:
-    0 16px 36px rgb(0 0 0 / 0.28),
-    0 1px 0 rgb(255 255 255 / 0.06) inset;
-}
-
 .settings-tabs-scroll {
   @apply overflow-x-auto;
   -ms-overflow-style: none;
@@ -9063,10 +9055,6 @@ watch(
   opacity: 1;
 }
 
-:global(.dark) .settings-tab::before {
-  background: linear-gradient(135deg, rgb(30 41 59 / 0.9), rgb(51 65 85 / 0.62));
-}
-
 .settings-tab:focus-visible {
   @apply ring-2 ring-primary-500/40 ring-offset-2 ring-offset-white dark:ring-offset-dark-900;
 }
@@ -9076,12 +9064,6 @@ watch(
   box-shadow:
     0 8px 18px rgb(15 23 42 / 0.08),
     0 1px 0 rgb(255 255 255 / 0.92) inset;
-}
-
-:global(.dark) .settings-tab-active {
-  box-shadow:
-    0 12px 26px rgb(0 0 0 / 0.22),
-    0 1px 0 rgb(255 255 255 / 0.08) inset;
 }
 
 .settings-tab-active::before {
@@ -9114,5 +9096,28 @@ watch(
 
 .settings-tab-label {
   @apply min-w-0 overflow-hidden text-ellipsis whitespace-nowrap leading-none;
+}
+</style>
+
+<style>
+/* Dark-mode overrides for the settings tabs shell. Kept in an UNSCOPED block
+   because Vue's scoped-CSS compiler was dropping the `:global(.dark) ...`
+   rules in the production build, leaving inactive tabs unreadable on dark. */
+.dark .settings-tabs-shell {
+  border-color: rgb(51 65 85 / 0.65);
+  background: rgb(15 23 42 / 0.86);
+  box-shadow:
+    0 16px 36px rgb(0 0 0 / 0.28),
+    0 1px 0 rgb(255 255 255 / 0.06) inset;
+}
+
+.dark .settings-tab::before {
+  background: linear-gradient(135deg, rgb(30 41 59 / 0.9), rgb(51 65 85 / 0.62));
+}
+
+.dark .settings-tab-active {
+  box-shadow:
+    0 12px 26px rgb(0 0 0 / 0.22),
+    0 1px 0 rgb(255 255 255 / 0.08) inset;
 }
 </style>


### PR DESCRIPTION
## Problem

On the `/admin/settings` page in dark mode, the tab strip (登录条款 / 功能开关 / 安全与... etc.) keeps a light/white background while the inactive tab labels render in `text-gray-300` (#d1d5db), giving roughly a **1.6:1 contrast ratio** — effectively unreadable.

Repro: visit `/admin/settings`, toggle dark mode, look at any tab that isn't the active one.

## Root cause

In `SettingsView.vue`'s scoped `<style>` block we have rules like:

```css
:global(.dark) .settings-tabs-shell {
  background: rgb(15 23 42 / 0.86);
  ...
}
```

Vue's scoped-CSS compiler is dropping these three `:global(.dark) …` rules from the production build — they don't appear in the compiled stylesheet at all. As a result, the dark-mode overrides for `.settings-tabs-shell`, `.settings-tab::before`, and `.settings-tab-active` never apply, and the shell stays on its light-mode white background.

(Other `dark:` Tailwind variants applied inline via `@apply` on the same elements survive — only the standalone `:global(.dark)` selectors are affected.)

## Fix

Hoist the three dark-mode overrides into a second, **unscoped** `<style>` block at the bottom of the file. The selectors (`.settings-tabs-shell`, `.settings-tab::before`, `.settings-tab-active`) are component-specific enough that going unscoped is safe.

After the fix:
- `.settings-tabs-shell` shows the intended `rgb(15 23 42 / 0.86)` slate background in dark mode
- Inactive tab text on that background hits ~10:1 contrast (WCAG AAA)
- No change to light-mode appearance

## Test plan

- [x] Built frontend + verified dark-mode tab strip renders the slate background in production build
- [x] Verified light mode is unchanged
- [x] No new lint or build warnings