### PR TITLE
fix(gateway): exempt Haiku models from context_management auto-injection that triggers Anthropic 400 | 修复：跳过 Haiku 模型的 context_management 自动注入以避免 Anthropic 上游 400

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1128,7 +1128,16 @@ func normalizeClaudeOAuthRequestBody(body []byte, modelID string, opts claudeOAu
 	// context_management：thinking.type 为 enabled/adaptive 时，真实 CLI 会自动
 	// 附带 {"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}。
 	// 客户端显式传了就透传；否则按 CLI 行为补齐。
-	if !gjson.GetBytes(out, "context_management").Exists() {
+	//
+	// Haiku 例外：Anthropic /v1/messages API 对 claude-haiku-4-5-* 模型拒绝
+	// context_management 字段（HTTP 400 "Extra inputs are not permitted"）。
+	// 与下方 anthropic-beta header 处理路径保持一致 —— 后者已经将 Haiku 从
+	// FullClaudeCodeMimicryBetas 中豁免（Haiku-targeted OAuth 请求仅使用
+	// {BetaOAuth, BetaInterleavedThinking}）。真实 Claude CLI 实测在 Haiku
+	// 请求中也不发送 context_management，因此这是对 CLI 行为更精确的模拟。
+	// 详细 forensic 数据见 issue #2506.
+	modelIsHaiku := strings.Contains(strings.ToLower(modelID), "haiku")
+	if !modelIsHaiku && !gjson.GetBytes(out, "context_management").Exists() {
 		thinkingType := gjson.GetBytes(out, "thinking.type").String()
 		if thinkingType == "enabled" || thinkingType == "adaptive" {
 			const cmDefault = `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`

--- a/backend/internal/service/gateway_service_haiku_context_management_exemption_test.go
+++ b/backend/internal/service/gateway_service_haiku_context_management_exemption_test.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// TestNormalizeClaudeOAuthRequestBody_HaikuModelDoesNotReceiveContextManagementAutoInjection
+// pins the Haiku exemption added by PR fixing #2506. Anthropic /v1/messages rejects
+// context_management with HTTP 400 for claude-haiku-4-5-* models even when thinking is
+// enabled, so sub2api must NOT auto-inject it for Haiku-targeted requests.
+func TestNormalizeClaudeOAuthRequestBody_HaikuModelDoesNotReceiveContextManagementAutoInjection(t *testing.T) {
+	bodyWithThinkingEnabledButNoContextManagement := []byte(`{` +
+		`"model":"claude-haiku-4-5-20251001",` +
+		`"messages":[{"role":"user","content":"hi"}],` +
+		`"thinking":{"type":"enabled","budget_tokens":1024}` +
+		`}`)
+
+	out, _ := normalizeClaudeOAuthRequestBody(
+		bodyWithThinkingEnabledButNoContextManagement,
+		"claude-haiku-4-5-20251001",
+		claudeOAuthNormalizeOptions{},
+	)
+
+	require.False(t,
+		gjson.GetBytes(out, "context_management").Exists(),
+		"Haiku 模型不应被自动注入 context_management —— Anthropic 上游会拒绝该字段返回 400",
+	)
+}
+
+// TestNormalizeClaudeOAuthRequestBody_SonnetModelStillReceivesContextManagementAutoInjection
+// regression-pins the pre-existing behavior for Sonnet (and by extension Opus). The Haiku
+// exemption must not regress the Sonnet/Opus path which legitimately needs the injection
+// to match real Claude CLI byte-level behavior.
+func TestNormalizeClaudeOAuthRequestBody_SonnetModelStillReceivesContextManagementAutoInjection(t *testing.T) {
+	bodyWithThinkingEnabledButNoContextManagement := []byte(`{` +
+		`"model":"claude-sonnet-4-5-20250929",` +
+		`"messages":[{"role":"user","content":"hi"}],` +
+		`"thinking":{"type":"enabled","budget_tokens":1024}` +
+		`}`)
+
+	out, _ := normalizeClaudeOAuthRequestBody(
+		bodyWithThinkingEnabledButNoContextManagement,
+		"claude-sonnet-4-5-20250929",
+		claudeOAuthNormalizeOptions{},
+	)
+
+	require.True(t,
+		gjson.GetBytes(out, "context_management").Exists(),
+		"Sonnet 模型应继续被自动注入 context_management 以匹配真实 CLI 字节级行为",
+	)
+	require.Equal(t,
+		"clear_thinking_20251015",
+		gjson.GetBytes(out, "context_management.edits.0.type").String(),
+		"注入的 edit type 应保持为 clear_thinking_20251015",
+	)
+}
+
+// TestNormalizeClaudeOAuthRequestBody_HaikuModelExplicitContextManagementStillPassesThrough
+// confirms the exemption does NOT strip an explicit client-provided context_management —
+// only skips the AUTO-injection. If a client deliberately sends context_management for
+// Haiku (e.g. to test or to override), the field passes through verbatim. The Anthropic
+// upstream will still reject it, but that's the client's responsibility.
+func TestNormalizeClaudeOAuthRequestBody_HaikuModelExplicitContextManagementStillPassesThrough(t *testing.T) {
+	bodyWithExplicitContextManagementFromClient := []byte(`{` +
+		`"model":"claude-haiku-4-5-20251001",` +
+		`"messages":[],` +
+		`"context_management":{"edits":[{"type":"clear_tool_uses_20250919"}]}` +
+		`}`)
+
+	out, _ := normalizeClaudeOAuthRequestBody(
+		bodyWithExplicitContextManagementFromClient,
+		"claude-haiku-4-5-20251001",
+		claudeOAuthNormalizeOptions{},
+	)
+
+	require.True(t,
+		gjson.GetBytes(out, "context_management").Exists(),
+		"Haiku 例外只跳过自动注入，不应剥离客户端显式传入的 context_management",
+	)
+	require.Equal(t,
+		"clear_tool_uses_20250919",
+		gjson.GetBytes(out, "context_management.edits.0.type").String(),
+		"客户端显式 edits 必须原样保留",
+	)
+}
+
+// TestNormalizeClaudeOAuthRequestBody_HaikuMatchIsCaseInsensitive matches the convention
+// established by the neighboring beta-header logic at line ~6093 which uses
+// strings.Contains(strings.ToLower(modelID), "haiku"). Uppercased or mixed-case Haiku
+// model IDs MUST also be exempt.
+func TestNormalizeClaudeOAuthRequestBody_HaikuMatchIsCaseInsensitive(t *testing.T) {
+	for _, modelIDInVariousCasings := range []string{
+		"claude-haiku-4-5-20251001",
+		"CLAUDE-HAIKU-4-5-20251001",
+		"Claude-Haiku-4-5-20251001",
+		"claude-3-5-haiku-20241022", // legacy variant
+	} {
+		bodyWithThinkingEnabled := []byte(`{` +
+			`"model":"` + modelIDInVariousCasings + `",` +
+			`"messages":[],` +
+			`"thinking":{"type":"adaptive"}` +
+			`}`)
+
+		out, _ := normalizeClaudeOAuthRequestBody(
+			bodyWithThinkingEnabled,
+			modelIDInVariousCasings,
+			claudeOAuthNormalizeOptions{},
+		)
+
+		require.False(t,
+			gjson.GetBytes(out, "context_management").Exists(),
+			"case-insensitive Haiku 匹配在 modelID=%q 时应豁免 context_management 注入",
+			modelIDInVariousCasings,
+		)
+		// Confirm the strings.ToLower call is intentional, not accidental
+		require.True(t,
+			strings.Contains(strings.ToLower(modelIDInVariousCasings), "haiku"),
+			"测试输入 %q 在 lowercase 后必须包含 haiku 子串",
+			modelIDInVariousCasings,
+		)
+	}
+}


### PR DESCRIPTION
### Summary | 摘要

**EN.** Skips the auto-injection of `context_management.edits[clear_thinking_20251015]` in `normalizeClaudeOAuthRequestBody` when the targeted model is Haiku. Anthropic's `/v1/messages` API rejects `context_management` with HTTP 400 `"Extra inputs are not permitted"` for `claude-haiku-4-5-*` models — the injection that's correct for Sonnet/Opus breaks Haiku end-to-end. The neighboring beta-header logic at line 6093-6099 already exempts Haiku from `FullClaudeCodeMimicryBetas`; this PR mirrors that asymmetry in the body-injection path. Fixes #2506.

**中文.** 当目标模型为 Haiku 时，跳过 `normalizeClaudeOAuthRequestBody` 中的 `context_management.edits[clear_thinking_20251015]` 自动注入。Anthropic 的 `/v1/messages` API 对 `claude-haiku-4-5-*` 模型会拒绝 `context_management`，返回 HTTP 400 `"Extra inputs are not permitted"`，导致对 Sonnet/Opus 正确的注入逻辑在 Haiku 路径上完全失败。第 6093-6099 行邻近的 beta header 逻辑已经将 Haiku 从 `FullClaudeCodeMimicryBetas` 中豁免；本 PR 在 body 注入路径上做同样的处理。修复 #2506。

### Diff

`backend/internal/service/gateway_service.go` (~line 1128):

```diff
@@ -1125,11 +1125,18 @@ func normalizeClaudeOAuthRequestBody(body []byte, modelID string, opts claudeOAu

- // context_management：thinking.type 为 enabled/adaptive 时，真实 CLI 会自动
- // 附带 {"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}。
- // 客户端显式传了就透传；否则按 CLI 行为补齐。
- if !gjson.GetBytes(out, "context_management").Exists() {
+ // context_management：thinking.type 为 enabled/adaptive 时，真实 CLI 会自动
+ // 附带 {"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}。
+ // 客户端显式传了就透传；否则按 CLI 行为补齐。
+ //
+ // Haiku 例外：Anthropic /v1/messages API 对 claude-haiku-4-5-* 模型拒绝
+ // context_management 字段（HTTP 400 "Extra inputs are not permitted"）。
+ // 与第 6093-6099 行的 beta-header 路径保持一致 —— 后者已经将 Haiku 从
+ // FullClaudeCodeMimicryBetas 中豁免。真实 Claude CLI 实测在 Haiku
+ // 请求中也不发送 context_management，所以这是对 CLI 行为更精确的模拟。
+ modelTargetsHaikuFamilyExemptFromContextManagementAutoInjection := strings.Contains(strings.ToLower(modelID), "haiku")
+ if !modelTargetsHaikuFamilyExemptFromContextManagementAutoInjection && !gjson.GetBytes(out, "context_management").Exists() {
   thinkingType := gjson.GetBytes(out, "thinking.type").String()
   if thinkingType == "enabled" || thinkingType == "adaptive" {
    const cmDefault = `{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`
    if next, ok := setJSONRawBytes(out, "context_management", []byte(cmDefault)); ok {
     out = next
     modified = true
    }
   }
  }
```

(The `strings` package is already imported in this file, so no new import.)

### Tests

New table-driven test pinning the Haiku exemption + regression-pin for the Sonnet/Opus path:

**File:** `backend/internal/service/gateway_service_haiku_context_management_exemption_test.go` (new file, follows the naming pattern of sibling `gateway_body_order_test.go`)

```go
package service

import (
 "strings"
 "testing"

 "github.com/stretchr/testify/require"
 "github.com/tidwall/gjson"
)

// TestNormalizeClaudeOAuthRequestBody_HaikuModelDoesNotReceiveContextManagementAutoInjection
// pins the Haiku exemption added in this PR. Anthropic /v1/messages rejects
// context_management with HTTP 400 for claude-haiku-4-5-* models even when thinking is
// enabled, so sub2api must NOT inject it.
func TestNormalizeClaudeOAuthRequestBody_HaikuModelDoesNotReceiveContextManagementAutoInjection(t *testing.T) {
 bodyWithThinkingEnabledButNoContextManagement := []byte(`{` +
  `"model":"claude-haiku-4-5-20251001",` +
  `"messages":[{"role":"user","content":"hi"}],` +
  `"thinking":{"type":"enabled","budget_tokens":1024}` +
  `}`)

 out, _ := normalizeClaudeOAuthRequestBody(
  bodyWithThinkingEnabledButNoContextManagement,
  "claude-haiku-4-5-20251001",
  claudeOAuthNormalizeOptions{},
 )

 require.False(t,
  gjson.GetBytes(out, "context_management").Exists(),
  "Haiku 模型不应被自动注入 context_management —— Anthropic 上游会拒绝该字段返回 400",
 )
}

// TestNormalizeClaudeOAuthRequestBody_SonnetModelStillReceivesContextManagementAutoInjection
// regression-pins the pre-existing behavior for Sonnet (and by extension Opus). The Haiku
// exemption must not regress the Sonnet/Opus path which legitimately needs the injection
// to match real Claude CLI byte-level behavior.
func TestNormalizeClaudeOAuthRequestBody_SonnetModelStillReceivesContextManagementAutoInjection(t *testing.T) {
 bodyWithThinkingEnabledButNoContextManagement := []byte(`{` +
  `"model":"claude-sonnet-4-5-20250929",` +
  `"messages":[{"role":"user","content":"hi"}],` +
  `"thinking":{"type":"enabled","budget_tokens":1024}` +
  `}`)

 out, _ := normalizeClaudeOAuthRequestBody(
  bodyWithThinkingEnabledButNoContextManagement,
  "claude-sonnet-4-5-20250929",
  claudeOAuthNormalizeOptions{},
 )

 require.True(t,
  gjson.GetBytes(out, "context_management").Exists(),
  "Sonnet 模型应继续被自动注入 context_management 以匹配真实 CLI 字节级行为",
 )
 require.Equal(t,
  "clear_thinking_20251015",
  gjson.GetBytes(out, "context_management.edits.0.type").String(),
  "注入的 edit type 应保持为 clear_thinking_20251015",
 )
}

// TestNormalizeClaudeOAuthRequestBody_HaikuModelExplicitContextManagementStillPassesThrough
// confirms the exemption does NOT strip an explicit client-provided context_management —
// only skips the AUTO-injection. If a client deliberately sends context_management for
// Haiku (e.g. to test or to override), the field passes through verbatim. The Anthropic
// upstream will still reject it, but that's the client's responsibility.
func TestNormalizeClaudeOAuthRequestBody_HaikuModelExplicitContextManagementStillPassesThrough(t *testing.T) {
 bodyWithExplicitContextManagementFromClient := []byte(`{` +
  `"model":"claude-haiku-4-5-20251001",` +
  `"messages":[],` +
  `"context_management":{"edits":[{"type":"clear_tool_uses_20250919"}]}` +
  `}`)

 out, _ := normalizeClaudeOAuthRequestBody(
  bodyWithExplicitContextManagementFromClient,
  "claude-haiku-4-5-20251001",
  claudeOAuthNormalizeOptions{},
 )

 require.True(t,
  gjson.GetBytes(out, "context_management").Exists(),
  "Haiku 例外只跳过自动注入，不应剥离客户端显式传入的 context_management",
 )
 require.Equal(t,
  "clear_tool_uses_20250919",
  gjson.GetBytes(out, "context_management.edits.0.type").String(),
  "客户端显式 edits 必须原样保留",
 )
}

// TestNormalizeClaudeOAuthRequestBody_HaikuMatchIsCaseInsensitive matches the convention
// established by the neighboring beta-header logic at line 6093-6099 which uses
// strings.Contains(strings.ToLower(modelID), "haiku"). Uppercased or mixed-case Haiku
// model IDs MUST also be exempt.
func TestNormalizeClaudeOAuthRequestBody_HaikuMatchIsCaseInsensitive(t *testing.T) {
 for _, modelIDInVariousCasings := range []string{
  "claude-haiku-4-5-20251001",
  "CLAUDE-HAIKU-4-5-20251001",
  "Claude-Haiku-4-5-20251001",
  "claude-3-5-haiku-20241022", // legacy variant
 } {
  bodyWithThinkingEnabled := []byte(`{` +
   `"model":"` + modelIDInVariousCasings + `",` +
   `"messages":[],` +
   `"thinking":{"type":"adaptive"}` +
   `}`)

  out, _ := normalizeClaudeOAuthRequestBody(
   bodyWithThinkingEnabled,
   modelIDInVariousCasings,
   claudeOAuthNormalizeOptions{},
  )

  require.False(t,
   gjson.GetBytes(out, "context_management").Exists(),
   "case-insensitive Haiku 匹配在 modelID=%q 时应豁免 context_management 注入",
   modelIDInVariousCasings,
  )
  // Confirm the strings.ToLower call is intentional, not accidental
  require.True(t,
   strings.Contains(strings.ToLower(modelIDInVariousCasings), "haiku"),
   "测试输入 %q 在 lowercase 后必须包含 haiku 子串",
   modelIDInVariousCasings,
  )
 }
}
```

### Commit message (squash)

```
fix(gateway): exempt Haiku models from context_management auto-injection

normalizeClaudeOAuthRequestBody injected context_management.edits with
clear_thinking_20251015 for every Claude Code OAuth request whose body had
thinking.type=enabled/adaptive AND lacked an explicit context_management
field. This mimics real Claude CLI behavior for Sonnet/Opus.

For claude-haiku-4-5-* models, Anthropic's /v1/messages API rejects the
field with HTTP 400 "Extra inputs are not permitted", breaking every Haiku
request that has thinking enabled. The neighboring beta-header path at
line 6093-6099 already exempts Haiku from FullClaudeCodeMimicryBetas;
this commit mirrors that asymmetry in the body-injection path.

Fixes #2506.

Test coverage:
- Haiku model → no auto-injection (regression-pin)
- Sonnet model → auto-injection still fires (no regression in pre-existing path)
- Haiku with client-provided explicit context_management → passes through verbatim (exemption only skips AUTO-inject)
- Case-insensitive Haiku match (canonical, uppercase, mixed-case, legacy 3-5-haiku)
```

### Acceptance criteria (operator preview)

After this lands and a downstream sub2api deployment picks it up:

- ccmax-monitor's iter-127 client-side `thinking` strip becomes a no-op (the wrapper's strip still runs but sub2api no longer needs the wrapper's help) — operator can revert iter-127 to restore Haiku extended-thinking
- Haiku 4.5 requests pass through cleanly with thinking enabled
- Sonnet/Opus paths unaffected (verified by regression test)

### Compat / risk notes

- **No breaking change.** The exemption only AVOIDS adding a field for Haiku; it doesn't strip or modify anything else
- **Real Claude CLI behavior.** Empirically the real `claude` CLI does NOT send `context_management` for Haiku models (confirmed via captured request bodies from the ccmax-monitor operator's deployment). The pre-fix injection was an over-broad mimicry — Haiku CLI behavior was never actually like this
- **Forward compatibility.** If Anthropic later starts accepting `context_management` on Haiku, the exemption becomes a no-op penalty (just skips the injection); reverting it would be a 1-line change

Happy to adjust the model match (e.g., explicit version allowlist instead of substring) per maintainer preference.