### PR TITLE
fix: 修复管理后台分组页可用账号数显示错误

### DIFF
--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -201,10 +201,7 @@
                 }}</span>
                 <span
                   class="ml-1 font-medium text-emerald-600 dark:text-emerald-400"
-                  >{{
-                    (row.active_account_count || 0) -
-                    (row.rate_limited_account_count || 0)
-                  }}</span
+                  >{{ row.active_account_count || 0 }}</span
                 >
                 <span
                   class="ml-1 inline-flex items-center rounded bg-gray-100 px-1.5 py-0.5 font-medium text-gray-800 dark:bg-dark-600 dark:text-gray-300"


### PR DESCRIPTION
## 变更说明

修复管理后台分组列表中“可用账号数”的显示逻辑错误。

此前前端使用的是：

`active_account_count - rate_limited_account_count`

但后端返回的 `active_account_count` 本身已经表示：

- `status = active`
- `schedulable = true`

也就是说，这个字段已经是当前可用账号数。前端再减一次 `rate_limited_account_count`，会把部分本来就不在可用集合里的账号重复扣减，导致页面出现负数结果。

## 修复内容

将管理后台分组页中的“可用账号数”改为直接显示：

`active_account_count`

不再额外减去 `rate_limited_account_count`。

## 修复原因

当前后端分组统计口径为：

- `active_account_count`：活跃且可调度的账号数
- `rate_limited_account_count`：当前处于限流 / overload / 临时不可调度状态的账号数

由于 `active_account_count` 已经可以直接表示该页面所需的“可用账号数”，前端继续减去 `rate_limited_account_count` 属于重复扣减，逻辑不正确。

## 示例

以 `codex` 分组为例：

- `active_account_count = 5`
- `rate_limited_account_count = 10`

旧逻辑显示：
- `5 - 10 = -5`

修复后显示：
- `5`