### PR TITLE
Update CORS allowed headers to include X-Goog-Api-Key

### DIFF
--- a/backend/internal/server/middleware/cors.go
+++ b/backend/internal/server/middleware/cors.go
@@ -52,7 +52,7 @@ func CORS(cfg config.CORSConfig) gin.HandlerFunc {
 	}
 	allowHeaders := []string{
 		"Content-Type", "Content-Length", "Accept-Encoding", "X-CSRF-Token", "Authorization",
-		"accept", "origin", "Cache-Control", "X-Requested-With", "X-API-Key",
+		"accept", "origin", "Cache-Control", "X-Requested-With", "X-API-Key", "X-Goog-Api-Key",
 	}
 	// OpenAI Node SDK 会发送 x-stainless-* 请求头，需在 CORS 中显式放行。
 	openAIProperties := []string{


### PR DESCRIPTION
Added 'X-Goog-Api-Key' to allowed CORS headers.