### PR TITLE
fix: hide model scopes for non-antigravity plans

### DIFF
--- a/frontend/src/components/payment/SubscriptionPlanCard.vue
+++ b/frontend/src/components/payment/SubscriptionPlanCard.vue
@@ -147,6 +147,7 @@ const MODEL_SCOPE_LABELS: Record<string, string> = {
 }
 
 const modelScopeLabels = computed(() => {
+  if (platform.value !== 'antigravity') return []
   const scopes = props.plan.supported_model_scopes
   if (!scopes || scopes.length === 0) return []
   return scopes.map(s => MODEL_SCOPE_LABELS[s] || s)

--- a/frontend/src/components/payment/__tests__/SubscriptionPlanCard.spec.ts
+++ b/frontend/src/components/payment/__tests__/SubscriptionPlanCard.spec.ts
@@ -1,0 +1,64 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { createI18n } from "vue-i18n";
+import SubscriptionPlanCard from "../SubscriptionPlanCard.vue";
+
+const i18n = createI18n({
+  legacy: false,
+  locale: "en",
+  fallbackWarn: false,
+  missingWarn: false,
+  messages: {
+    en: {
+      payment: {
+        days: "days",
+        models: "Models",
+        planCard: {
+          quota: "Quota",
+          rate: "Rate",
+          unlimited: "Unlimited",
+        },
+        subscribeNow: "Subscribe now",
+      },
+    },
+  },
+});
+
+const mountPlanCard = (groupPlatform: string) =>
+  mount(SubscriptionPlanCard, {
+    props: {
+      plan: {
+        id: 1,
+        group_id: 10,
+        group_platform: groupPlatform,
+        name: "Pro",
+        price: 10,
+        amount: 1000,
+        features: [],
+        rate_multiplier: 1,
+        validity_days: 30,
+        validity_unit: "day",
+        supported_model_scopes: ["claude", "gemini_text", "gemini_image"],
+        is_active: true,
+      },
+    },
+    global: { plugins: [i18n] },
+  });
+
+describe("SubscriptionPlanCard", () => {
+  it("does not show Antigravity model scopes for OpenAI plans", () => {
+    const text = mountPlanCard("openai").text();
+
+    expect(text).not.toContain("Claude");
+    expect(text).not.toContain("Gemini");
+    expect(text).not.toContain("Imagen");
+  });
+
+  it("shows model scopes for Antigravity plans", () => {
+    const text = mountPlanCard("antigravity").text();
+
+    expect(text).toContain("Claude");
+    expect(text).toContain("Gemini");
+    expect(text).toContain("Imagen");
+  });
+});

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -2865,6 +2865,7 @@ import {
   resetMessagesDispatchFormState,
   type MessagesDispatchMappingRow,
 } from "./groupsMessagesDispatch";
+import { normalizeSupportedModelScopesForPlatform } from "./groupsSupportedModelScopes";
 
 const { t } = useI18n();
 const appStore = useAppStore();
@@ -3710,6 +3711,10 @@ const handleCreateGroup = async () => {
       model_routing: convertRoutingRulesToApiFormat(
         createModelRoutingRules.value,
       ),
+      supported_model_scopes: normalizeSupportedModelScopesForPlatform(
+        createForm.platform,
+        createForm.supported_model_scopes,
+      ),
       messages_dispatch_model_config:
         createForm.platform === "openai"
           ? messagesDispatchFormStateToConfig({
@@ -3840,6 +3845,10 @@ const handleUpdateGroup = async () => {
           : editForm.fallback_group_id_on_invalid_request,
       model_routing: convertRoutingRulesToApiFormat(
         editModelRoutingRules.value,
+      ),
+      supported_model_scopes: normalizeSupportedModelScopesForPlatform(
+        editForm.platform,
+        editForm.supported_model_scopes,
       ),
       messages_dispatch_model_config:
         editForm.platform === "openai"

--- a/frontend/src/views/admin/__tests__/groupsSupportedModelScopes.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsSupportedModelScopes.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSupportedModelScopesForPlatform } from "../groupsSupportedModelScopes";
+
+describe("normalizeSupportedModelScopesForPlatform", () => {
+  it("preserves model scopes for Antigravity groups", () => {
+    expect(
+      normalizeSupportedModelScopesForPlatform("antigravity", [
+        "claude",
+        "gemini_text",
+      ]),
+    ).toEqual(["claude", "gemini_text"]);
+  });
+
+  it("returns an empty array for Antigravity groups without scopes", () => {
+    expect(normalizeSupportedModelScopesForPlatform("antigravity", undefined)).toEqual([]);
+  });
+
+  it("drops hidden model scopes for OpenAI groups", () => {
+    expect(
+      normalizeSupportedModelScopesForPlatform("openai", [
+        "claude",
+        "gemini_text",
+        "gemini_image",
+      ]),
+    ).toEqual([]);
+  });
+
+  it("drops hidden model scopes for other non-Antigravity groups", () => {
+    expect(normalizeSupportedModelScopesForPlatform("claude", ["claude"])).toEqual([]);
+  });
+});

--- a/frontend/src/views/admin/groupsSupportedModelScopes.ts
+++ b/frontend/src/views/admin/groupsSupportedModelScopes.ts
@@ -1,0 +1,7 @@
+export const normalizeSupportedModelScopesForPlatform = (
+  platform: string,
+  scopes: string[] | undefined,
+): string[] => {
+  if (platform !== "antigravity") return [];
+  return scopes ?? [];
+};


### PR DESCRIPTION
## Summary
- hide Antigravity model scope badges on non-Antigravity subscription plan cards
- normalize submitted `supported_model_scopes` so non-Antigravity groups clear hidden scope values on create/update
- add focused tests for plan-card rendering and scope normalization

## Root cause
The Antigravity-only `supported_model_scopes` field can keep its default values even when the group platform is OpenAI or another provider. Subscription cards rendered those scopes without checking the platform, so non-Antigravity plans could show Claude/Gemini/Imagen badges.

## Test Plan
- `pnpm run typecheck`
- `pnpm exec vitest run src/components/payment/__tests__/SubscriptionPlanCard.spec.ts src/views/admin/__tests__/groupsSupportedModelScopes.spec.ts src/components/payment/__tests__/paymentFlow.spec.ts src/views/admin/__tests__/groupsMessagesDispatch.spec.ts`
