### PR TITLE
fix: support ipv6 proxy management in admin ui

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,6 +29,9 @@ build/
 # Node modules (will be installed in container)
 frontend/node_modules/
 node_modules/
+# Do not let local pnpm approval/workspace scratch files affect the frontend
+# Docker build; this project builds the frontend as a standalone package.
+frontend/pnpm-workspace.yaml
 
 # Go build cache (will be built in container)
 backend/vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,13 @@ ARG ALPINE_IMAGE=alpine:3.21
 ARG POSTGRES_IMAGE=postgres:18-alpine
 ARG GOPROXY=https://goproxy.cn,direct
 ARG GOSUMDB=sum.golang.google.cn
+ARG PNPM_VERSION=9.15.9
 
 # -----------------------------------------------------------------------------
 # Stage 1: Frontend Builder
 # -----------------------------------------------------------------------------
 FROM ${NODE_IMAGE} AS frontend-builder
+ARG PNPM_VERSION
 
 WORKDIR /app/frontend
 
@@ -24,8 +26,9 @@ WORKDIR /app/frontend
 # Docker builders; otherwise vite can fail with an out-of-memory error.
 ENV NODE_OPTIONS=--max-old-space-size=4096
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Install the pnpm major version used by this lockfile. Avoid pnpm@latest here:
+# newer pnpm releases require interactive build-script approvals during Docker builds.
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 
 # Install dependencies first (better caching). Keep .npmrc with the lockfile so
 # pnpm honors the project's script policy for packages such as esbuild.

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ ENV NODE_OPTIONS=--max-old-space-size=4096
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Install dependencies first (better caching)
-COPY frontend/package.json frontend/pnpm-lock.yaml ./
+# Install dependencies first (better caching). Keep .npmrc with the lockfile so
+# pnpm honors the project's script policy for packages such as esbuild.
+COPY frontend/package.json frontend/pnpm-lock.yaml frontend/.npmrc ./
 RUN pnpm install --frozen-lockfile
 
 # Copy frontend source and build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ FROM ${NODE_IMAGE} AS frontend-builder
 
 WORKDIR /app/frontend
 
+# The admin frontend needs a larger V8 heap when built inside small CI/server
+# Docker builders; otherwise vite can fail with an out-of-memory error.
+ENV NODE_OPTIONS=--max-old-space-size=4096
+
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1087,6 +1087,7 @@ var (
 		{Name: "name", Type: field.TypeString, Size: 100},
 		{Name: "protocol", Type: field.TypeString, Size: 20},
 		{Name: "host", Type: field.TypeString, Size: 255},
+		{Name: "ip_version", Type: field.TypeString, Size: 10, Default: "ipv4"},
 		{Name: "port", Type: field.TypeInt},
 		{Name: "username", Type: field.TypeString, Nullable: true, Size: 100},
 		{Name: "password", Type: field.TypeString, Nullable: true, Size: 100},
@@ -1101,7 +1102,7 @@ var (
 			{
 				Name:    "proxy_status",
 				Unique:  false,
-				Columns: []*schema.Column{ProxiesColumns[10]},
+				Columns: []*schema.Column{ProxiesColumns[11]},
 			},
 			{
 				Name:    "proxy_deleted_at",

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -27599,6 +27599,7 @@ type ProxyMutation struct {
 	name            *string
 	protocol        *string
 	host            *string
+	ip_version      *string
 	port            *int
 	addport         *int
 	username        *string
@@ -27940,6 +27941,42 @@ func (m *ProxyMutation) ResetHost() {
 	m.host = nil
 }
 
+// SetIPVersion sets the "ip_version" field.
+func (m *ProxyMutation) SetIPVersion(s string) {
+	m.ip_version = &s
+}
+
+// IPVersion returns the value of the "ip_version" field in the mutation.
+func (m *ProxyMutation) IPVersion() (r string, exists bool) {
+	v := m.ip_version
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldIPVersion returns the old "ip_version" field's value of the Proxy entity.
+// If the Proxy object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ProxyMutation) OldIPVersion(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldIPVersion is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldIPVersion requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldIPVersion: %w", err)
+	}
+	return oldValue.IPVersion, nil
+}
+
+// ResetIPVersion resets all changes to the "ip_version" field.
+func (m *ProxyMutation) ResetIPVersion() {
+	m.ip_version = nil
+}
+
 // SetPort sets the "port" field.
 func (m *ProxyMutation) SetPort(i int) {
 	m.port = &i
@@ -28218,7 +28255,7 @@ func (m *ProxyMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ProxyMutation) Fields() []string {
-	fields := make([]string, 0, 10)
+	fields := make([]string, 0, 11)
 	if m.created_at != nil {
 		fields = append(fields, proxy.FieldCreatedAt)
 	}
@@ -28236,6 +28273,9 @@ func (m *ProxyMutation) Fields() []string {
 	}
 	if m.host != nil {
 		fields = append(fields, proxy.FieldHost)
+	}
+	if m.ip_version != nil {
+		fields = append(fields, proxy.FieldIPVersion)
 	}
 	if m.port != nil {
 		fields = append(fields, proxy.FieldPort)
@@ -28269,6 +28309,8 @@ func (m *ProxyMutation) Field(name string) (ent.Value, bool) {
 		return m.Protocol()
 	case proxy.FieldHost:
 		return m.Host()
+	case proxy.FieldIPVersion:
+		return m.IPVersion()
 	case proxy.FieldPort:
 		return m.Port()
 	case proxy.FieldUsername:
@@ -28298,6 +28340,8 @@ func (m *ProxyMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldProtocol(ctx)
 	case proxy.FieldHost:
 		return m.OldHost(ctx)
+	case proxy.FieldIPVersion:
+		return m.OldIPVersion(ctx)
 	case proxy.FieldPort:
 		return m.OldPort(ctx)
 	case proxy.FieldUsername:
@@ -28356,6 +28400,13 @@ func (m *ProxyMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetHost(v)
+		return nil
+	case proxy.FieldIPVersion:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetIPVersion(v)
 		return nil
 	case proxy.FieldPort:
 		v, ok := value.(int)
@@ -28487,6 +28538,9 @@ func (m *ProxyMutation) ResetField(name string) error {
 		return nil
 	case proxy.FieldHost:
 		m.ResetHost()
+		return nil
+	case proxy.FieldIPVersion:
+		m.ResetIPVersion()
 		return nil
 	case proxy.FieldPort:
 		m.ResetPort()

--- a/backend/ent/proxy.go
+++ b/backend/ent/proxy.go
@@ -29,6 +29,8 @@ type Proxy struct {
 	Protocol string `json:"protocol,omitempty"`
 	// Host holds the value of the "host" field.
 	Host string `json:"host,omitempty"`
+	// IPVersion holds the value of the "ip_version" field.
+	IPVersion string `json:"ip_version,omitempty"`
 	// Port holds the value of the "port" field.
 	Port int `json:"port,omitempty"`
 	// Username holds the value of the "username" field.
@@ -68,7 +70,7 @@ func (*Proxy) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case proxy.FieldID, proxy.FieldPort:
 			values[i] = new(sql.NullInt64)
-		case proxy.FieldName, proxy.FieldProtocol, proxy.FieldHost, proxy.FieldUsername, proxy.FieldPassword, proxy.FieldStatus:
+		case proxy.FieldName, proxy.FieldProtocol, proxy.FieldHost, proxy.FieldIPVersion, proxy.FieldUsername, proxy.FieldPassword, proxy.FieldStatus:
 			values[i] = new(sql.NullString)
 		case proxy.FieldCreatedAt, proxy.FieldUpdatedAt, proxy.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -129,6 +131,12 @@ func (_m *Proxy) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field host", values[i])
 			} else if value.Valid {
 				_m.Host = value.String
+			}
+		case proxy.FieldIPVersion:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field ip_version", values[i])
+			} else if value.Valid {
+				_m.IPVersion = value.String
 			}
 		case proxy.FieldPort:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
@@ -216,6 +224,9 @@ func (_m *Proxy) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("host=")
 	builder.WriteString(_m.Host)
+	builder.WriteString(", ")
+	builder.WriteString("ip_version=")
+	builder.WriteString(_m.IPVersion)
 	builder.WriteString(", ")
 	builder.WriteString("port=")
 	builder.WriteString(fmt.Sprintf("%v", _m.Port))

--- a/backend/ent/proxy/proxy.go
+++ b/backend/ent/proxy/proxy.go
@@ -27,6 +27,8 @@ const (
 	FieldProtocol = "protocol"
 	// FieldHost holds the string denoting the host field in the database.
 	FieldHost = "host"
+	// FieldIPVersion holds the string denoting the ip_version field in the database.
+	FieldIPVersion = "ip_version"
 	// FieldPort holds the string denoting the port field in the database.
 	FieldPort = "port"
 	// FieldUsername holds the string denoting the username field in the database.
@@ -57,6 +59,7 @@ var Columns = []string{
 	FieldName,
 	FieldProtocol,
 	FieldHost,
+	FieldIPVersion,
 	FieldPort,
 	FieldUsername,
 	FieldPassword,
@@ -93,6 +96,10 @@ var (
 	ProtocolValidator func(string) error
 	// HostValidator is a validator for the "host" field. It is called by the builders before save.
 	HostValidator func(string) error
+	// DefaultIPVersion holds the default value on creation for the "ip_version" field.
+	DefaultIPVersion string
+	// IPVersionValidator is a validator for the "ip_version" field. It is called by the builders before save.
+	IPVersionValidator func(string) error
 	// UsernameValidator is a validator for the "username" field. It is called by the builders before save.
 	UsernameValidator func(string) error
 	// PasswordValidator is a validator for the "password" field. It is called by the builders before save.
@@ -139,6 +146,11 @@ func ByProtocol(opts ...sql.OrderTermOption) OrderOption {
 // ByHost orders the results by the host field.
 func ByHost(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldHost, opts...).ToFunc()
+}
+
+// ByIPVersion orders the results by the ip_version field.
+func ByIPVersion(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldIPVersion, opts...).ToFunc()
 }
 
 // ByPort orders the results by the port field.

--- a/backend/ent/proxy/where.go
+++ b/backend/ent/proxy/where.go
@@ -85,6 +85,11 @@ func Host(v string) predicate.Proxy {
 	return predicate.Proxy(sql.FieldEQ(FieldHost, v))
 }
 
+// IPVersion applies equality check predicate on the "ip_version" field. It's identical to IPVersionEQ.
+func IPVersion(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldEQ(FieldIPVersion, v))
+}
+
 // Port applies equality check predicate on the "port" field. It's identical to PortEQ.
 func Port(v int) predicate.Proxy {
 	return predicate.Proxy(sql.FieldEQ(FieldPort, v))
@@ -428,6 +433,71 @@ func HostEqualFold(v string) predicate.Proxy {
 // HostContainsFold applies the ContainsFold predicate on the "host" field.
 func HostContainsFold(v string) predicate.Proxy {
 	return predicate.Proxy(sql.FieldContainsFold(FieldHost, v))
+}
+
+// IPVersionEQ applies the EQ predicate on the "ip_version" field.
+func IPVersionEQ(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldEQ(FieldIPVersion, v))
+}
+
+// IPVersionNEQ applies the NEQ predicate on the "ip_version" field.
+func IPVersionNEQ(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldNEQ(FieldIPVersion, v))
+}
+
+// IPVersionIn applies the In predicate on the "ip_version" field.
+func IPVersionIn(vs ...string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldIn(FieldIPVersion, vs...))
+}
+
+// IPVersionNotIn applies the NotIn predicate on the "ip_version" field.
+func IPVersionNotIn(vs ...string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldNotIn(FieldIPVersion, vs...))
+}
+
+// IPVersionGT applies the GT predicate on the "ip_version" field.
+func IPVersionGT(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldGT(FieldIPVersion, v))
+}
+
+// IPVersionGTE applies the GTE predicate on the "ip_version" field.
+func IPVersionGTE(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldGTE(FieldIPVersion, v))
+}
+
+// IPVersionLT applies the LT predicate on the "ip_version" field.
+func IPVersionLT(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldLT(FieldIPVersion, v))
+}
+
+// IPVersionLTE applies the LTE predicate on the "ip_version" field.
+func IPVersionLTE(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldLTE(FieldIPVersion, v))
+}
+
+// IPVersionContains applies the Contains predicate on the "ip_version" field.
+func IPVersionContains(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldContains(FieldIPVersion, v))
+}
+
+// IPVersionHasPrefix applies the HasPrefix predicate on the "ip_version" field.
+func IPVersionHasPrefix(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldHasPrefix(FieldIPVersion, v))
+}
+
+// IPVersionHasSuffix applies the HasSuffix predicate on the "ip_version" field.
+func IPVersionHasSuffix(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldHasSuffix(FieldIPVersion, v))
+}
+
+// IPVersionEqualFold applies the EqualFold predicate on the "ip_version" field.
+func IPVersionEqualFold(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldEqualFold(FieldIPVersion, v))
+}
+
+// IPVersionContainsFold applies the ContainsFold predicate on the "ip_version" field.
+func IPVersionContainsFold(v string) predicate.Proxy {
+	return predicate.Proxy(sql.FieldContainsFold(FieldIPVersion, v))
 }
 
 // PortEQ applies the EQ predicate on the "port" field.

--- a/backend/ent/proxy_create.go
+++ b/backend/ent/proxy_create.go
@@ -83,6 +83,20 @@ func (_c *ProxyCreate) SetHost(v string) *ProxyCreate {
 	return _c
 }
 
+// SetIPVersion sets the "ip_version" field.
+func (_c *ProxyCreate) SetIPVersion(v string) *ProxyCreate {
+	_c.mutation.SetIPVersion(v)
+	return _c
+}
+
+// SetNillableIPVersion sets the "ip_version" field if the given value is not nil.
+func (_c *ProxyCreate) SetNillableIPVersion(v *string) *ProxyCreate {
+	if v != nil {
+		_c.SetIPVersion(*v)
+	}
+	return _c
+}
+
 // SetPort sets the "port" field.
 func (_c *ProxyCreate) SetPort(v int) *ProxyCreate {
 	_c.mutation.SetPort(v)
@@ -197,6 +211,10 @@ func (_c *ProxyCreate) defaults() error {
 		v := proxy.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.IPVersion(); !ok {
+		v := proxy.DefaultIPVersion
+		_c.mutation.SetIPVersion(v)
+	}
 	if _, ok := _c.mutation.Status(); !ok {
 		v := proxy.DefaultStatus
 		_c.mutation.SetStatus(v)
@@ -234,6 +252,14 @@ func (_c *ProxyCreate) check() error {
 	if v, ok := _c.mutation.Host(); ok {
 		if err := proxy.HostValidator(v); err != nil {
 			return &ValidationError{Name: "host", err: fmt.Errorf(`ent: validator failed for field "Proxy.host": %w`, err)}
+		}
+	}
+	if _, ok := _c.mutation.IPVersion(); !ok {
+		return &ValidationError{Name: "ip_version", err: errors.New(`ent: missing required field "Proxy.ip_version"`)}
+	}
+	if v, ok := _c.mutation.IPVersion(); ok {
+		if err := proxy.IPVersionValidator(v); err != nil {
+			return &ValidationError{Name: "ip_version", err: fmt.Errorf(`ent: validator failed for field "Proxy.ip_version": %w`, err)}
 		}
 	}
 	if _, ok := _c.mutation.Port(); !ok {
@@ -307,6 +333,10 @@ func (_c *ProxyCreate) createSpec() (*Proxy, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Host(); ok {
 		_spec.SetField(proxy.FieldHost, field.TypeString, value)
 		_node.Host = value
+	}
+	if value, ok := _c.mutation.IPVersion(); ok {
+		_spec.SetField(proxy.FieldIPVersion, field.TypeString, value)
+		_node.IPVersion = value
 	}
 	if value, ok := _c.mutation.Port(); ok {
 		_spec.SetField(proxy.FieldPort, field.TypeInt, value)
@@ -455,6 +485,18 @@ func (u *ProxyUpsert) SetHost(v string) *ProxyUpsert {
 // UpdateHost sets the "host" field to the value that was provided on create.
 func (u *ProxyUpsert) UpdateHost() *ProxyUpsert {
 	u.SetExcluded(proxy.FieldHost)
+	return u
+}
+
+// SetIPVersion sets the "ip_version" field.
+func (u *ProxyUpsert) SetIPVersion(v string) *ProxyUpsert {
+	u.Set(proxy.FieldIPVersion, v)
+	return u
+}
+
+// UpdateIPVersion sets the "ip_version" field to the value that was provided on create.
+func (u *ProxyUpsert) UpdateIPVersion() *ProxyUpsert {
+	u.SetExcluded(proxy.FieldIPVersion)
 	return u
 }
 
@@ -643,6 +685,20 @@ func (u *ProxyUpsertOne) SetHost(v string) *ProxyUpsertOne {
 func (u *ProxyUpsertOne) UpdateHost() *ProxyUpsertOne {
 	return u.Update(func(s *ProxyUpsert) {
 		s.UpdateHost()
+	})
+}
+
+// SetIPVersion sets the "ip_version" field.
+func (u *ProxyUpsertOne) SetIPVersion(v string) *ProxyUpsertOne {
+	return u.Update(func(s *ProxyUpsert) {
+		s.SetIPVersion(v)
+	})
+}
+
+// UpdateIPVersion sets the "ip_version" field to the value that was provided on create.
+func (u *ProxyUpsertOne) UpdateIPVersion() *ProxyUpsertOne {
+	return u.Update(func(s *ProxyUpsert) {
+		s.UpdateIPVersion()
 	})
 }
 
@@ -1008,6 +1064,20 @@ func (u *ProxyUpsertBulk) SetHost(v string) *ProxyUpsertBulk {
 func (u *ProxyUpsertBulk) UpdateHost() *ProxyUpsertBulk {
 	return u.Update(func(s *ProxyUpsert) {
 		s.UpdateHost()
+	})
+}
+
+// SetIPVersion sets the "ip_version" field.
+func (u *ProxyUpsertBulk) SetIPVersion(v string) *ProxyUpsertBulk {
+	return u.Update(func(s *ProxyUpsert) {
+		s.SetIPVersion(v)
+	})
+}
+
+// UpdateIPVersion sets the "ip_version" field to the value that was provided on create.
+func (u *ProxyUpsertBulk) UpdateIPVersion() *ProxyUpsertBulk {
+	return u.Update(func(s *ProxyUpsert) {
+		s.UpdateIPVersion()
 	})
 }
 

--- a/backend/ent/proxy_update.go
+++ b/backend/ent/proxy_update.go
@@ -97,6 +97,20 @@ func (_u *ProxyUpdate) SetNillableHost(v *string) *ProxyUpdate {
 	return _u
 }
 
+// SetIPVersion sets the "ip_version" field.
+func (_u *ProxyUpdate) SetIPVersion(v string) *ProxyUpdate {
+	_u.mutation.SetIPVersion(v)
+	return _u
+}
+
+// SetNillableIPVersion sets the "ip_version" field if the given value is not nil.
+func (_u *ProxyUpdate) SetNillableIPVersion(v *string) *ProxyUpdate {
+	if v != nil {
+		_u.SetIPVersion(*v)
+	}
+	return _u
+}
+
 // SetPort sets the "port" field.
 func (_u *ProxyUpdate) SetPort(v int) *ProxyUpdate {
 	_u.mutation.ResetPort()
@@ -272,6 +286,11 @@ func (_u *ProxyUpdate) check() error {
 			return &ValidationError{Name: "host", err: fmt.Errorf(`ent: validator failed for field "Proxy.host": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.IPVersion(); ok {
+		if err := proxy.IPVersionValidator(v); err != nil {
+			return &ValidationError{Name: "ip_version", err: fmt.Errorf(`ent: validator failed for field "Proxy.ip_version": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Username(); ok {
 		if err := proxy.UsernameValidator(v); err != nil {
 			return &ValidationError{Name: "username", err: fmt.Errorf(`ent: validator failed for field "Proxy.username": %w`, err)}
@@ -319,6 +338,9 @@ func (_u *ProxyUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.Host(); ok {
 		_spec.SetField(proxy.FieldHost, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.IPVersion(); ok {
+		_spec.SetField(proxy.FieldIPVersion, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.Port(); ok {
 		_spec.SetField(proxy.FieldPort, field.TypeInt, value)
@@ -470,6 +492,20 @@ func (_u *ProxyUpdateOne) SetHost(v string) *ProxyUpdateOne {
 func (_u *ProxyUpdateOne) SetNillableHost(v *string) *ProxyUpdateOne {
 	if v != nil {
 		_u.SetHost(*v)
+	}
+	return _u
+}
+
+// SetIPVersion sets the "ip_version" field.
+func (_u *ProxyUpdateOne) SetIPVersion(v string) *ProxyUpdateOne {
+	_u.mutation.SetIPVersion(v)
+	return _u
+}
+
+// SetNillableIPVersion sets the "ip_version" field if the given value is not nil.
+func (_u *ProxyUpdateOne) SetNillableIPVersion(v *string) *ProxyUpdateOne {
+	if v != nil {
+		_u.SetIPVersion(*v)
 	}
 	return _u
 }
@@ -662,6 +698,11 @@ func (_u *ProxyUpdateOne) check() error {
 			return &ValidationError{Name: "host", err: fmt.Errorf(`ent: validator failed for field "Proxy.host": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.IPVersion(); ok {
+		if err := proxy.IPVersionValidator(v); err != nil {
+			return &ValidationError{Name: "ip_version", err: fmt.Errorf(`ent: validator failed for field "Proxy.ip_version": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Username(); ok {
 		if err := proxy.UsernameValidator(v); err != nil {
 			return &ValidationError{Name: "username", err: fmt.Errorf(`ent: validator failed for field "Proxy.username": %w`, err)}
@@ -726,6 +767,9 @@ func (_u *ProxyUpdateOne) sqlSave(ctx context.Context) (_node *Proxy, err error)
 	}
 	if value, ok := _u.mutation.Host(); ok {
 		_spec.SetField(proxy.FieldHost, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.IPVersion(); ok {
+		_spec.SetField(proxy.FieldIPVersion, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.Port(); ok {
 		_spec.SetField(proxy.FieldPort, field.TypeInt, value)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -1331,16 +1331,22 @@ func init() {
 			return nil
 		}
 	}()
+	// proxyDescIPVersion is the schema descriptor for ip_version field.
+	proxyDescIPVersion := proxyFields[3].Descriptor()
+	// proxy.DefaultIPVersion holds the default value on creation for the ip_version field.
+	proxy.DefaultIPVersion = proxyDescIPVersion.Default.(string)
+	// proxy.IPVersionValidator is a validator for the "ip_version" field. It is called by the builders before save.
+	proxy.IPVersionValidator = proxyDescIPVersion.Validators[0].(func(string) error)
 	// proxyDescUsername is the schema descriptor for username field.
-	proxyDescUsername := proxyFields[4].Descriptor()
+	proxyDescUsername := proxyFields[5].Descriptor()
 	// proxy.UsernameValidator is a validator for the "username" field. It is called by the builders before save.
 	proxy.UsernameValidator = proxyDescUsername.Validators[0].(func(string) error)
 	// proxyDescPassword is the schema descriptor for password field.
-	proxyDescPassword := proxyFields[5].Descriptor()
+	proxyDescPassword := proxyFields[6].Descriptor()
 	// proxy.PasswordValidator is a validator for the "password" field. It is called by the builders before save.
 	proxy.PasswordValidator = proxyDescPassword.Validators[0].(func(string) error)
 	// proxyDescStatus is the schema descriptor for status field.
-	proxyDescStatus := proxyFields[6].Descriptor()
+	proxyDescStatus := proxyFields[7].Descriptor()
 	// proxy.DefaultStatus holds the default value on creation for the status field.
 	proxy.DefaultStatus = proxyDescStatus.Default.(string)
 	// proxy.StatusValidator is a validator for the "status" field. It is called by the builders before save.

--- a/backend/ent/schema/proxy.go
+++ b/backend/ent/schema/proxy.go
@@ -40,6 +40,9 @@ func (Proxy) Fields() []ent.Field {
 		field.String("host").
 			MaxLen(255).
 			NotEmpty(),
+		field.String("ip_version").
+			MaxLen(10).
+			Default("ipv4"),
 		field.Int("port"),
 		field.String("username").
 			MaxLen(100).

--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -80,7 +80,34 @@ type DataImportError struct {
 }
 
 func buildProxyKey(protocol, host string, port int, username, password string) string {
-	return fmt.Sprintf("%s|%s|%d|%s|%s", strings.TrimSpace(protocol), strings.TrimSpace(host), port, strings.TrimSpace(username), strings.TrimSpace(password))
+	return fmt.Sprintf(
+		"%s|%s|%d|%s|%s",
+		strings.TrimSpace(protocol),
+		service.NormalizeProxyHost(host),
+		port,
+		strings.TrimSpace(username),
+		strings.TrimSpace(password),
+	)
+}
+
+func normalizeImportedProxyKey(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "|")
+	if len(parts) != 5 {
+		return raw
+	}
+	return buildProxyKey(parts[0], parts[1], mustAtoi(parts[2]), parts[3], parts[4])
+}
+
+func mustAtoi(raw string) int {
+	value, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0
+	}
+	return value
 }
 
 func (h *AccountHandler) ExportData(c *gin.Context) {
@@ -212,7 +239,7 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 
 	for i := range dataPayload.Proxies {
 		item := dataPayload.Proxies[i]
-		key := item.ProxyKey
+		key := normalizeImportedProxyKey(item.ProxyKey)
 		if key == "" {
 			key = buildProxyKey(item.Protocol, item.Host, item.Port, item.Username, item.Password)
 		}
@@ -284,15 +311,16 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 		}
 
 		var proxyID *int64
-		if item.ProxyKey != nil && *item.ProxyKey != "" {
-			if id, ok := proxyKeyToID[*item.ProxyKey]; ok {
+		if item.ProxyKey != nil && strings.TrimSpace(*item.ProxyKey) != "" {
+			normalizedProxyKey := normalizeImportedProxyKey(*item.ProxyKey)
+			if id, ok := proxyKeyToID[normalizedProxyKey]; ok {
 				proxyID = &id
 			} else {
 				result.AccountFailed++
 				result.Errors = append(result.Errors, DataImportError{
 					Kind:     "account",
 					Name:     item.Name,
-					ProxyKey: *item.ProxyKey,
+					ProxyKey: normalizedProxyKey,
 					Message:  "proxy_key not found",
 				})
 				continue

--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -37,6 +37,7 @@ type DataProxy struct {
 	Name     string `json:"name"`
 	Protocol string `json:"protocol"`
 	Host     string `json:"host"`
+	IPVersion string `json:"ip_version,omitempty"`
 	Port     int    `json:"port"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
@@ -153,6 +154,7 @@ func (h *AccountHandler) ExportData(c *gin.Context) {
 			Name:     p.Name,
 			Protocol: p.Protocol,
 			Host:     p.Host,
+			IPVersion: service.NormalizeProxyIPVersion(p.IPVersion),
 			Port:     p.Port,
 			Username: p.Username,
 			Password: p.Password,
@@ -257,11 +259,19 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 		if existingID, ok := proxyKeyToID[key]; ok {
 			proxyKeyToID[key] = existingID
 			result.ProxyReused++
-			if normalizedStatus != "" {
-				if proxy, getErr := h.adminService.GetProxy(ctx, existingID); getErr == nil && proxy != nil && proxy.Status != normalizedStatus {
-					_, _ = h.adminService.UpdateProxy(ctx, existingID, &service.UpdateProxyInput{
-						Status: normalizedStatus,
-					})
+			if proxy, getErr := h.adminService.GetProxy(ctx, existingID); getErr == nil && proxy != nil {
+				update := &service.UpdateProxyInput{}
+				if normalizedStatus != "" && proxy.Status != normalizedStatus {
+					update.Status = normalizedStatus
+				}
+				if item.IPVersion != "" {
+					normalizedIPVersion := service.NormalizeProxyIPVersion(item.IPVersion)
+					if normalizedIPVersion != service.NormalizeProxyIPVersion(proxy.IPVersion) {
+						update.IPVersion = normalizedIPVersion
+					}
+				}
+				if update.Status != "" || update.IPVersion != "" {
+					_, _ = h.adminService.UpdateProxy(ctx, existingID, update)
 				}
 			}
 			continue
@@ -271,6 +281,7 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 			Name:     defaultProxyName(item.Name),
 			Protocol: item.Protocol,
 			Host:     item.Host,
+			IPVersion: item.IPVersion,
 			Port:     item.Port,
 			Username: item.Username,
 			Password: item.Password,
@@ -569,6 +580,13 @@ func validateDataProxy(item DataProxy) error {
 		normalizedStatus := normalizeProxyStatus(item.Status)
 		if normalizedStatus != service.StatusActive && normalizedStatus != "inactive" {
 			return fmt.Errorf("proxy status is invalid: %s", item.Status)
+		}
+	}
+	if item.IPVersion != "" {
+		switch strings.ToLower(strings.TrimSpace(item.IPVersion)) {
+		case service.ProxyIPVersionIPv4, service.ProxyIPVersionIPv6:
+		default:
+			return fmt.Errorf("proxy ip_version is invalid: %s", item.IPVersion)
 		}
 	}
 	return nil

--- a/backend/internal/handler/admin/account_data_handler_test.go
+++ b/backend/internal/handler/admin/account_data_handler_test.go
@@ -275,3 +275,63 @@ func TestImportDataReusesProxyAndSkipsDefaultGroup(t *testing.T) {
 	require.Len(t, adminSvc.createdAccounts, 1)
 	require.True(t, adminSvc.createdAccounts[0].SkipDefaultGroupBind)
 }
+
+func TestImportDataReusesIPv6ProxyKeyAcrossBracketFormats(t *testing.T) {
+	router, adminSvc := setupAccountDataRouter()
+
+	adminSvc.proxies = []service.Proxy{
+		{
+			ID:       1,
+			Name:     "ipv6-proxy",
+			Protocol: "socks5",
+			Host:     "2001:db8::1",
+			Port:     1080,
+			Username: "u",
+			Password: "p",
+			Status:   service.StatusActive,
+		},
+	}
+
+	dataPayload := map[string]any{
+		"data": map[string]any{
+			"type":    dataType,
+			"version": dataVersion,
+			"proxies": []map[string]any{
+				{
+					"proxy_key": "socks5|[2001:db8::1]|1080|u|p",
+					"name":      "ipv6-proxy",
+					"protocol":  "socks5",
+					"host":      "[2001:db8::1]",
+					"port":      1080,
+					"username":  "u",
+					"password":  "p",
+					"status":    "active",
+				},
+			},
+			"accounts": []map[string]any{
+				{
+					"name":        "ipv6-account",
+					"platform":    service.PlatformOpenAI,
+					"type":        service.AccountTypeOAuth,
+					"credentials": map[string]any{"token": "x"},
+					"proxy_key":   "socks5|[2001:db8::1]|1080|u|p",
+					"concurrency": 3,
+					"priority":    50,
+				},
+			},
+		},
+		"skip_default_group_bind": true,
+	}
+
+	body, _ := json.Marshal(dataPayload)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/data", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, adminSvc.createdProxies, 0)
+	require.Len(t, adminSvc.createdAccounts, 1)
+	require.NotNil(t, adminSvc.createdAccounts[0].ProxyID)
+	require.Equal(t, int64(1), *adminSvc.createdAccounts[0].ProxyID)
+}

--- a/backend/internal/handler/admin/admin_basic_handlers_test.go
+++ b/backend/internal/handler/admin/admin_basic_handlers_test.go
@@ -271,6 +271,28 @@ func TestProxyHandlerEndpoints(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestProxyHandlerCreateNormalizesIPv6Host(t *testing.T) {
+	router, adminSvc := setupAdminRouter()
+
+	body, _ := json.Marshal(map[string]any{
+		"name":     "ipv6-proxy",
+		"protocol": "socks5",
+		"host":     "[2001:db8::1]",
+		"port":     1080,
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	adminSvc.mu.Lock()
+	defer adminSvc.mu.Unlock()
+	require.Len(t, adminSvc.createdProxies, 1)
+	require.Equal(t, "2001:db8::1", adminSvc.createdProxies[0].Host)
+}
+
 func TestRedeemHandlerEndpoints(t *testing.T) {
 	router, _ := setupAdminRouter()
 

--- a/backend/internal/handler/admin/admin_basic_handlers_test.go
+++ b/backend/internal/handler/admin/admin_basic_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -278,6 +279,7 @@ func TestProxyHandlerCreateNormalizesIPv6Host(t *testing.T) {
 		"name":     "ipv6-proxy",
 		"protocol": "socks5",
 		"host":     "[2001:db8::1]",
+		"ip_version": "ipv6",
 		"port":     1080,
 	})
 
@@ -291,6 +293,7 @@ func TestProxyHandlerCreateNormalizesIPv6Host(t *testing.T) {
 	defer adminSvc.mu.Unlock()
 	require.Len(t, adminSvc.createdProxies, 1)
 	require.Equal(t, "2001:db8::1", adminSvc.createdProxies[0].Host)
+	require.Equal(t, service.ProxyIPVersionIPv6, adminSvc.createdProxies[0].IPVersion)
 }
 
 func TestRedeemHandlerEndpoints(t *testing.T) {

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -452,6 +452,7 @@ func (s *stubAdminService) GetProxiesByIDs(ctx context.Context, ids []int64) ([]
 }
 
 func (s *stubAdminService) CreateProxy(ctx context.Context, input *service.CreateProxyInput) (*service.Proxy, error) {
+	input.Host = service.NormalizeProxyHost(input.Host)
 	s.mu.Lock()
 	s.createdProxies = append(s.createdProxies, input)
 	s.mu.Unlock()

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -456,7 +456,7 @@ func (s *stubAdminService) CreateProxy(ctx context.Context, input *service.Creat
 	s.mu.Lock()
 	s.createdProxies = append(s.createdProxies, input)
 	s.mu.Unlock()
-	proxy := service.Proxy{ID: 400, Name: input.Name, Status: service.StatusActive}
+	proxy := service.Proxy{ID: 400, Name: input.Name, Host: input.Host, IPVersion: service.NormalizeProxyIPVersion(input.IPVersion), Status: service.StatusActive}
 	return &proxy, nil
 }
 
@@ -465,7 +465,7 @@ func (s *stubAdminService) UpdateProxy(ctx context.Context, id int64, input *ser
 	s.updatedProxyIDs = append(s.updatedProxyIDs, id)
 	s.updatedProxies = append(s.updatedProxies, input)
 	s.mu.Unlock()
-	proxy := service.Proxy{ID: id, Name: input.Name, Status: service.StatusActive}
+	proxy := service.Proxy{ID: id, Name: input.Name, IPVersion: service.NormalizeProxyIPVersion(input.IPVersion), Status: service.StatusActive}
 	return &proxy, nil
 }
 

--- a/backend/internal/handler/admin/proxy_data.go
+++ b/backend/internal/handler/admin/proxy_data.go
@@ -107,7 +107,7 @@ func (h *ProxyHandler) ImportData(c *gin.Context) {
 	latencyProbeIDs := make([]int64, 0, len(req.Data.Proxies))
 	for i := range req.Data.Proxies {
 		item := req.Data.Proxies[i]
-		key := item.ProxyKey
+		key := normalizeImportedProxyKey(item.ProxyKey)
 		if key == "" {
 			key = buildProxyKey(item.Protocol, item.Host, item.Port, item.Username, item.Password)
 		}

--- a/backend/internal/handler/admin/proxy_data.go
+++ b/backend/internal/handler/admin/proxy_data.go
@@ -55,6 +55,7 @@ func (h *ProxyHandler) ExportData(c *gin.Context) {
 			Name:     p.Name,
 			Protocol: p.Protocol,
 			Host:     p.Host,
+			IPVersion: service.NormalizeProxyIPVersion(p.IPVersion),
 			Port:     p.Port,
 			Username: p.Username,
 			Password: p.Password,
@@ -126,13 +127,23 @@ func (h *ProxyHandler) ImportData(c *gin.Context) {
 		normalizedStatus := normalizeProxyStatus(item.Status)
 		if existing, ok := proxyByKey[key]; ok {
 			result.ProxyReused++
+			update := &service.UpdateProxyInput{}
 			if normalizedStatus != "" && normalizedStatus != existing.Status {
-				if _, err := h.adminService.UpdateProxy(ctx, existing.ID, &service.UpdateProxyInput{Status: normalizedStatus}); err != nil {
+				update.Status = normalizedStatus
+			}
+			if item.IPVersion != "" {
+				normalizedIPVersion := service.NormalizeProxyIPVersion(item.IPVersion)
+				if normalizedIPVersion != service.NormalizeProxyIPVersion(existing.IPVersion) {
+					update.IPVersion = normalizedIPVersion
+				}
+			}
+			if update.Status != "" || update.IPVersion != "" {
+				if _, err := h.adminService.UpdateProxy(ctx, existing.ID, update); err != nil {
 					result.Errors = append(result.Errors, DataImportError{
 						Kind:     "proxy",
 						Name:     item.Name,
 						ProxyKey: key,
-						Message:  "update status failed: " + err.Error(),
+						Message:  "update proxy failed: " + err.Error(),
 					})
 				}
 			}
@@ -144,6 +155,7 @@ func (h *ProxyHandler) ImportData(c *gin.Context) {
 			Name:     defaultProxyName(item.Name),
 			Protocol: item.Protocol,
 			Host:     item.Host,
+			IPVersion: item.IPVersion,
 			Port:     item.Port,
 			Username: item.Username,
 			Password: item.Password,

--- a/backend/internal/handler/admin/proxy_data_handler_test.go
+++ b/backend/internal/handler/admin/proxy_data_handler_test.go
@@ -280,3 +280,113 @@ func TestProxyImportDataReusesAndTriggersLatencyProbe(t *testing.T) {
 		return len(adminSvc.testedProxyIDs) == 1
 	}, time.Second, 10*time.Millisecond)
 }
+
+func TestProxyImportDataReusesIPv6ProxyAcrossBracketFormats(t *testing.T) {
+	router, adminSvc := setupProxyDataRouter()
+
+	adminSvc.proxies = []service.Proxy{
+		{
+			ID:       1,
+			Name:     "ipv6-existing",
+			Protocol: "socks5",
+			Host:     "2001:db8::1",
+			Port:     1080,
+			Username: "u",
+			Password: "p",
+			Status:   service.StatusActive,
+		},
+	}
+
+	payload := map[string]any{
+		"data": map[string]any{
+			"type":    dataType,
+			"version": dataVersion,
+			"proxies": []map[string]any{
+				{
+					"proxy_key": "socks5|[2001:db8::1]|1080|u|p",
+					"name":      "ipv6-existing",
+					"protocol":  "socks5",
+					"host":      "[2001:db8::1]",
+					"port":      1080,
+					"username":  "u",
+					"password":  "p",
+					"status":    "active",
+				},
+			},
+			"accounts": []map[string]any{},
+		},
+	}
+
+	body, _ := json.Marshal(payload)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/data", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp proxyImportResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, 0, resp.Data.ProxyCreated)
+	require.Equal(t, 1, resp.Data.ProxyReused)
+	require.Equal(t, 0, resp.Data.ProxyFailed)
+
+	adminSvc.mu.Lock()
+	defer adminSvc.mu.Unlock()
+	require.Len(t, adminSvc.createdProxies, 0)
+}
+
+func TestProxyImportDataReusesIPv6ProxyWhenKeyOnlyUsesBracketedHost(t *testing.T) {
+	router, adminSvc := setupProxyDataRouter()
+
+	adminSvc.proxies = []service.Proxy{
+		{
+			ID:       1,
+			Name:     "ipv6-existing",
+			Protocol: "socks5",
+			Host:     "2001:db8::2",
+			Port:     1080,
+			Username: "u",
+			Password: "p",
+			Status:   service.StatusActive,
+		},
+	}
+
+	payload := map[string]any{
+		"data": map[string]any{
+			"type":    dataType,
+			"version": dataVersion,
+			"proxies": []map[string]any{
+				{
+					"proxy_key": "socks5|[2001:db8::2]|1080|u|p",
+					"name":      "ipv6-existing",
+					"protocol":  "socks5",
+					"host":      "2001:db8::2",
+					"port":      1080,
+					"username":  "u",
+					"password":  "p",
+					"status":    "active",
+				},
+			},
+			"accounts": []map[string]any{},
+		},
+	}
+
+	body, _ := json.Marshal(payload)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/proxies/data", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var resp proxyImportResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, 0, resp.Code)
+	require.Equal(t, 0, resp.Data.ProxyCreated)
+	require.Equal(t, 1, resp.Data.ProxyReused)
+	require.Equal(t, 0, resp.Data.ProxyFailed)
+
+	adminSvc.mu.Lock()
+	defer adminSvc.mu.Unlock()
+	require.Len(t, adminSvc.createdProxies, 0)
+}

--- a/backend/internal/handler/admin/proxy_data_handler_test.go
+++ b/backend/internal/handler/admin/proxy_data_handler_test.go
@@ -54,6 +54,7 @@ func TestProxyExportDataRespectsFilters(t *testing.T) {
 			Name:     "proxy-b",
 			Protocol: "https",
 			Host:     "10.0.0.2",
+			IPVersion: service.ProxyIPVersionIPv6,
 			Port:     443,
 			Username: "u",
 			Password: "p",
@@ -74,6 +75,7 @@ func TestProxyExportDataRespectsFilters(t *testing.T) {
 	require.Len(t, resp.Data.Proxies, 1)
 	require.Len(t, resp.Data.Accounts, 0)
 	require.Equal(t, "https", resp.Data.Proxies[0].Protocol)
+	require.Equal(t, service.ProxyIPVersionIPv6, resp.Data.Proxies[0].IPVersion)
 	require.Equal(t, 1, adminSvc.lastListProxies.calls)
 	require.Equal(t, "https", adminSvc.lastListProxies.protocol)
 	require.Equal(t, "id", adminSvc.lastListProxies.sortBy)
@@ -245,6 +247,7 @@ func TestProxyImportDataReusesAndTriggersLatencyProbe(t *testing.T) {
 					"name":      "proxy-b",
 					"protocol":  "https",
 					"host":      "10.0.0.2",
+					"ip_version": "ipv6",
 					"port":      443,
 					"username":  "u",
 					"password":  "p",
@@ -268,6 +271,8 @@ func TestProxyImportDataReusesAndTriggersLatencyProbe(t *testing.T) {
 	require.Equal(t, 1, resp.Data.ProxyCreated)
 	require.Equal(t, 1, resp.Data.ProxyReused)
 	require.Equal(t, 0, resp.Data.ProxyFailed)
+	require.Len(t, adminSvc.createdProxies, 1)
+	require.Equal(t, service.ProxyIPVersionIPv6, adminSvc.createdProxies[0].IPVersion)
 
 	adminSvc.mu.Lock()
 	updatedIDs := append([]int64(nil), adminSvc.updatedProxyIDs...)

--- a/backend/internal/handler/admin/proxy_handler.go
+++ b/backend/internal/handler/admin/proxy_handler.go
@@ -29,6 +29,7 @@ type CreateProxyRequest struct {
 	Name     string `json:"name" binding:"required"`
 	Protocol string `json:"protocol" binding:"required,oneof=http https socks5 socks5h"`
 	Host     string `json:"host" binding:"required"`
+	IPVersion string `json:"ip_version" binding:"omitempty,oneof=ipv4 ipv6"`
 	Port     int    `json:"port" binding:"required,min=1,max=65535"`
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -39,6 +40,7 @@ type UpdateProxyRequest struct {
 	Name     string `json:"name"`
 	Protocol string `json:"protocol" binding:"omitempty,oneof=http https socks5 socks5h"`
 	Host     string `json:"host"`
+	IPVersion string `json:"ip_version" binding:"omitempty,oneof=ipv4 ipv6"`
 	Port     int    `json:"port" binding:"omitempty,min=1,max=65535"`
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -138,6 +140,7 @@ func (h *ProxyHandler) Create(c *gin.Context) {
 			Name:     strings.TrimSpace(req.Name),
 			Protocol: strings.TrimSpace(req.Protocol),
 			Host:     strings.TrimSpace(req.Host),
+			IPVersion: strings.TrimSpace(req.IPVersion),
 			Port:     req.Port,
 			Username: strings.TrimSpace(req.Username),
 			Password: strings.TrimSpace(req.Password),
@@ -168,6 +171,7 @@ func (h *ProxyHandler) Update(c *gin.Context) {
 		Name:     strings.TrimSpace(req.Name),
 		Protocol: strings.TrimSpace(req.Protocol),
 		Host:     strings.TrimSpace(req.Host),
+		IPVersion: strings.TrimSpace(req.IPVersion),
 		Port:     req.Port,
 		Username: strings.TrimSpace(req.Username),
 		Password: strings.TrimSpace(req.Password),
@@ -303,6 +307,7 @@ func (h *ProxyHandler) GetProxyAccounts(c *gin.Context) {
 type BatchCreateProxyItem struct {
 	Protocol string `json:"protocol" binding:"required,oneof=http https socks5 socks5h"`
 	Host     string `json:"host" binding:"required"`
+	IPVersion string `json:"ip_version" binding:"omitempty,oneof=ipv4 ipv6"`
 	Port     int    `json:"port" binding:"required,min=1,max=65535"`
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -329,6 +334,7 @@ func (h *ProxyHandler) BatchCreate(c *gin.Context) {
 		// Trim all string fields
 		host := strings.TrimSpace(item.Host)
 		protocol := strings.TrimSpace(item.Protocol)
+		ipVersion := strings.TrimSpace(item.IPVersion)
 		username := strings.TrimSpace(item.Username)
 		password := strings.TrimSpace(item.Password)
 
@@ -349,6 +355,7 @@ func (h *ProxyHandler) BatchCreate(c *gin.Context) {
 			Name:     "default",
 			Protocol: protocol,
 			Host:     host,
+			IPVersion: ipVersion,
 			Port:     item.Port,
 			Username: username,
 			Password: password,

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -412,6 +412,7 @@ func ProxyFromService(p *service.Proxy) *Proxy {
 		Name:      p.Name,
 		Protocol:  p.Protocol,
 		Host:      p.Host,
+		IPVersion: service.NormalizeProxyIPVersion(p.IPVersion),
 		Port:      p.Port,
 		Username:  p.Username,
 		Status:    p.Status,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -266,6 +266,7 @@ type Proxy struct {
 	Name      string    `json:"name"`
 	Protocol  string    `json:"protocol"`
 	Host      string    `json:"host"`
+	IPVersion string    `json:"ip_version"`
 	Port      int       `json:"port"`
 	Username  string    `json:"username"`
 	Password  string    `json:"-"`

--- a/backend/internal/repository/proxy_probe_service.go
+++ b/backend/internal/repository/proxy_probe_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -44,14 +45,21 @@ const (
 	defaultProxyProbeResponseMaxBytes = int64(1024 * 1024)
 )
 
+type probeEndpoint struct {
+	url    string
+	parser string
+}
+
 // probeURLs 按优先级排列的探测 URL 列表
 // 某些 AI API 专用代理只允许访问特定域名，因此需要多个备选
-var probeURLs = []struct {
-	url    string
-	parser string // "ip-api" or "httpbin"
-}{
+var ipv4ProbeURLs = []probeEndpoint{
 	{"http://ip-api.com/json/?lang=zh-CN", "ip-api"},
 	{"http://httpbin.org/ip", "httpbin"},
+}
+
+var ipv6ProbeURLs = []probeEndpoint{
+	{"http://api6.ipify.org?format=json", "ipify"},
+	{"http://api64.ipify.org?format=json", "ipify"},
 }
 
 type proxyProbeService struct {
@@ -61,7 +69,7 @@ type proxyProbeService struct {
 	maxResponseBytes   int64
 }
 
-func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*service.ProxyExitInfo, int64, error) {
+func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string, ipVersion ...string) (*service.ProxyExitInfo, int64, error) {
 	client, err := httpclient.GetClient(httpclient.Options{
 		ProxyURL:           proxyURL,
 		Timeout:            defaultProxyProbeTimeout,
@@ -73,10 +81,23 @@ func (s *proxyProbeService) ProbeProxy(ctx context.Context, proxyURL string) (*s
 		return nil, 0, fmt.Errorf("failed to create proxy client: %w", err)
 	}
 
+	targetIPVersion := service.ProxyIPVersionIPv4
+	if len(ipVersion) > 0 {
+		targetIPVersion = service.NormalizeProxyIPVersion(ipVersion[0])
+	}
+	probes := ipv4ProbeURLs
+	if targetIPVersion == service.ProxyIPVersionIPv6 {
+		probes = ipv6ProbeURLs
+	}
+
 	var lastErr error
-	for _, probe := range probeURLs {
+	for _, probe := range probes {
 		exitInfo, latencyMs, err := s.probeWithURL(ctx, client, probe.url, probe.parser)
 		if err == nil {
+			if targetIPVersion == service.ProxyIPVersionIPv6 && !isIPv6Address(exitInfo.IP) {
+				lastErr = fmt.Errorf("probe returned non-IPv6 exit IP: %s", exitInfo.IP)
+				continue
+			}
 			return exitInfo, latencyMs, nil
 		}
 		lastErr = err
@@ -121,6 +142,8 @@ func (s *proxyProbeService) probeWithURL(ctx context.Context, client *http.Clien
 		return s.parseIPAPI(body, latencyMs)
 	case "httpbin":
 		return s.parseHTTPBin(body, latencyMs)
+	case "ipify":
+		return s.parseIPify(body, latencyMs)
 	default:
 		return nil, latencyMs, fmt.Errorf("unknown parser: %s", parser)
 	}
@@ -179,4 +202,24 @@ func (s *proxyProbeService) parseHTTPBin(body []byte, latencyMs int64) (*service
 	return &service.ProxyExitInfo{
 		IP: result.Origin,
 	}, latencyMs, nil
+}
+
+func (s *proxyProbeService) parseIPify(body []byte, latencyMs int64) (*service.ProxyExitInfo, int64, error) {
+	var result struct {
+		IP string `json:"ip"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, latencyMs, fmt.Errorf("failed to parse ipify response: %w", err)
+	}
+	if strings.TrimSpace(result.IP) == "" {
+		return nil, latencyMs, fmt.Errorf("ipify: no IP found in response")
+	}
+	return &service.ProxyExitInfo{
+		IP: strings.TrimSpace(result.IP),
+	}, latencyMs, nil
+}
+
+func isIPv6Address(value string) bool {
+	ip := net.ParseIP(strings.TrimSpace(value))
+	return ip != nil && ip.To4() == nil
 }

--- a/backend/internal/repository/proxy_probe_service_test.go
+++ b/backend/internal/repository/proxy_probe_service_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -69,6 +70,25 @@ func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_IPAPI() {
 	require.Equal(s.T(), "r", info.Region)
 	require.Equal(s.T(), "cc", info.Country)
 	require.Equal(s.T(), "CC", info.CountryCode)
+}
+
+func (s *ProxyProbeServiceSuite) TestProbeProxy_IPv6UsesIPv6ProbeEndpoint() {
+	var sawIPv6Endpoint bool
+	s.setupProxyServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "api6.ipify.org") {
+			sawIPv6Endpoint = true
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, `{"ip":"2001:db8::7"}`)
+			return
+		}
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	info, latencyMs, err := s.prober.ProbeProxy(s.ctx, s.proxySrv.URL, service.ProxyIPVersionIPv6)
+	require.NoError(s.T(), err, "ProbeProxy should use IPv6 probe endpoint")
+	require.GreaterOrEqual(s.T(), latencyMs, int64(0), "unexpected latency")
+	require.True(s.T(), sawIPv6Endpoint)
+	require.Equal(s.T(), "2001:db8::7", info.IP)
 }
 
 func (s *ProxyProbeServiceSuite) TestProbeProxy_Success_HTTPBinFallback() {

--- a/backend/internal/repository/proxy_repo.go
+++ b/backend/internal/repository/proxy_repo.go
@@ -37,6 +37,7 @@ func (r *proxyRepository) Create(ctx context.Context, proxyIn *service.Proxy) er
 		SetName(proxyIn.Name).
 		SetProtocol(proxyIn.Protocol).
 		SetHost(proxyIn.Host).
+		SetIPVersion(service.NormalizeProxyIPVersion(proxyIn.IPVersion)).
 		SetPort(proxyIn.Port).
 		SetStatus(proxyIn.Status)
 	if proxyIn.Username != "" {
@@ -88,6 +89,7 @@ func (r *proxyRepository) Update(ctx context.Context, proxyIn *service.Proxy) er
 		SetName(proxyIn.Name).
 		SetProtocol(proxyIn.Protocol).
 		SetHost(proxyIn.Host).
+		SetIPVersion(service.NormalizeProxyIPVersion(proxyIn.IPVersion)).
 		SetPort(proxyIn.Port).
 		SetStatus(proxyIn.Status)
 	if proxyIn.Username != "" {
@@ -421,6 +423,7 @@ func proxyEntityToService(m *dbent.Proxy) *service.Proxy {
 		Name:      m.Name,
 		Protocol:  m.Protocol,
 		Host:      m.Host,
+		IPVersion: service.NormalizeProxyIPVersion(m.IPVersion),
 		Port:      m.Port,
 		Status:    m.Status,
 		CreatedAt: m.CreatedAt,
@@ -440,6 +443,7 @@ func applyProxyEntityToService(dst *service.Proxy, src *dbent.Proxy) {
 		return
 	}
 	dst.ID = src.ID
+	dst.IPVersion = service.NormalizeProxyIPVersion(src.IPVersion)
 	dst.CreatedAt = src.CreatedAt
 	dst.UpdatedAt = src.UpdatedAt
 }

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -376,6 +376,7 @@ type CreateProxyInput struct {
 	Name     string
 	Protocol string
 	Host     string
+	IPVersion string
 	Port     int
 	Username string
 	Password string
@@ -385,6 +386,7 @@ type UpdateProxyInput struct {
 	Name     string
 	Protocol string
 	Host     string
+	IPVersion string
 	Port     int
 	Username string
 	Password string
@@ -458,7 +460,7 @@ type ProxyExitInfo struct {
 
 // ProxyExitInfoProber tests proxy connectivity and retrieves exit information
 type ProxyExitInfoProber interface {
-	ProbeProxy(ctx context.Context, proxyURL string) (*ProxyExitInfo, int64, error)
+	ProbeProxy(ctx context.Context, proxyURL string, ipVersion ...string) (*ProxyExitInfo, int64, error)
 }
 
 type groupExistenceBatchReader interface {
@@ -2850,6 +2852,7 @@ func (s *adminServiceImpl) CreateProxy(ctx context.Context, input *CreateProxyIn
 		Name:     input.Name,
 		Protocol: input.Protocol,
 		Host:     NormalizeProxyHost(input.Host),
+		IPVersion: NormalizeProxyIPVersion(input.IPVersion),
 		Port:     input.Port,
 		Username: input.Username,
 		Password: input.Password,
@@ -2877,6 +2880,9 @@ func (s *adminServiceImpl) UpdateProxy(ctx context.Context, id int64, input *Upd
 	}
 	if input.Host != "" {
 		proxy.Host = NormalizeProxyHost(input.Host)
+	}
+	if input.IPVersion != "" {
+		proxy.IPVersion = NormalizeProxyIPVersion(input.IPVersion)
 	}
 	if input.Port != 0 {
 		proxy.Port = input.Port
@@ -3042,7 +3048,7 @@ func (s *adminServiceImpl) TestProxy(ctx context.Context, id int64) (*ProxyTestR
 	}
 
 	proxyURL := proxy.URL()
-	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxyURL)
+	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxyURL, proxy.IPVersion)
 	if err != nil {
 		s.saveProxyLatency(ctx, id, &ProxyLatencyInfo{
 			Success:   false,
@@ -3106,7 +3112,7 @@ func (s *adminServiceImpl) CheckProxyQuality(ctx context.Context, id int64) (*Pr
 		return result, nil
 	}
 
-	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxyURL)
+	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxyURL, proxy.IPVersion)
 	if err != nil {
 		result.Items = append(result.Items, ProxyQualityCheckItem{
 			Target:    "base_connectivity",
@@ -3347,7 +3353,7 @@ func (s *adminServiceImpl) probeProxyLatency(ctx context.Context, proxy *Proxy) 
 	if s.proxyProber == nil || proxy == nil {
 		return
 	}
-	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxy.URL())
+	exitInfo, latencyMs, err := s.proxyProber.ProbeProxy(ctx, proxy.URL(), proxy.IPVersion)
 	if err != nil {
 		s.saveProxyLatency(ctx, proxy.ID, &ProxyLatencyInfo{
 			Success:   false,

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -2849,7 +2849,7 @@ func (s *adminServiceImpl) CreateProxy(ctx context.Context, input *CreateProxyIn
 	proxy := &Proxy{
 		Name:     input.Name,
 		Protocol: input.Protocol,
-		Host:     input.Host,
+		Host:     NormalizeProxyHost(input.Host),
 		Port:     input.Port,
 		Username: input.Username,
 		Password: input.Password,
@@ -2876,7 +2876,7 @@ func (s *adminServiceImpl) UpdateProxy(ctx context.Context, id int64, input *Upd
 		proxy.Protocol = input.Protocol
 	}
 	if input.Host != "" {
-		proxy.Host = input.Host
+		proxy.Host = NormalizeProxyHost(input.Host)
 	}
 	if input.Port != 0 {
 		proxy.Port = input.Port
@@ -2948,7 +2948,7 @@ func (s *adminServiceImpl) GetProxyAccounts(ctx context.Context, proxyID int64) 
 }
 
 func (s *adminServiceImpl) CheckProxyExists(ctx context.Context, host string, port int, username, password string) (bool, error) {
-	return s.proxyRepo.ExistsByHostPortAuth(ctx, host, port, username, password)
+	return s.proxyRepo.ExistsByHostPortAuth(ctx, NormalizeProxyHost(host), port, username, password)
 }
 
 // Redeem code management implementations

--- a/backend/internal/service/proxy.go
+++ b/backend/internal/service/proxy.go
@@ -27,7 +27,7 @@ func (p *Proxy) IsActive() bool {
 func (p *Proxy) URL() string {
 	u := &url.URL{
 		Scheme: p.Protocol,
-		Host:   net.JoinHostPort(p.Host, strconv.Itoa(p.Port)),
+		Host:   net.JoinHostPort(NormalizeProxyHost(p.Host), strconv.Itoa(p.Port)),
 	}
 	if p.Username != "" && p.Password != "" {
 		u.User = url.UserPassword(p.Username, p.Password)

--- a/backend/internal/service/proxy.go
+++ b/backend/internal/service/proxy.go
@@ -12,6 +12,7 @@ type Proxy struct {
 	Name      string
 	Protocol  string
 	Host      string
+	IPVersion string
 	Port      int
 	Username  string
 	Password  string

--- a/backend/internal/service/proxy_host.go
+++ b/backend/internal/service/proxy_host.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 )
 
+const (
+	ProxyIPVersionIPv4 = "ipv4"
+	ProxyIPVersionIPv6 = "ipv6"
+)
+
 // NormalizeProxyHost strips IPv6 brackets and surrounding whitespace so the
 // persisted host value stays canonical across UI, import, and API paths.
 func NormalizeProxyHost(host string) string {
@@ -26,4 +31,13 @@ func NormalizeProxyHost(host string) string {
 // automatically adding IPv6 brackets when needed.
 func FormatProxyHostPort(host string, port int) string {
 	return net.JoinHostPort(NormalizeProxyHost(host), strconv.Itoa(port))
+}
+
+func NormalizeProxyIPVersion(ipVersion string) string {
+	switch strings.ToLower(strings.TrimSpace(ipVersion)) {
+	case ProxyIPVersionIPv6:
+		return ProxyIPVersionIPv6
+	default:
+		return ProxyIPVersionIPv4
+	}
 }

--- a/backend/internal/service/proxy_host.go
+++ b/backend/internal/service/proxy_host.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"net"
+	"strconv"
+	"strings"
+)
+
+// NormalizeProxyHost strips IPv6 brackets and surrounding whitespace so the
+// persisted host value stays canonical across UI, import, and API paths.
+func NormalizeProxyHost(host string) string {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return ""
+	}
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		inner := strings.TrimSpace(trimmed[1 : len(trimmed)-1])
+		if inner != "" && strings.Contains(inner, ":") {
+			return inner
+		}
+	}
+	return trimmed
+}
+
+// FormatProxyHostPort formats host:port for display and URL generation,
+// automatically adding IPv6 brackets when needed.
+func FormatProxyHostPort(host string, port int) string {
+	return net.JoinHostPort(NormalizeProxyHost(host), strconv.Itoa(port))
+}

--- a/backend/internal/service/proxy_host_test.go
+++ b/backend/internal/service/proxy_host_test.go
@@ -1,0 +1,29 @@
+package service
+
+import "testing"
+
+func TestNormalizeProxyHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "ipv4 untouched", raw: "45.145.57.212", want: "45.145.57.212"},
+		{name: "hostname untouched", raw: "proxy.example.com", want: "proxy.example.com"},
+		{name: "trim whitespace", raw: "  proxy.example.com  ", want: "proxy.example.com"},
+		{name: "ipv6 brackets removed", raw: "[2001:db8::1]", want: "2001:db8::1"},
+		{name: "ipv6 brackets removed with spaces", raw: " [::1] ", want: "::1"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeProxyHost(tc.raw); got != tc.want {
+				t.Fatalf("NormalizeProxyHost(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/proxy_host_test.go
+++ b/backend/internal/service/proxy_host_test.go
@@ -27,3 +27,28 @@ func TestNormalizeProxyHost(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeProxyIPVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "defaults empty to ipv4", in: "", want: ProxyIPVersionIPv4},
+		{name: "keeps ipv4", in: "ipv4", want: ProxyIPVersionIPv4},
+		{name: "keeps ipv6 case insensitive", in: " IPV6 ", want: ProxyIPVersionIPv6},
+		{name: "unknown falls back to ipv4", in: "dual", want: ProxyIPVersionIPv4},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeProxyIPVersion(tc.in); got != tc.want {
+				t.Fatalf("NormalizeProxyIPVersion(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/service/proxy_service.go
+++ b/backend/internal/service/proxy_service.go
@@ -70,7 +70,7 @@ func (s *ProxyService) Create(ctx context.Context, req CreateProxyRequest) (*Pro
 	proxy := &Proxy{
 		Name:     req.Name,
 		Protocol: req.Protocol,
-		Host:     req.Host,
+		Host:     NormalizeProxyHost(req.Host),
 		Port:     req.Port,
 		Username: req.Username,
 		Password: req.Password,
@@ -128,7 +128,7 @@ func (s *ProxyService) Update(ctx context.Context, id int64, req UpdateProxyRequ
 	}
 
 	if req.Host != nil {
-		proxy.Host = *req.Host
+		proxy.Host = NormalizeProxyHost(*req.Host)
 	}
 
 	if req.Port != nil {

--- a/backend/internal/service/proxy_service.go
+++ b/backend/internal/service/proxy_service.go
@@ -36,6 +36,7 @@ type CreateProxyRequest struct {
 	Name     string `json:"name"`
 	Protocol string `json:"protocol"`
 	Host     string `json:"host"`
+	IPVersion string `json:"ip_version"`
 	Port     int    `json:"port"`
 	Username string `json:"username"`
 	Password string `json:"password"`
@@ -46,6 +47,7 @@ type UpdateProxyRequest struct {
 	Name     *string `json:"name"`
 	Protocol *string `json:"protocol"`
 	Host     *string `json:"host"`
+	IPVersion *string `json:"ip_version"`
 	Port     *int    `json:"port"`
 	Username *string `json:"username"`
 	Password *string `json:"password"`
@@ -71,6 +73,7 @@ func (s *ProxyService) Create(ctx context.Context, req CreateProxyRequest) (*Pro
 		Name:     req.Name,
 		Protocol: req.Protocol,
 		Host:     NormalizeProxyHost(req.Host),
+		IPVersion: NormalizeProxyIPVersion(req.IPVersion),
 		Port:     req.Port,
 		Username: req.Username,
 		Password: req.Password,
@@ -129,6 +132,10 @@ func (s *ProxyService) Update(ctx context.Context, id int64, req UpdateProxyRequ
 
 	if req.Host != nil {
 		proxy.Host = NormalizeProxyHost(*req.Host)
+	}
+
+	if req.IPVersion != nil {
+		proxy.IPVersion = NormalizeProxyIPVersion(*req.IPVersion)
 	}
 
 	if req.Port != nil {

--- a/backend/internal/service/proxy_test.go
+++ b/backend/internal/service/proxy_test.go
@@ -54,6 +54,24 @@ func TestProxyURL(t *testing.T) {
 			},
 			want: "http://first%20last%40corp:p%40%20ss%3A%23word@proxy.example.com:3128",
 		},
+		{
+			name: "ipv6 host without brackets is formatted correctly",
+			proxy: Proxy{
+				Protocol: "socks5h",
+				Host:     "2001:db8::1",
+				Port:     1080,
+			},
+			want: "socks5h://[2001:db8::1]:1080",
+		},
+		{
+			name: "ipv6 host with brackets is normalized before formatting",
+			proxy: Proxy{
+				Protocol: "http",
+				Host:     "[::1]",
+				Port:     8080,
+			},
+			want: "http://[::1]:8080",
+		},
 	}
 
 	for _, tc := range tests {

--- a/backend/migrations/001_init.sql
+++ b/backend/migrations/001_init.sql
@@ -7,6 +7,7 @@ CREATE TABLE IF NOT EXISTS proxies (
     name            VARCHAR(100) NOT NULL,
     protocol        VARCHAR(20) NOT NULL,                 -- http/https/socks5
     host            VARCHAR(255) NOT NULL,
+    ip_version      VARCHAR(10) NOT NULL DEFAULT 'ipv4',   -- ipv4/ipv6 exit probe target
     port            INT NOT NULL,
     username        VARCHAR(100),
     password        VARCHAR(100),

--- a/backend/migrations/001_init.sql
+++ b/backend/migrations/001_init.sql
@@ -7,7 +7,6 @@ CREATE TABLE IF NOT EXISTS proxies (
     name            VARCHAR(100) NOT NULL,
     protocol        VARCHAR(20) NOT NULL,                 -- http/https/socks5
     host            VARCHAR(255) NOT NULL,
-    ip_version      VARCHAR(10) NOT NULL DEFAULT 'ipv4',   -- ipv4/ipv6 exit probe target
     port            INT NOT NULL,
     username        VARCHAR(100),
     password        VARCHAR(100),

--- a/backend/migrations/136_add_proxy_ip_version.sql
+++ b/backend/migrations/136_add_proxy_ip_version.sql
@@ -1,0 +1,15 @@
+-- Add proxy exit IP version preference for IPv4/IPv6-aware connectivity probes.
+
+ALTER TABLE proxies
+    ADD COLUMN IF NOT EXISTS ip_version VARCHAR(10) NOT NULL DEFAULT 'ipv4';
+
+UPDATE proxies
+SET ip_version = 'ipv4'
+WHERE ip_version IS NULL OR ip_version = '';
+
+ALTER TABLE proxies
+    DROP CONSTRAINT IF EXISTS proxies_ip_version_check;
+
+ALTER TABLE proxies
+    ADD CONSTRAINT proxies_ip_version_check
+    CHECK (ip_version IN ('ipv4', 'ipv6'));

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -6,6 +6,7 @@
 
 - Added IPv6-aware proxy host normalization in backend proxy create, update, URL generation, duplicate checks, and import/export key matching.
 - Added a persisted `ip_version` field for proxies, including ent schema, SQL migrations, repository mapping, service models, API requests, DTO responses, admin import/export, and frontend API types.
+- Kept the already-applied `001_init.sql` migration immutable; existing and fresh databases receive `ip_version` through `136_add_proxy_ip_version.sql` so deployed databases do not hit checksum mismatches.
 - Updated backend proxy testing so `IP版本 = IPv6` uses IPv6 probe endpoints instead of the old IPv4-only `ip-api.com` / `httpbin.org` chain.
 - Added IPv6 probe endpoint parsing through `api6.ipify.org` and `api64.ipify.org`, and reject successful probe responses that do not return an IPv6 exit address when IPv6 is selected.
 - Updated admin `IP管理` UI to add an `IPv4 / IPv6` exit IP selection block in create and edit dialogs, aligned with the existing modal style.
@@ -35,6 +36,8 @@
   - Copied frontend `.npmrc` into the Docker dependency-install layer so pnpm runs the required `esbuild` / `vue-demi` postinstall scripts during image builds.
   - Pinned Docker frontend builds to pnpm 9 instead of `pnpm@latest` to avoid pnpm 11 interactive build-script approval failures.
   - Ignored local `frontend/pnpm-workspace.yaml` scratch files in Docker builds so deployment images always build the frontend as the standalone package defined by `frontend/package.json`.
+- Deployment migration check:
+  - Restored the original `001_init.sql` contents after Server A reported a migration checksum mismatch, then verified the new `136_add_proxy_ip_version.sql` migration is the only schema change used to add proxy `ip_version`.
 - Real SOCKS5 IPv6 exit verification on Server A:
   - `curl -x socks5h://[redacted] 'http://api6.ipify.org?format=json'` returned an IPv6 address.
   - `curl -x socks5h://[redacted] 'http://api64.ipify.org?format=json'` returned the same IPv6 address.

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -30,6 +30,8 @@
 - Frontend checks:
   - `pnpm test:run src/utils/__tests__/proxyAddress.spec.ts`
   - `NODE_OPTIONS=--max-old-space-size=4096 pnpm build`
+- Docker image build:
+  - Added the same frontend heap setting to the Docker frontend builder so Server A deployment builds do not fail with Vite/Node out-of-memory errors.
 - Real SOCKS5 IPv6 exit verification on Server A:
   - `curl -x socks5h://[redacted] 'http://api6.ipify.org?format=json'` returned an IPv6 address.
   - `curl -x socks5h://[redacted] 'http://api64.ipify.org?format=json'` returned the same IPv6 address.

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -34,6 +34,7 @@
   - Added the same frontend heap setting to the Docker frontend builder so Server A deployment builds do not fail with Vite/Node out-of-memory errors.
   - Copied frontend `.npmrc` into the Docker dependency-install layer so pnpm runs the required `esbuild` / `vue-demi` postinstall scripts during image builds.
   - Pinned Docker frontend builds to pnpm 9 instead of `pnpm@latest` to avoid pnpm 11 interactive build-script approval failures.
+  - Ignored local `frontend/pnpm-workspace.yaml` scratch files in Docker builds so deployment images always build the frontend as the standalone package defined by `frontend/package.json`.
 - Real SOCKS5 IPv6 exit verification on Server A:
   - `curl -x socks5h://[redacted] 'http://api6.ipify.org?format=json'` returned an IPv6 address.
   - `curl -x socks5h://[redacted] 'http://api64.ipify.org?format=json'` returned the same IPv6 address.

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -1,0 +1,39 @@
+# Update Log
+
+## 2026-05-17 - Admin proxy management supports IPv6
+
+### What changed
+
+- Added IPv6-aware proxy host normalization in backend proxy create, update, URL generation, duplicate checks, and import/export key matching.
+- Updated admin `IP管理` UI to add an `IPv4 / IPv6` selection block in create and edit dialogs, aligned with the existing modal style.
+- Replaced IPv4-only proxy URL parsing and address formatting in the admin proxy page with shared utilities that correctly support bracketed IPv6 input such as `socks5://user:pass@[2001:db8::1]:1080`.
+- Updated proxy display and copy behavior so IPv6 addresses are shown as `[ipv6]:port` and full proxy URLs remain valid.
+- Normalized frontend proxy queue grouping keys so the same IPv6 proxy is treated consistently whether the source host is stored as `2001:db8::1` or `[2001:db8::1]`.
+- Added regression tests for IPv6 proxy reuse across import paths and bracketed/unbracketed host formats.
+
+### Why it changed
+
+- The original admin proxy workflow only reliably handled IPv4-style `host:port` parsing and formatting.
+- SOCKS5 IPv6 proxies could be entered inconsistently, duplicated across imports, or copied into invalid URL formats.
+- The goal of this change is to make IPv6 proxies first-class in both backend data handling and the admin UI, not just add a visual toggle.
+
+### Verification
+
+- Backend targeted tests:
+  - `go test ./internal/service -run 'TestNormalizeProxyHost|TestProxyURL|TestProxyURLNormalizesBracketedIPv6Host'`
+  - `go test ./internal/handler/admin -run 'TestProxyHandlerCreateNormalizesIPv6Host|TestProxyImportDataReusesIPv6ProxyAcrossBracketFormats|TestProxyImportDataReusesIPv6ProxyWhenKeyOnlyUsesBracketedHost|TestImportDataReusesIPv6ProxyKeyAcrossBracketFormats'`
+- Frontend checks:
+  - `pnpm typecheck`
+  - `pnpm build`
+- Built module runtime spot-check:
+  - Verified `parseProxyUrl`, `normalizeProxyHost`, `formatProxyAddress`, and `buildProxyUrl` on an IPv6 SOCKS5 example from the built `proxyAddress` asset.
+
+### Environment notes
+
+- Full `go test ./internal/service ./internal/handler/admin` is currently blocked by an existing machine-level IPv6 loopback issue in tests that start `httptest` on `tcp6 [::1]`.
+- `pnpm test:run src/utils/__tests__/proxyAddress.spec.ts src/utils/__tests__/usageLoadQueue.spec.ts` is currently blocked on this machine by a local `localhost` resolution/listen failure in Vitest startup, while `typecheck` and production build both pass.
+
+### Preview entry
+
+- Frontend dev preview: run `pnpm dev` in `D:\挣钱\token\_release_worktrees\sub2api-desktop-client\frontend`
+- Expected local preview URL: `http://localhost:5173`

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -32,6 +32,7 @@
   - `NODE_OPTIONS=--max-old-space-size=4096 pnpm build`
 - Docker image build:
   - Added the same frontend heap setting to the Docker frontend builder so Server A deployment builds do not fail with Vite/Node out-of-memory errors.
+  - Copied frontend `.npmrc` into the Docker dependency-install layer so pnpm runs the required `esbuild` / `vue-demi` postinstall scripts during image builds.
 - Real SOCKS5 IPv6 exit verification on Server A:
   - `curl -x socks5h://[redacted] 'http://api6.ipify.org?format=json'` returned an IPv6 address.
   - `curl -x socks5h://[redacted] 'http://api64.ipify.org?format=json'` returned the same IPv6 address.

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -5,33 +5,41 @@
 ### What changed
 
 - Added IPv6-aware proxy host normalization in backend proxy create, update, URL generation, duplicate checks, and import/export key matching.
-- Updated admin `IP管理` UI to add an `IPv4 / IPv6` selection block in create and edit dialogs, aligned with the existing modal style.
+- Added a persisted `ip_version` field for proxies, including ent schema, SQL migrations, repository mapping, service models, API requests, DTO responses, admin import/export, and frontend API types.
+- Updated backend proxy testing so `IP版本 = IPv6` uses IPv6 probe endpoints instead of the old IPv4-only `ip-api.com` / `httpbin.org` chain.
+- Added IPv6 probe endpoint parsing through `api6.ipify.org` and `api64.ipify.org`, and reject successful probe responses that do not return an IPv6 exit address when IPv6 is selected.
+- Updated admin `IP管理` UI to add an `IPv4 / IPv6` exit IP selection block in create and edit dialogs, aligned with the existing modal style.
 - Replaced IPv4-only proxy URL parsing and address formatting in the admin proxy page with shared utilities that correctly support bracketed IPv6 input such as `socks5://user:pass@[2001:db8::1]:1080`.
 - Updated proxy display and copy behavior so IPv6 addresses are shown as `[ipv6]:port` and full proxy URLs remain valid.
 - Normalized frontend proxy queue grouping keys so the same IPv6 proxy is treated consistently whether the source host is stored as `2001:db8::1` or `[2001:db8::1]`.
-- Added regression tests for IPv6 proxy reuse across import paths and bracketed/unbracketed host formats.
+- Added regression tests for IPv6 proxy reuse, `ip_version` normalization, IPv6 probe endpoint selection, and bracketed/unbracketed host formats.
 
 ### Why it changed
 
 - The original admin proxy workflow only reliably handled IPv4-style `host:port` parsing and formatting.
-- SOCKS5 IPv6 proxies could be entered inconsistently, duplicated across imports, or copied into invalid URL formats.
-- The goal of this change is to make IPv6 proxies first-class in both backend data handling and the admin UI, not just add a visual toggle.
+- The previous IPv6 UI toggle did not fully affect the backend probe path, so SOCKS5 proxies with IPv4 entry hosts but IPv6 exits could still be tested through IPv4-only endpoints.
+- SOCKS5 IPv6 proxies could be entered inconsistently, duplicated across imports, copied into invalid URL formats, or probed with the wrong exit IP expectation.
+- The goal of this change is to make IPv6 proxies first-class in backend data handling, persistence, connectivity checks, import/export, and the admin UI, not just add a visual toggle.
 
 ### Verification
 
 - Backend targeted tests:
-  - `go test ./internal/service -run 'TestNormalizeProxyHost|TestProxyURL|TestProxyURLNormalizesBracketedIPv6Host'`
-  - `go test ./internal/handler/admin -run 'TestProxyHandlerCreateNormalizesIPv6Host|TestProxyImportDataReusesIPv6ProxyAcrossBracketFormats|TestProxyImportDataReusesIPv6ProxyWhenKeyOnlyUsesBracketedHost|TestImportDataReusesIPv6ProxyKeyAcrossBracketFormats'`
+  - `go test ./internal/repository -run 'TestProxyProbeServiceSuite/TestProbeProxy_IPv6UsesIPv6ProbeEndpoint|TestProxyProbeServiceSuite/TestProbeProxy_Success_IPAPI|TestProxyProbeServiceSuite/TestProbeProxy_Success_HTTPBinFallback|TestProxyProbeServiceSuite/TestProbeProxy_AllFail'`
+  - `go test ./internal/service -run 'TestNormalizeProxyHost|TestNormalizeProxyIPVersion|TestProxyURL|TestProxyURLNormalizesBracketedIPv6Host'`
+  - `go test ./internal/handler/admin -run 'TestProxyHandlerCreateNormalizesIPv6Host|TestProxyExportDataRespectsFilters|TestProxyImportDataReusesIPv6ProxyAcrossBracketFormats|TestProxyImportDataReusesIPv6ProxyWhenKeyOnlyUsesBracketedHost|TestImportDataReusesIPv6ProxyKeyAcrossBracketFormats'`
 - Frontend checks:
-  - `pnpm typecheck`
-  - `pnpm build`
+  - `pnpm test:run src/utils/__tests__/proxyAddress.spec.ts`
+  - `NODE_OPTIONS=--max-old-space-size=4096 pnpm build`
+- Real SOCKS5 IPv6 exit verification on Server A:
+  - `curl -x socks5h://[redacted] 'http://api6.ipify.org?format=json'` returned an IPv6 address.
+  - `curl -x socks5h://[redacted] 'http://api64.ipify.org?format=json'` returned the same IPv6 address.
 - Built module runtime spot-check:
   - Verified `parseProxyUrl`, `normalizeProxyHost`, `formatProxyAddress`, and `buildProxyUrl` on an IPv6 SOCKS5 example from the built `proxyAddress` asset.
 
 ### Environment notes
 
-- Full `go test ./internal/service ./internal/handler/admin` is currently blocked by an existing machine-level IPv6 loopback issue in tests that start `httptest` on `tcp6 [::1]`.
-- `pnpm test:run src/utils/__tests__/proxyAddress.spec.ts src/utils/__tests__/usageLoadQueue.spec.ts` is currently blocked on this machine by a local `localhost` resolution/listen failure in Vitest startup, while `typecheck` and production build both pass.
+- Local Windows Go cannot download the required `go1.26.3` toolchain in this environment, so backend generation and targeted backend tests were run on Server A with the matching Go toolchain.
+- Local Windows frontend `pnpm typecheck` is still blocked by existing dependency/type issues such as missing `axios` resolution and unrelated implicit `any` diagnostics; the Linux/Node frontend build and targeted proxy address test pass.
 
 ### Preview entry
 

--- a/docs/UPDATE_LOG.md
+++ b/docs/UPDATE_LOG.md
@@ -33,6 +33,7 @@
 - Docker image build:
   - Added the same frontend heap setting to the Docker frontend builder so Server A deployment builds do not fail with Vite/Node out-of-memory errors.
   - Copied frontend `.npmrc` into the Docker dependency-install layer so pnpm runs the required `esbuild` / `vue-demi` postinstall scripts during image builds.
+  - Pinned Docker frontend builds to pnpm 9 instead of `pnpm@latest` to avoid pnpm 11 interactive build-script approval failures.
 - Real SOCKS5 IPv6 exit verification on Server A:
   - `curl -x socks5h://[redacted] 'http://api6.ipify.org?format=json'` returned an IPv6 address.
   - `curl -x socks5h://[redacted] 'http://api64.ipify.org?format=json'` returned the same IPv6 address.

--- a/frontend/src/api/admin/proxies.ts
+++ b/frontend/src/api/admin/proxies.ts
@@ -197,6 +197,7 @@ export async function batchCreate(
   proxies: Array<{
     protocol: string
     host: string
+    ip_version?: 'ipv4' | 'ipv6'
     port: number
     username?: string
     password?: string

--- a/frontend/src/components/common/ProxySelector.vue
+++ b/frontend/src/components/common/ProxySelector.vue
@@ -114,7 +114,7 @@
                 </template>
               </div>
               <div class="truncate text-xs text-gray-500 dark:text-gray-400">
-                {{ proxy.protocol }}://{{ proxy.host }}:{{ proxy.port }}
+                {{ buildProxyUrl(proxy) }}
               </div>
             </div>
 
@@ -173,6 +173,7 @@ import { useI18n } from 'vue-i18n'
 import { adminAPI } from '@/api/admin'
 import Icon from '@/components/icons/Icon.vue'
 import type { Proxy } from '@/types'
+import { buildProxyUrl } from '@/utils/proxyAddress'
 
 const { t } = useI18n()
 
@@ -220,7 +221,7 @@ const selectedLabel = computed(() => {
     return t('admin.accounts.noProxy')
   }
   const proxy = selectedProxy.value
-  return `${proxy.name} (${proxy.protocol}://${proxy.host}:${proxy.port})`
+  return `${proxy.name} (${buildProxyUrl(proxy)})`
 })
 
 const filteredProxies = computed(() => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3949,6 +3949,7 @@ export default {
       optionalAuth: 'Optional authentication',
       form: {
         hostPlaceholder: 'proxy.example.com',
+        hostPlaceholderIpv6: 'Enter an IPv6 address, for example 2001:db8::1',
         portPlaceholder: '8080'
       },
       noProxiesYet: 'No proxies yet',
@@ -3956,11 +3957,12 @@ export default {
       // Batch import
       standardAdd: 'Standard Add',
       batchAdd: 'Quick Add',
+      ipType: 'Proxy IP Type',
       batchInput: 'Proxy List',
       batchInputPlaceholder:
-        "Enter one proxy per line in the following formats:\nsocks5://user:pass{'@'}192.168.1.1:1080\nhttp://192.168.1.1:8080\nhttps://user:pass{'@'}proxy.example.com:443",
+        "Enter one proxy per line in the following formats:\nsocks5://user:pass{'@'}192.168.1.1:1080\nsocks5://user:pass{'@'}[2001:db8::1]:1080\nhttps://user:pass{'@'}proxy.example.com:443",
       batchInputHint:
-        "Supports http, https, socks5 protocols. Format: protocol://[user:pass{'@'}]host:port",
+        "Supports http, https, socks5, and socks5h. For IPv6 use the [address]:port format.",
       parsedCount: '{count} valid',
       invalidCount: '{count} invalid',
       duplicateCount: '{count} duplicate',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3949,7 +3949,7 @@ export default {
       optionalAuth: 'Optional authentication',
       form: {
         hostPlaceholder: 'proxy.example.com',
-        hostPlaceholderIpv6: 'Enter an IPv6 address, for example 2001:db8::1',
+        hostPlaceholderIpv6: 'Enter the proxy entry host, for example 45.145.57.212 or 2001:db8::1',
         portPlaceholder: '8080'
       },
       noProxiesYet: 'No proxies yet',
@@ -3957,12 +3957,12 @@ export default {
       // Batch import
       standardAdd: 'Standard Add',
       batchAdd: 'Quick Add',
-      ipType: 'Proxy IP Type',
+      ipType: 'Exit IP Type',
       batchInput: 'Proxy List',
       batchInputPlaceholder:
         "Enter one proxy per line in the following formats:\nsocks5://user:pass{'@'}192.168.1.1:1080\nsocks5://user:pass{'@'}[2001:db8::1]:1080\nhttps://user:pass{'@'}proxy.example.com:443",
       batchInputHint:
-        "Supports http, https, socks5, and socks5h. For IPv6 use the [address]:port format.",
+        "Supports http, https, socks5, and socks5h. Batch import detects the entry host type automatically. For IPv4 entry proxies with IPv6 exits, edit the proxy and select IPv6.",
       parsedCount: '{count} valid',
       invalidCount: '{count} invalid',
       duplicateCount: '{count} duplicate',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4045,7 +4045,7 @@ export default {
       leaveEmptyToKeep: '留空保持不变',
       form: {
         hostPlaceholder: '请输入主机地址',
-        hostPlaceholderIpv6: '请输入 IPv6 地址，例如 2001:db8::1',
+        hostPlaceholderIpv6: '请输入代理入口地址，例如 45.145.57.212 或 2001:db8::1',
         portPlaceholder: '请输入端口'
       },
       noProxiesYet: '暂无代理',
@@ -4075,11 +4075,11 @@ export default {
       // Batch import
       standardAdd: '标准添加',
       batchAdd: '快捷添加',
-      ipType: '代理 IP 类型',
+      ipType: '出口 IP 类型',
       batchInput: '代理列表',
       batchInputPlaceholder:
         "每行输入一个代理，支持以下格式：\nsocks5://user:pass{'@'}192.168.1.1:1080\nsocks5://user:pass{'@'}[2001:db8::1]:1080\nhttps://user:pass{'@'}proxy.example.com:443",
-      batchInputHint: "支持 http、https、socks5、socks5h 协议，IPv6 请使用 [地址]:端口 格式",
+      batchInputHint: "支持 http、https、socks5、socks5h 协议。批量导入会按入口地址自动识别 IPv4/IPv6；IPv4 入口但 IPv6 出口的代理，请创建后在编辑里选择 IPv6。",
       parsedCount: '有效 {count} 个',
       invalidCount: '无效 {count} 个',
       duplicateCount: '重复 {count} 个',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4045,6 +4045,7 @@ export default {
       leaveEmptyToKeep: '留空保持不变',
       form: {
         hostPlaceholder: '请输入主机地址',
+        hostPlaceholderIpv6: '请输入 IPv6 地址，例如 2001:db8::1',
         portPlaceholder: '请输入端口'
       },
       noProxiesYet: '暂无代理',
@@ -4074,10 +4075,11 @@ export default {
       // Batch import
       standardAdd: '标准添加',
       batchAdd: '快捷添加',
+      ipType: '代理 IP 类型',
       batchInput: '代理列表',
       batchInputPlaceholder:
-        "每行输入一个代理，支持以下格式：\nsocks5://user:pass{'@'}192.168.1.1:1080\nhttp://192.168.1.1:8080\nhttps://user:pass{'@'}proxy.example.com:443",
-      batchInputHint: "支持 http、https、socks5 协议，格式：协议://[用户名:密码{'@'}]主机:端口",
+        "每行输入一个代理，支持以下格式：\nsocks5://user:pass{'@'}192.168.1.1:1080\nsocks5://user:pass{'@'}[2001:db8::1]:1080\nhttps://user:pass{'@'}proxy.example.com:443",
+      batchInputHint: "支持 http、https、socks5、socks5h 协议，IPv6 请使用 [地址]:端口 格式",
       parsedCount: '有效 {count} 个',
       invalidCount: '无效 {count} 个',
       duplicateCount: '重复 {count} 个',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -670,6 +670,7 @@ export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity'
 export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
 export type OAuthAddMethod = 'oauth' | 'setup-token'
 export type ProxyProtocol = 'http' | 'https' | 'socks5' | 'socks5h'
+export type ProxyIPVersion = 'ipv4' | 'ipv6'
 
 // Claude Model type (returned by /v1/models and account models API)
 export interface ClaudeModel {
@@ -684,6 +685,7 @@ export interface Proxy {
   name: string
   protocol: ProxyProtocol
   host: string
+  ip_version?: ProxyIPVersion
   port: number
   username: string | null
   password?: string | null
@@ -1040,6 +1042,7 @@ export interface CreateProxyRequest {
   name: string
   protocol: ProxyProtocol
   host: string
+  ip_version?: ProxyIPVersion
   port: number
   username?: string | null
   password?: string | null
@@ -1049,6 +1052,7 @@ export interface UpdateProxyRequest {
   name?: string
   protocol?: ProxyProtocol
   host?: string
+  ip_version?: ProxyIPVersion
   port?: number
   username?: string | null
   password?: string | null
@@ -1068,6 +1072,7 @@ export interface AdminDataProxy {
   name: string
   protocol: ProxyProtocol
   host: string
+  ip_version?: ProxyIPVersion
   port: number
   username?: string | null
   password?: string | null

--- a/frontend/src/utils/__tests__/proxyAddress.spec.ts
+++ b/frontend/src/utils/__tests__/proxyAddress.spec.ts
@@ -40,6 +40,7 @@ describe('proxyAddress', () => {
     expect(parseProxyUrl('socks5://user:pass@[2001:db8::1]:1080')).toEqual({
       protocol: 'socks5',
       host: '2001:db8::1',
+      ip_version: 'ipv6',
       port: 1080,
       username: 'user',
       password: 'pass'

--- a/frontend/src/utils/__tests__/proxyAddress.spec.ts
+++ b/frontend/src/utils/__tests__/proxyAddress.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildProxyUrl,
+  detectProxyIPVersion,
+  formatProxyAddress,
+  formatProxyHost,
+  normalizeProxyHost,
+  parseProxyUrl
+} from '../proxyAddress'
+
+describe('proxyAddress', () => {
+  it('normalizes bracketed IPv6 hosts', () => {
+    expect(normalizeProxyHost('[2001:db8::1]')).toBe('2001:db8::1')
+    expect(normalizeProxyHost(' [::1] ')).toBe('::1')
+  })
+
+  it('detects IPv6 correctly', () => {
+    expect(detectProxyIPVersion('45.145.57.212')).toBe('ipv4')
+    expect(detectProxyIPVersion('[2001:db8::1]')).toBe('ipv6')
+  })
+
+  it('formats IPv6 hosts with brackets for display', () => {
+    expect(formatProxyHost('2001:db8::1')).toBe('[2001:db8::1]')
+    expect(formatProxyAddress('2001:db8::1', 1080)).toBe('[2001:db8::1]:1080')
+  })
+
+  it('builds IPv6 proxy urls correctly', () => {
+    expect(
+      buildProxyUrl({
+        protocol: 'socks5',
+        host: '2001:db8::1',
+        port: 1080,
+        username: 'user',
+        password: 'p@ss:word'
+      })
+    ).toBe('socks5://user:p%40ss%3Aword@[2001:db8::1]:1080')
+  })
+
+  it('parses IPv6 proxy urls and removes brackets from host storage', () => {
+    expect(parseProxyUrl('socks5://user:pass@[2001:db8::1]:1080')).toEqual({
+      protocol: 'socks5',
+      host: '2001:db8::1',
+      port: 1080,
+      username: 'user',
+      password: 'pass'
+    })
+  })
+
+  it('rejects unsupported proxy urls', () => {
+    expect(parseProxyUrl('ftp://example.com:21')).toBeNull()
+    expect(parseProxyUrl('socks5://[2001:db8::1]')).toBeNull()
+  })
+})

--- a/frontend/src/utils/proxyAddress.ts
+++ b/frontend/src/utils/proxyAddress.ts
@@ -1,0 +1,84 @@
+import type { ProxyProtocol } from '@/types'
+
+export type ProxyIPVersion = 'ipv4' | 'ipv6'
+
+export interface ParsedProxyAddress {
+  protocol: ProxyProtocol
+  host: string
+  port: number
+  username: string
+  password: string
+}
+
+export function normalizeProxyHost(host: string): string {
+  const trimmed = host.trim()
+  if (!trimmed) return ''
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1).trim()
+    if (inner.includes(':')) return inner
+  }
+  return trimmed
+}
+
+export function detectProxyIPVersion(host: string): ProxyIPVersion {
+  return normalizeProxyHost(host).includes(':') ? 'ipv6' : 'ipv4'
+}
+
+export function formatProxyHost(host: string): string {
+  const normalized = normalizeProxyHost(host)
+  if (!normalized) return ''
+  return normalized.includes(':') ? `[${normalized}]` : normalized
+}
+
+export function formatProxyAddress(host: string, port: number): string {
+  return `${formatProxyHost(host)}:${port}`
+}
+
+export function buildProxyUrl(row: {
+  protocol: ProxyProtocol
+  host: string
+  port: number
+  username?: string | null
+  password?: string | null
+}): string {
+  const user = row.username ? encodeURIComponent(row.username) : ''
+  const pass = row.password ? encodeURIComponent(row.password) : ''
+  let auth = ''
+  if (user && pass) auth = `${user}:${pass}@`
+  else if (user) auth = `${user}@`
+  else if (pass) auth = `:${pass}@`
+  return `${row.protocol}://${auth}${formatProxyAddress(row.host, row.port)}`
+}
+
+export function parseProxyUrl(line: string): ParsedProxyAddress | null {
+  const trimmed = line.trim()
+  if (!trimmed) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return null
+  }
+
+  const protocol = parsed.protocol.replace(/:$/, '').toLowerCase()
+  if (!['http', 'https', 'socks5', 'socks5h'].includes(protocol)) {
+    return null
+  }
+
+  const port = Number(parsed.port)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    return null
+  }
+
+  const host = normalizeProxyHost(parsed.hostname)
+  if (!host) return null
+
+  return {
+    protocol: protocol as ProxyProtocol,
+    host,
+    port,
+    username: parsed.username ? decodeURIComponent(parsed.username) : '',
+    password: parsed.password ? decodeURIComponent(parsed.password) : ''
+  }
+}

--- a/frontend/src/utils/proxyAddress.ts
+++ b/frontend/src/utils/proxyAddress.ts
@@ -1,10 +1,9 @@
-import type { ProxyProtocol } from '@/types'
-
-export type ProxyIPVersion = 'ipv4' | 'ipv6'
+import type { ProxyIPVersion, ProxyProtocol } from '@/types'
 
 export interface ParsedProxyAddress {
   protocol: ProxyProtocol
   host: string
+  ip_version: ProxyIPVersion
   port: number
   username: string
   password: string
@@ -77,6 +76,7 @@ export function parseProxyUrl(line: string): ParsedProxyAddress | null {
   return {
     protocol: protocol as ProxyProtocol,
     host,
+    ip_version: detectProxyIPVersion(host),
     port,
     username: parsed.username ? decodeURIComponent(parsed.username) : '',
     password: parsed.password ? decodeURIComponent(parsed.password) : ''

--- a/frontend/src/utils/usageLoadQueue.ts
+++ b/frontend/src/utils/usageLoadQueue.ts
@@ -1,7 +1,7 @@
 /**
  * Usage request scheduler.
  *
- * All platforms execute immediately without queuing — the backend uses
+ * All platforms execute immediately without queuing - the backend uses
  * passive sampling so upstream 429 rate-limit errors are no longer a concern.
  */
 

--- a/frontend/src/views/admin/ProxiesView.vue
+++ b/frontend/src/views/admin/ProxiesView.vue
@@ -134,7 +134,7 @@
 
           <template #cell-address="{ row }">
             <div class="flex items-center gap-1.5">
-              <code class="code text-xs">{{ row.host }}:{{ row.port }}</code>
+              <code class="code text-xs">{{ formatProxyAddress(row.host, row.port) }}</code>
               <div class="relative">
                 <button
                   type="button"
@@ -419,6 +419,27 @@
           <label class="input-label">{{ t('admin.proxies.protocol') }}</label>
           <Select v-model="createForm.protocol" :options="protocolSelectOptions" />
         </div>
+        <div>
+          <label class="input-label">{{ t('admin.proxies.ipType') }}</label>
+          <div class="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              @click="setCreateIPVersion('ipv4')"
+              :class="proxyIpTypeButtonClass(createForm.ipVersion === 'ipv4')"
+            >
+              <span :class="proxyIpTypeDotClass(createForm.ipVersion === 'ipv4')"></span>
+              <span>IPv4</span>
+            </button>
+            <button
+              type="button"
+              @click="setCreateIPVersion('ipv6')"
+              :class="proxyIpTypeButtonClass(createForm.ipVersion === 'ipv6')"
+            >
+              <span :class="proxyIpTypeDotClass(createForm.ipVersion === 'ipv6')"></span>
+              <span>IPv6</span>
+            </button>
+          </div>
+        </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="input-label">{{ t('admin.proxies.host') }}</label>
@@ -426,7 +447,7 @@
               v-model="createForm.host"
               type="text"
               required
-              :placeholder="t('admin.proxies.form.hostPlaceholder')"
+              :placeholder="hostPlaceholderFor(createForm.ipVersion)"
               class="input"
             />
           </div>
@@ -624,10 +645,37 @@
           <label class="input-label">{{ t('admin.proxies.protocol') }}</label>
           <Select v-model="editForm.protocol" :options="protocolSelectOptions" />
         </div>
+        <div>
+          <label class="input-label">{{ t('admin.proxies.ipType') }}</label>
+          <div class="grid grid-cols-2 gap-3">
+            <button
+              type="button"
+              @click="setEditIPVersion('ipv4')"
+              :class="proxyIpTypeButtonClass(editForm.ipVersion === 'ipv4')"
+            >
+              <span :class="proxyIpTypeDotClass(editForm.ipVersion === 'ipv4')"></span>
+              <span>IPv4</span>
+            </button>
+            <button
+              type="button"
+              @click="setEditIPVersion('ipv6')"
+              :class="proxyIpTypeButtonClass(editForm.ipVersion === 'ipv6')"
+            >
+              <span :class="proxyIpTypeDotClass(editForm.ipVersion === 'ipv6')"></span>
+              <span>IPv6</span>
+            </button>
+          </div>
+        </div>
         <div class="grid grid-cols-2 gap-4">
           <div>
             <label class="input-label">{{ t('admin.proxies.host') }}</label>
-            <input v-model="editForm.host" type="text" required class="input" />
+            <input
+              v-model="editForm.host"
+              type="text"
+              required
+              :placeholder="hostPlaceholderFor(editForm.ipVersion)"
+              class="input"
+            />
           </div>
           <div>
             <label class="input-label">{{ t('admin.proxies.port') }}</label>
@@ -893,6 +941,14 @@ import { useClipboard } from '@/composables/useClipboard'
 import { useSwipeSelect } from '@/composables/useSwipeSelect'
 import { useTableSelection } from '@/composables/useTableSelection'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
+import {
+  buildProxyUrl,
+  detectProxyIPVersion,
+  formatProxyAddress,
+  normalizeProxyHost,
+  parseProxyUrl,
+  type ProxyIPVersion
+} from '@/utils/proxyAddress'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -1026,6 +1082,7 @@ const batchParseResult = reactive({
 const createForm = reactive({
   name: '',
   protocol: 'http' as ProxyProtocol,
+  ipVersion: 'ipv4' as ProxyIPVersion,
   host: '',
   port: 8080,
   username: '',
@@ -1035,6 +1092,7 @@ const createForm = reactive({
 const editForm = reactive({
   name: '',
   protocol: 'http' as ProxyProtocol,
+  ipVersion: 'ipv4' as ProxyIPVersion,
   host: '',
   port: 8080,
   username: '',
@@ -1138,6 +1196,7 @@ const closeCreateModal = () => {
   createMode.value = 'standard'
   createForm.name = ''
   createForm.protocol = 'http'
+  createForm.ipVersion = 'ipv4'
   createForm.host = ''
   createForm.port = 8080
   createForm.username = ''
@@ -1156,39 +1215,6 @@ const handleDataImported = () => {
   loadProxies()
 }
 
-// Parse proxy URL: protocol://user:pass@host:port or protocol://host:port
-const parseProxyUrl = (
-  line: string
-): {
-  protocol: ProxyProtocol
-  host: string
-  port: number
-  username: string
-  password: string
-} | null => {
-  const trimmed = line.trim()
-  if (!trimmed) return null
-
-  // Regex to parse proxy URL (supports http, https, socks5, socks5h)
-  const regex = /^(https?|socks5h?):\/\/(?:([^:@]+):([^@]+)@)?([^:]+):(\d+)$/i
-  const match = trimmed.match(regex)
-
-  if (!match) return null
-
-  const [, protocol, username, password, host, port] = match
-  const portNum = parseInt(port, 10)
-
-  if (portNum < 1 || portNum > 65535) return null
-
-  return {
-    protocol: protocol.toLowerCase() as ProxyProtocol,
-    host: host.trim(),
-    port: portNum,
-    username: username?.trim() || '',
-    password: password?.trim() || ''
-  }
-}
-
 const parseBatchInput = () => {
   const lines = batchInput.value.split('\n').filter((l) => l.trim())
   const seen = new Set<string>()
@@ -1204,7 +1230,7 @@ const parseBatchInput = () => {
     }
 
     // Check for duplicates (same host:port:username:password)
-    const key = `${parsed.host}:${parsed.port}:${parsed.username}:${parsed.password}`
+    const key = `${normalizeProxyHost(parsed.host)}:${parsed.port}:${parsed.username}:${parsed.password}`
     if (seen.has(key)) {
       duplicate++
       continue
@@ -1250,7 +1276,8 @@ const handleCreateProxy = async () => {
     appStore.showError(t('admin.proxies.nameRequired'))
     return
   }
-  if (!createForm.host.trim()) {
+  const normalizedHost = normalizeProxyHost(createForm.host)
+  if (!normalizedHost) {
     appStore.showError(t('admin.proxies.hostRequired'))
     return
   }
@@ -1263,7 +1290,7 @@ const handleCreateProxy = async () => {
     await adminAPI.proxies.create({
       name: createForm.name.trim(),
       protocol: createForm.protocol,
-      host: createForm.host.trim(),
+      host: normalizedHost,
       port: createForm.port,
       username: createForm.username.trim() || null,
       password: createForm.password.trim() || null
@@ -1284,6 +1311,7 @@ const handleEdit = (proxy: Proxy) => {
   editForm.name = proxy.name
   editForm.protocol = proxy.protocol
   editForm.host = proxy.host
+  editForm.ipVersion = detectProxyIPVersion(proxy.host)
   editForm.port = proxy.port
   editForm.username = proxy.username || ''
   editForm.password = proxy.password || ''
@@ -1306,7 +1334,8 @@ const handleUpdateProxy = async () => {
     appStore.showError(t('admin.proxies.nameRequired'))
     return
   }
-  if (!editForm.host.trim()) {
+  const normalizedHost = normalizeProxyHost(editForm.host)
+  if (!normalizedHost) {
     appStore.showError(t('admin.proxies.hostRequired'))
     return
   }
@@ -1320,7 +1349,7 @@ const handleUpdateProxy = async () => {
     const updateData: any = {
       name: editForm.name.trim(),
       protocol: editForm.protocol,
-      host: editForm.host.trim(),
+      host: normalizedHost,
       port: editForm.port,
       username: editForm.username.trim() || null,
       status: editForm.status
@@ -1824,17 +1853,31 @@ const closeAccountsModal = () => {
 }
 
 // ── Proxy URL copy ──
-function buildAuthPart(row: any): string {
-  const user = row.username ? encodeURIComponent(row.username) : ''
-  const pass = row.password ? encodeURIComponent(row.password) : ''
-  if (user && pass) return `${user}:${pass}@`
-  if (user) return `${user}@`
-  if (pass) return `:${pass}@`
-  return ''
+const hostPlaceholderFor = (version: ProxyIPVersion) =>
+  version === 'ipv6'
+    ? t('admin.proxies.form.hostPlaceholderIpv6')
+    : t('admin.proxies.form.hostPlaceholder')
+
+const proxyIpTypeButtonClass = (active: boolean) => [
+  'flex items-center gap-3 rounded-xl border px-4 py-3 text-left text-sm font-medium transition-all',
+  active
+    ? 'border-primary-500 bg-primary-50 text-primary-600 ring-1 ring-primary-500/20 dark:bg-primary-900/20 dark:text-primary-300'
+    : 'border-gray-200 bg-white text-gray-700 hover:border-primary-300 dark:border-dark-600 dark:bg-dark-800 dark:text-gray-200 dark:hover:border-primary-700'
+]
+
+const proxyIpTypeDotClass = (active: boolean) => [
+  'inline-flex h-5 w-5 flex-shrink-0 rounded-full border-2 transition-all',
+  active
+    ? 'border-primary-500 bg-primary-500 shadow-[inset_0_0_0_4px_white] dark:shadow-[inset_0_0_0_4px_rgba(17,24,39,1)]'
+    : 'border-gray-300 bg-white dark:border-dark-500 dark:bg-dark-800'
+]
+
+const setCreateIPVersion = (version: ProxyIPVersion) => {
+  createForm.ipVersion = version
 }
 
-function buildProxyUrl(row: any): string {
-  return `${row.protocol}://${buildAuthPart(row)}${row.host}:${row.port}`
+const setEditIPVersion = (version: ProxyIPVersion) => {
+  editForm.ipVersion = version
 }
 
 function getCopyFormats(row: any) {
@@ -1847,7 +1890,10 @@ function getCopyFormats(row: any) {
     const withoutProtocol = fullUrl.replace(/^[^:]+:\/\//, '')
     formats.push({ label: withoutProtocol, value: withoutProtocol })
   }
-  formats.push({ label: `${row.host}:${row.port}`, value: `${row.host}:${row.port}` })
+  formats.push({
+    label: formatProxyAddress(row.host, row.port),
+    value: formatProxyAddress(row.host, row.port)
+  })
   return formats
 }
 

--- a/frontend/src/views/admin/ProxiesView.vue
+++ b/frontend/src/views/admin/ProxiesView.vue
@@ -924,7 +924,7 @@ import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { adminAPI } from '@/api/admin'
-import type { Proxy, ProxyAccountSummary, ProxyProtocol, ProxyQualityCheckResult } from '@/types'
+import type { Proxy, ProxyAccountSummary, ProxyIPVersion, ProxyProtocol, ProxyQualityCheckResult } from '@/types'
 import type { Column } from '@/components/common/types'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'
@@ -946,8 +946,7 @@ import {
   detectProxyIPVersion,
   formatProxyAddress,
   normalizeProxyHost,
-  parseProxyUrl,
-  type ProxyIPVersion
+  parseProxyUrl
 } from '@/utils/proxyAddress'
 
 const { t } = useI18n()
@@ -1073,6 +1072,7 @@ const batchParseResult = reactive({
   proxies: [] as Array<{
     protocol: ProxyProtocol
     host: string
+    ip_version: ProxyIPVersion
     port: number
     username: string
     password: string
@@ -1291,6 +1291,7 @@ const handleCreateProxy = async () => {
       name: createForm.name.trim(),
       protocol: createForm.protocol,
       host: normalizedHost,
+      ip_version: createForm.ipVersion,
       port: createForm.port,
       username: createForm.username.trim() || null,
       password: createForm.password.trim() || null
@@ -1311,7 +1312,7 @@ const handleEdit = (proxy: Proxy) => {
   editForm.name = proxy.name
   editForm.protocol = proxy.protocol
   editForm.host = proxy.host
-  editForm.ipVersion = detectProxyIPVersion(proxy.host)
+  editForm.ipVersion = proxy.ip_version || detectProxyIPVersion(proxy.host)
   editForm.port = proxy.port
   editForm.username = proxy.username || ''
   editForm.password = proxy.password || ''
@@ -1350,6 +1351,7 @@ const handleUpdateProxy = async () => {
       name: editForm.name.trim(),
       protocol: editForm.protocol,
       host: normalizedHost,
+      ip_version: editForm.ipVersion,
       port: editForm.port,
       username: editForm.username.trim() || null,
       status: editForm.status


### PR DESCRIPTION
This fixes IPv6 proxy management in the Sub2API admin IP/proxy workflow.

Problem:
The admin proxy UI accepted proxy hosts as plain strings, while the backend and helper utilities treated host:port formatting as IPv4-shaped. SOCKS5 IPv6 proxies therefore could be stored or displayed inconsistently, and bracketed IPv6 URLs from imports/checks could fail to match existing proxy entries.

Root cause:
Proxy host normalization and URL formatting did not consistently distinguish the stored host from the URL authority form. IPv6 needs brackets only when combined with a port in URLs, but storage and comparisons should use the canonical bare host form.

Fix:
- Added backend proxy host normalization and URL formatting helpers.
- Normalized IPv6 hosts across create, update, check-exists, import/export, selector, and usage queue paths.
- Added an admin UI IP version selector for IPv4/IPv6 while keeping the existing UI style.
- Added frontend proxy-address helpers for bracketed IPv6 parsing, display, and copy formats.
- Added regression tests for backend normalization/import reuse and frontend IPv6 parsing/formatting.

Verification:
- go test ./internal/service -run "TestNormalizeProxyHost|TestProxyURL|TestProxyURLNormalizesBracketedIPv6Host"
- go test ./internal/handler/admin -run "TestProxyHandlerCreateNormalizesIPv6Host|TestProxyImportDataReusesIPv6ProxyAcrossBracketFormats|TestProxyImportDataReusesIPv6ProxyWhenKeyOnlyUsesBracketedHost|TestImportDataReusesIPv6ProxyKeyAcrossBracketFormats"
- pnpm install --frozen-lockfile
- pnpm typecheck
- pnpm build
- Built asset spot-check for socks5://user:p%40ss%3Aword@[2001:db8::1]:1080 parsing/normalization/URL formatting
