### PR TITLE
fix(docker): 固定前端构建阶段 pnpm 版本为 v9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ FROM ${NODE_IMAGE} AS frontend-builder
 
 WORKDIR /app/frontend
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# Install pnpm (pinned to v9 to match CI and keep builds reproducible)
+RUN corepack enable && corepack prepare pnpm@9 --activate
 
 # Install dependencies first (better caching)
 COPY frontend/package.json frontend/pnpm-lock.yaml ./


### PR DESCRIPTION
## 问题

修复 #2442 。

`docker build` 在 `frontend-builder` 阶段执行 `pnpm install --frozen-lockfile` 时失败：

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5, vue-demi@0.14.10
```

## 原因

Dockerfile 中使用 `corepack prepare pnpm@latest`，而 `pnpm@latest` 目前已指向 **pnpm 11**。pnpm 11 把「未批准的依赖构建脚本」从警告升级为**硬错误**（exit 1），导致构建中断。

CI 工作流（`.github/workflows/backend-ci.yml`）用的是 `pnpm/action-setup@v4` + `version: 9`，所以 CI 能通过、只有 Docker 构建失败；同时 `@latest` 会随时间漂移，构建不可复现。

> pnpm 9 / 10 / 11 对「依赖构建脚本白名单」的配置位置和键名各不相同（package.json 的 `pnpm.onlyBuiltDependencies` → `pnpm-workspace.yaml` 的 `onlyBuiltDependencies` → `allowBuilds`），不存在能同时兼容三者的单一配置，因此固定版本是唯一干净方案。

## 改动

将 Dockerfile 前端构建阶段的 pnpm 固定为 v9，与 CI 保持一致：

```diff
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@9 --activate
```

## 测试

- 复现：用 pnpm 11.1.2 执行 `pnpm install --frozen-lockfile` → `[ERR_PNPM_IGNORED_BUILDS]`，exit 1。
- 修复后：`docker build --target frontend-builder .` 成功通过，前端正常构建产出（`✓ built in 13.66s`，镜像生成成功）。