### PR TITLE
fix(openai): 修复 chat-completions 转 responses 时 content 为 null 导致上游 400

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -225,6 +225,41 @@ func TestChatCompletionsToResponses_WhitespaceOnlyBase64ImageURLSkipped(t *testi
 	assert.Equal(t, "Describe this", parts[0].Text)
 }
 
+func TestChatCompletionsToResponses_EmptyContentNeverNull(t *testing.T) {
+	// Regression for #2515: the upstream Responses API rejects an input item
+	// whose content field is JSON null. Any chat-completions message that
+	// yields no usable content parts must serialize content as a string.
+	cases := []struct {
+		name    string
+		content json.RawMessage
+	}{
+		{"null content", json.RawMessage(`null`)},
+		{"empty array content", json.RawMessage(`[]`)},
+		{"only empty text part", json.RawMessage(`[{"type":"text","text":""}]`)},
+		{"only empty base64 image part", json.RawMessage(`[{"type":"image_url","image_url":{"url":"data:image/png;base64,"}}]`)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := &ChatCompletionsRequest{
+				Model: "gpt-5.5",
+				Messages: []ChatMessage{
+					{Role: "user", Content: tc.content},
+				},
+			}
+			resp, err := ChatCompletionsToResponses(req)
+			require.NoError(t, err)
+			assert.NotContains(t, string(resp.Input), `"content":null`,
+				"converted input must not contain a null content field")
+
+			var items []ResponsesInputItem
+			require.NoError(t, json.Unmarshal(resp.Input, &items))
+			require.Len(t, items, 1)
+			assert.Equal(t, `""`, string(items[0].Content),
+				"content must be an empty string, not null")
+		})
+	}
+}
+
 func TestChatCompletionsToResponses_SystemArrayContent(t *testing.T) {
 	req := &ChatCompletionsRequest{
 		Model: "gpt-4o",

--- a/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_to_responses.go
@@ -325,7 +325,14 @@ func marshalChatInputContent(content chatMessageContent) (json.RawMessage, error
 	if content.Text != nil {
 		return json.Marshal(*content.Text)
 	}
-	return json.Marshal(convertChatContentPartsToResponses(content.Parts))
+	parts := convertChatContentPartsToResponses(content.Parts)
+	if len(parts) == 0 {
+		// A nil slice marshals to JSON null, which the upstream Responses API
+		// rejects ("expected an array of objects or string, but got null").
+		// Fall back to an empty string when no usable parts remain.
+		return json.Marshal("")
+	}
+	return json.Marshal(parts)
 }
 
 func convertChatContentPartsToResponses(parts []ChatContentPart) []ResponsesContentPart {


### PR DESCRIPTION
## 问题

Fixes #2515 。

代理 gpt-5.5 等模型时，入站 `/v1/chat/completions` 请求被转换为上游 `/v1/responses` 请求，偶发上游 400：

```
Invalid type for 'input[xx].content': expected one of an array of objects or string, but got null instead.
```

## 原因

`apicompat/chatcompletions_to_responses.go` 的 `marshalChatInputContent`：当消息内容没有任何「可用内容片段」时（例如 `content: []`、只含空文本片段、或图片片段被过滤掉），`convertChatContentPartsToResponses` 返回 nil slice，`json.Marshal(nil slice)` 会序列化为 JSON `null`。

`ResponsesInputItem.Content` 的 tag 是 `content,omitempty`，但 `json.RawMessage("null")` 长度非 0 不会被 omit，最终输出 `"content": null`，被上游 Responses API 拒绝。

## 改动

`marshalChatInputContent` 在转换结果为空时回退为空字符串，确保 content 字段永远是合法的 string / 数组而非 null：

```go
parts := convertChatContentPartsToResponses(content.Parts)
if len(parts) == 0 {
    return json.Marshal("")
}
return json.Marshal(parts)
```

## 测试

新增回归测试 `TestChatCompletionsToResponses_EmptyContentNeverNull`，覆盖 `null` / `[]` / 空文本片段 / 空图片片段四种场景：

- 修复前：`go test` 失败 —— content 实际序列化为 `null`。
- 修复后：全部通过，content 序列化为 `""`。
- `go test ./internal/pkg/apicompat/`（含 `-tags=unit`）全部通过，`gofmt` / `go vet` 无问题。