### PR TITLE
Fix Codex image_generation tool model

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -83,6 +83,8 @@ const (
 	codexSparkImageUnsupportedText   = codexSparkImageUnsupportedMarker + "\nThe current model is gpt-5.3-codex-spark, which does not support image generation, image editing, image input, the `image_generation` tool, or Codex `image_gen`/`$imagegen` workflows. If the user asks for image generation or image editing, clearly explain this model limitation and ask them to switch to a non-Spark Codex model such as gpt-5.3-codex or gpt-5.4. Do not claim that the local environment merely lacks image_gen tooling, and do not suggest CLI fallback as the primary fix while the model remains Spark.\n</sub2api-codex-spark-image-unsupported>"
 )
 
+const openAIResponsesImageGenerationToolModel = "gpt-image-2"
+
 var openAIChatGPTInternalUnsupportedFields = []string{
 	"user",
 	"metadata",
@@ -667,6 +669,33 @@ func normalizeOpenAIResponsesImageGenerationTools(reqBody map[string]any) bool {
 	return modified
 }
 
+func normalizeOpenAICodexResponsesImageGenerationToolModels(reqBody map[string]any) bool {
+	rawTools, ok := reqBody["tools"]
+	if !ok || rawTools == nil {
+		return false
+	}
+	if isCodexSparkModel(firstNonEmptyString(reqBody["model"])) {
+		return false
+	}
+	tools, ok := rawTools.([]any)
+	if !ok {
+		return false
+	}
+
+	modified := false
+	for _, rawTool := range tools {
+		toolMap, ok := rawTool.(map[string]any)
+		if !ok || strings.TrimSpace(firstNonEmptyString(toolMap["type"])) != "image_generation" {
+			continue
+		}
+		if strings.TrimSpace(firstNonEmptyString(toolMap["model"])) != openAIResponsesImageGenerationToolModel {
+			toolMap["model"] = openAIResponsesImageGenerationToolModel
+			modified = true
+		}
+	}
+	return modified
+}
+
 func ensureOpenAIResponsesImageGenerationTool(reqBody map[string]any) bool {
 	if len(reqBody) == 0 {
 		return false
@@ -677,6 +706,7 @@ func ensureOpenAIResponsesImageGenerationTool(reqBody map[string]any) bool {
 
 	tool := map[string]any{
 		"type":          "image_generation",
+		"model":         openAIResponsesImageGenerationToolModel,
 		"output_format": "png",
 	}
 
@@ -697,7 +727,16 @@ func ensureOpenAIResponsesImageGenerationTool(reqBody map[string]any) bool {
 			continue
 		}
 		if strings.TrimSpace(firstNonEmptyString(toolMap["type"])) == "image_generation" {
-			return false
+			modified := false
+			if strings.TrimSpace(firstNonEmptyString(toolMap["model"])) != openAIResponsesImageGenerationToolModel {
+				toolMap["model"] = openAIResponsesImageGenerationToolModel
+				modified = true
+			}
+			if _, ok := toolMap["output_format"]; !ok && strings.TrimSpace(firstNonEmptyString(toolMap["format"])) == "" {
+				toolMap["output_format"] = "png"
+				modified = true
+			}
+			return modified
 		}
 	}
 

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -545,6 +545,26 @@ func TestNormalizeOpenAIResponsesImageGenerationTools_RewritesLegacyFields(t *te
 	require.False(t, hasCompression)
 }
 
+func TestNormalizeOpenAICodexResponsesImageGenerationToolModels_FixesImageToolModel(t *testing.T) {
+	reqBody := map[string]any{
+		"model": "gpt-5.4",
+		"tools": []any{
+			map[string]any{"type": "image_generation", "model": "gpt-image-1.5", "output_format": "webp"},
+			map[string]any{"type": "web_search"},
+		},
+	}
+
+	modified := normalizeOpenAICodexResponsesImageGenerationToolModels(reqBody)
+	require.True(t, modified)
+
+	tools, ok := reqBody["tools"].([]any)
+	require.True(t, ok)
+	tool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, openAIResponsesImageGenerationToolModel, tool["model"])
+	require.Equal(t, "webp", tool["output_format"])
+}
+
 func TestEnsureOpenAIResponsesImageGenerationTool_NoTools(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.4",
@@ -560,6 +580,7 @@ func TestEnsureOpenAIResponsesImageGenerationTool_NoTools(t *testing.T) {
 	tool, ok := tools[0].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "image_generation", tool["type"])
+	require.Equal(t, openAIResponsesImageGenerationToolModel, tool["model"])
 	require.Equal(t, "png", tool["output_format"])
 }
 
@@ -594,26 +615,28 @@ func TestEnsureOpenAIResponsesImageGenerationTool_AppendsToExistingTools(t *test
 	second, ok := tools[1].(map[string]any)
 	require.True(t, ok)
 	require.Equal(t, "image_generation", second["type"])
+	require.Equal(t, openAIResponsesImageGenerationToolModel, second["model"])
 	require.Equal(t, "png", second["output_format"])
 }
 
-func TestEnsureOpenAIResponsesImageGenerationTool_PreservesExistingImageTool(t *testing.T) {
+func TestEnsureOpenAIResponsesImageGenerationTool_NormalizesExistingImageToolModel(t *testing.T) {
 	reqBody := map[string]any{
 		"model": "gpt-5.4",
 		"tools": []any{
-			map[string]any{"type": "image_generation", "output_format": "webp"},
+			map[string]any{"type": "image_generation", "model": "gpt-image-1.5", "output_format": "webp"},
 			map[string]any{"type": "web_search"},
 		},
 	}
 
 	modified := ensureOpenAIResponsesImageGenerationTool(reqBody)
-	require.False(t, modified)
+	require.True(t, modified)
 
 	tools, ok := reqBody["tools"].([]any)
 	require.True(t, ok)
 	require.Len(t, tools, 2)
 	tool, ok := tools[0].(map[string]any)
 	require.True(t, ok)
+	require.Equal(t, openAIResponsesImageGenerationToolModel, tool["model"])
 	require.Equal(t, "webp", tool["output_format"])
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2144,7 +2144,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		markPatchSet("instructions", "You are a helpful coding assistant.")
 	}
 
-	if codexImageGenerationBridgeEnabled && ensureOpenAIResponsesImageGenerationTool(reqBody) {
+	explicitCodexImageToolChoice := isCodexCLI && imageGenerationAllowed && openAIAnyToolChoiceSelectsImageGeneration(reqBody["tool_choice"])
+	if (codexImageGenerationBridgeEnabled || explicitCodexImageToolChoice) && ensureOpenAIResponsesImageGenerationTool(reqBody) {
 		bodyModified = true
 		disablePatch()
 		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Injected /responses image_generation tool for Codex client")
@@ -2154,6 +2155,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		bodyModified = true
 		disablePatch()
 		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized /responses image_generation tool payload")
+	}
+	if isCodexCLI && normalizeOpenAICodexResponsesImageGenerationToolModels(reqBody) {
+		bodyModified = true
+		disablePatch()
+		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized Codex /responses image_generation tool model")
 	}
 	if codexImageGenerationBridgeEnabled && applyCodexImageGenerationBridgeInstructions(reqBody) {
 		bodyModified = true

--- a/backend/internal/service/openai_image_generation_controls_test.go
+++ b/backend/internal/service/openai_image_generation_controls_test.go
@@ -114,6 +114,10 @@ func TestOpenAIGatewayServiceForward_CodexImageInjectionRespectsGroupCapability(
 			require.NotNil(t, upstream.lastReq)
 			hasImageTool := gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists()
 			require.Equal(t, tt.wantInjected, hasImageTool)
+			if tt.wantInjected {
+				require.Equal(t, openAIResponsesImageGenerationToolModel, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").model`).String())
+				require.Equal(t, "png", gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").output_format`).String())
+			}
 			instructions := gjson.GetBytes(upstream.lastBody, "instructions").String()
 			require.Equal(t, tt.wantInjected, strings.Contains(instructions, "image_generation"))
 		})
@@ -133,7 +137,7 @@ func TestOpenAIGatewayServiceForward_ExplicitImageToolWorksWithBridgeDisabled(t 
 	svc := newOpenAIImageGenerationControlTestService(upstream)
 	c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
 	account := newOpenAIImageGenerationControlTestAccount()
-	body := []byte(`{"model":"gpt-5.4","input":"draw","stream":false,"tools":[{"type":"image_generation","format":"jpeg"}]}`)
+	body := []byte(`{"model":"gpt-5.4","input":"draw","stream":false,"tools":[{"type":"image_generation","model":"gpt-image-1.5","format":"jpeg"}],"tool_choice":{"type":"image_generation"}}`)
 
 	result, err := svc.Forward(context.Background(), c, account, body)
 
@@ -141,10 +145,73 @@ func TestOpenAIGatewayServiceForward_ExplicitImageToolWorksWithBridgeDisabled(t 
 	require.NotNil(t, result)
 	require.NotNil(t, upstream.lastReq)
 	require.True(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists())
+	require.Equal(t, openAIResponsesImageGenerationToolModel, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").model`).String())
 	require.Equal(t, "jpeg", gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").output_format`).String())
 	require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").format`).Exists())
+	require.Equal(t, "image_generation", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
 	instructions := gjson.GetBytes(upstream.lastBody, "instructions").String()
 	require.NotContains(t, instructions, "image_generation")
+}
+
+func TestOpenAIGatewayServiceForward_CodexImageToolUsesImage2AndPreservesMainModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []string{"gpt-5.4", "gpt-5.4-mini", "gpt-5.5"}
+	for _, model := range tests {
+		t.Run(model, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_"+strings.ReplaceAll(model, ".", "_"), model)}
+			svc := newOpenAIImageGenerationControlTestService(upstream)
+			c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
+			account := newOpenAIImageGenerationControlTestOAuthAccount()
+			body := []byte(`{"model":"` + model + `","input":"draw","stream":false,"tool_choice":{"type":"image_generation"}}`)
+
+			result, err := svc.Forward(context.Background(), c, account, body)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, upstream.lastReq)
+			require.Equal(t, model, gjson.GetBytes(upstream.lastBody, "model").String())
+			require.Equal(t, "image_generation", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
+			require.Equal(t, openAIResponsesImageGenerationToolModel, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").model`).String())
+			require.Equal(t, "png", gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation").output_format`).String())
+		})
+	}
+}
+
+func TestOpenAIGatewayServiceForward_CodexTextRequestDoesNotForceImageTool(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_text_only", "gpt-5.4")}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
+	account := newOpenAIImageGenerationControlTestOAuthAccount()
+	body := []byte(`{"model":"gpt-5.4","input":"write code","stream":false}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists())
+}
+
+func TestOpenAIGatewayServiceForward_CodexSparkDoesNotInjectImage2(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_spark", "gpt-5.3-codex-spark")}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	svc.cfg.Gateway.CodexImageGenerationBridgeEnabled = true
+	c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
+	account := newOpenAIImageGenerationControlTestOAuthAccount()
+	body := []byte(`{"model":"gpt-5.3-codex-spark","input":"write code","stream":false}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists())
+	require.Contains(t, gjson.GetBytes(upstream.lastBody, "instructions").String(), codexSparkImageUnsupportedMarker)
 }
 
 func TestOpenAIGatewayServiceForward_ChannelBridgeOverrideEnablesCodexInjection(t *testing.T) {
@@ -373,6 +440,22 @@ func newOpenAIImageGenerationControlTestAccount() *Account {
 		Concurrency: 1,
 		Credentials: map[string]any{
 			"api_key": "sk-test",
+		},
+	}
+}
+
+func newOpenAIImageGenerationControlTestOAuthAccount() *Account {
+	return &Account{
+		ID:          6161,
+		Name:        "openai-image-controls-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
 		},
 	}
 }


### PR DESCRIPTION
## Summary\n- keep Codex main model unchanged while fixing image_generation tool model to gpt-image-2\n- ensure explicit image_generation tool_choice has a matching image_generation tool\n- preserve Spark image unsupported behavior\n\n## Testing\n- git diff --check\n- GitHub Actions pending