### PR TITLE
fix(apicompat): preserve empty streaming thinking blocks

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -744,6 +744,10 @@ func TestStreamingReasoning(t *testing.T) {
 	assert.Equal(t, "content_block_start", events[0].Type)
 	assert.Equal(t, "thinking", events[0].ContentBlock.Type)
 
+	sse, err := ResponsesAnthropicEventToSSE(events[0])
+	require.NoError(t, err)
+	assert.Contains(t, sse, `"content_block":{"thinking":"","type":"thinking"}`)
+
 	// reasoning text delta
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.reasoning_summary_text.delta",

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -75,6 +75,28 @@ type AnthropicContentBlock struct {
 	IsError   bool            `json:"is_error,omitempty"`
 }
 
+func (b AnthropicContentBlock) MarshalJSON() ([]byte, error) {
+	type anthropicContentBlock AnthropicContentBlock
+	base := struct {
+		anthropicContentBlock
+	}{anthropicContentBlock: anthropicContentBlock(b)}
+
+	switch b.Type {
+	case "text":
+		return json.Marshal(struct {
+			Text string `json:"text"`
+			anthropicContentBlock
+		}{Text: b.Text, anthropicContentBlock: anthropicContentBlock(b)})
+	case "thinking":
+		return json.Marshal(struct {
+			Thinking string `json:"thinking"`
+			anthropicContentBlock
+		}{Thinking: b.Thinking, anthropicContentBlock: anthropicContentBlock(b)})
+	default:
+		return json.Marshal(base)
+	}
+}
+
 // AnthropicImageSource describes the source data for an image content block.
 type AnthropicImageSource struct {
 	Type      string `json:"type"` // "base64"


### PR DESCRIPTION
## Summary
- Preserve required empty `thinking` fields when marshaling Anthropic `content_block_start` events for thinking blocks.
- Preserve empty `text` fields for text block starts while keeping other content block fields omitted when empty.
- Add a regression assertion for serialized SSE output so SDK validation catches this shape.

## Test plan
- [x] `go test -C "/Users/xiaoyong/Projects/sub2api/backend" ./internal/pkg/apicompat`
- [x] Verified remote streaming endpoint returns `content_block: {"thinking":"","type":"thinking"}` without errors.

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)