### PR TITLE
fix(setup): 初始化完成后阻止访问 setup 页面

### DIFF
--- a/frontend/src/router/__tests__/guards.spec.ts
+++ b/frontend/src/router/__tests__/guards.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { resolveCompletedSetupRedirectPath } from '@/router/setupRedirect'
 
 // Mock 导航加载状态
 vi.mock('@/composables/useNavigationLoading', () => {
@@ -53,6 +54,7 @@ interface MockAuthState {
   isSimpleMode: boolean
   backendModeEnabled: boolean
   hasPendingAuthSession: boolean
+  setupNeedsSetup?: boolean
 }
 
 /**
@@ -65,6 +67,10 @@ function simulateGuard(
 ): string | null {
   const requiresAuth = toMeta.requiresAuth !== false
   const requiresAdmin = toMeta.requiresAdmin === true
+
+  if (toPath === '/setup' && authState.setupNeedsSetup === false) {
+    return resolveCompletedSetupRedirectPath(authState.isAuthenticated, authState.isAdmin)
+  }
 
   // 不需要认证的路由
   if (!requiresAuth) {
@@ -376,6 +382,32 @@ describe('路由守卫逻辑', () => {
       }
       const redirect = simulateGuard('/setup', { requiresAuth: false }, authState)
       expect(redirect).toBeNull()
+    })
+
+    it('unauthenticated: initialized /setup redirects to /login', () => {
+      const authState: MockAuthState = {
+        isAuthenticated: false,
+        isAdmin: false,
+        isSimpleMode: false,
+        backendModeEnabled: true,
+        hasPendingAuthSession: false,
+        setupNeedsSetup: false,
+      }
+      const redirect = simulateGuard('/setup', { requiresAuth: false }, authState)
+      expect(redirect).toBe('/login')
+    })
+
+    it('admin: initialized /setup redirects to /admin/dashboard', () => {
+      const authState: MockAuthState = {
+        isAuthenticated: true,
+        isAdmin: true,
+        isSimpleMode: false,
+        backendModeEnabled: true,
+        hasPendingAuthSession: false,
+        setupNeedsSetup: false,
+      }
+      const redirect = simulateGuard('/setup', { requiresAuth: false }, authState)
+      expect(redirect).toBe('/admin/dashboard')
     })
 
     it('admin: /admin/dashboard is allowed', () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,8 @@ import { useAppStore } from '@/stores/app'
 import { useAdminSettingsStore } from '@/stores/adminSettings'
 import { useNavigationLoadingState } from '@/composables/useNavigationLoading'
 import { useRoutePrefetch } from '@/composables/useRoutePrefetch'
+import { getSetupStatus } from '@/api/setup'
+import { resolveCompletedSetupRedirectPath } from './setupRedirect'
 import { resolveDocumentTitle } from './title'
 
 /**
@@ -694,7 +696,7 @@ function isBackendModePublicRouteAllowed(path: string, hasPendingAuthSession: bo
   return false
 }
 
-router.beforeEach((to, _from, next) => {
+router.beforeEach(async (to, _from, next) => {
   // 开始导航加载状态
   navigationLoading.startNavigation()
 
@@ -728,6 +730,18 @@ router.beforeEach((to, _from, next) => {
   // Check if route requires authentication
   const requiresAuth = to.meta.requiresAuth !== false // Default to true
   const requiresAdmin = to.meta.requiresAdmin === true
+
+  if (to.path === '/setup') {
+    try {
+      const status = await getSetupStatus()
+      if (!status.needs_setup) {
+        next(resolveCompletedSetupRedirectPath(authStore.isAuthenticated, authStore.isAdmin))
+        return
+      }
+    } catch {
+      // If setup status cannot be determined, keep the setup page reachable.
+    }
+  }
 
   // If route doesn't require auth, allow access
   if (!requiresAuth) {

--- a/frontend/src/router/setupRedirect.ts
+++ b/frontend/src/router/setupRedirect.ts
@@ -1,0 +1,7 @@
+export function resolveCompletedSetupRedirectPath(isAuthenticated: boolean, isAdmin: boolean): string {
+  if (!isAuthenticated) {
+    return '/login'
+  }
+
+  return isAdmin ? '/admin/dashboard' : '/dashboard'
+}


### PR DESCRIPTION
## 背景

Issue #2561 反馈系统初始化完成后仍可手动打开 `/setup` 页面。当前 upstream/main 后端 normal 模式的 `GET /setup/status` 已固定返回 `needs_setup: false`，setup 模式的写接口也已有 `setupGuard` 和安装时二次检查；问题主要在前端路由守卫没有在进入 `/setup` 时根据 setup 状态拦截。

## 改动

- 在前端路由守卫中，当目标路由是 `/setup` 时调用 `/setup/status`。
- 当接口返回 `needs_setup: false` 时阻止继续访问 setup 页面：未登录用户跳转 `/login`，普通用户跳转 `/dashboard`，管理员跳转 `/admin/dashboard`。
- 抽出已初始化后的重定向目标 helper，并补充路由守卫单测覆盖未登录与管理员访问已初始化 setup 页的场景。
- 未改动后端：normal 模式 setup 状态接口和 setup 模式写接口拦截已存在。

## 测试

- `cd frontend && pnpm install`：通过
- `cd frontend && pnpm vitest run src/router/__tests__/guards.spec.ts`：通过，34 tests passed
- `cd frontend && pnpm typecheck`：通过
- `cd frontend && pnpm lint:check`：通过
- `cd frontend && pnpm build`：通过
- `cd frontend && pnpm test:run`：未通过；当前 upstream/main 测试集中存在与本次 setup 路由改动无关的既有失败，主要包括 `AccountUsageCell.spec.ts`、`ModelDistributionChart.spec.ts`、`GroupDistributionChart.spec.ts`、`EmailVerifyView.spec.ts`、`settings.authSourceDefaults.spec.ts`、`usePersistedPageSize.spec.ts` 等共 13 个失败
- 后端未改动，未运行后端测试

Fixes #2561
