### PR TITLE
fix: retry transient billing eligibility failures

### DIFF
--- a/backend/internal/handler/billing_eligibility_retry_test.go
+++ b/backend/internal/handler/billing_eligibility_retry_test.go
@@ -1,0 +1,73 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryBillingEligibility_RetriesTransientAndSucceeds(t *testing.T) {
+	attempts := 0
+	err := retryBillingEligibility(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts < billingEligibilityMaxAttempts {
+			return service.ErrBillingServiceUnavailable.WithCause(errors.New("redis unavailable"))
+		}
+		return nil
+	}, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, billingEligibilityMaxAttempts, attempts)
+}
+
+func TestRetryBillingEligibility_StopsAfterMaxAttemptsForTransient(t *testing.T) {
+	attempts := 0
+	err := retryBillingEligibility(context.Background(), func(context.Context) error {
+		attempts++
+		return service.ErrBillingServiceUnavailable
+	}, nil)
+
+	require.ErrorIs(t, err, service.ErrBillingServiceUnavailable)
+	require.Equal(t, billingEligibilityMaxAttempts, attempts)
+}
+
+func TestRetryBillingEligibility_DoesNotRetryNonTransientBillingError(t *testing.T) {
+	attempts := 0
+	err := retryBillingEligibility(context.Background(), func(context.Context) error {
+		attempts++
+		return service.ErrInsufficientBalance
+	}, nil)
+
+	require.ErrorIs(t, err, service.ErrInsufficientBalance)
+	require.Equal(t, 1, attempts)
+}
+
+func TestRetryBillingEligibility_StopsDuringBackoffWhenContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	attempts := 0
+
+	err := retryBillingEligibility(ctx, func(context.Context) error {
+		attempts++
+		cancel()
+		return service.ErrBillingServiceUnavailable
+	}, []time.Duration{time.Hour, time.Hour})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
+}
+
+func TestBillingEligibilityRetryDelay_UsesConfiguredBackoffsWithSmallJitter(t *testing.T) {
+	backoffs := []time.Duration{100 * time.Millisecond, 300 * time.Millisecond}
+
+	for attempt, base := range backoffs {
+		for i := 0; i < 100; i++ {
+			delay := billingEligibilityRetryDelay(attempt, backoffs)
+			require.GreaterOrEqual(t, delay, base-base/10)
+			require.LessOrEqual(t, delay, base+base/10)
+		}
+	}
+}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -249,7 +249,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	}
 
 	// 2. 【新增】Wait后二次检查余额/订阅
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("gateway.billing_eligibility_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {
@@ -801,7 +801,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 							return
 						}
 						fallbackAPIKey := cloneAPIKeyWithGroup(apiKey, fallbackGroup)
-						if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), fallbackAPIKey.User, fallbackAPIKey, fallbackGroup, nil); err != nil {
+						if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, fallbackAPIKey.User, fallbackAPIKey, fallbackGroup, nil); err != nil {
 							status, code, message, retryAfter := billingErrorDetails(err)
 							if retryAfter > 0 {
 								c.Header("Retry-After", strconv.Itoa(retryAfter))
@@ -1521,7 +1521,7 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 
 	// 校验 billing eligibility（订阅/余额）
 	// 【注意】不计算并发，但需要校验订阅/余额
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {
 			c.Header("Retry-After", strconv.Itoa(retryAfter))

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -140,7 +140,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	}
 
 	// 2. Re-check billing
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("gateway.cc.billing_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -145,7 +145,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 	}
 
 	// 2. Re-check billing
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("gateway.responses.billing_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/rand/v2"
 	"net/http"
@@ -127,6 +128,13 @@ const (
 	maxBackoff = 2 * time.Second
 )
 
+const billingEligibilityMaxAttempts = 3
+
+var billingEligibilityRetryBackoffs = [...]time.Duration{
+	100 * time.Millisecond,
+	300 * time.Millisecond,
+}
+
 // SSEPingFormat defines the format of SSE ping events for different platforms
 type SSEPingFormat string
 
@@ -193,6 +201,72 @@ func wrapReleaseOnDone(ctx context.Context, releaseFunc func()) func() {
 	stop = context.AfterFunc(ctx, release)
 
 	return release
+}
+
+func checkBillingEligibilityWithRetry(ctx context.Context, billingCacheService *service.BillingCacheService, user *service.User, apiKey *service.APIKey, group *service.Group, subscription *service.UserSubscription) error {
+	return retryBillingEligibility(ctx, func(ctx context.Context) error {
+		return billingCacheService.CheckBillingEligibility(ctx, user, apiKey, group, subscription)
+	}, billingEligibilityRetryBackoffs[:])
+}
+
+func retryBillingEligibility(ctx context.Context, check func(context.Context) error, backoffs []time.Duration) error {
+	for attempt := 0; attempt < billingEligibilityMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		err := check(ctx)
+		if err == nil {
+			return nil
+		}
+		if !errors.Is(err, service.ErrBillingServiceUnavailable) {
+			return err
+		}
+		if attempt == billingEligibilityMaxAttempts-1 {
+			return err
+		}
+		if err := waitBillingEligibilityRetryBackoff(ctx, attempt, backoffs); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitBillingEligibilityRetryBackoff(ctx context.Context, attempt int, backoffs []time.Duration) error {
+	delay := billingEligibilityRetryDelay(attempt, backoffs)
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func billingEligibilityRetryDelay(attempt int, backoffs []time.Duration) time.Duration {
+	if attempt < 0 || attempt >= len(backoffs) {
+		return 0
+	}
+	base := backoffs[attempt]
+	if base <= 0 {
+		return 0
+	}
+	jitter := base / 10
+	if jitter <= 0 {
+		return base
+	}
+	delta := time.Duration(rand.Int64N(int64(jitter)*2+1)) - jitter
+	delay := base + delta
+	if delay < 0 {
+		return 0
+	}
+	return delay
 }
 
 // IncrementWaitCount increments the wait count for a user

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -245,7 +245,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 	}
 
 	// 2) billing eligibility check (after wait)
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("gemini.billing_eligibility_check_failed", zap.Error(err))
 		status, _, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -106,7 +106,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		defer userReleaseFunc()
 	}
 
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("openai_chat_completions.billing_eligibility_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -243,7 +243,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	}
 
 	// 2. Re-check billing eligibility after wait
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("openai.billing_eligibility_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {
@@ -633,7 +633,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		defer userReleaseFunc()
 	}
 
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("openai_messages.billing_eligibility_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {
@@ -1208,7 +1208,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	currentUserRelease = wrapReleaseOnDone(ctx, userReleaseFunc)
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
-	if err := h.billingCacheService.CheckBillingEligibility(ctx, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(ctx, h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("openai.websocket_billing_eligibility_check_failed", zap.Error(err))
 		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, "billing check failed")
 		return

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -123,7 +123,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		defer userReleaseFunc()
 	}
 
-	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
+	if err := checkBillingEligibilityWithRetry(c.Request.Context(), h.billingCacheService, apiKey.User, apiKey, apiKey.Group, subscription); err != nil {
 		reqLog.Info("openai.images.billing_eligibility_check_failed", zap.Error(err))
 		status, code, message, retryAfter := billingErrorDetails(err)
 		if retryAfter > 0 {


### PR DESCRIPTION
## Summary
- retry transient billing eligibility failures up to 3 total attempts before returning 503
- add 100ms/300ms jittered backoff that respects request context cancellation
- route all gateway billing eligibility checks through the shared retry helper
- add focused unit tests for transient retry, max attempts, non-transient pass-through, context cancellation, and jitter bounds

## Tests
- /tmp/codex-go1.26.3/bin/go test ./internal/handler -run 'TestRetryBillingEligibility|TestBillingEligibilityRetryDelay|TestBillingErrorDetails' -count=1\n- /tmp/codex-go1.26.3/bin/go test ./internal/handler -count=1