### PR TITLE
fix(admin): 修复专属分组编辑界面"公开/专属"开关消失

### DIFF
--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -1692,7 +1692,7 @@
           />
           <p class="input-hint">{{ t("admin.groups.form.rpmLimitHint") }}</p>
         </div>
-        <div v-if="editForm.subscription_type !== 'subscription'">
+        <div v-if="isEditExclusiveToggleVisible(editForm.subscription_type)">
           <div class="mb-1.5 flex items-center gap-1">
             <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
               {{ t("admin.groups.form.exclusive") }}
@@ -2863,6 +2863,7 @@ import {
   type MessagesDispatchMappingRow,
 } from "./groupsMessagesDispatch";
 import { normalizeSupportedModelScopesForPlatform } from "./groupsSupportedModelScopes";
+import { isEditExclusiveToggleVisible } from "./groupsEditExclusiveToggle";
 
 const { t } = useI18n();
 const appStore = useAppStore();

--- a/frontend/src/views/admin/__tests__/groupsEditExclusiveToggle.spec.ts
+++ b/frontend/src/views/admin/__tests__/groupsEditExclusiveToggle.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isEditExclusiveToggleVisible } from "../groupsEditExclusiveToggle";
+
+/**
+ * Regression tests for https://github.com/Wei-Shaw/sub2api/issues/2584
+ *
+ * The edit form's exclusive/public toggle must always be visible, regardless
+ * of the group's subscription_type. Previously a `v-if` condition hid the
+ * toggle for subscription-type groups, preventing admins from ever switching
+ * them from exclusive to public.
+ */
+describe("isEditExclusiveToggleVisible", () => {
+  it("shows the toggle for subscription-type groups (regression: issue #2584)", () => {
+    expect(isEditExclusiveToggleVisible("subscription")).toBe(true);
+  });
+
+  it("shows the toggle for standard-type groups", () => {
+    expect(isEditExclusiveToggleVisible("standard")).toBe(true);
+  });
+
+  it("shows the toggle for any unknown subscription type", () => {
+    expect(isEditExclusiveToggleVisible("")).toBe(true);
+    expect(isEditExclusiveToggleVisible("future_type")).toBe(true);
+  });
+});

--- a/frontend/src/views/admin/groupsEditExclusiveToggle.ts
+++ b/frontend/src/views/admin/groupsEditExclusiveToggle.ts
@@ -1,0 +1,14 @@
+/**
+ * Returns whether the exclusive/public toggle should be visible in the
+ * group **edit** form.
+ *
+ * Unlike the *create* form — where subscription-type groups are always
+ * exclusive and the toggle is intentionally hidden — the edit form must
+ * expose the toggle for every subscription type so that admins can change
+ * the setting on existing groups.
+ *
+ * @see https://github.com/Wei-Shaw/sub2api/issues/2584
+ */
+export function isEditExclusiveToggleVisible(_subscriptionType: string): boolean {
+  return true
+}


### PR DESCRIPTION
## 背景

关联 issue：[#2584](https://github.com/Wei-Shaw/sub2api/issues/2584)

在编辑**计费类型为"订阅（配额）"的专属分组**时，编辑弹窗中"公开/专属"开关完全消失，导致管理员无法将此类分组从"专属"切回"公开"。

根本原因：`GroupsView.vue` 编辑表单中，开关所在 `<div>` 有条件 `v-if="editForm.subscription_type !== 'subscription'"`，这使得订阅类型分组的开关被隐藏。创建表单也有类似逻辑，但那里是有意为之（创建时订阅分组自动置为专属），因此保持不变。

## 改动

### `frontend/src/views/admin/GroupsView.vue`
- 移除编辑表单 exclusive 开关上的 `v-if="editForm.subscription_type !== 'subscription'"` 条件，改为调用 `isEditExclusiveToggleVisible(editForm.subscription_type)`，使开关在所有订阅类型下均可见。

### `frontend/src/views/admin/groupsEditExclusiveToggle.ts`（新增）
- 提取 `isEditExclusiveToggleVisible` 纯函数，始终返回 `true`，并通过 JSDoc 注释说明设计意图（编辑模式下不应限制开关可见性）。

### `frontend/src/views/admin/__tests__/groupsEditExclusiveToggle.spec.ts`（新增）
- 为上述函数补充回归测试，覆盖 `subscription`、`standard` 及未知类型，防止问题复现。

## 测试

- `pnpm test:run`：新增测试全部通过，其余 pass/fail 数量与 upstream/main 相同，均为环境问题与本次改动无关
- `pnpm typecheck`：无错误
- `pnpm lint:check`：无错误
- 手动验证：编辑一个计费类型为"订阅（配额）"的专属分组，开关已正常显示，可切换为"公开"并保存成功。

Fixes #2584
