### PR TITLE
Sanitize Claude thinking history before OpenAI Responses forwarding

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2369,6 +2369,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		bodyModified = true
 		disablePatch()
 	}
+	if sanitizeOpenAIResponsesInputThinkingFields(reqBody) {
+		bodyModified = true
+		disablePatch()
+	}
 
 	// Apply OpenAI fast policy (参照 Claude BetaPolicy 的 fast-mode 过滤)：
 	// 针对 body 的 service_tier 字段（"priority" 即 fast，"flex"），按策略
@@ -2907,6 +2911,13 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 	if sanitized {
 		body = sanitizedBody
+	}
+	thinkingSanitizedBody, thinkingSanitized, err := sanitizeOpenAIResponsesInputThinkingFieldsInBody(body)
+	if err != nil {
+		return nil, err
+	}
+	if thinkingSanitized {
+		body = thinkingSanitizedBody
 	}
 
 	// Apply OpenAI fast policy to the passthrough body (filter/block by service_tier).
@@ -5174,6 +5185,251 @@ func trimOpenAIEncryptedReasoningItems(reqBody map[string]any) bool {
 		return true
 	default:
 		return false
+	}
+}
+
+// sanitizeOpenAIResponsesInputThinkingFields removes Anthropic-style thinking
+// artifacts from OpenAI Responses input history before forwarding upstream.
+// OpenAI accepts reasoning items, but rejects stray fields such as
+// input[N].thinking and content blocks typed as thinking/redacted_thinking.
+func sanitizeOpenAIResponsesInputThinkingFields(reqBody map[string]any) bool {
+	if len(reqBody) == 0 {
+		return false
+	}
+	inputValue, has := reqBody["input"]
+	if !has {
+		return false
+	}
+	nextInput, changed := sanitizeOpenAIResponsesInputValue(inputValue)
+	if !changed {
+		return false
+	}
+	reqBody["input"] = nextInput
+	return true
+}
+
+func sanitizeOpenAIResponsesInputThinkingFieldsInBody(body []byte) ([]byte, bool, error) {
+	if len(body) == 0 ||
+		(!bytes.Contains(body, []byte(`"thinking"`)) &&
+			!bytes.Contains(body, []byte(`"redacted_thinking"`))) {
+		return body, false, nil
+	}
+
+	var reqBody map[string]any
+	if err := json.Unmarshal(body, &reqBody); err != nil {
+		return body, false, fmt.Errorf("parse OpenAI Responses body for thinking sanitization: %w", err)
+	}
+	if !sanitizeOpenAIResponsesInputThinkingFields(reqBody) {
+		return body, false, nil
+	}
+	normalized, err := json.Marshal(reqBody)
+	if err != nil {
+		return body, false, fmt.Errorf("serialize OpenAI Responses body after thinking sanitization: %w", err)
+	}
+	return normalized, true, nil
+}
+
+func sanitizeOpenAIResponsesInputValue(value any) (any, bool) {
+	switch input := value.(type) {
+	case []any:
+		changed := false
+		out := make([]any, 0, len(input))
+		for _, item := range input {
+			nextItem, itemChanged, keep := sanitizeOpenAIResponsesInputItem(item)
+			if itemChanged {
+				changed = true
+			}
+			if keep {
+				out = append(out, nextItem)
+			}
+		}
+		if !changed {
+			return value, false
+		}
+		return out, true
+	case []map[string]any:
+		changed := false
+		out := make([]map[string]any, 0, len(input))
+		for _, item := range input {
+			nextItem, itemChanged, keep := sanitizeOpenAIResponsesInputItem(item)
+			if itemChanged {
+				changed = true
+			}
+			if !keep {
+				continue
+			}
+			if nextMap, ok := nextItem.(map[string]any); ok {
+				out = append(out, nextMap)
+			} else {
+				out = append(out, item)
+			}
+		}
+		if !changed {
+			return value, false
+		}
+		return out, true
+	case map[string]any:
+		nextItem, changed, keep := sanitizeOpenAIResponsesInputItem(input)
+		if !changed {
+			return value, false
+		}
+		if !keep {
+			return []any{}, true
+		}
+		return nextItem, true
+	default:
+		return value, false
+	}
+}
+
+func sanitizeOpenAIResponsesInputItem(item any) (next any, changed bool, keep bool) {
+	inputItem, ok := item.(map[string]any)
+	if !ok {
+		return item, false, true
+	}
+
+	itemType, _ := inputItem["type"].(string)
+	if itemType == "redacted_thinking" {
+		return nil, true, false
+	}
+	if itemType == "thinking" {
+		if thinkingText := openAIResponsesThinkingText(inputItem); thinkingText != "" {
+			return map[string]any{
+				"type":    "message",
+				"role":    "assistant",
+				"content": []any{openAIResponsesTextBlock("assistant", thinkingText)},
+			}, true, true
+		}
+		return nil, true, false
+	}
+
+	if _, hasThinking := inputItem["thinking"]; hasThinking {
+		delete(inputItem, "thinking")
+		changed = true
+	}
+	if _, hasRedacted := inputItem["redacted_thinking"]; hasRedacted {
+		delete(inputItem, "redacted_thinking")
+		changed = true
+	}
+
+	if content, hasContent := inputItem["content"]; hasContent {
+		role, _ := inputItem["role"].(string)
+		nextContent, contentChanged := sanitizeOpenAIResponsesContentValue(content, role)
+		if contentChanged {
+			inputItem["content"] = nextContent
+			changed = true
+		}
+	}
+
+	return inputItem, changed, true
+}
+
+func sanitizeOpenAIResponsesContentValue(value any, role string) (any, bool) {
+	switch content := value.(type) {
+	case []any:
+		changed := false
+		out := make([]any, 0, len(content))
+		for _, block := range content {
+			nextBlock, blockChanged, keep := sanitizeOpenAIResponsesContentBlock(block, role)
+			if blockChanged {
+				changed = true
+			}
+			if keep {
+				out = append(out, nextBlock)
+			}
+		}
+		if !changed {
+			return value, false
+		}
+		return out, true
+	case []map[string]any:
+		changed := false
+		out := make([]map[string]any, 0, len(content))
+		for _, block := range content {
+			nextBlock, blockChanged, keep := sanitizeOpenAIResponsesContentBlock(block, role)
+			if blockChanged {
+				changed = true
+			}
+			if !keep {
+				continue
+			}
+			if nextMap, ok := nextBlock.(map[string]any); ok {
+				out = append(out, nextMap)
+			} else {
+				out = append(out, block)
+			}
+		}
+		if !changed {
+			return value, false
+		}
+		return out, true
+	case map[string]any:
+		nextBlock, changed, keep := sanitizeOpenAIResponsesContentBlock(content, role)
+		if !changed {
+			return value, false
+		}
+		if !keep {
+			return []any{}, true
+		}
+		return []any{nextBlock}, true
+	default:
+		return value, false
+	}
+}
+
+func sanitizeOpenAIResponsesContentBlock(block any, role string) (next any, changed bool, keep bool) {
+	blockMap, ok := block.(map[string]any)
+	if !ok {
+		return block, false, true
+	}
+	blockType, _ := blockMap["type"].(string)
+	switch blockType {
+	case "redacted_thinking":
+		return nil, true, false
+	case "thinking":
+		if thinkingText := openAIResponsesThinkingText(blockMap); thinkingText != "" {
+			return openAIResponsesTextBlock(role, thinkingText), true, true
+		}
+		return nil, true, false
+	}
+
+	if blockType == "" {
+		if thinkingText := openAIResponsesThinkingText(blockMap); thinkingText != "" {
+			return openAIResponsesTextBlock(role, thinkingText), true, true
+		}
+	}
+	if _, hasThinking := blockMap["thinking"]; hasThinking {
+		delete(blockMap, "thinking")
+		changed = true
+	}
+	if _, hasRedacted := blockMap["redacted_thinking"]; hasRedacted {
+		delete(blockMap, "redacted_thinking")
+		changed = true
+	}
+	return blockMap, changed, true
+}
+
+func openAIResponsesThinkingText(block map[string]any) string {
+	if block == nil {
+		return ""
+	}
+	if text, ok := block["thinking"].(string); ok {
+		if strings.TrimSpace(text) == "" {
+			return ""
+		}
+		return text
+	}
+	return ""
+}
+
+func openAIResponsesTextBlock(role, text string) map[string]any {
+	blockType := "input_text"
+	if strings.TrimSpace(role) == "assistant" {
+		blockType = "output_text"
+	}
+	return map[string]any{
+		"type": blockType,
+		"text": text,
 	}
 }
 

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -548,6 +548,92 @@ func TestOpenAIGatewayService_OAuthPassthrough_DisabledUsesLegacyTransform(t *te
 	require.Contains(t, string(upstream.lastBody), `"stream":true`)
 }
 
+func TestOpenAIGatewayService_OAuthLegacy_StripsUnsupportedThinkingFromResponsesInput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	inputBody := []byte(`{"model":"gpt-5.5","stream":false,"store":true,"input":[{"type":"message","role":"assistant","thinking":"internal trace","content":[{"type":"thinking","thinking":"nested trace"},{"type":"redacted_thinking","data":"sealed"},{"type":"output_text","text":"visible"}]},{"type":"reasoning","summary":[],"thinking":"unsupported but item is otherwise valid"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": false},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, inputBody)
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.NotContains(t, string(upstream.lastBody), `"thinking"`)
+	require.NotContains(t, string(upstream.lastBody), `"redacted_thinking"`)
+	require.Contains(t, string(upstream.lastBody), "nested trace")
+	require.Contains(t, string(upstream.lastBody), "visible")
+}
+
+func TestOpenAIGatewayService_OAuthPassthrough_StripsUnsupportedThinkingFromResponsesInput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	inputBody := []byte(`{"model":"gpt-5.5","instructions":"test","stream":false,"store":true,"input":[{"type":"message","role":"assistant","thinking":"internal trace","content":[{"type":"thinking","thinking":"nested trace"},{"type":"output_text","text":"visible","thinking":"stray field"}]},{"type":"reasoning","summary":[],"thinking":"unsupported but item is otherwise valid"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.1.0")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:             123,
+		Name:           "acc",
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          map[string]any{"openai_passthrough": true},
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, inputBody)
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.thinking").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input.1.thinking").Exists())
+	require.Equal(t, "reasoning", gjson.GetBytes(upstream.lastBody, "input.1.type").String())
+	require.Equal(t, "output_text", gjson.GetBytes(upstream.lastBody, "input.0.content.0.type").String())
+	require.Equal(t, "nested trace", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	require.Equal(t, "visible", gjson.GetBytes(upstream.lastBody, "input.0.content.1.text").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.content.1.thinking").Exists())
+	require.NotContains(t, string(upstream.lastBody), "stray field")
+}
+
 func TestOpenAIGatewayService_OAuthLegacy_UpstreamRequestIgnoresClientCancel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

This fixes OpenAI Responses requests that fail when Claude-style clients replay historical thinking fields in the input history.

Some clients can send Responses input items containing Anthropic-style fields such as:

- `input[N].thinking`
- content blocks with `type: "thinking"`
- content blocks/items with `type: "redacted_thinking"`

The OpenAI Responses upstream rejects these with `unknown_parameter`, for example:

```text
Unknown parameter: 'input[130].thinking'
```

That upstream 400 is currently surfaced by the gateway as a failed Responses request, and in failover paths can become a 502 to the client.

## Changes

- Normalize OpenAI Responses input history before upstream forwarding.
- Apply the normalization in both OAuth forwarding paths:
  - transformed OAuth Responses path
  - OAuth passthrough path
- Remove unsupported `thinking` / `redacted_thinking` fields from input items and content blocks.
- Convert explicit `type: "thinking"` content blocks to normal text blocks so historical context is preserved where possible.
- Preserve valid OpenAI Responses `type: "reasoning"` items instead of dropping them wholesale.
- Add regression coverage for both OAuth legacy transform and OAuth passthrough behavior.

## Why not route to Chat Completions?

Routing long-context traffic to Chat Completions avoids this specific schema error, but it changes endpoint semantics, reasoning parameters, usage accounting, tool/event behavior, and prompt-cache behavior. This PR keeps traffic on Responses and normalizes only the unsupported input-history fields.

## Test Plan

```bash
cd backend
go test ./internal/service -run 'OpenAI|Passthrough|Responses'
go test ./...
```
