### PR TITLE
fix(keys): use OPENAI_API_KEY auth for Codex CLI config template

### DIFF
--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -544,7 +544,8 @@ model_auto_compact_token_limit = 900000
 name = "OpenAI"
 base_url = "${baseUrl}"
 wire_api = "responses"
-requires_openai_auth = true`
+env_key = "OPENAI_API_KEY"
+requires_openai_auth = false`
 
   // auth.json content
   const authContent = `{
@@ -584,7 +585,8 @@ name = "OpenAI"
 base_url = "${baseUrl}"
 wire_api = "responses"
 supports_websockets = true
-requires_openai_auth = true
+env_key = "OPENAI_API_KEY"
+requires_openai_auth = false
 
 [features]
 responses_websockets_v2 = true`


### PR DESCRIPTION
## Summary

The "Use Key" dialog's Codex setup template (`UseKeyModal.vue`) emits a `~/.codex/config.toml` with `requires_openai_auth = true`, but the companion `~/.codex/auth.json` only contains `{"OPENAI_API_KEY": "..."}` — no OAuth tokens.

With `requires_openai_auth = true`, Codex CLI prefers OAuth bearer tokens from `auth.json.tokens.*` over the `OPENAI_API_KEY` field. This fails in two cases:

1. **User previously ran `codex login` against chatgpt.com.** Their existing `auth.json.tokens.access_token` is a ChatGPT OAuth token, not a sub2api API key. Codex sends that as `Authorization: Bearer ...` to sub2api, which rightly rejects it as `INVALID_API_KEY`.
2. **Fresh user follows the template verbatim.** No OAuth tokens exist, but `requires_openai_auth = true` still signals OpenAI-style auth flow; behavior is version-dependent and at minimum confusing.

## Fix

Switch to `requires_openai_auth = false` and add an explicit `env_key = "OPENAI_API_KEY"` so Codex CLI unambiguously reads `OPENAI_API_KEY` from the environment or `auth.json` and sends the sub2api-issued key as the Bearer.

Both `generateOpenAIFiles` (CLI variant) and `generateOpenAIWsFiles` (WebSocket v2 variant) updated.

## Reproduction

Tested on `sub2api v0.1.128` self-hosted at `https://sub2api.stg.<redacted>/`.

Before patch (template verbatim, user had prior `codex login`):

```
codex exec "say hi"
ERROR: unexpected status 401 Unauthorized: {"code":"INVALID_API_KEY","message":"Invalid API key"},
       url: https://sub2api.stg.<redacted>/responses
```

Meanwhile direct curl with the same key works:
```
curl https://sub2api.stg.<redacted>/v1/models \
  -H "Authorization: Bearer sk-<sub2api-issued-key>"
# 200 OK
```

After patch:
```
codex exec "say hi"
codex
Hi — what can I help with?
tokens used: 24,048
```

## Notes / non-goals

- `base_url` is left as `${baseUrl}` (without `/v1`) on purpose — both `/responses` and `/v1/responses` route to the same auto-routing handler in `gateway.go`, gated only by `RequireGroupAssignment` (the `requireGroupAnthropic` name is historical; it accepts any grouped key). So the URL-prefix is not the bug.
- This does not change behavior for users who explicitly want OAuth-style auth (e.g., direct chatgpt.com login). Self-hosted sub2api always uses the issued API key, which is what this template's `auth.json` already implies.

## Test plan

- [x] Manual: with patched template, `codex exec` round-trips through sub2api → upstream → returns answer.
- [ ] Frontend unit test in `UseKeyModal.spec.ts` for the emitted config (existing tests assert structure but not these specific fields — happy to add if reviewer wants).