### PR TITLE
feat(accounts): 支持导入账号按分组名绑定

### DIFF
--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -53,6 +53,7 @@ type DataAccount struct {
 	Type               string         `json:"type"`
 	Credentials        map[string]any `json:"credentials"`
 	Extra              map[string]any `json:"extra,omitempty"`
+	GroupName          string         `json:"group_name,omitempty"`
 	ProxyKey           *string        `json:"proxy_key,omitempty"`
 	Concurrency        int            `json:"concurrency"`
 	Priority           int            `json:"priority"`
@@ -80,6 +81,13 @@ type DataImportError struct {
 	Name     string `json:"name,omitempty"`
 	ProxyKey string `json:"proxy_key,omitempty"`
 	Message  string `json:"message"`
+}
+
+type dataImportGroupResolver struct {
+	handler      *AccountHandler
+	loadedGroups bool
+	groups       []service.Group
+	groupIDByKey map[string]int64
 }
 
 func buildProxyKey(protocol, host string, port int, username, password string) string {
@@ -200,6 +208,7 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 
 	dataPayload := req.Data
 	result := DataImportResult{}
+	groupResolver := newDataImportGroupResolver(h)
 
 	existingProxies, err := h.listAllProxies(ctx)
 	if err != nil {
@@ -303,6 +312,20 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 		}
 
 		enrichCredentialsFromIDToken(&item)
+		groupIDs, groupErr := groupResolver.resolve(ctx, item.GroupName, item.Platform)
+		if groupErr != nil {
+			result.AccountFailed++
+			result.Errors = append(result.Errors, DataImportError{
+				Kind:    "account",
+				Name:    item.Name,
+				Message: groupErr.Error(),
+			})
+			continue
+		}
+		accountSkipDefaultGroupBind := skipDefaultGroupBind
+		if strings.TrimSpace(item.GroupName) != "" && len(groupIDs) == 0 {
+			accountSkipDefaultGroupBind = true
+		}
 
 		accountInput := &service.CreateAccountInput{
 			Name:                 item.Name,
@@ -315,10 +338,10 @@ func (h *AccountHandler) importData(ctx context.Context, req DataImportRequest) 
 			Concurrency:          item.Concurrency,
 			Priority:             item.Priority,
 			RateMultiplier:       item.RateMultiplier,
-			GroupIDs:             nil,
+			GroupIDs:             groupIDs,
 			ExpiresAt:            item.ExpiresAt,
 			AutoPauseOnExpired:   item.AutoPauseOnExpired,
-			SkipDefaultGroupBind: skipDefaultGroupBind,
+			SkipDefaultGroupBind: accountSkipDefaultGroupBind,
 		}
 
 		created, err := h.adminService.CreateAccount(ctx, accountInput)
@@ -374,6 +397,60 @@ func (h *AccountHandler) listAllProxies(ctx context.Context) ([]service.Proxy, e
 		page++
 	}
 	return out, nil
+}
+
+func newDataImportGroupResolver(h *AccountHandler) *dataImportGroupResolver {
+	return &dataImportGroupResolver{
+		handler:      h,
+		groupIDByKey: make(map[string]int64),
+	}
+}
+
+func (r *dataImportGroupResolver) resolve(ctx context.Context, groupName, platform string) ([]int64, error) {
+	groupName = strings.TrimSpace(groupName)
+	if r == nil || groupName == "" {
+		return nil, nil
+	}
+
+	platform = strings.TrimSpace(platform)
+	if platform == "" {
+		return nil, errors.New("account platform is required")
+	}
+	cacheKey := platform + "\x00" + groupName
+	if groupID, ok := r.groupIDByKey[cacheKey]; ok {
+		if groupID <= 0 {
+			return nil, nil
+		}
+		return []int64{groupID}, nil
+	}
+
+	if err := r.loadGroups(ctx); err != nil {
+		return nil, err
+	}
+	for i := range r.groups {
+		group := r.groups[i]
+		if group.Name != groupName || group.Platform != platform {
+			continue
+		}
+		r.groupIDByKey[cacheKey] = group.ID
+		return []int64{group.ID}, nil
+	}
+
+	r.groupIDByKey[cacheKey] = 0
+	return nil, nil
+}
+
+func (r *dataImportGroupResolver) loadGroups(ctx context.Context) error {
+	if r.loadedGroups {
+		return nil
+	}
+	groups, err := r.handler.adminService.GetAllGroups(ctx)
+	if err != nil {
+		return err
+	}
+	r.groups = groups
+	r.loadedGroups = true
+	return nil
 }
 
 func (h *AccountHandler) listAccountsFiltered(ctx context.Context, platform, accountType, status, search string, groupID int64, privacyMode, sortBy, sortOrder string) ([]service.Account, error) {

--- a/backend/internal/handler/admin/account_data_handler_test.go
+++ b/backend/internal/handler/admin/account_data_handler_test.go
@@ -41,6 +41,7 @@ type dataAccount struct {
 	Type        string         `json:"type"`
 	Credentials map[string]any `json:"credentials"`
 	Extra       map[string]any `json:"extra"`
+	GroupName   string         `json:"group_name"`
 	ProxyKey    *string        `json:"proxy_key"`
 	Concurrency int            `json:"concurrency"`
 	Priority    int            `json:"priority"`
@@ -273,5 +274,116 @@ func TestImportDataReusesProxyAndSkipsDefaultGroup(t *testing.T) {
 
 	require.Len(t, adminSvc.createdProxies, 0)
 	require.Len(t, adminSvc.createdAccounts, 1)
+	require.True(t, adminSvc.createdAccounts[0].SkipDefaultGroupBind)
+}
+
+func TestImportDataBindsAccountsToExistingGroupName(t *testing.T) {
+	router, adminSvc := setupAccountDataRouter()
+	adminSvc.groups = []service.Group{
+		{ID: 88, Name: "import-group", Platform: service.PlatformOpenAI, Status: service.StatusActive},
+	}
+
+	dataPayload := map[string]any{
+		"data": map[string]any{
+			"type":    dataType,
+			"version": dataVersion,
+			"proxies": []map[string]any{},
+			"accounts": []map[string]any{
+				{
+					"name":        "acc",
+					"platform":    service.PlatformOpenAI,
+					"type":        service.AccountTypeOAuth,
+					"credentials": map[string]any{"token": "x"},
+					"group_name":  "import-group",
+					"concurrency": 3,
+					"priority":    50,
+				},
+			},
+		},
+		"skip_default_group_bind": true,
+	}
+
+	body, _ := json.Marshal(dataPayload)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/data", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, adminSvc.createdAccounts, 1)
+	require.Equal(t, []int64{88}, adminSvc.createdAccounts[0].GroupIDs)
+}
+
+func TestImportDataSkipsGroupNameWhenMissing(t *testing.T) {
+	router, adminSvc := setupAccountDataRouter()
+	adminSvc.groups = nil
+
+	dataPayload := map[string]any{
+		"data": map[string]any{
+			"type":    dataType,
+			"version": dataVersion,
+			"proxies": []map[string]any{},
+			"accounts": []map[string]any{
+				{
+					"name":        "acc",
+					"platform":    service.PlatformGemini,
+					"type":        service.AccountTypeOAuth,
+					"credentials": map[string]any{"token": "x"},
+					"group_name":  "new-import-group",
+					"concurrency": 3,
+					"priority":    50,
+				},
+			},
+		},
+		"skip_default_group_bind": false,
+	}
+
+	body, _ := json.Marshal(dataPayload)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/data", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, adminSvc.createdAccounts, 1)
+	require.Empty(t, adminSvc.createdAccounts[0].GroupIDs)
+	require.True(t, adminSvc.createdAccounts[0].SkipDefaultGroupBind)
+}
+
+func TestImportDataSkipsGroupNameFromDifferentPlatform(t *testing.T) {
+	router, adminSvc := setupAccountDataRouter()
+	adminSvc.groups = []service.Group{
+		{ID: 88, Name: "import-group", Platform: service.PlatformOpenAI, Status: service.StatusActive},
+	}
+
+	dataPayload := map[string]any{
+		"data": map[string]any{
+			"type":    dataType,
+			"version": dataVersion,
+			"proxies": []map[string]any{},
+			"accounts": []map[string]any{
+				{
+					"name":        "acc",
+					"platform":    service.PlatformGemini,
+					"type":        service.AccountTypeOAuth,
+					"credentials": map[string]any{"token": "x"},
+					"group_name":  "import-group",
+					"concurrency": 3,
+					"priority":    50,
+				},
+			},
+		},
+		"skip_default_group_bind": false,
+	}
+
+	body, _ := json.Marshal(dataPayload)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/data", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, adminSvc.createdAccounts, 1)
+	require.Empty(t, adminSvc.createdAccounts[0].GroupIDs)
 	require.True(t, adminSvc.createdAccounts[0].SkipDefaultGroupBind)
 }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2860,7 +2860,7 @@ export default {
       dataExportFailed: 'Failed to export data',
       dataImportTitle: 'Import Data',
       dataImportHint: 'Upload the exported JSON file to import accounts and proxies.',
-      dataImportWarning: 'Import will create new accounts/proxies; groups must be bound manually. Ensure existing data does not conflict.',
+      dataImportWarning: 'Import will create new accounts/proxies. Add group_name inside each account JSON to bind it when a same-name group exists on the same platform; otherwise group binding is skipped.',
       dataImportFile: 'Data file',
       dataImportButton: 'Start Import',
       dataImporting: 'Importing...',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2936,7 +2936,7 @@ export default {
       dataExportFailed: '数据导出失败',
       dataImportTitle: '导入数据',
       dataImportHint: '上传导出的 JSON 文件以批量导入账号与代理。',
-      dataImportWarning: '导入将创建新账号与代理，分组需手工绑定；请确认已有数据不会冲突。',
+      dataImportWarning: '导入将创建新账号与代理；账号 JSON 中可设置 group_name，存在同名且同平台分组时会自动绑定，否则跳过分组绑定。',
       dataImportFile: '数据文件',
       dataImportButton: '开始导入',
       dataImporting: '导入中...',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1093,6 +1093,7 @@ export interface AdminDataAccount {
   type: AccountType
   credentials: Record<string, unknown>
   extra?: Record<string, unknown>
+  group_name?: string
   proxy_key?: string | null
   concurrency: number
   priority: number


### PR DESCRIPTION
## Summary
- support per-account `group_name` in admin account data import JSON
- bind imported accounts only when a same-name group exists on the same platform
- skip group binding without failing when the group is missing or belongs to another platform

## Tests
- `go test ./internal/handler/admin`
- `pnpm run typecheck`