### PR TITLE
fix: typo in OAuth test function name (Triming -> Trimming)

### DIFF
--- a/backend/internal/pkg/geminicli/oauth_test.go
+++ b/backend/internal/pkg/geminicli/oauth_test.go
@@ -665,7 +665,7 @@ func TestEffectiveOAuthConfig_MixedCommaAndSpaceScopes(t *testing.T) {
 	}
 }
 
-func TestEffectiveOAuthConfig_WhitespaceTriming(t *testing.T) {
+func TestEffectiveOAuthConfig_WhitespaceTrimming(t *testing.T) {
 	// 输入中的前后空白应被清理
 	cfg, err := EffectiveOAuthConfig(OAuthConfig{
 		ClientID:     "  custom-id  ",


### PR DESCRIPTION
## Summary

Fixes a typo in the OAuth test file where the test function name was misspelled.

## Changes

- 
  - Renamed 
 to 

## Related Issue

Closes #2627

## Checklist

- [x] This is a minor spelling fix with no functional changes
- [ ] go test -tags=unit ./... (N/A - test function rename only)
- [ ] go test -tags=integration ./... (N/A - test function rename only)

## CLA

I have read the CLA Document and I hereby sign the CLA