### PR TITLE
fix(deploy): load .env into sub2api via env_file

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -207,6 +207,15 @@ docker compose down -v
 
 ### Environment Variables
 
+`deploy/.env` now serves two purposes for Docker deployments:
+
+- Compose variable substitution such as `${SERVER_PORT}`
+- Container environment injection for `sub2api` via `env_file`
+
+This means application-level settings in `.env` (for example `LOG_*`,
+`SERVER_H2C_*`, `SERVER_MAX_REQUEST_BODY_SIZE`) are available to the app
+without needing to duplicate each one in `docker-compose*.yml`.
+
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `POSTGRES_PASSWORD` | **Yes** | - | PostgreSQL password |

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -15,6 +15,8 @@ services:
       dockerfile: Dockerfile
     container_name: sub2api-dev
     restart: unless-stopped
+    env_file:
+      - .env
     ports:
       - "${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}:8080"
     volumes:

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -27,6 +27,8 @@ services:
     image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
+    env_file:
+      - .env
     ulimits:
       nofile:
         soft: 100000

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -15,6 +15,8 @@ services:
     image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
+    env_file:
+      - .env
     ulimits:
       nofile:
         soft: 100000

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
+    env_file:
+      - .env
     ulimits:
       nofile:
         soft: 100000


### PR DESCRIPTION
Closes #2630.

## Summary

This change loads `deploy/.env` into the `sub2api` container via `env_file` across the Docker deployment variants, while keeping the existing `environment` entries for required-value checks and deployment-specific overrides.

It also documents that behavior in `deploy/README.md` so users understand that `.env` now serves both Compose substitution and application env injection.

## Why

The backend already supports many application-level settings from process environment variables, but the Compose files only forwarded a small subset of them. That made settings documented in `.env.example` ineffective in Docker deployments unless they were duplicated manually into `environment:`.

## Validation

- Parsed all updated Compose YAML files successfully with `python3` + `yaml.safe_load`
