### PR TITLE
fix(payment): stop logging webhook raw bodies

### DIFF
--- a/backend/internal/handler/payment_webhook_handler.go
+++ b/backend/internal/handler/payment_webhook_handler.go
@@ -26,9 +26,6 @@ type PaymentWebhookHandler struct {
 // maxWebhookBodySize is the maximum allowed webhook request body size (1 MB).
 const maxWebhookBodySize = 1 << 20
 
-// webhookLogTruncateLen is the maximum length of raw body logged on verify failure.
-const webhookLogTruncateLen = 200
-
 // NewPaymentWebhookHandler creates a new PaymentWebhookHandler.
 func NewPaymentWebhookHandler(paymentService *service.PaymentService, registry *payment.Registry) *PaymentWebhookHandler {
 	return &PaymentWebhookHandler{
@@ -105,12 +102,7 @@ func (h *PaymentWebhookHandler) handleNotify(c *gin.Context, providerKey string)
 
 	resolvedProviderKey, notification, err := verifyNotificationWithProviders(c.Request.Context(), providers, rawBody, headers)
 	if err != nil {
-		truncatedBody := rawBody
-		if len(truncatedBody) > webhookLogTruncateLen {
-			truncatedBody = truncatedBody[:webhookLogTruncateLen] + "...(truncated)"
-		}
 		slog.Error("[Payment Webhook] verify failed", "provider", providerKey, "error", err, "method", c.Request.Method, "bodyLen", len(rawBody))
-		slog.Debug("[Payment Webhook] verify failed body", "provider", providerKey, "rawBody", truncatedBody)
 		c.String(http.StatusBadRequest, "verify failed")
 		return
 	}

--- a/backend/internal/handler/payment_webhook_handler_test.go
+++ b/backend/internal/handler/payment_webhook_handler_test.go
@@ -141,10 +141,6 @@ func TestWebhookConstants(t *testing.T) {
 	t.Run("maxWebhookBodySize is 1MB", func(t *testing.T) {
 		assert.Equal(t, int64(1<<20), int64(maxWebhookBodySize))
 	})
-
-	t.Run("webhookLogTruncateLen is 200", func(t *testing.T) {
-		assert.Equal(t, 200, webhookLogTruncateLen)
-	})
 }
 
 func TestExtractOutTradeNo(t *testing.T) {


### PR DESCRIPTION
Closes #2632.

## Summary

This change removes raw webhook request body logging from the verification-failure path in `PaymentWebhookHandler`.

The handler now keeps only minimal structured metadata in the failure log:

- provider
- verification error
- HTTP method
- body length

## Why

Webhook payloads can contain payment-related business data such as order IDs, trade IDs, amounts, currencies, and provider event metadata. Truncating the raw body does not meaningfully sanitize that information, so logging payload fragments is an unnecessary leakage risk.

## Validation

- Ran handler unit tests from `backend/`
- Command: `go test -tags unit ./internal/handler -run TestWebhookConstants|TestExtractOutTradeNo|TestVerifyNotificationWithProviders|TestWriteSuccessResponse|TestUnknownOrderWebhookAcksWithSuccess`
