### PR TITLE
fix(logredact): cover payment and cloud secrets

### DIFF
--- a/backend/internal/util/logredact/redact.go
+++ b/backend/internal/util/logredact/redact.go
@@ -11,18 +11,7 @@ import (
 // maxRedactDepth 限制递归深度以防止栈溢出
 const maxRedactDepth = 32
 
-var defaultSensitiveKeys = map[string]struct{}{
-	"authorization_code": {},
-	"code":               {},
-	"code_verifier":      {},
-	"access_token":       {},
-	"refresh_token":      {},
-	"id_token":           {},
-	"client_secret":      {},
-	"password":           {},
-}
-
-var defaultSensitiveKeyList = []string{
+var defaultSensitiveRawKeys = []string{
 	"authorization_code",
 	"code",
 	"code_verifier",
@@ -31,7 +20,35 @@ var defaultSensitiveKeyList = []string{
 	"id_token",
 	"client_secret",
 	"password",
+	"api_key",
+	"api-key",
+	"x-api-key",
+	"x-goog-api-key",
+	"private_key",
+	"privateKey",
+	"api_v3_key",
+	"apiV3Key",
+	"app_secret",
+	"appSecret",
+	"open_app_secret",
+	"openAppSecret",
+	"mp_app_secret",
+	"mpAppSecret",
+	"mobile_app_secret",
+	"mobileAppSecret",
+	"mch_id",
+	"mchId",
+	"secret_access_key",
+	"aws_secret_access_key",
 }
+
+var defaultSensitiveKeys = func() map[string]struct{} {
+	keys := make(map[string]struct{}, len(defaultSensitiveRawKeys))
+	for _, key := range defaultSensitiveRawKeys {
+		keys[normalizeKey(key)] = struct{}{}
+	}
+	return keys
+}()
 
 type textRedactPatterns struct {
 	reJSONLike  *regexp.Regexp
@@ -160,9 +177,9 @@ func normalizeAndSortExtraKeys(extraKeys []string) []string {
 }
 
 func buildKeyAlternation(extraKeys []string) string {
-	seen := make(map[string]struct{}, len(defaultSensitiveKeyList)+len(extraKeys))
-	keys := make([]string, 0, len(defaultSensitiveKeyList)+len(extraKeys))
-	for _, k := range defaultSensitiveKeyList {
+	seen := make(map[string]struct{}, len(defaultSensitiveRawKeys)+len(extraKeys))
+	keys := make([]string, 0, len(defaultSensitiveRawKeys)+len(extraKeys))
+	for _, k := range defaultSensitiveRawKeys {
 		seen[k] = struct{}{}
 		keys = append(keys, regexp.QuoteMeta(k))
 	}

--- a/backend/internal/util/logredact/redact_test.go
+++ b/backend/internal/util/logredact/redact_test.go
@@ -67,6 +67,68 @@ func TestRedactText_DefaultPathDoesNotUseExtraCache(t *testing.T) {
 	}
 }
 
+func TestRedactMap_DefaultSensitiveVariantKeys(t *testing.T) {
+	in := map[string]any{
+		"api_key":           "sk-test",
+		"x-api-key":         "header-secret",
+		"privateKey":        "pem-secret",
+		"apiV3Key":          "wxpay-secret",
+		"appSecret":         "wechat-secret",
+		"mchId":             "merchant-id",
+		"secret_access_key": "aws-secret",
+		"safe":              "ok",
+	}
+
+	out := RedactMap(in)
+
+	for _, key := range []string{
+		"api_key",
+		"x-api-key",
+		"privateKey",
+		"apiV3Key",
+		"appSecret",
+		"mchId",
+		"secret_access_key",
+	} {
+		if got := out[key]; got != "***" {
+			t.Fatalf("expected %s to be redacted, got %#v", key, got)
+		}
+	}
+	if got := out["safe"]; got != "ok" {
+		t.Fatalf("expected safe key preserved, got %#v", got)
+	}
+}
+
+func TestRedactText_DefaultSensitiveVariantForms(t *testing.T) {
+	in := `api-key=sk-live x-api-key=hdr-secret privateKey: pem-secret apiV3Key=wxpay-secret appSecret=wechat-secret secret_access_key=aws-secret`
+	out := RedactText(in)
+
+	for _, secret := range []string{
+		"sk-live",
+		"hdr-secret",
+		"pem-secret",
+		"wxpay-secret",
+		"wechat-secret",
+		"aws-secret",
+	} {
+		if strings.Contains(out, secret) {
+			t.Fatalf("expected secret %q to be redacted, got %q", secret, out)
+		}
+	}
+	for _, marker := range []string{
+		"api-key=***",
+		"x-api-key=***",
+		"privateKey: ***",
+		"apiV3Key=***",
+		"appSecret=***",
+		"secret_access_key=***",
+	} {
+		if !strings.Contains(out, marker) {
+			t.Fatalf("expected marker %q in %q", marker, out)
+		}
+	}
+}
+
 func clearExtraTextPatternCache() {
 	extraTextPatternCache.Range(func(key, value any) bool {
 		extraTextPatternCache.Delete(key)


### PR DESCRIPTION
Closes #2634.

## Summary

This change expands `logredact`'s default sensitive-key coverage to include payment, API key, and cloud credential fields that are already used in this repository.

It also adds tests covering both structured redaction (`RedactMap`) and plain-text redaction (`RedactText`) for snake_case, kebab-case, and camelCase key forms.

## Why

The previous default list was focused on a small OAuth-style subset and missed real repository keys such as:

- `api_key` / `api-key` / `x-api-key`
- `private_key` / `privateKey`
- `api_v3_key` / `apiV3Key`
- `app_secret` / `appSecret`
- `mch_id` / `mchId`
- `secret_access_key`

That created a risk that logs using `logredact.RedactText`, `RedactMap`, or `RedactJSON` would fail to redact sensitive values by default.

## Validation

- Ran: `go test ./internal/util/logredact` from `backend/`
