### PR TITLE
fix: 命中"thinking block must contain thinking"上游错误时触发重试

### DIFF
--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -379,6 +379,37 @@ func TestFilterThinkingBlocksForRetry_RemovesRedactedThinkingAndKeepsValidConten
 	require.Equal(t, "Visible", content0["text"])
 }
 
+func TestFilterThinkingBlocksForRetry_DropsThinkingBlockWithEmptyContent(t *testing.T) {
+	// 跨模型场景：其他模型回过的 assistant 历史里携带了 type=thinking 但 thinking 字段为空，
+	// 喂给开启 extended thinking 的 claude 时上游会报：
+	//   "messages.1.content.0.thinking: each thinking block must contain thinking"
+	// 重试应当把空 thinking 块丢弃，并保留其它有效内容。
+	input := []byte(`{
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[
+			{"role":"user","content":[{"type":"text","text":"Hi"}]},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"","signature":"sig"},
+				{"type":"text","text":"Answer"}
+			]}
+		]
+	}`)
+
+	out := FilterThinkingBlocksForRetry(input)
+
+	var req map[string]any
+	require.NoError(t, json.Unmarshal(out, &req))
+	_, hasThinking := req["thinking"]
+	require.False(t, hasThinking, "top-level thinking should be removed")
+
+	msgs := req["messages"].([]any)
+	assistant := msgs[1].(map[string]any)
+	content := assistant["content"].([]any)
+	require.Len(t, content, 1, "empty thinking block should be dropped, only text remains")
+	require.Equal(t, "text", content[0].(map[string]any)["type"])
+	require.Equal(t, "Answer", content[0].(map[string]any)["text"])
+}
+
 func TestFilterThinkingBlocksForRetry_EmptyContentGetsPlaceholder(t *testing.T) {
 	input := []byte(`{
 		"thinking":{"type":"enabled"},

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -6765,6 +6765,15 @@ func (s *GatewayService) isThinkingBlockSignatureError(respBody []byte) bool {
 		return true
 	}
 
+	// 检测 thinking block 缺少 thinking 字段的错误（跨模型切换时常见：
+	// 其他模型回过的 assistant 历史里有 type=thinking 但没有 thinking 文本，
+	// 喂给开启 extended thinking 的 claude 时会被拒）
+	// 例如: "messages.1.content.0.thinking: each thinking block must contain thinking"
+	if strings.Contains(msg, "thinking block must contain") {
+		logger.LegacyPrintf("service.gateway", "[SignatureCheck] Detected thinking block missing content error")
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
  ## 背景

  跨模型切换场景下，客户端经常把其他模型（或更早版本 claude）回过的 assistant 历史
  原封不动地丢给开启了 extended thinking 的 claude-opus-4-7。如果历史里存在一个
  `type=thinking` 但 `thinking` 字段缺失/为空的块，上游会直接 400：

  messages.1.content.0.thinking: each thinking block must contain thinking

  sub2api 本来就有一套"签名/thinking 类错误"重试链路：检测到相关错误 →
  `FilterThinkingBlocksForRetry` 关闭顶层 thinking、把 thinking 块转 text、丢弃空块 →
  用清洗后的请求体重发一次。

  问题在于 `isThinkingBlockSignatureError` 当前匹配的 4 类关键词
  （`signature` / `expected ... thinking` / `cannot be modified` / `non-empty content`）
  都不覆盖这条新的错误信息，所以这种 400 不会触发重试，直接报给用户。

  ## 改动

  - `gateway_service.go`：在 `isThinkingBlockSignatureError` 新增对
    `thinking block must contain` 关键词的匹配，命中后走既有重试路径。
  - `gateway_request_test.go`：补一个回归用例
    `TestFilterThinkingBlocksForRetry_DropsThinkingBlockWithEmptyContent`，
    验证 `FilterThinkingBlocksForRetry` 能正确丢弃空 thinking 块、保留其它有效内容、
    并关闭顶层 thinking 配置。

  不引入新分支逻辑，复用已有的清洗与重试基础设施。

  ## 测试

  - `go test -tags=unit ./internal/service/ -run TestFilterThinkingBlocksForRetry`
    全部通过（含新增用例）。
  - `go build ./...` 与 `go vet -tags=unit ./internal/service/...` 均无报错。

  ## 验证清单

  - [x] 单测覆盖空 thinking 块场景
  - [x] 不改动已有错误模式的匹配范围（只新增一条 OR 分支）
  - [x] 命中后走的是已有的 `FilterThinkingBlocksForRetry` 路径，无新行为