### PR TITLE
fix(channel-monitor): 兼容 Responses reasoning 输出

### DIFF
--- a/backend/internal/service/channel_monitor_checker.go
+++ b/backend/internal/service/channel_monitor_checker.go
@@ -281,7 +281,52 @@ func callProvider(ctx context.Context, provider, endpoint, apiKey, model, prompt
 	if err != nil {
 		return "", "", status, err
 	}
+	if provider == MonitorProviderOpenAI && apiMode == MonitorAPIModeResponses {
+		return extractOpenAIResponsesText(respBytes), string(respBytes), status, nil
+	}
 	return gjson.GetBytes(respBytes, adapter.textPath).String(), string(respBytes), status, nil
+}
+
+// extractOpenAIResponsesText 聚合 Responses API 的最终 assistant 文本。
+// Responses 的 output 数组顺序由模型决定：reasoning / tool-call item 可能排在 message 前面，
+// 因此不能假设文本永远在 output.0.content.0.text。
+func extractOpenAIResponsesText(respBytes []byte) string {
+	if text := gjson.GetBytes(respBytes, "output_text").String(); strings.TrimSpace(text) != "" {
+		return text
+	}
+
+	var texts []string
+	outputs := gjson.GetBytes(respBytes, "output")
+	if outputs.IsArray() {
+		outputs.ForEach(func(_, output gjson.Result) bool {
+			outputType := output.Get("type").String()
+			if outputType != "" && outputType != "message" {
+				return true
+			}
+
+			content := output.Get("content")
+			if !content.IsArray() {
+				return true
+			}
+
+			content.ForEach(func(_, block gjson.Result) bool {
+				blockType := block.Get("type").String()
+				if blockType != "" && blockType != "output_text" {
+					return true
+				}
+				if text := block.Get("text").String(); strings.TrimSpace(text) != "" {
+					texts = append(texts, text)
+				}
+				return true
+			})
+			return true
+		})
+	}
+
+	if len(texts) > 0 {
+		return strings.Join(texts, "")
+	}
+	return gjson.GetBytes(respBytes, providerOpenAIResponsesAdapter.textPath).String()
 }
 
 // mergeHeaders 把用户自定义 headers 合并到 adapter 默认 headers 上。

--- a/backend/internal/service/channel_monitor_checker_body_test.go
+++ b/backend/internal/service/channel_monitor_checker_body_test.go
@@ -60,10 +60,11 @@ func setupFakeAnthropic(t *testing.T, handler *captureHandler) string {
 }
 
 type openAICaptureHandler struct {
-	lastBody    map[string]any
-	lastHeaders http.Header
-	lastPath    string
-	status      int
+	lastBody                  map[string]any
+	lastHeaders               http.Header
+	lastPath                  string
+	status                    int
+	responsesLeadingReasoning bool
 }
 
 func (h *openAICaptureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -82,10 +83,23 @@ func (h *openAICaptureHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	answer := answerFromOpenAIRequest(parsed)
 	if h.lastPath == providerOpenAIResponsesPath {
+		output := []map[string]any{}
+		if h.responsesLeadingReasoning {
+			output = append(output, map[string]any{
+				"type":    "reasoning",
+				"summary": []any{},
+			})
+		}
+		output = append(output, map[string]any{
+			"type":   "message",
+			"status": "completed",
+			"role":   "assistant",
+			"content": []map[string]any{
+				{"type": "output_text", "text": answer},
+			},
+		})
 		_ = json.NewEncoder(w).Encode(map[string]any{
-			"output": []map[string]any{{
-				"content": []map[string]any{{"type": "output_text", "text": answer}},
-			}},
+			"output": output,
 		})
 		return
 	}
@@ -209,6 +223,22 @@ func TestRunCheckForModel_OpenAIResponses_DefaultRequest(t *testing.T) {
 	}
 	if h.lastHeaders.Get("Authorization") != "Bearer sk-openai" {
 		t.Errorf("expected bearer auth header, got %q", h.lastHeaders.Get("Authorization"))
+	}
+}
+
+func TestRunCheckForModel_OpenAIResponses_SkipsLeadingReasoningItem(t *testing.T) {
+	h := &openAICaptureHandler{responsesLeadingReasoning: true}
+	endpoint := setupFakeOpenAI(t, h)
+
+	res := runCheckForModel(context.Background(), MonitorProviderOpenAI, endpoint, "sk-openai", "gpt-5.5", &CheckOptions{
+		APIMode: MonitorAPIModeResponses,
+	})
+
+	if res.Status != MonitorStatusOperational {
+		t.Fatalf("responses request should find text after leading reasoning item, got status=%s message=%q", res.Status, res.Message)
+	}
+	if h.lastPath != providerOpenAIResponsesPath {
+		t.Fatalf("expected responses path %q, got %q", providerOpenAIResponsesPath, h.lastPath)
 	}
 }
 


### PR DESCRIPTION
## 背景

线上渠道监控中，OpenAI Responses 模式检测 `gpt-5.5` 时会出现：

```text
challenge mismatch (expected 48, got "")
```

排查发现 `gpt-5.5` 的 Responses 返回可能先给出 `type: "reasoning"` 的 output item，真正的 assistant 文本在后续 `type: "message"` 的 `content[].type == "output_text"` 块中。旧实现只读取 `output.0.content.0.text`，因此会把有效 200 响应误判为空文本。

## 修改

- OpenAI Responses 渠道监控改为聚合 Responses API 的最终 assistant 文本：
  - 优先使用顶层 `output_text`
  - 遍历 `output[]` 中的 `message` item
  - 提取 `content[]` 中的 `output_text.text`
  - 保留旧的 `output.0.content.0.text` 作为 fallback
- 新增回归测试，覆盖 `reasoning` item 排在最终 message 前面的响应形态。

## 验证

- `gofmt`
- `lsp_diagnostics`：两个修改文件均无诊断
- `go test -tags=unit ./internal/service -run "TestRunCheckForModel_OpenAIResponses|TestRunCheckForModel_OpenAI_DefaultChatRequest|TestRunCheckForModel_ReplaceMode"`
- `go test -tags=unit ./internal/service`
- 修复后 review：目标/约束、QA、代码质量、安全、上下文挖掘均 PASS