### PR TITLE
fix(auth): user_provider_default_grants 加入 github/google/dingtalk

### DIFF
--- a/backend/migrations/140_extend_user_provider_default_grants_check.sql
+++ b/backend/migrations/140_extend_user_provider_default_grants_check.sql
@@ -1,0 +1,12 @@
+-- 修复：user_provider_default_grants 表的 provider_type check 约束
+-- 与 auth_identities / auth_identity_channels / pending_auth_sessions 保持一致，
+-- 否则启用了 auth_source_default_{github,google,dingtalk}_grant_on_first_bind
+-- 之后，OAuth 首次绑定流程会因约束违反而失败。
+-- 参见 migrations 135、136 漏改本表。
+
+ALTER TABLE user_provider_default_grants
+    DROP CONSTRAINT IF EXISTS user_provider_default_grants_provider_type_check;
+
+ALTER TABLE user_provider_default_grants
+    ADD CONSTRAINT user_provider_default_grants_provider_type_check
+    CHECK (provider_type IN ('email', 'linuxdo', 'wechat', 'oidc', 'github', 'google', 'dingtalk'));


### PR DESCRIPTION
migration 135/136 把 github、google、dingtalk 加到 users / auth_identities / auth_identity_channels / pending_auth_sessions 的 check 约束时，漏改 user_provider_default_grants。一旦管理员开启 grant_on_first_bind，OAuth 首次 绑定就会在 INSERT user_provider_default_grants 时撞约束，触发 500。