### PR TITLE
feat(oidc): 上游邮箱已验证时跳过 choice 页直接登录注册

### DIFF
--- a/backend/internal/handler/auth_oidc_oauth.go
+++ b/backend/internal/handler/auth_oidc_oauth.go
@@ -454,6 +454,28 @@ func (h *AuthHandler) OIDCOAuthCallback(c *gin.Context) {
 		}
 	}
 
+	// Fast-path: when the upstream supplies a verified email and the deployment
+	// does not require any extra confirmation (force_email_on_third_party_signup
+	// disabled + invitation code disabled) and no local account collides with the
+	// upstream email, trust the upstream identity and finish login without
+	// rendering the choice page. Any failure falls through to the regular choice
+	// flow below.
+	if compatEmailUser == nil &&
+		strings.TrimSpace(compatEmail) != "" &&
+		emailVerified != nil && *emailVerified {
+		if h.tryOIDCVerifiedEmailFastPath(
+			c,
+			frontendCallback,
+			redirectTo,
+			identityRef,
+			compatEmail,
+			username,
+			upstreamClaims,
+		) {
+			return
+		}
+	}
+
 	if h.isForceEmailOnThirdPartySignup(c.Request.Context()) {
 		if err := h.createOIDCOAuthChoicePendingSession(
 			c,
@@ -1189,4 +1211,67 @@ func oidcClearCookie(c *gin.Context, name string, secure bool) {
 		Secure:   secure,
 		SameSite: http.SameSiteLaxMode,
 	})
+}
+
+// tryOIDCVerifiedEmailFastPath attempts to skip the choice/pending page when
+// the upstream identity carries a verified email and the deployment does not
+// require any additional confirmation. It mirrors the behaviour already used
+// for verified github/google logins via LoginOrRegisterVerifiedEmailOAuth.
+//
+// Returns true when the flow has completed (token issued and browser
+// redirected); a false return tells the caller to fall through to the regular
+// choice flow.
+func (h *AuthHandler) tryOIDCVerifiedEmailFastPath(
+	c *gin.Context,
+	frontendCallback string,
+	redirectTo string,
+	identity service.PendingAuthIdentityKey,
+	compatEmail string,
+	username string,
+	upstreamClaims map[string]any,
+) bool {
+	if h == nil || h.authService == nil || h.settingSvc == nil {
+		return false
+	}
+	ctx := c.Request.Context()
+	if h.isForceEmailOnThirdPartySignup(ctx) {
+		return false
+	}
+	if h.settingSvc.IsInvitationCodeEnabled(ctx) {
+		return false
+	}
+
+	upstreamMetadata := make(map[string]any, len(upstreamClaims))
+	for k, v := range upstreamClaims {
+		upstreamMetadata[k] = v
+	}
+	input := service.EmailOAuthIdentityInput{
+		ProviderType:     "oidc",
+		ProviderKey:      strings.TrimSpace(identity.ProviderKey),
+		ProviderSubject:  strings.TrimSpace(identity.ProviderSubject),
+		Email:            strings.TrimSpace(strings.ToLower(compatEmail)),
+		EmailVerified:    true,
+		Username:         strings.TrimSpace(username),
+		DisplayName:      pendingSessionStringValue(upstreamClaims, "suggested_display_name"),
+		AvatarURL:        pendingSessionStringValue(upstreamClaims, "suggested_avatar_url"),
+		UpstreamMetadata: upstreamMetadata,
+	}
+	tokenPair, user, err := h.authService.LoginOrRegisterVerifiedEmailOAuthWithInvitation(ctx, input, "", "")
+	if err != nil {
+		log.Printf("[OIDC OAuth] verified-email fast path skipped: %v", err)
+		return false
+	}
+	if err := h.ensureBackendModeAllowsUser(ctx, user); err != nil {
+		log.Printf("[OIDC OAuth] verified-email fast path blocked by backend mode: %v", err)
+		return false
+	}
+
+	fragment := url.Values{}
+	fragment.Set("access_token", tokenPair.AccessToken)
+	fragment.Set("refresh_token", tokenPair.RefreshToken)
+	fragment.Set("expires_in", fmt.Sprintf("%d", tokenPair.ExpiresIn))
+	fragment.Set("token_type", "Bearer")
+	fragment.Set("redirect", redirectTo)
+	redirectWithFragment(c, frontendCallback, fragment)
+	return true
 }

--- a/backend/internal/handler/auth_oidc_oauth.go
+++ b/backend/internal/handler/auth_oidc_oauth.go
@@ -1246,7 +1246,7 @@ func (h *AuthHandler) tryOIDCVerifiedEmailFastPath(
 		upstreamMetadata[k] = v
 	}
 	input := service.EmailOAuthIdentityInput{
-		ProviderType:     "oidc",
+		ProviderType:     strings.TrimSpace(identity.ProviderType),
 		ProviderKey:      strings.TrimSpace(identity.ProviderKey),
 		ProviderSubject:  strings.TrimSpace(identity.ProviderSubject),
 		Email:            strings.TrimSpace(strings.ToLower(compatEmail)),
@@ -1258,11 +1258,11 @@ func (h *AuthHandler) tryOIDCVerifiedEmailFastPath(
 	}
 	tokenPair, user, err := h.authService.LoginOrRegisterVerifiedEmailOAuthWithInvitation(ctx, input, "", "")
 	if err != nil {
-		log.Printf("[OIDC OAuth] verified-email fast path skipped: %v", err)
+		log.Printf("[OIDC OAuth] verified-email fast path skipped: reason=%s", infraerrors.Reason(err))
 		return false
 	}
 	if err := h.ensureBackendModeAllowsUser(ctx, user); err != nil {
-		log.Printf("[OIDC OAuth] verified-email fast path blocked by backend mode: %v", err)
+		log.Printf("[OIDC OAuth] verified-email fast path blocked by backend mode: reason=%s", infraerrors.Reason(err))
 		return false
 	}
 

--- a/backend/internal/handler/auth_oidc_oauth_test.go
+++ b/backend/internal/handler/auth_oidc_oauth_test.go
@@ -926,6 +926,123 @@ func TestCompleteOIDCOAuthRegistrationRejectsIdentityOwnershipConflictBeforeUser
 	require.Nil(t, storedSession.ConsumedAt)
 }
 
+func TestTryOIDCVerifiedEmailFastPathCreatesUserAndIdentity(t *testing.T) {
+	handler, client := newOAuthPendingFlowTestHandler(t, false)
+	t.Cleanup(func() { _ = client.Close() })
+
+	ctx := context.Background()
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/oauth/oidc/callback", nil)
+
+	identity := service.PendingAuthIdentityKey{
+		ProviderType:    "oidc",
+		ProviderKey:     "https://issuer.example.com",
+		ProviderSubject: "fast-path-subject",
+	}
+	completed := handler.tryOIDCVerifiedEmailFastPath(
+		c,
+		"/auth/oidc/callback",
+		"/dashboard",
+		identity,
+		"fastpath@example.com",
+		"fastpath_user",
+		map[string]any{
+			"suggested_display_name": "Fast Path",
+			"suggested_avatar_url":   "",
+		},
+	)
+	require.True(t, completed)
+	require.Equal(t, http.StatusFound, recorder.Code)
+
+	location := recorder.Header().Get("Location")
+	require.Contains(t, location, "/auth/oidc/callback")
+	require.Contains(t, location, "access_token=")
+	require.Contains(t, location, "refresh_token=")
+	require.Contains(t, location, "token_type=Bearer")
+
+	user, err := client.User.Query().Where(dbuser.EmailEQ("fastpath@example.com")).Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "fastpath_user", user.Username)
+	require.Equal(t, "oidc", user.SignupSource)
+
+	identityCount, err := client.AuthIdentity.Query().Where(
+		authidentity.ProviderTypeEQ("oidc"),
+		authidentity.ProviderKeyEQ("https://issuer.example.com"),
+		authidentity.ProviderSubjectEQ("fast-path-subject"),
+		authidentity.UserIDEQ(user.ID),
+	).Count(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, identityCount)
+
+	pendingCount, err := client.PendingAuthSession.Query().Count(ctx)
+	require.NoError(t, err)
+	require.Zero(t, pendingCount)
+}
+
+func TestTryOIDCVerifiedEmailFastPathSkippedWhenInvitationCodeRequired(t *testing.T) {
+	handler, client := newOAuthPendingFlowTestHandler(t, true)
+	t.Cleanup(func() { _ = client.Close() })
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/oauth/oidc/callback", nil)
+
+	identity := service.PendingAuthIdentityKey{
+		ProviderType:    "oidc",
+		ProviderKey:     "https://issuer.example.com",
+		ProviderSubject: "fast-path-skipped-invitation",
+	}
+	completed := handler.tryOIDCVerifiedEmailFastPath(
+		c,
+		"/auth/oidc/callback",
+		"/dashboard",
+		identity,
+		"invite-only@example.com",
+		"invite_only_user",
+		map[string]any{},
+	)
+	require.False(t, completed)
+	require.NotEqual(t, http.StatusFound, recorder.Code)
+
+	userCount, err := client.User.Query().Where(dbuser.EmailEQ("invite-only@example.com")).Count(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, userCount)
+}
+
+func TestTryOIDCVerifiedEmailFastPathSkippedWhenForceEmailEnabled(t *testing.T) {
+	handler, client := newOAuthPendingFlowTestHandlerWithDependencies(t, oauthPendingFlowTestHandlerOptions{
+		settingValues: map[string]string{
+			service.SettingKeyForceEmailOnThirdPartySignup: "true",
+		},
+	})
+	t.Cleanup(func() { _ = client.Close() })
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/auth/oauth/oidc/callback", nil)
+
+	identity := service.PendingAuthIdentityKey{
+		ProviderType:    "oidc",
+		ProviderKey:     "https://issuer.example.com",
+		ProviderSubject: "fast-path-skipped-force-email",
+	}
+	completed := handler.tryOIDCVerifiedEmailFastPath(
+		c,
+		"/auth/oidc/callback",
+		"/dashboard",
+		identity,
+		"force-email@example.com",
+		"force_email_user",
+		map[string]any{},
+	)
+	require.False(t, completed)
+
+	userCount, err := client.User.Query().Where(dbuser.EmailEQ("force-email@example.com")).Count(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, userCount)
+}
+
 type oidcProviderFixture struct {
 	Subject           string
 	PreferredUsername string

--- a/backend/internal/service/auth_email_oauth_auto.go
+++ b/backend/internal/service/auth_email_oauth_auto.go
@@ -49,7 +49,7 @@ func (s *AuthService) loginOrRegisterVerifiedEmailOAuth(
 	}
 
 	providerType := normalizeOAuthSignupSource(input.ProviderType)
-	if providerType != "github" && providerType != "google" {
+	if providerType != "github" && providerType != "google" && providerType != "oidc" {
 		return nil, nil, infraerrors.BadRequest("OAUTH_PROVIDER_INVALID", "oauth provider is invalid")
 	}
 	providerKey := strings.TrimSpace(input.ProviderKey)


### PR DESCRIPTION
## 背景

当前 OIDC 首次登录无条件创建 `choose_account_action_required` 的 pending session（`backend/internal/handler/auth_oidc_oauth.go` 中 `OIDCOAuthCallback` 在 `existingIdentityUser == nil` 后总是走 `createOIDCOAuthChoicePendingSession`），即使 `force_email_on_third_party_signup` 关闭，前端 `OidcCallbackView.vue` 拿到 `step=choose_account_action_required` 仍然会强制弹出"创建账号 / 绑定已有账号"的二选一界面。

而且 `createOIDCOAuthChoicePendingSession` 给前端的 `completion_response.email` 字段是内部合成邮箱（形如 `oidc-f012a8f5...@oidc-connect.invalid`），前端 `extractPendingAccountEmail` 优先用 `email`/`resolved_email`，结果用户在 choice 页看到的是这串合成邮箱，而不是上游 IDaaS 实际返回的真实邮箱。这造成两个问题：

1. **关掉"第三方注册强制补充邮箱"开关并不会真的跳过 choice 页**——该开关只控制 choice 页里邮箱字段是否必填，不控制是否显示 choice 页本身。
2. 选择"创建账号"时，邮箱字段默认填充的是合成邮箱（用户体验糟糕）。

GitHub/Google OAuth 这条路径上其实**已经**存在"上游邮箱已验证时直接信任并自动注册"的实现 (`LoginOrRegisterVerifiedEmailOAuth` in `backend/internal/service/auth_email_oauth_auto.go`)，但 line 52 处硬编码了 ``providerType != "github" && providerType != "google"`` 校验，把 OIDC 挡在门外。

## 改动

1. 放开 `loginOrRegisterVerifiedEmailOAuth` 的 provider 限制，允许 `oidc`。
2. 在 `OIDCOAuthCallback` 的 `cfg.RequireEmailVerified` 校验之后、`force_email_on_third_party_signup` 分支之前增加 fast-path：当**所有**前置条件满足时，跳过 choice 页直接复用 `LoginOrRegisterVerifiedEmailOAuthWithInvitation`，颁发 token 并以 fragment 形式重定向到前端回调。

Fast-path 触发条件（必须**全部**满足，任一不满足都自动回退到现有 choice 流程）：

- ``force_email_on_third_party_signup`` 关闭
- 邀请码模式未启用（`IsInvitationCodeEnabled = false`）
- 上游声明 ``email_verified = true`` 且 ``compat_email`` 非空
- 本地不存在同邮箱已有账号（``compatEmailUser == nil``）

复用 `LoginOrRegisterVerifiedEmailOAuth` 自然继承了所有现有约束：
- ``registration_email_suffix_whitelist`` 白名单校验
- ``IsRegistrationEnabled`` 注册开关
- ``isReservedEmail`` 保留邮箱
- ``AUTH_IDENTITY_OWNERSHIP_CONFLICT`` 冲突检测

任何检查失败时会日志输出 ``[OIDC OAuth] verified-email fast path skipped`` 并 fall through 到现有 choice 流程，保证对存量部署 100% 向后兼容。

## 行为对比

| 场景 | 改动前 | 改动后 |
|------|--------|--------|
| force=false + verified email + 无冲突 + 邀请码关 | 弹 choice 页（显示合成邮箱） | 直接登录，跳转目标页 |
| force=false + verified email + 库内同邮箱用户 | 弹 choice 页（提示绑定已有账号） | 不变（``compatEmailUser != nil`` 不触发 fast-path） |
| force=false + 邮箱未验证 / 无 compat_email | 弹 choice 页 | 不变 |
| force=true | choice 页 + 强制必填邮箱 | 不变 |
| 邀请码开启 | choice 页（让用户输邀请码） | 不变 |
| github/google verified email | 直接登录 | 不变 |

## 测试

新增三个单元测试覆盖 fast-path 三个关键分支：

- ``TestTryOIDCVerifiedEmailFastPathCreatesUserAndIdentity``：成功路径，验证用户/identity 创建、token fragment、无 pending session 残留
- ``TestTryOIDCVerifiedEmailFastPathSkippedWhenInvitationCodeRequired``：邀请码开启时返回 false，用户未创建
- ``TestTryOIDCVerifiedEmailFastPathSkippedWhenForceEmailEnabled``：force 开启时返回 false

## Test plan

- [x] ``go test -tags=unit ./...`` 全部通过
- [x] ``go vet ./...`` 干净
- [x] ``go build ./...`` 编译通过
- [ ] 上游 CI（golangci-lint v2.7 / integration tests）