### PR TITLE
fix(apicompat): Responses 转 Chat Completions 时 developer role 映射为 system

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -89,7 +89,7 @@ func responsesInputToChatMessages(instructions string, inputRaw json.RawMessage)
 			return nil, fmt.Errorf("parse responses input item: %w", err)
 		}
 
-		role := rawString(item["role"])
+		role := chatCompletionsBridgeRole(rawString(item["role"]))
 		itemType := rawString(item["type"])
 		switch itemType {
 		case "function_call":
@@ -130,9 +130,6 @@ func responsesInputToChatMessages(instructions string, inputRaw json.RawMessage)
 			continue
 		}
 
-		if role == "" {
-			role = "user"
-		}
 		content := item["content"]
 		if len(bytesTrimSpace(content)) == 0 {
 			if text := rawString(item["text"]); text != "" {
@@ -150,6 +147,17 @@ func responsesInputToChatMessages(instructions string, inputRaw json.RawMessage)
 	}
 
 	return messages, nil
+}
+
+func chatCompletionsBridgeRole(role string) string {
+	trimmed := strings.TrimSpace(role)
+	if trimmed == "" {
+		return "user"
+	}
+	if strings.EqualFold(trimmed, "developer") {
+		return "system"
+	}
+	return role
 }
 
 func responsesContentToChatContent(raw json.RawMessage, role string) (json.RawMessage, error) {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_test.go
@@ -1,0 +1,82 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesInputToChatMessages_DeveloperRoleMapsToSystem(t *testing.T) {
+	messages, err := responsesInputToChatMessages("", json.RawMessage(`[{"role":"developer","content":"follow project instructions"}]`))
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	assert.Equal(t, "system", messages[0].Role)
+	assert.JSONEq(t, `"follow project instructions"`, string(messages[0].Content))
+}
+
+func TestResponsesInputToChatMessages_KeepsChatCompletionRoles(t *testing.T) {
+	input := json.RawMessage(`[
+		{"role":"system","content":"system message"},
+		{"role":"user","content":"user message"},
+		{"role":"assistant","content":"assistant message"},
+		{"role":"tool","content":"tool message"}
+	]`)
+
+	messages, err := responsesInputToChatMessages("", input)
+	require.NoError(t, err)
+	require.Len(t, messages, 4)
+
+	assert.Equal(t, []string{"system", "user", "assistant", "tool"}, chatMessageRoles(messages))
+}
+
+func TestResponsesInputToChatMessages_EmptyRoleFallsBackToUser(t *testing.T) {
+	messages, err := responsesInputToChatMessages("", json.RawMessage(`[{"role":"","content":"hello"}]`))
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+
+	assert.Equal(t, "user", messages[0].Role)
+}
+
+func TestResponsesInputToChatMessages_DeveloperRoleTrimAndCaseInsensitive(t *testing.T) {
+	input := json.RawMessage(`[
+		{"role":" Developer ","content":"one"},
+		{"role":"\tDEVELOPER\n","content":"two"}
+	]`)
+
+	messages, err := responsesInputToChatMessages("", input)
+	require.NoError(t, err)
+	require.Len(t, messages, 2)
+
+	assert.Equal(t, []string{"system", "system"}, chatMessageRoles(messages))
+}
+
+func TestResponsesToChatCompletionsRequest_InstructionsAndInputDeveloperRole(t *testing.T) {
+	req := &ResponsesRequest{
+		Model:        "gpt-4o",
+		Instructions: "Use concise answers.",
+		Input: json.RawMessage(`[
+			{"role":"developer","content":[{"type":"input_text","text":"Prefer JSON."}]},
+			{"role":"user","content":"Hello"}
+		]`),
+	}
+
+	out, err := ResponsesToChatCompletionsRequest(req)
+	require.NoError(t, err)
+	require.Len(t, out.Messages, 3)
+
+	assert.Equal(t, []string{"system", "system", "user"}, chatMessageRoles(out.Messages))
+	assert.JSONEq(t, `"Use concise answers."`, string(out.Messages[0].Content))
+	assert.JSONEq(t, `"Prefer JSON."`, string(out.Messages[1].Content))
+	assert.JSONEq(t, `"Hello"`, string(out.Messages[2].Content))
+}
+
+func chatMessageRoles(messages []ChatMessage) []string {
+	roles := make([]string, 0, len(messages))
+	for _, message := range messages {
+		roles = append(roles, message.Role)
+	}
+	return roles
+}


### PR DESCRIPTION
## 背景

账号开启 force_chat_completions 后，从 /v1/responses 入口进入的请求会走 Responses → Chat Completions 桥接。Responses input 中的 developer role 如果原样下发到第三方 Chat Completions 上游，DeepSeek/Kimi/GLM 等兼容上游可能因不识别 developer 而反序列化失败。

此修复是 #2606（/v1/responses 入口尊重 force_chat_completions）的下游兼容性补齐，让第三方 CC 上游在该路径下可用。

## 改动

- 仅在 responsesInputToChatMessages 这条 Responses → Chat Completions 桥接路径中归一化 role，避免污染 Responses → Anthropic 等其他转换路径。
- 对 input item role 做 trim 后的大小写不敏感比较，将 developer 映射为 system。
- system/user/assistant/tool 等既有合法 role 保持不变，空 role 继续 fallback 为 user。
- 新增 chatcompletions_responses_bridge_test.go，覆盖 developer 映射、合法 role 保持、空 role fallback、大小写/前后空白 developer、Instructions + Input 混合场景。

## 测试

- cd backend && go test -tags=unit ./internal/pkg/apicompat/...
- cd backend && go test -tags=unit ./...
- cd backend && golangci-lint run ./...

说明：当前 upstream/main 的 backend/go.mod 声明 go 1.26.3；显式 GOTOOLCHAIN=go1.25.7 会因 go.mod requires go >= 1.26.3 无法启动测试。上述验证按仓库当前声明工具链执行并通过。

Fixes #2620