### PR TITLE
fix(notification): 订阅到期通知邮件去重，避免每分钟重复推送

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1621,6 +1621,9 @@ var (
 		{Name: "starts_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "expires_at", Type: field.TypeTime, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "status", Type: field.TypeString, Size: 20, Default: "active"},
+		{Name: "expiry_reminder_key", Type: field.TypeString, Nullable: true, Size: 32},
+		{Name: "expiry_reminder_expires_at", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
+		{Name: "expiry_reminder_sent_at", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "daily_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "weekly_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
 		{Name: "monthly_window_start", Type: field.TypeTime, Nullable: true, SchemaType: map[string]string{"postgres": "timestamptz"}},
@@ -1641,19 +1644,19 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "user_subscriptions_groups_subscriptions",
-				Columns:    []*schema.Column{UserSubscriptionsColumns[15]},
+				Columns:    []*schema.Column{UserSubscriptionsColumns[18]},
 				RefColumns: []*schema.Column{GroupsColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "user_subscriptions_users_subscriptions",
-				Columns:    []*schema.Column{UserSubscriptionsColumns[16]},
+				Columns:    []*schema.Column{UserSubscriptionsColumns[19]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
 			{
 				Symbol:     "user_subscriptions_users_assigned_subscriptions",
-				Columns:    []*schema.Column{UserSubscriptionsColumns[17]},
+				Columns:    []*schema.Column{UserSubscriptionsColumns[20]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -1662,12 +1665,12 @@ var (
 			{
 				Name:    "usersubscription_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{UserSubscriptionsColumns[16]},
+				Columns: []*schema.Column{UserSubscriptionsColumns[19]},
 			},
 			{
 				Name:    "usersubscription_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{UserSubscriptionsColumns[15]},
+				Columns: []*schema.Column{UserSubscriptionsColumns[18]},
 			},
 			{
 				Name:    "usersubscription_status",
@@ -1682,17 +1685,17 @@ var (
 			{
 				Name:    "usersubscription_user_id_status_expires_at",
 				Unique:  false,
-				Columns: []*schema.Column{UserSubscriptionsColumns[16], UserSubscriptionsColumns[6], UserSubscriptionsColumns[5]},
+				Columns: []*schema.Column{UserSubscriptionsColumns[19], UserSubscriptionsColumns[6], UserSubscriptionsColumns[5]},
 			},
 			{
 				Name:    "usersubscription_assigned_by",
 				Unique:  false,
-				Columns: []*schema.Column{UserSubscriptionsColumns[17]},
+				Columns: []*schema.Column{UserSubscriptionsColumns[20]},
 			},
 			{
 				Name:    "usersubscription_user_id_group_id",
 				Unique:  false,
-				Columns: []*schema.Column{UserSubscriptionsColumns[16], UserSubscriptionsColumns[15]},
+				Columns: []*schema.Column{UserSubscriptionsColumns[19], UserSubscriptionsColumns[18]},
 			},
 			{
 				Name:    "usersubscription_deleted_at",

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -43114,39 +43114,42 @@ func (m *UserAttributeValueMutation) ResetEdge(name string) error {
 // UserSubscriptionMutation represents an operation that mutates the UserSubscription nodes in the graph.
 type UserSubscriptionMutation struct {
 	config
-	op                      Op
-	typ                     string
-	id                      *int64
-	created_at              *time.Time
-	updated_at              *time.Time
-	deleted_at              *time.Time
-	starts_at               *time.Time
-	expires_at              *time.Time
-	status                  *string
-	daily_window_start      *time.Time
-	weekly_window_start     *time.Time
-	monthly_window_start    *time.Time
-	daily_usage_usd         *float64
-	adddaily_usage_usd      *float64
-	weekly_usage_usd        *float64
-	addweekly_usage_usd     *float64
-	monthly_usage_usd       *float64
-	addmonthly_usage_usd    *float64
-	assigned_at             *time.Time
-	notes                   *string
-	clearedFields           map[string]struct{}
-	user                    *int64
-	cleareduser             bool
-	group                   *int64
-	clearedgroup            bool
-	assigned_by_user        *int64
-	clearedassigned_by_user bool
-	usage_logs              map[int64]struct{}
-	removedusage_logs       map[int64]struct{}
-	clearedusage_logs       bool
-	done                    bool
-	oldValue                func(context.Context) (*UserSubscription, error)
-	predicates              []predicate.UserSubscription
+	op                         Op
+	typ                        string
+	id                         *int64
+	created_at                 *time.Time
+	updated_at                 *time.Time
+	deleted_at                 *time.Time
+	starts_at                  *time.Time
+	expires_at                 *time.Time
+	status                     *string
+	expiry_reminder_key        *string
+	expiry_reminder_expires_at *time.Time
+	expiry_reminder_sent_at    *time.Time
+	daily_window_start         *time.Time
+	weekly_window_start        *time.Time
+	monthly_window_start       *time.Time
+	daily_usage_usd            *float64
+	adddaily_usage_usd         *float64
+	weekly_usage_usd           *float64
+	addweekly_usage_usd        *float64
+	monthly_usage_usd          *float64
+	addmonthly_usage_usd       *float64
+	assigned_at                *time.Time
+	notes                      *string
+	clearedFields              map[string]struct{}
+	user                       *int64
+	cleareduser                bool
+	group                      *int64
+	clearedgroup               bool
+	assigned_by_user           *int64
+	clearedassigned_by_user    bool
+	usage_logs                 map[int64]struct{}
+	removedusage_logs          map[int64]struct{}
+	clearedusage_logs          bool
+	done                       bool
+	oldValue                   func(context.Context) (*UserSubscription, error)
+	predicates                 []predicate.UserSubscription
 }
 
 var _ ent.Mutation = (*UserSubscriptionMutation)(nil)
@@ -43546,6 +43549,153 @@ func (m *UserSubscriptionMutation) OldStatus(ctx context.Context) (v string, err
 // ResetStatus resets all changes to the "status" field.
 func (m *UserSubscriptionMutation) ResetStatus() {
 	m.status = nil
+}
+
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (m *UserSubscriptionMutation) SetExpiryReminderKey(s string) {
+	m.expiry_reminder_key = &s
+}
+
+// ExpiryReminderKey returns the value of the "expiry_reminder_key" field in the mutation.
+func (m *UserSubscriptionMutation) ExpiryReminderKey() (r string, exists bool) {
+	v := m.expiry_reminder_key
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExpiryReminderKey returns the old "expiry_reminder_key" field's value of the UserSubscription entity.
+// If the UserSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserSubscriptionMutation) OldExpiryReminderKey(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExpiryReminderKey is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExpiryReminderKey requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExpiryReminderKey: %w", err)
+	}
+	return oldValue.ExpiryReminderKey, nil
+}
+
+// ClearExpiryReminderKey clears the value of the "expiry_reminder_key" field.
+func (m *UserSubscriptionMutation) ClearExpiryReminderKey() {
+	m.expiry_reminder_key = nil
+	m.clearedFields[usersubscription.FieldExpiryReminderKey] = struct{}{}
+}
+
+// ExpiryReminderKeyCleared returns if the "expiry_reminder_key" field was cleared in this mutation.
+func (m *UserSubscriptionMutation) ExpiryReminderKeyCleared() bool {
+	_, ok := m.clearedFields[usersubscription.FieldExpiryReminderKey]
+	return ok
+}
+
+// ResetExpiryReminderKey resets all changes to the "expiry_reminder_key" field.
+func (m *UserSubscriptionMutation) ResetExpiryReminderKey() {
+	m.expiry_reminder_key = nil
+	delete(m.clearedFields, usersubscription.FieldExpiryReminderKey)
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (m *UserSubscriptionMutation) SetExpiryReminderExpiresAt(t time.Time) {
+	m.expiry_reminder_expires_at = &t
+}
+
+// ExpiryReminderExpiresAt returns the value of the "expiry_reminder_expires_at" field in the mutation.
+func (m *UserSubscriptionMutation) ExpiryReminderExpiresAt() (r time.Time, exists bool) {
+	v := m.expiry_reminder_expires_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExpiryReminderExpiresAt returns the old "expiry_reminder_expires_at" field's value of the UserSubscription entity.
+// If the UserSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserSubscriptionMutation) OldExpiryReminderExpiresAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExpiryReminderExpiresAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExpiryReminderExpiresAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExpiryReminderExpiresAt: %w", err)
+	}
+	return oldValue.ExpiryReminderExpiresAt, nil
+}
+
+// ClearExpiryReminderExpiresAt clears the value of the "expiry_reminder_expires_at" field.
+func (m *UserSubscriptionMutation) ClearExpiryReminderExpiresAt() {
+	m.expiry_reminder_expires_at = nil
+	m.clearedFields[usersubscription.FieldExpiryReminderExpiresAt] = struct{}{}
+}
+
+// ExpiryReminderExpiresAtCleared returns if the "expiry_reminder_expires_at" field was cleared in this mutation.
+func (m *UserSubscriptionMutation) ExpiryReminderExpiresAtCleared() bool {
+	_, ok := m.clearedFields[usersubscription.FieldExpiryReminderExpiresAt]
+	return ok
+}
+
+// ResetExpiryReminderExpiresAt resets all changes to the "expiry_reminder_expires_at" field.
+func (m *UserSubscriptionMutation) ResetExpiryReminderExpiresAt() {
+	m.expiry_reminder_expires_at = nil
+	delete(m.clearedFields, usersubscription.FieldExpiryReminderExpiresAt)
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (m *UserSubscriptionMutation) SetExpiryReminderSentAt(t time.Time) {
+	m.expiry_reminder_sent_at = &t
+}
+
+// ExpiryReminderSentAt returns the value of the "expiry_reminder_sent_at" field in the mutation.
+func (m *UserSubscriptionMutation) ExpiryReminderSentAt() (r time.Time, exists bool) {
+	v := m.expiry_reminder_sent_at
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldExpiryReminderSentAt returns the old "expiry_reminder_sent_at" field's value of the UserSubscription entity.
+// If the UserSubscription object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *UserSubscriptionMutation) OldExpiryReminderSentAt(ctx context.Context) (v *time.Time, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldExpiryReminderSentAt is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldExpiryReminderSentAt requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldExpiryReminderSentAt: %w", err)
+	}
+	return oldValue.ExpiryReminderSentAt, nil
+}
+
+// ClearExpiryReminderSentAt clears the value of the "expiry_reminder_sent_at" field.
+func (m *UserSubscriptionMutation) ClearExpiryReminderSentAt() {
+	m.expiry_reminder_sent_at = nil
+	m.clearedFields[usersubscription.FieldExpiryReminderSentAt] = struct{}{}
+}
+
+// ExpiryReminderSentAtCleared returns if the "expiry_reminder_sent_at" field was cleared in this mutation.
+func (m *UserSubscriptionMutation) ExpiryReminderSentAtCleared() bool {
+	_, ok := m.clearedFields[usersubscription.FieldExpiryReminderSentAt]
+	return ok
+}
+
+// ResetExpiryReminderSentAt resets all changes to the "expiry_reminder_sent_at" field.
+func (m *UserSubscriptionMutation) ResetExpiryReminderSentAt() {
+	m.expiry_reminder_sent_at = nil
+	delete(m.clearedFields, usersubscription.FieldExpiryReminderSentAt)
 }
 
 // SetDailyWindowStart sets the "daily_window_start" field.
@@ -44179,7 +44329,7 @@ func (m *UserSubscriptionMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *UserSubscriptionMutation) Fields() []string {
-	fields := make([]string, 0, 17)
+	fields := make([]string, 0, 20)
 	if m.created_at != nil {
 		fields = append(fields, usersubscription.FieldCreatedAt)
 	}
@@ -44203,6 +44353,15 @@ func (m *UserSubscriptionMutation) Fields() []string {
 	}
 	if m.status != nil {
 		fields = append(fields, usersubscription.FieldStatus)
+	}
+	if m.expiry_reminder_key != nil {
+		fields = append(fields, usersubscription.FieldExpiryReminderKey)
+	}
+	if m.expiry_reminder_expires_at != nil {
+		fields = append(fields, usersubscription.FieldExpiryReminderExpiresAt)
+	}
+	if m.expiry_reminder_sent_at != nil {
+		fields = append(fields, usersubscription.FieldExpiryReminderSentAt)
 	}
 	if m.daily_window_start != nil {
 		fields = append(fields, usersubscription.FieldDailyWindowStart)
@@ -44255,6 +44414,12 @@ func (m *UserSubscriptionMutation) Field(name string) (ent.Value, bool) {
 		return m.ExpiresAt()
 	case usersubscription.FieldStatus:
 		return m.Status()
+	case usersubscription.FieldExpiryReminderKey:
+		return m.ExpiryReminderKey()
+	case usersubscription.FieldExpiryReminderExpiresAt:
+		return m.ExpiryReminderExpiresAt()
+	case usersubscription.FieldExpiryReminderSentAt:
+		return m.ExpiryReminderSentAt()
 	case usersubscription.FieldDailyWindowStart:
 		return m.DailyWindowStart()
 	case usersubscription.FieldWeeklyWindowStart:
@@ -44298,6 +44463,12 @@ func (m *UserSubscriptionMutation) OldField(ctx context.Context, name string) (e
 		return m.OldExpiresAt(ctx)
 	case usersubscription.FieldStatus:
 		return m.OldStatus(ctx)
+	case usersubscription.FieldExpiryReminderKey:
+		return m.OldExpiryReminderKey(ctx)
+	case usersubscription.FieldExpiryReminderExpiresAt:
+		return m.OldExpiryReminderExpiresAt(ctx)
+	case usersubscription.FieldExpiryReminderSentAt:
+		return m.OldExpiryReminderSentAt(ctx)
 	case usersubscription.FieldDailyWindowStart:
 		return m.OldDailyWindowStart(ctx)
 	case usersubscription.FieldWeeklyWindowStart:
@@ -44380,6 +44551,27 @@ func (m *UserSubscriptionMutation) SetField(name string, value ent.Value) error 
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetStatus(v)
+		return nil
+	case usersubscription.FieldExpiryReminderKey:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExpiryReminderKey(v)
+		return nil
+	case usersubscription.FieldExpiryReminderExpiresAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExpiryReminderExpiresAt(v)
+		return nil
+	case usersubscription.FieldExpiryReminderSentAt:
+		v, ok := value.(time.Time)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetExpiryReminderSentAt(v)
 		return nil
 	case usersubscription.FieldDailyWindowStart:
 		v, ok := value.(time.Time)
@@ -44516,6 +44708,15 @@ func (m *UserSubscriptionMutation) ClearedFields() []string {
 	if m.FieldCleared(usersubscription.FieldDeletedAt) {
 		fields = append(fields, usersubscription.FieldDeletedAt)
 	}
+	if m.FieldCleared(usersubscription.FieldExpiryReminderKey) {
+		fields = append(fields, usersubscription.FieldExpiryReminderKey)
+	}
+	if m.FieldCleared(usersubscription.FieldExpiryReminderExpiresAt) {
+		fields = append(fields, usersubscription.FieldExpiryReminderExpiresAt)
+	}
+	if m.FieldCleared(usersubscription.FieldExpiryReminderSentAt) {
+		fields = append(fields, usersubscription.FieldExpiryReminderSentAt)
+	}
 	if m.FieldCleared(usersubscription.FieldDailyWindowStart) {
 		fields = append(fields, usersubscription.FieldDailyWindowStart)
 	}
@@ -44547,6 +44748,15 @@ func (m *UserSubscriptionMutation) ClearField(name string) error {
 	switch name {
 	case usersubscription.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case usersubscription.FieldExpiryReminderKey:
+		m.ClearExpiryReminderKey()
+		return nil
+	case usersubscription.FieldExpiryReminderExpiresAt:
+		m.ClearExpiryReminderExpiresAt()
+		return nil
+	case usersubscription.FieldExpiryReminderSentAt:
+		m.ClearExpiryReminderSentAt()
 		return nil
 	case usersubscription.FieldDailyWindowStart:
 		m.ClearDailyWindowStart()
@@ -44594,6 +44804,15 @@ func (m *UserSubscriptionMutation) ResetField(name string) error {
 		return nil
 	case usersubscription.FieldStatus:
 		m.ResetStatus()
+		return nil
+	case usersubscription.FieldExpiryReminderKey:
+		m.ResetExpiryReminderKey()
+		return nil
+	case usersubscription.FieldExpiryReminderExpiresAt:
+		m.ResetExpiryReminderExpiresAt()
+		return nil
+	case usersubscription.FieldExpiryReminderSentAt:
+		m.ResetExpiryReminderSentAt()
 		return nil
 	case usersubscription.FieldDailyWindowStart:
 		m.ResetDailyWindowStart()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -2022,20 +2022,24 @@ func init() {
 	usersubscription.DefaultStatus = usersubscriptionDescStatus.Default.(string)
 	// usersubscription.StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	usersubscription.StatusValidator = usersubscriptionDescStatus.Validators[0].(func(string) error)
+	// usersubscriptionDescExpiryReminderKey is the schema descriptor for expiry_reminder_key field.
+	usersubscriptionDescExpiryReminderKey := usersubscriptionFields[5].Descriptor()
+	// usersubscription.ExpiryReminderKeyValidator is a validator for the "expiry_reminder_key" field. It is called by the builders before save.
+	usersubscription.ExpiryReminderKeyValidator = usersubscriptionDescExpiryReminderKey.Validators[0].(func(string) error)
 	// usersubscriptionDescDailyUsageUsd is the schema descriptor for daily_usage_usd field.
-	usersubscriptionDescDailyUsageUsd := usersubscriptionFields[8].Descriptor()
+	usersubscriptionDescDailyUsageUsd := usersubscriptionFields[11].Descriptor()
 	// usersubscription.DefaultDailyUsageUsd holds the default value on creation for the daily_usage_usd field.
 	usersubscription.DefaultDailyUsageUsd = usersubscriptionDescDailyUsageUsd.Default.(float64)
 	// usersubscriptionDescWeeklyUsageUsd is the schema descriptor for weekly_usage_usd field.
-	usersubscriptionDescWeeklyUsageUsd := usersubscriptionFields[9].Descriptor()
+	usersubscriptionDescWeeklyUsageUsd := usersubscriptionFields[12].Descriptor()
 	// usersubscription.DefaultWeeklyUsageUsd holds the default value on creation for the weekly_usage_usd field.
 	usersubscription.DefaultWeeklyUsageUsd = usersubscriptionDescWeeklyUsageUsd.Default.(float64)
 	// usersubscriptionDescMonthlyUsageUsd is the schema descriptor for monthly_usage_usd field.
-	usersubscriptionDescMonthlyUsageUsd := usersubscriptionFields[10].Descriptor()
+	usersubscriptionDescMonthlyUsageUsd := usersubscriptionFields[13].Descriptor()
 	// usersubscription.DefaultMonthlyUsageUsd holds the default value on creation for the monthly_usage_usd field.
 	usersubscription.DefaultMonthlyUsageUsd = usersubscriptionDescMonthlyUsageUsd.Default.(float64)
 	// usersubscriptionDescAssignedAt is the schema descriptor for assigned_at field.
-	usersubscriptionDescAssignedAt := usersubscriptionFields[12].Descriptor()
+	usersubscriptionDescAssignedAt := usersubscriptionFields[15].Descriptor()
 	// usersubscription.DefaultAssignedAt holds the default value on creation for the assigned_at field.
 	usersubscription.DefaultAssignedAt = usersubscriptionDescAssignedAt.Default.(func() time.Time)
 }

--- a/backend/ent/schema/user_subscription.go
+++ b/backend/ent/schema/user_subscription.go
@@ -45,6 +45,18 @@ func (UserSubscription) Fields() []ent.Field {
 		field.String("status").
 			MaxLen(20).
 			Default(domain.SubscriptionStatusActive),
+		field.String("expiry_reminder_key").
+			MaxLen(32).
+			Optional().
+			Nillable(),
+		field.Time("expiry_reminder_expires_at").
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{dialect.Postgres: "timestamptz"}),
+		field.Time("expiry_reminder_sent_at").
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{dialect.Postgres: "timestamptz"}),
 
 		field.Time("daily_window_start").
 			Optional().

--- a/backend/ent/usersubscription.go
+++ b/backend/ent/usersubscription.go
@@ -35,6 +35,12 @@ type UserSubscription struct {
 	ExpiresAt time.Time `json:"expires_at,omitempty"`
 	// Status holds the value of the "status" field.
 	Status string `json:"status,omitempty"`
+	// ExpiryReminderKey holds the value of the "expiry_reminder_key" field.
+	ExpiryReminderKey *string `json:"expiry_reminder_key,omitempty"`
+	// ExpiryReminderExpiresAt holds the value of the "expiry_reminder_expires_at" field.
+	ExpiryReminderExpiresAt *time.Time `json:"expiry_reminder_expires_at,omitempty"`
+	// ExpiryReminderSentAt holds the value of the "expiry_reminder_sent_at" field.
+	ExpiryReminderSentAt *time.Time `json:"expiry_reminder_sent_at,omitempty"`
 	// DailyWindowStart holds the value of the "daily_window_start" field.
 	DailyWindowStart *time.Time `json:"daily_window_start,omitempty"`
 	// WeeklyWindowStart holds the value of the "weekly_window_start" field.
@@ -125,9 +131,9 @@ func (*UserSubscription) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case usersubscription.FieldID, usersubscription.FieldUserID, usersubscription.FieldGroupID, usersubscription.FieldAssignedBy:
 			values[i] = new(sql.NullInt64)
-		case usersubscription.FieldStatus, usersubscription.FieldNotes:
+		case usersubscription.FieldStatus, usersubscription.FieldExpiryReminderKey, usersubscription.FieldNotes:
 			values[i] = new(sql.NullString)
-		case usersubscription.FieldCreatedAt, usersubscription.FieldUpdatedAt, usersubscription.FieldDeletedAt, usersubscription.FieldStartsAt, usersubscription.FieldExpiresAt, usersubscription.FieldDailyWindowStart, usersubscription.FieldWeeklyWindowStart, usersubscription.FieldMonthlyWindowStart, usersubscription.FieldAssignedAt:
+		case usersubscription.FieldCreatedAt, usersubscription.FieldUpdatedAt, usersubscription.FieldDeletedAt, usersubscription.FieldStartsAt, usersubscription.FieldExpiresAt, usersubscription.FieldExpiryReminderExpiresAt, usersubscription.FieldExpiryReminderSentAt, usersubscription.FieldDailyWindowStart, usersubscription.FieldWeeklyWindowStart, usersubscription.FieldMonthlyWindowStart, usersubscription.FieldAssignedAt:
 			values[i] = new(sql.NullTime)
 		default:
 			values[i] = new(sql.UnknownType)
@@ -198,6 +204,27 @@ func (_m *UserSubscription) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field status", values[i])
 			} else if value.Valid {
 				_m.Status = value.String
+			}
+		case usersubscription.FieldExpiryReminderKey:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field expiry_reminder_key", values[i])
+			} else if value.Valid {
+				_m.ExpiryReminderKey = new(string)
+				*_m.ExpiryReminderKey = value.String
+			}
+		case usersubscription.FieldExpiryReminderExpiresAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field expiry_reminder_expires_at", values[i])
+			} else if value.Valid {
+				_m.ExpiryReminderExpiresAt = new(time.Time)
+				*_m.ExpiryReminderExpiresAt = value.Time
+			}
+		case usersubscription.FieldExpiryReminderSentAt:
+			if value, ok := values[i].(*sql.NullTime); !ok {
+				return fmt.Errorf("unexpected type %T for field expiry_reminder_sent_at", values[i])
+			} else if value.Valid {
+				_m.ExpiryReminderSentAt = new(time.Time)
+				*_m.ExpiryReminderSentAt = value.Time
 			}
 		case usersubscription.FieldDailyWindowStart:
 			if value, ok := values[i].(*sql.NullTime); !ok {
@@ -339,6 +366,21 @@ func (_m *UserSubscription) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("status=")
 	builder.WriteString(_m.Status)
+	builder.WriteString(", ")
+	if v := _m.ExpiryReminderKey; v != nil {
+		builder.WriteString("expiry_reminder_key=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	if v := _m.ExpiryReminderExpiresAt; v != nil {
+		builder.WriteString("expiry_reminder_expires_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
+	builder.WriteString(", ")
+	if v := _m.ExpiryReminderSentAt; v != nil {
+		builder.WriteString("expiry_reminder_sent_at=")
+		builder.WriteString(v.Format(time.ANSIC))
+	}
 	builder.WriteString(", ")
 	if v := _m.DailyWindowStart; v != nil {
 		builder.WriteString("daily_window_start=")

--- a/backend/ent/usersubscription/usersubscription.go
+++ b/backend/ent/usersubscription/usersubscription.go
@@ -31,6 +31,12 @@ const (
 	FieldExpiresAt = "expires_at"
 	// FieldStatus holds the string denoting the status field in the database.
 	FieldStatus = "status"
+	// FieldExpiryReminderKey holds the string denoting the expiry_reminder_key field in the database.
+	FieldExpiryReminderKey = "expiry_reminder_key"
+	// FieldExpiryReminderExpiresAt holds the string denoting the expiry_reminder_expires_at field in the database.
+	FieldExpiryReminderExpiresAt = "expiry_reminder_expires_at"
+	// FieldExpiryReminderSentAt holds the string denoting the expiry_reminder_sent_at field in the database.
+	FieldExpiryReminderSentAt = "expiry_reminder_sent_at"
 	// FieldDailyWindowStart holds the string denoting the daily_window_start field in the database.
 	FieldDailyWindowStart = "daily_window_start"
 	// FieldWeeklyWindowStart holds the string denoting the weekly_window_start field in the database.
@@ -100,6 +106,9 @@ var Columns = []string{
 	FieldStartsAt,
 	FieldExpiresAt,
 	FieldStatus,
+	FieldExpiryReminderKey,
+	FieldExpiryReminderExpiresAt,
+	FieldExpiryReminderSentAt,
 	FieldDailyWindowStart,
 	FieldWeeklyWindowStart,
 	FieldMonthlyWindowStart,
@@ -139,6 +148,8 @@ var (
 	DefaultStatus string
 	// StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	StatusValidator func(string) error
+	// ExpiryReminderKeyValidator is a validator for the "expiry_reminder_key" field. It is called by the builders before save.
+	ExpiryReminderKeyValidator func(string) error
 	// DefaultDailyUsageUsd holds the default value on creation for the "daily_usage_usd" field.
 	DefaultDailyUsageUsd float64
 	// DefaultWeeklyUsageUsd holds the default value on creation for the "weekly_usage_usd" field.
@@ -195,6 +206,21 @@ func ByExpiresAt(opts ...sql.OrderTermOption) OrderOption {
 // ByStatus orders the results by the status field.
 func ByStatus(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldStatus, opts...).ToFunc()
+}
+
+// ByExpiryReminderKey orders the results by the expiry_reminder_key field.
+func ByExpiryReminderKey(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExpiryReminderKey, opts...).ToFunc()
+}
+
+// ByExpiryReminderExpiresAt orders the results by the expiry_reminder_expires_at field.
+func ByExpiryReminderExpiresAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExpiryReminderExpiresAt, opts...).ToFunc()
+}
+
+// ByExpiryReminderSentAt orders the results by the expiry_reminder_sent_at field.
+func ByExpiryReminderSentAt(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldExpiryReminderSentAt, opts...).ToFunc()
 }
 
 // ByDailyWindowStart orders the results by the daily_window_start field.

--- a/backend/ent/usersubscription/where.go
+++ b/backend/ent/usersubscription/where.go
@@ -95,6 +95,21 @@ func Status(v string) predicate.UserSubscription {
 	return predicate.UserSubscription(sql.FieldEQ(FieldStatus, v))
 }
 
+// ExpiryReminderKey applies equality check predicate on the "expiry_reminder_key" field. It's identical to ExpiryReminderKeyEQ.
+func ExpiryReminderKey(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEQ(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderExpiresAt applies equality check predicate on the "expiry_reminder_expires_at" field. It's identical to ExpiryReminderExpiresAtEQ.
+func ExpiryReminderExpiresAt(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEQ(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderSentAt applies equality check predicate on the "expiry_reminder_sent_at" field. It's identical to ExpiryReminderSentAtEQ.
+func ExpiryReminderSentAt(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEQ(FieldExpiryReminderSentAt, v))
+}
+
 // DailyWindowStart applies equality check predicate on the "daily_window_start" field. It's identical to DailyWindowStartEQ.
 func DailyWindowStart(v time.Time) predicate.UserSubscription {
 	return predicate.UserSubscription(sql.FieldEQ(FieldDailyWindowStart, v))
@@ -453,6 +468,181 @@ func StatusEqualFold(v string) predicate.UserSubscription {
 // StatusContainsFold applies the ContainsFold predicate on the "status" field.
 func StatusContainsFold(v string) predicate.UserSubscription {
 	return predicate.UserSubscription(sql.FieldContainsFold(FieldStatus, v))
+}
+
+// ExpiryReminderKeyEQ applies the EQ predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyEQ(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEQ(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyNEQ applies the NEQ predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyNEQ(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNEQ(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyIn applies the In predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyIn(vs ...string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldIn(FieldExpiryReminderKey, vs...))
+}
+
+// ExpiryReminderKeyNotIn applies the NotIn predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyNotIn(vs ...string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNotIn(FieldExpiryReminderKey, vs...))
+}
+
+// ExpiryReminderKeyGT applies the GT predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyGT(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldGT(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyGTE applies the GTE predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyGTE(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldGTE(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyLT applies the LT predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyLT(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldLT(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyLTE applies the LTE predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyLTE(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldLTE(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyContains applies the Contains predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyContains(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldContains(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyHasPrefix applies the HasPrefix predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyHasPrefix(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldHasPrefix(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyHasSuffix applies the HasSuffix predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyHasSuffix(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldHasSuffix(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyIsNil applies the IsNil predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyIsNil() predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldIsNull(FieldExpiryReminderKey))
+}
+
+// ExpiryReminderKeyNotNil applies the NotNil predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyNotNil() predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNotNull(FieldExpiryReminderKey))
+}
+
+// ExpiryReminderKeyEqualFold applies the EqualFold predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyEqualFold(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEqualFold(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderKeyContainsFold applies the ContainsFold predicate on the "expiry_reminder_key" field.
+func ExpiryReminderKeyContainsFold(v string) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldContainsFold(FieldExpiryReminderKey, v))
+}
+
+// ExpiryReminderExpiresAtEQ applies the EQ predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtEQ(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEQ(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderExpiresAtNEQ applies the NEQ predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtNEQ(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNEQ(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderExpiresAtIn applies the In predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtIn(vs ...time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldIn(FieldExpiryReminderExpiresAt, vs...))
+}
+
+// ExpiryReminderExpiresAtNotIn applies the NotIn predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtNotIn(vs ...time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNotIn(FieldExpiryReminderExpiresAt, vs...))
+}
+
+// ExpiryReminderExpiresAtGT applies the GT predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtGT(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldGT(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderExpiresAtGTE applies the GTE predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtGTE(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldGTE(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderExpiresAtLT applies the LT predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtLT(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldLT(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderExpiresAtLTE applies the LTE predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtLTE(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldLTE(FieldExpiryReminderExpiresAt, v))
+}
+
+// ExpiryReminderExpiresAtIsNil applies the IsNil predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtIsNil() predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldIsNull(FieldExpiryReminderExpiresAt))
+}
+
+// ExpiryReminderExpiresAtNotNil applies the NotNil predicate on the "expiry_reminder_expires_at" field.
+func ExpiryReminderExpiresAtNotNil() predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNotNull(FieldExpiryReminderExpiresAt))
+}
+
+// ExpiryReminderSentAtEQ applies the EQ predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtEQ(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldEQ(FieldExpiryReminderSentAt, v))
+}
+
+// ExpiryReminderSentAtNEQ applies the NEQ predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtNEQ(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNEQ(FieldExpiryReminderSentAt, v))
+}
+
+// ExpiryReminderSentAtIn applies the In predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtIn(vs ...time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldIn(FieldExpiryReminderSentAt, vs...))
+}
+
+// ExpiryReminderSentAtNotIn applies the NotIn predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtNotIn(vs ...time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNotIn(FieldExpiryReminderSentAt, vs...))
+}
+
+// ExpiryReminderSentAtGT applies the GT predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtGT(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldGT(FieldExpiryReminderSentAt, v))
+}
+
+// ExpiryReminderSentAtGTE applies the GTE predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtGTE(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldGTE(FieldExpiryReminderSentAt, v))
+}
+
+// ExpiryReminderSentAtLT applies the LT predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtLT(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldLT(FieldExpiryReminderSentAt, v))
+}
+
+// ExpiryReminderSentAtLTE applies the LTE predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtLTE(v time.Time) predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldLTE(FieldExpiryReminderSentAt, v))
+}
+
+// ExpiryReminderSentAtIsNil applies the IsNil predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtIsNil() predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldIsNull(FieldExpiryReminderSentAt))
+}
+
+// ExpiryReminderSentAtNotNil applies the NotNil predicate on the "expiry_reminder_sent_at" field.
+func ExpiryReminderSentAtNotNil() predicate.UserSubscription {
+	return predicate.UserSubscription(sql.FieldNotNull(FieldExpiryReminderSentAt))
 }
 
 // DailyWindowStartEQ applies the EQ predicate on the "daily_window_start" field.

--- a/backend/ent/usersubscription_create.go
+++ b/backend/ent/usersubscription_create.go
@@ -105,6 +105,48 @@ func (_c *UserSubscriptionCreate) SetNillableStatus(v *string) *UserSubscription
 	return _c
 }
 
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (_c *UserSubscriptionCreate) SetExpiryReminderKey(v string) *UserSubscriptionCreate {
+	_c.mutation.SetExpiryReminderKey(v)
+	return _c
+}
+
+// SetNillableExpiryReminderKey sets the "expiry_reminder_key" field if the given value is not nil.
+func (_c *UserSubscriptionCreate) SetNillableExpiryReminderKey(v *string) *UserSubscriptionCreate {
+	if v != nil {
+		_c.SetExpiryReminderKey(*v)
+	}
+	return _c
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (_c *UserSubscriptionCreate) SetExpiryReminderExpiresAt(v time.Time) *UserSubscriptionCreate {
+	_c.mutation.SetExpiryReminderExpiresAt(v)
+	return _c
+}
+
+// SetNillableExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field if the given value is not nil.
+func (_c *UserSubscriptionCreate) SetNillableExpiryReminderExpiresAt(v *time.Time) *UserSubscriptionCreate {
+	if v != nil {
+		_c.SetExpiryReminderExpiresAt(*v)
+	}
+	return _c
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (_c *UserSubscriptionCreate) SetExpiryReminderSentAt(v time.Time) *UserSubscriptionCreate {
+	_c.mutation.SetExpiryReminderSentAt(v)
+	return _c
+}
+
+// SetNillableExpiryReminderSentAt sets the "expiry_reminder_sent_at" field if the given value is not nil.
+func (_c *UserSubscriptionCreate) SetNillableExpiryReminderSentAt(v *time.Time) *UserSubscriptionCreate {
+	if v != nil {
+		_c.SetExpiryReminderSentAt(*v)
+	}
+	return _c
+}
+
 // SetDailyWindowStart sets the "daily_window_start" field.
 func (_c *UserSubscriptionCreate) SetDailyWindowStart(v time.Time) *UserSubscriptionCreate {
 	_c.mutation.SetDailyWindowStart(v)
@@ -380,6 +422,11 @@ func (_c *UserSubscriptionCreate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "UserSubscription.status": %w`, err)}
 		}
 	}
+	if v, ok := _c.mutation.ExpiryReminderKey(); ok {
+		if err := usersubscription.ExpiryReminderKeyValidator(v); err != nil {
+			return &ValidationError{Name: "expiry_reminder_key", err: fmt.Errorf(`ent: validator failed for field "UserSubscription.expiry_reminder_key": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.DailyUsageUsd(); !ok {
 		return &ValidationError{Name: "daily_usage_usd", err: errors.New(`ent: missing required field "UserSubscription.daily_usage_usd"`)}
 	}
@@ -448,6 +495,18 @@ func (_c *UserSubscriptionCreate) createSpec() (*UserSubscription, *sqlgraph.Cre
 	if value, ok := _c.mutation.Status(); ok {
 		_spec.SetField(usersubscription.FieldStatus, field.TypeString, value)
 		_node.Status = value
+	}
+	if value, ok := _c.mutation.ExpiryReminderKey(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderKey, field.TypeString, value)
+		_node.ExpiryReminderKey = &value
+	}
+	if value, ok := _c.mutation.ExpiryReminderExpiresAt(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderExpiresAt, field.TypeTime, value)
+		_node.ExpiryReminderExpiresAt = &value
+	}
+	if value, ok := _c.mutation.ExpiryReminderSentAt(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderSentAt, field.TypeTime, value)
+		_node.ExpiryReminderSentAt = &value
 	}
 	if value, ok := _c.mutation.DailyWindowStart(); ok {
 		_spec.SetField(usersubscription.FieldDailyWindowStart, field.TypeTime, value)
@@ -687,6 +746,60 @@ func (u *UserSubscriptionUpsert) SetStatus(v string) *UserSubscriptionUpsert {
 // UpdateStatus sets the "status" field to the value that was provided on create.
 func (u *UserSubscriptionUpsert) UpdateStatus() *UserSubscriptionUpsert {
 	u.SetExcluded(usersubscription.FieldStatus)
+	return u
+}
+
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (u *UserSubscriptionUpsert) SetExpiryReminderKey(v string) *UserSubscriptionUpsert {
+	u.Set(usersubscription.FieldExpiryReminderKey, v)
+	return u
+}
+
+// UpdateExpiryReminderKey sets the "expiry_reminder_key" field to the value that was provided on create.
+func (u *UserSubscriptionUpsert) UpdateExpiryReminderKey() *UserSubscriptionUpsert {
+	u.SetExcluded(usersubscription.FieldExpiryReminderKey)
+	return u
+}
+
+// ClearExpiryReminderKey clears the value of the "expiry_reminder_key" field.
+func (u *UserSubscriptionUpsert) ClearExpiryReminderKey() *UserSubscriptionUpsert {
+	u.SetNull(usersubscription.FieldExpiryReminderKey)
+	return u
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (u *UserSubscriptionUpsert) SetExpiryReminderExpiresAt(v time.Time) *UserSubscriptionUpsert {
+	u.Set(usersubscription.FieldExpiryReminderExpiresAt, v)
+	return u
+}
+
+// UpdateExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field to the value that was provided on create.
+func (u *UserSubscriptionUpsert) UpdateExpiryReminderExpiresAt() *UserSubscriptionUpsert {
+	u.SetExcluded(usersubscription.FieldExpiryReminderExpiresAt)
+	return u
+}
+
+// ClearExpiryReminderExpiresAt clears the value of the "expiry_reminder_expires_at" field.
+func (u *UserSubscriptionUpsert) ClearExpiryReminderExpiresAt() *UserSubscriptionUpsert {
+	u.SetNull(usersubscription.FieldExpiryReminderExpiresAt)
+	return u
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (u *UserSubscriptionUpsert) SetExpiryReminderSentAt(v time.Time) *UserSubscriptionUpsert {
+	u.Set(usersubscription.FieldExpiryReminderSentAt, v)
+	return u
+}
+
+// UpdateExpiryReminderSentAt sets the "expiry_reminder_sent_at" field to the value that was provided on create.
+func (u *UserSubscriptionUpsert) UpdateExpiryReminderSentAt() *UserSubscriptionUpsert {
+	u.SetExcluded(usersubscription.FieldExpiryReminderSentAt)
+	return u
+}
+
+// ClearExpiryReminderSentAt clears the value of the "expiry_reminder_sent_at" field.
+func (u *UserSubscriptionUpsert) ClearExpiryReminderSentAt() *UserSubscriptionUpsert {
+	u.SetNull(usersubscription.FieldExpiryReminderSentAt)
 	return u
 }
 
@@ -993,6 +1106,69 @@ func (u *UserSubscriptionUpsertOne) SetStatus(v string) *UserSubscriptionUpsertO
 func (u *UserSubscriptionUpsertOne) UpdateStatus() *UserSubscriptionUpsertOne {
 	return u.Update(func(s *UserSubscriptionUpsert) {
 		s.UpdateStatus()
+	})
+}
+
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (u *UserSubscriptionUpsertOne) SetExpiryReminderKey(v string) *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.SetExpiryReminderKey(v)
+	})
+}
+
+// UpdateExpiryReminderKey sets the "expiry_reminder_key" field to the value that was provided on create.
+func (u *UserSubscriptionUpsertOne) UpdateExpiryReminderKey() *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.UpdateExpiryReminderKey()
+	})
+}
+
+// ClearExpiryReminderKey clears the value of the "expiry_reminder_key" field.
+func (u *UserSubscriptionUpsertOne) ClearExpiryReminderKey() *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.ClearExpiryReminderKey()
+	})
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (u *UserSubscriptionUpsertOne) SetExpiryReminderExpiresAt(v time.Time) *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.SetExpiryReminderExpiresAt(v)
+	})
+}
+
+// UpdateExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field to the value that was provided on create.
+func (u *UserSubscriptionUpsertOne) UpdateExpiryReminderExpiresAt() *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.UpdateExpiryReminderExpiresAt()
+	})
+}
+
+// ClearExpiryReminderExpiresAt clears the value of the "expiry_reminder_expires_at" field.
+func (u *UserSubscriptionUpsertOne) ClearExpiryReminderExpiresAt() *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.ClearExpiryReminderExpiresAt()
+	})
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (u *UserSubscriptionUpsertOne) SetExpiryReminderSentAt(v time.Time) *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.SetExpiryReminderSentAt(v)
+	})
+}
+
+// UpdateExpiryReminderSentAt sets the "expiry_reminder_sent_at" field to the value that was provided on create.
+func (u *UserSubscriptionUpsertOne) UpdateExpiryReminderSentAt() *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.UpdateExpiryReminderSentAt()
+	})
+}
+
+// ClearExpiryReminderSentAt clears the value of the "expiry_reminder_sent_at" field.
+func (u *UserSubscriptionUpsertOne) ClearExpiryReminderSentAt() *UserSubscriptionUpsertOne {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.ClearExpiryReminderSentAt()
 	})
 }
 
@@ -1491,6 +1667,69 @@ func (u *UserSubscriptionUpsertBulk) SetStatus(v string) *UserSubscriptionUpsert
 func (u *UserSubscriptionUpsertBulk) UpdateStatus() *UserSubscriptionUpsertBulk {
 	return u.Update(func(s *UserSubscriptionUpsert) {
 		s.UpdateStatus()
+	})
+}
+
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (u *UserSubscriptionUpsertBulk) SetExpiryReminderKey(v string) *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.SetExpiryReminderKey(v)
+	})
+}
+
+// UpdateExpiryReminderKey sets the "expiry_reminder_key" field to the value that was provided on create.
+func (u *UserSubscriptionUpsertBulk) UpdateExpiryReminderKey() *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.UpdateExpiryReminderKey()
+	})
+}
+
+// ClearExpiryReminderKey clears the value of the "expiry_reminder_key" field.
+func (u *UserSubscriptionUpsertBulk) ClearExpiryReminderKey() *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.ClearExpiryReminderKey()
+	})
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (u *UserSubscriptionUpsertBulk) SetExpiryReminderExpiresAt(v time.Time) *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.SetExpiryReminderExpiresAt(v)
+	})
+}
+
+// UpdateExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field to the value that was provided on create.
+func (u *UserSubscriptionUpsertBulk) UpdateExpiryReminderExpiresAt() *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.UpdateExpiryReminderExpiresAt()
+	})
+}
+
+// ClearExpiryReminderExpiresAt clears the value of the "expiry_reminder_expires_at" field.
+func (u *UserSubscriptionUpsertBulk) ClearExpiryReminderExpiresAt() *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.ClearExpiryReminderExpiresAt()
+	})
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (u *UserSubscriptionUpsertBulk) SetExpiryReminderSentAt(v time.Time) *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.SetExpiryReminderSentAt(v)
+	})
+}
+
+// UpdateExpiryReminderSentAt sets the "expiry_reminder_sent_at" field to the value that was provided on create.
+func (u *UserSubscriptionUpsertBulk) UpdateExpiryReminderSentAt() *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.UpdateExpiryReminderSentAt()
+	})
+}
+
+// ClearExpiryReminderSentAt clears the value of the "expiry_reminder_sent_at" field.
+func (u *UserSubscriptionUpsertBulk) ClearExpiryReminderSentAt() *UserSubscriptionUpsertBulk {
+	return u.Update(func(s *UserSubscriptionUpsert) {
+		s.ClearExpiryReminderSentAt()
 	})
 }
 

--- a/backend/ent/usersubscription_update.go
+++ b/backend/ent/usersubscription_update.go
@@ -127,6 +127,66 @@ func (_u *UserSubscriptionUpdate) SetNillableStatus(v *string) *UserSubscription
 	return _u
 }
 
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (_u *UserSubscriptionUpdate) SetExpiryReminderKey(v string) *UserSubscriptionUpdate {
+	_u.mutation.SetExpiryReminderKey(v)
+	return _u
+}
+
+// SetNillableExpiryReminderKey sets the "expiry_reminder_key" field if the given value is not nil.
+func (_u *UserSubscriptionUpdate) SetNillableExpiryReminderKey(v *string) *UserSubscriptionUpdate {
+	if v != nil {
+		_u.SetExpiryReminderKey(*v)
+	}
+	return _u
+}
+
+// ClearExpiryReminderKey clears the value of the "expiry_reminder_key" field.
+func (_u *UserSubscriptionUpdate) ClearExpiryReminderKey() *UserSubscriptionUpdate {
+	_u.mutation.ClearExpiryReminderKey()
+	return _u
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (_u *UserSubscriptionUpdate) SetExpiryReminderExpiresAt(v time.Time) *UserSubscriptionUpdate {
+	_u.mutation.SetExpiryReminderExpiresAt(v)
+	return _u
+}
+
+// SetNillableExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field if the given value is not nil.
+func (_u *UserSubscriptionUpdate) SetNillableExpiryReminderExpiresAt(v *time.Time) *UserSubscriptionUpdate {
+	if v != nil {
+		_u.SetExpiryReminderExpiresAt(*v)
+	}
+	return _u
+}
+
+// ClearExpiryReminderExpiresAt clears the value of the "expiry_reminder_expires_at" field.
+func (_u *UserSubscriptionUpdate) ClearExpiryReminderExpiresAt() *UserSubscriptionUpdate {
+	_u.mutation.ClearExpiryReminderExpiresAt()
+	return _u
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (_u *UserSubscriptionUpdate) SetExpiryReminderSentAt(v time.Time) *UserSubscriptionUpdate {
+	_u.mutation.SetExpiryReminderSentAt(v)
+	return _u
+}
+
+// SetNillableExpiryReminderSentAt sets the "expiry_reminder_sent_at" field if the given value is not nil.
+func (_u *UserSubscriptionUpdate) SetNillableExpiryReminderSentAt(v *time.Time) *UserSubscriptionUpdate {
+	if v != nil {
+		_u.SetExpiryReminderSentAt(*v)
+	}
+	return _u
+}
+
+// ClearExpiryReminderSentAt clears the value of the "expiry_reminder_sent_at" field.
+func (_u *UserSubscriptionUpdate) ClearExpiryReminderSentAt() *UserSubscriptionUpdate {
+	_u.mutation.ClearExpiryReminderSentAt()
+	return _u
+}
+
 // SetDailyWindowStart sets the "daily_window_start" field.
 func (_u *UserSubscriptionUpdate) SetDailyWindowStart(v time.Time) *UserSubscriptionUpdate {
 	_u.mutation.SetDailyWindowStart(v)
@@ -441,6 +501,11 @@ func (_u *UserSubscriptionUpdate) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "UserSubscription.status": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ExpiryReminderKey(); ok {
+		if err := usersubscription.ExpiryReminderKeyValidator(v); err != nil {
+			return &ValidationError{Name: "expiry_reminder_key", err: fmt.Errorf(`ent: validator failed for field "UserSubscription.expiry_reminder_key": %w`, err)}
+		}
+	}
 	if _u.mutation.UserCleared() && len(_u.mutation.UserIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "UserSubscription.user"`)
 	}
@@ -479,6 +544,24 @@ func (_u *UserSubscriptionUpdate) sqlSave(ctx context.Context) (_node int, err e
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(usersubscription.FieldStatus, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.ExpiryReminderKey(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderKey, field.TypeString, value)
+	}
+	if _u.mutation.ExpiryReminderKeyCleared() {
+		_spec.ClearField(usersubscription.FieldExpiryReminderKey, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExpiryReminderExpiresAt(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderExpiresAt, field.TypeTime, value)
+	}
+	if _u.mutation.ExpiryReminderExpiresAtCleared() {
+		_spec.ClearField(usersubscription.FieldExpiryReminderExpiresAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.ExpiryReminderSentAt(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderSentAt, field.TypeTime, value)
+	}
+	if _u.mutation.ExpiryReminderSentAtCleared() {
+		_spec.ClearField(usersubscription.FieldExpiryReminderSentAt, field.TypeTime)
 	}
 	if value, ok := _u.mutation.DailyWindowStart(); ok {
 		_spec.SetField(usersubscription.FieldDailyWindowStart, field.TypeTime, value)
@@ -770,6 +853,66 @@ func (_u *UserSubscriptionUpdateOne) SetNillableStatus(v *string) *UserSubscript
 	if v != nil {
 		_u.SetStatus(*v)
 	}
+	return _u
+}
+
+// SetExpiryReminderKey sets the "expiry_reminder_key" field.
+func (_u *UserSubscriptionUpdateOne) SetExpiryReminderKey(v string) *UserSubscriptionUpdateOne {
+	_u.mutation.SetExpiryReminderKey(v)
+	return _u
+}
+
+// SetNillableExpiryReminderKey sets the "expiry_reminder_key" field if the given value is not nil.
+func (_u *UserSubscriptionUpdateOne) SetNillableExpiryReminderKey(v *string) *UserSubscriptionUpdateOne {
+	if v != nil {
+		_u.SetExpiryReminderKey(*v)
+	}
+	return _u
+}
+
+// ClearExpiryReminderKey clears the value of the "expiry_reminder_key" field.
+func (_u *UserSubscriptionUpdateOne) ClearExpiryReminderKey() *UserSubscriptionUpdateOne {
+	_u.mutation.ClearExpiryReminderKey()
+	return _u
+}
+
+// SetExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field.
+func (_u *UserSubscriptionUpdateOne) SetExpiryReminderExpiresAt(v time.Time) *UserSubscriptionUpdateOne {
+	_u.mutation.SetExpiryReminderExpiresAt(v)
+	return _u
+}
+
+// SetNillableExpiryReminderExpiresAt sets the "expiry_reminder_expires_at" field if the given value is not nil.
+func (_u *UserSubscriptionUpdateOne) SetNillableExpiryReminderExpiresAt(v *time.Time) *UserSubscriptionUpdateOne {
+	if v != nil {
+		_u.SetExpiryReminderExpiresAt(*v)
+	}
+	return _u
+}
+
+// ClearExpiryReminderExpiresAt clears the value of the "expiry_reminder_expires_at" field.
+func (_u *UserSubscriptionUpdateOne) ClearExpiryReminderExpiresAt() *UserSubscriptionUpdateOne {
+	_u.mutation.ClearExpiryReminderExpiresAt()
+	return _u
+}
+
+// SetExpiryReminderSentAt sets the "expiry_reminder_sent_at" field.
+func (_u *UserSubscriptionUpdateOne) SetExpiryReminderSentAt(v time.Time) *UserSubscriptionUpdateOne {
+	_u.mutation.SetExpiryReminderSentAt(v)
+	return _u
+}
+
+// SetNillableExpiryReminderSentAt sets the "expiry_reminder_sent_at" field if the given value is not nil.
+func (_u *UserSubscriptionUpdateOne) SetNillableExpiryReminderSentAt(v *time.Time) *UserSubscriptionUpdateOne {
+	if v != nil {
+		_u.SetExpiryReminderSentAt(*v)
+	}
+	return _u
+}
+
+// ClearExpiryReminderSentAt clears the value of the "expiry_reminder_sent_at" field.
+func (_u *UserSubscriptionUpdateOne) ClearExpiryReminderSentAt() *UserSubscriptionUpdateOne {
+	_u.mutation.ClearExpiryReminderSentAt()
 	return _u
 }
 
@@ -1100,6 +1243,11 @@ func (_u *UserSubscriptionUpdateOne) check() error {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "UserSubscription.status": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.ExpiryReminderKey(); ok {
+		if err := usersubscription.ExpiryReminderKeyValidator(v); err != nil {
+			return &ValidationError{Name: "expiry_reminder_key", err: fmt.Errorf(`ent: validator failed for field "UserSubscription.expiry_reminder_key": %w`, err)}
+		}
+	}
 	if _u.mutation.UserCleared() && len(_u.mutation.UserIDs()) > 0 {
 		return errors.New(`ent: clearing a required unique edge "UserSubscription.user"`)
 	}
@@ -1155,6 +1303,24 @@ func (_u *UserSubscriptionUpdateOne) sqlSave(ctx context.Context) (_node *UserSu
 	}
 	if value, ok := _u.mutation.Status(); ok {
 		_spec.SetField(usersubscription.FieldStatus, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.ExpiryReminderKey(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderKey, field.TypeString, value)
+	}
+	if _u.mutation.ExpiryReminderKeyCleared() {
+		_spec.ClearField(usersubscription.FieldExpiryReminderKey, field.TypeString)
+	}
+	if value, ok := _u.mutation.ExpiryReminderExpiresAt(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderExpiresAt, field.TypeTime, value)
+	}
+	if _u.mutation.ExpiryReminderExpiresAtCleared() {
+		_spec.ClearField(usersubscription.FieldExpiryReminderExpiresAt, field.TypeTime)
+	}
+	if value, ok := _u.mutation.ExpiryReminderSentAt(); ok {
+		_spec.SetField(usersubscription.FieldExpiryReminderSentAt, field.TypeTime, value)
+	}
+	if _u.mutation.ExpiryReminderSentAtCleared() {
+		_spec.ClearField(usersubscription.FieldExpiryReminderSentAt, field.TypeTime)
 	}
 	if value, ok := _u.mutation.DailyWindowStart(); ok {
 		_spec.SetField(usersubscription.FieldDailyWindowStart, field.TypeTime, value)

--- a/backend/internal/repository/migrations_schema_integration_test.go
+++ b/backend/internal/repository/migrations_schema_integration_test.go
@@ -103,6 +103,10 @@ func TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate(t *testing.T) {
 
 	// user_subscriptions: deleted_at for soft delete support (migration 012)
 	requireColumn(t, tx, "user_subscriptions", "deleted_at", "timestamp with time zone", 0, true)
+	requireColumn(t, tx, "user_subscriptions", "expiry_reminder_key", "character varying", 32, true)
+	requireColumn(t, tx, "user_subscriptions", "expiry_reminder_expires_at", "timestamp with time zone", 0, true)
+	requireColumn(t, tx, "user_subscriptions", "expiry_reminder_sent_at", "timestamp with time zone", 0, true)
+	requireIndex(t, tx, "user_subscriptions", "idx_user_subscriptions_expiry_reminder_state")
 
 	// orphan_allowed_groups_audit table should exist (migration 013)
 	var orphanAuditRegclass sql.NullString

--- a/backend/internal/repository/user_subscription_repo.go
+++ b/backend/internal/repository/user_subscription_repo.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
@@ -35,8 +36,13 @@ func (r *userSubscriptionRepository) Create(ctx context.Context, sub *service.Us
 		SetDailyUsageUsd(sub.DailyUsageUSD).
 		SetWeeklyUsageUsd(sub.WeeklyUsageUSD).
 		SetMonthlyUsageUsd(sub.MonthlyUsageUSD).
+		SetNillableExpiryReminderExpiresAt(sub.ExpiryReminderExpiresAt).
+		SetNillableExpiryReminderSentAt(sub.ExpiryReminderSentAt).
 		SetNillableAssignedBy(sub.AssignedBy)
 
+	if strings.TrimSpace(sub.ExpiryReminderKey) != "" {
+		builder.SetExpiryReminderKey(sub.ExpiryReminderKey)
+	}
 	if sub.StartsAt.IsZero() {
 		builder.SetStartsAt(time.Now())
 	} else {
@@ -122,6 +128,21 @@ func (r *userSubscriptionRepository) Update(ctx context.Context, sub *service.Us
 		SetNillableAssignedBy(sub.AssignedBy).
 		SetAssignedAt(sub.AssignedAt).
 		SetNotes(sub.Notes)
+	if strings.TrimSpace(sub.ExpiryReminderKey) == "" {
+		builder.ClearExpiryReminderKey()
+	} else {
+		builder.SetExpiryReminderKey(sub.ExpiryReminderKey)
+	}
+	if sub.ExpiryReminderExpiresAt == nil {
+		builder.ClearExpiryReminderExpiresAt()
+	} else {
+		builder.SetExpiryReminderExpiresAt(*sub.ExpiryReminderExpiresAt)
+	}
+	if sub.ExpiryReminderSentAt == nil {
+		builder.ClearExpiryReminderSentAt()
+	} else {
+		builder.SetExpiryReminderSentAt(*sub.ExpiryReminderSentAt)
+	}
 
 	updated, err := builder.Save(ctx)
 	if err == nil {
@@ -299,6 +320,16 @@ func (r *userSubscriptionRepository) UpdateNotes(ctx context.Context, subscripti
 	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
 }
 
+func (r *userSubscriptionRepository) MarkExpiryReminderSent(ctx context.Context, subscriptionID int64, reminderKey string, expiresAt, sentAt time.Time) error {
+	client := clientFromContext(ctx, r.client)
+	_, err := client.UserSubscription.UpdateOneID(subscriptionID).
+		SetExpiryReminderKey(reminderKey).
+		SetExpiryReminderExpiresAt(expiresAt).
+		SetExpiryReminderSentAt(sentAt).
+		Save(ctx)
+	return translatePersistenceError(err, service.ErrSubscriptionNotFound, nil)
+}
+
 func (r *userSubscriptionRepository) ActivateWindows(ctx context.Context, id int64, start time.Time) error {
 	client := clientFromContext(ctx, r.client)
 	_, err := client.UserSubscription.UpdateOneID(id).
@@ -430,23 +461,26 @@ func userSubscriptionEntityToService(m *dbent.UserSubscription) *service.UserSub
 		return nil
 	}
 	out := &service.UserSubscription{
-		ID:                 m.ID,
-		UserID:             m.UserID,
-		GroupID:            m.GroupID,
-		StartsAt:           m.StartsAt,
-		ExpiresAt:          m.ExpiresAt,
-		Status:             m.Status,
-		DailyWindowStart:   m.DailyWindowStart,
-		WeeklyWindowStart:  m.WeeklyWindowStart,
-		MonthlyWindowStart: m.MonthlyWindowStart,
-		DailyUsageUSD:      m.DailyUsageUsd,
-		WeeklyUsageUSD:     m.WeeklyUsageUsd,
-		MonthlyUsageUSD:    m.MonthlyUsageUsd,
-		AssignedBy:         m.AssignedBy,
-		AssignedAt:         m.AssignedAt,
-		Notes:              derefString(m.Notes),
-		CreatedAt:          m.CreatedAt,
-		UpdatedAt:          m.UpdatedAt,
+		ID:                      m.ID,
+		UserID:                  m.UserID,
+		GroupID:                 m.GroupID,
+		StartsAt:                m.StartsAt,
+		ExpiresAt:               m.ExpiresAt,
+		Status:                  m.Status,
+		ExpiryReminderKey:       derefString(m.ExpiryReminderKey),
+		ExpiryReminderExpiresAt: m.ExpiryReminderExpiresAt,
+		ExpiryReminderSentAt:    m.ExpiryReminderSentAt,
+		DailyWindowStart:        m.DailyWindowStart,
+		WeeklyWindowStart:       m.WeeklyWindowStart,
+		MonthlyWindowStart:      m.MonthlyWindowStart,
+		DailyUsageUSD:           m.DailyUsageUsd,
+		WeeklyUsageUSD:          m.WeeklyUsageUsd,
+		MonthlyUsageUSD:         m.MonthlyUsageUsd,
+		AssignedBy:              m.AssignedBy,
+		AssignedAt:              m.AssignedAt,
+		Notes:                   derefString(m.Notes),
+		CreatedAt:               m.CreatedAt,
+		UpdatedAt:               m.UpdatedAt,
 	}
 	if m.Edges.User != nil {
 		out.User = userEntityToService(m.Edges.User)

--- a/backend/internal/service/subscription_expiry_service.go
+++ b/backend/internal/service/subscription_expiry_service.go
@@ -107,6 +107,10 @@ func (s *SubscriptionExpiryService) sendExpiryReminderIfDue(ctx context.Context,
 	if daysRemaining != 7 && daysRemaining != 3 && daysRemaining != 1 {
 		return
 	}
+	reminderKey := subscriptionExpiryReminderKey(daysRemaining)
+	if sub.HasSentExpiryReminder(reminderKey) {
+		return
+	}
 	if err := s.notificationEmailService.Send(ctx, NotificationEmailSendInput{
 		Event:          NotificationEmailEventSubscriptionExpiryReminder,
 		RecipientEmail: sub.User.Email,
@@ -114,7 +118,7 @@ func (s *SubscriptionExpiryService) sendExpiryReminderIfDue(ctx context.Context,
 		UserID:         sub.UserID,
 		SourceType:     "user_subscription",
 		SourceID:       strconv.FormatInt(sub.ID, 10),
-		ReminderKey:    fmt.Sprintf("%dd", daysRemaining),
+		ReminderKey:    subscriptionExpiryReminderDeliveryKey(reminderKey, sub.ExpiresAt),
 		Variables: map[string]string{
 			"subscription_group": sub.Group.Name,
 			"expiry_time":        sub.ExpiresAt.Format("2006-01-02 15:04"),
@@ -122,5 +126,35 @@ func (s *SubscriptionExpiryService) sendExpiryReminderIfDue(ctx context.Context,
 		},
 	}); err != nil {
 		log.Printf("[SubscriptionExpiry] Send expiry reminder failed: subscription=%d user=%d err=%v", sub.ID, sub.UserID, err)
+		return
 	}
+	if err := s.markExpiryReminderSent(ctx, sub, reminderKey); err != nil {
+		log.Printf("[SubscriptionExpiry] Mark expiry reminder failed: subscription=%d user=%d err=%v", sub.ID, sub.UserID, err)
+	}
+}
+
+func subscriptionExpiryReminderKey(daysRemaining int) string {
+	return fmt.Sprintf("%dd", daysRemaining)
+}
+
+func subscriptionExpiryReminderDeliveryKey(reminderKey string, expiresAt time.Time) string {
+	return fmt.Sprintf("%s:%d", reminderKey, expiresAt.UTC().Unix())
+}
+
+func (s *SubscriptionExpiryService) markExpiryReminderSent(ctx context.Context, sub *UserSubscription, reminderKey string) error {
+	if s == nil || sub == nil {
+		return nil
+	}
+	repo, ok := s.userSubRepo.(UserSubscriptionExpiryReminderRepository)
+	if !ok {
+		return nil
+	}
+	sentAt := time.Now().UTC()
+	if err := repo.MarkExpiryReminderSent(ctx, sub.ID, reminderKey, sub.ExpiresAt, sentAt); err != nil {
+		return err
+	}
+	sub.ExpiryReminderKey = reminderKey
+	sub.ExpiryReminderExpiresAt = &sub.ExpiresAt
+	sub.ExpiryReminderSentAt = &sentAt
+	return nil
 }

--- a/backend/internal/service/subscription_expiry_service_test.go
+++ b/backend/internal/service/subscription_expiry_service_test.go
@@ -1,0 +1,158 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriptionExpiryServiceDeduplicatesSameBucketAcrossTicks(t *testing.T) {
+	repo := newExpiryReminderSubscriptionRepo(expiryReminderTestSubscription(1, time.Now().Add(7*24*time.Hour+2*time.Hour)))
+	notificationSvc, smtpServer := newSubscriptionExpiryTestNotificationService(t)
+	svc := NewSubscriptionExpiryService(repo, time.Minute)
+	svc.SetNotificationEmailService(notificationSvc)
+
+	for i := 0; i < 5; i++ {
+		svc.runOnce()
+	}
+
+	require.Equal(t, int64(1), smtpServer.messageCount())
+	require.Len(t, repo.marks, 1)
+	require.Equal(t, "7d", repo.marks[0].reminderKey)
+}
+
+func TestSubscriptionExpiryServiceSendsEachReminderBucketOnce(t *testing.T) {
+	firstExpiry := time.Now().Add(7*24*time.Hour + 2*time.Hour)
+	repo := newExpiryReminderSubscriptionRepo(expiryReminderTestSubscription(1, firstExpiry))
+	notificationSvc, smtpServer := newSubscriptionExpiryTestNotificationService(t)
+	svc := NewSubscriptionExpiryService(repo, time.Minute)
+	svc.SetNotificationEmailService(notificationSvc)
+
+	svc.runOnce()
+	repo.setExpiresAt(t, 1, time.Now().Add(3*24*time.Hour+2*time.Hour))
+	svc.runOnce()
+	repo.setExpiresAt(t, 1, time.Now().Add(24*time.Hour+2*time.Hour))
+	svc.runOnce()
+
+	require.Equal(t, int64(3), smtpServer.messageCount())
+	require.Len(t, repo.marks, 3)
+	require.Equal(t, []string{"7d", "3d", "1d"}, []string{
+		repo.marks[0].reminderKey,
+		repo.marks[1].reminderKey,
+		repo.marks[2].reminderKey,
+	})
+}
+
+func TestSubscriptionExpiryServiceAllowsSameBucketAfterRenewal(t *testing.T) {
+	firstExpiry := time.Now().Add(7*24*time.Hour + 2*time.Hour)
+	secondExpiry := time.Now().Add(7*24*time.Hour + 4*time.Hour)
+	repo := newExpiryReminderSubscriptionRepo(expiryReminderTestSubscription(1, firstExpiry))
+	notificationSvc, smtpServer := newSubscriptionExpiryTestNotificationService(t)
+	svc := NewSubscriptionExpiryService(repo, time.Minute)
+	svc.SetNotificationEmailService(notificationSvc)
+
+	svc.runOnce()
+	repo.setExpiresAt(t, 1, secondExpiry)
+	svc.runOnce()
+
+	require.Equal(t, int64(2), smtpServer.messageCount())
+	require.Len(t, repo.marks, 2)
+	require.Equal(t, "7d", repo.marks[0].reminderKey)
+	require.Equal(t, "7d", repo.marks[1].reminderKey)
+	require.True(t, repo.marks[0].expiresAt.Equal(firstExpiry))
+	require.True(t, repo.marks[1].expiresAt.Equal(secondExpiry))
+}
+
+func newSubscriptionExpiryTestNotificationService(t *testing.T) (*NotificationEmailService, *notificationEmailTestSMTPServer) {
+	t.Helper()
+	repo := newNotificationEmailMemorySettingRepo()
+	smtpServer := startNotificationEmailTestSMTPServer(t)
+	require.NoError(t, repo.SetMultiple(context.Background(), smtpServer.settings()))
+	emailSvc := NewEmailService(repo, nil)
+	return NewNotificationEmailService(repo, emailSvc), smtpServer
+}
+
+func expiryReminderTestSubscription(id int64, expiresAt time.Time) UserSubscription {
+	return UserSubscription{
+		ID:        id,
+		UserID:    id * 10,
+		GroupID:   id * 100,
+		StartsAt:  time.Now().Add(-24 * time.Hour),
+		ExpiresAt: expiresAt,
+		Status:    SubscriptionStatusActive,
+		User: &User{
+			ID:       id * 10,
+			Email:    "user@example.com",
+			Username: "user",
+		},
+		Group: &Group{
+			ID:   id * 100,
+			Name: "Pro",
+		},
+	}
+}
+
+type expiryReminderSubscriptionRepo struct {
+	UserSubscriptionRepository
+	subs  []UserSubscription
+	marks []expiryReminderMark
+}
+
+type expiryReminderMark struct {
+	subscriptionID int64
+	reminderKey    string
+	expiresAt      time.Time
+	sentAt         time.Time
+}
+
+func newExpiryReminderSubscriptionRepo(sub UserSubscription) *expiryReminderSubscriptionRepo {
+	return &expiryReminderSubscriptionRepo{subs: []UserSubscription{sub}}
+}
+
+func (r *expiryReminderSubscriptionRepo) BatchUpdateExpiredStatus(context.Context) (int64, error) {
+	return 0, nil
+}
+
+func (r *expiryReminderSubscriptionRepo) List(_ context.Context, params pagination.PaginationParams, _, _ *int64, _, _, _, _ string) ([]UserSubscription, *pagination.PaginationResult, error) {
+	subs := make([]UserSubscription, len(r.subs))
+	copy(subs, r.subs)
+	return subs, &pagination.PaginationResult{
+		Total:    int64(len(subs)),
+		Page:     params.Page,
+		PageSize: params.PageSize,
+		Pages:    1,
+	}, nil
+}
+
+func (r *expiryReminderSubscriptionRepo) MarkExpiryReminderSent(_ context.Context, subscriptionID int64, reminderKey string, expiresAt, sentAt time.Time) error {
+	for i := range r.subs {
+		if r.subs[i].ID != subscriptionID {
+			continue
+		}
+		r.subs[i].ExpiryReminderKey = reminderKey
+		r.subs[i].ExpiryReminderExpiresAt = &expiresAt
+		r.subs[i].ExpiryReminderSentAt = &sentAt
+		r.marks = append(r.marks, expiryReminderMark{
+			subscriptionID: subscriptionID,
+			reminderKey:    reminderKey,
+			expiresAt:      expiresAt,
+			sentAt:         sentAt,
+		})
+		return nil
+	}
+	return ErrSubscriptionNotFound
+}
+
+func (r *expiryReminderSubscriptionRepo) setExpiresAt(t *testing.T, subscriptionID int64, expiresAt time.Time) {
+	t.Helper()
+	for i := range r.subs {
+		if r.subs[i].ID == subscriptionID {
+			r.subs[i].ExpiresAt = expiresAt
+			return
+		}
+	}
+	t.Fatalf("subscription %d not found", subscriptionID)
+}

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -324,6 +324,9 @@ func renewedSubscriptionTerm(existingSub *UserSubscription, notes string, starts
 	renewed.DailyUsageUSD = 0
 	renewed.WeeklyUsageUSD = 0
 	renewed.MonthlyUsageUSD = 0
+	renewed.ExpiryReminderKey = ""
+	renewed.ExpiryReminderExpiresAt = nil
+	renewed.ExpiryReminderSentAt = nil
 	renewed.Notes = appendSubscriptionNotes(existingSub.Notes, notes)
 	return &renewed
 }

--- a/backend/internal/service/user_subscription.go
+++ b/backend/internal/service/user_subscription.go
@@ -1,6 +1,9 @@
 package service
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type UserSubscription struct {
 	ID      int64
@@ -10,6 +13,10 @@ type UserSubscription struct {
 	StartsAt  time.Time
 	ExpiresAt time.Time
 	Status    string
+
+	ExpiryReminderKey       string
+	ExpiryReminderExpiresAt *time.Time
+	ExpiryReminderSentAt    *time.Time
 
 	DailyWindowStart   *time.Time
 	WeeklyWindowStart  *time.Time
@@ -44,6 +51,16 @@ func (s *UserSubscription) DaysRemaining() int {
 		return 0
 	}
 	return int(time.Until(s.ExpiresAt).Hours() / 24)
+}
+
+func (s *UserSubscription) HasSentExpiryReminder(reminderKey string) bool {
+	if s == nil || s.ExpiryReminderExpiresAt == nil {
+		return false
+	}
+	if strings.TrimSpace(reminderKey) == "" || strings.TrimSpace(s.ExpiryReminderKey) != reminderKey {
+		return false
+	}
+	return s.ExpiryReminderExpiresAt.Equal(s.ExpiresAt)
 }
 
 func (s *UserSubscription) IsWindowActivated() bool {

--- a/backend/internal/service/user_subscription_port.go
+++ b/backend/internal/service/user_subscription_port.go
@@ -33,3 +33,7 @@ type UserSubscriptionRepository interface {
 
 	BatchUpdateExpiredStatus(ctx context.Context) (int64, error)
 }
+
+type UserSubscriptionExpiryReminderRepository interface {
+	MarkExpiryReminderSent(ctx context.Context, subscriptionID int64, reminderKey string, expiresAt, sentAt time.Time) error
+}

--- a/backend/migrations/140_subscription_expiry_reminder_state.sql
+++ b/backend/migrations/140_subscription_expiry_reminder_state.sql
@@ -1,0 +1,14 @@
+-- Persist per-subscription expiry reminder state so each reminder bucket is sent once per expiry cycle.
+
+ALTER TABLE user_subscriptions
+    ADD COLUMN IF NOT EXISTS expiry_reminder_key VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS expiry_reminder_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS expiry_reminder_sent_at TIMESTAMPTZ;
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_expiry_reminder_state
+    ON user_subscriptions (expiry_reminder_key, expiry_reminder_expires_at)
+    WHERE deleted_at IS NULL;
+
+COMMENT ON COLUMN user_subscriptions.expiry_reminder_key IS 'Last subscription expiry reminder bucket sent, e.g. 7d, 3d, 1d.';
+COMMENT ON COLUMN user_subscriptions.expiry_reminder_expires_at IS 'Subscription expiry timestamp associated with the last expiry reminder.';
+COMMENT ON COLUMN user_subscriptions.expiry_reminder_sent_at IS 'Timestamp when the last subscription expiry reminder was sent.';


### PR DESCRIPTION
## 背景

v0.1.128 起订阅到期提醒接入模板化通知邮件后，订阅扫描定时任务每分钟 tick 都会重新触发同一到期档位提醒。#2599 引入的通知邮件 delivery key 已能做一层去重，但提醒状态没有落在订阅记录上，且同一订阅续费后的下一轮相同档位可能被旧 key 误拦。

## 改动

- 在 `user_subscriptions` 持久化最近一次到期提醒的档位、关联到期时间和发送时间，并补充迁移与 Ent 生成代码。
- `SubscriptionExpiryService` 发信前先按 `(subscription, reminder_bucket, expires_at)` 判断是否已发送；发送成功后写回提醒状态。
- 通知邮件 `ReminderKey` 增加本次 `expires_at` 周期信息，避免续费后的下一次 7/3/1 天提醒被上一轮 delivery key 挡掉。
- 补充单测覆盖同档位连续 tick 只发一封、7→3→1 档位各发一封、续费后同档位可再次发送，并在迁移集成测试中校验新增列和索引。

## 测试

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `golangci-lint run ./...`

Fixes #2626