### PR TITLE
fix(antigravity): tool_choice forwarding, system_instruction oneof, and non-stream functionCall collection

### DIFF
--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -15,6 +15,7 @@ type ClaudeRequest struct {
 	TopP        *float64        `json:"top_p,omitempty"`
 	TopK        *int            `json:"top_k,omitempty"`
 	Tools       []ClaudeTool    `json:"tools,omitempty"`
+	ToolChoice  json.RawMessage `json:"tool_choice,omitempty"`
 	Thinking    *ThinkingConfig `json:"thinking,omitempty"`
 	Metadata    *ClaudeMetadata `json:"metadata,omitempty"`
 }

--- a/backend/internal/pkg/antigravity/gemini_types.go
+++ b/backend/internal/pkg/antigravity/gemini_types.go
@@ -117,7 +117,8 @@ type GeminiToolConfig struct {
 
 // GeminiFunctionCallingConfig 函数调用配置
 type GeminiFunctionCallingConfig struct {
-	Mode string `json:"mode,omitempty"` // VALIDATED, AUTO, NONE
+	Mode                 string   `json:"mode,omitempty"` // VALIDATED, AUTO, ANY, NONE
+	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
 }
 
 // GeminiSafetySetting Gemini 安全设置

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -146,8 +146,12 @@ func TransformClaudeToGeminiWithOptions(claudeReq *ClaudeRequest, projectID, map
 		// 总是生成 sessionId，基于用户消息内容
 		SessionID: generateStableSessionID(contents),
 	}
+	applyToolChoiceToFunctionCallingConfig(claudeReq.ToolChoice, innerRequest.ToolConfig.FunctionCallingConfig)
 
-	if systemInstruction != nil {
+	if systemInstruction != nil && len(tools) > 0 {
+		contents = prependSystemInstructionToContents(systemInstruction, contents)
+		innerRequest.Contents = contents
+	} else if systemInstruction != nil {
 		innerRequest.SystemInstruction = systemInstruction
 	}
 	if generationConfig != nil {
@@ -173,6 +177,64 @@ func TransformClaudeToGeminiWithOptions(claudeReq *ClaudeRequest, projectID, map
 	}
 
 	return json.Marshal(v1Req)
+}
+
+func applyToolChoiceToFunctionCallingConfig(toolChoice json.RawMessage, cfg *GeminiFunctionCallingConfig) {
+	if len(toolChoice) == 0 || cfg == nil {
+		return
+	}
+
+	var choice struct {
+		Type     string `json:"type"`
+		Name     string `json:"name"`
+		Function *struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(toolChoice, &choice); err != nil {
+		return
+	}
+
+	switch choice.Type {
+	case "auto":
+		cfg.Mode = "AUTO"
+		cfg.AllowedFunctionNames = nil
+	case "any":
+		cfg.Mode = "ANY"
+		cfg.AllowedFunctionNames = nil
+	case "tool":
+		cfg.Mode = "ANY"
+		if choice.Name != "" {
+			cfg.AllowedFunctionNames = []string{choice.Name}
+		}
+	case "function":
+		cfg.Mode = "ANY"
+		if choice.Function != nil && choice.Function.Name != "" {
+			cfg.AllowedFunctionNames = []string{choice.Function.Name}
+		}
+	case "none":
+		cfg.Mode = "NONE"
+		cfg.AllowedFunctionNames = nil
+	}
+}
+
+func prependSystemInstructionToContents(systemInstruction *GeminiContent, contents []GeminiContent) []GeminiContent {
+	if systemInstruction == nil || len(systemInstruction.Parts) == 0 {
+		return contents
+	}
+
+	merged := make([]GeminiContent, 0, len(contents)+1)
+	if len(contents) > 0 && contents[0].Role == "user" {
+		first := contents[0]
+		first.Parts = append(append([]GeminiPart{}, systemInstruction.Parts...), first.Parts...)
+		merged = append(merged, first)
+		merged = append(merged, contents[1:]...)
+		return merged
+	}
+
+	merged = append(merged, *systemInstruction)
+	merged = append(merged, contents...)
+	return merged
 }
 
 // antigravityIdentity Antigravity identity 提示词

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -424,6 +424,129 @@ func TestTransformClaudeToGeminiWithOptions_PreservesBillingHeaderSystemBlock(t 
 	}
 }
 
+func TestTransformClaudeToGeminiWithOptions_MapsToolChoiceToFunctionCallingConfig(t *testing.T) {
+	tests := []struct {
+		name                 string
+		toolChoice           json.RawMessage
+		wantMode             string
+		wantAllowedFunctions []string
+	}{
+		{
+			name:       "absent keeps validated default",
+			wantMode:   "VALIDATED",
+			toolChoice: nil,
+		},
+		{
+			name:       "auto maps to auto mode",
+			toolChoice: json.RawMessage(`{"type":"auto"}`),
+			wantMode:   "AUTO",
+		},
+		{
+			name:       "any maps to any mode",
+			toolChoice: json.RawMessage(`{"type":"any"}`),
+			wantMode:   "ANY",
+		},
+		{
+			name:                 "named tool maps to any mode with allowed function",
+			toolChoice:           json.RawMessage(`{"type":"tool","name":"get_weather"}`),
+			wantMode:             "ANY",
+			wantAllowedFunctions: []string{"get_weather"},
+		},
+		{
+			name:       "none maps to none mode",
+			toolChoice: json.RawMessage(`{"type":"none"}`),
+			wantMode:   "NONE",
+		},
+		{
+			name:                 "openai function choice maps to allowed function",
+			toolChoice:           json.RawMessage(`{"type":"function","function":{"name":"get_weather"}}`),
+			wantMode:             "ANY",
+			wantAllowedFunctions: []string{"get_weather"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			claudeReq := &ClaudeRequest{
+				Model: "claude-3-5-sonnet-latest",
+				Messages: []ClaudeMessage{
+					{
+						Role:    "user",
+						Content: json.RawMessage(`[{"type":"text","text":"what is the weather?"}]`),
+					},
+				},
+				Tools: []ClaudeTool{
+					{
+						Name:        "get_weather",
+						Description: "Get weather information",
+						InputSchema: map[string]any{"type": "object"},
+					},
+				},
+				ToolChoice: tt.toolChoice,
+			}
+
+			body, err := TransformClaudeToGeminiWithOptions(claudeReq, "project-1", "gemini-2.5-flash", DefaultTransformOptions())
+			require.NoError(t, err)
+
+			var req V1InternalRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.NotNil(t, req.Request.ToolConfig)
+			require.NotNil(t, req.Request.ToolConfig.FunctionCallingConfig)
+			require.Equal(t, tt.wantMode, req.Request.ToolConfig.FunctionCallingConfig.Mode)
+			require.Equal(t, tt.wantAllowedFunctions, req.Request.ToolConfig.FunctionCallingConfig.AllowedFunctionNames)
+		})
+	}
+}
+
+func TestTransformClaudeToGeminiWithOptions_MovesSystemIntoContentsWhenToolsPresent(t *testing.T) {
+	claudeReq := &ClaudeRequest{
+		Model:  "claude-3-5-sonnet-latest",
+		System: json.RawMessage(`"You are helpful"`),
+		Messages: []ClaudeMessage{
+			{
+				Role:    "user",
+				Content: json.RawMessage(`[{"type":"text","text":"What is the weather?"}]`),
+			},
+		},
+		Tools: []ClaudeTool{
+			{
+				Name:        "get_weather",
+				Description: "Get weather information",
+				InputSchema: map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"location": map[string]any{"type": "string"},
+					},
+				},
+			},
+		},
+	}
+
+	body, err := TransformClaudeToGeminiWithOptions(claudeReq, "project-1", "gemini-2.5-flash", DefaultTransformOptions())
+	require.NoError(t, err)
+
+	var req V1InternalRequest
+	require.NoError(t, json.Unmarshal(body, &req))
+	require.Len(t, req.Request.Tools, 1)
+	require.Nil(t, req.Request.SystemInstruction, "tool requests must not set systemInstruction because upstream treats it as a conflicting oneof field")
+
+	foundSystem := false
+	foundUserMessage := false
+	for _, content := range req.Request.Contents {
+		for _, part := range content.Parts {
+			if strings.Contains(part.Text, "You are helpful") {
+				foundSystem = true
+			}
+			if strings.Contains(part.Text, "What is the weather?") {
+				foundUserMessage = true
+			}
+		}
+	}
+
+	require.True(t, foundSystem, "system prompt content must be preserved in contents when tools are present")
+	require.True(t, foundUserMessage, "original user message must remain in contents")
+}
+
 func TestTransformClaudeToGeminiWithOptions_PreservesWebSearchAlongsideFunctions(t *testing.T) {
 	claudeReq := &ClaudeRequest{
 		Model: "claude-3-5-sonnet-latest",

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -1238,6 +1238,10 @@ func extractTextFromSSEResponse(respBody []byte) string {
 
 // injectIdentityPatchToGeminiRequest 为 Gemini 格式请求注入身份提示词
 // 如果请求中已包含 "You are Antigravity" 则不重复注入
+//
+// Antigravity upstream protobuf 对 system_instruction 有 oneof 约束，
+// 当请求同时携带 tools 时不能使用 systemInstruction 字段。
+// 此时将 systemInstruction 内容合并到 contents 的第一条 user 消息前。
 func injectIdentityPatchToGeminiRequest(body []byte) ([]byte, error) {
 	var request map[string]any
 	if err := json.Unmarshal(body, &request); err != nil {
@@ -1245,14 +1249,15 @@ func injectIdentityPatchToGeminiRequest(body []byte) ([]byte, error) {
 	}
 
 	// 检查现有 systemInstruction 是否已包含身份提示词
+	alreadyHasIdentity := false
 	if sysInst, ok := request["systemInstruction"].(map[string]any); ok {
 		if parts, ok := sysInst["parts"].([]any); ok {
 			for _, part := range parts {
 				if partMap, ok := part.(map[string]any); ok {
 					if text, ok := partMap["text"].(string); ok {
 						if strings.Contains(text, "You are Antigravity") {
-							// 已包含身份提示词，直接返回原始请求
-							return body, nil
+							alreadyHasIdentity = true
+							break
 						}
 					}
 				}
@@ -1260,23 +1265,47 @@ func injectIdentityPatchToGeminiRequest(body []byte) ([]byte, error) {
 		}
 	}
 
-	// 获取默认身份提示词
 	identityPatch := antigravity.GetDefaultIdentityPatch()
+	identityPart := map[string]any{"text": identityPatch}
 
-	// 构建新的 systemInstruction
-	newPart := map[string]any{"text": identityPatch}
+	hasTools := false
+	if tools, ok := request["tools"].([]any); ok && len(tools) > 0 {
+		hasTools = true
+	}
 
-	if existing, ok := request["systemInstruction"].(map[string]any); ok {
-		// 已有 systemInstruction，在开头插入身份提示词
-		if parts, ok := existing["parts"].([]any); ok {
-			existing["parts"] = append([]any{newPart}, parts...)
-		} else {
-			existing["parts"] = []any{newPart}
+	if hasTools {
+		// tools 存在时不能使用 systemInstruction 字段（Antigravity protobuf oneof 约束）。
+		// 将 identity + 原有 systemInstruction 合并到 contents 前面作为一条 user 消息。
+		var sysParts []any
+		if !alreadyHasIdentity {
+			sysParts = append(sysParts, identityPart)
+		}
+		if sysInst, ok := request["systemInstruction"].(map[string]any); ok {
+			if parts, ok := sysInst["parts"].([]any); ok {
+				sysParts = append(sysParts, parts...)
+			}
+		}
+		delete(request, "systemInstruction")
+
+		if len(sysParts) > 0 {
+			sysContent := map[string]any{"role": "user", "parts": sysParts}
+			contents, _ := request["contents"].([]any)
+			request["contents"] = append([]any{sysContent}, contents...)
 		}
 	} else {
-		// 没有 systemInstruction，创建新的
-		request["systemInstruction"] = map[string]any{
-			"parts": []any{newPart},
+		if alreadyHasIdentity {
+			return body, nil
+		}
+		if existing, ok := request["systemInstruction"].(map[string]any); ok {
+			if parts, ok := existing["parts"].([]any); ok {
+				existing["parts"] = append([]any{identityPart}, parts...)
+			} else {
+				existing["parts"] = []any{identityPart}
+			}
+		} else {
+			request["systemInstruction"] = map[string]any{
+				"parts": []any{identityPart},
+			}
 		}
 	}
 
@@ -3244,8 +3273,7 @@ func (s *AntigravityGatewayService) handleGeminiStreamToNonStreaming(c *gin.Cont
 	var firstTokenMs *int
 	var last map[string]any
 	var lastWithParts map[string]any
-	var collectedImageParts []map[string]any // 收集所有包含图片的 parts
-	var collectedTextParts []string          // 收集所有文本片段
+	var collectedParts []map[string]any
 
 	type scanEvent struct {
 		line string
@@ -3360,19 +3388,9 @@ func (s *AntigravityGatewayService) handleGeminiStreamToNonStreaming(c *gin.Cont
 				}
 			}
 
-			// 保留最后一个有 parts 的响应
 			if parts := extractGeminiParts(parsed); len(parts) > 0 {
 				lastWithParts = parsed
-				// 收集包含图片和文本的 parts
-				for _, part := range parts {
-					if inlineData, ok := part["inlineData"].(map[string]any); ok {
-						collectedImageParts = append(collectedImageParts, part)
-						_ = inlineData // 避免 unused 警告
-					}
-					if text, ok := part["text"].(string); ok && text != "" {
-						collectedTextParts = append(collectedTextParts, text)
-					}
-				}
+				collectedParts = append(collectedParts, parts...)
 			}
 
 		case <-intervalCh:
@@ -3399,14 +3417,8 @@ returnResponse:
 		}
 	}
 
-	// 如果收集到了图片 parts，需要合并到最终响应中
-	if len(collectedImageParts) > 0 {
-		finalResponse = mergeImagePartsToResponse(finalResponse, collectedImageParts)
-	}
-
-	// 如果收集到了文本，需要合并到最终响应中
-	if len(collectedTextParts) > 0 {
-		finalResponse = mergeTextPartsToResponse(finalResponse, collectedTextParts)
+	if len(collectedParts) > 0 {
+		finalResponse = mergeCollectedPartsToResponse(finalResponse, collectedParts)
 	}
 
 	respBody, err := json.Marshal(finalResponse)


### PR DESCRIPTION
## Summary

Three bugs fixed in the Antigravity gateway:

### 1. `tool_choice` not forwarded to Gemini `FunctionCallingConfig`

**Problem:** OpenAI `tool_choice` parameter (e.g. `{"type":"function","function":{"name":"get_weather"}}`) was completely ignored when constructing Gemini upstream requests. `ClaudeRequest` had no `ToolChoice` field, and `GeminiFunctionCallingConfig` was hardcoded to `Mode: "VALIDATED"` with no `AllowedFunctionNames` support.

**Impact:** Non-streaming requests with forced `tool_choice` returned `tool_calls=null` — the model spent all tokens on reasoning instead of calling the specified tool.

**Fix:**
- Added `ToolChoice json.RawMessage` to `ClaudeRequest`
- Added `AllowedFunctionNames []string` to `GeminiFunctionCallingConfig`
- `TransformClaudeToGeminiWithOptions` now maps `tool_choice` to Gemini modes:
  - `auto` → `AUTO`
  - `any` → `ANY`
  - `tool`/`function` with name → `ANY` + `AllowedFunctionNames`
  - `none` → `NONE`
  - absent → keeps existing `VALIDATED` (backward compatible)

### 2. `system_instruction` oneof conflict (HTTP 400) when tools present

**Problem:** Requests with both a `system` message and `tools` produced HTTP 400 from Antigravity upstream:
```
Invalid value at 'request' (oneof), oneof field '_system_instruction' is already set.
Cannot set 'system_instruction'
```

**Root cause:** The Antigravity upstream protobuf schema treats `system_instruction` as a oneof field that conflicts with `tools`/`toolConfig` in the same request.

**Fix:**
- When tools are present, system instruction content is prepended to `contents` instead of using the `systemInstruction` field
- Applied in both the Claude-to-Gemini transform path (`request_transformer.go`) and the native Gemini forwarding path (`injectIdentityPatchToGeminiRequest` in `antigravity_gateway_service.go`)
- Behavior unchanged when no tools are present

### 3. Non-streaming responses dropping `functionCall` parts

**Problem:** `handleGeminiStreamToNonStreaming` only collected `text` and `inlineData` parts from streaming chunks, silently dropping `functionCall`, `thought`, and all other part types. Since `ForwardGemini` always uses `streamGenerateContent` upstream (even for non-streaming client requests), this meant non-streaming tool calls never worked.

**Fix:** Replaced the type-specific `collectedImageParts`/`collectedTextParts` collection with a unified `collectedParts []map[string]any` that captures all part types, then calls the existing `mergeCollectedPartsToResponse` helper — matching the pattern already used by `handleClaudeStreamToNonStreaming`.

## Testing

- 7 new regression tests added in `request_transformer_test.go` covering tool_choice mapping and system+tools handling
- All existing tests pass: `go test ./internal/pkg/antigravity/...` and `go test -tags unit ./internal/service/...`
- Verified in production with live requests:
  - Non-streaming forced `tool_choice` now returns `finish_reason=tool_calls` with correct function call
  - System + tools requests return HTTP 200 (previously 400)
  - Full tool round-trip (Turn 1: tool call → Turn 2: tool result → natural language response) works end-to-end
  - Streaming tool calls and simple requests unchanged (regression verified)

## Changed Files

| File | Changes |
|---|---|
| `backend/internal/pkg/antigravity/claude_types.go` | +1: `ToolChoice` field |
| `backend/internal/pkg/antigravity/gemini_types.go` | +2: `AllowedFunctionNames` field |
| `backend/internal/pkg/antigravity/request_transformer.go` | +64: tool_choice mapping + system→contents migration |
| `backend/internal/pkg/antigravity/request_transformer_test.go` | +123: regression tests |
| `backend/internal/service/antigravity_gateway_service.go` | +45/-37: system_instruction oneof fix + unified parts collection |