### PR TITLE
fix(risk-control): Agent 工具循环中同一用户消息重复审计去重

### DIFF
--- a/backend/internal/service/content_moderation_input.go
+++ b/backend/internal/service/content_moderation_input.go
@@ -48,44 +48,44 @@ func collectLastRoleMessage(messages gjson.Result, role string, parts *[]string,
 	if !messages.IsArray() {
 		return
 	}
-	var lastParts []string
-	var lastImages []string
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		if strings.ToLower(strings.TrimSpace(msg.Get("role").String())) == role {
-			var candidate []string
-			var candidateImages []string
-			collectContentValue(msg.Get("content"), &candidate, &candidateImages)
-			if normalizeContentModerationText(strings.Join(candidate, "\n")) != "" || len(candidateImages) > 0 {
-				lastParts = candidate
-				lastImages = candidateImages
-			}
-		}
-		return true
-	})
-	*parts = append(*parts, lastParts...)
-	*images = append(*images, lastImages...)
+	array := messages.Array()
+	if len(array) == 0 {
+		return
+	}
+	last := array[len(array)-1]
+	if strings.ToLower(strings.TrimSpace(last.Get("role").String())) != role {
+		return
+	}
+	var candidate []string
+	var candidateImages []string
+	collectContentValue(last.Get("content"), &candidate, &candidateImages)
+	if normalizeContentModerationText(strings.Join(candidate, "\n")) == "" && len(candidateImages) == 0 {
+		return
+	}
+	*parts = append(*parts, candidate...)
+	*images = append(*images, candidateImages...)
 }
 
 func collectLastAnthropicUserMessage(messages gjson.Result, parts *[]string, images *[]string) {
 	if !messages.IsArray() {
 		return
 	}
-	var lastParts []string
-	var lastImages []string
-	messages.ForEach(func(_, msg gjson.Result) bool {
-		if strings.ToLower(strings.TrimSpace(msg.Get("role").String())) == "user" {
-			var candidate []string
-			var candidateImages []string
-			collectAnthropicUserContentValue(msg.Get("content"), &candidate, &candidateImages)
-			if normalizeContentModerationText(strings.Join(candidate, "\n")) != "" || len(candidateImages) > 0 {
-				lastParts = candidate
-				lastImages = candidateImages
-			}
-		}
-		return true
-	})
-	*parts = append(*parts, lastParts...)
-	*images = append(*images, lastImages...)
+	array := messages.Array()
+	if len(array) == 0 {
+		return
+	}
+	last := array[len(array)-1]
+	if strings.ToLower(strings.TrimSpace(last.Get("role").String())) != "user" {
+		return
+	}
+	var candidate []string
+	var candidateImages []string
+	collectAnthropicUserContentValue(last.Get("content"), &candidate, &candidateImages)
+	if normalizeContentModerationText(strings.Join(candidate, "\n")) == "" && len(candidateImages) == 0 {
+		return
+	}
+	*parts = append(*parts, candidate...)
+	*images = append(*images, candidateImages...)
 }
 
 func collectAnthropicUserContentValue(value gjson.Result, parts *[]string, images *[]string) {
@@ -128,18 +128,17 @@ func collectLastResponsesInput(input gjson.Result, parts *[]string, images *[]st
 	case input.Type == gjson.String:
 		addModerationText(parts, input.String())
 	case input.IsArray():
-		var last gjson.Result
-		input.ForEach(func(_, item gjson.Result) bool {
-			if isResponsesUserTextItem(item) {
-				last = item
-			}
-			return true
-		})
-		if last.Exists() {
-			collectContentValue(last.Get("content"), parts, images)
-			if last.Get("type").String() == "input_text" || last.Get("text").Exists() {
-				collectContentValue(last, parts, images)
-			}
+		array := input.Array()
+		if len(array) == 0 {
+			return
+		}
+		last := array[len(array)-1]
+		if !isResponsesUserTextItem(last) {
+			return
+		}
+		collectContentValue(last.Get("content"), parts, images)
+		if last.Get("type").String() == "input_text" || last.Get("text").Exists() {
+			collectContentValue(last, parts, images)
 		}
 	case input.IsObject():
 		if isResponsesUserTextItem(input) {
@@ -176,29 +175,29 @@ func collectLastGeminiContent(contents gjson.Result, parts *[]string, images *[]
 	if !contents.IsArray() {
 		return
 	}
-	var lastParts []string
-	var lastImages []string
-	contents.ForEach(func(_, content gjson.Result) bool {
-		role := strings.ToLower(strings.TrimSpace(content.Get("role").String()))
-		if role == "" || role == "user" {
-			var candidate []string
-			var candidateImages []string
-			if arr := content.Get("parts"); arr.IsArray() {
-				arr.ForEach(func(_, part gjson.Result) bool {
-					addModerationText(&candidate, part.Get("text").String())
-					addGeminiModerationImage(&candidateImages, part)
-					return true
-				})
-			}
-			if normalizeContentModerationText(strings.Join(candidate, "\n")) != "" || len(candidateImages) > 0 {
-				lastParts = candidate
-				lastImages = candidateImages
-			}
-		}
-		return true
-	})
-	*parts = append(*parts, lastParts...)
-	*images = append(*images, lastImages...)
+	array := contents.Array()
+	if len(array) == 0 {
+		return
+	}
+	last := array[len(array)-1]
+	role := strings.ToLower(strings.TrimSpace(last.Get("role").String()))
+	if role != "" && role != "user" {
+		return
+	}
+	var candidate []string
+	var candidateImages []string
+	if arr := last.Get("parts"); arr.IsArray() {
+		arr.ForEach(func(_, part gjson.Result) bool {
+			addModerationText(&candidate, part.Get("text").String())
+			addGeminiModerationImage(&candidateImages, part)
+			return true
+		})
+	}
+	if normalizeContentModerationText(strings.Join(candidate, "\n")) == "" && len(candidateImages) == 0 {
+		return
+	}
+	*parts = append(*parts, candidate...)
+	*images = append(*images, candidateImages...)
 }
 
 func collectContentValue(value gjson.Result, parts *[]string, images *[]string) {

--- a/backend/internal/service/content_moderation_input_test.go
+++ b/backend/internal/service/content_moderation_input_test.go
@@ -1,0 +1,179 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// 当数组末尾不是用户消息时（典型场景：Agent 工具循环结束于 tool/assistant），
+// 应直接跳过审计——不再回溯查找历史中的某条用户消息。
+
+func TestExtractContentModerationInput_AnthropicAgentToolLoopSkipsAudit(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role":"user","content":"调用一下天气工具"},
+			{"role":"assistant","content":[{"type":"tool_use","id":"tool_1","name":"weather","input":{}}]},
+			{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_1","content":"晴 25 度"}]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}
+
+func TestExtractContentModerationInput_AnthropicFirstTurnExtractsUser(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role":"user","content":"Q1"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
+
+	require.Equal(t, "Q1", input.Text)
+}
+
+func TestExtractContentModerationInput_AnthropicMultiTurnExtractsLatestUser(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role":"user","content":"Q1"},
+			{"role":"assistant","content":"A1"},
+			{"role":"user","content":"Q2"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
+
+	require.Equal(t, "Q2", input.Text)
+}
+
+func TestExtractContentModerationInput_AnthropicStreamResendExtractsResend(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role":"user","content":"原问题"},
+			{"role":"assistant","content":"部分回答……"},
+			{"role":"user","content":"重发"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
+
+	require.Equal(t, "重发", input.Text)
+}
+
+func TestExtractContentModerationInput_OpenAIChatAgentToolLoopSkipsAudit(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role":"system","content":"sys"},
+			{"role":"user","content":"列出我的订单"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"orders","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"call_1","content":"[]"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}
+
+func TestExtractContentModerationInput_OpenAIChatMultiTurnExtractsLatestUser(t *testing.T) {
+	body := []byte(`{
+		"messages": [
+			{"role":"user","content":"Q1"},
+			{"role":"assistant","content":"A1"},
+			{"role":"user","content":"Q2"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, body)
+
+	require.Equal(t, "Q2", input.Text)
+}
+
+func TestExtractContentModerationInput_GeminiAgentToolLoopSkipsAudit(t *testing.T) {
+	body := []byte(`{
+		"contents": [
+			{"role":"user","parts":[{"text":"查询天气"}]},
+			{"role":"model","parts":[{"functionCall":{"name":"weather","args":{}}}]},
+			{"role":"user","parts":[{"functionResponse":{"name":"weather","response":{"temp":25}}}]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolGemini, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}
+
+func TestExtractContentModerationInput_GeminiFirstTurnExtractsUser(t *testing.T) {
+	body := []byte(`{
+		"contents": [
+			{"role":"user","parts":[{"text":"你好"}]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolGemini, body)
+
+	require.Equal(t, "你好", input.Text)
+}
+
+func TestExtractContentModerationInput_GeminiMultiTurnExtractsLatestUser(t *testing.T) {
+	body := []byte(`{
+		"contents": [
+			{"role":"user","parts":[{"text":"Q1"}]},
+			{"role":"model","parts":[{"text":"A1"}]},
+			{"role":"user","parts":[{"text":"Q2"}]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolGemini, body)
+
+	require.Equal(t, "Q2", input.Text)
+}
+
+func TestExtractContentModerationInput_ResponsesAgentToolLoopSkipsAudit(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"运行测试"}]},
+			{"type":"function_call","call_id":"call_1","name":"run_tests","arguments":"{}"},
+			{"type":"function_call_output","call_id":"call_1","output":"all passed"}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}
+
+func TestExtractContentModerationInput_ResponsesLastUserMessageExtracted(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"answer"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"latest"}]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Equal(t, "latest", input.Text)
+}
+
+func TestExtractContentModerationInput_ResponsesLastIsAssistantSkipped(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"q1"}]},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"a1"}]}
+		]
+	}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
+}


### PR DESCRIPTION
## 背景

#2678 反馈：当客户端在一次 Agent 工具循环中持续 append 工具调用与结果（即 `messages` 末尾是 `tool` / `function_call_output` 等非用户消息），上一版内容审计逻辑会**回溯查找历史中最后一条 user 消息**并对其再次审计，导致同一条用户输入被反复送审、重复计费、重复写日志。流式中断重发等高频复用前文的场景也存在同样问题。

## 改动

采用了 review 中 @huweiATgithub 提出的更简方案——**末尾 role 检查**，替代上一版基于 `hash + TTL` 的去重缓存（缓存方案带 sync.Map / janitor / 配置项，工程开销大，且在用户连续重试相同问题时会被误命中）：

在 `backend/internal/service/content_moderation_input.go` 的四个提取入口加早退：

- `collectLastAnthropicUserMessage`：`messages[last].role != "user"` → 返回空
- `collectLastRoleMessage`（OpenAI Chat）：`messages[last].role != "user"` → 返回空
- `collectLastGeminiContent`：`contents[last].role` 不为空也不为 `"user"` → 返回空
- `collectLastResponsesInput`：`input[last]` 不满足 `isResponsesUserTextItem` → 返回空（`function_call_output` / tool 输出 这类条目按"非 user message"处理，一并跳过）

`runContentModeration` 已有 `content.IsEmpty()` 早退路径，提取为空后会自然走 `content_moderation.skip_empty_input` 分支，无需新增判断。无新增配置项、无新增缓存、无新增 goroutine。

## 测试

新增 `backend/internal/service/content_moderation_input_test.go`，覆盖：

- Agent 工具循环 `[user, assistant_with_toolcall, tool]` → 提取为空（Anthropic / OpenAI Chat / Gemini / Responses 四协议各一组）
- 用户首轮 `[user "Q1"]` → 提取 `Q1`
- 多轮 `[user "Q1", assistant "A1", user "Q2"]` → 提取 `Q2`
- 流式中断重发 `[user, assistant partial, user "重发"]` → 提取 `重发`
- Responses 边界：末尾 `function_call_output` → 跳过；末尾 `role=assistant` → 跳过；末尾 `role=user/input_text` → 提取

执行结果：

- `go test -tags=unit ./internal/service/... -run ContentModeration`：PASS
- `go test -tags=unit ./...`：PASS
- `go test -tags=integration ./...`：PASS
- `golangci-lint run ./...`：0 issues

Fixes #2678