### PR TITLE
fix(frontend): 修正 Cache Hit Rate 计算分母，包含全部 prompt tokens

### DIFF
--- a/frontend/src/components/charts/TokenUsageTrend.vue
+++ b/frontend/src/components/charts/TokenUsageTrend.vue
@@ -109,8 +109,8 @@ const chartData = computed(() => {
       {
         label: 'Cache Hit Rate',
         data: props.trendData.map((d) => {
-          const total = d.cache_read_tokens + d.cache_creation_tokens
-          return total > 0 ? (d.cache_read_tokens / total) * 100 : 0
+          const totalPromptTokens = d.input_tokens + d.cache_read_tokens + d.cache_creation_tokens
+          return totalPromptTokens > 0 ? (d.cache_read_tokens / totalPromptTokens) * 100 : 0
         }),
         borderColor: chartColors.value.cacheHitRate,
         backgroundColor: `${chartColors.value.cacheHitRate}20`,

--- a/frontend/src/components/charts/__tests__/TokenUsageTrend.spec.ts
+++ b/frontend/src/components/charts/__tests__/TokenUsageTrend.spec.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+import TokenUsageTrend from '../TokenUsageTrend.vue'
+
+const messages: Record<string, string> = {
+  'admin.dashboard.tokenUsageTrend': 'Token Usage Trend',
+  'admin.dashboard.noDataAvailable': 'No data available',
+}
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => messages[key] ?? key,
+    }),
+  }
+})
+
+vi.mock('vue-chartjs', () => ({
+  Line: {
+    props: ['data', 'options'],
+    template: '<div class="chart-data">{{ JSON.stringify(data) }}</div>',
+  },
+}))
+
+describe('TokenUsageTrend', () => {
+  it('calculates cache hit rate against all prompt tokens', () => {
+    const wrapper = mount(TokenUsageTrend, {
+      props: {
+        trendData: [
+          {
+            date: '2026-05-08',
+            requests: 1,
+            input_tokens: 500,
+            output_tokens: 100,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 1500,
+            cost: 0.01,
+            actual_cost: 0.005,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          LoadingSpinner: true,
+        },
+      },
+    })
+
+    const chartData = JSON.parse(wrapper.find('.chart-data').text())
+    const hitRateDataset = chartData.datasets.find(
+      (ds: any) => ds.label === 'Cache Hit Rate'
+    )
+    // Hit rate = 1500 / (500 + 1500 + 0) * 100 = 75%
+    expect(hitRateDataset.data[0]).toBe(75)
+  })
+
+  it('returns 0 hit rate when all prompt tokens are zero', () => {
+    const wrapper = mount(TokenUsageTrend, {
+      props: {
+        trendData: [
+          {
+            date: '2026-05-08',
+            requests: 0,
+            input_tokens: 0,
+            output_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            cost: 0,
+            actual_cost: 0,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          LoadingSpinner: true,
+        },
+      },
+    })
+
+    const chartData = JSON.parse(wrapper.find('.chart-data').text())
+    const hitRateDataset = chartData.datasets.find(
+      (ds: any) => ds.label === 'Cache Hit Rate'
+    )
+    expect(hitRateDataset.data[0]).toBe(0)
+  })
+
+  it('includes cache_creation_tokens in denominator for Anthropic models', () => {
+    const wrapper = mount(TokenUsageTrend, {
+      props: {
+        trendData: [
+          {
+            date: '2026-05-08',
+            requests: 1,
+            input_tokens: 200,
+            output_tokens: 50,
+            cache_creation_tokens: 300,
+            cache_read_tokens: 500,
+            cost: 0.02,
+            actual_cost: 0.01,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          LoadingSpinner: true,
+        },
+      },
+    })
+
+    const chartData = JSON.parse(wrapper.find('.chart-data').text())
+    const hitRateDataset = chartData.datasets.find(
+      (ds: any) => ds.label === 'Cache Hit Rate'
+    )
+    // Hit rate = 500 / (200 + 500 + 300) * 100 = 50%
+    expect(hitRateDataset.data[0]).toBe(50)
+  })
+})


### PR DESCRIPTION
## 概要

- 修正 Token 使用趋势图中 Cache Hit Rate 的计算公式，分母改为所有 prompt tokens：`cache_read_tokens / (input_tokens + cache_read_tokens + cache_creation_tokens)`。
- 新增 3 个回归测试，覆盖 OpenAI（无 cache_creation）、Anthropic（有 cache_creation）以及零 token 场景。

## 问题说明

当前公式 `cache_read / (cache_read + cache_creation)` 对于 OpenAI 模型（如 gpt-5.4-mini、gpt-5.5）始终得出 **100%**，因为 OpenAI API 不返回 `cache_creation_tokens`，导致该指标对 OpenAI 用户毫无参考价值。

当前公式示例：
- `cache_read=1500, cache_creation=0 → 1500/(1500+0) = 100%`（误导）

修正后公式：
- `cache_read=1500, input=500, cache_creation=0 → 1500/(500+1500+0) = 75%`（准确）

对于 Anthropic 模型同样正确：
- `cache_read=500, input=200, cache_creation=300 → 500/(200+500+300) = 50%`

## 测试

新增 `TokenUsageTrend.spec.ts`，包含 3 个测试用例：
1. OpenAI 场景（cache_creation=0）——验证命中率 75%，而非 100%
2. 零 token 场景——验证命中率返回 0
3. Anthropic 场景——验证 cache_creation 正确纳入分母

Fixes #2291