### PR TITLE
fix: record upstream error body in ops logs

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -35,6 +35,20 @@ const gatewayCompatibilityMetricsLogInterval = 1024
 
 var gatewayCompatibilityMetricsLogCounter atomic.Uint64
 
+func upstreamErrorDetailFromBody(cfg *config.Config, body []byte) string {
+	if cfg == nil || !cfg.Gateway.LogUpstreamErrorBody || len(body) == 0 {
+		return ""
+	}
+	maxBytes := cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+	if maxBytes <= 0 {
+		maxBytes = 2048
+	}
+	if len(body) > maxBytes {
+		body = body[:maxBytes]
+	}
+	return strings.TrimSpace(string(body))
+}
+
 // GatewayHandler handles API gateway requests
 type GatewayHandler struct {
 	gatewayService            *service.GatewayService
@@ -1386,7 +1400,7 @@ func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *se
 
 	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误
 	upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
-	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
+	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, upstreamErrorDetailFromBody(h.cfg, responseBody))
 
 	// 使用默认的错误映射
 	status, errType, errMsg := h.mapUpstreamError(statusCode)

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -617,7 +617,7 @@ func (h *GatewayHandler) handleGeminiFailoverExhausted(c *gin.Context, failoverE
 
 	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误
 	upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
-	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
+	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, upstreamErrorDetailFromBody(h.cfg, responseBody))
 
 	// 使用默认的错误映射
 	status, message := mapGeminiUpstreamError(statusCode)

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1657,7 +1657,7 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 
 	// 记录原始上游状态码，以便 ops 错误日志捕获真实的上游错误
 	upstreamMsg := service.ExtractUpstreamErrorMessage(responseBody)
-	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, "")
+	service.SetOpsUpstreamError(c, statusCode, upstreamMsg, upstreamErrorDetailFromBody(h.cfg, responseBody))
 
 	// 使用默认的错误映射
 	status, errType, errMsg := h.mapUpstreamError(statusCode)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4931,11 +4931,6 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	if reqStream {
 		streamResult, err := s.handleStreamingResponse(ctx, resp, c, account, startTime, originalModel, reqModel, shouldMimicClaudeCode)
 		if err != nil {
-			if err.Error() == "have error in stream" {
-				return nil, &UpstreamFailoverError{
-					StatusCode: 403,
-				}
-			}
 			return nil, err
 		}
 		usage = streamResult.usage
@@ -7362,7 +7357,14 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 		}
 
 		if eventName == "error" {
-			return nil, dataLine, nil, errors.New("have error in stream")
+			body := []byte(strings.TrimSpace(dataLine))
+			if len(body) == 0 {
+				body = []byte(`{"type":"error","error":{"type":"upstream_error","message":"upstream stream returned an error event"}}`)
+			}
+			return nil, dataLine, nil, &UpstreamFailoverError{
+				StatusCode:   http.StatusForbidden,
+				ResponseBody: body,
+			}
 		}
 
 		if dataLine == "" {

--- a/backend/internal/service/gateway_streaming_test.go
+++ b/backend/internal/service/gateway_streaming_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -259,6 +260,35 @@ func TestHandleStreamingResponse_StreamReadErrorBeforeOutput_TriggersFailover(t 
 
 	// 客户端应收不到任何 stream_read_error 事件，由 handler 层根据 failover 结果再决定
 	require.NotContains(t, rec.Body.String(), "stream_read_error")
+}
+
+func TestHandleStreamingResponse_StreamErrorBeforeOutput_ReturnsFailoverWithBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := newMinimalGatewayService()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	upstreamBody := `{"type":"error","error":{"type":"permission_error","message":"model unavailable for this account"}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader("event: error\n" +
+			"data: " + upstreamBody + "\n\n")),
+	}
+
+	result, err := svc.handleStreamingResponse(context.Background(), resp, c, &Account{ID: 1}, time.Now(), "model", "model", false)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr))
+	require.Equal(t, http.StatusForbidden, failoverErr.StatusCode)
+	require.JSONEq(t, upstreamBody, string(failoverErr.ResponseBody))
+	require.Equal(t, "model unavailable for this account", ExtractUpstreamErrorMessage(failoverErr.ResponseBody))
+	require.Empty(t, rec.Body.String(), "未向客户端写出前应保留给 handler 层 failover/ops 处理")
 }
 
 // 上游已经发送过事件（c.Writer 已写过字节）后再发生读错误：


### PR DESCRIPTION
## Summary
- populate ops upstream error detail from failover response bodies when configured
- apply the same failover-exhausted detail capture to Anthropic, OpenAI, and Gemini handlers
- keep client-facing error mapping unchanged while preserving upstream diagnostics for the ops UI

## Tests
- go test ./internal/handler ./internal/service ./cmd/server