### PR TITLE
fix(deps): 升级 js-cookie 解决 GHSA-qjx8-664m-686j 阻塞 frontend-security CI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,5 +57,10 @@
     "vite-plugin-checker": "^0.9.1",
     "vitest": "^2.1.9",
     "vue-tsc": "^2.2.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-cookie": "3.0.7"
+    }
   }
 }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  js-cookie: 3.0.7
+
 importers:
 
   .:
@@ -2882,9 +2885,9 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
+  js-cookie@3.0.7:
+    resolution: {integrity: sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==}
+    engines: {node: '>=20'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -6365,7 +6368,7 @@ snapshots:
       '@types/js-cookie': 3.0.6
       dayjs: 1.11.20
       intersection-observer: 0.12.2
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       lodash: 4.18.1
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
@@ -7656,10 +7659,10 @@ snapshots:
       config-chain: 1.1.13
       editorconfig: 1.0.4
       glob: 10.5.0
-      js-cookie: 3.0.5
+      js-cookie: 3.0.7
       nopt: 7.2.1
 
-  js-cookie@3.0.5: {}
+  js-cookie@3.0.7: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## 背景
upstream/main 当前 `frontend-security` 会因 `pnpm audit --prod --audit-level=high` 报出 `js-cookie@3.0.5` 的高危漏洞 `GHSA-qjx8-664m-686j` 而阻塞。该问题影响多个 in-flight PR（如 #2656 #2658 #2672 #2674 #2681 #2683）。

本次选择 A 路径：`pnpm view js-cookie versions --json` 和 npm latest 均显示已发布 `3.0.7`，GitHub Advisory 的 Patched versions 字段也标明 `3.0.7`，属于 3.x patch 升级，无需做 4.x major bump，也不需要添加临时 audit 豁免。

## 改动
- 在 `frontend/package.json` 中通过 `pnpm.overrides` 将传递依赖 `js-cookie` 固定到 patched `3.0.7`。
- 更新 `frontend/pnpm-lock.yaml`，只将 lockfile 中的 `js-cookie` 解析从 `3.0.5` 提升到 `3.0.7`。
- 未修改业务代码、Vue 组件或 Go 代码；未添加 TODO。

## 测试
- `cd frontend && pnpm install` 通过。
- `cd frontend && pnpm audit --prod --audit-level=high` 不再列出 `GHSA-qjx8-664m-686j`；仍会列出既有 `xlsx` high advisories。
- `cd frontend && pnpm typecheck` 通过。
- `cd frontend && pnpm lint:check` 通过。
- `cd frontend && pnpm build` 通过。
- `cd frontend && pnpm audit --prod --audit-level=high --json > /tmp/audit.json || true && python3 ../tools/check_pnpm_audit_exceptions.py --audit /tmp/audit.json --exceptions ../.github/audit-exceptions.yml` 通过，输出 `Audit exceptions validated.`
- `cd frontend && pnpm test:run` 未通过：当前 upstream/main 前端业务单测存在 13 个失败点（如 `EmailVerifyView.spec.ts`、`ModelDistributionChart.spec.ts`、`GroupDistributionChart.spec.ts`、`AccountUsageCell.spec.ts`、`usePersistedPageSize.spec.ts` 等），这些失败与本 PR 仅锁定 `js-cookie` 的依赖变更无直接关联，本 PR 未修改相关业务代码。