### PR TITLE
fix(openai): 忽略客户端取消导致的并发误报

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1602,8 +1602,36 @@ func (h *OpenAIGatewayHandler) acquireImageGenerationSlot(c *gin.Context, stream
 
 // handleConcurrencyError handles concurrency-related errors with proper 429 response
 func (h *OpenAIGatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
+	if isOpenAIClientCanceledRequest(c, err) {
+		abortOpenAIClientCanceledRequest(c)
+		return
+	}
 	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
 		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+}
+
+const statusClientClosedRequest = 499
+
+func isOpenAIClientCanceledRequest(c *gin.Context, err error) bool {
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if c == nil || c.Request == nil {
+		return false
+	}
+	reqErr := c.Request.Context().Err()
+	return errors.Is(reqErr, context.Canceled) || errors.Is(reqErr, context.DeadlineExceeded)
+}
+
+func abortOpenAIClientCanceledRequest(c *gin.Context) {
+	if c == nil {
+		return
+	}
+	c.Set(service.OpsSkipPassthroughKey, true)
+	if c.Writer != nil && !c.Writer.Written() {
+		c.Status(statusClientClosedRequest)
+	}
+	c.Abort()
 }
 
 func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"go.uber.org/zap"
 )
 
 func TestOpenAIHandleStreamingAwareError_JSONEscaping(t *testing.T) {
@@ -130,6 +131,38 @@ func TestOpenAIHandleStreamingAwareError_NonStreaming(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "upstream_error", errorObj["type"])
 	assert.Equal(t, "test error", errorObj["message"])
+}
+
+func TestOpenAIAcquireResponsesUserSlot_ClientCanceledDoesNotReturnRateLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c.Request = httptest.NewRequest(http.MethodPost, "/responses", nil).WithContext(ctx)
+
+	cache := &concurrencyCacheMock{
+		acquireUserSlotFn: func(ctx context.Context, userID int64, maxConcurrency int, requestID string) (bool, error) {
+			return false, ctx.Err()
+		},
+	}
+	h := &OpenAIGatewayHandler{
+		concurrencyHelper: NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatComment, time.Millisecond),
+	}
+
+	streamStarted := false
+	release, acquired := h.acquireResponsesUserSlot(c, 17, 5, true, &streamStarted, zap.NewNop())
+
+	require.False(t, acquired)
+	require.Nil(t, release)
+	require.Equal(t, statusClientClosedRequest, c.Writer.Status())
+	require.False(t, c.Writer.Written())
+	require.Empty(t, w.Body.String())
+	v, ok := c.Get(service.OpsSkipPassthroughKey)
+	require.True(t, ok)
+	skipOpsLog, ok := v.(bool)
+	require.True(t, ok)
+	require.True(t, skipOpsLog)
 }
 
 func TestReadRequestBodyWithPrealloc(t *testing.T) {


### PR DESCRIPTION
## 事故原因

- 线上错误 #37994 发生在 `/responses` 用户并发槽获取阶段；同一 request_id 的应用日志是 `openai.user_slot_acquire_failed error="context canceled"`，OpenResty 访问日志返回 499。
- 该请求没有进入上游账号选择，也没有 `account_id`、`upstream_status_code` 或上游错误信息；用户并发配置为 5，并没有真实超过并发限制。
- 旧逻辑把 `AcquireUserSlot` 返回的错误统一交给并发错误处理，导致客户端主动取消/断开被误包装成 429 `Concurrency limit exceeded for user`，并进入 ops 错误日志。

## 修复范围

- 仅收窄修改 OpenAI gateway 的并发错误处理：识别 `context.Canceled`、请求上下文已取消或超时的场景。
- 对已取消的客户端请求返回 499，且设置现有 `OpsSkipPassthroughKey`，让这类客户端取消不再进入 ops 错误日志。
- 保留真实并发超限仍返回 429 的行为；不改并发计数、账号调度、上游转发、429 语义或其他日志链路。
- 增加 `/responses` 用户并发槽获取被取消时不返回 429 的回归测试。

## 验证

- `go test ./internal/handler ./internal/service`
- `golangci-lint v2.9.0 run --timeout=30m`