### PR TITLE
fix(db-pool): 强制连接生命期下限，缓解 lib/pq watchCancel 协程泄漏

### DIFF
--- a/backend/internal/repository/db_pool.go
+++ b/backend/internal/repository/db_pool.go
@@ -1,10 +1,24 @@
+// Package repository contains persistence infrastructure helpers.
+//
+// DB pool lifetimes are clamped here because lib/pq starts watchCancel
+// goroutines for context-aware queries. If a cloud proxy silently drops idle
+// TCP without RST/FIN, those goroutines can block in Read until database/sql
+// retires the connection. This is a short-term mitigation; the long-term
+// follow-up is migrating PostgreSQL access to jackc/pgx/v5/stdlib.
 package repository
 
 import (
 	"database/sql"
+	"log/slog"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+const (
+	defaultConnMaxLifetime = 30 * time.Minute
+	defaultConnMaxIdleTime = 5 * time.Minute
+	maxConfiguredConnAge   = 24 * time.Hour
 )
 
 type dbPoolSettings struct {
@@ -14,19 +28,41 @@ type dbPoolSettings struct {
 	ConnMaxIdleTime time.Duration
 }
 
-func buildDBPoolSettings(cfg *config.Config) dbPoolSettings {
+func clampDBPoolSettings(cfg *config.Config) dbPoolSettings {
 	return dbPoolSettings{
 		MaxOpenConns:    cfg.Database.MaxOpenConns,
 		MaxIdleConns:    cfg.Database.MaxIdleConns,
-		ConnMaxLifetime: time.Duration(cfg.Database.ConnMaxLifetimeMinutes) * time.Minute,
-		ConnMaxIdleTime: time.Duration(cfg.Database.ConnMaxIdleTimeMinutes) * time.Minute,
+		ConnMaxLifetime: clampDBPoolDuration("database.conn_max_lifetime_minutes", cfg.Database.ConnMaxLifetimeMinutes, defaultConnMaxLifetime),
+		ConnMaxIdleTime: clampDBPoolDuration("database.conn_max_idle_time_minutes", cfg.Database.ConnMaxIdleTimeMinutes, defaultConnMaxIdleTime),
 	}
 }
 
+func clampDBPoolDuration(key string, minutes int, fallback time.Duration) time.Duration {
+	if minutes <= 0 || minutes > int(maxConfiguredConnAge/time.Minute) {
+		slog.Warn("database connection pool duration clamped",
+			"key", key,
+			"before", minutes,
+			"after", int(fallback/time.Minute),
+		)
+		return fallback
+	}
+
+	return time.Duration(minutes) * time.Minute
+}
+
 func applyDBPoolSettings(db *sql.DB, cfg *config.Config) {
-	settings := buildDBPoolSettings(cfg)
+	settings := clampDBPoolSettings(cfg)
 	db.SetMaxOpenConns(settings.MaxOpenConns)
 	db.SetMaxIdleConns(settings.MaxIdleConns)
 	db.SetConnMaxLifetime(settings.ConnMaxLifetime)
 	db.SetConnMaxIdleTime(settings.ConnMaxIdleTime)
+
+	slog.Info("database connection pool configured",
+		slog.Group("effective",
+			slog.Int("max_open", settings.MaxOpenConns),
+			slog.Int("max_idle", settings.MaxIdleConns),
+			slog.Duration("max_lifetime", settings.ConnMaxLifetime),
+			slog.Duration("max_idle_time", settings.ConnMaxIdleTime),
+		),
+	)
 }

--- a/backend/internal/repository/db_pool_test.go
+++ b/backend/internal/repository/db_pool_test.go
@@ -11,21 +11,62 @@ import (
 	_ "github.com/lib/pq"
 )
 
-func TestBuildDBPoolSettings(t *testing.T) {
-	cfg := &config.Config{
-		Database: config.DatabaseConfig{
-			MaxOpenConns:           50,
-			MaxIdleConns:           10,
-			ConnMaxLifetimeMinutes: 30,
-			ConnMaxIdleTimeMinutes: 5,
+func TestClampDBPoolSettings(t *testing.T) {
+	tests := []struct {
+		name                string
+		connMaxLifetime     int
+		connMaxIdleTime     int
+		wantMaxLifetime     time.Duration
+		wantConnMaxIdleTime time.Duration
+	}{
+		{
+			name:                "zero values fall back to safe defaults",
+			connMaxLifetime:     0,
+			connMaxIdleTime:     0,
+			wantMaxLifetime:     30 * time.Minute,
+			wantConnMaxIdleTime: 5 * time.Minute,
+		},
+		{
+			name:                "negative values fall back to safe defaults",
+			connMaxLifetime:     -1,
+			connMaxIdleTime:     -5,
+			wantMaxLifetime:     30 * time.Minute,
+			wantConnMaxIdleTime: 5 * time.Minute,
+		},
+		{
+			name:                "reasonable values pass through",
+			connMaxLifetime:     15,
+			connMaxIdleTime:     3,
+			wantMaxLifetime:     15 * time.Minute,
+			wantConnMaxIdleTime: 3 * time.Minute,
+		},
+		{
+			name:                "values over twenty four hours fall back to safe defaults",
+			connMaxLifetime:     24*60 + 1,
+			connMaxIdleTime:     24*60 + 1,
+			wantMaxLifetime:     30 * time.Minute,
+			wantConnMaxIdleTime: 5 * time.Minute,
 		},
 	}
 
-	settings := buildDBPoolSettings(cfg)
-	require.Equal(t, 50, settings.MaxOpenConns)
-	require.Equal(t, 10, settings.MaxIdleConns)
-	require.Equal(t, 30*time.Minute, settings.ConnMaxLifetime)
-	require.Equal(t, 5*time.Minute, settings.ConnMaxIdleTime)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Database: config.DatabaseConfig{
+					MaxOpenConns:           50,
+					MaxIdleConns:           10,
+					ConnMaxLifetimeMinutes: tt.connMaxLifetime,
+					ConnMaxIdleTimeMinutes: tt.connMaxIdleTime,
+				},
+			}
+
+			settings := clampDBPoolSettings(cfg)
+			require.Equal(t, 50, settings.MaxOpenConns)
+			require.Equal(t, 10, settings.MaxIdleConns)
+			require.Equal(t, tt.wantMaxLifetime, settings.ConnMaxLifetime)
+			require.Equal(t, tt.wantConnMaxIdleTime, settings.ConnMaxIdleTime)
+		})
+	}
 }
 
 func TestApplyDBPoolSettings(t *testing.T) {


### PR DESCRIPTION
## 背景

Issue #2708 报告了 lib/pq 在带 context 查询下启动的 watchCancel goroutine 泄漏问题：当数据库前方的云代理静默断开空闲 TCP，且没有发送 RST/FIN 时，watchCancel 可能长期阻塞在 Read()，连接也无法自然释放。

项目默认的 `conn_max_lifetime_minutes = 30`、`conn_max_idle_time_minutes = 5` 本身是健康的，但当前 validation 允许用户显式配置 0，而 `database/sql` 会把 `time.Duration(0)` 解释为永不过期，导致死连接可以一直留在池里，放大 lib/pq watchCancel 的泄漏诱因。

本 PR 是短期 mitigation：通过连接池生效层的防御式钳制降低泄漏风险。长期仍建议另起 issue / PR 跟踪迁移到 `jackc/pgx/v5/stdlib`，不要把本 PR 视作对 lib/pq dead-TCP Read 阻塞的根治方案。

## 改动

- 在 `applyDBPoolSettings` 入口拆出 `clampDBPoolSettings`，对 `ConnMaxLifetime` / `ConnMaxIdleTime` 做下限和上限保护。
- 当配置值 `<= 0` 或 `> 24h` 时，分别回落到安全默认值 `30min` / `5min`，保持已有配置文件里写 0 的用户仍可平滑启动。
- 钳制发生时输出 `slog.Warn`，包含 `key` / `before` / `after`，便于定位误配置。
- 连接池设置应用后输出 `slog.Info`，结构化展示 effective `max_open` / `max_idle` / `max_lifetime` / `max_idle_time`。
- 在 `db_pool.go` 文件头记录 lib/pq watchCancel、云代理静默断连背景，以及长期迁 pgx 的 follow-up 方向。
- 扩展 `db_pool_test.go` 覆盖 0、负数、合理值、超过 24h 四类配置。

## 测试

- `cd backend && go test -tags=unit ./internal/repository/...`
- `cd backend && go test -tags=unit ./...`
- `cd backend && golangci-lint run ./...`

Fixes #2708