### PR TITLE
fix(notification): 邮件未配置时跳过订阅到期提醒，避免日志刷错

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -263,7 +263,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	opsScheduledReportService := service.ProvideOpsScheduledReportService(opsService, userService, emailService, redisClient, configConfig)
 	tokenRefreshService := service.ProvideTokenRefreshService(accountRepository, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, compositeTokenCacheInvalidator, schedulerCache, configConfig, tempUnschedCache, privacyClientFactory, proxyRepository, oAuthRefreshAPI, openAIGatewayService)
 	accountExpiryService := service.ProvideAccountExpiryService(accountRepository)
-	subscriptionExpiryService := service.ProvideSubscriptionExpiryService(userSubscriptionRepository, settingRepository, notificationEmailService)
+	subscriptionExpiryService := service.ProvideSubscriptionExpiryService(userSubscriptionRepository, settingRepository, emailService, notificationEmailService)
 	scheduledTestRunnerService := service.ProvideScheduledTestRunnerService(scheduledTestPlanRepository, scheduledTestService, accountTestService, rateLimitService, configConfig)
 	paymentOrderExpiryService := service.ProvidePaymentOrderExpiryService(paymentService)
 	channelMonitorRunner := service.ProvideChannelMonitorRunner(channelMonitorService, settingService)

--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"crypto/tls"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -109,6 +110,20 @@ func NewEmailService(settingRepo SettingRepository, cache EmailCache) *EmailServ
 
 func (s *EmailService) SetNotificationEmailService(notificationEmailService *NotificationEmailService) {
 	s.notificationEmailService = notificationEmailService
+}
+
+func (s *EmailService) IsConfigured(ctx context.Context) bool {
+	if s == nil || s.settingRepo == nil {
+		return false
+	}
+	_, err := s.GetSMTPConfig(ctx)
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, ErrEmailNotConfigured) {
+		return false
+	}
+	return true
 }
 
 func firstEmailLocale(locales []string) string {

--- a/backend/internal/service/email_service_test.go
+++ b/backend/internal/service/email_service_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type emailServiceSettingRepoStub struct {
+	values map[string]string
+	err    error
+}
+
+func (s *emailServiceSettingRepoStub) Get(context.Context, string) (*Setting, error) {
+	return nil, ErrSettingNotFound
+}
+
+func (s *emailServiceSettingRepoStub) GetValue(context.Context, string) (string, error) {
+	return "", ErrSettingNotFound
+}
+
+func (s *emailServiceSettingRepoStub) Set(context.Context, string, string) error {
+	return nil
+}
+
+func (s *emailServiceSettingRepoStub) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	result := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := s.values[key]; ok {
+			result[key] = value
+		}
+	}
+	return result, nil
+}
+
+func (s *emailServiceSettingRepoStub) SetMultiple(context.Context, map[string]string) error {
+	return nil
+}
+
+func (s *emailServiceSettingRepoStub) GetAll(context.Context) (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *emailServiceSettingRepoStub) Delete(context.Context, string) error {
+	return nil
+}
+
+func TestEmailService_IsConfigured(t *testing.T) {
+	t.Run("returns false when smtp host is missing", func(t *testing.T) {
+		svc := NewEmailService(&emailServiceSettingRepoStub{values: map[string]string{}}, nil)
+
+		require.False(t, svc.IsConfigured(context.Background()))
+	})
+
+	t.Run("returns true when smtp host is configured", func(t *testing.T) {
+		svc := NewEmailService(&emailServiceSettingRepoStub{
+			values: map[string]string{SettingKeySMTPHost: "smtp.example.com"},
+		}, nil)
+
+		require.True(t, svc.IsConfigured(context.Background()))
+	})
+
+	t.Run("returns true for non configuration errors", func(t *testing.T) {
+		svc := NewEmailService(&emailServiceSettingRepoStub{err: errors.New("db down")}, nil)
+
+		require.True(t, svc.IsConfigured(context.Background()))
+	})
+}

--- a/backend/internal/service/subscription_expiry_service.go
+++ b/backend/internal/service/subscription_expiry_service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"log/slog"
 	"strconv"
 	"sync"
 	"time"
@@ -14,14 +15,19 @@ import (
 
 // SubscriptionExpiryService periodically updates expired subscription status.
 type SubscriptionExpiryService struct {
-	userSubRepo              UserSubscriptionRepository
-	settingRepo              SettingRepository
-	notificationEmailService *NotificationEmailService
-	interval                 time.Duration
-	stopCh                   chan struct{}
-	stopOnce                 sync.Once
-	wg                       sync.WaitGroup
+	userSubRepo               UserSubscriptionRepository
+	settingRepo               SettingRepository
+	emailService              *EmailService
+	notificationEmailService  *NotificationEmailService
+	interval                  time.Duration
+	stopCh                    chan struct{}
+	stopOnce                  sync.Once
+	wg                        sync.WaitGroup
+	emailNotConfiguredLogMu   sync.Mutex
+	lastEmailNotConfiguredLog time.Time
 }
+
+const subscriptionExpiryEmailNotConfiguredLogInterval = time.Hour
 
 func NewSubscriptionExpiryService(userSubRepo UserSubscriptionRepository, interval time.Duration) *SubscriptionExpiryService {
 	return &SubscriptionExpiryService{
@@ -33,6 +39,10 @@ func NewSubscriptionExpiryService(userSubRepo UserSubscriptionRepository, interv
 
 func (s *SubscriptionExpiryService) SetSettingRepository(settingRepo SettingRepository) {
 	s.settingRepo = settingRepo
+}
+
+func (s *SubscriptionExpiryService) SetEmailService(emailService *EmailService) {
+	s.emailService = emailService
 }
 
 func (s *SubscriptionExpiryService) SetNotificationEmailService(notificationEmailService *NotificationEmailService) {
@@ -75,6 +85,10 @@ func (s *SubscriptionExpiryService) runOnce() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	if !s.emailConfiguredForReminderPass(ctx, time.Now()) {
+		return
+	}
+
 	updated, err := s.userSubRepo.BatchUpdateExpiredStatus(ctx)
 	if err != nil {
 		log.Printf("[SubscriptionExpiry] Update expired subscriptions failed: %v", err)
@@ -84,6 +98,28 @@ func (s *SubscriptionExpiryService) runOnce() {
 		log.Printf("[SubscriptionExpiry] Updated %d expired subscriptions", updated)
 	}
 	s.sendExpiryReminders(ctx)
+}
+
+func (s *SubscriptionExpiryService) emailConfiguredForReminderPass(ctx context.Context, now time.Time) bool {
+	if s == nil || s.emailService == nil {
+		return true
+	}
+	if s.emailService.IsConfigured(ctx) {
+		return true
+	}
+	s.logEmailNotConfiguredSkip(now)
+	return false
+}
+
+func (s *SubscriptionExpiryService) logEmailNotConfiguredSkip(now time.Time) {
+	s.emailNotConfiguredLogMu.Lock()
+	defer s.emailNotConfiguredLogMu.Unlock()
+
+	if !s.lastEmailNotConfiguredLog.IsZero() && now.Sub(s.lastEmailNotConfiguredLog) < subscriptionExpiryEmailNotConfiguredLogInterval {
+		return
+	}
+	s.lastEmailNotConfiguredLog = now
+	slog.Info("[SubscriptionExpiry] email service not configured, skipping reminder pass")
 }
 
 func (s *SubscriptionExpiryService) sendExpiryReminders(ctx context.Context) {
@@ -145,6 +181,9 @@ func (s *SubscriptionExpiryService) sendExpiryReminderIfDue(ctx context.Context,
 			"days_remaining":     strconv.Itoa(daysRemaining),
 		},
 	}); err != nil {
+		if errors.Is(err, ErrEmailNotConfigured) {
+			return
+		}
 		log.Printf("[SubscriptionExpiry] Send expiry reminder failed: subscription=%d user=%d err=%v", sub.ID, sub.UserID, err)
 	}
 }

--- a/backend/internal/service/subscription_expiry_service_test.go
+++ b/backend/internal/service/subscription_expiry_service_test.go
@@ -1,8 +1,13 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log"
+	"log/slog"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,7 +16,8 @@ import (
 )
 
 type subscriptionExpiryRepoStub struct {
-	listCalls int
+	listCalls        int64
+	batchUpdateCalls int64
 }
 
 func (r *subscriptionExpiryRepoStub) Create(context.Context, *UserSubscription) error {
@@ -51,7 +57,7 @@ func (r *subscriptionExpiryRepoStub) ListByGroupID(context.Context, int64, pagin
 }
 
 func (r *subscriptionExpiryRepoStub) List(context.Context, pagination.PaginationParams, *int64, *int64, string, string, string, string) ([]UserSubscription, *pagination.PaginationResult, error) {
-	r.listCalls++
+	atomic.AddInt64(&r.listCalls, 1)
 	return nil, &pagination.PaginationResult{Page: 1, Pages: 1}, nil
 }
 
@@ -92,12 +98,14 @@ func (r *subscriptionExpiryRepoStub) IncrementUsage(context.Context, int64, floa
 }
 
 func (r *subscriptionExpiryRepoStub) BatchUpdateExpiredStatus(context.Context) (int64, error) {
+	atomic.AddInt64(&r.batchUpdateCalls, 1)
 	return 0, nil
 }
 
 type subscriptionExpirySettingRepoStub struct {
-	values map[string]string
-	err    error
+	values           map[string]string
+	err              error
+	getMultipleCalls int64
 }
 
 func (r *subscriptionExpirySettingRepoStub) Get(context.Context, string) (*Setting, error) {
@@ -119,8 +127,18 @@ func (r *subscriptionExpirySettingRepoStub) Set(context.Context, string, string)
 	return nil
 }
 
-func (r *subscriptionExpirySettingRepoStub) GetMultiple(context.Context, []string) (map[string]string, error) {
-	return nil, nil
+func (r *subscriptionExpirySettingRepoStub) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
+	atomic.AddInt64(&r.getMultipleCalls, 1)
+	if r.err != nil {
+		return nil, r.err
+	}
+	result := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := r.values[key]; ok {
+			result[key] = value
+		}
+	}
+	return result, nil
 }
 
 func (r *subscriptionExpirySettingRepoStub) SetMultiple(context.Context, map[string]string) error {
@@ -153,7 +171,7 @@ func TestSubscriptionExpiryService_ExpiryReminderDisabledSkipsSubscriptionScan(t
 
 	svc.sendExpiryReminders(context.Background())
 
-	require.Zero(t, repo.listCalls)
+	require.Zero(t, atomic.LoadInt64(&repo.listCalls))
 }
 
 func TestSubscriptionExpiryService_ExpiryReminderSettingReadErrorFailsClosed(t *testing.T) {
@@ -161,4 +179,78 @@ func TestSubscriptionExpiryService_ExpiryReminderSettingReadErrorFailsClosed(t *
 	svc.SetSettingRepository(&subscriptionExpirySettingRepoStub{err: errors.New("db down")})
 
 	require.False(t, svc.expiryReminderEnabled(context.Background()))
+}
+
+func TestSubscriptionExpiryService_EmailNotConfiguredSkipsRunWithoutRepoCalls(t *testing.T) {
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	repo := &subscriptionExpiryRepoStub{}
+	settingRepo := &subscriptionExpirySettingRepoStub{values: map[string]string{}}
+	emailService := NewEmailService(settingRepo, nil)
+	svc := NewSubscriptionExpiryService(repo, time.Millisecond)
+	svc.SetSettingRepository(settingRepo)
+	svc.SetEmailService(emailService)
+	svc.SetNotificationEmailService(NewNotificationEmailService(settingRepo, emailService))
+
+	svc.Start()
+	t.Cleanup(svc.Stop)
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt64(&settingRepo.getMultipleCalls) >= 2
+	}, 200*time.Millisecond, time.Millisecond)
+	svc.Stop()
+
+	require.Zero(t, atomic.LoadInt64(&repo.batchUpdateCalls))
+	require.Zero(t, atomic.LoadInt64(&repo.listCalls))
+	require.Equal(t, 1, strings.Count(logs.String(), "[SubscriptionExpiry] email service not configured, skipping reminder pass"))
+}
+
+func TestSubscriptionExpiryService_EmailConfiguredRunsExistingPass(t *testing.T) {
+	repo := &subscriptionExpiryRepoStub{}
+	settingRepo := &subscriptionExpirySettingRepoStub{
+		values: map[string]string{
+			SettingKeySMTPHost: "smtp.example.com",
+		},
+	}
+	emailService := NewEmailService(settingRepo, nil)
+	svc := NewSubscriptionExpiryService(repo, time.Minute)
+	svc.SetSettingRepository(settingRepo)
+	svc.SetEmailService(emailService)
+	svc.SetNotificationEmailService(NewNotificationEmailService(settingRepo, emailService))
+
+	svc.runOnce()
+
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.batchUpdateCalls))
+	require.Equal(t, int64(1), atomic.LoadInt64(&repo.listCalls))
+}
+
+func TestSubscriptionExpiryService_SendReminderIgnoresEmailNotConfigured(t *testing.T) {
+	var logs bytes.Buffer
+	originalWriter := log.Writer()
+	originalFlags := log.Flags()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(originalWriter)
+		log.SetFlags(originalFlags)
+	})
+
+	settingRepo := &subscriptionExpirySettingRepoStub{values: map[string]string{}}
+	emailService := NewEmailService(settingRepo, nil)
+	svc := NewSubscriptionExpiryService(nil, time.Minute)
+	svc.SetNotificationEmailService(NewNotificationEmailService(settingRepo, emailService))
+
+	svc.sendExpiryReminderIfDue(context.Background(), &UserSubscription{
+		ID:        1,
+		UserID:    2,
+		ExpiresAt: time.Now().Add(7*24*time.Hour + time.Hour),
+		User:      &User{ID: 2, Email: "user@example.com", Username: "user"},
+		Group:     &Group{ID: 3, Name: "Pro"},
+	})
+
+	require.NotContains(t, logs.String(), "[SubscriptionExpiry] Send expiry reminder failed")
 }

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -153,9 +153,10 @@ func ProvideAccountExpiryService(accountRepo AccountRepository) *AccountExpirySe
 }
 
 // ProvideSubscriptionExpiryService creates and starts SubscriptionExpiryService.
-func ProvideSubscriptionExpiryService(userSubRepo UserSubscriptionRepository, settingRepo SettingRepository, notificationEmailService *NotificationEmailService) *SubscriptionExpiryService {
+func ProvideSubscriptionExpiryService(userSubRepo UserSubscriptionRepository, settingRepo SettingRepository, emailService *EmailService, notificationEmailService *NotificationEmailService) *SubscriptionExpiryService {
 	svc := NewSubscriptionExpiryService(userSubRepo, time.Minute)
 	svc.SetSettingRepository(settingRepo)
+	svc.SetEmailService(emailService)
 	svc.SetNotificationEmailService(notificationEmailService)
 	svc.Start()
 	return svc


### PR DESCRIPTION
## 背景

未配置 SMTP 时，订阅到期提醒定时任务每轮仍会扫描订阅并尝试发送邮件，最终把 ErrEmailNotConfigured 作为错误日志持续输出，导致实例日志被反复刷屏。

## 改动

- 新增 EmailService.IsConfigured(ctx)，对 ErrEmailNotConfigured 返回 false，其它错误继续走原路径。
- SubscriptionExpiryService 每轮入口先检查邮件配置，未配置时整轮跳过，并将提示日志限制为 1 小时最多一次。
- sendExpiryReminderIfDue 对被包装的 ErrEmailNotConfigured 做静默兜底，其它发送错误仍按原逻辑记录。
- 补充订阅到期提醒与 EmailService 配置判定单测。

## 测试

- cd backend && go test -tags=unit ./...
- cd backend && go test -tags=integration ./...
- cd backend && golangci-lint run ./...

Fixes #2695