### PR TITLE
Display the actual usage within the current 5h/7d quota window rather than on the past 5h/7d

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -528,14 +528,14 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-5*time.Hour)); err == nil {
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStart(account.Extra, "5h", now)); err == nil {
 		if usage.FiveHour == nil {
 			usage.FiveHour = &UsageProgress{Utilization: 0}
 		}
 		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-7*24*time.Hour)); err == nil {
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStart(account.Extra, "7d", now)); err == nil {
 		if usage.SevenDay == nil {
 			usage.SevenDay = &UsageProgress{Utilization: 0}
 		}
@@ -1118,6 +1118,43 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	return progress
+}
+
+func codexWindowStart(extra map[string]any, window string, now time.Time) time.Time {
+	var (
+		resetAtKey      string
+		windowMinuteKey string
+		fallback        time.Time
+	)
+
+	switch window {
+	case "5h":
+		resetAtKey = "codex_5h_reset_at"
+		windowMinuteKey = "codex_5h_window_minutes"
+		fallback = now.Add(-5 * time.Hour)
+	case "7d":
+		resetAtKey = "codex_7d_reset_at"
+		windowMinuteKey = "codex_7d_window_minutes"
+		fallback = now.Add(-7 * 24 * time.Hour)
+	default:
+		return now
+	}
+
+	resetAtRaw, hasResetAt := extra[resetAtKey]
+	windowMinutes := parseExtraInt(extra[windowMinuteKey])
+	if !hasResetAt || windowMinutes <= 0 {
+		return fallback
+	}
+
+	resetAt, err := parseTime(fmt.Sprint(resetAtRaw))
+	if err != nil {
+		return fallback
+	}
+	if !now.Before(resetAt) {
+		return fallback
+	}
+
+	return resetAt.Add(-time.Duration(windowMinutes) * time.Minute)
 }
 
 func (s *AccountUsageService) GetAccountUsageStats(ctx context.Context, accountID int64, startTime, endTime time.Time) (*usagestats.AccountUsageStatsResponse, error) {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -97,6 +97,11 @@ type windowStatsCache struct {
 	timestamp time.Time
 }
 
+type windowStatsCacheKey struct {
+	accountID     int64
+	startUnixNano int64
+}
+
 // antigravityUsageCache 缓存 Antigravity 额度数据
 type antigravityUsageCache struct {
 	usageInfo *UsageInfo
@@ -116,7 +121,7 @@ const (
 // UsageCache 封装账户使用量相关的缓存
 type UsageCache struct {
 	apiCache          sync.Map           // accountID -> *apiUsageCache
-	windowStatsCache  sync.Map           // accountID -> *windowStatsCache
+	windowStatsCache  sync.Map           // windowStatsCacheKey -> *windowStatsCache
 	antigravityCache  sync.Map           // accountID -> *antigravityUsageCache
 	apiFlight         singleflight.Group // 防止同一账号的并发请求击穿缓存（Anthropic）
 	antigravityFlight singleflight.Group // 防止同一 Antigravity 账号的并发请求击穿缓存
@@ -928,44 +933,65 @@ func (s *AccountUsageService) addWindowStats(ctx context.Context, account *Accou
 		return
 	}
 
-	// 检查窗口统计缓存（1 分钟）
-	var windowStats *WindowStats
-	if cached, ok := s.cache.windowStatsCache.Load(account.ID); ok {
-		if cache, ok := cached.(*windowStatsCache); ok && time.Since(cache.timestamp) < windowStatsCacheTTL {
-			windowStats = cache.stats
-		}
-	}
-
-	// 如果没有缓存，从数据库查询
-	if windowStats == nil {
-		// 使用统一的窗口开始时间计算逻辑（考虑窗口过期情况）
-		startTime := account.GetCurrentWindowStartTime()
-
-		stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, startTime)
-		if err != nil {
-			log.Printf("Failed to get window stats for account %d: %v", account.ID, err)
-			return
-		}
-
-		windowStats = &WindowStats{
-			Requests:     stats.Requests,
-			Tokens:       stats.Tokens,
-			Cost:         stats.Cost,
-			StandardCost: stats.StandardCost,
-			UserCost:     stats.UserCost,
-		}
-
-		// 缓存窗口统计（1 分钟）
-		s.cache.windowStatsCache.Store(account.ID, &windowStatsCache{
-			stats:     windowStats,
-			timestamp: time.Now(),
-		})
-	}
-
 	// 为 FiveHour 添加 WindowStats（5h 窗口统计）
 	if usage.FiveHour != nil {
-		usage.FiveHour.WindowStats = windowStats
+		if windowStats, err := s.accountWindowStats(ctx, account.ID, account.GetCurrentWindowStartTime()); err == nil {
+			usage.FiveHour.WindowStats = windowStats
+		} else {
+			log.Printf("Failed to get 5h window stats for account %d: %v", account.ID, err)
+		}
 	}
+
+	if usage.SevenDay != nil {
+		if startTime, ok := usageWindowStartFromReset(usage.SevenDay, 7*24*time.Hour); ok {
+			if windowStats, err := s.accountWindowStats(ctx, account.ID, startTime); err == nil {
+				usage.SevenDay.WindowStats = windowStats
+			} else {
+				log.Printf("Failed to get 7d window stats for account %d: %v", account.ID, err)
+			}
+		}
+	}
+
+	if usage.SevenDaySonnet != nil {
+		if startTime, ok := usageWindowStartFromReset(usage.SevenDaySonnet, 7*24*time.Hour); ok {
+			if windowStats, err := s.accountWindowStats(ctx, account.ID, startTime); err == nil {
+				usage.SevenDaySonnet.WindowStats = windowStats
+			} else {
+				log.Printf("Failed to get 7d Sonnet window stats for account %d: %v", account.ID, err)
+			}
+		}
+	}
+}
+
+func (s *AccountUsageService) accountWindowStats(ctx context.Context, accountID int64, startTime time.Time) (*WindowStats, error) {
+	key := windowStatsCacheKey{accountID: accountID, startUnixNano: startTime.UnixNano()}
+	if cached, ok := s.cache.windowStatsCache.Load(key); ok {
+		if cache, ok := cached.(*windowStatsCache); ok && time.Since(cache.timestamp) < windowStatsCacheTTL {
+			return cache.stats, nil
+		}
+	}
+
+	stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, accountID, startTime)
+	if err != nil {
+		return nil, err
+	}
+
+	windowStats := windowStatsFromAccountStats(stats)
+	s.cache.windowStatsCache.Store(key, &windowStatsCache{
+		stats:     windowStats,
+		timestamp: time.Now(),
+	})
+	return windowStats, nil
+}
+
+func usageWindowStartFromReset(progress *UsageProgress, duration time.Duration) (time.Time, bool) {
+	if progress == nil || progress.ResetsAt == nil || duration <= 0 {
+		return time.Time{}, false
+	}
+	if !progress.ResetsAt.After(time.Now()) {
+		return time.Time{}, false
+	}
+	return progress.ResetsAt.Add(-duration), true
 }
 
 // GetTodayStats 获取账号今日统计

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -5,7 +5,23 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 )
+
+type accountUsageWindowStatsRepo struct {
+	UsageLogRepository
+	statsByStart map[int64]*usagestats.AccountStats
+	calls        []time.Time
+}
+
+func (r *accountUsageWindowStatsRepo) GetAccountWindowStats(_ context.Context, _ int64, startTime time.Time) (*usagestats.AccountStats, error) {
+	r.calls = append(r.calls, startTime)
+	if stats, ok := r.statsByStart[startTime.UnixNano()]; ok {
+		return stats, nil
+	}
+	return &usagestats.AccountStats{}, nil
+}
 
 type accountUsageCodexProbeRepo struct {
 	stubOpenAIAccountRepo
@@ -63,6 +79,50 @@ func TestShouldRefreshOpenAICodexSnapshot(t *testing.T) {
 		},
 	}, usage, now) {
 		t.Fatal("expected stale ws snapshot to trigger refresh")
+	}
+}
+
+func TestAccountUsageService_AddWindowStatsAttachesAnthropicSevenDay(t *testing.T) {
+	now := time.Now().UTC()
+	fiveHourStart := now.Add(-2 * time.Hour).Truncate(time.Second)
+	fiveHourEnd := now.Add(3 * time.Hour).Truncate(time.Second)
+	sevenDayReset := now.Add(48 * time.Hour).Truncate(time.Second)
+	sevenDayStart := sevenDayReset.Add(-7 * 24 * time.Hour)
+
+	repo := &accountUsageWindowStatsRepo{statsByStart: map[int64]*usagestats.AccountStats{
+		fiveHourStart.UnixNano(): {
+			Requests:     5,
+			Tokens:       50,
+			StandardCost: 0.5,
+		},
+		sevenDayStart.UnixNano(): {
+			Requests:     70,
+			Tokens:       700,
+			StandardCost: 7,
+		},
+	}}
+	svc := &AccountUsageService{usageLogRepo: repo, cache: NewUsageCache()}
+	usage := &UsageInfo{
+		FiveHour: &UsageProgress{Utilization: 10},
+		SevenDay: &UsageProgress{Utilization: 20, ResetsAt: &sevenDayReset},
+	}
+	account := &Account{ID: 42, SessionWindowStart: &fiveHourStart, SessionWindowEnd: &fiveHourEnd}
+
+	svc.addWindowStats(context.Background(), account, usage)
+
+	if usage.FiveHour.WindowStats == nil || usage.FiveHour.WindowStats.Requests != 5 {
+		t.Fatalf("FiveHour.WindowStats = %#v, want requests=5", usage.FiveHour.WindowStats)
+	}
+	if usage.SevenDay.WindowStats == nil || usage.SevenDay.WindowStats.Requests != 70 {
+		t.Fatalf("SevenDay.WindowStats = %#v, want requests=70", usage.SevenDay.WindowStats)
+	}
+	if len(repo.calls) != 2 {
+		t.Fatalf("GetAccountWindowStats calls = %d, want 2", len(repo.calls))
+	}
+
+	svc.addWindowStats(context.Background(), account, usage)
+	if len(repo.calls) != 2 {
+		t.Fatalf("GetAccountWindowStats calls after cache hit = %d, want 2", len(repo.calls))
 	}
 }
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -207,3 +207,53 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 	})
 }
+
+func TestCodexWindowStart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)
+
+	t.Run("uses reset minus 5h window length", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_5h_reset_at":       "2026-03-16T15:30:00Z",
+			"codex_5h_window_minutes": 300,
+		}
+		got := codexWindowStart(extra, "5h", now)
+		want := time.Date(2026, 3, 16, 10, 30, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("uses reset minus 7d window length", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_7d_reset_at":       "2026-03-20T00:00:00Z",
+			"codex_7d_window_minutes": 10080,
+		}
+		got := codexWindowStart(extra, "7d", now)
+		want := time.Date(2026, 3, 13, 0, 0, 0, 0, time.UTC)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls back to rolling window when metadata is missing", func(t *testing.T) {
+		got := codexWindowStart(map[string]any{}, "5h", now)
+		want := now.Add(-5 * time.Hour)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls back to rolling window when reset is expired", func(t *testing.T) {
+		extra := map[string]any{
+			"codex_5h_reset_at":       "2026-03-16T10:00:00Z",
+			"codex_5h_window_minutes": 300,
+		}
+		got := codexWindowStart(extra, "5h", now)
+		want := now.Add(-5 * time.Hour)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStart() = %v, want %v", got, want)
+		}
+	})
+}

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -56,6 +56,7 @@
           label="7d"
           :utilization="usageInfo.seven_day.utilization"
           :resets-at="usageInfo.seven_day.resets_at"
+          :window-stats="usageInfo.seven_day.window_stats"
           color="emerald"
         />
 
@@ -65,6 +66,7 @@
           label="7d S"
           :utilization="usageInfo.seven_day_sonnet.utilization"
           :resets-at="usageInfo.seven_day_sonnet.resets_at"
+          :window-stats="usageInfo.seven_day_sonnet.window_stats"
           color="purple"
         />
 

--- a/frontend/src/components/account/UsageProgressBar.vue
+++ b/frontend/src/components/account/UsageProgressBar.vue
@@ -185,7 +185,7 @@ const formatTokens = computed(() => {
 
 const formatAccountCost = computed(() => {
   if (!props.windowStats) return '0.00'
-  return props.windowStats.cost.toFixed(2)
+  return (props.windowStats.standard_cost ?? props.windowStats.cost).toFixed(2)
 })
 
 const formatUserCost = computed(() => {

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -211,6 +211,74 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('7d|77|300')
   })
 
+  it('Anthropic OAuth 会把 5h/7d/7d Sonnet 各自 window_stats 传给窗口条', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: {
+        utilization: 10,
+        resets_at: '2026-03-08T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 5,
+          tokens: 500,
+          cost: 0.5,
+          standard_cost: 0.55,
+          user_cost: 0.25
+        }
+      },
+      seven_day: {
+        utilization: 20,
+        resets_at: '2026-03-13T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 70,
+          tokens: 7000,
+          cost: 7,
+          standard_cost: 7.7,
+          user_cost: 3.5
+        }
+      },
+      seven_day_sonnet: {
+        utilization: 30,
+        resets_at: '2026-03-13T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 17,
+          tokens: 1700,
+          cost: 1.7,
+          standard_cost: 1.87,
+          user_cost: 0.85
+        }
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2100,
+          platform: 'anthropic',
+          type: 'oauth',
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.requests }}|{{ windowStats?.tokens }}|{{ windowStats?.standard_cost }}|{{ windowStats?.user_cost }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2100)
+    expect(wrapper.text()).toContain('5h|10|5|500|0.55|0.25')
+    expect(wrapper.text()).toContain('7d|20|70|7000|7.7|3.5')
+    expect(wrapper.text()).toContain('7d S|30|17|1700|1.87|0.85')
+  })
+
   it('OpenAI OAuth 有 codex 快照时仍然使用 /usage API 数据渲染', async () => {
     getUsage.mockResolvedValue({
       five_hour: {

--- a/frontend/src/components/account/__tests__/UsageProgressBar.spec.ts
+++ b/frontend/src/components/account/__tests__/UsageProgressBar.spec.ts
@@ -66,4 +66,27 @@ describe('UsageProgressBar', () => {
     expect(wrapper.text()).toContain('2h 30m')
     expect(wrapper.text()).not.toContain('现在')
   })
+
+  it('窗口统计展示 req、Token、A-USD 标准成本和 U-USD 用户成本', () => {
+    const wrapper = mount(UsageProgressBar, {
+      props: {
+        label: '7d',
+        utilization: 12,
+        resetsAt: '2026-03-17T02:30:00Z',
+        color: 'emerald',
+        windowStats: {
+          requests: 12,
+          tokens: 3456,
+          cost: 9.99,
+          standard_cost: 1.23,
+          user_cost: 4.56
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('12 req')
+    expect(wrapper.text()).toContain('3.5K')
+    expect(wrapper.text()).toContain('A $1.23')
+    expect(wrapper.text()).toContain('U $4.56')
+  })
 })


### PR DESCRIPTION
## Summary

This PR fixes local `window_stats` alignment for usage windows and makes the frontend display the correct per-window stats.
We should display the actual usage within the current 5h/7d quota window, rather than simply calculating the rolling usage over the past 5 hours or 7 days. Otherwise, the local window_stats will be misaligned with the utilization window returned by the upstream.

### Backend

- Fix Codex/OpenAI 5h and 7d local `window_stats` to use fixed upstream window boundaries from Codex reset/window metadata instead of rolling `now - duration` windows.
- Add Anthropic 7d and 7d Sonnet `window_stats` support by deriving the local stats window from `resets_at - 7d`.
- Keep Anthropic 5h `window_stats` based on the stored session window start.
- Change the `windowStatsCache` key from account-only to account + window start time, preventing 5h and 7d stats from reusing the same cached value.

### Frontend

- Pass Anthropic `seven_day.window_stats` and `seven_day_sonnet.window_stats` into the usage progress bars.
- Display A-USD from `standard_cost` when present, falling back to `cost`.
- Keep U-USD sourced from `user_cost`.