### PR TITLE
fix(apicompat): 非流式 Responses 补齐 output[].id 与 content[].annotations

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -359,8 +359,9 @@ func chatMessageToResponsesOutput(message ChatMessage) []ResponsesOutput {
 			ID:   generateItemID(),
 			Role: "assistant",
 			Content: []ResponsesContentPart{{
-				Type: "output_text",
-				Text: text,
+				Type:        "output_text",
+				Text:        text,
+				Annotations: EmptyResponsesAnnotations(),
 			}},
 			Status: "completed",
 		})
@@ -386,11 +387,15 @@ func chatMessageToResponsesOutput(message ChatMessage) []ResponsesOutput {
 
 func emptyResponsesMessageOutput() ResponsesOutput {
 	return ResponsesOutput{
-		Type:    "message",
-		ID:      generateItemID(),
-		Role:    "assistant",
-		Content: []ResponsesContentPart{{Type: "output_text", Text: ""}},
-		Status:  "completed",
+		Type: "message",
+		ID:   generateItemID(),
+		Role: "assistant",
+		Content: []ResponsesContentPart{{
+			Type:        "output_text",
+			Text:        "",
+			Annotations: EmptyResponsesAnnotations(),
+		}},
+		Status: "completed",
 	}
 }
 
@@ -655,8 +660,9 @@ func (state *ChatCompletionsToResponsesStreamState) chatOutput() []ResponsesOutp
 			ID:   nonEmpty(state.MessageItemID, generateItemID()),
 			Role: "assistant",
 			Content: []ResponsesContentPart{{
-				Type: "output_text",
-				Text: state.Text.String(),
+				Type:        "output_text",
+				Text:        state.Text.String(),
+				Annotations: EmptyResponsesAnnotations(),
 			}},
 			Status: "completed",
 		})

--- a/backend/internal/pkg/apicompat/responses_output_schema_test.go
+++ b/backend/internal/pkg/apicompat/responses_output_schema_test.go
@@ -1,0 +1,178 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// 防回归测试集：保证响应路径上构造的 Responses output 项与 OpenAI Responses API
+// schema 兼容（@ai-sdk/openai 的 Zod 校验等严格客户端不再因为字段缺失而拒绝）。
+//
+// 必须满足：
+//   1. 每个 output 项的 "id" 字段非空（避免被 omitempty 剔除）。
+//   2. type=message 的 content[i] 必须包含 "annotations" 字段，且序列化为 [] 而
+//      非 null 或省略。
+
+// outputItemKeys 返回单个 output 项序列化后的顶层 JSON key 集合。
+func outputItemKeys(t *testing.T, item ResponsesOutput) map[string]struct{} {
+	t.Helper()
+	raw, err := json.Marshal(item)
+	require.NoError(t, err)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &m))
+	keys := make(map[string]struct{}, len(m))
+	for k := range m {
+		keys[k] = struct{}{}
+	}
+	return keys
+}
+
+// contentPartKeys 返回 message output 第一个 content part 序列化后的顶层 JSON key。
+func contentPartKeys(t *testing.T, item ResponsesOutput) map[string]json.RawMessage {
+	t.Helper()
+	require.NotEmpty(t, item.Content, "message output must have content parts")
+	raw, err := json.Marshal(item.Content[0])
+	require.NoError(t, err)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}
+
+func TestBuildOutput_TextOutputHasIDAndAnnotations(t *testing.T) {
+	acc := NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.output_text.delta", Delta: "hi"})
+
+	output := acc.BuildOutput()
+	require.Len(t, output, 1)
+	msg := output[0]
+	assert.Equal(t, "message", msg.Type)
+	assert.NotEmpty(t, msg.ID, "message output must carry a non-empty id")
+	assert.True(t, strings.HasPrefix(msg.ID, "item_"), "id should use project's item_ prefix; got %q", msg.ID)
+
+	keys := outputItemKeys(t, msg)
+	_, hasID := keys["id"]
+	assert.True(t, hasID, "serialized message output must contain id key; keys=%v", keys)
+
+	cp := contentPartKeys(t, msg)
+	raw, ok := cp["annotations"]
+	require.True(t, ok, "serialized content part must contain annotations key; got keys=%v", keys)
+	assert.JSONEq(t, "[]", string(raw), "annotations must be empty array, got %s", raw)
+}
+
+func TestBuildOutput_ReasoningHasID(t *testing.T) {
+	acc := NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.reasoning_summary_text.delta", Delta: "thinking"})
+
+	output := acc.BuildOutput()
+	require.Len(t, output, 1)
+	assert.Equal(t, "reasoning", output[0].Type)
+	assert.NotEmpty(t, output[0].ID)
+	assert.True(t, strings.HasPrefix(output[0].ID, "item_"))
+
+	keys := outputItemKeys(t, output[0])
+	_, hasID := keys["id"]
+	assert.True(t, hasID, "serialized reasoning output must contain id key")
+}
+
+func TestBuildOutput_FunctionCallHasID(t *testing.T) {
+	acc := NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_xyz",
+			Name:   "do_thing",
+		},
+	})
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 0,
+		Delta:       `{}`,
+	})
+
+	output := acc.BuildOutput()
+	require.Len(t, output, 1)
+	assert.Equal(t, "function_call", output[0].Type)
+	assert.NotEmpty(t, output[0].ID)
+	assert.True(t, strings.HasPrefix(output[0].ID, "item_"))
+}
+
+func TestBuildOutput_AllItemsGetUniqueIDs(t *testing.T) {
+	acc := NewBufferedResponseAccumulator()
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.reasoning_summary_text.delta", Delta: "think"})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.output_text.delta", Delta: "answer"})
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 2,
+		Item:        &ResponsesOutput{Type: "function_call", CallID: "call_1", Name: "fn"},
+	})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.function_call_arguments.delta", OutputIndex: 2, Delta: "{}"})
+
+	output := acc.BuildOutput()
+	require.Len(t, output, 3)
+	seen := make(map[string]struct{}, 3)
+	for _, item := range output {
+		require.NotEmpty(t, item.ID, "every output item must have an id (type=%s)", item.Type)
+		if _, dup := seen[item.ID]; dup {
+			t.Fatalf("duplicate id %q across output items", item.ID)
+		}
+		seen[item.ID] = struct{}{}
+	}
+}
+
+func TestChatMessageToResponsesOutput_TextHasAnnotations(t *testing.T) {
+	outputs := chatMessageToResponsesOutput(ChatMessage{
+		Role:    "assistant",
+		Content: json.RawMessage(`"hello"`),
+	})
+	require.Len(t, outputs, 1)
+	msg := outputs[0]
+	assert.Equal(t, "message", msg.Type)
+	assert.NotEmpty(t, msg.ID)
+
+	cp := contentPartKeys(t, msg)
+	raw, ok := cp["annotations"]
+	require.True(t, ok, "content part must contain annotations key")
+	assert.JSONEq(t, "[]", string(raw))
+}
+
+func TestEmptyResponsesMessageOutput_HasIDAndAnnotations(t *testing.T) {
+	out := emptyResponsesMessageOutput()
+	assert.NotEmpty(t, out.ID)
+
+	cp := contentPartKeys(t, out)
+	raw, ok := cp["annotations"]
+	require.True(t, ok, "empty message output must still carry annotations key")
+	assert.JSONEq(t, "[]", string(raw))
+}
+
+func TestResponsesContentPart_InputBlocksDoNotEmitAnnotations(t *testing.T) {
+	// 请求路径（input_text / input_image）不应该带 annotations 字段，避免污染上游
+	// 请求。指针 + omitempty 的设计保证未初始化时序列化时剔除该字段。
+	for _, part := range []ResponsesContentPart{
+		{Type: "input_text", Text: "hi"},
+		{Type: "input_image", ImageURL: "data:image/png;base64,AAAA"},
+	} {
+		raw, err := json.Marshal(part)
+		require.NoError(t, err)
+		assert.NotContains(t, string(raw), `"annotations"`,
+			"input-side ResponsesContentPart should not emit annotations; got %s", raw)
+	}
+}
+
+func TestEmptyResponsesAnnotations_SerializesAsEmptyArray(t *testing.T) {
+	part := ResponsesContentPart{
+		Type:        "output_text",
+		Text:        "hello",
+		Annotations: EmptyResponsesAnnotations(),
+	}
+	raw, err := json.Marshal(part)
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"annotations":[]`,
+		"EmptyResponsesAnnotations should serialize as []; got %s", raw)
+}

--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
@@ -443,12 +443,18 @@ func (a *BufferedResponseAccumulator) HasContent() bool {
 // BuildOutput constructs a []ResponsesOutput from the accumulated delta
 // content. The order matches what ResponsesToChatCompletions expects:
 // reasoning → message → function_calls.
+//
+// 每个 output 项都会填充 ID（reasoning/message/function_call），且 message
+// 的 content part 会显式初始化 Annotations 为空切片，确保最终 JSON 中输出
+// "annotations":[]。这避免严格遵循 Responses API schema 的客户端（如
+// @ai-sdk/openai 的 Zod）因缺失字段而拒绝响应。
 func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 	var out []ResponsesOutput
 
 	if a.reasoning.Len() > 0 {
 		out = append(out, ResponsesOutput{
 			Type: "reasoning",
+			ID:   generateItemID(),
 			Summary: []ResponsesSummary{{
 				Type: "summary_text",
 				Text: a.reasoning.String(),
@@ -459,10 +465,12 @@ func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 	if a.text.Len() > 0 {
 		out = append(out, ResponsesOutput{
 			Type: "message",
+			ID:   generateItemID(),
 			Role: "assistant",
 			Content: []ResponsesContentPart{{
-				Type: "output_text",
-				Text: a.text.String(),
+				Type:        "output_text",
+				Text:        a.text.String(),
+				Annotations: EmptyResponsesAnnotations(),
 			}},
 		})
 	}
@@ -470,6 +478,7 @@ func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 	for i := range a.funcCalls {
 		out = append(out, ResponsesOutput{
 			Type:      "function_call",
+			ID:        generateItemID(),
 			CallID:    a.funcCalls[i].CallID,
 			Name:      a.funcCalls[i].Name,
 			Arguments: a.funcCalls[i].Args.String(),

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -244,6 +244,29 @@ type ResponsesContentPart struct {
 	Type     string `json:"type"` // "input_text" | "output_text" | "input_image"
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // data URI for input_image
+	// Annotations 仅出现在响应侧 output_text 块上，且必须始终存在（OpenAI Responses
+	// API spec 要求；严格遵循该 schema 的客户端如 @ai-sdk/openai 的 Zod 会因缺失
+	// 该字段拒绝响应）。请求侧 input_text/input_image 不需要此字段。
+	//
+	// 类型用指针切片 + omitempty 是为了同时满足两种语义：
+	//   - 请求侧构造（nil 指针）→ 序列化时剔除字段，避免给上游塞无效数据
+	//   - 响应侧构造（指向空切片）→ 序列化为 "annotations":[]
+	// 使用 EmptyResponsesAnnotations() 取一个非 nil 的 *[]ResponsesAnnotation。
+	Annotations *[]ResponsesAnnotation `json:"annotations,omitempty"`
+}
+
+// ResponsesAnnotation 描述 output_text 内容部分中的一条标注（如 file_citation、
+// url_citation 等）。当前仅暴露公共的 type 字段；如有其他字段，由更上层 API 类型
+// 扩展。
+type ResponsesAnnotation struct {
+	Type string `json:"type,omitempty"`
+}
+
+// EmptyResponsesAnnotations 返回一个指向非 nil 空切片的指针，适用于构造响应侧
+// output_text content part，使其序列化时输出 "annotations":[]。
+func EmptyResponsesAnnotations() *[]ResponsesAnnotation {
+	empty := []ResponsesAnnotation{}
+	return &empty
 }
 
 // ResponsesTool describes a tool in the Responses API.


### PR DESCRIPTION
## 问题

`stream=false` 调用 `/v1/responses` 时，sub2api 在 OAuth 通道（codex 内部协议）下会消费 SSE 流并通过 `BufferedResponseAccumulator.BuildOutput` 重建响应。原实现两处缺陷导致最终响应缺字段：

1. **`output[].id` 缺失**：`BuildOutput` 内构造的 `ResponsesOutput` 未赋 ID；`ResponsesOutput.ID` 标了 `json:"id,omitempty"`，空字符串时整字段被序列化剔除。
2. **`content[].annotations` 缺失**：`ResponsesContentPart` 结构体根本没有 `annotations` 字段，无论上游 SSE 流里是否带了 annotations，序列化结果都不会包含。

严格遵循 [OpenAI Responses API schema](https://platform.openai.com/docs/api-reference/responses/object) 的客户端会拒绝该响应，最典型的是 `@ai-sdk/openai` 的 Zod schema，会抛 `AI_APICallError: Invalid JSON response`。

## 复现路径

```
客户端 stream=false POST /v1/responses
        ↓
sub2api OAuth 上游 → 必须以 SSE 发起
        ↓
handlePassthroughSSEToJSON()
        ↓ output 数组为空（OpenAI 上游 response.completed 事件的设计）
reconstructResponseOutputFromSSE() → BuildOutput()   ← 缺陷点
        ↓
返回缺 id/annotations 的 JSON → @ai-sdk/openai Zod 校验失败
```

`stream=true` 路径是 SSE 直接透传不经过 `BuildOutput`，所以不触发，因此在用户视角呈现为「概率发生」（实际 100% 等价于 `stream=false`）。

## 修复

### 1. `ResponsesContentPart` 增加 Annotations 字段（指针切片 + omitempty）

```go
type ResponsesContentPart struct {
    Type     string `json:"type"`
    Text     string `json:"text,omitempty"`
    ImageURL string `json:"image_url,omitempty"`
    // 仅响应侧 output_text 需要；指针 + omitempty 同时满足两种语义：
    //   - 请求侧（input_text/input_image）保持 nil → 字段被剔除
    //   - 响应侧通过 EmptyResponsesAnnotations() 取空切片指针 → "annotations":[]
    Annotations *[]ResponsesAnnotation `json:"annotations,omitempty"`
}
```

### 2. `BuildOutput` 三种 output 项均补 ID，message 补 Annotations

复用项目内已有的 `generateItemID()`，与 `chatMessageToResponsesOutput` 风格一致。

### 3. 同包内其他响应路径（Chat Completions → Responses）顺手修复

- `chatMessageToResponsesOutput`
- `emptyResponsesMessageOutput`
- `ChatCompletionsToResponsesStreamState.chatOutput`

避免 Chat Completions 上游通道下回归同一类缺陷。

## 测试

新增 `responses_output_schema_test.go`（8 个测试）作为防回归门：

- `BuildOutput` 三种 output 类型必带非空 id；id 之间唯一
- message output 的 content part 序列化结果必含 `"annotations":[]`
- 请求侧 `input_text`/`input_image` 块**不**带 annotations 字段（避免污染上游请求）
- `EmptyResponsesAnnotations()` 序列化为 `[]` 而非 `null`

### 本地验证

```bash
$ cd backend
$ make test-unit         # ok
$ make test-integration  # ok
$ golangci-lint run ./... --timeout=30m --new-from-rev=upstream/main
0 issues.
```

## 影响范围 / 兼容性

- **修改仅限响应输出路径**（output → 客户端）。请求路径（input → 上游）的 `input_text`/`input_image` 块不受影响（指针 nil + omitempty 保证字段被剔除）。
- 不改变现有客户端响应里**已有**字段的语义，只是**补齐**缺失字段。Codex CLI 等宽容客户端不受影响。
- 修复后 `@ai-sdk/openai`、官方 OpenAI Python/Node SDK 等严格客户端可正常解析响应。

## 检查清单（DEV_GUIDE 第十一条）

- [x] `make test-unit` 通过
- [x] `make test-integration` 通过
- [x] `golangci-lint run ./...` 无新增问题
- [x] 未改动 ent schema、interface、前端依赖