### PR TITLE
fix(openai): 区分 remote compact 成功后客户端断连日志

### DIFF
--- a/backend/internal/handler/openai_gateway_compact_log_test.go
+++ b/backend/internal/handler/openai_gateway_compact_log_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -119,6 +120,7 @@ func TestLogOpenAIRemoteCompactOutcome_Succeeded(t *testing.T) {
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
 	c.Set(opsModelKey, "gpt-5.3-codex")
 	c.Set(opsAccountIDKey, int64(123))
+	c.Set(openAIRemoteCompactRequestBodyBytesKey, 9557292)
 	c.Header("x-request-id", "rid-compact-ok")
 	c.Status(http.StatusOK)
 
@@ -132,6 +134,31 @@ func TestLogOpenAIRemoteCompactOutcome_Succeeded(t *testing.T) {
 	require.True(t, logSink.ContainsFieldValue("request_model", "gpt-5.3-codex"))
 	require.True(t, logSink.ContainsFieldValue("account_id", "123"))
 	require.True(t, logSink.ContainsFieldValue("upstream_request_id", "rid-compact-ok"))
+	require.True(t, logSink.ContainsFieldValue("body_bytes", "9557292"))
+}
+
+func TestLogOpenAIRemoteCompactOutcome_ClientDisconnectedAfterSuccess(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logSink, restore := captureHandlerStructuredLog(t)
+	defer restore()
+
+	reqCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil).WithContext(reqCtx)
+	c.Set(openAIRemoteCompactRequestBodyBytesKey, 1024)
+	c.Status(http.StatusOK)
+
+	h := &OpenAIGatewayHandler{}
+	h.logOpenAIRemoteCompactOutcome(c, time.Now())
+
+	require.True(t, logSink.ContainsMessageAtLevel("codex.remote_compact.client_disconnected_after_success", "warn"))
+	require.True(t, logSink.ContainsFieldValue("compact_outcome", "client_disconnected_after_success"))
+	require.True(t, logSink.ContainsFieldValue("status_code", "200"))
+	require.True(t, logSink.ContainsFieldValue("client_context_error", "context canceled"))
+	require.True(t, logSink.ContainsFieldValue("body_bytes", "1024"))
 }
 
 func TestLogOpenAIRemoteCompactOutcome_Failed(t *testing.T) {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -39,6 +39,8 @@ type OpenAIGatewayHandler struct {
 	cfg                      *config.Config
 }
 
+const openAIRemoteCompactRequestBodyBytesKey = "openai_remote_compact_request_body_bytes"
+
 func resolveOpenAIMessagesDispatchMappedModel(apiKey *service.APIKey, requestedModel string) string {
 	if apiKey == nil || apiKey.Group == nil {
 		return ""
@@ -128,6 +130,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	if len(body) == 0 {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Request body is empty")
 		return
+	}
+	if isOpenAIRemoteCompactPath(c) {
+		c.Set(openAIRemoteCompactRequestBodyBytesKey, len(body))
 	}
 
 	setOpsRequestContext(c, "", false)
@@ -504,6 +509,15 @@ func (h *OpenAIGatewayHandler) logOpenAIRemoteCompactOutcome(c *gin.Context, sta
 	if status >= 200 && status < 300 {
 		outcome = "succeeded"
 	}
+	clientContextErr := ""
+	if ctx != nil {
+		if err := ctx.Err(); err != nil {
+			clientContextErr = err.Error()
+			if outcome == "succeeded" {
+				outcome = "client_disconnected_after_success"
+			}
+		}
+	}
 	latencyMs := time.Since(startedAt).Milliseconds()
 	if latencyMs < 0 {
 		latencyMs = 0
@@ -518,8 +532,16 @@ func (h *OpenAIGatewayHandler) logOpenAIRemoteCompactOutcome(c *gin.Context, sta
 		zap.String("path", path),
 		zap.Bool("force_codex_cli", h != nil && h.cfg != nil && h.cfg.Gateway.ForceCodexCLI),
 	}
+	if clientContextErr != "" {
+		fields = append(fields, zap.String("client_context_error", clientContextErr))
+	}
 
 	if c != nil {
+		if v, ok := c.Get(openAIRemoteCompactRequestBodyBytesKey); ok {
+			if bodyBytes, ok := v.(int); ok && bodyBytes >= 0 {
+				fields = append(fields, zap.Int("body_bytes", bodyBytes))
+			}
+		}
 		if userAgent := strings.TrimSpace(c.GetHeader("User-Agent")); userAgent != "" {
 			fields = append(fields, zap.String("request_user_agent", userAgent))
 		}
@@ -545,6 +567,10 @@ func (h *OpenAIGatewayHandler) logOpenAIRemoteCompactOutcome(c *gin.Context, sta
 	log := logger.FromContext(ctx).With(fields...)
 	if outcome == "succeeded" {
 		log.Info("codex.remote_compact.succeeded")
+		return
+	}
+	if outcome == "client_disconnected_after_success" {
+		log.Warn("codex.remote_compact.client_disconnected_after_success")
 		return
 	}
 	log.Warn("codex.remote_compact.failed")


### PR DESCRIPTION
## 背景

Codex remote compact (`/v1/responses/compact`) 请求可能携带较大的上下文请求体，且上游处理耗时较长。排查这类问题时，当前日志只能按最终 HTTP 状态粗略记录 `codex.remote_compact.succeeded/failed`，难以区分：

- 上游 compact 本身失败
- 上游已经成功返回，但客户端在写回结果前/过程中断开

这会让线上排查 `stream disconnected before completion`、`broken pipe` 等问题时缺少关键判断依据。

## 改动

- remote compact outcome 日志增加 `body_bytes`，记录原始 compact 请求体大小，便于判断是否属于大上下文 compact。
- 当响应状态为 2xx、但请求 context 已取消时，将 outcome 标记为 `client_disconnected_after_success`。
- 对该场景单独输出 `codex.remote_compact.client_disconnected_after_success` warn 日志，并记录 `client_context_error`。
- 补充单元测试覆盖 body_bytes 记录与成功后客户端断连的日志分支。

本 PR 只改善 compact 诊断日志，不改变请求转发、计费或 compact 返回协议。

## 测试

已通过：

```bash
go test ./internal/handler -run 'Test(LogOpenAIRemoteCompactOutcome|IsOpenAIRemoteCompactPath|OpenAIResponses_CompactUnauthorizedLogsFailed)'
```