### PR TITLE
fix(ops): Postgres 不可达时限制错误重试队列内存增长，避免 OOM

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -78,15 +78,16 @@ var (
 	opsErrorLogOnce  sync.Once
 	opsErrorLogQueue chan opsErrorLogJob
 
-	opsErrorLogStopOnce  sync.Once
-	opsErrorLogWorkersWg sync.WaitGroup
-	opsErrorLogMu        sync.RWMutex
-	opsErrorLogStopping  bool
-	opsErrorLogQueueLen  atomic.Int64
-	opsErrorLogEnqueued  atomic.Int64
-	opsErrorLogDropped   atomic.Int64
-	opsErrorLogProcessed atomic.Int64
-	opsErrorLogSanitized atomic.Int64
+	opsErrorLogStopOnce           sync.Once
+	opsErrorLogWorkersWg          sync.WaitGroup
+	opsErrorLogMu                 sync.RWMutex
+	opsErrorLogStopping           bool
+	opsErrorLogQueueLen           atomic.Int64
+	opsErrorLogEnqueued           atomic.Int64
+	opsErrorLogDropped            atomic.Int64
+	opsErrorLogProcessed          atomic.Int64
+	opsErrorLogSanitized          atomic.Int64
+	opsErrorLogDroppedOnDBFailure atomic.Int64
 
 	opsErrorLogLastDropLogAt atomic.Int64
 
@@ -180,9 +181,21 @@ func flushOpsErrorLogBatch(batch []opsErrorLogJob) {
 		if opsSvc == nil || len(entries) == 0 {
 			continue
 		}
+		dbGate := service.DefaultDBHealthGate()
+		if !dbGate.IsHealthy() {
+			opsErrorLogDroppedOnDBFailure.Add(int64(len(entries)))
+			dbGate.LogSkip("ops_error_logger", "record_error_batch")
+			continue
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), opsErrorLogTimeout)
-		_ = opsSvc.RecordErrorBatch(ctx, entries)
+		err := opsSvc.RecordErrorBatch(ctx, entries)
 		cancel()
+		if err != nil {
+			opsErrorLogDroppedOnDBFailure.Add(int64(len(entries)))
+			dbGate.MarkFailure()
+		} else {
+			dbGate.MarkSuccess()
+		}
 	}
 	opsErrorLogProcessed.Add(processed)
 }
@@ -293,6 +306,10 @@ func OpsErrorLogSanitizedTotal() int64 {
 	return opsErrorLogSanitized.Load()
 }
 
+func OpsErrorLogDroppedOnDBFailureTotal() int64 {
+	return opsErrorLogDroppedOnDBFailure.Load()
+}
+
 func maybeLogOpsErrorLogDrop() {
 	now := time.Now().Unix()
 
@@ -310,11 +327,12 @@ func maybeLogOpsErrorLogDrop() {
 	queueCap := OpsErrorLogQueueCapacity()
 
 	log.Printf(
-		"[OpsErrorLogger] queue is full; dropping logs (queued=%d cap=%d enqueued_total=%d dropped_total=%d processed_total=%d sanitized_total=%d)",
+		"[OpsErrorLogger] queue is full; dropping logs (queued=%d cap=%d enqueued_total=%d dropped_total=%d dropped_on_db_failure_total=%d processed_total=%d sanitized_total=%d)",
 		queued,
 		queueCap,
 		opsErrorLogEnqueued.Load(),
 		opsErrorLogDropped.Load(),
+		opsErrorLogDroppedOnDBFailure.Load(),
 		opsErrorLogProcessed.Load(),
 		opsErrorLogSanitized.Load(),
 	)

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -37,7 +37,9 @@ func resetOpsErrorLoggerStateForTest(t *testing.T) {
 	opsErrorLogDropped.Store(0)
 	opsErrorLogProcessed.Store(0)
 	opsErrorLogSanitized.Store(0)
+	opsErrorLogDroppedOnDBFailure.Store(0)
 	opsErrorLogLastDropLogAt.Store(0)
+	service.DefaultDBHealthGate().Reset()
 
 	opsErrorLogShutdownCh = make(chan struct{})
 	opsErrorLogShutdownOnce = sync.Once{}

--- a/backend/internal/service/db_health_gate.go
+++ b/backend/internal/service/db_health_gate.go
@@ -1,0 +1,176 @@
+package service
+
+import (
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	dbHealthGateWindow            = 60 * time.Second
+	dbHealthGateUnhealthyDuration = 60 * time.Second
+	dbHealthGateMinFailures       = 10
+	dbHealthGateFailureRate       = 0.8
+	dbHealthGateSkipLogInterval   = 5 * time.Minute
+)
+
+type dbHealthGate struct {
+	mu sync.Mutex
+
+	now func() time.Time
+
+	windowStart         time.Time
+	total               int
+	failures            int
+	consecutiveFailures int
+
+	unhealthyUntil time.Time
+	skipLogAt      map[string]time.Time
+}
+
+var defaultDBHealthGate = newDBHealthGate(time.Now)
+
+func newDBHealthGate(now func() time.Time) *dbHealthGate {
+	if now == nil {
+		now = time.Now
+	}
+	return &dbHealthGate{
+		now:         now,
+		windowStart: now(),
+		skipLogAt:   make(map[string]time.Time),
+	}
+}
+
+func DefaultDBHealthGate() *dbHealthGate {
+	return defaultDBHealthGate
+}
+
+func (g *dbHealthGate) IsHealthy() bool {
+	if g == nil {
+		return true
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := g.now()
+	return !now.Before(g.unhealthyUntil)
+}
+
+func (g *dbHealthGate) MarkFailure() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := g.now()
+	g.rollWindowLocked(now)
+
+	g.total++
+	g.failures++
+	g.consecutiveFailures++
+	if g.failures < dbHealthGateMinFailures {
+		return
+	}
+	if g.consecutiveFailures < dbHealthGateMinFailures && float64(g.failures)/float64(g.total) < dbHealthGateFailureRate {
+		return
+	}
+
+	unhealthyUntil := now.Add(dbHealthGateUnhealthyDuration)
+	if unhealthyUntil.After(g.unhealthyUntil) {
+		g.unhealthyUntil = unhealthyUntil
+	}
+}
+
+func (g *dbHealthGate) MarkSuccess() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := g.now()
+	if !g.unhealthyUntil.IsZero() {
+		g.windowStart = now
+		g.total = 0
+		g.failures = 0
+		g.consecutiveFailures = 0
+		g.unhealthyUntil = time.Time{}
+		return
+	}
+
+	g.rollWindowLocked(now)
+	g.total++
+	g.consecutiveFailures = 0
+}
+
+func (g *dbHealthGate) ShouldLogSkip(key string, interval time.Duration) bool {
+	if g == nil {
+		return false
+	}
+	if interval <= 0 {
+		interval = dbHealthGateSkipLogInterval
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	now := g.now()
+	if g.skipLogAt == nil {
+		g.skipLogAt = make(map[string]time.Time)
+	}
+	last := g.skipLogAt[key]
+	if !last.IsZero() && now.Sub(last) < interval {
+		return false
+	}
+	g.skipLogAt[key] = now
+	return true
+}
+
+func (g *dbHealthGate) LogSkip(component, operation string) {
+	if g == nil {
+		return
+	}
+	key := component + ":" + operation
+	if !g.ShouldLogSkip(key, dbHealthGateSkipLogInterval) {
+		return
+	}
+	slog.Info(
+		"[DBHealthGate] skipping background DB work while unhealthy",
+		"component", component,
+		"operation", operation,
+		"unhealthy_until", g.UnhealthyUntil().Format(time.RFC3339),
+	)
+}
+
+func (g *dbHealthGate) UnhealthyUntil() time.Time {
+	if g == nil {
+		return time.Time{}
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.unhealthyUntil
+}
+
+func (g *dbHealthGate) Reset() {
+	if g == nil {
+		return
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.windowStart = g.now()
+	g.total = 0
+	g.failures = 0
+	g.consecutiveFailures = 0
+	g.unhealthyUntil = time.Time{}
+	g.skipLogAt = make(map[string]time.Time)
+}
+
+func (g *dbHealthGate) rollWindowLocked(now time.Time) {
+	if g.windowStart.IsZero() || now.Sub(g.windowStart) >= dbHealthGateWindow {
+		g.windowStart = now
+		g.total = 0
+		g.failures = 0
+		g.consecutiveFailures = 0
+	}
+}

--- a/backend/internal/service/db_health_gate_test.go
+++ b/backend/internal/service/db_health_gate_test.go
@@ -1,0 +1,84 @@
+package service
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBHealthGateStateTransitions(t *testing.T) {
+	now := time.Date(2026, 5, 25, 10, 0, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+
+	for i := 0; i < dbHealthGateMinFailures-1; i++ {
+		gate.MarkFailure()
+		require.True(t, gate.IsHealthy())
+	}
+
+	gate.MarkFailure()
+	require.False(t, gate.IsHealthy())
+
+	now = now.Add(dbHealthGateUnhealthyDuration - time.Second)
+	require.False(t, gate.IsHealthy())
+
+	now = now.Add(2 * time.Second)
+	require.True(t, gate.IsHealthy())
+
+	gate.MarkSuccess()
+	require.True(t, gate.IsHealthy())
+}
+
+func TestDBHealthGateFailureRateThreshold(t *testing.T) {
+	now := time.Date(2026, 5, 25, 11, 0, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		gate.MarkSuccess()
+	}
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		gate.MarkFailure()
+		gate.MarkSuccess()
+	}
+
+	require.True(t, gate.IsHealthy())
+
+	now = now.Add(dbHealthGateWindow + time.Second)
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		gate.MarkFailure()
+	}
+	require.False(t, gate.IsHealthy())
+}
+
+func TestDBHealthGateSkipLogRateLimit(t *testing.T) {
+	now := time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+
+	require.True(t, gate.ShouldLogSkip("scheduler:poll", time.Minute))
+	require.False(t, gate.ShouldLogSkip("scheduler:poll", time.Minute))
+
+	now = now.Add(time.Minute)
+	require.True(t, gate.ShouldLogSkip("scheduler:poll", time.Minute))
+}
+
+func TestDBHealthGateConcurrentAccess(t *testing.T) {
+	gate := newDBHealthGate(time.Now)
+	var wg sync.WaitGroup
+
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%3 == 0 {
+				gate.MarkSuccess()
+			} else {
+				gate.MarkFailure()
+			}
+			_ = gate.IsHealthy()
+			_ = gate.ShouldLogSkip("concurrent", time.Millisecond)
+		}(i)
+	}
+
+	wg.Wait()
+}

--- a/backend/internal/service/idempotency_cleanup_service.go
+++ b/backend/internal/service/idempotency_cleanup_service.go
@@ -14,6 +14,7 @@ type IdempotencyCleanupService struct {
 	repo     IdempotencyRepository
 	interval time.Duration
 	batch    int
+	dbGate   *dbHealthGate
 
 	startOnce sync.Once
 	stopOnce  sync.Once
@@ -35,6 +36,7 @@ func NewIdempotencyCleanupService(repo IdempotencyRepository, cfg *config.Config
 		repo:     repo,
 		interval: interval,
 		batch:    batch,
+		dbGate:   DefaultDBHealthGate(),
 		stopCh:   make(chan struct{}),
 	}
 }
@@ -77,15 +79,29 @@ func (s *IdempotencyCleanupService) runLoop() {
 }
 
 func (s *IdempotencyCleanupService) cleanupOnce() {
+	if !s.dbHealthGate().IsHealthy() {
+		s.dbHealthGate().LogSkip("idempotency_cleanup", "cleanup_once")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	deleted, err := s.repo.DeleteExpired(ctx, time.Now(), s.batch)
 	if err != nil {
+		s.dbHealthGate().MarkFailure()
 		logger.LegacyPrintf("service.idempotency_cleanup", "[IdempotencyCleanup] cleanup failed err=%v", err)
 		return
 	}
+	s.dbHealthGate().MarkSuccess()
 	if deleted > 0 {
 		logger.LegacyPrintf("service.idempotency_cleanup", "[IdempotencyCleanup] cleaned expired records count=%d", deleted)
 	}
+}
+
+func (s *IdempotencyCleanupService) dbHealthGate() *dbHealthGate {
+	if s == nil || s.dbGate == nil {
+		return DefaultDBHealthGate()
+	}
+	return s.dbGate
 }

--- a/backend/internal/service/idempotency_cleanup_service_test.go
+++ b/backend/internal/service/idempotency_cleanup_service_test.go
@@ -67,3 +67,19 @@ func TestIdempotencyCleanupService_CleanupOnce(t *testing.T) {
 	require.Equal(t, 1, repo.deleteCalls)
 	require.Equal(t, 99, repo.lastLimit)
 }
+
+func TestIdempotencyCleanupService_CleanupOnceSkipsWhenDBUnhealthy(t *testing.T) {
+	now := time.Date(2026, 5, 25, 13, 30, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		gate.MarkFailure()
+	}
+
+	repo := &idempotencyCleanupRepoStub{}
+	svc := NewIdempotencyCleanupService(repo, nil)
+	svc.dbGate = gate
+
+	svc.cleanupOnce()
+
+	require.Zero(t, repo.deleteCalls)
+}

--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -160,25 +161,51 @@ func (s *OpsService) RecordErrorBatch(ctx context.Context, entries []*OpsInsertE
 	if len(prepared) == 1 {
 		_, err := s.opsRepo.InsertErrorLog(ctx, prepared[0])
 		if err != nil {
-			log.Printf("[Ops] RecordErrorBatch single insert failed: %v", err)
+			log.Printf("[Ops] RecordErrorBatch single insert failed; dropping entry: %v", err)
+			logDroppedOpsErrorLogOnDBFailure(prepared[0], err)
 		}
 		return err
 	}
 
 	if _, err := s.opsRepo.BatchInsertErrorLogs(ctx, prepared); err != nil {
-		log.Printf("[Ops] RecordErrorBatch failed, fallback to single inserts: %v", err)
-		var firstErr error
+		log.Printf("[Ops] RecordErrorBatch failed; dropping entries without single insert fallback: %v", err)
 		for _, entry := range prepared {
-			if _, insertErr := s.opsRepo.InsertErrorLog(ctx, entry); insertErr != nil {
-				log.Printf("[Ops] RecordErrorBatch fallback insert failed: %v", insertErr)
-				if firstErr == nil {
-					firstErr = insertErr
-				}
-			}
+			logDroppedOpsErrorLogOnDBFailure(entry, err)
 		}
-		return firstErr
+		return err
 	}
 	return nil
+}
+
+func logDroppedOpsErrorLogOnDBFailure(entry *OpsInsertErrorLogInput, err error) {
+	if entry == nil {
+		return
+	}
+
+	status := entry.StatusCode
+	if status == 0 && entry.UpstreamStatusCode != nil {
+		status = *entry.UpstreamStatusCode
+	}
+	message := strings.TrimSpace(entry.ErrorMessage)
+	if message == "" && entry.UpstreamErrorMessage != nil {
+		message = strings.TrimSpace(*entry.UpstreamErrorMessage)
+	}
+
+	slog.Error(
+		"[Ops] dropping error log after DB failure",
+		"user_id", int64PtrValue(entry.UserID),
+		"endpoint", firstNonEmpty(entry.InboundEndpoint, entry.RequestPath, entry.UpstreamEndpoint),
+		"status", status,
+		"message", truncateString(message, 512),
+		"error", err,
+	)
+}
+
+func int64PtrValue(v *int64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
 }
 
 func (s *OpsService) prepareErrorLogInput(ctx context.Context, entry *OpsInsertErrorLogInput) (*OpsInsertErrorLogInput, bool, error) {

--- a/backend/internal/service/ops_service_batch_test.go
+++ b/backend/internal/service/ops_service_batch_test.go
@@ -69,7 +69,7 @@ func TestOpsServiceRecordErrorBatch_SanitizesAndBatches(t *testing.T) {
 	require.False(t, second.CreatedAt.IsZero())
 }
 
-func TestOpsServiceRecordErrorBatch_FallsBackToSingleInsert(t *testing.T) {
+func TestOpsServiceRecordErrorBatch_DropsBatchFailureWithoutSingleInsertFallback(t *testing.T) {
 	t.Parallel()
 
 	var (
@@ -92,9 +92,28 @@ func TestOpsServiceRecordErrorBatch_FallsBackToSingleInsert(t *testing.T) {
 		{ErrorMessage: "first"},
 		{ErrorMessage: "second"},
 	})
-	require.NoError(t, err)
+	require.Error(t, err)
 	require.Equal(t, 1, batchCalls)
-	require.Equal(t, 2, singleCalls)
+	require.Equal(t, 0, singleCalls)
+}
+
+func TestOpsServiceRecordErrorBatch_SingleEntryAttemptsOnce(t *testing.T) {
+	t.Parallel()
+
+	var singleCalls int
+	repo := &opsRepoMock{
+		InsertErrorLogFn: func(ctx context.Context, input *OpsInsertErrorLogInput) (int64, error) {
+			singleCalls++
+			return 0, errors.New("db unavailable")
+		},
+	}
+	svc := NewOpsService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+
+	err := svc.RecordErrorBatch(context.Background(), []*OpsInsertErrorLogInput{
+		{ErrorMessage: "single"},
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, singleCalls)
 }
 
 func strPtr(v string) *string {

--- a/backend/internal/service/scheduler_snapshot_resilience_test.go
+++ b/backend/internal/service/scheduler_snapshot_resilience_test.go
@@ -1,0 +1,254 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+type schedulerResilienceCache struct {
+	buckets           []SchedulerBucket
+	watermark         int64
+	setWatermarkCalls int
+}
+
+func (c *schedulerResilienceCache) GetSnapshot(context.Context, SchedulerBucket) ([]*Account, bool, error) {
+	return nil, false, nil
+}
+
+func (c *schedulerResilienceCache) SetSnapshot(context.Context, SchedulerBucket, []Account) error {
+	return nil
+}
+
+func (c *schedulerResilienceCache) GetAccount(context.Context, int64) (*Account, error) {
+	return nil, nil
+}
+
+func (c *schedulerResilienceCache) SetAccount(context.Context, *Account) error {
+	return nil
+}
+
+func (c *schedulerResilienceCache) DeleteAccount(context.Context, int64) error {
+	return nil
+}
+
+func (c *schedulerResilienceCache) UpdateLastUsed(context.Context, map[int64]time.Time) error {
+	return nil
+}
+
+func (c *schedulerResilienceCache) TryLockBucket(context.Context, SchedulerBucket, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (c *schedulerResilienceCache) UnlockBucket(context.Context, SchedulerBucket) error {
+	return nil
+}
+
+func (c *schedulerResilienceCache) ListBuckets(context.Context) ([]SchedulerBucket, error) {
+	return c.buckets, nil
+}
+
+func (c *schedulerResilienceCache) GetOutboxWatermark(context.Context) (int64, error) {
+	return c.watermark, nil
+}
+
+func (c *schedulerResilienceCache) SetOutboxWatermark(_ context.Context, id int64) error {
+	c.setWatermarkCalls++
+	c.watermark = id
+	return nil
+}
+
+type schedulerOutboxRepoStub struct {
+	listAfterCalls int
+	listErr        error
+}
+
+func (r *schedulerOutboxRepoStub) ListAfter(context.Context, int64, int) ([]SchedulerOutboxEvent, error) {
+	r.listAfterCalls++
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	return nil, nil
+}
+
+func (r *schedulerOutboxRepoStub) MaxID(context.Context) (int64, error) {
+	return 0, nil
+}
+
+type schedulerFailingAccountRepo struct {
+	listUngroupedByPlatformCalls int
+	err                          error
+}
+
+func (r *schedulerFailingAccountRepo) Create(context.Context, *Account) error { return nil }
+func (r *schedulerFailingAccountRepo) GetByID(context.Context, int64) (*Account, error) {
+	return nil, ErrAccountNotFound
+}
+func (r *schedulerFailingAccountRepo) GetByIDs(context.Context, []int64) ([]*Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ExistsByID(context.Context, int64) (bool, error) {
+	return false, nil
+}
+func (r *schedulerFailingAccountRepo) GetByCRSAccountID(context.Context, string) (*Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) FindByExtraField(context.Context, string, any) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListCRSAccountIDs(context.Context) (map[string]int64, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) Update(context.Context, *Account) error { return nil }
+func (r *schedulerFailingAccountRepo) Delete(context.Context, int64) error    { return nil }
+func (r *schedulerFailingAccountRepo) List(context.Context, pagination.PaginationParams) ([]Account, *pagination.PaginationResult, error) {
+	return nil, nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListWithFilters(context.Context, pagination.PaginationParams, string, string, string, string, int64, string) ([]Account, *pagination.PaginationResult, error) {
+	return nil, nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListByGroup(context.Context, int64) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListActive(context.Context) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListByPlatform(context.Context, string) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) UpdateLastUsed(context.Context, int64) error { return nil }
+func (r *schedulerFailingAccountRepo) BatchUpdateLastUsed(context.Context, map[int64]time.Time) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) SetError(context.Context, int64, string) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) ClearError(context.Context, int64) error { return nil }
+func (r *schedulerFailingAccountRepo) SetSchedulable(context.Context, int64, bool) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) AutoPauseExpiredAccounts(context.Context, time.Time) (int64, error) {
+	return 0, nil
+}
+func (r *schedulerFailingAccountRepo) BindGroups(context.Context, int64, []int64) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) ListSchedulable(context.Context) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListSchedulableByGroupID(context.Context, int64) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListSchedulableByPlatform(context.Context, string) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListSchedulableByGroupIDAndPlatform(context.Context, int64, string) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListSchedulableByPlatforms(context.Context, []string) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) ListSchedulableByGroupIDAndPlatforms(context.Context, int64, []string) ([]Account, error) {
+	return nil, nil
+}
+
+func (r *schedulerFailingAccountRepo) ListSchedulableUngroupedByPlatform(context.Context, string) ([]Account, error) {
+	r.listUngroupedByPlatformCalls++
+	return nil, r.err
+}
+
+func (r *schedulerFailingAccountRepo) ListSchedulableUngroupedByPlatforms(context.Context, []string) ([]Account, error) {
+	return nil, nil
+}
+func (r *schedulerFailingAccountRepo) SetRateLimited(context.Context, int64, time.Time) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) SetModelRateLimit(context.Context, int64, string, time.Time) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) SetOverloaded(context.Context, int64, time.Time) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) SetTempUnschedulable(context.Context, int64, time.Time, string) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) ClearTempUnschedulable(context.Context, int64) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) ClearRateLimit(context.Context, int64) error { return nil }
+func (r *schedulerFailingAccountRepo) ClearAntigravityQuotaScopes(context.Context, int64) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) ClearModelRateLimits(context.Context, int64) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) UpdateSessionWindow(context.Context, int64, *time.Time, *time.Time, string) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) UpdateExtra(context.Context, int64, map[string]any) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) BulkUpdate(context.Context, []int64, AccountBulkUpdate) (int64, error) {
+	return 0, nil
+}
+func (r *schedulerFailingAccountRepo) IncrementQuotaUsed(context.Context, int64, float64) error {
+	return nil
+}
+func (r *schedulerFailingAccountRepo) ResetQuotaUsed(context.Context, int64) error { return nil }
+
+func TestSchedulerSnapshotPollOutboxSkipsWhenDBUnhealthy(t *testing.T) {
+	now := time.Date(2026, 5, 25, 10, 0, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		gate.MarkFailure()
+	}
+
+	outbox := &schedulerOutboxRepoStub{}
+	svc := NewSchedulerSnapshotService(&schedulerResilienceCache{}, outbox, nil, nil, nil)
+	svc.dbGate = gate
+
+	svc.pollOutbox()
+
+	require.Zero(t, outbox.listAfterCalls)
+}
+
+func TestSchedulerSnapshotPollOutboxFailureDoesNotAdvanceWatermark(t *testing.T) {
+	gate := newDBHealthGate(time.Now)
+	cache := &schedulerResilienceCache{watermark: 10}
+	outbox := &schedulerOutboxRepoStub{listErr: errors.New("db down")}
+	svc := NewSchedulerSnapshotService(cache, outbox, nil, nil, nil)
+	svc.dbGate = gate
+
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		svc.pollOutbox()
+	}
+
+	require.Equal(t, dbHealthGateMinFailures, outbox.listAfterCalls)
+	require.Zero(t, cache.setWatermarkCalls)
+	require.False(t, gate.IsHealthy())
+}
+
+func TestSchedulerSnapshotRebuildBackoffSkipsAfterContinuousFailures(t *testing.T) {
+	now := time.Date(2026, 5, 25, 10, 30, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+	cache := &schedulerResilienceCache{
+		buckets: []SchedulerBucket{{GroupID: 0, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}},
+	}
+	accountRepo := &schedulerFailingAccountRepo{err: errors.New("db down")}
+	svc := NewSchedulerSnapshotService(cache, nil, accountRepo, nil, nil)
+	svc.dbGate = gate
+	svc.now = func() time.Time { return now }
+
+	for i := 0; i < schedulerRebuildBackoffFailureThreshold; i++ {
+		require.Error(t, svc.triggerFullRebuild("test"))
+	}
+	require.True(t, now.Before(svc.rebuildBackoffUntil))
+
+	calls := accountRepo.listUngroupedByPlatformCalls
+	require.NoError(t, svc.triggerFullRebuild("test"))
+	require.Equal(t, calls, accountRepo.listUngroupedByPlatformCalls)
+}

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -18,7 +18,14 @@ var (
 	ErrSchedulerFallbackLimited = errors.New("scheduler db fallback limited")
 )
 
-const outboxEventTimeout = 2 * time.Minute
+const (
+	outboxEventTimeout = 2 * time.Minute
+
+	schedulerRebuildBackoffFailureThreshold = 3
+	schedulerRebuildBackoffInitial          = 30 * time.Second
+	schedulerRebuildBackoffMax              = 5 * time.Minute
+	schedulerRebuildBackoffLogInterval      = time.Minute
+)
 
 // batchSeenKey tracks which (groupID, platform) bucket sets have already been
 // rebuilt within a single pollOutbox call, to avoid redundant work when multiple
@@ -29,17 +36,23 @@ type batchSeenKey struct {
 }
 
 type SchedulerSnapshotService struct {
-	cache         SchedulerCache
-	outboxRepo    SchedulerOutboxRepository
-	accountRepo   AccountRepository
-	groupRepo     GroupRepository
-	cfg           *config.Config
-	stopCh        chan struct{}
-	stopOnce      sync.Once
-	wg            sync.WaitGroup
-	fallbackLimit *fallbackLimiter
-	lagMu         sync.Mutex
-	lagFailures   int
+	cache                   SchedulerCache
+	outboxRepo              SchedulerOutboxRepository
+	accountRepo             AccountRepository
+	groupRepo               GroupRepository
+	cfg                     *config.Config
+	stopCh                  chan struct{}
+	stopOnce                sync.Once
+	wg                      sync.WaitGroup
+	fallbackLimit           *fallbackLimiter
+	dbGate                  *dbHealthGate
+	now                     func() time.Time
+	lagMu                   sync.Mutex
+	lagFailures             int
+	rebuildMu               sync.Mutex
+	rebuildFailures         int
+	rebuildBackoffUntil     time.Time
+	rebuildBackoffLastLogAt time.Time
 }
 
 func NewSchedulerSnapshotService(
@@ -61,6 +74,8 @@ func NewSchedulerSnapshotService(
 		cfg:           cfg,
 		stopCh:        make(chan struct{}),
 		fallbackLimit: newFallbackLimiter(maxQPS),
+		dbGate:        DefaultDBHealthGate(),
+		now:           time.Now,
 	}
 }
 
@@ -180,6 +195,9 @@ func (s *SchedulerSnapshotService) runInitialRebuild() {
 	if s.cache == nil {
 		return
 	}
+	if s.skipBackgroundDBWork("initial_rebuild") {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 	buckets, err := s.cache.ListBuckets(ctx)
@@ -194,7 +212,10 @@ func (s *SchedulerSnapshotService) runInitialRebuild() {
 		}
 	}
 	if err := s.rebuildBuckets(ctx, buckets, "startup"); err != nil {
+		s.recordRebuildFailure("startup", err)
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild startup failed: %v", err)
+	} else {
+		s.recordRebuildSuccess()
 	}
 }
 
@@ -233,6 +254,9 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 	if s.outboxRepo == nil || s.cache == nil {
 		return
 	}
+	if s.skipBackgroundDBWork("outbox_poll") {
+		return
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -244,9 +268,11 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 
 	events, err := s.outboxRepo.ListAfter(ctx, watermark, 200)
 	if err != nil {
+		s.markBackgroundDBFailure()
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox poll failed: %v", err)
 		return
 	}
+	s.markBackgroundDBSuccess()
 	if len(events) == 0 {
 		return
 	}
@@ -362,8 +388,10 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 	preloadGroupIDs := parseInt64Slice(payload["group_ids"])
 	accounts, err := s.accountRepo.GetByIDs(ctx, ids)
 	if err != nil {
+		s.markBackgroundDBFailure()
 		return err
 	}
+	s.markBackgroundDBSuccess()
 
 	found := make(map[int64]struct{}, len(accounts))
 	rebuildGroupSet := make(map[int64]struct{}, len(preloadGroupIDs))
@@ -424,6 +452,7 @@ func (s *SchedulerSnapshotService) handleAccountEvent(ctx context.Context, accou
 	account, err := s.accountRepo.GetByID(ctx, *accountID)
 	if err != nil {
 		if errors.Is(err, ErrAccountNotFound) {
+			s.markBackgroundDBSuccess()
 			if s.cache != nil {
 				if err := s.cache.DeleteAccount(ctx, *accountID); err != nil {
 					return err
@@ -431,8 +460,10 @@ func (s *SchedulerSnapshotService) handleAccountEvent(ctx context.Context, accou
 			}
 			return s.rebuildByGroupIDs(ctx, groupIDs, "account_miss", seen)
 		}
+		s.markBackgroundDBFailure()
 		return err
 	}
+	s.markBackgroundDBSuccess()
 	if s.cache != nil {
 		if err := s.cache.SetAccount(ctx, account); err != nil {
 			return err
@@ -508,15 +539,30 @@ func (s *SchedulerSnapshotService) rebuildBucketsForPlatform(ctx context.Context
 			}
 			seen[key] = struct{}{}
 		}
-		if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeSingle}, reason); err != nil && firstErr == nil {
-			firstErr = err
+		if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeSingle}, reason); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if !s.dbHealthGate().IsHealthy() {
+				return firstErr
+			}
 		}
-		if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeForced}, reason); err != nil && firstErr == nil {
-			firstErr = err
+		if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeForced}, reason); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if !s.dbHealthGate().IsHealthy() {
+				return firstErr
+			}
 		}
 		if platform == PlatformAnthropic || platform == PlatformGemini {
-			if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeMixed}, reason); err != nil && firstErr == nil {
-				firstErr = err
+			if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeMixed}, reason); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				if !s.dbHealthGate().IsHealthy() {
+					return firstErr
+				}
 			}
 		}
 	}
@@ -526,8 +572,13 @@ func (s *SchedulerSnapshotService) rebuildBucketsForPlatform(ctx context.Context
 func (s *SchedulerSnapshotService) rebuildBuckets(ctx context.Context, buckets []SchedulerBucket, reason string) error {
 	var firstErr error
 	for _, bucket := range buckets {
-		if err := s.rebuildBucket(ctx, bucket, reason); err != nil && firstErr == nil {
-			firstErr = err
+		if err := s.rebuildBucket(ctx, bucket, reason); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if !s.dbHealthGate().IsHealthy() {
+				return firstErr
+			}
 		}
 	}
 	return firstErr
@@ -553,9 +604,11 @@ func (s *SchedulerSnapshotService) rebuildBucket(ctx context.Context, bucket Sch
 
 	accounts, err := s.loadAccountsFromDB(rebuildCtx, bucket, bucket.Mode == SchedulerModeMixed)
 	if err != nil {
+		s.markBackgroundDBFailure()
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
 	}
+	s.markBackgroundDBSuccess()
 	if err := s.cache.SetSnapshot(rebuildCtx, bucket, accounts); err != nil {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild cache failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
@@ -567,6 +620,9 @@ func (s *SchedulerSnapshotService) rebuildBucket(ctx context.Context, bucket Sch
 func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) error {
 	if s.cache == nil {
 		return ErrSchedulerCacheNotReady
+	}
+	if s.skipBackgroundDBWork("full_rebuild") || s.shouldSkipRebuild(reason) {
+		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
@@ -583,7 +639,12 @@ func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) error {
 			return err
 		}
 	}
-	return s.rebuildBuckets(ctx, buckets, reason)
+	if err := s.rebuildBuckets(ctx, buckets, reason); err != nil {
+		s.recordRebuildFailure(reason, err)
+		return err
+	}
+	s.recordRebuildSuccess()
+	return nil
 }
 
 func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, oldest SchedulerOutboxEvent, watermark int64) {
@@ -621,10 +682,15 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, oldest Sc
 	if threshold <= 0 || s.outboxRepo == nil {
 		return
 	}
-	maxID, err := s.outboxRepo.MaxID(ctx)
-	if err != nil {
+	if s.skipBackgroundDBWork("outbox_backlog_check") {
 		return
 	}
+	maxID, err := s.outboxRepo.MaxID(ctx)
+	if err != nil {
+		s.markBackgroundDBFailure()
+		return
+	}
+	s.markBackgroundDBSuccess()
 	if maxID-watermark >= int64(threshold) {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox backlog rebuild triggered: backlog=%d", maxID-watermark)
 		if err := s.triggerFullRebuild("outbox_backlog"); err != nil {
@@ -798,8 +864,10 @@ func (s *SchedulerSnapshotService) defaultBuckets(ctx context.Context) ([]Schedu
 
 	groups, err := s.groupRepo.ListActive(ctx)
 	if err != nil {
+		s.markBackgroundDBFailure()
 		return dedupeBuckets(buckets), nil
 	}
+	s.markBackgroundDBSuccess()
 	for _, group := range groups {
 		if group.Platform == "" {
 			continue
@@ -811,6 +879,106 @@ func (s *SchedulerSnapshotService) defaultBuckets(ctx context.Context) ([]Schedu
 		}
 	}
 	return dedupeBuckets(buckets), nil
+}
+
+func (s *SchedulerSnapshotService) dbHealthGate() *dbHealthGate {
+	if s == nil || s.dbGate == nil {
+		return DefaultDBHealthGate()
+	}
+	return s.dbGate
+}
+
+func (s *SchedulerSnapshotService) nowTime() time.Time {
+	if s == nil || s.now == nil {
+		return time.Now()
+	}
+	return s.now()
+}
+
+func (s *SchedulerSnapshotService) skipBackgroundDBWork(operation string) bool {
+	gate := s.dbHealthGate()
+	if gate.IsHealthy() {
+		return false
+	}
+	gate.LogSkip("scheduler_snapshot", operation)
+	return true
+}
+
+func (s *SchedulerSnapshotService) markBackgroundDBFailure() {
+	s.dbHealthGate().MarkFailure()
+}
+
+func (s *SchedulerSnapshotService) markBackgroundDBSuccess() {
+	s.dbHealthGate().MarkSuccess()
+}
+
+func (s *SchedulerSnapshotService) shouldSkipRebuild(reason string) bool {
+	if s == nil {
+		return false
+	}
+	s.rebuildMu.Lock()
+	defer s.rebuildMu.Unlock()
+
+	now := s.nowTime()
+	if !now.Before(s.rebuildBackoffUntil) {
+		return false
+	}
+	if s.rebuildBackoffLastLogAt.IsZero() || now.Sub(s.rebuildBackoffLastLogAt) >= schedulerRebuildBackoffLogInterval {
+		s.rebuildBackoffLastLogAt = now
+		logger.LegacyPrintf(
+			"service.scheduler_snapshot",
+			"[Scheduler] rebuild skipped by backoff: reason=%s failures=%d until=%s",
+			reason,
+			s.rebuildFailures,
+			s.rebuildBackoffUntil.Format(time.RFC3339),
+		)
+	}
+	return true
+}
+
+func (s *SchedulerSnapshotService) recordRebuildFailure(reason string, err error) {
+	if s == nil {
+		return
+	}
+	s.rebuildMu.Lock()
+	defer s.rebuildMu.Unlock()
+
+	s.rebuildFailures++
+	if s.rebuildFailures < schedulerRebuildBackoffFailureThreshold {
+		return
+	}
+
+	delay := schedulerRebuildBackoffInitial
+	for i := 0; i < s.rebuildFailures-schedulerRebuildBackoffFailureThreshold && delay < schedulerRebuildBackoffMax; i++ {
+		delay *= 2
+	}
+	if delay > schedulerRebuildBackoffMax {
+		delay = schedulerRebuildBackoffMax
+	}
+
+	now := s.nowTime()
+	s.rebuildBackoffUntil = now.Add(delay)
+	s.rebuildBackoffLastLogAt = now
+	logger.LegacyPrintf(
+		"service.scheduler_snapshot",
+		"[Scheduler] rebuild backoff enabled: reason=%s failures=%d delay=%s err=%v",
+		reason,
+		s.rebuildFailures,
+		delay,
+		err,
+	)
+}
+
+func (s *SchedulerSnapshotService) recordRebuildSuccess() {
+	if s == nil {
+		return
+	}
+	s.rebuildMu.Lock()
+	defer s.rebuildMu.Unlock()
+
+	s.rebuildFailures = 0
+	s.rebuildBackoffUntil = time.Time{}
+	s.rebuildBackoffLastLogAt = time.Time{}
 }
 
 func dedupeBuckets(in []SchedulerBucket) []SchedulerBucket {

--- a/backend/internal/service/subscription_expiry_service.go
+++ b/backend/internal/service/subscription_expiry_service.go
@@ -21,6 +21,7 @@ type SubscriptionExpiryService struct {
 	stopCh                   chan struct{}
 	stopOnce                 sync.Once
 	wg                       sync.WaitGroup
+	dbGate                   *dbHealthGate
 }
 
 func NewSubscriptionExpiryService(userSubRepo UserSubscriptionRepository, interval time.Duration) *SubscriptionExpiryService {
@@ -28,6 +29,7 @@ func NewSubscriptionExpiryService(userSubRepo UserSubscriptionRepository, interv
 		userSubRepo: userSubRepo,
 		interval:    interval,
 		stopCh:      make(chan struct{}),
+		dbGate:      DefaultDBHealthGate(),
 	}
 }
 
@@ -72,14 +74,21 @@ func (s *SubscriptionExpiryService) Stop() {
 }
 
 func (s *SubscriptionExpiryService) runOnce() {
+	if !s.dbHealthGate().IsHealthy() {
+		s.dbHealthGate().LogSkip("subscription_expiry", "run_once")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
 	updated, err := s.userSubRepo.BatchUpdateExpiredStatus(ctx)
 	if err != nil {
+		s.dbHealthGate().MarkFailure()
 		log.Printf("[SubscriptionExpiry] Update expired subscriptions failed: %v", err)
 		return
 	}
+	s.dbHealthGate().MarkSuccess()
 	if updated > 0 {
 		log.Printf("[SubscriptionExpiry] Updated %d expired subscriptions", updated)
 	}
@@ -96,9 +105,11 @@ func (s *SubscriptionExpiryService) sendExpiryReminders(ctx context.Context) {
 	for page := 1; ; page++ {
 		subs, pag, err := s.userSubRepo.List(ctx, pagination.PaginationParams{Page: page, PageSize: 200}, nil, nil, SubscriptionStatusActive, "", "expires_at", "asc")
 		if err != nil {
+			s.dbHealthGate().MarkFailure()
 			log.Printf("[SubscriptionExpiry] List active subscriptions for reminder failed: %v", err)
 			return
 		}
+		s.dbHealthGate().MarkSuccess()
 		for i := range subs {
 			s.sendExpiryReminderIfDue(ctx, &subs[i])
 		}
@@ -118,6 +129,7 @@ func (s *SubscriptionExpiryService) expiryReminderEnabled(ctx context.Context) b
 			return true
 		}
 		log.Printf("[SubscriptionExpiry] Read expiry reminder switch failed: %v", err)
+		s.dbHealthGate().MarkFailure()
 		return false
 	}
 	return !isFalseSettingValue(value)
@@ -147,4 +159,11 @@ func (s *SubscriptionExpiryService) sendExpiryReminderIfDue(ctx context.Context,
 	}); err != nil {
 		log.Printf("[SubscriptionExpiry] Send expiry reminder failed: subscription=%d user=%d err=%v", sub.ID, sub.UserID, err)
 	}
+}
+
+func (s *SubscriptionExpiryService) dbHealthGate() *dbHealthGate {
+	if s == nil || s.dbGate == nil {
+		return DefaultDBHealthGate()
+	}
+	return s.dbGate
 }

--- a/backend/internal/service/subscription_expiry_service_test.go
+++ b/backend/internal/service/subscription_expiry_service_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 type subscriptionExpiryRepoStub struct {
-	listCalls int
+	listCalls   int
+	updateCalls int
+	updateErr   error
 }
 
 func (r *subscriptionExpiryRepoStub) Create(context.Context, *UserSubscription) error {
@@ -92,6 +94,10 @@ func (r *subscriptionExpiryRepoStub) IncrementUsage(context.Context, int64, floa
 }
 
 func (r *subscriptionExpiryRepoStub) BatchUpdateExpiredStatus(context.Context) (int64, error) {
+	r.updateCalls++
+	if r.updateErr != nil {
+		return 0, r.updateErr
+	}
 	return 0, nil
 }
 
@@ -161,4 +167,20 @@ func TestSubscriptionExpiryService_ExpiryReminderSettingReadErrorFailsClosed(t *
 	svc.SetSettingRepository(&subscriptionExpirySettingRepoStub{err: errors.New("db down")})
 
 	require.False(t, svc.expiryReminderEnabled(context.Background()))
+}
+
+func TestSubscriptionExpiryService_RunOnceSkipsWhenDBUnhealthy(t *testing.T) {
+	now := time.Date(2026, 5, 25, 13, 0, 0, 0, time.UTC)
+	gate := newDBHealthGate(func() time.Time { return now })
+	for i := 0; i < dbHealthGateMinFailures; i++ {
+		gate.MarkFailure()
+	}
+
+	repo := &subscriptionExpiryRepoStub{}
+	svc := NewSubscriptionExpiryService(repo, time.Minute)
+	svc.dbGate = gate
+
+	svc.runOnce()
+
+	require.Zero(t, repo.updateCalls)
 }


### PR DESCRIPTION
## 背景
Issue #2733 记录了 Postgres 临时不可达（如 pq: the database system is not yet accepting connections）时，后台 ops/scheduler/cleanup 路径持续触发 context deadline exceeded，最终导致宿主机内存持续增长并 OOM 的生产事故。

本 PR 聚焦 server 侧失败处理与轻量 circuit breaker；它与 K2 #2711（db_pool 强制连接生命期下限）同属 DB 不可达治理线，但触面不同、互补不重叠：K2 约束连接生命周期，本 PR 限制后台失败重试与内存/协程放大。

## 改动
- ops_error_logger：RecordErrorBatch 的 batch insert 失败后不再拆成 N 次 single insert 串行 fallback；失败 entries 通过 slog.Error 记录关键字段后丢弃，并在 OpsErrorLogger stats 中增加 dropped_on_db_failure_total。
- dbHealthGate：新增轻量后台 DB 健康门禁，60s 窗口内失败达到阈值后短暂 Unhealthy，后台任务在 Unhealthy 时跳过本轮，并对 skip 日志做限频。
- scheduler_snapshot：outbox poll / full rebuild 接入 dbHealthGate；rebuild 连续失败后指数退避，最高 5 分钟；失败时不引入跨 tick 的内存 pending，继续依赖 outbox watermark 在后续 tick 重放。
- subscription_expiry 与 idempotency_cleanup：后台 tick 接入 dbHealthGate，DB Unhealthy 时直接跳过本轮，避免持续制造超时查询。

## 测试
- cd backend && go test -tags=unit ./...
- cd backend && go test -tags=integration ./...
- cd backend && golangci-lint run ./...

Fixes #2733