### PR TITLE
Drop invalid OpenAI placeholder tools before forwarding

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1165,6 +1165,10 @@ func normalizeCodexTools(reqBody map[string]any) bool {
 
 		toolType, _ := toolMap["type"].(string)
 		toolType = strings.TrimSpace(toolType)
+		if isInvalidCodexToolPlaceholderType(toolType) {
+			modified = true
+			continue
+		}
 		if toolType != "function" {
 			validTools = append(validTools, toolMap)
 			continue
@@ -1218,4 +1222,48 @@ func normalizeCodexTools(reqBody map[string]any) bool {
 	}
 
 	return modified
+}
+
+func isInvalidCodexToolPlaceholderType(toolType string) bool {
+	switch strings.ToLower(strings.TrimSpace(toolType)) {
+	case "", "none", "null":
+		return true
+	default:
+		return false
+	}
+}
+
+// dropInvalidPlaceholderTools strips tools entries with an invalid placeholder
+// type ("", "None", "null") that the upstream OpenAI Responses API rejects
+// with `Unsupported tool type: None`. Safe to call on any reqBody regardless
+// of account type; returns true when at least one entry was dropped.
+func dropInvalidPlaceholderTools(reqBody map[string]any) bool {
+	rawTools, ok := reqBody["tools"]
+	if !ok || rawTools == nil {
+		return false
+	}
+	tools, ok := rawTools.([]any)
+	if !ok {
+		return false
+	}
+	filtered := make([]any, 0, len(tools))
+	dropped := false
+	for _, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if !ok {
+			filtered = append(filtered, tool)
+			continue
+		}
+		toolType, _ := toolMap["type"].(string)
+		if isInvalidCodexToolPlaceholderType(toolType) {
+			dropped = true
+			continue
+		}
+		filtered = append(filtered, tool)
+	}
+	if !dropped {
+		return false
+	}
+	reqBody["tools"] = filtered
+	return true
 }

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -519,6 +519,64 @@ func TestApplyCodexOAuthTransform_NormalizeCodexTools_PreservesResponsesFunction
 	require.Equal(t, "bash", first["name"])
 }
 
+func TestApplyCodexOAuthTransform_NormalizeCodexTools_DropsNonePlaceholderTools(t *testing.T) {
+	reqBody := map[string]any{
+		"model": "gpt-5.5",
+		"tools": []any{
+			map[string]any{"type": "None"},
+			map[string]any{"type": " none "},
+			map[string]any{"type": ""},
+			map[string]any{"type": "web_search"},
+		},
+	}
+
+	result := applyCodexOAuthTransform(reqBody, false, false)
+
+	require.True(t, result.Modified)
+	tools, ok := reqBody["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	tool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "web_search", tool["type"])
+}
+
+func TestDropInvalidPlaceholderTools_DropsAcrossAccountTypes(t *testing.T) {
+	reqBody := map[string]any{
+		"tools": []any{
+			map[string]any{"type": "None"},
+			map[string]any{"type": "null"},
+			map[string]any{"type": ""},
+			map[string]any{"type": "function", "name": "shell"},
+		},
+	}
+
+	require.True(t, dropInvalidPlaceholderTools(reqBody))
+
+	tools, ok := reqBody["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+	tool, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "function", tool["type"])
+	require.Equal(t, "shell", tool["name"])
+}
+
+func TestDropInvalidPlaceholderTools_NoOpWhenAllValid(t *testing.T) {
+	reqBody := map[string]any{
+		"tools": []any{
+			map[string]any{"type": "function", "name": "shell"},
+			map[string]any{"type": "web_search"},
+		},
+	}
+
+	require.False(t, dropInvalidPlaceholderTools(reqBody))
+
+	tools, ok := reqBody["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 2)
+}
+
 func TestNormalizeOpenAIResponsesImageGenerationTools_RewritesLegacyFields(t *testing.T) {
 	reqBody := map[string]any{
 		"tools": []any{

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2349,6 +2349,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
+	if dropInvalidPlaceholderTools(reqBody) {
+		bodyModified = true
+		disablePatch()
+	}
+
 	if account.Type == AccountTypeOAuth {
 		codexResult := codexTransformResult{}
 		if compatMessagesBridge {


### PR DESCRIPTION
### Summary

- Drop invalid OpenAI/Codex placeholder tool entries whose `tools[].type` is empty, `none`, `None`, or `null` before forwarding requests upstream.
- Apply the cleanup in both the Codex OAuth transform path and the shared OpenAI gateway request path so valid tools remain while unsupported placeholders are removed.
- Add focused tests proving placeholder tools are dropped and valid `web_search` / `function` tools remain.

Fixes #2753.

### Root Cause

Some clients can emit placeholder tool entries such as `tools[].type = \"None\"`. The upstream OpenAI Responses API rejects those entries with an unsupported tool type error, causing the upstream 400 response to surface through the gateway as a failed request. The gateway should not forward these invalid placeholder entries when valid tools can remain in the request.

### Scope

Changed only:

- `backend/internal/service/openai_codex_transform.go`
- `backend/internal/service/openai_codex_transform_test.go`
- `backend/internal/service/openai_gateway_service.go`

This PR does not change Claude routing, frontend code, migrations, Ent/Wire generated files, deployment files, or docs.

This PR does not rewrite `tool_choice` semantics. PR #1634 is adjacent but separate and covers Responses API `tool_choice.function` flattening; this PR is limited to invalid `tools[].type = \"None\"` / placeholder tool cleanup.

### Tests

```bash
cd backend && go test -tags unit ./internal/service -run 'TestApplyCodexOAuthTransform_NormalizeCodexTools_DropsNonePlaceholderTools|TestDropInvalidPlaceholderTools'
cd backend && go test ./internal/service -run 'Test.*(DropInvalidPlaceholderTools|NormalizeCodexTools|ToolChoice)'
GIT_MASTER=1 git diff --check
```