### PR TITLE
Use full Claude Code OAuth mimicry for Haiku requests

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -72,8 +72,8 @@ const CLICurrentVersion = "2.1.92"
 // 顺序与真实 CLI 抓包一致。
 //
 // 使用建议：
-//   - OAuth 账号 + 非 haiku：追加这整份列表，再按需保留 client 带来的 beta。
-//   - OAuth 账号 + haiku：Anthropic 对 haiku 不做 third-party 判定，使用 HaikuBetaHeader 即可。
+//   - OAuth 账号（所有模型，包括 haiku）：追加这整份列表，再按需保留 client 带来的 beta。
+//     haiku 之前被认为"免 third-party 判定"，但实测同样触发 extra usage 警告，故统一使用完整列表。
 //   - API-key 账号：不要使用本函数，参见 APIKeyBetaHeader。
 //   - 不默认加入 redact-thinking，避免上游抹除 thinking 内容；客户端显式传入时由合并逻辑保留。
 func FullClaudeCodeMimicryBetas() []string {

--- a/backend/internal/service/gateway_context_management_test.go
+++ b/backend/internal/service/gateway_context_management_test.go
@@ -147,14 +147,15 @@ func TestComputeFinalAnthropicBeta_OAuthMimic_NonHaiku_IncludesContextManagement
 	require.True(t, anthropicBetaTokensContains(final, claude.BetaClaudeCode))
 }
 
-func TestComputeFinalAnthropicBeta_OAuthMimic_Haiku_ExcludesContextManagement(t *testing.T) {
+func TestComputeFinalAnthropicBeta_OAuthMimic_Haiku_IncludesContextManagement(t *testing.T) {
 	s := newTestGatewayServiceForBeta(false)
 	final, ok := s.computeFinalAnthropicBeta("oauth", true, "claude-haiku-4-5", http.Header{}, []byte(`{}`), nil)
 	require.True(t, ok)
-	require.False(t, anthropicBetaTokensContains(final, claude.BetaContextManagement),
-		"OAuth mimic haiku 仅注入 oauth + interleaved-thinking，不含 context-management")
+	require.True(t, anthropicBetaTokensContains(final, claude.BetaContextManagement),
+		"haiku patch: OAuth mimic haiku 注入完整 CC mimicry beta，含 context-management（实测 haiku 同样触发 third-party 警告）")
 	require.True(t, anthropicBetaTokensContains(final, claude.BetaOAuth))
 	require.True(t, anthropicBetaTokensContains(final, claude.BetaInterleavedThinking))
+	require.True(t, anthropicBetaTokensContains(final, claude.BetaClaudeCode))
 }
 
 func TestComputeFinalAnthropicBeta_OAuthMimic_IgnoresClientBeta(t *testing.T) {
@@ -412,7 +413,7 @@ func TestBuildCountTokensRequestAnthropicAPIKeyPassthrough_StripsContextManageme
 // 这个测试能挡住未来某人忘调 sanitize / 将 sanitize 挪到 CCH 之后 等 regression。
 // ============================================================================
 
-func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t *testing.T) {
+func TestBuildUpstreamRequest_OAuthMimicHaiku_PreservesContextManagementEndToEnd(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -423,8 +424,8 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 		Status:      StatusActive,
 		Schedulable: true,
 	}
-	// haiku + mimic CC → final beta = HaikuBetaHeader（不含 context-management）→
-	// body 必须 strip。
+	// haiku patch: haiku + mimic CC → final beta = FullClaudeCodeMimicryBetas（含
+	// context-management）→ body 必须保留（与 sonnet/opus 一致，对称约束）。
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
 	req, err := svc.buildUpstreamRequest(
@@ -436,10 +437,10 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 	outBody := readUpstreamBodyForTest(t, req)
 	outBeta := getHeaderRaw(req.Header, "anthropic-beta")
 
-	require.False(t, gjson.GetBytes(outBody, "context_management").Exists(),
-		"OAuth mimic + haiku 端到端：outgoing body 不应含 context_management")
-	require.False(t, anthropicBetaTokensContains(outBeta, claude.BetaContextManagement),
-		"对称约束：outgoing anthropic-beta header 也不带 context-management beta")
+	require.True(t, gjson.GetBytes(outBody, "context_management").Exists(),
+		"OAuth mimic + haiku 端到端：outgoing body 必须保留 context_management")
+	require.True(t, anthropicBetaTokensContains(outBeta, claude.BetaContextManagement),
+		"对称约束：outgoing anthropic-beta header 同时含 context-management beta")
 }
 
 func TestBuildUpstreamRequest_OAuthMimicNonHaiku_PreservesContextManagementEndToEnd(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -1282,11 +1282,11 @@ func (s *GatewayService) applyClaudeCodeOAuthMimicryToBody(
 		return body
 	}
 
-	systemRewritten := false
-	if !strings.Contains(strings.ToLower(model), "haiku") {
-		body = rewriteSystemForNonClaudeCode(body, systemRaw)
-		systemRewritten = true
-	}
+	// haiku patch: 移除 haiku 旁路，让 haiku 与 sonnet/opus 一样走完整 system rewrite + OAuth mimicry。
+	// 原逻辑假设 Anthropic 对 haiku 不做 third-party 判定，但实测 haiku 同样触发
+	// "Third-party apps now draw from your extra usage" 警告，需要完整 mimicry。
+	body = rewriteSystemForNonClaudeCode(body, systemRaw)
+	systemRewritten := true
 
 	normalizeOpts := claudeOAuthNormalizeOptions{stripSystemCacheControl: !systemRewritten}
 
@@ -4472,14 +4472,12 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		// Code..." system prompt 但缺少 billing attribution block，导致 Anthropic
 		// 检测到"有 CC prompt 但无 billing block"的不一致而判为 third-party。
 		// Parrot 的 transform_request 从不检查客户端 system 内容，直接覆盖。
-		systemRewritten := false
-		if !strings.Contains(strings.ToLower(reqModel), "haiku") {
-			body = rewriteSystemForNonClaudeCode(body, parsed.System)
-			systemRewritten = true
-		}
+		// haiku patch: 移除 haiku 旁路，让 haiku 与 sonnet/opus 一样走完整 system rewrite。
+		// 实测 haiku 同样触发 "Third-party apps now draw from your extra usage" 警告。
+		body = rewriteSystemForNonClaudeCode(body, parsed.System)
+		systemRewritten := true
 
 		// system 被重写时保留 CC prompt 的 cache_control: ephemeral（匹配真实 Claude Code 行为）；
-		// 未重写时（haiku / 已含 CC 前缀）剥离客户端 cache_control，与原有行为一致。
 		// 两种情况下 enforceCacheControlLimit 都会兜底处理上限。
 		normalizeOpts := claudeOAuthNormalizeOptions{stripSystemCacheControl: !systemRewritten}
 		if s.identityService != nil {
@@ -6491,10 +6489,10 @@ func (s *GatewayService) computeFinalAnthropicBeta(
 		if mimicClaudeCode {
 			// mimic 路径：原代码跳过白名单透传，incomingBeta 总是空字符串。
 			// 这里传空 string 以严格对齐原行为。
-			requiredBetas := []string{claude.BetaOAuth, claude.BetaInterleavedThinking}
-			if !strings.Contains(strings.ToLower(modelID), "haiku") {
-				requiredBetas = claude.FullClaudeCodeMimicryBetas()
-			}
+			// haiku patch: 移除 haiku 免检测假设，让 haiku 与 sonnet/opus 一样追加完整
+			// Claude Code beta 列表。实测 haiku 同样触发 "Third-party apps now draw from
+			// your extra usage" 警告，需要完整 mimicry（含 context-management）。
+			requiredBetas := claude.FullClaudeCodeMimicryBetas()
 			return mergeAnthropicBetaDropping(requiredBetas, "", effectiveDropSet), true
 		}
 		// 真 Claude Code 客户端透传路径


### PR DESCRIPTION
### Summary

- Removes the Haiku-specific bypass from the Claude OAuth mimic path so Haiku requests from non-Claude-Code clients use the same full Claude Code mimicry behavior as Sonnet/Opus.
- Ensures OAuth mimic mode always merges `claude.FullClaudeCodeMimicryBetas()` into `anthropic-beta`, including Haiku models.
- Updates the inline beta-list guidance to reflect observed Haiku behavior.

Fixes #2754.

### Reproduction Context

Haiku OAuth requests from third-party clients can still trigger Anthropic's warning that third-party apps draw from extra usage when the request does not look like full Claude Code traffic. The previous Haiku bypass assumed Haiku did not need the complete Claude Code beta/header mimicry, but observed behavior indicates Haiku can require the same full mimicry set.

### Scope

This change is intentionally separate from #2755, which is about OpenAI/Codex placeholder tool cleanup. This PR is only about Claude/Haiku OAuth mimic beta/header behavior.

Changed only:

- `backend/internal/pkg/claude/constants.go`
- `backend/internal/service/gateway_service.go`

### Risk And Coverage

This is higher risk than #2755 because it broadens Haiku OAuth mimic behavior in the gateway hot path. I verified the existing related tests compile/pass, but I did not find a direct existing test that asserts Haiku + OAuth + mimic mode emits the full `claude.FullClaudeCodeMimicryBetas()` set.

Before merge, I recommend adding focused tests for:

- Haiku OAuth mimic mode emits the full Claude Code beta set, including `claude-code-20250219`.
- Non-Haiku OAuth mimic behavior is unchanged.
- True Claude Code client paths are not expanded accidentally when `mimicClaudeCode=false`.

### Verification

```bash
cd backend && go test ./internal/pkg/claude ./internal/service -run 'Test.*(Claude|Haiku|Mimic|Beta|Header)'
cd backend && go test ./internal/service -run 'Test.*(ClaudeCode|Mimic|Gateway)'
GIT_MASTER=1 git diff --check
```