### PR TITLE
fix: encode unicode email headers

### DIFF
--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"mime"
 	"net"
+	"net/mail"
 	"net/smtp"
 	"net/url"
 	"strconv"
@@ -189,13 +191,10 @@ func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body
 	to = sanitizeEmailHeader(to)
 	subject = sanitizeEmailHeader(subject)
 
-	from := sanitizeEmailHeader(config.From)
-	if config.FromName != "" {
-		from = fmt.Sprintf("%s <%s>", sanitizeEmailHeader(config.FromName), sanitizeEmailHeader(config.From))
-	}
+	from := formatEmailAddressHeader(config.From, config.FromName)
 
 	msg := fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=UTF-8\r\n\r\n%s",
-		from, to, subject, body)
+		from, to, encodeEmailTextHeader(subject), body)
 
 	addr := fmt.Sprintf("%s:%d", config.Host, config.Port)
 	auth := smtp.PlainAuth("", config.Username, config.Password, config.Host)
@@ -205,6 +204,19 @@ func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body
 	}
 
 	return s.sendMailPlain(addr, auth, config.From, to, []byte(msg), config.Host)
+}
+
+func encodeEmailTextHeader(value string) string {
+	return mime.QEncoding.Encode("UTF-8", sanitizeEmailHeader(value))
+}
+
+func formatEmailAddressHeader(address, name string) string {
+	address = sanitizeEmailHeader(address)
+	name = sanitizeEmailHeader(name)
+	if strings.TrimSpace(name) == "" {
+		return address
+	}
+	return (&mail.Address{Name: name, Address: address}).String()
 }
 
 // sendMailPlain sends mail without TLS using a dialer with timeout.

--- a/backend/internal/service/email_service_rfc2047_test.go
+++ b/backend/internal/service/email_service_rfc2047_test.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeEmailTextHeader_EncodesUnicodeAsRFC2047(t *testing.T) {
+	const siteName = "\u6d4b\u8bd5\u7ad9"
+	const codeLabel = "\u9a8c\u8bc1\u7801"
+	header := encodeEmailTextHeader("[" + siteName + "] " + codeLabel)
+
+	if strings.Contains(header, siteName) || strings.Contains(header, codeLabel) {
+		t.Fatalf("expected unicode text to be RFC2047 encoded, got %q", header)
+	}
+	if !strings.HasPrefix(header, "=?UTF-8?") {
+		t.Fatalf("expected RFC2047 UTF-8 encoded-word, got %q", header)
+	}
+}
+
+func TestEncodeEmailTextHeader_RemovesCRLFBeforeEncoding(t *testing.T) {
+	header := encodeEmailTextHeader("Subject\r\n injected")
+
+	if strings.ContainsAny(header, "\r\n") {
+		t.Fatalf("expected CR/LF to be removed, got %q", header)
+	}
+	if header != "Subject injected" {
+		t.Fatalf("expected sanitized ASCII header to stay readable, got %q", header)
+	}
+}
+
+func TestFormatEmailAddressHeader_EncodesUnicodeDisplayNameAsRFC2047(t *testing.T) {
+	const displayName = "\u6d4b\u8bd5\u7ad9"
+	header := formatEmailAddressHeader("noreply@example.com", displayName)
+
+	if strings.Contains(header, displayName) {
+		t.Fatalf("expected unicode display name to be RFC2047 encoded, got %q", header)
+	}
+	if !strings.Contains(header, "=?utf-8?") && !strings.Contains(header, "=?UTF-8?") {
+		t.Fatalf("expected encoded display name, got %q", header)
+	}
+	if !strings.Contains(header, "<noreply@example.com>") {
+		t.Fatalf("expected address to be preserved, got %q", header)
+	}
+}
+
+func TestFormatEmailAddressHeader_RemovesCRLFFromDisplayName(t *testing.T) {
+	header := formatEmailAddressHeader("noreply@example.com", "Sub2API\r\nInjected")
+
+	if strings.ContainsAny(header, "\r\n") {
+		t.Fatalf("expected CR/LF to be removed, got %q", header)
+	}
+	if !strings.Contains(header, "Sub2APIInjected") {
+		t.Fatalf("expected sanitized display name, got %q", header)
+	}
+}


### PR DESCRIPTION
## Summary

- encode non-ASCII email subjects with RFC 2047 before sending SMTP DATA
- format sender display names with `net/mail` so Unicode names are encoded correctly
- keep existing CR/LF header injection sanitization in place

## Why

Some strict recipient servers reject messages containing raw Unicode in headers, for example:

`550 Message denied: non-RFC2047 unicode in headers`

This can happen when the site name or SMTP sender display name contains non-ASCII text.

## Tests

- `go test ./internal/service -run 'Test(EncodeEmailTextHeader|FormatEmailAddressHeader)'`
- `go test ./internal/service`