### PR TITLE
fix: search usage API keys remotely

### DIFF
--- a/frontend/src/components/common/Select.vue
+++ b/frontend/src/components/common/Select.vue
@@ -61,7 +61,7 @@
           <!-- Options list -->
           <div class="select-options" ref="optionsListRef">
             <div
-              v-for="(option, index) in filteredOptions"
+              v-for="(option, index) in visibleOptions"
               :key="`${typeof getOptionValue(option)}:${String(getOptionValue(option) ?? '')}`"
               role="option"
               :aria-selected="isSelected(option)"
@@ -95,7 +95,10 @@
             </div>
 
             <!-- Empty state -->
-            <div v-if="filteredOptions.length === 0" class="select-empty">
+            <div v-if="loading" class="select-empty">
+              {{ loadingTextDisplay }}
+            </div>
+            <div v-else-if="visibleOptions.length === 0" class="select-empty">
               {{ emptyTextDisplay }}
             </div>
           </div>
@@ -131,23 +134,29 @@ interface Props {
   searchable?: boolean | 'auto'
   searchPlaceholder?: string
   emptyText?: string
+  loading?: boolean
+  loadingText?: string
   valueKey?: string
   labelKey?: string
   creatable?: boolean
   creatablePrefix?: string
+  remoteSearch?: boolean
 }
 
 interface Emits {
   (e: 'update:modelValue', value: string | number | boolean | null): void
   (e: 'change', value: string | number | boolean | null, option: SelectOption | null): void
+  (e: 'search', query: string): void
 }
 
 const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   error: false,
   searchable: 'auto',
+  loading: false,
   creatable: false,
   creatablePrefix: '',
+  remoteSearch: false,
   valueKey: 'value',
   labelKey: 'label'
 })
@@ -169,6 +178,7 @@ const triggerRect = ref<DOMRect | null>(null)
 const placeholderText = computed(() => props.placeholder ?? t('common.selectOption'))
 const searchPlaceholderText = computed(() => props.searchPlaceholder ?? t('common.searchPlaceholder'))
 const emptyTextDisplay = computed(() => props.emptyText ?? t('common.noOptionsFound'))
+const loadingTextDisplay = computed(() => props.loadingText ?? t('common.processing'))
 
 const isSearchable = computed(() => {
   if (props.searchable === 'auto') return props.options.length > 5
@@ -241,7 +251,7 @@ const selectedLabel = computed(() => {
 
 const filteredOptions = computed(() => {
   let opts = props.options as any[]
-  if (isSearchable.value && searchQuery.value) {
+  if (isSearchable.value && searchQuery.value && !props.remoteSearch) {
     const query = searchQuery.value.toLowerCase()
     opts = opts.filter((opt) => {
       // Match label
@@ -260,12 +270,20 @@ const filteredOptions = computed(() => {
   return opts
 })
 
+const visibleOptions = computed(() => (props.loading ? [] : filteredOptions.value))
+
+watch(searchQuery, (query) => {
+  if (props.remoteSearch && isSearchable.value) {
+    emit('search', query)
+  }
+})
+
 const isSelected = (option: any): boolean => {
   return getOptionValue(option) === props.modelValue
 }
 
 const findNextEnabledIndex = (startIndex: number): number => {
-  const opts = filteredOptions.value
+  const opts = visibleOptions.value
   if (opts.length === 0) return -1
   for (let offset = 0; offset < opts.length; offset++) {
     const idx = (startIndex + offset) % opts.length
@@ -275,7 +293,7 @@ const findNextEnabledIndex = (startIndex: number): number => {
 }
 
 const findPrevEnabledIndex = (startIndex: number): number => {
-  const opts = filteredOptions.value
+  const opts = visibleOptions.value
   if (opts.length === 0) return -1
   for (let offset = 0; offset < opts.length; offset++) {
     const idx = (startIndex - offset + opts.length) % opts.length
@@ -323,12 +341,12 @@ watch(isOpen, (open) => {
   if (open) {
     calculateDropdownPosition()
     // Reset focused index to current selection or first item
-    if (filteredOptions.value.length === 0) {
+    if (visibleOptions.value.length === 0) {
       focusedIndex.value = -1
     } else {
-      const selectedIdx = filteredOptions.value.findIndex(isSelected)
+      const selectedIdx = visibleOptions.value.findIndex(isSelected)
       const initialIdx = selectedIdx >= 0 ? selectedIdx : 0
-      focusedIndex.value = isOptionDisabled(filteredOptions.value[initialIdx])
+      focusedIndex.value = isOptionDisabled(visibleOptions.value[initialIdx])
         ? findNextEnabledIndex(initialIdx + 1)
         : initialIdx
     }
@@ -376,8 +394,8 @@ const onDropdownKeyDown = (e: KeyboardEvent) => {
       break
     case 'Enter':
       e.preventDefault()
-      if (focusedIndex.value >= 0 && focusedIndex.value < filteredOptions.value.length) {
-        const opt = filteredOptions.value[focusedIndex.value]
+      if (focusedIndex.value >= 0 && focusedIndex.value < visibleOptions.value.length) {
+        const opt = visibleOptions.value[focusedIndex.value]
         if (!isOptionDisabled(opt)) selectOption(opt)
       }
       break

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -97,7 +97,11 @@
                 v-model="filters.api_key_id"
                 :options="apiKeyOptions"
                 :placeholder="t('usage.allApiKeys')"
-                @change="applyFilters"
+                :searchable="true"
+                :remote-search="true"
+                :loading="apiKeySearchLoading"
+                @search="handleApiKeySearch"
+                @change="handleApiKeyChange"
               />
             </div>
 
@@ -538,7 +542,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, reactive, onMounted } from 'vue'
+import { ref, computed, reactive, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { usageAPI, keysAPI } from '@/api'
@@ -609,14 +613,27 @@ const usageLogs = ref<UsageLog[]>([])
 const apiKeys = ref<ApiKey[]>([])
 const loading = ref(false)
 const exporting = ref(false)
+const apiKeySearchLoading = ref(false)
+const selectedApiKeyOption = ref<{ value: number; label: string } | null>(null)
+const API_KEY_FILTER_PAGE_SIZE = 20
+let apiKeySearchTimer: ReturnType<typeof setTimeout> | null = null
+let apiKeySearchRequestId = 0
 
 const apiKeyOptions = computed(() => {
+  const options = apiKeys.value.map((key) => ({
+    value: key.id,
+    label: key.name
+  }))
+  if (
+    selectedApiKeyOption.value &&
+    !options.some((option) => option.value === selectedApiKeyOption.value?.value)
+  ) {
+    options.unshift(selectedApiKeyOption.value)
+  }
+
   return [
     { value: null, label: t('usage.allApiKeys') },
-    ...apiKeys.value.map((key) => ({
-      value: key.id,
-      label: key.name
-    }))
+    ...options
   ]
 })
 
@@ -782,13 +799,48 @@ const loadUsageLogs = async () => {
   }
 }
 
-const loadApiKeys = async () => {
+const loadApiKeys = async (search?: string, requestId = ++apiKeySearchRequestId) => {
+  apiKeySearchLoading.value = true
   try {
-    const response = await keysAPI.list(1, 100)
-    apiKeys.value = response.items
+    const filters = search?.trim() ? { search: search.trim() } : undefined
+    const response = await keysAPI.list(1, API_KEY_FILTER_PAGE_SIZE, filters)
+    if (requestId === apiKeySearchRequestId) {
+      apiKeys.value = response.items
+    }
   } catch (error) {
     console.error('Failed to load API keys:', error)
+  } finally {
+    if (requestId === apiKeySearchRequestId) {
+      apiKeySearchLoading.value = false
+    }
   }
+}
+
+const handleApiKeySearch = (query: string) => {
+  const requestId = ++apiKeySearchRequestId
+  apiKeySearchLoading.value = true
+  if (apiKeySearchTimer) {
+    clearTimeout(apiKeySearchTimer)
+  }
+  apiKeySearchTimer = setTimeout(() => {
+    apiKeySearchTimer = null
+    loadApiKeys(query, requestId)
+  }, 250)
+}
+
+const handleApiKeyChange = (
+  value: string | number | boolean | null,
+  option: { value: string | number | boolean | null; label: string } | null
+) => {
+  if (value === null) {
+    selectedApiKeyOption.value = null
+  } else if (option) {
+    selectedApiKeyOption.value = {
+      value: Number(option.value),
+      label: option.label
+    }
+  }
+  applyFilters()
 }
 
 const loadUsageStats = async () => {
@@ -992,5 +1044,11 @@ onMounted(() => {
   loadApiKeys()
   loadUsageLogs()
   loadUsageStats()
+})
+
+onUnmounted(() => {
+  if (apiKeySearchTimer) {
+    clearTimeout(apiKeySearchTimer)
+  }
 })
 </script>

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { flushPromises, mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
 
@@ -132,6 +132,10 @@ describe('user UsageView tooltip', () => {
     }
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('shows fast service tier and unit prices in user tooltip', async () => {
     query.mockResolvedValue({
       items: [
@@ -214,6 +218,165 @@ describe('user UsageView tooltip', () => {
     expect(text).toContain('$0.092883')
     expect(text).toContain('$5.0000 / 1M tokens')
     expect(text).toContain('$30.0000 / 1M tokens')
+  })
+
+  it('searches api keys remotely for the usage key filter', async () => {
+    vi.useFakeTimers()
+    query.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0,
+    })
+    getStatsByDateRange.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      avg_duration_ms: 0,
+    })
+    list
+      .mockResolvedValueOnce({
+        items: [{ id: 1, name: 'first-page-key' }],
+        total: 175,
+        pages: 9,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: 2, name: 'remote-only-key' }],
+        total: 1,
+        pages: 1,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: 1, name: 'first-page-key' }],
+        total: 175,
+        pages: 9,
+      })
+
+    const wrapper = mount(UsageView, {
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          TablePageLayout: TablePageLayoutStub,
+          Pagination: true,
+          EmptyState: true,
+          Select: true,
+          DateRangePicker: true,
+          DataTable: DataTableStub,
+          Icon: true,
+          Teleport: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    expect(list).toHaveBeenNthCalledWith(1, 1, 20, undefined)
+    expect(setupState.apiKeyOptions.map((option: { label: string }) => option.label)).toEqual([
+      'All API Keys',
+      'first-page-key',
+    ])
+
+    setupState.handleApiKeySearch('remote-only')
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(list).toHaveBeenNthCalledWith(2, 1, 20, { search: 'remote-only' })
+    expect(setupState.apiKeyOptions.map((option: { label: string }) => option.label)).toEqual([
+      'All API Keys',
+      'remote-only-key',
+    ])
+
+    setupState.handleApiKeyChange(2, { value: 2, label: 'remote-only-key' })
+    setupState.handleApiKeySearch('')
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(list).toHaveBeenNthCalledWith(3, 1, 20, undefined)
+    expect(setupState.apiKeyOptions.map((option: { label: string }) => option.label)).toEqual([
+      'All API Keys',
+      'remote-only-key',
+      'first-page-key',
+    ])
+    vi.useRealTimers()
+  })
+
+  it('ignores stale api key search responses while a new search is debounced', async () => {
+    vi.useFakeTimers()
+    query.mockResolvedValue({
+      items: [],
+      total: 0,
+      pages: 0,
+    })
+    getStatsByDateRange.mockResolvedValue({
+      total_requests: 0,
+      total_tokens: 0,
+      total_cost: 0,
+      avg_duration_ms: 0,
+    })
+
+    let resolveOldSearch: (value: unknown) => void = () => {}
+    const oldSearch = new Promise((resolve) => {
+      resolveOldSearch = resolve
+    })
+    list
+      .mockResolvedValueOnce({
+        items: [{ id: 1, name: 'first-page-key' }],
+        total: 175,
+        pages: 9,
+      })
+      .mockImplementationOnce(() => oldSearch as any)
+      .mockResolvedValueOnce({
+        items: [{ id: 3, name: 'current-result-key' }],
+        total: 1,
+        pages: 1,
+      })
+
+    const wrapper = mount(UsageView, {
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          TablePageLayout: TablePageLayoutStub,
+          Pagination: true,
+          EmptyState: true,
+          Select: true,
+          DateRangePicker: true,
+          DataTable: DataTableStub,
+          Icon: true,
+          Teleport: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    const setupState = (wrapper.vm as any).$?.setupState
+    setupState.handleApiKeySearch('old')
+    await vi.advanceTimersByTimeAsync(250)
+    expect(list).toHaveBeenNthCalledWith(2, 1, 20, { search: 'old' })
+
+    setupState.handleApiKeySearch('current')
+    resolveOldSearch({
+      items: [{ id: 2, name: 'old-result' }],
+      total: 1,
+      pages: 1,
+    })
+    await flushPromises()
+
+    expect(setupState.apiKeyOptions.map((option: { label: string }) => option.label)).toEqual([
+      'All API Keys',
+      'first-page-key',
+    ])
+
+    await vi.advanceTimersByTimeAsync(250)
+    await flushPromises()
+
+    expect(list).toHaveBeenNthCalledWith(3, 1, 20, { search: 'current' })
+    expect(setupState.apiKeyOptions.map((option: { label: string }) => option.label)).toEqual([
+      'All API Keys',
+      'current-result-key',
+    ])
+    vi.useRealTimers()
   })
 
   it('exports csv with input and output unit price columns', async () => {


### PR DESCRIPTION
## Background

The user usage page only loaded a small first page of API keys for the API key filter, then filtered that local list inside the select component. When a user had more keys than the initial page contained, keys outside that page could not be found from the usage filter even though they existed in the API keys page.

## Solution

- Add remote-search support to the shared Select component, including a loading state and search event.
- Change the user usage API key filter to debounce search input and query `/keys` with the search term.
- Keep the currently selected key option available after the dropdown refreshes back to the default page.
- Guard against stale in-flight search responses overwriting newer results.

## Tests

- `pnpm test:run src/views/user/__tests__/UsageView.spec.ts`
- `pnpm typecheck`