### PR TITLE
feat: add compact response header timeout

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -689,6 +689,9 @@ type GatewayConfig struct {
 	// OpenAIResponseHeaderTimeout: OpenAI/Codex 上游等待响应头的超时时间（秒），0表示无超时
 	// OpenAI/Codex 请求可能在上游排队较久；默认不使用通用响应头超时截断。
 	OpenAIResponseHeaderTimeout int `mapstructure:"openai_response_header_timeout"`
+	// CompactResponseHeaderTimeout: OpenAI /responses/compact 等待上游响应头的超时时间（秒）
+	// 0/未显式配置时跟随 ResponseHeaderTimeout；compact 请求仍使用独立 HTTP client。
+	CompactResponseHeaderTimeout int `mapstructure:"compact_response_header_timeout"`
 	// 请求体最大字节数，用于网关请求体大小限制
 	MaxBodySize int64 `mapstructure:"max_body_size"`
 	// 非流式上游响应体读取上限（字节），用于防止无界读取导致内存放大
@@ -1364,6 +1367,7 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 		}
 		// 配置文件不存在时使用默认值
 	}
+	compactResponseHeaderTimeoutExplicit := hasExplicitConfigOrEnv("gateway.compact_response_header_timeout", "GATEWAY_COMPACT_RESPONSE_HEADER_TIMEOUT")
 
 	var cfg Config
 	if err := viper.Unmarshal(&cfg); err != nil {
@@ -1429,6 +1433,9 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 			return nil, fmt.Errorf("read forced codex instructions template %q: %w", cfg.Gateway.ForcedCodexInstructionsTemplateFile, err)
 		}
 		cfg.Gateway.ForcedCodexInstructionsTemplate = string(content)
+	}
+	if !compactResponseHeaderTimeoutExplicit {
+		cfg.Gateway.CompactResponseHeaderTimeout = cfg.Gateway.ResponseHeaderTimeout
 	}
 
 	// 兼容旧键 gateway.openai_ws.sticky_previous_response_ttl_seconds。
@@ -1771,6 +1778,7 @@ func setDefaults() {
 	// Gateway
 	viper.SetDefault("gateway.response_header_timeout", 600) // 600秒(10分钟)等待上游响应头，LLM高负载时可能排队较久
 	viper.SetDefault("gateway.openai_response_header_timeout", 0)
+	viper.SetDefault("gateway.compact_response_header_timeout", 600)
 	viper.SetDefault("gateway.log_upstream_error_body", true)
 	viper.SetDefault("gateway.log_upstream_error_body_max_bytes", 2048)
 	viper.SetDefault("gateway.inject_beta_for_apikey", false)
@@ -2404,6 +2412,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Gateway.OpenAIResponseHeaderTimeout < 0 {
 		return fmt.Errorf("gateway.openai_response_header_timeout must be non-negative")
+	}
+	if c.Gateway.CompactResponseHeaderTimeout < 0 {
+		return fmt.Errorf("gateway.compact_response_header_timeout must be non-negative")
 	}
 	if strings.TrimSpace(c.Gateway.ConnectionPoolIsolation) != "" {
 		switch c.Gateway.ConnectionPoolIsolation {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -327,6 +327,41 @@ func TestLoadForcedCodexInstructionsTemplate(t *testing.T) {
 	require.Equal(t, "server-prefix\n\n{{ .ExistingInstructions }}", cfg.Gateway.ForcedCodexInstructionsTemplate)
 }
 
+func TestLoadCompactResponseHeaderTimeoutFollowsGatewayDefault(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("GATEWAY_RESPONSE_HEADER_TIMEOUT", "42")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 42, cfg.Gateway.ResponseHeaderTimeout)
+	require.Equal(t, 42, cfg.Gateway.CompactResponseHeaderTimeout)
+}
+
+func TestLoadCompactResponseHeaderTimeoutExplicitEnv(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("GATEWAY_RESPONSE_HEADER_TIMEOUT", "42")
+	t.Setenv("GATEWAY_COMPACT_RESPONSE_HEADER_TIMEOUT", "99")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 42, cfg.Gateway.ResponseHeaderTimeout)
+	require.Equal(t, 99, cfg.Gateway.CompactResponseHeaderTimeout)
+}
+
+func TestLoadCompactResponseHeaderTimeoutExplicitConfig(t *testing.T) {
+	resetViperWithJWTSecret(t)
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("gateway:\n  response_header_timeout: 42\n  compact_response_header_timeout: 88\n"), 0o644))
+	t.Setenv("DATA_DIR", tempDir)
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 42, cfg.Gateway.ResponseHeaderTimeout)
+	require.Equal(t, 88, cfg.Gateway.CompactResponseHeaderTimeout)
+}
+
 func TestLoadDefaultSecurityToggles(t *testing.T) {
 	resetViperWithJWTSecret(t)
 
@@ -1264,6 +1299,11 @@ func TestValidateConfigErrors(t *testing.T) {
 			name:    "gateway openai response header timeout",
 			mutate:  func(c *Config) { c.Gateway.OpenAIResponseHeaderTimeout = -1 },
 			wantErr: "gateway.openai_response_header_timeout",
+		},
+		{
+			name:    "gateway compact response header timeout",
+			mutate:  func(c *Config) { c.Gateway.CompactResponseHeaderTimeout = -1 },
+			wantErr: "gateway.compact_response_header_timeout",
 		},
 		{
 			name:    "gateway max idle conns",

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -256,11 +256,6 @@ func (s *httpUpstreamService) DoWithTLSOptions(req *http.Request, proxyURL strin
 	return resp, nil
 }
 
-// acquireClientWithTLS 获取或创建带 TLS 指纹的客户端
-func (s *httpUpstreamService) acquireClientWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile) (*upstreamClientEntry, error) {
-	return s.acquireClientWithTLSOptions(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, service.HTTPUpstreamOptions{})
-}
-
 func (s *httpUpstreamService) acquireClientWithTLSOptions(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, opts service.HTTPUpstreamOptions) (*upstreamClientEntry, error) {
 	return s.getClientEntryWithTLSOptions(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, opts, true, true)
 }

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -159,6 +159,10 @@ func NewHTTPUpstream(cfg *config.Config) service.HTTPUpstream {
 //   - 调用方必须关闭 resp.Body，否则会导致 inFlight 计数泄漏
 //   - inFlight > 0 的客户端不会被淘汰，确保活跃请求不被中断
 func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	return s.DoWithOptions(req, proxyURL, accountID, accountConcurrency, service.HTTPUpstreamOptions{})
+}
+
+func (s *httpUpstreamService) DoWithOptions(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, opts service.HTTPUpstreamOptions) (*http.Response, error) {
 	if err := s.validateRequestHost(req); err != nil {
 		return nil, err
 	}
@@ -168,7 +172,7 @@ func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID i
 	}
 
 	// 获取或创建对应的客户端，并标记请求占用
-	entry, err := s.acquireClientWithProfile(proxyURL, accountID, accountConcurrency, profile)
+	entry, err := s.acquireClientWithProfileAndOptions(proxyURL, accountID, accountConcurrency, profile, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -202,8 +206,12 @@ func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID i
 // profile 为 nil 时不启用 TLS 指纹，行为与 Do 方法相同。
 // profile 非 nil 时使用指定的 Profile 进行 TLS 指纹伪装。
 func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
+	return s.DoWithTLSOptions(req, proxyURL, accountID, accountConcurrency, profile, service.HTTPUpstreamOptions{})
+}
+
+func (s *httpUpstreamService) DoWithTLSOptions(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, opts service.HTTPUpstreamOptions) (*http.Response, error) {
 	if profile == nil {
-		return s.Do(req, proxyURL, accountID, accountConcurrency)
+		return s.DoWithOptions(req, proxyURL, accountID, accountConcurrency, opts)
 	}
 	upstreamProfile := service.HTTPUpstreamProfileDefault
 	if req != nil {
@@ -224,7 +232,7 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 		return nil, err
 	}
 
-	entry, err := s.acquireClientWithTLS(proxyURL, accountID, accountConcurrency, profile, upstreamProfile)
+	entry, err := s.acquireClientWithTLSOptions(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, opts)
 	if err != nil {
 		slog.Debug("tls_fingerprint_acquire_client_failed", "account_id", accountID, "error", err)
 		return nil, err
@@ -250,12 +258,20 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 
 // acquireClientWithTLS 获取或创建带 TLS 指纹的客户端
 func (s *httpUpstreamService) acquireClientWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile) (*upstreamClientEntry, error) {
-	return s.getClientEntryWithTLS(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, true, true)
+	return s.acquireClientWithTLSOptions(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, service.HTTPUpstreamOptions{})
+}
+
+func (s *httpUpstreamService) acquireClientWithTLSOptions(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, opts service.HTTPUpstreamOptions) (*upstreamClientEntry, error) {
+	return s.getClientEntryWithTLSOptions(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, opts, true, true)
 }
 
 // getClientEntryWithTLS 获取或创建带 TLS 指纹的客户端条目
 // TLS 指纹客户端使用独立的缓存键，与普通客户端隔离
 func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
+	return s.getClientEntryWithTLSOptions(proxyURL, accountID, accountConcurrency, profile, upstreamProfile, service.HTTPUpstreamOptions{}, markInFlight, enforceLimit)
+}
+
+func (s *httpUpstreamService) getClientEntryWithTLSOptions(proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, upstreamProfile service.HTTPUpstreamProfile, opts service.HTTPUpstreamOptions, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
 	isolation := s.getIsolationMode()
 	proxyKey, parsedProxy, err := normalizeProxyURL(proxyURL)
 	if err != nil {
@@ -263,9 +279,10 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 	}
 	settings := s.resolvePoolSettings(isolation, accountConcurrency)
 	settings = s.applyProfilePoolSettings(settings, upstreamProfile)
+	settings = s.applyRequestOptionsPoolSettings(settings, opts)
 	// TLS 指纹客户端使用独立的缓存键，加 "tls:" 前缀
-	cacheKey := "tls:" + buildCacheKey(isolation, proxyKey, accountID, upstreamProtocolModeDefault)
-	poolKey := buildPoolKey(settings, upstreamProtocolModeDefault) + ":tls"
+	cacheKey := "tls:" + appendRequestClassToKey(buildCacheKey(isolation, proxyKey, accountID, upstreamProtocolModeDefault), opts)
+	poolKey := appendRequestClassToKey(buildPoolKey(settings, upstreamProtocolModeDefault), opts) + ":tls"
 
 	now := time.Now()
 	nowUnix := now.UnixNano()
@@ -386,7 +403,11 @@ func (s *httpUpstreamService) acquireClient(proxyURL string, accountID int64, ac
 
 // acquireClientWithProfile 获取或创建客户端，并按请求 profile 选择协议策略。
 func (s *httpUpstreamService) acquireClientWithProfile(proxyURL string, accountID int64, accountConcurrency int, profile service.HTTPUpstreamProfile) (*upstreamClientEntry, error) {
-	return s.getClientEntry(proxyURL, accountID, accountConcurrency, profile, true, true)
+	return s.acquireClientWithProfileAndOptions(proxyURL, accountID, accountConcurrency, profile, service.HTTPUpstreamOptions{})
+}
+
+func (s *httpUpstreamService) acquireClientWithProfileAndOptions(proxyURL string, accountID int64, accountConcurrency int, profile service.HTTPUpstreamProfile, opts service.HTTPUpstreamOptions) (*upstreamClientEntry, error) {
+	return s.getClientEntryWithOptions(proxyURL, accountID, accountConcurrency, profile, opts, true, true)
 }
 
 // getOrCreateClient 获取或创建客户端
@@ -412,6 +433,10 @@ func (s *httpUpstreamService) getOrCreateClient(proxyURL string, accountID int64
 // markInFlight=true 时会标记进行中请求，用于请求路径防止被淘汰
 // enforceLimit=true 时会限制客户端数量，超限且无法淘汰时返回错误
 func (s *httpUpstreamService) getClientEntry(proxyURL string, accountID int64, accountConcurrency int, profile service.HTTPUpstreamProfile, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
+	return s.getClientEntryWithOptions(proxyURL, accountID, accountConcurrency, profile, service.HTTPUpstreamOptions{}, markInFlight, enforceLimit)
+}
+
+func (s *httpUpstreamService) getClientEntryWithOptions(proxyURL string, accountID int64, accountConcurrency int, profile service.HTTPUpstreamProfile, opts service.HTTPUpstreamOptions, markInFlight bool, enforceLimit bool) (*upstreamClientEntry, error) {
 	// 获取隔离模式
 	isolation := s.getIsolationMode()
 	// 标准化代理 URL 并解析
@@ -423,10 +448,11 @@ func (s *httpUpstreamService) getClientEntry(proxyURL string, accountID int64, a
 	protocolMode := s.resolveProtocolMode(profile, proxyKey, parsedProxy)
 	settings := s.resolvePoolSettings(isolation, accountConcurrency)
 	settings = s.applyProfilePoolSettings(settings, profile)
+	settings = s.applyRequestOptionsPoolSettings(settings, opts)
 	// 构建缓存键（根据隔离策略不同）
-	cacheKey := buildCacheKey(isolation, proxyKey, accountID, protocolMode)
+	cacheKey := appendRequestClassToKey(buildCacheKey(isolation, proxyKey, accountID, protocolMode), opts)
 	// 构建连接池配置键（用于检测配置变更）
-	poolKey := buildPoolKey(settings, protocolMode)
+	poolKey := appendRequestClassToKey(buildPoolKey(settings, protocolMode), opts)
 
 	now := time.Now()
 	nowUnix := now.UnixNano()
@@ -677,6 +703,13 @@ func (s *httpUpstreamService) applyProfilePoolSettings(settings poolSettings, pr
 	return settings
 }
 
+func (s *httpUpstreamService) applyRequestOptionsPoolSettings(settings poolSettings, opts service.HTTPUpstreamOptions) poolSettings {
+	if opts.CompactResponseHeaders {
+		settings.responseHeaderTimeout = compactResponseHeaderTimeout(s.cfg, settings.responseHeaderTimeout)
+	}
+	return settings
+}
+
 // buildPoolKey 构建连接池配置键，用于检测连接池配置变更。
 func buildPoolKey(settings poolSettings, protocolMode string) string {
 	base := fmt.Sprintf(
@@ -691,6 +724,26 @@ func buildPoolKey(settings poolSettings, protocolMode string) string {
 		return base
 	}
 	return base + "|proto:" + protocolMode
+}
+
+func appendRequestClassToKey(base string, opts service.HTTPUpstreamOptions) string {
+	if opts.CompactResponseHeaders {
+		return base + "|class:compact"
+	}
+	return base
+}
+
+func compactResponseHeaderTimeout(cfg *config.Config, fallback time.Duration) time.Duration {
+	if cfg == nil {
+		return fallback
+	}
+	if cfg.Gateway.CompactResponseHeaderTimeout > 0 {
+		return time.Duration(cfg.Gateway.CompactResponseHeaderTimeout) * time.Second
+	}
+	if cfg.Gateway.ResponseHeaderTimeout >= 0 {
+		return time.Duration(cfg.Gateway.ResponseHeaderTimeout) * time.Second
+	}
+	return fallback
 }
 
 // buildCacheKey 构建客户端缓存键

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -75,6 +75,72 @@ func (s *HTTPUpstreamSuite) TestCustomResponseHeaderTimeout() {
 	require.Equal(s.T(), 7*time.Second, transport.ResponseHeaderTimeout, "ResponseHeaderTimeout mismatch")
 }
 
+func (s *HTTPUpstreamSuite) TestCompactResponseHeaderTimeoutUsesDedicatedClient() {
+	s.cfg.Gateway = config.GatewayConfig{
+		ResponseHeaderTimeout:        7,
+		CompactResponseHeaderTimeout: 19,
+	}
+	svc := s.newService()
+
+	defaultEntry := mustGetOrCreateClient(s.T(), svc, "", 42, 0)
+	compactEntry, err := svc.getClientEntryWithOptions("", 42, 0, service.HTTPUpstreamProfileDefault, service.HTTPUpstreamOptions{CompactResponseHeaders: true}, false, false)
+	require.NoError(s.T(), err)
+	require.NotSame(s.T(), defaultEntry, compactEntry, "compact should use a dedicated client")
+
+	defaultTransport, ok := defaultEntry.client.Transport.(*http.Transport)
+	require.True(s.T(), ok, "expected default *http.Transport")
+	compactTransport, ok := compactEntry.client.Transport.(*http.Transport)
+	require.True(s.T(), ok, "expected compact *http.Transport")
+	require.Equal(s.T(), 7*time.Second, defaultTransport.ResponseHeaderTimeout)
+	require.Equal(s.T(), 19*time.Second, compactTransport.ResponseHeaderTimeout)
+	require.Equal(s.T(), 2, len(svc.clients), "default and compact clients should be cached separately")
+}
+
+func (s *HTTPUpstreamSuite) TestCompactResponseHeaderTimeoutFallbackStillDedicatedClient() {
+	s.cfg.Gateway = config.GatewayConfig{ResponseHeaderTimeout: 7}
+	svc := s.newService()
+
+	defaultEntry := mustGetOrCreateClient(s.T(), svc, "", 42, 0)
+	compactEntry, err := svc.getClientEntryWithOptions("", 42, 0, service.HTTPUpstreamProfileDefault, service.HTTPUpstreamOptions{CompactResponseHeaders: true}, false, false)
+	require.NoError(s.T(), err)
+	require.NotSame(s.T(), defaultEntry, compactEntry, "compact should use a dedicated client even when timeout matches")
+
+	defaultTransport, ok := defaultEntry.client.Transport.(*http.Transport)
+	require.True(s.T(), ok, "expected default *http.Transport")
+	compactTransport, ok := compactEntry.client.Transport.(*http.Transport)
+	require.True(s.T(), ok, "expected compact *http.Transport")
+	require.Equal(s.T(), 7*time.Second, defaultTransport.ResponseHeaderTimeout)
+	require.Equal(s.T(), 7*time.Second, compactTransport.ResponseHeaderTimeout)
+	require.Equal(s.T(), 2, len(svc.clients), "default and compact clients should be cached separately")
+}
+
+func (s *HTTPUpstreamSuite) TestCompactResponseHeaderTimeoutKeepsOpenAIProfileSeparate() {
+	s.cfg.Gateway = config.GatewayConfig{
+		ResponseHeaderTimeout:        600,
+		CompactResponseHeaderTimeout: 19,
+		OpenAIHTTP2: config.GatewayOpenAIHTTP2Config{
+			Enabled: true,
+		},
+	}
+	svc := s.newService()
+
+	openAIEntry, err := svc.getClientEntry("", 42, 0, service.HTTPUpstreamProfileOpenAI, false, false)
+	require.NoError(s.T(), err)
+	compactEntry, err := svc.getClientEntryWithOptions("", 42, 0, service.HTTPUpstreamProfileOpenAI, service.HTTPUpstreamOptions{CompactResponseHeaders: true}, false, false)
+	require.NoError(s.T(), err)
+	require.NotSame(s.T(), openAIEntry, compactEntry, "compact OpenAI requests should use a dedicated client")
+	require.Equal(s.T(), upstreamProtocolModeOpenAIH2, compactEntry.protocolMode)
+
+	openAITransport, ok := openAIEntry.client.Transport.(*http.Transport)
+	require.True(s.T(), ok, "expected OpenAI *http.Transport")
+	compactTransport, ok := compactEntry.client.Transport.(*http.Transport)
+	require.True(s.T(), ok, "expected compact *http.Transport")
+	require.Equal(s.T(), time.Duration(0), openAITransport.ResponseHeaderTimeout)
+	require.Equal(s.T(), 19*time.Second, compactTransport.ResponseHeaderTimeout)
+	require.True(s.T(), compactTransport.ForceAttemptHTTP2, "compact OpenAI profile should keep HTTP/2")
+	require.Equal(s.T(), 2, len(svc.clients), "OpenAI and compact clients should be cached separately")
+}
+
 // TestGetOrCreateClient_InvalidURLReturnsError 测试无效代理 URL 返回错误
 // 验证解析失败时拒绝回退到直连模式
 func (s *HTTPUpstreamSuite) TestGetOrCreateClient_InvalidURLReturnsError() {

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -766,7 +767,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 		proxyURL = account.Proxy.URL()
 	}
 
-	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	resp, err := s.doOpenAICompactProbeUpstream(req, proxyURL, account)
 	if err != nil {
 		if s.accountRepo != nil {
 			updates := buildOpenAICompactProbeExtraUpdates(nil, nil, err, time.Now())
@@ -805,6 +806,20 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 	s.sendEvent(c, TestEvent{Type: "content", Text: "Compact probe succeeded"})
 	s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
 	return nil
+}
+
+func (s *AccountTestService) doOpenAICompactProbeUpstream(req *http.Request, proxyURL string, account *Account) (*http.Response, error) {
+	if account == nil {
+		return nil, errors.New("openai account is nil")
+	}
+	var profile *tlsfingerprint.Profile
+	if s.tlsFPProfileService != nil {
+		profile = s.tlsFPProfileService.ResolveTLSProfile(account)
+	}
+	if upstream, ok := s.httpUpstream.(HTTPUpstreamWithOptions); ok {
+		return upstream.DoWithTLSOptions(req, proxyURL, account.ID, account.Concurrency, profile, HTTPUpstreamOptions{CompactResponseHeaders: true})
+	}
+	return s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, profile)
 }
 
 func (s *AccountTestService) reconcileOpenAI429State(ctx context.Context, account *Account, headers http.Header, body []byte) {

--- a/backend/internal/service/account_test_service_openai_compact_test.go
+++ b/backend/internal/service/account_test_service_openai_compact_test.go
@@ -61,6 +61,8 @@ func TestAccountTestService_TestAccountConnection_OpenAICompactOAuthSuccessPersi
 	require.Equal(t, codexCLIUserAgent, upstream.lastReq.Header.Get("User-Agent"))
 	require.Equal(t, "chatgpt-acc", upstream.lastReq.Header.Get("chatgpt-account-id"))
 	require.Equal(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Len(t, upstream.options, 1)
+	require.True(t, upstream.options[0].CompactResponseHeaders)
 
 	updates := <-updateCalls
 	require.Equal(t, true, updates["openai_compact_supported"])

--- a/backend/internal/service/http_upstream_port.go
+++ b/backend/internal/service/http_upstream_port.go
@@ -22,3 +22,18 @@ type HTTPUpstream interface {
 	// 支持按账号绑定的数据库 profile 或内置默认 profile。
 	DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error)
 }
+
+// HTTPUpstreamOptions carries request-class hints for upstream client selection.
+// The base HTTPUpstream interface remains small so existing tests and stubs do
+// not need to implement every optional transport profile.
+type HTTPUpstreamOptions struct {
+	// CompactResponseHeaders selects the dedicated /responses/compact HTTP client.
+	CompactResponseHeaders bool
+}
+
+// HTTPUpstreamWithOptions is implemented by upstream transports that can choose
+// a dedicated client/transport profile for special request classes.
+type HTTPUpstreamWithOptions interface {
+	DoWithOptions(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, opts HTTPUpstreamOptions) (*http.Response, error)
+	DoWithTLSOptions(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, opts HTTPUpstreamOptions) (*http.Response, error)
+}

--- a/backend/internal/service/openai_compact_model_mapping_test.go
+++ b/backend/internal/service/openai_compact_model_mapping_test.go
@@ -51,6 +51,8 @@ func TestOpenAIGatewayService_Forward_CompactOnlyModelMappingOverridesOAuthUpstr
 	require.Equal(t, "gpt-5.4", result.Model)
 	require.Equal(t, "gpt-5.4-openai-compact", result.UpstreamModel)
 	require.Equal(t, "gpt-5.4-openai-compact", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Len(t, upstream.options, 1)
+	require.True(t, upstream.options[0].CompactResponseHeaders)
 }
 
 func TestOpenAIGatewayService_Forward_NonCompactRequestIgnoresCompactOnlyModelMapping(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2051,6 +2051,18 @@ func (s *OpenAIGatewayService) GetAccessToken(ctx context.Context, account *Acco
 	}
 }
 
+func (s *OpenAIGatewayService) doOpenAIHTTPUpstream(req *http.Request, proxyURL string, account *Account, compact bool) (*http.Response, error) {
+	if account == nil {
+		return nil, errors.New("openai account is nil")
+	}
+	if compact {
+		if upstream, ok := s.httpUpstream.(HTTPUpstreamWithOptions); ok {
+			return upstream.DoWithOptions(req, proxyURL, account.ID, account.Concurrency, HTTPUpstreamOptions{CompactResponseHeaders: true})
+		}
+	}
+	return s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+}
+
 func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
 	case 401, 402, 403, 429, 529:
@@ -2786,7 +2798,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 		// Send request
 		upstreamStart := time.Now()
-		resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+		resp, err := s.doOpenAIHTTPUpstream(upstreamReq, proxyURL, account, isOpenAIResponsesCompactPath(c))
 		SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 		if err != nil {
 			// Ensure the client receives an error response (handlers assume Forward writes on non-failover errors).
@@ -3087,7 +3099,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 
 	upstreamStart := time.Now()
-	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	resp, err := s.doOpenAIHTTPUpstream(upstreamReq, proxyURL, account, isOpenAIResponsesCompactPath(c))
 	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 	if err != nil {
 		safeErr := sanitizeUpstreamErrorMessage(err.Error())

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -27,6 +27,7 @@ type httpUpstreamRecorder struct {
 	lastBody []byte
 	requests []*http.Request
 	bodies   [][]byte
+	options  []HTTPUpstreamOptions
 
 	resp      *http.Response
 	responses []*http.Response
@@ -56,6 +57,16 @@ func (u *httpUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID 
 
 func (u *httpUpstreamRecorder) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile) (*http.Response, error) {
 	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func (u *httpUpstreamRecorder) DoWithOptions(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, opts HTTPUpstreamOptions) (*http.Response, error) {
+	u.options = append(u.options, opts)
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func (u *httpUpstreamRecorder) DoWithTLSOptions(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, profile *tlsfingerprint.Profile, opts HTTPUpstreamOptions) (*http.Response, error) {
+	u.options = append(u.options, opts)
+	return u.DoWithTLS(req, proxyURL, accountID, accountConcurrency, profile)
 }
 
 func TestOpenAIGatewayService_ResponsesUnknownModelDoesNotFallbackToGPT54(t *testing.T) {
@@ -401,6 +412,8 @@ func TestOpenAIGatewayService_OAuthPassthrough_CompactUsesJSONAndKeepsNonStreami
 	require.NotEmpty(t, upstream.lastReq.Header.Get("Session_Id"))
 	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
 	require.Equal(t, "chatgpt-acc", upstream.lastReq.Header.Get("chatgpt-account-id"))
+	require.Len(t, upstream.options, 1)
+	require.True(t, upstream.options[0].CompactResponseHeaders)
 	require.Contains(t, rec.Body.String(), `"id":"cmp_123"`)
 }
 

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -152,6 +152,10 @@ gateway:
   # OpenAI/Codex upstream response header timeout (seconds, 0=disabled)
   # OpenAI/Codex 等待上游响应头超时时间（秒，0=禁用本地响应头超时）
   openai_response_header_timeout: 0
+  # Timeout for waiting upstream response headers on /responses/compact (seconds).
+  # Uncomment to override response_header_timeout; compact uses a dedicated client either way.
+  # /responses/compact 等待上游响应头超时时间（秒）。取消注释后覆盖 response_header_timeout；compact 始终使用独立客户端。
+  # compact_response_header_timeout: 600
   # Max request body size in bytes (default: 256MB)
   # 请求体最大字节数（默认 256MB）
   max_body_size: 268435456


### PR DESCRIPTION
## Summary
- 新增 `gateway.compact_response_header_timeout`，用于单独控制 OpenAI `/responses/compact` 等待上游响应头的超时时间。
- `/responses/compact` 首包/响应头等待时间通常比普通 Responses 请求更长；如果只调大全局 `gateway.response_header_timeout`，会让普通请求在上游异常慢、排队或卡住时更久占用用户并发、账号并发和连接资源，也会拖慢 failover。
- 因此拆成两个配置：普通请求继续使用 `gateway.response_header_timeout`，compact 请求使用独立配置；未显式配置 `compact_response_header_timeout` 时默认跟随普通配置，避免升级后行为变化。
- compact 请求始终使用独立 upstream HTTP client/cache profile，即使 timeout 数值与普通请求相同，也避免普通请求和 compact 请求共用同一个 transport 配置面。

Closes #2773

## Tests
- `go test ./internal/config ./internal/repository ./internal/service`