### PR TITLE
支持关闭自定义 iframe 参数传输

### DIFF
--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -9,13 +9,15 @@ import (
 
 // CustomMenuItem represents a user-configured custom menu entry.
 type CustomMenuItem struct {
-	ID         string `json:"id"`
-	Label      string `json:"label"`
-	IconSVG    string `json:"icon_svg"`
-	URL        string `json:"url"`
-	PageSlug   string `json:"page_slug,omitempty"`
-	Visibility string `json:"visibility"` // "user" or "admin"
-	SortOrder  int    `json:"sort_order"`
+	ID               string   `json:"id"`
+	Label            string   `json:"label"`
+	IconSVG          string   `json:"icon_svg"`
+	URL              string   `json:"url"`
+	PageSlug         string   `json:"page_slug,omitempty"`
+	Visibility       string   `json:"visibility"` // "user" or "admin"
+	SortOrder        int      `json:"sort_order"`
+	AppendEmbedParams bool     `json:"append_embed_params"`
+	EmbeddedParamKeys []string `json:"embedded_param_keys,omitempty"`
 }
 
 // CustomEndpoint represents an admin-configured API endpoint for quick copy.

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5694,6 +5694,8 @@ export default {
         visibility: 'Visible To',
         visibilityUser: 'Regular Users',
         visibilityAdmin: 'Administrators',
+        appendParams: 'Pass iframe parameters',
+        appendParamsHint: 'When enabled, user, token, theme, language, and source parameters are appended to the page URL. When disabled, the original URL is used.',
         add: 'Add Menu Item',
         remove: 'Remove',
         moveUp: 'Move Up',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5853,6 +5853,8 @@ export default {
         visibility: '可见角色',
         visibilityUser: '普通用户',
         visibilityAdmin: '管理员',
+        appendParams: '传递 iframe 参数',
+        appendParamsHint: '开启后会向页面 URL 追加用户、令牌、主题、语言和来源等参数；关闭后保持原始 URL 不变。',
         add: '添加菜单项',
         remove: '删除',
         moveUp: '上移',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -169,6 +169,8 @@ export interface CustomMenuItem {
   icon_svg: string
   url: string
   page_slug?: string
+  append_embed_params?: boolean
+  embedded_param_keys?: string[]
   visibility: 'user' | 'admin'
   sort_order: number
 }

--- a/frontend/src/utils/__tests__/embedded-url.spec.ts
+++ b/frontend/src/utils/__tests__/embedded-url.spec.ts
@@ -56,6 +56,40 @@ describe('embedded-url', () => {
     expect(url.searchParams.has('lang')).toBe(false)
   })
 
+  it('keeps original url when embedded params are disabled', () => {
+    const result = buildEmbeddedUrl(
+      'https://pay.example.com/checkout?plan=pro',
+      42,
+      'token-123',
+      'dark',
+      'zh-CN',
+      { appendParams: false },
+    )
+
+    expect(result).toBe('https://pay.example.com/checkout?plan=pro')
+  })
+
+  it('only appends selected embedded params', () => {
+    const result = buildEmbeddedUrl(
+      'https://pay.example.com/checkout?plan=pro',
+      42,
+      'token-123',
+      'dark',
+      'zh-CN',
+      { paramKeys: ['theme', 'lang'] },
+    )
+
+    const url = new URL(result)
+    expect(url.searchParams.get('plan')).toBe('pro')
+    expect(url.searchParams.get('theme')).toBe('dark')
+    expect(url.searchParams.get('lang')).toBe('zh-CN')
+    expect(url.searchParams.has('user_id')).toBe(false)
+    expect(url.searchParams.has('token')).toBe(false)
+    expect(url.searchParams.has('ui_mode')).toBe(false)
+    expect(url.searchParams.has('src_host')).toBe(false)
+    expect(url.searchParams.has('src_url')).toBe(false)
+  })
+
   it('returns original string for invalid url input', () => {
     expect(buildEmbeddedUrl('not a url', 1, 'token')).toBe('not a url')
   })

--- a/frontend/src/utils/embedded-url.ts
+++ b/frontend/src/utils/embedded-url.ts
@@ -1,9 +1,3 @@
-/**
- * Shared URL builder for iframe-embedded pages.
- * Used by PurchaseSubscriptionView and CustomPageView to build consistent URLs
- * with user_id, token, theme, lang, ui_mode, src_host, and src parameters.
- */
-
 const EMBEDDED_USER_ID_QUERY_KEY = 'user_id'
 const EMBEDDED_AUTH_TOKEN_QUERY_KEY = 'token'
 const EMBEDDED_THEME_QUERY_KEY = 'theme'
@@ -13,30 +7,62 @@ const EMBEDDED_UI_MODE_VALUE = 'embedded'
 const EMBEDDED_SRC_HOST_QUERY_KEY = 'src_host'
 const EMBEDDED_SRC_QUERY_KEY = 'src_url'
 
+export type EmbeddedQueryParamKey =
+  | 'user_id'
+  | 'token'
+  | 'theme'
+  | 'lang'
+  | 'ui_mode'
+  | 'src_host'
+  | 'src_url'
+
+export const DEFAULT_EMBEDDED_QUERY_PARAM_KEYS: EmbeddedQueryParamKey[] = [
+  'user_id',
+  'token',
+  'theme',
+  'lang',
+  'ui_mode',
+  'src_host',
+  'src_url',
+]
+
+export interface EmbeddedUrlOptions {
+  appendParams?: boolean
+  paramKeys?: EmbeddedQueryParamKey[]
+}
+
 export function buildEmbeddedUrl(
   baseUrl: string,
   userId?: number,
   authToken?: string | null,
   theme: 'light' | 'dark' = 'light',
   lang?: string,
+  options: EmbeddedUrlOptions = {},
 ): string {
   if (!baseUrl) return baseUrl
+  if (options.appendParams === false) return baseUrl
   try {
     const url = new URL(baseUrl)
-    if (userId) {
+    const paramKeys = new Set(options.paramKeys ?? DEFAULT_EMBEDDED_QUERY_PARAM_KEYS)
+    if (userId && paramKeys.has('user_id')) {
       url.searchParams.set(EMBEDDED_USER_ID_QUERY_KEY, String(userId))
     }
-    if (authToken) {
+    if (authToken && paramKeys.has('token')) {
       url.searchParams.set(EMBEDDED_AUTH_TOKEN_QUERY_KEY, authToken)
     }
-    url.searchParams.set(EMBEDDED_THEME_QUERY_KEY, theme)
-    if (lang) {
+    if (paramKeys.has('theme')) {
+      url.searchParams.set(EMBEDDED_THEME_QUERY_KEY, theme)
+    }
+    if (lang && paramKeys.has('lang')) {
       url.searchParams.set(EMBEDDED_LANG_QUERY_KEY, lang)
     }
-    url.searchParams.set(EMBEDDED_UI_MODE_QUERY_KEY, EMBEDDED_UI_MODE_VALUE)
-    // Source tracking: let the embedded page know where it's being loaded from
-    if (typeof window !== 'undefined') {
+    if (paramKeys.has('ui_mode')) {
+      url.searchParams.set(EMBEDDED_UI_MODE_QUERY_KEY, EMBEDDED_UI_MODE_VALUE)
+    }
+    if (typeof window !== 'undefined' && paramKeys.has('src_host')) {
       url.searchParams.set(EMBEDDED_SRC_HOST_QUERY_KEY, window.location.origin)
+    }
+    if (typeof window !== 'undefined' && paramKeys.has('src_url')) {
       url.searchParams.set(EMBEDDED_SRC_QUERY_KEY, window.location.href)
     }
     return url.toString()

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -4892,6 +4892,39 @@
                     />
                   </div>
 
+                  <div class="sm:col-span-2">
+                    <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                      <input
+                        :checked="item.append_embed_params !== false"
+                        type="checkbox"
+                        class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                        @change="item.append_embed_params = ($event.target as HTMLInputElement).checked"
+                      />
+                      {{ t("admin.settings.customMenu.appendParams") }}
+                    </label>
+                    <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.customMenu.appendParamsHint") }}
+                    </p>
+                    <div
+                      v-if="item.append_embed_params !== false"
+                      class="mt-3 grid grid-cols-2 gap-2 rounded-lg border border-gray-200 p-3 text-xs dark:border-dark-600 sm:grid-cols-4"
+                    >
+                      <label
+                        v-for="paramKey in embeddedParamKeyOptions"
+                        :key="paramKey"
+                        class="flex items-center gap-2 text-gray-600 dark:text-gray-300"
+                      >
+                        <input
+                          :checked="getMenuItemEmbeddedParamKeys(item).includes(paramKey)"
+                          type="checkbox"
+                          class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                          @change="toggleMenuItemEmbeddedParamKey(item, paramKey, ($event.target as HTMLInputElement).checked)"
+                        />
+                        {{ paramKey }}
+                      </label>
+                    </div>
+                  </div>
+
                   <!-- SVG Icon (full width) -->
                   <div class="sm:col-span-2">
                     <label
@@ -7030,6 +7063,8 @@ const form = reactive<SettingsForm>({
     label: string;
     icon_svg: string;
     url: string;
+    append_embed_params?: boolean;
+    embedded_param_keys?: string[];
     visibility: "user" | "admin";
     sort_order: number;
   }>,
@@ -7662,9 +7697,29 @@ function addMenuItem() {
     label: "",
     icon_svg: "",
     url: "",
+    append_embed_params: true,
+    embedded_param_keys: [...embeddedParamKeyOptions],
     visibility: "user",
     sort_order: form.custom_menu_items.length,
   });
+}
+
+const embeddedParamKeyOptions = ["user_id", "token", "theme", "lang", "ui_mode", "src_host", "src_url"];
+
+function getMenuItemEmbeddedParamKeys(item: { embedded_param_keys?: string[] }) {
+  return Array.isArray(item.embedded_param_keys)
+    ? item.embedded_param_keys
+    : embeddedParamKeyOptions;
+}
+
+function toggleMenuItemEmbeddedParamKey(item: { embedded_param_keys?: string[] }, key: string, checked: boolean) {
+  const keys = new Set(getMenuItemEmbeddedParamKeys(item));
+  if (checked) {
+    keys.add(key);
+  } else {
+    keys.delete(key);
+  }
+  item.embedded_param_keys = embeddedParamKeyOptions.filter((paramKey) => keys.has(paramKey));
 }
 
 function removeMenuItem(index: number) {

--- a/frontend/src/views/user/CustomPageView.vue
+++ b/frontend/src/views/user/CustomPageView.vue
@@ -124,7 +124,7 @@ import { useAuthStore } from '@/stores/auth'
 import { useAdminSettingsStore } from '@/stores/adminSettings'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
-import { buildEmbeddedUrl, detectTheme } from '@/utils/embedded-url'
+import { buildEmbeddedUrl, DEFAULT_EMBEDDED_QUERY_PARAM_KEYS, detectTheme, type EmbeddedQueryParamKey } from '@/utils/embedded-url'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 
@@ -174,12 +174,21 @@ const isMarkdownMode = computed(() => !!markdownSlug.value)
 
 const embeddedUrl = computed(() => {
   if (!menuItem.value || isMarkdownMode.value) return ''
+  const paramKeys = Array.isArray(menuItem.value.embedded_param_keys)
+    ? menuItem.value.embedded_param_keys.filter((key): key is EmbeddedQueryParamKey =>
+      DEFAULT_EMBEDDED_QUERY_PARAM_KEYS.includes(key as EmbeddedQueryParamKey)
+    )
+    : undefined
   return buildEmbeddedUrl(
     menuItem.value.url,
     authStore.user?.id,
     authStore.token,
     pageTheme.value,
     locale.value,
+    {
+      appendParams: menuItem.value.append_embed_params !== false,
+      paramKeys,
+    },
   )
 })
 


### PR DESCRIPTION
## 问题背景

自定义 iframe 页面当前会在生成目标 URL 时强制追加一组固定参数，包括 `user_id`、`token`、`theme`、`lang`、`ui_mode`、`src_host`、`src_url`。这个行为对已有使用场景有帮助，但缺少开关控制，管理员无法按页面实际需求决定是否传递这些参数。

## 风险点

- **目标站点参数冲突**：如果自定义 URL 本身已经使用 `token`、`theme`、`lang` 等参数，当前逻辑会直接覆盖同名参数，可能导致目标站点鉴权、主题、语言或业务状态异常。
- **用户隐私泄露**：`user_id`、`token`、`src_url` 等信息会被自动带到第三方页面，可能暴露用户身份、访问来源和当前页面地址。
- **自定义 URL 兼容性差**：部分外部页面不接受未知参数，或对来源、认证参数有严格校验，强制追加参数可能导致页面加载失败、跳转异常或业务逻辑误判。
- **配置灵活性不足**：管理员无法针对纯展示页、外部文档页、第三方系统入口等场景关闭参数传输。

## 修复方案

- 在自定义菜单配置中新增“传递 iframe 参数”开关。
- 为了兼容现有使用场景，旧配置默认保持开启状态，继续追加原有参数。
- 当管理员关闭开关时，iframe 直接使用原始 URL，不再追加固定参数。
- 保留参数自定义能力，开启传参后可按需选择 `user_id`、`token`、`theme`、`lang`、`ui_mode`、`src_host`、`src_url` 中需要传递的参数。
- 用户侧渲染 iframe 时根据菜单配置决定是否拼接参数。

## 验证

- `corepack pnpm exec vitest run src/utils/__tests__/embedded-url.spec.ts`
- `corepack pnpm typecheck`
- `git diff --check`

以上验证均已通过。