### PR TITLE
fix: search admin accounts by email

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -536,7 +536,10 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 		}
 	}
 	if search != "" {
-		q = q.Where(dbaccount.NameContainsFold(search))
+		q = q.Where(dbaccount.Or(
+			dbaccount.NameContainsFold(search),
+			accountEmailContainsFold(search),
+		))
 	}
 	if groupID == service.AccountListGroupUngrouped {
 		q = q.Where(dbaccount.Not(dbaccount.HasAccountGroups()))
@@ -580,6 +583,26 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 		return nil, nil, err
 	}
 	return outAccounts, paginationResultFromTotal(int64(total), params), nil
+}
+
+func accountEmailContainsFold(search string) dbpredicate.Account {
+	pattern := "%" + strings.ToLower(search) + "%"
+	return dbpredicate.Account(func(s *entsql.Selector) {
+		s.Where(entsql.Or(
+			jsonTextContainsFold(dbaccount.FieldExtra, "email_address", pattern),
+			jsonTextContainsFold(dbaccount.FieldExtra, "email", pattern),
+			jsonTextContainsFold(dbaccount.FieldCredentials, "email", pattern),
+		))
+	})
+}
+
+func jsonTextContainsFold(column, key, pattern string) *entsql.Predicate {
+	return entsql.P(func(b *entsql.Builder) {
+		b.WriteString("LOWER(COALESCE(")
+		b.Join(sqljson.ValuePath(column, sqljson.Path(key), sqljson.Unquote(true)))
+		b.WriteString(", '')) LIKE ")
+		b.Arg(pattern)
+	})
 }
 
 func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selector) {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -393,6 +393,42 @@ func (s *AccountRepoSuite) TestListWithFilters() {
 			},
 		},
 		{
+			name: "filter_by_extra_email_address",
+			setup: func(client *dbent.Client) {
+				mustCreateAccount(s.T(), client, &service.Account{Name: "openai-alpha", Extra: map[string]any{"email_address": "owner.alpha@example.com"}})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "openai-beta", Extra: map[string]any{"email_address": "owner.beta@example.com"}})
+			},
+			search:    "alpha@example",
+			wantCount: 1,
+			validate: func(accounts []service.Account) {
+				s.Require().Equal("openai-alpha", accounts[0].Name)
+			},
+		},
+		{
+			name: "filter_by_extra_email",
+			setup: func(client *dbent.Client) {
+				mustCreateAccount(s.T(), client, &service.Account{Name: "openai-extra-email", Extra: map[string]any{"email": "extra.owner@example.com"}})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "openai-other-email", Extra: map[string]any{"email": "other.owner@example.com"}})
+			},
+			search:    "extra.owner",
+			wantCount: 1,
+			validate: func(accounts []service.Account) {
+				s.Require().Equal("openai-extra-email", accounts[0].Name)
+			},
+		},
+		{
+			name: "filter_by_credentials_email",
+			setup: func(client *dbent.Client) {
+				mustCreateAccount(s.T(), client, &service.Account{Name: "openai-credentials-email", Credentials: map[string]any{"email": "credentials.owner@example.com"}})
+				mustCreateAccount(s.T(), client, &service.Account{Name: "openai-credentials-other", Credentials: map[string]any{"email": "other.credentials@example.com"}})
+			},
+			search:    "credentials.owner",
+			wantCount: 1,
+			validate: func(accounts []service.Account) {
+				s.Require().Equal("openai-credentials-email", accounts[0].Name)
+			},
+		},
+		{
 			name: "filter_by_ungrouped",
 			setup: func(client *dbent.Client) {
 				group := mustCreateGroup(s.T(), client, &service.Group{Name: "g-ungrouped"})


### PR DESCRIPTION
## 中文总结

- 账号管理列表现在可以通过已展示的账号邮箱进行搜索。
- 搜索范围从原来的账号名称扩展到 `extra.email_address`、`extra.email`、`credentials.email` 三个邮箱来源。
- 保持现有搜索框和 `search` 参数不变，可继续与平台、类型、状态、分组、隐私模式等筛选条件组合使用。
- 补充了 repository integration 测试，覆盖三种邮箱字段来源。

## Summary

- extend admin account search to match displayed account email fields
- search `extra.email_address`, `extra.email`, and `credentials.email` in addition to account name
- add repository integration coverage for all three email sources

Fixes #2783

## 测试验证

- `GOMODCACHE=/tmp/sub2api-gomodcache GOCACHE=/tmp/sub2api-gocache go test -tags integration ./internal/repository -run 'TestAccountRepoSuite/TestListWithFilters' -count=1 -v`
- `GOMODCACHE=/tmp/sub2api-gomodcache GOCACHE=/tmp/sub2api-gocache go test ./internal/service ./internal/handler/admin -run 'Account|AdminService_ListAccounts|AccountHandler' -count=1`

## Tests

- `GOMODCACHE=/tmp/sub2api-gomodcache GOCACHE=/tmp/sub2api-gocache go test -tags integration ./internal/repository -run 'TestAccountRepoSuite/TestListWithFilters' -count=1 -v`
- `GOMODCACHE=/tmp/sub2api-gomodcache GOCACHE=/tmp/sub2api-gocache go test ./internal/service ./internal/handler/admin -run 'Account|AdminService_ListAccounts|AccountHandler' -count=1`
