### PR TITLE
fix: add scroll for long model lists in available channels

### DIFF
--- a/frontend/src/components/channels/AvailableChannelsTable.vue
+++ b/frontend/src/components/channels/AvailableChannelsTable.vue
@@ -124,19 +124,21 @@
 
           <!-- 支持模型 -->
           <td class="align-top px-4 py-3">
-            <div class="flex flex-wrap gap-1">
-              <SupportedModelChip
-                v-for="m in section.supported_models"
-                :key="`${section.platform}-${m.name}`"
-                :model="m"
-                :pricing-key-prefix="pricingKeyPrefix"
-                :no-pricing-label="noPricingLabel"
-                :show-platform="false"
-                :platform-hint="section.platform"
-              />
-              <span v-if="section.supported_models.length === 0" class="text-xs text-gray-400">
-                {{ noModelsLabel }}
-              </span>
+            <div class="max-h-40 overflow-y-auto pr-1">
+              <div class="flex flex-wrap gap-1">
+                <SupportedModelChip
+                  v-for="m in section.supported_models"
+                  :key="`${section.platform}-${m.name}`"
+                  :model="m"
+                  :pricing-key-prefix="pricingKeyPrefix"
+                  :no-pricing-label="noPricingLabel"
+                  :show-platform="false"
+                  :platform-hint="section.platform"
+                />
+                <span v-if="section.supported_models.length === 0" class="text-xs text-gray-400">
+                  {{ noModelsLabel }}
+                </span>
+              </div>
             </div>
           </td>
         </tr>


### PR DESCRIPTION
## Summary
- add a vertical scroll area for supported models on the available channels page
- prevent models at the bottom of long per-channel model lists from being hidden
- keep the existing chip layout unchanged for shorter model lists

## Problem
On the available channels page, when a single channel contains many supported models, the model list can grow beyond the visible area and the models near the bottom become inaccessible because the cell does not provide a scrollable container.

## Changes
- wrap the supported models content in a max-height container with vertical scrolling
- update `frontend/src/components/channels/AvailableChannelsTable.vue`

## Test plan
- [ ] open the available channels page
- [ ] verify a channel with many supported models shows a vertical scrollbar
- [ ] verify the bottom models can be reached by scrolling
- [ ] verify channels with only a few models still render normally
