### PR TITLE
feat(gateway): add per-group auto mode classifier model rewrite

### DIFF
--- a/backend/ent/group.go
+++ b/backend/ent/group.go
@@ -127,6 +127,8 @@ type Group struct {
 	MessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config,omitempty"`
 	// 自定义 /v1/models 展示列表配置；仅影响模型列表响应，不影响调度
 	ModelsListConfig domain.GroupModelsListConfig `json:"models_list_config,omitempty"`
+	// Auto Mode 分类器请求使用的模型，空表示不改写
+	AutoModeClassifierModel string `json:"auto_mode_classifier_model,omitempty"`
 	// 分组 RPM 上限，0 表示不限制；设置后接管该分组用户的限流
 	RpmLimit int `json:"rpm_limit,omitempty"`
 	// OpenAI reasoning effort 上限；可选 minimal/low/medium/high/xhigh/max
@@ -253,7 +255,7 @@ func (*Group) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullFloat64)
 		case group.FieldID, group.FieldDefaultValidityDays, group.FieldFallbackGroupID, group.FieldFallbackGroupIDOnInvalidRequest, group.FieldSortOrder, group.FieldRpmLimit:
 			values[i] = new(sql.NullInt64)
-		case group.FieldName, group.FieldDescription, group.FieldPeakStart, group.FieldPeakEnd, group.FieldStatus, group.FieldDuplicateOperationID, group.FieldPlatform, group.FieldSubscriptionType, group.FieldDefaultMappedModel, group.FieldMaxReasoningEffort:
+		case group.FieldName, group.FieldDescription, group.FieldPeakStart, group.FieldPeakEnd, group.FieldStatus, group.FieldDuplicateOperationID, group.FieldPlatform, group.FieldSubscriptionType, group.FieldDefaultMappedModel, group.FieldAutoModeClassifierModel, group.FieldMaxReasoningEffort:
 			values[i] = new(sql.NullString)
 		case group.FieldCreatedAt, group.FieldUpdatedAt, group.FieldDeletedAt:
 			values[i] = new(sql.NullTime)
@@ -631,6 +633,12 @@ func (_m *Group) assignValues(columns []string, values []any) error {
 					return fmt.Errorf("unmarshal field models_list_config: %w", err)
 				}
 			}
+		case group.FieldAutoModeClassifierModel:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field auto_mode_classifier_model", values[i])
+			} else if value.Valid {
+				_m.AutoModeClassifierModel = value.String
+			}
 		case group.FieldRpmLimit:
 			if value, ok := values[i].(*sql.NullInt64); !ok {
 				return fmt.Errorf("unexpected type %T for field rpm_limit", values[i])
@@ -944,6 +952,9 @@ func (_m *Group) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("models_list_config=")
 	builder.WriteString(fmt.Sprintf("%v", _m.ModelsListConfig))
+	builder.WriteString(", ")
+	builder.WriteString("auto_mode_classifier_model=")
+	builder.WriteString(_m.AutoModeClassifierModel)
 	builder.WriteString(", ")
 	builder.WriteString("rpm_limit=")
 	builder.WriteString(fmt.Sprintf("%v", _m.RpmLimit))

--- a/backend/ent/group/group.go
+++ b/backend/ent/group/group.go
@@ -124,6 +124,8 @@ const (
 	FieldMessagesDispatchModelConfig = "messages_dispatch_model_config"
 	// FieldModelsListConfig holds the string denoting the models_list_config field in the database.
 	FieldModelsListConfig = "models_list_config"
+	// FieldAutoModeClassifierModel holds the string denoting the auto_mode_classifier_model field in the database.
+	FieldAutoModeClassifierModel = "auto_mode_classifier_model"
 	// FieldRpmLimit holds the string denoting the rpm_limit field in the database.
 	FieldRpmLimit = "rpm_limit"
 	// FieldMaxReasoningEffort holds the string denoting the max_reasoning_effort field in the database.
@@ -265,6 +267,7 @@ var Columns = []string{
 	FieldDefaultMappedModel,
 	FieldMessagesDispatchModelConfig,
 	FieldModelsListConfig,
+	FieldAutoModeClassifierModel,
 	FieldRpmLimit,
 	FieldMaxReasoningEffort,
 	FieldReasoningEffortMappings,
@@ -390,6 +393,10 @@ var (
 	DefaultMessagesDispatchModelConfig domain.OpenAIMessagesDispatchModelConfig
 	// DefaultModelsListConfig holds the default value on creation for the "models_list_config" field.
 	DefaultModelsListConfig domain.GroupModelsListConfig
+	// DefaultAutoModeClassifierModel holds the default value on creation for the "auto_mode_classifier_model" field.
+	DefaultAutoModeClassifierModel string
+	// AutoModeClassifierModelValidator is a validator for the "auto_mode_classifier_model" field. It is called by the builders before save.
+	AutoModeClassifierModelValidator func(string) error
 	// DefaultRpmLimit holds the default value on creation for the "rpm_limit" field.
 	DefaultRpmLimit int
 	// DefaultMaxReasoningEffort holds the default value on creation for the "max_reasoning_effort" field.
@@ -657,6 +664,11 @@ func ByRequirePrivacySet(opts ...sql.OrderTermOption) OrderOption {
 // ByDefaultMappedModel orders the results by the default_mapped_model field.
 func ByDefaultMappedModel(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldDefaultMappedModel, opts...).ToFunc()
+}
+
+// ByAutoModeClassifierModel orders the results by the auto_mode_classifier_model field.
+func ByAutoModeClassifierModel(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAutoModeClassifierModel, opts...).ToFunc()
 }
 
 // ByRpmLimit orders the results by the rpm_limit field.

--- a/backend/ent/group/where.go
+++ b/backend/ent/group/where.go
@@ -300,6 +300,11 @@ func DefaultMappedModel(v string) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldDefaultMappedModel, v))
 }
 
+// AutoModeClassifierModel applies equality check predicate on the "auto_mode_classifier_model" field. It's identical to AutoModeClassifierModelEQ.
+func AutoModeClassifierModel(v string) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldAutoModeClassifierModel, v))
+}
+
 // RpmLimit applies equality check predicate on the "rpm_limit" field. It's identical to RpmLimitEQ.
 func RpmLimit(v int) predicate.Group {
 	return predicate.Group(sql.FieldEQ(FieldRpmLimit, v))
@@ -2328,6 +2333,71 @@ func DefaultMappedModelEqualFold(v string) predicate.Group {
 // DefaultMappedModelContainsFold applies the ContainsFold predicate on the "default_mapped_model" field.
 func DefaultMappedModelContainsFold(v string) predicate.Group {
 	return predicate.Group(sql.FieldContainsFold(FieldDefaultMappedModel, v))
+}
+
+// AutoModeClassifierModelEQ applies the EQ predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelEQ(v string) predicate.Group {
+	return predicate.Group(sql.FieldEQ(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelNEQ applies the NEQ predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelNEQ(v string) predicate.Group {
+	return predicate.Group(sql.FieldNEQ(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelIn applies the In predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelIn(vs ...string) predicate.Group {
+	return predicate.Group(sql.FieldIn(FieldAutoModeClassifierModel, vs...))
+}
+
+// AutoModeClassifierModelNotIn applies the NotIn predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelNotIn(vs ...string) predicate.Group {
+	return predicate.Group(sql.FieldNotIn(FieldAutoModeClassifierModel, vs...))
+}
+
+// AutoModeClassifierModelGT applies the GT predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelGT(v string) predicate.Group {
+	return predicate.Group(sql.FieldGT(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelGTE applies the GTE predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelGTE(v string) predicate.Group {
+	return predicate.Group(sql.FieldGTE(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelLT applies the LT predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelLT(v string) predicate.Group {
+	return predicate.Group(sql.FieldLT(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelLTE applies the LTE predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelLTE(v string) predicate.Group {
+	return predicate.Group(sql.FieldLTE(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelContains applies the Contains predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelContains(v string) predicate.Group {
+	return predicate.Group(sql.FieldContains(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelHasPrefix applies the HasPrefix predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelHasPrefix(v string) predicate.Group {
+	return predicate.Group(sql.FieldHasPrefix(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelHasSuffix applies the HasSuffix predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelHasSuffix(v string) predicate.Group {
+	return predicate.Group(sql.FieldHasSuffix(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelEqualFold applies the EqualFold predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelEqualFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldEqualFold(FieldAutoModeClassifierModel, v))
+}
+
+// AutoModeClassifierModelContainsFold applies the ContainsFold predicate on the "auto_mode_classifier_model" field.
+func AutoModeClassifierModelContainsFold(v string) predicate.Group {
+	return predicate.Group(sql.FieldContainsFold(FieldAutoModeClassifierModel, v))
 }
 
 // RpmLimitEQ applies the EQ predicate on the "rpm_limit" field.

--- a/backend/ent/group_create.go
+++ b/backend/ent/group_create.go
@@ -753,6 +753,20 @@ func (_c *GroupCreate) SetNillableModelsListConfig(v *domain.GroupModelsListConf
 	return _c
 }
 
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (_c *GroupCreate) SetAutoModeClassifierModel(v string) *GroupCreate {
+	_c.mutation.SetAutoModeClassifierModel(v)
+	return _c
+}
+
+// SetNillableAutoModeClassifierModel sets the "auto_mode_classifier_model" field if the given value is not nil.
+func (_c *GroupCreate) SetNillableAutoModeClassifierModel(v *string) *GroupCreate {
+	if v != nil {
+		_c.SetAutoModeClassifierModel(*v)
+	}
+	return _c
+}
+
 // SetRpmLimit sets the "rpm_limit" field.
 func (_c *GroupCreate) SetRpmLimit(v int) *GroupCreate {
 	_c.mutation.SetRpmLimit(v)
@@ -1090,6 +1104,10 @@ func (_c *GroupCreate) defaults() error {
 		v := group.DefaultModelsListConfig
 		_c.mutation.SetModelsListConfig(v)
 	}
+	if _, ok := _c.mutation.AutoModeClassifierModel(); !ok {
+		v := group.DefaultAutoModeClassifierModel
+		_c.mutation.SetAutoModeClassifierModel(v)
+	}
 	if _, ok := _c.mutation.RpmLimit(); !ok {
 		v := group.DefaultRpmLimit
 		_c.mutation.SetRpmLimit(v)
@@ -1277,6 +1295,14 @@ func (_c *GroupCreate) check() error {
 	}
 	if _, ok := _c.mutation.ModelsListConfig(); !ok {
 		return &ValidationError{Name: "models_list_config", err: errors.New(`ent: missing required field "Group.models_list_config"`)}
+	}
+	if _, ok := _c.mutation.AutoModeClassifierModel(); !ok {
+		return &ValidationError{Name: "auto_mode_classifier_model", err: errors.New(`ent: missing required field "Group.auto_mode_classifier_model"`)}
+	}
+	if v, ok := _c.mutation.AutoModeClassifierModel(); ok {
+		if err := group.AutoModeClassifierModelValidator(v); err != nil {
+			return &ValidationError{Name: "auto_mode_classifier_model", err: fmt.Errorf(`ent: validator failed for field "Group.auto_mode_classifier_model": %w`, err)}
+		}
 	}
 	if _, ok := _c.mutation.RpmLimit(); !ok {
 		return &ValidationError{Name: "rpm_limit", err: errors.New(`ent: missing required field "Group.rpm_limit"`)}
@@ -1543,6 +1569,10 @@ func (_c *GroupCreate) createSpec() (*Group, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.ModelsListConfig(); ok {
 		_spec.SetField(group.FieldModelsListConfig, field.TypeJSON, value)
 		_node.ModelsListConfig = value
+	}
+	if value, ok := _c.mutation.AutoModeClassifierModel(); ok {
+		_spec.SetField(group.FieldAutoModeClassifierModel, field.TypeString, value)
+		_node.AutoModeClassifierModel = value
 	}
 	if value, ok := _c.mutation.RpmLimit(); ok {
 		_spec.SetField(group.FieldRpmLimit, field.TypeInt, value)
@@ -2609,6 +2639,18 @@ func (u *GroupUpsert) SetModelsListConfig(v domain.GroupModelsListConfig) *Group
 // UpdateModelsListConfig sets the "models_list_config" field to the value that was provided on create.
 func (u *GroupUpsert) UpdateModelsListConfig() *GroupUpsert {
 	u.SetExcluded(group.FieldModelsListConfig)
+	return u
+}
+
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (u *GroupUpsert) SetAutoModeClassifierModel(v string) *GroupUpsert {
+	u.Set(group.FieldAutoModeClassifierModel, v)
+	return u
+}
+
+// UpdateAutoModeClassifierModel sets the "auto_mode_classifier_model" field to the value that was provided on create.
+func (u *GroupUpsert) UpdateAutoModeClassifierModel() *GroupUpsert {
+	u.SetExcluded(group.FieldAutoModeClassifierModel)
 	return u
 }
 
@@ -3783,6 +3825,20 @@ func (u *GroupUpsertOne) SetModelsListConfig(v domain.GroupModelsListConfig) *Gr
 func (u *GroupUpsertOne) UpdateModelsListConfig() *GroupUpsertOne {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateModelsListConfig()
+	})
+}
+
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (u *GroupUpsertOne) SetAutoModeClassifierModel(v string) *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetAutoModeClassifierModel(v)
+	})
+}
+
+// UpdateAutoModeClassifierModel sets the "auto_mode_classifier_model" field to the value that was provided on create.
+func (u *GroupUpsertOne) UpdateAutoModeClassifierModel() *GroupUpsertOne {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateAutoModeClassifierModel()
 	})
 }
 
@@ -5138,6 +5194,20 @@ func (u *GroupUpsertBulk) SetModelsListConfig(v domain.GroupModelsListConfig) *G
 func (u *GroupUpsertBulk) UpdateModelsListConfig() *GroupUpsertBulk {
 	return u.Update(func(s *GroupUpsert) {
 		s.UpdateModelsListConfig()
+	})
+}
+
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (u *GroupUpsertBulk) SetAutoModeClassifierModel(v string) *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.SetAutoModeClassifierModel(v)
+	})
+}
+
+// UpdateAutoModeClassifierModel sets the "auto_mode_classifier_model" field to the value that was provided on create.
+func (u *GroupUpsertBulk) UpdateAutoModeClassifierModel() *GroupUpsertBulk {
+	return u.Update(func(s *GroupUpsert) {
+		s.UpdateAutoModeClassifierModel()
 	})
 }
 

--- a/backend/ent/group_update.go
+++ b/backend/ent/group_update.go
@@ -1026,6 +1026,20 @@ func (_u *GroupUpdate) SetNillableModelsListConfig(v *domain.GroupModelsListConf
 	return _u
 }
 
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (_u *GroupUpdate) SetAutoModeClassifierModel(v string) *GroupUpdate {
+	_u.mutation.SetAutoModeClassifierModel(v)
+	return _u
+}
+
+// SetNillableAutoModeClassifierModel sets the "auto_mode_classifier_model" field if the given value is not nil.
+func (_u *GroupUpdate) SetNillableAutoModeClassifierModel(v *string) *GroupUpdate {
+	if v != nil {
+		_u.SetAutoModeClassifierModel(*v)
+	}
+	return _u
+}
+
 // SetRpmLimit sets the "rpm_limit" field.
 func (_u *GroupUpdate) SetRpmLimit(v int) *GroupUpdate {
 	_u.mutation.ResetRpmLimit()
@@ -1449,6 +1463,11 @@ func (_u *GroupUpdate) check() error {
 			return &ValidationError{Name: "default_mapped_model", err: fmt.Errorf(`ent: validator failed for field "Group.default_mapped_model": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.AutoModeClassifierModel(); ok {
+		if err := group.AutoModeClassifierModelValidator(v); err != nil {
+			return &ValidationError{Name: "auto_mode_classifier_model", err: fmt.Errorf(`ent: validator failed for field "Group.auto_mode_classifier_model": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.MaxReasoningEffort(); ok {
 		if err := group.MaxReasoningEffortValidator(v); err != nil {
 			return &ValidationError{Name: "max_reasoning_effort", err: fmt.Errorf(`ent: validator failed for field "Group.max_reasoning_effort": %w`, err)}
@@ -1764,6 +1783,9 @@ func (_u *GroupUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.ModelsListConfig(); ok {
 		_spec.SetField(group.FieldModelsListConfig, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AutoModeClassifierModel(); ok {
+		_spec.SetField(group.FieldAutoModeClassifierModel, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.RpmLimit(); ok {
 		_spec.SetField(group.FieldRpmLimit, field.TypeInt, value)
@@ -3101,6 +3123,20 @@ func (_u *GroupUpdateOne) SetNillableModelsListConfig(v *domain.GroupModelsListC
 	return _u
 }
 
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (_u *GroupUpdateOne) SetAutoModeClassifierModel(v string) *GroupUpdateOne {
+	_u.mutation.SetAutoModeClassifierModel(v)
+	return _u
+}
+
+// SetNillableAutoModeClassifierModel sets the "auto_mode_classifier_model" field if the given value is not nil.
+func (_u *GroupUpdateOne) SetNillableAutoModeClassifierModel(v *string) *GroupUpdateOne {
+	if v != nil {
+		_u.SetAutoModeClassifierModel(*v)
+	}
+	return _u
+}
+
 // SetRpmLimit sets the "rpm_limit" field.
 func (_u *GroupUpdateOne) SetRpmLimit(v int) *GroupUpdateOne {
 	_u.mutation.ResetRpmLimit()
@@ -3537,6 +3573,11 @@ func (_u *GroupUpdateOne) check() error {
 			return &ValidationError{Name: "default_mapped_model", err: fmt.Errorf(`ent: validator failed for field "Group.default_mapped_model": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.AutoModeClassifierModel(); ok {
+		if err := group.AutoModeClassifierModelValidator(v); err != nil {
+			return &ValidationError{Name: "auto_mode_classifier_model", err: fmt.Errorf(`ent: validator failed for field "Group.auto_mode_classifier_model": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.MaxReasoningEffort(); ok {
 		if err := group.MaxReasoningEffortValidator(v); err != nil {
 			return &ValidationError{Name: "max_reasoning_effort", err: fmt.Errorf(`ent: validator failed for field "Group.max_reasoning_effort": %w`, err)}
@@ -3869,6 +3910,9 @@ func (_u *GroupUpdateOne) sqlSave(ctx context.Context) (_node *Group, err error)
 	}
 	if value, ok := _u.mutation.ModelsListConfig(); ok {
 		_spec.SetField(group.FieldModelsListConfig, field.TypeJSON, value)
+	}
+	if value, ok := _u.mutation.AutoModeClassifierModel(); ok {
+		_spec.SetField(group.FieldAutoModeClassifierModel, field.TypeString, value)
 	}
 	if value, ok := _u.mutation.RpmLimit(); ok {
 		_spec.SetField(group.FieldRpmLimit, field.TypeInt, value)

--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -949,6 +949,7 @@ var (
 		{Name: "default_mapped_model", Type: field.TypeString, Size: 100, Default: ""},
 		{Name: "messages_dispatch_model_config", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},
 		{Name: "models_list_config", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "auto_mode_classifier_model", Type: field.TypeString, Size: 100, Default: ""},
 		{Name: "rpm_limit", Type: field.TypeInt, Default: 0},
 		{Name: "max_reasoning_effort", Type: field.TypeString, Size: 20, Default: ""},
 		{Name: "reasoning_effort_mappings", Type: field.TypeJSON, SchemaType: map[string]string{"postgres": "jsonb"}},

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -21926,6 +21926,7 @@ type GroupMutation struct {
 	default_mapped_model                    *string
 	messages_dispatch_model_config          *domain.OpenAIMessagesDispatchModelConfig
 	models_list_config                      *domain.GroupModelsListConfig
+	auto_mode_classifier_model              *string
 	rpm_limit                               *int
 	addrpm_limit                            *int
 	max_reasoning_effort                    *string
@@ -24786,6 +24787,42 @@ func (m *GroupMutation) ResetModelsListConfig() {
 	m.models_list_config = nil
 }
 
+// SetAutoModeClassifierModel sets the "auto_mode_classifier_model" field.
+func (m *GroupMutation) SetAutoModeClassifierModel(s string) {
+	m.auto_mode_classifier_model = &s
+}
+
+// AutoModeClassifierModel returns the value of the "auto_mode_classifier_model" field in the mutation.
+func (m *GroupMutation) AutoModeClassifierModel() (r string, exists bool) {
+	v := m.auto_mode_classifier_model
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAutoModeClassifierModel returns the old "auto_mode_classifier_model" field's value of the Group entity.
+// If the Group object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *GroupMutation) OldAutoModeClassifierModel(ctx context.Context) (v string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAutoModeClassifierModel is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAutoModeClassifierModel requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAutoModeClassifierModel: %w", err)
+	}
+	return oldValue.AutoModeClassifierModel, nil
+}
+
+// ResetAutoModeClassifierModel resets all changes to the "auto_mode_classifier_model" field.
+func (m *GroupMutation) ResetAutoModeClassifierModel() {
+	m.auto_mode_classifier_model = nil
+}
+
 // SetRpmLimit sets the "rpm_limit" field.
 func (m *GroupMutation) SetRpmLimit(i int) {
 	m.rpm_limit = &i
@@ -25435,7 +25472,7 @@ func (m *GroupMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *GroupMutation) Fields() []string {
-	fields := make([]string, 0, 60)
+	fields := make([]string, 0, 61)
 	if m.created_at != nil {
 		fields = append(fields, group.FieldCreatedAt)
 	}
@@ -25598,6 +25635,9 @@ func (m *GroupMutation) Fields() []string {
 	if m.models_list_config != nil {
 		fields = append(fields, group.FieldModelsListConfig)
 	}
+	if m.auto_mode_classifier_model != nil {
+		fields = append(fields, group.FieldAutoModeClassifierModel)
+	}
 	if m.rpm_limit != nil {
 		fields = append(fields, group.FieldRpmLimit)
 	}
@@ -25732,6 +25772,8 @@ func (m *GroupMutation) Field(name string) (ent.Value, bool) {
 		return m.MessagesDispatchModelConfig()
 	case group.FieldModelsListConfig:
 		return m.ModelsListConfig()
+	case group.FieldAutoModeClassifierModel:
+		return m.AutoModeClassifierModel()
 	case group.FieldRpmLimit:
 		return m.RpmLimit()
 	case group.FieldMaxReasoningEffort:
@@ -25861,6 +25903,8 @@ func (m *GroupMutation) OldField(ctx context.Context, name string) (ent.Value, e
 		return m.OldMessagesDispatchModelConfig(ctx)
 	case group.FieldModelsListConfig:
 		return m.OldModelsListConfig(ctx)
+	case group.FieldAutoModeClassifierModel:
+		return m.OldAutoModeClassifierModel(ctx)
 	case group.FieldRpmLimit:
 		return m.OldRpmLimit(ctx)
 	case group.FieldMaxReasoningEffort:
@@ -26259,6 +26303,13 @@ func (m *GroupMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetModelsListConfig(v)
+		return nil
+	case group.FieldAutoModeClassifierModel:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAutoModeClassifierModel(v)
 		return nil
 	case group.FieldRpmLimit:
 		v, ok := value.(int)
@@ -26968,6 +27019,9 @@ func (m *GroupMutation) ResetField(name string) error {
 		return nil
 	case group.FieldModelsListConfig:
 		m.ResetModelsListConfig()
+		return nil
+	case group.FieldAutoModeClassifierModel:
+		m.ResetAutoModeClassifierModel()
 		return nil
 	case group.FieldRpmLimit:
 		m.ResetRpmLimit()

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -1183,30 +1183,36 @@ func init() {
 	groupDescModelsListConfig := groupFields[50].Descriptor()
 	// group.DefaultModelsListConfig holds the default value on creation for the models_list_config field.
 	group.DefaultModelsListConfig = groupDescModelsListConfig.Default.(domain.GroupModelsListConfig)
+	// groupDescAutoModeClassifierModel is the schema descriptor for auto_mode_classifier_model field.
+	groupDescAutoModeClassifierModel := groupFields[51].Descriptor()
+	// group.DefaultAutoModeClassifierModel holds the default value on creation for the auto_mode_classifier_model field.
+	group.DefaultAutoModeClassifierModel = groupDescAutoModeClassifierModel.Default.(string)
+	// group.AutoModeClassifierModelValidator is a validator for the "auto_mode_classifier_model" field. It is called by the builders before save.
+	group.AutoModeClassifierModelValidator = groupDescAutoModeClassifierModel.Validators[0].(func(string) error)
 	// groupDescRpmLimit is the schema descriptor for rpm_limit field.
-	groupDescRpmLimit := groupFields[51].Descriptor()
+	groupDescRpmLimit := groupFields[52].Descriptor()
 	// group.DefaultRpmLimit holds the default value on creation for the rpm_limit field.
 	group.DefaultRpmLimit = groupDescRpmLimit.Default.(int)
 	// groupDescMaxReasoningEffort is the schema descriptor for max_reasoning_effort field.
-	groupDescMaxReasoningEffort := groupFields[52].Descriptor()
+	groupDescMaxReasoningEffort := groupFields[53].Descriptor()
 	// group.DefaultMaxReasoningEffort holds the default value on creation for the max_reasoning_effort field.
 	group.DefaultMaxReasoningEffort = groupDescMaxReasoningEffort.Default.(string)
 	// group.MaxReasoningEffortValidator is a validator for the "max_reasoning_effort" field. It is called by the builders before save.
 	group.MaxReasoningEffortValidator = groupDescMaxReasoningEffort.Validators[0].(func(string) error)
 	// groupDescReasoningEffortMappings is the schema descriptor for reasoning_effort_mappings field.
-	groupDescReasoningEffortMappings := groupFields[53].Descriptor()
+	groupDescReasoningEffortMappings := groupFields[54].Descriptor()
 	// group.DefaultReasoningEffortMappings holds the default value on creation for the reasoning_effort_mappings field.
 	group.DefaultReasoningEffortMappings = groupDescReasoningEffortMappings.Default.([]domain.ReasoningEffortMapping)
 	// groupDescProfitControlEnabled is the schema descriptor for profit_control_enabled field.
-	groupDescProfitControlEnabled := groupFields[54].Descriptor()
+	groupDescProfitControlEnabled := groupFields[55].Descriptor()
 	// group.DefaultProfitControlEnabled holds the default value on creation for the profit_control_enabled field.
 	group.DefaultProfitControlEnabled = groupDescProfitControlEnabled.Default.(bool)
 	// groupDescProfitMinMargin is the schema descriptor for profit_min_margin field.
-	groupDescProfitMinMargin := groupFields[55].Descriptor()
+	groupDescProfitMinMargin := groupFields[56].Descriptor()
 	// group.DefaultProfitMinMargin holds the default value on creation for the profit_min_margin field.
 	group.DefaultProfitMinMargin = groupDescProfitMinMargin.Default.(float64)
 	// groupDescProfitSafetyBuffer is the schema descriptor for profit_safety_buffer field.
-	groupDescProfitSafetyBuffer := groupFields[56].Descriptor()
+	groupDescProfitSafetyBuffer := groupFields[57].Descriptor()
 	// group.DefaultProfitSafetyBuffer holds the default value on creation for the profit_safety_buffer field.
 	group.DefaultProfitSafetyBuffer = groupDescProfitSafetyBuffer.Default.(float64)
 	idempotencyrecordMixin := schema.IdempotencyRecord{}.Mixin()

--- a/backend/ent/schema/group.go
+++ b/backend/ent/schema/group.go
@@ -252,6 +252,12 @@ func (Group) Fields() []ent.Field {
 			SchemaType(map[string]string{dialect.Postgres: "jsonb"}).
 			Comment("自定义 /v1/models 展示列表配置；仅影响模型列表响应，不影响调度"),
 
+		// Claude Code Auto Mode 分类器模型（空字符串 = 不改写，使用原始模型）
+		field.String("auto_mode_classifier_model").
+			MaxLen(100).
+			Default("").
+			Comment("Auto Mode 分类器请求使用的模型，空表示不改写"),
+
 		// 分组级每分钟请求数上限（0 = 不限制）。设置后优先于用户级兜底生效。
 		field.Int("rpm_limit").
 			Default(0).

--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -150,6 +150,8 @@ type CreateGroupRequest struct {
 	DefaultMappedModel          string                                    `json:"default_mapped_model"`
 	MessagesDispatchModelConfig service.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
 	ModelsListConfig            service.GroupModelsListConfig             `json:"models_list_config"`
+	// Claude Code Auto Mode 分类器模型
+	AutoModeClassifierModel string `json:"auto_mode_classifier_model"`
 	// 分组 RPM 上限（0 = 不限制）
 	RPMLimit int `json:"rpm_limit"`
 	// OpenAI/Codex 请求推理强度上限，空字符串表示不限制。
@@ -217,6 +219,8 @@ type UpdateGroupRequest struct {
 	DefaultMappedModel          *string                                    `json:"default_mapped_model"`
 	MessagesDispatchModelConfig *service.OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config"`
 	ModelsListConfig            *service.GroupModelsListConfig             `json:"models_list_config"`
+	// Claude Code Auto Mode 分类器模型
+	AutoModeClassifierModel *string `json:"auto_mode_classifier_model"`
 	// 分组 RPM 上限（0 = 不限制）；nil 表示未提供不改动
 	RPMLimit *int `json:"rpm_limit"`
 	// OpenAI/Codex 请求推理强度上限；空字符串清除，nil 不修改。
@@ -549,6 +553,7 @@ func (h *GroupHandler) Create(c *gin.Context) {
 		DefaultMappedModel:              req.DefaultMappedModel,
 		MessagesDispatchModelConfig:     req.MessagesDispatchModelConfig,
 		ModelsListConfig:                req.ModelsListConfig,
+		AutoModeClassifierModel:         req.AutoModeClassifierModel,
 		RPMLimit:                        req.RPMLimit,
 		MaxReasoningEffort:              req.MaxReasoningEffort,
 		ReasoningEffortMappings:         req.ReasoningEffortMappings,
@@ -676,6 +681,7 @@ func (h *GroupHandler) Update(c *gin.Context) {
 		DefaultMappedModel:              req.DefaultMappedModel,
 		MessagesDispatchModelConfig:     req.MessagesDispatchModelConfig,
 		ModelsListConfig:                req.ModelsListConfig,
+		AutoModeClassifierModel:         req.AutoModeClassifierModel,
 		RPMLimit:                        req.RPMLimit,
 		MaxReasoningEffort:              req.MaxReasoningEffort,
 		ReasoningEffortMappings:         req.ReasoningEffortMappings,

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -156,6 +156,7 @@ func GroupFromServiceAdmin(g *service.Group) *AdminGroup {
 		MessagesDispatchModelConfig: g.MessagesDispatchModelConfig,
 		ModelsListConfig:            g.ModelsListConfig,
 		SupportedModelScopes:        g.SupportedModelScopes,
+		AutoModeClassifierModel:     g.AutoModeClassifierModel,
 		AccountCount:                g.AccountCount,
 		ActiveAccountCount:          g.ActiveAccountCount,
 		RateLimitedAccountCount:     g.RateLimitedAccountCount,
@@ -633,6 +634,12 @@ func usageLogFromServiceUser(l *service.UsageLog) UsageLog {
 	if requestedModel == "" {
 		requestedModel = l.Model
 	}
+	var upstreamModel *string
+	if l.UpstreamModel != nil {
+		upstreamModel = l.UpstreamModel
+	} else if requestedModel != l.Model {
+		upstreamModel = &l.Model
+	}
 	return UsageLog{
 		ID:                        l.ID,
 		UserID:                    l.UserID,
@@ -640,6 +647,7 @@ func usageLogFromServiceUser(l *service.UsageLog) UsageLog {
 		AccountID:                 l.AccountID,
 		RequestID:                 l.RequestID,
 		Model:                     requestedModel,
+		UpstreamModel:             upstreamModel,
 		ServiceTier:               l.ServiceTier,
 		ReasoningEffort:           l.ReasoningEffort,
 		InboundEndpoint:           l.InboundEndpoint,
@@ -709,7 +717,6 @@ func UsageLogFromServiceAdmin(l *service.UsageLog) *AdminUsageLog {
 	usageLog.UpstreamEndpoint = l.UpstreamEndpoint
 	return &AdminUsageLog{
 		UsageLog:              usageLog,
-		UpstreamModel:         l.UpstreamModel,
 		UpstreamResponseModel: l.UpstreamResponseModel,
 		UpstreamModelMismatch: l.UpstreamModelMismatch,
 		ChannelID:             l.ChannelID,

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -181,7 +181,11 @@ type AdminGroup struct {
 	ModelsListConfig            domain.GroupModelsListConfig             `json:"models_list_config"`
 
 	// 支持的模型系列（仅 antigravity 平台使用）
-	SupportedModelScopes    []string       `json:"supported_model_scopes"`
+	SupportedModelScopes []string `json:"supported_model_scopes"`
+
+	// Claude Code Auto Mode 分类器模型
+	AutoModeClassifierModel string `json:"auto_mode_classifier_model"`
+
 	AccountGroups           []AccountGroup `json:"account_groups,omitempty"`
 	AccountCount            int64          `json:"account_count,omitempty"`
 	ActiveAccountCount      int64          `json:"active_account_count,omitempty"`
@@ -481,7 +485,8 @@ type UsageLog struct {
 	APIKeyID  int64  `json:"api_key_id"`
 	AccountID int64  `json:"account_id"`
 	RequestID string `json:"request_id"`
-	Model     string `json:"model"`
+	Model         string  `json:"model"`
+	UpstreamModel *string `json:"upstream_model,omitempty"`
 	// ServiceTier records the OpenAI service tier used for billing, e.g. "priority" / "flex".
 	ServiceTier *string `json:"service_tier,omitempty"`
 	// ReasoningEffort is the request's reasoning effort level.
@@ -558,9 +563,6 @@ type UsageLog struct {
 type AdminUsageLog struct {
 	UsageLog
 
-	// UpstreamModel is the actual model sent to the upstream provider after mapping.
-	// Omitted when no mapping was applied (requested model was used as-is).
-	UpstreamModel *string `json:"upstream_model,omitempty"`
 	// UpstreamResponseModel is the raw model declared by the upstream response.
 	UpstreamResponseModel *string `json:"upstream_response_model,omitempty"`
 	// UpstreamModelMismatch is nil when the upstream did not declare a model.

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -221,6 +221,7 @@ func (r *apiKeyRepository) GetByKeyForAuth(ctx context.Context, key string) (*se
 				group.FieldProfitControlEnabled,
 				group.FieldProfitMinMargin,
 				group.FieldProfitSafetyBuffer,
+				group.FieldAutoModeClassifierModel,
 			)
 		}).
 		Only(ctx)
@@ -996,6 +997,7 @@ func groupEntityToService(g *dbent.Group) *service.Group {
 		DefaultMappedModel:              g.DefaultMappedModel,
 		MessagesDispatchModelConfig:     g.MessagesDispatchModelConfig,
 		ModelsListConfig:                g.ModelsListConfig,
+		AutoModeClassifierModel:         g.AutoModeClassifierModel,
 		RPMLimit:                        g.RpmLimit,
 		MaxReasoningEffort:              g.MaxReasoningEffort,
 		ReasoningEffortMappings:         g.ReasoningEffortMappings,

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -110,7 +110,8 @@ func createGroupRecord(ctx context.Context, client *dbent.Client, groupIn *servi
 		SetPeakRateMultiplier(groupIn.PeakRateMultiplier).
 		SetProfitControlEnabled(groupIn.ProfitControlEnabled).
 		SetProfitMinMargin(groupIn.ProfitMinMargin).
-		SetProfitSafetyBuffer(groupIn.ProfitSafetyBuffer)
+		SetProfitSafetyBuffer(groupIn.ProfitSafetyBuffer).
+		SetAutoModeClassifierModel(groupIn.AutoModeClassifierModel)
 	if groupIn.DuplicateOperationID != "" {
 		builder = builder.SetDuplicateOperationID(groupIn.DuplicateOperationID)
 	}
@@ -280,7 +281,8 @@ func (r *groupRepository) Update(ctx context.Context, groupIn *service.Group) er
 		SetPeakRateMultiplier(groupIn.PeakRateMultiplier).
 		SetProfitControlEnabled(groupIn.ProfitControlEnabled).
 		SetProfitMinMargin(groupIn.ProfitMinMargin).
-		SetProfitSafetyBuffer(groupIn.ProfitSafetyBuffer)
+		SetProfitSafetyBuffer(groupIn.ProfitSafetyBuffer).
+		SetAutoModeClassifierModel(groupIn.AutoModeClassifierModel)
 
 	// 显式处理可空字段：nil 需要 clear，非 nil 需要 set。
 	if groupIn.DailyLimitUSD != nil {

--- a/backend/internal/service/admin_group.go
+++ b/backend/internal/service/admin_group.go
@@ -499,6 +499,7 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 		DefaultMappedModel:              input.DefaultMappedModel,
 		MessagesDispatchModelConfig:     normalizeOpenAIMessagesDispatchModelConfig(input.MessagesDispatchModelConfig),
 		ModelsListConfig:                normalizeGroupModelsListConfig(input.ModelsListConfig),
+		AutoModeClassifierModel:         strings.TrimSpace(input.AutoModeClassifierModel),
 		RPMLimit:                        input.RPMLimit,
 		MaxReasoningEffort:              maxReasoningEffort,
 		ReasoningEffortMappings:         reasoningEffortMappings,
@@ -852,6 +853,9 @@ func (s *adminServiceImpl) UpdateGroup(ctx context.Context, id int64, input *Upd
 	}
 	if input.ModelsListConfig != nil {
 		group.ModelsListConfig = normalizeGroupModelsListConfig(*input.ModelsListConfig)
+	}
+	if input.AutoModeClassifierModel != nil {
+		group.AutoModeClassifierModel = strings.TrimSpace(*input.AutoModeClassifierModel)
 	}
 	if input.RPMLimit != nil {
 		group.RPMLimit = *input.RPMLimit

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -266,6 +266,8 @@ type CreateGroupInput struct {
 	RequirePrivacySet           bool
 	MessagesDispatchModelConfig OpenAIMessagesDispatchModelConfig
 	ModelsListConfig            GroupModelsListConfig
+	// AutoModeClassifierModel Claude Code Auto Mode 分类器请求改写为此模型，空字符串表示不改写
+	AutoModeClassifierModel string
 	// RPMLimit 分组 RPM 上限（0 = 不限制）
 	RPMLimit int
 	// MaxReasoningEffort OpenAI/Codex 请求的推理强度上限，空字符串表示不限制。
@@ -339,6 +341,8 @@ type UpdateGroupInput struct {
 	RequirePrivacySet           *bool
 	MessagesDispatchModelConfig *OpenAIMessagesDispatchModelConfig
 	ModelsListConfig            *GroupModelsListConfig
+	// AutoModeClassifierModel Claude Code Auto Mode 分类器请求改写为此模型，nil 表示未提供不改动
+	AutoModeClassifierModel *string
 	// RPMLimit 分组 RPM 上限（0 = 不限制），nil 表示未提供不改动。
 	RPMLimit *int
 	// MaxReasoningEffort 空字符串表示清除上限；nil 表示未提供不改动。

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -130,6 +130,9 @@ type APIKeyAuthGroupSnapshot struct {
 	ProfitControlEnabled bool    `json:"profit_control_enabled"`
 	ProfitMinMargin      float64 `json:"profit_min_margin"`
 	ProfitSafetyBuffer   float64 `json:"profit_safety_buffer"`
+
+	// AutoModeClassifierModel 分组级 Claude Code auto mode 分类器模型改写目标（空 = 不改写）。
+	AutoModeClassifierModel string `json:"auto_mode_classifier_model,omitempty"`
 }
 
 // APIKeyAuthCacheEntry 缓存条目，支持负缓存

--- a/backend/internal/service/api_key_auth_cache_impl.go
+++ b/backend/internal/service/api_key_auth_cache_impl.go
@@ -428,6 +428,7 @@ func (s *APIKeyService) snapshotFromAPIKey(ctx context.Context, apiKey *APIKey) 
 			ProfitControlEnabled:            apiKey.Group.ProfitControlEnabled,
 			ProfitMinMargin:                 apiKey.Group.ProfitMinMargin,
 			ProfitSafetyBuffer:              apiKey.Group.ProfitSafetyBuffer,
+			AutoModeClassifierModel:         apiKey.Group.AutoModeClassifierModel,
 		}
 	}
 	return snapshot
@@ -523,6 +524,7 @@ func (s *APIKeyService) snapshotToAPIKey(key string, snapshot *APIKeyAuthSnapsho
 			ProfitControlEnabled:            snapshot.Group.ProfitControlEnabled,
 			ProfitMinMargin:                 snapshot.Group.ProfitMinMargin,
 			ProfitSafetyBuffer:              snapshot.Group.ProfitSafetyBuffer,
+			AutoModeClassifierModel:         snapshot.Group.AutoModeClassifierModel,
 		}
 	}
 	s.compileAPIKeyIPRules(apiKey)

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 
 	"github.com/gin-gonic/gin"
@@ -257,6 +258,26 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// 强制执行 cache_control 块数量限制（最多 4 个）
 	if err := replaceBody(enforceCacheControlLimit(body)); err != nil {
 		return nil, err
+	}
+
+	// Claude Code Auto Mode 分类器模型改写：
+	// 当请求来自 Claude Code 客户端、非流式、未开启 thinking 时，
+	// 判定为 auto mode 分类器请求，改写为分组配置的廉价模型以节省 token 费用。
+	if isClaudeCode && !reqStream && !parsed.ThinkingEnabled {
+		if group, ok := ctx.Value(ctxkey.Group).(*Group); ok && IsGroupContextValid(group) && group.AutoModeClassifierModel != "" {
+			classifierModel := group.AutoModeClassifierModel
+			if err := replaceBody(s.replaceModelInBody(body, classifierModel)); err != nil {
+				return nil, err
+			}
+			logger.LegacyPrintf("service.gateway", "Auto mode classifier model rewrite: %s -> %s (group: %s)", reqModel, classifierModel, group.Name)
+			reqModel = classifierModel
+			originalModel = classifierModel
+			parsed.Model = classifierModel
+			if c != nil && c.Request != nil {
+				newCtx := context.WithValue(c.Request.Context(), ctxkey.Model, classifierModel)
+				c.Request = c.Request.WithContext(newCtx)
+			}
+		}
 	}
 
 	// 应用模型映射：

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -101,6 +101,9 @@ type Group struct {
 	MessagesDispatchModelConfig OpenAIMessagesDispatchModelConfig
 	ModelsListConfig            GroupModelsListConfig
 
+	// AutoModeClassifierModel Claude Code Auto Mode 分类器请求使用的模型，空字符串表示不改写
+	AutoModeClassifierModel string
+
 	// RPMLimit 分组级每分钟请求数上限（0 = 不限制）。
 	// 一旦设置即接管该分组用户的限流（覆盖用户级 rpm_limit），可被 user-group rpm_override 进一步覆盖。
 	RPMLimit int

--- a/backend/migrations/221_add_group_auto_mode_classifier_model.sql
+++ b/backend/migrations/221_add_group_auto_mode_classifier_model.sql
@@ -1,0 +1,4 @@
+-- Add auto_mode_classifier_model column to groups table
+-- Stores the model to use for Claude Code auto mode classifier requests (sync, no thinking).
+-- Empty string means no rewrite (use original model).
+ALTER TABLE groups ADD COLUMN IF NOT EXISTS auto_mode_classifier_model VARCHAR(100) NOT NULL DEFAULT '';

--- a/frontend/src/i18n/locales/en/admin/overview.ts
+++ b/frontend/src/i18n/locales/en/admin/overview.ts
@@ -1100,7 +1100,10 @@ export default {
         disabled: 'Allow All Clients',
         fallbackGroup: 'Fallback Group',
         fallbackHint: 'Non-Claude Code requests will use this group. Leave empty to reject directly.',
-        noFallback: 'No Fallback (Reject)'
+        noFallback: 'No Fallback (Reject)',
+        classifierModel: 'Auto Mode Classifier Model',
+        classifierModelPlaceholder: 'e.g. claude-haiku-4-5-20251001',
+        classifierModelHint: 'When set, Claude Code auto mode classifier requests (sync, no reasoning) will use this model instead. Leave empty to keep original model.'
       },
       openaiMessages: {
         title: 'OpenAI Messages Dispatch',

--- a/frontend/src/i18n/locales/zh/admin/overview.ts
+++ b/frontend/src/i18n/locales/zh/admin/overview.ts
@@ -1098,7 +1098,10 @@ export default {
         disabled: '允许所有客户端',
         fallbackGroup: '降级分组',
         fallbackHint: '非 Claude Code 请求将使用此分组，留空则直接拒绝',
-        noFallback: '不降级（直接拒绝）'
+        noFallback: '不降级（直接拒绝）',
+        classifierModel: 'Auto Mode 分类器模型',
+        classifierModelPlaceholder: '例如 claude-haiku-4-5-20251001',
+        classifierModelHint: '设置后，Claude Code Auto Mode 的分类器请求（同步、无推理）将改用此模型，留空则不改写'
       },
       openaiMessages: {
         title: 'OpenAI Messages 调度配置',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -620,6 +620,9 @@ export interface AdminGroup extends Group {
   // 支持的模型系列（仅 antigravity 平台使用）
   supported_model_scopes?: string[]
 
+  // Claude Code Auto Mode 分类器模型
+  auto_mode_classifier_model?: string
+
   // 分组下账号数量（仅管理员可见）
   account_count?: number
   active_account_count?: number
@@ -809,6 +812,7 @@ export interface CreateGroupRequest {
   rpm_limit?: number
   max_reasoning_effort?: string
   reasoning_effort_mappings?: ReasoningEffortMapping[]
+  auto_mode_classifier_model?: string
   require_oauth_only?: boolean
   require_privacy_set?: boolean
   // 从指定分组复制账号
@@ -869,6 +873,7 @@ export interface UpdateGroupRequest {
   rpm_limit?: number
   max_reasoning_effort?: string
   reasoning_effort_mappings?: ReasoningEffortMapping[]
+  auto_mode_classifier_model?: string
   require_oauth_only?: boolean
   require_privacy_set?: boolean
   copy_accounts_from_group_ids?: number[]
@@ -1617,6 +1622,7 @@ export interface UsageLog {
   account_id: number | null
   request_id: string
   model: string
+  upstream_model?: string | null
   service_tier?: string | null
   reasoning_effort?: string | null
   inbound_endpoint?: string | null

--- a/frontend/src/views/admin/GroupsView.vue
+++ b/frontend/src/views/admin/GroupsView.vue
@@ -1446,6 +1446,21 @@
               {{ t("admin.groups.claudeCode.fallbackHint") }}
             </p>
           </div>
+          <!-- Auto Mode 分类器模型 -->
+          <div class="mt-3">
+            <label class="input-label">{{
+              t("admin.groups.claudeCode.classifierModel")
+            }}</label>
+            <input
+              v-model="createForm.auto_mode_classifier_model"
+              type="text"
+              class="input"
+              :placeholder="t('admin.groups.claudeCode.classifierModelPlaceholder')"
+            />
+            <p class="input-hint">
+              {{ t("admin.groups.claudeCode.classifierModelHint") }}
+            </p>
+          </div>
         </div>
 
         <!-- Codex 网页搜索按次计费（仅 openai 平台） -->
@@ -3147,6 +3162,21 @@
             />
             <p class="input-hint">
               {{ t("admin.groups.claudeCode.fallbackHint") }}
+            </p>
+          </div>
+          <!-- Auto Mode 分类器模型 -->
+          <div class="mt-3">
+            <label class="input-label">{{
+              t("admin.groups.claudeCode.classifierModel")
+            }}</label>
+            <input
+              v-model="editForm.auto_mode_classifier_model"
+              type="text"
+              class="input"
+              :placeholder="t('admin.groups.claudeCode.classifierModelPlaceholder')"
+            />
+            <p class="input-hint">
+              {{ t("admin.groups.claudeCode.classifierModelHint") }}
             </p>
           </div>
         </div>
@@ -4949,6 +4979,7 @@ const createForm = reactive({
   claude_code_only: false,
   fallback_group_id: null as number | null,
   fallback_group_id_on_invalid_request: null as number | null,
+  auto_mode_classifier_model: '',
   // OpenAI Messages 调度配置（仅 openai 平台使用）
   allow_messages_dispatch: false,
   allow_live: false,
@@ -5308,6 +5339,7 @@ const editForm = reactive({
   claude_code_only: false,
   fallback_group_id: null as number | null,
   fallback_group_id_on_invalid_request: null as number | null,
+  auto_mode_classifier_model: '',
   // OpenAI Messages 调度配置（仅 openai 平台使用）
   allow_messages_dispatch: false,
   allow_live: false,
@@ -5759,6 +5791,7 @@ const closeCreateModal = () => {
   createForm.claude_code_only = false;
   createForm.fallback_group_id = null;
   createForm.fallback_group_id_on_invalid_request = null;
+  createForm.auto_mode_classifier_model = '';
   resetMessagesDispatchFormState(createForm);
   createForm.allow_live = false;
   createForm.require_oauth_only = false;
@@ -6004,6 +6037,7 @@ const handleEdit = async (group: AdminGroup) => {
   editForm.fallback_group_id = group.fallback_group_id;
   editForm.fallback_group_id_on_invalid_request =
     group.fallback_group_id_on_invalid_request;
+  editForm.auto_mode_classifier_model = group.auto_mode_classifier_model || '';
   const messagesDispatchFormState = messagesDispatchConfigToFormState(
     group.messages_dispatch_model_config,
   );


### PR DESCRIPTION
## Summary

Claude Code's auto mode sends synchronous (`stream=false`), non-thinking classifier requests to decide tool-call auto-approval. These use the same expensive model as regular conversations.

This adds a per-group `auto_mode_classifier_model` setting that automatically rewrites these classifier requests to a cheaper model (e.g. `claude-sonnet-4-6` instead of `claude-opus-4-7`), significantly reducing token costs without affecting regular conversation quality.

### Detection criteria
- Claude Code client (UA `claude-cli/*` + valid `metadata.user_id`)
- `stream: false`
- Thinking not enabled

### Changes

**Backend:**
- Schema: add `auto_mode_classifier_model` field to groups (`VARCHAR(100)`)
- Repository: include field in `GetByKeyForAuth` SELECT and group queries
- Auth cache: include field in snapshot build/restore cycle
- Gateway service: rewrite model in request body for classifier requests, update context model for access logs, set `originalModel` for correct billing
- Admin handler: support CRUD for the new field
- DTO/mappers: expose `upstream_model` to user usage API when model differs from `requested_model` (classifier rewrite visibility)
- Migration: `143_add_group_auto_mode_classifier_model.sql`

**Frontend:**
- Admin group settings: classifier model input in Claude Code section
- User usage page: show `↳ upstream_model` when model was rewritten
- i18n: en/zh translations

### Billing
Classifier requests are billed at the rewritten model's rate (e.g. Sonnet pricing instead of Opus).
