### PR TITLE
fix(billing): apply long-context multiplier to cache_read price (#2293)

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -535,6 +535,9 @@ func (s *BillingService) computeTokenBreakdown(
 	if applyLongCtx && s.shouldApplySessionLongContextPricing(tokens, pricing) {
 		inputPrice *= pricing.LongContextInputMultiplier
 		outputPrice *= pricing.LongContextOutputMultiplier
+		// 缓存读取本质上是输入侧的复用，应与 input 一同应用长上下文倍率；
+		// 否则 cache hit 越多，少计的费用越多（见 #2293）。
+		cacheReadPrice *= pricing.LongContextInputMultiplier
 	}
 
 	bd := &CostBreakdown{}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -197,6 +197,55 @@ func TestCalculateCost_OpenAIGPT54LongContextAppliesWholeSessionMultipliers(t *t
 	require.InDelta(t, expectedInput+expectedOutput, cost.ActualCost, 1e-10)
 }
 
+// 回归测试 #2293：长上下文计费触发时，cache_read_tokens 也应应用 LongContextInputMultiplier。
+// 修复前：CacheReadCost = tokens * 0.25e-6 （漏乘倍率，少计费用）。
+// 修复后：CacheReadCost = tokens * 0.25e-6 * LongContextInputMultiplier(=2.0)。
+func TestCalculateCost_OpenAIGPT54LongContextAppliesMultiplierToCacheRead(t *testing.T) {
+	svc := newTestBillingService()
+
+	// InputTokens + CacheReadTokens = 1000 + 300000 = 301000 > 272000 阈值
+	tokens := UsageTokens{
+		InputTokens:     1000,
+		CacheReadTokens: 300000,
+		OutputTokens:    1000,
+	}
+
+	cost, err := svc.CalculateCost("gpt-5.4-2026-03-05", tokens, 1.0)
+	require.NoError(t, err)
+
+	expectedInput := float64(tokens.InputTokens) * 2.5e-6 * 2.0
+	expectedOutput := float64(tokens.OutputTokens) * 15e-6 * 1.5
+	expectedCacheRead := float64(tokens.CacheReadTokens) * 0.25e-6 * 2.0
+
+	require.InDelta(t, expectedInput, cost.InputCost, 1e-10)
+	require.InDelta(t, expectedOutput, cost.OutputCost, 1e-10)
+	require.InDelta(t, expectedCacheRead, cost.CacheReadCost, 1e-10,
+		"cache_read_cost should be scaled by LongContextInputMultiplier when long-context pricing applies (issue #2293)")
+
+	expectedTotal := expectedInput + expectedOutput + expectedCacheRead
+	require.InDelta(t, expectedTotal, cost.TotalCost, 1e-10)
+	require.InDelta(t, expectedTotal, cost.ActualCost, 1e-10)
+}
+
+// 阴性测试：未触发长上下文时，cache_read_price 不应被错误地乘以倍率。
+func TestCalculateCost_OpenAIGPT54NoLongContextKeepsCacheReadAtBasePrice(t *testing.T) {
+	svc := newTestBillingService()
+
+	// InputTokens + CacheReadTokens = 1000 + 100000 = 101000 < 272000 阈值，不触发长上下文
+	tokens := UsageTokens{
+		InputTokens:     1000,
+		CacheReadTokens: 100000,
+		OutputTokens:    1000,
+	}
+
+	cost, err := svc.CalculateCost("gpt-5.4-2026-03-05", tokens, 1.0)
+	require.NoError(t, err)
+
+	expectedCacheRead := float64(tokens.CacheReadTokens) * 0.25e-6
+	require.InDelta(t, expectedCacheRead, cost.CacheReadCost, 1e-10,
+		"cache_read_cost should remain at base price when below long-context threshold")
+}
+
 func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 	svc := newTestBillingService()
 


### PR DESCRIPTION
## Summary

Fixes #2293.

When session long-context pricing is triggered in `BillingService.computeTokenBreakdown` (e.g. `gpt-5.4` / `gpt-5.5` once `InputTokens + CacheReadTokens > 272000`), the `LongContextInputMultiplier` / `LongContextOutputMultiplier` were only applied to `inputPrice` and `outputPrice`. The local `cacheReadPrice` was left at its base value, so `CacheReadCost` was silently undercharged whenever a long-context session also had cache hits — which is essentially every long Codex / Claude Code session.

## Reproduction (from the issue)

For `gpt-5.4` with:

- `input_tokens = 408`
- `output_tokens = 1019`
- `cache_read_tokens = 320896`

The reporter observed `cache_read_cost = $0.080224`, but per the long-context spec for gpt-5.4 it should have been:

```
320896 * 0.25e-6 * 2.0 = $0.160448
```

i.e. the bug consistently halves the cache-read portion of the bill (or scales it down by whatever `LongContextInputMultiplier` is for the model).

## Fix

`backend/internal/service/billing_service.go`

```go
if applyLongCtx && s.shouldApplySessionLongContextPricing(tokens, pricing) {
    inputPrice  *= pricing.LongContextInputMultiplier
    outputPrice *= pricing.LongContextOutputMultiplier
    // 缓存读取本质上是输入侧的复用，应与 input 一同应用长上下文倍率；
    // 否则 cache hit 越多，少计的费用越多（见 #2293）。
    cacheReadPrice *= pricing.LongContextInputMultiplier
}
```

Cache reads are conceptually input-side replays, so they scale with `LongContextInputMultiplier`, matching the treatment of `InputPricePerToken`.

## Tests

Adds two regression tests next to the existing `TestCalculateCost_OpenAIGPT54LongContextAppliesWholeSessionMultipliers`:

1. **Positive** — `TestCalculateCost_OpenAIGPT54LongContextAppliesMultiplierToCacheRead`
   - `InputTokens=1000`, `CacheReadTokens=300000`, `OutputTokens=1000` (`> 272000` threshold)
   - Asserts `CacheReadCost == 300000 * 0.25e-6 * 2.0`
   - **Verified to fail on `main` (actual `0.075` vs expected `0.150`) and to pass with the fix.**

2. **Negative** — `TestCalculateCost_OpenAIGPT54NoLongContextKeepsCacheReadAtBasePrice`
   - `InputTokens=1000`, `CacheReadTokens=100000` (below threshold)
   - Asserts `cache_read` is **not** scaled, to prevent the opposite regression.

Local test run with `GOTOOLCHAIN=go1.26.3 go test -tags unit ./internal/service/`:

```
--- PASS: TestCalculateCost_OpenAIGPT54LongContextAppliesWholeSessionMultipliers (0.00s)
--- PASS: TestCalculateCost_OpenAIGPT54LongContextAppliesMultiplierToCacheRead (0.00s)
--- PASS: TestCalculateCost_OpenAIGPT54NoLongContextKeepsCacheReadAtBasePrice (0.00s)
PASS
```

All other existing billing tests continue to pass; `go vet` and `gofmt` are clean.

## Scope notes

- This PR intentionally only fixes the `cache_read` path called out in #2293. The same pattern very likely affects `computeCacheCreationCost` (cache *creation* prices come from `pricing` directly and are also not scaled by the long-context multiplier when `applyLongCtx` is true). I left that out of this PR to keep the change focused on the reported regression and a tight test, and I'm happy to send a follow-up PR if you'd like that addressed as well.
- Only new usage records will be affected; historical `usage_logs` rows are not recomputed (this matches the note in the original issue).

## CLA

I've read the project's [CLA.md](https://github.com/Wei-Shaw/sub2api/blob/main/CLA.md) and I agree to its terms for this contribution.

Made with [Cursor](https://cursor.com)