### PR TITLE
fix(antigravity): capture message_start input_tokens in streaming passthrough

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -4463,6 +4463,14 @@ func (s *AntigravityGatewayService) streamUpstreamResponse(c *gin.Context, resp 
 }
 
 // extractSSEUsage 从 SSE data 行中提取 Claude usage（用于流式透传场景）
+//
+// Anthropic streaming 的 usage 字段分布在两类事件中：
+//   - message_start：嵌套在 event.message.usage（input_tokens、cache_creation_input_tokens、
+//     cache_read_input_tokens 等输入侧字段）
+//   - message_delta：位于顶层 event.usage（流结束时的最终 output_tokens）
+//
+// 仅读取顶层 event.usage 会漏掉 message_start 的输入侧字段，导致流式透传请求落库的
+// usage_logs 记录 input_tokens=0。
 func (s *AntigravityGatewayService) extractSSEUsage(line string, usage *ClaudeUsage) {
 	if !strings.HasPrefix(line, "data: ") {
 		return
@@ -4472,8 +4480,15 @@ func (s *AntigravityGatewayService) extractSSEUsage(line string, usage *ClaudeUs
 	if json.Unmarshal([]byte(dataStr), &event) != nil {
 		return
 	}
-	u, ok := event["usage"].(map[string]any)
-	if !ok {
+	var u map[string]any
+	if eventType, _ := event["type"].(string); eventType == "message_start" {
+		if msg, ok := event["message"].(map[string]any); ok {
+			u, _ = msg["usage"].(map[string]any)
+		}
+	} else {
+		u, _ = event["usage"].(map[string]any)
+	}
+	if u == nil {
 		return
 	}
 	if v, ok := u["input_tokens"].(float64); ok && int(v) > 0 {

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -1301,6 +1301,19 @@ func TestExtractSSEUsage(t *testing.T) {
 			line:     `data: {"usage":{"input_tokens":10,"output_tokens":20,"cache_read_input_tokens":5,"cache_creation_input_tokens":3}}`,
 			expected: ClaudeUsage{InputTokens: 10, OutputTokens: 20, CacheReadInputTokens: 5, CacheCreationInputTokens: 3},
 		},
+		{
+			// Anthropic message_start 把 usage 嵌套在 message.usage 下，
+			// 必须从这里提取输入侧字段（含 cache_read/cache_creation_input_tokens）。
+			name:     "message_start nested usage with input/cache tokens",
+			line:     `data: {"type":"message_start","message":{"id":"msg_01","usage":{"input_tokens":35576,"cache_creation_input_tokens":0,"cache_read_input_tokens":12000,"output_tokens":1}}}`,
+			expected: ClaudeUsage{InputTokens: 35576, OutputTokens: 1, CacheReadInputTokens: 12000},
+		},
+		{
+			// message_start.message.usage.cache_creation 内的 5m/1h 明细也要解析。
+			name:     "message_start nested usage with cache_creation breakdown",
+			line:     `data: {"type":"message_start","message":{"usage":{"input_tokens":100,"cache_creation":{"ephemeral_5m_input_tokens":30,"ephemeral_1h_input_tokens":70}}}}`,
+			expected: ClaudeUsage{InputTokens: 100, CacheCreation5mTokens: 30, CacheCreation1hTokens: 70},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1309,6 +1322,29 @@ func TestExtractSSEUsage(t *testing.T) {
 			require.Equal(t, tt.expected, *usage)
 		})
 	}
+}
+
+// TestExtractSSEUsage_StreamingSequence 复现 issue #2332：完整的 Anthropic streaming
+// 序列（message_start → message_delta）必须把两类事件中的 usage 字段都汇入同一份累计值，
+// 否则透传账号产出的 usage_logs 会出现 input_tokens=0、仅有 output_tokens 的"残缺"记录。
+func TestExtractSSEUsage_StreamingSequence(t *testing.T) {
+	svc := &AntigravityGatewayService{}
+	usage := &ClaudeUsage{}
+
+	// 1) message_start：携带完整输入侧 usage（input_tokens + cache_read）
+	svc.extractSSEUsage(
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-opus-4-6","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":35576,"cache_creation_input_tokens":0,"cache_read_input_tokens":12000,"output_tokens":1}}}`,
+		usage,
+	)
+	// 2) message_delta：流结束时只带 output_tokens（无 input_tokens 字段）
+	svc.extractSSEUsage(
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":816}}`,
+		usage,
+	)
+
+	require.Equal(t, 35576, usage.InputTokens, "message_start 的 input_tokens 必须被记录，否则记账会缺失输入侧 token (#2332)")
+	require.Equal(t, 12000, usage.CacheReadInputTokens, "message_start 的 cache_read_input_tokens 必须被记录")
+	require.Equal(t, 816, usage.OutputTokens, "message_delta 的最终 output_tokens 必须被记录")
 }
 
 // TestAntigravityClientWriter 验证 antigravityClientWriter 的断开检测


### PR DESCRIPTION
## Summary

Fixes #2332.

`AntigravityGatewayService.streamUpstreamResponse` (used when `account.Type == AccountTypeUpstream` forwards `/v1/messages` to a Claude-format upstream) drains the SSE stream by calling `extractSSEUsage` on every line. The extractor only inspects top-level `event["usage"]` — that matches Anthropic's `message_delta` event but completely misses `message_start`, where the input-side usage is nested at `event.message.usage`.

So for every streaming request through this path:

- `message_start` ⇒ `event["usage"]` doesn't exist ⇒ extractor returns early ⇒ no `input_tokens` / `cache_read_input_tokens` / `cache_creation_*` collected.
- `message_delta` ⇒ `event["usage"]` only carries `output_tokens` ⇒ extractor sets `OutputTokens` only.

The resulting `usage_logs` row has `input_tokens=0, output_tokens>0` and the user is billed for output but the input side is silently dropped.

## Reproduction (from #2332)

The reporter on `v0.1.125` observed:

```sql
SELECT COUNT(*) FROM usage_logs
WHERE input_tokens = 0 AND output_tokens > 0
  AND inbound_endpoint = '/v1/messages' AND stream = true;
-- 2,728 rows
```

83% on `claude-opus-4-6`, 9% on `claude-haiku-4-5`, 6% on `claude-opus-4-7`, 91% `request_type=2` (stream), all matching the antigravity upstream-passthrough route.

> Note on the issue's "duplicate write" hypothesis: `RecordUsage` is called once per request from the gateway handler, and `writeUsageLogBestEffort` dedupes by `(request_id, api_key_id)` at the repository layer. There is no second write path for `message_delta`. What the user is observing is a single record produced with `input=0` because of the extractor bug above (their inferred pairing with "normal" rows within ±5s is coincidence — the rows have different `request_id`s). Fixing the extractor restores correct input-side accounting on those rows.

## Fix

`backend/internal/service/antigravity_gateway_service.go` — branch on `event.type` so `message_start` reads from `event.message.usage` while every other event keeps the existing `event.usage` path. This matches how `parseSSEUsagePassthrough` (Anthropic OAuth / API-key / Bedrock paths) already handles both shapes.

```go
var u map[string]any
if eventType, _ := event["type"].(string); eventType == "message_start" {
    if msg, ok := event["message"].(map[string]any); ok {
        u, _ = msg["usage"].(map[string]any)
    }
} else {
    u, _ = event["usage"].(map[string]any)
}
if u == nil {
    return
}
```

The downstream field-by-field extraction is unchanged — it still requires non-zero values to overwrite (so `message_delta`'s implicit `input_tokens=0` cannot blow away what `message_start` already set).

### Boundary behavior

| Scenario | Before | After |
|---|---|---|
| `message_start` carries `input_tokens=N`, `cache_read=M` | dropped (input=0, cache=0) | recorded (input=N, cache=M) |
| `message_delta` carries `output_tokens=K` | recorded | recorded (unchanged) |
| GLM-style `data: {"usage":{...}}` (no `type` field) | recorded | recorded (falls into `else` branch) |
| `message_start` has `cache_creation.ephemeral_5m/1h` breakdown | dropped | recorded |
| `message_stop` / `ping` / `content_block_*` | no-op | no-op (no `usage` either nested or top-level) |
| Invalid JSON / non-`data:` line | no-op | no-op |

## Tests

`backend/internal/service/antigravity_gateway_service_test.go`

1. Two new cases added to `TestExtractSSEUsage` for `message_start` shapes (basic input + cache, and `cache_creation` 5m/1h breakdown).
2. New `TestExtractSSEUsage_StreamingSequence` that drives the full `message_start` → `message_delta` sequence end-to-end and asserts `InputTokens=35576, CacheReadInputTokens=12000, OutputTokens=816`. The literals come straight from the Anthropic stream sample in #2332.

**Verified to fail on `main` and pass with this change** — captured by stashing the production-code edit and rerunning the same tests:

```
--- FAIL: TestExtractSSEUsage/message_start_nested_usage_with_input/cache_tokens (0.00s)
--- FAIL: TestExtractSSEUsage/message_start_nested_usage_with_cache_creation_breakdown (0.00s)
--- FAIL: TestExtractSSEUsage_StreamingSequence (0.00s)
        message_start 的 input_tokens 必须被记录，否则记账会缺失输入侧 token (#2332)
```

After restoring the fix:

```
$ GOTOOLCHAIN=go1.26.3 go test ./internal/service/ -run TestExtractSSEUsage -v
--- PASS: TestExtractSSEUsage (0.00s)
    --- PASS: TestExtractSSEUsage/message_delta_with_output_tokens (0.00s)
    --- PASS: TestExtractSSEUsage/non-data_line_ignored (0.00s)
    --- PASS: TestExtractSSEUsage/top-level_usage_with_all_fields (0.00s)
    --- PASS: TestExtractSSEUsage/message_start_nested_usage_with_input/cache_tokens (0.00s)
    --- PASS: TestExtractSSEUsage/message_start_nested_usage_with_cache_creation_breakdown (0.00s)
--- PASS: TestExtractSSEUsage_StreamingSequence (0.00s)
PASS
ok  	github.com/Wei-Shaw/sub2api/internal/service	0.034s
```

The full antigravity / streamUpstream test families also still pass:

```
$ go test ./internal/service/ -run "Antigravity|StreamUpstream|extractSSE" -count=1
ok  	github.com/Wei-Shaw/sub2api/internal/service	2.065s
```

`gofmt -l` clean on both files; `go vet ./internal/service/` matches `main` (no new warnings).

## Scope notes

- This PR only changes `extractSSEUsage`; the `streamUpstreamResponse` callers and the rest of the antigravity passthrough flow are untouched.
- Only fresh streaming requests are affected — historical `usage_logs` rows with `input_tokens=0` are not retroactively corrected (matches the workaround the reporter is already running).
- The other `/v1/messages` streaming code paths (`gatewayService.handleStreamingResponse` for Anthropic OAuth, `handleStreamingResponseAnthropicAPIKeyPassthrough` for API-key passthrough, `handleBedrockStreamingResponse` for Bedrock) all already use `parseSSEUsagePassthrough` / `extractSSEUsagePatch`, which read both shapes correctly. They are not affected by this bug, and this PR does not touch them.

## CLA

I've already signed the project's CLA on a prior PR (#2816), which the bot's records cover.

Made with [Cursor](https://cursor.com)