### PR TITLE
fix: stop waiting on blocked OpenAI accounts

### DIFF
--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -143,9 +143,13 @@ const (
 type ConcurrencyError struct {
 	SlotType  string
 	IsTimeout bool
+	IsBlocked bool
 }
 
 func (e *ConcurrencyError) Error() string {
+	if e.IsBlocked {
+		return fmt.Sprintf("%s scheduling blocked", e.SlotType)
+	}
 	if e.IsTimeout {
 		return fmt.Sprintf("timeout waiting for %s concurrency slot", e.SlotType)
 	}
@@ -284,11 +288,11 @@ func (h *ConcurrencyHelper) AcquireAccountSlotWithWait(c *gin.Context, accountID
 // waitForSlotWithPing waits for a concurrency slot, sending ping events for streaming requests.
 // streamStarted pointer is updated when streaming begins (for proper error handling by caller).
 func (h *ConcurrencyHelper) waitForSlotWithPing(c *gin.Context, slotType string, id int64, maxConcurrency int, isStream bool, streamStarted *bool) (func(), error) {
-	return h.waitForSlotWithPingTimeout(c, slotType, id, maxConcurrency, maxConcurrencyWait, isStream, streamStarted, false)
+	return h.waitForSlotWithPingTimeout(c, slotType, id, maxConcurrency, maxConcurrencyWait, isStream, streamStarted, false, nil)
 }
 
 // waitForSlotWithPingTimeout waits for a concurrency slot with a custom timeout.
-func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType string, id int64, maxConcurrency int, timeout time.Duration, isStream bool, streamStarted *bool, tryImmediate bool) (func(), error) {
+func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType string, id int64, maxConcurrency int, timeout time.Duration, isStream bool, streamStarted *bool, tryImmediate bool, shouldStopWaiting func() bool) (func(), error) {
 	ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
 	defer cancel()
 
@@ -300,6 +304,9 @@ func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType 
 	}
 
 	if tryImmediate {
+		if shouldStopWaiting != nil && shouldStopWaiting() {
+			return nil, &ConcurrencyError{SlotType: slotType, IsBlocked: true}
+		}
 		result, err := acquireSlot()
 		if err != nil {
 			return nil, err
@@ -356,6 +363,9 @@ func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType 
 			flusher.Flush()
 
 		case <-timer.C:
+			if shouldStopWaiting != nil && shouldStopWaiting() {
+				return nil, &ConcurrencyError{SlotType: slotType, IsBlocked: true}
+			}
 			// Try to acquire slot
 			result, err := acquireSlot()
 			if err != nil {
@@ -373,7 +383,24 @@ func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType 
 
 // AcquireAccountSlotWithWaitTimeout acquires an account slot with a custom timeout (keeps SSE ping).
 func (h *ConcurrencyHelper) AcquireAccountSlotWithWaitTimeout(c *gin.Context, accountID int64, maxConcurrency int, timeout time.Duration, isStream bool, streamStarted *bool) (func(), error) {
-	return h.waitForSlotWithPingTimeout(c, "account", accountID, maxConcurrency, timeout, isStream, streamStarted, true)
+	return h.waitForSlotWithPingTimeout(c, "account", accountID, maxConcurrency, timeout, isStream, streamStarted, true, nil)
+}
+
+func (h *ConcurrencyHelper) AcquireOpenAIAccountSlotWithWaitTimeout(
+	c *gin.Context,
+	gatewayService *service.OpenAIGatewayService,
+	account *service.Account,
+	maxConcurrency int,
+	timeout time.Duration,
+	isStream bool,
+	streamStarted *bool,
+) (func(), error) {
+	if gatewayService != nil && gatewayService.IsAccountSchedulingBlocked(account) {
+		return nil, &ConcurrencyError{SlotType: "account", IsBlocked: true}
+	}
+	return h.waitForSlotWithPingTimeout(c, "account", account.ID, maxConcurrency, timeout, isStream, streamStarted, true, func() bool {
+		return gatewayService != nil && gatewayService.IsAccountSchedulingBlocked(account)
+	})
 }
 
 // nextBackoff 计算下一次退避时间

--- a/backend/internal/handler/gateway_helper_fastpath_test.go
+++ b/backend/internal/handler/gateway_helper_fastpath_test.go
@@ -2,11 +2,14 @@ package handler
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,5 +125,35 @@ func TestConcurrencyHelper_TryAcquireAccountSlot_NotAcquired(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, acquired)
 	require.Nil(t, release)
+	require.Equal(t, int32(0), atomic.LoadInt32(&cache.releaseAccountCalled))
+}
+
+func TestConcurrencyHelper_OpenAIAccountWaitStopsWhenAccountBlocked(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c, _ := newHelperTestContext(http.MethodPost, "/v1/responses")
+
+	var acquireCalls int32
+	account := &service.Account{ID: 301, Platform: service.PlatformOpenAI, Type: service.AccountTypeOAuth}
+	gateway := &service.OpenAIGatewayService{}
+	cache := &concurrencyCacheMock{
+		acquireAccountSlotFn: func(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
+			call := atomic.AddInt32(&acquireCalls, 1)
+			if call == 1 {
+				gateway.BlockAccountScheduling(account, time.Now().Add(time.Minute), "429")
+				return false, nil
+			}
+			return true, nil
+		},
+	}
+	helper := NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatNone, time.Second)
+	streamStarted := false
+
+	release, err := helper.AcquireOpenAIAccountSlotWithWaitTimeout(c, gateway, account, 1, time.Second, false, &streamStarted)
+
+	require.Nil(t, release)
+	var concurrencyErr *ConcurrencyError
+	require.True(t, errors.As(err, &concurrencyErr), "expected concurrency error, got %T: %v", err, err)
+	require.True(t, concurrencyErr.IsBlocked)
+	require.Equal(t, int32(1), atomic.LoadInt32(&acquireCalls))
 	require.Equal(t, int32(0), atomic.LoadInt32(&cache.releaseAccountCalled))
 }

--- a/backend/internal/handler/gateway_helper_hotpath_test.go
+++ b/backend/internal/handler/gateway_helper_hotpath_test.go
@@ -228,7 +228,7 @@ func TestWaitForSlotWithPingTimeout_AccountAndUserAcquire(t *testing.T) {
 	t.Run("account_slot_acquired_after_retry", func(t *testing.T) {
 		c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
 		streamStarted := false
-		release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, time.Second, false, &streamStarted, true)
+		release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, time.Second, false, &streamStarted, true, nil)
 		require.NoError(t, err)
 		require.NotNil(t, release)
 		require.False(t, streamStarted)
@@ -240,7 +240,7 @@ func TestWaitForSlotWithPingTimeout_AccountAndUserAcquire(t *testing.T) {
 	t.Run("user_slot_acquired_after_retry", func(t *testing.T) {
 		c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
 		streamStarted := false
-		release, err := helper.waitForSlotWithPingTimeout(c, "user", 202, 3, time.Second, false, &streamStarted, true)
+		release, err := helper.waitForSlotWithPingTimeout(c, "user", 202, 3, time.Second, false, &streamStarted, true, nil)
 		require.NoError(t, err)
 		require.NotNil(t, release)
 		release()
@@ -259,7 +259,7 @@ func TestWaitForSlotWithPingTimeout_TimeoutAndStreamPing(t *testing.T) {
 		helper := NewConcurrencyHelper(concurrency, SSEPingFormatNone, 5*time.Millisecond)
 		c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
 		streamStarted := false
-		release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, 130*time.Millisecond, false, &streamStarted, true)
+		release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, 130*time.Millisecond, false, &streamStarted, true, nil)
 		require.Nil(t, release)
 		var cErr *ConcurrencyError
 		require.ErrorAs(t, err, &cErr)
@@ -270,7 +270,7 @@ func TestWaitForSlotWithPingTimeout_TimeoutAndStreamPing(t *testing.T) {
 		helper := NewConcurrencyHelper(concurrency, SSEPingFormatComment, 10*time.Millisecond)
 		c, rec := newHelperTestContext(http.MethodPost, "/v1/messages")
 		streamStarted := false
-		release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, 70*time.Millisecond, true, &streamStarted, true)
+		release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, 70*time.Millisecond, true, &streamStarted, true, nil)
 		require.Nil(t, release)
 		var cErr *ConcurrencyError
 		require.ErrorAs(t, err, &cErr)
@@ -288,7 +288,7 @@ func TestWaitForSlotWithPingTimeout_AcquireError(t *testing.T) {
 	helper := NewConcurrencyHelper(concurrency, SSEPingFormatNone, 5*time.Millisecond)
 	c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
 	streamStarted := false
-	release, err := helper.waitForSlotWithPingTimeout(c, "account", 1, 1, 200*time.Millisecond, false, &streamStarted, true)
+	release, err := helper.waitForSlotWithPingTimeout(c, "account", 1, 1, 200*time.Millisecond, false, &streamStarted, true, nil)
 	require.Nil(t, release)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "redis unavailable")

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1071,9 +1071,10 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	}
 	defer releaseWait()
 
-	accountReleaseFunc, err := h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+	accountReleaseFunc, err := h.concurrencyHelper.AcquireOpenAIAccountSlotWithWaitTimeout(
 		c,
-		account.ID,
+		h.gatewayService,
+		account,
 		selection.WaitPlan.MaxConcurrency,
 		selection.WaitPlan.Timeout,
 		reqStream,

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -132,6 +132,10 @@ func (s *OpenAIGatewayService) isOpenAIAccountRuntimeBlocked(account *Account) b
 	return false
 }
 
+func (s *OpenAIGatewayService) IsAccountSchedulingBlocked(account *Account) bool {
+	return s.isOpenAIAccountRuntimeBlocked(account)
+}
+
 func (s *OpenAIGatewayService) recordOpenAIOAuth429() {
 	if s == nil {
 		return


### PR DESCRIPTION
Fixes #2566

## Summary
- Stop OpenAI account wait loops when the selected account becomes runtime-blocked.
- Add regression coverage for a 429/runtime block during account wait.

## Tests
- go test -tags unit ./internal/handler -run 'TestConcurrencyHelper_(TryAcquireAccountSlot_NotAcquired|OpenAIAccountWaitStopsWhenAccountBlocked)|TestWaitForSlotWithPingTimeout|TestAcquireAccountSlotWithWaitTimeout'
- go test -tags unit ./internal/service -run 'TestOpenAI429FastPath|TestOpenAIRuntimeBlock|TestShouldStopOpenAIOAuth429Failover'