### PR TITLE
fix(openai): normalize terminal responses output

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -3536,6 +3536,46 @@ func openAIStreamFailedEventShouldFailover(payload []byte, message string) bool 
 	return true
 }
 
+func ensureOpenAIResponsesOutputArray(body []byte) ([]byte, bool) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return body, false
+	}
+	output := gjson.GetBytes(body, "output")
+	if output.Exists() && output.Type != gjson.Null {
+		return body, false
+	}
+	patched, err := sjson.SetRawBytes(body, "output", []byte("[]"))
+	if err != nil {
+		return body, false
+	}
+	return patched, true
+}
+
+func ensureOpenAIResponsesTerminalSSEOutputArray(data []byte) ([]byte, bool) {
+	if len(data) == 0 || !gjson.ValidBytes(data) {
+		return data, false
+	}
+	eventType := strings.TrimSpace(gjson.GetBytes(data, "type").String())
+	switch eventType {
+	case "response.completed", "response.done", "response.incomplete", "response.cancelled", "response.canceled":
+	default:
+		return data, false
+	}
+	response := gjson.GetBytes(data, "response")
+	if !response.Exists() || !response.IsObject() {
+		return data, false
+	}
+	output := response.Get("output")
+	if output.Exists() && output.Type != gjson.Null {
+		return data, false
+	}
+	patched, err := sjson.SetRawBytes(data, "response.output", []byte("[]"))
+	if err != nil {
+		return data, false
+	}
+	return patched, true
+}
+
 func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 	c *gin.Context,
 	account *Account,
@@ -3667,6 +3707,11 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 					dataBytes = []byte(replacedData)
 					trimmedData = strings.TrimSpace(replacedData)
 				}
+			}
+			if patchedData, patched := ensureOpenAIResponsesTerminalSSEOutputArray(dataBytes); patched {
+				dataBytes = patchedData
+				trimmedData = strings.TrimSpace(string(patchedData))
+				line = "data: " + string(patchedData)
 			}
 			eventType := strings.TrimSpace(gjson.Get(trimmedData, "type").String())
 			if eventType == "response.failed" {
@@ -3836,6 +3881,9 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 					finalResponse = patched
 				}
 			}
+		}
+		if patched, changed := ensureOpenAIResponsesOutputArray(finalResponse); changed {
+			finalResponse = patched
 		}
 		body = finalResponse
 		if originalModel != "" && mappedModel != "" && originalModel != mappedModel {
@@ -4537,9 +4585,17 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 			// Fast path: most events do not contain model field values.
 			if needModelReplace && mappedModel != "" && strings.Contains(data, mappedModel) {
 				line = s.replaceModelInSSELine(line, mappedModel, originalModel)
+				if replacedData, replaced := extractOpenAISSEDataLine(line); replaced {
+					data = replacedData
+				}
 			}
 
 			dataBytes := []byte(data)
+			if patchedData, patched := ensureOpenAIResponsesTerminalSSEOutputArray(dataBytes); patched {
+				dataBytes = patchedData
+				data = string(patchedData)
+				line = "data: " + data
+			}
 			if openAIStreamEventIsTerminal(data) {
 				sawTerminalEvent = true
 			}
@@ -4989,6 +5045,9 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 					finalResponse = patched
 				}
 			}
+		}
+		if patched, changed := ensureOpenAIResponsesOutputArray(finalResponse); changed {
+			finalResponse = patched
 		}
 		body = finalResponse
 		if originalModel != mappedModel {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1349,6 +1349,45 @@ func TestOpenAIStreamingMissingTerminalEventReturnsIncompleteError(t *testing.T)
 	}
 }
 
+func TestOpenAIStreamingResponseCompletedNullOutputPatchedToEmptyArray(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 0,
+			StreamKeepaliveInterval:   0,
+			MaxLineSize:               defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg, toolCorrector: NewCodexToolCorrector()}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       pr,
+		Header:     http.Header{},
+	}
+
+	go func() {
+		defer func() { _ = pw.Close() }()
+		_, _ = pw.Write([]byte(strings.Join([]string{
+			`data: {"type":"response.output_item.done","item":{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"output_text","text":"pong"}]},"output_index":0}`,
+			`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":null,"usage":{"input_tokens":1,"output_tokens":1}}}`,
+		}, "\n") + "\n\n"))
+	}()
+
+	result, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, time.Now(), "model", "model")
+	_ = pr.Close()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, rec.Body.String(), `"type":"response.completed"`)
+	require.Contains(t, rec.Body.String(), `"output":[]`)
+	require.NotContains(t, rec.Body.String(), `"output":null`)
+}
+
 func TestOpenAIStreamingPassthroughMissingTerminalEventReturnsIncompleteError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
@@ -1450,6 +1489,41 @@ func TestOpenAIStreamingPassthroughResponseDoneWithoutDoneMarkerStillSucceeds(t 
 	require.Equal(t, 2, result.usage.InputTokens)
 	require.Equal(t, 3, result.usage.OutputTokens)
 	require.Equal(t, 1, result.usage.CacheReadInputTokens)
+}
+
+func TestOpenAIStreamingPassthroughResponseDoneNullOutputPatchedToEmptyArray(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			MaxLineSize: defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       pr,
+		Header:     http.Header{},
+	}
+
+	go func() {
+		defer func() { _ = pw.Close() }()
+		_, _ = pw.Write([]byte(`data: {"type":"response.done","response":{"output":null,"usage":{"input_tokens":2,"output_tokens":3}}}` + "\n\n"))
+	}()
+
+	result, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{ID: 1}, time.Now(), "", "")
+	_ = pr.Close()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 2, result.usage.InputTokens)
+	require.Equal(t, 3, result.usage.OutputTokens)
+	require.Contains(t, rec.Body.String(), `"output":[]`)
+	require.NotContains(t, rec.Body.String(), `"output":null`)
 }
 
 func TestOpenAIStreamingPassthroughResponseIncompleteWithoutDoneMarkerStillSucceeds(t *testing.T) {
@@ -2308,6 +2382,30 @@ func TestHandleNonStreamingResponse_APIKeyFallsBackToSSEBodyWhenContentTypeIsWro
 	require.NotContains(t, rec.Body.String(), "data:")
 	require.Equal(t, "resp_api_key_sse", gjson.Get(rec.Body.String(), "id").String())
 	require.Equal(t, "hello", gjson.Get(rec.Body.String(), "output.0.content.0.text").String())
+}
+
+func TestHandleSSEToJSON_CompletedNullOutputReturnsEmptyArray(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	body := []byte(strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_null","model":"gpt-5.4","status":"completed","output":null,"usage":{"input_tokens":7,"output_tokens":9}}}`,
+		`data: [DONE]`,
+	}, "\n"))
+
+	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-5.4", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+	require.Equal(t, 7, usage.InputTokens)
+	require.Equal(t, 9, usage.OutputTokens)
+	require.Equal(t, `[]`, gjson.Get(rec.Body.String(), "output").Raw)
 }
 
 func TestHandleSSEToJSON_ReconstructsImageGenerationOutputItemDone(t *testing.T) {


### PR DESCRIPTION
## Summary

- normalize terminal OpenAI Responses SSE events so `response.output` is `[]` instead of `null` or missing
- apply the same fallback to SSE-to-JSON conversion when output reconstruction finds no content
- add coverage for streaming, passthrough streaming, and non-streaming SSE conversion paths

Fixes #2819.

## Testing

- `gofmt -w internal/service/openai_gateway_service.go internal/service/openai_gateway_service_test.go`
- `git diff --check`

I also attempted a targeted Go test run:

```sh
GOMAXPROCS=1 go test -p=1 ./internal/service -run 'Test(OpenAIStreamingResponseCompletedNullOutputPatchedToEmptyArray|OpenAIStreamingPassthroughResponseDoneNullOutputPatchedToEmptyArray|HandleSSEToJSON_CompletedNullOutputReturnsEmptyArray)$'
```

The local run did not complete because the temporary Docker test container stalled during dependency download/network wait on my small server, so I stopped it to avoid leaving a long-running job.
