### PR TITLE
[codex] support moderation proxy selection

### DIFF
--- a/backend/internal/handler/admin/content_moderation_handler.go
+++ b/backend/internal/handler/admin/content_moderation_handler.go
@@ -24,6 +24,7 @@ type contentModerationConfigRequest struct {
 	Mode                 *string                               `json:"mode"`
 	BaseURL              *string                               `json:"base_url"`
 	Model                *string                               `json:"model"`
+	ProxyID              *int64                                `json:"proxy_id"`
 	APIKey               *string                               `json:"api_key"`
 	APIKeys              *[]string                             `json:"api_keys"`
 	APIKeysMode          string                                `json:"api_keys_mode"`
@@ -56,6 +57,7 @@ type contentModerationAPIKeyTestRequest struct {
 	APIKeys   []string `json:"api_keys"`
 	BaseURL   string   `json:"base_url"`
 	Model     string   `json:"model"`
+	ProxyID   *int64   `json:"proxy_id"`
 	TimeoutMS int      `json:"timeout_ms"`
 	Prompt    string   `json:"prompt"`
 	Images    []string `json:"images"`
@@ -85,6 +87,7 @@ func (h *ContentModerationHandler) UpdateConfig(c *gin.Context) {
 		Mode:                 req.Mode,
 		BaseURL:              req.BaseURL,
 		Model:                req.Model,
+		ProxyID:              req.ProxyID,
 		APIKey:               req.APIKey,
 		APIKeys:              req.APIKeys,
 		APIKeysMode:          req.APIKeysMode,
@@ -129,6 +132,7 @@ func (h *ContentModerationHandler) TestAPIKeys(c *gin.Context) {
 		APIKeys:   req.APIKeys,
 		BaseURL:   req.BaseURL,
 		Model:     req.Model,
+		ProxyID:   req.ProxyID,
 		TimeoutMS: req.TimeoutMS,
 		Prompt:    req.Prompt,
 		Images:    req.Images,

--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -22,6 +22,8 @@ import (
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 )
 
 const (
@@ -137,6 +139,7 @@ type ContentModerationConfig struct {
 	Mode                 string                       `json:"mode"`
 	BaseURL              string                       `json:"base_url"`
 	Model                string                       `json:"model"`
+	ProxyID              *int64                       `json:"proxy_id,omitempty"`
 	APIKey               string                       `json:"api_key,omitempty"`
 	APIKeys              []string                     `json:"api_keys,omitempty"`
 	TimeoutMS            int                          `json:"timeout_ms"`
@@ -167,6 +170,7 @@ type ContentModerationConfigView struct {
 	Mode                 string                          `json:"mode"`
 	BaseURL              string                          `json:"base_url"`
 	Model                string                          `json:"model"`
+	ProxyID              *int64                          `json:"proxy_id,omitempty"`
 	APIKeyConfigured     bool                            `json:"api_key_configured"`
 	APIKeyMasked         string                          `json:"api_key_masked"`
 	APIKeyCount          int                             `json:"api_key_count"`
@@ -229,6 +233,7 @@ type TestContentModerationAPIKeysInput struct {
 	APIKeys   []string `json:"api_keys"`
 	BaseURL   string   `json:"base_url"`
 	Model     string   `json:"model"`
+	ProxyID   *int64   `json:"proxy_id"`
 	TimeoutMS int      `json:"timeout_ms"`
 	Prompt    string   `json:"prompt"`
 	Images    []string `json:"images"`
@@ -254,6 +259,7 @@ type UpdateContentModerationConfigInput struct {
 	Mode                 *string                       `json:"mode"`
 	BaseURL              *string                       `json:"base_url"`
 	Model                *string                       `json:"model"`
+	ProxyID              *int64                        `json:"proxy_id"`
 	APIKey               *string                       `json:"api_key"`
 	APIKeys              *[]string                     `json:"api_keys"`
 	APIKeysMode          string                        `json:"api_keys_mode"`
@@ -478,6 +484,7 @@ type ContentModerationService struct {
 	repo                     ContentModerationRepository
 	hashCache                ContentModerationHashCache
 	groupRepo                GroupRepository
+	proxyRepo                ProxyRepository
 	userRepo                 UserRepository
 	authCacheInvalidator     APIKeyAuthCacheInvalidator
 	emailService             *EmailService
@@ -563,6 +570,13 @@ func NewContentModerationService(
 	return svc
 }
 
+func (s *ContentModerationService) SetProxyRepository(repo ProxyRepository) {
+	if s == nil {
+		return
+	}
+	s.proxyRepo = repo
+}
+
 func (s *ContentModerationService) GetConfig(ctx context.Context) (*ContentModerationConfigView, error) {
 	cfg, err := s.loadConfig(ctx)
 	if err != nil {
@@ -587,6 +601,9 @@ func (s *ContentModerationService) UpdateConfig(ctx context.Context, input Updat
 	}
 	if input.Model != nil {
 		cfg.Model = strings.TrimSpace(*input.Model)
+	}
+	if input.ProxyID != nil {
+		cfg.ProxyID = normalizeContentModerationProxyID(*input.ProxyID)
 	}
 	if input.TimeoutMS != nil {
 		cfg.TimeoutMS = *input.TimeoutMS
@@ -703,6 +720,9 @@ func (s *ContentModerationService) TestAPIKeys(ctx context.Context, input TestCo
 	}
 	if strings.TrimSpace(input.Model) != "" {
 		cfg.Model = input.Model
+	}
+	if input.ProxyID != nil {
+		cfg.ProxyID = normalizeContentModerationProxyID(*input.ProxyID)
 	}
 	if input.TimeoutMS > 0 {
 		cfg.TimeoutMS = input.TimeoutMS
@@ -1468,6 +1488,15 @@ func (s *ContentModerationService) validateConfig(ctx context.Context, cfg *Cont
 	if cfg.ModelFilter.Type != ContentModerationModelFilterAll && len(cfg.ModelFilter.Models) == 0 {
 		return infraerrors.BadRequest("INVALID_CONTENT_MODERATION_MODEL_FILTER", "指定或排除模型时至少需要配置 1 个模型")
 	}
+	if cfg.ProxyID != nil {
+		proxy, err := s.contentModerationProxy(ctx, *cfg.ProxyID)
+		if err != nil {
+			return err
+		}
+		if proxy == nil || !proxy.IsActive() {
+			return infraerrors.BadRequest("INVALID_CONTENT_MODERATION_PROXY", "内容审计代理不存在或未启用")
+		}
+	}
 	if !cfg.AllGroups && len(cfg.GroupIDs) > 0 && s.groupRepo != nil {
 		for _, groupID := range cfg.GroupIDs {
 			if _, err := s.groupRepo.GetByIDLite(ctx, groupID); err != nil {
@@ -1554,10 +1583,14 @@ func (s *ContentModerationService) callModerationOnceWithInput(ctx context.Conte
 	req.Header.Set("Authorization", "Bearer "+apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := s.httpClient
-	if client == nil {
-		client = http.DefaultClient
+	client, proxy, err := s.contentModerationHTTPClient(ctx, cfg)
+	if err != nil {
+		return nil, err
 	}
+	slog.Debug("content_moderation.audit_request",
+		"proxy_enabled", proxy != nil,
+		"proxy_id", contentModerationProxyLogID(proxy),
+		"proxy_name", contentModerationProxyLogName(proxy))
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -1579,6 +1612,59 @@ func (s *ContentModerationService) callModerationOnceWithInput(ctx context.Conte
 		return nil, errors.New("moderation api returned empty results")
 	}
 	return &out.Results[0], nil
+}
+
+func (s *ContentModerationService) contentModerationHTTPClient(ctx context.Context, cfg *ContentModerationConfig) (*http.Client, *Proxy, error) {
+	if cfg == nil || cfg.ProxyID == nil {
+		if s != nil && s.httpClient != nil {
+			return s.httpClient, nil, nil
+		}
+		return http.DefaultClient, nil, nil
+	}
+	proxy, err := s.contentModerationProxy(ctx, *cfg.ProxyID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if proxy == nil || !proxy.IsActive() {
+		return nil, nil, infraerrors.BadRequest("INVALID_CONTENT_MODERATION_PROXY", "内容审计代理不存在或未启用")
+	}
+	_, parsedProxy, err := proxyurl.Parse(proxy.URL())
+	if err != nil {
+		return nil, nil, fmt.Errorf("parse content moderation proxy: %w", err)
+	}
+	transport := &http.Transport{}
+	if err := proxyutil.ConfigureTransportProxy(transport, parsedProxy); err != nil {
+		return nil, nil, fmt.Errorf("configure content moderation proxy: %w", err)
+	}
+	return &http.Client{Transport: transport}, proxy, nil
+}
+
+func (s *ContentModerationService) contentModerationProxy(ctx context.Context, proxyID int64) (*Proxy, error) {
+	if proxyID <= 0 {
+		return nil, nil
+	}
+	if s == nil || s.proxyRepo == nil {
+		return nil, infraerrors.InternalServer("CONTENT_MODERATION_PROXY_REPOSITORY_UNAVAILABLE", "内容审计代理仓储不可用")
+	}
+	proxy, err := s.proxyRepo.GetByID(ctx, proxyID)
+	if err != nil {
+		return nil, fmt.Errorf("get content moderation proxy: %w", err)
+	}
+	return proxy, nil
+}
+
+func contentModerationProxyLogID(proxy *Proxy) int64 {
+	if proxy == nil {
+		return 0
+	}
+	return proxy.ID
+}
+
+func contentModerationProxyLogName(proxy *Proxy) string {
+	if proxy == nil {
+		return ""
+	}
+	return proxy.Name
 }
 
 func (s *ContentModerationService) buildLog(input ContentModerationCheckInput, cfg *ContentModerationConfig, action string, flagged bool, highestCategory string, highestScore float64, scores map[string]float64, text string, latency *int, queueDelay *int, errText string) *ContentModerationLog {
@@ -1867,6 +1953,9 @@ func (cfg *ContentModerationConfig) normalize() {
 		cfg.Model = defaultContentModerationModel
 	}
 	cfg.Model = strings.TrimSpace(cfg.Model)
+	if cfg.ProxyID != nil {
+		cfg.ProxyID = normalizeContentModerationProxyID(*cfg.ProxyID)
+	}
 	if cfg.TimeoutMS <= 0 {
 		cfg.TimeoutMS = defaultContentModerationTimeoutMS
 	}
@@ -2130,6 +2219,7 @@ func (s *ContentModerationService) configView(cfg *ContentModerationConfig) *Con
 		Mode:                 cfg.Mode,
 		BaseURL:              cfg.BaseURL,
 		Model:                cfg.Model,
+		ProxyID:              cloneInt64Ptr(cfg.ProxyID),
 		APIKeyConfigured:     len(keys) > 0,
 		APIKeyMasked:         apiKeyMasked,
 		APIKeyCount:          len(keys),
@@ -2550,6 +2640,13 @@ func normalizeContentModerationModelNames(models []string) []string {
 		}
 	}
 	return out
+}
+
+func normalizeContentModerationProxyID(proxyID int64) *int64 {
+	if proxyID <= 0 {
+		return nil
+	}
+	return &proxyID
 }
 
 func contentModerationModelListContains(models []string, model string) bool {

--- a/backend/internal/service/content_moderation_test.go
+++ b/backend/internal/service/content_moderation_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -138,6 +140,70 @@ func requireRecordedHashCount(t *testing.T, cache *contentModerationTestHashCach
 		return len(hashes) == want
 	}, time.Second, 10*time.Millisecond)
 	return hashes
+}
+
+type contentModerationTestProxyRepo struct {
+	proxies map[int64]*Proxy
+}
+
+func (r *contentModerationTestProxyRepo) Create(ctx context.Context, proxy *Proxy) error {
+	panic("unexpected Create call")
+}
+
+func (r *contentModerationTestProxyRepo) GetByID(ctx context.Context, id int64) (*Proxy, error) {
+	if r == nil || r.proxies == nil {
+		return nil, ErrProxyNotFound
+	}
+	proxy := r.proxies[id]
+	if proxy == nil {
+		return nil, ErrProxyNotFound
+	}
+	clone := *proxy
+	return &clone, nil
+}
+
+func (r *contentModerationTestProxyRepo) ListByIDs(ctx context.Context, ids []int64) ([]Proxy, error) {
+	panic("unexpected ListByIDs call")
+}
+
+func (r *contentModerationTestProxyRepo) Update(ctx context.Context, proxy *Proxy) error {
+	panic("unexpected Update call")
+}
+
+func (r *contentModerationTestProxyRepo) Delete(ctx context.Context, id int64) error {
+	panic("unexpected Delete call")
+}
+
+func (r *contentModerationTestProxyRepo) List(ctx context.Context, params pagination.PaginationParams) ([]Proxy, *pagination.PaginationResult, error) {
+	panic("unexpected List call")
+}
+
+func (r *contentModerationTestProxyRepo) ListWithFilters(ctx context.Context, params pagination.PaginationParams, protocol, status, search string) ([]Proxy, *pagination.PaginationResult, error) {
+	panic("unexpected ListWithFilters call")
+}
+
+func (r *contentModerationTestProxyRepo) ListWithFiltersAndAccountCount(ctx context.Context, params pagination.PaginationParams, protocol, status, search string) ([]ProxyWithAccountCount, *pagination.PaginationResult, error) {
+	panic("unexpected ListWithFiltersAndAccountCount call")
+}
+
+func (r *contentModerationTestProxyRepo) ListActive(ctx context.Context) ([]Proxy, error) {
+	panic("unexpected ListActive call")
+}
+
+func (r *contentModerationTestProxyRepo) ListActiveWithAccountCount(ctx context.Context) ([]ProxyWithAccountCount, error) {
+	panic("unexpected ListActiveWithAccountCount call")
+}
+
+func (r *contentModerationTestProxyRepo) ExistsByHostPortAuth(ctx context.Context, host string, port int, username, password string) (bool, error) {
+	panic("unexpected ExistsByHostPortAuth call")
+}
+
+func (r *contentModerationTestProxyRepo) CountAccountsByProxyID(ctx context.Context, proxyID int64) (int64, error) {
+	panic("unexpected CountAccountsByProxyID call")
+}
+
+func (r *contentModerationTestProxyRepo) ListAccountSummariesByProxyID(ctx context.Context, proxyID int64) ([]ProxyAccountSummary, error) {
+	panic("unexpected ListAccountSummariesByProxyID call")
 }
 
 type contentModerationTestHashCache struct {
@@ -1337,6 +1403,130 @@ func TestContentModerationCallModeration_FreezesByHTTPStatus(t *testing.T) {
 	}
 }
 
+func TestContentModerationCallModeration_UsesConfiguredProxy(t *testing.T) {
+	seenProxyRequest := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenProxyRequest <- r.URL.String()
+		require.Equal(t, "http://moderation.example/v1/moderations", r.URL.String())
+		require.Equal(t, "Bearer sk-test", r.Header.Get("Authorization"))
+		_ = json.NewEncoder(w).Encode(moderationAPIResponse{
+			Results: []moderationAPIResult{{
+				CategoryScores: map[string]float64{"sexual": 0.01},
+			}},
+		})
+	}))
+	defer proxyServer.Close()
+
+	proxyID := int64(7)
+	cfg := defaultContentModerationConfig()
+	cfg.BaseURL = "http://moderation.example"
+	cfg.APIKeys = []string{"sk-test"}
+	cfg.ProxyID = &proxyID
+	cfg.RetryCount = 0
+
+	svc := NewContentModerationService(nil, nil, nil, nil, nil, nil, nil)
+	svc.SetProxyRepository(&contentModerationTestProxyRepo{
+		proxies: map[int64]*Proxy{
+			proxyID: contentModerationProxyFromURL(t, proxyID, proxyServer.URL),
+		},
+	})
+
+	result, err := svc.callModeration(context.Background(), cfg, "hello")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0.01, result.CategoryScores["sexual"])
+	select {
+	case got := <-seenProxyRequest:
+		require.Equal(t, "http://moderation.example/v1/moderations", got)
+	default:
+		t.Fatal("moderation request did not reach configured proxy")
+	}
+}
+
+func TestContentModerationTestAPIKeys_UsesSelectedProxy(t *testing.T) {
+	seenProxyRequest := make(chan string, 1)
+	proxyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenProxyRequest <- r.URL.String()
+		_ = json.NewEncoder(w).Encode(moderationAPIResponse{
+			Results: []moderationAPIResult{{
+				CategoryScores: map[string]float64{"sexual": 0.01},
+			}},
+		})
+	}))
+	defer proxyServer.Close()
+
+	proxyID := int64(9)
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{}},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	svc.SetProxyRepository(&contentModerationTestProxyRepo{
+		proxies: map[int64]*Proxy{
+			proxyID: contentModerationProxyFromURL(t, proxyID, proxyServer.URL),
+		},
+	})
+
+	result, err := svc.TestAPIKeys(context.Background(), TestContentModerationAPIKeysInput{
+		APIKeys: []string{"sk-test"},
+		BaseURL: "http://moderation.example",
+		ProxyID: &proxyID,
+		Prompt:  "hello",
+	})
+
+	require.NoError(t, err)
+	require.Len(t, result.Items, 1)
+	require.Equal(t, "ok", result.Items[0].Status)
+	select {
+	case got := <-seenProxyRequest:
+		require.Equal(t, "http://moderation.example/v1/moderations", got)
+	default:
+		t.Fatal("api key test request did not reach configured proxy")
+	}
+}
+
+func TestContentModerationUpdateConfig_StoresAndClearsProxyID(t *testing.T) {
+	proxyID := int64(11)
+	settingRepo := &contentModerationTestSettingRepo{values: map[string]string{}}
+	svc := NewContentModerationService(settingRepo, nil, nil, nil, nil, nil, nil)
+	svc.SetProxyRepository(&contentModerationTestProxyRepo{
+		proxies: map[int64]*Proxy{
+			proxyID: &Proxy{
+				ID:       proxyID,
+				Name:     "moderation-proxy",
+				Protocol: "http",
+				Host:     "proxy.example.com",
+				Port:     8080,
+				Status:   StatusActive,
+			},
+		},
+	})
+
+	view, err := svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{ProxyID: &proxyID})
+
+	require.NoError(t, err)
+	require.NotNil(t, view.ProxyID)
+	require.Equal(t, proxyID, *view.ProxyID)
+	var saved ContentModerationConfig
+	require.NoError(t, json.Unmarshal([]byte(settingRepo.values[SettingKeyContentModerationConfig]), &saved))
+	require.NotNil(t, saved.ProxyID)
+	require.Equal(t, proxyID, *saved.ProxyID)
+
+	clearProxyID := int64(0)
+	view, err = svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{ProxyID: &clearProxyID})
+
+	require.NoError(t, err)
+	require.Nil(t, view.ProxyID)
+	saved = ContentModerationConfig{}
+	require.NoError(t, json.Unmarshal([]byte(settingRepo.values[SettingKeyContentModerationConfig]), &saved))
+	require.Nil(t, saved.ProxyID)
+}
+
 func TestContentModerationTestAPIKeys_400DoesNotFreezeAPIKey(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -1694,4 +1884,20 @@ func TestContentModerationUnbanUser_ActiveUserOnlyInvalidatesAuthCache(t *testin
 
 func contentModerationIntPtr(v int) *int {
 	return &v
+}
+
+func contentModerationProxyFromURL(t *testing.T, id int64, rawURL string) *Proxy {
+	t.Helper()
+	parsed, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+	return &Proxy{
+		ID:       id,
+		Name:     "moderation-proxy",
+		Protocol: parsed.Scheme,
+		Host:     parsed.Hostname(),
+		Port:     port,
+		Status:   StatusActive,
+	}
 }

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -408,6 +408,21 @@ func ProvideSettingService(settingRepo SettingRepository, groupRepo GroupReposit
 	return svc
 }
 
+func ProvideContentModerationService(
+	settingRepo SettingRepository,
+	repo ContentModerationRepository,
+	hashCache ContentModerationHashCache,
+	groupRepo GroupRepository,
+	proxyRepo ProxyRepository,
+	userRepo UserRepository,
+	authCacheInvalidator APIKeyAuthCacheInvalidator,
+	emailService *EmailService,
+) *ContentModerationService {
+	svc := NewContentModerationService(settingRepo, repo, hashCache, groupRepo, userRepo, authCacheInvalidator, emailService)
+	svc.SetProxyRepository(proxyRepo)
+	return svc
+}
+
 // ProvideBillingCacheService wires BillingCacheService with its RPM dependencies.
 func ProvideBillingCacheService(
 	cache BillingCache,
@@ -522,7 +537,7 @@ var ProviderSet = wire.NewSet(
 	NewGroupCapacityService,
 	NewChannelService,
 	NewModelPricingResolver,
-	NewContentModerationService,
+	ProvideContentModerationService,
 	NewAffiliateService,
 	ProvidePaymentConfigService,
 	ProvidePaymentService,

--- a/frontend/src/api/admin/riskControl.ts
+++ b/frontend/src/api/admin/riskControl.ts
@@ -14,6 +14,7 @@ export interface ContentModerationConfig {
   mode: ModerationMode
   base_url: string
   model: string
+  proxy_id?: number | null
   api_key_configured: boolean
   api_key_masked: string
   api_key_count: number
@@ -64,6 +65,7 @@ export interface TestContentModerationAPIKeysPayload {
   api_keys?: string[]
   base_url?: string
   model?: string
+  proxy_id?: number | null
   timeout_ms?: number
   prompt?: string
   images?: string[]
@@ -89,6 +91,7 @@ export interface UpdateContentModerationConfig {
   mode?: ModerationMode
   base_url?: string
   model?: string
+  proxy_id?: number | null
   api_key?: string
   api_keys?: string[]
   api_keys_mode?: 'append' | 'replace'

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2467,6 +2467,8 @@ export default {
       modeOffDesc: 'Content moderation is disabled and no audit records are written.',
       baseUrl: 'OpenAI Base URL',
       model: 'Model',
+      proxy: 'Moderations Proxy',
+      proxyHint: 'Direct connection by default. When selected, content moderation and key tests use this proxy.',
       apiKey: 'OpenAI API Key',
       apiKeys: 'OpenAI API Keys',
       apiKeyCount: '{count} keys',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2544,6 +2544,8 @@ export default {
       modeOffDesc: '不执行内容审计，也不会写入审核记录。',
       baseUrl: 'OpenAI Base URL',
       model: '模型名',
+      proxy: 'Moderations 代理',
+      proxyHint: '默认直连；选择后内容审计和测试 Key 请求都会通过该代理发起。',
       apiKey: 'OpenAI API Key',
       apiKeys: 'OpenAI API Keys',
       apiKeyCount: '{count} 个 Key',

--- a/frontend/src/views/admin/RiskControlView.vue
+++ b/frontend/src/views/admin/RiskControlView.vue
@@ -407,6 +407,11 @@
                 <input v-model.trim="configForm.model" type="text" class="input" placeholder="omni-moderation-latest" />
               </div>
               <div>
+                <label class="input-label">{{ t('admin.riskControl.proxy') }}</label>
+                <ProxySelector v-model="configForm.proxy_id" :proxies="proxies" />
+                <p class="mt-2 text-xs leading-5 text-gray-500 dark:text-gray-400">{{ t('admin.riskControl.proxyHint') }}</p>
+              </div>
+              <div>
                 <label class="input-label">{{ t('admin.riskControl.timeoutMs') }}</label>
                 <input v-model.number="configForm.timeout_ms" type="number" min="500" max="30000" class="input" />
               </div>
@@ -1108,6 +1113,7 @@ import Icon from '@/components/icons/Icon.vue'
 import Select from '@/components/common/Select.vue'
 import Toggle from '@/components/common/Toggle.vue'
 import Pagination from '@/components/common/Pagination.vue'
+import ProxySelector from '@/components/common/ProxySelector.vue'
 import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.vue'
 import { adminAPI } from '@/api/admin'
 import type {
@@ -1123,7 +1129,7 @@ import type {
   ModerationMode,
   UpdateContentModerationConfig,
 } from '@/api/admin/riskControl'
-import type { AdminGroup, SelectOption } from '@/types'
+import type { AdminGroup, Proxy, SelectOption } from '@/types'
 import { useAppStore } from '@/stores/app'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { formatDateTime as formatDateTimeValue } from '@/utils/format'
@@ -1190,6 +1196,7 @@ const activeSettingsTab = ref<SettingsTab>('basic')
 const groupSearch = ref('')
 const flaggedHashInput = ref('')
 const groups = ref<AdminGroup[]>([])
+const proxies = ref<Proxy[]>([])
 const logs = ref<ContentModerationLog[]>([])
 const status = ref<ContentModerationRuntimeStatus | null>(null)
 const testedApiKeyStatuses = ref<ContentModerationAPIKeyStatus[]>([])
@@ -1206,6 +1213,7 @@ const configForm = reactive({
   mode: 'pre_block' as ModerationMode,
   base_url: 'https://api.openai.com',
   model: 'omni-moderation-latest',
+  proxy_id: null as number | null,
   api_keys_text: '',
   api_key_configured: false,
   api_key_masked: '',
@@ -1679,6 +1687,7 @@ function applyConfig(config: ContentModerationConfig) {
   configForm.mode = config.mode
   configForm.base_url = config.base_url || 'https://api.openai.com'
   configForm.model = config.model || 'omni-moderation-latest'
+  configForm.proxy_id = config.proxy_id ?? null
   configForm.api_keys_text = ''
   configForm.api_key_configured = config.api_key_configured
   configForm.api_key_masked = config.api_key_masked || ''
@@ -1718,13 +1727,15 @@ function applyConfig(config: ContentModerationConfig) {
 async function loadAll() {
   loading.value = true
   try {
-    const [config, groupItems, runtimeStatus] = await Promise.all([
+    const [config, groupItems, proxyItems, runtimeStatus] = await Promise.all([
       adminAPI.riskControl.getConfig(),
       adminAPI.groups.getAll(),
+      adminAPI.proxies.getAll(),
       adminAPI.riskControl.getStatus(),
     ])
     applyConfig(config)
     groups.value = groupItems
+    proxies.value = proxyItems
     status.value = runtimeStatus
     if (Array.isArray(runtimeStatus.api_key_statuses)) {
       configForm.api_key_statuses = [...runtimeStatus.api_key_statuses]
@@ -1769,6 +1780,7 @@ async function saveConfig() {
       mode: configForm.mode,
       base_url: configForm.base_url,
       model: configForm.model,
+      proxy_id: configForm.proxy_id || 0,
       timeout_ms: Number(configForm.timeout_ms) || 3000,
       retry_count: Number(configForm.retry_count) || 0,
       sample_rate: Number(configForm.sample_rate) || 0,
@@ -1965,6 +1977,7 @@ async function testApiKeys(useInputKeys: boolean) {
       api_keys: keys,
       base_url: configForm.base_url,
       model: configForm.model,
+      proxy_id: configForm.proxy_id || 0,
       timeout_ms: Number(configForm.timeout_ms) || 3000,
       prompt: moderationTestPrompt.value,
       images: moderationTestImages.value,

--- a/frontend/src/views/admin/__tests__/RiskControlView.spec.ts
+++ b/frontend/src/views/admin/__tests__/RiskControlView.spec.ts
@@ -12,6 +12,7 @@ const {
   getStatus,
   listLogs,
   getGroups,
+  getProxies,
   showError,
   showSuccess,
 } = vi.hoisted(() => ({
@@ -20,6 +21,7 @@ const {
   getStatus: vi.fn(),
   listLogs: vi.fn(),
   getGroups: vi.fn(),
+  getProxies: vi.fn(),
   showError: vi.fn(),
   showSuccess: vi.fn(),
 }))
@@ -38,6 +40,10 @@ vi.mock('@/api/admin', () => ({
     },
     groups: {
       getAll: getGroups,
+    },
+    proxies: {
+      getAll: getProxies,
+      testProxy: vi.fn(),
     },
   },
 }))
@@ -73,6 +79,7 @@ const baseConfig = (): ContentModerationConfig => ({
   mode: 'pre_block',
   base_url: 'https://api.openai.com',
   model: 'omni-moderation-latest',
+  proxy_id: null,
   api_key_configured: false,
   api_key_masked: '',
   api_key_count: 0,
@@ -175,6 +182,34 @@ const ModelWhitelistSelectorStub = defineComponent({
       })
   },
 })
+const ProxySelectorStub = defineComponent({
+  props: {
+    modelValue: {
+      type: Number,
+      default: null,
+    },
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const onChange = (event: Event) => {
+      const value = Number((event.target as HTMLSelectElement).value)
+      emit('update:modelValue', value > 0 ? value : null)
+    }
+    return () =>
+      h(
+        'select',
+        {
+          'data-test': 'moderation-proxy-select',
+          value: props.modelValue ?? 0,
+          onChange,
+        },
+        [
+          h('option', { value: 0 }, 'direct'),
+          h('option', { value: 23 }, 'proxy-23'),
+        ]
+      )
+  },
+})
 
 function findButtonByText(wrapper: VueWrapper, text: string): DOMWrapper<HTMLButtonElement> {
   const button = wrapper.findAll<HTMLButtonElement>('button').find((item) => item.text().includes(text))
@@ -191,6 +226,7 @@ describe('admin RiskControlView', () => {
     getStatus.mockReset()
     listLogs.mockReset()
     getGroups.mockReset()
+    getProxies.mockReset()
     showError.mockReset()
     showSuccess.mockReset()
 
@@ -198,6 +234,7 @@ describe('admin RiskControlView', () => {
     getStatus.mockResolvedValue(runtimeStatus())
     listLogs.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 20, pages: 1 })
     getGroups.mockResolvedValue([])
+    getProxies.mockResolvedValue([])
     updateConfig.mockImplementation(async (payload: UpdateContentModerationConfig) => ({
       ...baseConfig(),
       ...payload,
@@ -221,6 +258,7 @@ describe('admin RiskControlView', () => {
           Toggle: true,
           Pagination: true,
           ModelWhitelistSelector: ModelWhitelistSelectorStub,
+          ProxySelector: ProxySelectorStub,
         },
       },
     })
@@ -254,6 +292,7 @@ describe('admin RiskControlView', () => {
           Toggle: true,
           Pagination: true,
           ModelWhitelistSelector: ModelWhitelistSelectorStub,
+          ProxySelector: ProxySelectorStub,
         },
       },
     })
@@ -294,6 +333,7 @@ describe('admin RiskControlView', () => {
           Toggle: true,
           Pagination: true,
           ModelWhitelistSelector: ModelWhitelistSelectorStub,
+          ProxySelector: ProxySelectorStub,
         },
       },
     })
@@ -361,6 +401,7 @@ describe('admin RiskControlView', () => {
           Toggle: true,
           Pagination: true,
           ModelWhitelistSelector: ModelWhitelistSelectorStub,
+          ProxySelector: ProxySelectorStub,
         },
       },
     })
@@ -403,5 +444,34 @@ describe('admin RiskControlView', () => {
       'max-h-[280px]',
       'overflow-y-auto',
     ]))
+  })
+
+  it('submits selected proxy id when saving moderation config', async () => {
+    const wrapper = mount(RiskControlView, {
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          BaseDialog: BaseDialogStub,
+          Icon: true,
+          Select: true,
+          Toggle: true,
+          Pagination: true,
+          ModelWhitelistSelector: ModelWhitelistSelectorStub,
+          ProxySelector: ProxySelectorStub,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    await findButtonByText(wrapper, 'admin.riskControl.openSettings').trigger('click')
+    await wrapper.get('[data-test="moderation-proxy-select"]').setValue('23')
+    await findButtonByText(wrapper, 'admin.riskControl.saveConfig').trigger('click')
+    await flushPromises()
+
+    expect(updateConfig).toHaveBeenCalledWith(expect.objectContaining({
+      proxy_id: 23,
+    }))
+    expect(showError).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- Add optional `proxy_id` to content moderation config and API-key test payloads.
- Resolve active proxy records and send OpenAI Moderations requests through the selected proxy when configured.
- Add a proxy selector to the Risk Control moderation settings so saved checks and test-key requests share the same route.

## Root Cause
Content moderation used the service default HTTP client directly, so `/v1/moderations` always went out through the server's direct egress even when the admin had configured proxy servers.

## Tests
- `go test ./internal/service -run "TestContentModeration(CallModeration_UsesConfiguredProxy|TestAPIKeys_UsesSelectedProxy|UpdateConfig_StoresAndClearsProxyID|CallModeration_400DoesNotFreezeAPIKey|CallModeration_FreezesByHTTPStatus)"`
- `go test ./internal/service ./internal/handler/admin`
- `pnpm test:run src/views/admin/__tests__/RiskControlView.spec.ts`
- `pnpm typecheck`

Closes #2646
