### PR TITLE
feat(admin/proxies): show exit IP address in location column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,5 +134,6 @@ docs/*
 .serena/
 .codex/
 frontend/coverage/
+.pnpm-store/
 aicodex
 output/

--- a/frontend/src/views/admin/ProxiesView.vue
+++ b/frontend/src/views/admin/ProxiesView.vue
@@ -184,18 +184,23 @@
           </template>
 
           <template #cell-location="{ row }">
-            <div class="flex items-center gap-2">
+            <div v-if="row.ip_address || row.country_code" class="flex items-center gap-2">
               <img
                 v-if="row.country_code"
                 :src="flagUrl(row.country_code)"
                 :alt="row.country || row.country_code"
                 class="h-4 w-6 rounded-sm"
               />
-              <span v-if="formatLocation(row)" class="text-sm text-gray-700 dark:text-gray-200">
-                {{ formatLocation(row) }}
-              </span>
-              <span v-else class="text-sm text-gray-400">-</span>
+              <div class="flex flex-col">
+                <span v-if="formatLocation(row)" class="text-sm text-gray-700 dark:text-gray-200">
+                  {{ formatLocation(row) }}
+                </span>
+                <code v-if="row.ip_address" class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ row.ip_address }}
+                </code>
+              </div>
             </div>
+            <span v-else class="text-sm text-gray-400">-</span>
           </template>
 
           <template #cell-account_count="{ row, value }">


### PR DESCRIPTION
## Summary

- Display the proxy exit IP address in the admin proxies table's location column
- IP shown as a compact `<code>` block below the country/city text
- Only renders when `ip_address` is present in the latency cache data

## Changes

- `frontend/src/views/admin/ProxiesView.vue`: Updated location cell template to show `row.ip_address` alongside existing geo info

## Screenshot

The location column now shows:
```
🇺🇸 United States
203.0.113.42
```

Instead of just:
```
🇺🇸 United States
```