### PR TITLE
feat: add configurable daily token leaderboard

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -91,7 +91,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService)
 	usageLogRepository := repository.NewUsageLogRepository(client, db)
 	usageService := service.NewUsageService(usageLogRepository, userRepository, client, apiKeyAuthCacheInvalidator)
-	usageHandler := handler.NewUsageHandler(usageService, apiKeyService)
+	usageHandler := handler.NewUsageHandler(usageService, apiKeyService, settingService)
 	redeemHandler := handler.NewRedeemHandler(redeemService)
 	subscriptionHandler := handler.NewSubscriptionHandler(subscriptionService)
 	announcementRepository := repository.NewAnnouncementRepository(client)

--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -295,6 +295,8 @@ func (h *SettingHandler) GetSettings(c *gin.Context) {
 
 		AvailableChannelsEnabled: settings.AvailableChannelsEnabled,
 
+		DailyTokenLeaderboardEnabled: settings.DailyTokenLeaderboardEnabled,
+
 		AffiliateEnabled: settings.AffiliateEnabled,
 	}
 
@@ -635,6 +637,9 @@ type UpdateSettingsRequest struct {
 
 	// Available Channels feature switch (user-facing)
 	AvailableChannelsEnabled *bool `json:"available_channels_enabled"`
+
+	// Daily Token Leaderboard feature switch
+	DailyTokenLeaderboardEnabled *bool `json:"daily_token_leaderboard_enabled"`
 
 	// Affiliate (邀请返利) feature switch
 	AffiliateEnabled *bool `json:"affiliate_enabled"`
@@ -1739,6 +1744,12 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 			}
 			return previousSettings.AvailableChannelsEnabled
 		}(),
+		DailyTokenLeaderboardEnabled: func() bool {
+			if req.DailyTokenLeaderboardEnabled != nil {
+				return *req.DailyTokenLeaderboardEnabled
+			}
+			return previousSettings.DailyTokenLeaderboardEnabled
+		}(),
 		AffiliateEnabled: func() bool {
 			if req.AffiliateEnabled != nil {
 				return *req.AffiliateEnabled
@@ -2068,6 +2079,8 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		ChannelMonitorDefaultIntervalSeconds: updatedSettings.ChannelMonitorDefaultIntervalSeconds,
 
 		AvailableChannelsEnabled: updatedSettings.AvailableChannelsEnabled,
+
+		DailyTokenLeaderboardEnabled: updatedSettings.DailyTokenLeaderboardEnabled,
 
 		AffiliateEnabled: updatedSettings.AffiliateEnabled,
 
@@ -2542,6 +2555,9 @@ func diffSettings(before *service.SystemSettings, after *service.SystemSettings,
 	}
 	if before.AvailableChannelsEnabled != after.AvailableChannelsEnabled {
 		changed = append(changed, "available_channels_enabled")
+	}
+	if before.DailyTokenLeaderboardEnabled != after.DailyTokenLeaderboardEnabled {
+		changed = append(changed, "daily_token_leaderboard_enabled")
 	}
 	if before.AffiliateEnabled != after.AffiliateEnabled {
 		changed = append(changed, "affiliate_enabled")

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -240,6 +240,9 @@ type SystemSettings struct {
 	// Available Channels feature switch (user-facing aggregate view)
 	AvailableChannelsEnabled bool `json:"available_channels_enabled"`
 
+	// Daily Token Leaderboard feature switch
+	DailyTokenLeaderboardEnabled bool `json:"daily_token_leaderboard_enabled"`
+
 	// 风控中心功能开关
 	RiskControlEnabled bool `json:"risk_control_enabled"`
 
@@ -311,6 +314,8 @@ type PublicSettings struct {
 	ChannelMonitorDefaultIntervalSeconds int  `json:"channel_monitor_default_interval_seconds"`
 
 	AvailableChannelsEnabled bool `json:"available_channels_enabled"`
+
+	DailyTokenLeaderboardEnabled bool `json:"daily_token_leaderboard_enabled"`
 
 	AffiliateEnabled bool `json:"affiliate_enabled"`
 

--- a/backend/internal/handler/setting_handler.go
+++ b/backend/internal/handler/setting_handler.go
@@ -95,6 +95,8 @@ func (h *SettingHandler) GetPublicSettings(c *gin.Context) {
 
 		AvailableChannelsEnabled: settings.AvailableChannelsEnabled,
 
+		DailyTokenLeaderboardEnabled: settings.DailyTokenLeaderboardEnabled,
+
 		AffiliateEnabled: settings.AffiliateEnabled,
 
 		RiskControlEnabled: settings.RiskControlEnabled,

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -18,17 +19,19 @@ import (
 
 // UsageHandler handles usage-related requests
 type UsageHandler struct {
-	usageService  *service.UsageService
-	apiKeyService *service.APIKeyService
+	usageService   *service.UsageService
+	apiKeyService  *service.APIKeyService
+	settingService *service.SettingService
 }
 
 const dailyTokenLeaderboardLimit = 5
 
 // NewUsageHandler creates a new UsageHandler
-func NewUsageHandler(usageService *service.UsageService, apiKeyService *service.APIKeyService) *UsageHandler {
+func NewUsageHandler(usageService *service.UsageService, apiKeyService *service.APIKeyService, settingService *service.SettingService) *UsageHandler {
 	return &UsageHandler{
-		usageService:  usageService,
-		apiKeyService: apiKeyService,
+		usageService:   usageService,
+		apiKeyService:  apiKeyService,
+		settingService: settingService,
 	}
 }
 
@@ -396,6 +399,10 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 func (h *UsageHandler) DailyTokenLeaderboard(c *gin.Context) {
 	if _, ok := middleware2.GetAuthSubjectFromContext(c); !ok {
 		response.Unauthorized(c, "User not authenticated")
+		return
+	}
+	if h.settingService == nil || !h.settingService.IsDailyTokenLeaderboardEnabled(c.Request.Context()) {
+		response.Error(c, http.StatusNotFound, "Daily token leaderboard is disabled")
 		return
 	}
 

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -22,6 +22,8 @@ type UsageHandler struct {
 	apiKeyService *service.APIKeyService
 }
 
+const dailyTokenLeaderboardLimit = 5
+
 // NewUsageHandler creates a new UsageHandler
 func NewUsageHandler(usageService *service.UsageService, apiKeyService *service.APIKeyService) *UsageHandler {
 	return &UsageHandler{
@@ -387,6 +389,62 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 		"start_date": startTime.Format("2006-01-02"),
 		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 	})
+}
+
+// DailyTokenLeaderboard handles getting today's global token leaderboard.
+// GET /api/v1/usage/leaderboard/daily
+func (h *UsageHandler) DailyTokenLeaderboard(c *gin.Context) {
+	if _, ok := middleware2.GetAuthSubjectFromContext(c); !ok {
+		response.Unauthorized(c, "User not authenticated")
+		return
+	}
+
+	now := timezone.Now()
+	startTime := timezone.StartOfDay(now)
+	endTime := now
+
+	rows, err := h.usageService.GetDailyTokenLeaderboard(c.Request.Context(), startTime, endTime, dailyTokenLeaderboardLimit)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	items := make([]usagestats.DailyTokenLeaderboardItem, 0, len(rows))
+	for i, row := range rows {
+		items = append(items, usagestats.DailyTokenLeaderboardItem{
+			Rank:        i + 1,
+			DisplayName: maskLeaderboardDisplayName(row.Username, row.Email, c.GetHeader("Accept-Language")),
+			TotalTokens: row.TotalTokens,
+		})
+	}
+
+	response.Success(c, usagestats.DailyTokenLeaderboardResponse{
+		Items:       items,
+		StartDate:   startTime.Format("2006-01-02"),
+		EndDate:     endTime.Format("2006-01-02"),
+		Limit:       dailyTokenLeaderboardLimit,
+		GeneratedAt: now.Format(time.RFC3339),
+	})
+}
+
+func maskLeaderboardDisplayName(username, email, acceptLanguage string) string {
+	source := strings.TrimSpace(username)
+	if source == "" {
+		emailPrefix, _, _ := strings.Cut(strings.TrimSpace(email), "@")
+		source = strings.TrimSpace(emailPrefix)
+	}
+	if source == "" {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(acceptLanguage)), "en") {
+			return "User***"
+		}
+		return "用户***"
+	}
+
+	runes := []rune(source)
+	if len(runes) > 3 {
+		runes = runes[:3]
+	}
+	return string(runes) + "***"
 }
 
 // BatchAPIKeysUsageRequest represents the request for batch API keys usage

--- a/backend/internal/handler/usage_handler_daily_test.go
+++ b/backend/internal/handler/usage_handler_daily_test.go
@@ -64,7 +64,7 @@ func newDailyUsageTestRouter(usageRepo *dailyUsageRepoStub, apiKeyRepo *dailyUsa
 	gin.SetMode(gin.TestMode)
 	usageSvc := service.NewUsageService(usageRepo, nil, nil, nil)
 	apiKeySvc := service.NewAPIKeyService(apiKeyRepo, nil, nil, nil, nil, nil, nil)
-	handler := NewUsageHandler(usageSvc, apiKeySvc)
+	handler := NewUsageHandler(usageSvc, apiKeySvc, nil)
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
 		c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: userID})

--- a/backend/internal/handler/usage_handler_leaderboard_test.go
+++ b/backend/internal/handler/usage_handler_leaderboard_test.go
@@ -1,0 +1,144 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type leaderboardRepoStub struct {
+	service.UsageLogRepository
+	items []usagestats.DailyTokenLeaderboardSourceItem
+
+	called    bool
+	startTime time.Time
+	endTime   time.Time
+	limit     int
+}
+
+func (s *leaderboardRepoStub) GetDailyTokenLeaderboard(
+	ctx context.Context,
+	startTime, endTime time.Time,
+	limit int,
+) ([]usagestats.DailyTokenLeaderboardSourceItem, error) {
+	s.called = true
+	s.startTime = startTime
+	s.endTime = endTime
+	s.limit = limit
+	return s.items, nil
+}
+
+func newLeaderboardTestRouter(repo *leaderboardRepoStub, authenticated bool) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	usageSvc := service.NewUsageService(repo, nil, nil, nil)
+	handler := NewUsageHandler(usageSvc, nil)
+	router := gin.New()
+	if authenticated {
+		router.Use(func(c *gin.Context) {
+			c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 42})
+			c.Next()
+		})
+	}
+	router.GET("/usage/leaderboard/daily", handler.DailyTokenLeaderboard)
+	return router
+}
+
+type dailyTokenLeaderboardHandlerResponse struct {
+	Code int `json:"code"`
+	Data struct {
+		Items []usagestats.DailyTokenLeaderboardItem `json:"items"`
+		Limit int                                    `json:"limit"`
+	} `json:"data"`
+}
+
+func TestDailyTokenLeaderboardRequiresAuthenticatedUser(t *testing.T) {
+	repo := &leaderboardRepoStub{}
+	router := newLeaderboardTestRouter(repo, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/leaderboard/daily", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, repo.called)
+}
+
+func TestDailyTokenLeaderboardReturnsMaskedTopFiveWithoutRawIdentity(t *testing.T) {
+	repo := &leaderboardRepoStub{
+		items: []usagestats.DailyTokenLeaderboardSourceItem{
+			{UserID: 1, Username: "alice", Email: "alice@example.com", TotalTokens: 3000},
+			{UserID: 2, Username: "", Email: "bo@example.com", TotalTokens: 2000},
+			{UserID: 3, Username: "", Email: "", TotalTokens: 1000},
+		},
+	}
+	router := newLeaderboardTestRouter(repo, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/leaderboard/daily", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, repo.called)
+	require.Equal(t, 5, repo.limit)
+	require.True(t, repo.startTime.Before(repo.endTime))
+
+	body := rec.Body.String()
+	require.NotContains(t, body, "alice@example.com")
+	require.NotContains(t, body, `"user_id"`)
+
+	var got dailyTokenLeaderboardHandlerResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, 5, got.Data.Limit)
+	require.Equal(t, []usagestats.DailyTokenLeaderboardItem{
+		{Rank: 1, DisplayName: "ali***", TotalTokens: 3000},
+		{Rank: 2, DisplayName: "bo***", TotalTokens: 2000},
+		{Rank: 3, DisplayName: "用户***", TotalTokens: 1000},
+	}, got.Data.Items)
+}
+
+func TestDailyTokenLeaderboardUsesEnglishFallbackForEnglishLocale(t *testing.T) {
+	repo := &leaderboardRepoStub{
+		items: []usagestats.DailyTokenLeaderboardSourceItem{
+			{UserID: 1, Username: "", Email: "", TotalTokens: 1000},
+		},
+	}
+	router := newLeaderboardTestRouter(repo, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/leaderboard/daily", nil)
+	req.Header.Set("Accept-Language", "en")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var got dailyTokenLeaderboardHandlerResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Equal(t, []usagestats.DailyTokenLeaderboardItem{
+		{Rank: 1, DisplayName: "User***", TotalTokens: 1000},
+	}, got.Data.Items)
+}
+
+func TestDailyTokenLeaderboardReturnsEmptyItems(t *testing.T) {
+	repo := &leaderboardRepoStub{items: []usagestats.DailyTokenLeaderboardSourceItem{}}
+	router := newLeaderboardTestRouter(repo, true)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/leaderboard/daily", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var got dailyTokenLeaderboardHandlerResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &got))
+	require.Empty(t, got.Data.Items)
+	require.False(t, strings.Contains(rec.Body.String(), "email"))
+}

--- a/backend/internal/handler/usage_handler_leaderboard_test.go
+++ b/backend/internal/handler/usage_handler_leaderboard_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -38,10 +39,29 @@ func (s *leaderboardRepoStub) GetDailyTokenLeaderboard(
 	return s.items, nil
 }
 
+type leaderboardSettingRepoStub struct {
+	service.SettingRepository
+	leaderboardEnabled string
+}
+
+func (s *leaderboardSettingRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	if key == service.SettingKeyDailyTokenLeaderboardEnabled {
+		return s.leaderboardEnabled, nil
+	}
+	return "", service.ErrSettingNotFound
+}
+
 func newLeaderboardTestRouter(repo *leaderboardRepoStub, authenticated bool) *gin.Engine {
+	return newLeaderboardTestRouterWithFeature(repo, authenticated, true)
+}
+
+func newLeaderboardTestRouterWithFeature(repo *leaderboardRepoStub, authenticated bool, enabled bool) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	usageSvc := service.NewUsageService(repo, nil, nil, nil)
-	handler := NewUsageHandler(usageSvc, nil)
+	settingSvc := service.NewSettingService(&leaderboardSettingRepoStub{
+		leaderboardEnabled: strconv.FormatBool(enabled),
+	}, nil)
+	handler := NewUsageHandler(usageSvc, nil, settingSvc)
 	router := gin.New()
 	if authenticated {
 		router.Use(func(c *gin.Context) {
@@ -70,6 +90,18 @@ func TestDailyTokenLeaderboardRequiresAuthenticatedUser(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, repo.called)
+}
+
+func TestDailyTokenLeaderboardReturnsNotFoundWhenFeatureDisabled(t *testing.T) {
+	repo := &leaderboardRepoStub{}
+	router := newLeaderboardTestRouterWithFeature(repo, true, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/leaderboard/daily", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
 	require.False(t, repo.called)
 }
 

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -34,7 +34,7 @@ func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagin
 func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	usageSvc := service.NewUsageService(repo, nil, nil, nil)
-	handler := NewUsageHandler(usageSvc, nil)
+	handler := NewUsageHandler(usageSvc, nil, nil)
 	router := gin.New()
 	router.Use(func(c *gin.Context) {
 		c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 42})

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -162,6 +162,30 @@ type UserSpendingRankingResponse struct {
 	TotalTokens     int64                     `json:"total_tokens"`
 }
 
+// DailyTokenLeaderboardSourceItem represents a raw per-user token ranking row.
+type DailyTokenLeaderboardSourceItem struct {
+	UserID      int64
+	Username    string
+	Email       string
+	TotalTokens int64
+}
+
+// DailyTokenLeaderboardItem represents a public, identity-masked token leaderboard row.
+type DailyTokenLeaderboardItem struct {
+	Rank        int    `json:"rank"`
+	DisplayName string `json:"display_name"`
+	TotalTokens int64  `json:"total_tokens"`
+}
+
+// DailyTokenLeaderboardResponse represents today's public token leaderboard.
+type DailyTokenLeaderboardResponse struct {
+	Items       []DailyTokenLeaderboardItem `json:"items"`
+	StartDate   string                      `json:"start_date"`
+	EndDate     string                      `json:"end_date"`
+	Limit       int                         `json:"limit"`
+	GeneratedAt string                      `json:"generated_at"`
+}
+
 // UserBreakdownItem represents per-user usage breakdown within a dimension (group, model, endpoint).
 type UserBreakdownItem struct {
 	UserID      int64   `json:"user_id"`

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -2427,6 +2427,56 @@ func (r *usageLogRepository) GetUserSpendingRanking(ctx context.Context, startTi
 	}, nil
 }
 
+// GetDailyTokenLeaderboard returns the top users by total tokens in a time range.
+func (r *usageLogRepository) GetDailyTokenLeaderboard(ctx context.Context, startTime, endTime time.Time, limit int) (results []usagestats.DailyTokenLeaderboardSourceItem, err error) {
+	if limit <= 0 {
+		limit = 5
+	}
+
+	query := `
+		WITH daily_tokens AS (
+			SELECT
+				u.user_id,
+				COALESCE(us.username, '') AS username,
+				COALESCE(us.email, '') AS email,
+				COALESCE(SUM(u.input_tokens + u.output_tokens + u.cache_creation_tokens + u.cache_read_tokens), 0) AS total_tokens
+			FROM usage_logs u
+			LEFT JOIN users us ON u.user_id = us.id
+			WHERE u.created_at >= $1 AND u.created_at < $2
+			GROUP BY u.user_id, us.username, us.email
+		)
+		SELECT user_id, username, email, total_tokens
+		FROM daily_tokens
+		ORDER BY total_tokens DESC, user_id ASC
+		LIMIT $3
+	`
+
+	rows, err := r.sql.QueryContext(ctx, query, startTime, endTime, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			err = closeErr
+			results = nil
+		}
+	}()
+
+	results = make([]usagestats.DailyTokenLeaderboardSourceItem, 0)
+	for rows.Next() {
+		var row usagestats.DailyTokenLeaderboardSourceItem
+		if err = rows.Scan(&row.UserID, &row.Username, &row.Email, &row.TotalTokens); err != nil {
+			return nil, err
+		}
+		results = append(results, row)
+	}
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
 // UserDashboardStats 用户仪表盘统计
 type UserDashboardStats = usagestats.UserDashboardStats
 

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -537,6 +537,32 @@ func TestUsageLogRepositoryGetUserSpendingRanking(t *testing.T) {
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestUsageLogRepositoryGetDailyTokenLeaderboard(t *testing.T) {
+	db, mock := newSQLMock(t)
+	repo := &usageLogRepository{sql: db}
+
+	start := time.Date(2026, 5, 27, 0, 0, 0, 0, time.Local)
+	end := start.Add(24 * time.Hour)
+
+	rows := sqlmock.NewRows([]string{"user_id", "username", "email", "total_tokens"}).
+		AddRow(int64(2), "beta-user", "beta@example.com", int64(1200)).
+		AddRow(int64(1), "", "alpha@example.com", int64(1200)).
+		AddRow(int64(3), "", "", int64(50))
+
+	mock.ExpectQuery("WITH daily_tokens AS \\(").
+		WithArgs(start, end, 5).
+		WillReturnRows(rows)
+
+	got, err := repo.GetDailyTokenLeaderboard(context.Background(), start, end, 5)
+	require.NoError(t, err)
+	require.Equal(t, []usagestats.DailyTokenLeaderboardSourceItem{
+		{UserID: 2, Username: "beta-user", Email: "beta@example.com", TotalTokens: 1200},
+		{UserID: 1, Username: "", Email: "alpha@example.com", TotalTokens: 1200},
+		{UserID: 3, Username: "", Email: "", TotalTokens: 50},
+	}, got)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestBuildRequestTypeFilterConditionLegacyFallback(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -674,6 +674,7 @@ func TestAPIContracts(t *testing.T) {
 					"email_verify_enabled": false,
 					"registration_email_suffix_whitelist": [],
 					"promo_code_enabled": true,
+					"daily_token_leaderboard_enabled": false,
 					"password_reset_enabled": false,
 						"frontend_url": "",
 						"totp_enabled": false,
@@ -944,6 +945,7 @@ func TestAPIContracts(t *testing.T) {
 					"email_verify_enabled": false,
 					"registration_email_suffix_whitelist": [],
 					"promo_code_enabled": true,
+					"daily_token_leaderboard_enabled": false,
 					"password_reset_enabled": false,
 					"frontend_url": "",
 						"invitation_code_enabled": false,
@@ -1277,7 +1279,7 @@ func newContractDeps(t *testing.T) *contractDeps {
 	adminService := service.NewAdminService(userRepo, groupRepo, &accountRepo, proxyRepo, apiKeyRepo, redeemRepo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	authHandler := handler.NewAuthHandler(cfg, nil, userService, settingService, nil, redeemService, nil, nil)
 	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService)
-	usageHandler := handler.NewUsageHandler(usageService, apiKeyService)
+	usageHandler := handler.NewUsageHandler(usageService, apiKeyService, settingService)
 	adminSettingHandler := adminhandler.NewSettingHandler(settingService, nil, nil, nil, nil, nil, nil)
 	adminAccountHandler := adminhandler.NewAccountHandler(adminService, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 

--- a/backend/internal/server/routes/user.go
+++ b/backend/internal/server/routes/user.go
@@ -84,6 +84,7 @@ func RegisterUserRoutes(
 			usage.GET("", h.Usage.List)
 			usage.GET("/:id", h.Usage.GetByID)
 			usage.GET("/stats", h.Usage.Stats)
+			usage.GET("/leaderboard/daily", h.Usage.DailyTokenLeaderboard)
 			// User dashboard endpoints
 			usage.GET("/dashboard/stats", h.Usage.DashboardStats)
 			usage.GET("/dashboard/trend", h.Usage.DashboardTrend)

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -361,6 +361,11 @@ const (
 	// sidebar entry is hidden. Defaults to false (opt-in feature).
 	SettingKeyAvailableChannelsEnabled = "available_channels_enabled"
 
+	// SettingKeyDailyTokenLeaderboardEnabled is a DB-backed soft switch for the daily
+	// token leaderboard. When false: the sidebar entry is hidden and the user endpoint
+	// returns 404. Defaults to false (opt-in feature).
+	SettingKeyDailyTokenLeaderboardEnabled = "daily_token_leaderboard_enabled"
+
 	// =========================
 	// Overload Cooldown (529)
 	// =========================

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -726,6 +726,7 @@ func (s *SettingService) GetPublicSettings(ctx context.Context) (*PublicSettings
 		SettingKeyChannelMonitorEnabled,
 		SettingKeyChannelMonitorDefaultIntervalSeconds,
 		SettingKeyAvailableChannelsEnabled,
+		SettingKeyDailyTokenLeaderboardEnabled,
 		SettingKeyAffiliateEnabled,
 		SettingKeyRiskControlEnabled,
 	}
@@ -836,6 +837,8 @@ func (s *SettingService) GetPublicSettings(ctx context.Context) (*PublicSettings
 		ChannelMonitorDefaultIntervalSeconds: parseChannelMonitorInterval(settings[SettingKeyChannelMonitorDefaultIntervalSeconds]),
 
 		AvailableChannelsEnabled: settings[SettingKeyAvailableChannelsEnabled] == "true",
+
+		DailyTokenLeaderboardEnabled: settings[SettingKeyDailyTokenLeaderboardEnabled] == "true",
 
 		AffiliateEnabled: settings[SettingKeyAffiliateEnabled] == "true",
 
@@ -1092,6 +1095,7 @@ type PublicSettingsInjectionPayload struct {
 	ChannelMonitorEnabled                bool `json:"channel_monitor_enabled"`
 	ChannelMonitorDefaultIntervalSeconds int  `json:"channel_monitor_default_interval_seconds"`
 	AvailableChannelsEnabled             bool `json:"available_channels_enabled"`
+	DailyTokenLeaderboardEnabled         bool `json:"daily_token_leaderboard_enabled"`
 	AffiliateEnabled                     bool `json:"affiliate_enabled"`
 	RiskControlEnabled                   bool `json:"risk_control_enabled"`
 }
@@ -1154,6 +1158,7 @@ func (s *SettingService) GetPublicSettingsForInjection(ctx context.Context) (any
 		ChannelMonitorEnabled:                settings.ChannelMonitorEnabled,
 		ChannelMonitorDefaultIntervalSeconds: settings.ChannelMonitorDefaultIntervalSeconds,
 		AvailableChannelsEnabled:             settings.AvailableChannelsEnabled,
+		DailyTokenLeaderboardEnabled:         settings.DailyTokenLeaderboardEnabled,
 		AffiliateEnabled:                     settings.AffiliateEnabled,
 		RiskControlEnabled:                   settings.RiskControlEnabled,
 	}, nil
@@ -1792,6 +1797,9 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	// Available channels feature switch
 	updates[SettingKeyAvailableChannelsEnabled] = strconv.FormatBool(settings.AvailableChannelsEnabled)
 
+	// Daily token leaderboard feature switch
+	updates[SettingKeyDailyTokenLeaderboardEnabled] = strconv.FormatBool(settings.DailyTokenLeaderboardEnabled)
+
 	// Affiliate (邀请返利) feature switch
 	updates[SettingKeyAffiliateEnabled] = strconv.FormatBool(settings.AffiliateEnabled)
 
@@ -2281,6 +2289,18 @@ func (s *SettingService) IsAffiliateEnabled(ctx context.Context) bool {
 	return value == "true"
 }
 
+// IsDailyTokenLeaderboardEnabled checks if the daily token leaderboard is enabled.
+func (s *SettingService) IsDailyTokenLeaderboardEnabled(ctx context.Context) bool {
+	if s == nil || s.settingRepo == nil {
+		return false
+	}
+	value, err := s.settingRepo.GetValue(ctx, SettingKeyDailyTokenLeaderboardEnabled)
+	if err != nil {
+		return false
+	}
+	return value == "true"
+}
+
 // GetAffiliateRebateRatePercent 读取并 clamp 全局返利比例。
 // 解析失败、缺失或越界都回退到 AffiliateRebateRateDefault — 该比例从不抛错，
 // 调用方只关心一个可用的数值。
@@ -2696,6 +2716,9 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 
 		// Available channels feature (default disabled; opt-in)
 		SettingKeyAvailableChannelsEnabled: "false",
+
+		// Daily token leaderboard feature (default disabled; opt-in)
+		SettingKeyDailyTokenLeaderboardEnabled: "false",
 
 		// Affiliate (邀请返利) feature (default disabled; opt-in)
 		SettingKeyAffiliateEnabled: "false",
@@ -3203,6 +3226,9 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 
 	// Available channels feature (default: disabled; strict true)
 	result.AvailableChannelsEnabled = settings[SettingKeyAvailableChannelsEnabled] == "true"
+
+	// Daily token leaderboard feature (default: disabled; strict true)
+	result.DailyTokenLeaderboardEnabled = settings[SettingKeyDailyTokenLeaderboardEnabled] == "true"
 
 	// Affiliate (邀请返利) feature (default: disabled; strict true)
 	result.AffiliateEnabled = settings[SettingKeyAffiliateEnabled] == "true"

--- a/backend/internal/service/setting_service_leaderboard_test.go
+++ b/backend/internal/service/setting_service_leaderboard_test.go
@@ -1,0 +1,105 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type leaderboardSettingsRepoStub struct {
+	values  map[string]string
+	updates map[string]string
+}
+
+func (s *leaderboardSettingsRepoStub) Get(ctx context.Context, key string) (*Setting, error) {
+	panic("unexpected Get call")
+}
+
+func (s *leaderboardSettingsRepoStub) GetValue(ctx context.Context, key string) (string, error) {
+	if value, ok := s.values[key]; ok {
+		return value, nil
+	}
+	return "", ErrSettingNotFound
+}
+
+func (s *leaderboardSettingsRepoStub) Set(ctx context.Context, key, value string) error {
+	panic("unexpected Set call")
+}
+
+func (s *leaderboardSettingsRepoStub) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
+	out := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := s.values[key]; ok {
+			out[key] = value
+		}
+	}
+	return out, nil
+}
+
+func (s *leaderboardSettingsRepoStub) SetMultiple(ctx context.Context, settings map[string]string) error {
+	s.updates = make(map[string]string, len(settings))
+	for key, value := range settings {
+		s.updates[key] = value
+	}
+	return nil
+}
+
+func (s *leaderboardSettingsRepoStub) GetAll(ctx context.Context) (map[string]string, error) {
+	out := make(map[string]string, len(s.values))
+	for key, value := range s.values {
+		out[key] = value
+	}
+	return out, nil
+}
+
+func (s *leaderboardSettingsRepoStub) Delete(ctx context.Context, key string) error {
+	panic("unexpected Delete call")
+}
+
+func TestDailyTokenLeaderboardSettingDefaultsDisabled(t *testing.T) {
+	svc := NewSettingService(&leaderboardSettingsRepoStub{values: map[string]string{}}, &config.Config{})
+
+	require.False(t, svc.IsDailyTokenLeaderboardEnabled(context.Background()))
+}
+
+func TestDailyTokenLeaderboardSettingReadsStrictTrue(t *testing.T) {
+	svc := NewSettingService(&leaderboardSettingsRepoStub{
+		values: map[string]string{
+			SettingKeyDailyTokenLeaderboardEnabled: "true",
+		},
+	}, &config.Config{})
+
+	require.True(t, svc.IsDailyTokenLeaderboardEnabled(context.Background()))
+}
+
+func TestPublicAndSystemSettingsIncludeDailyTokenLeaderboardEnabled(t *testing.T) {
+	svc := NewSettingService(&leaderboardSettingsRepoStub{
+		values: map[string]string{
+			SettingKeyDailyTokenLeaderboardEnabled: "true",
+		},
+	}, &config.Config{})
+
+	publicSettings, err := svc.GetPublicSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, publicSettings.DailyTokenLeaderboardEnabled)
+
+	systemSettings, err := svc.GetAllSettings(context.Background())
+	require.NoError(t, err)
+	require.True(t, systemSettings.DailyTokenLeaderboardEnabled)
+}
+
+func TestUpdateSettingsStoresDailyTokenLeaderboardEnabled(t *testing.T) {
+	repo := &leaderboardSettingsRepoStub{values: map[string]string{}}
+	svc := NewSettingService(repo, &config.Config{})
+
+	err := svc.UpdateSettings(context.Background(), &SystemSettings{
+		DailyTokenLeaderboardEnabled: true,
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "true", repo.updates[SettingKeyDailyTokenLeaderboardEnabled])
+}

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -177,6 +177,9 @@ type SystemSettings struct {
 	// Available Channels feature (user-facing aggregate view)
 	AvailableChannelsEnabled bool `json:"available_channels_enabled"`
 
+	// Daily Token Leaderboard feature
+	DailyTokenLeaderboardEnabled bool `json:"daily_token_leaderboard_enabled"`
+
 	// Claude Code version check
 	MinClaudeCodeVersion string
 	MaxClaudeCodeVersion string
@@ -286,6 +289,9 @@ type PublicSettings struct {
 
 	// Available Channels feature (user-facing aggregate view)
 	AvailableChannelsEnabled bool `json:"available_channels_enabled"`
+
+	// Daily Token Leaderboard feature
+	DailyTokenLeaderboardEnabled bool `json:"daily_token_leaderboard_enabled"`
 
 	// Affiliate (邀请返利) feature toggle
 	AffiliateEnabled bool `json:"affiliate_enabled"`

--- a/backend/internal/service/usage_service.go
+++ b/backend/internal/service/usage_service.go
@@ -315,6 +315,23 @@ func (s *UsageService) GetUserModelStats(ctx context.Context, userID int64, star
 	return stats, nil
 }
 
+type dailyTokenLeaderboardRepository interface {
+	GetDailyTokenLeaderboard(ctx context.Context, startTime, endTime time.Time, limit int) ([]usagestats.DailyTokenLeaderboardSourceItem, error)
+}
+
+// GetDailyTokenLeaderboard returns today's global token leaderboard source rows.
+func (s *UsageService) GetDailyTokenLeaderboard(ctx context.Context, startTime, endTime time.Time, limit int) ([]usagestats.DailyTokenLeaderboardSourceItem, error) {
+	repo, ok := s.usageRepo.(dailyTokenLeaderboardRepository)
+	if !ok {
+		return nil, fmt.Errorf("daily token leaderboard repository unavailable")
+	}
+	items, err := repo.GetDailyTokenLeaderboard(ctx, startTime, endTime, limit)
+	if err != nil {
+		return nil, fmt.Errorf("get daily token leaderboard: %w", err)
+	}
+	return items, nil
+}
+
 // GetAPIKeyModelStats returns per-model usage stats for a specific API Key.
 func (s *UsageService) GetAPIKeyModelStats(ctx context.Context, apiKeyID int64, startTime, endTime time.Time) ([]usagestats.ModelStat, error) {
 	stats, err := s.usageRepo.GetModelStatsWithFilters(ctx, startTime, endTime, 0, apiKeyID, 0, 0, nil, nil, nil)

--- a/frontend/src/api/__tests__/usage.spec.ts
+++ b/frontend/src/api/__tests__/usage.spec.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { get } = vi.hoisted(() => ({
+  get: vi.fn(),
+}))
+
+vi.mock('@/api/client', () => ({
+  apiClient: {
+    get,
+  },
+}))
+
+import { usageAPI } from '@/api/usage'
+
+describe('usage api', () => {
+  beforeEach(() => {
+    get.mockReset()
+  })
+
+  it('fetches the daily token leaderboard from the user usage endpoint', async () => {
+    const response = {
+      items: [{ rank: 1, display_name: 'ali***', total_tokens: 123456 }],
+      start_date: '2026-05-27',
+      end_date: '2026-05-27',
+      limit: 5,
+      generated_at: '2026-05-27T12:00:00+08:00',
+    }
+    get.mockResolvedValue({ data: response })
+
+    await expect(usageAPI.getDailyTokenLeaderboard()).resolves.toEqual(response)
+
+    expect(get).toHaveBeenCalledWith('/usage/leaderboard/daily')
+  })
+})

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -606,6 +606,9 @@ export interface SystemSettings {
   // Available Channels feature switch
   available_channels_enabled: boolean;
 
+  // Daily Token Leaderboard feature switch
+  daily_token_leaderboard_enabled: boolean;
+
   // Affiliate (邀请返利) feature switch
   affiliate_enabled: boolean;
 
@@ -834,6 +837,9 @@ export interface UpdateSettingsRequest {
 
   // Available Channels feature switch
   available_channels_enabled?: boolean;
+
+  // Daily Token Leaderboard feature switch
+  daily_token_leaderboard_enabled?: boolean;
 
   // Affiliate (邀请返利) feature switch
   affiliate_enabled?: boolean;

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -88,6 +88,20 @@ export interface ApiKeyDailyUsageResponse {
   end_date: string
 }
 
+export interface DailyTokenLeaderboardItem {
+  rank: number
+  display_name: string
+  total_tokens: number
+}
+
+export interface DailyTokenLeaderboardResponse {
+  items: DailyTokenLeaderboardItem[]
+  start_date: string
+  end_date: string
+  limit: number
+  generated_at: string
+}
+
 /**
  * List usage logs with optional filters
  * @param page - Page number (default: 1)
@@ -254,6 +268,15 @@ export async function getDashboardModels(params?: {
 }
 
 /**
+ * Get today's public token leaderboard for authenticated users.
+ * @returns Daily token leaderboard rows
+ */
+export async function getDailyTokenLeaderboard(): Promise<DailyTokenLeaderboardResponse> {
+  const { data } = await apiClient.get<DailyTokenLeaderboardResponse>('/usage/leaderboard/daily')
+  return data
+}
+
+/**
  * Get daily usage details for one API key owned by the current user.
  * @param apiKeyId - API key ID
  * @param days - Number of days to include (1-90)
@@ -315,6 +338,7 @@ export const usageAPI = {
   getDashboardStats,
   getDashboardTrend,
   getDashboardModels,
+  getDailyTokenLeaderboard,
   getMyApiKeyDailyUsage,
   getDashboardApiKeysUsage
 }

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -664,6 +664,7 @@ const ChevronDownIcon = {
 const flagChannelMonitor = makeSidebarFlag(FeatureFlags.channelMonitor)
 const flagPayment = makeSidebarFlag(FeatureFlags.payment)
 const flagAvailableChannels = makeSidebarFlag(FeatureFlags.availableChannels)
+const flagDailyTokenLeaderboard = makeSidebarFlag(FeatureFlags.dailyTokenLeaderboard)
 const flagAffiliate = makeSidebarFlag(FeatureFlags.affiliate)
 const flagRiskControl = makeSidebarFlag(FeatureFlags.riskControl)
 const flagOpsMonitoring = () => adminSettingsStore.opsMonitoringEnabled
@@ -682,7 +683,7 @@ function buildSelfNavItems(withDashboard: boolean): NavItem[] {
   items.push(
     { path: '/keys', label: t('nav.apiKeys'), icon: KeyIcon },
     { path: '/usage', label: t('nav.usage'), icon: ChartIcon, hideInSimpleMode: true },
-    { path: '/leaderboard', label: t('nav.leaderboard'), icon: TrophyIcon },
+    { path: '/leaderboard', label: t('nav.leaderboard'), icon: TrophyIcon, hideInSimpleMode: true, featureFlag: flagDailyTokenLeaderboard },
     { path: '/available-channels', label: t('nav.availableChannels'), icon: ChannelIcon, hideInSimpleMode: true, featureFlag: flagAvailableChannels },
     { path: '/monitor', label: t('nav.channelStatus'), icon: SignalIcon, featureFlag: flagChannelMonitor },
     { path: '/subscriptions', label: t('nav.mySubscriptions'), icon: CreditCardIcon, hideInSimpleMode: true },

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -293,6 +293,21 @@ const ChartIcon = {
     )
 }
 
+const TrophyIcon = {
+  render: () =>
+    h(
+      'svg',
+      { fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', 'stroke-width': '1.5' },
+      [
+        h('path', {
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
+          d: 'M16.5 18.75h-9m9 0a3 3 0 0 1 3 3h-15a3 3 0 0 1 3-3m9 0v-3.375c0-.621-.504-1.125-1.125-1.125h-.871M7.5 18.75v-3.375c0-.621.504-1.125 1.125-1.125h.871m0 0A6.736 6.736 0 0 1 6.75 8.75V3.75h10.5v5a6.736 6.736 0 0 1-2.746 5.5m-5.008 0h5.008M5.25 5.25H3.75v2.25A2.25 2.25 0 0 0 6 9.75h.75m10.5-4.5h1.5v2.25a2.25 2.25 0 0 1-2.25 2.25h-.75'
+        })
+      ]
+    )
+}
+
 const GiftIcon = {
   render: () =>
     h(
@@ -667,6 +682,7 @@ function buildSelfNavItems(withDashboard: boolean): NavItem[] {
   items.push(
     { path: '/keys', label: t('nav.apiKeys'), icon: KeyIcon },
     { path: '/usage', label: t('nav.usage'), icon: ChartIcon, hideInSimpleMode: true },
+    { path: '/leaderboard', label: t('nav.leaderboard'), icon: TrophyIcon },
     { path: '/available-channels', label: t('nav.availableChannels'), icon: ChannelIcon, hideInSimpleMode: true, featureFlag: flagAvailableChannels },
     { path: '/monitor', label: t('nav.channelStatus'), icon: SignalIcon, featureFlag: flagChannelMonitor },
     { path: '/subscriptions', label: t('nav.mySubscriptions'), icon: CreditCardIcon, hideInSimpleMode: true },

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -32,11 +32,12 @@ describe('AppSidebar header styles', () => {
 })
 
 describe('AppSidebar leaderboard navigation', () => {
-  it('adds leaderboard to shared user and admin personal navigation items', () => {
+  it('adds feature-flagged leaderboard to shared user and admin personal navigation items', () => {
     const buildSelfNavItemsMatch = componentSource.match(/function buildSelfNavItems\(withDashboard: boolean\): NavItem\[] \{[\s\S]*?return items\n\}/)
 
     expect(buildSelfNavItemsMatch).not.toBeNull()
     expect(buildSelfNavItemsMatch?.[0]).toContain("path: '/leaderboard'")
     expect(buildSelfNavItemsMatch?.[0]).toContain("label: t('nav.leaderboard')")
+    expect(buildSelfNavItemsMatch?.[0]).toContain('featureFlag: flagDailyTokenLeaderboard')
   })
 })

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -30,3 +30,13 @@ describe('AppSidebar header styles', () => {
     expect(sidebarBrandBlockMatch?.[0]).not.toContain('overflow: hidden;')
   })
 })
+
+describe('AppSidebar leaderboard navigation', () => {
+  it('adds leaderboard to shared user and admin personal navigation items', () => {
+    const buildSelfNavItemsMatch = componentSource.match(/function buildSelfNavItems\(withDashboard: boolean\): NavItem\[] \{[\s\S]*?return items\n\}/)
+
+    expect(buildSelfNavItemsMatch).not.toBeNull()
+    expect(buildSelfNavItemsMatch?.[0]).toContain("path: '/leaderboard'")
+    expect(buildSelfNavItemsMatch?.[0]).toContain("label: t('nav.leaderboard')")
+  })
+})

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5291,6 +5291,12 @@ export default {
           enabled: 'Enable Available Channels',
           enabledHint: 'When off, the sidebar entry is hidden and the endpoint returns an empty list.',
         },
+        dailyTokenLeaderboard: {
+          title: 'Daily Token Leaderboard',
+          description: 'Show logged-in users the top 5 site-wide token consumers for today. Disabled by default.',
+          enabled: 'Enable Daily Token Leaderboard',
+          enabledHint: 'When off, the user sidebar entry is hidden and the leaderboard endpoint is unavailable.',
+        },
         riskControl: {
           title: 'Risk Control',
           description: 'Enable the content moderation menu and gateway audit entry point. Disabled by default.',

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -350,6 +350,7 @@ export default {
     announcements: 'Announcements',
     apiKeys: 'API Keys',
     usage: 'Usage',
+    leaderboard: 'Leaderboard',
     redeem: 'Redeem',
     affiliate: 'Affiliate Rebates',
     affiliateManagement: 'Affiliate Rebates',
@@ -388,6 +389,19 @@ export default {
     channelMonitor: 'Channel Monitor',
     channelStatus: 'Channel Status',
     riskControl: 'Risk Control',
+  },
+
+  leaderboard: {
+    title: 'Leaderboard',
+    subtitle: "Today's top 5 token users across the site",
+    todayTop: 'Today Token Top 5',
+    rank: 'Rank',
+    user: 'User',
+    tokensToday: 'Tokens Today',
+    empty: 'No token usage today',
+    failedToLoad: 'Failed to load leaderboard',
+    refresh: 'Refresh',
+    refreshing: 'Refreshing...',
   },
 
   // Auth

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -350,6 +350,7 @@ export default {
     announcements: '公告',
     apiKeys: 'API 密钥',
     usage: '使用记录',
+    leaderboard: '排行榜',
     redeem: '兑换',
     affiliate: '邀请返利',
     affiliateManagement: '邀请返利',
@@ -388,6 +389,19 @@ export default {
     channelMonitor: '渠道监控',
     channelStatus: '渠道状态',
     riskControl: '风控中心',
+  },
+
+  leaderboard: {
+    title: '排行榜',
+    subtitle: '查看今日全站 Token 用量前 5 名',
+    todayTop: '今日 Token Top 5',
+    rank: '排名',
+    user: '用户',
+    tokensToday: '今日 Token',
+    empty: '今日暂无 Token 用量',
+    failedToLoad: '排行榜加载失败',
+    refresh: '刷新',
+    refreshing: '刷新中...',
   },
 
   // Auth

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5454,6 +5454,12 @@ export default {
           enabled: '启用可用渠道',
           enabledHint: '关闭后用户端侧边栏入口隐藏，接口返回空数组。',
         },
+        dailyTokenLeaderboard: {
+          title: '每日 Token 排行榜',
+          description: '向已登录用户展示全站今日 Token 用量前 5 名。默认关闭。',
+          enabled: '启用每日 Token 排行榜',
+          enabledHint: '关闭后用户侧边栏入口隐藏，排行榜接口不可访问。',
+        },
         riskControl: {
           title: '风控中心',
           description: '启用内容审计菜单和全端点请求审核入口。默认关闭。',

--- a/frontend/src/router/__tests__/guards.spec.ts
+++ b/frontend/src/router/__tests__/guards.spec.ts
@@ -53,6 +53,7 @@ interface MockAuthState {
   isAdmin: boolean
   isSimpleMode: boolean
   backendModeEnabled: boolean
+  dailyTokenLeaderboardEnabled?: boolean
   hasPendingAuthSession: boolean
   setupNeedsSetup?: boolean
 }
@@ -114,6 +115,12 @@ function simulateGuard(
     return '/dashboard'
   }
 
+  if (toMeta.requiresDailyTokenLeaderboard) {
+    if (authState.dailyTokenLeaderboardEnabled !== true) {
+      return authState.isAdmin ? '/admin/dashboard' : '/dashboard'
+    }
+  }
+
   // 简易模式限制
   if (authState.isSimpleMode) {
     const restrictedPaths = [
@@ -152,6 +159,13 @@ function simulateGuard(
   }
 
   return null // 允许通过
+}
+
+function resolveDailyTokenLeaderboardEnabled(
+  cachedValue: boolean | undefined,
+  fetchedValue: boolean | null,
+): boolean {
+  return (cachedValue ?? fetchedValue) === true
 }
 
 describe('路由守卫逻辑', () => {
@@ -215,6 +229,30 @@ describe('路由守卫逻辑', () => {
     it('访问 /dashboard 允许通过', () => {
       const redirect = simulateGuard('/dashboard', {}, authState)
       expect(redirect).toBeNull()
+    })
+
+    it('排行榜未启用时访问 /leaderboard 重定向到 /dashboard', () => {
+      const redirect = simulateGuard(
+        '/leaderboard',
+        { requiresDailyTokenLeaderboard: true },
+        { ...authState, dailyTokenLeaderboardEnabled: false },
+      )
+      expect(redirect).toBe('/dashboard')
+    })
+
+    it('排行榜启用时允许访问 /leaderboard', () => {
+      const redirect = simulateGuard(
+        '/leaderboard',
+        { requiresDailyTokenLeaderboard: true },
+        { ...authState, dailyTokenLeaderboardEnabled: true },
+      )
+      expect(redirect).toBeNull()
+    })
+
+    it('排行榜守卫无缓存时使用拉取到的公共设置', () => {
+      expect(resolveDailyTokenLeaderboardEnabled(undefined, true)).toBe(true)
+      expect(resolveDailyTokenLeaderboardEnabled(undefined, false)).toBe(false)
+      expect(resolveDailyTokenLeaderboardEnabled(false, true)).toBe(false)
     })
 
     it('访问管理页面被拒绝，重定向到 /dashboard', () => {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -225,7 +225,8 @@ const routes: RouteRecordRaw[] = [
       requiresAdmin: false,
       title: 'Leaderboard',
       titleKey: 'leaderboard.title',
-      descriptionKey: 'leaderboard.subtitle'
+      descriptionKey: 'leaderboard.subtitle',
+      requiresDailyTokenLeaderboard: true
     }
   },
   {
@@ -833,6 +834,15 @@ router.beforeEach(async (to, _from, next) => {
     const riskControlEnabled = appStore.cachedPublicSettings?.risk_control_enabled === true
     if (!riskControlEnabled) {
       next(authStore.isAdmin ? '/admin/settings' : '/dashboard')
+      return
+    }
+  }
+
+  if (to.meta.requiresDailyTokenLeaderboard) {
+    const publicSettings = appStore.cachedPublicSettings ?? await appStore.fetchPublicSettings()
+    const dailyTokenLeaderboardEnabled = publicSettings?.daily_token_leaderboard_enabled === true
+    if (!dailyTokenLeaderboardEnabled) {
+      next(authStore.isAdmin ? '/admin/dashboard' : '/dashboard')
       return
     }
   }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -217,6 +217,18 @@ const routes: RouteRecordRaw[] = [
     }
   },
   {
+    path: '/leaderboard',
+    name: 'Leaderboard',
+    component: () => import('@/views/user/LeaderboardView.vue'),
+    meta: {
+      requiresAuth: true,
+      requiresAdmin: false,
+      title: 'Leaderboard',
+      titleKey: 'leaderboard.title',
+      descriptionKey: 'leaderboard.subtitle'
+    }
+  },
+  {
     path: '/redeem',
     name: 'Redeem',
     component: () => import('@/views/user/RedeemView.vue'),

--- a/frontend/src/router/meta.d.ts
+++ b/frontend/src/router/meta.d.ts
@@ -56,6 +56,13 @@ declare module 'vue-router' {
     requiresRiskControl?: boolean
 
     /**
+     * Whether this route requires the daily token leaderboard feature switch
+     * to be enabled.
+     * @default false
+     */
+    requiresDailyTokenLeaderboard?: boolean
+
+    /**
      * i18n key for the page title
      */
     titleKey?: string

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -357,6 +357,7 @@ export const useAppStore = defineStore('app', () => {
         channel_monitor_enabled: true,
         channel_monitor_default_interval_seconds: 60,
         available_channels_enabled: false,
+        daily_token_leaderboard_enabled: false,
         risk_control_enabled: false,
         affiliate_enabled: false,
       }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -232,6 +232,7 @@ export interface PublicSettings {
   channel_monitor_enabled: boolean
   channel_monitor_default_interval_seconds: number
   available_channels_enabled: boolean
+  daily_token_leaderboard_enabled: boolean
   affiliate_enabled: boolean
 }
 

--- a/frontend/src/utils/featureFlags.ts
+++ b/frontend/src/utils/featureFlags.ts
@@ -104,6 +104,11 @@ export const FeatureFlags = {
     mode: 'opt-in',
     label: 'Available Channels',
   }),
+  dailyTokenLeaderboard: defineFlag({
+    key: 'daily_token_leaderboard_enabled',
+    mode: 'opt-in',
+    label: 'Daily Token Leaderboard',
+  }),
   payment: defineFlag({
     key: 'payment_enabled',
     mode: 'opt-out',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -5228,6 +5228,30 @@
         <div class="card">
           <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+              {{ t('admin.settings.features.dailyTokenLeaderboard.title') }}
+            </h2>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              {{ t('admin.settings.features.dailyTokenLeaderboard.description') }}
+            </p>
+          </div>
+          <div class="space-y-5 p-6">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t('admin.settings.features.dailyTokenLeaderboard.enabled') }}
+                </label>
+                <p class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('admin.settings.features.dailyTokenLeaderboard.enabledHint') }}
+                </p>
+              </div>
+              <Toggle v-model="form.daily_token_leaderboard_enabled" />
+            </div>
+          </div>
+        </div>
+
+        <div class="card">
+          <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
               {{ t('admin.settings.features.riskControl.title') }}
             </h2>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
@@ -7174,6 +7198,8 @@ const form = reactive<SettingsForm>({
   channel_monitor_default_interval_seconds: 60,
   // Available Channels feature switch
   available_channels_enabled: false,
+  // Daily Token Leaderboard feature switch
+  daily_token_leaderboard_enabled: false,
   // Affiliate (邀请返利) feature switch
   affiliate_enabled: false,
 });
@@ -8314,6 +8340,8 @@ async function saveSettings() {
         Number(form.channel_monitor_default_interval_seconds) || 60,
       // Available Channels feature switch
       available_channels_enabled: form.available_channels_enabled,
+      // Daily Token Leaderboard feature switch
+      daily_token_leaderboard_enabled: form.daily_token_leaderboard_enabled,
       // Affiliate (邀请返利) feature switch
       affiliate_enabled: form.affiliate_enabled,
     };

--- a/frontend/src/views/user/LeaderboardView.vue
+++ b/frontend/src/views/user/LeaderboardView.vue
@@ -1,0 +1,148 @@
+<template>
+  <AppLayout>
+    <div class="space-y-6">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-gray-900 dark:text-white">
+            {{ t('leaderboard.title') }}
+          </h1>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('leaderboard.subtitle') }}
+          </p>
+        </div>
+        <button
+          type="button"
+          class="btn btn-secondary"
+          :disabled="loading"
+          @click="loadLeaderboard"
+        >
+          <RefreshIcon class="h-4 w-4" :class="{ 'animate-spin': loading }" />
+          <span>{{ loading ? t('leaderboard.refreshing') : t('leaderboard.refresh') }}</span>
+        </button>
+      </div>
+
+      <div class="card overflow-hidden">
+        <div class="card-header flex items-center justify-between gap-4">
+          <div>
+            <h2 class="text-base font-semibold text-gray-900 dark:text-white">
+              {{ t('leaderboard.todayTop') }}
+            </h2>
+            <p v-if="leaderboard" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ leaderboard.start_date }}
+            </p>
+          </div>
+          <div class="rounded-full bg-primary-50 px-3 py-1 text-xs font-medium text-primary-700 dark:bg-primary-900/30 dark:text-primary-200">
+            Top {{ leaderboard?.limit ?? 5 }}
+          </div>
+        </div>
+
+        <div v-if="loading && !leaderboard" class="flex items-center justify-center py-16">
+          <LoadingSpinner size="lg" />
+        </div>
+
+        <div v-else-if="error" class="px-6 py-14 text-center">
+          <p class="text-sm font-medium text-red-600 dark:text-red-400">
+            {{ t('leaderboard.failedToLoad') }}
+          </p>
+          <button type="button" class="btn btn-primary mt-4" @click="loadLeaderboard">
+            <RefreshIcon class="h-4 w-4" />
+            <span>{{ t('leaderboard.refresh') }}</span>
+          </button>
+        </div>
+
+        <div v-else-if="!leaderboard?.items.length" class="px-6 py-14 text-center">
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            {{ t('leaderboard.empty') }}
+          </p>
+        </div>
+
+        <div v-else class="divide-y divide-gray-100 dark:divide-dark-700">
+          <div class="grid grid-cols-[72px_1fr_minmax(120px,180px)] gap-3 px-6 py-3 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            <span>{{ t('leaderboard.rank') }}</span>
+            <span>{{ t('leaderboard.user') }}</span>
+            <span class="text-right">{{ t('leaderboard.tokensToday') }}</span>
+          </div>
+          <div
+            v-for="item in leaderboard.items"
+            :key="item.rank"
+            class="grid grid-cols-[72px_1fr_minmax(120px,180px)] items-center gap-3 px-6 py-4"
+          >
+            <div class="flex items-center gap-2">
+              <span
+                class="flex h-9 w-9 items-center justify-center rounded-full text-sm font-bold"
+                :class="rankClass(item.rank)"
+              >
+                #{{ item.rank }}
+              </span>
+            </div>
+            <div class="min-w-0">
+              <p class="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                {{ item.display_name }}
+              </p>
+            </div>
+            <p class="text-right text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
+              {{ formatTokens(item.total_tokens) }}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </AppLayout>
+</template>
+
+<script setup lang="ts">
+import { h, onMounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import AppLayout from '@/components/layout/AppLayout.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+import { usageAPI, type DailyTokenLeaderboardResponse } from '@/api/usage'
+
+const { t } = useI18n()
+
+const leaderboard = ref<DailyTokenLeaderboardResponse | null>(null)
+const loading = ref(false)
+const error = ref(false)
+
+const RefreshIcon = {
+  render: () =>
+    h(
+      'svg',
+      { fill: 'none', viewBox: '0 0 24 24', stroke: 'currentColor', 'stroke-width': '1.5' },
+      [
+        h('path', {
+          'stroke-linecap': 'round',
+          'stroke-linejoin': 'round',
+          d: 'M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M7.977 14.652H2.985m0 0V9.66m0 4.992 3.181-3.183a8.25 8.25 0 0 1 13.803 3.7'
+        })
+      ]
+    )
+}
+
+function formatTokens(value: number): string {
+  return new Intl.NumberFormat().format(value)
+}
+
+function rankClass(rank: number): string {
+  if (rank === 1) return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-200'
+  if (rank === 2) return 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-200'
+  if (rank === 3) return 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-200'
+  return 'bg-gray-100 text-gray-700 dark:bg-dark-700 dark:text-gray-200'
+}
+
+async function loadLeaderboard() {
+  loading.value = true
+  error.value = false
+  try {
+    leaderboard.value = await usageAPI.getDailyTokenLeaderboard()
+  } catch (err) {
+    console.error('Failed to load daily token leaderboard:', err)
+    error.value = true
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  loadLeaderboard()
+})
+</script>

--- a/frontend/src/views/user/__tests__/LeaderboardView.spec.ts
+++ b/frontend/src/views/user/__tests__/LeaderboardView.spec.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import LeaderboardView from '../LeaderboardView.vue'
+
+const { getDailyTokenLeaderboard } = vi.hoisted(() => ({
+  getDailyTokenLeaderboard: vi.fn(),
+}))
+
+const messages: Record<string, string> = {
+  'leaderboard.title': 'Daily Token Leaderboard',
+  'leaderboard.subtitle': 'Top 5 token users today',
+  'leaderboard.rank': 'Rank',
+  'leaderboard.user': 'User',
+  'leaderboard.tokensToday': 'Tokens Today',
+  'leaderboard.empty': 'No token usage today',
+  'leaderboard.failedToLoad': 'Failed to load leaderboard',
+  'leaderboard.refresh': 'Refresh',
+  'leaderboard.refreshing': 'Refreshing...',
+}
+
+vi.mock('@/api/usage', () => ({
+  usageAPI: {
+    getDailyTokenLeaderboard,
+  },
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => messages[key] ?? key,
+    }),
+  }
+})
+
+const AppLayoutStub = { template: '<div><slot /></div>' }
+const LoadingSpinnerStub = { template: '<div data-testid="loading-spinner" />' }
+
+function mountView() {
+  return mount(LeaderboardView, {
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        LoadingSpinner: LoadingSpinnerStub,
+      },
+    },
+  })
+}
+
+describe('LeaderboardView', () => {
+  beforeEach(() => {
+    getDailyTokenLeaderboard.mockReset()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('renders the top 5 rows with formatted token counts', async () => {
+    getDailyTokenLeaderboard.mockResolvedValue({
+      items: [
+        { rank: 1, display_name: 'ali***', total_tokens: 1234567 },
+        { rank: 2, display_name: 'bo***', total_tokens: 98765 },
+      ],
+      start_date: '2026-05-27',
+      end_date: '2026-05-27',
+      limit: 5,
+      generated_at: '2026-05-27T12:00:00+08:00',
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Daily Token Leaderboard')
+    expect(wrapper.text()).toContain('#1')
+    expect(wrapper.text()).toContain('ali***')
+    expect(wrapper.text()).toContain('1,234,567')
+    expect(wrapper.text()).toContain('#2')
+    expect(wrapper.text()).toContain('bo***')
+    expect(wrapper.text()).toContain('98,765')
+  })
+
+  it('renders an empty state when there are no leaderboard rows', async () => {
+    getDailyTokenLeaderboard.mockResolvedValue({
+      items: [],
+      start_date: '2026-05-27',
+      end_date: '2026-05-27',
+      limit: 5,
+      generated_at: '2026-05-27T12:00:00+08:00',
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('No token usage today')
+  })
+
+  it('renders an error state and can retry manually', async () => {
+    getDailyTokenLeaderboard.mockRejectedValueOnce(new Error('network'))
+    getDailyTokenLeaderboard.mockResolvedValueOnce({
+      items: [{ rank: 1, display_name: 'zoe***', total_tokens: 42 }],
+      start_date: '2026-05-27',
+      end_date: '2026-05-27',
+      limit: 5,
+      generated_at: '2026-05-27T12:00:00+08:00',
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Failed to load leaderboard')
+
+    await wrapper.get('button').trigger('click')
+    await flushPromises()
+
+    expect(getDailyTokenLeaderboard).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('zoe***')
+  })
+})


### PR DESCRIPTION
## Summary
- Add an authenticated daily token leaderboard showing today’s top 5 site-wide token users.
- Mask user identity and expose only rank, display name, and total tokens.
- Add an admin system setting to enable or disable the leaderboard, disabled by default.
- Hide the frontend navigation and block the route/API when disabled.

## Tests
- `make test-unit`
- `make test-frontend`
- `git diff --check upstream/main..HEAD`

## Notes
- `make test-integration` was attempted locally, but Docker could not pull Redis/Postgres testcontainers images from Docker Hub due a local network/proxy timeout.