### PR TITLE
Fix OpenAI OAuth image n fanout

### DIFF
--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -373,10 +374,6 @@ func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel st
 	tool := []byte(`{"type":"image_generation","action":"","model":""}`)
 	tool, _ = sjson.SetBytes(tool, "action", action)
 	tool, _ = sjson.SetBytes(tool, "model", strings.TrimSpace(toolModel))
-	if shouldPassOpenAIImagesN(toolModel, parsed.N) {
-		tool, _ = sjson.SetBytes(tool, "n", parsed.N)
-	}
-
 	for _, field := range []struct {
 		path  string
 		value string
@@ -414,13 +411,6 @@ func buildOpenAIImagesResponsesRequest(parsed *OpenAIImagesRequest, toolModel st
 	req, _ = sjson.SetRawBytes(req, "tools", []byte(`[]`))
 	req, _ = sjson.SetRawBytes(req, "tools.-1", tool)
 	return req, nil
-}
-
-func shouldPassOpenAIImagesN(model string, n int) bool {
-	if n <= 1 {
-		return false
-	}
-	return !strings.EqualFold(strings.TrimSpace(model), "dall-e-3")
 }
 
 func extractOpenAIImagesFromResponsesCompleted(payload []byte) ([]openAIResponsesImageResult, int64, []byte, openAIResponsesImageResult, error) {
@@ -1242,21 +1232,47 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 		return OpenAIUsage{}, 0, nil, err
 	}
 
+	collected, err := s.collectOpenAIImagesOAuthNonStreamingBody(body, fallbackModel)
+	if err != nil {
+		s.reportOpenAIImagesOAuthCollectError(c, body, err)
+		return OpenAIUsage{}, 0, nil, err
+	}
+
+	responseBody, err := buildOpenAIImagesAPIResponse(collected.results, collected.createdAt, collected.usageRaw, collected.firstMeta, responseFormat)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, err
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
+	return collected.usage, len(collected.results), openAIResponsesImageResultSizes(collected.results), nil
+}
+
+type openAIImagesOAuthNonStreamingResult struct {
+	usage     OpenAIUsage
+	results   []openAIResponsesImageResult
+	createdAt int64
+	usageRaw  []byte
+	firstMeta openAIResponsesImageResult
+}
+
+// collectOpenAIImagesOAuthNonStreamingBody 解析非流式 OAuth 生图响应体，只做纯解析
+// 不触碰 gin.Context（fanout 并发 attempt 内调用，副作用统一由调用方在主 goroutine
+// 通过 reportOpenAIImagesOAuthCollectError 重放）。
+func (s *OpenAIGatewayService) collectOpenAIImagesOAuthNonStreamingBody(
+	body []byte,
+	fallbackModel string,
+) (openAIImagesOAuthNonStreamingResult, error) {
 	var usage OpenAIUsage
 	forEachOpenAISSEDataPayload(string(body), func(data []byte) {
 		s.parseOpenAIImagesSSEUsageBytes(data, &usage)
 	})
 	results, createdAt, usageRaw, firstMeta, _, err := collectOpenAIImagesFromResponsesBody(body)
 	if err != nil {
-		return OpenAIUsage{}, 0, nil, err
+		return openAIImagesOAuthNonStreamingResult{}, err
 	}
 	if len(results) == 0 {
 		if upstreamErr := extractOpenAIImagesUpstreamError(body); upstreamErr != nil {
-			setOpsUpstreamError(c, upstreamErr.clientStatusCode(), upstreamErr.clientMessage(), "")
-			if !IsOpenAIImagesRetryableUpstreamError(upstreamErr) {
-				writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
-			}
-			return OpenAIUsage{}, 0, nil, upstreamErr
+			return openAIImagesOAuthNonStreamingResult{}, upstreamErr
 		}
 		// 软失败兜底：上游无图。先区分两种情形（实测真因，见下）：
 		//
@@ -1268,23 +1284,19 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 		// (B) 真空响应：既无图也无任何文字输出（罕见，如偶发路由到 gpt-5.x-mini、
 		//     image_gen 工具未执行）。这是上游的概率性失败，此时才按可重试处理。
 		if refusal := extractOpenAIImagesModelRefusal(body); refusal != "" {
-			refusalErr := &OpenAIImagesUpstreamError{
+			return openAIImagesOAuthNonStreamingResult{}, &OpenAIImagesUpstreamError{
 				StatusCode: http.StatusBadRequest,
 				ErrorType:  "image_generation_user_error",
 				Code:       "content_policy_violation",
 				Message:    sanitizeUpstreamErrorMessage(refusal),
 			}
-			setOpsUpstreamError(c, http.StatusBadRequest, refusalErr.clientMessage(), summarizeOpenAIImagesNoOutputBody(body))
-			writeOpenAIImagesUpstreamErrorResponse(c, refusalErr)
-			return OpenAIUsage{}, 0, nil, refusalErr
 		}
-		// (B) 真空响应：记录上游诊断摘要到 ops（last_event/status/model/body 片段）便于
-		// 排查，并返回 UpstreamFailoverError 触发重试。因实测为「同账号概率性失败」，优先
+		// (B) 真空响应：诊断摘要由 reportOpenAIImagesOAuthCollectError 记录到 ops。返回
+		// UpstreamFailoverError 触发重试。因实测为「同账号概率性失败」，优先
 		// RetryableOnSameAccount 同账号快速重试（默认 3 次，大概率某次正常出图），用尽后
 		// 由 handler 自然换账号 failover（switchCount 上限保护），既提高成功率又不无谓
 		// 消耗其它账号配额。
-		setOpsUpstreamError(c, http.StatusBadGateway, "upstream did not return image output", summarizeOpenAIImagesNoOutputBody(body))
-		return OpenAIUsage{}, 0, nil, &UpstreamFailoverError{
+		return openAIImagesOAuthNonStreamingResult{}, &UpstreamFailoverError{
 			StatusCode:             http.StatusBadGateway,
 			ResponseBody:           body,
 			RetryableOnSameAccount: true,
@@ -1293,14 +1305,72 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	if strings.TrimSpace(firstMeta.Model) == "" {
 		firstMeta.Model = strings.TrimSpace(fallbackModel)
 	}
+	return openAIImagesOAuthNonStreamingResult{
+		usage:     usage,
+		results:   results,
+		createdAt: createdAt,
+		usageRaw:  usageRaw,
+		firstMeta: firstMeta,
+	}, nil
+}
 
-	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
-	if err != nil {
-		return OpenAIUsage{}, 0, nil, err
+func isOpenAIImagesRefusalError(err *OpenAIImagesUpstreamError) bool {
+	return err != nil &&
+		err.ErrorType == "image_generation_user_error" &&
+		err.Code == "content_policy_violation"
+}
+
+// reportOpenAIImagesOAuthCollectError 重放 collect 错误对应的 ops 记录与客户端错误
+// 响应，与拆分前 handleOpenAIImagesOAuthNonStreamingResponse 的内联行为一致：
+// 不可重试的上游错误与内容审核拒绝会直接写响应，可重试错误留给 handler failover。
+func (s *OpenAIGatewayService) reportOpenAIImagesOAuthCollectError(c *gin.Context, body []byte, err error) {
+	var failoverErr *UpstreamFailoverError
+	if errors.As(err, &failoverErr) {
+		setOpsUpstreamError(c, http.StatusBadGateway, "upstream did not return image output", summarizeOpenAIImagesNoOutputBody(body))
+		return
 	}
-	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
-	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
-	return usage, len(results), openAIResponsesImageResultSizes(results), nil
+	var upstreamErr *OpenAIImagesUpstreamError
+	if !errors.As(err, &upstreamErr) {
+		return
+	}
+	if isOpenAIImagesRefusalError(upstreamErr) {
+		setOpsUpstreamError(c, http.StatusBadRequest, upstreamErr.clientMessage(), summarizeOpenAIImagesNoOutputBody(body))
+		writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
+		return
+	}
+	setOpsUpstreamError(c, upstreamErr.clientStatusCode(), upstreamErr.clientMessage(), "")
+	if !IsOpenAIImagesRetryableUpstreamError(upstreamErr) {
+		writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
+	}
+}
+
+// buildOpenAIImagesUsageRaw 以 Responses usage JSON 的字段布局重建聚合后的 usage，
+// 字段路径与 openAIUsageFromGJSON 的解析路径保持一致。
+func buildOpenAIImagesUsageRaw(usage OpenAIUsage) []byte {
+	if usage == (OpenAIUsage{}) {
+		return nil
+	}
+
+	body := []byte(`{}`)
+	if usage.InputTokens > 0 {
+		body, _ = sjson.SetBytes(body, "input_tokens", usage.InputTokens)
+	}
+	if usage.OutputTokens > 0 {
+		body, _ = sjson.SetBytes(body, "output_tokens", usage.OutputTokens)
+	}
+	if usage.CacheReadInputTokens > 0 {
+		body, _ = sjson.SetBytes(body, "input_tokens_details.cached_tokens", usage.CacheReadInputTokens)
+	}
+	if usage.CacheCreationInputTokens > 0 {
+		body, _ = sjson.SetBytes(body, "input_tokens_details.cache_creation_tokens", usage.CacheCreationInputTokens)
+	}
+	if usage.ImageInputTokens > 0 {
+		body, _ = sjson.SetBytes(body, "input_tokens_details.image_tokens", usage.ImageInputTokens)
+	}
+	if usage.ImageOutputTokens > 0 {
+		body, _ = sjson.SetBytes(body, "output_tokens_details.image_tokens", usage.ImageOutputTokens)
+	}
+	return body
 }
 
 func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
@@ -1695,6 +1765,25 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 		return nil, err
 	}
 
+	// 上游 Responses 的 image_generation 工具不支持 n 参数（传了也只出一张图），
+	// n > 1 通过并发 fanout 成 n 个 n=1 请求聚合；流式 fanout 无法保持标准流
+	// 契约，明确拒绝。
+	if parsed.N > 1 {
+		if parsed.Stream {
+			upstreamErr := &OpenAIImagesUpstreamError{
+				StatusCode: http.StatusBadRequest,
+				ErrorType:  "invalid_request_error",
+				Code:       "unsupported_parameter",
+				Message:    "n > 1 is only supported for non-streaming OAuth image requests; retry with stream=false",
+				Param:      "n",
+			}
+			setOpsUpstreamError(c, upstreamErr.clientStatusCode(), upstreamErr.clientMessage(), "")
+			writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
+			return nil, upstreamErr
+		}
+		return s.forwardOpenAIImagesOAuthFanoutNonStreaming(upstreamCtx, c, account, parsed, requestModel, token, startTime)
+	}
+
 	responsesBody, err := buildOpenAIImagesResponsesRequest(parsed, requestModel)
 	if err != nil {
 		return nil, err
@@ -1892,4 +1981,303 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthResponseError(
 		ResponseHeaders:        headers,
 		RetryableOnSameAccount: !shouldDisable && account.IsPoolMode() && account.IsPoolModeRetryableStatus(upstreamErr.StatusCode),
 	}
+}
+
+type openAIImagesOAuthFanoutPreparedRequest struct {
+	index int
+	body  []byte
+	req   *http.Request
+}
+
+type openAIImagesOAuthFanoutAttemptResult struct {
+	index        int
+	collected    openAIImagesOAuthNonStreamingResult
+	collectBody  []byte
+	headers      http.Header
+	requestID    string
+	upstreamURL  string
+	statusCode   int
+	responseBody []byte
+	upstreamMsg  string
+	err          error
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIImagesOAuthFanoutNonStreaming(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	parsed *OpenAIImagesRequest,
+	requestModel string,
+	token string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	targetCount := parsed.N
+	single := *parsed
+	single.N = 1
+	fanoutCtx, cancelFanout := context.WithCancel(ctx)
+	defer cancelFanout()
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	writerSizeBeforeResponse := OpenAIImagesJSONKeepaliveAdjustedWrittenSize(c)
+
+	baseStickySeed := parsed.StickySessionSeed()
+	prepared := make([]openAIImagesOAuthFanoutPreparedRequest, 0, targetCount)
+	for i := 0; i < targetCount; i++ {
+		responsesBody, err := buildOpenAIImagesResponsesRequest(&single, requestModel)
+		if err != nil {
+			return nil, err
+		}
+		stickySeed := baseStickySeed
+		if stickySeed != "" {
+			stickySeed = fmt.Sprintf("%s|fanout=%d", stickySeed, i+1)
+		}
+		upstreamReq, err := s.buildUpstreamRequest(fanoutCtx, c, account, responsesBody, token, true, stickySeed, false)
+		if err != nil {
+			return nil, err
+		}
+		upstreamReq.Header.Set("Content-Type", "application/json")
+		upstreamReq.Header.Set("Accept", "text/event-stream")
+		prepared = append(prepared, openAIImagesOAuthFanoutPreparedRequest{
+			index: i,
+			body:  responsesBody,
+			req:   upstreamReq,
+		})
+	}
+
+	upstreamTotalStart := time.Now()
+	resultCh := make(chan openAIImagesOAuthFanoutAttemptResult, targetCount)
+	var wg sync.WaitGroup
+	for _, attempt := range prepared {
+		attempt := attempt
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result := s.runOpenAIImagesOAuthFanoutAttempt(account, proxyURL, requestModel, attempt)
+			if result.err != nil || result.statusCode >= 400 {
+				cancelFanout()
+			}
+			resultCh <- result
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultCh)
+	}()
+
+	attemptResults := make([]openAIImagesOAuthFanoutAttemptResult, targetCount)
+	for result := range resultCh {
+		attemptResults[result.index] = result
+	}
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamTotalStart).Milliseconds())
+	if problem := firstOpenAIImagesOAuthFanoutProblem(attemptResults); problem != nil {
+		return s.handleOpenAIImagesOAuthFanoutProblem(ctx, c, account, requestModel, writerSizeBeforeResponse, problem)
+	}
+
+	var usage OpenAIUsage
+	results := make([]openAIResponsesImageResult, 0, targetCount)
+	var outputSizes []string
+	var createdAt int64
+	var firstMeta openAIResponsesImageResult
+	var firstHeaders http.Header
+	var requestIDs []string
+
+	for _, attempt := range attemptResults {
+		collected := attempt.collected
+		addOpenAIUsage(&usage, collected.usage)
+		results = append(results, collected.results...)
+		outputSizes = append(outputSizes, openAIResponsesImageResultSizes(collected.results)...)
+		if createdAt <= 0 {
+			createdAt = collected.createdAt
+		}
+		if strings.TrimSpace(firstMeta.Model) == "" {
+			firstMeta = collected.firstMeta
+		}
+		if firstHeaders == nil {
+			firstHeaders = attempt.headers.Clone()
+		}
+		if requestID := strings.TrimSpace(attempt.requestID); requestID != "" {
+			requestIDs = append(requestIDs, requestID)
+		}
+	}
+
+	if len(results) == 0 {
+		return nil, fmt.Errorf("upstream did not return image output")
+	}
+	if strings.TrimSpace(firstMeta.Model) == "" {
+		firstMeta.Model = strings.TrimSpace(requestModel)
+	}
+
+	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, buildOpenAIImagesUsageRaw(usage), firstMeta, parsed.ResponseFormat)
+	if err != nil {
+		return nil, err
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), firstHeaders, s.responseHeaderFilter)
+	c.Data(http.StatusOK, "application/json; charset=utf-8", responseBody)
+
+	return &OpenAIForwardResult{
+		RequestID:        strings.Join(requestIDs, ","),
+		Usage:            usage,
+		Model:            requestModel,
+		UpstreamModel:    requestModel,
+		Stream:           parsed.Stream,
+		ResponseHeaders:  firstHeaders,
+		Duration:         time.Since(startTime),
+		ImageCount:       len(results),
+		ImageSize:        parsed.SizeTier,
+		ImageInputSize:   parsed.Size,
+		ImageOutputSizes: outputSizes,
+	}, nil
+}
+
+// runOpenAIImagesOAuthFanoutAttempt 在独立 goroutine 内执行单次 fanout 子请求。
+// 此函数不得触碰 gin.Context（并发写不安全）：ops 记录与客户端响应由主 goroutine
+// 依据返回的 attempt result 统一处理。
+func (s *OpenAIGatewayService) runOpenAIImagesOAuthFanoutAttempt(
+	account *Account,
+	proxyURL string,
+	requestModel string,
+	attempt openAIImagesOAuthFanoutPreparedRequest,
+) openAIImagesOAuthFanoutAttemptResult {
+	result := openAIImagesOAuthFanoutAttemptResult{index: attempt.index}
+	if attempt.req != nil && attempt.req.URL != nil {
+		result.upstreamURL = safeUpstreamURL(attempt.req.URL.String())
+	}
+
+	resp, err := s.httpUpstream.Do(attempt.req, proxyURL, account.ID, account.Concurrency)
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		result.upstreamMsg = safeErr
+		result.err = fmt.Errorf("upstream request failed: %s", safeErr)
+		return result
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	result.statusCode = resp.StatusCode
+	result.headers = resp.Header.Clone()
+	result.requestID = strings.TrimSpace(resp.Header.Get("x-request-id"))
+	if resp.StatusCode >= 400 {
+		result.responseBody = s.readUpstreamErrorBody(resp)
+		result.upstreamMsg = sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(result.responseBody)))
+		return result
+	}
+
+	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, nil, nil)
+	if err != nil {
+		result.err = err
+		return result
+	}
+	result.collectBody = body
+	collected, err := s.collectOpenAIImagesOAuthNonStreamingBody(body, requestModel)
+	if err != nil {
+		result.err = err
+		return result
+	}
+	result.collected = collected
+	return result
+}
+
+// firstOpenAIImagesOAuthFanoutProblem 挑出最值得上报的失败：HTTP 错误优先，其次
+// 真实错误，context.Canceled（被其它失败连带取消）垫底。
+func firstOpenAIImagesOAuthFanoutProblem(results []openAIImagesOAuthFanoutAttemptResult) *openAIImagesOAuthFanoutAttemptResult {
+	for i := range results {
+		if results[i].statusCode >= 400 {
+			return &results[i]
+		}
+	}
+	for i := range results {
+		if results[i].err != nil && !errors.Is(results[i].err, context.Canceled) {
+			return &results[i]
+		}
+	}
+	for i := range results {
+		if results[i].err != nil {
+			return &results[i]
+		}
+	}
+	return nil
+}
+
+// handleOpenAIImagesOAuthFanoutProblem 在主 goroutine 内重放单请求路径对同类失败
+// 的处理（ops 记录、客户端响应、failover 语义）。与单请求路径的差异仅有一点：不做
+// agent identity 任务的原地恢复，让错误按 failover 冒泡由 handler 换账号重试。
+func (s *OpenAIGatewayService) handleOpenAIImagesOAuthFanoutProblem(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	requestModel string,
+	writerSizeBeforeResponse int,
+	problem *openAIImagesOAuthFanoutAttemptResult,
+) (*OpenAIForwardResult, error) {
+	if problem == nil {
+		return nil, nil
+	}
+
+	if problem.err != nil {
+		if errors.Is(problem.err, ErrUpstreamResponseBodyTooLarge) {
+			setOpsUpstreamError(c, http.StatusBadGateway, "upstream response too large", "")
+			openAITooLargeError(c)
+			return nil, problem.err
+		}
+		var upstreamErr *OpenAIImagesUpstreamError
+		var failoverErr *UpstreamFailoverError
+		if errors.As(problem.err, &upstreamErr) || errors.As(problem.err, &failoverErr) {
+			s.reportOpenAIImagesOAuthCollectError(c, problem.collectBody, problem.err)
+			problemResp := &http.Response{StatusCode: problem.statusCode, Header: problem.headers}
+			return nil, s.handleOpenAIImagesOAuthResponseError(
+				ctx,
+				c,
+				account,
+				requestModel,
+				problem.upstreamURL,
+				problemResp,
+				writerSizeBeforeResponse,
+				problem.err,
+			)
+		}
+		safeErr := sanitizeUpstreamErrorMessage(problem.upstreamMsg)
+		if safeErr == "" {
+			safeErr = sanitizeUpstreamErrorMessage(problem.err.Error())
+		}
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: 0,
+			UpstreamURL:        problem.upstreamURL,
+			Kind:               "request_error",
+			Message:            safeErr,
+		})
+		return nil, problem.err
+	}
+
+	respBody := s.redactAgentIdentitySensitiveBody(ctx, account, problem.responseBody)
+	resp := &http.Response{
+		StatusCode: problem.statusCode,
+		Header:     problem.headers.Clone(),
+		Body:       io.NopCloser(bytes.NewReader(respBody)),
+	}
+	upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+	if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody) {
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  problem.requestID,
+			UpstreamURL:        problem.upstreamURL,
+			Kind:               "failover",
+			Message:            upstreamMsg,
+		})
+		shouldDisable := s.handleFailoverSideEffects(ctx, resp, account, respBody, requestModel)
+		return nil, &UpstreamFailoverError{
+			StatusCode:             resp.StatusCode,
+			ResponseBody:           respBody,
+			RetryableOnSameAccount: !shouldDisable && account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+		}
+	}
+	return s.handleOpenAIImagesErrorResponse(ctx, resp, c, account, requestModel)
 }

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -12,6 +12,7 @@ import (
 	"net/textproto"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
@@ -709,7 +710,7 @@ func findOpenAIImageTestSSEEvent(events []openAIImageTestSSEEvent, name string) 
 	return openAIImageTestSSEEvent{}, false
 }
 
-func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *testing.T) {
+func TestOpenAIGatewayServiceForwardImages_OAuthFanoutNAndReturnsAllImages(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","size":"1024x1024","quality":"high","n":3}`)
 
@@ -724,17 +725,39 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
 	require.NoError(t, err)
 
+	fanoutImages := []string{"aW1hZ2UtMQ==", "aW1hZ2UtMg==", "aW1hZ2UtMw=="}
+	fanoutResponseBody := func(index int) string {
+		return "data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000000,\"usage\":{\"input_tokens\":11,\"output_tokens\":22,\"input_tokens_details\":{\"cached_tokens\":3},\"output_tokens_details\":{\"image_tokens\":7}},\"tool_usage\":{\"image_gen\":{\"input_tokens\":46,\"output_tokens\":2459,\"output_tokens_details\":{\"image_tokens\":2459},\"images\":1}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"" +
+			fanoutImages[index] + "\",\"revised_prompt\":\"draw a cat " + fmt.Sprintf("%d", index+1) + "\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
+			"data: [DONE]\n\n"
+	}
 	upstream := &httpUpstreamRecorder{
-		resp: &http.Response{
-			StatusCode: http.StatusOK,
-			Header: http.Header{
-				"Content-Type": []string{"text/event-stream"},
-				"X-Request-Id": []string{"req_img_123"},
+		delay: 50 * time.Millisecond,
+		responses: []*http.Response{
+			{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+					"X-Request-Id": []string{"req_img_1"},
+				},
+				Body: io.NopCloser(strings.NewReader(fanoutResponseBody(0))),
 			},
-			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000000,\"usage\":{\"input_tokens\":11,\"output_tokens\":22,\"input_tokens_details\":{\"cached_tokens\":3},\"output_tokens_details\":{\"image_tokens\":7}},\"tool_usage\":{\"image_gen\":{\"input_tokens\":46,\"output_tokens\":2459,\"output_tokens_details\":{\"image_tokens\":2459},\"images\":3}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMQ==\",\"revised_prompt\":\"draw a cat 1\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMg==\",\"revised_prompt\":\"draw a cat 2\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMw==\",\"revised_prompt\":\"draw a cat 3\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
-					"data: [DONE]\n\n",
-			)),
+			{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+					"X-Request-Id": []string{"req_img_2"},
+				},
+				Body: io.NopCloser(strings.NewReader(fanoutResponseBody(1))),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"text/event-stream"},
+					"X-Request-Id": []string{"req_img_3"},
+				},
+				Body: io.NopCloser(strings.NewReader(fanoutResponseBody(2))),
+			},
 		},
 	}
 	svc.httpUpstream = upstream
@@ -756,11 +779,14 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.Equal(t, "gpt-image-2", result.Model)
 	require.Equal(t, "gpt-image-2", result.UpstreamModel)
 	require.Equal(t, 3, result.ImageCount)
-	require.Equal(t, 46, result.Usage.InputTokens)
-	require.Equal(t, 2459, result.Usage.OutputTokens)
-	require.Equal(t, 2459, result.Usage.ImageOutputTokens)
+	require.Equal(t, 138, result.Usage.InputTokens)
+	require.Equal(t, 7377, result.Usage.OutputTokens)
+	require.Equal(t, 7377, result.Usage.ImageOutputTokens)
 
 	require.NotNil(t, upstream.lastReq)
+	require.Len(t, upstream.requests, 3)
+	require.Len(t, upstream.bodies, 3)
+	require.GreaterOrEqual(t, upstream.maxFlight, 2)
 	require.Equal(t, chatgptCodexURL, upstream.lastReq.URL.String())
 	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.lastReq.Context()))
@@ -776,17 +802,64 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "tools.0.model").String())
 	require.Equal(t, "1024x1024", gjson.GetBytes(upstream.lastBody, "tools.0.size").String())
 	require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "tools.0.quality").String())
-	require.Equal(t, int64(3), gjson.GetBytes(upstream.lastBody, "tools.0.n").Int())
 	require.Equal(t, "draw a cat", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	for _, upstreamBody := range upstream.bodies {
+		require.False(t, gjson.GetBytes(upstreamBody, "tools.0.n").Exists())
+	}
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "gpt-image-2", gjson.Get(rec.Body.String(), "model").String())
-	require.Len(t, gjson.Get(rec.Body.String(), "data").Array(), 3)
-	require.Equal(t, "aW1hZ2UtMQ==", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
-	require.Equal(t, "aW1hZ2UtMg==", gjson.Get(rec.Body.String(), "data.1.b64_json").String())
-	require.Equal(t, "aW1hZ2UtMw==", gjson.Get(rec.Body.String(), "data.2.b64_json").String())
-	require.Equal(t, "draw a cat 1", gjson.Get(rec.Body.String(), "data.0.revised_prompt").String())
-	require.Equal(t, "draw a cat 3", gjson.Get(rec.Body.String(), "data.2.revised_prompt").String())
+	data := gjson.Get(rec.Body.String(), "data").Array()
+	require.Len(t, data, 3)
+	var images []string
+	var revisedPrompts []string
+	for _, item := range data {
+		images = append(images, item.Get("b64_json").String())
+		revisedPrompts = append(revisedPrompts, item.Get("revised_prompt").String())
+	}
+	require.ElementsMatch(t, []string{"aW1hZ2UtMQ==", "aW1hZ2UtMg==", "aW1hZ2UtMw=="}, images)
+	require.ElementsMatch(t, []string{"draw a cat 1", "draw a cat 2", "draw a cat 3"}, revisedPrompts)
+	require.Equal(t, int64(138), gjson.Get(rec.Body.String(), "usage.input_tokens").Int())
+	require.Equal(t, int64(7377), gjson.Get(rec.Body.String(), "usage.output_tokens").Int())
+	require.Equal(t, int64(7377), gjson.Get(rec.Body.String(), "usage.output_tokens_details.image_tokens").Int())
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthRejectsStreamingN(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"n":2}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	c.Set("api_key", &APIKey{ID: 42})
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	upstream := &httpUpstreamRecorder{}
+	svc.httpUpstream = upstream
+
+	account := &Account{
+		ID:       1,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token":       "token-123",
+			"chatgpt_account_id": "acct-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Len(t, upstream.requests, 0)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "unsupported_parameter", gjson.Get(rec.Body.String(), "error.code").String())
+	require.Equal(t, "n", gjson.Get(rec.Body.String(), "error.param").String())
 }
 
 func TestParseOpenAIImagesSSEUsageBytes_ToolUsagePrecedenceAndFallback(t *testing.T) {
@@ -1688,35 +1761,22 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsStreamingTransformsEvents(t
 	require.False(t, gjson.Get(completed.Data, "revised_prompt").Exists())
 }
 
-func TestBuildOpenAIImagesResponsesRequest_PassesThroughNForMultiImageModels(t *testing.T) {
-	parsed := &OpenAIImagesRequest{
-		Endpoint: openAIImagesGenerationsEndpoint,
-		Model:    "gpt-image-2",
-		Prompt:   "draw a cat",
-		N:        2,
+func TestBuildOpenAIImagesResponsesRequest_NeverPassesNToImageTool(t *testing.T) {
+	for _, model := range []string{"gpt-image-2", "dall-e-3"} {
+		parsed := &OpenAIImagesRequest{
+			Endpoint: openAIImagesGenerationsEndpoint,
+			Model:    model,
+			Prompt:   "draw a cat",
+			N:        2,
+		}
+
+		body, err := buildOpenAIImagesResponsesRequest(parsed, model)
+		require.NoError(t, err)
+		require.NotNil(t, body)
+		require.False(t, gjson.GetBytes(body, "tools.0.n").Exists())
+		require.Equal(t, model, gjson.GetBytes(body, "tools.0.model").String())
+		require.Equal(t, "draw a cat", gjson.GetBytes(body, "input.0.content.0.text").String())
 	}
-
-	body, err := buildOpenAIImagesResponsesRequest(parsed, "gpt-image-2")
-	require.NoError(t, err)
-	require.NotNil(t, body)
-	require.Equal(t, int64(2), gjson.GetBytes(body, "tools.0.n").Int())
-	require.Equal(t, "gpt-image-2", gjson.GetBytes(body, "tools.0.model").String())
-	require.Equal(t, "draw a cat", gjson.GetBytes(body, "input.0.content.0.text").String())
-}
-
-func TestBuildOpenAIImagesResponsesRequest_DoesNotPassNForDallE3(t *testing.T) {
-	parsed := &OpenAIImagesRequest{
-		Endpoint: openAIImagesGenerationsEndpoint,
-		Model:    "dall-e-3",
-		Prompt:   "draw a cat",
-		N:        2,
-	}
-
-	body, err := buildOpenAIImagesResponsesRequest(parsed, "dall-e-3")
-	require.NoError(t, err)
-	require.NotNil(t, body)
-	require.False(t, gjson.GetBytes(body, "tools.0.n").Exists())
-	require.Equal(t, "dall-e-3", gjson.GetBytes(body, "tools.0.model").String())
 }
 
 func TestBuildOpenAIImagesResponsesRequest_StripsInputFidelity(t *testing.T) {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -26,6 +26,7 @@ import (
 func f64p(v float64) *float64 { return &v }
 
 type httpUpstreamRecorder struct {
+	mu           sync.Mutex
 	lastReq      *http.Request
 	lastBody     []byte
 	lastProxyURL string
@@ -35,6 +36,9 @@ type httpUpstreamRecorder struct {
 	resp      *http.Response
 	responses []*http.Response
 	err       error
+	delay     time.Duration
+	inFlight  int
+	maxFlight int
 }
 
 type passthroughErrReadCloser struct {
@@ -63,14 +67,36 @@ func (r passthroughErrReadCloser) Close() error {
 }
 
 func (u *httpUpstreamRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
-	u.lastReq = req
-	u.lastProxyURL = proxyURL
+	u.mu.Lock()
+	u.inFlight++
+	if u.inFlight > u.maxFlight {
+		u.maxFlight = u.inFlight
+	}
+	u.mu.Unlock()
+	defer func() {
+		u.mu.Lock()
+		u.inFlight--
+		u.mu.Unlock()
+	}()
+
+	if u.delay > 0 {
+		time.Sleep(u.delay)
+	}
+
+	var body []byte
 	if req != nil && req.Body != nil {
 		b, _ := io.ReadAll(req.Body)
-		u.lastBody = b
-		u.bodies = append(u.bodies, append([]byte(nil), b...))
+		body = b
 		_ = req.Body.Close()
 		req.Body = io.NopCloser(bytes.NewReader(b))
+	}
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.lastReq = req
+	u.lastProxyURL = proxyURL
+	if body != nil {
+		u.lastBody = body
+		u.bodies = append(u.bodies, append([]byte(nil), body...))
 	}
 	u.requests = append(u.requests, req)
 	if u.err != nil {


### PR DESCRIPTION
## Summary
- stop passing unsupported `tools[0].n` to the Responses image_generation tool (the tool ignores it, so `n > 1` silently returned a single image)
- fan out non-streaming OAuth image requests with `n > 1` into n concurrent `n=1` upstream calls and aggregate the Images API `data[]`/usage response
- reject streaming OAuth image requests with `n > 1` explicitly because streaming fanout cannot preserve a standard stream contract

## Notes
- Rebased onto current main: the fanout is implemented on top of the present error-handling paths (refusal vs vacuum-response classification, keepalive-adjusted written-size accounting, `handleFailoverSideEffects` shouldDisable semantics, pool-mode same-account retry).
- Fanout attempts run concurrently and any failure cancels the remaining attempts; the first problem is reported through the same failover/error paths as the single-request flow.
- Intentional difference: fanout attempts skip in-place agent-identity task recovery; such errors bubble up as failover so the handler retries on another account.

## Tests
- `go test ./internal/service -run 'TestOpenAIGatewayServiceForwardImages_OAuth(FanoutNAndReturnsAllImages|RejectsStreamingN)' -count=1 -v` — pass
- `go test ./internal/service -run 'Images' -count=1 -race` — pass
- `go test ./internal/service -count=1` — passes except pre-existing `TestEstimateOpenAIInputTokens_CompareWithOpenAIAPI`, which needs live OpenAI API access and fails identically on unmodified main