### PR TITLE
fix: classify concurrency acquire failures

### DIFF
--- a/backend/internal/handler/concurrency_error_response.go
+++ b/backend/internal/handler/concurrency_error_response.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+const statusClientClosedRequest = 499
+
+func concurrencyErrorResponse(err error, slotType string) (int, string, string) {
+	var concurrencyErr *ConcurrencyError
+	if errors.As(err, &concurrencyErr) {
+		if concurrencyErr.SlotType != "" {
+			slotType = concurrencyErr.SlotType
+		}
+		return http.StatusTooManyRequests, "rate_limit_error",
+			fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType)
+	}
+
+	if errors.Is(err, context.Canceled) {
+		return statusClientClosedRequest, "api_error", "context canceled"
+	}
+
+	return http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable, please retry later"
+}

--- a/backend/internal/handler/concurrency_error_response_test.go
+++ b/backend/internal/handler/concurrency_error_response_test.go
@@ -1,0 +1,63 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrencyErrorResponse(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		slotType    string
+		wantStatus  int
+		wantType    string
+		wantMessage string
+	}{
+		{
+			name:        "true concurrency timeout remains rate limit",
+			err:         &ConcurrencyError{SlotType: "account", IsTimeout: true},
+			slotType:    "user",
+			wantStatus:  http.StatusTooManyRequests,
+			wantType:    "rate_limit_error",
+			wantMessage: "Concurrency limit exceeded for account, please retry later",
+		},
+		{
+			name:        "client cancellation is not classified as concurrency limit",
+			err:         context.Canceled,
+			slotType:    "user",
+			wantStatus:  statusClientClosedRequest,
+			wantType:    "api_error",
+			wantMessage: "context canceled",
+		},
+		{
+			name:        "deadline exceeded is service unavailable",
+			err:         context.DeadlineExceeded,
+			slotType:    "user",
+			wantStatus:  http.StatusServiceUnavailable,
+			wantType:    "api_error",
+			wantMessage: "Service temporarily unavailable, please retry later",
+		},
+		{
+			name:        "redis acquire error is service unavailable",
+			err:         errors.New("redis unavailable"),
+			slotType:    "user",
+			wantStatus:  http.StatusServiceUnavailable,
+			wantType:    "api_error",
+			wantMessage: "Service temporarily unavailable, please retry later",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, errType, message := concurrencyErrorResponse(tt.err, tt.slotType)
+			require.Equal(t, tt.wantStatus, status)
+			require.Equal(t, tt.wantType, errType)
+			require.Equal(t, tt.wantMessage, message)
+		})
+	}
+}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1471,10 +1471,10 @@ func (h *GatewayHandler) calculateSubscriptionRemaining(group *service.Group, su
 	return min
 }
 
-// handleConcurrencyError handles concurrency-related errors with proper 429 response
+// handleConcurrencyError handles concurrency-related acquire errors.
 func (h *GatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
-	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
-		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+	status, errType, message := concurrencyErrorResponse(err, slotType)
+	h.handleStreamingAwareError(c, status, errType, message, streamStarted)
 }
 
 func (h *GatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, platform string, streamStarted bool) {

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -336,6 +336,9 @@ func (h *ConcurrencyHelper) waitForSlotWithPingTimeout(c *gin.Context, slotType 
 	for {
 		select {
 		case <-ctx.Done():
+			if parentErr := c.Request.Context().Err(); parentErr != nil {
+				return nil, parentErr
+			}
 			return nil, &ConcurrencyError{
 				SlotType:  slotType,
 				IsTimeout: true,

--- a/backend/internal/handler/gateway_helper_hotpath_test.go
+++ b/backend/internal/handler/gateway_helper_hotpath_test.go
@@ -280,6 +280,25 @@ func TestWaitForSlotWithPingTimeout_TimeoutAndStreamPing(t *testing.T) {
 	})
 }
 
+func TestWaitForSlotWithPingTimeout_ParentContextCanceled(t *testing.T) {
+	cache := &helperConcurrencyCacheStub{
+		accountSeq: []bool{false},
+	}
+	concurrency := service.NewConcurrencyService(cache)
+	helper := NewConcurrencyHelper(concurrency, SSEPingFormatNone, 5*time.Millisecond)
+	c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
+	reqCtx, cancel := context.WithCancel(c.Request.Context())
+	c.Request = c.Request.WithContext(reqCtx)
+	cancel()
+
+	streamStarted := false
+	release, err := helper.waitForSlotWithPingTimeout(c, "account", 101, 2, time.Second, false, &streamStarted, true)
+	require.Nil(t, release)
+	require.ErrorIs(t, err, context.Canceled)
+	var cErr *ConcurrencyError
+	require.False(t, errors.As(err, &cErr))
+}
+
 func TestWaitForSlotWithPingTimeout_AcquireError(t *testing.T) {
 	errCache := &helperConcurrencyCacheStubWithError{
 		err: errors.New("redis unavailable"),

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1685,10 +1685,10 @@ func (h *OpenAIGatewayHandler) acquireImageGenerationSlot(c *gin.Context, stream
 	return nil, false
 }
 
-// handleConcurrencyError handles concurrency-related errors with proper 429 response
+// handleConcurrencyError handles concurrency-related acquire errors.
 func (h *OpenAIGatewayHandler) handleConcurrencyError(c *gin.Context, err error, slotType string, streamStarted bool) {
-	h.handleStreamingAwareError(c, http.StatusTooManyRequests, "rate_limit_error",
-		fmt.Sprintf("Concurrency limit exceeded for %s, please retry later", slotType), streamStarted)
+	status, errType, message := concurrencyErrorResponse(err, slotType)
+	h.handleStreamingAwareError(c, status, errType, message, streamStarted)
 }
 
 func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {


### PR DESCRIPTION
# 修复并发槽位获取失败被误报为用户并发超限

## 概要

修复 gateway 在获取用户/账号并发槽位失败时的错误分类问题。

原实现会把所有并发槽位获取失败统一返回为：

```text
429 rate_limit_error: Concurrency limit exceeded for {user|account}, please retry later
```

这会把客户端取消请求、请求上下文超时、Redis 访问失败、Redis DNS/网络超时等非业务限流问题误报为“用户/账号并发超限”。本 PR 保留真实并发等待超时的 429 行为，同时把客户端取消和基础设施类错误拆开处理，避免错误日志和下游监控错误归因。

## 原问题发生机理

sub2api 的用户和账号并发控制依赖 Redis 中的并发槽位。请求进入 gateway 后会先尝试获取用户槽位，后续再获取账号槽位。如果槽位已满，`ConcurrencyHelper.waitForSlotWithPingTimeout` 会创建一个带超时的等待上下文：

```go
ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
```

这个上下文会在两类情况下结束：

1. 子上下文自己的等待时间到期，也就是真正等不到并发槽位。
2. 父请求上下文结束，例如客户端断开连接、反向代理取消请求、请求 deadline 到期。

原实现没有区分这两种情况。只要 `<-ctx.Done()` 触发，就固定返回：

```go
&ConcurrencyError{
    SlotType:  slotType,
    IsTimeout: true,
}
```

这一步会丢失原始错误原因。即使真实原因是 `context canceled`，也会被包装成“等待并发槽位超时”。

后续 `GatewayHandler.handleConcurrencyError` 和 `OpenAIGatewayHandler.handleConcurrencyError` 又没有读取传入的 `err`，而是无条件返回：

```text
429 rate_limit_error: Concurrency limit exceeded for {slotType}, please retry later
```

因此以下不同性质的问题都会被压成同一个用户侧业务限流错误：

- 用户/账号槽位真的等到超时。
- 客户端取消请求导致 `context canceled`。
- 请求父上下文 deadline 到期。
- Redis 获取槽位失败，例如 `dial tcp ... i/o timeout`、`lookup sub2api-redis: i/o timeout`、`context deadline exceeded`。

在 ops 错误日志里，这类响应会进一步被解析为：

- `status_code = 429`
- `error_type = rate_limit_error`
- `error_source = client_request`
- message 包含 `Concurrency limit exceeded`

这会把平台/Redis/网络问题错误归因到用户请求侧，并可能被下游系统展示成 `FAKE_200_JSON_ERROR_MESSAGE_NON_EMPTY: Concurrency limit exceeded for user, please retry later` 一类告警。实际排查中，用户并发额度很高，相关日志附近同时出现 Redis 超时和 `context canceled`，说明这不是用户真实撞并发上限。

## 为什么这是 bug

这不是简单的错误文案问题，而是错误语义被改变：

- `context canceled` 代表请求被取消，不代表用户并发已满。
- Redis 超时/连接失败代表 gateway 依赖的并发状态服务不可用，不代表用户触发限流。
- 只有子等待上下文自身超时，且父请求上下文仍然正常时，才能认为是“等待并发槽位超时”。

错误分类错误会带来两个直接影响：

1. 对用户不公平：用户会看到“并发超限”，但实际上可能是客户端断连或 Redis 抖动。
2. 对运维误导：ops 日志会把平台侧基础设施问题记成 `client_request` 的 429，掩盖 Redis/网关稳定性问题。

## 修复方案

### 1. 保留父请求上下文的取消原因

在 `waitForSlotWithPingTimeout` 中，`ctx.Done()` 触发后先检查父请求上下文：

```go
if parentErr := c.Request.Context().Err(); parentErr != nil {
    return nil, parentErr
}
```

只有父请求上下文没有错误，才返回 `ConcurrencyError{IsTimeout: true}`。这样可以区分：

- 父请求取消或 deadline：返回原始 `context.Canceled` / `context.DeadlineExceeded`。
- 并发等待窗口自己超时：返回 `ConcurrencyError`。

### 2. 集中并发获取失败的响应分类

新增 `concurrencyErrorResponse`，由 Anthropic/Gemini gateway 和 OpenAI gateway 共用：

- `*ConcurrencyError`：保持原行为，返回 429 `rate_limit_error` 和原有 `Concurrency limit exceeded...` 文案。
- `context.Canceled`：返回 499 `api_error`，message 为 `context canceled`，便于现有 ops 过滤规则忽略客户端断连。
- 其他错误，包括 Redis acquire 错误、父请求 deadline、未知基础设施错误：返回 503 `api_error`，对客户端暴露通用重试文案 `Service temporarily unavailable, please retry later`。

### 3. 两个 gateway handler 使用同一分类函数

`GatewayHandler.handleConcurrencyError` 和 `OpenAIGatewayHandler.handleConcurrencyError` 都改为调用同一个分类函数，避免两个入口后续行为再次分叉。

## 设计理由

### 保持真实业务限流兼容

真实的并发等待超时仍然返回：

```text
429 rate_limit_error: Concurrency limit exceeded for {user|account}, please retry later
```

这避免改变正常限流语义，也不会影响依赖 429 判断是否重试的客户端。

### 不向客户端泄露内部 Redis 细节

Redis/DNS/网络错误统一返回 503 和通用重试文案，而不是把 `dial tcp`、`lookup sub2api-redis` 等内部细节暴露给 API 调用方。详细错误仍然会通过现有 `reqLog.Warn("...slot_acquire_failed", zap.Error(err))` 进入系统日志，便于管理员排查。

### 让 ops 归因更接近真实故障域

Redis 或 gateway 内部异常不应被归类为 `client_request` 的 429。改为 503 `api_error` 后，ops 更容易把它识别为平台侧问题，避免误判用户并发额度。

### 复用现有 context canceled 过滤机制

ops advanced settings 默认会忽略包含 `context canceled` 的错误。客户端断连返回 499 + `context canceled` 后，可以被现有过滤逻辑正确处理，不需要引入新的配置项或迁移。

### 最小改动，降低回归风险

本 PR 不修改 Redis Lua 脚本、不修改并发槽位计数模型、不修改等待队列语义，只修复错误原因保留和 handler 响应分类。改动面集中在 handler 层，风险较低。

## 测试

新增/更新测试覆盖：

- 真实并发等待超时仍返回 `ConcurrencyError`，并保持 429 `rate_limit_error`。
- 父请求 `context.Canceled` 不再被包装为 `ConcurrencyError`。
- `context.Canceled` 分类为 499 `api_error: context canceled`。
- `context.DeadlineExceeded` 分类为 503 `api_error`。
- Redis/未知 acquire 错误分类为 503 `api_error`。

已运行：

```bash
go test ./internal/handler -run 'TestWaitForSlotWithPingTimeout|TestConcurrencyErrorResponse'
```