### PR TITLE
fix: 刷新令牌失效问题

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -248,17 +248,9 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				shouldDisable = true
 				break
 			}
-			// 2. 设置 expires_at 为当前时间，强制下次请求刷新 token
-			if account.Credentials == nil {
-				account.Credentials = make(map[string]any)
-			}
-			account.Credentials["expires_at"] = time.Now().Format(time.RFC3339)
-			if err := persistAccountCredentials(ctx, s.accountRepo, account, account.Credentials); err != nil {
-				slog.Warn("oauth_401_force_refresh_update_failed", "account_id", account.ID, "error", err)
-			} else {
-				slog.Info("oauth_401_force_refresh_set", "account_id", account.ID, "platform", account.Platform)
-			}
-			// 3. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
+			// 不要在此处写 credentials.expires_at = now：那是 RefreshIfNeeded 锁外的全量覆盖写，
+			// 会用请求开始时的内存快照把后台刚拿到的新 refresh_token 覆盖回旧值 → invalid_grant。
+			// 2. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
 			msg := "Authentication failed (401): invalid or expired credentials"
 			if upstreamMsg != "" {
 				msg = "OAuth 401: " + upstreamMsg


### PR DESCRIPTION
## 现象
  
  部分 Claude OAuth 账号在用了几天之后突然 invalid_grant：
  
  Token refresh failed (non-retryable): token refresh failed: status 400,
  body: {"error": "invalid_grant", "error_description": "Refresh token not found or invalid"}

  不是全挂、也不是一次性挂一批，而是几天里零星掉 1-2 个。
  重启过、刷新成功记录也有，但下一个周期就 invalid_grant 了。

  ## 原因

  `ratelimit_service.go` 在收到上游 401 时，会主动把 `expires_at` 改成当前
  时间，目的是逼下次请求触发刷新。问题是它走的是 `persistAccountCredentials`
  ——整张 credentials map 覆盖写——并且**不在 `OAuthRefreshAPI.RefreshIfNeeded`
  的分布式锁内**。

  1. 后台刷新循环跑 `RefreshIfNeeded`，拿锁、从 DB 重读、调 Anthropic、
     拿到新 `refresh_token=B`、写回 DB（此时 Anthropic 端 A 已立即作废）
  2. 与此同时，某个 in-flight 请求拿着旧的 `access_token A` 收到上游 401后整体写回 DB
  3. **DB 里的 `refresh_token=B` 被回退成 A**

  issue #1035 之前修过两个刷新入口之间的竞争（加了 `RefreshIfNeeded` 的分布式
  锁 + 锁内 DB 重读），但 401 handler 这条"credentials"的路径没被覆盖，
  所以问题还在，issue #1381 就是后续复现。

  ## 修复
  
  最小改动：直接把 `ratelimit_service.go` 里那段 `account.Credentials["expires_at"] = now`
  + `persistAccountCredentials` 删掉。