### PR TITLE
fix(oauth): 401 handler 不再回写 credentials,避免 refresh_token 被陈旧快照覆盖

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -248,17 +248,15 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 				shouldDisable = true
 				break
 			}
-			// 2. 设置 expires_at 为当前时间，强制下次请求刷新 token
-			if account.Credentials == nil {
-				account.Credentials = make(map[string]any)
-			}
-			account.Credentials["expires_at"] = time.Now().Format(time.RFC3339)
-			if err := persistAccountCredentials(ctx, s.accountRepo, account, account.Credentials); err != nil {
-				slog.Warn("oauth_401_force_refresh_update_failed", "account_id", account.ID, "error", err)
-			} else {
-				slog.Info("oauth_401_force_refresh_set", "account_id", account.ID, "platform", account.Platform)
-			}
-			// 3. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
+			// 2. 临时不可调度，替代 SetError（保持 status=active 让刷新服务能拾取）
+			// 注意：此处不再写回 account.Credentials/expires_at。
+			// 原实现使用请求开始时的 account 快照整列覆盖 credentials JSONB（见
+			// persistAccountCredentials → accountRepository.UpdateCredentials → SetCredentials），
+			// 在另一个 worker 刚刷新完 refresh_token 的窄窗口内会把新 refresh_token 回滚为旧值，
+			// 导致下一周期用旧 refresh_token 调上游拿到 invalid_grant 后，
+			// tryRecoverFromRefreshRace 重读 DB 发现 currentRT == usedRT 也救不回来，账号被错误 disable。
+			// 这里仅依赖 InvalidateToken + SetTempUnschedulable 让账号在冷却期内不被调度，
+			// 冷却结束后由 token_provider 的 NeedsRefresh / token_refresh_service 走带分布式锁的正路刷新。
 			msg := "Authentication failed (401): invalid or expired credentials"
 			if upstreamMsg != "" {
 				msg = "OAuth 401: " + upstreamMsg

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -129,7 +129,10 @@ func TestRateLimitService_HandleUpstreamError_OAuth401SetsTempUnschedulable(t *t
 }
 
 // TestRateLimitService_HandleUpstreamError_OAuth401InvalidatorError
-// OpenAI OAuth 401 缓存失效出错时仍走 temp_unschedulable
+// OpenAI OAuth 401 缓存失效出错时仍走 temp_unschedulable。
+// 注意：401 handler 不再回写 credentials(避免请求开始时的快照整列覆盖 DB
+// 把另一个 worker 刚刷新出来的新 refresh_token 回滚为旧值),
+// 因此 updateCredentialsCalls 应当为 0。
 func TestRateLimitService_HandleUpstreamError_OAuth401InvalidatorError(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	invalidator := &tokenCacheInvalidatorRecorder{err: errors.New("boom")}
@@ -149,7 +152,7 @@ func TestRateLimitService_HandleUpstreamError_OAuth401InvalidatorError(t *testin
 	require.True(t, shouldDisable)
 	require.Equal(t, 0, repo.setErrorCalls)
 	require.Equal(t, 1, repo.tempCalls)
-	require.Equal(t, 1, repo.updateCredentialsCalls)
+	require.Equal(t, 0, repo.updateCredentialsCalls)
 	require.Len(t, invalidator.accounts, 1)
 }
 
@@ -171,7 +174,12 @@ func TestRateLimitService_HandleUpstreamError_NonOAuth401(t *testing.T) {
 	require.Empty(t, invalidator.accounts)
 }
 
-func TestRateLimitService_HandleUpstreamError_OAuth401UsesCredentialsUpdater(t *testing.T) {
+// TestRateLimitService_HandleUpstreamError_OAuth401DoesNotOverwriteCredentials
+// 回归测试:确保 401 handler 不再使用请求开始时的 account 快照写回 credentials。
+// 原实现会通过 persistAccountCredentials → UpdateCredentials → SetCredentials
+// 整列覆盖 credentials JSONB,在另一个 worker 刚刷新完 refresh_token 的窄窗口内
+// 会把新 refresh_token 回滚为快照中的旧值,导致下一周期拿 invalid_grant 被错误 disable。
+func TestRateLimitService_HandleUpstreamError_OAuth401DoesNotOverwriteCredentials(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
 	account := &Account{
@@ -187,8 +195,9 @@ func TestRateLimitService_HandleUpstreamError_OAuth401UsesCredentialsUpdater(t *
 	shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
 
 	require.True(t, shouldDisable)
-	require.Equal(t, 1, repo.updateCredentialsCalls)
-	require.NotEmpty(t, repo.lastCredentials["expires_at"])
+	require.Equal(t, 0, repo.updateCredentialsCalls, "401 handler must not write credentials back from the request-start snapshot")
+	require.Equal(t, 1, repo.tempCalls, "401 handler should still set temp-unschedulable cooldown")
+	require.Nil(t, repo.lastCredentials, "no credentials should have been persisted")
 }
 
 // 缺少 refresh_token 的 OAuth 账号 401 应直接 SetError 永久禁用，


### PR DESCRIPTION
## 现象

OAuth 账号在长期运行中频繁出现 token 刷新失败 → `invalid_grant` → 账号被自动 disable,且经常集中在某些时段批量发生。

## 根因

`RateLimitService.HandleUpstreamError` 在 OAuth 401 分支(`backend/internal/service/ratelimit_service.go:233-274`)按顺序做了 4 步:

1. `InvalidateToken` 失效 token cache
2. `account.Credentials["expires_at"] = time.Now()` —— 想强制下次请求触发刷新
3. `persistAccountCredentials(ctx, s.accountRepo, account, account.Credentials)` —— 把整张 credentials map 写回 DB
4. `SetTempUnschedulable` 10 分钟冷却

第 3 步是 bug 来源。它沿这条链路写 DB:

```
persistAccountCredentials (account_credentials_persistence.go:9-19)
  → accountRepository.UpdateCredentials (account_repo.go:411-420)
    → ent UpdateOneID(...).SetCredentials(...)
      → 整列覆盖 PostgreSQL JSONB(schema 见 ent/schema/account.go:74-81)
```

`SetCredentials` 是 JSONB **整字段替换**,不是 merge。因此入参 `account.Credentials` 里的所有字段都会被写回 DB,包括 `refresh_token`。

而 `account` 是网关 `SelectAccount` 时拿到的请求开始时快照 —— 401 handler 全程没有重读 DB,也没有拿分布式锁。当另一个 worker 已经通过 `oauth_refresh_api.RefreshIfNeeded` 把 `refresh_token` 轮换成新值时,这次 401 handler 会用快照里的旧 `refresh_token` 把 DB 里的新值覆盖回去。

下一周期触发 refresh 时:
- 从 DB 重读拿到的是被回滚后的旧 `refresh_token`
- 调上游收到 `invalid_grant`
- `tryRecoverFromRefreshRace`(`oauth_refresh_api.go:175-193`)重读 DB 比对 `usedRT` 与 `currentRT`
- 因为 DB 早已被 401 handler 污染成与 `usedRT` 相同的旧值,返回 `false`
- 救援失败,账号最终被 disable

另外 `accountRepository.UpdateCredentials` 末尾还会 `syncSchedulerAccountSnapshot`,把污染过的 credentials 同步到 in-memory 调度器快照,放大影响面。

## 修复

直接移除第 2、3 步,401 handler 仅保留:
- `InvalidateToken` 失效 token cache
- `SetTempUnschedulable` 10 分钟冷却

冷却结束后由两条正路接管:
- **场景 B(快照陈旧,DB 已是新 token)**:`token_provider` 看到有效 `expires_at`,直接用 DB 里的新 access_token → ✓
- **场景 A(access_token 真过期)**:`token_provider.NeedsRefresh` 返回 true,走 `RefreshIfNeeded`(`oauth_refresh_api.go:75-166`)的"分布式锁 + DB 重读"正路刷新 → ✓

`tryRecoverFromRefreshRace` 在 DB 未被污染的前提下能正常生效:DB 里的 `refresh_token` 是新值、`usedRT` 是旧值,两者不等 → 救援成功,账号不会被错误 disable。

## 取舍

本修复有意放弃"401 触发后立刻把 `expires_at` 设为 `now`,让后台刷新服务立即捡起来"这一语义。

可接受性:
- `token_refresh_service` 后台循环按真实 `expires_at` 进入刷新窗口判断,真正接近过期时会自然刷新
- 冷却结束后若真实 `expires_at` 已过期,`token_provider.GetAccessToken` 的 `NeedsRefresh` 会同步触发 `RefreshIfNeeded`
- 相比当前 bug 把账号 **永久 disable**,延迟 ≤ 10 分钟自愈是显著更优的取舍

如果想保留"立即强制刷新"语义,可以在仓库层补一个字段级写入(`SetCredentialField(id, key, value)` 或 DB 侧 `credentials || jsonb_build_object(...)`),401 handler 只更新 `expires_at` 一个 key。本 PR 选最小修改路径,先止血;字段级写入可以作为后续独立 PR。

## Diff

只动一个文件,+9 / -11:`backend/internal/service/ratelimit_service.go`。

## 验证

- `go build ./internal/service/...` 通过
- `go vet ./internal/service/...` 通过
- 项目中无任何测试引用被删除的 log key(`oauth_401_force_refresh_*`),无需同步修改测试
