### PR TITLE
fix(ws): exclude terminal events from first-token detection

### DIFF
--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -3915,7 +3915,10 @@ func isOpenAIWSTokenEvent(eventType string) bool {
 	if strings.HasPrefix(eventType, "response.output") {
 		return true
 	}
-	return eventType == "response.completed" || eventType == "response.done"
+	// 终止事件（response.completed/done/failed/...）由 isOpenAIWSTerminalEvent 单独处理。
+	// 不能把它们当作 token event，否则当上游没有可识别的 delta 时，
+	// firstTokenMs 会被填到终止时刻，等于把"总耗时"误报为"首 token 延迟"。
+	return false
 }
 
 func replaceOpenAIWSMessageModel(message []byte, fromModel, toModel string) []byte {

--- a/backend/internal/service/openai_ws_forwarder_test.go
+++ b/backend/internal/service/openai_ws_forwarder_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsOpenAIWSTokenEvent_TerminalEventsExcluded 覆盖 isOpenAIWSTokenEvent 的回归用例。
+// 重点验证终止事件（response.completed / response.done）不再被当作 token event，
+// 否则当上游没有可识别的 delta 时，firstTokenMs 会被填到终止时刻，
+// 等于把"总耗时"误报为"首 token 延迟"（issue #2651）。
+func TestIsOpenAIWSTokenEvent_TerminalEventsExcluded(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+		want      bool
+	}{
+		{name: "empty", eventType: "", want: false},
+		{name: "whitespace_trimmed_empty", eventType: "   ", want: false},
+
+		{name: "response.created", eventType: "response.created", want: false},
+		{name: "response.in_progress", eventType: "response.in_progress", want: false},
+		{name: "response.output_item.added", eventType: "response.output_item.added", want: false},
+		{name: "response.output_item.done", eventType: "response.output_item.done", want: false},
+
+		{name: "terminal_response.completed", eventType: "response.completed", want: false},
+		{name: "terminal_response.done", eventType: "response.done", want: false},
+		{name: "terminal_response.completed_padded", eventType: "  response.completed  ", want: false},
+		{name: "terminal_response.done_padded", eventType: "  response.done  ", want: false},
+
+		{name: "delta_text", eventType: "response.output_text.delta", want: true},
+		{name: "delta_audio_transcript", eventType: "response.audio_transcript.delta", want: true},
+		{name: "delta_function_call_arguments", eventType: "response.function_call_arguments.delta", want: true},
+
+		{name: "output_text_done", eventType: "response.output_text.done", want: true},
+		{name: "output_text_annotation_added", eventType: "response.output_text.annotation.added", want: true},
+
+		{name: "output_audio_done", eventType: "response.output_audio.done", want: true},
+
+		{name: "reasoning_summary_delta", eventType: "response.reasoning_summary_text.delta", want: true},
+
+		{name: "unrelated_event_error", eventType: "error", want: false},
+		{name: "unknown_event_without_match", eventType: "response.reasoning_summary_part.added", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := isOpenAIWSTokenEvent(tc.eventType)
+			require.Equal(t, tc.want, got, "isOpenAIWSTokenEvent(%q)", tc.eventType)
+		})
+	}
+}
+
+// TestIsOpenAIWSTokenEvent_DisjointWithTerminal 守护「token 事件集合与终止事件集合互斥」的不变量。
+// firstTokenMs 的计算依赖于 isTokenEvent && !isTerminalEvent；
+// 若两者再次出现交集，则 issue #2651 描述的 latency 误报会重现。
+func TestIsOpenAIWSTokenEvent_DisjointWithTerminal(t *testing.T) {
+	terminalEvents := []string{
+		"response.completed",
+		"response.done",
+		"response.failed",
+		"response.incomplete",
+		"response.cancelled",
+		"response.canceled",
+	}
+	for _, ev := range terminalEvents {
+		ev := ev
+		t.Run(ev, func(t *testing.T) {
+			require.True(t, isOpenAIWSTerminalEvent(ev), "expected terminal event %q to be classified as terminal", ev)
+			require.False(t, isOpenAIWSTokenEvent(ev), "terminal event %q must NOT be classified as token event (issue #2651)", ev)
+		})
+	}
+}


### PR DESCRIPTION
## 描述

`isOpenAIWSTokenEvent` 在 `backend/internal/service/openai_ws_forwarder.go` 把 `response.completed` 与 `response.done` 当成 token 事件。当上游一次请求里没有任何可识别的 delta（部分模型，或缓存命中），首 token 判定被延迟到了终止事件，导致 `firstTokenMs` 被填到终止事件的时刻 —— 首 token 延迟 metric 等同于整个请求的总耗时（reporter @fmnx 在 #2651 给出了对应的现象）。

## 根因

终止事件已经由 `isOpenAIWSTerminalEvent` 单独处理；让 token 事件集合与终止事件集合互斥，是 `firstTokenMs` 计算的隐式不变量。两条最终 `return` 把这条不变量打破了。

```go
// 修复前
return eventType == "response.completed" || eventType == "response.done"
```

## 修复

把这两条最终 return 改成 `return false`，并加注释指向 `isOpenAIWSTerminalEvent`。

仅影响 `ForwardResult.FirstTokenMs`（日志 / observability 字段），不影响计费、不影响路由。改动 1 处生产代码 + 1 处中文注释，行数 ≤ 5。

## Closes

Fixes #2651

## 测试

新增 `backend/internal/service/openai_ws_forwarder_test.go`，覆盖两类不变量：

- `TestIsOpenAIWSTokenEvent_TerminalEventsExcluded` 逐类型覆盖每条分支
- `TestIsOpenAIWSTokenEvent_DisjointWithTerminal` 守护"token 事件 ⊥ 终止事件"集合不相交不变量，避免后续重新打破

回归校验：临时把生产代码改回 `return eventType == "response.completed" || eventType == "response.done"`，第二条测试在 `response.completed` 和 `response.done` 上 FAIL，恢复后两条全 PASS。

## Proof of Work

```text
$ GOTOOLCHAIN=auto go build ./internal/service/...
(ok)

$ GOTOOLCHAIN=auto go vet ./internal/service/...
(ok)

$ GOTOOLCHAIN=auto gofmt -l internal/service/openai_ws_forwarder.go internal/service/openai_ws_forwarder_test.go
(no output → no formatting diff)

$ GOTOOLCHAIN=auto go test ./internal/service/ -run TestIsOpenAIWSTokenEvent -v
=== RUN   TestIsOpenAIWSTokenEvent_TerminalEventsExcluded
--- PASS: TestIsOpenAIWSTokenEvent_TerminalEventsExcluded (0.00s)
    ... 19 sub-tests all PASS
=== RUN   TestIsOpenAIWSTokenEvent_DisjointWithTerminal
--- PASS: TestIsOpenAIWSTokenEvent_DisjointWithTerminal (0.00s)
    ... 6 terminal-event sub-tests all PASS
PASS
ok  	github.com/Wei-Shaw/sub2api/internal/service	0.032s
```

## 边界行为

| 事件类型 | 之前 | 现在 |
|---------|------|------|
| `response.output_text.delta` | token | token (不变) |
| `response.output_audio.done` | token | token (不变) |
| `response.output_item.added` / `.done` | 非 token | 非 token (不变) |
| `response.completed` | **token (bug)** | **非 token (修复)** |
| `response.done` | **token (bug)** | **非 token (修复)** |
| `response.failed` / `.cancelled` / `.incomplete` | 非 token | 非 token (不变) |

Made with [Cursor](https://cursor.com)