### PR TITLE
feat: 新增 DeepSeek 平台支持

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -22,6 +22,7 @@ const (
 	PlatformOpenAI      = "openai"
 	PlatformGemini      = "gemini"
 	PlatformAntigravity = "antigravity"
+	PlatformDeepSeek    = "deepseek"
 )
 
 // Account type constants

--- a/backend/internal/model/error_passthrough_rule.go
+++ b/backend/internal/model/error_passthrough_rule.go
@@ -36,11 +36,12 @@ const (
 	PlatformOpenAI      = "openai"
 	PlatformGemini      = "gemini"
 	PlatformAntigravity = "antigravity"
+	PlatformDeepSeek    = "deepseek"
 )
 
 // AllPlatforms 返回所有支持的平台列表
 func AllPlatforms() []string {
-	return []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity}
+	return []string{PlatformAnthropic, PlatformOpenAI, PlatformGemini, PlatformAntigravity, PlatformDeepSeek}
 }
 
 // Validate 验证规则配置的有效性

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -42,7 +42,8 @@ func RegisterGatewayRoutes(
 	{
 		// /v1/messages: auto-route based on group platform
 		gateway.POST("/messages", func(c *gin.Context) {
-			if getGroupPlatform(c) == service.PlatformOpenAI {
+			plat := getGroupPlatform(c)
+			if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 				h.OpenAIGateway.Messages(c)
 				return
 			}
@@ -50,7 +51,8 @@ func RegisterGatewayRoutes(
 		})
 		// /v1/messages/count_tokens: OpenAI groups get 404
 		gateway.POST("/messages/count_tokens", func(c *gin.Context) {
-			if getGroupPlatform(c) == service.PlatformOpenAI {
+			plat := getGroupPlatform(c)
+			if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
 				c.JSON(http.StatusNotFound, gin.H{
 					"type": "error",
@@ -67,14 +69,16 @@ func RegisterGatewayRoutes(
 		gateway.GET("/usage", h.Gateway.Usage)
 		// OpenAI Responses API: auto-route based on group platform
 		gateway.POST("/responses", func(c *gin.Context) {
-			if getGroupPlatform(c) == service.PlatformOpenAI {
+			plat := getGroupPlatform(c)
+			if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 				h.OpenAIGateway.Responses(c)
 				return
 			}
 			h.Gateway.Responses(c)
 		})
 		gateway.POST("/responses/*subpath", func(c *gin.Context) {
-			if getGroupPlatform(c) == service.PlatformOpenAI {
+			plat := getGroupPlatform(c)
+			if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 				h.OpenAIGateway.Responses(c)
 				return
 			}
@@ -83,7 +87,8 @@ func RegisterGatewayRoutes(
 		gateway.GET("/responses", h.OpenAIGateway.ResponsesWebSocket)
 		// OpenAI Chat Completions API: auto-route based on group platform
 		gateway.POST("/chat/completions", func(c *gin.Context) {
-			if getGroupPlatform(c) == service.PlatformOpenAI {
+			plat := getGroupPlatform(c)
+			if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 				h.OpenAIGateway.ChatCompletions(c)
 				return
 			}
@@ -134,7 +139,8 @@ func RegisterGatewayRoutes(
 
 	// OpenAI Responses API（不带v1前缀的别名）— auto-route based on group platform
 	responsesHandler := func(c *gin.Context) {
-		if getGroupPlatform(c) == service.PlatformOpenAI {
+		plat := getGroupPlatform(c)
+		if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 			h.OpenAIGateway.Responses(c)
 			return
 		}
@@ -152,7 +158,8 @@ func RegisterGatewayRoutes(
 	}
 	// OpenAI Chat Completions API（不带v1前缀的别名）— auto-route based on group platform
 	r.POST("/chat/completions", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic, func(c *gin.Context) {
-		if getGroupPlatform(c) == service.PlatformOpenAI {
+		plat := getGroupPlatform(c)
+		if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
 			h.OpenAIGateway.ChatCompletions(c)
 			return
 		}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1045,6 +1045,34 @@ func (a *Account) IsAnthropic() bool {
 	return a.Platform == PlatformAnthropic
 }
 
+func (a *Account) IsDeepSeek() bool {
+	return a.Platform == PlatformDeepSeek
+}
+
+func (a *Account) IsDeepSeekAPIKey() bool {
+	return a.IsDeepSeek() && a.Type == AccountTypeAPIKey
+}
+
+func (a *Account) GetDeepSeekAPIKey() string {
+	if !a.IsDeepSeekAPIKey() {
+		return ""
+	}
+	return a.GetCredential("api_key")
+}
+
+func (a *Account) GetDeepSeekBaseURL() string {
+	if !a.IsDeepSeek() {
+		return ""
+	}
+	if a.Type == AccountTypeAPIKey {
+		baseURL := a.GetCredential("base_url")
+		if baseURL != "" {
+			return baseURL
+		}
+	}
+	return "https://api.deepseek.com"
+}
+
 func (a *Account) IsOpenAIOAuth() bool {
 	return a.IsOpenAI() && a.Type == AccountTypeOAuth
 }

--- a/backend/internal/service/deepseek_token_provider.go
+++ b/backend/internal/service/deepseek_token_provider.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+var ErrDeepSeekOAuthNotImplemented = errors.New("deepseek OAuth not implemented")
+
+// DeepSeekTokenProvider 管理 DeepSeek 账号访问凭证。
+// 当前仅支持 API Key 模式，OAuth 模式预留接口。
+type DeepSeekTokenProvider struct{}
+
+func NewDeepSeekTokenProvider() *DeepSeekTokenProvider {
+	return &DeepSeekTokenProvider{}
+}
+
+// GetAccessToken 返回 DeepSeek 账号的访问令牌。
+// API Key 模式：直接返回 credentials.api_key。
+// OAuth 模式：预留，返回 ErrDeepSeekOAuthNotImplemented。
+func (p *DeepSeekTokenProvider) GetAccessToken(ctx context.Context, account *Account) (string, error) {
+	if account == nil {
+		return "", errors.New("account is nil")
+	}
+	if account.Platform != PlatformDeepSeek {
+		return "", errors.New("not a deepseek account")
+	}
+
+	if account.Type == AccountTypeAPIKey {
+		token := account.GetCredential("api_key")
+		if strings.TrimSpace(token) == "" {
+			return "", errors.New("api_key not found in credentials")
+		}
+		return token, nil
+	}
+
+	return "", ErrDeepSeekOAuthNotImplemented
+}

--- a/backend/internal/service/deepseek_token_provider_test.go
+++ b/backend/internal/service/deepseek_token_provider_test.go
@@ -1,0 +1,78 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeepSeekTokenProvider_APIKey(t *testing.T) {
+	provider := NewDeepSeekTokenProvider()
+	account := &Account{
+		ID:       1,
+		Platform: PlatformDeepSeek,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "sk-deepseek-test-key",
+		},
+	}
+
+	token, err := provider.GetAccessToken(context.Background(), account)
+	require.NoError(t, err)
+	require.Equal(t, "sk-deepseek-test-key", token)
+}
+
+func TestDeepSeekTokenProvider_NilAccount(t *testing.T) {
+	provider := NewDeepSeekTokenProvider()
+
+	token, err := provider.GetAccessToken(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "account is nil")
+	require.Empty(t, token)
+}
+
+func TestDeepSeekTokenProvider_WrongPlatform(t *testing.T) {
+	provider := NewDeepSeekTokenProvider()
+	account := &Account{
+		ID:       2,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+	}
+
+	token, err := provider.GetAccessToken(context.Background(), account)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a deepseek account")
+	require.Empty(t, token)
+}
+
+func TestDeepSeekTokenProvider_MissingAPIKey(t *testing.T) {
+	provider := NewDeepSeekTokenProvider()
+	account := &Account{
+		ID:          3,
+		Platform:    PlatformDeepSeek,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{},
+	}
+
+	token, err := provider.GetAccessToken(context.Background(), account)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "api_key not found in credentials")
+	require.Empty(t, token)
+}
+
+func TestDeepSeekTokenProvider_OAuthNotImplemented(t *testing.T) {
+	provider := NewDeepSeekTokenProvider()
+	account := &Account{
+		ID:       4,
+		Platform: PlatformDeepSeek,
+		Type:     AccountTypeOAuth,
+	}
+
+	token, err := provider.GetAccessToken(context.Background(), account)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrDeepSeekOAuthNotImplemented)
+	require.Empty(t, token)
+}

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -41,6 +41,7 @@ const (
 	PlatformOpenAI      = domain.PlatformOpenAI
 	PlatformGemini      = domain.PlatformGemini
 	PlatformAntigravity = domain.PlatformAntigravity
+	PlatformDeepSeek    = domain.PlatformDeepSeek
 )
 
 // AllowedQuotaPlatforms 是允许设置 user × platform quota 的平台列表（单一权威来源）。
@@ -51,6 +52,7 @@ var AllowedQuotaPlatforms = []string{
 	PlatformOpenAI,
 	PlatformGemini,
 	PlatformAntigravity,
+	PlatformDeepSeek,
 }
 
 // IsAllowedQuotaPlatform 报告 s 是否为合法的 quota platform 标识。

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -3748,6 +3748,10 @@ func (s *GatewayService) isModelSupportedByAccount(account *Account, requestedMo
 	if account.Platform == PlatformOpenAI && account.IsOpenAIPassthroughEnabled() {
 		return true
 	}
+	// DeepSeek 平台：API Key 模式，使用账号 model_mapping，允许所有映射后的模型
+	if account.Platform == PlatformDeepSeek && account.Type == AccountTypeAPIKey {
+		return true // 允许，由 GetMappedModel 处理
+	}
 	// OAuth/SetupToken 账号使用 Anthropic 标准映射（短ID → 长ID）
 	if account.Platform == PlatformAnthropic && account.Type != AccountTypeAPIKey {
 		if account.Type == AccountTypeServiceAccount {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -1884,18 +1884,26 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 }
 
 func (s *OpenAIGatewayService) listSchedulableAccounts(ctx context.Context, groupID *int64) ([]Account, error) {
+	openAIPlatforms := []string{PlatformOpenAI, PlatformDeepSeek}
 	if s.schedulerSnapshot != nil {
-		accounts, _, err := s.schedulerSnapshot.ListSchedulableAccounts(ctx, groupID, PlatformOpenAI, false)
-		return accounts, err
+		var allAccounts []Account
+		for _, platform := range openAIPlatforms {
+			accounts, _, err := s.schedulerSnapshot.ListSchedulableAccounts(ctx, groupID, platform, true)
+			if err != nil {
+				return nil, err
+			}
+			allAccounts = append(allAccounts, accounts...)
+		}
+		return allAccounts, nil
 	}
 	var accounts []Account
 	var err error
 	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
-		accounts, err = s.accountRepo.ListSchedulableByPlatform(ctx, PlatformOpenAI)
+		accounts, err = s.accountRepo.ListSchedulableByPlatforms(ctx, openAIPlatforms)
 	} else if groupID != nil {
-		accounts, err = s.accountRepo.ListSchedulableByGroupIDAndPlatform(ctx, *groupID, PlatformOpenAI)
+		accounts, err = s.accountRepo.ListSchedulableByGroupIDAndPlatforms(ctx, *groupID, openAIPlatforms)
 	} else {
-		accounts, err = s.accountRepo.ListSchedulableUngroupedByPlatform(ctx, PlatformOpenAI)
+		accounts, err = s.accountRepo.ListSchedulableUngroupedByPlatforms(ctx, openAIPlatforms)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("query accounts failed: %w", err)

--- a/docs/superpowers/plans/2026-05-29-deepseek-platform.md
+++ b/docs/superpowers/plans/2026-05-29-deepseek-platform.md
@@ -1,0 +1,552 @@
+# DeepSeek 平台集成实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 在 Sub2API 中新增 DeepSeek 作为独立平台，支持 API Key 类型账号，复用 OpenAI 兼容转发逻辑，带模型白名单管理。
+
+**Architecture:** DeepSeek 拥有独立的 `platform = "deepseek"` 常量。路由层将 DeepSeek 平台请求分发到 `OpenAIGatewayHandler`（与 OpenAI 平台共享同一 handler），因为 DeepSeek API 完全兼容 OpenAI 格式（`/v1/chat/completions`）。账号的 `credentials.base_url` 设为 `https://api.deepseek.com`，`credentials.api_key` 为 DeepSeek API Key。前端新增平台选择按钮和 API Key 表单。
+
+**Tech Stack:** Go (Gin, Ent ORM), Vue 3, TypeScript, i18n
+
+**Key architectural insight:** 当前路由根据 group platform 分发请求：
+- `PlatformOpenAI` → `h.OpenAIGateway.Messages` / `h.OpenAIGateway.ChatCompletions`
+- 其他平台 → `h.Gateway.Messages` / `h.Gateway.ChatCompletions`
+
+DeepSeek 需要与 OpenAI 共享同一个 handler（因为格式兼容），但保持独立的 platform 标识（用于调度、模型白名单、配额等）。
+
+---
+
+### Task 1: 后端 — 新增 DeepSeek 平台常量
+
+**Files:**
+- Modify: `backend/internal/domain/constants.go`
+- Modify: `backend/internal/service/domain_constants.go`
+- Modify: `backend/internal/model/error_passthrough_rule.go`
+
+- [ ] **Step 1: domain/constants.go 新增 DeepSeek 常量**
+
+在 `PlatformAntigravity` 后面添加：
+```go
+PlatformDeepSeek    = "deepseek"
+```
+
+- [ ] **Step 2: service/domain_constants.go 新增常量 + AllowedQuotaPlatforms**
+
+在 `PlatformAntigravity` 重新导出后面添加：
+```go
+PlatformDeepSeek    = domain.PlatformDeepSeek
+```
+
+在 `AllowedQuotaPlatforms` 切片中加入 `PlatformDeepSeek`。
+
+- [ ] **Step 3: model/error_passthrough_rule.go 新增常量 + AllPlatforms**
+
+在平台常量区添加 `PlatformDeepSeek = "deepseek"`，在 `AllPlatforms()` 返回值中加入。
+
+- [ ] **Step 4: 编译验证**
+
+```bash
+cd backend && go build ./...
+```
+Expected: 编译成功
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/domain/constants.go backend/internal/service/domain_constants.go backend/internal/model/error_passthrough_rule.go
+git commit -m "feat(deepseek): 新增 DeepSeek 平台常量定义"
+```
+
+---
+
+### Task 2: 后端 — 新增 DeepSeek Token Provider + Account 方法
+
+**Files:**
+- Create: `backend/internal/service/deepseek_token_provider.go`
+- Create: `backend/internal/service/deepseek_token_provider_test.go`
+- Modify: `backend/internal/service/account.go`（IsAnthropic 方法后面）
+
+- [ ] **Step 1: 创建 deepseek_token_provider.go**
+
+```go
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+)
+
+var ErrDeepSeekOAuthNotImplemented = errors.New("deepseek OAuth not implemented")
+
+// DeepSeekTokenProvider 管理 DeepSeek 账号访问凭证。
+// 当前仅支持 API Key 模式，OAuth 模式预留接口。
+type DeepSeekTokenProvider struct{}
+
+func NewDeepSeekTokenProvider() *DeepSeekTokenProvider {
+	return &DeepSeekTokenProvider{}
+}
+
+// GetAccessToken 返回 DeepSeek 账号的访问令牌。
+// API Key 模式：直接返回 credentials.api_key。
+// OAuth 模式：预留，返回 ErrDeepSeekOAuthNotImplemented。
+func (p *DeepSeekTokenProvider) GetAccessToken(ctx context.Context, account *Account) (string, error) {
+	if account == nil {
+		return "", errors.New("account is nil")
+	}
+	if account.Platform != PlatformDeepSeek {
+		return "", errors.New("not a deepseek account")
+	}
+
+	if account.Type == AccountTypeAPIKey {
+		token := account.GetCredential("api_key")
+		if strings.TrimSpace(token) == "" {
+			return "", errors.New("api_key not found in credentials")
+		}
+		return token, nil
+	}
+
+	return "", ErrDeepSeekOAuthNotImplemented
+}
+```
+
+- [ ] **Step 2: 创建 deepseek_token_provider_test.go**
+
+测试：API Key 正常返回、Nil 账号报错、错误平台报错、缺失 API Key 报错、OAuth 类型返回 ErrDeepSeekOAuthNotImplemented。
+
+- [ ] **Step 3: account.go 新增方法**
+
+在 `IsAnthropic()` 方法后面添加：
+```go
+func (a *Account) IsDeepSeek() bool {
+	return a.Platform == PlatformDeepSeek
+}
+
+func (a *Account) IsDeepSeekAPIKey() bool {
+	return a.IsDeepSeek() && a.Type == AccountTypeAPIKey
+}
+
+func (a *Account) GetDeepSeekAPIKey() string {
+	if !a.IsDeepSeekAPIKey() {
+		return ""
+	}
+	return a.GetCredential("api_key")
+}
+
+func (a *Account) GetDeepSeekBaseURL() string {
+	if !a.IsDeepSeek() {
+		return ""
+	}
+	if a.Type == AccountTypeAPIKey {
+		baseURL := a.GetCredential("base_url")
+		if baseURL != "" {
+			return baseURL
+		}
+	}
+	return "https://api.deepseek.com"
+}
+```
+
+- [ ] **Step 4: 运行测试**
+
+```bash
+cd backend && go test -tags=unit ./... -run TestDeepSeek -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/service/deepseek_token_provider.go backend/internal/service/deepseek_token_provider_test.go backend/internal/service/account.go
+git commit -m "feat(deepseek): Token Provider + Account 判断方法"
+```
+
+---
+
+### Task 3: 后端 — 路由层 DeepSeek 分发
+
+**Files:**
+- Modify: `backend/internal/server/routes/gateway.go`
+
+**架构说明：** 当前 `gateway.go` 中，OpenAI 平台请求走 `OpenAIGatewayHandler`（支持 OpenAI 格式转发），其他平台走 `GatewayHandler`（Anthropic 格式）。DeepSeek API 兼容 OpenAI 格式，所以应该与 OpenAI 共享 handler。
+
+- [ ] **Step 1: 修改 /v1/messages 路由**
+
+将 `gateway.go` 中的条件从 `== service.PlatformOpenAI` 改为同时支持 OpenAI 和 DeepSeek：
+
+```go
+// /v1/messages: auto-route based on group platform
+gateway.POST("/messages", func(c *gin.Context) {
+    plat := getGroupPlatform(c)
+    if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
+        h.OpenAIGateway.Messages(c)
+        return
+    }
+    h.Gateway.Messages(c)
+})
+```
+
+- [ ] **Step 2: 修改 /v1/messages/count_tokens 路由**
+
+DeepSeek 不支持 count_tokens（与 OpenAI 一致）：
+
+```go
+gateway.POST("/messages/count_tokens", func(c *gin.Context) {
+    plat := getGroupPlatform(c)
+    if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
+        service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
+        c.JSON(http.StatusNotFound, gin.H{...})
+        return
+    }
+    h.Gateway.CountTokens(c)
+})
+```
+
+- [ ] **Step 3: 修改 /v1/responses 路由**
+
+```go
+gateway.POST("/responses", func(c *gin.Context) {
+    plat := getGroupPlatform(c)
+    if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
+        h.OpenAIGateway.Responses(c)
+        return
+    }
+    h.Gateway.Responses(c)
+})
+```
+
+- [ ] **Step 4: 修改 /v1/chat/completions 路由**
+
+```go
+gateway.POST("/chat/completions", func(c *gin.Context) {
+    plat := getGroupPlatform(c)
+    if plat == service.PlatformOpenAI || plat == service.PlatformDeepSeek {
+        h.OpenAIGateway.ChatCompletions(c)
+        return
+    }
+    h.Gateway.ChatCompletions(c)
+})
+```
+
+- [ ] **Step 5: 修改不带 v1 前缀的别名路由（/responses、/chat/completions 等）**
+
+在 `gateway.go` 中所有 `getGroupPlatform(c) == service.PlatformOpenAI` 判断处，添加 `|| getGroupPlatform(c) == service.PlatformDeepSeek`。
+
+- [ ] **Step 6: 编译验证**
+
+```bash
+cd backend && go build ./...
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/internal/server/routes/gateway.go
+git commit -m "feat(deepseek): 路由层 DeepSeek 分发到 OpenAIGateway"
+```
+
+---
+
+### Task 4: 后端 — OpenAI Gateway 增加 DeepSeek 平台支持
+
+**Files:**
+- Modify: `backend/internal/service/openai_gateway_service.go`（或相关调度/转发文件）
+- Modify: `backend/internal/service/openai_account_scheduler.go`（DeepSeek 账号调度）
+
+**关键检查点：** `OpenAIGatewayService` 的账号调度逻辑需要能调度 DeepSeek 平台账号。需要确认调度器是否按 platform 字符串过滤。
+
+- [ ] **Step 1: 检查 OpenAI 账号调度器是否按 platform 硬编码**
+
+检查 `openai_account_scheduler.go` 中是否有硬编码 `PlatformOpenAI` 的过滤。如果有，需要加入 `PlatformDeepSeek`。
+
+- [ ] **Step 2: 在 OpenAI Gateway 的消息处理中加入 DeepSeek 平台识别**
+
+检查 `openai_gateway_messages.go` 或相关方法中是否有 platform 检查。确保 DeepSeek 平台能进入账号调度流程。
+
+- [ ] **Step 3: 确认 base_url 和 API Key 的获取**
+
+`OpenAIGatewayService` 转发请求时使用 `account.GetBaseURL()` 或类似方法获取上游 URL，使用 `account.GetCredential("api_key")` 获取凭证。由于 DeepSeek API Key 账号的 credentials 中包含 `base_url` 和 `api_key`，这些已有的 accessor 应该能直接工作。
+
+需要确认：`OpenAIGatewayService` 对 API Key 账号的转发 URL 构建是否使用 `GetBaseURL()` 返回的值（可被 custom base_url 覆盖）。如果是，DeepSeek 账号默认会使用 `https://api.deepseek.com`。
+
+- [ ] **Step 4: 编译验证**
+
+```bash
+cd backend && go build ./...
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/service/openai_*.go
+git commit -m "feat(deepseek): OpenAI Gateway 支持 DeepSeek 平台调度"
+```
+
+---
+
+### Task 5: 后端 — isModelSupportedByAccount 增加 DeepSeek 分支
+
+**Files:**
+- Modify: `backend/internal/service/gateway_service.go`（isModelSupportedByAccount 方法）
+
+- [ ] **Step 1: 在 isModelSupportedByAccount 中处理 DeepSeek**
+
+在 `isModelSupportedByAccount` 方法中（约 line 3736），DeepSeek 使用与 OpenAI 相同的模型支持策略（API Key 账号使用账号的 model_mapping）：
+
+```go
+// DeepSeek 平台：API Key 模式，使用账号 model_mapping
+if account.Platform == PlatformDeepSeek && account.Type == AccountTypeAPIKey {
+    return true // 允许，由 GetMappedModel 处理
+}
+```
+
+- [ ] **Step 2: GetAccessToken 增加 DeepSeek 分支**
+
+在 `GetAccessToken` 方法中（约 line 3764），DeepSeek API Key 走已有的 `AccountTypeAPIKey` 分支（直接取 `api_key`），无需额外修改。但如果后续要接入 DeepSeek Token Provider：
+
+```go
+case AccountTypeAPIKey:
+    if account.Platform == PlatformDeepSeek {
+        // 未来可接入 DeepSeekTokenProvider 做 OAuth
+        apiKey := account.GetCredential("api_key")
+        if apiKey == "" {
+            return "", "", errors.New("api_key not found in credentials")
+        }
+        return apiKey, "apikey", nil
+    }
+    apiKey := account.GetCredential("api_key")
+    ...
+```
+
+实际上当前 APIKey 分支已经是通用的，**无需额外修改**。
+
+- [ ] **Step 3: 编译验证**
+
+```bash
+cd backend && go build ./...
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/service/gateway_service.go
+git commit -m "feat(deepseek): isModelSupportedByAccount 支持 DeepSeek"
+```
+
+---
+
+### Task 6: 前端 — 类型定义 + CreateAccountModal
+
+**Files:**
+- Modify: `frontend/src/types/index.ts`
+- Modify: `frontend/src/components/account/CreateAccountModal.vue`
+
+- [ ] **Step 1: types/index.ts 增加 'deepseek'**
+
+在第 690 行的 `AccountPlatform` 类型中加入 `'deepseek'`：
+```ts
+export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'deepseek'
+```
+
+- [ ] **Step 2: CreateAccountModal.vue — 平台选择按钮**
+
+在 Antigravity 按钮后面添加 DeepSeek 按钮。找到平台选择区域的模板代码，添加：
+
+```vue
+<button
+  type="button"
+  @click="form.platform = 'deepseek'"
+  :class="[
+    'flex items-center gap-2 rounded-lg border-2 px-4 py-2.5 text-sm font-medium transition-all',
+    form.platform === 'deepseek'
+      ? 'border-cyan-500 bg-cyan-50 text-cyan-700 dark:bg-cyan-900/20 dark:text-cyan-400'
+      : 'border-gray-200 hover:border-cyan-300 dark:border-dark-600 dark:hover:border-cyan-700'
+  ]"
+>
+  <span class="flex h-6 w-6 items-center justify-center rounded-full bg-cyan-500 text-white text-xs font-bold">D</span>
+  DeepSeek
+</button>
+```
+
+- [ ] **Step 3: CreateAccountModal.vue — baseUrlHint 和 apiKeyHint**
+
+在 `baseUrlHint` computed 中添加 DeepSeek 分支：
+```ts
+const baseUrlHint = computed(() => {
+  if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
+  if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === 'deepseek') return t('admin.accounts.deepseek.baseUrlHint')
+  return t('admin.accounts.baseUrlHint')
+})
+```
+
+在 `apiKeyHint` computed 中添加：
+```ts
+const apiKeyHint = computed(() => {
+  if (form.platform === 'openai') return t('admin.accounts.openai.apiKeyHint')
+  if (form.platform === 'gemini') return t('admin.accounts.gemini.apiKeyHint')
+  if (form.platform === 'deepseek') return t('admin.accounts.deepseek.apiKeyHint')
+  return t('admin.accounts.apiKeyHint')
+})
+```
+
+- [ ] **Step 4: CreateAccountModal.vue — resetForm 默认 URL**
+
+在 `resetForm` 函数中，`apiKeyBaseUrl.value` 的默认值需要支持 DeepSeek。检查当前逻辑：
+
+```ts
+const defaultBaseUrl =
+  form.platform === 'openai'
+    ? 'https://api.openai.com'
+    : form.platform === 'gemini'
+      ? 'https://generativelanguage.googleapis.com'
+      : form.platform === 'deepseek'
+        ? 'https://api.deepseek.com'
+        : 'https://api.anthropic.com'
+```
+
+找到 handleSubmit 中的 `defaultBaseUrl` 变量（约 line 4477），添加 DeepSeek 分支。
+
+- [ ] **Step 5: CreateAccountModal.vue — isOAuthFlow**
+
+DeepSeek 当前只支持 API Key，不支持 OAuth。确保 `isOAuthFlow` 对 DeepSeek 返回 false。当前逻辑是 `accountCategory.value === 'oauth-based'` 才返回 true。需要在 DeepSeek 平台时强制 `accountCategory = 'apikey'` 或者在 `isOAuthFlow` 中添加：
+
+```ts
+const isOAuthFlow = computed(() => {
+  if (form.platform === 'deepseek') return false
+  // ... 原有逻辑
+})
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/types/index.ts frontend/src/components/account/CreateAccountModal.vue
+git commit -m "feat(deepseek): 前端类型 + 账号创建 UI"
+```
+
+---
+
+### Task 7: 前端 — EditAccountModal + i18n + 模型白名单
+
+**Files:**
+- Modify: `frontend/src/components/account/EditAccountModal.vue`
+- Modify: `frontend/src/locales/en.ts`（或对应的 i18n 文件）
+- Modify: `frontend/src/locales/zh.ts`
+- Modify: `frontend/src/composables/useModelWhitelist.ts`
+
+- [ ] **Step 1: EditAccountModal.vue — baseUrl 和 apiKey placeholder**
+
+在模板的 placeholder 条件链中加入 DeepSeek（约 line 38-44 和 60-66）：
+```vue
+:placeholder="
+  account.platform === 'openai'
+    ? 'https://api.openai.com'
+    : account.platform === 'gemini'
+      ? 'https://generativelanguage.googleapis.com'
+      : account.platform === 'deepseek'
+        ? 'https://api.deepseek.com'
+        : account.platform === 'antigravity'
+          ? 'https://cloudcode-pa.googleapis.com'
+          : 'https://api.anthropic.com'
+"
+```
+
+API Key placeholder 同样加入：
+```vue
+:placeholder="
+  account.platform === 'openai'
+    ? 'sk-proj-...'
+    : account.platform === 'gemini'
+      ? 'AIza...'
+      : account.platform === 'deepseek'
+        ? 'sk-...'
+        : account.platform === 'antigravity'
+          ? 'sk-...'
+          : 'sk-ant-...'
+"
+```
+
+- [ ] **Step 2: i18n — 添加 DeepSeek 翻译**
+
+在 `frontend/src/locales/en.ts` 和 `frontend/src/locales/zh.ts` 的 `admin.accounts` 下添加：
+```ts
+deepseek: {
+  baseUrlHint: 'Default: https://api.deepseek.com',
+  apiKeyHint: 'Get your API key from https://platform.deepseek.com',
+}
+```
+
+- [ ] **Step 3: useModelWhitelist.ts — DeepSeek 模型白名单 + 预设映射**
+
+在 `deepseekModels` 数组（已存在，约 line 102）中加入 V4 模型：
+```ts
+const deepseekModels = [
+  'deepseek-chat', 'deepseek-coder', 'deepseek-reasoner',
+  'deepseek-v3', 'deepseek-v3-0324',
+  'deepseek-v4-flash', 'deepseek-v4-pro',
+  'deepseek-r1', 'deepseek-r1-0528',
+  'deepseek-r1-distill-qwen-32b', 'deepseek-r1-distill-qwen-14b', 'deepseek-r1-distill-qwen-7b',
+  'deepseek-r1-distill-llama-70b', 'deepseek-r1-distill-llama-8b'
+]
+```
+
+在 `getPresetMappingsByPlatform` 函数中加入 DeepSeek 预设映射：
+```ts
+if (platform === 'deepseek') return deepseekPresetMappings
+```
+
+新增 `deepseekPresetMappings`：
+```ts
+const deepseekPresetMappings = [
+  { label: 'V4 Flash', from: 'deepseek-v4-flash', to: 'deepseek-v4-flash', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'V4 Pro', from: 'deepseek-v4-pro', to: 'deepseek-v4-pro', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'V3', from: 'deepseek-v3', to: 'deepseek-v3', color: 'bg-teal-100 text-teal-700 hover:bg-teal-200 dark:bg-teal-900/30 dark:text-teal-400' },
+  { label: 'R1', from: 'deepseek-r1', to: 'deepseek-r1', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
+  { label: 'Chat→V3', from: 'deepseek-chat', to: 'deepseek-v3', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' },
+]
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/account/EditAccountModal.vue frontend/src/locales/en.ts frontend/src/locales/zh.ts frontend/src/composables/useModelWhitelist.ts
+git commit -m "feat(deepseek): 编辑 UI + i18n + 模型白名单"
+```
+
+---
+
+### Task 8: 集成测试 & 验证
+
+**Files:**
+- Test: 端到端手动测试
+
+- [ ] **Step 1: 启动后端**
+
+```bash
+cd backend && go run ./cmd/server/
+```
+
+- [ ] **Step 2: 启动前端**
+
+```bash
+cd frontend && npm run dev
+```
+
+- [ ] **Step 3: 验证 DeepSeek 账号创建**
+
+1. 打开前端管理页面
+2. 添加账号 → 选择 DeepSeek 平台
+3. 确认 API Key 表单显示
+4. 填入测试 API Key 和 base_url
+5. 确认创建成功
+
+- [ ] **Step 4: 验证模型白名单**
+
+在账号配置页面确认 DeepSeek 模型列表包含 V4-Flash、V4-Pro 等。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "chore: DeepSeek 平台集成完成"
+```

--- a/docs/superpowers/specs/2026-05-29-deepseek-platform-design.md
+++ b/docs/superpowers/specs/2026-05-29-deepseek-platform-design.md
@@ -1,0 +1,135 @@
+---
+title: "DeepSeek Platform Integration"
+change: "deepseek-platform"
+design-doc: "docs/superpowers/specs/2026-05-29-deepseek-platform-design.md"
+date: "2026-05-29"
+status: "draft"
+---
+
+# DeepSeek 平台集成设计
+
+## 1. 概述
+
+在 Sub2API 中新增 DeepSeek 作为独立平台，支持 API Key 类型账号，复用 OpenAI 兼容转发逻辑，自带独立的模型白名单管理。用户通过 Sub2API 统一入口发送请求（支持 Anthropic 和 OpenAI 两种格式），网关自动路由并格式转换后转发给 DeepSeek。
+
+本次集成同时预留 OAuth 扩展接口，为后续可能的 OAuth 登录流程做准备。
+
+## 2. 架构决策
+
+### 2.1 平台标识策略
+
+采用 **独立 Platform 字符串 + 复用 OpenAI 转发逻辑** 的策略：
+
+- DeepSeek 拥有独立的 `platform = "deepseek"` 常量
+- 在模型白名单、调度策略、账号管理上与 OpenAI 完全解耦
+- 网关转发层复用 OpenAI `/v1/chat/completions` 格式（DeepSeek API 完全兼容此格式）
+
+选择理由：DeepSeek 作为独立平台需要自己的生态位（模型白名单、配额策略、调度规则），但其 API 与 OpenAI 完全兼容，转发逻辑无需重复实现。
+
+### 2.2 请求路由
+
+| 用户请求格式 | 网关处理 | 转发目标 |
+|-------------|---------|---------|
+| Anthropic `/v1/messages` | 转换为 OpenAI `/v1/chat/completions` | `api.deepseek.com/v1/chat/completions` |
+| OpenAI `/v1/chat/completions` | 直接透传 | `api.deepseek.com/v1/chat/completions` |
+
+### 2.3 数据流
+
+```
+客户端 → Sub2API Gateway
+  → resolvePlatform 解析 platform = "deepseek"
+  → listSchedulableAccounts 筛选 deepseek 账号
+  → 按 RPM/配额/模型白名单过滤
+  → 选中最佳账号，取出 API Key
+  → 如有需要，将 Anthropic 格式转为 OpenAI 格式
+  → 转发到 api.deepseek.com/v1/chat/completions
+  → 将响应按原始请求格式返回
+```
+
+## 3. 后端改动
+
+### 3.1 常量定义
+
+**`backend/internal/domain/constants.go`**
+- 新增 `PlatformDeepSeek = "deepseek"`
+
+**`backend/internal/service/domain_constants.go`**
+- 新增 `PlatformDeepSeek = "deepseek"` 重新导出
+- 加入 `AllowedQuotaPlatforms` 列表
+
+### 3.2 账号逻辑
+
+**`backend/internal/service/account.go`**
+- 新增 `IsDeepSeek()` 平台判断方法
+- 新增 `GetDeepSeekAPIKey()` / `GetDeepSeekBaseURL()` 凭证访问器
+- 新增 `IsDeepSeekAPIKey()` 类型判断方法
+- 在 `IsModelSupported()` 等模型相关方法中加入 DeepSeek 分支
+
+### 3.3 Token Provider
+
+**`backend/internal/service/deepseek_token_provider.go`（新文件）**
+- 新建 Token Provider，复用 OpenAI 的结构定义
+- 本次只实现 API Key 模式（`GetToken()` 直接返回 API Key）
+- 预留 OAuth 接口方法，返回 `ErrNotImplemented`
+
+### 3.4 网关转发
+
+**`backend/internal/service/gateway_service.go`**
+- 在 `resolvePlatform` 中支持 deepseek
+- 在账号选择逻辑的 platform 分支中加入 DeepSeek
+- DeepSeek 转发复用 OpenAI 格式的转发路径（`/v1/chat/completions`）
+- 在 Anthropic → OpenAI 格式转换层中，DeepSeek 作为目标平台时走 OpenAI 转换逻辑
+
+### 3.5 Handler
+
+**`backend/internal/handler/admin/account_handler.go`**
+- 创建 DeepSeek 账号时走 API Key 路径
+- 不支持 OAuth 创建（预留入口，返回明确错误提示）
+
+## 4. 前端改动
+
+### 4.1 类型定义
+
+**`frontend/src/types/index.ts`**
+- `AccountPlatform` 联合类型增加 `'deepseek'`
+
+### 4.2 账号创建
+
+**`frontend/src/components/account/CreateAccountModal.vue`**
+- DeepSeek 平台选择按钮
+- API Key 表单字段（`api_key`、`base_url`，默认 `https://api.deepseek.com`）
+
+### 4.3 账号编辑
+
+**`frontend/src/components/account/EditAccountModal.vue`**
+- DeepSeek 编辑表单，复用 OpenAI 风格的凭证输入
+
+### 4.4 模型白名单
+
+**`frontend/src/composables/useModelWhitelist.ts`**
+- DeepSeek 预设模型列表：`deepseek-chat`、`deepseek-reasoner`、`deepseek-v4-flash`、`deepseek-v4-pro`
+- DeepSeek 模型预设映射
+
+## 5. 不做的范围
+
+- DeepSeek OAuth 登录流程（仅预留接口定义）
+- DeepSeek WebSocket 实时流
+- Anthropic 专有功能（tool use、extended thinking）到 DeepSeek 的完整映射
+- 健康检测 / 自动重试
+- 数据库 schema 变更（platform 字段是通用字符串，无需 migration）
+
+## 6. 错误处理
+
+| 错误场景 | 处理方式 |
+|---------|---------|
+| DeepSeek 401/403 | 标记账号异常 |
+| DeepSeek 429 | 标记限流，按 RPM 调度逻辑处理 |
+| DeepSeek 5xx | 尝试重试或降级 |
+| 模型不在白名单 | 在模型白名单层拦截 |
+
+## 7. 测试策略
+
+- DeepSeek 平台常量单元测试
+- 账号创建 API 集成测试
+- 模型白名单匹配测试
+- 网关 Anthropic → OpenAI 格式转换单元测试

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -147,6 +147,31 @@
             <Icon name="cloud" size="sm" />
             Antigravity
           </button>
+          <button
+            type="button"
+            @click="form.platform = 'deepseek'"
+            :class="[
+              'flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2.5 text-sm font-medium transition-all',
+              form.platform === 'deepseek'
+                ? 'bg-white text-cyan-600 shadow-sm dark:bg-dark-600 dark:text-cyan-400'
+                : 'text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+            ]"
+          >
+            <svg
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+              />
+            </svg>
+            DeepSeek
+          </button>
         </div>
       </div>
 
@@ -1021,7 +1046,9 @@
                 ? 'https://api.openai.com'
                 : form.platform === 'gemini'
                   ? 'https://generativelanguage.googleapis.com'
-                  : 'https://api.anthropic.com'
+                  : form.platform === 'deepseek'
+                    ? 'https://api.deepseek.com'
+                    : 'https://api.anthropic.com'
             "
           />
           <p class="input-hint">{{ baseUrlHint }}</p>
@@ -1038,7 +1065,9 @@
                 ? 'sk-proj-...'
                 : form.platform === 'gemini'
                   ? 'AIza...'
-                  : 'sk-ant-...'
+                  : form.platform === 'deepseek'
+                    ? 'sk-...'
+                    : 'sk-ant-...'
             "
           />
           <p class="input-hint">{{ apiKeyHint }}</p>
@@ -3225,12 +3254,14 @@ const oauthStepTitle = computed(() => {
 const baseUrlHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
   if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === 'deepseek') return t('admin.accounts.deepseek.baseUrlHint')
   return t('admin.accounts.baseUrlHint')
 })
 
 const apiKeyHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.apiKeyHint')
   if (form.platform === 'gemini') return t('admin.accounts.gemini.apiKeyHint')
+  if (form.platform === 'deepseek') return t('admin.accounts.deepseek.apiKeyHint')
   return t('admin.accounts.apiKeyHint')
 })
 
@@ -3586,6 +3617,10 @@ const isOAuthFlow = computed(() => {
   if (form.platform === 'anthropic' && accountCategory.value === 'bedrock') {
     return false
   }
+  // DeepSeek 仅支持 API Key，不需要 OAuth 流程
+  if (form.platform === 'deepseek') {
+    return false
+  }
   return accountCategory.value === 'oauth-based'
 })
 
@@ -3652,6 +3687,11 @@ watch(
       form.type = 'apikey'
       return
     }
+    // DeepSeek 仅支持 API Key
+    if (form.platform === 'deepseek') {
+      form.type = 'apikey'
+      return
+    }
     // Bedrock 类型
     if (form.platform === 'anthropic' && category === 'bedrock') {
       form.type = 'bedrock' as AccountType
@@ -3678,7 +3718,9 @@ watch(
         ? 'https://api.openai.com'
         : newPlatform === 'gemini'
           ? 'https://generativelanguage.googleapis.com'
-          : 'https://api.anthropic.com'
+          : newPlatform === 'deepseek'
+            ? 'https://api.deepseek.com'
+            : 'https://api.anthropic.com'
     // Clear model-related settings
     allowedModels.value = []
     modelMappings.value = []
@@ -3702,6 +3744,10 @@ watch(
     }
     if (newPlatform !== 'anthropic' && accountCategory.value === 'bedrock') {
       accountCategory.value = 'oauth-based'
+    }
+    // DeepSeek 仅支持 API Key
+    if (newPlatform === 'deepseek') {
+      accountCategory.value = 'apikey'
     }
     // Reset Bedrock fields when switching platforms
     bedrockAccessKeyId.value = ''
@@ -4479,7 +4525,9 @@ const handleSubmit = async () => {
       ? 'https://api.openai.com'
       : form.platform === 'gemini'
         ? 'https://generativelanguage.googleapis.com'
-        : 'https://api.anthropic.com'
+        : form.platform === 'deepseek'
+          ? 'https://api.deepseek.com'
+          : 'https://api.anthropic.com'
 
   // Build credentials with optional model mapping
   const credentials: Record<string, unknown> = {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -41,7 +41,9 @@
                   ? 'https://generativelanguage.googleapis.com'
                   : account.platform === 'antigravity'
                     ? 'https://cloudcode-pa.googleapis.com'
-                    : 'https://api.anthropic.com'
+                    : account.platform === 'deepseek'
+                      ? 'https://api.deepseek.com'
+                      : 'https://api.anthropic.com'
             "
           />
           <p class="input-hint">{{ baseUrlHint }}</p>
@@ -63,7 +65,9 @@
                   ? 'AIza...'
                   : account.platform === 'antigravity'
                     ? 'sk-...'
-                    : 'sk-ant-...'
+                    : account.platform === 'deepseek'
+                      ? 'sk-...'
+                      : 'sk-ant-...'
             "
           />
           <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
@@ -2298,6 +2302,7 @@ const baseUrlHint = computed(() => {
   if (!props.account) return t('admin.accounts.baseUrlHint')
   if (props.account.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
   if (props.account.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (props.account.platform === 'deepseek') return t('admin.accounts.deepseek.baseUrlHint')
   return t('admin.accounts.baseUrlHint')
 })
 
@@ -2614,6 +2619,7 @@ const tempUnschedPresets = computed(() => [
 const defaultBaseUrl = computed(() => {
   if (props.account?.platform === 'openai') return 'https://api.openai.com'
   if (props.account?.platform === 'gemini') return 'https://generativelanguage.googleapis.com'
+  if (props.account?.platform === 'deepseek') return 'https://api.deepseek.com'
   return 'https://api.anthropic.com'
 })
 
@@ -2854,7 +2860,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
           ? 'https://generativelanguage.googleapis.com'
-          : 'https://api.anthropic.com'
+          : newAccount.platform === 'deepseek'
+            ? 'https://api.deepseek.com'
+            : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
 
     // Load model mappings and detect mode
@@ -2922,7 +2930,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
           ? 'https://generativelanguage.googleapis.com'
-          : 'https://api.anthropic.com'
+          : newAccount.platform === 'deepseek'
+            ? 'https://api.deepseek.com'
+            : 'https://api.anthropic.com'
     editBaseUrl.value = platformDefaultUrl
 
     // Load model mappings for OpenAI OAuth accounts

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -101,7 +101,8 @@ const qwenModels = [
 // DeepSeek
 const deepseekModels = [
   'deepseek-chat', 'deepseek-coder', 'deepseek-reasoner',
-  'deepseek-v3', 'deepseek-v3-0324',
+  'deepseek-v3', 'deepseek-v3-0324', 'deepseek-v3-2-251201',
+  'deepseek-v4-pro', 'deepseek-v4-flash',
   'deepseek-r1', 'deepseek-r1-0528',
   'deepseek-r1-distill-qwen-32b', 'deepseek-r1-distill-qwen-14b', 'deepseek-r1-distill-qwen-7b',
   'deepseek-r1-distill-llama-70b', 'deepseek-r1-distill-llama-8b'
@@ -267,6 +268,17 @@ const geminiPresetMappings = [
   { label: '3.1 Image', from: 'gemini-3.1-flash-image', to: 'gemini-3.1-flash-image', color: 'bg-sky-100 text-sky-700 hover:bg-sky-200 dark:bg-sky-900/30 dark:text-sky-400' }
 ]
 
+// DeepSeek 预设映射
+const deepseekPresetMappings = [
+  { label: 'DeepSeek Chat', from: 'deepseek-chat', to: 'deepseek-chat', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
+  { label: 'DeepSeek Reasoner', from: 'deepseek-reasoner', to: 'deepseek-reasoner', color: 'bg-teal-100 text-teal-700 hover:bg-teal-200 dark:bg-teal-900/30 dark:text-teal-400' },
+  { label: 'V3.2', from: 'deepseek-v3-2', to: 'deepseek-v3-2-251201', color: 'bg-sky-100 text-sky-700 hover:bg-sky-200 dark:bg-sky-900/30 dark:text-sky-400' },
+  { label: 'V4 Pro', from: 'deepseek-v4-pro', to: 'deepseek-v4-pro', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
+  { label: 'V4 Flash', from: 'deepseek-v4-flash', to: 'deepseek-v4-flash', color: 'bg-violet-100 text-violet-700 hover:bg-violet-200 dark:bg-violet-900/30 dark:text-violet-400' },
+  { label: 'Sonnet→Chat', from: 'claude-sonnet-4-6', to: 'deepseek-chat', color: 'bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/30 dark:text-blue-400' },
+  { label: 'Opus→Pro', from: 'claude-opus-4-6', to: 'deepseek-v4-pro', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' }
+]
+
 // Antigravity 预设映射（支持通配符）
 const antigravityPresetMappings = [
   // Claude 通配符映射
@@ -379,6 +391,7 @@ export function getModelsByPlatform(platform: string): string[] {
 export function getPresetMappingsByPlatform(platform: string) {
   if (platform === 'openai') return openaiPresetMappings
   if (platform === 'gemini') return geminiPresetMappings
+  if (platform === 'deepseek') return deepseekPresetMappings
   if (platform === 'antigravity') return antigravityPresetMappings
   if (platform === 'bedrock') return bedrockPresetMappings
   return anthropicPresetMappings

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -484,7 +484,7 @@ export interface PaginationConfig {
 
 // ==================== API Key & Group Types ====================
 
-export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity'
+export type GroupPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'deepseek'
 
 export type SubscriptionType = 'standard' | 'subscription'
 
@@ -687,7 +687,7 @@ export interface UpdateGroupRequest {
 
 // ==================== Account & Proxy Types ====================
 
-export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity'
+export type AccountPlatform = 'anthropic' | 'openai' | 'gemini' | 'antigravity' | 'deepseek'
 export type AccountType = 'oauth' | 'setup-token' | 'apikey' | 'upstream' | 'bedrock' | 'service_account'
 export type OAuthAddMethod = 'oauth' | 'setup-token'
 export type ProxyProtocol = 'http' | 'https' | 'socks5' | 'socks5h'

--- a/openspec/changes/deepseek-platform/.comet.yaml
+++ b/openspec/changes/deepseek-platform/.comet.yaml
@@ -1,0 +1,14 @@
+workflow: full
+phase: build
+design_doc: docs/superpowers/specs/2026-05-29-deepseek-platform-design.md
+plan: docs/superpowers/plans/2026-05-29-deepseek-platform.md
+base_ref: c5ad56f1
+build_mode: null
+isolation: null
+verify_mode: null
+verify_result: pending
+verification_report: null
+branch_status: pending
+created_at: 2026-05-29
+verified_at: null
+archived: false

--- a/openspec/changes/deepseek-platform/.openspec.yaml
+++ b/openspec/changes/deepseek-platform/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-29

--- a/openspec/changes/deepseek-platform/design.md
+++ b/openspec/changes/deepseek-platform/design.md
@@ -1,0 +1,17 @@
+# DeepSeek 平台集成 — 高层设计
+
+详见 Superpowers Design Doc: `docs/superpowers/specs/2026-05-29-deepseek-platform-design.md`
+
+## 架构决策
+
+1. **独立 platform 字符串 + 复用 OpenAI 转发逻辑**
+   - DeepSeek 有独立的 `platform = "deepseek"` 常量
+   - 路由层分发到 OpenAIGatewayHandler（格式完全兼容）
+   - 调度、模型白名单、配额与 OpenAI 解耦
+
+2. **API Key 先行，预留 OAuth**
+   - 本次仅支持 API Key 类型
+   - 新建 DeepSeekTokenProvider，OAuth 方法返回 ErrNotImplemented
+
+3. **无需数据库变更**
+   - platform 字段为通用字符串，无需 migration

--- a/openspec/changes/deepseek-platform/proposal.md
+++ b/openspec/changes/deepseek-platform/proposal.md
@@ -1,0 +1,20 @@
+# DeepSeek 平台集成
+
+## Why
+
+用户需求：Sub2API 当前支持 Anthropic、OpenAI、Gemini、Antigravity 四个平台，需要增加国内平台支持。首选 DeepSeek，因其 API 完全兼容 OpenAI 格式、V4 刚发布热度高、集成成本最低。
+
+## What
+
+- 新增 `platform = "deepseek"` 作为独立平台标识
+- 支持 API Key 类型账号（base_url + api_key）
+- 复用 OpenAI 兼容转发逻辑（/v1/chat/completions）
+- 独立的模型白名单（V3、V4-Flash、V4-Pro、R1 等）
+- 预留 OAuth 扩展接口（本次不实现）
+
+## Impact
+
+- 新增平台不影响现有 Anthropic/OpenAI/Gemini/Antigravity 平台功能
+- 路由层将 DeepSeek 请求分发到 OpenAIGatewayHandler（格式兼容）
+- 前端新增 DeepSeek 平台选择按钮和 API Key 表单
+- 无需数据库 schema 变更

--- a/openspec/changes/deepseek-platform/tasks.md
+++ b/openspec/changes/deepseek-platform/tasks.md
@@ -1,0 +1,10 @@
+# DeepSeek 平台集成 — 任务清单
+
+- [ ] Task 1: 后端 — 新增 DeepSeek 平台常量
+- [ ] Task 2: 后端 — 新增 DeepSeek Token Provider + Account 方法
+- [ ] Task 3: 后端 — 路由层 DeepSeek 分发
+- [ ] Task 4: 后端 — OpenAI Gateway 增加 DeepSeek 平台支持
+- [ ] Task 5: 后端 — isModelSupportedByAccount 增加 DeepSeek 分支
+- [ ] Task 6: 前端 — 类型定义 + CreateAccountModal
+- [ ] Task 7: 前端 — EditAccountModal + i18n + 模型白名单
+- [ ] Task 8: 集成测试 & 验证


### PR DESCRIPTION
## Summary
- 新增 `platform = "deepseek"` 作为第 5 个独立平台标识
- 支持 API Key 类型账号（base_url + api_key），默认上游地址 `https://api.deepseek.com`
- 复用 OpenAI 兼容转发逻辑（/v1/chat/completions），路由层自动分发到 OpenAIGatewayHandler
- 独立的模型白名单管理（V3、V4-Flash、V4-Pro、R1 等）
- 预留 OAuth 扩展接口（本次不实现）

## Changes
| 层 | 改动 |
|---|---|
| 后端常量 | domain/service/model 三层新增 PlatformDeepSeek |
| Token Provider | 新建 deepseek_token_provider.go（API Key 模式，OAuth 预留） |
| 账号方法 | account.go 新增 IsDeepSeek/GetDeepSeekAPIKey/GetDeepSeekBaseURL |
| 路由分发 | gateway.go 中 7 处 PlatformOpenAI 判断加入 DeepSeek |
| Gateway 调度 | openai_gateway_service.go listSchedulableAccounts 支持双平台 |
| 模型校验 | isModelSupportedByAccount 新增 DeepSeek 分支 |
| 前端类型 | AccountPlatform 联合类型加入 'deepseek' |
| 创建账号 | CreateAccountModal 新增 DeepSeek 平台按钮 + API Key 表单 |
| 编辑账号 | EditAccountModal 新增 DeepSeek placeholder |
| 模型白名单 | useModelWhitelist.ts 新增 V4 模型 + 预设映射 |

## Test Plan
- [ ] 后端编译 `go build ./...` 通过
- [ ] DeepSeek Token Provider 5 个单元测试全部通过
- [ ] 前端创建/编辑 DeepSeek 账号 UI 正常显示
- [ ] 模型白名单包含 V4-Flash、V4-Pro 等新模型

🤖 Generated with [Claude Code](https://claude.com/claude-code)