### PR TITLE
修复 OpenAI OAuth 刷新未补全账号信息

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -137,7 +137,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	httpUpstream := repository.NewHTTPUpstream(configConfig)
 	deferredService := service.ProvideDeferredService(accountRepository, timingWheelService)
 	openAIOAuthClient := repository.NewOpenAIOAuthClient()
-	openAIOAuthService := service.NewOpenAIOAuthService(proxyRepository, openAIOAuthClient)
+	openAIOAuthService := service.ProvideOpenAIOAuthService(proxyRepository, openAIOAuthClient, privacyClientFactory)
 	oAuthRefreshAPI := service.ProvideOAuthRefreshAPI(accountRepository, geminiTokenCache)
 	openAITokenProvider := service.ProvideOpenAITokenProvider(accountRepository, geminiTokenCache, openAIOAuthService, oAuthRefreshAPI)
 	channelRepository := repository.NewChannelRepository(db)

--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -278,9 +278,27 @@ func (s *OpenAIOAuthService) enrichTokenInfo(ctx context.Context, tokenInfo *Ope
 			tokenInfo.Email = info.Email
 		}
 	}
+	if strings.TrimSpace(tokenInfo.SubscriptionExpiresAt) == "" {
+		if expiresAt := fetchChatGPTSubscriptionExpiresAt(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL, resolveChatGPTSubscriptionAccountID(tokenInfo, orgID)); expiresAt != "" {
+			tokenInfo.SubscriptionExpiresAt = expiresAt
+		}
+	}
 
 	// 尝试设置隐私（关闭训练数据共享），best-effort
 	tokenInfo.PrivacyMode = disableOpenAITraining(ctx, s.privacyClientFactory, tokenInfo.AccessToken, proxyURL)
+}
+
+func resolveChatGPTSubscriptionAccountID(tokenInfo *OpenAITokenInfo, orgID string) string {
+	for _, candidate := range []string{
+		tokenInfo.ChatGPTAccountID,
+		tokenInfo.OrganizationID,
+		orgID,
+	} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 // RefreshAccountToken refreshes token for an OpenAI OAuth account
@@ -292,36 +310,38 @@ func (s *OpenAIOAuthService) RefreshAccountToken(ctx context.Context, account *A
 		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_OAUTH_INVALID_ACCOUNT_TYPE", "account is not an OAuth account")
 	}
 
-	refreshToken := account.GetCredential("refresh_token")
-	if refreshToken == "" {
-		accessToken := account.GetCredential("access_token")
-		if accessToken != "" {
-			tokenInfo := &OpenAITokenInfo{
-				AccessToken:      accessToken,
-				RefreshToken:     "",
-				IDToken:          account.GetCredential("id_token"),
-				ClientID:         account.GetCredential("client_id"),
-				Email:            account.GetCredential("email"),
-				ChatGPTAccountID: account.GetCredential("chatgpt_account_id"),
-				ChatGPTUserID:    account.GetCredential("chatgpt_user_id"),
-				OrganizationID:   account.GetCredential("organization_id"),
-				PlanType:         account.GetCredential("plan_type"),
-			}
-			if expiresAt := account.GetCredentialAsTime("expires_at"); expiresAt != nil {
-				tokenInfo.ExpiresAt = expiresAt.Unix()
-				tokenInfo.ExpiresIn = int64(time.Until(*expiresAt).Seconds())
-			}
-			return tokenInfo, nil
-		}
-		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_OAUTH_NO_REFRESH_TOKEN", "no refresh token available")
-	}
-
 	var proxyURL string
 	if account.ProxyID != nil {
 		proxy, err := s.proxyRepo.GetByID(ctx, *account.ProxyID)
 		if err == nil && proxy != nil {
 			proxyURL = proxy.URL()
 		}
+	}
+
+	refreshToken := account.GetCredential("refresh_token")
+	if refreshToken == "" {
+		accessToken := account.GetCredential("access_token")
+		if accessToken != "" {
+			tokenInfo := &OpenAITokenInfo{
+				AccessToken:           accessToken,
+				RefreshToken:          "",
+				IDToken:               account.GetCredential("id_token"),
+				ClientID:              account.GetCredential("client_id"),
+				Email:                 account.GetCredential("email"),
+				ChatGPTAccountID:      account.GetCredential("chatgpt_account_id"),
+				ChatGPTUserID:         account.GetCredential("chatgpt_user_id"),
+				OrganizationID:        account.GetCredential("organization_id"),
+				PlanType:              account.GetCredential("plan_type"),
+				SubscriptionExpiresAt: account.GetCredential("subscription_expires_at"),
+			}
+			if expiresAt := account.GetCredentialAsTime("expires_at"); expiresAt != nil {
+				tokenInfo.ExpiresAt = expiresAt.Unix()
+				tokenInfo.ExpiresIn = int64(time.Until(*expiresAt).Seconds())
+			}
+			s.enrichTokenInfo(ctx, tokenInfo, proxyURL)
+			return tokenInfo, nil
+		}
+		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_OAUTH_NO_REFRESH_TOKEN", "no refresh token available")
 	}
 
 	clientID := account.GetCredential("client_id")

--- a/backend/internal/service/openai_oauth_service_refresh_test.go
+++ b/backend/internal/service/openai_oauth_service_refresh_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
+	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,6 +33,11 @@ func (s *openaiOAuthClientRefreshStub) RefreshTokenWithClientID(ctx context.Cont
 func TestOpenAIOAuthService_RefreshAccountToken_NoRefreshTokenUsesExistingAccessToken(t *testing.T) {
 	client := &openaiOAuthClientRefreshStub{}
 	svc := NewOpenAIOAuthService(nil, client)
+	var privacyClientCalls int32
+	svc.SetPrivacyClientFactory(func(proxyURL string) (*req.Client, error) {
+		atomic.AddInt32(&privacyClientCalls, 1)
+		return nil, errors.New("stop before request")
+	})
 
 	expiresAt := time.Now().Add(30 * time.Minute).UTC().Format(time.RFC3339)
 	account := &Account{
@@ -51,6 +57,7 @@ func TestOpenAIOAuthService_RefreshAccountToken_NoRefreshTokenUsesExistingAccess
 	require.Equal(t, "existing-access-token", info.AccessToken)
 	require.Equal(t, "client-id-1", info.ClientID)
 	require.Zero(t, atomic.LoadInt32(&client.refreshCalls), "existing access token should be reused without calling refresh")
+	require.Positive(t, atomic.LoadInt32(&privacyClientCalls), "existing access token should still run enrichment")
 }
 
 func TestOpenAITokenRefresher_NeedsRefresh_SkipsAccountWithoutRefreshToken(t *testing.T) {

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -95,6 +95,8 @@ type ChatGPTAccountInfo struct {
 
 const chatGPTAccountsCheckURL = "https://chatgpt.com/backend-api/accounts/check/v4-2023-04-27"
 
+var chatGPTSubscriptionsURL = "https://chatgpt.com/backend-api/subscriptions"
+
 // fetchChatGPTAccountInfo calls ChatGPT backend-api to get account info (plan_type, etc.).
 // Used as fallback when id_token doesn't contain these fields (e.g., Mobile RT).
 // orgID is used to match the correct account when multiple accounts exist (e.g., personal + team).
@@ -197,6 +199,62 @@ func fetchChatGPTAccountInfo(ctx context.Context, clientFactory PrivacyClientFac
 
 	slog.Info("chatgpt_account_check_success", "plan_type", info.PlanType, "subscription_expires_at", info.SubscriptionExpiresAt, "org_id", orgID)
 	return info
+}
+
+// fetchChatGPTSubscriptionExpiresAt reads the lightweight subscription endpoint used by
+// ChatGPT/Codex clients. Some Plus accounts no longer expose entitlement.expires_at in
+// accounts/check, but this endpoint still returns active_until.
+func fetchChatGPTSubscriptionExpiresAt(ctx context.Context, clientFactory PrivacyClientFactory, accessToken, proxyURL, accountID string) string {
+	accountID = strings.TrimSpace(accountID)
+	if accessToken == "" || accountID == "" || clientFactory == nil {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	client, err := clientFactory(proxyURL)
+	if err != nil {
+		slog.Debug("chatgpt_subscription_client_error", "error", err.Error())
+		return ""
+	}
+
+	var result struct {
+		PlanType    string `json:"plan_type"`
+		ActiveUntil string `json:"active_until"`
+		WillRenew   bool   `json:"will_renew"`
+		ID          string `json:"id"`
+	}
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeader("Authorization", "Bearer "+accessToken).
+		SetHeader("Origin", "https://chatgpt.com").
+		SetHeader("Referer", "https://chatgpt.com/").
+		SetHeader("Accept", "application/json").
+		SetSuccessResult(&result).
+		SetQueryParam("account_id", accountID).
+		Get(chatGPTSubscriptionsURL)
+	if err != nil {
+		slog.Debug("chatgpt_subscription_request_error", "error", err.Error())
+		return ""
+	}
+	if !resp.IsSuccessState() {
+		slog.Debug("chatgpt_subscription_failed", "status", resp.StatusCode, "body", truncate(resp.String(), 200))
+		return ""
+	}
+
+	activeUntil := strings.TrimSpace(result.ActiveUntil)
+	if activeUntil == "" {
+		slog.Debug("chatgpt_subscription_no_active_until", "plan_type", result.PlanType, "has_subscription_id", strings.TrimSpace(result.ID) != "", "will_renew", result.WillRenew)
+		return ""
+	}
+	if _, err := time.Parse(time.RFC3339, activeUntil); err != nil {
+		slog.Debug("chatgpt_subscription_bad_active_until", "active_until", activeUntil, "error", err.Error())
+		return ""
+	}
+
+	slog.Info("chatgpt_subscription_success", "plan_type", result.PlanType, "subscription_expires_at", activeUntil, "account_id", accountID)
+	return activeUntil
 }
 
 // fillAccountInfo 从单个 account 对象中提取 plan_type 和 subscription_expires_at

--- a/backend/internal/service/openai_subscription_test.go
+++ b/backend/internal/service/openai_subscription_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/imroc/req/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchChatGPTSubscriptionExpiresAt(t *testing.T) {
+	const wantExpiresAt = "2026-06-10T02:52:15Z"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/subscriptions", r.URL.Path)
+		require.Equal(t, "acc_123", r.URL.Query().Get("account_id"))
+		require.Equal(t, "Bearer access-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"plan_type":    "plus",
+			"active_until": wantExpiresAt,
+			"will_renew":   true,
+			"id":           "sub_123",
+		})
+	}))
+	defer server.Close()
+
+	oldURL := chatGPTSubscriptionsURL
+	chatGPTSubscriptionsURL = server.URL + "/backend-api/subscriptions"
+	t.Cleanup(func() { chatGPTSubscriptionsURL = oldURL })
+
+	got := fetchChatGPTSubscriptionExpiresAt(context.Background(), func(proxyURL string) (*req.Client, error) {
+		return req.C().SetTimeout(5 * time.Second), nil
+	}, "access-token", "", "acc_123")
+
+	require.Equal(t, wantExpiresAt, got)
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -45,6 +45,17 @@ func ProvideOAuthRefreshAPI(accountRepo AccountRepository, tokenCache GeminiToke
 	return NewOAuthRefreshAPI(accountRepo, tokenCache)
 }
 
+// ProvideOpenAIOAuthService creates OpenAIOAuthService with privacy/account enrichment support.
+func ProvideOpenAIOAuthService(
+	proxyRepo ProxyRepository,
+	oauthClient OpenAIOAuthClient,
+	privacyClientFactory PrivacyClientFactory,
+) *OpenAIOAuthService {
+	svc := NewOpenAIOAuthService(proxyRepo, oauthClient)
+	svc.SetPrivacyClientFactory(privacyClientFactory)
+	return svc
+}
+
 // ProvideTokenRefreshService creates and starts TokenRefreshService
 func ProvideTokenRefreshService(
 	accountRepo AccountRepository,
@@ -461,7 +472,7 @@ var ProviderSet = wire.NewSet(
 	NewOpenAIGatewayService,
 	wire.Bind(new(AccountRuntimeBlocker), new(*OpenAIGatewayService)),
 	NewOAuthService,
-	NewOpenAIOAuthService,
+	ProvideOpenAIOAuthService,
 	NewGeminiOAuthService,
 	NewGeminiQuotaService,
 	NewCompositeTokenCacheInvalidator,


### PR DESCRIPTION
## 修复内容

本 PR 修复 OpenAI OAuth 账号刷新时账号信息补全没有生效的问题：

- 为 `OpenAIOAuthService` 的正式启动注入 `PrivacyClientFactory`，确保 `enrichTokenInfo` 能实际调用 ChatGPT backend-api。
- 修复无 `refresh_token`、仅复用现有 `access_token` 的刷新路径，使手动“刷新令牌”时也会执行账号信息补全。
- 当 `accounts/check` 没有返回 `subscription_expires_at` 时，补充调用 `backend-api/subscriptions?account_id=...`，从 `active_until` 回填 Plus 到期时间。
- 增加相关单测，覆盖订阅到期时间提取和 access-token-only 刷新仍触发 enrichment 的路径。

## 问题背景

当前代码里已有 OpenAI plan / privacy / subscription enrichment 相关逻辑，但 `OpenAIOAuthService` 在 Wire 启动链路中是直接通过 `NewOpenAIOAuthService` 创建的，没有注入 `PrivacyClientFactory`。因此 `enrichTokenInfo` 会因为 `privacyClientFactory == nil` 直接返回。

另外，当账号没有 `refresh_token` 但已有 `access_token` 时，`RefreshAccountToken` 会直接复用现有 token 返回，也没有执行补全逻辑。这样会导致管理员手动点击刷新后，Plus 到期时间、训练数据共享状态等字段仍然不更新。

## 测试

已执行：

```bash
go test ./internal/service -run "TestFetchChatGPTSubscriptionExpiresAt|TestOpenAIOAuthService_RefreshAccountToken_NoRefreshTokenUsesExistingAccessToken|TestOpenAITokenRefresher_NeedsRefresh_SkipsAccountWithoutRefreshToken|TestOpenAITokenProvider_NoRefreshTokenExpiredAccessTokenReturnsError" -count=1
```

结果通过。

本地也通过真实刷新接口验证：对一个 `subscription_expires_at` 为空的 OpenAI OAuth Plus 账号调用 `/api/v1/admin/accounts/:id/refresh` 后，数据库成功写入 `subscription_expires_at`，并更新 `privacy_mode=training_off`。
