### PR TITLE
fix(gateway): claude_code_only 不再误拦截官方 Claude Code 的 count_tokens 与非流式 messages 请求

### DIFF
--- a/backend/internal/service/claude_code_validator.go
+++ b/backend/internal/service/claude_code_validator.go
@@ -56,7 +56,7 @@ func NewClaudeCodeValidator() *ClaudeCodeValidator {
 // 采用与 claude-relay-service 完全一致的验证策略：
 //
 //	Step 1: User-Agent 检查 (必需) - 必须是 claude-cli/x.x.x
-//	Step 2: 对于非 messages 路径，只要 UA 匹配就通过
+//	Step 2: 对于非 messages 路径和 /messages/count_tokens，只要 UA 匹配就通过
 //	Step 3: 检查 max_tokens=1 + haiku 探测请求绕过（UA 已验证）
 //	Step 4: 对于 messages 路径，进行严格验证：
 //	        - System prompt 相似度检查
@@ -71,9 +71,14 @@ func (v *ClaudeCodeValidator) Validate(r *http.Request, body map[string]any) boo
 		return false
 	}
 
-	// Step 2: 非 messages 路径，只要 UA 匹配就通过
+	// Step 2: 非 messages 路径只要 UA 匹配就通过
 	path := r.URL.Path
 	if !strings.Contains(path, "messages") {
+		return true
+	}
+
+	// count_tokens 是 Claude Code 官方辅助请求，通常不携带完整 messages system prompt。
+	if isMessagesCountTokensPath(path) {
 		return true
 	}
 
@@ -126,6 +131,10 @@ func (v *ClaudeCodeValidator) Validate(r *http.Request, body map[string]any) boo
 	}
 
 	return true
+}
+
+func isMessagesCountTokensPath(path string) bool {
+	return strings.HasSuffix(path, "/messages/count_tokens")
 }
 
 // hasClaudeCodeSystemPrompt 检查请求是否包含 Claude Code 系统提示词

--- a/backend/internal/service/claude_code_validator_test.go
+++ b/backend/internal/service/claude_code_validator_test.go
@@ -48,6 +48,97 @@ func TestClaudeCodeValidator_MessagesWithoutProbeStillNeedStrictValidation(t *te
 	require.False(t, ok)
 }
 
+func TestClaudeCodeValidator_CountTokensPathUAOnly(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages/count_tokens", nil)
+	req.Header.Set("User-Agent", "claude-cli/2.1.156 (Claude Code)")
+
+	ok := validator.Validate(req, map[string]any{
+		"model": "claude-opus-4-8",
+	})
+	require.True(t, ok)
+}
+
+func TestClaudeCodeValidator_CountTokensPathRequiresUA(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages/count_tokens", nil)
+	req.Header.Set("User-Agent", "curl/8.0.0")
+
+	ok := validator.Validate(req, map[string]any{
+		"model": "claude-opus-4-8",
+	})
+	require.False(t, ok)
+}
+
+func TestClaudeCodeValidator_MessagesPathFullValid(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+	req.Header.Set("User-Agent", "claude-cli/2.1.156 (Claude Code)")
+	req.Header.Set("X-App", "claude-code")
+	req.Header.Set("anthropic-beta", "claude-code-20250219")
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	ok := validator.Validate(req, map[string]any{
+		"model":  "claude-opus-4-8",
+		"stream": true,
+		"system": []any{
+			map[string]any{
+				"type": "text",
+				"text": "You are Claude Code, Anthropic's official CLI for Claude.",
+			},
+		},
+		"metadata": map[string]any{
+			"user_id": "user_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_account__session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+	})
+	require.True(t, ok)
+}
+
+func TestClaudeCodeValidator_MessagesPathRejectsNonClaudeCodeUA(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+	req.Header.Set("User-Agent", "curl/8.0.0")
+	req.Header.Set("X-App", "claude-code")
+	req.Header.Set("anthropic-beta", "claude-code-20250219")
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	ok := validator.Validate(req, map[string]any{
+		"model":  "claude-opus-4-8",
+		"stream": true,
+		"system": []any{
+			map[string]any{
+				"type": "text",
+				"text": "You are Claude Code, Anthropic's official CLI for Claude.",
+			},
+		},
+		"metadata": map[string]any{
+			"user_id": "user_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_account__session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+	})
+	require.False(t, ok)
+}
+
+func TestClaudeCodeValidator_MessagesPathWithoutSystemPromptStillRejected(t *testing.T) {
+	validator := NewClaudeCodeValidator()
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/messages", nil)
+	req.Header.Set("User-Agent", "claude-cli/2.1.156 (Claude Code)")
+	req.Header.Set("X-App", "claude-code")
+	req.Header.Set("anthropic-beta", "claude-code-20250219")
+	req.Header.Set("anthropic-version", "2023-06-01")
+
+	ok := validator.Validate(req, map[string]any{
+		"model":  "claude-opus-4-8",
+		"stream": true,
+		"messages": []any{
+			map[string]any{"role": "user", "content": "hello"},
+		},
+		"metadata": map[string]any{
+			"user_id": "user_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_account__session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+		},
+	})
+	require.False(t, ok)
+}
+
 func TestClaudeCodeValidator_NonMessagesPathUAOnly(t *testing.T) {
 	validator := NewClaudeCodeValidator()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/v1/models", nil)


### PR DESCRIPTION
## 背景

开启 `claude_code_only` 后，`/v1/messages/count_tokens` 因路径包含 `messages` 会进入 Claude Code messages 严格校验。官方 Claude Code CLI 的 count_tokens 辅助请求通常不携带完整 system prompt 或 `metadata.user_id`，导致账号选择阶段误判为非 Claude Code 客户端。

issue 中还提到部分 `stream=false /v1/messages` 请求，但当前没有提供可稳定区分的真实请求样本。为避免第三方客户端仅伪造 UA 就绕过普通 messages 主路径校验，本 PR 不额外放宽普通 `/v1/messages`。

## 改动

- 对 `/messages/count_tokens` 路径新增 Claude Code UA-only 放行，和非 messages 路径保持一致。
- 保留普通 `/v1/messages` 的 system prompt、`X-App`、`anthropic-beta`、`anthropic-version`、`metadata.user_id` 严格校验。
- 保留现有 `max_tokens=1` + Haiku 探测请求 bypass 行为不变。
- 补充 ClaudeCodeValidator 回归测试，覆盖 count_tokens 放行、UA 安全边界和普通 messages 未被放宽。

## 测试

- `go test -tags=unit ./...`
- `golangci-lint run ./...`

Fixes #2909
