### PR TITLE
fix: avoid OpenAI WS usage dedup conflicts

### DIFF
--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -721,6 +721,37 @@ func TestOpenAIGatewayServiceRecordUsage_PrefersClientRequestIDOverUpstreamReque
 	require.Equal(t, "client:openai-client-stable-123", usageRepo.lastLog.RequestID)
 }
 
+func TestOpenAIGatewayServiceRecordUsage_WSModePrefersUpstreamRequestIDOverClientRequestID(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{}
+	billingRepo := &openAIRecordUsageBillingRepoStub{result: &UsageBillingApplyResult{Applied: true}}
+	userRepo := &openAIRecordUsageUserRepoStub{}
+	subRepo := &openAIRecordUsageSubRepoStub{}
+	svc := newOpenAIRecordUsageServiceWithBillingRepoForTest(usageRepo, billingRepo, userRepo, subRepo, nil)
+
+	ctx := context.WithValue(context.Background(), ctxkey.ClientRequestID, "openai-ws-connection-123")
+	err := svc.RecordUsage(ctx, &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:    "resp_openai_ws_turn_456",
+			OpenAIWSMode: true,
+			Usage: OpenAIUsage{
+				InputTokens:  8,
+				OutputTokens: 4,
+			},
+			Model:    "gpt-5.1",
+			Duration: time.Second,
+		},
+		APIKey:  &APIKey{ID: 10050},
+		User:    &User{ID: 20050},
+		Account: &Account{ID: 30050},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, billingRepo.lastCmd)
+	require.Equal(t, "resp_openai_ws_turn_456", billingRepo.lastCmd.RequestID)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, "resp_openai_ws_turn_456", usageRepo.lastLog.RequestID)
+}
+
 func TestOpenAIGatewayServiceRecordUsage_GeneratesRequestIDWhenAllSourcesMissing(t *testing.T) {
 	usageRepo := &openAIRecordUsageLogRepoStub{}
 	billingRepo := &openAIRecordUsageBillingRepoStub{result: &UsageBillingApplyResult{Applied: true}}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -5761,6 +5761,11 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	durationMs := int(result.Duration.Milliseconds())
 	accountRateMultiplier := account.BillingRateMultiplier()
 	requestID := resolveUsageBillingRequestID(ctx, result.RequestID)
+	if result.OpenAIWSMode {
+		if upstreamRequestID := strings.TrimSpace(result.RequestID); upstreamRequestID != "" {
+			requestID = upstreamRequestID
+		}
+	}
 
 	// 确定 RequestedModel（渠道映射前的原始模型）
 	requestedModel := result.Model


### PR DESCRIPTION
## Summary

- use each OpenAI WebSocket turn's upstream `resp_*` id as the usage billing id when `OpenAIWSMode` is true
- keep the existing `client_request_id` preference for normal OpenAI usage records
- add a regression test for WS usage records with a connection-level client request id

## Root cause

`v0.1.133` started preserving request context for async usage recording. That is correct for normal HTTP requests, but OpenAI Responses WebSocket sessions can contain multiple billable turns under one connection-level `client_request_id`.

When every turn reuses `client:<client_request_id>` as the usage billing key, the first turn records successfully and later turns hit `usage billing request fingerprint conflict` because their token/cost fingerprint differs. Using the per-turn upstream response id keeps WebSocket usage idempotent per billable turn.

## Testing

- `go test ./internal/service -run 'TestOpenAIGatewayServiceRecordUsage_(WSModePrefersUpstreamRequestIDOverClientRequestID|PrefersClientRequestIDOverUpstreamRequestID|UsesFallbackRequestIDForBillingAndUsageLog|BillingFingerprintIncludesRequestPayloadHash)' -count=1`
- `go test ./internal/handler -run 'TestOpenAIGatewayHandlerSubmit|TestOpenAIResponsesWebSocket_PassthroughUsageLog|TestOpenAIResponsesWebSocket_FailoverOnUpstreamUsageLimitEvent' -count=1`
- `go test ./internal/service -count=1`
