### PR TITLE
refactor(gateway): 降低大请求体内存保留

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -747,10 +747,10 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 应用渠道模型映射到请求
 			if channelMapping.Mapped {
 				parsedReq.Model = channelMapping.MappedModel
-				parsedReq.Body.Replace(h.gatewayService.ReplaceModelInBody(parsedReq.Body.Bytes(), channelMapping.MappedModel))
+				parsedReq.ReplaceBody(h.gatewayService.ReplaceModelInBody(parsedReq.Body.Bytes(), channelMapping.MappedModel))
 			}
 			// Bedrock CC 兼容：渠道模型映射后，清理 Anthropic API 专有字段、注入 Bedrock 必需字段
-			parsedReq.Body.Replace(h.gatewayService.ApplyBedrockCCCompat(c.Request.Context(), parsedReq.Body.Bytes(), parsedReq.Model, account, apiKey.GroupID))
+			parsedReq.ReplaceBody(h.gatewayService.ApplyBedrockCCCompat(c.Request.Context(), parsedReq.Body.Bytes(), parsedReq.Model, account, apiKey.GroupID))
 			body = parsedReq.Body.Bytes()
 
 			// 转发请求 - 根据账号平台分流

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -510,11 +510,12 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 
 			// 使用量记录通过有界 worker 池提交，避免请求热路径创建无界 goroutine。
+			// ForceCacheBilling 提前拍成标量，避免 worker 闭包保活 failover 状态里的响应体。
+			forceCacheBilling := fs.ForceCacheBilling
 			quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 			h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 				if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 					Result:             result,
-					ParsedRequest:      parsedReq,
 					QuotaPlatform:      quotaPlatform,
 					APIKey:             apiKey,
 					User:               apiKey.User,
@@ -525,7 +526,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					UserAgent:          userAgent,
 					IPAddress:          clientIP,
 					RequestPayloadHash: requestPayloadHash,
-					ForceCacheBilling:  fs.ForceCacheBilling,
+					ForceCacheBilling:  forceCacheBilling,
 					APIKeyService:      h.apiKeyService,
 					ChannelUsageFields: channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
 				}); err != nil {
@@ -918,11 +919,12 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			}
 
 			// 使用量记录通过有界 worker 池提交，避免请求热路径创建无界 goroutine。
+			// ForceCacheBilling 提前拍成标量，避免 worker 闭包保活 failover 状态里的响应体。
+			forceCacheBilling := fs.ForceCacheBilling
 			quotaPlatform := service.QuotaPlatform(c.Request.Context(), currentAPIKey)
 			h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 				if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 					Result:             result,
-					ParsedRequest:      attemptParsedReq,
 					QuotaPlatform:      quotaPlatform,
 					APIKey:             currentAPIKey,
 					User:               currentAPIKey.User,
@@ -933,7 +935,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					UserAgent:          userAgent,
 					IPAddress:          clientIP,
 					RequestPayloadHash: requestPayloadHash,
-					ForceCacheBilling:  fs.ForceCacheBilling,
+					ForceCacheBilling:  forceCacheBilling,
 					APIKeyService:      h.apiKeyService,
 					ChannelUsageFields: channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
 				}); err != nil {

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -563,6 +563,12 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 		retryWithFallback := false
 
 		for {
+			attemptParsedReq, err := parsedReq.CloneForBody(body)
+			if err != nil {
+				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+				return
+			}
+
 			// 选择支持该模型的账号
 			reqLog.Info("sticky.selecting_account",
 				zap.String("session_key", sessionKey),
@@ -694,7 +700,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 			// ===== 用户消息串行队列 START =====
 			var queueRelease func()
-			umqMode := h.getUserMsgQueueMode(account, parsedReq)
+			umqMode := h.getUserMsgQueueMode(account, attemptParsedReq)
 
 			switch umqMode {
 			case config.UMQModeSerialize:
@@ -741,20 +747,26 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 用 wrapReleaseOnDone 确保 context 取消时自动释放（仅 serialize 模式有 queueRelease）
 			queueRelease = wrapReleaseOnDone(c.Request.Context(), queueRelease)
 			// 注入回调到 ParsedRequest：使用外层 wrapper 以便提前清理 AfterFunc
-			parsedReq.OnUpstreamAccepted = queueRelease
+			attemptParsedReq.OnUpstreamAccepted = queueRelease
 			// ===== 用户消息串行队列 END =====
 
-			// 应用渠道模型映射到请求
+			// 渠道模型映射只作用于本次账号尝试，避免 failover 后污染原始 ParsedRequest。
 			if channelMapping.Mapped {
-				parsedReq.Model = channelMapping.MappedModel
-				parsedReq.ReplaceBody(h.gatewayService.ReplaceModelInBody(parsedReq.Body.Bytes(), channelMapping.MappedModel))
+				attemptParsedReq.Model = channelMapping.MappedModel
+				if err := attemptParsedReq.ReplaceBody(h.gatewayService.ReplaceModelInBody(attemptParsedReq.Body.Bytes(), channelMapping.MappedModel)); err != nil {
+					h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+					return
+				}
 			}
 			// Bedrock CC 兼容：渠道模型映射后，清理 Anthropic API 专有字段、注入 Bedrock 必需字段
-			parsedReq.ReplaceBody(h.gatewayService.ApplyBedrockCCCompat(c.Request.Context(), parsedReq.Body.Bytes(), parsedReq.Model, account, apiKey.GroupID))
-			body = parsedReq.Body.Bytes()
+			if err := attemptParsedReq.ReplaceBody(h.gatewayService.ApplyBedrockCCCompat(c.Request.Context(), attemptParsedReq.Body.Bytes(), attemptParsedReq.Model, account, apiKey.GroupID)); err != nil {
+				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+				return
+			}
+			attemptBody := attemptParsedReq.Body.Bytes()
 
 			// 转发请求 - 根据账号平台分流
-			c.Set("parsed_request", parsedReq)
+			c.Set("parsed_request", attemptParsedReq)
 			var result *service.ForwardResult
 			requestCtx := c.Request.Context()
 			if fs.SwitchCount > 0 {
@@ -763,9 +775,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 记录 Forward 前已写入字节数，Forward 后若增加则说明 SSE 内容已发，禁止 failover
 			writerSizeBeforeForward := c.Writer.Size()
 			if account.Platform == service.PlatformAntigravity && account.Type != service.AccountTypeAPIKey {
-				result, err = h.antigravityGatewayService.Forward(requestCtx, c, account, body, hasBoundSession)
+				result, err = h.antigravityGatewayService.Forward(requestCtx, c, account, attemptBody, hasBoundSession)
 			} else {
-				result, err = h.gatewayService.Forward(requestCtx, c, account, parsedReq)
+				result, err = h.gatewayService.Forward(requestCtx, c, account, attemptParsedReq)
 			}
 
 			// 兜底释放串行锁（正常情况已通过回调提前释放）
@@ -773,7 +785,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				queueRelease()
 			}
 			// 清理回调引用，防止 failover 重试时旧回调被错误调用
-			parsedReq.OnUpstreamAccepted = nil
+			attemptParsedReq.OnUpstreamAccepted = nil
 
 			if accountReleaseFunc != nil {
 				accountReleaseFunc()
@@ -896,12 +908,13 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）
 			userAgent := c.GetHeader("User-Agent")
 			clientIP := ip.GetClientIP(c)
-			requestPayloadHash := service.HashUsageRequestPayload(body)
+			// Forward 内部可能继续改写 body，usage 去重指纹必须使用最终上游接受的当前 body。
+			requestPayloadHash := service.HashUsageRequestPayload(attemptParsedReq.Body.Bytes())
 			inboundEndpoint := GetInboundEndpoint(c)
 			upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
 
 			if result.ReasoningEffort == nil {
-				result.ReasoningEffort = service.NormalizeClaudeOutputEffort(parsedReq.OutputEffort)
+				result.ReasoningEffort = service.NormalizeClaudeOutputEffort(attemptParsedReq.OutputEffort)
 			}
 
 			// 使用量记录通过有界 worker 池提交，避免请求热路径创建无界 goroutine。
@@ -909,7 +922,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 				if err := h.gatewayService.RecordUsage(ctx, &service.RecordUsageInput{
 					Result:             result,
-					ParsedRequest:      parsedReq,
+					ParsedRequest:      attemptParsedReq,
 					QuotaPlatform:      quotaPlatform,
 					APIKey:             currentAPIKey,
 					User:               currentAPIKey.User,

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -154,7 +154,8 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 	setOpsRequestContext(c, "", false)
 
-	parsedReq, err := service.ParseGatewayRequest(body, domain.PlatformAnthropic)
+	bodyRef := service.NewRequestBodyRef(body)
+	parsedReq, err := service.ParseGatewayRequest(bodyRef, domain.PlatformAnthropic)
 	if err != nil {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return
@@ -746,11 +747,11 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 			// 应用渠道模型映射到请求
 			if channelMapping.Mapped {
 				parsedReq.Model = channelMapping.MappedModel
-				parsedReq.Body = h.gatewayService.ReplaceModelInBody(parsedReq.Body, channelMapping.MappedModel)
+				parsedReq.Body.Replace(h.gatewayService.ReplaceModelInBody(parsedReq.Body.Bytes(), channelMapping.MappedModel))
 			}
 			// Bedrock CC 兼容：渠道模型映射后，清理 Anthropic API 专有字段、注入 Bedrock 必需字段
-			parsedReq.Body = h.gatewayService.ApplyBedrockCCCompat(c.Request.Context(), parsedReq.Body, parsedReq.Model, account, apiKey.GroupID)
-			body = parsedReq.Body
+			parsedReq.Body.Replace(h.gatewayService.ApplyBedrockCCCompat(c.Request.Context(), parsedReq.Body.Bytes(), parsedReq.Model, account, apiKey.GroupID))
+			body = parsedReq.Body.Bytes()
 
 			// 转发请求 - 根据账号平台分流
 			c.Set("parsed_request", parsedReq)
@@ -1683,7 +1684,8 @@ func (h *GatewayHandler) CountTokens(c *gin.Context) {
 
 	setOpsRequestContext(c, "", false)
 
-	parsedReq, err := service.ParseGatewayRequest(body, domain.PlatformAnthropic)
+	bodyRef := service.NewRequestBodyRef(body)
+	parsedReq, err := service.ParseGatewayRequest(bodyRef, domain.PlatformAnthropic)
 	if err != nil {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -151,9 +151,10 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 	}
 
 	// Parse request for session hash
-	parsedReq, _ := service.ParseGatewayRequest(body, "chat_completions")
+	bodyRef := service.NewRequestBodyRef(body)
+	parsedReq, _ := service.ParseGatewayRequest(bodyRef, "chat_completions")
 	if parsedReq == nil {
-		parsedReq = &service.ParsedRequest{Model: reqModel, Stream: reqStream, Body: body}
+		parsedReq = &service.ParsedRequest{Model: reqModel, Stream: reqStream, Body: bodyRef}
 	}
 	parsedReq.SessionContext = &service.SessionContext{
 		ClientIP:  ip.GetClientIP(c),

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -156,9 +156,10 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 	}
 
 	// Parse request for session hash
-	parsedReq, _ := service.ParseGatewayRequest(body, "responses")
+	bodyRef := service.NewRequestBodyRef(body)
+	parsedReq, _ := service.ParseGatewayRequest(bodyRef, "responses")
 	if parsedReq == nil {
-		parsedReq = &service.ParsedRequest{Model: reqModel, Stream: reqStream, Body: body}
+		parsedReq = &service.ParsedRequest{Model: reqModel, Stream: reqStream, Body: bodyRef}
 	}
 	parsedReq.SessionContext = &service.SessionContext{
 		ClientIP:  ip.GetClientIP(c),

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -74,8 +74,12 @@ func claudeCodeBodyMapFromParsedRequest(parsedReq *service.ParsedRequest) map[st
 	bodyMap := map[string]any{
 		"model": parsedReq.Model,
 	}
-	if parsedReq.System != nil || parsedReq.HasSystem {
-		bodyMap["system"] = parsedReq.System
+	if parsedReq.HasSystem {
+		if system, ok := parsedReq.SystemValue(); ok {
+			bodyMap["system"] = system
+		} else {
+			bodyMap["system"] = nil
+		}
 	}
 	if parsedReq.MetadataUserID != "" {
 		bodyMap["metadata"] = map[string]any{"user_id": parsedReq.MetadataUserID}
@@ -87,10 +91,8 @@ func claudeCodeBodyMapFromContextCache(c *gin.Context) map[string]any {
 	if c == nil {
 		return nil
 	}
-	if cached, ok := c.Get(service.OpenAIParsedRequestBodyKey); ok {
-		if bodyMap, ok := cached.(map[string]any); ok {
-			return bodyMap
-		}
+	if bodyMap := service.CachedOpenAIParsedRequestBody(c); bodyMap != nil {
+		return bodyMap
 	}
 	if cached, ok := c.Get(claudeCodeParsedRequestContextKey); ok {
 		switch v := cached.(type) {

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -18,18 +18,12 @@ import (
 // claudeCodeValidator is a singleton validator for Claude Code client detection
 var claudeCodeValidator = service.NewClaudeCodeValidator()
 
-const claudeCodeParsedRequestContextKey = "claude_code_parsed_request"
-
 // SetClaudeCodeClientContext 检查请求是否来自 Claude Code 客户端，并设置到 context 中
 // 返回更新后的 context
 func SetClaudeCodeClientContext(c *gin.Context, body []byte, parsedReq *service.ParsedRequest) {
 	if c == nil || c.Request == nil {
 		return
 	}
-	if parsedReq != nil {
-		c.Set(claudeCodeParsedRequestContextKey, parsedReq)
-	}
-
 	ua := c.GetHeader("User-Agent")
 	// Fast path：非 Claude CLI UA 直接判定 false，避免热路径二次 JSON 反序列化。
 	if !claudeCodeValidator.ValidateUserAgent(ua) {
@@ -45,9 +39,6 @@ func SetClaudeCodeClientContext(c *gin.Context, body []byte, parsedReq *service.
 	} else {
 		// 仅在确认为 Claude CLI 且 messages 路径时再做 body 解析。
 		bodyMap := claudeCodeBodyMapFromParsedRequest(parsedReq)
-		if bodyMap == nil {
-			bodyMap = claudeCodeBodyMapFromContextCache(c)
-		}
 		if bodyMap == nil && len(body) > 0 {
 			_ = json.Unmarshal(body, &bodyMap)
 		}
@@ -85,24 +76,6 @@ func claudeCodeBodyMapFromParsedRequest(parsedReq *service.ParsedRequest) map[st
 		bodyMap["metadata"] = map[string]any{"user_id": parsedReq.MetadataUserID}
 	}
 	return bodyMap
-}
-
-func claudeCodeBodyMapFromContextCache(c *gin.Context) map[string]any {
-	if c == nil {
-		return nil
-	}
-	if bodyMap := service.CachedOpenAIParsedRequestBody(c); bodyMap != nil {
-		return bodyMap
-	}
-	if cached, ok := c.Get(claudeCodeParsedRequestContextKey); ok {
-		switch v := cached.(type) {
-		case *service.ParsedRequest:
-			return claudeCodeBodyMapFromParsedRequest(v)
-		case service.ParsedRequest:
-			return claudeCodeBodyMapFromParsedRequest(&v)
-		}
-	}
-	return nil
 }
 
 // 并发槽位等待相关常量

--- a/backend/internal/handler/gateway_helper_hotpath_test.go
+++ b/backend/internal/handler/gateway_helper_hotpath_test.go
@@ -185,13 +185,8 @@ func TestSetClaudeCodeClientContext_ReuseParsedRequestAndContextCache(t *testing
 		c.Request.Header.Set("anthropic-beta", "message-batches-2024-09-24")
 		c.Request.Header.Set("anthropic-version", "2023-06-01")
 
-		parsedReq := &service.ParsedRequest{
-			Model: "claude-3-5-sonnet-20241022",
-			System: []any{
-				map[string]any{"text": "You are Claude Code, Anthropic's official CLI for Claude."},
-			},
-			MetadataUserID: "user_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_account__session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
-		}
+		parsedReq, err := service.ParseGatewayRequest(service.NewRequestBodyRef(validClaudeCodeBodyJSON()), "")
+		require.NoError(t, err)
 
 		// body 非法 JSON，如果函数复用 parsedReq 成功则仍应判定为 Claude Code。
 		SetClaudeCodeClientContext(c, []byte(`{invalid`), parsedReq)
@@ -204,7 +199,7 @@ func TestSetClaudeCodeClientContext_ReuseParsedRequestAndContextCache(t *testing
 		c.Request.Header.Set("X-App", "claude-code")
 		c.Request.Header.Set("anthropic-beta", "message-batches-2024-09-24")
 		c.Request.Header.Set("anthropic-version", "2023-06-01")
-		c.Set(service.OpenAIParsedRequestBodyKey, map[string]any{
+		service.CacheOpenAIParsedRequestBody(c, []byte(`{invalid`), map[string]any{
 			"model": "claude-3-5-sonnet-20241022",
 			"system": []any{
 				map[string]any{"text": "You are Claude Code, Anthropic's official CLI for Claude."},

--- a/backend/internal/handler/gateway_helper_hotpath_test.go
+++ b/backend/internal/handler/gateway_helper_hotpath_test.go
@@ -177,7 +177,7 @@ func TestSetClaudeCodeClientContext_FastPathAndStrictPath(t *testing.T) {
 	})
 }
 
-func TestSetClaudeCodeClientContext_ReuseParsedRequestAndContextCache(t *testing.T) {
+func TestSetClaudeCodeClientContext_ReuseParsedRequest(t *testing.T) {
 	t.Run("reuse parsed request without body unmarshal", func(t *testing.T) {
 		c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
 		c.Request.Header.Set("User-Agent", "claude-cli/1.0.1")
@@ -190,24 +190,6 @@ func TestSetClaudeCodeClientContext_ReuseParsedRequestAndContextCache(t *testing
 
 		// body 非法 JSON，如果函数复用 parsedReq 成功则仍应判定为 Claude Code。
 		SetClaudeCodeClientContext(c, []byte(`{invalid`), parsedReq)
-		require.True(t, service.IsClaudeCodeClient(c.Request.Context()))
-	})
-
-	t.Run("reuse context cache without body unmarshal", func(t *testing.T) {
-		c, _ := newHelperTestContext(http.MethodPost, "/v1/messages")
-		c.Request.Header.Set("User-Agent", "claude-cli/1.0.1")
-		c.Request.Header.Set("X-App", "claude-code")
-		c.Request.Header.Set("anthropic-beta", "message-batches-2024-09-24")
-		c.Request.Header.Set("anthropic-version", "2023-06-01")
-		service.CacheOpenAIParsedRequestBody(c, []byte(`{invalid`), map[string]any{
-			"model": "claude-3-5-sonnet-20241022",
-			"system": []any{
-				map[string]any{"text": "You are Claude Code, Anthropic's official CLI for Claude."},
-			},
-			"metadata": map[string]any{"user_id": "user_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_account__session_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"},
-		})
-
-		SetClaudeCodeClientContext(c, []byte(`{invalid`), nil)
 		require.True(t, service.IsClaudeCodeClient(c.Request.Context()))
 	})
 }

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -262,7 +262,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 	sessionHash := extractGeminiCLISessionHash(c, body)
 	if sessionHash == "" {
 		// Fallback: 使用通用的会话哈希生成逻辑（适用于其他客户端）
-		parsedReq, _ := service.ParseGatewayRequest(body, domain.PlatformGemini)
+		parsedReq, _ := service.ParseGatewayRequest(service.NewRequestBodyRef(body), domain.PlatformGemini)
 		if parsedReq != nil {
 			parsedReq.SessionContext = &service.SessionContext{
 				ClientIP:  ip.GetClientIP(c),

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -527,6 +527,8 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 		requestPayloadHash := service.HashUsageRequestPayload(body)
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+		// ForceCacheBilling 提前拍成标量，避免 worker 闭包保活 failover 状态里的响应体。
+		forceCacheBilling := fs.ForceCacheBilling
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsageWithLongContext(ctx, &service.RecordUsageLongContextInput{
@@ -543,7 +545,7 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 				RequestPayloadHash:    requestPayloadHash,
 				LongContextThreshold:  200000, // Gemini 200K 阈值
 				LongContextMultiplier: 2.0,    // 超出部分双倍计费
-				ForceCacheBilling:     fs.ForceCacheBilling,
+				ForceCacheBilling:     forceCacheBilling,
 				APIKeyService:         h.apiKeyService,
 				ChannelUsageFields:    channelMapping.ToUsageFields(reqModel, result.UpstreamModel),
 			}); err != nil {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -954,7 +954,7 @@ func (h *OpenAIGatewayHandler) validateFunctionCallOutputRequest(c *gin.Context,
 		return true
 	}
 
-	c.Set(service.OpenAIParsedRequestBodyKey, reqBody)
+	service.CacheOpenAIParsedRequestBody(c, body, reqBody)
 	validation := service.ValidateFunctionCallOutputContext(reqBody)
 	if !validation.HasFunctionCallOutput {
 		return true

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -948,19 +948,12 @@ func (h *OpenAIGatewayHandler) validateFunctionCallOutputRequest(c *gin.Context,
 		return true
 	}
 
-	var reqBody map[string]any
-	if err := json.Unmarshal(body, &reqBody); err != nil {
-		// 保持原有容错语义：解析失败时跳过预校验，沿用后续上游校验结果。
-		return true
-	}
-
-	service.CacheOpenAIParsedRequestBody(c, body, reqBody)
-	validation := service.ValidateFunctionCallOutputContext(reqBody)
+	validation := service.ValidateFunctionCallOutputContextBytes(body)
 	if !validation.HasFunctionCallOutput {
 		return true
 	}
 
-	previousResponseID, _ := reqBody["previous_response_id"].(string)
+	previousResponseID := gjson.GetBytes(body, "previous_response_id").String()
 	if strings.TrimSpace(previousResponseID) != "" || validation.HasToolCallContext {
 		return true
 	}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1379,6 +1379,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			zap.Int("candidate_count", scheduleDecision.CandidateCount),
 		)
 
+		var requestPayloadHash string
 		hooks := &service.OpenAIWSIngressHooks{
 			InitialRequestModel: reqModel,
 			BeforeRequest: func(turn int, payload []byte, originalModel string) error {
@@ -1464,7 +1465,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 						UpstreamEndpoint:   upstreamEndpoint,
 						UserAgent:          userAgent,
 						IPAddress:          clientIP,
-						RequestPayloadHash: service.HashUsageRequestPayload(firstMessage),
+						RequestPayloadHash: requestPayloadHash,
 						APIKeyService:      h.apiKeyService,
 						ChannelUsageFields: channelMappingWS.ToUsageFields(reqModel, result.UpstreamModel),
 					}); err != nil {
@@ -1483,6 +1484,9 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		if channelMappingWS.Mapped {
 			wsFirstMessage = h.gatewayService.ReplaceModelInBody(firstMessage, channelMappingWS.MappedModel)
 		}
+
+		// WebSocket 首包可能很大，hash 必须在 hooks 外算成字符串，避免 AfterTurn 闭包保活请求体。
+		requestPayloadHash = service.HashUsageRequestPayload(wsFirstMessage)
 
 		if err := h.gatewayService.ProxyResponsesWebSocketFromClient(ctx, c, wsConn, account, token, wsFirstMessage, hooks); err != nil {
 			var failoverErr *service.UpstreamFailoverError

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -73,9 +73,10 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", err.Error())
 		return
 	}
+	requestModel := parsed.Model
 
 	reqLog = reqLog.With(
-		zap.String("model", parsed.Model),
+		zap.String("model", requestModel),
 		zap.Bool("stream", parsed.Stream),
 		zap.Bool("multipart", parsed.Multipart),
 		zap.String("capability", string(parsed.RequiredCapability)),
@@ -85,7 +86,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
 		return
 	}
-	if decision := h.checkContentModeration(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIImages, parsed.Model, parsed.ModerationBody()); decision != nil && decision.Blocked {
+	if decision := h.checkContentModeration(c, reqLog, apiKey, subject, service.ContentModerationProtocolOpenAIImages, requestModel, parsed.ModerationBody()); decision != nil && decision.Blocked {
 		h.errorResponse(c, contentModerationStatus(decision), contentModerationErrorCode(decision), decision.Message)
 		return
 	}
@@ -98,13 +99,13 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 	}
 
 	if parsed.Multipart {
-		setOpsRequestContext(c, parsed.Model, parsed.Stream)
+		setOpsRequestContext(c, requestModel, parsed.Stream)
 	} else {
-		setOpsRequestContext(c, parsed.Model, parsed.Stream)
+		setOpsRequestContext(c, requestModel, parsed.Stream)
 	}
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(parsed.Stream, false)))
 
-	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, parsed.Model)
+	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, requestModel)
 
 	if h.errorPassthroughService != nil {
 		service.BindErrorPassthroughService(c, h.errorPassthroughService)
@@ -147,7 +148,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 			c.Request.Context(),
 			apiKey.GroupID,
 			sessionHash,
-			parsed.Model,
+			requestModel,
 			failedAccountIDs,
 			parsed.RequiredCapability,
 		)
@@ -324,14 +325,14 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,
 				APIKeyService:      h.apiKeyService,
-				ChannelUsageFields: channelMapping.ToUsageFields(parsed.Model, upstreamModel),
+				ChannelUsageFields: channelMapping.ToUsageFields(requestModel, upstreamModel),
 			}); err != nil {
 				logger.L().With(
 					zap.String("component", "handler.openai_gateway.images"),
 					zap.Int64("user_id", subject.UserID),
 					zap.Int64("api_key_id", apiKey.ID),
 					zap.Any("group_id", apiKey.GroupID),
-					zap.String("model", parsed.Model),
+					zap.String("model", requestModel),
 					zap.Int64("account_id", account.ID),
 				).Error("openai.images.record_usage_failed", zap.Error(err))
 			}

--- a/backend/internal/service/anthropic_session.go
+++ b/backend/internal/service/anthropic_session.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"time"
+
+	"github.com/tidwall/gjson"
 )
 
 // Anthropic 会话 Fallback 相关常量
@@ -30,28 +32,37 @@ func BuildAnthropicDigestChain(parsed *ParsedRequest) string {
 
 	var parts []string
 
-	// 1. system prompt
-	if parsed.System != nil {
-		systemData, _ := json.Marshal(parsed.System)
-		if len(systemData) > 0 && string(systemData) != "null" {
-			parts = append(parts, "s:"+shortHash(systemData))
-		}
+	if systemRaw := parsed.SystemRaw(); len(systemRaw) > 0 && string(systemRaw) != "null" {
+		parts = append(parts, "s:"+shortHash(canonicalAnthropicDigestJSON(systemRaw)))
 	}
 
-	// 2. messages
-	for _, msg := range parsed.Messages {
-		msgMap, ok := msg.(map[string]any)
-		if !ok {
-			continue
-		}
-		role, _ := msgMap["role"].(string)
-		prefix := rolePrefix(role)
-		content := msgMap["content"]
-		contentData, _ := json.Marshal(content)
-		parts = append(parts, prefix+":"+shortHash(contentData))
+	messages := parsed.MessagesRaw()
+	if len(messages) > 0 {
+		gjson.ParseBytes(messages).ForEach(func(_, msg gjson.Result) bool {
+			prefix := rolePrefix(msg.Get("role").String())
+			content := msg.Get("content")
+			parts = append(parts, prefix+":"+shortHash(canonicalAnthropicDigestJSON([]byte(content.Raw))))
+			return true
+		})
 	}
 
 	return strings.Join(parts, "-")
+}
+
+// canonicalAnthropicDigestJSON 保持 digest 对 JSON key 顺序和空白不敏感。
+func canonicalAnthropicDigestJSON(raw []byte) []byte {
+	if len(raw) == 0 {
+		return raw
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return raw
+	}
+	canonical, err := json.Marshal(value)
+	if err != nil {
+		return raw
+	}
+	return canonical
 }
 
 // rolePrefix 将 Anthropic 的 role 映射为单字符前缀

--- a/backend/internal/service/anthropic_session_test.go
+++ b/backend/internal/service/anthropic_session_test.go
@@ -1,9 +1,20 @@
+//go:build unit
+
 package service
 
 import (
 	"strings"
 	"testing"
 )
+
+func mustParseAnthropicDigestRequest(t *testing.T, body string) *ParsedRequest {
+	t.Helper()
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(body)), "")
+	if err != nil {
+		t.Fatalf("ParseGatewayRequest failed: %v", err)
+	}
+	return parsed
+}
 
 func TestBuildAnthropicDigestChain_NilRequest(t *testing.T) {
 	result := BuildAnthropicDigestChain(nil)
@@ -13,9 +24,7 @@ func TestBuildAnthropicDigestChain_NilRequest(t *testing.T) {
 }
 
 func TestBuildAnthropicDigestChain_EmptyMessages(t *testing.T) {
-	parsed := &ParsedRequest{
-		Messages: []any{},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"messages":[]}`)
 	result := BuildAnthropicDigestChain(parsed)
 	if result != "" {
 		t.Errorf("expected empty string for empty messages, got: %s", result)
@@ -23,11 +32,7 @@ func TestBuildAnthropicDigestChain_EmptyMessages(t *testing.T) {
 }
 
 func TestBuildAnthropicDigestChain_SingleUserMessage(t *testing.T) {
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"messages":[{"role":"user","content":"hello"}]}`)
 	result := BuildAnthropicDigestChain(parsed)
 	parts := splitChain(result)
 	if len(parts) != 1 {
@@ -39,12 +44,7 @@ func TestBuildAnthropicDigestChain_SingleUserMessage(t *testing.T) {
 }
 
 func TestBuildAnthropicDigestChain_UserAndAssistant(t *testing.T) {
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "hi there"},
-		},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi there"}]}`)
 	result := BuildAnthropicDigestChain(parsed)
 	parts := splitChain(result)
 	if len(parts) != 2 {
@@ -59,12 +59,7 @@ func TestBuildAnthropicDigestChain_UserAndAssistant(t *testing.T) {
 }
 
 func TestBuildAnthropicDigestChain_WithSystemString(t *testing.T) {
-	parsed := &ParsedRequest{
-		System: "You are a helpful assistant",
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"system":"You are a helpful assistant","messages":[{"role":"user","content":"hello"}]}`)
 	result := BuildAnthropicDigestChain(parsed)
 	parts := splitChain(result)
 	if len(parts) != 2 {
@@ -79,14 +74,7 @@ func TestBuildAnthropicDigestChain_WithSystemString(t *testing.T) {
 }
 
 func TestBuildAnthropicDigestChain_WithSystemContentBlocks(t *testing.T) {
-	parsed := &ParsedRequest{
-		System: []any{
-			map[string]any{"type": "text", "text": "You are a helpful assistant"},
-		},
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"system":[{"type":"text","text":"You are a helpful assistant"}],"messages":[{"role":"user","content":"hello"}]}`)
 	result := BuildAnthropicDigestChain(parsed)
 	parts := splitChain(result)
 	if len(parts) != 2 {
@@ -100,74 +88,33 @@ func TestBuildAnthropicDigestChain_WithSystemContentBlocks(t *testing.T) {
 func TestBuildAnthropicDigestChain_ConversationPrefixRelationship(t *testing.T) {
 	// 核心测试：验证对话增长时链的前缀关系
 	// 上一轮的完整链一定是下一轮链的前缀
-	system := "You are a helpful assistant"
-
-	// 第 1 轮: system + user
-	round1 := &ParsedRequest{
-		System: system,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	round1 := mustParseAnthropicDigestRequest(t, `{"system":"You are a helpful assistant","messages":[{"role":"user","content":"hello"}]}`)
 	chain1 := BuildAnthropicDigestChain(round1)
 
-	// 第 2 轮: system + user + assistant + user
-	round2 := &ParsedRequest{
-		System: system,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "hi there"},
-			map[string]any{"role": "user", "content": "how are you?"},
-		},
-	}
+	round2 := mustParseAnthropicDigestRequest(t, `{"system":"You are a helpful assistant","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi there"},{"role":"user","content":"how are you?"}]}`)
 	chain2 := BuildAnthropicDigestChain(round2)
 
-	// 第 3 轮: system + user + assistant + user + assistant + user
-	round3 := &ParsedRequest{
-		System: system,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "hi there"},
-			map[string]any{"role": "user", "content": "how are you?"},
-			map[string]any{"role": "assistant", "content": "I'm doing well"},
-			map[string]any{"role": "user", "content": "great"},
-		},
-	}
+	round3 := mustParseAnthropicDigestRequest(t, `{"system":"You are a helpful assistant","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi there"},{"role":"user","content":"how are you?"},{"role":"assistant","content":"I'm doing well"},{"role":"user","content":"great"}]}`)
 	chain3 := BuildAnthropicDigestChain(round3)
 
 	t.Logf("Chain1: %s", chain1)
 	t.Logf("Chain2: %s", chain2)
 	t.Logf("Chain3: %s", chain3)
 
-	// chain1 是 chain2 的前缀
 	if !strings.HasPrefix(chain2, chain1) {
 		t.Errorf("chain1 should be prefix of chain2:\n  chain1: %s\n  chain2: %s", chain1, chain2)
 	}
-
-	// chain2 是 chain3 的前缀
 	if !strings.HasPrefix(chain3, chain2) {
 		t.Errorf("chain2 should be prefix of chain3:\n  chain2: %s\n  chain3: %s", chain2, chain3)
 	}
-
-	// chain1 也是 chain3 的前缀（传递性）
 	if !strings.HasPrefix(chain3, chain1) {
 		t.Errorf("chain1 should be prefix of chain3:\n  chain1: %s\n  chain3: %s", chain1, chain3)
 	}
 }
 
 func TestBuildAnthropicDigestChain_DifferentSystemProducesDifferentChain(t *testing.T) {
-	parsed1 := &ParsedRequest{
-		System: "System A",
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
-	parsed2 := &ParsedRequest{
-		System: "System B",
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	parsed1 := mustParseAnthropicDigestRequest(t, `{"system":"System A","messages":[{"role":"user","content":"hello"}]}`)
+	parsed2 := mustParseAnthropicDigestRequest(t, `{"system":"System B","messages":[{"role":"user","content":"hello"}]}`)
 
 	chain1 := BuildAnthropicDigestChain(parsed1)
 	chain2 := BuildAnthropicDigestChain(parsed2)
@@ -176,7 +123,6 @@ func TestBuildAnthropicDigestChain_DifferentSystemProducesDifferentChain(t *test
 		t.Error("Different system prompts should produce different chains")
 	}
 
-	// 但 user 部分的 hash 应该相同
 	parts1 := splitChain(chain1)
 	parts2 := splitChain(chain2)
 	if parts1[1] != parts2[1] {
@@ -185,20 +131,8 @@ func TestBuildAnthropicDigestChain_DifferentSystemProducesDifferentChain(t *test
 }
 
 func TestBuildAnthropicDigestChain_DifferentContentProducesDifferentChain(t *testing.T) {
-	parsed1 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "ORIGINAL reply"},
-			map[string]any{"role": "user", "content": "next"},
-		},
-	}
-	parsed2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "TAMPERED reply"},
-			map[string]any{"role": "user", "content": "next"},
-		},
-	}
+	parsed1 := mustParseAnthropicDigestRequest(t, `{"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"ORIGINAL reply"},{"role":"user","content":"next"}]}`)
+	parsed2 := mustParseAnthropicDigestRequest(t, `{"messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"TAMPERED reply"},{"role":"user","content":"next"}]}`)
 
 	chain1 := BuildAnthropicDigestChain(parsed1)
 	chain2 := BuildAnthropicDigestChain(parsed2)
@@ -209,30 +143,34 @@ func TestBuildAnthropicDigestChain_DifferentContentProducesDifferentChain(t *tes
 
 	parts1 := splitChain(chain1)
 	parts2 := splitChain(chain2)
-	// 第一个 user message hash 应该相同
 	if parts1[0] != parts2[0] {
 		t.Error("First user message hash should be the same")
 	}
-	// assistant reply hash 应该不同
 	if parts1[1] == parts2[1] {
 		t.Error("Assistant reply hash should differ")
 	}
 }
 
 func TestBuildAnthropicDigestChain_Deterministic(t *testing.T) {
-	parsed := &ParsedRequest{
-		System: "test system",
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "hi"},
-		},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"system":"test system","messages":[{"role":"user","content":"hello"},{"role":"assistant","content":"hi"}]}`)
 
 	chain1 := BuildAnthropicDigestChain(parsed)
 	chain2 := BuildAnthropicDigestChain(parsed)
 
 	if chain1 != chain2 {
 		t.Errorf("BuildAnthropicDigestChain not deterministic: %s vs %s", chain1, chain2)
+	}
+}
+
+func TestBuildAnthropicDigestChain_CanonicalJSON(t *testing.T) {
+	parsed1 := mustParseAnthropicDigestRequest(t, `{"system":[{"type":"text","text":"system"}],"messages":[{"role":"user","content":{"type":"text","text":"hello"}}]}`)
+	parsed2 := mustParseAnthropicDigestRequest(t, `{"system":[{"text":"system","type":"text"}],"messages":[{"role":"user","content":{"text":"hello","type":"text"}}]}`)
+
+	chain1 := BuildAnthropicDigestChain(parsed1)
+	chain2 := BuildAnthropicDigestChain(parsed2)
+
+	if chain1 != chain2 {
+		t.Errorf("semantically equivalent JSON should produce same chain: %s vs %s", chain1, chain2)
 	}
 }
 
@@ -278,7 +216,6 @@ func TestGenerateAnthropicDigestSessionKey(t *testing.T) {
 		})
 	}
 
-	// 验证不同 uuid 产生不同 sessionKey
 	t.Run("different uuid different key", func(t *testing.T) {
 		hash := "sameprefix123456"
 		result1 := GenerateAnthropicDigestSessionKey(hash, "uuid0001-session-a")
@@ -297,18 +234,7 @@ func TestAnthropicSessionTTL(t *testing.T) {
 }
 
 func TestBuildAnthropicDigestChain_ContentBlocks(t *testing.T) {
-	// 测试 content 为 content blocks 数组的情况
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"content": []any{
-					map[string]any{"type": "text", "text": "describe this image"},
-					map[string]any{"type": "image", "source": map[string]any{"type": "base64"}},
-				},
-			},
-		},
-	}
+	parsed := mustParseAnthropicDigestRequest(t, `{"messages":[{"role":"user","content":[{"type":"text","text":"describe this image"},{"type":"image","source":{"type":"base64"}}]}]}`)
 	result := BuildAnthropicDigestChain(parsed)
 	parts := splitChain(result)
 	if len(parts) != 1 {

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -662,7 +662,7 @@ urlFallbackLoop:
 
 			// 统一处理错误响应
 			if resp.StatusCode >= 400 {
-				respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+				respBody := s.readUpstreamErrorBody(resp)
 				_ = resp.Body.Close()
 
 				if overagesInjected && shouldMarkCreditsExhausted(resp, respBody, nil) {
@@ -873,6 +873,22 @@ type AntigravityGatewayService struct {
 	cache             GatewayCache // 用于模型级限流时清除粘性会话绑定
 	schedulerSnapshot *SchedulerSnapshotService
 	internal500Cache  Internal500CounterCache // INTERNAL 500 渐进惩罚计数器
+}
+
+func (s *AntigravityGatewayService) upstreamErrorBodyReadLimit() int64 {
+	limit := gatewayUpstreamErrorBodyReadLimit
+	if s != nil && s.settingService != nil && s.settingService.cfg != nil && s.settingService.cfg.Gateway.LogUpstreamErrorBody && s.settingService.cfg.Gateway.LogUpstreamErrorBodyMaxBytes > int(limit) {
+		limit = int64(s.settingService.cfg.Gateway.LogUpstreamErrorBodyMaxBytes)
+	}
+	return limit
+}
+
+func (s *AntigravityGatewayService) readUpstreamErrorBody(resp *http.Response) []byte {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, s.upstreamErrorBodyReadLimit()))
+	return body
 }
 
 func NewAntigravityGatewayService(
@@ -1090,7 +1106,7 @@ func (s *AntigravityGatewayService) TestConnection(ctx context.Context, account 
 	}
 	defer func() { _ = result.resp.Body.Close() }()
 
-	respBody, err := io.ReadAll(io.LimitReader(result.resp.Body, 2<<20))
+	respBody, err := io.ReadAll(io.LimitReader(result.resp.Body, s.upstreamErrorBodyReadLimit()))
 	if err != nil {
 		return nil, fmt.Errorf("读取响应失败: %w", err)
 	}
@@ -1427,7 +1443,7 @@ func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context,
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 
 		// 优先检测 thinking block 的 signature 相关错误（400）并重试一次：
 		// Antigravity /v1internal 链路在部分场景会对 thought/thinking signature 做严格校验，
@@ -1622,7 +1638,7 @@ func (s *AntigravityGatewayService) Forward(ctx context.Context, c *gin.Context,
 								resp = retryResp
 								respBody = nil
 							} else {
-								retryBody, _ := io.ReadAll(io.LimitReader(retryResp.Body, 2<<20))
+								retryBody := s.readUpstreamErrorBody(retryResp)
 								_ = retryResp.Body.Close()
 								respBody = retryBody
 								resp = &http.Response{
@@ -2189,7 +2205,7 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 
 	// 处理错误响应
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		contentType := resp.Header.Get("Content-Type")
 		// 尽早关闭原始响应体，释放连接；后续逻辑仍可能需要读取 body，因此用内存副本重新包装。
 		_ = resp.Body.Close()
@@ -2270,7 +2286,7 @@ func (s *AntigravityGatewayService) ForwardGemini(ctx context.Context, c *gin.Co
 					if retryResp.StatusCode < 400 {
 						resp = retryResp
 					} else {
-						retryRespBody, _ := io.ReadAll(io.LimitReader(retryResp.Body, 2<<20))
+						retryRespBody := s.readUpstreamErrorBody(retryResp)
 						_ = retryResp.Body.Close()
 						retryOpsBody := retryRespBody
 						if retryUnwrapped, unwrapErr := s.unwrapV1InternalResponse(retryRespBody); unwrapErr == nil && len(retryUnwrapped) > 0 {
@@ -4252,7 +4268,7 @@ func (s *AntigravityGatewayService) ForwardUpstream(ctx context.Context, c *gin.
 
 	// 处理错误响应
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 
 		// 429 错误时标记账号限流
 		if resp.StatusCode == http.StatusTooManyRequests {

--- a/backend/internal/service/antigravity_gateway_service_test.go
+++ b/backend/internal/service/antigravity_gateway_service_test.go
@@ -42,6 +42,15 @@ func newAntigravityTestService(cfg *config.Config) *AntigravityGatewayService {
 	}
 }
 
+func TestAntigravityUpstreamErrorBodyReadLimit_RespectsDiagnosticLimit(t *testing.T) {
+	svc := newAntigravityTestService(&config.Config{Gateway: config.GatewayConfig{
+		LogUpstreamErrorBody:         true,
+		LogUpstreamErrorBodyMaxBytes: int(gatewayUpstreamErrorBodyReadLimit) + 1024,
+	}})
+
+	require.Equal(t, int64(svc.settingService.cfg.Gateway.LogUpstreamErrorBodyMaxBytes), svc.upstreamErrorBodyReadLimit())
+}
+
 func TestStripSignatureSensitiveBlocksFromClaudeRequest(t *testing.T) {
 	req := &antigravity.ClaudeRequest{
 		Model: "claude-sonnet-4-5",

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -112,7 +112,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardStreamPreservesBodyAnd
 
 	body := []byte(`{"model":"claude-3-7-sonnet-20250219","stream":true,"system":[{"type":"text","text":"x-anthropic-billing-header keep"}],"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
 	parsed := &ParsedRequest{
-		Body:   body,
+		Body:   NewRequestBodyRef(body),
 		Model:  "claude-3-7-sonnet-20250219",
 		Stream: true,
 	}
@@ -202,7 +202,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ForwardCountTokensPreservesBo
 
 	body := []byte(`{"model":"claude-3-5-sonnet-latest","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}],"thinking":{"type":"enabled"}}`)
 	parsed := &ParsedRequest{
-		Body:  body,
+		Body:  NewRequestBodyRef(body),
 		Model: "claude-3-5-sonnet-latest",
 	}
 
@@ -344,7 +344,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingEdgeCases(t *test
 
 			body := []byte(`{"model":"` + tt.model + `","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
 			parsed := &ParsedRequest{
-				Body:  body,
+				Body:  NewRequestBodyRef(body),
 				Model: tt.model,
 			}
 
@@ -429,7 +429,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_ModelMappingPreservesOtherFie
 	// 包含复杂字段的请求体：system、thinking、messages
 	body := []byte(`{"model":"claude-sonnet-4-20250514","system":[{"type":"text","text":"You are a helpful assistant."}],"messages":[{"role":"user","content":[{"type":"text","text":"hello world"}]}],"thinking":{"type":"enabled","budget_tokens":5000},"max_tokens":1024}`)
 	parsed := &ParsedRequest{
-		Body:  body,
+		Body:  NewRequestBodyRef(body),
 		Model: "claude-sonnet-4-20250514",
 	}
 
@@ -485,7 +485,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_CountTokensFiltersGenerationF
 
 	body := []byte(`{"model":"claude-sonnet-4-20250514","system":[{"type":"text","text":"sys"}],"messages":[{"role":"user","content":"hello"}],"tools":[{"name":"tool","input_schema":{"type":"object"}}],"temperature":0.7,"top_p":0.9,"top_k":40,"stream":true,"stop_sequences":["END"],"max_tokens":1024,"thinking":{"type":"enabled","budget_tokens":5000}}`)
 	parsed := &ParsedRequest{
-		Body:  body,
+		Body:  NewRequestBodyRef(body),
 		Model: "claude-sonnet-4-20250514",
 	}
 
@@ -547,7 +547,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_EmptyModelSkipsMapping(t *tes
 
 	body := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
 	parsed := &ParsedRequest{
-		Body:  body,
+		Body:  NewRequestBodyRef(body),
 		Model: "", // 空模型
 	}
 
@@ -636,7 +636,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_CountTokens404PassthroughNotE
 			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages/count_tokens", nil)
 
 			body := []byte(`{"model":"claude-sonnet-4-5-20250929","messages":[{"role":"user","content":"hi"}]}`)
-			parsed := &ParsedRequest{Body: body, Model: "claude-sonnet-4-5-20250929"}
+			parsed := &ParsedRequest{Body: NewRequestBodyRef(body), Model: "claude-sonnet-4-5-20250929"}
 
 			upstream := &anthropicHTTPUpstreamRecorder{
 				resp: &http.Response{
@@ -767,7 +767,7 @@ func TestGatewayService_AnthropicOAuth_ForwardPreservesBillingHeaderSystemBlock(
 			c, _ := gin.CreateTestContext(rec)
 			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
 
-			parsed, err := ParseGatewayRequest([]byte(tt.body), PlatformAnthropic)
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(tt.body)), PlatformAnthropic)
 			require.NoError(t, err)
 
 			upstream := &anthropicHTTPUpstreamRecorder{

--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -713,7 +713,7 @@ func TestGatewayService_AnthropicAPIKeyPassthrough_BuildRequestRejectsInvalidBas
 		},
 	}
 
-	_, err := svc.buildUpstreamRequestAnthropicAPIKeyPassthrough(context.Background(), c, account, []byte(`{}`), "k")
+	_, _, err := svc.buildUpstreamRequestAnthropicAPIKeyPassthrough(context.Background(), c, account, []byte(`{}`), "k")
 	require.Error(t, err)
 }
 
@@ -738,7 +738,7 @@ func TestGatewayService_AnthropicOAuth_NotAffectedByAPIKeyPassthroughToggle(t *t
 
 	require.False(t, account.IsAnthropicAPIKeyPassthroughEnabled())
 
-	req, err := svc.buildUpstreamRequest(context.Background(), c, account, []byte(`{"model":"claude-3-7-sonnet-20250219"}`), "oauth-token", "oauth", "claude-3-7-sonnet-20250219", true, false)
+	req, _, err := svc.buildUpstreamRequest(context.Background(), c, account, []byte(`{"model":"claude-3-7-sonnet-20250219"}`), "oauth-token", "oauth", "claude-3-7-sonnet-20250219", true, false)
 	require.NoError(t, err)
 	require.Equal(t, "Bearer oauth-token", getHeaderRaw(req.Header, "authorization"))
 	require.Contains(t, getHeaderRaw(req.Header, "anthropic-beta"), claude.BetaOAuth, "OAuth 链路仍应按原逻辑补齐 oauth beta")

--- a/backend/internal/service/gateway_anthropic_vertex_service_account_test.go
+++ b/backend/internal/service/gateway_anthropic_vertex_service_account_test.go
@@ -35,7 +35,7 @@ func TestGatewayService_BuildAnthropicVertexServiceAccountRequest(t *testing.T) 
 	body := []byte(`{"model":"claude-sonnet-4-5","stream":false,"max_tokens":32,"messages":[{"role":"user","content":"hello"}]}`)
 
 	svc := &GatewayService{}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(),
 		c,
 		account,
@@ -87,7 +87,7 @@ func TestGatewayService_BuildAnthropicVertexServiceAccount_StripsContextManageme
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]},"messages":[{"role":"user","content":"hi"}]}`)
 
 	svc := &GatewayService{}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(), c, account, body,
 		"vertex-token", "service_account", "claude-haiku-4-5@20251001", false, false,
 	)
@@ -117,7 +117,7 @@ func TestGatewayService_BuildAnthropicVertexServiceAccount_PreservesContextManag
 	body := []byte(`{"model":"claude-sonnet-4-6","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 
 	svc := &GatewayService{}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(), c, account, body,
 		"vertex-token", "service_account", "claude-sonnet-4-6@20260218", false, false,
 	)

--- a/backend/internal/service/gateway_context_management_test.go
+++ b/backend/internal/service/gateway_context_management_test.go
@@ -364,7 +364,7 @@ func TestBuildUpstreamRequestAnthropicAPIKeyPassthrough_StripsContextManagementW
 
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildUpstreamRequestAnthropicAPIKeyPassthrough(
+	req, _, err := svc.buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		context.Background(), c, newAnthropicAPIKeyPassthroughAccountForBetaTest(), body, "token",
 	)
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestBuildUpstreamRequestAnthropicAPIKeyPassthrough_PreservesContextManageme
 
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildUpstreamRequestAnthropicAPIKeyPassthrough(
+	req, _, err := svc.buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		context.Background(), c, newAnthropicAPIKeyPassthroughAccountForBetaTest(), body, "token",
 	)
 	require.NoError(t, err)
@@ -427,7 +427,7 @@ func TestBuildUpstreamRequest_OAuthMimicHaiku_StripsContextManagementEndToEnd(t 
 	// body 必须 strip。
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(), c, account, body,
 		"oauth-tok", "oauth", "claude-haiku-4-5", false, true, // mimicClaudeCode=true
 	)
@@ -457,7 +457,7 @@ func TestBuildUpstreamRequest_OAuthMimicNonHaiku_PreservesContextManagementEndTo
 	// body 保留。
 	body := []byte(`{"model":"claude-sonnet-4-6","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(), c, account, body,
 		"oauth-tok", "oauth", "claude-sonnet-4-6", false, true,
 	)
@@ -488,7 +488,7 @@ func TestBuildUpstreamRequest_OAuthTransparentHaikuWithRealCCBeta_PreservesField
 	}
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(), c, account, body,
 		"oauth-tok", "oauth", "claude-haiku-4-5", false, false, // mimicClaudeCode=false（真 CC）
 	)
@@ -580,7 +580,7 @@ func TestBuildCountTokensRequest_OAuthMimicHaiku_PreservesContextManagementEndTo
 	}
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[{"type":"clear_thinking_20251015"}]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildCountTokensRequest(
+	req, _, err := svc.buildCountTokensRequest(
 		context.Background(), c, account, body,
 		"oauth-tok", "oauth", "claude-haiku-4-5", true, // mimicClaudeCode=true
 	)
@@ -611,7 +611,7 @@ func TestBuildCountTokensRequest_APIKeyHaiku_StripsContextManagementEndToEnd(t *
 	}
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildCountTokensRequest(
+	req, _, err := svc.buildCountTokensRequest(
 		context.Background(), c, account, body,
 		"sk-ant-xxx", "apikey", "claude-haiku-4-5", false,
 	)
@@ -655,7 +655,7 @@ func TestBuildUpstreamRequest_APIKeyHaikuWithContextManagement_StripsField(t *te
 	}
 	body := []byte(`{"model":"claude-haiku-4-5","context_management":{"edits":[]},"messages":[]}`)
 	svc := &GatewayService{cfg: &config.Config{}}
-	req, err := svc.buildUpstreamRequest(
+	req, _, err := svc.buildUpstreamRequest(
 		context.Background(), c, account, body,
 		"sk-ant-xxx", "apikey", "claude-haiku-4-5", false, false,
 	)

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -119,7 +119,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 10. Build upstream request
 	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
+	upstreamReq, _, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
 	releaseUpstreamCtx()
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)

--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -148,7 +148,7 @@ func (s *GatewayService) ForwardAsChatCompletions(
 
 	// 12. Handle error response with failover
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -116,7 +116,7 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 10. Build upstream request
 	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
+	upstreamReq, _, err := s.buildUpstreamRequest(upstreamCtx, c, account, anthropicBody, token, tokenType, mappedModel, reqStream, shouldMimicClaudeCode)
 	releaseUpstreamCtx()
 	if err != nil {
 		return nil, fmt.Errorf("build upstream request: %w", err)

--- a/backend/internal/service/gateway_forward_as_responses.go
+++ b/backend/internal/service/gateway_forward_as_responses.go
@@ -145,7 +145,7 @@ func (s *GatewayService) ForwardAsResponses(
 
 	// 12. Handle error response with failover
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/gateway_oauth_metadata_test.go
+++ b/backend/internal/service/gateway_oauth_metadata_test.go
@@ -14,8 +14,6 @@ func TestBuildOAuthMetadataUserID_FallbackWithoutAccountUUID(t *testing.T) {
 		Model:          "claude-sonnet-4-5",
 		Stream:         true,
 		MetadataUserID: "",
-		System:         nil,
-		Messages:       nil,
 	}
 
 	account := &Account{

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -105,6 +105,22 @@ func (r jsonRange) exists() bool {
 	return r.start >= 0 && r.end >= r.start
 }
 
+// clearGatewayRequestDerivedState 清空绑定当前 body 的轻量派生字段，防止 ReplaceBody 后读到旧值。
+func clearGatewayRequestDerivedState(parsed *ParsedRequest) {
+	if parsed == nil {
+		return
+	}
+	parsed.Model = ""
+	parsed.Stream = false
+	parsed.MetadataUserID = ""
+	parsed.HasSystem = false
+	parsed.ThinkingEnabled = false
+	parsed.OutputEffort = ""
+	parsed.MaxTokens = 0
+	parsed.systemRange = missingJSONRange()
+	parsed.messagesRange = missingJSONRange()
+}
+
 func clearGatewayRequestRanges(parsed *ParsedRequest) {
 	if parsed == nil {
 		return
@@ -137,12 +153,9 @@ func setGatewayRequestRanges(parsed *ParsedRequest, protocol string, jsonStr str
 	}
 }
 
-func refreshGatewayRequestRanges(parsed *ParsedRequest, protocol string) error {
-	if parsed == nil {
-		return fmt.Errorf("empty request body")
-	}
-	clearGatewayRequestRanges(parsed)
-	if parsed.Body == nil {
+// parseGatewayRequestCurrentBody 只做标量和 raw range 轻量解析，不恢复 system/messages 对象图。
+func parseGatewayRequestCurrentBody(parsed *ParsedRequest, protocol string) error {
+	if parsed == nil || parsed.Body == nil {
 		return fmt.Errorf("empty request body")
 	}
 
@@ -151,9 +164,49 @@ func refreshGatewayRequestRanges(parsed *ParsedRequest, protocol string) error {
 		return fmt.Errorf("invalid json")
 	}
 
+	// 只在当前函数内零拷贝读取 JSON 字段；ReplaceBody 后必须重新进入本函数刷新派生状态。
 	jsonStr := *(*string)(unsafe.Pointer(&bodyBytes))
+	clearGatewayRequestDerivedState(parsed)
+	parsed.protocol = protocol
+
+	modelResult := gjson.Get(jsonStr, "model")
+	if modelResult.Exists() {
+		if modelResult.Type != gjson.String {
+			return fmt.Errorf("invalid model field type")
+		}
+		parsed.Model = modelResult.String()
+	}
+
+	streamResult := gjson.Get(jsonStr, "stream")
+	if streamResult.Exists() {
+		if streamResult.Type != gjson.True && streamResult.Type != gjson.False {
+			return fmt.Errorf("invalid stream field type")
+		}
+		parsed.Stream = streamResult.Bool()
+	}
+
+	parsed.MetadataUserID = gjson.Get(jsonStr, "metadata.user_id").String()
+
+	thinkingType := gjson.Get(jsonStr, "thinking.type").String()
+	parsed.ThinkingEnabled = thinkingType == "enabled" || thinkingType == "adaptive"
+
+	parsed.OutputEffort = strings.TrimSpace(gjson.Get(jsonStr, "output_config.effort").String())
+
+	maxTokensResult := gjson.Get(jsonStr, "max_tokens")
+	if maxTokensResult.Exists() && maxTokensResult.Type == gjson.Number {
+		f := maxTokensResult.Float()
+		if !math.IsNaN(f) && !math.IsInf(f, 0) && f == math.Trunc(f) &&
+			f <= float64(math.MaxInt) && f >= float64(math.MinInt) {
+			parsed.MaxTokens = int(f)
+		}
+	}
+
 	setGatewayRequestRanges(parsed, protocol, jsonStr)
 	return nil
+}
+
+func refreshGatewayRequestRanges(parsed *ParsedRequest, protocol string) error {
+	return parseGatewayRequestCurrentBody(parsed, protocol)
 }
 
 // ParsedRequest 保存网关请求的预解析结果
@@ -238,71 +291,10 @@ func normalizeSessionUserAgentFallback(raw string) string {
 // protocol 指定请求协议格式（domain.PlatformAnthropic / domain.PlatformGemini），
 // 不同协议使用不同的 system/messages 字段名。
 func ParseGatewayRequest(body *RequestBodyRef, protocol string) (*ParsedRequest, error) {
-	bodyBytes := body.Bytes()
-	// 保持与旧实现一致：请求体必须是合法 JSON。
-	// 注意：gjson.GetBytes 对非法 JSON 不会报错，因此需要显式校验。
-	if !gjson.ValidBytes(bodyBytes) {
-		return nil, fmt.Errorf("invalid json")
+	parsed := &ParsedRequest{Body: body}
+	if err := parseGatewayRequestCurrentBody(parsed, protocol); err != nil {
+		return nil, err
 	}
-
-	// 性能：
-	// - gjson.GetBytes 会把匹配的 Raw/Str 安全复制成 string（对于巨大 messages 会产生额外拷贝）。
-	// - 这里将 body 通过 unsafe 零拷贝视为 string，仅在本函数内使用，且 body 不会被修改。
-	jsonStr := *(*string)(unsafe.Pointer(&bodyBytes))
-
-	parsed := &ParsedRequest{
-		Body:          body,
-		protocol:      protocol,
-		systemRange:   missingJSONRange(),
-		messagesRange: missingJSONRange(),
-	}
-
-	// --- gjson 提取简单字段（避免完整 Unmarshal） ---
-
-	// model: 需要严格类型校验，非 string 返回错误
-	modelResult := gjson.Get(jsonStr, "model")
-	if modelResult.Exists() {
-		if modelResult.Type != gjson.String {
-			return nil, fmt.Errorf("invalid model field type")
-		}
-		parsed.Model = modelResult.String()
-	}
-
-	// stream: 需要严格类型校验，非 bool 返回错误
-	streamResult := gjson.Get(jsonStr, "stream")
-	if streamResult.Exists() {
-		if streamResult.Type != gjson.True && streamResult.Type != gjson.False {
-			return nil, fmt.Errorf("invalid stream field type")
-		}
-		parsed.Stream = streamResult.Bool()
-	}
-
-	// metadata.user_id: 直接路径提取，不需要严格类型校验
-	parsed.MetadataUserID = gjson.Get(jsonStr, "metadata.user_id").String()
-
-	// thinking.type: enabled/adaptive 都视为开启
-	thinkingType := gjson.Get(jsonStr, "thinking.type").String()
-	if thinkingType == "enabled" || thinkingType == "adaptive" {
-		parsed.ThinkingEnabled = true
-	}
-
-	// output_config.effort: Claude API 的推理强度控制参数
-	parsed.OutputEffort = strings.TrimSpace(gjson.Get(jsonStr, "output_config.effort").String())
-
-	// max_tokens: 仅接受整数值
-	maxTokensResult := gjson.Get(jsonStr, "max_tokens")
-	if maxTokensResult.Exists() && maxTokensResult.Type == gjson.Number {
-		f := maxTokensResult.Float()
-		if !math.IsNaN(f) && !math.IsInf(f, 0) && f == math.Trunc(f) &&
-			f <= float64(math.MaxInt) && f >= float64(math.MinInt) {
-			parsed.MaxTokens = int(f)
-		}
-	}
-
-	// --- system/messages 提取 ---
-	// 只保存大字段 raw range，不默认反序列化成 []any/map[string]any 对象图。
-	setGatewayRequestRanges(parsed, protocol, jsonStr)
-
 	return parsed, nil
 }
 
@@ -353,9 +345,24 @@ func (p *ParsedRequest) SystemValue() (any, bool) {
 	return system, true
 }
 
-func (p *ParsedRequest) ReplaceBody(data []byte) {
+// CloneForBody 为单次账号尝试创建独立 body 视图，避免 failover 复用已改写的 ParsedRequest。
+func (p *ParsedRequest) CloneForBody(body []byte) (*ParsedRequest, error) {
 	if p == nil {
-		return
+		return nil, fmt.Errorf("parse request: empty request")
+	}
+	clone := *p
+	clone.Body = NewRequestBodyRef(body)
+	clone.OnUpstreamAccepted = nil
+	if err := refreshGatewayRequestRanges(&clone, clone.protocol); err != nil {
+		return nil, err
+	}
+	return &clone, nil
+}
+
+// ReplaceBody 统一刷新当前 body 和 raw range，保证后续 helper 读取的是最新请求体。
+func (p *ParsedRequest) ReplaceBody(data []byte) error {
+	if p == nil {
+		return fmt.Errorf("parse request: empty request")
 	}
 	if p.Body == nil {
 		p.Body = NewRequestBodyRef(data)
@@ -364,7 +371,9 @@ func (p *ParsedRequest) ReplaceBody(data []byte) {
 	}
 	if err := refreshGatewayRequestRanges(p, p.protocol); err != nil {
 		clearGatewayRequestRanges(p)
+		return err
 	}
+	return nil
 }
 
 // sliceRawFromBody 返回 Result.Raw 对应的原始字节切片。

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -51,6 +51,12 @@ type SessionContext struct {
 	APIKeyID  int64
 }
 
+type jsonRange struct {
+	start int        // 原始请求体中的起始偏移（闭区间）
+	end   int        // 原始请求体中的结束偏移（开区间）
+	kind  gjson.Type // JSON 值类型，用于调用方做轻量分支
+}
+
 type RequestBodyRef struct {
 	data []byte
 }
@@ -80,6 +86,76 @@ func (b *RequestBodyRef) Replace(data []byte) {
 	b.data = data
 }
 
+func missingJSONRange() jsonRange {
+	return jsonRange{start: -1, end: -1}
+}
+
+func rangeFromResult(r gjson.Result) jsonRange {
+	if r.Raw == "" || r.Index <= 0 {
+		return missingJSONRange()
+	}
+	end := r.Index + len(r.Raw)
+	if end < r.Index {
+		return missingJSONRange()
+	}
+	return jsonRange{start: r.Index, end: end, kind: r.Type}
+}
+
+func (r jsonRange) exists() bool {
+	return r.start >= 0 && r.end >= r.start
+}
+
+func clearGatewayRequestRanges(parsed *ParsedRequest) {
+	if parsed == nil {
+		return
+	}
+	parsed.HasSystem = false
+	parsed.systemRange = missingJSONRange()
+	parsed.messagesRange = missingJSONRange()
+}
+
+func setGatewayRequestRanges(parsed *ParsedRequest, protocol string, jsonStr string) {
+	if parsed == nil {
+		return
+	}
+	switch protocol {
+	case domain.PlatformGemini:
+		if sysParts := gjson.Get(jsonStr, "systemInstruction.parts"); sysParts.Exists() && sysParts.IsArray() {
+			parsed.systemRange = rangeFromResult(sysParts)
+		}
+		if contents := gjson.Get(jsonStr, "contents"); contents.Exists() && contents.IsArray() {
+			parsed.messagesRange = rangeFromResult(contents)
+		}
+	default:
+		if sys := gjson.Get(jsonStr, "system"); sys.Exists() {
+			parsed.HasSystem = true
+			parsed.systemRange = rangeFromResult(sys)
+		}
+		if msgs := gjson.Get(jsonStr, "messages"); msgs.Exists() && msgs.IsArray() {
+			parsed.messagesRange = rangeFromResult(msgs)
+		}
+	}
+}
+
+func refreshGatewayRequestRanges(parsed *ParsedRequest, protocol string) error {
+	if parsed == nil {
+		return fmt.Errorf("empty request body")
+	}
+	clearGatewayRequestRanges(parsed)
+	if parsed.Body == nil {
+		return fmt.Errorf("empty request body")
+	}
+
+	bodyBytes := parsed.Body.Bytes()
+	if !gjson.ValidBytes(bodyBytes) {
+		return fmt.Errorf("invalid json")
+	}
+
+	jsonStr := *(*string)(unsafe.Pointer(&bodyBytes))
+	setGatewayRequestRanges(parsed, protocol, jsonStr)
+	return nil
+}
+
 // ParsedRequest 保存网关请求的预解析结果
 //
 // 性能优化说明：
@@ -93,17 +169,19 @@ func (b *RequestBodyRef) Replace(data []byte) {
 // 2. 将解析结果 ParsedRequest 传递给 Service 层
 // 3. 避免重复 json.Unmarshal，减少 CPU 和内存开销
 type ParsedRequest struct {
-	Body            *RequestBodyRef // 原始请求体引用（保留用于转发）
+	Body            *RequestBodyRef // 原始请求体引用（保留用于转发）；替换内容请走 ReplaceBody
 	Model           string          // 请求的模型名称
 	Stream          bool            // 是否为流式请求
 	MetadataUserID  string          // metadata.user_id（用于会话亲和）
-	System          any             // system 字段内容
-	Messages        []any           // messages 数组
 	HasSystem       bool            // 是否包含 system 字段（包含 null 也视为显式传入）
 	ThinkingEnabled bool            // 是否开启 thinking（部分平台会影响最终模型名）
 	OutputEffort    string          // output_config.effort（Claude API 的推理强度控制）
 	MaxTokens       int             // max_tokens 值（用于探测请求拦截）
 	SessionContext  *SessionContext // 可选：请求上下文区分因子（nil 时行为不变）
+
+	protocol      string    // 当前 Body 的协议格式，用于 Body 替换后刷新 raw range
+	systemRange   jsonRange // system/systemInstruction.parts 的 raw JSON 范围，绑定 Body 当前内容
+	messagesRange jsonRange // messages/contents 的 raw JSON 范围，绑定 Body 当前内容
 
 	// GroupID 请求所属分组 ID（来自 API Key）
 	GroupID *int64
@@ -173,7 +251,10 @@ func ParseGatewayRequest(body *RequestBodyRef, protocol string) (*ParsedRequest,
 	jsonStr := *(*string)(unsafe.Pointer(&bodyBytes))
 
 	parsed := &ParsedRequest{
-		Body: body,
+		Body:          body,
+		protocol:      protocol,
+		systemRange:   missingJSONRange(),
+		messagesRange: missingJSONRange(),
 	}
 
 	// --- gjson 提取简单字段（避免完整 Unmarshal） ---
@@ -219,58 +300,71 @@ func ParseGatewayRequest(body *RequestBodyRef, protocol string) (*ParsedRequest,
 	}
 
 	// --- system/messages 提取 ---
-	// 避免把整个 body Unmarshal 到 map（会产生大量 map/接口分配）。
-	// 使用 gjson 抽取目标字段的 Raw，再对该子树进行 Unmarshal。
-
-	switch protocol {
-	case domain.PlatformGemini:
-		// Gemini 原生格式: systemInstruction.parts / contents
-		if sysParts := gjson.Get(jsonStr, "systemInstruction.parts"); sysParts.Exists() && sysParts.IsArray() {
-			var parts []any
-			if err := json.Unmarshal(sliceRawFromBody(bodyBytes, sysParts), &parts); err != nil {
-				return nil, err
-			}
-			parsed.System = parts
-		}
-
-		if contents := gjson.Get(jsonStr, "contents"); contents.Exists() && contents.IsArray() {
-			var msgs []any
-			if err := json.Unmarshal(sliceRawFromBody(bodyBytes, contents), &msgs); err != nil {
-				return nil, err
-			}
-			parsed.Messages = msgs
-		}
-	default:
-		// Anthropic / OpenAI 格式: system / messages
-		// system 字段只要存在就视为显式提供（即使为 null），
-		// 以避免客户端传 null 时被默认 system 误注入。
-		if sys := gjson.Get(jsonStr, "system"); sys.Exists() {
-			parsed.HasSystem = true
-			switch sys.Type {
-			case gjson.Null:
-				parsed.System = nil
-			case gjson.String:
-				// 与 encoding/json 的 Unmarshal 行为一致：返回解码后的字符串。
-				parsed.System = sys.String()
-			default:
-				var system any
-				if err := json.Unmarshal(sliceRawFromBody(bodyBytes, sys), &system); err != nil {
-					return nil, err
-				}
-				parsed.System = system
-			}
-		}
-
-		if msgs := gjson.Get(jsonStr, "messages"); msgs.Exists() && msgs.IsArray() {
-			var messages []any
-			if err := json.Unmarshal(sliceRawFromBody(bodyBytes, msgs), &messages); err != nil {
-				return nil, err
-			}
-			parsed.Messages = messages
-		}
-	}
+	// 只保存大字段 raw range，不默认反序列化成 []any/map[string]any 对象图。
+	setGatewayRequestRanges(parsed, protocol, jsonStr)
 
 	return parsed, nil
+}
+
+func (p *ParsedRequest) raw(r jsonRange) []byte {
+	if p == nil || p.Body == nil || !r.exists() {
+		return nil
+	}
+	body := p.Body.Bytes()
+	if r.end > len(body) {
+		return nil
+	}
+	return body[r.start:r.end]
+}
+
+func (p *ParsedRequest) SystemRaw() []byte {
+	return p.raw(p.systemRange)
+}
+
+func (p *ParsedRequest) MessagesRaw() []byte {
+	return p.raw(p.messagesRange)
+}
+
+func (p *ParsedRequest) DecodeSystem(dst any) error {
+	raw := p.SystemRaw()
+	if len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func (p *ParsedRequest) DecodeMessages(dst any) error {
+	raw := p.MessagesRaw()
+	if len(raw) == 0 {
+		return nil
+	}
+	return json.Unmarshal(raw, dst)
+}
+
+func (p *ParsedRequest) SystemValue() (any, bool) {
+	raw := p.SystemRaw()
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var system any
+	if err := json.Unmarshal(raw, &system); err != nil {
+		return nil, false
+	}
+	return system, true
+}
+
+func (p *ParsedRequest) ReplaceBody(data []byte) {
+	if p == nil {
+		return
+	}
+	if p.Body == nil {
+		p.Body = NewRequestBodyRef(data)
+	} else {
+		p.Body.Replace(data)
+	}
+	if err := refreshGatewayRequestRanges(p, p.protocol); err != nil {
+		clearGatewayRequestRanges(p)
+	}
 }
 
 // sliceRawFromBody 返回 Result.Raw 对应的原始字节切片。

--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -51,6 +51,35 @@ type SessionContext struct {
 	APIKeyID  int64
 }
 
+type RequestBodyRef struct {
+	data []byte
+}
+
+func NewRequestBodyRef(data []byte) *RequestBodyRef {
+	return &RequestBodyRef{data: data}
+}
+
+func (b *RequestBodyRef) Bytes() []byte {
+	if b == nil {
+		return nil
+	}
+	return b.data
+}
+
+func (b *RequestBodyRef) Len() int {
+	if b == nil {
+		return 0
+	}
+	return len(b.data)
+}
+
+func (b *RequestBodyRef) Replace(data []byte) {
+	if b == nil {
+		return
+	}
+	b.data = data
+}
+
 // ParsedRequest 保存网关请求的预解析结果
 //
 // 性能优化说明：
@@ -64,7 +93,7 @@ type SessionContext struct {
 // 2. 将解析结果 ParsedRequest 传递给 Service 层
 // 3. 避免重复 json.Unmarshal，减少 CPU 和内存开销
 type ParsedRequest struct {
-	Body            []byte          // 原始请求体（保留用于转发）
+	Body            *RequestBodyRef // 原始请求体引用（保留用于转发）
 	Model           string          // 请求的模型名称
 	Stream          bool            // 是否为流式请求
 	MetadataUserID  string          // metadata.user_id（用于会话亲和）
@@ -130,17 +159,18 @@ func normalizeSessionUserAgentFallback(raw string) string {
 // ParseGatewayRequest 解析网关请求体并返回结构化结果。
 // protocol 指定请求协议格式（domain.PlatformAnthropic / domain.PlatformGemini），
 // 不同协议使用不同的 system/messages 字段名。
-func ParseGatewayRequest(body []byte, protocol string) (*ParsedRequest, error) {
+func ParseGatewayRequest(body *RequestBodyRef, protocol string) (*ParsedRequest, error) {
+	bodyBytes := body.Bytes()
 	// 保持与旧实现一致：请求体必须是合法 JSON。
 	// 注意：gjson.GetBytes 对非法 JSON 不会报错，因此需要显式校验。
-	if !gjson.ValidBytes(body) {
+	if !gjson.ValidBytes(bodyBytes) {
 		return nil, fmt.Errorf("invalid json")
 	}
 
 	// 性能：
 	// - gjson.GetBytes 会把匹配的 Raw/Str 安全复制成 string（对于巨大 messages 会产生额外拷贝）。
 	// - 这里将 body 通过 unsafe 零拷贝视为 string，仅在本函数内使用，且 body 不会被修改。
-	jsonStr := *(*string)(unsafe.Pointer(&body))
+	jsonStr := *(*string)(unsafe.Pointer(&bodyBytes))
 
 	parsed := &ParsedRequest{
 		Body: body,
@@ -197,7 +227,7 @@ func ParseGatewayRequest(body []byte, protocol string) (*ParsedRequest, error) {
 		// Gemini 原生格式: systemInstruction.parts / contents
 		if sysParts := gjson.Get(jsonStr, "systemInstruction.parts"); sysParts.Exists() && sysParts.IsArray() {
 			var parts []any
-			if err := json.Unmarshal(sliceRawFromBody(body, sysParts), &parts); err != nil {
+			if err := json.Unmarshal(sliceRawFromBody(bodyBytes, sysParts), &parts); err != nil {
 				return nil, err
 			}
 			parsed.System = parts
@@ -205,7 +235,7 @@ func ParseGatewayRequest(body []byte, protocol string) (*ParsedRequest, error) {
 
 		if contents := gjson.Get(jsonStr, "contents"); contents.Exists() && contents.IsArray() {
 			var msgs []any
-			if err := json.Unmarshal(sliceRawFromBody(body, contents), &msgs); err != nil {
+			if err := json.Unmarshal(sliceRawFromBody(bodyBytes, contents), &msgs); err != nil {
 				return nil, err
 			}
 			parsed.Messages = msgs
@@ -224,7 +254,7 @@ func ParseGatewayRequest(body []byte, protocol string) (*ParsedRequest, error) {
 				parsed.System = sys.String()
 			default:
 				var system any
-				if err := json.Unmarshal(sliceRawFromBody(body, sys), &system); err != nil {
+				if err := json.Unmarshal(sliceRawFromBody(bodyBytes, sys), &system); err != nil {
 					return nil, err
 				}
 				parsed.System = system
@@ -233,7 +263,7 @@ func ParseGatewayRequest(body []byte, protocol string) (*ParsedRequest, error) {
 
 		if msgs := gjson.Get(jsonStr, "messages"); msgs.Exists() && msgs.IsArray() {
 			var messages []any
-			if err := json.Unmarshal(sliceRawFromBody(body, msgs), &messages); err != nil {
+			if err := json.Unmarshal(sliceRawFromBody(bodyBytes, msgs), &messages); err != nil {
 				return nil, err
 			}
 			parsed.Messages = messages

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestParseGatewayRequest(t *testing.T) {
@@ -20,8 +21,8 @@ func TestParseGatewayRequest(t *testing.T) {
 	require.True(t, parsed.Stream)
 	require.Equal(t, "session_123e4567-e89b-12d3-a456-426614174000", parsed.MetadataUserID)
 	require.True(t, parsed.HasSystem)
-	require.NotNil(t, parsed.System)
-	require.Len(t, parsed.Messages, 1)
+	require.NotEmpty(t, parsed.SystemRaw())
+	require.NotEmpty(t, parsed.MessagesRaw())
 	require.False(t, parsed.ThinkingEnabled)
 }
 
@@ -61,7 +62,7 @@ func TestParseGatewayRequest_SystemNull(t *testing.T) {
 	require.NoError(t, err)
 	// 显式传入 system:null 也应视为“字段已存在”，避免默认 system 被注入。
 	require.True(t, parsed.HasSystem)
-	require.Nil(t, parsed.System)
+	require.Equal(t, []byte("null"), parsed.SystemRaw())
 }
 
 func TestParseGatewayRequest_InvalidModelType(t *testing.T) {
@@ -88,9 +89,9 @@ func TestParseGatewayRequest_GeminiContents(t *testing.T) {
 	}`)
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
-	require.Len(t, parsed.Messages, 3, "should parse contents as Messages")
+	require.Len(t, gjson.ParseBytes(parsed.MessagesRaw()).Array(), 3, "should parse contents as Messages")
 	require.False(t, parsed.HasSystem, "Gemini format should not set HasSystem")
-	require.Nil(t, parsed.System, "no systemInstruction means nil System")
+	require.Nil(t, parsed.SystemRaw(), "no systemInstruction means nil System")
 }
 
 func TestParseGatewayRequest_GeminiSystemInstruction(t *testing.T) {
@@ -104,14 +105,11 @@ func TestParseGatewayRequest_GeminiSystemInstruction(t *testing.T) {
 	}`)
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
-	require.NotNil(t, parsed.System, "should parse systemInstruction.parts as System")
-	parts, ok := parsed.System.([]any)
-	require.True(t, ok)
-	require.Len(t, parts, 1)
-	partMap, ok := parts[0].(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "You are a helpful assistant.", partMap["text"])
-	require.Len(t, parsed.Messages, 1)
+	system := gjson.ParseBytes(parsed.SystemRaw())
+	require.True(t, system.IsArray(), "should parse systemInstruction.parts as System")
+	require.Len(t, system.Array(), 1)
+	require.Equal(t, "You are a helpful assistant.", system.Get("0.text").String())
+	require.Len(t, gjson.ParseBytes(parsed.MessagesRaw()).Array(), 1)
 }
 
 func TestParseGatewayRequest_GeminiWithModel(t *testing.T) {
@@ -122,7 +120,7 @@ func TestParseGatewayRequest_GeminiWithModel(t *testing.T) {
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.Equal(t, "gemini-2.5-pro", parsed.Model)
-	require.Len(t, parsed.Messages, 1)
+	require.Len(t, gjson.ParseBytes(parsed.MessagesRaw()).Array(), 1)
 }
 
 func TestParseGatewayRequest_GeminiIgnoresAnthropicFields(t *testing.T) {
@@ -135,22 +133,22 @@ func TestParseGatewayRequest_GeminiIgnoresAnthropicFields(t *testing.T) {
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.False(t, parsed.HasSystem, "Gemini protocol should not parse Anthropic system field")
-	require.Nil(t, parsed.System, "no systemInstruction = nil System")
-	require.Len(t, parsed.Messages, 1, "should use contents, not messages")
+	require.Nil(t, parsed.SystemRaw(), "no systemInstruction = nil System")
+	require.Len(t, gjson.ParseBytes(parsed.MessagesRaw()).Array(), 1, "should use contents, not messages")
 }
 
 func TestParseGatewayRequest_GeminiEmptyContents(t *testing.T) {
 	body := []byte(`{"contents": []}`)
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
-	require.Empty(t, parsed.Messages)
+	require.Empty(t, gjson.ParseBytes(parsed.MessagesRaw()).Array())
 }
 
 func TestParseGatewayRequest_GeminiNoContents(t *testing.T) {
 	body := []byte(`{"model": "gemini-2.5-flash"}`)
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
-	require.Nil(t, parsed.Messages)
+	require.Nil(t, parsed.MessagesRaw())
 	require.Equal(t, "gemini-2.5-flash", parsed.Model)
 }
 
@@ -165,11 +163,10 @@ func TestParseGatewayRequest_AnthropicIgnoresGeminiFields(t *testing.T) {
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformAnthropic)
 	require.NoError(t, err)
 	require.True(t, parsed.HasSystem)
-	require.Equal(t, "real system", parsed.System)
-	require.Len(t, parsed.Messages, 1)
-	msg, ok := parsed.Messages[0].(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, "real content", msg["content"])
+	require.Equal(t, "real system", gjson.ParseBytes(parsed.SystemRaw()).String())
+	messages := gjson.ParseBytes(parsed.MessagesRaw()).Array()
+	require.Len(t, messages, 1)
+	require.Equal(t, "real content", messages[0].Get("content").String())
 }
 
 func TestFilterThinkingBlocks(t *testing.T) {
@@ -970,10 +967,10 @@ func TestParseGatewayRequest_OptionalFieldsMissing(t *testing.T) {
 			require.Equal(t, tt.wantMaxTokens, parsed.MaxTokens)
 
 			if tt.wantMessagesNil {
-				require.Nil(t, parsed.Messages)
+				require.Nil(t, parsed.MessagesRaw())
 			}
 			if tt.wantMessagesLen > 0 {
-				require.Len(t, parsed.Messages, tt.wantMessagesLen)
+				require.Len(t, gjson.ParseBytes(parsed.MessagesRaw()).Array(), tt.wantMessagesLen)
 			}
 		})
 	}
@@ -1087,25 +1084,8 @@ func parseGatewayRequestOld(body []byte, protocol string) (*ParsedRequest, error
 		}
 	}
 
-	// system / messages（按协议分支）
-	switch protocol {
-	case domain.PlatformGemini:
-		if sysInst, ok := req["systemInstruction"].(map[string]any); ok {
-			if parts, ok := sysInst["parts"].([]any); ok {
-				parsed.System = parts
-			}
-		}
-		if contents, ok := req["contents"].([]any); ok {
-			parsed.Messages = contents
-		}
-	default:
-		if system, ok := req["system"]; ok {
-			parsed.HasSystem = true
-			parsed.System = system
-		}
-		if messages, ok := req["messages"].([]any); ok {
-			parsed.Messages = messages
-		}
+	if err := refreshGatewayRequestRanges(parsed, protocol); err != nil {
+		return nil, err
 	}
 
 	return parsed, nil

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestParseGatewayRequest(t *testing.T) {
 	body := []byte(`{"model":"claude-3-7-sonnet","stream":true,"metadata":{"user_id":"session_123e4567-e89b-12d3-a456-426614174000"},"system":[{"type":"text","text":"hello","cache_control":{"type":"ephemeral"}}],"messages":[{"content":"hi"}]}`)
-	parsed, err := ParseGatewayRequest(body, "")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.NoError(t, err)
 	require.Equal(t, "claude-3-7-sonnet", parsed.Model)
 	require.True(t, parsed.Stream)
@@ -27,7 +27,7 @@ func TestParseGatewayRequest(t *testing.T) {
 
 func TestParseGatewayRequest_ThinkingEnabled(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-5","thinking":{"type":"enabled"},"messages":[{"content":"hi"}]}`)
-	parsed, err := ParseGatewayRequest(body, "")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.NoError(t, err)
 	require.Equal(t, "claude-sonnet-4-5", parsed.Model)
 	require.True(t, parsed.ThinkingEnabled)
@@ -35,7 +35,7 @@ func TestParseGatewayRequest_ThinkingEnabled(t *testing.T) {
 
 func TestParseGatewayRequest_ThinkingAdaptiveEnabled(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-5","thinking":{"type":"adaptive"},"messages":[{"content":"hi"}]}`)
-	parsed, err := ParseGatewayRequest(body, "")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.NoError(t, err)
 	require.Equal(t, "claude-sonnet-4-5", parsed.Model)
 	require.True(t, parsed.ThinkingEnabled)
@@ -43,21 +43,21 @@ func TestParseGatewayRequest_ThinkingAdaptiveEnabled(t *testing.T) {
 
 func TestParseGatewayRequest_MaxTokens(t *testing.T) {
 	body := []byte(`{"model":"claude-haiku-4-5","max_tokens":1}`)
-	parsed, err := ParseGatewayRequest(body, "")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.NoError(t, err)
 	require.Equal(t, 1, parsed.MaxTokens)
 }
 
 func TestParseGatewayRequest_MaxTokensNonIntegralIgnored(t *testing.T) {
 	body := []byte(`{"model":"claude-haiku-4-5","max_tokens":1.5}`)
-	parsed, err := ParseGatewayRequest(body, "")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.NoError(t, err)
 	require.Equal(t, 0, parsed.MaxTokens)
 }
 
 func TestParseGatewayRequest_SystemNull(t *testing.T) {
 	body := []byte(`{"model":"claude-3","system":null}`)
-	parsed, err := ParseGatewayRequest(body, "")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.NoError(t, err)
 	// 显式传入 system:null 也应视为“字段已存在”，避免默认 system 被注入。
 	require.True(t, parsed.HasSystem)
@@ -66,13 +66,13 @@ func TestParseGatewayRequest_SystemNull(t *testing.T) {
 
 func TestParseGatewayRequest_InvalidModelType(t *testing.T) {
 	body := []byte(`{"model":123}`)
-	_, err := ParseGatewayRequest(body, "")
+	_, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.Error(t, err)
 }
 
 func TestParseGatewayRequest_InvalidStreamType(t *testing.T) {
 	body := []byte(`{"stream":"true"}`)
-	_, err := ParseGatewayRequest(body, "")
+	_, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 	require.Error(t, err)
 }
 
@@ -86,7 +86,7 @@ func TestParseGatewayRequest_GeminiContents(t *testing.T) {
 			{"role": "user", "parts": [{"text": "How are you?"}]}
 		]
 	}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformGemini)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.Len(t, parsed.Messages, 3, "should parse contents as Messages")
 	require.False(t, parsed.HasSystem, "Gemini format should not set HasSystem")
@@ -102,7 +102,7 @@ func TestParseGatewayRequest_GeminiSystemInstruction(t *testing.T) {
 			{"role": "user", "parts": [{"text": "Hello"}]}
 		]
 	}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformGemini)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.NotNil(t, parsed.System, "should parse systemInstruction.parts as System")
 	parts, ok := parsed.System.([]any)
@@ -119,7 +119,7 @@ func TestParseGatewayRequest_GeminiWithModel(t *testing.T) {
 		"model": "gemini-2.5-pro",
 		"contents": [{"role": "user", "parts": [{"text": "test"}]}]
 	}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformGemini)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.Equal(t, "gemini-2.5-pro", parsed.Model)
 	require.Len(t, parsed.Messages, 1)
@@ -132,7 +132,7 @@ func TestParseGatewayRequest_GeminiIgnoresAnthropicFields(t *testing.T) {
 		"messages": [{"role": "user", "content": "ignored"}],
 		"contents": [{"role": "user", "parts": [{"text": "real content"}]}]
 	}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformGemini)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.False(t, parsed.HasSystem, "Gemini protocol should not parse Anthropic system field")
 	require.Nil(t, parsed.System, "no systemInstruction = nil System")
@@ -141,14 +141,14 @@ func TestParseGatewayRequest_GeminiIgnoresAnthropicFields(t *testing.T) {
 
 func TestParseGatewayRequest_GeminiEmptyContents(t *testing.T) {
 	body := []byte(`{"contents": []}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformGemini)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.Empty(t, parsed.Messages)
 }
 
 func TestParseGatewayRequest_GeminiNoContents(t *testing.T) {
 	body := []byte(`{"model": "gemini-2.5-flash"}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformGemini)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
 	require.NoError(t, err)
 	require.Nil(t, parsed.Messages)
 	require.Equal(t, "gemini-2.5-flash", parsed.Model)
@@ -162,7 +162,7 @@ func TestParseGatewayRequest_AnthropicIgnoresGeminiFields(t *testing.T) {
 		"contents": [{"role": "user", "parts": [{"text": "ignored"}]}],
 		"systemInstruction": {"parts": [{"text": "ignored"}]}
 	}`)
-	parsed, err := ParseGatewayRequest(body, domain.PlatformAnthropic)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformAnthropic)
 	require.NoError(t, err)
 	require.True(t, parsed.HasSystem)
 	require.Equal(t, "real system", parsed.System)
@@ -897,7 +897,7 @@ func TestParseGatewayRequest_TypeValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseGatewayRequest([]byte(tt.body), "")
+			_, err := ParseGatewayRequest(NewRequestBodyRef([]byte(tt.body)), "")
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errSubstr != "" {
@@ -959,7 +959,7 @@ func TestParseGatewayRequest_OptionalFieldsMissing(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, err := ParseGatewayRequest([]byte(tt.body), "")
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(tt.body)), "")
 			require.NoError(t, err)
 
 			require.Equal(t, tt.wantModel, parsed.Model)
@@ -1023,7 +1023,7 @@ func TestParseGatewayRequest_MaxTokensBoundary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, err := ParseGatewayRequest([]byte(tt.body), "")
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(tt.body)), "")
 			if tt.wantErr {
 				require.Error(t, err)
 				return
@@ -1040,7 +1040,7 @@ func TestParseGatewayRequest_MaxTokensBoundary(t *testing.T) {
 // 核心路径：先 Unmarshal 到 map[string]any，再逐字段提取。
 func parseGatewayRequestOld(body []byte, protocol string) (*ParsedRequest, error) {
 	parsed := &ParsedRequest{
-		Body: body,
+		Body: NewRequestBodyRef(body),
 	}
 
 	var req map[string]any
@@ -1151,7 +1151,7 @@ func BenchmarkParseGatewayRequest_New_Small(b *testing.B) {
 	b.SetBytes(int64(len(data)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = ParseGatewayRequest(data, "")
+		_, _ = ParseGatewayRequest(NewRequestBodyRef(data), "")
 	}
 }
 
@@ -1203,7 +1203,7 @@ func TestParseGatewayRequest_OutputEffort(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			parsed, err := ParseGatewayRequest([]byte(tt.body), "")
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(tt.body)), "")
 			require.NoError(t, err)
 			require.Equal(t, tt.wantEffort, parsed.OutputEffort)
 		})
@@ -1245,6 +1245,6 @@ func BenchmarkParseGatewayRequest_New_Large(b *testing.B) {
 	b.SetBytes(int64(len(data)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = ParseGatewayRequest(data, "")
+		_, _ = ParseGatewayRequest(NewRequestBodyRef(data), "")
 	}
 }

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4400,12 +4400,12 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	}
 
 	// Web Search 模拟：纯 web_search 请求时，直接调用搜索 API 构造响应
-	if account != nil && s.shouldEmulateWebSearch(ctx, account, parsed.GroupID, parsed.Body) {
+	if account != nil && s.shouldEmulateWebSearch(ctx, account, parsed.GroupID, parsed.Body.Bytes()) {
 		return s.handleWebSearchEmulation(ctx, c, account, parsed)
 	}
 
 	if account != nil && account.IsAnthropicAPIKeyPassthroughEnabled() {
-		passthroughBody := parsed.Body
+		passthroughBody := parsed.Body.Bytes()
 		passthroughModel := parsed.Model
 		if passthroughModel != "" {
 			if mappedModel := account.GetMappedModel(passthroughModel); mappedModel != passthroughModel {
@@ -4441,7 +4441,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		c.Set(betaPolicyFilterSetKey, filterSet)
 	}
 
-	body := parsed.Body
+	body := parsed.Body.Bytes()
 	reqModel := parsed.Model
 	reqStream := parsed.Stream
 	originalModel := reqModel
@@ -5735,7 +5735,7 @@ func (s *GatewayService) forwardBedrock(
 ) (*ForwardResult, error) {
 	reqModel := parsed.Model
 	reqStream := parsed.Stream
-	body := parsed.Body
+	body := parsed.Body.Bytes()
 
 	region := bedrockRuntimeRegion(account)
 	mappedModel, ok := ResolveBedrockModelID(account, reqModel)
@@ -9172,7 +9172,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	}
 
 	if account != nil && account.IsAnthropicAPIKeyPassthroughEnabled() {
-		passthroughBody := parsed.Body
+		passthroughBody := parsed.Body.Bytes()
 		if reqModel := parsed.Model; reqModel != "" {
 			if mappedModel := account.GetMappedModel(reqModel); mappedModel != reqModel {
 				passthroughBody = s.replaceModelInBody(passthroughBody, mappedModel)
@@ -9188,7 +9188,7 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 		return nil
 	}
 
-	body := parsed.Body
+	body := parsed.Body.Bytes()
 	reqModel := parsed.Model
 
 	// Pre-filter: strip empty text blocks to prevent upstream 400.

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4729,6 +4729,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 						if retryErr == nil {
 							if retryResp.StatusCode < 400 {
 								// 重试请求被上游接受后同步 ParsedRequest，保证 usage/日志看到真实请求体。
+								lastWireBody = retryWireBody
 								if err := replaceBody(retryWireBody); err != nil {
 									_ = retryResp.Body.Close()
 									return nil, err
@@ -4769,6 +4770,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 										if retryErr2 == nil {
 											if retryResp2.StatusCode < 400 {
 												// 二阶段工具块降级成功时也必须更新当前 body。
+												lastWireBody = retryWireBody2
 												if err := replaceBody(retryWireBody2); err != nil {
 													_ = retryResp2.Body.Close()
 													return nil, err
@@ -4847,6 +4849,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 							if retryErr == nil {
 								if budgetRetryResp.StatusCode < 400 {
 									// budget 修正请求成功后，ParsedRequest 也要描述被接受的修正版。
+									lastWireBody = budgetWireBody
 									if err := replaceBody(budgetWireBody); err != nil {
 										_ = budgetRetryResp.Body.Close()
 										return nil, err
@@ -8228,10 +8231,10 @@ func (s *GatewayService) getUserGroupRateMultiplier(ctx context.Context, userID,
 	return resolver.Resolve(ctx, userID, groupID, groupDefaultMultiplier)
 }
 
-// RecordUsageInput 记录使用量的输入参数
+// RecordUsageInput 记录使用量的输入参数。
+// 异步 worker 只接收计费所需快照，不能持有 ParsedRequest/RequestBodyRef 这类大请求体引用。
 type RecordUsageInput struct {
 	Result             *ForwardResult
-	ParsedRequest      *ParsedRequest
 	APIKey             *APIKey
 	User               *User
 	Account            *Account
@@ -8709,15 +8712,8 @@ func writeUsageLogBestEffort(ctx context.Context, repo UsageLogRepository, usage
 	}
 }
 
-// recordUsageOpts 内部选项，参数化 RecordUsage 与 RecordUsageWithLongContext 的差异点。
+// recordUsageOpts 内部选项，参数化普通计费与长上下文计费的差异点。
 type recordUsageOpts struct {
-	// Claude Max 策略所需的 ParsedRequest（可选，仅 Claude 路径传入）
-	ParsedRequest *ParsedRequest
-
-	// EnableClaudePath 启用 Claude 路径特有逻辑：
-	// - Claude Max 缓存计费策略
-	EnableClaudePath bool
-
 	// 长上下文计费（仅 Gemini 路径需要）
 	LongContextThreshold  int
 	LongContextMultiplier float64
@@ -8740,9 +8736,7 @@ func (s *GatewayService) RecordUsage(ctx context.Context, input *RecordUsageInpu
 		APIKeyService:      input.APIKeyService,
 		QuotaPlatform:      input.QuotaPlatform,
 		ChannelUsageFields: input.ChannelUsageFields,
-	}, &recordUsageOpts{
-		EnableClaudePath: true,
-	})
+	}, &recordUsageOpts{})
 }
 
 // RecordUsageLongContextInput 记录使用量的输入参数（支持长上下文双倍计费）
@@ -8808,9 +8802,7 @@ type recordUsageCoreInput struct {
 }
 
 // recordUsageCore 是 RecordUsage 和 RecordUsageWithLongContext 的统一实现。
-// opts 中的字段控制两者之间的差异行为：
-// - ParsedRequest != nil → 启用 Claude Max 缓存计费策略
-// - LongContextThreshold > 0 → Token 计费回退走 CalculateCostWithLongContext
+// LongContextThreshold > 0 时 Token 计费回退走 CalculateCostWithLongContext。
 func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsageCoreInput, opts *recordUsageOpts) error {
 	result := input.Result
 	apiKey := input.APIKey

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -748,31 +748,10 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 		_, _ = combined.WriteString(strconv.FormatInt(parsed.SessionContext.APIKeyID, 10))
 		_, _ = combined.WriteString("|")
 	}
-	if parsed.System != nil {
-		systemText := s.extractTextFromSystem(parsed.System)
-		if systemText != "" {
-			_, _ = combined.WriteString(systemText)
-		}
+	if systemText := extractTextFromSystemRaw(parsed.SystemRaw()); systemText != "" {
+		_, _ = combined.WriteString(systemText)
 	}
-	for _, msg := range parsed.Messages {
-		if m, ok := msg.(map[string]any); ok {
-			if content, exists := m["content"]; exists {
-				// Anthropic: messages[].content
-				if msgText := s.extractTextFromContent(content); msgText != "" {
-					_, _ = combined.WriteString(msgText)
-				}
-			} else if parts, ok := m["parts"].([]any); ok {
-				// Gemini: contents[].parts[].text
-				for _, part := range parts {
-					if partMap, ok := part.(map[string]any); ok {
-						if text, ok := partMap["text"].(string); ok {
-							_, _ = combined.WriteString(text)
-						}
-					}
-				}
-			}
-		}
-	}
+	appendMessageTextsFromRaw(&combined, parsed.MessagesRaw())
 	if combined.Len() > 0 {
 		hash := s.hashContent(combined.String())
 		slog.Info("sticky.hash_source",
@@ -847,80 +826,125 @@ func (s *GatewayService) extractCacheableContent(parsed *ParsedRequest) string {
 		return ""
 	}
 
-	var builder strings.Builder
-
-	// 检查 system 中的 cacheable 内容
-	if system, ok := parsed.System.([]any); ok {
-		for _, part := range system {
-			if partMap, ok := part.(map[string]any); ok {
-				if cc, ok := partMap["cache_control"].(map[string]any); ok {
-					if cc["type"] == "ephemeral" {
-						if text, ok := partMap["text"].(string); ok {
-							_, _ = builder.WriteString(text)
-						}
-					}
-				}
-			}
-		}
+	systemText := extractCacheableTextFromSystemRaw(parsed.SystemRaw())
+	if messageText := extractCacheableTextFromMessagesRaw(parsed.MessagesRaw()); messageText != "" {
+		return messageText
 	}
-	systemText := builder.String()
-
-	// 检查 messages 中的 cacheable 内容
-	for _, msg := range parsed.Messages {
-		if msgMap, ok := msg.(map[string]any); ok {
-			if msgContent, ok := msgMap["content"].([]any); ok {
-				for _, part := range msgContent {
-					if partMap, ok := part.(map[string]any); ok {
-						if cc, ok := partMap["cache_control"].(map[string]any); ok {
-							if cc["type"] == "ephemeral" {
-								return s.extractTextFromContent(msgMap["content"])
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
 	return systemText
 }
 
-func (s *GatewayService) extractTextFromSystem(system any) string {
-	switch v := system.(type) {
-	case string:
-		return v
-	case []any:
-		var texts []string
-		for _, part := range v {
-			if partMap, ok := part.(map[string]any); ok {
-				if text, ok := partMap["text"].(string); ok {
-					texts = append(texts, text)
-				}
-			}
+func extractTextFromSystemRaw(raw []byte) string {
+	system := gjson.ParseBytes(raw)
+	switch system.Type {
+	case gjson.String:
+		return system.String()
+	case gjson.JSON:
+		if !system.IsArray() {
+			return ""
 		}
-		return strings.Join(texts, "")
+		var builder strings.Builder
+		system.ForEach(func(_, part gjson.Result) bool {
+			if text := part.Get("text").String(); text != "" {
+				_, _ = builder.WriteString(text)
+			}
+			return true
+		})
+		return builder.String()
 	}
 	return ""
 }
 
-func (s *GatewayService) extractTextFromContent(content any) string {
-	switch v := content.(type) {
-	case string:
-		return v
-	case []any:
-		var texts []string
-		for _, part := range v {
-			if partMap, ok := part.(map[string]any); ok {
-				if partMap["type"] == "text" {
-					if text, ok := partMap["text"].(string); ok {
-						texts = append(texts, text)
-					}
+func extractTextFromContentRaw(content gjson.Result) string {
+	switch content.Type {
+	case gjson.String:
+		return content.String()
+	case gjson.JSON:
+		if !content.IsArray() {
+			return ""
+		}
+		var builder strings.Builder
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("type").String() == "text" {
+				if text := part.Get("text").String(); text != "" {
+					_, _ = builder.WriteString(text)
 				}
 			}
-		}
-		return strings.Join(texts, "")
+			return true
+		})
+		return builder.String()
 	}
 	return ""
+}
+
+func appendMessageTextsFromRaw(builder *strings.Builder, raw []byte) {
+	if builder == nil || len(raw) == 0 {
+		return
+	}
+	messages := gjson.ParseBytes(raw)
+	if !messages.IsArray() {
+		return
+	}
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		if content := msg.Get("content"); content.Exists() {
+			_, _ = builder.WriteString(extractTextFromContentRaw(content))
+			return true
+		}
+		parts := msg.Get("parts")
+		if parts.IsArray() {
+			parts.ForEach(func(_, part gjson.Result) bool {
+				if text := part.Get("text").String(); text != "" {
+					_, _ = builder.WriteString(text)
+				}
+				return true
+			})
+		}
+		return true
+	})
+}
+
+func extractCacheableTextFromSystemRaw(raw []byte) string {
+	system := gjson.ParseBytes(raw)
+	if !system.IsArray() {
+		return ""
+	}
+	var builder strings.Builder
+	system.ForEach(func(_, part gjson.Result) bool {
+		if part.Get("cache_control.type").String() == "ephemeral" {
+			if text := part.Get("text").String(); text != "" {
+				_, _ = builder.WriteString(text)
+			}
+		}
+		return true
+	})
+	return builder.String()
+}
+
+func extractCacheableTextFromMessagesRaw(raw []byte) string {
+	messages := gjson.ParseBytes(raw)
+	if !messages.IsArray() {
+		return ""
+	}
+	var text string
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		content := msg.Get("content")
+		if !content.IsArray() {
+			return true
+		}
+		found := false
+		content.ForEach(func(_, part gjson.Result) bool {
+			if part.Get("cache_control.type").String() == "ephemeral" {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			text = extractTextFromContentRaw(content)
+			return false
+		}
+		return true
+	})
+	return text
 }
 
 func (s *GatewayService) hashContent(content string) string {
@@ -1284,7 +1308,7 @@ func (s *GatewayService) applyClaudeCodeOAuthMimicryToBody(
 
 	systemRewritten := false
 	if !strings.Contains(strings.ToLower(model), "haiku") {
-		body = rewriteSystemForNonClaudeCode(body, systemRaw)
+		body = rewriteSystemForNonClaudeCode(body, normalizeSystemParam(systemRaw))
 		systemRewritten = true
 	}
 
@@ -4474,7 +4498,8 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		// Parrot 的 transform_request 从不检查客户端 system 内容，直接覆盖。
 		systemRewritten := false
 		if !strings.Contains(strings.ToLower(reqModel), "haiku") {
-			body = rewriteSystemForNonClaudeCode(body, parsed.System)
+			systemRaw, _ := parsed.SystemValue()
+			body = rewriteSystemForNonClaudeCode(body, systemRaw)
 			systemRewritten = true
 		}
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -23,6 +23,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"unsafe"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
@@ -56,6 +57,8 @@ const (
 	defaultModelsListCacheTTL    = 15 * time.Second
 	postUsageBillingTimeout      = 15 * time.Second
 	debugGatewayBodyEnv          = "SUB2API_DEBUG_GATEWAY_BODY"
+	// 上游错误体只需要提取错误 JSON/日志摘要，默认 512KiB 避免错误风暴叠加大请求体。
+	gatewayUpstreamErrorBodyReadLimit int64 = 512 << 10
 )
 
 const (
@@ -833,8 +836,16 @@ func (s *GatewayService) extractCacheableContent(parsed *ParsedRequest) string {
 	return systemText
 }
 
+func parseRawJSONView(raw []byte) gjson.Result {
+	if len(raw) == 0 {
+		return gjson.Result{}
+	}
+	// 这里只做同步只读解析，避免 gjson.ParseBytes 为大 messages/contents 复制整段 raw。
+	return gjson.Parse(*(*string)(unsafe.Pointer(&raw)))
+}
+
 func extractTextFromSystemRaw(raw []byte) string {
-	system := gjson.ParseBytes(raw)
+	system := parseRawJSONView(raw)
 	switch system.Type {
 	case gjson.String:
 		return system.String()
@@ -880,7 +891,7 @@ func appendMessageTextsFromRaw(builder *strings.Builder, raw []byte) {
 	if builder == nil || len(raw) == 0 {
 		return
 	}
-	messages := gjson.ParseBytes(raw)
+	messages := parseRawJSONView(raw)
 	if !messages.IsArray() {
 		return
 	}
@@ -903,7 +914,7 @@ func appendMessageTextsFromRaw(builder *strings.Builder, raw []byte) {
 }
 
 func extractCacheableTextFromSystemRaw(raw []byte) string {
-	system := gjson.ParseBytes(raw)
+	system := parseRawJSONView(raw)
 	if !system.IsArray() {
 		return ""
 	}
@@ -920,7 +931,7 @@ func extractCacheableTextFromSystemRaw(raw []byte) string {
 }
 
 func extractCacheableTextFromMessagesRaw(raw []byte) string {
-	messages := gjson.ParseBytes(raw)
+	messages := parseRawJSONView(raw)
 	if !messages.IsArray() {
 		return ""
 	}
@@ -4676,7 +4687,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 		// 优先检测thinking block签名错误（400）并重试一次
 		if resp.StatusCode == 400 {
-			respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody, readErr := s.readUpstreamErrorBody(resp)
 			if readErr == nil {
 				_ = resp.Body.Close()
 
@@ -4739,7 +4750,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 								break
 							}
 
-							retryRespBody, retryReadErr := io.ReadAll(io.LimitReader(retryResp.Body, 2<<20))
+							retryRespBody, retryReadErr := s.readUpstreamErrorBody(retryResp)
 							_ = retryResp.Body.Close()
 							if retryReadErr == nil && retryResp.StatusCode == 400 && s.isSignatureErrorPattern(ctx, account, retryRespBody) {
 								appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
@@ -4889,7 +4900,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					break
 				}
 
-				respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+				respBody, _ := s.readUpstreamErrorBody(resp)
 				_ = resp.Body.Close()
 				appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 					Platform:           account.Platform,
@@ -4936,7 +4947,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	// 处理重试耗尽的情况
 	if resp.StatusCode >= 400 && s.shouldRetryUpstreamError(account, resp.StatusCode) {
 		if s.shouldFailoverUpstreamError(resp.StatusCode) {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody, _ := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -4971,7 +4982,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 	// 处理可切换账号的错误
 	if resp.StatusCode >= 400 && s.shouldFailoverUpstreamError(resp.StatusCode) {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -5003,7 +5014,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	if resp.StatusCode >= 400 {
 		// 可选：对部分 400 触发 failover（默认关闭以保持语义）
 		if resp.StatusCode == 400 && s.cfg != nil && s.cfg.Gateway.FailoverOn400 {
-			respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody, readErr := s.readUpstreamErrorBody(resp)
 			if readErr != nil {
 				// ReadAll failed, fall back to normal error handling without consuming the stream
 				return s.handleErrorResponse(ctx, resp, c, account, reqModel)
@@ -5221,7 +5232,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 					break
 				}
 
-				respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+				respBody, _ := s.readUpstreamErrorBody(resp)
 				_ = resp.Body.Close()
 				appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 					Platform:           account.Platform,
@@ -5259,7 +5270,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 
 	if resp.StatusCode >= 400 && s.shouldRetryUpstreamError(account, resp.StatusCode) {
 		if s.shouldFailoverUpstreamError(resp.StatusCode) {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody, _ := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -5293,7 +5304,7 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	}
 
 	if resp.StatusCode >= 400 && s.shouldFailoverUpstreamError(resp.StatusCode) {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -6011,7 +6022,7 @@ func (s *GatewayService) executeBedrockUpstream(
 					break
 				}
 
-				respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+				respBody, _ := s.readUpstreamErrorBody(resp)
 				_ = resp.Body.Close()
 				appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 					Platform:           account.Platform,
@@ -6056,7 +6067,7 @@ func (s *GatewayService) handleBedrockUpstreamErrors(
 	// retry exhausted + failover
 	if s.shouldRetryUpstreamError(account, resp.StatusCode) {
 		if s.shouldFailoverUpstreamError(resp.StatusCode) {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody, _ := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -6083,7 +6094,7 @@ func (s *GatewayService) handleBedrockUpstreamErrors(
 
 	// non-retryable failover
 	if s.shouldFailoverUpstreamError(resp.StatusCode) {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody, _ := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -7226,8 +7237,19 @@ func isCountTokensUnsupported404(statusCode int, body []byte) bool {
 	return strings.Contains(msg, "count_tokens") && strings.Contains(msg, "not found")
 }
 
+func (s *GatewayService) readUpstreamErrorBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, nil
+	}
+	limit := gatewayUpstreamErrorBodyReadLimit
+	if s != nil && s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody && s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes > int(limit) {
+		limit = int64(s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, limit))
+}
+
 func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, requestedModel ...string) (*ForwardResult, error) {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body, _ := s.readUpstreamErrorBody(resp)
 
 	// 调试日志：打印上游错误响应
 	logger.LegacyPrintf("service.gateway", "[Forward] Upstream error (non-retryable): Account=%d(%s) Status=%d RequestID=%s Body=%s",
@@ -7380,7 +7402,7 @@ func (s *GatewayService) handleErrorResponse(ctx context.Context, resp *http.Res
 }
 
 func (s *GatewayService) handleRetryExhaustedSideEffects(ctx context.Context, resp *http.Response, account *Account) {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body, _ := s.readUpstreamErrorBody(resp)
 	statusCode := resp.StatusCode
 
 	// OAuth/Setup Token 账号的 403：标记账号异常
@@ -7394,7 +7416,7 @@ func (s *GatewayService) handleRetryExhaustedSideEffects(ctx context.Context, re
 }
 
 func (s *GatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, requestedModel ...string) {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body, _ := s.readUpstreamErrorBody(resp)
 	if len(requestedModel) > 0 {
 		s.rateLimitService.HandleUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, requestedModel[0])
 		return
@@ -7407,7 +7429,7 @@ func (s *GatewayService) handleFailoverSideEffects(ctx context.Context, resp *ht
 // API Key 未配置错误码：仅返回错误，不标记账号
 func (s *GatewayService) handleRetryExhaustedError(ctx context.Context, resp *http.Response, c *gin.Context, account *Account) (*ForwardResult, error) {
 	// Capture upstream error body before side-effects consume the stream.
-	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	respBody, _ := s.readUpstreamErrorBody(resp)
 	_ = resp.Body.Close()
 	resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4440,6 +4440,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		}
 		return s.forwardAnthropicAPIKeyPassthroughWithInput(ctx, c, account, anthropicPassthroughForwardInput{
 			Body:          passthroughBody,
+			Parsed:        parsed,
 			RequestModel:  passthroughModel,
 			OriginalModel: parsed.Model,
 			RequestStream: parsed.Stream,
@@ -4466,6 +4467,13 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	}
 
 	body := parsed.Body.Bytes()
+	replaceBody := func(next []byte) error {
+		if err := parsed.ReplaceBody(next); err != nil {
+			return fmt.Errorf("rewrite request body: %w", err)
+		}
+		body = parsed.Body.Bytes()
+		return nil
+	}
 	reqModel := parsed.Model
 	reqStream := parsed.Stream
 	originalModel := reqModel
@@ -4499,7 +4507,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		systemRewritten := false
 		if !strings.Contains(strings.ToLower(reqModel), "haiku") {
 			systemRaw, _ := parsed.SystemValue()
-			body = rewriteSystemForNonClaudeCode(body, systemRaw)
+			if err := replaceBody(rewriteSystemForNonClaudeCode(body, systemRaw)); err != nil {
+				return nil, err
+			}
 			systemRewritten = true
 		}
 
@@ -4521,22 +4531,34 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 			}
 		}
 
-		body, reqModel = normalizeClaudeOAuthRequestBody(body, reqModel, normalizeOpts)
+		var normalizedBody []byte
+		normalizedBody, reqModel = normalizeClaudeOAuthRequestBody(body, reqModel, normalizeOpts)
+		if err := replaceBody(normalizedBody); err != nil {
+			return nil, err
+		}
 
 		// D/E/F: 可选 messages cache 策略 + 工具名混淆 + tools[-1] 断点
 		// 与 forward_as_chat_completions / forward_as_responses 路径对齐，
 		// 原生 /v1/messages 路径也走同一套可配置字段级改写。
-		body = s.rewriteMessageCacheControlIfEnabled(ctx, body)
+		if err := replaceBody(s.rewriteMessageCacheControlIfEnabled(ctx, body)); err != nil {
+			return nil, err
+		}
 		if rw := buildToolNameRewriteFromBody(body); rw != nil {
-			body = applyToolNameRewriteToBody(body, rw)
+			if err := replaceBody(applyToolNameRewriteToBody(body, rw)); err != nil {
+				return nil, err
+			}
 			c.Set(toolNameRewriteKey, rw)
 		} else {
-			body = applyToolsLastCacheBreakpoint(body)
+			if err := replaceBody(applyToolsLastCacheBreakpoint(body)); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	// 强制执行 cache_control 块数量限制（最多 4 个）
-	body = enforceCacheControlLimit(body)
+	if err := replaceBody(enforceCacheControlLimit(body)); err != nil {
+		return nil, err
+	}
 
 	// 应用模型映射：
 	// - APIKey 账号：使用账号级别的显式映射（如果配置），否则透传原始模型名
@@ -4570,13 +4592,18 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	}
 	if mappedModel != reqModel {
 		// 替换请求体中的模型名
-		body = s.replaceModelInBody(body, mappedModel)
+		if err := replaceBody(s.replaceModelInBody(body, mappedModel)); err != nil {
+			return nil, err
+		}
 		reqModel = mappedModel
+		parsed.Model = mappedModel
 		logger.LegacyPrintf("service.gateway", "Model mapping applied: %s -> %s (account: %s, source=%s)", originalModel, mappedModel, account.Name, mappingSource)
 	}
 
 	if s.shouldInjectAnthropicCacheTTL1h(ctx, account) {
-		body = injectAnthropicCacheControlTTL1h(body)
+		if err := replaceBody(injectAnthropicCacheControlTTL1h(body)); err != nil {
+			return nil, err
+		}
 	}
 
 	// 获取凭证
@@ -4600,19 +4627,24 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	logger.LegacyPrintf("service.gateway", "[Forward] Using account: ID=%d Name=%s Platform=%s Type=%s TLSFingerprint=%v Proxy=%s",
 		account.ID, account.Name, account.Platform, account.Type, tlsProfile, proxyURL)
 	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
-	body = StripEmptyTextBlocks(body)
+	if err := replaceBody(StripEmptyTextBlocks(body)); err != nil {
+		return nil, err
+	}
 
 	// 重试循环
 	var resp *http.Response
+	lastWireBody := body
 	retryStart := time.Now()
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		// 构建上游请求（每次重试需要重新构建，因为请求体需要重新读取）
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
-		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
+		upstreamReq, wireBody, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 		releaseUpstreamCtx()
 		if err != nil {
 			return nil, err
 		}
+		// 记录本次实际发送的 wire body；只有请求成功后才写回 ParsedRequest，避免 400 retry 基于已签名 CCH 再改写。
+		lastWireBody = wireBody
 
 		// 发送请求
 		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
@@ -4690,12 +4722,17 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 					filteredBody := FilterThinkingBlocksForRetry(body)
 					retryCtx, releaseRetryCtx := detachStreamUpstreamContext(ctx, reqStream)
-					retryReq, buildErr := s.buildUpstreamRequest(retryCtx, c, account, filteredBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
+					retryReq, retryWireBody, buildErr := s.buildUpstreamRequest(retryCtx, c, account, filteredBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 					releaseRetryCtx()
 					if buildErr == nil {
 						retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
 						if retryErr == nil {
 							if retryResp.StatusCode < 400 {
+								// 重试请求被上游接受后同步 ParsedRequest，保证 usage/日志看到真实请求体。
+								if err := replaceBody(retryWireBody); err != nil {
+									_ = retryResp.Body.Close()
+									return nil, err
+								}
 								logger.LegacyPrintf("service.gateway", "Account %d: thinking block retry succeeded (blocks downgraded)", account.ID)
 								resp = retryResp
 								break
@@ -4725,11 +4762,18 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 									logger.LegacyPrintf("service.gateway", "Account %d: signature retry still failing and looks tool-related, retrying with tool blocks downgraded", account.ID)
 									filteredBody2 := FilterSignatureSensitiveBlocksForRetry(body)
 									retryCtx2, releaseRetryCtx2 := detachStreamUpstreamContext(ctx, reqStream)
-									retryReq2, buildErr2 := s.buildUpstreamRequest(retryCtx2, c, account, filteredBody2, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
+									retryReq2, retryWireBody2, buildErr2 := s.buildUpstreamRequest(retryCtx2, c, account, filteredBody2, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 									releaseRetryCtx2()
 									if buildErr2 == nil {
 										retryResp2, retryErr2 := s.httpUpstream.DoWithTLS(retryReq2, proxyURL, account.ID, account.Concurrency, tlsProfile)
 										if retryErr2 == nil {
+											if retryResp2.StatusCode < 400 {
+												// 二阶段工具块降级成功时也必须更新当前 body。
+												if err := replaceBody(retryWireBody2); err != nil {
+													_ = retryResp2.Body.Close()
+													return nil, err
+												}
+											}
 											resp = retryResp2
 											break
 										}
@@ -4796,11 +4840,18 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					if applied && time.Since(retryStart) < maxRetryElapsed {
 						logger.LegacyPrintf("service.gateway", "Account %d: detected budget_tokens constraint error, retrying with rectified budget (budget_tokens=%d, max_tokens=%d)", account.ID, BudgetRectifyBudgetTokens, BudgetRectifyMaxTokens)
 						budgetRetryCtx, releaseBudgetRetryCtx := detachStreamUpstreamContext(ctx, reqStream)
-						budgetRetryReq, buildErr := s.buildUpstreamRequest(budgetRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
+						budgetRetryReq, budgetWireBody, buildErr := s.buildUpstreamRequest(budgetRetryCtx, c, account, rectifiedBody, token, tokenType, reqModel, reqStream, shouldMimicClaudeCode)
 						releaseBudgetRetryCtx()
 						if buildErr == nil {
 							budgetRetryResp, retryErr := s.httpUpstream.DoWithTLS(budgetRetryReq, proxyURL, account.ID, account.Concurrency, tlsProfile)
 							if retryErr == nil {
+								if budgetRetryResp.StatusCode < 400 {
+									// budget 修正请求成功后，ParsedRequest 也要描述被接受的修正版。
+									if err := replaceBody(budgetWireBody); err != nil {
+										_ = budgetRetryResp.Body.Close()
+										return nil, err
+									}
+								}
 								resp = budgetRetryResp
 								break
 							}
@@ -4997,6 +5048,13 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 	// 处理正常响应
 
+	if !bytes.Equal(lastWireBody, body) {
+		// 成功后再同步最终 wire body，避免失败重试从已签名 CCH 的 body 继续派生。
+		if err := replaceBody(lastWireBody); err != nil {
+			return nil, err
+		}
+	}
+
 	// 触发上游接受回调（提前释放串行锁，不等流完成）
 	if parsed.OnUpstreamAccepted != nil {
 		parsed.OnUpstreamAccepted()
@@ -5039,6 +5097,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 type anthropicPassthroughForwardInput struct {
 	Body          []byte
+	Parsed        *ParsedRequest
 	RequestModel  string
 	OriginalModel string
 	RequestStream bool
@@ -5091,15 +5150,28 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	}
 	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
 	input.Body = StripEmptyTextBlocks(input.Body)
+	if input.Parsed != nil {
+		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
+		if err := input.Parsed.ReplaceBody(input.Body); err != nil {
+			return nil, err
+		}
+	}
 
 	var resp *http.Response
 	retryStart := time.Now()
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, input.RequestStream)
-		upstreamReq, err := s.buildUpstreamRequestAnthropicAPIKeyPassthrough(upstreamCtx, c, account, input.Body, token)
+		upstreamReq, wireBody, err := s.buildUpstreamRequestAnthropicAPIKeyPassthrough(upstreamCtx, c, account, input.Body, token)
 		releaseUpstreamCtx()
 		if err != nil {
 			return nil, err
+		}
+		if input.Parsed != nil && !bytes.Equal(wireBody, input.Body) {
+			// build 阶段会按 beta 能力清理 body，发送前同步到 ParsedRequest 当前视图。
+			if err := input.Parsed.ReplaceBody(wireBody); err != nil {
+				return nil, err
+			}
+			input.Body = input.Parsed.Body.Bytes()
 		}
 
 		resp, err = s.httpUpstream.DoWithTLS(upstreamReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
@@ -5292,13 +5364,13 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 	account *Account,
 	body []byte,
 	token string,
-) (*http.Request, error) {
+) (*http.Request, []byte, error) {
 	targetURL := claudeAPIURL
 	baseURL := account.GetBaseURL()
 	if baseURL != "" {
 		validatedURL, err := s.validateUpstreamBaseURL(baseURL)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		targetURL = validatedURL + "/v1/messages?beta=true"
 	}
@@ -5316,7 +5388,7 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if c != nil && c.Request != nil {
@@ -5346,7 +5418,7 @@ func (s *GatewayService) buildUpstreamRequestAnthropicAPIKeyPassthrough(
 		setHeaderRaw(req.Header, "anthropic-version", "2023-06-01")
 	}
 
-	return req, nil
+	return req, body, nil
 }
 
 func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
@@ -5828,6 +5900,11 @@ func (s *GatewayService) forwardBedrock(
 		return s.handleBedrockUpstreamErrors(ctx, resp, c, account)
 	}
 
+	// Bedrock 分支绕过通用 Forward 成功路径，这里保持上游接受回调语义一致。
+	if parsed.OnUpstreamAccepted != nil {
+		parsed.OnUpstreamAccepted()
+	}
+
 	// 响应处理
 	var usage *ClaudeUsage
 	var firstTokenMs *int
@@ -6104,9 +6181,10 @@ func (s *GatewayService) handleBedrockNonStreamingResponse(
 	return usage, nil
 }
 
-func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token, tokenType, modelID string, reqStream bool, mimicClaudeCode bool) (*http.Request, error) {
+func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token, tokenType, modelID string, reqStream bool, mimicClaudeCode bool) (*http.Request, []byte, error) {
 	if account.Platform == PlatformAnthropic && account.Type == AccountTypeServiceAccount {
-		return s.buildUpstreamRequestAnthropicVertex(ctx, c, account, body, token, modelID, reqStream)
+		req, err := s.buildUpstreamRequestAnthropicVertex(ctx, c, account, body, token, modelID, reqStream)
+		return req, body, err
 	}
 
 	// 确定目标URL
@@ -6116,18 +6194,18 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 		if baseURL != "" {
 			validatedURL, err := s.validateUpstreamBaseURL(baseURL)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			targetURL = validatedURL + "/v1/messages?beta=true"
 		}
 	} else if account.IsCustomBaseURLEnabled() {
 		customURL := account.GetCustomBaseURL()
 		if customURL == "" {
-			return nil, fmt.Errorf("custom_base_url is enabled but not configured for account %d", account.ID)
+			return nil, nil, fmt.Errorf("custom_base_url is enabled but not configured for account %d", account.ID)
 		}
 		validatedURL, err := s.validateUpstreamBaseURL(customURL)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		targetURL = s.buildCustomRelayURL(validatedURL, "/v1/messages", account)
 	}
@@ -6202,7 +6280,7 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// 设置认证头（保持原始大小写）
@@ -6287,7 +6365,7 @@ func (s *GatewayService) buildUpstreamRequest(ctx context.Context, c *gin.Contex
 		logClaudeMimicDebug(req, body, account, tokenType, mimicClaudeCode)
 	}
 
-	return req, nil
+	return req, body, nil
 }
 
 func (s *GatewayService) buildUpstreamRequestAnthropicVertex(
@@ -9214,23 +9292,42 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	}
 
 	body := parsed.Body.Bytes()
+	replaceBody := func(next []byte) error {
+		if err := parsed.ReplaceBody(next); err != nil {
+			return fmt.Errorf("rewrite count_tokens body: %w", err)
+		}
+		body = parsed.Body.Bytes()
+		return nil
+	}
 	reqModel := parsed.Model
 
 	// Pre-filter: strip empty text blocks to prevent upstream 400.
-	body = StripEmptyTextBlocks(body)
+	if err := replaceBody(StripEmptyTextBlocks(body)); err != nil {
+		return err
+	}
 
 	isClaudeCodeCT := IsClaudeCodeClient(ctx) || isClaudeCodeClient(c.GetHeader("User-Agent"), parsed.MetadataUserID)
 	shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCodeCT
 
 	if shouldMimicClaudeCode {
 		normalizeOpts := claudeOAuthNormalizeOptions{stripSystemCacheControl: true}
-		body, reqModel = normalizeClaudeOAuthRequestBody(body, reqModel, normalizeOpts)
+		var normalizedBody []byte
+		normalizedBody, reqModel = normalizeClaudeOAuthRequestBody(body, reqModel, normalizeOpts)
+		if err := replaceBody(normalizedBody); err != nil {
+			return err
+		}
 
-		body = s.rewriteMessageCacheControlIfEnabled(ctx, body)
+		if err := replaceBody(s.rewriteMessageCacheControlIfEnabled(ctx, body)); err != nil {
+			return err
+		}
 		if rw := buildToolNameRewriteFromBody(body); rw != nil {
-			body = applyToolNameRewriteToBody(body, rw)
+			if err := replaceBody(applyToolNameRewriteToBody(body, rw)); err != nil {
+				return err
+			}
 		} else {
-			body = applyToolsLastCacheBreakpoint(body)
+			if err := replaceBody(applyToolsLastCacheBreakpoint(body)); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -9261,9 +9358,13 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 			}
 		}
 		if mappedModel != reqModel {
-			body = s.replaceModelInBody(body, mappedModel)
+			originalReqModel := reqModel
+			if err := replaceBody(s.replaceModelInBody(body, mappedModel)); err != nil {
+				return err
+			}
 			reqModel = mappedModel
-			logger.LegacyPrintf("service.gateway", "CountTokens model mapping applied: %s -> %s (account: %s, source=%s)", parsed.Model, mappedModel, account.Name, mappingSource)
+			parsed.Model = mappedModel
+			logger.LegacyPrintf("service.gateway", "CountTokens model mapping applied: %s -> %s (account: %s, source=%s)", originalReqModel, mappedModel, account.Name, mappingSource)
 		}
 	}
 
@@ -9275,11 +9376,13 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 	}
 
 	// 构建上游请求
-	upstreamReq, err := s.buildCountTokensRequest(ctx, c, account, body, token, tokenType, reqModel, shouldMimicClaudeCode)
+	upstreamReq, wireBody, err := s.buildCountTokensRequest(ctx, c, account, body, token, tokenType, reqModel, shouldMimicClaudeCode)
 	if err != nil {
 		s.countTokensError(c, http.StatusInternalServerError, "api_error", "Failed to build request")
 		return err
 	}
+	// 先记录首发 wire body；如果后面进入 400 retry，retry 会基于未签名的逻辑 body 重新构建。
+	acceptedWireBody := wireBody
 
 	// 获取代理URL（自定义 base URL 模式下，proxy 通过 buildCustomRelayURL 作为查询参数传递）
 	proxyURL := ""
@@ -9315,10 +9418,14 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 		logger.LegacyPrintf("service.gateway", "Account %d: detected thinking block signature error on count_tokens, retrying with filtered thinking blocks", account.ID)
 
 		filteredBody := FilterThinkingBlocksForRetry(body)
-		retryReq, buildErr := s.buildCountTokensRequest(ctx, c, account, filteredBody, token, tokenType, reqModel, shouldMimicClaudeCode)
+		retryReq, retryWireBody, buildErr := s.buildCountTokensRequest(ctx, c, account, filteredBody, token, tokenType, reqModel, shouldMimicClaudeCode)
 		if buildErr == nil {
 			retryResp, retryErr := s.httpUpstream.DoWithTLS(retryReq, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
 			if retryErr == nil {
+				if retryResp.StatusCode < 400 {
+					// count_tokens 签名重试成功后记录最终 wire body，错误响应仍保留原 body 便于后续处理。
+					acceptedWireBody = retryWireBody
+				}
 				resp = retryResp
 				respBody, err = ReadUpstreamResponseBody(resp.Body, s.cfg, c, countTokensTooLarge)
 				_ = resp.Body.Close()
@@ -9329,6 +9436,13 @@ func (s *GatewayService) ForwardCountTokens(ctx context.Context, c *gin.Context,
 					return err
 				}
 			}
+		}
+	}
+
+	if resp.StatusCode < 400 && !bytes.Equal(acceptedWireBody, body) {
+		// count_tokens 成功后再同步最终 wire body，避免 retry 从已签名 body 派生。
+		if err := replaceBody(acceptedWireBody); err != nil {
+			return err
 		}
 	}
 
@@ -9558,7 +9672,7 @@ func (s *GatewayService) buildCountTokensRequestAnthropicAPIKeyPassthrough(
 }
 
 // buildCountTokensRequest 构建 count_tokens 上游请求
-func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token, tokenType, modelID string, mimicClaudeCode bool) (*http.Request, error) {
+func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token, tokenType, modelID string, mimicClaudeCode bool) (*http.Request, []byte, error) {
 	// 确定目标 URL
 	targetURL := claudeAPICountTokensURL
 	if account.Type == AccountTypeAPIKey {
@@ -9566,18 +9680,18 @@ func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Con
 		if baseURL != "" {
 			validatedURL, err := s.validateUpstreamBaseURL(baseURL)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			targetURL = validatedURL + "/v1/messages/count_tokens?beta=true"
 		}
 	} else if account.IsCustomBaseURLEnabled() {
 		customURL := account.GetCustomBaseURL()
 		if customURL == "" {
-			return nil, fmt.Errorf("custom_base_url is enabled but not configured for account %d", account.ID)
+			return nil, nil, fmt.Errorf("custom_base_url is enabled but not configured for account %d", account.ID)
 		}
 		validatedURL, err := s.validateUpstreamBaseURL(customURL)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		targetURL = s.buildCustomRelayURL(validatedURL, "/v1/messages/count_tokens", account)
 	}
@@ -9633,7 +9747,7 @@ func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Con
 
 	req, err := http.NewRequestWithContext(ctx, "POST", targetURL, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// 设置认证头（保持原始大小写）
@@ -9697,7 +9811,7 @@ func (s *GatewayService) buildCountTokensRequest(ctx context.Context, c *gin.Con
 		logClaudeMimicDebug(req, body, account, tokenType, mimicClaudeCode)
 	}
 
-	return req, nil
+	return req, body, nil
 }
 
 func sanitizeCountTokensRequestBody(body []byte) []byte {

--- a/backend/internal/service/gateway_service_benchmark_test.go
+++ b/backend/internal/service/gateway_service_benchmark_test.go
@@ -124,6 +124,64 @@ func BenchmarkOpenAIResponses_LargeInputDecodeMap(b *testing.B) {
 	}
 }
 
+func BenchmarkOpenAIResponses_LargeInputRawPatch(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeOpenAIResponsesBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				view := newOpenAIRequestView(body)
+				view.MarkPatchSet("instructions", "You are a helpful coding assistant.")
+				view.MarkPatchSet("reasoning.effort", "none")
+				patched, err := view.ApplyPatches()
+				if err != nil {
+					b.Fatalf("应用 OpenAI raw patch 失败: %v", err)
+				}
+				benchmarkIntSink = len(patched)
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIResponses_LargeInputImageBillingRaw(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeOpenAIResponsesImageToolBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				cfg, err := resolveOpenAIResponsesImageBillingConfigDetailedFromBody(body, "gpt-5.4")
+				if err != nil {
+					b.Fatalf("解析 OpenAI 图片计费配置失败: %v", err)
+				}
+				benchmarkStringSink = cfg.Model + cfg.SizeTier + cfg.InputSize
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIResponses_LargeInputEmptyBase64Guard(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeOpenAIResponsesBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if openAIRequestBodyMayContainEmptyBase64InputImage(body) {
+					benchmarkIntSink++
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkOpenAIResponses_LargeInputFunctionCallValidation(b *testing.B) {
 	for _, size := range benchmarkBodySizes() {
 		b.Run(size.name, func(b *testing.B) {
@@ -260,6 +318,23 @@ func buildLargeOpenAIResponsesToolContinuationBody(targetBytes int) []byte {
 		builder.WriteString(strings.Repeat("tool output payload ", 48))
 		builder.WriteString(strconv.Itoa(i))
 		builder.WriteString(`"}`)
+	}
+	builder.WriteString(`]}`)
+	return []byte(builder.String())
+}
+
+func buildLargeOpenAIResponsesImageToolBody(targetBytes int) []byte {
+	var builder strings.Builder
+	builder.Grow(targetBytes + 1024)
+	builder.WriteString(`{"model":"gpt-5.4","stream":false,"tools":[{"type":"image_generation","model":"gpt-image-2","size":"2048x1152"}],"input":[`)
+	for i := 0; builder.Len() < targetBytes; i++ {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(`{"type":"message","role":"user","content":[{"type":"input_text","text":"`)
+		builder.WriteString(strings.Repeat("openai image billing payload ", 48))
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(`"}]}`)
 	}
 	builder.WriteString(`]}`)
 	return []byte(builder.String())

--- a/backend/internal/service/gateway_service_benchmark_test.go
+++ b/backend/internal/service/gateway_service_benchmark_test.go
@@ -14,7 +14,7 @@ func BenchmarkGenerateSessionHash_Metadata(b *testing.B) {
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		parsed, err := ParseGatewayRequest(body, "")
+		parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "")
 		if err != nil {
 			b.Fatalf("解析请求失败: %v", err)
 		}

--- a/backend/internal/service/gateway_service_benchmark_test.go
+++ b/backend/internal/service/gateway_service_benchmark_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -34,17 +35,20 @@ func BenchmarkExtractCacheableContent_System(b *testing.B) {
 }
 
 func buildSystemCacheableRequest(parts int) *ParsedRequest {
-	systemParts := make([]any, 0, parts)
+	var builder strings.Builder
+	builder.WriteString(`{"system":[`)
 	for i := 0; i < parts; i++ {
-		systemParts = append(systemParts, map[string]any{
-			"text": "system_part_" + strconv.Itoa(i),
-			"cache_control": map[string]any{
-				"type": "ephemeral",
-			},
-		})
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(`{"text":"system_part_`)
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(`","cache_control":{"type":"ephemeral"}}`)
 	}
-	return &ParsedRequest{
-		System:    systemParts,
-		HasSystem: true,
+	builder.WriteString(`]}`)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(builder.String())), "")
+	if err != nil {
+		panic(err)
 	}
+	return parsed
 }

--- a/backend/internal/service/gateway_service_benchmark_test.go
+++ b/backend/internal/service/gateway_service_benchmark_test.go
@@ -4,9 +4,14 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 )
 
-var benchmarkStringSink string
+var (
+	benchmarkStringSink string
+	benchmarkIntSink    int
+)
 
 // BenchmarkGenerateSessionHash_Metadata 关注 JSON 解析与正则匹配开销。
 func BenchmarkGenerateSessionHash_Metadata(b *testing.B) {
@@ -23,6 +28,121 @@ func BenchmarkGenerateSessionHash_Metadata(b *testing.B) {
 	}
 }
 
+func BenchmarkParseGatewayRequest_LargeAnthropicMessages(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeAnthropicMessagesBody(size.bytes, false)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformAnthropic)
+				if err != nil {
+					b.Fatalf("解析 Anthropic 请求失败: %v", err)
+				}
+				benchmarkIntSink = len(parsed.MessagesRaw())
+			}
+		})
+	}
+}
+
+func BenchmarkParseGatewayRequest_LargeGeminiContents(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeGeminiContentsBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformGemini)
+				if err != nil {
+					b.Fatalf("解析 Gemini 请求失败: %v", err)
+				}
+				benchmarkIntSink = len(parsed.MessagesRaw())
+			}
+		})
+	}
+}
+
+func BenchmarkGenerateSessionHash_LargeAnthropicMessages(b *testing.B) {
+	svc := &GatewayService{}
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeAnthropicMessagesBody(size.bytes, true)
+			parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), domain.PlatformAnthropic)
+			if err != nil {
+				b.Fatalf("解析请求失败: %v", err)
+			}
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkStringSink = svc.GenerateSessionHash(parsed)
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIResponses_LargeInputMeta(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeOpenAIResponsesBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				model, stream, promptCacheKey := extractOpenAIRequestMetaFromBody(body)
+				benchmarkStringSink = model + promptCacheKey
+				if stream {
+					benchmarkIntSink++
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIResponses_LargeInputDecodeMap(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeOpenAIResponsesBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reqBody, err := getOpenAIRequestBodyMap(nil, body)
+				if err != nil {
+					b.Fatalf("解析 OpenAI 请求失败: %v", err)
+				}
+				benchmarkIntSink = len(reqBody)
+			}
+		})
+	}
+}
+
+func BenchmarkOpenAIResponses_LargeInputFunctionCallValidation(b *testing.B) {
+	for _, size := range benchmarkBodySizes() {
+		b.Run(size.name, func(b *testing.B) {
+			body := buildLargeOpenAIResponsesToolContinuationBody(size.bytes)
+
+			b.SetBytes(int64(len(body)))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				validation := ValidateFunctionCallOutputContextBytes(body)
+				if !validation.HasFunctionCallOutput || !validation.HasItemReferenceForAllCallIDs {
+					b.Fatalf("工具续链校验结果异常: %+v", validation)
+				}
+				benchmarkIntSink++
+			}
+		})
+	}
+}
+
 // BenchmarkExtractCacheableContent_System 关注字符串拼接路径的性能。
 func BenchmarkExtractCacheableContent_System(b *testing.B) {
 	svc := &GatewayService{}
@@ -31,6 +151,21 @@ func BenchmarkExtractCacheableContent_System(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		benchmarkStringSink = svc.extractCacheableContent(req)
+	}
+}
+
+func benchmarkBodySizes() []struct {
+	name  string
+	bytes int
+} {
+	return []struct {
+		name  string
+		bytes int
+	}{
+		{name: "4MB", bytes: 4 << 20},
+		{name: "8MB", bytes: 8 << 20},
+		{name: "16MB", bytes: 16 << 20},
+		{name: "32MB", bytes: 32 << 20},
 	}
 }
 
@@ -51,4 +186,81 @@ func buildSystemCacheableRequest(parts int) *ParsedRequest {
 		panic(err)
 	}
 	return parsed
+}
+
+func buildLargeAnthropicMessagesBody(targetBytes int, includeCacheControl bool) []byte {
+	var builder strings.Builder
+	builder.Grow(targetBytes + 1024)
+	builder.WriteString(`{"model":"claude-sonnet-4-5","stream":true,"system":[{"type":"text","text":"system seed"}],"messages":[`)
+	for i := 0; builder.Len() < targetBytes; i++ {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(`{"role":"user","content":[{"type":"text","text":"`)
+		builder.WriteString(strings.Repeat("anthropic payload ", 64))
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteByte('"')
+		if includeCacheControl && i%32 == 0 {
+			builder.WriteString(`,"cache_control":{"type":"ephemeral"}`)
+		}
+		builder.WriteString(`}]}`)
+	}
+	builder.WriteString(`]}`)
+	return []byte(builder.String())
+}
+
+func buildLargeGeminiContentsBody(targetBytes int) []byte {
+	var builder strings.Builder
+	builder.Grow(targetBytes + 1024)
+	builder.WriteString(`{"model":"gemini-2.5-pro","systemInstruction":{"parts":[{"text":"system seed"}]},"contents":[`)
+	for i := 0; builder.Len() < targetBytes; i++ {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(`{"role":"user","parts":[{"text":"`)
+		builder.WriteString(strings.Repeat("gemini payload ", 64))
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(`"}]}`)
+	}
+	builder.WriteString(`]}`)
+	return []byte(builder.String())
+}
+
+func buildLargeOpenAIResponsesBody(targetBytes int) []byte {
+	var builder strings.Builder
+	builder.Grow(targetBytes + 1024)
+	builder.WriteString(`{"model":"gpt-5.4","stream":true,"prompt_cache_key":"session-benchmark","input":[`)
+	for i := 0; builder.Len() < targetBytes; i++ {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		builder.WriteString(`{"type":"message","role":"user","content":[{"type":"input_text","text":"`)
+		builder.WriteString(strings.Repeat("openai responses payload ", 48))
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(`"}]}`)
+	}
+	builder.WriteString(`],"tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{"query":{"type":"string"}}}}]}`)
+	return []byte(builder.String())
+}
+
+func buildLargeOpenAIResponsesToolContinuationBody(targetBytes int) []byte {
+	var builder strings.Builder
+	builder.Grow(targetBytes + 1024)
+	builder.WriteString(`{"model":"gpt-5.4","stream":true,"previous_response_id":"resp_benchmark","input":[`)
+	for i := 0; builder.Len() < targetBytes; i++ {
+		if i > 0 {
+			builder.WriteByte(',')
+		}
+		callID := "call_" + strconv.Itoa(i)
+		builder.WriteString(`{"type":"item_reference","id":"`)
+		builder.WriteString(callID)
+		builder.WriteString(`"},{"type":"function_call_output","call_id":"`)
+		builder.WriteString(callID)
+		builder.WriteString(`","output":"`)
+		builder.WriteString(strings.Repeat("tool output payload ", 48))
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(`"}`)
+	}
+	builder.WriteString(`]}`)
+	return []byte(builder.String())
 }

--- a/backend/internal/service/gateway_service_benchmark_test.go
+++ b/backend/internal/service/gateway_service_benchmark_test.go
@@ -229,16 +229,16 @@ func benchmarkBodySizes() []struct {
 
 func buildSystemCacheableRequest(parts int) *ParsedRequest {
 	var builder strings.Builder
-	builder.WriteString(`{"system":[`)
+	_, _ = builder.WriteString(`{"system":[`)
 	for i := 0; i < parts; i++ {
 		if i > 0 {
-			builder.WriteByte(',')
+			_ = builder.WriteByte(',')
 		}
-		builder.WriteString(`{"text":"system_part_`)
-		builder.WriteString(strconv.Itoa(i))
-		builder.WriteString(`","cache_control":{"type":"ephemeral"}}`)
+		_, _ = builder.WriteString(`{"text":"system_part_`)
+		_, _ = builder.WriteString(strconv.Itoa(i))
+		_, _ = builder.WriteString(`","cache_control":{"type":"ephemeral"}}`)
 	}
-	builder.WriteString(`]}`)
+	_, _ = builder.WriteString(`]}`)
 	parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(builder.String())), "")
 	if err != nil {
 		panic(err)
@@ -249,93 +249,93 @@ func buildSystemCacheableRequest(parts int) *ParsedRequest {
 func buildLargeAnthropicMessagesBody(targetBytes int, includeCacheControl bool) []byte {
 	var builder strings.Builder
 	builder.Grow(targetBytes + 1024)
-	builder.WriteString(`{"model":"claude-sonnet-4-5","stream":true,"system":[{"type":"text","text":"system seed"}],"messages":[`)
+	_, _ = builder.WriteString(`{"model":"claude-sonnet-4-5","stream":true,"system":[{"type":"text","text":"system seed"}],"messages":[`)
 	for i := 0; builder.Len() < targetBytes; i++ {
 		if i > 0 {
-			builder.WriteByte(',')
+			_ = builder.WriteByte(',')
 		}
-		builder.WriteString(`{"role":"user","content":[{"type":"text","text":"`)
-		builder.WriteString(strings.Repeat("anthropic payload ", 64))
-		builder.WriteString(strconv.Itoa(i))
-		builder.WriteByte('"')
+		_, _ = builder.WriteString(`{"role":"user","content":[{"type":"text","text":"`)
+		_, _ = builder.WriteString(strings.Repeat("anthropic payload ", 64))
+		_, _ = builder.WriteString(strconv.Itoa(i))
+		_ = builder.WriteByte('"')
 		if includeCacheControl && i%32 == 0 {
-			builder.WriteString(`,"cache_control":{"type":"ephemeral"}`)
+			_, _ = builder.WriteString(`,"cache_control":{"type":"ephemeral"}`)
 		}
-		builder.WriteString(`}]}`)
+		_, _ = builder.WriteString(`}]}`)
 	}
-	builder.WriteString(`]}`)
+	_, _ = builder.WriteString(`]}`)
 	return []byte(builder.String())
 }
 
 func buildLargeGeminiContentsBody(targetBytes int) []byte {
 	var builder strings.Builder
 	builder.Grow(targetBytes + 1024)
-	builder.WriteString(`{"model":"gemini-2.5-pro","systemInstruction":{"parts":[{"text":"system seed"}]},"contents":[`)
+	_, _ = builder.WriteString(`{"model":"gemini-2.5-pro","systemInstruction":{"parts":[{"text":"system seed"}]},"contents":[`)
 	for i := 0; builder.Len() < targetBytes; i++ {
 		if i > 0 {
-			builder.WriteByte(',')
+			_ = builder.WriteByte(',')
 		}
-		builder.WriteString(`{"role":"user","parts":[{"text":"`)
-		builder.WriteString(strings.Repeat("gemini payload ", 64))
-		builder.WriteString(strconv.Itoa(i))
-		builder.WriteString(`"}]}`)
+		_, _ = builder.WriteString(`{"role":"user","parts":[{"text":"`)
+		_, _ = builder.WriteString(strings.Repeat("gemini payload ", 64))
+		_, _ = builder.WriteString(strconv.Itoa(i))
+		_, _ = builder.WriteString(`"}]}`)
 	}
-	builder.WriteString(`]}`)
+	_, _ = builder.WriteString(`]}`)
 	return []byte(builder.String())
 }
 
 func buildLargeOpenAIResponsesBody(targetBytes int) []byte {
 	var builder strings.Builder
 	builder.Grow(targetBytes + 1024)
-	builder.WriteString(`{"model":"gpt-5.4","stream":true,"prompt_cache_key":"session-benchmark","input":[`)
+	_, _ = builder.WriteString(`{"model":"gpt-5.4","stream":true,"prompt_cache_key":"session-benchmark","input":[`)
 	for i := 0; builder.Len() < targetBytes; i++ {
 		if i > 0 {
-			builder.WriteByte(',')
+			_ = builder.WriteByte(',')
 		}
-		builder.WriteString(`{"type":"message","role":"user","content":[{"type":"input_text","text":"`)
-		builder.WriteString(strings.Repeat("openai responses payload ", 48))
-		builder.WriteString(strconv.Itoa(i))
-		builder.WriteString(`"}]}`)
+		_, _ = builder.WriteString(`{"type":"message","role":"user","content":[{"type":"input_text","text":"`)
+		_, _ = builder.WriteString(strings.Repeat("openai responses payload ", 48))
+		_, _ = builder.WriteString(strconv.Itoa(i))
+		_, _ = builder.WriteString(`"}]}`)
 	}
-	builder.WriteString(`],"tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{"query":{"type":"string"}}}}]}`)
+	_, _ = builder.WriteString(`],"tools":[{"type":"function","name":"lookup","parameters":{"type":"object","properties":{"query":{"type":"string"}}}}]}`)
 	return []byte(builder.String())
 }
 
 func buildLargeOpenAIResponsesToolContinuationBody(targetBytes int) []byte {
 	var builder strings.Builder
 	builder.Grow(targetBytes + 1024)
-	builder.WriteString(`{"model":"gpt-5.4","stream":true,"previous_response_id":"resp_benchmark","input":[`)
+	_, _ = builder.WriteString(`{"model":"gpt-5.4","stream":true,"previous_response_id":"resp_benchmark","input":[`)
 	for i := 0; builder.Len() < targetBytes; i++ {
 		if i > 0 {
-			builder.WriteByte(',')
+			_ = builder.WriteByte(',')
 		}
 		callID := "call_" + strconv.Itoa(i)
-		builder.WriteString(`{"type":"item_reference","id":"`)
-		builder.WriteString(callID)
-		builder.WriteString(`"},{"type":"function_call_output","call_id":"`)
-		builder.WriteString(callID)
-		builder.WriteString(`","output":"`)
-		builder.WriteString(strings.Repeat("tool output payload ", 48))
-		builder.WriteString(strconv.Itoa(i))
-		builder.WriteString(`"}`)
+		_, _ = builder.WriteString(`{"type":"item_reference","id":"`)
+		_, _ = builder.WriteString(callID)
+		_, _ = builder.WriteString(`"},{"type":"function_call_output","call_id":"`)
+		_, _ = builder.WriteString(callID)
+		_, _ = builder.WriteString(`","output":"`)
+		_, _ = builder.WriteString(strings.Repeat("tool output payload ", 48))
+		_, _ = builder.WriteString(strconv.Itoa(i))
+		_, _ = builder.WriteString(`"}`)
 	}
-	builder.WriteString(`]}`)
+	_, _ = builder.WriteString(`]}`)
 	return []byte(builder.String())
 }
 
 func buildLargeOpenAIResponsesImageToolBody(targetBytes int) []byte {
 	var builder strings.Builder
 	builder.Grow(targetBytes + 1024)
-	builder.WriteString(`{"model":"gpt-5.4","stream":false,"tools":[{"type":"image_generation","model":"gpt-image-2","size":"2048x1152"}],"input":[`)
+	_, _ = builder.WriteString(`{"model":"gpt-5.4","stream":false,"tools":[{"type":"image_generation","model":"gpt-image-2","size":"2048x1152"}],"input":[`)
 	for i := 0; builder.Len() < targetBytes; i++ {
 		if i > 0 {
-			builder.WriteByte(',')
+			_ = builder.WriteByte(',')
 		}
-		builder.WriteString(`{"type":"message","role":"user","content":[{"type":"input_text","text":"`)
-		builder.WriteString(strings.Repeat("openai image billing payload ", 48))
-		builder.WriteString(strconv.Itoa(i))
-		builder.WriteString(`"}]}`)
+		_, _ = builder.WriteString(`{"type":"message","role":"user","content":[{"type":"input_text","text":"`)
+		_, _ = builder.WriteString(strings.Repeat("openai image billing payload ", 48))
+		_, _ = builder.WriteString(strconv.Itoa(i))
+		_, _ = builder.WriteString(`"}]}`)
 	}
-	builder.WriteString(`]}`)
+	_, _ = builder.WriteString(`]}`)
 	return []byte(builder.String())
 }

--- a/backend/internal/service/gateway_websearch_emulation.go
+++ b/backend/internal/service/gateway_websearch_emulation.go
@@ -150,7 +150,7 @@ func (s *GatewayService) handleWebSearchEmulation(
 		parsed.OnUpstreamAccepted()
 	}
 
-	query := extractSearchQueryFromBody(parsed.Body)
+	query := extractSearchQueryFromBody(parsed.Body.Bytes())
 	if query == "" {
 		return nil, fmt.Errorf("web search emulation: no query found in messages")
 	}

--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -151,7 +151,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsChatCompletions(
 		}
 
 		if resp.StatusCode >= 400 && s.shouldRetryGeminiUpstreamError(account, resp.StatusCode) {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			if resp.StatusCode == http.StatusForbidden && isGeminiInsufficientScope(resp.Header, respBody) {
 				resp = &http.Response{
@@ -207,7 +207,7 @@ func (s *GeminiMessagesCompatService) forwardClaudeBodyAsChatCompletions(
 	reasoningEffort := extractCCReasoningEffortFromBody(originalChatBody)
 
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		s.handleGeminiUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody)
 		evBody := unwrapIfNeeded(account.Type == AccountTypeOAuth, respBody)
 

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -56,6 +56,18 @@ type GeminiMessagesCompatService struct {
 	responseHeaderFilter      *responseheaders.CompiledHeaderFilter
 }
 
+func (s *GeminiMessagesCompatService) readUpstreamErrorBody(resp *http.Response) []byte {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	limit := gatewayUpstreamErrorBodyReadLimit
+	if s != nil && s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody && s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes > int(limit) {
+		limit = int64(s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes)
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, limit))
+	return body
+}
+
 func NewGeminiMessagesCompatService(
 	accountRepo AccountRepository,
 	groupRepo GroupRepository,
@@ -789,7 +801,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 		// Special-case: signature/thought_signature validation errors are not transient, but may be fixed by
 		// downgrading Claude thinking/tool history to plain text (conservative two-stage retry).
 		if resp.StatusCode == http.StatusBadRequest && signatureRetryStage < 2 {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 
 			if isGeminiSignatureRelatedError(respBody) {
@@ -860,7 +872,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 		}
 
 		if resp.StatusCode >= 400 && s.shouldRetryGeminiUpstreamError(account, resp.StatusCode) {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			// Don't treat insufficient-scope as transient.
 			if resp.StatusCode == 403 && isGeminiInsufficientScope(resp.Header, respBody) {
@@ -919,7 +931,7 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		// 统一错误策略：自定义错误码 + 临时不可调度
 		if s.rateLimitService != nil {
 			switch s.rateLimitService.CheckErrorPolicy(ctx, account, resp.StatusCode, respBody) {
@@ -1329,7 +1341,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 		}
 
 		if resp.StatusCode >= 400 && s.shouldRetryGeminiUpstreamError(account, resp.StatusCode) {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			// Don't treat insufficient-scope as transient.
 			if resp.StatusCode == 403 && isGeminiInsufficientScope(resp.Header, respBody) {
@@ -1410,7 +1422,7 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 	isOAuth := account.Type == AccountTypeOAuth
 
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		// Best-effort fallback for OAuth tokens missing AI Studio scopes when calling countTokens.
 		// This avoids Gemini SDKs failing hard during preflight token counting.
 		// Checked before error policy so it always works regardless of custom error codes.
@@ -1619,7 +1631,7 @@ func (s *GeminiMessagesCompatService) checkErrorPolicyInLoop(
 	if resp.StatusCode < 400 || s.rateLimitService == nil {
 		return false, resp
 	}
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body := s.readUpstreamErrorBody(resp)
 	_ = resp.Body.Close()
 	rebuilt = &http.Response{
 		StatusCode: resp.StatusCode,

--- a/backend/internal/service/generate_session_hash_test.go
+++ b/backend/internal/service/generate_session_hash_test.go
@@ -3,12 +3,67 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/domain"
 	"github.com/stretchr/testify/require"
 )
 
-// ============ 基础优先级测试 ============
+func mustParseSessionHashRequest(t *testing.T, body string, ctx *SessionContext) *ParsedRequest {
+	t.Helper()
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(body)), domain.PlatformAnthropic)
+	require.NoError(t, err)
+	parsed.SessionContext = ctx
+	return parsed
+}
+
+func mustParseGeminiSessionHashRequest(t *testing.T, body string, ctx *SessionContext) *ParsedRequest {
+	t.Helper()
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(body)), domain.PlatformGemini)
+	require.NoError(t, err)
+	parsed.SessionContext = ctx
+	return parsed
+}
+
+func anthropicSessionBody(system any, messages []any, metadataUserID string) string {
+	body := map[string]any{}
+	if system != nil {
+		body["system"] = system
+	}
+	if messages != nil {
+		body["messages"] = messages
+	}
+	if metadataUserID != "" {
+		body["metadata"] = map[string]any{"user_id": metadataUserID}
+	}
+	data, _ := json.Marshal(body)
+	return string(data)
+}
+
+func geminiSessionBody(systemParts []any, contents []any) string {
+	body := map[string]any{}
+	if systemParts != nil {
+		body["systemInstruction"] = map[string]any{"parts": systemParts}
+	}
+	if contents != nil {
+		body["contents"] = contents
+	}
+	data, _ := json.Marshal(body)
+	return string(data)
+}
+
+func msg(role string, content any) map[string]any {
+	return map[string]any{"role": role, "content": content}
+}
+
+func geminiMsg(role string, texts ...string) map[string]any {
+	parts := make([]any, 0, len(texts))
+	for _, text := range texts {
+		parts = append(parts, map[string]any{"text": text})
+	}
+	return map[string]any{"role": role, "parts": parts}
+}
 
 func TestGenerateSessionHash_NilParsedRequest(t *testing.T) {
 	svc := &GatewayService{}
@@ -22,37 +77,17 @@ func TestGenerateSessionHash_EmptyRequest(t *testing.T) {
 
 func TestGenerateSessionHash_MetadataHasHighestPriority(t *testing.T) {
 	svc := &GatewayService{}
-
-	parsed := &ParsedRequest{
-		MetadataUserID: "user_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2_account__session_123e4567-e89b-12d3-a456-426614174000",
-		System:         "You are a helpful assistant.",
-		HasSystem:      true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	metadata := "user_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2_account__session_123e4567-e89b-12d3-a456-426614174000"
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello")}, metadata), nil)
 
 	hash := svc.GenerateSessionHash(parsed)
 	require.Equal(t, "123e4567-e89b-12d3-a456-426614174000", hash, "metadata session_id should have highest priority")
 }
 
-// ============ System + Messages 基础测试 ============
-
 func TestGenerateSessionHash_SystemPlusMessages(t *testing.T) {
 	svc := &GatewayService{}
-
-	withSystem := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
-	withoutSystem := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	withSystem := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello")}, ""), nil)
+	withoutSystem := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", "hello")}, ""), nil)
 
 	h1 := svc.GenerateSessionHash(withSystem)
 	h2 := svc.GenerateSessionHash(withoutSystem)
@@ -63,32 +98,16 @@ func TestGenerateSessionHash_SystemPlusMessages(t *testing.T) {
 
 func TestGenerateSessionHash_SystemOnlyProducesHash(t *testing.T) {
 	svc := &GatewayService{}
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", nil, ""), nil)
 
-	parsed := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-	}
 	hash := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, hash, "system prompt alone should produce a hash as part of full digest")
 }
 
 func TestGenerateSessionHash_DifferentSystemsSameMessages(t *testing.T) {
 	svc := &GatewayService{}
-
-	parsed1 := &ParsedRequest{
-		System:    "You are assistant A.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
-	parsed2 := &ParsedRequest{
-		System:    "You are assistant B.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	parsed1 := mustParseSessionHashRequest(t, anthropicSessionBody("You are assistant A.", []any{msg("user", "hello")}, ""), nil)
+	parsed2 := mustParseSessionHashRequest(t, anthropicSessionBody("You are assistant B.", []any{msg("user", "hello")}, ""), nil)
 
 	h1 := svc.GenerateSessionHash(parsed1)
 	h2 := svc.GenerateSessionHash(parsed2)
@@ -97,16 +116,8 @@ func TestGenerateSessionHash_DifferentSystemsSameMessages(t *testing.T) {
 
 func TestGenerateSessionHash_SameSystemSameMessages(t *testing.T) {
 	svc := &GatewayService{}
-
 	mk := func() *ParsedRequest {
-		return &ParsedRequest{
-			System:    "You are a helpful assistant.",
-			HasSystem: true,
-			Messages: []any{
-				map[string]any{"role": "user", "content": "hello"},
-				map[string]any{"role": "assistant", "content": "hi"},
-			},
-		}
+		return mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello"), msg("assistant", "hi")}, ""), nil)
 	}
 
 	h1 := svc.GenerateSessionHash(mk())
@@ -116,53 +127,19 @@ func TestGenerateSessionHash_SameSystemSameMessages(t *testing.T) {
 
 func TestGenerateSessionHash_DifferentMessagesProduceDifferentHash(t *testing.T) {
 	svc := &GatewayService{}
-
-	parsed1 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "help me with Go"},
-		},
-	}
-	parsed2 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "help me with Python"},
-		},
-	}
+	parsed1 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "help me with Go")}, ""), nil)
+	parsed2 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "help me with Python")}, ""), nil)
 
 	h1 := svc.GenerateSessionHash(parsed1)
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.NotEqual(t, h1, h2, "same system but different messages should produce different hashes")
 }
 
-// ============ SessionContext 核心测试 ============
-
 func TestGenerateSessionHash_DifferentSessionContextProducesDifferentHash(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 相同消息 + 不同 SessionContext → 不同 hash（解决碰撞问题的核心场景）
-	parsed1 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "192.168.1.1",
-			UserAgent: "Mozilla/5.0",
-			APIKeyID:  100,
-		},
-	}
-	parsed2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "10.0.0.1",
-			UserAgent: "curl/7.0",
-			APIKeyID:  200,
-		},
-	}
+	body := anthropicSessionBody(nil, []any{msg("user", "hello")}, "")
+	parsed1 := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "192.168.1.1", UserAgent: "Mozilla/5.0", APIKeyID: 100})
+	parsed2 := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "10.0.0.1", UserAgent: "curl/7.0", APIKeyID: 200})
 
 	h1 := svc.GenerateSessionHash(parsed1)
 	h2 := svc.GenerateSessionHash(parsed2)
@@ -173,19 +150,9 @@ func TestGenerateSessionHash_DifferentSessionContextProducesDifferentHash(t *tes
 
 func TestGenerateSessionHash_SameSessionContextProducesSameHash(t *testing.T) {
 	svc := &GatewayService{}
-
-	mk := func() *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "hello"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  "192.168.1.1",
-				UserAgent: "Mozilla/5.0",
-				APIKeyID:  100,
-			},
-		}
-	}
+	ctx := &SessionContext{ClientIP: "192.168.1.1", UserAgent: "Mozilla/5.0", APIKeyID: 100}
+	body := anthropicSessionBody(nil, []any{msg("user", "hello")}, "")
+	mk := func() *ParsedRequest { return mustParseSessionHashRequest(t, body, ctx) }
 
 	h1 := svc.GenerateSessionHash(mk())
 	h2 := svc.GenerateSessionHash(mk())
@@ -194,35 +161,17 @@ func TestGenerateSessionHash_SameSessionContextProducesSameHash(t *testing.T) {
 
 func TestGenerateSessionHash_MetadataOverridesSessionContext(t *testing.T) {
 	svc := &GatewayService{}
-
-	parsed := &ParsedRequest{
-		MetadataUserID: "user_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2_account__session_123e4567-e89b-12d3-a456-426614174000",
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "192.168.1.1",
-			UserAgent: "Mozilla/5.0",
-			APIKeyID:  100,
-		},
-	}
+	metadata := "user_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2_account__session_123e4567-e89b-12d3-a456-426614174000"
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", "hello")}, metadata), &SessionContext{ClientIP: "192.168.1.1", UserAgent: "Mozilla/5.0", APIKeyID: 100})
 
 	hash := svc.GenerateSessionHash(parsed)
-	require.Equal(t, "123e4567-e89b-12d3-a456-426614174000", hash,
-		"metadata session_id should take priority over SessionContext")
+	require.Equal(t, "123e4567-e89b-12d3-a456-426614174000", hash, "metadata session_id should take priority over SessionContext")
 }
 
 func TestGenerateSessionHash_MetadataJSON_HasHighestPriority(t *testing.T) {
 	svc := &GatewayService{}
-
-	parsed := &ParsedRequest{
-		MetadataUserID: `{"device_id":"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2","account_uuid":"","session_id":"c72554f2-1234-5678-abcd-123456789abc"}`,
-		System:         "You are a helpful assistant.",
-		HasSystem:      true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	metadata := `{"device_id":"a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2","account_uuid":"","session_id":"c72554f2-1234-5678-abcd-123456789abc"}`
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello")}, metadata), nil)
 
 	hash := svc.GenerateSessionHash(parsed)
 	require.Equal(t, "c72554f2-1234-5678-abcd-123456789abc", hash, "JSON format metadata session_id should have highest priority")
@@ -230,69 +179,25 @@ func TestGenerateSessionHash_MetadataJSON_HasHighestPriority(t *testing.T) {
 
 func TestGenerateSessionHash_NilSessionContextBackwardCompatible(t *testing.T) {
 	svc := &GatewayService{}
-
-	withCtx := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: nil,
-	}
-	withoutCtx := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-	}
+	body := anthropicSessionBody(nil, []any{msg("user", "hello")}, "")
+	withCtx := mustParseSessionHashRequest(t, body, nil)
+	withoutCtx := mustParseSessionHashRequest(t, body, nil)
 
 	h1 := svc.GenerateSessionHash(withCtx)
 	h2 := svc.GenerateSessionHash(withoutCtx)
 	require.Equal(t, h1, h2, "nil SessionContext should produce same hash as no SessionContext")
 }
 
-// ============ 多轮连续会话测试 ============
-
 func TestGenerateSessionHash_ContinuousConversation_HashChangesWithMessages(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 模拟连续会话：每增加一轮对话，hash 应该不同（内容累积变化）
-	round1 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: ctx,
-	}
-
-	round2 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "Hi there!"},
-			map[string]any{"role": "user", "content": "How are you?"},
-		},
-		SessionContext: ctx,
-	}
-
-	round3 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-			map[string]any{"role": "assistant", "content": "Hi there!"},
-			map[string]any{"role": "user", "content": "How are you?"},
-			map[string]any{"role": "assistant", "content": "I'm doing well!"},
-			map[string]any{"role": "user", "content": "Tell me a joke"},
-		},
-		SessionContext: ctx,
-	}
+	round1 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello")}, ""), ctx)
+	round2 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello"), msg("assistant", "Hi there!"), msg("user", "How are you?")}, ""), ctx)
+	round3 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello"), msg("assistant", "Hi there!"), msg("user", "How are you?"), msg("assistant", "I'm doing well!"), msg("user", "Tell me a joke")}, ""), ctx)
 
 	h1 := svc.GenerateSessionHash(round1)
 	h2 := svc.GenerateSessionHash(round2)
 	h3 := svc.GenerateSessionHash(round3)
-
 	require.NotEmpty(t, h1)
 	require.NotEmpty(t, h2)
 	require.NotEmpty(t, h3)
@@ -303,62 +208,20 @@ func TestGenerateSessionHash_ContinuousConversation_HashChangesWithMessages(t *t
 
 func TestGenerateSessionHash_ContinuousConversation_SameRoundSameHash(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 同一轮对话重复请求（如重试）应产生相同 hash
-	mk := func() *ParsedRequest {
-		return &ParsedRequest{
-			System:    "You are a helpful assistant.",
-			HasSystem: true,
-			Messages: []any{
-				map[string]any{"role": "user", "content": "hello"},
-				map[string]any{"role": "assistant", "content": "Hi there!"},
-				map[string]any{"role": "user", "content": "How are you?"},
-			},
-			SessionContext: ctx,
-		}
-	}
+	body := anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello"), msg("assistant", "Hi there!"), msg("user", "How are you?")}, "")
+	mk := func() *ParsedRequest { return mustParseSessionHashRequest(t, body, ctx) }
 
 	h1 := svc.GenerateSessionHash(mk())
 	h2 := svc.GenerateSessionHash(mk())
 	require.Equal(t, h1, h2, "same conversation state should produce identical hash on retry")
 }
 
-// ============ 消息回退测试 ============
-
 func TestGenerateSessionHash_MessageRollback(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 模拟消息回退：用户删掉最后一轮再重发
-	original := &ParsedRequest{
-		System:    "System prompt",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "msg1"},
-			map[string]any{"role": "assistant", "content": "reply1"},
-			map[string]any{"role": "user", "content": "msg2"},
-			map[string]any{"role": "assistant", "content": "reply2"},
-			map[string]any{"role": "user", "content": "msg3"},
-		},
-		SessionContext: ctx,
-	}
-
-	// 回退到 msg2 后，用新的 msg3 替代
-	rollback := &ParsedRequest{
-		System:    "System prompt",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "msg1"},
-			map[string]any{"role": "assistant", "content": "reply1"},
-			map[string]any{"role": "user", "content": "msg2"},
-			map[string]any{"role": "assistant", "content": "reply2"},
-			map[string]any{"role": "user", "content": "different msg3"},
-		},
-		SessionContext: ctx,
-	}
+	original := mustParseSessionHashRequest(t, anthropicSessionBody("System prompt", []any{msg("user", "msg1"), msg("assistant", "reply1"), msg("user", "msg2"), msg("assistant", "reply2"), msg("user", "msg3")}, ""), ctx)
+	rollback := mustParseSessionHashRequest(t, anthropicSessionBody("System prompt", []any{msg("user", "msg1"), msg("assistant", "reply1"), msg("user", "msg2"), msg("assistant", "reply2"), msg("user", "different msg3")}, ""), ctx)
 
 	hOrig := svc.GenerateSessionHash(original)
 	hRollback := svc.GenerateSessionHash(rollback)
@@ -367,58 +230,19 @@ func TestGenerateSessionHash_MessageRollback(t *testing.T) {
 
 func TestGenerateSessionHash_MessageRollbackSameContent(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 回退后重新发送相同内容 → 相同 hash（合理的粘性恢复）
-	mk := func() *ParsedRequest {
-		return &ParsedRequest{
-			System:    "System prompt",
-			HasSystem: true,
-			Messages: []any{
-				map[string]any{"role": "user", "content": "msg1"},
-				map[string]any{"role": "assistant", "content": "reply1"},
-				map[string]any{"role": "user", "content": "msg2"},
-			},
-			SessionContext: ctx,
-		}
-	}
+	body := anthropicSessionBody("System prompt", []any{msg("user", "msg1"), msg("assistant", "reply1"), msg("user", "msg2")}, "")
+	mk := func() *ParsedRequest { return mustParseSessionHashRequest(t, body, ctx) }
 
 	h1 := svc.GenerateSessionHash(mk())
 	h2 := svc.GenerateSessionHash(mk())
 	require.Equal(t, h1, h2, "rollback and resend same content should produce same hash")
 }
 
-// ============ 相同 System、不同用户消息 ============
-
 func TestGenerateSessionHash_SameSystemDifferentUsers(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 两个不同用户使用相同 system prompt 但发送不同消息
-	user1 := &ParsedRequest{
-		System:    "You are a code reviewer.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "Review this Go code"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "1.1.1.1",
-			UserAgent: "vscode",
-			APIKeyID:  1,
-		},
-	}
-	user2 := &ParsedRequest{
-		System:    "You are a code reviewer.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "Review this Python code"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "2.2.2.2",
-			UserAgent: "vscode",
-			APIKeyID:  2,
-		},
-	}
+	user1 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a code reviewer.", []any{msg("user", "Review this Go code")}, ""), &SessionContext{ClientIP: "1.1.1.1", UserAgent: "vscode", APIKeyID: 1})
+	user2 := mustParseSessionHashRequest(t, anthropicSessionBody("You are a code reviewer.", []any{msg("user", "Review this Python code")}, ""), &SessionContext{ClientIP: "2.2.2.2", UserAgent: "vscode", APIKeyID: 2})
 
 	h1 := svc.GenerateSessionHash(user1)
 	h2 := svc.GenerateSessionHash(user2)
@@ -427,55 +251,20 @@ func TestGenerateSessionHash_SameSystemDifferentUsers(t *testing.T) {
 
 func TestGenerateSessionHash_SameSystemSameMessageDifferentContext(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 这是修复的核心场景：两个不同用户发送完全相同的 system + messages（如 "hello"）
-	// 有了 SessionContext 后应该产生不同 hash
-	user1 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "1.1.1.1",
-			UserAgent: "Mozilla/5.0",
-			APIKeyID:  10,
-		},
-	}
-	user2 := &ParsedRequest{
-		System:    "You are a helpful assistant.",
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "2.2.2.2",
-			UserAgent: "Mozilla/5.0",
-			APIKeyID:  20,
-		},
-	}
+	body := anthropicSessionBody("You are a helpful assistant.", []any{msg("user", "hello")}, "")
+	user1 := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: "Mozilla/5.0", APIKeyID: 10})
+	user2 := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "2.2.2.2", UserAgent: "Mozilla/5.0", APIKeyID: 20})
 
 	h1 := svc.GenerateSessionHash(user1)
 	h2 := svc.GenerateSessionHash(user2)
 	require.NotEqual(t, h1, h2, "CRITICAL: same system+messages but different users should get different hashes")
 }
 
-// ============ SessionContext 各字段独立影响测试 ============
-
 func TestGenerateSessionHash_SessionContext_IPDifference(t *testing.T) {
 	svc := &GatewayService{}
-
+	body := anthropicSessionBody(nil, []any{msg("user", "test")}, "")
 	base := func(ip string) *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "test"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  ip,
-				UserAgent: "same-ua",
-				APIKeyID:  1,
-			},
-		}
+		return mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: ip, UserAgent: "same-ua", APIKeyID: 1})
 	}
 
 	h1 := svc.GenerateSessionHash(base("1.1.1.1"))
@@ -485,18 +274,9 @@ func TestGenerateSessionHash_SessionContext_IPDifference(t *testing.T) {
 
 func TestGenerateSessionHash_SessionContext_UADifference(t *testing.T) {
 	svc := &GatewayService{}
-
+	body := anthropicSessionBody(nil, []any{msg("user", "test")}, "")
 	base := func(ua string) *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "test"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  "1.1.1.1",
-				UserAgent: ua,
-				APIKeyID:  1,
-			},
-		}
+		return mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: ua, APIKeyID: 1})
 	}
 
 	h1 := svc.GenerateSessionHash(base("Mozilla/5.0"))
@@ -506,18 +286,9 @@ func TestGenerateSessionHash_SessionContext_UADifference(t *testing.T) {
 
 func TestGenerateSessionHash_SessionContext_UAVersionNoiseIgnored(t *testing.T) {
 	svc := &GatewayService{}
-
+	body := anthropicSessionBody(nil, []any{msg("user", "test")}, "")
 	base := func(ua string) *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "test"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  "1.1.1.1",
-				UserAgent: ua,
-				APIKeyID:  1,
-			},
-		}
+		return mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: ua, APIKeyID: 1})
 	}
 
 	h1 := svc.GenerateSessionHash(base("Mozilla/5.0 codex_cli_rs/0.1.0"))
@@ -527,18 +298,9 @@ func TestGenerateSessionHash_SessionContext_UAVersionNoiseIgnored(t *testing.T) 
 
 func TestGenerateSessionHash_SessionContext_FreeformUAVersionNoiseIgnored(t *testing.T) {
 	svc := &GatewayService{}
-
+	body := anthropicSessionBody(nil, []any{msg("user", "test")}, "")
 	base := func(ua string) *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "test"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  "1.1.1.1",
-				UserAgent: ua,
-				APIKeyID:  1,
-			},
-		}
+		return mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: ua, APIKeyID: 1})
 	}
 
 	h1 := svc.GenerateSessionHash(base("Codex CLI 0.1.0"))
@@ -548,18 +310,9 @@ func TestGenerateSessionHash_SessionContext_FreeformUAVersionNoiseIgnored(t *tes
 
 func TestGenerateSessionHash_SessionContext_APIKeyIDDifference(t *testing.T) {
 	svc := &GatewayService{}
-
+	body := anthropicSessionBody(nil, []any{msg("user", "test")}, "")
 	base := func(keyID int64) *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "test"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  "1.1.1.1",
-				UserAgent: "same-ua",
-				APIKeyID:  keyID,
-			},
-		}
+		return mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: "same-ua", APIKeyID: keyID})
 	}
 
 	h1 := svc.GenerateSessionHash(base(1))
@@ -567,24 +320,12 @@ func TestGenerateSessionHash_SessionContext_APIKeyIDDifference(t *testing.T) {
 	require.NotEqual(t, h1, h2, "different APIKeyID should produce different hash")
 }
 
-// ============ 多用户并发相同消息场景 ============
-
 func TestGenerateSessionHash_MultipleUsersSameFirstMessage(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 模拟 5 个不同用户同时发送 "hello" → 应该产生 5 个不同的 hash
 	hashes := make(map[string]bool)
+	body := anthropicSessionBody(nil, []any{msg("user", "hello")}, "")
 	for i := 0; i < 5; i++ {
-		parsed := &ParsedRequest{
-			Messages: []any{
-				map[string]any{"role": "user", "content": "hello"},
-			},
-			SessionContext: &SessionContext{
-				ClientIP:  "192.168.1." + string(rune('1'+i)),
-				UserAgent: "client-" + string(rune('A'+i)),
-				APIKeyID:  int64(i + 1),
-			},
-		}
+		parsed := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "192.168.1." + string(rune('1'+i)), UserAgent: "client-" + string(rune('A'+i)), APIKeyID: int64(i + 1)})
 		h := svc.GenerateSessionHash(parsed)
 		require.NotEmpty(t, h)
 		require.False(t, hashes[h], "hash collision detected for user %d", i)
@@ -593,134 +334,56 @@ func TestGenerateSessionHash_MultipleUsersSameFirstMessage(t *testing.T) {
 	require.Len(t, hashes, 5, "5 different users should produce 5 unique hashes")
 }
 
-// ============ 连续会话粘性：多轮对话同一用户 ============
-
 func TestGenerateSessionHash_SameUserGrowingConversation(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "browser", APIKeyID: 42}
-
-	// 模拟同一用户的连续会话，每轮 hash 不同但同用户重试保持一致
-	messages := []map[string]any{
-		{"role": "user", "content": "msg1"},
-		{"role": "assistant", "content": "reply1"},
-		{"role": "user", "content": "msg2"},
-		{"role": "assistant", "content": "reply2"},
-		{"role": "user", "content": "msg3"},
-		{"role": "assistant", "content": "reply3"},
-		{"role": "user", "content": "msg4"},
+	messages := []any{
+		msg("user", "msg1"), msg("assistant", "reply1"), msg("user", "msg2"), msg("assistant", "reply2"),
+		msg("user", "msg3"), msg("assistant", "reply3"), msg("user", "msg4"),
 	}
 
 	prevHash := ""
 	for round := 1; round <= len(messages); round += 2 {
-		// 构建前 round 条消息
-		msgs := make([]any, round)
-		for j := 0; j < round; j++ {
-			msgs[j] = messages[j]
-		}
-		parsed := &ParsedRequest{
-			System:         "System",
-			HasSystem:      true,
-			Messages:       msgs,
-			SessionContext: ctx,
-		}
+		parsed := mustParseSessionHashRequest(t, anthropicSessionBody("System", messages[:round], ""), ctx)
 		h := svc.GenerateSessionHash(parsed)
 		require.NotEmpty(t, h, "round %d hash should not be empty", round)
-
 		if prevHash != "" {
 			require.NotEqual(t, prevHash, h, "round %d hash should differ from previous round", round)
 		}
 		prevHash = h
-
-		// 同一轮重试应该相同
 		h2 := svc.GenerateSessionHash(parsed)
 		require.Equal(t, h, h2, "retry of round %d should produce same hash", round)
 	}
 }
 
-// ============ 多轮消息内容结构化测试 ============
-
 func TestGenerateSessionHash_MultipleUserMessages(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 5 条用户消息（无 assistant 回复）
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "first"},
-			map[string]any{"role": "user", "content": "second"},
-			map[string]any{"role": "user", "content": "third"},
-			map[string]any{"role": "user", "content": "fourth"},
-			map[string]any{"role": "user", "content": "fifth"},
-		},
-		SessionContext: ctx,
-	}
-
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", "first"), msg("user", "second"), msg("user", "third"), msg("user", "fourth"), msg("user", "fifth")}, ""), ctx)
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h)
 
-	// 修改中间一条消息应该改变 hash
-	parsed2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "first"},
-			map[string]any{"role": "user", "content": "CHANGED"},
-			map[string]any{"role": "user", "content": "third"},
-			map[string]any{"role": "user", "content": "fourth"},
-			map[string]any{"role": "user", "content": "fifth"},
-		},
-		SessionContext: ctx,
-	}
-
+	parsed2 := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", "first"), msg("user", "CHANGED"), msg("user", "third"), msg("user", "fourth"), msg("user", "fifth")}, ""), ctx)
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.NotEqual(t, h, h2, "changing any message should change the hash")
 }
 
 func TestGenerateSessionHash_MessageOrderMatters(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	parsed1 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "alpha"},
-			map[string]any{"role": "user", "content": "beta"},
-		},
-		SessionContext: ctx,
-	}
-	parsed2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "beta"},
-			map[string]any{"role": "user", "content": "alpha"},
-		},
-		SessionContext: ctx,
-	}
+	parsed1 := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", "alpha"), msg("user", "beta")}, ""), ctx)
+	parsed2 := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", "beta"), msg("user", "alpha")}, ""), ctx)
 
 	h1 := svc.GenerateSessionHash(parsed1)
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.NotEqual(t, h1, h2, "message order should affect the hash")
 }
 
-// ============ 复杂内容格式测试 ============
-
 func TestGenerateSessionHash_StructuredContent(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 结构化 content（数组形式）
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"content": []any{
-					map[string]any{"type": "text", "text": "Look at this"},
-					map[string]any{"type": "text", "text": "And this too"},
-				},
-			},
-		},
-		SessionContext: ctx,
-	}
+	content := []any{map[string]any{"type": "text", "text": "Look at this"}, map[string]any{"type": "text", "text": "And this too"}}
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{msg("user", content)}, ""), ctx)
 
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "structured content should produce a hash")
@@ -728,100 +391,37 @@ func TestGenerateSessionHash_StructuredContent(t *testing.T) {
 
 func TestGenerateSessionHash_ArraySystemPrompt(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 数组格式的 system prompt
-	parsed := &ParsedRequest{
-		System: []any{
-			map[string]any{"type": "text", "text": "You are a helpful assistant."},
-			map[string]any{"type": "text", "text": "Be concise."},
-		},
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: ctx,
-	}
+	system := []any{map[string]any{"type": "text", "text": "You are a helpful assistant."}, map[string]any{"type": "text", "text": "Be concise."}}
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody(system, []any{msg("user", "hello")}, ""), ctx)
 
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "array system prompt should produce a hash")
 }
 
-// ============ SessionContext 与 cache_control 优先级 ============
-
 func TestGenerateSessionHash_CacheControlOverridesSessionContext(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 当有 cache_control: ephemeral 时，使用第 2 级优先级
-	// SessionContext 不应影响结果
-	parsed1 := &ParsedRequest{
-		System: []any{
-			map[string]any{
-				"type":          "text",
-				"text":          "You are a tool-specific assistant.",
-				"cache_control": map[string]any{"type": "ephemeral"},
-			},
-		},
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "1.1.1.1",
-			UserAgent: "ua1",
-			APIKeyID:  100,
-		},
-	}
-	parsed2 := &ParsedRequest{
-		System: []any{
-			map[string]any{
-				"type":          "text",
-				"text":          "You are a tool-specific assistant.",
-				"cache_control": map[string]any{"type": "ephemeral"},
-			},
-		},
-		HasSystem: true,
-		Messages: []any{
-			map[string]any{"role": "user", "content": "hello"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "2.2.2.2",
-			UserAgent: "ua2",
-			APIKeyID:  200,
-		},
-	}
+	system := []any{map[string]any{"type": "text", "text": "You are a tool-specific assistant.", "cache_control": map[string]any{"type": "ephemeral"}}}
+	body := anthropicSessionBody(system, []any{msg("user", "hello")}, "")
+	parsed1 := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: "ua1", APIKeyID: 100})
+	parsed2 := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "2.2.2.2", UserAgent: "ua2", APIKeyID: 200})
 
 	h1 := svc.GenerateSessionHash(parsed1)
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.Equal(t, h1, h2, "cache_control ephemeral has higher priority, SessionContext should not affect result")
 }
 
-// ============ 边界情况 ============
-
 func TestGenerateSessionHash_EmptyMessages(t *testing.T) {
 	svc := &GatewayService{}
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{}, ""), &SessionContext{ClientIP: "1.1.1.1", UserAgent: "test", APIKeyID: 1})
 
-	parsed := &ParsedRequest{
-		Messages: []any{},
-		SessionContext: &SessionContext{
-			ClientIP:  "1.1.1.1",
-			UserAgent: "test",
-			APIKeyID:  1,
-		},
-	}
-
-	// 空 messages + 只有 SessionContext 时，combined.Len() > 0 因为有 context 写入
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "empty messages with SessionContext should still produce a hash from context")
 }
 
 func TestGenerateSessionHash_EmptyMessagesNoContext(t *testing.T) {
 	svc := &GatewayService{}
-
-	parsed := &ParsedRequest{
-		Messages: []any{},
-	}
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody(nil, []any{}, ""), nil)
 
 	h := svc.GenerateSessionHash(parsed)
 	require.Empty(t, h, "empty messages without SessionContext should produce empty hash")
@@ -829,98 +429,37 @@ func TestGenerateSessionHash_EmptyMessagesNoContext(t *testing.T) {
 
 func TestGenerateSessionHash_SessionContextWithEmptyFields(t *testing.T) {
 	svc := &GatewayService{}
-
-	// SessionContext 字段为空字符串和零值时仍应影响 hash
-	withEmptyCtx := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "test"},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "",
-			UserAgent: "",
-			APIKeyID:  0,
-		},
-	}
-	withoutCtx := &ParsedRequest{
-		Messages: []any{
-			map[string]any{"role": "user", "content": "test"},
-		},
-	}
+	body := anthropicSessionBody(nil, []any{msg("user", "test")}, "")
+	withEmptyCtx := mustParseSessionHashRequest(t, body, &SessionContext{ClientIP: "", UserAgent: "", APIKeyID: 0})
+	withoutCtx := mustParseSessionHashRequest(t, body, nil)
 
 	h1 := svc.GenerateSessionHash(withEmptyCtx)
 	h2 := svc.GenerateSessionHash(withoutCtx)
-	// 有 SessionContext（即使字段为空）仍然会写入分隔符 "::" 等
 	require.NotEqual(t, h1, h2, "empty-field SessionContext should still differ from nil SessionContext")
 }
 
-// ============ 长对话历史测试 ============
-
 func TestGenerateSessionHash_LongConversation(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
-
-	// 构建 20 轮对话
 	messages := make([]any, 0, 40)
 	for i := 0; i < 20; i++ {
-		messages = append(messages, map[string]any{
-			"role":    "user",
-			"content": "user message " + string(rune('A'+i)),
-		})
-		messages = append(messages, map[string]any{
-			"role":    "assistant",
-			"content": "assistant reply " + string(rune('A'+i)),
-		})
+		messages = append(messages, msg("user", "user message "+string(rune('A'+i))))
+		messages = append(messages, msg("assistant", "assistant reply "+string(rune('A'+i))))
 	}
 
-	parsed := &ParsedRequest{
-		System:         "System prompt",
-		HasSystem:      true,
-		Messages:       messages,
-		SessionContext: ctx,
-	}
-
+	parsed := mustParseSessionHashRequest(t, anthropicSessionBody("System prompt", messages, ""), ctx)
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h)
 
-	// 再加一轮应该不同
-	moreMessages := make([]any, len(messages)+2)
-	copy(moreMessages, messages)
-	moreMessages[len(messages)] = map[string]any{"role": "user", "content": "one more"}
-	moreMessages[len(messages)+1] = map[string]any{"role": "assistant", "content": "ok"}
-
-	parsed2 := &ParsedRequest{
-		System:         "System prompt",
-		HasSystem:      true,
-		Messages:       moreMessages,
-		SessionContext: ctx,
-	}
-
+	moreMessages := append(append([]any{}, messages...), msg("user", "one more"), msg("assistant", "ok"))
+	parsed2 := mustParseSessionHashRequest(t, anthropicSessionBody("System prompt", moreMessages, ""), ctx)
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.NotEqual(t, h, h2, "adding more messages to long conversation should change hash")
 }
 
-// ============ Gemini 原生格式 session hash 测试 ============
-
 func TestGenerateSessionHash_GeminiContentsProducesHash(t *testing.T) {
 	svc := &GatewayService{}
-
-	// Gemini 格式: contents[].parts[].text
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"parts": []any{
-					map[string]any{"text": "Hello from Gemini"},
-				},
-			},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "1.2.3.4",
-			UserAgent: "gemini-cli",
-			APIKeyID:  1,
-		},
-	}
+	parsed := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "Hello from Gemini")}), &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1})
 
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "Gemini contents with parts should produce a non-empty hash")
@@ -928,31 +467,9 @@ func TestGenerateSessionHash_GeminiContentsProducesHash(t *testing.T) {
 
 func TestGenerateSessionHash_GeminiDifferentContentsDifferentHash(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1}
-
-	parsed1 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"parts": []any{
-					map[string]any{"text": "Hello"},
-				},
-			},
-		},
-		SessionContext: ctx,
-	}
-	parsed2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"parts": []any{
-					map[string]any{"text": "Goodbye"},
-				},
-			},
-		},
-		SessionContext: ctx,
-	}
+	parsed1 := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "Hello")}), ctx)
+	parsed2 := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "Goodbye")}), ctx)
 
 	h1 := svc.GenerateSessionHash(parsed1)
 	h2 := svc.GenerateSessionHash(parsed2)
@@ -961,28 +478,9 @@ func TestGenerateSessionHash_GeminiDifferentContentsDifferentHash(t *testing.T) 
 
 func TestGenerateSessionHash_GeminiSameContentsSameHash(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1}
-
-	mk := func() *ParsedRequest {
-		return &ParsedRequest{
-			Messages: []any{
-				map[string]any{
-					"role": "user",
-					"parts": []any{
-						map[string]any{"text": "Hello"},
-					},
-				},
-				map[string]any{
-					"role": "model",
-					"parts": []any{
-						map[string]any{"text": "Hi there!"},
-					},
-				},
-			},
-			SessionContext: ctx,
-		}
-	}
+	body := geminiSessionBody(nil, []any{geminiMsg("user", "Hello"), geminiMsg("model", "Hi there!")})
+	mk := func() *ParsedRequest { return mustParseGeminiSessionHashRequest(t, body, ctx) }
 
 	h1 := svc.GenerateSessionHash(mk())
 	h2 := svc.GenerateSessionHash(mk())
@@ -991,36 +489,9 @@ func TestGenerateSessionHash_GeminiSameContentsSameHash(t *testing.T) {
 
 func TestGenerateSessionHash_GeminiMultiTurnHashChanges(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1}
-
-	round1 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "hello"}},
-			},
-		},
-		SessionContext: ctx,
-	}
-
-	round2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "hello"}},
-			},
-			map[string]any{
-				"role":  "model",
-				"parts": []any{map[string]any{"text": "Hi!"}},
-			},
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "How are you?"}},
-			},
-		},
-		SessionContext: ctx,
-	}
+	round1 := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "hello")}), ctx)
+	round2 := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "hello"), geminiMsg("model", "Hi!"), geminiMsg("user", "How are you?")}), ctx)
 
 	h1 := svc.GenerateSessionHash(round1)
 	h2 := svc.GenerateSessionHash(round2)
@@ -1031,34 +502,9 @@ func TestGenerateSessionHash_GeminiMultiTurnHashChanges(t *testing.T) {
 
 func TestGenerateSessionHash_GeminiDifferentUsersSameContentDifferentHash(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 核心场景：两个不同用户发送相同 Gemini 格式消息应得到不同 hash
-	user1 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "hello"}},
-			},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "1.1.1.1",
-			UserAgent: "gemini-cli",
-			APIKeyID:  10,
-		},
-	}
-	user2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "hello"}},
-			},
-		},
-		SessionContext: &SessionContext{
-			ClientIP:  "2.2.2.2",
-			UserAgent: "gemini-cli",
-			APIKeyID:  20,
-		},
-	}
+	body := geminiSessionBody(nil, []any{geminiMsg("user", "hello")})
+	user1 := mustParseGeminiSessionHashRequest(t, body, &SessionContext{ClientIP: "1.1.1.1", UserAgent: "gemini-cli", APIKeyID: 10})
+	user2 := mustParseGeminiSessionHashRequest(t, body, &SessionContext{ClientIP: "2.2.2.2", UserAgent: "gemini-cli", APIKeyID: 20})
 
 	h1 := svc.GenerateSessionHash(user1)
 	h2 := svc.GenerateSessionHash(user2)
@@ -1067,31 +513,9 @@ func TestGenerateSessionHash_GeminiDifferentUsersSameContentDifferentHash(t *tes
 
 func TestGenerateSessionHash_GeminiSystemInstructionAffectsHash(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1}
-
-	// systemInstruction 经 ParseGatewayRequest 解析后存入 parsed.System
-	withSys := &ParsedRequest{
-		System: []any{
-			map[string]any{"text": "You are a coding assistant."},
-		},
-		Messages: []any{
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "hello"}},
-			},
-		},
-		SessionContext: ctx,
-	}
-	withoutSys := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role":  "user",
-				"parts": []any{map[string]any{"text": "hello"}},
-			},
-		},
-		SessionContext: ctx,
-	}
+	withSys := mustParseGeminiSessionHashRequest(t, geminiSessionBody([]any{map[string]any{"text": "You are a coding assistant."}}, []any{geminiMsg("user", "hello")}), ctx)
+	withoutSys := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "hello")}), ctx)
 
 	h1 := svc.GenerateSessionHash(withSys)
 	h2 := svc.GenerateSessionHash(withoutSys)
@@ -1100,64 +524,21 @@ func TestGenerateSessionHash_GeminiSystemInstructionAffectsHash(t *testing.T) {
 
 func TestGenerateSessionHash_GeminiMultiPartMessage(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1}
-
-	// 多 parts 的消息
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"parts": []any{
-					map[string]any{"text": "Part 1"},
-					map[string]any{"text": "Part 2"},
-					map[string]any{"text": "Part 3"},
-				},
-			},
-		},
-		SessionContext: ctx,
-	}
-
+	parsed := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "Part 1", "Part 2", "Part 3")}), ctx)
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "multi-part Gemini message should produce a hash")
 
-	// 不同内容的多 parts
-	parsed2 := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"parts": []any{
-					map[string]any{"text": "Part 1"},
-					map[string]any{"text": "CHANGED"},
-					map[string]any{"text": "Part 3"},
-				},
-			},
-		},
-		SessionContext: ctx,
-	}
-
+	parsed2 := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, []any{geminiMsg("user", "Part 1", "CHANGED", "Part 3")}), ctx)
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.NotEqual(t, h, h2, "changing a part should change the hash")
 }
 
 func TestGenerateSessionHash_GeminiNonTextPartsIgnored(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "gemini-cli", APIKeyID: 1}
-
-	// 含非 text 类型 parts（如 inline_data），应被跳过但不报错
-	parsed := &ParsedRequest{
-		Messages: []any{
-			map[string]any{
-				"role": "user",
-				"parts": []any{
-					map[string]any{"text": "Describe this image"},
-					map[string]any{"inline_data": map[string]any{"mime_type": "image/png", "data": "base64..."}},
-				},
-			},
-		},
-		SessionContext: ctx,
-	}
+	content := []any{map[string]any{"role": "user", "parts": []any{map[string]any{"text": "Describe this image"}, map[string]any{"inline_data": map[string]any{"mime_type": "image/png", "data": "base64..."}}}}}
+	parsed := mustParseGeminiSessionHashRequest(t, geminiSessionBody(nil, content), ctx)
 
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "Gemini message with mixed parts should still produce a hash from text parts")
@@ -1165,107 +546,41 @@ func TestGenerateSessionHash_GeminiNonTextPartsIgnored(t *testing.T) {
 
 func TestGenerateSessionHash_GeminiMultiTurnHashNotSticky(t *testing.T) {
 	svc := &GatewayService{}
-
 	ctx := &SessionContext{ClientIP: "10.0.0.1", UserAgent: "gemini-cli", APIKeyID: 42}
+	rounds := []string{
+		geminiSessionBody([]any{map[string]any{"text": "You are a coding assistant."}}, []any{geminiMsg("user", "Write a Go function")}),
+		geminiSessionBody([]any{map[string]any{"text": "You are a coding assistant."}}, []any{geminiMsg("user", "Write a Go function"), geminiMsg("model", "func hello() {}"), geminiMsg("user", "Add error handling")}),
+		geminiSessionBody([]any{map[string]any{"text": "You are a coding assistant."}}, []any{geminiMsg("user", "Write a Go function"), geminiMsg("model", "func hello() {}"), geminiMsg("user", "Add error handling"), geminiMsg("model", "func hello() error { return nil }"), geminiMsg("user", "Now add tests")}),
+	}
 
-	// 模拟同一 Gemini 会话的三轮请求，每轮 contents 累积增长。
-	// 验证预期行为：每轮 hash 都不同，即 GenerateSessionHash 不具备跨轮粘性。
-	// 这是 by-design 的——Gemini 的跨轮粘性由 Digest Fallback（BuildGeminiDigestChain）负责。
-	round1Body := []byte(`{
-		"systemInstruction": {"parts": [{"text": "You are a coding assistant."}]},
-		"contents": [
-			{"role": "user", "parts": [{"text": "Write a Go function"}]}
-		]
-	}`)
-	round2Body := []byte(`{
-		"systemInstruction": {"parts": [{"text": "You are a coding assistant."}]},
-		"contents": [
-			{"role": "user", "parts": [{"text": "Write a Go function"}]},
-			{"role": "model", "parts": [{"text": "func hello() {}"}]},
-			{"role": "user", "parts": [{"text": "Add error handling"}]}
-		]
-	}`)
-	round3Body := []byte(`{
-		"systemInstruction": {"parts": [{"text": "You are a coding assistant."}]},
-		"contents": [
-			{"role": "user", "parts": [{"text": "Write a Go function"}]},
-			{"role": "model", "parts": [{"text": "func hello() {}"}]},
-			{"role": "user", "parts": [{"text": "Add error handling"}]},
-			{"role": "model", "parts": [{"text": "func hello() error { return nil }"}]},
-			{"role": "user", "parts": [{"text": "Now add tests"}]}
-		]
-	}`)
-
-	hashes := make([]string, 3)
-	for i, body := range [][]byte{round1Body, round2Body, round3Body} {
-		parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
-		require.NoError(t, err)
-		parsed.SessionContext = ctx
+	hashes := make([]string, len(rounds))
+	for i, body := range rounds {
+		parsed := mustParseGeminiSessionHashRequest(t, body, ctx)
 		hashes[i] = svc.GenerateSessionHash(parsed)
 		require.NotEmpty(t, hashes[i], "round %d hash should not be empty", i+1)
 	}
-
-	// 每轮 hash 都不同——这是预期行为
 	require.NotEqual(t, hashes[0], hashes[1], "round 1 vs 2 hash should differ (contents grow)")
 	require.NotEqual(t, hashes[1], hashes[2], "round 2 vs 3 hash should differ (contents grow)")
 	require.NotEqual(t, hashes[0], hashes[2], "round 1 vs 3 hash should differ")
 
-	// 同一轮重试应产生相同 hash
-	parsed1Again, err := ParseGatewayRequest(NewRequestBodyRef(round2Body), "gemini")
-	require.NoError(t, err)
-	parsed1Again.SessionContext = ctx
-	h2Again := svc.GenerateSessionHash(parsed1Again)
+	parsedAgain := mustParseGeminiSessionHashRequest(t, rounds[1], ctx)
+	h2Again := svc.GenerateSessionHash(parsedAgain)
 	require.Equal(t, hashes[1], h2Again, "retry of same round should produce same hash")
 }
 
 func TestGenerateSessionHash_GeminiEndToEnd(t *testing.T) {
 	svc := &GatewayService{}
-
-	// 端到端测试：模拟 ParseGatewayRequest + GenerateSessionHash 完整流程
-	body := []byte(`{
-		"model": "gemini-2.5-pro",
-		"systemInstruction": {
-			"parts": [{"text": "You are a coding assistant."}]
-		},
-		"contents": [
-			{"role": "user", "parts": [{"text": "Write a Go function"}]},
-			{"role": "model", "parts": [{"text": "Here is a function..."}]},
-			{"role": "user", "parts": [{"text": "Now add error handling"}]}
-		]
-	}`)
-
-	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
-	require.NoError(t, err)
-	parsed.SessionContext = &SessionContext{
-		ClientIP:  "10.0.0.1",
-		UserAgent: "gemini-cli/1.0",
-		APIKeyID:  42,
-	}
+	body := geminiSessionBody([]any{map[string]any{"text": "You are a coding assistant."}}, []any{geminiMsg("user", "Write a Go function"), geminiMsg("model", "Here is a function..."), geminiMsg("user", "Now add error handling")})
+	parsed := mustParseGeminiSessionHashRequest(t, body, &SessionContext{ClientIP: "10.0.0.1", UserAgent: "gemini-cli/1.0", APIKeyID: 42})
 
 	h := svc.GenerateSessionHash(parsed)
 	require.NotEmpty(t, h, "end-to-end Gemini flow should produce a hash")
 
-	// 同一请求再次解析应产生相同 hash
-	parsed2, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
-	require.NoError(t, err)
-	parsed2.SessionContext = &SessionContext{
-		ClientIP:  "10.0.0.1",
-		UserAgent: "gemini-cli/1.0",
-		APIKeyID:  42,
-	}
-
+	parsed2 := mustParseGeminiSessionHashRequest(t, body, &SessionContext{ClientIP: "10.0.0.1", UserAgent: "gemini-cli/1.0", APIKeyID: 42})
 	h2 := svc.GenerateSessionHash(parsed2)
 	require.Equal(t, h, h2, "same request should produce same hash")
 
-	// 不同用户发送相同请求应产生不同 hash
-	parsed3, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
-	require.NoError(t, err)
-	parsed3.SessionContext = &SessionContext{
-		ClientIP:  "10.0.0.2",
-		UserAgent: "gemini-cli/1.0",
-		APIKeyID:  99,
-	}
-
+	parsed3 := mustParseGeminiSessionHashRequest(t, body, &SessionContext{ClientIP: "10.0.0.2", UserAgent: "gemini-cli/1.0", APIKeyID: 99})
 	h3 := svc.GenerateSessionHash(parsed3)
 	require.NotEqual(t, h, h3, "different user with same Gemini request should get different hash")
 }

--- a/backend/internal/service/generate_session_hash_test.go
+++ b/backend/internal/service/generate_session_hash_test.go
@@ -1198,7 +1198,7 @@ func TestGenerateSessionHash_GeminiMultiTurnHashNotSticky(t *testing.T) {
 
 	hashes := make([]string, 3)
 	for i, body := range [][]byte{round1Body, round2Body, round3Body} {
-		parsed, err := ParseGatewayRequest(body, "gemini")
+		parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
 		require.NoError(t, err)
 		parsed.SessionContext = ctx
 		hashes[i] = svc.GenerateSessionHash(parsed)
@@ -1211,7 +1211,7 @@ func TestGenerateSessionHash_GeminiMultiTurnHashNotSticky(t *testing.T) {
 	require.NotEqual(t, hashes[0], hashes[2], "round 1 vs 3 hash should differ")
 
 	// 同一轮重试应产生相同 hash
-	parsed1Again, err := ParseGatewayRequest(round2Body, "gemini")
+	parsed1Again, err := ParseGatewayRequest(NewRequestBodyRef(round2Body), "gemini")
 	require.NoError(t, err)
 	parsed1Again.SessionContext = ctx
 	h2Again := svc.GenerateSessionHash(parsed1Again)
@@ -1234,7 +1234,7 @@ func TestGenerateSessionHash_GeminiEndToEnd(t *testing.T) {
 		]
 	}`)
 
-	parsed, err := ParseGatewayRequest(body, "gemini")
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
 	require.NoError(t, err)
 	parsed.SessionContext = &SessionContext{
 		ClientIP:  "10.0.0.1",
@@ -1246,7 +1246,7 @@ func TestGenerateSessionHash_GeminiEndToEnd(t *testing.T) {
 	require.NotEmpty(t, h, "end-to-end Gemini flow should produce a hash")
 
 	// 同一请求再次解析应产生相同 hash
-	parsed2, err := ParseGatewayRequest(body, "gemini")
+	parsed2, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
 	require.NoError(t, err)
 	parsed2.SessionContext = &SessionContext{
 		ClientIP:  "10.0.0.1",
@@ -1258,7 +1258,7 @@ func TestGenerateSessionHash_GeminiEndToEnd(t *testing.T) {
 	require.Equal(t, h, h2, "same request should produce same hash")
 
 	// 不同用户发送相同请求应产生不同 hash
-	parsed3, err := ParseGatewayRequest(body, "gemini")
+	parsed3, err := ParseGatewayRequest(NewRequestBodyRef(body), "gemini")
 	require.NoError(t, err)
 	parsed3.SessionContext = &SessionContext{
 		ClientIP:  "10.0.0.2",

--- a/backend/internal/service/image_generation_intent.go
+++ b/backend/internal/service/image_generation_intent.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"encoding/json"
 	"strings"
 
 	"github.com/tidwall/gjson"
@@ -91,13 +90,43 @@ func openAIJSONToolsContainImageGeneration(tools gjson.Result) bool {
 	}
 	found := false
 	tools.ForEach(func(_, item gjson.Result) bool {
-		if strings.TrimSpace(item.Get("type").String()) == "image_generation" {
+		if openAIJSONString(item.Get("type")) == "image_generation" {
 			found = true
 			return false
 		}
 		return true
 	})
 	return found
+}
+
+func openAIRequestBodyHasImageGenerationTool(body []byte) bool {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return false
+	}
+	return openAIJSONToolsContainImageGeneration(gjson.GetBytes(body, "tools"))
+}
+
+func openAIRequestBodyImageGenerationToolNeedsNormalization(body []byte) bool {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return false
+	}
+	tools := gjson.GetBytes(body, "tools")
+	if !tools.IsArray() {
+		return false
+	}
+	needsNormalization := false
+	tools.ForEach(func(_, item gjson.Result) bool {
+		if openAIJSONString(item.Get("type")) != "image_generation" {
+			return true
+		}
+		// 只有旧字段需要迁移时才进入 map 修改，纯计费读取保持 raw 路径。
+		if item.Get("format").Exists() || item.Get("compression").Exists() {
+			needsNormalization = true
+			return false
+		}
+		return true
+	})
+	return needsNormalization
 }
 
 func openAIJSONToolChoiceSelectsImageGeneration(choice gjson.Result) bool {
@@ -159,17 +188,6 @@ func apiKeyGroup(apiKey *APIKey) *Group {
 	return apiKey.Group
 }
 
-func cloneRequestMapForImageIntent(body []byte) map[string]any {
-	if len(body) == 0 {
-		return nil
-	}
-	var out map[string]any
-	if err := json.Unmarshal(body, &out); err != nil {
-		return nil
-	}
-	return out
-}
-
 type OpenAIResponsesImageBillingConfig struct {
 	Model     string
 	SizeTier  string
@@ -225,8 +243,43 @@ func resolveOpenAIResponsesImageBillingConfigFromBody(body []byte, fallbackModel
 }
 
 func resolveOpenAIResponsesImageBillingConfigDetailedFromBody(body []byte, fallbackModel string) (OpenAIResponsesImageBillingConfig, error) {
-	reqBody := cloneRequestMapForImageIntent(body)
-	return resolveOpenAIResponsesImageBillingConfigDetailed(reqBody, fallbackModel)
+	imageModel := ""
+	imageSize := ""
+	hasImageTool := false
+	if len(body) > 0 && gjson.ValidBytes(body) {
+		tools := gjson.GetBytes(body, "tools")
+		if tools.IsArray() {
+			tools.ForEach(func(_, item gjson.Result) bool {
+				if openAIJSONString(item.Get("type")) != "image_generation" {
+					return true
+				}
+				hasImageTool = true
+				imageModel = openAIJSONString(item.Get("model"))
+				imageSize = openAIJSONString(item.Get("size"))
+				return false
+			})
+		}
+		if imageSize == "" {
+			imageSize = openAIJSONString(gjson.GetBytes(body, "size"))
+		}
+		if imageModel == "" {
+			bodyModel := openAIJSONString(gjson.GetBytes(body, "model"))
+			if isOpenAIImageBillingModelAlias(bodyModel) || !hasImageTool {
+				imageModel = bodyModel
+			}
+		}
+	}
+	if imageModel == "" && hasImageTool {
+		imageModel = "gpt-image-2"
+	}
+	if imageModel == "" {
+		imageModel = strings.TrimSpace(fallbackModel)
+	}
+	return OpenAIResponsesImageBillingConfig{
+		Model:     imageModel,
+		SizeTier:  normalizeOpenAIImageSizeTier(imageSize),
+		InputSize: imageSize,
+	}, nil
 }
 
 func isOpenAIImageBillingModelAlias(model string) bool {
@@ -235,4 +288,11 @@ func isOpenAIImageBillingModelAlias(model string) bool {
 		return false
 	}
 	return isOpenAIImageGenerationModel(normalized) || strings.Contains(normalized, "image")
+}
+
+func openAIJSONString(value gjson.Result) string {
+	if value.Type != gjson.String {
+		return ""
+	}
+	return strings.TrimSpace(value.String())
 }

--- a/backend/internal/service/image_generation_intent_test.go
+++ b/backend/internal/service/image_generation_intent_test.go
@@ -84,6 +84,17 @@ func TestResolveOpenAIResponsesImageBillingConfigToolModelWins(t *testing.T) {
 	require.Equal(t, "2K", imageSize)
 }
 
+func TestResolveOpenAIResponsesImageBillingConfigFromBodyIgnoresUnrelatedLargeInput(t *testing.T) {
+	cfg, err := resolveOpenAIResponsesImageBillingConfigDetailedFromBody(
+		[]byte(`{"model":"mapped-text-model","tools":[{"type":"image_generation","model":"gpt-image-2","size":"2048x1152"}],"input":[{"type":"message","content":[{"type":"input_text","text":"hi","nonce":1e1000000}]}]}`),
+		"requested-model",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-image-2", cfg.Model)
+	require.Equal(t, "2K", cfg.SizeTier)
+	require.Equal(t, "2048x1152", cfg.InputSize)
+}
+
 func TestResolveOpenAIResponsesImageBillingConfigSupportsOfficialAndCustomSizes(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/internal/service/openai_embeddings.go
+++ b/backend/internal/service/openai_embeddings.go
@@ -104,7 +104,7 @@ func (s *OpenAIGatewayService) ForwardEmbeddings(
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -241,7 +241,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 
 	// 8. Handle error response with failover
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -183,7 +183,7 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 
 	// 7. Handle error response with failover
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -300,7 +300,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 
 	// 8. Handle error response with failover
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -163,7 +163,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -49,6 +49,8 @@ const (
 	// OpenAI WS Mode 失败后的重连次数上限（不含首次尝试）。
 	// 与 Codex 客户端保持一致：失败后最多重连 5 次。
 	openAIWSReconnectRetryLimit = 5
+	// 上游错误体只需要提取错误 JSON/日志摘要，默认 512KiB 避免错误风暴叠加大请求体。
+	openAIUpstreamErrorBodyReadLimit int64 = 512 << 10
 	// OpenAI WS Mode 重连退避默认值（可由配置覆盖）。
 	openAIWSRetryBackoffInitialDefault = 120 * time.Millisecond
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
@@ -2296,8 +2298,28 @@ func marshalOpenAIUpstreamJSON(v any) ([]byte, error) {
 	return out, nil
 }
 
+func openAIUpstreamErrorBodyReadLimitForConfig(cfg *config.Config) int64 {
+	limit := openAIUpstreamErrorBodyReadLimit
+	if cfg != nil && cfg.Gateway.LogUpstreamErrorBody && cfg.Gateway.LogUpstreamErrorBodyMaxBytes > int(limit) {
+		limit = int64(cfg.Gateway.LogUpstreamErrorBodyMaxBytes)
+	}
+	return limit
+}
+
+func (s *OpenAIGatewayService) readUpstreamErrorBody(resp *http.Response) []byte {
+	if resp == nil || resp.Body == nil {
+		return nil
+	}
+	cfg := (*config.Config)(nil)
+	if s != nil {
+		cfg = s.cfg
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, openAIUpstreamErrorBodyReadLimitForConfig(cfg)))
+	return body
+}
+
 func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, requestedModel ...string) {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body := s.readUpstreamErrorBody(resp)
 	if len(requestedModel) > 0 {
 		s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, requestedModel[0])
 		return
@@ -3045,7 +3067,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 		// Handle error response
 		if resp.StatusCode >= 400 {
-			respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 
@@ -3563,7 +3585,7 @@ func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(
 	account *Account,
 	requestBody []byte,
 ) error {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body := s.readUpstreamErrorBody(resp)
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
 	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -3605,7 +3627,7 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 	account *Account,
 	requestBody []byte,
 ) error {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body := s.readUpstreamErrorBody(resp)
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
 	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -4298,7 +4320,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	requestBody []byte,
 	requestedModel ...string,
 ) (*OpenAIForwardResult, error) {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body := s.readUpstreamErrorBody(resp)
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
 	upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -4459,7 +4481,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 	writeError compatErrorWriter,
 	requestedModel ...string,
 ) (*OpenAIForwardResult, error) {
-	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	body := s.readUpstreamErrorBody(resp)
 
 	upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(body))
 	if upstreamMsg == "" {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -36,6 +36,13 @@ import (
 	"go.uber.org/zap"
 )
 
+// openAIParsedRequestBodyCache 绑定 body 指纹，避免 handler 预解析的旧 body 污染后续 forwardBody。
+type openAIParsedRequestBodyCache struct {
+	bodyHash uint64
+	bodyLen  int
+	reqBody  map[string]any
+}
+
 const (
 	// ChatGPT internal API for OAuth accounts
 	chatgptCodexURL = "https://chatgpt.com/backend-api/codex/responses"
@@ -2284,6 +2291,20 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
 }
 
+func marshalOpenAIUpstreamJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	if len(out) > 0 && out[len(out)-1] == '\n' {
+		out = out[:len(out)-1]
+	}
+	return out, nil
+}
+
 func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, resp *http.Response, account *Account, requestedModel ...string) {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
 	if len(requestedModel) > 0 {
@@ -2561,7 +2582,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		// 确保高版本模型向低版本模型映射不报错
 		if !SupportsVerbosity(upstreamModel) {
 			if text, ok := reqBody["text"].(map[string]any); ok {
-				delete(text, "verbosity")
+				if _, exists := text["verbosity"]; exists {
+					delete(text, "verbosity")
+					bodyModified = true
+					markPatchDelete("text.verbosity")
+				}
 			}
 		}
 	}
@@ -2762,7 +2787,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		if !serializedByPatch {
 			var marshalErr error
-			body, marshalErr = json.Marshal(reqBody)
+			body, marshalErr = marshalOpenAIUpstreamJSON(reqBody)
 			if marshalErr != nil {
 				return nil, fmt.Errorf("serialize request body: %w", marshalErr)
 			}
@@ -3043,7 +3068,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			upstreamCode := extractUpstreamErrorCode(respBody)
 			if !httpInvalidEncryptedContentRetryTried && resp.StatusCode == http.StatusBadRequest && upstreamCode == "invalid_encrypted_content" {
 				if trimOpenAIEncryptedReasoningItems(reqBody) {
-					body, err = json.Marshal(reqBody)
+					body, err = marshalOpenAIUpstreamJSON(reqBody)
 					if err != nil {
 						return nil, fmt.Errorf("serialize invalid_encrypted_content retry body: %w", err)
 					}
@@ -3074,6 +3099,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				})
 
 				s.handleFailoverSideEffects(ctx, resp, account, upstreamModel)
+				// reqBody 会被本次账号尝试原地修改，failover 前必须释放，避免下一账号复用脏 map。
+				releaseOpenAIParsedRequestBody(c)
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
@@ -6711,7 +6738,7 @@ func sanitizeEmptyBase64InputImagesInOpenAIBody(body []byte) ([]byte, bool, erro
 	if !sanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap(reqBody) {
 		return body, false, nil
 	}
-	normalized, err := json.Marshal(reqBody)
+	normalized, err := marshalOpenAIUpstreamJSON(reqBody)
 	if err != nil {
 		return body, false, fmt.Errorf("serialize sanitized request body: %w", err)
 	}
@@ -6817,10 +6844,13 @@ func isEmptyBase64DataURI(raw string) bool {
 }
 
 func getOpenAIRequestBodyMap(c *gin.Context, body []byte) (map[string]any, error) {
+	// 同一个 gin.Context 内 failover/渠道映射可能传入新 body，缓存必须先校验 body 指纹。
+	bodyHash := xxhash.Sum64(body)
+	bodyLen := len(body)
 	if c != nil {
 		if cached, ok := c.Get(OpenAIParsedRequestBodyKey); ok {
-			if reqBody, ok := cached.(map[string]any); ok && reqBody != nil {
-				return reqBody, nil
+			if cache, ok := cached.(openAIParsedRequestBodyCache); ok && cache.reqBody != nil && cache.bodyLen == bodyLen && cache.bodyHash == bodyHash {
+				return cache.reqBody, nil
 			}
 		}
 	}
@@ -6830,9 +6860,34 @@ func getOpenAIRequestBodyMap(c *gin.Context, body []byte) (map[string]any, error
 		return nil, fmt.Errorf("parse request: %w", err)
 	}
 	if c != nil {
-		c.Set(OpenAIParsedRequestBodyKey, reqBody)
+		c.Set(OpenAIParsedRequestBodyKey, openAIParsedRequestBodyCache{bodyHash: bodyHash, bodyLen: bodyLen, reqBody: reqBody})
 	}
 	return reqBody, nil
+}
+
+// CacheOpenAIParsedRequestBody 仅缓存与当前 body 绑定的解析结果。
+func CacheOpenAIParsedRequestBody(c *gin.Context, body []byte, reqBody map[string]any) {
+	if c == nil || reqBody == nil {
+		return
+	}
+	c.Set(OpenAIParsedRequestBodyKey, openAIParsedRequestBodyCache{
+		bodyHash: xxhash.Sum64(body),
+		bodyLen:  len(body),
+		reqBody:  reqBody,
+	})
+}
+
+// CachedOpenAIParsedRequestBody 只给同请求内不关心 body 参数的轻量识别逻辑使用。
+func CachedOpenAIParsedRequestBody(c *gin.Context) map[string]any {
+	if c == nil {
+		return nil
+	}
+	if cached, ok := c.Get(OpenAIParsedRequestBodyKey); ok {
+		if cache, ok := cached.(openAIParsedRequestBodyCache); ok {
+			return cache.reqBody
+		}
+	}
+	return nil
 }
 
 func releaseOpenAIParsedRequestBody(c *gin.Context) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -36,13 +36,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// openAIParsedRequestBodyCache 绑定 body 指纹，避免 handler 预解析的旧 body 污染后续 forwardBody。
-type openAIParsedRequestBodyCache struct {
-	bodyHash uint64
-	bodyLen  int
-	reqBody  map[string]any
-}
-
 const (
 	// ChatGPT internal API for OAuth accounts
 	chatgptCodexURL = "https://chatgpt.com/backend-api/codex/responses"
@@ -53,8 +46,6 @@ const (
 	// codex_cli_only 拒绝时单个请求头日志长度上限（字符）
 	codexCLIOnlyHeaderValueMaxBytes = 256
 
-	// OpenAIParsedRequestBodyKey 缓存 handler 侧已解析的请求体，避免重复解析。
-	OpenAIParsedRequestBodyKey = "openai_parsed_request_body"
 	// OpenAI WS Mode 失败后的重连次数上限（不含首次尝试）。
 	// 与 Codex 客户端保持一致：失败后最多重连 5 次。
 	openAIWSReconnectRetryLimit = 5
@@ -3099,8 +3090,6 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				})
 
 				s.handleFailoverSideEffects(ctx, resp, account, upstreamModel)
-				// reqBody 会被本次账号尝试原地修改，failover 前必须释放，避免下一账号复用脏 map。
-				releaseOpenAIParsedRequestBody(c)
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
@@ -3113,7 +3102,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 		reasoningEffort := extractOpenAIReasoningEffort(reqBody, originalModel)
 		serviceTier := extractOpenAIServiceTier(reqBody)
-		releaseOpenAIParsedRequestBody(c)
+		// 上游接受后只保留计费需要的标量，避免响应处理期间继续保活完整 input/tools map。
+		reqBody = nil
 
 		// Handle normal response
 		var usage *OpenAIUsage
@@ -6843,58 +6833,12 @@ func isEmptyBase64DataURI(raw string) bool {
 	return strings.TrimSpace(strings.TrimPrefix(rest, "base64,")) == ""
 }
 
-func getOpenAIRequestBodyMap(c *gin.Context, body []byte) (map[string]any, error) {
-	// 同一个 gin.Context 内 failover/渠道映射可能传入新 body，缓存必须先校验 body 指纹。
-	bodyHash := xxhash.Sum64(body)
-	bodyLen := len(body)
-	if c != nil {
-		if cached, ok := c.Get(OpenAIParsedRequestBodyKey); ok {
-			if cache, ok := cached.(openAIParsedRequestBodyCache); ok && cache.reqBody != nil && cache.bodyLen == bodyLen && cache.bodyHash == bodyHash {
-				return cache.reqBody, nil
-			}
-		}
-	}
-
+func getOpenAIRequestBodyMap(_ *gin.Context, body []byte) (map[string]any, error) {
 	var reqBody map[string]any
 	if err := json.Unmarshal(body, &reqBody); err != nil {
 		return nil, fmt.Errorf("parse request: %w", err)
 	}
-	if c != nil {
-		c.Set(OpenAIParsedRequestBodyKey, openAIParsedRequestBodyCache{bodyHash: bodyHash, bodyLen: bodyLen, reqBody: reqBody})
-	}
 	return reqBody, nil
-}
-
-// CacheOpenAIParsedRequestBody 仅缓存与当前 body 绑定的解析结果。
-func CacheOpenAIParsedRequestBody(c *gin.Context, body []byte, reqBody map[string]any) {
-	if c == nil || reqBody == nil {
-		return
-	}
-	c.Set(OpenAIParsedRequestBodyKey, openAIParsedRequestBodyCache{
-		bodyHash: xxhash.Sum64(body),
-		bodyLen:  len(body),
-		reqBody:  reqBody,
-	})
-}
-
-// CachedOpenAIParsedRequestBody 只给同请求内不关心 body 参数的轻量识别逻辑使用。
-func CachedOpenAIParsedRequestBody(c *gin.Context) map[string]any {
-	if c == nil {
-		return nil
-	}
-	if cached, ok := c.Get(OpenAIParsedRequestBodyKey); ok {
-		if cache, ok := cached.(openAIParsedRequestBodyCache); ok {
-			return cache.reqBody
-		}
-	}
-	return nil
-}
-
-func releaseOpenAIParsedRequestBody(c *gin.Context) {
-	if c == nil {
-		return
-	}
-	delete(c.Keys, OpenAIParsedRequestBodyKey)
 }
 
 func extractOpenAIReasoningEffort(reqBody map[string]any, requestedModel string) *string {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2544,6 +2544,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Added Codex image_generation bridge instructions")
 		}
 	} else if imageGenerationAllowed && imageIntent && openAIRequestBodyHasImageGenerationTool(body) {
+		// 完整 image_generation tool 只做 raw 计费读取，校验/桥接/旧字段迁移命中时才展开大 input map。
 		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] /responses image_generation request inbound_model=%s mapped_model=%s account_type=%s", requestView.Model, upstreamModel, account.Type)
 	}
 
@@ -6215,7 +6216,7 @@ func (v *openAIRequestView) MarkPatchSet(path string, value any) {
 		return
 	}
 	path = strings.TrimSpace(path)
-	if path == "" {
+	if !isSimpleOpenAIRequestPatchPath(path) {
 		v.DisablePatches()
 		return
 	}
@@ -6227,11 +6228,23 @@ func (v *openAIRequestView) MarkPatchDelete(path string) {
 		return
 	}
 	path = strings.TrimSpace(path)
-	if path == "" {
+	if !isSimpleOpenAIRequestPatchPath(path) {
 		v.DisablePatches()
 		return
 	}
 	v.patches = append(v.patches, openAIRequestPatch{path: path, delete: true})
+}
+
+func isSimpleOpenAIRequestPatchPath(path string) bool {
+	if path == "" || strings.ContainsRune(path, '\\') {
+		return false
+	}
+	for _, part := range strings.Split(path, ".") {
+		if strings.TrimSpace(part) == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func (v *openAIRequestView) DisablePatches() {
@@ -6772,7 +6785,7 @@ func openAIRequestBodyMayContainImageInput(body []byte) bool {
 		return false
 	}
 	input := gjson.GetBytes(body, "input")
-	messages := gjson.GetBytes(body, "messages")
+	messages := gjson.GetBytes(body, "messages.#-1")
 	return openAIJSONValueMayContainImageInput(input) || openAIJSONValueMayContainImageInput(messages)
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2793,13 +2793,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 	// 命中 WS 时仅走 WebSocket Mode；不再自动回退 HTTP。
 	if wsDecision.Transport == OpenAIUpstreamTransportResponsesWebsocketV2 {
+		// WS 分支不会再回落 HTTP；重连恢复可直接更新 reqBody，避免额外保留一份完整顶层 map。
 		wsReqBody := reqBody
-		if len(reqBody) > 0 {
-			wsReqBody = make(map[string]any, len(reqBody))
-			for k, v := range reqBody {
-				wsReqBody[k] = v
-			}
-		}
 		_, hasPreviousResponseID := wsReqBody["previous_response_id"]
 		logOpenAIWSModeDebug(
 			"forward_start account_id=%d account_type=%s model=%s stream=%v has_previous_response_id=%v",

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2346,7 +2346,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	}
 
 	originalBody := body
-	reqModel, reqStream, promptCacheKey := extractOpenAIRequestMetaFromBody(body)
+	requestView := newOpenAIRequestView(body)
+	reqModel, reqStream, promptCacheKey := requestView.Model, requestView.Stream, requestView.PromptCacheKey
 	originalModel := reqModel
 
 	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
@@ -2396,7 +2397,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return s.forwardOpenAIPassthrough(ctx, c, account, originalBody, reqModel, reasoningEffort, reqStream, startTime)
 	}
 
-	reqBody, err := getOpenAIRequestBodyMap(c, body)
+	reqBody, err := requestView.Decode(c)
 	if err != nil {
 		return nil, err
 	}
@@ -6274,15 +6275,39 @@ func deriveOpenAIReasoningEffortFromModel(model string) string {
 	return normalizeOpenAIReasoningEffort(parts[len(parts)-1])
 }
 
-func extractOpenAIRequestMetaFromBody(body []byte) (model string, stream bool, promptCacheKey string) {
-	if len(body) == 0 {
-		return "", false, ""
-	}
+type openAIRequestView struct {
+	body               []byte
+	Model              string
+	Stream             bool
+	PromptCacheKey     string
+	PreviousResponseID string
+	ServiceTier        string
+	ReasoningEffort    string
+}
 
-	model = strings.TrimSpace(gjson.GetBytes(body, "model").String())
-	stream = gjson.GetBytes(body, "stream").Bool()
-	promptCacheKey = strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String())
-	return model, stream, promptCacheKey
+func newOpenAIRequestView(body []byte) openAIRequestView {
+	if len(body) == 0 {
+		return openAIRequestView{}
+	}
+	return openAIRequestView{
+		body:               body,
+		Model:              strings.TrimSpace(gjson.GetBytes(body, "model").String()),
+		Stream:             gjson.GetBytes(body, "stream").Bool(),
+		PromptCacheKey:     strings.TrimSpace(gjson.GetBytes(body, "prompt_cache_key").String()),
+		PreviousResponseID: strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String()),
+		ServiceTier:        strings.TrimSpace(gjson.GetBytes(body, "service_tier").String()),
+		ReasoningEffort:    strings.TrimSpace(gjson.GetBytes(body, "reasoning.effort").String()),
+	}
+}
+
+// Decode 保留阶段一既有 full-map 行为；后续阶段会把调用点下沉到复杂分支。
+func (v openAIRequestView) Decode(c *gin.Context) (map[string]any, error) {
+	return getOpenAIRequestBodyMap(c, v.body)
+}
+
+func extractOpenAIRequestMetaFromBody(body []byte) (model string, stream bool, promptCacheKey string) {
+	view := newOpenAIRequestView(body)
+	return view.Model, view.Stream, view.PromptCacheKey
 }
 
 // normalizeOpenAIPassthroughOAuthBody 将透传 OAuth 请求体收敛为旧链路关键行为：

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2397,172 +2397,83 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return s.forwardOpenAIPassthrough(ctx, c, account, originalBody, reqModel, reasoningEffort, reqStream, startTime)
 	}
 
-	reqBody, err := requestView.Decode(c)
-	if err != nil {
-		return nil, err
+	bodyModified := false
+	var reqBody map[string]any
+	ensureReqBody := func() (map[string]any, error) {
+		if requestView.HasPatches() {
+			patchedBody, patchErr := requestView.ApplyPatches()
+			if patchErr != nil {
+				return nil, patchErr
+			}
+			body = patchedBody
+			requestView = newOpenAIRequestView(body)
+			reqBody = nil
+			bodyModified = false
+		}
+		if reqBody != nil {
+			return reqBody, nil
+		}
+		decoded, decodeErr := requestView.Decode(c)
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		reqBody = decoded
+		return reqBody, nil
+	}
+	markPatchSet := func(path string, value any) {
+		bodyModified = true
+		if requestView.patchesDisabled {
+			if reqBody != nil {
+				setOpenAIRequestMapPath(reqBody, path, value)
+			}
+			return
+		}
+		requestView.MarkPatchSet(path, value)
+	}
+	markPatchDelete := func(path string) {
+		bodyModified = true
+		if requestView.patchesDisabled {
+			if reqBody != nil {
+				deleteOpenAIRequestMapPath(reqBody, path)
+			}
+			return
+		}
+		requestView.MarkPatchDelete(path)
+	}
+	disablePatch := func() {
+		requestView.DisablePatches()
+	}
+	markDecodedModified := func() {
+		bodyModified = true
+		disablePatch()
 	}
 
-	if v, ok := reqBody["model"].(string); ok {
-		reqModel = v
-		originalModel = reqModel
-	}
-	if v, ok := reqBody["stream"].(bool); ok {
-		reqStream = v
-	}
-	if promptCacheKey == "" {
-		if v, ok := reqBody["prompt_cache_key"].(string); ok {
-			promptCacheKey = strings.TrimSpace(v)
-		}
-	}
 	apiKey := getAPIKeyFromContext(c)
 	imageGenerationAllowed := GroupAllowsImageGeneration(nil)
 	if apiKey != nil {
 		imageGenerationAllowed = GroupAllowsImageGeneration(apiKey.Group)
 	}
 	codexImageGenerationBridgeEnabled := isCodexCLI && imageGenerationAllowed && s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey)
-	if IsImageGenerationIntentMap(openAIResponsesEndpoint, reqModel, reqBody) && !imageGenerationAllowed {
+	imageIntent := IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body)
+	if imageIntent && !imageGenerationAllowed {
 		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "permission_error",
-				"message": ImageGenerationPermissionMessage(),
-			},
-		})
+		c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"type": "permission_error", "message": ImageGenerationPermissionMessage()}})
 		return nil, errors.New("image generation disabled for group")
 	}
 
-	// Track if body needs re-serialization
-	bodyModified := false
-	// 单字段补丁快速路径：只要整个变更集最终可归约为同一路径的 set/delete，就避免全量 Marshal。
-	patchDisabled := false
-	patchHasOp := false
-	patchDelete := false
-	patchPath := ""
-	var patchValue any
-	markPatchSet := func(path string, value any) {
-		if strings.TrimSpace(path) == "" {
-			patchDisabled = true
-			return
-		}
-		if patchDisabled {
-			return
-		}
-		if !patchHasOp {
-			patchHasOp = true
-			patchDelete = false
-			patchPath = path
-			patchValue = value
-			return
-		}
-		if patchDelete || patchPath != path {
-			patchDisabled = true
-			return
-		}
-		patchValue = value
-	}
-	markPatchDelete := func(path string) {
-		if strings.TrimSpace(path) == "" {
-			patchDisabled = true
-			return
-		}
-		if patchDisabled {
-			return
-		}
-		if !patchHasOp {
-			patchHasOp = true
-			patchDelete = true
-			patchPath = path
-			return
-		}
-		if !patchDelete || patchPath != path {
-			patchDisabled = true
-		}
-	}
-	disablePatch := func() {
-		patchDisabled = true
-	}
-
-	// 非透传模式下，instructions 为空时注入默认指令。
-	if isInstructionsEmpty(reqBody) && !compatMessagesBridge {
-		reqBody["instructions"] = "You are a helpful coding assistant."
-		bodyModified = true
+	instructions := gjson.GetBytes(body, "instructions")
+	instructionsEmpty := !instructions.Exists() || instructions.Type != gjson.String || strings.TrimSpace(instructions.String()) == ""
+	if instructionsEmpty && !compatMessagesBridge {
 		markPatchSet("instructions", "You are a helpful coding assistant.")
 	}
 
-	if codexImageGenerationBridgeEnabled && ensureOpenAIResponsesImageGenerationTool(reqBody) {
-		bodyModified = true
-		disablePatch()
-		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Injected /responses image_generation tool for Codex client")
-	}
-
-	if normalizeOpenAIResponsesImageGenerationTools(reqBody) {
-		bodyModified = true
-		disablePatch()
-		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized /responses image_generation tool payload")
-	}
-	if codexImageGenerationBridgeEnabled && applyCodexImageGenerationBridgeInstructions(reqBody) {
-		bodyModified = true
-		disablePatch()
-		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Added Codex image_generation bridge instructions")
-	}
-
-	// 对所有请求执行模型映射（包含 Codex CLI）。
 	billingModel := account.GetMappedModel(reqModel)
 	if billingModel != reqModel {
 		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Model mapping applied: %s -> %s (account: %s, isCodexCLI: %v)", reqModel, billingModel, account.Name, isCodexCLI)
-		reqBody["model"] = billingModel
-		bodyModified = true
+		reqModel = billingModel
 		markPatchSet("model", billingModel)
 	}
 	upstreamModel := billingModel
-	if imageGenerationAllowed && normalizeOpenAIResponsesImageOnlyModel(reqBody) {
-		bodyModified = true
-		disablePatch()
-		if model, ok := reqBody["model"].(string); ok {
-			upstreamModel = strings.TrimSpace(model)
-		}
-		logger.LegacyPrintf(
-			"service.openai_gateway",
-			"[OpenAI] Normalized /responses image-only model request inbound_model=%s image_model=%s upstream_model=%s",
-			reqModel,
-			billingModel,
-			upstreamModel,
-		)
-	}
-	if err := validateOpenAIResponsesImageModel(reqBody, upstreamModel); err != nil {
-		setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": gin.H{
-				"type":    "invalid_request_error",
-				"message": err.Error(),
-				"param":   "model",
-			},
-		})
-		return nil, err
-	}
-	if hasOpenAIImageGenerationTool(reqBody) {
-		logger.LegacyPrintf(
-			"service.openai_gateway",
-			"[OpenAI] /responses image_generation request inbound_model=%s mapped_model=%s account_type=%s",
-			reqModel,
-			upstreamModel,
-			account.Type,
-		)
-	}
-	if err := validateCodexSparkInput(reqBody, upstreamModel); err != nil {
-		setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
-		c.JSON(http.StatusBadRequest, gin.H{
-			"error": gin.H{
-				"type":    "invalid_request_error",
-				"message": err.Error(),
-				"param":   "input",
-			},
-		})
-		return nil, err
-	}
-
-	// Compact-only model 映射：仅在 /responses/compact 路径生效，且优先级高于
-	// OAuth 模型规范化（避免 OAuth 规范化覆盖 compact-only 自定义模型）。
 	isCompactRequest := isOpenAIResponsesCompactPath(c)
 	compactMapped := false
 	if isCompactRequest {
@@ -2570,69 +2481,99 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		if compactMappedModel != "" && compactMappedModel != billingModel {
 			compactMapped = true
 			upstreamModel = compactMappedModel
-			reqBody["model"] = compactMappedModel
-			bodyModified = true
+			reqModel = compactMappedModel
 			markPatchSet("model", compactMappedModel)
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Compact model mapping applied: %s -> %s (account: %s, isCodexCLI: %v)", billingModel, compactMappedModel, account.Name, isCodexCLI)
 		}
 	}
-
-	// OpenAI OAuth 账号走 ChatGPT internal Codex endpoint，需要将模型名规范化为
-	// 上游可识别的 Codex/GPT 系列。API Key 账号则应保留原始/映射后的模型名，
-	// 以兼容自定义 base_url 的 OpenAI-compatible 上游。
-	if model, ok := reqBody["model"].(string); ok {
-		if !compactMapped {
-			upstreamModel = normalizeOpenAIModelForUpstream(account, model)
-			if upstreamModel != "" && upstreamModel != model {
-				logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Upstream model resolved: %s -> %s (account: %s, type: %s, isCodexCLI: %v)",
-					model, upstreamModel, account.Name, account.Type, isCodexCLI)
-				reqBody["model"] = upstreamModel
-				bodyModified = true
-				markPatchSet("model", upstreamModel)
-			}
+	if !compactMapped {
+		modelForNormalize := reqModel
+		if modelForNormalize == "" {
+			modelForNormalize = requestView.Model
 		}
-
-		// 移除 gpt-5.2-codex 以下的版本 verbosity 参数
-		// 确保高版本模型向低版本模型映射不报错
-		if !SupportsVerbosity(upstreamModel) {
-			if text, ok := reqBody["text"].(map[string]any); ok {
-				if _, exists := text["verbosity"]; exists {
-					delete(text, "verbosity")
-					bodyModified = true
-					markPatchDelete("text.verbosity")
-				}
-			}
+		upstreamModel = normalizeOpenAIModelForUpstream(account, modelForNormalize)
+		if upstreamModel != "" && upstreamModel != modelForNormalize {
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Upstream model resolved: %s -> %s (account: %s, type: %s, isCodexCLI: %v)", modelForNormalize, upstreamModel, account.Name, account.Type, isCodexCLI)
+			reqModel = upstreamModel
+			markPatchSet("model", upstreamModel)
 		}
 	}
+	if strings.TrimSpace(gjson.GetBytes(body, "reasoning.effort").String()) == "minimal" {
+		markPatchSet("reasoning.effort", "none")
+		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized reasoning.effort: minimal -> none (account: %s)", account.Name)
+	}
 
-	// 规范化 reasoning.effort 参数（minimal -> none），与上游允许值对齐。
-	if reasoning, ok := reqBody["reasoning"].(map[string]any); ok {
-		if effort, ok := reasoning["effort"].(string); ok && effort == "minimal" {
-			reasoning["effort"] = "none"
-			bodyModified = true
-			markPatchSet("reasoning.effort", "none")
-			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized reasoning.effort: minimal -> none (account: %s)", account.Name)
+	imageIntent = imageIntent || IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, nil) || isOpenAIImageGenerationModel(upstreamModel)
+	if imageIntent && !imageGenerationAllowed {
+		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
+		c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"type": "permission_error", "message": ImageGenerationPermissionMessage()}})
+		return nil, errors.New("image generation disabled for group")
+	}
+
+	if imageGenerationAllowed && (codexImageGenerationBridgeEnabled || isOpenAIImageGenerationModel(requestView.Model) || openAIRequestBodyImageGenerationToolNeedsNormalization(body) || isOpenAIImageGenerationModel(upstreamModel)) {
+		decoded, decodeErr := ensureReqBody()
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if codexImageGenerationBridgeEnabled && ensureOpenAIResponsesImageGenerationTool(decoded) {
+			markDecodedModified()
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Injected /responses image_generation tool for Codex client")
+		}
+		if normalizeOpenAIResponsesImageGenerationTools(decoded) {
+			markDecodedModified()
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized /responses image_generation tool payload")
+		}
+		if normalizeOpenAIResponsesImageOnlyModel(decoded) {
+			markDecodedModified()
+			if model, ok := decoded["model"].(string); ok {
+				upstreamModel = strings.TrimSpace(model)
+			}
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized /responses image-only model request inbound_model=%s image_model=%s upstream_model=%s", requestView.Model, billingModel, upstreamModel)
+		}
+		if err := validateOpenAIResponsesImageModel(decoded, upstreamModel); err != nil {
+			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"type": "invalid_request_error", "message": err.Error(), "param": "model"}})
+			return nil, err
+		}
+		if hasOpenAIImageGenerationTool(decoded) {
+			imageIntent = true
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] /responses image_generation request inbound_model=%s mapped_model=%s account_type=%s", requestView.Model, upstreamModel, account.Type)
+		}
+		if codexImageGenerationBridgeEnabled && applyCodexImageGenerationBridgeInstructions(decoded) {
+			markDecodedModified()
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Added Codex image_generation bridge instructions")
+		}
+	} else if imageGenerationAllowed && imageIntent && openAIRequestBodyHasImageGenerationTool(body) {
+		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] /responses image_generation request inbound_model=%s mapped_model=%s account_type=%s", requestView.Model, upstreamModel, account.Type)
+	}
+
+	if isCodexSparkModel(upstreamModel) && openAIRequestBodyMayContainImageInput(body) {
+		decoded, decodeErr := ensureReqBody()
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if err := validateCodexSparkInput(decoded, upstreamModel); err != nil {
+			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"type": "invalid_request_error", "message": err.Error(), "param": "input"}})
+			return nil, err
 		}
 	}
 
 	if account.Type == AccountTypeOAuth {
+		decoded, decodeErr := ensureReqBody()
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
 		codexResult := codexTransformResult{}
 		if compatMessagesBridge {
-			codexResult = applyCodexOAuthTransformWithOptions(reqBody, codexOAuthTransformOptions{
-				IsCodexCLI:              isCodexCLI,
-				IsCompact:               isCompactRequest,
-				SkipDefaultInstructions: true,
-				PreserveToolCallIDs:     true,
-			})
-			ensureCodexOAuthInstructionsField(reqBody)
-			bodyModified = true
-			disablePatch()
+			codexResult = applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{IsCodexCLI: isCodexCLI, IsCompact: isCompactRequest, SkipDefaultInstructions: true, PreserveToolCallIDs: true})
+			ensureCodexOAuthInstructionsField(decoded)
+			markDecodedModified()
 		} else {
-			codexResult = applyCodexOAuthTransform(reqBody, isCodexCLI, isCompactRequest)
+			codexResult = applyCodexOAuthTransform(decoded, isCodexCLI, isCompactRequest)
 		}
 		if codexResult.Modified {
-			bodyModified = true
-			disablePatch()
+			markDecodedModified()
 		}
 		if codexResult.NormalizedModel != "" {
 			upstreamModel = codexResult.NormalizedModel
@@ -2642,90 +2583,57 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	// Handle max_output_tokens based on platform and account type
+	if !SupportsVerbosity(upstreamModel) && gjson.GetBytes(body, "text.verbosity").Exists() {
+		markPatchDelete("text.verbosity")
+	}
+
 	if !isCodexCLI {
-		if maxOutputTokens, hasMaxOutputTokens := reqBody["max_output_tokens"]; hasMaxOutputTokens {
+		maxOutputTokens := gjson.GetBytes(body, "max_output_tokens")
+		if maxOutputTokens.Exists() {
 			switch account.Platform {
 			case PlatformOpenAI:
-				// For OpenAI API Key, remove max_output_tokens (not supported)
-				// For OpenAI OAuth (Responses API), keep it (supported)
 				if account.Type == AccountTypeAPIKey {
-					delete(reqBody, "max_output_tokens")
-					bodyModified = true
 					markPatchDelete("max_output_tokens")
 				}
 			case PlatformAnthropic:
-				// For Anthropic (Claude), convert to max_tokens
-				delete(reqBody, "max_output_tokens")
-				markPatchDelete("max_output_tokens")
-				if _, hasMaxTokens := reqBody["max_tokens"]; !hasMaxTokens {
-					reqBody["max_tokens"] = maxOutputTokens
-					disablePatch()
+				decoded, decodeErr := ensureReqBody()
+				if decodeErr != nil {
+					return nil, decodeErr
 				}
-				bodyModified = true
+				delete(decoded, "max_output_tokens")
+				if _, hasMaxTokens := decoded["max_tokens"]; !hasMaxTokens {
+					decoded["max_tokens"] = maxOutputTokens.Value()
+				}
+				markDecodedModified()
 			case PlatformGemini:
-				// For Gemini, remove (will be handled by Gemini-specific transform)
-				delete(reqBody, "max_output_tokens")
-				bodyModified = true
 				markPatchDelete("max_output_tokens")
 			default:
-				// For unknown platforms, remove to be safe
-				delete(reqBody, "max_output_tokens")
-				bodyModified = true
 				markPatchDelete("max_output_tokens")
 			}
 		}
-
-		// Also handle max_completion_tokens (similar logic)
-		if _, hasMaxCompletionTokens := reqBody["max_completion_tokens"]; hasMaxCompletionTokens {
-			if account.Type == AccountTypeAPIKey || account.Platform != PlatformOpenAI {
-				delete(reqBody, "max_completion_tokens")
-				bodyModified = true
-				markPatchDelete("max_completion_tokens")
-			}
+		if gjson.GetBytes(body, "max_completion_tokens").Exists() && (account.Type == AccountTypeAPIKey || account.Platform != PlatformOpenAI) {
+			markPatchDelete("max_completion_tokens")
 		}
-
-		// Remove unsupported fields (not supported by upstream OpenAI API)
-		unsupportedFields := []string{"prompt_cache_retention", "safety_identifier"}
-		for _, unsupportedField := range unsupportedFields {
-			if _, has := reqBody[unsupportedField]; has {
-				delete(reqBody, unsupportedField)
-				bodyModified = true
+		for _, unsupportedField := range []string{"prompt_cache_retention", "safety_identifier"} {
+			if gjson.GetBytes(body, unsupportedField).Exists() {
 				markPatchDelete(unsupportedField)
 			}
 		}
 	}
-
-	// 仅在 WSv2 模式保留 previous_response_id，其他模式（HTTP/WSv1）统一过滤。
-	// 注意：该规则同样适用于 Codex CLI 请求，避免 WSv1 向上游透传不支持字段。
-	if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
-		if _, has := reqBody["previous_response_id"]; has {
-			delete(reqBody, "previous_response_id")
-			bodyModified = true
-			markPatchDelete("previous_response_id")
+	if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 && gjson.GetBytes(body, "previous_response_id").Exists() {
+		markPatchDelete("previous_response_id")
+	}
+	if openAIRequestBodyMayContainEmptyBase64InputImage(body) {
+		decoded, decodeErr := ensureReqBody()
+		if decodeErr != nil {
+			return nil, decodeErr
+		}
+		if sanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap(decoded) {
+			markDecodedModified()
 		}
 	}
 
-	if sanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap(reqBody) {
-		bodyModified = true
-		disablePatch()
-	}
-
-	// Apply OpenAI fast policy (参照 Claude BetaPolicy 的 fast-mode 过滤)：
-	// 针对 body 的 service_tier 字段（"priority" 即 fast，"flex"），按策略
-	// 执行 filter（删除字段）或 block（拒绝请求）。对 gpt-5.5 等模型屏蔽
-	// fast 时在此生效。
-	//
-	// 注意：
-	//   1. 此处统一使用 upstreamModel（已经过 GetMappedModel +
-	//      normalizeOpenAIModelForUpstream + Codex OAuth normalize），与
-	//      chat-completions / messages 入口保持一致，避免不同入口因为模型
-	//      维度不同而出现 whitelist 命中差异。
-	//   2. action=pass 时也要把 raw "fast" 归一化为 "priority" 写回 body，
-	//      否则 native /responses 入口透传 "fast" 给上游会被拒。chat-
-	//      completions 入口由 normalizeResponsesBodyServiceTier 完成同一
-	//      行为，这里手工实现等效逻辑。
-	if rawTier, ok := reqBody["service_tier"].(string); ok {
+	if rawTier := requestView.ServiceTier; rawTier != "" {
 		if normTier := normalizedOpenAIServiceTierValue(rawTier); normTier != "" {
 			action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, upstreamModel, normTier)
 			switch action {
@@ -2738,74 +2646,56 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				writeOpenAIFastPolicyBlockedResponse(c, blocked)
 				return nil, blocked
 			case BetaPolicyActionFilter:
-				delete(reqBody, "service_tier")
-				bodyModified = true
-				disablePatch()
+				markPatchDelete("service_tier")
 			default:
-				// pass：若客户端传的是别名 "fast"，归一化为 "priority"
-				// 后写回 body，确保上游收到的是其能识别的规范值。
 				if normTier != rawTier {
-					reqBody["service_tier"] = normTier
-					bodyModified = true
 					markPatchSet("service_tier", normTier)
 				}
 			}
 		}
 	}
 
-	if IsImageGenerationIntentMap(openAIResponsesEndpoint, reqModel, reqBody) && !imageGenerationAllowed {
-		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "permission_error",
-				"message": ImageGenerationPermissionMessage(),
-			},
-		})
-		return nil, errors.New("image generation disabled for group")
+	if bodyModified {
+		if requestView.HasPatches() {
+			if patchedBody, patchErr := requestView.ApplyPatches(); patchErr == nil {
+				body = patchedBody
+				requestView = newOpenAIRequestView(body)
+				reqBody = nil
+				bodyModified = false
+			}
+		}
+		if bodyModified {
+			decoded, decodeErr := ensureReqBody()
+			if decodeErr != nil {
+				return nil, decodeErr
+			}
+			var marshalErr error
+			body, marshalErr = marshalOpenAIUpstreamJSON(decoded)
+			if marshalErr != nil {
+				return nil, fmt.Errorf("serialize request body: %w", marshalErr)
+			}
+			requestView = newOpenAIRequestView(body)
+		}
 	}
 	imageBillingModel := ""
 	imageSizeTier := ""
 	imageInputSize := ""
-	if IsImageGenerationIntentMap(openAIResponsesEndpoint, reqModel, reqBody) {
+	if imageIntent {
+		var imageCfg OpenAIResponsesImageBillingConfig
 		var imageCfgErr error
-		imageCfg, imageCfgErr := resolveOpenAIResponsesImageBillingConfigDetailed(reqBody, billingModel)
+		if reqBody != nil {
+			imageCfg, imageCfgErr = resolveOpenAIResponsesImageBillingConfigDetailed(reqBody, billingModel)
+		} else {
+			imageCfg, imageCfgErr = resolveOpenAIResponsesImageBillingConfigDetailedFromBody(body, billingModel)
+		}
 		if imageCfgErr != nil {
 			setOpsUpstreamError(c, http.StatusBadRequest, imageCfgErr.Error(), "")
-			c.JSON(http.StatusBadRequest, gin.H{
-				"error": gin.H{
-					"type":    "invalid_request_error",
-					"message": imageCfgErr.Error(),
-					"param":   "size",
-				},
-			})
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{"type": "invalid_request_error", "message": imageCfgErr.Error(), "param": "size"}})
 			return nil, imageCfgErr
 		}
 		imageBillingModel = imageCfg.Model
 		imageSizeTier = imageCfg.SizeTier
 		imageInputSize = imageCfg.InputSize
-	}
-
-	// Re-serialize body only if modified
-	if bodyModified {
-		serializedByPatch := false
-		if !patchDisabled && patchHasOp {
-			var patchErr error
-			if patchDelete {
-				body, patchErr = sjson.DeleteBytes(body, patchPath)
-			} else {
-				body, patchErr = sjson.SetBytes(body, patchPath, patchValue)
-			}
-			if patchErr == nil {
-				serializedByPatch = true
-			}
-		}
-		if !serializedByPatch {
-			var marshalErr error
-			body, marshalErr = marshalOpenAIUpstreamJSON(reqBody)
-			if marshalErr != nil {
-				return nil, fmt.Errorf("serialize request body: %w", marshalErr)
-			}
-		}
 	}
 
 	// Get access token
@@ -2816,8 +2706,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 	// 命中 WS 时仅走 WebSocket Mode；不再自动回退 HTTP。
 	if wsDecision.Transport == OpenAIUpstreamTransportResponsesWebsocketV2 {
-		// WS 分支不会再回落 HTTP；重连恢复可直接更新 reqBody，避免额外保留一份完整顶层 map。
-		wsReqBody := reqBody
+		// WS 分支需要结构化 payload 与重连恢复，命中后再触发 full-map decode。
+		wsReqBody, err := ensureReqBody()
+		if err != nil {
+			return nil, err
+		}
 		_, hasPreviousResponseID := wsReqBody["previous_response_id"]
 		logOpenAIWSModeDebug(
 			"forward_start account_id=%d account_type=%s model=%s stream=%v has_previous_response_id=%v",
@@ -3076,8 +2969,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 			upstreamCode := extractUpstreamErrorCode(respBody)
 			if !httpInvalidEncryptedContentRetryTried && resp.StatusCode == http.StatusBadRequest && upstreamCode == "invalid_encrypted_content" {
-				if trimOpenAIEncryptedReasoningItems(reqBody) {
-					body, err = marshalOpenAIUpstreamJSON(reqBody)
+				decoded, decodeErr := ensureReqBody()
+				if decodeErr != nil {
+					return nil, decodeErr
+				}
+				if trimOpenAIEncryptedReasoningItems(decoded) {
+					body, err = marshalOpenAIUpstreamJSON(decoded)
 					if err != nil {
 						return nil, fmt.Errorf("serialize invalid_encrypted_content retry body: %w", err)
 					}
@@ -3118,8 +3015,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		reasoningEffort := extractOpenAIReasoningEffort(reqBody, originalModel)
-		serviceTier := extractOpenAIServiceTier(reqBody)
+		reasoningEffort := extractOpenAIReasoningEffortFromBody(body, originalModel)
+		serviceTier := extractOpenAIServiceTierFromBody(body)
 		// 上游接受后只保留计费需要的标量，避免响应处理期间继续保活完整 input/tools map。
 		reqBody = nil
 
@@ -6283,6 +6180,14 @@ type openAIRequestView struct {
 	PreviousResponseID string
 	ServiceTier        string
 	ReasoningEffort    string
+	patches            []openAIRequestPatch
+	patchesDisabled    bool
+}
+
+type openAIRequestPatch struct {
+	path   string
+	delete bool
+	value  any
 }
 
 func newOpenAIRequestView(body []byte) openAIRequestView {
@@ -6303,6 +6208,110 @@ func newOpenAIRequestView(body []byte) openAIRequestView {
 // Decode 保留阶段一既有 full-map 行为；后续阶段会把调用点下沉到复杂分支。
 func (v openAIRequestView) Decode(c *gin.Context) (map[string]any, error) {
 	return getOpenAIRequestBodyMap(c, v.body)
+}
+
+func (v *openAIRequestView) MarkPatchSet(path string, value any) {
+	if v == nil || v.patchesDisabled {
+		return
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		v.DisablePatches()
+		return
+	}
+	v.patches = append(v.patches, openAIRequestPatch{path: path, value: value})
+}
+
+func (v *openAIRequestView) MarkPatchDelete(path string) {
+	if v == nil || v.patchesDisabled {
+		return
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		v.DisablePatches()
+		return
+	}
+	v.patches = append(v.patches, openAIRequestPatch{path: path, delete: true})
+}
+
+func (v *openAIRequestView) DisablePatches() {
+	if v == nil {
+		return
+	}
+	v.patchesDisabled = true
+	v.patches = nil
+}
+
+func (v openAIRequestView) HasPatches() bool {
+	return !v.patchesDisabled && len(v.patches) > 0
+}
+
+func (v openAIRequestView) ApplyPatches() ([]byte, error) {
+	if v.patchesDisabled || len(v.patches) == 0 {
+		return nil, errors.New("openai request patches disabled")
+	}
+	body := v.body
+	for _, patch := range v.patches {
+		var err error
+		if patch.delete {
+			body, err = sjson.DeleteBytes(body, patch.path)
+		} else {
+			body, err = sjson.SetBytes(body, patch.path, patch.value)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return body, nil
+}
+
+func setOpenAIRequestMapPath(reqBody map[string]any, path string, value any) {
+	path = strings.TrimSpace(path)
+	if reqBody == nil || path == "" {
+		return
+	}
+	parts := strings.Split(path, ".")
+	current := reqBody
+	for _, part := range parts[:len(parts)-1] {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			next = map[string]any{}
+			current[part] = next
+		}
+		current = next
+	}
+	last := strings.TrimSpace(parts[len(parts)-1])
+	if last != "" {
+		current[last] = value
+	}
+}
+
+func deleteOpenAIRequestMapPath(reqBody map[string]any, path string) {
+	path = strings.TrimSpace(path)
+	if reqBody == nil || path == "" {
+		return
+	}
+	parts := strings.Split(path, ".")
+	current := reqBody
+	for _, part := range parts[:len(parts)-1] {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			return
+		}
+		next, _ := current[part].(map[string]any)
+		if next == nil {
+			return
+		}
+		current = next
+	}
+	last := strings.TrimSpace(parts[len(parts)-1])
+	if last != "" {
+		delete(current, last)
+	}
 }
 
 func extractOpenAIRequestMetaFromBody(body []byte) (model string, stream bool, promptCacheKey string) {
@@ -6758,8 +6767,84 @@ func buildOpenAIFastPolicyBlockedWSEvent(err *OpenAIFastBlockedError) []byte {
 	return payload
 }
 
+func openAIRequestBodyMayContainImageInput(body []byte) bool {
+	if len(body) == 0 {
+		return false
+	}
+	input := gjson.GetBytes(body, "input")
+	messages := gjson.GetBytes(body, "messages")
+	return openAIJSONValueMayContainImageInput(input) || openAIJSONValueMayContainImageInput(messages)
+}
+
+func openAIJSONValueMayContainImageInput(value gjson.Result) bool {
+	if !value.Exists() {
+		return false
+	}
+	if value.IsArray() {
+		found := false
+		value.ForEach(func(_, item gjson.Result) bool {
+			if openAIJSONValueMayContainImageInput(item) {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
+	}
+	if value.IsObject() {
+		if strings.TrimSpace(value.Get("type").String()) == "input_image" || value.Get("image_url").Exists() {
+			return true
+		}
+		return openAIJSONValueMayContainImageInput(value.Get("content"))
+	}
+	return false
+}
+
+func openAIRequestBodyMayContainEmptyBase64InputImage(body []byte) bool {
+	if len(body) == 0 || !openAIRequestBodyMayContainInputImageToken(body) {
+		return false
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() {
+		return false
+	}
+	return openAIJSONValueMayContainEmptyBase64InputImage(input)
+}
+
+func openAIRequestBodyMayContainInputImageToken(body []byte) bool {
+	if bytes.Contains(body, []byte("input_image")) {
+		return true
+	}
+	// JSON 字符串任意字符都可能被 unicode escape，遇到 \u 时交给 gjson 解码后的结构扫描兜底。
+	return bytes.Contains(body, []byte("\\u"))
+}
+
+func openAIJSONValueMayContainEmptyBase64InputImage(value gjson.Result) bool {
+	if !value.Exists() {
+		return false
+	}
+	if value.IsArray() {
+		found := false
+		value.ForEach(func(_, item gjson.Result) bool {
+			if openAIJSONValueMayContainEmptyBase64InputImage(item) {
+				found = true
+				return false
+			}
+			return true
+		})
+		return found
+	}
+	if value.IsObject() {
+		if strings.TrimSpace(value.Get("type").String()) == "input_image" && isEmptyBase64DataURI(value.Get("image_url").String()) {
+			return true
+		}
+		return openAIJSONValueMayContainEmptyBase64InputImage(value.Get("content"))
+	}
+	return false
+}
+
 func sanitizeEmptyBase64InputImagesInOpenAIBody(body []byte) ([]byte, bool, error) {
-	if len(body) == 0 || !bytes.Contains(body, []byte(`"image_url"`)) || !bytes.Contains(body, []byte(`base64,`)) {
+	if !openAIRequestBodyMayContainEmptyBase64InputImage(body) {
 		return body, false, nil
 	}
 

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -1,12 +1,18 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestOpenAIRequestView_ExtractsRawScalars(t *testing.T) {
@@ -27,6 +33,454 @@ func TestOpenAIRequestView_DecodeKeepsFullMapBehavior(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "gpt-5", reqBody["model"])
 	require.IsType(t, []any{}, reqBody["input"])
+}
+
+func TestOpenAIRequestView_ApplyPatches(t *testing.T) {
+	view := newOpenAIRequestView([]byte(`{"model":"gpt-5","previous_response_id":"resp_1","reasoning":{"effort":"minimal"},"input":[{"type":"message","content":"hi"}]}`))
+	view.MarkPatchSet("model", "gpt-5.1")
+	view.MarkPatchDelete("previous_response_id")
+	view.MarkPatchSet("reasoning.effort", "none")
+
+	patched, err := view.ApplyPatches()
+	require.NoError(t, err)
+	require.JSONEq(t, `{"model":"gpt-5.1","reasoning":{"effort":"none"},"input":[{"type":"message","content":"hi"}]}`, string(patched))
+}
+
+func TestOpenAIRequestView_ApplyPatchesDisabled(t *testing.T) {
+	view := newOpenAIRequestView([]byte(`{"model":"gpt-5"}`))
+	view.MarkPatchSet("model", "gpt-5.1")
+	view.DisablePatches()
+
+	_, err := view.ApplyPatches()
+	require.Error(t, err)
+}
+
+func TestOpenAIRequestView_HasPatches(t *testing.T) {
+	view := newOpenAIRequestView([]byte(`{"model":"gpt-5"}`))
+	require.False(t, view.HasPatches())
+
+	view.MarkPatchSet("model", "gpt-5.1")
+	require.True(t, view.HasPatches())
+
+	view.DisablePatches()
+	require.False(t, view.HasPatches())
+}
+
+func TestOpenAIGatewayService_Forward_HTTPPatchPathKeepsLargeInputRaw(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`,
+			)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5","stream":false,"reasoning":{"effort":"minimal"},"input":[{"type":"message","content":[{"type":"input_text","text":"hi","nonce":9007199254740993}]}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.JSONEq(t, `{"model":"gpt-5","stream":false,"reasoning":{"effort":"none"},"instructions":"You are a helpful coding assistant.","input":[{"type":"message","content":[{"type":"input_text","text":"hi","nonce":9007199254740993}]}]}`, string(upstream.lastBody))
+	require.Equal(t, "9007199254740993", gjson.GetBytes(upstream.lastBody, "input.0.content.0.nonce").Raw)
+}
+
+func TestOpenAIGatewayService_Forward_DecodedMutationKeepsLaterFieldDeletes(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          2,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5.4","stream":false,"max_completion_tokens":12,"tools":[{"type":"image_generation","format":"png"}],"input":[{"type":"message","content":"draw"}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "max_completion_tokens").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools.0.format").Exists())
+	require.Equal(t, "png", gjson.GetBytes(upstream.lastBody, "tools.0.output_format").String())
+}
+
+func TestOpenAIGatewayService_Forward_MappedImageModelUsesImageGate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          3,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":       "sk-test",
+			"base_url":      "https://example.com",
+			"model_mapping": map[string]any{"draw-alias": "gpt-image-2"},
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Set("api_key", &APIKey{Group: &Group{AllowImageGeneration: false}})
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"draw-alias","stream":false,"input":"draw"}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Nil(t, upstream.lastReq)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+func TestOpenAIGatewayService_Forward_TextDataImageDoesNotForceMapMarshal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          4,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5","stream":false,"input":[{"type":"message","content":[{"type":"input_text","text":"literal data:image/png;base64, only","nonce":1e1000000}]}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "1e1000000", gjson.GetBytes(upstream.lastBody, "input.0.content.0.nonce").Raw)
+}
+
+func TestOpenAIGatewayService_Forward_ImageToolBillingDoesNotForceFullDecode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"output":[{"id":"ig_1","type":"image_generation_call","result":"final-image"}],"usage":{"input_tokens":1,"output_tokens":2}}`,
+			)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          9,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5","stream":false,"tools":[{"type":"image_generation","model":"gpt-image-2","size":"2048x1152"}],"input":[{"type":"message","content":[{"type":"input_text","text":"draw","nonce":1e1000000}]}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "1e1000000", gjson.GetBytes(upstream.lastBody, "input.0.content.0.nonce").Raw)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, "2K", result.ImageSize)
+	require.Equal(t, "gpt-image-2", result.BillingModel)
+}
+
+func TestOpenAIGatewayService_Forward_HTTPRetryRecoveryDoesNotDecodeBeforeError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		responses: []*http.Response{
+			{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"invalid_encrypted_content","type":"invalid_request_error","message":"bad encrypted content"}}`)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+			},
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          10,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5","stream":false,"input":[{"type":"reasoning","encrypted_content":"gAAA","summary":[{"type":"summary_text","text":"keep me"}]},{"type":"message","content":[{"type":"input_text","text":"hi","nonce":9007199254740993}]}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "gAAA", gjson.GetBytes(upstream.bodies[0], "input.0.encrypted_content").String())
+	require.Equal(t, "9007199254740993", gjson.GetBytes(upstream.bodies[0], "input.1.content.0.nonce").Raw)
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "input.0.encrypted_content").Exists())
+	require.Equal(t, "summary_text", gjson.GetBytes(upstream.bodies[1], "input.0.summary.0.type").String())
+}
+
+func TestOpenAIGatewayService_Forward_CodexSparkRejectsEscapedInputImage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          5,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5.3-codex-spark","stream":false,"input":[{"type":"input_` + "\\u0069" + `mage","file_id":"file_1"}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Nil(t, upstream.lastReq)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestOpenAIGatewayService_Forward_CodexBridgeInjectionSetsImageBilling(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"output":[{"id":"ig_1","type":"image_generation_call","result":"final-image","size":"1024x1024"}],"usage":{"input_tokens":1,"output_tokens":2}}`,
+			)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Gateway.ForceCodexCLI = true
+	cfg.Gateway.CodexImageGenerationBridgeEnabled = true
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          7,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Set("api_key", &APIKey{Group: &Group{AllowImageGeneration: true}})
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-5","stream":false,"input":"draw if needed"}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, "2K", result.ImageSize)
+	require.Equal(t, "gpt-image-2", result.BillingModel)
+}
+
+func TestOpenAIGatewayService_Forward_HTTPDeletesPreviousResponseIDWhenPresent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	account := &Account{
+		ID:          8,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+
+	for _, body := range [][]byte{
+		[]byte(`{"model":"gpt-5","stream":false,"previous_response_id":"","input":"hi"}`),
+		[]byte(`{"model":"gpt-5","stream":false,"previous_response_id":null,"input":"hi"}`),
+	} {
+		upstream := &httpUpstreamRecorder{
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+			},
+		}
+		svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+		SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+		result, err := svc.Forward(context.Background(), c, account, body)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, gjson.GetBytes(upstream.lastBody, "previous_response_id").Exists())
+	}
+}
+
+func TestOpenAIRequestBodyMayContainEmptyBase64InputImageSeesEscapedJSON(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","content":[{"type":"input_image","image_` + "\\u0075" + `rl":"data:image/png;base64` + "\\u002c" + `   "}]}]}`)
+
+	require.True(t, openAIRequestBodyMayContainEmptyBase64InputImage(body))
+}
+
+func TestOpenAIRequestBodyMayContainEmptyBase64InputImageSeesEscapedImageType(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","content":[{"type":"input_` + "\\u0069" + `mage","image_url":"data:image/png;base64,   "}]}]}`)
+
+	require.True(t, openAIRequestBodyMayContainEmptyBase64InputImage(body))
+}
+
+func TestOpenAIRequestBodyMayContainEmptyBase64InputImageSeesEscapedInputPrefix(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","content":[{"type":"inp` + "\\u0075" + `t_image","image_url":"data:image/png;base64,   "}]}]}`)
+
+	require.True(t, openAIRequestBodyMayContainEmptyBase64InputImage(body))
+}
+
+func TestOpenAIGatewayService_Forward_ImageOnlyModelKeepsSupportedVerbosity(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          6,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-image-2","stream":false,"text":{"verbosity":"low"},"input":"draw"}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "low", gjson.GetBytes(upstream.lastBody, "text.verbosity").String())
+	require.Equal(t, openAIImagesResponsesMainModel, gjson.GetBytes(upstream.lastBody, "model").String())
 }
 
 func TestExtractOpenAIRequestMetaFromBody(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -46,6 +46,15 @@ func TestOpenAIRequestView_ApplyPatches(t *testing.T) {
 	require.JSONEq(t, `{"model":"gpt-5.1","reasoning":{"effort":"none"},"input":[{"type":"message","content":"hi"}]}`, string(patched))
 }
 
+func TestOpenAIRequestView_RejectsEscapedPatchPath(t *testing.T) {
+	view := newOpenAIRequestView([]byte(`{"metadata":{"user.id":"old"}}`))
+	view.MarkPatchSet(`metadata.user\.id`, "new")
+
+	require.False(t, view.HasPatches())
+	_, err := view.ApplyPatches()
+	require.Error(t, err)
+}
+
 func TestOpenAIRequestView_ApplyPatchesDisabled(t *testing.T) {
 	view := newOpenAIRequestView([]byte(`{"model":"gpt-5"}`))
 	view.MarkPatchSet("model", "gpt-5.1")
@@ -258,6 +267,42 @@ func TestOpenAIGatewayService_Forward_ImageToolBillingDoesNotForceFullDecode(t *
 	require.Equal(t, 1, result.ImageCount)
 	require.Equal(t, "2K", result.ImageSize)
 	require.Equal(t, "gpt-image-2", result.BillingModel)
+}
+
+func TestOpenAIGatewayService_Forward_ImageToolWithImageOnlyModelIsNormalized(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          11,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	body := []byte(`{"model":"gpt-image-2","stream":false,"tools":[{"type":"image_generation","model":"gpt-image-2"}],"input":"draw"}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, openAIImagesResponsesMainModel, gjson.GetBytes(upstream.lastBody, "model").String())
 }
 
 func TestOpenAIGatewayService_Forward_HTTPRetryRecoveryDoesNotDecodeBeforeError(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -112,7 +112,7 @@ func TestGetOpenAIRequestBodyMap_UsesContextCache(t *testing.T) {
 	c, _ := gin.CreateTestContext(rec)
 
 	cached := map[string]any{"model": "cached-model", "stream": true}
-	c.Set(OpenAIParsedRequestBodyKey, cached)
+	CacheOpenAIParsedRequestBody(c, []byte(`{invalid-json`), cached)
 
 	got, err := getOpenAIRequestBodyMap(c, []byte(`{invalid-json`))
 	require.NoError(t, err)
@@ -134,11 +134,19 @@ func TestGetOpenAIRequestBodyMap_WriteBackContextCache(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "gpt-5", got["model"])
 
-	cached, ok := c.Get(OpenAIParsedRequestBodyKey)
-	require.True(t, ok)
-	cachedMap, ok := cached.(map[string]any)
-	require.True(t, ok)
-	require.Equal(t, got, cachedMap)
+	require.Equal(t, got, CachedOpenAIParsedRequestBody(c))
+}
+
+func TestGetOpenAIRequestBodyMap_IgnoresCacheForDifferentBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	CacheOpenAIParsedRequestBody(c, []byte(`{"model":"cached-model"}`), map[string]any{"model": "cached-model"})
+
+	got, err := getOpenAIRequestBodyMap(c, []byte(`{"model":"forward-model"}`))
+	require.NoError(t, err)
+	require.Equal(t, "forward-model", got["model"])
 }
 
 func TestSanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -106,26 +106,13 @@ func TestExtractOpenAIReasoningEffortFromBody(t *testing.T) {
 	}
 }
 
-func TestGetOpenAIRequestBodyMap_UsesContextCache(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-
-	cached := map[string]any{"model": "cached-model", "stream": true}
-	CacheOpenAIParsedRequestBody(c, []byte(`{invalid-json`), cached)
-
-	got, err := getOpenAIRequestBodyMap(c, []byte(`{invalid-json`))
-	require.NoError(t, err)
-	require.Equal(t, cached, got)
-}
-
-func TestGetOpenAIRequestBodyMap_ParseErrorWithoutCache(t *testing.T) {
+func TestGetOpenAIRequestBodyMap_ParseError(t *testing.T) {
 	_, err := getOpenAIRequestBodyMap(nil, []byte(`{invalid-json`))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "parse request")
 }
 
-func TestGetOpenAIRequestBodyMap_WriteBackContextCache(t *testing.T) {
+func TestGetOpenAIRequestBodyMap_DoesNotWriteContextCache(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
@@ -133,20 +120,7 @@ func TestGetOpenAIRequestBodyMap_WriteBackContextCache(t *testing.T) {
 	got, err := getOpenAIRequestBodyMap(c, []byte(`{"model":"gpt-5","stream":true}`))
 	require.NoError(t, err)
 	require.Equal(t, "gpt-5", got["model"])
-
-	require.Equal(t, got, CachedOpenAIParsedRequestBody(c))
-}
-
-func TestGetOpenAIRequestBodyMap_IgnoresCacheForDifferentBody(t *testing.T) {
-	gin.SetMode(gin.TestMode)
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-
-	CacheOpenAIParsedRequestBody(c, []byte(`{"model":"cached-model"}`), map[string]any{"model": "cached-model"})
-
-	got, err := getOpenAIRequestBodyMap(c, []byte(`{"model":"forward-model"}`))
-	require.NoError(t, err)
-	require.Equal(t, "forward-model", got["model"])
+	require.Empty(t, c.Keys)
 }
 
 func TestSanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -9,6 +9,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestOpenAIRequestView_ExtractsRawScalars(t *testing.T) {
+	view := newOpenAIRequestView([]byte(`{"model":" gpt-5 ","stream":true,"prompt_cache_key":" ses-1 ","previous_response_id":" resp-1 ","service_tier":" fast ","reasoning":{"effort":" medium "}}`))
+
+	require.Equal(t, "gpt-5", view.Model)
+	require.True(t, view.Stream)
+	require.Equal(t, "ses-1", view.PromptCacheKey)
+	require.Equal(t, "resp-1", view.PreviousResponseID)
+	require.Equal(t, "fast", view.ServiceTier)
+	require.Equal(t, "medium", view.ReasoningEffort)
+}
+
+func TestOpenAIRequestView_DecodeKeepsFullMapBehavior(t *testing.T) {
+	view := newOpenAIRequestView([]byte(`{"model":"gpt-5","stream":true,"input":[{"type":"message","content":"hi"}]}`))
+
+	reqBody, err := view.Decode(nil)
+	require.NoError(t, err)
+	require.Equal(t, "gpt-5", reqBody["model"])
+	require.IsType(t, []any{}, reqBody["input"])
+}
+
 func TestExtractOpenAIRequestMetaFromBody(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -622,7 +622,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
 	}
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
@@ -1276,21 +1276,22 @@ func resolveOpenAIImageBytes(
 	headers http.Header,
 	conversationID string,
 	pointer openAIImagePointerInfo,
+	errorBodyReadLimit int64,
 ) ([]byte, error) {
 	if normalized := normalizeOpenAIImageBase64(pointer.B64JSON); normalized != "" {
 		return base64.StdEncoding.DecodeString(normalized)
 	}
 	if downloadURL := strings.TrimSpace(pointer.DownloadURL); downloadURL != "" {
-		return downloadOpenAIImageBytes(ctx, client, headers, downloadURL)
+		return downloadOpenAIImageBytes(ctx, client, headers, downloadURL, errorBodyReadLimit)
 	}
 	if strings.TrimSpace(pointer.Pointer) == "" {
 		return nil, fmt.Errorf("image asset is missing pointer, url, and base64 data")
 	}
-	downloadURL, err := fetchOpenAIImageDownloadURL(ctx, client, headers, conversationID, pointer.Pointer)
+	downloadURL, err := fetchOpenAIImageDownloadURL(ctx, client, headers, conversationID, pointer.Pointer, errorBodyReadLimit)
 	if err != nil {
 		return nil, err
 	}
-	return downloadOpenAIImageBytes(ctx, client, headers, downloadURL)
+	return downloadOpenAIImageBytes(ctx, client, headers, downloadURL, errorBodyReadLimit)
 }
 
 func normalizeOpenAIImageBase64(raw string) string {
@@ -1395,6 +1396,7 @@ func fetchOpenAIImageDownloadURL(
 	headers http.Header,
 	conversationID string,
 	pointer string,
+	errorBodyReadLimit int64,
 ) (string, error) {
 	url := ""
 	allowConversationRetry := false
@@ -1425,7 +1427,7 @@ func fetchOpenAIImageDownloadURL(
 		} else if resp.IsSuccessState() && strings.TrimSpace(result.DownloadURL) != "" {
 			return strings.TrimSpace(result.DownloadURL), nil
 		} else {
-			statusErr := newOpenAIImageStatusError(resp, "fetch image download url failed")
+			statusErr := newOpenAIImageStatusError(resp, "fetch image download url failed", errorBodyReadLimit)
 			if !allowConversationRetry || !isOpenAIImageTransientConversationNotFoundError(statusErr) {
 				return "", statusErr
 			}
@@ -1450,7 +1452,7 @@ func fetchOpenAIImageDownloadURL(
 	return "", lastErr
 }
 
-func downloadOpenAIImageBytes(ctx context.Context, client *req.Client, headers http.Header, downloadURL string) ([]byte, error) {
+func downloadOpenAIImageBytes(ctx context.Context, client *req.Client, headers http.Header, downloadURL string, errorBodyReadLimit int64) ([]byte, error) {
 	request := client.R().
 		SetContext(ctx).
 		DisableAutoReadResponse()
@@ -1478,7 +1480,7 @@ func downloadOpenAIImageBytes(ctx context.Context, client *req.Client, headers h
 		}
 	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, newOpenAIImageStatusError(resp, "download image bytes failed")
+		return nil, newOpenAIImageStatusError(resp, "download image bytes failed", errorBodyReadLimit)
 	}
 	return io.ReadAll(io.LimitReader(resp.Body, openAIImageMaxDownloadBytes))
 }
@@ -1505,7 +1507,7 @@ func (e *openAIImageStatusError) Error() string {
 	return "openai image backend request failed"
 }
 
-func newOpenAIImageStatusError(resp *req.Response, fallback string) error {
+func newOpenAIImageStatusError(resp *req.Response, fallback string, errorBodyReadLimit int64) error {
 	if resp == nil {
 		if strings.TrimSpace(fallback) == "" {
 			fallback = "openai image backend request failed"
@@ -1526,7 +1528,10 @@ func newOpenAIImageStatusError(resp *req.Response, fallback string) error {
 			requestURL = resp.Request.URL.String()
 		}
 		if resp.Body != nil {
-			body, _ = io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+			if errorBodyReadLimit <= 0 {
+				errorBodyReadLimit = openAIUpstreamErrorBodyReadLimit
+			}
+			body, _ = io.ReadAll(io.LimitReader(resp.Body, errorBodyReadLimit))
 			_ = resp.Body.Close()
 		}
 	}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -1172,7 +1172,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
 	}
 	if resp.StatusCode >= 400 {
-		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+		respBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(respBody))
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
+	"github.com/imroc/req/v3"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -398,9 +400,36 @@ func TestCollectOpenAIImagePointers_RecognizesDirectAssets(t *testing.T) {
 func TestResolveOpenAIImageBytes_PrefersInlineBase64(t *testing.T) {
 	data, err := resolveOpenAIImageBytes(context.Background(), nil, nil, "", openAIImagePointerInfo{
 		B64JSON: "data:image/png;base64,QUJD",
-	})
+	}, openAIUpstreamErrorBodyReadLimit)
 	require.NoError(t, err)
 	require.Equal(t, []byte("ABC"), data)
+}
+
+func TestNewOpenAIImageStatusError_UsesProvidedReadLimit(t *testing.T) {
+	padding := strings.Repeat("x", int(openAIUpstreamErrorBodyReadLimit)+1024)
+	body := fmt.Sprintf(`{"error":{"padding":"%s","message":"diagnostic-marker"}}`, padding)
+	resp := &req.Response{Response: &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}}
+
+	err := newOpenAIImageStatusError(resp, "download image bytes failed", int64(len(body)))
+	require.Error(t, err)
+	require.Equal(t, "diagnostic-marker", err.Error())
+
+	var statusErr *openAIImageStatusError
+	require.ErrorAs(t, err, &statusErr)
+	require.Len(t, statusErr.ResponseBody, len(body))
+}
+
+func TestOpenAIUpstreamErrorBodyReadLimitForConfig_RespectsDiagnosticLimit(t *testing.T) {
+	cfg := &config.Config{Gateway: config.GatewayConfig{
+		LogUpstreamErrorBody:         true,
+		LogUpstreamErrorBodyMaxBytes: int(openAIUpstreamErrorBodyReadLimit) + 1024,
+	}}
+
+	require.Equal(t, int64(cfg.Gateway.LogUpstreamErrorBodyMaxBytes), openAIUpstreamErrorBodyReadLimitForConfig(cfg))
 }
 
 func TestAccountSupportsOpenAIImageCapability_OAuthSupportsNative(t *testing.T) {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -99,6 +100,57 @@ func TestOpenAIGatewayService_ResponsesUnknownModelDoesNotFallbackToGPT54(t *tes
 	require.Equal(t, "gpt6", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.NotEqual(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.True(t, rec.Code >= http.StatusBadRequest)
+}
+
+func TestOpenAIGatewayService_NativeResponsesBodyModificationPreservesHTMLChars(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	payloadText := strings.Repeat(`<tag>&value</tag>`, 128)
+	originalBody := []byte(fmt.Sprintf(`{"model":"gpt-5.5","stream":false,"max_output_tokens":100,"previous_response_id":"resp_prev","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":%q}]}]}`, payloadText))
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(originalBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_native_reencode"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop after capture"}}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          456,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "http://upstream.example",
+		},
+		Extra: map[string]any{
+			openai_compat.ExtraKeyResponsesMode:      string(openai_compat.ResponsesSupportModeAuto),
+			openai_compat.ExtraKeyResponsesSupported: true,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	result, err := svc.Forward(context.Background(), c, account, originalBody)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "http://upstream.example/v1/responses", upstream.lastReq.URL.String())
+	require.Contains(t, string(upstream.lastBody), payloadText)
+	require.NotContains(t, string(upstream.lastBody), `\\u003c`)
+	require.NotContains(t, string(upstream.lastBody), `\\u003e`)
+	require.NotContains(t, string(upstream.lastBody), `\\u0026`)
 }
 
 func TestOpenAIGatewayService_OAuthMessagesBridgeDoesNotInjectDefaultInstructions(t *testing.T) {

--- a/backend/internal/service/openai_tool_continuation.go
+++ b/backend/internal/service/openai_tool_continuation.go
@@ -199,7 +199,7 @@ func ValidateFunctionCallOutputContextBytes(body []byte) FunctionCallOutputValid
 			}
 			referenceIDs[idValue] = struct{}{}
 		}
-		return !(result.HasFunctionCallOutput && result.HasToolCallContext)
+		return !result.HasFunctionCallOutput || !result.HasToolCallContext
 	})
 	if !result.HasFunctionCallOutput || result.HasToolCallContext || len(callIDs) == 0 || len(referenceIDs) == 0 {
 		return result

--- a/backend/internal/service/openai_tool_continuation.go
+++ b/backend/internal/service/openai_tool_continuation.go
@@ -1,6 +1,10 @@
 package service
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
 
 // ToolContinuationSignals 聚合工具续链相关信号，避免重复遍历 input。
 type ToolContinuationSignals struct {
@@ -148,6 +152,63 @@ func AnalyzeToolContinuationSignals(reqBody map[string]any) ToolContinuationSign
 	}
 	signals.HasItemReferenceForAllCallIDs = allReferenced
 	return signals
+}
+
+// ValidateFunctionCallOutputContextBytes 基于 raw JSON 校验工具输出续链，避免 handler 预校验阶段全量解码大 input。
+func ValidateFunctionCallOutputContextBytes(body []byte) FunctionCallOutputValidation {
+	result := FunctionCallOutputValidation{}
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return result
+	}
+
+	var callIDs map[string]struct{}
+	var referenceIDs map[string]struct{}
+	input.ForEach(func(_, item gjson.Result) bool {
+		if !item.IsObject() {
+			return true
+		}
+		itemType := item.Get("type").String()
+		switch {
+		case isCodexToolCallOutputItemType(itemType):
+			result.HasFunctionCallOutput = true
+			callID := strings.TrimSpace(item.Get("call_id").String())
+			if callID == "" {
+				result.HasFunctionCallOutputMissingCallID = true
+				return true
+			}
+			if callIDs == nil {
+				callIDs = make(map[string]struct{})
+			}
+			callIDs[callID] = struct{}{}
+		case isCodexToolCallContextItemType(itemType):
+			if strings.TrimSpace(item.Get("call_id").String()) != "" {
+				result.HasToolCallContext = true
+			}
+		case itemType == "item_reference":
+			idValue := strings.TrimSpace(item.Get("id").String())
+			if idValue == "" {
+				return true
+			}
+			if referenceIDs == nil {
+				referenceIDs = make(map[string]struct{})
+			}
+			referenceIDs[idValue] = struct{}{}
+		}
+		return !(result.HasFunctionCallOutput && result.HasToolCallContext)
+	})
+	if !result.HasFunctionCallOutput || result.HasToolCallContext || len(callIDs) == 0 || len(referenceIDs) == 0 {
+		return result
+	}
+	allReferenced := true
+	for callID := range callIDs {
+		if _, ok := referenceIDs[callID]; !ok {
+			allReferenced = false
+			break
+		}
+	}
+	result.HasItemReferenceForAllCallIDs = allReferenced
+	return result
 }
 
 // ValidateFunctionCallOutputContext 为 handler 提供低开销校验结果：

--- a/backend/internal/service/openai_tool_continuation.go
+++ b/backend/internal/service/openai_tool_continuation.go
@@ -157,7 +157,11 @@ func AnalyzeToolContinuationSignals(reqBody map[string]any) ToolContinuationSign
 // ValidateFunctionCallOutputContextBytes 基于 raw JSON 校验工具输出续链，避免 handler 预校验阶段全量解码大 input。
 func ValidateFunctionCallOutputContextBytes(body []byte) FunctionCallOutputValidation {
 	result := FunctionCallOutputValidation{}
-	input := gjson.GetBytes(body, "input")
+	if len(body) == 0 {
+		return result
+	}
+	// handler 热路径只读扫描 input，避免 GetBytes 为大 Responses body 复制整段 JSON。
+	input := parseRawJSONView(body).Get("input")
 	if !input.IsArray() {
 		return result
 	}

--- a/backend/internal/service/openai_tool_continuation_test.go
+++ b/backend/internal/service/openai_tool_continuation_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -117,4 +118,69 @@ func TestHasItemReferenceForCallIDs(t *testing.T) {
 	require.True(t, HasItemReferenceForCallIDs(req, []string{"call_1"}))
 	require.True(t, HasItemReferenceForCallIDs(req, []string{"call_1", "call_2"}))
 	require.False(t, HasItemReferenceForCallIDs(req, []string{"call_1", "call_3"}))
+}
+
+func TestValidateFunctionCallOutputContextBytesMatchesMapValidation(t *testing.T) {
+	// handler 预校验走 raw JSON 扫描，语义必须与 service 内部 map 校验保持一致。
+	cases := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "no_input",
+			body: map[string]any{"model": "gpt-5.4"},
+		},
+		{
+			name: "missing_call_id",
+			body: map[string]any{"input": []any{map[string]any{"type": "function_call_output"}}},
+		},
+		{
+			name: "call_id_without_reference",
+			body: map[string]any{"input": []any{map[string]any{"type": "function_call_output", "call_id": "call_1"}}},
+		},
+		{
+			name: "matching_reference",
+			body: map[string]any{"input": []any{
+				map[string]any{"type": "function_call_output", "call_id": "call_1"},
+				map[string]any{"type": "item_reference", "id": "call_1"},
+			}},
+		},
+		{
+			name: "partial_reference",
+			body: map[string]any{"input": []any{
+				map[string]any{"type": "function_call_output", "call_id": "call_1"},
+				map[string]any{"type": "tool_search_output", "call_id": "call_2"},
+				map[string]any{"type": "item_reference", "id": "call_1"},
+			}},
+		},
+		{
+			name: "tool_context",
+			body: map[string]any{"input": []any{
+				map[string]any{"type": "function_call_output", "call_id": "call_1"},
+				map[string]any{"type": "function_call", "call_id": "call_1"},
+			}},
+		},
+		{
+			name: "all_codex_tool_outputs",
+			body: map[string]any{"input": []any{
+				map[string]any{"type": "function_call_output", "call_id": "call_function"},
+				map[string]any{"type": "tool_search_output", "call_id": "call_search"},
+				map[string]any{"type": "custom_tool_call_output", "call_id": "call_custom"},
+				map[string]any{"type": "mcp_tool_call_output", "call_id": "call_mcp"},
+				map[string]any{"type": "item_reference", "id": "call_function"},
+				map[string]any{"type": "item_reference", "id": "call_search"},
+				map[string]any{"type": "item_reference", "id": "call_custom"},
+				map[string]any{"type": "item_reference", "id": "call_mcp"},
+			}},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			bodyBytes, err := json.Marshal(tt.body)
+			require.NoError(t, err)
+
+			require.Equal(t, ValidateFunctionCallOutputContext(tt.body), ValidateFunctionCallOutputContextBytes(bodyBytes))
+		})
+	}
 }

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -171,6 +171,91 @@ func TestOpenAIGatewayService_Forward_WSv2_SuccessAndBindSticky(t *testing.T) {
 	require.Equal(t, "resp_new_1", gjson.GetBytes(responseBody, "id").String())
 }
 
+func TestOpenAIGatewayService_Forward_WSv2_UsesPatchedBodyAfterValidationDecode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	type receivedPayload struct {
+		MaxCompletionTokensExists bool
+	}
+	receivedCh := make(chan receivedPayload, 1)
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket failed: %v", err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		var request map[string]any
+		if err := conn.ReadJSON(&request); err != nil {
+			t.Errorf("read ws request failed: %v", err)
+			return
+		}
+		requestJSON := requestToJSONString(request)
+		receivedCh <- receivedPayload{MaxCompletionTokensExists: gjson.Get(requestJSON, "max_completion_tokens").Exists()}
+
+		if err := conn.WriteJSON(map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"id":    "resp_patched_ws_1",
+				"model": "gpt-5.3-codex-spark",
+				"usage": map[string]any{"input_tokens": 1, "output_tokens": 1},
+			},
+		}); err != nil {
+			t.Errorf("write response.completed failed: %v", err)
+			return
+		}
+	}))
+	defer wsServer.Close()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "unit-test-agent/1.0")
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 30
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 10
+
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+	}
+
+	account := &Account{
+		ID:          10,
+		Name:        "openai-ws",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": wsServer.URL,
+		},
+		Extra: map[string]any{"responses_websockets_v2_enabled": true},
+	}
+
+	body := []byte(`{"model":"gpt-5.4","stream":false,"max_completion_tokens":12,"tools":[{"type":"image_generation"}],"input":[{"type":"input_text","text":"hello"}]}`)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.OpenAIWSMode)
+
+	received := <-receivedCh
+	require.False(t, received.MaxCompletionTokensExists)
+}
+
 func TestOpenAIGatewayService_Forward_WSv2_ImageGenerationCountsOutputs(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/user_msg_queue_service.go
+++ b/backend/internal/service/user_msg_queue_service.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/tidwall/gjson"
 )
 
 // UserMsgQueueCache 用户消息串行队列 Redis 缓存接口
@@ -62,43 +63,48 @@ func NewUserMessageQueueService(cache UserMsgQueueCache, rpmCache RPMCache, cfg 
 // 2. 最后一条消息 role == "user"
 // 3. 最后一条消息 content（如果是数组）中不含 type:"tool_result" / "tool_use_result"
 func IsRealUserMessage(parsed *ParsedRequest) bool {
-	if parsed == nil || len(parsed.Messages) == 0 {
+	if parsed == nil {
+		return false
+	}
+	messagesRaw := parsed.MessagesRaw()
+	if len(messagesRaw) == 0 {
 		return false
 	}
 
-	lastMsg := parsed.Messages[len(parsed.Messages)-1]
-	msgMap, ok := lastMsg.(map[string]any)
-	if !ok {
+	messages := gjson.ParseBytes(messagesRaw)
+	if !messages.IsArray() {
+		return false
+	}
+	lastMsg := gjson.Result{}
+	messages.ForEach(func(_, msg gjson.Result) bool {
+		lastMsg = msg
+		return true
+	})
+	if !lastMsg.Exists() || !lastMsg.IsObject() {
+		return false
+	}
+	if lastMsg.Get("role").String() != "user" {
 		return false
 	}
 
-	role, _ := msgMap["role"].(string)
-	if role != "user" {
-		return false
+	content := lastMsg.Get("content")
+	if !content.Exists() {
+		return true
+	}
+	if !content.IsArray() {
+		return true
 	}
 
-	// 检查 content 是否包含 tool_result 类型
-	content, ok := msgMap["content"]
-	if !ok {
-		return true // 没有 content 字段，视为普通用户消息
-	}
-
-	contentArr, ok := content.([]any)
-	if !ok {
-		return true // content 不是数组（可能是 string），视为普通用户消息
-	}
-
-	for _, item := range contentArr {
-		itemMap, ok := item.(map[string]any)
-		if !ok {
-			continue
-		}
-		itemType, _ := itemMap["type"].(string)
+	isReal := true
+	content.ForEach(func(_, item gjson.Result) bool {
+		itemType := item.Get("type").String()
 		if itemType == "tool_result" || itemType == "tool_use_result" {
+			isReal = false
 			return false
 		}
-	}
-	return true
+		return true
+	})
+	return isReal
 }
 
 // TryAcquire 尝试立即获取串行锁


### PR DESCRIPTION
  ## 摘要

  - 引入请求体引用和 raw range 懒解析，避免网关请求处理过程中重复保留大请求体的完整解码对象图。
  - OpenAI `/v1/responses` 入口不再无条件 full map decode，普通热路径改为 raw 标量读取和按需 patch。
  - 将 OpenAI 图片意图/计费、WS payload、`invalid_encrypted_content` retry、空 base64 图片清理等逻辑收敛到 raw /
  lazy decode 边界内。

  ## 主要改动

  - 增加 `RequestBodyRef` 和 ParsedRequest raw range 机制，减少请求体复制。
  - OpenAI Responses 普通路径保持 raw body 作为主数据源。
  - 使用 `openAIRequestView` 提取 model、stream、prompt cache、service tier、reasoning effort 等标量。
  - 简单字段修改走 raw patch，避免 map decode + marshal。
  - 只有真正需要结构化修改的分支才 full decode：
    - OAuth normalize
    - WSv2 payload 构造
    - `invalid_encrypted_content` retry recovery
    - 空 base64 input image sanitize
    - image tool normalize / validation
  - 补充热路径回归测试和大请求体 benchmark：
    - raw patch
    - raw image billing
    - empty-base64 guard
    - HTTP retry / WS 行为

  ## 测试

  - `go test -C backend ./internal/service`
  - `go test -C backend ./internal/service -run '^$' -bench
  'BenchmarkOpenAIResponses_LargeInput(RawPatch|ImageBillingRaw|EmptyBase64Guard)$' -benchtime=1x`