### PR TITLE
fix(usage): 修复账号管理分页数值过大后切换使用记录页卡死(分页大小独立持久化)

### DIFF
--- a/frontend/src/components/common/Pagination.vue
+++ b/frontend/src/components/common/Pagination.vue
@@ -134,6 +134,7 @@ interface Props {
   pageSizeOptions?: number[]
   showPageSizeSelector?: boolean
   showJump?: boolean
+  storageKey?: string
 }
 
 interface Emits {
@@ -225,7 +226,7 @@ const goToPage = (newPage: number) => {
 const handlePageSizeChange = (value: string | number | boolean | null) => {
   if (value === null || typeof value === 'boolean') return
   const newPageSize = normalizeTablePageSize(typeof value === 'string' ? parseInt(value, 10) : value)
-  setPersistedPageSize(newPageSize)
+  setPersistedPageSize(newPageSize, props.storageKey)
   emit('update:pageSize', newPageSize)
 }
 

--- a/frontend/src/composables/usePersistedPageSize.ts
+++ b/frontend/src/composables/usePersistedPageSize.ts
@@ -2,10 +2,13 @@ import { getConfiguredTableDefaultPageSize, normalizeTablePageSize } from '@/uti
 
 const STORAGE_KEY = 'table-page-size'
 
-export function getPersistedPageSize(fallback = getConfiguredTableDefaultPageSize()): number {
+export function getPersistedPageSize(
+  fallback = getConfiguredTableDefaultPageSize(),
+  storageKey: string = STORAGE_KEY
+): number {
   if (typeof window !== 'undefined') {
     try {
-      const stored = window.localStorage.getItem(STORAGE_KEY)
+      const stored = window.localStorage.getItem(storageKey)
       if (stored !== null) {
         const parsed = Number(stored)
         if (Number.isFinite(parsed)) {
@@ -19,10 +22,10 @@ export function getPersistedPageSize(fallback = getConfiguredTableDefaultPageSiz
   return normalizeTablePageSize(getConfiguredTableDefaultPageSize() || fallback)
 }
 
-export function setPersistedPageSize(size: number): void {
+export function setPersistedPageSize(size: number, storageKey: string = STORAGE_KEY): void {
   if (typeof window === 'undefined') return
   try {
-    window.localStorage.setItem(STORAGE_KEY, String(size))
+    window.localStorage.setItem(storageKey, String(size))
   } catch (error) {
     console.warn('Failed to persist page size:', error)
   }

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -110,7 +110,7 @@
         @sort="handleSort"
         @userClick="handleUserClick"
       />
-      <Pagination v-if="pagination.total > 0" :page="pagination.page" :total="pagination.total" :page-size="pagination.page_size" @update:page="handlePageChange" @update:pageSize="handlePageSizeChange" />
+      <Pagination v-if="pagination.total > 0" :page="pagination.page" :total="pagination.total" :page-size="pagination.page_size" storage-key="usage-page-size" @update:page="handlePageChange" @update:pageSize="handlePageSizeChange" />
     </div>
   </AppLayout>
   <UsageExportProgress :show="exportProgress.show" :progress="exportProgress.progress" :current="exportProgress.current" :total="exportProgress.total" :estimated-time="exportProgress.estimatedTime" @cancel="cancelExport" />
@@ -227,7 +227,7 @@ const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
-const pagination = reactive({ page: 1, page_size: getPersistedPageSize(), total: 0 })
+const pagination = reactive({ page: 1, page_size: getPersistedPageSize(undefined, 'usage-page-size'), total: 0 })
 const sortState = reactive({
   sort_by: 'created_at',
   sort_order: 'desc' as 'asc' | 'desc'

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -340,6 +340,7 @@
           :page="pagination.page"
           :total="pagination.total"
           :page-size="pagination.page_size"
+          storage-key="usage-page-size"
           @update:page="handlePageChange"
           @update:pageSize="handlePageSizeChange"
         />
@@ -657,7 +658,7 @@ const onDateRangeChange = (range: {
 
 const pagination = reactive({
   page: 1,
-  page_size: getPersistedPageSize(),
+  page_size: getPersistedPageSize(undefined, 'usage-page-size'),
   total: 0,
   pages: 0
 })


### PR DESCRIPTION
## 变更摘要 (Summary)

修复使用记录页因与其他列表页共享分页大小而卡死的问题。

此前所有列表页共用同一个全局 localStorage key `table-page-size` 来持久化每页条数。在「账号管理」页将每页设为 1000 后,切换到「使用记录」页会沿用该全局值,一次性拉取并渲染 1000 条用量记录,导致页面卡死。本 PR 为使用记录页(管理端 + 用户端)启用独立的持久化 key,与其他列表页隔离,其余页面行为完全不变。

## 主要改动 (Key Changes)

### 1. 分页持久化支持自定义 storage key

- **问题**:
  - `usePersistedPageSize` 用单一全局 key `table-page-size` 读写每页条数,`Pagination.vue` 改 pageSize 时无条件写回该全局 key,所有列表页共享同一份配置。
  - 账号管理等轻量列表可承受 1000 条/页,但使用记录每条字段多、渲染重,1000 条直接卡死。
- **方案**:
  - `get/setPersistedPageSize` 增加可选 `storageKey` 参数,默认仍为全局 `table-page-size`,保持向后兼容。
  - `Pagination.vue` 新增可选 `storageKey` prop,写回时透传;不传则维持原全局行为。

### 2. 使用记录页使用独立 key 隔离

- **方案**:
  - `views/admin/UsageView.vue` 与 `views/user/UsageView.vue` 的 Pagination 传入独立 key `usage-page-size`,初始化时也读同一 key,保证刷新后一致。

## 文件变更 (Changes)

| 文件 | 改动说明 |
|------|----------|
| `frontend/src/composables/usePersistedPageSize.ts` | `get/setPersistedPageSize` 新增可选 `storageKey` 参数,默认沿用全局 key |
| `frontend/src/components/common/Pagination.vue` | 新增可选 `storageKey` prop,持久化时透传;不传维持全局行为 |
| `frontend/src/views/admin/UsageView.vue` | Pagination 使用独立 key `usage-page-size` 持久化分页 |
| `frontend/src/views/user/UsageView.vue` | 同上(用户端使用记录页) |

## 影响范围 (Impact)

- 其他列表页未传 `storageKey`,行为完全不变。
- 使用记录页用独立 key,修复后首次进入因新 key 无值会回退到默认每页条数,不会再读到旧的 1000。
- 仅前端改动,无后端 / 数据库 / 数据迁移变更。

## 测试 (Test Plan)

- [x] `vue-tsc --noEmit` 前端类型检查通过(无相关报错)
- [x] Docker dev 环境构建并端到端验证:账号管理设为 1000 后,切换使用记录页不再卡死,且分页设置互相独立