### PR TITLE
fix(gateway): preserve system block cache control during rewrite

### DIFF
--- a/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
+++ b/backend/internal/service/gateway_anthropic_apikey_passthrough_test.go
@@ -831,7 +831,7 @@ func TestGatewayService_AnthropicOAuth_ForwardPreservesBillingHeaderSystemBlock(
 			require.True(t, messages.IsArray())
 			firstMsg := messages.Array()[0]
 			require.Equal(t, "user", firstMsg.Get("role").String())
-			require.Contains(t, firstMsg.Get("content.0.text").String(), "x-anthropic-billing-header keep")
+			require.Equal(t, firstMsg.Get("content.1.text").String(), "x-anthropic-billing-header keep")
 		})
 	}
 }

--- a/backend/internal/service/gateway_prompt_test.go
+++ b/backend/internal/service/gateway_prompt_test.go
@@ -304,14 +304,14 @@ func TestInjectClaudeCodePrompt(t *testing.T) {
 
 func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 	tests := []struct {
-		name             string
-		body             string
-		system           any
-		wantSystemText   string // system array 第一个 block 的 text
-		wantMessagesLen  int    // messages 数组长度
-		wantFirstMsgRole string // 第一条消息的 role
-		wantFirstMsgText string // 第一条消息的 content[0].text
-		wantAckMsgText   string // 第二条消息的 content[0].text
+		name                string
+		body                string
+		system              any
+		wantSystemText      string           // system array 第一个 block 的 text
+		wantMessagesLen     int              // messages 数组长度
+		wantFirstMsgRole    string           // 第一条消息的 role
+		wantFirstMsgContent []map[string]any // 第一条消息的 content
+		wantAckMsgText      string           // 第二条消息的 content[0].text
 	}{
 		{
 			name:            "nil system - no messages injected",
@@ -334,8 +334,11 @@ func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 			wantSystemText:   claudeCodeSystemPrompt,
 			wantMessagesLen:  3, // instruction + ack + original
 			wantFirstMsgRole: "user",
-			wantFirstMsgText: "[System Instructions]\nYou are a personal assistant running inside OpenClaw.",
-			wantAckMsgText:   "Understood. I will follow these instructions.",
+			wantFirstMsgContent: []map[string]any{
+				{"type": "text", "text": "[System Instructions]"},
+				{"type": "text", "text": "You are a personal assistant running inside OpenClaw."},
+			},
+			wantAckMsgText: "Understood. I will follow these instructions.",
 		},
 		{
 			name:            "system equals Claude Code prompt - no messages injected",
@@ -345,7 +348,7 @@ func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 			wantMessagesLen: 1,
 		},
 		{
-			name: "array system with custom blocks - text joined and migrated",
+			name: "array system with custom blocks",
 			body: `{"model":"claude-3","messages":[{"role":"user","content":"hello"}]}`,
 			system: []any{
 				map[string]any{"type": "text", "text": "First instruction"},
@@ -354,8 +357,29 @@ func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 			wantSystemText:   claudeCodeSystemPrompt,
 			wantMessagesLen:  3,
 			wantFirstMsgRole: "user",
-			wantFirstMsgText: "[System Instructions]\nFirst instruction\n\nSecond instruction",
-			wantAckMsgText:   "Understood. I will follow these instructions.",
+			wantFirstMsgContent: []map[string]any{
+				{"type": "text", "text": "[System Instructions]"},
+				{"type": "text", "text": "First instruction"},
+				{"type": "text", "text": "Second instruction"},
+			},
+			wantAckMsgText: "Understood. I will follow these instructions.",
+		},
+		{
+			name: "system with custom cache_control blocks ",
+			body: `{"model":"claude-3","messages":[{"role":"user","content":"hello"}]}`,
+			system: []any{
+				map[string]any{"type": "text", "text": "First instruction"},
+				map[string]any{"type": "text", "text": "Second instruction", "cache_control": map[string]any{"type": "ephemeral"}},
+			},
+			wantSystemText:   claudeCodeSystemPrompt,
+			wantMessagesLen:  3,
+			wantFirstMsgRole: "user",
+			wantFirstMsgContent: []map[string]any{
+				{"type": "text", "text": "[System Instructions]"},
+				{"type": "text", "text": "First instruction"},
+				{"type": "text", "text": "Second instruction", "cache_control": map[string]any{"type": "ephemeral"}},
+			},
+			wantAckMsgText: "Understood. I will follow these instructions.",
 		},
 		{
 			name:            "empty array system - no messages injected",
@@ -371,8 +395,11 @@ func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 			wantSystemText:   claudeCodeSystemPrompt,
 			wantMessagesLen:  3,
 			wantFirstMsgRole: "user",
-			wantFirstMsgText: "[System Instructions]\nCustom prompt",
-			wantAckMsgText:   "Understood. I will follow these instructions.",
+			wantFirstMsgContent: []map[string]any{
+				{"type": "text", "text": "[System Instructions]"},
+				{"type": "text", "text": "Custom prompt"},
+			},
+			wantAckMsgText: "Understood. I will follow these instructions.",
 		},
 		{
 			name:            "json.RawMessage nil system",
@@ -388,8 +415,11 @@ func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 			wantSystemText:   claudeCodeSystemPrompt,
 			wantMessagesLen:  5, // 2 injected + 3 original
 			wantFirstMsgRole: "user",
-			wantFirstMsgText: "[System Instructions]\nBe helpful",
-			wantAckMsgText:   "Understood. I will follow these instructions.",
+			wantFirstMsgContent: []map[string]any{
+				{"type": "text", "text": "[System Instructions]"},
+				{"type": "text", "text": "Be helpful"},
+			},
+			wantAckMsgText: "Understood. I will follow these instructions.",
 		},
 	}
 
@@ -437,10 +467,12 @@ func TestRewriteSystemForNonClaudeCode(t *testing.T) {
 
 				firstContent, ok := firstMsg["content"].([]any)
 				require.True(t, ok)
-				require.Len(t, firstContent, 1)
-				firstBlock, ok := firstContent[0].(map[string]any)
-				require.True(t, ok)
-				require.Equal(t, tt.wantFirstMsgText, firstBlock["text"])
+				require.Len(t, firstContent, len(tt.wantFirstMsgContent))
+				for i := range firstContent {
+					content, ok := firstContent[i].(map[string]any)
+					require.True(t, ok)
+					require.Equal(t, tt.wantFirstMsgContent[i], content)
+				}
 
 				// 检查注入的 ack 消息
 				ackMsg, ok := messages[1].(map[string]any)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -4117,21 +4117,30 @@ func injectClaudeCodePrompt(body []byte, system any) []byte {
 func rewriteSystemForNonClaudeCode(body []byte, system any) []byte {
 	system = normalizeSystemParam(system)
 
-	// 1. 提取原始 system prompt 文本
-	var originalSystemText string
+	// 1. 提取原始 system prompt 文本和可迁移的 content blocks
+	originalSystemBlocks := []map[string]any{{"type": "text", "text": "[System Instructions]"}}
+	ccPromptTrimmed := strings.TrimSpace(claudeCodeSystemPrompt)
 	switch v := system.(type) {
 	case string:
-		originalSystemText = strings.TrimSpace(v)
+		textTrimmed := strings.TrimSpace(v)
+		if textTrimmed != "" && textTrimmed != ccPromptTrimmed && !hasClaudeCodePrefix(textTrimmed) {
+			originalSystemBlocks = append(originalSystemBlocks, map[string]any{"type": "text", "text": textTrimmed})
+		}
 	case []any:
-		var parts []string
 		for _, item := range v {
 			if m, ok := item.(map[string]any); ok {
-				if text, ok := m["text"].(string); ok && strings.TrimSpace(text) != "" {
-					parts = append(parts, text)
+				if text, ok := m["text"].(string); ok {
+					textTrimmed := strings.TrimSpace(text)
+					if textTrimmed != "" && textTrimmed != ccPromptTrimmed && !hasClaudeCodePrefix(textTrimmed) {
+						block := map[string]any{"type": "text", "text": textTrimmed}
+						if cacheControl, ok := m["cache_control"]; ok {
+							block["cache_control"] = cacheControl
+						}
+						originalSystemBlocks = append(originalSystemBlocks, block)
+					}
 				}
 			}
 		}
-		originalSystemText = strings.Join(parts, "\n\n")
 	}
 
 	// 2. 构造 system 数组，对齐真实 Claude Code CLI 的 2-block 形态：
@@ -4155,14 +4164,8 @@ func rewriteSystemForNonClaudeCode(body []byte, system any) []byte {
 
 	// 3. 将原始 system prompt 作为 user/assistant 消息对注入到 messages 开头
 	//    模型仍通过 messages 接收完整指令，保留客户端功能
-	ccPromptTrimmed := strings.TrimSpace(claudeCodeSystemPrompt)
-	if originalSystemText != "" && originalSystemText != ccPromptTrimmed && !hasClaudeCodePrefix(originalSystemText) {
-		instrMsg, err1 := json.Marshal(map[string]any{
-			"role": "user",
-			"content": []map[string]any{
-				{"type": "text", "text": "[System Instructions]\n" + originalSystemText},
-			},
-		})
+	if len(originalSystemBlocks) > 1 {
+		instrMsg, err1 := json.Marshal(map[string]any{"role": "user", "content": originalSystemBlocks})
 		ackMsg, err2 := json.Marshal(map[string]any{
 			"role": "assistant",
 			"content": []map[string]any{


### PR DESCRIPTION
## 摘要

在 rewriteSystemForNonClaudeCode 时, 不合并为字符串, 而是将原始的 system content 以 block 为单位迁移 (包括 cache_control)

## 背景

### 问题

在使用 sub2api 作为 base_url 测试缓存命中时发现, 如果手动控制 system 块缓存, 多次请求缓存无法命中

最小复现请求是:
```json
{
    "model": "claude-opus-4-7",
    "max_tokens": 64,
    "system": [
        { "type": "text", "text": "system prompt 1 ..." },
        { "type": "text", "text": "system prompt 2 ...", "cache_control": { "type": "ephemeral" } }
    ],
    "messages": [
        { "role": "user", "content": "reply with one short sentence." }
    ]
}
```
sub2api 会将 system 注入到 messages 中,改写影响了对应的 cache_control:
```json
{
    "model": "claude-opus-4-7",
    "max_tokens": 64,
    "messages": [
        {
            "role": "user",
            "content": [
                { "text": "[System Instructions]\nsystem prompt 1 ...\n\nsystem prompt 2 ...", "type": "text" }
            ]
        },
        { "role": "assistant", "content": "Understood. I will follow these instructions." },
        { "role": "user", "content": "Request 1: reply with one short sentence." }
    ],
    "system": ...
}
```

### 方案

将 system text block 整个迁移为 user message content block, 保留 cache_control 属性


```diff
{
    "model": "claude-opus-4-7",
    "max_tokens": 64,
    "messages": [
        {
            "role": "user",
            "content": [
-                { "text": "[System Instructions]\nsystem prompt 1 ...\n\nsystem prompt 2 ...", "type": "text" }
+                { "text": "[System Instructions]", "type": "text" },
+                { "text": "system prompt 1 ...", "type": "text" },
+                { "text": "system prompt 2 ...", "type": "text", "cache_control": { "type": "ephemeral" } },
            ]
        },
        { "role": "assistant" "content": "Understood. I will follow these instructions." },
        { "role": "user", "content": "Request 1: reply with one short sentence." }
    ],
    "system": ...
}
```