### PR TITLE
Add codex-auto-review to OpenAI default models

### DIFF
--- a/backend/internal/pkg/openai/constants.go
+++ b/backend/internal/pkg/openai/constants.go
@@ -20,6 +20,7 @@ var DefaultModels = []Model{
 	{ID: "gpt-5.4-mini", Object: "model", Created: 1738368000, OwnedBy: "openai", Type: "model", DisplayName: "GPT-5.4 Mini"},
 	{ID: "gpt-5.3-codex", Object: "model", Created: 1735689600, OwnedBy: "openai", Type: "model", DisplayName: "GPT-5.3 Codex"},
 	{ID: "gpt-5.3-codex-spark", Object: "model", Created: 1735689600, OwnedBy: "openai", Type: "model", DisplayName: "GPT-5.3 Codex Spark"},
+	{ID: "codex-auto-review", Object: "model", Created: 1776902400, OwnedBy: "openai", Type: "model", DisplayName: "Codex Auto Review"},
 	{ID: "gpt-5.2", Object: "model", Created: 1733875200, OwnedBy: "openai", Type: "model", DisplayName: "GPT-5.2"},
 	{ID: "gpt-image-1", Object: "model", Created: 1733875200, OwnedBy: "openai", Type: "model", DisplayName: "GPT Image 1"},
 	{ID: "gpt-image-1.5", Object: "model", Created: 1735689600, OwnedBy: "openai", Type: "model", DisplayName: "GPT Image 1.5"},


### PR DESCRIPTION
## Summary
- add `codex-auto-review` to the OpenAI default `/v1/models` fallback catalog
- add a focused regression test so the default model list keeps exposing it

## Validation
- `go test ./internal/pkg/openai ./internal/handler -run 'TestDefaultModelsContainsCodexAutoReview|TestGatewayModels'`\n- `make test-unit`\n- `git diff --check`\n\n## Notes\n- `golangci-lint run ./...` was started locally with golangci-lint 2.11.4, but it ran for several minutes without output and was stopped; CI uses v2.9 and should provide the authoritative lint result.