### PR TITLE
Align OpenAI Codex usage stats with reset windows

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -528,14 +528,14 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-5*time.Hour)); err == nil {
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
 		if usage.FiveHour == nil {
 			usage.FiveHour = &UsageProgress{Utilization: 0}
 		}
 		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, now.Add(-7*24*time.Hour)); err == nil {
+	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.SevenDay, 7*24*time.Hour, now)); err == nil {
 		if usage.SevenDay == nil {
 			usage.SevenDay = &UsageProgress{Utilization: 0}
 		}
@@ -1118,6 +1118,13 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	return progress
+}
+
+func codexWindowStatsStart(progress *UsageProgress, fallbackWindow time.Duration, now time.Time) time.Time {
+	if progress != nil && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
+		return progress.ResetsAt.Add(-fallbackWindow)
+	}
+	return now.Add(-fallbackWindow)
 }
 
 func (s *AccountUsageService) GetAccountUsageStats(ctx context.Context, accountID int64, startTime, endTime time.Time) (*usagestats.AccountUsageStatsResponse, error) {


### PR DESCRIPTION
## Summary

This PR aligns OpenAI OAuth Codex usage window stats with the displayed reset windows.

Previously, the `5h` and `7d` local stats were always queried using rolling windows:

- `now - 5h`
- `now - 7d`

That could make requests/tokens/cost differ from the actual quota window shown by the Codex utilization and
reset time.

## Changes

- Added a small helper to derive the stats start time from the already parsed `UsageProgress.ResetsAt`.
- For active reset windows, stats now use:
  - `5h`: `resets_at - 5h`
  - `7d`: `resets_at - 7d`
- If the reset time is missing or expired, behavior falls back to the previous rolling window logic.

## Notes

This keeps the change minimal and reuses the existing parsed `UsageProgress` data instead of reparsing raw
`accounts.extra` fields.

Closes https://github.com/Wei-Shaw/sub2api/issues/2954