### PR TITLE
[Security] fix: sanitize API key name to prevent stored XSS

### DIFF
--- a/backend/internal/service/api_key_service.go
+++ b/backend/internal/service/api_key_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"html"
 	"strconv"
 	"strings"
 	"sync"
@@ -399,7 +400,7 @@ func (s *APIKeyService) Create(ctx context.Context, userID int64, req CreateAPIK
 	apiKey := &APIKey{
 		UserID:      userID,
 		Key:         key,
-		Name:        req.Name,
+		Name:        html.EscapeString(req.Name),
 		GroupID:     req.GroupID,
 		Status:      StatusActive,
 		IPWhitelist: req.IPWhitelist,
@@ -538,7 +539,7 @@ func (s *APIKeyService) Update(ctx context.Context, id int64, userID int64, req 
 
 	// 更新字段
 	if req.Name != nil {
-		apiKey.Name = *req.Name
+		apiKey.Name = html.EscapeString(*req.Name)
 	}
 
 	if req.GroupID != nil {


### PR DESCRIPTION
创建和更新 API Key 的时候，name 字段没有做 HTML 转义，直接存进了数据库。

## Problem

`backend/internal/service/api_key_service.go`

创建 Key（第 402 行）：
```go
Name: req.Name,  // 用户输入直接入库
```

更新 Key（第 541 行）：
```go
apiKey.Name = *req.Name  // 同上
```

## How to reproduce

本地搭了一套 sub2api，POST 一个带 script 标签的 name：

```bash
curl -s http://localhost:9090/api/v1/keys \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"name":"<img src=x onerror=alert(1)>"}'
```

返回的数据里 name 原封不动：

```json
{ "data": { "id": 5, "name": "<img src=x onerror=alert(1)>" } }
```

库里也是：

```
sub2api=# SELECT id, name FROM api_keys WHERE id = 5;
 id |                   name
----+------------------------------------------
  5 | <img src=x onerror=alert(1)>
```

虽然用户端 Vue 用的 `{{ }}` 插值不会执行，但如果管理员面板或者第三方消费端用了 v-html / innerHTML 来渲染 name，就直接触发存储型 XSS。

## How to fix

在 Create 和 Update 里对 name 做一次 `html.EscapeString()`，把 `<` 转成 `&lt;` 之类的。修完以后再传同样的 payload，返回的就是：

```json
{ "data": { "id": 6, "name": "&lt;img src=x onerror=alert(1)&gt;" } }
```

改的就是标准库里现成的函数，不引入新依赖。