### PR TITLE
[Security] fix: return 404 instead of 403 to prevent key ID enumeration

### DIFF
--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -131,7 +131,7 @@ func (h *APIKeyHandler) GetByID(c *gin.Context) {
 
 	// 验证所有权
 	if key.UserID != subject.UserID {
-		response.Forbidden(c, "Not authorized to access this key")
+		response.NotFound(c, "API key not found")
 		return
 	}
 


### PR DESCRIPTION
`GET /api/v1/keys/:id` 在 key 不存在和 key 存在但不属于当前用户时，返回了不一样的 HTTP 状态码，导致可以枚举有效的 key ID。

## Problem

`backend/internal/handler/api_key_handler.go` 的 `GetByID` 方法（第 126-136 行）：

```go
key, err := h.apiKeyService.GetByID(c.Request.Context(), keyID)
if err != nil {
    response.ErrorFrom(c, err)     // key 不存在 → 404
    return
}
if key.UserID != subject.UserID {
    response.Forbidden(c, "Not authorized to access this key")  // 别人的 key → 403
    return
}
```

逻辑很清晰：先查 key，查不到就 404，查到了但不是自己的就 403。问题是这两个状态码不一样，外部可以靠它来判断一个 key ID 是否存在。

## How to reproduce

本地起了一套 sub2api，建了两个用户（admin 和 user2）。admin 下面有 key ID=1,2,3。用 user2 的 token 去枚举：

```bash
TOKEN=$(curl -s http://localhost:9090/api/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"user2@vuln.demo","password":"User21234"}' \
  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['access_token'])")

for id in 1 2 3 99999; do
  curl -s -o /dev/null -w "ID=$id HTTP=%{http_code}\n" \
    http://localhost:9090/api/v1/keys/$id \
    -H "Authorization: Bearer $TOKEN"
done
```

输出：

```
ID=1     HTTP=403
ID=2     HTTP=403
ID=3     HTTP=403
ID=99999 HTTP=404
```

403 的就说明 key 存在，404 的不存在。靠这个就能把系统里所有的 key ID 扫出来。

## How to fix

把 403 改成 404，两种情况返回一样的响应：

```go
if key.UserID != subject.UserID {
    response.NotFound(c, "API key not found")
    return
}
```

修完以后再跑上面的脚本：

```
ID=1     HTTP=404
ID=2     HTTP=404
ID=3     HTTP=404
ID=99999 HTTP=404
```

完全区分不了了。