### PR TITLE
compat(redis): support Redis 3.2-4.x via explicit Lua command replication

### DIFF
--- a/backend/internal/repository/concurrency_cache.go
+++ b/backend/internal/repository/concurrency_cache.go
@@ -44,6 +44,7 @@ var (
 	// ARGV[2] = TTL（秒）
 	// ARGV[3] = requestID
 	acquireScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local maxConcurrency = tonumber(ARGV[1])
 		local ttl = tonumber(ARGV[2])
@@ -81,6 +82,7 @@ var (
 	// KEYS[1] = 有序集合键
 	// ARGV[1] = TTL（秒）
 	getCountScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local ttl = tonumber(ARGV[1])
 
@@ -151,6 +153,7 @@ var (
 	// KEYS[1] = 有序集合键
 	// ARGV[1] = TTL（秒）
 	cleanupExpiredSlotsScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local ttl = tonumber(ARGV[1])
 		local timeResult = redis.call('TIME')

--- a/backend/internal/repository/session_limit_cache.go
+++ b/backend/internal/repository/session_limit_cache.go
@@ -42,6 +42,7 @@ var (
 	// ARGV[3] = sessionUUID
 	// 返回: 1 = 允许, 0 = 拒绝
 	registerSessionScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local maxSessions = tonumber(ARGV[1])
 		local idleTimeout = tonumber(ARGV[2])
@@ -82,6 +83,7 @@ var (
 	// ARGV[1] = idleTimeout（秒）
 	// ARGV[2] = sessionUUID
 	refreshSessionScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local idleTimeout = tonumber(ARGV[1])
 		local sessionUUID = ARGV[2]
@@ -102,6 +104,7 @@ var (
 	// KEYS[1] = session_limit:account:{accountID}
 	// ARGV[1] = idleTimeout（秒）
 	getActiveSessionCountScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local idleTimeout = tonumber(ARGV[1])
 
@@ -120,6 +123,7 @@ var (
 	// ARGV[1] = idleTimeout（秒）
 	// ARGV[2] = sessionUUID
 	isSessionActiveScript = redis.NewScript(`
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local idleTimeout = tonumber(ARGV[1])
 		local sessionUUID = ARGV[2]

--- a/backend/internal/repository/user_msg_queue_cache.go
+++ b/backend/internal/repository/user_msg_queue_cache.go
@@ -34,6 +34,7 @@ return 1
 
 // Lua 脚本：原子释放锁 + 记录完成时间（使用 Redis TIME 避免时钟偏差）
 var releaseLockScript = redis.NewScript(`
+redis.replicate_commands()
 local cur = redis.call('GET', KEYS[1])
 if cur == ARGV[1] then
     redis.call('DEL', KEYS[1])


### PR DESCRIPTION
## Summary

Add `redis.replicate_commands()` at the top of every Lua script that calls `redis.call('TIME')`, opting those scripts into Redis **effects replication** mode. This is a **no-op on Redis 5.0+** and a backward-compatibility fix for deployments still running Redis 3.2–4.x.

## Background

Eight Lua scripts across three files in `backend/internal/repository/` call `redis.call('TIME')` to read the Redis server clock. The existing inline comments document the design intent: avoid client-side clock skew across multiple application instances.

`TIME` is a non-deterministic command, and Redis replicates Lua scripts differently depending on version:

| Redis version | Default Lua replication mode | Behavior with non-deterministic commands |
| --- | --- | --- |
| 3.2 – 4.x | script replication | Effects of non-deterministic commands can desync between primary, replicas and AOF; some scripts are rejected at write time unless `redis.replicate_commands()` is called first |
| 5.0+ | effects (command) replication | `redis.replicate_commands()` is a **no-op**; behavior unchanged |
| 7.0+ | effects (command) replication | `redis.replicate_commands()` is deprecated but still callable; behavior unchanged |

The bundled `deploy/docker-compose*.yml` files use `redis:8-alpine`, so this never surfaces on a fresh stack. It only surfaces in environments deploying against older Redis (private/enterprise registries pinned to 3.2 – 4.x).

## Why not switch to a client-supplied timestamp?

Each affected script's inline comment explicitly states the design intent: read the time from the Redis server so the timestamp source stays consistent across multiple application instances. Passing a timestamp via `ARGV` would regress that design and reintroduce the clock-skew problem this code was written to avoid. Opting into explicit command replication is the correct fix.

## Changes

8 lines added — one `redis.replicate_commands()` per script that calls `TIME`.

| File | Scripts touched |
| --- | --- |
| `backend/internal/repository/concurrency_cache.go` | `acquireScript`, `getCountScript`, `cleanupExpiredSlotsScript` |
| `backend/internal/repository/session_limit_cache.go` | `registerSessionScript`, `refreshSessionScript`, `getActiveSessionCountScript`, `isSessionActiveScript` |
| `backend/internal/repository/user_msg_queue_cache.go` | `releaseLockScript` |

Scripts that do not call `TIME` (or any other non-deterministic command) are intentionally left untouched.

## Compatibility

- No-op on Redis 5.0+ (the default deployment) — behavior unchanged
- Fixes incorrect replication / script rejection on Redis 3.2 – 4.x
- No client-side changes required
- `redis.replicate_commands()` is available since Redis 3.2, so no new Redis feature is introduced

## Test plan

- [ ] `go build ./...` succeeds
- [ ] Existing repository tests pass against `redis:8-alpine` (no behavior change)
- [ ] Manual smoke test against a Redis 4.x instance in a primary + replica setup, verifying the affected scripts execute and replicate cleanly