### PR TITLE
compat(redis): make TIME-using Lua scripts work on Redis 3.2-4.x

### DIFF
--- a/backend/internal/repository/concurrency_cache.go
+++ b/backend/internal/repository/concurrency_cache.go
@@ -44,6 +44,9 @@ var (
 	// ARGV[2] = TTL（秒）
 	// ARGV[3] = requestID
 	acquireScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local maxConcurrency = tonumber(ARGV[1])
 		local ttl = tonumber(ARGV[2])
@@ -81,6 +84,9 @@ var (
 	// KEYS[1] = 有序集合键
 	// ARGV[1] = TTL（秒）
 	getCountScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local ttl = tonumber(ARGV[1])
 
@@ -151,6 +157,9 @@ var (
 	// KEYS[1] = 有序集合键
 	// ARGV[1] = TTL（秒）
 	cleanupExpiredSlotsScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local ttl = tonumber(ARGV[1])
 		local timeResult = redis.call('TIME')

--- a/backend/internal/repository/session_limit_cache.go
+++ b/backend/internal/repository/session_limit_cache.go
@@ -42,6 +42,9 @@ var (
 	// ARGV[3] = sessionUUID
 	// 返回: 1 = 允许, 0 = 拒绝
 	registerSessionScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local maxSessions = tonumber(ARGV[1])
 		local idleTimeout = tonumber(ARGV[2])
@@ -82,6 +85,9 @@ var (
 	// ARGV[1] = idleTimeout（秒）
 	// ARGV[2] = sessionUUID
 	refreshSessionScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local idleTimeout = tonumber(ARGV[1])
 		local sessionUUID = ARGV[2]
@@ -102,6 +108,9 @@ var (
 	// KEYS[1] = session_limit:account:{accountID}
 	// ARGV[1] = idleTimeout（秒）
 	getActiveSessionCountScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local idleTimeout = tonumber(ARGV[1])
 
@@ -120,6 +129,9 @@ var (
 	// ARGV[1] = idleTimeout（秒）
 	// ARGV[2] = sessionUUID
 	isSessionActiveScript = redis.NewScript(`
+		-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+		-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+		redis.replicate_commands()
 		local key = KEYS[1]
 		local idleTimeout = tonumber(ARGV[1])
 		local sessionUUID = ARGV[2]

--- a/backend/internal/repository/user_msg_queue_cache.go
+++ b/backend/internal/repository/user_msg_queue_cache.go
@@ -34,6 +34,9 @@ return 1
 
 // Lua 脚本：原子释放锁 + 记录完成时间（使用 Redis TIME 避免时钟偏差）
 var releaseLockScript = redis.NewScript(`
+-- Redis 3.2-4.x compat: opt into effects replication so redis.call('TIME')
+-- replicates correctly. No-op on Redis 5.0+ (effects replication is default).
+redis.replicate_commands()
 local cur = redis.call('GET', KEYS[1])
 if cur == ARGV[1] then
     redis.call('DEL', KEYS[1])


### PR DESCRIPTION
## Summary

Eight Lua scripts in `backend/internal/repository/` call `redis.call('TIME')` to read the Redis server clock — by design, to avoid client-side clock skew across multiple application instances (the existing inline comments document this rationale).

`TIME` is non-deterministic, and Redis replicates that to replicas / AOF differently across versions. This PR adds a single `redis.replicate_commands()` call at the top of each affected script so the resulting writes (`ZADD`, `ZREMRANGEBYSCORE`, `SET`, `DEL`, `EXPIRE`) replicate correctly on Redis **3.2 – 4.x**.

## Compatibility

| Redis version | Behavior of `redis.replicate_commands()` | Effect of this PR |
| --- | --- | --- |
| 3.2 – 4.x | Required — switches Lua from script replication to effects replication so non-deterministic command effects can be propagated | **Fixes** incorrect replication / silent divergence on replicas and AOF |
| 5.0 – 6.x | No-op — effects replication is the default | **No-op** — behavior unchanged |
| 7.0+ | Still callable, marked deprecated (not removed); the docs still list it as the supported way to opt into effects replication when needed | **No-op** — behavior unchanged |

The bundled `deploy/docker-compose*.yml` files pin `redis:8-alpine`, so this never surfaces on the default stack. It only surfaces in deployments running against older Redis instances (private/enterprise registries, on-prem setups), which is where this fix is needed.

## Why not pass the timestamp in via `ARGV`?

Each affected script's inline comment explicitly documents the design intent: read the time from the Redis server so the timestamp source stays consistent across multiple application instances. Switching to a client-supplied `ARGV` timestamp would regress that design and reintroduce the clock-skew problem this code was written to avoid. Opting into explicit command replication is the correct fix.

## Affected scripts (8 total)

| File | Scripts |
| --- | --- |
| `backend/internal/repository/concurrency_cache.go` | `acquireScript`, `getCountScript`, `cleanupExpiredSlotsScript` |
| `backend/internal/repository/session_limit_cache.go` | `registerSessionScript`, `refreshSessionScript`, `getActiveSessionCountScript`, `isSessionActiveScript` |
| `backend/internal/repository/user_msg_queue_cache.go` | `releaseLockScript` |

Scripts that do not invoke non-deterministic commands (`incrementWaitScript`, `decrementWaitScript`, `acquireLockScript`, `forceReleaseLockScript`, `startupCleanupScript`, …) are intentionally left untouched.

## Test plan

- [ ] `go build ./...` passes
- [ ] Existing repository tests pass against `redis:8-alpine` (no behavior change, since `redis.replicate_commands()` is a no-op there)
- [ ] Manual smoke test against a Redis 4.x primary + replica setup, verifying the affected scripts execute and replicate cleanly

## Diff size

3 files changed, 24 insertions(+) — two comment lines + one call per script.