### PR TITLE
fix(openai): stabilize websocket bridge continuations

### DIFF
--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -132,7 +132,7 @@ func TestAccountTestService_OpenAISuccessPersistsSnapshotFromHeaders(t *testing.
 	require.Len(t, upstream.requests, 1)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.requests[0].Context()))
 	require.NotEmpty(t, repo.updatedExtra)
-	require.Equal(t, 58.0, repo.updatedExtra["codex_5h_used_percent"])
+	require.Equal(t, 42.0, repo.updatedExtra["codex_5h_used_percent"])
 	require.Equal(t, 88.0, repo.updatedExtra["codex_7d_used_percent"])
 	require.Contains(t, recorder.Body.String(), "test_complete")
 }
@@ -170,7 +170,7 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimitState(t *testin
 	resp.Header.Set("x-codex-primary-used-percent", "100")
 	resp.Header.Set("x-codex-primary-reset-after-seconds", "604800")
 	resp.Header.Set("x-codex-primary-window-minutes", "10080")
-	resp.Header.Set("x-codex-secondary-used-percent", "0")
+	resp.Header.Set("x-codex-secondary-used-percent", "100")
 	resp.Header.Set("x-codex-secondary-reset-after-seconds", "18000")
 	resp.Header.Set("x-codex-secondary-window-minutes", "300")
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -73,7 +73,7 @@ func TestExtractOpenAICodexProbeUpdatesAccepts429WithCodexHeaders(t *testing.T) 
 	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "604800")
 	headers.Set("x-codex-primary-window-minutes", "10080")
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -126,15 +126,16 @@ type NormalizedCodexLimits struct {
 	Window7dMinutes *int
 }
 
-func normalizeCodexFiveHourUsedPercent(raw *float64) *float64 {
+func normalizeCodexUsedPercent(raw *float64) *float64 {
 	if raw == nil {
 		return nil
 	}
-	// OpenAI's 5h Codex quota header is remaining%, despite the upstream header
-	// name saying "used"; the canonical codex_5h_used_percent field stores used%.
-	used := 100 - *raw
+	used := *raw
 	if used < 0 {
 		used = 0
+	}
+	if used > 100 {
+		used = 100
 	}
 	return &used
 }
@@ -197,17 +198,17 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 
 	// Assign values
 	if use5hFromPrimary {
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.PrimaryUsedPercent)
+		result.Used5hPercent = normalizeCodexUsedPercent(s.PrimaryUsedPercent)
 		result.Reset5hSeconds = s.PrimaryResetAfterSeconds
 		result.Window5hMinutes = s.PrimaryWindowMinutes
-		result.Used7dPercent = s.SecondaryUsedPercent
+		result.Used7dPercent = normalizeCodexUsedPercent(s.SecondaryUsedPercent)
 		result.Reset7dSeconds = s.SecondaryResetAfterSeconds
 		result.Window7dMinutes = s.SecondaryWindowMinutes
 	} else if use7dFromPrimary {
-		result.Used7dPercent = s.PrimaryUsedPercent
+		result.Used7dPercent = normalizeCodexUsedPercent(s.PrimaryUsedPercent)
 		result.Reset7dSeconds = s.PrimaryResetAfterSeconds
 		result.Window7dMinutes = s.PrimaryWindowMinutes
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.SecondaryUsedPercent)
+		result.Used5hPercent = normalizeCodexUsedPercent(s.SecondaryUsedPercent)
 		result.Reset5hSeconds = s.SecondaryResetAfterSeconds
 		result.Window5hMinutes = s.SecondaryWindowMinutes
 	}

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -104,11 +104,11 @@ func TestBuildCodexUsageExtraUpdates_UsesSnapshotUpdatedAt(t *testing.T) {
 	}
 }
 
-func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t *testing.T) {
+func TestBuildCodexUsageExtraUpdates_StoresFiveHourUsedPercent(t *testing.T) {
 	primaryUsed := 93.0
 	primaryReset := 86400
 	primaryWindow := 10080
-	secondaryRemaining := 6.0
+	secondaryUsed := 6.0
 	secondaryReset := 3600
 	secondaryWindow := 300
 
@@ -116,7 +116,7 @@ func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t 
 		PrimaryUsedPercent:         &primaryUsed,
 		PrimaryResetAfterSeconds:   &primaryReset,
 		PrimaryWindowMinutes:       &primaryWindow,
-		SecondaryUsedPercent:       &secondaryRemaining,
+		SecondaryUsedPercent:       &secondaryUsed,
 		SecondaryResetAfterSeconds: &secondaryReset,
 		SecondaryWindowMinutes:     &secondaryWindow,
 		UpdatedAt:                  "2026-05-30T07:04:09Z",
@@ -130,8 +130,8 @@ func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t 
 	if got := updates["codex_secondary_used_percent"]; got != 6.0 {
 		t.Fatalf("codex_secondary_used_percent = %v, want raw upstream value 6", got)
 	}
-	if got := updates["codex_5h_used_percent"]; got != 94.0 {
-		t.Fatalf("codex_5h_used_percent = %v, want 94", got)
+	if got := updates["codex_5h_used_percent"]; got != 6.0 {
+		t.Fatalf("codex_5h_used_percent = %v, want 6", got)
 	}
 	if got := updates["codex_7d_used_percent"]; got != 93.0 {
 		t.Fatalf("codex_7d_used_percent = %v, want 93", got)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1774,7 +1774,7 @@ func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 
 	select {
 	case updates := <-repo.updateExtraCalls:
-		require.Equal(t, 88.0, updates["codex_5h_used_percent"])
+		require.Equal(t, 12.0, updates["codex_5h_used_percent"])
 		require.Equal(t, 34.0, updates["codex_7d_used_percent"])
 		require.Equal(t, 600, updates["codex_5h_reset_after_seconds"])
 		require.Equal(t, 86400, updates["codex_7d_reset_after_seconds"])

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -2782,26 +2782,25 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 	refreshIngressRouteState(firstPayload)
 
-	if s.shouldBridgeOpenAIWSHTTP(firstPayload.payloadBytes, firstPayload.previousResponseID) {
+	runHTTPBridge := func(currentBridgePayload openAIWSClientPayload, bridgeReplayInput []json.RawMessage, bridgeReplayInputExists bool, firstBridgeTurn int, skipFirstTurnHooks bool) error {
 		logOpenAIWSModeInfo(
 			"ingress_ws_http_bridge_start account_id=%d account_type=%s payload_bytes=%d threshold_bytes=%d has_session_hash=%v store_disabled=%v",
 			account.ID,
 			account.Type,
-			firstPayload.payloadBytes,
+			currentBridgePayload.payloadBytes,
 			s.openAIWSHTTPBridgeThresholdBytes(),
 			sessionHash != "",
 			storeDisabled,
 		)
-		currentBridgePayload := firstPayload
-		var bridgeReplayInput []json.RawMessage
-		bridgeReplayInputExists := false
-		for turn := 1; ; turn++ {
-			if turn > 1 && hooks != nil && hooks.BeforeRequest != nil {
+		bridgeReplayInput = cloneOpenAIWSRawMessages(bridgeReplayInput)
+		for turn := firstBridgeTurn; ; turn++ {
+			isFirstBridgeTurn := turn == firstBridgeTurn
+			if !isFirstBridgeTurn && hooks != nil && hooks.BeforeRequest != nil {
 				if err := hooks.BeforeRequest(turn, currentBridgePayload.payloadRaw, currentBridgePayload.originalModel); err != nil {
 					return err
 				}
 			}
-			if hooks != nil && hooks.BeforeTurn != nil {
+			if !(skipFirstTurnHooks && isFirstBridgeTurn) && hooks != nil && hooks.BeforeTurn != nil {
 				if err := hooks.BeforeTurn(turn); err != nil {
 					return err
 				}
@@ -2822,6 +2821,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				return fmt.Errorf("build websocket http bridge replay input: %w", replayInputErr)
 			}
 			if needsBridgeReplay && turnReplayInputExists {
+				turnReplayInput = pruneOpenAIWSUnansweredToolCallContextItems(turnReplayInput)
 				updatedPayload, setInputErr := setOpenAIWSPayloadInputSequence(
 					currentBridgePayload.payloadRaw,
 					turnReplayInput,
@@ -2901,6 +2901,10 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 			currentBridgePayload = nextPayload
 		}
+	}
+
+	if s.shouldBridgeOpenAIWSHTTP(firstPayload.payloadBytes, firstPayload.previousResponseID) {
+		return runHTTPBridge(firstPayload, nil, false, 1, false)
 	}
 
 	wsHeaders, _ := s.buildOpenAIWSHeaders(c, account, token, wsDecision, isCodexCLI, turnState, strings.TrimSpace(c.GetHeader(openAIWSTurnMetadataHeader)), firstPayload.promptCacheKey)
@@ -3647,6 +3651,30 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					}
 				}
 			}
+		}
+		if s.shouldBridgeOpenAIWSHTTPPayload(currentPayloadBytes) {
+			logOpenAIWSModeInfo(
+				"ingress_ws_http_bridge_handoff account_id=%d turn=%d payload_bytes=%d threshold_bytes=%d has_previous_response_id=%v has_function_call_output=%v",
+				account.ID,
+				turn,
+				currentPayloadBytes,
+				s.openAIWSHTTPBridgeThresholdBytes(),
+				strings.TrimSpace(currentPreviousResponseID) != "",
+				hasFunctionCallOutput,
+			)
+			resetSessionLease(false)
+			currentBridgePayload := openAIWSClientPayload{
+				payloadRaw:         currentPayload,
+				rawForHash:         currentPayload,
+				promptCacheKey:     openAIWSPayloadStringFromRaw(currentPayload, "prompt_cache_key"),
+				previousResponseID: currentPreviousResponseID,
+				originalModel:      currentOriginalModel,
+				imageBillingModel:  currentImageBillingModel,
+				imageSizeTier:      currentImageSizeTier,
+				imageInputSize:     currentImageInputSize,
+				payloadBytes:       currentPayloadBytes,
+			}
+			return runHTTPBridge(currentBridgePayload, lastTurnReplayInput, lastTurnReplayInputExists, turn, true)
 		}
 		forcePreferredConn := isStrictAffinityTurn(currentPayload)
 		if sessionLease == nil {

--- a/backend/internal/service/openai_ws_http_bridge.go
+++ b/backend/internal/service/openai_ws_http_bridge.go
@@ -51,6 +51,14 @@ func (s *OpenAIGatewayService) shouldBridgeOpenAIWSHTTP(payloadBytes int, previo
 	return threshold > 0 && int64(payloadBytes) >= threshold
 }
 
+func (s *OpenAIGatewayService) shouldBridgeOpenAIWSHTTPPayload(payloadBytes int) bool {
+	if !s.openAIWSHTTPBridgeEnabled() {
+		return false
+	}
+	threshold := s.openAIWSHTTPBridgeThresholdBytes()
+	return threshold > 0 && int64(payloadBytes) >= threshold
+}
+
 func prepareOpenAIWSHTTPBridgeBody(payload []byte) ([]byte, error) {
 	var body map[string]any
 	if err := json.Unmarshal(payload, &body); err != nil {
@@ -64,6 +72,42 @@ func prepareOpenAIWSHTTPBridgeBody(payload []byte) ([]byte, error) {
 	delete(body, "previous_response_id")
 	body["stream"] = true
 	return json.Marshal(body)
+}
+
+func pruneOpenAIWSUnansweredToolCallContextItems(items []json.RawMessage) []json.RawMessage {
+	if len(items) == 0 {
+		return cloneOpenAIWSRawMessages(items)
+	}
+	outputCallIDs := make(map[string]struct{})
+	for _, raw := range items {
+		item := gjson.ParseBytes(raw)
+		if !isCodexToolCallOutputItemType(item.Get("type").String()) {
+			continue
+		}
+		callID := strings.TrimSpace(item.Get("call_id").String())
+		if callID != "" {
+			outputCallIDs[callID] = struct{}{}
+		}
+	}
+	pruned := make([]json.RawMessage, 0, len(items))
+	changed := false
+	for _, raw := range items {
+		item := gjson.ParseBytes(raw)
+		if isCodexToolCallContextItemType(item.Get("type").String()) {
+			callID := strings.TrimSpace(item.Get("call_id").String())
+			if callID != "" {
+				if _, ok := outputCallIDs[callID]; !ok {
+					changed = true
+					continue
+				}
+			}
+		}
+		pruned = append(pruned, json.RawMessage(append([]byte(nil), raw...)))
+	}
+	if !changed {
+		return cloneOpenAIWSRawMessages(items)
+	}
+	return pruned
 }
 
 type openAIWSToolCallReplayCollector struct {

--- a/backend/internal/service/openai_ws_http_bridge_test.go
+++ b/backend/internal/service/openai_ws_http_bridge_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -458,4 +459,169 @@ func TestOpenAIWSHTTPBridgeKeepsContinuationFramesOnHTTPWithoutPreviousResponseI
 	require.Equal(t, "call_bridge_1", secondInput[2].Get("call_id").String())
 	require.Equal(t, 0, captureDialer.DialCount())
 	require.Empty(t, captureConn.writes)
+}
+
+func TestPruneOpenAIWSUnansweredToolCallContextItems(t *testing.T) {
+	items := []json.RawMessage{
+		json.RawMessage(`{"type":"message","role":"user","content":"first"}`),
+		json.RawMessage(`{"type":"function_call","id":"fc_stale","call_id":"call_stale","name":"shell","arguments":"{}"}`),
+		json.RawMessage(`{"type":"function_call","id":"fc_keep","call_id":"call_keep","name":"shell","arguments":"{}"}`),
+		json.RawMessage(`{"type":"function_call_output","call_id":"call_keep","output":"ok"}`),
+	}
+
+	pruned := pruneOpenAIWSUnansweredToolCallContextItems(items)
+	require.Len(t, pruned, 3)
+	joined := string([]byte("[" + strings.Join([]string{
+		string(pruned[0]),
+		string(pruned[1]),
+		string(pruned[2]),
+	}, ",") + "]"))
+	require.False(t, strings.Contains(joined, "call_stale"))
+	require.True(t, strings.Contains(joined, "call_keep"))
+}
+
+func TestOpenAIWSHTTPBridgeHandoffWhenLaterFrameExceedsThreshold(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	secondSSEBody := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_bridge_second","model":"gpt-5.1","usage":{"input_tokens":2,"output_tokens":1}}}`,
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+			},
+			Body: io.NopCloser(strings.NewReader(secondSSEBody)),
+		},
+	}}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.HTTPBridgeEnabled = true
+	cfg.Gateway.OpenAIWS.HTTPBridgeThresholdBytes = 512
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	captureConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_ws_first","model":"gpt-5.1","output":[{"type":"function_call","id":"fc_ws_1","call_id":"call_ws_1","name":"shell","arguments":"{}"}],"usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	captureDialer := &openAIWSCaptureDialer{conn: captureConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(captureDialer)
+
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     upstream,
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          21,
+		Name:        "api-key-later-bridge",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Credentials: map[string]any{"api_key": "sk-upstream"},
+		Extra: map[string]any{
+			"responses_websockets_v2_enabled": true,
+		},
+		Concurrency: 1,
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	errCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			errCh <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		readCtx, cancelRead := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, err := conn.Read(readCtx)
+		cancelRead()
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			errCh <- NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "unexpected client websocket message type", nil)
+			return
+		}
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		req := r.Clone(r.Context())
+		req.Header = req.Header.Clone()
+		req.Header.Set("User-Agent", "codex_cli_rs/0.135.0")
+		ginCtx.Request = req
+
+		errCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, nil)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	writeMessage := func(payload string) {
+		writeCtx, cancelWrite := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelWrite()
+		require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(payload)))
+	}
+	readMessage := func() []byte {
+		readCtx, cancelRead := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancelRead()
+		msgType, event, readErr := clientConn.Read(readCtx)
+		require.NoError(t, readErr)
+		require.Equal(t, coderws.MessageText, msgType)
+		return event
+	}
+
+	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":true,"input":"first"}`)
+	firstTurnEvent := readMessage()
+	require.Equal(t, "response.completed", gjson.GetBytes(firstTurnEvent, "type").String())
+	require.Equal(t, "resp_ws_first", gjson.GetBytes(firstTurnEvent, "response.id").String())
+
+	largeToolOutput := strings.Repeat("x", 1024)
+	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":true,"previous_response_id":"resp_ws_first","input":[{"type":"function_call_output","call_id":"call_ws_1","output":"` + largeToolOutput + `"}]}`)
+	secondTurnEvent := readMessage()
+	require.Equal(t, "response.completed", gjson.GetBytes(secondTurnEvent, "type").String())
+	require.Equal(t, "resp_bridge_second", gjson.GetBytes(secondTurnEvent, "response.id").String())
+
+	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	select {
+	case proxyErr := <-errCh:
+		require.NoError(t, proxyErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for websocket bridge proxy to finish")
+	}
+
+	require.Equal(t, 1, captureDialer.DialCount())
+	require.Len(t, captureConn.writes, 1, "second oversized turn must not be sent to upstream websocket")
+	require.Len(t, upstream.bodies, 1)
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "previous_response_id").Exists())
+	bridgeInput := gjson.GetBytes(upstream.bodies[0], "input").Array()
+	require.Len(t, bridgeInput, 3)
+	require.Equal(t, "first", bridgeInput[0].String())
+	require.Equal(t, "function_call", bridgeInput[1].Get("type").String())
+	require.Equal(t, "call_ws_1", bridgeInput[1].Get("call_id").String())
+	require.Equal(t, "function_call_output", bridgeInput[2].Get("type").String())
+	require.Equal(t, "call_ws_1", bridgeInput[2].Get("call_id").String())
 }

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -51,7 +51,7 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 	headers.Set("x-codex-primary-used-percent", "50")
 	headers.Set("x-codex-primary-reset-after-seconds", "500000")
 	headers.Set("x-codex-primary-window-minutes", "10080") // 7 days
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-secondary-window-minutes", "300")       // 5 hours
 
@@ -122,7 +122,7 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 	// Test when OpenAI sends primary as 5h and secondary as 7d (reversed)
 	headers := http.Header{}
-	headers.Set("x-codex-primary-used-percent", "0")           // This is 5h remaining%
+	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-primary-window-minutes", "300")       // 5 hours - smaller!
 	headers.Set("x-codex-secondary-used-percent", "50")
@@ -180,7 +180,7 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "604800")
 	headers.Set("x-codex-primary-window-minutes", "10080")
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
@@ -224,7 +224,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	pUsed := 100.0
 	pReset := 384607
 	pWindow := 10080
-	sRemaining := 3.0
+	sUsed := 3.0
 	sReset := 17369
 	sWindow := 300
 
@@ -232,7 +232,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 		PrimaryUsedPercent:         &pUsed,
 		PrimaryResetAfterSeconds:   &pReset,
 		PrimaryWindowMinutes:       &pWindow,
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		SecondaryWindowMinutes:     &sWindow,
 	}
@@ -249,8 +249,8 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 384607 {
 		t.Errorf("expected Reset7dSeconds=384607, got %v", normalized.Reset7dSeconds)
 	}
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 97.0 {
-		t.Errorf("expected Used5hPercent=97, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 3.0 {
+		t.Errorf("expected Used5hPercent=3, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 17369 {
 		t.Errorf("expected Reset5hSeconds=17369, got %v", normalized.Reset5hSeconds)
@@ -338,11 +338,11 @@ func TestRateLimitService_HandleUpstreamError_403FallsBackToRawBody(t *testing.T
 
 func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 	// Test when only secondary has data, no window_minutes
-	sRemaining := 60.0
+	sUsed := 60.0
 	sReset := 3000
 
 	snapshot := &OpenAICodexUsageSnapshot{
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		// No window_minutes, no primary data
 	}
@@ -354,8 +354,8 @@ func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 
 	// Legacy assumption: primary=7d, secondary=5h
 	// So secondary goes to 5h
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 40.0 {
-		t.Errorf("expected Used5hPercent=40, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 60.0 {
+		t.Errorf("expected Used5hPercent=60, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 3000 {
 		t.Errorf("expected Reset5hSeconds=3000, got %v", normalized.Reset5hSeconds)
@@ -370,13 +370,13 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	// Test when both have data but no window_minutes
 	pUsed := 100.0
 	pReset := 400000
-	sRemaining := 30.0
+	sUsed := 30.0
 	sReset := 10000
 
 	snapshot := &OpenAICodexUsageSnapshot{
 		PrimaryUsedPercent:         &pUsed,
 		PrimaryResetAfterSeconds:   &pReset,
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		// No window_minutes
 	}
@@ -393,8 +393,8 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 400000 {
 		t.Errorf("expected Reset7dSeconds=400000, got %v", normalized.Reset7dSeconds)
 	}
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 70.0 {
-		t.Errorf("expected Used5hPercent=70, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 30.0 {
+		t.Errorf("expected Used5hPercent=30, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 10000 {
 		t.Errorf("expected Reset5hSeconds=10000, got %v", normalized.Reset5hSeconds)
@@ -422,24 +422,18 @@ func TestHandle429_AnthropicPlatformUnaffected(t *testing.T) {
 }
 
 func TestCalculateOpenAI429ResetTime_UserProvidedScenario(t *testing.T) {
-	// This is the exact scenario from the user:
-	// codex_7d_used_percent: 100
-	// codex_7d_reset_after_seconds: 384607 (约4.5天后重置)
-	// codex_5h_used_percent: 97 (from upstream 3% remaining)
-	// codex_5h_reset_after_seconds: 17369 (约4.8小时后重置)
+	// Official UI showed 5h remaining 0% and weekly remaining 34%.
+	// The raw headers observed online were primary=5h used 100 and secondary=7d used 66.
 
 	svc := &RateLimitService{}
 
-	// Simulate headers matching user's data
-	// Note: We need to map the canonical 5h/7d back to primary/secondary
-	// Based on typical OpenAI behavior: primary=7d (larger window), secondary=5h (smaller window)
 	headers := http.Header{}
 	headers.Set("x-codex-primary-used-percent", "100")
-	headers.Set("x-codex-primary-reset-after-seconds", "384607")
-	headers.Set("x-codex-primary-window-minutes", "10080") // 7 days = 10080 minutes
-	headers.Set("x-codex-secondary-used-percent", "3")
-	headers.Set("x-codex-secondary-reset-after-seconds", "17369")
-	headers.Set("x-codex-secondary-window-minutes", "300") // 5 hours = 300 minutes
+	headers.Set("x-codex-primary-reset-after-seconds", "4210")
+	headers.Set("x-codex-primary-window-minutes", "300")
+	headers.Set("x-codex-secondary-used-percent", "66")
+	headers.Set("x-codex-secondary-reset-after-seconds", "463536")
+	headers.Set("x-codex-secondary-window-minutes", "10080")
 
 	before := time.Now()
 	resetAt := svc.calculateOpenAI429ResetTime(headers)
@@ -449,8 +443,8 @@ func TestCalculateOpenAI429ResetTime_UserProvidedScenario(t *testing.T) {
 		t.Fatal("expected non-nil resetAt for user scenario")
 	}
 
-	// Should use the 7d reset time (384607 seconds) since 7d limit is exhausted (100%)
-	expectedDuration := 384607 * time.Second
+	// Should use the 5h reset time because the 5h window is exhausted.
+	expectedDuration := 4210 * time.Second
 	minExpected := before.Add(expectedDuration)
 	maxExpected := after.Add(expectedDuration)
 
@@ -458,16 +452,14 @@ func TestCalculateOpenAI429ResetTime_UserProvidedScenario(t *testing.T) {
 		t.Errorf("resetAt %v not in expected range [%v, %v]", resetAt, minExpected, maxExpected)
 	}
 
-	// Verify it's approximately 4.45 days (384607 seconds)
+	// Verify it is approximately 70 minutes, not the weekly reset.
 	duration := resetAt.Sub(before)
-	actualDays := duration.Hours() / 24.0
-
-	// 384607 / 86400 = ~4.45 days
-	if actualDays < 4.4 || actualDays > 4.5 {
-		t.Errorf("expected ~4.45 days, got %.2f days", actualDays)
+	actualMinutes := duration.Minutes()
+	if actualMinutes < 70 || actualMinutes > 71 {
+		t.Errorf("expected ~70 minutes, got %.2f minutes", actualMinutes)
 	}
 
-	t.Logf("User scenario: reset_at=%v, duration=%.2f days", resetAt, actualDays)
+	t.Logf("User scenario: reset_at=%v, duration=%.2f minutes", resetAt, actualMinutes)
 }
 
 func TestCalculateOpenAI429ResetTime_5MinFallbackWhenNoReset(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-up to #2936. This tightens two websocket bridge edge cases observed in production:

- hand off an existing downstream websocket session to the HTTP/SSE bridge when a later `response.create` frame crosses the bridge threshold, so oversized continuation turns do not reach the upstream websocket and trigger `StatusMessageTooBig`;
- prune pending tool-call context items that are not answered by the current replay input before sending HTTP bridge requests, avoiding upstream `No tool output found for function call ...` errors while preserving matched tool-call / tool-output pairs.

The downstream client connection still receives websocket messages; only the upstream transport switches to HTTP/SSE for the bridge path.

## Tests

- `go test ./internal/service -run 'Test(OpenAIWSHTTPBridge|PruneOpenAIWSUnanswered)'`
- `go test ./...`

`mvn compile` was requested by the local AGENTS instructions, but this repository has no `pom.xml` and is not a Maven project.
