### PR TITLE
[codex] fix OpenAI Codex primary 5h quota reset

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -126,15 +126,20 @@ type NormalizedCodexLimits struct {
 	Window7dMinutes *int
 }
 
-func normalizeCodexFiveHourUsedPercent(raw *float64) *float64 {
+func normalizeCodexFiveHourUsedPercent(raw *float64, fromPrimary bool) *float64 {
 	if raw == nil {
 		return nil
 	}
-	// OpenAI's 5h Codex quota header is remaining%, despite the upstream header
-	// name saying "used"; the canonical codex_5h_used_percent field stores used%.
-	used := 100 - *raw
+	used := *raw
+	if !fromPrimary {
+		// Legacy OpenAI secondary 5h quota snapshots report remaining%, despite the
+		// upstream header name saying "used"; the canonical field stores used%.
+		used = 100 - *raw
+	}
 	if used < 0 {
 		used = 0
+	} else if used > 100 {
+		used = 100
 	}
 	return &used
 }
@@ -197,7 +202,7 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 
 	// Assign values
 	if use5hFromPrimary {
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.PrimaryUsedPercent)
+		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.PrimaryUsedPercent, true)
 		result.Reset5hSeconds = s.PrimaryResetAfterSeconds
 		result.Window5hMinutes = s.PrimaryWindowMinutes
 		result.Used7dPercent = s.SecondaryUsedPercent
@@ -207,7 +212,7 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 		result.Used7dPercent = s.PrimaryUsedPercent
 		result.Reset7dSeconds = s.PrimaryResetAfterSeconds
 		result.Window7dMinutes = s.PrimaryWindowMinutes
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.SecondaryUsedPercent)
+		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.SecondaryUsedPercent, false)
 		result.Reset5hSeconds = s.SecondaryResetAfterSeconds
 		result.Window5hMinutes = s.SecondaryWindowMinutes
 	}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1774,7 +1774,7 @@ func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 
 	select {
 	case updates := <-repo.updateExtraCalls:
-		require.Equal(t, 88.0, updates["codex_5h_used_percent"])
+		require.Equal(t, 12.0, updates["codex_5h_used_percent"])
 		require.Equal(t, 34.0, updates["codex_7d_used_percent"])
 		require.Equal(t, 600, updates["codex_5h_reset_after_seconds"])
 		require.Equal(t, 86400, updates["codex_7d_reset_after_seconds"])

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -122,7 +122,7 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 	// Test when OpenAI sends primary as 5h and secondary as 7d (reversed)
 	headers := http.Header{}
-	headers.Set("x-codex-primary-used-percent", "0")           // This is 5h remaining%
+	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-primary-window-minutes", "300")       // 5 hours - smaller!
 	headers.Set("x-codex-secondary-used-percent", "50")
@@ -144,6 +144,34 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 	if resetAt.Before(minExpected) || resetAt.After(maxExpected) {
 		t.Errorf("resetAt %v not in expected range [%v, %v]", resetAt, minExpected, maxExpected)
+	}
+}
+
+func TestCalculateOpenAI429ResetTime_Primary5hExhaustedLiveScenario(t *testing.T) {
+	svc := &RateLimitService{}
+
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "100")
+	headers.Set("x-codex-primary-reset-after-seconds", "5919")
+	headers.Set("x-codex-primary-window-minutes", "300")
+	headers.Set("x-codex-secondary-used-percent", "36")
+	headers.Set("x-codex-secondary-reset-after-seconds", "448655")
+	headers.Set("x-codex-secondary-window-minutes", "10080")
+
+	before := time.Now()
+	resetAt := svc.calculateOpenAI429ResetTime(headers)
+	after := time.Now()
+
+	if resetAt == nil {
+		t.Fatal("expected non-nil resetAt")
+	}
+
+	expectedDuration := 5919 * time.Second
+	minExpected := before.Add(expectedDuration)
+	maxExpected := after.Add(expectedDuration)
+
+	if resetAt.Before(minExpected) || resetAt.After(maxExpected) {
+		t.Errorf("resetAt %v not in expected 5h range [%v, %v]", resetAt, minExpected, maxExpected)
 	}
 }
 
@@ -254,6 +282,43 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 17369 {
 		t.Errorf("expected Reset5hSeconds=17369, got %v", normalized.Reset5hSeconds)
+	}
+}
+
+func TestNormalizedCodexLimits_Primary5hReportsUsedPercent(t *testing.T) {
+	pUsed := 0.0
+	pReset := 17523
+	pWindow := 300
+	sUsed := 36.0
+	sReset := 441984
+	sWindow := 10080
+
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:          &pUsed,
+		PrimaryResetAfterSeconds:    &pReset,
+		PrimaryWindowMinutes:        &pWindow,
+		SecondaryUsedPercent:        &sUsed,
+		SecondaryResetAfterSeconds:  &sReset,
+		SecondaryWindowMinutes:      &sWindow,
+		PrimaryOverSecondaryPercent: &pUsed,
+	}
+
+	normalized := snapshot.Normalize()
+	if normalized == nil {
+		t.Fatal("expected non-nil normalized")
+	}
+
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 0.0 {
+		t.Errorf("expected Used5hPercent=0, got %v", normalized.Used5hPercent)
+	}
+	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 17523 {
+		t.Errorf("expected Reset5hSeconds=17523, got %v", normalized.Reset5hSeconds)
+	}
+	if normalized.Used7dPercent == nil || *normalized.Used7dPercent != 36.0 {
+		t.Errorf("expected Used7dPercent=36, got %v", normalized.Used7dPercent)
+	}
+	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 441984 {
+		t.Errorf("expected Reset7dSeconds=441984, got %v", normalized.Reset7dSeconds)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Treat primary-window Codex 5h quota headers as used percent instead of inverting them as remaining percent.
- Keep the legacy secondary-window 5h remaining-percent conversion.
- Add regression cases for both an exhausted primary 5h window and an available primary 5h window (`primary_used_percent=0`).

## Root cause
When OpenAI sends the 5h Codex limit in the primary quota window (`x-codex-primary-window-minutes: 300`), `x-codex-primary-used-percent` is already a used percentage. The previous normalization always calculated `100 - raw` for the canonical 5h used percent, so a primary 5h value of `0` became `100`. That can make an account with available 5h quota display as fully exhausted.

The same inversion also affects reset selection when primary=5h is exhausted, because the canonical 5h used percent may no longer reflect the actual upstream limit state.

## Validation
- `go test -tags=unit ./internal/service -run 'TestCalculateOpenAI429ResetTime|TestOpenAIUpdateCodexUsageSnapshotFromHeaders|TestNormalizedCodexLimits'`\n- `go test -tags=unit ./internal/service`