### PR TITLE
Add channel billing multiplier rules

### DIFF
--- a/backend/internal/handler/admin/channel_handler.go
+++ b/backend/internal/handler/admin/channel_handler.go
@@ -39,6 +39,7 @@ type createChannelRequest struct {
 	FeaturesConfig             map[string]any                   `json:"features_config"`
 	ApplyPricingToAccountStats bool                             `json:"apply_pricing_to_account_stats"`
 	AccountStatsPricingRules   []accountStatsPricingRuleRequest `json:"account_stats_pricing_rules"`
+	BillingMultiplierRules     []billingMultiplierRuleRequest   `json:"billing_multiplier_rules"`
 }
 
 type updateChannelRequest struct {
@@ -54,6 +55,7 @@ type updateChannelRequest struct {
 	FeaturesConfig             map[string]any                    `json:"features_config"`
 	ApplyPricingToAccountStats *bool                             `json:"apply_pricing_to_account_stats"`
 	AccountStatsPricingRules   *[]accountStatsPricingRuleRequest `json:"account_stats_pricing_rules"`
+	BillingMultiplierRules     *[]billingMultiplierRuleRequest   `json:"billing_multiplier_rules"`
 }
 
 type channelModelPricingRequest struct {
@@ -88,6 +90,13 @@ type accountStatsPricingRuleRequest struct {
 	Pricing    []channelModelPricingRequest `json:"pricing"`
 }
 
+type billingMultiplierRuleRequest struct {
+	Name           string  `json:"name"`
+	GroupIDs       []int64 `json:"group_ids"`
+	AccountIDs     []int64 `json:"account_ids"`
+	RateMultiplier float64 `json:"rate_multiplier"`
+}
+
 type channelResponse struct {
 	ID                         int64                             `json:"id"`
 	Name                       string                            `json:"name"`
@@ -102,6 +111,7 @@ type channelResponse struct {
 	ModelMapping               map[string]map[string]string      `json:"model_mapping"`
 	ApplyPricingToAccountStats bool                              `json:"apply_pricing_to_account_stats"`
 	AccountStatsPricingRules   []accountStatsPricingRuleResponse `json:"account_stats_pricing_rules"`
+	BillingMultiplierRules     []billingMultiplierRuleResponse   `json:"billing_multiplier_rules"`
 	CreatedAt                  string                            `json:"created_at"`
 	UpdatedAt                  string                            `json:"updated_at"`
 }
@@ -139,6 +149,14 @@ type accountStatsPricingRuleResponse struct {
 	GroupIDs   []int64                       `json:"group_ids"`
 	AccountIDs []int64                       `json:"account_ids"`
 	Pricing    []channelModelPricingResponse `json:"pricing"`
+}
+
+type billingMultiplierRuleResponse struct {
+	ID             int64   `json:"id"`
+	Name           string  `json:"name"`
+	GroupIDs       []int64 `json:"group_ids"`
+	AccountIDs     []int64 `json:"account_ids"`
+	RateMultiplier float64 `json:"rate_multiplier"`
 }
 
 func channelToResponse(ch *service.Channel) *channelResponse {
@@ -191,6 +209,24 @@ func channelToResponse(ch *service.Channel) *channelResponse {
 			ruleResp.Pricing = append(ruleResp.Pricing, pricingToResponse(&rule.Pricing[i]))
 		}
 		resp.AccountStatsPricingRules = append(resp.AccountStatsPricingRules, ruleResp)
+	}
+
+	resp.BillingMultiplierRules = make([]billingMultiplierRuleResponse, 0, len(ch.BillingMultiplierRules))
+	for _, rule := range ch.BillingMultiplierRules {
+		ruleResp := billingMultiplierRuleResponse{
+			ID:             rule.ID,
+			Name:           rule.Name,
+			GroupIDs:       rule.GroupIDs,
+			AccountIDs:     rule.AccountIDs,
+			RateMultiplier: rule.RateMultiplier,
+		}
+		if ruleResp.GroupIDs == nil {
+			ruleResp.GroupIDs = []int64{}
+		}
+		if ruleResp.AccountIDs == nil {
+			ruleResp.AccountIDs = []int64{}
+		}
+		resp.BillingMultiplierRules = append(resp.BillingMultiplierRules, ruleResp)
 	}
 
 	return resp
@@ -290,6 +326,15 @@ func accountStatsPricingRuleRequestToService(r accountStatsPricingRuleRequest) s
 	}
 }
 
+func billingMultiplierRuleRequestToService(r billingMultiplierRuleRequest) service.ChannelBillingMultiplierRule {
+	return service.ChannelBillingMultiplierRule{
+		Name:           r.Name,
+		GroupIDs:       r.GroupIDs,
+		AccountIDs:     r.AccountIDs,
+		RateMultiplier: r.RateMultiplier,
+	}
+}
+
 // --- Handlers ---
 
 // List handles listing channels with pagination
@@ -372,6 +417,23 @@ func (h *ChannelHandler) Create(c *gin.Context) {
 		statsRules = append(statsRules, rule)
 	}
 
+	billingMultiplierRules := make([]service.ChannelBillingMultiplierRule, 0, len(req.BillingMultiplierRules))
+	for i, r := range req.BillingMultiplierRules {
+		if len(r.GroupIDs) == 0 {
+			response.ErrorFrom(c, infraerrors.BadRequest("BILLING_MULTIPLIER_RULE_EMPTY_GROUPS",
+				fmt.Sprintf("billing multiplier rule #%d must have at least one group", i+1)))
+			return
+		}
+		if r.RateMultiplier < 0 {
+			response.ErrorFrom(c, infraerrors.BadRequest("BILLING_MULTIPLIER_RULE_NEGATIVE_RATE",
+				fmt.Sprintf("billing multiplier rule #%d rate_multiplier must be >= 0", i+1)))
+			return
+		}
+		rule := billingMultiplierRuleRequestToService(r)
+		rule.SortOrder = i
+		billingMultiplierRules = append(billingMultiplierRules, rule)
+	}
+
 	channel, err := h.channelService.Create(c.Request.Context(), &service.CreateChannelInput{
 		Name:                       req.Name,
 		Description:                req.Description,
@@ -384,6 +446,7 @@ func (h *ChannelHandler) Create(c *gin.Context) {
 		FeaturesConfig:             req.FeaturesConfig,
 		ApplyPricingToAccountStats: req.ApplyPricingToAccountStats,
 		AccountStatsPricingRules:   statsRules,
+		BillingMultiplierRules:     billingMultiplierRules,
 	})
 	if err != nil {
 		response.ErrorFrom(c, err)
@@ -447,6 +510,25 @@ func (h *ChannelHandler) Update(c *gin.Context) {
 			statsRules = append(statsRules, rule)
 		}
 		input.AccountStatsPricingRules = &statsRules
+	}
+	if req.BillingMultiplierRules != nil {
+		billingMultiplierRules := make([]service.ChannelBillingMultiplierRule, 0, len(*req.BillingMultiplierRules))
+		for i, r := range *req.BillingMultiplierRules {
+			if len(r.GroupIDs) == 0 {
+				response.ErrorFrom(c, infraerrors.BadRequest("BILLING_MULTIPLIER_RULE_EMPTY_GROUPS",
+					fmt.Sprintf("billing multiplier rule #%d must have at least one group", i+1)))
+				return
+			}
+			if r.RateMultiplier < 0 {
+				response.ErrorFrom(c, infraerrors.BadRequest("BILLING_MULTIPLIER_RULE_NEGATIVE_RATE",
+					fmt.Sprintf("billing multiplier rule #%d rate_multiplier must be >= 0", i+1)))
+				return
+			}
+			rule := billingMultiplierRuleRequestToService(r)
+			rule.SortOrder = i
+			billingMultiplierRules = append(billingMultiplierRules, rule)
+		}
+		input.BillingMultiplierRules = &billingMultiplierRules
 	}
 
 	channel, err := h.channelService.Update(c.Request.Context(), id, input)

--- a/backend/internal/repository/channel_repo.go
+++ b/backend/internal/repository/channel_repo.go
@@ -78,6 +78,13 @@ func (r *channelRepository) Create(ctx context.Context, channel *service.Channel
 			}
 		}
 
+		// 设置实际计费倍率规则
+		if len(channel.BillingMultiplierRules) > 0 {
+			if err := replaceBillingMultiplierRulesTx(ctx, tx, channel.ID, channel.BillingMultiplierRules); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
 }
@@ -115,6 +122,12 @@ func (r *channelRepository) GetByID(ctx context.Context, id int64) (*service.Cha
 		return nil, err
 	}
 	ch.AccountStatsPricingRules = statsPricingRules
+
+	billingMultiplierRules, err := r.loadBillingMultiplierRules(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	ch.BillingMultiplierRules = billingMultiplierRules
 
 	return ch, nil
 }
@@ -162,6 +175,13 @@ func (r *channelRepository) Update(ctx context.Context, channel *service.Channel
 		// 更新账号统计定价规则
 		if channel.AccountStatsPricingRules != nil {
 			if err := replaceAccountStatsPricingRulesTx(ctx, tx, channel.ID, channel.AccountStatsPricingRules); err != nil {
+				return err
+			}
+		}
+
+		// 更新实际计费倍率规则
+		if channel.BillingMultiplierRules != nil {
+			if err := replaceBillingMultiplierRulesTx(ctx, tx, channel.ID, channel.BillingMultiplierRules); err != nil {
 				return err
 			}
 		}
@@ -259,10 +279,15 @@ func (r *channelRepository) List(ctx context.Context, params pagination.Paginati
 		if err != nil {
 			return nil, nil, err
 		}
+		billingRulesMap, err := r.batchLoadBillingMultiplierRules(ctx, channelIDs)
+		if err != nil {
+			return nil, nil, err
+		}
 		for i := range channels {
 			channels[i].GroupIDs = groupMap[channels[i].ID]
 			channels[i].ModelPricing = pricingMap[channels[i].ID]
 			channels[i].AccountStatsPricingRules = statsRulesMap[channels[i].ID]
+			channels[i].BillingMultiplierRules = billingRulesMap[channels[i].ID]
 		}
 	}
 
@@ -354,13 +379,26 @@ func (r *channelRepository) ListAll(ctx context.Context) ([]service.Channel, err
 		return nil, err
 	}
 
+	// 批量加载实际计费倍率规则
+	billingRulesMap, err := r.batchLoadBillingMultiplierRules(ctx, channelIDs)
+	if err != nil {
+		return nil, err
+	}
+
 	for i := range channels {
 		channels[i].GroupIDs = groupMap[channels[i].ID]
 		channels[i].ModelPricing = pricingMap[channels[i].ID]
 		channels[i].AccountStatsPricingRules = statsRulesMap[channels[i].ID]
+		channels[i].BillingMultiplierRules = billingRulesMap[channels[i].ID]
 	}
 
 	return channels, nil
+}
+
+func (r *channelRepository) ReplaceBillingMultiplierRules(ctx context.Context, channelID int64, rules []service.ChannelBillingMultiplierRule) error {
+	return r.runInTx(ctx, func(tx *sql.Tx) error {
+		return replaceBillingMultiplierRulesTx(ctx, tx, channelID, rules)
+	})
 }
 
 // --- 批量加载辅助方法 ---

--- a/backend/internal/repository/channel_repo_billing_multiplier_rules.go
+++ b/backend/internal/repository/channel_repo_billing_multiplier_rules.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/lib/pq"
+)
+
+// batchLoadBillingMultiplierRules loads channel billing multiplier rules for multiple channels.
+func (r *channelRepository) batchLoadBillingMultiplierRules(ctx context.Context, channelIDs []int64) (map[int64][]service.ChannelBillingMultiplierRule, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, channel_id, name, group_ids, account_ids, rate_multiplier, sort_order, created_at, updated_at
+		 FROM channel_billing_multiplier_rules WHERE channel_id = ANY($1) ORDER BY channel_id, sort_order, id`,
+		pq.Array(channelIDs),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("batch load channel billing multiplier rules: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	result := make(map[int64][]service.ChannelBillingMultiplierRule, len(channelIDs))
+	for rows.Next() {
+		var rule service.ChannelBillingMultiplierRule
+		if err := rows.Scan(
+			&rule.ID, &rule.ChannelID, &rule.Name,
+			pq.Array(&rule.GroupIDs), pq.Array(&rule.AccountIDs),
+			&rule.RateMultiplier, &rule.SortOrder, &rule.CreatedAt, &rule.UpdatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan channel billing multiplier rule: %w", err)
+		}
+		result[rule.ChannelID] = append(result[rule.ChannelID], rule)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate channel billing multiplier rules: %w", err)
+	}
+	return result, nil
+}
+
+func (r *channelRepository) loadBillingMultiplierRules(ctx context.Context, channelID int64) ([]service.ChannelBillingMultiplierRule, error) {
+	result, err := r.batchLoadBillingMultiplierRules(ctx, []int64{channelID})
+	if err != nil {
+		return nil, err
+	}
+	return result[channelID], nil
+}
+
+func replaceBillingMultiplierRulesTx(ctx context.Context, tx *sql.Tx, channelID int64, rules []service.ChannelBillingMultiplierRule) error {
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM channel_billing_multiplier_rules WHERE channel_id = $1`, channelID,
+	); err != nil {
+		return fmt.Errorf("delete old channel billing multiplier rules: %w", err)
+	}
+
+	for i := range rules {
+		rules[i].ChannelID = channelID
+		if err := createBillingMultiplierRuleTx(ctx, tx, &rules[i]); err != nil {
+			return fmt.Errorf("insert channel billing multiplier rule: %w", err)
+		}
+	}
+	return nil
+}
+
+func createBillingMultiplierRuleTx(ctx context.Context, tx *sql.Tx, rule *service.ChannelBillingMultiplierRule) error {
+	err := tx.QueryRowContext(ctx,
+		`INSERT INTO channel_billing_multiplier_rules (channel_id, name, group_ids, account_ids, rate_multiplier, sort_order)
+		 VALUES ($1, $2, $3, $4, $5, $6) RETURNING id, created_at, updated_at`,
+		rule.ChannelID, rule.Name, pq.Array(rule.GroupIDs), pq.Array(rule.AccountIDs),
+		rule.RateMultiplier, rule.SortOrder,
+	).Scan(&rule.ID, &rule.CreatedAt, &rule.UpdatedAt)
+	if err != nil {
+		return fmt.Errorf("insert channel billing multiplier rule: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/service/channel.go
+++ b/backend/internal/service/channel.go
@@ -54,6 +54,22 @@ type Channel struct {
 	// 账号统计定价
 	ApplyPricingToAccountStats bool                      // 是否应用渠道模型定价到账号统计
 	AccountStatsPricingRules   []AccountStatsPricingRule // 自定义账号统计定价规则（按 SortOrder 排序，先命中为准）
+	BillingMultiplierRules     []ChannelBillingMultiplierRule
+}
+
+// ChannelBillingMultiplierRule 渠道实际计费倍率规则。
+// 多条规则按 SortOrder 排序，先命中为准。GroupIDs 为必填匹配范围，
+// AccountIDs 可选；配置后需要同时匹配分组和账号。
+type ChannelBillingMultiplierRule struct {
+	ID             int64
+	ChannelID      int64
+	Name           string
+	GroupIDs       []int64
+	AccountIDs     []int64
+	RateMultiplier float64
+	SortOrder      int
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 // AccountStatsPricingRule 账号统计定价规则
@@ -229,6 +245,20 @@ func (c *Channel) Clone() *Channel {
 				for j := range rule.Pricing {
 					cp.AccountStatsPricingRules[i].Pricing[j] = rule.Pricing[j].Clone()
 				}
+			}
+		}
+	}
+	if c.BillingMultiplierRules != nil {
+		cp.BillingMultiplierRules = make([]ChannelBillingMultiplierRule, len(c.BillingMultiplierRules))
+		for i, rule := range c.BillingMultiplierRules {
+			cp.BillingMultiplierRules[i] = rule
+			if rule.GroupIDs != nil {
+				cp.BillingMultiplierRules[i].GroupIDs = make([]int64, len(rule.GroupIDs))
+				copy(cp.BillingMultiplierRules[i].GroupIDs, rule.GroupIDs)
+			}
+			if rule.AccountIDs != nil {
+				cp.BillingMultiplierRules[i].AccountIDs = make([]int64, len(rule.AccountIDs))
+				copy(cp.BillingMultiplierRules[i].AccountIDs, rule.AccountIDs)
 			}
 		}
 	}

--- a/backend/internal/service/channel_billing_multiplier.go
+++ b/backend/internal/service/channel_billing_multiplier.go
@@ -1,0 +1,84 @@
+package service
+
+import "context"
+
+// ResolveBillingMultiplier returns the first channel billing multiplier rule
+// matching the selected group/account. A missing rule is neutral (1x).
+func (s *ChannelService) ResolveBillingMultiplier(ctx context.Context, groupID int64, accountID int64) float64 {
+	if s == nil || groupID <= 0 {
+		return 1
+	}
+	if cached, ok := s.cache.Load().(*channelCache); ok && cached != nil {
+		channel, ok := cached.channelByGroupID[groupID]
+		if ok && channel != nil && channel.IsActive() {
+			return channel.resolveBillingMultiplierFromRules(groupID, accountID)
+		}
+	}
+	if s.repo == nil {
+		return 1
+	}
+	channel, err := s.GetChannelForGroup(ctx, groupID)
+	if err != nil || channel == nil {
+		return 1
+	}
+	return channel.resolveBillingMultiplierFromRules(groupID, accountID)
+}
+
+func (c *Channel) resolveBillingMultiplierFromRules(groupID int64, accountID int64) float64 {
+	if c == nil {
+		return 1
+	}
+	for _, rule := range c.BillingMultiplierRules {
+		if matchBillingMultiplierRule(&rule, groupID, accountID) {
+			if rule.RateMultiplier < 0 {
+				return 0
+			}
+			return rule.RateMultiplier
+		}
+	}
+	return 1
+}
+
+func matchBillingMultiplierRule(rule *ChannelBillingMultiplierRule, groupID, accountID int64) bool {
+	if rule == nil || len(rule.GroupIDs) == 0 {
+		return false
+	}
+
+	groupMatched := false
+	for _, id := range rule.GroupIDs {
+		if id == groupID {
+			groupMatched = true
+			break
+		}
+	}
+	if !groupMatched {
+		return false
+	}
+
+	if len(rule.AccountIDs) == 0 {
+		return true
+	}
+	for _, id := range rule.AccountIDs {
+		if id == accountID {
+			return true
+		}
+	}
+	return false
+}
+
+func applyChannelBillingMultiplier(
+	ctx context.Context,
+	channelService *ChannelService,
+	groupID *int64,
+	accountID int64,
+	baseMultiplier float64,
+) float64 {
+	if channelService == nil || groupID == nil {
+		return baseMultiplier
+	}
+	channelMultiplier := channelService.ResolveBillingMultiplier(ctx, *groupID, accountID)
+	if channelMultiplier < 0 {
+		channelMultiplier = 0
+	}
+	return baseMultiplier * channelMultiplier
+}

--- a/backend/internal/service/channel_billing_multiplier_test.go
+++ b/backend/internal/service/channel_billing_multiplier_test.go
@@ -1,0 +1,89 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchBillingMultiplierRule_GroupOnly(t *testing.T) {
+	rule := &ChannelBillingMultiplierRule{
+		GroupIDs:       []int64{10},
+		RateMultiplier: 1.5,
+	}
+
+	require.True(t, matchBillingMultiplierRule(rule, 10, 999))
+	require.False(t, matchBillingMultiplierRule(rule, 20, 999))
+}
+
+func TestMatchBillingMultiplierRule_GroupAndAccountAreAnd(t *testing.T) {
+	rule := &ChannelBillingMultiplierRule{
+		GroupIDs:       []int64{10},
+		AccountIDs:     []int64{2},
+		RateMultiplier: 2,
+	}
+
+	require.True(t, matchBillingMultiplierRule(rule, 10, 2))
+	require.False(t, matchBillingMultiplierRule(rule, 10, 3))
+	require.False(t, matchBillingMultiplierRule(rule, 11, 2))
+}
+
+func TestMatchBillingMultiplierRule_RequiresGroupScope(t *testing.T) {
+	rule := &ChannelBillingMultiplierRule{
+		AccountIDs:     []int64{2},
+		RateMultiplier: 2,
+	}
+
+	require.False(t, matchBillingMultiplierRule(rule, 10, 2))
+}
+
+func TestResolveBillingMultiplier_FirstMatchingRuleWins(t *testing.T) {
+	groupID := int64(10)
+	channel := &Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{groupID},
+		BillingMultiplierRules: []ChannelBillingMultiplierRule{
+			{
+				GroupIDs:       []int64{groupID},
+				AccountIDs:     []int64{7},
+				RateMultiplier: 0.5,
+				SortOrder:      0,
+			},
+			{
+				GroupIDs:       []int64{groupID},
+				RateMultiplier: 2,
+				SortOrder:      1,
+			},
+		},
+	}
+	cs := newTestChannelServiceForStats(t, channel, groupID, PlatformAnthropic)
+
+	require.InDelta(t, 0.5, cs.ResolveBillingMultiplier(context.Background(), groupID, 7), 1e-12)
+	require.InDelta(t, 2.0, cs.ResolveBillingMultiplier(context.Background(), groupID, 8), 1e-12)
+	require.InDelta(t, 1.0, cs.ResolveBillingMultiplier(context.Background(), 99, 7), 1e-12)
+}
+
+func TestApplyChannelBillingMultiplier_CombinesWithBaseMultiplier(t *testing.T) {
+	groupID := int64(10)
+	channel := &Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{groupID},
+		BillingMultiplierRules: []ChannelBillingMultiplierRule{
+			{
+				GroupIDs:       []int64{groupID},
+				AccountIDs:     []int64{7},
+				RateMultiplier: 1.25,
+			},
+		},
+	}
+	cs := newTestChannelServiceForStats(t, channel, groupID, PlatformAnthropic)
+
+	actual := applyChannelBillingMultiplier(context.Background(), cs, &groupID, 7, 2)
+
+	require.InDelta(t, 2.5, actual, 1e-12)
+}

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -50,6 +50,7 @@ type ChannelRepository interface {
 	UpdateModelPricing(ctx context.Context, pricing *ChannelModelPricing) error
 	DeleteModelPricing(ctx context.Context, id int64) error
 	ReplaceModelPricing(ctx context.Context, channelID int64, pricingList []ChannelModelPricing) error
+	ReplaceBillingMultiplierRules(ctx context.Context, channelID int64, rules []ChannelBillingMultiplierRule) error
 }
 
 // channelModelKey 渠道缓存复合键（显式包含 platform 防止跨平台同名模型冲突）
@@ -692,6 +693,7 @@ func (s *ChannelService) Create(ctx context.Context, input *CreateChannelInput) 
 		FeaturesConfig:             input.FeaturesConfig,
 		ApplyPricingToAccountStats: input.ApplyPricingToAccountStats,
 		AccountStatsPricingRules:   input.AccountStatsPricingRules,
+		BillingMultiplierRules:     input.BillingMultiplierRules,
 	}
 	channel.normalizeBillingModelSource()
 
@@ -702,6 +704,9 @@ func (s *ChannelService) Create(ctx context.Context, input *CreateChannelInput) 
 		if err := validatePricingEntries(rule.Pricing); err != nil {
 			return nil, fmt.Errorf("account stats pricing rule #%d: %w", i+1, err)
 		}
+	}
+	if err := validateBillingMultiplierRules(channel.BillingMultiplierRules); err != nil {
+		return nil, err
 	}
 
 	if err := s.repo.Create(ctx, channel); err != nil {
@@ -746,6 +751,9 @@ func (s *ChannelService) Update(ctx context.Context, id int64, input *UpdateChan
 		if err := validatePricingEntries(rule.Pricing); err != nil {
 			return nil, fmt.Errorf("account stats pricing rule #%d: %w", i+1, err)
 		}
+	}
+	if err := validateBillingMultiplierRules(channel.BillingMultiplierRules); err != nil {
+		return nil, err
 	}
 
 	oldGroupIDs := s.getOldGroupIDs(ctx, id)
@@ -812,6 +820,27 @@ func (s *ChannelService) applyUpdateInput(ctx context.Context, channel *Channel,
 	}
 	if input.AccountStatsPricingRules != nil {
 		channel.AccountStatsPricingRules = *input.AccountStatsPricingRules
+	}
+	if input.BillingMultiplierRules != nil {
+		channel.BillingMultiplierRules = *input.BillingMultiplierRules
+	}
+	return nil
+}
+
+func validateBillingMultiplierRules(rules []ChannelBillingMultiplierRule) error {
+	for i, rule := range rules {
+		if len(rule.GroupIDs) == 0 {
+			return infraerrors.BadRequest(
+				"BILLING_MULTIPLIER_RULE_EMPTY_GROUPS",
+				fmt.Sprintf("billing multiplier rule #%d must have at least one group", i+1),
+			)
+		}
+		if rule.RateMultiplier < 0 {
+			return infraerrors.BadRequest(
+				"BILLING_MULTIPLIER_RULE_NEGATIVE_RATE",
+				fmt.Sprintf("billing multiplier rule #%d rate_multiplier must be >= 0", i+1),
+			)
+		}
 	}
 	return nil
 }
@@ -991,6 +1020,7 @@ type CreateChannelInput struct {
 	FeaturesConfig             map[string]any
 	ApplyPricingToAccountStats bool
 	AccountStatsPricingRules   []AccountStatsPricingRule
+	BillingMultiplierRules     []ChannelBillingMultiplierRule
 }
 
 // UpdateChannelInput 更新渠道输入
@@ -1007,4 +1037,5 @@ type UpdateChannelInput struct {
 	FeaturesConfig             map[string]any
 	ApplyPricingToAccountStats *bool
 	AccountStatsPricingRules   *[]AccountStatsPricingRule
+	BillingMultiplierRules     *[]ChannelBillingMultiplierRule
 }

--- a/backend/internal/service/channel_service_test.go
+++ b/backend/internal/service/channel_service_test.go
@@ -34,6 +34,7 @@ type mockChannelRepository struct {
 	updateModelPricingFn       func(ctx context.Context, pricing *ChannelModelPricing) error
 	deleteModelPricingFn       func(ctx context.Context, id int64) error
 	replaceModelPricingFn      func(ctx context.Context, channelID int64, pricingList []ChannelModelPricing) error
+	replaceBillingMultiplierFn func(ctx context.Context, channelID int64, rules []ChannelBillingMultiplierRule) error
 }
 
 func (m *mockChannelRepository) Create(ctx context.Context, channel *Channel) error {
@@ -158,6 +159,13 @@ func (m *mockChannelRepository) DeleteModelPricing(ctx context.Context, id int64
 func (m *mockChannelRepository) ReplaceModelPricing(ctx context.Context, channelID int64, pricingList []ChannelModelPricing) error {
 	if m.replaceModelPricingFn != nil {
 		return m.replaceModelPricingFn(ctx, channelID, pricingList)
+	}
+	return nil
+}
+
+func (m *mockChannelRepository) ReplaceBillingMultiplierRules(ctx context.Context, channelID int64, rules []ChannelBillingMultiplierRule) error {
+	if m.replaceBillingMultiplierFn != nil {
+		return m.replaceBillingMultiplierFn(ctx, channelID, rules)
 	}
 	return nil
 }

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -8859,6 +8859,7 @@ func (s *GatewayService) recordUsageCore(ctx context.Context, input *recordUsage
 		groupDefault := apiKey.Group.RateMultiplier
 		multiplier = s.getUserGroupRateMultiplier(ctx, user.ID, *apiKey.GroupID, groupDefault)
 	}
+	multiplier = applyChannelBillingMultiplier(ctx, s.channelService, apiKey.GroupID, account.ID, multiplier)
 	imageMultiplier := resolveImageRateMultiplier(apiKey, multiplier)
 
 	// 确定计费模型

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -5656,6 +5656,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		}
 		multiplier = resolver.Resolve(ctx, user.ID, *apiKey.GroupID, apiKey.Group.RateMultiplier)
 	}
+	multiplier = applyChannelBillingMultiplier(ctx, s.channelService, apiKey.GroupID, account.ID, multiplier)
 	imageMultiplier := resolveImageRateMultiplier(apiKey, multiplier)
 
 	var cost *CostBreakdown

--- a/backend/migrations/145_add_channel_billing_multiplier_rules.sql
+++ b/backend/migrations/145_add_channel_billing_multiplier_rules.sql
@@ -1,0 +1,25 @@
+-- Channel billing multiplier rules: allow channel pricing to apply an
+-- additional multiplier to user-facing actual cost by group/account scope.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+CREATE TABLE IF NOT EXISTS channel_billing_multiplier_rules (
+    id              BIGSERIAL      PRIMARY KEY,
+    channel_id      BIGINT         NOT NULL REFERENCES channels(id) ON DELETE CASCADE,
+    name            VARCHAR(100)   NOT NULL DEFAULT '',
+    group_ids       BIGINT[]       NOT NULL DEFAULT '{}',
+    account_ids     BIGINT[]       NOT NULL DEFAULT '{}',
+    rate_multiplier NUMERIC(10,4)  NOT NULL DEFAULT 1.0,
+    sort_order      INT            NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_channel_billing_multiplier_rules_channel_id
+    ON channel_billing_multiplier_rules(channel_id);
+
+COMMENT ON TABLE channel_billing_multiplier_rules IS '渠道实际计费倍率规则：按分组/账号命中后影响用户余额、订阅和 API Key quota';
+COMMENT ON COLUMN channel_billing_multiplier_rules.group_ids IS '匹配的分组 ID；规则至少需要一个分组';
+COMMENT ON COLUMN channel_billing_multiplier_rules.account_ids IS '可选的账号 ID 限定；配置后需要同时匹配 group_ids 与 account_ids';
+COMMENT ON COLUMN channel_billing_multiplier_rules.rate_multiplier IS '额外计费倍率，>=0；最终 ActualCost = 基础费用 × 分组/用户倍率 × 此倍率';

--- a/frontend/src/api/admin/channels.ts
+++ b/frontend/src/api/admin/channels.ts
@@ -43,6 +43,14 @@ export interface AccountStatsPricingRule {
   pricing: ChannelModelPricing[]
 }
 
+export interface BillingMultiplierRule {
+  id?: number
+  name: string
+  group_ids: number[]
+  account_ids: number[]
+  rate_multiplier: number
+}
+
 export interface Channel {
   id: number
   name: string
@@ -56,6 +64,7 @@ export interface Channel {
   model_mapping: Record<string, Record<string, string>> // platform → {src→dst}
   apply_pricing_to_account_stats: boolean
   account_stats_pricing_rules: AccountStatsPricingRule[]
+  billing_multiplier_rules?: BillingMultiplierRule[]
   created_at: string
   updated_at: string
 }
@@ -71,6 +80,7 @@ export interface CreateChannelRequest {
   features_config?: Record<string, unknown>
   apply_pricing_to_account_stats?: boolean
   account_stats_pricing_rules?: AccountStatsPricingRule[]
+  billing_multiplier_rules?: BillingMultiplierRule[]
 }
 
 export interface UpdateChannelRequest {
@@ -85,6 +95,7 @@ export interface UpdateChannelRequest {
   features_config?: Record<string, unknown>
   apply_pricing_to_account_stats?: boolean
   account_stats_pricing_rules?: AccountStatsPricingRule[]
+  billing_multiplier_rules?: BillingMultiplierRule[]
 }
 
 interface PaginatedResponse<T> {

--- a/frontend/src/views/admin/ChannelsView.vue
+++ b/frontend/src/views/admin/ChannelsView.vue
@@ -453,6 +453,120 @@
               </div>
             </div>
 
+            <!-- Billing Multiplier Rules (per-platform, actual user billing) -->
+            <div class="mt-4 border-t border-gray-200 pt-4 dark:border-dark-700 space-y-3">
+              <div class="flex items-center justify-between">
+                <h4 class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t('admin.channels.form.billingMultiplierRules', '计费倍率规则') }}
+                </h4>
+                <button
+                  type="button"
+                  @click="addBillingMultiplierRule(sIdx)"
+                  class="rounded-lg border border-primary-300 px-3 py-1 text-xs font-medium text-primary-600 hover:bg-primary-50 dark:border-primary-600 dark:text-primary-400 dark:hover:bg-primary-900/20"
+                >
+                  + {{ t('admin.channels.form.addRule', '添加规则') }}
+                </button>
+              </div>
+
+              <p
+                v-if="section.billing_multiplier_rules.length === 0"
+                class="text-xs italic text-gray-400 dark:text-gray-500"
+              >
+                {{ t('admin.channels.form.noRulesConfigured', 'No rules configured') }}
+              </p>
+
+              <div
+                v-for="(rule, ruleIndex) in section.billing_multiplier_rules"
+                :key="ruleIndex"
+                class="space-y-3 rounded-lg border border-gray-200 p-4 dark:border-dark-600"
+              >
+                <div class="grid gap-3 sm:grid-cols-[minmax(0,1fr)_160px_auto] sm:items-center">
+                  <input
+                    v-model="rule.name"
+                    :placeholder="t('admin.channels.form.ruleName', '规则名称')"
+                    class="input text-sm"
+                  />
+                  <input
+                    v-model.number="rule.rate_multiplier"
+                    type="number"
+                    step="0.0001"
+                    min="0"
+                    class="input text-sm"
+                    :placeholder="t('admin.channels.form.rateMultiplier', '倍率')"
+                  />
+                  <button type="button" @click="removeBillingMultiplierRule(sIdx, ruleIndex)" class="text-xs text-red-500 hover:text-red-700">
+                    {{ t('common.delete', 'Delete') }}
+                  </button>
+                </div>
+
+                <div>
+                  <label class="text-xs text-gray-500 dark:text-gray-400">{{ t('admin.channels.form.ruleGroups', '匹配分组') }}</label>
+                  <div class="mt-1 flex flex-wrap gap-1">
+                    <label
+                      v-for="gid in section.group_ids"
+                      :key="gid"
+                      class="inline-flex cursor-pointer items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors"
+                      :class="rule.group_ids.includes(gid)
+                        ? 'border-primary-300 bg-primary-50 dark:border-primary-700 dark:bg-primary-900/20'
+                        : 'border-gray-200 hover:bg-gray-50 dark:border-dark-600 dark:hover:bg-dark-700'"
+                    >
+                      <input type="checkbox" :checked="rule.group_ids.includes(gid)" class="h-3 w-3 rounded border-gray-300 text-primary-600 focus:ring-primary-500" @change="toggleBillingMultiplierRuleGroup(rule, gid)" />
+                      <span :class="['font-medium', platformTextClass(section.platform)]">{{ getGroupNameById(gid) }}</span>
+                    </label>
+                  </div>
+                  <p v-if="section.group_ids.length === 0" class="mt-1 text-xs text-gray-400">
+                    {{ t('admin.channels.form.noGroupsInChannel', 'No groups in this channel') }}
+                  </p>
+                </div>
+
+                <div>
+                  <label class="text-xs text-gray-500 dark:text-gray-400">{{ t('admin.channels.form.ruleAccounts', '匹配账号') }}</label>
+                  <div class="mt-1 flex flex-wrap gap-1">
+                    <span
+                      v-for="accountId in rule.account_ids"
+                      :key="accountId"
+                      class="inline-flex items-center gap-1 rounded-md border border-primary-300 bg-primary-50 px-2 py-0.5 text-xs dark:border-primary-700 dark:bg-primary-900/20"
+                    >
+                      <span :class="['font-medium', platformTextClass(section.platform)]">{{ getRuleAccountLabel(accountId) }}</span>
+                      <button type="button" @click="removeRuleAccount(rule, accountId)" class="text-gray-400 hover:text-red-500">
+                        <Icon name="x" size="xs" />
+                      </button>
+                    </span>
+                  </div>
+                  <div class="relative mt-1 rule-account-search-container">
+                    <input
+                      v-model="ruleAccountSearchKeyword[ruleAccountSearchKey('billing', section.platform, ruleIndex)]"
+                      type="text"
+                      class="input text-sm"
+                      :placeholder="t('admin.channels.form.searchAccountPlaceholder', 'Search accounts')"
+                      @input="onRuleAccountSearchInput('billing', section.platform, ruleIndex)"
+                      @focus="onRuleAccountSearchFocus('billing', section.platform, ruleIndex)"
+                    />
+                    <div
+                      v-if="showRuleAccountDropdown[ruleAccountSearchKey('billing', section.platform, ruleIndex)] && (ruleAccountSearchResults[ruleAccountSearchKey('billing', section.platform, ruleIndex)]?.length ?? 0) > 0"
+                      class="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-lg border bg-white shadow-lg dark:border-dark-600 dark:bg-dark-800"
+                    >
+                      <button
+                        v-for="account in ruleAccountSearchResults[ruleAccountSearchKey('billing', section.platform, ruleIndex)]"
+                        :key="account.id"
+                        type="button"
+                        @click="selectRuleAccount(rule, account, 'billing', section.platform, ruleIndex)"
+                        class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-dark-700"
+                        :class="{ 'opacity-50': rule.account_ids.includes(account.id) }"
+                        :disabled="rule.account_ids.includes(account.id)"
+                      >
+                        <span :class="platformTextClass(account.platform)">{{ account.name }}</span>
+                        <span class="ml-2 text-xs text-gray-400">#{{ account.id }}</span>
+                      </button>
+                    </div>
+                  </div>
+                  <p class="mt-1 text-xs text-gray-400">
+                    {{ t('admin.channels.form.billingMultiplierAccountsHint', '留空则该分组下所有账号使用该倍率；填写账号后需同时匹配分组和账号') }}
+                  </p>
+                </div>
+              </div>
+            </div>
+
             <!-- Account Stats Pricing Rules (per-platform, always visible) -->
             <div class="mt-4 border-t border-gray-200 pt-4 dark:border-dark-700 space-y-3">
               <div class="flex items-center justify-between">
@@ -530,23 +644,23 @@
                   <!-- Account search input -->
                   <div class="relative mt-1 rule-account-search-container">
                     <input
-                      v-model="ruleAccountSearchKeyword[`${section.platform}-${ruleIndex}`]"
+                      v-model="ruleAccountSearchKeyword[ruleAccountSearchKey('stats', section.platform, ruleIndex)]"
                       type="text"
                       class="input text-sm"
                       :placeholder="t('admin.channels.form.searchAccountPlaceholder')"
-                      @input="onRuleAccountSearchInput(section.platform, ruleIndex)"
-                      @focus="onRuleAccountSearchFocus(section.platform, ruleIndex)"
+                      @input="onRuleAccountSearchInput('stats', section.platform, ruleIndex)"
+                      @focus="onRuleAccountSearchFocus('stats', section.platform, ruleIndex)"
                     />
                     <!-- Search results dropdown -->
                     <div
-                      v-if="showRuleAccountDropdown[`${section.platform}-${ruleIndex}`] && (ruleAccountSearchResults[`${section.platform}-${ruleIndex}`]?.length ?? 0) > 0"
+                      v-if="showRuleAccountDropdown[ruleAccountSearchKey('stats', section.platform, ruleIndex)] && (ruleAccountSearchResults[ruleAccountSearchKey('stats', section.platform, ruleIndex)]?.length ?? 0) > 0"
                       class="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-lg border bg-white shadow-lg dark:border-dark-600 dark:bg-dark-800"
                     >
                       <button
-                        v-for="account in ruleAccountSearchResults[`${section.platform}-${ruleIndex}`]"
+                        v-for="account in ruleAccountSearchResults[ruleAccountSearchKey('stats', section.platform, ruleIndex)]"
                         :key="account.id"
                         type="button"
-                        @click="selectRuleAccount(rule, account, section.platform, ruleIndex)"
+                        @click="selectRuleAccount(rule, account, 'stats', section.platform, ruleIndex)"
                         class="w-full px-3 py-2 text-left text-sm hover:bg-gray-100 dark:hover:bg-dark-700"
                         :class="{ 'opacity-50': rule.account_ids.includes(account.id) }"
                         :disabled="rule.account_ids.includes(account.id)"
@@ -630,7 +744,7 @@ import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { extractApiErrorMessage } from '@/utils/apiError'
 import { adminAPI } from '@/api/admin'
-import type { Channel, ChannelModelPricing, CreateChannelRequest, UpdateChannelRequest, AccountStatsPricingRule } from '@/api/admin/channels'
+import type { Channel, ChannelModelPricing, CreateChannelRequest, UpdateChannelRequest, AccountStatsPricingRule, BillingMultiplierRule } from '@/api/admin/channels'
 import type { PricingFormEntry } from '@/components/admin/channel/types'
 import { mTokToPerToken, perTokenToMTok, apiIntervalsToForm, formIntervalsToAPI, findModelConflict, validateIntervals } from '@/components/admin/channel/types'
 import type { AdminGroup, GroupPlatform } from '@/types'
@@ -674,6 +788,13 @@ interface FormPricingRule {
   pricing: PricingFormEntry[]
 }
 
+interface FormBillingMultiplierRule {
+  name: string
+  group_ids: number[]
+  account_ids: number[]
+  rate_multiplier: number | null
+}
+
 // ── Platform Section type ──
 interface PlatformSection {
   platform: GroupPlatform
@@ -686,6 +807,7 @@ interface PlatformSection {
   codex_image_generation_bridge: boolean
   bedrock_cc_compat: boolean
   account_stats_pricing_rules: FormPricingRule[]
+  billing_multiplier_rules: FormBillingMultiplierRule[]
 }
 
 // ── Table columns ──
@@ -783,6 +905,7 @@ function addPlatformSection(platform: GroupPlatform) {
     codex_image_generation_bridge: false,
     bedrock_cc_compat: false,
     account_stats_pricing_rules: [],
+    billing_multiplier_rules: [],
   })
 }
 
@@ -933,6 +1056,31 @@ function renameMappingKey(sectionIdx: number, oldKey: string, newKey: string) {
   mapping[newKey] = value
 }
 
+// ── Billing Multiplier helpers ──
+function addBillingMultiplierRule(sectionIdx: number) {
+  form.platforms[sectionIdx].billing_multiplier_rules.push({
+    name: '',
+    group_ids: [],
+    account_ids: [],
+    rate_multiplier: 1
+  })
+}
+
+function removeBillingMultiplierRule(sectionIdx: number, ruleIndex: number) {
+  form.platforms[sectionIdx].billing_multiplier_rules.splice(ruleIndex, 1)
+  ruleAccountSearchRunner.clearAll()
+  clearAllRuleAccountSearchState()
+}
+
+function toggleBillingMultiplierRuleGroup(rule: FormBillingMultiplierRule, groupId: number) {
+  const idx = rule.group_ids.indexOf(groupId)
+  if (idx >= 0) {
+    rule.group_ids.splice(idx, 1)
+  } else {
+    rule.group_ids.push(groupId)
+  }
+}
+
 // ── Account Stats Pricing helpers ──
 function addAccountStatsRule(sectionIdx: number) {
   form.platforms[sectionIdx].account_stats_pricing_rules.push({
@@ -985,7 +1133,8 @@ const ruleAccountNameCache = ref<Record<number, string>>({})
 const ruleAccountSearchRunner = useKeyedDebouncedSearch<SimpleAccount[]>({
   delay: 300,
   search: async (keyword, { key, signal }) => {
-    const platform = key.split('-')[0]
+    const parts = key.split('-')
+    const platform = parts.length >= 3 ? parts[1] : parts[0]
     const res = await adminAPI.accounts.list(1, 20, { platform, search: keyword }, { signal })
     return res.items.map(a => ({ id: a.id, name: a.name, platform: a.platform }))
   },
@@ -993,14 +1142,20 @@ const ruleAccountSearchRunner = useKeyedDebouncedSearch<SimpleAccount[]>({
   onError: (key) => { ruleAccountSearchResults.value[key] = [] },
 })
 
-function onRuleAccountSearchInput(platform: string, ruleIndex: number) {
-  const key = `${platform}-${ruleIndex}`
+type RuleAccountSearchScope = 'billing' | 'stats'
+
+function ruleAccountSearchKey(scope: RuleAccountSearchScope, platform: string, ruleIndex: number): string {
+  return `${scope}-${platform}-${ruleIndex}`
+}
+
+function onRuleAccountSearchInput(scope: RuleAccountSearchScope, platform: string, ruleIndex: number) {
+  const key = ruleAccountSearchKey(scope, platform, ruleIndex)
   showRuleAccountDropdown.value[key] = true
   ruleAccountSearchRunner.trigger(key, ruleAccountSearchKeyword.value[key] || '')
 }
 
-function onRuleAccountSearchFocus(platform: string, ruleIndex: number) {
-  const key = `${platform}-${ruleIndex}`
+function onRuleAccountSearchFocus(scope: RuleAccountSearchScope, platform: string, ruleIndex: number) {
+  const key = ruleAccountSearchKey(scope, platform, ruleIndex)
   showRuleAccountDropdown.value[key] = true
   if (!ruleAccountSearchResults.value[key]?.length) {
     ruleAccountSearchRunner.trigger(key, ruleAccountSearchKeyword.value[key] || '')
@@ -1010,6 +1165,7 @@ function onRuleAccountSearchFocus(platform: string, ruleIndex: number) {
 function selectRuleAccount(
   rule: { account_ids: number[] },
   account: SimpleAccount,
+  scope: RuleAccountSearchScope,
   platform: string,
   ruleIndex: number,
 ) {
@@ -1017,7 +1173,7 @@ function selectRuleAccount(
     rule.account_ids.push(account.id)
     ruleAccountNameCache.value[account.id] = account.name
   }
-  const key = `${platform}-${ruleIndex}`
+  const key = ruleAccountSearchKey(scope, platform, ruleIndex)
   ruleAccountSearchKeyword.value[key] = ''
   showRuleAccountDropdown.value[key] = false
 }
@@ -1070,6 +1226,22 @@ function accountStatsRulesToAPI(): AccountStatsPricingRule[] {
             per_request_price: p.per_request_price != null && p.per_request_price !== '' ? Number(p.per_request_price) : null,
             intervals: formIntervalsToAPI(p.intervals || [])
           }))
+      })
+    }
+  }
+  return rules
+}
+
+function billingMultiplierRulesToAPI(): BillingMultiplierRule[] {
+  const rules: BillingMultiplierRule[] = []
+  for (const section of form.platforms) {
+    if (!section.enabled) continue
+    for (const rule of section.billing_multiplier_rules) {
+      rules.push({
+        name: rule.name,
+        group_ids: rule.group_ids,
+        account_ids: rule.account_ids,
+        rate_multiplier: rule.rate_multiplier == null ? 1 : Number(rule.rate_multiplier)
       })
     }
   }
@@ -1177,6 +1349,18 @@ function apiToForm(channel: Channel): PlatformSection[] {
   for (const p of Object.keys(channel.model_mapping || {})) {
     if (platformOrder.includes(p as GroupPlatform)) activePlatforms.add(p as GroupPlatform)
   }
+  for (const rule of channel.billing_multiplier_rules || []) {
+    for (const gid of rule.group_ids || []) {
+      const p = groupPlatformMap.get(gid)
+      if (p) activePlatforms.add(p)
+    }
+  }
+  for (const rule of channel.account_stats_pricing_rules || []) {
+    for (const gid of rule.group_ids || []) {
+      const p = groupPlatformMap.get(gid)
+      if (p) activePlatforms.add(p)
+    }
+  }
 
   // Build sections in platform order
   const sections: PlatformSection[] = []
@@ -1219,6 +1403,7 @@ function apiToForm(channel: Channel): PlatformSection[] {
       codex_image_generation_bridge: codexImageGenerationBridgeEnabled,
       bedrock_cc_compat: bedrockCCCompatEnabled,
       account_stats_pricing_rules: [],
+      billing_multiplier_rules: [],
     })
   }
 
@@ -1338,12 +1523,41 @@ async function openEditDialog(channel: Channel) {
   form.platforms = apiToForm(channel)
 
   // Distribute channel-level rules into per-platform sections
+  distributeBillingMultiplierRulesToPlatforms(channel.billing_multiplier_rules || [])
   distributeRulesToPlatforms(channel.account_stats_pricing_rules || [])
 
   // Populate ruleAccountNameCache for existing rule accounts
   await populateRuleAccountNameCache()
 
   showDialog.value = true
+}
+
+/** Distribute flat channel-level billing multiplier rules into the matching platform section based on group_ids */
+function distributeBillingMultiplierRulesToPlatforms(apiRules: BillingMultiplierRule[]) {
+  const groupPlatformMap = new Map<number, GroupPlatform>()
+  for (const g of allGroups.value) {
+    groupPlatformMap.set(g.id, g.platform)
+  }
+
+  for (const apiRule of apiRules) {
+    const platforms = new Set<GroupPlatform>()
+    for (const gid of apiRule.group_ids || []) {
+      const p = groupPlatformMap.get(gid)
+      if (p) platforms.add(p)
+    }
+    const targetPlatform = platforms.size >= 1 ? [...platforms][0] : null
+    if (!targetPlatform) continue
+
+    const section = form.platforms.find(s => s.platform === targetPlatform)
+    if (!section) continue
+
+    section.billing_multiplier_rules.push({
+      name: apiRule.name || '',
+      group_ids: [...(apiRule.group_ids || [])],
+      account_ids: [...(apiRule.account_ids || [])],
+      rate_multiplier: apiRule.rate_multiplier
+    })
+  }
 }
 
 /** Distribute flat channel-level rules into the matching platform section based on group_ids */
@@ -1396,6 +1610,11 @@ function distributeRulesToPlatforms(apiRules: AccountStatsPricingRule[]) {
 async function populateRuleAccountNameCache() {
   const allAccountIds = new Set<number>()
   for (const section of form.platforms) {
+    for (const rule of section.billing_multiplier_rules) {
+      for (const id of rule.account_ids) {
+        allAccountIds.add(id)
+      }
+    }
     for (const rule of section.account_stats_pricing_rules) {
       for (const id of rule.account_ids) {
         allAccountIds.add(id)
@@ -1443,6 +1662,20 @@ async function handleSubmit() {
       if (entry.models.length === 0) {
         const platformLabel = t('admin.groups.platforms.' + section.platform, section.platform)
         appStore.showError(t('admin.channels.emptyModelsInPricing', { platform: platformLabel }, `${platformLabel} 平台下有定价条目未添加模型，请添加模型或删除该条目`))
+        activeTab.value = section.platform
+        return
+      }
+    }
+    for (const rule of section.billing_multiplier_rules) {
+      if (rule.group_ids.length === 0) {
+        const platformLabel = t('admin.groups.platforms.' + section.platform, section.platform)
+        appStore.showError(t('admin.channels.billingMultiplierRuleGroupsRequired', { platform: platformLabel }, `${platformLabel} 平台下有计费倍率规则未选择分组`))
+        activeTab.value = section.platform
+        return
+      }
+      if (rule.rate_multiplier == null || Number(rule.rate_multiplier) < 0) {
+        const platformLabel = t('admin.groups.platforms.' + section.platform, section.platform)
+        appStore.showError(t('admin.channels.billingMultiplierRateInvalid', { platform: platformLabel }, `${platformLabel} 平台下计费倍率必须大于或等于 0`))
         activeTab.value = section.platform
         return
       }
@@ -1526,7 +1759,8 @@ async function handleSubmit() {
         restrict_models: form.restrict_models,
         features_config,
         apply_pricing_to_account_stats: form.apply_pricing_to_account_stats,
-        account_stats_pricing_rules: accountStatsRulesToAPI()
+        account_stats_pricing_rules: accountStatsRulesToAPI(),
+        billing_multiplier_rules: billingMultiplierRulesToAPI()
       }
       await adminAPI.channels.update(editingChannel.value.id, req)
       appStore.showSuccess(t('admin.channels.updateSuccess', 'Channel updated'))
@@ -1541,7 +1775,8 @@ async function handleSubmit() {
         restrict_models: form.restrict_models,
         features_config,
         apply_pricing_to_account_stats: form.apply_pricing_to_account_stats,
-        account_stats_pricing_rules: accountStatsRulesToAPI()
+        account_stats_pricing_rules: accountStatsRulesToAPI(),
+        billing_multiplier_rules: billingMultiplierRulesToAPI()
       }
       await adminAPI.channels.create(req)
       appStore.showSuccess(t('admin.channels.createSuccess', 'Channel created'))


### PR DESCRIPTION
## Summary
- add ordered channel billing multiplier rules scoped by group and optional account
- apply matched channel multipliers to user-facing ActualCost for balance, subscription, API key quota, and rate-limit accounting
- expose rule management in the admin channel form alongside existing channel pricing controls

## Notes
- account stats pricing remains separate and continues to control account/statistics cost semantics
- rules require at least one group; account IDs are optional and narrow the match when present
- first matching rule wins according to saved order

## Tests
- `go test -tags unit ./internal/service ./internal/repository ./internal/handler/admin`
- `pnpm typecheck`
- local smoke test on isolated deployment at `127.0.0.1:18080`: health endpoint, admin login, migration table
