### PR TITLE
feat: refresh homepage as unified gateway landing

### DIFF
--- a/frontend/src/components/common/LocaleSwitcher.vue
+++ b/frontend/src/components/common/LocaleSwitcher.vue
@@ -44,10 +44,13 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useRoute, useRouter } from 'vue-router'
 import Icon from '@/components/icons/Icon.vue'
 import { setLocale, availableLocales } from '@/i18n'
 
 const { locale } = useI18n()
+const router = useRouter()
+const route = useRoute()
 
 const isOpen = ref(false)
 const dropdownRef = ref<HTMLElement | null>(null)
@@ -68,6 +71,9 @@ async function selectLocale(code: string) {
   switching.value = true
   try {
     await setLocale(code)
+    if (route.path === '/' || route.path === '/home' || route.path === '/en') {
+      await router.replace(code === 'en' ? '/en' : '/home')
+    }
     isOpen.value = false
   } finally {
     switching.value = false

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1,6 +1,7 @@
 export default {
   // Home Page
   home: {
+    title: 'Unified AI API Gateway',
     viewOnGithub: 'View on GitHub',
     viewDocs: 'View Documentation',
     docs: 'Docs',

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -9,6 +9,7 @@ import { useAppStore } from '@/stores/app'
 import { useAdminSettingsStore } from '@/stores/adminSettings'
 import { useNavigationLoadingState } from '@/composables/useNavigationLoading'
 import { useRoutePrefetch } from '@/composables/useRoutePrefetch'
+import { setLocale } from '@/i18n'
 import { resolveDocumentTitle } from './title'
 
 /**
@@ -31,9 +32,24 @@ const routes: RouteRecordRaw[] = [
     path: '/home',
     name: 'Home',
     component: () => import('@/views/HomeView.vue'),
+    beforeEnter: async () => {
+      await setLocale('zh')
+    },
     meta: {
       requiresAuth: false,
-      title: 'Home'
+      title: '统一 AI API 网关'
+    }
+  },
+  {
+    path: '/en',
+    name: 'HomeEn',
+    component: () => import('@/views/HomeView.vue'),
+    beforeEnter: async () => {
+      await setLocale('en')
+    },
+    meta: {
+      requiresAuth: false,
+      title: 'Unified AI API Gateway'
     }
   },
   {
@@ -668,7 +684,7 @@ let authInitialized = false
 const navigationLoading = useNavigationLoadingState()
 // 延迟初始化预加载，传入 router 实例
 let routePrefetch: ReturnType<typeof useRoutePrefetch> | null = null
-const BACKEND_MODE_ALLOWED_PATHS = ['/login', '/key-usage', '/setup', '/payment/result', '/payment/airwallex', '/legal']
+const BACKEND_MODE_ALLOWED_PATHS = ['/home', '/en', '/login', '/key-usage', '/setup', '/payment/result', '/payment/airwallex', '/legal']
 const BACKEND_MODE_CALLBACK_PATHS = [
   '/auth/callback',
   '/auth/linuxdo/callback',

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,400 +1,411 @@
 <template>
-  <!-- Custom Home Content: Full Page Mode -->
-  <div v-if="homeContent" class="min-h-screen">
-    <!-- iframe mode -->
+  <section v-if="homeContent" class="min-h-screen">
     <iframe
       v-if="isHomeContentUrl"
       :src="homeContent.trim()"
       class="h-screen w-full border-0"
       allowfullscreen
     ></iframe>
-    <!-- HTML mode - SECURITY: homeContent is admin-only setting, XSS risk is acceptable -->
     <div v-else v-html="homeContent"></div>
-  </div>
+  </section>
 
-  <!-- Default Home Page -->
   <div
     v-else
-    class="relative flex min-h-screen flex-col overflow-hidden bg-gradient-to-br from-gray-50 via-primary-50/30 to-gray-100 dark:from-dark-950 dark:via-dark-900 dark:to-dark-950"
+    class="relative min-h-screen overflow-x-clip bg-[linear-gradient(180deg,#f7fbff_0%,#f4f7fb_48%,#f7f8fb_100%)] text-slate-900"
   >
-    <!-- Background Decorations -->
     <div class="pointer-events-none absolute inset-0 overflow-hidden">
-      <div
-        class="absolute -right-40 -top-40 h-96 w-96 rounded-full bg-primary-400/20 blur-3xl"
-      ></div>
-      <div
-        class="absolute -bottom-40 -left-40 h-96 w-96 rounded-full bg-primary-500/15 blur-3xl"
-      ></div>
-      <div
-        class="absolute left-1/3 top-1/4 h-72 w-72 rounded-full bg-primary-300/10 blur-3xl"
-      ></div>
-      <div
-        class="absolute bottom-1/4 right-1/4 h-64 w-64 rounded-full bg-primary-400/10 blur-3xl"
-      ></div>
-      <div
-        class="absolute inset-0 bg-[linear-gradient(rgba(20,184,166,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(20,184,166,0.03)_1px,transparent_1px)] bg-[size:64px_64px]"
-      ></div>
+      <div class="absolute -left-32 top-0 h-80 w-80 rounded-full bg-sky-200/30 blur-3xl"></div>
+      <div class="absolute right-0 top-24 h-96 w-96 rounded-full bg-orange-100/40 blur-3xl"></div>
+      <div class="absolute bottom-0 left-1/3 h-72 w-72 rounded-full bg-indigo-200/20 blur-3xl"></div>
+      <div class="absolute inset-0 bg-[linear-gradient(rgba(148,163,184,0.06)_1px,transparent_1px),linear-gradient(90deg,rgba(148,163,184,0.06)_1px,transparent_1px)] bg-[size:44px_44px]"></div>
     </div>
 
-    <!-- Header -->
-    <header class="relative z-20 px-6 py-4">
-      <nav class="mx-auto flex max-w-6xl items-center justify-between">
-        <!-- Logo -->
-        <div class="flex items-center">
-          <div class="h-10 w-10 overflow-hidden rounded-xl shadow-md">
-            <img :src="siteLogo || '/logo.png'" alt="Logo" class="h-full w-full object-contain" />
-          </div>
-        </div>
+    <header class="sticky top-0 z-30 border-b border-slate-200/80 bg-white/88 backdrop-blur-xl">
+      <div class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-4 py-3 lg:px-6">
+        <router-link to="/home" class="min-w-0">
+          <p class="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+            {{ localText('Star-X 平台', 'Star-X Platform') }}
+          </p>
+          <p class="text-lg font-semibold tracking-[-0.03em] text-slate-950">
+            {{ siteName }}
+          </p>
+        </router-link>
 
-        <!-- Nav Actions -->
-        <div class="flex items-center gap-3">
-          <!-- Language Switcher -->
-          <LocaleSwitcher />
-
-          <!-- Doc Link -->
+        <nav class="hidden items-center gap-1.5 lg:flex" aria-label="Homepage navigation">
           <a
-            v-if="docUrl"
-            :href="docUrl"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="rounded-lg p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-dark-400 dark:hover:bg-dark-800 dark:hover:text-white"
-            :title="t('home.viewDocs')"
+            v-for="item in desktopNavItems"
+            :key="item.label"
+            :href="item.href"
+            class="rounded-full border border-transparent px-3 py-1.5 text-xs font-medium text-slate-500 transition hover:border-sky-200 hover:bg-white hover:text-sky-700"
           >
-            <Icon name="book" size="md" />
+            {{ item.label }}
           </a>
+        </nav>
 
-          <!-- Theme Toggle -->
+        <div class="flex items-center gap-2">
+          <LocaleSwitcher />
           <button
+            type="button"
+            class="rounded-full border border-slate-200 bg-white px-2.5 py-2 text-slate-500 transition hover:border-slate-300 hover:text-slate-800"
+            :title="isDark ? localText('切换到浅色模式', 'Switch to light mode') : localText('切换到深色模式', 'Switch to dark mode')"
             @click="toggleTheme"
-            class="rounded-lg p-2 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:text-dark-400 dark:hover:bg-dark-800 dark:hover:text-white"
-            :title="isDark ? t('home.switchToLight') : t('home.switchToDark')"
           >
-            <Icon v-if="isDark" name="sun" size="md" />
-            <Icon v-else name="moon" size="md" />
+            <Icon v-if="isDark" name="sun" size="sm" />
+            <Icon v-else name="moon" size="sm" />
           </button>
-
-          <!-- Login / Dashboard Button -->
           <router-link
-            v-if="isAuthenticated"
-            :to="dashboardPath"
-            class="inline-flex items-center gap-1.5 rounded-full bg-gray-900 py-1 pl-1 pr-2.5 transition-colors hover:bg-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700"
+            :to="isAuthenticated ? dashboardPath : '/login'"
+            class="rounded-full border border-slate-200 bg-white px-3 py-2 text-xs font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900"
           >
-            <span
-              class="flex h-5 w-5 items-center justify-center rounded-full bg-gradient-to-br from-primary-400 to-primary-600 text-[10px] font-semibold text-white"
-            >
-              {{ userInitial }}
-            </span>
-            <span class="text-xs font-medium text-white">{{ t('home.dashboard') }}</span>
-            <svg
-              class="h-3 w-3 text-gray-400"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25"
-              />
-            </svg>
+            {{ isAuthenticated ? localText('控制台', 'Console') : localText('登录', 'Sign in') }}
           </router-link>
           <router-link
-            v-else
-            to="/login"
-            class="inline-flex items-center rounded-full bg-gray-900 px-3 py-1 text-xs font-medium text-white transition-colors hover:bg-gray-800 dark:bg-gray-800 dark:hover:bg-gray-700"
+            :to="isAuthenticated ? dashboardPath : '/register'"
+            class="rounded-full bg-slate-950 px-3.5 py-2 text-xs font-medium text-white shadow-[0_10px_24px_rgba(15,23,42,0.18)] transition hover:bg-slate-800"
           >
-            {{ t('home.login') }}
+            {{ isAuthenticated ? t('home.goToDashboard') : localText('开始使用', 'Get started') }}
           </router-link>
         </div>
+      </div>
+
+      <nav class="flex gap-2 overflow-x-auto px-4 pb-3 lg:hidden" aria-label="Compact homepage navigation">
+        <a
+          v-for="item in mobileNavItems"
+          :key="item.label"
+          :href="item.href"
+          class="shrink-0 rounded-full border border-slate-200 bg-white px-3 py-1.5 text-[11px] font-medium text-slate-600"
+        >
+          {{ item.label }}
+        </a>
       </nav>
     </header>
 
-    <!-- Main Content -->
-    <main class="relative z-10 flex-1 px-6 py-16">
+    <main class="relative z-10 px-4 pb-16 pt-8 lg:px-6 lg:pt-12">
       <div class="mx-auto max-w-6xl">
-        <!-- Hero Section - Left/Right Layout -->
-        <div class="mb-12 flex flex-col items-center justify-between gap-12 lg:flex-row lg:gap-16">
-          <!-- Left: Text Content -->
-          <div class="flex-1 text-center lg:text-left">
-            <h1
-              class="mb-4 text-4xl font-bold text-gray-900 dark:text-white md:text-5xl lg:text-6xl"
-            >
-              {{ siteName }}
+        <section class="rounded-[28px] border border-white/90 bg-white/75 p-6 shadow-[0_30px_90px_rgba(15,23,42,0.08)] backdrop-blur-xl lg:p-10">
+          <div class="mx-auto max-w-4xl text-center">
+            <span class="inline-flex items-center gap-2 rounded-full border border-sky-200 bg-sky-50/90 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-700">
+              <Icon name="sparkles" size="xs" />
+              {{ localText('统一 AI API 网关', 'Unified AI API gateway') }}
+            </span>
+
+            <h1 class="mt-6 text-4xl font-semibold tracking-[-0.06em] text-slate-950 md:text-6xl">
+              <span>{{ localText('统一 API 网关，服务于', 'One API gateway, built for') }}</span>
+              <span class="mt-2 block bg-[linear-gradient(90deg,#4f87da_0%,#8d68ff_52%,#6db6ff_100%)] bg-clip-text text-transparent">
+                {{ localText('所有 AI 模型', 'every AI model') }}
+              </span>
             </h1>
-            <p class="mb-8 text-lg text-gray-600 dark:text-dark-300 md:text-xl">
-              {{ siteSubtitle }}
+
+            <p class="mx-auto mt-6 max-w-3xl text-sm leading-7 text-slate-600 md:text-base md:leading-8">
+              {{
+                localText(
+                  'Star-X 把多上游接入、模型目录、统一密钥、额度、日志、路由与计费收束到同一个控制面，帮助你用一套兼容接口服务更多模型与团队场景。',
+                  'Star-X brings multi-upstream access, model catalog, unified keys, quotas, logs, routing, and billing into one control plane so one compatible interface can serve more models and team workflows.',
+                )
+              }}
             </p>
 
-            <!-- CTA Button -->
-            <div>
+            <p class="mt-5 text-xs font-semibold uppercase tracking-[0.22em] text-sky-700">
+              {{ heroSubtitle }}
+            </p>
+
+            <div class="mt-7 flex flex-col justify-center gap-3 sm:flex-row">
               <router-link
-                :to="isAuthenticated ? dashboardPath : '/login'"
-                class="btn btn-primary px-8 py-3 text-base shadow-lg shadow-primary-500/30"
+                :to="isAuthenticated ? dashboardPath : '/register'"
+                class="inline-flex min-h-11 items-center justify-center rounded-full bg-slate-950 px-5 text-sm font-semibold text-white shadow-[0_12px_24px_rgba(15,23,42,0.18)] transition hover:bg-slate-800"
               >
-                {{ isAuthenticated ? t('home.goToDashboard') : t('home.getStarted') }}
-                <Icon name="arrowRight" size="md" class="ml-2" :stroke-width="2" />
+                {{ isAuthenticated ? t('home.goToDashboard') : localText('开始使用', 'Get started') }}
+              </router-link>
+              <router-link
+                :to="pricingPath"
+                class="inline-flex min-h-11 items-center justify-center rounded-full border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-950"
+              >
+                {{ localText('查看定价', 'View pricing') }}
+              </router-link>
+              <a
+                :href="resolvedDocUrl"
+                :target="docUrl ? '_blank' : undefined"
+                rel="noopener noreferrer"
+                class="inline-flex min-h-11 items-center justify-center rounded-full border border-sky-200 bg-sky-50 px-5 text-sm font-semibold text-sky-700 transition hover:bg-sky-100"
+              >
+                {{ localText('查看文档', 'Read docs') }}
+              </a>
+            </div>
+          </div>
+
+          <div class="mt-10 grid gap-6 lg:grid-cols-[1.08fr_0.92fr]">
+            <article class="overflow-hidden rounded-[24px] border border-slate-200 bg-white shadow-[0_20px_50px_rgba(15,23,42,0.06)]">
+              <header class="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+                <nav class="flex flex-wrap items-center gap-2 text-[11px] font-semibold">
+                  <span
+                    v-for="tab in protocolTabs"
+                    :key="tab"
+                    class="rounded-full px-2.5 py-1"
+                    :class="tab === protocolTabs[0] ? 'bg-sky-100 text-sky-700' : 'text-slate-400'"
+                  >
+                    {{ tab }}
+                  </span>
+                </nav>
+                <span class="inline-flex items-center gap-2 text-[11px] font-medium text-slate-400">
+                  <span class="h-2 w-2 rounded-full bg-emerald-500"></span>
+                  200 OK
+                </span>
+              </header>
+
+              <div class="space-y-5 px-4 py-4">
+                <div class="grid gap-3 sm:grid-cols-3">
+                  <article
+                    v-for="item in sampleStats"
+                    :key="item.label"
+                    class="rounded-2xl border border-slate-200 bg-slate-50/80 p-3"
+                  >
+                    <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ item.label }}</p>
+                    <p class="mt-1 text-lg font-semibold text-slate-950">{{ item.value }}</p>
+                  </article>
+                </div>
+
+                <div>
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">POST</p>
+                  <p class="mt-1 break-all font-mono text-sm text-slate-900">/v1/chat/completions</p>
+                </div>
+
+                <div>
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ localText('请求', 'Request') }}</p>
+                  <pre class="mt-2 overflow-x-auto rounded-2xl bg-slate-50 p-4 text-[12px] leading-7 text-sky-800">{{ quickCurl }}</pre>
+                </div>
+
+                <div>
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ localText('响应', 'Response') }}</p>
+                  <pre class="mt-2 overflow-x-auto rounded-2xl bg-slate-50 p-4 text-[12px] leading-7 text-slate-600">{{ sampleResponse }}</pre>
+                </div>
+
+                <div class="grid gap-3 border-t border-slate-200 pt-4 sm:grid-cols-2">
+                  <article class="rounded-2xl border border-slate-200 bg-white p-4">
+                    <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ localText('兼容特性', 'Compatibility') }}</p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                      <span
+                        v-for="item in compatibilityTags"
+                        :key="item"
+                        class="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-600"
+                      >
+                        {{ item }}
+                      </span>
+                    </div>
+                  </article>
+                  <article class="rounded-2xl border border-slate-200 bg-white p-4">
+                    <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ localText('运行指标', 'Runtime') }}</p>
+                    <div class="mt-3 flex flex-wrap gap-2">
+                      <span
+                        v-for="item in runtimeBadges"
+                        :key="item"
+                        class="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-600"
+                      >
+                        {{ item }}
+                      </span>
+                    </div>
+                  </article>
+                </div>
+
+                <footer class="flex flex-wrap gap-3 border-t border-slate-200 pt-3 text-[11px] font-medium text-slate-400">
+                  <span>{{ localText('路由完成', 'Route complete') }}</span>
+                  <span>142 ms</span>
+                  <span>27 tokens</span>
+                  <span>$0.00081</span>
+                  <span>SSE</span>
+                </footer>
+              </div>
+            </article>
+
+            <aside class="rounded-[24px] border border-slate-200 bg-white/86 p-5 shadow-[0_20px_50px_rgba(15,23,42,0.05)]">
+              <p class="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">
+                {{ localText('控制面概览', 'Control plane overview') }}
+              </p>
+              <h2 class="mt-3 text-3xl font-semibold tracking-[-0.05em] text-slate-950">
+                {{ localText('统一接入、统一路由、统一计费。', 'One integration surface, one routing layer, one billing view.') }}
+              </h2>
+
+              <div class="mt-5 grid gap-3">
+                <article
+                  v-for="item in sideHighlights"
+                  :key="item.title"
+                  class="rounded-2xl border border-slate-200 bg-white p-4"
+                >
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-sky-700">{{ item.kicker }}</p>
+                  <h3 class="mt-1 text-sm font-semibold text-slate-900">{{ item.title }}</h3>
+                  <p class="mt-2 text-xs leading-6 text-slate-600">{{ item.copy }}</p>
+                </article>
+              </div>
+
+              <div class="mt-5 grid gap-3">
+                <article class="rounded-2xl border border-slate-200 bg-white p-4">
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ localText('基础地址', 'Base URL') }}</p>
+                  <p class="mt-2 break-all font-mono text-[12px] text-sky-800">{{ sampleBaseUrl }}</p>
+                </article>
+                <article class="rounded-2xl border border-slate-200 bg-white p-4">
+                  <p class="text-[10px] font-semibold uppercase tracking-[0.14em] text-slate-400">{{ localText('推荐模型', 'Suggested model') }}</p>
+                  <p class="mt-2 break-all font-mono text-[12px] text-sky-800">{{ suggestedModel }}</p>
+                </article>
+              </div>
+            </aside>
+          </div>
+        </section>
+
+        <section class="mt-6 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <article
+            v-for="metric in heroMetrics"
+            :key="metric.label"
+            class="rounded-3xl border border-white/80 bg-white/88 p-5 shadow-[0_18px_40px_rgba(15,23,42,0.05)]"
+          >
+            <p class="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">{{ metric.label }}</p>
+            <p class="mt-3 text-4xl font-semibold tracking-[-0.06em] text-slate-950">{{ metric.value }}</p>
+            <p class="mt-2 text-sm leading-6 text-slate-500">{{ metric.note }}</p>
+          </article>
+        </section>
+
+        <section id="features" class="mt-6 rounded-[28px] border border-white/80 bg-white/90 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.05)] lg:p-8">
+          <div class="max-w-3xl">
+            <p class="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">{{ localText('核心功能', 'Core capabilities') }}</p>
+            <h2 class="mt-3 text-3xl font-semibold tracking-[-0.05em] text-slate-950">{{ localText('为开发者打造，为规模而设计。', 'Built for developers, designed for scale.') }}</h2>
+          </div>
+
+          <div class="mt-6 grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
+            <article
+              v-for="item in featureCards"
+              :key="item.index"
+              class="rounded-3xl border border-slate-200 bg-[linear-gradient(180deg,rgba(255,255,255,0.96),rgba(247,250,255,0.98))] p-5"
+            >
+              <span class="inline-flex h-9 min-w-9 items-center justify-center rounded-full bg-sky-100 text-sm font-semibold text-sky-700">{{ item.index }}</span>
+              <h3 class="mt-4 text-xl font-semibold tracking-[-0.03em] text-slate-950">{{ item.title }}</h3>
+              <p class="mt-3 text-sm leading-7 text-slate-600">{{ item.copy }}</p>
+              <div class="mt-5 flex flex-wrap gap-2">
+                <span
+                  v-for="tag in item.tags"
+                  :key="`${item.index}-${tag}`"
+                  class="rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] font-medium text-slate-500"
+                >
+                  {{ tag }}
+                </span>
+              </div>
+            </article>
+          </div>
+        </section>
+
+        <section class="mt-6 grid gap-6 xl:grid-cols-[0.9fr_1.1fr]">
+          <article id="workflow" class="rounded-[28px] border border-slate-900 bg-slate-950 p-6 text-white shadow-[0_24px_60px_rgba(15,23,42,0.18)] lg:p-8">
+            <p class="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-300">{{ localText('工作流程', 'Workflow') }}</p>
+            <h2 class="mt-3 text-3xl font-semibold tracking-[-0.05em]">{{ localText('三步快速上手。', 'Get started in three steps.') }}</h2>
+
+            <div class="mt-6 space-y-3">
+              <article
+                v-for="step in workflowSteps"
+                :key="step.index"
+                class="rounded-3xl border border-white/10 bg-white/5 p-5"
+              >
+                <div class="flex gap-3">
+                  <span class="inline-flex h-9 min-w-9 items-center justify-center rounded-full bg-white text-sm font-semibold text-slate-950">{{ step.index }}</span>
+                  <div>
+                    <h3 class="text-base font-semibold">{{ step.title }}</h3>
+                    <p class="mt-2 text-sm leading-7 text-slate-300">{{ step.copy }}</p>
+                  </div>
+                </div>
+              </article>
+            </div>
+          </article>
+
+          <article id="providers" class="rounded-[28px] border border-white/80 bg-white/90 p-6 shadow-[0_20px_50px_rgba(15,23,42,0.05)] lg:p-8">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p class="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">{{ localText('模型广场', 'Model plaza') }}</p>
+                <h2 class="mt-3 text-3xl font-semibold tracking-[-0.05em] text-slate-950">{{ localText('统一目录下查看当前可用模型。', 'Browse live models from one unified catalog.') }}</h2>
+              </div>
+              <router-link
+                :to="isAuthenticated ? '/dashboard' : '/login'"
+                class="inline-flex min-h-10 items-center justify-center rounded-full border border-slate-200 bg-white px-4 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-950"
+              >
+                {{ localText('进入控制台', 'Open console') }}
               </router-link>
             </div>
-          </div>
 
-          <!-- Right: Terminal Animation -->
-          <div class="flex flex-1 justify-center lg:justify-end">
-            <div class="terminal-container">
-              <div class="terminal-window">
-                <!-- Window header -->
-                <div class="terminal-header">
-                  <div class="terminal-buttons">
-                    <span class="btn-close"></span>
-                    <span class="btn-minimize"></span>
-                    <span class="btn-maximize"></span>
-                  </div>
-                  <span class="terminal-title">terminal</span>
-                </div>
-                <!-- Terminal content -->
-                <div class="terminal-body">
-                  <div class="code-line line-1">
-                    <span class="code-prompt">$</span>
-                    <span class="code-cmd">curl</span>
-                    <span class="code-flag">-X POST</span>
-                    <span class="code-url">/v1/messages</span>
-                  </div>
-                  <div class="code-line line-2">
-                    <span class="code-comment"># Routing to upstream...</span>
-                  </div>
-                  <div class="code-line line-3">
-                    <span class="code-success">200 OK</span>
-                    <span class="code-response">{ "content": "Hello!" }</span>
-                  </div>
-                  <div class="code-line line-4">
-                    <span class="code-prompt">$</span>
-                    <span class="cursor"></span>
+            <div class="mt-6 grid gap-3 sm:grid-cols-2">
+              <article
+                v-for="provider in providers"
+                :key="provider.name"
+                class="rounded-3xl border border-slate-200 bg-slate-50/90 p-5"
+              >
+                <div class="flex items-center gap-3">
+                  <span
+                    class="inline-flex h-10 w-10 items-center justify-center rounded-2xl text-sm font-semibold text-white"
+                    :style="{ background: provider.color }"
+                  >
+                    {{ provider.initial }}
+                  </span>
+                  <div>
+                    <h3 class="text-base font-semibold text-slate-950">{{ provider.name }}</h3>
+                    <p class="text-xs text-slate-500">{{ provider.status }}</p>
                   </div>
                 </div>
-              </div>
+                <p class="mt-4 text-sm leading-7 text-slate-600">{{ provider.copy }}</p>
+              </article>
             </div>
-          </div>
-        </div>
+          </article>
+        </section>
 
-        <!-- Feature Tags - Centered -->
-        <div class="mb-12 flex flex-wrap items-center justify-center gap-4 md:gap-6">
-          <div
-            class="inline-flex items-center gap-2.5 rounded-full border border-gray-200/50 bg-white/80 px-5 py-2.5 shadow-sm backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/80"
-          >
-            <Icon name="swap" size="sm" class="text-primary-500" />
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{
-              t('home.tags.subscriptionToApi')
-            }}</span>
-          </div>
-          <div
-            class="inline-flex items-center gap-2.5 rounded-full border border-gray-200/50 bg-white/80 px-5 py-2.5 shadow-sm backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/80"
-          >
-            <Icon name="shield" size="sm" class="text-primary-500" />
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{
-              t('home.tags.stickySession')
-            }}</span>
-          </div>
-          <div
-            class="inline-flex items-center gap-2.5 rounded-full border border-gray-200/50 bg-white/80 px-5 py-2.5 shadow-sm backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/80"
-          >
-            <Icon name="chart" size="sm" class="text-primary-500" />
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{
-              t('home.tags.realtimeBilling')
-            }}</span>
-          </div>
-        </div>
-
-        <!-- Features Grid -->
-        <div class="mb-12 grid gap-6 md:grid-cols-3">
-          <!-- Feature 1: Unified Gateway -->
-          <div
-            class="group rounded-2xl border border-gray-200/50 bg-white/60 p-6 backdrop-blur-sm transition-all duration-300 hover:shadow-xl hover:shadow-primary-500/10 dark:border-dark-700/50 dark:bg-dark-800/60"
-          >
-            <div
-              class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-blue-500 to-blue-600 shadow-lg shadow-blue-500/30 transition-transform group-hover:scale-110"
-            >
-              <Icon name="server" size="lg" class="text-white" />
+        <section id="about" class="mt-6 rounded-[28px] border border-white/80 bg-white/85 p-6 shadow-[0_18px_40px_rgba(15,23,42,0.05)] lg:p-8">
+          <div class="flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
+            <div class="max-w-2xl">
+              <p class="text-[10px] font-semibold uppercase tracking-[0.16em] text-sky-700">{{ localText('准备好开始了吗？', 'Ready to simplify your AI integration?') }}</p>
+              <h2 class="mt-3 text-3xl font-semibold tracking-[-0.05em] text-slate-950">
+                {{ localText('部署你的网关，通过已配置的上游服务开始转发请求。', 'Deploy your gateway and start routing requests through configured upstream services.') }}
+              </h2>
             </div>
-            <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-              {{ t('home.features.unifiedGateway') }}
-            </h3>
-            <p class="text-sm leading-relaxed text-gray-600 dark:text-dark-400">
-              {{ t('home.features.unifiedGatewayDesc') }}
-            </p>
-          </div>
-
-          <!-- Feature 2: Account Pool -->
-          <div
-            class="group rounded-2xl border border-gray-200/50 bg-white/60 p-6 backdrop-blur-sm transition-all duration-300 hover:shadow-xl hover:shadow-primary-500/10 dark:border-dark-700/50 dark:bg-dark-800/60"
-          >
-            <div
-              class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-primary-500 to-primary-600 shadow-lg shadow-primary-500/30 transition-transform group-hover:scale-110"
-            >
-              <svg
-                class="h-6 w-6 text-white"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
+            <div class="flex flex-col gap-3 sm:flex-row">
+              <router-link
+                :to="isAuthenticated ? dashboardPath : '/register'"
+                class="inline-flex min-h-11 items-center justify-center rounded-full bg-slate-950 px-5 text-sm font-semibold text-white transition hover:bg-slate-800"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z"
-                />
-              </svg>
-            </div>
-            <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-              {{ t('home.features.multiAccount') }}
-            </h3>
-            <p class="text-sm leading-relaxed text-gray-600 dark:text-dark-400">
-              {{ t('home.features.multiAccountDesc') }}
-            </p>
-          </div>
-
-          <!-- Feature 3: Billing & Quota -->
-          <div
-            class="group rounded-2xl border border-gray-200/50 bg-white/60 p-6 backdrop-blur-sm transition-all duration-300 hover:shadow-xl hover:shadow-primary-500/10 dark:border-dark-700/50 dark:bg-dark-800/60"
-          >
-            <div
-              class="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-purple-500 to-purple-600 shadow-lg shadow-purple-500/30 transition-transform group-hover:scale-110"
-            >
-              <svg
-                class="h-6 w-6 text-white"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
+                {{ isAuthenticated ? t('home.goToDashboard') : localText('开始使用', 'Get started') }}
+              </router-link>
+              <a
+                :href="resolvedDocUrl"
+                :target="docUrl ? '_blank' : undefined"
+                rel="noopener noreferrer"
+                class="inline-flex min-h-11 items-center justify-center rounded-full border border-slate-200 bg-white px-5 text-sm font-semibold text-slate-700 transition hover:border-slate-300 hover:text-slate-950"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M2.25 18.75a60.07 60.07 0 0115.797 2.101c.727.198 1.453-.342 1.453-1.096V18.75M3.75 4.5v.75A.75.75 0 013 6h-.75m0 0v-.375c0-.621.504-1.125 1.125-1.125H20.25M2.25 6v9m18-10.5v.75c0 .414.336.75.75.75h.75m-1.5-1.5h.375c.621 0 1.125.504 1.125 1.125v9.75c0 .621-.504 1.125-1.125 1.125h-.375m1.5-1.5H21a.75.75 0 00-.75.75v.75m0 0H3.75m0 0h-.375a1.125 1.125 0 01-1.125-1.125V15m1.5 1.5v-.75A.75.75 0 003 15h-.75M15 10.5a3 3 0 11-6 0 3 3 0 016 0zm3 0h.008v.008H18V10.5zm-12 0h.008v.008H6V10.5z"
-                />
-              </svg>
+                {{ localText('查看文档', 'Read docs') }}
+              </a>
             </div>
-            <h3 class="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-              {{ t('home.features.balanceQuota') }}
-            </h3>
-            <p class="text-sm leading-relaxed text-gray-600 dark:text-dark-400">
-              {{ t('home.features.balanceQuotaDesc') }}
-            </p>
           </div>
-        </div>
-
-        <!-- Supported Providers -->
-        <div class="mb-8 text-center">
-          <h2 class="mb-3 text-2xl font-bold text-gray-900 dark:text-white">
-            {{ t('home.providers.title') }}
-          </h2>
-          <p class="text-sm text-gray-600 dark:text-dark-400">
-            {{ t('home.providers.description') }}
-          </p>
-        </div>
-
-        <div class="mb-16 flex flex-wrap items-center justify-center gap-4">
-          <!-- Claude - Supported -->
-          <div
-            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
-          >
-            <div
-              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-orange-400 to-orange-500"
-            >
-              <span class="text-xs font-bold text-white">C</span>
-            </div>
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.claude') }}</span>
-            <span
-              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
-              >{{ t('home.providers.supported') }}</span
-            >
-          </div>
-          <!-- GPT - Supported -->
-          <div
-            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
-          >
-            <div
-              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-green-500 to-green-600"
-            >
-              <span class="text-xs font-bold text-white">G</span>
-            </div>
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">GPT</span>
-            <span
-              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
-              >{{ t('home.providers.supported') }}</span
-            >
-          </div>
-          <!-- Gemini - Supported -->
-          <div
-            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
-          >
-            <div
-              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-blue-500 to-blue-600"
-            >
-              <span class="text-xs font-bold text-white">G</span>
-            </div>
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.gemini') }}</span>
-            <span
-              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
-              >{{ t('home.providers.supported') }}</span
-            >
-          </div>
-          <!-- Antigravity - Supported -->
-          <div
-            class="flex items-center gap-2 rounded-xl border border-primary-200 bg-white/60 px-5 py-3 ring-1 ring-primary-500/20 backdrop-blur-sm dark:border-primary-800 dark:bg-dark-800/60"
-          >
-            <div
-              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-rose-500 to-pink-600"
-            >
-              <span class="text-xs font-bold text-white">A</span>
-            </div>
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.antigravity') }}</span>
-            <span
-              class="rounded bg-primary-100 px-1.5 py-0.5 text-[10px] font-medium text-primary-600 dark:bg-primary-900/30 dark:text-primary-400"
-              >{{ t('home.providers.supported') }}</span
-            >
-          </div>
-          <!-- More - Coming Soon -->
-          <div
-            class="flex items-center gap-2 rounded-xl border border-gray-200/50 bg-white/40 px-5 py-3 opacity-60 backdrop-blur-sm dark:border-dark-700/50 dark:bg-dark-800/40"
-          >
-            <div
-              class="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-to-br from-gray-500 to-gray-600"
-            >
-              <span class="text-xs font-bold text-white">+</span>
-            </div>
-            <span class="text-sm font-medium text-gray-700 dark:text-dark-200">{{ t('home.providers.more') }}</span>
-            <span
-              class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-dark-700 dark:text-dark-400"
-              >{{ t('home.providers.soon') }}</span
-            >
-          </div>
-        </div>
+        </section>
       </div>
     </main>
 
-    <!-- Footer -->
-    <footer class="relative z-10 border-t border-gray-200/50 px-6 py-8 dark:border-dark-800/50">
-      <div
-        class="mx-auto flex max-w-6xl flex-col items-center justify-center gap-4 text-center sm:flex-row sm:text-left"
-      >
-        <p class="text-sm text-gray-500 dark:text-dark-400">
-          &copy; {{ currentYear }} {{ siteName }}. {{ t('home.footer.allRightsReserved') }}
-        </p>
-        <div class="flex items-center gap-4">
+    <footer class="relative z-10 border-t border-white/80 px-4 py-8">
+      <div class="mx-auto flex max-w-6xl flex-col gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left">
+        <div>
+          <p class="text-sm text-slate-500">
+            &copy; {{ currentYear }} {{ siteName }}. {{ t('home.footer.allRightsReserved') }}
+          </p>
+        </div>
+        <div class="flex flex-wrap items-center justify-center gap-4 text-sm text-slate-500 sm:justify-end">
           <a
-            v-if="docUrl"
-            :href="docUrl"
-            target="_blank"
+            :href="resolvedDocUrl"
+            :target="docUrl ? '_blank' : undefined"
             rel="noopener noreferrer"
-            class="text-sm text-gray-500 transition-colors hover:text-gray-700 dark:text-dark-400 dark:hover:text-white"
+            class="transition hover:text-slate-900"
           >
-            {{ t('home.docs') }}
+            {{ localText('文档', 'Docs') }}
           </a>
+          <a href="#providers" class="transition hover:text-slate-900">
+            {{ localText('模型', 'Models') }}
+          </a>
+          <router-link :to="pricingPath" class="transition hover:text-slate-900">
+            {{ localText('定价', 'Pricing') }}
+          </router-link>
           <a
             :href="githubUrl"
             target="_blank"
             rel="noopener noreferrer"
-            class="text-sm text-gray-500 transition-colors hover:text-gray-700 dark:text-dark-400 dark:hover:text-white"
+            class="transition hover:text-slate-900"
           >
             GitHub
           </a>
@@ -405,63 +416,294 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore, useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
 
-const { t } = useI18n()
-
+const { locale, t } = useI18n()
 const authStore = useAuthStore()
 const appStore = useAppStore()
 
-// Site settings - directly from appStore (already initialized from injected config)
+const isDark = ref(document.documentElement.classList.contains('dark'))
+
 const siteName = computed(() => appStore.cachedPublicSettings?.site_name || appStore.siteName || 'Sub2API')
-const siteLogo = computed(() => appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '')
-const siteSubtitle = computed(() => appStore.cachedPublicSettings?.site_subtitle || 'AI API Gateway Platform')
 const docUrl = computed(() => appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '')
 const homeContent = computed(() => appStore.cachedPublicSettings?.home_content || '')
-
-// Check if homeContent is a URL (for iframe display)
 const isHomeContentUrl = computed(() => {
   const content = homeContent.value.trim()
   return content.startsWith('http://') || content.startsWith('https://')
 })
 
-// Theme
-const isDark = ref(document.documentElement.classList.contains('dark'))
-
-// GitHub URL
-const githubUrl = 'https://github.com/Wei-Shaw/sub2api'
-
-// Auth state
 const isAuthenticated = computed(() => authStore.isAuthenticated)
 const isAdmin = computed(() => authStore.isAdmin)
-const dashboardPath = computed(() => isAdmin.value ? '/admin/dashboard' : '/dashboard')
-const userInitial = computed(() => {
-  const user = authStore.user
-  if (!user || !user.email) return ''
-  return user.email.charAt(0).toUpperCase()
-})
-
-// Current year for footer
+const dashboardPath = computed(() => (isAdmin.value ? '/admin/dashboard' : '/dashboard'))
+const pricingPath = computed(() => (isAuthenticated.value ? '/purchase' : '/register'))
 const currentYear = computed(() => new Date().getFullYear())
+const githubUrl = 'https://github.com/Wei-Shaw/sub2api'
+const resolvedDocUrl = computed(() => docUrl.value || '#workflow')
+const sampleBaseUrl = computed(() => `${window.location.origin}/v1`)
+const suggestedModel = computed(() => 'claude-3-5-sonnet-latest')
+const heroSubtitle = computed(() =>
+  localText(
+    'OpenAI-compatible routing',
+    'OpenAI-compatible routing',
+  ),
+)
+const demoPrompt = computed(() =>
+  localText(
+    '给我一份适用于 AI API 网关上线前的检查清单。',
+    'Give me a launch checklist for an AI API gateway.',
+  ),
+)
+const quickCurl = computed(() =>
+  [
+    `curl ${sampleBaseUrl.value}/chat/completions \\`,
+    '  -H "Authorization: Bearer sk-starx-demo" \\',
+    '  -H "Content-Type: application/json" \\',
+    "  -d '{",
+    `    "model": "${suggestedModel.value}",`,
+    `    "messages": [{"role":"user","content":"${demoPrompt.value}"}],`,
+    '    "stream": true',
+    "  }'",
+  ].join('\n'),
+)
+const sampleResponse = computed(() =>
+  JSON.stringify(
+    {
+      id: 'chatcmpl-starx-demo',
+      object: 'chat.completion',
+      created: 1717329600,
+      model: suggestedModel.value,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: localText(
+              '已生成上线检查清单，涵盖路由、鉴权、监控、计费与回退策略。',
+              'Launch checklist generated, covering routing, auth, monitoring, billing, and failover.',
+            ),
+          },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: 17,
+        completion_tokens: 10,
+        total_tokens: 27,
+      },
+    },
+    null,
+    2,
+  ),
+)
 
-// Toggle theme
+const desktopNavItems = computed(() => [
+  { label: localText('主页', 'Home'), href: '#top' },
+  { label: localText('控制台', 'Console'), href: isAuthenticated.value ? '/dashboard' : '/login' },
+  { label: localText('功能', 'Features'), href: '#features' },
+  { label: localText('流程', 'Workflow'), href: '#workflow' },
+  { label: localText('模型', 'Models'), href: '#providers' },
+  { label: localText('文档', 'Docs'), href: resolvedDocUrl.value },
+])
+
+const mobileNavItems = computed(() => [
+  { label: localText('主页', 'Home'), href: '#top' },
+  { label: localText('功能', 'Features'), href: '#features' },
+  { label: localText('流程', 'Workflow'), href: '#workflow' },
+  { label: localText('模型', 'Models'), href: '#providers' },
+  { label: localText('文档', 'Docs'), href: resolvedDocUrl.value },
+])
+
+const protocolTabs = ['Chat', 'Responses', 'Claude', 'Gemini']
+
+const sampleStats = computed(() => [
+  { label: localText('状态', 'Status'), value: '200 OK' },
+  { label: localText('延迟', 'Latency'), value: '142 ms' },
+  { label: localText('总 Tokens', 'Tokens'), value: '27' },
+])
+
+const compatibilityTags = computed(() =>
+  localTextArray(
+    ['OpenAI 兼容', '流式返回', '统一鉴权', '多模型路由'],
+    ['OpenAI compatible', 'Streaming', 'Unified auth', 'Model routing'],
+  ),
+)
+
+const runtimeBadges = computed(() =>
+  localTextArray(
+    ['负载均衡', '自动回退', '成本跟踪', '统一日志'],
+    ['Load balancing', 'Failover', 'Cost tracking', 'Unified logs'],
+  ),
+)
+
+const sideHighlights = computed(() => [
+  {
+    kicker: localText('统一接入', 'Unified access'),
+    title: localText('一个地址接所有模型', 'One endpoint for all models'),
+    copy: localText('统一 OpenAI 兼容入口，减少客户端改造和接入分叉。', 'One OpenAI-compatible surface reduces client rewrites and integration drift.'),
+  },
+  {
+    kicker: localText('统一治理', 'Unified control'),
+    title: localText('密钥、额度、路由集中管理', 'Centralized keys, quotas, and routing'),
+    copy: localText('把访问控制、分组策略、日志和路由规则收束到同一个控制面。', 'Bring access control, grouping, logs, and routing rules into one control plane.'),
+  },
+  {
+    kicker: localText('统一计费', 'Unified billing'),
+    title: localText('模型用量与成本透明', 'Transparent usage and cost'),
+    copy: localText('用量、账单和支付状态都从统一视图查看，而不是散在多个上游后台。', 'Track usage, billing, and payment status from one view instead of multiple upstream dashboards.'),
+  },
+])
+
+const heroMetrics = computed(() =>
+  localTextArray(
+    [
+      { label: '上游服务适配', value: '47+', note: '多上游接入与调度' },
+      { label: '模型计费支持', value: '94+', note: '统一模型目录与定价' },
+      { label: '兼容 API 路由', value: '47+', note: '支持更多客户端与工作流' },
+      { label: '调度控制能力', value: '9+', note: '路由、配额、日志与监控' },
+    ],
+    [
+      { label: 'Upstream integrations', value: '47+', note: 'Multi-upstream routing and switching' },
+      { label: 'Pricing entries', value: '94+', note: 'Unified catalog and pricing surface' },
+      { label: 'Compatible routes', value: '47+', note: 'Broader client and workflow support' },
+      { label: 'Control features', value: '9+', note: 'Routing, quota, logging, and monitoring' },
+    ],
+  ),
+)
+
+const featureCards = computed(() =>
+  localTextArray(
+    [
+      {
+        index: '01',
+        title: '极速接入',
+        copy: '优化过的网关入口和兼容 API 路由，让现有 OpenAI 工作流更快迁移过来。',
+        tags: ['OpenAI', 'Claude', 'Gemini'],
+      },
+      {
+        index: '02',
+        title: '安全可靠',
+        copy: '统一身份、分组、额度和日志边界，避免把权限散落在多个系统。',
+        tags: ['权限', '配额', '审计'],
+      },
+      {
+        index: '03',
+        title: '全球覆盖',
+        copy: '多上游接入、自动回退和统一状态视图，支持稳定的跨区域访问。',
+        tags: ['负载均衡', '回退', '监控'],
+      },
+      {
+        index: '04',
+        title: '开发者友好',
+        copy: '文档、模型广场、代码示例和控制台保持同一套产品语言，减少学习成本。',
+        tags: ['API', 'SDK', 'CLI'],
+      },
+    ],
+    [
+      {
+        index: '01',
+        title: 'Fast integration',
+        copy: 'An optimized gateway surface and compatible API routes make existing OpenAI workflows easier to migrate.',
+        tags: ['OpenAI', 'Claude', 'Gemini'],
+      },
+      {
+        index: '02',
+        title: 'Secure and reliable',
+        copy: 'Keep identity, groups, quotas, and logs behind one boundary instead of scattering permissions across systems.',
+        tags: ['RBAC', 'Quota', 'Audit'],
+      },
+      {
+        index: '03',
+        title: 'Global coverage',
+        copy: 'Multi-upstream access, automatic fallback, and one status view support reliable cross-region delivery.',
+        tags: ['Load balancing', 'Failover', 'Monitoring'],
+      },
+      {
+        index: '04',
+        title: 'Developer-friendly',
+        copy: 'Docs, catalog, code samples, and console share one product language so the platform is easier to operate.',
+        tags: ['API', 'SDK', 'CLI'],
+      },
+    ],
+  ),
+)
+
+const workflowSteps = computed(() =>
+  localTextArray(
+    [
+      {
+        index: '1',
+        title: '配置',
+        copy: '添加 API 密钥，接入上游服务，并设置路由和访问策略。',
+      },
+      {
+        index: '2',
+        title: '连接',
+        copy: '通过 OpenAI 兼容接口、Claude、Gemini 等工作流开始接入。',
+      },
+      {
+        index: '3',
+        title: '监控',
+        copy: '通过统一的用量、成本、状态和日志视图跟踪运行情况。',
+      },
+    ],
+    [
+      {
+        index: '1',
+        title: 'Configure',
+        copy: 'Add API keys, connect upstream services, and define routing plus access policies.',
+      },
+      {
+        index: '2',
+        title: 'Connect',
+        copy: 'Connect through OpenAI-compatible endpoints, Claude, Gemini, and related workflows.',
+      },
+      {
+        index: '3',
+        title: 'Monitor',
+        copy: 'Track usage, cost, health, and logs from one shared operational view.',
+      },
+    ],
+  ),
+)
+
+const providers = computed(() =>
+  localTextArray(
+    [
+      { initial: 'C', name: 'Claude', status: 'Supported', copy: '高质量通用模型，适合复杂推理与代码工作流。', color: 'linear-gradient(135deg,#fb923c 0%,#f97316 100%)' },
+      { initial: 'G', name: 'GPT', status: 'Supported', copy: '覆盖广泛的 OpenAI 兼容调用场景，适合标准客户端接入。', color: 'linear-gradient(135deg,#22c55e 0%,#16a34a 100%)' },
+      { initial: 'G', name: 'Gemini', status: 'Supported', copy: '适合多模态与 Google 生态工作流的统一接入。', color: 'linear-gradient(135deg,#3b82f6 0%,#2563eb 100%)' },
+      { initial: 'A', name: 'Anthropic / More', status: 'Expandable', copy: '继续扩展更多上游与模型，保持统一路由和治理方式。', color: 'linear-gradient(135deg,#8b5cf6 0%,#7c3aed 100%)' },
+    ],
+    [
+      { initial: 'C', name: 'Claude', status: 'Supported', copy: 'High-quality general-purpose models for reasoning-heavy and coding workflows.', color: 'linear-gradient(135deg,#fb923c 0%,#f97316 100%)' },
+      { initial: 'G', name: 'GPT', status: 'Supported', copy: 'Wide OpenAI-compatible coverage for mainstream clients and application flows.', color: 'linear-gradient(135deg,#22c55e 0%,#16a34a 100%)' },
+      { initial: 'G', name: 'Gemini', status: 'Supported', copy: 'Unified access for multimodal use cases and Google-oriented workflows.', color: 'linear-gradient(135deg,#3b82f6 0%,#2563eb 100%)' },
+      { initial: 'A', name: 'Anthropic / More', status: 'Expandable', copy: 'Extend to more upstreams and models while preserving one routing and governance layer.', color: 'linear-gradient(135deg,#8b5cf6 0%,#7c3aed 100%)' },
+    ],
+  ),
+)
+
+function localText(zh: string, en: string): string {
+  return locale.value.startsWith('zh') ? zh : en
+}
+
+function localTextArray<T>(zh: T, en: T): T {
+  return locale.value.startsWith('zh') ? zh : en
+}
+
 function toggleTheme() {
   isDark.value = !isDark.value
   document.documentElement.classList.toggle('dark', isDark.value)
   localStorage.setItem('theme', isDark.value ? 'dark' : 'light')
 }
 
-// Initialize theme
 function initTheme() {
   const savedTheme = localStorage.getItem('theme')
-  if (
-    savedTheme === 'dark' ||
-    (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)
-  ) {
+  if (savedTheme === 'dark' || (!savedTheme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
     isDark.value = true
     document.documentElement.classList.add('dark')
   }
@@ -469,176 +711,9 @@ function initTheme() {
 
 onMounted(() => {
   initTheme()
-
-  // Check auth state
   authStore.checkAuth()
-
-  // Ensure public settings are loaded (will use cache if already loaded from injected config)
   if (!appStore.publicSettingsLoaded) {
     appStore.fetchPublicSettings()
   }
 })
 </script>
-
-<style scoped>
-/* Terminal Container */
-.terminal-container {
-  position: relative;
-  display: inline-block;
-}
-
-/* Terminal Window */
-.terminal-window {
-  width: 420px;
-  background: linear-gradient(145deg, #1e293b 0%, #0f172a 100%);
-  border-radius: 14px;
-  box-shadow:
-    0 25px 50px -12px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(255, 255, 255, 0.1),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  overflow: hidden;
-  transform: perspective(1000px) rotateX(2deg) rotateY(-2deg);
-  transition: transform 0.3s ease;
-}
-
-.terminal-window:hover {
-  transform: perspective(1000px) rotateX(0deg) rotateY(0deg) translateY(-4px);
-}
-
-/* Terminal Header */
-.terminal-header {
-  display: flex;
-  align-items: center;
-  padding: 12px 16px;
-  background: rgba(30, 41, 59, 0.8);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
-}
-
-.terminal-buttons {
-  display: flex;
-  gap: 8px;
-}
-
-.terminal-buttons span {
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-}
-
-.btn-close {
-  background: #ef4444;
-}
-.btn-minimize {
-  background: #eab308;
-}
-.btn-maximize {
-  background: #22c55e;
-}
-
-.terminal-title {
-  flex: 1;
-  text-align: center;
-  font-size: 12px;
-  font-family: ui-monospace, monospace;
-  color: #64748b;
-  margin-right: 52px;
-}
-
-/* Terminal Body */
-.terminal-body {
-  padding: 20px 24px;
-  font-family: ui-monospace, 'Fira Code', monospace;
-  font-size: 14px;
-  line-height: 2;
-}
-
-.code-line {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  opacity: 0;
-  animation: line-appear 0.5s ease forwards;
-}
-
-.line-1 {
-  animation-delay: 0.3s;
-}
-.line-2 {
-  animation-delay: 1s;
-}
-.line-3 {
-  animation-delay: 1.8s;
-}
-.line-4 {
-  animation-delay: 2.5s;
-}
-
-@keyframes line-appear {
-  from {
-    opacity: 0;
-    transform: translateY(5px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.code-prompt {
-  color: #22c55e;
-  font-weight: bold;
-}
-.code-cmd {
-  color: #38bdf8;
-}
-.code-flag {
-  color: #a78bfa;
-}
-.code-url {
-  color: #14b8a6;
-}
-.code-comment {
-  color: #64748b;
-  font-style: italic;
-}
-.code-success {
-  color: #22c55e;
-  background: rgba(34, 197, 94, 0.15);
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-weight: 600;
-}
-.code-response {
-  color: #fbbf24;
-}
-
-/* Blinking Cursor */
-.cursor {
-  display: inline-block;
-  width: 8px;
-  height: 16px;
-  background: #22c55e;
-  animation: blink 1s step-end infinite;
-}
-
-@keyframes blink {
-  0%,
-  50% {
-    opacity: 1;
-  }
-  51%,
-  100% {
-    opacity: 0;
-  }
-}
-
-/* Dark mode adjustments */
-:deep(.dark) .terminal-window {
-  box-shadow:
-    0 25px 50px -12px rgba(0, 0, 0, 0.6),
-    0 0 0 1px rgba(20, 184, 166, 0.2),
-    0 0 40px rgba(20, 184, 166, 0.1),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-}
-</style>


### PR DESCRIPTION
## Summary
- rebuild the homepage into a WanAPIs-style unified AI API gateway landing page
- add a dedicated /en homepage route and keep locale switching aligned with /home and /en
- update the public entry flow so backend mode still allows the homepage routes

## Verification
- npm run typecheck
- npm run build
- local preview responded on /home and /en
