### PR TITLE
fix(usage): revert OpenAI 5h used_percent inversion (#2918 regression)

### DIFF
--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -132,7 +132,7 @@ func TestAccountTestService_OpenAISuccessPersistsSnapshotFromHeaders(t *testing.
 	require.Len(t, upstream.requests, 1)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.requests[0].Context()))
 	require.NotEmpty(t, repo.updatedExtra)
-	require.Equal(t, 58.0, repo.updatedExtra["codex_5h_used_percent"])
+	require.Equal(t, 42.0, repo.updatedExtra["codex_5h_used_percent"])
 	require.Equal(t, 88.0, repo.updatedExtra["codex_7d_used_percent"])
 	require.Contains(t, recorder.Body.String(), "test_complete")
 }
@@ -170,7 +170,7 @@ func TestAccountTestService_OpenAI429PersistsSnapshotAndRateLimitState(t *testin
 	resp.Header.Set("x-codex-primary-used-percent", "100")
 	resp.Header.Set("x-codex-primary-reset-after-seconds", "604800")
 	resp.Header.Set("x-codex-primary-window-minutes", "10080")
-	resp.Header.Set("x-codex-secondary-used-percent", "0")
+	resp.Header.Set("x-codex-secondary-used-percent", "100")
 	resp.Header.Set("x-codex-secondary-reset-after-seconds", "18000")
 	resp.Header.Set("x-codex-secondary-window-minutes", "300")
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -73,7 +73,7 @@ func TestExtractOpenAICodexProbeUpdatesAccepts429WithCodexHeaders(t *testing.T) 
 	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "604800")
 	headers.Set("x-codex-primary-window-minutes", "10080")
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
@@ -89,33 +89,6 @@ func TestExtractOpenAICodexProbeUpdatesAccepts429WithCodexHeaders(t *testing.T) 
 	}
 	if got := updates["codex_7d_used_percent"]; got != 100.0 {
 		t.Fatalf("codex_7d_used_percent = %v, want 100", got)
-	}
-}
-
-func TestBuildCodexUsageProgressFromExtra_UsesCanonicalUsedPercent(t *testing.T) {
-	t.Parallel()
-	now := time.Date(2026, 5, 30, 7, 4, 9, 0, time.UTC)
-	extra := map[string]any{
-		"codex_5h_used_percent": 94.0,
-		"codex_5h_reset_at":     now.Add(2 * time.Hour).Format(time.RFC3339),
-		"codex_7d_used_percent": 93.0,
-		"codex_7d_reset_at":     now.Add(5 * 24 * time.Hour).Format(time.RFC3339),
-	}
-
-	fiveHour := buildCodexUsageProgressFromExtra(extra, "5h", now)
-	if fiveHour == nil {
-		t.Fatal("expected non-nil 5h progress")
-	}
-	if fiveHour.Utilization != 94.0 {
-		t.Fatalf("5h Utilization = %v, want 94", fiveHour.Utilization)
-	}
-
-	sevenDay := buildCodexUsageProgressFromExtra(extra, "7d", now)
-	if sevenDay == nil {
-		t.Fatal("expected non-nil 7d progress")
-	}
-	if sevenDay.Utilization != 93.0 {
-		t.Fatalf("7d Utilization = %v, want 93", sevenDay.Utilization)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -126,19 +126,6 @@ type NormalizedCodexLimits struct {
 	Window7dMinutes *int
 }
 
-func normalizeCodexFiveHourUsedPercent(raw *float64) *float64 {
-	if raw == nil {
-		return nil
-	}
-	// OpenAI's 5h Codex quota header is remaining%, despite the upstream header
-	// name saying "used"; the canonical codex_5h_used_percent field stores used%.
-	used := 100 - *raw
-	if used < 0 {
-		used = 0
-	}
-	return &used
-}
-
 // Normalize converts primary/secondary fields to canonical 5h/7d fields.
 // Strategy: Compare window_minutes to determine which is 5h vs 7d.
 // Returns nil if snapshot is nil or has no useful data.
@@ -197,7 +184,7 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 
 	// Assign values
 	if use5hFromPrimary {
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.PrimaryUsedPercent)
+		result.Used5hPercent = s.PrimaryUsedPercent
 		result.Reset5hSeconds = s.PrimaryResetAfterSeconds
 		result.Window5hMinutes = s.PrimaryWindowMinutes
 		result.Used7dPercent = s.SecondaryUsedPercent
@@ -207,7 +194,7 @@ func (s *OpenAICodexUsageSnapshot) Normalize() *NormalizedCodexLimits {
 		result.Used7dPercent = s.PrimaryUsedPercent
 		result.Reset7dSeconds = s.PrimaryResetAfterSeconds
 		result.Window7dMinutes = s.PrimaryWindowMinutes
-		result.Used5hPercent = normalizeCodexFiveHourUsedPercent(s.SecondaryUsedPercent)
+		result.Used5hPercent = s.SecondaryUsedPercent
 		result.Reset5hSeconds = s.SecondaryResetAfterSeconds
 		result.Window5hMinutes = s.SecondaryWindowMinutes
 	}

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -104,40 +104,6 @@ func TestBuildCodexUsageExtraUpdates_UsesSnapshotUpdatedAt(t *testing.T) {
 	}
 }
 
-func TestBuildCodexUsageExtraUpdates_NormalizesFiveHourRemainingToUsedPercent(t *testing.T) {
-	primaryUsed := 93.0
-	primaryReset := 86400
-	primaryWindow := 10080
-	secondaryRemaining := 6.0
-	secondaryReset := 3600
-	secondaryWindow := 300
-
-	snapshot := &OpenAICodexUsageSnapshot{
-		PrimaryUsedPercent:         &primaryUsed,
-		PrimaryResetAfterSeconds:   &primaryReset,
-		PrimaryWindowMinutes:       &primaryWindow,
-		SecondaryUsedPercent:       &secondaryRemaining,
-		SecondaryResetAfterSeconds: &secondaryReset,
-		SecondaryWindowMinutes:     &secondaryWindow,
-		UpdatedAt:                  "2026-05-30T07:04:09Z",
-	}
-
-	updates := buildCodexUsageExtraUpdates(snapshot, time.Time{})
-	if updates == nil {
-		t.Fatal("expected non-nil updates")
-	}
-
-	if got := updates["codex_secondary_used_percent"]; got != 6.0 {
-		t.Fatalf("codex_secondary_used_percent = %v, want raw upstream value 6", got)
-	}
-	if got := updates["codex_5h_used_percent"]; got != 94.0 {
-		t.Fatalf("codex_5h_used_percent = %v, want 94", got)
-	}
-	if got := updates["codex_7d_used_percent"]; got != 93.0 {
-		t.Fatalf("codex_7d_used_percent = %v, want 93", got)
-	}
-}
-
 func TestBuildCodexUsageExtraUpdates_FallbackToNowWhenUpdatedAtInvalid(t *testing.T) {
 	primaryUsed := 15.0
 	primaryReset := 30

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1774,7 +1774,7 @@ func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 
 	select {
 	case updates := <-repo.updateExtraCalls:
-		require.Equal(t, 88.0, updates["codex_5h_used_percent"])
+		require.Equal(t, 12.0, updates["codex_5h_used_percent"])
 		require.Equal(t, 34.0, updates["codex_7d_used_percent"])
 		require.Equal(t, 600, updates["codex_5h_reset_after_seconds"])
 		require.Equal(t, 86400, updates["codex_7d_reset_after_seconds"])

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -51,7 +51,7 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 	headers.Set("x-codex-primary-used-percent", "50")
 	headers.Set("x-codex-primary-reset-after-seconds", "500000")
 	headers.Set("x-codex-primary-window-minutes", "10080") // 7 days
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-secondary-window-minutes", "300")       // 5 hours
 
@@ -122,7 +122,7 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 	// Test when OpenAI sends primary as 5h and secondary as 7d (reversed)
 	headers := http.Header{}
-	headers.Set("x-codex-primary-used-percent", "0")           // This is 5h remaining%
+	headers.Set("x-codex-primary-used-percent", "100")         // This is 5h
 	headers.Set("x-codex-primary-reset-after-seconds", "3600") // 1 hour
 	headers.Set("x-codex-primary-window-minutes", "300")       // 5 hours - smaller!
 	headers.Set("x-codex-secondary-used-percent", "50")
@@ -180,7 +180,7 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	headers.Set("x-codex-primary-used-percent", "100")
 	headers.Set("x-codex-primary-reset-after-seconds", "604800")
 	headers.Set("x-codex-primary-window-minutes", "10080")
-	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "100")
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
@@ -224,7 +224,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	pUsed := 100.0
 	pReset := 384607
 	pWindow := 10080
-	sRemaining := 3.0
+	sUsed := 3.0
 	sReset := 17369
 	sWindow := 300
 
@@ -232,7 +232,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 		PrimaryUsedPercent:         &pUsed,
 		PrimaryResetAfterSeconds:   &pReset,
 		PrimaryWindowMinutes:       &pWindow,
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		SecondaryWindowMinutes:     &sWindow,
 	}
@@ -249,8 +249,8 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 384607 {
 		t.Errorf("expected Reset7dSeconds=384607, got %v", normalized.Reset7dSeconds)
 	}
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 97.0 {
-		t.Errorf("expected Used5hPercent=97, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 3.0 {
+		t.Errorf("expected Used5hPercent=3, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 17369 {
 		t.Errorf("expected Reset5hSeconds=17369, got %v", normalized.Reset5hSeconds)
@@ -338,11 +338,11 @@ func TestRateLimitService_HandleUpstreamError_403FallsBackToRawBody(t *testing.T
 
 func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 	// Test when only secondary has data, no window_minutes
-	sRemaining := 60.0
+	sUsed := 60.0
 	sReset := 3000
 
 	snapshot := &OpenAICodexUsageSnapshot{
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		// No window_minutes, no primary data
 	}
@@ -354,8 +354,8 @@ func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 
 	// Legacy assumption: primary=7d, secondary=5h
 	// So secondary goes to 5h
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 40.0 {
-		t.Errorf("expected Used5hPercent=40, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 60.0 {
+		t.Errorf("expected Used5hPercent=60, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 3000 {
 		t.Errorf("expected Reset5hSeconds=3000, got %v", normalized.Reset5hSeconds)
@@ -370,13 +370,13 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	// Test when both have data but no window_minutes
 	pUsed := 100.0
 	pReset := 400000
-	sRemaining := 30.0
+	sUsed := 50.0
 	sReset := 10000
 
 	snapshot := &OpenAICodexUsageSnapshot{
 		PrimaryUsedPercent:         &pUsed,
 		PrimaryResetAfterSeconds:   &pReset,
-		SecondaryUsedPercent:       &sRemaining,
+		SecondaryUsedPercent:       &sUsed,
 		SecondaryResetAfterSeconds: &sReset,
 		// No window_minutes
 	}
@@ -393,8 +393,8 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	if normalized.Reset7dSeconds == nil || *normalized.Reset7dSeconds != 400000 {
 		t.Errorf("expected Reset7dSeconds=400000, got %v", normalized.Reset7dSeconds)
 	}
-	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 70.0 {
-		t.Errorf("expected Used5hPercent=70, got %v", normalized.Used5hPercent)
+	if normalized.Used5hPercent == nil || *normalized.Used5hPercent != 50.0 {
+		t.Errorf("expected Used5hPercent=50, got %v", normalized.Used5hPercent)
 	}
 	if normalized.Reset5hSeconds == nil || *normalized.Reset5hSeconds != 10000 {
 		t.Errorf("expected Reset5hSeconds=10000, got %v", normalized.Reset5hSeconds)
@@ -425,7 +425,7 @@ func TestCalculateOpenAI429ResetTime_UserProvidedScenario(t *testing.T) {
 	// This is the exact scenario from the user:
 	// codex_7d_used_percent: 100
 	// codex_7d_reset_after_seconds: 384607 (约4.5天后重置)
-	// codex_5h_used_percent: 97 (from upstream 3% remaining)
+	// codex_5h_used_percent: 3
 	// codex_5h_reset_after_seconds: 17369 (约4.8小时后重置)
 
 	svc := &RateLimitService{}


### PR DESCRIPTION
## 背景

[PR #2918](https://github.com/Wei-Shaw/sub2api/pull/2918) 基于 [issue #2904](https://github.com/Wei-Shaw/sub2api/issues/2904) 的误判，在 \`OpenAICodexUsageSnapshot.Normalize()\` 里把 5h 窗口加了一层 \`used = 100 - raw\` 反转。这次 revert 是把它撤回。

## 为什么 #2918 是错的

OpenAI Codex 官方仓库 [\`codex-rs/protocol/src/protocol.rs\`](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs) 里 \`RateLimitWindow\` 的定义：

\`\`\`rust
pub struct RateLimitWindow {
    /// Percentage (0-100) of the window that has been consumed.
    pub used_percent: f64,
    ...
}
\`\`\`

注释明确写 **\"that has been consumed\"**，即上游 \`x-codex-primary-used-percent\` / \`x-codex-secondary-used-percent\` 两个 header 都是**已用%**，primary（5h）和 secondary（7d）语义一致，没有不对称。

#2918 引用的 issue #2904 对比表：

| 窗口 | OpenAI App | Sub2API |
|---|---|---|
| 5h | 6% **remaining** | 6% |
| 7d | 7% remaining → 93% **used** | 93% |

报告者把 OpenAI App 的 **remaining%** 直接跟 sub2api 的 **used%** 对数字比较，看到都是 6 就判定反了。但他自己 7d 那一行就是反例：app remaining 7% → used 93%，sub2api 显示 93%（used），他认可正确；同一套逻辑套到 5h 上也成立：app remaining 6% → used 94%，sub2api 显示 94%（used）就是对的。两个窗口本来就都是 used%。

## 现网现象

反转合入后，所有活跃 OpenAI OAuth 账号的 5h 窗口被显示成 96~99% 高位：

| 账号 | 5h 显示 | 5h 实际 req/token | 7d 显示（未反转） |
|---|---|---|---|
| acct-A | **99%** | 55 req / 1.7M | 2% |
| acct-B | **96%** | 239 req / 13.8M | 8% |
| acct-C | **96%** | 196 req / 12.2M | 3% |
| acct-D | **99%** | 93 req / 4.4M | 2% |

5h 的高位显示跟实际请求量、跟 7d 完全对不上。请求仍能正常通过，因为上游真实 used% 才 1~4%，远没触发 429；后端只在收到 429 时才会 pause。

如果 #2873 引入的 5h auto-pause 阈值设得低（比如 95%），会因为这个反转误暂停大量健康账号。

## 改动

\`git revert b65dde634bf7a5338f22b46ad0f9d98a197526fc\`，机械对称还原 PR #2918 的 6 个文件、22 行加 / 96 行删。包含：

- 删除 \`normalizeCodexFiveHourUsedPercent\` 函数
- 恢复 \`Normalize()\` 里 5h 字段直接透传 \`PrimaryUsedPercent\` / \`SecondaryUsedPercent\`
- 还原所有相关测试（\`ratelimit_service_openai_test.go\` / \`openai_gateway_service_codex_snapshot_test.go\` / \`account_usage_service_test.go\` 等）回 PR #2918 之前的期望值

## 测试

revert 是机械对称操作，测试一并还原到 PR #2918 之前的状态——那时这些测试在主线 CI 上是绿的。本地无 Go 环境，烦请上游 CI 跑一次。

如有需要进一步保险，建议合入后任选一个活跃 Codex 账号抓一次响应头，对比 \`x-codex-secondary-used-percent\` 原值和 \`codex_5h_used_percent\` 落库值，确认两者相等。

## 关联

- Reverts: #2918
- Re-opens: #2904（需要按官方语义重新评估，可能直接 close as not-a-bug）