### PR TITLE
fix: treat allowed proxy quality statuses as pass not warn

### DIFF
--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -3339,12 +3339,13 @@ func runProxyQualityTarget(ctx context.Context, client *http.Client, target prox
 	}
 
 	if _, ok := target.AllowedStatuses[resp.StatusCode]; ok {
+		// 白名单内的状态码均代表目标可达：2xx 表示接口直接可用，
+		// 401/405 等是无鉴权探测的预期结果，同样视为连通正常，不再扣分。
+		item.Status = "pass"
 		if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
-			item.Status = "pass"
 			item.Message = fmt.Sprintf("HTTP %d", resp.StatusCode)
 		} else {
-			item.Status = "warn"
-			item.Message = fmt.Sprintf("HTTP %d（目标可达，但鉴权或方法受限）", resp.StatusCode)
+			item.Message = fmt.Sprintf("HTTP %d（目标可达）", resp.StatusCode)
 		}
 		return item
 	}

--- a/backend/internal/service/admin_service_proxy_quality_test.go
+++ b/backend/internal/service/admin_service_proxy_quality_test.go
@@ -72,7 +72,7 @@ func TestRunProxyQualityTarget_AllowedStatusPass(t *testing.T) {
 	require.Equal(t, http.StatusOK, item.HTTPStatus)
 }
 
-func TestRunProxyQualityTarget_AllowedStatusWarnForUnauthorized(t *testing.T) {
+func TestRunProxyQualityTarget_AllowedStatusPassForUnauthorized(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
@@ -89,7 +89,7 @@ func TestRunProxyQualityTarget_AllowedStatusWarnForUnauthorized(t *testing.T) {
 	}
 
 	item := runProxyQualityTarget(context.Background(), server.Client(), target)
-	require.Equal(t, "warn", item.Status)
+	require.Equal(t, "pass", item.Status)
 	require.Equal(t, http.StatusUnauthorized, item.HTTPStatus)
 	require.Contains(t, item.Message, "目标可达")
 }


### PR DESCRIPTION
## 代理质量检测里 401/405 不该算告警
  - OpenAI 没 key 必然返 401
  - Anthropic 用 GET 打 /v1/messages 必然返 405
  - Gemini 那个是公开文档接口，返 200
  所以正常的代理 只要能通 就应该显示通过, 不应该显示告警, 会让人误以为代理有问题

  ## 效果
    健康代理的 OpenAI / Anthropic 两项会从黄色"告警"变成绿色"通过"，告警数归零，分数回到 100 / A。前端不用改。

正常代理测试:

修改前:
<img width="1060" height="1014" alt="image" src="https://github.com/user-attachments/assets/3e2b55fb-6f9f-458e-871d-ffb6284de214" />

修改后:
<img width="1044" height="1034" alt="image" src="https://github.com/user-attachments/assets/e1980fb7-0d12-44a7-95fe-bd4e741ad643" />
