### PR TITLE
chore: bump Go patch version to 1.26.4

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Unit tests
         working-directory: backend
         run: make test-unit
@@ -60,7 +60,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
 
       # Docker setup for GoReleaser
       - name: Set up QEMU

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.3'
+          go version | grep -q 'go1.26.4'
       - name: Run govulncheck
         working-directory: backend
         run: |

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/Wei-Shaw/sub2api
 
-go 1.26.3
+go 1.26.4
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
## Summary
- bump the backend Go directive from 1.26.3 to 1.26.4
- update CI, security scan, and release workflow version assertions to expect go1.26.4

The current backend security scan fails under Go 1.26.3 because `govulncheck` reports standard-library vulnerabilities GO-2026-5039 and GO-2026-5037, both fixed in Go 1.26.4.

## Tests
- `GOTOOLCHAIN=go1.26.4 go version`
- `GOTOOLCHAIN=go1.26.4 go test ./internal/handler -run TestOpenAIHandler_GjsonExtraction -count=1`
- `GOTOOLCHAIN=go1.26.4 $(go env GOPATH)/bin/govulncheck ./...`
