### PR TITLE
fix(apicompat): surface reasoning-only chat streams

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -787,6 +787,7 @@ func FinalizeChatCompletionsResponsesStream(state *ChatCompletionsToResponsesStr
 	// Close a reasoning item that never transitioned to content (reasoning-only
 	// or empty completion).
 	events = append(events, closeChatReasoningItem(state)...)
+	events = append(events, synthesizeChatReasoningFallbackMessage(state)...)
 
 	if state.MessageItemID != "" {
 		if state.TextPartOpen {
@@ -915,6 +916,33 @@ func closeChatReasoningItem(state *ChatCompletionsToResponsesStreamState) []Resp
 			},
 		}),
 	}
+}
+
+func synthesizeChatReasoningFallbackMessage(state *ChatCompletionsToResponsesStreamState) []ResponsesStreamEvent {
+	if state == nil ||
+		state.MessageItemID != "" ||
+		state.Text.Len() > 0 ||
+		state.Reasoning.Len() == 0 ||
+		len(state.ToolCalls) > 0 {
+		return nil
+	}
+
+	text := state.Reasoning.String()
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+
+	var events []ResponsesStreamEvent
+	events = append(events, ensureChatToResponsesMessageItem(state)...)
+	events = append(events, ensureChatToResponsesTextPart(state)...)
+	_, _ = state.Text.WriteString(text)
+	events = append(events, chatToResponsesEvent(state, "response.output_text.delta", &ResponsesStreamEvent{
+		OutputIndex:  state.MessageIndex,
+		ContentIndex: 0,
+		Delta:        text,
+		ItemID:       state.MessageItemID,
+	}))
+	return events
 }
 
 func ensureChatToResponsesMessageItem(state *ChatCompletionsToResponsesStreamState) []ResponsesStreamEvent {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
@@ -79,6 +79,106 @@ func TestStream_ToolCallLifecycleComplete(t *testing.T) {
 	require.True(t, sawItemDone, "function_call output_item.done missing")
 }
 
+func TestStream_ReasoningOnlySynthesizesVisibleText(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"role":"assistant","content":null,"reasoning_content":""}}]}`,
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"thinking before final"}}]}`,
+		`{"choices":[{"index":0,"delta":{"content":""},"finish_reason":"length"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+	})
+
+	open := map[int]string{}
+	var sawTextDelta, sawTextDone, sawMessageDone bool
+	for _, e := range events {
+		switch e.Type {
+		case "response.output_item.added":
+			require.NotNil(t, e.Item)
+			open[e.OutputIndex] = e.Item.Type
+		case "response.output_text.delta":
+			sawTextDelta = true
+			require.Equalf(t, "message", open[e.OutputIndex], "fallback text delta before its item was opened")
+			require.Equal(t, "thinking before final", e.Delta)
+		case "response.output_text.done":
+			sawTextDone = true
+			require.Equal(t, "thinking before final", e.Text)
+		case "response.output_item.done":
+			if e.Item != nil && e.Item.Type == "message" {
+				sawMessageDone = true
+				require.Equal(t, "thinking before final", e.Item.Content[0].Text)
+			}
+		case "response.completed":
+			require.NotNil(t, e.Response)
+			require.Equal(t, "incomplete", e.Response.Status)
+			require.NotNil(t, e.Response.IncompleteDetails)
+			require.Equal(t, "max_output_tokens", e.Response.IncompleteDetails.Reason)
+			require.Len(t, e.Response.Output, 2)
+			require.Equal(t, "reasoning", e.Response.Output[0].Type)
+			require.Equal(t, "message", e.Response.Output[1].Type)
+			require.Equal(t, "thinking before final", e.Response.Output[1].Content[0].Text)
+		}
+	}
+	require.True(t, sawTextDelta, "reasoning-only stream must produce visible text delta")
+	require.True(t, sawTextDone, "reasoning-only stream must close visible text part")
+	require.True(t, sawMessageDone, "reasoning-only stream must close synthesized message item")
+}
+
+func TestStream_ReasoningOnlyBlankDoesNotSynthesizeVisibleText(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"   "}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+	})
+
+	for _, e := range events {
+		require.NotEqual(t, "response.output_text.delta", e.Type)
+		if e.Type == "response.completed" {
+			require.NotNil(t, e.Response)
+			require.Len(t, e.Response.Output, 2)
+			require.Equal(t, "reasoning", e.Response.Output[0].Type)
+			require.Equal(t, "message", e.Response.Output[1].Type)
+			require.Equal(t, "", e.Response.Output[1].Content[0].Text)
+		}
+	}
+}
+
+func TestStream_ReasoningThenContentDoesNotDuplicateFallbackText(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"private plan"}}]}`,
+		`{"choices":[{"index":0,"delta":{"content":"final answer"}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+	})
+
+	var textDeltas []string
+	for _, e := range events {
+		switch e.Type {
+		case "response.output_text.delta":
+			textDeltas = append(textDeltas, e.Delta)
+		case "response.completed":
+			require.NotNil(t, e.Response)
+			require.Len(t, e.Response.Output, 2)
+			require.Equal(t, "private plan", e.Response.Output[0].Summary[0].Text)
+			require.Equal(t, "final answer", e.Response.Output[1].Content[0].Text)
+		}
+	}
+	require.Equal(t, []string{"final answer"}, textDeltas)
+}
+
+func TestStream_ReasoningThenToolCallDoesNotSynthesizeVisibleText(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"call a tool"}}]}`,
+		`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"exec","arguments":"{}"}}]}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	})
+
+	for _, e := range events {
+		require.NotEqual(t, "response.output_text.delta", e.Type)
+		if e.Type == "response.completed" {
+			require.NotNil(t, e.Response)
+			require.Len(t, e.Response.Output, 2)
+			require.Equal(t, "reasoning", e.Response.Output[0].Type)
+			require.Equal(t, "function_call", e.Response.Output[1].Type)
+		}
+	}
+}
+
 // TestStream_SSEWireComplete drives the full stream through SSE encoding and
 // asserts the function_call events carry complete fields on the wire.
 func TestStream_SSEWireComplete(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix Chat Completions -> Responses streaming compatibility for DeepSeek-backed models when the stream has reasoning output but no visible content.

In this case the bridge used to close a Responses `reasoning` item but never create a visible `message` / `response.output_text.*` item, so Codex clients could receive a successful stream that still looked blank.

This patch synthesizes a visible fallback message from collected reasoning text only when all of these are true at stream finalization:

- no message item exists
- no visible text has been emitted
- reasoning text is non-blank
- no tool calls are present

Normal content streams and tool-call streams are unchanged.

## Real sub2api SSE sample

Captured from a real sub2api `/v1/responses` streaming request routed to a DeepSeek-backed model, redacted and minimized.

Request shape:

```json
{
  "model": "deepseek-v4-flash",
  "input": "只回复 pong",
  "stream": true,
  "max_output_tokens": 8,
  "reasoning": { "effort": "medium" }
}

Observed summary after this patch:
responses_output_text_delta=2
responses_reasoning_items=2
responses_message_items=2
responses_completed=1

Relevant SSE excerpt:
event: response.output_item.added
data: {"item":{"id":"<redacted>","status":"in_progress","summary":[],"type":"reasoning"},"output_index":0,"type":"response.output_item.added"}

event: response.reasoning_summary_text.delta
data: {"delta":"<reasoning delta>","item_id":"<redacted>","output_index":0,"summary_index":0,"type":"response.reasoning_summary_text.delta"}

event: response.output_item.done
data: {"item":{"id":"<redacted>","status":"completed","summary":[{"text":"<reasoning text>","type":"summary_text"}],"type":"reasoning"},"output_index":0,"type":"response.output_item.done"}

event: response.output_item.added
data: {"item":{"content":[{"text":"<fallback visible text>","type":"output_text"}],"id":"<redacted>","role":"assistant","status":"in_progress","type":"message"},"output_index":1,"type":"response.output_item.added"}

event: response.output_text.delta
data: {"content_index":0,"delta":"<fallback visible text delta>","item_id":"<redacted>","output_index":1,"type":"response.output_text.delta"}

event: response.output_text.done
data: {"content_index":0,"item_id":"<redacted>","output_index":1,"text":"<fallback visible text>","type":"response.output_text.done"}

event: response.completed
data: {"type":"response.completed","response":{"id":"<redacted>","object":"response","model":"deepseek-v4-flash","status":"completed","output":[{"type":"reasoning","id":"<redacted>","summary":[{"type":"summary_text","text":"<reasoning text>"}]},{"type":"message","id":"<redacted>","role":"assistant","content":[{"type":"output_text","text":"<fallback visible text>"}],"status":"completed"}]}}

Tests
Added lifecycle coverage for:
reasoning-only stream synthesizes visible text
blank reasoning does not synthesize visible text
normal content after reasoning does not duplicate fallback text
tool-call streams do not synthesize fallback visible text

Verified:
go test ./internal/pkg/apicompat -count=1
Note: I kept this PR scoped to the Chat Completions -> Responses bridge. On my local Windows environment, full go test ./... still exposes an unrelated existing internal/service WebSocket large-frame test issue, so I did not mix that fix into this PR.