### PR TITLE
feat: OpenAI 账户调度增加剩余周限额度权重

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -955,6 +955,11 @@ type GatewayOpenAIWSSchedulerScoreWeights struct {
 	Queue     float64 `mapstructure:"queue"`
 	ErrorRate float64 `mapstructure:"error_rate"`
 	TTFT      float64 `mapstructure:"ttft"`
+	// RemainingUsage 七日(7d)剩余用量权重：剩余越多得分越高。
+	// 仅在 RemainingUsageEnabled=true 时参与打分。
+	RemainingUsage float64 `mapstructure:"remaining_usage"`
+	// RemainingUsageEnabled 是否让“七日剩余用量”参与调度打分，默认关闭。
+	RemainingUsageEnabled bool `mapstructure:"remaining_usage_enabled"`
 }
 
 // GatewayUsageRecordConfig 使用量记录异步队列配置
@@ -1849,6 +1854,8 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.queue", 0.7)
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.error_rate", 0.8)
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.ttft", 0.5)
+	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.remaining_usage", 1.0)
+	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.remaining_usage_enabled", false)
 	// OpenAI HTTP upstream protocol strategy
 	viper.SetDefault("gateway.openai_http2.enabled", true)
 	viper.SetDefault("gateway.openai_http2.allow_proxy_fallback_to_http1", true)
@@ -2624,7 +2631,8 @@ func (c *Config) Validate() error {
 		c.Gateway.OpenAIWS.SchedulerScoreWeights.Load < 0 ||
 		c.Gateway.OpenAIWS.SchedulerScoreWeights.Queue < 0 ||
 		c.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate < 0 ||
-		c.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT < 0 {
+		c.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT < 0 ||
+		c.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsage < 0 {
 		return fmt.Errorf("gateway.openai_ws.scheduler_score_weights.* must be non-negative")
 	}
 	weightSum := c.Gateway.OpenAIWS.SchedulerScoreWeights.Priority +
@@ -2632,6 +2640,9 @@ func (c *Config) Validate() error {
 		c.Gateway.OpenAIWS.SchedulerScoreWeights.Queue +
 		c.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate +
 		c.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT
+	if c.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsageEnabled {
+		weightSum += c.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsage
+	}
 	if weightSum <= 0 {
 		return fmt.Errorf("gateway.openai_ws.scheduler_score_weights must not all be zero")
 	}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1588,6 +1588,19 @@ func TestValidateConfig_OpenAIWSRules(t *testing.T) {
 		require.Equal(t, 7200, cfg.Gateway.OpenAIWS.StickyResponseIDTTLSeconds)
 	})
 
+	t.Run("scheduler_score_weights 可只启用 remaining_usage", func(t *testing.T) {
+		cfg := buildValid(t)
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority = 0
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Load = 0
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Queue = 0
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate = 0
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT = 0
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsage = 1
+		cfg.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsageEnabled = true
+
+		require.NoError(t, cfg.Validate())
+	})
+
 	cases := []struct {
 		name    string
 		mutate  func(*Config)

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -681,6 +681,7 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 	plan.loadSkew = calcLoadSkewByMoments(loadRateSum, loadRateSumSquares, len(candidates))
 
 	weights := s.service.openAIWSSchedulerWeights()
+	now := time.Now()
 	for i := range candidates {
 		item := &candidates[i]
 		priorityFactor := 1.0
@@ -700,6 +701,17 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 			weights.Queue*queueFactor +
 			weights.ErrorRate*errorFactor +
 			weights.TTFT*ttftFactor
+
+		// 七日剩余用量因子（可选，默认关闭）：剩余越多得分越高。
+		// 无该信号或检测到窗口已重置时取中性 0.5，避免对无数据账号过度加成/惩罚。
+		if weights.RemainingUsageEnabled {
+			remainingUsageFactor := 0.5
+			if used, ok := resolveAccountExtraNumber(item.account.Extra, "codex_7d_used_percent"); ok &&
+				!openAIQuotaWindowReset(item.account.Extra, "7d", now) {
+				remainingUsageFactor = 1 - clamp01(used/100.0)
+			}
+			item.score += weights.RemainingUsage * remainingUsageFactor
+		}
 	}
 	plan.candidates = candidates
 
@@ -1315,19 +1327,23 @@ func (s *OpenAIGatewayService) openAIWSLBTopK() int {
 func (s *OpenAIGatewayService) openAIWSSchedulerWeights() GatewayOpenAIWSSchedulerScoreWeightsView {
 	if s != nil && s.cfg != nil {
 		return GatewayOpenAIWSSchedulerScoreWeightsView{
-			Priority:  s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority,
-			Load:      s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Load,
-			Queue:     s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Queue,
-			ErrorRate: s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate,
-			TTFT:      s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT,
+			Priority:              s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority,
+			Load:                  s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Load,
+			Queue:                 s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Queue,
+			ErrorRate:             s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate,
+			TTFT:                  s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT,
+			RemainingUsage:        s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsage,
+			RemainingUsageEnabled: s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.RemainingUsageEnabled,
 		}
 	}
 	return GatewayOpenAIWSSchedulerScoreWeightsView{
-		Priority:  1.0,
-		Load:      1.0,
-		Queue:     0.7,
-		ErrorRate: 0.8,
-		TTFT:      0.5,
+		Priority:              1.0,
+		Load:                  1.0,
+		Queue:                 0.7,
+		ErrorRate:             0.8,
+		TTFT:                  0.5,
+		RemainingUsage:        1.0,
+		RemainingUsageEnabled: false,
 	}
 }
 
@@ -1337,6 +1353,9 @@ type GatewayOpenAIWSSchedulerScoreWeightsView struct {
 	Queue     float64
 	ErrorRate float64
 	TTFT      float64
+	// RemainingUsage 七日剩余用量权重；仅在 RemainingUsageEnabled=true 时生效。
+	RemainingUsage        float64
+	RemainingUsageEnabled bool
 }
 
 func clamp01(value float64) float64 {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -1958,3 +1958,81 @@ func TestDefaultOpenAIAccountScheduler_IsAccountTransportCompatible_Branches(t *
 func int64PtrForTest(v int64) *int64 {
 	return &v
 }
+
+// TestOpenAIAccountScheduler_RemainingUsageWeight 验证“七日剩余用量”打分因子：
+// 关闭时(默认)不影响打分；开启时剩余越多得分越高；无 7d 数据时取中性 0.5。
+func TestOpenAIAccountScheduler_RemainingUsageWeight(t *testing.T) {
+	baseWeights := func(enabled bool) config.GatewayOpenAIWSSchedulerScoreWeights {
+		return config.GatewayOpenAIWSSchedulerScoreWeights{
+			Priority:              1.0,
+			Load:                  1.0,
+			Queue:                 0.7,
+			ErrorRate:             0.8,
+			TTFT:                  0.5,
+			RemainingUsage:        1.0,
+			RemainingUsageEnabled: enabled,
+		}
+	}
+	newScheduler := func(enabled bool) *defaultOpenAIAccountScheduler {
+		svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{
+			OpenAIWS: config.GatewayOpenAIWSConfig{SchedulerScoreWeights: baseWeights(enabled)},
+		}}}
+		return newDefaultOpenAIAccountScheduler(svc, nil).(*defaultOpenAIAccountScheduler)
+	}
+	scoreByID := func(plan openAIAccountLoadPlan) map[int64]float64 {
+		m := make(map[int64]float64, len(plan.candidates))
+		for _, c := range plan.candidates {
+			m[c.account.ID] = c.score
+		}
+		return m
+	}
+	// 两个除 7d 用量外完全相同的 OpenAI 账号：highRemaining=10% used，lowRemaining=90% used。
+	mkAccounts := func() []*Account {
+		high := &Account{ID: 7001, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_7d_used_percent": 10.0}}
+		low := &Account{ID: 7002, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_7d_used_percent": 90.0}}
+		return []*Account{high, low}
+	}
+	req := OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.1"}
+	loadMap := map[int64]*AccountLoadInfo{}
+
+	t.Run("disabled keeps scores equal (zero regression)", func(t *testing.T) {
+		plan := newScheduler(false).buildOpenAIAccountLoadPlan(req, mkAccounts(), loadMap)
+		s := scoreByID(plan)
+		require.InDelta(t, s[7001], s[7002], 1e-9, "7d remaining must not affect score when disabled")
+	})
+
+	t.Run("enabled prefers account with more remaining", func(t *testing.T) {
+		plan := newScheduler(true).buildOpenAIAccountLoadPlan(req, mkAccounts(), loadMap)
+		s := scoreByID(plan)
+		require.Greater(t, s[7001], s[7002], "more 7d remaining must score higher when enabled")
+		// factor 差 = (1-0.10) - (1-0.90) = 0.8，权重 1.0
+		require.InDelta(t, 0.8, s[7001]-s[7002], 1e-9)
+	})
+
+	t.Run("enabled with no 7d signal is neutral", func(t *testing.T) {
+		high := &Account{ID: 7101, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_7d_used_percent": 10.0}} // factor 0.9
+		noData := &Account{ID: 7102, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0}                                                     // 无 Extra -> 中性 0.5
+		low := &Account{ID: 7103, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_7d_used_percent": 90.0}}  // factor 0.1
+		plan := newScheduler(true).buildOpenAIAccountLoadPlan(req, []*Account{high, noData, low}, loadMap)
+		s := scoreByID(plan)
+		require.Greater(t, s[7101], s[7102], "known high-remaining beats no-data")
+		require.Greater(t, s[7102], s[7103], "no-data (neutral) beats known low-remaining")
+		require.InDelta(t, 0.4, s[7102]-s[7103], 1e-9) // 0.5 - 0.1
+	})
+
+	t.Run("enabled with expired 7d window is neutral", func(t *testing.T) {
+		expiredResetAt := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+		high := &Account{ID: 7201, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_7d_used_percent": 10.0}} // factor 0.9
+		expired := &Account{ID: 7202, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{
+			"codex_7d_used_percent": 90.0,
+			"codex_7d_reset_at":     expiredResetAt,
+		}} // 过期窗口 -> 中性 0.5
+		low := &Account{ID: 7203, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true, Concurrency: 1, Priority: 0, Extra: map[string]any{"codex_7d_used_percent": 90.0}} // factor 0.1
+
+		plan := newScheduler(true).buildOpenAIAccountLoadPlan(req, []*Account{high, expired, low}, loadMap)
+		s := scoreByID(plan)
+		require.Greater(t, s[7201], s[7202], "known high-remaining beats expired-window neutral")
+		require.Greater(t, s[7202], s[7203], "expired-window neutral beats known low-remaining")
+		require.InDelta(t, 0.4, s[7202]-s[7203], 1e-9) // 0.5 - 0.1
+	})
+}

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -320,6 +320,11 @@ gateway:
       queue: 0.7
       error_rate: 0.8
       ttft: 0.5
+      # remaining_usage: 七日(7d)剩余用量权重，剩余越多得分越高（剩余配额多的账号优先调度）。
+      # 仅在 remaining_usage_enabled=true 时生效。
+      remaining_usage: 1.0
+      # remaining_usage_enabled: 是否让“七日剩余用量”参与调度打分，默认关闭。
+      remaining_usage_enabled: false
   # OpenAI HTTP upstream protocol strategy.
   # OpenAI HTTP 上游协议策略（默认 HTTP/2；代理明确不兼容时可临时回退 HTTP/1.1）。
   openai_http2:


### PR DESCRIPTION
## Summary

为 OpenAI 账号调度新增可选的“七日剩余用量”打分权重，让剩余 7d 配额更多的账号在负载均衡阶段获得更高分。

## Changes

- 在 `gateway.openai_ws.scheduler_score_weights` 中新增 `remaining_usage` 和 `remaining_usage_enabled` 配置项。
- 默认关闭 `remaining_usage_enabled`，保持现有调度行为不变。
- 启用后基于账号 `Extra` 中的 `codex_7d_used_percent` 计算剩余用量因子：使用率越低，调度得分越高。
- 复用已有 7d 窗口重置判断；无 7d 数据或窗口已过期时使用中性值，避免对账号过度加成或惩罚。
- 更新配置示例和配置校验测试，补充调度器单元测试覆盖启用、关闭、无数据、窗口过期场景。

## Behavior

- 默认配置下不会改变已有 OpenAI 账号调度结果。
- 开启 `remaining_usage_enabled` 后，剩余 7d 配额更高的账号会在同等优先级、负载、队列、错误率和 TTFT 条件下获得更高分。
- 过期的 `codex_7d_reset_at` 会被视为旧窗口数据，不继续按旧用量影响调度。

## Test

```bash
go test -tags unit ./internal/config ./internal/service -run 'TestValidateConfig_OpenAIWSRules|TestOpenAIGatewayService_SchedulerWrappersAndDefaults|TestOpenAIAccountScheduler_RemainingUsageWeight|TestOpenAIAccountScheduler_.*Quota|TestOpenAIQuota|TestOpenAIAccountScheduler_Select'
```
