### PR TITLE
[codex] Handle OpenAI chat request EOF with failover

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -225,17 +225,11 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 	if err != nil {
 		safeErr := sanitizeUpstreamErrorMessage(err.Error())
-		setOpsUpstreamError(c, 0, safeErr, "")
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: 0,
-			Kind:               "request_error",
-			Message:            safeErr,
-		})
-		writeChatCompletionsError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
-		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+		recordOpenAIChatCompletionsRequestError(c, account, safeErr)
+		return nil, &UpstreamFailoverError{
+			StatusCode:   http.StatusBadGateway,
+			ResponseBody: []byte(safeErr),
+		}
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -350,6 +344,18 @@ func normalizedOpenAIServiceTierValue(raw string) string {
 		return ""
 	}
 	return *normalized
+}
+
+func recordOpenAIChatCompletionsRequestError(c *gin.Context, account *Account, message string) {
+	setOpsUpstreamError(c, 0, message, "")
+	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+		Platform:           account.Platform,
+		AccountID:          account.ID,
+		AccountName:        account.Name,
+		UpstreamStatusCode: 0,
+		Kind:               "request_error",
+		Message:            message,
+	})
 }
 
 // handleChatCompletionsErrorResponse reads an upstream error and returns it in

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -167,17 +167,11 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 	if err != nil {
 		safeErr := sanitizeUpstreamErrorMessage(err.Error())
-		setOpsUpstreamError(c, 0, safeErr, "")
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: 0,
-			Kind:               "request_error",
-			Message:            safeErr,
-		})
-		writeChatCompletionsError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
-		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+		recordOpenAIChatCompletionsRequestError(c, account, safeErr)
+		return nil, &UpstreamFailoverError{
+			StatusCode:   http.StatusBadGateway,
+			ResponseBody: []byte(safeErr),
+		}
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/openai_gateway_chat_completions_raw_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw_test.go
@@ -122,6 +122,30 @@ func TestForwardAsRawChatCompletions_ForcesStreamUsageUpstreamAndPassesUsageDown
 	require.Contains(t, rec.Body.String(), "data: [DONE]")
 }
 
+func TestForwardAsRawChatCompletions_UpstreamRequestEOFTriggersFailoverWithoutWritingResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{err: io.EOF}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.forwardAsRawChatCompletions(context.Background(), c, rawChatCompletionsTestAccount(), body, "")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "request EOF before response should let handler switch accounts")
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.False(t, c.Writer.Written(), "failoverable request errors must not commit a downstream 502")
+	require.Empty(t, rec.Body.String())
+}
+
 func TestForwardAsRawChatCompletions_PreservesDeepSeekReasoningContentNonStreaming(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_chat_completions_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_test.go
@@ -133,6 +133,38 @@ func TestForwardAsChatCompletions_UnknownModelDoesNotUseDefaultMappedModel(t *te
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
 
+func TestForwardAsChatCompletions_UpstreamRequestEOFTriggersFailoverWithoutWritingResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{err: io.EOF}
+	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	account := &Account{
+		ID:          16,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "", "gpt-5.5")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "request EOF before response should let handler switch accounts")
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.False(t, c.Writer.Written(), "failoverable request errors must not commit a downstream 502")
+	require.Empty(t, rec.Body.String())
+}
+
 func TestForwardAsChatCompletions_ClientDisconnectDrainsUpstreamUsage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

- Treat pre-response OpenAI Chat Completions upstream request failures as failoverable errors instead of immediately writing a downstream 502.
- Share request-error ops recording between the converted Responses path and raw Chat Completions path.
- Add regression coverage for OAuth/Responses and raw Chat Completions EOF-before-response cases.

## Root Cause

When `httpUpstream.Do(...)` failed before an upstream response was available, the service wrote a Chat Completions 502 response directly and returned a plain error. The OpenAI chat handler only switches accounts for `UpstreamFailoverError`, so transient connection failures such as an upstream EOF could bypass the existing failover loop and stop the client request.

## Impact

Transient upstream connection failures before any downstream bytes are written can now reuse the existing account failover path. Errors that happen after a response stream has already started are not retried, avoiding duplicate or corrupted client output.

## Validation

- `git diff --check`
- `GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.google.cn go test -tags unit -run 'TestForwardAs(ChatCompletions|RawChatCompletions)_UpstreamRequestEOFTriggersFailoverWithoutWritingResponse' ./internal/service -count=1`