### PR TITLE
fix: delete user API keys when deleting user

### DIFF
--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -834,6 +834,25 @@ func (s *adminServiceImpl) DeleteUser(ctx context.Context, id int64) error {
 	if user.Role == "admin" {
 		return errors.New("cannot delete admin user")
 	}
+	if s.apiKeyRepo != nil {
+		params := pagination.PaginationParams{Page: 1, PageSize: 1000, SortBy: "id", SortOrder: pagination.SortOrderAsc}
+		for {
+			keys, _, err := s.apiKeyRepo.ListByUserID(ctx, id, params, APIKeyListFilters{})
+			if err != nil {
+				logger.LegacyPrintf("service.admin", "list user api keys before delete failed: user_id=%d err=%v", id, err)
+				return err
+			}
+			if len(keys) == 0 {
+				break
+			}
+			for i := range keys {
+				if err := s.apiKeyRepo.DeleteWithAudit(ctx, keys[i].ID); err != nil {
+					logger.LegacyPrintf("service.admin", "delete user api key failed: user_id=%d api_key_id=%d err=%v", id, keys[i].ID, err)
+					return err
+				}
+			}
+		}
+	}
 	if err := s.userRepo.Delete(ctx, id); err != nil {
 		logger.LegacyPrintf("service.admin", "delete user failed: user_id=%d err=%v", id, err)
 		return err

--- a/backend/internal/service/admin_service_delete_test.go
+++ b/backend/internal/service/admin_service_delete_test.go
@@ -263,6 +263,39 @@ func (s *deleteGroupAPIKeyRepoStub) ListKeysByGroupID(ctx context.Context, group
 	return s.keys, nil
 }
 
+type deleteUserAPIKeyRepoStub struct {
+	apiKeyRepoStubForGroupUpdate
+	keysByUserID           map[int64][]APIKey
+	listUserIDs            []int64
+	deleteWithAuditIDs     []int64
+	deleteWithAuditErrByID map[int64]error
+}
+
+func (s *deleteUserAPIKeyRepoStub) ListByUserID(ctx context.Context, userID int64, params pagination.PaginationParams, filters APIKeyListFilters) ([]APIKey, *pagination.PaginationResult, error) {
+	s.listUserIDs = append(s.listUserIDs, userID)
+	keys := append([]APIKey(nil), s.keysByUserID[userID]...)
+	return keys, &pagination.PaginationResult{Total: int64(len(keys)), Page: params.Page, PageSize: params.PageSize}, nil
+}
+
+func (s *deleteUserAPIKeyRepoStub) DeleteWithAudit(ctx context.Context, id int64) error {
+	s.deleteWithAuditIDs = append(s.deleteWithAuditIDs, id)
+	if s.deleteWithAuditErrByID != nil {
+		if err, ok := s.deleteWithAuditErrByID[id]; ok {
+			return err
+		}
+	}
+	for userID, keys := range s.keysByUserID {
+		remaining := keys[:0]
+		for _, key := range keys {
+			if key.ID != id {
+				remaining = append(remaining, key)
+			}
+		}
+		s.keysByUserID[userID] = remaining
+	}
+	return nil
+}
+
 type proxyRepoStub struct {
 	deleteErr    error
 	countErr     error
@@ -513,6 +546,43 @@ func TestAdminService_DeleteUser_Success(t *testing.T) {
 	err := svc.DeleteUser(context.Background(), 7)
 	require.NoError(t, err)
 	require.Equal(t, []int64{7}, repo.deletedIDs)
+}
+
+func TestAdminService_DeleteUser_DeletesOwnedAPIKeys(t *testing.T) {
+	userRepo := &userRepoStub{user: &User{ID: 7, Role: RoleUser}}
+	apiKeyRepo := &deleteUserAPIKeyRepoStub{
+		keysByUserID: map[int64][]APIKey{
+			7: {
+				{ID: 101, UserID: 7, Key: "redacted-key-1"},
+				{ID: 102, UserID: 7, Key: "redacted-key-2"},
+			},
+		},
+	}
+	svc := &adminServiceImpl{userRepo: userRepo, apiKeyRepo: apiKeyRepo}
+
+	err := svc.DeleteUser(context.Background(), 7)
+	require.NoError(t, err)
+	require.Equal(t, []int64{7, 7}, apiKeyRepo.listUserIDs)
+	require.Equal(t, []int64{101, 102}, apiKeyRepo.deleteWithAuditIDs)
+	require.Equal(t, []int64{7}, userRepo.deletedIDs)
+}
+
+func TestAdminService_DeleteUser_StopsWhenAPIKeyDeleteFails(t *testing.T) {
+	deleteKeyErr := errors.New("delete api key failed")
+	userRepo := &userRepoStub{user: &User{ID: 7, Role: RoleUser}}
+	apiKeyRepo := &deleteUserAPIKeyRepoStub{
+		keysByUserID: map[int64][]APIKey{
+			7: {{ID: 101, UserID: 7, Key: "redacted-key"}},
+		},
+		deleteWithAuditErrByID: map[int64]error{101: deleteKeyErr},
+	}
+	svc := &adminServiceImpl{userRepo: userRepo, apiKeyRepo: apiKeyRepo}
+
+	err := svc.DeleteUser(context.Background(), 7)
+	require.ErrorIs(t, err, deleteKeyErr)
+	require.Equal(t, []int64{7}, apiKeyRepo.listUserIDs)
+	require.Equal(t, []int64{101}, apiKeyRepo.deleteWithAuditIDs)
+	require.Empty(t, userRepo.deletedIDs)
 }
 
 func TestAdminService_DeleteUser_NotFound(t *testing.T) {


### PR DESCRIPTION
## Summary
- Delete a user's API keys with audit before soft-deleting the user.
- Stop user deletion if an API key cannot be deleted, avoiding partially cleaned-up state.
- Add regression tests for API key cleanup and failure handling.

Fixes #3021

## Test Plan
- `go test -tags=unit ./internal/service -run 'TestAdminService_DeleteUser_(Success|DeletesOwnedAPIKeys|StopsWhenAPIKeyDeleteFails|NotFound|AdminGuard|DeleteError)$' -count=1`
- `go test -tags=unit ./internal/service -count=1`
- `go test -tags=unit ./...` *(fails only in `internal/config`: `TestLoadForBootstrapAllowsMissingJWTSecret` and `TestLoadDefaultDatabaseSSLMode`, due to local environment/default config differences; unrelated packages including `internal/service` pass)*

## Notes
- The delete-user path uses soft delete, so DB-level cascades do not remove related API keys. This fix explicitly deletes active keys via `DeleteWithAudit` before deleting the user.