### PR TITLE
fix(openai): 切组后剥离失配的 previous_response_id，修复跨组会话鉴权失败

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -358,6 +358,17 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
 		}
+		// 切组/会话失配防护：previous_response_id 未在当前分组命中粘连账号（StickyPreviousHit=false）
+		// 说明会话链不属于本次账号，携带它会触发上游会话链鉴权失败，故主动剥离改用完整 input 重建。
+		// 带 function_call_output 的工具续链无法重建，保持原样（与 WS 重连恢复一致）。
+		if previousResponseID != "" && !scheduleDecision.StickyPreviousHit &&
+			!service.ValidateFunctionCallOutputContextBytes(forwardBody).HasFunctionCallOutput {
+			forwardBody = service.RemovePreviousResponseIDFromBody(forwardBody)
+			reqLog.Debug("openai.previous_response_id_stripped_cross_group",
+				zap.Int64("account_id", account.ID),
+				zap.String("schedule_layer", scheduleDecision.Layer),
+			)
+		}
 		writerSizeBeforeForward := c.Writer.Size()
 		result, err := func() (*service.OpenAIForwardResult, error) {
 			defer func() {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -358,17 +358,6 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		if channelMapping.Mapped {
 			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
 		}
-		// 切组/会话失配防护：previous_response_id 未在当前分组命中粘连账号（StickyPreviousHit=false）
-		// 说明会话链不属于本次账号，携带它会触发上游会话链鉴权失败，故主动剥离改用完整 input 重建。
-		// 带 function_call_output 的工具续链无法重建，保持原样（与 WS 重连恢复一致）。
-		if previousResponseID != "" && !scheduleDecision.StickyPreviousHit &&
-			!service.ValidateFunctionCallOutputContextBytes(forwardBody).HasFunctionCallOutput {
-			forwardBody = service.RemovePreviousResponseIDFromBody(forwardBody)
-			reqLog.Debug("openai.previous_response_id_stripped_cross_group",
-				zap.Int64("account_id", account.ID),
-				zap.String("schedule_layer", scheduleDecision.Layer),
-			)
-		}
 		writerSizeBeforeForward := c.Writer.Size()
 		result, err := func() (*service.OpenAIForwardResult, error) {
 			defer func() {
@@ -1503,6 +1492,18 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		wsFirstMessage := firstMessage
 		if channelMappingWS.Mapped {
 			wsFirstMessage = h.gatewayService.ReplaceModelInBody(firstMessage, channelMappingWS.MappedModel)
+		}
+		// 切组/会话失配防护：previous_response_id 未在当前分组命中粘连账号（StickyPreviousHit=false），
+		// 说明该会话链不属于本次调度到的账号，原样转发会触发上游会话链鉴权失败（“鉴权失败，请检查 API Key”）。
+		// 故剥离首包里的 previous_response_id，改用首包内 input 重建上下文；带 function_call_output 的
+		// 工具续链无法重建，保持原样。仅作用于首轮首包，后续 turn 的续链由 WS 转发层既有逻辑处理。
+		if previousResponseID != "" && !scheduleDecision.StickyPreviousHit &&
+			!service.ValidateFunctionCallOutputContextBytes(wsFirstMessage).HasFunctionCallOutput {
+			wsFirstMessage = service.RemovePreviousResponseIDFromBody(wsFirstMessage)
+			reqLog.Debug("openai.websocket_previous_response_id_stripped_cross_group",
+				zap.Int64("account_id", account.ID),
+				zap.String("schedule_layer", scheduleDecision.Layer),
+			)
 		}
 
 		// WebSocket 首包可能很大，hash 必须在 hooks 外算成字符串，避免 AfterTurn 闭包保活请求体。

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -572,6 +572,21 @@ func ReplaceModelInBody(body []byte, newModel string) []byte {
 	return newBody
 }
 
+// RemovePreviousResponseIDFromBody 删除请求体中的 previous_response_id，用于会话失配时改用完整 input 重建上下文。
+func RemovePreviousResponseIDFromBody(body []byte) []byte {
+	if len(body) == 0 {
+		return body
+	}
+	if !gjson.GetBytes(body, "previous_response_id").Exists() {
+		return body
+	}
+	newBody, err := sjson.DeleteBytes(body, "previous_response_id")
+	if err != nil {
+		return body
+	}
+	return newBody
+}
+
 // validateChannelConfig 校验渠道的定价和映射配置（冲突检测 + 区间校验 + 计费模式校验）。
 // Create 和 Update 共用此函数，避免重复。
 func validateChannelConfig(pricing []ChannelModelPricing, mapping map[string]map[string]string) error {

--- a/backend/internal/service/channel_service_test.go
+++ b/backend/internal/service/channel_service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 // ---------------------------------------------------------------------------
@@ -1919,6 +1920,33 @@ func TestReplaceModelInBody_InvalidJSON(t *testing.T) {
 	arrayBody := []byte("[]")
 	result2 := ReplaceModelInBody(arrayBody, "new-model")
 	require.Equal(t, arrayBody, result2)
+}
+
+func TestRemovePreviousResponseIDFromBody(t *testing.T) {
+	t.Run("empty body returned as-is", func(t *testing.T) {
+		require.Equal(t, []byte{}, RemovePreviousResponseIDFromBody([]byte{}))
+		require.Nil(t, RemovePreviousResponseIDFromBody(nil))
+	})
+
+	t.Run("no previous_response_id field is a no-op", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5","input":"hi"}`)
+		result := RemovePreviousResponseIDFromBody(body)
+		require.Equal(t, body, result)
+	})
+
+	t.Run("strips previous_response_id and preserves other fields", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5","previous_response_id":"resp_abc","input":"hi"}`)
+		result := RemovePreviousResponseIDFromBody(body)
+		require.False(t, gjson.GetBytes(result, "previous_response_id").Exists())
+		require.Equal(t, "gpt-5", gjson.GetBytes(result, "model").String())
+		require.Equal(t, "hi", gjson.GetBytes(result, "input").String())
+	})
+
+	t.Run("empty-string previous_response_id is also stripped", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5","previous_response_id":""}`)
+		result := RemovePreviousResponseIDFromBody(body)
+		require.False(t, gjson.GetBytes(result, "previous_response_id").Exists())
+	})
 }
 
 // ===========================================================================

--- a/backend/internal/service/openai_ws_state_store.go
+++ b/backend/internal/service/openai_ws_state_store.go
@@ -100,9 +100,10 @@ func (s *defaultOpenAIWSStateStore) BindResponseAccount(ctx context.Context, gro
 	s.maybeCleanup()
 
 	expiresAt := time.Now().Add(ttl)
+	mapKey := openAIWSResponseAccountMapKey(groupID, id)
 	s.responseToAccountMu.Lock()
-	ensureBindingCapacity(s.responseToAccount, id, openAIWSStateStoreMaxEntriesPerMap)
-	s.responseToAccount[id] = openAIWSAccountBinding{accountID: accountID, expiresAt: expiresAt}
+	ensureBindingCapacity(s.responseToAccount, mapKey, openAIWSStateStoreMaxEntriesPerMap)
+	s.responseToAccount[mapKey] = openAIWSAccountBinding{accountID: accountID, expiresAt: expiresAt}
 	s.responseToAccountMu.Unlock()
 
 	if s.cache == nil {
@@ -122,8 +123,9 @@ func (s *defaultOpenAIWSStateStore) GetResponseAccount(ctx context.Context, grou
 	s.maybeCleanup()
 
 	now := time.Now()
+	mapKey := openAIWSResponseAccountMapKey(groupID, id)
 	s.responseToAccountMu.RLock()
-	if binding, ok := s.responseToAccount[id]; ok {
+	if binding, ok := s.responseToAccount[mapKey]; ok {
 		if now.Before(binding.expiresAt) {
 			accountID := binding.accountID
 			s.responseToAccountMu.RUnlock()
@@ -153,7 +155,7 @@ func (s *defaultOpenAIWSStateStore) DeleteResponseAccount(ctx context.Context, g
 		return nil
 	}
 	s.responseToAccountMu.Lock()
-	delete(s.responseToAccount, id)
+	delete(s.responseToAccount, openAIWSResponseAccountMapKey(groupID, id))
 	s.responseToAccountMu.Unlock()
 
 	if s.cache == nil {
@@ -415,6 +417,11 @@ func normalizeOpenAIWSResponseID(responseID string) string {
 func openAIWSResponseAccountCacheKey(responseID string) string {
 	sum := sha256.Sum256([]byte(responseID))
 	return openAIWSResponseAccountCachePrefix + hex.EncodeToString(sum[:])
+}
+
+// openAIWSResponseAccountMapKey 本地热缓存按分组隔离的 key，与 Redis 层保持一致，避免跨组命中。
+func openAIWSResponseAccountMapKey(groupID int64, responseID string) string {
+	return fmt.Sprintf("%d:%s", groupID, responseID)
 }
 
 func normalizeOpenAIWSTTL(ttl time.Duration) time.Duration {


### PR DESCRIPTION
## 背景 / 问题

OpenAI Responses API 的 `previous_response_id` 是有状态的会话续链锚点，绑定到具体上游账号。
当用户把 API Key 从一个分组切换到另一个分组（如公开组 ↔ 订阅组）后，客户端仍沿用切组前的
旧 `previous_response_id`，网关会把这条不属于当前分组任何账号的会话链原样转发给新调度到的账号，
上游因会话链鉴权不匹配返回误导性的错误：

```json
{"error":{"code":null,"message":"鉴权失败，请检查 API Key","param":null,"type":"api_error"}}
```

表现为「换组用一段时间再切回原组就报鉴权失败」，但 API Key、账号本身都正常。

## 根因

1. **本地热缓存未按分组隔离**
   `defaultOpenAIWSStateStore` 的本地热缓存 `responseToAccount` 只用 `responseID` 作为 key，
   而 Redis 层用 `sticky_session:{groupID}:...` 按分组隔离。两层命名空间不一致 —— 单实例下，
   A 组的 `response_id` 在 B 组查询时会错误命中 A 组遗留的本地账号绑定，解析到不属于当前分组的账号，
   导致 `StickyPreviousHit` 信号不可信。

2. **缺少失配 `previous_response_id` 的兜底**
   当 `previous_response_id` 在当前分组解析不到对应账号（切组 / 绑定失效）时，网关直接把它透传给
   正常调度选出的账号 —— 该账号并不拥有这条会话链，上游遂返回鉴权类错误。而现有的
   「丢弃 previous_response_id 重试」恢复逻辑只匹配 400/404 的 `previous_response_not_found`，
   401/403 鉴权错误会直接穿透返回给用户。

## 改动

- **`internal/service/openai_ws_state_store.go`**
  本地热缓存 `responseToAccount` 改为按 `{groupID}:{responseID}` 命名空间（新增
  `openAIWSResponseAccountMapKey`），与 Redis 层保持一致，消除跨组误命中。

- **`internal/handler/openai_gateway_handler.go`**
  转发前，若请求带了 `previous_response_id` 但本次选号并非凭它在当前分组粘连命中
  （`scheduleDecision.StickyPreviousHit == false`），主动剥离该字段，改用完整 `input` 重建上下文。
  带 `function_call_output` 的工具续链无法靠重建恢复，保持原样（与 WS 重连恢复逻辑一致），
  避免引入新的失败模式。

- **`internal/service/channel_service.go`**
  新增 `RemovePreviousResponseIDFromBody` 工具函数。

## 行为变化

| 场景 | 改动前 | 改动后 |
|---|---|---|
| 同组正常续链（命中粘连） | 透传 previous_response_id | 不变，正常透传 |
| 切组 / 绑定失效，普通对话 | 透传 → 上游鉴权失败 | 剥离 → 用完整 input 重建，正常返回 |
| 切组，带 function_call_output | 透传 → 失败 | 保持原样（不可恢复，行为不变） |
| 跨组复用同一 response_id（单实例） | 本地缓存误命中外组账号 | 正确未命中，走正常调度 |

## 测试

- `go build ./...` 通过
- `go test ./internal/service/ -run 'OpenAIWSStateStore|SelectAccountByPreviousResponseID|SelectAccountWithScheduler|Forward_WSv2'` 通过

## 备注

改动 1 是数据隔离修复；改动 2 是对「无状态网关 vs 有状态 Responses 会话」边界的健壮性兜底。
两者都不影响正常的同组续链路径，只在失配 / 跨组场景生效。