### PR TITLE
feat: support fractional subscription validity

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -1215,7 +1215,7 @@ var (
 		{Name: "description", Type: field.TypeString, Default: "", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "price", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "decimal(20,2)"}},
 		{Name: "original_price", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(20,2)"}},
-		{Name: "validity_days", Type: field.TypeInt, Default: 30},
+		{Name: "validity_days", Type: field.TypeFloat64, Default: 30, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
 		{Name: "validity_unit", Type: field.TypeString, Size: 10, Default: "day"},
 		{Name: "features", Type: field.TypeString, Default: "", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "product_name", Type: field.TypeString, Size: 100, Default: ""},

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -30834,8 +30834,8 @@ type SubscriptionPlanMutation struct {
 	addprice          *float64
 	original_price    *float64
 	addoriginal_price *float64
-	validity_days     *int
-	addvalidity_days  *int
+	validity_days     *float64
+	addvalidity_days  *float64
 	validity_unit     *string
 	features          *string
 	product_name      *string
@@ -31203,13 +31203,13 @@ func (m *SubscriptionPlanMutation) ResetOriginalPrice() {
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (m *SubscriptionPlanMutation) SetValidityDays(i int) {
-	m.validity_days = &i
+func (m *SubscriptionPlanMutation) SetValidityDays(f float64) {
+	m.validity_days = &f
 	m.addvalidity_days = nil
 }
 
 // ValidityDays returns the value of the "validity_days" field in the mutation.
-func (m *SubscriptionPlanMutation) ValidityDays() (r int, exists bool) {
+func (m *SubscriptionPlanMutation) ValidityDays() (r float64, exists bool) {
 	v := m.validity_days
 	if v == nil {
 		return
@@ -31220,7 +31220,7 @@ func (m *SubscriptionPlanMutation) ValidityDays() (r int, exists bool) {
 // OldValidityDays returns the old "validity_days" field's value of the SubscriptionPlan entity.
 // If the SubscriptionPlan object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SubscriptionPlanMutation) OldValidityDays(ctx context.Context) (v int, err error) {
+func (m *SubscriptionPlanMutation) OldValidityDays(ctx context.Context) (v float64, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldValidityDays is only allowed on UpdateOne operations")
 	}
@@ -31234,17 +31234,17 @@ func (m *SubscriptionPlanMutation) OldValidityDays(ctx context.Context) (v int, 
 	return oldValue.ValidityDays, nil
 }
 
-// AddValidityDays adds i to the "validity_days" field.
-func (m *SubscriptionPlanMutation) AddValidityDays(i int) {
+// AddValidityDays adds f to the "validity_days" field.
+func (m *SubscriptionPlanMutation) AddValidityDays(f float64) {
 	if m.addvalidity_days != nil {
-		*m.addvalidity_days += i
+		*m.addvalidity_days += f
 	} else {
-		m.addvalidity_days = &i
+		m.addvalidity_days = &f
 	}
 }
 
 // AddedValidityDays returns the value that was added to the "validity_days" field in this mutation.
-func (m *SubscriptionPlanMutation) AddedValidityDays() (r int, exists bool) {
+func (m *SubscriptionPlanMutation) AddedValidityDays() (r float64, exists bool) {
 	v := m.addvalidity_days
 	if v == nil {
 		return
@@ -31718,7 +31718,7 @@ func (m *SubscriptionPlanMutation) SetField(name string, value ent.Value) error 
 		m.SetOriginalPrice(v)
 		return nil
 	case subscriptionplan.FieldValidityDays:
-		v, ok := value.(int)
+		v, ok := value.(float64)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -31845,7 +31845,7 @@ func (m *SubscriptionPlanMutation) AddField(name string, value ent.Value) error 
 		m.AddOriginalPrice(v)
 		return nil
 	case subscriptionplan.FieldValidityDays:
-		v, ok := value.(int)
+		v, ok := value.(float64)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -1496,7 +1496,7 @@ func init() {
 	// subscriptionplanDescValidityDays is the schema descriptor for validity_days field.
 	subscriptionplanDescValidityDays := subscriptionplanFields[5].Descriptor()
 	// subscriptionplan.DefaultValidityDays holds the default value on creation for the validity_days field.
-	subscriptionplan.DefaultValidityDays = subscriptionplanDescValidityDays.Default.(int)
+	subscriptionplan.DefaultValidityDays = subscriptionplanDescValidityDays.Default.(float64)
 	// subscriptionplanDescValidityUnit is the schema descriptor for validity_unit field.
 	subscriptionplanDescValidityUnit := subscriptionplanFields[6].Descriptor()
 	// subscriptionplan.DefaultValidityUnit holds the default value on creation for the validity_unit field.

--- a/backend/ent/schema/subscription_plan.go
+++ b/backend/ent/schema/subscription_plan.go
@@ -43,7 +43,8 @@ func (SubscriptionPlan) Fields() []ent.Field {
 			SchemaType(map[string]string{dialect.Postgres: "decimal(20,2)"}).
 			Optional().
 			Nillable(),
-		field.Int("validity_days").
+		field.Float("validity_days").
+			SchemaType(map[string]string{dialect.Postgres: "decimal(20,8)"}).
 			Default(30),
 		field.String("validity_unit").
 			MaxLen(10).

--- a/backend/ent/subscriptionplan.go
+++ b/backend/ent/subscriptionplan.go
@@ -28,7 +28,7 @@ type SubscriptionPlan struct {
 	// OriginalPrice holds the value of the "original_price" field.
 	OriginalPrice *float64 `json:"original_price,omitempty"`
 	// ValidityDays holds the value of the "validity_days" field.
-	ValidityDays int `json:"validity_days,omitempty"`
+	ValidityDays float64 `json:"validity_days,omitempty"`
 	// ValidityUnit holds the value of the "validity_unit" field.
 	ValidityUnit string `json:"validity_unit,omitempty"`
 	// Features holds the value of the "features" field.
@@ -53,9 +53,9 @@ func (*SubscriptionPlan) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case subscriptionplan.FieldForSale:
 			values[i] = new(sql.NullBool)
-		case subscriptionplan.FieldPrice, subscriptionplan.FieldOriginalPrice:
+		case subscriptionplan.FieldPrice, subscriptionplan.FieldOriginalPrice, subscriptionplan.FieldValidityDays:
 			values[i] = new(sql.NullFloat64)
-		case subscriptionplan.FieldID, subscriptionplan.FieldGroupID, subscriptionplan.FieldValidityDays, subscriptionplan.FieldSortOrder:
+		case subscriptionplan.FieldID, subscriptionplan.FieldGroupID, subscriptionplan.FieldSortOrder:
 			values[i] = new(sql.NullInt64)
 		case subscriptionplan.FieldName, subscriptionplan.FieldDescription, subscriptionplan.FieldValidityUnit, subscriptionplan.FieldFeatures, subscriptionplan.FieldProductName:
 			values[i] = new(sql.NullString)
@@ -114,10 +114,10 @@ func (_m *SubscriptionPlan) assignValues(columns []string, values []any) error {
 				*_m.OriginalPrice = value.Float64
 			}
 		case subscriptionplan.FieldValidityDays:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
 				return fmt.Errorf("unexpected type %T for field validity_days", values[i])
 			} else if value.Valid {
-				_m.ValidityDays = int(value.Int64)
+				_m.ValidityDays = value.Float64
 			}
 		case subscriptionplan.FieldValidityUnit:
 			if value, ok := values[i].(*sql.NullString); !ok {

--- a/backend/ent/subscriptionplan/subscriptionplan.go
+++ b/backend/ent/subscriptionplan/subscriptionplan.go
@@ -77,7 +77,7 @@ var (
 	// DefaultDescription holds the default value on creation for the "description" field.
 	DefaultDescription string
 	// DefaultValidityDays holds the default value on creation for the "validity_days" field.
-	DefaultValidityDays int
+	DefaultValidityDays float64
 	// DefaultValidityUnit holds the default value on creation for the "validity_unit" field.
 	DefaultValidityUnit string
 	// ValidityUnitValidator is a validator for the "validity_unit" field. It is called by the builders before save.

--- a/backend/ent/subscriptionplan/where.go
+++ b/backend/ent/subscriptionplan/where.go
@@ -80,7 +80,7 @@ func OriginalPrice(v float64) predicate.SubscriptionPlan {
 }
 
 // ValidityDays applies equality check predicate on the "validity_days" field. It's identical to ValidityDaysEQ.
-func ValidityDays(v int) predicate.SubscriptionPlan {
+func ValidityDays(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldEQ(FieldValidityDays, v))
 }
 
@@ -380,42 +380,42 @@ func OriginalPriceNotNil() predicate.SubscriptionPlan {
 }
 
 // ValidityDaysEQ applies the EQ predicate on the "validity_days" field.
-func ValidityDaysEQ(v int) predicate.SubscriptionPlan {
+func ValidityDaysEQ(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldEQ(FieldValidityDays, v))
 }
 
 // ValidityDaysNEQ applies the NEQ predicate on the "validity_days" field.
-func ValidityDaysNEQ(v int) predicate.SubscriptionPlan {
+func ValidityDaysNEQ(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldNEQ(FieldValidityDays, v))
 }
 
 // ValidityDaysIn applies the In predicate on the "validity_days" field.
-func ValidityDaysIn(vs ...int) predicate.SubscriptionPlan {
+func ValidityDaysIn(vs ...float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldIn(FieldValidityDays, vs...))
 }
 
 // ValidityDaysNotIn applies the NotIn predicate on the "validity_days" field.
-func ValidityDaysNotIn(vs ...int) predicate.SubscriptionPlan {
+func ValidityDaysNotIn(vs ...float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldNotIn(FieldValidityDays, vs...))
 }
 
 // ValidityDaysGT applies the GT predicate on the "validity_days" field.
-func ValidityDaysGT(v int) predicate.SubscriptionPlan {
+func ValidityDaysGT(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldGT(FieldValidityDays, v))
 }
 
 // ValidityDaysGTE applies the GTE predicate on the "validity_days" field.
-func ValidityDaysGTE(v int) predicate.SubscriptionPlan {
+func ValidityDaysGTE(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldGTE(FieldValidityDays, v))
 }
 
 // ValidityDaysLT applies the LT predicate on the "validity_days" field.
-func ValidityDaysLT(v int) predicate.SubscriptionPlan {
+func ValidityDaysLT(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldLT(FieldValidityDays, v))
 }
 
 // ValidityDaysLTE applies the LTE predicate on the "validity_days" field.
-func ValidityDaysLTE(v int) predicate.SubscriptionPlan {
+func ValidityDaysLTE(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldLTE(FieldValidityDays, v))
 }
 

--- a/backend/ent/subscriptionplan_create.go
+++ b/backend/ent/subscriptionplan_create.go
@@ -69,13 +69,13 @@ func (_c *SubscriptionPlanCreate) SetNillableOriginalPrice(v *float64) *Subscrip
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (_c *SubscriptionPlanCreate) SetValidityDays(v int) *SubscriptionPlanCreate {
+func (_c *SubscriptionPlanCreate) SetValidityDays(v float64) *SubscriptionPlanCreate {
 	_c.mutation.SetValidityDays(v)
 	return _c
 }
 
 // SetNillableValidityDays sets the "validity_days" field if the given value is not nil.
-func (_c *SubscriptionPlanCreate) SetNillableValidityDays(v *int) *SubscriptionPlanCreate {
+func (_c *SubscriptionPlanCreate) SetNillableValidityDays(v *float64) *SubscriptionPlanCreate {
 	if v != nil {
 		_c.SetValidityDays(*v)
 	}
@@ -354,7 +354,7 @@ func (_c *SubscriptionPlanCreate) createSpec() (*SubscriptionPlan, *sqlgraph.Cre
 		_node.OriginalPrice = &value
 	}
 	if value, ok := _c.mutation.ValidityDays(); ok {
-		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 		_node.ValidityDays = value
 	}
 	if value, ok := _c.mutation.ValidityUnit(); ok {
@@ -522,7 +522,7 @@ func (u *SubscriptionPlanUpsert) ClearOriginalPrice() *SubscriptionPlanUpsert {
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (u *SubscriptionPlanUpsert) SetValidityDays(v int) *SubscriptionPlanUpsert {
+func (u *SubscriptionPlanUpsert) SetValidityDays(v float64) *SubscriptionPlanUpsert {
 	u.Set(subscriptionplan.FieldValidityDays, v)
 	return u
 }
@@ -534,7 +534,7 @@ func (u *SubscriptionPlanUpsert) UpdateValidityDays() *SubscriptionPlanUpsert {
 }
 
 // AddValidityDays adds v to the "validity_days" field.
-func (u *SubscriptionPlanUpsert) AddValidityDays(v int) *SubscriptionPlanUpsert {
+func (u *SubscriptionPlanUpsert) AddValidityDays(v float64) *SubscriptionPlanUpsert {
 	u.Add(subscriptionplan.FieldValidityDays, v)
 	return u
 }
@@ -761,14 +761,14 @@ func (u *SubscriptionPlanUpsertOne) ClearOriginalPrice() *SubscriptionPlanUpsert
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (u *SubscriptionPlanUpsertOne) SetValidityDays(v int) *SubscriptionPlanUpsertOne {
+func (u *SubscriptionPlanUpsertOne) SetValidityDays(v float64) *SubscriptionPlanUpsertOne {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.SetValidityDays(v)
 	})
 }
 
 // AddValidityDays adds v to the "validity_days" field.
-func (u *SubscriptionPlanUpsertOne) AddValidityDays(v int) *SubscriptionPlanUpsertOne {
+func (u *SubscriptionPlanUpsertOne) AddValidityDays(v float64) *SubscriptionPlanUpsertOne {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.AddValidityDays(v)
 	})
@@ -1182,14 +1182,14 @@ func (u *SubscriptionPlanUpsertBulk) ClearOriginalPrice() *SubscriptionPlanUpser
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (u *SubscriptionPlanUpsertBulk) SetValidityDays(v int) *SubscriptionPlanUpsertBulk {
+func (u *SubscriptionPlanUpsertBulk) SetValidityDays(v float64) *SubscriptionPlanUpsertBulk {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.SetValidityDays(v)
 	})
 }
 
 // AddValidityDays adds v to the "validity_days" field.
-func (u *SubscriptionPlanUpsertBulk) AddValidityDays(v int) *SubscriptionPlanUpsertBulk {
+func (u *SubscriptionPlanUpsertBulk) AddValidityDays(v float64) *SubscriptionPlanUpsertBulk {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.AddValidityDays(v)
 	})

--- a/backend/ent/subscriptionplan_update.go
+++ b/backend/ent/subscriptionplan_update.go
@@ -126,14 +126,14 @@ func (_u *SubscriptionPlanUpdate) ClearOriginalPrice() *SubscriptionPlanUpdate {
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (_u *SubscriptionPlanUpdate) SetValidityDays(v int) *SubscriptionPlanUpdate {
+func (_u *SubscriptionPlanUpdate) SetValidityDays(v float64) *SubscriptionPlanUpdate {
 	_u.mutation.ResetValidityDays()
 	_u.mutation.SetValidityDays(v)
 	return _u
 }
 
 // SetNillableValidityDays sets the "validity_days" field if the given value is not nil.
-func (_u *SubscriptionPlanUpdate) SetNillableValidityDays(v *int) *SubscriptionPlanUpdate {
+func (_u *SubscriptionPlanUpdate) SetNillableValidityDays(v *float64) *SubscriptionPlanUpdate {
 	if v != nil {
 		_u.SetValidityDays(*v)
 	}
@@ -141,7 +141,7 @@ func (_u *SubscriptionPlanUpdate) SetNillableValidityDays(v *int) *SubscriptionP
 }
 
 // AddValidityDays adds value to the "validity_days" field.
-func (_u *SubscriptionPlanUpdate) AddValidityDays(v int) *SubscriptionPlanUpdate {
+func (_u *SubscriptionPlanUpdate) AddValidityDays(v float64) *SubscriptionPlanUpdate {
 	_u.mutation.AddValidityDays(v)
 	return _u
 }
@@ -330,10 +330,10 @@ func (_u *SubscriptionPlanUpdate) sqlSave(ctx context.Context) (_node int, err e
 		_spec.ClearField(subscriptionplan.FieldOriginalPrice, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.ValidityDays(); ok {
-		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.AddedValidityDays(); ok {
-		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.ValidityUnit(); ok {
 		_spec.SetField(subscriptionplan.FieldValidityUnit, field.TypeString, value)
@@ -474,14 +474,14 @@ func (_u *SubscriptionPlanUpdateOne) ClearOriginalPrice() *SubscriptionPlanUpdat
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (_u *SubscriptionPlanUpdateOne) SetValidityDays(v int) *SubscriptionPlanUpdateOne {
+func (_u *SubscriptionPlanUpdateOne) SetValidityDays(v float64) *SubscriptionPlanUpdateOne {
 	_u.mutation.ResetValidityDays()
 	_u.mutation.SetValidityDays(v)
 	return _u
 }
 
 // SetNillableValidityDays sets the "validity_days" field if the given value is not nil.
-func (_u *SubscriptionPlanUpdateOne) SetNillableValidityDays(v *int) *SubscriptionPlanUpdateOne {
+func (_u *SubscriptionPlanUpdateOne) SetNillableValidityDays(v *float64) *SubscriptionPlanUpdateOne {
 	if v != nil {
 		_u.SetValidityDays(*v)
 	}
@@ -489,7 +489,7 @@ func (_u *SubscriptionPlanUpdateOne) SetNillableValidityDays(v *int) *Subscripti
 }
 
 // AddValidityDays adds value to the "validity_days" field.
-func (_u *SubscriptionPlanUpdateOne) AddValidityDays(v int) *SubscriptionPlanUpdateOne {
+func (_u *SubscriptionPlanUpdateOne) AddValidityDays(v float64) *SubscriptionPlanUpdateOne {
 	_u.mutation.AddValidityDays(v)
 	return _u
 }
@@ -708,10 +708,10 @@ func (_u *SubscriptionPlanUpdateOne) sqlSave(ctx context.Context) (_node *Subscr
 		_spec.ClearField(subscriptionplan.FieldOriginalPrice, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.ValidityDays(); ok {
-		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.AddedValidityDays(); ok {
-		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.ValidityUnit(); ok {
 		_spec.SetField(subscriptionplan.FieldValidityUnit, field.TypeString, value)

--- a/backend/internal/service/payment_config_plans.go
+++ b/backend/internal/service/payment_config_plans.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
@@ -12,7 +13,7 @@ import (
 )
 
 // validatePlanRequired checks that all required fields for a plan are provided.
-func validatePlanRequired(name string, groupID int64, price float64, validityDays int, validityUnit string, originalPrice *float64) error {
+func validatePlanRequired(name string, groupID int64, price float64, validityDays float64, validityUnit string, originalPrice *float64) error {
 	if strings.TrimSpace(name) == "" {
 		return infraerrors.BadRequest("PLAN_NAME_REQUIRED", "plan name is required")
 	}
@@ -22,7 +23,7 @@ func validatePlanRequired(name string, groupID int64, price float64, validityDay
 	if price <= 0 {
 		return infraerrors.BadRequest("PLAN_PRICE_INVALID", "price must be > 0")
 	}
-	if validityDays <= 0 {
+	if validityDays <= 0 || math.IsNaN(validityDays) || math.IsInf(validityDays, 0) {
 		return infraerrors.BadRequest("PLAN_VALIDITY_REQUIRED", "validity days must be > 0")
 	}
 	if strings.TrimSpace(validityUnit) == "" {
@@ -45,7 +46,7 @@ func validatePlanPatch(req UpdatePlanRequest) error {
 	if req.Price != nil && *req.Price <= 0 {
 		return infraerrors.BadRequest("PLAN_PRICE_INVALID", "price must be > 0")
 	}
-	if req.ValidityDays != nil && *req.ValidityDays <= 0 {
+	if req.ValidityDays != nil && (*req.ValidityDays <= 0 || math.IsNaN(*req.ValidityDays) || math.IsInf(*req.ValidityDays, 0)) {
 		return infraerrors.BadRequest("PLAN_VALIDITY_REQUIRED", "validity days must be > 0")
 	}
 	if req.ValidityUnit != nil && strings.TrimSpace(*req.ValidityUnit) == "" {

--- a/backend/internal/service/payment_config_plans_validation_test.go
+++ b/backend/internal/service/payment_config_plans_validation_test.go
@@ -171,7 +171,7 @@ func TestValidatePlanPatch_ValidPrice(t *testing.T) {
 }
 
 func TestValidatePlanPatch_ZeroValidityDays(t *testing.T) {
-	err := validatePlanPatch(UpdatePlanRequest{ValidityDays: ptrInt(0)})
+	err := validatePlanPatch(UpdatePlanRequest{ValidityDays: ptrFloat(0)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "validity days")
 }

--- a/backend/internal/service/payment_config_service.go
+++ b/backend/internal/service/payment_config_service.go
@@ -155,7 +155,7 @@ type CreatePlanRequest struct {
 	Description   string   `json:"description"`
 	Price         float64  `json:"price"`
 	OriginalPrice *float64 `json:"original_price"`
-	ValidityDays  int      `json:"validity_days"`
+	ValidityDays  float64  `json:"validity_days"`
 	ValidityUnit  string   `json:"validity_unit"`
 	Features      string   `json:"features"`
 	ProductName   string   `json:"product_name"`
@@ -169,7 +169,7 @@ type UpdatePlanRequest struct {
 	Description   *string  `json:"description"`
 	Price         *float64 `json:"price"`
 	OriginalPrice *float64 `json:"original_price"`
-	ValidityDays  *int     `json:"validity_days"`
+	ValidityDays  *float64 `json:"validity_days"`
 	ValidityUnit  *string  `json:"validity_unit"`
 	Features      *string  `json:"features"`
 	ProductName   *string  `json:"product_name"`

--- a/backend/internal/service/payment_fulfillment.go
+++ b/backend/internal/service/payment_fulfillment.go
@@ -365,7 +365,9 @@ func (s *PaymentService) sendSubscriptionPurchaseSuccessNotification(ctx context
 		"expiry_time":        "",
 		"order_id":           strconv.FormatInt(o.ID, 10),
 	}
-	if o.SubscriptionDays != nil {
+	if seconds := subscriptionValiditySecondsFromOrder(o); seconds > 0 {
+		variables["subscription_days"] = formatSubscriptionValidityDays(seconds)
+	} else if o.SubscriptionDays != nil {
 		variables["subscription_days"] = strconv.Itoa(*o.SubscriptionDays)
 	}
 	if o.SubscriptionGroupID != nil {
@@ -425,6 +427,10 @@ func (s *PaymentService) ExecuteSubscriptionFulfillment(ctx context.Context, oid
 func (s *PaymentService) doSub(ctx context.Context, o *dbent.PaymentOrder) error {
 	gid := *o.SubscriptionGroupID
 	days := *o.SubscriptionDays
+	validityDuration := time.Duration(0)
+	if seconds := subscriptionValiditySecondsFromOrder(o); seconds > 0 {
+		validityDuration = time.Duration(seconds) * time.Second
+	}
 	g, err := s.groupRepo.GetByID(ctx, gid)
 	if err != nil || g.Status != payment.EntityStatusActive {
 		return fmt.Errorf("group %d no longer exists or inactive", gid)
@@ -436,11 +442,26 @@ func (s *PaymentService) doSub(ctx context.Context, o *dbent.PaymentOrder) error
 		return s.markCompleted(ctx, o, "SUBSCRIPTION_SUCCESS")
 	}
 	orderNote := fmt.Sprintf("payment order %d", o.ID)
-	_, _, err = s.subscriptionSvc.AssignOrExtendSubscription(ctx, &AssignSubscriptionInput{UserID: o.UserID, GroupID: gid, ValidityDays: days, AssignedBy: 0, Notes: orderNote})
+	_, _, err = s.subscriptionSvc.AssignOrExtendSubscription(ctx, &AssignSubscriptionInput{UserID: o.UserID, GroupID: gid, ValidityDays: days, ValidityDuration: validityDuration, AssignedBy: 0, Notes: orderNote})
 	if err != nil {
 		return fmt.Errorf("assign subscription: %w", err)
 	}
 	return s.markCompleted(ctx, o, "SUBSCRIPTION_SUCCESS")
+}
+
+func subscriptionValiditySecondsFromOrder(o *dbent.PaymentOrder) int64 {
+	if snapshot := psOrderProviderSnapshot(o); snapshot != nil && snapshot.SubscriptionValiditySeconds > 0 {
+		return snapshot.SubscriptionValiditySeconds
+	}
+	return 0
+}
+
+func formatSubscriptionValidityDays(seconds int64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	days := float64(seconds) / 86400
+	return strconv.FormatFloat(days, 'f', -1, 64)
 }
 
 func (s *PaymentService) hasAuditLog(ctx context.Context, orderID int64, action string) bool {

--- a/backend/internal/service/payment_order.go
+++ b/backend/internal/service/payment_order.go
@@ -201,11 +201,18 @@ func (s *PaymentService) createOrderInTx(ctx context.Context, req CreateOrderReq
 	if selectedProviderKey != "" {
 		b.SetProviderKey(selectedProviderKey)
 	}
+	if plan != nil {
+		validityDays, validityDuration := psComputeValidityForOrder(plan.ValidityDays, plan.ValidityUnit)
+		b.SetPlanID(plan.ID).SetSubscriptionGroupID(plan.GroupID).SetSubscriptionDays(validityDays)
+		if validityDuration > 0 {
+			if providerSnapshot == nil {
+				providerSnapshot = map[string]any{"schema_version": 2}
+			}
+			providerSnapshot["subscription_validity_seconds"] = int64(validityDuration / time.Second)
+		}
+	}
 	if providerSnapshot != nil {
 		b.SetProviderSnapshot(providerSnapshot)
-	}
-	if plan != nil {
-		b.SetPlanID(plan.ID).SetSubscriptionGroupID(plan.GroupID).SetSubscriptionDays(psComputeValidityDays(plan.ValidityDays, plan.ValidityUnit))
 	}
 	order, err := b.Save(ctx)
 	if err != nil {

--- a/backend/internal/service/payment_order_provider_snapshot.go
+++ b/backend/internal/service/payment_order_provider_snapshot.go
@@ -11,13 +11,14 @@ import (
 )
 
 type paymentOrderProviderSnapshot struct {
-	SchemaVersion      int
-	ProviderInstanceID string
-	ProviderKey        string
-	PaymentMode        string
-	MerchantAppID      string
-	MerchantID         string
-	Currency           string
+	SchemaVersion               int
+	ProviderInstanceID          string
+	ProviderKey                 string
+	PaymentMode                 string
+	MerchantAppID               string
+	MerchantID                  string
+	Currency                    string
+	SubscriptionValiditySeconds int64
 }
 
 func psOrderProviderSnapshot(order *dbent.PaymentOrder) *paymentOrderProviderSnapshot {
@@ -26,13 +27,14 @@ func psOrderProviderSnapshot(order *dbent.PaymentOrder) *paymentOrderProviderSna
 	}
 
 	snapshot := &paymentOrderProviderSnapshot{
-		SchemaVersion:      psSnapshotIntValue(order.ProviderSnapshot["schema_version"]),
-		ProviderInstanceID: psSnapshotStringValue(order.ProviderSnapshot["provider_instance_id"]),
-		ProviderKey:        psSnapshotStringValue(order.ProviderSnapshot["provider_key"]),
-		PaymentMode:        psSnapshotStringValue(order.ProviderSnapshot["payment_mode"]),
-		MerchantAppID:      psSnapshotStringValue(order.ProviderSnapshot["merchant_app_id"]),
-		MerchantID:         psSnapshotStringValue(order.ProviderSnapshot["merchant_id"]),
-		Currency:           psSnapshotStringValue(order.ProviderSnapshot["currency"]),
+		SchemaVersion:               psSnapshotIntValue(order.ProviderSnapshot["schema_version"]),
+		ProviderInstanceID:          psSnapshotStringValue(order.ProviderSnapshot["provider_instance_id"]),
+		ProviderKey:                 psSnapshotStringValue(order.ProviderSnapshot["provider_key"]),
+		PaymentMode:                 psSnapshotStringValue(order.ProviderSnapshot["payment_mode"]),
+		MerchantAppID:               psSnapshotStringValue(order.ProviderSnapshot["merchant_app_id"]),
+		MerchantID:                  psSnapshotStringValue(order.ProviderSnapshot["merchant_id"]),
+		Currency:                    psSnapshotStringValue(order.ProviderSnapshot["currency"]),
+		SubscriptionValiditySeconds: psSnapshotInt64Value(order.ProviderSnapshot["subscription_validity_seconds"]),
 	}
 	if snapshot.SchemaVersion == 0 &&
 		snapshot.ProviderInstanceID == "" &&
@@ -40,7 +42,8 @@ func psOrderProviderSnapshot(order *dbent.PaymentOrder) *paymentOrderProviderSna
 		snapshot.PaymentMode == "" &&
 		snapshot.MerchantAppID == "" &&
 		snapshot.MerchantID == "" &&
-		snapshot.Currency == "" {
+		snapshot.Currency == "" &&
+		snapshot.SubscriptionValiditySeconds == 0 {
 		return nil
 	}
 	return snapshot
@@ -56,19 +59,23 @@ func psSnapshotStringValue(value any) string {
 }
 
 func psSnapshotIntValue(value any) int {
+	return int(psSnapshotInt64Value(value))
+}
+
+func psSnapshotInt64Value(value any) int64 {
 	switch typed := value.(type) {
 	case int:
-		return typed
+		return int64(typed)
 	case int32:
-		return int(typed)
+		return int64(typed)
 	case int64:
-		return int(typed)
+		return typed
 	case float32:
-		return int(typed)
+		return int64(typed)
 	case float64:
-		return int(typed)
+		return int64(typed)
 	case string:
-		n, err := strconv.Atoi(strings.TrimSpace(typed))
+		n, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
 		if err == nil {
 			return n
 		}

--- a/backend/internal/service/payment_service.go
+++ b/backend/internal/service/payment_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -341,15 +342,58 @@ const (
 	validityUnitMonth = "month"
 )
 
-func psComputeValidityDays(days int, unit string) int {
+var paymentNow = time.Now
+
+func computeSubscriptionValidity(days float64, unit string, from time.Time) (int, time.Duration) {
 	switch unit {
 	case validityUnitWeek:
-		return days * 7
+		return splitSubscriptionValidityDuration(days * 7)
 	case validityUnitMonth:
-		return days * 30
+		wholeMonths := int(days)
+		target := from.AddDate(0, wholeMonths, 0)
+		wholeDays := int(target.Sub(from).Hours() / 24)
+		fractionalMonths := days - float64(wholeMonths)
+		if fractionalMonths <= 0 {
+			return wholeDays, 0
+		}
+		fractionalWholeDays, fractionalDuration := splitSubscriptionValidityDuration(fractionalMonths * 30)
+		return wholeDays + fractionalWholeDays, fractionalDuration
 	default:
-		return days
+		return splitSubscriptionValidityDuration(days)
 	}
+}
+
+func splitSubscriptionValidityDuration(days float64) (int, time.Duration) {
+	if days <= 0 || math.IsNaN(days) || math.IsInf(days, 0) {
+		return 0, 0
+	}
+	wholeDays := int(math.Floor(days))
+	fractional := days - float64(wholeDays)
+	if fractional <= 0 {
+		return wholeDays, 0
+	}
+	seconds := int64(math.Round(fractional * 24 * float64(time.Hour/time.Second)))
+	if seconds >= int64((24*time.Hour)/time.Second) {
+		wholeDays++
+		seconds -= int64((24 * time.Hour) / time.Second)
+	}
+	return wholeDays, time.Duration(seconds) * time.Second
+}
+
+func computeSubscriptionValidityDays(days float64, unit string, from time.Time) int {
+	wholeDays, duration := computeSubscriptionValidity(days, unit, from)
+	if duration > 0 {
+		wholeDays += int(math.Ceil(duration.Hours() / 24))
+	}
+	return wholeDays
+}
+
+func psComputeValidityDays(days float64, unit string) int {
+	return computeSubscriptionValidityDays(days, unit, paymentNow())
+}
+
+func psComputeValidityForOrder(days float64, unit string) (int, time.Duration) {
+	return computeSubscriptionValidity(days, unit, paymentNow())
 }
 
 func psStartOfDayUTC(t time.Time) time.Time {

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -144,11 +144,12 @@ func (s *SubscriptionService) InvalidateSubCache(userID, groupID int64) {
 
 // AssignSubscriptionInput 分配订阅输入
 type AssignSubscriptionInput struct {
-	UserID       int64
-	GroupID      int64
-	ValidityDays int
-	AssignedBy   int64
-	Notes        string
+	UserID           int64
+	GroupID          int64
+	ValidityDays     int
+	ValidityDuration time.Duration
+	AssignedBy       int64
+	Notes            string
 }
 
 // AssignSubscription 分配订阅给用户（不允许重复分配）
@@ -183,13 +184,7 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		existingSub = nil
 	}
 
-	validityDays := input.ValidityDays
-	if validityDays <= 0 {
-		validityDays = 30
-	}
-	if validityDays > MaxValidityDays {
-		validityDays = MaxValidityDays
-	}
+	validityDuration := normalizeAssignValidityDuration(input)
 
 	// 已有订阅，执行续期（在事务中完成所有更新）
 	if existingSub != nil {
@@ -199,10 +194,10 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		isExpired := !existingSub.ExpiresAt.After(now)
 		if !isExpired {
 			// 未过期：从当前过期时间累加
-			newExpiresAt = existingSub.ExpiresAt.AddDate(0, 0, validityDays)
+			newExpiresAt = existingSub.ExpiresAt.Add(validityDuration)
 		} else {
 			// 已过期：从当前时间开始计算
-			newExpiresAt = now.AddDate(0, 0, validityDays)
+			newExpiresAt = now.Add(validityDuration)
 		}
 
 		// 确保不超过最大过期时间
@@ -340,16 +335,10 @@ func appendSubscriptionNotes(existingNotes, newNotes string) string {
 
 // createSubscription 创建新订阅（内部方法）
 func (s *SubscriptionService) createSubscription(ctx context.Context, input *AssignSubscriptionInput) (*UserSubscription, error) {
-	validityDays := input.ValidityDays
-	if validityDays <= 0 {
-		validityDays = 30
-	}
-	if validityDays > MaxValidityDays {
-		validityDays = MaxValidityDays
-	}
+	validityDuration := normalizeAssignValidityDuration(input)
 
 	now := time.Now()
-	expiresAt := now.AddDate(0, 0, validityDays)
+	expiresAt := now.Add(validityDuration)
 	if expiresAt.After(MaxExpiresAt) {
 		expiresAt = MaxExpiresAt
 	}
@@ -486,9 +475,9 @@ func detectAssignSemanticConflict(existing *UserSubscription, input *AssignSubsc
 		return "", false
 	}
 
-	normalizedDays := normalizeAssignValidityDays(input.ValidityDays)
+	validityDuration := normalizeAssignValidityDuration(input)
 	if !existing.StartsAt.IsZero() {
-		expectedExpiresAt := existing.StartsAt.AddDate(0, 0, normalizedDays)
+		expectedExpiresAt := existing.StartsAt.Add(validityDuration)
 		if expectedExpiresAt.After(MaxExpiresAt) {
 			expectedExpiresAt = MaxExpiresAt
 		}
@@ -514,6 +503,20 @@ func normalizeAssignValidityDays(days int) int {
 		days = MaxValidityDays
 	}
 	return days
+}
+
+func normalizeAssignValidityDuration(input *AssignSubscriptionInput) time.Duration {
+	if input == nil {
+		return time.Duration(30) * 24 * time.Hour
+	}
+	if input.ValidityDuration > 0 {
+		maxDuration := time.Duration(MaxValidityDays) * 24 * time.Hour
+		if input.ValidityDuration > maxDuration {
+			return maxDuration
+		}
+		return input.ValidityDuration
+	}
+	return time.Duration(normalizeAssignValidityDays(input.ValidityDays)) * 24 * time.Hour
 }
 
 // RevokeSubscription 撤销订阅

--- a/backend/migrations/149_subscription_plan_validity_days_decimal.sql
+++ b/backend/migrations/149_subscription_plan_validity_days_decimal.sql
@@ -1,0 +1,3 @@
+-- Allow subscription plan validity to store fractional days such as 0.5.
+ALTER TABLE subscription_plans
+    ALTER COLUMN validity_days TYPE numeric(20,8) USING validity_days::numeric;

--- a/frontend/src/views/admin/orders/PlanEditDialog.vue
+++ b/frontend/src/views/admin/orders/PlanEditDialog.vue
@@ -39,7 +39,7 @@
         <div><label class="input-label">{{ t('payment.admin.originalPrice') }}</label><input v-model.number="planForm.original_price" type="number" step="0.01" min="0" class="input" /></div>
       </div>
       <div class="grid grid-cols-2 gap-4">
-        <div><label class="input-label">{{ t('payment.admin.validityDays') }} <span class="text-red-500">*</span></label><input v-model.number="planForm.validity_days" type="number" min="1" class="input" required /></div>
+        <div><label class="input-label">{{ t('payment.admin.validityDays') }} <span class="text-red-500">*</span></label><input v-model.number="planForm.validity_days" type="number" min="0.001" step="any" class="input" required /></div>
         <div><label class="input-label">{{ t('payment.admin.validityUnit') }} <span class="text-red-500">*</span></label><Select v-model="planForm.validity_unit" :options="validityUnitOptions" /></div>
       </div>
       <div class="grid grid-cols-2 gap-4">
@@ -167,7 +167,7 @@ async function handleSavePlan() {
     appStore.showError(t('payment.admin.priceRequired'))
     return
   }
-  if (!planForm.validity_days || planForm.validity_days < 1) {
+  if (!planForm.validity_days || planForm.validity_days <= 0) {
     appStore.showError(t('payment.admin.validityDaysRequired'))
     return
   }


### PR DESCRIPTION
Summary:
- Allow subscription plan validity to be stored and processed as decimal days.
- Add a migration for decimal validity values.
- Update payment plan validation, fulfillment, order handling, and the admin plan editor for fractional-day durations.

Tests:
- Not run in this split pass.