### PR TITLE
feat: make gateway failover policy configurable

### DIFF
--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -156,6 +156,23 @@ func (s *FailoverState) HandleSelectionExhausted(ctx context.Context) FailoverAc
 
 // needForceCacheBilling 判断 failover 时是否需要强制缓存计费。
 // 粘性会话切换账号、或上游明确标记时，将 input_tokens 转为 cache_read 计费。
+// HandleAccountSlotExhausted excludes a saturated account and continues the
+// failover loop so another account can be selected instead of failing the
+// request immediately.
+func (s *FailoverState) HandleAccountSlotExhausted(ctx context.Context, accountID int64) FailoverAction {
+	s.FailedAccountIDs[accountID] = struct{}{}
+	if s.SwitchCount >= s.MaxSwitches {
+		return FailoverExhausted
+	}
+	s.SwitchCount++
+	logger.FromContext(ctx).Warn("gateway.failover_account_slot_exhausted_switch_account",
+		zap.Int64("account_id", accountID),
+		zap.Int("switch_count", s.SwitchCount),
+		zap.Int("max_switches", s.MaxSwitches),
+	)
+	return FailoverContinue
+}
+
 func needForceCacheBilling(hasBoundSession bool, failoverErr *service.UpstreamFailoverError) bool {
 	return hasBoundSession || (failoverErr != nil && failoverErr.ForceCacheBilling)
 }

--- a/backend/internal/handler/failover_loop_test.go
+++ b/backend/internal/handler/failover_loop_test.go
@@ -70,6 +70,27 @@ func TestNewFailoverState(t *testing.T) {
 	})
 }
 
+func TestHandleAccountSlotExhausted(t *testing.T) {
+	fs := NewFailoverState(2, false)
+
+	action := fs.HandleAccountSlotExhausted(context.Background(), 101)
+	if action != FailoverContinue {
+		t.Fatalf("first saturated account: got %v, want %v", action, FailoverContinue)
+	}
+	if _, ok := fs.FailedAccountIDs[101]; !ok {
+		t.Fatalf("expected saturated account to be excluded")
+	}
+	if fs.SwitchCount != 1 {
+		t.Fatalf("switch count = %d, want 1", fs.SwitchCount)
+	}
+
+	_ = fs.HandleAccountSlotExhausted(context.Background(), 102)
+	action = fs.HandleAccountSlotExhausted(context.Background(), 103)
+	if action != FailoverExhausted {
+		t.Fatalf("exhausted action: got %v, want %v", action, FailoverExhausted)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // sleepWithContext 测试
 // ---------------------------------------------------------------------------

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -420,6 +420,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				if err != nil {
 					reqLog.Warn("gateway.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 					releaseWait()
+					if fs.HandleAccountSlotExhausted(c.Request.Context(), account.ID) == FailoverContinue {
+						continue
+					}
 					h.handleConcurrencyError(c, err, "account", streamStarted)
 					return
 				}
@@ -693,6 +696,9 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 				if err != nil {
 					reqLog.Warn("gateway.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
 					releaseWait()
+					if fs.HandleAccountSlotExhausted(c.Request.Context(), account.ID) == FailoverContinue {
+						continue
+					}
 					h.handleConcurrencyError(c, err, "account", streamStarted)
 					return
 				}

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -225,6 +225,9 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 			)
 			if err != nil {
 				reqLog.Warn("gateway.cc.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+				if fs.HandleAccountSlotExhausted(c.Request.Context(), account.ID) == FailoverContinue {
+					continue
+				}
 				h.handleConcurrencyError(c, err, "account", streamStarted)
 				return
 			}

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -223,6 +223,9 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 			)
 			if err != nil {
 				reqLog.Warn("gateway.responses.account_slot_acquire_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+				if fs.HandleAccountSlotExhausted(c.Request.Context(), account.ID) == FailoverContinue {
+					continue
+				}
 				h.handleConcurrencyError(c, err, "account", streamStarted)
 				return
 			}

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -2509,12 +2509,7 @@ handleSuccess:
 }
 
 func (s *AntigravityGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
-	switch statusCode {
-	case 401, 403, 429, 529:
-		return true
-	default:
-		return statusCode >= 500
-	}
+	return shouldFailoverStatusCode(statusCode)
 }
 
 // isGoogleProjectConfigError 判断（已提取的小写）错误消息是否属于 Google 服务端配置类问题。

--- a/backend/internal/service/failover_status_policy.go
+++ b/backend/internal/service/failover_status_policy.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	failoverStatusCodesEnv        = "SUB2API_FAILOVER_STATUS_CODES"
+	failoverExcludeStatusCodesEnv = "SUB2API_FAILOVER_EXCLUDE_STATUS_CODES"
+)
+
+// shouldFailoverStatusCode applies the runtime-configurable upstream HTTP failover policy.
+//
+// SUB2API_FAILOVER_STATUS_CODES defaults to ">=400".
+// SUB2API_FAILOVER_EXCLUDE_STATUS_CODES defaults to "524".
+//
+// Supported tokens: 429, 400-499, >=500, <=499, 4xx, 5xx. Tokens are separated
+// by comma, semicolon, pipe, or whitespace. Invalid tokens are ignored; if no
+// include token is valid, the default include policy is used.
+func shouldFailoverStatusCode(statusCode int) bool {
+	if !statusCodeMatchesPolicy(statusCode, os.Getenv(failoverStatusCodesEnv), ">=400") {
+		return false
+	}
+	return !statusCodeMatchesPolicy(statusCode, os.Getenv(failoverExcludeStatusCodesEnv), "524")
+}
+
+func statusCodeMatchesPolicy(statusCode int, raw string, defaultRaw string) bool {
+	if raw == "" {
+		raw = defaultRaw
+	}
+	matched, valid := false, false
+	for _, token := range splitStatusPolicy(raw) {
+		tokenMatched, tokenValid := statusPolicyTokenMatches(statusCode, token)
+		if !tokenValid {
+			continue
+		}
+		valid = true
+		matched = matched || tokenMatched
+	}
+	if !valid && defaultRaw != "" && raw != defaultRaw {
+		return statusCodeMatchesPolicy(statusCode, defaultRaw, "")
+	}
+	return matched
+}
+
+func splitStatusPolicy(raw string) []string {
+	return strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == '|' || r == ' ' || r == '\t' || r == '\n' || r == '\r'
+	})
+}
+
+func statusPolicyTokenMatches(statusCode int, token string) (bool, bool) {
+	token = strings.ToLower(strings.TrimSpace(token))
+	if token == "" {
+		return false, false
+	}
+	if strings.HasSuffix(token, "xx") && len(token) == 3 {
+		prefix, err := strconv.Atoi(token[:1])
+		if err != nil {
+			return false, false
+		}
+		start := prefix * 100
+		return statusCode >= start && statusCode <= start+99, true
+	}
+	if strings.HasPrefix(token, ">=") || strings.HasPrefix(token, "<=") {
+		n, err := strconv.Atoi(strings.TrimSpace(token[2:]))
+		if err != nil {
+			return false, false
+		}
+		if strings.HasPrefix(token, ">=") {
+			return statusCode >= n, true
+		}
+		return statusCode <= n, true
+	}
+	if strings.HasPrefix(token, ">") || strings.HasPrefix(token, "<") {
+		n, err := strconv.Atoi(strings.TrimSpace(token[1:]))
+		if err != nil {
+			return false, false
+		}
+		if strings.HasPrefix(token, ">") {
+			return statusCode > n, true
+		}
+		return statusCode < n, true
+	}
+	if strings.Contains(token, "-") {
+		parts := strings.SplitN(token, "-", 2)
+		start, errStart := strconv.Atoi(strings.TrimSpace(parts[0]))
+		end, errEnd := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if errStart != nil || errEnd != nil {
+			return false, false
+		}
+		if start > end {
+			start, end = end, start
+		}
+		return statusCode >= start && statusCode <= end, true
+	}
+	n, err := strconv.Atoi(token)
+	if err != nil {
+		return false, false
+	}
+	return statusCode == n, true
+}

--- a/backend/internal/service/failover_status_policy_test.go
+++ b/backend/internal/service/failover_status_policy_test.go
@@ -1,0 +1,73 @@
+package service
+
+import "testing"
+
+func TestShouldFailoverStatusCodeDefaultPolicy(t *testing.T) {
+	t.Setenv(failoverStatusCodesEnv, "")
+	t.Setenv(failoverExcludeStatusCodesEnv, "")
+
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{399, false},
+		{400, true},
+		{404, true},
+		{500, true},
+		{524, false},
+		{529, true},
+	}
+
+	for _, tt := range tests {
+		if got := shouldFailoverStatusCode(tt.status); got != tt.want {
+			t.Fatalf("status %d: got %v, want %v", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestShouldFailoverStatusCodeEnvOverrides(t *testing.T) {
+	t.Setenv(failoverStatusCodesEnv, "401, 429, 500-599")
+	t.Setenv(failoverExcludeStatusCodesEnv, "503|529")
+
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{400, false},
+		{401, true},
+		{429, true},
+		{500, true},
+		{503, false},
+		{524, true},
+		{529, false},
+	}
+
+	for _, tt := range tests {
+		if got := shouldFailoverStatusCode(tt.status); got != tt.want {
+			t.Fatalf("status %d: got %v, want %v", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestShouldFailoverStatusCodeSupportsClassAndComparisons(t *testing.T) {
+	t.Setenv(failoverStatusCodesEnv, "4xx >=500")
+	t.Setenv(failoverExcludeStatusCodesEnv, "<=401")
+
+	tests := []struct {
+		status int
+		want   bool
+	}{
+		{399, false},
+		{400, false},
+		{401, false},
+		{402, true},
+		{499, true},
+		{500, true},
+	}
+
+	for _, tt := range tests {
+		if got := shouldFailoverStatusCode(tt.status); got != tt.want {
+			t.Fatalf("status %d: got %v, want %v", tt.status, got, tt.want)
+		}
+	}
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2307,12 +2307,7 @@ func (s *OpenAIGatewayService) GetAccessToken(ctx context.Context, account *Acco
 }
 
 func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
-	switch statusCode {
-	case 401, 402, 403, 429, 529:
-		return true
-	default:
-		return statusCode >= 500
-	}
+	return shouldFailoverStatusCode(statusCode)
 }
 
 func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
@@ -3521,12 +3516,7 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 }
 
 func shouldFailoverOpenAIPassthroughResponse(statusCode int) bool {
-	switch statusCode {
-	case http.StatusTooManyRequests, 529:
-		return true
-	default:
-		return false
-	}
+	return shouldFailoverStatusCode(statusCode)
 }
 
 func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(


### PR DESCRIPTION
Summary:
- Add runtime-configurable HTTP status failover policy via SUB2API_FAILOVER_STATUS_CODES and SUB2API_FAILOVER_EXCLUDE_STATUS_CODES.
- Apply the shared failover policy to OpenAI and Antigravity gateway upstream errors, including passthrough OpenAI responses.
- Treat saturated account slots as failover candidates so the loop can select another account before returning concurrency errors.

Tests:
- go test ./internal/service -run TestShouldFailoverStatusCode
- go test ./internal/handler -run TestHandleAccountSlotExhausted