### PR TITLE
fix(ui): 账号管理状态下拉菜单列表显示不全的问题

### DIFF
--- a/frontend/src/components/common/Select.vue
+++ b/frontend/src/components/common/Select.vue
@@ -517,7 +517,7 @@ onUnmounted(() => {
 }
 
 .select-dropdown-portal .select-options {
-  @apply max-h-60 overflow-y-auto py-1 outline-none;
+  @apply max-h-80 overflow-y-auto py-1 outline-none;
 }
 
 .select-dropdown-portal .select-option {


### PR DESCRIPTION
<img width="560" height="728" alt="image" src="https://github.com/user-attachments/assets/f7a29ca8-d707-45cf-afb3-c6708629668c" />
由于高度限制, 最后一个选项没有显示出来, 容易造成用户误解
增加高度, 显示全部选项
修复后:
<img width="1254" height="656" alt="image" src="https://github.com/user-attachments/assets/21988eb1-0350-4cde-b6c8-39b84986628d" />
