### PR TITLE
fix(openai): detect small silent refusals

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions_raw_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw_test.go
@@ -227,7 +227,7 @@ func TestForwardAsRawChatCompletions_PreservesDeepSeekReasoningContentInRequest(
 func TestForwardAsRawChatCompletions_SilentRefusalTriggersFailover(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	body := largeRawChatCompletionsBody()
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":true}`)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
@@ -265,7 +265,7 @@ func TestForwardAsRawChatCompletions_SilentRefusalTriggersFailover(t *testing.T)
 func TestForwardAsRawChatCompletions_SilentRefusalToolCallsExempt(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	body := largeRawChatCompletionsBody()
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":true}`)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
@@ -340,7 +340,7 @@ func TestHandleChatStreamingResponse_SilentRefusalReasoningSummaryExempt(t *test
 func TestForwardAsRawChatCompletions_SilentRefusalNormalContentExempt(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	body := largeRawChatCompletionsBody()
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":true}`)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))

--- a/backend/internal/service/openai_silent_refusal.go
+++ b/backend/internal/service/openai_silent_refusal.go
@@ -30,10 +30,8 @@ type openAIChatSilentRefusalDetector struct {
 	finishReason    string
 }
 
-func newOpenAIChatSilentRefusalDetector(requestBodyLen int) *openAIChatSilentRefusalDetector {
-	return &openAIChatSilentRefusalDetector{
-		enabled: requestBodyLen >= openAISilentRefusalMinRequestBodyBytes,
-	}
+func newOpenAIChatSilentRefusalDetector(_ int) *openAIChatSilentRefusalDetector {
+	return &openAIChatSilentRefusalDetector{enabled: true}
 }
 
 func (d *openAIChatSilentRefusalDetector) Enabled() bool {


### PR DESCRIPTION
## Summary
- enable OpenAI silent-refusal detection for small chat completion requests
- update silent-refusal streaming tests to cover short request bodies

## Rationale
OpenAI upstream can return a successful streaming response that contains only an assistant role / empty content followed by `finish_reason=stop`, with no content, tool call, reasoning, usage, or error. Before this change, the gateway only enabled silent-refusal detection when the request body was at least 64 KiB, so smaller requests could be forwarded as a normal 200 stream and clients would see an empty answer.

The detector already waits to release buffered stream output until it observes real content, a tool/function call, reasoning, usage, an error, or a non-stop finish reason. Enabling it for all request sizes makes small requests follow the same failover/error path as large requests, without changing normal streaming behavior. The updated tests use short request bodies to lock this case while keeping exemptions for tool calls, reasoning-only streams, and normal content.

## Testing
- `cd backend && go test -tags=unit ./internal/service -run 'TestForwardAsRawChatCompletions_SilentRefusal|TestHandleChatStreamingResponse_SilentRefusalReasoningSummaryExempt|TestForwardAsChatCompletions_StreamsUsageWithoutClientStreamOptions'`

## CLA
I have read the CLA Document and I hereby sign the CLA