### PR TITLE
fix(openai): Chat Completions 转 Responses 时保留 prompt_cache_key

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -187,6 +187,22 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		}
 	}
 
+	if account.Type == AccountTypeAPIKey {
+		if trimmedKey := strings.TrimSpace(promptCacheKey); trimmedKey != "" {
+			var reqBody map[string]any
+			if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
+				return nil, fmt.Errorf("unmarshal for prompt cache key injection: %w", err)
+			}
+			if existing, ok := reqBody["prompt_cache_key"].(string); !ok || strings.TrimSpace(existing) == "" {
+				reqBody["prompt_cache_key"] = trimmedKey
+				responsesBody, err = json.Marshal(reqBody)
+				if err != nil {
+					return nil, fmt.Errorf("remarshal after prompt cache key injection: %w", err)
+				}
+			}
+		}
+	}
+
 	// 4b. Apply OpenAI fast policy (may filter service_tier or block the request).
 	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, responsesBody)
 	if policyErr != nil {
@@ -214,7 +230,8 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	}
 
 	if promptCacheKey != "" {
-		upstreamReq.Header.Set("session_id", generateSessionUUID(promptCacheKey))
+		apiKeyID := getAPIKeyIDFromContext(c)
+		upstreamReq.Header.Set("session_id", generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey)))
 	}
 
 	// 7. Send request

--- a/backend/internal/service/openai_gateway_chat_completions_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -112,7 +113,10 @@ func TestForwardAsChatCompletions_UnknownModelDoesNotUseDefaultMappedModel(t *te
 		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"model not found"}}`)),
 	}}
 
-	svc := &OpenAIGatewayService{httpUpstream: upstream}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
 	account := &Account{
 		ID:          1,
 		Name:        "openai-oauth",
@@ -131,6 +135,50 @@ func TestForwardAsChatCompletions_UnknownModelDoesNotUseDefaultMappedModel(t *te
 	require.Equal(t, "gpt6", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.NotEqual(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestForwardAsChatCompletions_APIKeyPropagatesPromptCacheKeyInResponsesBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Set("api_key", &APIKey{ID: 99})
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_chat_prompt_cache"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"invalid_request_error","message":"stop before response parsing"}}`)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          2,
+		Name:        "openai-compatible",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-compatible",
+		},
+		Extra: map[string]any{
+			"openai_responses_supported": true,
+		},
+	}
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body, "cache-key-123", "gpt-5.4")
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "cache-key-123", gjson.GetBytes(upstream.lastBody, "prompt_cache_key").String())
+	require.Equal(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "https://api.openai.com/v1/responses", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer sk-compatible", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, generateSessionUUID(isolateOpenAISessionID(99, "cache-key-123")), upstream.lastReq.Header.Get("session_id"))
 }
 
 func TestForwardAsChatCompletions_ClientDisconnectDrainsUpstreamUsage(t *testing.T) {


### PR DESCRIPTION
## 背景

这条修复针对 OpenAI-compatible 入口的转换链路：

- 入站：`/v1/chat/completions`
- 上游：`/v1/responses`

这个路径会先把 Chat Completions 请求转换成 OpenAI Responses 请求，再转发给上游。问题是 API Key / compatible 账号在转换后会丢掉原始请求里的会话缓存信号，导致上游看不到 `prompt_cache_key`，同一段对话在 Responses 侧更容易表现成缓存不命中或会话不连续。

本地 OAuth 账号路径之前没有这个问题，因为 OAuth 的 Codex transform 会保留或注入 `prompt_cache_key`，并且会对上游 session 做隔离。也就是说，同样是走 Responses，上游看到的请求形态在 OAuth 账号和 API Key 账号之间不一致。

## 修改内容

- API Key / OpenAI-compatible 账号走 `/v1/chat/completions -> /v1/responses` 时，如果网关已经解析到 `promptCacheKey`，会把它写回上游 Responses body 的 `prompt_cache_key` 字段。
- 设置上游 `session_id` 时，不再直接使用裸 `promptCacheKey` 生成 UUID，而是先混入当前 API Key ID：
  - 旧逻辑：`generateSessionUUID(promptCacheKey)`
  - 新逻辑：`generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey))`
- 这个行为和已有 `/v1/messages -> /v1/responses` 兼容路径保持一致，避免不同 API Key 用户使用相同 cache key 时在上游产生会话碰撞。

## 影响范围

这不是 Chat Completions / Responses 转换逻辑的大改，只补齐两个会话连续性相关信号：

- `prompt_cache_key`：让上游 Responses 仍然能看到客户端传入的缓存 key。
- `session_id`：让上游 session 继续稳定，但按 API Key 做隔离。

OAuth 账号路径的行为保持不变；API Key / compatible 账号的请求会更接近 OAuth 路径和 messages 兼容路径。

## 测试

- `go test ./internal/service -count=1`

新增回归测试覆盖 API Key 账号的 chat-completions 兼容转发，验证：

- 上游 URL 是 `/v1/responses`
- 上游 body 包含 `prompt_cache_key`
- 上游 `session_id` 使用 API Key 隔离后的值
- Authorization header 保持正确
