### PR TITLE
feat: respect url_allowlist for channel monitor SSRF

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -162,7 +162,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	announcementService := service.NewAnnouncementService(announcementRepository, announcementReadRepository, userRepository, userSubscriptionRepository)
 	announcementHandler := handler.NewAnnouncementHandler(announcementService)
 	channelMonitorRepository := repository.NewChannelMonitorRepository(client, db)
-	channelMonitorService := service.ProvideChannelMonitorService(channelMonitorRepository, secretEncryptor)
+	channelMonitorService := service.ProvideChannelMonitorService(channelMonitorRepository, secretEncryptor, configConfig)
 	channelMonitorUserHandler := handler.NewChannelMonitorUserHandler(channelMonitorService, settingService)
 	dashboardAggregationRepository := repository.NewDashboardAggregationRepository(db)
 	dashboardStatsCache := repository.NewDashboardCache(redisClient, configConfig)

--- a/backend/internal/service/channel_monitor_ssrf.go
+++ b/backend/internal/service/channel_monitor_ssrf.go
@@ -4,7 +4,14 @@ import (
 	"context"
 	"net"
 	"strings"
+	"sync/atomic"
 )
+
+// monitorAllowPrivateEndpoints 由 ProvideChannelMonitorService 在启动时按 security.url_allowlist
+// 设置：白名单整体关闭(enabled=false)或显式允许私网(allow_private_hosts=true)时放行私网/内网 endpoint，
+// 与 http_upstream.shouldValidateResolvedIP 等出站服务的语义一致，便于内网部署。
+// 默认 false：未注入配置的场景（含单测）保持原有 SSRF 防护。
+var monitorAllowPrivateEndpoints atomic.Bool
 
 // SSRF 防护 helper：
 //   - validateEndpoint 在 admin 提交时阻止 http/loopback/私网/云元数据 URL
@@ -86,6 +93,10 @@ func isPrivateIP(ip net.IP) bool {
 //
 // hostname 是 IP 字面量时也走同一路径。
 func isPrivateOrLoopbackHost(ctx context.Context, hostname string) (bool, error) {
+	// 运维显式允许私网时不再按 host/IP 拒绝；validateEndpoint 的 https / origin-only 校验仍照常执行。
+	if monitorAllowPrivateEndpoints.Load() {
+		return false, nil
+	}
 	if isBlockedHostname(hostname) {
 		return true, nil
 	}
@@ -112,6 +123,10 @@ func isPrivateOrLoopbackHost(ctx context.Context, hostname string) (bool, error)
 // safeDialContext 在真实 dial 前再次校验目标 IP，防止 DNS rebinding。
 // 解析 hostname 后逐个 IP 尝试连接，命中私网即拒绝（即便 validateEndpoint 时返回的是公网 IP）。
 func safeDialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	// 运维显式允许私网时跳过 dial 层的 IP 重校验（DNS-rebinding 防护），直接连接。
+	if monitorAllowPrivateEndpoints.Load() {
+		return monitorDialer.DialContext(ctx, network, address)
+	}
 	host, port, err := net.SplitHostPort(address)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/channel_monitor_ssrf_test.go
+++ b/backend/internal/service/channel_monitor_ssrf_test.go
@@ -1,0 +1,39 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestValidateEndpoint_AllowPrivateToggle 验证 monitorAllowPrivateEndpoints 双向生效：
+// 关闭时私网 endpoint 被拒；开启时放行，但 https / origin-only 校验不受影响。
+func TestValidateEndpoint_AllowPrivateToggle(t *testing.T) {
+	// 用例结束复位为默认 false，避免污染其它用例（包级状态）。
+	t.Cleanup(func() { monitorAllowPrivateEndpoints.Store(false) })
+
+	// 默认（false）：私网字面量 IP 被拒。
+	monitorAllowPrivateEndpoints.Store(false)
+	if err := validateEndpoint("https://10.0.0.1"); !errors.Is(err, ErrChannelMonitorEndpointPrivate) {
+		t.Fatalf("allow_private=false: 期望 ErrChannelMonitorEndpointPrivate, got %v", err)
+	}
+
+	// 开启（true）：同一私网地址通过校验。
+	monitorAllowPrivateEndpoints.Store(true)
+	for _, ep := range []string{"https://10.0.0.1", "https://192.168.1.10", "https://172.16.0.1"} {
+		if err := validateEndpoint(ep); err != nil {
+			t.Fatalf("allow_private=true: %q 期望通过, got %v", ep, err)
+		}
+	}
+
+	// 开启时仍强制 https：http 私网地址按 scheme 错误拒绝（非 SSRF 放行范围）。
+	if err := validateEndpoint("http://10.0.0.1"); !errors.Is(err, ErrChannelMonitorEndpointScheme) {
+		t.Fatalf("allow_private=true: http 期望 ErrChannelMonitorEndpointScheme, got %v", err)
+	}
+
+	// 开启时仍要求 origin-only：带 path 的地址按 path 错误拒绝。
+	if err := validateEndpoint("https://10.0.0.1/v1"); !errors.Is(err, ErrChannelMonitorEndpointPath) {
+		t.Fatalf("allow_private=true: 带 path 期望 ErrChannelMonitorEndpointPath, got %v", err)
+	}
+}

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -633,10 +633,15 @@ func ProvidePaymentOrderExpiryService(paymentSvc *PaymentService, lockCache Lead
 
 // ProvideChannelMonitorService 创建渠道监控服务（CRUD + RunCheck + 用户视图聚合）。
 // 加密器复用 wire 中已注入的 SecretEncryptor（AES-256-GCM）。
+// 同时按 security.url_allowlist 设置监控的 SSRF 私网放行开关，与本项目其它出站服务保持一致：
+// 白名单整体关闭(enabled=false)或显式允许私网(allow_private_hosts=true)时放行私网 endpoint（内网部署默认放行）。
 func ProvideChannelMonitorService(
 	repo ChannelMonitorRepository,
 	encryptor SecretEncryptor,
+	cfg *config.Config,
 ) *ChannelMonitorService {
+	allowlist := cfg.Security.URLAllowlist
+	monitorAllowPrivateEndpoints.Store(!allowlist.Enabled || allowlist.AllowPrivateHosts)
 	return NewChannelMonitorService(repo, encryptor)
 }
 

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -105,8 +105,8 @@ security:
     # Allowed hosts for CRS sync (required when using CRS sync)
     # 允许 CRS 同步的主机列表（使用 CRS 同步功能时必须配置）
     crs_hosts: []
-    # Allow localhost/private IPs for upstream/pricing/CRS (use only in trusted networks)
-    # 允许本地/私有 IP 地址用于上游/定价/CRS（仅在可信网络中使用）
+    # Allow localhost/private IPs for upstream/pricing/CRS/channel-monitor (use only in trusted networks)
+    # 允许本地/私有 IP 地址用于上游/定价/CRS/渠道监控（仅在可信网络中使用；内网部署需保持 true）
     allow_private_hosts: true
     # Allow http:// URLs when allowlist is disabled (default: false, require https)
     # 白名单禁用时是否允许 http:// URL（默认: false，要求 https）


### PR DESCRIPTION
## 背景
渠道监控（channel-monitor）的 SSRF 防护对私网/内网url一律拒绝，导致内网部署
无法监控部署在私有网段的渠道。而项目里其它出站服务（upstream / pricing / CRS 等）早已支持
通过 `security.url_allowlist` 放行私网地址，监控服务是写死的

## 改动
让渠道监控的 SSRF 防护遵循 `security.url_allowlist`，与 `http_upstream.shouldValidateResolvedIP`语义对齐
Closer: #2459

## 兼容性
默认 `false`——未注入配置的场景（含单测）保持原有 SSRF 防护，对现有部署行为无变化。
仅当运维在可信网络中显式开启 `allow_private_hosts` 或关闭白名单时才放行。

修复前:
<img width="2622" height="782" alt="image" src="https://github.com/user-attachments/assets/4ebc649d-21fc-44f1-80f3-16dc8d230038" />
修复后:
allow_private_hosts=true时, 渠道监控不再拦截内网ip
<img width="626" height="389" alt="image" src="https://github.com/user-attachments/assets/57826f30-2806-45df-9028-59fb73f85ff5" />
