### PR TITLE
fix(openai): avoid Codex image bridge on compact requests

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -692,6 +692,9 @@ type GatewayConfig struct {
 	// OpenAIResponseHeaderTimeout: OpenAI/Codex 上游等待响应头的超时时间（秒），0表示无超时
 	// OpenAI/Codex 请求可能在上游排队较久；默认不使用通用响应头超时截断。
 	OpenAIResponseHeaderTimeout int `mapstructure:"openai_response_header_timeout"`
+	// OpenAIResponsesStreamDataIntervalTimeout: OpenAI `/responses` 上游 SSE 数据间隔超时（秒），0表示禁用。
+	// Codex 长推理/compact 可能长时间只有下游 keepalive、上游无新事件；默认禁用避免误杀正常长流。
+	OpenAIResponsesStreamDataIntervalTimeout int `mapstructure:"openai_responses_stream_data_interval_timeout"`
 	// 请求体最大字节数，用于网关请求体大小限制
 	MaxBodySize int64 `mapstructure:"max_body_size"`
 	// 非流式上游响应体读取上限（字节），用于防止无界读取导致内存放大
@@ -708,6 +711,9 @@ type GatewayConfig struct {
 	// CodexImageGenerationBridgeEnabled: 是否为 Codex `/v1/responses` 自动注入 image_generation 工具和桥接指令。
 	// 默认关闭，避免纯文本 Codex 请求被意外改写；显式携带 image_generation 工具的请求仍按分组能力转发。
 	CodexImageGenerationBridgeEnabled bool `mapstructure:"codex_image_generation_bridge_enabled"`
+	// CompactDrainAfterClientDisconnect: Codex compact/internal summary 请求下游断开后是否继续 drain 上游。
+	// 默认关闭，避免内部摘要任务在客户端超时后继续占用连接/内存。
+	CompactDrainAfterClientDisconnect bool `mapstructure:"compact_drain_after_client_disconnect"`
 	// ForcedCodexInstructionsTemplateFile: 服务端强制附加到 Codex 顶层 instructions 的模板文件路径。
 	// 模板渲染后会直接覆盖最终 instructions；若需要保留客户端 system 转换结果，请在模板中显式引用 {{ .ExistingInstructions }}。
 	ForcedCodexInstructionsTemplateFile string `mapstructure:"forced_codex_instructions_template_file"`
@@ -1812,6 +1818,7 @@ func setDefaults() {
 	// Gateway
 	viper.SetDefault("gateway.response_header_timeout", 600) // 600秒(10分钟)等待上游响应头，LLM高负载时可能排队较久
 	viper.SetDefault("gateway.openai_response_header_timeout", 0)
+	viper.SetDefault("gateway.openai_responses_stream_data_interval_timeout", 0)
 	viper.SetDefault("gateway.log_upstream_error_body", true)
 	viper.SetDefault("gateway.log_upstream_error_body_max_bytes", 2048)
 	viper.SetDefault("gateway.inject_beta_for_apikey", false)
@@ -1820,6 +1827,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.max_account_switches_gemini", 3)
 	viper.SetDefault("gateway.force_codex_cli", false)
 	viper.SetDefault("gateway.codex_image_generation_bridge_enabled", false)
+	viper.SetDefault("gateway.compact_drain_after_client_disconnect", false)
 	viper.SetDefault("gateway.openai_passthrough_allow_timeout_headers", false)
 	// OpenAI Responses WebSocket（默认开启；可通过 force_http 紧急回滚）
 	viper.SetDefault("gateway.openai_ws.enabled", true)
@@ -2448,6 +2456,13 @@ func (c *Config) Validate() error {
 	}
 	if c.Gateway.OpenAIResponseHeaderTimeout < 0 {
 		return fmt.Errorf("gateway.openai_response_header_timeout must be non-negative")
+	}
+	if c.Gateway.OpenAIResponsesStreamDataIntervalTimeout < 0 {
+		return fmt.Errorf("gateway.openai_responses_stream_data_interval_timeout must be non-negative")
+	}
+	if c.Gateway.OpenAIResponsesStreamDataIntervalTimeout != 0 &&
+		(c.Gateway.OpenAIResponsesStreamDataIntervalTimeout < 60 || c.Gateway.OpenAIResponsesStreamDataIntervalTimeout > 1800) {
+		return fmt.Errorf("gateway.openai_responses_stream_data_interval_timeout must be 0 or between 60-1800 seconds")
 	}
 	if strings.TrimSpace(c.Gateway.ConnectionPoolIsolation) != "" {
 		switch c.Gateway.ConnectionPoolIsolation {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -216,6 +216,24 @@ func TestLoadOpenAIResponseHeaderTimeoutFromEnv(t *testing.T) {
 	require.Equal(t, 1800, cfg.Gateway.OpenAIResponseHeaderTimeout)
 }
 
+func TestLoadOpenAIResponsesStreamDataIntervalTimeoutFromEnv(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("GATEWAY_OPENAI_RESPONSES_STREAM_DATA_INTERVAL_TIMEOUT", "900")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.Equal(t, 900, cfg.Gateway.OpenAIResponsesStreamDataIntervalTimeout)
+}
+
+func TestLoadCompactDrainAfterClientDisconnectFromEnv(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("GATEWAY_COMPACT_DRAIN_AFTER_CLIENT_DISCONNECT", "true")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+	require.True(t, cfg.Gateway.CompactDrainAfterClientDisconnect)
+}
+
 func TestLoadOpenAIWSStickyTTLCompatibility(t *testing.T) {
 	resetViperWithJWTSecret(t)
 	t.Setenv("GATEWAY_OPENAI_WS_STICKY_RESPONSE_ID_TTL_SECONDS", "0")
@@ -1284,6 +1302,16 @@ func TestValidateConfigErrors(t *testing.T) {
 			wantErr: "gateway.openai_response_header_timeout",
 		},
 		{
+			name:    "gateway openai responses stream data interval negative",
+			mutate:  func(c *Config) { c.Gateway.OpenAIResponsesStreamDataIntervalTimeout = -1 },
+			wantErr: "gateway.openai_responses_stream_data_interval_timeout must be non-negative",
+		},
+		{
+			name:    "gateway openai responses stream data interval range",
+			mutate:  func(c *Config) { c.Gateway.OpenAIResponsesStreamDataIntervalTimeout = 30 },
+			wantErr: "gateway.openai_responses_stream_data_interval_timeout must be 0 or between 60-1800 seconds",
+		},
+		{
 			name:    "gateway max idle conns",
 			mutate:  func(c *Config) { c.Gateway.MaxIdleConns = 0 },
 			wantErr: "gateway.max_idle_conns",
@@ -1905,6 +1933,9 @@ func TestLoad_DefaultGatewayImageStreamConfig(t *testing.T) {
 	if cfg.Gateway.StreamDataIntervalTimeout != 180 {
 		t.Fatalf("stream_data_interval_timeout = %d, want 180", cfg.Gateway.StreamDataIntervalTimeout)
 	}
+	if cfg.Gateway.OpenAIResponsesStreamDataIntervalTimeout != 0 {
+		t.Fatalf("openai_responses_stream_data_interval_timeout = %d, want 0", cfg.Gateway.OpenAIResponsesStreamDataIntervalTimeout)
+	}
 	if cfg.Gateway.StreamKeepaliveInterval != 10 {
 		t.Fatalf("stream_keepalive_interval = %d, want 10", cfg.Gateway.StreamKeepaliveInterval)
 	}
@@ -1913,6 +1944,9 @@ func TestLoad_DefaultGatewayImageStreamConfig(t *testing.T) {
 	}
 	if cfg.Gateway.ImageStreamKeepaliveInterval != 10 {
 		t.Fatalf("image_stream_keepalive_interval = %d, want 10", cfg.Gateway.ImageStreamKeepaliveInterval)
+	}
+	if cfg.Gateway.CompactDrainAfterClientDisconnect {
+		t.Fatalf("compact_drain_after_client_disconnect = true, want false")
 	}
 	if cfg.Gateway.ImageConcurrency.Enabled {
 		t.Fatalf("image_concurrency.enabled = true, want false")

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2493,7 +2493,15 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	if apiKey != nil {
 		imageGenerationAllowed = GroupAllowsImageGeneration(apiKey.Group)
 	}
-	codexImageGenerationBridgeEnabled := isCodexCLI && imageGenerationAllowed && s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey)
+	codexCompactRequest := isOpenAIResponsesCompactPath(c) || (isCodexCLI && isCodexCompactRequest(body))
+	setOpenAICompactRequestContext(c, codexCompactRequest)
+	codexImageGenerationBridgeEnabled := isCodexCLI &&
+		shouldEnableCodexImageGenerationBridge(c, body, reqModel, account, apiKey) &&
+		imageGenerationAllowed &&
+		s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey)
+	if codexCompactRequest && isCodexCLI && !IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body) {
+		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Skip image_generation bridge for Codex compact request")
+	}
 	imageIntent := IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body)
 	if imageIntent && !imageGenerationAllowed {
 		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
@@ -2503,7 +2511,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 
 	instructions := gjson.GetBytes(body, "instructions")
 	instructionsEmpty := !instructions.Exists() || instructions.Type != gjson.String || strings.TrimSpace(instructions.String()) == ""
-	if instructionsEmpty && !compatMessagesBridge {
+	if instructionsEmpty && !compatMessagesBridge && !(codexCompactRequest && !imageIntent) {
 		markPatchSet("instructions", defaultCodexSynthInstructions(reqModel))
 	}
 
@@ -2514,7 +2522,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		markPatchSet("model", billingModel)
 	}
 	upstreamModel := billingModel
-	isCompactRequest := isOpenAIResponsesCompactPath(c)
+	isCompactRequest := codexCompactRequest
 	compactMapped := false
 	if isCompactRequest {
 		compactMappedModel := resolveOpenAICompactForwardModel(account, billingModel)
@@ -2967,9 +2975,17 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	for {
 		// Build upstream request
 		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+		var cancelUpstream context.CancelFunc
+		if codexCompactRequest && !shouldDrainOpenAIStreamAfterClientDisconnect(s.cfg, c) {
+			upstreamCtx, cancelUpstream = context.WithCancel(upstreamCtx)
+			setOpenAIUpstreamCancelContext(c, cancelUpstream)
+		}
 		upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, body, token, reqStream, promptCacheKey, isCodexCLI)
 		releaseUpstreamCtx()
 		if err != nil {
+			if cancelUpstream != nil {
+				cancelUpstream()
+			}
 			return nil, err
 		}
 
@@ -2984,6 +3000,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 		SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 		if err != nil {
+			if cancelUpstream != nil {
+				cancelUpstream()
+			}
 			// Transport-level failure (proxy/DNS/TCP/TLS — no HTTP response). Convert to
 			// a failover so the handler switches to a healthy account, and temporarily
 			// unschedule the account on durable faults (e.g. rejected proxy credentials).
@@ -2995,6 +3014,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			if cancelUpstream != nil {
+				cancelUpstream()
+				cancelUpstream = nil
+			}
 
 			upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 			upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
@@ -3044,7 +3067,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 			return s.handleErrorResponse(ctx, resp, c, account, body, billingModel)
 		}
-		defer func() { _ = resp.Body.Close() }()
+		defer func() {
+			if cancelUpstream != nil {
+				cancelUpstream()
+			}
+			_ = resp.Body.Close()
+		}()
 
 		reasoningEffort := extractOpenAIReasoningEffortFromBody(body, originalModel)
 		serviceTier := extractOpenAIServiceTierFromBody(body)
@@ -3251,10 +3279,21 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		return nil, err
 	}
 
+	isCodexCLI := openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator")) || (s.cfg != nil && s.cfg.Gateway.ForceCodexCLI)
+	compactRequest := isOpenAIResponsesCompactPath(c) || (isCodexCLI && isCodexCompactRequest(body))
+	setOpenAICompactRequestContext(c, compactRequest)
 	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+	var cancelUpstream context.CancelFunc
+	if compactRequest && !shouldDrainOpenAIStreamAfterClientDisconnect(s.cfg, c) {
+		upstreamCtx, cancelUpstream = context.WithCancel(upstreamCtx)
+		setOpenAIUpstreamCancelContext(c, cancelUpstream)
+	}
 	upstreamReq, err := s.buildUpstreamRequestOpenAIPassthrough(upstreamCtx, c, account, body, token)
 	releaseUpstreamCtx()
 	if err != nil {
+		if cancelUpstream != nil {
+			cancelUpstream()
+		}
 		return nil, err
 	}
 
@@ -3271,12 +3310,20 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
 	if err != nil {
+		if cancelUpstream != nil {
+			cancelUpstream()
+		}
 		// Transport-level failure (proxy/DNS/TCP/TLS — no HTTP response). Convert to
 		// a failover so the handler switches to a healthy account, and temporarily
 		// unschedule the account on durable faults (e.g. rejected proxy credentials).
 		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, true)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if cancelUpstream != nil {
+			cancelUpstream()
+		}
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode >= 400 {
 		// 透传模式默认保持原样代理；但 429/529 属于网关必须兜底的
@@ -3795,6 +3842,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	var firstTokenMs *int
 	responseID := ""
 	clientDisconnected := false
+	drainAfterClientDisconnect := shouldDrainOpenAIStreamAfterClientDisconnect(s.cfg, c)
 	sawDone := false
 	sawTerminalEvent := false
 	sawFailedEvent := false
@@ -3802,11 +3850,20 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 	clientOutputStarted := false
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
 	pendingLines := make([]string, 0, 8)
+	var compactDisconnectErr error
+	markClientDisconnected := func(reason string) {
+		clientDisconnected = true
+		if !drainAfterClientDisconnect && compactDisconnectErr == nil {
+			compactDisconnectErr = stopOpenAICompactUpstreamDrain(c, resp, reason)
+		}
+	}
 	writePendingLines := func() bool {
 		for _, pending := range pendingLines {
 			if _, err := fmt.Fprintln(w, pending); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				markClientDisconnected("passthrough pending write")
+				if drainAfterClientDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				}
 				return false
 			}
 		}
@@ -3834,8 +3891,7 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		}
 	}
 
-	for scanner.Scan() {
-		line := scanner.Text()
+	processPassthroughLine := func(line string) {
 		lineStartsClientOutput := false
 		forceFlushFailedEvent := false
 		if data, ok := extractOpenAISSEDataLine(line); ok {
@@ -3852,8 +3908,8 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			if eventType == "response.failed" {
 				failedMessage = extractOpenAISSEErrorMessage(dataBytes)
 				if !openAIStreamClientOutputStarted(c, clientOutputStarted) && openAIStreamFailedEventShouldFailover(dataBytes, failedMessage) {
-					return resultWithUsage(),
-						s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage)
+					compactDisconnectErr = s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, dataBytes, failedMessage)
+					return
 				}
 				forceFlushFailedEvent = true
 				sawFailedEvent = true
@@ -3879,35 +3935,40 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 		if !clientDisconnected {
 			if !clientOutputStarted && !lineStartsClientOutput {
 				pendingLines = append(pendingLines, line)
-				continue
+				return
 			}
 			if !clientOutputStarted && len(pendingLines) > 0 {
 				if !writePendingLines() {
-					continue
+					return
 				}
 			}
 			if _, err := fmt.Fprintln(w, line); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				markClientDisconnected("passthrough streaming write")
+				if drainAfterClientDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Client disconnected during streaming, continue draining upstream for usage: account=%d", account.ID)
+				}
 			} else {
 				clientOutputStarted = true
 				flusher.Flush()
 			}
 		}
 	}
-	if err := scanner.Err(); err != nil {
+	handlePassthroughScanErr := func(err error) (*openaiStreamingResultPassthrough, error, bool) {
+		if err == nil {
+			return nil, nil, false
+		}
 		if sawTerminalEvent && !sawFailedEvent {
-			return resultWithUsage(), nil
+			return resultWithUsage(), nil, true
 		}
 		if sawFailedEvent {
-			return resultWithUsage(), fmt.Errorf("upstream response failed: %s", failedMessage)
+			return resultWithUsage(), fmt.Errorf("upstream response failed: %s", failedMessage), true
 		}
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return resultWithUsage(), fmt.Errorf("stream usage incomplete: %w", err)
+			return resultWithUsage(), fmt.Errorf("stream usage incomplete: %w", err), true
 		}
 		if errors.Is(err, bufio.ErrTooLong) {
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] SSE line too long: account=%d max_size=%d error=%v", account.ID, maxLineSize, err)
-			return resultWithUsage(), err
+			return resultWithUsage(), err, true
 		}
 		if !openAIStreamClientOutputStarted(c, clientOutputStarted) {
 			msg := "OpenAI stream disconnected before completion"
@@ -3915,10 +3976,10 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 				msg += ": " + errText
 			}
 			return resultWithUsage(),
-				s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, nil, msg)
+				s.newOpenAIStreamFailoverError(c, account, true, upstreamRequestID, nil, msg), true
 		}
 		if clientDisconnected {
-			return resultWithUsage(), fmt.Errorf("stream usage incomplete after disconnect: %w", err)
+			return resultWithUsage(), fmt.Errorf("stream usage incomplete after disconnect: %w", err), true
 		}
 		logger.LegacyPrintf("service.openai_gateway",
 			"[OpenAI passthrough] 流读取异常中断: account=%d request_id=%s err=%v",
@@ -3926,7 +3987,77 @@ func (s *OpenAIGatewayService) handleStreamingResponsePassthrough(
 			upstreamRequestID,
 			err,
 		)
-		return resultWithUsage(), fmt.Errorf("stream read error: %w", err)
+		return resultWithUsage(), fmt.Errorf("stream read error: %w", err), true
+	}
+	streamInterval := s.openAIResponsesStreamDataIntervalTimeout()
+	if streamInterval <= 0 {
+		for scanner.Scan() {
+			processPassthroughLine(scanner.Text())
+			if compactDisconnectErr != nil {
+				return resultWithUsage(), compactDisconnectErr
+			}
+		}
+		if result, err, done := handlePassthroughScanErr(scanner.Err()); done {
+			return result, err
+		}
+	} else {
+		type scanEvent struct {
+			line string
+			err  error
+		}
+		events := make(chan scanEvent, 16)
+		done := make(chan struct{})
+		var lastReadAt int64
+		atomic.StoreInt64(&lastReadAt, time.Now().UnixNano())
+		go func() {
+			defer close(events)
+			for scanner.Scan() {
+				atomic.StoreInt64(&lastReadAt, time.Now().UnixNano())
+				select {
+				case events <- scanEvent{line: scanner.Text()}:
+				case <-done:
+					return
+				}
+			}
+			if err := scanner.Err(); err != nil {
+				select {
+				case events <- scanEvent{err: err}:
+				case <-done:
+				}
+			}
+		}()
+		defer close(done)
+		ticker := time.NewTicker(streamInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case ev, ok := <-events:
+				if !ok {
+					goto passthroughScanComplete
+				}
+				if result, err, done := handlePassthroughScanErr(ev.err); done {
+					return result, err
+				}
+				processPassthroughLine(ev.line)
+				if compactDisconnectErr != nil {
+					return resultWithUsage(), compactDisconnectErr
+				}
+			case <-ticker.C:
+				lastRead := time.Unix(0, atomic.LoadInt64(&lastReadAt))
+				if time.Since(lastRead) < streamInterval {
+					continue
+				}
+				if clientDisconnected {
+					return resultWithUsage(), fmt.Errorf("stream usage incomplete after timeout")
+				}
+				logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Stream data interval timeout: account=%d model=%s interval=%s", account.ID, originalModel, streamInterval)
+				if s.rateLimitService != nil {
+					s.rateLimitService.HandleStreamTimeout(ctx, account, originalModel)
+				}
+				return resultWithUsage(), fmt.Errorf("stream data interval timeout")
+			}
+		}
+	passthroughScanComplete:
 	}
 	if sawFailedEvent {
 		return resultWithUsage(), fmt.Errorf("upstream response failed: %s", failedMessage)
@@ -4574,10 +4705,7 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	scanBuf := getSSEScannerBuf64K()
 	scanner.Buffer(scanBuf[:0], maxLineSize)
 
-	streamInterval := time.Duration(0)
-	if s.cfg != nil && s.cfg.Gateway.StreamDataIntervalTimeout > 0 {
-		streamInterval = time.Duration(s.cfg.Gateway.StreamDataIntervalTimeout) * time.Second
-	}
+	streamInterval := s.openAIResponsesStreamDataIntervalTimeout()
 	// 仅监控上游数据间隔超时，不被下游写入阻塞影响
 	var intervalTicker *time.Ticker
 	if streamInterval > 0 {
@@ -4613,12 +4741,19 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 	// 否则下游 SDK（例如 OpenCode）会因为类型校验失败而报错。
 	errorEventSent := false
 	clientDisconnected := false // 客户端断开后继续 drain 上游以收集 usage
+	drainAfterClientDisconnect := shouldDrainOpenAIStreamAfterClientDisconnect(s.cfg, c)
 	sawTerminalEvent := false
 	sawFailedEvent := false
 	failedMessage := ""
 	clientOutputStarted := false
 	upstreamRequestID := strings.TrimSpace(resp.Header.Get("x-request-id"))
 	var streamFailoverErr error
+	markClientDisconnected := func(reason string) {
+		clientDisconnected = true
+		if !drainAfterClientDisconnect && streamFailoverErr == nil {
+			streamFailoverErr = stopOpenAICompactUpstreamDrain(c, resp, reason)
+		}
+	}
 	sendErrorEvent := func(reason string) {
 		if errorEventSent || clientDisconnected {
 			return
@@ -4626,15 +4761,15 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 		errorEventSent = true
 		payload := `{"type":"error","sequence_number":0,"error":{"type":"upstream_error","message":` + strconv.Quote(reason) + `,"code":` + strconv.Quote(reason) + `}}`
 		if err := flushBuffered(); err != nil {
-			clientDisconnected = true
+			markClientDisconnected("error-event preflush")
 			return
 		}
 		if _, err := bufferedWriter.WriteString("data: " + payload + "\n\n"); err != nil {
-			clientDisconnected = true
+			markClientDisconnected("error-event write")
 			return
 		}
 		if err := flushBuffered(); err != nil {
-			clientDisconnected = true
+			markClientDisconnected("error-event flush")
 			return
 		}
 		clientOutputStarted = true
@@ -4674,8 +4809,11 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 		if !clientDisconnected {
 			hadBufferedData := bufferedWriter.Buffered() > 0
 			if err := flushBuffered(); err != nil {
-				clientDisconnected = true
+				markClientDisconnected("final flush")
 				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during final flush, returning collected usage")
+				if streamFailoverErr != nil {
+					return resultWithUsage(), streamFailoverErr
+				}
 			} else if hadBufferedData {
 				clientOutputStarted = true
 				lastDownstreamWriteAt = time.Now()
@@ -4782,15 +4920,21 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 					shouldFlush = true
 				}
 				if _, err := bufferedWriter.WriteString(line); err != nil {
-					clientDisconnected = true
-					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					markClientDisconnected("streaming write")
+					if drainAfterClientDisconnect {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					}
 				} else if _, err := bufferedWriter.WriteString("\n"); err != nil {
-					clientDisconnected = true
-					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					markClientDisconnected("streaming write")
+					if drainAfterClientDisconnect {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+					}
 				} else if shouldFlush {
 					if err := flushBuffered(); err != nil {
-						clientDisconnected = true
-						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+						markClientDisconnected("streaming flush")
+						if drainAfterClientDisconnect {
+							logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+						}
 					} else {
 						clientOutputStarted = true
 						lastDownstreamWriteAt = time.Now()
@@ -4810,15 +4954,21 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 		// Forward non-data lines as-is
 		if !clientDisconnected {
 			if _, err := bufferedWriter.WriteString(line); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				markClientDisconnected("streaming write")
+				if drainAfterClientDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				}
 			} else if _, err := bufferedWriter.WriteString("\n"); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				markClientDisconnected("streaming write")
+				if drainAfterClientDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				}
 			} else if queueDrained && clientOutputStarted {
 				if err := flushBuffered(); err != nil {
-					clientDisconnected = true
-					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+					markClientDisconnected("streaming flush")
+					if drainAfterClientDisconnect {
+						logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming flush, continuing to drain upstream for billing")
+					}
 				} else {
 					clientOutputStarted = true
 					lastDownstreamWriteAt = time.Now()
@@ -4912,19 +5062,36 @@ func (s *OpenAIGatewayService) handleStreamingResponse(ctx context.Context, resp
 				continue
 			}
 			if _, err := bufferedWriter.WriteString(":\n\n"); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				markClientDisconnected("keepalive write")
+				if drainAfterClientDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
+				}
 				continue
 			}
 			if err := flushBuffered(); err != nil {
-				clientDisconnected = true
-				logger.LegacyPrintf("service.openai_gateway", "Client disconnected during keepalive flush, continuing to drain upstream for billing")
+				markClientDisconnected("keepalive flush")
+				if drainAfterClientDisconnect {
+					logger.LegacyPrintf("service.openai_gateway", "Client disconnected during keepalive flush, continuing to drain upstream for billing")
+				}
+				if streamFailoverErr != nil {
+					return resultWithUsage(), streamFailoverErr
+				}
 			} else {
 				lastDownstreamWriteAt = time.Now()
 			}
 		}
 	}
 
+}
+
+func (s *OpenAIGatewayService) openAIResponsesStreamDataIntervalTimeout() time.Duration {
+	if s == nil || s.cfg == nil {
+		return 0
+	}
+	if s.cfg.Gateway.OpenAIResponsesStreamDataIntervalTimeout > 0 {
+		return time.Duration(s.cfg.Gateway.OpenAIResponsesStreamDataIntervalTimeout) * time.Second
+	}
+	return 0
 }
 
 // extractOpenAISSEDataLine 低开销提取 SSE `data:` 行内容。
@@ -5612,6 +5779,125 @@ func NormalizeOpenAICompactRequestBodyForTest(body []byte) ([]byte, bool, error)
 func isOpenAIResponsesCompactPath(c *gin.Context) bool {
 	suffix := strings.TrimSpace(openAIResponsesRequestPathSuffix(c))
 	return suffix == "/compact" || strings.HasPrefix(suffix, "/compact/")
+}
+
+const (
+	openAICompactRequestContextKey       = "openai_compact_request"
+	openAIUpstreamCancelContextKey       = "openai_upstream_cancel"
+	openAICompactClientDisconnectedError = "compact client disconnected; stop draining upstream"
+)
+
+func isCodexCompactRequest(body []byte) bool {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return false
+	}
+	if IsImageGenerationIntent(openAIResponsesEndpoint, "", body) {
+		return false
+	}
+
+	parts := make([]string, 0, 4)
+	for _, path := range []string{"instructions", "input"} {
+		value := gjson.GetBytes(body, path)
+		if !value.Exists() {
+			continue
+		}
+		switch value.Type {
+		case gjson.String:
+			parts = append(parts, value.String())
+		default:
+			parts = append(parts, value.Raw)
+		}
+	}
+	haystack := strings.ToLower(strings.Join(parts, "\n"))
+	if strings.TrimSpace(haystack) == "" {
+		return false
+	}
+
+	strongCompactSignature := false
+	for _, phrase := range []string{
+		"remote compact task",
+		"remote compact request",
+		"compact task",
+		"compact request",
+	} {
+		if strings.Contains(haystack, phrase) {
+			strongCompactSignature = true
+			break
+		}
+	}
+	if !strongCompactSignature {
+		return false
+	}
+
+	for _, phrase := range []string{
+		"context",
+		"summarize",
+		"summary",
+		"conversation",
+		"transcript",
+	} {
+		if strings.Contains(haystack, phrase) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func shouldEnableCodexImageGenerationBridge(c *gin.Context, body []byte, reqModel string, _ *Account, _ *APIKey) bool {
+	if (isOpenAIResponsesCompactPath(c) || isCodexCompactRequest(body)) &&
+		!IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body) {
+		return false
+	}
+	return true
+}
+
+func setOpenAICompactRequestContext(c *gin.Context, compact bool) {
+	if c == nil {
+		return
+	}
+	c.Set(openAICompactRequestContextKey, compact)
+}
+
+func isOpenAICompactRequestContext(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	value, exists := c.Get(openAICompactRequestContextKey)
+	if !exists {
+		return isOpenAIResponsesCompactPath(c)
+	}
+	compact, _ := value.(bool)
+	return compact
+}
+
+func setOpenAIUpstreamCancelContext(c *gin.Context, cancel context.CancelFunc) {
+	if c == nil || cancel == nil {
+		return
+	}
+	c.Set(openAIUpstreamCancelContextKey, cancel)
+}
+
+func shouldDrainOpenAIStreamAfterClientDisconnect(cfg *config.Config, c *gin.Context) bool {
+	if isOpenAICompactRequestContext(c) {
+		return cfg != nil && cfg.Gateway.CompactDrainAfterClientDisconnect
+	}
+	return true
+}
+
+func stopOpenAICompactUpstreamDrain(c *gin.Context, resp *http.Response, reason string) error {
+	if c != nil {
+		if value, exists := c.Get(openAIUpstreamCancelContextKey); exists {
+			if cancel, ok := value.(context.CancelFunc); ok && cancel != nil {
+				cancel()
+			}
+		}
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
+	}
+	logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Compact client disconnected during %s; cancel upstream and stop draining", reason)
+	return errors.New(openAICompactClientDisconnectedError)
 }
 
 func normalizeOpenAICompactRequestBody(body []byte) ([]byte, bool, error) {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1151,13 +1151,34 @@ func TestOpenAISelectAccountWithLoadAwareness_PreferNeverUsed(t *testing.T) {
 	}
 }
 
+func TestOpenAIResponsesStreamTimeoutDefaultDisabled(t *testing.T) {
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout: 180,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+	require.Zero(t, svc.openAIResponsesStreamDataIntervalTimeout())
+}
+
+func TestOpenAIResponsesStreamTimeoutUsesDedicatedConfig(t *testing.T) {
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			StreamDataIntervalTimeout:                180,
+			OpenAIResponsesStreamDataIntervalTimeout: 900,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+	require.Equal(t, 900*time.Second, svc.openAIResponsesStreamDataIntervalTimeout())
+}
+
 func TestOpenAIStreamingTimeout(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	cfg := &config.Config{
 		Gateway: config.GatewayConfig{
-			StreamDataIntervalTimeout: 1,
-			StreamKeepaliveInterval:   0,
-			MaxLineSize:               defaultMaxLineSize,
+			OpenAIResponsesStreamDataIntervalTimeout: 1,
+			StreamKeepaliveInterval:                  0,
+			MaxLineSize:                              defaultMaxLineSize,
 		},
 	}
 	svc := &OpenAIGatewayService{cfg: cfg}
@@ -2667,4 +2688,323 @@ func TestOpenAICompatSSEFrameParserResetsEventTypeAtFrameBoundary(t *testing.T) 
 	require.True(t, ok)
 	require.Empty(t, frame.EventType)
 	require.JSONEq(t, `{"delta":"ok"}`, frame.Data)
+}
+
+func TestIsCodexCompactRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{
+			name: "context compaction instructions",
+			body: []byte(`{"model":"gpt-5.5","instructions":"Perform context compaction for a remote compact task","input":"summarize the conversation"}`),
+			want: true,
+		},
+		{
+			name: "compact context input",
+			body: []byte(`{"model":"gpt-5.5","input":[{"role":"user","content":"remote compact task: compact the context into a summary"}]}`),
+			want: true,
+		},
+		{
+			name: "ordinary coding summary prompt",
+			body: []byte(`{"model":"gpt-5.5","instructions":"You are a coding assistant","input":"summarize this file and explain the context"}`),
+			want: false,
+		},
+		{
+			name: "ordinary coding compact adjective",
+			body: []byte(`{"model":"gpt-5.5","input":"write a compact helper for the request context"}`),
+			want: false,
+		},
+		{
+			name: "ordinary compaction discussion",
+			body: []byte(`{"model":"gpt-5.5","input":"explain context compaction with examples"}`),
+			want: false,
+		},
+		{
+			name: "explicit image tool overrides compact text",
+			body: []byte(`{"model":"gpt-5.5","instructions":"context compaction","tools":[{"type":"image_generation"}],"input":"draw a compact context diagram"}`),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isCodexCompactRequest(tt.body))
+		})
+	}
+}
+
+func TestShouldEnableCodexImageGenerationBridge_CompactSuppressionAndImageOverride(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	compactBody := []byte(`{"model":"gpt-5.5","instructions":"Remote compact task: perform context compaction","input":"summarize conversation"}`)
+	imageBody := []byte(`{"model":"gpt-5.5","instructions":"Remote compact task: perform context compaction","tools":[{"type":"image_generation"}],"input":"draw it"}`)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
+
+	require.False(t, shouldEnableCodexImageGenerationBridge(c, compactBody, "gpt-5.5", nil, nil))
+	require.True(t, shouldEnableCodexImageGenerationBridge(c, imageBody, "gpt-5.5", nil, nil))
+
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
+	require.False(t, shouldEnableCodexImageGenerationBridge(c, []byte(`{"model":"gpt-5.5","input":"hello"}`), "gpt-5.5", nil, nil))
+}
+
+func TestShouldDrainOpenAIStreamAfterClientDisconnect_CompactConfigOverride(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil)
+	setOpenAICompactRequestContext(c, true)
+
+	require.False(t, shouldDrainOpenAIStreamAfterClientDisconnect(&config.Config{}, c))
+	require.True(t, shouldDrainOpenAIStreamAfterClientDisconnect(&config.Config{
+		Gateway: config.GatewayConfig{CompactDrainAfterClientDisconnect: true},
+	}, c))
+
+	rec = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	require.True(t, shouldDrainOpenAIStreamAfterClientDisconnect(&config.Config{}, c))
+}
+
+func TestOpenAIForward_CodexCompactDoesNotInjectImageGenerationBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"Remote compact task: perform context compaction","input":"summarize conversation"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_compact","status":"completed","model":"gpt-5.5","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{CodexImageGenerationBridgeEnabled: true}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists(), string(upstream.lastBody))
+	require.NotContains(t, gjson.GetBytes(upstream.lastBody, "instructions").String(), codexImageGenerationBridgeMarker)
+}
+
+func TestOpenAIForward_CodexOrdinaryImageRequestStillInjectsBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"You are a coding assistant","input":"Please generate an image asset for this UI"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_image","status":"completed","model":"gpt-5.5","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{CodexImageGenerationBridgeEnabled: true}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          2,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.True(t, openAIRequestBodyHasImageGenerationTool(upstream.lastBody), string(upstream.lastBody))
+	require.Contains(t, gjson.GetBytes(upstream.lastBody, "instructions").String(), codexImageGenerationBridgeMarker)
+}
+
+func TestOpenAIForward_CodexImageRequestMentioningCompactionStillInjectsBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"You are a coding assistant","input":"Generate an image explaining context compaction for this architecture note"}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_image","status":"completed","model":"gpt-5.5","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{Gateway: config.GatewayConfig{CodexImageGenerationBridgeEnabled: true}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          3,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	_, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.True(t, openAIRequestBodyHasImageGenerationTool(upstream.lastBody), string(upstream.lastBody))
+	require.Contains(t, gjson.GetBytes(upstream.lastBody, "instructions").String(), codexImageGenerationBridgeMarker)
+}
+
+type closeTrackingReadCloser struct {
+	readStarted chan struct{}
+	closed      chan struct{}
+	data        []byte
+	pos         int
+	onClose     func()
+}
+
+func newCloseTrackingReadCloser() *closeTrackingReadCloser {
+	return &closeTrackingReadCloser{
+		readStarted: make(chan struct{}, 1),
+		closed:      make(chan struct{}),
+		data:        []byte("data: {\"type\":\"response.output_text.delta\",\"delta\":\"x\"}\n\n"),
+		onClose:     func() {},
+	}
+}
+
+func (r *closeTrackingReadCloser) Read(p []byte) (int, error) {
+	select {
+	case r.readStarted <- struct{}{}:
+	default:
+	}
+	if r.pos < len(r.data) {
+		n := copy(p, r.data[r.pos:])
+		r.pos += n
+		return n, nil
+	}
+	select {
+	case <-r.closed:
+		return 0, io.EOF
+	case <-time.After(5 * time.Second):
+		return 0, errors.New("test body was not closed")
+	}
+}
+
+func (r *closeTrackingReadCloser) Close() error {
+	r.onClose()
+	select {
+	case <-r.closed:
+	default:
+		close(r.closed)
+	}
+	return nil
+}
+
+func TestOpenAIStreamingCompactClientDisconnectStopsDrainingUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	ctx, cancel := context.WithCancel(context.Background())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil).WithContext(ctx)
+	setOpenAICompactRequestContext(c, true)
+	setOpenAIUpstreamCancelContext(c, cancel)
+	c.Writer = &failingGinWriter{ResponseWriter: c.Writer, failAfter: 0}
+
+	body := newCloseTrackingReadCloser()
+	resp := &http.Response{StatusCode: http.StatusOK, Body: body, Header: http.Header{}}
+
+	start := time.Now()
+	_, err := svc.handleStreamingResponse(c.Request.Context(), resp, c, &Account{ID: 1}, start, "model", "model")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), openAICompactClientDisconnectedError)
+	require.Less(t, time.Since(start), 500*time.Millisecond)
+	select {
+	case <-body.closed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected upstream body close")
+	}
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+}
+
+func TestOpenAIStreamingPassthroughUsesDedicatedResponsesTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{
+		Gateway: config.GatewayConfig{
+			OpenAIResponsesStreamDataIntervalTimeout: 1,
+			MaxLineSize:                              defaultMaxLineSize,
+		},
+	}
+	svc := &OpenAIGatewayService{cfg: cfg}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	pr, pw := io.Pipe()
+	resp := &http.Response{StatusCode: http.StatusOK, Body: pr, Header: http.Header{}}
+
+	start := time.Now()
+	_, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{ID: 1}, start, "model", "model")
+	_ = pw.Close()
+	_ = pr.Close()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stream data interval timeout")
+	require.Less(t, time.Since(start), 1500*time.Millisecond)
+}
+
+func TestOpenAIStreamingPassthroughCompactClientDisconnectStopsDrainingUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	ctx, cancel := context.WithCancel(context.Background())
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", nil).WithContext(ctx)
+	setOpenAICompactRequestContext(c, true)
+	setOpenAIUpstreamCancelContext(c, cancel)
+	c.Writer = &failingGinWriter{ResponseWriter: c.Writer, failAfter: 0}
+
+	body := newCloseTrackingReadCloser()
+	resp := &http.Response{StatusCode: http.StatusOK, Body: body, Header: http.Header{}}
+
+	start := time.Now()
+	_, err := svc.handleStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{ID: 1}, start, "model", "model")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), openAICompactClientDisconnectedError)
+	require.Less(t, time.Since(start), 500*time.Millisecond)
+	select {
+	case <-body.closed:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatalf("expected upstream body close")
+	}
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
 }

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -93,8 +94,11 @@ func (e *OpenAIImagesUpstreamError) clientMessage() string {
 }
 
 func openAIResponsesImageResultKey(itemID string, result openAIResponsesImageResult) string {
-	if strings.TrimSpace(result.Result) != "" {
-		return strings.TrimSpace(result.OutputFormat) + "|" + strings.TrimSpace(result.Result)
+	if trimmed := strings.TrimSpace(result.Result); trimmed != "" {
+		sum := sha256.Sum256([]byte(trimmed))
+		return strings.TrimSpace(result.OutputFormat) + "|" +
+			strings.TrimSpace(result.Size) + "|" +
+			fmt.Sprintf("%x", sum[:])
 	}
 	return "item:" + strings.TrimSpace(itemID)
 }

--- a/backend/internal/service/openai_images_responses_test.go
+++ b/backend/internal/service/openai_images_responses_test.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIResponsesImageResultKeyHashesLargeBase64(t *testing.T) {
+	large := strings.Repeat("abcd", 1024*1024)
+	key := openAIResponsesImageResultKey("item-1", openAIResponsesImageResult{Result: large, OutputFormat: "png", Size: "1024x1024"})
+	require.Contains(t, key, "png|1024x1024|")
+	require.Len(t, key, len("png|1024x1024|")+64)
+	require.NotContains(t, key, large[:128])
+
+	same := openAIResponsesImageResultKey("item-2", openAIResponsesImageResult{Result: large, OutputFormat: "png", Size: "1024x1024"})
+	differentSize := openAIResponsesImageResultKey("item-3", openAIResponsesImageResult{Result: large, OutputFormat: "png", Size: "512x512"})
+	require.Equal(t, key, same)
+	require.NotEqual(t, key, differentSize)
+}


### PR DESCRIPTION
## Summary

- Detect Codex `/responses/compact` requests by path and by compact-task payload signatures.
- Do not inject the Codex `image_generation` bridge or default coding-assistant instructions into compact requests unless the payload explicitly asks for images.
- For compact requests only, cancel upstream and stop draining after client disconnects by default, with `gateway.compact_drain_after_client_disconnect` available to opt back into drain behavior.
- Hash image response result keys instead of retaining full base64 result payloads in the dedupe key.

## Related issues

Related to compact timeout / slow header symptoms reported in:

- #2773
- #2738

This PR is not a full timeout-policy overhaul. It addresses one compact-specific amplification path: Codex compact requests being treated like normal image-capable responses requests and, after disconnects/timeouts, continuing upstream draining work by default.

## Why

Codex compact calls are internal text summarization/context-compaction requests. When they are mutated into image-generation-capable requests, they can become slower/heavier and may continue consuming upstream work even after the client has timed out or disconnected. This keeps normal non-compact streaming drain behavior unchanged for usage accounting.

## Tests

- `go test ./internal/service -run 'CodexCompact|Compact|ImageResultKey|DrainAfterClientDisconnect|ImageGenerationBridge'`
- `go test ./internal/config`
- `go test ./internal/service`
