### PR TITLE
fix: auto-grant creator access for exclusive groups

### DIFF
--- a/backend/internal/handler/admin/group_handler.go
+++ b/backend/internal/handler/admin/group_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	servermiddleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -271,12 +272,18 @@ func (h *GroupHandler) Create(c *gin.Context) {
 		return
 	}
 
+	var operatorUserID *int64
+	if subject, ok := servermiddleware.GetAuthSubjectFromContext(c); ok && subject.UserID > 0 {
+		operatorUserID = &subject.UserID
+	}
+
 	group, err := h.adminService.CreateGroup(c.Request.Context(), &service.CreateGroupInput{
 		Name:                            req.Name,
 		Description:                     req.Description,
 		Platform:                        req.Platform,
 		RateMultiplier:                  req.RateMultiplier,
 		IsExclusive:                     req.IsExclusive,
+		OperatorUserID:                  operatorUserID,
 		SubscriptionType:                req.SubscriptionType,
 		DailyLimitUSD:                   req.DailyLimitUSD.ToServiceInput(),
 		WeeklyLimitUSD:                  req.WeeklyLimitUSD.ToServiceInput(),

--- a/backend/internal/repository/group_repo.go
+++ b/backend/internal/repository/group_repo.go
@@ -37,7 +37,8 @@ func newGroupRepositoryWithSQL(client *dbent.Client, sqlq sqlExecutor) *groupRep
 }
 
 func (r *groupRepository) Create(ctx context.Context, groupIn *service.Group) error {
-	builder := r.client.Group.Create().
+	client := clientFromContext(ctx, r.client)
+	builder := client.Group.Create().
 		SetName(groupIn.Name).
 		SetDescription(groupIn.Description).
 		SetPlatform(groupIn.Platform).

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -197,6 +197,7 @@ type CreateGroupInput struct {
 	Platform         string
 	RateMultiplier   float64
 	IsExclusive      bool
+	OperatorUserID   *int64
 	SubscriptionType string   // standard/subscription
 	DailyLimitUSD    *float64 // 日限额 (USD)
 	WeeklyLimitUSD   *float64 // 周限额 (USD)
@@ -1866,6 +1867,23 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 		}
 	}
 
+	autoGrantCreator := input.IsExclusive &&
+		subscriptionType == SubscriptionTypeStandard &&
+		input.OperatorUserID != nil &&
+		*input.OperatorUserID > 0
+
+	opCtx := ctx
+	var tx *dbent.Tx
+	if autoGrantCreator && s.entClient != nil {
+		var err error
+		tx, err = s.entClient.Tx(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("begin transaction: %w", err)
+		}
+		defer func() { _ = tx.Rollback() }()
+		opCtx = dbent.NewTxContext(ctx, tx)
+	}
+
 	group := &Group{
 		Name:                            input.Name,
 		Description:                     input.Description,
@@ -1898,8 +1916,18 @@ func (s *adminServiceImpl) CreateGroup(ctx context.Context, input *CreateGroupIn
 		RPMLimit:                        input.RPMLimit,
 	}
 	sanitizeGroupMessagesDispatchFields(group)
-	if err := s.groupRepo.Create(ctx, group); err != nil {
+	if err := s.groupRepo.Create(opCtx, group); err != nil {
 		return nil, err
+	}
+	if autoGrantCreator {
+		if err := s.userRepo.AddGroupToAllowedGroups(opCtx, *input.OperatorUserID, group.ID); err != nil {
+			return nil, fmt.Errorf("grant creator access to exclusive group: %w", err)
+		}
+	}
+	if tx != nil {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit transaction: %w", err)
+		}
 	}
 
 	// require_oauth_only: 过滤掉 apikey 类型账号

--- a/backend/internal/service/admin_service_group_test.go
+++ b/backend/internal/service/admin_service_group_test.go
@@ -34,6 +34,9 @@ type groupRepoStubForAdmin struct {
 }
 
 func (s *groupRepoStubForAdmin) Create(_ context.Context, g *Group) error {
+	if g.ID == 0 {
+		g.ID = 101
+	}
 	s.created = g
 	return nil
 }
@@ -196,6 +199,75 @@ func TestAdminService_CreateGroup_NilImagePricing(t *testing.T) {
 	require.Nil(t, repo.created.ImagePrice1K)
 	require.Nil(t, repo.created.ImagePrice2K)
 	require.Nil(t, repo.created.ImagePrice4K)
+}
+
+func TestAdminService_CreateGroup_ExclusiveStandardGroupAutoGrantsCreator(t *testing.T) {
+	repo := &groupRepoStubForAdmin{}
+	userRepo := &userRepoStubForGroupUpdate{}
+	operatorUserID := int64(7)
+	svc := &adminServiceImpl{
+		groupRepo: repo,
+		userRepo:  userRepo,
+	}
+
+	group, err := svc.CreateGroup(context.Background(), &CreateGroupInput{
+		Name:           "vip-only",
+		Description:    "exclusive group",
+		Platform:       PlatformOpenAI,
+		RateMultiplier: 1.0,
+		IsExclusive:    true,
+		OperatorUserID: &operatorUserID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.True(t, userRepo.addGroupCalled)
+	require.Equal(t, operatorUserID, userRepo.addedUserID)
+	require.Equal(t, group.ID, userRepo.addedGroupID)
+}
+
+func TestAdminService_CreateGroup_PublicGroupDoesNotGrantCreator(t *testing.T) {
+	repo := &groupRepoStubForAdmin{}
+	userRepo := &userRepoStubForGroupUpdate{}
+	operatorUserID := int64(7)
+	svc := &adminServiceImpl{
+		groupRepo: repo,
+		userRepo:  userRepo,
+	}
+
+	group, err := svc.CreateGroup(context.Background(), &CreateGroupInput{
+		Name:           "public-group",
+		Description:    "public",
+		Platform:       PlatformOpenAI,
+		RateMultiplier: 1.0,
+		IsExclusive:    false,
+		OperatorUserID: &operatorUserID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.False(t, userRepo.addGroupCalled)
+}
+
+func TestAdminService_CreateGroup_ExclusiveSubscriptionGroupDoesNotGrantCreator(t *testing.T) {
+	repo := &groupRepoStubForAdmin{}
+	userRepo := &userRepoStubForGroupUpdate{}
+	operatorUserID := int64(7)
+	svc := &adminServiceImpl{
+		groupRepo: repo,
+		userRepo:  userRepo,
+	}
+
+	group, err := svc.CreateGroup(context.Background(), &CreateGroupInput{
+		Name:             "exclusive-sub",
+		Description:      "subscription group",
+		Platform:         PlatformOpenAI,
+		RateMultiplier:   1.0,
+		IsExclusive:      true,
+		OperatorUserID:   &operatorUserID,
+		SubscriptionType: SubscriptionTypeSubscription,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, group)
+	require.False(t, userRepo.addGroupCalled)
 }
 
 // TestAdminService_UpdateGroup_WithImagePricing 测试更新分组时 ImagePrice 字段正确更新


### PR DESCRIPTION
## Summary
  - auto-grant the creator access when creating an exclusive standard group
  - pass the operator user id from the admin group create handler into CreateGroup
  - make group repository create use tx-aware ent client so group creation and allow-list insert stay in one transaction
  - add tests covering exclusive/public/subscription group creation behavior

  ## Problem
  After recent exclusive-group auth enforcement, an admin who creates an exclusive standard group can immediately lose access to that group because no corresponding `user_allowed_groups` record is
  created for the creator.

  ## Fix
  When creating an exclusive standard group, automatically insert the creator into `user_allowed_groups` in the same transaction as group creation.