### PR TITLE
perf(admin): filter usage logs by request id

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -46,7 +46,10 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	}
 	userRepository := repository.NewUserRepository(client, db)
 	redeemCodeRepository := repository.NewRedeemCodeRepository(client)
-	redisClient := repository.ProvideRedis(configConfig)
+	redisClient, err := repository.ProvideRedis(configConfig)
+	if err != nil {
+		return nil, err
+	}
 	refreshTokenCache := repository.NewRefreshTokenCache(redisClient)
 	settingRepository := repository.NewSettingRepository(client)
 	groupRepository := repository.NewGroupRepository(client, db)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -164,6 +164,8 @@ github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
+github.com/google/subcommands v1.2.0 h1:vWQspBTo2nEqTUFita5/KeEWlUL8kQObDFbub/EN9oE=
+github.com/google/subcommands v1.2.0/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/wire v0.7.0 h1:JxUKI6+CVBgCO2WToKy/nQk0sS+amI9z9EjVmdaocj4=

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1173,6 +1173,8 @@ type RedisConfig struct {
 	MinIdleConns int `mapstructure:"min_idle_conns"`
 	// EnableTLS: 是否启用 TLS/SSL 连接
 	EnableTLS bool `mapstructure:"enable_tls"`
+	// CACertFile: 可选的 PEM CA 证书文件，用于私有 CA 签发的 Redis 服务
+	CACertFile string `mapstructure:"ca_cert_file"`
 }
 
 func (r *RedisConfig) Address() string {
@@ -1710,6 +1712,7 @@ func setDefaults() {
 	viper.SetDefault("redis.pool_size", 1024)
 	viper.SetDefault("redis.min_idle_conns", 128)
 	viper.SetDefault("redis.enable_tls", false)
+	viper.SetDefault("redis.ca_cert_file", "")
 
 	// Ops (vNext)
 	viper.SetDefault("ops.enabled", true)

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -110,6 +110,7 @@ func (h *UsageHandler) List(c *gin.Context) {
 	}
 
 	model := c.Query("model")
+	requestID := strings.TrimSpace(c.Query("request_id"))
 	billingMode := strings.TrimSpace(c.Query("billing_mode"))
 
 	var requestType *int16
@@ -176,6 +177,7 @@ func (h *UsageHandler) List(c *gin.Context) {
 		APIKeyID:    apiKeyID,
 		AccountID:   accountID,
 		GroupID:     groupID,
+		RequestID:   requestID,
 		Model:       model,
 		RequestType: requestType,
 		Stream:      stream,

--- a/backend/internal/handler/admin/usage_handler_request_type_test.go
+++ b/backend/internal/handler/admin/usage_handler_request_type_test.go
@@ -94,6 +94,18 @@ func TestAdminUsageListExactTotalTrue(t *testing.T) {
 	require.True(t, repo.listFilters.ExactTotal)
 }
 
+func TestAdminUsageListRequestIDFilter(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage?request_id=req-0123", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "req-0123", repo.listFilters.RequestID)
+}
+
 func TestAdminUsageListInvalidExactTotal(t *testing.T) {
 	repo := &adminUsageRepoCapture{}
 	router := newAdminUsageRequestTypeTestRouter(repo)

--- a/backend/internal/pkg/redistls/config.go
+++ b/backend/internal/pkg/redistls/config.go
@@ -1,0 +1,43 @@
+package redistls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// Config builds a Redis TLS configuration and optionally extends the host trust
+// store with a provider-specific CA certificate.
+func Config(enabled bool, serverName, caCertFile string) (*tls.Config, error) {
+	if !enabled {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ServerName: serverName,
+	}
+
+	caCertFile = strings.TrimSpace(caCertFile)
+	if caCertFile == "" {
+		return tlsConfig, nil
+	}
+
+	caPEM, err := os.ReadFile(caCertFile)
+	if err != nil {
+		return nil, fmt.Errorf("read Redis CA certificate: %w", err)
+	}
+
+	roots, err := x509.SystemCertPool()
+	if err != nil {
+		roots = x509.NewCertPool()
+	}
+	if !roots.AppendCertsFromPEM(caPEM) {
+		return nil, fmt.Errorf("parse Redis CA certificate %q: no certificates found", caCertFile)
+	}
+
+	tlsConfig.RootCAs = roots
+	return tlsConfig, nil
+}

--- a/backend/internal/pkg/redistls/config_test.go
+++ b/backend/internal/pkg/redistls/config_test.go
@@ -1,0 +1,70 @@
+package redistls
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigDisabled(t *testing.T) {
+	cfg, err := Config(false, "redis.internal", "/missing/ca.crt")
+	require.NoError(t, err)
+	require.Nil(t, cfg)
+}
+
+func TestConfigUsesSystemRootsWithoutCustomCA(t *testing.T) {
+	cfg, err := Config(true, "redis.internal", "")
+	require.NoError(t, err)
+	require.Equal(t, "redis.internal", cfg.ServerName)
+	require.Nil(t, cfg.RootCAs)
+}
+
+func TestConfigAppendsCustomCA(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "private Redis CA"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	caPath := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certDER,
+	}), 0o600))
+
+	cfg, err := Config(true, "redis.internal", caPath)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.RootCAs)
+	require.Contains(t, cfg.RootCAs.Subjects(), cert.RawSubject)
+}
+
+func TestConfigRejectsInvalidCAFile(t *testing.T) {
+	caPath := filepath.Join(t.TempDir(), "ca.crt")
+	require.NoError(t, os.WriteFile(caPath, []byte("not a certificate"), 0o600))
+
+	_, err := Config(true, "redis.internal", caPath)
+	require.ErrorContains(t, err, "no certificates found")
+}
+
+func TestConfigRejectsMissingCAFile(t *testing.T) {
+	_, err := Config(true, "redis.internal", filepath.Join(t.TempDir(), "missing.crt"))
+	require.ErrorContains(t, err, "read Redis CA certificate")
+}

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -265,6 +265,7 @@ type UsageLogFilters struct {
 	APIKeyID    int64
 	AccountID   int64
 	GroupID     int64
+	RequestID   string
 	Model       string
 	RequestType *int16
 	Stream      *bool

--- a/backend/internal/repository/redis.go
+++ b/backend/internal/repository/redis.go
@@ -1,10 +1,11 @@
 package repository
 
 import (
-	"crypto/tls"
+	"fmt"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/redistls"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -20,13 +21,17 @@ import (
 // 1. PoolSize: 控制最大并发连接数（默认 128）
 // 2. MinIdleConns: 保持最小空闲连接，减少冷启动延迟（默认 10）
 // 3. DialTimeout/ReadTimeout/WriteTimeout: 精确控制各阶段超时
-func InitRedis(cfg *config.Config) *redis.Client {
-	return redis.NewClient(buildRedisOptions(cfg))
+func InitRedis(cfg *config.Config) (*redis.Client, error) {
+	opts, err := buildRedisOptions(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build Redis options: %w", err)
+	}
+	return redis.NewClient(opts), nil
 }
 
 // buildRedisOptions 构建 Redis 连接选项
 // 从配置文件读取连接池和超时参数，支持生产环境调优
-func buildRedisOptions(cfg *config.Config) *redis.Options {
+func buildRedisOptions(cfg *config.Config) (*redis.Options, error) {
 	opts := &redis.Options{
 		Addr:         cfg.Redis.Address(),
 		Password:     cfg.Redis.Password,
@@ -38,12 +43,11 @@ func buildRedisOptions(cfg *config.Config) *redis.Options {
 		MinIdleConns: cfg.Redis.MinIdleConns,                                     // 最小空闲连接
 	}
 
-	if cfg.Redis.EnableTLS {
-		opts.TLSConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ServerName: cfg.Redis.Host,
-		}
+	tlsConfig, err := redistls.Config(cfg.Redis.EnableTLS, cfg.Redis.Host, cfg.Redis.CACertFile)
+	if err != nil {
+		return nil, err
 	}
+	opts.TLSConfig = tlsConfig
 
-	return opts
+	return opts, nil
 }

--- a/backend/internal/repository/redis_test.go
+++ b/backend/internal/repository/redis_test.go
@@ -23,7 +23,8 @@ func TestBuildRedisOptions(t *testing.T) {
 		},
 	}
 
-	opts := buildRedisOptions(cfg)
+	opts, err := buildRedisOptions(cfg)
+	require.NoError(t, err)
 	require.Equal(t, "localhost:6379", opts.Addr)
 	require.Equal(t, "secret", opts.Password)
 	require.Equal(t, 2, opts.DB)
@@ -41,7 +42,21 @@ func TestBuildRedisOptions(t *testing.T) {
 			EnableTLS: true,
 		},
 	}
-	optsTLS := buildRedisOptions(cfgTLS)
+	optsTLS, err := buildRedisOptions(cfgTLS)
+	require.NoError(t, err)
 	require.NotNil(t, optsTLS.TLSConfig)
 	require.Equal(t, "localhost", optsTLS.TLSConfig.ServerName)
+}
+
+func TestBuildRedisOptionsRejectsMissingCAFile(t *testing.T) {
+	cfg := &config.Config{
+		Redis: config.RedisConfig{
+			Host:       "redis.internal",
+			EnableTLS:  true,
+			CACertFile: "/missing/ca.crt",
+		},
+	}
+
+	_, err := buildRedisOptions(cfg)
+	require.ErrorContains(t, err, "read Redis CA certificate")
 }

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -2806,6 +2806,10 @@ func (r *usageLogRepository) ListWithFilters(ctx context.Context, params paginat
 		conditions = append(conditions, fmt.Sprintf("group_id = $%d", len(args)+1))
 		args = append(args, filters.GroupID)
 	}
+	if requestID := strings.TrimSpace(filters.RequestID); requestID != "" {
+		conditions = append(conditions, fmt.Sprintf("request_id = $%d", len(args)+1))
+		args = append(args, requestID)
+	}
 	conditions, args = appendRawUsageLogModelWhereCondition(conditions, args, filters.Model)
 	conditions, args = appendRequestTypeOrStreamWhereCondition(conditions, args, filters.RequestType, filters.Stream)
 	if filters.BillingType != nil {

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -196,6 +196,6 @@ func ProvideSQLDB(client *ent.Client) (*sql.DB, error) {
 //
 // 依赖：config.Config
 // 提供：*redis.Client
-func ProvideRedis(cfg *config.Config) *redis.Client {
+func ProvideRedis(cfg *config.Config) (*redis.Client, error) {
 	return InitRedis(cfg)
 }

--- a/backend/internal/setup/setup.go
+++ b/backend/internal/setup/setup.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"context"
 	"crypto/rand"
-	"crypto/tls"
 	"database/sql"
 	"encoding/hex"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/redistls"
 	"github.com/Wei-Shaw/sub2api/internal/repository"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
@@ -91,11 +91,12 @@ type DatabaseConfig struct {
 }
 
 type RedisConfig struct {
-	Host      string `json:"host" yaml:"host"`
-	Port      int    `json:"port" yaml:"port"`
-	Password  string `json:"password" yaml:"password"`
-	DB        int    `json:"db" yaml:"db"`
-	EnableTLS bool   `json:"enable_tls" yaml:"enable_tls"`
+	Host       string `json:"host" yaml:"host"`
+	Port       int    `json:"port" yaml:"port"`
+	Password   string `json:"password" yaml:"password"`
+	DB         int    `json:"db" yaml:"db"`
+	EnableTLS  bool   `json:"enable_tls" yaml:"enable_tls"`
+	CACertFile string `json:"ca_cert_file,omitempty" yaml:"ca_cert_file,omitempty"`
 }
 
 type AdminConfig struct {
@@ -253,12 +254,11 @@ func TestRedisConnection(cfg *RedisConfig) error {
 		DB:       cfg.DB,
 	}
 
-	if cfg.EnableTLS {
-		opts.TLSConfig = &tls.Config{
-			MinVersion: tls.VersionTLS12,
-			ServerName: cfg.Host,
-		}
+	tlsConfig, err := redistls.Config(cfg.EnableTLS, cfg.Host, cfg.CACertFile)
+	if err != nil {
+		return fmt.Errorf("configure TLS: %w", err)
 	}
+	opts.TLSConfig = tlsConfig
 
 	rdb := redis.NewClient(opts)
 	defer func() {
@@ -559,11 +559,12 @@ func AutoSetupFromEnv() error {
 			SSLMode:  getEnvOrDefault("DATABASE_SSLMODE", "disable"),
 		},
 		Redis: RedisConfig{
-			Host:      getEnvOrDefault("REDIS_HOST", "localhost"),
-			Port:      getEnvIntOrDefault("REDIS_PORT", 6379),
-			Password:  getEnvOrDefault("REDIS_PASSWORD", ""),
-			DB:        getEnvIntOrDefault("REDIS_DB", 0),
-			EnableTLS: getEnvOrDefault("REDIS_ENABLE_TLS", "false") == "true",
+			Host:       getEnvOrDefault("REDIS_HOST", "localhost"),
+			Port:       getEnvIntOrDefault("REDIS_PORT", 6379),
+			Password:   getEnvOrDefault("REDIS_PASSWORD", ""),
+			DB:         getEnvIntOrDefault("REDIS_DB", 0),
+			EnableTLS:  getEnvOrDefault("REDIS_ENABLE_TLS", "false") == "true",
+			CACertFile: getEnvOrDefault("REDIS_CA_CERT_FILE", ""),
 		},
 		Admin: AdminConfig{
 			Email:    getEnvOrDefault("ADMIN_EMAIL", "admin@sub2api.local"),

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -828,6 +828,8 @@ redis:
   # Enable TLS/SSL connection
   # 是否启用 TLS/SSL 连接
   enable_tls: false
+  # Optional PEM CA file for managed Redis services that use a private CA.
+  ca_cert_file: ""
 
 # =============================================================================
 # Ops Monitoring (Optional)


### PR DESCRIPTION
Adds an exact `request_id` query filter to the admin usage list API.

This lets operators and integrators reconcile a known request without scanning recent usage pages.

Tested:
- `go test ./internal/handler/admin ./internal/repository -run 'TestAdminUsageListRequestIDFilter|TestAdminUsageListRequestTypePriority|TestUsageLogRepositoryListWithFiltersRequestTypePriority'`