### PR TITLE
fix: use Codex window length for account usage stats

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -146,6 +146,7 @@ type UsageProgress struct {
 	Utilization      float64      `json:"utilization"`            // 使用率百分比 (0-100+，100表示100%)
 	ResetsAt         *time.Time   `json:"resets_at"`              // 重置时间
 	RemainingSeconds int          `json:"remaining_seconds"`      // 距重置剩余秒数
+	WindowMinutes    int          `json:"-"`                      // 上游窗口长度（分钟）
 	WindowStats      *WindowStats `json:"window_stats,omitempty"` // 窗口期统计（从窗口开始到当前的使用量）
 	UsedRequests     int64        `json:"used_requests,omitempty"`
 	LimitRequests    int64        `json:"limit_requests,omitempty"`
@@ -1070,9 +1071,10 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	var (
-		usedPercentKey string
-		resetAfterKey  string
-		resetAtKey     string
+		usedPercentKey   string
+		resetAfterKey    string
+		resetAtKey       string
+		windowMinutesKey string
 	)
 
 	switch window {
@@ -1080,10 +1082,12 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 		usedPercentKey = "codex_5h_used_percent"
 		resetAfterKey = "codex_5h_reset_after_seconds"
 		resetAtKey = "codex_5h_reset_at"
+		windowMinutesKey = "codex_5h_window_minutes"
 	case "7d":
 		usedPercentKey = "codex_7d_used_percent"
 		resetAfterKey = "codex_7d_reset_after_seconds"
 		resetAtKey = "codex_7d_reset_at"
+		windowMinutesKey = "codex_7d_window_minutes"
 	default:
 		return nil
 	}
@@ -1094,6 +1098,9 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	progress := &UsageProgress{Utilization: parseExtraFloat64(usedRaw)}
+	if windowMinutes := parseExtraInt(extra[windowMinutesKey]); windowMinutes > 0 {
+		progress.WindowMinutes = windowMinutes
+	}
 	if resetAtRaw, ok := extra[resetAtKey]; ok {
 		if resetAt, err := parseTime(fmt.Sprint(resetAtRaw)); err == nil {
 			progress.ResetsAt = &resetAt
@@ -1129,10 +1136,14 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 }
 
 func codexWindowStatsStart(progress *UsageProgress, fallbackWindow time.Duration, now time.Time) time.Time {
-	if progress != nil && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
-		return progress.ResetsAt.Add(-fallbackWindow)
+	window := fallbackWindow
+	if progress != nil && progress.WindowMinutes > 0 {
+		window = time.Duration(progress.WindowMinutes) * time.Minute
 	}
-	return now.Add(-fallbackWindow)
+	if progress != nil && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
+		return progress.ResetsAt.Add(-window)
+	}
+	return now.Add(-window)
 }
 
 func (s *AccountUsageService) GetAccountUsageStats(ctx context.Context, accountID int64, startTime, endTime time.Time) (*usagestats.AccountUsageStatsResponse, error) {

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -193,6 +193,22 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 	})
 
+	t.Run("captures upstream window minutes", func(t *testing.T) {
+		resetAt := now.Add(30 * 24 * time.Hour).Format(time.RFC3339)
+		extra := map[string]any{
+			"codex_7d_used_percent":   68.0,
+			"codex_7d_reset_at":       resetAt,
+			"codex_7d_window_minutes": "43800",
+		}
+		progress := buildCodexUsageProgressFromExtra(extra, "7d", now)
+		if progress == nil {
+			t.Fatal("expected non-nil progress")
+		}
+		if progress.WindowMinutes != 43800 {
+			t.Fatalf("expected WindowMinutes=43800, got %v", progress.WindowMinutes)
+		}
+	})
+
 	t.Run("expired 7d window zeroes utilization", func(t *testing.T) {
 		extra := map[string]any{
 			"codex_7d_used_percent": 88.0,
@@ -204,6 +220,47 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 		if progress.Utilization != 0 {
 			t.Fatalf("expected Utilization=0 for expired 7d window, got %v", progress.Utilization)
+		}
+	})
+}
+
+func TestCodexWindowStatsStart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+	resetAt := time.Date(2026, 7, 8, 10, 0, 0, 0, time.UTC)
+
+	t.Run("uses upstream window minutes before fallback duration", func(t *testing.T) {
+		progress := &UsageProgress{
+			ResetsAt:      &resetAt,
+			WindowMinutes: 43800,
+		}
+		got := codexWindowStatsStart(progress, 7*24*time.Hour, now)
+		want := resetAt.Add(-43800 * time.Minute)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStatsStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("falls back to fixed duration without window minutes", func(t *testing.T) {
+		progress := &UsageProgress{ResetsAt: &resetAt}
+		got := codexWindowStatsStart(progress, 7*24*time.Hour, now)
+		want := resetAt.Add(-7 * 24 * time.Hour)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStatsStart() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("uses window minutes from now after reset expires", func(t *testing.T) {
+		expiredResetAt := now.Add(-time.Hour)
+		progress := &UsageProgress{
+			ResetsAt:      &expiredResetAt,
+			WindowMinutes: 300,
+		}
+		got := codexWindowStatsStart(progress, 5*time.Hour, now)
+		want := now.Add(-300 * time.Minute)
+		if !got.Equal(want) {
+			t.Fatalf("codexWindowStatsStart() = %v, want %v", got, want)
 		}
 	})
 }


### PR DESCRIPTION
Fix OpenAI Codex account window stats to use the upstream window length saved in account extra.

OpenAI Codex snapshots can report a long window via `codex_7d_window_minutes` while the reset time is much farther out than 7 days. The current stats query always subtracts the fixed 7-day fallback from `codex_7d_reset_at`, which can put the start time in the future and make `seven_day.window_stats` empty.

This change keeps the existing 5h/7d fallback behavior when no upstream window length exists, but prefers `codex_*_window_minutes` for window stats when present.

Tests:
- `go test ./internal/service -run 'TestBuildCodexUsageProgressFromExtra|TestCodexWindowStatsStart'`
- `go test ./internal/service`
