### PR TITLE
Fix last-used account sorting for unused accounts

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -607,8 +607,16 @@ func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selecto
 		field = dbaccount.FieldRateMultiplier
 		defaultOrder = false
 	case "last_used_at":
-		field = dbaccount.FieldLastUsedAt
-		defaultOrder = false
+		if sortOrder == pagination.SortOrderDesc {
+			return []func(*entsql.Selector){
+				dbaccount.ByLastUsedAt(entsql.OrderDesc(), entsql.OrderNullsLast()),
+				dbaccount.ByID(entsql.OrderDesc()),
+			}
+		}
+		return []func(*entsql.Selector){
+			dbaccount.ByLastUsedAt(entsql.OrderNullsLast()),
+			dbaccount.ByID(),
+		}
 	case "expires_at":
 		field = dbaccount.FieldExpiresAt
 		defaultOrder = false

--- a/backend/internal/repository/account_repo_sort_integration_test.go
+++ b/backend/internal/repository/account_repo_sort_integration_test.go
@@ -3,6 +3,8 @@
 package repository
 
 import (
+	"time"
+
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 )
@@ -32,4 +34,38 @@ func (s *AccountRepoSuite) TestListWithFilters_SortByPriorityDesc() {
 	s.Require().Len(accounts, 2)
 	s.Require().Equal("high-priority", accounts[0].Name)
 	s.Require().Equal("low-priority", accounts[1].Name)
+}
+
+func (s *AccountRepoSuite) TestListWithFilters_SortByLastUsedAtNullsLast() {
+	older := time.Date(2026, 6, 9, 10, 0, 0, 0, time.UTC)
+	recent := older.Add(time.Minute)
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "never-used"})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "older-used", LastUsedAt: &older})
+	mustCreateAccount(s.T(), s.client, &service.Account{Name: "recent-used", LastUsedAt: &recent})
+
+	descAccounts, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{
+		Page:      1,
+		PageSize:  10,
+		SortBy:    "last_used_at",
+		SortOrder: "desc",
+	}, "", "", "", "", 0, "")
+	s.Require().NoError(err)
+	s.Require().Len(descAccounts, 3)
+	s.Require().Equal(
+		[]string{"recent-used", "older-used", "never-used"},
+		[]string{descAccounts[0].Name, descAccounts[1].Name, descAccounts[2].Name},
+	)
+
+	ascAccounts, _, err := s.repo.ListWithFilters(s.ctx, pagination.PaginationParams{
+		Page:      1,
+		PageSize:  10,
+		SortBy:    "last_used_at",
+		SortOrder: "asc",
+	}, "", "", "", "", 0, "")
+	s.Require().NoError(err)
+	s.Require().Len(ascAccounts, 3)
+	s.Require().Equal(
+		[]string{"older-used", "recent-used", "never-used"},
+		[]string{ascAccounts[0].Name, ascAccounts[1].Name, ascAccounts[2].Name},
+	)
 }


### PR DESCRIPTION
## Summary
- Ensure admin account sorting by `last_used_at` keeps accounts that have never been used at the end.
- Add an integration regression test covering both ascending and descending last-used sorting.

## Validation
- VS Code diagnostics: no errors for changed files.
- `git diff --check`: passed.
- Go tests were not run locally because the Go toolchain is not installed in this environment.