### PR TITLE
fix: normalize Codex OAuth responses parameters

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -95,6 +95,8 @@ var openAIChatGPTInternalUnsupportedFields = []string{
 }
 
 var openAICodexOAuthUnsupportedFields = append([]string{
+	"truncation",
+	"reasoning_effort",
 	"max_output_tokens",
 	"max_completion_tokens",
 	"temperature",
@@ -108,6 +110,40 @@ func applyCodexOAuthTransform(reqBody map[string]any, isCodexCLI bool, isCompact
 		IsCodexCLI: isCodexCLI,
 		IsCompact:  isCompact,
 	})
+}
+
+func normalizeOpenAIReasoningEffortAliasInMap(reqBody map[string]any) bool {
+	raw, exists := reqBody["reasoning_effort"]
+	if !exists {
+		return false
+	}
+
+	delete(reqBody, "reasoning_effort")
+	if reasoning, ok := reqBody["reasoning"].(map[string]any); ok {
+		if _, hasEffort := reasoning["effort"]; hasEffort {
+			return true
+		}
+	}
+
+	rawEffort, ok := raw.(string)
+	if !ok {
+		return true
+	}
+	effort := normalizeOpenAIReasoningEffortForUpstream(rawEffort)
+	if effort == "" {
+		return true
+	}
+
+	reasoning, ok := reqBody["reasoning"].(map[string]any)
+	if !ok {
+		if _, hasReasoning := reqBody["reasoning"]; hasReasoning {
+			return true
+		}
+		reasoning = map[string]any{}
+		reqBody["reasoning"] = reasoning
+	}
+	reasoning["effort"] = effort
+	return true
 }
 
 func applyCodexOAuthTransformWithOptions(reqBody map[string]any, opts codexOAuthTransformOptions) codexTransformResult {
@@ -148,6 +184,10 @@ func applyCodexOAuthTransformWithOptions(reqBody map[string]any, opts codexOAuth
 			reqBody["stream"] = true
 			result.Modified = true
 		}
+	}
+
+	if normalizeOpenAIReasoningEffortAliasInMap(reqBody) {
+		result.Modified = true
 	}
 
 	// Strip parameters unsupported by ChatGPT internal Codex endpoint.

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1140,6 +1140,8 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 		"prompt_cache_retention": "24h",
 		"safety_identifier":      "sid",
 		"stream_options":         map[string]any{"include_usage": true},
+		"truncation":             "auto",
+		"reasoning_effort":       "high",
 		"input": []any{
 			map[string]any{"role": "user", "content": "hi"},
 		},
@@ -1151,6 +1153,9 @@ func TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields(t *test
 	for _, field := range openAIChatGPTInternalUnsupportedFields {
 		require.NotContains(t, reqBody, field)
 	}
+	require.NotContains(t, reqBody, "truncation")
+	require.NotContains(t, reqBody, "reasoning_effort")
+	require.Equal(t, map[string]any{"effort": "high"}, reqBody["reasoning"])
 }
 
 func TestApplyCodexOAuthTransform_ExtractsSystemMessages(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -7166,3 +7166,22 @@ func normalizeOpenAIReasoningEffort(raw string) string {
 		return ""
 	}
 }
+
+func normalizeOpenAIReasoningEffortForUpstream(raw string) string {
+	value := strings.ToLower(strings.TrimSpace(raw))
+	if value == "" {
+		return ""
+	}
+
+	value = strings.NewReplacer("-", "", "_", "", " ", "").Replace(value)
+	switch value {
+	case "none", "minimal":
+		return "none"
+	case "low", "medium", "high":
+		return value
+	case "xhigh", "extrahigh":
+		return "xhigh"
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary
- strip `truncation` before forwarding Codex OAuth requests to the ChatGPT internal upstream
- normalize top-level `reasoning_effort` into `reasoning.effort` before stripping the unsupported alias
- extend the Codex OAuth transform regression test to cover both fields

## Tests
- `go test ./internal/service -run "TestApplyCodexOAuthTransform_StripsChatGPTInternalUnsupportedFields" -count=1`