### PR TITLE
fix(gemini): cleanToolSchema 展开 type 联合数组并剥离 $defs/$ref，修复工具调用 400

### DIFF
--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -3399,39 +3399,122 @@ func isClaudeWebSearchToolMap(tool map[string]any) bool {
 	}
 }
 
+const maxCleanToolSchemaDepth = 100
+
 // cleanToolSchema 清理工具的 JSON Schema，移除 Gemini 不支持的字段
 func cleanToolSchema(schema any) any {
+	defs := extractToolSchemaDefinitions(schema)
+	return cleanToolSchemaRecursive(schema, defs, make(map[string]bool), 0)
+}
+
+func extractToolSchemaDefinitions(schema any) map[string]any {
+	root, ok := schema.(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	defs := make(map[string]any)
+	for _, key := range []string{"$defs", "definitions"} {
+		if definitions, ok := root[key].(map[string]any); ok {
+			for name, definition := range definitions {
+				defs[name] = definition
+			}
+		}
+	}
+	return defs
+}
+
+func cleanToolSchemaRecursive(schema any, defs map[string]any, activeRefs map[string]bool, depth int) any {
 	if schema == nil {
+		return nil
+	}
+	if depth >= maxCleanToolSchemaDepth {
 		return nil
 	}
 
 	switch v := schema.(type) {
 	case map[string]any:
-		cleaned := make(map[string]any)
+		cleaned := make(map[string]any, len(v))
+		if ref, ok := v["$ref"].(string); ok {
+			if refName, ok := toolSchemaRefName(ref); ok && !activeRefs[refName] {
+				if definition, exists := defs[refName]; exists {
+					activeRefs[refName] = true
+					expanded := cleanToolSchemaRecursive(definition, defs, activeRefs, depth+1)
+					delete(activeRefs, refName)
+					if expandedMap, ok := expanded.(map[string]any); ok {
+						for key, value := range expandedMap {
+							cleaned[key] = value
+						}
+					}
+				}
+			}
+		}
+
 		for key, value := range v {
 			// 跳过不支持的字段
 			if key == "$schema" || key == "$id" || key == "$ref" ||
+				key == "$defs" || key == "definitions" ||
 				key == "additionalProperties" || key == "patternProperties" || key == "minLength" ||
 				key == "maxLength" || key == "minItems" || key == "maxItems" {
 				continue
 			}
 			// 递归清理嵌套对象
-			cleaned[key] = cleanToolSchema(value)
+			cleaned[key] = cleanToolSchemaRecursive(value, defs, activeRefs, depth+1)
 		}
-		// 规范化 type 字段为大写
-		if typeVal, ok := cleaned["type"].(string); ok {
+
+		switch typeVal := cleaned["type"].(type) {
+		case string:
 			cleaned["type"] = strings.ToUpper(typeVal)
+		case []any:
+			selectedType := ""
+			nullable := false
+			for _, item := range typeVal {
+				itemType, ok := item.(string)
+				if !ok {
+					continue
+				}
+				if strings.EqualFold(itemType, "null") {
+					nullable = true
+					continue
+				}
+				if selectedType == "" {
+					selectedType = itemType
+				}
+			}
+			if selectedType == "" && nullable {
+				selectedType = "string"
+			}
+			if selectedType == "" {
+				delete(cleaned, "type")
+			} else {
+				cleaned["type"] = strings.ToUpper(selectedType)
+			}
+			if nullable {
+				cleaned["nullable"] = true
+			}
 		}
 		return cleaned
 	case []any:
 		cleaned := make([]any, len(v))
 		for i, item := range v {
-			cleaned[i] = cleanToolSchema(item)
+			cleaned[i] = cleanToolSchemaRecursive(item, defs, activeRefs, depth+1)
 		}
 		return cleaned
 	default:
 		return v
 	}
+}
+
+func toolSchemaRefName(ref string) (string, bool) {
+	for _, prefix := range []string{"#/$defs/", "#/definitions/"} {
+		if strings.HasPrefix(ref, prefix) {
+			name := strings.TrimPrefix(ref, prefix)
+			if name != "" && !strings.Contains(name, "/") {
+				return strings.ReplaceAll(strings.ReplaceAll(name, "~1", "/"), "~0", "~"), true
+			}
+		}
+	}
+	return "", false
 }
 
 func convertClaudeGenerationConfig(req map[string]any) map[string]any {

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -322,6 +322,133 @@ func TestConvertClaudeToolsToGeminiTools_PreservesWebSearchAlongsideFunctions(t 
 	require.Empty(t, googleSearch)
 }
 
+func TestCleanToolSchema(t *testing.T) {
+	t.Run("collapses nullable type union", func(t *testing.T) {
+		schema := map[string]any{
+			"type": []any{"string", "null"},
+		}
+
+		require.Equal(t, map[string]any{
+			"type":     "STRING",
+			"nullable": true,
+		}, cleanToolSchema(schema))
+	})
+
+	t.Run("inlines root ref and removes defs", func(t *testing.T) {
+		schema := map[string]any{
+			"$ref": "#/$defs/Person",
+			"$defs": map[string]any{
+				"Person": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"name": map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+
+		require.Equal(t, map[string]any{
+			"type": "OBJECT",
+			"properties": map[string]any{
+				"name": map[string]any{"type": "STRING"},
+			},
+		}, cleanToolSchema(schema))
+	})
+
+	t.Run("cleans nested unions and refs", func(t *testing.T) {
+		schema := map[string]any{
+			"type": "object",
+			"definitions": map[string]any{
+				"Identifier": map[string]any{
+					"type":        []any{"integer", "null"},
+					"description": "Resource identifier",
+				},
+			},
+			"properties": map[string]any{
+				"label": map[string]any{
+					"type": []any{"string", "null"},
+				},
+				"id": map[string]any{
+					"$ref": "#/definitions/Identifier",
+				},
+			},
+		}
+
+		require.Equal(t, map[string]any{
+			"type": "OBJECT",
+			"properties": map[string]any{
+				"label": map[string]any{
+					"type":     "STRING",
+					"nullable": true,
+				},
+				"id": map[string]any{
+					"type":        "INTEGER",
+					"nullable":    true,
+					"description": "Resource identifier",
+				},
+			},
+		}, cleanToolSchema(schema))
+	})
+
+	t.Run("preserves existing cleanup behavior", func(t *testing.T) {
+		schema := map[string]any{
+			"type":                 "object",
+			"additionalProperties": false,
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "string",
+					"description": "Display name",
+				},
+			},
+			"required": []any{"name"},
+		}
+
+		require.Equal(t, map[string]any{
+			"type": "OBJECT",
+			"properties": map[string]any{
+				"name": map[string]any{
+					"type":        "STRING",
+					"description": "Display name",
+				},
+			},
+			"required": []any{"name"},
+		}, cleanToolSchema(schema))
+	})
+
+	t.Run("breaks circular refs", func(t *testing.T) {
+		schema := map[string]any{
+			"type": "object",
+			"$defs": map[string]any{
+				"Node": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"next": map[string]any{"$ref": "#/$defs/Node"},
+					},
+				},
+			},
+			"properties": map[string]any{
+				"root": map[string]any{"$ref": "#/$defs/Node"},
+			},
+		}
+
+		var cleaned any
+		require.NotPanics(t, func() {
+			cleaned = cleanToolSchema(schema)
+		})
+		require.Equal(t, map[string]any{
+			"type": "OBJECT",
+			"properties": map[string]any{
+				"root": map[string]any{
+					"type": "OBJECT",
+					"properties": map[string]any{
+						"next": map[string]any{},
+					},
+				},
+			},
+		}, cleaned)
+	})
+}
+
 func TestGeminiHandleNativeNonStreamingResponse_DebugDisabledDoesNotEmitHeaderLogs(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	logSink, restore := captureStructuredLog(t)


### PR DESCRIPTION
## 背景

通过 Anthropic `/v1/messages` 或 OpenAI `/v1/chat/completions` 转发到 Gemini 时，工具 JSON Schema 会经过 `convertClaudeMessagesToGeminiGenerateContent` 和 `cleanToolSchema`。原实现只处理字符串形式的 `type`，联合数组（如 `["string", "null"]`）会原样进入 Gemini 的 `function_declarations`；同时 `$defs` 会残留，而 `$ref` 只被删除、没有展开，最终触发 `400 INVALID_ARGUMENT`。

## 改动

- 将 `type` 联合数组折叠为第一个非 `null` 的 Gemini 单一类型；包含 `null` 时设置 `nullable: true`，全为 `null` 时兜底为 `STRING`。
- 解析顶层 `$defs` / `definitions`，递归内联 `#/$defs/X` 与 `#/definitions/X` 本地引用，并从最终 schema 中移除定义表和 `$ref`。
- 使用活动引用集合阻断循环引用，并增加最大递归深度兜底；保留 `$ref` 同级字段覆盖展开定义的行为。
- 保持原有 Gemini 不支持字段过滤逻辑不变，不影响 OpenAI、Anthropic 和 Antigravity 的 schema 处理路径。
- 增加单元测试覆盖联合类型、根级与嵌套引用、普通 schema 兼容性和循环引用。

## 测试

- `cd backend && go test -tags=unit ./...`
- `cd backend && golangci-lint run ./...`（0 issues）

Fixes #3143。