### PR TITLE
fix(openai): Responses API session hash fallback 纳入 input 内容，避免 sticky 绑死账号

### DIFF
--- a/backend/internal/service/gateway_request.go
+++ b/backend/internal/service/gateway_request.go
@@ -119,6 +119,7 @@ func clearGatewayRequestDerivedState(parsed *ParsedRequest) {
 	parsed.MaxTokens = 0
 	parsed.systemRange = missingJSONRange()
 	parsed.messagesRange = missingJSONRange()
+	parsed.inputRange = missingJSONRange()
 }
 
 func clearGatewayRequestRanges(parsed *ParsedRequest) {
@@ -128,6 +129,7 @@ func clearGatewayRequestRanges(parsed *ParsedRequest) {
 	parsed.HasSystem = false
 	parsed.systemRange = missingJSONRange()
 	parsed.messagesRange = missingJSONRange()
+	parsed.inputRange = missingJSONRange()
 }
 
 func setGatewayRequestRanges(parsed *ParsedRequest, protocol string, jsonStr string) {
@@ -149,6 +151,11 @@ func setGatewayRequestRanges(parsed *ParsedRequest, protocol string, jsonStr str
 		}
 		if msgs := gjson.Get(jsonStr, "messages"); msgs.Exists() && msgs.IsArray() {
 			parsed.messagesRange = rangeFromResult(msgs)
+		}
+		if protocol == "responses" {
+			if input := gjson.Get(jsonStr, "input"); input.Exists() {
+				parsed.inputRange = rangeFromResult(input)
+			}
 		}
 	}
 }
@@ -235,6 +242,7 @@ type ParsedRequest struct {
 	protocol      string    // 当前 Body 的协议格式，用于 Body 替换后刷新 raw range
 	systemRange   jsonRange // system/systemInstruction.parts 的 raw JSON 范围，绑定 Body 当前内容
 	messagesRange jsonRange // messages/contents 的 raw JSON 范围，绑定 Body 当前内容
+	inputRange    jsonRange // Responses API input 的 raw JSON 范围，绑定 Body 当前内容
 
 	// GroupID 请求所属分组 ID（来自 API Key）
 	GroupID *int64
@@ -315,6 +323,10 @@ func (p *ParsedRequest) SystemRaw() []byte {
 
 func (p *ParsedRequest) MessagesRaw() []byte {
 	return p.raw(p.messagesRange)
+}
+
+func (p *ParsedRequest) InputRaw() []byte {
+	return p.raw(p.inputRange)
 }
 
 func (p *ParsedRequest) DecodeSystem(dst any) error {

--- a/backend/internal/service/gateway_request_test.go
+++ b/backend/internal/service/gateway_request_test.go
@@ -77,6 +77,15 @@ func TestParseGatewayRequest_InvalidStreamType(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestParseGatewayRequest_ResponsesInput(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.1","input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]}]}`)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), "responses")
+	require.NoError(t, err)
+	require.NotEmpty(t, parsed.InputRaw())
+	require.Nil(t, parsed.MessagesRaw())
+	require.Equal(t, "hello", gjson.ParseBytes(parsed.InputRaw()).Get("0.content.0.text").String())
+}
+
 // ============ Gemini 原生格式解析测试 ============
 
 func TestParseGatewayRequest_GeminiContents(t *testing.T) {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -770,7 +770,11 @@ func (s *GatewayService) GenerateSessionHash(parsed *ParsedRequest) string {
 	if systemText := extractTextFromSystemRaw(parsed.SystemRaw()); systemText != "" {
 		_, _ = combined.WriteString(systemText)
 	}
+	contentStart := combined.Len()
 	appendMessageTextsFromRaw(&combined, parsed.MessagesRaw())
+	if combined.Len() == contentStart {
+		appendResponsesSessionAnchorFromRaw(&combined, parsed.InputRaw())
+	}
 	if combined.Len() > 0 {
 		hash := s.hashContent(combined.String())
 		slog.Info("sticky.hash_source",
@@ -924,6 +928,65 @@ func appendMessageTextsFromRaw(builder *strings.Builder, raw []byte) {
 				}
 				return true
 			})
+		}
+		return true
+	})
+}
+
+func appendResponsesSessionAnchorFromRaw(builder *strings.Builder, raw []byte) {
+	if builder == nil || len(raw) == 0 {
+		return
+	}
+	input := parseRawJSONView(raw)
+	if input.Type == gjson.String {
+		_, _ = builder.WriteString(input.String())
+		return
+	}
+	if !input.IsArray() {
+		return
+	}
+
+	input.ForEach(func(_, item gjson.Result) bool {
+		if item.Type == gjson.String {
+			_, _ = builder.WriteString(item.String())
+			return false
+		}
+
+		switch item.Get("role").String() {
+		case "system", "developer":
+			appendResponsesContentText(builder, item.Get("content"))
+		case "user":
+			appendResponsesContentText(builder, item.Get("content"))
+			return false
+		default:
+			if item.Get("type").String() == "input_text" {
+				if text := item.Get("text").String(); text != "" {
+					_, _ = builder.WriteString(text)
+				}
+				return false
+			}
+		}
+		return true
+	})
+}
+
+func appendResponsesContentText(builder *strings.Builder, content gjson.Result) {
+	if builder == nil || !content.Exists() {
+		return
+	}
+	if content.Type == gjson.String {
+		_, _ = builder.WriteString(content.String())
+		return
+	}
+	if !content.IsArray() {
+		return
+	}
+	content.ForEach(func(_, part gjson.Result) bool {
+		switch part.Get("type").String() {
+		case "input_text", "text":
+			if text := part.Get("text").String(); text != "" {
+				_, _ = builder.WriteString(text)
+			}
 		}
 		return true
 	})

--- a/backend/internal/service/generate_session_hash_test.go
+++ b/backend/internal/service/generate_session_hash_test.go
@@ -26,6 +26,14 @@ func mustParseGeminiSessionHashRequest(t *testing.T, body string, ctx *SessionCo
 	return parsed
 }
 
+func mustParseResponsesSessionHashRequest(t *testing.T, body string, ctx *SessionContext) *ParsedRequest {
+	t.Helper()
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef([]byte(body)), "responses")
+	require.NoError(t, err)
+	parsed.SessionContext = ctx
+	return parsed
+}
+
 func anthropicSessionBody(system any, messages []any, metadataUserID string) string {
 	body := map[string]any{}
 	if system != nil {
@@ -215,6 +223,60 @@ func TestGenerateSessionHash_ContinuousConversation_SameRoundSameHash(t *testing
 	h1 := svc.GenerateSessionHash(mk())
 	h2 := svc.GenerateSessionHash(mk())
 	require.Equal(t, h1, h2, "same conversation state should produce identical hash on retry")
+}
+
+func TestGenerateSessionHash_ResponsesDifferentInputProducesDifferentHash(t *testing.T) {
+	svc := &GatewayService{}
+	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "codex_cli_rs/0.1.0", APIKeyID: 1}
+	first := mustParseResponsesSessionHashRequest(t, `{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"help me with Go"}]}]}`, ctx)
+	second := mustParseResponsesSessionHashRequest(t, `{"input":[{"type":"message","role":"user","content":[{"type":"input_text","text":"help me with Python"}]}]}`, ctx)
+
+	h1 := svc.GenerateSessionHash(first)
+	h2 := svc.GenerateSessionHash(second)
+	require.NotEmpty(t, h1)
+	require.NotEmpty(t, h2)
+	require.NotEqual(t, h1, h2, "different Responses input should produce different hashes for the same client")
+}
+
+func TestGenerateSessionHash_ResponsesGrowingInputKeepsStableHash(t *testing.T) {
+	svc := &GatewayService{}
+	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "codex_cli_rs/0.1.0", APIKeyID: 1}
+	round1 := mustParseResponsesSessionHashRequest(t, `{"input":[{"type":"message","role":"developer","content":[{"type":"input_text","text":"Be concise."}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"help me with Go"}]}]}`, ctx)
+	round2 := mustParseResponsesSessionHashRequest(t, `{"input":[{"type":"message","role":"developer","content":[{"type":"input_text","text":"Be concise."}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"help me with Go"}]},{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Sure."}]},{"type":"message","role":"user","content":[{"type":"input_text","text":"add tests"}]}]}`, ctx)
+
+	h1 := svc.GenerateSessionHash(round1)
+	h2 := svc.GenerateSessionHash(round2)
+	require.NotEmpty(t, h1)
+	require.Equal(t, h1, h2, "Responses input growth should preserve the hash when the conversation prefix is stable")
+}
+
+func TestGenerateSessionHash_MessagesPathIgnoresResponsesInput(t *testing.T) {
+	svc := &GatewayService{}
+	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
+	first := mustParseResponsesSessionHashRequest(t, `{"messages":[{"role":"user","content":"hello"}],"input":"first"}`, ctx)
+	second := mustParseResponsesSessionHashRequest(t, `{"messages":[{"role":"user","content":"hello"}],"input":"second"}`, ctx)
+
+	h1 := svc.GenerateSessionHash(first)
+	h2 := svc.GenerateSessionHash(second)
+	require.Equal(t, h1, h2, "existing messages fallback should remain authoritative when messages contain text")
+}
+
+func TestGenerateSessionHash_ResponsesInputDoesNotOverrideHigherPrioritySources(t *testing.T) {
+	svc := &GatewayService{}
+	ctx := &SessionContext{ClientIP: "1.2.3.4", UserAgent: "test", APIKeyID: 1}
+
+	t.Run("metadata user id", func(t *testing.T) {
+		metadata := "user_a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2_account__session_123e4567-e89b-12d3-a456-426614174000"
+		parsed := mustParseResponsesSessionHashRequest(t, `{"metadata":{"user_id":"`+metadata+`"},"input":"hello"}`, ctx)
+		require.Equal(t, "123e4567-e89b-12d3-a456-426614174000", svc.GenerateSessionHash(parsed))
+	})
+
+	t.Run("cache control", func(t *testing.T) {
+		body := `{"system":[{"type":"text","text":"stable cache anchor","cache_control":{"type":"ephemeral"}}],"input":"hello"}`
+		first := mustParseResponsesSessionHashRequest(t, body, ctx)
+		second := mustParseResponsesSessionHashRequest(t, body, &SessionContext{ClientIP: "9.8.7.6", UserAgent: "other", APIKeyID: 2})
+		require.Equal(t, svc.GenerateSessionHash(first), svc.GenerateSessionHash(second))
+	})
 }
 
 func TestGenerateSessionHash_MessageRollback(t *testing.T) {


### PR DESCRIPTION
## 背景

`/v1/responses` 通过通用 `GatewayService.GenerateSessionHash` 生成 sticky session hash。请求未携带可解析的 `metadata.user_id`，也没有 Anthropic `cache_control: {type: "ephemeral"}` 时，会进入内容 fallback。

此前 `ParsedRequest` 只保留 `system/messages`，没有解析 Responses API 的 `input`。因此同一客户端的 fallback 实际只包含 client IP、User-Agent 和 API Key ID，不同会话会得到相同 hash，并持续粘在首次命中的账号。

本 PR 与 #2872（sticky 健康度逃逸）互补：本 PR 修复 fallback hash 的会话区分度，#2872 修复账号绑定后的健康度逃逸。

## 改动

- 在 Responses 协议解析中轻量记录 `input` 的 raw range，并在请求体替换时同步刷新。
- fallback 中 `messages` 未提供可哈希文本时，从 Responses `input` 提取稳定会话首部：前置 system/developer 内容与首条 user 文本。
- 只使用稳定首部，避免多轮 `input` 增长导致每次请求都生成不同 hash，保留合理的 sticky 亲和。
- 保持 `metadata.user_id`、`cache_control` 两级优先级和现有 `messages` 路径行为不变。

## 测试

- 两个不同 `input`、相同 client IP/User-Agent/API Key 的 Responses 请求生成不同 session hash。
- 同一会话首部稳定、后续 `input` 增长时生成相同 session hash。
- `messages` 路径继续优先，不受 Responses `input` 影响。
- `metadata.user_id` 与 `cache_control` 命中时仍走原有高优先级路径。
- `cd backend && go test -tags=unit ./...`
- `cd backend && golangci-lint run ./...`（0 issues）

Fixes #3127