### PR TITLE
fix(openai): restore Codex image bridge in WS v2 passthrough

### DIFF
--- a/backend/internal/service/openai_fast_policy_ws_test.go
+++ b/backend/internal/service/openai_fast_policy_ws_test.go
@@ -994,7 +994,7 @@ func TestPassthroughUsageMeta_TracksReasoningEffortAcrossTurns(t *testing.T) {
 	firstOut, firstBlocked, firstErr := svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, capturedSessionModel, firstFrame)
 	require.NoError(t, firstErr)
 	require.Nil(t, firstBlocked)
-	meta.initFromFirstFrame(firstOut)
+	require.NoError(t, meta.initFromFirstFrame(firstOut, nil))
 	require.NotNil(t, meta.reasoningEffort.Load())
 	require.Equal(t, "medium", *meta.reasoningEffort.Load())
 
@@ -1011,7 +1011,7 @@ func TestPassthroughUsageMeta_TracksReasoningEffortAcrossTurns(t *testing.T) {
 		out, blocked, policyErr := svc.applyOpenAIFastPolicyToWSResponseCreate(context.Background(), account, model, payload)
 		if policyErr == nil && blocked == nil &&
 			strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "response.create" {
-			meta.updateFromResponseCreate(out, requestModelForThisFrame)
+			require.NoError(t, meta.updateFromResponseCreate(out, requestModelForThisFrame, nil))
 		}
 		return out, blocked, policyErr
 	}

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -711,6 +711,146 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeR
 	require.Len(t, upstreamConn.writes, 1, "passthrough 模式应透传首条 response.create")
 }
 
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeInjectsCodexImageBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.ForceCodexCLI = true
+	cfg.Gateway.CodexImageGenerationBridgeEnabled = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModeCtxPool
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	upstreamConn := &openAIWSCaptureConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.completed","response":{"id":"resp_passthrough_image","model":"gpt-5.1","usage":{"input_tokens":5,"output_tokens":9,"output_tokens_details":{"image_tokens":4}},"output":[{"id":"ig_passthrough","type":"image_generation_call","result":"ZmluYWw=","size":"1024x1024"}]}}`),
+		},
+	}
+	captureDialer := &openAIWSCaptureDialer{conn: upstreamConn}
+	svc := &OpenAIGatewayService{
+		cfg:                       cfg,
+		httpUpstream:              &httpUpstreamRecorder{},
+		cache:                     &stubGatewayCache{},
+		openaiWSResolver:          NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:             NewCodexToolCorrector(),
+		openaiWSPassthroughDialer: captureDialer,
+	}
+
+	account := &Account{
+		ID:          453,
+		Name:        "openai-ingress-passthrough-image",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-test",
+		},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_mode": OpenAIWSIngressModePassthrough,
+		},
+	}
+
+	serverErrCh := make(chan error, 1)
+	resultCh := make(chan *OpenAIForwardResult, 1)
+	hooks := &OpenAIWSIngressHooks{
+		AfterTurn: func(_ int, result *OpenAIForwardResult, turnErr error) {
+			if turnErr == nil && result != nil {
+				resultCh <- result
+			}
+		},
+	}
+
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{
+			CompressionMode: coderws.CompressionContextTakeover,
+		})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() {
+			_ = conn.CloseNow()
+		}()
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		req := r.Clone(r.Context())
+		req.Header = req.Header.Clone()
+		req.Header.Set("User-Agent", "unit-test-agent/1.0")
+		ginCtx.Request = req
+
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErrCh <- errors.New("unsupported websocket client message type")
+			return
+		}
+
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, hooks)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() {
+		_ = clientConn.CloseNow()
+	}()
+
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"input":"生成一张花朵的图片"}`))
+	cancelWrite()
+	require.NoError(t, err)
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	_, event, readErr := clientConn.Read(readCtx)
+	cancelRead()
+	require.NoError(t, readErr)
+	require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, "resp_passthrough_image", gjson.GetBytes(event, "response.id").String())
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
+
+	select {
+	case serverErr := <-serverErrCh:
+		if serverErr != nil {
+			require.Contains(t, serverErr.Error(), "StatusNormalClosure",
+				"server error should only be a normal close frame, got: %v", serverErr)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待 passthrough image websocket 结束超时")
+	}
+
+	select {
+	case result := <-resultCh:
+		require.Equal(t, "resp_passthrough_image", result.RequestID)
+		require.Equal(t, 1, result.ImageCount)
+		require.Equal(t, []string{"1024x1024"}, result.ImageOutputSizes)
+		require.Equal(t, 4, result.Usage.ImageOutputTokens)
+	case <-time.After(2 * time.Second):
+		t.Fatal("未收到 passthrough image turn 结果回调")
+	}
+
+	require.Equal(t, 1, captureDialer.DialCount(), "passthrough 模式应直接建立上游 websocket")
+	require.Len(t, upstreamConn.writes, 1, "passthrough 模式应向上游发送首条 response.create")
+	require.Equal(t, "image_generation", gjson.Get(requestToJSONString(upstreamConn.writes[0]), "tools.0.type").String())
+}
+
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughHeadersUsePromptCacheAndTurnState(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -127,9 +128,16 @@ func openAIWSPassthroughPolicyModelFromSessionFrame(account *Account, payload []
 type openAIWSPassthroughUsageMeta struct {
 	serviceTier     atomic.Pointer[string]
 	reasoningEffort atomic.Pointer[string]
+	imageBilling    atomic.Pointer[openAIWSPassthroughImageBillingMeta]
 
 	// 仅在 client->upstream filter goroutine 中读写；Load 侧通过上方原子指针同步。
 	sessionRequestModel string
+}
+
+type openAIWSPassthroughImageBillingMeta struct {
+	BillingModel string
+	SizeTier     string
+	InputSize    string
 }
 
 func newOpenAIWSPassthroughUsageMeta(initialRequestModel string, firstFrame []byte) *openAIWSPassthroughUsageMeta {
@@ -142,12 +150,13 @@ func newOpenAIWSPassthroughUsageMeta(initialRequestModel string, firstFrame []by
 	return meta
 }
 
-func (m *openAIWSPassthroughUsageMeta) initFromFirstFrame(policyOutput []byte) {
+func (m *openAIWSPassthroughUsageMeta) initFromFirstFrame(policyOutput []byte, apiKey *APIKey) error {
 	if m == nil {
-		return
+		return nil
 	}
 	m.serviceTier.Store(extractOpenAIServiceTierFromBody(policyOutput))
 	m.reasoningEffort.Store(extractOpenAIReasoningEffortFromBody(policyOutput, m.sessionRequestModel))
+	return m.updateImageBillingFromResponseCreate(policyOutput, m.sessionRequestModel, apiKey)
 }
 
 func (m *openAIWSPassthroughUsageMeta) updateSessionRequestModel(payload []byte) {
@@ -169,12 +178,58 @@ func (m *openAIWSPassthroughUsageMeta) requestModelForFrame(payload []byte) stri
 	return m.sessionRequestModel
 }
 
-func (m *openAIWSPassthroughUsageMeta) updateFromResponseCreate(policyOutput []byte, requestModelForFrame string) {
+func (m *openAIWSPassthroughUsageMeta) updateFromResponseCreate(policyOutput []byte, requestModelForFrame string, apiKey *APIKey) error {
 	if m == nil {
-		return
+		return nil
 	}
 	m.serviceTier.Store(extractOpenAIServiceTierFromBody(policyOutput))
 	m.reasoningEffort.Store(extractOpenAIReasoningEffortFromBody(policyOutput, requestModelForFrame))
+	return m.updateImageBillingFromResponseCreate(policyOutput, requestModelForFrame, apiKey)
+}
+
+func (m *openAIWSPassthroughUsageMeta) updateImageBillingFromResponseCreate(policyOutput []byte, requestModelForFrame string, apiKey *APIKey) error {
+	if m == nil {
+		return nil
+	}
+	requestModelForFrame = strings.TrimSpace(requestModelForFrame)
+	if requestModelForFrame == "" {
+		requestModelForFrame = m.sessionRequestModel
+	}
+	if !IsImageGenerationIntent(openAIResponsesEndpoint, requestModelForFrame, policyOutput) {
+		m.imageBilling.Store(nil)
+		return nil
+	}
+	if !GroupAllowsImageGeneration(apiKeyGroup(apiKey)) {
+		return NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, ImageGenerationPermissionMessage(), nil)
+	}
+	imageCfg, err := resolveOpenAIResponsesImageBillingConfigDetailedFromBody(policyOutput, requestModelForFrame)
+	if err != nil {
+		return err
+	}
+	m.imageBilling.Store(&openAIWSPassthroughImageBillingMeta{
+		BillingModel: imageCfg.Model,
+		SizeTier:     imageCfg.SizeTier,
+		InputSize:    imageCfg.InputSize,
+	})
+	return nil
+}
+
+func applyOpenAIWSPassthroughImageBillingResult(result *OpenAIForwardResult, counter *openAIImageOutputCounter, meta *openAIWSPassthroughImageBillingMeta) {
+	if result == nil || counter == nil {
+		return
+	}
+	imageCount := counter.Count()
+	if imageCount <= 0 {
+		return
+	}
+	result.ImageCount = imageCount
+	result.ImageOutputSizes = counter.Sizes()
+	if meta == nil {
+		return
+	}
+	result.BillingModel = strings.TrimSpace(meta.BillingModel)
+	result.ImageSize = strings.TrimSpace(meta.SizeTier)
+	result.ImageInputSize = strings.TrimSpace(meta.InputSize)
 }
 
 func openAIWSPassthroughRequestModelForFrame(payload []byte) string {
@@ -189,6 +244,49 @@ func openAIWSPassthroughRequestModelFromSessionFrame(payload []byte) string {
 		return ""
 	}
 	return strings.TrimSpace(gjson.GetBytes(payload, "session.model").String())
+}
+
+func (s *OpenAIGatewayService) applyCodexImageGenerationBridgeToWSResponseCreate(
+	ctx context.Context,
+	account *Account,
+	apiKey *APIKey,
+	frame []byte,
+	isCodexCLI bool,
+) ([]byte, bool, error) {
+	if len(frame) == 0 || !gjson.ValidBytes(frame) {
+		return frame, false, nil
+	}
+	if strings.TrimSpace(gjson.GetBytes(frame, "type").String()) != "response.create" {
+		return frame, false, nil
+	}
+	if !isCodexCLI || !GroupAllowsImageGeneration(apiKeyGroup(apiKey)) || !s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey) {
+		return frame, false, nil
+	}
+
+	payloadMap := make(map[string]any)
+	if err := json.Unmarshal(frame, &payloadMap); err != nil {
+		return frame, false, err
+	}
+	modified := false
+	if ensureOpenAIResponsesImageGenerationTool(payloadMap) {
+		modified = true
+		logOpenAIWSModeInfo("ingress_ws_passthrough_codex_image_tool_injected account_id=%d", account.ID)
+	}
+	if normalizeOpenAIResponsesImageGenerationTools(payloadMap) {
+		modified = true
+	}
+	if applyCodexImageGenerationBridgeInstructions(payloadMap) {
+		modified = true
+		logOpenAIWSModeInfo("ingress_ws_passthrough_codex_image_bridge_instructions_added account_id=%d", account.ID)
+	}
+	if !modified {
+		return frame, false, nil
+	}
+	rebuilt, err := json.Marshal(payloadMap)
+	if err != nil {
+		return frame, false, err
+	}
+	return rebuilt, true, nil
 }
 
 const openaiWSV2PassthroughModeFields = "ws_mode=passthrough ws_router=v2"
@@ -246,6 +344,14 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	if strings.TrimSpace(token) == "" {
 		return errors.New("token is empty")
 	}
+	apiKey := getAPIKeyFromContext(c)
+	isCodexCLI := false
+	if c != nil {
+		isCodexCLI = openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator"))
+	}
+	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		isCodexCLI = true
+	}
 	requestModel := strings.TrimSpace(gjson.GetBytes(firstClientMessage, "model").String())
 	requestPreviousResponseID := strings.TrimSpace(gjson.GetBytes(firstClientMessage, "previous_response_id").String())
 	logOpenAIWSV2Passthrough(
@@ -257,10 +363,10 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		len(firstClientMessage),
 	)
 
-	// Apply OpenAI Fast Policy on the first response.create frame. Subsequent
-	// frames are filtered via a wrapping FrameConn below so every client→
-	// upstream frame goes through the same policy evaluator/normalize/scope as
-	// HTTP entrypoints.
+	// Apply the Codex image bridge and OpenAI Fast Policy on the first
+	// response.create frame. Subsequent frames are filtered via a wrapping
+	// FrameConn below so every client→upstream frame goes through the same
+	// bridge/policy path as HTTP entrypoints.
 	//
 	// We capture the session-level model from the first frame here so the
 	// per-frame filter (below) can fall back to it when a follow-up frame
@@ -269,6 +375,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	// negotiated at session.update time. Without this fallback, an empty
 	// model would miss any admin-configured model whitelist and be silently
 	// passed through, defeating that policy on every frame after the first.
+	bridgedFirst, _, bridgeErr := s.applyCodexImageGenerationBridgeToWSResponseCreate(ctx, account, apiKey, firstClientMessage, isCodexCLI)
+	if bridgeErr != nil {
+		return fmt.Errorf("apply codex image generation bridge on first ws frame: %w", bridgeErr)
+	}
+	firstClientMessage = bridgedFirst
 	capturedSessionModel := openAIWSPassthroughPolicyModelForFrame(account, firstClientMessage)
 	initialRequestModel := ""
 	if hooks != nil {
@@ -311,7 +422,9 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	// 因此使用 atomic.Pointer[string] 在 filter（runClientToUpstream
 	// goroutine）和 OnTurnComplete / final result（runUpstreamToClient
 	// goroutine）之间同步当前 turn 的 usage metadata。
-	usageMeta.initFromFirstFrame(firstClientMessage)
+	if err := usageMeta.initFromFirstFrame(firstClientMessage, apiKey); err != nil {
+		return err
+	}
 	promptCacheKey := strings.TrimSpace(gjson.GetBytes(firstClientMessage, "prompt_cache_key").String())
 
 	wsURL, err := s.buildOpenAIResponsesWSURL(account)
@@ -332,13 +445,6 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		account.ProxyID != nil && account.Proxy != nil,
 	)
 
-	isCodexCLI := false
-	if c != nil {
-		isCodexCLI = openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator"))
-	}
-	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
-		isCodexCLI = true
-	}
 	turnState := ""
 	turnMetadata := ""
 	if c != nil {
@@ -401,6 +507,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			if msgType != coderws.MessageText {
 				return payload, nil, nil
 			}
+			bridgedPayload, _, bridgeErr := s.applyCodexImageGenerationBridgeToWSResponseCreate(ctx, account, apiKey, payload, isCodexCLI)
+			if bridgeErr != nil {
+				return payload, nil, bridgeErr
+			}
+			payload = bridgedPayload
 			if strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "response.create" && hooks != nil && hooks.BeforeRequest != nil {
 				turnNo := int(completedTurns.Load()) + 1
 				if turnNo < 2 {
@@ -452,7 +563,9 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			//     service_tier 时按 default 处理，billing 应如实反映。
 			if policyErr == nil && blocked == nil &&
 				strings.TrimSpace(gjson.GetBytes(payload, "type").String()) == "response.create" {
-				usageMeta.updateFromResponseCreate(out, requestModelForThisFrame)
+				if err := usageMeta.updateFromResponseCreate(out, requestModelForThisFrame, apiKey); err != nil {
+					return out, nil, err
+				}
 			}
 			return out, blocked, policyErr
 		},
@@ -498,6 +611,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		}
 	}
 
+	turnImageCounter := newOpenAIImageOutputCounter()
 	relayResult, relayExit := openaiwsv2.RunEntry(openaiwsv2.EntryInput{
 		Ctx:                ctx,
 		ClientConn:         policyClientConn,
@@ -537,6 +651,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 					Duration:        turn.Duration,
 					FirstTokenMs:    turn.FirstTokenMs,
 				}
+				applyOpenAIWSPassthroughImageBillingResult(turnResult, turnImageCounter, usageMeta.imageBilling.Load())
 				logOpenAIWSV2Passthrough(
 					"relay_turn_completed account_id=%d turn=%d request_id=%s terminal_event=%s duration_ms=%d first_token_ms=%d input_tokens=%d output_tokens=%d cache_read_tokens=%d",
 					account.ID,
@@ -552,8 +667,12 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				if hooks != nil && hooks.AfterTurn != nil {
 					hooks.AfterTurn(turnNo, turnResult, nil)
 				}
+				turnImageCounter = newOpenAIImageOutputCounter()
 			},
 			BeforeWriteClient: func(msgType coderws.MessageType, payload []byte, wroteDownstream bool) error {
+				if msgType == coderws.MessageText {
+					turnImageCounter.AddSSEData(payload)
+				}
 				if msgType != coderws.MessageText || wroteDownstream {
 					return nil
 				}
@@ -612,6 +731,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		Duration:        relayResult.Duration,
 		FirstTokenMs:    relayResult.FirstTokenMs,
 	}
+	applyOpenAIWSPassthroughImageBillingResult(result, turnImageCounter, usageMeta.imageBilling.Load())
 
 	turnCount := int(completedTurns.Load())
 	if relayExit == nil {


### PR DESCRIPTION
## Summary

- apply the Codex image-generation bridge to WS v2 `passthrough` response.create frames
- reuse passthrough image-intent permission and billing metadata checks so generated image output is counted
- add a regression test covering Codex image bridge injection through the passthrough adapter

Fixes #3158.

## Background

#2937 fixed the regular WS v2 ingress path in `openai_ws_forwarder.go`, but accounts configured with `openai_*_responses_websockets_v2_mode=passthrough` return early into `proxyResponsesWebSocketV2Passthrough` and bypass that bridge path.

This PR applies the same bridge/policy path to the passthrough adapter before forwarding `response.create` frames upstream.

## Tests

```sh
go test ./internal/service -run TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_PassthroughModeInjectsCodexImageBridge -count=1
go test ./internal/service -run 'TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_(PassthroughMode|PassthroughHeaders)|TestPassthroughUsageMeta|TestPassthroughBilling|TestApplyCodexImageGenerationBridgeInstructions|TestEnsureOpenAIResponsesImageGenerationTool|TestNormalizeOpenAIResponsesImageGenerationTools' -count=1
go test ./internal/service -count=1
git diff --check
```
