### PR TITLE
feat(gateway): universal silent-refusal retry for streaming Claude responses

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -770,18 +770,19 @@ type GatewayConfig struct {
 	// MaxLineSize: 上游 SSE 单行最大字节数（0使用默认值）
 	MaxLineSize int `mapstructure:"max_line_size"`
 
-	// AntigravityRefusalRetry: 对 antigravity(Gemini-backed Claude) 静默拒绝
-	// (blocking finishReason 且无内容) 在切换账号后透明重试。默认关闭。
-	AntigravityRefusalRetryEnabled bool `mapstructure:"antigravity_refusal_retry_enabled"`
-	// AntigravityRefusalFinishReasons: 视为拒绝的 Gemini finishReason 列表
+	// RefusalRetryEnabled: 对上游静默拒绝（native Anthropic stop_reason=refusal
+	// 或 antigravity/Gemini blocking finishReason 且无内容）在切换账号后透明
+	// 重试。覆盖 native Anthropic 与 antigravity 两条流式路径。默认关闭。
+	RefusalRetryEnabled bool `mapstructure:"refusal_retry_enabled"`
+	// RefusalFinishReasons: antigravity(Gemini) 路径下视为拒绝的 finishReason 列表
 	// (留空使用默认 SAFETY/RECITATION/PROHIBITED_CONTENT/BLOCKLIST/SPII)
-	AntigravityRefusalFinishReasons []string `mapstructure:"antigravity_refusal_finish_reasons"`
-	// AntigravityRefusalHoldTimeoutMs: 缓冲保持上限(毫秒)，超时则释放(默认 15000)
-	AntigravityRefusalHoldTimeoutMs int `mapstructure:"antigravity_refusal_hold_timeout_ms"`
-	// AntigravityRefusalHoldMaxBytes: 缓冲字节上限，超过则释放(默认 65536)
-	AntigravityRefusalHoldMaxBytes int `mapstructure:"antigravity_refusal_hold_max_bytes"`
-	// AntigravityRefusalMaxRetries: 拒绝触发的账号切换次数上限(默认 2)
-	AntigravityRefusalMaxRetries int `mapstructure:"antigravity_refusal_max_retries"`
+	RefusalFinishReasons []string `mapstructure:"refusal_finish_reasons"`
+	// RefusalHoldTimeoutMs: 缓冲保持上限(毫秒)，超时则释放(默认 15000)
+	RefusalHoldTimeoutMs int `mapstructure:"refusal_hold_timeout_ms"`
+	// RefusalHoldMaxBytes: 缓冲字节上限，超过则释放(默认 65536)
+	RefusalHoldMaxBytes int `mapstructure:"refusal_hold_max_bytes"`
+	// RefusalMaxRetries: 拒绝触发的账号切换次数上限(默认 2，0 表示不限制)
+	RefusalMaxRetries int `mapstructure:"refusal_max_retries"`
 
 	// 是否记录上游错误响应体摘要（避免输出请求内容）
 	LogUpstreamErrorBody bool `mapstructure:"log_upstream_error_body"`

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1854,6 +1854,12 @@ func setDefaults() {
 	viper.SetDefault("gateway.codex_image_generation_bridge_enabled", false)
 	viper.SetDefault("gateway.openai_passthrough_allow_timeout_headers", false)
 	viper.SetDefault("gateway.openai_compact_model", "gpt-5.4")
+	// Silent-refusal retry (native Anthropic + antigravity). Disabled by default.
+	viper.SetDefault("gateway.refusal_retry_enabled", false)
+	viper.SetDefault("gateway.refusal_finish_reasons", []string{})
+	viper.SetDefault("gateway.refusal_hold_timeout_ms", 15000)
+	viper.SetDefault("gateway.refusal_hold_max_bytes", 64*1024)
+	viper.SetDefault("gateway.refusal_max_retries", 2)
 	// OpenAI Responses WebSocket（默认开启；可通过 force_http 紧急回滚）
 	viper.SetDefault("gateway.openai_ws.enabled", true)
 	viper.SetDefault("gateway.openai_ws.mode_router_v2_enabled", false)

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -777,7 +777,8 @@ type GatewayConfig struct {
 	// RefusalFinishReasons: antigravity(Gemini) 路径下视为拒绝的 finishReason 列表
 	// (留空使用默认 SAFETY/RECITATION/PROHIBITED_CONTENT/BLOCKLIST/SPII)
 	RefusalFinishReasons []string `mapstructure:"refusal_finish_reasons"`
-	// RefusalHoldTimeoutMs: 缓冲保持上限(毫秒)，超时则释放(默认 15000)
+	// RefusalHoldTimeoutMs: 缓冲保持上限(毫秒)，超时则释放(默认 10000，
+	// 保持在常见客户端首字节预算之内，期间抑制 keepalive)
 	RefusalHoldTimeoutMs int `mapstructure:"refusal_hold_timeout_ms"`
 	// RefusalHoldMaxBytes: 缓冲字节上限，超过则释放(默认 65536)
 	RefusalHoldMaxBytes int `mapstructure:"refusal_hold_max_bytes"`
@@ -1857,7 +1858,7 @@ func setDefaults() {
 	// Silent-refusal retry (native Anthropic + antigravity). Disabled by default.
 	viper.SetDefault("gateway.refusal_retry_enabled", false)
 	viper.SetDefault("gateway.refusal_finish_reasons", []string{})
-	viper.SetDefault("gateway.refusal_hold_timeout_ms", 15000)
+	viper.SetDefault("gateway.refusal_hold_timeout_ms", 10000)
 	viper.SetDefault("gateway.refusal_hold_max_bytes", 64*1024)
 	viper.SetDefault("gateway.refusal_max_retries", 2)
 	// OpenAI Responses WebSocket（默认开启；可通过 force_http 紧急回滚）

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -770,6 +770,19 @@ type GatewayConfig struct {
 	// MaxLineSize: 上游 SSE 单行最大字节数（0使用默认值）
 	MaxLineSize int `mapstructure:"max_line_size"`
 
+	// AntigravityRefusalRetry: 对 antigravity(Gemini-backed Claude) 静默拒绝
+	// (blocking finishReason 且无内容) 在切换账号后透明重试。默认关闭。
+	AntigravityRefusalRetryEnabled bool `mapstructure:"antigravity_refusal_retry_enabled"`
+	// AntigravityRefusalFinishReasons: 视为拒绝的 Gemini finishReason 列表
+	// (留空使用默认 SAFETY/RECITATION/PROHIBITED_CONTENT/BLOCKLIST/SPII)
+	AntigravityRefusalFinishReasons []string `mapstructure:"antigravity_refusal_finish_reasons"`
+	// AntigravityRefusalHoldTimeoutMs: 缓冲保持上限(毫秒)，超时则释放(默认 15000)
+	AntigravityRefusalHoldTimeoutMs int `mapstructure:"antigravity_refusal_hold_timeout_ms"`
+	// AntigravityRefusalHoldMaxBytes: 缓冲字节上限，超过则释放(默认 65536)
+	AntigravityRefusalHoldMaxBytes int `mapstructure:"antigravity_refusal_hold_max_bytes"`
+	// AntigravityRefusalMaxRetries: 拒绝触发的账号切换次数上限(默认 2)
+	AntigravityRefusalMaxRetries int `mapstructure:"antigravity_refusal_max_retries"`
+
 	// 是否记录上游错误响应体摘要（避免输出请求内容）
 	LogUpstreamErrorBody bool `mapstructure:"log_upstream_error_body"`
 	// 上游错误响应体记录最大字节数（超过会截断）

--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -48,6 +48,12 @@ type FailoverState struct {
 	LastFailoverErr       *service.UpstreamFailoverError
 	ForceCacheBilling     bool
 	hasBoundSession       bool
+
+	// RefusalSwitchCount/MaxRefusalSwitches bound account switches caused by
+	// silent refusals separately from normal failover, so a refusal storm
+	// can't churn the whole account pool (anti-amplification). 0 = unbounded.
+	RefusalSwitchCount int
+	MaxRefusalSwitches int
 }
 
 // NewFailoverState 创建 failover 状态
@@ -58,6 +64,20 @@ func NewFailoverState(maxSwitches int, hasBoundSession bool) *FailoverState {
 		SameAccountRetryCount: make(map[int64]int),
 		hasBoundSession:       hasBoundSession,
 	}
+}
+
+// WithRefusalCap sets the antigravity silent-refusal account-switch cap.
+func (s *FailoverState) WithRefusalCap(maxRefusalSwitches int) *FailoverState {
+	s.MaxRefusalSwitches = maxRefusalSwitches
+	return s
+}
+
+// isSilentRefusal reports whether the failover was triggered by our antigravity
+// silent-refusal detector (distinct from generic empty-stream/5xx failover).
+func isSilentRefusal(failoverErr *service.UpstreamFailoverError) bool {
+	return failoverErr != nil && !failoverErr.RetryableOnSameAccount &&
+		failoverErr.StatusCode == http.StatusBadGateway &&
+		string(failoverErr.ResponseBody) == `{"error":"antigravity_silent_refusal"}`
 }
 
 // HandleFailoverError 处理 UpstreamFailoverError，返回下一步动作。
@@ -89,6 +109,20 @@ func (s *FailoverState) HandleFailoverError(
 			return FailoverCanceled
 		}
 		return FailoverContinue
+	}
+
+	// Silent-refusal account-switch cap (anti-amplification). Bounded separately
+	// from MaxSwitches so a deterministic refusal can't churn the whole pool.
+	if isSilentRefusal(failoverErr) && s.MaxRefusalSwitches > 0 {
+		if s.RefusalSwitchCount >= s.MaxRefusalSwitches {
+			logger.FromContext(ctx).Warn("gateway.failover_refusal_cap_reached",
+				zap.Int64("account_id", accountID),
+				zap.Int("refusal_switch_count", s.RefusalSwitchCount),
+				zap.Int("max_refusal_switches", s.MaxRefusalSwitches),
+			)
+			return FailoverExhausted
+		}
+		s.RefusalSwitchCount++
 	}
 
 	// 同账号重试用尽，执行临时封禁

--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -66,18 +66,16 @@ func NewFailoverState(maxSwitches int, hasBoundSession bool) *FailoverState {
 	}
 }
 
-// WithRefusalCap sets the antigravity silent-refusal account-switch cap.
+// WithRefusalCap sets the silent-refusal account-switch cap.
 func (s *FailoverState) WithRefusalCap(maxRefusalSwitches int) *FailoverState {
 	s.MaxRefusalSwitches = maxRefusalSwitches
 	return s
 }
 
-// isSilentRefusal reports whether the failover was triggered by our antigravity
-// silent-refusal detector (distinct from generic empty-stream/5xx failover).
+// isSilentRefusal reports whether the failover was triggered by an upstream
+// silent refusal (distinct from generic empty-stream/5xx failover).
 func isSilentRefusal(failoverErr *service.UpstreamFailoverError) bool {
-	return failoverErr != nil && !failoverErr.RetryableOnSameAccount &&
-		failoverErr.StatusCode == http.StatusBadGateway &&
-		string(failoverErr.ResponseBody) == `{"error":"antigravity_silent_refusal"}`
+	return failoverErr != nil && failoverErr.SilentRefusal
 }
 
 // HandleFailoverError 处理 UpstreamFailoverError，返回下一步动作。

--- a/backend/internal/handler/failover_refusal_test.go
+++ b/backend/internal/handler/failover_refusal_test.go
@@ -16,8 +16,9 @@ func (noopTempUnscheduler) TempUnscheduleRetryableError(context.Context, int64, 
 func refusalErr() *service.UpstreamFailoverError {
 	return &service.UpstreamFailoverError{
 		StatusCode:             http.StatusBadGateway,
-		ResponseBody:           []byte(`{"error":"antigravity_silent_refusal"}`),
+		ResponseBody:           []byte(`{"error":"upstream_silent_refusal"}`),
 		RetryableOnSameAccount: false,
+		SilentRefusal:          true,
 	}
 }
 

--- a/backend/internal/handler/failover_refusal_test.go
+++ b/backend/internal/handler/failover_refusal_test.go
@@ -1,0 +1,70 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+type noopTempUnscheduler struct{}
+
+func (noopTempUnscheduler) TempUnscheduleRetryableError(context.Context, int64, *service.UpstreamFailoverError) {
+}
+
+func refusalErr() *service.UpstreamFailoverError {
+	return &service.UpstreamFailoverError{
+		StatusCode:             http.StatusBadGateway,
+		ResponseBody:           []byte(`{"error":"antigravity_silent_refusal"}`),
+		RetryableOnSameAccount: false,
+	}
+}
+
+func TestIsSilentRefusal(t *testing.T) {
+	if !isSilentRefusal(refusalErr()) {
+		t.Fatal("refusal error should be detected")
+	}
+	emptyStream := &service.UpstreamFailoverError{
+		StatusCode:             http.StatusBadGateway,
+		ResponseBody:           []byte(`{"error":"empty stream response from upstream"}`),
+		RetryableOnSameAccount: true,
+	}
+	if isSilentRefusal(emptyStream) {
+		t.Fatal("empty-stream error must not be classified as silent refusal")
+	}
+	if isSilentRefusal(nil) {
+		t.Fatal("nil must not be a silent refusal")
+	}
+}
+
+func TestRefusalSwitchCap(t *testing.T) {
+	fs := NewFailoverState(10, false).WithRefusalCap(2)
+	ctx := context.Background()
+	g := noopTempUnscheduler{}
+
+	// Two refusal switches are allowed.
+	for i := 0; i < 2; i++ {
+		act := fs.HandleFailoverError(ctx, g, int64(i+1), service.PlatformAntigravity, refusalErr())
+		if act != FailoverContinue {
+			t.Fatalf("refusal switch %d: got %v, want FailoverContinue", i+1, act)
+		}
+	}
+	// Third refusal exceeds the cap even though MaxSwitches=10 is not reached.
+	act := fs.HandleFailoverError(ctx, g, 3, service.PlatformAntigravity, refusalErr())
+	if act != FailoverExhausted {
+		t.Fatalf("refusal switch over cap: got %v, want FailoverExhausted", act)
+	}
+}
+
+func TestRefusalCapZeroDisables(t *testing.T) {
+	fs := NewFailoverState(10, false).WithRefusalCap(0)
+	ctx := context.Background()
+	g := noopTempUnscheduler{}
+	for i := 0; i < 5; i++ {
+		act := fs.HandleFailoverError(ctx, g, int64(i+1), service.PlatformAntigravity, refusalErr())
+		if act != FailoverContinue {
+			t.Fatalf("cap=0 switch %d: got %v, want FailoverContinue", i+1, act)
+		}
+	}
+}

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -57,6 +57,15 @@ type GatewayHandler struct {
 	settingService            *service.SettingService
 }
 
+// antigravityRefusalMaxRetries returns the cap on refusal-driven account
+// switches (anti-amplification). Default 2; 0 disables the cap.
+func (h *GatewayHandler) antigravityRefusalMaxRetries() int {
+	if h.cfg != nil && h.cfg.Gateway.AntigravityRefusalMaxRetries > 0 {
+		return h.cfg.Gateway.AntigravityRefusalMaxRetries
+	}
+	return 2
+}
+
 // NewGatewayHandler creates a new GatewayHandler
 func NewGatewayHandler(
 	gatewayService *service.GatewayService,
@@ -289,7 +298,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	hasBoundSession := sessionKey != "" && sessionBoundAccountID > 0
 
 	if platform == service.PlatformGemini {
-		fs := NewFailoverState(h.maxAccountSwitchesGemini, hasBoundSession)
+		fs := NewFailoverState(h.maxAccountSwitchesGemini, hasBoundSession).WithRefusalCap(h.antigravityRefusalMaxRetries())
 
 		// 单账号分组提前设置 SingleAccountRetry 标记，让 Service 层首次 503 就不设模型限流标记。
 		// 避免单账号分组收到 503 (MODEL_CAPACITY_EXHAUSTED) 时设 29s 限流，导致后续请求连续快速失败。
@@ -567,7 +576,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	}
 
 	for {
-		fs := NewFailoverState(h.maxAccountSwitches, hasBoundSession)
+		fs := NewFailoverState(h.maxAccountSwitches, hasBoundSession).WithRefusalCap(h.antigravityRefusalMaxRetries())
 		retryWithFallback := false
 
 		for {

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -57,11 +57,12 @@ type GatewayHandler struct {
 	settingService            *service.SettingService
 }
 
-// antigravityRefusalMaxRetries returns the cap on refusal-driven account
-// switches (anti-amplification). Default 2; 0 disables the cap.
-func (h *GatewayHandler) antigravityRefusalMaxRetries() int {
-	if h.cfg != nil && h.cfg.Gateway.AntigravityRefusalMaxRetries > 0 {
-		return h.cfg.Gateway.AntigravityRefusalMaxRetries
+// refusalMaxRetries returns the cap on refusal-driven account switches
+// (anti-amplification), shared by the native Anthropic and antigravity paths.
+// Default 2; 0 disables the cap.
+func (h *GatewayHandler) refusalMaxRetries() int {
+	if h.cfg != nil && h.cfg.Gateway.RefusalMaxRetries > 0 {
+		return h.cfg.Gateway.RefusalMaxRetries
 	}
 	return 2
 }
@@ -298,7 +299,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	hasBoundSession := sessionKey != "" && sessionBoundAccountID > 0
 
 	if platform == service.PlatformGemini {
-		fs := NewFailoverState(h.maxAccountSwitchesGemini, hasBoundSession).WithRefusalCap(h.antigravityRefusalMaxRetries())
+		fs := NewFailoverState(h.maxAccountSwitchesGemini, hasBoundSession).WithRefusalCap(h.refusalMaxRetries())
 
 		// 单账号分组提前设置 SingleAccountRetry 标记，让 Service 层首次 503 就不设模型限流标记。
 		// 避免单账号分组收到 503 (MODEL_CAPACITY_EXHAUSTED) 时设 29s 限流，导致后续请求连续快速失败。
@@ -576,7 +577,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 	}
 
 	for {
-		fs := NewFailoverState(h.maxAccountSwitches, hasBoundSession).WithRefusalCap(h.antigravityRefusalMaxRetries())
+		fs := NewFailoverState(h.maxAccountSwitches, hasBoundSession).WithRefusalCap(h.refusalMaxRetries())
 		retryWithFallback := false
 
 		for {

--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -59,12 +59,13 @@ type GatewayHandler struct {
 
 // refusalMaxRetries returns the cap on refusal-driven account switches
 // (anti-amplification), shared by the native Anthropic and antigravity paths.
-// Default 2; 0 disables the cap.
+// The viper default is 2 (set in config); an explicit 0 means unbounded and is
+// passed through verbatim. nil cfg falls back to the default 2.
 func (h *GatewayHandler) refusalMaxRetries() int {
-	if h.cfg != nil && h.cfg.Gateway.RefusalMaxRetries > 0 {
-		return h.cfg.Gateway.RefusalMaxRetries
+	if h.cfg == nil {
+		return 2
 	}
-	return 2
+	return h.cfg.Gateway.RefusalMaxRetries
 }
 
 // NewGatewayHandler creates a new GatewayHandler

--- a/backend/internal/pkg/antigravity/stream_transformer.go
+++ b/backend/internal/pkg/antigravity/stream_transformer.go
@@ -40,6 +40,12 @@ type StreamingProcessor struct {
 	outputTokens      int
 	cacheReadTokens   int
 	imageOutputTokens int
+
+	// refusal detection signals (keyed on raw Gemini finishReason + content).
+	// sawToolUse reuses usedTool; tracked here for query symmetry.
+	lastFinishReason string
+	sawVisibleText   bool
+	sawThinking      bool
 }
 
 // NewStreamingProcessor 创建流式响应处理器
@@ -131,6 +137,9 @@ func (p *StreamingProcessor) ProcessLine(line string) []byte {
 	// 检查是否结束
 	if len(geminiResp.Candidates) > 0 {
 		finishReason := geminiResp.Candidates[0].FinishReason
+		if finishReason != "" {
+			p.lastFinishReason = finishReason
+		}
 		if finishReason == "MALFORMED_FUNCTION_CALL" {
 			log.Printf("[Antigravity] MALFORMED_FUNCTION_CALL detected in stream for model %s", p.originalModel)
 			if geminiResp.Candidates[0].Content != nil {
@@ -173,6 +182,22 @@ func (p *StreamingProcessor) Finish() ([]byte, *ClaudeUsage) {
 // MessageStartSent 报告流中是否已发出过 message_start 事件（即是否收到过有效的上游数据）
 func (p *StreamingProcessor) MessageStartSent() bool {
 	return p.messageStartSent
+}
+
+// LastFinishReason returns the most recent raw Gemini finishReason seen.
+func (p *StreamingProcessor) LastFinishReason() string {
+	return p.lastFinishReason
+}
+
+// SawMeaningfulContent reports whether any visible text, thinking, or tool use
+// was produced. A refusal/empty turn produces none.
+func (p *StreamingProcessor) SawMeaningfulContent() bool {
+	return p.sawVisibleText || p.sawThinking || p.usedTool
+}
+
+// SawToolUse reports whether a tool_use block was produced.
+func (p *StreamingProcessor) SawToolUse() bool {
+	return p.usedTool
 }
 
 // emitMessageStart 发送 message_start 事件
@@ -296,6 +321,7 @@ func (p *StreamingProcessor) processThinking(text, signature string) []byte {
 	}
 
 	if text != "" {
+		p.sawThinking = true
 		_, _ = result.Write(p.emitDelta("thinking_delta", map[string]any{
 			"thinking": text,
 		}))
@@ -320,6 +346,8 @@ func (p *StreamingProcessor) processText(text, signature string) []byte {
 		}
 		return nil
 	}
+
+	p.sawVisibleText = true
 
 	// 处理之前的 trailingSignature
 	if p.trailingSignature != "" {

--- a/backend/internal/pkg/antigravity/stream_transformer_refusal_test.go
+++ b/backend/internal/pkg/antigravity/stream_transformer_refusal_test.go
@@ -1,0 +1,62 @@
+package antigravity
+
+import "testing"
+
+func feedLines(p *StreamingProcessor, lines []string) {
+	for _, l := range lines {
+		_ = p.ProcessLine(l)
+	}
+	_, _ = p.Finish()
+}
+
+func TestStreamingProcessor_RefusalSignals_SafetyNoContent(t *testing.T) {
+	p := NewStreamingProcessor("claude-opus-4")
+	feedLines(p, []string{
+		`data: {"response":{"candidates":[{"finishReason":"SAFETY","content":{"parts":[]}}]}}`,
+	})
+	if got := p.LastFinishReason(); got != "SAFETY" {
+		t.Fatalf("LastFinishReason = %q, want SAFETY", got)
+	}
+	if p.SawMeaningfulContent() {
+		t.Fatal("SafetyNoContent: SawMeaningfulContent should be false")
+	}
+}
+
+func TestStreamingProcessor_RefusalSignals_TextContent(t *testing.T) {
+	p := NewStreamingProcessor("claude-opus-4")
+	feedLines(p, []string{
+		`data: {"response":{"candidates":[{"content":{"parts":[{"text":"hello"}]}}]}}`,
+		`data: {"response":{"candidates":[{"finishReason":"STOP"}]}}`,
+	})
+	if !p.SawMeaningfulContent() {
+		t.Fatal("TextContent: SawMeaningfulContent should be true")
+	}
+	if got := p.LastFinishReason(); got != "STOP" {
+		t.Fatalf("LastFinishReason = %q, want STOP", got)
+	}
+}
+
+func TestStreamingProcessor_RefusalSignals_ThinkingCounts(t *testing.T) {
+	p := NewStreamingProcessor("claude-opus-4")
+	feedLines(p, []string{
+		`data: {"response":{"candidates":[{"content":{"parts":[{"text":"reasoning","thought":true}]}}]}}`,
+		`data: {"response":{"candidates":[{"finishReason":"SAFETY"}]}}`,
+	})
+	if !p.SawMeaningfulContent() {
+		t.Fatal("ThinkingCounts: thinking should count as meaningful content")
+	}
+}
+
+func TestStreamingProcessor_RefusalSignals_ToolUseCounts(t *testing.T) {
+	p := NewStreamingProcessor("claude-opus-4")
+	feedLines(p, []string{
+		`data: {"response":{"candidates":[{"content":{"parts":[{"functionCall":{"name":"read","args":{}}}]}}]}}`,
+		`data: {"response":{"candidates":[{"finishReason":"STOP"}]}}`,
+	})
+	if !p.SawMeaningfulContent() {
+		t.Fatal("ToolUseCounts: tool use should count as meaningful content")
+	}
+	if !p.SawToolUse() {
+		t.Fatal("ToolUseCounts: SawToolUse should be true")
+	}
+}

--- a/backend/internal/service/anthropic_silent_refusal.go
+++ b/backend/internal/service/anthropic_silent_refusal.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+)
+
+// refusalHoldTimeout is the max wall-clock the buffered-hold may withhold client
+// output while waiting to classify a refusal (shared by all streaming paths).
+func refusalHoldTimeout(cfg *config.Config) time.Duration {
+	ms := 15000
+	if cfg != nil && cfg.Gateway.RefusalHoldTimeoutMs > 0 {
+		ms = cfg.Gateway.RefusalHoldTimeoutMs
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// refusalHoldMaxBytes is the max buffered bytes before the hold force-releases.
+func refusalHoldMaxBytes(cfg *config.Config) int {
+	n := 64 * 1024
+	if cfg != nil && cfg.Gateway.RefusalHoldMaxBytes > 0 {
+		n = cfg.Gateway.RefusalHoldMaxBytes
+	}
+	return n
+}
+
+// refusalRetryEnabled reports whether silent-refusal retry is enabled on the
+// native Anthropic streaming path.
+func (s *GatewayService) refusalRetryEnabled() bool {
+	return s.cfg != nil && s.cfg.Gateway.RefusalRetryEnabled
+}
+
+// anthropicRefusalDetector decides whether a native Anthropic (non-Gemini)
+// streaming response is a silent refusal: the upstream emitted
+// stop_reason="refusal" (Claude 4 streaming classifier) without producing any
+// meaningful content. It observes the parsed SSE events the native handlers
+// already decode, so it never re-parses raw bytes.
+type anthropicRefusalDetector struct {
+	enabled              bool
+	sawMeaningfulContent bool
+	sawRefusalStop       bool
+}
+
+func newAnthropicRefusalDetector(enabled bool) *anthropicRefusalDetector {
+	return &anthropicRefusalDetector{enabled: enabled}
+}
+
+func (d *anthropicRefusalDetector) Enabled() bool {
+	return d != nil && d.enabled
+}
+
+// ObserveEvent inspects one decoded Anthropic SSE event. eventType is the
+// event's "type" field; event is the decoded JSON object (may be nil for
+// non-JSON frames like [DONE]).
+func (d *anthropicRefusalDetector) ObserveEvent(eventType string, event map[string]any) {
+	if d == nil || !d.enabled {
+		return
+	}
+	switch eventType {
+	case "content_block_start":
+		// text / tool_use / thinking blocks all count as meaningful output.
+		d.sawMeaningfulContent = true
+	case "content_block_delta":
+		d.sawMeaningfulContent = true
+	case "message_delta":
+		if delta, ok := event["delta"].(map[string]any); ok {
+			if sr, ok := delta["stop_reason"].(string); ok && sr == "refusal" {
+				d.sawRefusalStop = true
+			}
+		}
+	}
+}
+
+// HasMeaningfulContent reports whether any content block was produced. Used by
+// the buffered hold to release output as soon as a real response begins.
+func (d *anthropicRefusalDetector) HasMeaningfulContent() bool {
+	return d != nil && d.sawMeaningfulContent
+}
+
+// IsSilentRefusal reports whether the finished stream was a refusal with no
+// meaningful content. A content-bearing turn is never a silent refusal.
+func (d *anthropicRefusalDetector) IsSilentRefusal() bool {
+	if d == nil || !d.enabled {
+		return false
+	}
+	return d.sawRefusalStop && !d.sawMeaningfulContent
+}

--- a/backend/internal/service/anthropic_silent_refusal_test.go
+++ b/backend/internal/service/anthropic_silent_refusal_test.go
@@ -1,0 +1,61 @@
+package service
+
+import "testing"
+
+func TestAnthropicRefusalDetector_IsSilentRefusal(t *testing.T) {
+	refusalDelta := map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": "refusal"},
+	}
+	endTurnDelta := map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": "end_turn"},
+	}
+	contentStart := map[string]any{"type": "content_block_start"}
+	contentDelta := map[string]any{"type": "content_block_delta"}
+
+	t.Run("refusal with no content", func(t *testing.T) {
+		d := newAnthropicRefusalDetector(true)
+		d.ObserveEvent("message_delta", refusalDelta)
+		if !d.IsSilentRefusal() {
+			t.Fatal("want silent refusal")
+		}
+	})
+
+	t.Run("refusal after content is not silent", func(t *testing.T) {
+		d := newAnthropicRefusalDetector(true)
+		d.ObserveEvent("content_block_start", contentStart)
+		d.ObserveEvent("content_block_delta", contentDelta)
+		d.ObserveEvent("message_delta", refusalDelta)
+		if d.IsSilentRefusal() {
+			t.Fatal("content-bearing turn must not be a silent refusal")
+		}
+	})
+
+	t.Run("end_turn no content is not refusal", func(t *testing.T) {
+		d := newAnthropicRefusalDetector(true)
+		d.ObserveEvent("message_delta", endTurnDelta)
+		if d.IsSilentRefusal() {
+			t.Fatal("end_turn must not be a silent refusal")
+		}
+	})
+
+	t.Run("disabled never reports refusal", func(t *testing.T) {
+		d := newAnthropicRefusalDetector(false)
+		d.ObserveEvent("message_delta", refusalDelta)
+		if d.IsSilentRefusal() {
+			t.Fatal("disabled detector must not report refusal")
+		}
+		if d.Enabled() {
+			t.Fatal("disabled detector must report not enabled")
+		}
+	})
+
+	t.Run("nil safe", func(t *testing.T) {
+		var d *anthropicRefusalDetector
+		d.ObserveEvent("message_delta", refusalDelta)
+		if d.IsSilentRefusal() || d.Enabled() || d.HasMeaningfulContent() {
+			t.Fatal("nil detector must be inert")
+		}
+	})
+}

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -3973,23 +3973,15 @@ func (s *AntigravityGatewayService) newAntigravityRefusalDetector() *antigravity
 		return newAntigravityRefusalDetector(false, nil)
 	}
 	g := s.settingService.cfg.Gateway
-	return newAntigravityRefusalDetector(g.AntigravityRefusalRetryEnabled, g.AntigravityRefusalFinishReasons)
+	return newAntigravityRefusalDetector(g.RefusalRetryEnabled, g.RefusalFinishReasons)
 }
 
 func (s *AntigravityGatewayService) antigravityRefusalHoldTimeout() time.Duration {
-	ms := 15000
-	if s.settingService.cfg != nil && s.settingService.cfg.Gateway.AntigravityRefusalHoldTimeoutMs > 0 {
-		ms = s.settingService.cfg.Gateway.AntigravityRefusalHoldTimeoutMs
-	}
-	return time.Duration(ms) * time.Millisecond
+	return refusalHoldTimeout(s.settingService.cfg)
 }
 
 func (s *AntigravityGatewayService) antigravityRefusalHoldMaxBytes() int {
-	n := 64 * 1024
-	if s.settingService.cfg != nil && s.settingService.cfg.Gateway.AntigravityRefusalHoldMaxBytes > 0 {
-		n = s.settingService.cfg.Gateway.AntigravityRefusalHoldMaxBytes
-	}
-	return n
+	return refusalHoldMaxBytes(s.settingService.cfg)
 }
 
 func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context, resp *http.Response, startTime time.Time, originalModel string) (*antigravityStreamResult, error) {
@@ -4176,8 +4168,9 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 					logger.LegacyPrintf("service.antigravity_gateway", "[antigravity-Claude-Stream] silent refusal (finishReason=%s, no content), triggering account failover", processor.LastFinishReason())
 					return nil, &UpstreamFailoverError{
 						StatusCode:             http.StatusBadGateway,
-						ResponseBody:           []byte(`{"error":"antigravity_silent_refusal"}`),
+						ResponseBody:           []byte(`{"error":"upstream_silent_refusal"}`),
 						RetryableOnSameAccount: false,
+						SilentRefusal:          true,
 					}
 				}
 				if len(finalEvents) > 0 {

--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -3968,16 +3968,55 @@ returnResponse:
 }
 
 // handleClaudeStreamingResponse 处理 Claude 流式响应（Gemini SSE → Claude SSE 转换）
+func (s *AntigravityGatewayService) newAntigravityRefusalDetector() *antigravityRefusalDetector {
+	if s.settingService.cfg == nil {
+		return newAntigravityRefusalDetector(false, nil)
+	}
+	g := s.settingService.cfg.Gateway
+	return newAntigravityRefusalDetector(g.AntigravityRefusalRetryEnabled, g.AntigravityRefusalFinishReasons)
+}
+
+func (s *AntigravityGatewayService) antigravityRefusalHoldTimeout() time.Duration {
+	ms := 15000
+	if s.settingService.cfg != nil && s.settingService.cfg.Gateway.AntigravityRefusalHoldTimeoutMs > 0 {
+		ms = s.settingService.cfg.Gateway.AntigravityRefusalHoldTimeoutMs
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func (s *AntigravityGatewayService) antigravityRefusalHoldMaxBytes() int {
+	n := 64 * 1024
+	if s.settingService.cfg != nil && s.settingService.cfg.Gateway.AntigravityRefusalHoldMaxBytes > 0 {
+		n = s.settingService.cfg.Gateway.AntigravityRefusalHoldMaxBytes
+	}
+	return n
+}
+
 func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context, resp *http.Response, startTime time.Time, originalModel string) (*antigravityStreamResult, error) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
 	c.Header("X-Accel-Buffering", "no")
-	c.Status(http.StatusOK)
 
 	flusher, ok := c.Writer.(http.Flusher)
 	if !ok {
 		return nil, errors.New("streaming not supported")
+	}
+
+	// Refusal-retry buffered hold: while the detector is enabled and no
+	// meaningful content has been seen, hold converted events (and defer the
+	// HTTP 200 + first write) so a silent refusal can still trigger failover
+	// (the failover hard-guard requires zero bytes written). Released on first
+	// meaningful content, a non-blocking finish, buffer cap, or a time bound.
+	refusalDetector := s.newAntigravityRefusalDetector()
+	clientOutputStarted := !refusalDetector.Enabled()
+	var pendingEvents [][]byte
+	pendingBytes := 0
+	holdDeadline := time.Now().Add(s.antigravityRefusalHoldTimeout())
+	maxHoldBytes := s.antigravityRefusalHoldMaxBytes()
+
+	if clientOutputStarted {
+		c.Status(http.StatusOK)
 	}
 
 	processor := antigravity.NewStreamingProcessor(originalModel)
@@ -4085,14 +4124,64 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 		return convertUsage(agUsage)
 	}
 
+	// releaseClientOutput commits the HTTP 200 (first time) and flushes any held
+	// events to the client. After this, the failover hard-guard no longer allows
+	// retry — call it only once the response is committed to streaming.
+	releaseClientOutput := func() {
+		if clientOutputStarted {
+			return
+		}
+		clientOutputStarted = true
+		c.Status(http.StatusOK)
+		for _, ev := range pendingEvents {
+			cw.Write(ev)
+		}
+		pendingEvents = nil
+		pendingBytes = 0
+	}
+
+	// writeClaude either holds the converted events (while the detector is armed
+	// and nothing meaningful has been released yet) or writes them through. The
+	// hold is bounded by byte size and wall-clock to protect TTFB / memory.
+	writeClaude := func(claudeEvents []byte) {
+		if clientOutputStarted {
+			cw.Write(claudeEvents)
+			return
+		}
+		release := processor.SawMeaningfulContent() ||
+			pendingBytes+len(claudeEvents) > maxHoldBytes ||
+			time.Now().After(holdDeadline)
+		if release {
+			releaseClientOutput()
+			cw.Write(claudeEvents)
+			return
+		}
+		buf := make([]byte, len(claudeEvents))
+		copy(buf, claudeEvents)
+		pendingEvents = append(pendingEvents, buf)
+		pendingBytes += len(claudeEvents)
+	}
+
 	for {
 		select {
 		case ev, ok := <-events:
 			if !ok {
 				// 上游完成，发送结束事件
 				finalEvents, agUsage := processor.Finish()
+				// Silent-refusal failover: a blocking Gemini finishReason with no
+				// meaningful content, detected BEFORE any client byte. Switches
+				// account (RetryableOnSameAccount=false bypasses the temp-ban path).
+				if !clientOutputStarted && !cw.Disconnected() &&
+					refusalDetector.IsSilentRefusal(processor.LastFinishReason(), processor.SawMeaningfulContent()) {
+					logger.LegacyPrintf("service.antigravity_gateway", "[antigravity-Claude-Stream] silent refusal (finishReason=%s, no content), triggering account failover", processor.LastFinishReason())
+					return nil, &UpstreamFailoverError{
+						StatusCode:             http.StatusBadGateway,
+						ResponseBody:           []byte(`{"error":"antigravity_silent_refusal"}`),
+						RetryableOnSameAccount: false,
+					}
+				}
 				if len(finalEvents) > 0 {
-					cw.Write(finalEvents)
+					writeClaude(finalEvents)
 				} else if !processor.MessageStartSent() && !cw.Disconnected() {
 					// 整个流未收到任何可解析的上游数据（全部 SSE 行均无法被 JSON 解析），
 					// 触发 failover 在同账号重试，避免向客户端发出缺少 message_start 的残缺流
@@ -4103,6 +4192,9 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 						RetryableOnSameAccount: true,
 					}
 				}
+				// Stream ended cleanly without refusal: make sure any held events
+				// (and the deferred 200) are flushed so the client gets the reply.
+				releaseClientOutput()
 				return &antigravityStreamResult{usage: convertUsage(agUsage), firstTokenMs: firstTokenMs, clientDisconnect: cw.Disconnected()}, nil
 			}
 			if ev.err != nil {
@@ -4127,7 +4219,7 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 					ms := int(time.Since(startTime).Milliseconds())
 					firstTokenMs = &ms
 				}
-				cw.Write(claudeEvents)
+				writeClaude(claudeEvents)
 			}
 
 		case <-intervalCh:
@@ -4148,6 +4240,12 @@ func (s *AntigravityGatewayService) handleClaudeStreamingResponse(c *gin.Context
 				continue
 			}
 			if time.Since(lastDataAt) < keepaliveInterval {
+				continue
+			}
+			// During the refusal-retry hold no bytes may be written (the failover
+			// guard requires zero bytes), so suppress the ping; the hold is
+			// time-bounded so it self-releases before any realistic idle timeout.
+			if !clientOutputStarted {
 				continue
 			}
 			// SSE ping 事件：Anthropic 原生格式，客户端会正确处理，

--- a/backend/internal/service/antigravity_silent_refusal.go
+++ b/backend/internal/service/antigravity_silent_refusal.go
@@ -1,0 +1,53 @@
+package service
+
+import "strings"
+
+// Default Gemini finishReason values that indicate the upstream blocked the
+// response (documented Gemini values). Configurable via settings so the set can
+// be corrected against the empirically captured refusal shapes (Step 0).
+var defaultAntigravityBlockingFinishReasons = map[string]struct{}{
+	"SAFETY":             {},
+	"RECITATION":         {},
+	"PROHIBITED_CONTENT": {},
+	"BLOCKLIST":          {},
+	"SPII":               {},
+}
+
+// antigravityRefusalDetector decides whether an antigravity (Gemini-backed
+// Claude) stream is a silent refusal. It reads signals from the StreamingProcessor
+// (raw Gemini finishReason + whether any meaningful content was produced) rather
+// than re-parsing the converted Claude SSE.
+type antigravityRefusalDetector struct {
+	enabled        bool
+	blockingFinish map[string]struct{}
+}
+
+func newAntigravityRefusalDetector(enabled bool, blockingFinish []string) *antigravityRefusalDetector {
+	set := defaultAntigravityBlockingFinishReasons
+	if len(blockingFinish) > 0 {
+		set = make(map[string]struct{}, len(blockingFinish))
+		for _, r := range blockingFinish {
+			set[strings.ToUpper(strings.TrimSpace(r))] = struct{}{}
+		}
+	}
+	return &antigravityRefusalDetector{enabled: enabled, blockingFinish: set}
+}
+
+func (d *antigravityRefusalDetector) Enabled() bool {
+	return d != nil && d.enabled
+}
+
+// IsSilentRefusal reports whether a finished stream is a refusal: a blocking
+// finishReason with no meaningful content produced. sawMeaningfulContent must
+// be false (no visible text, thinking, or tool use). A turn that produced any
+// real content is never a silent refusal, even if it later blocks.
+func (d *antigravityRefusalDetector) IsSilentRefusal(finishReason string, sawMeaningfulContent bool) bool {
+	if d == nil || !d.enabled {
+		return false
+	}
+	if sawMeaningfulContent {
+		return false
+	}
+	_, blocking := d.blockingFinish[strings.ToUpper(strings.TrimSpace(finishReason))]
+	return blocking
+}

--- a/backend/internal/service/antigravity_silent_refusal_test.go
+++ b/backend/internal/service/antigravity_silent_refusal_test.go
@@ -1,0 +1,47 @@
+package service
+
+import "testing"
+
+func TestAntigravityRefusalDetector_IsSilentRefusal(t *testing.T) {
+	cases := []struct {
+		name             string
+		enabled          bool
+		blockingOverride []string
+		finishReason     string
+		sawContent       bool
+		want             bool
+	}{
+		{name: "SAFETY no content -> refusal", enabled: true, finishReason: "SAFETY", sawContent: false, want: true},
+		{name: "RECITATION no content -> refusal", enabled: true, finishReason: "RECITATION", sawContent: false, want: true},
+		{name: "PROHIBITED_CONTENT no content -> refusal", enabled: true, finishReason: "PROHIBITED_CONTENT", sawContent: false, want: true},
+		{name: "SAFETY with content -> not refusal", enabled: true, finishReason: "SAFETY", sawContent: true, want: false},
+		{name: "STOP no content -> not refusal", enabled: true, finishReason: "STOP", sawContent: false, want: false},
+		{name: "MAX_TOKENS no content -> not refusal", enabled: true, finishReason: "MAX_TOKENS", sawContent: false, want: false},
+		{name: "empty finish no content -> not refusal", enabled: true, finishReason: "", sawContent: false, want: false},
+		{name: "lowercase safety normalized -> refusal", enabled: true, finishReason: "safety", sawContent: false, want: true},
+		{name: "whitespace padded -> refusal", enabled: true, finishReason: " SAFETY ", sawContent: false, want: true},
+		{name: "disabled -> never refusal", enabled: false, finishReason: "SAFETY", sawContent: false, want: false},
+		{name: "override set excludes SAFETY", enabled: true, blockingOverride: []string{"RECITATION"}, finishReason: "SAFETY", sawContent: false, want: false},
+		{name: "override set includes custom", enabled: true, blockingOverride: []string{"CUSTOM_BLOCK"}, finishReason: "custom_block", sawContent: false, want: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newAntigravityRefusalDetector(tc.enabled, tc.blockingOverride)
+			got := d.IsSilentRefusal(tc.finishReason, tc.sawContent)
+			if got != tc.want {
+				t.Fatalf("IsSilentRefusal(%q, content=%v) = %v, want %v", tc.finishReason, tc.sawContent, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAntigravityRefusalDetector_NilSafe(t *testing.T) {
+	var d *antigravityRefusalDetector
+	if d.Enabled() {
+		t.Fatal("nil detector should not be enabled")
+	}
+	if d.IsSilentRefusal("SAFETY", false) {
+		t.Fatal("nil detector should never report a refusal")
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -583,6 +583,7 @@ type UpstreamFailoverError struct {
 	ResponseHeaders        http.Header // 上游响应头，用于透传 cf-ray/cf-mitigated/content-type 等诊断信息
 	ForceCacheBilling      bool        // Antigravity 粘性会话切换时设为 true
 	RetryableOnSameAccount bool        // 临时性错误（如 Google 间歇性 400、空响应），应在同一账号上重试 N 次再切换
+	SilentRefusal          bool        // 上游静默拒绝（Anthropic stop_reason=refusal 或 Gemini SAFETY 等）且未产生任何内容，应切换账号重试
 }
 
 func (e *UpstreamFailoverError) Error() string {
@@ -6081,10 +6082,52 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 	}
 	inPartialEvent := false
 
+	// Refusal-retry buffered hold (Anthropic API-key passthrough path). Holds
+	// raw SSE lines until meaningful content / byte cap / time bound, so a
+	// silent refusal (stop_reason=refusal, no content) can fail over before any
+	// byte reaches the client.
+	refusalDetector := newAnthropicRefusalDetector(s.refusalRetryEnabled())
+	clientOutputStarted := !refusalDetector.Enabled()
+	var pendingRefusalLines []string
+	pendingRefusalBytes := 0
+	refusalHoldDeadline := time.Now().Add(refusalHoldTimeout(s.cfg))
+	refusalHoldMax := refusalHoldMaxBytes(s.cfg)
+
+	flushRefusalHold := func() bool {
+		clientOutputStarted = true
+		for _, held := range pendingRefusalLines {
+			restored := string(reverseToolNamesIfPresent(c, []byte(held)))
+			if _, err := io.WriteString(w, restored); err != nil {
+				return false
+			}
+			if _, err := io.WriteString(w, "\n"); err != nil {
+				return false
+			}
+		}
+		pendingRefusalLines = nil
+		pendingRefusalBytes = 0
+		flusher.Flush()
+		return true
+	}
+
 	for {
 		select {
 		case ev, ok := <-events:
 			if !ok {
+				if !clientDisconnected && !clientOutputStarted && refusalDetector.IsSilentRefusal() {
+					logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] silent refusal (stop_reason=refusal, no content), triggering account failover (account=%d)", account.ID)
+					return nil, &UpstreamFailoverError{
+						StatusCode:             http.StatusBadGateway,
+						ResponseBody:           []byte(`{"error":"upstream_silent_refusal"}`),
+						RetryableOnSameAccount: false,
+						SilentRefusal:          true,
+					}
+				}
+				if !clientDisconnected && !clientOutputStarted {
+					if !flushRefusalHold() {
+						clientDisconnected = true
+					}
+				}
 				if !clientDisconnected {
 					// 兜底补刷，确保最后一个未以空行结尾的事件也能及时送达客户端。
 					flusher.Flush()
@@ -6128,10 +6171,42 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 					firstTokenMs = &ms
 				}
 				s.parseSSEUsagePassthrough(data, usage)
+				if refusalDetector.Enabled() && !clientOutputStarted && trimmed != "" && trimmed != "[DONE]" {
+					var event map[string]any
+					if err := json.Unmarshal([]byte(trimmed), &event); err == nil {
+						eventType, _ := event["type"].(string)
+						refusalDetector.ObserveEvent(eventType, event)
+					}
+				}
 			} else {
 				trimmed := strings.TrimSpace(line)
 				if strings.HasPrefix(trimmed, "event:") && anthropicStreamEventIsTerminal(strings.TrimSpace(strings.TrimPrefix(trimmed, "event:")), "") {
 					sawTerminalEvent = true
+				}
+			}
+
+			if !clientDisconnected {
+				// While the refusal hold is active, buffer raw lines instead of
+				// writing, so a silent refusal can still fail over (zero bytes
+				// written). Release on meaningful content, byte cap, or time bound.
+				if !clientOutputStarted {
+					release := refusalDetector.HasMeaningfulContent() ||
+						pendingRefusalBytes+len(line) > refusalHoldMax ||
+						time.Now().After(refusalHoldDeadline)
+					if !release {
+						pendingRefusalLines = append(pendingRefusalLines, line)
+						pendingRefusalBytes += len(line)
+						if line == "" {
+							inPartialEvent = false
+						} else {
+							inPartialEvent = true
+						}
+						continue
+					}
+					if !flushRefusalHold() {
+						clientDisconnected = true
+						logger.LegacyPrintf("service.gateway", "[Anthropic passthrough] Client disconnected flushing refusal hold: account=%d", account.ID)
+					}
 				}
 			}
 
@@ -6174,6 +6249,10 @@ func (s *GatewayService) handleStreamingResponseAnthropicAPIKeyPassthrough(
 			}
 			if inPartialEvent {
 				resetKeepaliveTimer()
+				continue
+			}
+			// 拒绝缓冲保持期间不得写入任何字节（failover 要求零字节），抑制 ping。
+			if !clientOutputStarted {
 				continue
 			}
 			if time.Since(lastDataAt) < keepaliveInterval {
@@ -8348,6 +8427,18 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 
 	pendingEventLines := make([]string, 0, 4)
 
+	// Refusal-retry buffered hold (native Anthropic path). While armed and no
+	// meaningful content has been written, hold output blocks so a silent
+	// refusal (stop_reason=refusal, no content) can trigger account failover
+	// before any byte reaches the client. Released on first meaningful content,
+	// a byte cap, or a wall-clock bound.
+	refusalDetector := newAnthropicRefusalDetector(s.refusalRetryEnabled())
+	clientOutputStarted := !refusalDetector.Enabled()
+	var pendingRefusalBlocks []string
+	pendingRefusalBytes := 0
+	refusalHoldDeadline := time.Now().Add(refusalHoldTimeout(s.cfg))
+	refusalHoldMax := refusalHoldMaxBytes(s.cfg)
+
 	processSSEEvent := func(lines []string) ([]string, string, *sseUsagePatch, error) {
 		if len(lines) == 0 {
 			return nil, "", nil, nil
@@ -8399,6 +8490,7 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 		if eventName == "" {
 			eventName = eventType
 		}
+		refusalDetector.ObserveEvent(eventType, event)
 		eventChanged := false
 
 		if useNoopDeltaKeepalive {
@@ -8508,10 +8600,69 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 		return []string{block}, string(newData), usagePatch, nil
 	}
 
+	// writeBlock either writes a transformed SSE block to the client or, while
+	// the refusal hold is active, buffers it. Returns false if the client
+	// disconnected mid-write. The hold releases on meaningful content, a byte
+	// cap, or a wall-clock bound (see refusalDetector / refusalHold*).
+	writeBlock := func(block string) bool {
+		if !clientOutputStarted {
+			release := !refusalDetector.IsSilentRefusal() &&
+				(refusalDetector.HasMeaningfulContent() ||
+					pendingRefusalBytes+len(block) > refusalHoldMax ||
+					time.Now().After(refusalHoldDeadline))
+			if !release {
+				pendingRefusalBlocks = append(pendingRefusalBlocks, block)
+				pendingRefusalBytes += len(block)
+				return true
+			}
+			clientOutputStarted = true
+			for _, held := range pendingRefusalBlocks {
+				restored := reverseToolNamesIfPresent(c, []byte(held))
+				if _, werr := fmt.Fprint(w, string(restored)); werr != nil {
+					return false
+				}
+			}
+			pendingRefusalBlocks = nil
+			pendingRefusalBytes = 0
+		}
+		restored := reverseToolNamesIfPresent(c, []byte(block))
+		if _, werr := fmt.Fprint(w, string(restored)); werr != nil {
+			return false
+		}
+		flusher.Flush()
+		return true
+	}
+
 	for {
 		select {
 		case ev, ok := <-events:
 			if !ok {
+				// 上游静默拒绝（stop_reason=refusal 且无内容），且尚未向客户端写入
+				// 任何字节：切换账号重试（不在同账号重试，绕过临时封禁）。
+				if !clientOutputStarted && !clientDisconnected && refusalDetector.IsSilentRefusal() {
+					logger.LegacyPrintf("service.gateway", "[anthropic-stream] silent refusal (stop_reason=refusal, no content), triggering account failover (account=%d)", account.ID)
+					return nil, &UpstreamFailoverError{
+						StatusCode:             http.StatusBadGateway,
+						ResponseBody:           []byte(`{"error":"upstream_silent_refusal"}`),
+						RetryableOnSameAccount: false,
+						SilentRefusal:          true,
+					}
+				}
+				// 正常结束：冲刷可能仍被缓冲的事件（非拒绝场景）。
+				if !clientOutputStarted {
+					clientOutputStarted = true
+					for _, held := range pendingRefusalBlocks {
+						restored := reverseToolNamesIfPresent(c, []byte(held))
+						if _, werr := fmt.Fprint(w, string(restored)); werr != nil {
+							clientDisconnected = true
+							break
+						}
+					}
+					if !clientDisconnected {
+						flusher.Flush()
+					}
+					pendingRefusalBlocks = nil
+				}
 				// 上游完成，返回结果
 				if !sawTerminalEvent {
 					return &streamingResult{usage: usage, firstTokenMs: firstTokenMs, clientDisconnect: clientDisconnected}, fmt.Errorf("stream usage incomplete: missing terminal event")
@@ -8580,13 +8731,11 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 
 				for _, block := range outputBlocks {
 					if !clientDisconnected {
-						restored := reverseToolNamesIfPresent(c, []byte(block))
-						if _, werr := fmt.Fprint(w, string(restored)); werr != nil {
+						if !writeBlock(block) {
 							clientDisconnected = true
 							logger.LegacyPrintf("service.gateway", "Client disconnected during streaming, continuing to drain upstream for billing")
 							break
 						}
-						flusher.Flush()
 						lastDataAt = time.Now()
 						resetKeepaliveTimer()
 					}
@@ -8623,6 +8772,11 @@ func (s *GatewayService) handleStreamingResponse(ctx context.Context, resp *http
 
 		case <-keepaliveCh:
 			if clientDisconnected {
+				continue
+			}
+			// 拒绝缓冲保持期间不得写入任何字节（failover 要求零字节），抑制 ping；
+			// 保持有 wall-clock 上限，会在空闲超时前自动释放。
+			if !clientOutputStarted {
 				continue
 			}
 			if time.Since(lastDataAt) < keepaliveInterval {

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -254,6 +254,13 @@ GATEWAY_FORCE_CODEX_CLI=false
 # OpenAI /responses/compact 上游模型（默认 gpt-5.4）。
 # 当 compact 端点暂未支持更新模型时，可通过这里降级规避失败。
 GATEWAY_OPENAI_COMPACT_MODEL=gpt-5.4
+# Transparently retry silent upstream refusals by switching account
+# (covers native Anthropic and antigravity/Gemini); default off.
+# 对上游静默拒绝在切换账号后透明重试（覆盖 native Anthropic 与 antigravity/Gemini）；默认关闭。
+GATEWAY_REFUSAL_RETRY_ENABLED=false
+# Cap on refusal-driven account switches, anti-amplification; default 2, 0=unbounded.
+# 拒绝触发的账号切换次数上限，防放大；默认 2，0 表示不限制。
+GATEWAY_REFUSAL_MAX_RETRIES=2
 # OpenAI/Codex 等待上游响应头超时（秒）；0 表示不使用本地响应头超时截断。
 GATEWAY_OPENAI_RESPONSE_HEADER_TIMEOUT=0
 # OpenAI HTTP 上游默认启用 HTTP/2；如需紧急回滚可设为 false。

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -416,6 +416,27 @@ gateway:
   # Allow failover on selected 400 errors (default: off)
   # 允许在特定 400 错误时进行故障转移（默认：关闭）
   failover_on_400: false
+  # Transparently retry silent upstream refusals by switching account (default: off).
+  # Covers native Anthropic (stop_reason=refusal) and antigravity/Gemini blocking
+  # finishReasons when the stream produced no meaningful content.
+  # 对上游静默拒绝在切换账号后透明重试（默认：关闭）。覆盖 native Anthropic
+  # (stop_reason=refusal) 与 antigravity/Gemini blocking finishReason 且无有效内容的情况。
+  refusal_retry_enabled: false
+  # antigravity/Gemini finishReasons treated as a refusal (empty = built-in set:
+  # SAFETY/RECITATION/PROHIBITED_CONTENT/BLOCKLIST/SPII). Native Anthropic always
+  # uses stop_reason=refusal and ignores this list.
+  # antigravity/Gemini 视为拒绝的 finishReason 列表（留空使用内置集合）。
+  refusal_finish_reasons: []
+  # Max time to hold initial SSE output while detecting a refusal, ms (default 10000).
+  # Keepalive is suppressed during the hold; keep within client first-byte budgets.
+  # 检测拒绝期间缓冲首段 SSE 输出的上限（毫秒，默认 10000；期间抑制 keepalive）。
+  refusal_hold_timeout_ms: 10000
+  # Max buffered bytes before the hold is released regardless of detection (default 65536).
+  # 缓冲字节上限，超过则无条件释放（默认 65536）。
+  refusal_hold_max_bytes: 65536
+  # Cap on refusal-driven account switches, anti-amplification (default 2, 0=unbounded).
+  # 拒绝触发的账号切换次数上限，防放大（默认 2，0=不限制）。
+  refusal_max_retries: 2
   # Scheduling configuration
   # 调度配置
   scheduling:


### PR DESCRIPTION
## Summary

Add an optional, default-off **silent-refusal retry** for streaming
Claude-compatible responses. When an upstream turn ends as a refusal but
carries no meaningful content, the gateway transparently switches account and
retries *before* any bytes reach the client — so callers never receive an empty
or refused assistant turn.

This extends the existing OpenAI silent-refusal handling
(`openai_silent_refusal.go` + the `pendingSSE` buffered-hold) to the Claude
paths, reusing the same mechanism and the same failover loop. No new failover
infrastructure is introduced.

## Motivation

Some upstream Claude/Gemini-backed streams terminate with a refusal signal and
no usable content (a policy/safety block, not a model answer). Today that empty
turn is forwarded verbatim, which surfaces to end users as a blank or broken
response. Operators with multiple accounts would prefer the gateway to retry on
another account, exactly as it already does for OpenAI.

## What it does

Detection is keyed on the upstream's own refusal signal — **not** on
`output_tokens == 0` (which both false-positives on legitimate empty turns and
false-negatives on partial-content refusals). Three streaming paths are covered:

| Path | Detector |
|------|----------|
| Antigravity (Gemini-backed Claude) | Gemini `finishReason` in the configured blocking set (`SAFETY`, `RECITATION`, `PROHIBITED_CONTENT`, `BLOCKLIST`, `SPII`) **and** no text/thinking/tool_use |
| Native Anthropic OAuth | `stop_reason == "refusal"` **and** no meaningful content |
| Native Anthropic API-key passthrough | `stop_reason == "refusal"` **and** no meaningful content |

### Mechanism

- **Buffered hold.** While the detector is armed and no meaningful content has
  been seen, converted SSE events are buffered and the HTTP 200 / first byte is
  deferred. The hold is released on the first meaningful content
  (text/thinking/tool_use), a byte cap (`refusal_hold_max_bytes`, default
  64 KiB), or a wall-clock bound (`refusal_hold_timeout_ms`, default 10 s).
  Keepalive pings are suppressed during the hold so the client cannot observe a
  partial stream that we still intend to retry.
- **Failover.** On stream end, if no client bytes were written and the turn is a
  silent refusal, the path returns
  `UpstreamFailoverError{StatusCode: 502, RetryableOnSameAccount: false,
  SilentRefusal: true}`. The existing failover loop then switches account.
  `RetryableOnSameAccount: false` is intentional: a prompt-triggered refusal is
  deterministic on the same account, and we do not want to trip the 1-minute
  temp-ban path on an otherwise-healthy account.
- **Anti-amplification.** A dedicated cap, `FailoverState.MaxRefusalSwitches`
  (config `refusal_max_retries`, default 2, `0 = unbounded`), bounds
  refusal-driven account switches independently of the general `MaxSwitches`,
  so a deterministic policy refusal cannot burn through every account.
- A typed `UpstreamFailoverError.SilentRefusal` field replaces an earlier
  magic-string match, so the failover loop classifies refusals explicitly.

## Configuration (all under `gateway.`, default-off)

| Key | Default | Notes |
|-----|---------|-------|
| `refusal_retry_enabled` | `false` | Master switch. When off, behavior is byte-for-byte unchanged. |
| `refusal_finish_reasons` | built-in Gemini set | Antigravity-only; native Anthropic always uses `stop_reason=refusal` and ignores this. |
| `refusal_hold_timeout_ms` | `10000` | Kept within common client first-byte budgets (keepalive is suppressed during the hold). |
| `refusal_hold_max_bytes` | `65536` | Hold released unconditionally past this. |
| `refusal_max_retries` | `2` | Cap on refusal-driven switches; `0` = unbounded. |

Documented bilingually in `deploy/config.example.yaml`; the two operator-facing
env vars (`GATEWAY_REFUSAL_RETRY_ENABLED`, `GATEWAY_REFUSAL_MAX_RETRIES`) are in
`deploy/.env.example`.

## Testing

- Detector predicate matrices for native Anthropic (`anthropic_silent_refusal_test.go`)
  and antigravity (`antigravity_silent_refusal_test.go`).
- Antigravity stream-transformer signal tests — finishReason / meaningful-content
  tracking (`stream_transformer_refusal_test.go`).
- Refusal-cap behavior in the failover loop (`failover_refusal_test.go`).
- `go build ./...`, `go vet ./...`, the refusal test suite, and
  `golangci-lint run ./...` (v2.9, matching CI) all pass.

## Backward compatibility

Fully gated behind `refusal_retry_enabled` (default `false`). With the flag off,
the streaming paths, usage accounting, sticky sessions, and the
`c.Writer.Written()` failover guard behave exactly as before — the buffered hold
is never armed.

## Why mirror the OpenAI pattern

The OpenAI path already solved this problem with a buffered-hold + silent-refusal
detector + failover. Rather than invent a parallel mechanism, this PR reuses the
same shape (hold → detect → typed failover error → existing loop) for the Claude
paths, keeping the failover semantics and operator mental model consistent across
providers.

## Out of scope / known gaps

- **Non-streaming** refusal retry (this PR only touches the streaming paths).
- **Partial-content refusals** are intentionally *not* retried — once meaningful
  content has been emitted to the client, the hold is released and the turn is
  delivered as-is.
- No end-to-end integration test of the buffered hold itself yet; coverage is at
  the predicate/signal level plus the shared, already-proven OpenAI hold
  mechanism. An e2e streaming hold test is a reasonable follow-up.

## Notes

- `VERSION` is intentionally left unchanged — release tagging (`v*` →
  `release.yml`) owns versioning.
- No schema/`ent` changes; no frontend changes.
