### PR TITLE
feat(oidc): send configurable prompt on authorize request

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -237,6 +237,9 @@ type OIDCConnectConfig struct {
 	ClockSkewSeconds        int    `mapstructure:"clock_skew_seconds"`     // 默认 120
 	RequireEmailVerified    bool   `mapstructure:"require_email_verified"` // 默认 false
 
+	// OIDC authorize 的 prompt 参数；为空时不发送。常用 login（强制重新认证）/ select_account / consent
+	Prompt string `mapstructure:"prompt"`
+
 	// 可选：用于从 userinfo JSON 中提取字段的 gjson 路径。
 	// 为空时，服务端会尝试一组常见字段名。
 	UserInfoEmailPath    string `mapstructure:"userinfo_email_path"`

--- a/backend/internal/handler/auth_oidc_oauth.go
+++ b/backend/internal/handler/auth_oidc_oauth.go
@@ -944,6 +944,9 @@ func buildOIDCAuthorizeURL(cfg config.OIDCConnectConfig, state, nonce, codeChall
 		q.Set("code_challenge", codeChallenge)
 		q.Set("code_challenge_method", "S256")
 	}
+	if prompt := strings.TrimSpace(cfg.Prompt); prompt != "" {
+		q.Set("prompt", prompt)
+	}
 
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -936,6 +936,8 @@ oidc_connect:
   clock_skew_seconds: 120
   # 若 Provider 返回 email_verified=false，是否拒绝登录
   require_email_verified: false
+  # OIDC authorize 的 prompt 参数；为空时不发送。常用 login（强制重新认证）/ select_account / consent
+  prompt: ""
   userinfo_email_path: ""
   userinfo_id_path: ""
   userinfo_username_path: ""


### PR DESCRIPTION
目前oidc退出登录后, 重新登录会默认直接登录之前的账号
正常退出后再次登录需要重新验证或切换账号
本提交按oidc标准, 支持了配置`prompt`来控制是否需要重新登录或切换账号

##兼容性:
默认为空兼容原来的行为直接登录

##枚举值:
- `login`:强制重新认证(每次都要重新登录)
- `select_account`:强制弹出账号选择页
- `consent`:强制重新授权

在配置文件 `oidc_connect` 下加一行即可(默认留空,不影响现有部署):

```yaml
oidc_connect:
  # ...其余配置...
  prompt: "login"   # 留空则沿用 IdP 默认 SSO 行为