### PR TITLE
fix(openai-ws): keep passthrough downstream connections alive

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -917,6 +917,10 @@ type GatewayOpenAIWSConfig struct {
 	EventFlushBatchSize int `mapstructure:"event_flush_batch_size"`
 	// EventFlushIntervalMS: WS 流式写出最大等待时间（毫秒）；0 表示仅按 batch 触发
 	EventFlushIntervalMS int `mapstructure:"event_flush_interval_ms"`
+	// PassthroughDownstreamPingIntervalSeconds: passthrough 模式下游 WS Ping 间隔；0 表示关闭。
+	PassthroughDownstreamPingIntervalSeconds int `mapstructure:"passthrough_downstream_ping_interval_seconds"`
+	// PassthroughDownstreamPingTimeoutSeconds: passthrough 模式下游 WS Ping 等待 Pong 的超时时间。
+	PassthroughDownstreamPingTimeoutSeconds int `mapstructure:"passthrough_downstream_ping_timeout_seconds"`
 	// PrewarmCooldownMS: 连接池预热触发冷却时间（毫秒）
 	PrewarmCooldownMS int `mapstructure:"prewarm_cooldown_ms"`
 	// FallbackCooldownSeconds: WS 回退冷却窗口，避免 WS/HTTP 抖动；0 表示关闭冷却
@@ -1851,6 +1855,8 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_ws.queue_limit_per_conn", 64)
 	viper.SetDefault("gateway.openai_ws.event_flush_batch_size", 1)
 	viper.SetDefault("gateway.openai_ws.event_flush_interval_ms", 10)
+	viper.SetDefault("gateway.openai_ws.passthrough_downstream_ping_interval_seconds", 20)
+	viper.SetDefault("gateway.openai_ws.passthrough_downstream_ping_timeout_seconds", 5)
 	viper.SetDefault("gateway.openai_ws.prewarm_cooldown_ms", 300)
 	viper.SetDefault("gateway.openai_ws.fallback_cooldown_seconds", 30)
 	viper.SetDefault("gateway.openai_ws.retry_backoff_initial_ms", 120)
@@ -2569,6 +2575,22 @@ func (c *Config) Validate() error {
 	}
 	if c.Gateway.OpenAIWS.EventFlushIntervalMS < 0 {
 		return fmt.Errorf("gateway.openai_ws.event_flush_interval_ms must be non-negative")
+	}
+	if c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds != 0 &&
+		(c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds < 5 ||
+			c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds > 60) {
+		return fmt.Errorf("gateway.openai_ws.passthrough_downstream_ping_interval_seconds must be 0 or between 5-60 seconds")
+	}
+	if c.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds < 0 {
+		return fmt.Errorf("gateway.openai_ws.passthrough_downstream_ping_timeout_seconds must be non-negative")
+	}
+	if c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds > 0 &&
+		c.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds <= 0 {
+		return fmt.Errorf("gateway.openai_ws.passthrough_downstream_ping_timeout_seconds must be positive when passthrough downstream ping is enabled")
+	}
+	if c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds > 0 &&
+		c.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds >= c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds {
+		return fmt.Errorf("gateway.openai_ws.passthrough_downstream_ping_timeout_seconds must be less than passthrough_downstream_ping_interval_seconds")
 	}
 	if c.Gateway.OpenAIWS.PrewarmCooldownMS < 0 {
 		return fmt.Errorf("gateway.openai_ws.prewarm_cooldown_ms must be non-negative")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -140,6 +140,12 @@ func TestLoadDefaultOpenAIWSConfig(t *testing.T) {
 	if cfg.Gateway.OpenAIWS.EventFlushIntervalMS != 10 {
 		t.Fatalf("Gateway.OpenAIWS.EventFlushIntervalMS = %d, want 10", cfg.Gateway.OpenAIWS.EventFlushIntervalMS)
 	}
+	if cfg.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds != 20 {
+		t.Fatalf("Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds = %d, want 20", cfg.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds)
+	}
+	if cfg.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds != 5 {
+		t.Fatalf("Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds = %d, want 5", cfg.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds)
+	}
 	if cfg.Gateway.OpenAIWS.PrewarmCooldownMS != 300 {
 		t.Fatalf("Gateway.OpenAIWS.PrewarmCooldownMS = %d, want 300", cfg.Gateway.OpenAIWS.PrewarmCooldownMS)
 	}
@@ -1648,6 +1654,32 @@ func TestValidateConfig_OpenAIWSRules(t *testing.T) {
 			name:    "write_timeout_seconds 必须为正数",
 			mutate:  func(c *Config) { c.Gateway.OpenAIWS.WriteTimeoutSeconds = 0 },
 			wantErr: "gateway.openai_ws.write_timeout_seconds",
+		},
+		{
+			name:    "passthrough_downstream_ping_interval_seconds 必须为 0 或 5-60 秒",
+			mutate:  func(c *Config) { c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds = 4 },
+			wantErr: "gateway.openai_ws.passthrough_downstream_ping_interval_seconds",
+		},
+		{
+			name:    "passthrough_downstream_ping_timeout_seconds 不能为负数",
+			mutate:  func(c *Config) { c.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds = -1 },
+			wantErr: "gateway.openai_ws.passthrough_downstream_ping_timeout_seconds",
+		},
+		{
+			name: "启用 passthrough downstream ping 时 timeout 必须为正数",
+			mutate: func(c *Config) {
+				c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds = 20
+				c.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds = 0
+			},
+			wantErr: "gateway.openai_ws.passthrough_downstream_ping_timeout_seconds",
+		},
+		{
+			name: "passthrough downstream ping timeout 必须小于 interval",
+			mutate: func(c *Config) {
+				c.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds = 20
+				c.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds = 20
+			},
+			wantErr: "gateway.openai_ws.passthrough_downstream_ping_timeout_seconds must be less than passthrough_downstream_ping_interval_seconds",
 		},
 		{
 			name:    "pool_target_utilization 必须在 (0,1]",

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -991,6 +991,26 @@ func (s *OpenAIGatewayService) openAIWSPassthroughIdleTimeout() time.Duration {
 	return openAIWSPassthroughIdleTimeoutDefault
 }
 
+func (s *OpenAIGatewayService) openAIWSPassthroughDownstreamPingInterval() time.Duration {
+	if s != nil && s.cfg != nil {
+		seconds := s.cfg.Gateway.OpenAIWS.PassthroughDownstreamPingIntervalSeconds
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return 0
+}
+
+func (s *OpenAIGatewayService) openAIWSPassthroughDownstreamPingTimeout() time.Duration {
+	if s != nil && s.cfg != nil {
+		seconds := s.cfg.Gateway.OpenAIWS.PassthroughDownstreamPingTimeoutSeconds
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+	}
+	return 5 * time.Second
+}
+
 func (s *OpenAIGatewayService) openAIWSWriteTimeout() time.Duration {
 	if s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIWS.WriteTimeoutSeconds > 0 {
 		return time.Duration(s.cfg.Gateway.OpenAIWS.WriteTimeoutSeconds) * time.Second

--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -20,6 +20,10 @@ type FrameConn interface {
 	Close() error
 }
 
+type PingableFrameConn interface {
+	Ping(ctx context.Context) error
+}
+
 type Usage struct {
 	InputTokens              int
 	OutputTokens             int
@@ -59,6 +63,8 @@ type RelayOptions struct {
 	WriteTimeout                    time.Duration
 	IdleTimeout                     time.Duration
 	UpstreamDrainTimeout            time.Duration
+	DownstreamPingInterval          time.Duration
+	DownstreamPingTimeout           time.Duration
 	FirstMessageType                coderws.MessageType
 	FirstMessageSent                bool
 	StartClientAfterFirstDownstream bool
@@ -138,6 +144,11 @@ func Relay(
 	if drainTimeout <= 0 {
 		drainTimeout = 1200 * time.Millisecond
 	}
+	downstreamPingInterval := options.DownstreamPingInterval
+	downstreamPingTimeout := options.DownstreamPingTimeout
+	if downstreamPingInterval > 0 && downstreamPingTimeout <= 0 {
+		downstreamPingTimeout = 5 * time.Second
+	}
 	firstMessageType := options.FirstMessageType
 	if firstMessageType != coderws.MessageBinary {
 		firstMessageType = coderws.MessageText
@@ -154,6 +165,7 @@ func Relay(
 	markActivity := func() {
 		lastActivity.Store(nowFn().UnixNano())
 	}
+	lastDownstreamWrite := atomic.Int64{}
 
 	writeUpstream := func(msgType coderws.MessageType, payload []byte) error {
 		writeCtx, cancel := context.WithTimeout(relayCtx, writeTimeout)
@@ -163,7 +175,11 @@ func Relay(
 	writeClient := func(msgType coderws.MessageType, payload []byte) error {
 		writeCtx, cancel := context.WithTimeout(relayCtx, writeTimeout)
 		defer cancel()
-		return clientConn.WriteFrame(writeCtx, msgType, payload)
+		if err := clientConn.WriteFrame(writeCtx, msgType, payload); err != nil {
+			return err
+		}
+		lastDownstreamWrite.Store(nowFn().UnixNano())
+		return nil
 	}
 
 	clientToUpstreamFrames := &atomic.Int64{}
@@ -204,14 +220,33 @@ func Relay(
 	clientToUpstreamFrames.Add(1)
 	markActivity()
 
-	exitCh := make(chan relayExitSignal, 3)
+	exitCh := make(chan relayExitSignal, 4)
 	dropDownstreamWrites := atomic.Bool{}
 	clientReaderStarted := atomic.Bool{}
+	downstreamKeepaliveStarted := atomic.Bool{}
 	startClientReader := func() {
 		if !clientReaderStarted.CompareAndSwap(false, true) {
 			return
 		}
 		go runClientToUpstream(relayCtx, clientConn, options.ReadClientFrame, writeUpstream, markActivity, clientToUpstreamFrames, onTrace, exitCh)
+	}
+	startDownstreamKeepalive := func() {
+		if downstreamPingInterval <= 0 {
+			return
+		}
+		if !downstreamKeepaliveStarted.CompareAndSwap(false, true) {
+			return
+		}
+		go runDownstreamKeepalive(
+			relayCtx,
+			clientConn,
+			nowFn,
+			downstreamPingInterval,
+			downstreamPingTimeout,
+			&lastDownstreamWrite,
+			onTrace,
+			exitCh,
+		)
 	}
 	if !options.StartClientAfterFirstDownstream {
 		startClientReader()
@@ -230,6 +265,7 @@ func Relay(
 			if options.StartClientAfterFirstDownstream {
 				startClientReader()
 			}
+			startDownstreamKeepalive()
 		},
 		&dropDownstreamWrites,
 		upstreamToClientFrames,
@@ -555,6 +591,75 @@ func runIdleWatchdog(
 			})
 			exitCh <- relayExitSignal{stage: "idle_timeout", err: context.DeadlineExceeded}
 			return
+		}
+	}
+}
+
+func runDownstreamKeepalive(
+	ctx context.Context,
+	clientConn FrameConn,
+	nowFn func() time.Time,
+	pingInterval time.Duration,
+	pingTimeout time.Duration,
+	lastDownstreamWrite *atomic.Int64,
+	onTrace func(event RelayTraceEvent),
+	exitCh chan<- relayExitSignal,
+) {
+	if pingInterval <= 0 || lastDownstreamWrite == nil {
+		return
+	}
+	pingable, ok := clientConn.(PingableFrameConn)
+	if !ok {
+		emitRelayTrace(onTrace, RelayTraceEvent{
+			Stage:     "downstream_ping_unsupported",
+			Direction: "downstream_keepalive",
+		})
+		return
+	}
+	if pingTimeout <= 0 {
+		pingTimeout = 5 * time.Second
+	}
+	emitRelayTrace(onTrace, RelayTraceEvent{
+		Stage:     "downstream_ping_started",
+		Direction: "downstream_keepalive",
+	})
+	ticker := time.NewTicker(pingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			last := lastDownstreamWrite.Load()
+			if last == 0 || nowFn().Sub(time.Unix(0, last)) < pingInterval {
+				continue
+			}
+			pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+			err := pingable.Ping(pingCtx)
+			cancel()
+			if err != nil {
+				emitRelayTrace(onTrace, RelayTraceEvent{
+					Stage:           "downstream_ping_failed",
+					Direction:       "downstream_keepalive",
+					Error:           err.Error(),
+					Graceful:        true,
+					WroteDownstream: true,
+				})
+				exitCh <- relayExitSignal{
+					stage:           "read_client",
+					err:             err,
+					graceful:        true,
+					wroteDownstream: true,
+				}
+				return
+			}
+			emitRelayTrace(onTrace, RelayTraceEvent{
+				Stage:           "downstream_ping_ok",
+				Direction:       "downstream_keepalive",
+				Graceful:        true,
+				WroteDownstream: true,
+			})
 		}
 	}
 }

--- a/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay_test.go
@@ -25,6 +25,13 @@ type passthroughTestFrameConn struct {
 	once   sync.Once
 }
 
+type passthroughPingableFrameConn struct {
+	base     *passthroughTestFrameConn
+	pingErr  error
+	pingCh   chan struct{}
+	pingDone atomic.Int64
+}
+
 type delayedReadFrameConn struct {
 	base       FrameConn
 	firstDelay time.Duration
@@ -93,6 +100,47 @@ func (c *passthroughTestFrameConn) Writes() []passthroughTestFrame {
 	out := make([]passthroughTestFrame, len(c.writes))
 	copy(out, c.writes)
 	return out
+}
+
+func (c *passthroughPingableFrameConn) ReadFrame(ctx context.Context) (coderws.MessageType, []byte, error) {
+	return c.base.ReadFrame(ctx)
+}
+
+func (c *passthroughPingableFrameConn) WriteFrame(ctx context.Context, msgType coderws.MessageType, payload []byte) error {
+	return c.base.WriteFrame(ctx, msgType, payload)
+}
+
+func (c *passthroughPingableFrameConn) Close() error {
+	return c.base.Close()
+}
+
+func (c *passthroughPingableFrameConn) Ping(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	c.pingDone.Add(1)
+	if c.pingCh != nil {
+		select {
+		case c.pingCh <- struct{}{}:
+		default:
+		}
+	}
+	if c.pingErr != nil {
+		return c.pingErr
+	}
+	return nil
+}
+
+func (c *passthroughPingableFrameConn) PingCount() int64 {
+	if c == nil {
+		return 0
+	}
+	return c.pingDone.Load()
 }
 
 func (c *delayedReadFrameConn) ReadFrame(ctx context.Context) (coderws.MessageType, []byte, error) {
@@ -289,6 +337,225 @@ func TestRelay_ClientDisconnect_DrainCapturesLateUsage(t *testing.T) {
 	require.Equal(t, int64(1), result.ClientToUpstreamFrames)
 	require.Equal(t, int64(0), result.UpstreamToClientFrames)
 	require.Equal(t, int64(1), result.DroppedDownstreamFrames)
+}
+
+func TestRelay_DownstreamPingAfterIdleDownstreamWrite(t *testing.T) {
+	clientConn := &passthroughPingableFrameConn{
+		base:   newPassthroughTestFrameConn(nil, false),
+		pingCh: make(chan struct{}, 4),
+	}
+	upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.output_text.delta","delta":"hello"}`),
+		},
+	}, false)
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-4o","input":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stages := make([]string, 0, 8)
+	var stagesMu sync.Mutex
+	done := make(chan struct {
+		result RelayResult
+		exit   *RelayExit
+	}, 1)
+	go func() {
+		result, relayExit := Relay(ctx, clientConn, upstreamConn, firstPayload, RelayOptions{
+			StartClientAfterFirstDownstream: true,
+			DownstreamPingInterval:          20 * time.Millisecond,
+			DownstreamPingTimeout:           10 * time.Millisecond,
+			OnTrace: func(event RelayTraceEvent) {
+				stagesMu.Lock()
+				stages = append(stages, event.Stage)
+				stagesMu.Unlock()
+			},
+		})
+		done <- struct {
+			result RelayResult
+			exit   *RelayExit
+		}{result: result, exit: relayExit}
+	}()
+
+	select {
+	case <-clientConn.pingCh:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for downstream ping: %v", ctx.Err())
+	}
+
+	upstreamConn.readCh <- passthroughTestFrame{
+		msgType: coderws.MessageText,
+		payload: []byte(`{"type":"response.completed","response":{"id":"resp_ping","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}
+	require.NoError(t, upstreamConn.Close())
+
+	var observed struct {
+		result RelayResult
+		exit   *RelayExit
+	}
+	select {
+	case observed = <-done:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for relay completion: %v", ctx.Err())
+	}
+
+	require.Nil(t, observed.exit)
+	require.Equal(t, "resp_ping", observed.result.RequestID)
+	require.GreaterOrEqual(t, clientConn.PingCount(), int64(1))
+	stagesMu.Lock()
+	capturedStages := append([]string(nil), stages...)
+	stagesMu.Unlock()
+	require.Contains(t, capturedStages, "downstream_ping_ok")
+}
+
+func TestRelay_DownstreamPingDoesNotStartBeforeFirstDownstreamWrite(t *testing.T) {
+	clientConn := &passthroughPingableFrameConn{
+		base:   newPassthroughTestFrameConn(nil, false),
+		pingCh: make(chan struct{}, 4),
+	}
+	upstreamBase := newPassthroughTestFrameConn([]passthroughTestFrame{
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.completed","response":{"id":"resp_delayed","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		},
+	}, true)
+	upstreamConn := &delayedReadFrameConn{
+		base:       upstreamBase,
+		firstDelay: 120 * time.Millisecond,
+	}
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-4o","input":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan *RelayExit, 1)
+	go func() {
+		_, relayExit := Relay(ctx, clientConn, upstreamConn, firstPayload, RelayOptions{
+			StartClientAfterFirstDownstream: true,
+			DownstreamPingInterval:          20 * time.Millisecond,
+			DownstreamPingTimeout:           10 * time.Millisecond,
+		})
+		done <- relayExit
+	}()
+
+	time.Sleep(60 * time.Millisecond)
+	require.Zero(t, clientConn.PingCount(), "downstream ping must not start before the first downstream business frame")
+
+	select {
+	case relayExit := <-done:
+		require.Nil(t, relayExit)
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for relay completion: %v", ctx.Err())
+	}
+}
+
+func TestRelay_DownstreamPingFailureDrainsLateUsage(t *testing.T) {
+	clientConn := &passthroughPingableFrameConn{
+		base:    newPassthroughTestFrameConn(nil, false),
+		pingErr: errors.New("downstream ping failed"),
+		pingCh:  make(chan struct{}, 4),
+	}
+	upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.output_text.delta","delta":"hello"}`),
+		},
+	}, false)
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-4o","input":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	stages := make([]string, 0, 12)
+	var stagesMu sync.Mutex
+	done := make(chan struct {
+		result RelayResult
+		exit   *RelayExit
+	}, 1)
+	go func() {
+		result, relayExit := Relay(ctx, clientConn, upstreamConn, firstPayload, RelayOptions{
+			FirstMessageSent:                true,
+			StartClientAfterFirstDownstream: true,
+			UpstreamDrainTimeout:            400 * time.Millisecond,
+			DownstreamPingInterval:          20 * time.Millisecond,
+			DownstreamPingTimeout:           10 * time.Millisecond,
+			OnTrace: func(event RelayTraceEvent) {
+				stagesMu.Lock()
+				stages = append(stages, event.Stage)
+				stagesMu.Unlock()
+			},
+		})
+		done <- struct {
+			result RelayResult
+			exit   *RelayExit
+		}{result: result, exit: relayExit}
+	}()
+
+	select {
+	case <-clientConn.pingCh:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for downstream ping failure: %v", ctx.Err())
+	}
+
+	upstreamConn.readCh <- passthroughTestFrame{
+		msgType: coderws.MessageText,
+		payload: []byte(`{"type":"response.completed","response":{"id":"resp_drain_ping","usage":{"input_tokens":6,"output_tokens":4,"input_tokens_details":{"cached_tokens":1}}}}`),
+	}
+	require.NoError(t, upstreamConn.Close())
+
+	var observed struct {
+		result RelayResult
+		exit   *RelayExit
+	}
+	select {
+	case observed = <-done:
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for relay completion: %v", ctx.Err())
+	}
+
+	require.Nil(t, observed.exit, "passthrough client disconnect after the upstream first message is an observed completion, not a server failure")
+	require.Equal(t, "resp_drain_ping", observed.result.RequestID)
+	require.Equal(t, "response.completed", observed.result.TerminalEventType)
+	require.Equal(t, 6, observed.result.Usage.InputTokens)
+	require.Equal(t, 4, observed.result.Usage.OutputTokens)
+	require.Equal(t, 1, observed.result.Usage.CacheReadInputTokens)
+	require.Equal(t, int64(1), observed.result.UpstreamToClientFrames)
+	require.Equal(t, int64(1), observed.result.DroppedDownstreamFrames)
+	stagesMu.Lock()
+	capturedStages := append([]string(nil), stages...)
+	stagesMu.Unlock()
+	require.Contains(t, capturedStages, "downstream_ping_failed")
+	require.Contains(t, capturedStages, "drop_downstream_frame")
+}
+
+func TestRelay_DownstreamPingDoesNotResetIdleTimeout(t *testing.T) {
+	clientConn := &passthroughPingableFrameConn{
+		base:   newPassthroughTestFrameConn(nil, false),
+		pingCh: make(chan struct{}, 16),
+	}
+	upstreamConn := newPassthroughTestFrameConn([]passthroughTestFrame{
+		{
+			msgType: coderws.MessageText,
+			payload: []byte(`{"type":"response.output_text.delta","delta":"hello"}`),
+		},
+	}, false)
+
+	firstPayload := []byte(`{"type":"response.create","model":"gpt-4o","input":[]}`)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+	defer cancel()
+
+	result, relayExit := Relay(ctx, clientConn, upstreamConn, firstPayload, RelayOptions{
+		FirstMessageSent:                true,
+		StartClientAfterFirstDownstream: true,
+		IdleTimeout:                     time.Second,
+		DownstreamPingInterval:          20 * time.Millisecond,
+		DownstreamPingTimeout:           10 * time.Millisecond,
+	})
+	require.NotNil(t, relayExit)
+	require.Equal(t, "idle_timeout", relayExit.Stage)
+	require.Equal(t, "gpt-4o", result.RequestModel)
+	require.Greater(t, clientConn.PingCount(), int64(0), "test must exercise downstream pings before idle timeout fires")
 }
 
 func TestRelay_IdleTimeout(t *testing.T) {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -69,6 +69,17 @@ func (c *openAIWSPolicyEnforcingFrameConn) WriteFrame(ctx context.Context, msgTy
 	return c.inner.WriteFrame(ctx, msgType, payload)
 }
 
+func (c *openAIWSPolicyEnforcingFrameConn) Ping(ctx context.Context) error {
+	if c == nil || c.inner == nil {
+		return errOpenAIWSConnClosed
+	}
+	pingable, ok := c.inner.(openaiwsv2.PingableFrameConn)
+	if !ok {
+		return errOpenAIWSConnClosed
+	}
+	return pingable.Ping(ctx)
+}
+
 func (c *openAIWSPolicyEnforcingFrameConn) Close() error {
 	if c == nil || c.inner == nil {
 		return nil
@@ -213,6 +224,16 @@ func (c *openAIWSClientFrameConn) WriteFrame(ctx context.Context, msgType coderw
 		ctx = context.Background()
 	}
 	return c.conn.Write(ctx, msgType, payload)
+}
+
+func (c *openAIWSClientFrameConn) Ping(ctx context.Context) error {
+	if c == nil || c.conn == nil {
+		return errOpenAIWSConnClosed
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return c.conn.Ping(ctx)
 }
 
 func (c *openAIWSClientFrameConn) Close() error {
@@ -506,6 +527,8 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 		Options: openaiwsv2.RelayOptions{
 			WriteTimeout:                    s.openAIWSWriteTimeout(),
 			IdleTimeout:                     s.openAIWSPassthroughIdleTimeout(),
+			DownstreamPingInterval:          s.openAIWSPassthroughDownstreamPingInterval(),
+			DownstreamPingTimeout:           s.openAIWSPassthroughDownstreamPingTimeout(),
 			FirstMessageType:                coderws.MessageText,
 			FirstMessageSent:                upstreamFirstMessageSent,
 			StartClientAfterFirstDownstream: true,


### PR DESCRIPTION
## Summary

Fixes #3171.

This adds downstream WebSocket Ping/Pong keepalive for OpenAI Responses WS v2 passthrough mode. Long Codex turns such as `image_generation` can otherwise leave the downstream client-facing WebSocket idle long enough for intermediate proxies to close it before `response.completed`.

The keepalive starts only after the first downstream business frame has been written, so failed handshakes or never-started relays are not kept alive artificially.

## Changes

- Add configurable passthrough downstream ping interval and timeout:
  - `gateway.openai_ws.passthrough_downstream_ping_interval_seconds` default `20`
  - `gateway.openai_ws.passthrough_downstream_ping_timeout_seconds` default `5`
- Add `Ping(ctx)` support to the passthrough downstream frame connection.
- Start a downstream keepalive loop for idle downstream passthrough sessions.
- Treat downstream Ping/Pong failure as a graceful client disconnect while preserving upstream drain/usage capture behavior.
- Add regression tests for successful ping, delayed start, ping failure/drain, and idle timeout behavior while pings succeed.

## Validation

```text
ok   github.com/Wei-Shaw/sub2api/internal/service/openai_ws_v2  4.314s
ok   github.com/Wei-Shaw/sub2api/internal/config                0.310s
ok   github.com/Wei-Shaw/sub2api/internal/service               10.451s
```

Commands run:

```bash
go test ./internal/service/openai_ws_v2 -count=1
go test ./internal/config -count=1
go test ./internal/service -run 'OpenAIWS|Passthrough' -count=1
```
