### PR TITLE
fix idempotency response utf8 truncation / 响应缓存按字节截断时可能切断 UTF-8 多字节字符的问题。

### DIFF
--- a/backend/internal/service/idempotency.go
+++ b/backend/internal/service/idempotency.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
@@ -454,9 +455,19 @@ func (c *IdempotencyCoordinator) marshalStoredResponse(data any) (string, error)
 	}
 	redacted := logredact.RedactText(string(raw))
 	if c.cfg.MaxStoredResponseLen > 0 && len(redacted) > c.cfg.MaxStoredResponseLen {
-		redacted = redacted[:c.cfg.MaxStoredResponseLen] + "...(truncated)"
+		redacted = truncateUTF8(redacted, c.cfg.MaxStoredResponseLen) + "...(truncated)"
 	}
 	return redacted, nil
+}
+
+func truncateUTF8(s string, maxBytes int) string {
+	if maxBytes <= 0 || len(s) <= maxBytes {
+		return s
+	}
+	for maxBytes > 0 && !utf8.ValidString(s[:maxBytes]) {
+		maxBytes--
+	}
+	return s[:maxBytes]
 }
 
 func (c *IdempotencyCoordinator) decodeStoredResponse(stored *string) (any, error) {

--- a/backend/internal/service/idempotency_test.go
+++ b/backend/internal/service/idempotency_test.go
@@ -3,10 +3,12 @@ package service
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -439,6 +441,51 @@ func TestIdempotencyCoordinator_StoreUnavailableMetrics(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, infraerrors.Code(ErrIdempotencyStoreUnavail), infraerrors.Code(err))
 	require.GreaterOrEqual(t, GetIdempotencyMetricsSnapshot().StoreUnavailableTotal, uint64(1))
+}
+
+type utf8RejectingIdempotencyRepo struct {
+	inMemoryIdempotencyRepo
+}
+
+func newUTF8RejectingIdempotencyRepo() *utf8RejectingIdempotencyRepo {
+	return &utf8RejectingIdempotencyRepo{inMemoryIdempotencyRepo: *newInMemoryIdempotencyRepo()}
+}
+
+func (r *utf8RejectingIdempotencyRepo) MarkSucceeded(ctx context.Context, id int64, responseStatus int, responseBody string, expiresAt time.Time) error {
+	if !utf8.ValidString(responseBody) {
+		return errors.New(`pq: invalid byte sequence for encoding "UTF8": 0xe8 0xb4 0x2e`)
+	}
+	return r.inMemoryIdempotencyRepo.MarkSucceeded(ctx, id, responseStatus, responseBody, expiresAt)
+}
+
+func TestIdempotencyCoordinator_TruncatedStoredResponseRemainsUTF8(t *testing.T) {
+	repo := newUTF8RejectingIdempotencyRepo()
+	cfg := DefaultIdempotencyConfig()
+	cfg.MaxStoredResponseLen = len(`{"message":"`) + 2
+	coordinator := NewIdempotencyCoordinator(repo, cfg)
+
+	opts := IdempotencyExecuteOptions{
+		Scope:          "test.scope.truncate_utf8",
+		Method:         "POST",
+		Route:          "/api/v1/accounts/import/codex-session",
+		ActorScope:     "admin:1",
+		RequireKey:     true,
+		IdempotencyKey: "truncate-utf8",
+		Payload:        map[string]any{"content": "codex-session"},
+	}
+
+	result, err := coordinator.Execute(context.Background(), opts, func(ctx context.Context) (any, error) {
+		return map[string]any{"message": strings.Repeat("\u8d26", 8)}, nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	stored, err := repo.GetByScopeAndKeyHash(context.Background(), opts.Scope, HashIdempotencyKey(opts.IdempotencyKey))
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	require.NotNil(t, stored.ResponseBody)
+	require.True(t, utf8.ValidString(*stored.ResponseBody))
+	require.Contains(t, *stored.ResponseBody, "...(truncated)")
 }
 
 func TestDefaultIdempotencyCoordinatorAndTTLs(t *testing.T) {


### PR DESCRIPTION
```
2026/6/9 19:00:34	error	[ERROR] POST /api/v1/accounts/import/codex-session Error: error: code=*** reason="IDEMPOTENCY_STORE_UNAVAILABLE" message="idempotency store unavailable" metadata=map[] cause=pq: invalid byte sequence for encoding "UTF8": 0xe8 0xb4 0x2e
2026/6/9 18:55:35	error	[ERROR] POST /api/v1/accounts/import/codex-session Error: error: code=*** reason="IDEMPOTENCY_STORE_UNAVAILABLE" message="idempotency store unavailable" metadata=map[] cause=pq: invalid byte sequence for encoding "UTF8": 0xe6 0x2e 0x2e
2026/6/9 18:53:05	error	[ERROR] POST /api/v1/accounts/import/codex-session Error: error: code=*** reason="IDEMPOTENCY_STORE_UNAVAILABLE" message="idempotency store unavailable" metadata=map[] cause=pq: invalid byte sequence for encoding "UTF8": 0xe6 0x2e 0x2e
```

## Summary

修复幂等响应缓存按字节截断时可能切断 UTF-8 多字节字符的问题。

此前 `marshalStoredResponse` 在超过 `MaxStoredResponseLen` 时直接使用 `s[:max]` 截断字符串。如果截断点落在中文等多字节字符中间，会生成非法 UTF-8，随后写入 PostgreSQL `response_body` 时触发：

`pq: invalid byte sequence for encoding "UTF8"`

这会让接口表现为 `IDEMPOTENCY_STORE_UNAVAILABLE`，例如 `/api/v1/accounts/import/codex-session`。

## Changes

- 将幂等响应缓存截断改为 UTF-8 安全截断。
- 新增回归测试，模拟 PostgreSQL 拒绝非法 UTF-8 的行为，复现并覆盖该 bug。

## Tests

- `go test ./internal/service -run TestIdempotencyCoordinator_TruncatedStoredResponseRemainsUTF8 -count=1`
- `go test ./internal/service -run Idempotency -count=1`
- `go test ./internal/handler/admin -run "Idempotent|CodexSession|CodexImport" -count=1`
- `go test ./internal/service -count=1`
- `git diff --check`