### PR TITLE
支持一键导入 API 密钥到 RelaySwitch

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -702,6 +702,7 @@ export default {
     copyToClipboard: 'Copy to clipboard',
     copied: 'Copied!',
     importToCcSwitch: 'Import to CCS',
+    importToRelaySwitch: 'Import to RS',
     enable: 'Enable',
     disable: 'Disable',
     nameLabel: 'Name',
@@ -787,6 +788,7 @@ export default {
     ipBlacklistHint: 'One IP or CIDR per line. These IPs will be blocked from using this key.',
     ipRestrictionEnabled: 'IP restriction enabled',
     ccSwitchNotInstalled: 'CC-Switch is not installed or the protocol handler is not registered. Please install CC-Switch first or manually copy the API key.',
+    relaySwitchNotInstalled: 'RelaySwitch is not installed or the protocol handler is not registered. Please install it from the Release page: https://github.com/xiaoyuandev/relay-switch/releases',
     ccsClientSelect: {
       title: 'Select Client',
       description: 'Please select the client type to import to CC-Switch:',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -701,6 +701,7 @@ export default {
     copyToClipboard: '复制到剪贴板',
     copied: '已复制！',
     importToCcSwitch: '导入到 CCS',
+    importToRelaySwitch: '导入到 RS',
     enable: '启用',
     disable: '禁用',
     nameLabel: '名称',
@@ -791,6 +792,8 @@ export default {
     ipRestrictionEnabled: '已配置 IP 限制',
     ccSwitchNotInstalled:
       'CC-Switch 未安装或协议处理程序未注册。请先安装 CC-Switch 或手动复制 API 密钥。',
+    relaySwitchNotInstalled:
+      'RelaySwitch 未安装或协议处理程序未注册。请前往 Release 页面下载安装：https://github.com/xiaoyuandev/relay-switch/releases',
     ccsClientSelect: {
       title: '选择客户端',
       description: '请选择您要导入到 CC-Switch 的客户端类型：',

--- a/frontend/src/utils/__tests__/relayswitchImport.spec.ts
+++ b/frontend/src/utils/__tests__/relayswitchImport.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+import { buildRelaySwitchProviderImportDeeplink } from '@/utils/relayswitchImport'
+
+function paramsFromDeeplink(deeplink: string): URLSearchParams {
+  const query = deeplink.split('?')[1] || ''
+  return new URLSearchParams(query)
+}
+
+function decodePayload(encodedPayload: string): unknown {
+  const base64 = encodedPayload.replace(/-/g, '+').replace(/_/g, '/')
+  const padding = base64.length % 4 === 0 ? '' : '='.repeat(4 - (base64.length % 4))
+  const binary = atob(base64 + padding)
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0))
+
+  return JSON.parse(new TextDecoder().decode(bytes))
+}
+
+describe('relayswitchImport utils', () => {
+  it('builds a provider import deeplink with the required RelaySwitch shape', () => {
+    const deeplink = buildRelaySwitchProviderImportDeeplink({
+      name: 'Sub2API',
+      baseUrl: 'https://api.example.com',
+      apiKey: 'sk-test'
+    })
+    const params = paramsFromDeeplink(deeplink)
+
+    expect(deeplink.startsWith('relay-switch://v1/import?')).toBe(true)
+    expect(params.get('resource')).toBe('provider')
+    expect(decodePayload(params.get('payload') || '')).toEqual({
+      name: 'Sub2API',
+      baseUrl: 'https://api.example.com',
+      apiKey: 'sk-test'
+    })
+  })
+
+  it('encodes non-ascii provider names as utf-8 base64url', () => {
+    const params = paramsFromDeeplink(
+      buildRelaySwitchProviderImportDeeplink({
+        name: '测试站点',
+        baseUrl: 'https://api.example.com',
+        apiKey: 'sk-test'
+      })
+    )
+
+    expect(decodePayload(params.get('payload') || '')).toEqual({
+      name: '测试站点',
+      baseUrl: 'https://api.example.com',
+      apiKey: 'sk-test'
+    })
+  })
+
+  it('uses url-safe base64 without padding', () => {
+    const params = paramsFromDeeplink(
+      buildRelaySwitchProviderImportDeeplink({
+        name: 'Sub2API',
+        baseUrl: 'https://api.example.com',
+        apiKey: 'sk-test'
+      })
+    )
+    const payload = params.get('payload') || ''
+
+    expect(payload).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(payload).not.toContain('=')
+    expect(payload).not.toContain('+')
+    expect(payload).not.toContain('/')
+  })
+})

--- a/frontend/src/utils/relayswitchImport.ts
+++ b/frontend/src/utils/relayswitchImport.ts
@@ -1,0 +1,31 @@
+export interface RelaySwitchProviderImportInput {
+  name: string
+  baseUrl: string
+  apiKey: string
+}
+
+function toBase64UrlUtf8(value: unknown): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(value))
+  let binary = ''
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+}
+
+export function buildRelaySwitchProviderImportDeeplink(
+  input: RelaySwitchProviderImportInput
+): string {
+  const payload = toBase64UrlUtf8({
+    name: input.name,
+    baseUrl: input.baseUrl,
+    apiKey: input.apiKey
+  })
+
+  return `relay-switch://v1/import?resource=provider&payload=${payload}`
+}

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -328,6 +328,15 @@
                 <Icon name="upload" size="sm" />
                 <span class="text-xs">{{ t('keys.importToCcSwitch') }}</span>
               </button>
+              <!-- Import to RelaySwitch Button -->
+              <button
+                v-if="!publicSettings?.hide_ccs_import_button"
+                @click="importToRelaySwitch(row)"
+                class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-teal-50 hover:text-teal-600 dark:hover:bg-teal-900/20 dark:hover:text-teal-400"
+              >
+                <Icon name="link" size="sm" />
+                <span class="text-xs">{{ t('keys.importToRelaySwitch') }}</span>
+              </button>
               <!-- Toggle Status Button -->
               <button
                 @click="toggleKeyStatus(row)"
@@ -1077,6 +1086,7 @@ import {
   buildCcSwitchImportDeeplink,
   type CcSwitchClientType
 } from '@/utils/ccswitchImport'
+import { buildRelaySwitchProviderImportDeeplink } from '@/utils/relayswitchImport'
 
 // Helper to format date for datetime-local input
 const formatDateTimeLocal = (isoDate: string): string => {
@@ -1153,6 +1163,7 @@ const dropdownRef = ref<HTMLElement | null>(null)
 const dropdownPosition = ref<{ top?: number; bottom?: number; left: number } | null>(null)
 const groupButtonRefs = ref<Map<number, HTMLElement>>(new Map())
 let abortController: AbortController | null = null
+let relaySwitchLaunchReminderTimer: ReturnType<typeof setTimeout> | null = null
 
 // Get the currently selected key for group change
 const selectedKeyForGroup = computed(() => {
@@ -1762,6 +1773,48 @@ const closeCcsClientSelect = () => {
   pendingCcsRow.value = null
 }
 
+const clearRelaySwitchLaunchReminder = () => {
+  if (relaySwitchLaunchReminderTimer) {
+    clearTimeout(relaySwitchLaunchReminderTimer)
+    relaySwitchLaunchReminderTimer = null
+  }
+}
+
+const importToRelaySwitch = (row: ApiKey) => {
+  const baseUrl = publicSettings.value?.api_base_url || window.location.origin
+  const providerName = (publicSettings.value?.site_name || 'sub2api').trim() || 'sub2api'
+  const deeplink = buildRelaySwitchProviderImportDeeplink({
+    name: providerName,
+    baseUrl,
+    apiKey: row.key
+  })
+
+  clearRelaySwitchLaunchReminder()
+
+  const handleVisibilityChange = () => {
+    if (document.visibilityState === 'hidden') {
+      clearRelaySwitchLaunchReminder()
+    }
+  }
+
+  try {
+    document.addEventListener('visibilitychange', handleVisibilityChange, { once: true })
+    window.location.href = deeplink
+
+    relaySwitchLaunchReminderTimer = setTimeout(() => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+      if (document.visibilityState !== 'hidden' && document.hasFocus()) {
+        appStore.showError(t('keys.relaySwitchNotInstalled'))
+      }
+      relaySwitchLaunchReminderTimer = null
+    }, 1400)
+  } catch (error) {
+    document.removeEventListener('visibilitychange', handleVisibilityChange)
+    clearRelaySwitchLaunchReminder()
+    appStore.showError(t('keys.relaySwitchNotInstalled'))
+  }
+}
+
 function formatResetTime(resetAt: string | null): string {
   if (!resetAt) return ''
   const diff = new Date(resetAt).getTime() - now.value.getTime()
@@ -1786,5 +1839,6 @@ onMounted(() => {
 onUnmounted(() => {
   document.removeEventListener('click', closeGroupSelector)
   if (resetTimer) clearInterval(resetTimer)
+  clearRelaySwitchLaunchReminder()
 })
 </script>

--- a/frontend/src/views/user/__tests__/KeysView.relaySwitch.spec.ts
+++ b/frontend/src/views/user/__tests__/KeysView.relaySwitch.spec.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+
+import KeysView from '../KeysView.vue'
+
+const {
+  buildRelaySwitchProviderImportDeeplink,
+  getAvailable,
+  getDashboardApiKeysUsage,
+  getPublicSettings,
+  getUserGroupRates,
+  list,
+  showError
+} = vi.hoisted(() => ({
+  buildRelaySwitchProviderImportDeeplink: vi.fn(),
+  getAvailable: vi.fn(),
+  getDashboardApiKeysUsage: vi.fn(),
+  getPublicSettings: vi.fn(),
+  getUserGroupRates: vi.fn(),
+  list: vi.fn(),
+  showError: vi.fn()
+}))
+
+const messages: Record<string, string> = {
+  'keys.importToCcSwitch': 'Import to CCS',
+  'keys.importToRelaySwitch': 'Import to RS',
+  'keys.relaySwitchNotInstalled': 'RelaySwitch missing'
+}
+
+vi.mock('@/api', () => ({
+  authAPI: {
+    getPublicSettings
+  },
+  keysAPI: {
+    list
+  },
+  usageAPI: {
+    getDashboardApiKeysUsage
+  },
+  userGroupsAPI: {
+    getAvailable,
+    getUserGroupRates
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError
+  })
+}))
+
+vi.mock('@/stores/onboarding', () => ({
+  useOnboardingStore: () => ({
+    isCurrentStep: vi.fn(() => false),
+    nextStep: vi.fn()
+  })
+}))
+
+vi.mock('@/utils/relayswitchImport', () => ({
+  buildRelaySwitchProviderImportDeeplink
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => messages[key] ?? key
+    })
+  }
+})
+
+const publicSettings = {
+  registration_enabled: true,
+  email_verify_enabled: false,
+  force_email_on_third_party_signup: false,
+  registration_email_suffix_whitelist: [],
+  promo_code_enabled: false,
+  password_reset_enabled: true,
+  invitation_code_enabled: false,
+  turnstile_enabled: false,
+  turnstile_site_key: '',
+  site_name: 'Test Site',
+  site_logo: '',
+  site_subtitle: '',
+  api_base_url: 'https://api.example.com',
+  contact_info: '',
+  doc_url: '',
+  home_content: '',
+  hide_ccs_import_button: false,
+  payment_enabled: false,
+  risk_control_enabled: false,
+  table_default_page_size: 20,
+  table_page_size_options: [10, 20, 50],
+  custom_menu_items: [],
+  custom_endpoints: [],
+  linuxdo_oauth_enabled: false,
+  wechat_oauth_enabled: false
+}
+
+const apiKeyRow = {
+  id: 1,
+  name: 'Primary key',
+  key: 'sk-row',
+  status: 'active',
+  group_id: null,
+  group: null,
+  quota: null,
+  quota_used: 0,
+  rate_limit_5h: null,
+  rate_limit_1d: null,
+  rate_limit_7d: null,
+  rate_limit_5h_used: 0,
+  rate_limit_1d_used: 0,
+  rate_limit_7d_used: 0,
+  rate_limit_5h_reset_at: null,
+  rate_limit_1d_reset_at: null,
+  rate_limit_7d_reset_at: null,
+  expires_at: null,
+  last_used_at: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z'
+}
+
+const AppLayoutStub = { template: '<div><slot /></div>' }
+const TablePageLayoutStub = {
+  template: '<div><slot name="filters" /><slot name="actions" /><slot name="table" /><slot /></div>'
+}
+const DataTableStub = {
+  props: ['data'],
+  template: `
+    <div>
+      <div v-for="row in data" :key="row.id">
+        <slot name="cell-actions" :row="row" />
+      </div>
+    </div>
+  `
+}
+const IconStub = {
+  props: ['name'],
+  template: '<span :data-icon="name" />'
+}
+
+function mountView() {
+  return mount(KeysView, {
+    global: {
+      stubs: {
+        AppLayout: AppLayoutStub,
+        TablePageLayout: TablePageLayoutStub,
+        DataTable: DataTableStub,
+        Icon: IconStub,
+        BaseDialog: true,
+        ConfirmDialog: true,
+        EmptyState: true,
+        EndpointPopover: true,
+        GroupBadge: true,
+        GroupOptionItem: true,
+        Pagination: true,
+        SearchInput: true,
+        Select: true,
+        UseKeyModal: true
+      }
+    }
+  })
+}
+
+describe('KeysView RelaySwitch import', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    buildRelaySwitchProviderImportDeeplink.mockReset()
+    buildRelaySwitchProviderImportDeeplink.mockReturnValue('#relay-switch-import')
+    getAvailable.mockReset()
+    getAvailable.mockResolvedValue([])
+    getDashboardApiKeysUsage.mockReset()
+    getDashboardApiKeysUsage.mockResolvedValue({ stats: {} })
+    getPublicSettings.mockReset()
+    getPublicSettings.mockResolvedValue(publicSettings)
+    getUserGroupRates.mockReset()
+    getUserGroupRates.mockResolvedValue({})
+    list.mockReset()
+    list.mockResolvedValue({
+      items: [apiKeyRow],
+      total: 1,
+      pages: 1
+    })
+    showError.mockReset()
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      value: 'visible'
+    })
+    vi.spyOn(document, 'hasFocus').mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('shows the RelaySwitch import button beside the CCS import button', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Import to CCS')
+    expect(wrapper.text()).toContain('Import to RS')
+  })
+
+  it('hides the RelaySwitch import button when CCS import is hidden', async () => {
+    getPublicSettings.mockResolvedValue({
+      ...publicSettings,
+      hide_ccs_import_button: true
+    })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Import to CCS')
+    expect(wrapper.text()).not.toContain('Import to RS')
+  })
+
+  it('builds a RelaySwitch provider deeplink and warns when the protocol handler does not open', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const importButton = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('Import to RS'))
+    expect(importButton).toBeTruthy()
+
+    await importButton!.trigger('click')
+    await nextTick()
+
+    expect(buildRelaySwitchProviderImportDeeplink).toHaveBeenCalledWith({
+      name: 'Test Site',
+      baseUrl: 'https://api.example.com',
+      apiKey: 'sk-row'
+    })
+
+    vi.advanceTimersByTime(1400)
+    await nextTick()
+
+    expect(showError).toHaveBeenCalledWith('RelaySwitch missing')
+  })
+})


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA

添加支持将密钥一键导入到RelaySwitch中使用。
RelaySwitch是一个一键切换中转站和大模型的开源工具
github地址: [https://github.com/xiaoyuandev/relay-switch](https://github.com/xiaoyuandev/relay-switch)

<img width="1360" height="590" alt="image" src="https://github.com/user-attachments/assets/8caf607d-069d-4ae6-a50c-3ab86f2aaca5" />

<img width="2710" height="1746" alt="5f436010bc0f5f28a6ac547f40f5810a" src="https://github.com/user-attachments/assets/0a29df3e-cf9f-4275-bdd4-7fe1269d49c0" />
