### PR TITLE
优化账号分组调度索引 / Add two concurrent composite indexes

### DIFF
--- a/backend/migrations/150_account_group_scheduler_indexes_notx.sql
+++ b/backend/migrations/150_account_group_scheduler_indexes_notx.sql
@@ -1,0 +1,5 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_account_groups_group_priority_account
+    ON account_groups (group_id, priority, account_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_account_groups_account_priority_group
+    ON account_groups (account_id, priority, group_id);


### PR DESCRIPTION
## 变更内容

新增 `account_groups` 复合并发索引：

- `(group_id, priority, account_id)`
- `(account_id, priority, group_id)`

用于优化账号调度路径中高频的分组账号查询和账号分组补齐查询。

## 性能影响预估

`account_groups` 表数据量 ：约 100,390 行
 `accounts` 表数据量 ：约 258,281 行

 
| 指标 | 优化前 | 优化后 | 
| --- | --- | --- | 
| 当前 Postgres CPU | 约 72% | 约 50% - 60% | 
| 全部 SQL 总执行时间 | 约 8,272s | 下降约 8% - 18% | 
| `account_groups` 相关 SQL 总执行时间 | 约 3,058s，占 36.97% | 下降约 25% - 45% | 
| 新索引直接命中的 SQL 总执行时间 | 约 1,306s，占全部 SQL 约 15.8% | 明显下降 | 
| 分组调度查询 | 典型单次约 228ms | 明显降低 `account_groups` 扫描/排序成本 | 
| 账号分组补齐查询 | 1000 个账号模拟约 45ms，当前可能全表扫描 | 避免全表扫和额外排序 | 

 `accounts WHERE id IN (...)` ：当前仍是主要瓶颈之一 
 

## Change Description

Added compound concurrent indexes on `account_groups`:

- `(group_id, priority, account_id)`
- `(account_id, priority, group_id)`

These indexes are used to optimize high-frequency queries in the account scheduling path, specifically group-based account queries and account-to-group completion queries.

## Performance Impact Estimation

`account_groups` table row count: ~100,390 rows  
`accounts` table row count: ~258,281 rows

| Metric | Before Optimization | After Optimization |
| --- | --- | --- |
| Current PostgreSQL CPU | ~72% | ~50% – 60% |
| Total SQL execution time | ~8,272s | Decrease by ~8% – 18% |
| Total execution time for queries related to `account_groups` | ~3,058s (36.97% of total) | Decrease by ~25% – 45% |
| Total execution time for queries that directly hit the new indexes | ~1,306s (~15.8% of total) | Significant decrease |
| Group scheduling query | ~228ms per typical query | Significantly reduced scan/sort cost on `account_groups` |
| Account‑group completion query | ~45ms for 1,000 simulated accounts; currently may perform full table scan | Avoids full table scan and extra sorting |

`accounts WHERE id IN (...)` remains a major bottleneck.