### PR TITLE
fix: normalize image response metadata usage

### DIFF
--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -692,7 +692,11 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 			ImageOutputSizes: imageOutputSizes,
 		}, nil
 	} else {
-		nonStreamUsage, nonStreamCount, nonStreamSizes, err := s.handleOpenAIImagesNonStreamingResponse(resp, c)
+		clientModel := strings.TrimSpace(parsed.Model)
+		if clientModel == "" {
+			clientModel = requestModel
+		}
+		nonStreamUsage, nonStreamCount, nonStreamSizes, err := s.handleOpenAIImagesNonStreamingResponse(resp, c, clientModel, parsed.Quality, parsed.Size)
 		if err != nil {
 			return nil, err
 		}
@@ -853,11 +857,16 @@ func cloneMultipartHeader(src textproto.MIMEHeader) textproto.MIMEHeader {
 	return dst
 }
 
-func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponse(resp *http.Response, c *gin.Context) (OpenAIUsage, int, []string, error) {
+func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponse(resp *http.Response, c *gin.Context, requestedModel string, requestedQuality string, fallbackSize string) (OpenAIUsage, int, []string, error) {
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
 		return OpenAIUsage{}, 0, nil, err
 	}
+	usage, _ := extractOpenAIUsageFromJSONBytes(body)
+	imageCount := extractOpenAIImageCountFromJSONBytes(body)
+	imageOutputSizes := collectOpenAIResponseImageOutputSizesFromJSONBytes(body)
+	body, usage = normalizeOpenAIImagesResponseMetadata(body, usage, imageCount, imageOutputSizes, requestedModel, requestedQuality, fallbackSize)
+
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	contentType := "application/json"
 	if s.cfg != nil && !s.cfg.Security.ResponseHeaders.Enabled {
@@ -867,8 +876,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponse(resp *http
 	}
 	c.Data(resp.StatusCode, contentType, body)
 
-	usage, _ := extractOpenAIUsageFromJSONBytes(body)
-	return usage, extractOpenAIImageCountFromJSONBytes(body), collectOpenAIResponseImageOutputSizesFromJSONBytes(body), nil
+	return usage, imageCount, imageOutputSizes, nil
 }
 
 func (s *OpenAIGatewayService) handleOpenAIImagesStreamingResponse(
@@ -1131,6 +1139,180 @@ func mergeOpenAIUsage(dst *OpenAIUsage, body []byte) {
 			dst.ImageOutputTokens = parsed.ImageOutputTokens
 		}
 	}
+}
+
+func normalizeOpenAIImagesResponseMetadata(body []byte, usage OpenAIUsage, imageCount int, imageOutputSizes []string, requestedModel string, requestedQuality string, fallbackSize string) ([]byte, OpenAIUsage) {
+	quality := normalizeOpenAIImageQuality(requestedQuality)
+	shouldNormalizeUsage := quality != "" && quality != "auto"
+	if imageCount > 0 && shouldNormalizeUsage {
+		imageTokens := estimateOpenAIImageOutputTokens(imageOutputSizes, imageCount, requestedQuality, fallbackSize)
+		if imageTokens > 0 && (usage.OutputTokens != imageTokens || usage.ImageOutputTokens != imageTokens) {
+			usage.OutputTokens = imageTokens
+			usage.ImageOutputTokens = imageTokens
+		}
+		if usage.InputTokens < 0 {
+			usage.InputTokens = 0
+		}
+	}
+	if !gjson.ValidBytes(body) {
+		return body, usage
+	}
+
+	patched := body
+	setIfMissingOrZero := func(path string, value int) {
+		current := gjson.GetBytes(patched, path)
+		if !current.Exists() || current.Int() == 0 {
+			if next, err := sjson.SetBytes(patched, path, value); err == nil {
+				patched = next
+			}
+		}
+	}
+	setInt := func(path string, value int) {
+		if next, err := sjson.SetBytes(patched, path, value); err == nil {
+			patched = next
+		}
+	}
+	setStringIfNeeded := func(path string, value string, replaceAuto bool) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		current := strings.TrimSpace(gjson.GetBytes(patched, path).String())
+		if current == "" || (replaceAuto && strings.EqualFold(current, "auto")) {
+			if next, err := sjson.SetBytes(patched, path, value); err == nil {
+				patched = next
+			}
+		}
+	}
+
+	if model := strings.TrimSpace(requestedModel); model != "" {
+		if next, err := sjson.SetBytes(patched, "model", model); err == nil {
+			patched = next
+		}
+	}
+	if quality != "" && quality != "auto" {
+		if next, err := sjson.SetBytes(patched, "quality", quality); err == nil {
+			patched = next
+		}
+	}
+
+	if imageCount > 0 && usage.OutputTokens > 0 && shouldNormalizeUsage {
+		setIfMissingOrZero("usage.input_tokens", usage.InputTokens)
+		setInt("usage.output_tokens", usage.OutputTokens)
+		setInt("usage.output_tokens_details.image_tokens", usage.ImageOutputTokens)
+		setInt("usage.output_tokens_details.text_tokens", 0)
+		setIfMissingOrZero("usage.input_tokens_details.image_tokens", 0)
+		setIfMissingOrZero("usage.input_tokens_details.text_tokens", usage.InputTokens)
+		setInt("usage.total_tokens", usage.InputTokens+usage.OutputTokens)
+	}
+
+	if size := selectOpenAIImageSizeForMetadata(imageOutputSizes, fallbackSize); strings.TrimSpace(size) != "" {
+		setStringIfNeeded("size", size, true)
+		data := gjson.GetBytes(patched, "data")
+		if data.IsArray() {
+			for idx, item := range data.Array() {
+				if strings.TrimSpace(item.Get("size").String()) == "" || strings.EqualFold(strings.TrimSpace(item.Get("size").String()), "auto") {
+					if next, err := sjson.SetBytes(patched, fmt.Sprintf("data.%d.size", idx), size); err == nil {
+						patched = next
+					}
+				}
+			}
+		}
+	}
+	return patched, usage
+}
+
+func estimateOpenAIImageOutputTokens(outputSizes []string, imageCount int, quality string, fallbackSize string) int {
+	if imageCount <= 0 {
+		return 0
+	}
+	sizes := compactTrimmedStrings(outputSizes)
+	if len(sizes) == 0 {
+		sizes = []string{fallbackSize}
+	}
+	total := 0
+	for idx := 0; idx < imageCount; idx++ {
+		size := ""
+		if idx < len(sizes) {
+			size = sizes[idx]
+		} else if len(sizes) > 0 {
+			size = sizes[len(sizes)-1]
+		}
+		if strings.EqualFold(strings.TrimSpace(size), "auto") || strings.TrimSpace(size) == "" {
+			size = fallbackSize
+		}
+		total += estimateOpenAIImageOutputTokensForSizeQuality(size, quality)
+	}
+	return total
+}
+
+func estimateOpenAIImageOutputTokensForSizeQuality(size string, quality string) int {
+	q := normalizeOpenAIImageQuality(quality)
+	if q == "" || q == "auto" {
+		q = "medium"
+	}
+	switch normalizeOpenAIImageDimensionKey(size) {
+	case "1024x1024":
+		return openAIImageTokenByQuality(q, 196, 1756, 7024)
+	case "1024x1536", "1536x1024":
+		return openAIImageTokenByQuality(q, 168, 1372, 5488)
+	case "2048x2048":
+		return openAIImageTokenByQuality(q, 397, 3568, 14272)
+	case "1152x2048", "2048x1152":
+		return openAIImageTokenByQuality(q, 229, 2223, 8892)
+	case "2160x3840", "3840x2160":
+		return openAIImageTokenByQuality(q, 1543, 7919, 23719)
+	}
+	switch NormalizeImageBillingTierOrDefault(size) {
+	case ImageBillingSize1K:
+		return openAIImageTokenByQuality(q, 196, 1756, 7024)
+	case ImageBillingSize4K:
+		return openAIImageTokenByQuality(q, 1543, 7919, 23719)
+	default:
+		return openAIImageTokenByQuality(q, 397, 3568, 14272)
+	}
+}
+
+func openAIImageTokenByQuality(quality string, low int, medium int, high int) int {
+	switch normalizeOpenAIImageQuality(quality) {
+	case "low":
+		return low
+	case "high":
+		return high
+	default:
+		return medium
+	}
+}
+
+func normalizeOpenAIImageQuality(quality string) string {
+	switch strings.ToLower(strings.TrimSpace(quality)) {
+	case "low", "medium", "high", "auto":
+		return strings.ToLower(strings.TrimSpace(quality))
+	default:
+		return ""
+	}
+}
+
+func normalizeOpenAIImageDimensionKey(size string) string {
+	width, height, ok := parseImageBillingDimensions(size)
+	if !ok {
+		return strings.ToLower(strings.TrimSpace(size))
+	}
+	return fmt.Sprintf("%dx%d", width, height)
+}
+
+func selectOpenAIImageSizeForMetadata(outputSizes []string, fallbackSize string) string {
+	for _, output := range outputSizes {
+		trimmed := strings.TrimSpace(output)
+		if trimmed != "" && !strings.EqualFold(trimmed, "auto") {
+			return trimmed
+		}
+	}
+	fallbackSize = strings.TrimSpace(fallbackSize)
+	if fallbackSize != "" {
+		return fallbackSize
+	}
+	return firstDisplayImageOutputSize(outputSizes)
 }
 
 func extractOpenAIImageCountFromJSONBytes(body []byte) int {

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -892,6 +892,7 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 	c *gin.Context,
 	responseFormat string,
 	fallbackModel string,
+	requestedQuality string,
 ) (OpenAIUsage, int, []string, error) {
 	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
 	if err != nil {
@@ -914,17 +915,28 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 		}
 		return OpenAIUsage{}, 0, nil, fmt.Errorf("upstream did not return image output")
 	}
-	if strings.TrimSpace(firstMeta.Model) == "" {
+	if strings.TrimSpace(fallbackModel) != "" {
 		firstMeta.Model = strings.TrimSpace(fallbackModel)
+	}
+	if quality := normalizeOpenAIImageQuality(requestedQuality); quality != "" && quality != "auto" {
+		firstMeta.Quality = quality
 	}
 
 	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
 	if err != nil {
 		return OpenAIUsage{}, 0, nil, err
 	}
+	imageOutputSizes := openAIResponsesImageResultSizes(results)
+	if parsedUsage, ok := extractOpenAIUsageFromJSONBytes(responseBody); ok {
+		mergeOpenAIUsage(&usage, responseBody)
+		if usage.InputTokens == 0 {
+			usage.InputTokens = parsedUsage.InputTokens
+		}
+	}
+	responseBody, usage = normalizeOpenAIImagesResponseMetadata(responseBody, usage, len(results), imageOutputSizes, firstMeta.Model, requestedQuality, firstMeta.Size)
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
-	return usage, len(results), openAIResponsesImageResultSizes(results), nil
+	return usage, len(results), imageOutputSizes, nil
 }
 
 func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
@@ -1397,7 +1409,7 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesOAuth(
 			return nil, err
 		}
 	} else {
-		usage, imageCount, imageOutputSizes, err = s.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, parsed.ResponseFormat, requestModel)
+		usage, imageCount, imageOutputSizes, err = s.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, parsed.ResponseFormat, requestModel, parsed.Quality)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -624,8 +624,8 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.Equal(t, "gpt-image-2", result.UpstreamModel)
 	require.Equal(t, 3, result.ImageCount)
 	require.Equal(t, 11, result.Usage.InputTokens)
-	require.Equal(t, 22, result.Usage.OutputTokens)
-	require.Equal(t, 7, result.Usage.ImageOutputTokens)
+	require.Equal(t, 21072, result.Usage.OutputTokens)
+	require.Equal(t, 21072, result.Usage.ImageOutputTokens)
 
 	require.NotNil(t, upstream.lastReq)
 	require.Equal(t, chatgptCodexURL, upstream.lastReq.URL.String())
@@ -820,6 +820,114 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyGenerationUsesConfiguredV1BaseU
 	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "aGVsbG8=", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
+}
+
+func TestOpenAIGatewayServiceForwardImages_APIKeyNormalizesImageMetadataAndUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2-sp","prompt":"draw a cat","size":"1024x1024","quality":"high","response_format":"b64_json"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{},
+		httpUpstream: &httpUpstreamRecorder{
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"X-Request-Id": []string{"req_img_apikey_metadata"},
+				},
+				Body: io.NopCloser(strings.NewReader(`{"created":1710000011,"model":"gpt-image-2-codex","quality":"auto","size":"1024x1024","data":[{"b64_json":"aGVsbG8=","size":"1024x1024"}],"usage":{"input_tokens":40,"output_tokens":196,"output_tokens_details":{"image_tokens":196,"text_tokens":0},"total_tokens":236}}`)),
+			},
+		},
+	}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	account := &Account{
+		ID:       6,
+		Name:     "openai-apikey",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key": "test-api-key",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, 40, result.Usage.InputTokens)
+	require.Equal(t, 7024, result.Usage.OutputTokens)
+	require.Equal(t, 7024, result.Usage.ImageOutputTokens)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "gpt-image-2-sp", gjson.Get(rec.Body.String(), "model").String())
+	require.Equal(t, "high", gjson.Get(rec.Body.String(), "quality").String())
+	require.Equal(t, int64(7024), gjson.Get(rec.Body.String(), "usage.output_tokens").Int())
+	require.Equal(t, int64(7024), gjson.Get(rec.Body.String(), "usage.output_tokens_details.image_tokens").Int())
+	require.Equal(t, int64(7064), gjson.Get(rec.Body.String(), "usage.total_tokens").Int())
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthNormalizesImageMetadataAndUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2-sp","prompt":"draw a cat","size":"1536x1024","quality":"medium","response_format":"b64_json"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	c.Set("api_key", &APIKey{ID: 42})
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	svc.httpUpstream = &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"text/event-stream"},
+				"X-Request-Id": []string{"req_img_oauth_metadata"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000012,\"usage\":{\"input_tokens\":35,\"output_tokens\":196,\"output_tokens_details\":{\"image_tokens\":196,\"text_tokens\":0}},\"tool_usage\":{\"image_gen\":{\"images\":1}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2U=\",\"output_format\":\"png\",\"quality\":\"auto\",\"size\":\"1536x1024\",\"model\":\"gpt-image-2-codex\"}]}}\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+
+	account := &Account{
+		ID:       1,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, 35, result.Usage.InputTokens)
+	require.Equal(t, 1372, result.Usage.OutputTokens)
+	require.Equal(t, 1372, result.Usage.ImageOutputTokens)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "gpt-image-2-sp", gjson.Get(rec.Body.String(), "model").String())
+	require.Equal(t, "medium", gjson.Get(rec.Body.String(), "quality").String())
+	require.Equal(t, "1536x1024", gjson.Get(rec.Body.String(), "size").String())
+	require.Equal(t, int64(1372), gjson.Get(rec.Body.String(), "usage.output_tokens").Int())
+	require.Equal(t, int64(1372), gjson.Get(rec.Body.String(), "usage.output_tokens_details.image_tokens").Int())
+	require.Equal(t, int64(1407), gjson.Get(rec.Body.String(), "usage.total_tokens").Int())
 }
 
 func TestOpenAIGatewayServiceForwardImages_APIKeyStreamJSONResponseBillsImage(t *testing.T) {


### PR DESCRIPTION
## Summary
- normalize OpenAI Images API response metadata back to the requested model and explicit quality
- normalize image usage token fields for explicit low/medium/high requests using the image size/quality table
- apply the same normalization to API key and OAuth/Responses non-streaming image paths

## Tests
- go test ./internal/service -run OpenAIGatewayServiceForwardImages|OpenAIImages|ImageOutput|ImageBilling|NormalizeImage -count=1