### PR TITLE
Move pnpm from package.json to pnpm-workspace.yaml

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -57,10 +57,5 @@
     "vite-plugin-checker": "^0.9.1",
     "vitest": "^2.1.9",
     "vue-tsc": "^2.2.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "js-cookie": "3.0.7"
-    }
   }
 }

--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  esbuild: true
+  vue-demi: true
+overrides:
+  "js-cookie": "3.0.7"


### PR DESCRIPTION
Move pnpm config to workspace file to match the pnpm 11 migration guide: https://pnpm.io/migration.

Before this `pnpm install` gives warning and asks explicit confirmation for building some packages. On the latest stable tag (v0.1.135) it will sliently modify package.json which makes building with nix fail (package.json doesn't match lock).

After modification `pnpm install` and `pnpm run build` gives no warning and no manual confirmation needed.