### PR TITLE
fix: treat invalid_refresh_token as non-retryable / 将 invalid_refresh_token 判定为不可重试

### DIFF
--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -440,12 +440,13 @@ func isNonRetryableRefreshError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	nonRetryable := []string{
-		"invalid_grant",        // refresh_token 已失效
-		"refresh_token_reused", // OpenAI refresh_token 已被使用，必须重新授权
-		"invalid_client",       // 客户端配置错误
-		"unauthorized_client",  // 客户端未授权
-		"access_denied",        // 访问被拒绝
-		"missing_project_id",   // 缺少 project_id
+		"invalid_grant",         // refresh_token 已失效
+		"invalid_refresh_token", // refresh_token 无效, team 账号工作区被删除会出现
+		"refresh_token_reused",  // OpenAI refresh_token 已被使用，必须重新授权
+		"invalid_client",        // 客户端配置错误
+		"unauthorized_client",   // 客户端未授权
+		"access_denied",         // 访问被拒绝
+		"missing_project_id",    // 缺少 project_id
 		"no refresh token available",
 	}
 	for _, needle := range nonRetryable {

--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -440,13 +440,14 @@ func isNonRetryableRefreshError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	nonRetryable := []string{
-		"invalid_grant",         // refresh_token 已失效
-		"invalid_refresh_token", // refresh_token 无效, team 账号工作区被删除会出现
-		"refresh_token_reused",  // OpenAI refresh_token 已被使用，必须重新授权
-		"invalid_client",        // 客户端配置错误
-		"unauthorized_client",   // 客户端未授权
-		"access_denied",         // 访问被拒绝
-		"missing_project_id",    // 缺少 project_id
+		"invalid_grant",          // refresh_token 已失效
+		"invalid_refresh_token",  // refresh_token 无效, team 账号工作区被删除会出现
+		"app_session_terminated", // refresh_token team 账号工作区被删除
+		"refresh_token_reused",   // OpenAI refresh_token 已被使用，必须重新授权
+		"invalid_client",         // 客户端配置错误
+		"unauthorized_client",    // 客户端未授权
+		"access_denied",          // 访问被拒绝
+		"missing_project_id",     // 缺少 project_id
 		"no refresh token available",
 	}
 	for _, needle := range nonRetryable {

--- a/backend/internal/service/token_refresh_service_test.go
+++ b/backend/internal/service/token_refresh_service_test.go
@@ -534,6 +534,7 @@ func TestIsNonRetryableRefreshError(t *testing.T) {
 		{name: "invalid_client", err: errors.New("invalid_client"), expected: true},
 		{name: "invalid_refresh_token", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"invalid_refresh_token"}}`), expected: true},
 		{name: "refresh_token_reused", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"refresh_token_reused"}}`), expected: true},
+		{name: "app_session_terminated", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error": {"code": "app_session_terminated"}}`), expected: true},
 		{name: "unauthorized_client", err: errors.New("unauthorized_client"), expected: true},
 		{name: "access_denied", err: errors.New("access_denied"), expected: true},
 		{name: "no_refresh_token", err: errors.New("no refresh token available"), expected: true},

--- a/backend/internal/service/token_refresh_service_test.go
+++ b/backend/internal/service/token_refresh_service_test.go
@@ -532,6 +532,7 @@ func TestIsNonRetryableRefreshError(t *testing.T) {
 		{name: "network_error", err: errors.New("network timeout"), expected: false},
 		{name: "invalid_grant", err: errors.New("invalid_grant"), expected: true},
 		{name: "invalid_client", err: errors.New("invalid_client"), expected: true},
+		{name: "invalid_refresh_token", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"invalid_refresh_token"}}`), expected: true},
 		{name: "refresh_token_reused", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"refresh_token_reused"}}`), expected: true},
 		{name: "unauthorized_client", err: errors.New("unauthorized_client"), expected: true},
 		{name: "access_denied", err: errors.New("access_denied"), expected: true},


### PR DESCRIPTION
日志里出现大量重试,性能下降严重，排查了原因，发现team账号失效有部分会报```invalid_refresh_token```,没有纳入不可重试错误。
```
2026/6/10 04:30:14	warn	token_refresh.account_refresh_failed acc=267892 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Invalid refresh token.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"invalid_refresh_token\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 04:30:14	warn	token_refresh.retry_exhausted acc=267892 platform=openai error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Invalid refresh token.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"invalid_refresh_token\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 04:30:14	warn	token_refresh.retry_attempt_failed acc=267892 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Invalid refresh token.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"invalid_refresh_token\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 04:30:10	warn	token_refresh.retry_attempt_failed acc=267892 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Invalid refresh token.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"invalid_refresh_token\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 04:30:08	warn	token_refresh.retry_attempt_failed acc=267892 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Invalid refresh token.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"invalid_refresh_token\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 04:30:01	warn	token_refresh.account_refresh_failed acc=268336 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Invalid refresh token.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"invalid_refresh_token\"\n }\n}" metadata=map[upstream_status:400]
```


补充一个 ·```app_session_terminated```
```
2026/6/10 22:22:06	warn	token_refresh.retry_attempt_failed acc=69276 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Your session has ended. Please log in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"app_session_terminated\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 22:22:04	warn	token_refresh.retry_attempt_failed acc=69276 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Your session has ended. Please log in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"app_session_terminated\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 22:22:03	warn	token_refresh.account_refresh_failed acc=69373 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Your session has ended. Please log in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"app_session_terminated\"\n }\n}" metadata=map[upstream_status:400]
2026/6/10 22:22:03	warn	token_refresh.retry_exhausted acc=69373 platform=openai error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 400, body: {\n \"error\": {\n \"message\": \"Your session has ended. Please log in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"app_session_terminated\"\n }\n}" metadata=map[upstream_status:400]
```


