### PR TITLE
fix(admin/accounts): show real count in bulk-delete confirm & clear s…

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3091,6 +3091,7 @@ export default {
       crsBack: 'Back',
       editAccount: 'Edit Account',
       deleteAccount: 'Delete Account',
+      bulkDeleteConfirm: 'Are you sure you want to delete the {count} selected account(s)? This action cannot be undone.',
       searchAccounts: 'Search accounts...',
       notes: 'Notes',
       notesPlaceholder: 'Enter notes',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3167,6 +3167,7 @@ export default {
       editAccount: '编辑账号',
       deleteAccount: '删除账号',
       deleteConfirmMessage: "确定要删除账号 '{name}' 吗？",
+      bulkDeleteConfirm: '确定要删除选中的 {count} 个账号吗？此操作无法撤销。',
       refreshCookie: '刷新 Cookie',
       testAccount: '测试账号',
       searchAccounts: '搜索账号...',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -822,6 +822,8 @@ const debouncedReload = () => {
   hasPendingListSync.value = false
   resetAutoRefreshCache()
   pendingTodayStatsRefresh.value = true
+  // 筛选/搜索（作用域）变化时清理选择，避免删除到屏幕外残留的旧选择
+  clearSelection()
   baseDebouncedReload()
 }
 
@@ -1227,7 +1229,18 @@ const toggleSelectAllVisible = (event: Event) => {
   const target = event.target as HTMLInputElement
   toggleVisible(target.checked)
 }
-const handleBulkDelete = async () => { if(!confirm(t('common.confirm'))) return; try { await Promise.all(selIds.value.map(id => adminAPI.accounts.delete(id))); clearSelection(); reload() } catch (error) { console.error('Failed to bulk delete accounts:', error) } }
+const handleBulkDelete = async () => {
+  const count = selIds.value.length
+  if (count === 0) return
+  if (!confirm(t('admin.accounts.bulkDeleteConfirm', { count }))) return
+  try {
+    await Promise.all(selIds.value.map(id => adminAPI.accounts.delete(id)))
+    clearSelection()
+    reload()
+  } catch (error) {
+    console.error('Failed to bulk delete accounts:', error)
+  }
+}
 const handleBulkResetStatus = async () => {
   if (!confirm(t('common.confirm'))) return
   try {


### PR DESCRIPTION
…election on filter/search change

批量删除确认显示真实数量，并在筛选/搜索变化时清空选择

Batch delete could remove more accounts than visibly selected because the selection ID set persists across pagination/filter/search and the confirm prompt showed no count. Now the confirm dialog shows the real count and stale selection is cleared when the filter/search scope changes; pagination and sort keep their selection by design.

批量删除会删掉比可见选中更多的账号：选择 ID 集合跨分页/筛选/搜索累积，且确认
框不显示数量。现确认框显示真实数量，并在筛选/搜索作用域变化时清空残留选择；
翻页与排序按设计保留选择。

- AccountsView: handleBulkDelete confirms with {count} (+ empty guard)
- AccountsView: debouncedReload clears selection (filter/search entry)
- i18n: add admin.accounts.bulkDeleteConfirm (zh/en)