### PR TITLE
fix(docker): 将 docs/legal 纳入构建上下文以支持 admin-compliance gate

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,11 @@
 *.md
 !deploy/DOCKER.md
 docs/
+# admin-compliance gate (LegalDocumentView.vue) build-time imports
+# docs/legal/*.md?raw into the frontend bundle; keep that subtree in the
+# Docker build context even though docs/ is otherwise excluded.
+!docs/legal/
+!docs/legal/*.md
 
 # IDE
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,13 @@ RUN corepack enable && corepack prepare pnpm@9 --activate
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copy frontend source and build
+# Copy frontend source and build.
+# LegalDocumentView.vue (admin-compliance gate) build-time imports
+# ../../../../docs/legal/*.md?raw, so docs/legal/ must sit beside frontend/
+# in the image (WORKDIR /app/frontend -> resolves to /app/docs/legal/*.md).
+# Copy only that subtree to keep the build dependency minimal.
 COPY frontend/ ./
+COPY docs/legal/ /app/docs/legal/
 RUN pnpm run build
 
 # -----------------------------------------------------------------------------

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,8 +26,13 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
-# Copy frontend source and build
+# Copy frontend source and build.
+# LegalDocumentView.vue (admin-compliance gate) build-time imports
+# ../../../../docs/legal/*.md?raw, so docs/legal/ must sit beside frontend/
+# in the image (WORKDIR /app/frontend -> resolves to /app/docs/legal/*.md).
+# Copy only that subtree to keep the build dependency minimal.
 COPY frontend/ ./
+COPY docs/legal/ /app/docs/legal/
 RUN pnpm run build
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## 问题

`LegalDocumentView.vue`（admin-compliance 合规确认 gate）在构建时 import 了 `../../../../docs/legal/*.md?raw`：

```ts
import zhAdminCompliance from '../../../../docs/legal/admin-compliance.zh.md?raw'
import enAdminCompliance from '../../../../docs/legal/admin-compliance.en.md?raw'
```

这会导致 **Docker 镜像构建失败**：

```
Could not resolve "../../../../docs/legal/admin-compliance.zh.md?raw"
from "src/views/public/LegalDocumentView.vue"
```

多阶段 Dockerfile 路径下有两个原因：
1. `frontend-builder` stage 只 `COPY frontend/ ./`，从不 COPY `docs/`。
2. `.dockerignore` 把 `docs/` 和 `*.md` 都排除出构建上下文。

GitHub Actions CI 在仓库根跑 `pnpm build`（此处 `../docs/` 可解析），且从不走 Docker 构建，因此上游 CI 一直没暴露这个问题。任何构建容器镜像（`Dockerfile` / `deploy/Dockerfile`）的人都会踩到。

## 修复

- 在 `Dockerfile` 和 `deploy/Dockerfile` 中 `COPY docs/legal/ /app/docs/legal/`，使其与 `WORKDIR /app/frontend` 平级，让相对 import 解析到 `/app/docs/legal/*.md`。只复制需要的子树，保持构建依赖最小。
- 在 `.dockerignore` 中重新纳入 `docs/legal/*.md`（原先被 `docs/` 排除），使用"先排除目录、再否定文件"的标准写法，让 BuildKit 把该子树打入上下文。

未改动任何应用代码，纯构建上下文修复。