### PR TITLE
fix(gemini): support Vertex API key routing

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1582,6 +1582,7 @@ func setDefaults() {
 		"open.bigmodel.cn",
 		"api.minimaxi.com",
 		"generativelanguage.googleapis.com",
+		"aiplatform.googleapis.com",
 		"cloudcode-pa.googleapis.com",
 		"*.openai.azure.com",
 	})

--- a/backend/internal/pkg/geminicli/constants.go
+++ b/backend/internal/pkg/geminicli/constants.go
@@ -4,8 +4,9 @@ package geminicli
 import "time"
 
 const (
-	AIStudioBaseURL  = "https://generativelanguage.googleapis.com"
-	GeminiCliBaseURL = "https://cloudcode-pa.googleapis.com"
+	AIStudioBaseURL      = "https://generativelanguage.googleapis.com"
+	VertexExpressBaseURL = "https://aiplatform.googleapis.com"
+	GeminiCliBaseURL     = "https://cloudcode-pa.googleapis.com"
 
 	AuthorizeURL = "https://accounts.google.com/o/oauth2/v2/auth"
 	TokenURL     = "https://oauth2.googleapis.com/token"

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -175,6 +175,27 @@ func (a *Account) IsGemini() bool {
 	return a.Platform == PlatformGemini
 }
 
+const (
+	GeminiAPIModeAIStudio = "ai_studio"
+	GeminiAPIModeVertex   = "vertex"
+)
+
+func (a *Account) GeminiAPIMode() string {
+	if a.Platform != PlatformGemini || a.Type != AccountTypeAPIKey {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(a.GetCredential("api_mode"))) {
+	case GeminiAPIModeVertex:
+		return GeminiAPIModeVertex
+	default:
+		return GeminiAPIModeAIStudio
+	}
+}
+
+func (a *Account) IsGeminiVertexAPIKey() bool {
+	return a.GeminiAPIMode() == GeminiAPIModeVertex
+}
+
 func (a *Account) GeminiOAuthType() string {
 	if a.Platform != PlatformGemini || a.Type != AccountTypeOAuth {
 		return ""

--- a/backend/internal/service/account_base_url_test.go
+++ b/backend/internal/service/account_base_url_test.go
@@ -158,3 +158,54 @@ func TestGetGeminiBaseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGeminiAPIMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		account  Account
+		expected string
+		vertex   bool
+	}{
+		{
+			name: "gemini apikey defaults to ai studio",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{},
+			},
+			expected: GeminiAPIModeAIStudio,
+			vertex:   false,
+		},
+		{
+			name: "gemini apikey vertex mode",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			expected: GeminiAPIModeVertex,
+			vertex:   true,
+		},
+		{
+			name: "non gemini account returns empty mode",
+			account: Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformOpenAI,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			expected: "",
+			vertex:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.account.GeminiAPIMode(); got != tt.expected {
+				t.Fatalf("GeminiAPIMode() = %q, want %q", got, tt.expected)
+			}
+			if got := tt.account.IsGeminiVertexAPIKey(); got != tt.vertex {
+				t.Fatalf("IsGeminiVertexAPIKey() = %v, want %v", got, tt.vertex)
+			}
+		})
+	}
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -974,18 +974,10 @@ func (s *AccountTestService) buildGeminiAPIKeyRequest(ctx context.Context, accou
 		return nil, fmt.Errorf("no API key available")
 	}
 
-	baseURL := account.GetCredential("base_url")
-	if baseURL == "" {
-		baseURL = geminicli.AIStudioBaseURL
-	}
-	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+	fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, modelID, "streamGenerateContent", true)
 	if err != nil {
 		return nil, err
 	}
-
-	// Use streamGenerateContent for real-time feedback
-	fullURL := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse",
-		strings.TrimRight(normalizedBaseURL, "/"), modelID)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewReader(payload))
 	if err != nil {

--- a/backend/internal/service/gemini_api_key_upstream.go
+++ b/backend/internal/service/gemini_api_key_upstream.go
@@ -1,0 +1,99 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gemini"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
+)
+
+func geminiAPIKeyDefaultBaseURL(account *Account) string {
+	if account != nil && account.IsGeminiVertexAPIKey() {
+		return geminicli.VertexExpressBaseURL
+	}
+	return geminicli.AIStudioBaseURL
+}
+
+func buildGeminiAPIKeyUpstreamURL(
+	account *Account,
+	validateBaseURL func(string) (string, error),
+	model string,
+	action string,
+	stream bool,
+) (string, error) {
+	if account == nil {
+		return "", fmt.Errorf("account is nil")
+	}
+	baseURL := account.GetGeminiBaseURL(geminiAPIKeyDefaultBaseURL(account))
+	normalizedBaseURL, err := validateBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	trimmedBaseURL := strings.TrimRight(normalizedBaseURL, "/")
+	trimmedModel := strings.TrimSpace(model)
+	if trimmedModel == "" {
+		return "", fmt.Errorf("missing model")
+	}
+
+	var fullURL string
+	if account.IsGeminiVertexAPIKey() {
+		resource := geminiVertexModelResource(trimmedModel)
+		fullURL = fmt.Sprintf("%s/v1beta1/%s:%s", trimmedBaseURL, resource, action)
+	} else {
+		fullURL = fmt.Sprintf("%s/v1beta/models/%s:%s", trimmedBaseURL, trimmedModel, action)
+	}
+
+	if stream {
+		fullURL += "?alt=sse"
+	}
+	return fullURL, nil
+}
+
+func geminiVertexModelResource(model string) string {
+	trimmed := strings.Trim(strings.TrimSpace(model), "/")
+	switch {
+	case strings.HasPrefix(trimmed, "publishers/"):
+		return trimmed
+	case strings.HasPrefix(trimmed, "models/"):
+		trimmed = strings.TrimPrefix(trimmed, "models/")
+	}
+	return "publishers/google/models/" + trimmed
+}
+
+func buildGeminiVertexModelsFallback(path string) (*UpstreamHTTPResult, bool, error) {
+	trimmedPath := strings.TrimSpace(path)
+	headers := http.Header{"Content-Type": []string{"application/json; charset=utf-8"}}
+
+	switch {
+	case trimmedPath == "/v1beta/models":
+		body, err := json.Marshal(gemini.FallbackModelsList())
+		if err != nil {
+			return nil, true, err
+		}
+		return &UpstreamHTTPResult{
+			StatusCode: http.StatusOK,
+			Headers:    headers,
+			Body:       body,
+		}, true, nil
+	case strings.HasPrefix(trimmedPath, "/v1beta/models/"):
+		modelName := strings.TrimSpace(strings.TrimPrefix(trimmedPath, "/v1beta/models/"))
+		if modelName == "" {
+			return nil, true, fmt.Errorf("invalid path")
+		}
+		body, err := json.Marshal(gemini.FallbackModel(modelName))
+		if err != nil {
+			return nil, true, err
+		}
+		return &UpstreamHTTPResult{
+			StatusCode: http.StatusOK,
+			Headers:    headers,
+			Body:       body,
+		}, true, nil
+	default:
+		return nil, false, nil
+	}
+}

--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -299,19 +299,13 @@ func (s *GeminiMessagesCompatService) buildGeminiChatCompletionsUpstreamRequestF
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
-			if err != nil {
-				return nil, "", err
-			}
-
 			action := "generateContent"
 			if clientStream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
-			if clientStream {
-				fullURL += "?alt=sse"
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, action, clientStream)
+			if err != nil {
+				return nil, "", err
 			}
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -498,7 +498,8 @@ func (s *GeminiMessagesCompatService) HasAntigravityAccounts(ctx context.Context
 // 1) API key accounts (AI Studio)
 // 2) OAuth accounts without project_id (AI Studio OAuth)
 // 3) OAuth accounts explicitly marked as ai_studio
-// 4) Any remaining Gemini accounts (fallback)
+// 4) API key accounts (Vertex API key; GET models falls back to local metadata)
+// 5) Any remaining Gemini accounts (fallback)
 func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx context.Context, groupID *int64) (*Account, error) {
 	accounts, err := s.listSchedulableAccountsOnce(ctx, groupID, PlatformGemini, true)
 	if err != nil {
@@ -515,6 +516,9 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 		switch a.Type {
 		case AccountTypeAPIKey:
 			if strings.TrimSpace(a.GetCredential("api_key")) != "" {
+				if a.IsGeminiVertexAPIKey() {
+					return 3
+				}
 				return 0
 			}
 			return 9
@@ -526,7 +530,7 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 				return 2
 			}
 			// Code Assist OAuth tokens often lack AI Studio scopes for models listing.
-			return 3
+			return 4
 		case AccountTypeServiceAccount:
 			// Vertex service accounts use aiplatform.googleapis.com, not the AI Studio
 			// endpoint (generativelanguage.googleapis.com), so they cannot serve these requests.
@@ -627,19 +631,13 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
-			if err != nil {
-				return nil, "", err
-			}
-
 			action := "generateContent"
 			if req.Stream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
-			if req.Stream {
-				fullURL += "?alt=sse"
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, action, req.Stream)
+			if err != nil {
+				return nil, "", err
 			}
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)
@@ -1165,15 +1163,9 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, upstreamAction, useUpstreamStream)
 			if err != nil {
 				return nil, "", err
-			}
-
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, upstreamAction)
-			if useUpstreamStream {
-				fullURL += "?alt=sse"
 			}
 
 			upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(body))
@@ -2640,6 +2632,11 @@ func (s *GeminiMessagesCompatService) ForwardAIStudioGET(ctx context.Context, ac
 	path = strings.TrimSpace(path)
 	if path == "" || !strings.HasPrefix(path, "/") {
 		return nil, errors.New("invalid path")
+	}
+	if account.IsGeminiVertexAPIKey() {
+		if fallbackRes, handled, err := buildGeminiVertexModelsFallback(path); handled || err != nil {
+			return fallbackRes, err
+		}
 	}
 
 	baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -170,6 +170,47 @@ func TestGeminiForwardAsChatCompletions_StreamsOpenAIChunksFromGeminiSSE(t *test
 	require.Contains(t, out, "data: [DONE]")
 }
 
+func TestGeminiForwardAsChatCompletions_APIKeyVertexUsesVertexEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	httpStub := &geminiCompatHTTPUpstreamStub{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":1}}`)),
+		},
+	}
+	svc := &GeminiMessagesCompatService{
+		httpUpstream: httpStub,
+		cfg:          &config.Config{},
+	}
+	account := &Account{
+		ID:       360,
+		Platform: PlatformGemini,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "gemini-api-key",
+			"api_mode": "vertex",
+			"base_url": "https://aiplatform.googleapis.com",
+		},
+		Concurrency: 1,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gemini-3.1-flash-image","messages":[{"role":"user","content":"hi"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gemini-3.1-flash-image", result.UpstreamModel)
+	require.Equal(t, 1, httpStub.calls)
+	require.NotNil(t, httpStub.lastReq)
+	require.Equal(t, "gemini-api-key", httpStub.lastReq.Header.Get("x-goog-api-key"))
+	require.Equal(t, "https://aiplatform.googleapis.com/v1beta1/publishers/google/models/gemini-3.1-flash-image:generateContent", httpStub.lastReq.URL.String())
+}
+
 // TestConvertClaudeToolsToGeminiTools_CustomType 测试custom类型工具转换
 func TestConvertClaudeToolsToGeminiTools_CustomType(t *testing.T) {
 	tests := []struct {
@@ -388,6 +429,120 @@ func TestGeminiMessagesCompatServiceForward_PreservesRequestedModelAndMappedUpst
 	require.Equal(t, 1, httpStub.calls)
 	require.NotNil(t, httpStub.lastReq)
 	require.Contains(t, httpStub.lastReq.URL.String(), "/models/claude-sonnet-4-20250514:")
+}
+
+func TestGeminiMessagesCompatServiceForward_APIKeyVertexUsesVertexEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	httpStub := &geminiCompatHTTPUpstreamStub{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"x-request-id": []string{"vertex-req-messages"}},
+			Body:       io.NopCloser(strings.NewReader(`{"candidates":[{"content":{"parts":[{"text":"hello"}]}}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5}}`)),
+		},
+	}
+	svc := &GeminiMessagesCompatService{httpUpstream: httpStub, cfg: &config.Config{}}
+	account := &Account{
+		ID:       360,
+		Platform: PlatformGemini,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "test-key",
+			"api_mode": "vertex",
+			"base_url": "https://aiplatform.googleapis.com",
+		},
+		Concurrency: 1,
+	}
+	body := []byte(`{"model":"gemini-3.1-flash-image","max_tokens":16,"messages":[{"role":"user","content":"hello"}]}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gemini-3.1-flash-image", result.UpstreamModel)
+	require.Equal(t, 1, httpStub.calls)
+	require.NotNil(t, httpStub.lastReq)
+	require.Equal(t, "test-key", httpStub.lastReq.Header.Get("x-goog-api-key"))
+	require.Equal(t, "https://aiplatform.googleapis.com/v1beta1/publishers/google/models/gemini-3.1-flash-image:generateContent", httpStub.lastReq.URL.String())
+}
+
+func TestBuildGeminiAPIKeyUpstreamURL_VertexExpressMode(t *testing.T) {
+	account := &Account{
+		Type:     AccountTypeAPIKey,
+		Platform: PlatformGemini,
+		Credentials: map[string]any{
+			"api_key":  "test-key",
+			"api_mode": "vertex",
+		},
+	}
+
+	fullURL, err := buildGeminiAPIKeyUpstreamURL(
+		account,
+		func(raw string) (string, error) { return raw, nil },
+		"gemini-2.5-flash",
+		"streamGenerateContent",
+		true,
+	)
+	require.NoError(t, err)
+	require.Equal(
+		t,
+		"https://aiplatform.googleapis.com/v1beta1/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse",
+		fullURL,
+	)
+}
+
+func TestBuildGeminiVertexModelsFallback(t *testing.T) {
+	res, handled, err := buildGeminiVertexModelsFallback("/v1beta/models")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, string(res.Body), "\"models\"")
+
+	res, handled, err = buildGeminiVertexModelsFallback("/v1beta/models/gemini-2.5-flash")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+	require.Contains(t, string(res.Body), "\"models/gemini-2.5-flash\"")
+}
+
+func TestGeminiMessagesCompatServiceForwardNative_APIKeyVertexUsesVertexEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1beta/models/gemini-3.1-flash-image:generateContent", nil)
+
+	httpStub := &geminiCompatHTTPUpstreamStub{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"x-request-id": []string{"vertex-req-1"}},
+			Body:       io.NopCloser(strings.NewReader(`{"candidates":[{"content":{"parts":[{"text":"ok"}]}}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4}}`)),
+		},
+	}
+	svc := &GeminiMessagesCompatService{httpUpstream: httpStub, cfg: &config.Config{}}
+	account := &Account{
+		ID:       360,
+		Platform: PlatformGemini,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "test-key",
+			"api_mode": "vertex",
+			"base_url": "https://aiplatform.googleapis.com",
+		},
+		Concurrency: 1,
+	}
+	body := []byte(`{"contents":[{"role":"user","parts":[{"text":"draw a cat"}]}],"generationConfig":{"responseModalities":["TEXT","IMAGE"],"imageConfig":{"aspectRatio":"1:1"}}}`)
+
+	result, err := svc.ForwardNative(context.Background(), c, account, "gemini-3.1-flash-image", "generateContent", false, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gemini-3.1-flash-image", result.UpstreamModel)
+	require.Equal(t, 1, httpStub.calls)
+	require.NotNil(t, httpStub.lastReq)
+	require.Equal(t, "test-key", httpStub.lastReq.Header.Get("x-goog-api-key"))
+	require.Contains(t, httpStub.lastReq.URL.String(), "https://aiplatform.googleapis.com/v1beta1/publishers/google/models/gemini-3.1-flash-image:generateContent")
+	require.NotContains(t, httpStub.lastReq.URL.String(), "/v1beta/models/")
 }
 
 func TestGeminiMessagesCompatServiceForward_NormalizesWebSearchToolForAIStudio(t *testing.T) {

--- a/backend/internal/service/gemini_quota.go
+++ b/backend/internal/service/gemini_quota.go
@@ -373,6 +373,12 @@ func geminiQuotaTierKeyForAccount(account *Account) string {
 	if account == nil || account.Platform != PlatformGemini {
 		return ""
 	}
+	if account.Type == AccountTypeAPIKey && account.IsGeminiVertexAPIKey() {
+		if tierID := normalizeGeminiTierID(account.GeminiTierID()); tierID != "" {
+			return tierID
+		}
+		return GeminiTierGCPStandard
+	}
 
 	// Note: GeminiOAuthType() already defaults legacy (project_id present) to code_assist.
 	oauthType := strings.ToLower(strings.TrimSpace(account.GeminiOAuthType()))

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -1010,6 +1010,14 @@
 
       <!-- API Key input (only for apikey type, excluding Antigravity which has its own fields) -->
       <div v-if="form.type === 'apikey' && form.platform !== 'antigravity'" class="space-y-4">
+        <div v-if="form.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.apiModeLabel') }}</label>
+          <select v-model="geminiApiMode" class="input">
+            <option value="ai_studio">{{ t('admin.accounts.gemini.apiMode.aiStudio') }}</option>
+            <option value="vertex">{{ t('admin.accounts.gemini.apiMode.vertex') }}</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.gemini.apiModeHint') }}</p>
+        </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
           <input
@@ -1020,7 +1028,9 @@
               form.platform === 'openai'
                 ? 'https://api.openai.com'
                 : form.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
+                  ? geminiApiMode === 'vertex'
+                    ? 'https://aiplatform.googleapis.com'
+                    : 'https://generativelanguage.googleapis.com'
                   : 'https://api.anthropic.com'
             "
           />
@@ -1047,11 +1057,21 @@
         <!-- Gemini API Key tier selection -->
         <div v-if="form.platform === 'gemini'">
           <label class="input-label">{{ t('admin.accounts.gemini.tier.label') }}</label>
-          <select v-model="geminiTierAIStudio" class="input">
+          <select v-if="geminiApiMode === 'vertex'" v-model="geminiTierGcp" class="input">
+            <option value="gcp_standard">{{ t('admin.accounts.gemini.tier.vertex.standard') }}</option>
+            <option value="gcp_enterprise">{{ t('admin.accounts.gemini.tier.vertex.enterprise') }}</option>
+          </select>
+          <select v-else v-model="geminiTierAIStudio" class="input">
             <option value="aistudio_free">{{ t('admin.accounts.gemini.tier.aiStudio.free') }}</option>
             <option value="aistudio_paid">{{ t('admin.accounts.gemini.tier.aiStudio.paid') }}</option>
           </select>
-          <p class="input-hint">{{ t('admin.accounts.gemini.tier.aiStudioHint') }}</p>
+          <p class="input-hint">
+            {{
+              geminiApiMode === 'vertex'
+                ? t('admin.accounts.gemini.tier.vertexHint')
+                : t('admin.accounts.gemini.tier.aiStudioHint')
+            }}
+          </p>
         </div>
 
         <!-- Model Restriction Section (Antigravity 已在上层条件排除) -->
@@ -3279,7 +3299,11 @@ const oauthStepTitle = computed(() => {
 // Platform-specific hints for API Key type
 const baseUrlHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === 'gemini') {
+    return geminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.baseUrlHintVertex')
+      : t('admin.accounts.gemini.baseUrlHint')
+  }
   return t('admin.accounts.baseUrlHint')
 })
 
@@ -3583,10 +3607,13 @@ const customBaseUrl = ref('')
 const geminiTierGoogleOne = ref<'google_one_free' | 'google_ai_pro' | 'google_ai_ultra'>('google_one_free')
 const geminiTierGcp = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
 const geminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free')
+const geminiApiMode = ref<'ai_studio' | 'vertex'>('ai_studio')
 
 const geminiSelectedTier = computed(() => {
   if (form.platform !== 'gemini') return ''
-  if (accountCategory.value === 'apikey') return geminiTierAIStudio.value
+  if (accountCategory.value === 'apikey') {
+    return geminiApiMode.value === 'vertex' ? geminiTierGcp.value : geminiTierAIStudio.value
+  }
   switch (geminiOAuthType.value) {
     case 'google_one':
       return geminiTierGoogleOne.value
@@ -4283,6 +4310,7 @@ const resetForm = () => {
   geminiTierGoogleOne.value = 'google_one_free'
   geminiTierGcp.value = 'gcp_standard'
   geminiTierAIStudio.value = 'aistudio_free'
+  geminiApiMode.value = 'ai_studio'
   oauth.resetState()
   openaiOAuth.resetState()
   geminiOAuth.resetState()
@@ -4616,7 +4644,9 @@ const handleSubmit = async () => {
     form.platform === 'openai'
       ? 'https://api.openai.com'
       : form.platform === 'gemini'
-        ? 'https://generativelanguage.googleapis.com'
+        ? geminiApiMode.value === 'vertex'
+          ? 'https://aiplatform.googleapis.com'
+          : 'https://generativelanguage.googleapis.com'
         : 'https://api.anthropic.com'
 
   // Build credentials with optional model mapping
@@ -4625,7 +4655,8 @@ const handleSubmit = async () => {
     api_key: apiKeyValue.value.trim()
   }
   if (form.platform === 'gemini') {
-    credentials.tier_id = geminiTierAIStudio.value
+    credentials.api_mode = geminiApiMode.value
+    credentials.tier_id = geminiSelectedTier.value
   }
 
   // Add model mapping if configured（OpenAI 开启自动透传时不应用）

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -28,6 +28,14 @@
 
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
+        <div v-if="account.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.apiModeLabel') }}</label>
+          <select v-model="editGeminiApiMode" class="input">
+            <option value="ai_studio">{{ t('admin.accounts.gemini.apiMode.aiStudio') }}</option>
+            <option value="vertex">{{ t('admin.accounts.gemini.apiMode.vertex') }}</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.gemini.apiModeHint') }}</p>
+        </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
           <input
@@ -38,7 +46,9 @@
               account.platform === 'openai'
                 ? 'https://api.openai.com'
                 : account.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
+                  ? editGeminiApiMode === 'vertex'
+                    ? 'https://aiplatform.googleapis.com'
+                    : 'https://generativelanguage.googleapis.com'
                   : account.platform === 'antigravity'
                     ? 'https://cloudcode-pa.googleapis.com'
                     : 'https://api.anthropic.com'
@@ -67,6 +77,24 @@
             "
           />
           <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
+        </div>
+        <div v-if="account.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.tier.label') }}</label>
+          <select v-if="editGeminiApiMode === 'vertex'" v-model="editGeminiTierVertex" class="input">
+            <option value="gcp_standard">{{ t('admin.accounts.gemini.tier.vertex.standard') }}</option>
+            <option value="gcp_enterprise">{{ t('admin.accounts.gemini.tier.vertex.enterprise') }}</option>
+          </select>
+          <select v-else v-model="editGeminiTierAIStudio" class="input">
+            <option value="aistudio_free">{{ t('admin.accounts.gemini.tier.aiStudio.free') }}</option>
+            <option value="aistudio_paid">{{ t('admin.accounts.gemini.tier.aiStudio.paid') }}</option>
+          </select>
+          <p class="input-hint">
+            {{
+              editGeminiApiMode === 'vertex'
+                ? t('admin.accounts.gemini.tier.vertexHint')
+                : t('admin.accounts.gemini.tier.aiStudioHint')
+            }}
+          </p>
         </div>
 
         <!-- Model Restriction Section (不适用于 Antigravity) -->
@@ -2440,7 +2468,11 @@ const authStore = useAuthStore()
 const baseUrlHint = computed(() => {
   if (!props.account) return t('admin.accounts.baseUrlHint')
   if (props.account.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (props.account.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (props.account.platform === 'gemini') {
+    return editGeminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.baseUrlHintVertex')
+      : t('admin.accounts.gemini.baseUrlHint')
+  }
   return t('admin.accounts.baseUrlHint')
 })
 
@@ -2464,6 +2496,9 @@ interface TempUnschedRuleForm {
 const submitting = ref(false)
 const editBaseUrl = ref('https://api.anthropic.com')
 const editApiKey = ref('')
+const editGeminiApiMode = ref<'ai_studio' | 'vertex'>('ai_studio')
+const editGeminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free')
+const editGeminiTierVertex = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
 // Bedrock credentials
 const editBedrockAccessKeyId = ref('')
 const editBedrockSecretAccessKey = ref('')
@@ -3092,11 +3127,24 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Initialize API Key fields for apikey type
   if (newAccount.type === 'apikey' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
+    if (newAccount.platform === 'gemini') {
+      editGeminiApiMode.value = credentials.api_mode === 'vertex' ? 'vertex' : 'ai_studio'
+      editGeminiTierAIStudio.value =
+        credentials.tier_id === 'aistudio_paid' ? 'aistudio_paid' : 'aistudio_free'
+      editGeminiTierVertex.value =
+        credentials.tier_id === 'gcp_enterprise' ? 'gcp_enterprise' : 'gcp_standard'
+    } else {
+      editGeminiApiMode.value = 'ai_studio'
+      editGeminiTierAIStudio.value = 'aistudio_free'
+      editGeminiTierVertex.value = 'gcp_standard'
+    }
     const platformDefaultUrl =
       newAccount.platform === 'openai'
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
-          ? 'https://generativelanguage.googleapis.com'
+          ? editGeminiApiMode.value === 'vertex'
+            ? 'https://aiplatform.googleapis.com'
+            : 'https://generativelanguage.googleapis.com'
           : 'https://api.anthropic.com'
     editBaseUrl.value = (credentials.base_url as string) || platformDefaultUrl
 
@@ -3705,6 +3753,11 @@ const handleSubmit = async () => {
       } else if (!hasExistingApiKey) {
         appStore.showError(t('admin.accounts.apiKeyIsRequired'))
         return
+      }
+      if (props.account.platform === 'gemini') {
+        newCredentials.api_mode = editGeminiApiMode.value
+        newCredentials.tier_id =
+          editGeminiApiMode.value === 'vertex' ? editGeminiTierVertex.value : editGeminiTierAIStudio.value
       }
 
       // Add model mapping if configured（OpenAI 开启自动透传时保留现有映射，不再编辑）

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3897,11 +3897,22 @@ export default {
           'All model requests are forwarded directly to the Gemini API without model restrictions or mappings.',
         baseUrlHint: 'Leave default for official Gemini API',
         apiKeyHint: 'Your Gemini API Key (starts with AIza)',
+        baseUrlHintVertex: 'Leave default for the official Vertex AI express mode endpoint',
+        apiKeyHintVertex: 'Your Vertex AI API Key (usually starts with AQ)',
+        apiModeLabel: 'API Mode',
+        apiModeHint:
+          'AI Studio stays the default. When switched to Vertex AI, sub2api will call Vertex directly instead of using an upstream compatibility relay.',
+        apiMode: {
+          aiStudio: 'AI Studio',
+          vertex: 'Vertex AI'
+        },
         tier: {
           label: 'Account Tier',
           hint: 'Tip: The system will try to auto-detect the tier first; if auto-detection is unavailable or fails, your selected tier is used as a fallback (simulated quota).',
           aiStudioHint:
             'AI Studio quotas are per-model (Pro/Flash are limited independently). If billing is enabled, choose Pay-as-you-go.',
+          vertexHint:
+            'Vertex API keys use Vertex AI Express Mode. This tier is only used for local scheduling heuristics and does not change Google-side quota.',
           googleOne: {
             free: 'Google One Free',
             pro: 'Google One Pro',
@@ -3914,6 +3925,10 @@ export default {
           aiStudio: {
             free: 'Google AI Free',
             paid: 'Google AI Pay-as-you-go'
+          },
+          vertex: {
+            standard: 'GCP Standard',
+            enterprise: 'GCP Enterprise'
           }
         },
         accountType: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -4025,11 +4025,21 @@ export default {
         modelPassthroughDesc: '所有模型请求将直接转发至 Gemini API，不进行模型限制或映射。',
         baseUrlHint: '留空使用官方 Gemini API',
         apiKeyHint: '您的 Gemini API Key（以 AIza 开头）',
+        baseUrlHintVertex: '留空使用官方 Vertex AI Express Mode 地址',
+        apiKeyHintVertex: '您的 Vertex AI API Key（通常以 AQ 开头）',
+        apiModeLabel: '接口类型',
+        apiModeHint: '默认使用 AI Studio。切到 Vertex AI 后，sub2api 会直接请求 Vertex，不经过上游兼容模式。',
+        apiMode: {
+          aiStudio: 'AI Studio',
+          vertex: 'Vertex AI'
+        },
         tier: {
           label: '账号等级',
           hint: '提示：系统会优先尝试自动识别账号等级；若自动识别不可用或失败，则使用你选择的等级作为回退（本地模拟配额）。',
           aiStudioHint:
             'AI Studio 的配额是按模型分别限流（Pro/Flash 独立）。若已绑卡（按量付费），请选 Pay-as-you-go。',
+          vertexHint:
+            'Vertex API key 走的是 Vertex AI Express Mode。这里的等级仅用于本地调度参考，不会改变 Google 侧真实额度。',
           googleOne: {
             free: 'Google One Free',
             pro: 'Google One Pro',
@@ -4042,6 +4052,10 @@ export default {
           aiStudio: {
             free: 'Google AI Free',
             paid: 'Google AI Pay-as-you-go'
+          },
+          vertex: {
+            standard: 'GCP Standard',
+            enterprise: 'GCP Enterprise'
           }
         },
         accountType: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -772,6 +772,7 @@ export interface ProxyQualityCheckResult {
 export interface GeminiCredentials {
   // API Key authentication
   api_key?: string
+  api_mode?: 'ai_studio' | 'vertex' | string
 
   // OAuth authentication
   access_token?: string


### PR DESCRIPTION
## Summary
- add Gemini API key API mode support for AI Studio vs Vertex
- route Vertex API key requests to Vertex Express endpoints across Claude messages, Gemini native, and OpenAI chat completions compatibility paths
- add local models fallback for Vertex API keys and expose API mode/tier fields in account create/edit UI

## Tests
- go test ./internal/service
- npm --prefix frontend run typecheck