### PR TITLE
Add user management row selection

### DIFF
--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1880,6 +1880,13 @@ export default {
         created: 'Created',
         actions: 'Actions'
       },
+      bulkActions: {
+        selected: '{count} users selected',
+        selectCurrentPage: 'Select page',
+        clear: 'Clear selection',
+        selectAllVisible: 'Select visible users',
+        selectUser: 'Select user {email}'
+      },
       today: 'Today',
       total: 'Last 30d',
       sortBy: 'Sort By',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1901,6 +1901,13 @@ export default {
         created: '创建时间',
         actions: '操作'
       },
+      bulkActions: {
+        selected: '已选择 {count} 个用户',
+        selectCurrentPage: '本页全选',
+        clear: '清除选择',
+        selectAllVisible: '选择本页用户',
+        selectUser: '选择用户 {email}'
+      },
       today: '今日',
       total: '近30天',
       sortBy: '排序方式',

--- a/frontend/src/views/admin/UsersView.vue
+++ b/frontend/src/views/admin/UsersView.vue
@@ -253,6 +253,31 @@
 
       <!-- Users Table -->
       <template #table>
+        <div
+          v-if="selectedUserIds.length > 0"
+          class="mb-4 flex items-center justify-between rounded-lg bg-primary-50 p-3 dark:bg-primary-900/20"
+        >
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-sm font-medium text-primary-900 dark:text-primary-100">
+              {{ t('admin.users.bulkActions.selected', { count: selectedUserIds.length }) }}
+            </span>
+            <button
+              type="button"
+              class="text-xs font-medium text-primary-700 hover:text-primary-800 dark:text-primary-300 dark:hover:text-primary-200"
+              @click="selectVisibleUsers"
+            >
+              {{ t('admin.users.bulkActions.selectCurrentPage') }}
+            </button>
+            <span class="text-gray-300 dark:text-primary-800">•</span>
+            <button
+              type="button"
+              class="text-xs font-medium text-primary-700 hover:text-primary-800 dark:text-primary-300 dark:hover:text-primary-200"
+              @click="clearUserSelection"
+            >
+              {{ t('admin.users.bulkActions.clear') }}
+            </button>
+          </div>
+        </div>
         <DataTable
           :columns="columns"
           :data="sortedUsers"
@@ -264,6 +289,29 @@
           :sort-storage-key="USER_SORT_STORAGE_KEY"
           @sort="handleSort"
         >
+          <template #header-select>
+            <input
+              type="checkbox"
+              class="h-4 w-4 cursor-pointer rounded border-gray-300 text-primary-600 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50"
+              :checked="allVisibleUsersSelected"
+              :disabled="loading || sortedUsers.length === 0"
+              :aria-label="t('admin.users.bulkActions.selectAllVisible')"
+              @click.stop
+              @change="toggleSelectAllVisibleUsers($event)"
+            />
+          </template>
+
+          <template #cell-select="{ row }">
+            <input
+              type="checkbox"
+              class="h-4 w-4 cursor-pointer rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+              :checked="isUserSelected(row.id)"
+              :aria-label="t('admin.users.bulkActions.selectUser', { email: row.email })"
+              @click.stop
+              @change="toggleUserSelection(row.id)"
+            />
+          </template>
+
           <template #cell-email="{ value }">
             <div class="flex items-center gap-2">
               <div
@@ -753,6 +801,7 @@ import { ref, reactive, computed, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAppStore } from '@/stores/app'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
+import { useTableSelection } from '@/composables/useTableSelection'
 import { formatDateTime } from '@/utils/format'
 import Icon from '@/components/icons/Icon.vue'
 
@@ -836,6 +885,7 @@ const getAttributeValue = (userId: number, attrId: number): string => {
 
 // All possible columns (for column settings)
 const allColumns = computed<Column[]>(() => [
+  { key: 'select', label: '', sortable: false },
   { key: 'email', label: t('admin.users.columns.user'), sortable: true },
   { key: 'id', label: t('admin.users.columns.id'), sortable: true },
   { key: 'username', label: t('admin.users.columns.username'), sortable: true },
@@ -860,9 +910,9 @@ const allColumns = computed<Column[]>(() => [
   { key: 'actions', label: t('admin.users.columns.actions'), sortable: false }
 ])
 
-// Columns that can be toggled (exclude email and actions which are always visible)
+// Columns that can be toggled (exclude select, email, and actions which are always visible)
 const toggleableColumns = computed(() =>
-  allColumns.value.filter(col => col.key !== 'email' && col.key !== 'actions')
+  allColumns.value.filter(col => col.key !== 'select' && col.key !== 'email' && col.key !== 'actions')
 )
 
 // Hidden columns (stored in Set - columns NOT in this set are visible)
@@ -990,7 +1040,7 @@ const hasVisibleAttributeColumns = computed(() =>
 // Filtered columns based on visibility
 const columns = computed<Column[]>(() =>
   allColumns.value.filter(col =>
-    col.key === 'email' || col.key === 'actions' || !hiddenColumns.has(col.key)
+    col.key === 'select' || col.key === 'email' || col.key === 'actions' || !hiddenColumns.has(col.key)
   )
 )
 
@@ -1259,6 +1309,25 @@ const sortedUsers = computed(() => {
     })
     .map((x) => x.row)
 })
+
+const {
+  selectedIds: selectedUserIds,
+  allVisibleSelected: allVisibleUsersSelected,
+  isSelected: isUserSelected,
+  toggle: toggleUserSelection,
+  clear: clearUserSelection,
+  removeMany: removeSelectedUsers,
+  toggleVisible: toggleVisibleUsers,
+  selectVisible: selectVisibleUsers
+} = useTableSelection<AdminUser>({
+  rows: users,
+  getId: (user) => user.id
+})
+
+const toggleSelectAllVisibleUsers = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  toggleVisibleUsers(target.checked)
+}
 
 // User attribute definitions and values
 const attributeDefinitions = ref<UserAttributeDefinition[]>([])
@@ -1718,9 +1787,11 @@ const handleDelete = (user: AdminUser) => {
 
 const confirmDelete = async () => {
   if (!deletingUser.value) return
+  const deletedUserId = deletingUser.value.id
   try {
-    await adminAPI.users.delete(deletingUser.value.id)
+    await adminAPI.users.delete(deletedUserId)
     appStore.showSuccess(t('common.success'))
+    removeSelectedUsers([deletedUserId])
     showDeleteDialog.value = false
     deletingUser.value = null
     loadUsers()


### PR DESCRIPTION
## Summary
- Add a selection checkbox column to the admin user management table.
- Add select-all for the current visible page and a selected-count bar with clear/page-select actions.
- Keep the selection column always visible and add English/Chinese labels.

## Validation
- Checked `Wei-Shaw/sub2api`: no PR template or CONTRIBUTING guide is present; the repository uses a CLA workflow (`CLA.md` / `.github/workflows/cla.yml`).
- `git diff --check`
- `npx pnpm@10 run lint:check`
- `npx pnpm@10 run typecheck`
- `npx pnpm@10 exec vitest run src/views/auth/__tests__/LinuxDoCallbackView.spec.ts src/views/auth/__tests__/WechatCallbackView.spec.ts src/views/user/__tests__/PaymentView.spec.ts src/views/user/__tests__/PaymentResultView.spec.ts src/components/user/profile/__tests__/ProfileInfoCard.spec.ts src/views/admin/__tests__/SettingsView.spec.ts`
- `npx pnpm@10 run build`

## Notes
- `make test-frontend` could not be invoked directly on this Windows host because `make` is not installed, so the Makefile target commands were run manually.