### PR TITLE
fix(gateway): strip spawn_agent tools to prevent encrypted parameters errors

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1232,6 +1232,54 @@ func codexInputItemRequiresName(typ string) bool {
 	}
 }
 
+func stripEncryptedTools(reqBody map[string]any) bool {
+	rawTools, ok := reqBody["tools"]
+	if !ok || rawTools == nil {
+		return false
+	}
+	tools, ok := rawTools.([]any)
+	if !ok {
+		return false
+	}
+
+	modified := false
+	validTools := make([]any, 0, len(tools))
+
+	for _, tool := range tools {
+		toolMap, ok := tool.(map[string]any)
+		if !ok {
+			validTools = append(validTools, tool)
+			continue
+		}
+
+		toolName := ""
+		if name, ok := toolMap["name"].(string); ok {
+			toolName = strings.TrimSpace(name)
+		}
+		if toolName == "" {
+			if functionValue, ok := toolMap["function"]; ok && functionValue != nil {
+				if function, ok := functionValue.(map[string]any); ok && function != nil {
+					if name, ok := function["name"].(string); ok {
+						toolName = strings.TrimSpace(name)
+					}
+				}
+			}
+		}
+
+		if toolName == "spawn_agent" || toolName == "functions.spawn_agent" {
+			modified = true
+			continue
+		}
+
+		validTools = append(validTools, toolMap)
+	}
+
+	if modified {
+		reqBody["tools"] = validTools
+	}
+	return modified
+}
+
 func normalizeCodexTools(reqBody map[string]any) bool {
 	rawTools, ok := reqBody["tools"]
 	if !ok || rawTools == nil {

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1266,7 +1266,8 @@ func stripEncryptedTools(reqBody map[string]any) bool {
 			}
 		}
 
-		if toolName == "spawn_agent" || toolName == "functions.spawn_agent" {
+		if toolName == "spawn_agent" || toolName == "functions.spawn_agent" ||
+			toolName == "followup_task" || toolName == "functions.followup_task" {
 			modified = true
 			continue
 		}

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -534,6 +534,16 @@ func TestStripEncryptedTools(t *testing.T) {
 			},
 			map[string]any{
 				"type": "function",
+				"name": "functions.followup_task",
+			},
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "followup_task",
+				},
+			},
+			map[string]any{
+				"type": "function",
 				"name": "bash",
 			},
 		},

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -519,6 +519,38 @@ func TestApplyCodexOAuthTransform_NormalizeCodexTools_PreservesResponsesFunction
 	require.Equal(t, "bash", first["name"])
 }
 
+func TestStripEncryptedTools(t *testing.T) {
+	reqBody := map[string]any{
+		"tools": []any{
+			map[string]any{
+				"type": "function",
+				"name": "functions.spawn_agent",
+			},
+			map[string]any{
+				"type": "function",
+				"function": map[string]any{
+					"name": "spawn_agent",
+				},
+			},
+			map[string]any{
+				"type": "function",
+				"name": "bash",
+			},
+		},
+	}
+
+	modified := stripEncryptedTools(reqBody)
+	require.True(t, modified)
+
+	tools, ok := reqBody["tools"].([]any)
+	require.True(t, ok)
+	require.Len(t, tools, 1)
+
+	first, ok := tools[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "bash", first["name"])
+}
+
 func TestNormalizeOpenAIResponsesImageGenerationTools_RewritesLegacyFields(t *testing.T) {
 	reqBody := map[string]any{
 		"tools": []any{

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -203,6 +203,18 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		}
 	}
 
+	if account.Type != AccountTypeOAuth || account.Platform != PlatformOpenAI {
+		var reqBody map[string]any
+		if err := json.Unmarshal(responsesBody, &reqBody); err == nil {
+			if stripEncryptedTools(reqBody) {
+				responsesBody, err = json.Marshal(reqBody)
+				if err != nil {
+					return nil, fmt.Errorf("remarshal after tools normalization: %w", err)
+				}
+			}
+		}
+	}
+
 	// 4b. Apply OpenAI fast policy (may filter service_tier or block the request).
 	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, responsesBody)
 	if policyErr != nil {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2628,6 +2628,15 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
+	if account.Type != AccountTypeOAuth || account.Platform != PlatformOpenAI {
+		decoded, decodeErr := ensureReqBody()
+		if decodeErr == nil {
+			if stripEncryptedTools(decoded) {
+				markDecodedModified()
+			}
+		}
+	}
+
 	if !SupportsVerbosity(upstreamModel) && gjson.GetBytes(body, "text.verbosity").Exists() {
 		markPatchDelete("text.verbosity")
 	}


### PR DESCRIPTION
Drops the spawn_agent / functions.spawn_agent tools from Codex request payloads to prevent validation errors on models (like Gemini) that do not support encrypted parameters.