### PR TITLE
fix: 修复CC Switch改为流式测试后请求失败的问题

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -169,7 +169,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 	// 设置 max_tokens=1 + haiku 探测请求标识到 context 中
 	// 必须在 SetClaudeCodeClientContext 之前设置，因为 ClaudeCodeValidator 需要读取此标识进行绕过判断
-	if isMaxTokensOneHaikuRequest(reqModel, parsedReq.MaxTokens, reqStream) {
+	if isMaxTokensOneHaikuRequest(reqModel, parsedReq.MaxTokens) {
 		ctx := service.WithIsMaxTokensOneHaikuRequest(c.Request.Context(), true, h.metadataBridgeEnabled())
 		c.Request = c.Request.WithContext(ctx)
 	}
@@ -360,7 +360,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 			// 检查请求拦截（预热请求、SUGGESTION MODE等）
 			if account.IsInterceptWarmupEnabled() {
-				interceptType := detectInterceptType(body, reqModel, parsedReq.MaxTokens, reqStream, isClaudeCodeClient)
+				interceptType := detectInterceptType(body, reqModel, parsedReq.MaxTokens, isClaudeCodeClient)
 				if interceptType != InterceptTypeNone {
 					if selection.Acquired && selection.ReleaseFunc != nil {
 						selection.ReleaseFunc()
@@ -638,7 +638,7 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 
 			// 检查请求拦截（预热请求、SUGGESTION MODE等）
 			if account.IsInterceptWarmupEnabled() {
-				interceptType := detectInterceptType(body, reqModel, parsedReq.MaxTokens, reqStream, isClaudeCodeClient)
+				interceptType := detectInterceptType(body, reqModel, parsedReq.MaxTokens, isClaudeCodeClient)
 				if interceptType != InterceptTypeNone {
 					if selection.Acquired && selection.ReleaseFunc != nil {
 						selection.ReleaseFunc()
@@ -1824,10 +1824,10 @@ func isHaikuModel(model string) bool {
 }
 
 // isMaxTokensOneHaikuRequest 检查是否为 max_tokens=1 + haiku 模型的探测请求
-// 这类请求用于 Claude Code 验证 API 连通性
-// 条件：max_tokens == 1 且 model 包含 "haiku" 且非流式请求
-func isMaxTokensOneHaikuRequest(model string, maxTokens int, isStream bool) bool {
-	return maxTokens == 1 && isHaikuModel(model) && !isStream
+// 这类请求用于 Claude Code 验证 API 连通性（流式/非流式均会出现，如 cc-switch v3.9.0 起的健康检查探测为流式）
+// 条件：max_tokens == 1 且 model 包含 "haiku"
+func isMaxTokensOneHaikuRequest(model string, maxTokens int) bool {
+	return maxTokens == 1 && isHaikuModel(model)
 }
 
 // detectInterceptType 检测请求是否需要拦截，返回拦截类型
@@ -1835,11 +1835,10 @@ func isMaxTokensOneHaikuRequest(model string, maxTokens int, isStream bool) bool
 //   - body: 请求体字节
 //   - model: 请求的模型名称
 //   - maxTokens: max_tokens 值
-//   - isStream: 是否为流式请求
 //   - isClaudeCodeClient: 是否已通过 Claude Code 客户端校验
-func detectInterceptType(body []byte, model string, maxTokens int, isStream bool, isClaudeCodeClient bool) InterceptType {
-	// 优先检查 max_tokens=1 + haiku 探测请求（仅非流式）
-	if isClaudeCodeClient && isMaxTokensOneHaikuRequest(model, maxTokens, isStream) {
+func detectInterceptType(body []byte, model string, maxTokens int, isClaudeCodeClient bool) InterceptType {
+	// 优先检查 max_tokens=1 + haiku 探测请求（流式/非流式均适用）
+	if isClaudeCodeClient && isMaxTokensOneHaikuRequest(model, maxTokens) {
 		return InterceptTypeMaxTokensOneHaiku
 	}
 

--- a/backend/internal/handler/gateway_handler_intercept_test.go
+++ b/backend/internal/handler/gateway_handler_intercept_test.go
@@ -14,10 +14,10 @@ import (
 func TestDetectInterceptType_MaxTokensOneHaikuRequiresClaudeCodeClient(t *testing.T) {
 	body := []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`)
 
-	notClaudeCode := detectInterceptType(body, "claude-haiku-4-5", 1, false, false)
+	notClaudeCode := detectInterceptType(body, "claude-haiku-4-5", 1, false)
 	require.Equal(t, InterceptTypeNone, notClaudeCode)
 
-	isClaudeCode := detectInterceptType(body, "claude-haiku-4-5", 1, false, true)
+	isClaudeCode := detectInterceptType(body, "claude-haiku-4-5", 1, true)
 	require.Equal(t, InterceptTypeMaxTokensOneHaiku, isClaudeCode)
 }
 
@@ -30,7 +30,7 @@ func TestDetectInterceptType_SuggestionModeUnaffected(t *testing.T) {
 		"system":[]
 	}`)
 
-	got := detectInterceptType(body, "claude-sonnet-4-5", 256, false, false)
+	got := detectInterceptType(body, "claude-sonnet-4-5", 256, false)
 	require.Equal(t, InterceptTypeSuggestionMode, got)
 }
 


### PR DESCRIPTION
## 问题

max_tokens=1 + haiku 的探测请求拦截目前只对非流式请求生效。但部分客户端的健康检查探测是流式的（如 cc-switch v3.9.0 起），这类探测请求不会被拦截，会真实转发到上游账号。
<img width="2368" height="752" alt="image" src="https://github.com/user-attachments/assets/64026b32-5cc9-4835-b453-5ddb4f8ce090" />


## 修改

- 去掉 非流式  限制
- 同步更新单元测试

修复前:
<img width="1994" height="796" alt="image" src="https://github.com/user-attachments/assets/49946f61-5dcd-4e89-8ddc-ab85f4dc1c38" />

修复后:
<img width="2002" height="796" alt="image" src="https://github.com/user-attachments/assets/bbfe7a69-4539-43f3-bf05-bdf28dadc8f5" />
