### PR TITLE
fix: 修复根目录 Dockerfile 因 legal 文档缺失导致的前端构建失败

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,8 @@
 *.md
 !deploy/DOCKER.md
 docs/
+# Legal documents are imported via ?raw by the frontend build
+!docs/legal/*.md
 
 # IDE
 .idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ RUN corepack enable && corepack prepare pnpm@9 --activate
 COPY frontend/package.json frontend/pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
+# Legal documents are imported via ?raw from frontend source (resolved as ../../../../docs/legal)
+COPY docs/legal/ /app/docs/legal/
+
 # Copy frontend source and build
 COPY frontend/ ./
 RUN pnpm run build


### PR DESCRIPTION
Fixes #3207

## 问题

commit 0acf00c4 在前端通过 `?raw` 引用了仓库根目录的 `docs/legal/admin-compliance.{zh,en}.md`，但 `.dockerignore` 排除了整个 `docs/`，且根目录 `Dockerfile` 的 frontend-builder 阶段只复制 `frontend/`，导致 `docker build .` 在 `pnpm run build` 时失败：

```
Could not resolve "../../../../docs/legal/admin-compliance.zh.md?raw" from "src/views/public/LegalDocumentView.vue"
```

## 修复

- `.dockerignore`：在 `docs/` 排除规则后追加 `!docs/legal/*.md`，仅放行法律文档进入构建上下文
- `Dockerfile`：frontend-builder 阶段在复制前端源码前增加 `COPY docs/legal/ /app/docs/legal/`，与前端 `../../../../docs/legal` 相对 import 路径对齐

## 验证

修复前 `docker build --target frontend-builder .` 在 `pnpm run build` 报错，修复后构建成功。正式 release 流程（完整 checkout 构建前端 + `Dockerfile.goreleaser`）不受影响。
<img width="1468" height="1036" alt="image" src="https://github.com/user-attachments/assets/ab1bfbee-ba5a-4188-91d1-29cd246f8988" />
