### PR TITLE
fix：account expiry autopause index / 账号过期自动禁用索引优化

### DIFF
--- a/backend/internal/repository/migrations_schema_integration_test.go
+++ b/backend/internal/repository/migrations_schema_integration_test.go
@@ -32,6 +32,7 @@ func TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate(t *testing.T) {
 	requireColumn(t, tx, "accounts", "rate_limit_reset_at", "timestamp with time zone", 0, true)
 	requireColumn(t, tx, "accounts", "overload_until", "timestamp with time zone", 0, true)
 	requireColumn(t, tx, "accounts", "session_window_status", "character varying", 20, true)
+	requireIndex(t, tx, "accounts", "idx_accounts_autopause_expiry_due")
 
 	// api_keys: key length should be 128
 	requireColumn(t, tx, "api_keys", "key", "character varying", 128, false)

--- a/backend/migrations/151_account_autopause_expiry_index_notx.sql
+++ b/backend/migrations/151_account_autopause_expiry_index_notx.sql
@@ -1,0 +1,6 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_autopause_expiry_due
+    ON accounts (expires_at)
+    WHERE deleted_at IS NULL
+      AND schedulable = TRUE
+      AND auto_pause_on_expired = TRUE
+      AND expires_at IS NOT NULL;

--- a/backend/migrations/auth_identity_payment_migrations_regression_test.go
+++ b/backend/migrations/auth_identity_payment_migrations_regression_test.go
@@ -155,3 +155,16 @@ func TestMigration135AllowsGitHubAndGoogleAuthProviders(t *testing.T) {
 	require.Contains(t, sql, "'github'")
 	require.Contains(t, sql, "'google'")
 }
+
+func TestMigration151AddsAccountAutoPauseExpiryPartialIndex(t *testing.T) {
+	content, err := FS.ReadFile("151_account_autopause_expiry_index_notx.sql")
+	require.NoError(t, err)
+
+	sql := string(content)
+	require.Contains(t, sql, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_autopause_expiry_due")
+	require.Contains(t, sql, "ON accounts (expires_at)")
+	require.Contains(t, sql, "WHERE deleted_at IS NULL")
+	require.Contains(t, sql, "schedulable = TRUE")
+	require.Contains(t, sql, "auto_pause_on_expired = TRUE")
+	require.Contains(t, sql, "expires_at IS NOT NULL")
+}


### PR DESCRIPTION
 `AccountExpiryService` 启动后每分钟调用 `AccountRepository.AutoPauseExpiredAccounts`，执行下面的空扫型 UPDATE：

```sql
UPDATE accounts
SET schedulable = FALSE, updated_at = NOW()
WHERE deleted_at IS NULL
  AND schedulable = TRUE
  AND auto_pause_on_expired = TRUE
  AND expires_at IS NOT NULL
  AND expires_at <= $1
```

生产证据显示当前符合自动暂停条件的账号数为 0，但该 UPDATE 仍执行约 `5,682` 次，总耗时约 `85,761 ms`。在账号表变大后，即使没有命中，每分钟扫描判断也会持续消耗 PostgreSQL CPU。


## 修复的方法

新增在线迁移 `backend/migrations/151_account_autopause_expiry_index_notx.sql`：

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_autopause_expiry_due
    ON accounts (expires_at)
    WHERE deleted_at IS NULL
      AND schedulable = TRUE
      AND auto_pause_on_expired = TRUE
      AND expires_at IS NOT NULL;
```

该索引精确覆盖自动暂停任务的固定过滤条件，只让 PostgreSQL 在“仍可调度、允许过期自动暂停、确实有过期时间”的小集合上按 `expires_at` 查找。业务语义不变，后台任务仍按原逻辑更新；只是让空命中和少量命中更便宜。

## 修复前后真实测试数据

### 数据 ：PostgreSQL EXPLAIN 前后对比

构造数据：

- `accounts` 共 200,000 行。
- 100,000 行 `expires_at IS NULL`。
- 100,000 行 `expires_at = now() + 30 days`。
- 当前应暂停账号 0 行，模拟生产“无命中空扫”。

同一空命中 UPDATE 的执行时间从 `9.954 ms` 降到 `0.179 ms`，约下降 `98.2%`；扫描方式从全表扫描变为部分索引扫描。


