### PR TITLE
fix: concurrency load pipeline cache / 优化Redis负载

### DIFF
--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -29,6 +29,11 @@ const (
 	openAIAdvancedSchedulerSettingDBTimeout = 2 * time.Second
 )
 
+const (
+	minOpenAIAccountLoadCandidateLimit = 32
+	openAIAccountLoadCandidateTopKMult = 4
+)
+
 type cachedOpenAIAdvancedSchedulerSetting struct {
 	enabled   bool
 	expiresAt int64
@@ -661,10 +666,55 @@ func buildOpenAIWeightedSelectionOrder(
 	return order
 }
 
+func openAIAccountLoadCandidateLimit(topK int) int {
+	if topK <= 0 {
+		topK = 1
+	}
+	limit := topK * openAIAccountLoadCandidateTopKMult
+	if limit < minOpenAIAccountLoadCandidateLimit {
+		limit = minOpenAIAccountLoadCandidateLimit
+	}
+	return limit
+}
+
+func limitOpenAIAccountLoadCandidates(accounts []*Account, req OpenAIAccountScheduleRequest, limit int) []*Account {
+	if len(accounts) == 0 || limit <= 0 || len(accounts) <= limit {
+		return accounts
+	}
+	limited := append([]*Account(nil), accounts...)
+	sort.SliceStable(limited, func(i, j int) bool {
+		left, right := limited[i], limited[j]
+		if req.RequireCompact {
+			leftTier, rightTier := openAICompactSupportTier(left), openAICompactSupportTier(right)
+			if leftTier != rightTier {
+				return leftTier > rightTier
+			}
+		}
+		if left.Priority != right.Priority {
+			return left.Priority < right.Priority
+		}
+		switch {
+		case left.LastUsedAt == nil && right.LastUsedAt != nil:
+			return true
+		case left.LastUsedAt != nil && right.LastUsedAt == nil:
+			return false
+		case left.LastUsedAt != nil && right.LastUsedAt != nil && !left.LastUsedAt.Equal(*right.LastUsedAt):
+			return left.LastUsedAt.Before(*right.LastUsedAt)
+		}
+		return left.ID < right.ID
+	})
+	return limited[:limit]
+}
+
+func sortedOpenAIAccountLoadCandidates(accounts []*Account, req OpenAIAccountScheduleRequest) []*Account {
+	return limitOpenAIAccountLoadCandidates(accounts, req, len(accounts))
+}
+
 func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 	req OpenAIAccountScheduleRequest,
 	filtered []*Account,
 	loadMap map[int64]*AccountLoadInfo,
+	totalCandidateCount ...int,
 ) openAIAccountLoadPlan {
 	allCandidates := make([]openAIAccountCandidateScore, 0, len(filtered))
 	for _, account := range filtered {
@@ -703,6 +753,9 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 		candidates:                candidates,
 		staleSnapshotCompactRetry: staleSnapshotCompactRetry,
 		candidateCount:            len(candidates),
+	}
+	if len(totalCandidateCount) > 0 && totalCandidateCount[0] > plan.candidateCount {
+		plan.candidateCount = totalCandidateCount[0]
 	}
 	if len(candidates) == 0 {
 		plan.selectionOrder = s.buildOpenAISelectionOrder(req, plan)
@@ -905,7 +958,6 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	}
 
 	filtered := make([]*Account, 0, len(accounts))
-	loadReq := make([]AccountWithConcurrency, 0, len(accounts))
 	for i := range accounts {
 		account := &accounts[i]
 		if req.ExcludedIDs != nil {
@@ -933,80 +985,110 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 			continue
 		}
 		filtered = append(filtered, account)
-		loadReq = append(loadReq, AccountWithConcurrency{
-			ID:             account.ID,
-			MaxConcurrency: account.EffectiveLoadFactor(),
-		})
 	}
 	if len(filtered) == 0 {
 		return nil, 0, 0, 0, noAvailableOpenAISelectionError(req.RequestedModel, false)
 	}
 
-	loadMap := map[int64]*AccountLoadInfo{}
-	if s.service.concurrencyService != nil {
-		if batchLoad, loadErr := s.service.concurrencyService.GetAccountsLoadBatch(ctx, loadReq); loadErr == nil {
-			loadMap = batchLoad
+	totalCandidateCount := len(filtered)
+	orderedCandidates := sortedOpenAIAccountLoadCandidates(filtered, req)
+	loadCandidateLimit := openAIAccountLoadCandidateLimit(s.service.openAIWSLBTopK())
+	candidateCount := totalCandidateCount
+	topK := 0
+	loadSkew := 0.0
+	compactBlocked := false
+	var waitCandidate *openAIAccountCandidateScore
+	for start := 0; start < len(orderedCandidates); start += loadCandidateLimit {
+		end := start + loadCandidateLimit
+		if end > len(orderedCandidates) {
+			end = len(orderedCandidates)
 		}
-	}
+		loadCandidates := orderedCandidates[start:end]
+		loadReq := make([]AccountWithConcurrency, 0, len(loadCandidates))
+		for _, account := range loadCandidates {
+			loadReq = append(loadReq, AccountWithConcurrency{
+				ID:             account.ID,
+				MaxConcurrency: account.EffectiveLoadFactor(),
+			})
+		}
 
-	plan := s.buildOpenAIAccountLoadPlan(req, filtered, loadMap)
-	candidateCount := plan.candidateCount
-	topK := plan.topK
-	loadSkew := plan.loadSkew
-	selectionOrder := plan.selectionOrder
-	if req.RequireCompact && len(plan.candidates) == 0 && len(plan.staleSnapshotCompactRetry) == 0 {
-		return nil, 0, 0, 0, ErrNoAvailableCompactAccounts
-	}
-	if req.RequireCompact && len(selectionOrder) == 0 && s.service.schedulerSnapshot == nil {
-		return nil, candidateCount, topK, loadSkew, ErrNoAvailableCompactAccounts
-	}
-	if len(selectionOrder) == 0 {
-		return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, req.RequireCompact && len(plan.allCandidates) > 0)
-	}
+		loadMap := map[int64]*AccountLoadInfo{}
+		if s.service.concurrencyService != nil {
+			if batchLoad, loadErr := s.service.concurrencyService.GetAccountsLoadBatch(ctx, loadReq); loadErr == nil {
+				loadMap = batchLoad
+			}
+		}
 
-	result, compactBlocked, acquireErr := s.tryAcquireOpenAISelectionOrder(ctx, req, selectionOrder)
-	if acquireErr != nil {
-		return nil, candidateCount, topK, loadSkew, acquireErr
-	}
-	if result != nil {
-		return result, candidateCount, topK, loadSkew, nil
-	}
+		plan := s.buildOpenAIAccountLoadPlan(req, loadCandidates, loadMap, totalCandidateCount)
+		candidateCount = plan.candidateCount
+		topK = plan.topK
+		loadSkew = plan.loadSkew
+		selectionOrder := plan.selectionOrder
+		if req.RequireCompact && len(plan.candidates) == 0 && len(plan.staleSnapshotCompactRetry) == 0 {
+			continue
+		}
+		if req.RequireCompact && len(selectionOrder) == 0 && s.service.schedulerSnapshot == nil {
+			continue
+		}
+		if len(selectionOrder) == 0 {
+			continue
+		}
 
-	if s.service.concurrencyService != nil {
-		if freshLoadMap, loadErr := s.service.concurrencyService.GetAccountsLoadBatchFresh(ctx, loadReq); loadErr == nil {
-			freshPlan := s.buildOpenAIAccountLoadPlan(req, filtered, freshLoadMap)
-			if len(freshPlan.selectionOrder) > 0 {
-				freshResult, freshCompactBlocked, freshAcquireErr := s.tryAcquireOpenAISelectionOrder(ctx, req, freshPlan.selectionOrder)
-				if freshAcquireErr != nil {
-					return nil, candidateCount, topK, loadSkew, freshAcquireErr
+		result, windowCompactBlocked, acquireErr := s.tryAcquireOpenAISelectionOrder(ctx, req, selectionOrder)
+		if acquireErr != nil {
+			return nil, candidateCount, topK, loadSkew, acquireErr
+		}
+		if result != nil {
+			return result, candidateCount, topK, loadSkew, nil
+		}
+		compactBlocked = compactBlocked || windowCompactBlocked
+
+		if s.service.concurrencyService != nil {
+			if freshLoadMap, loadErr := s.service.concurrencyService.GetAccountsLoadBatchFresh(ctx, loadReq); loadErr == nil {
+				freshPlan := s.buildOpenAIAccountLoadPlan(req, loadCandidates, freshLoadMap, totalCandidateCount)
+				if len(freshPlan.selectionOrder) > 0 {
+					freshResult, freshCompactBlocked, freshAcquireErr := s.tryAcquireOpenAISelectionOrder(ctx, req, freshPlan.selectionOrder)
+					if freshAcquireErr != nil {
+						return nil, candidateCount, topK, loadSkew, freshAcquireErr
+					}
+					if freshResult != nil {
+						return freshResult, freshPlan.candidateCount, freshPlan.topK, freshPlan.loadSkew, nil
+					}
+					compactBlocked = compactBlocked || freshCompactBlocked
+					selectionOrder = freshPlan.selectionOrder
+					candidateCount = freshPlan.candidateCount
+					topK = freshPlan.topK
+					loadSkew = freshPlan.loadSkew
 				}
-				if freshResult != nil {
-					return freshResult, freshPlan.candidateCount, freshPlan.topK, freshPlan.loadSkew, nil
+			}
+		}
+
+		if waitCandidate == nil {
+			for i := range selectionOrder {
+				candidate := selectionOrder[i]
+				fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.RequestedModel, false, req.RequiredCapability)
+				if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
+					continue
 				}
-				compactBlocked = compactBlocked || freshCompactBlocked
-				selectionOrder = freshPlan.selectionOrder
-				candidateCount = freshPlan.candidateCount
-				topK = freshPlan.topK
-				loadSkew = freshPlan.loadSkew
+				fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.RequestedModel, false, req.RequiredCapability)
+				if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
+					continue
+				}
+				if req.RequireCompact && openAICompactSupportTier(fresh) == 0 {
+					compactBlocked = true
+					continue
+				}
+				candidate.account = fresh
+				waitCandidate = &candidate
+				break
 			}
 		}
 	}
 
 	cfg := s.service.schedulingConfig()
 	// WaitPlan.MaxConcurrency 使用 Concurrency（非 EffectiveLoadFactor），因为 WaitPlan 控制的是 Redis 实际并发槽位等待。
-	for _, candidate := range selectionOrder {
-		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.RequestedModel, false, req.RequiredCapability)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
-			continue
-		}
-		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.RequestedModel, false, req.RequiredCapability)
-		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
-			continue
-		}
-		if req.RequireCompact && openAICompactSupportTier(fresh) == 0 {
-			compactBlocked = true
-			continue
-		}
+	if waitCandidate != nil && waitCandidate.account != nil {
+		fresh := waitCandidate.account
 		return &AccountSelectionResult{
 			Account: fresh,
 			WaitPlan: &AccountWaitPlan{

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -83,11 +83,12 @@ func (r schedulerGroupAwareOpenAIAccountRepo) ListSchedulableUngroupedByPlatform
 
 type schedulerTestConcurrencyCache struct {
 	ConcurrencyCache
-	loadBatchErr    error
-	loadMap         map[int64]*AccountLoadInfo
-	acquireResults  map[int64]bool
-	waitCounts      map[int64]int
-	skipDefaultLoad bool
+	loadBatchErr      error
+	loadMap           map[int64]*AccountLoadInfo
+	acquireResults    map[int64]bool
+	waitCounts        map[int64]int
+	skipDefaultLoad   bool
+	loadBatchSizeSink *[]int
 }
 
 func (c schedulerTestConcurrencyCache) AcquireAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
@@ -104,6 +105,9 @@ func (c schedulerTestConcurrencyCache) ReleaseAccountSlot(ctx context.Context, a
 }
 
 func (c schedulerTestConcurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []AccountWithConcurrency) (map[int64]*AccountLoadInfo, error) {
+	if c.loadBatchSizeSink != nil {
+		*c.loadBatchSizeSink = append(*c.loadBatchSizeSink, len(accounts))
+	}
 	if c.loadBatchErr != nil {
 		return nil, c.loadBatchErr
 	}
@@ -2186,6 +2190,100 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_LoadBalanceDistributesA
 
 	// 多 session 应该能打散到多个账号，避免“恒定单账号命中”。
 	require.GreaterOrEqual(t, len(selected), 2)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_LimitsLoadBatchCandidateSet(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(39101)
+	const accountCount = 500
+
+	accounts := make([]Account, 0, accountCount)
+	for i := 0; i < accountCount; i++ {
+		accounts = append(accounts, Account{
+			ID:          int64(391000 + i),
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    i,
+			GroupIDs:    []int64{groupID},
+			AccountGroups: []AccountGroup{{
+				GroupID: groupID,
+			}},
+		})
+	}
+
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = true
+	cfg.Gateway.OpenAIWS.LBTopK = 1
+	loadBatchSizes := []int{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cfg:                cfg,
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{loadBatchSizeSink: &loadBatchSizes}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "session_hash_limited_load_batch", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.Equal(t, accountCount, decision.CandidateCount)
+	require.NotEmpty(t, loadBatchSizes)
+	require.LessOrEqual(t, loadBatchSizes[0], 32)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_LoadBatchLimitFallsBackToNextWindow(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(39102)
+	const accountCount = 40
+
+	accounts := make([]Account, 0, accountCount)
+	acquireResults := make(map[int64]bool, accountCount)
+	for i := 0; i < accountCount; i++ {
+		id := int64(392000 + i)
+		accounts = append(accounts, Account{
+			ID:          id,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    i,
+			GroupIDs:    []int64{groupID},
+			AccountGroups: []AccountGroup{{
+				GroupID: groupID,
+			}},
+		})
+		acquireResults[id] = i >= 32
+	}
+
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = true
+	cfg.Gateway.OpenAIWS.LBTopK = 7
+	loadBatchSizes := []int{}
+	svc := &OpenAIGatewayService{
+		accountRepo:      schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts}},
+		cfg:              cfg,
+		rateLimitService: newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{
+			acquireResults:    acquireResults,
+			loadBatchSizeSink: &loadBatchSizes,
+		}),
+	}
+
+	selection, _, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "session_hash_limited_load_batch_fallback", "gpt-5.1", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.GreaterOrEqual(t, selection.Account.ID, int64(392032))
+	require.Less(t, selection.Account.ID, int64(392040))
+	require.GreaterOrEqual(t, len(loadBatchSizes), 3)
+	require.Equal(t, 32, loadBatchSizes[0])
+	require.Equal(t, 32, loadBatchSizes[1])
+	require.LessOrEqual(t, loadBatchSizes[2], 8)
 }
 
 func TestDeriveOpenAISelectionSeed_NoAffinityAddsEntropy(t *testing.T) {


### PR DESCRIPTION

 OpenAI 高级调度器在负载均衡阶段，会先过滤出所有可用候选账号，然后把全部候选传给 `ConcurrencyService.GetAccountsLoadBatch` 读取 Redis 并发负载。生产证据显示 Redis `hgetall/hget/hmget/ping` 命令量达到数亿级，说明大候选池下并发槽位读取是主要 CPU 压力来源之一。

高级调度器对全量候选读取负载，候选数越大，Redis pipeline 内命令数仍线性增长。500 个候选时，首轮负载读取会提交 500 个账号。

## 修复的方法

- 在 OpenAI 高级调度器中，将进入 Redis 负载读取的候选集改为小窗口读取。
- 窗口大小为 `max(lb_top_k * 4, 32)`，默认 `lb_top_k=7` 时为 `32`。
- 候选窗口按 compact 支持层级、账号优先级、LRU、账号 ID 排序，优先保留更可能被选中的账号。
- 如果当前窗口所有候选都抢槽失败，再对同窗口做一次 fresh 负载读取；仍失败时才扩展到下一窗口，避免漏掉后续空闲账号。
- `decision.CandidateCount` 仍报告全量过滤后候选数，不隐藏真实账号池规模。

修改位置：

- `backend/internal/service/openai_account_scheduler.go`
- `backend/internal/service/openai_account_scheduler_test.go`

## 修复前后真实测试数据

### 数据 1：500 个候选账号的首轮负载读取

修复前：

- 命令：`go test -tags=unit ./internal/service -run TestOpenAIGatewayService_SelectAccountWithScheduler_LimitsLoadBatchCandidateSet -count=1 -v`
- 关键数据：500 个候选全部进入 `GetAccountsLoadBatch`

修复后：

- 同命令通过。
- 关键数据：
  - 全量候选数 `decision.CandidateCount = 500`。
  - 首轮传给 `GetAccountsLoadBatch` 的账号数 `<= 32`。
  - 首轮 Redis 负载读取规模从 500 个账号降到 32 个账号，下降约 `93.6%`。

### 数据 2：首窗口满载时不漏掉后续可用账号

修复后新增回归测试：

- 命令：`go test -tags=unit ./internal/service -run TestOpenAIGatewayService_SelectAccountWithScheduler_LoadBatchLimitFallsBackToNextWindow -count=1 -v`
- 结果：通过。
- 测试数据：
  - 总候选数：40。
  - 第 1 窗口：32 个账号，全部抢槽失败。
  - fresh 复查第 1 窗口：32 个账号。
  - 第 2 窗口：最多 8 个账号。
  - 最终选中第 2 窗口中的可用账号，证明优化不会在首窗口忙满时直接返回等待计划而漏掉后续空闲账号。

## 功能回归验证

- `go test -tags=unit ./internal/service -run TestOpenAIGatewayService_SelectAccountWithScheduler -count=1`：通过。
- `go test -tags=unit ./internal/service -count=1`：通过，耗时 `99.211s`。
- `go test -tags=unit ./...`：通过，后端全部单元测试通过。
- `go test -tags=integration ./internal/repository -run TestConcurrencyCacheSuite -count=1`：通过，耗时 `5.200s`；上游原有 `TestGetAccountsLoadBatch` 子用例按现有 TODO 注释跳过。

## 预期收益

该修复不改变并发控制语义，只减少常态调度时进入 Redis 负载读取的账号数量。对大账号池场景，首轮 Redis 负载读取从“全量候选”变为“小窗口候选”；在默认配置和 500 个候选的测试中，账号负载读取数量从 500 降到 32。只有当前窗口全部不可抢槽时才扩展下一窗口，因此常态 Redis 命令量明显下降，同时保留高负载场景的兜底可用性。
