### PR TITLE
fix(account-stats): avoid double counting image output tokens

### DIFF
--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -65,8 +65,9 @@ func tryModelFilePricing(billingService *BillingService, model string, tokens Us
 	if err != nil || pricing == nil {
 		return nil
 	}
+	textOutputTokens := accountStatsTextOutputTokens(tokens)
 	cost := float64(tokens.InputTokens)*pricing.InputPricePerToken +
-		float64(tokens.OutputTokens)*pricing.OutputPricePerToken +
+		float64(textOutputTokens)*pricing.OutputPricePerToken +
 		float64(tokens.CacheCreationTokens)*pricing.CacheCreationPricePerToken +
 		float64(tokens.CacheReadTokens)*pricing.CacheReadPricePerToken +
 		float64(tokens.ImageOutputTokens)*pricing.ImageOutputPricePerToken
@@ -203,8 +204,9 @@ func calculateTokenStatsCost(pricing *ChannelModelPricing, tokens UsageTokens) *
 		}
 		return *ptr
 	}
+	textOutputTokens := accountStatsTextOutputTokens(tokens)
 	cost := float64(tokens.InputTokens)*deref(p.InputPrice) +
-		float64(tokens.OutputTokens)*deref(p.OutputPrice) +
+		float64(textOutputTokens)*deref(p.OutputPrice) +
 		float64(tokens.CacheCreationTokens)*deref(p.CacheWritePrice) +
 		float64(tokens.CacheReadTokens)*deref(p.CacheReadPrice) +
 		float64(tokens.ImageOutputTokens)*deref(p.ImageOutputPrice)
@@ -212,6 +214,14 @@ func calculateTokenStatsCost(pricing *ChannelModelPricing, tokens UsageTokens) *
 		return nil
 	}
 	return &cost
+}
+
+func accountStatsTextOutputTokens(tokens UsageTokens) int {
+	textOutputTokens := tokens.OutputTokens - tokens.ImageOutputTokens
+	if textOutputTokens < 0 {
+		return 0
+	}
+	return textOutputTokens
 }
 
 // applyAccountStatsCost resolves the account stats cost for a usage log entry.

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -241,8 +241,9 @@ func TestCalculateStatsCost_TokenBilling_WithImageOutput(t *testing.T) {
 	}
 	result := calculateStatsCost(pricing, tokens, 1)
 	require.NotNil(t, result)
-	// 100*0.001 + 50*0.002 + 10*0.01 = 0.1 + 0.1 + 0.1 = 0.3
-	require.InDelta(t, 0.3, *result, 1e-12)
+	// OutputTokens includes ImageOutputTokens, so text output is 50 - 10 = 40.
+	// 100*0.001 + 40*0.002 + 10*0.01 = 0.1 + 0.08 + 0.1 = 0.28
+	require.InDelta(t, 0.28, *result, 1e-12)
 }
 
 func TestCalculateStatsCost_TokenBilling_PartialPricesNil(t *testing.T) {
@@ -504,8 +505,27 @@ func TestTryModelFilePricing_WithImageOutput(t *testing.T) {
 	}
 	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens)
 	require.NotNil(t, result)
-	// 100*0.001 + 50*0.002 + 10*0.01 = 0.1 + 0.1 + 0.1 = 0.3
-	require.InDelta(t, 0.3, *result, 1e-12)
+	// OutputTokens includes ImageOutputTokens, so text output is 50 - 10 = 40.
+	// 100*0.001 + 40*0.002 + 10*0.01 = 0.1 + 0.08 + 0.1 = 0.28
+	require.InDelta(t, 0.28, *result, 1e-12)
+}
+
+func TestTryModelFilePricing_ImageOutputTokensAreNotDoubleCountedAsTextOutput(t *testing.T) {
+	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{
+		"claude-sonnet-4": {
+			InputPricePerToken:       5e-6,
+			OutputPricePerToken:      10e-6,
+			ImageOutputPricePerToken: 30e-6,
+		},
+	})
+	tokens := UsageTokens{
+		InputTokens:       1247,
+		OutputTokens:      1756,
+		ImageOutputTokens: 1756,
+	}
+	result := tryModelFilePricing(bs, "claude-sonnet-4", tokens)
+	require.NotNil(t, result)
+	require.InDelta(t, 0.058915, *result, 1e-12)
 }
 
 func TestTryModelFilePricing_WithCacheTokens(t *testing.T) {


### PR DESCRIPTION
## Summary
- split image output tokens from text output tokens when computing account stats cost
- keep image output tokens billed with the dedicated image output token price
- add regression coverage for model-file and custom account-stats pricing

## Why
GPT image usage reports output tokens that can be entirely image output. The old account stats formula multiplied the full output token count by text output price and then added image output cost again.

## Validation
- go test -tags=unit ./internal/service -run 'TestTryModelFilePricing_ImageOutputTokensAreNotDoubleCountedAsTextOutput|TestCalculateStatsCost_TokenBilling_WithImageOutput' -count=1