### PR TITLE
fix(gateway): 解压 zstd 上游响应体，修复非流式 usage 静默记 0 的计费丢失

### DIFF
--- a/backend/internal/repository/decompress_response_test.go
+++ b/backend/internal/repository/decompress_response_test.go
@@ -1,0 +1,190 @@
+package repository
+
+import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
+	"io"
+	"log/slog"
+	"net/http"
+	"testing"
+
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestDecompressResponseBodyZstdUsage(t *testing.T) {
+	payload := []byte(`{"usage":{"input_tokens":123,"output_tokens":45,"cache_read_input_tokens":67}}`)
+	compressed := compressZstd(t, payload)
+	resp := newEncodedResponse("zstd", compressed)
+
+	decompressResponseBody(resp)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, payload, body)
+	require.Equal(t, int64(123), gjson.GetBytes(body, "usage.input_tokens").Int())
+	require.Equal(t, int64(45), gjson.GetBytes(body, "usage.output_tokens").Int())
+	require.Equal(t, int64(67), gjson.GetBytes(body, "usage.cache_read_input_tokens").Int())
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+	require.Empty(t, resp.Header.Get("Content-Length"))
+	require.Equal(t, int64(-1), resp.ContentLength)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDecompressResponseBodyExistingEncodings(t *testing.T) {
+	payload := []byte(`{"ok":true}`)
+	tests := []struct {
+		name     string
+		encoding string
+		compress func(*testing.T, []byte) []byte
+	}{
+		{name: "gzip", encoding: "gzip", compress: compressGzip},
+		{name: "brotli", encoding: "br", compress: compressBrotli},
+		{name: "deflate", encoding: "deflate", compress: compressDeflate},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := newEncodedResponse(tt.encoding, tt.compress(t, payload))
+
+			decompressResponseBody(resp)
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			require.Equal(t, payload, body)
+			require.Empty(t, resp.Header.Get("Content-Encoding"))
+			require.Empty(t, resp.Header.Get("Content-Length"))
+			require.Equal(t, int64(-1), resp.ContentLength)
+			require.NoError(t, resp.Body.Close())
+		})
+	}
+}
+
+func TestDecompressResponseBodyWithoutEncodingLeavesBodyUntouched(t *testing.T) {
+	originalBody := &responseTestBody{Reader: bytes.NewReader([]byte("plain"))}
+	resp := &http.Response{
+		Header:        make(http.Header),
+		Body:          originalBody,
+		ContentLength: 5,
+	}
+
+	decompressResponseBody(resp)
+
+	require.Same(t, originalBody, resp.Body)
+	require.Equal(t, int64(5), resp.ContentLength)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "plain", string(body))
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDecompressResponseBodyInvalidZstdWarnsAndPreservesBody(t *testing.T) {
+	previousLogger := slog.Default()
+	var logOutput bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	payload := []byte("not a zstd response")
+	resp := newEncodedResponse("zstd", payload)
+
+	require.NotPanics(t, func() {
+		decompressResponseBody(resp)
+	})
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, payload, body)
+	require.Equal(t, "zstd", resp.Header.Get("Content-Encoding"))
+	require.Equal(t, int64(len(payload)), resp.ContentLength)
+	require.Contains(t, logOutput.String(), "msg=zstd_decompress_failed")
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDecompressResponseBodyEmptyZstdWarnsAndPreservesBody(t *testing.T) {
+	previousLogger := slog.Default()
+	var logOutput bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logOutput, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	resp := newEncodedResponse("zstd", nil)
+
+	require.NotPanics(t, func() {
+		decompressResponseBody(resp)
+	})
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Empty(t, body)
+	require.Equal(t, "zstd", resp.Header.Get("Content-Encoding"))
+	require.Equal(t, int64(0), resp.ContentLength)
+	require.Contains(t, logOutput.String(), "msg=zstd_decompress_failed")
+	require.NoError(t, resp.Body.Close())
+}
+
+type responseTestBody struct {
+	io.Reader
+}
+
+func (b *responseTestBody) Close() error {
+	return nil
+}
+
+func newEncodedResponse(encoding string, body []byte) *http.Response {
+	header := make(http.Header)
+	header.Set("Content-Encoding", encoding)
+	header.Set("Content-Length", "123")
+	return &http.Response{
+		Header:        header,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+}
+
+func compressZstd(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := zstd.NewWriter(&buf)
+	require.NoError(t, err)
+	_, err = zw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func compressGzip(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func compressBrotli(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := brotli.NewWriter(&buf)
+	_, err := zw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func compressDeflate(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	require.NoError(t, err)
+	_, err = zw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"bufio"
 	"compress/flate"
 	"compress/gzip"
 	"context"
@@ -18,6 +19,7 @@ import (
 	"time"
 
 	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
@@ -1178,6 +1180,7 @@ func decompressResponseBody(resp *http.Response) {
 		return
 	}
 
+	originalBody := resp.Body
 	var reader io.Reader
 	switch ce {
 	case "gzip":
@@ -1190,15 +1193,46 @@ func decompressResponseBody(resp *http.Response) {
 		reader = brotli.NewReader(resp.Body)
 	case "deflate":
 		reader = flate.NewReader(resp.Body)
+	case "zstd":
+		bufferedBody := bufio.NewReader(resp.Body)
+		resp.Body = &decompressedBody{reader: bufferedBody, closer: originalBody}
+
+		headerBytes, _ := bufferedBody.Peek(zstd.HeaderMaxSize)
+		var header zstd.Header
+		if err := header.Decode(headerBytes); err != nil {
+			slog.Warn("zstd_decompress_failed", "error", err)
+			return
+		}
+
+		zr, err := zstd.NewReader(bufferedBody)
+		if err != nil {
+			slog.Warn("zstd_decompress_failed", "error", err)
+			return
+		}
+		reader = &zstdResponseReader{ReadCloser: zr.IOReadCloser()}
 	default:
 		return
 	}
 
-	originalBody := resp.Body
 	resp.Body = &decompressedBody{reader: reader, closer: originalBody}
 	resp.Header.Del("Content-Encoding")
 	resp.Header.Del("Content-Length") // 解压后长度不确定
 	resp.ContentLength = -1
+}
+
+type zstdResponseReader struct {
+	io.ReadCloser
+	warnOnce sync.Once
+}
+
+func (r *zstdResponseReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err != nil && !errors.Is(err, io.EOF) {
+		r.warnOnce.Do(func() {
+			slog.Warn("zstd_decompress_failed", "error", err)
+		})
+	}
+	return n, err
 }
 
 // decompressedBody 组合解压 reader 和原始 body 的 close。


### PR DESCRIPTION
## 背景

新版 Claude Code CLI 会发送 `accept-encoding: gzip, deflate, br, zstd`，该请求头按现有设计透传给上游。由于请求显式设置了 `Accept-Encoding`，Go Transport 不会再自动解压，响应解压完全依赖 `decompressResponseBody()`。

当前实现只处理 gzip / br / deflate。上游返回 `Content-Encoding: zstd` 时，压缩字节会原样进入业务层：非流式 passthrough 的 usage 解析静默失败，input / output / cache token 全部记为 0，但请求耗时正常、客户端仍能自行解压收到正常响应，日志也没有任何错误，最终造成难以发现的静默计费丢失。

此前 #2122 是我在长期未获 review 后清理队列时主动关闭，并非维护者否决。现在 #3219 提供了完整复现、根因和实际计费影响，因此重新提交这个响应侧修复。

## 改动

- 在 `decompressResponseBody()` 增加 zstd 响应解压，直接复用项目已有的 `github.com/klauspost/compress/zstd`，不新增依赖。
- 合法 zstd 响应继续以流式 reader 交给业务层；解压成功后与现有 gzip / br / deflate 路径一致，清理 `Content-Encoding` / `Content-Length` 并将 `ContentLength` 设为 `-1`。
- 对空 body、实际非 zstd 内容和后续解码错误记录 `slog.Warn("zstd_decompress_failed")`；帧头校验失败时保留原响应字节和编码头，避免再次静默掩盖问题。
- 不修改 `accept-encoding` 转发白名单，也不改变 gzip / br / deflate 的现有行为。
- `HTTPUpstream.Do` / `DoWithTLS` 在业务层区分流式与非流式前统一调用该函数，因此本修复同时覆盖非流式 JSON usage 解析和流式 SSE 读取路径。

## 测试

新增 `backend/internal/repository/decompress_response_test.go`，覆盖：

- zstd 压缩 JSON 解压后可正确解析 input / output / cache usage
- gzip / br / deflate 回归行为不变
- 无 `Content-Encoding` 时 body 保持不变
- zstd 头配损坏内容及空 body 时告警、不 panic、原 body 可继续读取
- 解压后正确清理 `Content-Encoding` / `Content-Length`

已通过：

- `cd backend && go test -tags=unit ./internal/repository/...`
- `cd backend && go test -tags=unit ./...`
- `cd backend && golangci-lint run ./...`（0 issues）

Fixes #3219