### PR TITLE
Fix1/outbox scheduler snapshot coalesce / 降低高频账号状态变更下的 outbox 写入压力

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -1146,7 +1146,7 @@ func (r *accountRepository) SetOverloaded(ctx context.Context, id int64, until t
 }
 
 func (r *accountRepository) SetTempUnschedulable(ctx context.Context, id int64, until time.Time, reason string) error {
-	_, err := r.sql.ExecContext(ctx, `
+	result, err := r.sql.ExecContext(ctx, `
 		UPDATE accounts
 		SET temp_unschedulable_until = $1,
 			temp_unschedulable_reason = $2,
@@ -1157,6 +1157,13 @@ func (r *accountRepository) SetTempUnschedulable(ctx context.Context, id int64, 
 	`, until, reason, id)
 	if err != nil {
 		return err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return nil
 	}
 	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue temp unschedulable failed: account=%d err=%v", id, err)

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -752,6 +752,37 @@ func (s *AccountRepoSuite) TestTempUnschedulableFieldsLoadedByGetByIDAndGetByIDs
 	s.Require().Equal("", cacheRecorder.setAccounts[0].TempUnschedulableReason)
 }
 
+func (s *AccountRepoSuite) TestSetTempUnschedulableSkipsOutboxWhenWindowDoesNotExtend() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-temp-noop"})
+	cacheRecorder := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cacheRecorder
+
+	_, err := s.repo.sql.ExecContext(s.ctx, "TRUNCATE scheduler_outbox")
+	s.Require().NoError(err)
+
+	until := time.Now().Add(30 * time.Minute).UTC().Truncate(time.Second)
+	s.Require().NoError(s.repo.SetTempUnschedulable(s.ctx, account.ID, until, "first"))
+
+	var count int
+	err = scanSingleRow(s.ctx, s.repo.sql, "SELECT COUNT(*) FROM scheduler_outbox", nil, &count)
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+
+	s.Require().NoError(s.repo.SetTempUnschedulable(s.ctx, account.ID, until.Add(-5*time.Minute), "older"))
+
+	err = scanSingleRow(s.ctx, s.repo.sql, "SELECT COUNT(*) FROM scheduler_outbox", nil, &count)
+	s.Require().NoError(err)
+	s.Require().Equal(1, count)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().Equal("first", got.TempUnschedulableReason)
+	s.Require().NotNil(got.TempUnschedulableUntil)
+	s.Require().WithinDuration(until, *got.TempUnschedulableUntil, time.Second)
+}
+
 func (s *AccountRepoSuite) TestClearModelRateLimits_SyncsSchedulerSnapshot() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{
 		Name: "acc-clear-model-rate",

--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -53,6 +53,8 @@ const migrationsLockRetryInterval = 500 * time.Millisecond
 const nonTransactionalMigrationSuffix = "_notx.sql"
 const paymentOrdersOutTradeNoUniqueMigration = "120_enforce_payment_orders_out_trade_no_unique_notx.sql"
 const paymentOrdersOutTradeNoUniqueIndex = "paymentorder_out_trade_no_unique"
+const schedulerOutboxPendingDedupKeyMigration = "152_scheduler_outbox_pending_dedup_key_index_notx.sql"
+const schedulerOutboxPendingDedupKeyIndex = "idx_scheduler_outbox_pending_dedup_key"
 
 type migrationChecksumCompatibilityRule struct {
 	fileChecksum       string
@@ -258,6 +260,8 @@ func prepareNonTransactionalMigration(ctx context.Context, db *sql.DB, name stri
 	switch name {
 	case paymentOrdersOutTradeNoUniqueMigration:
 		return preparePaymentOrdersOutTradeNoUniqueMigration(ctx, db)
+	case schedulerOutboxPendingDedupKeyMigration:
+		return dropInvalidIndexIfPresent(ctx, db, schedulerOutboxPendingDedupKeyIndex)
 	default:
 		return nil
 	}
@@ -276,16 +280,20 @@ func preparePaymentOrdersOutTradeNoUniqueMigration(ctx context.Context, db *sql.
 		)
 	}
 
-	invalid, err := indexIsInvalid(ctx, db, paymentOrdersOutTradeNoUniqueIndex)
+	return dropInvalidIndexIfPresent(ctx, db, paymentOrdersOutTradeNoUniqueIndex)
+}
+
+func dropInvalidIndexIfPresent(ctx context.Context, db *sql.DB, indexName string) error {
+	invalid, err := indexIsInvalid(ctx, db, indexName)
 	if err != nil {
-		return fmt.Errorf("check invalid index %s: %w", paymentOrdersOutTradeNoUniqueIndex, err)
+		return fmt.Errorf("check invalid index %s: %w", indexName, err)
 	}
 	if !invalid {
 		return nil
 	}
 
-	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX CONCURRENTLY IF EXISTS %s", paymentOrdersOutTradeNoUniqueIndex)); err != nil {
-		return fmt.Errorf("drop invalid index %s: %w", paymentOrdersOutTradeNoUniqueIndex, err)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("DROP INDEX CONCURRENTLY IF EXISTS %s", indexName)); err != nil {
+		return fmt.Errorf("drop invalid index %s: %w", indexName, err)
 	}
 	return nil
 }

--- a/backend/internal/repository/migrations_runner_notx_test.go
+++ b/backend/internal/repository/migrations_runner_notx_test.go
@@ -194,6 +194,44 @@ DROP INDEX CONCURRENTLY IF EXISTS paymentorder_out_trade_no;
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestApplyMigrationsFS_SchedulerOutboxPendingDedupKeyMigration_DropsInvalidIndexBeforeRetry(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs("152_scheduler_outbox_pending_dedup_key_index_notx.sql").
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT EXISTS \\(").
+		WithArgs("idx_scheduler_outbox_pending_dedup_key").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("DROP INDEX CONCURRENTLY IF EXISTS idx_scheduler_outbox_pending_dedup_key").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_scheduler_outbox_pending_dedup_key").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs("152_scheduler_outbox_pending_dedup_key_index_notx.sql", sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		"152_scheduler_outbox_pending_dedup_key_index_notx.sql": &fstest.MapFile{
+			Data: []byte(`
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_scheduler_outbox_pending_dedup_key
+    ON scheduler_outbox (dedup_key)
+    WHERE dedup_key IS NOT NULL;
+`),
+		},
+	}
+
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestApplyMigrationsFS_TransactionalMigration(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/backend/internal/repository/migrations_schema_integration_test.go
+++ b/backend/internal/repository/migrations_schema_integration_test.go
@@ -96,6 +96,10 @@ func TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate(t *testing.T) {
 	require.NoError(t, tx.QueryRowContext(context.Background(), "SELECT to_regclass('public.security_secrets')").Scan(&securitySecretsRegclass))
 	require.True(t, securitySecretsRegclass.Valid, "expected security_secrets table to exist")
 
+	// scheduler_outbox pending dedup support
+	requireColumn(t, tx, "scheduler_outbox", "dedup_key", "text", 0, true)
+	requireIndex(t, tx, "scheduler_outbox", "idx_scheduler_outbox_pending_dedup_key")
+
 	// user_allowed_groups table should exist
 	var uagRegclass sql.NullString
 	require.NoError(t, tx.QueryRowContext(context.Background(), "SELECT to_regclass('public.user_allowed_groups')").Scan(&uagRegclass))

--- a/backend/internal/repository/ops_write_pressure_integration_test.go
+++ b/backend/internal/repository/ops_write_pressure_integration_test.go
@@ -57,12 +57,13 @@ func TestEnqueueSchedulerOutbox_DeduplicatesIdempotentEvents(t *testing.T) {
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 1, count)
 
-	require.GreaterOrEqual(t, schedulerOutboxDedupWindow, 10*time.Second)
+	var firstID int64
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT id FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&firstID))
+	require.NoError(t, NewSchedulerOutboxRepository(integrationDB).MarkProcessed(ctx, []int64{firstID}))
 
-	time.Sleep(1200 * time.Millisecond)
 	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
-	require.Equal(t, 1, count)
+	require.Equal(t, 2, count)
 }
 
 func TestEnqueueSchedulerOutbox_CoalescesAccountStateBurst(t *testing.T) {
@@ -76,8 +77,23 @@ func TestEnqueueSchedulerOutbox_CoalescesAccountStateBurst(t *testing.T) {
 
 	var count int
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
-	t.Logf("same-account account_changed burst: calls=50 inserted=%d dedup_window=%s", count, schedulerOutboxDedupWindow)
+	t.Logf("same-account account_changed burst: calls=50 inserted=%d", count)
 	require.Equal(t, 1, count)
+}
+
+func TestEnqueueSchedulerOutbox_DoesNotDeduplicateDifferentPayload(t *testing.T) {
+	ctx := context.Background()
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE scheduler_outbox RESTART IDENTITY")
+
+	accountID := int64(32345)
+	payload1 := map[string]any{"group_ids": []int64{1}}
+	payload2 := map[string]any{"group_ids": []int64{2}}
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, payload1))
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, payload2))
+
+	var count int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.Equal(t, 2, count)
 }
 
 func TestEnqueueSchedulerOutbox_DoesNotDeduplicateLastUsed(t *testing.T) {

--- a/backend/internal/repository/ops_write_pressure_integration_test.go
+++ b/backend/internal/repository/ops_write_pressure_integration_test.go
@@ -59,11 +59,36 @@ func TestEnqueueSchedulerOutbox_DeduplicatesIdempotentEvents(t *testing.T) {
 
 	var firstID int64
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT id FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&firstID))
-	require.NoError(t, NewSchedulerOutboxRepository(integrationDB).MarkProcessed(ctx, []int64{firstID}))
+	events, err := NewSchedulerOutboxRepository(integrationDB).ListAfterAndReleaseDedup(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	require.Equal(t, firstID, events[0].ID)
 
 	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 2, count)
+}
+
+func TestSchedulerOutbox_ListAfterAndReleaseDedup_AllowsSameKeyWhileEventInFlight(t *testing.T) {
+	ctx := context.Background()
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE scheduler_outbox RESTART IDENTITY")
+
+	accountID := int64(17345)
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+
+	events, err := NewSchedulerOutboxRepository(integrationDB).ListAfterAndReleaseDedup(ctx, 0, 100)
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+
+	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+
+	var count int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	require.Equal(t, 2, count)
+
+	var pendingKeys int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE dedup_key IS NOT NULL").Scan(&pendingKeys))
+	require.Equal(t, 1, pendingKeys)
 }
 
 func TestEnqueueSchedulerOutbox_CoalescesAccountStateBurst(t *testing.T) {

--- a/backend/internal/repository/ops_write_pressure_integration_test.go
+++ b/backend/internal/repository/ops_write_pressure_integration_test.go
@@ -57,10 +57,27 @@ func TestEnqueueSchedulerOutbox_DeduplicatesIdempotentEvents(t *testing.T) {
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
 	require.Equal(t, 1, count)
 
-	time.Sleep(schedulerOutboxDedupWindow + 150*time.Millisecond)
+	require.GreaterOrEqual(t, schedulerOutboxDedupWindow, 10*time.Second)
+
+	time.Sleep(1200 * time.Millisecond)
 	require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
 	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
-	require.Equal(t, 2, count)
+	require.Equal(t, 1, count)
+}
+
+func TestEnqueueSchedulerOutbox_CoalescesAccountStateBurst(t *testing.T) {
+	ctx := context.Background()
+	_, _ = integrationDB.ExecContext(ctx, "TRUNCATE scheduler_outbox RESTART IDENTITY")
+
+	accountID := int64(22345)
+	for range 50 {
+		require.NoError(t, enqueueSchedulerOutbox(ctx, integrationDB, service.SchedulerOutboxEventAccountChanged, &accountID, nil, nil))
+	}
+
+	var count int
+	require.NoError(t, integrationDB.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_outbox WHERE event_type = $1", service.SchedulerOutboxEventAccountChanged).Scan(&count))
+	t.Logf("same-account account_changed burst: calls=50 inserted=%d dedup_window=%s", count, schedulerOutboxDedupWindow)
+	require.Equal(t, 1, count)
 }
 
 func TestEnqueueSchedulerOutbox_DoesNotDeduplicateLastUsed(t *testing.T) {

--- a/backend/internal/repository/scheduler_outbox_repo.go
+++ b/backend/internal/repository/scheduler_outbox_repo.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
-	"github.com/lib/pq"
 )
 
 type schedulerOutboxRepository struct {
@@ -21,16 +20,30 @@ func NewSchedulerOutboxRepository(db *sql.DB) service.SchedulerOutboxRepository 
 	return &schedulerOutboxRepository{db: db}
 }
 
-func (r *schedulerOutboxRepository) ListAfter(ctx context.Context, afterID int64, limit int) ([]service.SchedulerOutboxEvent, error) {
+func (r *schedulerOutboxRepository) ListAfterAndReleaseDedup(ctx context.Context, afterID int64, limit int) ([]service.SchedulerOutboxEvent, error) {
 	if limit <= 0 {
 		limit = 100
 	}
 	rows, err := r.db.QueryContext(ctx, `
-		SELECT id, event_type, account_id, group_id, payload, created_at
-		FROM scheduler_outbox
-		WHERE id > $1
-		ORDER BY id ASC
-		LIMIT $2
+		WITH selected AS MATERIALIZED (
+			SELECT id, event_type, account_id, group_id, payload, created_at
+			FROM scheduler_outbox
+			WHERE id > $1
+			ORDER BY id ASC
+			LIMIT $2
+			FOR UPDATE
+		), released AS (
+			UPDATE scheduler_outbox AS o
+			SET dedup_key = NULL
+			FROM selected AS s
+			WHERE o.id = s.id
+				AND o.dedup_key IS NOT NULL
+			RETURNING o.id
+		)
+		SELECT s.id, s.event_type, s.account_id, s.group_id, s.payload, s.created_at
+		FROM selected AS s
+		CROSS JOIN (SELECT COUNT(*) FROM released) AS release_barrier
+		ORDER BY s.id ASC
 	`, afterID, limit)
 	if err != nil {
 		return nil, err
@@ -79,19 +92,6 @@ func (r *schedulerOutboxRepository) MaxID(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 	return maxID, nil
-}
-
-func (r *schedulerOutboxRepository) MarkProcessed(ctx context.Context, eventIDs []int64) error {
-	if len(eventIDs) == 0 {
-		return nil
-	}
-	_, err := r.db.ExecContext(ctx, `
-		UPDATE scheduler_outbox
-		SET dedup_key = NULL
-		WHERE id = ANY($1)
-			AND dedup_key IS NOT NULL
-	`, pq.Array(eventIDs))
-	return err
 }
 
 func enqueueSchedulerOutbox(ctx context.Context, exec sqlExecutor, eventType string, accountID *int64, groupID *int64, payload any) error {

--- a/backend/internal/repository/scheduler_outbox_repo.go
+++ b/backend/internal/repository/scheduler_outbox_repo.go
@@ -13,7 +13,7 @@ type schedulerOutboxRepository struct {
 	db *sql.DB
 }
 
-const schedulerOutboxDedupWindow = time.Second
+const schedulerOutboxDedupWindow = 10 * time.Second
 
 func NewSchedulerOutboxRepository(db *sql.DB) service.SchedulerOutboxRepository {
 	return &schedulerOutboxRepository{db: db}

--- a/backend/internal/repository/scheduler_outbox_repo.go
+++ b/backend/internal/repository/scheduler_outbox_repo.go
@@ -2,18 +2,20 @@ package repository
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
-	"time"
+	"fmt"
+	"strconv"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/lib/pq"
 )
 
 type schedulerOutboxRepository struct {
 	db *sql.DB
 }
-
-const schedulerOutboxDedupWindow = 10 * time.Second
 
 func NewSchedulerOutboxRepository(db *sql.DB) service.SchedulerOutboxRepository {
 	return &schedulerOutboxRepository{db: db}
@@ -79,17 +81,32 @@ func (r *schedulerOutboxRepository) MaxID(ctx context.Context) (int64, error) {
 	return maxID, nil
 }
 
+func (r *schedulerOutboxRepository) MarkProcessed(ctx context.Context, eventIDs []int64) error {
+	if len(eventIDs) == 0 {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduler_outbox
+		SET dedup_key = NULL
+		WHERE id = ANY($1)
+			AND dedup_key IS NOT NULL
+	`, pq.Array(eventIDs))
+	return err
+}
+
 func enqueueSchedulerOutbox(ctx context.Context, exec sqlExecutor, eventType string, accountID *int64, groupID *int64, payload any) error {
 	if exec == nil {
 		return nil
 	}
 	var payloadArg any
+	var payloadJSON []byte
 	if payload != nil {
 		encoded, err := json.Marshal(payload)
 		if err != nil {
 			return err
 		}
 		payloadArg = encoded
+		payloadJSON = encoded
 	}
 	query := `
 		INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
@@ -97,22 +114,32 @@ func enqueueSchedulerOutbox(ctx context.Context, exec sqlExecutor, eventType str
 	`
 	args := []any{eventType, accountID, groupID, payloadArg}
 	if schedulerOutboxEventSupportsDedup(eventType) {
+		dedupKey := schedulerOutboxDedupKey(eventType, accountID, groupID, payloadJSON)
 		query = `
-			INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload)
-			SELECT $1, $2, $3, $4
-			WHERE NOT EXISTS (
-				SELECT 1
-				FROM scheduler_outbox
-				WHERE event_type = $1
-					AND account_id IS NOT DISTINCT FROM $2
-					AND group_id IS NOT DISTINCT FROM $3
-					AND created_at >= NOW() - make_interval(secs => $5)
-			)
+			INSERT INTO scheduler_outbox (event_type, account_id, group_id, payload, dedup_key)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT (dedup_key) WHERE dedup_key IS NOT NULL DO NOTHING
 		`
-		args = append(args, schedulerOutboxDedupWindow.Seconds())
+		args = append(args, dedupKey)
 	}
 	_, err := exec.ExecContext(ctx, query, args...)
 	return err
+}
+
+func schedulerOutboxDedupKey(eventType string, accountID *int64, groupID *int64, payloadJSON []byte) string {
+	h := sha256.New()
+	_, _ = h.Write([]byte(eventType))
+	_, _ = h.Write([]byte{0})
+	if accountID != nil {
+		_, _ = h.Write([]byte(strconv.FormatInt(*accountID, 10)))
+	}
+	_, _ = h.Write([]byte{0})
+	if groupID != nil {
+		_, _ = h.Write([]byte(strconv.FormatInt(*groupID, 10)))
+	}
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write(payloadJSON)
+	return fmt.Sprintf("scheduler_outbox:%s", hex.EncodeToString(h.Sum(nil)))
 }
 
 func schedulerOutboxEventSupportsDedup(eventType string) bool {

--- a/backend/internal/service/scheduler_outbox.go
+++ b/backend/internal/service/scheduler_outbox.go
@@ -16,7 +16,6 @@ type SchedulerOutboxEvent struct {
 
 // SchedulerOutboxRepository 提供调度 outbox 的读取接口。
 type SchedulerOutboxRepository interface {
-	ListAfter(ctx context.Context, afterID int64, limit int) ([]SchedulerOutboxEvent, error)
+	ListAfterAndReleaseDedup(ctx context.Context, afterID int64, limit int) ([]SchedulerOutboxEvent, error)
 	MaxID(ctx context.Context) (int64, error)
-	MarkProcessed(ctx context.Context, eventIDs []int64) error
 }

--- a/backend/internal/service/scheduler_outbox.go
+++ b/backend/internal/service/scheduler_outbox.go
@@ -18,4 +18,5 @@ type SchedulerOutboxEvent struct {
 type SchedulerOutboxRepository interface {
 	ListAfter(ctx context.Context, afterID int64, limit int) ([]SchedulerOutboxEvent, error)
 	MaxID(ctx context.Context) (int64, error)
+	MarkProcessed(ctx context.Context, eventIDs []int64) error
 }

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -242,7 +242,7 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 		return
 	}
 
-	events, err := s.outboxRepo.ListAfter(ctx, watermark, 200)
+	events, err := s.outboxRepo.ListAfterAndReleaseDedup(ctx, watermark, 200)
 	if err != nil {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox poll failed: %v", err)
 		return
@@ -253,7 +253,6 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 
 	watermarkForCheck := watermark
 	seen := make(map[batchSeenKey]struct{})
-	processedIDs := make([]int64, 0, len(events))
 	for _, event := range events {
 		eventCtx, cancel := context.WithTimeout(context.Background(), outboxEventTimeout)
 		err := s.handleOutboxEvent(eventCtx, event, seen)
@@ -262,15 +261,6 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox handle failed: id=%d type=%s err=%v", event.ID, event.EventType, err)
 			return
 		}
-		processedIDs = append(processedIDs, event.ID)
-	}
-
-	markCtx, markCancel := context.WithTimeout(context.Background(), 5*time.Second)
-	markErr := s.outboxRepo.MarkProcessed(markCtx, processedIDs)
-	markCancel()
-	if markErr != nil {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox mark processed failed: %v", markErr)
-		return
 	}
 
 	lastID := events[len(events)-1].ID

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -253,6 +253,7 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 
 	watermarkForCheck := watermark
 	seen := make(map[batchSeenKey]struct{})
+	processedIDs := make([]int64, 0, len(events))
 	for _, event := range events {
 		eventCtx, cancel := context.WithTimeout(context.Background(), outboxEventTimeout)
 		err := s.handleOutboxEvent(eventCtx, event, seen)
@@ -261,6 +262,15 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox handle failed: id=%d type=%s err=%v", event.ID, event.EventType, err)
 			return
 		}
+		processedIDs = append(processedIDs, event.ID)
+	}
+
+	markCtx, markCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	markErr := s.outboxRepo.MarkProcessed(markCtx, processedIDs)
+	markCancel()
+	if markErr != nil {
+		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox mark processed failed: %v", markErr)
+		return
 	}
 
 	lastID := events[len(events)-1].ID

--- a/backend/migrations/151_scheduler_outbox_dedup_key.sql
+++ b/backend/migrations/151_scheduler_outbox_dedup_key.sql
@@ -1,0 +1,2 @@
+ALTER TABLE scheduler_outbox
+    ADD COLUMN IF NOT EXISTS dedup_key TEXT;

--- a/backend/migrations/152_scheduler_outbox_pending_dedup_key_index_notx.sql
+++ b/backend/migrations/152_scheduler_outbox_pending_dedup_key_index_notx.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_scheduler_outbox_pending_dedup_key
+    ON scheduler_outbox (dedup_key)
+    WHERE dedup_key IS NOT NULL;


### PR DESCRIPTION
## 实际生产环境中数据
账号规模大时状态变更频率放大，cpu占用长期较高
现象：scheduler_outbox 长期累积 160 万行，最近 1 小时主要是 account_changed。事件被消费后会触发按分组/平台的调度快照重建，进而放大问题 1 的重 SQL。

服务器 / 数据库证据：scheduler_outbox 总行数 1,608,351，最近 1 小时 account_changed=2,205、account_last_used=349、account_groups_changed=2。
最近 15 分钟按分钟聚合出现尖峰：2026-06-10 21:00 有 account_changed=613，21:01 有 714，21:02 有 71；随后回落到每分钟约 7-13。
当前账号状态聚合：未删除账号中 error_accounts=24,975、rate_limited_now=5,864、temp_unsched_now=91，说明生产存在大量会触发调度状态变化的账号。

## Summary

优化 scheduler outbox 的去重与消费流程，降低高频账号状态变更下的 outbox 写入压力，并修复时间窗口去重可能吞掉后续状态变更的问题。

## Changes

- 将 scheduler outbox 去重从 `created_at` 时间窗口扫描改为 `dedup_key` 部分唯一索引。
- 新增 `scheduler_outbox.dedup_key` 字段和 pending dedup 唯一索引。
- worker 拉取 outbox 批次时立即释放 `dedup_key`，避免同 key 事件在 in-flight 期间被 `ON CONFLICT DO NOTHING` 吞掉。
- `SetTempUnschedulable` 在 DB update 未实际延长窗口时直接返回，跳过无效 outbox 写入和 snapshot 同步。
- 迁移 runner 增加 invalid concurrent index 恢复逻辑，避免 `CREATE INDEX CONCURRENTLY` 中断后留下 invalid index 并被 `IF NOT EXISTS` 误跳过。
- 补充 integration tests 覆盖：
  - pending 同 key 事件去重
  - in-flight 同 key 事件可再次入队
  - 不同 payload 不误合并
  - no-op temp unschedulable 不写 outbox
  - 新迁移 schema/index 存在性

## Performance

使用 WSL Docker + `postgres:18.1-alpine3.23` 做实际压测，基线为 `e34ad2b1`，优化后为 `5906ec80`，`scheduler_outbox` 预填 50,000 行，每项 3 轮。

| Scenario | Before avg | After avg | Change |
|---|---:|---:|---:|
| 同 key burst 入队 5,000 次 | 9753.70 ms | 95.41 ms | ~102x faster |
| 不同 key 入队 5,000 次 | 10590.54 ms | 125.51 ms | ~84x faster |
| `SetTempUnschedulable` no-op 5,000 次 | 9606.14 ms | 12.52 ms | ~767x faster |
| worker 拉取/释放 50,000 行 | 18.36 ms | 424.16 ms | slower, expected |

worker poll 变慢是预期 tradeoff：取出批次时释放 pending dedup key，换取 in-flight 同 key 事件不丢失的正确性。


## 受影响的接口/路径
直接受益的是会触发 account_changed、group_changed、full_rebuild 的路径：
- 管理端账号写接口：POST /api/v1/admin/accounts、PUT /api/v1/admin/accounts/:id、DELETE /api/v1/admin/accounts/:id、POST /api/v1/admin/accounts/bulk-update、批量创建/导入/同步 CRS/导入 Codex session、清错误、清限流、重置 quota、切换 schedulable、清 temp unschedulable 等。
- 管理端分组写接口：POST /api/v1/admin/groups、PUT /api/v1/admin/groups/:id、DELETE /api/v1/admin/groups/:id、PUT /api/v1/admin/groups/sort-order。
- 网关请求的异常状态路径：/v1/messages、/v1/chat/completions、/v1/responses、/v1/images/generations、/v1/images/edits、/v1beta/models/*、/antigravity/v1/messages 等，在触发上游 401/403/429/529/5xx、临时不可调度、账号限流、额度跨阈值时受益。
- 后台任务：过期代理扫描触发的 full_rebuild、账号自动暂停、token refresh 或 upstream transport error 导致的账号不可调度更新。

## Tests

- `go test ./...`
- `go build -trimpath ./cmd/server`
- `go test ./internal/repository ./internal/service`
- WSL Docker + Linux Go 1.26.4:
  - `go test -tags=integration ./... -count=1`
  - targeted scheduler outbox integration tests with real Postgres/Redis
- SQL-level checks:
  - normal unique partial index creation
  - invalid index recovery after failed concurrent index creation
  - in-flight same-key enqueue behavior

## Rollout Notes

- 新代码依赖 `scheduler_outbox.dedup_key` 字段和 `idx_scheduler_outbox_pending_dedup_key` 索引。
- 如果生产环境未开启自动迁移，需要先应用 migrations `151` 和 `152` 再部署应用代码。