### PR TITLE
docs: update Sub2API admin skill

### DIFF
--- a/skills/sub2api-admin/CHANGELOG.md
+++ b/skills/sub2api-admin/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Sub2API Admin Skill Changelog
+
+## 2026-06-13
+
+- 同步上游 `Wei-Shaw/sub2api` 当前 `main` 的管理端路由范围，补充账号、分组、代理、兑换码、错误透传规则、TLS 指纹模板和 raw admin API 的说明。
+- 新增用户侧辅助命令：`auth login`、`user-groups available`、`user-groups rates`、`user-keys list|get|create|update|delete|toggle`。
+- 扩展账号命令：`refresh-tier`、`batch-refresh-tier`、`sync-models-preview`、`set-privacy`。
+- 扩展分组命令：分页列表、用量/容量摘要、模型候选、统计、API Key 列表、用户倍率和 RPM 覆盖管理。
+- 扩展代理命令：分页列表、测试、质量检查、统计、关联账号、导入导出、批量创建和批量删除。
+- 在参考文档中标出更多已确认但未专门封装的 admin route family，建议用 `api <METHOD> <path>` 直通调用。

--- a/skills/sub2api-admin/SKILL.md
+++ b/skills/sub2api-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sub2api-admin
-description: Manage Sub2API admin APIs for accounts, redeem codes, groups, proxies, error passthrough rules, TLS fingerprint profiles, imports, exports, batch updates, and raw administrator API calls. Use when the user mentions Sub2API, admin API keys, account management, redeem code management, recharge codes, invitation codes, bulk account import/export, keeping or deleting accounts, refreshing accounts, clearing errors, CRS sync, or managing Sub2API backend settings through the admin API.
+description: Manage Sub2API admin and operator APIs for accounts, user API keys, redeem codes, groups, proxies, error passthrough rules, TLS fingerprint profiles, imports, exports, batch updates, route-backed admin actions, and raw administrator API calls. Use when the user mentions Sub2API, admin API keys, user tokens, account management, redeem code management, recharge codes, invitation codes, bulk account/proxy import/export, keeping or deleting accounts, refreshing accounts, clearing errors, CRS sync, or managing Sub2API backend settings through the admin API.
 ---
 
 # Sub2API Admin
@@ -10,15 +10,17 @@ Use the bundled CLI instead of ad hoc `curl`. Run examples from this skill direc
 ```bash
 export SUB2API_BASE_URL='https://your-sub2api-host'
 export SUB2API_ADMIN_API_KEY='<admin api key>'
+export SUB2API_USER_TOKEN='<login access token>'
 node scripts/sub2api-admin.js accounts list
 ```
 
 For all commands and payload examples, read [references/admin-cli.md](references/admin-cli.md).
+For recent skill changes, read [CHANGELOG.md](CHANGELOG.md).
 
 ## Workflow
 
 1. Reuse `SUB2API_BASE_URL` and `SUB2API_ADMIN_API_KEY` from the environment.
-2. Run read-only commands first: `accounts list`, `accounts get <id>`, `groups all`, or `proxies all`.
+2. Run read-only commands first: `accounts list`, `accounts get <id>`, `groups all`, `groups list`, `proxies all`, or `proxies list`.
 3. Before destructive or bulk writes, print the target account names and IDs.
 4. Execute the write command only after the target set is clear.
 5. Run a follow-up read command to verify the result.
@@ -30,18 +32,28 @@ node scripts/sub2api-admin.js accounts list --page-size 20
 node scripts/sub2api-admin.js accounts get 40
 node scripts/sub2api-admin.js accounts usage 40
 node scripts/sub2api-admin.js accounts set-schedulable 40 true
+node scripts/sub2api-admin.js accounts refresh-tier 40
+node scripts/sub2api-admin.js accounts batch-refresh-tier --ids 40,39
 node scripts/sub2api-admin.js accounts bulk-update --ids 40,39 --json '{"concurrency":10}'
+node scripts/sub2api-admin.js groups list --page-size 20
+node scripts/sub2api-admin.js groups rate-multipliers 2
+node scripts/sub2api-admin.js proxies list --page-size 20
+node scripts/sub2api-admin.js proxies test 3
 node scripts/sub2api-admin.js redeem-codes list --page-size 20
 node scripts/sub2api-admin.js redeem-codes generate --json '{"count":1,"type":"balance","value":10}' --idempotency-key redeem-$(date +%s)
 node scripts/sub2api-admin.js redeem-codes create-and-redeem --json '{"code":"order_123","type":"balance","value":10,"user_id":123}' --idempotency-key order-123
 node scripts/sub2api-admin.js error-rules list
 node scripts/sub2api-admin.js tls-profiles list
+node scripts/sub2api-admin.js auth login --email user@example.com --password '<password>'
+node scripts/sub2api-admin.js user-keys list --page-size 20
 ```
 
 ## Safety Notes
 
 - Authentication uses only `x-api-key`.
+- User API authentication uses `Authorization: Bearer <token>` from `auth login`.
 - If the API returns `INVALID_ADMIN_KEY`, ask the user to regenerate the admin API key.
 - `accounts export` includes credentials and tokens. Prefer `--file` and avoid printing exports in chat.
+- `proxies export` can include proxy credentials. Prefer `--file`.
 - Redeem code create/redeem commands should use `--idempotency-key` for payment or recharge workflows.
 - For uncertain or newly added backend APIs, use `api <METHOD> <admin-path>` after a read-only check.

--- a/skills/sub2api-admin/references/admin-cli.md
+++ b/skills/sub2api-admin/references/admin-cli.md
@@ -5,9 +5,11 @@
 ```bash
 export SUB2API_BASE_URL='https://your-sub2api-host'
 export SUB2API_ADMIN_API_KEY='<admin api key>'
+export SUB2API_USER_TOKEN='<login access token>'
 ```
 
 后台鉴权只使用 `x-api-key`。如果返回 `INVALID_ADMIN_KEY`，重新生成管理员 API Key。
+用户侧命令使用 `auth login` 返回的 `access_token`，通过 `Authorization: Bearer <token>` 鉴权。
 
 ## CLI
 
@@ -15,6 +17,28 @@ export SUB2API_ADMIN_API_KEY='<admin api key>'
 
 ```bash
 node scripts/sub2api-admin.js <command>
+```
+
+## User Auth And Keys
+
+登录并取得用户 token：
+
+```bash
+node scripts/sub2api-admin.js auth login --email user@example.com --password '<password>'
+export SUB2API_USER_TOKEN='<access_token>'
+```
+
+用户可用分组和用户 API Key：
+
+```bash
+node scripts/sub2api-admin.js user-groups available
+node scripts/sub2api-admin.js user-groups rates
+node scripts/sub2api-admin.js user-keys list --page-size 20
+node scripts/sub2api-admin.js user-keys get 12
+node scripts/sub2api-admin.js user-keys create --name cc-max --group-id 5 --quota 0 --idempotency-key key-$(date +%s)
+node scripts/sub2api-admin.js user-keys create --json '{"name":"cc-max","group_id":5,"quota":0}'
+node scripts/sub2api-admin.js user-keys update 12 --json '{"status":"inactive"}'
+node scripts/sub2api-admin.js user-keys delete 12
 ```
 
 ## Accounts
@@ -32,6 +56,7 @@ node scripts/sub2api-admin.js accounts batch-today-stats --ids 40,39
 node scripts/sub2api-admin.js accounts models 40
 node scripts/sub2api-admin.js accounts temp-unschedulable 40
 node scripts/sub2api-admin.js accounts antigravity-default-model-mapping
+node scripts/sub2api-admin.js accounts sync-models-preview --json '{"platform":"openai","type":"api-key","api_key":"sk-..."}'
 ```
 
 `accounts export` 会包含账号凭据和 token，建议写入文件，不要直接刷屏：
@@ -53,8 +78,10 @@ node scripts/sub2api-admin.js accounts clear-rate-limit 40
 node scripts/sub2api-admin.js accounts recover-state 40
 node scripts/sub2api-admin.js accounts reset-quota 40
 node scripts/sub2api-admin.js accounts refresh 40
+node scripts/sub2api-admin.js accounts refresh-tier 40
 node scripts/sub2api-admin.js accounts test 40
 node scripts/sub2api-admin.js accounts sync-models 40
+node scripts/sub2api-admin.js accounts set-privacy 40
 node scripts/sub2api-admin.js accounts apply-oauth 40 --file credentials.json
 node scripts/sub2api-admin.js accounts reset-temp-unschedulable 40
 ```
@@ -75,6 +102,8 @@ node scripts/sub2api-admin.js accounts batch-create --file accounts.json
 node scripts/sub2api-admin.js accounts batch-update-credentials --file payload.json
 node scripts/sub2api-admin.js accounts bulk-update --ids 40,39 --json '{"concurrency":10,"priority":2}'
 node scripts/sub2api-admin.js accounts batch-refresh --ids 40,39
+node scripts/sub2api-admin.js accounts batch-refresh-tier --ids 40,39
+node scripts/sub2api-admin.js accounts batch-refresh-tier
 node scripts/sub2api-admin.js accounts batch-clear-error --ids 40,39
 ```
 
@@ -115,9 +144,37 @@ node scripts/sub2api-admin.js accounts import-json \
 ## Groups And Proxies
 
 ```bash
+node scripts/sub2api-admin.js groups list --page-size 20
 node scripts/sub2api-admin.js groups all
+node scripts/sub2api-admin.js groups all --include-inactive
+node scripts/sub2api-admin.js groups get 2
+node scripts/sub2api-admin.js groups usage-summary
+node scripts/sub2api-admin.js groups capacity-summary
+node scripts/sub2api-admin.js groups models-list-candidates 2 --platform openai
+node scripts/sub2api-admin.js groups stats 2
+node scripts/sub2api-admin.js groups api-keys 2 --page-size 20
+node scripts/sub2api-admin.js groups rate-multipliers 2
+node scripts/sub2api-admin.js groups set-rate-multipliers 2 --json '{"entries":[{"user_id":123,"rate_multiplier":0.8}]}'
+node scripts/sub2api-admin.js groups clear-rate-multipliers 2
+node scripts/sub2api-admin.js groups set-rpm-overrides 2 --json '{"entries":[{"user_id":123,"rpm_override":60}]}'
+node scripts/sub2api-admin.js groups clear-rpm-overrides 2
+node scripts/sub2api-admin.js groups update 2 --json '{"status":"inactive"}'
+
+node scripts/sub2api-admin.js proxies list --page-size 20
 node scripts/sub2api-admin.js proxies all
+node scripts/sub2api-admin.js proxies all --with-count
+node scripts/sub2api-admin.js proxies get 3
+node scripts/sub2api-admin.js proxies test 3
+node scripts/sub2api-admin.js proxies quality-check 3
+node scripts/sub2api-admin.js proxies stats 3
+node scripts/sub2api-admin.js proxies accounts 3
+node scripts/sub2api-admin.js proxies export --ids 3,4 --file proxies-export.json
+node scripts/sub2api-admin.js proxies import-data --file proxies-export.json
+node scripts/sub2api-admin.js proxies batch-create --file proxies.json
+node scripts/sub2api-admin.js proxies batch-delete --ids 3,4
 ```
+
+分组倍率、RPM 覆盖、代理删除等会影响真实调度；写入前先 `list`/`get` 核对目标。
 
 ## Redeem Codes
 
@@ -215,6 +272,8 @@ node scripts/sub2api-admin.js api POST /admin/accounts/bulk-update \
 - `POST /api/v1/admin/accounts/:id/test`
 - `POST /api/v1/admin/accounts/:id/refresh`
 - `POST /api/v1/admin/accounts/:id/apply-oauth-credentials`
+- `POST /api/v1/admin/accounts/:id/set-privacy`
+- `POST /api/v1/admin/accounts/:id/refresh-tier`
 - `POST /api/v1/admin/accounts/:id/clear-error`
 - `POST /api/v1/admin/accounts/:id/clear-rate-limit`
 - `POST /api/v1/admin/accounts/:id/recover-state`
@@ -223,8 +282,10 @@ node scripts/sub2api-admin.js api POST /admin/accounts/bulk-update \
 - `DELETE /api/v1/admin/accounts/:id/temp-unschedulable`
 - `GET /api/v1/admin/accounts/:id/models`
 - `POST /api/v1/admin/accounts/:id/models/sync-upstream`
+- `POST /api/v1/admin/accounts/models/sync-upstream-preview`
 - `POST /api/v1/admin/accounts/batch`
 - `POST /api/v1/admin/accounts/batch-update-credentials`
+- `POST /api/v1/admin/accounts/batch-refresh-tier`
 - `POST /api/v1/admin/accounts/bulk-update`
 - `POST /api/v1/admin/accounts/batch-refresh`
 - `POST /api/v1/admin/accounts/batch-clear-error`
@@ -234,8 +295,43 @@ node scripts/sub2api-admin.js api POST /admin/accounts/bulk-update \
 - `POST /api/v1/admin/accounts/sync/crs/preview`
 - `POST /api/v1/admin/accounts/sync/crs`
 - `GET /api/v1/admin/accounts/antigravity/default-model-mapping`
+- `POST /api/v1/admin/accounts/generate-auth-url`
+- `POST /api/v1/admin/accounts/generate-setup-token-url`
+- `POST /api/v1/admin/accounts/exchange-code`
+- `POST /api/v1/admin/accounts/exchange-setup-token-code`
+- `POST /api/v1/admin/accounts/cookie-auth`
+- `POST /api/v1/admin/accounts/setup-token-cookie-auth`
+- `GET /api/v1/admin/groups`
 - `GET /api/v1/admin/groups/all`
+- `GET /api/v1/admin/groups/usage-summary`
+- `GET /api/v1/admin/groups/capacity-summary`
+- `PUT /api/v1/admin/groups/sort-order`
+- `GET /api/v1/admin/groups/:id/models-list-candidates`
+- `GET /api/v1/admin/groups/:id`
+- `POST /api/v1/admin/groups`
+- `PUT /api/v1/admin/groups/:id`
+- `DELETE /api/v1/admin/groups/:id`
+- `GET /api/v1/admin/groups/:id/stats`
+- `GET /api/v1/admin/groups/:id/rate-multipliers`
+- `PUT /api/v1/admin/groups/:id/rate-multipliers`
+- `DELETE /api/v1/admin/groups/:id/rate-multipliers`
+- `PUT /api/v1/admin/groups/:id/rpm-overrides`
+- `DELETE /api/v1/admin/groups/:id/rpm-overrides`
+- `GET /api/v1/admin/groups/:id/api-keys`
+- `GET /api/v1/admin/proxies`
 - `GET /api/v1/admin/proxies/all`
+- `GET /api/v1/admin/proxies/data`
+- `POST /api/v1/admin/proxies/data`
+- `GET /api/v1/admin/proxies/:id`
+- `POST /api/v1/admin/proxies`
+- `PUT /api/v1/admin/proxies/:id`
+- `DELETE /api/v1/admin/proxies/:id`
+- `POST /api/v1/admin/proxies/:id/test`
+- `POST /api/v1/admin/proxies/:id/quality-check`
+- `GET /api/v1/admin/proxies/:id/stats`
+- `GET /api/v1/admin/proxies/:id/accounts`
+- `POST /api/v1/admin/proxies/batch-delete`
+- `POST /api/v1/admin/proxies/batch`
 - `GET /api/v1/admin/redeem-codes`
 - `GET /api/v1/admin/redeem-codes/export`
 - `GET /api/v1/admin/redeem-codes/stats`
@@ -257,8 +353,38 @@ node scripts/sub2api-admin.js api POST /admin/accounts/bulk-update \
 - `PUT /api/v1/admin/tls-fingerprint-profiles/:id`
 - `DELETE /api/v1/admin/tls-fingerprint-profiles/:id`
 
+以下接口已在上游路由中确认，但当前 CLI 主要通过 `api <METHOD> <path>` 直通调用：
+
+- `GET /api/v1/admin/dashboard/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/users/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/announcements/*`
+- `POST /api/v1/admin/openai/*`
+- `GET|POST /api/v1/admin/gemini/oauth/*`
+- `POST /api/v1/admin/antigravity/oauth/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/promo-codes/*`
+- `GET|PUT|POST|DELETE /api/v1/admin/settings/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/data-management/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/backups/*`
+- `GET|POST /api/v1/admin/system/*`
+- `GET|POST|DELETE /api/v1/admin/subscriptions/*`
+- `GET|POST /api/v1/admin/usage/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/user-attributes/*`
+- `PUT /api/v1/admin/api-keys/:id`
+- `GET|POST|PUT|DELETE /api/v1/admin/ops/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/scheduled-test-plans/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/channels/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/channel-monitors/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/channel-monitor-templates/*`
+- `GET|PUT|POST|DELETE /api/v1/admin/risk-control/*`
+- `GET|POST|PUT|DELETE /api/v1/admin/affiliates/*`
+- `POST /api/v1/auth/login`
+- `GET /api/v1/groups/available`
+- `GET /api/v1/groups/rates`
+- `GET|POST|PUT|DELETE /api/v1/keys/*`
+
 ## Notes
 
 - 线上写入前先只读核对目标集合。
 - 导出结果包含敏感凭据，优先使用 `--file`。
+- `proxies export` 可能包含代理凭据，优先使用 `--file`。
 - `PUT /admin/accounts/:id` 和 `bulk-update` 接受宽松请求体，字段名不确定时先用 `accounts get` 或后台页面确认。

--- a/skills/sub2api-admin/scripts/sub2api-admin.js
+++ b/skills/sub2api-admin/scripts/sub2api-admin.js
@@ -5,6 +5,7 @@ const path = require("path");
 
 const BASE_URL = (process.env.SUB2API_BASE_URL || "").replace(/\/$/, "");
 const ADMIN_API_KEY = process.env.SUB2API_ADMIN_API_KEY || "";
+const USER_TOKEN = process.env.SUB2API_USER_TOKEN || "";
 
 function usage() {
   console.log(`Usage:
@@ -27,14 +28,17 @@ function usage() {
   sub2api-admin.js accounts recover-state <id>
   sub2api-admin.js accounts reset-quota <id>
   sub2api-admin.js accounts refresh <id>
+  sub2api-admin.js accounts refresh-tier <id>
   sub2api-admin.js accounts test <id>
   sub2api-admin.js accounts models <id>
   sub2api-admin.js accounts sync-models <id>
+  sub2api-admin.js accounts sync-models-preview --json '{...}' | --file payload.json
   sub2api-admin.js accounts apply-oauth <id> --json '{...}' | --file credentials.json
   sub2api-admin.js accounts batch-create --file accounts.json
   sub2api-admin.js accounts batch-update-credentials --json '{...}' | --file payload.json
   sub2api-admin.js accounts bulk-update --ids 1,2 --json '{...}' | --file patch.json
   sub2api-admin.js accounts batch-refresh --ids 1,2
+  sub2api-admin.js accounts batch-refresh-tier [--ids 1,2]
   sub2api-admin.js accounts batch-clear-error --ids 1,2
   sub2api-admin.js accounts temp-unschedulable <id>
   sub2api-admin.js accounts reset-temp-unschedulable <id>
@@ -43,8 +47,18 @@ function usage() {
   sub2api-admin.js accounts import-codex-session --json '{...}' | --file payload.json
   sub2api-admin.js accounts antigravity-default-model-mapping
   sub2api-admin.js accounts import-json --file <path> --template-name <name> [--skip-name <name>] [--dry-run]
-  sub2api-admin.js groups all
-  sub2api-admin.js proxies all
+  sub2api-admin.js groups list|all|get|create|update|delete|stats|api-keys ...
+  sub2api-admin.js groups usage-summary|capacity-summary
+  sub2api-admin.js groups models-list-candidates <id> [--platform PLATFORM]
+  sub2api-admin.js groups set-rate-multipliers <id> --json '{"entries":[...]}'
+  sub2api-admin.js groups clear-rate-multipliers <id>
+  sub2api-admin.js groups set-rpm-overrides <id> --json '{"entries":[...]}'
+  sub2api-admin.js groups clear-rpm-overrides <id>
+  sub2api-admin.js proxies list|all|get|create|update|delete|test|quality-check|stats|accounts ...
+  sub2api-admin.js proxies export [--ids 1,2] [--file proxies.json] [list filters...]
+  sub2api-admin.js proxies import-data --file proxies.json
+  sub2api-admin.js proxies batch-create --file proxies.json
+  sub2api-admin.js proxies batch-delete --ids 1,2
   sub2api-admin.js redeem-codes list [--page-size 200] [--page N] [--type balance] [--status unused] [--search TEXT] [--sort-by id] [--sort-order desc]
   sub2api-admin.js redeem-codes export [--file redeem-codes.csv] [list filters...]
   sub2api-admin.js redeem-codes get <id>
@@ -57,6 +71,9 @@ function usage() {
   sub2api-admin.js redeem-codes stats
   sub2api-admin.js error-rules list|get|create|update|delete|toggle ...
   sub2api-admin.js tls-profiles list|get|create|update|delete ...
+  sub2api-admin.js auth login --email <email> --password <password>
+  sub2api-admin.js user-groups available|rates
+  sub2api-admin.js user-keys list|get|create|update|delete|toggle ...
   sub2api-admin.js api <GET|POST|PUT|DELETE> <admin-path> [--json '{...}' | --file payload.json]
 `);
 }
@@ -94,12 +111,22 @@ function authHeaders() {
   throw new Error("Missing SUB2API_ADMIN_API_KEY");
 }
 
-async function apiRequest(method, pathname, body, extraHeaders = {}) {
+function userAuthHeaders() {
+  if (!BASE_URL) throw new Error("Missing SUB2API_BASE_URL");
+  if (USER_TOKEN) return { Authorization: `Bearer ${USER_TOKEN}` };
+  throw new Error("Missing SUB2API_USER_TOKEN");
+}
+
+async function jsonRequest(method, pathname, body, authHeadersValue = {}, extraHeaders = {}) {
+  if (!BASE_URL) throw new Error("Missing SUB2API_BASE_URL");
   const headers = {
-    ...authHeaders(),
+    ...authHeadersValue,
     Accept: "application/json",
     ...extraHeaders,
   };
+  for (const key of Object.keys(headers)) {
+    if (headers[key] === undefined) delete headers[key];
+  }
   const options = { method, headers };
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
@@ -118,6 +145,19 @@ async function apiRequest(method, pathname, body, extraHeaders = {}) {
     throw new Error(`${method} ${pathname} failed: ${detail}`);
   }
   return data.data;
+}
+
+async function apiRequest(method, pathname, body, extraHeaders = {}) {
+  return jsonRequest(method, pathname, body, authHeaders(), extraHeaders);
+}
+
+async function userRequest(method, userPath, body, extraHeaders = {}) {
+  const pathname = userPath.startsWith("/api/v1/") ? userPath : `/api/v1${userPath.startsWith("/") ? userPath : `/${userPath}`}`;
+  return jsonRequest(method, pathname, body, userAuthHeaders(), extraHeaders);
+}
+
+async function publicRequest(method, pathname, body, extraHeaders = {}) {
+  return jsonRequest(method, pathname, body, {}, extraHeaders);
 }
 
 async function apiRawRequest(method, pathname, body, extraHeaders = {}) {
@@ -271,6 +311,17 @@ function redeemCodesQuery(flags) {
   });
 }
 
+function standardListQuery(flags, extra = {}) {
+  return encodeQuery({
+    page: Number(flags.page || 1),
+    page_size: Number(flags["page-size"] || 20),
+    sort_by: flags["sort-by"],
+    sort_order: flags["sort-order"],
+    search: flags.search,
+    ...extra,
+  });
+}
+
 function idempotencyHeaders(flags) {
   if (!flags["idempotency-key"]) return {};
   return { "Idempotency-Key": flags["idempotency-key"] };
@@ -278,6 +329,89 @@ function idempotencyHeaders(flags) {
 
 function printJson(data) {
   console.log(JSON.stringify(data, null, 2));
+}
+
+async function commandAuth(args) {
+  const sub = args.positional[1];
+  if (sub === "login") {
+    const email = args.flags.email;
+    const password = args.flags.password;
+    if (!email || !password) throw new Error("auth login requires --email and --password");
+    printJson(await publicRequest("POST", "/api/v1/auth/login", { email, password }));
+    return;
+  }
+  throw new Error(`unknown auth subcommand: ${sub || "(missing)"}`);
+}
+
+async function commandUserGroups(args) {
+  const sub = args.positional[1];
+  if (sub === "available") {
+    printJson(await userRequest("GET", `/groups/available${encodeQuery({ timezone: args.flags.timezone || "Asia/Shanghai" })}`));
+    return;
+  }
+  if (sub === "rates") {
+    printJson(await userRequest("GET", "/groups/rates"));
+    return;
+  }
+  throw new Error(`unknown user-groups subcommand: ${sub || "(missing)"}`);
+}
+
+function userKeysQuery(flags) {
+  return standardListQuery(flags, {
+    sort_by: flags["sort-by"] || "created_at",
+    sort_order: flags["sort-order"] || "desc",
+    status: flags.status,
+    group_id: flags["group-id"],
+    timezone: flags.timezone || "Asia/Shanghai",
+  });
+}
+
+function userKeyCreatePayload(flags) {
+  const payload = readJsonPayload(flags, { required: false }) || {};
+  if (flags.name) payload.name = flags.name;
+  if (flags["group-id"]) payload.group_id = Number(flags["group-id"]);
+  if (flags.quota !== undefined) payload.quota = Number(flags.quota);
+  if (flags["expires-in-days"]) payload.expires_in_days = Number(flags["expires-in-days"]);
+  if (flags["expires-at"]) payload.expires_at = flags["expires-at"];
+  if (flags["custom-key"]) payload.custom_key = flags["custom-key"];
+  if (!payload.name) throw new Error("user-keys create requires name");
+  if (payload.quota === undefined) payload.quota = 0;
+  return payload;
+}
+
+async function commandUserKeys(args) {
+  const sub = args.positional[1];
+  const id = args.positional[2];
+  if (sub === "list") {
+    printJson(await userRequest("GET", `/keys${userKeysQuery(args.flags)}`));
+    return;
+  }
+  if (sub === "get") {
+    if (!id) throw new Error("user-keys get requires <id>");
+    printJson(await userRequest("GET", `/keys/${id}`));
+    return;
+  }
+  if (sub === "create") {
+    printJson(await userRequest("POST", "/keys", userKeyCreatePayload(args.flags), idempotencyHeaders(args.flags)));
+    return;
+  }
+  if (sub === "update") {
+    if (!id) throw new Error("user-keys update requires <id>");
+    printJson(await userRequest("PUT", `/keys/${id}`, readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "toggle") {
+    const status = args.positional[3];
+    if (!id || !status) throw new Error("user-keys toggle requires <id> <active|inactive>");
+    printJson(await userRequest("PUT", `/keys/${id}`, { status }));
+    return;
+  }
+  if (sub === "delete") {
+    if (!id) throw new Error("user-keys delete requires <id>");
+    printJson(await userRequest("DELETE", `/keys/${id}`));
+    return;
+  }
+  throw new Error(`unknown user-keys subcommand: ${sub || "(missing)"}`);
 }
 
 async function accountData(flags) {
@@ -429,6 +563,7 @@ async function commandAccounts(args) {
     "recover-state": "recover-state",
     "reset-quota": "reset-quota",
     refresh: "refresh",
+    "refresh-tier": "refresh-tier",
     test: "test",
     "sync-models": "models/sync-upstream",
     "set-privacy": "set-privacy",
@@ -482,6 +617,12 @@ async function commandAccounts(args) {
     return;
   }
 
+  if (sub === "batch-refresh-tier") {
+    const payload = args.flags.ids ? { account_ids: parseIds(args.flags.ids) } : {};
+    printJson(await adminRequest("POST", "/admin/accounts/batch-refresh-tier", payload));
+    return;
+  }
+
   if (sub === "batch-clear-error") {
     printJson(await adminRequest("POST", "/admin/accounts/batch-clear-error", { account_ids: parseIds(args.flags.ids) }));
     return;
@@ -508,6 +649,11 @@ async function commandAccounts(args) {
 
   if (sub === "crs-sync") {
     printJson(await adminRequest("POST", "/admin/accounts/sync/crs", readJsonPayload(args.flags)));
+    return;
+  }
+
+  if (sub === "sync-models-preview") {
+    printJson(await adminRequest("POST", "/admin/accounts/models/sync-upstream-preview", readJsonPayload(args.flags)));
     return;
   }
 
@@ -589,8 +735,91 @@ async function commandAccounts(args) {
 
 async function commandGroups(args) {
   const sub = args.positional[1];
+  const id = args.positional[2];
+  if (sub === "list") {
+    printJson(await adminRequest("GET", `/admin/groups${standardListQuery(args.flags, {
+      platform: args.flags.platform,
+      status: args.flags.status,
+      is_exclusive: args.flags["is-exclusive"],
+    })}`));
+    return;
+  }
   if (sub === "all") {
-    printJson(await adminRequest("GET", "/admin/groups/all"));
+    printJson(await adminRequest("GET", `/admin/groups/all${encodeQuery({
+      platform: args.flags.platform,
+      include_inactive: args.flags["include-inactive"] ? "true" : undefined,
+    })}`));
+    return;
+  }
+  if (sub === "get") {
+    if (!id) throw new Error("groups get requires <id>");
+    printJson(await adminRequest("GET", `/admin/groups/${id}`));
+    return;
+  }
+  if (sub === "create") {
+    printJson(await adminRequest("POST", "/admin/groups", readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "update") {
+    if (!id) throw new Error("groups update requires <id>");
+    printJson(await adminRequest("PUT", `/admin/groups/${id}`, readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "delete") {
+    if (!id) throw new Error("groups delete requires <id>");
+    printJson(await adminRequest("DELETE", `/admin/groups/${id}`));
+    return;
+  }
+  if (sub === "usage-summary") {
+    printJson(await adminRequest("GET", "/admin/groups/usage-summary"));
+    return;
+  }
+  if (sub === "capacity-summary") {
+    printJson(await adminRequest("GET", "/admin/groups/capacity-summary"));
+    return;
+  }
+  if (sub === "sort-order") {
+    printJson(await adminRequest("PUT", "/admin/groups/sort-order", readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "models-list-candidates") {
+    if (!id) throw new Error("groups models-list-candidates requires <id>");
+    printJson(await adminRequest("GET", `/admin/groups/${id}/models-list-candidates${encodeQuery({ platform: args.flags.platform })}`));
+    return;
+  }
+  if (sub === "stats") {
+    if (!id) throw new Error("groups stats requires <id>");
+    printJson(await adminRequest("GET", `/admin/groups/${id}/stats`));
+    return;
+  }
+  if (sub === "api-keys") {
+    if (!id) throw new Error("groups api-keys requires <id>");
+    printJson(await adminRequest("GET", `/admin/groups/${id}/api-keys${standardListQuery(args.flags)}`));
+    return;
+  }
+  if (sub === "rate-multipliers") {
+    if (!id) throw new Error("groups rate-multipliers requires <id>");
+    printJson(await adminRequest("GET", `/admin/groups/${id}/rate-multipliers`));
+    return;
+  }
+  if (sub === "set-rate-multipliers") {
+    if (!id) throw new Error("groups set-rate-multipliers requires <id>");
+    printJson(await adminRequest("PUT", `/admin/groups/${id}/rate-multipliers`, readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "clear-rate-multipliers") {
+    if (!id) throw new Error("groups clear-rate-multipliers requires <id>");
+    printJson(await adminRequest("DELETE", `/admin/groups/${id}/rate-multipliers`));
+    return;
+  }
+  if (sub === "set-rpm-overrides") {
+    if (!id) throw new Error("groups set-rpm-overrides requires <id>");
+    printJson(await adminRequest("PUT", `/admin/groups/${id}/rpm-overrides`, readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "clear-rpm-overrides") {
+    if (!id) throw new Error("groups clear-rpm-overrides requires <id>");
+    printJson(await adminRequest("DELETE", `/admin/groups/${id}/rpm-overrides`));
     return;
   }
   throw new Error(`unknown groups subcommand: ${sub || "(missing)"}`);
@@ -598,8 +827,86 @@ async function commandGroups(args) {
 
 async function commandProxies(args) {
   const sub = args.positional[1];
+  const id = args.positional[2];
+  if (sub === "list") {
+    printJson(await adminRequest("GET", `/admin/proxies${standardListQuery(args.flags, {
+      protocol: args.flags.protocol,
+      status: args.flags.status,
+    })}`));
+    return;
+  }
   if (sub === "all") {
-    printJson(await adminRequest("GET", "/admin/proxies/all"));
+    printJson(await adminRequest("GET", `/admin/proxies/all${encodeQuery({ with_count: args.flags["with-count"] ? "true" : undefined })}`));
+    return;
+  }
+  if (sub === "get") {
+    if (!id) throw new Error("proxies get requires <id>");
+    printJson(await adminRequest("GET", `/admin/proxies/${id}`));
+    return;
+  }
+  if (sub === "create") {
+    printJson(await adminRequest("POST", "/admin/proxies", readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "update") {
+    if (!id) throw new Error("proxies update requires <id>");
+    printJson(await adminRequest("PUT", `/admin/proxies/${id}`, readJsonPayload(args.flags)));
+    return;
+  }
+  if (sub === "delete") {
+    if (!id) throw new Error("proxies delete requires <id>");
+    printJson(await adminRequest("DELETE", `/admin/proxies/${id}`));
+    return;
+  }
+  for (const action of ["test", "quality-check"]) {
+    if (sub === action) {
+      if (!id) throw new Error(`proxies ${action} requires <id>`);
+      printJson(await adminRequest("POST", `/admin/proxies/${id}/${action}`));
+      return;
+    }
+  }
+  for (const action of ["stats", "accounts"]) {
+    if (sub === action) {
+      if (!id) throw new Error(`proxies ${action} requires <id>`);
+      printJson(await adminRequest("GET", `/admin/proxies/${id}/${action}`));
+      return;
+    }
+  }
+  if (sub === "export") {
+    const params = {};
+    if (args.flags.ids) {
+      params.ids = parseIds(args.flags.ids).join(",");
+    } else {
+      params.protocol = args.flags.protocol;
+      params.status = args.flags.status;
+      params.search = args.flags.search;
+      params.sort_by = args.flags["sort-by"];
+      params.sort_order = args.flags["sort-order"];
+    }
+    const data = await adminRequest("GET", `/admin/proxies/data${encodeQuery(params)}`);
+    if (args.flags.file) {
+      fs.writeFileSync(path.resolve(args.flags.file), JSON.stringify(data, null, 2));
+      printJson({ file: path.resolve(args.flags.file), count: Array.isArray(data) ? data.length : data.count });
+    } else {
+      printJson(data);
+    }
+    return;
+  }
+  if (sub === "import-data") {
+    const file = args.flags.file;
+    if (!file) throw new Error("proxies import-data requires --file");
+    printJson(await adminRequest("POST", "/admin/proxies/data", { data: JSON.parse(fs.readFileSync(path.resolve(file), "utf8")) }));
+    return;
+  }
+  if (sub === "batch-create") {
+    const payload = readJsonPayload(args.flags);
+    const proxies = Array.isArray(payload) ? payload : payload.proxies;
+    if (!Array.isArray(proxies)) throw new Error("batch-create payload must be an array or {proxies:[...]}");
+    printJson(await adminRequest("POST", "/admin/proxies/batch", { proxies }));
+    return;
+  }
+  if (sub === "batch-delete") {
+    printJson(await adminRequest("POST", "/admin/proxies/batch-delete", { ids: parseIds(args.flags.ids) }));
     return;
   }
   throw new Error(`unknown proxies subcommand: ${sub || "(missing)"}`);
@@ -742,6 +1049,18 @@ async function main() {
   }
   if (root === "tls-profiles") {
     await commandCrudResource(args, "tls-profiles", "/admin/tls-fingerprint-profiles");
+    return;
+  }
+  if (root === "auth") {
+    await commandAuth(args);
+    return;
+  }
+  if (root === "user-groups") {
+    await commandUserGroups(args);
+    return;
+  }
+  if (root === "user-keys") {
+    await commandUserKeys(args);
     return;
   }
   if (root === "api") {


### PR DESCRIPTION
## Summary

- expand `skills/sub2api-admin` to cover the current upstream admin route surface for accounts, groups, proxies, user keys, and route-backed raw admin calls
- add user-side helper commands for login, available groups, group rates, and API key CRUD
- add a skill changelog documenting the 2026-06-13 update scope

## Notes

- The branch is based on `Wei-Shaw/sub2api@main` after fetching the upstream repository.
- The CLI remains dependency-free and continues to use the existing single-file Node.js script style.
- Newly added wrappers keep destructive operations explicit and preserve the existing read-first workflow guidance.

## Validation

- `node --check skills/sub2api-admin/scripts/sub2api-admin.js`
- `git diff --check`

Backend/frontend tests were not run because this PR only changes the bundled skill documentation and helper script under `skills/sub2api-admin`.
