### PR TITLE
feat(email): 增加Resend与Cloudflare 邮件发送提供商

### DIFF
--- a/backend/internal/handler/admin/setting_handler.go
+++ b/backend/internal/handler/admin/setting_handler.go
@@ -139,6 +139,15 @@ func (h *SettingHandler) GetSettings(c *gin.Context) {
 		SMTPFrom:                               settings.SMTPFrom,
 		SMTPFromName:                           settings.SMTPFromName,
 		SMTPUseTLS:                             settings.SMTPUseTLS,
+		EmailProvider:                          settings.EmailProvider,
+		ResendAPIKeyConfigured:                 settings.ResendAPIKeyConfigured,
+		ResendFromEmail:                        settings.ResendFromEmail,
+		ResendFromName:                         settings.ResendFromName,
+		ResendAPIBaseURL:                       settings.ResendAPIBaseURL,
+		CloudflareAPITokenConfigured:           settings.CloudflareAPITokenConfigured,
+		CloudflareAccountID:                    settings.CloudflareAccountID,
+		CloudflareFromEmail:                    settings.CloudflareFromEmail,
+		CloudflareFromName:                     settings.CloudflareFromName,
 		TurnstileEnabled:                       settings.TurnstileEnabled,
 		TurnstileSiteKey:                       settings.TurnstileSiteKey,
 		TurnstileSecretKeyConfigured:           settings.TurnstileSecretKeyConfigured,
@@ -398,13 +407,22 @@ type UpdateSettingsRequest struct {
 	LoginAgreementDocuments          []dto.LoginAgreementDocument `json:"login_agreement_documents"`
 
 	// 邮件服务设置
-	SMTPHost     string `json:"smtp_host"`
-	SMTPPort     int    `json:"smtp_port"`
-	SMTPUsername string `json:"smtp_username"`
-	SMTPPassword string `json:"smtp_password"`
-	SMTPFrom     string `json:"smtp_from_email"`
-	SMTPFromName string `json:"smtp_from_name"`
-	SMTPUseTLS   bool   `json:"smtp_use_tls"`
+	SMTPHost            string `json:"smtp_host"`
+	SMTPPort            int    `json:"smtp_port"`
+	SMTPUsername        string `json:"smtp_username"`
+	SMTPPassword        string `json:"smtp_password"`
+	SMTPFrom            string `json:"smtp_from_email"`
+	SMTPFromName        string `json:"smtp_from_name"`
+	SMTPUseTLS          bool   `json:"smtp_use_tls"`
+	EmailProvider       string `json:"email_provider"`
+	ResendAPIKey        string `json:"resend_api_key"`
+	ResendFromEmail     string `json:"resend_from_email"`
+	ResendFromName      string `json:"resend_from_name"`
+	ResendAPIBaseURL    string `json:"resend_api_base_url"`
+	CloudflareAPIToken  string `json:"cloudflare_api_token"`
+	CloudflareAccountID string `json:"cloudflare_account_id"`
+	CloudflareFromEmail string `json:"cloudflare_from_email"`
+	CloudflareFromName  string `json:"cloudflare_from_name"`
 
 	// Cloudflare Turnstile 设置
 	TurnstileEnabled   bool   `json:"turnstile_enabled"`
@@ -740,6 +758,15 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 	req.SMTPPassword = strings.TrimSpace(req.SMTPPassword)
 	req.SMTPFrom = strings.TrimSpace(req.SMTPFrom)
 	req.SMTPFromName = strings.TrimSpace(req.SMTPFromName)
+	req.EmailProvider = strings.TrimSpace(req.EmailProvider)
+	req.ResendAPIKey = strings.TrimSpace(req.ResendAPIKey)
+	req.ResendFromEmail = strings.TrimSpace(req.ResendFromEmail)
+	req.ResendFromName = strings.TrimSpace(req.ResendFromName)
+	req.ResendAPIBaseURL = strings.TrimSpace(req.ResendAPIBaseURL)
+	req.CloudflareAPIToken = strings.TrimSpace(req.CloudflareAPIToken)
+	req.CloudflareAccountID = strings.TrimSpace(req.CloudflareAccountID)
+	req.CloudflareFromEmail = strings.TrimSpace(req.CloudflareFromEmail)
+	req.CloudflareFromName = strings.TrimSpace(req.CloudflareFromName)
 	if req.SMTPPort <= 0 {
 		req.SMTPPort = 587
 	}
@@ -759,6 +786,50 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		req.SMTPFrom = previousSettings.SMTPFrom
 		req.SMTPFromName = previousSettings.SMTPFromName
 		req.SMTPUseTLS = previousSettings.SMTPUseTLS
+	}
+
+	if req.EmailProvider == "" {
+		req.EmailProvider = previousSettings.EmailProvider
+	}
+	provider, err := service.NormalizeEmailProvider(req.EmailProvider)
+	if err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+	req.EmailProvider = provider
+	if req.ResendAPIBaseURL == "" {
+		req.ResendAPIBaseURL = previousSettings.ResendAPIBaseURL
+	}
+	if req.ResendAPIBaseURL == "" {
+		req.ResendAPIBaseURL = service.DefaultResendAPIBaseURL()
+	}
+	if _, err := service.NormalizeResendAPIBaseURL(req.ResendAPIBaseURL); err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+	if req.EmailProvider == service.EmailProviderResend {
+		if req.ResendAPIKey == "" && previousSettings.ResendAPIKey == "" {
+			response.BadRequest(c, "Resend API key is required when Resend is selected")
+			return
+		}
+		if req.ResendFromEmail == "" {
+			response.BadRequest(c, "Resend from email is required when Resend is selected")
+			return
+		}
+	}
+	if req.EmailProvider == service.EmailProviderCloudflare {
+		if req.CloudflareAPIToken == "" && previousSettings.CloudflareAPIToken == "" {
+			response.BadRequest(c, "Cloudflare API token is required when Cloudflare is selected")
+			return
+		}
+		if req.CloudflareAccountID == "" {
+			response.BadRequest(c, "Cloudflare account ID is required when Cloudflare is selected")
+			return
+		}
+		if req.CloudflareFromEmail == "" {
+			response.BadRequest(c, "Cloudflare from email is required when Cloudflare is selected")
+			return
+		}
 	}
 
 	// Turnstile 参数验证
@@ -1485,6 +1556,15 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		SMTPFrom:                         req.SMTPFrom,
 		SMTPFromName:                     req.SMTPFromName,
 		SMTPUseTLS:                       req.SMTPUseTLS,
+		EmailProvider:                    req.EmailProvider,
+		ResendAPIKey:                     req.ResendAPIKey,
+		ResendFromEmail:                  req.ResendFromEmail,
+		ResendFromName:                   req.ResendFromName,
+		ResendAPIBaseURL:                 req.ResendAPIBaseURL,
+		CloudflareAPIToken:               req.CloudflareAPIToken,
+		CloudflareAccountID:              req.CloudflareAccountID,
+		CloudflareFromEmail:              req.CloudflareFromEmail,
+		CloudflareFromName:               req.CloudflareFromName,
 		TurnstileEnabled:                 req.TurnstileEnabled,
 		TurnstileSiteKey:                 req.TurnstileSiteKey,
 		TurnstileSecretKey:               req.TurnstileSecretKey,
@@ -1933,6 +2013,15 @@ func (h *SettingHandler) UpdateSettings(c *gin.Context) {
 		SMTPFrom:                               updatedSettings.SMTPFrom,
 		SMTPFromName:                           updatedSettings.SMTPFromName,
 		SMTPUseTLS:                             updatedSettings.SMTPUseTLS,
+		EmailProvider:                          updatedSettings.EmailProvider,
+		ResendAPIKeyConfigured:                 updatedSettings.ResendAPIKeyConfigured,
+		ResendFromEmail:                        updatedSettings.ResendFromEmail,
+		ResendFromName:                         updatedSettings.ResendFromName,
+		ResendAPIBaseURL:                       updatedSettings.ResendAPIBaseURL,
+		CloudflareAPITokenConfigured:           updatedSettings.CloudflareAPITokenConfigured,
+		CloudflareAccountID:                    updatedSettings.CloudflareAccountID,
+		CloudflareFromEmail:                    updatedSettings.CloudflareFromEmail,
+		CloudflareFromName:                     updatedSettings.CloudflareFromName,
 		TurnstileEnabled:                       updatedSettings.TurnstileEnabled,
 		TurnstileSiteKey:                       updatedSettings.TurnstileSiteKey,
 		TurnstileSecretKeyConfigured:           updatedSettings.TurnstileSecretKeyConfigured,
@@ -2213,6 +2302,33 @@ func diffSettings(before *service.SystemSettings, after *service.SystemSettings,
 	}
 	if before.SMTPUseTLS != after.SMTPUseTLS {
 		changed = append(changed, "smtp_use_tls")
+	}
+	if before.EmailProvider != after.EmailProvider {
+		changed = append(changed, "email_provider")
+	}
+	if req.ResendAPIKey != "" {
+		changed = append(changed, "resend_api_key")
+	}
+	if before.ResendFromEmail != after.ResendFromEmail {
+		changed = append(changed, "resend_from_email")
+	}
+	if before.ResendFromName != after.ResendFromName {
+		changed = append(changed, "resend_from_name")
+	}
+	if before.ResendAPIBaseURL != after.ResendAPIBaseURL {
+		changed = append(changed, "resend_api_base_url")
+	}
+	if req.CloudflareAPIToken != "" {
+		changed = append(changed, "cloudflare_api_token")
+	}
+	if before.CloudflareAccountID != after.CloudflareAccountID {
+		changed = append(changed, "cloudflare_account_id")
+	}
+	if before.CloudflareFromEmail != after.CloudflareFromEmail {
+		changed = append(changed, "cloudflare_from_email")
+	}
+	if before.CloudflareFromName != after.CloudflareFromName {
+		changed = append(changed, "cloudflare_from_name")
 	}
 	if before.TurnstileEnabled != after.TurnstileEnabled {
 		changed = append(changed, "turnstile_enabled")
@@ -2885,14 +3001,23 @@ func (h *SettingHandler) TestSMTPConnection(c *gin.Context) {
 
 // SendTestEmailRequest 发送测试邮件请求
 type SendTestEmailRequest struct {
-	Email        string `json:"email" binding:"required,email"`
-	SMTPHost     string `json:"smtp_host"`
-	SMTPPort     int    `json:"smtp_port"`
-	SMTPUsername string `json:"smtp_username"`
-	SMTPPassword string `json:"smtp_password"`
-	SMTPFrom     string `json:"smtp_from_email"`
-	SMTPFromName string `json:"smtp_from_name"`
-	SMTPUseTLS   bool   `json:"smtp_use_tls"`
+	Email               string `json:"email" binding:"required,email"`
+	SMTPHost            string `json:"smtp_host"`
+	SMTPPort            int    `json:"smtp_port"`
+	SMTPUsername        string `json:"smtp_username"`
+	SMTPPassword        string `json:"smtp_password"`
+	SMTPFrom            string `json:"smtp_from_email"`
+	SMTPFromName        string `json:"smtp_from_name"`
+	SMTPUseTLS          bool   `json:"smtp_use_tls"`
+	EmailProvider       string `json:"email_provider"`
+	ResendAPIKey        string `json:"resend_api_key"`
+	ResendFromEmail     string `json:"resend_from_email"`
+	ResendFromName      string `json:"resend_from_name"`
+	ResendAPIBaseURL    string `json:"resend_api_base_url"`
+	CloudflareAPIToken  string `json:"cloudflare_api_token"`
+	CloudflareAccountID string `json:"cloudflare_account_id"`
+	CloudflareFromEmail string `json:"cloudflare_from_email"`
+	CloudflareFromName  string `json:"cloudflare_from_name"`
 }
 
 // SendTestEmail 发送测试邮件
@@ -2908,6 +3033,21 @@ func (h *SettingHandler) SendTestEmail(c *gin.Context) {
 	req.SMTPUsername = strings.TrimSpace(req.SMTPUsername)
 	req.SMTPFrom = strings.TrimSpace(req.SMTPFrom)
 	req.SMTPFromName = strings.TrimSpace(req.SMTPFromName)
+	req.EmailProvider = strings.TrimSpace(req.EmailProvider)
+	req.ResendAPIKey = strings.TrimSpace(req.ResendAPIKey)
+	req.ResendFromEmail = strings.TrimSpace(req.ResendFromEmail)
+	req.ResendFromName = strings.TrimSpace(req.ResendFromName)
+	req.ResendAPIBaseURL = strings.TrimSpace(req.ResendAPIBaseURL)
+	req.CloudflareAPIToken = strings.TrimSpace(req.CloudflareAPIToken)
+	req.CloudflareAccountID = strings.TrimSpace(req.CloudflareAccountID)
+	req.CloudflareFromEmail = strings.TrimSpace(req.CloudflareFromEmail)
+	req.CloudflareFromName = strings.TrimSpace(req.CloudflareFromName)
+
+	provider, err := service.NormalizeEmailProvider(req.EmailProvider)
+	if err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
 
 	var savedConfig *service.SMTPConfig
 	if cfg, err := h.emailService.GetSMTPConfig(c.Request.Context()); err == nil && cfg != nil {
@@ -2937,12 +3077,12 @@ func (h *SettingHandler) SendTestEmail(c *gin.Context) {
 	if req.SMTPFromName == "" && savedConfig != nil {
 		req.SMTPFromName = savedConfig.FromName
 	}
-	if req.SMTPHost == "" {
+	if provider == service.EmailProviderSMTP && req.SMTPHost == "" {
 		response.BadRequest(c, "SMTP host is required")
 		return
 	}
 
-	config := &service.SMTPConfig{
+	smtpConfig := &service.SMTPConfig{
 		Host:     req.SMTPHost,
 		Port:     req.SMTPPort,
 		Username: req.SMTPUsername,
@@ -2981,13 +3121,60 @@ func (h *SettingHandler) SendTestEmail(c *gin.Context) {
         <div class="footer">
             <p>This is an automated test message.</p>
         </div>
-    </div>
+	</div>
 </body>
 </html>
 `
 
-	if err := h.emailService.SendEmailWithConfig(config, req.Email, subject, body); err != nil {
-		response.BadRequest(c, "Failed to send test email: "+err.Error())
+	var sendErr error
+	switch provider {
+	case service.EmailProviderSMTP:
+		sendErr = h.emailService.SendEmailWithConfig(smtpConfig, req.Email, subject, body)
+	case service.EmailProviderResend:
+		if req.ResendAPIKey == "" {
+			if cfg, err := h.emailService.GetResendConfig(c.Request.Context()); err == nil && cfg != nil {
+				req.ResendAPIKey = cfg.APIKey
+				if req.ResendFromEmail == "" {
+					req.ResendFromEmail = cfg.FromEmail
+				}
+				if req.ResendFromName == "" {
+					req.ResendFromName = cfg.FromName
+				}
+				if req.ResendAPIBaseURL == "" {
+					req.ResendAPIBaseURL = cfg.APIBaseURL
+				}
+			}
+		}
+		sendErr = h.emailService.SendEmailWithResendConfig(c.Request.Context(), &service.ResendConfig{
+			APIKey:     req.ResendAPIKey,
+			FromEmail:  req.ResendFromEmail,
+			FromName:   req.ResendFromName,
+			APIBaseURL: req.ResendAPIBaseURL,
+		}, req.Email, subject, body)
+	case service.EmailProviderCloudflare:
+		if req.CloudflareAPIToken == "" {
+			if cfg, err := h.emailService.GetCloudflareEmailConfig(c.Request.Context()); err == nil && cfg != nil {
+				req.CloudflareAPIToken = cfg.APIToken
+				if req.CloudflareAccountID == "" {
+					req.CloudflareAccountID = cfg.AccountID
+				}
+				if req.CloudflareFromEmail == "" {
+					req.CloudflareFromEmail = cfg.FromEmail
+				}
+				if req.CloudflareFromName == "" {
+					req.CloudflareFromName = cfg.FromName
+				}
+			}
+		}
+		sendErr = h.emailService.SendEmailWithCloudflareConfig(c.Request.Context(), &service.CloudflareEmailConfig{
+			APIToken:  req.CloudflareAPIToken,
+			AccountID: req.CloudflareAccountID,
+			FromEmail: req.CloudflareFromEmail,
+			FromName:  req.CloudflareFromName,
+		}, req.Email, subject, body)
+	}
+	if sendErr != nil {
+		response.BadRequest(c, "Failed to send test email: "+sendErr.Error())
 		return
 	}
 

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -41,13 +41,22 @@ type SystemSettings struct {
 	LoginAgreementUpdatedAt          string                   `json:"login_agreement_updated_at"`
 	LoginAgreementDocuments          []LoginAgreementDocument `json:"login_agreement_documents"`
 
-	SMTPHost               string `json:"smtp_host"`
-	SMTPPort               int    `json:"smtp_port"`
-	SMTPUsername           string `json:"smtp_username"`
-	SMTPPasswordConfigured bool   `json:"smtp_password_configured"`
-	SMTPFrom               string `json:"smtp_from_email"`
-	SMTPFromName           string `json:"smtp_from_name"`
-	SMTPUseTLS             bool   `json:"smtp_use_tls"`
+	SMTPHost                     string `json:"smtp_host"`
+	SMTPPort                     int    `json:"smtp_port"`
+	SMTPUsername                 string `json:"smtp_username"`
+	SMTPPasswordConfigured       bool   `json:"smtp_password_configured"`
+	SMTPFrom                     string `json:"smtp_from_email"`
+	SMTPFromName                 string `json:"smtp_from_name"`
+	SMTPUseTLS                   bool   `json:"smtp_use_tls"`
+	EmailProvider                string `json:"email_provider"`
+	ResendAPIKeyConfigured       bool   `json:"resend_api_key_configured"`
+	ResendFromEmail              string `json:"resend_from_email"`
+	ResendFromName               string `json:"resend_from_name"`
+	ResendAPIBaseURL             string `json:"resend_api_base_url"`
+	CloudflareAPITokenConfigured bool   `json:"cloudflare_api_token_configured"`
+	CloudflareAccountID          string `json:"cloudflare_account_id"`
+	CloudflareFromEmail          string `json:"cloudflare_from_email"`
+	CloudflareFromName           string `json:"cloudflare_from_name"`
 
 	TurnstileEnabled             bool   `json:"turnstile_enabled"`
 	TurnstileSiteKey             string `json:"turnstile_site_key"`

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -142,13 +142,22 @@ const (
 	SettingKeyLoginAgreementDocuments          = "login_agreement_documents"           // 条款文档列表（JSON，Markdown 内容）
 
 	// 邮件服务设置
-	SettingKeySMTPHost     = "smtp_host"      // SMTP服务器地址
-	SettingKeySMTPPort     = "smtp_port"      // SMTP端口
-	SettingKeySMTPUsername = "smtp_username"  // SMTP用户名
-	SettingKeySMTPPassword = "smtp_password"  // SMTP密码（加密存储）
-	SettingKeySMTPFrom     = "smtp_from"      // 发件人地址
-	SettingKeySMTPFromName = "smtp_from_name" // 发件人名称
-	SettingKeySMTPUseTLS   = "smtp_use_tls"   // 是否使用TLS
+	SettingKeyEmailProvider       = "email_provider"        // 邮件发送提供商：smtp/resend/cloudflare
+	SettingKeySMTPHost            = "smtp_host"             // SMTP服务器地址
+	SettingKeySMTPPort            = "smtp_port"             // SMTP端口
+	SettingKeySMTPUsername        = "smtp_username"         // SMTP用户名
+	SettingKeySMTPPassword        = "smtp_password"         // SMTP密码（加密存储）
+	SettingKeySMTPFrom            = "smtp_from"             // 发件人地址
+	SettingKeySMTPFromName        = "smtp_from_name"        // 发件人名称
+	SettingKeySMTPUseTLS          = "smtp_use_tls"          // 是否使用TLS
+	SettingKeyResendAPIKey        = "resend_api_key"        // Resend API Key
+	SettingKeyResendFromEmail     = "resend_from_email"     // Resend 发件人地址
+	SettingKeyResendFromName      = "resend_from_name"      // Resend 发件人名称
+	SettingKeyResendAPIBaseURL    = "resend_api_base_url"   // Resend API Base URL
+	SettingKeyCloudflareAPIToken  = "cloudflare_api_token"  // Cloudflare API Token
+	SettingKeyCloudflareAccountID = "cloudflare_account_id" // Cloudflare Account ID
+	SettingKeyCloudflareFromEmail = "cloudflare_from_email" // Cloudflare 发件人地址
+	SettingKeyCloudflareFromName  = "cloudflare_from_name"  // Cloudflare 发件人名称
 
 	// Cloudflare Turnstile 设置
 	SettingKeyTurnstileEnabled   = "turnstile_enabled"    // 是否启用 Turnstile 验证

--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -1,15 +1,19 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
 	"crypto/tls"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"math/big"
 	"net"
+	"net/http"
 	"net/smtp"
 	"net/url"
 	"strconv"
@@ -24,6 +28,7 @@ var (
 	ErrInvalidVerifyCode     = infraerrors.BadRequest("INVALID_VERIFY_CODE", "invalid or expired verification code")
 	ErrVerifyCodeTooFrequent = infraerrors.TooManyRequests("VERIFY_CODE_TOO_FREQUENT", "please wait before requesting a new code")
 	ErrVerifyCodeMaxAttempts = infraerrors.TooManyRequests("VERIFY_CODE_MAX_ATTEMPTS", "too many failed attempts, please request a new code")
+	ErrInvalidEmailProvider  = infraerrors.BadRequest("INVALID_EMAIL_PROVIDER", "email provider must be smtp, resend, or cloudflare")
 
 	// Password reset errors
 	ErrInvalidResetToken = infraerrors.BadRequest("INVALID_RESET_TOKEN", "invalid or expired password reset token")
@@ -92,6 +97,32 @@ type SMTPConfig struct {
 	UseTLS   bool
 }
 
+const (
+	EmailProviderSMTP       = "smtp"
+	EmailProviderResend     = "resend"
+	EmailProviderCloudflare = "cloudflare"
+
+	defaultResendAPIBaseURL = "https://api.resend.com"
+
+	emailHTTPTimeout = 20 * time.Second
+)
+
+// ResendConfig stores Resend Email API configuration.
+type ResendConfig struct {
+	APIKey     string
+	FromEmail  string
+	FromName   string
+	APIBaseURL string
+}
+
+// CloudflareEmailConfig stores Cloudflare Email Sending API configuration.
+type CloudflareEmailConfig struct {
+	APIToken  string
+	AccountID string
+	FromEmail string
+	FromName  string
+}
+
 // EmailService 邮件服务
 type EmailService struct {
 	settingRepo              SettingRepository
@@ -127,6 +158,23 @@ func emailRecipientName(email string) string {
 		return trimmed[:at]
 	}
 	return trimmed
+}
+
+func NormalizeEmailProvider(provider string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "", EmailProviderSMTP:
+		return EmailProviderSMTP, nil
+	case EmailProviderResend:
+		return EmailProviderResend, nil
+	case EmailProviderCloudflare:
+		return EmailProviderCloudflare, nil
+	default:
+		return "", ErrInvalidEmailProvider
+	}
+}
+
+func DefaultResendAPIBaseURL() string {
+	return defaultResendAPIBaseURL
 }
 
 // GetSMTPConfig 从数据库获取SMTP配置
@@ -173,15 +221,97 @@ func (s *EmailService) GetSMTPConfig(ctx context.Context) (*SMTPConfig, error) {
 
 // SendEmail 发送邮件（使用数据库中保存的配置）
 func (s *EmailService) SendEmail(ctx context.Context, to, subject, body string) error {
-	config, err := s.GetSMTPConfig(ctx)
+	provider, err := s.GetEmailProvider(ctx)
 	if err != nil {
 		return err
 	}
-	return s.SendEmailWithConfig(config, to, subject, body)
+
+	switch provider {
+	case EmailProviderSMTP:
+		config, err := s.GetSMTPConfig(ctx)
+		if err != nil {
+			return err
+		}
+		return s.SendEmailWithConfig(config, to, subject, body)
+	case EmailProviderResend:
+		config, err := s.GetResendConfig(ctx)
+		if err != nil {
+			return err
+		}
+		return s.SendEmailWithResendConfig(ctx, config, to, subject, body)
+	case EmailProviderCloudflare:
+		config, err := s.GetCloudflareEmailConfig(ctx)
+		if err != nil {
+			return err
+		}
+		return s.SendEmailWithCloudflareConfig(ctx, config, to, subject, body)
+	default:
+		return ErrInvalidEmailProvider
+	}
 }
 
 const smtpDialTimeout = 10 * time.Second
 const smtpIOTimeout = 20 * time.Second
+
+// GetEmailProvider returns the configured email provider, defaulting blank values to SMTP.
+func (s *EmailService) GetEmailProvider(ctx context.Context) (string, error) {
+	settings, err := s.settingRepo.GetMultiple(ctx, []string{SettingKeyEmailProvider})
+	if err != nil {
+		return "", fmt.Errorf("get email provider: %w", err)
+	}
+	return NormalizeEmailProvider(settings[SettingKeyEmailProvider])
+}
+
+func (s *EmailService) GetResendConfig(ctx context.Context) (*ResendConfig, error) {
+	settings, err := s.settingRepo.GetMultiple(ctx, []string{
+		SettingKeyResendAPIKey,
+		SettingKeyResendFromEmail,
+		SettingKeyResendFromName,
+		SettingKeyResendAPIBaseURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get resend settings: %w", err)
+	}
+
+	baseURL, err := NormalizeResendAPIBaseURL(settings[SettingKeyResendAPIBaseURL])
+	if err != nil {
+		return nil, err
+	}
+
+	config := &ResendConfig{
+		APIKey:     strings.TrimSpace(settings[SettingKeyResendAPIKey]),
+		FromEmail:  strings.TrimSpace(settings[SettingKeyResendFromEmail]),
+		FromName:   strings.TrimSpace(settings[SettingKeyResendFromName]),
+		APIBaseURL: baseURL,
+	}
+	if config.APIKey == "" || config.FromEmail == "" {
+		return nil, ErrEmailNotConfigured
+	}
+	return config, nil
+}
+
+func (s *EmailService) GetCloudflareEmailConfig(ctx context.Context) (*CloudflareEmailConfig, error) {
+	settings, err := s.settingRepo.GetMultiple(ctx, []string{
+		SettingKeyCloudflareAPIToken,
+		SettingKeyCloudflareAccountID,
+		SettingKeyCloudflareFromEmail,
+		SettingKeyCloudflareFromName,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get cloudflare email settings: %w", err)
+	}
+
+	config := &CloudflareEmailConfig{
+		APIToken:  strings.TrimSpace(settings[SettingKeyCloudflareAPIToken]),
+		AccountID: strings.TrimSpace(settings[SettingKeyCloudflareAccountID]),
+		FromEmail: strings.TrimSpace(settings[SettingKeyCloudflareFromEmail]),
+		FromName:  strings.TrimSpace(settings[SettingKeyCloudflareFromName]),
+	}
+	if config.APIToken == "" || config.AccountID == "" || config.FromEmail == "" {
+		return nil, ErrEmailNotConfigured
+	}
+	return config, nil
+}
 
 // SendEmailWithConfig 使用指定配置发送邮件
 func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body string) error {
@@ -205,6 +335,106 @@ func (s *EmailService) SendEmailWithConfig(config *SMTPConfig, to, subject, body
 	}
 
 	return s.sendMailPlain(addr, auth, config.From, to, []byte(msg), config.Host)
+}
+
+// SendEmailWithResendConfig sends an HTML email via Resend's HTTP API.
+func (s *EmailService) SendEmailWithResendConfig(ctx context.Context, config *ResendConfig, to, subject, body string) error {
+	if config == nil || strings.TrimSpace(config.APIKey) == "" || strings.TrimSpace(config.FromEmail) == "" {
+		return ErrEmailNotConfigured
+	}
+
+	baseURL, err := NormalizeResendAPIBaseURL(config.APIBaseURL)
+	if err != nil {
+		return err
+	}
+
+	payload := map[string]any{
+		"from":    formatEmailAddress(config.FromName, config.FromEmail),
+		"to":      []string{sanitizeEmailHeader(to)},
+		"subject": sanitizeEmailHeader(subject),
+		"html":    body,
+	}
+	return postEmailJSON(ctx, baseURL+"/emails", "Bearer "+strings.TrimSpace(config.APIKey), payload)
+}
+
+// SendEmailWithCloudflareConfig sends an HTML email via Cloudflare Email Sending API.
+func (s *EmailService) SendEmailWithCloudflareConfig(ctx context.Context, config *CloudflareEmailConfig, to, subject, body string) error {
+	if config == nil || strings.TrimSpace(config.APIToken) == "" || strings.TrimSpace(config.AccountID) == "" || strings.TrimSpace(config.FromEmail) == "" {
+		return ErrEmailNotConfigured
+	}
+
+	endpoint := fmt.Sprintf("https://api.cloudflare.com/client/v4/accounts/%s/email/routing/send", url.PathEscape(strings.TrimSpace(config.AccountID)))
+	payload := map[string]any{
+		"from":    formatEmailAddress(config.FromName, config.FromEmail),
+		"to":      []string{sanitizeEmailHeader(to)},
+		"subject": sanitizeEmailHeader(subject),
+		"html":    body,
+	}
+	return postEmailJSON(ctx, endpoint, "Bearer "+strings.TrimSpace(config.APIToken), payload)
+}
+
+func NormalizeResendAPIBaseURL(raw string) (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(raw), "/")
+	if base == "" {
+		base = defaultResendAPIBaseURL
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return "", infraerrors.BadRequest("INVALID_RESEND_API_BASE_URL", "invalid Resend API base URL")
+	}
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && isLocalResendAPIHost(parsed.Hostname())) {
+		return "", infraerrors.BadRequest("INVALID_RESEND_API_BASE_URL", "Resend API base URL must use https")
+	}
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func isLocalResendAPIHost(host string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+func formatEmailAddress(name, email string) string {
+	email = sanitizeEmailHeader(email)
+	if strings.TrimSpace(name) == "" {
+		return email
+	}
+	return fmt.Sprintf("%s <%s>", sanitizeEmailHeader(name), email)
+}
+
+func postEmailJSON(ctx context.Context, endpoint, authorization string, payload any) error {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal email payload: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, emailHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create email request: %w", err)
+	}
+	req.Header.Set("Authorization", authorization)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("send email request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	message := strings.TrimSpace(string(respBody))
+	if token := strings.TrimSpace(strings.TrimPrefix(authorization, "Bearer ")); token != "" {
+		message = strings.ReplaceAll(message, token, "[redacted]")
+	}
+	return fmt.Errorf("email provider returned status %d: %s", resp.StatusCode, message)
 }
 
 // sendMailPlain sends mail without TLS using a dialer with timeout.

--- a/backend/internal/service/email_service_http_providers_test.go
+++ b/backend/internal/service/email_service_http_providers_test.go
@@ -1,0 +1,121 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type emailProviderSettingRepoStub struct {
+	values map[string]string
+}
+
+func (s *emailProviderSettingRepoStub) Get(context.Context, string) (*Setting, error) {
+	return nil, errors.New("unexpected Get call")
+}
+
+func (s *emailProviderSettingRepoStub) GetValue(context.Context, string) (string, error) {
+	return "", errors.New("unexpected GetValue call")
+}
+
+func (s *emailProviderSettingRepoStub) Set(context.Context, string, string) error {
+	return errors.New("unexpected Set call")
+}
+
+func (s *emailProviderSettingRepoStub) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
+	result := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := s.values[key]; ok {
+			result[key] = value
+		}
+	}
+	return result, nil
+}
+
+func (s *emailProviderSettingRepoStub) SetMultiple(context.Context, map[string]string) error {
+	return errors.New("unexpected SetMultiple call")
+}
+
+func (s *emailProviderSettingRepoStub) GetAll(context.Context) (map[string]string, error) {
+	return nil, errors.New("unexpected GetAll call")
+}
+
+func (s *emailProviderSettingRepoStub) Delete(context.Context, string) error {
+	return errors.New("unexpected Delete call")
+}
+
+func TestNormalizeEmailProviderDefaultsToSMTP(t *testing.T) {
+	provider, err := NormalizeEmailProvider("")
+	require.NoError(t, err)
+	require.Equal(t, EmailProviderSMTP, provider)
+}
+
+func TestNormalizeResendAPIBaseURL(t *testing.T) {
+	baseURL, err := NormalizeResendAPIBaseURL("")
+	require.NoError(t, err)
+	require.Equal(t, defaultResendAPIBaseURL, baseURL)
+
+	baseURL, err = NormalizeResendAPIBaseURL("https://api.resend.com/")
+	require.NoError(t, err)
+	require.Equal(t, "https://api.resend.com", baseURL)
+
+	_, err = NormalizeResendAPIBaseURL("http://api.resend.com")
+	require.Error(t, err)
+}
+
+func TestSendEmailWithResendConfigPostsExpectedPayload(t *testing.T) {
+	var receivedAuth string
+	var payload map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/emails", r.URL.Path)
+		receivedAuth = r.Header.Get("Authorization")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	svc := NewEmailService(&emailProviderSettingRepoStub{}, nil)
+	err := svc.SendEmailWithResendConfig(context.Background(), &ResendConfig{
+		APIKey:     "resend-token",
+		FromEmail:  "noreply@example.com",
+		FromName:   "Sub2API",
+		APIBaseURL: server.URL,
+	}, "user@example.com", "Hello", "<p>Hi</p>")
+	require.NoError(t, err)
+	require.Equal(t, "Bearer resend-token", receivedAuth)
+	require.Equal(t, "Sub2API <noreply@example.com>", payload["from"])
+	require.Equal(t, "Hello", payload["subject"])
+	require.Equal(t, "<p>Hi</p>", payload["html"])
+	require.Equal(t, []any{"user@example.com"}, payload["to"])
+}
+
+func TestCloudflareEmailConfigRequiresCredentials(t *testing.T) {
+	svc := NewEmailService(&emailProviderSettingRepoStub{values: map[string]string{
+		SettingKeyCloudflareAPIToken:  "token",
+		SettingKeyCloudflareAccountID: "",
+		SettingKeyCloudflareFromEmail: "noreply@example.com",
+	}}, nil)
+
+	_, err := svc.GetCloudflareEmailConfig(context.Background())
+	require.ErrorIs(t, err, ErrEmailNotConfigured)
+}
+
+func TestPostEmailJSONRedactsAuthorizationFromError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"bad token"}`))
+	}))
+	defer server.Close()
+
+	err := postEmailJSON(context.Background(), server.URL, "Bearer secret-token", map[string]string{"hello": "world"})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status 401")
+	require.False(t, strings.Contains(err.Error(), "secret-token"))
+}

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -1693,6 +1693,17 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	updates[SettingKeyLoginAgreementDocuments] = loginAgreementDocumentsJSON
 
 	// 邮件服务设置（只有非空才更新密码）
+	provider, err := NormalizeEmailProvider(settings.EmailProvider)
+	if err != nil {
+		return nil, err
+	}
+	settings.EmailProvider = provider
+	resendBaseURL, err := NormalizeResendAPIBaseURL(settings.ResendAPIBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	settings.ResendAPIBaseURL = resendBaseURL
+	updates[SettingKeyEmailProvider] = settings.EmailProvider
 	updates[SettingKeySMTPHost] = settings.SMTPHost
 	updates[SettingKeySMTPPort] = strconv.Itoa(settings.SMTPPort)
 	updates[SettingKeySMTPUsername] = settings.SMTPUsername
@@ -1702,6 +1713,18 @@ func (s *SettingService) buildSystemSettingsUpdates(ctx context.Context, setting
 	updates[SettingKeySMTPFrom] = settings.SMTPFrom
 	updates[SettingKeySMTPFromName] = settings.SMTPFromName
 	updates[SettingKeySMTPUseTLS] = strconv.FormatBool(settings.SMTPUseTLS)
+	if settings.ResendAPIKey != "" {
+		updates[SettingKeyResendAPIKey] = settings.ResendAPIKey
+	}
+	updates[SettingKeyResendFromEmail] = settings.ResendFromEmail
+	updates[SettingKeyResendFromName] = settings.ResendFromName
+	updates[SettingKeyResendAPIBaseURL] = settings.ResendAPIBaseURL
+	if settings.CloudflareAPIToken != "" {
+		updates[SettingKeyCloudflareAPIToken] = settings.CloudflareAPIToken
+	}
+	updates[SettingKeyCloudflareAccountID] = settings.CloudflareAccountID
+	updates[SettingKeyCloudflareFromEmail] = settings.CloudflareFromEmail
+	updates[SettingKeyCloudflareFromName] = settings.CloudflareFromName
 
 	// Cloudflare Turnstile 设置（只有非空才更新密钥）
 	updates[SettingKeyTurnstileEnabled] = strconv.FormatBool(settings.TurnstileEnabled)
@@ -2687,6 +2710,8 @@ func (s *SettingService) InitializeDefaultSettings(ctx context.Context) error {
 		SettingKeyLoginAgreementMode:                        defaultLoginAgreementMode,
 		SettingKeyLoginAgreementUpdatedAt:                   defaultLoginAgreementDate,
 		SettingKeyLoginAgreementDocuments:                   loginAgreementDocumentsJSON,
+		SettingKeyEmailProvider:                             EmailProviderSMTP,
+		SettingKeyResendAPIBaseURL:                          defaultResendAPIBaseURL,
 		SettingKeyAPIKeyACLTrustForwardedIP:                 "false",
 		SettingKeySiteName:                                  "Sub2API",
 		SettingKeySiteLogo:                                  "",
@@ -2855,6 +2880,14 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 	} else if s != nil && s.cfg != nil {
 		apiKeyACLTrustForwardedIP = s.cfg.Security.TrustForwardedIPForAPIKeyACL
 	}
+	emailProvider, err := NormalizeEmailProvider(settings[SettingKeyEmailProvider])
+	if err != nil {
+		emailProvider = strings.TrimSpace(settings[SettingKeyEmailProvider])
+	}
+	resendBaseURL, err := NormalizeResendAPIBaseURL(settings[SettingKeyResendAPIBaseURL])
+	if err != nil {
+		resendBaseURL = defaultResendAPIBaseURL
+	}
 	result := &SystemSettings{
 		RegistrationEnabled:              settings[SettingKeyRegistrationEnabled] == "true",
 		EmailVerifyEnabled:               emailVerifyEnabled,
@@ -2874,6 +2907,15 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 		SMTPFromName:                     settings[SettingKeySMTPFromName],
 		SMTPUseTLS:                       settings[SettingKeySMTPUseTLS] == "true",
 		SMTPPasswordConfigured:           settings[SettingKeySMTPPassword] != "",
+		EmailProvider:                    emailProvider,
+		ResendAPIKeyConfigured:           settings[SettingKeyResendAPIKey] != "",
+		ResendFromEmail:                  strings.TrimSpace(settings[SettingKeyResendFromEmail]),
+		ResendFromName:                   strings.TrimSpace(settings[SettingKeyResendFromName]),
+		ResendAPIBaseURL:                 resendBaseURL,
+		CloudflareAPITokenConfigured:     settings[SettingKeyCloudflareAPIToken] != "",
+		CloudflareAccountID:              strings.TrimSpace(settings[SettingKeyCloudflareAccountID]),
+		CloudflareFromEmail:              strings.TrimSpace(settings[SettingKeyCloudflareFromEmail]),
+		CloudflareFromName:               strings.TrimSpace(settings[SettingKeyCloudflareFromName]),
 		TurnstileEnabled:                 settings[SettingKeyTurnstileEnabled] == "true",
 		TurnstileSiteKey:                 settings[SettingKeyTurnstileSiteKey],
 		TurnstileSecretKeyConfigured:     settings[SettingKeyTurnstileSecretKey] != "",
@@ -2944,6 +2986,8 @@ func (s *SettingService) parseSettings(settings map[string]string) *SystemSettin
 
 	// 敏感信息直接返回，方便测试连接时使用
 	result.SMTPPassword = settings[SettingKeySMTPPassword]
+	result.ResendAPIKey = strings.TrimSpace(settings[SettingKeyResendAPIKey])
+	result.CloudflareAPIToken = strings.TrimSpace(settings[SettingKeyCloudflareAPIToken])
 	result.TurnstileSecretKey = settings[SettingKeyTurnstileSecretKey]
 
 	// LinuxDo Connect 设置：

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -25,14 +25,25 @@ type SystemSettings struct {
 	LoginAgreementUpdatedAt          string
 	LoginAgreementDocuments          []LoginAgreementDocument
 
-	SMTPHost               string
-	SMTPPort               int
-	SMTPUsername           string
-	SMTPPassword           string
-	SMTPPasswordConfigured bool
-	SMTPFrom               string
-	SMTPFromName           string
-	SMTPUseTLS             bool
+	SMTPHost                     string
+	SMTPPort                     int
+	SMTPUsername                 string
+	SMTPPassword                 string
+	SMTPPasswordConfigured       bool
+	SMTPFrom                     string
+	SMTPFromName                 string
+	SMTPUseTLS                   bool
+	EmailProvider                string
+	ResendAPIKey                 string
+	ResendAPIKeyConfigured       bool
+	ResendFromEmail              string
+	ResendFromName               string
+	ResendAPIBaseURL             string
+	CloudflareAPIToken           string
+	CloudflareAPITokenConfigured bool
+	CloudflareAccountID          string
+	CloudflareFromEmail          string
+	CloudflareFromName           string
 
 	TurnstileEnabled             bool
 	TurnstileSiteKey             string

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -446,6 +446,15 @@ export interface SystemSettings {
   smtp_from_email: string;
   smtp_from_name: string;
   smtp_use_tls: boolean;
+  email_provider: "smtp" | "resend" | "cloudflare";
+  resend_api_key_configured: boolean;
+  resend_from_email: string;
+  resend_from_name: string;
+  resend_api_base_url: string;
+  cloudflare_api_token_configured: boolean;
+  cloudflare_account_id: string;
+  cloudflare_from_email: string;
+  cloudflare_from_name: string;
   // Cloudflare Turnstile settings
   turnstile_enabled: boolean;
   turnstile_site_key: string;
@@ -703,6 +712,15 @@ export interface UpdateSettingsRequest {
   smtp_from_email?: string;
   smtp_from_name?: string;
   smtp_use_tls?: boolean;
+  email_provider?: "smtp" | "resend" | "cloudflare";
+  resend_api_key?: string;
+  resend_from_email?: string;
+  resend_from_name?: string;
+  resend_api_base_url?: string;
+  cloudflare_api_token?: string;
+  cloudflare_account_id?: string;
+  cloudflare_from_email?: string;
+  cloudflare_from_name?: string;
   turnstile_enabled?: boolean;
   turnstile_site_key?: string;
   turnstile_secret_key?: string;
@@ -911,6 +929,15 @@ export interface SendTestEmailRequest {
   smtp_from_email: string;
   smtp_from_name: string;
   smtp_use_tls: boolean;
+  email_provider?: "smtp" | "resend" | "cloudflare";
+  resend_api_key?: string;
+  resend_from_email?: string;
+  resend_from_name?: string;
+  resend_api_base_url?: string;
+  cloudflare_api_token?: string;
+  cloudflare_account_id?: string;
+  cloudflare_from_email?: string;
+  cloudflare_from_name?: string;
 }
 
 /**

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -6038,6 +6038,16 @@ export default {
         enabled: 'Enable Subscription Expiry Reminder',
         enabledHint: 'When enabled, the system sends reminders 7, 3, and 1 day before expiry.'
       },
+      emailProvider: {
+        title: 'Email Provider',
+        description: 'Choose how system emails are delivered.',
+        smtp: 'SMTP',
+        smtpDescription: 'Use an SMTP server.',
+        resend: 'Resend',
+        resendDescription: 'Send email through the Resend HTTP API.',
+        cloudflare: 'Cloudflare',
+        cloudflareDescription: 'Send email through Cloudflare Email Sending.'
+      },
       smtp: {
         title: 'SMTP Settings',
         description: 'Configure email sending for verification codes',
@@ -6060,6 +6070,37 @@ export default {
         fromNamePlaceholder: 'Sub2API',
         useTls: 'Use TLS',
         useTlsHint: 'Enable TLS encryption for SMTP connection'
+      },
+      resend: {
+        title: 'Resend Email API',
+        description: 'Configure Resend for email delivery without SMTP.',
+        apiKey: 'API Key',
+        apiKeyPlaceholder: 'Enter Resend API key',
+        apiKeyHint: 'Create an API key in Resend and keep it secret.',
+        apiKeyConfiguredPlaceholder: '********',
+        apiKeyConfiguredHint: 'API key configured. Leave empty to keep the current value.',
+        apiBaseUrl: 'API Base URL',
+        apiBaseUrlPlaceholder: 'https://api.resend.com',
+        apiBaseUrlHint: 'Use the default official endpoint unless you proxy Resend.',
+        fromEmail: 'From Email',
+        fromEmailPlaceholder: "noreply{'@'}example.com",
+        fromName: 'From Name',
+        fromNamePlaceholder: 'Sub2API'
+      },
+      cloudflareEmail: {
+        title: 'Cloudflare Email Sending',
+        description: 'Configure Cloudflare Email Sending for system email delivery.',
+        apiToken: 'API Token',
+        apiTokenPlaceholder: 'Enter Cloudflare API token',
+        apiTokenHint: 'Use a token with Cloudflare Email Sending permission.',
+        apiTokenConfiguredPlaceholder: '********',
+        apiTokenConfiguredHint: 'API token configured. Leave empty to keep the current value.',
+        accountId: 'Account ID',
+        accountIdPlaceholder: 'Enter Cloudflare account ID',
+        fromEmail: 'From Email',
+        fromEmailPlaceholder: "noreply{'@'}example.com",
+        fromName: 'From Name',
+        fromNamePlaceholder: 'Sub2API'
       },
       testEmail: {
         title: 'Send Test Email',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -6194,6 +6194,16 @@ export default {
         enabled: '启用订阅到期提醒',
         enabledHint: '开启后，系统会在订阅到期前 7 天、3 天、1 天各发送一次提醒。'
       },
+      emailProvider: {
+        title: '邮件发送方式',
+        description: '选择系统邮件的发送通道。',
+        smtp: 'SMTP',
+        smtpDescription: '使用现有 SMTP 服务器发送邮件。',
+        resend: 'Resend',
+        resendDescription: '通过 Resend HTTP API 发送邮件。',
+        cloudflare: 'Cloudflare',
+        cloudflareDescription: '通过 Cloudflare Email Sending 发送邮件。'
+      },
       smtp: {
         title: 'SMTP 设置',
         description: '配置用于发送验证码的邮件服务',
@@ -6216,6 +6226,37 @@ export default {
         fromNamePlaceholder: 'Sub2API',
         useTls: '使用 TLS',
         useTlsHint: '为 SMTP 连接启用 TLS 加密'
+      },
+      resend: {
+        title: 'Resend Email API',
+        description: '配置 Resend，在不使用 SMTP 的情况下发送邮件。',
+        apiKey: 'API Key',
+        apiKeyPlaceholder: '请输入 Resend API Key',
+        apiKeyHint: '请在 Resend 后台创建 API Key，并妥善保管。',
+        apiKeyConfiguredPlaceholder: '********',
+        apiKeyConfiguredHint: 'API Key 已配置，留空以保留当前值。',
+        apiBaseUrl: 'API Base URL',
+        apiBaseUrlPlaceholder: 'https://api.resend.com',
+        apiBaseUrlHint: '默认使用 Resend 官方地址，除非你使用了代理。',
+        fromEmail: '发件人邮箱',
+        fromEmailPlaceholder: "noreply{'@'}example.com",
+        fromName: '发件人名称',
+        fromNamePlaceholder: 'Sub2API'
+      },
+      cloudflareEmail: {
+        title: 'Cloudflare Email Sending',
+        description: '配置 Cloudflare Email Sending 发送系统邮件。',
+        apiToken: 'API Token',
+        apiTokenPlaceholder: '请输入 Cloudflare API Token',
+        apiTokenHint: '需要具备 Cloudflare Email Sending 发送权限。',
+        apiTokenConfiguredPlaceholder: '********',
+        apiTokenConfiguredHint: 'API Token 已配置，留空以保留当前值。',
+        accountId: 'Account ID',
+        accountIdPlaceholder: '请输入 Cloudflare Account ID',
+        fromEmail: '发件人邮箱',
+        fromEmailPlaceholder: "noreply{'@'}example.com",
+        fromName: '发件人名称',
+        fromNamePlaceholder: 'Sub2API'
       },
       testEmail: {
         title: '发送测试邮件',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -6217,8 +6217,45 @@
             </div>
           </div>
 
-          <!-- SMTP Settings - Only show when email verification is enabled -->
           <div v-if="form.email_verify_enabled" class="card">
+            <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ t("admin.settings.emailProvider.title") }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ t("admin.settings.emailProvider.description") }}
+              </p>
+            </div>
+            <div class="grid gap-3 p-6 md:grid-cols-3">
+              <label
+                v-for="provider in ['smtp', 'resend', 'cloudflare']"
+                :key="provider"
+                class="cursor-pointer rounded-lg border p-4 transition-colors"
+                :class="
+                  form.email_provider === provider
+                    ? 'border-primary-500 bg-primary-50 dark:border-primary-400 dark:bg-primary-900/20'
+                    : 'border-gray-200 hover:border-primary-300 dark:border-dark-700'
+                "
+              >
+                <input
+                  v-model="form.email_provider"
+                  type="radio"
+                  name="email_provider"
+                  :value="provider"
+                  class="sr-only"
+                />
+                <div class="font-medium text-gray-900 dark:text-white">
+                  {{ t(`admin.settings.emailProvider.${provider}`) }}
+                </div>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  {{ t(`admin.settings.emailProvider.${provider}Description`) }}
+                </p>
+              </label>
+            </div>
+          </div>
+
+          <!-- SMTP Settings - Only show when SMTP is selected -->
+          <div v-if="form.email_verify_enabled && form.email_provider === 'smtp'" class="card">
             <div
               class="flex items-center justify-between border-b border-gray-100 px-6 py-4 dark:border-dark-700"
             >
@@ -6376,6 +6413,151 @@
                   </p>
                 </div>
                 <Toggle v-model="form.smtp_use_tls" />
+              </div>
+            </div>
+          </div>
+
+          <div v-if="form.email_verify_enabled && form.email_provider === 'resend'" class="card">
+            <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ t("admin.settings.resend.title") }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ t("admin.settings.resend.description") }}
+              </p>
+            </div>
+            <div class="grid grid-cols-1 gap-6 p-6 md:grid-cols-2">
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.resend.apiKey") }}
+                </label>
+                <input
+                  v-model="form.resend_api_key"
+                  type="password"
+                  class="input"
+                  autocomplete="new-password"
+                  @keydown="resendApiKeyManuallyEdited = true"
+                  @paste="resendApiKeyManuallyEdited = true"
+                  :placeholder="
+                    form.resend_api_key_configured
+                      ? t('admin.settings.resend.apiKeyConfiguredPlaceholder')
+                      : t('admin.settings.resend.apiKeyPlaceholder')
+                  "
+                />
+                <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                  {{
+                    form.resend_api_key_configured
+                      ? t("admin.settings.resend.apiKeyConfiguredHint")
+                      : t("admin.settings.resend.apiKeyHint")
+                  }}
+                </p>
+              </div>
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.resend.apiBaseUrl") }}
+                </label>
+                <input
+                  v-model="form.resend_api_base_url"
+                  type="url"
+                  class="input"
+                  :placeholder="t('admin.settings.resend.apiBaseUrlPlaceholder')"
+                />
+                <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                  {{ t("admin.settings.resend.apiBaseUrlHint") }}
+                </p>
+              </div>
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.resend.fromEmail") }}
+                </label>
+                <input
+                  v-model="form.resend_from_email"
+                  type="email"
+                  class="input"
+                  :placeholder="t('admin.settings.resend.fromEmailPlaceholder')"
+                />
+              </div>
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.resend.fromName") }}
+                </label>
+                <input
+                  v-model="form.resend_from_name"
+                  type="text"
+                  class="input"
+                  :placeholder="t('admin.settings.resend.fromNamePlaceholder')"
+                />
+              </div>
+            </div>
+          </div>
+
+          <div v-if="form.email_verify_enabled && form.email_provider === 'cloudflare'" class="card">
+            <div class="border-b border-gray-100 px-6 py-4 dark:border-dark-700">
+              <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
+                {{ t("admin.settings.cloudflareEmail.title") }}
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ t("admin.settings.cloudflareEmail.description") }}
+              </p>
+            </div>
+            <div class="grid grid-cols-1 gap-6 p-6 md:grid-cols-2">
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.cloudflareEmail.apiToken") }}
+                </label>
+                <input
+                  v-model="form.cloudflare_api_token"
+                  type="password"
+                  class="input"
+                  autocomplete="new-password"
+                  @keydown="cloudflareApiTokenManuallyEdited = true"
+                  @paste="cloudflareApiTokenManuallyEdited = true"
+                  :placeholder="
+                    form.cloudflare_api_token_configured
+                      ? t('admin.settings.cloudflareEmail.apiTokenConfiguredPlaceholder')
+                      : t('admin.settings.cloudflareEmail.apiTokenPlaceholder')
+                  "
+                />
+                <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                  {{
+                    form.cloudflare_api_token_configured
+                      ? t("admin.settings.cloudflareEmail.apiTokenConfiguredHint")
+                      : t("admin.settings.cloudflareEmail.apiTokenHint")
+                  }}
+                </p>
+              </div>
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.cloudflareEmail.accountId") }}
+                </label>
+                <input
+                  v-model="form.cloudflare_account_id"
+                  type="text"
+                  class="input"
+                  :placeholder="t('admin.settings.cloudflareEmail.accountIdPlaceholder')"
+                />
+              </div>
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.cloudflareEmail.fromEmail") }}
+                </label>
+                <input
+                  v-model="form.cloudflare_from_email"
+                  type="email"
+                  class="input"
+                  :placeholder="t('admin.settings.cloudflareEmail.fromEmailPlaceholder')"
+                />
+              </div>
+              <div>
+                <label class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  {{ t("admin.settings.cloudflareEmail.fromName") }}
+                </label>
+                <input
+                  v-model="form.cloudflare_from_name"
+                  type="text"
+                  class="input"
+                  :placeholder="t('admin.settings.cloudflareEmail.fromNamePlaceholder')"
+                />
               </div>
             </div>
           </div>
@@ -6854,6 +7036,8 @@ const saving = ref(false);
 const testingSmtp = ref(false);
 const sendingTestEmail = ref(false);
 const smtpPasswordManuallyEdited = ref(false);
+const resendApiKeyManuallyEdited = ref(false);
+const cloudflareApiTokenManuallyEdited = ref(false);
 const testEmailAddress = ref("");
 const registrationEmailSuffixWhitelistTags = ref<string[]>([]);
 const registrationEmailSuffixWhitelistDraft = ref("");
@@ -6992,6 +7176,8 @@ type SettingsForm = Omit<
   | "wechat_connect_mobile_enabled"
 > & {
   smtp_password: string;
+  resend_api_key: string;
+  cloudflare_api_token: string;
   turnstile_secret_key: string;
   linuxdo_connect_client_secret: string;
   dingtalk_connect_client_secret: string;
@@ -7089,6 +7275,17 @@ const form = reactive<SettingsForm>({
   smtp_from_email: "",
   smtp_from_name: "",
   smtp_use_tls: true,
+  email_provider: "smtp",
+  resend_api_key: "",
+  resend_api_key_configured: false,
+  resend_from_email: "",
+  resend_from_name: "",
+  resend_api_base_url: "https://api.resend.com",
+  cloudflare_api_token: "",
+  cloudflare_api_token_configured: false,
+  cloudflare_account_id: "",
+  cloudflare_from_email: "",
+  cloudflare_from_name: "",
   // Cloudflare Turnstile
   turnstile_enabled: false,
   turnstile_site_key: "",
@@ -7854,6 +8051,10 @@ async function loadSettings() {
     registrationEmailSuffixWhitelistDraft.value = "";
     form.smtp_password = "";
     smtpPasswordManuallyEdited.value = false;
+    form.resend_api_key = "";
+    resendApiKeyManuallyEdited.value = false;
+    form.cloudflare_api_token = "";
+    cloudflareApiTokenManuallyEdited.value = false;
     form.turnstile_secret_key = "";
     form.linuxdo_connect_client_secret = "";
     form.dingtalk_connect_client_secret = "";
@@ -8201,6 +8402,15 @@ async function saveSettings() {
       smtp_from_email: form.smtp_from_email,
       smtp_from_name: form.smtp_from_name,
       smtp_use_tls: form.smtp_use_tls,
+      email_provider: form.email_provider,
+      resend_api_key: form.resend_api_key || undefined,
+      resend_from_email: form.resend_from_email,
+      resend_from_name: form.resend_from_name,
+      resend_api_base_url: form.resend_api_base_url,
+      cloudflare_api_token: form.cloudflare_api_token || undefined,
+      cloudflare_account_id: form.cloudflare_account_id,
+      cloudflare_from_email: form.cloudflare_from_email,
+      cloudflare_from_name: form.cloudflare_from_name,
       turnstile_enabled: form.turnstile_enabled,
       turnstile_site_key: form.turnstile_site_key,
       turnstile_secret_key: form.turnstile_secret_key || undefined,
@@ -8417,6 +8627,10 @@ async function saveSettings() {
     registrationEmailSuffixWhitelistDraft.value = "";
     form.smtp_password = "";
     smtpPasswordManuallyEdited.value = false;
+    form.resend_api_key = "";
+    resendApiKeyManuallyEdited.value = false;
+    form.cloudflare_api_token = "";
+    cloudflareApiTokenManuallyEdited.value = false;
     form.turnstile_secret_key = "";
     form.linuxdo_connect_client_secret = "";
     form.dingtalk_connect_client_secret = "";
@@ -8514,6 +8728,12 @@ async function sendTestEmail() {
     const smtpPasswordForSend = smtpPasswordManuallyEdited.value
       ? form.smtp_password
       : "";
+    const resendApiKeyForSend = resendApiKeyManuallyEdited.value
+      ? form.resend_api_key
+      : "";
+    const cloudflareApiTokenForSend = cloudflareApiTokenManuallyEdited.value
+      ? form.cloudflare_api_token
+      : "";
     const result = await adminAPI.settings.sendTestEmail({
       email: testEmailAddress.value,
       smtp_host: form.smtp_host,
@@ -8523,6 +8743,15 @@ async function sendTestEmail() {
       smtp_from_email: form.smtp_from_email,
       smtp_from_name: form.smtp_from_name,
       smtp_use_tls: form.smtp_use_tls,
+      email_provider: form.email_provider,
+      resend_api_key: resendApiKeyForSend,
+      resend_from_email: form.resend_from_email,
+      resend_from_name: form.resend_from_name,
+      resend_api_base_url: form.resend_api_base_url,
+      cloudflare_api_token: cloudflareApiTokenForSend,
+      cloudflare_account_id: form.cloudflare_account_id,
+      cloudflare_from_email: form.cloudflare_from_email,
+      cloudflare_from_name: form.cloudflare_from_name,
     });
     // API returns { message: "..." } on success, errors are thrown as exceptions
     appStore.showSuccess(result.message || t("admin.settings.testEmailSent"));


### PR DESCRIPTION
## Summary / 概要

Adds HTTP email provider support alongside the existing SMTP delivery path.

在现有 SMTP 邮件发送路径之外，新增基于 HTTP API 的邮件发送提供商支持。

- Add selectable email providers: SMTP, Resend, and Cloudflare Email Sending.
- Persist provider-specific settings without exposing saved secrets in admin responses.
- Route verification, password reset, and notification fallback emails through the selected provider.
- Extend the admin settings UI to configure and test Resend/Cloudflare delivery.
- Keep SMTP as the default provider for backward compatibility.

- 新增可选邮件发送方式：SMTP、Resend、Cloudflare Email Sending。
- 持久化不同提供商的配置，并且后台响应中不暴露已保存的密钥。
- 验证码、密码重置、通知类 fallback 邮件会根据所选提供商发送。
- 扩展管理员设置页，支持配置和测试 Resend / Cloudflare 邮件发送。
- 保持 SMTP 为默认发送方式，确保兼容现有部署。

## Motivation / 背景

Some deployment platforms, including serverless/container platforms, restrict outbound SMTP or make SMTP delivery unreliable. Resend and Cloudflare Email Sending provide HTTPS APIs that work in those environments while preserving the existing email flows.

部分部署平台，包括 serverless 或容器平台，会限制 SMTP 出站连接，或者导致 SMTP 投递不稳定。Resend 和 Cloudflare Email Sending 提供 HTTPS API，可以在这些环境中更可靠地发送邮件，同时复用现有的邮箱验证、密码重置和通知邮件流程。

## Implementation Notes / 实现说明

- `EmailService.SendEmail` now reads `email_provider` and dispatches to SMTP, Resend, or Cloudflare.
- Resend uses `POST {resend_api_base_url}/emails`.
- Cloudflare uses `POST https://api.cloudflare.com/client/v4/accounts/{account_id}/email/routing/send`.
- Secrets are only updated when a new value is submitted; blank values preserve existing API keys/tokens.
- Resend base URL requires HTTPS except for localhost test endpoints.
- Existing SMTP behavior remains the default when `email_provider` is empty or unset.

- `EmailService.SendEmail` 现在会读取 `email_provider`，并分发到 SMTP、Resend 或 Cloudflare。
- Resend 使用 `POST {resend_api_base_url}/emails`。
- Cloudflare 使用 `POST https://api.cloudflare.com/client/v4/accounts/{account_id}/email/routing/send`。
- 密钥类配置仅在提交新值时更新；留空会保留已有 API key / token。
- Resend base URL 默认要求 HTTPS，仅允许 localhost 测试端点使用 HTTP。
- 当 `email_provider` 为空或未设置时，仍默认使用 SMTP。

## Testing / 测试

- `go test ./internal/service ./internal/handler/admin ./internal/server`
- `pnpm --dir frontend typecheck`

## Compatibility / 兼容性

No database schema migration is required. The new provider settings are stored in the existing settings table. Existing deployments continue to use SMTP unless admins explicitly choose Resend or Cloudflare.

无需数据库结构迁移。新增的邮件提供商配置会保存在现有 `settings` 表中。现有部署会继续使用 SMTP，除非管理员明确切换到 Resend 或 Cloudflare。

<img width="1752" height="891" alt="image" src="https://github.com/user-attachments/assets/93dee45f-d099-4a09-a698-df11bcc9458c" />


<img width="1772" height="912" alt="image" src="https://github.com/user-attachments/assets/429f2083-00e1-4940-a840-250c907a5c32" />

