### PR TITLE
feat(openai): add audio transcriptions gateway

### DIFF
--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -15,13 +15,14 @@ import (
 // ──────────────────────────────────────────────────────────
 
 const (
-	EndpointMessages          = "/v1/messages"
-	EndpointChatCompletions   = "/v1/chat/completions"
-	EndpointEmbeddings        = "/v1/embeddings"
-	EndpointResponses         = "/v1/responses"
-	EndpointImagesGenerations = "/v1/images/generations"
-	EndpointImagesEdits       = "/v1/images/edits"
-	EndpointGeminiModels      = "/v1beta/models"
+	EndpointMessages            = "/v1/messages"
+	EndpointChatCompletions     = "/v1/chat/completions"
+	EndpointEmbeddings          = "/v1/embeddings"
+	EndpointAudioTranscriptions = "/v1/audio/transcriptions"
+	EndpointResponses           = "/v1/responses"
+	EndpointImagesGenerations   = "/v1/images/generations"
+	EndpointImagesEdits         = "/v1/images/edits"
+	EndpointGeminiModels        = "/v1beta/models"
 )
 
 // gin.Context keys used by the middleware and helpers below.
@@ -45,6 +46,8 @@ func NormalizeInboundEndpoint(path string) string {
 	switch {
 	case strings.Contains(path, EndpointEmbeddings):
 		return EndpointEmbeddings
+	case strings.Contains(path, EndpointAudioTranscriptions) || strings.Contains(path, "/audio/transcriptions"):
+		return EndpointAudioTranscriptions
 	case strings.Contains(path, EndpointChatCompletions):
 		return EndpointChatCompletions
 	case strings.Contains(path, EndpointMessages):
@@ -78,7 +81,7 @@ func DeriveUpstreamEndpoint(inbound, rawRequestPath, platform string) string {
 
 	switch platform {
 	case service.PlatformOpenAI:
-		if inbound == EndpointEmbeddings || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits {
+		if inbound == EndpointEmbeddings || inbound == EndpointAudioTranscriptions || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits {
 			return inbound
 		}
 		// OpenAI forwards everything to the Responses API.

--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -25,6 +25,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/v1/messages", EndpointMessages},
 		{"/v1/chat/completions", EndpointChatCompletions},
 		{"/v1/embeddings", EndpointEmbeddings},
+		{"/v1/audio/transcriptions", EndpointAudioTranscriptions},
 		{"/v1/responses", EndpointResponses},
 		{"/v1/images/generations", EndpointImagesGenerations},
 		{"/v1/images/edits", EndpointImagesEdits},
@@ -36,6 +37,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/openai/v1/responses/compact", EndpointResponses},
 		{"/openai/v1/images/generations", EndpointImagesGenerations},
 		{"/openai/v1/images/edits", EndpointImagesEdits},
+		{"/openai/v1/audio/transcriptions", EndpointAudioTranscriptions},
 		{"/antigravity/v1beta/models/gemini:generateContent", EndpointGeminiModels},
 
 		// Gin route patterns with wildcards.
@@ -79,6 +81,7 @@ func TestDeriveUpstreamEndpoint(t *testing.T) {
 		{"openai from messages", EndpointMessages, "/v1/messages", service.PlatformOpenAI, EndpointResponses},
 		{"openai from completions", EndpointChatCompletions, "/v1/chat/completions", service.PlatformOpenAI, EndpointResponses},
 		{"openai embeddings", EndpointEmbeddings, "/v1/embeddings", service.PlatformOpenAI, EndpointEmbeddings},
+		{"openai audio transcriptions", EndpointAudioTranscriptions, "/v1/audio/transcriptions", service.PlatformOpenAI, EndpointAudioTranscriptions},
 		{"openai image generations", EndpointImagesGenerations, "/v1/images/generations", service.PlatformOpenAI, EndpointImagesGenerations},
 		{"openai image edits", EndpointImagesEdits, "/openai/v1/images/edits", service.PlatformOpenAI, EndpointImagesEdits},
 

--- a/backend/internal/handler/openai_audio_transcriptions.go
+++ b/backend/internal/handler/openai_audio_transcriptions.go
@@ -1,0 +1,279 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	pkghttputil "github.com/Wei-Shaw/sub2api/internal/pkg/httputil"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"go.uber.org/zap"
+)
+
+// AudioTranscriptions handles the OpenAI-compatible Audio Transcriptions API.
+// POST /v1/audio/transcriptions
+func (h *OpenAIGatewayHandler) AudioTranscriptions(c *gin.Context) {
+	streamStarted := false
+	requestStart := time.Now()
+
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusUnauthorized, "authentication_error", "Invalid API key")
+		return
+	}
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusInternalServerError, "api_error", "User context not found")
+		return
+	}
+
+	reqLog := requestLogger(
+		c,
+		"handler.openai_gateway.audio_transcriptions",
+		zap.Int64("user_id", subject.UserID),
+		zap.Int64("api_key_id", apiKey.ID),
+		zap.Any("group_id", apiKey.GroupID),
+		zap.String("model", service.OpenAIAudioTranscriptionModel),
+	)
+	if !h.ensureResponsesDependencies(c, reqLog) {
+		return
+	}
+
+	body, err := pkghttputil.ReadRequestBodyWithPrealloc(c.Request)
+	if err != nil {
+		if maxErr, ok := extractMaxBytesError(err); ok {
+			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
+			return
+		}
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body")
+		return
+	}
+	parsed, err := h.gatewayService.ParseOpenAIAudioTranscriptionRequest(body, c.GetHeader("Content-Type"))
+	if err != nil {
+		var reqErr *service.OpenAIAudioTranscriptionRequestError
+		if errors.As(err, &reqErr) {
+			h.openAIAudioTranscriptionErrorResponse(c, reqErr.Status, reqErr.Type, reqErr.Message, reqErr.Param)
+			return
+		}
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", err.Error())
+		return
+	}
+
+	setOpsRequestContext(c, service.OpenAIAudioTranscriptionModel, false)
+	setOpsEndpointContext(c, "", int16(service.RequestTypeSync))
+
+	subscription, _ := middleware2.GetSubscriptionFromContext(c)
+	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+
+	userReleaseFunc, acquired := h.acquireResponsesUserSlot(c, subject.UserID, subject.Concurrency, false, &streamStarted, reqLog)
+	if !acquired {
+		return
+	}
+	if userReleaseFunc != nil {
+		defer userReleaseFunc()
+	}
+
+	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription, service.QuotaPlatform(c.Request.Context(), apiKey)); err != nil {
+		reqLog.Info("openai_audio_transcriptions.billing_check_failed", zap.Error(err))
+		status, code, message, retryAfter := billingErrorDetails(err)
+		if retryAfter > 0 {
+			c.Header("Retry-After", strconv.Itoa(retryAfter))
+		}
+		h.errorResponse(c, status, code, message)
+		return
+	}
+
+	requestPayloadHash := service.HashOpenAIAudioTranscriptionPayload(parsed.Model, parsed.FileBytes, parsed.Prompt)
+	sessionHash := h.gatewayService.GenerateExplicitSessionHash(c, []byte(requestPayloadHash))
+	failedAccountIDs := make(map[int64]struct{})
+	var lastFailoverErr *service.UpstreamFailoverError
+	switchCount := 0
+	maxAccountSwitches := h.maxAccountSwitches
+	if maxAccountSwitches <= 0 {
+		maxAccountSwitches = 3
+	}
+	routingStart := time.Now()
+
+	for {
+		selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+			c.Request.Context(),
+			apiKey.GroupID,
+			"",
+			sessionHash,
+			"",
+			failedAccountIDs,
+			service.OpenAIUpstreamTransportHTTPSSE,
+			service.OpenAIEndpointCapabilityAudioTranscribe,
+			false,
+		)
+		if err != nil {
+			reqLog.Warn("openai_audio_transcriptions.account_select_failed",
+				zap.Error(err),
+				zap.Int("excluded_account_count", len(failedAccountIDs)),
+			)
+			if len(failedAccountIDs) == 0 {
+				markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+				h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "Service temporarily unavailable")
+				return
+			}
+			if lastFailoverErr != nil {
+				h.handleFailoverExhausted(c, lastFailoverErr, false)
+			} else {
+				h.errorResponse(c, http.StatusBadGateway, "api_error", "No billable compatible accounts")
+			}
+			return
+		}
+		if selection == nil || selection.Account == nil {
+			markOpsRoutingCapacityLimited(c)
+			h.errorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
+			return
+		}
+		account := selection.Account
+		if account.Type == service.AccountTypeOAuth && !h.gatewayService.CanBillOpenAIAudioDuration(c.Request.Context(), apiKey, service.OpenAIAudioTranscriptionModel, parsed.DurationSeconds) {
+			failedAccountIDs[account.ID] = struct{}{}
+			reqLog.Warn("openai_audio_transcriptions.oauth_account_skipped_without_duration_billing",
+				zap.Int64("account_id", account.ID),
+				zap.Bool("duration_parsed", parsed.DurationParsed),
+				zap.Int("duration_seconds", parsed.DurationSeconds),
+			)
+			continue
+		}
+
+		sessionHash = ensureOpenAIPoolModeSessionHash(sessionHash, account)
+		setOpsSelectedAccount(c, account.ID, account.Platform)
+		accountReleaseFunc, accountAcquired := h.acquireResponsesAccountSlot(c, apiKey.GroupID, sessionHash, selection, false, &streamStarted, reqLog)
+		if !accountAcquired {
+			return
+		}
+
+		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
+		forwardStart := time.Now()
+		output, err := func() (*service.OpenAIAudioTranscriptionOutput, error) {
+			defer func() {
+				if accountReleaseFunc != nil {
+					accountReleaseFunc()
+				}
+			}()
+			return h.gatewayService.ForwardAudioTranscription(c.Request.Context(), c, account, parsed)
+		}()
+		forwardDurationMs := time.Since(forwardStart).Milliseconds()
+		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
+		responseLatencyMs := forwardDurationMs
+		if upstreamLatencyMs > 0 && forwardDurationMs > upstreamLatencyMs {
+			responseLatencyMs = forwardDurationMs - upstreamLatencyMs
+		}
+		service.SetOpsLatencyMs(c, service.OpsResponseLatencyMsKey, responseLatencyMs)
+
+		if err != nil {
+			var upstreamErr *service.OpenAIAudioTranscriptionUpstreamError
+			if errors.As(err, &upstreamErr) {
+				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
+				h.gatewayService.WriteOpenAIAudioTranscriptionUpstreamError(c, upstreamErr)
+				return
+			}
+			var failoverErr *service.UpstreamFailoverError
+			if errors.As(err, &failoverErr) {
+				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
+				h.gatewayService.RecordOpenAIAccountSwitch()
+				failedAccountIDs[account.ID] = struct{}{}
+				lastFailoverErr = failoverErr
+				if switchCount >= maxAccountSwitches {
+					h.handleFailoverExhausted(c, failoverErr, false)
+					return
+				}
+				switchCount++
+				if h.gatewayService.ShouldStopOpenAIOAuth429Failover(account, failoverErr.StatusCode, switchCount) {
+					h.handleFailoverExhausted(c, failoverErr, false)
+					return
+				}
+				reqLog.Warn("openai_audio_transcriptions.upstream_failover_switching",
+					zap.Int64("account_id", account.ID),
+					zap.Int("upstream_status", failoverErr.StatusCode),
+					zap.Int("switch_count", switchCount),
+					zap.Int("max_switches", maxAccountSwitches),
+				)
+				continue
+			}
+			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
+			reqLog.Warn("openai_audio_transcriptions.forward_failed",
+				zap.Int64("account_id", account.ID),
+				zap.Error(err),
+			)
+			h.errorResponse(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+			return
+		}
+
+		h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
+		if err := h.gatewayService.EnsureOpenAIAudioTranscriptionBillable(output); err != nil {
+			reqLog.Error("openai_audio_transcriptions.unbillable_success_rejected",
+				zap.Int64("account_id", account.ID),
+				zap.Error(err),
+			)
+			h.errorResponse(c, http.StatusBadGateway, "upstream_error", "Upstream transcription usage unavailable")
+			return
+		}
+
+		userAgent := c.GetHeader("User-Agent")
+		clientIP := ip.GetClientIP(c)
+		inboundEndpoint := GetInboundEndpoint(c)
+		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+		channelUsage := service.ChannelUsageFields{
+			OriginalModel:      service.OpenAIAudioTranscriptionModel,
+			ChannelMappedModel: service.OpenAIAudioTranscriptionModel,
+			BillingModelSource: service.BillingModelSourceRequested,
+		}
+		if mapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, service.OpenAIAudioTranscriptionModel); mapping.ChannelID > 0 {
+			channelUsage.ChannelID = mapping.ChannelID
+		}
+
+		if err := h.gatewayService.RecordUsage(context.Background(), &service.OpenAIRecordUsageInput{
+			Result:             output.Result,
+			APIKey:             apiKey,
+			User:               apiKey.User,
+			Account:            account,
+			Subscription:       subscription,
+			InboundEndpoint:    inboundEndpoint,
+			UpstreamEndpoint:   upstreamEndpoint,
+			UserAgent:          userAgent,
+			IPAddress:          clientIP,
+			RequestPayloadHash: requestPayloadHash,
+			APIKeyService:      h.apiKeyService,
+			ChannelUsageFields: channelUsage,
+		}); err != nil {
+			logger.L().With(
+				zap.String("component", "handler.openai_gateway.audio_transcriptions"),
+				zap.Int64("user_id", subject.UserID),
+				zap.Int64("api_key_id", apiKey.ID),
+				zap.Any("group_id", apiKey.GroupID),
+				zap.String("model", service.OpenAIAudioTranscriptionModel),
+				zap.Int64("account_id", account.ID),
+			).Error("openai_audio_transcriptions.record_usage_failed", zap.Error(err))
+			h.errorResponse(c, http.StatusInternalServerError, "api_error", "Failed to record usage")
+			return
+		}
+
+		h.gatewayService.WriteOpenAIAudioTranscriptionResponse(c, output)
+		reqLog.Debug("openai_audio_transcriptions.request_completed",
+			zap.Int64("account_id", account.ID),
+			zap.Int("switch_count", switchCount),
+		)
+		return
+	}
+}
+
+func (h *OpenAIGatewayHandler) openAIAudioTranscriptionErrorResponse(c *gin.Context, status int, errType, message, param string) {
+	errObj := gin.H{
+		"type":    errType,
+		"message": message,
+	}
+	if param != "" {
+		errObj["param"] = param
+	}
+	c.JSON(status, gin.H{"error": errObj})
+}

--- a/backend/internal/handler/openai_audio_transcriptions.go
+++ b/backend/internal/handler/openai_audio_transcriptions.go
@@ -89,7 +89,7 @@ func (h *OpenAIGatewayHandler) AudioTranscriptions(c *gin.Context) {
 		return
 	}
 
-	requestPayloadHash := service.HashOpenAIAudioTranscriptionPayload(parsed.Model, parsed.FileBytes, parsed.Prompt)
+	requestPayloadHash := service.HashOpenAIAudioTranscriptionPayload(parsed.Model, parsed.FileBytes, parsed.Prompt, parsed.ExtraFields...)
 	sessionHash := h.gatewayService.GenerateExplicitSessionHash(c, []byte(requestPayloadHash))
 	failedAccountIDs := make(map[int64]struct{})
 	var lastFailoverErr *service.UpstreamFailoverError

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, billable_duration_seconds, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, created_at"
 
 // usageLogInsertArgTypes must stay in the same order as:
 //  1. prepareUsageLogInsert().args
@@ -74,6 +74,7 @@ var usageLogInsertArgTypes = [...]string{
 	"text",        // user_agent
 	"text",        // ip_address
 	"integer",     // image_count
+	"integer",     // billable_duration_seconds
 	"text",        // image_size
 	"text",        // image_input_size
 	"text",        // image_output_size
@@ -391,6 +392,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			user_agent,
 			ip_address,
 			image_count,
+			billable_duration_seconds,
 			image_size,
 			image_input_size,
 			image_output_size,
@@ -413,7 +415,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 		RETURNING id, created_at
@@ -833,6 +835,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			user_agent,
 			ip_address,
 			image_count,
+			billable_duration_seconds,
 			image_size,
 			image_input_size,
 			image_output_size,
@@ -851,7 +854,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			created_at
 		) AS (VALUES `)
 
-	args := make([]any, 0, len(keys)*50)
+	args := make([]any, 0, len(keys)*51)
 	argPos := 1
 	for idx, key := range keys {
 		if idx > 0 {
@@ -914,6 +917,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				user_agent,
 				ip_address,
 				image_count,
+				billable_duration_seconds,
 				image_size,
 				image_input_size,
 				image_output_size,
@@ -966,6 +970,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				user_agent,
 				ip_address,
 				image_count,
+				billable_duration_seconds,
 				image_size,
 				image_input_size,
 				image_output_size,
@@ -1058,6 +1063,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			user_agent,
 			ip_address,
 			image_count,
+			billable_duration_seconds,
 			image_size,
 			image_input_size,
 			image_output_size,
@@ -1076,7 +1082,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			created_at
 		) AS (VALUES `)
 
-	args := make([]any, 0, len(preparedList)*50)
+	args := make([]any, 0, len(preparedList)*51)
 	argPos := 1
 	for idx, prepared := range preparedList {
 		if idx > 0 {
@@ -1136,6 +1142,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			user_agent,
 			ip_address,
 			image_count,
+			billable_duration_seconds,
 			image_size,
 			image_input_size,
 			image_output_size,
@@ -1188,6 +1195,7 @@ func buildUsageLogBestEffortInsertQuery(preparedList []usageLogInsertPrepared) (
 			user_agent,
 			ip_address,
 			image_count,
+			billable_duration_seconds,
 			image_size,
 			image_input_size,
 			image_output_size,
@@ -1248,6 +1256,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			user_agent,
 			ip_address,
 			image_count,
+			billable_duration_seconds,
 			image_size,
 			image_input_size,
 			image_output_size,
@@ -1270,7 +1279,7 @@ func execUsageLogInsertNoResult(ctx context.Context, sqlq sqlExecutor, prepared 
 			$10, $11, $12, $13,
 			$14, $15, $16, $17,
 			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50
+			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 	`, prepared.args...)
@@ -1360,6 +1369,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			userAgent,
 			ipAddress,
 			log.ImageCount,
+			log.BillableDurationSeconds,
 			imageSize,
 			imageInputSize,
 			imageOutputSize,
@@ -4284,6 +4294,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		userAgent             sql.NullString
 		ipAddress             sql.NullString
 		imageCount            int
+		billableDurationSecs  int
 		imageSize             sql.NullString
 		imageInputSize        sql.NullString
 		imageOutputSize       sql.NullString
@@ -4338,6 +4349,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&userAgent,
 		&ipAddress,
 		&imageCount,
+		&billableDurationSecs,
 		&imageSize,
 		&imageInputSize,
 		&imageOutputSize,
@@ -4359,33 +4371,34 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 	}
 
 	log := &service.UsageLog{
-		ID:                    id,
-		UserID:                userID,
-		APIKeyID:              apiKeyID,
-		AccountID:             accountID,
-		Model:                 model,
-		RequestedModel:        coalesceTrimmedString(requestedModel, model),
-		InputTokens:           inputTokens,
-		OutputTokens:          outputTokens,
-		CacheCreationTokens:   cacheCreationTokens,
-		CacheReadTokens:       cacheReadTokens,
-		CacheCreation5mTokens: cacheCreation5m,
-		CacheCreation1hTokens: cacheCreation1h,
-		ImageOutputTokens:     imageOutputTokens,
-		ImageOutputCost:       imageOutputCost,
-		InputCost:             inputCost,
-		OutputCost:            outputCost,
-		CacheCreationCost:     cacheCreationCost,
-		CacheReadCost:         cacheReadCost,
-		TotalCost:             totalCost,
-		ActualCost:            actualCost,
-		RateMultiplier:        rateMultiplier,
-		AccountRateMultiplier: nullFloat64Ptr(accountRateMultiplier),
-		BillingType:           int8(billingType),
-		RequestType:           service.RequestTypeFromInt16(requestTypeRaw),
-		ImageCount:            imageCount,
-		CacheTTLOverridden:    cacheTTLOverridden,
-		CreatedAt:             createdAt,
+		ID:                      id,
+		UserID:                  userID,
+		APIKeyID:                apiKeyID,
+		AccountID:               accountID,
+		Model:                   model,
+		RequestedModel:          coalesceTrimmedString(requestedModel, model),
+		InputTokens:             inputTokens,
+		OutputTokens:            outputTokens,
+		CacheCreationTokens:     cacheCreationTokens,
+		CacheReadTokens:         cacheReadTokens,
+		CacheCreation5mTokens:   cacheCreation5m,
+		CacheCreation1hTokens:   cacheCreation1h,
+		ImageOutputTokens:       imageOutputTokens,
+		ImageOutputCost:         imageOutputCost,
+		InputCost:               inputCost,
+		OutputCost:              outputCost,
+		CacheCreationCost:       cacheCreationCost,
+		CacheReadCost:           cacheReadCost,
+		TotalCost:               totalCost,
+		ActualCost:              actualCost,
+		RateMultiplier:          rateMultiplier,
+		AccountRateMultiplier:   nullFloat64Ptr(accountRateMultiplier),
+		BillingType:             int8(billingType),
+		RequestType:             service.RequestTypeFromInt16(requestTypeRaw),
+		ImageCount:              imageCount,
+		BillableDurationSeconds: billableDurationSecs,
+		CacheTTLOverridden:      cacheTTLOverridden,
+		CreatedAt:               createdAt,
 	}
 	// 先回填 legacy 字段，再基于 legacy + request_type 计算最终请求类型，保证历史数据兼容。
 	log.Stream = stream

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -75,6 +75,7 @@ func TestUsageLogRepositoryCreateSyncRequestTypeAndLegacyFields(t *testing.T) {
 			sqlmock.AnyArg(), // user_agent
 			sqlmock.AnyArg(), // ip_address
 			log.ImageCount,
+			log.BillableDurationSeconds,
 			sqlmock.AnyArg(), // image_size
 			sqlmock.AnyArg(), // image_input_size
 			sqlmock.AnyArg(), // image_output_size
@@ -158,6 +159,7 @@ func TestUsageLogRepositoryCreate_PersistsServiceTier(t *testing.T) {
 			sqlmock.AnyArg(),
 			sqlmock.AnyArg(),
 			log.ImageCount,
+			log.BillableDurationSeconds,
 			sqlmock.AnyArg(),
 			sqlmock.AnyArg(), // image_input_size
 			sqlmock.AnyArg(), // image_output_size
@@ -259,11 +261,12 @@ func TestPrepareUsageLogInsert_PersistsImageSizeMetadata(t *testing.T) {
 		CreatedAt:          time.Date(2025, 1, 6, 12, 0, 0, 0, time.UTC),
 	})
 
-	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[34])
-	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[35])
-	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[36])
-	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[37])
-	breakdownJSON, ok := prepared.args[38].(string)
+	require.Equal(t, 0, prepared.args[34])
+	require.Equal(t, sql.NullString{String: imageSize, Valid: true}, prepared.args[35])
+	require.Equal(t, sql.NullString{String: inputSize, Valid: true}, prepared.args[36])
+	require.Equal(t, sql.NullString{String: outputSize, Valid: true}, prepared.args[37])
+	require.Equal(t, sql.NullString{String: source, Valid: true}, prepared.args[38])
+	breakdownJSON, ok := prepared.args[39].(string)
 	require.True(t, ok)
 	require.JSONEq(t, `{"1K":1,"4K":1}`, breakdownJSON)
 }
@@ -625,6 +628,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			2,
+			0,
 			sql.NullString{Valid: true, String: "4K"},
 			sql.NullString{Valid: true, String: "1024x1024"},
 			sql.NullString{Valid: true, String: "3840x2160"},
@@ -693,6 +697,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			0,
+			0,
 			sql.NullString{},
 			sql.NullString{}, // image_input_size
 			sql.NullString{}, // image_output_size
@@ -745,6 +750,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullString{},
 			sql.NullString{},
 			0,
+			0,
 			sql.NullString{},
 			sql.NullString{}, // image_input_size
 			sql.NullString{}, // image_output_size
@@ -796,6 +802,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			sql.NullInt64{},
 			sql.NullString{},
 			sql.NullString{},
+			0,
 			0,
 			sql.NullString{},
 			sql.NullString{}, // image_input_size

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -102,6 +102,19 @@ func RegisterGatewayRoutes(
 			}
 			h.OpenAIGateway.Embeddings(c)
 		})
+		gateway.POST("/audio/transcriptions", func(c *gin.Context) {
+			if getGroupPlatform(c) != service.PlatformOpenAI {
+				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
+				c.JSON(http.StatusNotFound, gin.H{
+					"error": gin.H{
+						"type":    "not_found_error",
+						"message": "Audio Transcriptions API is not supported for this platform",
+					},
+				})
+				return
+			}
+			h.OpenAIGateway.AudioTranscriptions(c)
+		})
 		gateway.POST("/images/generations", func(c *gin.Context) {
 			if getGroupPlatform(c) != service.PlatformOpenAI {
 				service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -77,3 +77,21 @@ func TestGatewayRoutesOpenAIImagesPathsAreRegistered(t *testing.T) {
 		require.NotEqual(t, http.StatusNotFound, w.Code, "path=%s should hit OpenAI images handler", path)
 	}
 }
+
+func TestGatewayRoutesOpenAIAudioTranscriptionsPathIsRegisteredOnlyUnderV1(t *testing.T) {
+	router := newGatewayRoutesTestRouter()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", strings.NewReader(""))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusNotFound, w.Code)
+
+	for _, path := range []string{"/audio/transcriptions", "/backend-api/transcribe"} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(""))
+		req.Header.Set("Content-Type", "multipart/form-data; boundary=test")
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, "path=%s should not be publicly registered", path)
+	}
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -73,6 +73,7 @@ type OpenAIEndpointCapability string
 const (
 	OpenAIEndpointCapabilityChatCompletions OpenAIEndpointCapability = "chat_completions"
 	OpenAIEndpointCapabilityEmbeddings      OpenAIEndpointCapability = "embeddings"
+	OpenAIEndpointCapabilityAudioTranscribe OpenAIEndpointCapability = "audio_transcriptions"
 )
 
 const openAIEndpointCapabilitiesCredentialKey = "openai_capabilities"
@@ -1149,6 +1150,7 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 		if a.Type != AccountTypeAPIKey {
 			return false
 		}
+	case OpenAIEndpointCapabilityAudioTranscribe:
 	default:
 		return false
 	}

--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 )
 
+type accountStatsBillableQuantity struct {
+	DurationSeconds int
+}
+
 // resolveAccountStatsCost 计算账号统计定价费用。
 // 返回 nil 表示不覆盖，使用默认公式（total_cost × account_rate_multiplier）。
 //
@@ -26,6 +30,7 @@ func resolveAccountStatsCost(
 	tokens UsageTokens,
 	requestCount int,
 	totalCost float64,
+	quantities ...accountStatsBillableQuantity,
 ) *float64 {
 	if channelService == nil || upstreamModel == "" {
 		return nil
@@ -38,7 +43,7 @@ func resolveAccountStatsCost(
 	platform := channelService.GetGroupPlatform(ctx, groupID)
 
 	// 优先级 1：自定义规则（始终尝试）
-	if cost := tryCustomRules(channel, accountID, groupID, platform, upstreamModel, tokens, requestCount); cost != nil {
+	if cost := tryCustomRules(channel, accountID, groupID, platform, upstreamModel, tokens, requestCount, quantities...); cost != nil {
 		return cost
 	}
 
@@ -80,6 +85,7 @@ func tryModelFilePricing(billingService *BillingService, model string, tokens Us
 func tryCustomRules(
 	channel *Channel, accountID, groupID int64,
 	platform, model string, tokens UsageTokens, requestCount int,
+	quantities ...accountStatsBillableQuantity,
 ) *float64 {
 	modelLower := strings.ToLower(model)
 	for _, rule := range channel.AccountStatsPricingRules {
@@ -90,7 +96,7 @@ func tryCustomRules(
 		if pricing == nil {
 			continue // 规则匹配但模型不在规则定价中，继续下一条
 		}
-		return calculateStatsCost(pricing, tokens, requestCount)
+		return calculateStatsCost(pricing, tokens, requestCount, quantities...)
 	}
 	return nil
 }
@@ -159,13 +165,15 @@ func isPlatformMatch(queryPlatform, pricingPlatform string) bool {
 }
 
 // calculateStatsCost 使用给定的定价计算费用（不含任何倍率，原始费用）。
-func calculateStatsCost(pricing *ChannelModelPricing, tokens UsageTokens, requestCount int) *float64 {
+func calculateStatsCost(pricing *ChannelModelPricing, tokens UsageTokens, requestCount int, quantities ...accountStatsBillableQuantity) *float64 {
 	if pricing == nil {
 		return nil
 	}
 	switch pricing.BillingMode {
 	case BillingModePerRequest, BillingModeImage:
 		return calculatePerRequestStatsCost(pricing, requestCount)
+	case BillingModeDuration:
+		return calculateDurationStatsCost(pricing, firstAccountStatsBillableQuantity(quantities).DurationSeconds)
 	default:
 		return calculateTokenStatsCost(pricing, tokens)
 	}
@@ -178,6 +186,21 @@ func calculatePerRequestStatsCost(pricing *ChannelModelPricing, requestCount int
 	}
 	cost := *pricing.PerRequestPrice * float64(requestCount)
 	return &cost
+}
+
+func calculateDurationStatsCost(pricing *ChannelModelPricing, seconds int) *float64 {
+	if pricing.PerRequestPrice == nil || *pricing.PerRequestPrice <= 0 || seconds <= 0 {
+		return nil
+	}
+	cost := *pricing.PerRequestPrice * float64(seconds)
+	return &cost
+}
+
+func firstAccountStatsBillableQuantity(quantities []accountStatsBillableQuantity) accountStatsBillableQuantity {
+	if len(quantities) == 0 {
+		return accountStatsBillableQuantity{}
+	}
+	return quantities[0]
 }
 
 // calculateTokenStatsCost Token 计费。
@@ -236,5 +259,6 @@ func applyAccountStatsCost(
 	}
 	usageLog.AccountStatsCost = resolveAccountStatsCost(
 		ctx, cs, bs, accountID, groupID, model, tokens, requestCount, totalCost,
+		accountStatsBillableQuantity{DurationSeconds: usageLog.BillableDurationSeconds},
 	)
 }

--- a/backend/internal/service/billable_audio_duration.go
+++ b/backend/internal/service/billable_audio_duration.go
@@ -1,0 +1,462 @@
+package service
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+)
+
+const (
+	ebmlIDHeader        = 0x1A45DFA3
+	ebmlIDSegment       = 0x18538067
+	ebmlIDInfo          = 0x1549A966
+	ebmlIDTimecodeScale = 0x2AD7B1
+	ebmlIDDuration      = 0x4489
+	ebmlIDTracks        = 0x1654AE6B
+	ebmlIDTrackEntry    = 0xAE
+	ebmlIDTrackNumber   = 0xD7
+	ebmlIDTrackType     = 0x83
+	ebmlIDCodecID       = 0x86
+	ebmlIDAudio         = 0xE1
+	ebmlIDCluster       = 0x1F43B675
+	ebmlIDClusterTime   = 0xE7
+	ebmlIDSimpleBlock   = 0xA3
+	ebmlIDBlockGroup    = 0xA0
+	ebmlIDBlock         = 0xA1
+
+	webmDefaultTimecodeScale = uint64(1000000)
+)
+
+func ExtractBillableAudioDurationSeconds(data []byte) (int, bool) {
+	if len(data) == 0 {
+		return 0, false
+	}
+	return parseAudioDurationSeconds(data)
+}
+
+func ceilPositiveSeconds(value float64) int {
+	if value <= 0 || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0
+	}
+	return int(math.Ceil(value))
+}
+
+func parseAudioDurationSeconds(data []byte) (int, bool) {
+	switch {
+	case len(data) >= 12 && bytes.HasPrefix(data, []byte("RIFF")) && bytes.Equal(data[8:12], []byte("WAVE")):
+		return parseWAVDurationSeconds(data)
+	case len(data) >= 10 && bytes.HasPrefix(data, []byte("ID3")),
+		len(data) >= 2 && data[0] == 0xff && data[1]&0xe0 == 0xe0:
+		return parseMP3DurationSeconds(data)
+	case len(data) >= 12 && bytes.Equal(data[4:8], []byte("ftyp")):
+		return parseMP4DurationSeconds(data)
+	case len(data) >= 4 && bytes.Equal(data[:4], []byte{0x1A, 0x45, 0xDF, 0xA3}):
+		return parseWebMDurationSeconds(data)
+	default:
+		return 0, false
+	}
+}
+
+func parseWAVDurationSeconds(data []byte) (int, bool) {
+	var byteRate uint32
+	var dataSize uint32
+	for offset := 12; offset+8 <= len(data); {
+		chunkID := string(data[offset : offset+4])
+		chunkSize := binary.LittleEndian.Uint32(data[offset+4 : offset+8])
+		payload := offset + 8
+		next := payload + int(chunkSize)
+		if next > len(data) {
+			return 0, false
+		}
+		switch chunkID {
+		case "fmt ":
+			if chunkSize >= 16 {
+				byteRate = binary.LittleEndian.Uint32(data[payload+8 : payload+12])
+			}
+		case "data":
+			dataSize = chunkSize
+		}
+		if byteRate > 0 && dataSize > 0 {
+			return ceilPositiveSeconds(float64(dataSize) / float64(byteRate)), true
+		}
+		offset = next + int(chunkSize%2)
+	}
+	return 0, false
+}
+
+func parseMP3DurationSeconds(data []byte) (int, bool) {
+	offset := skipID3v2(data)
+	totalSeconds := 0.0
+	frames := 0
+	for offset+4 <= len(data) {
+		frameLen, samples, sampleRate, ok := parseMP3FrameHeader(data[offset : offset+4])
+		if !ok || frameLen <= 0 || offset+frameLen > len(data) {
+			offset++
+			continue
+		}
+		totalSeconds += float64(samples) / float64(sampleRate)
+		frames++
+		offset += frameLen
+	}
+	if frames == 0 {
+		return 0, false
+	}
+	return ceilPositiveSeconds(totalSeconds), true
+}
+
+func skipID3v2(data []byte) int {
+	if len(data) < 10 || !bytes.HasPrefix(data, []byte("ID3")) {
+		return 0
+	}
+	size := int(data[6]&0x7f)<<21 | int(data[7]&0x7f)<<14 | int(data[8]&0x7f)<<7 | int(data[9]&0x7f)
+	if 10+size >= len(data) {
+		return 0
+	}
+	return 10 + size
+}
+
+func parseMP3FrameHeader(h []byte) (frameLen int, samples int, sampleRate int, ok bool) {
+	if len(h) < 4 || h[0] != 0xff || h[1]&0xe0 != 0xe0 {
+		return 0, 0, 0, false
+	}
+	versionID := (h[1] >> 3) & 0x03
+	layerID := (h[1] >> 1) & 0x03
+	bitrateIdx := (h[2] >> 4) & 0x0f
+	sampleIdx := (h[2] >> 2) & 0x03
+	padding := int((h[2] >> 1) & 0x01)
+	if versionID == 1 || layerID == 0 || bitrateIdx == 0 || bitrateIdx == 15 || sampleIdx == 3 {
+		return 0, 0, 0, false
+	}
+	sampleRate = mp3SampleRate(versionID, sampleIdx)
+	bitrate := mp3BitrateKbps(versionID, layerID, bitrateIdx)
+	if sampleRate <= 0 || bitrate <= 0 {
+		return 0, 0, 0, false
+	}
+	samples = mp3SamplesPerFrame(versionID, layerID)
+	if layerID == 3 {
+		frameLen = (12*bitrate*1000/sampleRate + padding) * 4
+	} else if layerID == 1 && versionID != 3 {
+		frameLen = 72*bitrate*1000/sampleRate + padding
+	} else {
+		frameLen = 144*bitrate*1000/sampleRate + padding
+	}
+	return frameLen, samples, sampleRate, true
+}
+
+func mp3SampleRate(versionID byte, sampleIdx byte) int {
+	base := []int{44100, 48000, 32000}[sampleIdx]
+	switch versionID {
+	case 3:
+		return base
+	case 2:
+		return base / 2
+	case 0:
+		return base / 4
+	default:
+		return 0
+	}
+}
+
+func mp3BitrateKbps(versionID, layerID, idx byte) int {
+	tables := map[byte]map[byte][]int{
+		3: {
+			3: {0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448, 0},
+			2: {0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 0},
+			1: {0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0},
+		},
+		2: {
+			3: {0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256, 0},
+			2: {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},
+			1: {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},
+		},
+		0: {
+			3: {0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256, 0},
+			2: {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},
+			1: {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},
+		},
+	}
+	return tables[versionID][layerID][idx]
+}
+
+func mp3SamplesPerFrame(versionID, layerID byte) int {
+	switch layerID {
+	case 3:
+		return 384
+	case 2:
+		return 1152
+	case 1:
+		if versionID == 3 {
+			return 1152
+		}
+		return 576
+	default:
+		return 0
+	}
+}
+
+func parseMP4DurationSeconds(data []byte) (int, bool) {
+	duration, ok := scanMP4Duration(data, 0)
+	if !ok {
+		return 0, false
+	}
+	return ceilPositiveSeconds(duration), true
+}
+
+func scanMP4Duration(data []byte, depth int) (float64, bool) {
+	if depth > 8 {
+		return 0, false
+	}
+	for offset := 0; offset+8 <= len(data); {
+		size := uint64(binary.BigEndian.Uint32(data[offset : offset+4]))
+		boxType := string(data[offset+4 : offset+8])
+		header := 8
+		switch size {
+		case 1:
+			if offset+16 > len(data) {
+				return 0, false
+			}
+			size = binary.BigEndian.Uint64(data[offset+8 : offset+16])
+			header = 16
+		case 0:
+			size = uint64(len(data) - offset)
+		}
+		if size < uint64(header) || offset+int(size) > len(data) {
+			return 0, false
+		}
+		payload := data[offset+header : offset+int(size)]
+		switch boxType {
+		case "mvhd", "mdhd":
+			if duration, ok := parseMP4MovieHeaderDuration(payload); ok {
+				return duration, true
+			}
+		case "moov", "trak", "mdia":
+			if duration, ok := scanMP4Duration(payload, depth+1); ok {
+				return duration, true
+			}
+		}
+		offset += int(size)
+	}
+	return 0, false
+}
+
+func parseMP4MovieHeaderDuration(payload []byte) (float64, bool) {
+	if len(payload) < 20 {
+		return 0, false
+	}
+	version := payload[0]
+	if version == 1 {
+		if len(payload) < 32 {
+			return 0, false
+		}
+		timescale := binary.BigEndian.Uint32(payload[20:24])
+		duration := binary.BigEndian.Uint64(payload[24:32])
+		if timescale == 0 || duration == 0 {
+			return 0, false
+		}
+		return float64(duration) / float64(timescale), true
+	}
+	timescale := binary.BigEndian.Uint32(payload[12:16])
+	duration := binary.BigEndian.Uint32(payload[16:20])
+	if timescale == 0 || duration == 0 {
+		return 0, false
+	}
+	return float64(duration) / float64(timescale), true
+}
+
+func parseWebMDurationSeconds(data []byte) (int, bool) {
+	if len(data) < 4 || binary.BigEndian.Uint32(data[:4]) != ebmlIDHeader {
+		return 0, false
+	}
+	duration, ok := scanWebMDuration(data)
+	if !ok {
+		return 0, false
+	}
+	return ceilPositiveSeconds(duration), true
+}
+
+func scanWebMDuration(data []byte) (float64, bool) {
+	offset := 0
+	scale := webmDefaultTimecodeScale
+	for offset < len(data) {
+		id, idLen, ok := readEBMLVintID(data[offset:])
+		if !ok {
+			break
+		}
+		offset += idLen
+		size, sizeLen, unknown, ok := readEBMLVintSize(data[offset:])
+		if !ok {
+			break
+		}
+		offset += sizeLen
+		if unknown {
+			size = uint64(len(data) - offset)
+		}
+		if size > uint64(len(data)-offset) {
+			break
+		}
+		payload := data[offset : offset+int(size)]
+		switch id {
+		case ebmlIDInfo:
+			if duration, found := scanWebMInfo(payload, &scale); found {
+				return duration, true
+			}
+		case ebmlIDSegment:
+			if duration, found := scanWebMDuration(payload); found {
+				return duration, true
+			}
+		}
+		offset += int(size)
+	}
+	return scanWebMClusterDuration(data, scale)
+}
+
+func scanWebMInfo(data []byte, scale *uint64) (float64, bool) {
+	offset := 0
+	for offset < len(data) {
+		id, idLen, ok := readEBMLVintID(data[offset:])
+		if !ok {
+			break
+		}
+		offset += idLen
+		size, sizeLen, _, ok := readEBMLVintSize(data[offset:])
+		if !ok || size > uint64(len(data)-offset-sizeLen) {
+			break
+		}
+		offset += sizeLen
+		payload := data[offset : offset+int(size)]
+		switch id {
+		case ebmlIDTimecodeScale:
+			if value, ok := readUnsignedEBML(payload); ok && value > 0 {
+				*scale = value
+			}
+		case ebmlIDDuration:
+			if duration, ok := readFloatEBML(payload); ok && duration > 0 {
+				return duration * float64(*scale) / 1e9, true
+			}
+		}
+		offset += int(size)
+	}
+	return 0, false
+}
+
+func scanWebMClusterDuration(data []byte, scale uint64) (float64, bool) {
+	offset := 0
+	lastTimecode := uint64(0)
+	found := false
+	for offset < len(data) {
+		id, idLen, ok := readEBMLVintID(data[offset:])
+		if !ok {
+			break
+		}
+		offset += idLen
+		size, sizeLen, unknown, ok := readEBMLVintSize(data[offset:])
+		if !ok {
+			break
+		}
+		offset += sizeLen
+		if unknown {
+			size = uint64(len(data) - offset)
+		}
+		if size > uint64(len(data)-offset) {
+			break
+		}
+		if id == ebmlIDCluster {
+			if tc, ok := scanWebMClusterTimecode(data[offset : offset+int(size)]); ok {
+				lastTimecode = tc
+				found = true
+			}
+		}
+		offset += int(size)
+	}
+	if !found {
+		return 0, false
+	}
+	return float64(lastTimecode*scale) / 1e9, true
+}
+
+func scanWebMClusterTimecode(data []byte) (uint64, bool) {
+	offset := 0
+	for offset < len(data) {
+		id, idLen, ok := readEBMLVintID(data[offset:])
+		if !ok {
+			break
+		}
+		offset += idLen
+		size, sizeLen, _, ok := readEBMLVintSize(data[offset:])
+		if !ok || size > uint64(len(data)-offset-sizeLen) {
+			break
+		}
+		offset += sizeLen
+		payload := data[offset : offset+int(size)]
+		if id == ebmlIDClusterTime {
+			return readUnsignedEBML(payload)
+		}
+		offset += int(size)
+	}
+	return 0, false
+}
+
+func readEBMLVintID(data []byte) (uint64, int, bool) {
+	if len(data) == 0 {
+		return 0, 0, false
+	}
+	first := data[0]
+	mask := byte(0x80)
+	length := 1
+	for length <= 4 && first&mask == 0 {
+		mask >>= 1
+		length++
+	}
+	if length > 4 || length > len(data) {
+		return 0, 0, false
+	}
+	value := uint64(0)
+	for i := 0; i < length; i++ {
+		value = (value << 8) | uint64(data[i])
+	}
+	return value, length, true
+}
+
+func readEBMLVintSize(data []byte) (uint64, int, bool, bool) {
+	if len(data) == 0 {
+		return 0, 0, false, false
+	}
+	first := data[0]
+	mask := byte(0x80)
+	length := 1
+	for length <= 8 && first&mask == 0 {
+		mask >>= 1
+		length++
+	}
+	if length > 8 || length > len(data) {
+		return 0, 0, false, false
+	}
+	value := uint64(first & ^mask)
+	for i := 1; i < length; i++ {
+		value = (value << 8) | uint64(data[i])
+	}
+	unknown := value == (uint64(1)<<(uint(length)*7))-1
+	return value, length, unknown, true
+}
+
+func readUnsignedEBML(data []byte) (uint64, bool) {
+	if len(data) == 0 || len(data) > 8 {
+		return 0, false
+	}
+	value := uint64(0)
+	for _, b := range data {
+		value = (value << 8) | uint64(b)
+	}
+	return value, true
+}
+
+func readFloatEBML(data []byte) (float64, bool) {
+	switch len(data) {
+	case 4:
+		return float64(math.Float32frombits(binary.BigEndian.Uint32(data))), true
+	case 8:
+		return math.Float64frombits(binary.BigEndian.Uint64(data)), true
+	default:
+		return 0, false
+	}
+}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -156,7 +156,7 @@ type CostBreakdown struct {
 	CacheReadCost     float64
 	TotalCost         float64
 	ActualCost        float64 // 应用倍率后的实际费用
-	BillingMode       string  // 计费模式（"token"/"per_request"/"image"），由 CalculateCostUnified 填充
+	BillingMode       string  // 计费模式（"token"/"per_request"/"image"/"duration"），由 CalculateCostUnified 填充
 }
 
 // ErrModelPricingUnavailable indicates that none of the configured pricing
@@ -746,19 +746,20 @@ func (s *BillingService) GetModelPricingWithChannel(model string, channelPricing
 
 // CostInput 统一计费输入
 type CostInput struct {
-	Ctx            context.Context
-	Model          string
-	GroupID        *int64 // 用于渠道定价查找
-	Tokens         UsageTokens
-	RequestCount   int    // 按次计费时使用
-	SizeTier       string // 按次/图片模式的层级标签（"1K","2K","4K","HD" 等）
-	RateMultiplier float64
-	ServiceTier    string                // "priority","flex","" 等
-	Resolver       *ModelPricingResolver // 定价解析器
-	Resolved       *ResolvedPricing      // 可选：预解析的定价结果（避免重复 Resolve 调用）
+	Ctx             context.Context
+	Model           string
+	GroupID         *int64 // 用于渠道定价查找
+	Tokens          UsageTokens
+	RequestCount    int    // 按次计费时使用
+	SizeTier        string // 按次/图片模式的层级标签（"1K","2K","4K","HD" 等）
+	DurationSeconds int    // 按秒计费时使用
+	RateMultiplier  float64
+	ServiceTier     string                // "priority","flex","" 等
+	Resolver        *ModelPricingResolver // 定价解析器
+	Resolved        *ResolvedPricing      // 可选：预解析的定价结果（避免重复 Resolve 调用）
 }
 
-// CalculateCostUnified 统一计费入口，支持三种计费模式。
+// CalculateCostUnified 统一计费入口，支持 token/per_request/image/duration 计费模式。
 // 使用 ModelPricingResolver 解析定价，然后根据 BillingMode 分发计算。
 func (s *BillingService) CalculateCostUnified(input CostInput) (*CostBreakdown, error) {
 	if input.Resolver == nil {
@@ -785,6 +786,8 @@ func (s *BillingService) CalculateCostUnified(input CostInput) (*CostBreakdown, 
 	switch resolved.Mode {
 	case BillingModePerRequest, BillingModeImage:
 		breakdown, err = s.calculatePerRequestCost(resolved, input)
+	case BillingModeDuration:
+		breakdown, err = s.calculateDurationCost(resolved, input)
 	default: // BillingModeToken
 		breakdown, err = s.calculateTokenCost(resolved, input)
 	}
@@ -954,6 +957,22 @@ func (s *BillingService) calculatePerRequestCost(resolved *ResolvedPricing, inpu
 	totalCost := unitPrice * float64(count)
 	actualCost := totalCost * input.RateMultiplier
 
+	return &CostBreakdown{
+		TotalCost:  totalCost,
+		ActualCost: actualCost,
+	}, nil
+}
+
+func (s *BillingService) calculateDurationCost(resolved *ResolvedPricing, input CostInput) (*CostBreakdown, error) {
+	seconds := input.DurationSeconds
+	if seconds <= 0 {
+		return nil, fmt.Errorf("duration seconds required for model: %s: %w", input.Model, ErrModelPricingUnavailable)
+	}
+	if resolved.DefaultPerRequestPrice <= 0 {
+		return nil, fmt.Errorf("duration price required for model: %s: %w", input.Model, ErrModelPricingUnavailable)
+	}
+	totalCost := resolved.DefaultPerRequestPrice * float64(seconds)
+	actualCost := totalCost * input.RateMultiplier
 	return &CostBreakdown{
 		TotalCost:  totalCost,
 		ActualCost: actualCost,

--- a/backend/internal/service/channel.go
+++ b/backend/internal/service/channel.go
@@ -14,12 +14,13 @@ const (
 	BillingModeToken      BillingMode = "token"       // 按 token 区间计费
 	BillingModePerRequest BillingMode = "per_request" // 按次计费（支持上下文窗口分层）
 	BillingModeImage      BillingMode = "image"       // 图片计费（当前按次，预留 token 计费）
+	BillingModeDuration   BillingMode = "duration"    // 音频按秒计费
 )
 
 // IsValid 检查 BillingMode 是否为合法值
 func (m BillingMode) IsValid() bool {
 	switch m {
-	case BillingModeToken, BillingModePerRequest, BillingModeImage, "":
+	case BillingModeToken, BillingModePerRequest, BillingModeImage, BillingModeDuration, "":
 		return true
 	}
 	return false
@@ -277,7 +278,7 @@ func deepCopyFeaturesConfig(src map[string]any) map[string]any {
 // mode 决定区间语义：
 //   - BillingModeToken（含空值）：区间是上下文 token 数分段 (min, max]，
 //     按 MinTokens 排序后无重叠，无界区间（MaxTokens=nil）必须是最后一个。
-//   - BillingModePerRequest / BillingModeImage：区间是按 tier_label
+//   - BillingModePerRequest / BillingModeImage / BillingModeDuration：区间是按 tier_label
 //     (1K/2K/4K 等) 分层，匹配走 label 不依赖 min/max，因此跳过区间重叠
 //     与 last-unlimited 校验，仅做单条字段自洽（min/max/价格非负）检查。
 //
@@ -300,7 +301,7 @@ func ValidateIntervals(intervals []PricingInterval, mode BillingMode) error {
 	}
 
 	// per_request / image 模式按 tier_label 匹配，不做 token 区间重叠校验
-	if mode == BillingModePerRequest || mode == BillingModeImage {
+	if mode == BillingModePerRequest || mode == BillingModeImage || mode == BillingModeDuration {
 		return nil
 	}
 	return validateIntervalOverlap(sorted)

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -625,6 +625,15 @@ func validatePricingBillingMode(pricing []ChannelModelPricing) error {
 }
 
 func checkBillingModeRequirements(p ChannelModelPricing) error {
+	if p.BillingMode == BillingModeDuration {
+		if p.PerRequestPrice == nil {
+			return infraerrors.BadRequest(
+				"BILLING_MODE_MISSING_PRICE",
+				"per_request_price is required for duration billing mode",
+			)
+		}
+		return nil
+	}
 	if p.BillingMode == BillingModePerRequest || p.BillingMode == BillingModeImage {
 		if p.PerRequestPrice == nil && len(p.Intervals) == 0 {
 			return infraerrors.BadRequest(

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -8919,6 +8919,7 @@ func buildUsageBillingCommand(requestID string, usageLog *UsageLog, p *postUsage
 		cmd.CacheCreationTokens = usageLog.CacheCreationTokens
 		cmd.CacheReadTokens = usageLog.CacheReadTokens
 		cmd.ImageCount = usageLog.ImageCount
+		cmd.BillableDurationSeconds = usageLog.BillableDurationSeconds
 		if usageLog.ServiceTier != nil {
 			cmd.ServiceTier = *usageLog.ServiceTier
 		}

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -72,7 +72,7 @@ func (r *ModelPricingResolver) Resolve(ctx context.Context, input PricingInput) 
 			if mode == "" {
 				mode = BillingModeToken
 			}
-			if mode == BillingModePerRequest || mode == BillingModeImage {
+			if mode == BillingModePerRequest || mode == BillingModeImage || mode == BillingModeDuration {
 				resolved := &ResolvedPricing{
 					Mode:           mode,
 					Source:         PricingSourceChannel,
@@ -134,7 +134,7 @@ func (r *ModelPricingResolver) applyChannelOverrides(ctx context.Context, groupI
 	switch resolved.Mode {
 	case BillingModeToken:
 		r.applyTokenOverrides(chPricing, resolved)
-	case BillingModePerRequest, BillingModeImage:
+	case BillingModePerRequest, BillingModeImage, BillingModeDuration:
 		r.applyRequestTierOverrides(chPricing, resolved)
 	}
 }

--- a/backend/internal/service/openai_audio_transcriptions.go
+++ b/backend/internal/service/openai_audio_transcriptions.go
@@ -1,0 +1,562 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"go.uber.org/zap"
+)
+
+const (
+	OpenAIAudioTranscriptionModel       = "gpt-4o-transcribe"
+	openAIAudioTranscriptionMaxBytes    = 25 << 20
+	openAIAudioTranscriptionsEndpoint   = "/v1/audio/transcriptions"
+	chatgptAudioTranscriptionEndpoint   = "/backend-api/transcribe"
+	chatgptAudioTranscriptionUpstream   = "https://chatgpt.com/backend-api/transcribe"
+	defaultAudioTranscriptionFileName   = "audio.wav"
+	defaultAudioTranscriptionMediaType  = "application/octet-stream"
+	maxAudioTranscriptionTextFieldBytes = 64 << 10
+)
+
+type OpenAIAudioTranscriptionRequest struct {
+	FileName        string
+	ContentType     string
+	FileBytes       []byte
+	Model           string
+	Prompt          string
+	DurationSeconds int
+	DurationParsed  bool
+}
+
+type OpenAIAudioTranscriptionOutput struct {
+	Result      *OpenAIForwardResult
+	Body        []byte
+	Text        string
+	StatusCode  int
+	Header      http.Header
+	ContentType string
+}
+
+type OpenAIAudioTranscriptionRequestError struct {
+	Status  int
+	Type    string
+	Message string
+	Param   string
+}
+
+func (e *OpenAIAudioTranscriptionRequestError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+type OpenAIAudioTranscriptionUpstreamError struct {
+	StatusCode int
+	Body       []byte
+	Header     http.Header
+}
+
+func (e *OpenAIAudioTranscriptionUpstreamError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("audio transcription upstream returned status %d", e.StatusCode)
+}
+
+func (e *OpenAIAudioTranscriptionUpstreamError) contentType() string {
+	if e == nil || e.Header == nil {
+		return "application/json"
+	}
+	if ct := strings.TrimSpace(e.Header.Get("Content-Type")); ct != "" {
+		return ct
+	}
+	return "application/json"
+}
+
+func (s *OpenAIGatewayService) ParseOpenAIAudioTranscriptionRequest(body []byte, contentType string) (*OpenAIAudioTranscriptionRequest, error) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil || !strings.EqualFold(mediaType, "multipart/form-data") {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Expected multipart/form-data request", "")
+	}
+	boundary := strings.TrimSpace(params["boundary"])
+	if boundary == "" {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "multipart boundary is required", "")
+	}
+	if len(body) == 0 {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Request body is empty", "")
+	}
+
+	reader := multipart.NewReader(bytes.NewReader(body), boundary)
+	parsed := &OpenAIAudioTranscriptionRequest{}
+	modelSeen := false
+	fileSeen := false
+
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Failed to parse multipart request", "")
+		}
+
+		formName := strings.TrimSpace(part.FormName())
+		filename := strings.TrimSpace(part.FileName())
+		switch formName {
+		case "file":
+			if filename == "" {
+				_ = part.Close()
+				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "file must be a file upload", "file")
+			}
+			if fileSeen {
+				_ = part.Close()
+				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Only one file is supported", "file")
+			}
+			data, readErr := readAudioTranscriptionFilePart(part)
+			_ = part.Close()
+			if readErr != nil {
+				return nil, readErr
+			}
+			parsed.FileName = filename
+			parsed.ContentType = strings.TrimSpace(part.Header.Get("Content-Type"))
+			parsed.FileBytes = data
+			fileSeen = true
+		case "model":
+			if filename != "" {
+				_ = part.Close()
+				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "model must be a form field", "model")
+			}
+			value, readErr := readAudioTranscriptionTextField(part)
+			_ = part.Close()
+			if readErr != nil {
+				return nil, readErr
+			}
+			parsed.Model = strings.TrimSpace(value)
+			modelSeen = true
+		case "prompt":
+			if filename != "" {
+				_ = part.Close()
+				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "prompt must be a form field", "prompt")
+			}
+			value, readErr := readAudioTranscriptionTextField(part)
+			_ = part.Close()
+			if readErr != nil {
+				return nil, readErr
+			}
+			parsed.Prompt = strings.TrimSpace(value)
+		case "":
+			_ = part.Close()
+			return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Multipart field name is required", "")
+		default:
+			_ = part.Close()
+			if formName == "stream" {
+				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "stream is not supported for audio transcriptions", "stream")
+			}
+			return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Unsupported audio transcription field: "+formName, formName)
+		}
+	}
+
+	if !fileSeen || len(parsed.FileBytes) == 0 {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "file is required", "file")
+	}
+	if !modelSeen || strings.TrimSpace(parsed.Model) == "" {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "model is required", "model")
+	}
+	if parsed.Model != OpenAIAudioTranscriptionModel {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Unsupported audio transcription model: "+parsed.Model, "model")
+	}
+	if parsed.ContentType == "" {
+		parsed.ContentType = defaultAudioTranscriptionMediaType
+	}
+	if seconds, ok := ExtractBillableAudioDurationSeconds(parsed.FileBytes); ok {
+		parsed.DurationSeconds = seconds
+		parsed.DurationParsed = true
+	}
+	return parsed, nil
+}
+
+func readAudioTranscriptionFilePart(part *multipart.Part) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(part, openAIAudioTranscriptionMaxBytes+1))
+	if err != nil {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Failed to read file", "file")
+	}
+	if len(data) == 0 {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "file is required", "file")
+	}
+	if len(data) > openAIAudioTranscriptionMaxBytes {
+		return nil, newOpenAIAudioTranscriptionRequestError(http.StatusRequestEntityTooLarge, "invalid_request_error", "Audio file exceeds 25 MiB limit", "file")
+	}
+	return data, nil
+}
+
+func readAudioTranscriptionTextField(part *multipart.Part) (string, error) {
+	data, err := io.ReadAll(io.LimitReader(part, maxAudioTranscriptionTextFieldBytes+1))
+	if err != nil {
+		return "", newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Failed to read form field", part.FormName())
+	}
+	if len(data) > maxAudioTranscriptionTextFieldBytes {
+		return "", newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Form field is too large", part.FormName())
+	}
+	return string(data), nil
+}
+
+func newOpenAIAudioTranscriptionRequestError(status int, errType, message, param string) *OpenAIAudioTranscriptionRequestError {
+	if status == 0 {
+		status = http.StatusBadRequest
+	}
+	if strings.TrimSpace(errType) == "" {
+		errType = "invalid_request_error"
+	}
+	return &OpenAIAudioTranscriptionRequestError{
+		Status:  status,
+		Type:    errType,
+		Message: message,
+		Param:   strings.TrimSpace(param),
+	}
+}
+
+func (s *OpenAIGatewayService) ForwardAudioTranscription(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input *OpenAIAudioTranscriptionRequest,
+) (*OpenAIAudioTranscriptionOutput, error) {
+	if s == nil || s.httpUpstream == nil {
+		return nil, fmt.Errorf("openai gateway service is not configured")
+	}
+	if account == nil || !account.IsOpenAI() {
+		return nil, fmt.Errorf("audio transcription requires an OpenAI account")
+	}
+	if input == nil {
+		return nil, fmt.Errorf("audio transcription request is required")
+	}
+	switch account.Type {
+	case AccountTypeAPIKey:
+		return s.forwardOpenAIAudioTranscriptionAPIKey(ctx, c, account, input)
+	case AccountTypeOAuth:
+		return s.forwardOpenAIAudioTranscriptionOAuth(ctx, c, account, input)
+	default:
+		return nil, fmt.Errorf("unsupported OpenAI account type: %s", account.Type)
+	}
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionAPIKey(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input *OpenAIAudioTranscriptionRequest,
+) (*OpenAIAudioTranscriptionOutput, error) {
+	apiKey := account.GetOpenAIApiKey()
+	if strings.TrimSpace(apiKey) == "" {
+		return nil, fmt.Errorf("account %d missing api_key", account.ID)
+	}
+	baseURL := account.GetOpenAIBaseURL()
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+	validatedURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base_url: %w", err)
+	}
+	targetURL := buildOpenAIAudioTranscriptionsURL(validatedURL)
+	body, contentType, err := buildOpenAIAudioTranscriptionMultipart(input, true)
+	if err != nil {
+		return nil, err
+	}
+	req, err := s.buildOpenAIAudioTranscriptionHTTPRequest(ctx, targetURL, body, contentType)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+		req.Header.Set("User-Agent", customUA)
+	} else if c != nil {
+		req.Header.Set("User-Agent", c.GetHeader("User-Agent"))
+	}
+	return s.forwardOpenAIAudioTranscriptionHTTP(ctx, c, account, req, input, openAIAudioTranscriptionsEndpoint)
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionOAuth(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	input *OpenAIAudioTranscriptionRequest,
+) (*OpenAIAudioTranscriptionOutput, error) {
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		return nil, err
+	}
+	body, contentType, err := buildOpenAIAudioTranscriptionMultipart(input, false)
+	if err != nil {
+		return nil, err
+	}
+	req, err := s.buildOpenAIAudioTranscriptionHTTPRequest(ctx, chatgptAudioTranscriptionUpstream, body, contentType)
+	if err != nil {
+		return nil, err
+	}
+	req.Host = "chatgpt.com"
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+	if chatgptAccountID := strings.TrimSpace(account.GetChatGPTAccountID()); chatgptAccountID != "" {
+		req.Header.Set("chatgpt-account-id", chatgptAccountID)
+	}
+	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+		req.Header.Set("User-Agent", customUA)
+	}
+	if req.Header.Get("User-Agent") == "" || (s.cfg != nil && s.cfg.Gateway.ForceCodexCLI) {
+		req.Header.Set("User-Agent", codexCLIUserAgent)
+	}
+	return s.forwardOpenAIAudioTranscriptionHTTP(ctx, c, account, req, input, chatgptAudioTranscriptionEndpoint)
+}
+
+func (s *OpenAIGatewayService) buildOpenAIAudioTranscriptionHTTPRequest(ctx context.Context, targetURL string, body []byte, contentType string) (*http.Request, error) {
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+	req, err := http.NewRequestWithContext(upstreamCtx, http.MethodPost, targetURL, bytes.NewReader(body))
+	releaseUpstreamCtx()
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	req.Header.Set("Content-Type", contentType)
+	return req, nil
+}
+
+func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionHTTP(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	req *http.Request,
+	input *OpenAIAudioTranscriptionRequest,
+	upstreamEndpoint string,
+) (*OpenAIAudioTranscriptionOutput, error) {
+	start := time.Now()
+	proxyURL := resolveAccountProxyURL(account)
+
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 {
+		respBody := s.readUpstreamErrorBody(resp)
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+		if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody) {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: resp.StatusCode,
+				UpstreamRequestID:  resp.Header.Get("x-request-id"),
+				UpstreamURL:        safeUpstreamURL(req.URL.String()),
+				Kind:               "failover",
+				Message:            upstreamMsg,
+			})
+			s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, OpenAIAudioTranscriptionModel)
+			return nil, &UpstreamFailoverError{
+				StatusCode:             resp.StatusCode,
+				ResponseBody:           respBody,
+				ResponseHeaders:        resp.Header,
+				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			}
+		}
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  resp.Header.Get("x-request-id"),
+			UpstreamURL:        safeUpstreamURL(req.URL.String()),
+			Kind:               "http_error",
+			Message:            upstreamMsg,
+		})
+		return nil, &OpenAIAudioTranscriptionUpstreamError{
+			StatusCode: resp.StatusCode,
+			Body:       respBody,
+			Header:     resp.Header.Clone(),
+		}
+	}
+
+	respBody, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return nil, err
+	}
+	textResult := gjson.GetBytes(respBody, "text")
+	if !textResult.Exists() || textResult.Type != gjson.String {
+		return nil, fmt.Errorf("audio transcription upstream returned invalid response")
+	}
+	usage, _ := extractOpenAIUsageFromJSONBytes(respBody)
+	result := &OpenAIForwardResult{
+		RequestID:       firstNonEmptyString(resp.Header.Get("x-request-id"), resp.Header.Get("request-id")),
+		ResponseID:      extractOpenAIResponseIDFromJSONBytes(respBody),
+		Usage:           usage,
+		Model:           OpenAIAudioTranscriptionModel,
+		BillingModel:    OpenAIAudioTranscriptionModel,
+		UpstreamModel:   OpenAIAudioTranscriptionModel,
+		Stream:          false,
+		OpenAIWSMode:    false,
+		ResponseHeaders: resp.Header.Clone(),
+		Duration:        time.Since(start),
+	}
+	if !OpenAIUsageHasBillableTokens(usage) && input.DurationParsed {
+		result.BillableDurationSeconds = input.DurationSeconds
+	}
+
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	logger.L().Debug("openai audio transcription: upstream succeeded",
+		zap.Int64("account_id", account.ID),
+		zap.String("upstream_endpoint", upstreamEndpoint),
+		zap.Bool("has_token_usage", OpenAIUsageHasBillableTokens(usage)),
+		zap.Int("billable_duration_seconds", result.BillableDurationSeconds),
+	)
+	return &OpenAIAudioTranscriptionOutput{
+		Result:      result,
+		Body:        respBody,
+		Text:        textResult.String(),
+		StatusCode:  resp.StatusCode,
+		Header:      resp.Header.Clone(),
+		ContentType: contentType,
+	}, nil
+}
+
+func buildOpenAIAudioTranscriptionMultipart(input *OpenAIAudioTranscriptionRequest, includeModel bool) ([]byte, string, error) {
+	if input == nil {
+		return nil, "", fmt.Errorf("audio transcription request is required")
+	}
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	filename := strings.TrimSpace(input.FileName)
+	if filename == "" {
+		filename = defaultAudioTranscriptionFileName
+	}
+	contentType := strings.TrimSpace(input.ContentType)
+	if contentType == "" {
+		contentType = defaultAudioTranscriptionMediaType
+	}
+	partHeader := textproto.MIMEHeader{}
+	partHeader.Set("Content-Disposition", `form-data; name="file"; filename="`+escapeMultipartQuotedString(filename)+`"`)
+	partHeader.Set("Content-Type", contentType)
+	part, err := writer.CreatePart(partHeader)
+	if err != nil {
+		return nil, "", err
+	}
+	if _, err := part.Write(input.FileBytes); err != nil {
+		return nil, "", err
+	}
+	if includeModel {
+		if err := writer.WriteField("model", OpenAIAudioTranscriptionModel); err != nil {
+			return nil, "", err
+		}
+	}
+	if prompt := strings.TrimSpace(input.Prompt); prompt != "" {
+		if err := writer.WriteField("prompt", prompt); err != nil {
+			return nil, "", err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, "", err
+	}
+	return body.Bytes(), writer.FormDataContentType(), nil
+}
+
+func escapeMultipartQuotedString(value string) string {
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `"`, `\"`)
+	return value
+}
+
+func buildOpenAIAudioTranscriptionsURL(base string) string {
+	return buildOpenAIEndpointURL(base, openAIAudioTranscriptionsEndpoint)
+}
+
+func HashOpenAIAudioTranscriptionPayload(model string, fileBytes []byte, prompt string) string {
+	hash := sha256.New()
+	hash.Write([]byte(strings.TrimSpace(model)))
+	hash.Write([]byte{0})
+	fileHash := sha256.Sum256(fileBytes)
+	hash.Write([]byte(hex.EncodeToString(fileHash[:])))
+	hash.Write([]byte{0})
+	hash.Write([]byte(strings.TrimSpace(prompt)))
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func OpenAIUsageHasBillableTokens(usage OpenAIUsage) bool {
+	return usage.InputTokens > 0 ||
+		usage.OutputTokens > 0 ||
+		usage.CacheCreationInputTokens > 0 ||
+		usage.CacheReadInputTokens > 0 ||
+		usage.ImageOutputTokens > 0
+}
+
+func (s *OpenAIGatewayService) CanBillOpenAIAudioDuration(ctx context.Context, apiKey *APIKey, model string, durationSeconds int) bool {
+	if s == nil || apiKey == nil || apiKey.Group == nil || durationSeconds <= 0 {
+		return false
+	}
+	model = strings.TrimSpace(model)
+	if model == "" {
+		model = OpenAIAudioTranscriptionModel
+	}
+	resolved := s.resolveOpenAIChannelPricing(ctx, model, apiKey)
+	return resolved != nil && resolved.Mode == BillingModeDuration && resolved.DefaultPerRequestPrice > 0
+}
+
+func (s *OpenAIGatewayService) WriteOpenAIAudioTranscriptionResponse(c *gin.Context, output *OpenAIAudioTranscriptionOutput) {
+	if c == nil || output == nil || c.Writer.Written() {
+		return
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), output.Header, s.responseHeaderFilter)
+	contentType := strings.TrimSpace(output.ContentType)
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	statusCode := output.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	c.Data(statusCode, contentType, output.Body)
+}
+
+func (s *OpenAIGatewayService) WriteOpenAIAudioTranscriptionUpstreamError(c *gin.Context, err *OpenAIAudioTranscriptionUpstreamError) {
+	if c == nil || err == nil || c.Writer.Written() {
+		return
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), err.Header, s.responseHeaderFilter)
+	statusCode := err.StatusCode
+	if statusCode == 0 {
+		statusCode = http.StatusBadGateway
+	}
+	c.Data(statusCode, err.contentType(), err.Body)
+}
+
+func (s *OpenAIGatewayService) EnsureOpenAIAudioTranscriptionBillable(output *OpenAIAudioTranscriptionOutput) error {
+	if output == nil || output.Result == nil {
+		return errors.New("audio transcription result is nil")
+	}
+	if OpenAIUsageHasBillableTokens(output.Result.Usage) || output.Result.BillableDurationSeconds > 0 {
+		return nil
+	}
+	return errors.New("audio transcription upstream usage unavailable")
+}

--- a/backend/internal/service/openai_audio_transcriptions.go
+++ b/backend/internal/service/openai_audio_transcriptions.go
@@ -33,12 +33,20 @@ const (
 	maxAudioTranscriptionTextFieldBytes = 64 << 10
 )
 
+var openAIAudioTranscriptionOAuthHeaderPrefixes = [...]string{"x-openai-", "x-codex-"}
+
+type OpenAIAudioTranscriptionFormField struct {
+	Name  string
+	Value string
+}
+
 type OpenAIAudioTranscriptionRequest struct {
 	FileName        string
 	ContentType     string
 	FileBytes       []byte
 	Model           string
 	Prompt          string
+	ExtraFields     []OpenAIAudioTranscriptionFormField
 	DurationSeconds int
 	DurationParsed  bool
 }
@@ -160,14 +168,31 @@ func (s *OpenAIGatewayService) ParseOpenAIAudioTranscriptionRequest(body []byte,
 				return nil, readErr
 			}
 			parsed.Prompt = strings.TrimSpace(value)
+		case "language", "response_format", "temperature", "stream", "chunking_strategy",
+			"include", "include[]",
+			"timestamp_granularities", "timestamp_granularities[]",
+			"known_speaker_names", "known_speaker_names[]",
+			"known_speaker_references", "known_speaker_references[]":
+			if filename != "" {
+				_ = part.Close()
+				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", formName+" must be a form field", formName)
+			}
+			value, readErr := readAudioTranscriptionTextField(part)
+			_ = part.Close()
+			if readErr != nil {
+				return nil, readErr
+			}
+			if value = strings.TrimSpace(value); value != "" {
+				parsed.ExtraFields = append(parsed.ExtraFields, OpenAIAudioTranscriptionFormField{
+					Name:  formName,
+					Value: value,
+				})
+			}
 		case "":
 			_ = part.Close()
 			return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Multipart field name is required", "")
 		default:
 			_ = part.Close()
-			if formName == "stream" {
-				return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "stream is not supported for audio transcriptions", "stream")
-			}
 			return nil, newOpenAIAudioTranscriptionRequestError(http.StatusBadRequest, "invalid_request_error", "Unsupported audio transcription field: "+formName, formName)
 		}
 	}
@@ -275,7 +300,7 @@ func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionAPIKey(
 		return nil, fmt.Errorf("invalid base_url: %w", err)
 	}
 	targetURL := buildOpenAIAudioTranscriptionsURL(validatedURL)
-	body, contentType, err := buildOpenAIAudioTranscriptionMultipart(input, true)
+	body, contentType, err := buildOpenAIAudioTranscriptionMultipart(input, true, true)
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +328,7 @@ func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionOAuth(
 	if err != nil {
 		return nil, err
 	}
-	body, contentType, err := buildOpenAIAudioTranscriptionMultipart(input, false)
+	body, contentType, err := buildOpenAIAudioTranscriptionMultipart(input, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -313,17 +338,64 @@ func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionOAuth(
 	}
 	req.Host = "chatgpt.com"
 	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Accept", "application/json")
 	if chatgptAccountID := strings.TrimSpace(account.GetChatGPTAccountID()); chatgptAccountID != "" {
 		req.Header.Set("chatgpt-account-id", chatgptAccountID)
 	}
-	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
-		req.Header.Set("User-Agent", customUA)
-	}
-	if req.Header.Get("User-Agent") == "" || (s.cfg != nil && s.cfg.Gateway.ForceCodexCLI) {
-		req.Header.Set("User-Agent", codexCLIUserAgent)
-	}
+	applyOpenAIAudioTranscriptionOAuthClientHeaders(req, c)
 	return s.forwardOpenAIAudioTranscriptionHTTP(ctx, c, account, req, input, chatgptAudioTranscriptionEndpoint)
+}
+
+func applyOpenAIAudioTranscriptionOAuthClientHeaders(req *http.Request, c *gin.Context) {
+	if req == nil {
+		return
+	}
+	copiedUserAgent := false
+	if c != nil && c.Request != nil {
+		for key, values := range c.Request.Header {
+			lowerKey := strings.ToLower(key)
+			if lowerKey == "user-agent" {
+				if setOpenAIAudioTranscriptionFirstNonEmptyHeader(req.Header, key, values) {
+					copiedUserAgent = true
+				}
+				continue
+			}
+			if hasOpenAIAudioTranscriptionHeaderPrefix(lowerKey, openAIAudioTranscriptionOAuthHeaderPrefixes[:]) {
+				addOpenAIAudioTranscriptionNonEmptyHeaders(req.Header, key, values)
+			}
+		}
+	}
+	if !copiedUserAgent {
+		req.Header.Set("User-Agent", "")
+	}
+}
+
+func setOpenAIAudioTranscriptionFirstNonEmptyHeader(header http.Header, key string, values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		header.Set(key, value)
+		return true
+	}
+	return false
+}
+
+func addOpenAIAudioTranscriptionNonEmptyHeaders(header http.Header, key string, values []string) {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		header.Add(key, value)
+	}
+}
+
+func hasOpenAIAudioTranscriptionHeaderPrefix(value string, prefixes []string) bool {
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *OpenAIGatewayService) buildOpenAIAudioTranscriptionHTTPRequest(ctx context.Context, targetURL string, body []byte, contentType string) (*http.Request, error) {
@@ -401,8 +473,17 @@ func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionHTTP(
 	if err != nil {
 		return nil, err
 	}
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
 	textResult := gjson.GetBytes(respBody, "text")
-	if !textResult.Exists() || textResult.Type != gjson.String {
+	text := ""
+	if textResult.Exists() && textResult.Type == gjson.String {
+		text = textResult.String()
+	} else if shouldAcceptRawAudioTranscriptionBody(input, contentType) {
+		text = string(respBody)
+	} else {
 		return nil, fmt.Errorf("audio transcription upstream returned invalid response")
 	}
 	usage, _ := extractOpenAIUsageFromJSONBytes(respBody)
@@ -422,10 +503,6 @@ func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionHTTP(
 		result.BillableDurationSeconds = input.DurationSeconds
 	}
 
-	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
-	if contentType == "" {
-		contentType = "application/json"
-	}
 	logger.L().Debug("openai audio transcription: upstream succeeded",
 		zap.Int64("account_id", account.ID),
 		zap.String("upstream_endpoint", upstreamEndpoint),
@@ -435,14 +512,14 @@ func (s *OpenAIGatewayService) forwardOpenAIAudioTranscriptionHTTP(
 	return &OpenAIAudioTranscriptionOutput{
 		Result:      result,
 		Body:        respBody,
-		Text:        textResult.String(),
+		Text:        text,
 		StatusCode:  resp.StatusCode,
 		Header:      resp.Header.Clone(),
 		ContentType: contentType,
 	}, nil
 }
 
-func buildOpenAIAudioTranscriptionMultipart(input *OpenAIAudioTranscriptionRequest, includeModel bool) ([]byte, string, error) {
+func buildOpenAIAudioTranscriptionMultipart(input *OpenAIAudioTranscriptionRequest, includeModel bool, includeExtraFields bool) ([]byte, string, error) {
 	if input == nil {
 		return nil, "", fmt.Errorf("audio transcription request is required")
 	}
@@ -476,6 +553,18 @@ func buildOpenAIAudioTranscriptionMultipart(input *OpenAIAudioTranscriptionReque
 			return nil, "", err
 		}
 	}
+	if includeExtraFields {
+		for _, field := range input.ExtraFields {
+			name := strings.TrimSpace(field.Name)
+			value := strings.TrimSpace(field.Value)
+			if name == "" || value == "" {
+				continue
+			}
+			if err := writer.WriteField(name, value); err != nil {
+				return nil, "", err
+			}
+		}
+	}
 	if err := writer.Close(); err != nil {
 		return nil, "", err
 	}
@@ -492,15 +581,52 @@ func buildOpenAIAudioTranscriptionsURL(base string) string {
 	return buildOpenAIEndpointURL(base, openAIAudioTranscriptionsEndpoint)
 }
 
-func HashOpenAIAudioTranscriptionPayload(model string, fileBytes []byte, prompt string) string {
+func HashOpenAIAudioTranscriptionPayload(model string, fileBytes []byte, prompt string, fields ...OpenAIAudioTranscriptionFormField) string {
 	hash := sha256.New()
-	hash.Write([]byte(strings.TrimSpace(model)))
-	hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strings.TrimSpace(model)))
+	_, _ = hash.Write([]byte{0})
 	fileHash := sha256.Sum256(fileBytes)
-	hash.Write([]byte(hex.EncodeToString(fileHash[:])))
-	hash.Write([]byte{0})
-	hash.Write([]byte(strings.TrimSpace(prompt)))
+	_, _ = hash.Write([]byte(hex.EncodeToString(fileHash[:])))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strings.TrimSpace(prompt)))
+	for _, field := range fields {
+		name := strings.TrimSpace(field.Name)
+		value := strings.TrimSpace(field.Value)
+		if name == "" || value == "" {
+			continue
+		}
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(name))
+		_, _ = hash.Write([]byte{0})
+		_, _ = hash.Write([]byte(value))
+	}
 	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func shouldAcceptRawAudioTranscriptionBody(input *OpenAIAudioTranscriptionRequest, contentType string) bool {
+	contentType = strings.ToLower(strings.TrimSpace(contentType))
+	if contentType != "" && !strings.Contains(contentType, "json") {
+		return true
+	}
+	if input == nil {
+		return false
+	}
+	for _, field := range input.ExtraFields {
+		name := strings.TrimSpace(field.Name)
+		value := strings.ToLower(strings.TrimSpace(field.Value))
+		switch name {
+		case "stream":
+			if value == "true" || value == "1" {
+				return true
+			}
+		case "response_format":
+			switch value {
+			case "text", "srt", "vtt":
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func OpenAIUsageHasBillableTokens(usage OpenAIUsage) bool {

--- a/backend/internal/service/openai_audio_transcriptions_test.go
+++ b/backend/internal/service/openai_audio_transcriptions_test.go
@@ -65,7 +65,7 @@ func TestParseOpenAIAudioTranscriptionRequestValidatesStrictFields(t *testing.T)
 	require.Equal(t, []byte("RIFF....WAVEfmt "), parsed.FileBytes)
 }
 
-func TestParseOpenAIAudioTranscriptionRequestRejectsUnsupportedModelAndStream(t *testing.T) {
+func TestParseOpenAIAudioTranscriptionRequestRejectsUnsupportedModel(t *testing.T) {
 	tests := []struct {
 		name      string
 		fields    map[string]string
@@ -75,16 +75,6 @@ func TestParseOpenAIAudioTranscriptionRequestRejectsUnsupportedModelAndStream(t 
 			name:      "unsupported model",
 			fields:    map[string]string{"model": "gpt-4o-mini-transcribe"},
 			wantParam: "model",
-		},
-		{
-			name:      "stream field",
-			fields:    map[string]string{"model": OpenAIAudioTranscriptionModel, "stream": "true"},
-			wantParam: "stream",
-		},
-		{
-			name:      "language field",
-			fields:    map[string]string{"model": OpenAIAudioTranscriptionModel, "language": "zh"},
-			wantParam: "language",
 		},
 	}
 
@@ -101,6 +91,29 @@ func TestParseOpenAIAudioTranscriptionRequestRejectsUnsupportedModelAndStream(t 
 			require.Equal(t, tt.wantParam, reqErr.Param)
 		})
 	}
+}
+
+func TestParseOpenAIAudioTranscriptionRequestAcceptsOfficialOptionalFields(t *testing.T) {
+	body, contentType := buildAudioTranscriptionTestMultipart(t, map[string]string{
+		"model":                      OpenAIAudioTranscriptionModel,
+		"language":                   "en",
+		"response_format":            "json",
+		"temperature":                "0",
+		"stream":                     "false",
+		"include[]":                  "logprobs",
+		"timestamp_granularities[]":  "segment",
+		"chunking_strategy":          "auto",
+		"known_speaker_names[]":      "agent",
+		"known_speaker_references[]": "data:audio/wav;base64,AAA",
+	}, []byte("audio bytes"))
+
+	parsed, err := (&OpenAIGatewayService{}).ParseOpenAIAudioTranscriptionRequest(body, contentType)
+
+	require.NoError(t, err)
+	require.Contains(t, parsed.ExtraFields, OpenAIAudioTranscriptionFormField{Name: "language", Value: "en"})
+	require.Contains(t, parsed.ExtraFields, OpenAIAudioTranscriptionFormField{Name: "response_format", Value: "json"})
+	require.Contains(t, parsed.ExtraFields, OpenAIAudioTranscriptionFormField{Name: "include[]", Value: "logprobs"})
+	require.Contains(t, parsed.ExtraFields, OpenAIAudioTranscriptionFormField{Name: "known_speaker_names[]", Value: "agent"})
 }
 
 func TestParseOpenAIAudioTranscriptionRequestRejectsMissingFileOrModel(t *testing.T) {
@@ -154,6 +167,11 @@ func TestForwardAudioTranscriptionAPIKeyIncludesModelPromptAndUsesOfficialEndpoi
 		FileBytes:   []byte("audio bytes"),
 		Model:       OpenAIAudioTranscriptionModel,
 		Prompt:      "hint",
+		ExtraFields: []OpenAIAudioTranscriptionFormField{
+			{Name: "language", Value: "en"},
+			{Name: "response_format", Value: "json"},
+			{Name: "include[]", Value: "logprobs"},
+		},
 	})
 
 	require.NoError(t, err)
@@ -164,16 +182,61 @@ func TestForwardAudioTranscriptionAPIKeyIncludesModelPromptAndUsesOfficialEndpoi
 	parts := readAudioTranscriptionMultipartParts(t, upstream.lastReq.Header.Get("Content-Type"), upstream.lastBody)
 	require.Equal(t, OpenAIAudioTranscriptionModel, parts["model"])
 	require.Equal(t, "hint", parts["prompt"])
+	require.Equal(t, "en", parts["language"])
+	require.Equal(t, "json", parts["response_format"])
+	require.Equal(t, "logprobs", parts["include[]"])
 	require.Equal(t, "audio bytes", parts["file"])
 	require.True(t, OpenAIUsageHasBillableTokens(output.Result.Usage))
 	require.Zero(t, output.Result.BillableDurationSeconds)
 }
 
-func TestForwardAudioTranscriptionOAuthOmitsModelAndClientHeaders(t *testing.T) {
+func TestForwardAudioTranscriptionAPIKeyAcceptsTextResponseFormat(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c := newAudioTranscriptionGinContext(t)
+	upstream := &audioTranscriptionHTTPUpstream{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/plain"}},
+		Body:       io.NopCloser(strings.NewReader("hello from text response")),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:       13,
+		Type:     AccountTypeAPIKey,
+		Platform: PlatformOpenAI,
+		Credentials: map[string]any{
+			"api_key": "sk-upstream",
+		},
+	}
+
+	output, err := svc.ForwardAudioTranscription(context.Background(), c, account, &OpenAIAudioTranscriptionRequest{
+		FileName:        "voice.wav",
+		ContentType:     "audio/wav",
+		FileBytes:       []byte("audio bytes"),
+		Model:           OpenAIAudioTranscriptionModel,
+		DurationParsed:  true,
+		DurationSeconds: 4,
+		ExtraFields: []OpenAIAudioTranscriptionFormField{
+			{Name: "response_format", Value: "text"},
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "hello from text response", output.Text)
+	require.Equal(t, []byte("hello from text response"), output.Body)
+	require.Equal(t, "text/plain", output.ContentType)
+	require.Equal(t, 4, output.Result.BillableDurationSeconds)
+	parts := readAudioTranscriptionMultipartParts(t, upstream.lastReq.Header.Get("Content-Type"), upstream.lastBody)
+	require.Equal(t, "text", parts["response_format"])
+}
+
+func TestForwardAudioTranscriptionOAuthUsesMinimalUpstreamHeaderFingerprint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	c := newAudioTranscriptionGinContext(t)
 	c.Request.Header.Set("Authorization", "Bearer client-key")
+	c.Request.Header.Set("Accept", "text/plain")
+	c.Request.Header.Set("x-request-id", "client-request-id")
 	c.Request.Header.Set("x-codex-turn-state", "client-controlled")
+	c.Request.Header.Set("x-openai-client-version", "1.2.3")
 	upstream := &audioTranscriptionHTTPUpstream{resp: &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
@@ -187,16 +250,20 @@ func TestForwardAudioTranscriptionOAuthOmitsModelAndClientHeaders(t *testing.T) 
 		Credentials: map[string]any{
 			"access_token":       "oauth-token",
 			"chatgpt_account_id": "chatgpt-acc",
-			"user_agent":         "Codex-Test-UA/1.0",
+			"user_agent":         "Ignored-Account-UA/1.0",
 		},
 	}
 
 	output, err := svc.ForwardAudioTranscription(context.Background(), c, account, &OpenAIAudioTranscriptionRequest{
-		FileName:        "voice.wav",
-		ContentType:     "audio/wav",
-		FileBytes:       []byte("audio bytes"),
-		Model:           OpenAIAudioTranscriptionModel,
-		Prompt:          "hint",
+		FileName:    "voice.wav",
+		ContentType: "audio/wav",
+		FileBytes:   []byte("audio bytes"),
+		Model:       OpenAIAudioTranscriptionModel,
+		Prompt:      "hint",
+		ExtraFields: []OpenAIAudioTranscriptionFormField{
+			{Name: "language", Value: "en"},
+			{Name: "response_format", Value: "json"},
+		},
 		DurationParsed:  true,
 		DurationSeconds: 7,
 	})
@@ -207,10 +274,15 @@ func TestForwardAudioTranscriptionOAuthOmitsModelAndClientHeaders(t *testing.T) 
 	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
 	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("Authorization"))
 	require.Equal(t, "chatgpt-acc", upstream.lastReq.Header.Get("chatgpt-account-id"))
-	require.Equal(t, "Codex-Test-UA/1.0", upstream.lastReq.Header.Get("User-Agent"))
-	require.Empty(t, upstream.lastReq.Header.Get("x-codex-turn-state"))
+	require.Equal(t, "OpenAI-Go-Test/1.0", upstream.lastReq.Header.Get("User-Agent"))
+	require.Equal(t, "client-controlled", upstream.lastReq.Header.Get("x-codex-turn-state"))
+	require.Equal(t, "1.2.3", upstream.lastReq.Header.Get("x-openai-client-version"))
+	require.Empty(t, upstream.lastReq.Header.Get("Accept"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-request-id"))
 	parts := readAudioTranscriptionMultipartParts(t, upstream.lastReq.Header.Get("Content-Type"), upstream.lastBody)
 	require.NotContains(t, parts, "model")
+	require.NotContains(t, parts, "language")
+	require.NotContains(t, parts, "response_format")
 	require.Equal(t, "hint", parts["prompt"])
 	require.Equal(t, "audio bytes", parts["file"])
 	require.Equal(t, 7, output.Result.BillableDurationSeconds)

--- a/backend/internal/service/openai_audio_transcriptions_test.go
+++ b/backend/internal/service/openai_audio_transcriptions_test.go
@@ -1,0 +1,342 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"net/textproto"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type audioTranscriptionHTTPUpstream struct {
+	resp     *http.Response
+	err      error
+	lastReq  *http.Request
+	lastBody []byte
+}
+
+func (u *audioTranscriptionHTTPUpstream) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	u.lastReq = req
+	if req != nil && req.Body != nil {
+		u.lastBody, _ = io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(u.lastBody))
+	}
+	if u.err != nil {
+		return nil, u.err
+	}
+	if u.resp != nil {
+		return u.resp, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"text":"hello"}`)),
+	}, nil
+}
+
+func (u *audioTranscriptionHTTPUpstream) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func TestParseOpenAIAudioTranscriptionRequestValidatesStrictFields(t *testing.T) {
+	body, contentType := buildAudioTranscriptionTestMultipart(t, map[string]string{
+		"model":  OpenAIAudioTranscriptionModel,
+		"prompt": "domain words",
+	}, []byte("RIFF....WAVEfmt "))
+
+	parsed, err := (&OpenAIGatewayService{}).ParseOpenAIAudioTranscriptionRequest(body, contentType)
+
+	require.NoError(t, err)
+	require.Equal(t, OpenAIAudioTranscriptionModel, parsed.Model)
+	require.Equal(t, "domain words", parsed.Prompt)
+	require.Equal(t, "voice.wav", parsed.FileName)
+	require.Equal(t, "audio/wav", parsed.ContentType)
+	require.Equal(t, []byte("RIFF....WAVEfmt "), parsed.FileBytes)
+}
+
+func TestParseOpenAIAudioTranscriptionRequestRejectsUnsupportedModelAndStream(t *testing.T) {
+	tests := []struct {
+		name      string
+		fields    map[string]string
+		wantParam string
+	}{
+		{
+			name:      "unsupported model",
+			fields:    map[string]string{"model": "gpt-4o-mini-transcribe"},
+			wantParam: "model",
+		},
+		{
+			name:      "stream field",
+			fields:    map[string]string{"model": OpenAIAudioTranscriptionModel, "stream": "true"},
+			wantParam: "stream",
+		},
+		{
+			name:      "language field",
+			fields:    map[string]string{"model": OpenAIAudioTranscriptionModel, "language": "zh"},
+			wantParam: "language",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, contentType := buildAudioTranscriptionTestMultipart(t, tt.fields, []byte("audio bytes"))
+
+			_, err := (&OpenAIGatewayService{}).ParseOpenAIAudioTranscriptionRequest(body, contentType)
+
+			var reqErr *OpenAIAudioTranscriptionRequestError
+			require.ErrorAs(t, err, &reqErr)
+			require.Equal(t, http.StatusBadRequest, reqErr.Status)
+			require.Equal(t, "invalid_request_error", reqErr.Type)
+			require.Equal(t, tt.wantParam, reqErr.Param)
+		})
+	}
+}
+
+func TestParseOpenAIAudioTranscriptionRequestRejectsMissingFileOrModel(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		require.NoError(t, writer.WriteField("model", OpenAIAudioTranscriptionModel))
+		require.NoError(t, writer.Close())
+
+		_, err := (&OpenAIGatewayService{}).ParseOpenAIAudioTranscriptionRequest(buf.Bytes(), writer.FormDataContentType())
+
+		var reqErr *OpenAIAudioTranscriptionRequestError
+		require.ErrorAs(t, err, &reqErr)
+		require.Equal(t, "file", reqErr.Param)
+	})
+
+	t.Run("missing model", func(t *testing.T) {
+		body, contentType := buildAudioTranscriptionTestMultipart(t, nil, []byte("audio bytes"))
+
+		_, err := (&OpenAIGatewayService{}).ParseOpenAIAudioTranscriptionRequest(body, contentType)
+
+		var reqErr *OpenAIAudioTranscriptionRequestError
+		require.ErrorAs(t, err, &reqErr)
+		require.Equal(t, "model", reqErr.Param)
+	})
+}
+
+func TestForwardAudioTranscriptionAPIKeyIncludesModelPromptAndUsesOfficialEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c := newAudioTranscriptionGinContext(t)
+	upstream := &audioTranscriptionHTTPUpstream{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"up_req_1"}},
+		Body:       io.NopCloser(strings.NewReader(`{"text":"hello","usage":{"input_tokens":3,"output_tokens":1}}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:       11,
+		Type:     AccountTypeAPIKey,
+		Platform: PlatformOpenAI,
+		Credentials: map[string]any{
+			"api_key":    "sk-upstream",
+			"base_url":   "https://api.openai.test/v1",
+			"user_agent": "AudioTest/1.0",
+		},
+	}
+
+	output, err := svc.ForwardAudioTranscription(context.Background(), c, account, &OpenAIAudioTranscriptionRequest{
+		FileName:    "voice.wav",
+		ContentType: "audio/wav",
+		FileBytes:   []byte("audio bytes"),
+		Model:       OpenAIAudioTranscriptionModel,
+		Prompt:      "hint",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "hello", output.Text)
+	require.Equal(t, "https://api.openai.test/v1/audio/transcriptions", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer sk-upstream", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "AudioTest/1.0", upstream.lastReq.Header.Get("User-Agent"))
+	parts := readAudioTranscriptionMultipartParts(t, upstream.lastReq.Header.Get("Content-Type"), upstream.lastBody)
+	require.Equal(t, OpenAIAudioTranscriptionModel, parts["model"])
+	require.Equal(t, "hint", parts["prompt"])
+	require.Equal(t, "audio bytes", parts["file"])
+	require.True(t, OpenAIUsageHasBillableTokens(output.Result.Usage))
+	require.Zero(t, output.Result.BillableDurationSeconds)
+}
+
+func TestForwardAudioTranscriptionOAuthOmitsModelAndClientHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	c := newAudioTranscriptionGinContext(t)
+	c.Request.Header.Set("Authorization", "Bearer client-key")
+	c.Request.Header.Set("x-codex-turn-state", "client-controlled")
+	upstream := &audioTranscriptionHTTPUpstream{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"text":"hello"}`)),
+	}}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:       12,
+		Type:     AccountTypeOAuth,
+		Platform: PlatformOpenAI,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"user_agent":         "Codex-Test-UA/1.0",
+		},
+	}
+
+	output, err := svc.ForwardAudioTranscription(context.Background(), c, account, &OpenAIAudioTranscriptionRequest{
+		FileName:        "voice.wav",
+		ContentType:     "audio/wav",
+		FileBytes:       []byte("audio bytes"),
+		Model:           OpenAIAudioTranscriptionModel,
+		Prompt:          "hint",
+		DurationParsed:  true,
+		DurationSeconds: 7,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "hello", output.Text)
+	require.Equal(t, chatgptAudioTranscriptionUpstream, upstream.lastReq.URL.String())
+	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
+	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "chatgpt-acc", upstream.lastReq.Header.Get("chatgpt-account-id"))
+	require.Equal(t, "Codex-Test-UA/1.0", upstream.lastReq.Header.Get("User-Agent"))
+	require.Empty(t, upstream.lastReq.Header.Get("x-codex-turn-state"))
+	parts := readAudioTranscriptionMultipartParts(t, upstream.lastReq.Header.Get("Content-Type"), upstream.lastBody)
+	require.NotContains(t, parts, "model")
+	require.Equal(t, "hint", parts["prompt"])
+	require.Equal(t, "audio bytes", parts["file"])
+	require.Equal(t, 7, output.Result.BillableDurationSeconds)
+}
+
+func TestCanBillOpenAIAudioDurationRequiresDurationPricing(t *testing.T) {
+	groupID := int64(42)
+	price := 0.003
+	cache := newEmptyChannelCache()
+	cache.pricingByGroupModel[channelModelKey{groupID: groupID, platform: PlatformOpenAI, model: OpenAIAudioTranscriptionModel}] = &ChannelModelPricing{
+		BillingMode:     BillingModeDuration,
+		PerRequestPrice: &price,
+	}
+	cache.channelByGroupID[groupID] = &Channel{ID: 7, Status: StatusActive}
+	cache.groupPlatform[groupID] = PlatformOpenAI
+	cache.loadedAt = time.Now()
+	channelService := &ChannelService{}
+	channelService.cache.Store(cache)
+	svc := &OpenAIGatewayService{
+		resolver:       NewModelPricingResolver(channelService, NewBillingService(&config.Config{}, nil)),
+		channelService: channelService,
+	}
+	apiKey := &APIKey{GroupID: &groupID, Group: &Group{ID: groupID, Platform: PlatformOpenAI}}
+
+	require.True(t, svc.CanBillOpenAIAudioDuration(context.Background(), apiKey, OpenAIAudioTranscriptionModel, 3))
+	require.False(t, svc.CanBillOpenAIAudioDuration(context.Background(), apiKey, OpenAIAudioTranscriptionModel, 0))
+	require.False(t, (&OpenAIGatewayService{}).CanBillOpenAIAudioDuration(context.Background(), apiKey, OpenAIAudioTranscriptionModel, 3))
+}
+
+func TestOpenAIEndpointCapabilityAudioTranscriptionsSupportsAPIKeyAndOAuth(t *testing.T) {
+	require.True(t, (&Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}).SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAudioTranscribe))
+	require.True(t, (&Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}).SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAudioTranscribe))
+	require.False(t, (&Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey}).SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAudioTranscribe))
+	require.False(t, (&Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			openAIEndpointCapabilitiesCredentialKey: []any{string(OpenAIEndpointCapabilityChatCompletions)},
+		},
+	}).SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAudioTranscribe))
+}
+
+func TestCalculateCostUnifiedDurationMode(t *testing.T) {
+	bs := NewBillingService(&config.Config{}, nil)
+	resolver := NewModelPricingResolver(nil, bs)
+
+	cost, err := bs.CalculateCostUnified(CostInput{
+		Ctx:             context.Background(),
+		Model:           OpenAIAudioTranscriptionModel,
+		DurationSeconds: 9,
+		RateMultiplier:  2,
+		Resolver:        resolver,
+		Resolved: &ResolvedPricing{
+			Mode:                   BillingModeDuration,
+			DefaultPerRequestPrice: 0.01,
+		},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, string(BillingModeDuration), cost.BillingMode)
+	require.InDelta(t, 0.09, cost.TotalCost, 1e-12)
+	require.InDelta(t, 0.18, cost.ActualCost, 1e-12)
+}
+
+func TestUsageBillingFingerprintIncludesBillableDurationSeconds(t *testing.T) {
+	base := &UsageBillingCommand{
+		UserID:                  1,
+		AccountID:               2,
+		APIKeyID:                3,
+		AccountType:             string(AccountTypeOAuth),
+		Model:                   OpenAIAudioTranscriptionModel,
+		BillingType:             BillingTypeBalance,
+		BillableDurationSeconds: 7,
+		BalanceCost:             0.07,
+		RequestPayloadHash:      "payload",
+	}
+	other := *base
+	other.BillableDurationSeconds = 8
+
+	require.NotEqual(t, buildUsageBillingFingerprint(base), buildUsageBillingFingerprint(&other))
+}
+
+func buildAudioTranscriptionTestMultipart(t *testing.T, fields map[string]string, fileBytes []byte) ([]byte, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	header := textproto.MIMEHeader{}
+	header.Set("Content-Disposition", `form-data; name="file"; filename="voice.wav"`)
+	header.Set("Content-Type", "audio/wav")
+	part, err := writer.CreatePart(header)
+	require.NoError(t, err)
+	_, err = part.Write(fileBytes)
+	require.NoError(t, err)
+	for key, value := range fields {
+		require.NoError(t, writer.WriteField(key, value))
+	}
+	require.NoError(t, writer.Close())
+	return buf.Bytes(), writer.FormDataContentType()
+}
+
+func newAudioTranscriptionGinContext(t *testing.T) *gin.Context {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", nil)
+	c.Request.Header.Set("User-Agent", "OpenAI-Go-Test/1.0")
+	return c
+}
+
+func readAudioTranscriptionMultipartParts(t *testing.T, contentType string, body []byte) map[string]string {
+	t.Helper()
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	require.NoError(t, err)
+	require.Equal(t, "multipart/form-data", mediaType)
+	reader := multipart.NewReader(bytes.NewReader(body), params["boundary"])
+	parts := map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		data, err := io.ReadAll(part)
+		require.NoError(t, err)
+		parts[part.FormName()] = string(data)
+		require.NoError(t, part.Close())
+	}
+	return parts
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -238,20 +238,21 @@ type OpenAIForwardResult struct {
 	ServiceTier *string
 	// ReasoningEffort is extracted from request body (reasoning.effort) or derived from model suffix.
 	// Stored for usage records display; nil means not provided / not applicable.
-	ReasoningEffort    *string
-	Stream             bool
-	OpenAIWSMode       bool
-	ResponseHeaders    http.Header
-	Duration           time.Duration
-	FirstTokenMs       *int
-	ClientDisconnect   bool
-	ImageCount         int
-	ImageSize          string
-	ImageInputSize     string
-	ImageOutputSize    string
-	ImageOutputSizes   []string
-	ImageSizeSource    string
-	ImageSizeBreakdown map[string]int
+	ReasoningEffort         *string
+	Stream                  bool
+	OpenAIWSMode            bool
+	ResponseHeaders         http.Header
+	Duration                time.Duration
+	FirstTokenMs            *int
+	ClientDisconnect        bool
+	ImageCount              int
+	BillableDurationSeconds int
+	ImageSize               string
+	ImageInputSize          string
+	ImageOutputSize         string
+	ImageOutputSizes        []string
+	ImageSizeSource         string
+	ImageSizeBreakdown      map[string]int
 
 	wsReplayInput       []json.RawMessage
 	wsReplayInputExists bool
@@ -5965,6 +5966,9 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	}
 	cost, err = s.calculateOpenAIRecordUsageCost(ctx, result, apiKey, billingModels, multiplier, imageMultiplier, tokens, serviceTier)
 	if err != nil {
+		if result.BillableDurationSeconds > 0 {
+			return err
+		}
 		if !isUsagePricingUnavailableError(err) {
 			return err
 		}
@@ -6004,28 +6008,29 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	}
 
 	usageLog := &UsageLog{
-		UserID:              user.ID,
-		APIKeyID:            apiKey.ID,
-		AccountID:           account.ID,
-		RequestID:           requestID,
-		Model:               result.Model,
-		RequestedModel:      requestedModel,
-		UpstreamModel:       optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
-		ServiceTier:         result.ServiceTier,
-		ReasoningEffort:     result.ReasoningEffort,
-		InboundEndpoint:     optionalTrimmedStringPtr(input.InboundEndpoint),
-		UpstreamEndpoint:    optionalTrimmedStringPtr(input.UpstreamEndpoint),
-		InputTokens:         actualInputTokens,
-		OutputTokens:        result.Usage.OutputTokens,
-		CacheCreationTokens: result.Usage.CacheCreationInputTokens,
-		CacheReadTokens:     result.Usage.CacheReadInputTokens,
-		ImageOutputTokens:   result.Usage.ImageOutputTokens,
-		ImageCount:          result.ImageCount,
-		ImageSize:           optionalTrimmedStringPtr(result.ImageSize),
-		ImageInputSize:      optionalTrimmedStringPtr(result.ImageInputSize),
-		ImageOutputSize:     optionalTrimmedStringPtr(result.ImageOutputSize),
-		ImageSizeSource:     optionalTrimmedStringPtr(result.ImageSizeSource),
-		ImageSizeBreakdown:  result.ImageSizeBreakdown,
+		UserID:                  user.ID,
+		APIKeyID:                apiKey.ID,
+		AccountID:               account.ID,
+		RequestID:               requestID,
+		Model:                   result.Model,
+		RequestedModel:          requestedModel,
+		UpstreamModel:           optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
+		ServiceTier:             result.ServiceTier,
+		ReasoningEffort:         result.ReasoningEffort,
+		InboundEndpoint:         optionalTrimmedStringPtr(input.InboundEndpoint),
+		UpstreamEndpoint:        optionalTrimmedStringPtr(input.UpstreamEndpoint),
+		InputTokens:             actualInputTokens,
+		OutputTokens:            result.Usage.OutputTokens,
+		CacheCreationTokens:     result.Usage.CacheCreationInputTokens,
+		CacheReadTokens:         result.Usage.CacheReadInputTokens,
+		ImageOutputTokens:       result.Usage.ImageOutputTokens,
+		ImageCount:              result.ImageCount,
+		BillableDurationSeconds: result.BillableDurationSeconds,
+		ImageSize:               optionalTrimmedStringPtr(result.ImageSize),
+		ImageInputSize:          optionalTrimmedStringPtr(result.ImageInputSize),
+		ImageOutputSize:         optionalTrimmedStringPtr(result.ImageOutputSize),
+		ImageSizeSource:         optionalTrimmedStringPtr(result.ImageSizeSource),
+		ImageSizeBreakdown:      result.ImageSizeBreakdown,
 	}
 	if cost != nil {
 		usageLog.InputCost = cost.InputCost
@@ -6060,6 +6065,9 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		usageLog.BillingMode = &billingMode
 	} else if result.ImageCount > 0 {
 		billingMode := string(BillingModeImage)
+		usageLog.BillingMode = &billingMode
+	} else if result.BillableDurationSeconds > 0 {
+		billingMode := string(BillingModeDuration)
 		usageLog.BillingMode = &billingMode
 	} else {
 		billingMode := string(BillingModeToken)
@@ -6132,6 +6140,29 @@ func (s *OpenAIGatewayService) calculateOpenAIRecordUsageCost(
 	serviceTier string,
 ) (*CostBreakdown, error) {
 	billingModel := firstUsageBillingModel(billingModels)
+	if result != nil && result.BillableDurationSeconds > 0 {
+		if len(billingModels) == 0 || billingModel == "" {
+			return nil, errors.New("openai duration billing model is empty")
+		}
+		if apiKey == nil || apiKey.Group == nil {
+			return nil, fmt.Errorf("duration channel pricing is required for model: %s: %w", billingModel, ErrModelPricingUnavailable)
+		}
+		resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey)
+		if resolved == nil || resolved.Mode != BillingModeDuration {
+			return nil, fmt.Errorf("duration channel pricing is required for model: %s: %w", billingModel, ErrModelPricingUnavailable)
+		}
+		gid := apiKey.Group.ID
+		return s.billingService.CalculateCostUnified(CostInput{
+			Ctx:             ctx,
+			Model:           billingModel,
+			GroupID:         &gid,
+			RequestCount:    1,
+			DurationSeconds: result.BillableDurationSeconds,
+			RateMultiplier:  multiplier,
+			Resolver:        s.resolver,
+			Resolved:        resolved,
+		})
+	}
 	if result != nil && result.ImageCount > 0 {
 		// 渠道定价为 token 计费时走 token 路径，否则走图片计费
 		if resolved := s.resolveOpenAIChannelPricing(ctx, billingModel, apiKey); resolved == nil || resolved.Mode != BillingModeToken {

--- a/backend/internal/service/usage_billing.go
+++ b/backend/internal/service/usage_billing.go
@@ -19,20 +19,21 @@ type UsageBillingCommand struct {
 	RequestFingerprint string
 	RequestPayloadHash string
 
-	UserID              int64
-	AccountID           int64
-	SubscriptionID      *int64
-	AccountType         string
-	Model               string
-	ServiceTier         string
-	ReasoningEffort     string
-	BillingType         int8
-	InputTokens         int
-	OutputTokens        int
-	CacheCreationTokens int
-	CacheReadTokens     int
-	ImageCount          int
-	MediaType           string
+	UserID                  int64
+	AccountID               int64
+	SubscriptionID          *int64
+	AccountType             string
+	Model                   string
+	ServiceTier             string
+	ReasoningEffort         string
+	BillingType             int8
+	InputTokens             int
+	OutputTokens            int
+	CacheCreationTokens     int
+	CacheReadTokens         int
+	ImageCount              int
+	BillableDurationSeconds int
+	MediaType               string
 
 	BalanceCost         float64
 	SubscriptionCost    float64
@@ -56,7 +57,7 @@ func buildUsageBillingFingerprint(c *UsageBillingCommand) string {
 		return ""
 	}
 	raw := fmt.Sprintf(
-		"%d|%d|%d|%s|%s|%s|%s|%d|%d|%d|%d|%d|%d|%s|%d|%0.10f|%0.10f|%0.10f|%0.10f|%0.10f",
+		"%d|%d|%d|%s|%s|%s|%s|%d|%d|%d|%d|%d|%d|%d|%s|%d|%0.10f|%0.10f|%0.10f|%0.10f|%0.10f",
 		c.UserID,
 		c.AccountID,
 		c.APIKeyID,
@@ -70,6 +71,7 @@ func buildUsageBillingFingerprint(c *UsageBillingCommand) string {
 		c.CacheCreationTokens,
 		c.CacheReadTokens,
 		c.ImageCount,
+		c.BillableDurationSeconds,
 		strings.TrimSpace(c.MediaType),
 		valueOrZero(c.SubscriptionID),
 		c.BalanceCost,

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -113,9 +113,9 @@ type UsageLog struct {
 	ChannelID *int64
 	// ModelMappingChain 模型映射链，如 "a→b→c"
 	ModelMappingChain *string
-	// BillingTier 计费层级标签（per_request/image 模式）
+	// BillingTier 计费层级标签（per_request/image/duration 模式）
 	BillingTier *string
-	// BillingMode 计费模式：token/image
+	// BillingMode 计费模式：token/image/duration
 	BillingMode *string
 	// ServiceTier records the OpenAI service tier used for billing, e.g. "priority" / "flex".
 	ServiceTier *string
@@ -167,13 +167,14 @@ type UsageLog struct {
 	CacheTTLOverridden bool
 
 	// 图片生成字段
-	ImageCount         int
-	ImageSize          *string
-	ImageInputSize     *string
-	ImageOutputSize    *string
-	ImageSizeSource    *string
-	ImageSizeBreakdown map[string]int
-	MediaType          *string
+	ImageCount              int
+	BillableDurationSeconds int
+	ImageSize               *string
+	ImageInputSize          *string
+	ImageOutputSize         *string
+	ImageSizeSource         *string
+	ImageSizeBreakdown      map[string]int
+	MediaType               *string
 
 	CreatedAt time.Time
 

--- a/backend/migrations/151_openai_audio_transcription_duration.sql
+++ b/backend/migrations/151_openai_audio_transcription_duration.sql
@@ -1,0 +1,13 @@
+-- 151_openai_audio_transcription_duration.sql
+-- Store native OpenAI audio transcription duration billing facts.
+--
+-- Rollback guidance:
+--   Stop accepting /v1/audio/transcriptions requests before rollback. The column
+--   can be left in place safely; drop it only after confirming no duration-billed
+--   usage rows are needed for audit or reconciliation.
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '10min';
+
+ALTER TABLE usage_logs
+    ADD COLUMN IF NOT EXISTS billable_duration_seconds INTEGER NOT NULL DEFAULT 0;

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -14,6 +14,15 @@ describe('useModelWhitelist', () => {
     expect(models).toContain('gpt-5.4-mini')
     expect(models).toContain('gpt-5.4-2026-03-05')
     expect(models).toContain('codex-auto-review')
+    expect(models).toContain('gpt-4o-transcribe')
+  })
+
+  it('openai 默认白名单会为 managed STT 生成转写模型映射', () => {
+    const mapping = buildModelMappingObject('whitelist', getModelsByPlatform('openai'), [])
+
+    expect(mapping).toMatchObject({
+      'gpt-4o-transcribe': 'gpt-4o-transcribe'
+    })
   })
 
   it('openai 模型列表不再暴露已下线的 ChatGPT 登录 Codex 模型', () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -13,7 +13,7 @@ const openaiModels = [
   'gpt-5.4', 'gpt-5.4-mini', 'gpt-5.4-2026-03-05',
   // GPT-5.3 / Codex 系列
   'gpt-5.3-codex', 'gpt-5.3-codex-spark', 'codex-auto-review',
-  'gpt-4o-audio-preview', 'gpt-4o-realtime-preview',
+  'gpt-4o-audio-preview', 'gpt-4o-realtime-preview', 'gpt-4o-transcribe',
   // GPT Image 系列
   'gpt-image-1', 'gpt-image-1.5', 'gpt-image-2'
 ]


### PR DESCRIPTION
## Summary

Add OpenAI-compatible `/v1/audio/transcriptions` gateway support for `gpt-4o-transcribe`.

This PR implements multipart audio transcription forwarding through the existing OpenAI gateway stack, including native account scheduling, failover, usage logging, and billing. It supports both OpenAI API-key accounts and ChatGPT OAuth-backed accounts, while keeping OAuth forwarding behavior constrained to the upstream-compatible audio transcript shape.

## Changes

- Add `/v1/audio/transcriptions` route under the OpenAI gateway.
- Add audio transcription request parsing for multipart form data.
- Support `gpt-4o-transcribe` requests with `file`, `model`, and `prompt`.
- Accept OpenAI transcription optional fields:
  - `language`
  - `response_format`
  - `temperature`
  - `stream`
  - `include` / `include[]`
  - `timestamp_granularities` / `timestamp_granularities[]`
  - `chunking_strategy`
  - `known_speaker_names` / `known_speaker_names[]`
  - `known_speaker_references` / `known_speaker_references[]`
- Forward official optional fields on the OpenAI API-key path.
- Keep the OAuth path on the minimal upstream-compatible form payload.
- Reuse native account capability scheduling via `audio_transcriptions`.
- Reuse native billing/audit path through `RecordUsage`.
- Add duration-based fallback billing for transcription responses without token usage.
- Include request payload hash in billing fingerprint to keep idempotent billing behavior stable.
- Add tests for parsing, forwarding, OAuth header policy, capability routing, and billing fingerprint behavior.

## Verification

```bash
go test ./internal/service -run 'AudioTranscription|UsageBillingFingerprint' -count=1
go test ./internal/handler ./internal/server/routes -run 'AudioTranscription|AudioTranscriptions' -count=1
git diff --check
```

Local gateway verification:

- Sent a multipart `/v1/audio/transcriptions` request with:
  - `model=gpt-4o-transcribe`
  - `language=en`
  - `response_format=json`
  - `temperature=0`
  - `include[]=logprobs`
- Confirmed successful 200 response with expected transcript text.
- Confirmed request log recorded a successful `gpt-4o-transcribe` request through the native usage/audit path.

## References

- OpenAI Audio Transcriptions API: https://platform.openai.com/docs/api-reference/audio/createTranscription
- OpenAI Speech-to-text guide: https://developers.openai.com/api/docs/guides/speech-to-text
- OpenAI speaker diarization fields: https://developers.openai.com/api/docs/guides/speech-to-text#speaker-diarization
