### PR TITLE
fix(rpm): 修正限流说明与实际逻辑不一致

### DIFF
--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -29,7 +29,7 @@ type User struct {
 	BalanceNotifyExtraEmails   []NotifyEmailEntry `json:"balance_notify_extra_emails"`
 	TotalRecharged             float64            `json:"total_recharged"`
 
-	// RPMLimit 用户级每分钟请求数上限（0 = 不限制），仅在所用分组未设置 rpm_limit 时作为兜底生效。
+	// RPMLimit 用户跨所有分组的每分钟请求总上限（0 = 不限制）。
 	RPMLimit int `json:"rpm_limit"`
 
 	APIKeys       []APIKey           `json:"api_keys,omitempty"`
@@ -117,7 +117,7 @@ type Group struct {
 	RequireOAuthOnly  bool `json:"require_oauth_only"`
 	RequirePrivacySet bool `json:"require_privacy_set"`
 
-	// RPMLimit 分组级每分钟请求数上限（0 = 不限制），设置后覆盖用户级 rpm_limit。
+	// RPMLimit 分组级每分钟请求数上限（0 = 不限制），与用户级全局 rpm_limit 同时生效。
 	RPMLimit int `json:"rpm_limit"`
 
 	CreatedAt time.Time `json:"created_at"`

--- a/backend/internal/service/api_key_auth_cache.go
+++ b/backend/internal/service/api_key_auth_cache.go
@@ -46,7 +46,7 @@ type APIKeyAuthUserSnapshot struct {
 	BalanceNotifyExtraEmails   []NotifyEmailEntry `json:"balance_notify_extra_emails,omitempty"`
 	TotalRecharged             float64            `json:"total_recharged"`
 
-	// RPMLimit 用户级每分钟请求数上限（0 = 不限制）；用于 billing_cache_service.checkRPM 兜底判断。
+	// RPMLimit 用户跨所有分组的每分钟请求总上限（0 = 不限制）。
 	RPMLimit int `json:"rpm_limit"`
 
 	// UserGroupRPMOverride 该 API Key 对应的 (user, group) 专属 RPM 覆盖值。
@@ -91,7 +91,7 @@ type APIKeyAuthGroupSnapshot struct {
 	MessagesDispatchModelConfig OpenAIMessagesDispatchModelConfig `json:"messages_dispatch_model_config,omitempty"`
 	ModelsListConfig            GroupModelsListConfig             `json:"models_list_config,omitempty"`
 
-	// RPMLimit 分组级每分钟请求数上限（0 = 不限制）；用于 billing_cache_service.checkRPM 级联判断。
+	// RPMLimit 分组级每分钟请求数上限（0 = 不限制）；与用户级全局上限同时判断。
 	RPMLimit int `json:"rpm_limit"`
 }
 

--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -203,7 +203,7 @@ func (s *AuthService) RegisterWithVerification(ctx context.Context, email, passw
 
 	grantPlan := s.resolveSignupGrantPlan(ctx, "email")
 
-	// 新用户默认 RPM（0 = 不限制）。注册时写入，后续作为用户级兜底。
+	// 新用户默认 RPM（0 = 不限制）。注册时写入，后续作为用户级全局上限。
 	var defaultRPMLimit int
 	if s.settingService != nil {
 		defaultRPMLimit = s.settingService.GetDefaultUserRPMLimit(ctx)

--- a/backend/internal/service/billing_cache_service.go
+++ b/backend/internal/service/billing_cache_service.go
@@ -741,7 +741,7 @@ func (s *BillingCacheService) CheckBillingEligibility(ctx context.Context, user 
 		}
 	}
 
-	// RPM 限流：级联回落（Override → Group → User），放在最后以避免为注定失败的请求增加计数。
+	// RPM 限流：分组级（Override → Group）与用户全局上限同时生效。
 	if err := s.checkRPM(ctx, user, group); err != nil {
 		return err
 	}

--- a/backend/internal/service/billing_cache_service_rpm_test.go
+++ b/backend/internal/service/billing_cache_service_rpm_test.go
@@ -181,7 +181,7 @@ func TestBillingCacheService_CheckRPM_OverrideLookupErrorFallsThroughToGroup(t *
 	require.EqualValues(t, 1, atomic.LoadInt32(&repo.calls))
 }
 
-func TestBillingCacheService_CheckRPM_UserLevelFallbackWhenGroupUnlimited(t *testing.T) {
+func TestBillingCacheService_CheckRPM_UserLimitAppliesWhenGroupUnlimited(t *testing.T) {
 	cache := &userRPMCacheStub{userCounts: []int{1, 2, 3}}
 	repo := &rpmOverrideRepoStub{override: nil}
 	svc := newBillingServiceForRPM(t, cache, repo)

--- a/backend/internal/service/group.go
+++ b/backend/internal/service/group.go
@@ -65,7 +65,7 @@ type Group struct {
 	ModelsListConfig            GroupModelsListConfig
 
 	// RPMLimit 分组级每分钟请求数上限（0 = 不限制）。
-	// 一旦设置即接管该分组用户的限流（覆盖用户级 rpm_limit），可被 user-group rpm_override 进一步覆盖。
+	// 可被 user-group rpm_override 替代，但不会覆盖用户级全局 rpm_limit。
 	RPMLimit int
 
 	CreatedAt time.Time

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -50,8 +50,8 @@ type User struct {
 	BalanceNotifyExtraEmails   []NotifyEmailEntry
 	TotalRecharged             float64
 
-	// RPMLimit 用户级每分钟请求数上限（0 = 不限制）。仅在所用分组未设置 rpm_limit
-	// 且该 (用户, 分组) 无 rpm_override 时作为全局兜底生效，计数键 rpm:u:{userID}:{min}。
+	// RPMLimit 用户跨所有分组的每分钟请求总上限（0 = 不限制）。
+	// 与 group.rpm_limit / rpm_override 同时生效，计数键 rpm:u:{userID}:{min}。
 	RPMLimit int
 
 	// UserGroupRPMOverride 来自 auth cache snapshot 的 (user, group) RPM 覆盖值。

--- a/backend/internal/service/user_rpm_cache.go
+++ b/backend/internal/service/user_rpm_cache.go
@@ -14,7 +14,7 @@ type UserRPMCache interface {
 	IncrementUserGroupRPM(ctx context.Context, userID, groupID int64) (count int, err error)
 
 	// IncrementUserRPM 原子递增用户级分钟计数并返回最新值。
-	// 用于用户全局 rpm_limit 兜底分支（分组未设且无 override 时）。
+	// 用于始终生效的用户全局 rpm_limit。
 	IncrementUserRPM(ctx context.Context, userID int64) (count int, err error)
 
 	// GetUserGroupRPM 获取 (user, group) 当前分钟已用 RPM（只读，不递增）。

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -1855,7 +1855,7 @@ export default {
       form: {
         rpmLimit: 'Requests Per Minute (RPM)',
         rpmLimitPlaceholder: '0 = unlimited',
-        rpmLimitHint: 'Max requests per minute for this user; 0 = unlimited. Acts as a fallback only when the group has no rpm_limit set.'
+        rpmLimitHint: 'Global requests-per-minute cap for this user across all groups; 0 = unlimited. Group and override RPM limits do not replace this cap.'
       },
       columns: {
         user: 'User',
@@ -2121,7 +2121,7 @@ export default {
         platform: 'Platform',
         rateMultiplier: 'Rate Multiplier',
         rpmOverride: 'RPM Override',
-        rpmOverrideHint: 'Per-user RPM cap in this group; empty = group default; 0 = unlimited',
+        rpmOverrideHint: 'Per-user RPM cap in this group; empty = group default; 0 = no group-level cap (the global user RPM cap still applies)',
         rateDefault: 'default',
         rpmDefault: 'default',
         type: 'Type',
@@ -2153,7 +2153,7 @@ export default {
         exclusive: 'Exclusive Group',
         rpmLimit: 'Requests Per Minute (RPM)',
         rpmLimitPlaceholder: '0 = unlimited',
-        rpmLimitHint: 'Max requests per minute for each user in this group; 0 = unlimited. Once set, it takes over per-user rate limiting in this group (overrides the user-level rpm_limit fallback).'
+        rpmLimitHint: 'Max requests per minute for each user in this group; 0 = no group-level cap. The stricter of this limit and the global user RPM cap applies.'
       },
       enterGroupName: 'Enter group name',
       optionalDescription: 'Optional description',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -1961,7 +1961,7 @@ export default {
         selectStatus: '选择状态',
         rpmLimit: '每分钟请求数 (RPM)',
         rpmLimitPlaceholder: '0 表示不限制',
-        rpmLimitHint: '该用户每分钟最大请求数，0 = 不限制；仅在所用分组未设置 rpm_limit 时作为兜底生效'
+        rpmLimitHint: '该用户跨所有分组的每分钟请求总上限，0 = 不限制；分组 RPM 或专属 RPM 不会覆盖此全局上限'
       },
       adjustBalance: '调整余额',
       adjustConcurrency: '调整并发数',
@@ -2171,7 +2171,7 @@ export default {
         platform: '平台',
         rateMultiplier: '费率倍数',
         rpmOverride: 'RPM 覆盖',
-        rpmOverrideHint: '该用户在此分组的 RPM 上限；留空 = 使用分组默认；0 = 不限制',
+        rpmOverrideHint: '该用户在此分组的 RPM 上限；留空 = 使用分组默认；0 = 不限制分组级 RPM（用户全局 RPM 仍生效）',
         rateDefault: '默认',
         rpmDefault: '默认',
         exclusive: '独占',
@@ -2210,7 +2210,7 @@ export default {
         rateMultiplierHint: '1.0 = 标准费率，0.5 = 半价，2.0 = 双倍',
         rpmLimit: '每分钟请求数 (RPM)',
         rpmLimitPlaceholder: '0 表示不限制',
-        rpmLimitHint: '每用户在本分组每分钟最大请求数，0 = 不限制；一旦设置即接管该用户的限流（覆盖用户级 rpm_limit）',
+        rpmLimitHint: '每用户在本分组每分钟最大请求数，0 = 不限制分组级 RPM；与用户全局 RPM 同时生效，取更严格的限制',
         exclusiveLabel: '专属分组',
         exclusiveHint: '专属分组，可以手动指定给用户',
         platformLabel: '平台限制',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -87,7 +87,7 @@ export interface User {
   role: 'admin' | 'user' // User role for authorization
   balance: number // User balance for API usage
   concurrency: number // Allowed concurrent requests
-  rpm_limit?: number // User-level RPM cap (0 = unlimited); effective as fallback when group has no rpm_limit
+  rpm_limit?: number // Global per-user RPM cap across all groups (0 = unlimited)
   status: 'active' | 'disabled' // Account status
   allowed_groups: number[] | null // Allowed group IDs (null = all non-exclusive groups)
   balance_notify_enabled: boolean
@@ -504,7 +504,7 @@ export interface Group {
   description: string | null
   platform: GroupPlatform
   rate_multiplier: number
-  rpm_limit?: number // Group-level RPM cap (0 = unlimited); overrides user-level rpm_limit when set
+  rpm_limit?: number // Per-user RPM cap in this group (0 = no group-level cap); global user cap still applies
   is_exclusive: boolean
   status: 'active' | 'inactive'
   subscription_type: SubscriptionType


### PR DESCRIPTION
关联issue #3288

## 修复内容

- 明确用户级 RPM 是跨所有分组生效的全局上限
- 明确分组 RPM 和用户专属 RPM 仍受用户全局 RPM 上限约束
- 同步修正中英文界面文案、TypeScript 类型注释及后端契约注释

## 问题原因

管理后台原有文案表示分组 RPM 会覆盖用户级 RPM，但后端 `checkRPM` 的实际逻辑是在分组或专属 RPM 检查通过后，仍继续检查 `user.rpm_limit`。因此用户级 RPM 实际是全局硬上限。

当用户级 RPM 小于分组或专属 RPM 时，仅提高分组 RPM 仍会触发用户级限流，容易被误认为配置未生效或 Redis 缓存未刷新。

本 PR 仅修正文案和代码注释，不修改现有限流行为。

## 验证

- `GOCACHE=/tmp/sub2api-go-build go test -tags=unit ./internal/service -run TestBillingCacheService_CheckRPM_ -count=1`
- `pnpm exec eslint src/i18n/locales/zh.ts src/i18n/locales/en.ts src/types/index.ts`
- `pnpm typecheck`