### PR TITLE
fix(openai): filter disabled image_generation tool for Responses requests

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -257,7 +257,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			return
 		}
 		if service.FilterOpenAIResponsesImageGenerationControls(reqBody) {
-			filteredBody, err := json.Marshal(reqBody)
+			filteredBody, err := service.MarshalOpenAIUpstreamJSON(reqBody)
 			if err != nil {
 				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 				return

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -251,8 +251,25 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 
 	imageIntent := service.IsImageGenerationIntent("/v1/responses", reqModel, body)
 	if imageIntent && !service.GroupAllowsImageGeneration(apiKey.Group) {
-		h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
-		return
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+			return
+		}
+		if service.FilterOpenAIResponsesImageGenerationControls(reqBody) {
+			filteredBody, err := json.Marshal(reqBody)
+			if err != nil {
+				h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+				return
+			}
+			body = filteredBody
+			sessionHashBody = filteredBody
+			imageIntent = service.IsImageGenerationIntent("/v1/responses", reqModel, body)
+		}
+		if imageIntent {
+			h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
+			return
+		}
 	}
 	var imageReleaseFunc func()
 	if imageIntent {

--- a/backend/internal/service/image_generation_intent.go
+++ b/backend/internal/service/image_generation_intent.go
@@ -106,6 +106,36 @@ func openAIRequestBodyHasImageGenerationTool(body []byte) bool {
 	return openAIJSONToolsContainImageGeneration(gjson.GetBytes(body, "tools"))
 }
 
+func FilterOpenAIResponsesImageGenerationControls(reqBody map[string]any) bool {
+	if reqBody == nil {
+		return false
+	}
+
+	removed := false
+	rawTools, ok := reqBody["tools"]
+	if ok && rawTools != nil {
+		if tools, ok := rawTools.([]any); ok {
+			filtered := make([]any, 0, len(tools))
+			for _, rawTool := range tools {
+				toolMap, ok := rawTool.(map[string]any)
+				if ok && strings.TrimSpace(firstNonEmptyString(toolMap["type"])) == "image_generation" {
+					removed = true
+					continue
+				}
+				filtered = append(filtered, rawTool)
+			}
+			if removed {
+				reqBody["tools"] = filtered
+			}
+		}
+	}
+	if openAIAnyToolChoiceSelectsImageGeneration(reqBody["tool_choice"]) {
+		delete(reqBody, "tool_choice")
+		removed = true
+	}
+	return removed
+}
+
 func openAIRequestBodyImageGenerationToolNeedsNormalization(body []byte) bool {
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return false

--- a/backend/internal/service/image_generation_intent.go
+++ b/backend/internal/service/image_generation_intent.go
@@ -125,7 +125,12 @@ func FilterOpenAIResponsesImageGenerationControls(reqBody map[string]any) bool {
 				filtered = append(filtered, rawTool)
 			}
 			if removed {
-				reqBody["tools"] = filtered
+				if len(filtered) == 0 {
+					delete(reqBody, "tools")
+					delete(reqBody, "tool_choice")
+				} else {
+					reqBody["tools"] = filtered
+				}
 			}
 		}
 	}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2325,7 +2325,7 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
 }
 
-func marshalOpenAIUpstreamJSON(v any) ([]byte, error) {
+func MarshalOpenAIUpstreamJSON(v any) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
 	enc.SetEscapeHTML(false)
@@ -2729,7 +2729,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				return nil, decodeErr
 			}
 			var marshalErr error
-			body, marshalErr = marshalOpenAIUpstreamJSON(decoded)
+			body, marshalErr = MarshalOpenAIUpstreamJSON(decoded)
 			if marshalErr != nil {
 				return nil, fmt.Errorf("serialize request body: %w", marshalErr)
 			}
@@ -3019,7 +3019,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 					return nil, decodeErr
 				}
 				if trimOpenAIEncryptedReasoningItems(decoded) {
-					body, err = marshalOpenAIUpstreamJSON(decoded)
+					body, err = MarshalOpenAIUpstreamJSON(decoded)
 					if err != nil {
 						return nil, fmt.Errorf("serialize invalid_encrypted_content retry body: %w", err)
 					}
@@ -3215,7 +3215,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 				return nil, err
 			}
 			if FilterOpenAIResponsesImageGenerationControls(reqBody) {
-				filteredBody, err := marshalOpenAIUpstreamJSON(reqBody)
+				filteredBody, err := MarshalOpenAIUpstreamJSON(reqBody)
 				if err != nil {
 					return nil, fmt.Errorf("serialize request body: %w", err)
 				}
@@ -7205,7 +7205,7 @@ func sanitizeEmptyBase64InputImagesInOpenAIBody(body []byte) ([]byte, bool, erro
 	if !sanitizeEmptyBase64InputImagesInOpenAIRequestBodyMap(reqBody) {
 		return body, false, nil
 	}
-	normalized, err := marshalOpenAIUpstreamJSON(reqBody)
+	normalized, err := MarshalOpenAIUpstreamJSON(reqBody)
 	if err != nil {
 		return body, false, fmt.Errorf("serialize sanitized request body: %w", err)
 	}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2498,9 +2498,21 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	codexImageGenerationBridgeEnabled := isCodexCLI && imageGenerationAllowed && s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey)
 	imageIntent := IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body)
 	if imageIntent && !imageGenerationAllowed {
-		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
-		c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"type": "permission_error", "message": ImageGenerationPermissionMessage()}})
-		return nil, errors.New("image generation disabled for group")
+		if openAIRequestBodyHasImageGenerationTool(body) {
+			decoded, decodeErr := ensureReqBody()
+			if decodeErr != nil {
+				return nil, decodeErr
+			}
+			if FilterOpenAIResponsesImageGenerationControls(decoded) {
+				markDecodedModified()
+				imageIntent = IsImageGenerationIntentMap(openAIResponsesEndpoint, reqModel, decoded)
+			}
+		}
+		if imageIntent {
+			MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
+			c.JSON(http.StatusForbidden, gin.H{"error": gin.H{"type": "permission_error", "message": ImageGenerationPermissionMessage()}})
+			return nil, errors.New("image generation disabled for group")
+		}
 	}
 
 	instructions := gjson.GetBytes(body, "instructions")
@@ -3195,20 +3207,37 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	body = updatedBody
 
 	apiKey := getAPIKeyFromContext(c)
-	if IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body) && !GroupAllowsImageGeneration(apiKeyGroup(apiKey)) {
-		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
-		c.JSON(http.StatusForbidden, gin.H{
-			"error": gin.H{
-				"type":    "permission_error",
-				"message": ImageGenerationPermissionMessage(),
-			},
-		})
-		return nil, errors.New("image generation disabled for group")
+	imageIntent := IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body)
+	if imageIntent && !GroupAllowsImageGeneration(apiKeyGroup(apiKey)) {
+		if openAIRequestBodyHasImageGenerationTool(body) {
+			var reqBody map[string]any
+			if err := json.Unmarshal(body, &reqBody); err != nil {
+				return nil, err
+			}
+			if FilterOpenAIResponsesImageGenerationControls(reqBody) {
+				filteredBody, err := marshalOpenAIUpstreamJSON(reqBody)
+				if err != nil {
+					return nil, fmt.Errorf("serialize request body: %w", err)
+				}
+				body = filteredBody
+				imageIntent = IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body)
+			}
+		}
+		if imageIntent {
+			MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalFeatureGate)
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": gin.H{
+					"type":    "permission_error",
+					"message": ImageGenerationPermissionMessage(),
+				},
+			})
+			return nil, errors.New("image generation disabled for group")
+		}
 	}
 	imageBillingModel := ""
 	imageSizeTier := ""
 	imageInputSize := ""
-	if IsImageGenerationIntent(openAIResponsesEndpoint, reqModel, body) {
+	if imageIntent {
 		var imageCfgErr error
 		imageCfg, imageCfgErr := resolveOpenAIResponsesImageBillingConfigDetailedFromBody(body, reqModel)
 		if imageCfgErr != nil {

--- a/backend/internal/service/openai_image_generation_controls_test.go
+++ b/backend/internal/service/openai_image_generation_controls_test.go
@@ -100,6 +100,30 @@ func TestOpenAIGatewayServiceForward_DisabledGroupRemovesImageGenerationToolChoi
 	require.Equal(t, 0, result.ImageCount)
 }
 
+func TestFilterOpenAIResponsesImageGenerationControls_RemovesEmptyToolsAndToolChoice(t *testing.T) {
+	reqBody := map[string]any{
+		"model":       "gpt-5.4",
+		"input":       "search only",
+		"tools":       []any{map[string]any{"type": "image_generation"}},
+		"tool_choice": "auto",
+	}
+
+	modified := FilterOpenAIResponsesImageGenerationControls(reqBody)
+
+	require.True(t, modified)
+	require.NotContains(t, reqBody, "tools")
+	require.NotContains(t, reqBody, "tool_choice")
+}
+
+func TestMarshalOpenAIUpstreamJSON_DoesNotEscapeHTML(t *testing.T) {
+	body, err := MarshalOpenAIUpstreamJSON(map[string]any{
+		"input": "<div>&</div>",
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, string(body), `"<div>&</div>"`)
+}
+
 func TestOpenAIGatewayServiceForward_DisabledGroupAllowsTextOnlyResponses(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_image_generation_controls_test.go
+++ b/backend/internal/service/openai_image_generation_controls_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestOpenAIGatewayServiceForward_RejectsDisabledImageGenerationIntents(t *testing.T) {
+func TestOpenAIGatewayServiceForward_RejectsDisabledImageGenerationModels(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
@@ -25,14 +25,6 @@ func TestOpenAIGatewayServiceForward_RejectsDisabledImageGenerationIntents(t *te
 		{
 			name: "image model",
 			body: []byte(`{"model":"gpt-image-2","input":"draw"}`),
-		},
-		{
-			name: "image tool",
-			body: []byte(`{"model":"gpt-5.4","input":"draw","tools":[{"type":"image_generation"}]}`),
-		},
-		{
-			name: "image tool choice",
-			body: []byte(`{"model":"gpt-5.4","input":"draw","tool_choice":{"type":"image_generation"}}`),
 		},
 	}
 
@@ -52,6 +44,60 @@ func TestOpenAIGatewayServiceForward_RejectsDisabledImageGenerationIntents(t *te
 			require.Nil(t, upstream.lastReq, "disabled image request must not reach upstream")
 		})
 	}
+}
+
+func TestOpenAIGatewayServiceForward_DisabledGroupFiltersImageGenerationTool(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_filtered","model":"gpt-5.4","usage":{"input_tokens":4,"output_tokens":2}}`)),
+		},
+	}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	c, recorder := newOpenAIImageGenerationControlTestContext(false, "unit-test-agent/1.0")
+	account := newOpenAIImageGenerationControlTestAccount()
+	body := []byte(`{"model":"gpt-5.4","input":"search only","stream":false,"tools":[{"type":"web_search"},{"type":"image_generation"},{"type":"function","name":"inspect"}]}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists())
+	require.True(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="web_search")`).Exists())
+	require.True(t, gjson.GetBytes(upstream.lastBody, `tools.#(name=="inspect")`).Exists())
+	require.Equal(t, 0, result.ImageCount)
+}
+
+func TestOpenAIGatewayServiceForward_DisabledGroupRemovesImageGenerationToolChoice(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_filtered_choice","model":"gpt-5.4","usage":{"input_tokens":4,"output_tokens":2}}`)),
+		},
+	}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	c, recorder := newOpenAIImageGenerationControlTestContext(false, "unit-test-agent/1.0")
+	account := newOpenAIImageGenerationControlTestAccount()
+	body := []byte(`{"model":"gpt-5.4","input":"search only","stream":false,"tools":[{"type":"web_search"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tool_choice").Exists())
+	require.True(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="web_search")`).Exists())
+	require.Equal(t, 0, result.ImageCount)
 }
 
 func TestOpenAIGatewayServiceForward_DisabledGroupAllowsTextOnlyResponses(t *testing.T) {


### PR DESCRIPTION
## Summary

- Filter `image_generation` from OpenAI Responses `tools` when the API key group disables image generation.
- Remove stale `tool_choice` when it selects the filtered image generation tool.
- Keep true image-generation requests blocked, including image models and dedicated image endpoints.

## Why

Clients may send a default `tools` array containing both `web_search` and `image_generation`. When image generation is disabled for the group, a normal text request should not fail only because that optional tool is present.

## Tests

- `go test ./internal/service ./internal/handler -run 'ImageGeneration|OpenAIGatewayServiceForward|OpenAIGatewayHandler|FilterOpenAIResponsesImageGenerationControls|MarshalOpenAIUpstreamJSON' -count=1`\n- `go test ./...`\n