### PR TITLE
[codex] feat: add Codex quota-aware OpenAI scheduling

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1172,13 +1172,17 @@ type GatewayOpenAIWSSchedulerScoreWeights struct {
 	QuotaHeadroom float64 `mapstructure:"quota_headroom"`
 	// UpstreamCost 倾向上游声明倍率更低的账号；默认 0（关闭，不改变原有行为）。
 	UpstreamCost float64 `mapstructure:"upstream_cost"`
+	// Quota5h is a soft Codex 5-hour quota headroom weight: lower 5h usage scores higher.
+	Quota5h float64 `mapstructure:"quota_5h"`
+	// Quota7d is a soft Codex 7-day quota headroom weight: lower 7d usage scores higher.
+	Quota7d float64 `mapstructure:"quota_7d"`
 	// PreviousResponse/SessionSticky 仅在开启 OpenAI 高级调度的粘性加权时生效。
 	PreviousResponse float64 `mapstructure:"previous_response"`
 	SessionSticky    float64 `mapstructure:"session_sticky"`
 }
 
 func (w GatewayOpenAIWSSchedulerScoreWeights) BaseWeightSum() float64 {
-	return w.Priority + w.Load + w.Queue + w.ErrorRate + w.TTFT + w.Reset + w.QuotaHeadroom + w.UpstreamCost
+	return w.Priority + w.Load + w.Queue + w.ErrorRate + w.TTFT + w.Reset + w.QuotaHeadroom + w.UpstreamCost + w.Quota5h + w.Quota7d
 }
 
 func (w GatewayOpenAIWSSchedulerScoreWeights) TotalWeightSum() float64 {
@@ -1188,7 +1192,8 @@ func (w GatewayOpenAIWSSchedulerScoreWeights) TotalWeightSum() float64 {
 func (w GatewayOpenAIWSSchedulerScoreWeights) IsValid() bool {
 	for _, weight := range []float64{
 		w.Priority, w.Load, w.Queue, w.ErrorRate, w.TTFT, w.Reset,
-		w.QuotaHeadroom, w.UpstreamCost, w.PreviousResponse, w.SessionSticky,
+		w.QuotaHeadroom, w.UpstreamCost, w.Quota5h, w.Quota7d,
+		w.PreviousResponse, w.SessionSticky,
 	} {
 		if weight < 0 || math.IsNaN(weight) || math.IsInf(weight, 0) {
 			return false
@@ -2228,6 +2233,8 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.reset", 0.0)
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.quota_headroom", 0.0)
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.upstream_cost", 0.0)
+	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.quota_5h", 0.4)
+	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.quota_7d", 0.3)
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.previous_response", 5.0)
 	viper.SetDefault("gateway.openai_ws.scheduler_score_weights.session_sticky", 3.0)
 	// OpenAI HTTP upstream protocol strategy
@@ -3232,7 +3239,7 @@ func (c *Config) Validate() error {
 	weights := c.Gateway.OpenAIWS.SchedulerScoreWeights
 	for _, weight := range []float64{
 		weights.Priority, weights.Load, weights.Queue, weights.ErrorRate, weights.TTFT,
-		weights.Reset, weights.QuotaHeadroom, weights.UpstreamCost,
+		weights.Reset, weights.QuotaHeadroom, weights.UpstreamCost, weights.Quota5h, weights.Quota7d,
 		weights.PreviousResponse, weights.SessionSticky,
 	} {
 		if weight < 0 || math.IsNaN(weight) || math.IsInf(weight, 0) {

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -374,6 +374,12 @@ func TestLoadDefaultOpenAIWSConfig(t *testing.T) {
 	if cfg.Gateway.OpenAIScheduler.StickyEscapeErrorRate != 0.5 {
 		t.Fatalf("Gateway.OpenAIScheduler.StickyEscapeErrorRate = %v, want 0.5", cfg.Gateway.OpenAIScheduler.StickyEscapeErrorRate)
 	}
+	if cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h != 0.4 {
+		t.Fatalf("Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h = %v, want 0.4", cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h)
+	}
+	if cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d != 0.3 {
+		t.Fatalf("Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d = %v, want 0.3", cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d)
+	}
 	if !cfg.Gateway.OpenAIWS.SessionHashReadOldFallback {
 		t.Fatalf("Gateway.OpenAIWS.SessionHashReadOldFallback = false, want true")
 	}
@@ -2173,6 +2179,8 @@ func TestValidateConfig_OpenAIWSRules(t *testing.T) {
 				c.Gateway.OpenAIWS.SchedulerScoreWeights.Queue = 0
 				c.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate = 0
 				c.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT = 0
+				c.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h = 0
+				c.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d = 0
 			},
 			wantErr: "gateway.openai_ws.scheduler_score_weights must not all be zero",
 		},

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -959,7 +959,9 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAIAccountLoadPlan(
 			weights.TTFT*ttftFactor +
 			weights.Reset*resetFactor +
 			weights.QuotaHeadroom*quotaHeadroomFactor +
-			weights.UpstreamCost*(upstreamCostFactor-openAIUpstreamCostNeutralFactor)
+			weights.UpstreamCost*(upstreamCostFactor-openAIUpstreamCostNeutralFactor) +
+			weights.Quota5h*openAICodexQuotaHeadroomFactor(item.account, "5h", now) +
+			weights.Quota7d*openAICodexQuotaHeadroomFactor(item.account, "7d", now)
 		if req.StickyWeighted {
 			if req.PreviousResponseCanMove && req.StickyPreviousAccountID > 0 && item.account.ID == req.StickyPreviousAccountID {
 				item.score += weights.Previous
@@ -2208,6 +2210,8 @@ func (s *OpenAIGatewayService) openAIWSSchedulerWeights() GatewayOpenAIWSSchedul
 			Reset:         s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Reset,
 			QuotaHeadroom: s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.QuotaHeadroom,
 			UpstreamCost:  s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.UpstreamCost,
+			Quota5h:       s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h,
+			Quota7d:       s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d,
 			Previous:      s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.PreviousResponse,
 			SessionSticky: s.cfg.Gateway.OpenAIWS.SchedulerScoreWeights.SessionSticky,
 		}
@@ -2221,6 +2225,8 @@ func (s *OpenAIGatewayService) openAIWSSchedulerWeights() GatewayOpenAIWSSchedul
 		Reset:         0.0,
 		QuotaHeadroom: 0.0,
 		UpstreamCost:  0.0,
+		Quota5h:       0.4,
+		Quota7d:       0.3,
 		Previous:      5.0,
 		SessionSticky: 3.0,
 	}
@@ -2260,6 +2266,10 @@ func applyOpenAIAdvancedSchedulerWeightOverrides(
 			weights.Reset = value
 		case "quota_headroom":
 			weights.QuotaHeadroom = value
+		case "quota_5h":
+			weights.Quota5h = value
+		case "quota_7d":
+			weights.Quota7d = value
 		case "upstream_cost":
 			weights.UpstreamCost = value
 		case "previous_response":
@@ -2281,6 +2291,8 @@ type GatewayOpenAIWSSchedulerScoreWeightsView struct {
 	Reset         float64
 	QuotaHeadroom float64
 	UpstreamCost  float64
+	Quota5h       float64
+	Quota7d       float64
 	Previous      float64
 	SessionSticky float64
 }
@@ -2295,6 +2307,8 @@ func (w GatewayOpenAIWSSchedulerScoreWeightsView) configWeights() config.Gateway
 		Reset:            w.Reset,
 		QuotaHeadroom:    w.QuotaHeadroom,
 		UpstreamCost:     w.UpstreamCost,
+		Quota5h:          w.Quota5h,
+		Quota7d:          w.Quota7d,
 		PreviousResponse: w.Previous,
 		SessionSticky:    w.SessionSticky,
 	}
@@ -2447,7 +2461,9 @@ func buildOpenAIAccountSchedulerScoreSnapshot(
 			weights.TTFT*ttftFactor +
 			weights.Reset*resetFactor +
 			weights.QuotaHeadroom*quotaHeadroomFactor +
-			weights.UpstreamCost*(upstreamCostFactor-openAIUpstreamCostNeutralFactor)
+			weights.UpstreamCost*(upstreamCostFactor-openAIUpstreamCostNeutralFactor) +
+			weights.Quota5h*openAICodexQuotaHeadroomFactor(candidate.account, "5h", now) +
+			weights.Quota7d*openAICodexQuotaHeadroomFactor(candidate.account, "7d", now)
 		score := OpenAIAccountSchedulerScoreSnapshot{
 			BaseScore:             baseScore,
 			StickyWeightedEnabled: stickyWeightedEnabled,
@@ -2639,6 +2655,17 @@ func openAIQuotaWindowResetAny(extra map[string]any, now time.Time, windows ...s
 		}
 	}
 	return false
+}
+
+func openAICodexQuotaHeadroomFactor(account *Account, window string, now time.Time) float64 {
+	if account == nil {
+		return 0.5
+	}
+	utilization, ok := resolveOpenAIQuotaUtilization(account.Extra, window, now)
+	if !ok {
+		return 0.5
+	}
+	return 1 - clamp01(utilization)
 }
 
 func clamp01(value float64) float64 {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -3249,6 +3249,8 @@ func TestOpenAIGatewayService_SchedulerWrappersAndDefaults(t *testing.T) {
 	require.Equal(t, 0.7, defaultWeights.Queue)
 	require.Equal(t, 0.8, defaultWeights.ErrorRate)
 	require.Equal(t, 0.5, defaultWeights.TTFT)
+	require.Equal(t, 0.4, defaultWeights.Quota5h)
+	require.Equal(t, 0.3, defaultWeights.Quota7d)
 
 	cfg := &config.Config{}
 	cfg.Gateway.OpenAIWS.LBTopK = 9
@@ -3258,6 +3260,8 @@ func TestOpenAIGatewayService_SchedulerWrappersAndDefaults(t *testing.T) {
 	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Queue = 0.4
 	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate = 0.5
 	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT = 0.6
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h = 0.7
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d = 0.8
 	svcWithCfg := &OpenAIGatewayService{cfg: cfg}
 
 	require.Equal(t, 9, svcWithCfg.openAIWSLBTopK())
@@ -3268,6 +3272,166 @@ func TestOpenAIGatewayService_SchedulerWrappersAndDefaults(t *testing.T) {
 	require.Equal(t, 0.4, customWeights.Queue)
 	require.Equal(t, 0.5, customWeights.ErrorRate)
 	require.Equal(t, 0.6, customWeights.TTFT)
+	require.Equal(t, 0.7, customWeights.Quota5h)
+	require.Equal(t, 0.8, customWeights.Quota7d)
+}
+
+func TestOpenAIAccountScheduler_CodexQuotaWeightsPreferMoreHeadroom(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	now := time.Now().UTC()
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 3
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Load = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Queue = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h = 1
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d = 1
+
+	highHeadroom := &Account{
+		ID:          9101,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  10.0,
+			"codex_7d_used_percent":  20.0,
+			"codex_5h_reset_at":      now.Add(2 * time.Hour).Format(time.RFC3339),
+			"codex_7d_reset_at":      now.Add(48 * time.Hour).Format(time.RFC3339),
+			"codex_usage_updated_at": now.Format(time.RFC3339),
+		},
+	}
+	lowHeadroom := &Account{
+		ID:          9102,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  70.0,
+			"codex_7d_used_percent":  90.0,
+			"codex_5h_reset_at":      now.Add(2 * time.Hour).Format(time.RFC3339),
+			"codex_7d_reset_at":      now.Add(48 * time.Hour).Format(time.RFC3339),
+			"codex_usage_updated_at": now.Format(time.RFC3339),
+		},
+	}
+	noSignal := &Account{
+		ID:          9103,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+	}
+
+	svc := &OpenAIGatewayService{cfg: cfg}
+	scheduler, ok := newDefaultOpenAIAccountScheduler(svc, nil).(*defaultOpenAIAccountScheduler)
+	require.True(t, ok)
+	plan := scheduler.buildOpenAIAccountLoadPlan(
+		context.Background(),
+		OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.1"},
+		[]*Account{lowHeadroom, noSignal, highHeadroom},
+		map[int64]*AccountLoadInfo{},
+	)
+
+	scores := map[int64]float64{}
+	for _, candidate := range plan.candidates {
+		scores[candidate.account.ID] = candidate.score
+	}
+
+	require.Greater(t, scores[9101], scores[9103], "fresh high headroom should outrank neutral no-signal accounts")
+	require.Greater(t, scores[9103], scores[9102], "neutral no-signal accounts should outrank low-headroom accounts")
+	require.InDelta(t, 1.7, scores[9101], 1e-9)
+	require.InDelta(t, 1.0, scores[9103], 1e-9)
+	require.InDelta(t, 0.4, scores[9102], 1e-9)
+}
+
+func TestOpenAIAccountScheduler_CodexQuotaWeightsTreatStaleOrResetWindowsAsNeutral(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	now := time.Now().UTC()
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.LBTopK = 3
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Load = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Queue = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.ErrorRate = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.TTFT = 0
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota5h = 1
+	cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Quota7d = 1
+
+	freshLowHeadroom := &Account{
+		ID:          9201,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  90.0,
+			"codex_7d_used_percent":  90.0,
+			"codex_5h_reset_at":      now.Add(2 * time.Hour).Format(time.RFC3339),
+			"codex_7d_reset_at":      now.Add(48 * time.Hour).Format(time.RFC3339),
+			"codex_usage_updated_at": now.Format(time.RFC3339),
+		},
+	}
+	resetWindow := &Account{
+		ID:          9202,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  90.0,
+			"codex_7d_used_percent":  90.0,
+			"codex_5h_reset_at":      now.Add(-1 * time.Minute).Format(time.RFC3339),
+			"codex_7d_reset_at":      now.Add(-1 * time.Minute).Format(time.RFC3339),
+			"codex_usage_updated_at": now.Format(time.RFC3339),
+		},
+	}
+	staleSnapshot := &Account{
+		ID:          9203,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			"codex_5h_used_percent":  90.0,
+			"codex_7d_used_percent":  90.0,
+			"codex_5h_reset_at":      now.Add(2 * time.Hour).Format(time.RFC3339),
+			"codex_7d_reset_at":      now.Add(48 * time.Hour).Format(time.RFC3339),
+			"codex_usage_updated_at": now.Add(-3 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	svc := &OpenAIGatewayService{cfg: cfg}
+	scheduler, ok := newDefaultOpenAIAccountScheduler(svc, nil).(*defaultOpenAIAccountScheduler)
+	require.True(t, ok)
+	plan := scheduler.buildOpenAIAccountLoadPlan(
+		context.Background(),
+		OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.1"},
+		[]*Account{freshLowHeadroom, resetWindow, staleSnapshot},
+		map[int64]*AccountLoadInfo{},
+	)
+
+	scores := map[int64]float64{}
+	for _, candidate := range plan.candidates {
+		scores[candidate.account.ID] = candidate.score
+	}
+
+	require.InDelta(t, 0.2, scores[9201], 1e-9)
+	require.InDelta(t, 1.0, scores[9202], 1e-9)
+	require.InDelta(t, 1.0, scores[9203], 1e-9)
 }
 
 func TestDefaultOpenAIAccountScheduler_IsAccountTransportCompatible_Branches(t *testing.T) {

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -385,6 +385,12 @@ gateway:
       quota_headroom: 0.0
       # 倾向上游声明倍率更低的账号；0 表示关闭（默认），建议启用时从 1.5 开始。
       upstream_cost: 0.0
+      # Codex 5h quota headroom weight. Lower 5h usage gets a higher scheduler score.
+      # Set to 0 to disable the short-window quota signal.
+      quota_5h: 0.4
+      # Codex 7d quota headroom weight. Lower 7d usage gets a higher scheduler score.
+      # Set to 0 to disable the weekly quota signal.
+      quota_7d: 0.3
   # OpenAI 高级调度器补充配置
   openai_scheduler:
     # 是否允许 session_hash sticky 在账号健康度恶化时临时逃逸；false 可一键回退旧行为


### PR DESCRIPTION
## Summary

- Add Codex quota headroom signals to the existing OpenAI advanced scheduler score.
- Use both 5-hour and 7-day Codex usage snapshots so the scheduler can gradually prefer accounts with more remaining short-window and weekly capacity.
- Keep the existing auto-pause, sticky-session, TopK, load, queue, error-rate, and TTFT behavior intact.

## Algorithm

For each OpenAI candidate in the load-balance layer, the scheduler now adds two soft score terms:

```text
score += quota_5h * headroom(codex_5h_used_percent)
score += quota_7d * headroom(codex_7d_used_percent)
headroom = 1 - used_percent / 100
```

- A lower 5h usage percentage receives a higher 5h score, reducing the chance that one account hits the short rolling window too quickly.
- A lower 7d usage percentage receives a higher 7d score, spreading weekly Codex quota consumption across accounts more evenly.
- Missing, reset, or stale quota snapshots are treated as neutral `0.5`, reusing the existing reset/staleness guards instead of trusting old usage data.
- Set `gateway.openai_ws.scheduler_score_weights.quota_5h` or `quota_7d` to `0` to disable either quota signal.

## Why

This is a softer version of quota-aware routing than hard threshold switching: accounts are gradually demoted as their Codex windows fill up, while already-exhausted accounts are still handled by the existing auto-pause logic.

Related: #979, #477, #372

## Tests

```bash
go test -tags unit ./internal/service -run 'TestOpenAIAccountScheduler_CodexQuotaWeights|TestOpenAIGatewayService_SchedulerWrappersAndDefaults'
go test -tags unit ./internal/config -run 'TestLoadDefaultOpenAIWSConfig|TestValidateConfig_OpenAIWSRules'
go test -tags unit ./internal/service -run 'TestOpenAI.*Scheduler|TestDefaultOpenAIAccountScheduler|TestBuildOpenAIWeightedSelectionOrder|TestOpenAIAccountCandidateHeap|TestClamp01|TestCalcLoadSkewByMoments|TestDeriveOpenAISelectionSeed|TestOpenAISelectionRNG'
go test -tags unit ./internal/config ./internal/service
```
