### PR TITLE
feat(payment): add balance packages and flexible redeem validity

### DIFF
--- a/backend/ent/migrate/schema.go
+++ b/backend/ent/migrate/schema.go
@@ -822,6 +822,10 @@ var (
 		{Name: "amount", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "decimal(20,2)"}},
 		{Name: "pay_amount", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "decimal(20,2)"}},
 		{Name: "fee_rate", Type: field.TypeFloat64, Default: 0, SchemaType: map[string]string{"postgres": "decimal(10,4)"}},
+		{Name: "applied_rate_multiplier", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
+		{Name: "pricing_tier_label", Type: field.TypeString, Nullable: true, Size: 255},
+		{Name: "pricing_tier_snapshot", Type: field.TypeJSON, Nullable: true, SchemaType: map[string]string{"postgres": "jsonb"}},
+		{Name: "credited_amount", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
 		{Name: "recharge_code", Type: field.TypeString, Size: 64},
 		{Name: "out_trade_no", Type: field.TypeString, Size: 64, Default: ""},
 		{Name: "payment_type", Type: field.TypeString, Size: 30},
@@ -864,7 +868,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "payment_orders_users_payment_orders",
-				Columns:    []*schema.Column{PaymentOrdersColumns[39]},
+				Columns:    []*schema.Column{PaymentOrdersColumns[43]},
 				RefColumns: []*schema.Column{UsersColumns[0]},
 				OnDelete:   schema.NoAction,
 			},
@@ -873,7 +877,7 @@ var (
 			{
 				Name:    "paymentorder_out_trade_no",
 				Unique:  true,
-				Columns: []*schema.Column{PaymentOrdersColumns[8]},
+				Columns: []*schema.Column{PaymentOrdersColumns[12]},
 				Annotation: &entsql.IndexAnnotation{
 					Where: "out_trade_no <> ''",
 				},
@@ -881,37 +885,37 @@ var (
 			{
 				Name:    "paymentorder_user_id",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[39]},
+				Columns: []*schema.Column{PaymentOrdersColumns[43]},
 			},
 			{
 				Name:    "paymentorder_status",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[21]},
+				Columns: []*schema.Column{PaymentOrdersColumns[25]},
 			},
 			{
 				Name:    "paymentorder_expires_at",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[29]},
+				Columns: []*schema.Column{PaymentOrdersColumns[33]},
 			},
 			{
 				Name:    "paymentorder_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[37]},
+				Columns: []*schema.Column{PaymentOrdersColumns[41]},
 			},
 			{
 				Name:    "paymentorder_paid_at",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[30]},
+				Columns: []*schema.Column{PaymentOrdersColumns[34]},
 			},
 			{
 				Name:    "paymentorder_payment_type_paid_at",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[9], PaymentOrdersColumns[30]},
+				Columns: []*schema.Column{PaymentOrdersColumns[13], PaymentOrdersColumns[34]},
 			},
 			{
 				Name:    "paymentorder_order_type",
 				Unique:  false,
-				Columns: []*schema.Column{PaymentOrdersColumns[14]},
+				Columns: []*schema.Column{PaymentOrdersColumns[18]},
 			},
 		},
 	}
@@ -1215,7 +1219,7 @@ var (
 		{Name: "description", Type: field.TypeString, Default: "", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "price", Type: field.TypeFloat64, SchemaType: map[string]string{"postgres": "decimal(20,2)"}},
 		{Name: "original_price", Type: field.TypeFloat64, Nullable: true, SchemaType: map[string]string{"postgres": "decimal(20,2)"}},
-		{Name: "validity_days", Type: field.TypeInt, Default: 30},
+		{Name: "validity_days", Type: field.TypeFloat64, Default: 30, SchemaType: map[string]string{"postgres": "decimal(20,8)"}},
 		{Name: "validity_unit", Type: field.TypeString, Size: 10, Default: "day"},
 		{Name: "features", Type: field.TypeString, Default: "", SchemaType: map[string]string{"postgres": "text"}},
 		{Name: "product_name", Type: field.TypeString, Size: 100, Default: ""},

--- a/backend/ent/mutation.go
+++ b/backend/ent/mutation.go
@@ -20489,60 +20489,66 @@ func (m *PaymentAuditLogMutation) ResetEdge(name string) error {
 // PaymentOrderMutation represents an operation that mutates the PaymentOrder nodes in the graph.
 type PaymentOrderMutation struct {
 	config
-	op                       Op
-	typ                      string
-	id                       *int64
-	user_email               *string
-	user_name                *string
-	user_notes               *string
-	amount                   *float64
-	addamount                *float64
-	pay_amount               *float64
-	addpay_amount            *float64
-	fee_rate                 *float64
-	addfee_rate              *float64
-	recharge_code            *string
-	out_trade_no             *string
-	payment_type             *string
-	payment_trade_no         *string
-	pay_url                  *string
-	qr_code                  *string
-	qr_code_img              *string
-	order_type               *string
-	plan_id                  *int64
-	addplan_id               *int64
-	subscription_group_id    *int64
-	addsubscription_group_id *int64
-	subscription_days        *int
-	addsubscription_days     *int
-	provider_instance_id     *string
-	provider_key             *string
-	provider_snapshot        *map[string]interface{}
-	status                   *string
-	refund_amount            *float64
-	addrefund_amount         *float64
-	refund_reason            *string
-	refund_at                *time.Time
-	force_refund             *bool
-	refund_requested_at      *time.Time
-	refund_request_reason    *string
-	refund_requested_by      *string
-	expires_at               *time.Time
-	paid_at                  *time.Time
-	completed_at             *time.Time
-	failed_at                *time.Time
-	failed_reason            *string
-	client_ip                *string
-	src_host                 *string
-	src_url                  *string
-	created_at               *time.Time
-	updated_at               *time.Time
-	clearedFields            map[string]struct{}
-	user                     *int64
-	cleareduser              bool
-	done                     bool
-	oldValue                 func(context.Context) (*PaymentOrder, error)
-	predicates               []predicate.PaymentOrder
+	op                         Op
+	typ                        string
+	id                         *int64
+	user_email                 *string
+	user_name                  *string
+	user_notes                 *string
+	amount                     *float64
+	addamount                  *float64
+	pay_amount                 *float64
+	addpay_amount              *float64
+	fee_rate                   *float64
+	addfee_rate                *float64
+	applied_rate_multiplier    *float64
+	addapplied_rate_multiplier *float64
+	pricing_tier_label         *string
+	pricing_tier_snapshot      *map[string]interface{}
+	credited_amount            *float64
+	addcredited_amount         *float64
+	recharge_code              *string
+	out_trade_no               *string
+	payment_type               *string
+	payment_trade_no           *string
+	pay_url                    *string
+	qr_code                    *string
+	qr_code_img                *string
+	order_type                 *string
+	plan_id                    *int64
+	addplan_id                 *int64
+	subscription_group_id      *int64
+	addsubscription_group_id   *int64
+	subscription_days          *int
+	addsubscription_days       *int
+	provider_instance_id       *string
+	provider_key               *string
+	provider_snapshot          *map[string]interface{}
+	status                     *string
+	refund_amount              *float64
+	addrefund_amount           *float64
+	refund_reason              *string
+	refund_at                  *time.Time
+	force_refund               *bool
+	refund_requested_at        *time.Time
+	refund_request_reason      *string
+	refund_requested_by        *string
+	expires_at                 *time.Time
+	paid_at                    *time.Time
+	completed_at               *time.Time
+	failed_at                  *time.Time
+	failed_reason              *string
+	client_ip                  *string
+	src_host                   *string
+	src_url                    *string
+	created_at                 *time.Time
+	updated_at                 *time.Time
+	clearedFields              map[string]struct{}
+	user                       *int64
+	cleareduser                bool
+	done                       bool
+	oldValue                   func(context.Context) (*PaymentOrder, error)
+	predicates                 []predicate.PaymentOrder
 }
 
 var _ ent.Mutation = (*PaymentOrderMutation)(nil)
@@ -20966,6 +20972,244 @@ func (m *PaymentOrderMutation) AddedFeeRate() (r float64, exists bool) {
 func (m *PaymentOrderMutation) ResetFeeRate() {
 	m.fee_rate = nil
 	m.addfee_rate = nil
+}
+
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (m *PaymentOrderMutation) SetAppliedRateMultiplier(f float64) {
+	m.applied_rate_multiplier = &f
+	m.addapplied_rate_multiplier = nil
+}
+
+// AppliedRateMultiplier returns the value of the "applied_rate_multiplier" field in the mutation.
+func (m *PaymentOrderMutation) AppliedRateMultiplier() (r float64, exists bool) {
+	v := m.applied_rate_multiplier
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldAppliedRateMultiplier returns the old "applied_rate_multiplier" field's value of the PaymentOrder entity.
+// If the PaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentOrderMutation) OldAppliedRateMultiplier(ctx context.Context) (v *float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldAppliedRateMultiplier is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldAppliedRateMultiplier requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldAppliedRateMultiplier: %w", err)
+	}
+	return oldValue.AppliedRateMultiplier, nil
+}
+
+// AddAppliedRateMultiplier adds f to the "applied_rate_multiplier" field.
+func (m *PaymentOrderMutation) AddAppliedRateMultiplier(f float64) {
+	if m.addapplied_rate_multiplier != nil {
+		*m.addapplied_rate_multiplier += f
+	} else {
+		m.addapplied_rate_multiplier = &f
+	}
+}
+
+// AddedAppliedRateMultiplier returns the value that was added to the "applied_rate_multiplier" field in this mutation.
+func (m *PaymentOrderMutation) AddedAppliedRateMultiplier() (r float64, exists bool) {
+	v := m.addapplied_rate_multiplier
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearAppliedRateMultiplier clears the value of the "applied_rate_multiplier" field.
+func (m *PaymentOrderMutation) ClearAppliedRateMultiplier() {
+	m.applied_rate_multiplier = nil
+	m.addapplied_rate_multiplier = nil
+	m.clearedFields[paymentorder.FieldAppliedRateMultiplier] = struct{}{}
+}
+
+// AppliedRateMultiplierCleared returns if the "applied_rate_multiplier" field was cleared in this mutation.
+func (m *PaymentOrderMutation) AppliedRateMultiplierCleared() bool {
+	_, ok := m.clearedFields[paymentorder.FieldAppliedRateMultiplier]
+	return ok
+}
+
+// ResetAppliedRateMultiplier resets all changes to the "applied_rate_multiplier" field.
+func (m *PaymentOrderMutation) ResetAppliedRateMultiplier() {
+	m.applied_rate_multiplier = nil
+	m.addapplied_rate_multiplier = nil
+	delete(m.clearedFields, paymentorder.FieldAppliedRateMultiplier)
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (m *PaymentOrderMutation) SetPricingTierLabel(s string) {
+	m.pricing_tier_label = &s
+}
+
+// PricingTierLabel returns the value of the "pricing_tier_label" field in the mutation.
+func (m *PaymentOrderMutation) PricingTierLabel() (r string, exists bool) {
+	v := m.pricing_tier_label
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPricingTierLabel returns the old "pricing_tier_label" field's value of the PaymentOrder entity.
+// If the PaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentOrderMutation) OldPricingTierLabel(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPricingTierLabel is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPricingTierLabel requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPricingTierLabel: %w", err)
+	}
+	return oldValue.PricingTierLabel, nil
+}
+
+// ClearPricingTierLabel clears the value of the "pricing_tier_label" field.
+func (m *PaymentOrderMutation) ClearPricingTierLabel() {
+	m.pricing_tier_label = nil
+	m.clearedFields[paymentorder.FieldPricingTierLabel] = struct{}{}
+}
+
+// PricingTierLabelCleared returns if the "pricing_tier_label" field was cleared in this mutation.
+func (m *PaymentOrderMutation) PricingTierLabelCleared() bool {
+	_, ok := m.clearedFields[paymentorder.FieldPricingTierLabel]
+	return ok
+}
+
+// ResetPricingTierLabel resets all changes to the "pricing_tier_label" field.
+func (m *PaymentOrderMutation) ResetPricingTierLabel() {
+	m.pricing_tier_label = nil
+	delete(m.clearedFields, paymentorder.FieldPricingTierLabel)
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (m *PaymentOrderMutation) SetPricingTierSnapshot(value map[string]interface{}) {
+	m.pricing_tier_snapshot = &value
+}
+
+// PricingTierSnapshot returns the value of the "pricing_tier_snapshot" field in the mutation.
+func (m *PaymentOrderMutation) PricingTierSnapshot() (r map[string]interface{}, exists bool) {
+	v := m.pricing_tier_snapshot
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldPricingTierSnapshot returns the old "pricing_tier_snapshot" field's value of the PaymentOrder entity.
+// If the PaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentOrderMutation) OldPricingTierSnapshot(ctx context.Context) (v map[string]interface{}, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldPricingTierSnapshot is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldPricingTierSnapshot requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldPricingTierSnapshot: %w", err)
+	}
+	return oldValue.PricingTierSnapshot, nil
+}
+
+// ClearPricingTierSnapshot clears the value of the "pricing_tier_snapshot" field.
+func (m *PaymentOrderMutation) ClearPricingTierSnapshot() {
+	m.pricing_tier_snapshot = nil
+	m.clearedFields[paymentorder.FieldPricingTierSnapshot] = struct{}{}
+}
+
+// PricingTierSnapshotCleared returns if the "pricing_tier_snapshot" field was cleared in this mutation.
+func (m *PaymentOrderMutation) PricingTierSnapshotCleared() bool {
+	_, ok := m.clearedFields[paymentorder.FieldPricingTierSnapshot]
+	return ok
+}
+
+// ResetPricingTierSnapshot resets all changes to the "pricing_tier_snapshot" field.
+func (m *PaymentOrderMutation) ResetPricingTierSnapshot() {
+	m.pricing_tier_snapshot = nil
+	delete(m.clearedFields, paymentorder.FieldPricingTierSnapshot)
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (m *PaymentOrderMutation) SetCreditedAmount(f float64) {
+	m.credited_amount = &f
+	m.addcredited_amount = nil
+}
+
+// CreditedAmount returns the value of the "credited_amount" field in the mutation.
+func (m *PaymentOrderMutation) CreditedAmount() (r float64, exists bool) {
+	v := m.credited_amount
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCreditedAmount returns the old "credited_amount" field's value of the PaymentOrder entity.
+// If the PaymentOrder object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *PaymentOrderMutation) OldCreditedAmount(ctx context.Context) (v *float64, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCreditedAmount is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCreditedAmount requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCreditedAmount: %w", err)
+	}
+	return oldValue.CreditedAmount, nil
+}
+
+// AddCreditedAmount adds f to the "credited_amount" field.
+func (m *PaymentOrderMutation) AddCreditedAmount(f float64) {
+	if m.addcredited_amount != nil {
+		*m.addcredited_amount += f
+	} else {
+		m.addcredited_amount = &f
+	}
+}
+
+// AddedCreditedAmount returns the value that was added to the "credited_amount" field in this mutation.
+func (m *PaymentOrderMutation) AddedCreditedAmount() (r float64, exists bool) {
+	v := m.addcredited_amount
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// ClearCreditedAmount clears the value of the "credited_amount" field.
+func (m *PaymentOrderMutation) ClearCreditedAmount() {
+	m.credited_amount = nil
+	m.addcredited_amount = nil
+	m.clearedFields[paymentorder.FieldCreditedAmount] = struct{}{}
+}
+
+// CreditedAmountCleared returns if the "credited_amount" field was cleared in this mutation.
+func (m *PaymentOrderMutation) CreditedAmountCleared() bool {
+	_, ok := m.clearedFields[paymentorder.FieldCreditedAmount]
+	return ok
+}
+
+// ResetCreditedAmount resets all changes to the "credited_amount" field.
+func (m *PaymentOrderMutation) ResetCreditedAmount() {
+	m.credited_amount = nil
+	m.addcredited_amount = nil
+	delete(m.clearedFields, paymentorder.FieldCreditedAmount)
 }
 
 // SetRechargeCode sets the "recharge_code" field.
@@ -22511,7 +22755,7 @@ func (m *PaymentOrderMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *PaymentOrderMutation) Fields() []string {
-	fields := make([]string, 0, 39)
+	fields := make([]string, 0, 43)
 	if m.user != nil {
 		fields = append(fields, paymentorder.FieldUserID)
 	}
@@ -22532,6 +22776,18 @@ func (m *PaymentOrderMutation) Fields() []string {
 	}
 	if m.fee_rate != nil {
 		fields = append(fields, paymentorder.FieldFeeRate)
+	}
+	if m.applied_rate_multiplier != nil {
+		fields = append(fields, paymentorder.FieldAppliedRateMultiplier)
+	}
+	if m.pricing_tier_label != nil {
+		fields = append(fields, paymentorder.FieldPricingTierLabel)
+	}
+	if m.pricing_tier_snapshot != nil {
+		fields = append(fields, paymentorder.FieldPricingTierSnapshot)
+	}
+	if m.credited_amount != nil {
+		fields = append(fields, paymentorder.FieldCreditedAmount)
 	}
 	if m.recharge_code != nil {
 		fields = append(fields, paymentorder.FieldRechargeCode)
@@ -22651,6 +22907,14 @@ func (m *PaymentOrderMutation) Field(name string) (ent.Value, bool) {
 		return m.PayAmount()
 	case paymentorder.FieldFeeRate:
 		return m.FeeRate()
+	case paymentorder.FieldAppliedRateMultiplier:
+		return m.AppliedRateMultiplier()
+	case paymentorder.FieldPricingTierLabel:
+		return m.PricingTierLabel()
+	case paymentorder.FieldPricingTierSnapshot:
+		return m.PricingTierSnapshot()
+	case paymentorder.FieldCreditedAmount:
+		return m.CreditedAmount()
 	case paymentorder.FieldRechargeCode:
 		return m.RechargeCode()
 	case paymentorder.FieldOutTradeNo:
@@ -22738,6 +23002,14 @@ func (m *PaymentOrderMutation) OldField(ctx context.Context, name string) (ent.V
 		return m.OldPayAmount(ctx)
 	case paymentorder.FieldFeeRate:
 		return m.OldFeeRate(ctx)
+	case paymentorder.FieldAppliedRateMultiplier:
+		return m.OldAppliedRateMultiplier(ctx)
+	case paymentorder.FieldPricingTierLabel:
+		return m.OldPricingTierLabel(ctx)
+	case paymentorder.FieldPricingTierSnapshot:
+		return m.OldPricingTierSnapshot(ctx)
+	case paymentorder.FieldCreditedAmount:
+		return m.OldCreditedAmount(ctx)
 	case paymentorder.FieldRechargeCode:
 		return m.OldRechargeCode(ctx)
 	case paymentorder.FieldOutTradeNo:
@@ -22859,6 +23131,34 @@ func (m *PaymentOrderMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetFeeRate(v)
+		return nil
+	case paymentorder.FieldAppliedRateMultiplier:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetAppliedRateMultiplier(v)
+		return nil
+	case paymentorder.FieldPricingTierLabel:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPricingTierLabel(v)
+		return nil
+	case paymentorder.FieldPricingTierSnapshot:
+		v, ok := value.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetPricingTierSnapshot(v)
+		return nil
+	case paymentorder.FieldCreditedAmount:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCreditedAmount(v)
 		return nil
 	case paymentorder.FieldRechargeCode:
 		v, ok := value.(string)
@@ -23101,6 +23401,12 @@ func (m *PaymentOrderMutation) AddedFields() []string {
 	if m.addfee_rate != nil {
 		fields = append(fields, paymentorder.FieldFeeRate)
 	}
+	if m.addapplied_rate_multiplier != nil {
+		fields = append(fields, paymentorder.FieldAppliedRateMultiplier)
+	}
+	if m.addcredited_amount != nil {
+		fields = append(fields, paymentorder.FieldCreditedAmount)
+	}
 	if m.addplan_id != nil {
 		fields = append(fields, paymentorder.FieldPlanID)
 	}
@@ -23127,6 +23433,10 @@ func (m *PaymentOrderMutation) AddedField(name string) (ent.Value, bool) {
 		return m.AddedPayAmount()
 	case paymentorder.FieldFeeRate:
 		return m.AddedFeeRate()
+	case paymentorder.FieldAppliedRateMultiplier:
+		return m.AddedAppliedRateMultiplier()
+	case paymentorder.FieldCreditedAmount:
+		return m.AddedCreditedAmount()
 	case paymentorder.FieldPlanID:
 		return m.AddedPlanID()
 	case paymentorder.FieldSubscriptionGroupID:
@@ -23164,6 +23474,20 @@ func (m *PaymentOrderMutation) AddField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.AddFeeRate(v)
+		return nil
+	case paymentorder.FieldAppliedRateMultiplier:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddAppliedRateMultiplier(v)
+		return nil
+	case paymentorder.FieldCreditedAmount:
+		v, ok := value.(float64)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.AddCreditedAmount(v)
 		return nil
 	case paymentorder.FieldPlanID:
 		v, ok := value.(int64)
@@ -23203,6 +23527,18 @@ func (m *PaymentOrderMutation) ClearedFields() []string {
 	var fields []string
 	if m.FieldCleared(paymentorder.FieldUserNotes) {
 		fields = append(fields, paymentorder.FieldUserNotes)
+	}
+	if m.FieldCleared(paymentorder.FieldAppliedRateMultiplier) {
+		fields = append(fields, paymentorder.FieldAppliedRateMultiplier)
+	}
+	if m.FieldCleared(paymentorder.FieldPricingTierLabel) {
+		fields = append(fields, paymentorder.FieldPricingTierLabel)
+	}
+	if m.FieldCleared(paymentorder.FieldPricingTierSnapshot) {
+		fields = append(fields, paymentorder.FieldPricingTierSnapshot)
+	}
+	if m.FieldCleared(paymentorder.FieldCreditedAmount) {
+		fields = append(fields, paymentorder.FieldCreditedAmount)
 	}
 	if m.FieldCleared(paymentorder.FieldPayURL) {
 		fields = append(fields, paymentorder.FieldPayURL)
@@ -23277,6 +23613,18 @@ func (m *PaymentOrderMutation) ClearField(name string) error {
 	switch name {
 	case paymentorder.FieldUserNotes:
 		m.ClearUserNotes()
+		return nil
+	case paymentorder.FieldAppliedRateMultiplier:
+		m.ClearAppliedRateMultiplier()
+		return nil
+	case paymentorder.FieldPricingTierLabel:
+		m.ClearPricingTierLabel()
+		return nil
+	case paymentorder.FieldPricingTierSnapshot:
+		m.ClearPricingTierSnapshot()
+		return nil
+	case paymentorder.FieldCreditedAmount:
+		m.ClearCreditedAmount()
 		return nil
 	case paymentorder.FieldPayURL:
 		m.ClearPayURL()
@@ -23363,6 +23711,18 @@ func (m *PaymentOrderMutation) ResetField(name string) error {
 		return nil
 	case paymentorder.FieldFeeRate:
 		m.ResetFeeRate()
+		return nil
+	case paymentorder.FieldAppliedRateMultiplier:
+		m.ResetAppliedRateMultiplier()
+		return nil
+	case paymentorder.FieldPricingTierLabel:
+		m.ResetPricingTierLabel()
+		return nil
+	case paymentorder.FieldPricingTierSnapshot:
+		m.ResetPricingTierSnapshot()
+		return nil
+	case paymentorder.FieldCreditedAmount:
+		m.ResetCreditedAmount()
 		return nil
 	case paymentorder.FieldRechargeCode:
 		m.ResetRechargeCode()
@@ -30834,8 +31194,8 @@ type SubscriptionPlanMutation struct {
 	addprice          *float64
 	original_price    *float64
 	addoriginal_price *float64
-	validity_days     *int
-	addvalidity_days  *int
+	validity_days     *float64
+	addvalidity_days  *float64
 	validity_unit     *string
 	features          *string
 	product_name      *string
@@ -31203,13 +31563,13 @@ func (m *SubscriptionPlanMutation) ResetOriginalPrice() {
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (m *SubscriptionPlanMutation) SetValidityDays(i int) {
-	m.validity_days = &i
+func (m *SubscriptionPlanMutation) SetValidityDays(f float64) {
+	m.validity_days = &f
 	m.addvalidity_days = nil
 }
 
 // ValidityDays returns the value of the "validity_days" field in the mutation.
-func (m *SubscriptionPlanMutation) ValidityDays() (r int, exists bool) {
+func (m *SubscriptionPlanMutation) ValidityDays() (r float64, exists bool) {
 	v := m.validity_days
 	if v == nil {
 		return
@@ -31220,7 +31580,7 @@ func (m *SubscriptionPlanMutation) ValidityDays() (r int, exists bool) {
 // OldValidityDays returns the old "validity_days" field's value of the SubscriptionPlan entity.
 // If the SubscriptionPlan object wasn't provided to the builder, the object is fetched from the database.
 // An error is returned if the mutation operation is not UpdateOne, or the database query fails.
-func (m *SubscriptionPlanMutation) OldValidityDays(ctx context.Context) (v int, err error) {
+func (m *SubscriptionPlanMutation) OldValidityDays(ctx context.Context) (v float64, err error) {
 	if !m.op.Is(OpUpdateOne) {
 		return v, errors.New("OldValidityDays is only allowed on UpdateOne operations")
 	}
@@ -31234,17 +31594,17 @@ func (m *SubscriptionPlanMutation) OldValidityDays(ctx context.Context) (v int, 
 	return oldValue.ValidityDays, nil
 }
 
-// AddValidityDays adds i to the "validity_days" field.
-func (m *SubscriptionPlanMutation) AddValidityDays(i int) {
+// AddValidityDays adds f to the "validity_days" field.
+func (m *SubscriptionPlanMutation) AddValidityDays(f float64) {
 	if m.addvalidity_days != nil {
-		*m.addvalidity_days += i
+		*m.addvalidity_days += f
 	} else {
-		m.addvalidity_days = &i
+		m.addvalidity_days = &f
 	}
 }
 
 // AddedValidityDays returns the value that was added to the "validity_days" field in this mutation.
-func (m *SubscriptionPlanMutation) AddedValidityDays() (r int, exists bool) {
+func (m *SubscriptionPlanMutation) AddedValidityDays() (r float64, exists bool) {
 	v := m.addvalidity_days
 	if v == nil {
 		return
@@ -31718,7 +32078,7 @@ func (m *SubscriptionPlanMutation) SetField(name string, value ent.Value) error 
 		m.SetOriginalPrice(v)
 		return nil
 	case subscriptionplan.FieldValidityDays:
-		v, ok := value.(int)
+		v, ok := value.(float64)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
@@ -31845,7 +32205,7 @@ func (m *SubscriptionPlanMutation) AddField(name string, value ent.Value) error 
 		m.AddOriginalPrice(v)
 		return nil
 	case subscriptionplan.FieldValidityDays:
-		v, ok := value.(int)
+		v, ok := value.(float64)
 		if !ok {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}

--- a/backend/ent/paymentorder.go
+++ b/backend/ent/paymentorder.go
@@ -33,6 +33,14 @@ type PaymentOrder struct {
 	PayAmount float64 `json:"pay_amount,omitempty"`
 	// FeeRate holds the value of the "fee_rate" field.
 	FeeRate float64 `json:"fee_rate,omitempty"`
+	// AppliedRateMultiplier holds the value of the "applied_rate_multiplier" field.
+	AppliedRateMultiplier *float64 `json:"applied_rate_multiplier,omitempty"`
+	// PricingTierLabel holds the value of the "pricing_tier_label" field.
+	PricingTierLabel *string `json:"pricing_tier_label,omitempty"`
+	// PricingTierSnapshot holds the value of the "pricing_tier_snapshot" field.
+	PricingTierSnapshot map[string]interface{} `json:"pricing_tier_snapshot,omitempty"`
+	// CreditedAmount holds the value of the "credited_amount" field.
+	CreditedAmount *float64 `json:"credited_amount,omitempty"`
 	// RechargeCode holds the value of the "recharge_code" field.
 	RechargeCode string `json:"recharge_code,omitempty"`
 	// OutTradeNo holds the value of the "out_trade_no" field.
@@ -128,15 +136,15 @@ func (*PaymentOrder) scanValues(columns []string) ([]any, error) {
 	values := make([]any, len(columns))
 	for i := range columns {
 		switch columns[i] {
-		case paymentorder.FieldProviderSnapshot:
+		case paymentorder.FieldPricingTierSnapshot, paymentorder.FieldProviderSnapshot:
 			values[i] = new([]byte)
 		case paymentorder.FieldForceRefund:
 			values[i] = new(sql.NullBool)
-		case paymentorder.FieldAmount, paymentorder.FieldPayAmount, paymentorder.FieldFeeRate, paymentorder.FieldRefundAmount:
+		case paymentorder.FieldAmount, paymentorder.FieldPayAmount, paymentorder.FieldFeeRate, paymentorder.FieldAppliedRateMultiplier, paymentorder.FieldCreditedAmount, paymentorder.FieldRefundAmount:
 			values[i] = new(sql.NullFloat64)
 		case paymentorder.FieldID, paymentorder.FieldUserID, paymentorder.FieldPlanID, paymentorder.FieldSubscriptionGroupID, paymentorder.FieldSubscriptionDays:
 			values[i] = new(sql.NullInt64)
-		case paymentorder.FieldUserEmail, paymentorder.FieldUserName, paymentorder.FieldUserNotes, paymentorder.FieldRechargeCode, paymentorder.FieldOutTradeNo, paymentorder.FieldPaymentType, paymentorder.FieldPaymentTradeNo, paymentorder.FieldPayURL, paymentorder.FieldQrCode, paymentorder.FieldQrCodeImg, paymentorder.FieldOrderType, paymentorder.FieldProviderInstanceID, paymentorder.FieldProviderKey, paymentorder.FieldStatus, paymentorder.FieldRefundReason, paymentorder.FieldRefundRequestReason, paymentorder.FieldRefundRequestedBy, paymentorder.FieldFailedReason, paymentorder.FieldClientIP, paymentorder.FieldSrcHost, paymentorder.FieldSrcURL:
+		case paymentorder.FieldUserEmail, paymentorder.FieldUserName, paymentorder.FieldUserNotes, paymentorder.FieldPricingTierLabel, paymentorder.FieldRechargeCode, paymentorder.FieldOutTradeNo, paymentorder.FieldPaymentType, paymentorder.FieldPaymentTradeNo, paymentorder.FieldPayURL, paymentorder.FieldQrCode, paymentorder.FieldQrCodeImg, paymentorder.FieldOrderType, paymentorder.FieldProviderInstanceID, paymentorder.FieldProviderKey, paymentorder.FieldStatus, paymentorder.FieldRefundReason, paymentorder.FieldRefundRequestReason, paymentorder.FieldRefundRequestedBy, paymentorder.FieldFailedReason, paymentorder.FieldClientIP, paymentorder.FieldSrcHost, paymentorder.FieldSrcURL:
 			values[i] = new(sql.NullString)
 		case paymentorder.FieldRefundAt, paymentorder.FieldRefundRequestedAt, paymentorder.FieldExpiresAt, paymentorder.FieldPaidAt, paymentorder.FieldCompletedAt, paymentorder.FieldFailedAt, paymentorder.FieldCreatedAt, paymentorder.FieldUpdatedAt:
 			values[i] = new(sql.NullTime)
@@ -203,6 +211,35 @@ func (_m *PaymentOrder) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field fee_rate", values[i])
 			} else if value.Valid {
 				_m.FeeRate = value.Float64
+			}
+		case paymentorder.FieldAppliedRateMultiplier:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field applied_rate_multiplier", values[i])
+			} else if value.Valid {
+				_m.AppliedRateMultiplier = new(float64)
+				*_m.AppliedRateMultiplier = value.Float64
+			}
+		case paymentorder.FieldPricingTierLabel:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field pricing_tier_label", values[i])
+			} else if value.Valid {
+				_m.PricingTierLabel = new(string)
+				*_m.PricingTierLabel = value.String
+			}
+		case paymentorder.FieldPricingTierSnapshot:
+			if value, ok := values[i].(*[]byte); !ok {
+				return fmt.Errorf("unexpected type %T for field pricing_tier_snapshot", values[i])
+			} else if value != nil && len(*value) > 0 {
+				if err := json.Unmarshal(*value, &_m.PricingTierSnapshot); err != nil {
+					return fmt.Errorf("unmarshal field pricing_tier_snapshot: %w", err)
+				}
+			}
+		case paymentorder.FieldCreditedAmount:
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
+				return fmt.Errorf("unexpected type %T for field credited_amount", values[i])
+			} else if value.Valid {
+				_m.CreditedAmount = new(float64)
+				*_m.CreditedAmount = value.Float64
 			}
 		case paymentorder.FieldRechargeCode:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -479,6 +516,24 @@ func (_m *PaymentOrder) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("fee_rate=")
 	builder.WriteString(fmt.Sprintf("%v", _m.FeeRate))
+	builder.WriteString(", ")
+	if v := _m.AppliedRateMultiplier; v != nil {
+		builder.WriteString("applied_rate_multiplier=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
+	builder.WriteString(", ")
+	if v := _m.PricingTierLabel; v != nil {
+		builder.WriteString("pricing_tier_label=")
+		builder.WriteString(*v)
+	}
+	builder.WriteString(", ")
+	builder.WriteString("pricing_tier_snapshot=")
+	builder.WriteString(fmt.Sprintf("%v", _m.PricingTierSnapshot))
+	builder.WriteString(", ")
+	if v := _m.CreditedAmount; v != nil {
+		builder.WriteString("credited_amount=")
+		builder.WriteString(fmt.Sprintf("%v", *v))
+	}
 	builder.WriteString(", ")
 	builder.WriteString("recharge_code=")
 	builder.WriteString(_m.RechargeCode)

--- a/backend/ent/paymentorder/paymentorder.go
+++ b/backend/ent/paymentorder/paymentorder.go
@@ -28,6 +28,14 @@ const (
 	FieldPayAmount = "pay_amount"
 	// FieldFeeRate holds the string denoting the fee_rate field in the database.
 	FieldFeeRate = "fee_rate"
+	// FieldAppliedRateMultiplier holds the string denoting the applied_rate_multiplier field in the database.
+	FieldAppliedRateMultiplier = "applied_rate_multiplier"
+	// FieldPricingTierLabel holds the string denoting the pricing_tier_label field in the database.
+	FieldPricingTierLabel = "pricing_tier_label"
+	// FieldPricingTierSnapshot holds the string denoting the pricing_tier_snapshot field in the database.
+	FieldPricingTierSnapshot = "pricing_tier_snapshot"
+	// FieldCreditedAmount holds the string denoting the credited_amount field in the database.
+	FieldCreditedAmount = "credited_amount"
 	// FieldRechargeCode holds the string denoting the recharge_code field in the database.
 	FieldRechargeCode = "recharge_code"
 	// FieldOutTradeNo holds the string denoting the out_trade_no field in the database.
@@ -115,6 +123,10 @@ var Columns = []string{
 	FieldAmount,
 	FieldPayAmount,
 	FieldFeeRate,
+	FieldAppliedRateMultiplier,
+	FieldPricingTierLabel,
+	FieldPricingTierSnapshot,
+	FieldCreditedAmount,
 	FieldRechargeCode,
 	FieldOutTradeNo,
 	FieldPaymentType,
@@ -166,6 +178,8 @@ var (
 	UserNameValidator func(string) error
 	// DefaultFeeRate holds the default value on creation for the "fee_rate" field.
 	DefaultFeeRate float64
+	// PricingTierLabelValidator is a validator for the "pricing_tier_label" field. It is called by the builders before save.
+	PricingTierLabelValidator func(string) error
 	// RechargeCodeValidator is a validator for the "recharge_code" field. It is called by the builders before save.
 	RechargeCodeValidator func(string) error
 	// DefaultOutTradeNo holds the default value on creation for the "out_trade_no" field.
@@ -247,6 +261,21 @@ func ByPayAmount(opts ...sql.OrderTermOption) OrderOption {
 // ByFeeRate orders the results by the fee_rate field.
 func ByFeeRate(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldFeeRate, opts...).ToFunc()
+}
+
+// ByAppliedRateMultiplier orders the results by the applied_rate_multiplier field.
+func ByAppliedRateMultiplier(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldAppliedRateMultiplier, opts...).ToFunc()
+}
+
+// ByPricingTierLabel orders the results by the pricing_tier_label field.
+func ByPricingTierLabel(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldPricingTierLabel, opts...).ToFunc()
+}
+
+// ByCreditedAmount orders the results by the credited_amount field.
+func ByCreditedAmount(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCreditedAmount, opts...).ToFunc()
 }
 
 // ByRechargeCode orders the results by the recharge_code field.

--- a/backend/ent/paymentorder/where.go
+++ b/backend/ent/paymentorder/where.go
@@ -90,6 +90,21 @@ func FeeRate(v float64) predicate.PaymentOrder {
 	return predicate.PaymentOrder(sql.FieldEQ(FieldFeeRate, v))
 }
 
+// AppliedRateMultiplier applies equality check predicate on the "applied_rate_multiplier" field. It's identical to AppliedRateMultiplierEQ.
+func AppliedRateMultiplier(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldAppliedRateMultiplier, v))
+}
+
+// PricingTierLabel applies equality check predicate on the "pricing_tier_label" field. It's identical to PricingTierLabelEQ.
+func PricingTierLabel(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldPricingTierLabel, v))
+}
+
+// CreditedAmount applies equality check predicate on the "credited_amount" field. It's identical to CreditedAmountEQ.
+func CreditedAmount(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldCreditedAmount, v))
+}
+
 // RechargeCode applies equality check predicate on the "recharge_code" field. It's identical to RechargeCodeEQ.
 func RechargeCode(v string) predicate.PaymentOrder {
 	return predicate.PaymentOrder(sql.FieldEQ(FieldRechargeCode, v))
@@ -588,6 +603,191 @@ func FeeRateLT(v float64) predicate.PaymentOrder {
 // FeeRateLTE applies the LTE predicate on the "fee_rate" field.
 func FeeRateLTE(v float64) predicate.PaymentOrder {
 	return predicate.PaymentOrder(sql.FieldLTE(FieldFeeRate, v))
+}
+
+// AppliedRateMultiplierEQ applies the EQ predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierEQ(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldAppliedRateMultiplier, v))
+}
+
+// AppliedRateMultiplierNEQ applies the NEQ predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierNEQ(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNEQ(FieldAppliedRateMultiplier, v))
+}
+
+// AppliedRateMultiplierIn applies the In predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierIn(vs ...float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIn(FieldAppliedRateMultiplier, vs...))
+}
+
+// AppliedRateMultiplierNotIn applies the NotIn predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierNotIn(vs ...float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotIn(FieldAppliedRateMultiplier, vs...))
+}
+
+// AppliedRateMultiplierGT applies the GT predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierGT(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGT(FieldAppliedRateMultiplier, v))
+}
+
+// AppliedRateMultiplierGTE applies the GTE predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierGTE(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGTE(FieldAppliedRateMultiplier, v))
+}
+
+// AppliedRateMultiplierLT applies the LT predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierLT(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLT(FieldAppliedRateMultiplier, v))
+}
+
+// AppliedRateMultiplierLTE applies the LTE predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierLTE(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLTE(FieldAppliedRateMultiplier, v))
+}
+
+// AppliedRateMultiplierIsNil applies the IsNil predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierIsNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIsNull(FieldAppliedRateMultiplier))
+}
+
+// AppliedRateMultiplierNotNil applies the NotNil predicate on the "applied_rate_multiplier" field.
+func AppliedRateMultiplierNotNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotNull(FieldAppliedRateMultiplier))
+}
+
+// PricingTierLabelEQ applies the EQ predicate on the "pricing_tier_label" field.
+func PricingTierLabelEQ(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelNEQ applies the NEQ predicate on the "pricing_tier_label" field.
+func PricingTierLabelNEQ(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNEQ(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelIn applies the In predicate on the "pricing_tier_label" field.
+func PricingTierLabelIn(vs ...string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIn(FieldPricingTierLabel, vs...))
+}
+
+// PricingTierLabelNotIn applies the NotIn predicate on the "pricing_tier_label" field.
+func PricingTierLabelNotIn(vs ...string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotIn(FieldPricingTierLabel, vs...))
+}
+
+// PricingTierLabelGT applies the GT predicate on the "pricing_tier_label" field.
+func PricingTierLabelGT(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGT(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelGTE applies the GTE predicate on the "pricing_tier_label" field.
+func PricingTierLabelGTE(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGTE(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelLT applies the LT predicate on the "pricing_tier_label" field.
+func PricingTierLabelLT(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLT(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelLTE applies the LTE predicate on the "pricing_tier_label" field.
+func PricingTierLabelLTE(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLTE(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelContains applies the Contains predicate on the "pricing_tier_label" field.
+func PricingTierLabelContains(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldContains(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelHasPrefix applies the HasPrefix predicate on the "pricing_tier_label" field.
+func PricingTierLabelHasPrefix(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldHasPrefix(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelHasSuffix applies the HasSuffix predicate on the "pricing_tier_label" field.
+func PricingTierLabelHasSuffix(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldHasSuffix(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelIsNil applies the IsNil predicate on the "pricing_tier_label" field.
+func PricingTierLabelIsNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIsNull(FieldPricingTierLabel))
+}
+
+// PricingTierLabelNotNil applies the NotNil predicate on the "pricing_tier_label" field.
+func PricingTierLabelNotNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotNull(FieldPricingTierLabel))
+}
+
+// PricingTierLabelEqualFold applies the EqualFold predicate on the "pricing_tier_label" field.
+func PricingTierLabelEqualFold(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEqualFold(FieldPricingTierLabel, v))
+}
+
+// PricingTierLabelContainsFold applies the ContainsFold predicate on the "pricing_tier_label" field.
+func PricingTierLabelContainsFold(v string) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldContainsFold(FieldPricingTierLabel, v))
+}
+
+// PricingTierSnapshotIsNil applies the IsNil predicate on the "pricing_tier_snapshot" field.
+func PricingTierSnapshotIsNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIsNull(FieldPricingTierSnapshot))
+}
+
+// PricingTierSnapshotNotNil applies the NotNil predicate on the "pricing_tier_snapshot" field.
+func PricingTierSnapshotNotNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotNull(FieldPricingTierSnapshot))
+}
+
+// CreditedAmountEQ applies the EQ predicate on the "credited_amount" field.
+func CreditedAmountEQ(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldEQ(FieldCreditedAmount, v))
+}
+
+// CreditedAmountNEQ applies the NEQ predicate on the "credited_amount" field.
+func CreditedAmountNEQ(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNEQ(FieldCreditedAmount, v))
+}
+
+// CreditedAmountIn applies the In predicate on the "credited_amount" field.
+func CreditedAmountIn(vs ...float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIn(FieldCreditedAmount, vs...))
+}
+
+// CreditedAmountNotIn applies the NotIn predicate on the "credited_amount" field.
+func CreditedAmountNotIn(vs ...float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotIn(FieldCreditedAmount, vs...))
+}
+
+// CreditedAmountGT applies the GT predicate on the "credited_amount" field.
+func CreditedAmountGT(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGT(FieldCreditedAmount, v))
+}
+
+// CreditedAmountGTE applies the GTE predicate on the "credited_amount" field.
+func CreditedAmountGTE(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldGTE(FieldCreditedAmount, v))
+}
+
+// CreditedAmountLT applies the LT predicate on the "credited_amount" field.
+func CreditedAmountLT(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLT(FieldCreditedAmount, v))
+}
+
+// CreditedAmountLTE applies the LTE predicate on the "credited_amount" field.
+func CreditedAmountLTE(v float64) predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldLTE(FieldCreditedAmount, v))
+}
+
+// CreditedAmountIsNil applies the IsNil predicate on the "credited_amount" field.
+func CreditedAmountIsNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldIsNull(FieldCreditedAmount))
+}
+
+// CreditedAmountNotNil applies the NotNil predicate on the "credited_amount" field.
+func CreditedAmountNotNil() predicate.PaymentOrder {
+	return predicate.PaymentOrder(sql.FieldNotNull(FieldCreditedAmount))
 }
 
 // RechargeCodeEQ applies the EQ predicate on the "recharge_code" field.

--- a/backend/ent/paymentorder_create.go
+++ b/backend/ent/paymentorder_create.go
@@ -81,6 +81,54 @@ func (_c *PaymentOrderCreate) SetNillableFeeRate(v *float64) *PaymentOrderCreate
 	return _c
 }
 
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (_c *PaymentOrderCreate) SetAppliedRateMultiplier(v float64) *PaymentOrderCreate {
+	_c.mutation.SetAppliedRateMultiplier(v)
+	return _c
+}
+
+// SetNillableAppliedRateMultiplier sets the "applied_rate_multiplier" field if the given value is not nil.
+func (_c *PaymentOrderCreate) SetNillableAppliedRateMultiplier(v *float64) *PaymentOrderCreate {
+	if v != nil {
+		_c.SetAppliedRateMultiplier(*v)
+	}
+	return _c
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (_c *PaymentOrderCreate) SetPricingTierLabel(v string) *PaymentOrderCreate {
+	_c.mutation.SetPricingTierLabel(v)
+	return _c
+}
+
+// SetNillablePricingTierLabel sets the "pricing_tier_label" field if the given value is not nil.
+func (_c *PaymentOrderCreate) SetNillablePricingTierLabel(v *string) *PaymentOrderCreate {
+	if v != nil {
+		_c.SetPricingTierLabel(*v)
+	}
+	return _c
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (_c *PaymentOrderCreate) SetPricingTierSnapshot(v map[string]interface{}) *PaymentOrderCreate {
+	_c.mutation.SetPricingTierSnapshot(v)
+	return _c
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (_c *PaymentOrderCreate) SetCreditedAmount(v float64) *PaymentOrderCreate {
+	_c.mutation.SetCreditedAmount(v)
+	return _c
+}
+
+// SetNillableCreditedAmount sets the "credited_amount" field if the given value is not nil.
+func (_c *PaymentOrderCreate) SetNillableCreditedAmount(v *float64) *PaymentOrderCreate {
+	if v != nil {
+		_c.SetCreditedAmount(*v)
+	}
+	return _c
+}
+
 // SetRechargeCode sets the "recharge_code" field.
 func (_c *PaymentOrderCreate) SetRechargeCode(v string) *PaymentOrderCreate {
 	_c.mutation.SetRechargeCode(v)
@@ -577,6 +625,11 @@ func (_c *PaymentOrderCreate) check() error {
 	if _, ok := _c.mutation.FeeRate(); !ok {
 		return &ValidationError{Name: "fee_rate", err: errors.New(`ent: missing required field "PaymentOrder.fee_rate"`)}
 	}
+	if v, ok := _c.mutation.PricingTierLabel(); ok {
+		if err := paymentorder.PricingTierLabelValidator(v); err != nil {
+			return &ValidationError{Name: "pricing_tier_label", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.pricing_tier_label": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.RechargeCode(); !ok {
 		return &ValidationError{Name: "recharge_code", err: errors.New(`ent: missing required field "PaymentOrder.recharge_code"`)}
 	}
@@ -724,6 +777,22 @@ func (_c *PaymentOrderCreate) createSpec() (*PaymentOrder, *sqlgraph.CreateSpec)
 	if value, ok := _c.mutation.FeeRate(); ok {
 		_spec.SetField(paymentorder.FieldFeeRate, field.TypeFloat64, value)
 		_node.FeeRate = value
+	}
+	if value, ok := _c.mutation.AppliedRateMultiplier(); ok {
+		_spec.SetField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64, value)
+		_node.AppliedRateMultiplier = &value
+	}
+	if value, ok := _c.mutation.PricingTierLabel(); ok {
+		_spec.SetField(paymentorder.FieldPricingTierLabel, field.TypeString, value)
+		_node.PricingTierLabel = &value
+	}
+	if value, ok := _c.mutation.PricingTierSnapshot(); ok {
+		_spec.SetField(paymentorder.FieldPricingTierSnapshot, field.TypeJSON, value)
+		_node.PricingTierSnapshot = value
+	}
+	if value, ok := _c.mutation.CreditedAmount(); ok {
+		_spec.SetField(paymentorder.FieldCreditedAmount, field.TypeFloat64, value)
+		_node.CreditedAmount = &value
 	}
 	if value, ok := _c.mutation.RechargeCode(); ok {
 		_spec.SetField(paymentorder.FieldRechargeCode, field.TypeString, value)
@@ -1027,6 +1096,90 @@ func (u *PaymentOrderUpsert) UpdateFeeRate() *PaymentOrderUpsert {
 // AddFeeRate adds v to the "fee_rate" field.
 func (u *PaymentOrderUpsert) AddFeeRate(v float64) *PaymentOrderUpsert {
 	u.Add(paymentorder.FieldFeeRate, v)
+	return u
+}
+
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsert) SetAppliedRateMultiplier(v float64) *PaymentOrderUpsert {
+	u.Set(paymentorder.FieldAppliedRateMultiplier, v)
+	return u
+}
+
+// UpdateAppliedRateMultiplier sets the "applied_rate_multiplier" field to the value that was provided on create.
+func (u *PaymentOrderUpsert) UpdateAppliedRateMultiplier() *PaymentOrderUpsert {
+	u.SetExcluded(paymentorder.FieldAppliedRateMultiplier)
+	return u
+}
+
+// AddAppliedRateMultiplier adds v to the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsert) AddAppliedRateMultiplier(v float64) *PaymentOrderUpsert {
+	u.Add(paymentorder.FieldAppliedRateMultiplier, v)
+	return u
+}
+
+// ClearAppliedRateMultiplier clears the value of the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsert) ClearAppliedRateMultiplier() *PaymentOrderUpsert {
+	u.SetNull(paymentorder.FieldAppliedRateMultiplier)
+	return u
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (u *PaymentOrderUpsert) SetPricingTierLabel(v string) *PaymentOrderUpsert {
+	u.Set(paymentorder.FieldPricingTierLabel, v)
+	return u
+}
+
+// UpdatePricingTierLabel sets the "pricing_tier_label" field to the value that was provided on create.
+func (u *PaymentOrderUpsert) UpdatePricingTierLabel() *PaymentOrderUpsert {
+	u.SetExcluded(paymentorder.FieldPricingTierLabel)
+	return u
+}
+
+// ClearPricingTierLabel clears the value of the "pricing_tier_label" field.
+func (u *PaymentOrderUpsert) ClearPricingTierLabel() *PaymentOrderUpsert {
+	u.SetNull(paymentorder.FieldPricingTierLabel)
+	return u
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (u *PaymentOrderUpsert) SetPricingTierSnapshot(v map[string]interface{}) *PaymentOrderUpsert {
+	u.Set(paymentorder.FieldPricingTierSnapshot, v)
+	return u
+}
+
+// UpdatePricingTierSnapshot sets the "pricing_tier_snapshot" field to the value that was provided on create.
+func (u *PaymentOrderUpsert) UpdatePricingTierSnapshot() *PaymentOrderUpsert {
+	u.SetExcluded(paymentorder.FieldPricingTierSnapshot)
+	return u
+}
+
+// ClearPricingTierSnapshot clears the value of the "pricing_tier_snapshot" field.
+func (u *PaymentOrderUpsert) ClearPricingTierSnapshot() *PaymentOrderUpsert {
+	u.SetNull(paymentorder.FieldPricingTierSnapshot)
+	return u
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (u *PaymentOrderUpsert) SetCreditedAmount(v float64) *PaymentOrderUpsert {
+	u.Set(paymentorder.FieldCreditedAmount, v)
+	return u
+}
+
+// UpdateCreditedAmount sets the "credited_amount" field to the value that was provided on create.
+func (u *PaymentOrderUpsert) UpdateCreditedAmount() *PaymentOrderUpsert {
+	u.SetExcluded(paymentorder.FieldCreditedAmount)
+	return u
+}
+
+// AddCreditedAmount adds v to the "credited_amount" field.
+func (u *PaymentOrderUpsert) AddCreditedAmount(v float64) *PaymentOrderUpsert {
+	u.Add(paymentorder.FieldCreditedAmount, v)
+	return u
+}
+
+// ClearCreditedAmount clears the value of the "credited_amount" field.
+func (u *PaymentOrderUpsert) ClearCreditedAmount() *PaymentOrderUpsert {
+	u.SetNull(paymentorder.FieldCreditedAmount)
 	return u
 }
 
@@ -1708,6 +1861,104 @@ func (u *PaymentOrderUpsertOne) AddFeeRate(v float64) *PaymentOrderUpsertOne {
 func (u *PaymentOrderUpsertOne) UpdateFeeRate() *PaymentOrderUpsertOne {
 	return u.Update(func(s *PaymentOrderUpsert) {
 		s.UpdateFeeRate()
+	})
+}
+
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsertOne) SetAppliedRateMultiplier(v float64) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetAppliedRateMultiplier(v)
+	})
+}
+
+// AddAppliedRateMultiplier adds v to the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsertOne) AddAppliedRateMultiplier(v float64) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.AddAppliedRateMultiplier(v)
+	})
+}
+
+// UpdateAppliedRateMultiplier sets the "applied_rate_multiplier" field to the value that was provided on create.
+func (u *PaymentOrderUpsertOne) UpdateAppliedRateMultiplier() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdateAppliedRateMultiplier()
+	})
+}
+
+// ClearAppliedRateMultiplier clears the value of the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsertOne) ClearAppliedRateMultiplier() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearAppliedRateMultiplier()
+	})
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (u *PaymentOrderUpsertOne) SetPricingTierLabel(v string) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetPricingTierLabel(v)
+	})
+}
+
+// UpdatePricingTierLabel sets the "pricing_tier_label" field to the value that was provided on create.
+func (u *PaymentOrderUpsertOne) UpdatePricingTierLabel() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdatePricingTierLabel()
+	})
+}
+
+// ClearPricingTierLabel clears the value of the "pricing_tier_label" field.
+func (u *PaymentOrderUpsertOne) ClearPricingTierLabel() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearPricingTierLabel()
+	})
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (u *PaymentOrderUpsertOne) SetPricingTierSnapshot(v map[string]interface{}) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetPricingTierSnapshot(v)
+	})
+}
+
+// UpdatePricingTierSnapshot sets the "pricing_tier_snapshot" field to the value that was provided on create.
+func (u *PaymentOrderUpsertOne) UpdatePricingTierSnapshot() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdatePricingTierSnapshot()
+	})
+}
+
+// ClearPricingTierSnapshot clears the value of the "pricing_tier_snapshot" field.
+func (u *PaymentOrderUpsertOne) ClearPricingTierSnapshot() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearPricingTierSnapshot()
+	})
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (u *PaymentOrderUpsertOne) SetCreditedAmount(v float64) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetCreditedAmount(v)
+	})
+}
+
+// AddCreditedAmount adds v to the "credited_amount" field.
+func (u *PaymentOrderUpsertOne) AddCreditedAmount(v float64) *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.AddCreditedAmount(v)
+	})
+}
+
+// UpdateCreditedAmount sets the "credited_amount" field to the value that was provided on create.
+func (u *PaymentOrderUpsertOne) UpdateCreditedAmount() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdateCreditedAmount()
+	})
+}
+
+// ClearCreditedAmount clears the value of the "credited_amount" field.
+func (u *PaymentOrderUpsertOne) ClearCreditedAmount() *PaymentOrderUpsertOne {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearCreditedAmount()
 	})
 }
 
@@ -2640,6 +2891,104 @@ func (u *PaymentOrderUpsertBulk) AddFeeRate(v float64) *PaymentOrderUpsertBulk {
 func (u *PaymentOrderUpsertBulk) UpdateFeeRate() *PaymentOrderUpsertBulk {
 	return u.Update(func(s *PaymentOrderUpsert) {
 		s.UpdateFeeRate()
+	})
+}
+
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsertBulk) SetAppliedRateMultiplier(v float64) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetAppliedRateMultiplier(v)
+	})
+}
+
+// AddAppliedRateMultiplier adds v to the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsertBulk) AddAppliedRateMultiplier(v float64) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.AddAppliedRateMultiplier(v)
+	})
+}
+
+// UpdateAppliedRateMultiplier sets the "applied_rate_multiplier" field to the value that was provided on create.
+func (u *PaymentOrderUpsertBulk) UpdateAppliedRateMultiplier() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdateAppliedRateMultiplier()
+	})
+}
+
+// ClearAppliedRateMultiplier clears the value of the "applied_rate_multiplier" field.
+func (u *PaymentOrderUpsertBulk) ClearAppliedRateMultiplier() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearAppliedRateMultiplier()
+	})
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (u *PaymentOrderUpsertBulk) SetPricingTierLabel(v string) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetPricingTierLabel(v)
+	})
+}
+
+// UpdatePricingTierLabel sets the "pricing_tier_label" field to the value that was provided on create.
+func (u *PaymentOrderUpsertBulk) UpdatePricingTierLabel() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdatePricingTierLabel()
+	})
+}
+
+// ClearPricingTierLabel clears the value of the "pricing_tier_label" field.
+func (u *PaymentOrderUpsertBulk) ClearPricingTierLabel() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearPricingTierLabel()
+	})
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (u *PaymentOrderUpsertBulk) SetPricingTierSnapshot(v map[string]interface{}) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetPricingTierSnapshot(v)
+	})
+}
+
+// UpdatePricingTierSnapshot sets the "pricing_tier_snapshot" field to the value that was provided on create.
+func (u *PaymentOrderUpsertBulk) UpdatePricingTierSnapshot() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdatePricingTierSnapshot()
+	})
+}
+
+// ClearPricingTierSnapshot clears the value of the "pricing_tier_snapshot" field.
+func (u *PaymentOrderUpsertBulk) ClearPricingTierSnapshot() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearPricingTierSnapshot()
+	})
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (u *PaymentOrderUpsertBulk) SetCreditedAmount(v float64) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.SetCreditedAmount(v)
+	})
+}
+
+// AddCreditedAmount adds v to the "credited_amount" field.
+func (u *PaymentOrderUpsertBulk) AddCreditedAmount(v float64) *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.AddCreditedAmount(v)
+	})
+}
+
+// UpdateCreditedAmount sets the "credited_amount" field to the value that was provided on create.
+func (u *PaymentOrderUpsertBulk) UpdateCreditedAmount() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.UpdateCreditedAmount()
+	})
+}
+
+// ClearCreditedAmount clears the value of the "credited_amount" field.
+func (u *PaymentOrderUpsertBulk) ClearCreditedAmount() *PaymentOrderUpsertBulk {
+	return u.Update(func(s *PaymentOrderUpsert) {
+		s.ClearCreditedAmount()
 	})
 }
 

--- a/backend/ent/paymentorder_update.go
+++ b/backend/ent/paymentorder_update.go
@@ -154,6 +154,92 @@ func (_u *PaymentOrderUpdate) AddFeeRate(v float64) *PaymentOrderUpdate {
 	return _u
 }
 
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (_u *PaymentOrderUpdate) SetAppliedRateMultiplier(v float64) *PaymentOrderUpdate {
+	_u.mutation.ResetAppliedRateMultiplier()
+	_u.mutation.SetAppliedRateMultiplier(v)
+	return _u
+}
+
+// SetNillableAppliedRateMultiplier sets the "applied_rate_multiplier" field if the given value is not nil.
+func (_u *PaymentOrderUpdate) SetNillableAppliedRateMultiplier(v *float64) *PaymentOrderUpdate {
+	if v != nil {
+		_u.SetAppliedRateMultiplier(*v)
+	}
+	return _u
+}
+
+// AddAppliedRateMultiplier adds value to the "applied_rate_multiplier" field.
+func (_u *PaymentOrderUpdate) AddAppliedRateMultiplier(v float64) *PaymentOrderUpdate {
+	_u.mutation.AddAppliedRateMultiplier(v)
+	return _u
+}
+
+// ClearAppliedRateMultiplier clears the value of the "applied_rate_multiplier" field.
+func (_u *PaymentOrderUpdate) ClearAppliedRateMultiplier() *PaymentOrderUpdate {
+	_u.mutation.ClearAppliedRateMultiplier()
+	return _u
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (_u *PaymentOrderUpdate) SetPricingTierLabel(v string) *PaymentOrderUpdate {
+	_u.mutation.SetPricingTierLabel(v)
+	return _u
+}
+
+// SetNillablePricingTierLabel sets the "pricing_tier_label" field if the given value is not nil.
+func (_u *PaymentOrderUpdate) SetNillablePricingTierLabel(v *string) *PaymentOrderUpdate {
+	if v != nil {
+		_u.SetPricingTierLabel(*v)
+	}
+	return _u
+}
+
+// ClearPricingTierLabel clears the value of the "pricing_tier_label" field.
+func (_u *PaymentOrderUpdate) ClearPricingTierLabel() *PaymentOrderUpdate {
+	_u.mutation.ClearPricingTierLabel()
+	return _u
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (_u *PaymentOrderUpdate) SetPricingTierSnapshot(v map[string]interface{}) *PaymentOrderUpdate {
+	_u.mutation.SetPricingTierSnapshot(v)
+	return _u
+}
+
+// ClearPricingTierSnapshot clears the value of the "pricing_tier_snapshot" field.
+func (_u *PaymentOrderUpdate) ClearPricingTierSnapshot() *PaymentOrderUpdate {
+	_u.mutation.ClearPricingTierSnapshot()
+	return _u
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (_u *PaymentOrderUpdate) SetCreditedAmount(v float64) *PaymentOrderUpdate {
+	_u.mutation.ResetCreditedAmount()
+	_u.mutation.SetCreditedAmount(v)
+	return _u
+}
+
+// SetNillableCreditedAmount sets the "credited_amount" field if the given value is not nil.
+func (_u *PaymentOrderUpdate) SetNillableCreditedAmount(v *float64) *PaymentOrderUpdate {
+	if v != nil {
+		_u.SetCreditedAmount(*v)
+	}
+	return _u
+}
+
+// AddCreditedAmount adds value to the "credited_amount" field.
+func (_u *PaymentOrderUpdate) AddCreditedAmount(v float64) *PaymentOrderUpdate {
+	_u.mutation.AddCreditedAmount(v)
+	return _u
+}
+
+// ClearCreditedAmount clears the value of the "credited_amount" field.
+func (_u *PaymentOrderUpdate) ClearCreditedAmount() *PaymentOrderUpdate {
+	_u.mutation.ClearCreditedAmount()
+	return _u
+}
+
 // SetRechargeCode sets the "recharge_code" field.
 func (_u *PaymentOrderUpdate) SetRechargeCode(v string) *PaymentOrderUpdate {
 	_u.mutation.SetRechargeCode(v)
@@ -778,6 +864,11 @@ func (_u *PaymentOrderUpdate) check() error {
 			return &ValidationError{Name: "user_name", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.user_name": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.PricingTierLabel(); ok {
+		if err := paymentorder.PricingTierLabelValidator(v); err != nil {
+			return &ValidationError{Name: "pricing_tier_label", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.pricing_tier_label": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.RechargeCode(); ok {
 		if err := paymentorder.RechargeCodeValidator(v); err != nil {
 			return &ValidationError{Name: "recharge_code", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.recharge_code": %w`, err)}
@@ -880,6 +971,36 @@ func (_u *PaymentOrderUpdate) sqlSave(ctx context.Context) (_node int, err error
 	}
 	if value, ok := _u.mutation.AddedFeeRate(); ok {
 		_spec.AddField(paymentorder.FieldFeeRate, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AppliedRateMultiplier(); ok {
+		_spec.SetField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedAppliedRateMultiplier(); ok {
+		_spec.AddField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64, value)
+	}
+	if _u.mutation.AppliedRateMultiplierCleared() {
+		_spec.ClearField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64)
+	}
+	if value, ok := _u.mutation.PricingTierLabel(); ok {
+		_spec.SetField(paymentorder.FieldPricingTierLabel, field.TypeString, value)
+	}
+	if _u.mutation.PricingTierLabelCleared() {
+		_spec.ClearField(paymentorder.FieldPricingTierLabel, field.TypeString)
+	}
+	if value, ok := _u.mutation.PricingTierSnapshot(); ok {
+		_spec.SetField(paymentorder.FieldPricingTierSnapshot, field.TypeJSON, value)
+	}
+	if _u.mutation.PricingTierSnapshotCleared() {
+		_spec.ClearField(paymentorder.FieldPricingTierSnapshot, field.TypeJSON)
+	}
+	if value, ok := _u.mutation.CreditedAmount(); ok {
+		_spec.SetField(paymentorder.FieldCreditedAmount, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedCreditedAmount(); ok {
+		_spec.AddField(paymentorder.FieldCreditedAmount, field.TypeFloat64, value)
+	}
+	if _u.mutation.CreditedAmountCleared() {
+		_spec.ClearField(paymentorder.FieldCreditedAmount, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.RechargeCode(); ok {
 		_spec.SetField(paymentorder.FieldRechargeCode, field.TypeString, value)
@@ -1214,6 +1335,92 @@ func (_u *PaymentOrderUpdateOne) SetNillableFeeRate(v *float64) *PaymentOrderUpd
 // AddFeeRate adds value to the "fee_rate" field.
 func (_u *PaymentOrderUpdateOne) AddFeeRate(v float64) *PaymentOrderUpdateOne {
 	_u.mutation.AddFeeRate(v)
+	return _u
+}
+
+// SetAppliedRateMultiplier sets the "applied_rate_multiplier" field.
+func (_u *PaymentOrderUpdateOne) SetAppliedRateMultiplier(v float64) *PaymentOrderUpdateOne {
+	_u.mutation.ResetAppliedRateMultiplier()
+	_u.mutation.SetAppliedRateMultiplier(v)
+	return _u
+}
+
+// SetNillableAppliedRateMultiplier sets the "applied_rate_multiplier" field if the given value is not nil.
+func (_u *PaymentOrderUpdateOne) SetNillableAppliedRateMultiplier(v *float64) *PaymentOrderUpdateOne {
+	if v != nil {
+		_u.SetAppliedRateMultiplier(*v)
+	}
+	return _u
+}
+
+// AddAppliedRateMultiplier adds value to the "applied_rate_multiplier" field.
+func (_u *PaymentOrderUpdateOne) AddAppliedRateMultiplier(v float64) *PaymentOrderUpdateOne {
+	_u.mutation.AddAppliedRateMultiplier(v)
+	return _u
+}
+
+// ClearAppliedRateMultiplier clears the value of the "applied_rate_multiplier" field.
+func (_u *PaymentOrderUpdateOne) ClearAppliedRateMultiplier() *PaymentOrderUpdateOne {
+	_u.mutation.ClearAppliedRateMultiplier()
+	return _u
+}
+
+// SetPricingTierLabel sets the "pricing_tier_label" field.
+func (_u *PaymentOrderUpdateOne) SetPricingTierLabel(v string) *PaymentOrderUpdateOne {
+	_u.mutation.SetPricingTierLabel(v)
+	return _u
+}
+
+// SetNillablePricingTierLabel sets the "pricing_tier_label" field if the given value is not nil.
+func (_u *PaymentOrderUpdateOne) SetNillablePricingTierLabel(v *string) *PaymentOrderUpdateOne {
+	if v != nil {
+		_u.SetPricingTierLabel(*v)
+	}
+	return _u
+}
+
+// ClearPricingTierLabel clears the value of the "pricing_tier_label" field.
+func (_u *PaymentOrderUpdateOne) ClearPricingTierLabel() *PaymentOrderUpdateOne {
+	_u.mutation.ClearPricingTierLabel()
+	return _u
+}
+
+// SetPricingTierSnapshot sets the "pricing_tier_snapshot" field.
+func (_u *PaymentOrderUpdateOne) SetPricingTierSnapshot(v map[string]interface{}) *PaymentOrderUpdateOne {
+	_u.mutation.SetPricingTierSnapshot(v)
+	return _u
+}
+
+// ClearPricingTierSnapshot clears the value of the "pricing_tier_snapshot" field.
+func (_u *PaymentOrderUpdateOne) ClearPricingTierSnapshot() *PaymentOrderUpdateOne {
+	_u.mutation.ClearPricingTierSnapshot()
+	return _u
+}
+
+// SetCreditedAmount sets the "credited_amount" field.
+func (_u *PaymentOrderUpdateOne) SetCreditedAmount(v float64) *PaymentOrderUpdateOne {
+	_u.mutation.ResetCreditedAmount()
+	_u.mutation.SetCreditedAmount(v)
+	return _u
+}
+
+// SetNillableCreditedAmount sets the "credited_amount" field if the given value is not nil.
+func (_u *PaymentOrderUpdateOne) SetNillableCreditedAmount(v *float64) *PaymentOrderUpdateOne {
+	if v != nil {
+		_u.SetCreditedAmount(*v)
+	}
+	return _u
+}
+
+// AddCreditedAmount adds value to the "credited_amount" field.
+func (_u *PaymentOrderUpdateOne) AddCreditedAmount(v float64) *PaymentOrderUpdateOne {
+	_u.mutation.AddCreditedAmount(v)
+	return _u
+}
+
+// ClearCreditedAmount clears the value of the "credited_amount" field.
+func (_u *PaymentOrderUpdateOne) ClearCreditedAmount() *PaymentOrderUpdateOne {
+	_u.mutation.ClearCreditedAmount()
 	return _u
 }
 
@@ -1854,6 +2061,11 @@ func (_u *PaymentOrderUpdateOne) check() error {
 			return &ValidationError{Name: "user_name", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.user_name": %w`, err)}
 		}
 	}
+	if v, ok := _u.mutation.PricingTierLabel(); ok {
+		if err := paymentorder.PricingTierLabelValidator(v); err != nil {
+			return &ValidationError{Name: "pricing_tier_label", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.pricing_tier_label": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.RechargeCode(); ok {
 		if err := paymentorder.RechargeCodeValidator(v); err != nil {
 			return &ValidationError{Name: "recharge_code", err: fmt.Errorf(`ent: validator failed for field "PaymentOrder.recharge_code": %w`, err)}
@@ -1973,6 +2185,36 @@ func (_u *PaymentOrderUpdateOne) sqlSave(ctx context.Context) (_node *PaymentOrd
 	}
 	if value, ok := _u.mutation.AddedFeeRate(); ok {
 		_spec.AddField(paymentorder.FieldFeeRate, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AppliedRateMultiplier(); ok {
+		_spec.SetField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedAppliedRateMultiplier(); ok {
+		_spec.AddField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64, value)
+	}
+	if _u.mutation.AppliedRateMultiplierCleared() {
+		_spec.ClearField(paymentorder.FieldAppliedRateMultiplier, field.TypeFloat64)
+	}
+	if value, ok := _u.mutation.PricingTierLabel(); ok {
+		_spec.SetField(paymentorder.FieldPricingTierLabel, field.TypeString, value)
+	}
+	if _u.mutation.PricingTierLabelCleared() {
+		_spec.ClearField(paymentorder.FieldPricingTierLabel, field.TypeString)
+	}
+	if value, ok := _u.mutation.PricingTierSnapshot(); ok {
+		_spec.SetField(paymentorder.FieldPricingTierSnapshot, field.TypeJSON, value)
+	}
+	if _u.mutation.PricingTierSnapshotCleared() {
+		_spec.ClearField(paymentorder.FieldPricingTierSnapshot, field.TypeJSON)
+	}
+	if value, ok := _u.mutation.CreditedAmount(); ok {
+		_spec.SetField(paymentorder.FieldCreditedAmount, field.TypeFloat64, value)
+	}
+	if value, ok := _u.mutation.AddedCreditedAmount(); ok {
+		_spec.AddField(paymentorder.FieldCreditedAmount, field.TypeFloat64, value)
+	}
+	if _u.mutation.CreditedAmountCleared() {
+		_spec.ClearField(paymentorder.FieldCreditedAmount, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.RechargeCode(); ok {
 		_spec.SetField(paymentorder.FieldRechargeCode, field.TypeString, value)

--- a/backend/ent/runtime/runtime.go
+++ b/backend/ent/runtime/runtime.go
@@ -978,70 +978,74 @@ func init() {
 	paymentorderDescFeeRate := paymentorderFields[6].Descriptor()
 	// paymentorder.DefaultFeeRate holds the default value on creation for the fee_rate field.
 	paymentorder.DefaultFeeRate = paymentorderDescFeeRate.Default.(float64)
+	// paymentorderDescPricingTierLabel is the schema descriptor for pricing_tier_label field.
+	paymentorderDescPricingTierLabel := paymentorderFields[8].Descriptor()
+	// paymentorder.PricingTierLabelValidator is a validator for the "pricing_tier_label" field. It is called by the builders before save.
+	paymentorder.PricingTierLabelValidator = paymentorderDescPricingTierLabel.Validators[0].(func(string) error)
 	// paymentorderDescRechargeCode is the schema descriptor for recharge_code field.
-	paymentorderDescRechargeCode := paymentorderFields[7].Descriptor()
+	paymentorderDescRechargeCode := paymentorderFields[11].Descriptor()
 	// paymentorder.RechargeCodeValidator is a validator for the "recharge_code" field. It is called by the builders before save.
 	paymentorder.RechargeCodeValidator = paymentorderDescRechargeCode.Validators[0].(func(string) error)
 	// paymentorderDescOutTradeNo is the schema descriptor for out_trade_no field.
-	paymentorderDescOutTradeNo := paymentorderFields[8].Descriptor()
+	paymentorderDescOutTradeNo := paymentorderFields[12].Descriptor()
 	// paymentorder.DefaultOutTradeNo holds the default value on creation for the out_trade_no field.
 	paymentorder.DefaultOutTradeNo = paymentorderDescOutTradeNo.Default.(string)
 	// paymentorder.OutTradeNoValidator is a validator for the "out_trade_no" field. It is called by the builders before save.
 	paymentorder.OutTradeNoValidator = paymentorderDescOutTradeNo.Validators[0].(func(string) error)
 	// paymentorderDescPaymentType is the schema descriptor for payment_type field.
-	paymentorderDescPaymentType := paymentorderFields[9].Descriptor()
+	paymentorderDescPaymentType := paymentorderFields[13].Descriptor()
 	// paymentorder.PaymentTypeValidator is a validator for the "payment_type" field. It is called by the builders before save.
 	paymentorder.PaymentTypeValidator = paymentorderDescPaymentType.Validators[0].(func(string) error)
 	// paymentorderDescPaymentTradeNo is the schema descriptor for payment_trade_no field.
-	paymentorderDescPaymentTradeNo := paymentorderFields[10].Descriptor()
+	paymentorderDescPaymentTradeNo := paymentorderFields[14].Descriptor()
 	// paymentorder.PaymentTradeNoValidator is a validator for the "payment_trade_no" field. It is called by the builders before save.
 	paymentorder.PaymentTradeNoValidator = paymentorderDescPaymentTradeNo.Validators[0].(func(string) error)
 	// paymentorderDescOrderType is the schema descriptor for order_type field.
-	paymentorderDescOrderType := paymentorderFields[14].Descriptor()
+	paymentorderDescOrderType := paymentorderFields[18].Descriptor()
 	// paymentorder.DefaultOrderType holds the default value on creation for the order_type field.
 	paymentorder.DefaultOrderType = paymentorderDescOrderType.Default.(string)
 	// paymentorder.OrderTypeValidator is a validator for the "order_type" field. It is called by the builders before save.
 	paymentorder.OrderTypeValidator = paymentorderDescOrderType.Validators[0].(func(string) error)
 	// paymentorderDescProviderInstanceID is the schema descriptor for provider_instance_id field.
-	paymentorderDescProviderInstanceID := paymentorderFields[18].Descriptor()
+	paymentorderDescProviderInstanceID := paymentorderFields[22].Descriptor()
 	// paymentorder.ProviderInstanceIDValidator is a validator for the "provider_instance_id" field. It is called by the builders before save.
 	paymentorder.ProviderInstanceIDValidator = paymentorderDescProviderInstanceID.Validators[0].(func(string) error)
 	// paymentorderDescProviderKey is the schema descriptor for provider_key field.
-	paymentorderDescProviderKey := paymentorderFields[19].Descriptor()
+	paymentorderDescProviderKey := paymentorderFields[23].Descriptor()
 	// paymentorder.ProviderKeyValidator is a validator for the "provider_key" field. It is called by the builders before save.
 	paymentorder.ProviderKeyValidator = paymentorderDescProviderKey.Validators[0].(func(string) error)
 	// paymentorderDescStatus is the schema descriptor for status field.
-	paymentorderDescStatus := paymentorderFields[21].Descriptor()
+	paymentorderDescStatus := paymentorderFields[25].Descriptor()
 	// paymentorder.DefaultStatus holds the default value on creation for the status field.
 	paymentorder.DefaultStatus = paymentorderDescStatus.Default.(string)
 	// paymentorder.StatusValidator is a validator for the "status" field. It is called by the builders before save.
 	paymentorder.StatusValidator = paymentorderDescStatus.Validators[0].(func(string) error)
 	// paymentorderDescRefundAmount is the schema descriptor for refund_amount field.
-	paymentorderDescRefundAmount := paymentorderFields[22].Descriptor()
+	paymentorderDescRefundAmount := paymentorderFields[26].Descriptor()
 	// paymentorder.DefaultRefundAmount holds the default value on creation for the refund_amount field.
 	paymentorder.DefaultRefundAmount = paymentorderDescRefundAmount.Default.(float64)
 	// paymentorderDescForceRefund is the schema descriptor for force_refund field.
-	paymentorderDescForceRefund := paymentorderFields[25].Descriptor()
+	paymentorderDescForceRefund := paymentorderFields[29].Descriptor()
 	// paymentorder.DefaultForceRefund holds the default value on creation for the force_refund field.
 	paymentorder.DefaultForceRefund = paymentorderDescForceRefund.Default.(bool)
 	// paymentorderDescRefundRequestedBy is the schema descriptor for refund_requested_by field.
-	paymentorderDescRefundRequestedBy := paymentorderFields[28].Descriptor()
+	paymentorderDescRefundRequestedBy := paymentorderFields[32].Descriptor()
 	// paymentorder.RefundRequestedByValidator is a validator for the "refund_requested_by" field. It is called by the builders before save.
 	paymentorder.RefundRequestedByValidator = paymentorderDescRefundRequestedBy.Validators[0].(func(string) error)
 	// paymentorderDescClientIP is the schema descriptor for client_ip field.
-	paymentorderDescClientIP := paymentorderFields[34].Descriptor()
+	paymentorderDescClientIP := paymentorderFields[38].Descriptor()
 	// paymentorder.ClientIPValidator is a validator for the "client_ip" field. It is called by the builders before save.
 	paymentorder.ClientIPValidator = paymentorderDescClientIP.Validators[0].(func(string) error)
 	// paymentorderDescSrcHost is the schema descriptor for src_host field.
-	paymentorderDescSrcHost := paymentorderFields[35].Descriptor()
+	paymentorderDescSrcHost := paymentorderFields[39].Descriptor()
 	// paymentorder.SrcHostValidator is a validator for the "src_host" field. It is called by the builders before save.
 	paymentorder.SrcHostValidator = paymentorderDescSrcHost.Validators[0].(func(string) error)
 	// paymentorderDescCreatedAt is the schema descriptor for created_at field.
-	paymentorderDescCreatedAt := paymentorderFields[37].Descriptor()
+	paymentorderDescCreatedAt := paymentorderFields[41].Descriptor()
 	// paymentorder.DefaultCreatedAt holds the default value on creation for the created_at field.
 	paymentorder.DefaultCreatedAt = paymentorderDescCreatedAt.Default.(func() time.Time)
 	// paymentorderDescUpdatedAt is the schema descriptor for updated_at field.
-	paymentorderDescUpdatedAt := paymentorderFields[38].Descriptor()
+	paymentorderDescUpdatedAt := paymentorderFields[42].Descriptor()
 	// paymentorder.DefaultUpdatedAt holds the default value on creation for the updated_at field.
 	paymentorder.DefaultUpdatedAt = paymentorderDescUpdatedAt.Default.(func() time.Time)
 	// paymentorder.UpdateDefaultUpdatedAt holds the default value on update for the updated_at field.
@@ -1496,7 +1500,7 @@ func init() {
 	// subscriptionplanDescValidityDays is the schema descriptor for validity_days field.
 	subscriptionplanDescValidityDays := subscriptionplanFields[5].Descriptor()
 	// subscriptionplan.DefaultValidityDays holds the default value on creation for the validity_days field.
-	subscriptionplan.DefaultValidityDays = subscriptionplanDescValidityDays.Default.(int)
+	subscriptionplan.DefaultValidityDays = subscriptionplanDescValidityDays.Default.(float64)
 	// subscriptionplanDescValidityUnit is the schema descriptor for validity_unit field.
 	subscriptionplanDescValidityUnit := subscriptionplanFields[6].Descriptor()
 	// subscriptionplan.DefaultValidityUnit holds the default value on creation for the validity_unit field.

--- a/backend/ent/schema/payment_order.go
+++ b/backend/ent/schema/payment_order.go
@@ -50,6 +50,21 @@ func (PaymentOrder) Fields() []ent.Field {
 		field.Float("fee_rate").
 			SchemaType(map[string]string{dialect.Postgres: "decimal(10,4)"}).
 			Default(0),
+		field.Float("applied_rate_multiplier").
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{dialect.Postgres: "decimal(20,8)"}),
+		field.String("pricing_tier_label").
+			Optional().
+			Nillable().
+			MaxLen(255),
+		field.JSON("pricing_tier_snapshot", map[string]any{}).
+			Optional().
+			SchemaType(map[string]string{dialect.Postgres: "jsonb"}),
+		field.Float("credited_amount").
+			Optional().
+			Nillable().
+			SchemaType(map[string]string{dialect.Postgres: "decimal(20,8)"}),
 		field.String("recharge_code").
 			MaxLen(64),
 

--- a/backend/ent/schema/subscription_plan.go
+++ b/backend/ent/schema/subscription_plan.go
@@ -43,7 +43,8 @@ func (SubscriptionPlan) Fields() []ent.Field {
 			SchemaType(map[string]string{dialect.Postgres: "decimal(20,2)"}).
 			Optional().
 			Nillable(),
-		field.Int("validity_days").
+		field.Float("validity_days").
+			SchemaType(map[string]string{dialect.Postgres: "decimal(20,8)"}).
 			Default(30),
 		field.String("validity_unit").
 			MaxLen(10).

--- a/backend/ent/subscriptionplan.go
+++ b/backend/ent/subscriptionplan.go
@@ -28,7 +28,7 @@ type SubscriptionPlan struct {
 	// OriginalPrice holds the value of the "original_price" field.
 	OriginalPrice *float64 `json:"original_price,omitempty"`
 	// ValidityDays holds the value of the "validity_days" field.
-	ValidityDays int `json:"validity_days,omitempty"`
+	ValidityDays float64 `json:"validity_days,omitempty"`
 	// ValidityUnit holds the value of the "validity_unit" field.
 	ValidityUnit string `json:"validity_unit,omitempty"`
 	// Features holds the value of the "features" field.
@@ -53,9 +53,9 @@ func (*SubscriptionPlan) scanValues(columns []string) ([]any, error) {
 		switch columns[i] {
 		case subscriptionplan.FieldForSale:
 			values[i] = new(sql.NullBool)
-		case subscriptionplan.FieldPrice, subscriptionplan.FieldOriginalPrice:
+		case subscriptionplan.FieldPrice, subscriptionplan.FieldOriginalPrice, subscriptionplan.FieldValidityDays:
 			values[i] = new(sql.NullFloat64)
-		case subscriptionplan.FieldID, subscriptionplan.FieldGroupID, subscriptionplan.FieldValidityDays, subscriptionplan.FieldSortOrder:
+		case subscriptionplan.FieldID, subscriptionplan.FieldGroupID, subscriptionplan.FieldSortOrder:
 			values[i] = new(sql.NullInt64)
 		case subscriptionplan.FieldName, subscriptionplan.FieldDescription, subscriptionplan.FieldValidityUnit, subscriptionplan.FieldFeatures, subscriptionplan.FieldProductName:
 			values[i] = new(sql.NullString)
@@ -114,10 +114,10 @@ func (_m *SubscriptionPlan) assignValues(columns []string, values []any) error {
 				*_m.OriginalPrice = value.Float64
 			}
 		case subscriptionplan.FieldValidityDays:
-			if value, ok := values[i].(*sql.NullInt64); !ok {
+			if value, ok := values[i].(*sql.NullFloat64); !ok {
 				return fmt.Errorf("unexpected type %T for field validity_days", values[i])
 			} else if value.Valid {
-				_m.ValidityDays = int(value.Int64)
+				_m.ValidityDays = value.Float64
 			}
 		case subscriptionplan.FieldValidityUnit:
 			if value, ok := values[i].(*sql.NullString); !ok {

--- a/backend/ent/subscriptionplan/subscriptionplan.go
+++ b/backend/ent/subscriptionplan/subscriptionplan.go
@@ -77,7 +77,7 @@ var (
 	// DefaultDescription holds the default value on creation for the "description" field.
 	DefaultDescription string
 	// DefaultValidityDays holds the default value on creation for the "validity_days" field.
-	DefaultValidityDays int
+	DefaultValidityDays float64
 	// DefaultValidityUnit holds the default value on creation for the "validity_unit" field.
 	DefaultValidityUnit string
 	// ValidityUnitValidator is a validator for the "validity_unit" field. It is called by the builders before save.

--- a/backend/ent/subscriptionplan/where.go
+++ b/backend/ent/subscriptionplan/where.go
@@ -80,7 +80,7 @@ func OriginalPrice(v float64) predicate.SubscriptionPlan {
 }
 
 // ValidityDays applies equality check predicate on the "validity_days" field. It's identical to ValidityDaysEQ.
-func ValidityDays(v int) predicate.SubscriptionPlan {
+func ValidityDays(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldEQ(FieldValidityDays, v))
 }
 
@@ -380,42 +380,42 @@ func OriginalPriceNotNil() predicate.SubscriptionPlan {
 }
 
 // ValidityDaysEQ applies the EQ predicate on the "validity_days" field.
-func ValidityDaysEQ(v int) predicate.SubscriptionPlan {
+func ValidityDaysEQ(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldEQ(FieldValidityDays, v))
 }
 
 // ValidityDaysNEQ applies the NEQ predicate on the "validity_days" field.
-func ValidityDaysNEQ(v int) predicate.SubscriptionPlan {
+func ValidityDaysNEQ(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldNEQ(FieldValidityDays, v))
 }
 
 // ValidityDaysIn applies the In predicate on the "validity_days" field.
-func ValidityDaysIn(vs ...int) predicate.SubscriptionPlan {
+func ValidityDaysIn(vs ...float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldIn(FieldValidityDays, vs...))
 }
 
 // ValidityDaysNotIn applies the NotIn predicate on the "validity_days" field.
-func ValidityDaysNotIn(vs ...int) predicate.SubscriptionPlan {
+func ValidityDaysNotIn(vs ...float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldNotIn(FieldValidityDays, vs...))
 }
 
 // ValidityDaysGT applies the GT predicate on the "validity_days" field.
-func ValidityDaysGT(v int) predicate.SubscriptionPlan {
+func ValidityDaysGT(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldGT(FieldValidityDays, v))
 }
 
 // ValidityDaysGTE applies the GTE predicate on the "validity_days" field.
-func ValidityDaysGTE(v int) predicate.SubscriptionPlan {
+func ValidityDaysGTE(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldGTE(FieldValidityDays, v))
 }
 
 // ValidityDaysLT applies the LT predicate on the "validity_days" field.
-func ValidityDaysLT(v int) predicate.SubscriptionPlan {
+func ValidityDaysLT(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldLT(FieldValidityDays, v))
 }
 
 // ValidityDaysLTE applies the LTE predicate on the "validity_days" field.
-func ValidityDaysLTE(v int) predicate.SubscriptionPlan {
+func ValidityDaysLTE(v float64) predicate.SubscriptionPlan {
 	return predicate.SubscriptionPlan(sql.FieldLTE(FieldValidityDays, v))
 }
 

--- a/backend/ent/subscriptionplan_create.go
+++ b/backend/ent/subscriptionplan_create.go
@@ -69,13 +69,13 @@ func (_c *SubscriptionPlanCreate) SetNillableOriginalPrice(v *float64) *Subscrip
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (_c *SubscriptionPlanCreate) SetValidityDays(v int) *SubscriptionPlanCreate {
+func (_c *SubscriptionPlanCreate) SetValidityDays(v float64) *SubscriptionPlanCreate {
 	_c.mutation.SetValidityDays(v)
 	return _c
 }
 
 // SetNillableValidityDays sets the "validity_days" field if the given value is not nil.
-func (_c *SubscriptionPlanCreate) SetNillableValidityDays(v *int) *SubscriptionPlanCreate {
+func (_c *SubscriptionPlanCreate) SetNillableValidityDays(v *float64) *SubscriptionPlanCreate {
 	if v != nil {
 		_c.SetValidityDays(*v)
 	}
@@ -354,7 +354,7 @@ func (_c *SubscriptionPlanCreate) createSpec() (*SubscriptionPlan, *sqlgraph.Cre
 		_node.OriginalPrice = &value
 	}
 	if value, ok := _c.mutation.ValidityDays(); ok {
-		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 		_node.ValidityDays = value
 	}
 	if value, ok := _c.mutation.ValidityUnit(); ok {
@@ -522,7 +522,7 @@ func (u *SubscriptionPlanUpsert) ClearOriginalPrice() *SubscriptionPlanUpsert {
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (u *SubscriptionPlanUpsert) SetValidityDays(v int) *SubscriptionPlanUpsert {
+func (u *SubscriptionPlanUpsert) SetValidityDays(v float64) *SubscriptionPlanUpsert {
 	u.Set(subscriptionplan.FieldValidityDays, v)
 	return u
 }
@@ -534,7 +534,7 @@ func (u *SubscriptionPlanUpsert) UpdateValidityDays() *SubscriptionPlanUpsert {
 }
 
 // AddValidityDays adds v to the "validity_days" field.
-func (u *SubscriptionPlanUpsert) AddValidityDays(v int) *SubscriptionPlanUpsert {
+func (u *SubscriptionPlanUpsert) AddValidityDays(v float64) *SubscriptionPlanUpsert {
 	u.Add(subscriptionplan.FieldValidityDays, v)
 	return u
 }
@@ -761,14 +761,14 @@ func (u *SubscriptionPlanUpsertOne) ClearOriginalPrice() *SubscriptionPlanUpsert
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (u *SubscriptionPlanUpsertOne) SetValidityDays(v int) *SubscriptionPlanUpsertOne {
+func (u *SubscriptionPlanUpsertOne) SetValidityDays(v float64) *SubscriptionPlanUpsertOne {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.SetValidityDays(v)
 	})
 }
 
 // AddValidityDays adds v to the "validity_days" field.
-func (u *SubscriptionPlanUpsertOne) AddValidityDays(v int) *SubscriptionPlanUpsertOne {
+func (u *SubscriptionPlanUpsertOne) AddValidityDays(v float64) *SubscriptionPlanUpsertOne {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.AddValidityDays(v)
 	})
@@ -1182,14 +1182,14 @@ func (u *SubscriptionPlanUpsertBulk) ClearOriginalPrice() *SubscriptionPlanUpser
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (u *SubscriptionPlanUpsertBulk) SetValidityDays(v int) *SubscriptionPlanUpsertBulk {
+func (u *SubscriptionPlanUpsertBulk) SetValidityDays(v float64) *SubscriptionPlanUpsertBulk {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.SetValidityDays(v)
 	})
 }
 
 // AddValidityDays adds v to the "validity_days" field.
-func (u *SubscriptionPlanUpsertBulk) AddValidityDays(v int) *SubscriptionPlanUpsertBulk {
+func (u *SubscriptionPlanUpsertBulk) AddValidityDays(v float64) *SubscriptionPlanUpsertBulk {
 	return u.Update(func(s *SubscriptionPlanUpsert) {
 		s.AddValidityDays(v)
 	})

--- a/backend/ent/subscriptionplan_update.go
+++ b/backend/ent/subscriptionplan_update.go
@@ -126,14 +126,14 @@ func (_u *SubscriptionPlanUpdate) ClearOriginalPrice() *SubscriptionPlanUpdate {
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (_u *SubscriptionPlanUpdate) SetValidityDays(v int) *SubscriptionPlanUpdate {
+func (_u *SubscriptionPlanUpdate) SetValidityDays(v float64) *SubscriptionPlanUpdate {
 	_u.mutation.ResetValidityDays()
 	_u.mutation.SetValidityDays(v)
 	return _u
 }
 
 // SetNillableValidityDays sets the "validity_days" field if the given value is not nil.
-func (_u *SubscriptionPlanUpdate) SetNillableValidityDays(v *int) *SubscriptionPlanUpdate {
+func (_u *SubscriptionPlanUpdate) SetNillableValidityDays(v *float64) *SubscriptionPlanUpdate {
 	if v != nil {
 		_u.SetValidityDays(*v)
 	}
@@ -141,7 +141,7 @@ func (_u *SubscriptionPlanUpdate) SetNillableValidityDays(v *int) *SubscriptionP
 }
 
 // AddValidityDays adds value to the "validity_days" field.
-func (_u *SubscriptionPlanUpdate) AddValidityDays(v int) *SubscriptionPlanUpdate {
+func (_u *SubscriptionPlanUpdate) AddValidityDays(v float64) *SubscriptionPlanUpdate {
 	_u.mutation.AddValidityDays(v)
 	return _u
 }
@@ -330,10 +330,10 @@ func (_u *SubscriptionPlanUpdate) sqlSave(ctx context.Context) (_node int, err e
 		_spec.ClearField(subscriptionplan.FieldOriginalPrice, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.ValidityDays(); ok {
-		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.AddedValidityDays(); ok {
-		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.ValidityUnit(); ok {
 		_spec.SetField(subscriptionplan.FieldValidityUnit, field.TypeString, value)
@@ -474,14 +474,14 @@ func (_u *SubscriptionPlanUpdateOne) ClearOriginalPrice() *SubscriptionPlanUpdat
 }
 
 // SetValidityDays sets the "validity_days" field.
-func (_u *SubscriptionPlanUpdateOne) SetValidityDays(v int) *SubscriptionPlanUpdateOne {
+func (_u *SubscriptionPlanUpdateOne) SetValidityDays(v float64) *SubscriptionPlanUpdateOne {
 	_u.mutation.ResetValidityDays()
 	_u.mutation.SetValidityDays(v)
 	return _u
 }
 
 // SetNillableValidityDays sets the "validity_days" field if the given value is not nil.
-func (_u *SubscriptionPlanUpdateOne) SetNillableValidityDays(v *int) *SubscriptionPlanUpdateOne {
+func (_u *SubscriptionPlanUpdateOne) SetNillableValidityDays(v *float64) *SubscriptionPlanUpdateOne {
 	if v != nil {
 		_u.SetValidityDays(*v)
 	}
@@ -489,7 +489,7 @@ func (_u *SubscriptionPlanUpdateOne) SetNillableValidityDays(v *int) *Subscripti
 }
 
 // AddValidityDays adds value to the "validity_days" field.
-func (_u *SubscriptionPlanUpdateOne) AddValidityDays(v int) *SubscriptionPlanUpdateOne {
+func (_u *SubscriptionPlanUpdateOne) AddValidityDays(v float64) *SubscriptionPlanUpdateOne {
 	_u.mutation.AddValidityDays(v)
 	return _u
 }
@@ -708,10 +708,10 @@ func (_u *SubscriptionPlanUpdateOne) sqlSave(ctx context.Context) (_node *Subscr
 		_spec.ClearField(subscriptionplan.FieldOriginalPrice, field.TypeFloat64)
 	}
 	if value, ok := _u.mutation.ValidityDays(); ok {
-		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.SetField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.AddedValidityDays(); ok {
-		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeInt, value)
+		_spec.AddField(subscriptionplan.FieldValidityDays, field.TypeFloat64, value)
 	}
 	if value, ok := _u.mutation.ValidityUnit(); ok {
 		_spec.SetField(subscriptionplan.FieldValidityUnit, field.TypeString, value)

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -183,6 +183,11 @@ func (s *stubAdminService) UpdateUserBalance(ctx context.Context, userID int64, 
 	return &user, nil
 }
 
+func (s *stubAdminService) AddUserBalancePackage(ctx context.Context, userID int64, amount float64, validityDays float64, notes string) (*service.User, error) {
+	user := service.User{ID: userID, Balance: 0, Status: service.StatusActive}
+	return &user, nil
+}
+
 func (s *stubAdminService) BatchUpdateConcurrency(ctx context.Context, userIDs []int64, value int, mode string) (int, error) {
 	return len(userIDs), nil
 }

--- a/backend/internal/handler/admin/payment_handler.go
+++ b/backend/internal/handler/admin/payment_handler.go
@@ -1,7 +1,9 @@
 package admin
 
 import (
+	"math"
 	"strconv"
+	"time"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
@@ -41,6 +43,23 @@ func (h *PaymentHandler) GetDashboard(c *gin.Context) {
 		return
 	}
 	response.Success(c, stats)
+}
+
+// GetDashboardLegacy returns the old sub2apipay dashboard payload shape.
+// GET /api/v1/admin/sub2api/dashboard
+func (h *PaymentHandler) GetDashboardLegacy(c *gin.Context) {
+	days := 30
+	if d := c.Query("days"); d != "" {
+		if v, err := strconv.Atoi(d); err == nil && v > 0 {
+			days = v
+		}
+	}
+	stats, err := h.paymentService.GetDashboardStats(c.Request.Context(), days)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, legacyDashboardStatsFromService(stats, days, time.Now()))
 }
 
 // --- Orders ---
@@ -115,6 +134,84 @@ func (h *PaymentHandler) RetryFulfillment(c *gin.Context) {
 	response.Success(c, gin.H{"message": "fulfillment retried"})
 }
 
+// ListOrdersLegacy returns the old sub2apipay admin order list shape.
+// GET /api/v1/admin/sub2api/orders
+func (h *PaymentHandler) ListOrdersLegacy(c *gin.Context) {
+	page, pageSize := response.ParsePagination(c)
+	var userID int64
+	if uid := c.Query("user_id"); uid != "" {
+		if v, err := strconv.ParseInt(uid, 10, 64); err == nil {
+			userID = v
+		}
+	}
+	orders, total, err := h.paymentService.AdminListOrders(c.Request.Context(), userID, service.OrderListParams{
+		Page:        page,
+		PageSize:    pageSize,
+		Status:      c.Query("status"),
+		OrderType:   c.Query("order_type"),
+		PaymentType: c.Query("payment_type"),
+		Keyword:     c.Query("keyword"),
+	})
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	out := make([]gin.H, 0, len(orders))
+	for _, order := range orders {
+		out = append(out, legacyAdminOrderFromEnt(order))
+	}
+	totalPages := 0
+	if pageSize > 0 {
+		totalPages = (total + pageSize - 1) / pageSize
+	}
+	response.Success(c, gin.H{"orders": out, "total": total, "total_pages": totalPages})
+}
+
+// GetOrderDetailLegacy returns the old sub2apipay admin order detail shape.
+// GET /api/v1/admin/sub2api/orders/:id
+func (h *PaymentHandler) GetOrderDetailLegacy(c *gin.Context) {
+	orderID, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	order, err := h.paymentService.GetOrderByID(c.Request.Context(), orderID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	auditLogs, _ := h.paymentService.GetOrderAuditLogs(c.Request.Context(), orderID)
+	response.Success(c, legacyAdminOrderDetailFromEnt(order, auditLogs))
+}
+
+// CancelOrderLegacy cancels an order and responds using the old sub2apipay shape.
+// POST /api/v1/admin/sub2api/orders/:id/cancel
+func (h *PaymentHandler) CancelOrderLegacy(c *gin.Context) {
+	orderID, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	msg, err := h.paymentService.AdminCancelOrder(c.Request.Context(), orderID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, gin.H{"success": true, "message": msg})
+}
+
+// RetryFulfillmentLegacy retries fulfillment using the old sub2apipay route shape.
+// POST /api/v1/admin/sub2api/orders/:id/retry
+func (h *PaymentHandler) RetryFulfillmentLegacy(c *gin.Context) {
+	orderID, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if err := h.paymentService.RetryFulfillment(c.Request.Context(), orderID); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, gin.H{"success": true, "message": "fulfillment retried"})
+}
+
 func sanitizeAdminPaymentOrdersForResponse(orders []*dbent.PaymentOrder) []*dbent.PaymentOrder {
 	if len(orders) == 0 {
 		return orders
@@ -133,6 +230,182 @@ func sanitizeAdminPaymentOrderForResponse(order *dbent.PaymentOrder) *dbent.Paym
 	cloned := *order
 	cloned.ProviderSnapshot = nil
 	return &cloned
+}
+
+func legacyAdminOrderFromEnt(order *dbent.PaymentOrder) gin.H {
+	if order == nil {
+		return gin.H{}
+	}
+	return gin.H{
+		"id":              strconv.FormatInt(order.ID, 10),
+		"userId":          order.UserID,
+		"userName":        order.UserName,
+		"userEmail":       order.UserEmail,
+		"userNotes":       stringPtrValue(order.UserNotes),
+		"amount":          order.Amount,
+		"status":          order.Status,
+		"paymentType":     order.PaymentType,
+		"createdAt":       formatLegacyTime(order.CreatedAt),
+		"paidAt":          formatLegacyTimePtr(order.PaidAt),
+		"completedAt":     formatLegacyTimePtr(order.CompletedAt),
+		"failedReason":    stringPtrValue(order.FailedReason),
+		"expiresAt":       formatLegacyTime(order.ExpiresAt),
+		"srcHost":         order.SrcHost,
+		"rechargeCode":    order.RechargeCode,
+		"paymentTradeNo":  order.PaymentTradeNo,
+		"refundAmount":    order.RefundAmount,
+		"refundReason":    stringPtrValue(order.RefundReason),
+		"refundAt":        formatLegacyTimePtr(order.RefundAt),
+		"forceRefund":     order.ForceRefund,
+		"failedAt":        formatLegacyTimePtr(order.FailedAt),
+		"updatedAt":       formatLegacyTime(order.UpdatedAt),
+		"clientIp":        order.ClientIP,
+		"srcUrl":          stringPtrValue(order.SrcURL),
+		"paymentSuccess":  legacyPaymentSuccess(order),
+		"rechargeSuccess": legacyRechargeSuccess(order),
+		"rechargeStatus":  legacyRechargeStatus(order),
+	}
+}
+
+func legacyAdminOrderDetailFromEnt(order *dbent.PaymentOrder, logs []*dbent.PaymentAuditLog) gin.H {
+	out := legacyAdminOrderFromEnt(order)
+	auditLogs := make([]gin.H, 0, len(logs))
+	for _, log := range logs {
+		if log == nil {
+			continue
+		}
+		auditLogs = append(auditLogs, gin.H{
+			"id":        log.ID,
+			"action":    log.Action,
+			"detail":    log.Detail,
+			"operator":  log.Operator,
+			"createdAt": formatLegacyTime(log.CreatedAt),
+		})
+	}
+	out["auditLogs"] = auditLogs
+	return out
+}
+
+func legacyPaymentSuccess(order *dbent.PaymentOrder) bool {
+	if order == nil {
+		return false
+	}
+	return order.PaidAt != nil || legacyRechargeSuccess(order)
+}
+
+func legacyRechargeSuccess(order *dbent.PaymentOrder) bool {
+	return order != nil && (order.CompletedAt != nil || order.Status == "COMPLETED")
+}
+
+func legacyRechargeStatus(order *dbent.PaymentOrder) string {
+	if order == nil {
+		return "not_paid"
+	}
+	switch order.Status {
+	case "COMPLETED":
+		return "success"
+	case "RECHARGING":
+		return "recharging"
+	case "FAILED":
+		return "failed"
+	case "EXPIRED", "CANCELLED", "REFUNDING", "REFUNDED", "REFUND_FAILED":
+		return "closed"
+	}
+	if order.CompletedAt != nil {
+		return "success"
+	}
+	if order.PaidAt != nil {
+		return "paid_pending"
+	}
+	return "not_paid"
+}
+
+func formatLegacyTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+func formatLegacyTimePtr(t *time.Time) any {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return t.Format(time.RFC3339)
+}
+
+func stringPtrValue(v *string) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func legacyDashboardStatsFromService(stats *service.DashboardStats, days int, generatedAt time.Time) gin.H {
+	if stats == nil {
+		stats = &service.DashboardStats{}
+	}
+	dailySeries := make([]gin.H, 0, len(stats.DailySeries))
+	for _, item := range stats.DailySeries {
+		dailySeries = append(dailySeries, gin.H{
+			"date":   item.Date,
+			"amount": item.Amount,
+			"count":  item.Count,
+		})
+	}
+
+	leaderboard := make([]gin.H, 0, len(stats.TopUsers))
+	for _, user := range stats.TopUsers {
+		leaderboard = append(leaderboard, gin.H{
+			"userId":      user.UserID,
+			"userName":    nil,
+			"userEmail":   user.Email,
+			"totalAmount": user.Amount,
+			"orderCount":  0,
+		})
+	}
+
+	paymentMethods := make([]gin.H, 0, len(stats.PaymentMethods))
+	for _, method := range stats.PaymentMethods {
+		percentage := 0.0
+		if stats.TotalAmount > 0 {
+			percentage = math.Round(method.Amount/stats.TotalAmount*10000) / 100
+		}
+		paymentMethods = append(paymentMethods, gin.H{
+			"paymentType": method.Type,
+			"amount":      method.Amount,
+			"count":       method.Count,
+			"percentage":  percentage,
+		})
+	}
+
+	successRate := 0.0
+	if stats.TotalCount > 0 {
+		successRate = 100
+	}
+	return gin.H{
+		"summary": gin.H{
+			"today": gin.H{
+				"amount":     stats.TodayAmount,
+				"orderCount": stats.TodayCount,
+				"paidCount":  stats.TodayCount,
+			},
+			"total": gin.H{
+				"amount":     stats.TotalAmount,
+				"orderCount": stats.TotalCount,
+				"paidCount":  stats.TotalCount,
+			},
+			"successRate": successRate,
+			"avgAmount":   stats.AvgAmount,
+		},
+		"dailySeries":    dailySeries,
+		"leaderboard":    leaderboard,
+		"paymentMethods": paymentMethods,
+		"meta": gin.H{
+			"days":        days,
+			"generatedAt": formatLegacyTime(generatedAt),
+		},
+	}
 }
 
 // AdminProcessRefundRequest is the request body for admin refund processing.
@@ -186,6 +459,118 @@ func (h *PaymentHandler) ListPlans(c *gin.Context) {
 		return
 	}
 	response.Success(c, plans)
+}
+
+// ListPlansLegacy returns all subscription plans using the old sub2apipay
+// management API shape.
+// GET /api/v1/admin/subscription-plans
+func (h *PaymentHandler) ListPlansLegacy(c *gin.Context) {
+	plans, err := h.configService.ListPlans(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	groupInfo := h.configService.GetGroupInfoMap(c.Request.Context(), plans)
+	response.Success(c, gin.H{"plans": legacySubscriptionPlans(plans, groupInfo, true)})
+}
+
+// CreatePlanLegacy accepts the old sub2apipay plan payload and stores it in the
+// native sub2api subscription plan model.
+// POST /api/v1/admin/subscription-plans
+func (h *PaymentHandler) CreatePlanLegacy(c *gin.Context) {
+	var req legacyPlanUpsertRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	createReq := service.CreatePlanRequest{}
+	if req.GroupID != nil {
+		createReq.GroupID = *req.GroupID
+	}
+	if req.Name != nil {
+		createReq.Name = *req.Name
+	}
+	if req.Description != nil {
+		createReq.Description = *req.Description
+	}
+	if req.Price != nil {
+		createReq.Price = *req.Price
+	}
+	createReq.OriginalPrice = req.OriginalPrice
+	if req.ValidityDays != nil {
+		createReq.ValidityDays = *req.ValidityDays
+	}
+	if req.ValidityUnit != nil {
+		createReq.ValidityUnit = *req.ValidityUnit
+	}
+	if req.Features != nil {
+		createReq.Features = flattenLegacyFeatures(*req.Features)
+	}
+	if req.ProductName != nil {
+		createReq.ProductName = *req.ProductName
+	}
+	if req.ForSale != nil {
+		createReq.ForSale = *req.ForSale
+	}
+	if req.SortOrder != nil {
+		createReq.SortOrder = *req.SortOrder
+	}
+	plan, err := h.configService.CreatePlan(c.Request.Context(), createReq)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Created(c, plan)
+}
+
+// UpdatePlanLegacy accepts patch-style old sub2apipay plan updates.
+// PUT /api/v1/admin/subscription-plans/:id
+func (h *PaymentHandler) UpdatePlanLegacy(c *gin.Context) {
+	id, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	var req legacyPlanUpsertRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	updateReq := service.UpdatePlanRequest{
+		GroupID:       req.GroupID,
+		Name:          req.Name,
+		Description:   req.Description,
+		Price:         req.Price,
+		OriginalPrice: req.OriginalPrice,
+		ValidityDays:  req.ValidityDays,
+		ValidityUnit:  req.ValidityUnit,
+		ProductName:   req.ProductName,
+		ForSale:       req.ForSale,
+		SortOrder:     req.SortOrder,
+	}
+	if req.Features != nil {
+		features := flattenLegacyFeatures(*req.Features)
+		updateReq.Features = &features
+	}
+	plan, err := h.configService.UpdatePlan(c.Request.Context(), id, updateReq)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, plan)
+}
+
+// DeletePlanLegacy deletes a plan through the old sub2apipay route.
+// DELETE /api/v1/admin/subscription-plans/:id
+func (h *PaymentHandler) DeletePlanLegacy(c *gin.Context) {
+	id, ok := parseIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if err := h.configService.DeletePlan(c.Request.Context(), id); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, gin.H{"message": "deleted"})
 }
 
 // CreatePlan creates a new subscription plan.
@@ -313,6 +698,41 @@ func parseIDParam(c *gin.Context, paramName string) (int64, bool) {
 		return 0, false
 	}
 	return id, true
+}
+
+// --- Product catalog ---
+
+// GetCatalogProducts returns all homepage/shop products for admin editing.
+// GET /api/v1/admin/payment/products
+func (h *PaymentHandler) GetCatalogProducts(c *gin.Context) {
+	products, err := h.configService.GetCatalogProducts(c.Request.Context(), true)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, gin.H{"products": products})
+}
+
+// UpdateCatalogProducts replaces the homepage/shop product list.
+// PUT /api/v1/admin/payment/products
+func (h *PaymentHandler) UpdateCatalogProducts(c *gin.Context) {
+	var req struct {
+		Products []service.CatalogProduct `json:"products"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	if err := h.configService.SetCatalogProducts(c.Request.Context(), req.Products); err != nil {
+		response.BadRequest(c, err.Error())
+		return
+	}
+	products, err := h.configService.GetCatalogProducts(c.Request.Context(), true)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, gin.H{"products": products})
 }
 
 // --- Config ---

--- a/backend/internal/handler/admin/payment_plan_legacy.go
+++ b/backend/internal/handler/admin/payment_plan_legacy.go
@@ -1,0 +1,95 @@
+package admin
+
+import (
+	"strings"
+
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func legacySubscriptionPlans(plans []*dbent.SubscriptionPlan, groupInfo map[int64]service.PlanGroupInfo, admin bool) []gin.H {
+	out := make([]gin.H, 0, len(plans))
+	for _, p := range plans {
+		gi := groupInfo[p.GroupID]
+		item := gin.H{
+			"id":                    int64(p.ID),
+			"groupId":               p.GroupID,
+			"groupName":             gi.Name,
+			"name":                  p.Name,
+			"description":           p.Description,
+			"price":                 p.Price,
+			"originalPrice":         p.OriginalPrice,
+			"validityDays":          p.ValidityDays,
+			"validityUnit":          p.ValidityUnit,
+			"features":              parseFeatures(p.Features),
+			"productName":           p.ProductName,
+			"platform":              gi.Platform,
+			"rateMultiplier":        gi.RateMultiplier,
+			"allowMessagesDispatch": false,
+			"defaultMappedModel":    "",
+			"limits": gin.H{
+				"daily_limit_usd":   gi.DailyLimitUSD,
+				"weekly_limit_usd":  gi.WeeklyLimitUSD,
+				"monthly_limit_usd": gi.MonthlyLimitUSD,
+			},
+		}
+		if admin {
+			item["validDays"] = p.ValidityDays
+			item["sortOrder"] = p.SortOrder
+			item["enabled"] = p.ForSale
+			item["groupExists"] = gi.Name != ""
+			item["groupPlatform"] = gi.Platform
+			item["groupRateMultiplier"] = gi.RateMultiplier
+			item["groupDailyLimit"] = gi.DailyLimitUSD
+			item["groupWeeklyLimit"] = gi.WeeklyLimitUSD
+			item["groupMonthlyLimit"] = gi.MonthlyLimitUSD
+			item["groupModelScopes"] = gi.ModelScopes
+			item["createdAt"] = p.CreatedAt
+			item["updatedAt"] = p.UpdatedAt
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func parseFeatures(raw string) []string {
+	if raw == "" {
+		return []string{}
+	}
+	out := make([]string, 0)
+	for _, line := range strings.Split(raw, "\n") {
+		if s := strings.TrimSpace(line); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+type legacyPlanUpsertRequest struct {
+	GroupID       *int64    `json:"group_id"`
+	Name          *string   `json:"name"`
+	Description   *string   `json:"description"`
+	Price         *float64  `json:"price"`
+	OriginalPrice *float64  `json:"original_price"`
+	ValidityDays  *float64  `json:"validity_days"`
+	ValidityUnit  *string   `json:"validity_unit"`
+	Features      *[]string `json:"features"`
+	ProductName   *string   `json:"product_name"`
+	ForSale       *bool     `json:"for_sale"`
+	SortOrder     *int      `json:"sort_order"`
+}
+
+func flattenLegacyFeatures(features []string) string {
+	if len(features) == 0 {
+		return ""
+	}
+	clean := make([]string, 0, len(features))
+	for _, item := range features {
+		if s := strings.TrimSpace(item); s != "" {
+			clean = append(clean, s)
+		}
+	}
+	return strings.Join(clean, "\n")
+}

--- a/backend/internal/handler/admin/redeem_handler.go
+++ b/backend/internal/handler/admin/redeem_handler.go
@@ -37,21 +37,21 @@ type GenerateRedeemCodesRequest struct {
 	Count         int        `json:"count" binding:"required,min=1,max=100"`
 	Type          string     `json:"type" binding:"required,oneof=balance concurrency subscription invitation"`
 	Value         float64    `json:"value"`
-	GroupID       *int64     `json:"group_id"`      // 订阅类型必填
-	ValidityDays  int        `json:"validity_days"` // 订阅类型使用，正数增加/负数退款扣减
+	GroupID       *int64     `json:"group_id"`      // 璁㈤槄绫诲瀷蹇呭～
+	ValidityDays  float64    `json:"validity_days"` // subscription duration in days; decimals like 0.5 are allowed
 	ExpiresAt     *time.Time `json:"expires_at"`
 	ExpiresInDays *int       `json:"expires_in_days" binding:"omitempty,min=1,max=3650"`
 }
 
 // CreateAndRedeemCodeRequest represents creating a fixed code and redeeming it for a target user.
-// Type 为 omitempty 而非 required 是为了向后兼容旧版调用方（不传 type 时默认 balance）。
+// Type is omitempty for legacy callers. Missing type defaults to balance.
 type CreateAndRedeemCodeRequest struct {
 	Code          string     `json:"code" binding:"required,min=3,max=128"`
-	Type          string     `json:"type" binding:"omitempty,oneof=balance concurrency subscription invitation"` // 不传时默认 balance（向后兼容）
+	Type          string     `json:"type" binding:"omitempty,oneof=balance concurrency subscription invitation"` // 涓嶄紶鏃堕粯璁?balance锛堝悜鍚庡吋瀹癸級
 	Value         float64    `json:"value" binding:"required"`
 	UserID        int64      `json:"user_id" binding:"required,gt=0"`
-	GroupID       *int64     `json:"group_id"`      // subscription 类型必填
-	ValidityDays  int        `json:"validity_days"` // subscription 类型：正数增加，负数退款扣减
+	GroupID       *int64     `json:"group_id"`      // subscription 绫诲瀷蹇呭～
+	ValidityDays  float64    `json:"validity_days"` // subscription duration in days; decimals like 0.5 are allowed
 	Notes         string     `json:"notes"`
 	ExpiresAt     *time.Time `json:"expires_at"`
 	ExpiresInDays *int       `json:"expires_in_days" binding:"omitempty,min=1,max=3650"`
@@ -90,7 +90,7 @@ func (h *RedeemHandler) List(c *gin.Context) {
 	search := c.Query("search")
 	sortBy := c.DefaultQuery("sort_by", "id")
 	sortOrder := c.DefaultQuery("sort_order", "desc")
-	// 标准化和验证 search 参数
+	// 鏍囧噯鍖栧拰楠岃瘉 search 鍙傛暟
 	search = strings.TrimSpace(search)
 	if len(search) > 100 {
 		search = search[:100]
@@ -177,8 +177,7 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 		return
 	}
 	req.Code = strings.TrimSpace(req.Code)
-	// 向后兼容：旧版调用方（如 Sub2ApiPay）不传 type 字段，默认当作 balance 充值处理。
-	// 请勿删除此默认值逻辑，否则会导致旧版调用方 400 报错。
+	// Legacy callers may omit type; keep defaulting to balance.
 	if req.Type == "" {
 		req.Type = "balance"
 	}
@@ -188,7 +187,12 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 			response.BadRequest(c, "group_id is required for subscription type")
 			return
 		}
-		if req.ValidityDays == 0 {
+		validityDays, validitySeconds, err := service.NormalizeRedeemValidityDays(req.ValidityDays)
+		if err != nil {
+			response.BadRequest(c, err.Error())
+			return
+		}
+		if validityDays == 0 && validitySeconds == 0 {
 			response.BadRequest(c, "validity_days must not be zero for subscription type")
 			return
 		}
@@ -209,15 +213,26 @@ func (h *RedeemHandler) CreateAndRedeem(c *gin.Context) {
 			return nil, err
 		}
 
+		validityDays, validitySeconds, err := service.NormalizeRedeemValidityDays(req.ValidityDays)
+		if err != nil {
+			return nil, err
+		}
+		if req.Type == service.RedeemTypeBalance {
+			if validitySeconds <= 0 && validityDays > 0 {
+				validitySeconds = int64(validityDays) * 24 * int64(time.Hour/time.Second)
+			}
+			validityDays = 0
+		}
 		createErr := h.redeemService.CreateCode(ctx, &service.RedeemCode{
-			Code:         req.Code,
-			Type:         req.Type,
-			Value:        req.Value,
-			Status:       service.StatusUnused,
-			Notes:        req.Notes,
-			GroupID:      req.GroupID,
-			ValidityDays: req.ValidityDays,
-			ExpiresAt:    expiresAt,
+			Code:            req.Code,
+			Type:            req.Type,
+			Value:           req.Value,
+			Status:          service.StatusUnused,
+			Notes:           req.Notes,
+			GroupID:         req.GroupID,
+			ValidityDays:    validityDays,
+			ValiditySeconds: validitySeconds,
+			ExpiresAt:       expiresAt,
 		})
 		if createErr != nil {
 			// Unique code race: if code now exists, use idempotent semantics by used_by.

--- a/backend/internal/handler/admin/redeem_handler_test.go
+++ b/backend/internal/handler/admin/redeem_handler_test.go
@@ -114,17 +114,19 @@ func TestCreateAndRedeem_SubscriptionRequiresNonZeroValidityDays(t *testing.T) {
 func TestCreateAndRedeem_SubscriptionValidParamsPassValidation(t *testing.T) {
 	groupID := int64(5)
 	h := newCreateAndRedeemHandler()
-	code := postCreateAndRedeemValidation(t, h, map[string]any{
-		"code":          "test-sub-valid",
-		"type":          "subscription",
-		"value":         29.9,
-		"user_id":       1,
-		"group_id":      groupID,
-		"validity_days": 31,
-	})
+	for _, validityDays := range []float64{31, 0.5} {
+		code := postCreateAndRedeemValidation(t, h, map[string]any{
+			"code":          "test-sub-valid",
+			"type":          "subscription",
+			"value":         29.9,
+			"user_id":       1,
+			"group_id":      groupID,
+			"validity_days": validityDays,
+		})
 
-	assert.NotEqual(t, http.StatusBadRequest, code,
-		"valid subscription params should pass validation")
+		assert.NotEqual(t, http.StatusBadRequest, code,
+			"valid subscription params should pass validation")
+	}
 }
 
 func TestCreateAndRedeem_BalanceIgnoresSubscriptionFields(t *testing.T) {

--- a/backend/internal/handler/admin/subscription_handler.go
+++ b/backend/internal/handler/admin/subscription_handler.go
@@ -40,10 +40,11 @@ func NewSubscriptionHandler(subscriptionService *service.SubscriptionService) *S
 
 // AssignSubscriptionRequest represents assign subscription request
 type AssignSubscriptionRequest struct {
-	UserID       int64  `json:"user_id" binding:"required"`
-	GroupID      int64  `json:"group_id" binding:"required"`
-	ValidityDays int    `json:"validity_days" binding:"omitempty,max=36500"` // max 100 years
-	Notes        string `json:"notes"`
+	UserID            int64  `json:"user_id" binding:"required"`
+	GroupID           int64  `json:"group_id" binding:"required"`
+	ValidityDays      int    `json:"validity_days" binding:"omitempty,max=36500"` // max 100 years
+	Notes             string `json:"notes"`
+	OverwriteExisting bool   `json:"overwrite_existing"`
 }
 
 // BulkAssignSubscriptionRequest represents bulk assign subscription request
@@ -96,6 +97,77 @@ func (h *SubscriptionHandler) List(c *gin.Context) {
 	response.PaginatedWithResult(c, out, toResponsePagination(pagination))
 }
 
+// ListSub2ApiLegacy returns subscription data in the legacy sub2apipay admin shape.
+// Keep it on a separate /admin/sub2api/* route so the current admin UI contract stays unchanged.
+func (h *SubscriptionHandler) ListSub2ApiLegacy(c *gin.Context) {
+	page, pageSize := response.ParsePagination(c)
+
+	var userID, groupID *int64
+	if userIDStr := c.Query("user_id"); userIDStr != "" {
+		if id, err := strconv.ParseInt(userIDStr, 10, 64); err == nil {
+			userID = &id
+		}
+	}
+	if groupIDStr := c.Query("group_id"); groupIDStr != "" {
+		if id, err := strconv.ParseInt(groupIDStr, 10, 64); err == nil {
+			groupID = &id
+		}
+	}
+
+	status := c.Query("status")
+	platform := c.Query("platform")
+	sortBy := c.DefaultQuery("sort_by", "created_at")
+	sortOrder := c.DefaultQuery("sort_order", "desc")
+
+	subscriptions, pag, err := h.subscriptionService.List(c.Request.Context(), page, pageSize, userID, groupID, status, platform, sortBy, sortOrder)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+
+	out := make([]gin.H, 0, len(subscriptions))
+	var legacyUser any
+	for i := range subscriptions {
+		sub := subscriptions[i]
+		user := dto.UserFromServiceShallow(sub.User)
+		group := dto.GroupFromServiceShallow(sub.Group)
+		if legacyUser == nil && user != nil {
+			legacyUser = user
+		}
+		out = append(out, gin.H{
+			"id":                   sub.ID,
+			"user_id":              sub.UserID,
+			"group_id":             sub.GroupID,
+			"starts_at":            sub.StartsAt,
+			"expires_at":           sub.ExpiresAt,
+			"status":               sub.Status,
+			"daily_usage_usd":      sub.DailyUsageUSD,
+			"weekly_usage_usd":     sub.WeeklyUsageUSD,
+			"monthly_usage_usd":    sub.MonthlyUsageUSD,
+			"daily_window_start":   sub.DailyWindowStart,
+			"weekly_window_start":  sub.WeeklyWindowStart,
+			"monthly_window_start": sub.MonthlyWindowStart,
+			"assigned_by":          sub.AssignedBy,
+			"assigned_at":          sub.AssignedAt,
+			"notes":                sub.Notes,
+			"created_at":           sub.CreatedAt,
+			"updated_at":           sub.UpdatedAt,
+			"user":                 user,
+			"group":                group,
+		})
+	}
+
+	total := int64(len(out))
+	if pag != nil {
+		total = pag.Total
+	}
+	response.Success(c, gin.H{
+		"subscriptions": out,
+		"user":          legacyUser,
+		"total":         total,
+	})
+}
+
 // GetByID handles getting a subscription by ID
 // GET /api/v1/admin/subscriptions/:id
 func (h *SubscriptionHandler) GetByID(c *gin.Context) {
@@ -145,11 +217,12 @@ func (h *SubscriptionHandler) Assign(c *gin.Context) {
 	adminID := getAdminIDFromContext(c)
 
 	subscription, err := h.subscriptionService.AssignSubscription(c.Request.Context(), &service.AssignSubscriptionInput{
-		UserID:       req.UserID,
-		GroupID:      req.GroupID,
-		ValidityDays: req.ValidityDays,
-		AssignedBy:   adminID,
-		Notes:        req.Notes,
+		UserID:            req.UserID,
+		GroupID:           req.GroupID,
+		ValidityDays:      req.ValidityDays,
+		AssignedBy:        adminID,
+		Notes:             req.Notes,
+		OverwriteExisting: req.OverwriteExisting,
 	})
 	if err != nil {
 		response.ErrorFrom(c, err)

--- a/backend/internal/handler/payment_handler.go
+++ b/backend/internal/handler/payment_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -44,6 +45,28 @@ func (h *PaymentHandler) GetPaymentConfig(c *gin.Context) {
 	response.Success(c, cfg)
 }
 
+// GetCatalogProducts returns active homepage/shop products.
+// GET /api/v1/payment/catalog/products
+func (h *PaymentHandler) GetCatalogProducts(c *gin.Context) {
+	products, err := h.configService.GetCatalogProducts(c.Request.Context(), false)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, gin.H{"products": products})
+}
+
+// GetCatalogProductsLegacy returns the old sub2apipay catalog response shape.
+// It keeps the static /shop frontend on the merged sub2api product settings.
+func (h *PaymentHandler) GetCatalogProductsLegacy(c *gin.Context) {
+	products, err := h.configService.GetCatalogProducts(c.Request.Context(), false)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"products": products})
+}
+
 // GetPlans returns subscription plans available for sale.
 // GET /api/v1/payment/plans
 func (h *PaymentHandler) GetPlans(c *gin.Context) {
@@ -61,7 +84,7 @@ func (h *PaymentHandler) GetPlans(c *gin.Context) {
 		Description   string   `json:"description"`
 		Price         float64  `json:"price"`
 		OriginalPrice *float64 `json:"original_price,omitempty"`
-		ValidityDays  int      `json:"validity_days"`
+		ValidityDays  float64  `json:"validity_days"`
 		ValidityUnit  string   `json:"validity_unit"`
 		Features      string   `json:"features"`
 		ProductName   string   `json:"product_name"`
@@ -131,32 +154,38 @@ func (h *PaymentHandler) GetCheckoutInfo(c *gin.Context) {
 	}
 
 	response.Success(c, checkoutInfoResponse{
-		Methods:                   limitsResp.Methods,
-		GlobalMin:                 limitsResp.GlobalMin,
-		GlobalMax:                 limitsResp.GlobalMax,
-		Plans:                     planList,
-		BalanceDisabled:           cfg.BalanceDisabled,
-		BalanceRechargeMultiplier: cfg.BalanceRechargeMultiplier,
-		RechargeFeeRate:           cfg.RechargeFeeRate,
-		HelpText:                  cfg.HelpText,
-		HelpImageURL:              cfg.HelpImageURL,
-		StripePublishableKey:      cfg.StripePublishableKey,
-		AlipayForceQRCode:         cfg.AlipayForceQRCode,
+		Methods:                    limitsResp.Methods,
+		GlobalMin:                  limitsResp.GlobalMin,
+		GlobalMax:                  limitsResp.GlobalMax,
+		Plans:                      planList,
+		BalanceDisabled:            cfg.BalanceDisabled,
+		BalanceRechargeMultiplier:  cfg.BalanceRechargeMultiplier,
+		BalancePricingTiers:        cfg.BalancePricingTiers,
+		BalanceRechargeAsPackage:   cfg.BalanceRechargeAsPackage,
+		BalancePackageValidityDays: cfg.BalancePackageValidityDays,
+		RechargeFeeRate:            cfg.RechargeFeeRate,
+		HelpText:                   cfg.HelpText,
+		HelpImageURL:               cfg.HelpImageURL,
+		StripePublishableKey:       cfg.StripePublishableKey,
+		AlipayForceQRCode:          cfg.AlipayForceQRCode,
 	})
 }
 
 type checkoutInfoResponse struct {
-	Methods                   map[string]service.MethodLimits `json:"methods"`
-	GlobalMin                 float64                         `json:"global_min"`
-	GlobalMax                 float64                         `json:"global_max"`
-	Plans                     []checkoutPlan                  `json:"plans"`
-	BalanceDisabled           bool                            `json:"balance_disabled"`
-	BalanceRechargeMultiplier float64                         `json:"balance_recharge_multiplier"`
-	RechargeFeeRate           float64                         `json:"recharge_fee_rate"`
-	HelpText                  string                          `json:"help_text"`
-	HelpImageURL              string                          `json:"help_image_url"`
-	StripePublishableKey      string                          `json:"stripe_publishable_key"`
-	AlipayForceQRCode         bool                            `json:"alipay_force_qrcode"`
+	Methods                    map[string]service.MethodLimits `json:"methods"`
+	GlobalMin                  float64                         `json:"global_min"`
+	GlobalMax                  float64                         `json:"global_max"`
+	Plans                      []checkoutPlan                  `json:"plans"`
+	BalanceDisabled            bool                            `json:"balance_disabled"`
+	BalanceRechargeMultiplier  float64                         `json:"balance_recharge_multiplier"`
+	BalancePricingTiers        []service.BalancePricingTier    `json:"balance_pricing_tiers"`
+	BalanceRechargeAsPackage   bool                            `json:"balance_recharge_as_package"`
+	BalancePackageValidityDays float64                         `json:"balance_package_validity_days"`
+	RechargeFeeRate            float64                         `json:"recharge_fee_rate"`
+	HelpText                   string                          `json:"help_text"`
+	HelpImageURL               string                          `json:"help_image_url"`
+	StripePublishableKey       string                          `json:"stripe_publishable_key"`
+	AlipayForceQRCode          bool                            `json:"alipay_force_qrcode"`
 }
 
 type checkoutPlan struct {
@@ -173,10 +202,23 @@ type checkoutPlan struct {
 	Description     string   `json:"description"`
 	Price           float64  `json:"price"`
 	OriginalPrice   *float64 `json:"original_price,omitempty"`
-	ValidityDays    int      `json:"validity_days"`
+	ValidityDays    float64  `json:"validity_days"`
 	ValidityUnit    string   `json:"validity_unit"`
 	Features        []string `json:"features"`
 	ProductName     string   `json:"product_name"`
+}
+
+// GetPlansLegacy returns subscription plans using the old sub2apipay response
+// shape. It is kept as a compatibility endpoint for migrated clients.
+// GET /api/v1/subscription-plans
+func (h *PaymentHandler) GetPlansLegacy(c *gin.Context) {
+	plans, err := h.configService.ListPlansForSale(c.Request.Context())
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	groupInfo := h.configService.GetGroupInfoMap(c.Request.Context(), plans)
+	response.Success(c, gin.H{"plans": legacySubscriptionPlans(plans, groupInfo, false)})
 }
 
 // parseFeatures splits a newline-separated features string into a string slice.
@@ -209,14 +251,15 @@ func (h *PaymentHandler) GetLimits(c *gin.Context) {
 
 // CreateOrderRequest is the request body for creating a payment order.
 type CreateOrderRequest struct {
-	Amount            float64 `json:"amount"`
-	PaymentType       string  `json:"payment_type" binding:"required"`
-	OpenID            string  `json:"openid"`
-	WechatResumeToken string  `json:"wechat_resume_token"`
-	ReturnURL         string  `json:"return_url"`
-	PaymentSource     string  `json:"payment_source"`
-	OrderType         string  `json:"order_type"`
-	PlanID            int64   `json:"plan_id"`
+	Amount                     float64 `json:"amount"`
+	PaymentType                string  `json:"payment_type" binding:"required"`
+	OpenID                     string  `json:"openid"`
+	WechatResumeToken          string  `json:"wechat_resume_token"`
+	ReturnURL                  string  `json:"return_url"`
+	PaymentSource              string  `json:"payment_source"`
+	OrderType                  string  `json:"order_type"`
+	PlanID                     int64   `json:"plan_id"`
+	BalancePackageValidityDays float64 `json:"balance_package_validity_days"`
 	// IsMobile lets the frontend declare its mobile status directly. When
 	// nil we fall back to User-Agent heuristics (which miss iPadOS / some
 	// embedded browsers that strip the "Mobile" keyword).
@@ -253,20 +296,21 @@ func (h *PaymentHandler) CreateOrder(c *gin.Context) {
 		mobile = *req.IsMobile
 	}
 	result, err := h.paymentService.CreateOrder(c.Request.Context(), service.CreateOrderRequest{
-		UserID:          subject.UserID,
-		Amount:          req.Amount,
-		PaymentType:     req.PaymentType,
-		OpenID:          req.OpenID,
-		ClientIP:        c.ClientIP(),
-		IsMobile:        mobile,
-		IsWeChatBrowser: isWeChatBrowser(c),
-		SrcHost:         c.Request.Host,
-		SrcURL:          c.Request.Referer(),
-		ReturnURL:       req.ReturnURL,
-		PaymentSource:   req.PaymentSource,
-		OrderType:       req.OrderType,
-		PlanID:          req.PlanID,
-		Locale:          c.GetHeader("Accept-Language"),
+		UserID:                     subject.UserID,
+		Amount:                     req.Amount,
+		PaymentType:                req.PaymentType,
+		OpenID:                     req.OpenID,
+		ClientIP:                   c.ClientIP(),
+		IsMobile:                   mobile,
+		IsWeChatBrowser:            isWeChatBrowser(c),
+		SrcHost:                    c.Request.Host,
+		SrcURL:                     c.Request.Referer(),
+		ReturnURL:                  req.ReturnURL,
+		PaymentSource:              req.PaymentSource,
+		OrderType:                  req.OrderType,
+		PlanID:                     req.PlanID,
+		BalancePackageValidityDays: req.BalancePackageValidityDays,
+		Locale:                     c.GetHeader("Accept-Language"),
 	})
 	if err != nil {
 		response.ErrorFrom(c, err)
@@ -476,9 +520,43 @@ type PublicOrderResult struct {
 	RefundRequestedBy   *string    `json:"refund_requested_by,omitempty"`
 	RefundRequestReason *string    `json:"refund_request_reason,omitempty"`
 	PlanID              *int64     `json:"plan_id,omitempty"`
+	PaymentSuccess      bool       `json:"paymentSuccess"`
+	RechargeSuccess     bool       `json:"rechargeSuccess"`
+	RechargeStatus      string     `json:"rechargeStatus"`
+}
+
+func deriveRechargeStatus(order *dbent.PaymentOrder) (paymentSuccess bool, rechargeSuccess bool, rechargeStatus string) {
+	if order == nil {
+		return false, false, "not_paid"
+	}
+
+	paymentSuccess = order.PaidAt != nil
+	rechargeSuccess = order.CompletedAt != nil || order.Status == service.OrderStatusCompleted
+	if rechargeSuccess {
+		return paymentSuccess, true, "success"
+	}
+
+	switch order.Status {
+	case service.OrderStatusRecharging:
+		return paymentSuccess, false, "recharging"
+	case service.OrderStatusFailed:
+		return paymentSuccess, false, "failed"
+	case service.OrderStatusExpired,
+		service.OrderStatusCancelled,
+		service.OrderStatusRefunding,
+		service.OrderStatusRefunded,
+		service.OrderStatusRefundFailed:
+		return paymentSuccess, false, "closed"
+	}
+
+	if paymentSuccess {
+		return true, false, "paid_pending"
+	}
+	return false, false, "not_paid"
 }
 
 func buildPublicOrderResult(order *dbent.PaymentOrder) PublicOrderResult {
+	paymentSuccess, rechargeSuccess, rechargeStatus := deriveRechargeStatus(order)
 	return PublicOrderResult{
 		ID:                  order.ID,
 		OutTradeNo:          order.OutTradeNo,
@@ -499,6 +577,9 @@ func buildPublicOrderResult(order *dbent.PaymentOrder) PublicOrderResult {
 		RefundRequestedBy:   order.RefundRequestedBy,
 		RefundRequestReason: order.RefundRequestReason,
 		PlanID:              order.PlanID,
+		PaymentSuccess:      paymentSuccess,
+		RechargeSuccess:     rechargeSuccess,
+		RechargeStatus:      rechargeStatus,
 	}
 }
 
@@ -581,6 +662,9 @@ type PaymentOrderResult struct {
 	RefundRequestReason *string    `json:"refund_request_reason,omitempty"`
 	PlanID              *int64     `json:"plan_id,omitempty"`
 	ProviderInstanceID  *string    `json:"provider_instance_id,omitempty"`
+	PaymentSuccess      bool       `json:"paymentSuccess"`
+	RechargeSuccess     bool       `json:"rechargeSuccess"`
+	RechargeStatus      string     `json:"rechargeStatus"`
 }
 
 func sanitizePaymentOrdersForResponse(orders []*dbent.PaymentOrder) []PaymentOrderResult {
@@ -597,6 +681,7 @@ func sanitizePaymentOrderForResponse(order *dbent.PaymentOrder) *PaymentOrderRes
 	if order == nil {
 		return nil
 	}
+	paymentSuccess, rechargeSuccess, rechargeStatus := deriveRechargeStatus(order)
 	return &PaymentOrderResult{
 		ID:                  order.ID,
 		UserID:              order.UserID,
@@ -619,6 +704,9 @@ func sanitizePaymentOrderForResponse(order *dbent.PaymentOrder) *PaymentOrderRes
 		RefundRequestReason: order.RefundRequestReason,
 		PlanID:              order.PlanID,
 		ProviderInstanceID:  order.ProviderInstanceID,
+		PaymentSuccess:      paymentSuccess,
+		RechargeSuccess:     rechargeSuccess,
+		RechargeStatus:      rechargeStatus,
 	}
 }
 

--- a/backend/internal/handler/payment_handler_resume_test.go
+++ b/backend/internal/handler/payment_handler_resume_test.go
@@ -137,18 +137,21 @@ func TestVerifyOrderPublicReturnsLegacyOrderState(t *testing.T) {
 	var resp struct {
 		Code int `json:"code"`
 		Data struct {
-			ID           int64   `json:"id"`
-			OutTradeNo   string  `json:"out_trade_no"`
-			Amount       float64 `json:"amount"`
-			PayAmount    float64 `json:"pay_amount"`
-			FeeRate      float64 `json:"fee_rate"`
-			Currency     string  `json:"currency"`
-			PaymentType  string  `json:"payment_type"`
-			OrderType    string  `json:"order_type"`
-			Status       string  `json:"status"`
-			RefundAmount float64 `json:"refund_amount"`
-			CreatedAt    string  `json:"created_at"`
-			ExpiresAt    string  `json:"expires_at"`
+			ID              int64   `json:"id"`
+			OutTradeNo      string  `json:"out_trade_no"`
+			Amount          float64 `json:"amount"`
+			PayAmount       float64 `json:"pay_amount"`
+			FeeRate         float64 `json:"fee_rate"`
+			Currency        string  `json:"currency"`
+			PaymentType     string  `json:"payment_type"`
+			OrderType       string  `json:"order_type"`
+			Status          string  `json:"status"`
+			RefundAmount    float64 `json:"refund_amount"`
+			CreatedAt       string  `json:"created_at"`
+			ExpiresAt       string  `json:"expires_at"`
+			PaymentSuccess  bool    `json:"paymentSuccess"`
+			RechargeSuccess bool    `json:"rechargeSuccess"`
+			RechargeStatus  string  `json:"rechargeStatus"`
 		} `json:"data"`
 	}
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &resp))
@@ -162,6 +165,9 @@ func TestVerifyOrderPublicReturnsLegacyOrderState(t *testing.T) {
 	require.Equal(t, payment.OrderTypeBalance, resp.Data.OrderType)
 	require.Equal(t, service.OrderStatusPending, resp.Data.Status)
 	require.Equal(t, 0.0, resp.Data.RefundAmount)
+	require.False(t, resp.Data.PaymentSuccess)
+	require.False(t, resp.Data.RechargeSuccess)
+	require.Equal(t, "not_paid", resp.Data.RechargeStatus)
 	require.NotEmpty(t, resp.Data.CreatedAt)
 	require.NotEmpty(t, resp.Data.ExpiresAt)
 }
@@ -250,6 +256,9 @@ func TestResolveOrderPublicByResumeTokenReturnsFrontendContractFields(t *testing
 	require.Equal(t, payment.TypeAlipay, resp.Data["payment_type"])
 	require.Equal(t, payment.OrderTypeBalance, resp.Data["order_type"])
 	require.Equal(t, service.OrderStatusPaid, resp.Data["status"])
+	require.Equal(t, true, resp.Data["paymentSuccess"])
+	require.Equal(t, false, resp.Data["rechargeSuccess"])
+	require.Equal(t, "paid_pending", resp.Data["rechargeStatus"])
 	require.Contains(t, resp.Data, "created_at")
 	require.Contains(t, resp.Data, "expires_at")
 	require.Contains(t, resp.Data, "refund_amount")

--- a/backend/internal/handler/payment_plan_legacy.go
+++ b/backend/internal/handler/payment_plan_legacy.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func legacySubscriptionPlans(plans []*dbent.SubscriptionPlan, groupInfo map[int64]service.PlanGroupInfo, admin bool) []gin.H {
+	out := make([]gin.H, 0, len(plans))
+	for _, p := range plans {
+		gi := groupInfo[p.GroupID]
+		item := gin.H{
+			"id":                    int64(p.ID),
+			"groupId":               p.GroupID,
+			"groupName":             gi.Name,
+			"name":                  p.Name,
+			"description":           p.Description,
+			"price":                 p.Price,
+			"originalPrice":         p.OriginalPrice,
+			"validityDays":          p.ValidityDays,
+			"validityUnit":          p.ValidityUnit,
+			"features":              parseFeatures(p.Features),
+			"productName":           p.ProductName,
+			"platform":              gi.Platform,
+			"rateMultiplier":        gi.RateMultiplier,
+			"allowMessagesDispatch": false,
+			"defaultMappedModel":    "",
+			"limits": gin.H{
+				"daily_limit_usd":   gi.DailyLimitUSD,
+				"weekly_limit_usd":  gi.WeeklyLimitUSD,
+				"monthly_limit_usd": gi.MonthlyLimitUSD,
+			},
+		}
+		if admin {
+			item["validDays"] = p.ValidityDays
+			item["sortOrder"] = p.SortOrder
+			item["enabled"] = p.ForSale
+			item["groupExists"] = gi.Name != ""
+			item["groupPlatform"] = gi.Platform
+			item["groupRateMultiplier"] = gi.RateMultiplier
+			item["groupDailyLimit"] = gi.DailyLimitUSD
+			item["groupWeeklyLimit"] = gi.WeeklyLimitUSD
+			item["groupMonthlyLimit"] = gi.MonthlyLimitUSD
+			item["groupModelScopes"] = gi.ModelScopes
+			item["createdAt"] = p.CreatedAt
+			item["updatedAt"] = p.UpdatedAt
+		}
+		out = append(out, item)
+	}
+	return out
+}

--- a/backend/internal/handler/payment_plan_legacy_test.go
+++ b/backend/internal/handler/payment_plan_legacy_test.go
@@ -1,0 +1,235 @@
+//go:build unit
+
+package handler
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/ent/enttest"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	adminhandler "github.com/Wei-Shaw/sub2api/internal/handler/admin"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"entgo.io/ent/dialect"
+	entsql "entgo.io/ent/dialect/sql"
+	_ "modernc.org/sqlite"
+)
+
+func newPaymentPlanLegacyClient(t *testing.T) *dbent.Client {
+	t.Helper()
+	db, err := sql.Open("sqlite", "file:"+t.Name()+"?mode=memory&cache=shared")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec("PRAGMA foreign_keys = ON")
+	require.NoError(t, err)
+	drv := entsql.OpenDB(dialect.SQLite, db)
+	client := enttest.NewClient(t, enttest.WithOptions(dbent.Driver(drv)))
+	t.Cleanup(func() { _ = client.Close() })
+	return client
+}
+
+func seedLegacyPlan(t *testing.T, client *dbent.Client, forSale bool) int64 {
+	t.Helper()
+	ctx := context.Background()
+	group, err := client.Group.Create().
+		SetName("Pro Group").
+		SetPlatform(service.PlatformOpenAI).
+		SetStatus(service.StatusActive).
+		SetSubscriptionType(domain.SubscriptionTypeSubscription).
+		SetRateMultiplier(2.5).
+		SetSupportedModelScopes([]string{"gpt"}).
+		Save(ctx)
+	require.NoError(t, err)
+	_, err = client.SubscriptionPlan.Create().
+		SetGroupID(group.ID).
+		SetName("Pro Plan").
+		SetDescription("desc").
+		SetPrice(99).
+		SetOriginalPrice(129).
+		SetValidityDays(1).
+		SetValidityUnit("month").
+		SetFeatures(`["fast","quota"]`).
+		SetProductName("Pro Product").
+		SetForSale(forSale).
+		SetSortOrder(3).
+		Save(ctx)
+	require.NoError(t, err)
+	return group.ID
+}
+
+func TestGetPlansLegacyReturnsSub2ApiPayShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client := newPaymentPlanLegacyClient(t)
+	groupID := seedLegacyPlan(t, client, true)
+	configSvc := service.NewPaymentConfigService(client, nil, nil)
+	h := NewPaymentHandler(nil, configSvc, nil)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/subscription-plans", nil)
+
+	h.GetPlansLegacy(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Data struct {
+			Plans []map[string]any `json:"plans"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data.Plans, 1)
+	plan := body.Data.Plans[0]
+	require.Equal(t, float64(groupID), plan["groupId"])
+	require.Equal(t, "Pro Group", plan["groupName"])
+	require.Equal(t, "Pro Plan", plan["name"])
+	require.Equal(t, 99.0, plan["price"])
+	require.Equal(t, float64(1), plan["validityDays"])
+	require.Equal(t, "month", plan["validityUnit"])
+	require.Equal(t, service.PlatformOpenAI, plan["platform"])
+}
+
+func TestListPlansLegacyReturnsAdminSub2ApiPayShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client := newPaymentPlanLegacyClient(t)
+	groupID := seedLegacyPlan(t, client, false)
+	configSvc := service.NewPaymentConfigService(client, nil, nil)
+	h := adminhandler.NewPaymentHandler(nil, configSvc)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/admin/subscription-plans", nil)
+
+	h.ListPlansLegacy(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Data struct {
+			Plans []map[string]any `json:"plans"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Data.Plans, 1)
+	plan := body.Data.Plans[0]
+	require.Equal(t, float64(groupID), plan["groupId"])
+	require.Equal(t, "Pro Group", plan["groupName"])
+	require.Equal(t, service.PlatformOpenAI, plan["platform"])
+	require.Equal(t, false, plan["enabled"])
+	require.Equal(t, float64(3), plan["sortOrder"])
+	require.Equal(t, 2.5, plan["groupRateMultiplier"])
+}
+
+func TestCreatePlanLegacyAcceptsSub2ApiPayPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client := newPaymentPlanLegacyClient(t)
+	groupID := seedLegacyPlan(t, client, true)
+	configSvc := service.NewPaymentConfigService(client, nil, nil)
+	h := adminhandler.NewPaymentHandler(nil, configSvc)
+
+	body := `{
+		"group_id": ` + "1" + `,
+		"name": "Legacy Create",
+		"description": "legacy-desc",
+		"price": 19.9,
+		"original_price": 29.9,
+		"validity_days": 2,
+		"validity_unit": "week",
+		"features": ["f1", "f2"],
+		"sort_order": 9,
+		"for_sale": true,
+		"product_name": "Legacy Product"
+	}`
+	body = strings.Replace(body, `"group_id": 1`, `"group_id": `+strconv.FormatInt(groupID, 10), 1)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/subscription-plans", strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.CreatePlanLegacy(c)
+
+	require.Equal(t, http.StatusCreated, rec.Code)
+	plans, err := configSvc.ListPlans(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plans, 2)
+	var created *dbent.SubscriptionPlan
+	for _, plan := range plans {
+		if plan.Name == "Legacy Create" {
+			created = plan
+			break
+		}
+	}
+	require.NotNil(t, created)
+	require.Equal(t, "f1\nf2", created.Features)
+	require.Equal(t, "Legacy Product", created.ProductName)
+	require.Equal(t, 9, created.SortOrder)
+}
+
+func TestUpdatePlanLegacyAcceptsSub2ApiPayPayload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client := newPaymentPlanLegacyClient(t)
+	groupID := seedLegacyPlan(t, client, true)
+	configSvc := service.NewPaymentConfigService(client, nil, nil)
+	h := adminhandler.NewPaymentHandler(nil, configSvc)
+
+	plans, err := configSvc.ListPlans(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+	planID := plans[0].ID
+
+	body := `{
+		"group_id": ` + strconv.FormatInt(groupID, 10) + `,
+		"name": "Legacy Update",
+		"features": ["u1", "u2"],
+		"for_sale": false
+	}`
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: strconv.FormatInt(planID, 10)}}
+	c.Request = httptest.NewRequest(http.MethodPut, "/api/v1/admin/subscription-plans/"+strconv.FormatInt(planID, 10), strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.UpdatePlanLegacy(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	updated, err := configSvc.GetPlan(context.Background(), planID)
+	require.NoError(t, err)
+	require.Equal(t, "Legacy Update", updated.Name)
+	require.Equal(t, "u1\nu2", updated.Features)
+	require.False(t, updated.ForSale)
+}
+
+func TestDeletePlanLegacyDeletesPlan(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	client := newPaymentPlanLegacyClient(t)
+	seedLegacyPlan(t, client, true)
+	configSvc := service.NewPaymentConfigService(client, nil, nil)
+	h := adminhandler.NewPaymentHandler(nil, configSvc)
+
+	plans, err := configSvc.ListPlans(context.Background())
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+	planID := plans[0].ID
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Params = gin.Params{{Key: "id", Value: strconv.FormatInt(planID, 10)}}
+	c.Request = httptest.NewRequest(http.MethodDelete, "/api/v1/admin/subscription-plans/"+strconv.FormatInt(planID, 10), nil)
+
+	h.DeletePlanLegacy(c)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	remaining, err := configSvc.ListPlans(context.Background())
+	require.NoError(t, err)
+	require.Empty(t, remaining)
+}

--- a/backend/internal/handler/payment_webhook_handler.go
+++ b/backend/internal/handler/payment_webhook_handler.go
@@ -67,6 +67,12 @@ func (h *PaymentWebhookHandler) AirwallexWebhook(c *gin.Context) {
 	h.handleNotify(c, payment.TypeAirwallex)
 }
 
+// XunhuPayNotify handles XunhuPay payment notifications.
+// POST /api/v1/payment/webhook/xunhupay
+func (h *PaymentWebhookHandler) XunhuPayNotify(c *gin.Context) {
+	h.handleNotify(c, payment.TypeXunhuPay)
+}
+
 // handleNotify is the shared logic for all provider webhook handlers.
 func (h *PaymentWebhookHandler) handleNotify(c *gin.Context, providerKey string) {
 	var rawBody string
@@ -152,6 +158,11 @@ func extractOutTradeNo(rawBody, providerKey string) string {
 		values, err := url.ParseQuery(rawBody)
 		if err == nil {
 			return values.Get("out_trade_no")
+		}
+	case payment.TypeXunhuPay:
+		values, err := url.ParseQuery(rawBody)
+		if err == nil {
+			return values.Get("trade_order_id")
 		}
 	case payment.TypeAirwallex:
 		var payload struct {

--- a/backend/internal/payment/load_balancer.go
+++ b/backend/internal/payment/load_balancer.go
@@ -396,6 +396,8 @@ func normalizeVisibleMethodSupportType(paymentType PaymentType) PaymentType {
 		return TypeAlipay
 	case TypeWxpay, TypeWxpayDirect:
 		return TypeWxpay
+	case TypeXunhuPay, TypeWxpayXunhu:
+		return TypeXunhuPay
 	default:
 		return strings.TrimSpace(paymentType)
 	}

--- a/backend/internal/payment/load_balancer_test.go
+++ b/backend/internal/payment/load_balancer_test.go
@@ -80,6 +80,12 @@ func TestInstanceSupportsType(t *testing.T) {
 			expected:       true,
 		},
 		{
+			name:           "legacy xunhu wxpay method supports canonical xunhupay provider",
+			supportedTypes: "wxpay_xunhu",
+			target:         "xunhupay",
+			expected:       true,
+		},
+		{
 			name:           "empty supported types means all supported",
 			supportedTypes: "",
 			target:         "alipay",

--- a/backend/internal/payment/provider/factory.go
+++ b/backend/internal/payment/provider/factory.go
@@ -19,6 +19,8 @@ func CreateProvider(providerKey string, instanceID string, config map[string]str
 		return NewStripe(instanceID, config)
 	case payment.TypeAirwallex:
 		return NewAirwallex(instanceID, config)
+	case payment.TypeXunhuPay:
+		return NewXunhuPay(instanceID, config)
 	default:
 		return nil, fmt.Errorf("unknown provider key: %s", providerKey)
 	}

--- a/backend/internal/payment/provider/xunhupay.go
+++ b/backend/internal/payment/provider/xunhupay.go
@@ -1,0 +1,300 @@
+package provider
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/payment"
+)
+
+const (
+	xunhuPayHTTPTimeout     = 10 * time.Second
+	maxXunhuPayResponseSize = 1 << 20
+)
+
+// XunhuPay implements the Sub2ApiPay legacy XunhuPay integration.
+type XunhuPay struct {
+	instanceID string
+	config     map[string]string
+	httpClient *http.Client
+}
+
+// NewXunhuPay creates a XunhuPay provider.
+// config keys: appId, secret, gatewayUrl, notifyUrl, returnUrl
+func NewXunhuPay(instanceID string, config map[string]string) (*XunhuPay, error) {
+	for _, k := range []string{"appId", "secret", "gatewayUrl", "notifyUrl", "returnUrl"} {
+		if strings.TrimSpace(config[k]) == "" {
+			return nil, fmt.Errorf("xunhupay config missing required key: %s", k)
+		}
+	}
+	cfg := make(map[string]string, len(config))
+	for k, v := range config {
+		cfg[k] = v
+	}
+	cfg["gatewayUrl"] = strings.TrimSpace(cfg["gatewayUrl"])
+	return &XunhuPay{
+		instanceID: instanceID,
+		config:     cfg,
+		httpClient: &http.Client{Timeout: xunhuPayHTTPTimeout},
+	}, nil
+}
+
+func (x *XunhuPay) Name() string        { return "XunhuPay" }
+func (x *XunhuPay) ProviderKey() string { return payment.TypeXunhuPay }
+func (x *XunhuPay) SupportedTypes() []payment.PaymentType {
+	return []payment.PaymentType{payment.TypeWxpayXunhu}
+}
+
+func (x *XunhuPay) MerchantIdentityMetadata() map[string]string {
+	if x == nil {
+		return nil
+	}
+	appID := strings.TrimSpace(x.config["appId"])
+	if appID == "" {
+		return nil
+	}
+	return map[string]string{"appid": appID}
+}
+
+func (x *XunhuPay) CreatePayment(ctx context.Context, req payment.CreatePaymentRequest) (*payment.CreatePaymentResponse, error) {
+	notifyURL := req.NotifyURL
+	if notifyURL == "" {
+		notifyURL = x.config["notifyUrl"]
+	}
+	returnURL := req.ReturnURL
+	if returnURL == "" {
+		returnURL = x.config["returnUrl"]
+	}
+	params := map[string]string{
+		"version":        "1.1",
+		"appid":          x.config["appId"],
+		"trade_order_id": req.OrderID,
+		"total_fee":      req.Amount,
+		"title":          req.Subject,
+		"notify_url":     notifyURL,
+		"return_url":     returnURL,
+		"time":           strconv.FormatInt(time.Now().Unix(), 10),
+		"nonce_str":      strconv.FormatInt(time.Now().UnixNano(), 10),
+	}
+	params["hash"] = xunhuPaySign(params, x.config["secret"])
+
+	body, err := x.post(ctx, x.config["gatewayUrl"], params)
+	if err != nil {
+		return nil, fmt.Errorf("xunhupay create: %w", err)
+	}
+	var resp struct {
+		ErrCode       any    `json:"errcode"`
+		Code          any    `json:"code"`
+		ErrMsg        string `json:"errmsg"`
+		Msg           string `json:"msg"`
+		Message       string `json:"message"`
+		OrderID       string `json:"order_id"`
+		TransactionID string `json:"transaction_id"`
+		URL           string `json:"url"`
+		URLQRCode     string `json:"url_qrcode"`
+		QRCode        string `json:"qrcode"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("xunhupay parse create: %w", err)
+	}
+	if !xunhuPayCreateOK(resp.ErrCode, resp.Code, resp.URL, resp.URLQRCode, resp.QRCode) {
+		msg := firstNonEmpty(resp.ErrMsg, resp.Msg, resp.Message, strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("xunhupay error: %s", msg)
+	}
+	tradeNo := firstNonEmpty(resp.OrderID, resp.TransactionID, req.OrderID)
+	payURL, qrCode := normalizeXunhuPayCreateURLs(resp.URL, resp.URLQRCode, resp.QRCode)
+	return &payment.CreatePaymentResponse{TradeNo: tradeNo, PayURL: payURL, QRCode: qrCode}, nil
+}
+
+func (x *XunhuPay) QueryOrder(_ context.Context, tradeNo string) (*payment.QueryOrderResponse, error) {
+	return &payment.QueryOrderResponse{
+		TradeNo:  tradeNo,
+		Status:   payment.ProviderStatusPending,
+		Metadata: x.MerchantIdentityMetadata(),
+	}, nil
+}
+
+func (x *XunhuPay) VerifyNotification(_ context.Context, rawBody string, _ map[string]string) (*payment.PaymentNotification, error) {
+	values, err := url.ParseQuery(rawBody)
+	if err != nil {
+		return nil, fmt.Errorf("parse notify: %w", err)
+	}
+	params := make(map[string]string)
+	for k := range values {
+		params[k] = values.Get(k)
+	}
+	hash := params["hash"]
+	if hash == "" {
+		return nil, fmt.Errorf("missing hash")
+	}
+	if !xunhuPayVerifySign(params, x.config["secret"], hash) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+	amount, err := strconv.ParseFloat(params["total_fee"], 64)
+	if err != nil || amount <= 0 {
+		return nil, fmt.Errorf("invalid total_fee")
+	}
+	status := payment.ProviderStatusFailed
+	switch strings.ToUpper(strings.TrimSpace(params["status"])) {
+	case "OD", "SUCCESS", "TRADE_SUCCESS", "COMPLETED":
+		status = payment.ProviderStatusSuccess
+	}
+	metadata := x.MerchantIdentityMetadata()
+	if appID := strings.TrimSpace(params["appid"]); appID != "" {
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		metadata["appid"] = appID
+	}
+	return &payment.PaymentNotification{
+		TradeNo:  firstNonEmpty(params["transaction_id"], params["order_id"], params["trade_order_id"]),
+		OrderID:  params["trade_order_id"],
+		Amount:   amount,
+		Status:   status,
+		RawData:  rawBody,
+		Metadata: metadata,
+	}, nil
+}
+
+func (x *XunhuPay) Refund(_ context.Context, req payment.RefundRequest) (*payment.RefundResponse, error) {
+	return &payment.RefundResponse{
+		RefundID: firstNonEmpty(req.TradeNo, req.OrderID) + "-refund-unsupported",
+		Status:   payment.ProviderStatusFailed,
+	}, nil
+}
+
+func (x *XunhuPay) post(ctx context.Context, endpoint string, params map[string]string) ([]byte, error) {
+	form := url.Values{}
+	for k, v := range params {
+		form.Set(k, v)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	client := x.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: xunhuPayHTTPTimeout}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxXunhuPayResponseSize))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, strings.Join(strings.Fields(string(body)), " "))
+	}
+	return body, nil
+}
+
+func normalizeXunhuPayCreateURLs(urlValue, urlQRCode, qrCode string) (payURL string, qrContent string) {
+	payURL = strings.TrimSpace(urlValue)
+	urlQRCode = strings.TrimSpace(urlQRCode)
+	qrCode = strings.TrimSpace(qrCode)
+
+	if payURL == "" && isHTTPURL(urlQRCode) && !isRemoteQRURL(urlQRCode) {
+		payURL = urlQRCode
+		urlQRCode = ""
+	}
+	if payURL == "" && isHTTPURL(qrCode) && !isRemoteQRURL(qrCode) {
+		payURL = qrCode
+		qrCode = ""
+	}
+	return payURL, firstNonEmpty(urlQRCode, qrCode)
+}
+
+func isRemoteQRURL(value string) bool {
+	u, err := url.Parse(strings.TrimSpace(value))
+	if err != nil || !u.IsAbs() || (u.Scheme != "http" && u.Scheme != "https") {
+		return false
+	}
+	path := strings.ToLower(u.Path)
+	if strings.HasSuffix(path, ".png") || strings.HasSuffix(path, ".jpg") || strings.HasSuffix(path, ".jpeg") || strings.HasSuffix(path, ".gif") || strings.HasSuffix(path, ".webp") || strings.HasSuffix(path, ".svg") {
+		return true
+	}
+	return strings.Contains(path, "/qrcode/") || strings.Contains(path, "/qr_code/") || strings.Contains(path, "/qr/")
+}
+
+func isHTTPURL(value string) bool {
+	u, err := url.Parse(strings.TrimSpace(value))
+	return err == nil && u.IsAbs() && (u.Scheme == "http" || u.Scheme == "https")
+}
+
+func xunhuPaySign(params map[string]string, secret string) string {
+	keys := make([]string, 0, len(params))
+	for k, v := range params {
+		if k == "hash" || k == "signature" || v == "" {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			_ = buf.WriteByte('&')
+		}
+		_, _ = buf.WriteString(k + "=" + params[k])
+	}
+	_, _ = buf.WriteString(secret)
+	hash := md5.Sum([]byte(buf.String()))
+	return hex.EncodeToString(hash[:])
+}
+
+func xunhuPayVerifySign(params map[string]string, secret string, sign string) bool {
+	return hmac.Equal([]byte(xunhuPaySign(params, secret)), []byte(sign))
+}
+
+func xunhuPayCreateOK(errCode any, code any, values ...string) bool {
+	if anyNonEmpty(values...) {
+		return true
+	}
+	for _, v := range []any{errCode, code} {
+		switch typed := v.(type) {
+		case float64:
+			if typed == 0 {
+				return true
+			}
+		case string:
+			s := strings.ToLower(strings.TrimSpace(typed))
+			if s == "0" || s == "success" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func anyNonEmpty(values ...string) bool {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/backend/internal/payment/provider/xunhupay_test.go
+++ b/backend/internal/payment/provider/xunhupay_test.go
@@ -1,0 +1,141 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/payment"
+)
+
+func TestXunhuPayVerifyNotification(t *testing.T) {
+	prov, err := NewXunhuPay("x1", map[string]string{
+		"appId":      "app-1",
+		"secret":     "sec-1",
+		"gatewayUrl": "https://pay.example.invalid",
+		"notifyUrl":  "https://merchant.example/notify",
+		"returnUrl":  "https://merchant.example/return",
+	})
+	if err != nil {
+		t.Fatalf("NewXunhuPay error: %v", err)
+	}
+	params := map[string]string{
+		"appid":          "app-1",
+		"trade_order_id": "ord-1",
+		"transaction_id": "tx-1",
+		"total_fee":      "12.34",
+		"status":         "OD",
+	}
+	params["hash"] = xunhuPaySign(params, "sec-1")
+
+	body := "appid=app-1&trade_order_id=ord-1&transaction_id=tx-1&total_fee=12.34&status=OD&hash=" + params["hash"]
+	notice, err := prov.VerifyNotification(context.Background(), body, nil)
+	if err != nil {
+		t.Fatalf("VerifyNotification error: %v", err)
+	}
+	if notice.OrderID != "ord-1" || notice.TradeNo != "tx-1" || notice.Status != payment.ProviderStatusSuccess {
+		t.Fatalf("notification = %+v", notice)
+	}
+	if notice.Metadata["appid"] != "app-1" {
+		t.Fatalf("metadata appid = %q", notice.Metadata["appid"])
+	}
+}
+
+func TestXunhuPayCreatePayment(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errcode":0,"order_id":"up-1","url":"https://pay.example/checkout","url_qrcode":"weixin://wxpay/test"}`))
+	}))
+	defer server.Close()
+
+	prov, err := NewXunhuPay("x1", map[string]string{
+		"appId":      "app-1",
+		"secret":     "sec-1",
+		"gatewayUrl": server.URL,
+		"notifyUrl":  "https://merchant.example/notify",
+		"returnUrl":  "https://merchant.example/return",
+	})
+	if err != nil {
+		t.Fatalf("NewXunhuPay error: %v", err)
+	}
+	resp, err := prov.CreatePayment(context.Background(), payment.CreatePaymentRequest{
+		OrderID: "ord-1", Amount: "12.34", Subject: "Recharge",
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment error: %v", err)
+	}
+	if resp.TradeNo != "up-1" || resp.PayURL == "" || resp.QRCode == "" {
+		t.Fatalf("resp = %+v", resp)
+	}
+	if !strings.Contains(gotBody, "trade_order_id=ord-1") || !strings.Contains(gotBody, "hash=") {
+		t.Fatalf("request body missing expected params: %s", gotBody)
+	}
+}
+
+func TestXunhuPayCreatePaymentKeepsRemoteQRCodeImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errcode":0,"order_id":"up-2","url_qrcode":"https://pay.example/qrcode/order-2.png"}`))
+	}))
+	defer server.Close()
+
+	prov, err := NewXunhuPay("x1", map[string]string{
+		"appId":      "app-1",
+		"secret":     "sec-1",
+		"gatewayUrl": server.URL,
+		"notifyUrl":  "https://merchant.example/notify",
+		"returnUrl":  "https://merchant.example/return",
+	})
+	if err != nil {
+		t.Fatalf("NewXunhuPay error: %v", err)
+	}
+	resp, err := prov.CreatePayment(context.Background(), payment.CreatePaymentRequest{
+		OrderID: "ord-2", Amount: "12.34", Subject: "Recharge",
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment error: %v", err)
+	}
+	if resp.PayURL != "" {
+		t.Fatalf("pay_url = %q, want empty for remote qr image", resp.PayURL)
+	}
+	if resp.QRCode != "https://pay.example/qrcode/order-2.png" {
+		t.Fatalf("qr_code = %q", resp.QRCode)
+	}
+}
+
+func TestXunhuPayCreatePaymentTreatsHTTPURLQRCodeAsPayURL(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"errcode":0,"order_id":"up-2","url_qrcode":"https://pay.example/checkout-from-qrcode"}`))
+	}))
+	defer server.Close()
+
+	prov, err := NewXunhuPay("x1", map[string]string{
+		"appId":      "app-1",
+		"secret":     "sec-1",
+		"gatewayUrl": server.URL,
+		"notifyUrl":  "https://merchant.example/notify",
+		"returnUrl":  "https://merchant.example/return",
+	})
+	if err != nil {
+		t.Fatalf("NewXunhuPay error: %v", err)
+	}
+	resp, err := prov.CreatePayment(context.Background(), payment.CreatePaymentRequest{
+		OrderID: "ord-2", Amount: "12.34", Subject: "Recharge",
+	})
+	if err != nil {
+		t.Fatalf("CreatePayment error: %v", err)
+	}
+	if resp.PayURL != "https://pay.example/checkout-from-qrcode" {
+		t.Fatalf("pay_url = %q", resp.PayURL)
+	}
+	if resp.QRCode != "" {
+		t.Fatalf("qr_code = %q, want empty when url_qrcode is a checkout URL", resp.QRCode)
+	}
+}

--- a/backend/internal/payment/types.go
+++ b/backend/internal/payment/types.go
@@ -18,6 +18,8 @@ const (
 	TypeLink         PaymentType = "link"
 	TypeEasyPay      PaymentType = "easypay"
 	TypeAirwallex    PaymentType = "airwallex"
+	TypeXunhuPay     PaymentType = "xunhupay"
+	TypeWxpayXunhu   PaymentType = "wxpay_xunhu"
 )
 
 // Order status constants shared across payment and service layers.
@@ -85,6 +87,8 @@ func GetBasePaymentType(t string) string {
 		return TypeEasyPay
 	case t == TypeAirwallex:
 		return TypeAirwallex
+	case t == TypeXunhuPay || t == TypeWxpayXunhu:
+		return TypeXunhuPay
 	case t == TypeStripe || t == TypeCard || t == TypeLink:
 		return TypeStripe
 	case len(t) >= len(TypeAlipay) && t[:len(TypeAlipay)] == TypeAlipay:

--- a/backend/internal/repository/balance_package_repo.go
+++ b/backend/internal/repository/balance_package_repo.go
@@ -1,0 +1,212 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	dbent "github.com/Wei-Shaw/sub2api/ent"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+type balancePackageRepository struct {
+	client *dbent.Client
+}
+
+func NewBalancePackageRepository(client *dbent.Client) service.BalancePackageRepository {
+	return &balancePackageRepository{client: client}
+}
+
+func (r *balancePackageRepository) CreateBalancePackage(ctx context.Context, pkg *service.UserBalancePackage) error {
+	client := clientFromContext(ctx, r.client)
+	now := time.Now().UTC()
+	if pkg.Status == "" {
+		pkg.Status = service.BalancePackageStatusActive
+	}
+	if pkg.CreatedAt.IsZero() {
+		pkg.CreatedAt = now
+	}
+	if pkg.UpdatedAt.IsZero() {
+		pkg.UpdatedAt = now
+	}
+	if pkg.RemainingAmount == 0 && pkg.Amount > 0 {
+		pkg.RemainingAmount = pkg.Amount
+	}
+	rows, err := client.QueryContext(ctx, `
+INSERT INTO user_balance_packages
+	(user_id, redeem_code_id, amount, remaining_amount, expires_at, status, created_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+RETURNING id, created_at, updated_at
+`, pkg.UserID, pkg.RedeemCodeID, pkg.Amount, pkg.RemainingAmount, pkg.ExpiresAt, pkg.Status, pkg.CreatedAt, pkg.UpdatedAt)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		return service.ErrBalancePackageNotFound
+	}
+	return rows.Scan(&pkg.ID, &pkg.CreatedAt, &pkg.UpdatedAt)
+}
+
+func (r *balancePackageRepository) ListActiveBalancePackagesForUpdate(ctx context.Context, userID int64, now time.Time) ([]service.UserBalancePackage, error) {
+	client := clientFromContext(ctx, r.client)
+	rows, err := client.QueryContext(ctx, `
+SELECT id, user_id, redeem_code_id, amount, remaining_amount, expires_at, status, created_at, updated_at
+FROM user_balance_packages
+WHERE user_id = $1
+  AND status = $2
+  AND remaining_amount > 0
+  AND expires_at > $3
+ORDER BY expires_at ASC, id ASC
+FOR UPDATE
+`, userID, service.BalancePackageStatusActive, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]service.UserBalancePackage, 0)
+	for rows.Next() {
+		var pkg service.UserBalancePackage
+		var redeemCodeID sql.NullInt64
+		if err := rows.Scan(
+			&pkg.ID,
+			&pkg.UserID,
+			&redeemCodeID,
+			&pkg.Amount,
+			&pkg.RemainingAmount,
+			&pkg.ExpiresAt,
+			&pkg.Status,
+			&pkg.CreatedAt,
+			&pkg.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if redeemCodeID.Valid {
+			pkg.RedeemCodeID = &redeemCodeID.Int64
+		}
+		out = append(out, pkg)
+	}
+	return out, rows.Err()
+}
+
+func (r *balancePackageRepository) ListUserVisibleBalancePackages(ctx context.Context, userID int64, now time.Time) ([]service.UserBalancePackage, error) {
+	client := clientFromContext(ctx, r.client)
+	rows, err := client.QueryContext(ctx, `
+SELECT p.id, p.user_id, p.redeem_code_id, COALESCE(rc.code, ''), p.amount, p.remaining_amount, p.expires_at, p.status, p.created_at, p.updated_at
+FROM user_balance_packages p
+LEFT JOIN redeem_codes rc ON rc.id = p.redeem_code_id
+WHERE p.user_id = $1
+  AND p.status = $2
+  AND p.remaining_amount > 0
+  AND p.expires_at > $3
+ORDER BY p.expires_at ASC, p.id ASC
+`, userID, service.BalancePackageStatusActive, now)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make([]service.UserBalancePackage, 0)
+	for rows.Next() {
+		var pkg service.UserBalancePackage
+		var redeemCodeID sql.NullInt64
+		if err := rows.Scan(
+			&pkg.ID,
+			&pkg.UserID,
+			&redeemCodeID,
+			&pkg.RedeemCode,
+			&pkg.Amount,
+			&pkg.RemainingAmount,
+			&pkg.ExpiresAt,
+			&pkg.Status,
+			&pkg.CreatedAt,
+			&pkg.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if redeemCodeID.Valid {
+			pkg.RedeemCodeID = &redeemCodeID.Int64
+		}
+		out = append(out, pkg)
+	}
+	return out, rows.Err()
+}
+
+func (r *balancePackageRepository) UpdateBalancePackageRemaining(ctx context.Context, id int64, remaining float64, status string) error {
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(ctx, `
+UPDATE user_balance_packages
+SET remaining_amount = $2, status = $3, updated_at = NOW()
+WHERE id = $1
+`, id, remaining, status)
+	if err != nil {
+		return err
+	}
+	if n, err := result.RowsAffected(); err == nil && n == 0 {
+		return service.ErrBalancePackageNotFound
+	}
+	return nil
+}
+
+func (r *balancePackageRepository) GetUserBaseBalance(ctx context.Context, userID int64) (float64, error) {
+	client := clientFromContext(ctx, r.client)
+	var balance float64
+	rows, err := client.QueryContext(ctx, `SELECT balance FROM users WHERE id = $1`, userID)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if err := rows.Err(); err != nil {
+			return 0, err
+		}
+		return 0, service.ErrUserNotFound
+	}
+	if err := rows.Scan(&balance); err != nil {
+		return 0, err
+	}
+	return balance, nil
+}
+
+func (r *balancePackageRepository) UpdateUserBalance(ctx context.Context, userID int64, amount float64) error {
+	client := clientFromContext(ctx, r.client)
+	result, err := client.ExecContext(ctx, `
+UPDATE users
+SET balance = balance + $2, updated_at = NOW()
+WHERE id = $1
+`, userID, amount)
+	if err != nil {
+		return err
+	}
+	if n, err := result.RowsAffected(); err == nil && n == 0 {
+		return service.ErrUserNotFound
+	}
+	return nil
+}
+
+func (r *balancePackageRepository) SumActiveBalancePackages(ctx context.Context, userID int64, now time.Time) (float64, error) {
+	client := clientFromContext(ctx, r.client)
+	var sum float64
+	rows, err := client.QueryContext(ctx, `
+SELECT COALESCE(SUM(remaining_amount), 0)
+FROM user_balance_packages
+WHERE user_id = $1
+  AND status = $2
+  AND remaining_amount > 0
+  AND expires_at > $3
+`, userID, service.BalancePackageStatusActive, now)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+	if rows.Next() {
+		if err := rows.Scan(&sum); err != nil {
+			return 0, err
+		}
+	}
+	return sum, rows.Err()
+}

--- a/backend/internal/repository/redeem_code_repo.go
+++ b/backend/internal/repository/redeem_code_repo.go
@@ -23,12 +23,13 @@ func NewRedeemCodeRepository(client *dbent.Client) service.RedeemCodeRepository 
 }
 
 func (r *redeemCodeRepository) Create(ctx context.Context, code *service.RedeemCode) error {
+	notes := service.EncodeRedeemValiditySecondsNote(code.Notes, code.ValiditySeconds)
 	created, err := r.client.RedeemCode.Create().
 		SetCode(code.Code).
 		SetType(code.Type).
 		SetValue(code.Value).
 		SetStatus(code.Status).
-		SetNotes(code.Notes).
+		SetNotes(notes).
 		SetValidityDays(code.ValidityDays).
 		SetNillableExpiresAt(code.ExpiresAt).
 		SetNillableUsedBy(code.UsedBy).
@@ -50,12 +51,13 @@ func (r *redeemCodeRepository) CreateBatch(ctx context.Context, codes []service.
 	builders := make([]*dbent.RedeemCodeCreate, 0, len(codes))
 	for i := range codes {
 		c := &codes[i]
+		notes := service.EncodeRedeemValiditySecondsNote(c.Notes, c.ValiditySeconds)
 		b := r.client.RedeemCode.Create().
 			SetCode(c.Code).
 			SetType(c.Type).
 			SetValue(c.Value).
 			SetStatus(c.Status).
-			SetNotes(c.Notes).
+			SetNotes(notes).
 			SetValidityDays(c.ValidityDays).
 			SetNillableExpiresAt(c.ExpiresAt).
 			SetNillableUsedBy(c.UsedBy).
@@ -196,12 +198,13 @@ func redeemCodeListOrder(params pagination.PaginationParams) []func(*entsql.Sele
 }
 
 func (r *redeemCodeRepository) Update(ctx context.Context, code *service.RedeemCode) error {
+	notes := service.EncodeRedeemValiditySecondsNote(code.Notes, code.ValiditySeconds)
 	up := r.client.RedeemCode.UpdateOneID(code.ID).
 		SetCode(code.Code).
 		SetType(code.Type).
 		SetValue(code.Value).
 		SetStatus(code.Status).
-		SetNotes(code.Notes).
+		SetNotes(notes).
 		SetValidityDays(code.ValidityDays)
 
 	if code.UsedBy != nil {
@@ -412,19 +415,21 @@ func redeemCodeEntityToService(m *dbent.RedeemCode) *service.RedeemCode {
 	if m == nil {
 		return nil
 	}
+	notes, validitySeconds := service.DecodeRedeemValiditySecondsNote(derefString(m.Notes))
 	out := &service.RedeemCode{
-		ID:           m.ID,
-		Code:         m.Code,
-		Type:         m.Type,
-		Value:        m.Value,
-		Status:       m.Status,
-		UsedBy:       m.UsedBy,
-		UsedAt:       m.UsedAt,
-		Notes:        derefString(m.Notes),
-		CreatedAt:    m.CreatedAt,
-		ExpiresAt:    m.ExpiresAt,
-		GroupID:      m.GroupID,
-		ValidityDays: m.ValidityDays,
+		ID:              m.ID,
+		Code:            m.Code,
+		Type:            m.Type,
+		Value:           m.Value,
+		Status:          m.Status,
+		UsedBy:          m.UsedBy,
+		UsedAt:          m.UsedAt,
+		Notes:           notes,
+		CreatedAt:       m.CreatedAt,
+		ExpiresAt:       m.ExpiresAt,
+		GroupID:         m.GroupID,
+		ValidityDays:    m.ValidityDays,
+		ValiditySeconds: validitySeconds,
 	}
 	if m.Edges.User != nil {
 		out.User = userEntityToService(m.Edges.User)

--- a/backend/internal/server/routes/payment.go
+++ b/backend/internal/server/routes/payment.go
@@ -44,6 +44,9 @@ func RegisterPaymentRoutes(
 	}
 
 	// --- Public payment endpoints (no auth) ---
+	v1.GET("/payment/catalog/products", paymentHandler.GetCatalogProducts)
+	v1.GET("/catalog/products", paymentHandler.GetCatalogProducts)
+	v1.GET("/catalog/products/legacy", paymentHandler.GetCatalogProductsLegacy)
 	// Signed resume-token recovery is the preferred public lookup path.
 	// The legacy anonymous out_trade_no verify endpoint remains available as a
 	// persisted-state compatibility path for staggered upgrades.
@@ -52,6 +55,7 @@ func RegisterPaymentRoutes(
 		public.POST("/orders/verify", paymentHandler.VerifyOrderPublic)
 		public.POST("/orders/resolve", paymentHandler.ResolveOrderPublicByResumeToken)
 	}
+	v1.GET("/subscription-plans", paymentHandler.GetPlansLegacy)
 
 	// --- Webhook endpoints (no auth) ---
 	webhook := v1.Group("/payment/webhook")
@@ -63,6 +67,8 @@ func RegisterPaymentRoutes(
 		webhook.POST("/wxpay", webhookHandler.WxpayNotify)
 		webhook.POST("/stripe", webhookHandler.StripeWebhook)
 		webhook.POST("/airwallex", webhookHandler.AirwallexWebhook)
+		webhook.GET("/xunhupay", webhookHandler.XunhuPayNotify)
+		webhook.POST("/xunhupay", webhookHandler.XunhuPayNotify)
 	}
 
 	// --- Admin payment endpoints (admin auth) ---
@@ -75,6 +81,8 @@ func RegisterPaymentRoutes(
 		// Config
 		adminGroup.GET("/config", adminPaymentHandler.GetConfig)
 		adminGroup.PUT("/config", adminPaymentHandler.UpdateConfig)
+		adminGroup.GET("/products", adminPaymentHandler.GetCatalogProducts)
+		adminGroup.PUT("/products", adminPaymentHandler.UpdateCatalogProducts)
 
 		// Orders
 		adminOrders := adminGroup.Group("/orders")
@@ -103,5 +111,14 @@ func RegisterPaymentRoutes(
 			providers.PUT("/:id", adminPaymentHandler.UpdateProvider)
 			providers.DELETE("/:id", adminPaymentHandler.DeleteProvider)
 		}
+	}
+
+	legacyAdminPlans := v1.Group("/admin/subscription-plans")
+	legacyAdminPlans.Use(gin.HandlerFunc(adminAuth))
+	{
+		legacyAdminPlans.GET("", adminPaymentHandler.ListPlansLegacy)
+		legacyAdminPlans.POST("", adminPaymentHandler.CreatePlanLegacy)
+		legacyAdminPlans.PUT("/:id", adminPaymentHandler.UpdatePlanLegacy)
+		legacyAdminPlans.DELETE("/:id", adminPaymentHandler.DeletePlanLegacy)
 	}
 }

--- a/backend/internal/server/routes/payment_legacy_routes_test.go
+++ b/backend/internal/server/routes/payment_legacy_routes_test.go
@@ -1,0 +1,80 @@
+//go:build unit
+
+package routes
+
+import (
+	"net/http"
+	"testing"
+
+	userhandler "github.com/Wei-Shaw/sub2api/internal/handler"
+	adminhandler "github.com/Wei-Shaw/sub2api/internal/handler/admin"
+	servermiddleware "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaymentLegacyRoutesAreRegistered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	v1 := router.Group("/api/v1")
+	RegisterPaymentRoutes(
+		v1,
+		userhandler.NewPaymentHandler(nil, nil, nil),
+		nil,
+		adminhandler.NewPaymentHandler(nil, nil),
+		servermiddleware.JWTAuthMiddleware(func(c *gin.Context) { c.Next() }),
+		servermiddleware.AdminAuthMiddleware(func(c *gin.Context) { c.Next() }),
+		nil,
+	)
+
+	expected := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/subscription-plans"},
+		{http.MethodGet, "/api/v1/admin/subscription-plans"},
+		{http.MethodPost, "/api/v1/admin/subscription-plans"},
+		{http.MethodPut, "/api/v1/admin/subscription-plans/:id"},
+		{http.MethodDelete, "/api/v1/admin/subscription-plans/:id"},
+	}
+	for _, route := range expected {
+		require.True(t, routeExists(router.Routes(), route.method, route.path), "%s %s", route.method, route.path)
+	}
+}
+
+func TestSub2ApiAdminPaymentLegacyRoutesAreRegistered(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	admin := router.Group("/api/v1/admin")
+	h := &userhandler.Handlers{Admin: &userhandler.AdminHandlers{
+		Group:        adminhandler.NewGroupHandler(nil, nil, nil),
+		User:         adminhandler.NewUserHandler(nil, nil, nil, nil, nil),
+		Subscription: adminhandler.NewSubscriptionHandler(nil),
+		Payment:      adminhandler.NewPaymentHandler(nil, nil),
+	}}
+
+	registerGroupRoutes(admin, h)
+
+	expected := []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/api/v1/admin/sub2api/dashboard"},
+		{http.MethodGet, "/api/v1/admin/sub2api/orders"},
+		{http.MethodGet, "/api/v1/admin/sub2api/orders/:id"},
+		{http.MethodPost, "/api/v1/admin/sub2api/orders/:id/cancel"},
+		{http.MethodPost, "/api/v1/admin/sub2api/orders/:id/retry"},
+	}
+	for _, route := range expected {
+		require.True(t, routeExists(router.Routes(), route.method, route.path), "%s %s", route.method, route.path)
+	}
+}
+
+func routeExists(routes gin.RoutesInfo, method string, path string) bool {
+	for _, route := range routes {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -38,6 +38,7 @@ type AdminService interface {
 	UpdateUser(ctx context.Context, id int64, input *UpdateUserInput) (*User, error)
 	DeleteUser(ctx context.Context, id int64) error
 	UpdateUserBalance(ctx context.Context, userID int64, balance float64, operation string, notes string) (*User, error)
+	AddUserBalancePackage(ctx context.Context, userID int64, amount float64, validityDays float64, notes string) (*User, error)
 	BatchUpdateConcurrency(ctx context.Context, userIDs []int64, value int, mode string) (int, error)
 	GetUserAPIKeys(ctx context.Context, userID int64, page, pageSize int, sortBy, sortOrder string) ([]APIKey, int64, error)
 	GetUserUsageStats(ctx context.Context, userID int64, period string) (any, error)
@@ -406,8 +407,8 @@ type GenerateRedeemCodesInput struct {
 	Count        int
 	Type         string
 	Value        float64
-	GroupID      *int64 // 订阅类型专用：关联的分组ID
-	ValidityDays int    // 订阅类型专用：有效天数
+	GroupID      *int64  // 订阅类型专用：关联的分组ID
+	ValidityDays float64 // 订阅类型专用：有效天数，允许 0.5 这种小数
 	ExpiresAt    *time.Time
 }
 
@@ -531,6 +532,7 @@ type adminServiceImpl struct {
 	proxyRepo            ProxyRepository
 	apiKeyRepo           APIKeyRepository
 	redeemCodeRepo       RedeemCodeRepository
+	balancePackageRepo   BalancePackageRepository
 	userGroupRateRepo    UserGroupRateRepository
 	userRPMCache         UserRPMCache
 	billingCacheService  *BillingCacheService
@@ -557,6 +559,7 @@ func NewAdminService(
 	proxyRepo ProxyRepository,
 	apiKeyRepo APIKeyRepository,
 	redeemCodeRepo RedeemCodeRepository,
+	balancePackageRepo BalancePackageRepository,
 	userGroupRateRepo UserGroupRateRepository,
 	userRPMCache UserRPMCache,
 	billingCacheService *BillingCacheService,
@@ -577,6 +580,7 @@ func NewAdminService(
 		proxyRepo:            proxyRepo,
 		apiKeyRepo:           apiKeyRepo,
 		redeemCodeRepo:       redeemCodeRepo,
+		balancePackageRepo:   balancePackageRepo,
 		userGroupRateRepo:    userGroupRateRepo,
 		userRPMCache:         userRPMCache,
 		billingCacheService:  billingCacheService,
@@ -1009,6 +1013,77 @@ func (s *adminServiceImpl) UpdateUserBalance(ctx context.Context, userID int64, 
 		if err := s.redeemCodeRepo.Create(ctx, adjustmentRecord); err != nil {
 			logger.LegacyPrintf("service.admin", "failed to create balance adjustment redeem code: %v", err)
 		}
+	}
+
+	return user, nil
+}
+
+func (s *adminServiceImpl) AddUserBalancePackage(ctx context.Context, userID int64, amount float64, validityDays float64, notes string) (*User, error) {
+	if amount <= 0 {
+		return nil, errors.New("amount must be greater than 0")
+	}
+	validityDaysInt, validitySeconds, err := NormalizeRedeemValidityDays(validityDays)
+	if err != nil {
+		return nil, err
+	}
+	if validitySeconds <= 0 && validityDaysInt > 0 {
+		validitySeconds = int64(validityDaysInt) * 24 * int64(time.Hour/time.Second)
+	}
+	if validitySeconds <= 0 {
+		return nil, errors.New("balance package validity must be greater than 0")
+	}
+	if s.balancePackageRepo == nil {
+		return nil, errors.New("balance package repository not configured")
+	}
+
+	user, err := s.userRepo.GetByID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	code, err := GenerateRedeemCode()
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	expiresAt := now.Add(time.Duration(validitySeconds) * time.Second)
+	adjustmentRecord := &RedeemCode{
+		Code:            code,
+		Type:            RedeemTypeBalance,
+		Value:           amount,
+		Status:          StatusUsed,
+		UsedBy:          &user.ID,
+		ValidityDays:    0,
+		ValiditySeconds: validitySeconds,
+		Notes:           notes,
+	}
+	adjustmentRecord.UsedAt = &now
+	if err := s.redeemCodeRepo.Create(ctx, adjustmentRecord); err != nil {
+		return nil, err
+	}
+	redeemCodeID := adjustmentRecord.ID
+	if err := s.balancePackageRepo.CreateBalancePackage(ctx, &UserBalancePackage{
+		UserID:          user.ID,
+		RedeemCodeID:    &redeemCodeID,
+		Amount:          amount,
+		RemainingAmount: amount,
+		ExpiresAt:       expiresAt,
+		Status:          BalancePackageStatusActive,
+	}); err != nil {
+		return nil, err
+	}
+
+	if s.authCacheInvalidator != nil {
+		s.authCacheInvalidator.InvalidateAuthCacheByUserID(ctx, userID)
+	}
+	if s.billingCacheService != nil {
+		go func() {
+			cacheCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := s.billingCacheService.InvalidateUserBalance(cacheCtx, userID); err != nil {
+				logger.LegacyPrintf("service.admin", "invalidate user balance cache failed: user_id=%d err=%v", userID, err)
+			}
+		}()
 	}
 
 	return user, nil
@@ -3194,11 +3269,29 @@ func (s *adminServiceImpl) GenerateRedeemCodes(ctx context.Context, input *Gener
 		}
 		// 订阅类型专用字段
 		if input.Type == RedeemTypeSubscription {
-			code.GroupID = input.GroupID
-			code.ValidityDays = input.ValidityDays
-			if code.ValidityDays <= 0 {
-				code.ValidityDays = 30 // 默认30天
+			validityDays, validitySeconds, err := NormalizeRedeemValidityDays(input.ValidityDays)
+			if err != nil {
+				return nil, err
 			}
+			code.GroupID = input.GroupID
+			code.ValidityDays = validityDays
+			code.ValiditySeconds = validitySeconds
+			if code.ValidityDays <= 0 {
+				if code.ValiditySeconds <= 0 {
+					code.ValidityDays = 30 // 默认30天
+				}
+			}
+		}
+		if input.Type == RedeemTypeBalance && input.ValidityDays > 0 {
+			validityDays, validitySeconds, err := NormalizeRedeemValidityDays(input.ValidityDays)
+			if err != nil {
+				return nil, err
+			}
+			if validitySeconds <= 0 && validityDays > 0 {
+				validitySeconds = int64(validityDays) * 24 * int64(time.Hour/time.Second)
+			}
+			code.ValidityDays = 0
+			code.ValiditySeconds = validitySeconds
 		}
 		if err := s.redeemCodeRepo.Create(ctx, &code); err != nil {
 			return nil, err

--- a/backend/internal/service/balance_package.go
+++ b/backend/internal/service/balance_package.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+)
+
+const (
+	BalancePackageStatusActive   = "active"
+	BalancePackageStatusDepleted = "depleted"
+	BalancePackageStatusExpired  = "expired"
+)
+
+var ErrBalancePackageNotFound = infraerrors.NotFound("BALANCE_PACKAGE_NOT_FOUND", "balance package not found")
+
+type UserBalancePackage struct {
+	ID              int64
+	UserID          int64
+	RedeemCodeID    *int64
+	RedeemCode      string
+	Amount          float64
+	RemainingAmount float64
+	ExpiresAt       time.Time
+	Status          string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+type BalancePackageRepository interface {
+	CreateBalancePackage(ctx context.Context, pkg *UserBalancePackage) error
+	ListActiveBalancePackagesForUpdate(ctx context.Context, userID int64, now time.Time) ([]UserBalancePackage, error)
+	UpdateBalancePackageRemaining(ctx context.Context, id int64, remaining float64, status string) error
+	GetUserBaseBalance(ctx context.Context, userID int64) (float64, error)
+	UpdateUserBalance(ctx context.Context, userID int64, amount float64) error
+	SumActiveBalancePackages(ctx context.Context, userID int64, now time.Time) (float64, error)
+	ListUserVisibleBalancePackages(ctx context.Context, userID int64, now time.Time) ([]UserBalancePackage, error)
+}
+
+func DeductUserBalanceWithPackages(ctx context.Context, repo BalancePackageRepository, userID int64, amount float64, now time.Time) (float64, error) {
+	if repo == nil || amount <= 0 {
+		return amount, nil
+	}
+	packages, err := repo.ListActiveBalancePackagesForUpdate(ctx, userID, now)
+	if err != nil {
+		return amount, err
+	}
+	sort.SliceStable(packages, func(i, j int) bool {
+		if packages[i].ExpiresAt.Equal(packages[j].ExpiresAt) {
+			return packages[i].ID < packages[j].ID
+		}
+		return packages[i].ExpiresAt.Before(packages[j].ExpiresAt)
+	})
+
+	remainingCost := amount
+	for _, pkg := range packages {
+		if remainingCost <= 0 {
+			break
+		}
+		if pkg.RemainingAmount <= 0 {
+			continue
+		}
+		deduct := pkg.RemainingAmount
+		if deduct > remainingCost {
+			deduct = remainingCost
+		}
+		newRemaining := pkg.RemainingAmount - deduct
+		status := BalancePackageStatusActive
+		if newRemaining <= 0 {
+			newRemaining = 0
+			status = BalancePackageStatusDepleted
+		}
+		if err := repo.UpdateBalancePackageRemaining(ctx, pkg.ID, newRemaining, status); err != nil {
+			return remainingCost, err
+		}
+		remainingCost -= deduct
+	}
+
+	if remainingCost > 0 {
+		if err := repo.UpdateUserBalance(ctx, userID, -remainingCost); err != nil {
+			return remainingCost, err
+		}
+	}
+	return 0, nil
+}
+
+func GetUserAvailableBalanceWithPackages(ctx context.Context, repo BalancePackageRepository, userID int64, now time.Time) (float64, error) {
+	if repo == nil {
+		return 0, nil
+	}
+	base, err := repo.GetUserBaseBalance(ctx, userID)
+	if err != nil {
+		return 0, err
+	}
+	pkgBalance, err := repo.SumActiveBalancePackages(ctx, userID, now)
+	if err != nil {
+		return 0, err
+	}
+	return base + pkgBalance, nil
+}

--- a/backend/internal/service/balance_package_test.go
+++ b/backend/internal/service/balance_package_test.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeductBalancePackagesConsumesEarliestExpiryFirst(t *testing.T) {
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	earlyExpiry := now.Add(2 * time.Hour)
+	lateExpiry := now.Add(4 * time.Hour)
+	packages := []UserBalancePackage{
+		{ID: 1, UserID: 42, RemainingAmount: 3, ExpiresAt: lateExpiry, Status: BalancePackageStatusActive},
+		{ID: 2, UserID: 42, RemainingAmount: 5, ExpiresAt: earlyExpiry, Status: BalancePackageStatusActive},
+	}
+	repo := newMemoryBalancePackageRepo(packages, 0)
+
+	remaining, err := DeductUserBalanceWithPackages(context.Background(), repo, 42, 6, now)
+
+	require.NoError(t, err)
+	require.Zero(t, remaining)
+	require.InDelta(t, 2, repo.packageByID(1).RemainingAmount, 1e-9)
+	require.InDelta(t, 0, repo.packageByID(2).RemainingAmount, 1e-9)
+	require.Equal(t, BalancePackageStatusActive, repo.packageByID(1).Status)
+	require.Equal(t, BalancePackageStatusDepleted, repo.packageByID(2).Status)
+	require.Empty(t, repo.userBalanceDeltas)
+}
+
+func TestDeductBalancePackagesFallsBackToUserBalance(t *testing.T) {
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	repo := newMemoryBalancePackageRepo([]UserBalancePackage{
+		{ID: 1, UserID: 42, RemainingAmount: 2, ExpiresAt: now.Add(time.Hour), Status: BalancePackageStatusActive},
+	}, 10)
+
+	remaining, err := DeductUserBalanceWithPackages(context.Background(), repo, 42, 5, now)
+
+	require.NoError(t, err)
+	require.Zero(t, remaining)
+	require.InDelta(t, 0, repo.packageByID(1).RemainingAmount, 1e-9)
+	require.Equal(t, BalancePackageStatusDepleted, repo.packageByID(1).Status)
+	require.Equal(t, []float64{-3}, repo.userBalanceDeltas)
+	require.InDelta(t, 7, repo.userBalance, 1e-9)
+}
+
+func TestAvailableBalanceIncludesOnlyUnexpiredPackages(t *testing.T) {
+	now := time.Date(2026, 6, 13, 10, 0, 0, 0, time.UTC)
+	repo := newMemoryBalancePackageRepo([]UserBalancePackage{
+		{ID: 1, UserID: 42, RemainingAmount: 2, ExpiresAt: now.Add(time.Hour), Status: BalancePackageStatusActive},
+		{ID: 2, UserID: 42, RemainingAmount: 9, ExpiresAt: now.Add(-time.Hour), Status: BalancePackageStatusActive},
+		{ID: 3, UserID: 42, RemainingAmount: 4, ExpiresAt: now.Add(time.Hour), Status: BalancePackageStatusDepleted},
+	}, 1.5)
+
+	available, err := GetUserAvailableBalanceWithPackages(context.Background(), repo, 42, now)
+
+	require.NoError(t, err)
+	require.InDelta(t, 3.5, available, 1e-9)
+}
+
+func TestShouldDeductBalanceForBillingTypeOnlyBalance(t *testing.T) {
+	require.True(t, shouldDeductBalanceForBillingType(BillingTypeBalance, 1))
+	require.False(t, shouldDeductBalanceForBillingType(BillingTypeSubscription, 1))
+	require.False(t, shouldDeductBalanceForBillingType(BillingTypeBalance, 0))
+}
+
+type memoryBalancePackageRepo struct {
+	packages          []UserBalancePackage
+	userBalance       float64
+	userBalanceDeltas []float64
+}
+
+func newMemoryBalancePackageRepo(packages []UserBalancePackage, userBalance float64) *memoryBalancePackageRepo {
+	cp := make([]UserBalancePackage, len(packages))
+	copy(cp, packages)
+	return &memoryBalancePackageRepo{packages: cp, userBalance: userBalance}
+}
+
+func (r *memoryBalancePackageRepo) ListActiveBalancePackagesForUpdate(ctx context.Context, userID int64, now time.Time) ([]UserBalancePackage, error) {
+	out := make([]UserBalancePackage, 0, len(r.packages))
+	for _, pkg := range r.packages {
+		if pkg.UserID == userID && pkg.Status == BalancePackageStatusActive && pkg.RemainingAmount > 0 && pkg.ExpiresAt.After(now) {
+			out = append(out, pkg)
+		}
+	}
+	return out, nil
+}
+
+func (r *memoryBalancePackageRepo) ListUserVisibleBalancePackages(ctx context.Context, userID int64, now time.Time) ([]UserBalancePackage, error) {
+	return r.ListActiveBalancePackagesForUpdate(ctx, userID, now)
+}
+
+func (r *memoryBalancePackageRepo) CreateBalancePackage(ctx context.Context, pkg *UserBalancePackage) error {
+	if pkg.ID == 0 {
+		pkg.ID = int64(len(r.packages) + 1)
+	}
+	r.packages = append(r.packages, *pkg)
+	return nil
+}
+
+func (r *memoryBalancePackageRepo) UpdateBalancePackageRemaining(ctx context.Context, id int64, remaining float64, status string) error {
+	for i := range r.packages {
+		if r.packages[i].ID == id {
+			r.packages[i].RemainingAmount = remaining
+			r.packages[i].Status = status
+			return nil
+		}
+	}
+	return ErrBalancePackageNotFound
+}
+
+func (r *memoryBalancePackageRepo) GetUserBaseBalance(ctx context.Context, userID int64) (float64, error) {
+	return r.userBalance, nil
+}
+
+func (r *memoryBalancePackageRepo) UpdateUserBalance(ctx context.Context, userID int64, amount float64) error {
+	r.userBalance += amount
+	r.userBalanceDeltas = append(r.userBalanceDeltas, amount)
+	return nil
+}
+
+func (r *memoryBalancePackageRepo) SumActiveBalancePackages(ctx context.Context, userID int64, now time.Time) (float64, error) {
+	sum := 0.0
+	for _, pkg := range r.packages {
+		if pkg.UserID == userID && pkg.Status == BalancePackageStatusActive && pkg.RemainingAmount > 0 && pkg.ExpiresAt.After(now) {
+			sum += pkg.RemainingAmount
+		}
+	}
+	return sum, nil
+}
+
+func (r *memoryBalancePackageRepo) packageByID(id int64) UserBalancePackage {
+	for _, pkg := range r.packages {
+		if pkg.ID == id {
+			return pkg
+		}
+	}
+	return UserBalancePackage{}
+}

--- a/backend/internal/service/payment_balance_tiers.go
+++ b/backend/internal/service/payment_balance_tiers.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+
+	"github.com/shopspring/decimal"
+)
+
+type BalancePricingTier struct {
+	Min        float64 `json:"min"`
+	Max        float64 `json:"max"`
+	Multiplier float64 `json:"multiplier"`
+	Label      string  `json:"label"`
+	Enabled    bool    `json:"enabled"`
+	SortOrder  int     `json:"sortOrder"`
+}
+
+type ResolvedBalanceTier struct {
+	Tier           *BalancePricingTier
+	Multiplier     float64
+	CreditedAmount float64
+	Label          string
+}
+
+func parseBalancePricingTiers(raw string) ([]BalancePricingTier, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var parsed []struct {
+		Min        float64 `json:"min"`
+		Max        float64 `json:"max"`
+		Multiplier float64 `json:"multiplier"`
+		Label      string  `json:"label"`
+		Enabled    *bool   `json:"enabled"`
+		SortOrder  *int    `json:"sortOrder"`
+	}
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("parse balance pricing tiers: %w", err)
+	}
+	tiers := make([]BalancePricingTier, 0, len(parsed))
+	for i, item := range parsed {
+		label := strings.TrimSpace(item.Label)
+		if !isFinitePositiveOrZero(item.Min) || !isFinitePositiveOrZero(item.Max) || item.Min > item.Max {
+			return nil, fmt.Errorf("invalid min/max at tier %d", i)
+		}
+		if math.IsNaN(item.Multiplier) || math.IsInf(item.Multiplier, 0) || item.Multiplier <= 0 {
+			return nil, fmt.Errorf("invalid multiplier at tier %d", i)
+		}
+		if label == "" {
+			return nil, fmt.Errorf("invalid label at tier %d", i)
+		}
+		enabled := true
+		if item.Enabled != nil {
+			enabled = *item.Enabled
+		}
+		if !enabled {
+			continue
+		}
+		sortOrder := i
+		if item.SortOrder != nil {
+			sortOrder = *item.SortOrder
+		}
+		tiers = append(tiers, BalancePricingTier{
+			Min:        roundMoney(item.Min),
+			Max:        roundMoney(item.Max),
+			Multiplier: item.Multiplier,
+			Label:      label,
+			Enabled:    true,
+			SortOrder:  sortOrder,
+		})
+	}
+	sort.SliceStable(tiers, func(i, j int) bool {
+		if tiers[i].SortOrder != tiers[j].SortOrder {
+			return tiers[i].SortOrder < tiers[j].SortOrder
+		}
+		return tiers[i].Min < tiers[j].Min
+	})
+	for i := 1; i < len(tiers); i++ {
+		if tiers[i].Min <= tiers[i-1].Max {
+			return nil, fmt.Errorf("balance pricing tiers overlap at index %d", i)
+		}
+	}
+	return tiers, nil
+}
+
+func formatBalancePricingTiers(tiers []BalancePricingTier) (string, error) {
+	if len(tiers) == 0 {
+		return "", nil
+	}
+	raw, err := json.Marshal(tiers)
+	if err != nil {
+		return "", fmt.Errorf("serialize balance pricing tiers: %w", err)
+	}
+	normalized, err := parseBalancePricingTiers(string(raw))
+	if err != nil {
+		return "", err
+	}
+	out, err := json.Marshal(normalized)
+	if err != nil {
+		return "", fmt.Errorf("serialize normalized balance pricing tiers: %w", err)
+	}
+	return string(out), nil
+}
+
+func resolveBalancePricingTier(amount float64, tiers []BalancePricingTier, fallbackMultiplier float64) ResolvedBalanceTier {
+	multiplier := normalizeBalanceRechargeMultiplier(fallbackMultiplier)
+	var matched *BalancePricingTier
+	for i := range tiers {
+		if amount >= tiers[i].Min && amount <= tiers[i].Max {
+			matched = &tiers[i]
+			multiplier = tiers[i].Multiplier
+			break
+		}
+	}
+	resolved := ResolvedBalanceTier{
+		Tier:           matched,
+		Multiplier:     multiplier,
+		CreditedAmount: calculateCreditedBalanceFromPayAmount(amount, multiplier),
+	}
+	if matched != nil {
+		resolved.Label = matched.Label
+	}
+	return resolved
+}
+
+func calculateCreditedBalanceFromPayAmount(paymentAmount, multiplier float64) float64 {
+	if paymentAmount <= 0 || math.IsNaN(paymentAmount) || math.IsInf(paymentAmount, 0) {
+		return 0
+	}
+	multiplier = normalizeBalanceRechargeMultiplier(multiplier)
+	return decimal.NewFromFloat(paymentAmount).
+		Div(decimal.NewFromFloat(multiplier)).
+		Round(2).
+		InexactFloat64()
+}
+
+func roundMoney(value float64) float64 {
+	return decimal.NewFromFloat(value).Round(2).InexactFloat64()
+}
+
+func isFinitePositiveOrZero(value float64) bool {
+	return !math.IsNaN(value) && !math.IsInf(value, 0) && value >= 0
+}

--- a/backend/internal/service/payment_balance_tiers_test.go
+++ b/backend/internal/service/payment_balance_tiers_test.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBalancePricingTierUsesFirstEnabledMatchingTier(t *testing.T) {
+	tiers, err := parseBalancePricingTiers(`[{"min":100,"max":500,"multiplier":7.3,"label":"vip","enabled":true,"sortOrder":2},{"min":1,"max":99,"multiplier":1,"label":"base","enabled":true,"sortOrder":1}]`)
+	require.NoError(t, err)
+
+	resolved := resolveBalancePricingTier(320, tiers, 1)
+
+	require.Equal(t, "vip", resolved.Label)
+	require.Equal(t, 7.3, resolved.Multiplier)
+	require.Equal(t, 43.84, resolved.CreditedAmount)
+}
+
+func TestResolveBalancePricingTierFallsBackToGlobalMultiplier(t *testing.T) {
+	tiers, err := parseBalancePricingTiers(`[{"min":100,"max":500,"multiplier":7.3,"label":"vip","enabled":false,"sortOrder":1}]`)
+	require.NoError(t, err)
+
+	resolved := resolveBalancePricingTier(50, tiers, 2)
+
+	require.Empty(t, resolved.Label)
+	require.Equal(t, 2.0, resolved.Multiplier)
+	require.Equal(t, 25.0, resolved.CreditedAmount)
+}
+
+func TestParseBalancePricingTiersRejectsOverlap(t *testing.T) {
+	_, err := parseBalancePricingTiers(`[{"min":1,"max":100,"multiplier":1,"label":"a","enabled":true},{"min":100,"max":200,"multiplier":2,"label":"b","enabled":true}]`)
+	require.Error(t, err)
+}

--- a/backend/internal/service/payment_catalog.go
+++ b/backend/internal/service/payment_catalog.go
@@ -1,0 +1,250 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const SettingCatalogProducts = "PAYMENT_CATALOG_PRODUCTS"
+
+const (
+	CatalogProductTypeTopup        = "topup"
+	CatalogProductTypeSubscription = "subscription"
+)
+
+type CatalogProduct struct {
+	Slug        string   `json:"slug"`
+	Title       string   `json:"title"`
+	Category    string   `json:"category"`
+	Summary     string   `json:"summary"`
+	Description string   `json:"description"`
+	Image       string   `json:"image"`
+	CardImage   string   `json:"cardImage,omitempty"`
+	Tags        []string `json:"tags"`
+	PriceLabel  string   `json:"priceLabel"`
+	Currency    string   `json:"currency,omitempty"`
+	Badge       string   `json:"badge,omitempty"`
+	Active      bool     `json:"active"`
+	SortOrder   int      `json:"sortOrder"`
+	ProductType string   `json:"productType"`
+	Amount      float64  `json:"amount,omitempty"`
+	PlanID      string   `json:"planId,omitempty"`
+	CTAText     string   `json:"ctaText,omitempty"`
+}
+
+var defaultCatalogProducts = []CatalogProduct{
+	{Slug: "an-liang-ti-yan-5-mei-jin", Title: "余额充值|体验|5美金额度", Category: "余额充值", Summary: "每个人只能兑换一次，多买无用", Description: "适合首次体验。购买后可直接用于模型调用。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/33550c5e-188a-4e16-a669-0cc78b84d48a.webp", Tags: []string{"体验"}, PriceLabel: "1.00", Currency: "CNY", Active: true, SortOrder: 10, ProductType: CatalogProductTypeTopup, Amount: 5, CTAText: "立即购买"},
+	{Slug: "mei-ri-1-5-mei-jin-xiao-hao-yue-ka", Title: "入门版 | 15美金额度/天 | 月卡", Category: "个人月卡", Summary: "≈ 0.44 ¥/USD\nopus | sonnet | haiku", Description: "适合个人轻量长期使用，按月订阅。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/21c272a0-492d-45f4-bb06-934303098c6f.webp", Tags: []string{"体验"}, PriceLabel: "199.00", Currency: "CNY", Active: true, SortOrder: 20, ProductType: CatalogProductTypeSubscription, CTAText: "开通月卡"},
+	{Slug: "mei-ri-3-0-mei-jin-xiao-hao-yue-ka", Title: "轻量版 | 30美金额度/天 | 月卡", Category: "个人月卡", Summary: "≈ 0.38 ¥/USD\n省 15%\nopus | sonnet | haiku", Description: "更高日额度，适合稳定使用。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/7ec9bfd1-57e4-40c7-adbf-4f81fb3bf117.webp", Tags: []string{"轻量"}, PriceLabel: "339.00", Currency: "CNY", Active: true, SortOrder: 30, ProductType: CatalogProductTypeSubscription, CTAText: "开通月卡"},
+	{Slug: "mei-ri-5-0-mei-jin-xiao-hao-yue-ka", Title: "标准版 ⭐ | 50美金额度/天 | 月卡", Category: "个人月卡", Summary: "≈ 0.33 ¥/USD\n省 25%\nopus | sonnet | haiku", Description: "最适合大多数用户的标准套餐。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/faa83df5-e1eb-42b0-8462-420c54c663ab.webp", Tags: []string{"推荐⭐"}, PriceLabel: "499.00", Currency: "CNY", Active: true, SortOrder: 40, ProductType: CatalogProductTypeSubscription, CTAText: "开通月卡"},
+	{Slug: "gao-ji-ban-1-2-0-mei-jin-tian-yue-ka", Title: "高级版👑 | 120美金额度/天 | 月卡", Category: "个人月卡", Summary: "≈ 0.33 ¥/USD\n省 25%\nopus | sonnet | haiku", Description: "高强度用户推荐，日额度更大。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/f695ccc2-5bfb-4d05-a508-a5c06330ae4c.webp", Tags: []string{"进阶👑"}, PriceLabel: "1188.00", Currency: "CNY", Active: true, SortOrder: 50, ProductType: CatalogProductTypeSubscription, CTAText: "开通月卡"},
+	{Slug: "an-liang-fu-fei-2-0-mei-jin", Title: "余额充值|20美金额度", Category: "余额充值", Summary: "畅快使用 opus | sonnet | haiku", Description: "适合短期使用与测试。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/82e73a36-d5ba-4e61-8d08-4ee798ec67ff.webp", Tags: []string{}, PriceLabel: "20.00", Currency: "CNY", Active: true, SortOrder: 60, ProductType: CatalogProductTypeTopup, Amount: 20, CTAText: "立即充值"},
+	{Slug: "an-liang-fu-fei-5-0-mei-jin", Title: "余额充值|50美金额度", Category: "余额充值", Summary: "畅快使用 opus | sonnet | haiku", Description: "适合中轻度用户灵活充值。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/5ea3833a-d4fd-4646-a339-db3d227ba489.webp", Tags: []string{}, PriceLabel: "50.00", Currency: "CNY", Active: true, SortOrder: 70, ProductType: CatalogProductTypeTopup, Amount: 50, CTAText: "立即充值"},
+	{Slug: "an-liang-fu-fei-1-0-0-mei-jin", Title: "余额充值|100美金额度", Category: "余额充值", Summary: "畅快使用 opus | sonnet | haiku", Description: "适合稳定使用的常规充值档位。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/3c07ae71-3585-44b5-8d87-e38de91359d2.webp", Tags: []string{}, PriceLabel: "100.00", Currency: "CNY", Active: true, SortOrder: 80, ProductType: CatalogProductTypeTopup, Amount: 100, CTAText: "立即充值"},
+	{Slug: "an-liang-fu-fei-500-mei-jin", Title: "余额充值|500美金额度", Category: "余额充值", Summary: "畅快使用 opus | sonnet | haiku", Description: "适合高频模型调用和团队共享场景。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/d3075a4f-02c8-4c7f-adb5-50d455584b0d.webp", Tags: []string{"热门"}, PriceLabel: "500.00", Currency: "CNY", Active: true, SortOrder: 90, ProductType: CatalogProductTypeTopup, Amount: 500, CTAText: "立即充值"},
+	{Slug: "an-liang-fu-fei-1-0-0-0-mei-jin", Title: "余额充值|1000美金额度", Category: "余额充值", Summary: "畅快使用 opus | sonnet | haiku", Description: "大额充值，更适合高消耗场景。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/dc535aa3-7db6-4a34-a450-e43ac3ec04c6.webp", Tags: []string{}, PriceLabel: "1000.00", Currency: "CNY", Active: true, SortOrder: 100, ProductType: CatalogProductTypeTopup, Amount: 1000, CTAText: "立即充值"},
+	{Slug: "an-liang-fu-fei-5000-mei-jin", Title: "余额充值|5000美金额度", Category: "余额充值", Summary: "畅快使用 opus | sonnet | haiku", Description: "适合企业或长期大规模使用。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/3978268a-092b-4b92-9e41-a864c8715c08.webp", Tags: []string{}, PriceLabel: "5000.00", Currency: "CNY", Active: true, SortOrder: 110, ProductType: CatalogProductTypeTopup, Amount: 5000, CTAText: "立即充值"},
+	{Slug: "an-liang-fu-fei-1-0-0-0-0-mei-jin-qi-ye", Title: "余额充值|10000美金额度|企业", Category: "余额充值", Summary: "企业级大额充值", Description: "面向企业的大额账户充值。", Image: "https://shop.xuedingtoken.com/uploads/product/2026/04/86aaa189-c952-4934-a6a8-cee40baed46b.webp", Tags: []string{"企业"}, PriceLabel: "10000.00", Currency: "CNY", Active: true, SortOrder: 120, ProductType: CatalogProductTypeTopup, Amount: 10000, CTAText: "立即充值"},
+}
+
+func DefaultCatalogProducts() []CatalogProduct {
+	out := make([]CatalogProduct, 0, len(defaultCatalogProducts))
+	for _, item := range defaultCatalogProducts {
+		out = append(out, cloneCatalogProduct(item))
+	}
+	return out
+}
+
+func (s *PaymentConfigService) GetCatalogProducts(ctx context.Context, includeInactive bool) ([]CatalogProduct, error) {
+	raw, err := s.settingRepo.GetValue(ctx, SettingCatalogProducts)
+	if err != nil {
+		if !errors.Is(err, ErrSettingNotFound) {
+			return nil, fmt.Errorf("get catalog products: %w", err)
+		}
+		raw = ""
+	}
+	if strings.TrimSpace(raw) == "" {
+		defaults := DefaultCatalogProducts()
+		if err := s.SetCatalogProducts(ctx, defaults); err != nil {
+			return nil, err
+		}
+		if err := s.refreshCatalogProductPricing(ctx, defaults); err != nil {
+			return nil, err
+		}
+		return filterCatalogProducts(defaults, includeInactive), nil
+	}
+
+	var products []CatalogProduct
+	if err := json.Unmarshal([]byte(raw), &products); err != nil {
+		defaults := DefaultCatalogProducts()
+		if setErr := s.SetCatalogProducts(ctx, defaults); setErr != nil {
+			return nil, setErr
+		}
+		return filterCatalogProducts(defaults, includeInactive), nil
+	}
+	normalized, err := normalizeCatalogProducts(products)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.refreshCatalogProductPricing(ctx, normalized); err != nil {
+		return nil, err
+	}
+	return filterCatalogProducts(normalized, includeInactive), nil
+}
+
+func (s *PaymentConfigService) SetCatalogProducts(ctx context.Context, products []CatalogProduct) error {
+	normalized, err := normalizeCatalogProducts(products)
+	if err != nil {
+		return err
+	}
+	if err := s.refreshCatalogProductPricing(ctx, normalized); err != nil {
+		return err
+	}
+	payload, err := json.MarshalIndent(normalized, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal catalog products: %w", err)
+	}
+	return s.settingRepo.Set(ctx, SettingCatalogProducts, string(payload))
+}
+
+func (s *PaymentConfigService) refreshCatalogProductPricing(ctx context.Context, products []CatalogProduct) error {
+	cfg, err := s.GetPaymentConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("get payment config for catalog products: %w", err)
+	}
+	applyCatalogProductPricing(products, cfg)
+	return nil
+}
+
+func normalizeCatalogProducts(products []CatalogProduct) ([]CatalogProduct, error) {
+	out := make([]CatalogProduct, 0, len(products))
+	for i, item := range products {
+		product, err := normalizeCatalogProduct(item, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, product)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].SortOrder < out[j].SortOrder })
+	return out, nil
+}
+
+func normalizeCatalogProduct(input CatalogProduct, index int) (CatalogProduct, error) {
+	slug := strings.TrimSpace(input.Slug)
+	title := strings.TrimSpace(input.Title)
+	if slug == "" {
+		return CatalogProduct{}, fmt.Errorf("products[%d].slug is required", index)
+	}
+	if title == "" {
+		return CatalogProduct{}, fmt.Errorf("products[%d].title is required", index)
+	}
+
+	productType := strings.TrimSpace(input.ProductType)
+	if productType != CatalogProductTypeSubscription {
+		productType = CatalogProductTypeTopup
+	}
+	sortOrder := input.SortOrder
+	if sortOrder == 0 {
+		sortOrder = (index + 1) * 10
+	}
+
+	return CatalogProduct{
+		Slug:        slug,
+		Title:       title,
+		Category:    defaultString(strings.TrimSpace(input.Category), "Uncategorized"),
+		Summary:     strings.TrimSpace(input.Summary),
+		Description: strings.TrimSpace(input.Description),
+		Image:       strings.TrimSpace(input.Image),
+		CardImage:   strings.TrimSpace(input.CardImage),
+		Tags:        normalizeStringList(input.Tags),
+		PriceLabel:  strings.TrimSpace(input.PriceLabel),
+		Currency:    defaultString(strings.TrimSpace(input.Currency), "CNY"),
+		Badge:       strings.TrimSpace(input.Badge),
+		Active:      input.Active,
+		SortOrder:   sortOrder,
+		ProductType: productType,
+		Amount:      normalizeCatalogAmount(productType, input.Amount),
+		PlanID:      normalizeCatalogPlanID(productType, input.PlanID),
+		CTAText:     strings.TrimSpace(input.CTAText),
+	}, nil
+}
+
+func filterCatalogProducts(products []CatalogProduct, includeInactive bool) []CatalogProduct {
+	out := make([]CatalogProduct, 0, len(products))
+	for _, item := range products {
+		if includeInactive || item.Active {
+			out = append(out, cloneCatalogProduct(item))
+		}
+	}
+	return out
+}
+
+func cloneCatalogProduct(item CatalogProduct) CatalogProduct {
+	item.Tags = append([]string(nil), item.Tags...)
+	return item
+}
+
+func normalizeStringList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func normalizeCatalogAmount(productType string, amount float64) float64 {
+	if productType != CatalogProductTypeTopup || amount <= 0 {
+		return 0
+	}
+	return amount
+}
+
+func applyCatalogProductPricing(products []CatalogProduct, cfg *PaymentConfig) {
+	for i := range products {
+		if products[i].ProductType != CatalogProductTypeTopup {
+			products[i].Amount = 0
+			continue
+		}
+		payAmount, ok := parseCatalogPriceLabelAmount(products[i].PriceLabel)
+		if !ok {
+			products[i].Amount = 0
+			continue
+		}
+		products[i].Amount = cfg.ResolveBalancePricingTier(payAmount).CreditedAmount
+	}
+}
+
+func parseCatalogPriceLabelAmount(priceLabel string) (float64, bool) {
+	cleaned := strings.TrimSpace(priceLabel)
+	cleaned = strings.NewReplacer(",", "", "¥", "", "￥", "", "$", "").Replace(cleaned)
+	if fields := strings.Fields(cleaned); len(fields) > 0 {
+		cleaned = fields[0]
+	}
+	amount, err := strconv.ParseFloat(cleaned, 64)
+	if err != nil || amount <= 0 {
+		return 0, false
+	}
+	return amount, true
+}
+
+func normalizeCatalogPlanID(productType, planID string) string {
+	if productType != CatalogProductTypeSubscription {
+		return ""
+	}
+	return strings.TrimSpace(planID)
+}
+
+func defaultString(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}

--- a/backend/internal/service/payment_config_plans.go
+++ b/backend/internal/service/payment_config_plans.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	dbent "github.com/Wei-Shaw/sub2api/ent"
@@ -12,7 +13,7 @@ import (
 )
 
 // validatePlanRequired checks that all required fields for a plan are provided.
-func validatePlanRequired(name string, groupID int64, price float64, validityDays int, validityUnit string, originalPrice *float64) error {
+func validatePlanRequired(name string, groupID int64, price float64, validityDays float64, validityUnit string, originalPrice *float64) error {
 	if strings.TrimSpace(name) == "" {
 		return infraerrors.BadRequest("PLAN_NAME_REQUIRED", "plan name is required")
 	}
@@ -22,7 +23,7 @@ func validatePlanRequired(name string, groupID int64, price float64, validityDay
 	if price <= 0 {
 		return infraerrors.BadRequest("PLAN_PRICE_INVALID", "price must be > 0")
 	}
-	if validityDays <= 0 {
+	if validityDays <= 0 || math.IsNaN(validityDays) || math.IsInf(validityDays, 0) {
 		return infraerrors.BadRequest("PLAN_VALIDITY_REQUIRED", "validity days must be > 0")
 	}
 	if strings.TrimSpace(validityUnit) == "" {
@@ -45,7 +46,7 @@ func validatePlanPatch(req UpdatePlanRequest) error {
 	if req.Price != nil && *req.Price <= 0 {
 		return infraerrors.BadRequest("PLAN_PRICE_INVALID", "price must be > 0")
 	}
-	if req.ValidityDays != nil && *req.ValidityDays <= 0 {
+	if req.ValidityDays != nil && (*req.ValidityDays <= 0 || math.IsNaN(*req.ValidityDays) || math.IsInf(*req.ValidityDays, 0)) {
 		return infraerrors.BadRequest("PLAN_VALIDITY_REQUIRED", "validity days must be > 0")
 	}
 	if req.ValidityUnit != nil && strings.TrimSpace(*req.ValidityUnit) == "" {

--- a/backend/internal/service/payment_config_plans_validation_test.go
+++ b/backend/internal/service/payment_config_plans_validation_test.go
@@ -171,7 +171,7 @@ func TestValidatePlanPatch_ValidPrice(t *testing.T) {
 }
 
 func TestValidatePlanPatch_ZeroValidityDays(t *testing.T) {
-	err := validatePlanPatch(UpdatePlanRequest{ValidityDays: ptrInt(0)})
+	err := validatePlanPatch(UpdatePlanRequest{ValidityDays: ptrFloat(0)})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "validity days")
 }

--- a/backend/internal/service/payment_config_providers.go
+++ b/backend/internal/service/payment_config_providers.go
@@ -115,6 +115,7 @@ var providerSensitiveConfigFields = map[string]map[string]struct{}{
 	payment.TypeWxpay:     {"privatekey": {}, "apiv3key": {}, "publickey": {}},
 	payment.TypeStripe:    {"secretkey": {}, "webhooksecret": {}},
 	payment.TypeAirwallex: {"apikey": {}, "webhooksecret": {}},
+	payment.TypeXunhuPay:  {"secret": {}},
 }
 
 // providerPendingOrderProtectedConfigFields lists config keys that cannot be
@@ -127,6 +128,7 @@ var providerPendingOrderProtectedConfigFields = map[string]map[string]struct{}{
 	payment.TypeWxpay:     {"privatekey": {}, "apiv3key": {}, "publickey": {}, "appid": {}, "mpappid": {}, "mchid": {}, "publickeyid": {}, "certserial": {}},
 	payment.TypeStripe:    {"secretkey": {}, "webhooksecret": {}, "currency": {}},
 	payment.TypeAirwallex: {"clientid": {}, "apikey": {}, "webhooksecret": {}, "apibase": {}, "accountid": {}, "currency": {}},
+	payment.TypeXunhuPay:  {"appid": {}, "secret": {}},
 }
 
 func isSensitiveProviderConfigField(providerKey, fieldName string) bool {
@@ -178,6 +180,7 @@ func (s *PaymentConfigService) countPendingOrdersByPlan(ctx context.Context, pla
 
 var validProviderKeys = map[string]bool{
 	payment.TypeEasyPay: true, payment.TypeAlipay: true, payment.TypeWxpay: true, payment.TypeStripe: true, payment.TypeAirwallex: true,
+	payment.TypeXunhuPay: true,
 }
 
 func (s *PaymentConfigService) CreateProviderInstance(ctx context.Context, req CreateProviderInstanceRequest) (*dbent.PaymentProviderInstance, error) {

--- a/backend/internal/service/payment_config_service.go
+++ b/backend/internal/service/payment_config_service.go
@@ -24,6 +24,9 @@ const (
 	SettingLoadBalanceStrategy = "LOAD_BALANCE_STRATEGY"
 	SettingBalancePayDisabled  = "BALANCE_PAYMENT_DISABLED"
 	SettingBalanceRechargeMult = "BALANCE_RECHARGE_MULTIPLIER"
+	SettingBalancePricingTiers = "BALANCE_PRICING_TIERS"
+	SettingBalanceRechargeAsPackage = "BALANCE_RECHARGE_AS_PACKAGE"
+	SettingBalancePackageValidityDays = "BALANCE_PACKAGE_VALIDITY_DAYS"
 	SettingRechargeFeeRate     = "RECHARGE_FEE_RATE"
 	SettingProductNamePrefix   = "PRODUCT_NAME_PREFIX"
 	SettingProductNameSuffix   = "PRODUCT_NAME_SUFFIX"
@@ -45,22 +48,25 @@ const (
 
 // PaymentConfig holds the payment system configuration.
 type PaymentConfig struct {
-	Enabled                   bool     `json:"enabled"`
-	MinAmount                 float64  `json:"min_amount"`
-	MaxAmount                 float64  `json:"max_amount"`
-	DailyLimit                float64  `json:"daily_limit"`
-	OrderTimeoutMin           int      `json:"order_timeout_minutes"`
-	MaxPendingOrders          int      `json:"max_pending_orders"`
-	EnabledTypes              []string `json:"enabled_payment_types"`
-	BalanceDisabled           bool     `json:"balance_disabled"`
-	BalanceRechargeMultiplier float64  `json:"balance_recharge_multiplier"`
-	RechargeFeeRate           float64  `json:"recharge_fee_rate"`
-	LoadBalanceStrategy       string   `json:"load_balance_strategy"`
-	ProductNamePrefix         string   `json:"product_name_prefix"`
-	ProductNameSuffix         string   `json:"product_name_suffix"`
-	HelpImageURL              string   `json:"help_image_url"`
-	HelpText                  string   `json:"help_text"`
-	StripePublishableKey      string   `json:"stripe_publishable_key,omitempty"`
+	Enabled                   bool                 `json:"enabled"`
+	MinAmount                 float64              `json:"min_amount"`
+	MaxAmount                 float64              `json:"max_amount"`
+	DailyLimit                float64              `json:"daily_limit"`
+	OrderTimeoutMin           int                  `json:"order_timeout_minutes"`
+	MaxPendingOrders          int                  `json:"max_pending_orders"`
+	EnabledTypes              []string             `json:"enabled_payment_types"`
+	BalanceDisabled           bool                 `json:"balance_disabled"`
+	BalanceRechargeMultiplier float64              `json:"balance_recharge_multiplier"`
+	BalancePricingTiers       []BalancePricingTier `json:"balance_pricing_tiers"`
+	BalanceRechargeAsPackage  bool                 `json:"balance_recharge_as_package"`
+	BalancePackageValidityDays float64             `json:"balance_package_validity_days"`
+	RechargeFeeRate           float64              `json:"recharge_fee_rate"`
+	LoadBalanceStrategy       string               `json:"load_balance_strategy"`
+	ProductNamePrefix         string               `json:"product_name_prefix"`
+	ProductNameSuffix         string               `json:"product_name_suffix"`
+	HelpImageURL              string               `json:"help_image_url"`
+	HelpText                  string               `json:"help_text"`
+	StripePublishableKey      string               `json:"stripe_publishable_key,omitempty"`
 
 	// Cancel rate limit settings
 	CancelRateLimitEnabled bool   `json:"cancel_rate_limit_enabled"`
@@ -75,21 +81,24 @@ type PaymentConfig struct {
 
 // UpdatePaymentConfigRequest contains fields to update payment configuration.
 type UpdatePaymentConfigRequest struct {
-	Enabled                   *bool    `json:"enabled"`
-	MinAmount                 *float64 `json:"min_amount"`
-	MaxAmount                 *float64 `json:"max_amount"`
-	DailyLimit                *float64 `json:"daily_limit"`
-	OrderTimeoutMin           *int     `json:"order_timeout_minutes"`
-	MaxPendingOrders          *int     `json:"max_pending_orders"`
-	EnabledTypes              []string `json:"enabled_payment_types"`
-	BalanceDisabled           *bool    `json:"balance_disabled"`
-	BalanceRechargeMultiplier *float64 `json:"balance_recharge_multiplier"`
-	RechargeFeeRate           *float64 `json:"recharge_fee_rate"`
-	LoadBalanceStrategy       *string  `json:"load_balance_strategy"`
-	ProductNamePrefix         *string  `json:"product_name_prefix"`
-	ProductNameSuffix         *string  `json:"product_name_suffix"`
-	HelpImageURL              *string  `json:"help_image_url"`
-	HelpText                  *string  `json:"help_text"`
+	Enabled                   *bool                 `json:"enabled"`
+	MinAmount                 *float64              `json:"min_amount"`
+	MaxAmount                 *float64              `json:"max_amount"`
+	DailyLimit                *float64              `json:"daily_limit"`
+	OrderTimeoutMin           *int                  `json:"order_timeout_minutes"`
+	MaxPendingOrders          *int                  `json:"max_pending_orders"`
+	EnabledTypes              []string              `json:"enabled_payment_types"`
+	BalanceDisabled           *bool                 `json:"balance_disabled"`
+	BalanceRechargeMultiplier *float64              `json:"balance_recharge_multiplier"`
+	BalancePricingTiers       *[]BalancePricingTier `json:"balance_pricing_tiers"`
+	BalanceRechargeAsPackage  *bool                 `json:"balance_recharge_as_package"`
+	BalancePackageValidityDays *float64             `json:"balance_package_validity_days"`
+	RechargeFeeRate           *float64              `json:"recharge_fee_rate"`
+	LoadBalanceStrategy       *string               `json:"load_balance_strategy"`
+	ProductNamePrefix         *string               `json:"product_name_prefix"`
+	ProductNameSuffix         *string               `json:"product_name_suffix"`
+	HelpImageURL              *string               `json:"help_image_url"`
+	HelpText                  *string               `json:"help_text"`
 
 	// Cancel rate limit settings
 	CancelRateLimitEnabled *bool   `json:"cancel_rate_limit_enabled"`
@@ -155,7 +164,7 @@ type CreatePlanRequest struct {
 	Description   string   `json:"description"`
 	Price         float64  `json:"price"`
 	OriginalPrice *float64 `json:"original_price"`
-	ValidityDays  int      `json:"validity_days"`
+	ValidityDays  float64  `json:"validity_days"`
 	ValidityUnit  string   `json:"validity_unit"`
 	Features      string   `json:"features"`
 	ProductName   string   `json:"product_name"`
@@ -169,7 +178,7 @@ type UpdatePlanRequest struct {
 	Description   *string  `json:"description"`
 	Price         *float64 `json:"price"`
 	OriginalPrice *float64 `json:"original_price"`
-	ValidityDays  *int     `json:"validity_days"`
+	ValidityDays  *float64 `json:"validity_days"`
 	ValidityUnit  *string  `json:"validity_unit"`
 	Features      *string  `json:"features"`
 	ProductName   *string  `json:"product_name"`
@@ -204,7 +213,8 @@ func (s *PaymentConfigService) GetPaymentConfig(ctx context.Context) (*PaymentCo
 	keys := []string{
 		SettingPaymentEnabled, SettingMinRechargeAmount, SettingMaxRechargeAmount,
 		SettingDailyRechargeLimit, SettingOrderTimeoutMinutes, SettingMaxPendingOrders,
-		SettingEnabledPaymentTypes, SettingBalancePayDisabled, SettingBalanceRechargeMult, SettingRechargeFeeRate, SettingLoadBalanceStrategy,
+		SettingEnabledPaymentTypes, SettingBalancePayDisabled, SettingBalanceRechargeMult, SettingBalancePricingTiers,
+		SettingBalanceRechargeAsPackage, SettingBalancePackageValidityDays, SettingRechargeFeeRate, SettingLoadBalanceStrategy,
 		SettingProductNamePrefix, SettingProductNameSuffix,
 		SettingHelpImageURL, SettingHelpText,
 		SettingCancelRateLimitOn, SettingCancelRateLimitMax,
@@ -233,6 +243,8 @@ func (s *PaymentConfigService) parsePaymentConfig(vals map[string]string) *Payme
 		MaxPendingOrders:          pcParseInt(vals[SettingMaxPendingOrders], defaultMaxPendingOrders),
 		BalanceDisabled:           vals[SettingBalancePayDisabled] == "true",
 		BalanceRechargeMultiplier: normalizeBalanceRechargeMultiplier(pcParseFloat(vals[SettingBalanceRechargeMult], defaultBalanceRechargeMultiplier)),
+		BalanceRechargeAsPackage:  vals[SettingBalanceRechargeAsPackage] == "true",
+		BalancePackageValidityDays: pcParseFloat(vals[SettingBalancePackageValidityDays], 1),
 		RechargeFeeRate:           pcParseFloat(vals[SettingRechargeFeeRate], 0),
 		LoadBalanceStrategy:       vals[SettingLoadBalanceStrategy],
 		ProductNamePrefix:         vals[SettingProductNamePrefix],
@@ -248,6 +260,9 @@ func (s *PaymentConfigService) parsePaymentConfig(vals map[string]string) *Payme
 
 		AlipayForceQRCode: vals[SettingAlipayForceQRCode] == "true",
 	}
+	if tiers, err := parseBalancePricingTiers(vals[SettingBalancePricingTiers]); err == nil {
+		cfg.BalancePricingTiers = tiers
+	}
 	if cfg.LoadBalanceStrategy == "" {
 		cfg.LoadBalanceStrategy = payment.DefaultLoadBalanceStrategy
 	}
@@ -262,6 +277,13 @@ func (s *PaymentConfigService) parsePaymentConfig(vals map[string]string) *Payme
 		cfg.EnabledTypes = NormalizeVisibleMethods(types)
 	}
 	return cfg
+}
+
+func (cfg *PaymentConfig) ResolveBalancePricingTier(amount float64) ResolvedBalanceTier {
+	if cfg == nil {
+		return resolveBalancePricingTier(amount, nil, defaultBalanceRechargeMultiplier)
+	}
+	return resolveBalancePricingTier(amount, cfg.BalancePricingTiers, cfg.BalanceRechargeMultiplier)
 }
 
 // getStripePublishableKey finds the publishable key from the first enabled Stripe provider instance.
@@ -304,6 +326,20 @@ func (s *PaymentConfigService) UpdatePaymentConfig(ctx context.Context, req Upda
 			return infraerrors.BadRequest("INVALID_RECHARGE_FEE_RATE", "recharge fee rate allows at most 2 decimal places")
 		}
 	}
+	if req.BalancePackageValidityDays != nil {
+		v := *req.BalancePackageValidityDays
+		if math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
+			return infraerrors.BadRequest("INVALID_BALANCE_PACKAGE_VALIDITY", "balance package validity days must be greater than 0")
+		}
+	}
+	balancePricingTiersRaw := ""
+	if req.BalancePricingTiers != nil {
+		raw, err := formatBalancePricingTiers(*req.BalancePricingTiers)
+		if err != nil {
+			return infraerrors.BadRequest("INVALID_BALANCE_PRICING_TIERS", err.Error())
+		}
+		balancePricingTiersRaw = raw
+	}
 	m := map[string]string{
 		SettingPaymentEnabled:                    formatBoolOrEmpty(req.Enabled),
 		SettingMinRechargeAmount:                 formatPositiveFloat(req.MinAmount),
@@ -313,6 +349,9 @@ func (s *PaymentConfigService) UpdatePaymentConfig(ctx context.Context, req Upda
 		SettingMaxPendingOrders:                  formatPositiveInt(req.MaxPendingOrders),
 		SettingBalancePayDisabled:                formatBoolOrEmpty(req.BalanceDisabled),
 		SettingBalanceRechargeMult:               formatPositiveFloat(req.BalanceRechargeMultiplier),
+		SettingBalancePricingTiers:               balancePricingTiersRaw,
+		SettingBalanceRechargeAsPackage:          formatBoolOrEmpty(req.BalanceRechargeAsPackage),
+		SettingBalancePackageValidityDays:        formatPositiveFloat(req.BalancePackageValidityDays),
 		SettingRechargeFeeRate:                   formatNonNegativeFloat(req.RechargeFeeRate),
 		SettingLoadBalanceStrategy:               derefStr(req.LoadBalanceStrategy),
 		SettingProductNamePrefix:                 derefStr(req.ProductNamePrefix),

--- a/backend/internal/service/payment_config_service_test.go
+++ b/backend/internal/service/payment_config_service_test.go
@@ -199,6 +199,142 @@ func TestParsePaymentConfig(t *testing.T) {
 	})
 }
 
+func TestCatalogProductsDefaultAndUpdate(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	products, err := svc.GetCatalogProducts(context.Background(), false)
+	if err != nil {
+		t.Fatalf("GetCatalogProducts returned error: %v", err)
+	}
+	if len(products) == 0 {
+		t.Fatal("expected default catalog products")
+	}
+	if products[0].Slug == "" || products[0].Title == "" {
+		t.Fatalf("default product should include slug and title: %+v", products[0])
+	}
+	if repo.values[SettingCatalogProducts] == "" {
+		t.Fatal("expected defaults to be persisted")
+	}
+
+	next := []CatalogProduct{{
+		Slug:        "openai-pro",
+		Title:       "OpenAI Pro",
+		Category:    "Subscription",
+		Summary:     "Monthly plan",
+		Description: "OpenAI monthly subscription",
+		Image:       "https://example.test/openai.webp",
+		Tags:        []string{"hot", "pro"},
+		PriceLabel:  "99.00",
+		Currency:    "CNY",
+		Active:      true,
+		SortOrder:   20,
+		ProductType: CatalogProductTypeSubscription,
+		PlanID:      "7",
+		CTAText:     "Buy now",
+	}}
+	if err := svc.SetCatalogProducts(context.Background(), next); err != nil {
+		t.Fatalf("SetCatalogProducts returned error: %v", err)
+	}
+
+	products, err = svc.GetCatalogProducts(context.Background(), true)
+	if err != nil {
+		t.Fatalf("GetCatalogProducts after set returned error: %v", err)
+	}
+	if len(products) != 1 || products[0].Slug != "openai-pro" || products[0].PlanID != "7" {
+		t.Fatalf("products = %+v, want saved subscription product", products)
+	}
+}
+
+func TestSetCatalogProductsRecalculatesTopupAmountFromPricingTiers(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{
+		SettingBalanceRechargeMult: "1",
+		SettingBalancePricingTiers: `[{
+			"min":100,
+			"max":500,
+			"multiplier":7.3,
+			"label":"vip",
+			"enabled":true,
+			"sortOrder":1
+		}]`,
+	}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	input := []CatalogProduct{{
+		Slug:        "vip-topup",
+		Title:       "VIP Topup",
+		Category:    "Balance",
+		PriceLabel:  "320.00",
+		Currency:    "CNY",
+		Active:      true,
+		ProductType: CatalogProductTypeTopup,
+		Amount:      999,
+	}}
+	if err := svc.SetCatalogProducts(context.Background(), input); err != nil {
+		t.Fatalf("SetCatalogProducts returned error: %v", err)
+	}
+
+	products, err := svc.GetCatalogProducts(context.Background(), true)
+	if err != nil {
+		t.Fatalf("GetCatalogProducts returned error: %v", err)
+	}
+	if len(products) != 1 {
+		t.Fatalf("products len = %d, want 1", len(products))
+	}
+	if products[0].Amount != 43.84 {
+		t.Fatalf("topup amount = %v, want 43.84", products[0].Amount)
+	}
+}
+
+func TestGetCatalogProductsSeedsDefaultsWhenSettingIsMissing(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{}, missingKeys: map[string]bool{SettingCatalogProducts: true}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	products, err := svc.GetCatalogProducts(context.Background(), false)
+	if err != nil {
+		t.Fatalf("GetCatalogProducts returned error: %v", err)
+	}
+	if len(products) == 0 {
+		t.Fatal("expected missing catalog setting to seed defaults")
+	}
+	if repo.values[SettingCatalogProducts] == "" {
+		t.Fatal("expected missing catalog setting to be persisted with defaults")
+	}
+}
+
+func TestSetCatalogProductsValidatesRequiredFields(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	err := svc.SetCatalogProducts(context.Background(), []CatalogProduct{{Title: "Missing slug"}})
+	if err == nil {
+		t.Fatal("expected missing slug to fail")
+	}
+	if !strings.Contains(err.Error(), "slug") {
+		t.Fatalf("error = %v, want slug validation", err)
+	}
+}
+
+func TestGetCatalogProductsPublicFiltersInactive(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	if err := svc.SetCatalogProducts(context.Background(), []CatalogProduct{
+		{Slug: "active", Title: "Active", Active: true, ProductType: CatalogProductTypeTopup, Amount: 20, SortOrder: 20},
+		{Slug: "inactive", Title: "Inactive", Active: false, ProductType: CatalogProductTypeTopup, Amount: 30, SortOrder: 10},
+	}); err != nil {
+		t.Fatalf("SetCatalogProducts returned error: %v", err)
+	}
+
+	products, err := svc.GetCatalogProducts(context.Background(), false)
+	if err != nil {
+		t.Fatalf("GetCatalogProducts returned error: %v", err)
+	}
+	if len(products) != 1 || products[0].Slug != "active" {
+		t.Fatalf("products = %+v, want only active product", products)
+	}
+}
+
 func TestGetBasePaymentType(t *testing.T) {
 	t.Parallel()
 
@@ -368,17 +504,34 @@ func newPaymentConfigServiceTestClient(t *testing.T) *dbent.Client {
 }
 
 type paymentConfigSettingRepoStub struct {
-	values  map[string]string
-	updates map[string]string
+	values      map[string]string
+	updates     map[string]string
+	missingKeys map[string]bool
 }
 
 func (s *paymentConfigSettingRepoStub) Get(context.Context, string) (*Setting, error) {
 	return nil, nil
 }
 func (s *paymentConfigSettingRepoStub) GetValue(_ context.Context, key string) (string, error) {
+	if s.missingKeys != nil && s.missingKeys[key] {
+		return "", ErrSettingNotFound
+	}
 	return s.values[key], nil
 }
-func (s *paymentConfigSettingRepoStub) Set(context.Context, string, string) error { return nil }
+func (s *paymentConfigSettingRepoStub) Set(_ context.Context, key string, value string) error {
+	if s.values == nil {
+		s.values = map[string]string{}
+	}
+	if s.updates == nil {
+		s.updates = map[string]string{}
+	}
+	s.values[key] = value
+	s.updates[key] = value
+	if s.missingKeys != nil {
+		delete(s.missingKeys, key)
+	}
+	return nil
+}
 func (s *paymentConfigSettingRepoStub) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
 	out := make(map[string]string, len(keys))
 	for _, key := range keys {
@@ -429,6 +582,43 @@ func TestUpdatePaymentConfig_PersistsVisibleMethodRouting(t *testing.T) {
 	}
 	if repo.values[SettingPaymentVisibleMethodWxpaySource] != VisibleMethodSourceOfficialWechat {
 		t.Fatalf("wxpay source = %q, want %q", repo.values[SettingPaymentVisibleMethodWxpaySource], VisibleMethodSourceOfficialWechat)
+	}
+}
+
+func TestUpdatePaymentConfig_PersistsBalancePricingTiers(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	err := svc.UpdatePaymentConfig(context.Background(), UpdatePaymentConfigRequest{
+		BalancePricingTiers: &[]BalancePricingTier{
+			{Min: 100, Max: 500, Multiplier: 7.3, Label: "vip", Enabled: true, SortOrder: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("UpdatePaymentConfig returned error: %v", err)
+	}
+
+	cfg := svc.parsePaymentConfig(repo.values)
+	if len(cfg.BalancePricingTiers) != 1 {
+		t.Fatalf("BalancePricingTiers len = %d, want 1", len(cfg.BalancePricingTiers))
+	}
+	if cfg.BalancePricingTiers[0].Label != "vip" || cfg.BalancePricingTiers[0].Multiplier != 7.3 {
+		t.Fatalf("BalancePricingTiers[0] = %+v, want vip multiplier 7.3", cfg.BalancePricingTiers[0])
+	}
+}
+
+func TestUpdatePaymentConfig_RejectsOverlappingBalancePricingTiers(t *testing.T) {
+	repo := &paymentConfigSettingRepoStub{values: map[string]string{}}
+	svc := &PaymentConfigService{settingRepo: repo}
+
+	err := svc.UpdatePaymentConfig(context.Background(), UpdatePaymentConfigRequest{
+		BalancePricingTiers: &[]BalancePricingTier{
+			{Min: 1, Max: 100, Multiplier: 1, Label: "base", Enabled: true},
+			{Min: 100, Max: 200, Multiplier: 2, Label: "vip", Enabled: true},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected overlapping tiers to be rejected")
 	}
 }
 

--- a/backend/internal/service/payment_fulfillment.go
+++ b/backend/internal/service/payment_fulfillment.go
@@ -277,13 +277,14 @@ func (s *PaymentService) doBalance(ctx context.Context, o *dbent.PaymentOrder) e
 
 	switch action {
 	case redeemActionSkipCompleted:
-		if err := s.applyAffiliateRebateForOrder(ctx, o); err != nil {
-			return err
-		}
+		s.bestEffortAffiliateRebateForOrder(ctx, o)
 		// Code already created and redeemed — just mark completed
 		return s.markCompleted(ctx, o, "RECHARGE_SUCCESS")
 	case redeemActionCreate:
 		rc := &RedeemCode{Code: o.RechargeCode, Type: RedeemTypeBalance, Value: o.Amount, Status: StatusUnused}
+		if validitySeconds := balancePackageValiditySecondsFromOrder(o); validitySeconds > 0 {
+			rc.ValiditySeconds = validitySeconds
+		}
 		if err := s.redeemService.CreateCode(ctx, rc); err != nil {
 			return fmt.Errorf("create redeem code: %w", err)
 		}
@@ -293,10 +294,34 @@ func (s *PaymentService) doBalance(ctx context.Context, o *dbent.PaymentOrder) e
 	if _, err := s.redeemService.Redeem(ContextSkipRedeemAffiliate(ctx), o.UserID, o.RechargeCode); err != nil {
 		return fmt.Errorf("redeem balance: %w", err)
 	}
-	if err := s.applyAffiliateRebateForOrder(ctx, o); err != nil {
-		return err
-	}
+	s.bestEffortAffiliateRebateForOrder(ctx, o)
 	return s.markCompleted(ctx, o, "RECHARGE_SUCCESS")
+}
+
+func balancePackageValiditySecondsFromOrder(o *dbent.PaymentOrder) int64 {
+	if o == nil || o.ProviderSnapshot == nil {
+		return 0
+	}
+	raw, ok := o.ProviderSnapshot["balance_package_validity_seconds"]
+	if !ok {
+		return 0
+	}
+	switch v := raw.(type) {
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	case float64:
+		return int64(v)
+	case float32:
+		return int64(v)
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
 }
 
 func (s *PaymentService) markCompleted(ctx context.Context, o *dbent.PaymentOrder, auditAction string) error {
@@ -365,7 +390,9 @@ func (s *PaymentService) sendSubscriptionPurchaseSuccessNotification(ctx context
 		"expiry_time":        "",
 		"order_id":           strconv.FormatInt(o.ID, 10),
 	}
-	if o.SubscriptionDays != nil {
+	if seconds := subscriptionValiditySecondsFromOrder(o); seconds > 0 {
+		variables["subscription_days"] = formatSubscriptionValidityDays(seconds)
+	} else if o.SubscriptionDays != nil {
 		variables["subscription_days"] = strconv.Itoa(*o.SubscriptionDays)
 	}
 	if o.SubscriptionGroupID != nil {
@@ -425,6 +452,10 @@ func (s *PaymentService) ExecuteSubscriptionFulfillment(ctx context.Context, oid
 func (s *PaymentService) doSub(ctx context.Context, o *dbent.PaymentOrder) error {
 	gid := *o.SubscriptionGroupID
 	days := *o.SubscriptionDays
+	validityDuration := time.Duration(0)
+	if seconds := subscriptionValiditySecondsFromOrder(o); seconds > 0 {
+		validityDuration = time.Duration(seconds) * time.Second
+	}
 	g, err := s.groupRepo.GetByID(ctx, gid)
 	if err != nil || g.Status != payment.EntityStatusActive {
 		return fmt.Errorf("group %d no longer exists or inactive", gid)
@@ -436,11 +467,26 @@ func (s *PaymentService) doSub(ctx context.Context, o *dbent.PaymentOrder) error
 		return s.markCompleted(ctx, o, "SUBSCRIPTION_SUCCESS")
 	}
 	orderNote := fmt.Sprintf("payment order %d", o.ID)
-	_, _, err = s.subscriptionSvc.AssignOrExtendSubscription(ctx, &AssignSubscriptionInput{UserID: o.UserID, GroupID: gid, ValidityDays: days, AssignedBy: 0, Notes: orderNote})
+	_, _, err = s.subscriptionSvc.AssignOrExtendSubscription(ctx, &AssignSubscriptionInput{UserID: o.UserID, GroupID: gid, ValidityDays: days, ValidityDuration: validityDuration, AssignedBy: 0, Notes: orderNote})
 	if err != nil {
 		return fmt.Errorf("assign subscription: %w", err)
 	}
 	return s.markCompleted(ctx, o, "SUBSCRIPTION_SUCCESS")
+}
+
+func subscriptionValiditySecondsFromOrder(o *dbent.PaymentOrder) int64 {
+	if snapshot := psOrderProviderSnapshot(o); snapshot != nil && snapshot.SubscriptionValiditySeconds > 0 {
+		return snapshot.SubscriptionValiditySeconds
+	}
+	return 0
+}
+
+func formatSubscriptionValidityDays(seconds int64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	days := float64(seconds) / 86400
+	return strconv.FormatFloat(days, 'f', -1, 64)
 }
 
 func (s *PaymentService) hasAuditLog(ctx context.Context, orderID int64, action string) bool {
@@ -525,6 +571,15 @@ func (s *PaymentService) applyAffiliateRebateForOrder(ctx context.Context, o *db
 		return fmt.Errorf("commit affiliate rebate tx: %w", err)
 	}
 	return nil
+}
+
+func (s *PaymentService) bestEffortAffiliateRebateForOrder(ctx context.Context, o *dbent.PaymentOrder) {
+	if err := s.applyAffiliateRebateForOrder(ctx, o); err != nil {
+		slog.Warn("affiliate rebate failed during payment fulfillment; continuing core fulfillment",
+			"orderID", o.ID,
+			"error", err,
+		)
+	}
 }
 
 func (s *PaymentService) tryClaimAffiliateRebateAudit(ctx context.Context, client *dbent.Client, orderID int64, baseAmount float64) (bool, error) {

--- a/backend/internal/service/payment_order.go
+++ b/backend/internal/service/payment_order.go
@@ -34,6 +34,13 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 	if !cfg.Enabled {
 		return nil, infraerrors.Forbidden("PAYMENT_DISABLED", "payment system is disabled")
 	}
+	if req.OrderType == payment.OrderTypeBalance {
+		if cfg.BalanceRechargeAsPackage {
+			req.BalancePackageValidityDays = cfg.BalancePackageValidityDays
+		} else {
+			req.BalancePackageValidityDays = 0
+		}
+	}
 	plan, err := s.validateOrderInput(ctx, req, cfg)
 	if err != nil {
 		return nil, err
@@ -53,11 +60,13 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 	}
 	orderAmount := req.Amount
 	limitAmount := req.Amount
+	balanceTier := ResolvedBalanceTier{}
 	if plan != nil {
 		orderAmount = plan.Price
 		limitAmount = plan.Price
 	} else if req.OrderType == payment.OrderTypeBalance {
-		orderAmount = calculateCreditedBalance(req.Amount, cfg.BalanceRechargeMultiplier)
+		balanceTier = cfg.ResolveBalancePricingTier(req.Amount)
+		orderAmount = balanceTier.CreditedAmount
 	}
 	feeRate := cfg.RechargeFeeRate
 	methodCurrency := payment.DefaultPaymentCurrency
@@ -98,7 +107,7 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 	if oauthResp != nil {
 		return oauthResp, nil
 	}
-	order, err := s.createOrderInTx(ctx, req, user, plan, cfg, orderAmount, limitAmount, feeRate, payAmount, sel)
+	order, err := s.createOrderInTx(ctx, req, user, plan, cfg, orderAmount, limitAmount, feeRate, payAmount, sel, balanceTier)
 	if err != nil {
 		return nil, err
 	}
@@ -118,6 +127,9 @@ func (s *PaymentService) validateOrderInput(ctx context.Context, req CreateOrder
 	}
 	if req.OrderType == payment.OrderTypeSubscription {
 		return s.validateSubOrder(ctx, req)
+	}
+	if req.BalancePackageValidityDays < 0 || math.IsNaN(req.BalancePackageValidityDays) || math.IsInf(req.BalancePackageValidityDays, 0) {
+		return nil, infraerrors.BadRequest("INVALID_BALANCE_PACKAGE_VALIDITY", "balance package validity days must be a non-negative number")
 	}
 	if math.IsNaN(req.Amount) || math.IsInf(req.Amount, 0) || req.Amount <= 0 {
 		return nil, infraerrors.BadRequest("INVALID_AMOUNT", "amount must be a positive number")
@@ -147,7 +159,7 @@ func (s *PaymentService) validateSubOrder(ctx context.Context, req CreateOrderRe
 	return plan, nil
 }
 
-func (s *PaymentService) createOrderInTx(ctx context.Context, req CreateOrderRequest, user *User, plan *dbent.SubscriptionPlan, cfg *PaymentConfig, orderAmount, limitAmount, feeRate, payAmount float64, sel *payment.InstanceSelection) (*dbent.PaymentOrder, error) {
+func (s *PaymentService) createOrderInTx(ctx context.Context, req CreateOrderRequest, user *User, plan *dbent.SubscriptionPlan, cfg *PaymentConfig, orderAmount, limitAmount, feeRate, payAmount float64, sel *payment.InstanceSelection, balanceTier ResolvedBalanceTier) (*dbent.PaymentOrder, error) {
 	tx, err := s.entClient.Tx(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("begin transaction: %w", err)
@@ -192,6 +204,23 @@ func (s *PaymentService) createOrderInTx(ctx context.Context, req CreateOrderReq
 		SetExpiresAt(exp).
 		SetClientIP(req.ClientIP).
 		SetSrcHost(req.SrcHost)
+	if req.OrderType == payment.OrderTypeBalance && balanceTier.Multiplier > 0 {
+		b.SetAppliedRateMultiplier(balanceTier.Multiplier)
+		b.SetCreditedAmount(balanceTier.CreditedAmount)
+		if balanceTier.Label != "" {
+			b.SetPricingTierLabel(balanceTier.Label)
+		}
+		if balanceTier.Tier != nil {
+			b.SetPricingTierSnapshot(map[string]any{
+				"min":        balanceTier.Tier.Min,
+				"max":        balanceTier.Tier.Max,
+				"multiplier": balanceTier.Tier.Multiplier,
+				"label":      balanceTier.Tier.Label,
+				"enabled":    balanceTier.Tier.Enabled,
+				"sortOrder":  balanceTier.Tier.SortOrder,
+			})
+		}
+	}
 	if req.SrcURL != "" {
 		b.SetSrcURL(req.SrcURL)
 	}
@@ -201,11 +230,28 @@ func (s *PaymentService) createOrderInTx(ctx context.Context, req CreateOrderReq
 	if selectedProviderKey != "" {
 		b.SetProviderKey(selectedProviderKey)
 	}
+	if plan != nil {
+		validityDays, validityDuration := psComputeValidityForOrder(plan.ValidityDays, plan.ValidityUnit)
+		b.SetPlanID(plan.ID).SetSubscriptionGroupID(plan.GroupID).SetSubscriptionDays(validityDays)
+		if validityDuration > 0 {
+			if providerSnapshot == nil {
+				providerSnapshot = map[string]any{"schema_version": 2}
+			}
+			providerSnapshot["subscription_validity_seconds"] = int64(validityDuration / time.Second)
+		}
+	}
+	if req.OrderType == payment.OrderTypeBalance && req.BalancePackageValidityDays > 0 {
+		validitySeconds := int64(math.Round(req.BalancePackageValidityDays * 24 * float64(time.Hour/time.Second)))
+		if validitySeconds <= 0 {
+			return nil, infraerrors.BadRequest("INVALID_BALANCE_PACKAGE_VALIDITY", "balance package validity is too short")
+		}
+		if providerSnapshot == nil {
+			providerSnapshot = map[string]any{"schema_version": 2}
+		}
+		providerSnapshot["balance_package_validity_seconds"] = validitySeconds
+	}
 	if providerSnapshot != nil {
 		b.SetProviderSnapshot(providerSnapshot)
-	}
-	if plan != nil {
-		b.SetPlanID(plan.ID).SetSubscriptionGroupID(plan.GroupID).SetSubscriptionDays(psComputeValidityDays(plan.ValidityDays, plan.ValidityUnit))
 	}
 	order, err := b.Save(ctx)
 	if err != nil {
@@ -302,6 +348,11 @@ func buildPaymentOrderProviderSnapshot(sel *payment.InstanceSelection, req Creat
 			snapshot["merchant_id"] = accountID
 		}
 		snapshot["currency"] = paymentProviderConfigCurrency(providerKey, sel.Config)
+	}
+	if providerKey == payment.TypeXunhuPay {
+		if appID := strings.TrimSpace(sel.Config["appId"]); appID != "" {
+			snapshot["merchant_app_id"] = appID
+		}
 	}
 
 	if len(snapshot) == 1 {

--- a/backend/internal/service/payment_order_balance_tiers_test.go
+++ b/backend/internal/service/payment_order_balance_tiers_test.go
@@ -1,0 +1,187 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/payment"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOrderPersistsBalanceTierSnapshot(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentConfigServiceTestClient(t)
+	user, err := client.User.Create().
+		SetEmail("tier@example.com").
+		SetPasswordHash("hash").
+		SetUsername("tier-user").
+		SetStatus(StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	provider := &paymentBalanceTierProvider{}
+	registry := payment.NewRegistry()
+	registry.Register(provider)
+	svc := &PaymentService{
+		entClient: client,
+		registry:  registry,
+		loadBalancer: &paymentBalanceTierLoadBalancer{selection: &payment.InstanceSelection{
+			InstanceID:     "provider-1",
+			ProviderKey:    payment.TypeEasyPay,
+			SupportedTypes: "alipay",
+			PaymentMode:    "popup",
+			Config: map[string]string{
+				"pid":         "1001",
+				"pkey":        "secret",
+				"apiBase":     "https://pay.example.com",
+				"notifyUrl":   "https://app.example.com/notify",
+				"returnUrl":   "https://app.example.com/return",
+				"paymentMode": "popup",
+				"currency":    payment.DefaultPaymentCurrency,
+			},
+		}},
+		configService: &PaymentConfigService{
+			entClient: client,
+			settingRepo: &paymentConfigSettingRepoStub{values: map[string]string{
+				SettingPaymentEnabled:      "true",
+				SettingEnabledPaymentTypes: payment.TypeAlipay,
+				SettingBalanceRechargeMult: "1",
+				SettingBalancePricingTiers: `[{"min":100,"max":500,"multiplier":7.3,"label":"vip","enabled":true,"sortOrder":1}]`,
+			}},
+		},
+		userRepo: &paymentBalanceTierUserRepo{user: &User{
+			ID:       user.ID,
+			Email:    user.Email,
+			Username: user.Username,
+			Status:   StatusActive,
+		}},
+	}
+
+	resp, err := svc.CreateOrder(ctx, CreateOrderRequest{
+		UserID:      user.ID,
+		Amount:      320,
+		PaymentType: payment.TypeAlipay,
+		OrderType:   payment.OrderTypeBalance,
+		ClientIP:    "127.0.0.1",
+		SrcHost:     "example.com",
+	})
+	require.NoError(t, err)
+
+	order, err := client.PaymentOrder.Get(ctx, resp.OrderID)
+	require.NoError(t, err)
+	require.Equal(t, 43.84, order.Amount)
+	require.NotNil(t, order.AppliedRateMultiplier)
+	require.Equal(t, 7.3, *order.AppliedRateMultiplier)
+	require.NotNil(t, order.CreditedAmount)
+	require.Equal(t, 43.84, *order.CreditedAmount)
+	require.NotNil(t, order.PricingTierLabel)
+	require.Equal(t, "vip", *order.PricingTierLabel)
+	require.Equal(t, "vip", order.PricingTierSnapshot["label"])
+}
+
+type paymentBalanceTierProvider struct{}
+
+func (p *paymentBalanceTierProvider) Name() string        { return "testpay" }
+func (p *paymentBalanceTierProvider) ProviderKey() string { return "testpay" }
+func (p *paymentBalanceTierProvider) SupportedTypes() []payment.PaymentType {
+	return []payment.PaymentType{"testpay"}
+}
+func (p *paymentBalanceTierProvider) CreatePayment(context.Context, payment.CreatePaymentRequest) (*payment.CreatePaymentResponse, error) {
+	return &payment.CreatePaymentResponse{TradeNo: "upstream-trade", PayURL: "https://pay.example.com/order"}, nil
+}
+func (p *paymentBalanceTierProvider) QueryOrder(context.Context, string) (*payment.QueryOrderResponse, error) {
+	return nil, nil
+}
+func (p *paymentBalanceTierProvider) VerifyNotification(context.Context, string, map[string]string) (*payment.PaymentNotification, error) {
+	return nil, nil
+}
+func (p *paymentBalanceTierProvider) Refund(context.Context, payment.RefundRequest) (*payment.RefundResponse, error) {
+	return nil, nil
+}
+
+type paymentBalanceTierLoadBalancer struct {
+	selection *payment.InstanceSelection
+}
+
+func (l *paymentBalanceTierLoadBalancer) GetInstanceConfig(context.Context, int64) (map[string]string, error) {
+	return l.selection.Config, nil
+}
+func (l *paymentBalanceTierLoadBalancer) SelectInstance(context.Context, string, payment.PaymentType, payment.Strategy, float64) (*payment.InstanceSelection, error) {
+	return l.selection, nil
+}
+
+type paymentBalanceTierUserRepo struct {
+	user *User
+}
+
+func (r *paymentBalanceTierUserRepo) Create(context.Context, *User) error { return nil }
+func (r *paymentBalanceTierUserRepo) GetByID(context.Context, int64) (*User, error) {
+	return r.user, nil
+}
+func (r *paymentBalanceTierUserRepo) GetByEmail(context.Context, string) (*User, error) {
+	return r.user, nil
+}
+func (r *paymentBalanceTierUserRepo) GetFirstAdmin(context.Context) (*User, error) {
+	return r.user, nil
+}
+func (r *paymentBalanceTierUserRepo) Update(context.Context, *User) error { return nil }
+func (r *paymentBalanceTierUserRepo) Delete(context.Context, int64) error { return nil }
+func (r *paymentBalanceTierUserRepo) GetUserAvatar(context.Context, int64) (*UserAvatar, error) {
+	return nil, nil
+}
+func (r *paymentBalanceTierUserRepo) GetByIDIncludeDeleted(ctx context.Context, id int64) (*User, error) {
+	return r.GetByID(ctx, id)
+}
+func (r *paymentBalanceTierUserRepo) UpsertUserAvatar(context.Context, int64, UpsertUserAvatarInput) (*UserAvatar, error) {
+	return nil, nil
+}
+func (r *paymentBalanceTierUserRepo) DeleteUserAvatar(context.Context, int64) error { return nil }
+func (r *paymentBalanceTierUserRepo) List(context.Context, pagination.PaginationParams) ([]User, *pagination.PaginationResult, error) {
+	return nil, nil, nil
+}
+func (r *paymentBalanceTierUserRepo) ListWithFilters(context.Context, pagination.PaginationParams, UserListFilters) ([]User, *pagination.PaginationResult, error) {
+	return nil, nil, nil
+}
+func (r *paymentBalanceTierUserRepo) GetLatestUsedAtByUserIDs(context.Context, []int64) (map[int64]*time.Time, error) {
+	return nil, nil
+}
+func (r *paymentBalanceTierUserRepo) GetLatestUsedAtByUserID(context.Context, int64) (*time.Time, error) {
+	return nil, nil
+}
+func (r *paymentBalanceTierUserRepo) UpdateUserLastActiveAt(context.Context, int64, time.Time) error {
+	return nil
+}
+func (r *paymentBalanceTierUserRepo) UpdateBalance(context.Context, int64, float64) error { return nil }
+func (r *paymentBalanceTierUserRepo) DeductBalance(context.Context, int64, float64) error { return nil }
+func (r *paymentBalanceTierUserRepo) UpdateConcurrency(context.Context, int64, int) error { return nil }
+func (r *paymentBalanceTierUserRepo) BatchSetConcurrency(context.Context, []int64, int) (int, error) {
+	return 0, nil
+}
+func (r *paymentBalanceTierUserRepo) BatchAddConcurrency(context.Context, []int64, int) (int, error) {
+	return 0, nil
+}
+func (r *paymentBalanceTierUserRepo) ExistsByEmail(context.Context, string) (bool, error) {
+	return false, nil
+}
+func (r *paymentBalanceTierUserRepo) RemoveGroupFromAllowedGroups(context.Context, int64) (int64, error) {
+	return 0, nil
+}
+func (r *paymentBalanceTierUserRepo) AddGroupToAllowedGroups(context.Context, int64, int64) error {
+	return nil
+}
+func (r *paymentBalanceTierUserRepo) RemoveGroupFromUserAllowedGroups(context.Context, int64, int64) error {
+	return nil
+}
+func (r *paymentBalanceTierUserRepo) ListUserAuthIdentities(context.Context, int64) ([]UserAuthIdentityRecord, error) {
+	return nil, nil
+}
+func (r *paymentBalanceTierUserRepo) UnbindUserAuthProvider(context.Context, int64, string) error {
+	return nil
+}
+func (r *paymentBalanceTierUserRepo) UpdateTotpSecret(context.Context, int64, *string) error {
+	return nil
+}
+func (r *paymentBalanceTierUserRepo) EnableTotp(context.Context, int64) error  { return nil }
+func (r *paymentBalanceTierUserRepo) DisableTotp(context.Context, int64) error { return nil }

--- a/backend/internal/service/payment_order_provider_snapshot.go
+++ b/backend/internal/service/payment_order_provider_snapshot.go
@@ -11,13 +11,14 @@ import (
 )
 
 type paymentOrderProviderSnapshot struct {
-	SchemaVersion      int
-	ProviderInstanceID string
-	ProviderKey        string
-	PaymentMode        string
-	MerchantAppID      string
-	MerchantID         string
-	Currency           string
+	SchemaVersion               int
+	ProviderInstanceID          string
+	ProviderKey                 string
+	PaymentMode                 string
+	MerchantAppID               string
+	MerchantID                  string
+	Currency                    string
+	SubscriptionValiditySeconds int64
 }
 
 func psOrderProviderSnapshot(order *dbent.PaymentOrder) *paymentOrderProviderSnapshot {
@@ -26,13 +27,14 @@ func psOrderProviderSnapshot(order *dbent.PaymentOrder) *paymentOrderProviderSna
 	}
 
 	snapshot := &paymentOrderProviderSnapshot{
-		SchemaVersion:      psSnapshotIntValue(order.ProviderSnapshot["schema_version"]),
-		ProviderInstanceID: psSnapshotStringValue(order.ProviderSnapshot["provider_instance_id"]),
-		ProviderKey:        psSnapshotStringValue(order.ProviderSnapshot["provider_key"]),
-		PaymentMode:        psSnapshotStringValue(order.ProviderSnapshot["payment_mode"]),
-		MerchantAppID:      psSnapshotStringValue(order.ProviderSnapshot["merchant_app_id"]),
-		MerchantID:         psSnapshotStringValue(order.ProviderSnapshot["merchant_id"]),
-		Currency:           psSnapshotStringValue(order.ProviderSnapshot["currency"]),
+		SchemaVersion:               psSnapshotIntValue(order.ProviderSnapshot["schema_version"]),
+		ProviderInstanceID:          psSnapshotStringValue(order.ProviderSnapshot["provider_instance_id"]),
+		ProviderKey:                 psSnapshotStringValue(order.ProviderSnapshot["provider_key"]),
+		PaymentMode:                 psSnapshotStringValue(order.ProviderSnapshot["payment_mode"]),
+		MerchantAppID:               psSnapshotStringValue(order.ProviderSnapshot["merchant_app_id"]),
+		MerchantID:                  psSnapshotStringValue(order.ProviderSnapshot["merchant_id"]),
+		Currency:                    psSnapshotStringValue(order.ProviderSnapshot["currency"]),
+		SubscriptionValiditySeconds: psSnapshotInt64Value(order.ProviderSnapshot["subscription_validity_seconds"]),
 	}
 	if snapshot.SchemaVersion == 0 &&
 		snapshot.ProviderInstanceID == "" &&
@@ -40,7 +42,8 @@ func psOrderProviderSnapshot(order *dbent.PaymentOrder) *paymentOrderProviderSna
 		snapshot.PaymentMode == "" &&
 		snapshot.MerchantAppID == "" &&
 		snapshot.MerchantID == "" &&
-		snapshot.Currency == "" {
+		snapshot.Currency == "" &&
+		snapshot.SubscriptionValiditySeconds == 0 {
 		return nil
 	}
 	return snapshot
@@ -56,19 +59,23 @@ func psSnapshotStringValue(value any) string {
 }
 
 func psSnapshotIntValue(value any) int {
+	return int(psSnapshotInt64Value(value))
+}
+
+func psSnapshotInt64Value(value any) int64 {
 	switch typed := value.(type) {
 	case int:
-		return typed
+		return int64(typed)
 	case int32:
-		return int(typed)
+		return int64(typed)
 	case int64:
-		return int(typed)
+		return typed
 	case float32:
-		return int(typed)
+		return int64(typed)
 	case float64:
-		return int(typed)
+		return int64(typed)
 	case string:
-		n, err := strconv.Atoi(strings.TrimSpace(typed))
+		n, err := strconv.ParseInt(strings.TrimSpace(typed), 10, 64)
 		if err == nil {
 			return n
 		}
@@ -176,6 +183,16 @@ func validateProviderSnapshotMetadata(order *dbent.PaymentOrder, providerKey str
 			}
 			if !strings.EqualFold(expected, actual) {
 				return fmt.Errorf("alipay app_id mismatch: expected %s, got %s", expected, actual)
+			}
+		}
+	case payment.TypeXunhuPay:
+		if expected := strings.TrimSpace(snapshot.MerchantAppID); expected != "" {
+			actual := strings.TrimSpace(metadata["appid"])
+			if actual == "" {
+				return fmt.Errorf("xunhupay appid missing")
+			}
+			if !strings.EqualFold(expected, actual) {
+				return fmt.Errorf("xunhupay appid mismatch: expected %s, got %s", expected, actual)
 			}
 		}
 	case payment.TypeEasyPay:

--- a/backend/internal/service/payment_order_provider_snapshot_test.go
+++ b/backend/internal/service/payment_order_provider_snapshot_test.go
@@ -97,6 +97,7 @@ func TestCreateOrderInTx_WritesProviderSnapshot(t *testing.T) {
 				"secretKey": "do-not-copy",
 			},
 		},
+		ResolvedBalanceTier{},
 	)
 	require.NoError(t, err)
 	require.Equal(t, strconv.FormatInt(instance.ID, 10), valueOrEmpty(order.ProviderInstanceID))

--- a/backend/internal/service/payment_service.go
+++ b/backend/internal/service/payment_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"math"
 	"math/rand/v2"
 	"os"
 	"strings"
@@ -70,20 +71,21 @@ func generateRandomString(n int) string {
 }
 
 type CreateOrderRequest struct {
-	UserID          int64
-	Amount          float64
-	PaymentType     string
-	OpenID          string
-	ClientIP        string
-	IsMobile        bool
-	IsWeChatBrowser bool
-	SrcHost         string
-	SrcURL          string
-	ReturnURL       string
-	PaymentSource   string
-	OrderType       string
-	PlanID          int64
-	Locale          string
+	UserID                     int64
+	Amount                     float64
+	PaymentType                string
+	OpenID                     string
+	ClientIP                   string
+	IsMobile                   bool
+	IsWeChatBrowser            bool
+	SrcHost                    string
+	SrcURL                     string
+	ReturnURL                  string
+	PaymentSource              string
+	OrderType                  string
+	PlanID                     int64
+	Locale                     string
+	BalancePackageValidityDays float64
 }
 
 type CreateOrderResponse struct {
@@ -341,15 +343,59 @@ const (
 	validityUnitMonth = "month"
 )
 
-func psComputeValidityDays(days int, unit string) int {
+var paymentNow = time.Now
+
+func computeSubscriptionValidity(days float64, unit string, from time.Time) (int, time.Duration) {
 	switch unit {
 	case validityUnitWeek:
-		return days * 7
+		return splitSubscriptionValidityDuration(days * 7)
 	case validityUnitMonth:
-		return days * 30
+		wholeMonths := int(days)
+		target := from.AddDate(0, wholeMonths, 0)
+		wholeDays := int(target.Sub(from).Hours() / 24)
+		fractionalMonths := days - float64(wholeMonths)
+		if fractionalMonths <= 0 {
+			return wholeDays, 0
+		}
+		fractionalDays := fractionalMonths * 30
+		fractionalWholeDays, fractionalDuration := splitSubscriptionValidityDuration(fractionalDays)
+		return wholeDays + fractionalWholeDays, fractionalDuration
 	default:
-		return days
+		return splitSubscriptionValidityDuration(days)
 	}
+}
+
+func splitSubscriptionValidityDuration(days float64) (int, time.Duration) {
+	if days <= 0 || math.IsNaN(days) || math.IsInf(days, 0) {
+		return 0, 0
+	}
+	wholeDays := int(math.Floor(days))
+	fractional := days - float64(wholeDays)
+	if fractional <= 0 {
+		return wholeDays, 0
+	}
+	seconds := int64(math.Round(fractional * 24 * float64(time.Hour/time.Second)))
+	if seconds >= int64((24*time.Hour)/time.Second) {
+		wholeDays++
+		seconds -= int64((24 * time.Hour) / time.Second)
+	}
+	return wholeDays, time.Duration(seconds) * time.Second
+}
+
+func computeSubscriptionValidityDays(days float64, unit string, from time.Time) int {
+	wholeDays, duration := computeSubscriptionValidity(days, unit, from)
+	if duration > 0 {
+		wholeDays += int(math.Ceil(duration.Hours() / 24))
+	}
+	return wholeDays
+}
+
+func psComputeValidityDays(days float64, unit string) int {
+	return computeSubscriptionValidityDays(days, unit, paymentNow())
+}
+
+func psComputeValidityForOrder(days float64, unit string) (int, time.Duration) {
+	return computeSubscriptionValidity(days, unit, paymentNow())
 }
 
 func psStartOfDayUTC(t time.Time) time.Time {

--- a/backend/internal/service/payment_subscription_validity_test.go
+++ b/backend/internal/service/payment_subscription_validity_test.go
@@ -1,0 +1,157 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/payment"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeSubscriptionValidityDays(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, time.January, 31, 10, 0, 0, 0, time.UTC)
+
+	require.Equal(t, 15, computeSubscriptionValidityDays(15, "day", base))
+	require.Equal(t, 14, computeSubscriptionValidityDays(2, "week", base))
+	require.Equal(t, 31, computeSubscriptionValidityDays(1, "month", base))
+}
+
+func TestComputeSubscriptionValidityDuration_AllowsFractionalDays(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, time.January, 31, 10, 0, 0, 0, time.UTC)
+
+	days, duration := computeSubscriptionValidity(0.5, "day", base)
+	require.Equal(t, 0, days)
+	require.Equal(t, 12*time.Hour, duration)
+
+	days, duration = computeSubscriptionValidity(1.5, "week", base)
+	require.Equal(t, 10, days)
+	require.Equal(t, 12*time.Hour, duration)
+
+	days, duration = computeSubscriptionValidity(1, "month", base)
+	require.Equal(t, 31, days)
+	require.Zero(t, duration)
+}
+
+func TestCreateOrderInTx_StoresFractionalSubscriptionPlanValidity(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentConfigServiceTestClient(t)
+
+	user, err := client.User.Create().
+		SetEmail("halfday-plan@example.com").
+		SetPasswordHash("hash").
+		SetUsername("halfday-plan-user").
+		SetStatus(StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	plan, err := client.SubscriptionPlan.Create().
+		SetGroupID(123).
+		SetName("Half Day Plan").
+		SetDescription("test").
+		SetPrice(1.9).
+		SetValidityDays(0.5).
+		SetValidityUnit("day").
+		SetFeatures("[]").
+		SetProductName("Half Day").
+		SetForSale(true).
+		SetSortOrder(1).
+		Save(ctx)
+	require.NoError(t, err)
+
+	svc := &PaymentService{entClient: client}
+	order, err := svc.createOrderInTx(
+		ctx,
+		CreateOrderRequest{
+			UserID:      user.ID,
+			PaymentType: payment.TypeAlipay,
+			OrderType:   payment.OrderTypeSubscription,
+			ClientIP:    "127.0.0.1",
+			SrcHost:     "app.example.com",
+		},
+		&User{ID: user.ID, Email: user.Email, Username: user.Username},
+		plan,
+		&PaymentConfig{MaxPendingOrders: 3, OrderTimeoutMin: 30},
+		1.9,
+		1.9,
+		0,
+		1.9,
+		nil,
+		ResolvedBalanceTier{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, order.SubscriptionDays)
+	require.Equal(t, 0, *order.SubscriptionDays)
+	require.EqualValues(t, 43200, order.ProviderSnapshot["subscription_validity_seconds"])
+}
+
+func TestCreateOrderInTx_UsesCalendarMonthValidityForSubscriptionPlan(t *testing.T) {
+	ctx := context.Background()
+	client := newPaymentConfigServiceTestClient(t)
+
+	user, err := client.User.Create().
+		SetEmail("plan@example.com").
+		SetPasswordHash("hash").
+		SetUsername("plan-user").
+		SetStatus(StatusActive).
+		Save(ctx)
+	require.NoError(t, err)
+
+	plan, err := client.SubscriptionPlan.Create().
+		SetGroupID(123).
+		SetName("Monthly Plan").
+		SetDescription("test").
+		SetPrice(9.9).
+		SetValidityDays(1).
+		SetValidityUnit("month").
+		SetFeatures("[]").
+		SetProductName("Monthly").
+		SetForSale(true).
+		SetSortOrder(1).
+		Save(ctx)
+	require.NoError(t, err)
+
+	svc := &PaymentService{entClient: client}
+	base := time.Date(2026, time.January, 31, 10, 0, 0, 0, time.UTC)
+	originalNow := paymentNow
+	paymentNow = func() time.Time { return base }
+	t.Cleanup(func() {
+		paymentNow = originalNow
+	})
+
+	order, err := svc.createOrderInTx(
+		ctx,
+		CreateOrderRequest{
+			UserID:      user.ID,
+			PaymentType: payment.TypeAlipay,
+			OrderType:   payment.OrderTypeSubscription,
+			ClientIP:    "127.0.0.1",
+			SrcHost:     "app.example.com",
+		},
+		&User{
+			ID:       user.ID,
+			Email:    user.Email,
+			Username: user.Username,
+		},
+		plan,
+		&PaymentConfig{
+			MaxPendingOrders: 3,
+			OrderTimeoutMin:  30,
+		},
+		9.9,
+		9.9,
+		0,
+		9.9,
+		nil,
+		ResolvedBalanceTier{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, order.SubscriptionDays)
+	require.Equal(t, 31, *order.SubscriptionDays)
+}

--- a/backend/internal/service/redeem_code.go
+++ b/backend/internal/service/redeem_code.go
@@ -3,8 +3,14 @@ package service
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
 	"time"
 )
+
+const redeemValiditySecondsNotePrefix = "validity_seconds="
 
 type RedeemCode struct {
 	ID        int64
@@ -20,6 +26,9 @@ type RedeemCode struct {
 
 	GroupID      *int64
 	ValidityDays int
+	// ValiditySeconds is used when a subscription redeem code needs sub-day
+	// precision. Existing validity_days semantics stay unchanged.
+	ValiditySeconds int64
 
 	User  *User
 	Group *Group
@@ -53,4 +62,60 @@ func GenerateRedeemCode() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+func NormalizeRedeemValidityDays(validityDays float64) (int, int64, error) {
+	if validityDays == 0 {
+		return 0, 0, nil
+	}
+	if math.IsNaN(validityDays) || math.IsInf(validityDays, 0) {
+		return 0, 0, fmt.Errorf("validity_days must be a finite number")
+	}
+	if validityDays < 0 {
+		if validityDays != math.Trunc(validityDays) {
+			return 0, 0, fmt.Errorf("negative fractional validity_days is not supported")
+		}
+		return int(validityDays), 0, nil
+	}
+
+	seconds := int64(math.Round(validityDays * 24 * float64(time.Hour/time.Second)))
+	if seconds <= 0 {
+		seconds = 1
+	}
+	if seconds%(24*int64(time.Hour/time.Second)) == 0 {
+		return int(seconds / (24 * int64(time.Hour/time.Second))), 0, nil
+	}
+	return 0, seconds, nil
+}
+
+func EncodeRedeemValiditySecondsNote(notes string, seconds int64) string {
+	cleaned, _ := DecodeRedeemValiditySecondsNote(notes)
+	if seconds <= 0 {
+		return cleaned
+	}
+	line := redeemValiditySecondsNotePrefix + strconv.FormatInt(seconds, 10)
+	if strings.TrimSpace(cleaned) == "" {
+		return line
+	}
+	return cleaned + "\n" + line
+}
+
+func DecodeRedeemValiditySecondsNote(notes string) (string, int64) {
+	if notes == "" {
+		return "", 0
+	}
+	lines := strings.Split(notes, "\n")
+	cleaned := make([]string, 0, len(lines))
+	var seconds int64
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, redeemValiditySecondsNotePrefix) {
+			if parsed, err := strconv.ParseInt(strings.TrimSpace(strings.TrimPrefix(trimmed, redeemValiditySecondsNotePrefix)), 10, 64); err == nil && parsed > 0 {
+				seconds = parsed
+			}
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	return strings.TrimSpace(strings.Join(cleaned, "\n")), seconds
 }

--- a/backend/internal/service/redeem_code_test.go
+++ b/backend/internal/service/redeem_code_test.go
@@ -7,6 +7,33 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNormalizeRedeemValidityDays(t *testing.T) {
+	days, seconds, err := NormalizeRedeemValidityDays(0.5)
+	require.NoError(t, err)
+	require.Equal(t, 0, days)
+	require.Equal(t, int64(12*60*60), seconds)
+
+	days, seconds, err = NormalizeRedeemValidityDays(2)
+	require.NoError(t, err)
+	require.Equal(t, 2, days)
+	require.Equal(t, int64(0), seconds)
+
+	days, seconds, err = NormalizeRedeemValidityDays(-7)
+	require.NoError(t, err)
+	require.Equal(t, -7, days)
+	require.Equal(t, int64(0), seconds)
+
+	_, _, err = NormalizeRedeemValidityDays(-0.5)
+	require.Error(t, err)
+}
+
+func TestRedeemValiditySecondsNoteRoundTrip(t *testing.T) {
+	encoded := EncodeRedeemValiditySecondsNote("manual note", 12*60*60)
+	notes, seconds := DecodeRedeemValiditySecondsNote(encoded)
+	require.Equal(t, "manual note", notes)
+	require.Equal(t, int64(12*60*60), seconds)
+}
+
 func TestRedeemCodeExpiry(t *testing.T) {
 	now := time.Now().UTC()
 	past := now.Add(-time.Hour)

--- a/backend/internal/service/redeem_service.go
+++ b/backend/internal/service/redeem_service.go
@@ -141,6 +141,7 @@ type RedeemService struct {
 	entClient            *dbent.Client
 	authCacheInvalidator APIKeyAuthCacheInvalidator
 	affiliateService     *AffiliateService
+	balancePackageRepo   BalancePackageRepository
 }
 
 // NewRedeemService 创建兑换码服务实例
@@ -167,6 +168,10 @@ func NewRedeemService(
 }
 
 // GenerateRandomCode 生成随机兑换码
+func (s *RedeemService) SetBalancePackageRepository(repo BalancePackageRepository) {
+	s.balancePackageRepo = repo
+}
+
 func (s *RedeemService) GenerateRandomCode() (string, error) {
 	// 生成16字节随机数据
 	bytes := make([]byte, 16)
@@ -445,7 +450,19 @@ func (s *RedeemService) Redeem(ctx context.Context, userID int64, code string) (
 		if amount < 0 && user.Balance+amount < 0 {
 			amount = -user.Balance
 		}
-		if err := s.userRepo.UpdateBalance(txCtx, userID, amount); err != nil {
+		if amount > 0 && redeemCode.ValiditySeconds > 0 && s.balancePackageRepo != nil {
+			redeemCodeID := redeemCode.ID
+			if err := s.balancePackageRepo.CreateBalancePackage(txCtx, &UserBalancePackage{
+				UserID:          userID,
+				RedeemCodeID:    &redeemCodeID,
+				Amount:          amount,
+				RemainingAmount: amount,
+				ExpiresAt:       time.Now().UTC().Add(time.Duration(redeemCode.ValiditySeconds) * time.Second),
+				Status:          BalancePackageStatusActive,
+			}); err != nil {
+				return nil, fmt.Errorf("create balance package: %w", err)
+			}
+		} else if err := s.userRepo.UpdateBalance(txCtx, userID, amount); err != nil {
 			return nil, fmt.Errorf("update user balance: %w", err)
 		}
 
@@ -470,12 +487,18 @@ func (s *RedeemService) Redeem(ctx context.Context, userID int64, code string) (
 			if validityDays == 0 {
 				validityDays = 30
 			}
+			validityDuration := time.Duration(0)
+			if redeemCode.ValiditySeconds > 0 {
+				validityDays = 0
+				validityDuration = time.Duration(redeemCode.ValiditySeconds) * time.Second
+			}
 			_, _, err := s.subscriptionService.AssignOrExtendSubscription(txCtx, &AssignSubscriptionInput{
-				UserID:       userID,
-				GroupID:      *redeemCode.GroupID,
-				ValidityDays: validityDays,
-				AssignedBy:   0, // 系统分配
-				Notes:        fmt.Sprintf("通过兑换码 %s 兑换", redeemCode.Code),
+				UserID:           userID,
+				GroupID:          *redeemCode.GroupID,
+				ValidityDays:     validityDays,
+				ValidityDuration: validityDuration,
+				AssignedBy:       0, // 系统分配
+				Notes:            fmt.Sprintf("通过兑换码 %s 兑换", redeemCode.Code),
 			})
 			if err != nil {
 				return nil, fmt.Errorf("assign or extend subscription: %w", err)

--- a/backend/internal/service/subscription_assign_idempotency_test.go
+++ b/backend/internal/service/subscription_assign_idempotency_test.go
@@ -271,6 +271,46 @@ func TestAssignSubscriptionConflictWhenSemanticsMismatch(t *testing.T) {
 	require.Equal(t, 0, subRepo.createCalls, "conflict should not create or mutate existing subscription")
 }
 
+func TestAssignSubscriptionOverwriteExistingActiveSubscription(t *testing.T) {
+	start := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
+	groupRepo := &subscriptionGroupRepoStub{
+		group: &Group{ID: 1, SubscriptionType: SubscriptionTypeSubscription},
+	}
+	subRepo := newSubscriptionUserSubRepoStub()
+	subRepo.seed(&UserSubscription{
+		ID:              12,
+		UserID:          2002,
+		GroupID:         1,
+		StartsAt:        start,
+		ExpiresAt:       time.Now().Add(10 * 24 * time.Hour),
+		Status:          SubscriptionStatusActive,
+		DailyUsageUSD:   5,
+		WeeklyUsageUSD:  6,
+		MonthlyUsageUSD: 7,
+		Notes:           "old-note",
+	})
+
+	svc := NewSubscriptionService(groupRepo, subRepo, nil, nil, nil)
+	sub, err := svc.AssignSubscription(context.Background(), &AssignSubscriptionInput{
+		UserID:            2002,
+		GroupID:           1,
+		ValidityDays:      3,
+		AssignedBy:        9,
+		Notes:             "overwrite-note",
+		OverwriteExisting: true,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, int64(12), sub.ID)
+	require.Equal(t, SubscriptionStatusActive, sub.Status)
+	require.WithinDuration(t, time.Now().Add(3*24*time.Hour), sub.ExpiresAt, 3*time.Second)
+	require.InDelta(t, 0, sub.DailyUsageUSD, 1e-9)
+	require.InDelta(t, 0, sub.WeeklyUsageUSD, 1e-9)
+	require.InDelta(t, 0, sub.MonthlyUsageUSD, 1e-9)
+	require.Equal(t, "overwrite-note", sub.Notes)
+	require.Equal(t, 0, subRepo.createCalls, "overwrite should update existing subscription instead of creating a duplicate")
+}
+
 func TestBulkAssignSubscriptionCreatedReusedAndConflict(t *testing.T) {
 	start := time.Date(2026, 2, 20, 10, 0, 0, 0, time.UTC)
 	groupRepo := &subscriptionGroupRepoStub{

--- a/backend/internal/service/subscription_service.go
+++ b/backend/internal/service/subscription_service.go
@@ -144,11 +144,13 @@ func (s *SubscriptionService) InvalidateSubCache(userID, groupID int64) {
 
 // AssignSubscriptionInput 分配订阅输入
 type AssignSubscriptionInput struct {
-	UserID       int64
-	GroupID      int64
-	ValidityDays int
-	AssignedBy   int64
-	Notes        string
+	UserID            int64
+	GroupID           int64
+	ValidityDays      int
+	ValidityDuration  time.Duration
+	AssignedBy        int64
+	Notes             string
+	OverwriteExisting bool
 }
 
 // AssignSubscription 分配订阅给用户（不允许重复分配）
@@ -183,13 +185,7 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		existingSub = nil
 	}
 
-	validityDays := input.ValidityDays
-	if validityDays <= 0 {
-		validityDays = 30
-	}
-	if validityDays > MaxValidityDays {
-		validityDays = MaxValidityDays
-	}
+	validityDuration := normalizeAssignValidityDuration(input)
 
 	// 已有订阅，执行续期（在事务中完成所有更新）
 	if existingSub != nil {
@@ -199,10 +195,10 @@ func (s *SubscriptionService) AssignOrExtendSubscription(ctx context.Context, in
 		isExpired := !existingSub.ExpiresAt.After(now)
 		if !isExpired {
 			// 未过期：从当前过期时间累加
-			newExpiresAt = existingSub.ExpiresAt.AddDate(0, 0, validityDays)
+			newExpiresAt = existingSub.ExpiresAt.Add(validityDuration)
 		} else {
 			// 已过期：从当前时间开始计算
-			newExpiresAt = now.AddDate(0, 0, validityDays)
+			newExpiresAt = now.Add(validityDuration)
 		}
 
 		// 确保不超过最大过期时间
@@ -340,16 +336,8 @@ func appendSubscriptionNotes(existingNotes, newNotes string) string {
 
 // createSubscription 创建新订阅（内部方法）
 func (s *SubscriptionService) createSubscription(ctx context.Context, input *AssignSubscriptionInput) (*UserSubscription, error) {
-	validityDays := input.ValidityDays
-	if validityDays <= 0 {
-		validityDays = 30
-	}
-	if validityDays > MaxValidityDays {
-		validityDays = MaxValidityDays
-	}
-
 	now := time.Now()
-	expiresAt := now.AddDate(0, 0, validityDays)
+	expiresAt := now.Add(normalizeAssignValidityDuration(input))
 	if expiresAt.After(MaxExpiresAt) {
 		expiresAt = MaxExpiresAt
 	}
@@ -454,6 +442,10 @@ func (s *SubscriptionService) assignSubscriptionWithReuse(ctx context.Context, i
 		if getErr != nil {
 			return nil, false, getErr
 		}
+		if input.OverwriteExisting {
+			overwritten, err := s.overwriteExistingSubscription(ctx, sub, input)
+			return overwritten, true, err
+		}
 		if conflictReason, conflict := detectAssignSemanticConflict(sub, input); conflict {
 			return nil, false, ErrSubscriptionAssignConflict.WithMetadata(map[string]string{
 				"conflict_reason": conflictReason,
@@ -481,14 +473,45 @@ func (s *SubscriptionService) assignSubscriptionWithReuse(ctx context.Context, i
 	return sub, false, nil
 }
 
+func (s *SubscriptionService) overwriteExistingSubscription(ctx context.Context, existingSub *UserSubscription, input *AssignSubscriptionInput) (*UserSubscription, error) {
+	if existingSub == nil || input == nil {
+		return nil, ErrSubscriptionNilInput
+	}
+	now := time.Now()
+	expiresAt := now.Add(normalizeAssignValidityDuration(input))
+	if expiresAt.After(MaxExpiresAt) {
+		expiresAt = MaxExpiresAt
+	}
+	overwritten := renewedSubscriptionTerm(existingSub, input.Notes, now, expiresAt)
+	if input.AssignedBy > 0 {
+		overwritten.AssignedBy = &input.AssignedBy
+	}
+	overwritten.AssignedAt = now
+	overwritten.Notes = input.Notes
+	if err := s.withSubscriptionUpdateTx(ctx, func(txCtx context.Context) error {
+		return s.userSubRepo.Update(txCtx, overwritten)
+	}); err != nil {
+		return nil, err
+	}
+	s.InvalidateSubCache(input.UserID, input.GroupID)
+	if s.billingCacheService != nil {
+		userID, groupID := input.UserID, input.GroupID
+		go func() {
+			cacheCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = s.billingCacheService.InvalidateSubscription(cacheCtx, userID, groupID)
+		}()
+	}
+	return s.userSubRepo.GetByID(ctx, existingSub.ID)
+}
+
 func detectAssignSemanticConflict(existing *UserSubscription, input *AssignSubscriptionInput) (string, bool) {
 	if existing == nil || input == nil {
 		return "", false
 	}
 
-	normalizedDays := normalizeAssignValidityDays(input.ValidityDays)
 	if !existing.StartsAt.IsZero() {
-		expectedExpiresAt := existing.StartsAt.AddDate(0, 0, normalizedDays)
+		expectedExpiresAt := existing.StartsAt.Add(normalizeAssignValidityDuration(input))
 		if expectedExpiresAt.After(MaxExpiresAt) {
 			expectedExpiresAt = MaxExpiresAt
 		}
@@ -514,6 +537,20 @@ func normalizeAssignValidityDays(days int) int {
 		days = MaxValidityDays
 	}
 	return days
+}
+
+func normalizeAssignValidityDuration(input *AssignSubscriptionInput) time.Duration {
+	if input == nil {
+		return 30 * 24 * time.Hour
+	}
+	if input.ValidityDuration > 0 {
+		maxDuration := time.Duration(MaxValidityDays) * 24 * time.Hour
+		if input.ValidityDuration > maxDuration {
+			return maxDuration
+		}
+		return input.ValidityDuration
+	}
+	return time.Duration(normalizeAssignValidityDays(input.ValidityDays)) * 24 * time.Hour
 }
 
 // RevokeSubscription 撤销订阅

--- a/backend/internal/service/usage_service.go
+++ b/backend/internal/service/usage_service.go
@@ -36,6 +36,7 @@ type CreateUsageLogRequest struct {
 	TotalCost             float64 `json:"total_cost"`
 	ActualCost            float64 `json:"actual_cost"`
 	RateMultiplier        float64 `json:"rate_multiplier"`
+	BillingType           int8    `json:"billing_type"`
 	Stream                bool    `json:"stream"`
 	DurationMs            *int    `json:"duration_ms"`
 }
@@ -58,6 +59,7 @@ type UsageService struct {
 	userRepo             UserRepository
 	entClient            *dbent.Client
 	authCacheInvalidator APIKeyAuthCacheInvalidator
+	balancePackageRepo   BalancePackageRepository
 }
 
 // NewUsageService 创建使用统计服务实例
@@ -110,6 +112,7 @@ func (s *UsageService) Create(ctx context.Context, req CreateUsageLogRequest) (*
 		TotalCost:             req.TotalCost,
 		ActualCost:            req.ActualCost,
 		RateMultiplier:        req.RateMultiplier,
+		BillingType:           req.BillingType,
 		Stream:                req.Stream,
 		DurationMs:            req.DurationMs,
 	}
@@ -121,8 +124,12 @@ func (s *UsageService) Create(ctx context.Context, req CreateUsageLogRequest) (*
 
 	// 扣除用户余额
 	balanceUpdated := false
-	if inserted && req.ActualCost > 0 {
-		if err := s.userRepo.UpdateBalance(txCtx, req.UserID, -req.ActualCost); err != nil {
+	if inserted && shouldDeductBalanceForBillingType(req.BillingType, req.ActualCost) {
+		if s.balancePackageRepo != nil {
+			if _, err := DeductUserBalanceWithPackages(txCtx, s.balancePackageRepo, req.UserID, req.ActualCost, time.Now().UTC()); err != nil {
+				return nil, fmt.Errorf("deduct user balance packages: %w", err)
+			}
+		} else if err := s.userRepo.UpdateBalance(txCtx, req.UserID, -req.ActualCost); err != nil {
 			return nil, fmt.Errorf("update user balance: %w", err)
 		}
 		balanceUpdated = true
@@ -137,6 +144,10 @@ func (s *UsageService) Create(ctx context.Context, req CreateUsageLogRequest) (*
 	s.invalidateUsageCaches(ctx, req.UserID, balanceUpdated)
 
 	return usageLog, nil
+}
+
+func shouldDeductBalanceForBillingType(billingType int8, actualCost float64) bool {
+	return actualCost > 0 && billingType == BillingTypeBalance
 }
 
 func (s *UsageService) invalidateUsageCaches(ctx context.Context, userID int64, balanceUpdated bool) {

--- a/backend/migrations/147_repair_payment_audit_constraints.sql
+++ b/backend/migrations/147_repair_payment_audit_constraints.sql
@@ -1,0 +1,30 @@
+-- Repair payment_audit_logs constraints after legacy/imported tables that were
+-- created without the primary key and order/action idempotency index.
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY order_id, action ORDER BY id) AS rn
+    FROM payment_audit_logs
+)
+DELETE FROM payment_audit_logs p
+USING ranked r
+WHERE p.id = r.id
+  AND r.rn > 1;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'payment_audit_logs'::regclass
+          AND contype = 'p'
+    ) THEN
+        ALTER TABLE payment_audit_logs
+            ADD CONSTRAINT payment_audit_logs_pkey PRIMARY KEY (id);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_payment_audit_logs_order_id
+    ON payment_audit_logs(order_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_payment_audit_logs_order_action_uniq
+    ON payment_audit_logs(order_id, action);

--- a/backend/migrations/148_subscription_plan_validity_days_decimal.sql
+++ b/backend/migrations/148_subscription_plan_validity_days_decimal.sql
@@ -1,0 +1,3 @@
+-- Allow subscription plan validity to store fractional days such as 0.5.
+ALTER TABLE subscription_plans
+    ALTER COLUMN validity_days TYPE numeric(20,8) USING validity_days::numeric;

--- a/backend/migrations/149_user_balance_packages.sql
+++ b/backend/migrations/149_user_balance_packages.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS user_balance_packages (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    redeem_code_id BIGINT NULL REFERENCES redeem_codes(id) ON DELETE SET NULL,
+    amount DECIMAL(20,8) NOT NULL DEFAULT 0,
+    remaining_amount DECIMAL(20,8) NOT NULL DEFAULT 0,
+    expires_at TIMESTAMPTZ NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'active',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT user_balance_packages_amount_nonnegative CHECK (amount >= 0),
+    CONSTRAINT user_balance_packages_remaining_nonnegative CHECK (remaining_amount >= 0),
+    CONSTRAINT user_balance_packages_remaining_lte_amount CHECK (remaining_amount <= amount)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_balance_packages_user_active_expiry
+    ON user_balance_packages (user_id, status, expires_at, id)
+    WHERE remaining_amount > 0;
+
+CREATE INDEX IF NOT EXISTS idx_user_balance_packages_redeem_code
+    ON user_balance_packages (redeem_code_id);

--- a/frontend/src/api/admin/payment.ts
+++ b/frontend/src/api/admin/payment.ts
@@ -8,8 +8,10 @@ import type {
   DashboardStats,
   PaymentOrder,
   PaymentChannel,
+  CatalogProduct,
   SubscriptionPlan,
-  ProviderInstance
+  ProviderInstance,
+  BalancePricingTier
 } from '@/types/payment'
 import type { BasePaginationResponse } from '@/types'
 
@@ -24,6 +26,9 @@ export interface AdminPaymentConfig {
   enabled_payment_types: string[]
   balance_disabled: boolean
   balance_recharge_multiplier: number
+  balance_pricing_tiers?: BalancePricingTier[]
+  balance_recharge_as_package?: boolean
+  balance_package_validity_days?: number
   load_balance_strategy: string
   product_name_prefix: string
   product_name_suffix: string
@@ -42,6 +47,9 @@ export interface UpdatePaymentConfigRequest {
   enabled_payment_types?: string[]
   balance_disabled?: boolean
   balance_recharge_multiplier?: number
+  balance_pricing_tiers?: BalancePricingTier[]
+  balance_recharge_as_package?: boolean
+  balance_package_validity_days?: number
   load_balance_strategy?: string
   product_name_prefix?: string
   product_name_suffix?: string
@@ -60,6 +68,16 @@ export const adminPaymentAPI = {
   /** Update payment configuration */
   updateConfig(data: UpdatePaymentConfigRequest) {
     return apiClient.put('/admin/payment/config', data)
+  },
+
+  /** Get homepage/shop product catalog */
+  getProducts() {
+    return apiClient.get<{ products: CatalogProduct[] }>('/admin/payment/products')
+  },
+
+  /** Replace homepage/shop product catalog */
+  updateProducts(products: CatalogProduct[]) {
+    return apiClient.put<{ products: CatalogProduct[] }>('/admin/payment/products', { products })
   },
 
   // ==================== Dashboard ====================

--- a/frontend/src/api/admin/redeem.ts
+++ b/frontend/src/api/admin/redeem.ts
@@ -84,6 +84,8 @@ export async function generate(
     if (validityDays && validityDays > 0) {
       payload.validity_days = validityDays
     }
+  } else if (type === 'balance' && validityDays && validityDays > 0) {
+    payload.validity_days = validityDays
   }
   if (expiresInDays && expiresInDays > 0) {
     payload.expires_in_days = expiresInDays

--- a/frontend/src/api/payment.ts
+++ b/frontend/src/api/payment.ts
@@ -8,6 +8,7 @@ import type {
   PaymentConfig,
   SubscriptionPlan,
   PaymentChannel,
+  CatalogProduct,
   MethodLimitsResponse,
   CheckoutInfoResponse,
   CreateOrderRequest,
@@ -35,6 +36,11 @@ export const paymentAPI = {
   /** Get all checkout page data in a single call */
   getCheckoutInfo() {
     return apiClient.get<CheckoutInfoResponse>('/payment/checkout-info')
+  },
+
+  /** Get public homepage/shop products */
+  getCatalogProducts() {
+    return apiClient.get<{ products: CatalogProduct[] }>('/payment/catalog/products')
   },
 
   /** Get payment method limits and fee rates */

--- a/frontend/src/components/payment/PaymentMethodSelector.vue
+++ b/frontend/src/components/payment/PaymentMethodSelector.vue
@@ -80,14 +80,14 @@ const sortedMethods = computed(() => {
 
 function methodIcon(type: string): string {
   if (type.includes('alipay')) return METHOD_ICONS.alipay
-  if (type.includes('wxpay')) return METHOD_ICONS.wxpay
+  if (type.includes('wxpay') || type === 'xunhupay') return METHOD_ICONS.wxpay
   if (type === 'airwallex') return METHOD_ICONS.airwallex
   return METHOD_ICONS[type] || alipayIcon
 }
 
 function methodSelectedClass(type: string): string {
   if (type.includes('alipay')) return 'border-[#02A9F1] bg-blue-50 text-gray-900 shadow-sm dark:bg-blue-950 dark:text-gray-100'
-  if (type.includes('wxpay')) return 'border-[#09BB07] bg-green-50 text-gray-900 shadow-sm dark:bg-green-950 dark:text-gray-100'
+  if (type.includes('wxpay') || type === 'xunhupay') return 'border-[#09BB07] bg-green-50 text-gray-900 shadow-sm dark:bg-green-950 dark:text-gray-100'
   if (type === 'stripe') return 'border-[#676BE5] bg-indigo-50 text-gray-900 shadow-sm dark:bg-indigo-950 dark:text-gray-100'
   if (type === 'airwallex') return 'border-[#FF6B3D] bg-orange-50 text-gray-900 shadow-sm dark:border-[#FF8E3C] dark:bg-orange-950 dark:text-gray-100'
   return 'border-primary-500 bg-primary-50 text-gray-900 shadow-sm dark:bg-primary-950 dark:text-gray-100'

--- a/frontend/src/components/payment/PaymentQRDialog.vue
+++ b/frontend/src/components/payment/PaymentQRDialog.vue
@@ -5,7 +5,8 @@
       <!-- QR Code mode -->
       <template v-if="qrUrl">
         <div class="rounded-2xl bg-white p-4 shadow-sm dark:bg-dark-800">
-          <canvas ref="qrCanvas" class="mx-auto"></canvas>
+          <img v-if="remoteQrImageUrl" :src="remoteQrImageUrl" alt="" class="mx-auto h-[220px] w-[220px] object-contain" />
+          <canvas v-else ref="qrCanvas" class="mx-auto"></canvas>
         </div>
         <p v-if="scanHint" class="text-center text-sm text-gray-500 dark:text-gray-400">
           {{ scanHint }}
@@ -122,6 +123,12 @@ const VERIFY_RETRY_MAX_ATTEMPTS = 6
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const isXunhuPay = computed(() => props.paymentType.includes('xunhu'))
+const remoteQrImageUrl = computed(() => {
+  const value = qrUrl.value.trim()
+  if (!isXunhuPay.value || !/^https?:\/\//i.test(value)) return ''
+  return value
+})
 
 const dialogTitle = computed(() => {
   if (success.value) return t('payment.result.success')
@@ -158,7 +165,7 @@ function reopenPopup() {
 
 async function renderQR() {
   await nextTick()
-  if (!qrCanvas.value || !qrUrl.value) return
+  if (remoteQrImageUrl.value || !qrCanvas.value || !qrUrl.value) return
   const logoSrc = getLogoForType()
   await QRCode.toCanvas(qrCanvas.value, qrUrl.value, {
     width: 220,

--- a/frontend/src/components/payment/PaymentStatusPanel.vue
+++ b/frontend/src/components/payment/PaymentStatusPanel.vue
@@ -75,9 +75,10 @@
         <div class="flex flex-col items-center space-y-4">
           <p class="text-lg font-semibold text-gray-900 dark:text-white">{{ scanTitle }}</p>
           <div :class="['relative rounded-lg border-2 p-4', qrBorderClass]">
-            <canvas ref="qrCanvas" class="mx-auto"></canvas>
+            <img v-if="remoteQrImageUrl" :src="remoteQrImageUrl" alt="" class="mx-auto h-[220px] w-[220px] object-contain" />
+            <canvas v-else ref="qrCanvas" class="mx-auto"></canvas>
             <!-- Brand logo overlay -->
-            <div class="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div v-if="!remoteQrImageUrl" class="pointer-events-none absolute inset-0 flex items-center justify-center">
               <span :class="['rounded-full p-2 shadow ring-2 ring-white', qrLogoBgClass]">
                 <img :src="isAlipay ? alipayIcon : wxpayIcon" alt="" class="h-5 w-5 brightness-0 invert" />
               </span>
@@ -183,6 +184,12 @@ const VERIFY_RETRY_MAX_ATTEMPTS = 6
 
 const isAlipay = computed(() => props.paymentType.includes('alipay'))
 const isWxpay = computed(() => props.paymentType.includes('wxpay'))
+const isXunhuPay = computed(() => props.paymentType.includes('xunhu'))
+const remoteQrImageUrl = computed(() => {
+  const value = qrUrl.value.trim()
+  if (!isXunhuPay.value || !/^https?:\/\//i.test(value)) return ''
+  return value
+})
 
 const qrBorderClass = computed(() => {
   if (isAlipay.value) return 'border-[#00AEEF] bg-blue-50 dark:border-[#00AEEF]/70 dark:bg-blue-950/20'
@@ -239,7 +246,7 @@ function setOutcome(next: PaymentOutcome) {
 
 async function renderQR() {
   await nextTick()
-  if (!qrCanvas.value || !qrUrl.value) return
+  if (remoteQrImageUrl.value || !qrCanvas.value || !qrUrl.value) return
   await QRCode.toCanvas(qrCanvas.value, qrUrl.value, {
     width: 220, margin: 2,
     errorCorrectionLevel: 'M',

--- a/frontend/src/components/payment/SubscriptionPlanCard.vue
+++ b/frontend/src/components/payment/SubscriptionPlanCard.vue
@@ -1,82 +1,80 @@
 <template>
   <div
     :class="[
-      'group relative flex flex-col overflow-hidden rounded-2xl border transition-all',
-      'hover:shadow-xl hover:-translate-y-0.5',
+      'group relative flex min-h-[20rem] flex-col overflow-hidden rounded-3xl border transition-all duration-200',
+      'bg-white/95 shadow-sm hover:-translate-y-0.5 hover:shadow-xl dark:bg-dark-800/95',
       borderClass,
-      'bg-white dark:bg-dark-800',
     ]"
   >
-    <!-- Colored top accent bar -->
-    <div :class="['h-1.5', accentClass]" />
+    <div :class="['absolute inset-x-0 top-0 h-1', accentClass]" />
+    <div :class="['pointer-events-none absolute -right-12 -top-12 h-32 w-32 rounded-full opacity-10 blur-2xl', accentClass]" />
 
-    <div class="flex flex-1 flex-col p-4">
-      <!-- Header: name + badge + price -->
-      <div class="mb-3 flex items-start justify-between gap-2">
+    <div class="relative flex flex-1 flex-col p-5">
+      <div class="mb-4 flex items-start justify-between gap-4">
         <div class="min-w-0 flex-1">
-          <div class="flex items-center gap-2">
-            <h3 class="truncate text-base font-bold text-gray-900 dark:text-white">{{ plan.name }}</h3>
-            <span :class="['shrink-0 rounded-full px-2 py-0.5 text-[11px] font-medium', badgeLightClass]">
+          <div class="mb-2 flex flex-wrap items-center gap-2">
+            <span :class="['shrink-0 rounded-full px-2.5 py-1 text-[11px] font-semibold', badgeLightClass]">
               {{ pLabel }}
             </span>
+            <span v-if="discountText" :class="['rounded-full px-2 py-0.5 text-[10px] font-bold', discountClass]">
+              {{ discountText }}
+            </span>
           </div>
-          <p v-if="plan.description" class="mt-0.5 text-xs leading-relaxed text-gray-500 dark:text-dark-400 line-clamp-2">
+          <h3 class="line-clamp-2 text-lg font-extrabold leading-snug text-gray-950 dark:text-white" :title="plan.name">
+            {{ plan.name }}
+          </h3>
+          <p v-if="plan.description" class="mt-2 min-h-[2.25rem] text-sm leading-relaxed text-gray-500 line-clamp-2 dark:text-dark-300" :title="plan.description">
             {{ plan.description }}
           </p>
         </div>
         <div class="shrink-0 text-right">
-          <div class="flex items-baseline gap-1">
-            <span class="text-xs text-gray-400 dark:text-dark-500">$</span>
-            <span :class="['text-2xl font-extrabold tracking-tight', textClass]">{{ plan.price }}</span>
+          <div class="flex items-start justify-end gap-1">
+            <span class="mt-1 text-sm font-semibold text-gray-400 dark:text-dark-500">$</span>
+            <span :class="['text-4xl font-black leading-none tracking-tight', textClass]">{{ priceDisplay }}</span>
           </div>
-          <span class="text-[11px] text-gray-400 dark:text-dark-500">/ {{ validitySuffix }}</span>
-          <div v-if="plan.original_price" class="mt-0.5 flex items-center justify-end gap-1.5">
-            <span class="text-xs text-gray-400 line-through dark:text-dark-500">${{ plan.original_price }}</span>
-            <span :class="['rounded px-1 py-0.5 text-[10px] font-semibold', discountClass]">{{ discountText }}</span>
+          <div class="mt-1 text-xs font-medium text-gray-400 dark:text-dark-500">/ {{ validitySuffix }}</div>
+          <div v-if="plan.original_price" class="mt-1 text-xs text-gray-400 line-through dark:text-dark-500">
+            ${{ plan.original_price }}
           </div>
         </div>
       </div>
 
-      <!-- Group quota info (compact) -->
-      <div class="mb-3 grid grid-cols-2 gap-x-3 gap-y-1 rounded-lg bg-gray-50 px-3 py-2 text-xs dark:bg-dark-700/50">
-        <div class="flex items-center justify-between">
-          <span class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.rate') }}</span>
-          <span class="font-medium text-gray-700 dark:text-gray-300">{{ rateDisplay }}</span>
+      <div class="mb-4 grid grid-cols-2 gap-2 text-xs">
+        <div class="rounded-xl bg-gray-50 px-3 py-2 dark:bg-dark-700/50">
+          <div class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.rate') }}</div>
+          <div class="mt-0.5 font-bold text-gray-800 dark:text-gray-100">{{ rateDisplay }}</div>
         </div>
-        <div v-if="plan.daily_limit_usd != null" class="flex items-center justify-between">
-          <span class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.dailyLimit') }}</span>
-          <span class="font-medium text-gray-700 dark:text-gray-300">${{ plan.daily_limit_usd }}</span>
+        <div class="rounded-xl bg-gray-50 px-3 py-2 dark:bg-dark-700/50">
+          <div class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.dailyLimit') }}</div>
+          <div class="mt-0.5 font-bold text-gray-800 dark:text-gray-100">{{ limitDisplay(plan.daily_limit_usd) }}</div>
         </div>
-        <div v-if="plan.weekly_limit_usd != null" class="flex items-center justify-between">
-          <span class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.weeklyLimit') }}</span>
-          <span class="font-medium text-gray-700 dark:text-gray-300">${{ plan.weekly_limit_usd }}</span>
+        <div class="rounded-xl bg-gray-50 px-3 py-2 dark:bg-dark-700/50">
+          <div class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.weeklyLimit') }}</div>
+          <div class="mt-0.5 font-bold text-gray-800 dark:text-gray-100">{{ limitDisplay(plan.weekly_limit_usd) }}</div>
         </div>
-        <div v-if="plan.monthly_limit_usd != null" class="flex items-center justify-between">
-          <span class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.monthlyLimit') }}</span>
-          <span class="font-medium text-gray-700 dark:text-gray-300">${{ plan.monthly_limit_usd }}</span>
+        <div class="rounded-xl bg-gray-50 px-3 py-2 dark:bg-dark-700/50">
+          <div class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.monthlyLimit') }}</div>
+          <div class="mt-0.5 font-bold text-gray-800 dark:text-gray-100">{{ limitDisplay(plan.monthly_limit_usd) }}</div>
         </div>
-        <div v-if="plan.daily_limit_usd == null && plan.weekly_limit_usd == null && plan.monthly_limit_usd == null" class="flex items-center justify-between">
-          <span class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.quota') }}</span>
-          <span class="font-medium text-gray-700 dark:text-gray-300">{{ t('payment.planCard.unlimited') }}</span>
-        </div>
-        <div v-if="modelScopeLabels.length > 0" class="col-span-2 flex items-center justify-between">
-          <span class="text-gray-400 dark:text-dark-500">{{ t('payment.planCard.models') }}</span>
-          <div class="flex flex-wrap justify-end gap-1">
+        <div v-if="modelScopeLabels.length > 0" class="col-span-2 rounded-xl bg-gray-50 px-3 py-2 dark:bg-dark-700/50">
+          <div class="mb-1 text-gray-400 dark:text-dark-500">{{ t('payment.planCard.models') }}</div>
+          <div class="flex flex-wrap gap-1">
             <span v-for="scope in modelScopeLabels" :key="scope"
-              class="rounded bg-gray-200/80 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-dark-600 dark:text-gray-300">
+              class="rounded-full bg-gray-200/80 px-2 py-0.5 text-[10px] font-semibold text-gray-600 dark:bg-dark-600 dark:text-gray-300">
               {{ scope }}
             </span>
           </div>
         </div>
       </div>
 
-      <!-- Features list (compact) -->
-      <div v-if="plan.features.length > 0" class="mb-3 space-y-1">
-        <div v-for="feature in plan.features" :key="feature" class="flex items-start gap-1.5">
-          <svg :class="['mt-0.5 h-3.5 w-3.5 flex-shrink-0', iconClass]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-          </svg>
-          <span class="text-xs text-gray-600 dark:text-gray-300">{{ feature }}</span>
+      <div v-if="visibleFeatures.length > 0" class="mb-4 space-y-2">
+        <div v-for="feature in visibleFeatures" :key="feature" class="flex items-start gap-2">
+          <span :class="['mt-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-white', accentClass]">
+            <svg class="h-2.5 w-2.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          </span>
+          <span class="text-sm leading-5 text-gray-600 dark:text-gray-300">{{ feature }}</span>
         </div>
       </div>
 
@@ -104,7 +102,6 @@ import {
   platformBadgeLightClass,
   platformBorderClass,
   platformTextClass,
-  platformIconClass,
   platformButtonClass,
   platformDiscountClass,
   platformLabel,
@@ -124,7 +121,6 @@ const accentClass = computed(() => platformAccentBarClass(platform.value))
 const borderClass = computed(() => platformBorderClass(platform.value))
 const badgeLightClass = computed(() => platformBadgeLightClass(platform.value))
 const textClass = computed(() => platformTextClass(platform.value))
-const iconClass = computed(() => platformIconClass(platform.value))
 const btnClass = computed(() => platformButtonClass(platform.value))
 const discountClass = computed(() => platformDiscountClass(platform.value))
 const pLabel = computed(() => platformLabel(platform.value))
@@ -137,7 +133,20 @@ const discountText = computed(() => {
 
 const rateDisplay = computed(() => {
   const rate = props.plan.rate_multiplier ?? 1
-  return `×${Number(rate.toPrecision(10))}`
+  return `x${Number(rate.toPrecision(10))}`
+})
+
+const priceDisplay = computed(() => Number(props.plan.price || 0).toLocaleString(undefined, { maximumFractionDigits: 2 }))
+
+const limitDisplay = (value: number | null | undefined) => {
+  if (value == null || Number(value) <= 0) return t('payment.planCard.unlimited')
+  return `${Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })}`
+}
+
+const visibleFeatures = computed(() => {
+  return (props.plan.features || [])
+    .map(feature => String(feature || '').trim())
+    .filter(feature => feature && feature !== '[]' && feature !== '[ ]')
 })
 
 const MODEL_SCOPE_LABELS: Record<string, string> = {

--- a/frontend/src/components/payment/__tests__/PaymentStatusPanel.spec.ts
+++ b/frontend/src/components/payment/__tests__/PaymentStatusPanel.spec.ts
@@ -132,6 +132,29 @@ describe('PaymentStatusPanel', () => {
     openSpy.mockRestore()
   })
 
+  it('renders remote xunhupay QR images directly without generating a nested QR code', async () => {
+    const wrapper = mount(PaymentStatusPanel, {
+      props: {
+        orderId: 42,
+        qrCode: 'https://pay.example/qrcode/order.png',
+        expiresAt: '2099-01-01T12:30:00Z',
+        paymentType: 'wxpay_xunhu',
+        orderType: 'balance',
+      },
+      global: {
+        stubs: {
+          Icon: true,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    const img = wrapper.get('img[src="https://pay.example/qrcode/order.png"]')
+    expect(img.classes()).toContain('object-contain')
+    expect(toCanvas).not.toHaveBeenCalled()
+  })
+
   it('actively verifies a stuck pending order and settles it when upstream confirms payment', async () => {
     pollOrderStatus.mockResolvedValue(orderFactory('PENDING'))
     verifyOrder.mockResolvedValue({

--- a/frontend/src/components/payment/__tests__/paymentFlow.spec.ts
+++ b/frontend/src/components/payment/__tests__/paymentFlow.spec.ts
@@ -49,6 +49,16 @@ describe('getVisibleMethods', () => {
     })
   })
 
+  it('normalizes xunhupay legacy aliases', () => {
+    const visible = getVisibleMethods({
+      wxpay_xunhu: methodLimit({ single_max: 200 }),
+    })
+
+    expect(visible).toEqual({
+      xunhupay: methodLimit({ single_max: 200 }),
+    })
+  })
+
   it('prefers canonical visible methods over aliases when both exist', () => {
     const visible = getVisibleMethods({
       alipay: methodLimit({ single_min: 2 }),
@@ -175,6 +185,22 @@ describe('decidePaymentLaunch', () => {
 
     expect(decision.kind).toBe('qr_waiting')
     expect(decision.paymentState.qrCode).toBe('https://pay.example.com/qr/session')
+  })
+
+  it('keeps xunhupay QR display when a QR payload is available', () => {
+    const decision = decidePaymentLaunch(createOrderResult({
+      pay_url: 'https://pay.example.com/xunhu/checkout',
+      qr_code: 'https://pay.example.com/xunhu/qrcode.png',
+      payment_mode: 'qrcode',
+    }), {
+      visibleMethod: 'wxpay_xunhu',
+      orderType: 'balance',
+      isMobile: false,
+    })
+
+    expect(decision.kind).toBe('qr_waiting')
+    expect(decision.paymentState.payUrl).toBe('https://pay.example.com/xunhu/checkout')
+    expect(decision.paymentState.qrCode).toBe('https://pay.example.com/xunhu/qrcode.png')
   })
 
   it('returns wechat oauth launch when backend requires in-app authorization', () => {

--- a/frontend/src/components/payment/paymentFlow.ts
+++ b/frontend/src/components/payment/paymentFlow.ts
@@ -14,11 +14,13 @@ const VISIBLE_METHOD_ALIASES = {
   alipay_direct: 'alipay',
   wxpay: 'wxpay',
   wxpay_direct: 'wxpay',
+  xunhupay: 'xunhupay',
+  wxpay_xunhu: 'xunhupay',
   stripe: 'stripe',
   airwallex: 'airwallex',
 } as const
 
-export type VisiblePaymentMethod = 'alipay' | 'wxpay' | 'stripe' | 'airwallex'
+export type VisiblePaymentMethod = 'alipay' | 'wxpay' | 'xunhupay' | 'stripe' | 'airwallex'
 export type StripeVisibleMethod = 'alipay' | 'wechat_pay'
 export type PaymentLaunchKind =
   | 'qr_waiting'
@@ -213,6 +215,15 @@ export function decidePaymentLaunch(
 
   if (visibleMethod === 'wxpay' && context.isWechatBrowser && baseState.payUrl && !baseState.qrCode) {
     return { kind: 'redirect_waiting', paymentState: baseState, recovery: baseState }
+  }
+
+  if (visibleMethod === 'xunhupay') {
+    if (baseState.qrCode) {
+      return { kind: 'qr_waiting', paymentState: baseState, recovery: baseState }
+    }
+    if (baseState.payUrl) {
+      return { kind: 'redirect_waiting', paymentState: baseState, recovery: baseState }
+    }
   }
 
   if (prefersRedirect && baseState.payUrl) {

--- a/frontend/src/components/payment/providerConfig.ts
+++ b/frontend/src/components/payment/providerConfig.ts
@@ -36,13 +36,14 @@ export const PROVIDER_SUPPORTED_TYPES: Record<string, string[]> = {
   wxpay: ['wxpay'],
   stripe: ['card', 'alipay', 'wxpay', 'link'],
   airwallex: ['airwallex'],
+  xunhupay: ['wxpay_xunhu'],
 }
 
 /** Available payment modes for EasyPay providers. */
 export const EASYPAY_PAYMENT_MODES = ['qrcode', 'popup'] as const
 
 /** Fixed display order for user-facing payment methods */
-export const METHOD_ORDER = ['alipay', 'alipay_direct', 'wxpay', 'wxpay_direct', 'stripe', 'airwallex'] as const
+export const METHOD_ORDER = ['alipay', 'alipay_direct', 'wxpay', 'wxpay_direct', 'xunhupay', 'wxpay_xunhu', 'stripe', 'airwallex'] as const
 
 /** Payment mode constants */
 export const PAYMENT_MODE_QRCODE = 'qrcode'
@@ -96,6 +97,7 @@ export const WEBHOOK_PATHS: Record<string, string> = {
   wxpay: '/api/v1/payment/webhook/wxpay',
   stripe: '/api/v1/payment/webhook/stripe',
   airwallex: '/api/v1/payment/webhook/airwallex',
+  xunhupay: '/api/v1/payment/webhook/xunhupay',
 }
 
 export const RETURN_PATH = '/payment/result'
@@ -146,6 +148,11 @@ export const PROVIDER_CONFIG_FIELDS: Record<string, ConfigFieldDef[]> = {
     { key: 'countryCode', label: '', sensitive: false, defaultValue: 'CN' },
     { key: 'currency', label: '', sensitive: false, defaultValue: 'CNY', hintKey: 'admin.settings.payment.field_paymentCurrencyHint', options: PAYMENT_CURRENCY_OPTIONS },
     { key: 'accountId', label: '', sensitive: false, optional: true, clearable: true, hintKey: 'admin.settings.payment.field_accountIdHint' },
+  ],
+  xunhupay: [
+    { key: 'appId', label: 'App ID', sensitive: false },
+    { key: 'secret', label: 'Secret', sensitive: true },
+    { key: 'gatewayUrl', label: 'Gateway URL', sensitive: false },
   ],
 }
 

--- a/frontend/src/types/payment.ts
+++ b/frontend/src/types/payment.ts
@@ -33,6 +33,9 @@ export interface PaymentConfig {
   order_timeout_minutes: number
   balance_disabled: boolean
   balance_recharge_multiplier: number
+  balance_pricing_tiers?: BalancePricingTier[]
+  balance_recharge_as_package?: boolean
+  balance_package_validity_days?: number
   enabled_payment_types: PaymentType[]
   help_image_url: string
   help_text: string
@@ -65,12 +68,46 @@ export interface CheckoutInfoResponse {
   plans: SubscriptionPlan[]
   balance_disabled: boolean
   balance_recharge_multiplier: number
+  balance_pricing_tiers?: BalancePricingTier[]
+  balance_recharge_as_package?: boolean
+  balance_package_validity_days?: number
   recharge_fee_rate: number
   help_text: string
   help_image_url: string
   stripe_publishable_key: string
   /** When true, Alipay payments on mobile always show the QR code instead of redirecting */
   alipay_force_qrcode?: boolean
+}
+
+export interface BalancePricingTier {
+  min: number
+  max: number
+  multiplier: number
+  label: string
+  enabled: boolean
+  sortOrder: number
+}
+
+export type CatalogProductType = 'topup' | 'subscription'
+
+export interface CatalogProduct {
+  slug: string
+  title: string
+  category: string
+  summary: string
+  description: string
+  image: string
+  cardImage?: string
+  tags: string[]
+  priceLabel: string
+  currency?: string
+  badge?: string
+  active: boolean
+  sortOrder: number
+  productType: CatalogProductType
+  amount?: number
+  planId?: string
+  ctaText?: string
 }
 
 // ==================== Orders ====================
@@ -97,6 +134,9 @@ export interface PaymentOrder {
   refund_request_reason?: string
   plan_id?: number
   provider_instance_id?: string
+  paymentSuccess?: boolean
+  rechargeSuccess?: boolean
+  rechargeStatus?: 'not_paid' | 'paid_pending' | 'recharging' | 'success' | 'failed' | 'closed'
 }
 
 // ==================== Plans & Channels ====================

--- a/frontend/src/views/admin/RedeemView.vue
+++ b/frontend/src/views/admin/RedeemView.vue
@@ -132,7 +132,7 @@
             <span class="text-sm font-medium text-gray-900 dark:text-white">
               <template v-if="row.type === 'balance'">${{ value.toFixed(2) }}</template>
               <template v-else-if="row.type === 'subscription'">
-                {{ row.validity_days || 30 }} {{ t('admin.redeem.days') }}
+                {{ formatRedeemValidity(row) }}
                 <span v-if="row.group" class="ml-1 text-xs text-gray-500 dark:text-gray-400"
                   >({{ row.group.name }})</span
                 >
@@ -305,6 +305,18 @@
                 class="input"
               />
             </div>
+            <div v-if="generateForm.type === 'balance'">
+              <label class="input-label">余额包有效期（天，留空为普通余额）</label>
+              <input
+                v-model.number="generateForm.balance_validity_days"
+                type="number"
+                min="0.001"
+                max="365"
+                step="any"
+                class="input"
+                placeholder="例如 0.5 表示半天"
+              />
+            </div>
             <!-- 邀请码类型：显示提示信息 -->
             <div v-if="generateForm.type === 'invitation'" class="rounded-lg bg-blue-50 p-3 dark:bg-blue-900/20">
               <p class="text-sm text-blue-700 dark:text-blue-300">
@@ -349,8 +361,9 @@
                 <input
                   v-model.number="generateForm.validity_days"
                   type="number"
-                  min="1"
+                  min="0.001"
                   max="365"
+                  step="any"
                   required
                   class="input"
                 />
@@ -833,6 +846,7 @@ const generateForm = reactive({
   count: 1,
   group_id: null as number | null,
   validity_days: 30,
+  balance_validity_days: null as number | null,
   expiry_option: 'never' as RedeemCodeExpiryOption,
   custom_expiry_days: 7
 })
@@ -848,6 +862,14 @@ watch(
     }
   }
 )
+
+const formatRedeemValidity = (code: RedeemCode) => {
+  if (code.validity_seconds && code.validity_seconds > 0) {
+    const days = code.validity_seconds / 86400
+    return `${Number(days.toFixed(4))} ${t('admin.redeem.days')}`
+  }
+  return `${code.validity_days || 30} ${t('admin.redeem.days')}`
+}
 
 const buildRedeemQueryFilters = () => ({
   type: (filters.type || undefined) as RedeemCodeType | undefined,
@@ -1037,7 +1059,11 @@ const handleGenerateCodes = async () => {
       generateForm.type,
       generateForm.value,
       generateForm.type === 'subscription' ? generateForm.group_id : undefined,
-      generateForm.type === 'subscription' ? generateForm.validity_days : undefined,
+      generateForm.type === 'subscription'
+        ? Number(generateForm.validity_days)
+        : generateForm.type === 'balance' && Number(generateForm.balance_validity_days) > 0
+          ? Number(generateForm.balance_validity_days)
+          : undefined,
       expiresInDays
     )
     showGenerateDialog.value = false
@@ -1046,6 +1072,7 @@ const handleGenerateCodes = async () => {
     // 重置表单
     generateForm.group_id = null
     generateForm.validity_days = 30
+    generateForm.balance_validity_days = null
     generateForm.expiry_option = 'never'
     generateForm.custom_expiry_days = 7
     loadCodes()

--- a/frontend/src/views/admin/SubscriptionsView.vue
+++ b/frontend/src/views/admin/SubscriptionsView.vue
@@ -633,6 +633,44 @@
       </template>
     </BaseDialog>
 
+    <!-- Existing Active Subscription Choice Dialog -->
+    <BaseDialog
+      :show="showAssignChoiceDialog"
+      title="已有未结束订阅"
+      width="normal"
+      @close="closeAssignChoiceDialog"
+    >
+      <div v-if="assignConflictSubscription" class="space-y-3 text-sm text-gray-700 dark:text-gray-300">
+        <p>
+          用户
+          <span class="font-medium text-gray-900 dark:text-white">{{ selectedUser?.email }}</span>
+          已经有这个分组的未结束订阅。
+        </p>
+        <p>
+          当前结束时间：
+          <span class="font-medium text-gray-900 dark:text-white">
+            {{ assignConflictSubscription.expires_at ? formatDateOnly(assignConflictSubscription.expires_at) : '无结束时间' }}
+          </span>
+        </p>
+        <p class="text-xs text-gray-500 dark:text-gray-400">
+          续期会在当前结束时间后增加天数；覆盖会从现在开始重新计算有效期，并重置这条订阅的用量窗口。
+        </p>
+      </div>
+      <template #footer>
+        <div class="flex justify-end gap-3">
+          <button @click="closeAssignChoiceDialog" type="button" class="btn btn-secondary">
+            {{ t('common.cancel') }}
+          </button>
+          <button @click="confirmAssignExtend" type="button" :disabled="submitting" class="btn btn-secondary">
+            续期
+          </button>
+          <button @click="confirmAssignOverwrite" type="button" :disabled="submitting" class="btn btn-primary">
+            覆盖
+          </button>
+        </div>
+      </template>
+    </BaseDialog>
+
     <!-- Revoke Confirmation Dialog -->
     <ConfirmDialog
       :show="showRevokeDialog"
@@ -939,12 +977,14 @@ const pagination = reactive({
 
 const showAssignModal = ref(false)
 const showExtendModal = ref(false)
+const showAssignChoiceDialog = ref(false)
 const showRevokeDialog = ref(false)
 const showResetQuotaConfirm = ref(false)
 const submitting = ref(false)
 const resettingSubscription = ref<UserSubscription | null>(null)
 const resettingQuota = ref(false)
 const extendingSubscription = ref<UserSubscription | null>(null)
+const assignConflictSubscription = ref<UserSubscription | null>(null)
 const revokingSubscription = ref<UserSubscription | null>(null)
 
 const assignForm = reactive({
@@ -1167,6 +1207,33 @@ const closeAssignModal = () => {
   userSearchKeyword.value = ''
   userSearchResults.value = []
   showUserDropdown.value = false
+  assignConflictSubscription.value = null
+  showAssignChoiceDialog.value = false
+}
+
+const closeAssignChoiceDialog = () => {
+  showAssignChoiceDialog.value = false
+  assignConflictSubscription.value = null
+}
+
+const findExistingOpenSubscription = async (): Promise<UserSubscription | null> => {
+  if (!assignForm.user_id || !assignForm.group_id) return null
+  const result = await adminAPI.subscriptions.list(1, 50, {
+    status: 'active',
+    user_id: assignForm.user_id,
+    group_id: assignForm.group_id
+  })
+  const now = Date.now()
+  return result.items.find((sub) => !sub.expires_at || new Date(sub.expires_at).getTime() > now) || null
+}
+
+const assignSubscription = async (overwriteExisting = false) => {
+  await adminAPI.subscriptions.assign({
+    user_id: assignForm.user_id!,
+    group_id: assignForm.group_id!,
+    validity_days: assignForm.validity_days,
+    overwrite_existing: overwriteExisting
+  })
 }
 
 const handleAssignSubscription = async () => {
@@ -1185,17 +1252,54 @@ const handleAssignSubscription = async () => {
 
   submitting.value = true
   try {
-    await adminAPI.subscriptions.assign({
-      user_id: assignForm.user_id,
-      group_id: assignForm.group_id,
-      validity_days: assignForm.validity_days
-    })
+    const existingOpen = await findExistingOpenSubscription()
+    if (existingOpen) {
+      assignConflictSubscription.value = existingOpen
+      showAssignChoiceDialog.value = true
+      return
+    }
+    await assignSubscription(false)
     appStore.showSuccess(t('admin.subscriptions.subscriptionAssigned'))
     closeAssignModal()
     loadSubscriptions()
   } catch (error: any) {
     appStore.showError(error.response?.data?.detail || t('admin.subscriptions.failedToAssign'))
     console.error('Error assigning subscription:', error)
+  } finally {
+    submitting.value = false
+  }
+}
+
+const confirmAssignExtend = async () => {
+  if (!assignConflictSubscription.value) return
+  submitting.value = true
+  try {
+    await adminAPI.subscriptions.extend(assignConflictSubscription.value.id, {
+      days: assignForm.validity_days
+    })
+    appStore.showSuccess(t('admin.subscriptions.subscriptionAdjusted'))
+    closeAssignChoiceDialog()
+    closeAssignModal()
+    loadSubscriptions()
+  } catch (error: any) {
+    appStore.showError(error.response?.data?.detail || t('admin.subscriptions.failedToAdjust'))
+    console.error('Error extending existing subscription:', error)
+  } finally {
+    submitting.value = false
+  }
+}
+
+const confirmAssignOverwrite = async () => {
+  submitting.value = true
+  try {
+    await assignSubscription(true)
+    appStore.showSuccess(t('admin.subscriptions.subscriptionAssigned'))
+    closeAssignChoiceDialog()
+    closeAssignModal()
+    loadSubscriptions()
+  } catch (error: any) {
+    appStore.showError(error.response?.data?.detail || t('admin.subscriptions.failedToAssign'))
+    console.error('Error overwriting existing subscription:', error)
   } finally {
     submitting.value = false
   }

--- a/frontend/src/views/admin/orders/AdminPaymentPlansView.vue
+++ b/frontend/src/views/admin/orders/AdminPaymentPlansView.vue
@@ -64,6 +64,172 @@
           </div>
         </template>
       </DataTable>
+
+      <div class="card p-4">
+        <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h3 class="text-base font-semibold text-gray-900 dark:text-white">首页商品规格设置</h3>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">按 sub2apipay 原版方式维护商品卡片、详情、图片、价格、slug 与支付类型。</p>
+          </div>
+          <div class="flex flex-wrap gap-2">
+            <a class="btn btn-secondary" href="/payment" target="_blank" rel="noopener noreferrer">打开支付首页</a>
+            <button class="btn btn-secondary" :disabled="productsLoading" @click="loadProducts">刷新</button>
+            <button class="btn btn-secondary" :disabled="productsLoading" @click="addProduct">新增商品</button>
+            <button class="btn btn-primary" :disabled="productsSaving || products.length === 0" @click="saveProducts">保存商品设置</button>
+          </div>
+        </div>
+
+        <div class="grid gap-4 lg:grid-cols-[320px_minmax(0,1fr)]">
+          <aside class="rounded-2xl border border-gray-200 bg-gray-50 p-4 dark:border-dark-600 dark:bg-dark-800/60">
+            <div class="mb-3 flex items-center justify-between">
+              <h4 class="text-sm font-semibold text-gray-800 dark:text-gray-100">商品列表</h4>
+              <button class="rounded-xl border border-gray-200 bg-white px-3 py-1 text-xs text-gray-700 hover:bg-gray-100 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200" @click="jsonOpen = !jsonOpen">
+                {{ jsonOpen ? '关闭 JSON' : '打开 JSON' }}
+              </button>
+            </div>
+
+            <div class="space-y-2">
+              <button
+                v-for="(product, index) in products"
+                :key="`${product.slug || 'new'}-${index}`"
+                type="button"
+                :class="productListButtonClass(index)"
+                @click="selectProduct(index)"
+              >
+                <div class="flex items-center justify-between gap-3">
+                  <div class="min-w-0">
+                    <div class="truncate text-sm font-semibold text-gray-900 dark:text-white">{{ product.title || '未命名商品' }}</div>
+                    <div class="truncate text-xs text-gray-500 dark:text-gray-400">{{ product.slug || '未设置 slug' }}</div>
+                  </div>
+                  <span :class="['shrink-0 rounded-full px-2 py-0.5 text-[11px]', product.active ? 'bg-emerald-100 text-emerald-700' : 'bg-gray-200 text-gray-500 dark:bg-dark-600 dark:text-gray-400']">
+                    {{ product.active ? '启用' : '停用' }}
+                  </span>
+                </div>
+              </button>
+            </div>
+
+            <div v-if="jsonOpen" class="mt-4 border-t border-gray-200 pt-4 dark:border-dark-600">
+              <textarea v-model="jsonDraft" class="min-h-[280px] w-full rounded-2xl border border-gray-200 bg-white p-3 font-mono text-xs text-gray-900 outline-none dark:border-dark-600 dark:bg-dark-900 dark:text-gray-100" />
+              <div class="mt-3 flex gap-3">
+                <button class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 hover:bg-gray-100 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200" @click="applyJsonDraft">应用 JSON</button>
+                <button class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 hover:bg-gray-100 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200" @click="resetJsonDraft">重置 JSON</button>
+              </div>
+            </div>
+          </aside>
+
+          <section class="rounded-2xl border border-gray-200 bg-white p-5 dark:border-dark-600 dark:bg-dark-800/40">
+            <div v-if="selectedProduct" class="space-y-6">
+              <div class="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <h4 class="text-xl font-semibold text-gray-900 dark:text-white">{{ selectedProduct.title || '未命名商品' }}</h4>
+                  <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">当前编辑第 {{ selectedProductIndex + 1 }} 个商品</p>
+                </div>
+                <div class="flex flex-wrap gap-2">
+                  <button class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-50 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200" :disabled="selectedProductIndex <= 0" @click="moveSelectedProduct(-1)">上移</button>
+                  <button class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 hover:bg-gray-100 disabled:opacity-50 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200" :disabled="selectedProductIndex >= products.length - 1" @click="moveSelectedProduct(1)">下移</button>
+                  <button class="rounded-xl border border-gray-200 bg-white px-3 py-2 text-xs text-gray-700 hover:bg-gray-100 dark:border-dark-600 dark:bg-dark-700 dark:text-gray-200" @click="duplicateProduct">复制</button>
+                  <button class="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 hover:bg-red-100 dark:border-red-900/60 dark:bg-red-900/20 dark:text-red-300" @click="removeSelectedProduct">删除</button>
+                </div>
+              </div>
+
+              <div class="grid gap-4 md:grid-cols-2">
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">标题
+                  <input :value="selectedProduct.title" class="input" @input="updateSelectedProduct({ title: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">Slug
+                  <div class="space-y-2">
+                    <input :value="selectedProduct.slug" class="input" @input="updateSelectedProduct({ slug: normalizeSlug(inputValue($event)) })" />
+                    <button type="button" class="rounded-xl border border-gray-200 px-3 py-2 text-xs text-gray-600 hover:bg-gray-50 dark:border-dark-600 dark:text-gray-300 dark:hover:bg-dark-700" @click="updateSelectedProduct({ slug: normalizeSlug(selectedProduct.title) })">根据标题生成</button>
+                  </div>
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">分类
+                  <input :value="selectedProduct.category" class="input" @input="updateSelectedProduct({ category: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">价格 + 币种
+                  <div class="grid grid-cols-2 gap-3">
+                    <input :value="selectedProduct.priceLabel" class="input" @input="updateSelectedProduct({ priceLabel: inputValue($event) })" />
+                    <input :value="selectedProduct.currency || 'CNY'" class="input" @input="updateSelectedProduct({ currency: inputValue($event) })" />
+                  </div>
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">商品类型
+                  <select :value="selectedProduct.productType" class="input" @change="changeSelectedProductType(inputValue($event))">
+                    <option value="topup">充值</option>
+                    <option value="subscription">订阅</option>
+                  </select>
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">排序
+                  <input type="number" :value="selectedProduct.sortOrder" class="input" @input="updateSelectedProduct({ sortOrder: numberValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300 md:col-span-2">主图 URL
+                  <input :value="selectedProduct.image" class="input" @input="updateSelectedProduct({ image: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300 md:col-span-2">卡片图 URL
+                  <input :value="selectedProduct.cardImage || ''" class="input" @input="updateSelectedProduct({ cardImage: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300 md:col-span-2">标签（逗号分隔）
+                  <input :value="selectedProduct.tags.join(', ')" class="input" @input="updateSelectedProduct({ tags: splitTags(inputValue($event)) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">徽标
+                  <input :value="selectedProduct.badge || ''" class="input" @input="updateSelectedProduct({ badge: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">按钮文案
+                  <input :value="selectedProduct.ctaText || ''" class="input" @input="updateSelectedProduct({ ctaText: inputValue($event) })" />
+                </label>
+                <div v-if="selectedProduct.productType === 'topup'" class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">充值金额（amount）
+                  <div class="rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 dark:border-dark-600 dark:bg-dark-700/60">
+                    <div class="text-base font-semibold text-gray-900 dark:text-white">{{ formatCatalogAmount(selectedProduct.amount ?? 0) }}</div>
+                    <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      根据价格 {{ selectedProduct.priceLabel || '0.00' }} 和倍率 {{ selectedProductPricing?.multiplier.toFixed(4) || '1.0000' }} 自动计算
+                      <span v-if="selectedProductPricing?.label">（{{ selectedProductPricing.label }}）</span>
+                    </div>
+                  </div>
+                </div>
+                <label v-else class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">订阅 planId
+                  <input :value="selectedProduct.planId || ''" class="input" @input="updateSelectedProduct({ planId: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300">启用状态
+                  <span class="flex h-11 items-center gap-3 rounded-2xl border border-gray-200 bg-white px-4 dark:border-dark-600 dark:bg-dark-700">
+                    <input type="checkbox" :checked="selectedProduct.active" @change="updateSelectedProduct({ active: checkedValue($event) })" />
+                    <span class="text-sm text-gray-700 dark:text-gray-200">{{ selectedProduct.active ? '启用' : '停用' }}</span>
+                  </span>
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300 md:col-span-2">摘要
+                  <textarea :value="selectedProduct.summary" class="input min-h-[120px] py-3" @input="updateSelectedProduct({ summary: inputValue($event) })" />
+                </label>
+                <label class="space-y-2 text-sm font-medium text-gray-700 dark:text-gray-300 md:col-span-2">详情正文
+                  <textarea :value="selectedProduct.description" class="input min-h-[220px] py-3" @input="updateSelectedProduct({ description: inputValue($event) })" />
+                </label>
+              </div>
+
+              <div class="rounded-3xl border border-gray-200 bg-gray-50 p-5 dark:border-dark-600 dark:bg-dark-900/40">
+                <div class="mb-3 text-sm font-semibold text-gray-800 dark:text-gray-100">实时预览</div>
+                <div class="overflow-hidden rounded-3xl border border-gray-200 bg-white dark:border-dark-600 dark:bg-dark-800">
+                  <img v-if="selectedProduct.image" :src="selectedProduct.image" :alt="selectedProduct.title" class="h-64 w-full object-cover" />
+                  <div v-else class="flex h-64 items-center justify-center text-sm text-gray-500 dark:text-gray-400">暂无图片</div>
+                  <div class="p-5">
+                    <div class="mb-2 flex flex-wrap gap-2 text-xs">
+                      <span class="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700">{{ selectedProduct.category || '未分类' }}</span>
+                      <span v-for="tag in selectedProduct.tags" :key="tag" class="rounded-full bg-gray-100 px-3 py-1 text-gray-700 dark:bg-dark-700 dark:text-gray-200">{{ tag }}</span>
+                    </div>
+                    <div class="text-2xl font-bold text-gray-900 dark:text-white">{{ selectedProduct.title || '未命名商品' }}</div>
+                    <div class="mt-2 whitespace-pre-line text-sm leading-7 text-gray-500 dark:text-gray-400">{{ selectedProduct.summary }}</div>
+                    <div class="mt-5 flex items-center justify-between">
+                      <div class="text-3xl font-black text-gray-900 dark:text-white">
+                        {{ selectedProduct.priceLabel || '0.00' }}
+                        <span class="ml-2 text-sm font-semibold text-gray-500">{{ selectedProduct.currency || 'CNY' }}</span>
+                      </div>
+                      <span class="rounded-2xl bg-emerald-500 px-4 py-2 text-sm font-semibold text-white">{{ selectedProduct.ctaText || '立即购买' }}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div v-else class="flex min-h-[420px] items-center justify-center rounded-2xl border border-dashed border-gray-300 text-sm text-gray-500 dark:border-dark-600 dark:text-gray-400">
+              还没有商品，点击“新增商品”开始。
+            </div>
+          </section>
+        </div>
+      </div>
     </div>
 
     <!-- Plan Edit Dialog -->
@@ -80,7 +246,7 @@ import { useAppStore } from '@/stores/app'
 import { adminPaymentAPI } from '@/api/admin/payment'
 import { extractI18nErrorMessage } from '@/utils/apiError'
 import adminAPI from '@/api/admin'
-import type { SubscriptionPlan } from '@/types/payment'
+import type { BalancePricingTier, CatalogProduct, SubscriptionPlan } from '@/types/payment'
 import type { AdminGroup } from '@/types'
 import type { Column } from '@/components/common/types'
 import AppLayout from '@/components/layout/AppLayout.vue'
@@ -177,10 +343,267 @@ async function handleDeletePlan() {
   catch (err: unknown) { appStore.showError(extractI18nErrorMessage(err, t, 'payment.errors', t('common.error'))) }
 }
 
+// ==================== Homepage products ====================
+
+const emptyProduct: CatalogProduct = {
+  slug: '',
+  title: '',
+  category: '余额充值',
+  summary: '',
+  description: '',
+  image: '',
+  cardImage: '',
+  tags: [],
+  priceLabel: '',
+  currency: 'CNY',
+  badge: '',
+  active: true,
+  sortOrder: 10,
+  productType: 'topup',
+  amount: 0,
+  planId: '',
+  ctaText: '立即购买',
+}
+
+const productsLoading = ref(false)
+const productsSaving = ref(false)
+const products = ref<CatalogProduct[]>([])
+const selectedProductIndex = ref(0)
+const jsonOpen = ref(false)
+const jsonDraft = ref('')
+const balanceRechargeMultiplier = ref(1)
+const balancePricingTiers = ref<BalancePricingTier[]>([])
+
+const selectedProduct = computed(() => products.value[selectedProductIndex.value] || null)
+const selectedProductPricing = computed(() => selectedProduct.value ? resolveCatalogTopupPricing(selectedProduct.value) : null)
+
+async function loadPaymentPricingConfig() {
+  const res = await adminPaymentAPI.getConfig()
+  balanceRechargeMultiplier.value = normalizePositiveNumber(res.data.balance_recharge_multiplier, 1)
+  balancePricingTiers.value = normalizeBalancePricingTiers(res.data.balance_pricing_tiers)
+}
+
+async function loadProducts() {
+  productsLoading.value = true
+  try {
+    await loadPaymentPricingConfig()
+    const res = await adminPaymentAPI.getProducts()
+    products.value = (res.data?.products || []).map(normalizeProductForEdit)
+    selectedProductIndex.value = products.value.length > 0 ? 0 : -1
+    syncProductsJson()
+  } catch (err: unknown) {
+    appStore.showError(extractI18nErrorMessage(err, t, 'payment.errors', t('common.error')))
+  } finally {
+    productsLoading.value = false
+  }
+}
+
+function normalizeProductForEdit(product: CatalogProduct): CatalogProduct {
+  const normalized: CatalogProduct = {
+    ...emptyProduct,
+    ...product,
+    tags: Array.isArray(product.tags) ? product.tags : [],
+    productType: product.productType === 'subscription' ? 'subscription' : 'topup',
+    active: product.active !== false,
+    sortOrder: Number(product.sortOrder || 0),
+  }
+  return withCalculatedCatalogAmount(normalized)
+}
+
+function normalizePositiveNumber(value: unknown, fallback: number): number {
+  const numeric = Number(value)
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : fallback
+}
+
+function normalizeBalancePricingTiers(tiers: BalancePricingTier[] | undefined): BalancePricingTier[] {
+  return (tiers || [])
+    .filter(tier => tier?.enabled !== false && normalizePositiveNumber(tier.multiplier, 0) > 0 && Number(tier.min) >= 0 && Number(tier.max) >= Number(tier.min))
+    .map(tier => ({
+      ...tier,
+      min: Number(tier.min),
+      max: Number(tier.max),
+      multiplier: Number(tier.multiplier),
+      sortOrder: Number(tier.sortOrder || 0),
+    }))
+    .sort((a, b) => (a.sortOrder - b.sortOrder) || (a.min - b.min))
+}
+
+function parseCatalogPriceLabel(priceLabel: string): number {
+  const cleaned = String(priceLabel || '').trim().replace(/[,¥￥$]/g, '')
+  const first = cleaned.split(/\s+/)[0]
+  const amount = Number(first || 0)
+  return Number.isFinite(amount) && amount > 0 ? amount : 0
+}
+
+function resolveCatalogTopupPricing(product: CatalogProduct): { payAmount: number; multiplier: number; amount: number; label: string } {
+  const payAmount = parseCatalogPriceLabel(product.priceLabel)
+  const tier = balancePricingTiers.value.find(item => payAmount >= item.min && payAmount <= item.max)
+  const multiplier = normalizePositiveNumber(tier?.multiplier, balanceRechargeMultiplier.value)
+  return {
+    payAmount,
+    multiplier,
+    amount: payAmount > 0 ? Math.round((payAmount / multiplier) * 100) / 100 : 0,
+    label: tier?.label || '默认倍率',
+  }
+}
+
+function withCalculatedCatalogAmount(product: CatalogProduct): CatalogProduct {
+  if (product.productType !== 'topup') {
+    return { ...product, amount: undefined }
+  }
+  return { ...product, amount: resolveCatalogTopupPricing(product).amount }
+}
+
+function formatCatalogAmount(amount: number): string {
+  return Number(amount || 0).toFixed(2)
+}
+
+function syncProductsJson() {
+  jsonDraft.value = JSON.stringify(products.value, null, 2)
+}
+
+function resetJsonDraft() {
+  syncProductsJson()
+}
+
+function normalizeSlug(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fa5]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-')
+}
+
+function inputValue(event: Event): string {
+  return (event.target as HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement).value
+}
+
+function numberValue(event: Event): number {
+  return Number(inputValue(event) || 0)
+}
+
+function checkedValue(event: Event): boolean {
+  return (event.target as HTMLInputElement).checked
+}
+
+function splitTags(value: string): string[] {
+  return value.split(',').map(item => item.trim()).filter(Boolean)
+}
+
+function productListButtonClass(index: number): string[] {
+  const selected = index === selectedProductIndex.value
+  return [
+    'w-full rounded-2xl border px-3 py-3 text-left transition',
+    selected
+      ? 'border-emerald-400 bg-emerald-50 dark:border-emerald-500 dark:bg-emerald-900/20'
+      : 'border-gray-200 bg-white hover:bg-gray-50 dark:border-dark-600 dark:bg-dark-700 dark:hover:bg-dark-600',
+  ]
+}
+
+function selectProduct(index: number) {
+  selectedProductIndex.value = index
+}
+
+function updateSelectedProduct(patch: Partial<CatalogProduct>) {
+  const current = selectedProduct.value
+  if (!current) return
+  products.value[selectedProductIndex.value] = normalizeProductForEdit({ ...current, ...patch })
+  syncProductsJson()
+}
+
+function changeSelectedProductType(value: string) {
+  const current = selectedProduct.value
+  if (!current) return
+  const productType = value === 'subscription' ? 'subscription' : 'topup'
+  updateSelectedProduct({
+    productType,
+    amount: productType === 'topup' ? resolveCatalogTopupPricing(current).amount : undefined,
+    planId: productType === 'subscription' ? current.planId || '' : '',
+  })
+}
+
+function addProduct() {
+  const nextOrder = products.value.length > 0
+    ? Math.max(...products.value.map(product => product.sortOrder || 0)) + 10
+    : 10
+  products.value.push({
+    ...emptyProduct,
+    sortOrder: nextOrder,
+  })
+  selectedProductIndex.value = products.value.length - 1
+  syncProductsJson()
+}
+
+function duplicateProduct() {
+  const current = selectedProduct.value
+  if (!current) return
+  const copied = normalizeProductForEdit({
+    ...current,
+    slug: current.slug ? `${current.slug}-copy` : '',
+    title: current.title ? `${current.title}（副本）` : '',
+    sortOrder: (current.sortOrder || 0) + 1,
+    tags: [...(current.tags || [])],
+  })
+  products.value.splice(selectedProductIndex.value + 1, 0, copied)
+  selectedProductIndex.value += 1
+  syncProductsJson()
+}
+
+function removeSelectedProduct() {
+  if (!selectedProduct.value || products.value.length === 0) return
+  products.value.splice(selectedProductIndex.value, 1)
+  selectedProductIndex.value = products.value.length > 0
+    ? Math.max(0, Math.min(selectedProductIndex.value, products.value.length - 1))
+    : -1
+  syncProductsJson()
+}
+
+function moveSelectedProduct(direction: -1 | 1) {
+  const target = selectedProductIndex.value + direction
+  if (target < 0 || target >= products.value.length) return
+  const next = [...products.value]
+  ;[next[selectedProductIndex.value], next[target]] = [next[target], next[selectedProductIndex.value]]
+  products.value = next
+  selectedProductIndex.value = target
+  syncProductsJson()
+}
+
+function applyJsonDraft() {
+  try {
+    const parsed = JSON.parse(jsonDraft.value)
+    if (!Array.isArray(parsed)) throw new Error('JSON 顶层必须是数组')
+    products.value = parsed.map(normalizeProductForEdit)
+    selectedProductIndex.value = products.value.length > 0 ? 0 : -1
+    syncProductsJson()
+    appStore.showSuccess('已应用 JSON 草稿，记得点击保存商品设置')
+  } catch (err: unknown) {
+    appStore.showError(err instanceof Error ? err.message : 'JSON 解析失败')
+  }
+}
+
+async function saveProducts() {
+  productsSaving.value = true
+  try {
+    const res = await adminPaymentAPI.updateProducts(products.value.map(withCalculatedCatalogAmount))
+    products.value = (res.data?.products || products.value).map(normalizeProductForEdit)
+    selectedProductIndex.value = products.value.length > 0
+      ? Math.max(0, Math.min(selectedProductIndex.value, products.value.length - 1))
+      : -1
+    syncProductsJson()
+    appStore.showSuccess(t('common.saved'))
+  } catch (err: unknown) {
+    appStore.showError(extractI18nErrorMessage(err, t, 'payment.errors', t('common.error')))
+  } finally {
+    productsSaving.value = false
+  }
+}
+
 // ==================== Lifecycle ====================
 
 onMounted(() => {
   loadGroups()
   loadPlans()
+  loadProducts()
 })
 </script>

--- a/frontend/src/views/user/PaymentResultView.vue
+++ b/frontend/src/views/user/PaymentResultView.vue
@@ -87,7 +87,13 @@
           </div>
         </div>
         <!-- Actions -->
-        <div class="flex gap-3">
+        <div v-if="isInPopup" class="space-y-3 text-center">
+          <p v-if="isSuccess" class="text-sm text-gray-500 dark:text-gray-400">
+            支付已完成，窗口将自动关闭
+          </p>
+          <button class="btn btn-primary w-full" @click="closeCurrentWindow">立即关闭窗口</button>
+        </div>
+        <div v-else class="flex gap-3">
           <button class="btn btn-secondary flex-1" @click="router.push('/purchase')">{{ t('payment.result.backToRecharge') }}</button>
           <button class="btn btn-primary flex-1" @click="router.push('/orders')">{{ t('payment.result.viewOrders') }}</button>
         </div>
@@ -136,7 +142,15 @@ const STATUS_REFRESH_INTERVAL_MS = 2000
 const STATUS_REFRESH_MAX_ATTEMPTS = 15
 
 let statusRefreshTimer: ReturnType<typeof setTimeout> | null = null
+let autoCloseTimer: ReturnType<typeof setTimeout> | null = null
 const refreshAttempts = ref(0)
+const isInPopup = ref(false)
+
+type WindowWithAlipayBridge = Window & {
+  AlipayJSBridge?: {
+    call: (name: string, params?: unknown, callback?: (...args: unknown[]) => void) => void
+  }
+}
 
 /** 充值金额 = pay_amount / (1 + fee_rate/100)，fee_rate=0 时等于 pay_amount */
 const baseAmount = computed(() => {
@@ -286,6 +300,57 @@ function clearStatusRefreshTimer(): void {
   }
 }
 
+function clearAutoCloseTimer(): void {
+  if (autoCloseTimer !== null) {
+    clearTimeout(autoCloseTimer)
+    autoCloseTimer = null
+  }
+}
+
+function tryCloseViaAlipayBridge(): boolean {
+  if (typeof window === 'undefined') return false
+  const bridge = (window as WindowWithAlipayBridge).AlipayJSBridge
+  if (!bridge?.call) return false
+
+  try {
+    bridge.call('closeWebview')
+    return true
+  } catch (_err: unknown) {
+    return false
+  }
+}
+
+function closeCurrentWindow(): void {
+  if (typeof window === 'undefined') return
+  if (tryCloseViaAlipayBridge()) return
+
+  let settled = false
+  const handleBridgeReady = () => {
+    if (settled) return
+    settled = true
+    document.removeEventListener('AlipayJSBridgeReady', handleBridgeReady)
+    if (!tryCloseViaAlipayBridge()) {
+      window.close()
+    }
+  }
+
+  document.addEventListener('AlipayJSBridgeReady', handleBridgeReady, { once: true })
+  window.setTimeout(() => {
+    if (settled) return
+    settled = true
+    document.removeEventListener('AlipayJSBridgeReady', handleBridgeReady)
+    window.close()
+  }, 250)
+}
+
+function schedulePopupAutoClose(): void {
+  clearAutoCloseTimer()
+  if (!isInPopup.value || !isSuccess.value) return
+  autoCloseTimer = setTimeout(() => {
+    closeCurrentWindow()
+  }, 3000)
+}
+
 function clearRecoverySnapshot(): void {
   if (typeof window === 'undefined') return
   clearPaymentRecoverySnapshot(window.localStorage, PAYMENT_RECOVERY_STORAGE_KEY)
@@ -310,6 +375,7 @@ function scheduleStatusRefresh(refreshOrder: (() => Promise<PaymentOrder | null>
     if (refreshedOrder) {
       setResolvedOrder(refreshedOrder)
       clearRecoverySnapshotForTerminalStatus(refreshedOrder.status)
+      schedulePopupAutoClose()
     }
 
     if (isPendingStatus(order.value?.status)) {
@@ -319,6 +385,10 @@ function scheduleStatusRefresh(refreshOrder: (() => Promise<PaymentOrder | null>
 }
 
 onMounted(async () => {
+  if (typeof window !== 'undefined') {
+    isInPopup.value = readRouteQueryString('popup') === '1' || !!window.opener
+  }
+
   const resumeToken = readRouteQueryString('resume_token')
   const routeOrderId = Number(readRouteQueryString('order_id')) || 0
   let outTradeNo = readRouteQueryString('out_trade_no')
@@ -414,6 +484,7 @@ onMounted(async () => {
     scheduleStatusRefresh(refreshOrder)
   } else if (order.value) {
     clearRecoverySnapshotForTerminalStatus(order.value.status)
+    schedulePopupAutoClose()
   } else if (returnInfo.value) {
     clearRecoverySnapshot()
   }
@@ -422,5 +493,6 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   clearStatusRefreshTimer()
+  clearAutoCloseTimer()
 })
 </script>

--- a/frontend/src/views/user/PaymentView.vue
+++ b/frontend/src/views/user/PaymentView.vue
@@ -1,6 +1,6 @@
 <template>
   <AppLayout>
-    <div class="mx-auto max-w-4xl space-y-6">
+    <div class="mx-auto max-w-6xl space-y-6">
       <div v-if="loading" class="flex items-center justify-center py-20">
         <div class="h-8 w-8 animate-spin rounded-full border-4 border-primary-500 border-t-transparent"></div>
       </div>
@@ -32,10 +32,58 @@
           <!-- Top-up Tab -->
           <template v-if="activeTab === 'recharge'">
             <!-- Recharge Account Card -->
-            <div class="card p-5">
-              <p class="text-xs font-medium text-gray-400 dark:text-gray-500">{{ t('payment.rechargeAccount') }}</p>
-              <p class="mt-1 text-base font-semibold text-gray-900 dark:text-white">{{ user?.username || '' }}</p>
-              <p class="mt-0.5 text-sm font-medium text-green-600 dark:text-green-400">{{ t('payment.currentBalance') }}: {{ user?.balance?.toFixed(2) || '0.00' }}</p>
+            <div class="card p-4">
+              <div class="grid gap-3 lg:grid-cols-[minmax(0,0.78fr)_minmax(0,2.22fr)] lg:items-center">
+                <div>
+                  <p class="text-xs font-medium text-gray-400 dark:text-gray-500">{{ t('payment.rechargeAccount') }}</p>
+                  <p class="mt-1 text-base font-semibold text-gray-900 dark:text-white">{{ user?.username || '' }}</p>
+                  <p class="mt-0.5 text-sm font-medium text-green-600 dark:text-green-400">{{ t('payment.currentBalance') }}: {{ user?.balance?.toFixed(2) || '0.00' }}</p>
+                </div>
+                <div v-if="balanceTierCards.length > 0" class="rounded-2xl border border-gray-100 bg-gradient-to-r from-primary-50 via-green-50 to-emerald-50 p-2.5 dark:border-dark-700 dark:from-primary-900/20 dark:via-green-900/20 dark:to-emerald-900/20">
+                  <div class="mb-1.5 flex flex-wrap items-center justify-between gap-2">
+                    <div>
+                      <p class="text-sm font-semibold leading-tight text-gray-900 dark:text-white">{{ t('payment.balanceTierCardTitle') }}</p>
+                      <p class="text-xs leading-tight text-gray-500 dark:text-gray-400">{{ t('payment.balanceTierCardSubtitle') }}</p>
+                    </div>
+                    <span class="rounded-full bg-white px-2.5 py-0.5 text-xs font-medium text-primary-600 shadow-sm dark:bg-dark-800 dark:text-primary-300">
+                      {{ t('payment.rechargeRatePreview', { usd: balanceRechargeMultiplier.toFixed(2) }) }}
+                    </span>
+                  </div>
+                  <div class="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+                    <div
+                      v-for="(tier, index) in balanceTierCards"
+                      :key="`${tier.sortOrder ?? index}-${tier.min}-${tier.max}-${tier.multiplier}`"
+                      class="rounded-xl border bg-white/80 px-2.5 py-2 transition-all dark:bg-dark-800/70"
+                      :class="isCurrentTier(tier)
+                        ? 'border-primary-400 shadow-sm dark:border-primary-500'
+                        : 'border-gray-100 dark:border-dark-700'"
+                    >
+                      <div class="flex items-center gap-2">
+                        <div class="min-w-0 flex-1">
+                          <div class="flex items-center gap-1.5">
+                            <p class="truncate text-xs font-semibold leading-tight text-gray-900 dark:text-white">{{ tier.label || t('payment.defaultTier') }}</p>
+                            <span
+                              v-if="isCurrentTier(tier)"
+                              class="shrink-0 rounded-full bg-primary-600 px-1.5 py-0.5 text-[9px] font-semibold leading-none text-white"
+                            >
+                              {{ t('payment.balanceTierCurrent') }}
+                            </span>
+                          </div>
+                          <p class="mt-0.5 truncate text-[11px] leading-tight text-gray-500 dark:text-gray-400">{{ formatBalanceTierRange(tier) }}</p>
+                        </div>
+                        <div class="shrink-0">
+                          <p class="text-[10px] leading-tight text-gray-400 dark:text-gray-500">{{ t('payment.rechargeMultiplier') }}</p>
+                          <p class="text-lg font-bold leading-none text-primary-600 dark:text-primary-300">{{ tier.multiplier.toFixed(2) }}</p>
+                        </div>
+                        <div v-if="validAmount > 0" class="shrink-0 text-right">
+                          <p class="text-[10px] leading-tight text-gray-400 dark:text-gray-500">{{ t('payment.balanceTierCreditPreview') }}</p>
+                          <p class="text-xs font-semibold leading-tight text-green-600 dark:text-green-300">${{ calculateCreditedAmount(tier.multiplier).toFixed(2) }}</p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
             <div v-if="enabledMethods.length === 0" class="card py-16 text-center">
               <p class="text-gray-500 dark:text-gray-400">{{ t('payment.notAvailable') }}</p>
@@ -49,13 +97,25 @@
                 :max="globalMaxAmount"
               />
               <p v-if="amountError" class="mt-2 text-xs text-amber-600 dark:text-amber-300">{{ amountError }}</p>
-            </div>
-            <div v-if="enabledMethods.length >= 1" class="card p-6">
-              <PaymentMethodSelector
-                :methods="methodOptions"
-                :selected="selectedMethod"
-                @select="selectedMethod = $event"
-              />
+              <div class="mt-5 rounded-xl border border-gray-100 bg-gray-50 p-4 dark:border-dark-700 dark:bg-dark-800/60">
+                <div class="flex flex-wrap items-center justify-between gap-2">
+                  <p class="text-sm font-semibold text-gray-900 dark:text-white">充值规则</p>
+                  <span
+                    class="rounded-full px-2.5 py-1 text-xs font-semibold"
+                    :class="balanceRechargeAsPackage ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-200' : 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-200'"
+                  >
+                    {{ balanceRechargeAsPackage ? '限时余额包' : '普通余额' }}
+                  </span>
+                </div>
+                <p class="mt-2 text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+                  <template v-if="balanceRechargeAsPackage">
+                    本次充值会按管理员后台配置发放为限时余额包，有效期 {{ balancePackageValidityText }}。到期后剩余额度自动失效，多个余额包优先扣最早到期的。
+                  </template>
+                  <template v-else>
+                    本次充值会按管理员后台配置发放为普通余额，长期有效。
+                  </template>
+                </p>
+              </div>
             </div>
             <div v-if="validAmount > 0" class="card p-6">
               <div class="space-y-2 text-sm">
@@ -71,22 +131,48 @@
                   <span class="font-medium text-gray-700 dark:text-gray-300">{{ t('payment.actualPay') }}</span>
                   <span class="text-lg font-bold text-primary-600 dark:text-primary-400">{{ formatSelectedPaymentAmount(totalAmount) }}</span>
                 </div>
-                <div v-if="balanceRechargeMultiplier !== 1" class="flex justify-between" :class="{ 'border-t border-gray-200 pt-2 dark:border-dark-600': feeRate <= 0 }">
-                  <span class="text-gray-500 dark:text-gray-400">{{ t('payment.creditedBalance') }}</span>
-                  <span class="text-gray-900 dark:text-white">${{ creditedAmount.toFixed(2) }}</span>
+                <div class="flex justify-between">
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('payment.matchedTier') }}</span>
+                  <span class="text-gray-900 dark:text-white">{{ currentBalanceTier?.label || t('payment.defaultTier') }}</span>
                 </div>
-                <p v-if="balanceRechargeMultiplier !== 1" class="border-t border-gray-200 pt-2 text-xs text-gray-500 dark:border-dark-600 dark:text-gray-400">
+                <div class="flex justify-between">
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('payment.rechargeMultiplier') }}</span>
+                  <span class="text-gray-900 dark:text-white">{{ balanceRechargeMultiplier.toFixed(2) }}</span>
+                </div>
+                <div class="flex justify-between border-t border-gray-200 pt-2 dark:border-dark-600">
+                  <span class="text-gray-500 dark:text-gray-400">{{ t('payment.creditedBalance') }}</span>
+                  <span class="font-semibold text-green-600 dark:text-green-400">${{ creditedAmount.toFixed(2) }}</span>
+                </div>
+                <p v-if="nextBalanceTier" class="border-t border-gray-200 pt-2 text-xs text-orange-600 dark:border-dark-600 dark:text-orange-300">
+                  {{ t('payment.nextTierHint', { amount: formatSelectedPaymentAmount(nextTierUnlockAmount), tier: nextBalanceTier.label || t('payment.nextTier') }) }}
+                </p>
+                <p class="text-xs text-gray-500 dark:text-gray-400">
                   {{ t('payment.rechargeRatePreview', { usd: balanceRechargeMultiplier.toFixed(2) }) }}
                 </p>
               </div>
             </div>
-            <button :class="['btn w-full py-3 text-base font-medium', paymentButtonClass]" :disabled="!canSubmit || submitting" @click="handleSubmitRecharge">
-              <span v-if="submitting" class="flex items-center justify-center gap-2">
-                <span class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></span>
-                {{ t('common.processing') }}
-              </span>
-              <span v-else>{{ t('payment.createOrder') }} {{ formatSelectedPaymentAmount(totalAmount) }}</span>
-            </button>
+            <div v-if="enabledMethods.length >= 1" class="card p-6">
+              <PaymentMethodSelector
+                :methods="methodOptions"
+                :selected="selectedMethod"
+                @select="selectedMethod = $event"
+              />
+            </div>
+            <div class="sticky bottom-3 z-30 rounded-2xl border border-gray-200 bg-white/90 p-3 shadow-2xl shadow-gray-200/60 backdrop-blur dark:border-dark-700 dark:bg-dark-900/90 dark:shadow-black/30">
+              <div class="flex items-center justify-between gap-4">
+                <div class="min-w-0">
+                  <p class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ t('payment.creditedBalance') }}</p>
+                  <p class="text-lg font-bold text-green-600 dark:text-green-300">${{ creditedAmount.toFixed(2) }}</p>
+                </div>
+                <button :class="['btn w-3/4 py-3 text-base font-medium', paymentButtonClass]" :disabled="!canSubmit || submitting" @click="handleSubmitRecharge">
+                  <span v-if="submitting" class="flex items-center justify-center gap-2">
+                    <span class="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent"></span>
+                    {{ t('common.processing') }}
+                  </span>
+                  <span v-else>{{ t('payment.createOrder') }} {{ formatSelectedPaymentAmount(totalAmount) }}</span>
+                </button>
+              </div>
+            </div>
             </template>
           </template>
           <!-- Subscribe Tab -->
@@ -255,7 +341,7 @@ import { useAppStore } from '@/stores'
 import { paymentAPI } from '@/api/payment'
 import { extractApiErrorMessage, extractI18nErrorMessage } from '@/utils/apiError'
 import { isMobileDevice } from '@/utils/device'
-import type { SubscriptionPlan, CheckoutInfoResponse, CreateOrderResult, OrderType } from '@/types/payment'
+import type { SubscriptionPlan, CheckoutInfoResponse, CreateOrderResult, OrderType, BalancePricingTier } from '@/types/payment'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import AmountInput from '@/components/payment/AmountInput.vue'
 import PaymentMethodSelector from '@/components/payment/PaymentMethodSelector.vue'
@@ -478,7 +564,9 @@ function onPaymentSettled() {
 // All checkout data from single API call
 const checkout = ref<CheckoutInfoResponse>({
   methods: {}, global_min: 0, global_max: 0,
-  plans: [], balance_disabled: false, balance_recharge_multiplier: 1, recharge_fee_rate: 0, help_text: '', help_image_url: '', stripe_publishable_key: '',
+  plans: [], balance_disabled: false, balance_recharge_multiplier: 1, balance_pricing_tiers: [],
+  balance_recharge_as_package: false, balance_package_validity_days: 1,
+  recharge_fee_rate: 0, help_text: '', help_image_url: '', stripe_publishable_key: '',
 })
 
 const tabs = computed(() => {
@@ -491,11 +579,52 @@ const tabs = computed(() => {
 const visibleMethods = computed(() => getVisibleMethods(checkout.value.methods))
 const enabledMethods = computed(() => Object.keys(visibleMethods.value))
 const validAmount = computed(() => amount.value ?? 0)
+const enabledBalanceTiers = computed<BalancePricingTier[]>(() =>
+  (checkout.value.balance_pricing_tiers || [])
+    .filter(tier => tier.enabled !== false)
+    .sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.min - b.min)
+)
+const currentBalanceTier = computed(() =>
+  enabledBalanceTiers.value.find(tier => validAmount.value >= tier.min && validAmount.value <= tier.max)
+)
+const nextBalanceTier = computed(() =>
+  enabledBalanceTiers.value.find(tier => validAmount.value > 0 && validAmount.value < tier.min)
+)
+const nextTierUnlockAmount = computed(() => {
+  if (!nextBalanceTier.value) return 0
+  return Math.max(0, Math.round((nextBalanceTier.value.min - validAmount.value) * 100) / 100)
+})
 const balanceRechargeMultiplier = computed(() => {
-  const multiplier = checkout.value.balance_recharge_multiplier
+  const multiplier = currentBalanceTier.value?.multiplier || checkout.value.balance_recharge_multiplier
   return multiplier > 0 ? multiplier : 1
 })
-const creditedAmount = computed(() => Math.round((validAmount.value * balanceRechargeMultiplier.value) * 100) / 100)
+const balanceRechargeAsPackage = computed(() => checkout.value.balance_recharge_as_package === true)
+const balancePackageValidityDays = computed(() => {
+  const days = Number(checkout.value.balance_package_validity_days || 0)
+  return Number.isFinite(days) && days > 0 ? days : 1
+})
+const balancePackageValidityText = computed(() => {
+  const days = balancePackageValidityDays.value
+  if (days < 1) return `${Math.round(days * 24 * 100) / 100} 小时`
+  return `${days} 天`
+})
+const creditedAmount = computed(() => Math.round((validAmount.value / balanceRechargeMultiplier.value) * 100) / 100)
+const balanceTierCards = computed(() => enabledBalanceTiers.value)
+
+function calculateCreditedAmount(multiplier: number): number {
+  const safeMultiplier = multiplier > 0 ? multiplier : 1
+  return Math.round((validAmount.value / safeMultiplier) * 100) / 100
+}
+
+function isCurrentTier(tier: BalancePricingTier): boolean {
+  return validAmount.value > 0 && currentBalanceTier.value === tier
+}
+
+function formatBalanceTierRange(tier: BalancePricingTier): string {
+  if (tier.min <= 0 && tier.max > 0) return `≤ ${formatSelectedPaymentAmount(tier.max)}`
+  if (tier.max <= 0 || !Number.isFinite(tier.max)) return `≥ ${formatSelectedPaymentAmount(tier.min)}`
+  return `${formatSelectedPaymentAmount(tier.min)} - ${formatSelectedPaymentAmount(tier.max)}`
+}
 
 // Adaptive grid: center single card, 2-col for 2 plans, 3-col for 3+
 const planGridClass = computed(() => {

--- a/frontend/src/views/user/RedeemView.vue
+++ b/frontend/src/views/user/RedeemView.vue
@@ -11,11 +11,59 @@
           </div>
           <p class="text-sm font-medium text-primary-100">{{ t('redeem.currentBalance') }}</p>
           <p class="mt-2 text-4xl font-bold text-white">
-            ${{ user?.balance?.toFixed(2) || '0.00' }}
+            ${{ totalAvailableBalance.toFixed(2) }}
           </p>
+          <div class="mt-4 grid grid-cols-2 gap-3 text-left">
+            <div class="rounded-xl bg-white/15 px-3 py-2 backdrop-blur-sm">
+              <p class="text-xs text-primary-100">普通余额</p>
+              <p class="mt-1 text-lg font-semibold text-white">${{ baseBalance.toFixed(2) }}</p>
+            </div>
+            <div class="rounded-xl bg-white/15 px-3 py-2 backdrop-blur-sm">
+              <p class="text-xs text-primary-100">限时余额包</p>
+              <p class="mt-1 text-lg font-semibold text-white">
+                ${{ limitedBalance.toFixed(2) }}
+              </p>
+            </div>
+          </div>
           <p class="mt-2 text-sm text-primary-100">
             {{ t('redeem.concurrency') }}: {{ user?.concurrency || 0 }} {{ t('redeem.requests') }}
           </p>
+        </div>
+        <div v-if="balancePackages.length > 0" class="space-y-3 border-t border-gray-100 p-4 dark:border-dark-700">
+          <div class="flex items-center justify-between">
+            <p class="text-sm font-semibold text-gray-900 dark:text-white">限时余额包明细</p>
+            <p class="text-xs text-gray-500 dark:text-dark-400">
+              优先扣最早到期的余额包
+            </p>
+          </div>
+          <div
+            v-for="pkg in balancePackages"
+            :key="pkg.id"
+            class="rounded-xl border border-gray-100 bg-gray-50 p-3 dark:border-dark-700 dark:bg-dark-800/60"
+          >
+            <div class="mb-2 flex items-center justify-between gap-3">
+              <div>
+                <p class="text-sm font-semibold text-gray-900 dark:text-white">
+                  剩余 ${{ pkg.remaining_amount.toFixed(2) }} / ${{ pkg.amount.toFixed(2) }}
+                </p>
+                <p class="mt-0.5 text-xs text-gray-500 dark:text-dark-400">
+                  到期：{{ formatDateTime(pkg.expires_at) }}
+                </p>
+              </div>
+              <span class="rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300">
+                已用 {{ Math.min(100, Math.max(0, pkg.used_percent)).toFixed(0) }}%
+              </span>
+            </div>
+            <div class="h-2 overflow-hidden rounded-full bg-gray-200 dark:bg-dark-700">
+              <div
+                class="h-full rounded-full bg-gradient-to-r from-emerald-400 to-emerald-600"
+                :style="{ width: `${Math.min(100, Math.max(0, pkg.used_percent))}%` }"
+              ></div>
+            </div>
+            <p v-if="pkg.redeem_code" class="mt-2 font-mono text-xs text-gray-400 dark:text-dark-500">
+              来源兑换码：{{ pkg.redeem_code.slice(0, 8) }}...
+            </p>
+          </div>
         </div>
       </div>
 
@@ -347,7 +395,8 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore } from '@/stores/auth'
 import { useAppStore } from '@/stores/app'
 import { useSubscriptionStore } from '@/stores/subscriptions'
-import { redeemAPI, authAPI, type RedeemHistoryItem } from '@/api'
+import { redeemAPI, authAPI, userAPI, type RedeemHistoryItem } from '@/api'
+import type { UserBalancePackage } from '@/api/user'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { formatDateTime } from '@/utils/format'
@@ -358,6 +407,10 @@ const appStore = useAppStore()
 const subscriptionStore = useSubscriptionStore()
 
 const user = computed(() => authStore.user)
+const balancePackages = ref<UserBalancePackage[]>([])
+const limitedBalance = ref(0)
+const baseBalance = computed(() => user.value?.balance || 0)
+const totalAvailableBalance = computed(() => baseBalance.value + limitedBalance.value)
 
 const redeemCode = ref('')
 const submitting = ref(false)
@@ -431,6 +484,18 @@ const fetchHistory = async () => {
   }
 }
 
+const fetchBalancePackages = async () => {
+  try {
+    const data = await userAPI.getBalancePackages()
+    limitedBalance.value = data.total_limited_balance || 0
+    balancePackages.value = data.packages || []
+  } catch (error) {
+    console.error('Failed to fetch balance packages:', error)
+    limitedBalance.value = 0
+    balancePackages.value = []
+  }
+}
+
 const handleRedeem = async () => {
   if (!redeemCode.value.trim()) {
     appStore.showError(t('redeem.pleaseEnterCode'))
@@ -448,6 +513,7 @@ const handleRedeem = async () => {
 
     // Refresh user data to get updated balance/concurrency
     await authStore.refreshUser()
+    await fetchBalancePackages()
 
     // If subscription type, immediately refresh subscription status
     if (result.type === 'subscription') {
@@ -478,6 +544,7 @@ const handleRedeem = async () => {
 
 onMounted(async () => {
   fetchHistory()
+  fetchBalancePackages()
   try {
     const settings = await authAPI.getPublicSettings()
     contactInfo.value = settings.contact_info || ''


### PR DESCRIPTION
## Summary
- Add balance-package support so wallet balance can be granted with an expiry and deducted before permanent wallet balance.
- Allow redeem-code validity to be represented with sub-day precision and apply it to subscription/balance package redemption flows.
- Extend payment catalog/order handling, XunhuPay provider support, tiered balance pricing, and related admin/user payment UI.

## Tests
- `go test ./internal/service ./internal/payment ./internal/handler ./internal/handler/admin ./internal/server/routes -run 'Payment|Redeem|BalancePackage|Subscription|Xunhu|Plan|Fulfillment|Order'`

## Notes
- Frontend build was not run in the isolated worktree because `frontend/node_modules` is not installed there.