### PR TITLE
feat(scheduler): improve account routing and visibility

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
@@ -171,12 +172,51 @@ type AccountWithConcurrency struct {
 	*dto.Account
 	CurrentConcurrency int `json:"current_concurrency"`
 	// 以下字段仅对 Anthropic OAuth/SetupToken 账号有效，且仅在启用相应功能时返回
-	CurrentWindowCost *float64 `json:"current_window_cost,omitempty"` // 当前窗口费用
-	ActiveSessions    *int     `json:"active_sessions,omitempty"`     // 当前活跃会话数
-	CurrentRPM        *int     `json:"current_rpm,omitempty"`         // 当前分钟 RPM 计数
+	CurrentWindowCost *float64                         `json:"current_window_cost,omitempty"` // 当前窗口费用
+	ActiveSessions    *int                             `json:"active_sessions,omitempty"`     // 当前活跃会话数
+	CurrentRPM        *int                             `json:"current_rpm,omitempty"`         // 当前分钟 RPM 计数
+	AvgFirstTokenMs   *float64                         `json:"avg_first_token_ms,omitempty"`
+	HealthBuckets     []usagestats.AccountHealthBucket `json:"health_buckets,omitempty"`
 }
 
 const accountListGroupUngroupedQueryValue = "ungrouped"
+
+func parseAccountTTFTWindow(raw string) time.Duration {
+	value := strings.TrimSpace(raw)
+	switch value {
+	case "", "1h":
+		return time.Hour
+	case "5m":
+		return 5 * time.Minute
+	case "30m":
+		return 30 * time.Minute
+	case "6h":
+		return 6 * time.Hour
+	case "24h":
+		return 24 * time.Hour
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return time.Hour
+	}
+	if duration > 30*24*time.Hour {
+		return 30 * 24 * time.Hour
+	}
+	return duration
+}
+
+func accountHealthBucketCount(window time.Duration) int {
+	switch {
+	case window <= 5*time.Minute:
+		return 30
+	case window <= time.Hour:
+		return 60
+	case window <= 6*time.Hour:
+		return 72
+	default:
+		return 96
+	}
+}
 
 func (h *AccountHandler) buildAccountResponseWithRuntime(ctx context.Context, account *service.Account) AccountWithConcurrency {
 	item := AccountWithConcurrency{
@@ -233,6 +273,9 @@ func (h *AccountHandler) List(c *gin.Context) {
 	privacyMode := strings.TrimSpace(c.Query("privacy_mode"))
 	sortBy := c.DefaultQuery("sort_by", "name")
 	sortOrder := c.DefaultQuery("sort_order", "asc")
+	if strings.EqualFold(strings.TrimSpace(sortBy), "avg_first_token") {
+		sortBy = "avg_first_token:" + parseAccountTTFTWindow(c.Query("ttft_window")).String()
+	}
 	// 标准化和验证 search 参数
 	search = strings.TrimSpace(search)
 	if len(search) > 100 {
@@ -262,6 +305,35 @@ func (h *AccountHandler) List(c *gin.Context) {
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
+	}
+
+	avgFirstTokenByAccount := map[int64]*float64{}
+	healthBucketsByAccount := map[int64][]usagestats.AccountHealthBucket{}
+	apiKeyAccountIDs := make([]int64, 0)
+	for i := range accounts {
+		acc := &accounts[i]
+		if acc.Type == service.AccountTypeAPIKey {
+			apiKeyAccountIDs = append(apiKeyAccountIDs, acc.ID)
+		}
+	}
+	if h.accountUsageService != nil {
+		ttftWindow := parseAccountTTFTWindow(c.Query("ttft_window"))
+		now := time.Now().UTC()
+		startTime := now.Add(-ttftWindow)
+		if len(apiKeyAccountIDs) > 0 {
+			if averages, err := h.accountUsageService.GetAverageFirstTokenBatch(c.Request.Context(), apiKeyAccountIDs, startTime); err == nil && averages != nil {
+				avgFirstTokenByAccount = averages
+			}
+		}
+		if len(accounts) > 0 {
+			allAccountIDs := make([]int64, 0, len(accounts))
+			for i := range accounts {
+				allAccountIDs = append(allAccountIDs, accounts[i].ID)
+			}
+			if buckets, err := h.accountUsageService.GetHealthBucketsBatch(c.Request.Context(), allAccountIDs, startTime, now, accountHealthBucketCount(ttftWindow)); err == nil && buckets != nil {
+				healthBucketsByAccount = buckets
+			}
+		}
 	}
 
 	// Get current concurrency counts for all accounts
@@ -376,6 +448,10 @@ func (h *AccountHandler) List(c *gin.Context) {
 				item.CurrentRPM = &rpm
 			}
 		}
+		if acc.Type == service.AccountTypeAPIKey {
+			item.AvgFirstTokenMs = avgFirstTokenByAccount[acc.ID]
+		}
+		item.HealthBuckets = healthBucketsByAccount[acc.ID]
 
 		result[i] = item
 	}

--- a/backend/internal/pkg/ctxkey/ctxkey.go
+++ b/backend/internal/pkg/ctxkey/ctxkey.go
@@ -29,6 +29,9 @@ const (
 	// AccountSwitchCount 表示请求过程中发生的账号切换次数
 	AccountSwitchCount Key = "ctx_account_switch_count"
 
+	// EstimatedInputTokens 表示当前请求估算出的输入 token 数
+	EstimatedInputTokens Key = "ctx_estimated_input_tokens"
+
 	// IsClaudeCodeClient 标识当前请求是否来自 Claude Code 客户端
 	IsClaudeCodeClient Key = "ctx_is_claude_code_client"
 

--- a/backend/internal/pkg/usagestats/account_stats.go
+++ b/backend/internal/pkg/usagestats/account_stats.go
@@ -11,4 +11,13 @@ type AccountStats struct {
 	Cost         float64 `json:"cost"`
 	StandardCost float64 `json:"standard_cost"`
 	UserCost     float64 `json:"user_cost"`
+	SuccessCount int64   `json:"success_count"`
+	ErrorCount   int64   `json:"error_count"`
+}
+
+// AccountHealthBucket is a compact per-account request health sample for a time bucket.
+type AccountHealthBucket struct {
+	BucketStart  string `json:"bucket_start"`
+	SuccessCount int64  `json:"success_count"`
+	ErrorCount   int64  `json:"error_count"`
 }

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -15,6 +15,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -585,6 +586,15 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selector) {
 	sortBy := strings.ToLower(strings.TrimSpace(params.SortBy))
 	sortOrder := params.NormalizedSortOrder(pagination.SortOrderAsc)
+	if strings.HasPrefix(sortBy, "avg_first_token") {
+		window := time.Hour
+		if parts := strings.SplitN(sortBy, ":", 2); len(parts) == 2 {
+			if d, err := time.ParseDuration(parts[1]); err == nil && d > 0 {
+				window = d
+			}
+		}
+		return accountAvgFirstTokenOrder(sortOrder, window)
+	}
 
 	field := dbaccount.FieldName
 	defaultOrder := true
@@ -624,6 +634,26 @@ func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selecto
 		return []func(*entsql.Selector){dbent.Asc(dbaccount.FieldName), dbent.Asc(dbaccount.FieldID)}
 	}
 	return []func(*entsql.Selector){dbent.Asc(field), dbent.Asc(dbaccount.FieldID)}
+}
+
+func accountAvgFirstTokenOrder(sortOrder string, window time.Duration) []func(*entsql.Selector) {
+	orderExpr := func(direction, nulls string, tieOrder func(string) string) func(*entsql.Selector) {
+		return func(s *entsql.Selector) {
+			since := time.Now().Add(-window).UTC().Format(time.RFC3339Nano)
+			subquery := fmt.Sprintf(
+				"(SELECT AVG(first_token_ms) FROM usage_logs WHERE account_id = %s AND created_at >= TIMESTAMPTZ '%s' AND first_token_ms IS NOT NULL)",
+				s.C(dbaccount.FieldID),
+				since,
+			)
+			s.OrderExpr(entsql.Expr(subquery + " " + direction + " NULLS " + nulls))
+			s.OrderBy(tieOrder(s.C(dbaccount.FieldID)))
+		}
+	}
+
+	if sortOrder == pagination.SortOrderDesc {
+		return []func(*entsql.Selector){orderExpr("DESC", "LAST", entsql.Desc)}
+	}
+	return []func(*entsql.Selector){orderExpr("ASC", "LAST", entsql.Asc)}
 }
 
 func (r *accountRepository) ListByGroup(ctx context.Context, groupID int64) ([]service.Account, error) {
@@ -1508,11 +1538,36 @@ type accountGroupQueryOptions struct {
 }
 
 func (r *accountRepository) queryAccountsByGroup(ctx context.Context, groupID int64, opts accountGroupQueryOptions) ([]service.Account, error) {
-	q := r.client.AccountGroup.Query().
-		Where(dbaccountgroup.GroupIDEQ(groupID))
+	groupRows, err := r.client.AccountGroup.Query().
+		Where(dbaccountgroup.GroupIDEQ(groupID)).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(groupRows) == 0 {
+		return []service.Account{}, nil
+	}
 
-	// 通过 account_groups 中间表查询账号，并按需叠加状态/平台/调度能力过滤。
-	preds := make([]dbpredicate.Account, 0, 6)
+	accountIDs := make([]int64, 0, len(groupRows))
+	seen := make(map[int64]struct{}, len(groupRows))
+	for _, row := range groupRows {
+		if row.AccountID <= 0 {
+			continue
+		}
+		if _, ok := seen[row.AccountID]; ok {
+			continue
+		}
+		seen[row.AccountID] = struct{}{}
+		accountIDs = append(accountIDs, row.AccountID)
+	}
+	if len(accountIDs) == 0 {
+		return []service.Account{}, nil
+	}
+
+	// Resolve group bindings first, then query accounts directly to avoid
+	// ambiguous joined "id" columns and keep scheduling on account priority.
+	preds := make([]dbpredicate.Account, 0, 7)
+	preds = append(preds, dbaccount.IDIn(accountIDs...))
 	preds = append(preds, dbaccount.DeletedAtIsNil())
 	if opts.status != "" {
 		preds = append(preds, dbaccount.StatusEQ(opts.status))
@@ -1531,39 +1586,12 @@ func (r *accountRepository) queryAccountsByGroup(ctx context.Context, groupID in
 		)
 	}
 
-	if len(preds) > 0 {
-		q = q.Where(dbaccountgroup.HasAccountWith(preds...))
-	}
-
-	groups, err := q.
-		Order(
-			dbaccountgroup.ByPriority(),
-			dbaccountgroup.ByAccountField(dbaccount.FieldPriority),
-		).
-		WithAccount().
+	accounts, err := r.client.Account.Query().
+		Where(preds...).
+		Order(dbent.Asc(dbaccount.FieldPriority), dbent.Asc(dbaccount.FieldID)).
 		All(ctx)
 	if err != nil {
 		return nil, err
-	}
-
-	orderedIDs := make([]int64, 0, len(groups))
-	accountMap := make(map[int64]*dbent.Account, len(groups))
-	for _, ag := range groups {
-		if ag.Edges.Account == nil {
-			continue
-		}
-		if _, exists := accountMap[ag.AccountID]; exists {
-			continue
-		}
-		accountMap[ag.AccountID] = ag.Edges.Account
-		orderedIDs = append(orderedIDs, ag.AccountID)
-	}
-
-	accounts := make([]*dbent.Account, 0, len(orderedIDs))
-	for _, id := range orderedIDs {
-		if acc, ok := accountMap[id]; ok {
-			accounts = append(accounts, acc)
-		}
 	}
 
 	return r.accountsToService(ctx, accounts)

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -629,6 +629,18 @@ func (s *AccountRepoSuite) TestListSchedulableByGroupIDAndPlatform() {
 	s.Require().Equal(a1.ID, accounts[0].ID)
 }
 
+func (s *AccountRepoSuite) TestListSchedulableByGroupIDAndPlatform_OrdersByAccountPriority() {
+	group := mustCreateGroup(s.T(), s.client, &service.Group{Name: "g-sp-account-priority"})
+	lowAccountPriority := mustCreateAccount(s.T(), s.client, &service.Account{Name: "low-account-priority", Platform: service.PlatformAnthropic, Priority: 2, Schedulable: true})
+	highAccountPriority := mustCreateAccount(s.T(), s.client, &service.Account{Name: "high-account-priority", Platform: service.PlatformAnthropic, Priority: 1, Schedulable: true})
+	mustBindAccountToGroup(s.T(), s.client, lowAccountPriority.ID, group.ID, 1)
+	mustBindAccountToGroup(s.T(), s.client, highAccountPriority.ID, group.ID, 50)
+
+	accounts, err := s.repo.ListSchedulableByGroupIDAndPlatform(s.ctx, group.ID, service.PlatformAnthropic)
+	s.Require().NoError(err)
+	s.Require().Equal([]int64{highAccountPriority.ID, lowAccountPriority.ID}, idsOfAccounts(accounts))
+}
+
 func (s *AccountRepoSuite) TestSetSchedulable() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-sched", Schedulable: true})
 	cacheRecorder := &schedulerCacheRecorder{}

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -548,6 +548,7 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"openai_ws_force_http",
 		"openai_responses_mode",
 		"openai_responses_supported",
+		"context_length_filter",
 		"codex_5h_used_percent",
 		"codex_7d_used_percent",
 		"codex_5h_reset_at",

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -48,7 +48,13 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 			"window_cost_sticky_reserve":   8.0,
 			"max_sessions":                 4,
 			"session_idle_timeout_minutes": 11,
-			"unused_large_field":           strings.Repeat("y", 4096),
+			"context_length_filter": map[string]any{
+				"enabled":       true,
+				"mode":          "gt",
+				"threshold":     1000,
+				"allow_percent": 50,
+			},
+			"unused_large_field": strings.Repeat("y", 4096),
 		},
 		RateLimitResetAt:       &limitReset,
 		OverloadUntil:          &overloadUntil,
@@ -87,6 +93,12 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 	require.Equal(t, 8.0, got.GetWindowCostStickyReserve())
 	require.Equal(t, 4, got.GetMaxSessions())
 	require.Equal(t, 11, got.GetSessionIdleTimeoutMinutes())
+	require.Equal(t, map[string]any{
+		"enabled":       true,
+		"mode":          "gt",
+		"threshold":     float64(1000),
+		"allow_percent": float64(50),
+	}, got.Extra["context_length_filter"])
 	require.Nil(t, got.Extra["unused_large_field"])
 	require.Equal(t, []int64{bucket.GroupID}, got.GroupIDs)
 	require.Len(t, got.AccountGroups, 1)

--- a/backend/internal/repository/scheduler_cache_test.go
+++ b/backend/internal/repository/scheduler_cache_test.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSchedulerExtraKeepsContextLengthFilter(t *testing.T) {
+	filtered := filterSchedulerExtra(map[string]any{
+		"context_length_filter": map[string]any{
+			"enabled":       true,
+			"mode":          "gt",
+			"threshold":     5000,
+			"allow_percent": 50,
+		},
+		"unused_large_field": "drop-me",
+	})
+
+	require.Equal(t, map[string]any{
+		"enabled":       true,
+		"mode":          "gt",
+		"threshold":     5000,
+		"allow_percent": 50,
+	}, filtered["context_length_filter"])
+	require.NotContains(t, filtered, "unused_large_field")
+}

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -2,6 +2,7 @@
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"hash/fnv"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 )
 
 type Account struct {
@@ -82,8 +84,168 @@ type TempUnschedulableRule struct {
 	Description     string   `json:"description"`
 }
 
+type ContextLengthFilterConfig struct {
+	Enabled        bool
+	Mode           string
+	Threshold      int
+	MinInputTokens int
+	MaxInputTokens int
+	AllowPercent   int
+}
+
+func nestedExtraBool(m map[string]any, key string) bool {
+	if m == nil {
+		return false
+	}
+	if v, ok := m[key]; ok {
+		if b, ok := v.(bool); ok {
+			return b
+		}
+	}
+	return false
+}
+
+func nestedExtraInt(m map[string]any, key string) int {
+	if m == nil {
+		return 0
+	}
+	if v, ok := m[key]; ok {
+		return int(parseExtraFloat64(v))
+	}
+	return 0
+}
+
+func nestedExtraString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return strings.TrimSpace(v)
+	}
+	return ""
+}
+
 func (a *Account) IsActive() bool {
 	return a.Status == StatusActive
+}
+
+func (a *Account) ContextLengthFilterSettings() *ContextLengthFilterConfig {
+	if a == nil || a.Extra == nil {
+		return nil
+	}
+	raw, ok := a.Extra["context_length_filter"]
+	if !ok || raw == nil {
+		return nil
+	}
+	m, ok := raw.(map[string]any)
+	if !ok {
+		return nil
+	}
+	cfg := &ContextLengthFilterConfig{
+		Enabled:        nestedExtraBool(m, "enabled"),
+		Mode:           nestedExtraString(m, "mode"),
+		Threshold:      nestedExtraInt(m, "threshold"),
+		MinInputTokens: nestedExtraInt(m, "min_input_tokens"),
+		MaxInputTokens: nestedExtraInt(m, "max_input_tokens"),
+		AllowPercent:   nestedExtraInt(m, "allow_percent"),
+	}
+	if !cfg.Enabled {
+		return nil
+	}
+	if cfg.AllowPercent < 0 {
+		cfg.AllowPercent = 0
+	}
+	if cfg.AllowPercent > 100 {
+		cfg.AllowPercent = 100
+	}
+	if cfg.MinInputTokens < 0 {
+		cfg.MinInputTokens = 0
+	}
+	if cfg.MaxInputTokens < 0 {
+		cfg.MaxInputTokens = 0
+	}
+	if cfg.Threshold < 0 {
+		cfg.Threshold = 0
+	}
+	return cfg
+}
+
+func (a *Account) ContextLengthFilterAllows(ctx context.Context, estimatedInputTokens int, sessionHash string) bool {
+	cfg := a.ContextLengthFilterSettings()
+	if cfg == nil {
+		return true
+	}
+	if estimatedInputTokens <= 0 {
+		return true
+	}
+	trigger := false
+	switch cfg.Mode {
+	case "lt":
+		trigger = cfg.Threshold > 0 && estimatedInputTokens < cfg.Threshold
+	case "gt":
+		trigger = cfg.Threshold > 0 && estimatedInputTokens > cfg.Threshold
+	default:
+	}
+	if !trigger && cfg.Mode == "" {
+		if cfg.MaxInputTokens > 0 {
+			trigger = estimatedInputTokens > cfg.MaxInputTokens
+		} else if cfg.MinInputTokens > 0 {
+			trigger = estimatedInputTokens >= cfg.MinInputTokens
+		}
+	}
+	if !trigger {
+		return true
+	}
+	if cfg.AllowPercent <= 0 {
+		slog.Info("context_length_filter.decision", "account_id", a.ID, "estimated_input_tokens", estimatedInputTokens, "mode", cfg.Mode, "threshold", cfg.Threshold, "allow_percent", cfg.AllowPercent, "allowed", false)
+		return false
+	}
+	if cfg.AllowPercent >= 100 {
+		slog.Debug("context_length_filter.decision", "account_id", a.ID, "estimated_input_tokens", estimatedInputTokens, "mode", cfg.Mode, "threshold", cfg.Threshold, "allow_percent", cfg.AllowPercent, "allowed", true)
+		return true
+	}
+	seed := a.ID
+	if sessionHash != "" {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(sessionHash))
+		seed ^= int64(h.Sum32())
+	}
+	if ctx != nil {
+		if v, ok := ctx.Value(ctxkey.RequestID).(string); ok && v != "" {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(v))
+			seed ^= int64(h.Sum32())
+		}
+		if v, ok := ctx.Value(ctxkey.ClientRequestID).(string); ok && v != "" {
+			h := fnv.New32a()
+			_, _ = h.Write([]byte(v))
+			seed ^= int64(h.Sum32())
+		}
+	}
+	if seed < 0 {
+		seed = -seed
+	}
+	sample := int(seed % 100)
+	allowed := sample < cfg.AllowPercent
+	logContextLengthFilterDecision(a.ID, estimatedInputTokens, cfg, sample, allowed)
+	return allowed
+}
+
+func logContextLengthFilterDecision(accountID int64, estimatedInputTokens int, cfg *ContextLengthFilterConfig, sample int, allowed bool) {
+	args := []any{
+		"account_id", accountID,
+		"estimated_input_tokens", estimatedInputTokens,
+		"mode", cfg.Mode,
+		"threshold", cfg.Threshold,
+		"allow_percent", cfg.AllowPercent,
+		"sample", sample,
+		"allowed", allowed,
+	}
+	if allowed {
+		slog.Debug("context_length_filter.decision", args...)
+		return
+	}
+	slog.Info("context_length_filter.decision", args...)
 }
 
 // BillingRateMultiplier 返回账号计费倍率。

--- a/backend/internal/service/account_context_length_filter_test.go
+++ b/backend/internal/service/account_context_length_filter_test.go
@@ -1,0 +1,119 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccount_ContextLengthFilterSettings_FromExtra(t *testing.T) {
+	account := &Account{
+		Extra: map[string]any{
+			"context_length_filter": map[string]any{
+				"enabled":          true,
+				"mode":             "gt",
+				"threshold":        4096,
+				"min_input_tokens": 1200,
+				"max_input_tokens": 8000,
+				"allow_percent":    25,
+			},
+		},
+	}
+
+	cfg := account.ContextLengthFilterSettings()
+	require.NotNil(t, cfg)
+	require.True(t, cfg.Enabled)
+	require.Equal(t, "gt", cfg.Mode)
+	require.Equal(t, 4096, cfg.Threshold)
+	require.Equal(t, 1200, cfg.MinInputTokens)
+	require.Equal(t, 8000, cfg.MaxInputTokens)
+	require.Equal(t, 25, cfg.AllowPercent)
+}
+
+func TestAccount_ContextLengthFilterAllows_DefaultsToAllow(t *testing.T) {
+	account := &Account{}
+	require.True(t, account.ContextLengthFilterAllows(context.Background(), 1500, "session-a"), "missing config should not block")
+}
+
+func TestAccount_ContextLengthFilterAllows_BlocksAndAllowsByPercent(t *testing.T) {
+	account := &Account{
+		Extra: map[string]any{
+			"context_length_filter": map[string]any{
+				"enabled":          true,
+				"min_input_tokens": 1000,
+				"allow_percent":    0,
+			},
+		},
+	}
+
+	require.False(t, account.ContextLengthFilterAllows(context.Background(), 1501, "session-a"))
+
+	account.Extra["context_length_filter"].(map[string]any)["allow_percent"] = 100
+	require.True(t, account.ContextLengthFilterAllows(context.Background(), 1501, "session-a"))
+}
+
+func TestAccount_ContextLengthFilterAllows_ModeGreaterThanAndLessThan(t *testing.T) {
+	account := &Account{
+		Extra: map[string]any{
+			"context_length_filter": map[string]any{
+				"enabled":       true,
+				"mode":          "gt",
+				"threshold":     1000,
+				"allow_percent": 0,
+			},
+		},
+	}
+	require.True(t, account.ContextLengthFilterAllows(context.Background(), 1000, "session-a"))
+	require.False(t, account.ContextLengthFilterAllows(context.Background(), 1001, "session-a"))
+
+	account.Extra["context_length_filter"].(map[string]any)["mode"] = "lt"
+	require.False(t, account.ContextLengthFilterAllows(context.Background(), 999, "session-a"))
+	require.True(t, account.ContextLengthFilterAllows(context.Background(), 1000, "session-a"))
+}
+
+func TestAccount_ContextLengthFilterAllows_DeterministicPerRequest(t *testing.T) {
+	account := &Account{
+		Extra: map[string]any{
+			"context_length_filter": map[string]any{
+				"enabled":          true,
+				"min_input_tokens": 1000,
+				"allow_percent":    50,
+			},
+		},
+	}
+
+	first := account.ContextLengthFilterAllows(context.Background(), 2000, "session-a")
+	second := account.ContextLengthFilterAllows(context.Background(), 2000, "session-a")
+	require.Equal(t, first, second)
+}
+
+func TestAccount_ContextLengthFilterAllows_UsesClientRequestIDForPercentSampling(t *testing.T) {
+	account := &Account{
+		ID: 6,
+		Extra: map[string]any{
+			"context_length_filter": map[string]any{
+				"enabled":       true,
+				"mode":          "gt",
+				"threshold":     1000,
+				"allow_percent": 50,
+			},
+		},
+	}
+
+	seenAllowed := false
+	seenBlocked := false
+	for i := 0; i < 200; i++ {
+		ctx := context.WithValue(context.Background(), ctxkey.ClientRequestID, fmt.Sprintf("client-req-%d", i))
+		if account.ContextLengthFilterAllows(ctx, 2000, "same-sticky-session") {
+			seenAllowed = true
+		} else {
+			seenBlocked = true
+		}
+	}
+
+	require.True(t, seenAllowed, "percent sampling should allow some client request ids")
+	require.True(t, seenBlocked, "percent sampling should block some client request ids")
+}

--- a/backend/internal/service/account_routing_helpers.go
+++ b/backend/internal/service/account_routing_helpers.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"context"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+)
+
+func supportsGroupModelRouting(platform string) bool {
+	switch platform {
+	case PlatformAnthropic, PlatformOpenAI, PlatformGemini:
+		return true
+	default:
+		return false
+	}
+}
+
+func estimatedInputTokensFromContext(ctx context.Context) int {
+	if ctx == nil {
+		return 0
+	}
+	switch v := ctx.Value(ctxkey.EstimatedInputTokens).(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
+}
+
+func contextLengthFilterAllowsAccount(ctx context.Context, account *Account, sessionHash string) bool {
+	if account == nil {
+		return false
+	}
+	estimatedInputTokens := estimatedInputTokensFromContext(ctx)
+	if estimatedInputTokens <= 0 {
+		return true
+	}
+	return account.ContextLengthFilterAllows(ctx, estimatedInputTokens, sessionHash)
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -309,7 +309,7 @@ func (s *AccountTestService) testClaudeAccountConnection(c *gin.Context, account
 		errMsg := fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body))
 
 		// 403 表示账号被上游封禁，标记为 error 状态
-		if resp.StatusCode == http.StatusForbidden {
+		if shouldPersistAccountTestForbidden(resp.StatusCode, account) {
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
 		}
 
@@ -318,6 +318,23 @@ func (s *AccountTestService) testClaudeAccountConnection(c *gin.Context, account
 
 	// Process SSE stream
 	return s.processClaudeStream(c, resp.Body)
+}
+
+func shouldPersistAccountTestForbidden(statusCode int, account *Account) bool {
+	return statusCode == http.StatusForbidden && account != nil && !accountTestPoolModeEnabled(account)
+}
+
+func accountTestPoolModeEnabled(account *Account) bool {
+	if account == nil || account.Credentials == nil {
+		return false
+	}
+	if account.IsPoolMode() {
+		return true
+	}
+	if enabled, ok := account.Credentials["pool_mode"].(bool); ok {
+		return enabled
+	}
+	return false
 }
 
 func (s *AccountTestService) testClaudeVertexServiceAccountConnection(c *gin.Context, ctx context.Context, account *Account, testModelID string) error {
@@ -379,7 +396,7 @@ func (s *AccountTestService) testClaudeVertexServiceAccountConnection(c *gin.Con
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		errMsg := fmt.Sprintf("API returned %d: %s", resp.StatusCode, string(body))
-		if resp.StatusCode == http.StatusForbidden {
+		if shouldPersistAccountTestForbidden(resp.StatusCode, account) {
 			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
 		}
 		return s.sendErrorAndEnd(c, errMsg)

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -480,3 +480,106 @@ func TestAccountTestService_OpenAIChatCompletionsPathRejectsNonJSONStream(t *tes
 	require.Contains(t, recorder.Body.String(), "/v1/chat/completions")
 	require.NotContains(t, recorder.Body.String(), `"success":true`)
 }
+
+func TestAccountTestService_ClaudeAPIKeyPoolMode403DoesNotSetError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusForbidden, `{"error":"pool upstream forbidden"}`)
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream, cfg: claudeAccountTestConfig()}
+	account := &Account{
+		ID:          13,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":   "sk-test",
+			"base_url":  "https://example.test",
+			"pool_mode": true,
+		},
+	}
+
+	err := svc.testClaudeAccountConnection(ctx, account, "claude-sonnet-4-5")
+	require.Error(t, err)
+	require.Zero(t, repo.setErrorID)
+	require.Empty(t, repo.setErrorMsg)
+}
+
+func TestAccountTestService_ClaudeAPIKeyNonPool403SetsError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusForbidden, `{"error":"account forbidden"}`)
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream, cfg: claudeAccountTestConfig()}
+	account := &Account{
+		ID:          14,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.test",
+		},
+	}
+
+	err := svc.testClaudeAccountConnection(ctx, account, "claude-sonnet-4-5")
+	require.Error(t, err)
+	require.Equal(t, account.ID, repo.setErrorID)
+	require.Contains(t, repo.setErrorMsg, "API returned 403")
+}
+
+func TestAccountTestService_ClaudeVertexPoolMode403DoesNotSetError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, _ := newTestContext()
+
+	resp := newJSONResponse(http.StatusForbidden, `{"error":"vertex pool forbidden"}`)
+
+	repo := &openAIAccountTestRepo{}
+	upstream := &queuedHTTPUpstream{responses: []*http.Response{resp}}
+	account := &Account{
+		ID:          15,
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeServiceAccount,
+		Status:      StatusActive,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"pool_mode": true,
+			"service_account_json": map[string]any{
+				"type":           "service_account",
+				"project_id":     "test-project",
+				"private_key_id": "key-id",
+				"private_key":    "-----BEGIN PRIVATE KEY-----\ntest\n-----END PRIVATE KEY-----\n",
+				"client_email":   "svc@example.test",
+			},
+		},
+	}
+	cache := newClaudeTokenCacheStub()
+	key, err := parseVertexServiceAccountKey(account)
+	require.NoError(t, err)
+	cache.tokens[vertexServiceAccountCacheKey(account, key)] = "test-token"
+
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream, claudeTokenProvider: NewClaudeTokenProvider(nil, cache, nil)}
+
+	err = svc.testClaudeAccountConnection(ctx, account, "claude-sonnet-4-5")
+	require.Error(t, err)
+	require.Zero(t, repo.setErrorID)
+	require.Empty(t, repo.setErrorMsg)
+}
+
+func claudeAccountTestConfig() *config.Config {
+	return &config.Config{
+		Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{
+				AllowInsecureHTTP: true,
+			},
+		},
+	}
+}

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -83,6 +83,14 @@ type accountWindowStatsBatchReader interface {
 	GetAccountWindowStatsBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]*usagestats.AccountStats, error)
 }
 
+type accountAverageFirstTokenBatchReader interface {
+	GetAccountAverageFirstTokenBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]*float64, error)
+}
+
+type accountHealthBucketsBatchReader interface {
+	GetAccountHealthBucketsBatch(ctx context.Context, accountIDs []int64, startTime, endTime time.Time, bucketCount int) (map[int64][]usagestats.AccountHealthBucket, error)
+}
+
 // apiUsageCache 缓存从 Anthropic API 获取的使用率数据（utilization, resets_at）
 // 同时支持缓存错误响应（负缓存），防止 429 等错误导致的重试风暴
 type apiUsageCache struct {
@@ -139,6 +147,8 @@ type WindowStats struct {
 	Cost         float64 `json:"cost"`
 	StandardCost float64 `json:"standard_cost"`
 	UserCost     float64 `json:"user_cost"`
+	SuccessCount int64   `json:"success_count"`
+	ErrorCount   int64   `json:"error_count"`
 }
 
 // UsageProgress 使用量进度
@@ -1053,6 +1063,8 @@ func windowStatsFromAccountStats(stats *usagestats.AccountStats) *WindowStats {
 		Cost:         stats.Cost,
 		StandardCost: stats.StandardCost,
 		UserCost:     stats.UserCost,
+		SuccessCount: stats.SuccessCount,
+		ErrorCount:   stats.ErrorCount,
 	}
 }
 
@@ -1346,4 +1358,65 @@ func buildGeminiUsageProgress(used, limit int64, resetAt time.Time, tokens int64
 // 用于账号列表页面显示当前窗口费用
 func (s *AccountUsageService) GetAccountWindowStats(ctx context.Context, accountID int64, startTime time.Time) (*usagestats.AccountStats, error) {
 	return s.usageLogRepo.GetAccountWindowStats(ctx, accountID, startTime)
+}
+
+func uniquePositiveAccountIDs(accountIDs []int64) []int64 {
+	uniqueIDs := make([]int64, 0, len(accountIDs))
+	seen := make(map[int64]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		if accountID <= 0 {
+			continue
+		}
+		if _, exists := seen[accountID]; exists {
+			continue
+		}
+		seen[accountID] = struct{}{}
+		uniqueIDs = append(uniqueIDs, accountID)
+	}
+	return uniqueIDs
+}
+
+func (s *AccountUsageService) GetAverageFirstTokenBatch(ctx context.Context, accountIDs []int64, startTime time.Time) (map[int64]*float64, error) {
+	uniqueIDs := uniquePositiveAccountIDs(accountIDs)
+	result := make(map[int64]*float64, len(uniqueIDs))
+	if len(uniqueIDs) == 0 {
+		return result, nil
+	}
+	if batchReader, ok := s.usageLogRepo.(accountAverageFirstTokenBatchReader); ok {
+		stats, err := batchReader.GetAccountAverageFirstTokenBatch(ctx, uniqueIDs, startTime)
+		if err == nil {
+			for _, accountID := range uniqueIDs {
+				result[accountID] = stats[accountID]
+			}
+			return result, nil
+		}
+	}
+	return result, nil
+}
+
+func (s *AccountUsageService) GetHealthBucketsBatch(ctx context.Context, accountIDs []int64, startTime, endTime time.Time, bucketCount int) (map[int64][]usagestats.AccountHealthBucket, error) {
+	uniqueIDs := uniquePositiveAccountIDs(accountIDs)
+	result := make(map[int64][]usagestats.AccountHealthBucket, len(uniqueIDs))
+	if len(uniqueIDs) == 0 {
+		return result, nil
+	}
+	if bucketCount <= 0 {
+		bucketCount = 60
+	}
+	if bucketCount > 120 {
+		bucketCount = 120
+	}
+	if !endTime.After(startTime) {
+		return result, nil
+	}
+	if batchReader, ok := s.usageLogRepo.(accountHealthBucketsBatchReader); ok {
+		stats, err := batchReader.GetAccountHealthBucketsBatch(ctx, uniqueIDs, startTime, endTime, bucketCount)
+		if err == nil {
+			for _, accountID := range uniqueIDs {
+				result[accountID] = stats[accountID]
+			}
+			return result, nil
+		}
+	}
+	return result, nil
 }

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -883,8 +883,24 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	if req.GroupID != nil && s.service.schedulerSnapshot != nil {
 		schedGroup, _ = s.service.schedulerSnapshot.GetGroupByID(ctx, *req.GroupID)
 	}
+	if routedIDs := openAIGroupRoutingAccountIDs(schedGroup, req.RequestedModel); len(routedIDs) > 0 {
+		routedSet := make(map[int64]struct{}, len(routedIDs))
+		for _, id := range routedIDs {
+			routedSet[id] = struct{}{}
+		}
+		routedAccounts := make([]Account, 0, len(accounts))
+		for _, account := range accounts {
+			if _, ok := routedSet[account.ID]; ok {
+				routedAccounts = append(routedAccounts, account)
+			}
+		}
+		if len(routedAccounts) > 0 {
+			accounts = routedAccounts
+		}
+	}
 
 	filtered := make([]*Account, 0, len(accounts))
+	contextBlockedFiltered := make([]*Account, 0, len(accounts))
 	loadReq := make([]AccountWithConcurrency, 0, len(accounts))
 	for i := range accounts {
 		account := &accounts[i]
@@ -912,14 +928,28 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		if !s.isAccountTransportCompatible(account, req.RequiredTransport) {
 			continue
 		}
+		if !contextLengthFilterAllowsAccount(ctx, account, req.SessionHash) {
+			contextBlockedFiltered = append(contextBlockedFiltered, account)
+			continue
+		}
 		filtered = append(filtered, account)
 		loadReq = append(loadReq, AccountWithConcurrency{
 			ID:             account.ID,
 			MaxConcurrency: account.EffectiveLoadFactor(),
 		})
 	}
+	if len(filtered) == 0 && len(contextBlockedFiltered) == 1 && len(accounts) == 1 {
+		filtered = contextBlockedFiltered
+	}
 	if len(filtered) == 0 {
 		return nil, 0, 0, 0, noAvailableOpenAISelectionError(req.RequestedModel, false)
+	}
+	loadReq = loadReq[:0]
+	for _, account := range filtered {
+		loadReq = append(loadReq, AccountWithConcurrency{
+			ID:             account.ID,
+			MaxConcurrency: account.EffectiveLoadFactor(),
+		})
 	}
 
 	loadMap := map[int64]*AccountLoadInfo{}
@@ -999,6 +1029,13 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	}
 
 	return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked)
+}
+
+func openAIGroupRoutingAccountIDs(group *Group, requestedModel string) []int64 {
+	if group == nil || requestedModel == "" || !supportsGroupModelRouting(group.Platform) {
+		return nil
+	}
+	return group.GetRoutingAccountIDs(requestedModel)
 }
 
 func (s *defaultOpenAIAccountScheduler) isAccountTransportCompatible(account *Account, requiredTransport OpenAIUpstreamTransport) bool {

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,6 +23,44 @@ type openAISnapshotCacheStub struct {
 type schedulerTestOpenAIAccountRepo struct {
 	AccountRepository
 	accounts []Account
+}
+
+type schedulerTestGroupRepo struct {
+	GroupRepository
+	groups map[int64]*Group
+}
+
+func (r *schedulerTestGroupRepo) GetByID(ctx context.Context, id int64) (*Group, error) {
+	if r == nil || r.groups == nil {
+		return nil, ErrGroupNotFound
+	}
+	group := r.groups[id]
+	if group == nil {
+		return nil, ErrGroupNotFound
+	}
+	cloned := *group
+	return &cloned, nil
+}
+
+func (r *schedulerTestGroupRepo) GetByIDLite(ctx context.Context, id int64) (*Group, error) {
+	return r.GetByID(ctx, id)
+}
+
+func (r *schedulerTestGroupRepo) ListActive(ctx context.Context) ([]Group, error) {
+	if r == nil || r.groups == nil {
+		return nil, nil
+	}
+	result := make([]Group, 0, len(r.groups))
+	for _, group := range r.groups {
+		if group != nil && group.Status == StatusActive {
+			result = append(result, *group)
+		}
+	}
+	return result, nil
+}
+
+func (r *schedulerTestGroupRepo) List(ctx context.Context, params pagination.PaginationParams) ([]Group, *pagination.PaginationResult, error) {
+	return nil, nil, nil
 }
 
 func (r schedulerTestOpenAIAccountRepo) GetByID(ctx context.Context, id int64) (*Account, error) {
@@ -297,6 +336,67 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabledUsesLega
 	require.Equal(t, int64(36002), selection.Account.ID)
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 	require.False(t, decision.StickyPreviousHit)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_RespectsOpenAIGroupModelRouting(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(101061)
+	routed := &Account{
+		ID:          42,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    1,
+		Credentials: map[string]any{"model_mapping": map[string]any{"gpt-5.4": "gpt-5.4"}},
+	}
+	other := &Account{
+		ID:          19273,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    1,
+		Credentials: map[string]any{"model_mapping": map[string]any{"gpt-5.4": "gpt-5.4"}},
+	}
+	snapshotCache := &openAISnapshotCacheStub{
+		snapshotAccounts: []*Account{other, routed},
+		accountsByID:     map[int64]*Account{42: routed, 19273: other},
+	}
+	groupRepo := &schedulerTestGroupRepo{groups: map[int64]*Group{
+		groupID: {
+			ID:                  groupID,
+			Platform:            PlatformOpenAI,
+			Status:              StatusActive,
+			Hydrated:            true,
+			ModelRoutingEnabled: true,
+			ModelRouting: map[string][]int64{
+				"gpt-*": {42},
+			},
+		},
+	}}
+	snapshotService := &SchedulerSnapshotService{cache: snapshotCache, groupRepo: groupRepo}
+	svc := &OpenAIGatewayService{
+		accountRepo:           schedulerTestOpenAIAccountRepo{accounts: []Account{*other, *routed}},
+		cache:                 &schedulerTestGatewayCache{},
+		cfg:                   newSchedulerTestOpenAIWSV2Config(),
+		schedulerSnapshot:     snapshotService,
+		concurrencyService:    NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		rateLimitService:      newOpenAIAdvancedSchedulerRateLimitService("true"),
+		openaiAccountStats:    newOpenAIAccountRuntimeStats(),
+		codexSnapshotThrottle: newAccountWriteThrottle(openAICodexSnapshotPersistMinInterval),
+	}
+
+	selection, decision, err := svc.SelectAccountWithScheduler(ctx, &groupID, "", "route-openai", "gpt-5.4", nil, OpenAIUpstreamTransportAny, false)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(42), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 }
 
 func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_RequiredWSV2_SkipsHTTPOnlyAccount(t *testing.T) {

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -40,6 +40,7 @@ export async function list(
     search?: string
     privacy_mode?: string
     lite?: string
+    ttft_window?: string
     sort_by?: string
     sort_order?: 'asc' | 'desc'
   },
@@ -75,6 +76,7 @@ export async function listWithEtag(
     search?: string
     privacy_mode?: string
     lite?: string
+    ttft_window?: string
     sort_by?: string
     sort_order?: 'asc' | 'desc'
   },

--- a/frontend/src/components/account/AccountTodayStatsCell.vue
+++ b/frontend/src/components/account/AccountTodayStatsCell.vue
@@ -23,6 +23,18 @@
           formatNumber(props.stats.requests)
         }}</span>
       </div>
+      <!-- Completed / Errors -->
+      <div class="flex items-center gap-1">
+        <span class="text-gray-500 dark:text-gray-400">200/错:</span>
+        <span class="font-medium text-emerald-600 dark:text-emerald-400">{{
+          formatNumber(successCount)
+        }}</span>
+        <span class="text-gray-300 dark:text-gray-600">/</span>
+        <span
+          class="font-medium"
+          :class="errorCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-gray-500 dark:text-gray-400'"
+        >{{ formatNumber(errorCount) }}</span>
+      </div>
       <!-- Tokens -->
       <div class="flex items-center gap-1">
         <span class="text-gray-500 dark:text-gray-400"
@@ -54,6 +66,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { WindowStats } from '@/types'
 import { formatNumber, formatCurrency } from '@/utils/format'
@@ -72,6 +85,9 @@ const props = withDefaults(
 )
 
 const { t } = useI18n()
+
+const successCount = computed(() => props.stats?.success_count ?? props.stats?.requests ?? 0)
+const errorCount = computed(() => props.stats?.error_count ?? 0)
 
 // Format large token numbers (e.g., 1234567 -> 1.23M)
 const formatTokens = (tokens: number): string => {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1324,6 +1324,49 @@
         <input v-model="expiresAtInput" type="datetime-local" class="input" />
         <p class="input-hint">{{ t('admin.accounts.expiresAtHint') }}</p>
       </div>
+      <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">上下文长度过滤</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              按估算输入 tokens 做账号级放行；未命中时会优先切到同组其他可用账号，没有替代账号则仍放行。
+            </p>
+          </div>
+          <button
+            type="button"
+            @click="contextLengthFilterEnabled = !contextLengthFilterEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              contextLengthFilterEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                contextLengthFilterEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+        <div v-if="contextLengthFilterEnabled" class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <label class="input-label">放行条件</label>
+            <select v-model="contextLengthFilterMode" class="input">
+              <option value="gt">输入 tokens 大于阈值才按比例放行</option>
+              <option value="lt">输入 tokens 小于阈值才按比例放行</option>
+            </select>
+          </div>
+          <div>
+            <label class="input-label">阈值 tokens</label>
+            <input v-model.number="contextLengthFilterThreshold" type="number" min="1" step="1" class="input" />
+          </div>
+          <div>
+            <label class="input-label">放行比例 %</label>
+            <input v-model.number="contextLengthFilterAllowPercent" type="number" min="0" max="100" step="1" class="input" />
+            <p class="input-hint">0 表示命中条件时尽量不用该账号，100 表示不限制。</p>
+          </div>
+        </div>
+      </div>
 
       <!-- OpenAI 自动透传开关（OAuth/API Key） -->
       <div
@@ -2575,6 +2618,10 @@ const cacheTTLOverrideEnabled = ref(false)
 const cacheTTLOverrideTarget = ref<string>('5m')
 const customBaseUrlEnabled = ref(false)
 const customBaseUrl = ref('')
+const contextLengthFilterEnabled = ref(false)
+const contextLengthFilterMode = ref<'gt' | 'lt'>('gt')
+const contextLengthFilterThreshold = ref<number | null>(null)
+const contextLengthFilterAllowPercent = ref<number>(0)
 
 // OpenAI 自动透传开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
@@ -2944,13 +2991,18 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Load mixed scheduling setting (only for antigravity accounts)
   mixedScheduling.value = false
   allowOverages.value = false
-	const extra = newAccount.extra as Record<string, unknown> | undefined
-	mixedScheduling.value = extra?.mixed_scheduling === true
-	allowOverages.value = extra?.allow_overages === true
-	autoPause5hThreshold.value = typeof extra?.auto_pause_5h_threshold === 'number' ? extra.auto_pause_5h_threshold * 100 : null
-	autoPause7dThreshold.value = typeof extra?.auto_pause_7d_threshold === 'number' ? extra.auto_pause_7d_threshold * 100 : null
-	autoPause5hDisabled.value = extra?.auto_pause_5h_disabled === true
-	autoPause7dDisabled.value = extra?.auto_pause_7d_disabled === true
+  const extra = newAccount.extra as Record<string, unknown> | undefined
+  mixedScheduling.value = extra?.mixed_scheduling === true
+  allowOverages.value = extra?.allow_overages === true
+  const contextFilter = extra?.context_length_filter as Record<string, unknown> | undefined
+  contextLengthFilterEnabled.value = contextFilter?.enabled === true
+  contextLengthFilterMode.value = contextFilter?.mode === 'lt' ? 'lt' : 'gt'
+  contextLengthFilterThreshold.value = Number(contextFilter?.threshold || contextFilter?.min_input_tokens || contextFilter?.max_input_tokens || 0) || null
+  contextLengthFilterAllowPercent.value = Math.max(0, Math.min(100, Number(contextFilter?.allow_percent ?? 0) || 0))
+  autoPause5hThreshold.value = typeof extra?.auto_pause_5h_threshold === 'number' ? extra.auto_pause_5h_threshold * 100 : null
+  autoPause7dThreshold.value = typeof extra?.auto_pause_7d_threshold === 'number' ? extra.auto_pause_7d_threshold * 100 : null
+  autoPause5hDisabled.value = extra?.auto_pause_5h_disabled === true
+  autoPause7dDisabled.value = extra?.auto_pause_7d_disabled === true
 
   // Load OpenAI passthrough toggle (OpenAI OAuth/API Key)
   openaiPassthroughEnabled.value = false
@@ -3625,6 +3677,21 @@ const ensureAntigravityMixedChannelConfirmed = async (onConfirm: () => Promise<v
 const formatDateTimeLocal = formatDateTimeLocalInput
 const parseDateTimeLocal = parseDateTimeLocalInput
 
+const applyContextLengthFilterExtra = (extra: Record<string, unknown>) => {
+  if (!contextLengthFilterEnabled.value) {
+    delete extra.context_length_filter
+    return
+  }
+  const threshold = Math.max(1, Math.trunc(Number(contextLengthFilterThreshold.value) || 0))
+  const allowPercent = Math.max(0, Math.min(100, Math.trunc(Number(contextLengthFilterAllowPercent.value) || 0)))
+  extra.context_length_filter = {
+    enabled: true,
+    mode: contextLengthFilterMode.value,
+    threshold,
+    allow_percent: allowPercent,
+  }
+}
+
 // Methods
 const handleClose = () => {
   antigravityMixedChannelConfirmed.value = false
@@ -4203,6 +4270,14 @@ const handleSubmit = async () => {
       }
       // Quota notify config
       writeQuotaNotifyToExtra(newExtra, 'update')
+      updatePayload.extra = newExtra
+    }
+
+    {
+      const currentExtra = (updatePayload.extra as Record<string, unknown>) ||
+        (props.account.extra as Record<string, unknown>) || {}
+      const newExtra: Record<string, unknown> = { ...currentExtra }
+      applyContextLengthFilterExtra(newExtra)
       updatePayload.extra = newExtra
     }
 

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -17,6 +17,21 @@
             @create="showCreate = true"
           >
             <template #after>
+              <select
+                v-model="params.ttft_window"
+                class="rounded-lg border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-700 shadow-sm focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200"
+                title="平均首字时间窗口"
+                @change="handleTTFTWindowChange"
+              >
+                <option
+                  v-for="option in ttftWindowOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  首字时间：{{ option.label }}
+                </option>
+              </select>
+
               <!-- Auto Refresh Dropdown -->
               <div class="relative" ref="autoRefreshDropdownRef">
                 <button
@@ -195,7 +210,7 @@
           default-sort-key="name"
           default-sort-order="asc"
           :sort-storage-key="ACCOUNT_SORT_STORAGE_KEY"
-          :estimate-row-height="72"
+          :estimate-row-height="96"
           :overscan="5"
         >
           <template #header-select>
@@ -220,6 +235,25 @@
               >
                 {{ row.extra?.email_address || row.extra?.email || row.credentials?.email }}
               </span>
+              <div v-if="hasAccountHealthBuckets(row)" class="mt-2 w-56 max-w-full">
+                <div class="flex h-5 items-end gap-px">
+                  <div
+                    v-for="slot in accountHealthSlots(row)"
+                    :key="slot.key"
+                    class="flex min-w-[2px] flex-1 items-end"
+                  >
+                    <div
+                      v-if="slot.total > 0"
+                      :class="[
+                        'w-full rounded-sm transition-opacity hover:opacity-80',
+                        accountHealthBarClass(slot.errorRate)
+                      ]"
+                      :style="{ height: accountHealthBarHeight(slot.total, row.health_buckets) }"
+                      :title="accountHealthBucketTitle(slot)"
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
           </template>
           <template #cell-notes="{ value }">
@@ -269,6 +303,18 @@
               :loading="todayStatsLoading"
               :error="todayStatsError"
             />
+          </template>
+          <template #cell-avg_first_token="{ row }">
+            <span
+              v-if="row.type === 'apikey' && row.avg_first_token_ms != null"
+              :class="[
+                'badge text-xs whitespace-nowrap tabular-nums',
+                firstTokenLatencyClass(row.avg_first_token_ms)
+              ]"
+            >
+              {{ formatFirstTokenMs(row.avg_first_token_ms) }}
+            </span>
+            <span v-else class="text-sm text-gray-400 dark:text-dark-500">-</span>
           </template>
           <template #cell-groups="{ row }">
             <AccountGroupsCell :groups="row.groups" :max-display="4" />
@@ -421,7 +467,7 @@ import ErrorPassthroughRulesModal from '@/components/admin/ErrorPassthroughRules
 import TLSFingerprintProfilesModal from '@/components/admin/TLSFingerprintProfilesModal.vue'
 import { buildOpenAIUsageRefreshKey } from '@/utils/accountUsageRefresh'
 import { formatDateTime, formatRelativeTime } from '@/utils/format'
-import type { Account, AccountPlatform, AccountType, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel } from '@/types'
+import type { Account, AccountPlatform, AccountType, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel, AccountHealthBucket } from '@/types'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -520,7 +566,8 @@ const ACCOUNT_SORTABLE_KEYS = new Set([
   'rate_multiplier',
   'last_used_at',
   'created_at',
-  'expires_at'
+  'expires_at',
+  'avg_first_token'
 ])
 const loadInitialAccountSortState = (): AccountSortState => {
   const fallback: AccountSortState = { sort_by: 'name', sort_order: 'asc' }
@@ -559,13 +606,119 @@ const todayStatsError = ref<string | null>(null)
 const todayStatsReqSeq = ref(0)
 const pendingTodayStatsRefresh = ref(false)
 const usageManualRefreshToken = ref(0)
+const ttftWindowOptions = [
+  { value: '5m', label: '近5分钟' },
+  { value: '30m', label: '近30分钟' },
+  { value: '1h', label: '近1小时' },
+  { value: '6h', label: '近6小时' },
+  { value: '24h', label: '近24小时' }
+]
+
+type AccountHealthSlot = {
+  key: string
+  bucketStart: Date
+  successCount: number
+  errorCount: number
+  total: number
+  errorRate: number
+}
+
+const accountHealthWindowMs = (value: unknown) => {
+  switch (String(value || '1h')) {
+    case '5m': return 5 * 60 * 1000
+    case '30m': return 30 * 60 * 1000
+    case '6h': return 6 * 60 * 60 * 1000
+    case '24h': return 24 * 60 * 60 * 1000
+    case '1h':
+    default: return 60 * 60 * 1000
+  }
+}
+
+const accountHealthBucketCount = (value: unknown) => {
+  switch (String(value || '1h')) {
+    case '5m': return 30
+    case '6h': return 72
+    case '24h': return 96
+    case '30m':
+    case '1h':
+    default: return 60
+  }
+}
+
+const normalizeAccountHealthBucketTime = (value: string) => {
+  const time = new Date(value).getTime()
+  return Number.isFinite(time) ? time : 0
+}
+
+const accountHealthSignature = (buckets?: AccountHealthBucket[] | null) => {
+  if (!Array.isArray(buckets) || buckets.length === 0) return ''
+  return buckets
+    .map(bucket => `${bucket.bucket_start}:${bucket.success_count || 0}:${bucket.error_count || 0}`)
+    .join('|')
+}
+
+const hasAccountHealthBuckets = (account: Account) => {
+  return Array.isArray(account.health_buckets) && account.health_buckets.some(bucket => (bucket.success_count || 0) + (bucket.error_count || 0) > 0)
+}
+
+const accountHealthSlots = (account: Account): AccountHealthSlot[] => {
+  const bucketCount = accountHealthBucketCount(params.ttft_window)
+  const windowMs = accountHealthWindowMs(params.ttft_window)
+  const bucketMs = windowMs / bucketCount
+  const now = Date.now()
+  const startMs = now - windowMs
+  const byIndex = new Map<number, { successCount: number; errorCount: number }>()
+
+  for (const bucket of account.health_buckets || []) {
+    const bucketTime = normalizeAccountHealthBucketTime(bucket.bucket_start)
+    if (!bucketTime) continue
+    const index = Math.floor((bucketTime - startMs) / bucketMs)
+    if (index < 0 || index >= bucketCount) continue
+    const current = byIndex.get(index) || { successCount: 0, errorCount: 0 }
+    current.successCount += Number(bucket.success_count || 0)
+    current.errorCount += Number(bucket.error_count || 0)
+    byIndex.set(index, current)
+  }
+
+  return Array.from({ length: bucketCount }, (_, index) => {
+    const counts = byIndex.get(index) || { successCount: 0, errorCount: 0 }
+    const total = counts.successCount + counts.errorCount
+    return {
+      key: `${index}-${Math.floor(startMs + index * bucketMs)}`,
+      bucketStart: new Date(startMs + index * bucketMs),
+      successCount: counts.successCount,
+      errorCount: counts.errorCount,
+      total,
+      errorRate: total > 0 ? counts.errorCount / total : 0
+    }
+  })
+}
+
+const accountHealthBarClass = (errorRate: number) => {
+  if (errorRate < 0.15) return 'bg-emerald-500 dark:bg-emerald-400'
+  if (errorRate < 0.5) return 'bg-amber-400 dark:bg-amber-300'
+  return 'bg-red-500 dark:bg-red-400'
+}
+
+const accountHealthBarHeight = (total: number, buckets?: AccountHealthBucket[] | null) => {
+  const maxTotal = Math.max(1, ...(buckets || []).map(bucket => (bucket.success_count || 0) + (bucket.error_count || 0)))
+  const ratio = Math.max(0.25, Math.min(1, total / maxTotal))
+  return `${Math.round(20 * ratio)}px`
+}
+
+const accountHealthBucketTitle = (slot: AccountHealthSlot) => {
+  const errorRate = slot.total > 0 ? `${(slot.errorRate * 100).toFixed(1)}%` : '0%'
+  return `${formatDateTime(slot.bucketStart)}\n200: ${slot.successCount}\n错误: ${slot.errorCount}\n总数: ${slot.total}\n错误率: ${errorRate}`
+}
 
 const buildDefaultTodayStats = (): WindowStats => ({
   requests: 0,
   tokens: 0,
   cost: 0,
   standard_cost: 0,
-  user_cost: 0
+  user_cost: 0,
+  success_count: 0,
+  error_count: 0
 })
 
 const refreshTodayStatsBatch = async () => {
@@ -739,6 +892,7 @@ const {
     privacy_mode: '',
     group: '',
     search: '',
+    ttft_window: '1h',
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order
   }
@@ -826,6 +980,14 @@ const handlePageSizeChange = (size: number) => {
   baseHandlePageSizeChange(size)
 }
 
+const handleTTFTWindowChange = () => {
+  pagination.page = 1
+  hasPendingListSync.value = false
+  resetAutoRefreshCache()
+  pendingTodayStatsRefresh.value = true
+  load()
+}
+
 const handleSort = (key: string, order: AccountSortOrder) => {
   sortState.sort_by = key
   sortState.sort_order = order
@@ -881,6 +1043,8 @@ const shouldReplaceAutoRefreshRow = (current: Account, next: Account) => {
     current.updated_at !== next.updated_at ||
     current.current_concurrency !== next.current_concurrency ||
     current.current_window_cost !== next.current_window_cost ||
+    current.avg_first_token_ms !== next.avg_first_token_ms ||
+    accountHealthSignature(current.health_buckets) !== accountHealthSignature(next.health_buckets) ||
     current.active_sessions !== next.active_sessions ||
     current.schedulable !== next.schedulable ||
     current.status !== next.status ||
@@ -945,6 +1109,7 @@ const refreshAccountsIncrementally = async () => {
         search?: string
         sort_by?: string
         sort_order?: AccountSortOrder
+        ttft_window?: string
 
       },
       { etag: autoRefreshETag.value }
@@ -1127,7 +1292,8 @@ const allColumns = computed(() => {
     { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false },
     { key: 'status', label: t('admin.accounts.columns.status'), sortable: true },
     { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true },
-    { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false }
+    { key: 'today_stats', label: t('admin.accounts.columns.todayStats'), sortable: false },
+    { key: 'avg_first_token', label: '平均首字', sortable: true }
   ]
   if (!authStore.isSimpleMode) {
     c.push({ key: 'groups', label: t('admin.accounts.columns.groups'), sortable: false })
@@ -1460,6 +1626,8 @@ const mergeRuntimeFields = (oldAccount: Account, updatedAccount: Account): Accou
   ...updatedAccount,
   current_concurrency: updatedAccount.current_concurrency ?? oldAccount.current_concurrency,
   current_window_cost: updatedAccount.current_window_cost ?? oldAccount.current_window_cost,
+  avg_first_token_ms: updatedAccount.avg_first_token_ms ?? oldAccount.avg_first_token_ms,
+  health_buckets: updatedAccount.health_buckets ?? oldAccount.health_buckets,
   active_sessions: updatedAccount.active_sessions ?? oldAccount.active_sessions
 })
 
@@ -1635,6 +1803,29 @@ const formatExpiresAt = (value: number | null) => {
     'sv-SE'
   )
 }
+
+const formatFirstTokenMs = (value: number | null | undefined) => {
+  if (value == null || !Number.isFinite(value)) return '-'
+  if (value < 1000) return `${Math.round(value)}ms`
+  return `${(value / 1000).toFixed(value < 10000 ? 2 : 1)}s`
+}
+
+const firstTokenLatencyClass = (value: number | null | undefined) => {
+  if (value == null || !Number.isFinite(value)) {
+    return 'bg-gray-100 text-gray-500 dark:bg-dark-700 dark:text-dark-300'
+  }
+  if (value < 1000) {
+    return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+  }
+  if (value < 3000) {
+    return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+  }
+  if (value < 8000) {
+    return 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300'
+  }
+  return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+}
+
 const isExpired = (value: number | null) => {
   if (!value) return false
   return value * 1000 <= Date.now()


### PR DESCRIPTION
## Summary
- Add account-level scheduling metadata and context-length filters for account selection.
- Improve OpenAI account scheduler/model routing eligibility and cache behavior.
- Add admin account UI visibility for recent/account stats and routing-related fields.

## Tests
- `go test ./internal/service ./internal/repository ./internal/handler/admin -run 'Account|Scheduler|OpenAI|ContextLength|Routing|AvailableModels|SyncUpstreamModels'`

## Notes
- Frontend build was not run in the isolated worktree because `frontend/node_modules` is not installed there.