### PR TITLE
[codex] defer admin tour until compliance is ready

### DIFF
--- a/frontend/src/composables/__tests__/useOnboardingTour.spec.ts
+++ b/frontend/src/composables/__tests__/useOnboardingTour.spec.ts
@@ -1,0 +1,153 @@
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { defineComponent, nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useOnboardingTour } from '@/composables/useOnboardingTour'
+import { useAdminComplianceStore } from '@/stores/adminCompliance'
+import { useAuthStore } from '@/stores/auth'
+
+const driveMock = vi.fn()
+const destroyMock = vi.fn()
+
+vi.mock('driver.js', () => ({
+  driver: vi.fn(() => ({
+    drive: driveMock,
+    destroy: destroyMock,
+    isActive: vi.fn(() => false),
+    getActiveIndex: vi.fn(() => 0),
+    getActiveElement: vi.fn(() => null),
+    moveNext: vi.fn(),
+    movePrevious: vi.fn(),
+  })),
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock('@/components/Guide/steps', () => ({
+  getAdminSteps: () => [
+    {
+      popover: {
+        title: 'welcome',
+        description: 'welcome',
+      },
+    },
+  ],
+  getUserSteps: () => [
+    {
+      popover: {
+        title: 'welcome',
+        description: 'welcome',
+      },
+    },
+  ],
+}))
+
+const adminUser = {
+  id: 2,
+  username: 'admin',
+  email: 'admin@example.com',
+  role: 'admin' as const,
+  balance: 100,
+  concurrency: 5,
+  status: 'active' as const,
+  allowed_groups: null,
+  created_at: '2024-01-01',
+  updated_at: '2024-01-01',
+}
+
+function mountTour() {
+  return mount(defineComponent({
+    setup() {
+      useOnboardingTour({
+        storageKey: 'admin_guide',
+        autoStart: true,
+      })
+
+      return () => null
+    },
+  }))
+}
+
+function setAdminSession(): void {
+  const authStore = useAuthStore()
+  authStore.$patch({
+    user: adminUser,
+    token: 'admin-token',
+  })
+}
+
+describe('useOnboardingTour', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+    vi.useFakeTimers()
+    driveMock.mockClear()
+    destroyMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
+
+  it('does not auto-start for admins before compliance status is initialized', async () => {
+    setAdminSession()
+    const complianceStore = useAdminComplianceStore()
+    complianceStore.initialized = false
+
+    const wrapper = mountTour()
+    await nextTick()
+    vi.advanceTimersByTime(1000)
+    await nextTick()
+    await nextTick()
+
+    expect(driveMock).not.toHaveBeenCalled()
+
+    wrapper.unmount()
+  })
+
+  it('auto-starts after the admin compliance acknowledgement is no longer required', async () => {
+    setAdminSession()
+    const complianceStore = useAdminComplianceStore()
+    complianceStore.status = {
+      required: true,
+      version: 'v2026.06.10',
+      document_path_zh: 'docs/legal/admin-compliance.zh.md',
+      document_path_en: 'docs/legal/admin-compliance.en.md',
+      document_url_zh: 'https://example.com/zh',
+      document_url_en: 'https://example.com/en',
+      ack_phrase_zh: '确认',
+      ack_phrase_en: 'Confirm',
+    }
+    complianceStore.initialized = true
+
+    const wrapper = mountTour()
+    await nextTick()
+    vi.advanceTimersByTime(1000)
+    await nextTick()
+    await nextTick()
+    expect(driveMock).not.toHaveBeenCalled()
+
+    complianceStore.status = {
+      ...complianceStore.status!,
+      required: false,
+    }
+    await nextTick()
+    vi.advanceTimersByTime(1000)
+    await nextTick()
+    await nextTick()
+
+    expect(driveMock).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/composables/useOnboardingTour.ts
+++ b/frontend/src/composables/useOnboardingTour.ts
@@ -1,8 +1,9 @@
-import { onMounted, onUnmounted, nextTick } from 'vue'
+import { onMounted, onUnmounted, nextTick, watch } from 'vue'
 import { driver, type Driver, type DriveStep } from 'driver.js'
 import 'driver.js/dist/driver.css'
 import { useAuthStore as useUserStore } from '@/stores/auth'
 import { useOnboardingStore } from '@/stores/onboarding'
+import { useAdminComplianceStore } from '@/stores/adminCompliance'
 import { useI18n } from 'vue-i18n'
 import { getAdminSteps, getUserSteps } from '@/components/Guide/steps'
 
@@ -15,6 +16,7 @@ export function useOnboardingTour(options: OnboardingOptions) {
   const { t } = useI18n()
   const userStore = useUserStore()
   const onboardingStore = useOnboardingStore()
+  const adminComplianceStore = useAdminComplianceStore()
   const storageVersion = 'v4_interactive' // Bump version for new tour type
 
   // Timing constants for better maintainability
@@ -55,6 +57,7 @@ export function useOnboardingTour(options: OnboardingOptions) {
     eventTypes?: string[] // Track which event types were added
   } | null = null
   let autoStartTimer: ReturnType<typeof setTimeout> | null = null
+  let stopAutoStartWatch: (() => void) | null = null
   let globalKeyboardHandler: ((e: KeyboardEvent) => void) | null = null
 
   const getStorageKey = () => {
@@ -74,6 +77,44 @@ export function useOnboardingTour(options: OnboardingOptions) {
 
   const clearSeen = () => {
     localStorage.removeItem(getStorageKey())
+  }
+
+  const clearAutoStartTimer = () => {
+    if (!autoStartTimer) return
+    clearTimeout(autoStartTimer)
+    autoStartTimer = null
+  }
+
+  const canAutoStart = () => {
+    if (!options.autoStart || hasSeen()) {
+      return false
+    }
+    if (onboardingStore.isDriverActive() || userStore.isSimpleMode) {
+      return false
+    }
+    if (userStore.user?.role !== 'admin') {
+      return false
+    }
+    if (!adminComplianceStore.initialized || adminComplianceStore.shouldShow) {
+      return false
+    }
+    return true
+  }
+
+  const scheduleAutoStart = () => {
+    if (!canAutoStart()) {
+      clearAutoStartTimer()
+      return
+    }
+    if (autoStartTimer) {
+      return
+    }
+    autoStartTimer = setTimeout(() => {
+      autoStartTimer = null
+      if (canAutoStart()) {
+        void startTour()
+      }
+    }, TIMING.AUTO_START_DELAY_MS)
   }
 
   /**
@@ -542,16 +583,23 @@ export function useOnboardingTour(options: OnboardingOptions) {
       return
     }
 
-    if (!options.autoStart || hasSeen()) return
-    autoStartTimer = setTimeout(() => {
-      void startTour()
-    }, TIMING.AUTO_START_DELAY_MS)
+    stopAutoStartWatch = watch(
+      () => [
+        adminComplianceStore.initialized,
+        adminComplianceStore.shouldShow,
+        userStore.user?.role,
+        userStore.isSimpleMode,
+      ],
+      scheduleAutoStart,
+      { immediate: true },
+    )
   })
 
   onUnmounted(() => {
-    if (autoStartTimer) {
-      clearTimeout(autoStartTimer)
-      autoStartTimer = null
+    clearAutoStartTimer()
+    if (stopAutoStartWatch) {
+      stopAutoStartWatch()
+      stopAutoStartWatch = null
     }
     // 关键修复：不再此处清理 globalKeyboardHandler，交由 driver.onDestroyed 管理
     onboardingStore.clearControlMethods()


### PR DESCRIPTION
## Summary
- defer the admin onboarding tour until admin compliance status has loaded
- prevent the tour from starting while the compliance acknowledgement dialog is required
- add regression coverage for first-login compliance gating

## Root cause
The admin tour scheduled its auto-start as soon as `AppLayout` mounted. On first admin login, the compliance acknowledgement status is loaded asynchronously, so the tour could call `drive(0)` before the required compliance dialog finished.

## Validation
- `cd frontend && ./node_modules/.bin/vitest run src/composables/__tests__/useOnboardingTour.spec.ts`
- `cd frontend && ./node_modules/.bin/vue-tsc --noEmit`
- `cd frontend && ./node_modules/.bin/eslint src/composables/useOnboardingTour.ts src/composables/__tests__/useOnboardingTour.spec.ts`
- `git diff --check`