### PR TITLE
fix(promo): allow clearing promo code expiry on edit

### DIFF
--- a/backend/internal/handler/admin/promo_handler.go
+++ b/backend/internal/handler/admin/promo_handler.go
@@ -148,7 +148,7 @@ func (h *PromoHandler) Update(c *gin.Context) {
 	if req.ExpiresAt != nil {
 		if *req.ExpiresAt == 0 {
 			// 0 表示清除过期时间
-			input.ExpiresAt = nil
+			input.ExpiresAt = &time.Time{}
 		} else {
 			t := time.Unix(*req.ExpiresAt, 0)
 			input.ExpiresAt = &t

--- a/backend/internal/service/promo_service.go
+++ b/backend/internal/service/promo_service.go
@@ -236,6 +236,9 @@ func (s *PromoService) Update(ctx context.Context, id int64, input *UpdatePromoC
 		promoCode.Status = *input.Status
 	}
 	if input.ExpiresAt != nil {
+		if input.ExpiresAt.IsZero() {
+			input.ExpiresAt = nil
+		}
 		promoCode.ExpiresAt = input.ExpiresAt
 	}
 	if input.Notes != nil {


### PR DESCRIPTION
## 问题
编辑优惠码时清空「过期时间」并保存,过期时间不会被清除,仍保持原值。

## 原因
前端清空时发送 expires_at=0,handler 将其映射为 nil ExpiresAt 表示「清除」,但 service 把 nil 当作「不修改」直接跳过,清除意图丢失。

## 修复
改用零值时间作为「清除」哨兵:handler 收到 0 时传 &time.Time{},service 用 IsZero() 识别并置 nil,从而走到 repo 的 ClearExpiresAt()。

## 验证
修复后,带过期时间的优惠码可正确改为「永不过期」。
<img width="3022" height="658" alt="image" src="https://github.com/user-attachments/assets/e6235d53-9712-4e9b-b2e1-c417e7d799a5" />
