### PR TITLE
fix: avoid OAuth routing for native image requests

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1212,8 +1212,16 @@ func (a *Account) SupportsOpenAIImageCapability(capability OpenAIImagesCapabilit
 		return false
 	}
 	switch capability {
-	case OpenAIImagesCapabilityBasic, OpenAIImagesCapabilityNative:
+	case OpenAIImagesCapabilityBasic:
 		return a.Type == AccountTypeOAuth || a.Type == AccountTypeAPIKey
+	case OpenAIImagesCapabilityNative:
+		// Native Images API semantics (explicit custom size/model/native options)
+		// require the platform Images API. The ChatGPT OAuth/Codex bridge accepts
+		// the translated request but may silently coerce arbitrary gpt-image-2 sizes
+		// into canonical portrait/landscape buckets while still returning 200.
+		// Treat OAuth as basic-only so native requests either use an API key account
+		// or fail/fail over instead of producing a wrong-aspect image.
+		return a.Type == AccountTypeAPIKey
 	default:
 		return true
 	}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1201,15 +1201,12 @@ func (s *OpenAIGatewayService) SelectAccountWithSchedulerForImages(
 	excludedIDs map[int64]struct{},
 	requiredCapability OpenAIImagesCapability,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
-	selection, decision, err := s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", requiredCapability, false)
-	if err == nil && selection != nil && selection.Account != nil {
-		return selection, decision, nil
-	}
-	// 如果要求 native 能力（如指定了模型）但没有可用的 APIKey 账号，回退到 basic（OAuth 账号）
-	if requiredCapability == OpenAIImagesCapabilityNative {
-		return s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", OpenAIImagesCapabilityBasic, false)
-	}
-	return selection, decision, err
+	// Do not downgrade native image requests to basic OAuth routing. Native
+	// requests include explicit size/model or OpenAI Images API-only options, and
+	// the OAuth/Codex bridge can silently snap arbitrary custom sizes to canonical
+	// buckets. Let the caller fail/fail over instead of returning a 200 with the
+	// wrong aspect ratio.
+	return s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", requiredCapability, false)
 }
 
 func (s *OpenAIGatewayService) selectAccountWithScheduler(

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -432,14 +432,20 @@ func TestOpenAIUpstreamErrorBodyReadLimitForConfig_RespectsDiagnosticLimit(t *te
 	require.Equal(t, int64(cfg.Gateway.LogUpstreamErrorBodyMaxBytes), openAIUpstreamErrorBodyReadLimitForConfig(cfg))
 }
 
-func TestAccountSupportsOpenAIImageCapability_OAuthSupportsNative(t *testing.T) {
-	account := &Account{
+func TestAccountSupportsOpenAIImageCapability_NativeRequiresAPIKey(t *testing.T) {
+	oauthAccount := &Account{
 		Platform: PlatformOpenAI,
 		Type:     AccountTypeOAuth,
 	}
+	apiKeyAccount := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+	}
 
-	require.True(t, account.SupportsOpenAIImageCapability(OpenAIImagesCapabilityBasic))
-	require.True(t, account.SupportsOpenAIImageCapability(OpenAIImagesCapabilityNative))
+	require.True(t, oauthAccount.SupportsOpenAIImageCapability(OpenAIImagesCapabilityBasic))
+	require.False(t, oauthAccount.SupportsOpenAIImageCapability(OpenAIImagesCapabilityNative))
+	require.True(t, apiKeyAccount.SupportsOpenAIImageCapability(OpenAIImagesCapabilityBasic))
+	require.True(t, apiKeyAccount.SupportsOpenAIImageCapability(OpenAIImagesCapabilityNative))
 }
 
 func TestAccountSupportsOpenAIEndpointCapability(t *testing.T) {


### PR DESCRIPTION
## Summary
- Treat OpenAI OAuth accounts as basic Images-only; native Images requests now require API key accounts.
- Remove the native→basic scheduler downgrade for Images requests.
- Update coverage so explicit native image requests cannot silently route through the ChatGPT OAuth/Codex bridge.

## Why
Native Images requests can include explicit custom `size` values supported by the public gpt-image-2 API. The OAuth/Codex bridge forwards `tools[0].size`, but that internal route can still silently snap arbitrary portrait sizes to canonical buckets while returning HTTP 200. This makes wrong-aspect images look successful.

## Tests
- `cd backend && go test ./internal/service -run 'TestAccountSupportsOpenAIImageCapability_NativeRequiresAPIKey|TestOpenAIGatewayServiceParseOpenAIImagesRequest_ExplicitSizeRequiresNativeCapability|TestBuildOpenAIImagesResponsesRequest'`\n- `cd backend && go test ./internal/service -run 'OpenAI.*Image|Images|AccountSupportsOpenAIImageCapability|SelectAccountWithSchedulerForImages|Scheduler'`\n- `cd backend && go test ./internal/handler -run 'OpenAIImages|Images'`