### PR TITLE
fix(ccswitch): default OpenAI import model to gpt-5.5

### DIFF
--- a/frontend/src/utils/__tests__/ccswitchImport.spec.ts
+++ b/frontend/src/utils/__tests__/ccswitchImport.spec.ts
@@ -11,6 +11,10 @@ function paramsFromDeeplink(deeplink: string): URLSearchParams {
 }
 
 describe('ccswitchImport utils', () => {
+  it('defaults OpenAI CC Switch imports to the current Codex model', () => {
+    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.5')
+  })
+
   const baseInput = {
     baseUrl: 'https://api.example.com',
     providerName: 'Sub2API',

--- a/frontend/src/utils/ccswitchImport.ts
+++ b/frontend/src/utils/ccswitchImport.ts
@@ -1,6 +1,6 @@
 import type { GroupPlatform } from '@/types'
 
-export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.4'
+export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.5'
 
 export type CcSwitchClientType = 'claude' | 'gemini'
 


### PR DESCRIPTION
## Background

The Codex "Use key" config template already defaults `model` and `review_model` to `gpt-5.5`, but the CC Switch import path still defaults OpenAI/Codex imports to `gpt-5.4`.

This makes the two user-facing setup paths produce different default Codex models.

## Summary

- update the OpenAI CC Switch Codex import default model to `gpt-5.5`
- add an explicit test for the OpenAI CC Switch default model

## Tests

- `pnpm exec vitest run src/utils/__tests__/ccswitchImport.spec.ts`
