### PR TITLE
fix(images): 识别 response.incomplete 触发 failover + 记录软失败上游响应

### DIFF
--- a/backend/internal/service/openai_images_incomplete_test.go
+++ b/backend/internal/service/openai_images_incomplete_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// response.incomplete（生成超时/截断）应被识别为可重试的 502 上游错误，触发 failover。
+func TestExtractImagesUpstreamError_IncompleteIsRetryable(t *testing.T) {
+	body := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_1\"}}\n\n" +
+		"data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"resp_1\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"}}}\n\n"
+	got := extractOpenAIImagesUpstreamError([]byte(body))
+	if got == nil {
+		t.Fatal("incomplete event should produce an upstream error, got nil")
+	}
+	if got.StatusCode != http.StatusBadGateway {
+		t.Fatalf("incomplete(max_output_tokens) should be 502 retryable, got %d", got.StatusCode)
+	}
+	if !IsOpenAIImagesRetryableUpstreamError(got) {
+		t.Fatal("incomplete(max_output_tokens) should be retryable for failover")
+	}
+	if got.Code != "response_incomplete" {
+		t.Fatalf("unexpected code %q", got.Code)
+	}
+	if !strings.Contains(got.Message, "max_output_tokens") {
+		t.Fatalf("message should carry reason, got %q", got.Message)
+	}
+}
+
+// incomplete 因 content_filter → 400，重试无意义，不应触发 failover。
+func TestExtractImagesUpstreamError_IncompleteContentFilterNotRetryable(t *testing.T) {
+	body := "data: {\"type\":\"response.incomplete\",\"response\":{\"id\":\"r\",\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"content_filter\"}}}\n\n"
+	got := extractOpenAIImagesUpstreamError([]byte(body))
+	if got == nil {
+		t.Fatal("content_filter incomplete should produce error")
+	}
+	if got.StatusCode != http.StatusBadRequest {
+		t.Fatalf("content_filter should be 400 (non-retryable), got %d", got.StatusCode)
+	}
+	if IsOpenAIImagesRetryableUpstreamError(got) {
+		t.Fatal("content_filter must NOT be retryable")
+	}
+}
+
+// 旧行为不变：error / response.failed 仍按原逻辑识别。
+func TestExtractImagesUpstreamError_ErrorAndFailedUnchanged(t *testing.T) {
+	errBody := "data: {\"type\":\"error\",\"error\":{\"type\":\"image_generation_user_error\",\"code\":\"moderation_blocked\",\"message\":\"rejected\"}}\n\n"
+	if got := extractOpenAIImagesUpstreamError([]byte(errBody)); got == nil || got.StatusCode != http.StatusBadRequest {
+		t.Fatalf("moderation_blocked should still be 400, got %+v", got)
+	}
+}
+
+// 上游既无图、又无任何可识别事件时，摘要函数应提取诊断信息。
+func TestSummarizeNoOutputBody_ExtractsDiagnostics(t *testing.T) {
+	body := "data: {\"type\":\"response.created\",\"response\":{\"id\":\"r\"}}\n\n" +
+		"data: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"r\",\"status\":\"in_progress\"}}\n\n"
+	summary := summarizeOpenAIImagesNoOutputBody([]byte(body))
+	if !strings.HasPrefix(summary, "no_image_output") {
+		t.Fatalf("summary should start with marker, got %q", summary)
+	}
+	if !strings.Contains(summary, "last_event=response.in_progress") {
+		t.Fatalf("summary should capture last event type, got %q", summary)
+	}
+	if !strings.Contains(summary, "status=in_progress") {
+		t.Fatalf("summary should capture response status, got %q", summary)
+	}
+}
+
+// 摘要应能抓到 incomplete_reason 并对超长 body 截断。
+func TestSummarizeNoOutputBody_IncompleteReasonAndTruncation(t *testing.T) {
+	long := strings.Repeat("x", 2000)
+	body := "data: {\"type\":\"response.incomplete\",\"response\":{\"status\":\"incomplete\",\"incomplete_details\":{\"reason\":\"max_output_tokens\"},\"junk\":\"" + long + "\"}}\n\n"
+	summary := summarizeOpenAIImagesNoOutputBody([]byte(body))
+	if !strings.Contains(summary, "incomplete_reason=max_output_tokens") {
+		t.Fatalf("should capture incomplete reason, got %q", summary[:120])
+	}
+	if !strings.Contains(summary, "truncated") {
+		t.Fatalf("oversized body should be truncated, len=%d", len(summary))
+	}
+}
+
+// 软失败（上游 completed 但无图，如偶发路由到 mini 模型）应返回可重试的
+// UpstreamFailoverError 且优先同账号重试，而非一次性失败。
+func TestImagesOAuthNonStreaming_CompletedNoImageTriggersSameAccountRetry(t *testing.T) {
+	// 上游 SSE：response.completed 但 output 为空（实测的真实失败形态）。
+	upstreamSSE := "event: response.created\n" +
+		"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_x\",\"status\":\"in_progress\",\"model\":\"gpt-5.4-mini-2026-03-17\",\"output\":[]}}\n\n" +
+		"event: response.completed\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_x\",\"status\":\"completed\",\"model\":\"gpt-5.4-mini-2026-03-17\",\"output\":[],\"tool_usage\":{\"image_gen\":{\"output_tokens\":0}}}}\n\n"
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
+	}
+
+	svc := &OpenAIGatewayService{}
+	_, _, _, err := svc.handleOpenAIImagesOAuthNonStreamingResponse(resp, c, "b64_json", "gpt-image-2")
+
+	if err == nil {
+		t.Fatal("completed-but-no-image should return an error")
+	}
+	var failoverErr *UpstreamFailoverError
+	if !errors.As(err, &failoverErr) {
+		t.Fatalf("expected *UpstreamFailoverError to trigger retry, got %T: %v", err, err)
+	}
+	if failoverErr.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected 502, got %d", failoverErr.StatusCode)
+	}
+	if !failoverErr.RetryableOnSameAccount {
+		t.Fatal("soft-failure should prefer same-account retry (probabilistic upstream failure)")
+	}
+}

--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -597,8 +597,86 @@ func openAIImagesUpstreamErrorFromSSEPayload(payload []byte) *OpenAIImagesUpstre
 	case "response.failed":
 		response := gjson.GetBytes(payload, "response")
 		return openAIImagesUpstreamErrorFromGJSON(response.Get("error"), response.Get("id").String())
+	case "response.incomplete":
+		// 上游在生成预算内未产出图片（超时/被截断），返回 response.incomplete 而非 error。
+		// 旧逻辑识别不到，统一报成模糊的 "upstream did not return image output" + 502，
+		// 且不触发 failover。这里把它显式建模为可重试的上游错误，使其能换账号重试。
+		return openAIImagesIncompleteUpstreamError(gjson.GetBytes(payload, "response"))
 	default:
 		return nil
+	}
+}
+
+// summarizeOpenAIImagesNoOutputBody 从上游 SSE 响应体提取诊断摘要，用于软失败时
+// 记录到 ops 日志（上游无图、无标准错误的场景）。提取最终事件类型、response.status、
+// incomplete_details.reason，并附 body 截断片段，便于事后定位上游到底返回了什么。
+func summarizeOpenAIImagesNoOutputBody(body []byte) string {
+	var lastType, status, incompleteReason string
+	forEachOpenAISSEDataPayload(string(body), func(payload []byte) {
+		if !gjson.ValidBytes(payload) {
+			return
+		}
+		if t := strings.TrimSpace(gjson.GetBytes(payload, "type").String()); t != "" {
+			lastType = t
+		}
+		if resp := gjson.GetBytes(payload, "response"); resp.Exists() {
+			if s := strings.TrimSpace(resp.Get("status").String()); s != "" {
+				status = s
+			}
+			if r := strings.TrimSpace(resp.Get("incomplete_details.reason").String()); r != "" {
+				incompleteReason = r
+			}
+		}
+	})
+	var b strings.Builder
+	b.WriteString("no_image_output")
+	if lastType != "" {
+		fmt.Fprintf(&b, " last_event=%s", lastType)
+	}
+	if status != "" {
+		fmt.Fprintf(&b, " status=%s", status)
+	}
+	if incompleteReason != "" {
+		fmt.Fprintf(&b, " incomplete_reason=%s", incompleteReason)
+	}
+	// 附 body 截断片段（脱敏后），上限 1KB，避免日志膨胀。
+	snippet := strings.TrimSpace(string(body))
+	const maxSnippet = 1024
+	if len(snippet) > maxSnippet {
+		snippet = snippet[:maxSnippet] + "...(truncated)"
+	}
+	if snippet != "" {
+		fmt.Fprintf(&b, " body=%s", snippet)
+	}
+	return b.String()
+}
+
+// openAIImagesIncompleteUpstreamError 从 response.incomplete 事件构建可重试的上游错误。
+// incomplete_details.reason 常见取值：max_output_tokens / content_filter 等。
+// content_filter 视为客户端错误（400，重试无意义）；其余（生成超时/截断）视为
+// 可重试的 502，触发 failover 换账号重试。
+func openAIImagesIncompleteUpstreamError(response gjson.Result) *OpenAIImagesUpstreamError {
+	if !response.Exists() {
+		return nil
+	}
+	reason := strings.TrimSpace(response.Get("incomplete_details.reason").String())
+	statusCode := http.StatusBadGateway // 默认可重试（生成未完成）
+	errType := "incomplete_error"
+	if strings.Contains(strings.ToLower(reason), "content_filter") ||
+		strings.Contains(strings.ToLower(reason), "moderation") {
+		statusCode = http.StatusBadRequest // 内容过滤，重试无意义
+		errType = "image_generation_user_error"
+	}
+	message := "Upstream did not complete image generation"
+	if reason != "" {
+		message = fmt.Sprintf("Upstream image generation incomplete: %s", reason)
+	}
+	return &OpenAIImagesUpstreamError{
+		StatusCode:        statusCode,
+		ErrorType:         errType,
+		Code:              "response_incomplete",
+		Message:           sanitizeUpstreamErrorMessage(message),
+		UpstreamRequestID: strings.TrimSpace(response.Get("id").String()),
 	}
 }
 
@@ -959,7 +1037,20 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthNonStreamingResponse(
 			}
 			return OpenAIUsage{}, 0, nil, upstreamErr
 		}
-		return OpenAIUsage{}, 0, nil, fmt.Errorf("upstream did not return image output")
+		// 软失败兜底：上游既无图、又无任何可识别的 error/failed/incomplete 事件
+		// （实测：上游偶发把请求路由到 gpt-5.x-mini，返回 response.completed 但 output 为空、
+		// image_gen 工具未执行）。这是上游的概率性失败——同账号有时成功有时失败。
+		// 处理：① 记录上游诊断摘要到 ops（last_event/status/model/body 片段）便于排查；
+		// ② 返回 UpstreamFailoverError 触发重试。因实测为「同账号概率性失败」，优先
+		//    RetryableOnSameAccount 同账号快速重试（默认 3 次，大概率某次正常出图），
+		//    用尽后由 handler 自然换账号 failover（switchCount 上限保护），既提高成功率
+		//    又不无谓消耗其他账号配额。
+		setOpsUpstreamError(c, http.StatusBadGateway, "upstream did not return image output", summarizeOpenAIImagesNoOutputBody(body))
+		return OpenAIUsage{}, 0, nil, &UpstreamFailoverError{
+			StatusCode:             http.StatusBadGateway,
+			ResponseBody:           body,
+			RetryableOnSameAccount: true,
+		}
 	}
 	if strings.TrimSpace(firstMeta.Model) == "" {
 		firstMeta.Model = strings.TrimSpace(fallbackModel)
@@ -1096,6 +1187,9 @@ func (s *OpenAIGatewayService) handleOpenAIImagesOAuthStreamingResponse(
 			}
 			if len(finalResults) == 0 {
 				outputErr := fmt.Errorf("upstream did not return image output")
+				// 软失败：response.completed 事件里没有图片。记录上游诊断摘要到 ops，
+				// 与非流式路径保持一致，避免上游响应信息丢失。
+				setOpsUpstreamError(c, http.StatusBadGateway, "upstream did not return image output", summarizeOpenAIImagesNoOutputBody(dataBytes))
 				s.tryWriteOpenAIImagesStreamEvent(c, flusher, &clientDisconnected, &lastDownstreamWriteAt, "error", buildOpenAIImagesStreamErrorBody(outputErr.Error()))
 				processDataErr = outputErr
 				processDataDone = true


### PR DESCRIPTION
## 问题

`gpt-image-2` 通过 OpenAI OAuth 账号调用 `/v1/images/edits` 和 `/v1/images/generations` 时，大图 / 高分辨率 / 复杂编辑请求频繁返回 `502 upstream did not return image output`。生产日志显示这类请求耗时约 120–140 秒后失败，而简单小图请求稳定成功。

相关社区 issue：#2232、#3135、#2516（同一现象，跨多个版本复现）。

## 根因

上游 ChatGPT 图片后端在生成预算内未产出图片时（超时 / 被截断），返回 `response.incomplete` 事件，而非 `error` 或 `response.failed`。

当前 `openAIImagesUpstreamErrorFromSSEPayload` 只识别 `error` 和 `response.failed` 两种事件，导致：

1. **软失败被报成模糊的 502**，且**不触发 failover** —— 本可换账号重试的请求直接失败返回给客户端。
2. **上游真实响应未被记录** —— `ops_error_logs` 里 `upstream_error_message` / `upstream_error_detail` 全为空，无法排查。

## 修复

1. `openAIImagesUpstreamErrorFromSSEPayload` 增加 `response.incomplete` 识别：
   - 生成超时 / 截断（`max_output_tokens` 等）→ 可重试 502，触发 failover 换账号重试
   - `content_filter` / `moderation` → 400，重试无意义不重试
2. 软失败兜底（无图、无任何标准错误事件）时，记录上游诊断摘要到 ops（`last_event` / `status` / `incomplete_reason` / body 片段，截断上限 1KB），非流式 + 流式两条路径一致。

## 测试

- 新增 5 个单元测试覆盖：incomplete→可重试 502、content_filter→400 不重试、`error`/`response.failed` 旧行为不变、诊断摘要提取、超长 body 截断。
- 图片相关回归测试通过。
- 基于 v0.1.137 构建镜像在隔离环境验证：正常图片生成/编辑路径不受影响（200 成功），二进制确认含新逻辑。

## 影响

默认行为对成功路径零变更。仅改变上游软失败时的处理：从「模糊 502 + 不重试 + 无日志」变为「识别 incomplete + 触发 failover + 记录诊断」。
