### PR TITLE
[codex] fix Codex image generation transport

### DIFF
--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -550,7 +550,7 @@ func (s *OpenAIGatewayService) ForwardImages(
 	case AccountTypeAPIKey:
 		return s.forwardOpenAIImagesAPIKey(ctx, c, account, body, parsed, channelMappedModel)
 	case AccountTypeOAuth:
-		return s.forwardOpenAIImagesOAuth(ctx, c, account, parsed, channelMappedModel)
+		return s.forwardOpenAIImagesOAuthDirect(ctx, c, account, parsed, channelMappedModel)
 	default:
 		return nil, fmt.Errorf("unsupported account type: %s", account.Type)
 	}

--- a/backend/internal/service/openai_images_codex_direct.go
+++ b/backend/internal/service/openai_images_codex_direct.go
@@ -1,0 +1,636 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/imroc/req/v3"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	openAICodexImagesGenerationsURL = "https://chatgpt.com/backend-api/codex/images/generations"
+	openAICodexImagesEditsURL       = "https://chatgpt.com/backend-api/codex/images/edits"
+	openAICodexImagesOriginator     = "codex-tui"
+)
+
+func (s *OpenAIGatewayService) forwardOpenAIImagesOAuthDirect(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	parsed *OpenAIImagesRequest,
+	channelMappedModel string,
+) (*OpenAIForwardResult, error) {
+	startTime := time.Now()
+	requestModel := strings.TrimSpace(parsed.Model)
+	if mapped := strings.TrimSpace(channelMappedModel); mapped != "" {
+		requestModel = mapped
+	}
+	if requestModel == "" {
+		requestModel = "gpt-image-2"
+	}
+	if err := validateOpenAIImagesModel(requestModel); err != nil {
+		return nil, err
+	}
+	logger.LegacyPrintf(
+		"service.openai_gateway",
+		"[OpenAI] Images request routing request_model=%s endpoint=%s account_type=%s oauth_transport=codex_images uploads=%d",
+		requestModel,
+		parsed.Endpoint,
+		account.Type,
+		len(parsed.Uploads),
+	)
+
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+	defer releaseUpstreamCtx()
+
+	token, _, err := s.GetAccessToken(upstreamCtx, account)
+	if err != nil {
+		return nil, err
+	}
+
+	directBody, err := buildOpenAICodexImagesRequestBody(parsed, requestModel)
+	if err != nil {
+		return nil, err
+	}
+	upstreamReq, err := s.buildOpenAICodexImagesRequest(upstreamCtx, c, account, directBody, token, parsed.Endpoint, parsed.StickySessionSeed())
+	if err != nil {
+		return nil, err
+	}
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: 0,
+			UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+			Kind:               "request_error",
+			Message:            safeErr,
+		})
+		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+	}
+	if resp.StatusCode >= 400 {
+		respBody := s.readUpstreamErrorBody(resp)
+		_ = resp.Body.Close()
+		resp.Body = io.NopCloser(bytes.NewReader(respBody))
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+		if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody) {
+			appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+				Platform:           account.Platform,
+				AccountID:          account.ID,
+				AccountName:        account.Name,
+				UpstreamStatusCode: resp.StatusCode,
+				UpstreamRequestID:  resp.Header.Get("x-request-id"),
+				UpstreamURL:        safeUpstreamURL(upstreamReq.URL.String()),
+				Kind:               "failover",
+				Message:            upstreamMsg,
+			})
+			s.handleFailoverSideEffects(upstreamCtx, resp, account, respBody, requestModel)
+			return nil, &UpstreamFailoverError{
+				StatusCode:             resp.StatusCode,
+				ResponseBody:           respBody,
+				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			}
+		}
+		return s.handleOpenAIImagesErrorResponse(upstreamCtx, resp, c, account, requestModel)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	writerSizeBeforeResponse := c.Writer.Size()
+	usage, imageCount, imageOutputSizes, firstTokenMs, err := s.handleOpenAICodexImagesResponse(upstreamCtx, resp, c, parsed, requestModel, upstreamReq.Header, proxyURL)
+	if err != nil {
+		return nil, s.handleOpenAIImagesOAuthResponseError(
+			upstreamCtx,
+			c,
+			account,
+			requestModel,
+			safeUpstreamURL(upstreamReq.URL.String()),
+			resp,
+			writerSizeBeforeResponse,
+			err,
+		)
+	}
+	if imageCount <= 0 {
+		imageCount = parsed.N
+	}
+	return &OpenAIForwardResult{
+		RequestID:        resp.Header.Get("x-request-id"),
+		Usage:            usage,
+		Model:            requestModel,
+		UpstreamModel:    requestModel,
+		Stream:           parsed.Stream,
+		ResponseHeaders:  resp.Header.Clone(),
+		Duration:         time.Since(startTime),
+		FirstTokenMs:     firstTokenMs,
+		ImageCount:       imageCount,
+		ImageSize:        parsed.SizeTier,
+		ImageInputSize:   parsed.Size,
+		ImageOutputSizes: imageOutputSizes,
+	}, nil
+}
+
+func buildOpenAICodexImagesRequestBody(parsed *OpenAIImagesRequest, imageModel string) ([]byte, error) {
+	if parsed == nil {
+		return nil, fmt.Errorf("parsed images request is required")
+	}
+	prompt := strings.TrimSpace(parsed.Prompt)
+	if prompt == "" {
+		return nil, fmt.Errorf("prompt is required")
+	}
+
+	body := []byte(`{"model":"","prompt":"","n":1,"output_format":"png"}`)
+	body, _ = sjson.SetBytes(body, "model", strings.TrimSpace(imageModel))
+	body, _ = sjson.SetBytes(body, "prompt", prompt)
+	n := parsed.N
+	if n <= 0 {
+		n = 1
+	}
+	body, _ = sjson.SetBytes(body, "n", n)
+
+	outputFormat := strings.TrimSpace(parsed.OutputFormat)
+	if outputFormat == "" {
+		outputFormat = "png"
+	}
+	body, _ = sjson.SetBytes(body, "output_format", outputFormat)
+
+	for _, field := range []struct {
+		path  string
+		value string
+	}{
+		{path: "size", value: parsed.Size},
+		{path: "quality", value: parsed.Quality},
+		{path: "background", value: parsed.Background},
+		{path: "moderation", value: parsed.Moderation},
+	} {
+		if trimmed := strings.TrimSpace(field.value); trimmed != "" {
+			body, _ = sjson.SetBytes(body, field.path, trimmed)
+		}
+	}
+	if inputFidelity := strings.TrimSpace(parsed.InputFidelity); inputFidelity != "" && openAICodexImagesModelSupportsInputFidelity(imageModel) {
+		body, _ = sjson.SetBytes(body, "input_fidelity", inputFidelity)
+	}
+	if parsed.OutputCompression != nil {
+		body, _ = sjson.SetBytes(body, "output_compression", *parsed.OutputCompression)
+	}
+
+	if !parsed.IsEdits() {
+		return body, nil
+	}
+
+	inputImages := make([]string, 0, len(parsed.InputImageURLs)+len(parsed.Uploads))
+	for _, imageURL := range parsed.InputImageURLs {
+		if trimmed := strings.TrimSpace(imageURL); trimmed != "" {
+			inputImages = append(inputImages, trimmed)
+		}
+	}
+	for _, upload := range parsed.Uploads {
+		dataURL, err := openAIImageUploadToDataURL(upload)
+		if err != nil {
+			return nil, err
+		}
+		inputImages = append(inputImages, dataURL)
+	}
+	if len(inputImages) == 0 {
+		return nil, fmt.Errorf("image input is required")
+	}
+
+	body, _ = sjson.SetRawBytes(body, "images", []byte(`[]`))
+	for _, imageURL := range inputImages {
+		item := []byte(`{"image_url":""}`)
+		item, _ = sjson.SetBytes(item, "image_url", imageURL)
+		body, _ = sjson.SetRawBytes(body, "images.-1", item)
+	}
+
+	maskImageURL := strings.TrimSpace(parsed.MaskImageURL)
+	if parsed.MaskUpload != nil {
+		dataURL, err := openAIImageUploadToDataURL(*parsed.MaskUpload)
+		if err != nil {
+			return nil, err
+		}
+		maskImageURL = dataURL
+	}
+	if maskImageURL != "" {
+		mask := []byte(`{"image_url":""}`)
+		mask, _ = sjson.SetBytes(mask, "image_url", maskImageURL)
+		body, _ = sjson.SetRawBytes(body, "mask", mask)
+	}
+	return body, nil
+}
+
+func openAICodexImagesModelSupportsInputFidelity(model string) bool {
+	return !strings.EqualFold(strings.TrimSpace(model), "gpt-image-2")
+}
+
+func (s *OpenAIGatewayService) buildOpenAICodexImagesRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+	token string,
+	endpoint string,
+	sessionSeed string,
+) (*http.Request, error) {
+	targetURL := openAICodexImagesGenerationsURL
+	if endpoint == openAIImagesEditsEndpoint {
+		targetURL = openAICodexImagesEditsURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	req.Host = "chatgpt.com"
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Connection", "Keep-Alive")
+	req.Header.Set("Originator", openAICodexImagesOriginator)
+	req.Header.Set("User-Agent", s.openAICodexImagesUserAgent(ctx, account))
+	req.Header.Set("Session_id", generateSessionUUID(isolateOpenAISessionID(getAPIKeyIDFromContext(c), sessionSeed)))
+	req.Header.Set("X-Client-Request-Id", uuid.NewString())
+	if chatgptAccountID := account.GetChatGPTAccountID(); chatgptAccountID != "" {
+		req.Header.Set("Chatgpt-Account-Id", chatgptAccountID)
+	}
+	return req, nil
+}
+
+func (s *OpenAIGatewayService) openAICodexImagesUserAgent(ctx context.Context, account *Account) string {
+	if customUA := strings.TrimSpace(account.GetOpenAIUserAgent()); customUA != "" {
+		return customUA
+	}
+	if s != nil && s.settingService != nil {
+		if configured := strings.TrimSpace(s.settingService.GetOpenAICodexUserAgent(ctx)); configured != "" {
+			return configured
+		}
+	}
+	return DefaultOpenAICodexUserAgent
+}
+
+func (s *OpenAIGatewayService) handleOpenAICodexImagesResponse(
+	ctx context.Context,
+	resp *http.Response,
+	c *gin.Context,
+	parsed *OpenAIImagesRequest,
+	fallbackModel string,
+	upstreamHeaders http.Header,
+	proxyURL string,
+) (OpenAIUsage, int, []string, *int, error) {
+	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, nil, err
+	}
+	if openAICodexImagesLooksLikeSSE(resp, body) {
+		if parsed.Stream {
+			replay := *resp
+			replay.Body = io.NopCloser(bytes.NewReader(body))
+			return s.handleOpenAIImagesOAuthStreamingResponse(&replay, c, time.Now(), parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), fallbackModel)
+		}
+		usage, imageCount, imageOutputSizes, err := s.handleOpenAICodexImagesSSEBody(resp, c, body, parsed.ResponseFormat, fallbackModel)
+		return usage, imageCount, imageOutputSizes, nil, err
+	}
+
+	if upstreamErr := openAICodexImagesUpstreamErrorFromJSON(resp, body); upstreamErr != nil {
+		setOpsUpstreamError(c, upstreamErr.clientStatusCode(), upstreamErr.clientMessage(), "")
+		if !IsOpenAIImagesRetryableUpstreamError(upstreamErr) {
+			writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
+		}
+		return OpenAIUsage{}, 0, nil, nil, upstreamErr
+	}
+
+	usage, _ := extractOpenAIUsageFromJSONBytes(body)
+	fallbackMeta := openAIResponsesImageResult{
+		OutputFormat: strings.TrimSpace(parsed.OutputFormat),
+		Size:         strings.TrimSpace(parsed.Size),
+		Background:   strings.TrimSpace(parsed.Background),
+		Quality:      strings.TrimSpace(parsed.Quality),
+		Model:        strings.TrimSpace(fallbackModel),
+	}
+	if fallbackMeta.OutputFormat == "" {
+		fallbackMeta.OutputFormat = "png"
+	}
+	results, createdAt, usageRaw, firstMeta, err := collectOpenAICodexImagesDirectBody(ctx, upstreamHeaders, proxyURL, body, fallbackMeta)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, nil, err
+	}
+	if len(results) == 0 {
+		imageCount := extractOpenAIImageCountFromJSONBytes(body)
+		if imageCount <= 0 {
+			return OpenAIUsage{}, 0, nil, nil, fmt.Errorf("upstream did not return image output")
+		}
+		if parsed.Stream {
+			return OpenAIUsage{}, 0, nil, nil, fmt.Errorf("upstream returned unnormalizable image output")
+		}
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+		c.Data(resp.StatusCode, "application/json; charset=utf-8", body)
+		return usage, imageCount, collectOpenAIResponseImageOutputSizesFromJSONBytes(body), nil, nil
+	}
+	if parsed.Stream {
+		firstTokenMs, err := s.writeOpenAICodexImagesSyntheticStreamResponse(resp, c, parsed.ResponseFormat, openAIImagesStreamPrefix(parsed), results, createdAt, usageRaw)
+		return usage, len(results), openAIResponsesImageResultSizes(results), firstTokenMs, err
+	}
+
+	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, parsed.ResponseFormat)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, nil, err
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
+	return usage, len(results), openAIResponsesImageResultSizes(results), nil, nil
+}
+
+func openAICodexImagesLooksLikeSSE(resp *http.Response, body []byte) bool {
+	if resp != nil && isEventStreamResponse(resp.Header) {
+		return true
+	}
+	trimmed := bytes.TrimSpace(body)
+	return bytes.HasPrefix(trimmed, []byte("data:")) || bytes.Contains(trimmed, []byte("\ndata:"))
+}
+
+func (s *OpenAIGatewayService) handleOpenAICodexImagesSSEBody(
+	resp *http.Response,
+	c *gin.Context,
+	body []byte,
+	responseFormat string,
+	fallbackModel string,
+) (OpenAIUsage, int, []string, error) {
+	var usage OpenAIUsage
+	forEachOpenAISSEDataPayload(string(body), func(data []byte) {
+		s.parseSSEUsageBytes(data, &usage)
+	})
+	results, createdAt, usageRaw, firstMeta, _, err := collectOpenAIImagesFromResponsesBody(body)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, err
+	}
+	if len(results) == 0 {
+		if upstreamErr := extractOpenAIImagesUpstreamError(body); upstreamErr != nil {
+			setOpsUpstreamError(c, upstreamErr.clientStatusCode(), upstreamErr.clientMessage(), "")
+			if !IsOpenAIImagesRetryableUpstreamError(upstreamErr) {
+				writeOpenAIImagesUpstreamErrorResponse(c, upstreamErr)
+			}
+			return OpenAIUsage{}, 0, nil, upstreamErr
+		}
+		return OpenAIUsage{}, 0, nil, fmt.Errorf("upstream did not return image output")
+	}
+	if strings.TrimSpace(firstMeta.Model) == "" {
+		firstMeta.Model = strings.TrimSpace(fallbackModel)
+	}
+
+	responseBody, err := buildOpenAIImagesAPIResponse(results, createdAt, usageRaw, firstMeta, responseFormat)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, err
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Data(resp.StatusCode, "application/json; charset=utf-8", responseBody)
+	return usage, len(results), openAIResponsesImageResultSizes(results), nil
+}
+
+func openAICodexImagesUpstreamErrorFromJSON(resp *http.Response, body []byte) *OpenAIImagesUpstreamError {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return nil
+	}
+	errorObj := gjson.GetBytes(body, "error")
+	if !errorObj.Exists() {
+		return nil
+	}
+	requestID := ""
+	if resp != nil {
+		requestID = strings.TrimSpace(resp.Header.Get("x-request-id"))
+	}
+	upstreamErr := openAIImagesUpstreamErrorFromGJSON(errorObj, requestID)
+	if upstreamErr == nil {
+		return nil
+	}
+	if upstreamErr.StatusCode < http.StatusBadRequest {
+		upstreamErr.StatusCode = http.StatusBadGateway
+	}
+	return upstreamErr
+}
+
+func (s *OpenAIGatewayService) writeOpenAICodexImagesSyntheticStreamResponse(
+	resp *http.Response,
+	c *gin.Context,
+	responseFormat string,
+	streamPrefix string,
+	results []openAIResponsesImageResult,
+	createdAt int64,
+	usageRaw []byte,
+) (*int, error) {
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Status(resp.StatusCode)
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		return nil, fmt.Errorf("streaming is not supported by response writer")
+	}
+
+	firstTokenMs := 0
+	eventName := streamPrefix + ".completed"
+	for _, img := range results {
+		payload := buildOpenAIImagesStreamCompletedPayload(eventName, img, responseFormat, createdAt, usageRaw)
+		if err := s.writeOpenAIImagesStreamEvent(c, flusher, eventName, payload); err != nil {
+			return &firstTokenMs, err
+		}
+	}
+	if _, err := io.WriteString(c.Writer, "data: [DONE]\n\n"); err != nil {
+		return &firstTokenMs, err
+	}
+	flusher.Flush()
+	return &firstTokenMs, nil
+}
+
+func collectOpenAICodexImagesDirectBody(ctx context.Context, headers http.Header, proxyURL string, body []byte, fallbackMeta openAIResponsesImageResult) ([]openAIResponsesImageResult, int64, []byte, openAIResponsesImageResult, error) {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return nil, 0, nil, openAIResponsesImageResult{}, fmt.Errorf("upstream returned invalid image JSON")
+	}
+	root := gjson.ParseBytes(body)
+	createdAt := root.Get("created").Int()
+	if createdAt <= 0 {
+		createdAt = root.Get("created_at").Int()
+	}
+
+	var usageRaw []byte
+	if usage := root.Get("usage"); usage.Exists() && usage.IsObject() {
+		usageRaw = []byte(usage.Raw)
+	} else if usage := root.Get("tool_usage.image_gen"); usage.Exists() && usage.IsObject() {
+		usageRaw = []byte(usage.Raw)
+	}
+
+	firstMeta := openAIResponsesImageResult{
+		OutputFormat: strings.TrimSpace(root.Get("output_format").String()),
+		Size:         strings.TrimSpace(root.Get("size").String()),
+		Background:   strings.TrimSpace(root.Get("background").String()),
+		Quality:      strings.TrimSpace(root.Get("quality").String()),
+		Model:        strings.TrimSpace(root.Get("model").String()),
+	}
+	fillOpenAICodexImagesMeta(&firstMeta, fallbackMeta)
+
+	results := make([]openAIResponsesImageResult, 0)
+	seen := make(map[string]struct{})
+	var downloadClient *req.Client
+	var collectErr error
+	appendDirectItemResults := func(items gjson.Result) {
+		if !items.IsArray() || collectErr != nil {
+			return
+		}
+		for _, item := range items.Array() {
+			result, detectedFormat, resultErr := openAICodexImagesResultB64FromItem(ctx, &downloadClient, headers, proxyURL, item)
+			if resultErr != nil {
+				collectErr = resultErr
+				return
+			}
+			if result == "" {
+				continue
+			}
+			entry := openAIResponsesImageResult{
+				Result:        result,
+				RevisedPrompt: strings.TrimSpace(item.Get("revised_prompt").String()),
+				OutputFormat:  strings.TrimSpace(item.Get("output_format").String()),
+				Size:          strings.TrimSpace(item.Get("size").String()),
+				Background:    strings.TrimSpace(item.Get("background").String()),
+				Quality:       strings.TrimSpace(item.Get("quality").String()),
+				Model:         strings.TrimSpace(item.Get("model").String()),
+			}
+			if entry.OutputFormat == "" {
+				entry.OutputFormat = detectedFormat
+			}
+			fillOpenAICodexImagesMeta(&entry, firstMeta)
+			appendOpenAIResponsesImageResultDedup(&results, seen, "", entry)
+		}
+	}
+	appendDirectItemResults(root.Get("data"))
+	appendDirectItemResults(root.Get("output"))
+	appendDirectItemResults(root.Get("response.output"))
+	if collectErr != nil {
+		return nil, 0, nil, openAIResponsesImageResult{}, collectErr
+	}
+	return results, createdAt, usageRaw, firstMeta, nil
+}
+
+func fillOpenAICodexImagesMeta(dst *openAIResponsesImageResult, fallback openAIResponsesImageResult) {
+	if dst == nil {
+		return
+	}
+	if strings.TrimSpace(dst.OutputFormat) == "" {
+		dst.OutputFormat = strings.TrimSpace(fallback.OutputFormat)
+	}
+	if strings.TrimSpace(dst.Size) == "" {
+		dst.Size = strings.TrimSpace(fallback.Size)
+	}
+	if strings.TrimSpace(dst.Background) == "" {
+		dst.Background = strings.TrimSpace(fallback.Background)
+	}
+	if strings.TrimSpace(dst.Quality) == "" {
+		dst.Quality = strings.TrimSpace(fallback.Quality)
+	}
+	if strings.TrimSpace(dst.Model) == "" {
+		dst.Model = strings.TrimSpace(fallback.Model)
+	}
+}
+
+func openAICodexImagesResultB64FromItem(ctx context.Context, downloadClient **req.Client, headers http.Header, proxyURL string, item gjson.Result) (string, string, error) {
+	for _, path := range []string{"b64_json", "result"} {
+		if result := strings.TrimSpace(item.Get(path).String()); result != "" {
+			if b64, format := openAICodexImagesDataURLToB64(result); b64 != "" {
+				return b64, format, nil
+			}
+			return result, "", nil
+		}
+	}
+	for _, path := range []string{"url", "image_url"} {
+		value := strings.TrimSpace(item.Get(path).String())
+		if b64, format := openAICodexImagesDataURLToB64(value); b64 != "" {
+			return b64, format, nil
+		}
+		if openAICodexImagesIsHTTPURL(value) {
+			if downloadClient != nil && *downloadClient == nil {
+				client := req.C()
+				if trimmedProxy := strings.TrimSpace(proxyURL); trimmedProxy != "" {
+					client.SetProxyURL(trimmedProxy)
+				}
+				*downloadClient = client
+			}
+			if downloadClient == nil || *downloadClient == nil {
+				return "", "", fmt.Errorf("image URL downloader is unavailable")
+			}
+			imageBytes, err := downloadOpenAIImageBytes(ctx, *downloadClient, headers, value, openAIUpstreamErrorBodyReadLimit)
+			if err != nil {
+				return "", "", err
+			}
+			format := openAICodexImagesOutputFormatFromURL(value)
+			if format == "" {
+				detected := strings.ToLower(strings.TrimSpace(http.DetectContentType(imageBytes)))
+				if strings.HasPrefix(detected, "image/") {
+					format = strings.TrimPrefix(detected, "image/")
+				}
+			}
+			return base64.StdEncoding.EncodeToString(imageBytes), format, nil
+		}
+	}
+	return "", "", nil
+}
+
+func openAICodexImagesIsHTTPURL(value string) bool {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	return strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")
+}
+
+func openAICodexImagesOutputFormatFromURL(value string) string {
+	lower := strings.ToLower(strings.TrimSpace(value))
+	for _, suffix := range []struct {
+		needle string
+		format string
+	}{
+		{needle: ".png", format: "png"},
+		{needle: ".jpg", format: "jpeg"},
+		{needle: ".jpeg", format: "jpeg"},
+		{needle: ".webp", format: "webp"},
+	} {
+		if strings.Contains(lower, suffix.needle) {
+			return suffix.format
+		}
+	}
+	return ""
+}
+
+func openAICodexImagesDataURLToB64(value string) (string, string) {
+	if !strings.HasPrefix(strings.ToLower(value), "data:") {
+		return "", ""
+	}
+	comma := strings.Index(value, ",")
+	if comma < 0 {
+		return "", ""
+	}
+	meta := value[:comma]
+	if !strings.Contains(strings.ToLower(meta), ";base64") {
+		return "", ""
+	}
+	mimeType := strings.TrimPrefix(strings.Split(meta, ";")[0], "data:")
+	format := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(mimeType)), "image/")
+	return strings.TrimSpace(value[comma+1:]), format
+}

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -578,7 +578,7 @@ func findOpenAIImageTestSSEEvent(events []openAIImageTestSSEEvent, name string) 
 
 func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","size":"1024x1024","quality":"high","n":3}`)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","size":"3840x2160","quality":"high","n":3}`)
 
 	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -595,12 +595,11 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 		resp: &http.Response{
 			StatusCode: http.StatusOK,
 			Header: http.Header{
-				"Content-Type": []string{"text/event-stream"},
+				"Content-Type": []string{"application/json"},
 				"X-Request-Id": []string{"req_img_123"},
 			},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000000,\"usage\":{\"input_tokens\":11,\"output_tokens\":22,\"input_tokens_details\":{\"cached_tokens\":3},\"output_tokens_details\":{\"image_tokens\":7}},\"tool_usage\":{\"image_gen\":{\"images\":3}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMQ==\",\"revised_prompt\":\"draw a cat 1\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMg==\",\"revised_prompt\":\"draw a cat 2\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"},{\"type\":\"image_generation_call\",\"result\":\"aW1hZ2UtMw==\",\"revised_prompt\":\"draw a cat 3\",\"output_format\":\"png\",\"quality\":\"high\",\"size\":\"1024x1024\"}]}}\n\n" +
-					"data: [DONE]\n\n",
+				`{"created":1710000000,"model":"gpt-image-2","size":"3840x2160","quality":"high","output_format":"png","usage":{"input_tokens":11,"output_tokens":22,"input_tokens_details":{"cached_tokens":3},"output_tokens_details":{"image_tokens":7}},"data":[{"b64_json":"aW1hZ2UtMQ==","revised_prompt":"draw a cat 1","output_format":"png","quality":"high","size":"3840x2160"},{"b64_json":"aW1hZ2UtMg==","revised_prompt":"draw a cat 2","output_format":"png","quality":"high","size":"3840x2160"},{"b64_json":"aW1hZ2UtMw==","revised_prompt":"draw a cat 3","output_format":"png","quality":"high","size":"3840x2160"}]}`,
 			)),
 		},
 	}
@@ -626,34 +625,95 @@ func TestOpenAIGatewayServiceForwardImages_OAuthPassesNAndReturnsAllImages(t *te
 	require.Equal(t, 11, result.Usage.InputTokens)
 	require.Equal(t, 22, result.Usage.OutputTokens)
 	require.Equal(t, 7, result.Usage.ImageOutputTokens)
+	require.Equal(t, []string{"3840x2160", "3840x2160", "3840x2160"}, result.ImageOutputSizes)
 
 	require.NotNil(t, upstream.lastReq)
-	require.Equal(t, chatgptCodexURL, upstream.lastReq.URL.String())
+	require.Equal(t, openAICodexImagesGenerationsURL, upstream.lastReq.URL.String())
 	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
 	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.lastReq.Context()))
 	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
-	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
 	require.Equal(t, "acct-123", upstream.lastReq.Header.Get("chatgpt-account-id"))
-	require.Equal(t, "responses=experimental", upstream.lastReq.Header.Get("OpenAI-Beta"))
+	require.Equal(t, openAICodexImagesOriginator, upstream.lastReq.Header.Get("Originator"))
+	require.Equal(t, DefaultOpenAICodexUserAgent, upstream.lastReq.Header.Get("User-Agent"))
+	require.NotEmpty(t, upstream.lastReq.Header.Get("Session_id"))
+	require.NotEmpty(t, upstream.lastReq.Header.Get("X-Client-Request-Id"))
+	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
 
-	require.Equal(t, openAIImagesResponsesMainModel, gjson.GetBytes(upstream.lastBody, "model").String())
-	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
-	require.Equal(t, "image_generation", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
-	require.Equal(t, "generate", gjson.GetBytes(upstream.lastBody, "tools.0.action").String())
-	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "tools.0.model").String())
-	require.Equal(t, "1024x1024", gjson.GetBytes(upstream.lastBody, "tools.0.size").String())
-	require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "tools.0.quality").String())
-	require.Equal(t, int64(3), gjson.GetBytes(upstream.lastBody, "tools.0.n").Int())
-	require.Equal(t, "draw a cat", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "draw a cat", gjson.GetBytes(upstream.lastBody, "prompt").String())
+	require.Equal(t, "3840x2160", gjson.GetBytes(upstream.lastBody, "size").String())
+	require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "quality").String())
+	require.Equal(t, "png", gjson.GetBytes(upstream.lastBody, "output_format").String())
+	require.Equal(t, int64(3), gjson.GetBytes(upstream.lastBody, "n").Int())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "stream").Exists())
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Equal(t, "gpt-image-2", gjson.Get(rec.Body.String(), "model").String())
+	require.Equal(t, "3840x2160", gjson.Get(rec.Body.String(), "size").String())
 	require.Len(t, gjson.Get(rec.Body.String(), "data").Array(), 3)
 	require.Equal(t, "aW1hZ2UtMQ==", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
 	require.Equal(t, "aW1hZ2UtMg==", gjson.Get(rec.Body.String(), "data.1.b64_json").String())
 	require.Equal(t, "aW1hZ2UtMw==", gjson.Get(rec.Body.String(), "data.2.b64_json").String())
 	require.Equal(t, "draw a cat 1", gjson.Get(rec.Body.String(), "data.0.revised_prompt").String())
 	require.Equal(t, "draw a cat 3", gjson.Get(rec.Body.String(), "data.2.revised_prompt").String())
+}
+
+func TestOpenAIGatewayServiceForwardImages_OAuthDirectDownloadsURLResponseAsB64(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/image.png", r.URL.Path)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("downloaded-image"))
+	}))
+	defer imageServer.Close()
+
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","response_format":"b64_json","size":"2048x1152"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+				"X-Request-Id": []string{"req_img_url"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				`{"created":1710000005,"model":"gpt-image-2","size":"2048x1152","data":[{"url":"` + imageServer.URL + `/image.png","revised_prompt":"draw a cat","size":"2048x1152"}]}`,
+			)),
+		},
+	}
+	svc.httpUpstream = upstream
+
+	account := &Account{
+		ID:       11,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, []string{"2048x1152"}, result.ImageOutputSizes)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "ZG93bmxvYWRlZC1pbWFnZQ==", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
+	require.Equal(t, "2048x1152", gjson.Get(rec.Body.String(), "size").String())
+	require.False(t, gjson.Get(rec.Body.String(), "data.0.url").Exists())
 }
 
 func TestOpenAIGatewayServiceForwardImages_OAuthUpstreamHTTPErrorSurfacesRealError(t *testing.T) {
@@ -1262,6 +1322,69 @@ func TestOpenAIGatewayServiceForwardImages_OAuthStreamingTransformsEvents(t *tes
 	require.False(t, gjson.Get(completed.Data, "revised_prompt").Exists())
 }
 
+func TestOpenAIGatewayServiceForwardImages_OAuthStreamingDirectJSONPreserves4KSize(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true,"response_format":"url","size":"3840x2160","quality":"high"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+
+	svc := &OpenAIGatewayService{}
+	parsed, err := svc.ParseOpenAIImagesRequest(c, body)
+	require.NoError(t, err)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type": []string{"application/json"},
+				"X-Request-Id": []string{"req_img_stream_direct"},
+			},
+			Body: io.NopCloser(strings.NewReader(
+				`{"created":1710000010,"model":"gpt-image-2","size":"3840x2160","quality":"high","output_format":"png","usage":{"input_tokens":5,"output_tokens":9,"output_tokens_details":{"image_tokens":4}},"data":[{"b64_json":"ZmluYWw=","output_format":"png","quality":"high","size":"3840x2160"}]}`,
+			)),
+		},
+	}
+	svc.httpUpstream = upstream
+
+	account := &Account{
+		ID:       12,
+		Name:     "openai-oauth",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "token-123",
+		},
+	}
+
+	result, err := svc.ForwardImages(context.Background(), c, account, body, parsed, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.Stream)
+	require.Equal(t, 1, result.ImageCount)
+	require.Equal(t, []string{"3840x2160"}, result.ImageOutputSizes)
+	require.Equal(t, openAICodexImagesGenerationsURL, upstream.lastReq.URL.String())
+	require.Equal(t, "3840x2160", gjson.GetBytes(upstream.lastBody, "size").String())
+	require.Equal(t, "high", gjson.GetBytes(upstream.lastBody, "quality").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
+
+	events := parseOpenAIImageTestSSEEvents(rec.Body.String())
+	_, hasPartial := findOpenAIImageTestSSEEvent(events, "image_generation.partial_image")
+	require.False(t, hasPartial)
+	completed, ok := findOpenAIImageTestSSEEvent(events, "image_generation.completed")
+	require.True(t, ok)
+	require.Equal(t, "image_generation.completed", gjson.Get(completed.Data, "type").String())
+	require.Equal(t, int64(1710000010), gjson.Get(completed.Data, "created_at").Int())
+	require.Equal(t, "ZmluYWw=", gjson.Get(completed.Data, "b64_json").String())
+	require.Equal(t, "data:image/png;base64,ZmluYWw=", gjson.Get(completed.Data, "url").String())
+	require.Equal(t, "3840x2160", gjson.Get(completed.Data, "size").String())
+	require.Equal(t, "high", gjson.Get(completed.Data, "quality").String())
+	require.JSONEq(t, `{"input_tokens":5,"output_tokens":9,"output_tokens_details":{"image_tokens":4}}`, gjson.Get(completed.Data, "usage").Raw)
+}
+
 func TestOpenAIGatewayServiceForwardImages_APIKeyStreamingDrainsAfterClientDisconnect(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{"model":"gpt-image-2","prompt":"draw a cat","stream":true}`)
@@ -1317,7 +1440,7 @@ func TestOpenAIGatewayServiceForwardImages_APIKeyStreamingDrainsAfterClientDisco
 	require.Equal(t, 2, result.Usage.ImageOutputTokens)
 }
 
-func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t *testing.T) {
+func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesCodexImagesAPI(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	var body bytes.Buffer
@@ -1361,12 +1484,11 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t
 		resp: &http.Response{
 			StatusCode: http.StatusOK,
 			Header: http.Header{
-				"Content-Type": []string{"text/event-stream"},
+				"Content-Type": []string{"application/json"},
 				"X-Request-Id": []string{"req_img_edit_123"},
 			},
 			Body: io.NopCloser(strings.NewReader(
-				"data: {\"type\":\"response.completed\",\"response\":{\"created_at\":1710000002,\"usage\":{\"input_tokens\":13,\"output_tokens\":21,\"output_tokens_details\":{\"image_tokens\":8}},\"tool_usage\":{\"image_gen\":{\"images\":1}},\"output\":[{\"type\":\"image_generation_call\",\"result\":\"ZWRpdGVk\",\"revised_prompt\":\"replace background with aurora\",\"output_format\":\"webp\",\"quality\":\"high\"}]}}\n\n" +
-					"data: [DONE]\n\n",
+				`{"created":1710000002,"model":"gpt-image-2","output_format":"webp","quality":"high","usage":{"input_tokens":13,"output_tokens":21,"output_tokens_details":{"image_tokens":8}},"data":[{"b64_json":"ZWRpdGVk","revised_prompt":"replace background with aurora","output_format":"webp","quality":"high"}]}`,
 			)),
 		},
 	}
@@ -1386,13 +1508,20 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsMultipartUsesResponsesAPI(t
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 1, result.ImageCount)
-	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "tools.0.model").String())
-	require.Equal(t, "edit", gjson.GetBytes(upstream.lastBody, "tools.0.action").String())
-	require.False(t, gjson.GetBytes(upstream.lastBody, "tools.0.input_fidelity").Exists())
-	require.Equal(t, "webp", gjson.GetBytes(upstream.lastBody, "tools.0.output_format").String())
-	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "input.0.content.1.image_url").String(), "data:image/png;base64,"))
-	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "tools.0.input_image_mask.image_url").String(), "data:image/png;base64,"))
-	require.Equal(t, "replace background with aurora", gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String())
+	require.Equal(t, 13, result.Usage.InputTokens)
+	require.Equal(t, 21, result.Usage.OutputTokens)
+	require.Equal(t, 8, result.Usage.ImageOutputTokens)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, openAICodexImagesEditsURL, upstream.lastReq.URL.String())
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "replace background with aurora", gjson.GetBytes(upstream.lastBody, "prompt").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input_fidelity").Exists())
+	require.Equal(t, "webp", gjson.GetBytes(upstream.lastBody, "output_format").String())
+	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "images.0.image_url").String(), "data:image/png;base64,"))
+	require.True(t, strings.HasPrefix(gjson.GetBytes(upstream.lastBody, "mask.image_url").String(), "data:image/png;base64,"))
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
 	require.Equal(t, "ZWRpdGVk", gjson.Get(rec.Body.String(), "data.0.b64_json").String())
 	require.Equal(t, "replace background with aurora", gjson.Get(rec.Body.String(), "data.0.revised_prompt").String())
 }
@@ -1448,9 +1577,12 @@ func TestOpenAIGatewayServiceForwardImages_OAuthEditsStreamingTransformsEvents(t
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, 1, result.ImageCount)
-	require.Equal(t, "edit", gjson.GetBytes(upstream.lastBody, "tools.0.action").String())
-	require.Equal(t, "https://example.com/source.png", gjson.GetBytes(upstream.lastBody, "input.0.content.1.image_url").String())
-	require.Equal(t, "https://example.com/mask.png", gjson.GetBytes(upstream.lastBody, "tools.0.input_image_mask.image_url").String())
+	require.Equal(t, openAICodexImagesEditsURL, upstream.lastReq.URL.String())
+	require.Equal(t, "gpt-image-2", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "replace background with aurora", gjson.GetBytes(upstream.lastBody, "prompt").String())
+	require.Equal(t, "https://example.com/source.png", gjson.GetBytes(upstream.lastBody, "images.0.image_url").String())
+	require.Equal(t, "https://example.com/mask.png", gjson.GetBytes(upstream.lastBody, "mask.image_url").String())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tools").Exists())
 	events := parseOpenAIImageTestSSEEvents(rec.Body.String())
 	partial, ok := findOpenAIImageTestSSEEvent(events, "image_edit.partial_image")
 	require.True(t, ok)


### PR DESCRIPTION
## What changed

This PR routes OpenAI OAuth image generation/edit requests through ChatGPT's dedicated Codex images endpoints instead of the Responses API image tool path.

- Use `/backend-api/codex/images/generations` and `/backend-api/codex/images/edits` for OAuth image accounts.
- Preserve native image request fields such as `size`, `quality`, `background`, `output_format`, `output_compression`, and `n`.
- Normalize Codex image responses back into the existing OpenAI Images API shape.
- Convert URL-only upstream image outputs to `b64_json` when requested by downstream clients.
- Preserve synthetic SSE compatibility for downstream `stream: true` callers.

## Why

The previous OAuth image path wrapped image requests inside the Responses API image-generation tool. That path did not reliably preserve native `gpt-image-2` behavior, especially large output sizes such as `3840x2160`, and it made multi-image `n` handling depend on the Responses tool wrapper.

The dedicated Codex images endpoint accepts the native image payload directly, so `gpt-image-2` 2K/4K requests and `n` are passed to the upstream service without being translated into tool arguments.

## Validation

- `go test -tags unit ./internal/service -run 'TestOpenAIGatewayServiceForwardImages|TestOpenAIGatewayServiceParseOpenAIImagesRequest|TestBuildOpenAIImagesURL'`
- Live deployment smoke tested separately with `gpt-image-2` 4K generation returning `3840x2160`.
