### PR TITLE
fix(lint): check WriteString return value to fix errcheck failure on main

### DIFF
--- a/backend/internal/service/openai_images_responses.go
+++ b/backend/internal/service/openai_images_responses.go
@@ -629,7 +629,7 @@ func summarizeOpenAIImagesNoOutputBody(body []byte) string {
 		}
 	})
 	var b strings.Builder
-	b.WriteString("no_image_output")
+	_, _ = b.WriteString("no_image_output")
 	if lastType != "" {
 		fmt.Fprintf(&b, " last_event=%s", lastType)
 	}


### PR DESCRIPTION
## What

The `golangci-lint` job on `main` is currently red. `errcheck` flags an unchecked `(*strings.Builder).WriteString` return value:

```
backend/internal/service/openai_images_responses.go:632:15: Error return value of (*strings.Builder).WriteString is not checked (errcheck)
```

This was introduced in the recently merged `summarizeOpenAIImagesNoOutputBody` helper.

## Fix

Explicitly discard the return values with `_, _ =`, matching the existing convention used elsewhere in the package (e.g. `gateway_service.go`).

## Scope

Single-line change. No behavior change — `strings.Builder.WriteString` never returns a non-nil error; this only satisfies the linter and turns `main` green again so it doesn't block other contributors' CI runs.

```diff
-	b.WriteString("no_image_output")
+	_, _ = b.WriteString("no_image_output")
```
