### PR TITLE
fix: stop per-request fallback-pricing log spam for unknown models (#3394)

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -168,6 +169,11 @@ type BillingService struct {
 	cfg            *config.Config
 	pricingService *PricingService
 	fallbackPrices map[string]*ModelPricing // 硬编码回退价格
+
+	// fallbackWarnSeen 记录已打过 fallback 警告日志的(已小写化)模型名,
+	// 让 "[Billing] Using fallback pricing" 每个模型每进程最多打一条,
+	// 避免热路径上每请求刷屏(issue #3394)。零值即可用,无需在构造函数初始化。
+	fallbackWarnSeen sync.Map
 }
 
 // NewBillingService 创建计费服务实例
@@ -699,7 +705,11 @@ func (s *BillingService) GetModelPricing(model string) (*ModelPricing, error) {
 	// 2. 使用硬编码回退价格
 	fallback := s.getFallbackPricing(model)
 	if fallback != nil {
-		log.Printf("[Billing] Using fallback pricing for model: %s", model)
+		// 按模型名去重:每个模型每进程最多打一条 warn,避免热路径每请求刷屏（issue #3394）。
+		// model 在函数入口已 ToLower,故 GLM-5.2 / glm-5.2 视为同一条目。
+		if _, seen := s.fallbackWarnSeen.LoadOrStore(model, struct{}{}); !seen {
+			log.Printf("[Billing] Using fallback pricing for model: %s", model)
+		}
 		return s.applyModelSpecificPricingPolicy(model, fallback), nil
 	}
 

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -3,12 +3,31 @@
 package service
 
 import (
+	"bytes"
+	"log"
 	"math"
+	"strings"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
 )
+
+// captureStdLog 重定向 stdlib log 输出到 buffer,返回该 buffer;通过 t.Cleanup 还原。
+// 用于断言 GetModelPricing 的 fallback warn(log.Printf)打了几次。
+func captureStdLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+	return &buf
+}
 
 func newTestBillingService() *BillingService {
 	return NewBillingService(&config.Config{}, nil)
@@ -103,6 +122,53 @@ func TestGetModelPricing_CaseInsensitive(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, p1.InputPricePerToken, p2.InputPricePerToken)
+}
+
+// issue #3394: fallback warn 应按模型名去重,每个模型每进程最多打一条,
+// 避免热路径每请求刷屏 ops_system_logs。
+func TestGetModelPricing_FallbackWarnLoggedOncePerModel(t *testing.T) {
+	svc := newTestBillingService()
+	buf := captureStdLog(t)
+
+	// glm-5.2 不在 LiteLLM,经 strings.Contains 命中 glm-5 兜底价 → 触发 fallback warn。
+	for i := 0; i < 5; i++ {
+		pricing, err := svc.GetModelPricing("glm-5.2")
+		require.NoError(t, err)
+		require.NotNil(t, pricing)
+	}
+
+	got := strings.Count(buf.String(), "Using fallback pricing for model: glm-5.2")
+	require.Equal(t, 1, got, "同一模型的 fallback warn 应只打一条,实际日志:\n%s", buf.String())
+}
+
+// 去重按"每模型"而非全局:不同模型各打一条;大小写变体经入口 ToLower 归一,视为同一条目。
+func TestGetModelPricing_FallbackWarnPerModelNotGlobal(t *testing.T) {
+	svc := newTestBillingService()
+	buf := captureStdLog(t)
+
+	for i := 0; i < 3; i++ {
+		_, _ = svc.GetModelPricing("glm-5.2")
+		_, _ = svc.GetModelPricing("GLM-5.2") // 与上一行同模型(ToLower 后),去重后不再打
+		_, _ = svc.GetModelPricing("glm-4.6")
+	}
+
+	out := buf.String()
+	require.Equal(t, 1, strings.Count(out, "model: glm-5.2"), out)
+	require.Equal(t, 1, strings.Count(out, "model: glm-4.6"), out)
+	require.Equal(t, 0, strings.Count(out, "model: GLM-5.2"), out) // 大写经 ToLower 归一,不应单独成行
+}
+
+// 回归:glm-5.2 仍解析到 glm-5 兜底价(计费金额不变,防止日志改动掩盖未来计费回归)。
+func TestGetModelPricing_GLM52FallsBackToGLM5Price(t *testing.T) {
+	svc := newTestBillingService()
+
+	got, err := svc.GetModelPricing("glm-5.2")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// glm-5 base：Input 1e-6 / Output 3.2e-6(见 TestGetFallbackPricing_FamilyMatching)。
+	require.InDelta(t, 1e-6, got.InputPricePerToken, 1e-12)
+	require.InDelta(t, 3.2e-6, got.OutputPricePerToken, 1e-12)
 }
 
 func TestGetModelPricing_UnknownClaudeModelFallsBackToSonnet(t *testing.T) {

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -983,7 +983,8 @@ func detectConflicts(entries []modelEntry, platform, errCode, label string) erro
 		for j := i + 1; j < len(entries); j++ {
 			if conflictsBetween(entries[i], entries[j]) {
 				return infraerrors.BadRequest(errCode,
-					fmt.Sprintf("%s '%s' and '%s' conflict in platform '%s': overlapping match range",
+					fmt.Sprintf("%s '%s' and '%s' conflict in platform '%s': overlapping match range "+
+						"(model names are matched case-insensitively, so an existing entry already covers all case variants)",
 						label, entries[i].pattern, entries[j].pattern, platform))
 			}
 		}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2407,8 +2407,8 @@ export default {
       deleteError: 'Failed to delete channel',
       nameRequired: 'Please enter a channel name',
       duplicateModels: 'Model "{0}" appears in multiple pricing entries',
-      modelConflict: "Model patterns '{model1}' and '{model2}' conflict: overlapping match range",
-      mappingConflict: "Mapping source patterns '{model1}' and '{model2}' conflict: overlapping match range",
+      modelConflict: "Model patterns '{model1}' and '{model2}' conflict: overlapping match range. Model names are matched case-insensitively, so an existing entry already covers all case variants — no need to add the variant separately.",
+      mappingConflict: "Mapping source patterns '{model1}' and '{model2}' conflict: overlapping match range. Source patterns are matched case-insensitively, so an existing entry already covers all case variants.",
       deleteConfirm: 'Are you sure you want to delete channel "{name}"? This cannot be undone.',
       columns: {
         name: 'Name',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2484,8 +2484,8 @@ export default {
       deleteError: '删除渠道失败',
       nameRequired: '请输入渠道名称',
       duplicateModels: '模型「{0}」在多个定价条目中重复',
-      modelConflict: "模型模式 '{model1}' 和 '{model2}' 冲突：匹配范围重叠",
-      mappingConflict: "模型映射源 '{model1}' 和 '{model2}' 冲突：匹配范围重叠",
+      modelConflict: "模型模式 '{model1}' 和 '{model2}' 冲突：匹配范围重叠。模型名称按大小写不敏感匹配，已有条目已覆盖其所有大小写变体，无需重复添加。",
+      mappingConflict: "模型映射源 '{model1}' 和 '{model2}' 冲突：匹配范围重叠。源模式按大小写不敏感匹配，已有条目已覆盖其所有大小写变体。",
       deleteConfirm: '确定要删除渠道「{name}」吗？此操作不可撤销。',
       columns: {
         name: '名称',


### PR DESCRIPTION
## 背景 / Background

修复 #3394。Reporter 报告 `glm-5.2`(小写)无法匹配渠道定价、计费走 fallback 并每天打上万条 warn,且后台无法添加 `glm-5.2`(与已有 `GLM-5.2` 冲突),推断是「计费大小写敏感、冲突检测大小写不敏感」。

经核查,**reporter 的根因判断不成立**:

- **渠道定价匹配本来就大小写不敏感**:缓存按 `strings.ToLower(model)` 建键(`channel_service.go:225`),查询也先 `ToLower`(`:475`),已有测试 `TestGetChannelModelPricing_CaseInsensitive` 佐证。已配置的 `GLM-5.2` 本来就会对 `glm-5.2` 请求生效,**计费正确**。
- **冲突检测同样大小写不敏感且一致**(`toModelEntry` 在 `:932` 先 `ToLower`),所以拦截「再加 `glm-5.2`」是**正确行为**——`GLM-5.2` 已覆盖所有大小写变体。

**真正的问题只是日志刷屏**:`ModelPricingResolver.Resolve` 每次请求都无条件调用 `resolveBasePricing` → `BillingService.GetModelPricing`;`glm-5.2` 不在 LiteLLM,经 `strings.Contains("glm-5.2","glm-5")` 命中 `glm-5` 兜底价,于是 `billing_service.go:702` 每次请求都打 `[Billing] Using fallback pricing for model: glm-5.2`。这条 warn 经 stdlib log 桥接被判为 WARN 写入 `ops_system_logs`,即便渠道定价随后覆盖了价格仍照打。该 warn 来源不止 resolver(还有 `account_stats_pricing.go`、非渠道计费路径、admin 查询)。

## 改动 / Changes

**Backend** (`7c2fee6c`)
- `billing_service.go`:在 `GetModelPricing` 源头用 `sync.Map` 按已小写化的模型名去重 fallback warn,每个模型每进程最多打一条(保留一条 WARN 审计线索)。一处收口覆盖所有调用点;**计费金额完全不变**;`GetModelPricing` 公开签名不变;不跳过 base pricing 解析(渠道覆盖只替换非 nil 字段,跳过会改变计费)。dedup map 受兜底白名单约束,不会无限增长(未知模型返回 nil、不入 map)。
- `channel_service.go`:冲突报错文案补充「模型名按大小写不敏感匹配,已有条目已覆盖所有大小写变体」。
- `billing_service_test.go`:新增测试——同一模型 warn 只打一次、按模型而非全局去重、`glm-5.2` 仍解析到 `glm-5` 价格(计费回归保护)。

**Frontend** (`6239e395`)
- `en.ts` / `zh.ts`:`modelConflict` / `mappingConflict` 文案说明大小写不敏感,无需重复添加大小写变体——消解 reporter 的核心困惑。

## 明确未采纳 / Deliberately not done

- **不采纳 issue 的「方案 B」**(让 `glm-5.2`/`GLM-5.2` 共存):缓存按 `ToLower` 建键,两者会塌缩成同一 key、后写覆盖先写,反而是真 bug。
- **不新增 `glm-5.2` 兜底价**:它不是确认存在的独立 SKU,用户已用渠道定价自定义。若确认是有独立定价的真 SKU,正解是加 LiteLLM/兜底条目(可另开)。

## 测试 / Testing

- `go build ./...` 通过;`go test -tags=unit ./internal/service/` 全过;`gofmt` 干净。
- `pnpm lint:check`(0 error)、`pnpm typecheck` 通过。

Fixes #3394

🤖 Generated with [Claude Code](https://claude.com/claude-code)