### PR TITLE
fix(payment): 订阅套餐订单应用 BALANCE_RECHARGE_MULTIPLIER 汇率换算

### DIFF
--- a/backend/internal/service/payment_amounts.go
+++ b/backend/internal/service/payment_amounts.go
@@ -23,6 +23,14 @@ func calculateCreditedBalance(paymentAmount, multiplier float64) float64 {
 		InexactFloat64()
 }
 
+func calculateGatewayPaymentAmount(orderAmount, multiplier float64, currency string) float64 {
+	fractionDigits := int32(payment.CurrencyMaxFractionDigits(currency))
+	return decimal.NewFromFloat(orderAmount).
+		Div(decimal.NewFromFloat(normalizeBalanceRechargeMultiplier(multiplier))).
+		Round(fractionDigits).
+		InexactFloat64()
+}
+
 func calculateGatewayRefundAmount(orderAmount, payAmount, refundAmount float64, currency string) float64 {
 	if orderAmount <= 0 || payAmount <= 0 || refundAmount <= 0 {
 		return 0

--- a/backend/internal/service/payment_order.go
+++ b/backend/internal/service/payment_order.go
@@ -67,7 +67,7 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 			return nil, err
 		}
 	}
-	payAmountStr, payAmount, err := calculateCreateOrderPayAmount(limitAmount, feeRate, methodCurrency)
+	payAmountStr, payAmount, err := calculateCreateOrderPayAmountForOrder(req.OrderType, limitAmount, feeRate, cfg.BalanceRechargeMultiplier, methodCurrency)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 		selectedCurrency = paymentProviderConfigCurrency(sel.ProviderKey, sel.Config)
 	}
 	if selectedCurrency != methodCurrency {
-		payAmountStr, payAmount, err = calculateCreateOrderPayAmount(limitAmount, feeRate, selectedCurrency)
+		payAmountStr, payAmount, err = calculateCreateOrderPayAmountForOrder(req.OrderType, limitAmount, feeRate, cfg.BalanceRechargeMultiplier, selectedCurrency)
 		if err != nil {
 			return nil, err
 		}
@@ -610,6 +610,19 @@ func calculateCreateOrderPayAmount(limitAmount, feeRate float64, currency string
 			WithMetadata(map[string]string{"currency": currency})
 	}
 	return payAmountStr, payAmount, nil
+}
+
+func calculateCreateOrderPayAmountForOrder(orderType string, limitAmount, feeRate, multiplier float64, currency string) (string, float64, error) {
+	paymentAmount := calculateCreateOrderPaymentAmount(orderType, limitAmount, multiplier, currency)
+	return calculateCreateOrderPayAmount(paymentAmount, feeRate, currency)
+}
+
+func calculateCreateOrderPaymentAmount(orderType string, limitAmount, multiplier float64, currency string) float64 {
+	normalizedCurrency, err := payment.NormalizePaymentCurrency(currency)
+	if err != nil || normalizedCurrency != payment.DefaultPaymentCurrency || orderType != payment.OrderTypeSubscription {
+		return limitAmount
+	}
+	return calculateGatewayPaymentAmount(limitAmount, multiplier, normalizedCurrency)
 }
 
 func validateCreateOrderAmountCurrency(amount float64, currency string) error {

--- a/backend/internal/service/payment_order_result_test.go
+++ b/backend/internal/service/payment_order_result_test.go
@@ -126,6 +126,72 @@ func TestCalculateCreateOrderPayAmountUsesCurrencyPrecision(t *testing.T) {
 	}
 }
 
+func TestCalculateCreateOrderPayAmountForSubscriptionAppliesCNYMultiplier(t *testing.T) {
+	t.Parallel()
+
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrder(payment.OrderTypeSubscription, 7.99, 0, 0.14, "CNY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if amountStr != "57.07" || amount != 57.07 {
+		t.Fatalf("subscription CNY pay amount = (%q, %v), want (57.07, 57.07)", amountStr, amount)
+	}
+}
+
+func TestCalculateCreateOrderPayAmountForSubscriptionDefaultMultiplierKeepsPrice(t *testing.T) {
+	t.Parallel()
+
+	for _, multiplier := range []float64{0, 1} {
+		amountStr, amount, err := calculateCreateOrderPayAmountForOrder(payment.OrderTypeSubscription, 7.99, 0, multiplier, "CNY")
+		if err != nil {
+			t.Fatalf("unexpected error for multiplier %v: %v", multiplier, err)
+		}
+		if amountStr != "7.99" || amount != 7.99 {
+			t.Fatalf("multiplier %v pay amount = (%q, %v), want (7.99, 7.99)", multiplier, amountStr, amount)
+		}
+	}
+}
+
+func TestCalculateCreateOrderPayAmountForSubscriptionDoesNotConvertNonCNY(t *testing.T) {
+	t.Parallel()
+
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrder(payment.OrderTypeSubscription, 7.99, 0, 0.14, "USD")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if amountStr != "7.99" || amount != 7.99 {
+		t.Fatalf("subscription USD pay amount = (%q, %v), want (7.99, 7.99)", amountStr, amount)
+	}
+}
+
+func TestCalculateCreateOrderPayAmountForSubscriptionMatchesBalanceRechargeRatio(t *testing.T) {
+	t.Parallel()
+
+	credited := calculateCreditedBalance(10, 0.14)
+	if credited != 1.4 {
+		t.Fatalf("credited balance = %v, want 1.4", credited)
+	}
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrder(payment.OrderTypeSubscription, credited, 0, 0.14, "CNY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if amountStr != "10.00" || amount != 10 {
+		t.Fatalf("subscription CNY pay amount = (%q, %v), want (10.00, 10)", amountStr, amount)
+	}
+}
+
+func TestCalculateCreateOrderPayAmountForSubscriptionAppliesFeeAfterMultiplier(t *testing.T) {
+	t.Parallel()
+
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrder(payment.OrderTypeSubscription, 7.99, 2.5, 0.14, "CNY")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if amountStr != "58.50" || amount != 58.5 {
+		t.Fatalf("subscription CNY pay amount with fee = (%q, %v), want (58.50, 58.5)", amountStr, amount)
+	}
+}
+
 func TestCalculateCreateOrderPayAmountRejectsFractionalZeroDecimal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 背景

Issue #3376 反馈配置 BALANCE_RECHARGE_MULTIPLIER（例如 0.14，1 CNY = 0.14 USD）并使用 CNY 支付通道时，订阅套餐订单的 pay_amount 直接等于 USD 计价的套餐 price，导致支付宝等 CNY 通道实际收款金额严重偏低（约少收 86%）。余额充值订单已在 #1655 中按相同 multiplier 正确换算。

## 改动

- 订阅套餐订单在 CNY 支付通道下按套餐 USD 价格除以 BALANCE_RECHARGE_MULTIPLIER 计算支付基准金额，例如 7.99 / 0.14 = 57.07。
- 非 CNY 通道、multiplier 未配置或为 1 时保持原有 pay_amount = price 行为。
- 保留 amount 表示套餐 USD 价值、pay_amount 表示实际通道收款金额的语义，与余额充值订单口径对齐。
- 继续复用现有 RechargeFeeRate 计算：fee rate 会在 CNY 汇率换算后的支付基准金额上叠加，与余额充值 fee 处理保持一致。
- 增加单测覆盖 CNY multiplier、默认 multiplier、非 CNY 通道、与余额充值比例一致，以及 fee rate 叠加。

## 测试

- cd backend && go test -tags=unit ./...
- cd backend && go test -tags=integration ./...
- cd backend && golangci-lint run ./...

Fixes #3376