### PR TITLE
feat(openai): support custom upstream request headers

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -532,6 +532,9 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		isOAuth = true
 		// OAuth - use Bearer token with ChatGPT internal API
 		authToken = account.GetOpenAIAccessToken()
+		if hasOpenAICustomAuthorization(account) {
+			authToken = openAICustomAuthorizationTokenPlaceholder
+		}
 		if authToken == "" {
 			return s.sendErrorAndEnd(c, "No access token available")
 		}
@@ -594,6 +597,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 			req.Header.Set("chatgpt-account-id", chatgptAccountID)
 		}
 	}
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 
 	// Get proxy URL
 	proxyURL := ""
@@ -664,6 +668,7 @@ func (s *AccountTestService) testOpenAIChatCompletionsConnection(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Authorization", "Bearer "+authToken)
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {
@@ -705,6 +710,9 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 	case account.IsOAuth():
 		isOAuth = true
 		authToken = account.GetOpenAIAccessToken()
+		if hasOpenAICustomAuthorization(account) {
+			authToken = openAICustomAuthorizationTokenPlaceholder
+		}
 		if authToken == "" {
 			return s.sendErrorAndEnd(c, "No access token available")
 		}
@@ -760,6 +768,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 			req.Header.Set("chatgpt-account-id", chatgptAccountID)
 		}
 	}
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {
@@ -1511,6 +1520,7 @@ func (s *AccountTestService) testOpenAIImageAPIKey(c *gin.Context, ctx context.C
 	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+authToken)
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {
@@ -1567,6 +1577,9 @@ func (s *AccountTestService) testOpenAIImageAPIKey(c *gin.Context, ctx context.C
 // testOpenAIImageOAuth tests OpenAI image generation using an OAuth account via Codex /responses API.
 func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Context, account *Account, modelID, prompt string) error {
 	authToken := account.GetOpenAIAccessToken()
+	if hasOpenAICustomAuthorization(account) {
+		authToken = openAICustomAuthorizationTokenPlaceholder
+	}
 	if authToken == "" {
 		return s.sendErrorAndEnd(c, "No access token available")
 	}
@@ -1612,6 +1625,7 @@ func (s *AccountTestService) testOpenAIImageOAuth(c *gin.Context, ctx context.Co
 	if chatgptAccountID := strings.TrimSpace(account.GetChatGPTAccountID()); chatgptAccountID != "" {
 		req.Header.Set("chatgpt-account-id", chatgptAccountID)
 	}
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 
 	proxyURL := ""
 	if account.ProxyID != nil && account.Proxy != nil {

--- a/backend/internal/service/openai_custom_headers.go
+++ b/backend/internal/service/openai_custom_headers.go
@@ -1,0 +1,181 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"golang.org/x/net/http/httpguts"
+)
+
+const openAICustomHeadersExtraKey = "openai_custom_headers"
+const openAICustomAuthorizationTokenPlaceholder = "__sub2api_openai_custom_authorization__"
+
+var openAICustomHeaderForbiddenNames = map[string]struct{}{
+	"accept":                   {},
+	"chatgpt-account-id":       {},
+	"connection":               {},
+	"content-length":           {},
+	"content-type":             {},
+	"conversation_id":          {},
+	"cookie":                   {},
+	"host":                     {},
+	"openai-beta":              {},
+	"originator":               {},
+	"proxy-authorization":      {},
+	"sec-websocket-extensions": {},
+	"sec-websocket-key":        {},
+	"sec-websocket-protocol":   {},
+	"sec-websocket-version":    {},
+	"session_id":               {},
+	"set-cookie":               {},
+	"transfer-encoding":        {},
+	"upgrade":                  {},
+	"user-agent":               {},
+	"version":                  {},
+	"x-api-key":                {},
+	"x-codex-turn-metadata":    {},
+	"x-codex-turn-state":       {},
+	"x-goog-api-key":           {},
+}
+
+// GetOpenAICustomHeaders returns account-level custom request headers configured in Extra.
+// The canonical storage format is an object: {"Header-Name": "value"}. A row-array format is
+// also accepted for import/UI compatibility: [{"name":"Header-Name","value":"value"}].
+func (a *Account) GetOpenAICustomHeaders() http.Header {
+	if a == nil || !a.IsOpenAI() || len(a.Extra) == 0 {
+		return nil
+	}
+	raw, ok := a.Extra[openAICustomHeadersExtraKey]
+	if !ok || raw == nil {
+		return nil
+	}
+
+	headers := make(http.Header)
+	switch value := raw.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			addOpenAICustomHeader(headers, key, value[key])
+		}
+	case map[string]string:
+		keys := make([]string, 0, len(value))
+		for key := range value {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			addOpenAICustomHeader(headers, key, value[key])
+		}
+	case []any:
+		for _, row := range value {
+			addOpenAICustomHeaderRow(headers, row)
+		}
+	case []map[string]any:
+		for _, row := range value {
+			addOpenAICustomHeaderRow(headers, row)
+		}
+	case []map[string]string:
+		for _, row := range value {
+			addOpenAICustomHeaderRow(headers, row)
+		}
+	}
+
+	if len(headers) == 0 {
+		return nil
+	}
+	return headers
+}
+
+func applyOpenAIAccountCustomHeaders(dst http.Header, account *Account) {
+	if dst == nil {
+		return
+	}
+	for key, values := range account.GetOpenAICustomHeaders() {
+		if len(values) == 0 {
+			continue
+		}
+		dst.Set(key, values[0])
+	}
+}
+
+func getOpenAICustomAuthorization(account *Account) string {
+	if account == nil {
+		return ""
+	}
+	return strings.TrimSpace(account.GetOpenAICustomHeaders().Get("Authorization"))
+}
+
+func hasOpenAICustomAuthorization(account *Account) bool {
+	return getOpenAICustomAuthorization(account) != ""
+}
+
+func addOpenAICustomHeaderRow(dst http.Header, raw any) {
+	switch row := raw.(type) {
+	case map[string]any:
+		name := firstOpenAICustomHeaderRowString(row, "name", "key", "header")
+		addOpenAICustomHeader(dst, name, row["value"])
+	case map[string]string:
+		name := firstOpenAICustomHeaderRowString(row, "name", "key", "header")
+		addOpenAICustomHeader(dst, name, row["value"])
+	}
+}
+
+func firstOpenAICustomHeaderRowString[T any](row map[string]T, keys ...string) string {
+	for _, key := range keys {
+		if raw, ok := row[key]; ok {
+			return strings.TrimSpace(fmt.Sprint(raw))
+		}
+	}
+	return ""
+}
+
+func addOpenAICustomHeader(dst http.Header, rawName string, rawValue any) {
+	name := strings.TrimSpace(rawName)
+	value, ok := openAICustomHeaderValueString(rawValue)
+	if !ok {
+		return
+	}
+	if !isAllowedOpenAICustomHeader(name, value) {
+		return
+	}
+	dst.Set(http.CanonicalHeaderKey(name), value)
+}
+
+func openAICustomHeaderValueString(raw any) (string, bool) {
+	if raw == nil {
+		return "", false
+	}
+	switch v := raw.(type) {
+	case string:
+		return strings.TrimSpace(v), true
+	case json.Number:
+		return strings.TrimSpace(v.String()), true
+	case fmt.Stringer:
+		return strings.TrimSpace(v.String()), true
+	case bool, int, int64, float64:
+		return strings.TrimSpace(fmt.Sprint(v)), true
+	default:
+		return "", false
+	}
+}
+
+func isAllowedOpenAICustomHeader(name string, value string) bool {
+	if name == "" || value == "" {
+		return false
+	}
+	if !httpguts.ValidHeaderFieldName(name) || !httpguts.ValidHeaderFieldValue(value) {
+		return false
+	}
+	if strings.ContainsAny(value, "\r\n") {
+		return false
+	}
+	_, forbidden := openAICustomHeaderForbiddenNames[strings.ToLower(name)]
+	return !forbidden
+}

--- a/backend/internal/service/openai_custom_headers_test.go
+++ b/backend/internal/service/openai_custom_headers_test.go
@@ -1,0 +1,245 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAccount_GetOpenAICustomHeadersSanitizesConfiguredHeaders(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				" X-Trace-Id ":        " trace-1 ",
+				"CF-Access-Client-Id": "client-id",
+				"OpenAI-Organization": "org_123",
+				"Authorization":       "Bearer attacker",
+				"content-type":        "text/plain",
+				"session_id":          "shared-session",
+				"Bad Header":          "bad",
+				"X-Injected":          "line-1\nline-2",
+				"X-Empty":             "",
+				"X-Unsupported-Value": map[string]any{"nested": true},
+			},
+		},
+	}
+
+	headers := account.GetOpenAICustomHeaders()
+
+	require.Equal(t, "trace-1", headers.Get("X-Trace-Id"))
+	require.Equal(t, "client-id", headers.Get("CF-Access-Client-Id"))
+	require.Equal(t, "org_123", headers.Get("OpenAI-Organization"))
+	require.Equal(t, "Bearer attacker", headers.Get("Authorization"))
+	require.Empty(t, headers.Get("Content-Type"))
+	require.Empty(t, headers.Get("Session_Id"))
+	require.Empty(t, headers.Get("Bad Header"))
+	require.Empty(t, headers.Get("X-Injected"))
+	require.Empty(t, headers.Get("X-Empty"))
+	require.Empty(t, headers.Get("X-Unsupported-Value"))
+}
+
+func TestAccount_GetOpenAICustomHeadersAcceptsRowsFormat(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: []any{
+				map[string]any{"name": "X-Row-Name", "value": "row-value"},
+				map[string]any{"key": "X-Row-Key", "value": "key-value"},
+				map[string]any{"header": "authorization", "value": "Bearer attacker"},
+			},
+		},
+	}
+
+	headers := account.GetOpenAICustomHeaders()
+
+	require.Equal(t, "row-value", headers.Get("X-Row-Name"))
+	require.Equal(t, "key-value", headers.Get("X-Row-Key"))
+	require.Equal(t, "Bearer attacker", headers.Get("Authorization"))
+}
+
+func TestOpenAIBuildUpstreamRequestAppliesCustomHeadersWhileProtectingCoreHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader([]byte(`{"model":"gpt-5"}`)))
+	c.Request.Header.Set("Authorization", "Bearer client")
+	c.Request.Header.Set("session_id", "client-session")
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{
+		Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		},
+	}}
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				"X-Account-Header": "account-value",
+				"Authorization":    "Bearer attacker",
+				"session_id":       "custom-session",
+				"Content-Type":     "text/plain",
+			},
+		},
+	}
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token", false, "prompt-cache", true)
+
+	require.NoError(t, err)
+	require.Equal(t, "account-value", req.Header.Get("X-Account-Header"))
+	require.Equal(t, "Bearer attacker", req.Header.Get("Authorization"))
+	require.NotEqual(t, "custom-session", req.Header.Get("Session_Id"))
+	require.Equal(t, "application/json", req.Header.Get("Content-Type"))
+}
+
+func TestOpenAIBuildUpstreamRequestPassthroughAppliesCustomHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader([]byte(`{"model":"gpt-5"}`)))
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{
+		Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		},
+	}}
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				"X-Account-Header": "account-value",
+				"Authorization":    "Bearer attacker",
+			},
+		},
+	}
+
+	req, err := svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token")
+
+	require.NoError(t, err)
+	require.Equal(t, "account-value", req.Header.Get("X-Account-Header"))
+	require.Equal(t, "Bearer attacker", req.Header.Get("Authorization"))
+}
+
+func TestOpenAIWSHeadersApplyCustomHeadersWhileProtectingCoreHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.125.0")
+	c.Request.Header.Set("session_id", "client-session")
+
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				"X-Account-Header": "account-value",
+				"Authorization":    "Bearer attacker",
+				"OpenAI-Beta":      "attacker",
+				"User-Agent":       "attacker",
+			},
+		},
+	}
+
+	headers, _ := svc.buildOpenAIWSHeaders(
+		c,
+		account,
+		"token",
+		OpenAIWSProtocolDecision{Transport: OpenAIUpstreamTransportResponsesWebsocketV2},
+		true,
+		"",
+		"",
+		"prompt-cache",
+	)
+
+	require.Equal(t, "account-value", headers.Get("X-Account-Header"))
+	require.Equal(t, "Bearer attacker", headers.Get("Authorization"))
+	require.Equal(t, openAIWSBetaV2Value, headers.Get("OpenAI-Beta"))
+	require.NotEqual(t, "attacker", headers.Get("User-Agent"))
+}
+
+func TestOpenAITokenProviderSkipsOAuthTokenFlowWithCustomAuthorization(t *testing.T) {
+	cache := &openAICustomHeaderTokenCache{token: "cached-token"}
+	provider := NewOpenAITokenProvider(nil, cache, nil)
+	account := &Account{
+		ID:       10,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				"Authorization": "Bearer upstream-token",
+			},
+		},
+	}
+
+	token, err := provider.GetAccessToken(context.Background(), account)
+
+	require.NoError(t, err)
+	require.Equal(t, openAICustomAuthorizationTokenPlaceholder, token)
+	require.Zero(t, atomic.LoadInt32(&cache.getCalled))
+	require.Zero(t, atomic.LoadInt32(&cache.lockCalled))
+	require.Zero(t, atomic.LoadInt32(&cache.setCalled))
+}
+
+func TestOpenAIGatewayGetAccessTokenSkipsMissingOAuthTokenWithCustomAuthorization(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		ID:       11,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				"authorization": "Bearer upstream-token",
+			},
+		},
+	}
+
+	token, tokenType, err := svc.GetAccessToken(context.Background(), account)
+
+	require.NoError(t, err)
+	require.Equal(t, openAICustomAuthorizationTokenPlaceholder, token)
+	require.Equal(t, "oauth", tokenType)
+}
+
+type openAICustomHeaderTokenCache struct {
+	token      string
+	getCalled  int32
+	setCalled  int32
+	lockCalled int32
+}
+
+func (c *openAICustomHeaderTokenCache) GetAccessToken(context.Context, string) (string, error) {
+	atomic.AddInt32(&c.getCalled, 1)
+	return c.token, nil
+}
+
+func (c *openAICustomHeaderTokenCache) SetAccessToken(context.Context, string, string, time.Duration) error {
+	atomic.AddInt32(&c.setCalled, 1)
+	return nil
+}
+
+func (c *openAICustomHeaderTokenCache) DeleteAccessToken(context.Context, string) error {
+	return nil
+}
+
+func (c *openAICustomHeaderTokenCache) AcquireRefreshLock(context.Context, string, time.Duration) (bool, error) {
+	atomic.AddInt32(&c.lockCalled, 1)
+	return true, nil
+}
+
+func (c *openAICustomHeaderTokenCache) ReleaseRefreshLock(context.Context, string) error {
+	return nil
+}

--- a/backend/internal/service/openai_embeddings.go
+++ b/backend/internal/service/openai_embeddings.go
@@ -81,6 +81,7 @@ func (s *OpenAIGatewayService) ForwardEmbeddings(
 	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
 		upstreamReq.Header.Set("user-agent", customUA)
 	}
+	applyOpenAIAccountCustomHeaders(upstreamReq.Header, account)
 
 	proxyURL := ""
 	if account.Proxy != nil {

--- a/backend/internal/service/openai_embeddings_test.go
+++ b/backend/internal/service/openai_embeddings_test.go
@@ -82,6 +82,12 @@ func TestForwardEmbeddings_APIKeyPassthroughRecordsUsageAndBatchInput(t *testing
 				"nowledge-embedding": "jina-embeddings-v5-text-small",
 			},
 		},
+		Extra: map[string]any{
+			openAICustomHeadersExtraKey: map[string]any{
+				"X-Account-Header": "account-value",
+				"Authorization":    "Bearer attacker",
+			},
+		},
 	}
 
 	result, err := svc.ForwardEmbeddings(context.Background(), c, account, reqBody, "")
@@ -97,6 +103,7 @@ func TestForwardEmbeddings_APIKeyPassthroughRecordsUsageAndBatchInput(t *testing
 	require.Equal(t, 0, result.Usage.OutputTokens)
 	require.Equal(t, "https://api.jina.ai/v1/embeddings", upstream.lastReq.URL.String())
 	require.Equal(t, "Bearer sk-test", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "account-value", upstream.lastReq.Header.Get("X-Account-Header"))
 	require.Equal(t, "jina-embeddings-v5-text-small", gjson.GetBytes(upstream.lastBody, "model").String())
 	require.Equal(t, int64(2), gjson.GetBytes(upstream.lastBody, "input.#").Int())
 	require.Equal(t, "hello", gjson.GetBytes(upstream.lastBody, "input.0").String())

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -163,6 +163,7 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	if customUA != "" {
 		upstreamReq.Header.Set("user-agent", customUA)
 	}
+	applyOpenAIAccountCustomHeaders(upstreamReq.Header, account)
 
 	// 6. Send request
 	proxyURL := ""

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -137,6 +137,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
 		upstreamReq.Header.Set("user-agent", customUA)
 	}
+	applyOpenAIAccountCustomHeaders(upstreamReq.Header, account)
 
 	proxyURL := ""
 	if account.Proxy != nil {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2284,6 +2284,9 @@ func (s *OpenAIGatewayService) schedulingConfig() config.GatewaySchedulingConfig
 func (s *OpenAIGatewayService) GetAccessToken(ctx context.Context, account *Account) (string, string, error) {
 	switch account.Type {
 	case AccountTypeOAuth:
+		if hasOpenAICustomAuthorization(account) {
+			return openAICustomAuthorizationTokenPlaceholder, "oauth", nil
+		}
 		// 使用 TokenProvider 获取缓存的 token
 		if s.openAITokenProvider != nil {
 			accessToken, err := s.openAITokenProvider.GetAccessToken(ctx, account)
@@ -3492,6 +3495,8 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	// （Chrome/Firefox/Safari/Edge 等），替换为后台配置的 Codex UA，避免 Cloudflare 触发 JS 质询。
 	s.overrideBrowserUserAgent(ctx, account, req)
 
+	applyOpenAIAccountCustomHeaders(req.Header, account)
+
 	if req.Header.Get("content-type") == "" {
 		req.Header.Set("content-type", "application/json")
 	}
@@ -4247,6 +4252,8 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	// 浏览器型 UA 兜底：仅 OAuth（ChatGPT 内部接口）账号生效，若最终 user-agent 仍为浏览器
 	// （Chrome/Firefox/Safari/Edge 等），替换为后台配置的 Codex UA，避免 Cloudflare 触发 JS 质询。
 	s.overrideBrowserUserAgent(ctx, account, req)
+
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 
 	// Ensure required headers exist
 	if req.Header.Get("content-type") == "" {

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -757,6 +757,7 @@ func (s *OpenAIGatewayService) buildOpenAIImagesRequest(
 	if customUA != "" {
 		req.Header.Set("User-Agent", customUA)
 	}
+	applyOpenAIAccountCustomHeaders(req.Header, account)
 	if strings.TrimSpace(contentType) != "" {
 		req.Header.Set("Content-Type", contentType)
 	}

--- a/backend/internal/service/openai_token_provider.go
+++ b/backend/internal/service/openai_token_provider.go
@@ -139,6 +139,9 @@ func (p *OpenAITokenProvider) GetAccessToken(ctx context.Context, account *Accou
 	if account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth {
 		return "", errors.New("not an openai oauth account")
 	}
+	if hasOpenAICustomAuthorization(account) {
+		return openAICustomAuthorizationTokenPlaceholder, nil
+	}
 
 	cacheKey := OpenAITokenCacheKey(account)
 

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -1182,6 +1182,8 @@ func (s *OpenAIGatewayService) buildOpenAIWSHeaders(
 		headers.Set("user-agent", codexCLIUserAgent)
 	}
 
+	applyOpenAIAccountCustomHeaders(headers, account)
+
 	return headers, sessionResolution
 }
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2536,6 +2536,11 @@
         </div>
       </div>
 
+      <OpenAICustomHeadersEditor
+        v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
+        v-model="openAICustomHeaders"
+      />
+
       <!-- OpenAI WS Mode 三态（off/ctx_pool/passthrough） -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -3227,7 +3232,8 @@ import type {
   CodexSessionImportMessage,
   OpenAICompactMode,
   OpenAIResponsesMode,
-  OpenAIEndpointCapability
+  OpenAIEndpointCapability,
+  OpenAICustomHeader
 } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
@@ -3238,9 +3244,14 @@ import ProxyAdBanner from '@/components/common/ProxyAdBanner.vue'
 import GroupSelector from '@/components/common/GroupSelector.vue'
 import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.vue'
 import QuotaLimitCard from '@/components/account/QuotaLimitCard.vue'
+import OpenAICustomHeadersEditor from '@/components/account/OpenAICustomHeadersEditor.vue'
 import { applyInterceptWarmup } from '@/components/account/credentialsBuilder'
 import { formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
+import {
+  OPENAI_CUSTOM_HEADERS_EXTRA_KEY,
+  buildOpenAICustomHeadersObject
+} from '@/utils/openaiCustomHeaders'
 import { VERTEX_LOCATION_OPTIONS } from '@/constants/account'
 import {
   OPENAI_WS_MODE_CTX_POOL,
@@ -3419,6 +3430,7 @@ const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
+const openAICustomHeaders = ref<OpenAICustomHeader[]>([])
 const codexCLIOnlyEnabled = ref(false)
 const codexCLIOnlyAllowClaudeCodeEnabled = ref(false)
 const anthropicPassthroughEnabled = ref(false)
@@ -3844,6 +3856,7 @@ watch(
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
+      openAICustomHeaders.value = []
       codexCLIOnlyEnabled.value = false
       codexCLIOnlyAllowClaudeCodeEnabled.value = false
     }
@@ -4246,6 +4259,7 @@ const resetForm = () => {
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
+  openAICustomHeaders.value = []
   codexCLIOnlyEnabled.value = false
   codexCLIOnlyAllowClaudeCodeEnabled.value = false
   anthropicPassthroughEnabled.value = false
@@ -4319,6 +4333,12 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
   } else {
     delete extra.openai_passthrough
     delete extra.openai_oauth_passthrough
+  }
+  const customHeaders = buildOpenAICustomHeadersObject(openAICustomHeaders.value)
+  if (customHeaders) {
+    extra[OPENAI_CUSTOM_HEADERS_EXTRA_KEY] = customHeaders
+  } else {
+    delete extra[OPENAI_CUSTOM_HEADERS_EXTRA_KEY]
   }
 
   if (accountCategory.value === 'oauth-based' && codexCLIOnlyEnabled.value) {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1355,6 +1355,11 @@
         </div>
       </div>
 
+      <OpenAICustomHeadersEditor
+        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'apikey')"
+        v-model="openAICustomHeaders"
+      />
+
       <!-- OpenAI Codex 图片生成桥接账号级覆盖 -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'apikey')"
@@ -2387,7 +2392,8 @@ import type {
   CheckMixedChannelResponse,
   OpenAICompactMode,
   OpenAIResponsesMode,
-  OpenAIEndpointCapability
+  OpenAIEndpointCapability,
+  OpenAICustomHeader
 } from '@/types'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
@@ -2398,9 +2404,15 @@ import ProxyAdBanner from '@/components/common/ProxyAdBanner.vue'
 import GroupSelector from '@/components/common/GroupSelector.vue'
 import ModelWhitelistSelector from '@/components/account/ModelWhitelistSelector.vue'
 import QuotaLimitCard from '@/components/account/QuotaLimitCard.vue'
+import OpenAICustomHeadersEditor from '@/components/account/OpenAICustomHeadersEditor.vue'
 import { applyInterceptWarmup } from '@/components/account/credentialsBuilder'
 import { formatDateTime, formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
+import {
+  OPENAI_CUSTOM_HEADERS_EXTRA_KEY,
+  buildOpenAICustomHeadersObject,
+  readOpenAICustomHeaders
+} from '@/utils/openaiCustomHeaders'
 import { VERTEX_LOCATION_OPTIONS } from '@/constants/account'
 import {
   OPENAI_WS_MODE_CTX_POOL,
@@ -2583,6 +2595,7 @@ const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
+const openAICustomHeaders = ref<OpenAICustomHeader[]>([])
 const codexCLIOnlyEnabled = ref(false)
 const codexCLIOnlyAllowClaudeCodeEnabled = ref(false)
 type CodexImageGenerationBridgeMode = 'inherit' | 'enabled' | 'disabled'
@@ -2960,6 +2973,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
+  openAICustomHeaders.value = []
   codexCLIOnlyEnabled.value = false
   codexCLIOnlyAllowClaudeCodeEnabled.value = false
   codexImageGenerationBridgeMode.value = 'inherit'
@@ -2967,6 +2981,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   webSearchEmulationMode.value = 'default'
   if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'apikey')) {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
+    openAICustomHeaders.value = readOpenAICustomHeaders(extra?.[OPENAI_CUSTOM_HEADERS_EXTRA_KEY])
     openAICompactMode.value = (extra?.openai_compact_mode as OpenAICompactMode) || 'auto'
     if (newAccount.type === 'apikey') {
       openAIResponsesMode.value = normalizeOpenAIResponsesMode(extra?.openai_responses_mode)
@@ -4091,6 +4106,12 @@ const handleSubmit = async () => {
       } else {
         delete newExtra.openai_passthrough
         delete newExtra.openai_oauth_passthrough
+      }
+      const customHeaders = buildOpenAICustomHeadersObject(openAICustomHeaders.value)
+      if (customHeaders) {
+        newExtra[OPENAI_CUSTOM_HEADERS_EXTRA_KEY] = customHeaders
+      } else {
+        delete newExtra[OPENAI_CUSTOM_HEADERS_EXTRA_KEY]
       }
       if (openAICompactMode.value === 'auto') {
         delete newExtra.openai_compact_mode

--- a/frontend/src/components/account/OpenAICustomHeadersEditor.vue
+++ b/frontend/src/components/account/OpenAICustomHeadersEditor.vue
@@ -1,0 +1,116 @@
+<template>
+  <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
+    <div class="mb-3 flex items-center justify-between gap-3">
+      <div>
+        <label class="input-label mb-0">{{ t('admin.accounts.openai.customHeaders') }}</label>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {{ t('admin.accounts.openai.customHeadersDesc') }}
+        </p>
+      </div>
+      <button type="button" class="btn btn-secondary shrink-0 text-sm" @click="addRow">
+        <Icon name="plus" size="sm" class="mr-1" :stroke-width="2" />
+        {{ t('admin.accounts.openai.addCustomHeader') }}
+      </button>
+    </div>
+
+    <div v-if="rows.length > 0" class="space-y-2">
+      <div
+        v-for="(row, index) in rows"
+        :key="index"
+        class="grid grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.5rem]"
+      >
+        <input
+          :value="row.name"
+          type="text"
+          class="input font-mono text-sm"
+          :class="rowError(index) ? 'border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-700' : ''"
+          :placeholder="t('admin.accounts.openai.customHeaderNamePlaceholder')"
+          @input="updateRow(index, 'name', $event)"
+        />
+        <input
+          :value="row.value"
+          type="text"
+          class="input font-mono text-sm"
+          :class="rowError(index) ? 'border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-700' : ''"
+          :placeholder="t('admin.accounts.openai.customHeaderValuePlaceholder')"
+          @input="updateRow(index, 'value', $event)"
+        />
+        <button
+          type="button"
+          class="flex h-10 items-center justify-center rounded-md text-red-500 transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20"
+          @click="removeRow(index)"
+        >
+          <Icon name="trash" size="sm" :stroke-width="2" />
+        </button>
+        <p
+          v-if="rowError(index)"
+          class="text-xs text-red-600 dark:text-red-400 sm:col-span-3"
+        >
+          {{ t(rowErrorKey(index)) }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import type { OpenAICustomHeader } from '@/types'
+import Icon from '@/components/icons/Icon.vue'
+import {
+  getOpenAICustomHeaderRowError,
+  type OpenAICustomHeaderRowError
+} from '@/utils/openaiCustomHeaders'
+
+const props = defineProps<{
+  modelValue: OpenAICustomHeader[]
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: OpenAICustomHeader[]]
+}>()
+
+const { t } = useI18n()
+
+const rows = computed(() => props.modelValue || [])
+
+const emitRows = (value: OpenAICustomHeader[]) => {
+  emit('update:modelValue', value)
+}
+
+const addRow = () => {
+  emitRows([...rows.value, { name: '', value: '' }])
+}
+
+const removeRow = (index: number) => {
+  emitRows(rows.value.filter((_, rowIndex) => rowIndex !== index))
+}
+
+const updateRow = (index: number, field: keyof OpenAICustomHeader, event: Event) => {
+  const target = event.target as HTMLInputElement | null
+  const next = rows.value.map((row, rowIndex) =>
+    rowIndex === index ? { ...row, [field]: target?.value || '' } : row
+  )
+  emitRows(next)
+}
+
+const rowError = (index: number): OpenAICustomHeaderRowError | null =>
+  getOpenAICustomHeaderRowError(rows.value[index], rows.value)
+
+const rowErrorKey = (index: number) => {
+  const error = rowError(index)
+  switch (error) {
+    case 'incomplete':
+      return 'admin.accounts.openai.customHeaderIncomplete'
+    case 'invalid':
+      return 'admin.accounts.openai.customHeaderInvalid'
+    case 'protected':
+      return 'admin.accounts.openai.customHeaderProtected'
+    case 'duplicate':
+      return 'admin.accounts.openai.customHeaderDuplicate'
+    default:
+      return ''
+  }
+}
+</script>

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3409,6 +3409,16 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        customHeaders: 'Custom request headers',
+        customHeadersDesc:
+          'Sent with upstream OpenAI requests from this account. Authorization can be used for special upstream auth; session, WebSocket, and content headers are protected.',
+        addCustomHeader: 'Add header',
+        customHeaderNamePlaceholder: 'Header name',
+        customHeaderValuePlaceholder: 'Header value',
+        customHeaderIncomplete: 'Enter both a header name and value, or remove this row.',
+        customHeaderInvalid: 'Header name contains unsupported characters.',
+        customHeaderProtected: 'This header is managed by the gateway and cannot be overridden.',
+        customHeaderDuplicate: 'Header names must be unique.',
         responsesWebsocketsV2: 'Responses WebSocket v2',
         responsesWebsocketsV2Desc:
           'Disabled by default. Enable to allow responses_websockets_v2 capability (still gated by global and account-type switches).',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3568,6 +3568,15 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        customHeaders: '自定义请求头',
+        customHeadersDesc: '随该账号的 OpenAI 上游请求发送。Authorization 可用于特殊上游认证；会话、WebSocket 与内容类型等核心请求头受保护。',
+        addCustomHeader: '添加请求头',
+        customHeaderNamePlaceholder: 'Header 名称',
+        customHeaderValuePlaceholder: 'Header 值',
+        customHeaderIncomplete: '请同时填写 Header 名称和值，或删除该行。',
+        customHeaderInvalid: 'Header 名称包含不支持的字符。',
+        customHeaderProtected: '该 Header 由网关管理，不能覆盖。',
+        customHeaderDuplicate: 'Header 名称不能重复。',
         responsesWebsocketsV2: 'Responses WebSocket v2',
         responsesWebsocketsV2Desc:
           '默认关闭。开启后可启用 responses_websockets_v2 协议能力（受网关全局开关与账号类型开关约束）。',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1008,6 +1008,11 @@ export type OpenAICompactMode = 'auto' | 'force_on' | 'force_off'
 export type OpenAIResponsesMode = 'auto' | 'force_responses' | 'force_chat_completions'
 export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings'
 
+export interface OpenAICustomHeader {
+  name: string
+  value: string
+}
+
 export interface OpenAICompactState {
   openai_compact_mode?: OpenAICompactMode
   openai_compact_supported?: boolean

--- a/frontend/src/utils/__tests__/openaiCustomHeaders.spec.ts
+++ b/frontend/src/utils/__tests__/openaiCustomHeaders.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildOpenAICustomHeadersObject,
+  getOpenAICustomHeaderRowError,
+  readOpenAICustomHeaders
+} from '../openaiCustomHeaders'
+
+describe('openaiCustomHeaders', () => {
+  it('reads object and row formats', () => {
+    expect(readOpenAICustomHeaders({
+      'X-Trace-Id': 'trace-1',
+      Authorization: 'Bearer ignored-by-build'
+    })).toEqual([
+      { name: 'X-Trace-Id', value: 'trace-1' },
+      { name: 'Authorization', value: 'Bearer ignored-by-build' }
+    ])
+
+    expect(readOpenAICustomHeaders([
+      { name: 'X-Name', value: 'name-value' },
+      { key: 'X-Key', value: 'key-value' },
+      { header: 'X-Header', value: 'header-value' }
+    ])).toEqual([
+      { name: 'X-Name', value: 'name-value' },
+      { name: 'X-Key', value: 'key-value' },
+      { name: 'X-Header', value: 'header-value' }
+    ])
+  })
+
+  it('builds only complete allowed unique headers', () => {
+    const rows = [
+      { name: ' X-Trace-Id ', value: ' trace-1 ' },
+      { name: 'Authorization', value: 'Bearer blocked' },
+      { name: 'X-Dupe', value: 'one' },
+      { name: 'x-dupe', value: 'two' },
+      { name: 'Bad Header', value: 'bad' },
+      { name: 'X-Blank', value: '' }
+    ]
+
+    expect(buildOpenAICustomHeadersObject(rows)).toEqual({
+      'X-Trace-Id': 'trace-1',
+      Authorization: 'Bearer blocked'
+    })
+    expect(getOpenAICustomHeaderRowError(rows[1], rows)).toBeNull()
+    expect(getOpenAICustomHeaderRowError(rows[2], rows)).toBe('duplicate')
+    expect(getOpenAICustomHeaderRowError(rows[3], rows)).toBe('duplicate')
+    expect(getOpenAICustomHeaderRowError(rows[4], rows)).toBe('invalid')
+    expect(getOpenAICustomHeaderRowError(rows[5], rows)).toBe('incomplete')
+  })
+})

--- a/frontend/src/utils/openaiCustomHeaders.ts
+++ b/frontend/src/utils/openaiCustomHeaders.ts
@@ -1,0 +1,97 @@
+import type { OpenAICustomHeader } from '@/types'
+
+export const OPENAI_CUSTOM_HEADERS_EXTRA_KEY = 'openai_custom_headers'
+
+const HEADER_NAME_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+
+const FORBIDDEN_HEADER_NAMES = new Set([
+  'accept',
+  'chatgpt-account-id',
+  'connection',
+  'content-length',
+  'content-type',
+  'conversation_id',
+  'cookie',
+  'host',
+  'openai-beta',
+  'originator',
+  'proxy-authorization',
+  'sec-websocket-extensions',
+  'sec-websocket-key',
+  'sec-websocket-protocol',
+  'sec-websocket-version',
+  'session_id',
+  'set-cookie',
+  'transfer-encoding',
+  'upgrade',
+  'user-agent',
+  'version',
+  'x-api-key',
+  'x-codex-turn-metadata',
+  'x-codex-turn-state',
+  'x-goog-api-key'
+])
+
+export type OpenAICustomHeaderRowError = 'incomplete' | 'invalid' | 'protected' | 'duplicate'
+
+export const isOpenAICustomHeaderNameValid = (name: string) => HEADER_NAME_RE.test(name.trim())
+
+export const isOpenAICustomHeaderNameProtected = (name: string) =>
+  FORBIDDEN_HEADER_NAMES.has(name.trim().toLowerCase())
+
+export const readOpenAICustomHeaders = (raw: unknown): OpenAICustomHeader[] => {
+  if (!raw) return []
+  if (Array.isArray(raw)) {
+    return raw
+      .map((item) => {
+        if (!item || typeof item !== 'object') return null
+        const row = item as Record<string, unknown>
+        const name = typeof row.name === 'string'
+          ? row.name
+          : typeof row.key === 'string'
+            ? row.key
+            : typeof row.header === 'string'
+              ? row.header
+              : ''
+        const value = typeof row.value === 'string' ? row.value : ''
+        return { name, value }
+      })
+      .filter((item): item is OpenAICustomHeader => item !== null)
+  }
+  if (typeof raw === 'object') {
+    return Object.entries(raw as Record<string, unknown>)
+      .filter(([, value]) => typeof value === 'string')
+      .map(([name, value]) => ({ name, value: String(value) }))
+  }
+  return []
+}
+
+export const getOpenAICustomHeaderRowError = (
+  row: OpenAICustomHeader,
+  rows: OpenAICustomHeader[]
+): OpenAICustomHeaderRowError | null => {
+  const name = row.name.trim()
+  const value = row.value.trim()
+  if (!name && !value) return null
+  if (!name || !value) return 'incomplete'
+  if (!isOpenAICustomHeaderNameValid(name)) return 'invalid'
+  if (isOpenAICustomHeaderNameProtected(name)) return 'protected'
+  const lower = name.toLowerCase()
+  const duplicateCount = rows.filter((candidate) => candidate.name.trim().toLowerCase() === lower).length
+  if (duplicateCount > 1) return 'duplicate'
+  return null
+}
+
+export const buildOpenAICustomHeadersObject = (
+  rows: OpenAICustomHeader[]
+): Record<string, string> | undefined => {
+  const output: Record<string, string> = {}
+  rows.forEach((row) => {
+    if (getOpenAICustomHeaderRowError(row, rows)) return
+    const name = row.name.trim()
+    const value = row.value.trim()
+    if (!name || !value) return
+    output[name] = value
+  })
+  return Object.keys(output).length > 0 ? output : undefined
+}


### PR DESCRIPTION
## 概要

为 OpenAI 账号增加账号级自定义上游请求头配置，主要用于通过 AT 加入 Team 后的访问令牌直接接入上游，跳过 OAuth 接码/授权码流程。

## 背景

目前 OpenAI OAuth 账号通常需要走 OAuth 授权码流程，涉及接码、回调和 token 获取。

对于已经通过 AT 加入 Team 的账号，实际使用中可以直接导入 AT，然后在上游请求中携带指定的 Authorization 请求头完成访问。

但当前网关会统一管理上游认证 Header，无法在账号级别配置自定义 Authorization，导致这类场景无法直接使用。

## 使用方式

创建 OpenAI 账号时：

1. 选择 OpenAI 账号
2. 使用 AT 导入账号
3. 在“自定义请求头”中添加：

```text
Authorization: Bearer <token>
```

保存后，该账号发起 OpenAI 上游请求时会携带该自定义 Authorization Header。

## 主要改动

- 新增 OpenAI 账号 `extra.openai_custom_headers` 配置
- 在创建/编辑 OpenAI 账号弹窗中增加自定义请求头编辑器
- 在 OpenAI 上游请求链路中应用账号级自定义请求头
- 支持 Responses / Chat Completions / Embeddings / Images / WebSocket / 账号测试请求
- 允许自定义 `Authorization`，用于 AT / Team 访问令牌等特殊认证场景
- 继续保护会话、WebSocket、Content-Type、Host、OpenAI-Beta、User-Agent 等核心 Header

## 安全性

- 校验 Header name / value
- 拒绝 CRLF 注入
- 连接、会话、WebSocket、内容类型等关键 Header 仍然禁止覆盖
- 默认不配置时不影响现有账号行为

## 测试

- `go test ./internal/service -run 'TestAccount_GetOpenAICustomHeaders|TestOpenAIBuildUpstreamRequest.*Custom|TestOpenAIWSHeadersApplyCustom'`
- `pnpm exec eslint src/utils/openaiCustomHeaders.ts src/utils/__tests__/openaiCustomHeaders.spec.ts src/i18n/locales/zh.ts src/i18n/locales/en.ts --ext .ts`
- `pnpm test:run src/utils/__tests__/openaiCustomHeaders.spec.ts`