### PR TITLE
fix: omit expires_in from Claude OAuth token exchange

### DIFF
--- a/backend/internal/repository/claude_oauth_service.go
+++ b/backend/internal/repository/claude_oauth_service.go
@@ -197,11 +197,6 @@ func (s *claudeOAuthService) ExchangeCodeForToken(ctx context.Context, code, cod
 		reqBody["state"] = codeState
 	}
 
-	// Setup token requires longer expiration (1 year)
-	if isSetupToken {
-		reqBody["expires_in"] = 31536000 // 365 * 24 * 60 * 60 seconds
-	}
-
 	logger.LegacyPrintf("repository.claude_oauth", "[OAuth] Step 3: Exchanging code for token at %s", s.tokenURL)
 	reqBodyJSON, _ := json.Marshal(logredact.RedactMap(reqBody))
 	logger.LegacyPrintf("repository.claude_oauth", "[OAuth] Step 3 Request Body: %s", string(reqBodyJSON))

--- a/backend/internal/repository/claude_oauth_service_test.go
+++ b/backend/internal/repository/claude_oauth_service_test.go
@@ -228,7 +228,7 @@ func (s *ClaudeOAuthServiceSuite) TestExchangeCodeForToken() {
 			},
 		},
 		{
-			name: "setup_token_includes_expires_in",
+			name: "setup_token_omits_expires_in",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(oauth.TokenResponse{
@@ -243,9 +243,7 @@ func (s *ClaudeOAuthServiceSuite) TestExchangeCodeForToken() {
 				AccessToken: "at",
 			},
 			validate: func(captured requestCapture) {
-				// Setup token should include expires_in with 1 year value
-				require.Equal(s.T(), float64(31536000), captured.bodyJSON["expires_in"],
-					"setup token should include expires_in: 31536000")
+				require.Nil(s.T(), captured.bodyJSON["expires_in"], "setup token should not include expires_in")
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- remove the client-supplied expires_in field from Claude OAuth authorization_code token exchange requests
- update the setup-token test case to assert the request body omits expires_in

Fixes #3424.

## Test
- go test ./internal/repository -run TestClaudeOAuthServiceSuite/TestExchangeCodeForToken