### PR TITLE
fix(keys): add CLAUDE_CODE_ATTRIBUTION_HEADER=0 to Claude Code terminal templates

### DIFF
--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -442,19 +442,22 @@ function generateAnthropicFiles(baseUrl: string, apiKey: string): FileConfig[] {
       path = 'Terminal'
       content = `export ANTHROPIC_BASE_URL="${baseUrl}"
 export ANTHROPIC_AUTH_TOKEN="${apiKey}"
-export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+export CLAUDE_CODE_ATTRIBUTION_HEADER=0`
       break
     case 'cmd':
       path = 'Command Prompt'
       content = `set ANTHROPIC_BASE_URL=${baseUrl}
 set ANTHROPIC_AUTH_TOKEN=${apiKey}
-set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+set CLAUDE_CODE_ATTRIBUTION_HEADER=0`
       break
     case 'powershell':
       path = 'PowerShell'
       content = `$env:ANTHROPIC_BASE_URL="${baseUrl}"
 $env:ANTHROPIC_AUTH_TOKEN="${apiKey}"
-$env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1`
+$env:CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+$env:CLAUDE_CODE_ATTRIBUTION_HEADER=0`
       break
     default:
       path = 'Terminal'


### PR DESCRIPTION
## 问题

在「使用 API 密钥」弹窗里选 Claude Code 时,下方 VSCode `settings.json` 模板已经带了 `"CLAUDE_CODE_ATTRIBUTION_HEADER": "0"`,但上方的终端环境变量模板没有,两者不一致。

直接照终端模板复制的用户会缺这个变量,Claude Code 仍会在请求里带上 attribution header,影响第三方网关的 prompt cache key,导致缓存命中率下降。

修复 #3380。

## 改动

给三个终端变体都补上这一行,与 VSCode 模板对齐:

- Unix/macOS/Linux:`export CLAUDE_CODE_ATTRIBUTION_HEADER=0`
- Windows CMD:`set CLAUDE_CODE_ATTRIBUTION_HEADER=0`
- PowerShell:`$env:CLAUDE_CODE_ATTRIBUTION_HEADER=0`

纯模板文案改动,无逻辑变更。
