### PR TITLE
fix(gateway): enforce codex_cli_only restriction on /v1/chat/completions

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -61,6 +61,19 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	promptCacheKey string,
 	defaultMappedModel string,
 ) (*OpenAIForwardResult, error) {
+	restrictionResult := s.detectCodexClientRestriction(c, account)
+	logCodexCLIOnlyDetection(ctx, c, account, getAPIKeyIDFromContext(c), restrictionResult, body)
+	if restrictionResult.Enabled && !restrictionResult.Matched {
+		MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
+		c.JSON(http.StatusForbidden, gin.H{
+			"error": gin.H{
+				"type":    "forbidden_error",
+				"message": "This account only allows Codex official clients",
+			},
+		})
+		return nil, errors.New("codex_cli_only restriction: only codex official clients are allowed")
+	}
+
 	// 入口分流：APIKey 账号 + 强制或已探测确认上游不支持 Responses，走 CC 直转。
 	// 自动模式下标记缺失（未探测）按"现状即证据"原则继续走下方原 Responses 转换路径。
 	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {


### PR DESCRIPTION
## 问题

账号开启「仅允许 Codex 官方客户端」(`codex_cli_only`) 后,本应拒绝 opencode 等非官方客户端。但该限制只在 `/v1/responses` 走的 `Forward()` 里做了拦截,`/v1/chat/completions` 走的 `ForwardAsChatCompletions()` 没有,于是非官方客户端从 chat/completions 入口绕过了限制。

修复 #3409。

## 改动

在 `ForwardAsChatCompletions()` 入口处补上和 `Forward()` 完全一致的拦截逻辑(复用现有的 `detectCodexClientRestriction`),非官方客户端同样返回 403。放在分流之前,两条子路径(APIKey 直转 / OAuth 转 Responses)都覆盖到;对未开启该限制或非 OAuth 账号是无副作用的空操作。
