### PR TITLE
fix(ops): prevent monitoring trend cards from growing unbounded

### DIFF
--- a/frontend/src/views/admin/ops/OpsDashboard.vue
+++ b/frontend/src/views/admin/ops/OpsDashboard.vue
@@ -44,7 +44,7 @@
         <div class="lg:col-span-1 min-h-[360px]">
           <OpsConcurrencyCard :platform-filter="platform" :group-id-filter="groupId" :refresh-token="dashboardRefreshToken" />
         </div>
-        <div class="lg:col-span-1 min-h-[360px]">
+        <div class="lg:col-span-1 h-[360px]">
           <OpsSwitchRateTrendChart
             :points="switchTrend?.points ?? []"
             :loading="loadingSwitchTrend"
@@ -52,7 +52,7 @@
             :fullscreen="isFullscreen"
           />
         </div>
-        <div class="lg:col-span-2 min-h-[360px]">
+        <div class="lg:col-span-2 h-[360px]">
           <OpsThroughputTrendChart
             :points="throughputTrend?.points ?? []"
             :by-platform="throughputTrend?.by_platform ?? []"


### PR DESCRIPTION
## Problem

On the ops monitoring dashboard, the **concurrency**, **average switch-rate trend** and **throughput trend** cards can grow downward without bound under certain conditions — the page keeps stretching vertically.

## Root cause

The three cards sit in grid cells that only set `min-h-[360px]` (a floor, no definite height). The inner card uses `h-full` (`height: 100%`), which resolves to `auto` when the parent height is `auto`. Together with the Chart.js `responsive` + `maintainAspectRatio: false` charts this forms a height feedback loop:

```
canvas reads parent clientHeight to size itself
  → content grows
  → next ResizeObserver tick reads a larger height
  → canvas grows again → unbounded vertical growth
```

On wide screens (`lg:grid-cols-4`) a sibling card usually pins the row height via the default `align-items: stretch`, which masks the problem. It surfaces when **no sibling bounds the row height** — e.g. the single-column (`grid-cols-1`) stacked layout on narrow viewports, or when the concurrency card collapses to little content. `min-h` caps nothing on top, so the cards keep growing.

## Fix

Give the two Chart.js canvas cells (switch-rate and throughput) a **definite** height `h-[360px]`, so the responsive resize has a fixed reference and the loop cannot run. The concurrency card is not a responsive canvas (no feedback loop), so it keeps `min-h-[360px]` to avoid clipping its content.

Two lines changed, pure layout classes — no behavior change.

## How to reproduce

Open the ops dashboard on a narrow viewport (single-column stack), or in any state where the concurrency card has little/no data, and watch the trend chart cards stretch downward indefinitely.