### PR TITLE
fix(auth): stop swallowing email auth identity create error via shadowed err

### DIFF
--- a/backend/internal/service/auth_service.go
+++ b/backend/internal/service/auth_service.go
@@ -1042,7 +1042,7 @@ func (s *AuthService) ensureEmailAuthIdentity(ctx context.Context, user *User, s
 	}
 
 	if !existed {
-		if err := client.AuthIdentity.Create().
+		if err = client.AuthIdentity.Create().
 			SetUserID(user.ID).
 			SetProviderType("email").
 			SetProviderKey("email").


### PR DESCRIPTION
## 问题

之前使用`if err:= ` 会导致 下方实际的 `if err != nil` 判断失效
该 `err` 的作用域只在这个 if 块内。导致本该"打日志 + 返回"的分支变成了死代码。

结果:`Create` 的真实错误被静默吞掉,函数继续往下重新查询一次,最终仍返回 `nil, false`,但日志是误导性的 `Failed to reload`(而非 `Failed to ensure`),并多做一次无用查询。静态分析也会因此报 "impossible condition: nil != nil"。

## 改动

把内层的 `if err :=` 改成 `if err =`,复用外层 `err`,让后面的 `if err != nil` 能正确读到 `Exec` 的错误并按预期处理。一字符改动,无行为面外的影响。
