### PR TITLE
Fix OpenAI embedding account tests

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -75,7 +75,10 @@ const (
 	OpenAIEndpointCapabilityEmbeddings      OpenAIEndpointCapability = "embeddings"
 )
 
-const openAIEndpointCapabilitiesCredentialKey = "openai_capabilities"
+const (
+	openAIEndpointCapabilitiesCredentialKey       = "openai_capabilities"
+	legacyOpenAIEndpointCapabilitiesCredentialKey = "endpoint_capabilities"
+)
 
 type TempUnschedulableRule struct {
 	ErrorCode       int      `json:"error_code"`
@@ -1164,11 +1167,17 @@ func (a *Account) openAIEndpointCapabilitySet() (map[string]bool, bool) {
 	if a == nil || a.Credentials == nil {
 		return nil, false
 	}
-	raw, found := a.Credentials[openAIEndpointCapabilitiesCredentialKey]
-	if !found || raw == nil {
-		return nil, false
+	for _, key := range []string{openAIEndpointCapabilitiesCredentialKey, legacyOpenAIEndpointCapabilitiesCredentialKey} {
+		raw, found := a.Credentials[key]
+		if !found || raw == nil {
+			continue
+		}
+		return parseOpenAIEndpointCapabilitySet(raw), true
 	}
+	return nil, false
+}
 
+func parseOpenAIEndpointCapabilitySet(raw any) map[string]bool {
 	result := make(map[string]bool)
 	add := func(value string) {
 		value = strings.ToLower(strings.TrimSpace(value))
@@ -1189,6 +1198,10 @@ func (a *Account) openAIEndpointCapabilitySet() (map[string]bool, bool) {
 		for _, value := range capabilities {
 			add(value)
 		}
+	case string:
+		for _, value := range strings.Split(capabilities, ",") {
+			add(value)
+		}
 	case map[string]any:
 		for key, value := range capabilities {
 			enabled, ok := value.(bool)
@@ -1204,7 +1217,7 @@ func (a *Account) openAIEndpointCapabilitySet() (map[string]bool, bool) {
 		}
 	}
 
-	return result, true
+	return result
 }
 
 func (a *Account) SupportsOpenAIImageCapability(capability OpenAIImagesCapability) bool {

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -522,6 +522,12 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		return s.testOpenAIImageOAuth(c, ctx, account, testModelID, imagePrompt)
 	}
 
+	// Embeddings-only accounts do not expose /responses or /chat/completions.
+	// Probe the OpenAI-compatible embeddings endpoint directly.
+	if account.Type == AccountTypeAPIKey && shouldUseOpenAIEmbeddingsAccountTest(account, testModelID) {
+		return s.testOpenAIEmbeddingsConnection(c, account, testModelID, prompt)
+	}
+
 	// Determine authentication method and API URL
 	var authToken string
 	var apiURL string
@@ -629,6 +635,118 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 
 	// Process SSE stream
 	return s.processOpenAIStream(c, resp.Body)
+}
+
+func shouldUseOpenAIEmbeddingsAccountTest(account *Account, modelID string) bool {
+	if account == nil {
+		return false
+	}
+
+	model := strings.ToLower(strings.TrimSpace(modelID))
+	if strings.Contains(model, "embedding") || strings.Contains(model, "embed") {
+		return true
+	}
+
+	configured, found := account.openAIEndpointCapabilitySet()
+	if !found {
+		return false
+	}
+	return configured[string(OpenAIEndpointCapabilityEmbeddings)] && !configured[string(OpenAIEndpointCapabilityChatCompletions)]
+}
+
+func (s *AccountTestService) testOpenAIEmbeddingsConnection(c *gin.Context, account *Account, testModelID string, prompt string) error {
+	ctx := c.Request.Context()
+
+	authToken := account.GetOpenAIApiKey()
+	if authToken == "" {
+		return s.sendErrorAndEnd(c, "No API key available")
+	}
+
+	baseURL := account.GetOpenAIBaseURL()
+	if baseURL == "" {
+		baseURL = "https://api.openai.com"
+	}
+	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Invalid base URL: %s", err.Error()))
+	}
+
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Writer.Header().Set("X-Accel-Buffering", "no")
+	c.Writer.Flush()
+
+	upstreamModel := normalizeOpenAIModelForUpstream(account, testModelID)
+	if strings.TrimSpace(upstreamModel) == "" {
+		upstreamModel = testModelID
+	}
+	input := strings.TrimSpace(prompt)
+	if input == "" {
+		input = "你好"
+	}
+
+	s.sendEvent(c, TestEvent{Type: "test_start", Model: testModelID})
+	s.sendEvent(c, TestEvent{Type: "status", Text: "正在通过 /v1/embeddings 测试连接"})
+
+	payload := map[string]any{
+		"model": upstreamModel,
+		"input": input,
+	}
+	payloadBytes, _ := json.Marshal(payload)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, buildOpenAIEmbeddingsURL(normalizedBaseURL), bytes.NewReader(payloadBytes))
+	if err != nil {
+		return s.sendErrorAndEnd(c, "Failed to create Embeddings request")
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+authToken)
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+
+	resp, err := s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	if err != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Embeddings API (/v1/embeddings) request failed: %s", err.Error()))
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Failed to read Embeddings response: %s", readErr.Error()))
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusTooManyRequests {
+			s.reconcileOpenAI429State(ctx, account, resp.Header, body)
+		}
+		if resp.StatusCode == http.StatusUnauthorized && s.accountRepo != nil {
+			errMsg := fmt.Sprintf("Embeddings authentication failed (401): %s", string(body))
+			_ = s.accountRepo.SetError(ctx, account.ID, errMsg)
+		}
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Embeddings API (/v1/embeddings) returned %d: %s", resp.StatusCode, string(body)))
+	}
+
+	var parsed struct {
+		Data []struct {
+			Embedding []float64 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return s.sendErrorAndEnd(c, fmt.Sprintf("Failed to parse Embeddings response: %s", err.Error()))
+	}
+	if len(parsed.Data) == 0 || len(parsed.Data[0].Embedding) == 0 {
+		return s.sendErrorAndEnd(c, "Embeddings response missing data[0].embedding")
+	}
+
+	s.sendEvent(c, TestEvent{Type: "content", Text: fmt.Sprintf("embedding dim: %d", len(parsed.Data[0].Embedding))})
+	s.sendEvent(c, TestEvent{Type: "status", Text: "已通过 /v1/embeddings 验证"})
+	s.sendEvent(c, TestEvent{Type: "test_complete", Success: true})
+	return nil
 }
 
 // testOpenAIChatCompletionsConnection tests an OpenAI-compatible APIKey account

--- a/backend/internal/service/account_test_service_openai_test.go
+++ b/backend/internal/service/account_test_service_openai_test.go
@@ -338,6 +338,47 @@ func TestAccountTestService_OpenAI401SetsPermanentErrorOnly(t *testing.T) {
 	require.Nil(t, account.RateLimitResetAt)
 }
 
+func TestAccountTestService_OpenAIEmbeddingUsesEmbeddingsEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctx, recorder := newTestContext()
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"object":"list","data":[{"object":"embedding","embedding":[0.1,0.2]}],"model":"bge-m3"}`)),
+	}}
+	svc := &AccountTestService{
+		httpUpstream: upstream,
+		cfg: &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{
+			Enabled:           false,
+			AllowInsecureHTTP: true,
+		}}},
+	}
+	account := &Account{
+		ID:          93,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":               "sk-test",
+			"base_url":              "http://127.0.0.1:8001/v1",
+			"endpoint_capabilities": []any{"embeddings"},
+		},
+	}
+
+	err := svc.testOpenAIAccountConnection(ctx, account, "bge-m3", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.Equal(t, "http://127.0.0.1:8001/v1/embeddings", upstream.lastReq.URL.String())
+	require.Equal(t, HTTPUpstreamProfileOpenAI, HTTPUpstreamProfileFromContext(upstream.lastReq.Context()))
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "Bearer sk-test", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "bge-m3", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.Equal(t, "你好", gjson.GetBytes(upstream.lastBody, "input").String())
+	require.Contains(t, recorder.Body.String(), "embedding dim: 2")
+	require.Contains(t, recorder.Body.String(), "test_complete")
+}
+
 func TestAccountTestService_OpenAIAPIKeyResponsesUnsupportedUsesChatCompletionsPath(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	ctx, recorder := newTestContext()


### PR DESCRIPTION
## Summary
- route OpenAI-compatible embedding account tests through /v1/embeddings instead of Responses/Chat Completions
- validate embedding JSON responses and surface the embedding dimension in the SSE test output
- accept legacy endpoint_capabilities when reading OpenAI endpoint capabilities

## Tests
- docker run --rm -e GOPROXY=https://goproxy.cn,direct -e GOSUMDB=sum.golang.google.cn -e GOCACHE=/cache/go-build -e GOMODCACHE=/cache/gomod -v "$PWD/backend:/app/backend" -v "$PWD/.cache:/cache" -w /app/backend golang:1.26.4-alpine go test -tags unit ./internal/service -run "TestAccountTestService_OpenAIEmbeddingUsesEmbeddingsEndpoint|TestAccountTestService_OpenAIAPIKeyResponsesUnsupportedUsesChatCompletionsPath|TestAccountSupportsOpenAIEndpointCapability"