### PR TITLE
fix(token-refresh): treat refresh_token_invalidated as non-retryable / 添加 refresh_token_invalidated 到不可重试列表

### DIFF
--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -440,15 +440,15 @@ func isNonRetryableRefreshError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	nonRetryable := []string{
-		"invalid_grant",            // refresh_token 已失效
-		"invalid_refresh_token",    // refresh_token 无效, team 账号工作区被删除会出现
-		"app_session_terminated",   // refresh_token team 账号工作区被删除
-		"refresh_token_reused",     // OpenAI refresh_token 已被使用，必须重新授权
+		"invalid_grant",             // refresh_token 已失效
+		"invalid_refresh_token",     // refresh_token 无效, team 账号工作区被删除会出现
+		"app_session_terminated",    // refresh_token team 账号工作区被删除
+		"refresh_token_reused",      // OpenAI refresh_token 已被使用，必须重新授权
 		"refresh_token_invalidated", // OpenAI session ended; refresh token invalidated
-		"invalid_client",           // 客户端配置错误
-		"unauthorized_client",      // 客户端未授权
-		"access_denied",            // 访问被拒绝
-		"missing_project_id",       // 缺少 project_id
+		"invalid_client",            // 客户端配置错误
+		"unauthorized_client",       // 客户端未授权
+		"access_denied",             // 访问被拒绝
+		"missing_project_id",        // 缺少 project_id
 		"no refresh token available",
 	}
 	for _, needle := range nonRetryable {

--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -440,14 +440,15 @@ func isNonRetryableRefreshError(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	nonRetryable := []string{
-		"invalid_grant",          // refresh_token 已失效
-		"invalid_refresh_token",  // refresh_token 无效, team 账号工作区被删除会出现
-		"app_session_terminated", // refresh_token team 账号工作区被删除
-		"refresh_token_reused",   // OpenAI refresh_token 已被使用，必须重新授权
-		"invalid_client",         // 客户端配置错误
-		"unauthorized_client",    // 客户端未授权
-		"access_denied",          // 访问被拒绝
-		"missing_project_id",     // 缺少 project_id
+		"invalid_grant",            // refresh_token 已失效
+		"invalid_refresh_token",    // refresh_token 无效, team 账号工作区被删除会出现
+		"app_session_terminated",   // refresh_token team 账号工作区被删除
+		"refresh_token_reused",     // OpenAI refresh_token 已被使用，必须重新授权
+		"refresh_token_invalidated", // OpenAI session ended; refresh token invalidated
+		"invalid_client",           // 客户端配置错误
+		"unauthorized_client",      // 客户端未授权
+		"access_denied",            // 访问被拒绝
+		"missing_project_id",       // 缺少 project_id
 		"no refresh token available",
 	}
 	for _, needle := range nonRetryable {


### PR DESCRIPTION
后台一直刷这个，查了一下，发现是这个不在不可重试列表里，添加 refresh_token_invalidated 到不可重试列表。

```
token_refresh.retry_attempt_failed acc=230585 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 401, body: {\n \"error\": {\n \"message\": \"Your session has ended. Please log in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"refresh_token_invalidated\"\n }\n}" metadata=map[upstream_status:401]
token_refresh.account_refresh_failed acc=230583 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 401, body: {\n \"error\": {\n \"message\": \"Your session has ended. Please log in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"refresh_token_invalidated\"\n }\n}" metadata=map[upstream_status:401]
```