### PR TITLE
fix(apicompat): avoid doubling tool_call arguments from single-chunk upstreams (Codex + GLM)

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -737,6 +737,13 @@ func ChatCompletionsChunkToResponsesEvents(
 					copyCall.ID = generateItemID()
 				}
 				copyCall.Type = "function"
+				// Arguments are accumulated by the shared block below so the
+				// emitted delta and the stored value stay in sync. Some upstreams
+				// (e.g. GLM/Zhipu) pack id+name+arguments into the first tool_call
+				// chunk; without this reset the first chunk's arguments would be
+				// counted twice (once from this copy, once from the += below),
+				// producing a doubled, invalid JSON like {"a":1}{"a":1}.
+				copyCall.Function.Arguments = ""
 				state.ToolCalls[idx] = &copyCall
 				stored = &copyCall
 				itemID := generateItemID()

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_stream_lifecycle_test.go
@@ -179,6 +179,41 @@ func TestStream_ToolCallLifecycleComplete(t *testing.T) {
 	require.True(t, sawItemDone, "function_call output_item.done missing")
 }
 
+// TestStream_ToolCallArgumentsInFirstChunkNotDoubled guards the GLM/Zhipu shape
+// where a single tool_call delta chunk carries id+name+arguments together.
+// Earlier code copied the whole tool_call (including arguments) into state and
+// then accumulated the same chunk's arguments again, producing a doubled,
+// invalid JSON like {"cmd":"ls"}{"cmd":"ls"} that breaks Codex tool parsing
+// ("trailing characters").
+func TestStream_ToolCallArgumentsInFirstChunkNotDoubled(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"role":"assistant"}}]}`,
+		`{"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"exec","arguments":"{\"cmd\":\"ls\"}"}}]}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+	})
+
+	var argsDelta strings.Builder
+	var sawArgsDone, sawItemDone bool
+	for _, e := range events {
+		switch e.Type {
+		case "response.function_call_arguments.delta":
+			_, _ = argsDelta.WriteString(e.Delta)
+		case "response.function_call_arguments.done":
+			sawArgsDone = true
+			require.Equal(t, `{"cmd":"ls"}`, e.Arguments)
+		case "response.output_item.done":
+			if e.Item != nil && e.Item.Type == "function_call" {
+				sawItemDone = true
+				require.Equal(t, `{"cmd":"ls"}`, e.Item.Arguments)
+			}
+		}
+	}
+	require.True(t, sawArgsDone, "function_call_arguments.done missing")
+	require.True(t, sawItemDone, "function_call output_item.done missing")
+	// Accumulated deltas must equal the final arguments exactly (no duplication).
+	require.Equal(t, `{"cmd":"ls"}`, argsDelta.String())
+}
+
 // TestStream_SSEWireComplete drives the full stream through SSE encoding and
 // asserts the function_call events carry complete fields on the wire.
 func TestStream_SSEWireComplete(t *testing.T) {


### PR DESCRIPTION
## Problem

When Codex CLI is pointed at a GLM/Zhipu model through the OpenAI-compatible
gateway (Responses API client → Chat Completions upstream via the
`force_chat_completions` path), **every tool call fails** with:

```
ERROR codex_core::tools::router: error=failed to parse function arguments: trailing characters at line 1 column N
```

Codex then loops forever retrying, never executing a single tool.

## Root cause

In `ChatCompletionsChunkToResponsesEvents` (`chatcompletions_responses_bridge.go`),
the first tool_call delta chunk is copied wholesale into stream state:

```go
copyCall := toolCall          // includes copyCall.Function.Arguments
state.ToolCalls[idx] = &copyCall
...
stored.Function.Arguments += toolCall.Function.Arguments   // same chunk's args, again
```

For OpenAI this is harmless because its first tool_call chunk carries **empty**
arguments (id+name only), with the actual arguments arriving in later chunks.
But upstreams that pack **id + name + arguments into a single chunk** — GLM/Zhipu
does exactly this — get their arguments counted twice: once from the copy, once
from the shared `+=` accumulator. The accumulated value becomes a doubled,
invalid JSON, while the emitted `function_call_arguments.delta` is correct
(single), producing the tell-tale delta/done mismatch.

## Evidence (captured from the live gateway via mitmproxy)

```
response.function_call_arguments.delta : {"cmd":"echo hi"}                    ← correct (single)
response.function_call_arguments.done  : {"cmd":"echo hi"}{"cmd":"echo hi"}   ← DOUBLED
response.output_item.done / completed  : {"cmd":"echo hi"}{"cmd":"echo hi"}   ← DOUBLED
```

`12-char` valid JSON + duplicate → Codex reports trailing characters at column 13.

## Fix

Reset the copied arguments so the shared accumulator counts them exactly once,
keeping the emitted delta and the final `done`/`arguments` consistent. OpenAI
behaviour is unchanged (its first chunk had empty args anyway).

## Tests

Added `TestStream_ToolCallArgumentsInFirstChunkNotDoubled`, reproducing the
GLM single-chunk shape (id+name+arguments together). It fails on `master`
(`{"cmd":"ls"}{"cmd":"ls"}`) and passes with the fix. Full `apicompat` package
suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
