### PR TITLE
feat(risk-control): record matched keyword in keyword-block logs

### DIFF
--- a/backend/internal/repository/content_moderation_repo.go
+++ b/backend/internal/repository/content_moderation_repo.go
@@ -53,17 +53,17 @@ INSERT INTO content_moderation_logs (
     request_id, user_id, user_email, api_key_id, api_key_name, group_id, group_name,
     endpoint, provider, model, mode, action, flagged, highest_category, highest_score,
     category_scores, threshold_snapshot, input_excerpt, upstream_latency_ms, error,
-    violation_count, auto_banned, email_sent, queue_delay_ms
+    violation_count, auto_banned, email_sent, queue_delay_ms, matched_keyword
 ) VALUES (
     $1, $2, $3, $4, $5, $6, $7,
     $8, $9, $10, $11, $12, $13, $14, $15,
     $16::jsonb, $17::jsonb, $18, $19, $20,
-    $21, $22, $23, $24
+    $21, $22, $23, $24, $25
 ) RETURNING id, created_at`,
 		log.RequestID, userID, log.UserEmail, apiKeyID, log.APIKeyName, groupID, log.GroupName,
 		log.Endpoint, log.Provider, log.Model, log.Mode, log.Action, log.Flagged, log.HighestCategory, log.HighestScore,
 		string(categoryScores), string(thresholdSnapshot), log.InputExcerpt, latency, log.Error,
-		log.ViolationCount, log.AutoBanned, log.EmailSent, nullableIntPtr(log.QueueDelayMS),
+		log.ViolationCount, log.AutoBanned, log.EmailSent, nullableIntPtr(log.QueueDelayMS), log.MatchedKeyword,
 	).Scan(&log.ID, &log.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("insert content moderation log: %w", err)
@@ -97,7 +97,7 @@ SELECT
     l.id, l.request_id, l.user_id, l.user_email, l.api_key_id, l.api_key_name, l.group_id, l.group_name,
     l.endpoint, l.provider, l.model, l.mode, l.action, l.flagged, l.highest_category, l.highest_score,
     l.category_scores, l.threshold_snapshot, l.input_excerpt, l.upstream_latency_ms, l.error,
-    l.violation_count, l.auto_banned, l.email_sent, COALESCE(u.status, ''), l.queue_delay_ms, l.created_at
+    l.violation_count, l.auto_banned, l.email_sent, COALESCE(u.status, ''), l.queue_delay_ms, l.matched_keyword, l.created_at
 FROM content_moderation_logs l
 LEFT JOIN users u ON u.id = l.user_id `+whereSQL+`
 ORDER BY l.created_at DESC, l.id DESC
@@ -141,6 +141,7 @@ LIMIT $`+fmt.Sprint(len(queryArgs)-1)+` OFFSET $`+fmt.Sprint(len(queryArgs)),
 			&item.EmailSent,
 			&item.UserStatus,
 			&queueDelay,
+			&item.MatchedKeyword,
 			&item.CreatedAt,
 		); err != nil {
 			return nil, nil, fmt.Errorf("scan content moderation log: %w", err)

--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -390,6 +390,7 @@ type ContentModerationLog struct {
 	Flagged           bool               `json:"flagged"`
 	HighestCategory   string             `json:"highest_category"`
 	HighestScore      float64            `json:"highest_score"`
+	MatchedKeyword    string             `json:"matched_keyword"`
 	CategoryScores    map[string]float64 `json:"category_scores"`
 	ThresholdSnapshot map[string]float64 `json:"threshold_snapshot"`
 	InputExcerpt      string             `json:"input_excerpt"`
@@ -895,6 +896,7 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 					"keyword", keyword)
 				scores := map[string]float64{contentModerationKeywordCategory: 1.0}
 				log := s.buildLog(input, cfg, ContentModerationActionKeywordBlock, true, contentModerationKeywordCategory, 1.0, scores, content.ExcerptText(), nil, nil, "")
+				log.MatchedKeyword = keyword
 				s.enqueueRecord(input, cfg, log, hashText, false, true)
 				return &ContentModerationDecision{
 					Allowed:         false,

--- a/backend/internal/service/content_moderation_test.go
+++ b/backend/internal/service/content_moderation_test.go
@@ -485,6 +485,7 @@ func TestContentModerationCheck_PreBlockKeywordHitSkipsUpstreamCall(t *testing.T
 	require.True(t, logs[0].Flagged)
 	require.Equal(t, ContentModerationActionKeywordBlock, logs[0].Action)
 	require.Equal(t, contentModerationKeywordCategory, logs[0].HighestCategory)
+	require.Equal(t, "secret-token", logs[0].MatchedKeyword, "blocked log must record which keyword was hit")
 }
 
 func TestContentModerationCheck_KeywordsIgnoredInObserveMode(t *testing.T) {

--- a/backend/migrations/156_content_moderation_matched_keyword.sql
+++ b/backend/migrations/156_content_moderation_matched_keyword.sql
@@ -1,0 +1,3 @@
+-- 风控中心：记录关键词拦截命中的具体关键词
+
+ALTER TABLE content_moderation_logs ADD COLUMN IF NOT EXISTS matched_keyword VARCHAR(255) NOT NULL DEFAULT '';

--- a/frontend/src/api/admin/riskControl.ts
+++ b/frontend/src/api/admin/riskControl.ts
@@ -182,6 +182,7 @@ export interface ContentModerationLog {
   flagged: boolean
   highest_category: string
   highest_score: number
+  matched_keyword: string
   category_scores: Record<string, number>
   threshold_snapshot: Record<string, number>
   input_excerpt: string

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2648,6 +2648,7 @@ export default {
       unbanFailed: 'Failed to unban user',
       inputDetailTitle: 'Input Summary Detail',
       inputDetailContent: 'Full Content',
+      matchedKeyword: 'Matched Keyword',
       queueDelay: 'Queued {ms} ms',
       allGroups: 'All Groups',
       allGroupsHint: 'Auditing all groups',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2725,6 +2725,7 @@ export default {
       unbanFailed: '解封用户失败',
       inputDetailTitle: '输入摘要详情',
       inputDetailContent: '完整内容',
+      matchedKeyword: '命中关键词',
       queueDelay: '排队 {ms} ms',
       allGroups: '全部分组',
       allGroupsHint: '当前审计全部分组',

--- a/frontend/src/views/admin/RiskControlView.vue
+++ b/frontend/src/views/admin/RiskControlView.vue
@@ -317,6 +317,9 @@
                     <td class="whitespace-nowrap px-5 py-4 text-sm text-gray-700 dark:text-gray-300">
                       <div>{{ row.highest_category || '-' }}</div>
                       <div class="text-xs text-gray-400">{{ percent(row.highest_score) }}</div>
+                      <div v-if="row.matched_keyword" class="mt-0.5 text-xs font-medium text-red-600 dark:text-red-300" :title="t('admin.riskControl.matchedKeyword') + ': ' + row.matched_keyword">
+                        {{ t('admin.riskControl.matchedKeyword') }}: {{ row.matched_keyword }}
+                      </div>
                     </td>
                     <td class="whitespace-nowrap px-5 py-4 text-sm text-gray-700 dark:text-gray-300">
                       <div>{{ violationCountText(row) }}</div>
@@ -1077,6 +1080,10 @@
               <p class="mt-1 truncate text-sm font-semibold text-gray-900 dark:text-white">
                 {{ inputDetailRow.highest_category || '-' }} / {{ percent(inputDetailRow.highest_score) }}
               </p>
+            </div>
+            <div v-if="inputDetailRow.matched_keyword" class="rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-900/20">
+              <p class="text-xs font-medium text-red-500 dark:text-red-300">{{ t('admin.riskControl.matchedKeyword') }}</p>
+              <p class="mt-1 truncate text-sm font-semibold text-red-700 dark:text-red-200" :title="inputDetailRow.matched_keyword">{{ inputDetailRow.matched_keyword }}</p>
             </div>
           </div>
 


### PR DESCRIPTION
# PR：风控中心关键词拦截记录展示命中关键词

## 概述

本 PR 为风控中心的关键词拦截日志补充「命中关键词」记录与展示。

此前，后端结构化运行日志 `content_moderation.keyword_block` 中已经包含命中的关键词，但持久化到数据库的风控审计记录 `content_moderation_logs` 没有保存该字段。因此管理员在风控中心只能看到请求被关键词规则拦截，却无法直接判断具体命中了哪个关键词。

本 PR 将命中关键词写入数据库，并在管理端风控日志列表和详情弹窗中展示。

## 改动内容

- 为 `content_moderation_logs` 表新增 `matched_keyword` 字段
  - 新增迁移文件：`156_content_moderation_matched_keyword.sql`
- `ContentModerationLog` 新增 `MatchedKeyword` 字段
- 关键词拦截发生时，将实际命中的关键词写入风控日志记录
- 风控日志查询接口读取并返回 `matched_keyword`
- 前端管理端风控日志类型新增 `matched_keyword`
- 风控中心页面展示命中关键词：
  - 日志列表中直接显示「命中关键词: xxx」
  - 输入摘要详情弹窗中展示命中关键词卡片
- 新增中英文 i18n 文案：
  - 中文：`命中关键词`
  - 英文：`Matched Keyword`
- 测试中增加断言，确保关键词拦截日志会记录实际命中的关键词

## 背景与动机

风控中心用于审核和排查用户请求被拦截的原因。仅知道请求被「关键词拦截」并不足以定位问题，管理员还需要知道具体命中了哪个配置关键词。

该能力有助于：

- 排查误拦截
- 调整关键词黑名单
- 分析异常请求模式
- 向用户解释请求被拦截的具体原因
- 降低风控日志排查成本

## 行为变化

关键词拦截后的风控日志现在会返回类似字段：

```json
{
  "action": "keyword_block",
  "highest_category": "keyword",
  "matched_keyword": "example-keyword"
}
```

页面展示效果：

```text
keyword
100%
命中关键词: example-keyword
```

同时，在输入摘要详情弹窗中也会展示「命中关键词」。

## 数据库迁移

新增迁移：

```sql
ALTER TABLE content_moderation_logs
ADD COLUMN IF NOT EXISTS matched_keyword VARCHAR(255) NOT NULL DEFAULT '';
```

说明：

- 该字段默认值为空字符串，兼容历史数据。
- 不需要数据回填。
- 历史日志由于之前未保存命中关键词，`matched_keyword` 会保持为空。
- 新产生的关键词拦截日志会记录实际命中的关键词。

## 兼容性

- 对已有 API 调用兼容：只是新增响应字段，不会破坏旧客户端。
- 对历史数据兼容：新增字段有默认值。
- 对非关键词拦截日志兼容：`matched_keyword` 为空字符串。

## 测试

已验证以下命令通过：

```bash
cd backend
go build ./internal/...
go test ./internal/repository/... ./internal/service/... -run 'Moderation|ContentModeration|Keyword'

cd frontend
npx vue-tsc --noEmit
npx vitest run src/i18n/__tests__/riskControlLocales.spec.ts
npx vitest run src/views/admin/__tests__/RiskControlView.spec.ts
```

## 备注

该 PR 只补充关键词拦截命中信息的持久化和展示，不改变风控拦截判断逻辑。
