### PR TITLE
feat(openai): 展示并刷新 Spark 用量限额

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -56,6 +56,7 @@ var schedulerNeutralExtraKeyPrefixes = []string{
 	"codex_secondary_",
 	"codex_5h_",
 	"codex_7d_",
+	"codex_spark_",
 	"passive_usage_",
 }
 

--- a/backend/internal/repository/account_repo_compact_extra_test.go
+++ b/backend/internal/repository/account_repo_compact_extra_test.go
@@ -23,3 +23,17 @@ func TestShouldEnqueueSchedulerOutboxForExtraUpdates_OpenAIResponsesCapabilityKe
 		t.Fatalf("expected responses capability updates to enqueue scheduler outbox")
 	}
 }
+
+func TestShouldEnqueueSchedulerOutboxForExtraUpdates_CodexSparkObservationKeysAreNeutral(t *testing.T) {
+	updates := map[string]any{
+		"codex_spark_usage_updated_at":              "2026-03-11T10:00:00Z",
+		"codex_spark_primary_used_percent":          12.5,
+		"codex_spark_secondary_reset_after_seconds": 18000,
+		"codex_spark_5h_used_percent":               12.5,
+		"codex_spark_7d_reset_at":                   "2026-03-18T10:00:00Z",
+	}
+
+	if shouldEnqueueSchedulerOutboxForExtraUpdates(updates) {
+		t.Fatalf("expected codex_spark observation updates to skip scheduler outbox")
+	}
+}

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -612,7 +612,7 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	defer func() { _ = resp.Body.Close() }()
 
 	if isOAuth && s.accountRepo != nil {
-		if updates, err := extractOpenAICodexProbeUpdates(resp); err == nil && len(updates) > 0 {
+		if updates, err := extractOpenAICodexProbeUpdatesForModel(resp, testModelID); err == nil && len(updates) > 0 {
 			_ = s.accountRepo.UpdateExtra(ctx, account.ID, updates)
 			mergeAccountExtra(account, updates)
 		}
@@ -864,7 +864,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 
 	if s.accountRepo != nil {
 		updates := buildOpenAICompactProbeExtraUpdates(resp, body, nil, time.Now())
-		if codexUpdates, err := extractOpenAICodexProbeUpdates(resp); err == nil && len(codexUpdates) > 0 {
+		if codexUpdates, err := extractOpenAICodexProbeUpdatesForModel(resp, testModelID); err == nil && len(codexUpdates) > 0 {
 			updates = mergeExtraUpdates(updates, codexUpdates)
 		}
 		if len(updates) > 0 {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -542,11 +542,14 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 	if progress := buildCodexUsageProgressFromExtra(account.Extra, "7d", now); progress != nil {
 		usage.SevenDay = progress
 	}
-	if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "5h", now); progress != nil {
-		usage.CodexSparkFiveHour = progress
-	}
-	if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "7d", now); progress != nil {
-		usage.CodexSparkSevenDay = progress
+	includeSpark := accountEligibleForOpenAISparkUsage(account)
+	if includeSpark {
+		if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "5h", now); progress != nil {
+			usage.CodexSparkFiveHour = progress
+		}
+		if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "7d", now); progress != nil {
+			usage.CodexSparkSevenDay = progress
+		}
 	}
 
 	if (force || shouldRefreshOpenAICodexSnapshot(account, usage, now)) && s.shouldProbeOpenAICodexSnapshot(account.ID, now, force) {
@@ -561,11 +564,13 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 			if progress := buildCodexUsageProgressFromExtra(account.Extra, "7d", now); progress != nil {
 				usage.SevenDay = progress
 			}
-			if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "5h", now); progress != nil {
-				usage.CodexSparkFiveHour = progress
-			}
-			if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "7d", now); progress != nil {
-				usage.CodexSparkSevenDay = progress
+			if includeSpark {
+				if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "5h", now); progress != nil {
+					usage.CodexSparkFiveHour = progress
+				}
+				if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "7d", now); progress != nil {
+					usage.CodexSparkSevenDay = progress
+				}
 			}
 		}
 	}
@@ -589,6 +594,22 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 	}
 
 	return usage, nil
+}
+
+func accountEligibleForOpenAISparkUsage(account *Account) bool {
+	if account == nil || !account.IsOpenAIOAuth() {
+		return false
+	}
+	return openAIPlanEligibleForSparkUsage(account.GetCredential("plan_type"))
+}
+
+func openAIPlanEligibleForSparkUsage(planType string) bool {
+	switch strings.ToLower(strings.TrimSpace(planType)) {
+	case "pro", "prolite":
+		return true
+	default:
+		return false
+	}
 }
 
 func shouldRefreshOpenAICodexSnapshot(account *Account, usage *UsageInfo, now time.Time) bool {
@@ -641,8 +662,8 @@ func (s *AccountUsageService) shouldProbeOpenAICodexSnapshot(accountID int64, no
 	return true
 }
 
-func openAICodexProbeModels(force bool) []string {
-	if force {
+func openAICodexProbeModels(force bool, includeSpark bool) []string {
+	if force && includeSpark {
 		return []string{openaipkg.DefaultTestModel, openAICodexSparkProbeModel}
 	}
 	return []string{openaipkg.DefaultTestModel}
@@ -660,7 +681,7 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	var combinedUpdates map[string]any
 	var firstErr error
 	probeSucceeded := false
-	for _, modelID := range openAICodexProbeModels(force) {
+	for _, modelID := range openAICodexProbeModels(force, accountEligibleForOpenAISparkUsage(account)) {
 		updates, err := s.probeOpenAICodexSnapshotForModel(ctx, account, accessToken, modelID)
 		if err != nil {
 			if firstErr == nil {

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -105,13 +105,14 @@ type antigravityUsageCache struct {
 }
 
 const (
-	apiCacheTTL             = 3 * time.Minute
-	apiErrorCacheTTL        = 1 * time.Minute        // 负缓存 TTL：429 等错误缓存 1 分钟
-	antigravityErrorTTL     = 1 * time.Minute        // Antigravity 错误缓存 TTL（可恢复错误）
-	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
-	windowStatsCacheTTL     = 1 * time.Minute
-	openAIProbeCacheTTL     = 10 * time.Minute
-	openAICodexProbeVersion = "0.125.0"
+	apiCacheTTL                = 3 * time.Minute
+	apiErrorCacheTTL           = 1 * time.Minute        // 负缓存 TTL：429 等错误缓存 1 分钟
+	antigravityErrorTTL        = 1 * time.Minute        // Antigravity 错误缓存 TTL（可恢复错误）
+	apiQueryMaxJitter          = 800 * time.Millisecond // 用量查询最大随机延迟
+	windowStatsCacheTTL        = 1 * time.Minute
+	openAIProbeCacheTTL        = 10 * time.Minute
+	openAICodexProbeVersion    = "0.125.0"
+	openAICodexSparkProbeModel = "gpt-5.3-codex-spark"
 )
 
 // UsageCache 封装账户使用量相关的缓存
@@ -179,17 +180,19 @@ type AICredit struct {
 
 // UsageInfo 账号使用量信息
 type UsageInfo struct {
-	Source             string         `json:"source,omitempty"`               // "passive" or "active"
-	UpdatedAt          *time.Time     `json:"updated_at,omitempty"`           // 更新时间
-	FiveHour           *UsageProgress `json:"five_hour"`                      // 5小时窗口
-	SevenDay           *UsageProgress `json:"seven_day,omitempty"`            // 7天窗口
-	SevenDaySonnet     *UsageProgress `json:"seven_day_sonnet,omitempty"`     // 7天Sonnet窗口
-	GeminiSharedDaily  *UsageProgress `json:"gemini_shared_daily,omitempty"`  // Gemini shared pool RPD (Google One / Code Assist)
-	GeminiProDaily     *UsageProgress `json:"gemini_pro_daily,omitempty"`     // Gemini Pro 日配额
-	GeminiFlashDaily   *UsageProgress `json:"gemini_flash_daily,omitempty"`   // Gemini Flash 日配额
-	GeminiSharedMinute *UsageProgress `json:"gemini_shared_minute,omitempty"` // Gemini shared pool RPM (Google One / Code Assist)
-	GeminiProMinute    *UsageProgress `json:"gemini_pro_minute,omitempty"`    // Gemini Pro RPM
-	GeminiFlashMinute  *UsageProgress `json:"gemini_flash_minute,omitempty"`  // Gemini Flash RPM
+	Source             string         `json:"source,omitempty"`                // "passive" or "active"
+	UpdatedAt          *time.Time     `json:"updated_at,omitempty"`            // 更新时间
+	FiveHour           *UsageProgress `json:"five_hour"`                       // 5小时窗口
+	SevenDay           *UsageProgress `json:"seven_day,omitempty"`             // 7天窗口
+	SevenDaySonnet     *UsageProgress `json:"seven_day_sonnet,omitempty"`      // 7天Sonnet窗口
+	CodexSparkFiveHour *UsageProgress `json:"codex_spark_five_hour,omitempty"` // GPT-5.3-Codex-Spark 5小时窗口
+	CodexSparkSevenDay *UsageProgress `json:"codex_spark_seven_day,omitempty"` // GPT-5.3-Codex-Spark 7天窗口
+	GeminiSharedDaily  *UsageProgress `json:"gemini_shared_daily,omitempty"`   // Gemini shared pool RPD (Google One / Code Assist)
+	GeminiProDaily     *UsageProgress `json:"gemini_pro_daily,omitempty"`      // Gemini Pro 日配额
+	GeminiFlashDaily   *UsageProgress `json:"gemini_flash_daily,omitempty"`    // Gemini Flash 日配额
+	GeminiSharedMinute *UsageProgress `json:"gemini_shared_minute,omitempty"`  // Gemini shared pool RPM (Google One / Code Assist)
+	GeminiProMinute    *UsageProgress `json:"gemini_pro_minute,omitempty"`     // Gemini Pro RPM
+	GeminiFlashMinute  *UsageProgress `json:"gemini_flash_minute,omitempty"`   // Gemini Flash RPM
 
 	// Antigravity 多模型配额
 	AntigravityQuota map[string]*AntigravityModelQuota `json:"antigravity_quota,omitempty"`
@@ -539,9 +542,15 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 	if progress := buildCodexUsageProgressFromExtra(account.Extra, "7d", now); progress != nil {
 		usage.SevenDay = progress
 	}
+	if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "5h", now); progress != nil {
+		usage.CodexSparkFiveHour = progress
+	}
+	if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "7d", now); progress != nil {
+		usage.CodexSparkSevenDay = progress
+	}
 
 	if (force || shouldRefreshOpenAICodexSnapshot(account, usage, now)) && s.shouldProbeOpenAICodexSnapshot(account.ID, now, force) {
-		if updates, err := s.probeOpenAICodexSnapshot(ctx, account); err == nil && len(updates) > 0 {
+		if updates, err := s.probeOpenAICodexSnapshot(ctx, account, force); err == nil && len(updates) > 0 {
 			mergeAccountExtra(account, updates)
 			if usage.UpdatedAt == nil {
 				usage.UpdatedAt = &now
@@ -551,6 +560,12 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 			}
 			if progress := buildCodexUsageProgressFromExtra(account.Extra, "7d", now); progress != nil {
 				usage.SevenDay = progress
+			}
+			if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "5h", now); progress != nil {
+				usage.CodexSparkFiveHour = progress
+			}
+			if progress := buildCodexUsageProgressFromExtraWithPrefix(account.Extra, "codex_spark", "7d", now); progress != nil {
+				usage.CodexSparkSevenDay = progress
 			}
 		}
 	}
@@ -626,7 +641,14 @@ func (s *AccountUsageService) shouldProbeOpenAICodexSnapshot(accountID int64, no
 	return true
 }
 
-func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, account *Account) (map[string]any, error) {
+func openAICodexProbeModels(force bool) []string {
+	if force {
+		return []string{openaipkg.DefaultTestModel, openAICodexSparkProbeModel}
+	}
+	return []string{openaipkg.DefaultTestModel}
+}
+
+func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, account *Account, force bool) (map[string]any, error) {
 	if account == nil || !account.IsOAuth() {
 		return nil, nil
 	}
@@ -634,7 +656,28 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	if accessToken == "" {
 		return nil, fmt.Errorf("no access token available")
 	}
-	modelID := openaipkg.DefaultTestModel
+
+	var combinedUpdates map[string]any
+	var firstErr error
+	probeSucceeded := false
+	for _, modelID := range openAICodexProbeModels(force) {
+		updates, err := s.probeOpenAICodexSnapshotForModel(ctx, account, accessToken, modelID)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		probeSucceeded = true
+		combinedUpdates = mergeExtraUpdates(combinedUpdates, updates)
+	}
+	if !probeSucceeded && firstErr != nil {
+		return nil, firstErr
+	}
+	return combinedUpdates, nil
+}
+
+func (s *AccountUsageService) probeOpenAICodexSnapshotForModel(ctx context.Context, account *Account, accessToken string, modelID string) (map[string]any, error) {
 	payload := createOpenAITestPayload(modelID, true)
 	payloadBytes, err := json.Marshal(payload)
 	if err != nil {
@@ -680,7 +723,7 @@ func (s *AccountUsageService) probeOpenAICodexSnapshot(ctx context.Context, acco
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	updates, err := extractOpenAICodexProbeUpdates(resp)
+	updates, err := extractOpenAICodexProbeUpdatesForModel(resp, modelID)
 	if err != nil {
 		return nil, err
 	}
@@ -707,11 +750,15 @@ func (s *AccountUsageService) persistOpenAICodexProbeSnapshot(accountID int64, u
 }
 
 func extractOpenAICodexProbeUpdates(resp *http.Response) (map[string]any, error) {
+	return extractOpenAICodexProbeUpdatesForModel(resp, "")
+}
+
+func extractOpenAICodexProbeUpdatesForModel(resp *http.Response, model string) (map[string]any, error) {
 	if resp == nil {
 		return nil, nil
 	}
 	if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-		return buildCodexUsageExtraUpdates(snapshot, time.Now()), nil
+		return buildCodexUsageExtraUpdatesForModel(snapshot, time.Now(), model), nil
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return nil, fmt.Errorf("openai codex probe returned status %d", resp.StatusCode)
@@ -1110,8 +1157,15 @@ func windowStatsFromAccountStats(stats *usagestats.AccountStats) *WindowStats {
 }
 
 func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now time.Time) *UsageProgress {
+	return buildCodexUsageProgressFromExtraWithPrefix(extra, "codex", window, now)
+}
+
+func buildCodexUsageProgressFromExtraWithPrefix(extra map[string]any, prefix string, window string, now time.Time) *UsageProgress {
 	if len(extra) == 0 {
 		return nil
+	}
+	if strings.TrimSpace(prefix) == "" {
+		prefix = "codex"
 	}
 
 	var (
@@ -1122,13 +1176,13 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 
 	switch window {
 	case "5h":
-		usedPercentKey = "codex_5h_used_percent"
-		resetAfterKey = "codex_5h_reset_after_seconds"
-		resetAtKey = "codex_5h_reset_at"
+		usedPercentKey = prefix + "_5h_used_percent"
+		resetAfterKey = prefix + "_5h_reset_after_seconds"
+		resetAtKey = prefix + "_5h_reset_at"
 	case "7d":
-		usedPercentKey = "codex_7d_used_percent"
-		resetAfterKey = "codex_7d_reset_after_seconds"
-		resetAtKey = "codex_7d_reset_at"
+		usedPercentKey = prefix + "_7d_used_percent"
+		resetAfterKey = prefix + "_7d_reset_after_seconds"
+		resetAtKey = prefix + "_7d_reset_at"
 	default:
 		return nil
 	}
@@ -1151,7 +1205,7 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	if progress.ResetsAt == nil {
 		if resetAfterSeconds := parseExtraInt(extra[resetAfterKey]); resetAfterSeconds > 0 {
 			base := now
-			if updatedAtRaw, ok := extra["codex_usage_updated_at"]; ok {
+			if updatedAtRaw, ok := extra[prefix+"_usage_updated_at"]; ok {
 				if updatedAt, err := parseTime(fmt.Sprint(updatedAtRaw)); err == nil {
 					base = updatedAt
 				}

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -97,20 +97,47 @@ func TestExtractOpenAICodexProbeUpdatesAccepts429WithCodexHeaders(t *testing.T) 
 func TestOpenAICodexProbeModels(t *testing.T) {
 	t.Parallel()
 
-	passive := openAICodexProbeModels(false)
+	passive := openAICodexProbeModels(false, true)
 	if len(passive) != 1 || passive[0] != openaipkg.DefaultTestModel {
-		t.Fatalf("openAICodexProbeModels(false) = %#v, want only %q", passive, openaipkg.DefaultTestModel)
+		t.Fatalf("openAICodexProbeModels(false, true) = %#v, want only %q", passive, openaipkg.DefaultTestModel)
 	}
 
-	active := openAICodexProbeModels(true)
+	activeNonPro := openAICodexProbeModels(true, false)
+	if len(activeNonPro) != 1 || activeNonPro[0] != openaipkg.DefaultTestModel {
+		t.Fatalf("openAICodexProbeModels(true, false) = %#v, want only %q", activeNonPro, openaipkg.DefaultTestModel)
+	}
+
+	active := openAICodexProbeModels(true, true)
 	if len(active) != 2 {
-		t.Fatalf("openAICodexProbeModels(true) = %#v, want 2 models", active)
+		t.Fatalf("openAICodexProbeModels(true, true) = %#v, want 2 models", active)
 	}
 	if active[0] != openaipkg.DefaultTestModel {
 		t.Fatalf("active first model = %q, want %q", active[0], openaipkg.DefaultTestModel)
 	}
 	if active[1] != openAICodexSparkProbeModel {
 		t.Fatalf("active second model = %q, want %q", active[1], openAICodexSparkProbeModel)
+	}
+}
+
+func TestOpenAIPlanEligibleForSparkUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		planType string
+		want     bool
+	}{
+		{planType: "pro", want: true},
+		{planType: "prolite", want: true},
+		{planType: " ProLite ", want: true},
+		{planType: "plus", want: false},
+		{planType: "free", want: false},
+		{planType: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := openAIPlanEligibleForSparkUsage(tt.planType); got != tt.want {
+			t.Fatalf("openAIPlanEligibleForSparkUsage(%q) = %v, want %v", tt.planType, got, tt.want)
+		}
 	}
 }
 
@@ -185,8 +212,9 @@ func TestAccountUsageService_GetOpenAIUsage_ReturnsSparkSnapshot(t *testing.T) {
 	now := time.Now().UTC().Truncate(time.Second)
 	svc := &AccountUsageService{}
 	account := &Account{
-		Platform: PlatformOpenAI,
-		Type:     AccountTypeOAuth,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"plan_type": "pro"},
 		Extra: map[string]any{
 			"codex_5h_used_percent": 43.0,
 			"codex_5h_reset_at":     now.Add(30 * time.Minute).Format(time.RFC3339),
@@ -212,6 +240,37 @@ func TestAccountUsageService_GetOpenAIUsage_ReturnsSparkSnapshot(t *testing.T) {
 	}
 	if usage.CodexSparkSevenDay == nil || usage.CodexSparkSevenDay.Utilization != 16.0 {
 		t.Fatalf("spark 7d usage = %#v, want utilization 16", usage.CodexSparkSevenDay)
+	}
+}
+
+func TestAccountUsageService_GetOpenAIUsage_HidesSparkSnapshotForNonPro(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	svc := &AccountUsageService{}
+	account := &Account{
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"plan_type": "free"},
+		Extra: map[string]any{
+			"codex_5h_used_percent":       43.0,
+			"codex_5h_reset_at":           now.Add(30 * time.Minute).Format(time.RFC3339),
+			"codex_spark_5h_used_percent": 8.0,
+			"codex_spark_5h_reset_at":     now.Add(5 * time.Hour).Format(time.RFC3339),
+			"codex_spark_7d_used_percent": 41.0,
+			"codex_spark_7d_reset_at":     now.Add(6 * 24 * time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	usage, err := svc.getOpenAIUsage(context.Background(), account, false)
+	if err != nil {
+		t.Fatalf("getOpenAIUsage() error = %v", err)
+	}
+	if usage.FiveHour == nil || usage.FiveHour.Utilization != 43.0 {
+		t.Fatalf("normal 5h usage = %#v, want utilization 43", usage.FiveHour)
+	}
+	if usage.CodexSparkFiveHour != nil || usage.CodexSparkSevenDay != nil {
+		t.Fatalf("non-Pro account must not expose Spark usage: 5h=%#v 7d=%#v", usage.CodexSparkFiveHour, usage.CodexSparkSevenDay)
 	}
 }
 

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	openaipkg "github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 )
 
 type accountUsageCodexProbeRepo struct {
@@ -92,6 +94,26 @@ func TestExtractOpenAICodexProbeUpdatesAccepts429WithCodexHeaders(t *testing.T) 
 	}
 }
 
+func TestOpenAICodexProbeModels(t *testing.T) {
+	t.Parallel()
+
+	passive := openAICodexProbeModels(false)
+	if len(passive) != 1 || passive[0] != openaipkg.DefaultTestModel {
+		t.Fatalf("openAICodexProbeModels(false) = %#v, want only %q", passive, openaipkg.DefaultTestModel)
+	}
+
+	active := openAICodexProbeModels(true)
+	if len(active) != 2 {
+		t.Fatalf("openAICodexProbeModels(true) = %#v, want 2 models", active)
+	}
+	if active[0] != openaipkg.DefaultTestModel {
+		t.Fatalf("active first model = %q, want %q", active[0], openaipkg.DefaultTestModel)
+	}
+	if active[1] != openAICodexSparkProbeModel {
+		t.Fatalf("active second model = %q, want %q", active[1], openAICodexSparkProbeModel)
+	}
+}
+
 func TestAccountUsageService_PersistOpenAICodexProbeSnapshotOnlyUpdatesExtra(t *testing.T) {
 	t.Parallel()
 
@@ -154,6 +176,42 @@ func TestAccountUsageService_GetOpenAIUsage_DoesNotPromoteCodexExtraToRateLimit(
 	case got := <-repo.rateLimitCh:
 		t.Fatalf("不应将已耗尽的 codex extra 持久化为运行时限流状态: %v", got)
 	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestAccountUsageService_GetOpenAIUsage_ReturnsSparkSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	svc := &AccountUsageService{}
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_5h_used_percent": 43.0,
+			"codex_5h_reset_at":     now.Add(30 * time.Minute).Format(time.RFC3339),
+			"codex_7d_used_percent": 32.0,
+			"codex_7d_reset_at":     now.Add(6 * 24 * time.Hour).Format(time.RFC3339),
+
+			"codex_spark_5h_used_percent": 0.0,
+			"codex_spark_5h_reset_at":     now.Add(5 * time.Hour).Format(time.RFC3339),
+			"codex_spark_7d_used_percent": 16.0,
+			"codex_spark_7d_reset_at":     now.Add(6*24*time.Hour + 9*time.Hour).Format(time.RFC3339),
+		},
+	}
+
+	usage, err := svc.getOpenAIUsage(context.Background(), account, false)
+	if err != nil {
+		t.Fatalf("getOpenAIUsage() error = %v", err)
+	}
+	if usage.FiveHour == nil || usage.FiveHour.Utilization != 43.0 {
+		t.Fatalf("normal 5h usage = %#v, want utilization 43", usage.FiveHour)
+	}
+	if usage.CodexSparkFiveHour == nil || usage.CodexSparkFiveHour.Utilization != 0.0 {
+		t.Fatalf("spark 5h usage = %#v, want utilization 0", usage.CodexSparkFiveHour)
+	}
+	if usage.CodexSparkSevenDay == nil || usage.CodexSparkSevenDay.Utilization != 16.0 {
+		t.Fatalf("spark 7d usage = %#v, want utilization 16", usage.CodexSparkSevenDay)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -347,7 +347,7 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 	// Extract and save Codex usage snapshot from response headers (for OAuth accounts)
 	if handleErr == nil && account.Type == AccountTypeOAuth {
 		if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+			s.updateCodexUsageSnapshotForModel(ctx, account.ID, snapshot, upstreamModel)
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -415,7 +415,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		if account.Platform == PlatformGrok {
 			s.updateGrokUsageSnapshot(ctx, account.ID, xai.ParseQuotaHeaders(resp.Header, resp.StatusCode))
 		} else if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-			s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+			s.updateCodexUsageSnapshotForModel(ctx, account.ID, snapshot, upstreamModel)
 		}
 	}
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -291,34 +291,45 @@ type openAIWSRetryMetrics struct {
 type accountWriteThrottle struct {
 	minInterval time.Duration
 	mu          sync.Mutex
-	lastByID    map[int64]time.Time
+	lastByKey   map[string]time.Time
 }
 
 func newAccountWriteThrottle(minInterval time.Duration) *accountWriteThrottle {
 	return &accountWriteThrottle{
 		minInterval: minInterval,
-		lastByID:    make(map[int64]time.Time),
+		lastByKey:   make(map[string]time.Time),
 	}
 }
 
 func (t *accountWriteThrottle) Allow(id int64, now time.Time) bool {
-	if t == nil || id <= 0 || t.minInterval <= 0 {
+	if id <= 0 {
+		return true
+	}
+	return t.AllowKey(strconv.FormatInt(id, 10), now)
+}
+
+func (t *accountWriteThrottle) AllowKey(key string, now time.Time) bool {
+	key = strings.TrimSpace(key)
+	if t == nil || t.minInterval <= 0 {
+		return true
+	}
+	if key == "" {
 		return true
 	}
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if last, ok := t.lastByID[id]; ok && now.Sub(last) < t.minInterval {
+	if last, ok := t.lastByKey[key]; ok && now.Sub(last) < t.minInterval {
 		return false
 	}
-	t.lastByID[id] = now
+	t.lastByKey[key] = now
 
-	if len(t.lastByID) > 4096 {
+	if len(t.lastByKey) > 4096 {
 		cutoff := now.Add(-4 * t.minInterval)
-		for accountID, writtenAt := range t.lastByID {
+		for throttleKey, writtenAt := range t.lastByKey {
 			if writtenAt.Before(cutoff) {
-				delete(t.lastByID, accountID)
+				delete(t.lastByKey, throttleKey)
 			}
 		}
 	}
@@ -3288,7 +3299,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		// Extract and save Codex usage snapshot from response headers (for OAuth accounts)
 		if account.Type == AccountTypeOAuth {
 			if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-				s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+				s.updateCodexUsageSnapshotForModel(ctx, account.ID, snapshot, upstreamModel)
 			}
 		}
 
@@ -3523,7 +3534,8 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	s.bindHTTPResponseAccount(ctx, c, account, responseID)
 
 	if snapshot := ParseCodexRateLimitHeaders(resp.Header); snapshot != nil {
-		s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+		snapshotModel := resolveOpenAIPassthroughCodexSnapshotModel(reqModel, upstreamPassthroughModel, body)
+		s.updateCodexUsageSnapshotForModel(ctx, account.ID, snapshot, snapshotModel)
 	}
 
 	if usage == nil {
@@ -6692,8 +6704,38 @@ func codexResetAtRFC3339(base time.Time, resetAfterSeconds *int) *string {
 }
 
 func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow time.Time) map[string]any {
+	return buildCodexUsageExtraUpdatesWithPrefix(snapshot, fallbackNow, "codex")
+}
+
+func resolveOpenAIPassthroughCodexSnapshotModel(reqModel, upstreamPassthroughModel string, body []byte) string {
+	if model := strings.TrimSpace(upstreamPassthroughModel); model != "" {
+		return model
+	}
+	if len(body) > 0 {
+		if model := strings.TrimSpace(gjson.GetBytes(body, "model").String()); model != "" {
+			return model
+		}
+	}
+	return strings.TrimSpace(reqModel)
+}
+
+func buildCodexUsageExtraUpdatesForModel(snapshot *OpenAICodexUsageSnapshot, fallbackNow time.Time, model string) map[string]any {
+	return buildCodexUsageExtraUpdatesWithPrefix(snapshot, fallbackNow, codexUsageExtraPrefixForModel(model))
+}
+
+func codexUsageExtraPrefixForModel(model string) string {
+	if isCodexSparkModel(model) {
+		return "codex_spark"
+	}
+	return "codex"
+}
+
+func buildCodexUsageExtraUpdatesWithPrefix(snapshot *OpenAICodexUsageSnapshot, fallbackNow time.Time, prefix string) map[string]any {
 	if snapshot == nil {
 		return nil
+	}
+	if strings.TrimSpace(prefix) == "" {
+		prefix = "codex"
 	}
 
 	baseTime := codexSnapshotBaseTime(snapshot, fallbackNow)
@@ -6701,53 +6743,53 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 
 	// 保存原始 primary/secondary 字段，便于排查问题
 	if snapshot.PrimaryUsedPercent != nil {
-		updates["codex_primary_used_percent"] = *snapshot.PrimaryUsedPercent
+		updates[prefix+"_primary_used_percent"] = *snapshot.PrimaryUsedPercent
 	}
 	if snapshot.PrimaryResetAfterSeconds != nil {
-		updates["codex_primary_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
+		updates[prefix+"_primary_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
 	}
 	if snapshot.PrimaryWindowMinutes != nil {
-		updates["codex_primary_window_minutes"] = *snapshot.PrimaryWindowMinutes
+		updates[prefix+"_primary_window_minutes"] = *snapshot.PrimaryWindowMinutes
 	}
 	if snapshot.SecondaryUsedPercent != nil {
-		updates["codex_secondary_used_percent"] = *snapshot.SecondaryUsedPercent
+		updates[prefix+"_secondary_used_percent"] = *snapshot.SecondaryUsedPercent
 	}
 	if snapshot.SecondaryResetAfterSeconds != nil {
-		updates["codex_secondary_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
+		updates[prefix+"_secondary_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
 	}
 	if snapshot.SecondaryWindowMinutes != nil {
-		updates["codex_secondary_window_minutes"] = *snapshot.SecondaryWindowMinutes
+		updates[prefix+"_secondary_window_minutes"] = *snapshot.SecondaryWindowMinutes
 	}
 	if snapshot.PrimaryOverSecondaryPercent != nil {
-		updates["codex_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
+		updates[prefix+"_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
 	}
-	updates["codex_usage_updated_at"] = baseTime.Format(time.RFC3339)
+	updates[prefix+"_usage_updated_at"] = baseTime.Format(time.RFC3339)
 
 	// 归一化到 5h/7d 规范字段
 	if normalized := snapshot.Normalize(); normalized != nil {
 		if normalized.Used5hPercent != nil {
-			updates["codex_5h_used_percent"] = *normalized.Used5hPercent
+			updates[prefix+"_5h_used_percent"] = *normalized.Used5hPercent
 		}
 		if normalized.Reset5hSeconds != nil {
-			updates["codex_5h_reset_after_seconds"] = *normalized.Reset5hSeconds
+			updates[prefix+"_5h_reset_after_seconds"] = *normalized.Reset5hSeconds
 		}
 		if normalized.Window5hMinutes != nil {
-			updates["codex_5h_window_minutes"] = *normalized.Window5hMinutes
+			updates[prefix+"_5h_window_minutes"] = *normalized.Window5hMinutes
 		}
 		if normalized.Used7dPercent != nil {
-			updates["codex_7d_used_percent"] = *normalized.Used7dPercent
+			updates[prefix+"_7d_used_percent"] = *normalized.Used7dPercent
 		}
 		if normalized.Reset7dSeconds != nil {
-			updates["codex_7d_reset_after_seconds"] = *normalized.Reset7dSeconds
+			updates[prefix+"_7d_reset_after_seconds"] = *normalized.Reset7dSeconds
 		}
 		if normalized.Window7dMinutes != nil {
-			updates["codex_7d_window_minutes"] = *normalized.Window7dMinutes
+			updates[prefix+"_7d_window_minutes"] = *normalized.Window7dMinutes
 		}
 		if reset5hAt := codexResetAtRFC3339(baseTime, normalized.Reset5hSeconds); reset5hAt != nil {
-			updates["codex_5h_reset_at"] = *reset5hAt
+			updates[prefix+"_5h_reset_at"] = *reset5hAt
 		}
 		if reset7dAt := codexResetAtRFC3339(baseTime, normalized.Reset7dSeconds); reset7dAt != nil {
-			updates["codex_7d_reset_at"] = *reset7dAt
+			updates[prefix+"_7d_reset_at"] = *reset7dAt
 		}
 	}
 
@@ -6756,6 +6798,10 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 
 // updateCodexUsageSnapshot saves the Codex usage snapshot to account's Extra field
 func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot) {
+	s.updateCodexUsageSnapshotForModel(ctx, accountID, snapshot, "")
+}
+
+func (s *OpenAIGatewayService) updateCodexUsageSnapshotForModel(ctx context.Context, accountID int64, snapshot *OpenAICodexUsageSnapshot, model string) {
 	if snapshot == nil {
 		return
 	}
@@ -6764,11 +6810,13 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 	}
 
 	now := time.Now()
-	updates := buildCodexUsageExtraUpdates(snapshot, now)
+	updates := buildCodexUsageExtraUpdatesForModel(snapshot, now, model)
 	if len(updates) == 0 {
 		return
 	}
-	if !s.getCodexSnapshotThrottle().Allow(accountID, now) {
+	prefix := codexUsageExtraPrefixForModel(model)
+	throttleKey := strconv.FormatInt(accountID, 10) + ":" + prefix
+	if !s.getCodexSnapshotThrottle().AllowKey(throttleKey, now) {
 		return
 	}
 

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -137,6 +137,78 @@ func TestBuildCodexUsageExtraUpdates_FreshAccountUsedPercentNotInverted_Issue299
 	}
 }
 
+func TestBuildCodexUsageExtraUpdatesForModel_SparkUsesSeparateKeys(t *testing.T) {
+	primaryUsed := 16.0
+	primaryReset := 604800
+	primaryWindow := 10080
+	secondaryUsed := 0.0
+	secondaryReset := 18000
+	secondaryWindow := 300
+
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         &primaryUsed,
+		PrimaryResetAfterSeconds:   &primaryReset,
+		PrimaryWindowMinutes:       &primaryWindow,
+		SecondaryUsedPercent:       &secondaryUsed,
+		SecondaryResetAfterSeconds: &secondaryReset,
+		SecondaryWindowMinutes:     &secondaryWindow,
+		UpdatedAt:                  "2026-06-26T10:00:00Z",
+	}
+
+	updates := buildCodexUsageExtraUpdatesForModel(snapshot, time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC), "gpt-5.3-codex-spark")
+	if updates == nil {
+		t.Fatal("expected non-nil updates")
+	}
+
+	if got := updates["codex_spark_usage_updated_at"]; got != "2026-06-26T10:00:00Z" {
+		t.Fatalf("codex_spark_usage_updated_at = %v, want %s", got, "2026-06-26T10:00:00Z")
+	}
+	if got := updates["codex_spark_5h_used_percent"]; got != 0.0 {
+		t.Fatalf("codex_spark_5h_used_percent = %v, want 0", got)
+	}
+	if got := updates["codex_spark_7d_used_percent"]; got != 16.0 {
+		t.Fatalf("codex_spark_7d_used_percent = %v, want 16", got)
+	}
+	if _, ok := updates["codex_5h_used_percent"]; ok {
+		t.Fatalf("spark snapshot must not overwrite normal codex_5h_used_percent: %v", updates["codex_5h_used_percent"])
+	}
+	if _, ok := updates["codex_7d_used_percent"]; ok {
+		t.Fatalf("spark snapshot must not overwrite normal codex_7d_used_percent: %v", updates["codex_7d_used_percent"])
+	}
+}
+
+func TestResolveOpenAIPassthroughCodexSnapshotModel(t *testing.T) {
+	t.Run("prefers upstream passthrough model", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex-spark","stream":true}`)
+
+		got := resolveOpenAIPassthroughCodexSnapshotModel("gpt-5.2", "gpt-5.4", body)
+
+		if got != "gpt-5.4" {
+			t.Fatalf("resolveOpenAIPassthroughCodexSnapshotModel(...) = %q, want %q", got, "gpt-5.4")
+		}
+	})
+
+	t.Run("falls back to final body model", func(t *testing.T) {
+		body := []byte(`{"model":"gpt-5.3-codex-spark","stream":true}`)
+
+		got := resolveOpenAIPassthroughCodexSnapshotModel("gpt-5.2", "", body)
+
+		if got != "gpt-5.3-codex-spark" {
+			t.Fatalf("resolveOpenAIPassthroughCodexSnapshotModel(...) = %q, want %q", got, "gpt-5.3-codex-spark")
+		}
+	})
+
+	t.Run("falls back to request model when body has no model", func(t *testing.T) {
+		body := []byte(`{"stream":true}`)
+
+		got := resolveOpenAIPassthroughCodexSnapshotModel("gpt-5.2", "", body)
+
+		if got != "gpt-5.2" {
+			t.Fatalf("resolveOpenAIPassthroughCodexSnapshotModel(...) = %q, want %q", got, "gpt-5.2")
+		}
+	})
+}
+
 func TestBuildCodexUsageExtraUpdates_FallbackToNowWhenUpdatedAtInvalid(t *testing.T) {
 	primaryUsed := 15.0
 	primaryReset := 30

--- a/backend/internal/service/openai_ws_ratelimit_signal_test.go
+++ b/backend/internal/service/openai_ws_ratelimit_signal_test.go
@@ -440,6 +440,45 @@ func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThrottlesExtraWrites(t *t
 	}
 }
 
+func TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThrottlesNormalAndSparkSeparately(t *testing.T) {
+	repo := &openAICodexSnapshotAsyncRepo{
+		updateExtraCh: make(chan map[string]any, 2),
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:           repo,
+		codexSnapshotThrottle: newAccountWriteThrottle(time.Hour),
+	}
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:         ptrFloat64WS(16),
+		PrimaryResetAfterSeconds:   ptrIntWS(604800),
+		PrimaryWindowMinutes:       ptrIntWS(10080),
+		SecondaryUsedPercent:       ptrFloat64WS(0),
+		SecondaryResetAfterSeconds: ptrIntWS(18000),
+		SecondaryWindowMinutes:     ptrIntWS(300),
+	}
+
+	svc.updateCodexUsageSnapshotForModel(context.Background(), 778, snapshot, "gpt-5.4")
+	svc.updateCodexUsageSnapshotForModel(context.Background(), 778, snapshot, "gpt-5.3-codex-spark")
+
+	seenNormal := false
+	seenSpark := false
+	for i := 0; i < 2; i++ {
+		select {
+		case updates := <-repo.updateExtraCh:
+			if _, ok := updates["codex_5h_used_percent"]; ok {
+				seenNormal = true
+			}
+			if _, ok := updates["codex_spark_5h_used_percent"]; ok {
+				seenSpark = true
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatal("等待 codex/spark 快照落库超时")
+		}
+	}
+	require.True(t, seenNormal, "normal codex snapshot should be persisted")
+	require.True(t, seenSpark, "spark codex snapshot should be persisted")
+}
+
 func ptrFloat64WS(v float64) *float64 { return &v }
 func ptrIntWS(v int) *int             { return &v }
 

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -163,6 +163,10 @@ func (s *RateLimitService) CheckErrorPolicy(ctx context.Context, account *Accoun
 // 返回是否应该停止该账号的调度
 func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel ...string) (shouldDisable bool) {
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
+	upstreamModel := ""
+	if len(requestedModel) > 0 {
+		upstreamModel = strings.TrimSpace(requestedModel[0])
+	}
 
 	// 池模式默认不标记本地账号状态；仅当用户显式配置自定义错误码时按本地策略处理。
 	if account.IsPoolMode() && !customErrorCodesEnabled {
@@ -177,7 +181,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		return false
 	}
 
-	if len(requestedModel) > 0 && s.HandleUpstreamModelNotFound(ctx, account, requestedModel[0], statusCode, responseBody) {
+	if upstreamModel != "" && s.HandleUpstreamModelNotFound(ctx, account, upstreamModel, statusCode, responseBody) {
 		return true
 	}
 
@@ -327,7 +331,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		)
 		shouldDisable = s.handle403(ctx, account, upstreamMsg, responseBody)
 	case 429:
-		s.handle429(ctx, account, headers, responseBody)
+		s.handle429(ctx, account, headers, responseBody, upstreamModel)
 		shouldDisable = false
 	case 529:
 		s.handle529(ctx, account)
@@ -880,11 +884,15 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte, upstreamModel ...string) {
 	// 1. OpenAI 平台：优先尝试解析 x-codex-* 响应头（用于 rate_limit_exceeded）
 	if account.Platform == PlatformOpenAI {
 		persistOpenAI429PlanType(ctx, s.accountRepo, account, responseBody)
-		s.persistOpenAICodexSnapshot(ctx, account, headers)
+		model := ""
+		if len(upstreamModel) > 0 {
+			model = upstreamModel[0]
+		}
+		s.persistOpenAICodexSnapshot(ctx, account, headers, model)
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
 			s.notifyAccountSchedulingBlocked(account, *resetAt, "429")
 			if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
@@ -1302,7 +1310,7 @@ func pickSooner(a, b *time.Time) *time.Time {
 	}
 }
 
-func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, account *Account, headers http.Header) {
+func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, account *Account, headers http.Header, upstreamModel string) {
 	if s == nil || s.accountRepo == nil || account == nil || headers == nil {
 		return
 	}
@@ -1310,7 +1318,7 @@ func (s *RateLimitService) persistOpenAICodexSnapshot(ctx context.Context, accou
 	if snapshot == nil {
 		return
 	}
-	updates := buildCodexUsageExtraUpdates(snapshot, time.Now())
+	updates := buildCodexUsageExtraUpdatesForModel(snapshot, time.Now(), upstreamModel)
 	if len(updates) == 0 {
 		return
 	}

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -200,6 +200,38 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	}
 }
 
+func TestHandle429_OpenAIPersistsSparkCodexSnapshotSeparately(t *testing.T) {
+	repo := &openAI429SnapshotRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 125, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "16")
+	headers.Set("x-codex-primary-reset-after-seconds", "604800")
+	headers.Set("x-codex-primary-window-minutes", "10080")
+	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
+	headers.Set("x-codex-secondary-window-minutes", "300")
+
+	svc.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, headers, nil, "gpt-5.3-codex-spark")
+
+	if len(repo.updatedExtra) == 0 {
+		t.Fatal("expected codex spark snapshot to be persisted on 429")
+	}
+	if got := repo.updatedExtra["codex_spark_5h_used_percent"]; got != 0.0 {
+		t.Fatalf("codex_spark_5h_used_percent = %v, want 0", got)
+	}
+	if got := repo.updatedExtra["codex_spark_7d_used_percent"]; got != 16.0 {
+		t.Fatalf("codex_spark_7d_used_percent = %v, want 16", got)
+	}
+	if _, ok := repo.updatedExtra["codex_5h_used_percent"]; ok {
+		t.Fatalf("spark 429 snapshot must not overwrite normal codex_5h_used_percent: %v", repo.updatedExtra["codex_5h_used_percent"])
+	}
+	if _, ok := repo.updatedExtra["codex_7d_used_percent"]; ok {
+		t.Fatalf("spark 429 snapshot must not overwrite normal codex_7d_used_percent: %v", repo.updatedExtra["codex_7d_used_percent"])
+	}
+}
+
 func TestHandle429_OpenAISyncsObservedPlanType(t *testing.T) {
 	repo := &openAI429SnapshotRepo{}
 	svc := NewRateLimitService(repo, nil, nil, nil, nil)

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -130,6 +130,22 @@
           :show-now-when-idle="true"
           color="emerald"
         />
+        <UsageProgressBar
+          v-if="usageInfo?.codex_spark_five_hour"
+          label="Spark 5h"
+          :utilization="usageInfo.codex_spark_five_hour.utilization"
+          :resets-at="usageInfo.codex_spark_five_hour.resets_at"
+          :show-now-when-idle="true"
+          color="indigo"
+        />
+        <UsageProgressBar
+          v-if="usageInfo?.codex_spark_seven_day"
+          label="Spark 7d"
+          :utilization="usageInfo.codex_spark_seven_day.utilization"
+          :resets-at="usageInfo.codex_spark_seven_day.resets_at"
+          :show-now-when-idle="true"
+          color="emerald"
+        />
         <!--
           Upstream codex /wham/usage quota query + reset. The local active-sampling
           refresh button is rendered via the pre-actions slot so the user sees a
@@ -676,7 +692,12 @@ const geminiUsageAvailable = computed(() => {
 
 const hasOpenAIUsageFallback = computed(() => {
   if (props.account.platform !== 'openai' || props.account.type !== 'oauth') return false
-  return !!usageInfo.value?.five_hour || !!usageInfo.value?.seven_day
+  return (
+    !!usageInfo.value?.five_hour ||
+    !!usageInfo.value?.seven_day ||
+    !!usageInfo.value?.codex_spark_five_hour ||
+    !!usageInfo.value?.codex_spark_seven_day
+  )
 })
 
 const openAIUsageRefreshKey = computed(() => buildOpenAIUsageRefreshKey(props.account))

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -131,7 +131,7 @@
           color="emerald"
         />
         <UsageProgressBar
-          v-if="usageInfo?.codex_spark_five_hour"
+          v-if="showOpenAISparkUsage && usageInfo?.codex_spark_five_hour"
           label="Spark 5h"
           :utilization="usageInfo.codex_spark_five_hour.utilization"
           :resets-at="usageInfo.codex_spark_five_hour.resets_at"
@@ -139,7 +139,7 @@
           color="indigo"
         />
         <UsageProgressBar
-          v-if="usageInfo?.codex_spark_seven_day"
+          v-if="showOpenAISparkUsage && usageInfo?.codex_spark_seven_day"
           label="Spark 7d"
           :utilization="usageInfo.codex_spark_seven_day.utilization"
           :resets-at="usageInfo.codex_spark_seven_day.resets_at"
@@ -193,7 +193,32 @@
       <div v-else>
         <div class="text-xs text-gray-400">-</div>
         <!-- Always allow on-demand upstream quota query, even before local data exists. -->
-        <OpenAIQuotaResetCell :account="account" class="mt-1" />
+        <OpenAIQuotaResetCell :account="account" class="mt-1">
+          <template #pre-actions>
+            <button
+              type="button"
+              class="inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-900/30 transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              :disabled="activeQueryLoading"
+              @click="loadActiveUsage"
+            >
+              <svg
+                class="h-2.5 w-2.5"
+                :class="{ 'animate-spin': activeQueryLoading }"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
+              {{ t('admin.accounts.usageWindow.activeQuery') }}
+            </button>
+          </template>
+        </OpenAIQuotaResetCell>
       </div>
     </template>
 
@@ -690,13 +715,18 @@ const geminiUsageAvailable = computed(() => {
   )
 })
 
+const showOpenAISparkUsage = computed(() => {
+  if (props.account.platform !== 'openai' || props.account.type !== 'oauth') return false
+  return isOpenAISparkPlan(props.account.credentials?.plan_type)
+})
+
 const hasOpenAIUsageFallback = computed(() => {
   if (props.account.platform !== 'openai' || props.account.type !== 'oauth') return false
   return (
     !!usageInfo.value?.five_hour ||
     !!usageInfo.value?.seven_day ||
-    !!usageInfo.value?.codex_spark_five_hour ||
-    !!usageInfo.value?.codex_spark_seven_day
+    (showOpenAISparkUsage.value &&
+      (!!usageInfo.value?.codex_spark_five_hour || !!usageInfo.value?.codex_spark_seven_day))
   )
 })
 
@@ -709,6 +739,11 @@ const shouldAutoLoadUsageOnMount = computed(() => {
 const shouldLazyLoadOnMobile = computed(() => {
   return shouldFetchUsage.value && !isDesktopViewport.value
 })
+
+function isOpenAISparkPlan(planType: unknown): boolean {
+  const normalized = String(planType ?? '').trim().toLowerCase()
+  return normalized === 'pro' || normalized === 'prolite'
+}
 
 // Antigravity quota types (用于 API 返回的数据)
 interface AntigravityUsageResult {

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -273,6 +273,119 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('7d|36|900')
   })
 
+  it('OpenAI OAuth 会在用量窗口展示 Spark 独立限额', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: {
+        utilization: 43,
+        resets_at: '2099-03-07T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 9,
+          tokens: 900,
+          cost: 0.09,
+          standard_cost: 0.09,
+          user_cost: 0.09
+        }
+      },
+      seven_day: {
+        utilization: 32,
+        resets_at: '2099-03-13T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 9,
+          tokens: 900,
+          cost: 0.09,
+          standard_cost: 0.09,
+          user_cost: 0.09
+        }
+      },
+      codex_spark_five_hour: {
+        utilization: 0,
+        resets_at: '2099-03-07T17:00:00Z',
+        remaining_seconds: 18000
+      },
+      codex_spark_seven_day: {
+        utilization: 16,
+        resets_at: '2099-03-13T21:00:00Z',
+        remaining_seconds: 604800
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2005,
+          platform: 'openai',
+          type: 'oauth',
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ resetsAt }}|{{ color }}</div>'
+          },
+          AccountQuotaInfo: true,
+          OpenAIQuotaResetCell: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2005)
+    expect(wrapper.text()).toContain('5h|43|2099-03-07T12:00:00Z|indigo')
+    expect(wrapper.text()).toContain('7d|32|2099-03-13T12:00:00Z|emerald')
+    expect(wrapper.text()).toContain('Spark 5h|0|2099-03-07T17:00:00Z|indigo')
+    expect(wrapper.text()).toContain('Spark 7d|16|2099-03-13T21:00:00Z|emerald')
+  })
+
+  it('OpenAI OAuth 只有 Spark 快照时仍展示 Spark 独立限额', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: null,
+      seven_day: null,
+      codex_spark_five_hour: {
+        utilization: 8,
+        resets_at: '2099-03-07T17:00:00Z',
+        remaining_seconds: 18000
+      },
+      codex_spark_seven_day: {
+        utilization: 41,
+        resets_at: '2099-03-13T21:00:00Z',
+        remaining_seconds: 604800
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2006,
+          platform: 'openai',
+          type: 'oauth',
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ resetsAt }}|{{ color }}</div>'
+          },
+          AccountQuotaInfo: true,
+          OpenAIQuotaResetCell: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2006)
+    expect(wrapper.text()).toContain('Spark 5h|8|2099-03-07T17:00:00Z|indigo')
+    expect(wrapper.text()).toContain('Spark 7d|41|2099-03-13T21:00:00Z|emerald')
+    expect(wrapper.findAll('div').some((node) => node.text() === '-')).toBe(false)
+  })
+
   it('OpenAI OAuth 有现成快照时，手动刷新信号会触发 usage 重拉', async () => {
     getUsage.mockResolvedValue({
       five_hour: {

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -317,6 +317,7 @@ describe('AccountUsageCell', () => {
           id: 2005,
           platform: 'openai',
           type: 'oauth',
+          credentials: { plan_type: 'pro' },
           extra: {}
         })
       },
@@ -363,6 +364,7 @@ describe('AccountUsageCell', () => {
           id: 2006,
           platform: 'openai',
           type: 'oauth',
+          credentials: { plan_type: 'pro' },
           extra: {}
         })
       },
@@ -384,6 +386,160 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('Spark 5h|8|2099-03-07T17:00:00Z|indigo')
     expect(wrapper.text()).toContain('Spark 7d|41|2099-03-13T21:00:00Z|emerald')
     expect(wrapper.findAll('div').some((node) => node.text() === '-')).toBe(false)
+  })
+
+  it('OpenAI OAuth ProLite 账户展示 Spark 独立限额', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: null,
+      seven_day: null,
+      codex_spark_five_hour: {
+        utilization: 12,
+        resets_at: '2099-03-07T17:00:00Z',
+        remaining_seconds: 18000
+      },
+      codex_spark_seven_day: null
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2008,
+          platform: 'openai',
+          type: 'oauth',
+          credentials: { plan_type: ' ProLite ' },
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ resetsAt }}|{{ color }}</div>'
+          },
+          AccountQuotaInfo: true,
+          OpenAIQuotaResetCell: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2008)
+    expect(wrapper.text()).toContain('Spark 5h|12|2099-03-07T17:00:00Z|indigo')
+  })
+
+  it('OpenAI OAuth 空状态仍可触发主动用量查询', async () => {
+    getUsage
+      .mockResolvedValueOnce({
+        five_hour: null,
+        seven_day: null,
+        codex_spark_five_hour: null,
+        codex_spark_seven_day: null
+      })
+      .mockResolvedValueOnce({
+        five_hour: null,
+        seven_day: null,
+        codex_spark_five_hour: {
+          utilization: 12,
+          resets_at: '2099-03-07T17:00:00Z',
+          remaining_seconds: 18000
+        },
+        codex_spark_seven_day: null,
+        source: 'active'
+      })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2009,
+          platform: 'openai',
+          type: 'oauth',
+          credentials: { plan_type: 'prolite' },
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ resetsAt }}|{{ color }}</div>'
+          },
+          AccountQuotaInfo: true,
+          OpenAIQuotaResetCell: {
+            template: '<div class="quota-reset"><slot name="pre-actions" /></div>'
+          }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+
+    await button.trigger('click')
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenNthCalledWith(1, 2009)
+    expect(getUsage).toHaveBeenNthCalledWith(2, 2009, 'active', true)
+    expect(wrapper.text()).toContain('Spark 5h|12|2099-03-07T17:00:00Z|indigo')
+  })
+
+  it('OpenAI OAuth 非 Pro 账户不展示 Spark 独立限额', async () => {
+    getUsage.mockResolvedValue({
+      five_hour: {
+        utilization: 43,
+        resets_at: '2099-03-07T12:00:00Z',
+        remaining_seconds: 3600,
+        window_stats: {
+          requests: 9,
+          tokens: 900,
+          cost: 0.09,
+          standard_cost: 0.09,
+          user_cost: 0.09
+        }
+      },
+      seven_day: null,
+      codex_spark_five_hour: {
+        utilization: 8,
+        resets_at: '2099-03-07T17:00:00Z',
+        remaining_seconds: 18000
+      },
+      codex_spark_seven_day: {
+        utilization: 41,
+        resets_at: '2099-03-13T21:00:00Z',
+        remaining_seconds: 604800
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({
+          id: 2007,
+          platform: 'openai',
+          type: 'oauth',
+          credentials: { plan_type: 'free' },
+          extra: {}
+        })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'resetsAt', 'windowStats', 'color'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ resetsAt }}|{{ color }}</div>'
+          },
+          AccountQuotaInfo: true,
+          OpenAIQuotaResetCell: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(getUsage).toHaveBeenCalledWith(2007)
+    expect(wrapper.text()).toContain('5h|43|2099-03-07T12:00:00Z|indigo')
+    expect(wrapper.text()).not.toContain('Spark 5h')
+    expect(wrapper.text()).not.toContain('Spark 7d')
   })
 
   it('OpenAI OAuth 有现成快照时，手动刷新信号会触发 usage 重拉', async () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3275,6 +3275,7 @@ export default {
       },
       clearRateLimit: 'Clear Rate Limit',
       resetQuota: 'Reset Quota',
+      resetQuotaConfirm: 'Reset used quota for account "{name}" to 0?',
       quotaLimit: 'Quota Limit',
       quotaLimitPlaceholder: '0 means unlimited',
       quotaLimitHint: 'Set daily/weekly/total spending limits (USD). Anthropic API key accounts can also configure client affinity. Changing limits won\'t reset usage.',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3264,6 +3264,7 @@ export default {
       },
       clearRateLimit: '清除速率限制',
       resetQuota: '重置配额',
+      resetQuotaConfirm: '确定要将账号 "{name}" 的已用配额重置为 0 吗？',
       quotaLimit: '配额限制',
       quotaLimitPlaceholder: '0 表示不限制',
       quotaLimitHint: '设置日/周/总使用额度（美元），任一维度达到限额后账号暂停调度。Anthropic API Key 账号还可配置客户端亲和。修改限额不会重置已用额度。',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -957,6 +957,8 @@ export interface AccountUsageInfo {
   five_hour: UsageProgress | null
   seven_day: UsageProgress | null
   seven_day_sonnet: UsageProgress | null
+  codex_spark_five_hour?: UsageProgress | null
+  codex_spark_seven_day?: UsageProgress | null
   gemini_shared_daily?: UsageProgress | null
   gemini_pro_daily?: UsageProgress | null
   gemini_flash_daily?: UsageProgress | null
@@ -1018,6 +1020,19 @@ export interface CodexUsageSnapshot {
   codex_7d_window_minutes?: number // 7d window in minutes (should be ~10080)
 
   codex_usage_updated_at?: string // Last update timestamp
+
+  // GPT-5.3-Codex-Spark canonical fields. These use the same upstream
+  // x-codex-primary/secondary headers as normal Codex but must not overwrite
+  // the normal codex_5h/codex_7d snapshot.
+  codex_spark_5h_used_percent?: number
+  codex_spark_5h_reset_after_seconds?: number
+  codex_spark_5h_reset_at?: string
+  codex_spark_5h_window_minutes?: number
+  codex_spark_7d_used_percent?: number
+  codex_spark_7d_reset_after_seconds?: number
+  codex_spark_7d_reset_at?: string
+  codex_spark_7d_window_minutes?: number
+  codex_spark_usage_updated_at?: string
 }
 
 export type OpenAICompactMode = 'auto' | 'force_on' | 'force_off'

--- a/frontend/src/utils/__tests__/accountUsageRefresh.spec.ts
+++ b/frontend/src/utils/__tests__/accountUsageRefresh.spec.ts
@@ -50,6 +50,32 @@ describe('buildOpenAIUsageRefreshKey', () => {
     expect(buildOpenAIUsageRefreshKey(base)).not.toBe(buildOpenAIUsageRefreshKey(next))
   })
 
+  it('会在 Spark codex 快照变化时生成不同 key', () => {
+    const base = {
+      id: 4,
+      platform: 'openai',
+      type: 'oauth',
+      updated_at: '2026-03-07T10:00:00Z',
+      last_used_at: '2026-03-07T09:59:00Z',
+      extra: {
+        codex_spark_usage_updated_at: '2026-03-07T10:00:00Z',
+        codex_spark_5h_used_percent: 0,
+        codex_spark_7d_used_percent: 16
+      }
+    } as any
+
+    const next = {
+      ...base,
+      extra: {
+        ...base.extra,
+        codex_spark_usage_updated_at: '2026-03-07T10:05:00Z',
+        codex_spark_7d_used_percent: 17
+      }
+    }
+
+    expect(buildOpenAIUsageRefreshKey(base)).not.toBe(buildOpenAIUsageRefreshKey(next))
+  })
+
   it('非 OpenAI OAuth 账号返回空 key', () => {
     expect(buildOpenAIUsageRefreshKey({
       id: 2,

--- a/frontend/src/utils/__tests__/accountUsageRefresh.spec.ts
+++ b/frontend/src/utils/__tests__/accountUsageRefresh.spec.ts
@@ -76,6 +76,29 @@ describe('buildOpenAIUsageRefreshKey', () => {
     expect(buildOpenAIUsageRefreshKey(base)).not.toBe(buildOpenAIUsageRefreshKey(next))
   })
 
+  it('会在 OpenAI plan_type 变化时生成不同 key', () => {
+    const base = {
+      id: 5,
+      platform: 'openai',
+      type: 'oauth',
+      updated_at: '2026-03-07T10:00:00Z',
+      last_used_at: '2026-03-07T09:59:00Z',
+      credentials: {
+        plan_type: 'free'
+      },
+      extra: {}
+    } as any
+
+    const next = {
+      ...base,
+      credentials: {
+        plan_type: 'prolite'
+      }
+    }
+
+    expect(buildOpenAIUsageRefreshKey(base)).not.toBe(buildOpenAIUsageRefreshKey(next))
+  })
+
   it('非 OpenAI OAuth 账号返回空 key', () => {
     expect(buildOpenAIUsageRefreshKey({
       id: 2,

--- a/frontend/src/utils/accountUsageRefresh.ts
+++ b/frontend/src/utils/accountUsageRefresh.ts
@@ -24,6 +24,15 @@ export const buildOpenAIUsageRefreshKey = (account: Pick<Account, 'id' | 'platfo
     extra.codex_7d_used_percent,
     extra.codex_7d_reset_at,
     extra.codex_7d_reset_after_seconds,
-    extra.codex_7d_window_minutes
+    extra.codex_7d_window_minutes,
+    extra.codex_spark_usage_updated_at,
+    extra.codex_spark_5h_used_percent,
+    extra.codex_spark_5h_reset_at,
+    extra.codex_spark_5h_reset_after_seconds,
+    extra.codex_spark_5h_window_minutes,
+    extra.codex_spark_7d_used_percent,
+    extra.codex_spark_7d_reset_at,
+    extra.codex_spark_7d_reset_after_seconds,
+    extra.codex_spark_7d_window_minutes
   ].map(normalizeUsageRefreshValue).join('|')
 }

--- a/frontend/src/utils/accountUsageRefresh.ts
+++ b/frontend/src/utils/accountUsageRefresh.ts
@@ -5,17 +5,19 @@ const normalizeUsageRefreshValue = (value: unknown): string => {
   return String(value)
 }
 
-export const buildOpenAIUsageRefreshKey = (account: Pick<Account, 'id' | 'platform' | 'type' | 'updated_at' | 'last_used_at' | 'rate_limit_reset_at' | 'extra'>): string => {
+export const buildOpenAIUsageRefreshKey = (account: Pick<Account, 'id' | 'platform' | 'type' | 'updated_at' | 'last_used_at' | 'rate_limit_reset_at' | 'credentials' | 'extra'>): string => {
   if (account.platform !== 'openai' || account.type !== 'oauth') {
     return ''
   }
 
   const extra = account.extra ?? {}
+  const credentials = account.credentials ?? {}
   return [
     account.id,
     account.updated_at,
     account.last_used_at,
     account.rate_limit_reset_at,
+    String(credentials.plan_type ?? '').trim().toLowerCase(),
     extra.codex_usage_updated_at,
     extra.codex_5h_used_percent,
     extra.codex_5h_reset_at,

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -387,6 +387,7 @@
     />
     <TempUnschedStatusModal :show="showTempUnsched" :account="tempUnschedAcc" @close="showTempUnsched = false" @reset="handleTempUnschedReset" />
     <ConfirmDialog :show="showDeleteDialog" :title="t('admin.accounts.deleteAccount')" :message="t('admin.accounts.deleteConfirm', { name: deletingAcc?.name })" :confirm-text="t('common.delete')" :cancel-text="t('common.cancel')" :danger="true" @confirm="confirmDelete" @cancel="showDeleteDialog = false" />
+    <ConfirmDialog :show="showResetQuotaDialog" :title="t('admin.accounts.resetQuota')" :message="t('admin.accounts.resetQuotaConfirm', { name: resetQuotaAcc?.name })" :confirm-text="t('admin.accounts.resetQuota')" :cancel-text="t('common.cancel')" @confirm="confirmResetQuota" @cancel="cancelResetQuota" />
     <ConfirmDialog :show="showExportDataDialog" :title="t('admin.accounts.dataExport')" :message="t('admin.accounts.dataExportConfirmMessage')" :confirm-text="t('admin.accounts.dataExportConfirm')" :cancel-text="t('common.cancel')" @confirm="handleExportData" @cancel="showExportDataDialog = false">
       <label class="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
         <input type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500" v-model="includeProxyOnExport" />
@@ -496,6 +497,7 @@ const showBulkEdit = ref(false)
 const bulkEditTarget = ref<AccountBulkEditTarget | null>(null)
 const showTempUnsched = ref(false)
 const showDeleteDialog = ref(false)
+const showResetQuotaDialog = ref(false)
 const showReAuth = ref(false)
 const showTest = ref(false)
 const showStats = ref(false)
@@ -504,6 +506,7 @@ const showTLSFingerprintProfiles = ref(false)
 const edAcc = ref<Account | null>(null)
 const tempUnschedAcc = ref<Account | null>(null)
 const deletingAcc = ref<Account | null>(null)
+const resetQuotaAcc = ref<Account | null>(null)
 const reAuthAcc = ref<Account | null>(null)
 const testingAcc = ref<Account | null>(null)
 const statsAcc = ref<Account | null>(null)
@@ -875,6 +878,7 @@ const isAnyModalOpen = computed(() => {
     showBulkEdit.value ||
     showTempUnsched.value ||
     showDeleteDialog.value ||
+    showResetQuotaDialog.value ||
     showReAuth.value ||
     showTest.value ||
     showStats.value ||
@@ -913,6 +917,7 @@ const syncAccountRefs = (nextAccount: Account) => {
   if (reAuthAcc.value?.id === nextAccount.id) reAuthAcc.value = nextAccount
   if (tempUnschedAcc.value?.id === nextAccount.id) tempUnschedAcc.value = nextAccount
   if (deletingAcc.value?.id === nextAccount.id) deletingAcc.value = nextAccount
+  if (resetQuotaAcc.value?.id === nextAccount.id) resetQuotaAcc.value = nextAccount
   if (menu.acc?.id === nextAccount.id) menu.acc = nextAccount
 }
 
@@ -1594,11 +1599,21 @@ const handleRecoverState = async (a: Account) => {
     appStore.showError(error?.message || t('admin.accounts.recoverStateFailed'))
   }
 }
-const handleResetQuota = async (a: Account) => {
+const handleResetQuota = (a: Account) => {
+  resetQuotaAcc.value = a
+  showResetQuotaDialog.value = true
+}
+const cancelResetQuota = () => {
+  showResetQuotaDialog.value = false
+  resetQuotaAcc.value = null
+}
+const confirmResetQuota = async () => {
+  if (!resetQuotaAcc.value) return
   try {
-    const updated = await adminAPI.accounts.resetAccountQuota(a.id)
+    const updated = await adminAPI.accounts.resetAccountQuota(resetQuotaAcc.value.id)
     patchAccountInList(updated)
     enterAutoRefreshSilentWindow()
+    cancelResetQuota()
     appStore.showSuccess(t('common.success'))
   } catch (error) {
     console.error('Failed to reset quota:', error)

--- a/frontend/src/views/admin/__tests__/AccountsView.resetQuotaConfirm.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.resetQuotaConfirm.spec.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import AccountsView from '../AccountsView.vue'
+
+const {
+  listAccounts,
+  listWithEtag,
+  getBatchTodayStats,
+  getAllProxies,
+  getAllGroups,
+  resetAccountQuota,
+  showSuccess
+} = vi.hoisted(() => ({
+  listAccounts: vi.fn(),
+  listWithEtag: vi.fn(),
+  getBatchTodayStats: vi.fn(),
+  getAllProxies: vi.fn(),
+  getAllGroups: vi.fn(),
+  resetAccountQuota: vi.fn(),
+  showSuccess: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    accounts: {
+      list: listAccounts,
+      listWithEtag,
+      getBatchTodayStats,
+      resetAccountQuota,
+      delete: vi.fn(),
+      batchClearError: vi.fn(),
+      batchRefresh: vi.fn(),
+      toggleSchedulable: vi.fn()
+    },
+    proxies: {
+      getAll: getAllProxies
+    },
+    groups: {
+      getAll: getAllGroups
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess,
+    showInfo: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    token: 'test-token'
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string, params?: Record<string, unknown>) => params?.name ? `${key}:${params.name}` : key
+    })
+  }
+})
+
+const quotaAccount = {
+  id: 42,
+  name: 'quota-account',
+  platform: 'anthropic',
+  type: 'apikey',
+  status: 'active',
+  schedulable: true,
+  quota_limit: 10,
+  quota_used: 5,
+  created_at: '2026-03-07T10:00:00Z',
+  updated_at: '2026-03-07T10:00:00Z'
+}
+
+const DataTableStub = {
+  props: ['columns', 'data'],
+  template: `
+    <div data-test="data-table">
+      <div v-for="row in data" :key="row.id">
+        <slot name="cell-actions" :row="row" />
+      </div>
+    </div>
+  `
+}
+
+const AccountActionMenuStub = {
+  props: ['show', 'account'],
+  emits: ['reset-quota'],
+  template: `
+    <button
+      v-if="show && account"
+      data-test="reset-quota-menu-item"
+      @click="$emit('reset-quota', account)"
+    >
+      reset quota
+    </button>
+  `
+}
+
+const ConfirmDialogStub = {
+  props: ['show', 'title', 'message', 'confirmText', 'cancelText'],
+  emits: ['confirm', 'cancel'],
+  template: `
+    <div v-if="show" data-test="confirm-dialog">
+      <p data-test="confirm-title">{{ title }}</p>
+      <p data-test="confirm-message">{{ message }}</p>
+      <button data-test="confirm-reset-quota" @click="$emit('confirm')">{{ confirmText }}</button>
+      <button data-test="cancel-reset-quota" @click="$emit('cancel')">{{ cancelText }}</button>
+    </div>
+  `
+}
+
+function mountView() {
+  return mount(AccountsView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: {
+          template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+        },
+        DataTable: DataTableStub,
+        Pagination: true,
+        ConfirmDialog: ConfirmDialogStub,
+        AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
+        AccountTableFilters: { template: '<div></div>' },
+        AccountBulkActionsBar: true,
+        AccountActionMenu: AccountActionMenuStub,
+        ImportDataModal: true,
+        ReAuthAccountModal: true,
+        AccountTestModal: true,
+        AccountStatsModal: true,
+        ScheduledTestsPanel: true,
+        SyncFromCrsModal: true,
+        TempUnschedStatusModal: true,
+        ErrorPassthroughRulesModal: true,
+        TLSFingerprintProfilesModal: true,
+        CreateAccountModal: true,
+        EditAccountModal: true,
+        BulkEditAccountModal: true,
+        PlatformTypeBadge: true,
+        AccountCapacityCell: true,
+        AccountStatusIndicator: true,
+        AccountTodayStatsCell: true,
+        AccountGroupsCell: true,
+        AccountUsageCell: true,
+        Icon: true
+      }
+    }
+  })
+}
+
+describe('admin AccountsView reset quota confirmation', () => {
+  beforeEach(() => {
+    localStorage.clear()
+
+    listAccounts.mockReset()
+    listWithEtag.mockReset()
+    getBatchTodayStats.mockReset()
+    getAllProxies.mockReset()
+    getAllGroups.mockReset()
+    resetAccountQuota.mockReset()
+    showSuccess.mockReset()
+
+    listAccounts.mockResolvedValue({
+      items: [quotaAccount],
+      total: 1,
+      page: 1,
+      page_size: 20,
+      pages: 1
+    })
+    listWithEtag.mockResolvedValue({
+      notModified: true,
+      etag: null,
+      data: null
+    })
+    getBatchTodayStats.mockResolvedValue({ stats: {} })
+    getAllProxies.mockResolvedValue([])
+    getAllGroups.mockResolvedValue([])
+    resetAccountQuota.mockResolvedValue({
+      ...quotaAccount,
+      quota_used: 0,
+      updated_at: '2026-03-07T10:01:00Z'
+    })
+  })
+
+  it('asks for confirmation before resetting a single account quota', async () => {
+    const wrapper = mountView()
+    await flushPromises()
+
+    const actionButtons = wrapper.findAll('[data-test="data-table"] button')
+    await actionButtons[2].trigger('click')
+    await wrapper.get('[data-test="reset-quota-menu-item"]').trigger('click')
+    await flushPromises()
+
+    expect(resetAccountQuota).not.toHaveBeenCalled()
+    expect(wrapper.get('[data-test="confirm-title"]').text()).toBe('admin.accounts.resetQuota')
+    expect(wrapper.get('[data-test="confirm-message"]').text()).toBe('admin.accounts.resetQuotaConfirm:quota-account')
+
+    await wrapper.get('[data-test="cancel-reset-quota"]').trigger('click')
+    await flushPromises()
+
+    expect(resetAccountQuota).not.toHaveBeenCalled()
+    expect(wrapper.find('[data-test="confirm-dialog"]').exists()).toBe(false)
+
+    await actionButtons[2].trigger('click')
+    await wrapper.get('[data-test="reset-quota-menu-item"]').trigger('click')
+    await flushPromises()
+
+    await wrapper.get('[data-test="confirm-reset-quota"]').trigger('click')
+    await flushPromises()
+
+    expect(resetAccountQuota).toHaveBeenCalledTimes(1)
+    expect(resetAccountQuota).toHaveBeenCalledWith(42)
+    expect(showSuccess).toHaveBeenCalledWith('common.success')
+  })
+})


### PR DESCRIPTION
## 概要
- 在 OpenAI Codex 现有 5h / 7d 用量窗口旁展示 GPT-5.3-Codex-Spark 独立用量窗口。
- Spark quota 快照独立落到 `codex_spark_*` 字段，避免覆盖普通 Codex 的 `codex_*` 快照；覆盖 429 响应头路径和成功响应的节流采样路径。
- 手动刷新用量时主动探测 Spark，包括还没有本地用量快照的空状态。
- 仅 OpenAI OAuth 且 `credentials.plan_type` 为 `pro` 或 `prolite` 的账号展示并主动探测 Spark；其他 plan 即使存在旧的 `codex_spark_*` 数据也不展示。
- 将 `codex_spark_*` 观测型写入标记为 scheduler-neutral，避免展示用快照写入触发不必要的 scheduler outbox / 缓存刷新。

## 验证
- `git diff --check`
- `go test ./internal/service -run 'TestHandle429_OpenAIPersistsSparkCodexSnapshotSeparately|TestOpenAIGatewayService_UpdateCodexUsageSnapshot_ThrottlesNormalAndSparkSeparately|TestOpenAIPlanEligibleForSparkUsage|TestOpenAICodexProbeModels|TestAccountUsageService_GetOpenAIUsage_ReturnsSparkSnapshot|TestAccountUsageService_GetOpenAIUsage_HidesSparkSnapshotForNonPro' -count=1`
- `GOPROXY=https://goproxy.cn,direct go test ./internal/repository -run 'TestShouldEnqueueSchedulerOutboxForExtraUpdates_CodexSparkObservationKeysAreNeutral' -count=1`
- `vitest run src/components/account/__tests__/AccountUsageCell.spec.ts src/utils/__tests__/accountUsageRefresh.spec.ts`
- `vue-tsc --noEmit`
