### PR TITLE
feat:为 usage_logs 持久化脱敏后的用户输入摘要

### DIFF
--- a/backend/ent/schema/usage_log.go
+++ b/backend/ent/schema/usage_log.go
@@ -41,6 +41,9 @@ func (UsageLog) Fields() []ent.Field {
 		field.String("model").
 			MaxLen(100).
 			NotEmpty(),
+		field.String("input_excerpt").
+			Default("").
+			Comment("脱敏后的用户输入摘要"),
 		// RequestedModel stores the client-requested model name for stable display and analytics.
 		// NULL means historical rows written before requested_model dual-write was introduced.
 		field.String("requested_model").

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -587,6 +587,7 @@ func usageLogFromServiceUser(l *service.UsageLog) UsageLog {
 		AccountID:             l.AccountID,
 		RequestID:             l.RequestID,
 		Model:                 requestedModel,
+		InputExcerpt:          l.InputExcerpt,
 		ServiceTier:           l.ServiceTier,
 		ReasoningEffort:       l.ReasoningEffort,
 		InboundEndpoint:       l.InboundEndpoint,

--- a/backend/internal/handler/dto/mappers_usage_test.go
+++ b/backend/internal/handler/dto/mappers_usage_test.go
@@ -133,6 +133,22 @@ func TestUsageLogFromService_UsesRequestedModelAndKeepsUpstreamAdminOnly(t *test
 	require.Contains(t, string(adminJSON), `"upstream_model":"claude-sonnet-4-20250514"`)
 }
 
+func TestUsageLogFromService_MapsInputExcerpt(t *testing.T) {
+	t.Parallel()
+
+	log := &service.UsageLog{
+		RequestID:    "req_excerpt",
+		Model:        "gpt-5",
+		InputExcerpt: "hello world",
+	}
+
+	userDTO := UsageLogFromService(log)
+	adminDTO := UsageLogFromServiceAdmin(log)
+
+	require.Equal(t, "hello world", userDTO.InputExcerpt)
+	require.Equal(t, "hello world", adminDTO.InputExcerpt)
+}
+
 func TestUsageLogFromService_FallsBackToLegacyModelWhenRequestedModelMissing(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/handler/dto/types.go
+++ b/backend/internal/handler/dto/types.go
@@ -425,12 +425,13 @@ type BatchUpdateRedeemCodesRequest struct {
 
 // UsageLog 是普通用户接口使用的 usage log DTO（不包含管理员字段）。
 type UsageLog struct {
-	ID        int64  `json:"id"`
-	UserID    int64  `json:"user_id"`
-	APIKeyID  int64  `json:"api_key_id"`
-	AccountID int64  `json:"account_id"`
-	RequestID string `json:"request_id"`
-	Model     string `json:"model"`
+	ID           int64  `json:"id"`
+	UserID       int64  `json:"user_id"`
+	APIKeyID     int64  `json:"api_key_id"`
+	AccountID    int64  `json:"account_id"`
+	RequestID    string `json:"request_id"`
+	Model        string `json:"model"`
+	InputExcerpt string `json:"input_excerpt,omitempty"`
 	// ServiceTier records the OpenAI service tier used for billing, e.g. "priority" / "flex".
 	ServiceTier *string `json:"service_tier,omitempty"`
 	// ReasoningEffort is the request's reasoning effort level.

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -285,6 +285,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 		requestPayloadHash := service.HashUsageRequestPayload(body)
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+		inputExcerpt := service.BuildUsageInputExcerpt(body)
 
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
@@ -297,6 +298,7 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				Subscription:       subscription,
 				InboundEndpoint:    inboundEndpoint,
 				UpstreamEndpoint:   upstreamEndpoint,
+				InputExcerpt:       inputExcerpt,
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -264,6 +264,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 		requestPayloadHash := service.HashUsageRequestPayload(body)
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+		inputExcerpt := service.BuildUsageInputExcerpt(body)
 
 		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
 		h.submitUsageRecordTask(c.Request.Context(), func(ctx context.Context) {
@@ -276,6 +277,7 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				Subscription:       subscription,
 				InboundEndpoint:    inboundEndpoint,
 				UpstreamEndpoint:   upstreamEndpoint,
+				InputExcerpt:       inputExcerpt,
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,

--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -298,6 +298,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		clientIP := ip.GetClientIP(c)
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := resolveOpenAIUpstreamEndpoint(c, account)
+		inputExcerpt := service.BuildUsageInputExcerpt(body)
 
 		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
@@ -309,6 +310,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 				Subscription:       subscription,
 				InboundEndpoint:    inboundEndpoint,
 				UpstreamEndpoint:   upstreamEndpoint,
+				InputExcerpt:       inputExcerpt,
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				APIKeyService:      h.apiKeyService,

--- a/backend/internal/handler/openai_embeddings.go
+++ b/backend/internal/handler/openai_embeddings.go
@@ -219,6 +219,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 		clientIP := ip.GetClientIP(c)
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+		inputExcerpt := service.BuildUsageInputExcerpt(body)
 
 		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
 			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
@@ -229,6 +230,7 @@ func (h *OpenAIGatewayHandler) Embeddings(c *gin.Context) {
 				Subscription:       subscription,
 				InboundEndpoint:    inboundEndpoint,
 				UpstreamEndpoint:   upstreamEndpoint,
+				InputExcerpt:       inputExcerpt,
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				APIKeyService:      h.apiKeyService,

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -341,6 +341,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		}
 		inboundEndpoint := GetInboundEndpoint(c)
 		upstreamEndpoint := GetUpstreamEndpoint(c, account.Platform)
+		inputExcerpt := service.BuildUsageInputExcerpt(parsed.ModerationBody())
 
 		upstreamModel := ""
 		if result != nil {
@@ -355,6 +356,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 				Subscription:       subscription,
 				InboundEndpoint:    inboundEndpoint,
 				UpstreamEndpoint:   upstreamEndpoint,
+				InputExcerpt:       inputExcerpt,
 				UserAgent:          userAgent,
 				IPAddress:          clientIP,
 				RequestPayloadHash: requestPayloadHash,

--- a/backend/internal/repository/migrations_schema_integration_test.go
+++ b/backend/internal/repository/migrations_schema_integration_test.go
@@ -45,6 +45,7 @@ func TestMigrationsRunner_IsIdempotent_AndSchemaIsUpToDate(t *testing.T) {
 	requireColumn(t, tx, "usage_logs", "billing_type", "smallint", 0, false)
 	requireColumn(t, tx, "usage_logs", "request_type", "smallint", 0, false)
 	requireColumn(t, tx, "usage_logs", "openai_ws_mode", "boolean", 0, false)
+	requireColumn(t, tx, "usage_logs", "input_excerpt", "text", 0, false)
 	requireColumn(t, tx, "usage_logs", "image_input_size", "character varying", 32, true)
 	requireColumn(t, tx, "usage_logs", "image_output_size", "character varying", 32, true)
 	requireColumn(t, tx, "usage_logs", "image_size_source", "character varying", 16, true)

--- a/backend/internal/repository/usage_log_repo.go
+++ b/backend/internal/repository/usage_log_repo.go
@@ -30,7 +30,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, created_at"
+const usageLogSelectColumns = "id, user_id, api_key_id, account_id, request_id, model, input_excerpt, requested_model, upstream_model, group_id, subscription_id, input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cache_creation_5m_tokens, cache_creation_1h_tokens, image_output_tokens, image_output_cost, input_cost, output_cost, cache_creation_cost, cache_read_cost, total_cost, actual_cost, rate_multiplier, account_rate_multiplier, billing_type, request_type, stream, openai_ws_mode, duration_ms, first_token_ms, user_agent, ip_address, image_count, image_size, image_input_size, image_output_size, image_size_source, image_size_breakdown, service_tier, reasoning_effort, inbound_endpoint, upstream_endpoint, cache_ttl_overridden, channel_id, model_mapping_chain, billing_tier, billing_mode, account_stats_cost, created_at"
 
 // usageLogInsertArgTypes must stay in the same order as:
 //  1. prepareUsageLogInsert().args
@@ -45,6 +45,7 @@ var usageLogInsertArgTypes = [...]string{
 	"bigint",      // account_id
 	"text",        // request_id
 	"text",        // model
+	"text",        // input_excerpt
 	"text",        // requested_model
 	"text",        // upstream_model
 	"bigint",      // group_id
@@ -362,6 +363,7 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			account_id,
 			request_id,
 			model,
+			input_excerpt,
 			requested_model,
 			upstream_model,
 			group_id,
@@ -408,12 +410,12 @@ func (r *usageLogRepository) createSingle(ctx context.Context, sqlq sqlExecutor,
 			account_stats_cost,
 			created_at
 		) VALUES (
-			$1, $2, $3, $4, $5, $6, $7,
-			$8, $9,
-			$10, $11, $12, $13,
-			$14, $15, $16, $17,
-			$18, $19, $20, $21, $22, $23,
-			$24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50
+			$1, $2, $3, $4, $5, $6, $7, $8,
+			$9, $10,
+			$11, $12, $13, $14,
+			$15, $16, $17, $18,
+			$19, $20, $21, $22, $23, $24,
+			$25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37, $38, $39, $40, $41, $42, $43, $44, $45, $46, $47, $48, $49, $50, $51
 		)
 		ON CONFLICT (request_id, api_key_id) DO NOTHING
 		RETURNING id, created_at
@@ -804,6 +806,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			account_id,
 			request_id,
 			model,
+			input_excerpt,
 			requested_model,
 			upstream_model,
 			group_id,
@@ -851,7 +854,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 			created_at
 		) AS (VALUES `)
 
-	args := make([]any, 0, len(keys)*50)
+	args := make([]any, 0, len(keys)*51)
 	argPos := 1
 	for idx, key := range keys {
 		if idx > 0 {
@@ -885,6 +888,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				account_id,
 				request_id,
 				model,
+				input_excerpt,
 				requested_model,
 				upstream_model,
 				group_id,
@@ -937,6 +941,7 @@ func buildUsageLogBatchInsertQuery(keys []string, preparedByKey map[string]usage
 				account_id,
 				request_id,
 				model,
+				input_excerpt,
 				requested_model,
 				upstream_model,
 				group_id,
@@ -1331,6 +1336,7 @@ func prepareUsageLogInsert(log *service.UsageLog) usageLogInsertPrepared {
 			log.AccountID,
 			requestIDArg,
 			log.Model,
+			log.InputExcerpt,
 			nullString(&requestedModel),
 			upstreamModel,
 			groupID,
@@ -4259,6 +4265,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		accountID             int64
 		requestID             sql.NullString
 		model                 string
+		inputExcerpt          string
 		requestedModel        sql.NullString
 		upstreamModel         sql.NullString
 		groupID               sql.NullInt64
@@ -4313,6 +4320,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		&accountID,
 		&requestID,
 		&model,
+		&inputExcerpt,
 		&requestedModel,
 		&upstreamModel,
 		&groupID,
@@ -4368,6 +4376,7 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		APIKeyID:              apiKeyID,
 		AccountID:             accountID,
 		Model:                 model,
+		InputExcerpt:          inputExcerpt,
 		RequestedModel:        coalesceTrimmedString(requestedModel, model),
 		InputTokens:           inputTokens,
 		OutputTokens:          outputTokens,

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -610,6 +610,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int64(33),
 			sql.NullString{Valid: true, String: "req-image-metadata"},
 			"gpt-image-2",
+			"image prompt",
 			sql.NullString{Valid: true, String: "gpt-image-2"},
 			sql.NullString{},
 			sql.NullInt64{},
@@ -646,6 +647,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			now,
 		}})
 		require.NoError(t, err)
+		require.Equal(t, "image prompt", log.InputExcerpt)
 		require.Equal(t, 2, log.ImageCount)
 		require.NotNil(t, log.ImageSize)
 		require.Equal(t, "4K", *log.ImageSize)
@@ -666,7 +668,8 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int64(20), // api_key_id
 			int64(30), // account_id
 			sql.NullString{Valid: true, String: "req-1"},
-			"gpt-5", // model
+			"gpt-5",  // model
+			"prompt", // input_excerpt
 			sql.NullString{Valid: true, String: "gpt-5"}, // requested_model
 			sql.NullString{},  // upstream_model
 			sql.NullInt64{},   // group_id
@@ -714,6 +717,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			now,
 		}})
 		require.NoError(t, err)
+		require.Equal(t, "prompt", log.InputExcerpt)
 		require.NotNil(t, log.ServiceTier)
 		require.Equal(t, "priority", *log.ServiceTier)
 		require.Equal(t, service.RequestTypeWSV2, log.RequestType)
@@ -730,6 +734,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int64(31),
 			sql.NullString{Valid: true, String: "req-2"},
 			"gpt-5",
+			"legacy prompt",
 			sql.NullString{Valid: true, String: "gpt-5"},
 			sql.NullString{},
 			sql.NullInt64{},
@@ -766,6 +771,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			now,
 		}})
 		require.NoError(t, err)
+		require.Equal(t, "legacy prompt", log.InputExcerpt)
 		require.NotNil(t, log.ServiceTier)
 		require.Equal(t, "flex", *log.ServiceTier)
 		require.Equal(t, service.RequestTypeStream, log.RequestType)
@@ -782,6 +788,7 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 			int64(32),
 			sql.NullString{Valid: true, String: "req-3"},
 			"gpt-5.4",
+			"service tier prompt",
 			sql.NullString{Valid: true, String: "gpt-5.4"},
 			sql.NullString{},
 			sql.NullInt64{},

--- a/backend/internal/repository/usage_log_repo_unit_test.go
+++ b/backend/internal/repository/usage_log_repo_unit_test.go
@@ -65,3 +65,19 @@ func TestBuildUsageLogBatchInsertQuery_UsesConflictDoNothing(t *testing.T) {
 	require.Contains(t, query, "ON CONFLICT (request_id, api_key_id) DO NOTHING")
 	require.NotContains(t, strings.ToUpper(query), "DO UPDATE")
 }
+
+func TestPrepareUsageLogInsert_IncludesInputExcerpt(t *testing.T) {
+	log := &service.UsageLog{
+		UserID:       1,
+		APIKeyID:     2,
+		AccountID:    3,
+		RequestID:    "req-input-excerpt",
+		Model:        "gpt-5",
+		InputExcerpt: "hello",
+		CreatedAt:    time.Now().UTC(),
+	}
+
+	prepared := prepareUsageLogInsert(log)
+	require.GreaterOrEqual(t, len(prepared.args), 7)
+	require.Equal(t, "hello", prepared.args[5])
+}

--- a/backend/internal/service/gateway_record_usage_test.go
+++ b/backend/internal/service/gateway_record_usage_test.go
@@ -193,6 +193,29 @@ func TestGatewayServiceRecordUsage_PreservesRequestedAndUpstreamModels(t *testin
 	require.Equal(t, mappedModel, *usageRepo.lastLog.UpstreamModel)
 }
 
+func TestGatewayServiceRecordUsage_PersistsInputExcerpt(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})
+
+	err := svc.RecordUsage(context.Background(), &RecordUsageInput{
+		Result: &ForwardResult{
+			RequestID: "gateway_input_excerpt",
+			Usage:     ClaudeUsage{InputTokens: 10, OutputTokens: 6},
+			Model:     "claude-sonnet-4",
+			Duration:  time.Second,
+		},
+		APIKey:       &APIKey{ID: 501, Quota: 100},
+		User:         &User{ID: 601},
+		Account:      &Account{ID: 701},
+		InputExcerpt: "token=sk-proj-1234567890abcdef hello",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.NotContains(t, usageRepo.lastLog.InputExcerpt, "sk-proj-1234567890abcdef")
+	require.Contains(t, usageRepo.lastLog.InputExcerpt, "[已脱敏]")
+}
+
 func TestGatewayServiceRecordUsage_EmptyImageSizeDefaultsBeforeBillingAndPersistence(t *testing.T) {
 	imagePrice2K := 0.19
 	groupID := int64(901)

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -8818,6 +8818,7 @@ type RecordUsageInput struct {
 	Subscription       *UserSubscription  // 可选：订阅信息
 	InboundEndpoint    string             // 入站端点（客户端请求路径）
 	UpstreamEndpoint   string             // 上游端点（标准化后的上游路径）
+	InputExcerpt       string             // 脱敏后的用户输入摘要
 	UserAgent          string             // 请求的 User-Agent
 	IPAddress          string             // 请求的客户端 IP 地址
 	RequestPayloadHash string             // 请求体语义哈希，用于降低 request_id 误复用时的静默误去重风险
@@ -9328,6 +9329,7 @@ func (s *GatewayService) RecordUsage(ctx context.Context, input *RecordUsageInpu
 		Subscription:       input.Subscription,
 		InboundEndpoint:    input.InboundEndpoint,
 		UpstreamEndpoint:   input.UpstreamEndpoint,
+		InputExcerpt:       input.InputExcerpt,
 		UserAgent:          input.UserAgent,
 		IPAddress:          input.IPAddress,
 		RequestPayloadHash: input.RequestPayloadHash,
@@ -9347,6 +9349,7 @@ type RecordUsageLongContextInput struct {
 	Subscription          *UserSubscription  // 可选：订阅信息
 	InboundEndpoint       string             // 入站端点（客户端请求路径）
 	UpstreamEndpoint      string             // 上游端点（标准化后的上游路径）
+	InputExcerpt          string             // 脱敏后的用户输入摘要
 	UserAgent             string             // 请求的 User-Agent
 	IPAddress             string             // 请求的客户端 IP 地址
 	RequestPayloadHash    string             // 请求体语义哈希，用于降低 request_id 误复用时的静默误去重风险
@@ -9369,6 +9372,7 @@ func (s *GatewayService) RecordUsageWithLongContext(ctx context.Context, input *
 		Subscription:       input.Subscription,
 		InboundEndpoint:    input.InboundEndpoint,
 		UpstreamEndpoint:   input.UpstreamEndpoint,
+		InputExcerpt:       input.InputExcerpt,
 		UserAgent:          input.UserAgent,
 		IPAddress:          input.IPAddress,
 		RequestPayloadHash: input.RequestPayloadHash,
@@ -9391,6 +9395,7 @@ type recordUsageCoreInput struct {
 	Subscription       *UserSubscription
 	InboundEndpoint    string
 	UpstreamEndpoint   string
+	InputExcerpt       string
 	UserAgent          string
 	IPAddress          string
 	RequestPayloadHash string
@@ -9681,6 +9686,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		Model:                 result.Model,
 		RequestedModel:        requestedModel,
 		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
+		InputExcerpt:          sanitizeUsageInputExcerpt(input.InputExcerpt),
 		ReasoningEffort:       result.ReasoningEffort,
 		InboundEndpoint:       optionalTrimmedStringPtr(input.InboundEndpoint),
 		UpstreamEndpoint:      optionalTrimmedStringPtr(input.UpstreamEndpoint),

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -1855,6 +1855,29 @@ func TestRecordUsageMarksCyberRequestType(t *testing.T) {
 	require.Equal(t, 100, logStub.lastLog.InputTokens, "计费 token 不变(正常计费)")
 }
 
+func TestOpenAIRecordUsage_PersistsInputExcerpt(t *testing.T) {
+	logStub := &openAIRecordUsageLogRepoStub{inserted: true}
+	userStub := &openAIRecordUsageUserRepoStub{}
+	subStub := &openAIRecordUsageSubRepoStub{}
+	rateStub := &openAIUserGroupRateRepoStub{}
+	svc := newOpenAIRecordUsageServiceForTest(logStub, userStub, subStub, rateStub)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		InputExcerpt: "Bearer abcdefghijklmnopqrstuvwxyz123456",
+		Result: &OpenAIForwardResult{
+			Model:    "gpt-5",
+			Duration: time.Second,
+			Usage:    OpenAIUsage{InputTokens: 100, OutputTokens: 20},
+		},
+		APIKey:  &APIKey{ID: 2, Group: &Group{RateMultiplier: 1}},
+		User:    &User{ID: 1},
+		Account: &Account{ID: 3},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, logStub.lastLog)
+	require.Contains(t, logStub.lastLog.InputExcerpt, "[已脱敏]")
+}
+
 func TestGatewayServiceCalculateRecordUsageCost_ChannelImageBillingNormalizesMissingSizeTier(t *testing.T) {
 	groupID := int64(128)
 	defaultPrice := 0.10

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -6088,6 +6088,7 @@ type OpenAIRecordUsageInput struct {
 	Subscription       *UserSubscription
 	InboundEndpoint    string
 	UpstreamEndpoint   string
+	InputExcerpt       string
 	UserAgent          string // 请求的 User-Agent
 	IPAddress          string // 请求的客户端 IP 地址
 	RequestPayloadHash string
@@ -6280,6 +6281,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		Model:               result.Model,
 		RequestedModel:      requestedModel,
 		UpstreamModel:       optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
+		InputExcerpt:        sanitizeUsageInputExcerpt(input.InputExcerpt),
 		ServiceTier:         result.ServiceTier,
 		ReasoningEffort:     result.ReasoningEffort,
 		InboundEndpoint:     optionalTrimmedStringPtr(input.InboundEndpoint),

--- a/backend/internal/service/usage_input_excerpt.go
+++ b/backend/internal/service/usage_input_excerpt.go
@@ -1,0 +1,180 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+const maxUsageInputExcerptRunes = 240
+
+func BuildUsageInputExcerpt(body []byte) string {
+	if len(body) == 0 || !gjson.ValidBytes(body) {
+		return ""
+	}
+
+	candidates := []string{
+		extractUsageExcerptFromMessages(body),
+		extractUsageExcerptFromResponsesInput(body),
+		extractUsageExcerptFromStringOrArray(body, "prompt"),
+		extractUsageExcerptFromStringOrArray(body, "input"),
+		extractUsageExcerptFromContents(body),
+	}
+	for _, candidate := range candidates {
+		if excerpt := sanitizeUsageInputExcerpt(candidate); excerpt != "" {
+			return excerpt
+		}
+	}
+	return ""
+}
+
+func sanitizeUsageInputExcerpt(text string) string {
+	text = normalizeUsageExcerptWhitespace(text)
+	if text == "" {
+		return ""
+	}
+	return trimRunes(redactContentModerationSecrets(text), maxUsageInputExcerptRunes)
+}
+
+func normalizeUsageExcerptWhitespace(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(text), " ")
+}
+
+func extractUsageExcerptFromMessages(body []byte) string {
+	messages := gjson.GetBytes(body, "messages")
+	if !messages.Exists() || !messages.IsArray() {
+		return ""
+	}
+	for i := len(messages.Array()) - 1; i >= 0; i-- {
+		msg := messages.Array()[i]
+		role := strings.TrimSpace(msg.Get("role").String())
+		if role != "" && role != "user" {
+			continue
+		}
+		if text := collectUsageText(msg.Get("content")); text != "" {
+			return text
+		}
+	}
+	for i := len(messages.Array()) - 1; i >= 0; i-- {
+		if text := collectUsageText(messages.Array()[i].Get("content")); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func extractUsageExcerptFromResponsesInput(body []byte) string {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() {
+		return ""
+	}
+	if input.Type == gjson.String {
+		return input.String()
+	}
+	if input.IsArray() {
+		items := input.Array()
+		for i := len(items) - 1; i >= 0; i-- {
+			item := items[i]
+			role := strings.TrimSpace(item.Get("role").String())
+			if role != "" && role != "user" {
+				continue
+			}
+			if text := collectUsageText(item.Get("content")); text != "" {
+				return text
+			}
+			if text := collectUsageText(item); text != "" {
+				return text
+			}
+		}
+		for i := len(items) - 1; i >= 0; i-- {
+			if text := collectUsageText(items[i]); text != "" {
+				return text
+			}
+		}
+	}
+	return collectUsageText(input)
+}
+
+func extractUsageExcerptFromContents(body []byte) string {
+	contents := gjson.GetBytes(body, "contents")
+	if !contents.Exists() || !contents.IsArray() {
+		return ""
+	}
+	items := contents.Array()
+	for i := len(items) - 1; i >= 0; i-- {
+		item := items[i]
+		role := strings.TrimSpace(item.Get("role").String())
+		if role != "" && role != "user" {
+			continue
+		}
+		if text := collectUsageText(item.Get("parts")); text != "" {
+			return text
+		}
+	}
+	for i := len(items) - 1; i >= 0; i-- {
+		if text := collectUsageText(items[i].Get("parts")); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func extractUsageExcerptFromStringOrArray(body []byte, path string) string {
+	value := gjson.GetBytes(body, path)
+	if !value.Exists() {
+		return ""
+	}
+	return collectUsageText(value)
+}
+
+func collectUsageText(value gjson.Result) string {
+	if !value.Exists() {
+		return ""
+	}
+	switch value.Type {
+	case gjson.String:
+		return value.String()
+	case gjson.JSON:
+		if value.IsArray() {
+			var parts []string
+			for _, item := range value.Array() {
+				if text := collectUsageText(item); text != "" {
+					parts = append(parts, text)
+				}
+			}
+			return strings.Join(parts, " ")
+		}
+		for _, key := range []string{"text", "input_text", "content", "prompt", "query"} {
+			if text := collectUsageText(value.Get(key)); text != "" {
+				return text
+			}
+		}
+		if kind := strings.TrimSpace(value.Get("type").String()); kind != "" {
+			switch kind {
+			case "text", "input_text":
+				if text := strings.TrimSpace(value.Get("text").String()); text != "" {
+					return text
+				}
+			case "message":
+				if text := collectUsageText(value.Get("content")); text != "" {
+					return text
+				}
+			}
+		}
+		if raw := strings.TrimSpace(value.Raw); raw != "" && raw != "{}" && raw != "[]" {
+			var generic any
+			if err := json.Unmarshal([]byte(raw), &generic); err == nil {
+				switch typed := generic.(type) {
+				case string:
+					return typed
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/backend/internal/service/usage_input_excerpt_test.go
+++ b/backend/internal/service/usage_input_excerpt_test.go
@@ -1,0 +1,56 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildUsageInputExcerpt_ChatMessagesUsesLastUserPrompt(t *testing.T) {
+	body := []byte(`{
+		"messages":[
+			{"role":"system","content":"ignore"},
+			{"role":"user","content":"first prompt"},
+			{"role":"assistant","content":"reply"},
+			{"role":"user","content":[{"type":"text","text":"last user prompt"}]}
+		]
+	}`)
+
+	require.Equal(t, "last user prompt", BuildUsageInputExcerpt(body))
+}
+
+func TestBuildUsageInputExcerpt_ResponsesInputRedactsSecrets(t *testing.T) {
+	body := []byte(`{
+		"input":[{"role":"user","content":[{"type":"input_text","text":"token=sk-proj-1234567890abcdef hello"}]}]
+	}`)
+
+	excerpt := BuildUsageInputExcerpt(body)
+	require.NotContains(t, excerpt, "sk-proj-1234567890abcdef")
+	require.Contains(t, excerpt, "[已脱敏]")
+}
+
+func TestBuildUsageInputExcerpt_EmbeddingsArrayInput(t *testing.T) {
+	body := []byte(`{"input":["first embedding text","second embedding text"]}`)
+	require.Equal(t, "first embedding text second embedding text", BuildUsageInputExcerpt(body))
+}
+
+func TestBuildUsageInputExcerpt_GeminiContents(t *testing.T) {
+	body := []byte(`{
+		"contents":[
+			{"role":"model","parts":[{"text":"ignored"}]},
+			{"role":"user","parts":[{"text":"gemini prompt"}]}
+		]
+	}`)
+
+	require.Equal(t, "gemini prompt", BuildUsageInputExcerpt(body))
+}
+
+func TestBuildUsageInputExcerpt_TruncatesLongText(t *testing.T) {
+	body := []byte(`{"prompt":"` + strings.Repeat("a", maxUsageInputExcerptRunes+20) + `"}`)
+
+	excerpt := BuildUsageInputExcerpt(body)
+	require.Len(t, []rune(excerpt), maxUsageInputExcerptRunes)
+}

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -103,6 +103,8 @@ type UsageLog struct {
 	AccountID int64
 	RequestID string
 	Model     string
+	// InputExcerpt stores a redacted, truncated excerpt of the user-provided input.
+	InputExcerpt string
 	// RequestedModel is the client-requested model name recorded for stable user/admin display.
 	// Empty should be treated as Model for backward compatibility with historical rows.
 	RequestedModel string

--- a/backend/internal/service/usage_service.go
+++ b/backend/internal/service/usage_service.go
@@ -23,6 +23,7 @@ type CreateUsageLogRequest struct {
 	AccountID             int64   `json:"account_id"`
 	RequestID             string  `json:"request_id"`
 	Model                 string  `json:"model"`
+	InputExcerpt          string  `json:"input_excerpt"`
 	InputTokens           int     `json:"input_tokens"`
 	OutputTokens          int     `json:"output_tokens"`
 	CacheCreationTokens   int     `json:"cache_creation_tokens"`
@@ -99,6 +100,7 @@ func (s *UsageService) Create(ctx context.Context, req CreateUsageLogRequest) (*
 		AccountID:             req.AccountID,
 		RequestID:             req.RequestID,
 		Model:                 req.Model,
+		InputExcerpt:          req.InputExcerpt,
 		InputTokens:           req.InputTokens,
 		OutputTokens:          req.OutputTokens,
 		CacheCreationTokens:   req.CacheCreationTokens,

--- a/backend/migrations/154_add_usage_log_input_excerpt.sql
+++ b/backend/migrations/154_add_usage_log_input_excerpt.sql
@@ -1,0 +1,2 @@
+ALTER TABLE usage_logs
+ADD COLUMN IF NOT EXISTS input_excerpt TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## 变更说明

本 PR 为 `usage_logs` 增加了用户输入摘要的持久化能力，方便在排查请求问题、复现异常输入、定位计费或风控争议时，能够直接看到一段经过脱敏和截断处理后的输入摘要。

## 主要改动

- 为 `usage_logs` 新增 `input_excerpt` 字段
- 新增数据库迁移：
  - `backend/migrations/154_add_usage_log_input_excerpt.sql`
- 增加统一的输入摘要提取逻辑，支持多种请求格式：
  - Chat Completions `messages`
  - Responses `input`
  - Embeddings `input`
  - Images `prompt`
  - Gemini/兼容协议 `contents`
- 对提取出的摘要做统一处理：
  - 敏感信息脱敏
  - 长文本截断
  - 尽量只保留用户可读文本，不保留大块二进制/base64内容
- 将 `input_excerpt` 接入 usage log 主链路落库
- 将 `input_excerpt` 暴露到 usage log DTO
- 补充了对应测试

## 实现细节

- 复用了现有内容审计相关的脱敏思路，避免把 token、secret、Bearer、URL 等敏感信息原样写入日志
- 摘要字段通过统一提取器生成，避免在各个 handler 中散落重复逻辑
- 管理后台可查看该字段，便于排查问题

## 使用价值

这个字段主要用于：
- 排查用户具体发了什么 prompt
- 定位异常计费、异常拦截、异常请求
- 辅助复现上下游兼容性问题
- 降低只靠 request_id 排查时的信息缺失

## 注意事项

- 写入的不是完整原始输入，而是经过脱敏和截断后的摘要
- 该字段设计目标是便于排查问题，不是作为完整请求归档
- https://github.com/Wei-Shaw/sub2api/issues/3485 来自此建议