### PR TITLE
Add persistent reset credit expiry display

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -56,6 +56,7 @@ var schedulerNeutralExtraKeyPrefixes = []string{
 	"codex_secondary_",
 	"codex_5h_",
 	"codex_7d_",
+	"codex_reset_credit_",
 	"passive_usage_",
 }
 

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -7,10 +7,12 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/imroc/req/v3"
 )
 
 // Endpoints used by the OpenAI/ChatGPT/Codex quota query and reset feature.
@@ -24,6 +26,8 @@ const (
 	openaiQuotaSecFetchMode     = "no-cors"
 	openaiQuotaSecFetchDest     = "empty"
 )
+
+const chatGPTRateLimitResetInfoURL = "https://chatgpt.com/backend-api/wham/rate-limit-reset-credits"
 
 // OpenAIRateLimitWindow describes a single rate-limit window returned by
 // /wham/usage. The upstream returns an explicit `null` window when the slot
@@ -53,7 +57,14 @@ type OpenAIAdditionalRateLimit struct {
 // OpenAIRateLimitResetCredits captures the "available_count" surfaced for the
 // rate_limit_reset_credit grant type, which the reset action consumes.
 type OpenAIRateLimitResetCredits struct {
-	AvailableCount int `json:"available_count"`
+	AvailableCount    int      `json:"available_count"`
+	EarliestExpiresAt string   `json:"earliest_expires_at,omitempty"`
+	ExpiresAtList     []string `json:"expires_at_list,omitempty"`
+}
+
+type openAIRateLimitResetCreditsResponse struct {
+	AvailableCount int                      `json:"available_count"`
+	Credits        []OpenAIQuotaResetCredit `json:"credits"`
 }
 
 // OpenAIQuotaUsage is the typed projection of /wham/usage we expose to the UI.
@@ -151,8 +162,109 @@ func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*
 		return nil, infraerrors.Newf(mapUpstreamStatus(status), "OPENAI_QUOTA_UPSTREAM_ERROR", "upstream returned %d: %s", status, body)
 	}
 
+	if resetCredits, err := s.queryResetCredits(callCtx, client, accessToken, chatGPTAccountID, fedRAMP, accountID); err != nil {
+		slog.Warn("openai_quota_reset_credits_query_failed", "account_id", accountID, "error", err)
+	} else if resetCredits != nil {
+		if payload.RateLimitResetCredits == nil {
+			payload.RateLimitResetCredits = resetCredits
+		} else {
+			payload.RateLimitResetCredits.EarliestExpiresAt = resetCredits.EarliestExpiresAt
+			payload.RateLimitResetCredits.ExpiresAtList = resetCredits.ExpiresAtList
+		}
+		s.persistResetCreditsSnapshot(ctx, accountID, resetCredits)
+	}
+
 	payload.FetchedAt = time.Now().Unix()
 	return &payload, nil
+}
+
+func (s *OpenAIQuotaService) queryResetCredits(
+	ctx context.Context,
+	client *req.Client,
+	accessToken string,
+	chatGPTAccountID string,
+	fedRAMP bool,
+	accountID int64,
+) (*OpenAIRateLimitResetCredits, error) {
+	var payload openAIRateLimitResetCreditsResponse
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeaders(buildCodexCommonHeaders(accessToken, chatGPTAccountID, fedRAMP)).
+		SetSuccessResult(&payload).
+		Get(chatGPTRateLimitResetInfoURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_RESET_CREDITS_REQUEST_FAILED", "upstream request failed: %v", err)
+	}
+	if !resp.IsSuccessState() {
+		status := resp.StatusCode
+		body := truncate(resp.String(), 240)
+		slog.Warn("openai_quota_reset_credits_failed", "account_id", accountID, "status", status, "body", body)
+		return nil, infraerrors.Newf(mapUpstreamStatus(status), "OPENAI_QUOTA_RESET_CREDITS_UPSTREAM_ERROR", "upstream returned %d: %s", status, body)
+	}
+
+	return &OpenAIRateLimitResetCredits{
+		AvailableCount:    payload.AvailableCount,
+		EarliestExpiresAt: firstResetCreditExpiresAt(payload.Credits),
+		ExpiresAtList:     resetCreditExpiresAtList(payload.Credits, 5),
+	}, nil
+}
+
+func (s *OpenAIQuotaService) persistResetCreditsSnapshot(ctx context.Context, accountID int64, credits *OpenAIRateLimitResetCredits) {
+	if s == nil || s.accountRepo == nil || credits == nil {
+		return
+	}
+	updates := map[string]any{
+		"codex_reset_credit_available_count":    credits.AvailableCount,
+		"codex_reset_credit_expires_at_list":    credits.ExpiresAtList,
+		"codex_reset_credit_earliest_expires_at": credits.EarliestExpiresAt,
+		"codex_reset_credit_updated_at":         time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := s.accountRepo.UpdateExtra(ctx, accountID, updates); err != nil {
+		slog.Warn("openai_quota_reset_credits_persist_failed", "account_id", accountID, "error", err)
+	}
+}
+
+func firstResetCreditExpiresAt(credits []OpenAIQuotaResetCredit) string {
+	list := resetCreditExpiresAtList(credits, 1)
+	if len(list) == 0 {
+		return ""
+	}
+	return list[0]
+}
+
+func resetCreditExpiresAtList(credits []OpenAIQuotaResetCredit, limit int) []string {
+	if limit <= 0 {
+		return nil
+	}
+
+	type expiresAtItem struct {
+		raw string
+		t   time.Time
+	}
+	items := make([]expiresAtItem, 0, len(credits))
+	for _, credit := range credits {
+		raw := strings.TrimSpace(credit.ExpiresAt)
+		if raw == "" {
+			continue
+		}
+		expiresAt, err := parseTime(raw)
+		if err != nil {
+			continue
+		}
+		items = append(items, expiresAtItem{raw: raw, t: expiresAt})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].t.Before(items[j].t)
+	})
+
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		result = append(result, item.raw)
+	}
+	return result
 }
 
 // ResetCredit consumes one rate_limit_reset_credit for the given OpenAI account.

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -736,6 +736,8 @@ export interface OpenAIAdditionalRateLimit {
 
 export interface OpenAIRateLimitResetCredits {
   available_count: number
+  earliest_expires_at?: string
+  expires_at_list?: string[]
 }
 
 export interface OpenAIQuotaUsage {

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -135,7 +135,7 @@
           refresh button is rendered via the pre-actions slot so the user sees a
           single row of related buttons instead of two stacked rows.
         -->
-        <OpenAIQuotaResetCell :account="account">
+        <OpenAIQuotaResetCell :account="account" @reset-credit-expiry="emit('resetCreditExpiry', $event)">
           <template #pre-actions>
             <button
               type="button"
@@ -177,7 +177,7 @@
       <div v-else>
         <div class="text-xs text-gray-400">-</div>
         <!-- Always allow on-demand upstream quota query, even before local data exists. -->
-        <OpenAIQuotaResetCell :account="account" class="mt-1" />
+        <OpenAIQuotaResetCell :account="account" class="mt-1" @reset-credit-expiry="emit('resetCreditExpiry', $event)" />
       </div>
     </template>
 
@@ -610,6 +610,10 @@ const props = withDefaults(
     manualRefreshToken: 0
   }
 )
+
+const emit = defineEmits<{
+  resetCreditExpiry: [expiresAtList: string[]]
+}>()
 
 const { t } = useI18n()
 const desktopViewportQuery = '(min-width: 768px)'

--- a/frontend/src/components/account/OpenAIQuotaResetCell.vue
+++ b/frontend/src/components/account/OpenAIQuotaResetCell.vue
@@ -107,6 +107,10 @@ const props = defineProps<{
   account: Account
 }>()
 
+const emit = defineEmits<{
+  resetCreditExpiry: [expiresAtList: string[]]
+}>()
+
 const { t } = useI18n()
 
 // Visible only for OpenAI OAuth accounts.
@@ -118,6 +122,29 @@ const error = ref<string | null>(null)
 const data = ref<OpenAIQuotaUsage | null>(null)
 const resetMessage = ref<string | null>(null)
 const showResetConfirm = ref(false)
+
+const readCachedResetCredits = (account: Account): OpenAIQuotaUsage | null => {
+  const extra = account.extra ?? {}
+  const count = Number(extra.codex_reset_credit_available_count)
+  const expiresAtList = Array.isArray(extra.codex_reset_credit_expires_at_list)
+    ? extra.codex_reset_credit_expires_at_list.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+    : []
+  const earliest = typeof extra.codex_reset_credit_earliest_expires_at === 'string'
+    ? extra.codex_reset_credit_earliest_expires_at
+    : expiresAtList[0]
+
+  if (!Number.isFinite(count) && expiresAtList.length === 0 && !earliest) return null
+  return {
+    fetched_at: 0,
+    rate_limit_reset_credits: {
+      available_count: Number.isFinite(count) ? count : 0,
+      earliest_expires_at: earliest || undefined,
+      expires_at_list: expiresAtList
+    }
+  }
+}
+
+data.value = readCachedResetCredits(props.account)
 
 const availableResetCount = computed(() => data.value?.rate_limit_reset_credits?.available_count ?? 0)
 const canReset = computed(() => availableResetCount.value > 0)
@@ -139,6 +166,15 @@ const truncatedError = computed(() => {
   if (!error.value) return ''
   return error.value.length > 80 ? `${error.value.slice(0, 80)}…` : error.value
 })
+
+const resolveResetExpiryList = (usage: OpenAIQuotaUsage): string[] => {
+  const credits = usage.rate_limit_reset_credits
+  if (!credits) return []
+  if (Array.isArray(credits.expires_at_list) && credits.expires_at_list.length > 0) {
+    return credits.expires_at_list.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+  }
+  return credits.earliest_expires_at ? [credits.earliest_expires_at] : []
+}
 
 const extractErrorMessage = (e: unknown): string => {
   // The project's axios response interceptor (api/client.ts) flattens server
@@ -167,6 +203,7 @@ const handleQuery = async () => {
   resetMessage.value = null
   try {
     data.value = await queryOpenAIQuota(props.account.id)
+    emit('resetCreditExpiry', resolveResetExpiryList(data.value))
   } catch (e) {
     error.value = extractErrorMessage(e)
   } finally {
@@ -195,10 +232,6 @@ const confirmReset = async () => {
   resetMessage.value = null
   try {
     const result: OpenAIQuotaResetResult = await resetOpenAIQuota(props.account.id)
-    // Refresh the reset-credit count so the badge reflects the consumed credit.
-    // handleQuery clears resetMessage on entry, so the success toast is set
-    // AFTER it resolves.
-    await handleQuery()
     resetMessage.value = t('admin.accounts.openaiQuotaReset.resetSuccess', {
       windows: result.windows_reset
     })
@@ -213,7 +246,7 @@ watch(
   () => props.account.id,
   () => {
     // Account row may be reused across paginated lists; reset local state.
-    data.value = null
+    data.value = readCachedResetCredits(props.account)
     error.value = null
     resetMessage.value = null
     loading.value = false

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3182,6 +3182,7 @@ export default {
         todayStats: 'Today Stats',
         groups: 'Groups',
         usageWindows: 'Usage Windows',
+        resetCreditExpiresAt: 'Reset Expires At',
         proxy: 'Proxy',
         lastUsed: 'Last Used',
         createdAt: 'Created',
@@ -3189,6 +3190,10 @@ export default {
         actions: 'Actions'
       },
       usageWindowsHint: '"5h / 7d" are the upstream account\'s official rolling usage windows (e.g. OpenAI ChatGPT, Claude). They are imposed by the upstream provider on the account itself — not configured by sub2api, and unrelated to the models you map. Usage resets automatically once each window rolls over, and the limit cannot be lifted from within sub2api.',
+      resetCreditExpiresAt: {
+        empty: 'Click Credits to show reset-credit expiration times',
+        tooltip: 'Reset-credit expiration times:\n{time}'
+      },
       allPrivacyModes: 'All Privacy States',
       privacyUnset: 'Unset',
       privacyTrainingOff: 'Training data sharing disabled',

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3214,6 +3214,7 @@ export default {
         todayStats: '今日统计',
         groups: '分组',
         usageWindows: '用量窗口',
+        resetCreditExpiresAt: '重置过期时间',
         proxy: '代理',
         lastUsed: '最近使用',
         createdAt: '创建时间',
@@ -3221,6 +3222,10 @@ export default {
         actions: '操作'
       },
       usageWindowsHint: '“5h / 7d”是上游账号（如 OpenAI ChatGPT、Claude）官方的滚动用量窗口限制，由上游对账号设定，并非 sub2api 配置，也与你映射的模型无关。窗口滚动到期后用量会自动重置，无法在 sub2api 端解除该限制。',
+      resetCreditExpiresAt: {
+        empty: '点击“次数”查询后显示重置次数过期时间',
+        tooltip: '重置次数过期时间：\n{time}'
+      },
       allPrivacyModes: '全部Privacy状态',
       privacyUnset: '未设置',
       privacyTrainingOff: '已关闭训练数据共享',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -288,7 +288,21 @@
               :today-stats="todayStatsByAccountId[String(row.id)] ?? null"
               :today-stats-loading="todayStatsLoading"
               :manual-refresh-token="usageManualRefreshToken"
+              @reset-credit-expiry="handleResetCreditExpiry(row, $event)"
             />
+          </template>
+          <template #cell-reset_credit_expires_at="{ row }">
+            <div
+              class="flex flex-col gap-0.5 text-xs text-gray-500 dark:text-dark-400"
+              :title="formatResetCreditExpiryTitle(row)"
+            >
+              <template v-if="formatResetCreditExpiryList(row).length > 0">
+                <span v-for="expiresAt in formatResetCreditExpiryList(row)" :key="expiresAt">
+                  {{ expiresAt }}
+                </span>
+              </template>
+              <span v-else>-</span>
+            </div>
           </template>
           <template #cell-proxy="{ row }">
             <div class="flex flex-col gap-1">
@@ -576,6 +590,7 @@ const todayStatsError = ref<string | null>(null)
 const todayStatsReqSeq = ref(0)
 const pendingTodayStatsRefresh = ref(false)
 const usageManualRefreshToken = ref(0)
+const resetCreditExpiryByAccountId = ref<Record<string, string[]>>({})
 
 const buildDefaultTodayStats = (): WindowStats => ({
   requests: 0,
@@ -1152,6 +1167,7 @@ const allColumns = computed(() => {
   }
   c.push(
     { key: 'usage', label: t('admin.accounts.columns.usageWindows'), sortable: false },
+    { key: 'reset_credit_expires_at', label: t('admin.accounts.columns.resetCreditExpiresAt'), sortable: false },
     { key: 'proxy', label: t('admin.accounts.columns.proxy'), sortable: false },
     { key: 'priority', label: t('admin.accounts.columns.priority'), sortable: true },
     { key: 'rate_multiplier', label: t('admin.accounts.columns.billingRateMultiplier'), sortable: true },
@@ -1493,6 +1509,34 @@ const syncPaginationAfterLocalRemoval = () => {
   }
   // 行被本地移除后不立刻全量补页，改为提示用户手动同步。
   hasPendingListSync.value = nextTotal > 0
+}
+
+const handleResetCreditExpiry = (account: Account, expiresAtList: string[]) => {
+  resetCreditExpiryByAccountId.value = {
+    ...resetCreditExpiryByAccountId.value,
+    [String(account.id)]: expiresAtList
+  }
+}
+
+const cachedResetCreditExpiryList = (account: Account): string[] => {
+  const list = account.extra?.codex_reset_credit_expires_at_list
+  if (!Array.isArray(list)) return []
+  return list.filter((item): item is string => typeof item === 'string' && item.trim() !== '').slice(0, 5)
+}
+
+const resolveResetCreditExpiryList = (account: Account): string[] => {
+  if (account.platform !== 'openai' || account.type !== 'oauth') return []
+  return resetCreditExpiryByAccountId.value[String(account.id)] ?? cachedResetCreditExpiryList(account)
+}
+
+const formatResetCreditExpiryList = (account: Account): string[] => {
+  return resolveResetCreditExpiryList(account).map((expiresAt) => formatDateTime(expiresAt))
+}
+
+const formatResetCreditExpiryTitle = (account: Account): string => {
+  const list = formatResetCreditExpiryList(account)
+  if (list.length === 0) return t('admin.accounts.resetCreditExpiresAt.empty')
+  return t('admin.accounts.resetCreditExpiresAt.tooltip', { time: list.join('\n') })
 }
 
 const patchAccountInList = (updatedAccount: Account) => {


### PR DESCRIPTION
## Summary
- Add a reset credit expiry column for OpenAI OAuth account usage.
- Query and cache reset credit count plus up to five expiry times when clicking Credits.
- Preserve cached reset credit count and expiry times across page refreshes.
- Keep reset credit expiry values sorted by expiration time.

## Notes
- Cached values are only refreshed by clicking the Credits button.
- Reset-credit cache fields are treated as scheduler-neutral extra fields.