### PR TITLE
修复 OpenAI GPT-5.5 的 Codex 指令选择

### DIFF
--- a/backend/internal/pkg/openai/instructions_test.go
+++ b/backend/internal/pkg/openai/instructions_test.go
@@ -25,6 +25,7 @@ func TestCodexBaseInstructionsForModel(t *testing.T) {
 		{"gpt-5.1-codex-max", "You are Codex, based on GPT-5"},
 		{"gpt-5.2-codex", "You are Codex, based on GPT-5"},
 		{"gpt-5.5", "You are Codex, a coding agent based on GPT-5"},
+		{" GPT-5.5 ", "You are Codex, a coding agent based on GPT-5"},
 		{"gpt-5.2", "You are GPT-5.2 running in the Codex CLI"},
 		{"gpt-5.1", "You are GPT-5.1 running in the Codex CLI"},
 		{"gpt-5", "You are Codex, a coding agent based on GPT-5"},   // 回退到最新（GPT-5.5）

--- a/backend/internal/service/openai_codex_transform_additions_test.go
+++ b/backend/internal/service/openai_codex_transform_additions_test.go
@@ -61,6 +61,8 @@ func TestApplyCodexClientMetadata(t *testing.T) {
 // defaultCodexSynthInstructions：按模型选用真实 Codex base prompt。
 func TestDefaultCodexSynthInstructionsModelAware(t *testing.T) {
 	require.True(t, strings.Contains(defaultCodexSynthInstructions("gpt-5-codex"), "You are Codex, based on GPT-5"))
+	require.True(t, strings.Contains(defaultCodexSynthInstructions("gpt-5.5"), "You are Codex, a coding agent based on GPT-5"))
+	require.False(t, strings.Contains(defaultCodexSynthInstructions("gpt-5.5"), "You are GPT-5.1 running in the Codex CLI"))
 	require.True(t, strings.Contains(defaultCodexSynthInstructions("gpt-5.2"), "You are GPT-5.2 running in the Codex CLI"))
 	require.True(t, strings.Contains(defaultCodexSynthInstructions("gpt-5.1"), "You are GPT-5.1 running in the Codex CLI"))
 }

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -1008,6 +1008,21 @@ func TestApplyCodexOAuthTransform_CodexCLI_SuppliesDefaultWhenEmpty(t *testing.T
 	require.True(t, result.Modified)
 }
 
+func TestApplyCodexOAuthTransform_GPT55SuppliesModelSpecificInstructions(t *testing.T) {
+	reqBody := map[string]any{
+		"model":        "gpt-5.5",
+		"instructions": "   ",
+	}
+
+	result := applyCodexOAuthTransform(reqBody, true, false)
+
+	instructions, ok := reqBody["instructions"].(string)
+	require.True(t, ok)
+	require.Contains(t, instructions, "You are Codex, a coding agent based on GPT-5")
+	require.NotContains(t, instructions, "You are GPT-5.1 running in the Codex CLI")
+	require.True(t, result.Modified)
+}
+
 func TestApplyCodexOAuthTransform_NonCodexCLI_PreservesExistingInstructions(t *testing.T) {
 	// 非 Codex CLI 场景：已有 instructions 时保留客户端的值，不再覆盖
 


### PR DESCRIPTION
## 变更说明

补充 GPT-5.5 的 Codex 指令选择回归覆盖，确保 GPT-5.5 使用当前最新 Codex 指令，而不是退回到 GPT-5.1 指令。

- 基于最新 main 重新整理，保留主线已有的 GPT-5.5 指令和 fallback 逻辑
- 增加 GPT-5.5 模型名带空格时的指令选择测试
- 增加 OAuth transform 中 GPT-5.5 注入指令的回归测试
- 明确断言 GPT-5.5 不会使用 GPT-5.1 指令

## 适用场景

Codex CLI 或兼容客户端使用 GPT-5.5 模型时，需要自动注入匹配模型版本的系统指令，避免行为退回旧模型提示词。

Fixes #3257

## 验证

- `go test ./internal/pkg/openai ./internal/service`