### PR TITLE
fix: make account privacy setting idempotent

### DIFF
--- a/backend/internal/handler/admin/account_handler_mixed_channel_test.go
+++ b/backend/internal/handler/admin/account_handler_mixed_channel_test.go
@@ -20,6 +20,7 @@ func setupAccountMixedChannelRouter(adminSvc *stubAdminService) *gin.Engine {
 	router.POST("/api/v1/admin/accounts", accountHandler.Create)
 	router.PUT("/api/v1/admin/accounts/:id", accountHandler.Update)
 	router.POST("/api/v1/admin/accounts/bulk-update", accountHandler.BulkUpdate)
+	router.POST("/api/v1/admin/accounts/:id/set-privacy", accountHandler.SetPrivacy)
 	return router
 }
 
@@ -221,4 +222,62 @@ func TestBulkUpdateAcceptsFilterTargetRequest(t *testing.T) {
 	var resp map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Equal(t, float64(0), resp["code"])
+}
+
+func TestAccountHandlerSetPrivacyInitializesMissingExtra(t *testing.T) {
+	adminSvc := newStubAdminService()
+	adminSvc.accounts = []service.Account{{
+		ID:       7,
+		Name:     "openai-oauth",
+		Platform: service.PlatformOpenAI,
+		Type:     service.AccountTypeOAuth,
+		Status:   service.StatusActive,
+		Credentials: map[string]any{
+			"access_token": "token-1",
+		},
+	}}
+	router := setupAccountMixedChannelRouter(adminSvc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/7/set-privacy", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, float64(0), resp["code"])
+	data, ok := resp["data"].(map[string]any)
+	require.True(t, ok)
+	extra, ok := data["extra"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, service.PrivacyModeTrainingOff, extra["privacy_mode"])
+}
+
+func TestAccountHandlerSetPrivacyAlreadySetReturnsSuccess(t *testing.T) {
+	adminSvc := newStubAdminService()
+	adminSvc.accounts = []service.Account{{
+		ID:       8,
+		Name:     "antigravity-oauth",
+		Platform: service.PlatformAntigravity,
+		Type:     service.AccountTypeOAuth,
+		Status:   service.StatusActive,
+		Extra: map[string]any{
+			"privacy_mode": service.AntigravityPrivacySet,
+		},
+	}}
+	router := setupAccountMixedChannelRouter(adminSvc)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/8/set-privacy", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, float64(0), resp["code"])
+	data, ok := resp["data"].(map[string]any)
+	require.True(t, ok)
+	extra, ok := data["extra"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, service.AntigravityPrivacySet, extra["privacy_mode"])
 }

--- a/backend/internal/handler/admin/admin_service_stub_test.go
+++ b/backend/internal/handler/admin/admin_service_stub_test.go
@@ -332,6 +332,12 @@ func (s *stubAdminService) ListAccounts(ctx context.Context, page, pageSize int,
 }
 
 func (s *stubAdminService) GetAccount(ctx context.Context, id int64) (*service.Account, error) {
+	for i := range s.accounts {
+		if s.accounts[i].ID == id {
+			account := s.accounts[i]
+			return &account, nil
+		}
+	}
 	account := service.Account{ID: id, Name: "account", Status: service.StatusActive}
 	return &account, nil
 }
@@ -621,11 +627,41 @@ func (s *stubAdminService) EnsureAntigravityPrivacy(ctx context.Context, account
 }
 
 func (s *stubAdminService) ForceOpenAIPrivacy(ctx context.Context, account *service.Account) string {
-	return ""
+	if account != nil {
+		if account.Extra == nil {
+			account.Extra = make(map[string]any)
+		}
+		account.Extra["privacy_mode"] = service.PrivacyModeTrainingOff
+		for i := range s.accounts {
+			if s.accounts[i].ID == account.ID {
+				if s.accounts[i].Extra == nil {
+					s.accounts[i].Extra = make(map[string]any)
+				}
+				s.accounts[i].Extra["privacy_mode"] = service.PrivacyModeTrainingOff
+				break
+			}
+		}
+	}
+	return service.PrivacyModeTrainingOff
 }
 
 func (s *stubAdminService) ForceAntigravityPrivacy(ctx context.Context, account *service.Account) string {
-	return ""
+	if account != nil {
+		if account.Extra == nil {
+			account.Extra = make(map[string]any)
+		}
+		account.Extra["privacy_mode"] = service.AntigravityPrivacySet
+		for i := range s.accounts {
+			if s.accounts[i].ID == account.ID {
+				if s.accounts[i].Extra == nil {
+					s.accounts[i].Extra = make(map[string]any)
+				}
+				s.accounts[i].Extra["privacy_mode"] = service.AntigravityPrivacySet
+				break
+			}
+		}
+	}
+	return service.AntigravityPrivacySet
 }
 
 func (s *stubAdminService) ReplaceUserGroup(ctx context.Context, userID, oldGroupID, newGroupID int64) (*service.ReplaceUserGroupResult, error) {

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -93,9 +93,9 @@ type AdminService interface {
 	EnsureOpenAIPrivacy(ctx context.Context, account *Account) string
 	// EnsureAntigravityPrivacy 检查 Antigravity OAuth 账号 privacy_mode，未设置则调用 setUserSettings 并持久化。
 	EnsureAntigravityPrivacy(ctx context.Context, account *Account) string
-	// ForceOpenAIPrivacy 强制重新设置 OpenAI OAuth 账号隐私，无论当前状态。
+	// ForceOpenAIPrivacy 为 OpenAI OAuth 账号设置隐私；已成功设置时幂等返回当前成功状态。
 	ForceOpenAIPrivacy(ctx context.Context, account *Account) string
-	// ForceAntigravityPrivacy 强制重新设置 Antigravity OAuth 账号隐私，无论当前状态。
+	// ForceAntigravityPrivacy 为 Antigravity OAuth 账号设置隐私；已成功设置时幂等返回当前成功状态。
 	ForceAntigravityPrivacy(ctx context.Context, account *Account) string
 	SetAccountSchedulable(ctx context.Context, id int64, schedulable bool) (*Account, error)
 	BulkUpdateAccounts(ctx context.Context, input *BulkUpdateAccountsInput) (*BulkUpdateAccountsResult, error)
@@ -3887,10 +3887,13 @@ func (s *adminServiceImpl) EnsureOpenAIPrivacy(ctx context.Context, account *Acc
 	return mode
 }
 
-// ForceOpenAIPrivacy 强制重新设置 OpenAI OAuth 账号隐私，无论当前状态。
+// ForceOpenAIPrivacy 为 OpenAI OAuth 账号设置隐私；已成功设置时幂等返回当前成功状态。
 func (s *adminServiceImpl) ForceOpenAIPrivacy(ctx context.Context, account *Account) string {
 	if account.Platform != PlatformOpenAI || account.Type != AccountTypeOAuth {
 		return ""
+	}
+	if isOpenAIPrivacyModeSuccess(account.Extra) {
+		return PrivacyModeTrainingOff
 	}
 	if s.privacyClientFactory == nil {
 		return ""
@@ -3964,10 +3967,13 @@ func (s *adminServiceImpl) EnsureAntigravityPrivacy(ctx context.Context, account
 	return mode
 }
 
-// ForceAntigravityPrivacy 强制重新设置 Antigravity OAuth 账号隐私，无论当前状态。
+// ForceAntigravityPrivacy 为 Antigravity OAuth 账号设置隐私；已成功设置时幂等返回当前成功状态。
 func (s *adminServiceImpl) ForceAntigravityPrivacy(ctx context.Context, account *Account) string {
 	if account.Platform != PlatformAntigravity || account.Type != AccountTypeOAuth {
 		return ""
+	}
+	if account.IsPrivacySet() {
+		return AntigravityPrivacySet
 	}
 
 	token, _ := account.Credentials["access_token"].(string)

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -19,6 +19,7 @@ type mockAccountRepoForGemini struct {
 	accountsByID       map[int64]*Account
 	listByGroupFunc    func(ctx context.Context, groupID int64, platforms []string) ([]Account, error)
 	listByPlatformFunc func(ctx context.Context, platforms []string) ([]Account, error)
+	updateExtraCalls   int
 }
 
 func (m *mockAccountRepoForGemini) GetByID(ctx context.Context, id int64) (*Account, error) {
@@ -173,6 +174,7 @@ func (m *mockAccountRepoForGemini) UpdateSessionWindowEnd(ctx context.Context, i
 	return nil
 }
 func (m *mockAccountRepoForGemini) UpdateExtra(ctx context.Context, id int64, updates map[string]any) error {
+	m.updateExtraCalls++
 	return nil
 }
 func (m *mockAccountRepoForGemini) BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error) {

--- a/backend/internal/service/openai_privacy_retry_test.go
+++ b/backend/internal/service/openai_privacy_retry_test.go
@@ -15,8 +15,15 @@ import (
 func TestAdminService_EnsureOpenAIPrivacy_RetriesNonSuccessModes(t *testing.T) {
 	t.Parallel()
 
-	for _, mode := range []string{PrivacyModeFailed, PrivacyModeCFBlocked} {
-		t.Run(mode, func(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		mode string
+	}{
+		{name: "failed", mode: PrivacyModeFailed},
+		{name: "cf_blocked", mode: PrivacyModeCFBlocked},
+		{name: "empty", mode: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			privacyCalls := 0
@@ -36,7 +43,7 @@ func TestAdminService_EnsureOpenAIPrivacy_RetriesNonSuccessModes(t *testing.T) {
 					"access_token": "token-1",
 				},
 				Extra: map[string]any{
-					"privacy_mode": mode,
+					"privacy_mode": tc.mode,
 				},
 			}
 
@@ -46,6 +53,56 @@ func TestAdminService_EnsureOpenAIPrivacy_RetriesNonSuccessModes(t *testing.T) {
 			require.Equal(t, 1, privacyCalls)
 		})
 	}
+}
+
+func TestAdminService_ForceOpenAIPrivacy_IdempotentWhenAlreadyTrainingOff(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockAccountRepoForGemini{}
+	privacyCalls := 0
+	svc := &adminServiceImpl{
+		accountRepo: repo,
+		privacyClientFactory: func(proxyURL string) (*req.Client, error) {
+			privacyCalls++
+			return nil, errors.New("unexpected privacy call")
+		},
+	}
+
+	account := &Account{
+		ID:       101,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"privacy_mode": PrivacyModeTrainingOff,
+		},
+	}
+
+	got := svc.ForceOpenAIPrivacy(context.Background(), account)
+
+	require.Equal(t, PrivacyModeTrainingOff, got)
+	require.Equal(t, 0, privacyCalls)
+	require.Equal(t, 0, repo.updateExtraCalls)
+}
+
+func TestAdminService_ForceAntigravityPrivacy_IdempotentWhenAlreadySet(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockAccountRepoForGemini{}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	account := &Account{
+		ID:       102,
+		Platform: PlatformAntigravity,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"privacy_mode": AntigravityPrivacySet,
+		},
+	}
+
+	got := svc.ForceAntigravityPrivacy(context.Background(), account)
+
+	require.Equal(t, AntigravityPrivacySet, got)
+	require.Equal(t, 0, repo.updateExtraCalls)
 }
 
 func TestTokenRefreshService_ensureOpenAIPrivacy_RetriesNonSuccessModes(t *testing.T) {

--- a/backend/internal/service/openai_privacy_service.go
+++ b/backend/internal/service/openai_privacy_service.go
@@ -32,7 +32,15 @@ func shouldSkipOpenAIPrivacyEnsure(extra map[string]any) bool {
 	}
 	mode, _ := raw.(string)
 	mode = strings.TrimSpace(mode)
-	return mode != PrivacyModeFailed && mode != PrivacyModeCFBlocked
+	return mode != "" && mode != PrivacyModeFailed && mode != PrivacyModeCFBlocked
+}
+
+func isOpenAIPrivacyModeSuccess(extra map[string]any) bool {
+	if extra == nil {
+		return false
+	}
+	mode, _ := extra["privacy_mode"].(string)
+	return strings.TrimSpace(mode) == PrivacyModeTrainingOff
 }
 
 // disableOpenAITraining calls ChatGPT settings API to turn off "Improve the model for everyone".

--- a/backend/migrations/158_fix_openai_privacy_failed_states.sql
+++ b/backend/migrations/158_fix_openai_privacy_failed_states.sql
@@ -1,0 +1,8 @@
+-- Backfill historical OpenAI OAuth privacy attempts that reached the desired
+-- local scheduling state but were stored as retryable failures.
+UPDATE accounts
+SET extra = jsonb_set(COALESCE(extra, '{}'::jsonb), '{privacy_mode}', '"training_off"', true),
+    updated_at = NOW()
+WHERE platform = 'openai'
+  AND type = 'oauth'
+  AND extra->>'privacy_mode' IN ('training_set_failed', 'training_set_cf_blocked');

--- a/frontend/src/components/admin/account/AccountActionMenu.vue
+++ b/frontend/src/components/admin/account/AccountActionMenu.vue
@@ -32,9 +32,19 @@
                 {{ t('admin.accounts.refreshToken') }}
               </button>
             </template>
-            <button v-if="supportsPrivacy" @click="$emit('set-privacy', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
+            <button
+              v-if="supportsPrivacy"
+              :disabled="privacyAlreadySet"
+              :class="[
+                'flex w-full items-center gap-2 px-4 py-2 text-sm',
+                privacyAlreadySet
+                  ? 'cursor-not-allowed text-gray-400 dark:text-gray-500'
+                  : 'text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700'
+              ]"
+              @click="$emit('set-privacy', account); $emit('close')"
+            >
               <Icon name="shield" size="sm" />
-              {{ t('admin.accounts.setPrivacy') }}
+              {{ privacyAlreadySet ? t('admin.accounts.privacyAlreadySet') : t('admin.accounts.setPrivacy') }}
             </button>
             <div v-if="hasRecoverableState" class="my-1 border-t border-gray-100 dark:border-dark-700"></div>
             <button v-if="hasRecoverableState" @click="$emit('recover-state', account); $emit('close')" class="flex w-full items-center gap-2 px-4 py-2 text-sm text-emerald-600 hover:bg-gray-100 dark:hover:bg-dark-700">
@@ -82,6 +92,14 @@ const hasRecoverableState = computed(() => {
 const isAntigravityOAuth = computed(() => props.account?.platform === 'antigravity' && props.account?.type === 'oauth')
 const isOpenAIOAuth = computed(() => props.account?.platform === 'openai' && props.account?.type === 'oauth')
 const supportsPrivacy = computed(() => isAntigravityOAuth.value || isOpenAIOAuth.value)
+const privacyMode = computed(() => {
+  const mode = props.account?.extra?.privacy_mode
+  return typeof mode === 'string' ? mode.trim() : ''
+})
+const privacyAlreadySet = computed(() => {
+  return (isOpenAIOAuth.value && privacyMode.value === 'training_off') ||
+    (isAntigravityOAuth.value && privacyMode.value === 'privacy_set')
+})
 const hasQuotaLimit = computed(() => {
   return (props.account?.type === 'apikey' || props.account?.type === 'bedrock') && (
     (props.account?.quota_limit ?? 0) > 0 ||

--- a/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountActionMenu.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+import AccountActionMenu from '../AccountActionMenu.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+function mountMenu(account: Record<string, unknown>) {
+  return mount(AccountActionMenu, {
+    props: {
+      show: true,
+      account,
+      position: { top: 10, left: 10 }
+    } as any,
+    global: {
+      stubs: {
+        Teleport: true,
+        Icon: true
+      }
+    }
+  })
+}
+
+describe('AccountActionMenu', () => {
+  it('disables privacy action when OpenAI privacy is already set', async () => {
+    const wrapper = mountMenu({
+      id: 1,
+      platform: 'openai',
+      type: 'oauth',
+      extra: { privacy_mode: 'training_off' }
+    })
+
+    const button = wrapper.findAll('button').find((item) => item.text().includes('admin.accounts.privacyAlreadySet'))
+    expect(button).toBeTruthy()
+    expect(button!.attributes('disabled')).toBeDefined()
+
+    await button!.trigger('click')
+    expect(wrapper.emitted('set-privacy')).toBeUndefined()
+  })
+
+  it('keeps privacy action enabled for failed OpenAI states', async () => {
+    const wrapper = mountMenu({
+      id: 2,
+      platform: 'openai',
+      type: 'oauth',
+      extra: { privacy_mode: 'training_set_failed' }
+    })
+
+    const button = wrapper.findAll('button').find((item) => item.text().includes('admin.accounts.setPrivacy'))
+    expect(button).toBeTruthy()
+    expect(button!.attributes('disabled')).toBeUndefined()
+
+    await button!.trigger('click')
+    expect(wrapper.emitted('set-privacy')).toHaveLength(1)
+  })
+})

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -3200,6 +3200,7 @@ export default {
       privacyAntigravitySet: 'Telemetry and marketing emails disabled',
       privacyAntigravityFailed: 'Privacy setting failed',
       setPrivacy: 'Set Privacy',
+      privacyAlreadySet: 'Privacy Set',
       subscriptionAbnormal: 'Abnormal',
       subscriptionExpires: 'Expires',
       // Capacity status tooltips

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -3232,6 +3232,7 @@ export default {
       privacyAntigravitySet: '已关闭遥测和营销邮件',
       privacyAntigravityFailed: '隐私设置失败',
       setPrivacy: '设置隐私',
+      privacyAlreadySet: '已设置隐私',
       subscriptionAbnormal: '异常',
       subscriptionExpires: '到期',
       // 容量状态提示


### PR DESCRIPTION
## Summary
- make account privacy setting idempotent for already-successful OpenAI and Antigravity OAuth accounts
- retry empty OpenAI privacy_mode values instead of treating them as already handled
- disable the privacy action in the account action menu when privacy is already set
- add a migration to backfill historical OpenAI OAuth privacy failure states to training_off

## Tests
- go test -tags unit ./internal/service ./internal/handler/admin
- pnpm --dir frontend exec vitest run src/components/admin/account/__tests__/AccountActionMenu.spec.ts
- pnpm --dir frontend exec vue-tsc --noEmit