### PR TITLE
fix: source-build version resolution for release tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,8 @@ tests
 CLAUDE.md
 .claude
 scripts
+!backend/scripts/
+!backend/scripts/resolve-version.sh
 .code-review-state
 #openspec/
 code-reviews/

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,9 @@ COPY backend/ ./
 COPY --from=frontend-builder /app/backend/internal/web/dist ./internal/web/dist
 
 # Build the binary (BuildType=release for CI builds, embed frontend)
-# Version precedence: build arg VERSION > cmd/server/VERSION
+# Version precedence: build arg VERSION > exact git tag > cmd/server/VERSION
 RUN VERSION_VALUE="${VERSION}" && \
-    if [ -z "${VERSION_VALUE}" ]; then VERSION_VALUE="$(tr -d '\r\n' < ./cmd/server/VERSION)"; fi && \
+    if [ -z "${VERSION_VALUE}" ]; then VERSION_VALUE="$(./scripts/resolve-version.sh)"; fi && \
     DATE_VALUE="${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" && \
     CGO_ENABLED=0 GOOS=linux go build \
     -tags embed \

--- a/README.md
+++ b/README.md
@@ -447,7 +447,8 @@ pnpm run build
 
 # 4. Build backend with embedded frontend
 cd ../backend
-go build -tags embed -o sub2api ./cmd/server
+VERSION="$(./scripts/resolve-version.sh)"
+go build -tags embed -ldflags="-X main.Version=${VERSION}" -o sub2api ./cmd/server
 
 # 5. Create configuration file
 cp ../deploy/config.example.yaml ./config.yaml

--- a/README_CN.md
+++ b/README_CN.md
@@ -462,7 +462,8 @@ pnpm run build
 
 # 4. 编译后端（嵌入前端）
 cd ../backend
-go build -tags embed -o sub2api ./cmd/server
+VERSION="$(./scripts/resolve-version.sh)"
+go build -tags embed -ldflags="-X main.Version=${VERSION}" -o sub2api ./cmd/server
 
 # 5. 创建配置文件
 cp ../deploy/config.example.yaml ./config.yaml

--- a/README_JA.md
+++ b/README_JA.md
@@ -445,7 +445,8 @@ pnpm run build
 
 # 4. フロントエンドを組み込んだバックエンドをビルド
 cd ../backend
-go build -tags embed -o sub2api ./cmd/server
+VERSION="$(./scripts/resolve-version.sh)"
+go build -tags embed -ldflags="-X main.Version=${VERSION}" -o sub2api ./cmd/server
 
 # 5. 設定ファイルを作成
 cp ../deploy/config.example.yaml ./config.yaml

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,7 +15,8 @@ RUN go mod download
 COPY . .
 
 # 构建应用
-RUN go build -o main ./cmd/server/
+RUN VERSION_VALUE="$(./scripts/resolve-version.sh)" && \
+    go build -ldflags="-s -w -X main.Version=${VERSION_VALUE}" -o main ./cmd/server/
 
 # 暴露端口
 EXPOSE 8080

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build generate test test-unit test-integration test-e2e
 
-VERSION ?= $(shell tr -d '\r\n' < ./cmd/server/VERSION)
+VERSION ?= $(shell ./scripts/resolve-version.sh)
 LDFLAGS ?= -s -w -X main.Version=$(VERSION)
 
 build:

--- a/backend/scripts/resolve-version.sh
+++ b/backend/scripts/resolve-version.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+BACKEND_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(CDPATH= cd -- "$BACKEND_DIR/.." && pwd)"
+VERSION_FILE="$BACKEND_DIR/cmd/server/VERSION"
+
+# Prefer the exact release tag when building from a tagged checkout so
+# source builds from vX.Y.Z don't inherit the previous VERSION file value.
+if command -v git >/dev/null 2>&1; then
+  TAG="$(
+    git -C "$REPO_DIR" describe --tags --exact-match --match 'v[0-9]*' 2>/dev/null || \
+    git -C "$REPO_DIR" describe --tags --exact-match --match '[0-9]*' 2>/dev/null || \
+    true
+  )"
+  if [ -n "$TAG" ]; then
+    printf '%s\n' "${TAG#v}"
+    exit 0
+  fi
+fi
+
+printf '%s\n' "$(tr -d '\r\n' < "$VERSION_FILE")"

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -41,7 +41,7 @@ RUN pnpm run build
 FROM ${GOLANG_IMAGE} AS backend-builder
 
 # Build arguments for version info (set by CI)
-ARG VERSION=docker
+ARG VERSION=
 ARG COMMIT=docker
 ARG DATE
 ARG GOPROXY
@@ -66,9 +66,13 @@ COPY backend/ ./
 COPY --from=frontend-builder /app/backend/internal/web/dist ./internal/web/dist
 
 # Build the binary (BuildType=release for CI builds, embed frontend)
-RUN CGO_ENABLED=0 GOOS=linux go build \
+# Version precedence: build arg VERSION > exact git tag > cmd/server/VERSION
+RUN VERSION_VALUE="${VERSION}" && \
+    if [ -z "${VERSION_VALUE}" ]; then VERSION_VALUE="$(./scripts/resolve-version.sh)"; fi && \
+    DATE_VALUE="${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}" && \
+    CGO_ENABLED=0 GOOS=linux go build \
     -tags embed \
-    -ldflags="-s -w -X main.Commit=${COMMIT} -X main.Date=${DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)} -X main.BuildType=release" \
+    -ldflags="-s -w -X main.Version=${VERSION_VALUE} -X main.Commit=${COMMIT} -X main.Date=${DATE_VALUE} -X main.BuildType=release" \
     -o /app/sub2api \
     ./cmd/server
 

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,5 +1,8 @@
 .PHONY: wire build build-embed test-unit test-integration test-e2e test-cover-integration
 
+VERSION ?= $(shell ./scripts/resolve-version.sh)
+LDFLAGS ?= -s -w -X main.Version=$(VERSION)
+
 wire:
 	@echo "生成 Wire 代码..."
 	@cd cmd/server && go generate
@@ -7,12 +10,12 @@ wire:
 
 build:
 	@echo "构建后端（不嵌入前端）..."
-	@go build -o bin/server ./cmd/server
+	@go build -ldflags="$(LDFLAGS)" -o bin/server ./cmd/server
 	@echo "构建完成: bin/server"
 
 build-embed:
 	@echo "构建后端（嵌入前端）..."
-	@go build -tags embed -o bin/server ./cmd/server
+	@go build -tags embed -ldflags="$(LDFLAGS)" -o bin/server ./cmd/server
 	@echo "构建完成: bin/server (with embedded frontend)"
 
 test-unit:


### PR DESCRIPTION
## Summary

- prefer the exact Git release tag over `backend/cmd/server/VERSION` when resolving the source-build version
- wire the same version resolution into the main backend/deploy build entrypoints so manual source builds, Docker builds, and embedded frontend builds report the tagged version consistently
- update the EN/CN/JA source-build README snippets to use the resolved build version instead of relying on the stale file value inside older tags

When building directly from a release tag checkout, the embedded `VERSION` file can lag by one release because the sync back to `main` happens after the tag is cut. For example, `v0.1.140` still contains `backend/cmd/server/VERSION=0.1.139`, which makes `--version` and the sidebar version badge display the previous release for source builds from that tag.

This keeps the existing fallback order for non-tagged checkouts:

- explicit build arg / ldflags
- exact Git tag
- `backend/cmd/server/VERSION`

## Testing

```bash
cd backend
./scripts/resolve-version.sh
make build
./bin/server --version
```

```bash
# tag checkout reproduction
cd backend
./scripts/resolve-version.sh
VERSION="$(./scripts/resolve-version.sh)"
CGO_ENABLED=0 go build -ldflags="-s -w -X main.Version=${VERSION}" -o /tmp/sub2api-v0140 ./cmd/server
/tmp/sub2api-v0140 --version
```

Verified locally:

- `origin/main` resolves/builds as `0.1.141`
- `v0.1.140` resolves/builds as `0.1.140` even though the tag's `backend/cmd/server/VERSION` file is still `0.1.139`
- `golangci-lint v2.9.0` reports `0 issues` for `./internal/pkg/anthropicfp` after rebasing onto latest `main`

## Notes

- this does not rewrite historical tags or change the release workflow itself
- release CI keeps its existing explicit `VERSION` / ldflags precedence
- the README changes only keep the documented manual source-build commands aligned with the new resolution path
- after rebasing onto the latest `main`, this branch also includes a small lint-only fix in `backend/internal/pkg/anthropicfp/dateline.go`; that file came from upstream `main` during rebase and would otherwise keep this PR red even though it is unrelated to the tagged-version logic
