### PR TITLE
fix: Handle invalid arguments correctly for Gemini reasoning models

### DIFF
--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -1,6 +1,9 @@
 package antigravity
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // Claude 请求/响应类型定义
 
@@ -145,6 +148,7 @@ type modelDef struct {
 	ID          string
 	DisplayName string
 	CreatedAt   string // 仅 Claude API 格式使用
+	IsReasoning bool
 }
 
 // Antigravity 支持的 Claude 模型
@@ -166,15 +170,15 @@ var geminiModels = []modelDef{
 	{ID: "gemini-2.5-flash-image", DisplayName: "Gemini 2.5 Flash Image", CreatedAt: "2025-01-01T00:00:00Z"},
 	{ID: "gemini-2.5-flash-image-preview", DisplayName: "Gemini 2.5 Flash Image Preview", CreatedAt: "2025-01-01T00:00:00Z"},
 	{ID: "gemini-2.5-flash-lite", DisplayName: "Gemini 2.5 Flash Lite", CreatedAt: "2025-01-01T00:00:00Z"},
-	{ID: "gemini-2.5-flash-thinking", DisplayName: "Gemini 2.5 Flash Thinking", CreatedAt: "2025-01-01T00:00:00Z"},
+	{ID: "gemini-2.5-flash-thinking", DisplayName: "Gemini 2.5 Flash Thinking", CreatedAt: "2025-01-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3-flash", DisplayName: "Gemini 3 Flash", CreatedAt: "2025-06-01T00:00:00Z"},
 	{ID: "gemini-3-pro-low", DisplayName: "Gemini 3 Pro Low", CreatedAt: "2025-06-01T00:00:00Z"},
-	{ID: "gemini-3-pro-high", DisplayName: "Gemini 3 Pro High", CreatedAt: "2025-06-01T00:00:00Z"},
+	{ID: "gemini-3-pro-high", DisplayName: "Gemini 3 Pro High", CreatedAt: "2025-06-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.1-pro-low", DisplayName: "Gemini 3.1 Pro Low", CreatedAt: "2026-02-19T00:00:00Z"},
-	{ID: "gemini-3.1-pro-high", DisplayName: "Gemini 3.1 Pro High", CreatedAt: "2026-02-19T00:00:00Z"},
+	{ID: "gemini-3.1-pro-high", DisplayName: "Gemini 3.1 Pro High", CreatedAt: "2026-02-19T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.1-flash-image", DisplayName: "Gemini 3.1 Flash Image", CreatedAt: "2026-02-19T00:00:00Z"},
 	{ID: "gemini-3.1-flash-image-preview", DisplayName: "Gemini 3.1 Flash Image Preview", CreatedAt: "2026-02-19T00:00:00Z"},
-	{ID: "gemini-3-pro-preview", DisplayName: "Gemini 3 Pro Preview", CreatedAt: "2025-06-01T00:00:00Z"},
+	{ID: "gemini-3-pro-preview", DisplayName: "Gemini 3 Pro Preview", CreatedAt: "2025-06-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3-pro-image", DisplayName: "Gemini 3 Pro Image", CreatedAt: "2025-06-01T00:00:00Z"},
 }
 
@@ -239,3 +243,15 @@ func FallbackGeminiModel(model string) GeminiModel {
 	}
 	return GeminiModel{Name: name, SupportedGenerationMethods: defaultGeminiMethods}
 }
+
+// IsGeminiReasoningModel 判断是否为不支持参数和强制 ToolConfig 的 Gemini 推理模型
+func IsGeminiReasoningModel(modelID string) bool {
+	lowerID := strings.ToLower(modelID)
+	for _, m := range geminiModels {
+		if strings.Contains(lowerID, m.ID) && m.IsReasoning {
+			return true
+		}
+	}
+	return false
+}
+

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -254,4 +254,3 @@ func IsGeminiReasoningModel(modelID string) bool {
 	}
 	return false
 }
-

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -143,14 +143,19 @@ func TransformClaudeToGeminiWithOptions(claudeReq *ClaudeRequest, projectID, map
 	// 5. 构建内部请求
 	innerRequest := GeminiRequest{
 		Contents: contents,
+		// 总是生成 sessionId，基于用户消息内容
+		SessionID: generateStableSessionID(contents),
+	}
+
+	// 针对 Gemini Reasoning 模型（如 gemini-3.1-pro-high等）过滤强制空 ToolConfig
+	isReasoning := IsGeminiReasoningModel(targetModel)
+	if !isReasoning || len(tools) > 0 {
 		// 总是设置 toolConfig，与官方客户端一致
-		ToolConfig: &GeminiToolConfig{
+		innerRequest.ToolConfig = &GeminiToolConfig{
 			FunctionCallingConfig: &GeminiFunctionCallingConfig{
 				Mode: "VALIDATED",
 			},
-		},
-		// 总是生成 sessionId，基于用户消息内容
-		SessionID: generateStableSessionID(contents),
+		}
 	}
 
 	if systemInstruction != nil {
@@ -610,7 +615,11 @@ func buildGenerationConfig(req *ClaudeRequest) *GeminiGenerationConfig {
 	maxLimit := maxOutputTokensLimit(req.Model)
 	config := &GeminiGenerationConfig{
 		MaxOutputTokens: defaultMaxOutputTokens, // 默认最大输出
-		StopSequences:   DefaultStopSequences,
+	}
+
+	isReasoning := IsGeminiReasoningModel(req.Model)
+	if !isReasoning {
+		config.StopSequences = DefaultStopSequences
 	}
 
 	// 如果请求中指定了 MaxTokens，使用请求值
@@ -656,14 +665,16 @@ func buildGenerationConfig(req *ClaudeRequest) *GeminiGenerationConfig {
 	}
 
 	// 其他参数
-	if req.Temperature != nil {
-		config.Temperature = req.Temperature
-	}
-	if req.TopP != nil {
-		config.TopP = req.TopP
-	}
-	if req.TopK != nil {
-		config.TopK = req.TopK
+	if !isReasoning {
+		if req.Temperature != nil {
+			config.Temperature = req.Temperature
+		}
+		if req.TopP != nil {
+			config.TopP = req.TopP
+		}
+		if req.TopK != nil {
+			config.TopK = req.TopK
+		}
 	}
 
 	return config


### PR DESCRIPTION
### Summary
This PR resolves `INVALID_ARGUMENT` errors when proxying requests to Gemini reasoning/thinking models (e.g., `gemini-3.1-pro-high`) through the Antigravity gateway. 

Gemini reasoning models strictly reject requests that include generation configs with sampling parameters (`temperature`, `top_p`, `top_k`), `stop_sequences`, or empty `toolConfig` objects.
Previously, passing these fields would cause the upstream API to respond with a 400 Bad Request.

### Changes Made
- Introduced an `IsReasoning` boolean flag to the internal `modelDef` structs inside `claude_types. go` to explicitly tag thinking models in a structured way.
- Added a new helper function `IsGeminiReasoningModel(modelID string) bool` to perform model capability checks without relying on hardcoded name string matching across the codebase.
- Refactored `request_transformer.go` to intercept and strip out `Temperature`, `TopP`, `TopK`, `StopSequences`, and empty forced `ToolConfig`s during payload conversion when a reasoning model is detected.

### Impact
Ensures that all current and future Gemini reasoning models properly generate responses through the Antigravity gateway without triggering `INVALID_ARGUMENT` exceptions from the upstream API.