### PR TITLE
fix(openai): skip Codex image bridge injections for /responses/compact

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2794,7 +2794,9 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return nil, errors.New("image generation disabled for group")
 	}
 
-	if imageGenerationAllowed && (codexImageGenerationBridgeEnabled || isOpenAIImageGenerationModel(requestView.Model) || openAIRequestBodyImageGenerationToolNeedsNormalization(body) || isOpenAIImageGenerationModel(upstreamModel)) {
+	// /responses/compact 是会话压缩请求：上游不接受 tool_choice（400 unknown_parameter），
+	// 注入 image_generation 工具也没有意义，整块豁免。
+	if imageGenerationAllowed && !isCompactRequest && (codexImageGenerationBridgeEnabled || isOpenAIImageGenerationModel(requestView.Model) || openAIRequestBodyImageGenerationToolNeedsNormalization(body) || isOpenAIImageGenerationModel(upstreamModel)) {
 		decoded, decodeErr := ensureReqBody()
 		if decodeErr != nil {
 			return nil, decodeErr

--- a/backend/internal/service/openai_image_generation_controls_test.go
+++ b/backend/internal/service/openai_image_generation_controls_test.go
@@ -208,6 +208,35 @@ func TestOpenAIGatewayServiceForward_CodexBridgePreservesExistingToolChoice(t *t
 	require.Equal(t, "image_generation", gjson.GetBytes(upstream.lastBody, "tool_choice.type").String())
 }
 
+func TestOpenAIGatewayServiceForward_CodexBridgeSkipsCompactRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"id":"resp_codex_compact","model":"gpt-5.4","usage":{"input_tokens":1,"output_tokens":1}}`)),
+		},
+	}
+	svc := newOpenAIImageGenerationControlTestService(upstream)
+	svc.cfg.Gateway.CodexImageGenerationBridgeEnabled = true
+	c, _ := newOpenAIImageGenerationControlTestContext(true, "codex_cli_rs/0.98.0")
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses/compact", nil)
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.98.0")
+	account := newOpenAIImageGenerationControlTestAccount()
+
+	// /responses/compact 上游不接受 tool_choice，bridge 注入必须整体豁免 compact 请求。
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.4","input":"summarize the conversation","stream":false}`))
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, upstream.lastReq)
+	require.False(t, gjson.GetBytes(upstream.lastBody, "tool_choice").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, `tools.#(type=="image_generation")`).Exists())
+	instructions := gjson.GetBytes(upstream.lastBody, "instructions").String()
+	require.NotContains(t, instructions, "image_generation")
+}
+
 func TestOpenAIGatewayService_CodexImageGenerationBridgeOverridePrecedence(t *testing.T) {
 	groupID := int64(4242)
 


### PR DESCRIPTION
## 问题

开启 `codex_image_generation_bridge` 后，`Forward` 内的 image bridge 处理块对**所有** Codex 请求注入 `tools:[image_generation]` + `tool_choice:"auto"`（#3498 / v0.1.140 起），包括 `/responses/compact`。ChatGPT 上游 compact 端点不接受 `tool_choice`，导致所有远程压缩请求 100% 失败：

```json
{"error": {"message": "Unknown parameter: 'tool_choice'.", "type": "invalid_request_error", "param": "tool_choice", "code": "unknown_parameter"}}
```

handler 层的 `normalizeOpenAICompactRequestBody` 白名单清理在 `Forward` **之前**执行，挡不住之后注入的字段。完整根因分析见 #3629。

## 修复

image generation 处理块的 guard 增加 `!isCompactRequest`，compact 请求整体豁免——compact 是会话压缩请求，注入画图工具本身也没有意义。`isCompactRequest` 在同函数上文已经算出，改动为最小侵入。

## 测试

- 新增 `TestOpenAIGatewayServiceForward_CodexBridgeSkipsCompactRequests`：bridge 开启 + POST `/responses/compact` → 断言上游请求体不含 `tool_choice`、不含注入的 `image_generation` 工具、instructions 不含桥接指令。该测试在修复前会失败（`tool_choice=auto` 被注入），修复后通过。
- 存量 bridge 测试无回归：

```
--- PASS: TestNormalizeOpenAICompactRequestBodyPreservesCurrentCodexPayloadFields
--- PASS: TestOpenAIGatewayServiceForward_CodexImageInjectionRespectsGroupCapability (3 subtests)
--- PASS: TestOpenAIGatewayServiceForward_CodexBridgePreservesExistingToolChoice
--- PASS: TestOpenAIGatewayServiceForward_CodexBridgeSkipsCompactRequests
--- PASS: TestOpenAIGatewayService_CodexImageGenerationBridgeOverridePrecedence (6 subtests)
ok  	github.com/Wei-Shaw/sub2api/internal/service
```

另注：`openai_ws_forwarder.go` 的 WS ingress 有同样的注入逻辑，但 WS 通路的 gin context path 不会是 `/responses/compact`，故本 PR 不涉及；如 WS 将来承载 compact 语义，需要同样豁免。

Fixes #3629

🤖 Generated with [Claude Code](https://claude.com/claude-code)