### PR TITLE
fix(openai): persist subscription expiration from OAuth

### DIFF
--- a/frontend/src/composables/__tests__/useOpenAIOAuth.spec.ts
+++ b/frontend/src/composables/__tests__/useOpenAIOAuth.spec.ts
@@ -59,6 +59,20 @@ describe('useOpenAIOAuth.buildCredentials', () => {
     expect(creds.access_token).toBe('at')
     expect(creds.refresh_token).toBe('rt')
   })
+
+  it('should keep ChatGPT subscription expiration from token response', () => {
+    const oauth = useOpenAIOAuth()
+    const creds = oauth.buildCredentials({
+      access_token: 'at',
+      refresh_token: 'rt',
+      expires_at: 1700000000,
+      plan_type: 'team',
+      subscription_expires_at: '2026-07-20T19:22:48+00:00'
+    })
+
+    expect(creds.plan_type).toBe('team')
+    expect(creds.subscription_expires_at).toBe('2026-07-20T19:22:48+00:00')
+  })
 })
 
 describe('useOpenAIOAuth.exchangeAuthCode', () => {

--- a/frontend/src/composables/useOpenAIOAuth.ts
+++ b/frontend/src/composables/useOpenAIOAuth.ts
@@ -16,6 +16,7 @@ export interface OpenAITokenInfo {
   email?: string
   name?: string
   plan_type?: string
+  subscription_expires_at?: string
   privacy_mode?: string
   // OpenAI specific IDs (extracted from ID Token)
   chatgpt_account_id?: string
@@ -196,6 +197,9 @@ export function useOpenAIOAuth() {
     }
     if (tokenInfo.plan_type) {
       creds.plan_type = tokenInfo.plan_type
+    }
+    if (tokenInfo.subscription_expires_at) {
+      creds.subscription_expires_at = tokenInfo.subscription_expires_at
     }
     if (tokenInfo.client_id) {
       creds.client_id = tokenInfo.client_id


### PR DESCRIPTION
## Background
The OpenAI OAuth exchange already returns ChatGPT subscription expiration as subscription_expires_at, but the frontend did not include that field when building the create-account credentials payload.

As a result, newly added OpenAI OAuth accounts could save the plan type while dropping the subscription expiration, so the account list had no expiration value to display.

## Summary
- include subscription_expires_at in the OpenAI OAuth token info type
- carry subscription_expires_at into account credentials when building OpenAI OAuth accounts
- add composable coverage for preserving the subscription expiration value

## Tests
- vitest run src/composables/__tests__/useOpenAIOAuth.spec.ts
- vue-tsc --noEmit
- vite build
- Docker build for local preview