### PR TITLE
fix: 优化运维实时账号统计接口性能

### DIFF
--- a/backend/internal/handler/admin/ops_realtime_handler.go
+++ b/backend/internal/handler/admin/ops_realtime_handler.go
@@ -1,6 +1,8 @@
 package admin
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -47,6 +49,9 @@ func (h *OpsHandler) GetConcurrencyStats(c *gin.Context) {
 
 	platform, group, account, collectedAt, err := h.opsService.GetConcurrencyStats(c.Request.Context(), platformFilter, groupID)
 	if err != nil {
+		if isOpsRealtimeRequestCanceled(c, err) {
+			return
+		}
 		response.ErrorFrom(c, err)
 		return
 	}
@@ -86,6 +91,9 @@ func (h *OpsHandler) GetUserConcurrencyStats(c *gin.Context) {
 
 	users, collectedAt, err := h.opsService.GetUserConcurrencyStats(c.Request.Context())
 	if err != nil {
+		if isOpsRealtimeRequestCanceled(c, err) {
+			return
+		}
 		response.ErrorFrom(c, err)
 		return
 	}
@@ -140,6 +148,9 @@ func (h *OpsHandler) GetAccountAvailability(c *gin.Context) {
 
 	platformStats, groupStats, accountStats, collectedAt, err := h.opsService.GetAccountAvailabilityStats(c.Request.Context(), platform, groupID)
 	if err != nil {
+		if isOpsRealtimeRequestCanceled(c, err) {
+			return
+		}
 		response.ErrorFrom(c, err)
 		return
 	}
@@ -154,6 +165,19 @@ func (h *OpsHandler) GetAccountAvailability(c *gin.Context) {
 		payload["timestamp"] = collectedAt.UTC()
 	}
 	response.Success(c, payload)
+}
+
+func isOpsRealtimeRequestCanceled(c *gin.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	if c != nil && c.Request != nil && errors.Is(c.Request.Context().Err(), context.Canceled) {
+		return true
+	}
+	return strings.Contains(err.Error(), "canceling statement due to user request")
 }
 
 func parseOpsRealtimeWindow(v string) (time.Duration, string, bool) {
@@ -236,6 +260,9 @@ func (h *OpsHandler) GetRealtimeTrafficSummary(c *gin.Context) {
 
 	summary, err := h.opsService.GetRealtimeTrafficSummary(c.Request.Context(), filter)
 	if err != nil {
+		if isOpsRealtimeRequestCanceled(c, err) {
+			return
+		}
 		response.ErrorFrom(c, err)
 		return
 	}

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -603,6 +603,41 @@ func (r *accountRepository) ListWithFilters(ctx context.Context, params paginati
 	return outAccounts, paginationResultFromTotal(int64(total), params), nil
 }
 
+func (r *accountRepository) ListOpsAccountsForStats(ctx context.Context, platformFilter string, groupIDFilter *int64) ([]service.Account, error) {
+	if r == nil || r.client == nil {
+		return []service.Account{}, nil
+	}
+
+	q := r.client.Account.Query()
+	if platformFilter = strings.TrimSpace(platformFilter); platformFilter != "" {
+		q = q.Where(dbaccount.PlatformEQ(platformFilter))
+	}
+	if groupIDFilter != nil && *groupIDFilter > 0 {
+		q = q.Where(dbaccount.HasAccountGroupsWith(dbaccountgroup.GroupIDEQ(*groupIDFilter)))
+	}
+
+	accounts, err := q.
+		Select(
+			dbaccount.FieldID,
+			dbaccount.FieldName,
+			dbaccount.FieldPlatform,
+			dbaccount.FieldConcurrency,
+			dbaccount.FieldLoadFactor,
+			dbaccount.FieldStatus,
+			dbaccount.FieldErrorMessage,
+			dbaccount.FieldSchedulable,
+			dbaccount.FieldRateLimitResetAt,
+			dbaccount.FieldOverloadUntil,
+			dbaccount.FieldTempUnschedulableUntil,
+		).
+		Order(dbent.Asc(dbaccount.FieldID)).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return r.accountsToService(ctx, accounts)
+}
+
 func accountListOrder(params pagination.PaginationParams) []func(*entsql.Selector) {
 	sortBy := strings.ToLower(strings.TrimSpace(params.SortBy))
 	sortOrder := params.NormalizedSortOrder(pagination.SortOrderAsc)

--- a/backend/internal/service/ops_account_availability.go
+++ b/backend/internal/service/ops_account_availability.go
@@ -20,7 +20,7 @@ func (s *OpsService) GetAccountAvailabilityStats(ctx context.Context, platformFi
 		return nil, nil, nil, nil, err
 	}
 
-	accounts, err := s.listAllAccountsForOps(ctx, platformFilter)
+	accounts, err := s.listAllAccountsForOps(ctx, platformFilter, groupIDFilter)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/backend/internal/service/ops_concurrency.go
+++ b/backend/internal/service/ops_concurrency.go
@@ -13,18 +13,29 @@ const (
 	opsConcurrencyBatchChunkSize = 200
 )
 
-func (s *OpsService) listAllAccountsForOps(ctx context.Context, platformFilter string) ([]Account, error) {
+type opsAccountStatsRepository interface {
+	ListOpsAccountsForStats(ctx context.Context, platformFilter string, groupIDFilter *int64) ([]Account, error)
+}
+
+func (s *OpsService) listAllAccountsForOps(ctx context.Context, platformFilter string, groupIDFilter *int64) ([]Account, error) {
 	if s == nil || s.accountRepo == nil {
 		return []Account{}, nil
+	}
+	if repo, ok := s.accountRepo.(opsAccountStatsRepository); ok {
+		return repo.ListOpsAccountsForStats(ctx, platformFilter, groupIDFilter)
 	}
 
 	out := make([]Account, 0, 128)
 	page := 1
+	groupID := int64(0)
+	if groupIDFilter != nil {
+		groupID = *groupIDFilter
+	}
 	for {
 		accounts, pageInfo, err := s.accountRepo.ListWithFilters(ctx, pagination.PaginationParams{
 			Page:     page,
 			PageSize: opsAccountsPageSize,
-		}, platformFilter, "", "", "", 0, "")
+		}, platformFilter, "", "", "", groupID, "")
 		if err != nil {
 			return nil, err
 		}
@@ -112,7 +123,7 @@ func (s *OpsService) GetConcurrencyStats(
 		return nil, nil, nil, nil, err
 	}
 
-	accounts, err := s.listAllAccountsForOps(ctx, platformFilter)
+	accounts, err := s.listAllAccountsForOps(ctx, platformFilter, groupIDFilter)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
## 摘要

优化 `/admin/ops/concurrency` 和 `/admin/ops/account-availability` 两个运维实时接口，解决生产环境打开运维监控页面后 CPU 被打满的问题。并且还会因为响应速度太慢超时失败

实际生产日志中可以看到，这两个接口在大账号量场景下会反复分页扫描账号表：

```sql
  SELECT ... FROM accounts
  WHERE deleted_at IS NULL
  ORDER BY name ASC, id ASC
  LIMIT 100 OFFSET 21300
```

同时还会执行：
```sql
  SELECT COUNT(accounts.id) FROM accounts WHERE accounts.deleted_at IS NULL
```
  前端或 Cloudflare 取消请求后，PostgreSQL 会报：
```txt
  canceling statement due to user request
```
  后端随后将该错误按 ERROR 打出堆栈。

## 变更内容

  - 新增运维实时统计专用的轻量账号查询。
  - 避免实时统计路径反复执行分页 COUNT(*)。
  - 避免 OFFSET 深分页扫描。
  - 避免 ORDER BY name 大范围排序。
  - 不再加载统计不需要的 credentials / extra 字段。
  - 将 platform 和 group_id 过滤下推到数据库。
  - 对客户端取消导致的实时接口错误降级处理，避免刷 ERROR 堆栈。

## 预期效果

  - 打开运维监控页面时，不再因为这两个实时接口触发深分页全表扫描。
  - 降低账号量较大时的数据库和应用 CPU 压力。
  - 减少 pq: canceling statement due to user request 引发的 ERROR 堆栈噪声。