### PR TITLE
fix: require verify code before submitting OAuth pending account crea…

### DIFF
--- a/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
+++ b/frontend/src/components/auth/PendingOAuthCreateAccountForm.vue
@@ -71,7 +71,13 @@
       :data-testid="`${testIdPrefix}-create-account-submit`"
       type="button"
       class="btn btn-primary w-full"
-      :disabled="isSubmitting || !email.trim() || password.length < 6 || (invitationCodeEnabled && !invitationCode.trim())"
+      :disabled="
+        isSubmitting ||
+        !email.trim() ||
+        password.length < 6 ||
+        (emailVerifyEnabled && verifyCode.trim().length !== 6) ||
+        (invitationCodeEnabled && !invitationCode.trim())
+      "
       @click="handleSubmit"
     >
       {{ isSubmitting ? t('common.processing') : t('auth.createAccount') }}
@@ -241,14 +247,18 @@ async function handleSendCode() {
 
 function handleSubmit() {
   const trimmedEmail = email.value.trim()
+  const trimmedCode = verifyCode.value.trim()
   if (!trimmedEmail || password.value.length < 6) {
+    return
+  }
+  if (emailVerifyEnabled.value && trimmedCode.length !== 6) {
     return
   }
 
   emit('submit', {
     email: trimmedEmail,
     password: password.value,
-    verifyCode: emailVerifyEnabled.value ? verifyCode.value.trim() : '',
+    verifyCode: emailVerifyEnabled.value ? trimmedCode : '',
     invitationCode: invitationCode.value.trim() || undefined
   })
 }


### PR DESCRIPTION
…tion

The "创建账号" button in PendingOAuthCreateAccountForm only validated email and password, letting users submit without ever sending/entering the local email verification code. The backend unconditionally requires it (RegisterOAuthEmailAccount), so this silently failed with EMAIL_VERIFY_REQUIRED for every provider routed through this shared form (OIDC, LinuxDo, WeChat, GitHub, Google).