### PR TITLE
Add configurable Codex default OpenAI service tier

### DIFF
--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -403,6 +403,10 @@ const (
 	// targets OpenAI's body-level service_tier field instead of Claude's
 	// anthropic-beta header.
 	SettingKeyOpenAIFastPolicySettings = "openai_fast_policy_settings"
+	// SettingKeyOpenAICodexDefaultServiceTier stores an optional default
+	// OpenAI service_tier injected only for official Codex clients that omit
+	// service_tier. Empty means disabled.
+	SettingKeyOpenAICodexDefaultServiceTier = "openai_codex_default_service_tier"
 
 	// =========================
 	// Claude Code Version Check

--- a/backend/internal/service/openai_fast_policy_test.go
+++ b/backend/internal/service/openai_fast_policy_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -51,6 +54,10 @@ func (s *openAIFastPolicyRepoStub) Delete(ctx context.Context, key string) error
 }
 
 func newOpenAIGatewayServiceWithSettings(t *testing.T, settings *OpenAIFastPolicySettings) *OpenAIGatewayService {
+	return newOpenAIGatewayServiceWithFastSettings(t, settings, "")
+}
+
+func newOpenAIGatewayServiceWithFastSettings(t *testing.T, settings *OpenAIFastPolicySettings, codexDefaultServiceTier string) *OpenAIGatewayService {
 	t.Helper()
 	repo := &openAIFastPolicyRepoStub{values: map[string]string{}}
 	if settings != nil {
@@ -58,9 +65,27 @@ func newOpenAIGatewayServiceWithSettings(t *testing.T, settings *OpenAIFastPolic
 		require.NoError(t, err)
 		repo.values[SettingKeyOpenAIFastPolicySettings] = string(raw)
 	}
+	if codexDefaultServiceTier != "" {
+		repo.values[SettingKeyOpenAICodexDefaultServiceTier] = codexDefaultServiceTier
+	}
 	return &OpenAIGatewayService{
+		cfg:            &config.Config{},
 		settingService: NewSettingService(repo, &config.Config{}),
 	}
+}
+
+func newOpenAIFastPolicyGinContext(method, path, userAgent, originator string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(method, path, nil)
+	if userAgent != "" {
+		c.Request.Header.Set("User-Agent", userAgent)
+	}
+	if originator != "" {
+		c.Request.Header.Set("originator", originator)
+	}
+	return c
 }
 
 func openAIFastFilterPriorityPolicy() *OpenAIFastPolicySettings {
@@ -162,6 +187,47 @@ func TestApplyOpenAIFastPolicyToBody_DefaultPassesPriorityAndFast(t *testing.T) 
 	updated, err = svc.applyOpenAIFastPolicyToBody(context.Background(), account, "gpt-5.5", body)
 	require.NoError(t, err)
 	require.Equal(t, string(body), string(updated))
+}
+
+func TestApplyOpenAICodexDefaultServiceTierToBody_InjectsForOfficialCodexClient(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithFastSettings(t, DefaultOpenAIFastPolicySettings(), "fast")
+	c := newOpenAIFastPolicyGinContext(http.MethodPost, "/v1/responses", "codex-tui/0.142.4 (Mac OS 26.2.0; arm64)", "")
+
+	body := []byte(`{"model":"gpt-5.5","input":"hello"}`)
+	updated, err := svc.applyOpenAICodexDefaultServiceTierToBody(context.Background(), c, body)
+	require.NoError(t, err)
+	require.Equal(t, "priority", gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestApplyOpenAICodexDefaultServiceTierToBody_DoesNotOverwriteExplicitTier(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithFastSettings(t, DefaultOpenAIFastPolicySettings(), "priority")
+	c := newOpenAIFastPolicyGinContext(http.MethodPost, "/v1/responses", "codex-tui/0.142.4 (Mac OS 26.2.0; arm64)", "")
+
+	body := []byte(`{"model":"gpt-5.5","service_tier":"flex"}`)
+	updated, err := svc.applyOpenAICodexDefaultServiceTierToBody(context.Background(), c, body)
+	require.NoError(t, err)
+	require.Equal(t, "flex", gjson.GetBytes(updated, "service_tier").String())
+}
+
+func TestApplyOpenAICodexDefaultServiceTierToBody_SkipsNonCodexClient(t *testing.T) {
+	svc := newOpenAIGatewayServiceWithFastSettings(t, DefaultOpenAIFastPolicySettings(), "priority")
+	c := newOpenAIFastPolicyGinContext(http.MethodPost, "/v1/responses", "curl/8.0.1", "")
+
+	body := []byte(`{"model":"gpt-5.5"}`)
+	updated, err := svc.applyOpenAICodexDefaultServiceTierToBody(context.Background(), c, body)
+	require.NoError(t, err)
+	require.False(t, gjson.GetBytes(updated, "service_tier").Exists())
+}
+
+func TestGetOpenAICodexDefaultServiceTier_NormalizesAndRejectsInvalidValues(t *testing.T) {
+	repo := &openAIFastPolicyRepoStub{values: map[string]string{
+		SettingKeyOpenAICodexDefaultServiceTier: " fast ",
+	}}
+	svc := NewSettingService(repo, &config.Config{})
+	require.Equal(t, "priority", svc.GetOpenAICodexDefaultServiceTier(context.Background()))
+
+	repo.values[SettingKeyOpenAICodexDefaultServiceTier] = "turbo"
+	require.Empty(t, svc.GetOpenAICodexDefaultServiceTier(context.Background()))
 }
 
 func TestApplyOpenAIFastPolicyToBody_ExplicitFilterRemovesField(t *testing.T) {

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -225,6 +225,11 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		}
 	}
 
+	responsesBody, err = s.applyOpenAICodexDefaultServiceTierToBody(ctx, c, responsesBody)
+	if err != nil {
+		return nil, err
+	}
+
 	// 4b. Apply OpenAI fast policy (may filter service_tier or block the request).
 	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, responsesBody)
 	if policyErr != nil {

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -94,6 +94,12 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		upstreamBody = normalizedBody
 	}
 
+	upstreamBody, err := s.applyOpenAICodexDefaultServiceTierToBody(ctx, c, upstreamBody)
+	if err != nil {
+		return nil, err
+	}
+	serviceTier = extractOpenAIServiceTierFromBody(upstreamBody)
+
 	// 4. Apply OpenAI fast policy on the CC body
 	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, upstreamModel, upstreamBody)
 	if policyErr != nil {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -2942,7 +2942,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 
-	if rawTier := requestView.ServiceTier; rawTier != "" {
+	rawTier := requestView.ServiceTier
+	if rawTier == "" && !gjson.GetBytes(body, "service_tier").Exists() {
+		if tier := s.openAICodexDefaultServiceTier(ctx, c); tier != "" {
+			rawTier = tier
+			markPatchSet("service_tier", tier)
+		}
+	}
+	if rawTier != "" {
 		if normTier := normalizedOpenAIServiceTierValue(rawTier); normTier != "" {
 			action, errMsg := s.evaluateOpenAIFastPolicy(ctx, account, upstreamModel, normTier)
 			switch action {
@@ -3435,6 +3442,11 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 	if sanitized {
 		body = sanitizedBody
+	}
+
+	body, err = s.applyOpenAICodexDefaultServiceTierToBody(ctx, c, body)
+	if err != nil {
+		return nil, err
 	}
 
 	// Apply OpenAI fast policy to the passthrough body (filter/block by service_tier).
@@ -7205,6 +7217,38 @@ func normalizeOpenAIServiceTier(raw string) *string {
 	default:
 		return nil
 	}
+}
+
+func (s *OpenAIGatewayService) openAICodexDefaultServiceTier(ctx context.Context, c *gin.Context) string {
+	if s == nil || s.settingService == nil || !s.isOpenAICodexDefaultServiceTierEligible(c) {
+		return ""
+	}
+	return s.settingService.GetOpenAICodexDefaultServiceTier(ctx)
+}
+
+func (s *OpenAIGatewayService) applyOpenAICodexDefaultServiceTierToBody(ctx context.Context, c *gin.Context, body []byte) ([]byte, error) {
+	if len(body) == 0 || gjson.GetBytes(body, "service_tier").Exists() {
+		return body, nil
+	}
+	tier := s.openAICodexDefaultServiceTier(ctx, c)
+	if tier == "" {
+		return body, nil
+	}
+	updated, err := sjson.SetBytes(body, "service_tier", tier)
+	if err != nil {
+		return body, fmt.Errorf("inject openai codex default service_tier: %w", err)
+	}
+	return updated, nil
+}
+
+func (s *OpenAIGatewayService) isOpenAICodexDefaultServiceTierEligible(c *gin.Context) bool {
+	if s != nil && s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		return true
+	}
+	if c == nil {
+		return false
+	}
+	return openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator"))
 }
 
 // OpenAIFastBlockedError indicates a request was rejected by the OpenAI fast

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -5151,6 +5151,34 @@ func (s *SettingService) GetOpenAIFastPolicySettings(ctx context.Context) (*Open
 	return &settings, nil
 }
 
+// GetOpenAICodexDefaultServiceTier returns the optional service_tier that
+// should be injected for official Codex clients when they omit service_tier.
+// Invalid values fail closed to disabled so a bad setting cannot break traffic.
+func (s *SettingService) GetOpenAICodexDefaultServiceTier(ctx context.Context) string {
+	if s == nil || s.settingRepo == nil {
+		return ""
+	}
+	value, err := s.settingRepo.GetValue(ctx, SettingKeyOpenAICodexDefaultServiceTier)
+	if err != nil {
+		if !errors.Is(err, ErrSettingNotFound) {
+			slog.Warn("failed to get openai codex default service_tier setting",
+				"error", err,
+				"key", SettingKeyOpenAICodexDefaultServiceTier)
+		}
+		return ""
+	}
+	normalized := normalizeOpenAIServiceTier(value)
+	if normalized == nil {
+		if strings.TrimSpace(value) != "" {
+			slog.Warn("invalid openai codex default service_tier setting, disabling injection",
+				"key", SettingKeyOpenAICodexDefaultServiceTier,
+				"value", value)
+		}
+		return ""
+	}
+	return *normalized
+}
+
 // SetOpenAIFastPolicySettings 设置 OpenAI fast 策略配置
 func (s *SettingService) SetOpenAIFastPolicySettings(ctx context.Context, settings *OpenAIFastPolicySettings) error {
 	if settings == nil {


### PR DESCRIPTION
## Summary
- add `openai_codex_default_service_tier` as an optional setting
- inject the configured OpenAI `service_tier` only for official Codex clients when the request omits `service_tier`
- preserve explicit client-supplied `service_tier` and leave non-Codex clients unchanged
- normalize `fast` to `priority`, then run the injected tier through the existing OpenAI fast-policy path

## Motivation
Some gateway operators need to centralize OpenAI fast/priority behavior at Sub2API instead of configuring every Codex client to send `service_tier`. Sub2API already has OpenAI fast-policy handling for requests that include `service_tier`; this adds a first-class setting to inject a default for official Codex clients that omit it.

## Behavior
- Empty or missing `openai_codex_default_service_tier` disables injection.
- `fast` is normalized to `priority`.
- Accepted tier values follow the existing OpenAI normalization: `priority`, `flex`, `auto`, `default`, `scale`.
- Invalid setting values fail closed to disabled and emit a warning.
- Eligibility is limited to official Codex clients detected by headers, or deployments using `Gateway.ForceCodexCLI`.
- Existing request `service_tier` is never overwritten.

## Tests
- `go test ./internal/service -run 'TestApplyOpenAICodexDefaultServiceTierToBody|TestGetOpenAICodexDefaultServiceTier|TestApplyOpenAIFastPolicyToBody|TestEvaluateOpenAIFastPolicy' -count=1`\n- `go test ./internal/service -count=1`