### PR TITLE
fix(antigravity): 401 认证失败可自动恢复，不再永久卡在 error 状态

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -256,8 +256,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			break
 		}
 		// OAuth 账号在 401 错误时临时不可调度（给 token 刷新窗口）；非 OAuth 账号保持原有 SetError 行为。
-		// Antigravity 除外：其 401 由 applyErrorPolicy 的 temp_unschedulable_rules 自行控制。
-		if authAccount.Type == AccountTypeOAuth && authAccount.Platform != PlatformAntigravity {
+		if authAccount.Type == AccountTypeOAuth {
 			// 1. 失效缓存
 			if s.tokenCacheInvalidator != nil {
 				if err := s.tokenCacheInvalidator.InvalidateToken(ctx, authAccount); err != nil {
@@ -299,7 +298,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 			}
 			shouldDisable = true
 		} else {
-			// 非 OAuth / Antigravity OAuth：保持 SetError 行为
+			// 非 OAuth：保持 SetError 行为
 			msg := "Authentication failed (401): invalid or expired credentials"
 			if upstreamMsg != "" {
 				msg = "Authentication failed (401): " + upstreamMsg

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -110,9 +110,7 @@ func TestRateLimitService_HandleUpstreamError_OAuth401SetsTempUnschedulable(t *t
 		require.Len(t, invalidator.accounts, 1)
 	})
 
-	t.Run("antigravity_401_uses_SetError", func(t *testing.T) {
-		// Antigravity 401 由 applyErrorPolicy 的 temp_unschedulable_rules 控制，
-		// HandleUpstreamError 中走 SetError 路径。
+	t.Run("antigravity_401_sets_temp_unschedulable", func(t *testing.T) {
 		repo := &rateLimitAccountRepoStub{}
 		invalidator := &tokenCacheInvalidatorRecorder{}
 		service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
@@ -121,14 +119,22 @@ func TestRateLimitService_HandleUpstreamError_OAuth401SetsTempUnschedulable(t *t
 			ID:       100,
 			Platform: PlatformAntigravity,
 			Type:     AccountTypeOAuth,
+			Status:   StatusActive,
+			Credentials: map[string]any{
+				"access_token":  "expired-at",
+				"refresh_token": "rt-100",
+			},
 		}
 
 		shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
 
 		require.True(t, shouldDisable)
-		require.Equal(t, 1, repo.setErrorCalls)
-		require.Equal(t, 0, repo.tempCalls)
-		require.Empty(t, invalidator.accounts)
+		require.Equal(t, 0, repo.setErrorCalls, "Antigravity OAuth 401 must keep status=active so refresh worker can recover it")
+		require.Equal(t, 1, repo.tempCalls)
+		require.Equal(t, int64(100), repo.lastTempID)
+		require.Contains(t, repo.lastTempReason, "invalid or expired credentials")
+		require.Len(t, invalidator.accounts, 1)
+		require.Equal(t, int64(100), invalidator.accounts[0].ID)
 	})
 }
 
@@ -289,5 +295,28 @@ func TestRateLimitService_HandleUpstreamError_OAuth401NoRefreshTokenSetsError(t 
 		require.True(t, shouldDisable)
 		require.Equal(t, 1, repo.setErrorCalls)
 		require.Equal(t, 0, repo.tempCalls)
+	})
+
+	t.Run("antigravity_no_refresh_token_sets_error", func(t *testing.T) {
+		repo := &rateLimitAccountRepoStub{}
+		invalidator := &tokenCacheInvalidatorRecorder{}
+		service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+		service.SetTokenCacheInvalidator(invalidator)
+		account := &Account{
+			ID:       2883,
+			Platform: PlatformAntigravity,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"access_token": "expired-at",
+			},
+		}
+
+		shouldDisable := service.HandleUpstreamError(context.Background(), account, 401, http.Header{}, []byte("unauthorized"))
+
+		require.True(t, shouldDisable)
+		require.Equal(t, 1, repo.setErrorCalls, "Antigravity OAuth without refresh_token cannot self-recover")
+		require.Equal(t, 0, repo.tempCalls)
+		require.Contains(t, repo.lastErrorMsg, "refresh_token missing")
+		require.Len(t, invalidator.accounts, 1)
 	})
 }

--- a/backend/internal/service/token_refresh_service_candidates_test.go
+++ b/backend/internal/service/token_refresh_service_candidates_test.go
@@ -18,6 +18,7 @@ type tokenRefreshCandidateRepo struct {
 	updatedCredentialIDs  []int64
 	setErrorCalls         int
 	setTempUnschedCalls   int
+	clearTempCalls        int
 	lastTempUnschedReason string
 	listActiveCalls       int
 }
@@ -60,6 +61,11 @@ func (r *tokenRefreshCandidateRepo) SetError(context.Context, int64, string) err
 func (r *tokenRefreshCandidateRepo) SetTempUnschedulable(_ context.Context, _ int64, _ time.Time, reason string) error {
 	r.setTempUnschedCalls++
 	r.lastTempUnschedReason = reason
+	return nil
+}
+
+func (r *tokenRefreshCandidateRepo) ClearTempUnschedulable(context.Context, int64) error {
+	r.clearTempCalls++
 	return nil
 }
 
@@ -128,6 +134,16 @@ func TestTokenRefreshService_ProcessRefreshUsesOAuthRefreshCandidates(t *testing
 				Status:      StatusActive,
 				Credentials: map[string]any{"refresh_token": "refresh-token"},
 			},
+			{
+				ID:                      6,
+				Platform:                PlatformAntigravity,
+				Type:                    AccountTypeOAuth,
+				Status:                  StatusActive,
+				Credentials:             map[string]any{"refresh_token": "refresh-token"},
+				Extra:                   map[string]any{"privacy_mode": AntigravityPrivacySet},
+				TempUnschedulableUntil:  &future,
+				TempUnschedulableReason: "OAuth 401: unauthorized",
+			},
 		},
 	}
 	svc := &TokenRefreshService{
@@ -140,7 +156,8 @@ func TestTokenRefreshService_ProcessRefreshUsesOAuthRefreshCandidates(t *testing
 	svc.processRefresh()
 
 	require.Zero(t, repo.listActiveCalls, "TokenRefreshService should not use the broad active-account query")
-	require.Equal(t, []int64{1}, repo.updatedCredentialIDs)
+	require.Equal(t, []int64{1, 6}, repo.updatedCredentialIDs)
+	require.Equal(t, 1, repo.clearTempCalls, "successful refresh should clear the OAuth 401 temp-unschedulable state")
 }
 
 func TestTokenRefreshService_RefreshFailureDoesNotCallPrivacy(t *testing.T) {


### PR DESCRIPTION
## 背景

Antigravity OAuth 账号遇到上游 401 时，原先会绕过 OAuth 401 的临时不可调度处理，直接走 SetError，导致账号变为 status=error。后台 token refresh worker 只处理 active 的 OAuth 刷新候选，因此 access_token 过期/失效这类可恢复 401 会永久卡住，需要手动改 DB 或在 admin UI 恢复。

## 改动

- Antigravity OAuth 401 不再特殊排除，改为复用 OAuth 401 的处理：失效 token cache、设置临时不可调度冷却，并保持账号 active。
- 带 refresh_token 的 Antigravity 账号会在下一轮 token refresh worker 中被刷新，刷新成功后清除临时不可调度状态，恢复调度。
- 缺少 refresh_token 或 refresh_token 已真正失效的场景仍会进入不可恢复路径：前者在 401 处理时 SetError，后者由 token refresh 的 non-retryable 判定 SetError，避免永久吊销账号一直 active 空转。
- 补充/更新单测覆盖 Antigravity 401 自愈、缺 refresh_token 的不可恢复行为、刷新 worker 候选与刷新成功清冷却路径；OpenAI 401 token_revoked 逻辑保持不变。

## 测试

- cd backend && go test -tags=unit ./...
- cd backend && golangci-lint run ./...

Fixes #3620