### PR TITLE
fix:修复调度 outbox 重建反馈回路

### DIFF
--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -99,7 +99,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	usageBillingRepository := repository.NewUsageBillingRepository(client, db)
 	gatewayCache := repository.NewGatewayCache(redisClient)
 	schedulerOutboxRepository := repository.NewSchedulerOutboxRepository(db)
-	schedulerSnapshotService := service.ProvideSchedulerSnapshotService(schedulerCache, schedulerOutboxRepository, accountRepository, groupRepository, configConfig)
+	schedulerRebuildJobRepository := repository.NewSchedulerRebuildJobRepository(db)
+	schedulerSnapshotService := service.ProvideSchedulerSnapshotService(schedulerCache, schedulerOutboxRepository, schedulerRebuildJobRepository, accountRepository, groupRepository, configConfig)
 	pricingRemoteClient := repository.ProvidePricingRemoteClient(configConfig)
 	pricingService, err := service.ProvidePricingService(configConfig, pricingRemoteClient)
 	if err != nil {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1093,13 +1093,19 @@ type GatewaySchedulingConfig struct {
 	// Outbox 轮询与滞后阈值配置
 	// Outbox 轮询周期（秒）
 	OutboxPollIntervalSeconds int `mapstructure:"outbox_poll_interval_seconds"`
+	// Outbox 每批最多读取事件数
+	OutboxPollBatchSize int `mapstructure:"outbox_poll_batch_size"`
+	// Outbox 每个 tick 最多 drain 批次数
+	OutboxDrainMaxBatchesPerTick int `mapstructure:"outbox_drain_max_batches_per_tick"`
+	// Outbox 每个 tick 最长 drain 时间（秒）
+	OutboxDrainMaxDurationSeconds int `mapstructure:"outbox_drain_max_duration_seconds"`
 	// Outbox 滞后告警阈值（秒）
 	OutboxLagWarnSeconds int `mapstructure:"outbox_lag_warn_seconds"`
-	// Outbox 触发强制重建阈值（秒）
+	// Deprecated: Outbox 滞后不再触发强制重建；该字段仅保留兼容老配置。
 	OutboxLagRebuildSeconds int `mapstructure:"outbox_lag_rebuild_seconds"`
-	// Outbox 连续滞后触发次数
+	// Deprecated: Outbox 滞后不再触发强制重建；该字段仅保留兼容老配置。
 	OutboxLagRebuildFailures int `mapstructure:"outbox_lag_rebuild_failures"`
-	// Outbox 积压触发重建阈值（行数）
+	// Deprecated: Outbox 积压不再触发强制重建；该字段仅用于 warning 日志阈值。
 	OutboxBacklogRebuildRows int `mapstructure:"outbox_backlog_rebuild_rows"`
 
 	// 全量重建周期配置
@@ -1937,6 +1943,9 @@ func setDefaults() {
 	viper.SetDefault("gateway.scheduling.db_fallback_timeout_seconds", 0)
 	viper.SetDefault("gateway.scheduling.db_fallback_max_qps", 0)
 	viper.SetDefault("gateway.scheduling.outbox_poll_interval_seconds", 1)
+	viper.SetDefault("gateway.scheduling.outbox_poll_batch_size", 1000)
+	viper.SetDefault("gateway.scheduling.outbox_drain_max_batches_per_tick", 8)
+	viper.SetDefault("gateway.scheduling.outbox_drain_max_duration_seconds", 8)
 	viper.SetDefault("gateway.scheduling.outbox_lag_warn_seconds", 5)
 	viper.SetDefault("gateway.scheduling.outbox_lag_rebuild_seconds", 10)
 	viper.SetDefault("gateway.scheduling.outbox_lag_rebuild_failures", 3)
@@ -2795,25 +2804,29 @@ func (c *Config) Validate() error {
 	if c.Gateway.Scheduling.OutboxPollIntervalSeconds <= 0 {
 		return fmt.Errorf("gateway.scheduling.outbox_poll_interval_seconds must be positive")
 	}
+	if c.Gateway.Scheduling.OutboxPollBatchSize < 1 || c.Gateway.Scheduling.OutboxPollBatchSize > 10000 {
+		return fmt.Errorf("gateway.scheduling.outbox_poll_batch_size must be between 1-10000")
+	}
+	if c.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick < 1 || c.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick > 100 {
+		return fmt.Errorf("gateway.scheduling.outbox_drain_max_batches_per_tick must be between 1-100")
+	}
+	if c.Gateway.Scheduling.OutboxDrainMaxDurationSeconds < 1 {
+		return fmt.Errorf("gateway.scheduling.outbox_drain_max_duration_seconds must be positive")
+	}
 	if c.Gateway.Scheduling.OutboxLagWarnSeconds < 0 {
 		return fmt.Errorf("gateway.scheduling.outbox_lag_warn_seconds must be non-negative")
 	}
 	if c.Gateway.Scheduling.OutboxLagRebuildSeconds < 0 {
 		return fmt.Errorf("gateway.scheduling.outbox_lag_rebuild_seconds must be non-negative")
 	}
-	if c.Gateway.Scheduling.OutboxLagRebuildFailures <= 0 {
-		return fmt.Errorf("gateway.scheduling.outbox_lag_rebuild_failures must be positive")
+	if c.Gateway.Scheduling.OutboxLagRebuildFailures < 0 {
+		return fmt.Errorf("gateway.scheduling.outbox_lag_rebuild_failures must be non-negative")
 	}
 	if c.Gateway.Scheduling.OutboxBacklogRebuildRows < 0 {
 		return fmt.Errorf("gateway.scheduling.outbox_backlog_rebuild_rows must be non-negative")
 	}
 	if c.Gateway.Scheduling.FullRebuildIntervalSeconds < 0 {
 		return fmt.Errorf("gateway.scheduling.full_rebuild_interval_seconds must be non-negative")
-	}
-	if c.Gateway.Scheduling.OutboxLagWarnSeconds > 0 &&
-		c.Gateway.Scheduling.OutboxLagRebuildSeconds > 0 &&
-		c.Gateway.Scheduling.OutboxLagRebuildSeconds < c.Gateway.Scheduling.OutboxLagWarnSeconds {
-		return fmt.Errorf("gateway.scheduling.outbox_lag_rebuild_seconds must be >= outbox_lag_warn_seconds")
 	}
 	if c.Ops.MetricsCollectorCache.TTL < 0 {
 		return fmt.Errorf("ops.metrics_collector_cache.ttl must be non-negative")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -79,6 +79,15 @@ func TestLoadDefaultSchedulingConfig(t *testing.T) {
 	if cfg.Gateway.Scheduling.SlotCleanupInterval != 30*time.Second {
 		t.Fatalf("SlotCleanupInterval = %v, want 30s", cfg.Gateway.Scheduling.SlotCleanupInterval)
 	}
+	if cfg.Gateway.Scheduling.OutboxPollBatchSize != 1000 {
+		t.Fatalf("OutboxPollBatchSize = %d, want 1000", cfg.Gateway.Scheduling.OutboxPollBatchSize)
+	}
+	if cfg.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick != 8 {
+		t.Fatalf("OutboxDrainMaxBatchesPerTick = %d, want 8", cfg.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick)
+	}
+	if cfg.Gateway.Scheduling.OutboxDrainMaxDurationSeconds != 8 {
+		t.Fatalf("OutboxDrainMaxDurationSeconds = %d, want 8", cfg.Gateway.Scheduling.OutboxDrainMaxDurationSeconds)
+	}
 }
 
 func TestLoadDefaultOpenAIWSConfig(t *testing.T) {
@@ -290,6 +299,7 @@ func TestLoadIdempotencyConfigFromEnv(t *testing.T) {
 func TestLoadSchedulingConfigFromEnv(t *testing.T) {
 	resetViperWithJWTSecret(t)
 	t.Setenv("GATEWAY_SCHEDULING_STICKY_SESSION_MAX_WAITING", "5")
+	t.Setenv("GATEWAY_SCHEDULING_OUTBOX_POLL_BATCH_SIZE", "512")
 
 	cfg, err := Load()
 	if err != nil {
@@ -298,6 +308,9 @@ func TestLoadSchedulingConfigFromEnv(t *testing.T) {
 
 	if cfg.Gateway.Scheduling.StickySessionMaxWaiting != 5 {
 		t.Fatalf("StickySessionMaxWaiting = %d, want 5", cfg.Gateway.Scheduling.StickySessionMaxWaiting)
+	}
+	if cfg.Gateway.Scheduling.OutboxPollBatchSize != 512 {
+		t.Fatalf("OutboxPollBatchSize = %d, want 512", cfg.Gateway.Scheduling.OutboxPollBatchSize)
 	}
 }
 
@@ -1532,16 +1545,23 @@ func TestValidateConfigErrors(t *testing.T) {
 			wantErr: "gateway.scheduling.outbox_poll_interval_seconds",
 		},
 		{
-			name:    "gateway scheduling outbox failures",
-			mutate:  func(c *Config) { c.Gateway.Scheduling.OutboxLagRebuildFailures = 0 },
-			wantErr: "gateway.scheduling.outbox_lag_rebuild_failures",
+			name:    "gateway scheduling outbox batch size",
+			mutate:  func(c *Config) { c.Gateway.Scheduling.OutboxPollBatchSize = 10001 },
+			wantErr: "gateway.scheduling.outbox_poll_batch_size",
 		},
 		{
-			name: "gateway outbox lag rebuild",
-			mutate: func(c *Config) {
-				c.Gateway.Scheduling.OutboxLagWarnSeconds = 10
-				c.Gateway.Scheduling.OutboxLagRebuildSeconds = 5
-			},
+			name:    "gateway scheduling outbox drain batches",
+			mutate:  func(c *Config) { c.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick = 0 },
+			wantErr: "gateway.scheduling.outbox_drain_max_batches_per_tick",
+		},
+		{
+			name:    "gateway scheduling outbox drain duration",
+			mutate:  func(c *Config) { c.Gateway.Scheduling.OutboxDrainMaxDurationSeconds = 0 },
+			wantErr: "gateway.scheduling.outbox_drain_max_duration_seconds",
+		},
+		{
+			name:    "gateway outbox lag rebuild deprecated non-negative",
+			mutate:  func(c *Config) { c.Gateway.Scheduling.OutboxLagRebuildSeconds = -1 },
 			wantErr: "gateway.scheduling.outbox_lag_rebuild_seconds",
 		},
 		{

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -73,6 +73,14 @@ func (s *schedulerCacheRecorder) UnlockBucket(ctx context.Context, bucket servic
 	return nil
 }
 
+func (s *schedulerCacheRecorder) TryLockFullRebuild(ctx context.Context, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (s *schedulerCacheRecorder) UnlockFullRebuild(ctx context.Context) error {
+	return nil
+}
+
 func (s *schedulerCacheRecorder) ListBuckets(ctx context.Context) ([]service.SchedulerBucket, error) {
 	return nil, nil
 }

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -21,6 +21,7 @@ const (
 	schedulerVersionPrefix      = "sched:ver:"
 	schedulerSnapshotPrefix     = "sched:"
 	schedulerLockPrefix         = "sched:lock:"
+	schedulerFullRebuildLockKey = "sched:full_rebuild:lock"
 
 	defaultSchedulerSnapshotMGetChunkSize  = 128
 	defaultSchedulerSnapshotWriteChunkSize = 256
@@ -285,6 +286,14 @@ func (c *schedulerCache) TryLockBucket(ctx context.Context, bucket service.Sched
 func (c *schedulerCache) UnlockBucket(ctx context.Context, bucket service.SchedulerBucket) error {
 	key := schedulerBucketKey(schedulerLockPrefix, bucket)
 	return c.rdb.Del(ctx, key).Err()
+}
+
+func (c *schedulerCache) TryLockFullRebuild(ctx context.Context, ttl time.Duration) (bool, error) {
+	return c.rdb.SetNX(ctx, schedulerFullRebuildLockKey, time.Now().UnixNano(), ttl).Result()
+}
+
+func (c *schedulerCache) UnlockFullRebuild(ctx context.Context) error {
+	return c.rdb.Del(ctx, schedulerFullRebuildLockKey).Err()
 }
 
 func (c *schedulerCache) ListBuckets(ctx context.Context) ([]service.SchedulerBucket, error) {

--- a/backend/internal/repository/scheduler_rebuild_job_repo.go
+++ b/backend/internal/repository/scheduler_rebuild_job_repo.go
@@ -1,0 +1,171 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/lib/pq"
+)
+
+type schedulerRebuildJobRepository struct {
+	db *sql.DB
+}
+
+func NewSchedulerRebuildJobRepository(db *sql.DB) service.SchedulerRebuildJobRepository {
+	return &schedulerRebuildJobRepository{db: db}
+}
+
+func (r *schedulerRebuildJobRepository) EnqueueFullRebuild(ctx context.Context, reason string, source string, sourceOutboxID *int64) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		retry, err := r.enqueueFullRebuildTx(ctx, reason, source, sourceOutboxID)
+		if err == nil {
+			return nil
+		}
+		if retry && attempt == 0 {
+			continue
+		}
+		return err
+	}
+	return nil
+}
+
+func (r *schedulerRebuildJobRepository) enqueueFullRebuildTx(ctx context.Context, reason string, source string, sourceOutboxID *int64) (bool, error) {
+	if r == nil || r.db == nil {
+		return false, errors.New("scheduler rebuild job repository is not configured")
+	}
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var existingID int64
+	err = tx.QueryRowContext(ctx, `
+		SELECT id
+		FROM scheduler_rebuild_jobs
+		WHERE scope = 'full'
+		  AND status IN ('pending', 'running')
+		ORDER BY id ASC
+		LIMIT 1
+		FOR UPDATE
+	`).Scan(&existingID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, err
+	}
+
+	var sourceOutboxArg any
+	if sourceOutboxID != nil {
+		sourceOutboxArg = *sourceOutboxID
+	}
+	if err == nil {
+		if _, err := tx.ExecContext(ctx, `
+			UPDATE scheduler_rebuild_jobs
+			SET reason = $1,
+				source = $2,
+				source_outbox_id = COALESCE($3, source_outbox_id),
+				run_after = LEAST(run_after, NOW()),
+				updated_at = NOW()
+			WHERE id = $4
+		`, reason, source, sourceOutboxArg, existingID); err != nil {
+			return false, err
+		}
+		return false, tx.Commit()
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO scheduler_rebuild_jobs (scope, reason, source, source_outbox_id)
+		VALUES ('full', $1, $2, $3)
+	`, reason, source, sourceOutboxArg); err != nil {
+		return isSchedulerRebuildJobUniqueViolation(err), err
+	}
+	return false, tx.Commit()
+}
+
+func (r *schedulerRebuildJobRepository) ClaimNextFullRebuild(ctx context.Context, workerID string, lockTTL time.Duration) (*service.SchedulerRebuildJob, error) {
+	if r == nil || r.db == nil {
+		return nil, errors.New("scheduler rebuild job repository is not configured")
+	}
+	lockedUntil := time.Now().UTC().Add(lockTTL)
+	row := r.db.QueryRowContext(ctx, `
+		WITH candidate AS (
+			SELECT id
+			FROM scheduler_rebuild_jobs
+			WHERE scope = 'full'
+			  AND (
+				  status = 'pending'
+				  OR (status = 'running' AND locked_until < NOW())
+			  )
+			  AND run_after <= NOW()
+			ORDER BY id ASC
+			LIMIT 1
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE scheduler_rebuild_jobs j
+		SET status = 'running',
+			locked_by = $1,
+			locked_until = $2,
+			attempts = attempts + 1,
+			updated_at = NOW()
+		FROM candidate
+		WHERE j.id = candidate.id
+		RETURNING j.id, j.scope, j.reason, j.source, j.source_outbox_id, j.attempts
+	`, workerID, lockedUntil)
+
+	var (
+		job            service.SchedulerRebuildJob
+		sourceOutboxID sql.NullInt64
+	)
+	if err := row.Scan(&job.ID, &job.Scope, &job.Reason, &job.Source, &sourceOutboxID, &job.Attempts); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if sourceOutboxID.Valid {
+		v := sourceOutboxID.Int64
+		job.SourceOutboxID = &v
+	}
+	return &job, nil
+}
+
+func (r *schedulerRebuildJobRepository) MarkFullRebuildSucceeded(ctx context.Context, jobID int64) error {
+	if r == nil || r.db == nil || jobID <= 0 {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduler_rebuild_jobs
+		SET status = 'succeeded',
+			locked_by = NULL,
+			locked_until = NULL,
+			last_error = NULL,
+			updated_at = NOW(),
+			completed_at = NOW()
+		WHERE id = $1
+	`, jobID)
+	return err
+}
+
+func (r *schedulerRebuildJobRepository) MarkFullRebuildFailed(ctx context.Context, jobID int64, errText string, runAfter time.Time) error {
+	if r == nil || r.db == nil || jobID <= 0 {
+		return nil
+	}
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE scheduler_rebuild_jobs
+		SET status = 'pending',
+			run_after = $2,
+			locked_by = NULL,
+			locked_until = NULL,
+			last_error = $3,
+			updated_at = NOW()
+		WHERE id = $1
+	`, jobID, runAfter, errText)
+	return err
+}
+
+func isSchedulerRebuildJobUniqueViolation(err error) bool {
+	var pqErr *pq.Error
+	return errors.As(err, &pqErr) && string(pqErr.Code) == "23505"
+}

--- a/backend/internal/repository/scheduler_rebuild_job_repo_test.go
+++ b/backend/internal/repository/scheduler_rebuild_job_repo_test.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerRebuildJobEnqueueCoalescesActiveFullJob(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	repo := &schedulerRebuildJobRepository{db: db}
+	selectActive := `(?s)SELECT id.*FROM scheduler_rebuild_jobs.*status IN \('pending', 'running'\).*FOR UPDATE`
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(selectActive).WillReturnError(sql.ErrNoRows)
+	mock.ExpectExec(`(?s)INSERT INTO scheduler_rebuild_jobs \(scope, reason, source, source_outbox_id\).*VALUES \('full', \$1, \$2, \$3\)`).
+		WithArgs("startup", "startup", nil).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectCommit()
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(selectActive).WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(int64(7)))
+	mock.ExpectExec(`(?s)UPDATE scheduler_rebuild_jobs.*SET reason = \$1,.*source = \$2,.*source_outbox_id = COALESCE\(\$3, source_outbox_id\).*WHERE id = \$4`).
+		WithArgs("interval", "interval", nil, int64(7)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	require.NoError(t, repo.EnqueueFullRebuild(context.Background(), "startup", "startup", nil))
+	require.NoError(t, repo.EnqueueFullRebuild(context.Background(), "interval", "interval", nil))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSchedulerRebuildJobClaimUsesSkipLocked(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	repo := &schedulerRebuildJobRepository{db: db}
+	mock.ExpectQuery(`(?s)FOR UPDATE SKIP LOCKED.*UPDATE scheduler_rebuild_jobs j`).
+		WithArgs("worker-1", sqlmock.AnyArg()).
+		WillReturnError(sql.ErrNoRows)
+
+	job, err := repo.ClaimNextFullRebuild(context.Background(), "worker-1", time.Minute)
+	require.NoError(t, err)
+	require.Nil(t, job)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSchedulerRebuildJobFailedReturnsToPending(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	repo := &schedulerRebuildJobRepository{db: db}
+	runAfter := time.Now().Add(time.Minute)
+	mock.ExpectExec(`(?s)UPDATE scheduler_rebuild_jobs.*SET status = 'pending',.*run_after = \$2,.*last_error = \$3,.*WHERE id = \$1`).
+		WithArgs(int64(9), runAfter, "boom").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	require.NoError(t, repo.MarkFullRebuildFailed(context.Background(), 9, "boom", runAfter))
+	require.True(t, runAfter.After(time.Now()))
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -118,6 +118,7 @@ var ProviderSet = wire.NewSet(
 	NewLeaderLockCache,
 	ProvideSchedulerCache,
 	NewSchedulerOutboxRepository,
+	NewSchedulerRebuildJobRepository,
 	NewProxyLatencyCache,
 	NewTotpCache,
 	NewRefreshTokenCache,

--- a/backend/internal/service/scheduler_cache.go
+++ b/backend/internal/service/scheduler_cache.go
@@ -61,6 +61,10 @@ type SchedulerCache interface {
 	TryLockBucket(ctx context.Context, bucket SchedulerBucket, ttl time.Duration) (bool, error)
 	// UnlockBucket 释放分桶重建锁。
 	UnlockBucket(ctx context.Context, bucket SchedulerBucket) error
+	// TryLockFullRebuild 尝试获取全局全量重建锁。
+	TryLockFullRebuild(ctx context.Context, ttl time.Duration) (bool, error)
+	// UnlockFullRebuild 释放全局全量重建锁。
+	UnlockFullRebuild(ctx context.Context) error
 	// ListBuckets 返回已注册的分桶集合。
 	ListBuckets(ctx context.Context) ([]SchedulerBucket, error)
 	// GetOutboxWatermark 读取 outbox 水位。

--- a/backend/internal/service/scheduler_rebuild_job.go
+++ b/backend/internal/service/scheduler_rebuild_job.go
@@ -1,0 +1,22 @@
+package service
+
+import (
+	"context"
+	"time"
+)
+
+type SchedulerRebuildJob struct {
+	ID             int64
+	Scope          string
+	Reason         string
+	Source         string
+	SourceOutboxID *int64
+	Attempts       int
+}
+
+type SchedulerRebuildJobRepository interface {
+	EnqueueFullRebuild(ctx context.Context, reason string, source string, sourceOutboxID *int64) error
+	ClaimNextFullRebuild(ctx context.Context, workerID string, lockTTL time.Duration) (*SchedulerRebuildJob, error)
+	MarkFullRebuildSucceeded(ctx context.Context, jobID int64) error
+	MarkFullRebuildFailed(ctx context.Context, jobID int64, errText string, runAfter time.Time) error
+}

--- a/backend/internal/service/scheduler_snapshot_hydration_test.go
+++ b/backend/internal/service/scheduler_snapshot_hydration_test.go
@@ -50,6 +50,14 @@ func (c *snapshotHydrationCache) UnlockBucket(ctx context.Context, bucket Schedu
 	return nil
 }
 
+func (c *snapshotHydrationCache) TryLockFullRebuild(ctx context.Context, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (c *snapshotHydrationCache) UnlockFullRebuild(ctx context.Context) error {
+	return nil
+}
+
 func (c *snapshotHydrationCache) ListBuckets(ctx context.Context) ([]SchedulerBucket, error) {
 	return nil, nil
 }

--- a/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
+++ b/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
@@ -46,6 +46,14 @@ func (c *outboxCleanupCache) UnlockBucket(ctx context.Context, bucket SchedulerB
 	return nil
 }
 
+func (c *outboxCleanupCache) TryLockFullRebuild(ctx context.Context, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (c *outboxCleanupCache) UnlockFullRebuild(ctx context.Context) error {
+	return nil
+}
+
 func (c *outboxCleanupCache) ListBuckets(ctx context.Context) ([]SchedulerBucket, error) {
 	return nil, nil
 }
@@ -152,6 +160,7 @@ func TestSchedulerSnapshotServicePollOutboxCleansConsumedRowsAfterWatermark(t *t
 	svc := NewSchedulerSnapshotService(cache, repo, nil, nil, nil)
 
 	svc.pollOutbox()
+	svc.wg.Wait()
 
 	if cache.watermark != 10000 {
 		t.Fatalf("expected watermark 10000, got %d", cache.watermark)
@@ -187,6 +196,7 @@ func TestSchedulerSnapshotServicePollOutboxSkipsCleanupWhenLockUnavailable(t *te
 	svc := NewSchedulerSnapshotService(cache, repo, nil, nil, nil)
 
 	svc.pollOutbox()
+	svc.wg.Wait()
 
 	if cache.watermark != 3 {
 		t.Fatalf("expected watermark 3, got %d", cache.watermark)
@@ -225,6 +235,7 @@ func TestSchedulerSnapshotServicePollOutboxDoesNotCleanupOnHandleFailure(t *test
 	svc := NewSchedulerSnapshotService(cache, repo, nil, nil, nil)
 
 	svc.pollOutbox()
+	svc.wg.Wait()
 
 	if len(cache.setWatermarks) != 0 {
 		t.Fatalf("expected no watermark write on handle failure, got %#v", cache.setWatermarks)

--- a/backend/internal/service/scheduler_snapshot_rebuild_loop_test.go
+++ b/backend/internal/service/scheduler_snapshot_rebuild_loop_test.go
@@ -1,0 +1,466 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type schedulerLoopCache struct {
+	watermark          int64
+	setWatermarks      []int64
+	lastUsed           map[int64]time.Time
+	setAccounts        []int64
+	deletedAccounts    []int64
+	snapshots          []SchedulerBucket
+	fullRebuildLockOK  bool
+	fullLockAttempts   int
+	fullUnlockAttempts int
+	listBuckets        []SchedulerBucket
+}
+
+func (c *schedulerLoopCache) GetSnapshot(ctx context.Context, bucket SchedulerBucket) ([]*Account, bool, error) {
+	return nil, false, nil
+}
+
+func (c *schedulerLoopCache) SetSnapshot(ctx context.Context, bucket SchedulerBucket, accounts []Account) error {
+	c.snapshots = append(c.snapshots, bucket)
+	return nil
+}
+
+func (c *schedulerLoopCache) GetAccount(ctx context.Context, accountID int64) (*Account, error) {
+	return nil, nil
+}
+
+func (c *schedulerLoopCache) SetAccount(ctx context.Context, account *Account) error {
+	if account != nil {
+		c.setAccounts = append(c.setAccounts, account.ID)
+	}
+	return nil
+}
+
+func (c *schedulerLoopCache) DeleteAccount(ctx context.Context, accountID int64) error {
+	c.deletedAccounts = append(c.deletedAccounts, accountID)
+	return nil
+}
+
+func (c *schedulerLoopCache) UpdateLastUsed(ctx context.Context, updates map[int64]time.Time) error {
+	c.lastUsed = updates
+	return nil
+}
+
+func (c *schedulerLoopCache) TryLockBucket(ctx context.Context, bucket SchedulerBucket, ttl time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (c *schedulerLoopCache) UnlockBucket(ctx context.Context, bucket SchedulerBucket) error {
+	return nil
+}
+
+func (c *schedulerLoopCache) TryLockFullRebuild(ctx context.Context, ttl time.Duration) (bool, error) {
+	c.fullLockAttempts++
+	return c.fullRebuildLockOK, nil
+}
+
+func (c *schedulerLoopCache) UnlockFullRebuild(ctx context.Context) error {
+	c.fullUnlockAttempts++
+	return nil
+}
+
+func (c *schedulerLoopCache) ListBuckets(ctx context.Context) ([]SchedulerBucket, error) {
+	return c.listBuckets, nil
+}
+
+func (c *schedulerLoopCache) GetOutboxWatermark(ctx context.Context) (int64, error) {
+	return c.watermark, nil
+}
+
+func (c *schedulerLoopCache) SetOutboxWatermark(ctx context.Context, id int64) error {
+	c.watermark = id
+	c.setWatermarks = append(c.setWatermarks, id)
+	return nil
+}
+
+type schedulerLoopOutboxRepo struct {
+	batches [][]SchedulerOutboxEvent
+	maxID   int64
+}
+
+func (r *schedulerLoopOutboxRepo) ListAfterAndReleaseDedup(ctx context.Context, afterID int64, limit int) ([]SchedulerOutboxEvent, error) {
+	if len(r.batches) == 0 {
+		return nil, nil
+	}
+	events := r.batches[0]
+	r.batches = r.batches[1:]
+	return events, nil
+}
+
+func (r *schedulerLoopOutboxRepo) MaxID(ctx context.Context) (int64, error) {
+	return r.maxID, nil
+}
+
+func (r *schedulerLoopOutboxRepo) DeleteConsumedUpTo(ctx context.Context, watermark int64, limit int) (int64, error) {
+	return 0, nil
+}
+
+func (r *schedulerLoopOutboxRepo) TryAcquireCleanupLock(ctx context.Context) (SchedulerOutboxCleanupLease, bool, error) {
+	return nil, false, nil
+}
+
+type schedulerLoopEnqueue struct {
+	reason       string
+	source       string
+	sourceOutbox *int64
+}
+
+type schedulerLoopFailedJob struct {
+	id       int64
+	errText  string
+	runAfter time.Time
+}
+
+type schedulerLoopRebuildJobRepo struct {
+	mu        sync.Mutex
+	enqueued  []schedulerLoopEnqueue
+	claims    []*SchedulerRebuildJob
+	failed    []schedulerLoopFailedJob
+	succeeded []int64
+}
+
+func (r *schedulerLoopRebuildJobRepo) EnqueueFullRebuild(ctx context.Context, reason string, source string, sourceOutboxID *int64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var copied *int64
+	if sourceOutboxID != nil {
+		v := *sourceOutboxID
+		copied = &v
+	}
+	r.enqueued = append(r.enqueued, schedulerLoopEnqueue{reason: reason, source: source, sourceOutbox: copied})
+	return nil
+}
+
+func (r *schedulerLoopRebuildJobRepo) ClaimNextFullRebuild(ctx context.Context, workerID string, lockTTL time.Duration) (*SchedulerRebuildJob, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.claims) == 0 {
+		return nil, nil
+	}
+	job := r.claims[0]
+	r.claims = r.claims[1:]
+	return job, nil
+}
+
+func (r *schedulerLoopRebuildJobRepo) MarkFullRebuildSucceeded(ctx context.Context, jobID int64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.succeeded = append(r.succeeded, jobID)
+	return nil
+}
+
+func (r *schedulerLoopRebuildJobRepo) MarkFullRebuildFailed(ctx context.Context, jobID int64, errText string, runAfter time.Time) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failed = append(r.failed, schedulerLoopFailedJob{id: jobID, errText: errText, runAfter: runAfter})
+	return nil
+}
+
+func (r *schedulerLoopRebuildJobRepo) enqueueCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.enqueued)
+}
+
+type schedulerLoopAccountRepo struct {
+	AccountRepository
+	accounts      map[int64]*Account
+	getByIDsCalls int
+}
+
+func (r *schedulerLoopAccountRepo) GetByIDs(ctx context.Context, ids []int64) ([]*Account, error) {
+	r.getByIDsCalls++
+	out := make([]*Account, 0, len(ids))
+	for _, id := range ids {
+		if account := r.accounts[id]; account != nil {
+			out = append(out, account)
+		}
+	}
+	return out, nil
+}
+
+func (r *schedulerLoopAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]Account, error) {
+	return r.listByPlatformAndGroup(platform, groupID), nil
+}
+
+func (r *schedulerLoopAccountRepo) ListSchedulableByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	return r.listByPlatformAndGroup(platform, 0), nil
+}
+
+func (r *schedulerLoopAccountRepo) ListSchedulableUngroupedByPlatform(ctx context.Context, platform string) ([]Account, error) {
+	return r.listByPlatformAndGroup(platform, 0), nil
+}
+
+func (r *schedulerLoopAccountRepo) ListSchedulableByPlatforms(ctx context.Context, platforms []string) ([]Account, error) {
+	return r.listByPlatformsAndGroup(platforms, 0), nil
+}
+
+func (r *schedulerLoopAccountRepo) ListSchedulableByGroupIDAndPlatforms(ctx context.Context, groupID int64, platforms []string) ([]Account, error) {
+	return r.listByPlatformsAndGroup(platforms, groupID), nil
+}
+
+func (r *schedulerLoopAccountRepo) ListSchedulableUngroupedByPlatforms(ctx context.Context, platforms []string) ([]Account, error) {
+	return r.listByPlatformsAndGroup(platforms, 0), nil
+}
+
+func (r *schedulerLoopAccountRepo) listByPlatformsAndGroup(platforms []string, groupID int64) []Account {
+	allowed := make(map[string]struct{}, len(platforms))
+	for _, platform := range platforms {
+		allowed[platform] = struct{}{}
+	}
+	var out []Account
+	for _, account := range r.accounts {
+		if account == nil {
+			continue
+		}
+		if _, ok := allowed[account.Platform]; !ok {
+			continue
+		}
+		if groupID > 0 && !hasGroup(account.GroupIDs, groupID) {
+			continue
+		}
+		out = append(out, *account)
+	}
+	return out
+}
+
+func (r *schedulerLoopAccountRepo) listByPlatformAndGroup(platform string, groupID int64) []Account {
+	return r.listByPlatformsAndGroup([]string{platform}, groupID)
+}
+
+func hasGroup(groupIDs []int64, groupID int64) bool {
+	for _, id := range groupIDs {
+		if id == groupID {
+			return true
+		}
+	}
+	return false
+}
+
+func schedulerLoopConfig() *config.Config {
+	return &config.Config{
+		RunMode: config.RunModeStandard,
+		Gateway: config.GatewayConfig{
+			Scheduling: config.GatewaySchedulingConfig{
+				OutboxPollIntervalSeconds:     1,
+				OutboxPollBatchSize:           1000,
+				OutboxDrainMaxBatchesPerTick:  8,
+				OutboxDrainMaxDurationSeconds: 8,
+				OutboxLagWarnSeconds:          1,
+				OutboxLagRebuildSeconds:       1,
+				OutboxLagRebuildFailures:      1,
+				OutboxBacklogRebuildRows:      1,
+				FullRebuildIntervalSeconds:    0,
+				DbFallbackEnabled:             true,
+				SnapshotMGetChunkSize:         128,
+				SnapshotWriteChunkSize:        256,
+			},
+		},
+	}
+}
+
+func TestObserveOutboxLagDoesNotTriggerFullRebuild(t *testing.T) {
+	cache := &schedulerLoopCache{}
+	outbox := &schedulerLoopOutboxRepo{maxID: 100}
+	rebuildJobs := &schedulerLoopRebuildJobRepo{}
+	svc := NewSchedulerSnapshotService(cache, outbox, nil, nil, schedulerLoopConfig(), rebuildJobs)
+	runnerCalls := 0
+	svc.fullRebuildRunner = func(ctx context.Context, reason string) error {
+		runnerCalls++
+		return nil
+	}
+
+	svc.observeOutboxLag(context.Background(), SchedulerOutboxEvent{CreatedAt: time.Now().Add(-time.Hour)}, 1)
+
+	require.Equal(t, 0, rebuildJobs.enqueueCount())
+	require.Equal(t, 0, runnerCalls)
+}
+
+func TestPollOutboxFullRebuildEventEnqueuesDurableJobAndAdvancesWatermark(t *testing.T) {
+	cache := &schedulerLoopCache{}
+	outbox := &schedulerLoopOutboxRepo{
+		batches: [][]SchedulerOutboxEvent{{
+			{ID: 42, EventType: SchedulerOutboxEventFullRebuild, CreatedAt: time.Now()},
+		}},
+		maxID: 42,
+	}
+	rebuildJobs := &schedulerLoopRebuildJobRepo{}
+	svc := NewSchedulerSnapshotService(cache, outbox, nil, nil, schedulerLoopConfig(), rebuildJobs)
+	runnerCalls := 0
+	svc.fullRebuildRunner = func(ctx context.Context, reason string) error {
+		runnerCalls++
+		return nil
+	}
+
+	svc.pollOutbox()
+	svc.wg.Wait()
+
+	require.EqualValues(t, 42, cache.watermark)
+	require.Equal(t, []int64{42}, cache.setWatermarks)
+	require.Equal(t, 1, rebuildJobs.enqueueCount())
+	require.Equal(t, "outbox", rebuildJobs.enqueued[0].reason)
+	require.Equal(t, "outbox", rebuildJobs.enqueued[0].source)
+	require.NotNil(t, rebuildJobs.enqueued[0].sourceOutbox)
+	require.EqualValues(t, 42, *rebuildJobs.enqueued[0].sourceOutbox)
+	require.Equal(t, 0, runnerCalls)
+}
+
+func TestPollOutboxDoesNotReuseSeenAcrossDrainBatches(t *testing.T) {
+	cfg := schedulerLoopConfig()
+	cfg.Gateway.Scheduling.OutboxPollBatchSize = 1
+	cfg.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick = 2
+	cache := &schedulerLoopCache{}
+	outbox := &schedulerLoopOutboxRepo{
+		batches: [][]SchedulerOutboxEvent{
+			{{ID: 1, EventType: SchedulerOutboxEventGroupChanged, GroupID: ptrInt64ForSchedulerLoopTest(7), CreatedAt: time.Now()}},
+			{{ID: 2, EventType: SchedulerOutboxEventGroupChanged, GroupID: ptrInt64ForSchedulerLoopTest(7), CreatedAt: time.Now()}},
+		},
+		maxID: 2,
+	}
+	accountRepo := &schedulerLoopAccountRepo{accounts: map[int64]*Account{}}
+	svc := NewSchedulerSnapshotService(cache, outbox, accountRepo, nil, cfg, &schedulerLoopRebuildJobRepo{})
+
+	svc.pollOutbox()
+	svc.wg.Wait()
+
+	require.EqualValues(t, 2, cache.watermark)
+	require.Equal(t, 2, countSnapshots(cache.snapshots, SchedulerBucket{GroupID: 7, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}))
+}
+
+func TestProcessOutboxBatchCoalescesAccountEvents(t *testing.T) {
+	cache := &schedulerLoopCache{}
+	accountRepo := &schedulerLoopAccountRepo{accounts: map[int64]*Account{
+		1: &Account{ID: 1, Platform: PlatformOpenAI, GroupIDs: []int64{9}},
+		2: &Account{ID: 2, Platform: PlatformOpenAI, GroupIDs: []int64{9}},
+	}}
+	svc := NewSchedulerSnapshotService(cache, nil, accountRepo, nil, schedulerLoopConfig(), &schedulerLoopRebuildJobRepo{})
+	events := []SchedulerOutboxEvent{
+		{ID: 1, EventType: SchedulerOutboxEventAccountChanged, AccountID: ptrInt64ForSchedulerLoopTest(1)},
+		{ID: 2, EventType: SchedulerOutboxEventAccountChanged, AccountID: ptrInt64ForSchedulerLoopTest(2)},
+	}
+
+	require.NoError(t, svc.processOutboxBatch(context.Background(), events))
+
+	require.Equal(t, 1, accountRepo.getByIDsCalls)
+	require.Equal(t, 1, countSnapshots(cache.snapshots, SchedulerBucket{GroupID: 9, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}))
+	require.Equal(t, 1, countSnapshots(cache.snapshots, SchedulerBucket{GroupID: 9, Platform: PlatformOpenAI, Mode: SchedulerModeForced}))
+}
+
+func TestIntervalFullRebuildSkippedWhenOutboxBacklogPositive(t *testing.T) {
+	cache := &schedulerLoopCache{watermark: 1}
+	outbox := &schedulerLoopOutboxRepo{maxID: 2}
+	rebuildJobs := &schedulerLoopRebuildJobRepo{}
+	svc := NewSchedulerSnapshotService(cache, outbox, nil, nil, schedulerLoopConfig(), rebuildJobs)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		svc.runFullRebuildWorker(10 * time.Millisecond)
+	}()
+	time.Sleep(35 * time.Millisecond)
+	close(svc.stopCh)
+	<-done
+
+	require.Equal(t, 0, rebuildJobs.enqueueCount())
+}
+
+func TestFullRebuildJobRetriesWithBackoff(t *testing.T) {
+	cache := &schedulerLoopCache{
+		fullRebuildLockOK: true,
+		listBuckets:       []SchedulerBucket{{GroupID: 0, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}},
+	}
+	rebuildJobs := &schedulerLoopRebuildJobRepo{
+		claims: []*SchedulerRebuildJob{{ID: 10, Reason: "interval", Attempts: 1}},
+	}
+	svc := NewSchedulerSnapshotService(cache, nil, &schedulerLoopAccountRepo{accounts: map[int64]*Account{}}, nil, schedulerLoopConfig(), rebuildJobs)
+	svc.fullRebuildRunner = func(ctx context.Context, reason string) error {
+		return errors.New("rebuild failed")
+	}
+
+	before := time.Now()
+	require.True(t, svc.processOneFullRebuildJob(context.Background()))
+
+	require.Len(t, rebuildJobs.failed, 1)
+	require.EqualValues(t, 10, rebuildJobs.failed[0].id)
+	require.True(t, rebuildJobs.failed[0].runAfter.After(before.Add(25*time.Second)))
+	require.True(t, rebuildJobs.failed[0].runAfter.Before(before.Add(35*time.Second)))
+	require.Empty(t, rebuildJobs.succeeded)
+}
+
+func TestFullRebuildWorkerUsesGlobalLock(t *testing.T) {
+	cache := &schedulerLoopCache{fullRebuildLockOK: false}
+	rebuildJobs := &schedulerLoopRebuildJobRepo{
+		claims: []*SchedulerRebuildJob{{ID: 11, Reason: "startup", Attempts: 1}},
+	}
+	svc := NewSchedulerSnapshotService(cache, nil, nil, nil, schedulerLoopConfig(), rebuildJobs)
+	runnerCalls := 0
+	svc.fullRebuildRunner = func(ctx context.Context, reason string) error {
+		runnerCalls++
+		return nil
+	}
+
+	require.True(t, svc.processOneFullRebuildJob(context.Background()))
+
+	require.Equal(t, 1, cache.fullLockAttempts)
+	require.Equal(t, 0, runnerCalls)
+	require.Len(t, rebuildJobs.failed, 1)
+	require.Empty(t, rebuildJobs.succeeded)
+}
+
+func TestPollOutboxBacklogWarningDoesNotRunFullRebuild(t *testing.T) {
+	cache := &schedulerLoopCache{}
+	outbox := &schedulerLoopOutboxRepo{
+		batches: [][]SchedulerOutboxEvent{{
+			{
+				ID:        1,
+				EventType: SchedulerOutboxEventAccountLastUsed,
+				Payload: map[string]any{
+					"last_used": map[string]any{"101": float64(123)},
+				},
+				CreatedAt: time.Now().Add(-time.Hour),
+			},
+		}},
+		maxID: 100,
+	}
+	rebuildJobs := &schedulerLoopRebuildJobRepo{}
+	svc := NewSchedulerSnapshotService(cache, outbox, nil, nil, schedulerLoopConfig(), rebuildJobs)
+	runnerCalls := 0
+	svc.fullRebuildRunner = func(ctx context.Context, reason string) error {
+		runnerCalls++
+		return nil
+	}
+
+	svc.pollOutbox()
+	svc.wg.Wait()
+
+	require.EqualValues(t, 1, cache.watermark)
+	require.Equal(t, 0, rebuildJobs.enqueueCount())
+	require.Equal(t, 0, runnerCalls)
+}
+
+func countSnapshots(snapshots []SchedulerBucket, target SchedulerBucket) int {
+	count := 0
+	for _, bucket := range snapshots {
+		if bucket == target {
+			count++
+		}
+	}
+	return count
+}
+
+func ptrInt64ForSchedulerLoopTest(v int64) *int64 {
+	return &v
+}

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"os"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -21,6 +23,8 @@ var (
 const (
 	outboxEventTimeout          = 2 * time.Minute
 	schedulerOutboxCleanupBatch = 5000
+	fullRebuildLockTTL          = 10 * time.Minute
+	fullRebuildJobPollInterval  = 5 * time.Second
 )
 
 // batchSeenKey tracks which (groupID, platform) bucket sets have already been
@@ -32,17 +36,18 @@ type batchSeenKey struct {
 }
 
 type SchedulerSnapshotService struct {
-	cache         SchedulerCache
-	outboxRepo    SchedulerOutboxRepository
-	accountRepo   AccountRepository
-	groupRepo     GroupRepository
-	cfg           *config.Config
-	stopCh        chan struct{}
-	stopOnce      sync.Once
-	wg            sync.WaitGroup
-	fallbackLimit *fallbackLimiter
-	lagMu         sync.Mutex
-	lagFailures   int
+	cache             SchedulerCache
+	outboxRepo        SchedulerOutboxRepository
+	rebuildJobRepo    SchedulerRebuildJobRepository
+	accountRepo       AccountRepository
+	groupRepo         GroupRepository
+	cfg               *config.Config
+	stopCh            chan struct{}
+	stopOnce          sync.Once
+	wg                sync.WaitGroup
+	fallbackLimit     *fallbackLimiter
+	workerID          string
+	fullRebuildRunner func(context.Context, string) error
 }
 
 func NewSchedulerSnapshotService(
@@ -51,19 +56,26 @@ func NewSchedulerSnapshotService(
 	accountRepo AccountRepository,
 	groupRepo GroupRepository,
 	cfg *config.Config,
+	rebuildJobRepo ...SchedulerRebuildJobRepository,
 ) *SchedulerSnapshotService {
 	maxQPS := 0
 	if cfg != nil {
 		maxQPS = cfg.Gateway.Scheduling.DbFallbackMaxQPS
 	}
+	var jobRepo SchedulerRebuildJobRepository
+	if len(rebuildJobRepo) > 0 {
+		jobRepo = rebuildJobRepo[0]
+	}
 	return &SchedulerSnapshotService{
-		cache:         cache,
-		outboxRepo:    outboxRepo,
-		accountRepo:   accountRepo,
-		groupRepo:     groupRepo,
-		cfg:           cfg,
-		stopCh:        make(chan struct{}),
-		fallbackLimit: newFallbackLimiter(maxQPS),
+		cache:          cache,
+		outboxRepo:     outboxRepo,
+		rebuildJobRepo: jobRepo,
+		accountRepo:    accountRepo,
+		groupRepo:      groupRepo,
+		cfg:            cfg,
+		stopCh:         make(chan struct{}),
+		fallbackLimit:  newFallbackLimiter(maxQPS),
+		workerID:       schedulerWorkerID(),
 	}
 }
 
@@ -72,11 +84,19 @@ func (s *SchedulerSnapshotService) Start() {
 		return
 	}
 
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		s.runInitialRebuild()
-	}()
+	if s.rebuildJobRepo != nil {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.enqueueStartupRebuild()
+		}()
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			s.runFullRebuildJobWorker()
+		}()
+	}
 
 	interval := s.outboxPollInterval()
 	if s.outboxRepo != nil && interval > 0 {
@@ -88,7 +108,7 @@ func (s *SchedulerSnapshotService) Start() {
 	}
 
 	fullInterval := s.fullRebuildInterval()
-	if fullInterval > 0 {
+	if s.rebuildJobRepo != nil && fullInterval > 0 {
 		s.wg.Add(1)
 		go func() {
 			defer s.wg.Done()
@@ -179,25 +199,14 @@ func (s *SchedulerSnapshotService) UpdateAccountInCache(ctx context.Context, acc
 	return s.cache.SetAccount(ctx, account)
 }
 
-func (s *SchedulerSnapshotService) runInitialRebuild() {
-	if s.cache == nil {
+func (s *SchedulerSnapshotService) enqueueStartupRebuild() {
+	if s.rebuildJobRepo == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	buckets, err := s.cache.ListBuckets(ctx)
-	if err != nil {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] list buckets failed: %v", err)
-	}
-	if len(buckets) == 0 {
-		buckets, err = s.defaultBuckets(ctx)
-		if err != nil {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] default buckets failed: %v", err)
-			return
-		}
-	}
-	if err := s.rebuildBuckets(ctx, buckets, "startup"); err != nil {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild startup failed: %v", err)
+	if err := s.rebuildJobRepo.EnqueueFullRebuild(ctx, "startup", "startup", nil); err != nil {
+		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] startup full rebuild enqueue failed: %v", err)
 	}
 }
 
@@ -223,12 +232,97 @@ func (s *SchedulerSnapshotService) runFullRebuildWorker(interval time.Duration) 
 	for {
 		select {
 		case <-ticker.C:
-			if err := s.triggerFullRebuild("interval"); err != nil {
-				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] full rebuild failed: %v", err)
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			backlog, err := s.currentOutboxBacklog(ctx)
+			if err == nil && backlog > 0 {
+				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] interval full rebuild skipped because outbox backlog is positive: backlog=%d", backlog)
+				cancel()
+				continue
 			}
+			if err := s.rebuildJobRepo.EnqueueFullRebuild(ctx, "interval", "interval", nil); err != nil {
+				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] interval full rebuild enqueue failed: %v", err)
+			}
+			cancel()
 		case <-s.stopCh:
 			return
 		}
+	}
+}
+
+func (s *SchedulerSnapshotService) runFullRebuildJobWorker() {
+	ticker := time.NewTicker(fullRebuildJobPollInterval)
+	defer ticker.Stop()
+
+	for {
+		for {
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			processed := s.processOneFullRebuildJob(ctx)
+			cancel()
+			if !processed {
+				break
+			}
+		}
+
+		select {
+		case <-ticker.C:
+		case <-s.stopCh:
+			return
+		}
+	}
+}
+
+func (s *SchedulerSnapshotService) processOneFullRebuildJob(ctx context.Context) bool {
+	if s == nil || s.rebuildJobRepo == nil || s.cache == nil {
+		return false
+	}
+	job, err := s.rebuildJobRepo.ClaimNextFullRebuild(ctx, s.workerID, fullRebuildLockTTL)
+	if err != nil {
+		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] full rebuild job claim failed: %v", err)
+		return false
+	}
+	if job == nil {
+		return false
+	}
+
+	ok, err := s.cache.TryLockFullRebuild(ctx, fullRebuildLockTTL)
+	if err != nil {
+		s.markFullRebuildJobFailed(job, err)
+		return true
+	}
+	if !ok {
+		s.markFullRebuildJobFailed(job, errors.New("full rebuild lock is held"))
+		return true
+	}
+	defer func() {
+		_ = s.cache.UnlockFullRebuild(context.Background())
+	}()
+
+	runner := s.fullRebuildRunner
+	if runner == nil {
+		runner = s.runFullRebuildNow
+	}
+	if err := runner(ctx, job.Reason); err != nil {
+		s.markFullRebuildJobFailed(job, err)
+		return true
+	}
+
+	markCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.rebuildJobRepo.MarkFullRebuildSucceeded(markCtx, job.ID); err != nil {
+		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] full rebuild job success mark failed: id=%d err=%v", job.ID, err)
+	}
+	return true
+}
+
+func (s *SchedulerSnapshotService) markFullRebuildJobFailed(job *SchedulerRebuildJob, cause error) {
+	if s == nil || s.rebuildJobRepo == nil || job == nil {
+		return
+	}
+	runAfter := time.Now().Add(fullRebuildBackoff(job.Attempts))
+	markCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.rebuildJobRepo.MarkFullRebuildFailed(markCtx, job.ID, truncateSchedulerString(cause.Error(), 2048), runAfter); err != nil {
+		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] full rebuild job failure mark failed: id=%d err=%v", job.ID, err)
 	}
 }
 
@@ -236,57 +330,95 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 	if s.outboxRepo == nil || s.cache == nil {
 		return
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 
-	watermark, err := s.cache.GetOutboxWatermark(ctx)
-	if err != nil {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox watermark read failed: %v", err)
-		return
-	}
+	deadline := time.Now().Add(s.outboxDrainMaxDuration())
+	maxBatches := s.outboxDrainMaxBatchesPerTick()
+	batchSize := s.outboxPollBatchSize()
 
-	events, err := s.outboxRepo.ListAfterAndReleaseDedup(ctx, watermark, 200)
-	if err != nil {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox poll failed: %v", err)
-		return
-	}
-	if len(events) == 0 {
-		return
-	}
+	var oldestForObserve *SchedulerOutboxEvent
+	var watermarkForObserve int64
 
-	watermarkForCheck := watermark
-	seen := make(map[batchSeenKey]struct{})
-	for _, event := range events {
-		eventCtx, cancel := context.WithTimeout(context.Background(), outboxEventTimeout)
-		err := s.handleOutboxEvent(eventCtx, event, seen)
+	for batch := 0; batch < maxBatches; batch++ {
+		if time.Now().After(deadline) {
+			break
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		watermark, err := s.cache.GetOutboxWatermark(ctx)
+		if err != nil {
+			cancel()
+			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox watermark read failed: %v", err)
+			return
+		}
+
+		events, err := s.outboxRepo.ListAfterAndReleaseDedup(ctx, watermark, batchSize)
 		cancel()
 		if err != nil {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox handle failed: id=%d type=%s err=%v", event.ID, event.EventType, err)
+			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox poll failed: %v", err)
 			return
+		}
+		if len(events) == 0 {
+			break
+		}
+
+		if oldestForObserve == nil {
+			copy := events[0]
+			oldestForObserve = &copy
+		}
+
+		eventCtx, eventCancel := context.WithTimeout(context.Background(), outboxEventTimeout)
+		err = s.processOutboxBatch(eventCtx, events)
+		eventCancel()
+		if err != nil {
+			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox handle failed: first_id=%d last_id=%d err=%v", events[0].ID, events[len(events)-1].ID, err)
+			return
+		}
+
+		lastID := events[len(events)-1].ID
+		if err := s.writeOutboxWatermarkWithRetry(lastID); err != nil {
+			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox watermark write failed: %v", err)
+			return
+		}
+		watermarkForObserve = lastID
+		s.cleanupConsumedOutboxAsync(lastID)
+
+		if len(events) < batchSize {
+			break
 		}
 	}
 
-	lastID := events[len(events)-1].ID
+	if oldestForObserve != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		s.observeOutboxLag(ctx, *oldestForObserve, watermarkForObserve)
+		cancel()
+	}
+}
+
+func (s *SchedulerSnapshotService) writeOutboxWatermarkWithRetry(id int64) error {
 	var wmErr error
 	for i := range 3 {
 		wmCtx, wmCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		wmErr = s.cache.SetOutboxWatermark(wmCtx, lastID)
+		wmErr = s.cache.SetOutboxWatermark(wmCtx, id)
 		wmCancel()
 		if wmErr == nil {
-			break
+			return nil
 		}
 		if i < 2 {
 			time.Sleep(200 * time.Millisecond)
 		}
 	}
-	if wmErr != nil {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox watermark write failed: %v", wmErr)
-	} else {
-		watermarkForCheck = lastID
-		s.cleanupConsumedOutbox(lastID)
-	}
+	return wmErr
+}
 
-	s.checkOutboxLag(ctx, events[0], watermarkForCheck)
+func (s *SchedulerSnapshotService) cleanupConsumedOutboxAsync(watermark int64) {
+	if s == nil || watermark <= 0 {
+		return
+	}
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		s.cleanupConsumedOutbox(watermark)
+	}()
 }
 
 func (s *SchedulerSnapshotService) cleanupConsumedOutbox(watermark int64) {
@@ -319,34 +451,131 @@ func (s *SchedulerSnapshotService) cleanupConsumedOutbox(watermark int64) {
 	}
 }
 
-func (s *SchedulerSnapshotService) handleOutboxEvent(ctx context.Context, event SchedulerOutboxEvent, seen map[batchSeenKey]struct{}) error {
-	switch event.EventType {
-	case SchedulerOutboxEventAccountLastUsed:
-		return s.handleLastUsedEvent(ctx, event.Payload)
-	case SchedulerOutboxEventAccountBulkChanged:
-		return s.handleBulkAccountEvent(ctx, event.Payload, seen)
-	case SchedulerOutboxEventAccountGroupsChanged:
-		return s.handleAccountEvent(ctx, event.AccountID, event.Payload, seen)
-	case SchedulerOutboxEventAccountChanged:
-		return s.handleAccountEvent(ctx, event.AccountID, event.Payload, seen)
-	case SchedulerOutboxEventGroupChanged:
-		return s.handleGroupEvent(ctx, event.GroupID, seen)
-	case SchedulerOutboxEventFullRebuild:
-		return s.triggerFullRebuild("outbox")
-	default:
-		return nil
-	}
+type outboxBatchPlan struct {
+	lastUsed             map[int64]time.Time
+	accountIDs           map[int64]struct{}
+	allPlatformGroupIDs  map[int64]struct{}
+	platformGroupIDs     map[string]map[int64]struct{}
+	fullRebuildOutboxIDs []int64
 }
 
-func (s *SchedulerSnapshotService) handleLastUsedEvent(ctx context.Context, payload map[string]any) error {
-	if s.cache == nil || payload == nil {
+func (s *SchedulerSnapshotService) processOutboxBatch(ctx context.Context, events []SchedulerOutboxEvent) error {
+	if len(events) == 0 {
 		return nil
+	}
+	plan := outboxBatchPlan{
+		lastUsed:            make(map[int64]time.Time),
+		accountIDs:          make(map[int64]struct{}),
+		allPlatformGroupIDs: make(map[int64]struct{}),
+		platformGroupIDs:    make(map[string]map[int64]struct{}),
+	}
+
+	for _, event := range events {
+		switch event.EventType {
+		case SchedulerOutboxEventAccountLastUsed:
+			mergeLastUsed(plan.lastUsed, event.Payload)
+		case SchedulerOutboxEventAccountBulkChanged:
+			for _, id := range parseInt64Slice(event.Payload["account_ids"]) {
+				if id > 0 {
+					plan.accountIDs[id] = struct{}{}
+				}
+			}
+			if s.accountRepo != nil {
+				addGroupIDs(plan.allPlatformGroupIDs, parseInt64Slice(event.Payload["group_ids"]))
+			}
+		case SchedulerOutboxEventAccountGroupsChanged, SchedulerOutboxEventAccountChanged:
+			if event.AccountID != nil && *event.AccountID > 0 {
+				plan.accountIDs[*event.AccountID] = struct{}{}
+			}
+			if s.accountRepo != nil {
+				addGroupIDs(plan.allPlatformGroupIDs, parseInt64Slice(event.Payload["group_ids"]))
+			}
+		case SchedulerOutboxEventGroupChanged:
+			if event.GroupID != nil && *event.GroupID > 0 {
+				plan.allPlatformGroupIDs[*event.GroupID] = struct{}{}
+			}
+		case SchedulerOutboxEventFullRebuild:
+			plan.fullRebuildOutboxIDs = append(plan.fullRebuildOutboxIDs, event.ID)
+		}
+	}
+
+	for _, outboxID := range plan.fullRebuildOutboxIDs {
+		if s.rebuildJobRepo == nil {
+			return errors.New("scheduler rebuild job repository is not configured")
+		}
+		id := outboxID
+		if err := s.rebuildJobRepo.EnqueueFullRebuild(ctx, "outbox", "outbox", &id); err != nil {
+			return err
+		}
+	}
+
+	if len(plan.lastUsed) > 0 && s.cache != nil {
+		if err := s.cache.UpdateLastUsed(ctx, plan.lastUsed); err != nil {
+			return err
+		}
+	}
+
+	if len(plan.accountIDs) > 0 && s.accountRepo != nil {
+		ids := sortedIDs(plan.accountIDs)
+		accounts, err := s.accountRepo.GetByIDs(ctx, ids)
+		if err != nil {
+			return err
+		}
+
+		found := make(map[int64]struct{}, len(accounts))
+		for _, account := range accounts {
+			if account == nil || account.ID <= 0 {
+				continue
+			}
+			found[account.ID] = struct{}{}
+			if s.cache != nil {
+				if err := s.cache.SetAccount(ctx, account); err != nil {
+					return err
+				}
+			}
+			for _, gid := range account.GroupIDs {
+				addPlatformGroupID(plan.platformGroupIDs, account.Platform, gid)
+				if account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled() {
+					addPlatformGroupID(plan.platformGroupIDs, PlatformAnthropic, gid)
+					addPlatformGroupID(plan.platformGroupIDs, PlatformGemini, gid)
+				}
+			}
+		}
+
+		if s.cache != nil {
+			for _, id := range ids {
+				if _, ok := found[id]; ok {
+					continue
+				}
+				if err := s.cache.DeleteAccount(ctx, id); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	seen := make(map[batchSeenKey]struct{})
+	if len(plan.allPlatformGroupIDs) > 0 {
+		if err := s.rebuildByGroupIDs(ctx, sortedIDs(plan.allPlatformGroupIDs), "outbox_batch", seen); err != nil {
+			return err
+		}
+	}
+	for _, platform := range sortedPlatforms(plan.platformGroupIDs) {
+		if err := s.rebuildBucketsForPlatform(ctx, platform, sortedIDs(plan.platformGroupIDs[platform]), "outbox_batch", seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mergeLastUsed(out map[int64]time.Time, payload map[string]any) {
+	if payload == nil {
+		return
 	}
 	raw, ok := payload["last_used"].(map[string]any)
 	if !ok || len(raw) == 0 {
-		return nil
+		return
 	}
-	updates := make(map[int64]time.Time, len(raw))
 	for key, value := range raw {
 		id, err := strconv.ParseInt(key, 10, 64)
 		if err != nil || id <= 0 {
@@ -356,134 +585,51 @@ func (s *SchedulerSnapshotService) handleLastUsedEvent(ctx context.Context, payl
 		if !ok || sec <= 0 {
 			continue
 		}
-		updates[id] = time.Unix(sec, 0)
+		usedAt := time.Unix(sec, 0)
+		if existing, ok := out[id]; !ok || usedAt.After(existing) {
+			out[id] = usedAt
+		}
 	}
-	if len(updates) == 0 {
-		return nil
-	}
-	return s.cache.UpdateLastUsed(ctx, updates)
 }
 
-func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, payload map[string]any, seen map[batchSeenKey]struct{}) error {
-	if payload == nil {
-		return nil
-	}
-	if s.accountRepo == nil {
-		return nil
-	}
-
-	rawIDs := parseInt64Slice(payload["account_ids"])
-	if len(rawIDs) == 0 {
-		return nil
-	}
-
-	ids := make([]int64, 0, len(rawIDs))
-	seenIDs := make(map[int64]struct{}, len(rawIDs))
-	for _, id := range rawIDs {
-		if id <= 0 {
-			continue
-		}
-		if _, exists := seenIDs[id]; exists {
-			continue
-		}
-		seenIDs[id] = struct{}{}
-		ids = append(ids, id)
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-
-	preloadGroupIDs := parseInt64Slice(payload["group_ids"])
-	accounts, err := s.accountRepo.GetByIDs(ctx, ids)
-	if err != nil {
-		return err
-	}
-
-	found := make(map[int64]struct{}, len(accounts))
-	rebuildGroupSet := make(map[int64]struct{}, len(preloadGroupIDs))
-	for _, gid := range preloadGroupIDs {
-		if gid > 0 {
-			rebuildGroupSet[gid] = struct{}{}
+func addGroupIDs(dst map[int64]struct{}, ids []int64) {
+	for _, id := range ids {
+		if id > 0 {
+			dst[id] = struct{}{}
 		}
 	}
-
-	for _, account := range accounts {
-		if account == nil || account.ID <= 0 {
-			continue
-		}
-		found[account.ID] = struct{}{}
-		if s.cache != nil {
-			if err := s.cache.SetAccount(ctx, account); err != nil {
-				return err
-			}
-		}
-		for _, gid := range account.GroupIDs {
-			if gid > 0 {
-				rebuildGroupSet[gid] = struct{}{}
-			}
-		}
-	}
-
-	if s.cache != nil {
-		for _, id := range ids {
-			if _, ok := found[id]; ok {
-				continue
-			}
-			if err := s.cache.DeleteAccount(ctx, id); err != nil {
-				return err
-			}
-		}
-	}
-
-	rebuildGroupIDs := make([]int64, 0, len(rebuildGroupSet))
-	for gid := range rebuildGroupSet {
-		rebuildGroupIDs = append(rebuildGroupIDs, gid)
-	}
-	return s.rebuildByGroupIDs(ctx, rebuildGroupIDs, "account_bulk_change", seen)
 }
 
-func (s *SchedulerSnapshotService) handleAccountEvent(ctx context.Context, accountID *int64, payload map[string]any, seen map[batchSeenKey]struct{}) error {
-	if accountID == nil || *accountID <= 0 {
-		return nil
+func addPlatformGroupID(dst map[string]map[int64]struct{}, platform string, groupID int64) {
+	if platform == "" || groupID <= 0 {
+		return
 	}
-	if s.accountRepo == nil {
-		return nil
+	if dst[platform] == nil {
+		dst[platform] = make(map[int64]struct{})
 	}
-
-	var groupIDs []int64
-	if payload != nil {
-		groupIDs = parseInt64Slice(payload["group_ids"])
-	}
-
-	account, err := s.accountRepo.GetByID(ctx, *accountID)
-	if err != nil {
-		if errors.Is(err, ErrAccountNotFound) {
-			if s.cache != nil {
-				if err := s.cache.DeleteAccount(ctx, *accountID); err != nil {
-					return err
-				}
-			}
-			return s.rebuildByGroupIDs(ctx, groupIDs, "account_miss", seen)
-		}
-		return err
-	}
-	if s.cache != nil {
-		if err := s.cache.SetAccount(ctx, account); err != nil {
-			return err
-		}
-	}
-	if len(groupIDs) == 0 {
-		groupIDs = account.GroupIDs
-	}
-	return s.rebuildByAccount(ctx, account, groupIDs, "account_change", seen)
+	dst[platform][groupID] = struct{}{}
 }
 
-func (s *SchedulerSnapshotService) handleGroupEvent(ctx context.Context, groupID *int64, seen map[batchSeenKey]struct{}) error {
-	if groupID == nil || *groupID <= 0 {
-		return nil
+func sortedIDs(set map[int64]struct{}) []int64 {
+	ids := make([]int64, 0, len(set))
+	for id := range set {
+		if id > 0 {
+			ids = append(ids, id)
+		}
 	}
-	groupIDs := []int64{*groupID}
-	return s.rebuildByGroupIDs(ctx, groupIDs, "group_change", seen)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	return ids
+}
+
+func sortedPlatforms(groups map[string]map[int64]struct{}) []string {
+	platforms := make([]string, 0, len(groups))
+	for platform, ids := range groups {
+		if platform != "" && len(ids) > 0 {
+			platforms = append(platforms, platform)
+		}
+	}
+	sort.Strings(platforms)
+	return platforms
 }
 
 func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account *Account, groupIDs []int64, reason string, seen map[batchSeenKey]struct{}) error {
@@ -598,13 +744,10 @@ func (s *SchedulerSnapshotService) rebuildBucket(ctx context.Context, bucket Sch
 	return nil
 }
 
-func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) error {
+func (s *SchedulerSnapshotService) runFullRebuildNow(ctx context.Context, reason string) error {
 	if s.cache == nil {
 		return ErrSchedulerCacheNotReady
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
 	buckets, err := s.cache.ListBuckets(ctx)
 	if err != nil {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] list buckets failed: %v", err)
@@ -620,7 +763,7 @@ func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) error {
 	return s.rebuildBuckets(ctx, buckets, reason)
 }
 
-func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, oldest SchedulerOutboxEvent, watermark int64) {
+func (s *SchedulerSnapshotService) observeOutboxLag(ctx context.Context, oldest SchedulerOutboxEvent, watermark int64) {
 	if oldest.CreatedAt.IsZero() || s.cfg == nil {
 		return
 	}
@@ -628,27 +771,6 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, oldest Sc
 	lag := time.Since(oldest.CreatedAt)
 	if lagSeconds := int(lag.Seconds()); lagSeconds >= s.cfg.Gateway.Scheduling.OutboxLagWarnSeconds && s.cfg.Gateway.Scheduling.OutboxLagWarnSeconds > 0 {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox lag warning: %ds", lagSeconds)
-	}
-
-	if s.cfg.Gateway.Scheduling.OutboxLagRebuildSeconds > 0 && int(lag.Seconds()) >= s.cfg.Gateway.Scheduling.OutboxLagRebuildSeconds {
-		s.lagMu.Lock()
-		s.lagFailures++
-		failures := s.lagFailures
-		s.lagMu.Unlock()
-
-		if failures >= s.cfg.Gateway.Scheduling.OutboxLagRebuildFailures {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox lag rebuild triggered: lag=%s failures=%d", lag, failures)
-			s.lagMu.Lock()
-			s.lagFailures = 0
-			s.lagMu.Unlock()
-			if err := s.triggerFullRebuild("outbox_lag"); err != nil {
-				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox lag rebuild failed: %v", err)
-			}
-		}
-	} else {
-		s.lagMu.Lock()
-		s.lagFailures = 0
-		s.lagMu.Unlock()
 	}
 
 	threshold := s.cfg.Gateway.Scheduling.OutboxBacklogRebuildRows
@@ -660,11 +782,26 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, oldest Sc
 		return
 	}
 	if maxID-watermark >= int64(threshold) {
-		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox backlog rebuild triggered: backlog=%d", maxID-watermark)
-		if err := s.triggerFullRebuild("outbox_backlog"); err != nil {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox backlog rebuild failed: %v", err)
-		}
+		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox backlog warning: backlog=%d", maxID-watermark)
 	}
+}
+
+func (s *SchedulerSnapshotService) currentOutboxBacklog(ctx context.Context) (int64, error) {
+	if s == nil || s.cache == nil || s.outboxRepo == nil {
+		return 0, nil
+	}
+	watermark, err := s.cache.GetOutboxWatermark(ctx)
+	if err != nil {
+		return 0, err
+	}
+	maxID, err := s.outboxRepo.MaxID(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if maxID <= watermark {
+		return 0, nil
+	}
+	return maxID - watermark, nil
 }
 
 func (s *SchedulerSnapshotService) loadAccountsFromDB(ctx context.Context, bucket SchedulerBucket, useMixed bool) ([]Account, error) {
@@ -804,6 +941,27 @@ func (s *SchedulerSnapshotService) outboxPollInterval() time.Duration {
 	return time.Duration(sec) * time.Second
 }
 
+func (s *SchedulerSnapshotService) outboxPollBatchSize() int {
+	if s.cfg == nil || s.cfg.Gateway.Scheduling.OutboxPollBatchSize <= 0 {
+		return 1000
+	}
+	return s.cfg.Gateway.Scheduling.OutboxPollBatchSize
+}
+
+func (s *SchedulerSnapshotService) outboxDrainMaxBatchesPerTick() int {
+	if s.cfg == nil || s.cfg.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick <= 0 {
+		return 8
+	}
+	return s.cfg.Gateway.Scheduling.OutboxDrainMaxBatchesPerTick
+}
+
+func (s *SchedulerSnapshotService) outboxDrainMaxDuration() time.Duration {
+	if s.cfg == nil || s.cfg.Gateway.Scheduling.OutboxDrainMaxDurationSeconds <= 0 {
+		return 8 * time.Second
+	}
+	return time.Duration(s.cfg.Gateway.Scheduling.OutboxDrainMaxDurationSeconds) * time.Second
+}
+
 func (s *SchedulerSnapshotService) fullRebuildInterval() time.Duration {
 	if s.cfg == nil {
 		return 0
@@ -813,6 +971,34 @@ func (s *SchedulerSnapshotService) fullRebuildInterval() time.Duration {
 		return 0
 	}
 	return time.Duration(sec) * time.Second
+}
+
+func fullRebuildBackoff(attempts int) time.Duration {
+	switch {
+	case attempts <= 1:
+		return 30 * time.Second
+	case attempts == 2:
+		return time.Minute
+	case attempts == 3:
+		return 2 * time.Minute
+	default:
+		return 5 * time.Minute
+	}
+}
+
+func truncateSchedulerString(value string, maxLen int) string {
+	if maxLen <= 0 || len(value) <= maxLen {
+		return value
+	}
+	return value[:maxLen]
+}
+
+func schedulerWorkerID() string {
+	host, err := os.Hostname()
+	if err != nil || host == "" {
+		host = "unknown"
+	}
+	return host + ":" + strconv.Itoa(os.Getpid())
 }
 
 func (s *SchedulerSnapshotService) defaultBuckets(ctx context.Context) ([]SchedulerBucket, error) {
@@ -876,17 +1062,34 @@ func derefAccounts(accounts []*Account) []Account {
 }
 
 func parseInt64Slice(value any) []int64 {
-	raw, ok := value.([]any)
-	if !ok {
+	switch raw := value.(type) {
+	case []any:
+		out := make([]int64, 0, len(raw))
+		for _, item := range raw {
+			if v, ok := toInt64(item); ok && v > 0 {
+				out = append(out, v)
+			}
+		}
+		return out
+	case []int64:
+		out := make([]int64, 0, len(raw))
+		for _, v := range raw {
+			if v > 0 {
+				out = append(out, v)
+			}
+		}
+		return out
+	case []int:
+		out := make([]int64, 0, len(raw))
+		for _, v := range raw {
+			if v > 0 {
+				out = append(out, int64(v))
+			}
+		}
+		return out
+	default:
 		return nil
 	}
-	out := make([]int64, 0, len(raw))
-	for _, item := range raw {
-		if v, ok := toInt64(item); ok && v > 0 {
-			out = append(out, v)
-		}
-	}
-	return out
 }
 
 func toInt64(value any) (int64, bool) {

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -262,11 +262,12 @@ func ProvideUserMessageQueueService(cache UserMsgQueueCache, rpmCache RPMCache, 
 func ProvideSchedulerSnapshotService(
 	cache SchedulerCache,
 	outboxRepo SchedulerOutboxRepository,
+	rebuildJobRepo SchedulerRebuildJobRepository,
 	accountRepo AccountRepository,
 	groupRepo GroupRepository,
 	cfg *config.Config,
 ) *SchedulerSnapshotService {
-	svc := NewSchedulerSnapshotService(cache, outboxRepo, accountRepo, groupRepo, cfg)
+	svc := NewSchedulerSnapshotService(cache, outboxRepo, accountRepo, groupRepo, cfg, rebuildJobRepo)
 	svc.Start()
 	return svc
 }

--- a/backend/migrations/159_scheduler_rebuild_jobs.sql
+++ b/backend/migrations/159_scheduler_rebuild_jobs.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS scheduler_rebuild_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    scope TEXT NOT NULL DEFAULT 'full',
+    reason TEXT NOT NULL,
+    source TEXT NOT NULL DEFAULT 'system',
+    source_outbox_id BIGINT,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    run_after TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    locked_by TEXT,
+    locked_until TIMESTAMPTZ,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+    CONSTRAINT scheduler_rebuild_jobs_scope_check
+        CHECK (scope IN ('full')),
+    CONSTRAINT scheduler_rebuild_jobs_status_check
+        CHECK (status IN ('pending', 'running', 'succeeded', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduler_rebuild_jobs_claim
+    ON scheduler_rebuild_jobs (status, run_after, id)
+    WHERE status IN ('pending', 'running');
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduler_rebuild_jobs_active_full
+    ON scheduler_rebuild_jobs (scope)
+    WHERE scope = 'full' AND status IN ('pending', 'running');

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -452,13 +452,19 @@ gateway:
     db_fallback_max_qps: 0
     # outbox 轮询周期（秒）
     outbox_poll_interval_seconds: 1
+    # outbox 每批最多读取事件数
+    outbox_poll_batch_size: 1000
+    # outbox 每个 tick 最多 drain 批次数
+    outbox_drain_max_batches_per_tick: 8
+    # outbox 每个 tick 最长 drain 时间（秒）
+    outbox_drain_max_duration_seconds: 8
     # outbox 滞后告警阈值（秒）
     outbox_lag_warn_seconds: 5
-    # outbox 触发强制重建阈值（秒）
+    # Deprecated: outbox 滞后不再触发强制重建，仅保留兼容老配置
     outbox_lag_rebuild_seconds: 10
-    # outbox 连续滞后触发次数
+    # Deprecated: outbox 滞后不再触发强制重建，仅保留兼容老配置
     outbox_lag_rebuild_failures: 3
-    # outbox 积压触发重建阈值（行数）
+    # Deprecated: outbox 积压不再触发强制重建，仅作为 backlog warning 阈值
     outbox_backlog_rebuild_rows: 10000
     # 全量重建周期（秒），0 表示禁用
     full_rebuild_interval_seconds: 300


### PR DESCRIPTION
## 背景

生产环境中 scheduler outbox 出现大量 backlog 后，旧逻辑会因为 outbox lag/backlog 超阈值反复触发 full rebuild。full rebuild 本身又会进一步放大调度压力，导致 CPU 长时间偏高、outbox 消费变慢，形成重建反馈循环。

造成“outbox 积压 -> 触发全量 rebuild -> outbox worker 被占住 -> 积压更大”的循环

## 修复前生产数据

修复前观察到 scheduler outbox backlog 持续增长，且 lag/backlog 告警会反复触发 full rebuild：

- outbox backlog 持续上升：
  - `21:39:21` backlog `184894`
  - `21:42:40` backlog `197344`
  - `21:44:42` backlog `204389`
  - `21:47:30` backlog `212334`
  - `21:49:32` backlog `219438`
  - `21:53:16` backlog `232710`
  - `21:55:12` backlog `239665`
  - `21:58:55` backlog `250206`
- outbox lag 持续扩大：
  - `21:33:17` lag `11979s`
  - `21:51:35` lag `13044s`
  - `21:57:11` lag `13374s`
  - `21:58:55` lag `13476s`
- 日志中频繁出现：
  - `outbox backlog rebuild triggered`
  - `outbox lag rebuild triggered`
  - `full rebuild failed: context deadline exceeded`
  - `rebuild failed: pq: canceling statement due to user request`
- pprof 显示 full rebuild 是主要热点之一：
  - 30s CPU profile 总采样 `25.48s`，约 `84.92%` CPU。
  - `SchedulerSnapshotService.rebuildBucket` 占 `6.92s / 27.16%`。
  - 其中 `loadAccountsFromDB` 占 `3.37s`，`schedulerCache.SetSnapshot` 占 `2.81s`。
- goroutine 栈显示 interval full rebuild 与 outbox lag/backlog 触发的 full rebuild 同时存在，进一步放大 DB/Redis/CPU 压力。
- 容器 CPU 修复前多次采样处于高位：
  - `59.06%`
  - `108.90%`
  - `96.42%`
  - `89.81%`


## 修复内容

- 移除 outbox lag/backlog 告警路径中的自动 full rebuild 触发行为。
- 保留 outbox lag/backlog warning，仅用于观测，不再作为重建触发器。
- 当 outbox backlog 仍为正数时，周期性 full rebuild 会跳过，优先让 outbox worker 追赶存量事件。
- outbox worker 继续按事件批次执行增量 bucket/group rebuild，避免 backlog 期间反复扩大为全量重建。
- 补充回归测试，覆盖 backlog/lag 不再触发 full rebuild，以及 backlog 存在时 interval full rebuild 被跳过的行为。

## 验证

生产观察结果：

- 更新后 outbox backlog 持续下降：
  - `00:51:57` backlog `613140`
  - `01:00:39` backlog `333814`
  - `01:04:58` backlog `208181`
  - `01:09:57` backlog `66655`
  - `01:10:47` backlog `16877`
  - `01:16:46` backlog `63`
- pprof 显示 CPU 主要消耗在 `pollOutbox` / `processOutboxBatch` / `rebuildByGroupIDs` / `rebuildBucket`，符合“追赶存量 outbox 增量事件”的预期，而不是旧的 full rebuild 反馈循环。
- CPU 在 backlog 下降后出现明显回落，观察到从约 `100%+` 波动降至 `16.64%`、`30.70%` 等低位样本。

## 结论

该修复已缓解生产中的 scheduler outbox rebuild loop 问题。当前高 CPU 主要来自存量 outbox 追赶过程，旧的 backlog/lag 触发 full rebuild 循环未再出现。