### PR TITLE
Support Anthropic model-scoped weekly limits (Fable 5): usage display + scoped 429 handling

### DIFF
--- a/backend/internal/repository/claude_usage_service_test.go
+++ b/backend/internal/repository/claude_usage_service_test.go
@@ -41,7 +41,13 @@ func (s *ClaudeUsageServiceSuite) TestFetchUsage_Success() {
 		_, _ = io.WriteString(w, `{
   "five_hour": {"utilization": 12.5, "resets_at": "2025-01-01T00:00:00Z"},
   "seven_day": {"utilization": 34.0, "resets_at": "2025-01-08T00:00:00Z"},
-  "seven_day_sonnet": {"utilization": 56.0, "resets_at": "2025-01-08T00:00:00Z"}
+  "seven_day_sonnet": {"utilization": 56.0, "resets_at": "2025-01-08T00:00:00Z"},
+  "seven_day_opus": null,
+  "limits": [
+    {"kind": "session", "group": "session", "percent": 12, "severity": "normal", "resets_at": "2025-01-01T00:00:00Z", "scope": null, "is_active": false},
+    {"kind": "weekly_all", "group": "weekly", "percent": 34, "severity": "normal", "resets_at": "2025-01-08T00:00:00Z", "scope": null, "is_active": false},
+    {"kind": "weekly_scoped", "group": "weekly", "percent": 100, "severity": "critical", "resets_at": "2025-01-08T00:00:00Z", "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null}, "is_active": true}
+  ]
 }`)
 	}))
 
@@ -55,6 +61,12 @@ func (s *ClaudeUsageServiceSuite) TestFetchUsage_Success() {
 	require.Equal(s.T(), 12.5, resp.FiveHour.Utilization, "FiveHour utilization mismatch")
 	require.Equal(s.T(), 34.0, resp.SevenDay.Utilization, "SevenDay utilization mismatch")
 	require.Equal(s.T(), 56.0, resp.SevenDaySonnet.Utilization, "SevenDaySonnet utilization mismatch")
+	require.Len(s.T(), resp.Limits, 3, "limits length mismatch")
+	require.Equal(s.T(), "weekly_scoped", resp.Limits[2].Kind, "scoped limit kind mismatch")
+	require.NotNil(s.T(), resp.Limits[2].Scope, "scoped limit scope should be present")
+	require.NotNil(s.T(), resp.Limits[2].Scope.Model, "scoped limit model should be present")
+	require.Equal(s.T(), "Fable", resp.Limits[2].Scope.Model.DisplayName, "scoped limit model display name mismatch")
+	require.Equal(s.T(), 100.0, resp.Limits[2].Percent, "scoped limit percent mismatch")
 
 	// Assertions on captured request data
 	require.Equal(s.T(), "Bearer at", captured.authorization, "Authorization header mismatch")

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -152,6 +152,16 @@ type UsageProgress struct {
 	LimitRequests    int64        `json:"limit_requests,omitempty"`
 }
 
+// ScopedUsageWindow 表示模型维度的 7 天窗口 (如 Fable 5)，
+// 来源于 Anthropic usage 响应 limits[] 中 kind=weekly_scoped 的条目。
+// Label 取 scope.model.display_name（例如 "Fable"），前端渲染为 "7d {Label}"。
+type ScopedUsageWindow struct {
+	Label            string     `json:"label"`
+	Utilization      float64    `json:"utilization"`
+	ResetsAt         *time.Time `json:"resets_at"`
+	RemainingSeconds int        `json:"remaining_seconds"`
+}
+
 // AntigravityModelQuota Antigravity 单个模型的配额信息
 type AntigravityModelQuota struct {
 	Utilization int    `json:"utilization"` // 使用率 0-100
@@ -183,7 +193,10 @@ type UsageInfo struct {
 	UpdatedAt          *time.Time     `json:"updated_at,omitempty"`           // 更新时间
 	FiveHour           *UsageProgress `json:"five_hour"`                      // 5小时窗口
 	SevenDay           *UsageProgress `json:"seven_day,omitempty"`            // 7天窗口
-	SevenDaySonnet     *UsageProgress `json:"seven_day_sonnet,omitempty"`     // 7天Sonnet窗口
+	SevenDaySonnet     *UsageProgress `json:"seven_day_sonnet,omitempty"`     // 7天Sonnet窗口 (旧字段, 上游已弃用)
+	// 模型维度的 7 天窗口 (如 Fable 5)。上游把这类限额挪到了 usage.limits[] 里的
+	// kind=weekly_scoped 条目, 每个带 scope.model.display_name 作为标签。可能有多个。
+	SevenDayScoped     []*ScopedUsageWindow `json:"seven_day_scoped,omitempty"`
 	GeminiSharedDaily  *UsageProgress `json:"gemini_shared_daily,omitempty"`  // Gemini shared pool RPD (Google One / Code Assist)
 	GeminiProDaily     *UsageProgress `json:"gemini_pro_daily,omitempty"`     // Gemini Pro 日配额
 	GeminiFlashDaily   *UsageProgress `json:"gemini_flash_daily,omitempty"`   // Gemini Flash 日配额
@@ -250,6 +263,26 @@ type ClaudeUsageResponse struct {
 		Utilization float64 `json:"utilization"`
 		ResetsAt    string  `json:"resets_at"`
 	} `json:"seven_day_sonnet"`
+	// limits[] 是上游较新的、权威的窗口列表。模型维度的周窗口（如 Fable 5）
+	// 只出现在这里的 kind=weekly_scoped 条目中，旧的顶层 seven_day_opus/sonnet 字段已恒为 null。
+	Limits []ClaudeUsageLimit `json:"limits"`
+}
+
+// ClaudeUsageLimit 是 Anthropic usage 响应 limits[] 中的单条限额。
+// kind: session / weekly_all / weekly_scoped ...；weekly_scoped 带 scope.model。
+type ClaudeUsageLimit struct {
+	Kind     string  `json:"kind"`
+	Group    string  `json:"group"`
+	Percent  float64 `json:"percent"`
+	ResetsAt string  `json:"resets_at"`
+	Severity string  `json:"severity"`
+	IsActive bool    `json:"is_active"`
+	Scope    *struct {
+		Model *struct {
+			ID          *string `json:"id"`
+			DisplayName string  `json:"display_name"`
+		} `json:"model"`
+	} `json:"scope"`
 }
 
 // ClaudeUsageFetchOptions 包含获取 Claude 用量数据所需的所有选项
@@ -1010,8 +1043,8 @@ func enrichUsageWithAccountError(info *UsageInfo, account *Account) {
 // 使用独立缓存（1 分钟），与 API 缓存分离
 func (s *AccountUsageService) addWindowStats(ctx context.Context, account *Account, usage *UsageInfo) {
 	// 修复：即使 FiveHour 为 nil，也要尝试获取统计数据
-	// 因为 SevenDay/SevenDaySonnet 可能需要
-	if usage.FiveHour == nil && usage.SevenDay == nil && usage.SevenDaySonnet == nil {
+	// 因为 SevenDay/SevenDaySonnet/SevenDayScoped 可能需要
+	if usage.FiveHour == nil && usage.SevenDay == nil && usage.SevenDaySonnet == nil && len(usage.SevenDayScoped) == 0 {
 		return
 	}
 
@@ -1345,6 +1378,31 @@ func (s *AccountUsageService) buildUsageInfo(resp *ClaudeUsageResponse, updatedA
 				Utilization: resp.SevenDaySonnet.Utilization,
 			}
 		}
+	}
+
+	// 模型维度的 7 天窗口 (如 Fable 5) — 来自 limits[] 中 kind=weekly_scoped 的条目。
+	// 每个条目的 scope.model.display_name 作为标签，percent 即使用率。
+	for _, lim := range resp.Limits {
+		if lim.Kind != "weekly_scoped" || lim.Scope == nil || lim.Scope.Model == nil {
+			continue
+		}
+		label := strings.TrimSpace(lim.Scope.Model.DisplayName)
+		if label == "" {
+			label = "Scoped"
+		}
+		win := &ScopedUsageWindow{
+			Label:       label,
+			Utilization: lim.Percent,
+		}
+		if lim.ResetsAt != "" {
+			if scopedReset, err := parseTime(lim.ResetsAt); err == nil {
+				win.ResetsAt = &scopedReset
+				win.RemainingSeconds = int(time.Until(scopedReset).Seconds())
+			} else {
+				log.Printf("Failed to parse scoped limit resets_at (%s): %s, error: %v", label, lim.ResetsAt, err)
+			}
+		}
+		info.SevenDayScoped = append(info.SevenDayScoped, win)
 	}
 
 	return info

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -189,6 +189,13 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		if s.persistAnthropicExhaustedWindowLimit(ctx, account, headers) {
 			return false
 		}
+		// No general 5h/7d window is exhausted, but the request was still rejected
+		// → a model-scoped weekly limit (e.g. the Fable/Opus-tier window). Block only
+		// the requested model on this account instead of the whole account, so other
+		// models on the same account stay schedulable.
+		if len(requestedModel) > 0 && s.persistAnthropicModelScopedLimit(ctx, account, requestedModel[0], headers) {
+			return false
+		}
 	}
 
 	// 先尝试临时不可调度规则（401除外）
@@ -1143,6 +1150,64 @@ func isAnthropic5hRejected(headers http.Header) bool {
 	return strings.EqualFold(strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-5h-status")), "rejected")
 }
 
+func isAnthropic7dRejected(headers http.Header) bool {
+	return strings.EqualFold(strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-7d-status")), "rejected")
+}
+
+// isAnthropicScopedRejection reports whether a 429 was caused by a model-scoped
+// weekly window (e.g. the Fable/Opus-tier limit) rather than a general 5h/7d
+// window. The signal: the request was rejected overall
+// (anthropic-ratelimit-unified-status: rejected) while neither the 5h nor the 7d
+// general window is exhausted — so the rejection came from a scoped window such
+// as anthropic-ratelimit-unified-7d_oi-status: rejected.
+//
+// We key off the stable 5h/7d headers rather than the scoped window's own header
+// name (e.g. "7d_oi"), which looks internal and may change.
+func isAnthropicScopedRejection(headers http.Header) bool {
+	if !strings.EqualFold(strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-status")), "rejected") {
+		return false
+	}
+	if isAnthropic5hRejected(headers) || isAnthropicWindowExceeded(headers, "5h") {
+		return false
+	}
+	if isAnthropic7dRejected(headers) || isAnthropicWindowExceeded(headers, "7d") {
+		return false
+	}
+	return true
+}
+
+// anthropicScopedResetAt determines when a model-scoped weekly limit resets,
+// using the representative unified reset header, falling back to retry-after.
+// Values beyond a sane ceiling (8 days) are clamped so a bogus header can't
+// freeze a model for an absurd duration.
+func anthropicScopedResetAt(headers http.Header, now time.Time) (time.Time, bool) {
+	const maxAge = 8 * 24 * time.Hour
+	if raw := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-reset")); raw != "" {
+		if ts, err := strconv.ParseInt(raw, 10, 64); err == nil {
+			if ts > 1e11 {
+				ts = ts / 1000
+			}
+			resetAt := time.Unix(ts, 0)
+			if resetAt.After(now) {
+				if resetAt.After(now.Add(maxAge)) {
+					resetAt = now.Add(maxAge)
+				}
+				return resetAt, true
+			}
+		}
+	}
+	if raw := strings.TrimSpace(headers.Get("retry-after")); raw != "" {
+		if secs, err := strconv.ParseInt(raw, 10, 64); err == nil && secs > 0 {
+			resetAt := now.Add(time.Duration(secs) * time.Second)
+			if resetAt.After(now.Add(maxAge)) {
+				resetAt = now.Add(maxAge)
+			}
+			return resetAt, true
+		}
+	}
+	return time.Time{}, false
+}
+
 func parseAnthropicWindowReset(headers http.Header, window string, now time.Time) (time.Time, bool) {
 	raw := strings.TrimSpace(headers.Get("anthropic-ratelimit-unified-" + window + "-reset"))
 	if raw == "" {
@@ -1215,6 +1280,49 @@ func (s *RateLimitService) persistAnthropicExhaustedWindowLimit(ctx context.Cont
 		"window", limit.window,
 		"reset_at", limit.resetAt,
 		"reset_in", time.Until(limit.resetAt).Truncate(time.Second))
+	return true
+}
+
+// persistAnthropicModelScopedLimit handles an Anthropic 429 caused by a
+// model-scoped weekly window (e.g. the Fable/Opus-tier limit) while the general
+// 5h/7d windows still have headroom. It rate-limits ONLY the requested model on
+// this account (via Extra.model_rate_limits), leaving other models schedulable.
+//
+// It deliberately does NOT call notifyAccountSchedulingBlocked / SetRateLimited:
+// the runtime blocker and rate_limit_reset_at both pause the entire account,
+// which is exactly the over-blocking bug this path fixes. The scheduler already
+// excludes rate-limited models per request via IsSchedulableForModelWithContext.
+//
+// Returns true when it handled the 429 (so the caller stops further processing).
+func (s *RateLimitService) persistAnthropicModelScopedLimit(ctx context.Context, account *Account, requestedModel string, headers http.Header) bool {
+	if s == nil || s.accountRepo == nil || account == nil {
+		return false
+	}
+	if !isAnthropicScopedRejection(headers) {
+		return false
+	}
+	// Store under the same key the scheduler recomputes in
+	// modelRateLimitKeysForRequest (GetMappedModel), so set and check agree.
+	modelKey := strings.TrimSpace(account.GetMappedModel(requestedModel))
+	if modelKey == "" {
+		return false
+	}
+	now := time.Now()
+	resetAt, ok := anthropicScopedResetAt(headers, now)
+	if !ok {
+		return false
+	}
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelKey, resetAt, "anthropic_scoped_weekly_exhausted"); err != nil {
+		// Fall through to the account-wide path rather than dropping the 429.
+		slog.Warn("anthropic_model_scoped_rate_limit_set_failed",
+			"account_id", account.ID, "model", modelKey, "reset_at", resetAt, "error", err)
+		return false
+	}
+	slog.Info("anthropic_model_scoped_rate_limited",
+		"account_id", account.ID,
+		"model", modelKey,
+		"reset_at", resetAt,
+		"reset_in", time.Until(resetAt).Truncate(time.Second))
 	return true
 }
 

--- a/backend/internal/service/ratelimit_service_anthropic_model_scoped_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_model_scoped_test.go
@@ -1,0 +1,219 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fableRejected429Headers reproduces the real header set observed when a
+// claude-fable-5 request is rejected by the model-scoped weekly window while the
+// general 5h / 7d windows still have headroom (see probe against api.anthropic.com).
+func fableRejected429Headers(reset time.Time) http.Header {
+	h := http.Header{}
+	h.Set("anthropic-ratelimit-unified-status", "rejected")
+	h.Set("anthropic-ratelimit-unified-5h-status", "allowed")
+	h.Set("anthropic-ratelimit-unified-5h-utilization", "0.16")
+	h.Set("anthropic-ratelimit-unified-7d-status", "allowed")
+	h.Set("anthropic-ratelimit-unified-7d-utilization", "0.70")
+	h.Set("anthropic-ratelimit-unified-7d_oi-status", "rejected")
+	h.Set("anthropic-ratelimit-unified-7d_oi-utilization", "1.01")
+	h.Set("anthropic-ratelimit-unified-representative-claim", "seven_day_overage_included")
+	h.Set("anthropic-ratelimit-unified-reset", strconv.FormatInt(reset.Unix(), 10))
+	return h
+}
+
+func TestIsAnthropicScopedRejection(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers http.Header
+		want    bool
+	}{
+		{
+			name:    "fable scoped rejection (5h/7d allowed, overall rejected)",
+			headers: fableRejected429Headers(time.Now().Add(96 * time.Hour)),
+			want:    true,
+		},
+		{
+			name: "general 7d exhausted → not scoped",
+			headers: func() http.Header {
+				h := fableRejected429Headers(time.Now().Add(96 * time.Hour))
+				h.Set("anthropic-ratelimit-unified-7d-utilization", "1.05")
+				return h
+			}(),
+			want: false,
+		},
+		{
+			name: "general 5h rejected → not scoped",
+			headers: func() http.Header {
+				h := fableRejected429Headers(time.Now().Add(96 * time.Hour))
+				h.Set("anthropic-ratelimit-unified-5h-status", "rejected")
+				return h
+			}(),
+			want: false,
+		},
+		{
+			name: "general 7d status rejected → not scoped",
+			headers: func() http.Header {
+				h := fableRejected429Headers(time.Now().Add(96 * time.Hour))
+				h.Set("anthropic-ratelimit-unified-7d-status", "rejected")
+				return h
+			}(),
+			want: false,
+		},
+		{
+			name: "overall not rejected → not scoped",
+			headers: func() http.Header {
+				h := fableRejected429Headers(time.Now().Add(96 * time.Hour))
+				h.Set("anthropic-ratelimit-unified-status", "allowed")
+				return h
+			}(),
+			want: false,
+		},
+		{
+			name:    "no headers → not scoped",
+			headers: http.Header{},
+			want:    false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isAnthropicScopedRejection(tc.headers))
+		})
+	}
+}
+
+func TestAnthropicScopedResetAt(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+
+	t.Run("uses unified-reset when in the future", func(t *testing.T) {
+		reset := now.Add(96 * time.Hour)
+		h := http.Header{}
+		h.Set("anthropic-ratelimit-unified-reset", strconv.FormatInt(reset.Unix(), 10))
+		got, ok := anthropicScopedResetAt(h, now)
+		require.True(t, ok)
+		require.Equal(t, reset, got)
+	})
+
+	t.Run("falls back to retry-after seconds", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("retry-after", "3600")
+		got, ok := anthropicScopedResetAt(h, now)
+		require.True(t, ok)
+		require.Equal(t, now.Add(time.Hour), got)
+	})
+
+	t.Run("clamps values beyond 8 days", func(t *testing.T) {
+		h := http.Header{}
+		h.Set("anthropic-ratelimit-unified-reset", strconv.FormatInt(now.Add(30*24*time.Hour).Unix(), 10))
+		got, ok := anthropicScopedResetAt(h, now)
+		require.True(t, ok)
+		require.Equal(t, now.Add(8*24*time.Hour), got)
+	})
+
+	t.Run("no usable header → not ok", func(t *testing.T) {
+		_, ok := anthropicScopedResetAt(http.Header{}, now)
+		require.False(t, ok)
+	})
+}
+
+type anthropicModelScopedRepo struct {
+	mockAccountRepoForGemini
+	rateLimitCalls  int
+	modelLimitCalls []modelScopedCall
+}
+
+type modelScopedCall struct {
+	scope   string
+	resetAt time.Time
+	reason  string
+}
+
+func (r *anthropicModelScopedRepo) SetRateLimited(_ context.Context, _ int64, _ time.Time) error {
+	r.rateLimitCalls++
+	return nil
+}
+
+func (r *anthropicModelScopedRepo) SetModelRateLimit(_ context.Context, _ int64, scope string, resetAt time.Time, reason ...string) error {
+	call := modelScopedCall{scope: scope, resetAt: resetAt}
+	if len(reason) > 0 {
+		call.reason = reason[0]
+	}
+	r.modelLimitCalls = append(r.modelLimitCalls, call)
+	return nil
+}
+
+func anthropicOAuthAccount() *Account {
+	return &Account{ID: 42, Type: AccountTypeOAuth, Platform: PlatformAnthropic}
+}
+
+const rateLimitBody = `{"type":"error","error":{"type":"rate_limit_error","message":"This request would exceed your account's rate limit. Please try again later."}}`
+
+// A Fable 429 with headroom on the general windows should limit ONLY the
+// requested model, never the whole account.
+func TestHandleUpstreamError_FableScoped429_LimitsModelOnly(t *testing.T) {
+	reset := time.Now().Add(96 * time.Hour).Truncate(time.Second)
+	repo := &anthropicModelScopedRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+
+	svc.HandleUpstreamError(
+		context.Background(),
+		anthropicOAuthAccount(),
+		http.StatusTooManyRequests,
+		fableRejected429Headers(reset),
+		[]byte(rateLimitBody),
+		"claude-fable-5",
+	)
+
+	require.Zero(t, repo.rateLimitCalls, "scoped 429 must not rate-limit the whole account")
+	require.Len(t, repo.modelLimitCalls, 1)
+	require.Equal(t, "claude-fable-5", repo.modelLimitCalls[0].scope)
+	require.Equal(t, reset, repo.modelLimitCalls[0].resetAt)
+	require.Equal(t, "anthropic_scoped_weekly_exhausted", repo.modelLimitCalls[0].reason)
+}
+
+// A genuine general 7d exhaustion must still block the whole account.
+func TestHandleUpstreamError_General7dExhausted_LimitsAccount(t *testing.T) {
+	reset := time.Now().Add(96 * time.Hour).Truncate(time.Second)
+	headers := fableRejected429Headers(reset)
+	headers.Set("anthropic-ratelimit-unified-7d-status", "rejected")
+	headers.Set("anthropic-ratelimit-unified-7d-utilization", "1.05")
+	headers.Set("anthropic-ratelimit-unified-7d-reset", strconv.FormatInt(reset.Unix(), 10))
+
+	repo := &anthropicModelScopedRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+
+	svc.HandleUpstreamError(
+		context.Background(),
+		anthropicOAuthAccount(),
+		http.StatusTooManyRequests,
+		headers,
+		[]byte(rateLimitBody),
+		"claude-fable-5",
+	)
+
+	require.Equal(t, 1, repo.rateLimitCalls, "general 7d exhaustion should block the account")
+	require.Empty(t, repo.modelLimitCalls, "account-wide path must not also set a model limit")
+}
+
+// Without a requested model we cannot scope the limit; fall back to existing behavior.
+func TestHandleUpstreamError_Scoped429_NoModel_DoesNotSetModelLimit(t *testing.T) {
+	repo := &anthropicModelScopedRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+
+	svc.HandleUpstreamError(
+		context.Background(),
+		anthropicOAuthAccount(),
+		http.StatusTooManyRequests,
+		fableRejected429Headers(time.Now().Add(96*time.Hour)),
+		[]byte(rateLimitBody),
+	)
+
+	require.Empty(t, repo.modelLimitCalls, "no requested model → no model-scoped limit")
+}

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -68,6 +68,16 @@
           color="purple"
         />
 
+        <!-- Model-scoped 7d Windows (OAuth only, e.g. 7d Fable) -->
+        <UsageProgressBar
+          v-for="scoped in usageInfo.seven_day_scoped || []"
+          :key="scoped.label"
+          :label="`7d ${scoped.label}`"
+          :utilization="scoped.utilization"
+          :resets-at="scoped.resets_at"
+          color="amber"
+        />
+
         <!-- Passive sampling label + active query button -->
         <div class="flex items-center gap-1.5 mt-0.5">
           <span

--- a/frontend/src/components/account/UsageProgressBar.vue
+++ b/frontend/src/components/account/UsageProgressBar.vue
@@ -29,7 +29,7 @@
     <div class="flex items-center gap-1">
       <!-- Label badge (fixed width for alignment) -->
       <span
-        :class="['w-[32px] shrink-0 rounded px-1 text-center text-[10px] font-medium', labelClass]"
+        :class="['min-w-[32px] shrink-0 whitespace-nowrap rounded px-1 text-center text-[10px] font-medium', labelClass]"
       >
         {{ label }}
       </span>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -965,6 +965,15 @@ export interface UsageProgress {
   limit_requests?: number
 }
 
+// Model-scoped weekly usage window (e.g. Fable 5), from the upstream
+// usage limits[] weekly_scoped entries. `label` is the model display name.
+export interface ScopedUsageWindow {
+  label: string
+  utilization: number
+  resets_at: string | null
+  remaining_seconds?: number
+}
+
 // Antigravity 单个模型的配额信息
 export interface AntigravityModelQuota {
   utilization: number // 使用率 0-100
@@ -984,6 +993,9 @@ export interface AccountUsageInfo {
   five_hour: UsageProgress | null
   seven_day: UsageProgress | null
   seven_day_sonnet: UsageProgress | null
+  // Model-scoped 7-day windows (e.g. Fable 5), from the upstream usage limits[]
+  // weekly_scoped entries. `label` is the model display name (e.g. "Fable").
+  seven_day_scoped?: ScopedUsageWindow[] | null
   gemini_shared_daily?: UsageProgress | null
   gemini_pro_daily?: UsageProgress | null
   gemini_flash_daily?: UsageProgress | null


### PR DESCRIPTION
## Summary

Anthropic moved model-scoped weekly limits (e.g. the **Fable 5 / Opus-tier** window) out of the deprecated top-level `seven_day_opus` / `seven_day_sonnet` fields (now always `null`) and into a `limits[]` array on `/api/oauth/usage`, with matching `anthropic-ratelimit-unified-*` response headers on 429s. This PR teaches sub2api about that shape in two places.

## Changes

### 1. Show model-scoped 7d windows on the Accounts page (`feat`)
- Parse `limits[]` `weekly_scoped` entries into a new `seven_day_scoped[]` (`ScopedUsageWindow{label, utilization, resets_at}`), labelled by `scope.model.display_name` (e.g. "Fable").
- Render each as a `7d {label}` bar (e.g. **7d Fable**) in `AccountUsageCell`.
- Future-proof: any model Anthropic scopes shows up automatically, not just Fable.

### 2. Scope model-limited 429s to the requested model (`fix`)
- Previously a Fable 429 (scoped window exhausted, general 5h/7d still `allowed`) set an **account-wide** rate limit — pausing scheduling for *every* model on the account, and mis-timed to the 5h reset.
- Now detect that case from the 429 headers (`unified-status: rejected` while neither 5h nor 7d is rejected/exceeded) and rate-limit **only the requested model** via the existing per-model mechanism (`Extra.model_rate_limits`, already consulted by `IsSchedulableForModelWithContext`). General 5h/7d exhaustion keeps the account-wide behavior.
- Model key uses `GetMappedModel` so the stored key matches what the scheduler recomputes. Detection keys off the stable 5h/7d headers, not the internal `7d_oi` window name.

## Verification
- New Go unit tests built against the **real** `/api/oauth/usage` + 429 headers captured from `api.anthropic.com` (fable→model-only limit; general 7d→account-wide; no-model→fallback; detection/reset helpers). `go build ./...` + existing Anthropic rate-limit tests pass.
- Live check: a Fable request 429s while Sonnet/Opus on the same account return 200; the "7d Fable" bar renders in the admin UI after an active usage query.

## Notes
- Passive usage sampling can't show scoped windows (Anthropic doesn't emit them in the per-request rate-limit headers) — they appear via the active "Query" only, matching the existing 5h/7d passive behavior.

## Image
<img width="2988" height="1172" alt="image" src="https://github.com/user-attachments/assets/1e37fd3f-f007-4be9-b488-de02feb1b7b5" />

