### PR TITLE
fix：添加 token_expired 刷新不可重试判断

### DIFF
--- a/backend/internal/service/token_refresh_service.go
+++ b/backend/internal/service/token_refresh_service.go
@@ -446,6 +446,7 @@ func isNonRetryableRefreshError(err error) bool {
 	nonRetryable := []string{
 		"invalid_grant",             // refresh_token 已失效
 		"invalid_refresh_token",     // refresh_token 无效, team 账号工作区被删除会出现
+		"token_expired",             // OpenAI refresh_token 已过期，需要重新授权
 		"app_session_terminated",    // refresh_token team 账号工作区被删除
 		"refresh_token_reused",      // OpenAI refresh_token 已被使用，必须重新授权
 		"refresh_token_invalidated", // OpenAI session ended; refresh token invalidated

--- a/backend/internal/service/token_refresh_service_test.go
+++ b/backend/internal/service/token_refresh_service_test.go
@@ -541,6 +541,7 @@ func TestIsNonRetryableRefreshError(t *testing.T) {
 		{name: "invalid_grant", err: errors.New("invalid_grant"), expected: true},
 		{name: "invalid_client", err: errors.New("invalid_client"), expected: true},
 		{name: "invalid_refresh_token", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"invalid_refresh_token"}}`), expected: true},
+		{name: "token_expired", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"token_expired"}}`), expected: true},
 		{name: "refresh_token_reused", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error":{"code":"refresh_token_reused"}}`), expected: true},
 		{name: "app_session_terminated", err: errors.New(`OPENAI_OAUTH_TOKEN_REFRESH_FAILED: token refresh failed: status 401, body: {"error": {"code": "app_session_terminated"}}`), expected: true},
 		{name: "unauthorized_client", err: errors.New("unauthorized_client"), expected: true},


### PR DESCRIPTION
token_refresh.retry_attempt_failed acc=450382 error=error: code=400 reason="OPENAI_OAUTH_TOKEN_REFRESH_FAILED" message="token refresh failed: status 401, body: {\n \"error\": {\n \"message\": \"Could not validate your token. Please try signing in again.\",\n \"type\": \"invalid_request_error\",\n \"param\": null,\n \"code\": \"token_expired\"\n }\n}" metadata=map[upstream_status:401]

## 变更说明

- 将 OpenAI OAuth 刷新返回的 `token_expired` 纳入不可重试错误列表
- 补充 `token_expired` 的不可重试判断用例


