### PR TITLE
fix(antigravity): 网关转发默认走生产端点（修复一请求就 401/502、账号被 benched）

### DIFF
--- a/backend/internal/service/antigravity_gateway_service.go
+++ b/backend/internal/service/antigravity_gateway_service.go
@@ -153,14 +153,24 @@ type antigravityRetryLoopResult struct {
 }
 
 // resolveAntigravityForwardBaseURL 解析转发用 base URL。
-// 默认使用 daily（ForwardBaseURLs 的首个地址）；当环境变量为 prod 时使用第二个地址。
+//
+// 默认使用生产端点 cloudcode-pa.googleapis.com（antigravity.BaseURLs 的首个地址，
+// 与账号 OAuth 登录/测试连接所用的 antigravity.BaseURL 一致）。
+//
+// 历史上这里改用 ForwardBaseURLs()（把 daily/sandbox 排到首位）并默认取首个地址，
+// 导致网关把带生产 OAuth token 的请求发到 daily-cloudcode-pa.sandbox.googleapis.com，
+// 上游拒绝 → 账号被 401「Invalid bearer token」/502 打入临时不可调度且无法恢复
+// （见 #3611 / #2962）。后台「测试连接」用的是生产端点，所以「测试成功但网关 401」。
+//
+// daily/sandbox 端点仅供内部联调，需显式设置
+// GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily（或 sandbox）才启用。
 func resolveAntigravityForwardBaseURL() string {
-	baseURLs := antigravity.ForwardBaseURLs()
+	baseURLs := antigravity.BaseURLs
 	if len(baseURLs) == 0 {
 		return ""
 	}
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv(antigravityForwardBaseURLEnv)))
-	if mode == "prod" && len(baseURLs) > 1 {
+	if (mode == "daily" || mode == "sandbox") && len(baseURLs) > 1 {
 		return baseURLs[1]
 	}
 	return baseURLs[0]


### PR DESCRIPTION
## 根因（真机验证）

Antigravity 网关把**所有**转发请求发到了 Google 的 **daily/sandbox 端点** `daily-cloudcode-pa.sandbox.googleapis.com`，而不是生产端点 `cloudcode-pa.googleapis.com`。sandbox 端点拒绝生产 OAuth token → 账号被 `OAuth 401: Invalid bearer token` 打入临时不可调度且无法恢复（native 路径表现为 502）。

`resolveAntigravityForwardBaseURL()` 用了 `antigravity.ForwardBaseURLs()`（它把 daily/sandbox 排到首位）并默认取首个地址：

```go
baseURLs := antigravity.ForwardBaseURLs()   // [daily-sandbox, prod]
if mode == "prod" { return baseURLs[1] }     // 只有显式 env=prod 才用 prod
return baseURLs[0]                            // 默认 = daily sandbox  ❌
```

而后台「测试连接」用的是生产端点 `antigravity.BaseURL`（= `BaseURLs[0]` = prod），所以出现「**测试连接成功、但网关一请求就 401**」这一诡异现象（#3611、#2962 报告的正是它）。

## 为什么不是 token 问题（本 PR 取代原 self-heal 方案）

原方案假设是「token 未过期但被服务端失效」的 staleness。真机排查证伪：一个**刚授权 30 秒**的全新 token，在**测试路径返回 404**（到了模型层，说明 token 被接受），在**网关路径返回 401**。同一 token / 同一账号 / 同一实例、请求构造完全相同，唯一差异是网关发到了 sandbox 端点。所以刷新 token 无济于事（新 token 照样发到 sandbox）。

## 改动（1 文件，+13/-3）

`resolveAntigravityForwardBaseURL()` 默认使用生产端点 `antigravity.BaseURLs[0]`（与 OAuth 登录 / 测试连接一致）；daily/sandbox 改为**显式 opt-in**：`GATEWAY_ANTIGRAVITY_FORWARD_BASE_URL=daily|sandbox`。向后兼容：旧的 `=prod` 设置仍走 prod。

## 真机验证

挂本 patch 的实例，用刚授权的 Antigravity 账号：
- **修复前**：`/antigravity/v1/messages`、`/v1/messages` → 502 / 网关 401，账号被 benched。
- **修复后**（仅代码默认、未设任何 env）：
  - `claude-sonnet-4-6` → `200` `Hi there, friend! 👋`
  - `claude-opus-4-6` → `200` `Hey there, friend!`

（`claude-sonnet-4-5` 的 404 是该账号档位不含此模型，与本 bug 无关。）

## 说明
- `antigravity.ForwardBaseURLs()`（daily 优先重排）改后不再被网关使用；保留未删以最小化 diff，可后续清理。
- openai-compat `/v1/chat/completions` 走 antigravity 分组仍会 401 —— 那是另一条不经过本 forwarder 的路径，属独立问题，不在本 PR 范围。
