### PR TITLE
fix(usage): CSV 导出补 UTF-8 BOM，修复 Excel 打开中文列乱码

### DIFF
--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -677,7 +677,7 @@ const exportToCSV = async () => {
       headers.map(escapeCSVValue).join(','),
       ...rows.map((row) => row.join(',')),
     ].join('\n')
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const blob = new Blob(['\uFEFF' + csvContent], { type: 'text/csv;charset=utf-8;' })
     const url = window.URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -237,6 +237,11 @@ describe('user UsageView', () => {
     }))
     expect(clickSpy).toHaveBeenCalled()
     expect(showSuccess).toHaveBeenCalled()
+    expect(csvContent.startsWith('\uFEFF')).toBe(true)
+    expect(csvContent.slice(1)).toBe([
+      'Time,API Key Name,Model,Reasoning Effort,Inbound Endpoint,IP Address,Type,Billing Mode,Input Tokens,Output Tokens,Cache Read Tokens,Cache Creation Tokens,Rate Multiplier,Billed Cost,Original Cost,First Token (ms),Duration (ms)',
+      '2026-03-08T00:00:00Z,demo-key,gpt-5.4,"\'-",,203.0.113.10,Sync,Token,4057,101,278272,4,1,0.09288300,0.09288300,12,345',
+    ].join('\n'))
     expect(csvContent).toContain('IP Address')
     expect(csvContent).toContain('203.0.113.10')
     expect(csvContent).toContain('Billed Cost')


### PR DESCRIPTION
## 背景

用户端使用记录页 `/usage` 导出的 CSV 在 Excel 中直接打开时，中文列值会乱码。原因是导出 Blob 只声明了 `text/csv;charset=utf-8;`，但实际文件字节流没有 UTF-8 BOM；Excel 打开 `.csv` 时不会读取 MIME，而是依赖文件头 BOM 判断编码。

## 改动

- 为用户端使用记录 CSV 导出的 Blob 内容前添加显式 `\uFEFF`，让文件以 UTF-8 BOM 开头。
- 补充 UsageView 导出测试，断言导出的 CSV 包含 BOM，并确认 BOM 之后的 CSV 主体内容不变。

## 测试

- `cd frontend && pnpm install` 通过。
- `PNPM_ALLOW_BUILDS='{"esbuild":true,"vue-demi":true}' pnpm test:run src/views/user/__tests__/UsageView.spec.ts` 通过。
- `PNPM_ALLOW_BUILDS='{"esbuild":true,"vue-demi":true}' pnpm typecheck` 通过。
- `PNPM_ALLOW_BUILDS='{"esbuild":true,"vue-demi":true}' pnpm lint:check` 通过。
- `PNPM_ALLOW_BUILDS='{"esbuild":true,"vue-demi":true}' pnpm build` 通过。
- `PNPM_ALLOW_BUILDS='{"esbuild":true,"vue-demi":true}' pnpm test:run` 未完全通过：现有 `src/components/account/__tests__/BulkEditAccountModal.spec.ts > antigravity 映射预设包含图片映射并过滤 OpenAI 预设` 期望 `3.1-Flash-Image透传`，实际渲染为 `3.1-Flash-Image passthrough`；本 PR 未修改该文件。

Fixes #3710