### PR TITLE
fix: 避免 Fable 限流误升级为账号限流

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -187,11 +187,18 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 	// cooldown to a local temporary pause.
 	if statusCode == http.StatusTooManyRequests && account.Platform == PlatformAnthropic {
 		// 7d_oi 是 Fable 模型专属的 7d 窗口：只标记模型级限流，账号对其他模型仍可调度。
+		// fableHit 独立于 reset 是否可解析：即使因 7d_oi-reset / aggregate reset 缺失导致
+		// 模型级限流无法写入，只要 7d_oi 命中就绝不能 fall through 到旧 handle429 把
+		// 账号级 rate_limit_reset_at 写进去。
+		fableHit := isAnthropicFableWindowHit(headers)
 		fableLimited := s.persistAnthropicFableWindowLimit(ctx, account, headers)
-		if s.persistAnthropicExhaustedWindowLimit(ctx, account, headers) {
+		// fableHit 为真时，5h/7d 主窗口需要更强证据（surpassed-threshold=true 或
+		// utilization>=1.0，或 7d 明确 exceeded）才能把账号升级为账号级限流；
+		// 仅凭 5h-status=rejected 不足以升级（该信号本身可能只是 7d_oi 拒绝的伴生噪音）。
+		if s.persistAnthropicExhaustedWindowLimit(ctx, account, headers, fableHit) {
 			return false
 		}
-		if fableLimited {
+		if fableLimited || fableHit {
 			return false
 		}
 	}
@@ -1120,11 +1127,20 @@ type anthropicWindowLimit struct {
 	reason  string
 }
 
-func selectAnthropicExhaustedWindow(headers http.Header, now time.Time) *anthropicWindowLimit {
+// selectAnthropicExhaustedWindow determines whether the 5h/7d primary windows
+// are exhausted. When strict is true (the 429 was also a 7d_oi/Fable hit), a
+// bare 5h-status=rejected is NOT treated as exhaustion on its own because it can
+// be mere collateral noise from the 7d_oi rejection. Strict mode requires the
+// stronger surpassed-threshold=true or utilization>=1.0 signal for 5h (7d
+// already only relies on that stronger signal, so it is unaffected by strict).
+func selectAnthropicExhaustedWindow(headers http.Header, now time.Time, strict bool) *anthropicWindowLimit {
 	reset5h, ok5hReset := parseAnthropicWindowReset(headers, "5h", now)
 	reset7d, ok7dReset := parseAnthropicWindowReset(headers, "7d", now)
 
-	exceeded5h := isAnthropic5hRejected(headers) || isAnthropicWindowExceeded(headers, "5h")
+	exceeded5h := isAnthropicWindowExceeded(headers, "5h")
+	if !strict {
+		exceeded5h = exceeded5h || isAnthropic5hRejected(headers)
+	}
 	exceeded7d := isAnthropicWindowExceeded(headers, "7d")
 
 	if exceeded7d && ok7dReset {
@@ -1194,12 +1210,12 @@ func shouldPersistAnthropicWindowLimit(account *Account, limit *anthropicWindowL
 	return limit.resetAt.After(*account.RateLimitResetAt)
 }
 
-func (s *RateLimitService) persistAnthropicExhaustedWindowLimit(ctx context.Context, account *Account, headers http.Header) bool {
+func (s *RateLimitService) persistAnthropicExhaustedWindowLimit(ctx context.Context, account *Account, headers http.Header, strict bool) bool {
 	if s == nil || s.accountRepo == nil || account == nil {
 		return false
 	}
 	now := time.Now()
-	limit := selectAnthropicExhaustedWindow(headers, now)
+	limit := selectAnthropicExhaustedWindow(headers, now, strict)
 	if limit == nil {
 		return false
 	}
@@ -1242,7 +1258,7 @@ const anthropicFableWindowReason = "anthropic_7d_oi_window_exhausted"
 // anthropic-ratelimit-unified-reset is used (it mirrors the binding claim's
 // reset when 7d_oi is the representative claim).
 func selectAnthropicFableWindowLimit(headers http.Header, now time.Time) *anthropicWindowLimit {
-	if !isAnthropicWindowRejected(headers, "7d_oi") && !isAnthropicWindowExceeded(headers, "7d_oi") {
+	if !isAnthropicFableWindowHit(headers) {
 		return nil
 	}
 	resetAt, ok := parseAnthropicWindowReset(headers, "7d_oi", now)
@@ -1264,6 +1280,16 @@ func selectAnthropicFableWindowLimit(headers http.Header, now time.Time) *anthro
 // per-window variant (7d scale).
 func parseAnthropicAggregateReset(headers http.Header, now time.Time) (time.Time, bool) {
 	return parseAnthropicResetTimestamp(headers.Get("anthropic-ratelimit-unified-reset"), now, 8*24*time.Hour)
+}
+
+// isAnthropicFableWindowHit reports whether the 7d_oi (Fable-only) window claim
+// was rejected or exceeded in the 429 response headers, independent of whether
+// a reset timestamp usable for persisting a model-level limit is present. This
+// is used to gate account-level escalation and to prevent falling through to
+// the legacy handle429 path even when the model-level limit itself could not
+// be persisted (missing/unparseable 7d_oi-reset and aggregate reset headers).
+func isAnthropicFableWindowHit(headers http.Header) bool {
+	return isAnthropicWindowRejected(headers, "7d_oi") || isAnthropicWindowExceeded(headers, "7d_oi")
 }
 
 // persistAnthropicFableWindowLimit marks the Fable model family as rate limited

--- a/backend/internal/service/ratelimit_service_anthropic_window_limit_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_window_limit_test.go
@@ -202,6 +202,81 @@ func TestHandleUpstreamError_AnthropicAccountWindowStillWinsOver7dOi(t *testing.
 	require.Equal(t, anthropicFableRateLimitKey, repo.lastModelRateLimitScope)
 }
 
+func TestHandleUpstreamError_Anthropic7dOiHitWeak5hRejectedDoesNotEscalateAccount(t *testing.T) {
+	// 7d_oi 命中 + 5h-status=rejected 但 5h-utilization<1、7d allowed：
+	// 5h-status=rejected 本身可能只是 7d_oi 拒绝的伴生噪音，不足以把账号升级为账号级限流；
+	// 只应写模型级（Fable）限流。
+	now := time.Now()
+	reset5h := now.Add(2 * time.Hour).Truncate(time.Second)
+	resetOI := now.Add(80 * time.Hour).Truncate(time.Second)
+	headers := fable429Headers(reset5h, resetOI)
+	headers.Set("anthropic-ratelimit-unified-5h-status", "rejected")
+	headers.Set("anthropic-ratelimit-unified-5h-utilization", "0.5")
+
+	repo := &anthropicWindowLimitRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 42, Type: AccountTypeOAuth, Platform: PlatformAnthropic}
+
+	shouldDisable := svc.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, headers, nil, "claude-fable-5")
+
+	require.False(t, shouldDisable)
+	require.Zero(t, repo.rateLimitCalls, "bare 5h-status=rejected without utilization>=1.0/surpassed-threshold must not escalate to account-level rate limit")
+	require.Zero(t, repo.tempUnschedCalls)
+	require.Equal(t, 1, repo.modelRateLimitCalls, "7d_oi hit with resolvable reset should still mark the Fable model limited")
+	require.Equal(t, anthropicFableRateLimitKey, repo.lastModelRateLimitScope)
+}
+
+func TestHandleUpstreamError_Anthropic7dOiHitMissingResetNeverFallsThroughToLegacy(t *testing.T) {
+	// 7d_oi 命中但 7d_oi-reset 和 aggregate reset 缺失/不可解析，5h/7d 主窗口未超限但 reset 存在：
+	// 不能调用 SetRateLimited，不能触发 temp-unsched（也不落到旧 handle429），
+	// 模型级限流因 reset 缺失可以不写。
+	now := time.Now()
+	reset5h := now.Add(2 * time.Hour).Truncate(time.Second)
+	reset7d := now.Add(80 * time.Hour).Truncate(time.Second)
+
+	headers := http.Header{}
+	headers.Set("anthropic-ratelimit-unified-5h-reset", strconv.FormatInt(reset5h.Unix(), 10))
+	headers.Set("anthropic-ratelimit-unified-5h-status", "allowed")
+	headers.Set("anthropic-ratelimit-unified-5h-utilization", "0.4")
+	headers.Set("anthropic-ratelimit-unified-7d-reset", strconv.FormatInt(reset7d.Unix(), 10))
+	headers.Set("anthropic-ratelimit-unified-7d-status", "allowed")
+	headers.Set("anthropic-ratelimit-unified-7d-utilization", "0.3")
+	// 7d_oi 命中但没有可解析的 7d_oi-reset，也没有聚合 anthropic-ratelimit-unified-reset。
+	headers.Set("anthropic-ratelimit-unified-7d_oi-status", "rejected")
+	headers.Set("anthropic-ratelimit-unified-7d_oi-utilization", "1.0")
+
+	repo := &anthropicWindowLimitRepo{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{
+		ID:       42,
+		Type:     AccountTypeOAuth,
+		Platform: PlatformAnthropic,
+		Credentials: map[string]any{
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []any{
+				map[string]any{
+					"error_code":       float64(http.StatusTooManyRequests),
+					"keywords":         []any{"rate limit"},
+					"duration_minutes": float64(10),
+				},
+			},
+		},
+	}
+
+	shouldDisable := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		headers,
+		[]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"rate limit"}}`),
+		"claude-fable-5",
+	)
+
+	require.False(t, shouldDisable)
+	require.Zero(t, repo.rateLimitCalls, "7d_oi hit without a resolvable reset must not fall through to account-level rate limit")
+	require.Zero(t, repo.tempUnschedCalls, "7d_oi hit without a resolvable reset must not fall through to legacy temp-unsched rules")
+}
+
 func TestHandleUpstreamError_Anthropic429Without7dOiKeepsLegacyBehavior(t *testing.T) {
 	// 无 7d_oi 头、5h/7d 均未超限的 429：保持旧行为（按较早 reset 标记账号限流）。
 	now := time.Now()


### PR DESCRIPTION
## 背景

Anthropic Fable 的 `7d_oi` 窗口是 Fable 家族专属限流。当前处理会先写 Fable 模型级限流，但在 `7d_oi` 命中时仍可能仅凭 `5h-status=rejected` 或旧的 429 fallback 将账号写成账号级限流，导致同账号的 Opus/Sonnet 也被调度器排除。

## 修改

- 将 `7d_oi` 是否命中与模型级限流 reset 是否可解析分离。
- 当 `7d_oi` 命中时，账号级 5h/7d 限流需要更强证据：`surpassed-threshold=true` 或 `utilization>=1.0`。
- 即使 `7d_oi-reset` 和聚合 reset 缺失，也不会 fall through 到旧 `handle429` 写账号级限流。
- 增加回归测试覆盖弱 `5h-status=rejected` 与缺失 Fable reset 两种场景。

## 验证

- `cd backend && go test -tags unit ./internal/service -run 'TestHandleUpstreamError_Anthropic|TestSelectAnthropic|TestIsAnthropicWindow|TestIsModelRateLimited_AnthropicFableFamilyKey' -count=1`\n- `cd backend && go test -tags unit ./internal/service/...`\n- `cd backend && go build ./cmd/server/`