### PR TITLE
chore: add production image release gates

### DIFF
--- a/.github/workflows/production-image.yml
+++ b/.github/workflows/production-image.yml
@@ -1,0 +1,202 @@
+name: Sub2API Production Image
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'sub2api-*'
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      previous_image:
+        description: 'Optional previous image for marker regression comparison'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+  security-events: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          cache: true
+          cache-dependency-path: backend/go.sum
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Source marker matrix
+        run: scripts/marker-matrix.sh --project sub2api --target source:. --require-all --output release/marker-matrix-source.tsv
+
+      - name: Backend unit tests
+        working-directory: backend
+        run: make test-unit
+
+      - name: Frontend build
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Upload source marker matrix
+        uses: actions/upload-artifact@v7
+        with:
+          name: sub2api-source-marker-matrix
+          path: release/marker-matrix-source.tsv
+
+  image:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      image_ref: ${{ steps.manifest.outputs.image_ref }}
+      manifest_path: ${{ steps.manifest.outputs.manifest_path }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set image name
+        id: image
+        run: echo "image=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.image.outputs.image }}
+          tags: |
+            type=sha,prefix=git-
+            type=raw,value=production-${{ github.run_number }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+
+      - name: Attest image provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ${{ steps.image.outputs.image }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Inspect built image markers
+        env:
+          IMAGE_REF: ${{ steps.image.outputs.image }}@${{ steps.build.outputs.digest }}
+          PREVIOUS_IMAGE: ${{ github.event.inputs.previous_image }}
+        run: |
+          docker pull "$IMAGE_REF"
+          scripts/marker-matrix.sh --project sub2api --target "image:$IMAGE_REF" --output release/marker-matrix-image.tsv
+          if [ -n "$PREVIOUS_IMAGE" ]; then
+            scripts/marker-matrix.sh --project sub2api --compare "$PREVIOUS_IMAGE" "$IMAGE_REF" --output release/marker-matrix-compare.tsv
+          fi
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@0.32.0
+        with:
+          image-ref: ${{ steps.image.outputs.image }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: HIGH,CRITICAL
+          exit-code: '1'
+
+      - name: Upload Trivy results
+        if: always()
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Write release manifest
+        id: manifest
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p release/manifests
+          python3 - <<'PY'
+          import datetime, json, os, pathlib
+          image = os.environ["IMAGE"]
+          digest = os.environ["DIGEST"]
+          manifest = {
+              "project": "sub2api",
+              "source": "github-actions",
+              "git_sha": os.environ["GITHUB_SHA"],
+              "created_at": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "ci_run_url": os.environ["RUN_URL"],
+              "image": image,
+              "image_ref": f"{image}@{digest}",
+              "image_digest": digest,
+              "tags": [line for line in os.environ["TAGS"].splitlines() if line],
+              "base_image_digest": "recorded-by-buildkit-provenance",
+              "replaced_artifacts": ["/app/sub2api"],
+              "marker_matrix": {"status": "success", "regressions": 0, "path": "release/marker-matrix-image.tsv"},
+              "tests": [
+                  {"name": "source-marker-matrix", "status": "success"},
+                  {"name": "backend-unit-tests", "status": "success"},
+                  {"name": "frontend-build", "status": "success"},
+                  {"name": "trivy", "status": "success"}
+              ],
+              "attestations": {"sbom": True, "provenance": True}
+          }
+          path = pathlib.Path("release/manifests/sub2api-release-manifest.json")
+          path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          print(f"image_ref={manifest['image_ref']}")
+          print(f"manifest_path={path}")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"image_ref={manifest['image_ref']}\n")
+              out.write(f"manifest_path={path}\n")
+          PY
+          scripts/verify-release-manifest.sh release/manifests/sub2api-release-manifest.json --project sub2api --require-ci
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: sub2api-production-release
+          path: |
+            release/manifests/sub2api-release-manifest.json
+            release/marker-matrix-image.tsv
+            release/marker-matrix-compare.tsv
+            trivy-results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,10 @@ temp/
 dist/
 build/
 release/
+!release/
+release/*
+!release/markers/
+!release/markers/*.txt
 
 # 后端嵌入的前端构建产物
 # Keep a placeholder file so `//go:embed all:dist` always has a match in CI/lint,
@@ -119,6 +123,12 @@ tests
 CLAUDE.md
 .claude
 scripts
+!scripts/
+scripts/*
+!scripts/marker-matrix.sh
+!scripts/verify-release-manifest.sh
+!scripts/deploy-by-digest.sh
+!scripts/deploy-production-image.sh
 !backend/scripts/
 !backend/scripts/resolve-version.sh
 .code-review-state

--- a/release/markers/sub2api-core.txt
+++ b/release/markers/sub2api-core.txt
@@ -1,0 +1,48 @@
+# feature|literal marker string
+subscription pending-cycle UI/API|pending_cycle_count
+subscription pending-cycle UI/API|pending_quota_usd
+subscription pending-cycle UI/API|pendingCyclesTitle
+subscription pending-cycle UI/API|purchaseTimelineTitle
+subscription pending-cycle UI/API|currentCycleRemaining
+subscription remaining-time UI|remainingLessThanOneHour
+subscription remaining-time UI|remainingDaysHours
+subscription remaining-time UI|getRemainingDaysHours
+subscription primary-window protection|shouldAutoResetSubscriptionWindow
+subscription primary-window protection|subscriptionGroupForWindowPolicy
+expired subscription restart|subscriptionExpiredForFulfillment
+rollover on quota exhaustion or expiry|ActivateQueuedCycleIfDue
+rollover on quota exhaustion or expiry|ActivateQueuedCycleIfLimitReached
+rollover on quota exhaustion or expiry|HasQueuedSubscriptionCycle
+model square|ModelSquare
+model square|getModelSquare
+model square|ModelSquareView
+group status|DashboardGroupStatus
+group status|getDashboardGroupStatus
+group status|GroupStatusView
+channel status and monitor UI|ChannelStatusView
+channel status and monitor UI|ChannelMonitorView
+channel status and monitor UI|AvailableChannelsView
+channel status and monitor UI|useChannelMonitorFormat
+channel status and monitor UI|channelMonitor
+channel status and monitor UI|channel_monitor
+account admin UI|AccountsView
+account admin UI|AccountActionMenu
+account admin UI|AccountTableActions
+account admin UI|AccountTableFilters
+account admin UI|AccountCapacityCell
+account admin UI|AccountUsageCell
+account admin UI|AccountTodayStatsCell
+account admin UI|AccountGroupsCell
+channel/account cost accounting|apply_pricing_to_account_stats
+channel/account cost accounting|account_stats_cost
+OpenAI upload/import initial refresh|uploaded_openai_initial_refresh_started
+OpenAI upload/import initial refresh|uploaded_openai_initial_refresh_succeeded
+OpenAI upload/import initial refresh|uploaded_openai_initial_refresh_failed
+OpenAI upload/import initial refresh|uploaded_openai_initial_refresh_completed
+OpenAI upload/import initial refresh|SkipInitialPrivacy
+OpenAI upload/import initial refresh|SetAccountSchedulable
+OpenAI upload/import initial refresh|importContainsOpenAIOAuth
+OpenAI OAuth test models|buildOpenAIOAuthTestModels
+scheduled account tests|scheduled_test_plans
+scheduled account tests|ScheduledTestRunnerService
+scheduled account tests|auto_recover

--- a/scripts/deploy-by-digest.sh
+++ b/scripts/deploy-by-digest.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/deploy-by-digest.sh --manifest release-manifest.json --project NAME
+                              [--compose FILE --service SERVICE]
+                              [--container CONTAINER] [--lock FILE]
+                              [--apply] [--restart] [--skip-marker-compare] [--skip-pull]
+
+This script refuses mutable tag-only deployments. The manifest must be produced by CI
+and image_ref must contain @sha256:<digest>.
+USAGE
+}
+
+fail() {
+  echo "[deploy-by-digest] ERROR: $*" >&2
+  exit 2
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANIFEST=""
+PROJECT=""
+COMPOSE=""
+SERVICE=""
+CONTAINER=""
+LOCK_FILE=""
+APPLY=0
+RESTART=0
+SKIP_MARKER_COMPARE=0
+SKIP_PULL=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --manifest)
+      MANIFEST="${2:-}"
+      shift 2
+      ;;
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --compose)
+      COMPOSE="${2:-}"
+      shift 2
+      ;;
+    --service)
+      SERVICE="${2:-}"
+      shift 2
+      ;;
+    --container)
+      CONTAINER="${2:-}"
+      shift 2
+      ;;
+    --lock)
+      LOCK_FILE="${2:-}"
+      shift 2
+      ;;
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --restart)
+      RESTART=1
+      shift
+      ;;
+    --skip-marker-compare)
+      SKIP_MARKER_COMPARE=1
+      shift
+      ;;
+    --skip-pull)
+      SKIP_PULL=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || fail "missing --manifest"
+[ -n "$PROJECT" ] || fail "missing --project"
+
+VERIFY="$ROOT/scripts/verify-release-manifest.sh"
+MATRIX="$ROOT/scripts/marker-matrix.sh"
+[ -x "$VERIFY" ] || fail "missing executable verifier: $VERIFY"
+[ -x "$MATRIX" ] || fail "missing executable marker matrix: $MATRIX"
+
+IMAGE_REF="$("$VERIFY" "$MANIFEST" --project "$PROJECT" --require-ci --print-image-ref)"
+case "$IMAGE_REF" in
+  *@sha256:*) ;;
+  *) fail "manifest image_ref is not immutable: $IMAGE_REF" ;;
+esac
+
+echo "[deploy-by-digest] manifest ok"
+echo "[deploy-by-digest] image_ref=$IMAGE_REF"
+
+if [ "$SKIP_PULL" -eq 0 ] && { [ "$APPLY" -eq 1 ] || [ "$RESTART" -eq 1 ]; }; then
+  docker pull "$IMAGE_REF"
+fi
+
+if [ "$SKIP_MARKER_COMPARE" -eq 0 ] && [ -n "$CONTAINER" ]; then
+  PREV_IMAGE="$(docker inspect "$CONTAINER" --format '{{.Config.Image}}')"
+  echo "[deploy-by-digest] previous_image=$PREV_IMAGE"
+  "$MATRIX" --project "$PROJECT" --compare "$PREV_IMAGE" "$IMAGE_REF"
+fi
+
+if [ "$APPLY" -eq 0 ]; then
+  echo "[deploy-by-digest] dry-run only; pass --apply to edit compose/lock files"
+  exit 0
+fi
+
+[ -n "$COMPOSE" ] || fail "--apply requires --compose"
+[ -n "$SERVICE" ] || fail "--apply requires --service"
+[ -f "$COMPOSE" ] || fail "compose file not found: $COMPOSE"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+cp -a "$COMPOSE" "$COMPOSE.bak-$TS-before-digest-deploy"
+if [ -n "$LOCK_FILE" ] && [ -f "$LOCK_FILE" ]; then
+  cp -a "$LOCK_FILE" "$LOCK_FILE.bak-$TS-before-digest-deploy"
+fi
+
+python3 - "$COMPOSE" "$SERVICE" "$IMAGE_REF" <<'PY'
+import re
+import sys
+
+path, service, image = sys.argv[1:4]
+with open(path, "r", encoding="utf-8") as fh:
+    lines = fh.readlines()
+
+service_re = re.compile(rf"^(\s*){re.escape(service)}:\s*(?:#.*)?$")
+image_re = re.compile(r"^(\s*)image:\s*.*$")
+in_service = False
+service_indent = None
+replaced = False
+
+for idx, line in enumerate(lines):
+    if not in_service:
+        m = service_re.match(line)
+        if m:
+            in_service = True
+            service_indent = len(m.group(1))
+        continue
+
+    stripped = line.strip()
+    if stripped and not line.startswith(" ") and not line.startswith("\t"):
+        break
+    indent = len(line) - len(line.lstrip(" "))
+    if stripped and indent <= service_indent and re.match(r"^[A-Za-z0-9_.-]+:", stripped):
+        break
+    m = image_re.match(line)
+    if m:
+        lines[idx] = f"{m.group(1)}image: {image}\n"
+        replaced = True
+        break
+
+if not replaced:
+    raise SystemExit(f"service {service!r} image line not found in {path}")
+
+with open(path, "w", encoding="utf-8") as fh:
+    fh.writelines(lines)
+PY
+
+if [ -n "$LOCK_FILE" ]; then
+  printf '%s\n' "$IMAGE_REF" > "$LOCK_FILE"
+fi
+
+echo "[deploy-by-digest] updated compose=$COMPOSE service=$SERVICE"
+[ -z "$LOCK_FILE" ] || echo "[deploy-by-digest] updated lock=$LOCK_FILE"
+
+if [ "$RESTART" -eq 1 ]; then
+  docker compose -f "$COMPOSE" up -d --no-deps "$SERVICE"
+  echo "[deploy-by-digest] restarted service=$SERVICE"
+else
+  echo "[deploy-by-digest] restart skipped; pass --restart to run docker compose up"
+fi

--- a/scripts/deploy-production-image.sh
+++ b/scripts/deploy-production-image.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+exec "$ROOT/scripts/deploy-by-digest.sh" \
+  --project sub2api \
+  --compose "${SUB2API_COMPOSE_FILE:-$ROOT/deploy/docker-compose.yml}" \
+  --service "${SUB2API_DEPLOY_SERVICE:-sub2api}" \
+  --container "${SUB2API_DEPLOY_CONTAINER:-sub2api}" \
+  --lock "${SUB2API_IMAGE_LOCK:-$ROOT/deploy/IMAGE_LOCK.txt}" \
+  "$@"

--- a/scripts/marker-matrix.sh
+++ b/scripts/marker-matrix.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/marker-matrix.sh [--project gpt2api|sub2api] [--markers FILE]...
+                           [--target source:PATH|image:REF]... [--output FILE]
+  scripts/marker-matrix.sh --compare PREV_IMAGE CAND_IMAGE [--project ...] [--markers FILE]...
+
+Marker file format:
+  feature name|literal marker string
+
+The compare mode fails closed when a marker present in PREV is absent from CAND.
+USAGE
+}
+
+fail() {
+  echo "[marker-matrix] ERROR: $*" >&2
+  exit 2
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT=""
+OUTPUT=""
+REQUIRE_ALL=0
+COMPARE=0
+PREV_IMAGE=""
+CAND_IMAGE=""
+MARKER_FILES=()
+TARGETS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --markers)
+      MARKER_FILES+=("${2:-}")
+      shift 2
+      ;;
+    --target)
+      TARGETS+=("${2:-}")
+      shift 2
+      ;;
+    --output)
+      OUTPUT="${2:-}"
+      shift 2
+      ;;
+    --require-all)
+      REQUIRE_ALL=1
+      shift
+      ;;
+    --compare)
+      COMPARE=1
+      PREV_IMAGE="${2:-}"
+      CAND_IMAGE="${3:-}"
+      shift 3
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+done
+
+if [ -z "$PROJECT" ]; then
+  if [ -f "$ROOT/go.mod" ] && [ -d "$ROOT/web" ]; then
+    PROJECT="gpt2api"
+  elif [ -f "$ROOT/backend/go.mod" ]; then
+    PROJECT="sub2api"
+  else
+    fail "cannot infer project; pass --project"
+  fi
+fi
+
+case "$PROJECT" in
+  gpt2api|sub2api) ;;
+  *) fail "unsupported project: $PROJECT" ;;
+esac
+
+if [ "${#MARKER_FILES[@]}" -eq 0 ]; then
+  if [ ! -d "$ROOT/release/markers" ]; then
+    fail "missing marker directory: $ROOT/release/markers"
+  fi
+  while IFS= read -r file; do
+    MARKER_FILES+=("$file")
+  done < <(find "$ROOT/release/markers" -type f -name '*.txt' | sort)
+fi
+
+FEATURES=()
+MARKERS=()
+for file in "${MARKER_FILES[@]}"; do
+  [ -f "$file" ] || fail "missing marker file: $file"
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line%$'\r'}"
+    [ -z "$line" ] && continue
+    case "$line" in \#*) continue ;; esac
+    feature="${line%%|*}"
+    marker="${line#*|}"
+    if [ "$feature" = "$line" ] || [ -z "$feature" ] || [ -z "$marker" ]; then
+      fail "invalid marker line in $file: $line"
+    fi
+    FEATURES+=("$feature")
+    MARKERS+=("$marker")
+  done < "$file"
+done
+
+[ "${#MARKERS[@]}" -gt 0 ] || fail "no markers loaded"
+
+source_has_marker() {
+  local src="$1"
+  local marker="$2"
+  grep -R -I -F -q \
+    --exclude-dir=.git \
+    --exclude-dir=.codex-backups \
+    --exclude-dir=.codex-build \
+    --exclude-dir=node_modules \
+    --exclude-dir=dist \
+    --exclude-dir=vendor \
+    -- "$marker" "$src" 2>/dev/null
+}
+
+image_payload() {
+  local image="$1"
+  local out="$2"
+  docker image inspect "$image" >/dev/null 2>&1 || docker pull "$image" >/dev/null
+  case "$PROJECT" in
+    gpt2api)
+      docker run --rm --entrypoint sh "$image" -c '
+        [ -f /app/gpt2api ] && strings /app/gpt2api 2>/dev/null || true
+        if [ -d /app/web/dist ]; then
+          find /app/web/dist -maxdepth 30 -type f -exec grep -a -h "" {} + 2>/dev/null || true
+        fi
+      ' > "$out"
+      ;;
+    sub2api)
+      docker run --rm --entrypoint sh "$image" -c '
+        [ -f /app/sub2api ] && strings /app/sub2api 2>/dev/null || true
+        for d in /app/resources /app/web/dist /app/backend/internal/web/dist; do
+          if [ -d "$d" ]; then
+            find "$d" -maxdepth 30 -type f -exec grep -a -h "" {} + 2>/dev/null || true
+          fi
+        done
+      ' > "$out"
+      ;;
+  esac
+}
+
+payload_has_marker() {
+  local payload="$1"
+  local marker="$2"
+  grep -F -q -- "$marker" "$payload"
+}
+
+emit_target_matrix() {
+  local target="$1"
+  local kind="${target%%:*}"
+  local value="${target#*:}"
+  local payload=""
+  local missing=0
+
+  case "$kind" in
+    source)
+      [ -d "$value" ] || fail "source target is not a directory: $value"
+      ;;
+    image)
+      payload="$(mktemp)"
+      image_payload "$value" "$payload"
+      ;;
+    *)
+      fail "target must be source:PATH or image:REF: $target"
+      ;;
+  esac
+
+  for i in "${!MARKERS[@]}"; do
+    status="-"
+    if [ "$kind" = "source" ]; then
+      if source_has_marker "$value" "${MARKERS[$i]}"; then status="Y"; fi
+    else
+      if payload_has_marker "$payload" "${MARKERS[$i]}"; then status="Y"; fi
+    fi
+    if [ "$status" = "-" ] && [ "$REQUIRE_ALL" -eq 1 ]; then missing=1; fi
+    printf '%s\t%s\t%s\t%s\n' "$target" "${FEATURES[$i]}" "${MARKERS[$i]}" "$status"
+  done
+
+  [ -z "$payload" ] || rm -f "$payload"
+  return "$missing"
+}
+
+run_compare() {
+  [ -n "$PREV_IMAGE" ] || fail "missing previous image"
+  [ -n "$CAND_IMAGE" ] || fail "missing candidate image"
+
+  local prev_payload cand_payload regressions
+  prev_payload="$(mktemp)"
+  cand_payload="$(mktemp)"
+  regressions=0
+  image_payload "$PREV_IMAGE" "$prev_payload"
+  image_payload "$CAND_IMAGE" "$cand_payload"
+
+  printf 'target\tfeature\tmarker\tstatus\n'
+  for i in "${!MARKERS[@]}"; do
+    prev="-"
+    cand="-"
+    payload_has_marker "$prev_payload" "${MARKERS[$i]}" && prev="Y"
+    payload_has_marker "$cand_payload" "${MARKERS[$i]}" && cand="Y"
+    printf 'image:%s\t%s\t%s\t%s\n' "$PREV_IMAGE" "${FEATURES[$i]}" "${MARKERS[$i]}" "$prev"
+    printf 'image:%s\t%s\t%s\t%s\n' "$CAND_IMAGE" "${FEATURES[$i]}" "${MARKERS[$i]}" "$cand"
+    if [ "$prev" = "Y" ] && [ "$cand" = "-" ]; then
+      echo "REGRESSION: candidate lost previous image marker: ${FEATURES[$i]} | ${MARKERS[$i]}" >&2
+      regressions=$((regressions + 1))
+    fi
+  done
+
+  rm -f "$prev_payload" "$cand_payload"
+  if [ "$regressions" -gt 0 ]; then
+    echo "REGRESSION: candidate lost previous image markers ($regressions)" >&2
+    return 42
+  fi
+}
+
+run_all() {
+  if [ "$COMPARE" -eq 1 ]; then
+    run_compare
+    return $?
+  fi
+
+  if [ "${#TARGETS[@]}" -eq 0 ]; then
+    TARGETS=("source:$ROOT")
+  fi
+
+  printf 'target\tfeature\tmarker\tstatus\n'
+  local missing=0
+  for target in "${TARGETS[@]}"; do
+    if ! emit_target_matrix "$target"; then
+      missing=1
+    fi
+  done
+  return "$missing"
+}
+
+if [ -n "$OUTPUT" ]; then
+  mkdir -p "$(dirname "$OUTPUT")"
+  run_all | tee "$OUTPUT"
+else
+  run_all
+fi

--- a/scripts/verify-release-manifest.sh
+++ b/scripts/verify-release-manifest.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  scripts/verify-release-manifest.sh MANIFEST.json [--project NAME] [--image IMAGE_REF]
+                                             [--require-ci] [--print-digest|--print-image-ref]
+USAGE
+}
+
+MANIFEST=""
+PROJECT=""
+IMAGE_REF=""
+REQUIRE_CI=0
+PRINT_MODE=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --project)
+      PROJECT="${2:-}"
+      shift 2
+      ;;
+    --image)
+      IMAGE_REF="${2:-}"
+      shift 2
+      ;;
+    --require-ci)
+      REQUIRE_CI=1
+      shift
+      ;;
+    --print-digest)
+      PRINT_MODE="digest"
+      shift
+      ;;
+    --print-image-ref)
+      PRINT_MODE="image_ref"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [ -z "$MANIFEST" ]; then
+        MANIFEST="$1"
+        shift
+      else
+        echo "[verify-release-manifest] ERROR: unknown argument: $1" >&2
+        exit 2
+      fi
+      ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || { usage >&2; exit 2; }
+[ -f "$MANIFEST" ] || { echo "[verify-release-manifest] ERROR: missing manifest: $MANIFEST" >&2; exit 2; }
+
+python3 - "$MANIFEST" "$PROJECT" "$IMAGE_REF" "$REQUIRE_CI" "$PRINT_MODE" <<'PY'
+import json
+import re
+import sys
+
+path, expected_project, expected_image, require_ci, print_mode = sys.argv[1:6]
+require_ci = require_ci == "1"
+
+with open(path, "r", encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+errors = []
+
+def need(name):
+    value = manifest.get(name)
+    if value in (None, "", [], {}):
+        errors.append(f"missing required field: {name}")
+    return value
+
+project = need("project")
+git_sha = need("git_sha")
+image = need("image")
+image_ref = need("image_ref")
+image_digest = need("image_digest")
+created_at = need("created_at")
+source = need("source")
+marker_matrix = need("marker_matrix")
+tests = need("tests")
+attestations = need("attestations")
+
+if expected_project and project != expected_project:
+    errors.append(f"project mismatch: manifest={project!r} expected={expected_project!r}")
+
+if isinstance(git_sha, str) and not re.fullmatch(r"[0-9a-fA-F]{40}", git_sha):
+    errors.append("git_sha must be a full 40-character commit SHA")
+
+if isinstance(image_digest, str) and not re.fullmatch(r"sha256:[0-9a-fA-F]{64}", image_digest):
+    errors.append("image_digest must be sha256:<64 hex chars>")
+
+if isinstance(image_ref, str):
+    if "@sha256:" not in image_ref:
+        errors.append("image_ref must be immutable and contain @sha256:")
+    if isinstance(image_digest, str) and not image_ref.endswith(image_digest):
+        errors.append("image_ref must end with image_digest")
+else:
+    errors.append("image_ref must be a string")
+
+if expected_image and image_ref != expected_image:
+    errors.append(f"image_ref mismatch: manifest={image_ref!r} expected={expected_image!r}")
+
+if require_ci:
+    if source != "github-actions":
+        errors.append("source must be github-actions when --require-ci is set")
+    if not manifest.get("ci_run_url"):
+        errors.append("ci_run_url is required when --require-ci is set")
+
+if isinstance(marker_matrix, dict):
+    regressions = marker_matrix.get("regressions", 0)
+    if isinstance(regressions, list) and regressions:
+        errors.append("marker_matrix.regressions must be empty")
+    if isinstance(regressions, int) and regressions != 0:
+        errors.append("marker_matrix.regressions must be 0")
+    if marker_matrix.get("status") not in ("success", "passed"):
+        errors.append("marker_matrix.status must be success or passed")
+else:
+    errors.append("marker_matrix must be an object")
+
+if isinstance(tests, list):
+    for item in tests:
+        if not isinstance(item, dict):
+            errors.append("tests entries must be objects")
+            continue
+        if item.get("status") != "success":
+            errors.append(f"test did not succeed: {item.get('name', '<unnamed>')}")
+elif isinstance(tests, dict):
+    for name, status in tests.items():
+        if status != "success":
+            errors.append(f"test did not succeed: {name}")
+else:
+    errors.append("tests must be a list or object")
+
+if isinstance(attestations, dict):
+    if attestations.get("sbom") is not True:
+        errors.append("attestations.sbom must be true")
+    if attestations.get("provenance") is not True:
+        errors.append("attestations.provenance must be true")
+else:
+    errors.append("attestations must be an object")
+
+if errors:
+    for err in errors:
+        print(f"[verify-release-manifest] ERROR: {err}", file=sys.stderr)
+    sys.exit(3)
+
+if print_mode == "digest":
+    print(image_digest)
+elif print_mode == "image_ref":
+    print(image_ref)
+else:
+    print(f"[verify-release-manifest] ok project={project} image_ref={image_ref} created_at={created_at}")
+PY


### PR DESCRIPTION
## Summary
- add release marker files and marker-matrix regression gate
- add release manifest verifier and digest-only deployment helper
- add production image workflow with source marker checks, image build, Trivy scan, SBOM/provenance/attestation, and release manifest artifact

## Validation
- bash -n scripts/marker-matrix.sh scripts/verify-release-manifest.sh scripts/deploy-by-digest.sh
- scripts/marker-matrix.sh --project sub2api --target source:. --require-all
- scripts/verify-release-manifest.sh sample manifest --project sub2api --require-ci

## Production policy
Deployments should use scripts/deploy-by-digest.sh with a CI-produced manifest and image@sha256 digest.