### PR TITLE
fix(payment): 订阅确认页显示换算后 CNY 金额 + 邀请返利按 USD price 计算

### DIFF
--- a/backend/internal/service/payment_fulfillment_test.go
+++ b/backend/internal/service/payment_fulfillment_test.go
@@ -602,8 +602,8 @@ func TestExecuteSubscriptionFulfillmentAppliesAffiliateRebate(t *testing.T) {
 		SetUserID(user.ID).
 		SetUserEmail(user.Email).
 		SetUserName(user.Username).
-		SetAmount(120).
-		SetPayAmount(120).
+		SetAmount(9.99).
+		SetPayAmount(71.36).
 		SetFeeRate(0).
 		SetRechargeCode("PAY-SUB-AFFILIATE").
 		SetOutTradeNo("sub2_subscription_affiliate").
@@ -636,7 +636,7 @@ func TestExecuteSubscriptionFulfillmentAppliesAffiliateRebate(t *testing.T) {
 	}
 	settingSvc := NewSettingService(&paymentFulfillmentSettingRepoStub{values: map[string]string{
 		SettingKeyAffiliateEnabled:           "true",
-		SettingKeyAffiliateRebateRate:        "20",
+		SettingKeyAffiliateRebateRate:        "15",
 		SettingKeyAffiliateRebateFreezeHours: "0",
 	}}, nil)
 	subRepo := newSubscriptionUserSubRepoStub()
@@ -659,7 +659,7 @@ func TestExecuteSubscriptionFulfillmentAppliesAffiliateRebate(t *testing.T) {
 	require.Len(t, affiliateRepo.accrueCalls, 1)
 	require.Equal(t, inviterID, affiliateRepo.accrueCalls[0].inviterID)
 	require.Equal(t, user.ID, affiliateRepo.accrueCalls[0].inviteeUserID)
-	require.Equal(t, 24.0, affiliateRepo.accrueCalls[0].amount)
+	require.InDelta(t, 1.4985, affiliateRepo.accrueCalls[0].amount, 0.00000001)
 	require.NotNil(t, affiliateRepo.accrueCalls[0].sourceOrderID)
 	require.Equal(t, order.ID, *affiliateRepo.accrueCalls[0].sourceOrderID)
 	require.Equal(t, 1, subRepo.createCalls)
@@ -668,8 +668,8 @@ func TestExecuteSubscriptionFulfillmentAppliesAffiliateRebate(t *testing.T) {
 		Where(paymentauditlog.OrderIDEQ(strconv.FormatInt(order.ID, 10)), paymentauditlog.ActionEQ("AFFILIATE_REBATE_APPLIED")).
 		Only(ctx)
 	require.NoError(t, err)
-	require.Contains(t, applied.Detail, `"baseAmount":120`)
-	require.Contains(t, applied.Detail, `"rebateAmount":24`)
+	require.Contains(t, applied.Detail, `"baseAmount":9.99`)
+	require.Contains(t, applied.Detail, `"rebateAmount":1.4985`)
 }
 
 func TestExecuteSubscriptionFulfillmentDoesNotDuplicateWorkAfterLegacySuccessAudit(t *testing.T) {

--- a/backend/internal/service/payment_order.go
+++ b/backend/internal/service/payment_order.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 	"github.com/Wei-Shaw/sub2api/internal/payment/provider"
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/shopspring/decimal"
 )
 
 // --- Order Creation ---
@@ -67,8 +68,7 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 			return nil, err
 		}
 	}
-	// 订阅套餐 price 是直付价，余额充值倍率只影响余额充值到账，不参与订阅 pay_amount 计算。
-	payAmountStr, payAmount, err := calculateCreateOrderPayAmount(limitAmount, feeRate, methodCurrency)
+	payAmountStr, payAmount, err := calculateCreateOrderPayAmountForOrderType(limitAmount, feeRate, methodCurrency, req.OrderType, cfg.BalanceRechargeMultiplier)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func (s *PaymentService) CreateOrder(ctx context.Context, req CreateOrderRequest
 		selectedCurrency = paymentProviderConfigCurrency(sel.ProviderKey, sel.Config)
 	}
 	if selectedCurrency != methodCurrency {
-		payAmountStr, payAmount, err = calculateCreateOrderPayAmount(limitAmount, feeRate, selectedCurrency)
+		payAmountStr, payAmount, err = calculateCreateOrderPayAmountForOrderType(limitAmount, feeRate, selectedCurrency, req.OrderType, cfg.BalanceRechargeMultiplier)
 		if err != nil {
 			return nil, err
 		}
@@ -628,6 +628,24 @@ func calculateCreateOrderPayAmount(limitAmount, feeRate float64, currency string
 			WithMetadata(map[string]string{"currency": currency})
 	}
 	return payAmountStr, payAmount, nil
+}
+
+func calculateCreateOrderPayAmountForOrderType(limitAmount, feeRate float64, currency, orderType string, multiplier float64) (string, float64, error) {
+	paymentAmount := limitAmount
+	if orderType == payment.OrderTypeSubscription {
+		paymentAmount = calculateSubscriptionGatewayBaseAmount(limitAmount, multiplier, currency)
+	}
+	return calculateCreateOrderPayAmount(paymentAmount, feeRate, currency)
+}
+
+func calculateSubscriptionGatewayBaseAmount(amount, multiplier float64, currency string) float64 {
+	if currency != payment.DefaultPaymentCurrency {
+		return amount
+	}
+	return decimal.NewFromFloat(amount).
+		Div(decimal.NewFromFloat(normalizeBalanceRechargeMultiplier(multiplier))).
+		Round(int32(payment.CurrencyMaxFractionDigits(currency))).
+		InexactFloat64()
 }
 
 func validateCreateOrderAmountCurrency(amount float64, currency string) error {

--- a/backend/internal/service/payment_order_result_test.go
+++ b/backend/internal/service/payment_order_result_test.go
@@ -161,27 +161,39 @@ func TestCalculateCreateOrderPayAmountUsesCurrencyPrecision(t *testing.T) {
 	}
 }
 
-func TestCalculateCreateOrderPayAmountForSubscriptionKeepsDirectPrice(t *testing.T) {
+func TestCalculateCreateOrderPayAmountForSubscriptionConvertsCNYPrice(t *testing.T) {
 	t.Parallel()
 
-	amountStr, amount, err := calculateCreateOrderPayAmount(5, 0, "CNY")
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrderType(9.99, 0, "CNY", payment.OrderTypeSubscription, 0.14)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if amountStr != "5.00" || amount != 5 {
-		t.Fatalf("subscription CNY pay amount = (%q, %v), want (5.00, 5)", amountStr, amount)
+	if amountStr != "71.36" || amount != 71.36 {
+		t.Fatalf("subscription CNY pay amount = (%q, %v), want (71.36, 71.36)", amountStr, amount)
 	}
 }
 
-func TestCalculateCreateOrderPayAmountForSubscriptionAppliesFeeToDirectPrice(t *testing.T) {
+func TestCalculateCreateOrderPayAmountForSubscriptionAppliesFeeAfterCNYConversion(t *testing.T) {
 	t.Parallel()
 
-	amountStr, amount, err := calculateCreateOrderPayAmount(5, 2.5, "CNY")
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrderType(9.99, 2.5, "CNY", payment.OrderTypeSubscription, 0.14)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if amountStr != "5.13" || amount != 5.13 {
-		t.Fatalf("subscription CNY pay amount with fee = (%q, %v), want (5.13, 5.13)", amountStr, amount)
+	if amountStr != "73.15" || amount != 73.15 {
+		t.Fatalf("subscription CNY pay amount with fee = (%q, %v), want (73.15, 73.15)", amountStr, amount)
+	}
+}
+
+func TestCalculateCreateOrderPayAmountForSubscriptionKeepsNonCNYPrice(t *testing.T) {
+	t.Parallel()
+
+	amountStr, amount, err := calculateCreateOrderPayAmountForOrderType(9.99, 0, "USD", payment.OrderTypeSubscription, 0.14)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if amountStr != "9.99" || amount != 9.99 {
+		t.Fatalf("subscription USD pay amount = (%q, %v), want (9.99, 9.99)", amountStr, amount)
 	}
 }
 

--- a/frontend/src/views/user/PaymentView.vue
+++ b/frontend/src/views/user/PaymentView.vue
@@ -283,7 +283,7 @@ import { platformAccentBarClass, platformBadgeLightClass, platformBadgeClass, pl
 import SubscriptionPlanCard from '@/components/payment/SubscriptionPlanCard.vue'
 import PaymentStatusPanel from '@/components/payment/PaymentStatusPanel.vue'
 import Icon from '@/components/icons/Icon.vue'
-import { formatPaymentAmount, normalizePaymentCurrency } from '@/components/payment/currency'
+import { DEFAULT_PAYMENT_CURRENCY, formatPaymentAmount, normalizePaymentCurrency } from '@/components/payment/currency'
 import type { PaymentMethodOption } from '@/components/payment/PaymentMethodSelector.vue'
 import { buildPaymentErrorToastMessage, describePaymentScenarioError } from './paymentUx'
 import { hasWechatResumeQuery, parseWechatResumeRoute, stripWechatResumeQuery } from './paymentWechatResume'
@@ -579,12 +579,17 @@ function ceilPaymentAmount(value: number, currency: string): number {
   return Math.ceil(value * factor) / factor
 }
 
+function subscriptionPaymentAmountForCurrency(value: number, currency: string): number {
+  if (currency !== DEFAULT_PAYMENT_CURRENCY) return roundPaymentAmount(value, currency)
+  return roundPaymentAmount(value / balanceRechargeMultiplier.value, currency)
+}
+
 function formatSelectedPaymentAmount(value: number): string {
   return formatPaymentAmount(value, selectedCurrency.value, localeCode.value)
 }
 
 function formatSelectedSubscriptionPaymentAmount(value: number): string {
-  return formatSelectedPaymentAmount(roundPaymentAmount(value, selectedCurrency.value))
+  return formatSelectedPaymentAmount(subscriptionPaymentAmountForCurrency(value, selectedCurrency.value))
 }
 
 const methodOptions = computed<PaymentMethodOption[]>(() =>
@@ -633,7 +638,7 @@ const canSubmit = computed(() =>
 
 const subPaymentAmount = computed(() => {
   const price = selectedPlan.value?.price ?? 0
-  return roundPaymentAmount(price, selectedCurrency.value)
+  return subscriptionPaymentAmountForCurrency(price, selectedCurrency.value)
 })
 
 const subFeeAmount = computed(() => {
@@ -647,7 +652,7 @@ const subTotalAmount = computed(() => {
 })
 
 function subscriptionTotalAmountForCurrency(value: number, currency: string): number {
-  const paymentAmount = roundPaymentAmount(value, currency)
+  const paymentAmount = subscriptionPaymentAmountForCurrency(value, currency)
   if (feeRate.value <= 0 || paymentAmount <= 0) return paymentAmount
   const fee = ceilPaymentAmount((paymentAmount * feeRate.value) / 100, currency)
   return roundPaymentAmount(paymentAmount + fee, currency)

--- a/frontend/src/views/user/__tests__/PaymentView.spec.ts
+++ b/frontend/src/views/user/__tests__/PaymentView.spec.ts
@@ -236,29 +236,28 @@ async function mountSubscriptionConfirm(options: Parameters<typeof checkoutInfoW
 }
 
 describe('PaymentView subscription confirmation amounts', () => {
-  it('keeps subscription plan price independent from balance recharge multiplier', async () => {
+  it('shows converted CNY pay amount for plan price, original price, and create button', async () => {
     const wrapper = await mountSubscriptionConfirm({
       checkout: {
-        balance_recharge_multiplier: 4,
+        balance_recharge_multiplier: 0.14,
       },
       method: {
         currency: 'CNY',
       },
       plan: {
-        price: 200,
-        original_price: 300,
+        price: 9.99,
+        original_price: 12.99,
       },
     })
 
     const text = wrapper.text()
-    const planPrice = formatPaymentAmount(200, 'CNY')
-    const originalPrice = formatPaymentAmount(300, 'CNY')
-    const convertedByRechargeMultiplier = formatPaymentAmount(50, 'CNY')
+    const convertedPrice = formatPaymentAmount(71.36, 'CNY')
+    const convertedOriginalPrice = formatPaymentAmount(92.79, 'CNY')
 
-    expect(text).toContain(planPrice)
-    expect(text).toContain(originalPrice)
-    expect(text).not.toContain(convertedByRechargeMultiplier)
-    expect(wrapper.findAll('button').some(button => button.text().includes(planPrice))).toBe(true)
+    expect(text).toContain(convertedPrice)
+    expect(text).toContain(convertedOriginalPrice)
+    expect(text).not.toContain(formatPaymentAmount(9.99, 'CNY'))
+    expect(wrapper.findAll('button').some(button => button.text().includes(convertedPrice))).toBe(true)
   })
 
   it('keeps plan price when multiplier is not configured or payment currency is not CNY', async () => {
@@ -294,26 +293,26 @@ describe('PaymentView subscription confirmation amounts', () => {
     expect(usdWrapper.text()).toContain(formatPaymentAmount(9.99, 'USD'))
   })
 
-  it('adds fee rate to the direct subscription plan price to match backend pay_amount', async () => {
+  it('adds fee rate after CNY multiplier conversion to match backend pay_amount', async () => {
     const wrapper = await mountSubscriptionConfirm({
       checkout: {
-        balance_recharge_multiplier: 4,
+        balance_recharge_multiplier: 0.14,
         recharge_fee_rate: 2.5,
       },
       method: {
         currency: 'CNY',
       },
       plan: {
-        price: 7.99,
+        price: 9.99,
       },
     })
 
     const text = wrapper.text()
-    const price = formatPaymentAmount(7.99, 'CNY')
-    const fee = formatPaymentAmount(0.20, 'CNY')
-    const total = formatPaymentAmount(8.19, 'CNY')
+    const convertedPrice = formatPaymentAmount(71.36, 'CNY')
+    const fee = formatPaymentAmount(1.79, 'CNY')
+    const total = formatPaymentAmount(73.15, 'CNY')
 
-    expect(text).toContain(price)
+    expect(text).toContain(convertedPrice)
     expect(text).toContain(fee)
     expect(text).toContain(total)
     expect(wrapper.findAll('button').some(button => button.text().includes(total))).toBe(true)


### PR DESCRIPTION
## 背景

Issue #3732 指出 0.1.142 存在两个连锁问题：订阅确认页在 CNY 支付通道下仍显示套餐 USD price（例如 `¥9.99`），而实际运营期望展示与支付宝/微信最终扣款一致的 CNY 实付金额（例如 `9.99 / 0.14 = ¥71.36`）；由于确认页显示错误，运营方被迫把套餐 `price` 填成 CNY 金额，进而导致邀请返利按该字段计算时被放大约 7 倍。

我先看了 930326116（`fix: 修复订阅支付金额显示错误`）：维护者当时的意图是让订阅展示金额、按钮金额、手续费和支付限额都来自同一个金额来源，避免把余额充值到账金额误当成订阅价格。这个 PR 不是简单 revert 930326116，而是在保留“同一来源一致展示”的基础上，把这个来源修正为 CNY 通道下的网关实付金额：订阅 `amount` 继续保留套餐 USD price，用于订单语义和返利基数；`pay_amount` / 前端确认页则按 CNY multiplier 换算并在换算后计算手续费。

## 改动

- 前端 `PaymentView.vue`：CNY 通道下订阅确认页、原价、支付按钮、手续费和方法限额统一使用 `price / balance_recharge_multiplier` 后的 CNY 实付金额；非 CNY 或 multiplier 未配置时仍显示原 price。
- 后端订单创建：订阅订单 CNY `pay_amount` 按 `price / balance_recharge_multiplier` 计算，并在换算后套用 `recharge_fee_rate`，与前端确认页保持一致；`PaymentOrder.Amount` 仍保存套餐 `price`。
- 邀请返利：确认现有返利入口使用 `PaymentOrder.Amount` 作为基数，本 PR 用 `amount=9.99, pay_amount=71.36` 的单测锁住该语义，避免返利按 CNY `pay_amount` 放大。

## 测试

- `cd frontend && pnpm install`：通过（pnpm 11 会提示 `package.json` 中 `pnpm.overrides` 已不再读取，但安装结果为 Already up to date）
- `cd frontend && ./node_modules/.bin/vitest run src/views/user/__tests__/PaymentView.spec.ts`：通过
- `cd frontend && pnpm typecheck`：通过
- `cd frontend && pnpm lint:check`：通过
- `cd frontend && pnpm build`：通过
- `cd frontend && pnpm test:run`：1 个无关失败，`src/components/account/__tests__/BulkEditAccountModal.spec.ts` 期望 `3.1-Flash-Image透传`，当前渲染为 `3.1-Flash-Image passthrough`；支付相关 `PaymentView.spec.ts` 通过
- `cd backend && go test -tags=unit ./...`：通过
- `cd backend && golangci-lint run ./...`：通过

Fixes #3732
