### PR TITLE
fix: add missing Codex CLI headers for OAuth account test

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -602,7 +602,11 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 		req.Header.Set("accept", "text/event-stream")
 		req.Header.Set("OpenAI-Beta", "responses=experimental")
 		req.Header.Set("Originator", "codex_cli_rs")
-		req.Header.Set("User-Agent", codexCLIUserAgent)
+		if customUA := strings.TrimSpace(credentialAccount.GetOpenAIUserAgent()); customUA != "" {
+			req.Header.Set("User-Agent", customUA)
+		} else {
+			req.Header.Set("User-Agent", codexCLIUserAgent)
+		}
 		setOpenAIChatGPTAccountHeaders(req.Header, credentialAccount)
 	}
 

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -600,6 +600,9 @@ func (s *AccountTestService) testOpenAIAccountConnection(c *gin.Context, account
 	if isOAuth {
 		req.Host = "chatgpt.com"
 		req.Header.Set("accept", "text/event-stream")
+		req.Header.Set("OpenAI-Beta", "responses=experimental")
+		req.Header.Set("Originator", "codex_cli_rs")
+		req.Header.Set("User-Agent", codexCLIUserAgent)
 		setOpenAIChatGPTAccountHeaders(req.Header, credentialAccount)
 	}
 


### PR DESCRIPTION
## Problem

When testing OpenAI OAuth/PAT accounts via the built-in account test feature (sending "hi"), the request to `chatgpt.com/backend-api/codex/responses` returns **401 Unauthorized**.

## Root Cause

The `testOpenAIAccountConnection` function in `account_test_service.go` sends OAuth account test requests to `chatgpt.com` but is missing three required Codex CLI identification headers:

- `Originator: codex_cli_rs`
- `User-Agent: codex_cli_rs/<version>` (`codexCLIUserAgent`)
- `OpenAI-Beta: responses=experimental`

Without these headers, chatgpt.com cannot identify the request as coming from an official Codex CLI client and rejects it with 401.

Both the **gateway Forward path** (`openai_gateway_service.go` ~line 3744) and the **compact test path** (`testOpenAICompactConnection` in the same file) already set these headers. Only the normal OAuth test path was missing them.

## Fix

Add the three headers inside the existing `if isOAuth { }` block in `testOpenAIAccountConnection`, matching the gateway and compact test behavior exactly.

## Scope

- OAuth/PAT accounts (OpenAI): fixed — now sends proper Codex CLI headers
- API Key accounts (OpenAI): unaffected — `isOAuth = false`, different code path to `api.openai.com`
- Claude, Gemini, Grok, Antigravity: unaffected — separate test functions
