### PR TITLE
fix(frontend): add compact probe mode to admin account test modal

### DIFF
--- a/frontend/src/components/admin/account/AccountTestModal.vue
+++ b/frontend/src/components/admin/account/AccountTestModal.vue
@@ -55,6 +55,17 @@
         />
       </div>
 
+      <div v-if="isOpenAIAccount" class="space-y-1.5">
+        <label class="text-sm font-medium text-gray-700 dark:text-gray-300">
+          {{ t('admin.accounts.openai.testMode') }}
+        </label>
+        <Select
+          v-model="testMode"
+          :options="openAITestModeOptions"
+          :disabled="status === 'connecting'"
+        />
+      </div>
+
       <div v-if="supportsImageTest" class="space-y-1.5">
         <TextArea
           v-model="testPrompt"
@@ -276,6 +287,12 @@ const loadingModels = ref(false)
 let abortController: AbortController | null = null
 const generatedImages = ref<PreviewImage[]>([])
 const previewImageUrl = ref('')
+const testMode = ref<'default' | 'compact'>('default')
+const isOpenAIAccount = computed(() => props.account?.platform === 'openai')
+const openAITestModeOptions = computed(() => [
+  { value: 'default', label: t('admin.accounts.openai.testModeDefault') },
+  { value: 'compact', label: t('admin.accounts.openai.testModeCompact') }
+])
 const prioritizedGeminiModels = ['gemini-3.1-flash-image', 'gemini-2.5-flash-image', 'gemini-3.5-flash', 'gemini-2.5-flash', 'gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3-pro-preview', 'gemini-2.0-flash']
 const supportsGeminiImageTest = computed(() => {
   const modelID = selectedModelId.value.toLowerCase()
@@ -309,6 +326,7 @@ watch(
   async (newVal) => {
     if (newVal && props.account) {
       testPrompt.value = ''
+      testMode.value = 'default'
       resetState()
       await loadAvailableModels()
     } else {
@@ -400,6 +418,18 @@ const startTest = async () => {
   abortController = new AbortController()
 
   try {
+    const requestBody: {
+      model_id: string
+      prompt: string
+      mode?: 'default' | 'compact'
+    } = {
+      model_id: selectedModelId.value,
+      prompt: supportsImageTest.value ? testPrompt.value.trim() : ''
+    }
+    if (isOpenAIAccount.value) {
+      requestBody.mode = testMode.value
+    }
+
     // Use the configured API base; EventSource does not support POST.
     const url = buildApiUrl(`/admin/accounts/${props.account.id}/test`)
 
@@ -410,10 +440,7 @@ const startTest = async () => {
         Authorization: `Bearer ${localStorage.getItem('auth_token')}`,
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify({
-              model_id: selectedModelId.value,
-              prompt: supportsImageTest.value ? testPrompt.value.trim() : ''
-            }),
+      body: JSON.stringify(requestBody),
       signal: abortController.signal
     })
 
@@ -502,6 +529,12 @@ const handleEvent = (event: {
           mimeType: event.mime_type
         })
         addLine(t('admin.accounts.imageReceived', { count: generatedImages.value.length }), 'text-purple-300')
+      }
+      break
+
+    case 'status':
+      if (event.text) {
+        addLine(event.text, 'text-cyan-300')
       }
       break
 

--- a/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
+++ b/frontend/src/components/admin/account/__tests__/AccountTestModal.spec.ts
@@ -182,4 +182,38 @@ describe('AccountTestModal', () => {
       prompt: ''
     })
   })
+
+  it('OpenAI Compact 探测会携带 compact 测试模式', async () => {
+    getAvailableModels.mockResolvedValue([
+      { id: 'gpt-5.4', display_name: 'GPT-5.4' }
+    ])
+    global.fetch = vi.fn().mockResolvedValue(
+      createStreamResponse([
+        'data: {"type":"test_complete","success":true}\n'
+      ])
+    ) as any
+
+    const wrapper = mountModal({
+      id: 42,
+      name: 'OpenAI OAuth',
+      platform: 'openai',
+      type: 'oauth',
+      status: 'active'
+    })
+    await wrapper.setProps({ show: true })
+    await flushPromises()
+
+    ;(wrapper.vm as any).selectedModelId = 'gpt-5.4'
+    ;(wrapper.vm as any).testMode = 'compact'
+    await (wrapper.vm as any).startTest()
+    await flushPromises()
+
+    expect(global.fetch).toHaveBeenCalledTimes(1)
+    const [, request] = (global.fetch as any).mock.calls[0]
+    expect(JSON.parse(request.body)).toMatchObject({
+      model_id: 'gpt-5.4',
+      prompt: '',
+      mode: 'compact'
+    })
+  })
 })


### PR DESCRIPTION
## 背景

修复 #1949。

当前后端 `POST /api/v1/admin/accounts/{id}/test` 已支持通过请求体传入 `mode: "compact"` 来触发 OpenAI Compact 探测；普通账号测试弹窗也已经有对应的测试模式入口。

但管理后台账号列表实际使用的 `components/admin/account/AccountTestModal.vue` 只提供测试模型选择，没有 OpenAI 测试模式选择，也不会把 `mode` 传给后端。因此在管理页点击“测试账号连接”时，无法通过 UI 主动触发 Compact 探测，只能手动调用接口。

## 修改

- 在管理页账号测试弹窗中，为 OpenAI 账号增加“测试模式”选择：
  - 常规请求
  - Compact 探测
- 打开测试弹窗时将测试模式重置为默认值，避免复用上一次选择。
- OpenAI 账号测试请求会携带 `mode: "default" | "compact"`。
- 非 OpenAI 账号测试请求保持原有 payload，不额外发送 `mode`。
- 同步处理后端 SSE 的 `status` 事件，用于展示探测过程状态。
- 为管理页 `AccountTestModal` 补充 OpenAI Compact 探测请求体测试。

## 兼容性说明

本次修复只同步管理页测试弹窗缺失的 OpenAI Compact 探测入口，不修改后端接口，也不改变 Gemini、Grok 等非 OpenAI 账号的测试请求结构。

## 测试

已在本地运行：

- `corepack pnpm@9 run test:run src/components/admin/account/__tests__/AccountTestModal.spec.ts`
- `corepack pnpm@9 run lint:check`
- `corepack pnpm@9 run typecheck`
- `corepack pnpm@9 run build`

结果均通过。构建过程中仅出现项目既有的 chunk / dynamic import / Browserslist 警告。
