### PR TITLE
chore: renew expired xlsx audit exceptions to 2026-10-06

### DIFF
--- a/.github/audit-exceptions.yml
+++ b/.github/audit-exceptions.yml
@@ -5,14 +5,14 @@ exceptions:
     severity: high
     reason: "Admin export only; switched to dynamic import to reduce exposure (CVE-2023-30533)"
     mitigation: "Load only on export; restrict export permissions and data scope"
-    expires_on: "2026-07-06"
+    expires_on: "2026-10-06"
     owner: "security@your-domain"
   - package: xlsx
     advisory: "GHSA-5pgg-2g8v-p4x9"
     severity: high
     reason: "Admin export only; switched to dynamic import to reduce exposure (CVE-2024-22363)"
     mitigation: "Load only on export; restrict export permissions and data scope"
-    expires_on: "2026-07-06"
+    expires_on: "2026-10-06"
     owner: "security@your-domain"
   - package: lodash
     advisory: "GHSA-r5fr-rjxr-66jc"


### PR DESCRIPTION
## 背景

CI 中 `tools/check_pnpm_audit_exceptions.py` 报错：

```
Exceptions expired:
- xlsx (high) [GHSA-4r6h-8v6p-xvw6] expired on 2026-07-06
- xlsx (high) [GHSA-5pgg-2g8v-p4x9] expired on 2026-07-06
```

## 修复

沿用既有惯例（参见 08b45442，上次同样续期 3 个月），将两条 xlsx 例外的 `expires_on` 从 `2026-07-06` 续期至 `2026-10-06`。

不升级 xlsx 的原因：npm registry 上的 xlsx 停更于 0.18.5，两个 GHSA 的修复版本（0.19.3 / 0.20.2+）只发布在 SheetJS 自有 CDN，切换依赖源属于独立的供应链决策，不在本次 CI 修复范围内。缓解措施不变：仅管理员导出场景使用、动态 import 按需加载。

## 提醒

- axios 例外（GHSA-3p68-rc4w-qgx5, critical）将于 **2026-07-10** 过期，届时 CI 会再次报错，需提前升级 axios 或续期。
- lodash / lodash-es 两条例外已于 2026-07-02 过期但未触发 CI（当前 audit 中已无对应漏洞），属于陈旧条目，可在后续清理。