### PR TITLE
fix(websearch): 剥离历史消息中上游不接受的 web search 块

### DIFF
--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -5105,6 +5105,13 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	if err := replaceBody(StripEmptyTextBlocks(body)); err != nil {
 		return nil, err
 	}
+	// Pre-filter: strip web-search history blocks the upstream cannot accept
+	// (emulation-synthesized server_tool_use / web_search_tool_result always;
+	// genuine ones additionally for passback-required upstreams). See
+	// FilterWebSearchHistoryBlocks. reqModel 此时已是映射后的模型 ID。
+	if err := replaceBody(FilterWebSearchHistoryBlocks(body, reqModel)); err != nil {
+		return nil, err
+	}
 	// Pre-filter: remove thinking blocks with missing/invalid signatures before forwarding.
 	// Clients (e.g. Claude Code) sometimes send multi-turn conversations where a historical
 	// assistant message contains a thinking block that is missing the required "signature" field,
@@ -5688,6 +5695,11 @@ func (s *GatewayService) forwardAnthropicAPIKeyPassthroughWithInput(
 	}
 	// Pre-filter: strip empty text blocks (including nested in tool_result) to prevent upstream 400.
 	input.Body = StripEmptyTextBlocks(input.Body)
+	// Pre-filter: strip web-search history blocks the upstream cannot accept
+	// (emulation-synthesized ones always; genuine ones additionally for
+	// passback-required third-party upstreams such as GLM/Kimi/DeepSeek,
+	// which reject server_tool_use with 400). input.RequestModel 已是映射后的模型 ID。
+	input.Body = FilterWebSearchHistoryBlocks(input.Body, input.RequestModel)
 	if input.Parsed != nil {
 		// 透传分支也会改写实际 wire body，成功 usage hash 依赖这里同步当前 body。
 		if err := input.Parsed.ReplaceBody(input.Body); err != nil {

--- a/backend/internal/service/gateway_websearch_block_filter.go
+++ b/backend/internal/service/gateway_websearch_block_filter.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"unsafe"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+const (
+	blockTypeServerToolUse       = "server_tool_use"
+	blockTypeWebSearchToolResult = "web_search_tool_result"
+)
+
+// Fast-path byte patterns: both block types only ever appear as quoted JSON
+// string values, so a raw substring check is a safe pre-filter regardless of
+// key/value spacing.
+var (
+	patternServerToolUse       = []byte(`"server_tool_use"`)
+	patternWebSearchToolResult = []byte(`"web_search_tool_result"`)
+)
+
+// FilterWebSearchHistoryBlocks removes web-search content blocks from
+// historical messages when the upstream cannot accept them:
+//
+//  1. Emulation-synthesized blocks — server_tool_use / web_search_tool_result
+//     whose tool-use ID carries webSearchToolUseIDPrefix — are fabricated
+//     locally by the web-search emulation (gateway_websearch_emulation.go).
+//     No upstream ever issued them, so clients replaying the conversation
+//     (e.g. Claude Code) poison every follow-up request. They are stripped
+//     for all upstreams.
+//  2. For passback-required upstreams (DeepSeek/Kimi/GLM …, see
+//     ResolveThinkingProtocol) all server_tool_use / web_search_tool_result
+//     blocks are stripped: these upstreams only accept
+//     text/thinking/image/tool_use/tool_result and reject anything else with
+//     400 "invalid value: `server_tool_use`". anthropic-strict and unknown
+//     upstreams keep genuine blocks untouched.
+//
+// The emulated assistant turn always carries a trailing text summary, so the
+// search context survives the strip. A message whose content would become
+// empty gets a placeholder text block (mirroring FilterThinkingBlocksForRetry).
+// Returns the original body unchanged when nothing needs stripping.
+func FilterWebSearchHistoryBlocks(body []byte, mappedModel string) []byte {
+	if !bytes.Contains(body, patternServerToolUse) && !bytes.Contains(body, patternWebSearchToolResult) {
+		return body
+	}
+
+	stripAll := ResolveThinkingProtocol(mappedModel) == ThinkingProtocolPassbackRequired
+
+	jsonStr := *(*string)(unsafe.Pointer(&body))
+	msgsRes := gjson.Get(jsonStr, "messages")
+	if !msgsRes.Exists() || !msgsRes.IsArray() {
+		return body
+	}
+
+	var messages []any
+	if err := json.Unmarshal(sliceRawFromBody(body, msgsRes), &messages); err != nil {
+		return body
+	}
+
+	modified := false
+	for _, msg := range messages {
+		msgMap, ok := msg.(map[string]any)
+		if !ok {
+			continue
+		}
+		content, ok := msgMap["content"].([]any)
+		if !ok {
+			continue
+		}
+
+		// 延迟分配：只有命中需剥离的块才构建新 slice。
+		var newContent []any
+		for i, block := range content {
+			blockMap, isMap := block.(map[string]any)
+			if isMap && shouldStripWebSearchBlock(blockMap, stripAll) {
+				if newContent == nil {
+					newContent = make([]any, 0, len(content))
+					newContent = append(newContent, content[:i]...)
+				}
+				continue
+			}
+			if newContent != nil {
+				newContent = append(newContent, block)
+			}
+		}
+		if newContent == nil {
+			continue
+		}
+		modified = true
+		if len(newContent) == 0 {
+			role, _ := msgMap["role"].(string)
+			placeholder := "(content removed)"
+			if role == "assistant" {
+				placeholder = "(assistant content removed)"
+			}
+			newContent = []any{map[string]any{"type": "text", "text": placeholder}}
+		}
+		msgMap["content"] = newContent
+	}
+
+	if !modified {
+		return body
+	}
+
+	msgsBytes, err := json.Marshal(messages)
+	if err != nil {
+		return body
+	}
+	out, err := sjson.SetRawBytes(body, "messages", msgsBytes)
+	if err != nil {
+		return body
+	}
+	return out
+}
+
+func shouldStripWebSearchBlock(block map[string]any, stripAll bool) bool {
+	blockType, _ := block["type"].(string)
+	switch blockType {
+	case blockTypeServerToolUse:
+		if stripAll {
+			return true
+		}
+		id, _ := block["id"].(string)
+		return strings.HasPrefix(id, webSearchToolUseIDPrefix)
+	case blockTypeWebSearchToolResult:
+		if stripAll {
+			return true
+		}
+		id, _ := block["tool_use_id"].(string)
+		return strings.HasPrefix(id, webSearchToolUseIDPrefix)
+	default:
+		return false
+	}
+}

--- a/backend/internal/service/gateway_websearch_block_filter_test.go
+++ b/backend/internal/service/gateway_websearch_block_filter_test.go
@@ -1,0 +1,140 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+// emulatedWebSearchBody is a follow-up /v1/messages request whose history
+// contains an assistant turn synthesized by the web-search emulation
+// (server_tool_use + web_search_tool_result with the local srvtoolu_ws_ ID
+// prefix, followed by the text summary).
+const emulatedWebSearchBody = `{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[` +
+	`{"role":"user","content":[{"type":"text","text":"search the weather"}]},` +
+	`{"role":"assistant","content":[` +
+	`{"type":"server_tool_use","id":"srvtoolu_ws_0123456789abcdef","name":"web_search","input":{"query":"weather"}},` +
+	`{"type":"web_search_tool_result","tool_use_id":"srvtoolu_ws_0123456789abcdef","content":[{"type":"web_search_result","url":"https://example.com","title":"Weather"}]},` +
+	`{"type":"text","text":"Here are the search results for \"weather\":"}]},` +
+	`{"role":"user","content":[{"type":"text","text":"thanks, continue"}]}]}`
+
+// genuineWebSearchBody carries real Anthropic web-search blocks (upstream IDs
+// do NOT have the local srvtoolu_ws_ prefix).
+const genuineWebSearchBody = `{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[` +
+	`{"role":"user","content":[{"type":"text","text":"search"}]},` +
+	`{"role":"assistant","content":[` +
+	`{"type":"server_tool_use","id":"srvtoolu_01ABCDEF","name":"web_search","input":{"query":"weather"}},` +
+	`{"type":"web_search_tool_result","tool_use_id":"srvtoolu_01ABCDEF","content":[{"type":"web_search_result","url":"https://example.com","title":"Weather"}]},` +
+	`{"type":"text","text":"summary with citations"}]}]}`
+
+func collectContentTypes(t *testing.T, body []byte) []string {
+	t.Helper()
+	var types []string
+	for _, msg := range gjson.GetBytes(body, "messages").Array() {
+		for _, block := range msg.Get("content").Array() {
+			types = append(types, block.Get("type").String())
+		}
+	}
+	return types
+}
+
+func TestFilterWebSearchHistoryBlocks_StripsEmulatedBlocksForAnthropicStrict(t *testing.T) {
+	out := FilterWebSearchHistoryBlocks([]byte(emulatedWebSearchBody), "claude-sonnet-4-6")
+
+	require.Equal(t, []string{"text", "text", "text"}, collectContentTypes(t, out))
+	// The emulated text summary must survive so the search context is preserved.
+	require.Contains(t, string(out), "Here are the search results")
+	require.NotContains(t, string(out), "srvtoolu_ws_")
+	require.True(t, gjson.ValidBytes(out))
+}
+
+func TestFilterWebSearchHistoryBlocks_KeepsGenuineBlocksForAnthropicStrict(t *testing.T) {
+	body := []byte(genuineWebSearchBody)
+	out := FilterWebSearchHistoryBlocks(body, "claude-sonnet-4-6")
+
+	require.Equal(t, string(body), string(out))
+}
+
+func TestFilterWebSearchHistoryBlocks_StripsAllBlocksForPassbackRequired(t *testing.T) {
+	// GLM only accepts text/thinking/image/tool_use/tool_result and rejects
+	// server_tool_use with 400, so genuine blocks must be stripped as well.
+	out := FilterWebSearchHistoryBlocks([]byte(genuineWebSearchBody), "glm-4.7")
+
+	require.Equal(t, []string{"text", "text"}, collectContentTypes(t, out))
+	require.NotContains(t, string(out), "server_tool_use")
+	require.NotContains(t, string(out), "web_search_tool_result")
+	require.Contains(t, string(out), "summary with citations")
+}
+
+func TestFilterWebSearchHistoryBlocks_StripsEmulatedBlocksForUnknownModel(t *testing.T) {
+	out := FilterWebSearchHistoryBlocks([]byte(emulatedWebSearchBody), "totally-unknown-model")
+
+	require.Equal(t, []string{"text", "text", "text"}, collectContentTypes(t, out))
+	require.NotContains(t, string(out), "srvtoolu_ws_")
+}
+
+func TestFilterWebSearchHistoryBlocks_KeepsGenuineBlocksForUnknownModel(t *testing.T) {
+	body := []byte(genuineWebSearchBody)
+	out := FilterWebSearchHistoryBlocks(body, "totally-unknown-model")
+
+	require.Equal(t, string(body), string(out))
+}
+
+func TestFilterWebSearchHistoryBlocks_NoWebSearchBlocksFastPath(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}]}`)
+	out := FilterWebSearchHistoryBlocks(body, "claude-sonnet-4-6")
+
+	require.Equal(t, string(body), string(out))
+}
+
+func TestFilterWebSearchHistoryBlocks_EmptiedMessageGetsPlaceholder(t *testing.T) {
+	body := []byte(`{"model":"glm-4.7","messages":[` +
+		`{"role":"user","content":[{"type":"text","text":"search"}]},` +
+		`{"role":"assistant","content":[` +
+		`{"type":"server_tool_use","id":"srvtoolu_01X","name":"web_search","input":{"query":"q"}},` +
+		`{"type":"web_search_tool_result","tool_use_id":"srvtoolu_01X","content":[]}]}]}`)
+
+	out := FilterWebSearchHistoryBlocks(body, "glm-4.7")
+
+	msgs := gjson.GetBytes(out, "messages").Array()
+	require.Len(t, msgs, 2)
+	assistant := msgs[1]
+	require.Equal(t, "assistant", assistant.Get("role").String())
+	content := assistant.Get("content").Array()
+	require.Len(t, content, 1)
+	require.Equal(t, "text", content[0].Get("type").String())
+	require.Equal(t, "(assistant content removed)", content[0].Get("text").String())
+}
+
+func TestFilterWebSearchHistoryBlocks_StringContentUntouched(t *testing.T) {
+	// A string mentioning the pattern inside a text value must not trigger a rewrite.
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":[` +
+		`{"role":"user","content":"please explain \"server_tool_use\" blocks"}]}`)
+
+	out := FilterWebSearchHistoryBlocks(body, "claude-sonnet-4-6")
+
+	require.Equal(t, string(body), string(out))
+}
+
+func TestFilterWebSearchHistoryBlocks_InvalidMessagesUnchanged(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","messages":"server_tool_use"}`)
+	out := FilterWebSearchHistoryBlocks(body, "claude-sonnet-4-6")
+
+	require.Equal(t, string(body), string(out))
+}
+
+func TestFilterWebSearchHistoryBlocks_PreservesOtherToolBlocks(t *testing.T) {
+	body := []byte(`{"model":"glm-4.7","messages":[` +
+		`{"role":"assistant","content":[` +
+		`{"type":"tool_use","id":"toolu_01A","name":"get_weather","input":{}},` +
+		`{"type":"server_tool_use","id":"srvtoolu_ws_abc","name":"web_search","input":{"query":"q"}},` +
+		`{"type":"text","text":"result"}]},` +
+		`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01A","content":"sunny"}]}]}`)
+
+	out := FilterWebSearchHistoryBlocks(body, "glm-4.7")
+
+	require.Equal(t, []string{"tool_use", "text", "tool_result"}, collectContentTypes(t, out))
+}


### PR DESCRIPTION
## 背景

修复 #3677。

Web Search 模拟（`gateway_websearch_emulation.go`）会在响应里合成 `server_tool_use` + `web_search_tool_result` + text 摘要三个内容块（tool use ID 使用本地前缀 `srvtoolu_ws_`）。客户端（Claude Code 等）会把这条 assistant 消息原样回传到后续 `/v1/messages` 请求的历史里，但转发路径没有任何清洗：

- 这两个块是网关本地伪造的，任何上游都没有签发过它们；
- GLM / Kimi / DeepSeek 等第三方 Anthropic 兼容上游只接受 `text`/`thinking`/`image`/`tool_use`/`tool_result`，直接 400：

```
API Error: 400 The parameter `messages.content.type` specified in the request are not valid:
invalid value: `server_tool_use`, supported values are: `text`, `thinking`, `image`, `tool_use` and `tool_result`.
```

会话历史被污染后每次请求都携带这些块，Claude Code 从此卡死在 400 上，无法自愈。

## 修改

- 新增 `FilterWebSearchHistoryBlocks(body, mappedModel)`（`gateway_websearch_block_filter.go`），复用 `StripEmptyTextBlocks` / `FilterThinkingBlocksForRetry` 的既有模式（fast-path 字节检查 → 只对 `messages` 子树做 Unmarshal/Marshal → 失败一律返回原 body 的 fail-safe）：
  - **模拟合成块**（tool use ID 带 `srvtoolu_ws_` 前缀）：对所有上游无条件剥离——它们是网关伪造的，官方 Anthropic 同样不认；
  - **真实 web search 块**（如上游真实签发的 `srvtoolu_*`）：仅当映射后模型属于 passback-required 协议族（复用 `ResolveThinkingProtocol`，即 GLM/Kimi/DeepSeek/MiniMax 等第三方兼容上游）时剥离；anthropic-strict 与 unknown 族保持原样，不误伤官方 web search 会话；
  - 模拟消息自带 text 摘要块，剥离后搜索上下文仍保留；若消息内容被剥空则填充占位 text 块（与 `FilterThinkingBlocksForRetry` 的处理一致）。
- 在两条转发路径的既有 pre-filter 区接入（与 `StripEmptyTextBlocks` 相邻，传入均为映射后模型 ID）：
  - Anthropic 通用转发路径（OAuth / 非透传 API Key）；
  - Anthropic API Key 透传分支（`forwardAnthropicAPIKeyPassthroughWithInput`）。

`/v1/messages` 入站打到 OpenAI 账号的路径（`AnthropicToResponses`）在块类型 switch 里本就静默忽略未知类型，不受此问题影响，故未改动。

## 兼容性说明

- 官方 Anthropic（OAuth / API Key）上游：真实 `server_tool_use` / `web_search_tool_result` 块原样保留，仅剥离本地模拟伪造块，行为无回归；
- 未识别协议族的模型保守处理，只剥离伪造块；
- body 中不含这两种块时走 fast path，原样返回，无额外开销。

## 测试

新增 `gateway_websearch_block_filter_test.go`，10 个用例覆盖：

- anthropic-strict 模型剥离模拟块、保留真实块；
- passback-required（`glm-4.7`）剥离全部 web search 块、保留 text/`tool_use`/`tool_result`；
- unknown 模型仅剥离模拟块;
- 剥空消息填充占位块；
- fast path、字符串 content、非法 `messages` 结构 fail-safe 原样返回。

本地已运行：

- `go build ./...`
- `go test -tags=unit ./...`
- `go vet ./internal/service/`
