### PR TITLE
fix(responses): 本地拒绝非法 reasoning.effort 枚举值

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -237,6 +237,22 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		return
 	}
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
+	// 本地校验 reasoning.effort 枚举：非法值转发上游只会换回 400 invalid_value，
+	// 白耗一次上游调用且被误归类为 upstream error（#3782）。
+	if invalidEffort, effortOK := service.ValidateOpenAIResponsesReasoningEffort(body); !effortOK {
+		reqLog.Warn("openai.request_validation_failed",
+			zap.String("reason", "invalid_reasoning_effort"),
+		)
+		c.JSON(http.StatusBadRequest, gin.H{
+			"error": gin.H{
+				"type":    "invalid_request_error",
+				"code":    "invalid_value",
+				"param":   "reasoning.effort",
+				"message": service.OpenAIReasoningEffortInvalidValueMessage(invalidEffort),
+			},
+		})
+		return
+	}
 	previousResponseID := strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String())
 	if previousResponseID != "" {
 		previousResponseIDKind := service.ClassifyOpenAIPreviousResponseIDKind(previousResponseID)

--- a/backend/internal/service/openai_reasoning_effort_validation.go
+++ b/backend/internal/service/openai_reasoning_effort_validation.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+// openAIReasoningEffortAllowedValues 与 OpenAI Responses API 对齐的
+// reasoning.effort 枚举：none/minimal/low/medium/high/xhigh。
+var openAIReasoningEffortAllowedValues = map[string]struct{}{
+	"none":    {},
+	"minimal": {},
+	"low":     {},
+	"medium":  {},
+	"high":    {},
+	"xhigh":   {},
+}
+
+// ValidateOpenAIResponsesReasoningEffort 校验 /v1/responses 请求体里显式携带的
+// reasoning.effort 枚举值，返回 (invalidValue, ok)。
+//
+// 非法枚举值（如拼写错误 "xhign"）属于客户端请求错误：转发只会消耗一次上游
+// 调用并换回 400 invalid_value，且在网关侧被归类为 upstream error，误导排障
+// （#3782）。在本地直接拒绝可以把错误留在正确的归属方。
+//
+// 保守边界：
+//   - 字段缺失、非字符串类型不在本校验范围（维持原转发行为，语义交由上游）；
+//   - 大小写变体（如 "High"）小写化后命中枚举的不拒绝，仍交由上游裁决，
+//     避免对上游大小写宽容度做过强假设；只有小写化后仍不在枚举内的值
+//     （任何上游都不可能接受）才本地拒绝。
+func ValidateOpenAIResponsesReasoningEffort(body []byte) (invalidValue string, ok bool) {
+	effort := gjson.GetBytes(body, "reasoning.effort")
+	if !effort.Exists() || effort.Type != gjson.String {
+		return "", true
+	}
+	value := effort.String()
+	if _, allowed := openAIReasoningEffortAllowedValues[strings.ToLower(strings.TrimSpace(value))]; allowed {
+		return "", true
+	}
+	return value, false
+}
+
+// OpenAIReasoningEffortInvalidValueMessage 构造与 OpenAI 上游一致的
+// invalid_value 错误文案。回显值做长度截断，避免恶意超长值放大响应。
+func OpenAIReasoningEffortInvalidValueMessage(invalidValue string) string {
+	const maxEcho = 64
+	if len(invalidValue) > maxEcho {
+		invalidValue = invalidValue[:maxEcho] + "..."
+	}
+	return "Invalid value: '" + invalidValue + "'. Supported values are: 'none', 'minimal', 'low', 'medium', 'high', and 'xhigh'."
+}

--- a/backend/internal/service/openai_reasoning_effort_validation_test.go
+++ b/backend/internal/service/openai_reasoning_effort_validation_test.go
@@ -1,0 +1,59 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOpenAIResponsesReasoningEffort_AllowsValidValues(t *testing.T) {
+	for _, effort := range []string{"none", "minimal", "low", "medium", "high", "xhigh"} {
+		body := []byte(`{"model":"gpt-5.5","reasoning":{"effort":"` + effort + `"},"input":"hi"}`)
+		invalid, ok := ValidateOpenAIResponsesReasoningEffort(body)
+		require.True(t, ok, "expected %q to pass validation", effort)
+		require.Empty(t, invalid)
+	}
+}
+
+func TestValidateOpenAIResponsesReasoningEffort_RejectsTypo(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":true,"reasoning":{"effort":"xhign"},"input":[{"role":"user","content":"hello"}]}`)
+
+	invalid, ok := ValidateOpenAIResponsesReasoningEffort(body)
+
+	require.False(t, ok)
+	require.Equal(t, "xhign", invalid)
+}
+
+func TestValidateOpenAIResponsesReasoningEffort_MissingOrNonStringSkipped(t *testing.T) {
+	cases := []string{
+		`{"model":"gpt-5.5","input":"hi"}`,                             // 无 reasoning
+		`{"model":"gpt-5.5","reasoning":{},"input":"hi"}`,              // 无 effort
+		`{"model":"gpt-5.5","reasoning":{"effort":3},"input":"hi"}`,    // 非字符串类型交由上游
+		`{"model":"gpt-5.5","reasoning":{"effort":null},"input":"hi"}`, // null 交由上游
+	}
+	for _, body := range cases {
+		_, ok := ValidateOpenAIResponsesReasoningEffort([]byte(body))
+		require.True(t, ok, "expected body to skip validation: %s", body)
+	}
+}
+
+func TestValidateOpenAIResponsesReasoningEffort_CaseVariantsForwarded(t *testing.T) {
+	// 大小写变体小写化后命中枚举 → 不本地拒绝，交由上游裁决。
+	body := []byte(`{"model":"gpt-5.5","reasoning":{"effort":"High"},"input":"hi"}`)
+
+	_, ok := ValidateOpenAIResponsesReasoningEffort(body)
+
+	require.True(t, ok)
+}
+
+func TestOpenAIReasoningEffortInvalidValueMessage(t *testing.T) {
+	msg := OpenAIReasoningEffortInvalidValueMessage("xhign")
+	require.Equal(t, "Invalid value: 'xhign'. Supported values are: 'none', 'minimal', 'low', 'medium', 'high', and 'xhigh'.", msg)
+
+	long := OpenAIReasoningEffortInvalidValueMessage(strings.Repeat("a", 200))
+	require.Contains(t, long, strings.Repeat("a", 64)+"...")
+	require.NotContains(t, long, strings.Repeat("a", 65))
+}


### PR DESCRIPTION
## 背景

修复 #3782。

客户端向 `/v1/responses` 发送拼写错误的 `reasoning.effort`（如 `"xhign"`）时，Sub2API 原样转发到上游，上游返回 400 `invalid_value`。这白耗一次上游调用，且在网关侧表现为 upstream error，容易被误判为上游或账号问题。

## 修改

- 新增 `ValidateOpenAIResponsesReasoningEffort(body)`（`openai_reasoning_effort_validation.go`）：用 gjson 提取 `reasoning.effort`，校验是否在 OpenAI Responses API 枚举内（`none`/`minimal`/`low`/`medium`/`high`/`xhigh`）。
  - 保守边界：字段缺失、非字符串类型不拒绝（维持原转发行为，语义交由上游）；大小写变体（如 `"High"`）小写化后命中枚举的不拒绝，仅小写化后仍不在枚举内的值才本地拒绝。
  - 回显值长度截断至 64 字符，避免恶意超长值放大响应。
- 在 `/v1/responses` handler 入口（`openai_gateway_handler.go`，与 `previous_response_id` 校验同列）接入校验：非法值直接 400 + 与上游一致的错误结构（含 `code`/`param`/`message` 三字段），沿用 `openai.request_validation_failed` 日志标签。

## 兼容性说明

- 合法枚举值（含大小写变体）：行为不变，正常转发；
- 字段缺失 / 非字符串类型：行为不变，正常转发；
- 非法枚举值（今天就是 400）：由上游 400 变为网关本地 400，错误结构更完整（多了 `code` + `param`），错误归属从 upstream error 正确归位到 client request error。

## 测试

新增 `openai_reasoning_effort_validation_test.go`，5 个用例：

- 6 个合法值全部通过；
- 拼写错误 `"xhign"` 被正确拦截；
- 字段缺失 / 空对象 / 非字符串 / null 均跳过校验；
- 大小写变体 `"High"` 不拦截；
- 超长值回显截断。

本地已运行：

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `golangci-lint run --timeout=30m ./internal/service/... ./internal/handler/...`