### PR TITLE
fix(codex): 剥离续链 function_call item 的非法 item_* id

### DIFF
--- a/backend/internal/service/openai_codex_function_call_id_test.go
+++ b/backend/internal/service/openai_codex_function_call_id_test.go
@@ -1,0 +1,136 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterCodexInput_StripsFunctionCallItemID_WhenPreservingReferences
+// verifies that function_call items with non-fc id (e.g. item_*) have their
+// id stripped even when PreserveReferences is true. OpenAI upstream requires
+// function_call ids to begin with "fc" and rejects item_* with 400:
+// "Expected an ID that begins with 'fc'." (#3785)
+func TestFilterCodexInput_StripsFunctionCallItemID_WhenPreservingReferences(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type":    "function_call",
+			"id":      "item_A9v0SNfS3VaLrfX0j3y4xhyK",
+			"call_id": "fc_abc123",
+			"name":    "bash",
+		},
+		map[string]any{
+			"type":    "function_call_output",
+			"call_id": "fc_abc123",
+			"output":  "done",
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 2)
+
+	fc, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "function_call", fc["type"])
+	_, hasID := fc["id"]
+	require.False(t, hasID, "item_* id should be stripped from function_call")
+	require.Equal(t, "fc_abc123", fc["call_id"], "call_id must be preserved")
+	require.Equal(t, "bash", fc["name"])
+}
+
+// TestFilterCodexInput_KeepsFcID_WhenPreservingReferences
+// verifies that function_call items with a valid fc* id are kept when
+// PreserveReferences is true.
+func TestFilterCodexInput_KeepsFcID_WhenPreservingReferences(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type":    "function_call",
+			"id":      "fc_validID123",
+			"call_id": "fc_validID123",
+			"name":    "bash",
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 1)
+	fc, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "fc_validID123", fc["id"], "valid fc* id must be preserved")
+}
+
+// TestFilterCodexInput_StripsItemIDFromAllToolCallInputTypes verifies that
+// item_* ids are stripped from all call-input types (not output types).
+func TestFilterCodexInput_StripsItemIDFromAllToolCallInputTypes(t *testing.T) {
+	types := []string{"function_call", "tool_call", "local_shell_call", "custom_tool_call", "mcp_tool_call"}
+
+	for _, typ := range types {
+		input := []any{
+			map[string]any{
+				"type":    typ,
+				"id":      "item_xyz",
+				"call_id": "fc_001",
+				"name":    "tool",
+			},
+		}
+		filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+			PreserveReferences: true,
+		})
+		require.Len(t, filtered, 1)
+		item, ok := filtered[0].(map[string]any)
+		require.True(t, ok)
+		_, hasID := item["id"]
+		require.False(t, hasID, "item_* id should be stripped from %s", typ)
+	}
+}
+
+// TestFilterCodexInput_OutputTypeKeepsItemID ensures tool-output items
+// (e.g. function_call_output) keep their id — only call-input types have
+// the fc* constraint.
+func TestFilterCodexInput_OutputTypeKeepsItemID(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type":    "function_call_output",
+			"id":      "o1",
+			"call_id": "fc_abc",
+			"output":  "done",
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 1)
+	out, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "o1", out["id"], "output item id should be preserved")
+}
+
+// TestFilterCodexInput_NonToolCallItemKeepsID ensures non-tool-call items
+// (e.g. message) still keep their id when PreserveReferences is true.
+func TestFilterCodexInput_NonToolCallItemKeepsID(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type": "message",
+			"id":   "item_msg_001",
+			"role": "user",
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 1)
+	msg, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "item_msg_001", msg["id"], "non-tool-call items keep their id in preserve mode")
+}

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1303,6 +1303,16 @@ func filterCodexInputWithOptions(input []any, opts codexInputFilterOptions) []an
 		if !opts.PreserveReferences {
 			ensureCopy()
 			delete(newItem, "id")
+		} else if isCodexToolCallInputType(typ) {
+			// 续链模式下保留 id 以维持上下文引用，但 function_call 等
+			// call-input 类 item 的 id 必须以 "fc" 开头（上游校验
+			// "Expected an ID that begins with 'fc'"）。item_* 形式的 id
+			// 来自客户端回放，需要删除。
+			// 注意：function_call_output 等 output 类的 id 无此约束，不动。
+			if id, ok := m["id"].(string); ok && id != "" && !strings.HasPrefix(id, "fc") {
+				ensureCopy()
+				delete(newItem, "id")
+			}
 		}
 
 		filtered = append(filtered, newItem)
@@ -1322,6 +1332,22 @@ func isCodexToolCallItemType(typ string) bool {
 		"mcp_tool_call_output",
 		"custom_tool_call_output",
 		"tool_search_output":
+		return true
+	default:
+		return false
+	}
+}
+
+// isCodexToolCallInputType 仅匹配 call-input 类型（不含 output），这些类型的
+// id 必须以 "fc" 开头，上游会校验 "Expected an ID that begins with 'fc'."。
+func isCodexToolCallInputType(typ string) bool {
+	switch typ {
+	case "function_call",
+		"tool_call",
+		"local_shell_call",
+		"tool_search_call",
+		"custom_tool_call",
+		"mcp_tool_call":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## 背景

修复 #3785。

OpenAI OAuth 路径下，工具续链请求的 `function_call` input item 携带 `item_*` 形式的 `id` 时，上游返回 400：

```
Invalid 'input[1].id': 'item_A9v0SNfS3VaLrfX0j3y4xhyK'. Expected an ID that begins with 'fc'.
```

## 根因

`filterCodexInputWithOptions`（`openai_codex_transform.go`）在续链模式（`PreserveReferences=true`）下，1303-1306 行对非 `reasoning` / 非 `item_reference` 的通用 item 保留 `id` 字段。这对 `message` 等类型是正确的，但 `function_call` 类 item 的 `id` 有额外约束：上游要求以 `fc` 开头，而客户端回放的 `item_*` id 不满足。

现有的 `call_id` 修正逻辑（1263-1280 行，`call_*` → `fc_*`）只处理了 `call_id` 字段，没有覆盖 `id` 字段。

## 修改

在通用 `id` 保留逻辑（原 1303 行）增加一个分支：当 `PreserveReferences=true` 且 item 是 `function_call` 类（`isCodexToolCallItemType`）时，检查 `id` 是否以 `fc` 开头——不是则删除。

选择 `delete` 而非转换成 `fc_item_xxx`：`item_*` 不含有效的 function call 语义，转成 `fc_` 前缀的假 id 可能命中上游的 id 查找逻辑引发新问题（与 `reasoning` 项剥离 `rs_*` id 的处理一致）。

## 兼容性说明

- `fc*` 开头的合法 id：保留不变；
- `item_*` 开头的非法 id（今天必然 400）：删除后上游不再拒绝，续链恢复正常；
- `call_id` 字段：不受影响（独立字段，已有修正逻辑）；
- 非 tool-call 类 item（`message` / `text` 等）：保留原样，不受此改动影响；
- `PreserveReferences=false` 路径：原本就删除所有 `id`，不受影响。

## 测试

新增 `openai_codex_function_call_id_test.go`，4 个用例：

- `function_call` 的 `item_*` id 在 preserve 模式下被剥离，`call_id` 和 `name` 保留；
- `function_call` 的 `fc_*` id 在 preserve 模式下保留不变；
- 所有 tool-call 类型（`function_call`/`tool_call`/`local_shell_call`/`custom_tool_call`）的 `item_*` id 均被剥离；
- 非 tool-call 类型（`message`）在 preserve 模式下保留 `id`。

本地已运行：

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `golangci-lint run --timeout=30m ./internal/service/...`
