### PR TITLE
fix(image): 识别 Codex namespace image_gen 工具声明以拦截生图请求

### DIFF
--- a/backend/internal/service/image_generation_intent.go
+++ b/backend/internal/service/image_generation_intent.go
@@ -39,6 +39,9 @@ func IsImageGenerationIntent(endpoint string, requestedModel string, body []byte
 	if openAIJSONToolsContainImageGeneration(gjson.GetBytes(body, "tools")) {
 		return true
 	}
+	if openAIJSONInputContainsImageGenTool(gjson.GetBytes(body, "input")) {
+		return true
+	}
 	return openAIJSONToolChoiceSelectsImageGeneration(gjson.GetBytes(body, "tool_choice"))
 }
 
@@ -94,7 +97,48 @@ func openAIJSONToolsContainImageGeneration(tools gjson.Result) bool {
 			found = true
 			return false
 		}
+		if isImageGenNamespaceTool(item) {
+			found = true
+			return false
+		}
 		return true
+	})
+	return found
+}
+
+// isImageGenNamespaceTool detects the Codex namespace-style image generation
+// tool declaration: { "type": "namespace", "name": "image_gen", ... }.
+// Codex /image uses this instead of the flat { "type": "image_generation" }.
+func isImageGenNamespaceTool(tool gjson.Result) bool {
+	return openAIJSONString(tool.Get("type")) == "namespace" &&
+		openAIJSONString(tool.Get("name")) == "image_gen"
+}
+
+// openAIJSONInputContainsImageGenTool scans Responses input items for
+// additional_tools entries that declare the image_gen namespace. This covers
+// the "Responses Lite" format where tools are embedded inside input items
+// rather than top-level tools.
+func openAIJSONInputContainsImageGenTool(input gjson.Result) bool {
+	if !input.IsArray() {
+		return false
+	}
+	found := false
+	input.ForEach(func(_, item gjson.Result) bool {
+		if openAIJSONString(item.Get("type")) != "additional_tools" {
+			return true
+		}
+		tools := item.Get("tools")
+		if !tools.IsArray() {
+			return true
+		}
+		tools.ForEach(func(_, tool gjson.Result) bool {
+			if isImageGenNamespaceTool(tool) {
+				found = true
+				return false
+			}
+			return true
+		})
+		return !found
 	})
 	return found
 }

--- a/backend/internal/service/image_generation_intent_test.go
+++ b/backend/internal/service/image_generation_intent_test.go
@@ -55,11 +55,84 @@ func TestIsImageGenerationIntent(t *testing.T) {
 			body:     []byte(`{"model":"gpt-5.4","input":"write code"}`),
 			want:     false,
 		},
+		{
+			name:     "namespace image_gen tool in top-level tools",
+			endpoint: "/v1/responses",
+			model:    "gpt-5.5",
+			body:     []byte(`{"model":"gpt-5.5","tools":[{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]}]}`),
+			want:     true,
+		},
+		{
+			name:     "namespace image_gen in input additional_tools (Responses Lite)",
+			endpoint: "/v1/responses",
+			model:    "gpt-5.5",
+			body:     []byte(`{"model":"gpt-5.5","input":[{"type":"additional_tools","role":"developer","tools":[{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]}]}]}`),
+			want:     true,
+		},
+		{
+			name:     "non-image namespace tool is not flagged",
+			endpoint: "/v1/responses",
+			model:    "gpt-5.5",
+			body:     []byte(`{"model":"gpt-5.5","tools":[{"type":"namespace","name":"code_tools","tools":[{"type":"function","name":"run"}]}]}`),
+			want:     false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, IsImageGenerationIntent(tt.endpoint, tt.model, tt.body))
+		})
+	}
+}
+
+func TestIsImageGenerationIntentMap_NamespaceImageGen(t *testing.T) {
+	tests := []struct {
+		name    string
+		reqBody map[string]any
+		want    bool
+	}{
+		{
+			name: "top-level namespace image_gen",
+			reqBody: map[string]any{
+				"model": "gpt-5.5",
+				"tools": []any{
+					map[string]any{"type": "namespace", "name": "image_gen", "tools": []any{
+						map[string]any{"type": "function", "name": "imagegen"},
+					}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "additional_tools in input",
+			reqBody: map[string]any{
+				"model": "gpt-5.5",
+				"input": []any{
+					map[string]any{
+						"type": "additional_tools",
+						"tools": []any{
+							map[string]any{"type": "namespace", "name": "image_gen"},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "non-image namespace not flagged",
+			reqBody: map[string]any{
+				"model": "gpt-5.5",
+				"tools": []any{
+					map[string]any{"type": "namespace", "name": "code_tools"},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsImageGenerationIntentMap("/v1/responses", "gpt-5.5", tt.reqBody))
 		})
 	}
 }

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -593,8 +593,14 @@ func isCodexSparkModel(model string) bool {
 }
 
 func hasOpenAIImageGenerationTool(reqBody map[string]any) bool {
-	rawTools, ok := reqBody["tools"]
-	if !ok || rawTools == nil {
+	if toolsContainImageGeneration(reqBody["tools"]) {
+		return true
+	}
+	return inputContainsImageGenNamespace(reqBody["input"])
+}
+
+func toolsContainImageGeneration(rawTools any) bool {
+	if rawTools == nil {
 		return false
 	}
 	tools, ok := rawTools.([]any)
@@ -607,6 +613,34 @@ func hasOpenAIImageGenerationTool(reqBody map[string]any) bool {
 			continue
 		}
 		if strings.TrimSpace(firstNonEmptyString(toolMap["type"])) == "image_generation" {
+			return true
+		}
+		if isImageGenNamespaceToolMap(toolMap) {
+			return true
+		}
+	}
+	return false
+}
+
+func isImageGenNamespaceToolMap(tool map[string]any) bool {
+	return strings.TrimSpace(firstNonEmptyString(tool["type"])) == "namespace" &&
+		strings.TrimSpace(firstNonEmptyString(tool["name"])) == "image_gen"
+}
+
+func inputContainsImageGenNamespace(rawInput any) bool {
+	input, ok := rawInput.([]any)
+	if !ok {
+		return false
+	}
+	for _, rawItem := range input {
+		item, ok := rawItem.(map[string]any)
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(firstNonEmptyString(item["type"])) != "additional_tools" {
+			continue
+		}
+		if toolsContainImageGeneration(item["tools"]) {
 			return true
 		}
 	}


### PR DESCRIPTION
## 背景

修复 #3608。

分组 `allow_image_generation=false` 时，Codex `/image` 技能仍可成功出图。原因是 Codex 的 `/image` 走的不是 `{"type":"image_generation"}` 这种扁平工具声明，而是两种新格式：

1. **顶层 namespace 工具**：`tools[].type == "namespace"` + `name == "image_gen"`，内嵌 `imagegen` function；
2. **Responses Lite**：`input[].type == "additional_tools"`，其内嵌的 `tools` 数组同样使用 namespace 格式。

现有 `IsImageGenerationIntent` 及 map 版 `IsImageGenerationIntentMap` 只识别 `tools[].type == "image_generation"`，对以上两种格式完全无感。

## 修改

- **gjson 路径**（`image_generation_intent.go`）：
  - `openAIJSONToolsContainImageGeneration` 增加 `isImageGenNamespaceTool` 检测（`type=="namespace"` && `name=="image_gen"`）；
  - 新增 `openAIJSONInputContainsImageGenTool` 扫描 `input[].type=="additional_tools"` 内嵌的 tools 数组；
  - `IsImageGenerationIntent` 接入 input 扫描。

- **map 路径**（`openai_codex_transform.go`）：
  - `hasOpenAIImageGenerationTool` 拆分为 `toolsContainImageGeneration`（复用于顶层 tools 和嵌套 tools）+ `inputContainsImageGenNamespace`；
  - 新增 `isImageGenNamespaceToolMap` 做 map 版 namespace 判定。

两条路径的检测逻辑保持对称。

## 兼容性说明

- `{"type":"image_generation"}` 扁平工具声明：检测不变；
- `gpt-image-*` 模型 / `/v1/images/*` 端点 / `tool_choice.type=="image_generation"`：检测不变；
- 其他 namespace 工具（如 `code_tools`）：不触发生图检测，有测试覆盖；
- `allow_image_generation=true` 的分组：行为不变，检测结果不影响放行逻辑。

## 测试

在既有 `TestIsImageGenerationIntent` 表驱动用例中追加 3 个新场景 + 新增 `TestIsImageGenerationIntentMap_NamespaceImageGen` 共 3 个子用例：

- 顶层 namespace `image_gen` 工具被识别；
- `input[].additional_tools` 嵌套的 namespace `image_gen` 被识别；
- 非 `image_gen` 的 namespace 工具不误判（`code_tools`）；
- map 版本与 gjson 版本行为对称。

本地已运行：

- `go build ./...`
- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `go vet ./internal/service/`
- `golangci-lint run --timeout=30m ./internal/service/...`