### PR TITLE
fix(frontend): 路由切换后保持侧边栏滚动位置

### DIFF
--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -30,7 +30,7 @@
     </div>
 
     <!-- Navigation -->
-    <nav class="sidebar-nav scrollbar-hide">
+    <nav ref="sidebarNavRef" class="sidebar-nav scrollbar-hide">
       <!-- Admin View: Admin menu first, then personal menu -->
       <template v-if="isAdmin">
         <!-- Admin Section -->
@@ -188,7 +188,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, h, onMounted, ref, watch } from 'vue'
+import { computed, h, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { useAdminSettingsStore, useAppStore, useAuthStore, useOnboardingStore } from '@/stores'
@@ -246,6 +246,7 @@ const { canUseBatchImage, refreshBatchImageAccess } = useBatchImageAccess()
 const sidebarCollapsed = computed(() => appStore.sidebarCollapsed)
 const mobileOpen = computed(() => appStore.mobileOpen)
 const isAdmin = computed(() => authStore.isAdmin)
+const sidebarNavRef = ref<HTMLElement | null>(null)
 const isDark = ref(document.documentElement.classList.contains('dark'))
 
 const homePath = computed(() => (isAdmin.value ? '/admin/dashboard' : '/dashboard'))
@@ -923,6 +924,20 @@ onMounted(() => {
   void refreshBatchImageAccess()
   if (isAdmin.value) {
     adminSettingsStore.fetch()
+  }
+  // Restore sidebar scroll position after route change re-mounts the component
+  if (appStore.sidebarScrollTop > 0 && sidebarNavRef.value) {
+    void nextTick(() => {
+      if (sidebarNavRef.value) {
+        sidebarNavRef.value.scrollTop = appStore.sidebarScrollTop
+      }
+    })
+  }
+})
+
+onBeforeUnmount(() => {
+  if (sidebarNavRef.value) {
+    appStore.sidebarScrollTop = sidebarNavRef.value.scrollTop
   }
 })
 </script>

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -19,6 +19,29 @@ describe('AppSidebar custom SVG styles', () => {
   })
 })
 
+describe('AppSidebar scroll position persistence', () => {
+  it('binds a template ref to the sidebar nav element', () => {
+    expect(componentSource).toContain('ref="sidebarNavRef"')
+    expect(componentSource).toContain('sidebar-nav')
+  })
+
+  it('declares sidebarNavRef in script setup', () => {
+    expect(componentSource).toContain("const sidebarNavRef = ref<HTMLElement | null>(null)")
+  })
+
+  it('saves scroll position on beforeUnmount', () => {
+    expect(componentSource).toContain('onBeforeUnmount')
+    expect(componentSource).toContain('appStore.sidebarScrollTop')
+    expect(componentSource).toContain('sidebarNavRef.value.scrollTop')
+  })
+
+  it('restores scroll position on mount', () => {
+    expect(componentSource).toContain('onMounted')
+    expect(componentSource).toContain('appStore.sidebarScrollTop')
+    expect(componentSource).toContain('nextTick')
+  })
+})
+
 describe('AppSidebar header styles', () => {
   it('does not clip the version badge dropdown', () => {
     const sidebarHeaderBlockMatch = styleSource.match(/\.sidebar-header\s*\{[\s\S]*?\n {2}\}/)

--- a/frontend/src/stores/__tests__/app.spec.ts
+++ b/frontend/src/stores/__tests__/app.spec.ts
@@ -147,6 +147,17 @@ describe('useAppStore', () => {
       expect(store.sidebarCollapsed).toBe(false)
     })
 
+    it('sidebarScrollTop 默认为 0 且可读写', () => {
+      const store = useAppStore()
+      expect(store.sidebarScrollTop).toBe(0)
+
+      store.sidebarScrollTop = 256
+      expect(store.sidebarScrollTop).toBe(256)
+
+      store.sidebarScrollTop = 0
+      expect(store.sidebarScrollTop).toBe(0)
+    })
+
     it('toggleMobileSidebar 切换移动端状态', () => {
       const store = useAppStore()
       expect(store.mobileOpen).toBe(false)

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -19,6 +19,7 @@ export const useAppStore = defineStore('app', () => {
 
   const sidebarCollapsed = ref<boolean>(false)
   const mobileOpen = ref<boolean>(false)
+  const sidebarScrollTop = ref<number>(0)
   const loading = ref<boolean>(false)
   const toasts = ref<Toast[]>([])
 
@@ -409,6 +410,7 @@ export const useAppStore = defineStore('app', () => {
     // State
     sidebarCollapsed,
     mobileOpen,
+    sidebarScrollTop,
     loading,
     toasts,
 


### PR DESCRIPTION
## 背景

修复 #3796。

当前 `AppLayout` 在每个页面组件的 `<template>` 内部包裹（如 `SettingsView.vue`、`AccountsView.vue` 等），路由切换时整个组件树（含 `AppSidebar`）被销毁重建，侧边栏 `<nav class="sidebar-nav">` 的滚动位置丢失回到顶部。

管理员后台菜单较长、屏幕较矮、或配置了多个自定义菜单项时尤其明显——每次点击靠下的菜单项后都需重新向下滚动。

## 修改

- `stores/app.ts`：新增 `sidebarScrollTop` 状态（`ref<number>(0)`），跨路由切换持久化滚动位置。
- `AppSidebar.vue`：
  - `<nav>` 元素绑定 `ref="sidebarNavRef"`；
  - `onBeforeUnmount` 保存 `scrollTop` 到 store；
  - `onMounted` + `nextTick` 恢复滚动位置。

## 兼容性说明

- 不改动路由结构（扁平路由 + 页面内包裹 `AppLayout` 的模式不变）；
- 滚动位置存在 Pinia store（内存），刷新页面自然重置为 0，无副作用；
- 移动端（`mobileOpen` 控制的抽屉式侧边栏）不受影响——抽屉关闭不触发 unmount。

## 测试

新增/扩展测试：

- `AppSidebar.spec.ts`：4 个新用例——验证 template ref 绑定、sidebarNavRef 声明、onBeforeUnmount 保存 scrollTop、onMounted + nextTick 恢复；
- `app.spec.ts`：1 个新用例——验证 sidebarScrollTop 默认为 0 且可读写。

本地已运行：

- `pnpm run typecheck`
- `pnpm run lint:check`
- `pnpm run test:run -- src/components/layout/__tests__/AppSidebar.spec.ts src/stores/__tests__/app.spec.ts`（全部通过）