### PR TITLE
Fix OpenAI messages empty stream handling

### DIFF
--- a/backend/internal/handler/no_account_error.go
+++ b/backend/internal/handler/no_account_error.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
@@ -85,6 +86,13 @@ func classifyNoAccountError(
 			ErrType:       "model_not_found",
 			Message:       fmt.Sprintf("Model %q is not supported by any configured account in this group", displayModel),
 			ModelNotFound: true,
+		}
+	}
+	if result.HasModelSupport && result.AllModelSupportingAccountsRateLimited && result.RateLimitResetAt != nil {
+		return noAccountErrorClassification{
+			Status:  http.StatusTooManyRequests,
+			ErrType: "rate_limit_error",
+			Message: fmt.Sprintf("All configured accounts that support %q are rate-limited until %s", displayModel, result.RateLimitResetAt.Format(time.RFC3339)),
 		}
 	}
 	return fallback

--- a/backend/internal/handler/no_account_error_test.go
+++ b/backend/internal/handler/no_account_error_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,26 @@ func TestClassifyNoAccountError_HasModelSupport_KeepsRoutingMessageGenerationToC
 	require.Equal(t, http.StatusServiceUnavailable, cls.Status, "model exists somewhere — caller stays on 503")
 	require.Equal(t, "api_error", cls.ErrType)
 	require.False(t, cls.ModelNotFound)
+}
+
+func TestClassifyNoAccountError_AllSupportingAccountsRateLimited_Returns429(t *testing.T) {
+	c := newTestGinContextWithRequest()
+	resetAt := time.Date(2026, 7, 8, 20, 54, 13, 0, time.UTC)
+	fd := &fakeDiagnoser{resp: service.ModelAvailabilityDiagnosis{
+		HasAccountsInPool:                     true,
+		HasModelSupport:                       true,
+		AllModelSupportingAccountsRateLimited: true,
+		RateLimitResetAt:                      &resetAt,
+	}}
+	apiKey := &service.APIKey{GroupID: ptrInt64(7)}
+
+	cls := classifyNoAccountErrorFromGin(c, fd, apiKey, "gpt-5.5", "gpt-5.5", service.PlatformOpenAI)
+
+	require.Equal(t, http.StatusTooManyRequests, cls.Status)
+	require.Equal(t, "rate_limit_error", cls.ErrType)
+	require.False(t, cls.ModelNotFound)
+	require.Contains(t, cls.Message, "gpt-5.5")
+	require.Contains(t, cls.Message, resetAt.Format(time.RFC3339))
 }
 
 func TestClassifyNoAccountError_NoAccountsInPool_Stays503(t *testing.T) {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -869,9 +869,24 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			} else {
 				var failoverErr *service.UpstreamFailoverError
 				if errors.As(err, &failoverErr) {
-					if c.Writer.Size() != writerSizeBeforeForward {
+					writerSizeAfterForward := c.Writer.Size()
+					if writerSizeAfterForward != writerSizeBeforeForward && result != nil && result.ClientOutputStarted {
 						h.handleAnthropicFailoverExhausted(c, failoverErr, true)
 						return
+					}
+					if h.isAnthropicClientFailoverError(failoverErr) {
+						h.handleAnthropicFailoverExhausted(c, failoverErr, streamStarted)
+						return
+					}
+					if writerSizeAfterForward != writerSizeBeforeForward {
+						reqLog.Warn("openai_messages.retrying_after_pre_model_stream_error",
+							zap.Int64("account_id", account.ID),
+							zap.Int("writer_size_before", writerSizeBeforeForward),
+							zap.Int("writer_size_after", writerSizeAfterForward),
+							zap.Bool("retryable_on_same_account", failoverErr.RetryableOnSameAccount),
+							zap.String("failover_message", strings.TrimSpace(gjson.GetBytes(failoverErr.ResponseBody, "error.message").String())),
+							zap.Error(err),
+						)
 					}
 					h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
 					// 池模式：同账号重试
@@ -882,6 +897,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 							reqLog.Warn("openai_messages.pool_mode_same_account_retry",
 								zap.Int64("account_id", account.ID),
 								zap.Int("upstream_status", failoverErr.StatusCode),
+								zap.String("failover_message", strings.TrimSpace(gjson.GetBytes(failoverErr.ResponseBody, "error.message").String())),
 								zap.Int("retry_limit", retryLimit),
 								zap.Int("retry_count", sameAccountRetryCount[account.ID]),
 							)
@@ -1027,8 +1043,38 @@ func (h *OpenAIGatewayHandler) anthropicStreamingAwareError(c *gin.Context, stat
 
 // handleAnthropicFailoverExhausted maps upstream failover errors to Anthropic format.
 func (h *OpenAIGatewayHandler) handleAnthropicFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {
+	if failoverErr != nil {
+		if status, errType, errMsg, ok := h.mapAnthropicFailoverBodyError(failoverErr); ok {
+			h.anthropicStreamingAwareError(c, status, errType, errMsg, streamStarted)
+			return
+		}
+	}
 	status, errType, errMsg := h.mapUpstreamError(failoverErr.StatusCode)
 	h.anthropicStreamingAwareError(c, status, errType, errMsg, streamStarted)
+}
+
+func (h *OpenAIGatewayHandler) isAnthropicClientFailoverError(failoverErr *service.UpstreamFailoverError) bool {
+	if failoverErr == nil || failoverErr.StatusCode < 400 || failoverErr.StatusCode >= 500 {
+		return false
+	}
+	errType := strings.TrimSpace(gjson.GetBytes(failoverErr.ResponseBody, "error.type").String())
+	return errType == "invalid_request_error"
+}
+
+func (h *OpenAIGatewayHandler) mapAnthropicFailoverBodyError(failoverErr *service.UpstreamFailoverError) (int, string, string, bool) {
+	if failoverErr == nil || len(failoverErr.ResponseBody) == 0 {
+		return 0, "", "", false
+	}
+	errType := strings.TrimSpace(gjson.GetBytes(failoverErr.ResponseBody, "error.type").String())
+	errMsg := strings.TrimSpace(gjson.GetBytes(failoverErr.ResponseBody, "error.message").String())
+	if errType == "" || errMsg == "" {
+		return 0, "", "", false
+	}
+	status := failoverErr.StatusCode
+	if status < 400 || status >= 500 {
+		status = http.StatusBadGateway
+	}
+	return status, errType, errMsg, true
 }
 
 // ensureAnthropicErrorResponse writes a fallback Anthropic error if no response was written.

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -133,6 +133,23 @@ func TestOpenAIHandleStreamingAwareError_NonStreaming(t *testing.T) {
 	assert.Equal(t, "test error", errorObj["message"])
 }
 
+func TestOpenAIHandleAnthropicFailoverExhaustedPreservesClientError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	h := &OpenAIGatewayHandler{}
+	h.handleAnthropicFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:   http.StatusBadRequest,
+		ResponseBody: []byte(`{"error":{"type":"invalid_request_error","message":"context window exceeded"}}`),
+	}, false)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "invalid_request_error", gjson.GetBytes(w.Body.Bytes(), "error.type").String())
+	assert.Equal(t, "context window exceeded", gjson.GetBytes(w.Body.Bytes(), "error.message").String())
+}
+
 func TestReadRequestBodyWithPrealloc(t *testing.T) {
 	payload := `{"model":"gpt-5","input":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(payload))

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -432,6 +432,25 @@ func TestResponsesToAnthropic_EmptyOutput(t *testing.T) {
 // Streaming: ResponsesEventToAnthropicEvents tests
 // ---------------------------------------------------------------------------
 
+func TestStreamingMessageStartUsesPrefilledInputTokens(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	state.InputTokens = 123
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type: "response.created",
+		Response: &ResponsesResponse{
+			ID:    "resp_1",
+			Model: "gpt-5.5",
+		},
+	}, state)
+
+	require.Len(t, events, 1)
+	require.NotNil(t, events[0].Message)
+	assert.Equal(t, "message_start", events[0].Type)
+	assert.Equal(t, 123, events[0].Message.Usage.InputTokens)
+	assert.Equal(t, 0, events[0].Message.Usage.OutputTokens)
+}
+
 func TestStreamingTextOnly(t *testing.T) {
 	state := NewResponsesEventToAnthropicState()
 

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -563,6 +563,44 @@ func TestResponsesEventToAnthropicEvents_TopLevelTerminalUsage(t *testing.T) {
 	assert.Equal(t, "message_stop", events[1].Type)
 }
 
+func TestResponsesEventToAnthropicEvents_TerminalOutputTextOnly(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			ID:     "resp_terminal_text",
+			Model:  "gpt-5.5",
+			Status: "completed",
+			Output: []ResponsesOutput{{
+				Type: "message",
+				Content: []ResponsesContentPart{{
+					Type: "output_text",
+					Text: "ok",
+				}},
+			}},
+			Usage: &ResponsesUsage{InputTokens: 9, OutputTokens: 2},
+		},
+	}, state)
+
+	require.Len(t, events, 6)
+	assert.Equal(t, "message_start", events[0].Type)
+	require.NotNil(t, events[0].Message)
+	assert.Equal(t, "resp_terminal_text", events[0].Message.ID)
+	assert.Equal(t, "gpt-5.5", events[0].Message.Model)
+	assert.Equal(t, "content_block_start", events[1].Type)
+	assert.Equal(t, "content_block_delta", events[2].Type)
+	require.NotNil(t, events[2].Delta)
+	assert.Equal(t, "ok", events[2].Delta.Text)
+	assert.Equal(t, "content_block_stop", events[3].Type)
+	assert.Equal(t, "message_delta", events[4].Type)
+	require.NotNil(t, events[4].Usage)
+	assert.Equal(t, 9, events[4].Usage.InputTokens)
+	assert.Equal(t, 2, events[4].Usage.OutputTokens)
+	assert.Equal(t, "message_stop", events[5].Type)
+	assert.Nil(t, FinalizeResponsesAnthropicStream(state))
+}
+
 func TestResponsesEventToAnthropicEvents_ResponseDoneIncomplete(t *testing.T) {
 	state := NewResponsesEventToAnthropicState()
 	state.Model = "gpt-4o"

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -303,7 +303,7 @@ func resToAnthHandleCreated(evt *ResponsesStreamEvent, state *ResponsesEventToAn
 			Content: []AnthropicContentBlock{},
 			Model:   state.Model,
 			Usage: AnthropicUsage{
-				InputTokens:  0,
+				InputTokens:  state.InputTokens,
 				OutputTokens: 0,
 			},
 		},

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -572,7 +572,6 @@ func resToAnthHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventTo
 	var events []AnthropicStreamEvent
 	events = append(events, closeCurrentBlock(state)...)
 
-	stopReason := "end_turn"
 	if evt.Usage != nil {
 		usage := anthropicUsageFromResponsesUsage(evt.Usage)
 		state.InputTokens = usage.InputTokens
@@ -580,12 +579,23 @@ func resToAnthHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventTo
 		state.CacheReadInputTokens = usage.CacheReadInputTokens
 	}
 	if evt.Response != nil {
+		if evt.Response.ID != "" {
+			state.ResponseID = evt.Response.ID
+		}
+		if state.Model == "" {
+			state.Model = evt.Response.Model
+		}
 		if evt.Response.Usage != nil {
 			usage := anthropicUsageFromResponsesUsage(evt.Response.Usage)
 			state.InputTokens = usage.InputTokens
 			state.OutputTokens = usage.OutputTokens
 			state.CacheReadInputTokens = usage.CacheReadInputTokens
 		}
+		events = append(events, resToAnthHandleTerminalOutput(evt.Response, state)...)
+	}
+
+	stopReason := "end_turn"
+	if evt.Response != nil {
 		switch evt.Response.Status {
 		case "incomplete":
 			if evt.Response.IncompleteDetails != nil && evt.Response.IncompleteDetails.Reason == "max_output_tokens" {
@@ -613,6 +623,94 @@ func resToAnthHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventTo
 		AnthropicStreamEvent{Type: "message_stop"},
 	)
 	state.MessageStopSent = true
+	return events
+}
+
+func resToAnthHandleTerminalOutput(resp *ResponsesResponse, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
+	if resp == nil || state.ContentBlockOpen || state.ContentBlockIndex > 0 {
+		return nil
+	}
+	anthropicResp := ResponsesToAnthropic(resp, state.Model)
+	var blocks []AnthropicContentBlock
+	for _, block := range anthropicResp.Content {
+		switch block.Type {
+		case "text":
+			if block.Text != "" {
+				blocks = append(blocks, block)
+			}
+		case "thinking":
+			if block.Thinking != "" {
+				blocks = append(blocks, block)
+			}
+		case "tool_use", "server_tool_use", "web_search_tool_result":
+			blocks = append(blocks, block)
+		}
+	}
+	if len(blocks) == 0 {
+		return nil
+	}
+
+	var events []AnthropicStreamEvent
+	if !state.MessageStartSent {
+		state.MessageStartSent = true
+		events = append(events, AnthropicStreamEvent{
+			Type: "message_start",
+			Message: &AnthropicResponse{
+				ID:      state.ResponseID,
+				Type:    "message",
+				Role:    "assistant",
+				Content: []AnthropicContentBlock{},
+				Model:   state.Model,
+				Usage: AnthropicUsage{
+					InputTokens:  state.InputTokens,
+					OutputTokens: 0,
+				},
+			},
+		})
+	}
+
+	for _, block := range blocks {
+		idx := state.ContentBlockIndex
+		startBlock := block
+		switch block.Type {
+		case "text":
+			startBlock.Text = ""
+		case "thinking":
+			startBlock.Thinking = ""
+		case "tool_use", "server_tool_use":
+			state.HasToolCall = true
+		}
+		events = append(events, AnthropicStreamEvent{
+			Type:         "content_block_start",
+			Index:        &idx,
+			ContentBlock: &startBlock,
+		})
+		switch block.Type {
+		case "text":
+			events = append(events, AnthropicStreamEvent{
+				Type:  "content_block_delta",
+				Index: &idx,
+				Delta: &AnthropicDelta{
+					Type: "text_delta",
+					Text: block.Text,
+				},
+			})
+		case "thinking":
+			events = append(events, AnthropicStreamEvent{
+				Type:  "content_block_delta",
+				Index: &idx,
+				Delta: &AnthropicDelta{
+					Type:     "thinking_delta",
+					Thinking: block.Thinking,
+				},
+			})
+		}
+		events = append(events, AnthropicStreamEvent{
+			Type:  "content_block_stop",
+			Index: &idx,
+		})
+		state.ContentBlockIndex++
+	}
 	return events
 }
 

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -519,6 +519,70 @@ func stringMappingFromRaw(raw any) map[string]string {
 	}
 }
 
+func stringSliceFromRaw(raw any) ([]string, bool) {
+	switch value := raw.(type) {
+	case string:
+		return []string{value}, true
+	case []string:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			result = append(result, item)
+		}
+		return result, true
+	case []any:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			str, ok := item.(string)
+			if !ok {
+				continue
+			}
+			result = append(result, str)
+		}
+		return result, true
+	default:
+		return nil, false
+	}
+}
+
+func stringSliceMappingFromRaw(raw any) map[string][]string {
+	switch mapping := raw.(type) {
+	case map[string]any:
+		if len(mapping) == 0 {
+			return nil
+		}
+		result := make(map[string][]string, len(mapping))
+		for key, value := range mapping {
+			if items, ok := stringSliceFromRaw(value); ok {
+				result[key] = items
+			}
+		}
+		if len(result) == 0 {
+			return nil
+		}
+		return result
+	case map[string]string:
+		if len(mapping) == 0 {
+			return nil
+		}
+		result := make(map[string][]string, len(mapping))
+		for key, value := range mapping {
+			result[key] = []string{value}
+		}
+		return result
+	case map[string][]string:
+		if len(mapping) == 0 {
+			return nil
+		}
+		result := make(map[string][]string, len(mapping))
+		for key, value := range mapping {
+			result[key] = append([]string(nil), value...)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
 func (a *Account) GetModelMapping() map[string]string {
 	credentialsPtr := mapPtr(a.Credentials)
 	rawMapping, _ := a.Credentials["model_mapping"].(map[string]any)
@@ -749,6 +813,16 @@ func resolveRequestedModelInMapping(mapping map[string]string, requestedModel st
 	return matchWildcardMappingResult(mapping, requestedModel)
 }
 
+func resolveRequestedModelInSliceMapping(mapping map[string][]string, requestedModel string) (mappedModels []string, matched bool) {
+	if requestedModel == "" {
+		return nil, false
+	}
+	if mappedModels, exists := mapping[requestedModel]; exists {
+		return append([]string(nil), mappedModels...), true
+	}
+	return matchWildcardSliceMappingResult(mapping, requestedModel)
+}
+
 // IsModelSupported 检查模型是否在 model_mapping 中（支持通配符）
 // 如果未配置 mapping，返回 true（允许所有模型）
 func (a *Account) IsModelSupported(requestedModel string) bool {
@@ -860,6 +934,43 @@ func (a *Account) ResolveCompactMappedModel(requestedModel string) (mappedModel 
 	return requestedModel, false
 }
 
+// GetCompactModelFallbacks returns compact-only fallback model configuration.
+// Values may be either a string model id or a JSON array of model ids. An empty
+// array intentionally disables the built-in fallback for that key.
+func (a *Account) GetCompactModelFallbacks() map[string][]string {
+	if a == nil || a.Credentials == nil {
+		return nil
+	}
+	return stringSliceMappingFromRaw(a.Credentials["compact_model_fallbacks"])
+}
+
+// ResolveCompactFallbackModels resolves alternate compact models for a compact
+// reroute. It first honors account credentials and then falls back from Codex
+// Spark to 5.4 mini by default, because Spark has a smaller and more volatile
+// subscription quota than normal Codex models.
+func (a *Account) ResolveCompactFallbackModels(requestedModel, mappedModel string) []string {
+	requestedModel = strings.TrimSpace(requestedModel)
+	mappedModel = strings.TrimSpace(mappedModel)
+
+	mapping := a.GetCompactModelFallbacks()
+	configured := false
+	var candidates []string
+	for _, key := range []string{mappedModel, requestedModel} {
+		if key == "" || len(mapping) == 0 {
+			continue
+		}
+		if models, matched := resolveRequestedModelInSliceMapping(mapping, key); matched {
+			configured = true
+			candidates = append(candidates, models...)
+		}
+	}
+	if !configured && strings.EqualFold(mappedModel, "gpt-5.3-codex-spark") {
+		candidates = append(candidates, "gpt-5.4-mini")
+	}
+
+	return compactModelFallbackCandidates(candidates, mappedModel)
+}
+
 func (a *Account) GetBaseURL() string {
 	if a.Type != AccountTypeAPIKey {
 		return ""
@@ -958,6 +1069,58 @@ func matchWildcardMappingResult(mapping map[string]string, requestedModel string
 	})
 
 	return matches[0].target, true
+}
+
+func matchWildcardSliceMappingResult(mapping map[string][]string, requestedModel string) ([]string, bool) {
+	type patternMatch struct {
+		pattern string
+		target  []string
+	}
+	var matches []patternMatch
+
+	for pattern, target := range mapping {
+		if matchWildcard(pattern, requestedModel) {
+			matches = append(matches, patternMatch{
+				pattern: pattern,
+				target:  append([]string(nil), target...),
+			})
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, false
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		if len(matches[i].pattern) != len(matches[j].pattern) {
+			return len(matches[i].pattern) > len(matches[j].pattern)
+		}
+		return matches[i].pattern < matches[j].pattern
+	})
+
+	return matches[0].target, true
+}
+
+func compactModelFallbackCandidates(candidates []string, primaryModel string) []string {
+	primaryModel = strings.TrimSpace(primaryModel)
+	result := make([]string, 0, len(candidates))
+	seen := make(map[string]bool, len(candidates)+1)
+	if primaryModel != "" {
+		seen[strings.ToLower(primaryModel)] = true
+	}
+	for _, candidate := range candidates {
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, trimmed)
+	}
+	return result
 }
 
 func (a *Account) IsCustomErrorCodesEnabled() bool {

--- a/backend/internal/service/account_openai_compact_test.go
+++ b/backend/internal/service/account_openai_compact_test.go
@@ -356,12 +356,93 @@ func TestAccountResolveCompactMappedModel(t *testing.T) {
 	}
 }
 
+func TestAccountCompactModelFallbacks(t *testing.T) {
+	t.Run("parses string array and preserves empty override", func(t *testing.T) {
+		account := &Account{Credentials: map[string]any{
+			"compact_model_fallbacks": map[string]any{
+				"gpt-5.3-codex-spark": []any{"gpt-5.4-mini", "gpt-5.4"},
+				"gpt-5.5":             "gpt-5.4-mini",
+				"disabled":            []any{},
+				"invalid":             7,
+			},
+		}}
+
+		want := map[string][]string{
+			"gpt-5.3-codex-spark": []string{"gpt-5.4-mini", "gpt-5.4"},
+			"gpt-5.5":             []string{"gpt-5.4-mini"},
+			"disabled":            []string{},
+		}
+		if got := account.GetCompactModelFallbacks(); !equalStringSliceMap(got, want) {
+			t.Fatalf("GetCompactModelFallbacks() = %#v, want %#v", got, want)
+		}
+	})
+
+	t.Run("defaults spark to mini", func(t *testing.T) {
+		account := &Account{Credentials: map[string]any{}}
+		got := account.ResolveCompactFallbackModels("gpt-5.5", "gpt-5.3-codex-spark")
+		if !equalStringSlice(got, []string{"gpt-5.4-mini"}) {
+			t.Fatalf("ResolveCompactFallbackModels() = %#v", got)
+		}
+	})
+
+	t.Run("configured empty disables default", func(t *testing.T) {
+		account := &Account{Credentials: map[string]any{
+			"compact_model_fallbacks": map[string]any{
+				"gpt-5.3-codex-spark": []any{},
+			},
+		}}
+		if got := account.ResolveCompactFallbackModels("gpt-5.5", "gpt-5.3-codex-spark"); len(got) != 0 {
+			t.Fatalf("ResolveCompactFallbackModels() = %#v, want empty", got)
+		}
+	})
+
+	t.Run("wildcard fallback dedupes primary and duplicate models", func(t *testing.T) {
+		account := &Account{Credentials: map[string]any{
+			"compact_model_fallbacks": map[string]any{
+				"gpt-*":             []any{"gpt-5.3-codex-spark", "gpt-5.4-mini"},
+				"gpt-5.3-codex-*":   []any{"gpt-5.4-mini", "gpt-5.4-mini", "gpt-5.4"},
+				"gpt-5.3-codex-old": []any{"gpt-5.4"},
+			},
+		}}
+		got := account.ResolveCompactFallbackModels("gpt-5.5", "gpt-5.3-codex-spark")
+		want := []string{"gpt-5.4-mini", "gpt-5.4"}
+		if !equalStringSlice(got, want) {
+			t.Fatalf("ResolveCompactFallbackModels() = %#v, want %#v", got, want)
+		}
+	})
+}
+
 func equalStringMap(left, right map[string]string) bool {
 	if len(left) != len(right) {
 		return false
 	}
 	for key, want := range right {
 		if got, ok := left[key]; !ok || got != want {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringSlice(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range right {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalStringSliceMap(left, right map[string][]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, want := range right {
+		got, ok := left[key]
+		if !ok || !equalStringSlice(got, want) {
 			return false
 		}
 	}

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -756,6 +756,7 @@ func (s *AccountUsageService) persistOpenAICodexProbeSnapshot(accountID int64, u
 		defer updateCancel()
 		_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
 	}()
+	maybeRecoverOpenAICodexQuotaModelRateLimits(context.Background(), s.accountRepo, accountID, updates)
 }
 
 func extractOpenAICodexProbeUpdates(resp *http.Response) (map[string]any, error) {

--- a/backend/internal/service/gateway_model_availability.go
+++ b/backend/internal/service/gateway_model_availability.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"strings"
+	"time"
 )
 
 // ModelAvailabilityDiagnosis describes whether the requested model can be
@@ -18,6 +19,13 @@ type ModelAvailabilityDiagnosis struct {
 	// HasModelSupport is true if at least one account's model mapping admits
 	// the requested model.
 	HasModelSupport bool
+	// AllModelSupportingAccountsRateLimited is true when every account that
+	// could serve the requested model is currently blocked by a global upstream
+	// rate-limit cooldown.
+	AllModelSupportingAccountsRateLimited bool
+	// RateLimitResetAt is the earliest reset time among model-supporting
+	// accounts when AllModelSupportingAccountsRateLimited is true.
+	RateLimitResetAt *time.Time
 }
 
 // ModelAvailabilityDiagnoser is implemented by gateway services that can

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -105,7 +105,16 @@ func (m *mockAccountRepoForPlatform) ListActive(ctx context.Context) ([]Account,
 	return nil, nil
 }
 func (m *mockAccountRepoForPlatform) ListByPlatform(ctx context.Context, platform string) ([]Account, error) {
-	return nil, nil
+	if m.listPlatformFunc != nil {
+		return m.listPlatformFunc(ctx, platform)
+	}
+	var result []Account
+	for _, acc := range m.accounts {
+		if acc.Platform == platform && acc.Status == StatusActive {
+			result = append(result, acc)
+		}
+	}
+	return result, nil
 }
 func (m *mockAccountRepoForPlatform) UpdateLastUsed(ctx context.Context, id int64) error {
 	return nil

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -38,6 +39,7 @@ func isOpenAIAccount(account *Account) bool {
 func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel ...string) bool {
 	stateCtx, cancel := openAIAccountStateContext(ctx)
 	defer cancel()
+	modelScope := firstRequestedModel(requestedModel)
 
 	if account != nil && account.Platform == PlatformOpenAI && isOpenAIContextWindowError("", responseBody) {
 		return false
@@ -50,16 +52,16 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		return false
 	}
 
-	if statusCode == http.StatusTooManyRequests {
+	if statusCode == http.StatusTooManyRequests && strings.TrimSpace(modelScope) == "" {
 		s.markOpenAIOAuth429RateLimited(stateCtx, account, headers, responseBody)
 	}
 	if s == nil || account == nil || s.rateLimitService == nil {
 		return false
 	}
-	if len(requestedModel) > 0 && s.rateLimitService.HandleUpstreamModelNotFound(stateCtx, account, requestedModel[0], statusCode, responseBody) {
+	if strings.TrimSpace(modelScope) != "" && s.rateLimitService.HandleUpstreamModelNotFound(stateCtx, account, modelScope, statusCode, responseBody) {
 		return true
 	}
-	shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody)
+	shouldDisable := s.rateLimitService.HandleUpstreamError(stateCtx, account, statusCode, headers, responseBody, modelScope)
 	if shouldDisable {
 		s.BlockAccountScheduling(account, time.Time{}, "upstream_disable")
 	}

--- a/backend/internal/service/openai_account_runtime_block_fastpath_test.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath_test.go
@@ -52,6 +52,33 @@ func TestOpenAI429FastPath_SkipsSparkShadow(t *testing.T) {
 	require.True(t, svc.isOpenAIAccountRuntimeBlocked(normal), "normal OpenAI OAuth account should still be runtime-blocked")
 }
 
+func TestOpenAI429FastPath_ModelScopedCooldownDoesNotBlockWholeOAuthAccount(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := &OpenAIGatewayService{
+		rateLimitService: &RateLimitService{accountRepo: repo},
+	}
+	account := &Account{ID: 48, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "100")
+	headers.Set("x-codex-primary-reset-after-seconds", "300")
+	headers.Set("x-codex-primary-window-minutes", "300")
+
+	shouldDisable := svc.handleOpenAIAccountUpstreamError(
+		context.Background(),
+		account,
+		http.StatusTooManyRequests,
+		headers,
+		[]byte(`{"error":{"code":"rate_limit_exceeded","message":"The usage limit has been reached"}}`),
+		"gpt-5.3-codex-spark",
+	)
+
+	require.False(t, shouldDisable)
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account), "model-scoped 429 must not runtime-block the whole OpenAI account")
+	require.Zero(t, repo.rateLimitedCalls, "model-scoped 429 must not write global account cooldown")
+	require.Equal(t, 1, repo.modelRateLimitCalls)
+	require.Equal(t, "gpt-5.3-codex-spark", repo.lastModelRateScope)
+}
+
 func TestOpenAIRuntimeBlock_AppliesToOpenAIAPIKeyWhenRateLimitServiceStopsScheduling(t *testing.T) {
 	svc := &OpenAIGatewayService{}
 	account := &Account{ID: 44, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}

--- a/backend/internal/service/openai_codex_cooldown_recovery.go
+++ b/backend/internal/service/openai_codex_cooldown_recovery.go
@@ -1,0 +1,128 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"time"
+)
+
+func codexUsageUpdatesShowQuotaHeadroom(updates map[string]any) bool {
+	if len(updates) == 0 {
+		return false
+	}
+
+	seen := false
+	for _, key := range []string{
+		"codex_5h_used_percent",
+		"codex_7d_used_percent",
+		"codex_primary_used_percent",
+		"codex_secondary_used_percent",
+	} {
+		value, ok := quotaPercentFromAny(updates[key])
+		if !ok {
+			continue
+		}
+		seen = true
+		if value >= 100 {
+			return false
+		}
+	}
+	return seen
+}
+
+func clearStaleOpenAIQuotaModelRateLimits(ctx context.Context, repo AccountRepository, accountID int64) {
+	if repo == nil || accountID <= 0 {
+		return
+	}
+
+	account, err := repo.GetByID(ctx, accountID)
+	if err != nil {
+		slog.Warn("openai_codex_cooldown_recovery_get_account_failed", "account_id", accountID, "error", err)
+		return
+	}
+	if account == nil || account.Platform != PlatformOpenAI || len(account.Extra) == 0 {
+		return
+	}
+
+	cleaned, changed := filterOpenAIQuotaModelRateLimits(account.Extra[modelRateLimitsKey])
+	if !changed {
+		return
+	}
+	if err := repo.UpdateExtra(ctx, accountID, map[string]any{modelRateLimitsKey: cleaned}); err != nil {
+		slog.Warn("openai_codex_cooldown_recovery_update_failed", "account_id", accountID, "error", err)
+		return
+	}
+	slog.Info("openai_codex_cooldown_recovery_cleared_model_rate_limits", "account_id", accountID)
+}
+
+func maybeRecoverOpenAICodexQuotaModelRateLimits(ctx context.Context, repo AccountRepository, accountID int64, updates map[string]any) {
+	if !codexUsageUpdatesShowQuotaHeadroom(updates) {
+		return
+	}
+
+	go func() {
+		recoveryCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		clearStaleOpenAIQuotaModelRateLimits(recoveryCtx, repo, accountID)
+	}()
+}
+
+func filterOpenAIQuotaModelRateLimits(raw any) (map[string]any, bool) {
+	limits, ok := raw.(map[string]any)
+	if !ok || len(limits) == 0 {
+		return nil, false
+	}
+
+	cleaned := make(map[string]any, len(limits))
+	changed := false
+	for model, rawLimit := range limits {
+		limit, ok := rawLimit.(map[string]any)
+		if ok && isOpenAIQuotaModelRateLimitReason(limit["reason"]) {
+			changed = true
+			continue
+		}
+		cleaned[model] = rawLimit
+	}
+	return cleaned, changed
+}
+
+func isOpenAIQuotaModelRateLimitReason(raw any) bool {
+	reason := strings.TrimSpace(fmt.Sprint(raw))
+	return reason == openAIModelRateLimitReason || strings.HasPrefix(reason, openAIModelRateLimitReason+":")
+}
+
+func quotaPercentFromAny(raw any) (float64, bool) {
+	switch value := raw.(type) {
+	case float64:
+		return value, true
+	case float32:
+		return float64(value), true
+	case int:
+		return float64(value), true
+	case int64:
+		return float64(value), true
+	case int32:
+		return float64(value), true
+	case uint:
+		return float64(value), true
+	case uint64:
+		return float64(value), true
+	case uint32:
+		return float64(value), true
+	case string:
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			return 0, false
+		}
+		parsed, err := strconv.ParseFloat(trimmed, 64)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
+}

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -348,6 +348,175 @@ func TestForwardAsAnthropic_ClaudeCodeCompactChunksWhenCompactModelContextExceed
 	require.Contains(t, string(upstream.bodies[len(upstream.bodies)-1]), "chunk 1 summary")
 }
 
+func TestForwardAsAnthropic_ClaudeCodeCompactRecursivelyMergesWhenMergeContextExceeded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldChunkTarget := openAIAnthropicCompactChunkTargetChars
+	oldMergeTarget := openAIAnthropicCompactMergeTargetChars
+	openAIAnthropicCompactChunkTargetChars = 80
+	openAIAnthropicCompactMergeTargetChars = 100_000
+	defer func() {
+		openAIAnthropicCompactChunkTargetChars = oldChunkTarget
+		openAIAnthropicCompactMergeTargetChars = oldMergeTarget
+	}()
+
+	messages := make([]map[string]any, 0, 13)
+	for i := 0; i < 12; i++ {
+		role := "user"
+		if i%2 == 1 {
+			role = "assistant"
+		}
+		messages = append(messages, map[string]any{
+			"role":    role,
+			"content": strings.Repeat(fmt.Sprintf("turn-%02d file command error blocker verification ", i+1), 6),
+		})
+	}
+	compactPrompt := testClaudeCodeCompactPrompt()
+	messages = append(messages, map[string]any{
+		"role": "user",
+		"content": []map[string]string{{
+			"type": "text",
+			"text": compactPrompt,
+		}},
+	})
+	body, err := json.Marshal(map[string]any{
+		"model":      "gpt-5.5",
+		"max_tokens": 16,
+		"messages":   messages,
+		"stream":     true,
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	var anthropicReq apicompat.AnthropicRequest
+	require.NoError(t, json.Unmarshal(body, &anthropicReq))
+	_, transcript := buildAnthropicCompactFallbackTranscript(&anthropicReq)
+	chunks := splitAnthropicCompactTranscriptChunks(transcript, openAIAnthropicCompactChunkTargetChars, openAIAnthropicCompactFallbackMaxChunks)
+	require.GreaterOrEqual(t, len(chunks), 10)
+
+	responses := []*http.Response{
+		testOpenAICompatSSEFailedContextResponse("resp_full_too_big", "gpt-5.3-codex-spark", 246_445),
+	}
+	formattedSummaries := make([]string, 0, len(chunks))
+	for i := range chunks {
+		summary := fmt.Sprintf("chunk %d summary\n%s", i+1, strings.Repeat("important file command error test blocker next-step ", 130))
+		formattedSummaries = append(formattedSummaries, fmt.Sprintf("## Chunk %d/%d\n%s", i+1, len(chunks), summary))
+		responses = append(responses, testOpenAICompatSSECompletedResponse(
+			fmt.Sprintf("resp_chunk_%d", i+1),
+			"gpt-5.3-codex-spark",
+			summary,
+			100+i,
+			20+i,
+		))
+	}
+
+	retryGroups := groupAnthropicCompactSummariesForMerge(compactPrompt, formattedSummaries, openAIAnthropicCompactMergeTargetChars/2)
+	require.Greater(t, len(retryGroups), 1)
+	responses = append(responses, testOpenAICompatSSEFailedContextResponse("resp_merge_too_big", "gpt-5.3-codex-spark", 280_000))
+	for i := range retryGroups {
+		responses = append(responses, testOpenAICompatSSECompletedResponse(
+			fmt.Sprintf("resp_group_merge_%d", i+1),
+			"gpt-5.3-codex-spark",
+			fmt.Sprintf("group %d compact summary", i+1),
+			400+i,
+			40+i,
+		))
+	}
+	responses = append(responses, testOpenAICompatSSECompletedResponse(
+		"resp_final_recursive_merge",
+		"gpt-5.3-codex-spark",
+		"final recursive compact summary",
+		900,
+		90,
+	))
+	upstream := &httpUpstreamRecorder{responses: responses}
+
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.5",
+			},
+			"compact_model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.3-codex-spark",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "final recursive compact summary")
+	require.Equal(t, "resp_final_recursive_merge", result.ResponseID)
+	require.Equal(t, "gpt-5.3-codex-spark", result.UpstreamModel)
+	require.Greater(t, result.Usage.InputTokens, 246_445)
+	require.Len(t, upstream.bodies, len(chunks)+len(retryGroups)+3)
+	for _, upstreamBody := range upstream.bodies {
+		require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstreamBody, "model").String())
+		require.False(t, gjson.GetBytes(upstreamBody, "previous_response_id").Exists())
+	}
+}
+
+func TestForwardAsAnthropic_ClaudeCodeCompactReturnsEmergencySummaryWhenMergeStillTooLarge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(fmt.Sprintf(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"active task: fix compact overflow"},{"role":"user","content":[{"type":"text","text":%q}]}],"stream":true}`,
+		testClaudeCodeCompactPrompt(),
+	))
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		testOpenAICompatSSEFailedContextResponse("resp_full_too_big", "gpt-5.3-codex-spark", 246_445),
+		testOpenAICompatSSECompletedResponse("resp_chunk_1", "gpt-5.3-codex-spark", "active task: fix compact overflow\nnext: continue tests", 100, 20),
+		testOpenAICompatSSEFailedContextResponse("resp_merge_too_big", "gpt-5.3-codex-spark", 280_000),
+	}}
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"compact_model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.3-codex-spark",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.True(t, strings.HasPrefix(result.ResponseID, "compact_fallback_"))
+	require.Contains(t, rec.Body.String(), "# Compact Capsule")
+	require.Contains(t, rec.Body.String(), "active task: fix compact overflow")
+	require.Len(t, upstream.bodies, 3)
+}
+
 func testOpenAICompatSSEFailedContextResponse(id, model string, inputTokens int) *http.Response {
 	body := fmt.Sprintf(
 		"data: {\"type\":\"response.failed\",\"response\":{\"id\":%q,\"object\":\"response\",\"model\":%q,\"status\":\"failed\",\"output\":[],\"error\":{\"code\":\"context_length_exceeded\",\"message\":\"Your input exceeds the context window of this model. Please adjust your input and try again.\"},\"usage\":{\"input_tokens\":%d,\"output_tokens\":0,\"total_tokens\":%d}}}\n\ndata: [DONE]\n\n",
@@ -1991,6 +2160,8 @@ func TestForwardAsAnthropic_MissingTerminalAfterClientDisconnectSkipsOpsAndFailo
 
 	upstreamBody := strings.Join([]string{
 		`data: {"type":"response.created","response":{"id":"resp_1","model":"gpt-5.4","status":"in_progress","output":[]}}`,
+		"",
+		`data: {"type":"response.output_text.delta","delta":"partial"}`,
 		"",
 	}, "\n")
 	upstream := &httpUpstreamRecorder{resp: &http.Response{

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -124,6 +124,28 @@ func TestApplyOpenAICompatModelNormalization(t *testing.T) {
 	})
 }
 
+func TestIsClaudeCodeCompactAnthropicRequest(t *testing.T) {
+	t.Parallel()
+
+	compactPrompt := testClaudeCodeCompactPrompt()
+	req := &apicompat.AnthropicRequest{
+		Messages: []apicompat.AnthropicMessage{
+			{Role: "user", Content: []byte(`"normal earlier message"`)},
+			{Role: "assistant", Content: []byte(`"ok"`)},
+			{Role: "user", Content: []byte(fmt.Sprintf(`[{"type":"text","text":%q}]`, compactPrompt))},
+		},
+	}
+
+	require.True(t, isClaudeCodeCompactAnthropicRequest(req))
+
+	notCompact := &apicompat.AnthropicRequest{
+		Messages: []apicompat.AnthropicMessage{
+			{Role: "user", Content: []byte(`"please compact this code but do not summarize a Claude Code transcript"`)},
+		},
+	}
+	require.False(t, isClaudeCodeCompactAnthropicRequest(notCompact))
+}
+
 func TestForwardAsAnthropic_NormalizesRoutingAndEffortForGpt54XHigh(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -183,6 +205,63 @@ func TestForwardAsAnthropic_NormalizesRoutingAndEffortForGpt54XHigh(t *testing.T
 	t.Logf("response body: %s", rec.Body.String())
 }
 
+func TestForwardAsAnthropic_ClaudeCodeCompactUsesCompactModelMapping(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(fmt.Sprintf(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":[{"type":"text","text":%q}]}],"stream":true}`, testClaudeCodeCompactPrompt()))
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_compact","model":"gpt-5.3-codex-spark","status":"in_progress","output":[]}}`,
+		"",
+		`data: {"type":"response.output_text.delta","delta":"ok"}`,
+		"",
+		`data: {"type":"response.completed","response":{"id":"resp_compact","object":"response","model":"gpt-5.3-codex-spark","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":31,"output_tokens":9,"total_tokens":40}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_compact_model"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.5",
+			},
+			"compact_model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.3-codex-spark",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "gpt-5.5", result.Model)
+	require.Equal(t, "gpt-5.3-codex-spark", result.BillingModel)
+	require.Equal(t, "gpt-5.3-codex-spark", result.UpstreamModel)
+	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.lastBody, "model").String())
+}
+
 func TestForwardAsAnthropic_MappedClaudeModelAcceptsChatUsageShape(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -238,6 +317,20 @@ func TestForwardAsAnthropic_MappedClaudeModelAcceptsChatUsageShape(t *testing.T)
 	require.Equal(t, 9, result.Usage.OutputTokens)
 	require.Equal(t, 11, result.Usage.CacheReadInputTokens)
 	require.Equal(t, "gpt-5.5", gjson.GetBytes(upstream.lastBody, "model").String())
+}
+
+func testClaudeCodeCompactPrompt() string {
+	return strings.Join([]string{
+		"Your task is to create a detailed summary of the conversation so far, paying close attention to the user's explicit requests and your previous actions.",
+		"Before providing your final summary, wrap your analysis in <analysis> tags.",
+		"<analysis>",
+		"</analysis>",
+		"<summary>",
+		"6. All user messages:",
+		"7. Pending Tasks:",
+		"8. Current Work:",
+		"</summary>",
+	}, "\n")
 }
 
 func TestForwardAsAnthropic_InjectsPromptCacheKeyForAPIKeyMessagesDispatch(t *testing.T) {

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -263,6 +263,55 @@ func TestForwardAsAnthropic_ClaudeCodeCompactUsesCompactModelMapping(t *testing.
 	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.lastBody, "model").String())
 }
 
+func TestForwardAsAnthropic_ClaudeCodeCompactFallsBackToMiniWhenSparkRateLimited(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(fmt.Sprintf(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":"active task: keep compact moving"},{"role":"user","content":[{"type":"text","text":%q}]}],"stream":true}`, testClaudeCodeCompactPrompt()))
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		testOpenAICompatJSONErrorResponse(http.StatusTooManyRequests, "rate_limit_error", "The usage limit has been reached for gpt-5.3-codex-spark.", "rid_spark_rate_limited"),
+		testOpenAICompatSSECompletedResponse("resp_mini_chunk_1", "gpt-5.4-mini", "mini chunk summary", 120, 12),
+		testOpenAICompatSSECompletedResponse("resp_mini_merge", "gpt-5.4-mini", "mini merged compact summary", 180, 18),
+	}}
+
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"compact_model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.3-codex-spark",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "mini merged compact summary")
+	require.Equal(t, "resp_mini_merge", result.ResponseID)
+	require.Equal(t, "gpt-5.5", result.Model)
+	require.Equal(t, "gpt-5.4-mini", result.BillingModel)
+	require.Equal(t, "gpt-5.4-mini", result.UpstreamModel)
+	require.Len(t, upstream.bodies, 3)
+	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.bodies[0], "model").String())
+	require.Equal(t, "gpt-5.4-mini", gjson.GetBytes(upstream.bodies[1], "model").String())
+	require.Equal(t, "gpt-5.4-mini", gjson.GetBytes(upstream.bodies[2], "model").String())
+}
+
 func TestForwardAsAnthropic_ClaudeCodeCompactChunksWhenCompactModelContextExceeded(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -346,6 +395,88 @@ func TestForwardAsAnthropic_ClaudeCodeCompactChunksWhenCompactModelContextExceed
 		require.False(t, gjson.GetBytes(upstreamBody, "previous_response_id").Exists())
 	}
 	require.Contains(t, string(upstream.bodies[len(upstream.bodies)-1]), "chunk 1 summary")
+}
+
+func TestForwardAsAnthropic_ClaudeCodeCompactChunkFallbackSwitchesToMiniWhenSparkRateLimited(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldTarget := openAIAnthropicCompactChunkTargetChars
+	openAIAnthropicCompactChunkTargetChars = 80
+	defer func() { openAIAnthropicCompactChunkTargetChars = oldTarget }()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(fmt.Sprintf(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":%q},{"role":"assistant","content":%q},{"role":"user","content":[{"type":"text","text":%q}]}],"stream":true}`,
+		strings.Repeat("alpha file command error ", 20),
+		strings.Repeat("beta verification blocker ", 20),
+		testClaudeCodeCompactPrompt(),
+	))
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	var anthropicReq apicompat.AnthropicRequest
+	require.NoError(t, json.Unmarshal(body, &anthropicReq))
+	_, transcript := buildAnthropicCompactFallbackTranscript(&anthropicReq)
+	chunks := splitAnthropicCompactTranscriptChunks(transcript, openAIAnthropicCompactChunkTargetChars, openAIAnthropicCompactFallbackMaxChunks)
+	require.GreaterOrEqual(t, len(chunks), 2)
+
+	responses := []*http.Response{
+		testOpenAICompatSSEFailedContextResponse("resp_full_too_big", "gpt-5.3-codex-spark", 210_000),
+		testOpenAICompatJSONErrorResponse(http.StatusTooManyRequests, "rate_limit_error", "The usage limit has been reached for gpt-5.3-codex-spark.", "rid_spark_chunk_rate_limited"),
+	}
+	for i := range chunks {
+		responses = append(responses, testOpenAICompatSSECompletedResponse(
+			fmt.Sprintf("resp_mini_chunk_%d", i+1),
+			"gpt-5.4-mini",
+			fmt.Sprintf("mini chunk %d summary", i+1),
+			120+i,
+			12+i,
+		))
+	}
+	responses = append(responses, testOpenAICompatSSECompletedResponse(
+		"resp_mini_merge",
+		"gpt-5.4-mini",
+		"mini merged compact summary after spark limit",
+		240,
+		24,
+	))
+	upstream := &httpUpstreamRecorder{responses: responses}
+
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"compact_model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.3-codex-spark",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "mini merged compact summary after spark limit")
+	require.Equal(t, "resp_mini_merge", result.ResponseID)
+	require.Equal(t, "gpt-5.4-mini", result.BillingModel)
+	require.Equal(t, "gpt-5.4-mini", result.UpstreamModel)
+	require.Greater(t, result.Usage.InputTokens, 210_000)
+	require.Len(t, upstream.bodies, len(chunks)+3)
+	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.bodies[0], "model").String())
+	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.bodies[1], "model").String())
+	for _, upstreamBody := range upstream.bodies[2:] {
+		require.Equal(t, "gpt-5.4-mini", gjson.GetBytes(upstreamBody, "model").String())
+		require.False(t, gjson.GetBytes(upstreamBody, "previous_response_id").Exists())
+	}
 }
 
 func TestForwardAsAnthropic_ClaudeCodeCompactRecursivelyMergesWhenMergeContextExceeded(t *testing.T) {
@@ -528,6 +659,15 @@ func testOpenAICompatSSEFailedContextResponse(id, model string, inputTokens int)
 	return &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_" + id}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func testOpenAICompatJSONErrorResponse(statusCode int, code, message, requestID string) *http.Response {
+	body := fmt.Sprintf(`{"error":{"code":%q,"message":%q,"type":%q}}`, code, message, code)
+	return &http.Response{
+		StatusCode: statusCode,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{requestID}},
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -260,6 +261,124 @@ func TestForwardAsAnthropic_ClaudeCodeCompactUsesCompactModelMapping(t *testing.
 	require.Equal(t, "gpt-5.3-codex-spark", result.BillingModel)
 	require.Equal(t, "gpt-5.3-codex-spark", result.UpstreamModel)
 	require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstream.lastBody, "model").String())
+}
+
+func TestForwardAsAnthropic_ClaudeCodeCompactChunksWhenCompactModelContextExceeded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	oldTarget := openAIAnthropicCompactChunkTargetChars
+	openAIAnthropicCompactChunkTargetChars = 80
+	defer func() { openAIAnthropicCompactChunkTargetChars = oldTarget }()
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(fmt.Sprintf(`{"model":"gpt-5.5","max_tokens":16,"messages":[{"role":"user","content":%q},{"role":"assistant","content":%q},{"role":"user","content":[{"type":"text","text":%q}]}],"stream":true}`,
+		strings.Repeat("alpha file command error ", 20),
+		strings.Repeat("beta verification blocker ", 20),
+		testClaudeCodeCompactPrompt(),
+	))
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	var anthropicReq apicompat.AnthropicRequest
+	require.NoError(t, json.Unmarshal(body, &anthropicReq))
+	_, transcript := buildAnthropicCompactFallbackTranscript(&anthropicReq)
+	chunks := splitAnthropicCompactTranscriptChunks(transcript, openAIAnthropicCompactChunkTargetChars, openAIAnthropicCompactFallbackMaxChunks)
+	require.GreaterOrEqual(t, len(chunks), 2)
+
+	responses := []*http.Response{
+		testOpenAICompatSSEFailedContextResponse("resp_full_too_big", "gpt-5.3-codex-spark", 210_000),
+	}
+	for i := range chunks {
+		responses = append(responses, testOpenAICompatSSECompletedResponse(
+			fmt.Sprintf("resp_chunk_%d", i+1),
+			"gpt-5.3-codex-spark",
+			fmt.Sprintf("chunk %d summary", i+1),
+			100+i,
+			10+i,
+		))
+	}
+	responses = append(responses, testOpenAICompatSSECompletedResponse(
+		"resp_merge",
+		"gpt-5.3-codex-spark",
+		"merged compact summary",
+		300,
+		30,
+	))
+	upstream := &httpUpstreamRecorder{responses: responses}
+
+	svc := &OpenAIGatewayService{
+		httpUpstream: upstream,
+		cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+	}
+	account := &Account{
+		ID:          1,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.5",
+			},
+			"compact_model_mapping": map[string]any{
+				"gpt-5.5": "gpt-5.3-codex-spark",
+			},
+		},
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "merged compact summary")
+	require.Equal(t, "resp_merge", result.ResponseID)
+	require.Equal(t, "gpt-5.5", result.Model)
+	require.Equal(t, "gpt-5.3-codex-spark", result.BillingModel)
+	require.Equal(t, "gpt-5.3-codex-spark", result.UpstreamModel)
+	require.True(t, result.Stream)
+	require.Greater(t, result.Usage.InputTokens, 210_000)
+	require.Len(t, upstream.bodies, len(chunks)+2)
+	for _, upstreamBody := range upstream.bodies {
+		require.Equal(t, "gpt-5.3-codex-spark", gjson.GetBytes(upstreamBody, "model").String())
+		require.False(t, gjson.GetBytes(upstreamBody, "previous_response_id").Exists())
+	}
+	require.Contains(t, string(upstream.bodies[len(upstream.bodies)-1]), "chunk 1 summary")
+}
+
+func testOpenAICompatSSEFailedContextResponse(id, model string, inputTokens int) *http.Response {
+	body := fmt.Sprintf(
+		"data: {\"type\":\"response.failed\",\"response\":{\"id\":%q,\"object\":\"response\",\"model\":%q,\"status\":\"failed\",\"output\":[],\"error\":{\"code\":\"context_length_exceeded\",\"message\":\"Your input exceeds the context window of this model. Please adjust your input and try again.\"},\"usage\":{\"input_tokens\":%d,\"output_tokens\":0,\"total_tokens\":%d}}}\n\ndata: [DONE]\n\n",
+		id,
+		model,
+		inputTokens,
+		inputTokens,
+	)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_" + id}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func testOpenAICompatSSECompletedResponse(id, model, text string, inputTokens, outputTokens int) *http.Response {
+	body := fmt.Sprintf(
+		"data: {\"type\":\"response.completed\",\"response\":{\"id\":%q,\"object\":\"response\",\"model\":%q,\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"id\":\"msg_%s\",\"role\":\"assistant\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"text\":%q}]}],\"usage\":{\"input_tokens\":%d,\"output_tokens\":%d,\"total_tokens\":%d}}}\n\ndata: [DONE]\n\n",
+		id,
+		model,
+		id,
+		text,
+		inputTokens,
+		outputTokens,
+		inputTokens+outputTokens,
+	)
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_" + id}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
 }
 
 func TestForwardAsAnthropic_MappedClaudeModelAcceptsChatUsageShape(t *testing.T) {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -66,12 +66,15 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	anthropicCompactRequest := isClaudeCodeCompactAnthropicRequest(&anthropicReq)
 	anthropicCompactModelMapped := false
+	anthropicCompactRequestedModel := billingModel
+	var anthropicCompactFallbackUpstreamModels []string
 	if anthropicCompactRequest {
 		compactBillingModel := resolveOpenAICompactForwardModel(account, billingModel)
 		anthropicCompactModelMapped = compactBillingModel != "" && compactBillingModel != billingModel
 		if anthropicCompactModelMapped {
 			billingModel = compactBillingModel
 			upstreamModel = normalizeOpenAIModelForUpstream(account, billingModel)
+			anthropicCompactFallbackUpstreamModels = resolveOpenAICompactFallbackForwardModels(account, anthropicCompactRequestedModel, billingModel)
 		}
 	}
 	promptCacheKey = strings.TrimSpace(promptCacheKey)
@@ -150,6 +153,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 			zap.Bool("anthropic_compact_request", true),
 			zap.Bool("anthropic_compact_model_mapped", anthropicCompactModelMapped),
 		)
+		if len(anthropicCompactFallbackUpstreamModels) > 0 {
+			logFields = append(logFields, zap.Strings("anthropic_compact_fallback_upstream_models", anthropicCompactFallbackUpstreamModels))
+		}
 	}
 	if compatPromptCacheInjected {
 		logFields = append(logFields,
@@ -354,6 +360,30 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 
 		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+		if anthropicCompactRequest && anthropicCompactModelMapped &&
+			isOpenAICompactModelUnavailableHTTP(resp.StatusCode, upstreamMsg, respBody) &&
+			len(anthropicCompactFallbackUpstreamModels) > 0 {
+			logger.L().Warn("openai_messages.compact_model_unavailable_fallback",
+				zap.Int64("account_id", account.ID),
+				zap.String("model", originalModel),
+				zap.String("upstream_model", upstreamModel),
+				zap.Strings("fallback_upstream_models", anthropicCompactFallbackUpstreamModels),
+				zap.Int("upstream_status", resp.StatusCode),
+				zap.String("upstream_request_id", resp.Header.Get("x-request-id")),
+				zap.String("upstream_message", upstreamMsg),
+			)
+			result, fallbackErr := s.runAnthropicCompactChunkFallbackWithModelFallbacks(ctx, c, account, &anthropicReq, token, originalModel, anthropicCompactFallbackUpstreamModels, startTime, OpenAIUsage{}, clientStream, resp.Header.Get("x-request-id"))
+			if fallbackErr == nil || c.Writer.Written() {
+				return result, fallbackErr
+			}
+			logger.L().Warn("openai_messages.compact_model_unavailable_fallback_failed",
+				zap.Int64("account_id", account.ID),
+				zap.String("model", originalModel),
+				zap.String("upstream_model", upstreamModel),
+				zap.Strings("fallback_upstream_models", anthropicCompactFallbackUpstreamModels),
+				zap.Error(fallbackErr),
+			)
+		}
 		if previousResponseID != "" && (isOpenAICompatPreviousResponseNotFound(resp.StatusCode, upstreamMsg, respBody) || isOpenAICompatPreviousResponseUnsupported(resp.StatusCode, upstreamMsg, respBody)) {
 			if isOpenAICompatPreviousResponseUnsupported(resp.StatusCode, upstreamMsg, respBody) {
 				s.disableOpenAICompatSessionContinuation(ctx, c, account, promptCacheKey)
@@ -408,7 +438,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	var result *OpenAIForwardResult
 	var handleErr error
 	if anthropicCompactRequest && anthropicCompactModelMapped {
-		result, handleErr = s.handleAnthropicCompactMappedStreamingResponse(ctx, c, account, resp, originalModel, billingModel, upstreamModel, startTime, &anthropicReq, token, clientStream)
+		result, handleErr = s.handleAnthropicCompactMappedStreamingResponse(ctx, c, account, resp, originalModel, billingModel, upstreamModel, anthropicCompactFallbackUpstreamModels, startTime, &anthropicReq, token, clientStream)
 	} else if clientStream {
 		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime, estimatedInputTokens)
 	} else {
@@ -492,6 +522,7 @@ func (s *OpenAIGatewayService) handleAnthropicCompactMappedStreamingResponse(
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
+	compactFallbackUpstreamModels []string,
 	startTime time.Time,
 	anthropicReq *apicompat.AnthropicRequest,
 	token string,
@@ -508,6 +539,23 @@ func (s *OpenAIGatewayService) handleAnthropicCompactMappedStreamingResponse(
 		return nil, fmt.Errorf("upstream stream ended without terminal event")
 	}
 
+	if isOpenAIResponsesCompactModelUnavailable(finalResponse) && len(compactFallbackUpstreamModels) > 0 {
+		logger.L().Warn("openai_messages.compact_model_unavailable_fallback",
+			zap.String("request_id", requestID),
+			zap.Int64("account_id", account.ID),
+			zap.String("model", originalModel),
+			zap.String("upstream_model", upstreamModel),
+			zap.Strings("fallback_upstream_models", compactFallbackUpstreamModels),
+			zap.Int("initial_input_tokens", usage.InputTokens),
+			zap.String("upstream_message", openAIResponsesErrorMessage(finalResponse)),
+		)
+		result, fallbackErr := s.runAnthropicCompactChunkFallbackWithModelFallbacks(ctx, c, account, anthropicReq, token, originalModel, compactFallbackUpstreamModels, startTime, usage, clientStream, requestID)
+		if fallbackErr != nil && !c.Writer.Written() {
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", openAIAnthropicCompactFallbackFallbackResponse)
+		}
+		return result, fallbackErr
+	}
+
 	if isOpenAIResponsesContextLengthExceeded(finalResponse) {
 		logger.L().Warn("openai_messages.compact_context_length_fallback",
 			zap.String("request_id", requestID),
@@ -516,7 +564,8 @@ func (s *OpenAIGatewayService) handleAnthropicCompactMappedStreamingResponse(
 			zap.String("upstream_model", upstreamModel),
 			zap.Int("initial_input_tokens", usage.InputTokens),
 		)
-		result, fallbackErr := s.runAnthropicCompactChunkFallback(ctx, c, account, anthropicReq, token, originalModel, billingModel, upstreamModel, startTime, usage, clientStream, requestID)
+		candidates := append([]string{upstreamModel}, compactFallbackUpstreamModels...)
+		result, fallbackErr := s.runAnthropicCompactChunkFallbackWithModelFallbacks(ctx, c, account, anthropicReq, token, originalModel, candidates, startTime, usage, clientStream, requestID)
 		if fallbackErr != nil && !c.Writer.Written() {
 			writeAnthropicError(c, http.StatusBadGateway, "api_error", openAIAnthropicCompactFallbackFallbackResponse)
 		}
@@ -667,6 +716,65 @@ func isOpenAIResponsesContextLengthExceeded(resp *apicompat.ResponsesResponse) b
 	return strings.Contains(message, "context window") && strings.Contains(message, "exceed")
 }
 
+func isOpenAIResponsesCompactModelUnavailable(resp *apicompat.ResponsesResponse) bool {
+	if resp == nil || resp.Error == nil || isOpenAIResponsesContextLengthExceeded(resp) {
+		return false
+	}
+	return isOpenAICompactUnavailableText(resp.Error.Code + " " + resp.Error.Message)
+}
+
+func isOpenAICompactModelUnavailableHTTP(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	if isOpenAIContextWindowError(upstreamMsg, upstreamBody) {
+		return false
+	}
+	switch statusCode {
+	case http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout, 529:
+		return true
+	}
+	if statusCode >= 500 {
+		return true
+	}
+	return isOpenAICompactUnavailableText(upstreamMsg + " " + string(upstreamBody))
+}
+
+func isOpenAICompactModelUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isOpenAICompactUnavailableText(err.Error())
+}
+
+func isOpenAICompactUnavailableText(text string) bool {
+	lower := strings.ToLower(strings.TrimSpace(text))
+	if lower == "" {
+		return false
+	}
+	for _, pattern := range []string{
+		"429",
+		"529",
+		"rate_limit",
+		"rate limit",
+		"too many requests",
+		"usage limit",
+		"quota",
+		"resource exhausted",
+		"temporarily unavailable",
+		"service unavailable",
+		"no available account",
+		"no available accounts",
+		"selected model is at capacity",
+		"server is overloaded",
+		"slow_down",
+		"unsupported model",
+		"unknown model",
+	} {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return strings.Contains(lower, "unavailable") && strings.Contains(lower, "model")
+}
+
 func writeAnthropicResponseAsSSE(c *gin.Context, resp *apicompat.AnthropicResponse) error {
 	if resp == nil {
 		return errors.New("anthropic response is nil")
@@ -757,6 +865,60 @@ func writeAnthropicResponseAsSSE(c *gin.Context, resp *apicompat.AnthropicRespon
 	}
 	c.Writer.Flush()
 	return nil
+}
+
+func (s *OpenAIGatewayService) runAnthropicCompactChunkFallbackWithModelFallbacks(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	anthropicReq *apicompat.AnthropicRequest,
+	token string,
+	originalModel string,
+	candidateUpstreamModels []string,
+	startTime time.Time,
+	initialUsage OpenAIUsage,
+	clientStream bool,
+	initialRequestID string,
+) (*OpenAIForwardResult, error) {
+	candidates := compactModelFallbackCandidates(candidateUpstreamModels, "")
+	if len(candidates) == 0 {
+		return nil, errors.New("compact fallback has no candidate upstream models")
+	}
+
+	runningInitialUsage := initialUsage
+	var lastResult *OpenAIForwardResult
+	var lastErr error
+	for i, candidate := range candidates {
+		candidateUpstreamModel := normalizeOpenAIModelForUpstream(account, candidate)
+		if candidateUpstreamModel == "" {
+			continue
+		}
+		result, err := s.runAnthropicCompactChunkFallback(ctx, c, account, anthropicReq, token, originalModel, candidateUpstreamModel, candidateUpstreamModel, startTime, runningInitialUsage, clientStream, initialRequestID)
+		if err == nil {
+			return result, nil
+		}
+		lastResult = result
+		lastErr = err
+		if result != nil {
+			runningInitialUsage = result.Usage
+		}
+		if !isOpenAICompactModelUnavailableError(err) {
+			return result, err
+		}
+		if i+1 < len(candidates) {
+			logger.L().Warn("openai_messages.compact_chunk_model_unavailable_switching",
+				zap.Int64("account_id", account.ID),
+				zap.String("model", originalModel),
+				zap.String("failed_upstream_model", candidateUpstreamModel),
+				zap.String("next_upstream_model", normalizeOpenAIModelForUpstream(account, candidates[i+1])),
+				zap.Error(err),
+			)
+		}
+	}
+	if lastErr == nil {
+		lastErr = errors.New("compact fallback exhausted candidate upstream models")
+	}
+	return lastResult, lastErr
 }
 
 func (s *OpenAIGatewayService) runAnthropicCompactChunkFallback(

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -23,12 +23,15 @@ import (
 )
 
 var openAIAnthropicCompactChunkTargetChars = 300_000
+var openAIAnthropicCompactMergeTargetChars = 180_000
 
 const (
 	openAIAnthropicCompactFallbackMaxChunks        = 40
 	openAIAnthropicCompactChunkMaxOutputTokens     = 6_000
 	openAIAnthropicCompactMergeMaxOutputTokens     = 12_000
+	openAIAnthropicCompactEmergencyMaxRunes        = 90_000
 	openAIAnthropicCompactFallbackMinSplitRunes    = 4_000
+	openAIAnthropicCompactMergeMaxDepth            = 6
 	openAIAnthropicCompactFallbackChunkReasoning   = "low"
 	openAIAnthropicCompactFallbackFallbackResponse = "Claude Code compact fallback failed before producing a summary"
 )
@@ -833,8 +836,7 @@ func (s *OpenAIGatewayService) runAnthropicCompactChunkFallback(
 		summaries = append(summaries, fmt.Sprintf("## Chunk %d/%d\n%s", i+1, len(chunks), summary))
 	}
 
-	mergePrompt := buildAnthropicCompactMergePrompt(compactPrompt, summaries)
-	finalResponse, mergeUsage, mergeRequestID, err := s.runOpenAIAnthropicCompactFallbackResponsesRequest(ctx, c, account, token, upstreamModel, openAIAnthropicCompactMergeInstructions(), mergePrompt, openAIAnthropicCompactMergeMaxOutputTokens)
+	finalResponse, mergeUsage, mergeRequestID, err := s.mergeAnthropicCompactFallbackSummaries(ctx, c, account, token, upstreamModel, compactPrompt, summaries, openAIAnthropicCompactMergeTargetChars, 0)
 	totalUsage = addOpenAIUsage(totalUsage, mergeUsage)
 	if err != nil {
 		return &OpenAIForwardResult{
@@ -849,18 +851,6 @@ func (s *OpenAIGatewayService) runAnthropicCompactChunkFallback(
 	}
 	if finalResponse == nil {
 		return nil, errors.New("compact fallback merge response is nil")
-	}
-	if isOpenAIResponsesContextLengthExceeded(finalResponse) {
-		return &OpenAIForwardResult{
-			RequestID:     firstNonEmpty(mergeRequestID, initialRequestID),
-			ResponseID:    finalResponse.ID,
-			Usage:         totalUsage,
-			Model:         originalModel,
-			BillingModel:  billingModel,
-			UpstreamModel: upstreamModel,
-			Stream:        clientStream,
-			Duration:      time.Since(startTime),
-		}, errors.New("compact fallback merge exceeded context window")
 	}
 	if strings.TrimSpace(finalResponse.Status) == "failed" {
 		return &OpenAIForwardResult{
@@ -877,6 +867,78 @@ func (s *OpenAIGatewayService) runAnthropicCompactChunkFallback(
 
 	finalResponse.Usage = responsesUsageFromOpenAIUsage(totalUsage)
 	return s.writeAnthropicBufferedFinalResponse(c, account, nil, finalResponse, totalUsage, originalModel, billingModel, upstreamModel, startTime, clientStream, firstNonEmpty(mergeRequestID, initialRequestID))
+}
+
+func (s *OpenAIGatewayService) mergeAnthropicCompactFallbackSummaries(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	token string,
+	upstreamModel string,
+	compactPrompt string,
+	summaries []string,
+	targetChars int,
+	depth int,
+) (*apicompat.ResponsesResponse, OpenAIUsage, string, error) {
+	if len(summaries) == 0 {
+		return nil, OpenAIUsage{}, "", errors.New("compact fallback merge summaries are empty")
+	}
+	if targetChars <= 0 {
+		targetChars = openAIAnthropicCompactMergeTargetChars
+	}
+	if depth > openAIAnthropicCompactMergeMaxDepth {
+		return nil, OpenAIUsage{}, "", errors.New("compact fallback merge exceeded recursive depth")
+	}
+
+	groups := groupAnthropicCompactSummariesForMerge(compactPrompt, summaries, targetChars)
+	if len(groups) > 1 {
+		totalUsage := OpenAIUsage{}
+		reduced := make([]string, 0, len(groups))
+		lastRequestID := ""
+		for i, group := range groups {
+			groupResp, groupUsage, groupRequestID, err := s.mergeAnthropicCompactFallbackSummaries(ctx, c, account, token, upstreamModel, compactPrompt, group, targetChars, depth+1)
+			totalUsage = addOpenAIUsage(totalUsage, groupUsage)
+			lastRequestID = firstNonEmpty(groupRequestID, lastRequestID)
+			if err != nil {
+				return groupResp, totalUsage, lastRequestID, err
+			}
+			if groupResp == nil {
+				return nil, totalUsage, lastRequestID, errors.New("compact fallback grouped merge response is nil")
+			}
+			summary := strings.TrimSpace(openAIResponsesOutputText(groupResp))
+			if summary == "" {
+				return groupResp, totalUsage, lastRequestID, fmt.Errorf("compact fallback grouped merge %d produced empty summary", i+1)
+			}
+			reduced = append(reduced, fmt.Sprintf("## Summary group %d/%d\n%s", i+1, len(groups), summary))
+		}
+		finalResp, finalUsage, finalRequestID, err := s.mergeAnthropicCompactFallbackSummaries(ctx, c, account, token, upstreamModel, compactPrompt, reduced, targetChars, depth+1)
+		totalUsage = addOpenAIUsage(totalUsage, finalUsage)
+		return finalResp, totalUsage, firstNonEmpty(finalRequestID, lastRequestID), err
+	}
+
+	mergePrompt := buildAnthropicCompactMergePrompt(compactPrompt, summaries)
+	finalResponse, usage, requestID, err := s.runOpenAIAnthropicCompactFallbackResponsesRequest(ctx, c, account, token, upstreamModel, openAIAnthropicCompactMergeInstructions(), mergePrompt, openAIAnthropicCompactMergeMaxOutputTokens)
+	if err != nil {
+		return finalResponse, usage, requestID, err
+	}
+	if finalResponse == nil {
+		return nil, usage, requestID, errors.New("compact fallback merge response is nil")
+	}
+	if isOpenAIResponsesContextLengthExceeded(finalResponse) {
+		nextTarget := targetChars / 2
+		if nextTarget < openAIAnthropicCompactFallbackMinSplitRunes {
+			nextTarget = openAIAnthropicCompactFallbackMinSplitRunes
+		}
+		retrySummaries := retryAnthropicCompactFallbackSummaries(compactPrompt, summaries, nextTarget)
+		if len(retrySummaries) > 0 && nextTarget < targetChars {
+			retryResp, retryUsage, retryRequestID, retryErr := s.mergeAnthropicCompactFallbackSummaries(ctx, c, account, token, upstreamModel, compactPrompt, retrySummaries, nextTarget, depth+1)
+			usage = addOpenAIUsage(usage, retryUsage)
+			return retryResp, usage, firstNonEmpty(retryRequestID, requestID), retryErr
+		}
+		emergency := buildAnthropicCompactEmergencySummary(compactPrompt, summaries)
+		return buildAnthropicCompactEmergencyResponse(upstreamModel, emergency, usage), usage, requestID, nil
+	}
+	return finalResponse, usage, requestID, nil
 }
 
 func (s *OpenAIGatewayService) runOpenAIAnthropicCompactFallbackResponsesRequest(
@@ -1200,15 +1262,229 @@ func buildAnthropicCompactMergePrompt(compactPrompt string, summaries []string) 
 	if strings.TrimSpace(compactPrompt) == "" {
 		compactPrompt = "Create a detailed Claude Code compact summary for the conversation. Preserve current work, user intent, files, commands, blockers, and next steps."
 	}
-	return strings.TrimSpace(compactPrompt) + "\n\nThe original conversation was too large for one compact request, so it was summarized in chunks. Merge the chunk summaries below into one coherent final compact summary. Do not mention the chunking process unless it is relevant to the work state.\n\n" + strings.Join(summaries, "\n\n")
+	cleaned := make([]string, 0, len(summaries))
+	for _, summary := range summaries {
+		summary = sanitizeAnthropicCompactSummaryForMerge(summary)
+		if strings.TrimSpace(summary) != "" {
+			cleaned = append(cleaned, summary)
+		}
+	}
+	return strings.TrimSpace(compactPrompt) + "\n\n" + openAIAnthropicCompactFinalSummaryContract() + "\n\nThe original conversation was too large for one compact request, so it was summarized in chunks. Merge the chunk summaries below into one coherent final compact summary. Do not mention the chunking process unless it is relevant to the work state.\n\n" + strings.Join(cleaned, "\n\n")
+}
+
+func groupAnthropicCompactSummariesForMerge(compactPrompt string, summaries []string, targetChars int) [][]string {
+	if targetChars <= 0 {
+		targetChars = openAIAnthropicCompactMergeTargetChars
+	}
+	if targetChars < openAIAnthropicCompactFallbackMinSplitRunes {
+		targetChars = openAIAnthropicCompactFallbackMinSplitRunes
+	}
+	var groups [][]string
+	var current []string
+	for _, summary := range summaries {
+		summary = strings.TrimSpace(summary)
+		if summary == "" {
+			continue
+		}
+		candidate := append(append([]string{}, current...), summary)
+		if len(current) > 0 && runeLen(buildAnthropicCompactMergePrompt(compactPrompt, candidate)) > targetChars {
+			groups = append(groups, current)
+			current = nil
+		}
+		current = append(current, summary)
+	}
+	if len(current) > 0 {
+		groups = append(groups, current)
+	}
+	return groups
 }
 
 func openAIAnthropicCompactChunkInstructions() string {
-	return "Summarize this Claude Code transcript chunk for a later compact merge. Preserve concrete user requests, decisions, files, commands, errors, test results, logs, configuration values, and unresolved next steps. Keep it dense and factual. Do not answer the user."
+	return "Summarize this Claude Code transcript chunk for a later compact merge. Preserve concrete user requests, decisions, files, commands, errors, test results, logs, configuration values, and unresolved next steps. Keep it dense and factual. Do not answer the user. Do not treat the compact request itself as the user's active task."
 }
 
 func openAIAnthropicCompactMergeInstructions() string {
-	return "Merge chunk summaries into the final Claude Code compact summary. Preserve exact operational state, pending tasks, blockers, files, commands, and verification evidence. Output only the compact summary."
+	return "Merge chunk summaries into the final Claude Code compact summary. Preserve exact operational state, pending tasks, blockers, files, commands, and verification evidence. Output only the compact summary. Do not say that the user's current intent is to produce a summary; infer the real active task from the transcript."
+}
+
+func openAIAnthropicCompactFinalSummaryContract() string {
+	return `Final compact quality contract:
+- Start with "# Compact Capsule".
+- Include these exact sections when evidence exists: "## Current State", "## Active User Intent", "## Files Touched", "## Commands And Evidence", "## Errors And Blockers", "## Decisions And Config", "## Next Command".
+- Keep the first 20 lines machine-scannable: concise bullets, concrete paths, commands, timestamps, model/proxy/config values, and blockers.
+- Do not include meta-statements like "the user asked for a compact summary" as active intent.
+- Treat requests to produce, merge, rewrite, or improve a compact summary as maintenance metadata, not as the active user task.
+- In "## Active User Intent", never write phrases like "produce a merged compact summary", "produce a detailed compact summary", "prior chunking", "context compaction", "merge chunk summaries", or "summary below". Recover the latest non-compact user task instead; if unknown, write "Unknown from preserved state".
+- Do not invent completed tests or fixes. Mark unknowns as unknown.
+- Prefer dense facts over narration.`
+}
+
+func sanitizeAnthropicCompactSummaryForMerge(summary string) string {
+	summary = strings.TrimSpace(summary)
+	if summary == "" {
+		return ""
+	}
+	lines := strings.Split(strings.ReplaceAll(summary, "\r\n", "\n"), "\n")
+	cleaned := make([]string, 0, len(lines))
+	skipIndentedContinuation := false
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if skipIndentedContinuation {
+			if strings.HasPrefix(line, "  -") || strings.HasPrefix(line, "\t-") || strings.HasPrefix(line, "    -") {
+				continue
+			}
+			skipIndentedContinuation = false
+		}
+		if isAnthropicCompactMaintenanceIntentLine(trimmed) {
+			skipIndentedContinuation = true
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+	return strings.TrimSpace(strings.Join(cleaned, "\n"))
+}
+
+func isAnthropicCompactMaintenanceIntentLine(line string) bool {
+	lower := strings.ToLower(strings.TrimSpace(line))
+	if lower == "" {
+		return false
+	}
+	intentTerms := []string{
+		"active intent",
+		"current intent",
+		"user intent",
+		"user asked",
+		"user-visible turn",
+		"current inferred",
+		"latest user",
+	}
+	compactMaintenanceTerms := []string{
+		"compact summary",
+		"compact capsule",
+		"summary of prior conversation",
+		"prior chunking",
+		"due prior chunking",
+		"due to chunking",
+		"context compaction",
+		"conversation compaction",
+		"merge chunk summaries",
+		"merge the chunk summaries",
+		"chunk summaries below",
+		"summary below",
+	}
+	hasIntent := false
+	for _, term := range intentTerms {
+		if strings.Contains(lower, term) {
+			hasIntent = true
+			break
+		}
+	}
+	if !hasIntent {
+		return false
+	}
+	for _, term := range compactMaintenanceTerms {
+		if strings.Contains(lower, term) {
+			return true
+		}
+	}
+	return false
+}
+
+func retryAnthropicCompactFallbackSummaries(compactPrompt string, summaries []string, targetChars int) []string {
+	if targetChars <= 0 {
+		targetChars = openAIAnthropicCompactMergeTargetChars / 2
+	}
+	if targetChars < openAIAnthropicCompactFallbackMinSplitRunes {
+		targetChars = openAIAnthropicCompactFallbackMinSplitRunes
+	}
+	if len(summaries) == 0 {
+		return nil
+	}
+	if len(summaries) > 1 {
+		return summaries
+	}
+	summary := strings.TrimSpace(summaries[0])
+	if summary == "" {
+		return nil
+	}
+	// A single intermediate summary can still be too large once the final
+	// compact instructions are prepended. Split it so the recursive reducer can
+	// shrink it in smaller model calls instead of returning a hard 502.
+	parts := splitTextByRuneLimit(summary, targetChars)
+	if len(parts) <= 1 && runeLen(buildAnthropicCompactMergePrompt(compactPrompt, []string{summary})) <= targetChars {
+		return nil
+	}
+	retry := make([]string, 0, len(parts))
+	for i, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		retry = append(retry, fmt.Sprintf("## Oversized summary split %d/%d\n%s", i+1, len(parts), part))
+	}
+	return retry
+}
+
+func buildAnthropicCompactEmergencySummary(compactPrompt string, summaries []string) string {
+	joined := strings.TrimSpace(strings.Join(summaries, "\n\n"))
+	if joined == "" {
+		joined = strings.TrimSpace(compactPrompt)
+	}
+	if joined == "" {
+		joined = openAIAnthropicCompactFallbackFallbackResponse
+	}
+	joined = trimRunesMiddle(joined, openAIAnthropicCompactEmergencyMaxRunes)
+	return "# Compact Capsule\n\n" +
+		"## Current State\n" +
+		"- The proxy had to use its emergency compact fallback because the upstream compact merge still exceeded the context window.\n" +
+		"- The content below is the best available compressed state from chunk summaries; verify exact details against the transcript if precision matters.\n\n" +
+		"## Active User Intent\n" +
+		"- Continue the original task from the preserved state below. Do not treat the compact operation itself as the user task.\n\n" +
+		"## Preserved State\n" +
+		joined + "\n\n" +
+		"## Next Command\n" +
+		"- Inspect the latest user prompt and resume from the preserved state without asking for a recap."
+}
+
+func buildAnthropicCompactEmergencyResponse(model string, summary string, usage OpenAIUsage) *apicompat.ResponsesResponse {
+	if strings.TrimSpace(model) == "" {
+		model = "compact-fallback"
+	}
+	return &apicompat.ResponsesResponse{
+		ID:     fmt.Sprintf("compact_fallback_%d", time.Now().UnixNano()),
+		Object: "response",
+		Model:  model,
+		Status: "completed",
+		Output: []apicompat.ResponsesOutput{{
+			Type:   "message",
+			Role:   "assistant",
+			Status: "completed",
+			Content: []apicompat.ResponsesContentPart{{
+				Type: "output_text",
+				Text: summary,
+			}},
+		}},
+		Usage: responsesUsageFromOpenAIUsage(usage),
+	}
+}
+
+func trimRunesMiddle(text string, maxRunes int) string {
+	if maxRunes <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= maxRunes {
+		return text
+	}
+	keepHead := maxRunes * 2 / 3
+	keepTail := maxRunes - keepHead
+	if keepHead < 0 {
+		keepHead = 0
+	}
+	if keepTail < 0 {
+		keepTail = 0
+	}
+	return string(runes[:keepHead]) + "\n\n[... middle omitted by compact fallback emergency guard ...]\n\n" + string(runes[len(runes)-keepTail:])
 }
 
 func openAIResponsesOutputText(resp *apicompat.ResponsesResponse) string {
@@ -1528,6 +1804,8 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	clientDisconnected := false
 	clientOutputStarted := false
 	clientVisibleOutputStarted := false
+	terminalClientErrorHandled := false
+	var terminalClientError error
 	var pendingClientSSE []string
 	streamDiag := newOpenAIMessagesStreamDiagnostic(estimatedInputTokens)
 
@@ -1644,6 +1922,8 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 						}
 						clientDisconnected = true
 					}
+					terminalClientErrorHandled = true
+					terminalClientError = fmt.Errorf("openai cyber_policy: %s", msg)
 					return true
 				}
 			}
@@ -1721,6 +2001,12 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			if !clientDisconnected && clientVisibleOutputStarted {
 				c.Writer.Flush()
 			}
+		}
+		if terminalClientErrorHandled {
+			if terminalClientError == nil {
+				terminalClientError = errors.New("terminal stream error handled")
+			}
+			return nil, terminalClientError
 		}
 		if !clientVisibleOutputStarted {
 			result := resultWithUsage()

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -245,6 +245,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		}
 		responsesBody = patchedBody
 	}
+	estimatedInputTokens := estimateOpenAIAnthropicStreamInputTokens(responsesBody, upstreamModel)
 
 	// 5. Get access token
 	token, _, err := s.GetAccessToken(ctx, account)
@@ -377,10 +378,10 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	var result *OpenAIForwardResult
 	var handleErr error
 	if clientStream {
-		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime, estimatedInputTokens)
 	} else {
 		// Client wants JSON: buffer the streaming response and assemble a JSON reply.
-		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, originalModel, billingModel, upstreamModel, startTime)
+		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
 	}
 
 	// cyber_policy：标记已设、error 已按 Anthropic 格式发给客户端。丢弃 result、返回哨兵，
@@ -456,6 +457,7 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -500,6 +502,20 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 	acc.SupplementResponseOutput(finalResponse)
 
 	anthropicResp := apicompat.ResponsesToAnthropic(finalResponse, originalModel)
+	if !anthropicResponseHasVisibleOutput(anthropicResp) {
+		result := &OpenAIForwardResult{
+			RequestID:     requestID,
+			ResponseID:    finalResponse.ID,
+			Usage:         usage,
+			Model:         originalModel,
+			BillingModel:  billingModel,
+			UpstreamModel: upstreamModel,
+			Stream:        false,
+			Duration:      time.Since(startTime),
+		}
+		message := "OpenAI messages buffered response completed without assistant content or tool output"
+		return result, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, message)
+	}
 
 	if s.responseHeaderFilter != nil {
 		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
@@ -713,6 +729,21 @@ func (s *OpenAIGatewayService) readOpenAICompatBufferedTerminal(
 	}
 }
 
+func estimateOpenAIAnthropicStreamInputTokens(responsesBody []byte, fallbackModel string) int {
+	var req openAIInputTokensCountRequest
+	if err := json.Unmarshal(responsesBody, &req); err != nil {
+		return 0
+	}
+	if strings.TrimSpace(req.Model) == "" {
+		req.Model = fallbackModel
+	}
+	n, err := estimateOpenAIInputTokens(req)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
 // handleAnthropicStreamingResponse reads Responses SSE events from upstream,
 // converts each to Anthropic SSE events, and writes them to the client.
 // When StreamKeepaliveInterval is configured, it uses a goroutine + channel
@@ -726,6 +757,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	billingModel string,
 	upstreamModel string,
 	startTime time.Time,
+	estimatedInputTokens int,
 ) (*OpenAIForwardResult, error) {
 	requestID := resp.Header.Get("x-request-id")
 
@@ -747,12 +779,18 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 
 	state := apicompat.NewResponsesEventToAnthropicState()
 	state.Model = originalModel
+	if estimatedInputTokens > 0 {
+		state.InputTokens = estimatedInputTokens
+	}
 	var usage OpenAIUsage
 	responseID := ""
 	var firstTokenMs *int
 	firstChunk := true
 	clientDisconnected := false
 	clientOutputStarted := false
+	clientVisibleOutputStarted := false
+	var pendingClientSSE []string
+	streamDiag := newOpenAIMessagesStreamDiagnostic(estimatedInputTokens)
 
 	scanner := bufio.NewScanner(resp.Body)
 	maxLineSize := defaultMaxLineSize
@@ -778,16 +816,38 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 	// resultWithUsage builds the final result snapshot.
 	resultWithUsage := func() *OpenAIForwardResult {
 		return &OpenAIForwardResult{
-			RequestID:        requestID,
-			ResponseID:       responseID,
-			Usage:            usage,
-			Model:            originalModel,
-			BillingModel:     billingModel,
-			UpstreamModel:    upstreamModel,
-			Stream:           true,
-			Duration:         time.Since(startTime),
-			FirstTokenMs:     firstTokenMs,
-			ClientDisconnect: clientDisconnected,
+			RequestID:           requestID,
+			ResponseID:          responseID,
+			Usage:               usage,
+			Model:               originalModel,
+			BillingModel:        billingModel,
+			UpstreamModel:       upstreamModel,
+			Stream:              true,
+			Duration:            time.Since(startTime),
+			FirstTokenMs:        firstTokenMs,
+			ClientDisconnect:    clientDisconnected,
+			ClientOutputStarted: clientOutputStarted,
+		}
+	}
+
+	flushPendingClientSSE := func() {
+		if clientDisconnected || len(pendingClientSSE) == 0 {
+			return
+		}
+		writeStreamHeaders()
+		for _, sse := range pendingClientSSE {
+			if _, err := fmt.Fprint(c.Writer, sse); err != nil {
+				clientDisconnected = true
+				logger.L().Info("openai messages stream: client disconnected during buffered flush",
+					zap.String("request_id", requestID),
+				)
+				break
+			}
+			clientOutputStarted = true
+		}
+		pendingClientSSE = pendingClientSSE[:0]
+		if !clientDisconnected {
+			c.Writer.Flush()
 		}
 	}
 
@@ -807,6 +867,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			)
 			return false
 		}
+		streamDiag.Record(event)
 
 		isTerminalEvent := isOpenAICompatResponsesTerminalEvent(event.Type)
 		if isTerminalEvent {
@@ -861,6 +922,17 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 					)
 					continue
 				}
+				if !clientVisibleOutputStarted {
+					pendingClientSSE = append(pendingClientSSE, sse)
+					if anthropicStreamEventHasVisibleOutput(evt) {
+						clientVisibleOutputStarted = true
+						flushPendingClientSSE()
+						if clientDisconnected {
+							break
+						}
+					}
+					continue
+				}
 				writeStreamHeaders()
 				if _, err := fmt.Fprint(c.Writer, sse); err != nil {
 					clientDisconnected = true
@@ -872,7 +944,7 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 				clientOutputStarted = true
 			}
 		}
-		if len(events) > 0 && !clientDisconnected {
+		if len(events) > 0 && !clientDisconnected && clientVisibleOutputStarted {
 			c.Writer.Flush()
 		}
 		return isTerminalEvent
@@ -886,6 +958,17 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 				if err != nil {
 					continue
 				}
+				if !clientVisibleOutputStarted {
+					pendingClientSSE = append(pendingClientSSE, sse)
+					if anthropicStreamEventHasVisibleOutput(evt) {
+						clientVisibleOutputStarted = true
+						flushPendingClientSSE()
+						if clientDisconnected {
+							break
+						}
+					}
+					continue
+				}
 				writeStreamHeaders()
 				if _, err := fmt.Fprint(c.Writer, sse); err != nil {
 					clientDisconnected = true
@@ -896,10 +979,36 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 				}
 				clientOutputStarted = true
 			}
-			if !clientDisconnected {
+			if !clientDisconnected && clientVisibleOutputStarted {
 				c.Writer.Flush()
 			}
 		}
+		if !clientVisibleOutputStarted {
+			result := resultWithUsage()
+			fields := []zap.Field{
+				zap.String("request_id", requestID),
+				zap.String("response_id", responseID),
+				zap.Int64("account_id", account.ID),
+				zap.String("model", originalModel),
+				zap.String("upstream_model", upstreamModel),
+			}
+			fields = append(fields, streamDiag.ZapFields()...)
+			logger.L().Warn("openai_messages.stream_completed_without_visible_output", fields...)
+			if streamDiag.TerminalErrorCode == "context_length_exceeded" {
+				message := strings.TrimSpace(streamDiag.TerminalErrorMessage)
+				if message == "" {
+					message = "Your input exceeds the context window of this model. Please reduce the conversation context and try again."
+				}
+				return result, s.newOpenAIStreamClientError(c, account, requestID, http.StatusBadRequest, "invalid_request_error", message)
+			}
+			if streamDiag.TerminalStatus == "incomplete" && streamDiag.TerminalIncompleteReason == "max_output_tokens" {
+				message := "OpenAI response reached max_output_tokens before producing assistant content; reduce the conversation context or output budget and try again."
+				return result, s.newOpenAIStreamClientError(c, account, requestID, http.StatusBadRequest, "invalid_request_error", message)
+			}
+			message := "OpenAI messages stream completed without assistant content or tool output"
+			return result, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, message)
+		}
+		flushPendingClientSSE()
 		return resultWithUsage(), nil
 	}
 
@@ -1060,6 +1169,9 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			if clientDisconnected {
 				continue
 			}
+			if !clientVisibleOutputStarted {
+				continue
+			}
 			if time.Since(lastDataAt) < keepaliveInterval {
 				continue
 			}
@@ -1076,6 +1188,184 @@ func (s *OpenAIGatewayService) handleAnthropicStreamingResponse(
 			clientOutputStarted = true
 			c.Writer.Flush()
 		}
+	}
+}
+
+func anthropicStreamEventHasVisibleOutput(evt apicompat.AnthropicStreamEvent) bool {
+	switch strings.TrimSpace(evt.Type) {
+	case "content_block_start":
+		if evt.ContentBlock == nil {
+			return false
+		}
+		switch strings.TrimSpace(evt.ContentBlock.Type) {
+		case "tool_use", "server_tool_use":
+			return true
+		default:
+			return false
+		}
+	case "content_block_delta":
+		if evt.Delta == nil {
+			return false
+		}
+		return strings.TrimSpace(evt.Delta.Text) != "" ||
+			strings.TrimSpace(evt.Delta.PartialJSON) != ""
+	default:
+		return false
+	}
+}
+
+func anthropicResponseHasVisibleOutput(resp *apicompat.AnthropicResponse) bool {
+	if resp == nil {
+		return false
+	}
+	for _, block := range resp.Content {
+		switch strings.TrimSpace(block.Type) {
+		case "text":
+			if strings.TrimSpace(block.Text) != "" {
+				return true
+			}
+		case "tool_use", "server_tool_use":
+			return true
+		}
+	}
+	return false
+}
+
+type openAIMessagesStreamDiagnostic struct {
+	EstimatedInputTokens int
+	EventTypes           map[string]int
+	OutputItemTypes      map[string]int
+	FinalOutputTypes     map[string]int
+
+	OutputTextDeltaBytes       int
+	OutputTextDoneCount        int
+	ReasoningDeltaBytes        int
+	ReasoningDoneCount         int
+	FunctionArgsDeltaBytes     int
+	FunctionArgsDoneCount      int
+	TerminalType               string
+	TerminalStatus             string
+	TerminalOutputCount        int
+	TerminalIncompleteReason   string
+	TerminalErrorCode          string
+	TerminalErrorMessage       string
+	TerminalUsageInputTokens   int
+	TerminalUsageOutputTokens  int
+	TerminalUsageTotalTokens   int
+	TerminalMessageTextBytes   int
+	TerminalReasoningTextBytes int
+}
+
+func newOpenAIMessagesStreamDiagnostic(estimatedInputTokens int) *openAIMessagesStreamDiagnostic {
+	return &openAIMessagesStreamDiagnostic{
+		EstimatedInputTokens: estimatedInputTokens,
+		EventTypes:           make(map[string]int),
+		OutputItemTypes:      make(map[string]int),
+		FinalOutputTypes:     make(map[string]int),
+	}
+}
+
+func (d *openAIMessagesStreamDiagnostic) Record(evt apicompat.ResponsesStreamEvent) {
+	if d == nil {
+		return
+	}
+	eventType := strings.TrimSpace(evt.Type)
+	if eventType == "" {
+		eventType = "<empty>"
+	}
+	d.EventTypes[eventType]++
+	switch eventType {
+	case "response.output_item.added", "response.output_item.done":
+		if evt.Item != nil {
+			itemType := strings.TrimSpace(evt.Item.Type)
+			if itemType == "" {
+				itemType = "<empty>"
+			}
+			d.OutputItemTypes[itemType]++
+		}
+	case "response.output_text.delta":
+		d.OutputTextDeltaBytes += len(evt.Delta)
+	case "response.output_text.done":
+		d.OutputTextDoneCount++
+	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
+		d.ReasoningDeltaBytes += len(evt.Delta)
+	case "response.reasoning_summary_text.done":
+		d.ReasoningDoneCount++
+	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
+		d.FunctionArgsDeltaBytes += len(evt.Delta)
+	case "response.function_call_arguments.done":
+		d.FunctionArgsDoneCount++
+	}
+	if evt.Response != nil {
+		d.TerminalType = eventType
+		d.TerminalStatus = strings.TrimSpace(evt.Response.Status)
+		d.TerminalOutputCount = len(evt.Response.Output)
+		d.FinalOutputTypes = make(map[string]int)
+		for _, out := range evt.Response.Output {
+			outputType := strings.TrimSpace(out.Type)
+			if outputType == "" {
+				outputType = "<empty>"
+			}
+			d.FinalOutputTypes[outputType]++
+			switch outputType {
+			case "message":
+				for _, part := range out.Content {
+					if strings.TrimSpace(part.Type) == "output_text" {
+						d.TerminalMessageTextBytes += len(part.Text)
+					}
+				}
+			case "reasoning":
+				for _, summary := range out.Summary {
+					d.TerminalReasoningTextBytes += len(summary.Text)
+				}
+			}
+		}
+		if evt.Response.IncompleteDetails != nil {
+			d.TerminalIncompleteReason = strings.TrimSpace(evt.Response.IncompleteDetails.Reason)
+		}
+		if evt.Response.Error != nil {
+			d.TerminalErrorCode = strings.TrimSpace(evt.Response.Error.Code)
+			d.TerminalErrorMessage = strings.TrimSpace(evt.Response.Error.Message)
+		}
+		if evt.Response.Usage != nil {
+			d.TerminalUsageInputTokens = evt.Response.Usage.InputTokens
+			d.TerminalUsageOutputTokens = evt.Response.Usage.OutputTokens
+			d.TerminalUsageTotalTokens = evt.Response.Usage.TotalTokens
+		}
+	}
+	if evt.Usage != nil {
+		d.TerminalUsageInputTokens = evt.Usage.InputTokens
+		d.TerminalUsageOutputTokens = evt.Usage.OutputTokens
+		d.TerminalUsageTotalTokens = evt.Usage.TotalTokens
+	}
+}
+
+func (d *openAIMessagesStreamDiagnostic) ZapFields() []zap.Field {
+	if d == nil {
+		return nil
+	}
+	return []zap.Field{
+		zap.Int("estimated_input_tokens", d.EstimatedInputTokens),
+		zap.Any("responses_event_types", d.EventTypes),
+		zap.Any("responses_output_item_types", d.OutputItemTypes),
+		zap.Any("responses_final_output_types", d.FinalOutputTypes),
+		zap.Int("output_text_delta_bytes", d.OutputTextDeltaBytes),
+		zap.Int("output_text_done_count", d.OutputTextDoneCount),
+		zap.Int("reasoning_delta_bytes", d.ReasoningDeltaBytes),
+		zap.Int("reasoning_done_count", d.ReasoningDoneCount),
+		zap.Int("function_args_delta_bytes", d.FunctionArgsDeltaBytes),
+		zap.Int("function_args_done_count", d.FunctionArgsDoneCount),
+		zap.String("terminal_event_type", d.TerminalType),
+		zap.String("terminal_status", d.TerminalStatus),
+		zap.Int("terminal_output_count", d.TerminalOutputCount),
+		zap.String("terminal_incomplete_reason", d.TerminalIncompleteReason),
+		zap.String("terminal_error_code", d.TerminalErrorCode),
+		zap.String("terminal_error_message", d.TerminalErrorMessage),
+		zap.Int("terminal_usage_input_tokens", d.TerminalUsageInputTokens),
+		zap.Int("terminal_usage_output_tokens", d.TerminalUsageOutputTokens),
+		zap.Int("terminal_usage_total_tokens", d.TerminalUsageTotalTokens),
+		zap.Int("terminal_message_text_bytes", d.TerminalMessageTextBytes),
+		zap.Int("terminal_reasoning_text_bytes", d.TerminalReasoningTextBytes),
 	}
 }
 

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -50,6 +50,16 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// 2. Model mapping
 	billingModel := resolveOpenAIForwardModel(account, normalizedModel, defaultMappedModel)
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
+	anthropicCompactRequest := isClaudeCodeCompactAnthropicRequest(&anthropicReq)
+	anthropicCompactModelMapped := false
+	if anthropicCompactRequest {
+		compactBillingModel := resolveOpenAICompactForwardModel(account, billingModel)
+		anthropicCompactModelMapped = compactBillingModel != "" && compactBillingModel != billingModel
+		if anthropicCompactModelMapped {
+			billingModel = compactBillingModel
+			upstreamModel = normalizeOpenAIModelForUpstream(account, billingModel)
+		}
+	}
 	promptCacheKey = strings.TrimSpace(promptCacheKey)
 	apiKeyID := getAPIKeyIDFromContext(c)
 	anthropicDigestChain := ""
@@ -120,6 +130,12 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		zap.String("billing_model", billingModel),
 		zap.String("upstream_model", upstreamModel),
 		zap.Bool("stream", isStream),
+	}
+	if anthropicCompactRequest {
+		logFields = append(logFields,
+			zap.Bool("anthropic_compact_request", true),
+			zap.Bool("anthropic_compact_model_mapped", anthropicCompactModelMapped),
+		)
 	}
 	if compatPromptCacheInjected {
 		logFields = append(logFields,
@@ -1212,6 +1228,60 @@ func anthropicStreamEventHasVisibleOutput(evt apicompat.AnthropicStreamEvent) bo
 	default:
 		return false
 	}
+}
+
+func isClaudeCodeCompactAnthropicRequest(req *apicompat.AnthropicRequest) bool {
+	if req == nil || len(req.Messages) == 0 {
+		return false
+	}
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		msg := req.Messages[i]
+		if strings.TrimSpace(msg.Role) != "user" {
+			continue
+		}
+		return looksLikeClaudeCodeCompactPrompt(anthropicMessageText(msg.Content))
+	}
+	return false
+}
+
+func anthropicMessageText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var blocks []apicompat.AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return ""
+	}
+	var parts []string
+	for _, block := range blocks {
+		if strings.TrimSpace(block.Type) == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func looksLikeClaudeCodeCompactPrompt(text string) bool {
+	text = strings.TrimSpace(text)
+	if !strings.Contains(text, "Your task is to create a detailed summary") {
+		return false
+	}
+	for _, marker := range []string{
+		"<analysis>",
+		"<summary>",
+		"All user messages",
+		"Pending Tasks",
+		"Current Work",
+	} {
+		if !strings.Contains(text, marker) {
+			return false
+		}
+	}
+	return true
 }
 
 func anthropicResponseHasVisibleOutput(resp *apicompat.AnthropicResponse) bool {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -22,6 +22,17 @@ import (
 	"go.uber.org/zap"
 )
 
+var openAIAnthropicCompactChunkTargetChars = 300_000
+
+const (
+	openAIAnthropicCompactFallbackMaxChunks        = 40
+	openAIAnthropicCompactChunkMaxOutputTokens     = 6_000
+	openAIAnthropicCompactMergeMaxOutputTokens     = 12_000
+	openAIAnthropicCompactFallbackMinSplitRunes    = 4_000
+	openAIAnthropicCompactFallbackChunkReasoning   = "low"
+	openAIAnthropicCompactFallbackFallbackResponse = "Claude Code compact fallback failed before producing a summary"
+)
+
 // ForwardAsAnthropic accepts an Anthropic Messages request body, converts it
 // to OpenAI Responses API format, forwards to the OpenAI upstream, and converts
 // the response back to Anthropic Messages format. This enables Claude Code
@@ -393,7 +404,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// Upstream is always streaming; choose response format based on client preference.
 	var result *OpenAIForwardResult
 	var handleErr error
-	if clientStream {
+	if anthropicCompactRequest && anthropicCompactModelMapped {
+		result, handleErr = s.handleAnthropicCompactMappedStreamingResponse(ctx, c, account, resp, originalModel, billingModel, upstreamModel, startTime, &anthropicReq, token, clientStream)
+	} else if clientStream {
 		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime, estimatedInputTokens)
 	} else {
 		// Client wants JSON: buffer the streaming response and assemble a JSON reply.
@@ -464,6 +477,73 @@ func (s *OpenAIGatewayService) handleAnthropicErrorResponse(
 	return s.handleCompatErrorResponse(resp, c, account, writeAnthropicError, requestedModel...)
 }
 
+// handleAnthropicCompactMappedStreamingResponse keeps compact reroutes
+// buffered until we know whether the fast compact model can handle the full
+// transcript. If it cannot, it summarizes transcript chunks and merges those
+// summaries into the compact response Claude Code expects.
+func (s *OpenAIGatewayService) handleAnthropicCompactMappedStreamingResponse(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	resp *http.Response,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+	anthropicReq *apicompat.AnthropicRequest,
+	token string,
+	clientStream bool,
+) (*OpenAIForwardResult, error) {
+	requestID := resp.Header.Get("x-request-id")
+
+	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai messages compact buffered", requestID)
+	if err != nil {
+		return nil, err
+	}
+	if finalResponse == nil {
+		writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream stream ended without a terminal response event")
+		return nil, fmt.Errorf("upstream stream ended without terminal event")
+	}
+
+	if isOpenAIResponsesContextLengthExceeded(finalResponse) {
+		logger.L().Warn("openai_messages.compact_context_length_fallback",
+			zap.String("request_id", requestID),
+			zap.Int64("account_id", account.ID),
+			zap.String("model", originalModel),
+			zap.String("upstream_model", upstreamModel),
+			zap.Int("initial_input_tokens", usage.InputTokens),
+		)
+		result, fallbackErr := s.runAnthropicCompactChunkFallback(ctx, c, account, anthropicReq, token, originalModel, billingModel, upstreamModel, startTime, usage, clientStream, requestID)
+		if fallbackErr != nil && !c.Writer.Written() {
+			writeAnthropicError(c, http.StatusBadGateway, "api_error", openAIAnthropicCompactFallbackFallbackResponse)
+		}
+		return result, fallbackErr
+	}
+
+	if strings.TrimSpace(finalResponse.Status) == "failed" {
+		payload, _ := json.Marshal(gin.H{"type": "response.failed", "response": finalResponse})
+		if hit, code, msg := detectOpenAICyberPolicy(payload); hit {
+			MarkOpsCyberPolicy(c, CyberPolicyMark{
+				Code:           code,
+				Message:        msg,
+				Body:           truncateString(string(payload), 4096),
+				UpstreamStatus: http.StatusOK,
+				UpstreamInTok:  usage.InputTokens,
+				UpstreamOutTok: usage.OutputTokens,
+			})
+			clientMsg := msg
+			if clientMsg == "" {
+				clientMsg = "Request blocked by upstream cyber-security policy"
+			}
+			writeAnthropicError(c, http.StatusBadRequest, "invalid_request_error", clientMsg)
+			return nil, fmt.Errorf("openai cyber_policy: %s", msg)
+		}
+	}
+
+	acc.SupplementResponseOutput(finalResponse)
+	return s.writeAnthropicBufferedFinalResponse(c, account, resp.Header, finalResponse, usage, originalModel, billingModel, upstreamModel, startTime, clientStream, requestID)
+}
+
 // handleAnthropicBufferedStreamingResponse reads all Responses SSE events from
 // the upstream streaming response, finds the terminal event (response.completed
 // / response.incomplete / response.failed), converts the complete response to
@@ -517,6 +597,22 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 	// accumulated delta events so the client receives the full content.
 	acc.SupplementResponseOutput(finalResponse)
 
+	return s.writeAnthropicBufferedFinalResponse(c, account, resp.Header, finalResponse, usage, originalModel, billingModel, upstreamModel, startTime, false, requestID)
+}
+
+func (s *OpenAIGatewayService) writeAnthropicBufferedFinalResponse(
+	c *gin.Context,
+	account *Account,
+	upstreamHeaders http.Header,
+	finalResponse *apicompat.ResponsesResponse,
+	usage OpenAIUsage,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+	clientStream bool,
+	requestID string,
+) (*OpenAIForwardResult, error) {
 	anthropicResp := apicompat.ResponsesToAnthropic(finalResponse, originalModel)
 	if !anthropicResponseHasVisibleOutput(anthropicResp) {
 		result := &OpenAIForwardResult{
@@ -526,17 +622,23 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 			Model:         originalModel,
 			BillingModel:  billingModel,
 			UpstreamModel: upstreamModel,
-			Stream:        false,
+			Stream:        clientStream,
 			Duration:      time.Since(startTime),
 		}
 		message := "OpenAI messages buffered response completed without assistant content or tool output"
 		return result, s.newOpenAIStreamFailoverError(c, account, false, requestID, nil, message)
 	}
 
-	if s.responseHeaderFilter != nil {
-		responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	if s.responseHeaderFilter != nil && upstreamHeaders != nil {
+		responseheaders.WriteFilteredHeaders(c.Writer.Header(), upstreamHeaders, s.responseHeaderFilter)
 	}
-	c.JSON(http.StatusOK, anthropicResp)
+	if clientStream {
+		if err := writeAnthropicResponseAsSSE(c, anthropicResp); err != nil {
+			return nil, err
+		}
+	} else {
+		c.JSON(http.StatusOK, anthropicResp)
+	}
 
 	return &OpenAIForwardResult{
 		RequestID:     requestID,
@@ -545,9 +647,630 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 		Model:         originalModel,
 		BillingModel:  billingModel,
 		UpstreamModel: upstreamModel,
-		Stream:        false,
+		Stream:        clientStream,
 		Duration:      time.Since(startTime),
 	}, nil
+}
+
+func isOpenAIResponsesContextLengthExceeded(resp *apicompat.ResponsesResponse) bool {
+	if resp == nil || resp.Error == nil {
+		return false
+	}
+	code := strings.TrimSpace(resp.Error.Code)
+	if code == "context_length_exceeded" {
+		return true
+	}
+	message := strings.ToLower(strings.TrimSpace(resp.Error.Message))
+	return strings.Contains(message, "context window") && strings.Contains(message, "exceed")
+}
+
+func writeAnthropicResponseAsSSE(c *gin.Context, resp *apicompat.AnthropicResponse) error {
+	if resp == nil {
+		return errors.New("anthropic response is nil")
+	}
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
+	c.Writer.Header().Set("Cache-Control", "no-cache")
+	c.Writer.Header().Set("Connection", "keep-alive")
+	c.Status(http.StatusOK)
+
+	start := *resp
+	start.Content = []apicompat.AnthropicContentBlock{}
+	start.StopReason = ""
+	start.StopSequence = nil
+	start.Usage.OutputTokens = 0
+	events := []apicompat.AnthropicStreamEvent{{
+		Type:    "message_start",
+		Message: &start,
+	}}
+
+	for i, block := range resp.Content {
+		idx := i
+		startBlock := block
+		switch strings.TrimSpace(startBlock.Type) {
+		case "text":
+			startBlock.Text = ""
+		case "thinking":
+			startBlock.Thinking = ""
+		}
+		events = append(events, apicompat.AnthropicStreamEvent{
+			Type:         "content_block_start",
+			Index:        &idx,
+			ContentBlock: &startBlock,
+		})
+		switch strings.TrimSpace(block.Type) {
+		case "text":
+			if block.Text != "" {
+				events = append(events, apicompat.AnthropicStreamEvent{
+					Type:  "content_block_delta",
+					Index: &idx,
+					Delta: &apicompat.AnthropicDelta{
+						Type: "text_delta",
+						Text: block.Text,
+					},
+				})
+			}
+		case "thinking":
+			if block.Thinking != "" {
+				events = append(events, apicompat.AnthropicStreamEvent{
+					Type:  "content_block_delta",
+					Index: &idx,
+					Delta: &apicompat.AnthropicDelta{
+						Type:     "thinking_delta",
+						Thinking: block.Thinking,
+					},
+				})
+			}
+		}
+		events = append(events, apicompat.AnthropicStreamEvent{
+			Type:  "content_block_stop",
+			Index: &idx,
+		})
+	}
+
+	stopReason := strings.TrimSpace(resp.StopReason)
+	if stopReason == "" {
+		stopReason = "end_turn"
+	}
+	events = append(events,
+		apicompat.AnthropicStreamEvent{
+			Type: "message_delta",
+			Delta: &apicompat.AnthropicDelta{
+				StopReason:   stopReason,
+				StopSequence: resp.StopSequence,
+			},
+			Usage: &resp.Usage,
+		},
+		apicompat.AnthropicStreamEvent{Type: "message_stop"},
+	)
+
+	for _, evt := range events {
+		sse, err := apicompat.ResponsesAnthropicEventToSSE(evt)
+		if err != nil {
+			return err
+		}
+		if _, err := fmt.Fprint(c.Writer, sse); err != nil {
+			return err
+		}
+	}
+	c.Writer.Flush()
+	return nil
+}
+
+func (s *OpenAIGatewayService) runAnthropicCompactChunkFallback(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	anthropicReq *apicompat.AnthropicRequest,
+	token string,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+	initialUsage OpenAIUsage,
+	clientStream bool,
+	initialRequestID string,
+) (*OpenAIForwardResult, error) {
+	compactPrompt, transcript := buildAnthropicCompactFallbackTranscript(anthropicReq)
+	chunks := splitAnthropicCompactTranscriptChunks(transcript, openAIAnthropicCompactChunkTargetChars, openAIAnthropicCompactFallbackMaxChunks)
+	if len(chunks) == 0 {
+		return nil, errors.New("compact fallback transcript is empty")
+	}
+
+	totalUsage := initialUsage
+	summaries := make([]string, 0, len(chunks))
+	for i, chunk := range chunks {
+		prompt := fmt.Sprintf("Chunk %d of %d from a Claude Code conversation transcript:\n\n%s", i+1, len(chunks), chunk)
+		finalResponse, usage, requestID, err := s.runOpenAIAnthropicCompactFallbackResponsesRequest(ctx, c, account, token, upstreamModel, openAIAnthropicCompactChunkInstructions(), prompt, openAIAnthropicCompactChunkMaxOutputTokens)
+		totalUsage = addOpenAIUsage(totalUsage, usage)
+		if err != nil {
+			return &OpenAIForwardResult{
+				RequestID:     firstNonEmpty(requestID, initialRequestID),
+				Usage:         totalUsage,
+				Model:         originalModel,
+				BillingModel:  billingModel,
+				UpstreamModel: upstreamModel,
+				Stream:        clientStream,
+				Duration:      time.Since(startTime),
+			}, err
+		}
+		if isOpenAIResponsesContextLengthExceeded(finalResponse) {
+			return &OpenAIForwardResult{
+				RequestID:     firstNonEmpty(requestID, initialRequestID),
+				ResponseID:    finalResponse.ID,
+				Usage:         totalUsage,
+				Model:         originalModel,
+				BillingModel:  billingModel,
+				UpstreamModel: upstreamModel,
+				Stream:        clientStream,
+				Duration:      time.Since(startTime),
+			}, fmt.Errorf("compact fallback chunk %d exceeded context window", i+1)
+		}
+		if strings.TrimSpace(finalResponse.Status) == "failed" {
+			return &OpenAIForwardResult{
+				RequestID:     firstNonEmpty(requestID, initialRequestID),
+				ResponseID:    finalResponse.ID,
+				Usage:         totalUsage,
+				Model:         originalModel,
+				BillingModel:  billingModel,
+				UpstreamModel: upstreamModel,
+				Stream:        clientStream,
+				Duration:      time.Since(startTime),
+			}, fmt.Errorf("compact fallback chunk %d failed: %s", i+1, openAIResponsesErrorMessage(finalResponse))
+		}
+		summary := strings.TrimSpace(openAIResponsesOutputText(finalResponse))
+		if summary == "" {
+			return &OpenAIForwardResult{
+				RequestID:     firstNonEmpty(requestID, initialRequestID),
+				ResponseID:    finalResponse.ID,
+				Usage:         totalUsage,
+				Model:         originalModel,
+				BillingModel:  billingModel,
+				UpstreamModel: upstreamModel,
+				Stream:        clientStream,
+				Duration:      time.Since(startTime),
+			}, fmt.Errorf("compact fallback chunk %d produced empty summary", i+1)
+		}
+		summaries = append(summaries, fmt.Sprintf("## Chunk %d/%d\n%s", i+1, len(chunks), summary))
+	}
+
+	mergePrompt := buildAnthropicCompactMergePrompt(compactPrompt, summaries)
+	finalResponse, mergeUsage, mergeRequestID, err := s.runOpenAIAnthropicCompactFallbackResponsesRequest(ctx, c, account, token, upstreamModel, openAIAnthropicCompactMergeInstructions(), mergePrompt, openAIAnthropicCompactMergeMaxOutputTokens)
+	totalUsage = addOpenAIUsage(totalUsage, mergeUsage)
+	if err != nil {
+		return &OpenAIForwardResult{
+			RequestID:     firstNonEmpty(mergeRequestID, initialRequestID),
+			Usage:         totalUsage,
+			Model:         originalModel,
+			BillingModel:  billingModel,
+			UpstreamModel: upstreamModel,
+			Stream:        clientStream,
+			Duration:      time.Since(startTime),
+		}, err
+	}
+	if finalResponse == nil {
+		return nil, errors.New("compact fallback merge response is nil")
+	}
+	if isOpenAIResponsesContextLengthExceeded(finalResponse) {
+		return &OpenAIForwardResult{
+			RequestID:     firstNonEmpty(mergeRequestID, initialRequestID),
+			ResponseID:    finalResponse.ID,
+			Usage:         totalUsage,
+			Model:         originalModel,
+			BillingModel:  billingModel,
+			UpstreamModel: upstreamModel,
+			Stream:        clientStream,
+			Duration:      time.Since(startTime),
+		}, errors.New("compact fallback merge exceeded context window")
+	}
+	if strings.TrimSpace(finalResponse.Status) == "failed" {
+		return &OpenAIForwardResult{
+			RequestID:     firstNonEmpty(mergeRequestID, initialRequestID),
+			ResponseID:    finalResponse.ID,
+			Usage:         totalUsage,
+			Model:         originalModel,
+			BillingModel:  billingModel,
+			UpstreamModel: upstreamModel,
+			Stream:        clientStream,
+			Duration:      time.Since(startTime),
+		}, fmt.Errorf("compact fallback merge failed: %s", openAIResponsesErrorMessage(finalResponse))
+	}
+
+	finalResponse.Usage = responsesUsageFromOpenAIUsage(totalUsage)
+	return s.writeAnthropicBufferedFinalResponse(c, account, nil, finalResponse, totalUsage, originalModel, billingModel, upstreamModel, startTime, clientStream, firstNonEmpty(mergeRequestID, initialRequestID))
+}
+
+func (s *OpenAIGatewayService) runOpenAIAnthropicCompactFallbackResponsesRequest(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	token string,
+	upstreamModel string,
+	instructions string,
+	userText string,
+	maxOutputTokens int,
+) (*apicompat.ResponsesResponse, OpenAIUsage, string, error) {
+	body, requestModel, err := s.buildOpenAIAnthropicCompactFallbackResponsesBody(account, upstreamModel, instructions, userText, maxOutputTokens)
+	if err != nil {
+		return nil, OpenAIUsage{}, "", err
+	}
+
+	updatedBody, policyErr := s.applyOpenAIFastPolicyToBody(ctx, account, requestModel, body)
+	if policyErr != nil {
+		var blocked *OpenAIFastBlockedError
+		if errors.As(policyErr, &blocked) {
+			MarkOpsClientBusinessLimited(c, OpsClientBusinessLimitedReasonLocalPolicyDenied)
+			writeAnthropicError(c, http.StatusForbidden, "forbidden_error", blocked.Message)
+		}
+		return nil, OpenAIUsage{}, "", policyErr
+	}
+	body = updatedBody
+	if account.Platform == PlatformGrok {
+		patchedBody, patchErr := patchGrokResponsesBody(body, requestModel)
+		if patchErr != nil {
+			return nil, OpenAIUsage{}, "", patchErr
+		}
+		body = patchedBody
+	}
+
+	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+	var req *http.Request
+	if account.Platform == PlatformGrok {
+		req, err = buildGrokResponsesRequest(upstreamCtx, c, account, body, token)
+	} else {
+		req, err = s.buildUpstreamRequest(upstreamCtx, c, account, body, token, true, "", false)
+	}
+	releaseUpstreamCtx()
+	if err != nil {
+		return nil, OpenAIUsage{}, "", err
+	}
+	if account.Type == AccountTypeOAuth && account.Platform != PlatformGrok {
+		req.Header.Del("OpenAI-Beta")
+		req.Header.Del("originator")
+		req.Header.Del("conversation_id")
+		req.Header.Del("session_id")
+	}
+
+	proxyURL := ""
+	if account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: 0,
+			Kind:               "compact_fallback_request_error",
+			Message:            safeErr,
+		})
+		return nil, OpenAIUsage{}, "", fmt.Errorf("compact fallback upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	requestID := resp.Header.Get("x-request-id")
+	if resp.StatusCode >= 400 {
+		respBody := s.readUpstreamErrorBody(resp)
+		s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, requestModel)
+		upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		if upstreamMsg == "" {
+			upstreamMsg = http.StatusText(resp.StatusCode)
+		}
+		return nil, OpenAIUsage{}, requestID, fmt.Errorf("compact fallback upstream status %d: %s", resp.StatusCode, sanitizeUpstreamErrorMessage(upstreamMsg))
+	}
+
+	finalResponse, usage, acc, err := s.readOpenAICompatBufferedTerminal(resp, "openai messages compact fallback", requestID)
+	if err != nil {
+		return nil, usage, requestID, err
+	}
+	if finalResponse == nil {
+		return nil, usage, requestID, errors.New("compact fallback stream ended without terminal response")
+	}
+	acc.SupplementResponseOutput(finalResponse)
+	return finalResponse, usage, requestID, nil
+}
+
+func (s *OpenAIGatewayService) buildOpenAIAnthropicCompactFallbackResponsesBody(
+	account *Account,
+	upstreamModel string,
+	instructions string,
+	userText string,
+	maxOutputTokens int,
+) ([]byte, string, error) {
+	content, err := json.Marshal([]apicompat.ResponsesContentPart{{
+		Type: "input_text",
+		Text: userText,
+	}})
+	if err != nil {
+		return nil, upstreamModel, err
+	}
+	input, err := json.Marshal([]apicompat.ResponsesInputItem{{
+		Role:    "user",
+		Content: content,
+	}})
+	if err != nil {
+		return nil, upstreamModel, err
+	}
+	store := false
+	req := apicompat.ResponsesRequest{
+		Model:           upstreamModel,
+		Instructions:    instructions,
+		Input:           input,
+		MaxOutputTokens: &maxOutputTokens,
+		Stream:          true,
+		Store:           &store,
+		Reasoning: &apicompat.ResponsesReasoning{
+			Effort: openAIAnthropicCompactFallbackChunkReasoning,
+		},
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, upstreamModel, err
+	}
+
+	requestModel := upstreamModel
+	if account.Type == AccountTypeOAuth && account.Platform != PlatformGrok {
+		var reqBody map[string]any
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			return nil, requestModel, err
+		}
+		codexResult := applyCodexOAuthTransformWithOptions(reqBody, codexOAuthTransformOptions{
+			SkipDefaultInstructions: true,
+			PreserveToolCallIDs:     true,
+		})
+		if codexResult.NormalizedModel != "" {
+			requestModel = codexResult.NormalizedModel
+		}
+		ensureCodexOAuthInstructionsField(reqBody)
+		delete(reqBody, "prompt_cache_key")
+		body, err = json.Marshal(reqBody)
+		if err != nil {
+			return nil, requestModel, err
+		}
+	}
+	return body, requestModel, nil
+}
+
+func buildAnthropicCompactFallbackTranscript(req *apicompat.AnthropicRequest) (string, string) {
+	if req == nil {
+		return "", ""
+	}
+	compactIdx := -1
+	compactPrompt := ""
+	for i := len(req.Messages) - 1; i >= 0; i-- {
+		msg := req.Messages[i]
+		if strings.TrimSpace(msg.Role) != "user" {
+			continue
+		}
+		text := anthropicContentTextForCompactFallback(msg.Content)
+		if looksLikeClaudeCodeCompactPrompt(text) {
+			compactIdx = i
+			compactPrompt = text
+			break
+		}
+	}
+
+	var parts []string
+	if systemText := anthropicContentTextForCompactFallback(req.System); strings.TrimSpace(systemText) != "" {
+		parts = append(parts, "### System\n"+strings.TrimSpace(systemText))
+	}
+	for i, msg := range req.Messages {
+		if i == compactIdx {
+			continue
+		}
+		text := strings.TrimSpace(anthropicContentTextForCompactFallback(msg.Content))
+		if text == "" {
+			continue
+		}
+		role := strings.TrimSpace(msg.Role)
+		if role == "" {
+			role = "message"
+		}
+		parts = append(parts, fmt.Sprintf("### Message %d (%s)\n%s", i+1, role, text))
+	}
+	return compactPrompt, strings.Join(parts, "\n\n")
+}
+
+func anthropicContentTextForCompactFallback(raw json.RawMessage) string {
+	if len(raw) == 0 || string(raw) == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return s
+	}
+	var blocks []apicompat.AnthropicContentBlock
+	if err := json.Unmarshal(raw, &blocks); err != nil {
+		return strings.TrimSpace(string(raw))
+	}
+	var parts []string
+	for _, block := range blocks {
+		switch strings.TrimSpace(block.Type) {
+		case "text":
+			if block.Text != "" {
+				parts = append(parts, block.Text)
+			}
+		case "thinking":
+			if block.Thinking != "" {
+				parts = append(parts, "[thinking]\n"+block.Thinking)
+			}
+		case "tool_use", "server_tool_use":
+			input := strings.TrimSpace(string(block.Input))
+			if input == "" {
+				input = "{}"
+			}
+			parts = append(parts, fmt.Sprintf("[tool_use id=%s name=%s]\n%s", block.ID, block.Name, input))
+		case "tool_result", "web_search_tool_result":
+			content := anthropicContentTextForCompactFallback(block.Content)
+			if content == "" {
+				content = strings.TrimSpace(string(block.Content))
+			}
+			prefix := fmt.Sprintf("[tool_result tool_use_id=%s]", block.ToolUseID)
+			if block.IsError {
+				prefix += " [error]"
+			}
+			parts = append(parts, prefix+"\n"+content)
+		case "image":
+			parts = append(parts, "[image omitted]")
+		default:
+			if encoded, err := json.Marshal(block); err == nil {
+				parts = append(parts, string(encoded))
+			}
+		}
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func splitAnthropicCompactTranscriptChunks(text string, targetChars int, maxChunks int) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	if targetChars <= 0 {
+		targetChars = openAIAnthropicCompactChunkTargetChars
+	}
+	if maxChunks <= 0 {
+		maxChunks = openAIAnthropicCompactFallbackMaxChunks
+	}
+
+	sections := strings.Split(text, "\n\n### ")
+	var chunks []string
+	current := ""
+	for i, section := range sections {
+		if i > 0 {
+			section = "### " + section
+		}
+		section = strings.TrimSpace(section)
+		if section == "" {
+			continue
+		}
+		if runeLen(section) > targetChars {
+			if strings.TrimSpace(current) != "" {
+				chunks = append(chunks, strings.TrimSpace(current))
+				current = ""
+			}
+			chunks = append(chunks, splitTextByRuneLimit(section, targetChars)...)
+			continue
+		}
+		candidate := section
+		if current != "" {
+			candidate = current + "\n\n" + section
+		}
+		if runeLen(candidate) > targetChars && strings.TrimSpace(current) != "" {
+			chunks = append(chunks, strings.TrimSpace(current))
+			current = section
+			continue
+		}
+		current = candidate
+	}
+	if strings.TrimSpace(current) != "" {
+		chunks = append(chunks, strings.TrimSpace(current))
+	}
+	if len(chunks) <= maxChunks {
+		return chunks
+	}
+	return splitTextByRuneLimit(text, ceilDiv(runeLen(text), maxChunks))
+}
+
+func splitTextByRuneLimit(text string, targetChars int) []string {
+	if targetChars < openAIAnthropicCompactFallbackMinSplitRunes {
+		targetChars = openAIAnthropicCompactFallbackMinSplitRunes
+	}
+	runes := []rune(text)
+	if len(runes) <= targetChars {
+		return []string{strings.TrimSpace(text)}
+	}
+	var chunks []string
+	for start := 0; start < len(runes); start += targetChars {
+		end := start + targetChars
+		if end > len(runes) {
+			end = len(runes)
+		}
+		chunk := strings.TrimSpace(string(runes[start:end]))
+		if chunk != "" {
+			chunks = append(chunks, chunk)
+		}
+	}
+	return chunks
+}
+
+func buildAnthropicCompactMergePrompt(compactPrompt string, summaries []string) string {
+	if strings.TrimSpace(compactPrompt) == "" {
+		compactPrompt = "Create a detailed Claude Code compact summary for the conversation. Preserve current work, user intent, files, commands, blockers, and next steps."
+	}
+	return strings.TrimSpace(compactPrompt) + "\n\nThe original conversation was too large for one compact request, so it was summarized in chunks. Merge the chunk summaries below into one coherent final compact summary. Do not mention the chunking process unless it is relevant to the work state.\n\n" + strings.Join(summaries, "\n\n")
+}
+
+func openAIAnthropicCompactChunkInstructions() string {
+	return "Summarize this Claude Code transcript chunk for a later compact merge. Preserve concrete user requests, decisions, files, commands, errors, test results, logs, configuration values, and unresolved next steps. Keep it dense and factual. Do not answer the user."
+}
+
+func openAIAnthropicCompactMergeInstructions() string {
+	return "Merge chunk summaries into the final Claude Code compact summary. Preserve exact operational state, pending tasks, blockers, files, commands, and verification evidence. Output only the compact summary."
+}
+
+func openAIResponsesOutputText(resp *apicompat.ResponsesResponse) string {
+	if resp == nil {
+		return ""
+	}
+	var parts []string
+	for _, item := range resp.Output {
+		if strings.TrimSpace(item.Type) != "message" {
+			continue
+		}
+		for _, part := range item.Content {
+			if strings.TrimSpace(part.Type) == "output_text" && part.Text != "" {
+				parts = append(parts, part.Text)
+			}
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+func openAIResponsesErrorMessage(resp *apicompat.ResponsesResponse) string {
+	if resp == nil || resp.Error == nil {
+		return ""
+	}
+	if strings.TrimSpace(resp.Error.Message) != "" {
+		return strings.TrimSpace(resp.Error.Message)
+	}
+	return strings.TrimSpace(resp.Error.Code)
+}
+
+func responsesUsageFromOpenAIUsage(usage OpenAIUsage) *apicompat.ResponsesUsage {
+	result := &apicompat.ResponsesUsage{
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
+		TotalTokens:  usage.InputTokens + usage.OutputTokens,
+	}
+	if usage.CacheReadInputTokens > 0 {
+		result.InputTokensDetails = &apicompat.ResponsesInputTokensDetails{CachedTokens: usage.CacheReadInputTokens}
+	}
+	return result
+}
+
+func addOpenAIUsage(a OpenAIUsage, b OpenAIUsage) OpenAIUsage {
+	return OpenAIUsage{
+		InputTokens:              a.InputTokens + b.InputTokens,
+		ImageInputTokens:         a.ImageInputTokens + b.ImageInputTokens,
+		OutputTokens:             a.OutputTokens + b.OutputTokens,
+		CacheCreationInputTokens: a.CacheCreationInputTokens + b.CacheCreationInputTokens,
+		CacheReadInputTokens:     a.CacheReadInputTokens + b.CacheReadInputTokens,
+		ImageOutputTokens:        a.ImageOutputTokens + b.ImageOutputTokens,
+	}
+}
+
+func runeLen(s string) int {
+	return len([]rune(s))
+}
+
+func ceilDiv(a, b int) int {
+	if b <= 0 {
+		return 0
+	}
+	return (a + b - 1) / b
 }
 
 func isOpenAICompatResponsesTerminalEvent(eventType string) bool {

--- a/backend/internal/service/openai_gateway_messages_compact_test.go
+++ b/backend/internal/service/openai_gateway_messages_compact_test.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRetryAnthropicCompactFallbackSummariesSplitsSingleOversizedSummary(t *testing.T) {
+	oversized := strings.Repeat("important-state ", 1200)
+
+	retry := retryAnthropicCompactFallbackSummaries("compact prompt", []string{oversized}, 4_000)
+
+	if len(retry) < 2 {
+		t.Fatalf("retry summaries = %d, want split oversized single summary", len(retry))
+	}
+	for i, summary := range retry {
+		if !strings.Contains(summary, "Oversized summary split") {
+			t.Fatalf("retry summary %d missing split heading: %q", i, summary[:min(len(summary), 80)])
+		}
+		if runeLen(summary) > 4_500 {
+			t.Fatalf("retry summary %d too large: %d runes", i, runeLen(summary))
+		}
+	}
+}
+
+func TestBuildAnthropicCompactMergePromptIncludesQualityContract(t *testing.T) {
+	prompt := buildAnthropicCompactMergePrompt("Create a compact summary", []string{"## Chunk 1/1\nstate"})
+
+	for _, want := range []string{
+		"# Compact Capsule",
+		"## Current State",
+		"## Active User Intent",
+		"## Files Touched",
+		"## Commands And Evidence",
+		"## Errors And Blockers",
+		"## Decisions And Config",
+		"## Next Command",
+		"Do not include meta-statements",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("merge prompt missing %q\n%s", want, prompt)
+		}
+	}
+}
+
+func TestBuildAnthropicCompactEmergencyResponseReturnsCompletedSummary(t *testing.T) {
+	usage := OpenAIUsage{InputTokens: 123, OutputTokens: 45}
+	resp := buildAnthropicCompactEmergencyResponse("gpt-5.3-codex-spark", "summary text", usage)
+
+	if resp == nil {
+		t.Fatal("response is nil")
+	}
+	if resp.Status != "completed" {
+		t.Fatalf("status = %q, want completed", resp.Status)
+	}
+	if resp.Model != "gpt-5.3-codex-spark" {
+		t.Fatalf("model = %q", resp.Model)
+	}
+	if got := openAIResponsesOutputText(resp); got != "summary text" {
+		t.Fatalf("output text = %q", got)
+	}
+	if resp.Usage == nil || resp.Usage.InputTokens != 123 || resp.Usage.OutputTokens != 45 || resp.Usage.TotalTokens != 168 {
+		t.Fatalf("unexpected usage: %+v", resp.Usage)
+	}
+}
+
+func TestBuildAnthropicCompactEmergencySummaryCapsMiddle(t *testing.T) {
+	parts := []string{
+		"head-" + strings.Repeat("a", 70_000),
+		"tail-" + strings.Repeat("b", 70_000),
+	}
+
+	summary := buildAnthropicCompactEmergencySummary("", parts)
+
+	if !strings.Contains(summary, "# Compact Capsule") {
+		t.Fatalf("missing capsule heading")
+	}
+	if !strings.Contains(summary, "middle omitted by compact fallback emergency guard") {
+		t.Fatalf("summary was not middle-trimmed")
+	}
+	if runeLen(summary) > openAIAnthropicCompactEmergencyMaxRunes+2_000 {
+		t.Fatalf("summary too large: %d", runeLen(summary))
+	}
+}
+
+func TestAnthropicCompactQualityContractEval(t *testing.T) {
+	summaries := []string{
+		"User asked to continue session 07613379. Files: backend/internal/service/openai_gateway_messages.go. Error: compact fallback merge exceeded context window. Next: fix recursive merge and test.",
+		"Commands: go test ./internal/service. Config: CLAUDE_CODE_AUTO_COMPACT_WINDOW=240000, ANTHROPIC_SMALL_FAST_MODEL=gpt-5.3-codex-spark.",
+	}
+
+	prompt := buildAnthropicCompactMergePrompt("Create a compact summary", summaries)
+	required := []string{
+		"# Compact Capsule",
+		"## Current State",
+		"## Active User Intent",
+		"## Files Touched",
+		"## Commands And Evidence",
+		"## Errors And Blockers",
+		"## Decisions And Config",
+		"## Next Command",
+		"Do not invent completed tests",
+	}
+	for _, item := range required {
+		if !strings.Contains(prompt, item) {
+			t.Fatalf("quality contract missing %q", item)
+		}
+	}
+	if strings.Contains(prompt, "current intent is to produce a summary") {
+		t.Fatalf("quality contract still encourages meta compact intent")
+	}
+}
+
+func TestSanitizeAnthropicCompactSummaryForMergeDropsMetaIntentBlock(t *testing.T) {
+	raw := `# Compact Capsule
+
+## Current State
+- Task #55 still needs BDD repair.
+
+## Active User Intent
+- Current inferred active intent (from latest user-visible turn): produce a merged, detailed compact summary of prior conversation due prior chunking, preserving:
+  - exact operational state,
+  - pending tasks/blockers,
+  - files and commands.
+- Security/interaction constraints currently in force: respond text-only.
+- Real task: finish Task #55 BDD breakages and reduce false-positive claim-evidence blocking behavior.
+
+## Next Command
+- Run docker compose test.`
+
+	clean := sanitizeAnthropicCompactSummaryForMerge(raw)
+
+	for _, banned := range []string{
+		"produce a merged, detailed compact summary",
+		"prior chunking",
+		"exact operational state",
+		"pending tasks/blockers",
+	} {
+		if strings.Contains(clean, banned) {
+			t.Fatalf("sanitized summary still contains meta compact intent %q\n%s", banned, clean)
+		}
+	}
+	for _, want := range []string{
+		"Task #55 still needs BDD repair",
+		"Security/interaction constraints",
+		"Real task: finish Task #55 BDD breakages",
+		"Run docker compose test",
+	} {
+		if !strings.Contains(clean, want) {
+			t.Fatalf("sanitized summary dropped real state %q\n%s", want, clean)
+		}
+	}
+}
+
+func TestBuildAnthropicCompactMergePromptSanitizesMetaIntent(t *testing.T) {
+	prompt := buildAnthropicCompactMergePrompt("Create a compact summary", []string{
+		"## Active User Intent\n- Current inferred active intent: produce a detailed compact summary due to context compaction.\n- Real task: fix recursive merge and test.",
+	})
+
+	if strings.Contains(prompt, "produce a detailed compact summary due to context compaction") {
+		t.Fatalf("merge prompt preserved meta compact intent\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "Real task: fix recursive merge and test") {
+		t.Fatalf("merge prompt dropped real task\n%s", prompt)
+	}
+}
+
+func BenchmarkAnthropicCompactFallbackGrouping(b *testing.B) {
+	summary := strings.Repeat("file backend/internal/service/openai_gateway_messages.go error compact fallback merge exceeded context window next recursive merge test ", 500)
+	summaries := make([]string, 24)
+	for i := range summaries {
+		summaries[i] = summary
+	}
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		groups := groupAnthropicCompactSummariesForMerge("Create a compact summary", summaries, 35_000)
+		if len(groups) == 0 {
+			b.Fatal("no groups")
+		}
+		_ = buildAnthropicCompactEmergencySummary("Create a compact summary", summaries)
+	}
+}

--- a/backend/internal/service/openai_gateway_messages_stream_test.go
+++ b/backend/internal/service/openai_gateway_messages_stream_test.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIMessagesAnthropicStreamContextLengthBeforeVisibleOutputReturnsClientError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"X-Request-Id": []string{"rid-context-window"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.created",
+			`data: {"type":"response.created","response":{"id":"resp_context","model":"gpt-5.5","status":"in_progress"}}`,
+			"",
+			"event: response.in_progress",
+			`data: {"type":"response.in_progress","response":{"id":"resp_context","status":"in_progress"}}`,
+			"",
+			"event: response.failed",
+			`data: {"type":"response.failed","response":{"id":"resp_context","status":"failed","usage":{"input_tokens":271533,"output_tokens":0,"total_tokens":271533},"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again."}}}`,
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleAnthropicStreamingResponse(resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, "gpt-5.5[400k]", "gpt-5.5", "gpt-5.5", time.Now(), 272051)
+
+	require.Error(t, err)
+	require.NotNil(t, result)
+	assert.False(t, result.ClientOutputStarted)
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	assert.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	assert.False(t, failoverErr.RetryableOnSameAccount)
+	assert.Contains(t, string(failoverErr.ResponseBody), "invalid_request_error")
+	assert.Contains(t, string(failoverErr.ResponseBody), "context window")
+	assert.False(t, c.Writer.Written())
+	assert.Empty(t, rec.Body.String())
+}
+
+func TestOpenAIMessagesAnthropicStreamBuffersStartUntilVisibleOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{cfg: &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"X-Request-Id": []string{"rid-visible-output"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.created",
+			`data: {"type":"response.created","response":{"id":"resp_ok","model":"gpt-5.5","status":"in_progress"}}`,
+			"",
+			"event: response.output_item.added",
+			`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"msg_1","type":"message","role":"assistant","content":[]}}`,
+			"",
+			"event: response.output_text.delta",
+			`data: {"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"Hello"}`,
+			"",
+			"event: response.output_text.done",
+			`data: {"type":"response.output_text.done","output_index":0,"content_index":0}`,
+			"",
+			"event: response.completed",
+			`data: {"type":"response.completed","response":{"id":"resp_ok","status":"completed","usage":{"input_tokens":12345,"output_tokens":3,"total_tokens":12348},"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello"}]}]}}`,
+			"",
+		}, "\n"))),
+	}
+
+	result, err := svc.handleAnthropicStreamingResponse(resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Name: "acc"}, "gpt-5.5[400k]", "gpt-5.5", "gpt-5.5", time.Now(), 12345)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.ClientOutputStarted)
+
+	body := rec.Body.String()
+	require.Contains(t, body, "event: message_start")
+	require.Contains(t, body, `"input_tokens":12345`)
+	require.Contains(t, body, "event: content_block_delta")
+	assert.Less(t, strings.Index(body, "event: message_start"), strings.Index(body, "event: content_block_delta"))
+}

--- a/backend/internal/service/openai_gateway_model_availability.go
+++ b/backend/internal/service/openai_gateway_model_availability.go
@@ -3,6 +3,9 @@ package service
 import (
 	"context"
 	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
 )
 
 // DiagnoseModelAvailabilityForPlatform reports whether the requested model
@@ -28,7 +31,7 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 		return ModelAvailabilityDiagnosis{HasAccountsInPool: true, HasModelSupport: true}
 	}
 
-	accounts, err := s.listSchedulableAccounts(ctx, groupID, platform)
+	accounts, err := s.listAccountsForNoAccountDiagnosis(ctx, groupID, platform)
 	if err != nil {
 		// Conservative fallback so the caller keeps returning 503; we do not
 		// want a transient lookup failure to flip into 404 model_not_found.
@@ -36,6 +39,9 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 	}
 
 	diag := ModelAvailabilityDiagnosis{}
+	matchingModelAccounts := 0
+	rateLimitedMatchingAccounts := 0
+	now := time.Now()
 	for i := range accounts {
 		diag.HasAccountsInPool = true
 		// Mirrors the per-candidate filter used during account selection
@@ -44,8 +50,58 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 		// mapping must match.
 		if accounts[i].IsModelSupported(requestedModel) {
 			diag.HasModelSupport = true
-			return diag
+			matchingModelAccounts++
+			if accounts[i].RateLimitResetAt != nil && now.Before(*accounts[i].RateLimitResetAt) {
+				rateLimitedMatchingAccounts++
+				if diag.RateLimitResetAt == nil || accounts[i].RateLimitResetAt.Before(*diag.RateLimitResetAt) {
+					resetAt := *accounts[i].RateLimitResetAt
+					diag.RateLimitResetAt = &resetAt
+				}
+			}
 		}
 	}
+	if matchingModelAccounts > 0 && matchingModelAccounts == rateLimitedMatchingAccounts {
+		diag.AllModelSupportingAccountsRateLimited = true
+	}
 	return diag
+}
+
+func (s *OpenAIGatewayService) listAccountsForNoAccountDiagnosis(ctx context.Context, groupID *int64, platform string) ([]Account, error) {
+	if s == nil || s.accountRepo == nil {
+		return nil, nil
+	}
+	platform = normalizeOpenAICompatiblePlatform(platform)
+	accounts, err := s.accountRepo.ListByPlatform(ctx, platform)
+	if err != nil {
+		return nil, err
+	}
+	if s.cfg != nil && s.cfg.RunMode == config.RunModeSimple {
+		return accounts, nil
+	}
+
+	out := make([]Account, 0, len(accounts))
+	for i := range accounts {
+		if groupID != nil {
+			if openAIAccountHasGroupID(&accounts[i], *groupID) {
+				out = append(out, accounts[i])
+			}
+			continue
+		}
+		if len(accounts[i].GroupIDs) == 0 {
+			out = append(out, accounts[i])
+		}
+	}
+	return out, nil
+}
+
+func openAIAccountHasGroupID(account *Account, groupID int64) bool {
+	if account == nil {
+		return false
+	}
+	for _, id := range account.GroupIDs {
+		if id == groupID {
+			return true
+		}
+	}
+	return false
 }

--- a/backend/internal/service/openai_gateway_model_availability_test.go
+++ b/backend/internal/service/openai_gateway_model_availability_test.go
@@ -1,0 +1,84 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIDiagnoseModelAvailability_AllSupportingAccountsRateLimited(t *testing.T) {
+	resetSoon := time.Now().Add(30 * time.Minute).UTC()
+	resetLater := time.Now().Add(90 * time.Minute).UTC()
+	repo := &mockAccountRepoForPlatform{
+		accounts: []Account{
+			{
+				ID:               1,
+				Platform:         PlatformOpenAI,
+				Status:           StatusActive,
+				Schedulable:      true,
+				GroupIDs:         []int64{7},
+				RateLimitResetAt: &resetLater,
+				Credentials:      map[string]any{"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"}},
+			},
+			{
+				ID:               2,
+				Platform:         PlatformOpenAI,
+				Status:           StatusActive,
+				Schedulable:      true,
+				GroupIDs:         []int64{7},
+				RateLimitResetAt: &resetSoon,
+				Credentials:      map[string]any{"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"}},
+			},
+		},
+		accountsByID: map[int64]*Account{},
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo, cfg: testConfig()}
+	groupID := int64(7)
+
+	diag := svc.DiagnoseModelAvailabilityForPlatform(context.Background(), &groupID, "gpt-5.5", PlatformOpenAI)
+
+	require.True(t, diag.HasAccountsInPool)
+	require.True(t, diag.HasModelSupport)
+	require.True(t, diag.AllModelSupportingAccountsRateLimited)
+	require.NotNil(t, diag.RateLimitResetAt)
+	require.WithinDuration(t, resetSoon, *diag.RateLimitResetAt, time.Second)
+}
+
+func TestOpenAIDiagnoseModelAvailability_MixedRateLimitedAndUsableDoesNotReturnRateLimit(t *testing.T) {
+	resetAt := time.Now().Add(30 * time.Minute).UTC()
+	repo := &mockAccountRepoForPlatform{
+		accounts: []Account{
+			{
+				ID:               1,
+				Platform:         PlatformOpenAI,
+				Status:           StatusActive,
+				Schedulable:      true,
+				GroupIDs:         []int64{7},
+				RateLimitResetAt: &resetAt,
+				Credentials:      map[string]any{"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"}},
+			},
+			{
+				ID:          2,
+				Platform:    PlatformOpenAI,
+				Status:      StatusActive,
+				Schedulable: true,
+				GroupIDs:    []int64{7},
+				Credentials: map[string]any{"model_mapping": map[string]any{"gpt-5.5": "gpt-5.5"}},
+			},
+		},
+		accountsByID: map[int64]*Account{},
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo, cfg: testConfig()}
+	groupID := int64(7)
+
+	diag := svc.DiagnoseModelAvailabilityForPlatform(context.Background(), &groupID, "gpt-5.5", PlatformOpenAI)
+
+	require.True(t, diag.HasAccountsInPool)
+	require.True(t, diag.HasModelSupport)
+	require.False(t, diag.AllModelSupportingAccountsRateLimited)
+	require.NotNil(t, diag.RateLimitResetAt)
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
@@ -241,20 +242,21 @@ type OpenAIForwardResult struct {
 	ServiceTier *string
 	// ReasoningEffort is extracted from request body (reasoning.effort) or derived from model suffix.
 	// Stored for usage records display; nil means not provided / not applicable.
-	ReasoningEffort    *string
-	Stream             bool
-	OpenAIWSMode       bool
-	ResponseHeaders    http.Header
-	Duration           time.Duration
-	FirstTokenMs       *int
-	ClientDisconnect   bool
-	ImageCount         int
-	ImageSize          string
-	ImageInputSize     string
-	ImageOutputSize    string
-	ImageOutputSizes   []string
-	ImageSizeSource    string
-	ImageSizeBreakdown map[string]int
+	ReasoningEffort     *string
+	Stream              bool
+	OpenAIWSMode        bool
+	ResponseHeaders     http.Header
+	Duration            time.Duration
+	FirstTokenMs        *int
+	ClientDisconnect    bool
+	ClientOutputStarted bool
+	ImageCount          int
+	ImageSize           string
+	ImageInputSize      string
+	ImageOutputSize     string
+	ImageOutputSizes    []string
+	ImageSizeSource     string
+	ImageSizeBreakdown  map[string]int
 
 	wsReplayInput       []json.RawMessage
 	wsReplayInputExists bool
@@ -4083,6 +4085,28 @@ func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 		message = "OpenAI stream disconnected before completion"
 	}
 	message = s.recordOpenAIStreamUpstreamError(c, account, passthrough, upstreamRequestID, "failover", payload, message)
+	fields := []zap.Field{
+		zap.String("upstream_request_id", strings.TrimSpace(upstreamRequestID)),
+		zap.String("message", message),
+		zap.Bool("passthrough", passthrough),
+		zap.Int("payload_bytes", len(payload)),
+		zap.Bool("retryable_on_same_account", true),
+	}
+	if c != nil && c.Request != nil {
+		if requestID, _ := c.Request.Context().Value(ctxkey.RequestID).(string); strings.TrimSpace(requestID) != "" {
+			fields = append(fields, zap.String("request_id", strings.TrimSpace(requestID)))
+		}
+		if clientRequestID, _ := c.Request.Context().Value(ctxkey.ClientRequestID).(string); strings.TrimSpace(clientRequestID) != "" {
+			fields = append(fields, zap.String("client_request_id", strings.TrimSpace(clientRequestID)))
+		}
+	}
+	if account != nil {
+		fields = append(fields,
+			zap.Int64("account_id", account.ID),
+			zap.String("account_platform", account.Platform),
+		)
+	}
+	logger.L().Warn("openai_messages.stream_failover_retryable", fields...)
 	body, _ := json.Marshal(gin.H{
 		"error": gin.H{
 			"type":    "upstream_error",
@@ -4090,8 +4114,64 @@ func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 		},
 	})
 	return &UpstreamFailoverError{
-		StatusCode:   http.StatusBadGateway,
-		ResponseBody: body,
+		StatusCode:             http.StatusBadGateway,
+		ResponseBody:           body,
+		RetryableOnSameAccount: true,
+	}
+}
+
+func (s *OpenAIGatewayService) newOpenAIStreamClientError(
+	c *gin.Context,
+	account *Account,
+	upstreamRequestID string,
+	statusCode int,
+	errType string,
+	message string,
+) *UpstreamFailoverError {
+	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
+	if message == "" {
+		message = "OpenAI request failed"
+	}
+	errType = strings.TrimSpace(errType)
+	if errType == "" {
+		errType = "invalid_request_error"
+	}
+	if statusCode < 400 || statusCode >= 500 {
+		statusCode = http.StatusBadRequest
+	}
+	message = s.recordOpenAIStreamUpstreamError(c, account, false, upstreamRequestID, "client_error", nil, message)
+	fields := []zap.Field{
+		zap.String("upstream_request_id", strings.TrimSpace(upstreamRequestID)),
+		zap.Int("status_code", statusCode),
+		zap.String("error_type", errType),
+		zap.String("message", message),
+		zap.Bool("retryable_on_same_account", false),
+	}
+	if c != nil && c.Request != nil {
+		if requestID, _ := c.Request.Context().Value(ctxkey.RequestID).(string); strings.TrimSpace(requestID) != "" {
+			fields = append(fields, zap.String("request_id", strings.TrimSpace(requestID)))
+		}
+		if clientRequestID, _ := c.Request.Context().Value(ctxkey.ClientRequestID).(string); strings.TrimSpace(clientRequestID) != "" {
+			fields = append(fields, zap.String("client_request_id", strings.TrimSpace(clientRequestID)))
+		}
+	}
+	if account != nil {
+		fields = append(fields,
+			zap.Int64("account_id", account.ID),
+			zap.String("account_platform", account.Platform),
+		)
+	}
+	logger.L().Warn("openai_messages.stream_client_error", fields...)
+	body, _ := json.Marshal(gin.H{
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	})
+	return &UpstreamFailoverError{
+		StatusCode:             statusCode,
+		ResponseBody:           body,
+		RetryableOnSameAccount: false,
 	}
 }
 

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -6959,6 +6959,7 @@ func (s *OpenAIGatewayService) updateCodexUsageSnapshot(ctx context.Context, acc
 		defer cancel()
 		_ = s.accountRepo.UpdateExtra(updateCtx, accountID, updates)
 	}()
+	maybeRecoverOpenAICodexQuotaModelRateLimits(ctx, s.accountRepo, accountID, updates)
 }
 
 func (s *OpenAIGatewayService) UpdateCodexUsageSnapshotFromHeaders(ctx context.Context, accountID int64, headers http.Header) {

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -223,3 +223,59 @@ func TestBuildCodexUsageExtraUpdates_WithoutNormalizedWindowFields(t *testing.T)
 		t.Fatalf("did not expect codex_7d_reset_at in updates: %v", updates["codex_7d_reset_at"])
 	}
 }
+
+func TestCodexUsageUpdatesShowQuotaHeadroom(t *testing.T) {
+	if !codexUsageUpdatesShowQuotaHeadroom(map[string]any{
+		"codex_5h_used_percent": 1.0,
+		"codex_7d_used_percent": 0.0,
+	}) {
+		t.Fatal("expected fresh non-exhausted Codex usage to have headroom")
+	}
+
+	if codexUsageUpdatesShowQuotaHeadroom(map[string]any{
+		"codex_5h_used_percent": 1.0,
+		"codex_7d_used_percent": 100.0,
+	}) {
+		t.Fatal("expected exhausted 7d window to block cooldown recovery")
+	}
+
+	if codexUsageUpdatesShowQuotaHeadroom(map[string]any{}) {
+		t.Fatal("expected missing usage snapshot to block cooldown recovery")
+	}
+}
+
+func TestFilterOpenAIQuotaModelRateLimitsPreservesNonQuotaReasons(t *testing.T) {
+	cleaned, changed := filterOpenAIQuotaModelRateLimits(map[string]any{
+		"gpt-5.5": map[string]any{
+			"reason":              openAIModelRateLimitReason,
+			"rate_limit_reset_at": "2026-07-13T20:21:48Z",
+		},
+		"gpt-5.3-codex-spark": map[string]any{
+			"reason":              openAIModelRateLimitReason + ":no_reset_time",
+			"rate_limit_reset_at": "2026-07-15T12:54:11Z",
+		},
+		"gpt-5.6-luna": map[string]any{
+			"reason":              upstreamModelNotFoundReason,
+			"rate_limit_reset_at": "2026-07-10T22:40:35Z",
+		},
+		"openai:image_generation": map[string]any{
+			"reason":              openAIImageRateLimitReason,
+			"rate_limit_reset_at": "2026-07-10T22:40:35Z",
+		},
+	})
+	if !changed {
+		t.Fatal("expected quota model cooldowns to be removed")
+	}
+	if _, ok := cleaned["gpt-5.5"]; ok {
+		t.Fatal("expected gpt-5.5 quota cooldown to be removed")
+	}
+	if _, ok := cleaned["gpt-5.3-codex-spark"]; ok {
+		t.Fatal("expected fallback quota cooldown to be removed")
+	}
+	if _, ok := cleaned["gpt-5.6-luna"]; !ok {
+		t.Fatal("expected upstream 404 cooldown to be preserved")
+	}
+	if _, ok := cleaned["openai:image_generation"]; !ok {
+		t.Fatal("expected image cooldown to be preserved")
+	}
+}

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -523,6 +523,57 @@ func TestOpenAISelectAccountWithLoadAwareness_ImageRateLimitSkipsOnlyImageReques
 	}
 }
 
+func TestOpenAISelectAccountWithLoadAwareness_SparkRateLimitDoesNotBlockGPT55(t *testing.T) {
+	future := time.Now().Add(10 * time.Minute).Format(time.RFC3339)
+	groupID := int64(1)
+
+	sparkLimited := Account{
+		ID:          1,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				"gpt-5.3-codex-spark": map[string]any{
+					"rate_limit_reset_at": future,
+				},
+			},
+		},
+	}
+	available := Account{
+		ID:          2,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    1,
+	}
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{sparkLimited, available}},
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+	}
+
+	sparkSelection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gpt-5.3-codex-spark", nil)
+	require.NoError(t, err)
+	require.NotNil(t, sparkSelection)
+	require.Equal(t, available.ID, sparkSelection.Account.ID)
+	if sparkSelection.ReleaseFunc != nil {
+		sparkSelection.ReleaseFunc()
+	}
+
+	gpt55Selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gpt-5.5", nil)
+	require.NoError(t, err)
+	require.NotNil(t, gpt55Selection)
+	require.Equal(t, sparkLimited.ID, gpt55Selection.Account.ID)
+	if gpt55Selection.ReleaseFunc != nil {
+		gpt55Selection.ReleaseFunc()
+	}
+}
+
 func TestOpenAISelectAccountWithLoadAwareness_FiltersUnschedulableWhenNoConcurrencyService(t *testing.T) {
 	now := time.Now()
 	resetAt := now.Add(10 * time.Minute)

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -46,6 +46,10 @@ func (r *snapshotUpdateAccountRepo) UpdateExtra(ctx context.Context, id int64, u
 	return nil
 }
 
+func (r *snapshotUpdateAccountRepo) GetByID(ctx context.Context, id int64) (*Account, error) {
+	return r.stubOpenAIAccountRepo.GetByID(ctx, id)
+}
+
 func (r stubOpenAIAccountRepo) GetByID(ctx context.Context, id int64) (*Account, error) {
 	for i := range r.accounts {
 		if r.accounts[i].ID == id {
@@ -2254,6 +2258,97 @@ func TestOpenAIUpdateCodexUsageSnapshotFromHeaders(t *testing.T) {
 		require.Equal(t, 86400, updates["codex_7d_reset_after_seconds"])
 	case <-time.After(2 * time.Second):
 		t.Fatal("expected UpdateExtra to be called")
+	}
+}
+
+func TestOpenAIUpdateCodexUsageSnapshotFromHeadersClearsStaleQuotaModelLimits(t *testing.T) {
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{
+			accounts: []Account{
+				{
+					ID:       223,
+					Platform: PlatformOpenAI,
+					Extra: map[string]any{
+						modelRateLimitsKey: map[string]any{
+							"gpt-5.5": map[string]any{
+								"reason":              openAIModelRateLimitReason,
+								"rate_limit_reset_at": "2026-07-13T20:21:48Z",
+							},
+							"gpt-5.6-luna": map[string]any{
+								"reason":              upstreamModelNotFoundReason,
+								"rate_limit_reset_at": "2026-07-10T22:40:35Z",
+							},
+						},
+					},
+				},
+			},
+		},
+		updateExtraCalls: make(chan map[string]any, 2),
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "0")
+	headers.Set("x-codex-secondary-used-percent", "1")
+	headers.Set("x-codex-primary-window-minutes", "10080")
+	headers.Set("x-codex-secondary-window-minutes", "300")
+
+	svc.UpdateCodexUsageSnapshotFromHeaders(context.Background(), 223, headers)
+
+	var recovered map[string]any
+	deadline := time.After(2 * time.Second)
+	for recovered == nil {
+		select {
+		case updates := <-repo.updateExtraCalls:
+			if raw, ok := updates[modelRateLimitsKey].(map[string]any); ok {
+				recovered = raw
+			}
+		case <-deadline:
+			t.Fatal("expected stale quota model cooldowns to be cleared")
+		}
+	}
+	require.NotContains(t, recovered, "gpt-5.5")
+	require.Contains(t, recovered, "gpt-5.6-luna")
+}
+
+func TestOpenAIUpdateCodexUsageSnapshotFromHeadersKeepsQuotaLimitsWhenWindowExhausted(t *testing.T) {
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{
+			accounts: []Account{
+				{
+					ID:       323,
+					Platform: PlatformOpenAI,
+					Extra: map[string]any{
+						modelRateLimitsKey: map[string]any{
+							"gpt-5.5": map[string]any{
+								"reason":              openAIModelRateLimitReason,
+								"rate_limit_reset_at": "2026-07-13T20:21:48Z",
+							},
+						},
+					},
+				},
+			},
+		},
+		updateExtraCalls: make(chan map[string]any, 2),
+	}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "100")
+	headers.Set("x-codex-secondary-used-percent", "0")
+	headers.Set("x-codex-primary-window-minutes", "10080")
+	headers.Set("x-codex-secondary-window-minutes", "300")
+
+	svc.UpdateCodexUsageSnapshotFromHeaders(context.Background(), 323, headers)
+
+	select {
+	case updates := <-repo.updateExtraCalls:
+		require.NotContains(t, updates, modelRateLimitsKey)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected snapshot UpdateExtra call")
+	}
+	select {
+	case updates := <-repo.updateExtraCalls:
+		require.NotContains(t, updates, modelRateLimitsKey, "exhausted windows must not clear quota model cooldowns")
+	case <-time.After(150 * time.Millisecond):
 	}
 }
 

--- a/backend/internal/service/openai_model_alias.go
+++ b/backend/internal/service/openai_model_alias.go
@@ -65,37 +65,45 @@ func normalizeKnownOpenAICodexModel(model string) string {
 	}
 
 	switch {
-	case strings.Contains(normalized, "gpt-5.6-sol"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.6-sol"):
 		return "gpt-5.6-sol"
-	case strings.Contains(normalized, "gpt-5.6-terra"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.6-terra"):
 		return "gpt-5.6-terra"
-	case strings.Contains(normalized, "gpt-5.6-luna"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.6-luna"):
 		return "gpt-5.6-luna"
-	case strings.Contains(normalized, "gpt-5.5-pro"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.5-pro"):
 		return "gpt-5.5-pro"
-	case strings.Contains(normalized, "gpt-5.5"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.5"):
 		return "gpt-5.5"
-	case strings.Contains(normalized, "gpt-5.4-mini"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.4-mini"):
 		return "gpt-5.4-mini"
-	case strings.Contains(normalized, "gpt-5.4-nano"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.4-nano"):
 		return "gpt-5.4-nano"
-	case strings.Contains(normalized, "gpt-5.4"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.4"):
 		return "gpt-5.4"
-	case strings.Contains(normalized, "gpt-5.2"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.2"):
 		return "gpt-5.2"
-	case strings.Contains(normalized, "gpt-5.3-codex-spark"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.3-codex-spark"):
 		return "gpt-5.3-codex-spark"
-	case strings.Contains(normalized, "gpt-5.3-codex"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.3-codex"):
 		return "gpt-5.3-codex"
-	case strings.Contains(normalized, "gpt-5.3"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5.3"):
 		return "gpt-5.3-codex"
 	case strings.Contains(normalized, "codex"):
 		return "gpt-5.3-codex"
-	case strings.Contains(normalized, "gpt-5"):
+	case isKnownOpenAIModelVariant(normalized, "gpt-5"):
 		return "gpt-5.4"
 	default:
 		return ""
 	}
+}
+
+func isKnownOpenAIModelVariant(normalized string, base string) bool {
+	if normalized == base {
+		return true
+	}
+	suffix, ok := strings.CutPrefix(normalized, base+"-")
+	return ok && isKnownCodexModelSuffix(suffix)
 }
 
 func appendUsageBillingModelCandidate(candidates []string, seen map[string]struct{}, model string) []string {

--- a/backend/internal/service/openai_model_mapping.go
+++ b/backend/internal/service/openai_model_mapping.go
@@ -38,3 +38,37 @@ func resolveOpenAICompactForwardModel(account *Account, model string) string {
 	}
 	return trimmedModel
 }
+
+func resolveOpenAICompactFallbackForwardModels(account *Account, requestedModel, mappedModel string) []string {
+	if account == nil {
+		return nil
+	}
+	primaryUpstreamModel := normalizeOpenAIModelForUpstream(account, mappedModel)
+	rawCandidates := account.ResolveCompactFallbackModels(requestedModel, mappedModel)
+	if len(rawCandidates) == 0 {
+		return nil
+	}
+
+	result := make([]string, 0, len(rawCandidates))
+	seen := make(map[string]bool, len(rawCandidates)+1)
+	if primaryUpstreamModel != "" {
+		seen[strings.ToLower(primaryUpstreamModel)] = true
+	}
+	for _, candidate := range rawCandidates {
+		trimmed := strings.TrimSpace(candidate)
+		if trimmed == "" {
+			continue
+		}
+		upstreamModel := normalizeOpenAIModelForUpstream(account, trimmed)
+		if upstreamModel == "" {
+			continue
+		}
+		key := strings.ToLower(upstreamModel)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, upstreamModel)
+	}
+	return result
+}

--- a/backend/internal/service/openai_model_mapping_test.go
+++ b/backend/internal/service/openai_model_mapping_test.go
@@ -277,6 +277,18 @@ func TestNormalizeOpenAIModelForUpstream(t *testing.T) {
 			want:    "gpt-5.5-pro",
 		},
 		{
+			name:    "oauth preserves unknown GPT-5.5 mini variant",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.5-mini",
+			want:    "gpt-5.5-mini",
+		},
+		{
+			name:    "oauth normalizes known GPT-5.5 effort suffix",
+			account: &Account{Type: AccountTypeOAuth},
+			model:   "gpt-5.5-xhigh",
+			want:    "gpt-5.5",
+		},
+		{
 			name:    "oauth preserves codex auto review model",
 			account: &Account{Type: AccountTypeOAuth},
 			model:   "codex-auto-review",

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -226,6 +226,11 @@ func (r *openAIPassthroughFailoverRepo) SetRateLimited(_ context.Context, _ int6
 	return nil
 }
 
+func (r *openAIPassthroughFailoverRepo) SetModelRateLimit(_ context.Context, _ int64, _ string, resetAt time.Time, _ ...string) error {
+	r.rateLimitCalls = append(r.rateLimitCalls, resetAt)
+	return nil
+}
+
 func (r *openAIPassthroughFailoverRepo) SetOverloaded(_ context.Context, _ int64, until time.Time) error {
 	r.overloadCalls = append(r.overloadCalls, until)
 	return nil

--- a/backend/internal/service/rate_limit_429_cooldown_test.go
+++ b/backend/internal/service/rate_limit_429_cooldown_test.go
@@ -73,7 +73,7 @@ func TestHandle429_FallbackUsesDBSeconds(t *testing.T) {
 
 	account := &Account{ID: 42, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
 	before := time.Now()
-	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`))
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`), "")
 	after := time.Now()
 
 	require.Equal(t, 1, accountRepo.rateLimitCalls)
@@ -92,7 +92,7 @@ func TestHandle429_FallbackDisabledSkipsLocalMark(t *testing.T) {
 	svc.SetSettingService(settingSvc)
 
 	account := &Account{ID: 43, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
-	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`))
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"slow down"}}`), "")
 
 	require.Zero(t, accountRepo.rateLimitCalls)
 }
@@ -104,7 +104,7 @@ func TestHandle429_FallbackUsesDefaultSecondsWhenSettingServiceMissing(t *testin
 
 	account := &Account{ID: 44, Platform: PlatformGemini, Type: AccountTypeAPIKey}
 	before := time.Now()
-	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"message":"slow down"}}`))
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"message":"slow down"}}`), "")
 	after := time.Now()
 
 	require.Equal(t, 1, accountRepo.rateLimitCalls)

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -820,30 +820,35 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		"account may be suspended or lack permissions",
 	)
 
+	if account.Type != AccountTypeOAuth {
+		s.handleAuthError(ctx, account, msg)
+		return true
+	}
+
+	count := int64(1)
 	if s.openAI403CounterCache == nil {
-		s.handleAuthError(ctx, account, msg)
-		return true
-	}
-
-	count, err := s.openAI403CounterCache.IncrementOpenAI403Count(ctx, account.ID, openAI403CounterWindowMinutes)
-	if err != nil {
-		slog.Warn("openai_403_increment_failed", "account_id", account.ID, "error", err)
-		s.handleAuthError(ctx, account, msg)
-		return true
-	}
-
-	if count >= openAI403DisableThreshold {
-		msg = fmt.Sprintf("%s | consecutive_403=%d/%d", msg, count, openAI403DisableThreshold)
-		s.handleAuthError(ctx, account, msg)
-		return true
+		slog.Warn("openai_403_counter_unavailable", "account_id", account.ID)
+	} else {
+		var err error
+		count, err = s.openAI403CounterCache.IncrementOpenAI403Count(ctx, account.ID, openAI403CounterWindowMinutes)
+		if err != nil {
+			slog.Warn("openai_403_increment_failed", "account_id", account.ID, "error", err)
+			count = 1
+		}
 	}
 
 	until := time.Now().Add(time.Duration(openAI403CooldownMinutesDefault) * time.Minute)
-	reason := fmt.Sprintf("OpenAI 403 temporary cooldown (%d/%d): %s", count, openAI403DisableThreshold, msg)
+	thresholdReached := count >= openAI403DisableThreshold
+	if thresholdReached {
+		msg = fmt.Sprintf("%s | consecutive_403=%d/%d", msg, count, openAI403DisableThreshold)
+	}
+	reason := fmt.Sprintf("OpenAI OAuth 403 temporary cooldown (%d/%d): %s", count, openAI403DisableThreshold, msg)
+	if thresholdReached {
+		reason = fmt.Sprintf("OpenAI OAuth 403 temporary cooldown threshold reached (%d/%d): %s", count, openAI403DisableThreshold, msg)
+	}
 	s.notifyAccountSchedulingBlocked(account, until, "openai_403_temp")
 	if err := s.accountRepo.SetTempUnschedulable(ctx, account.ID, until, reason); err != nil {
 		slog.Warn("openai_403_set_temp_unschedulable_failed", "account_id", account.ID, "error", err)
-		s.handleAuthError(ctx, account, msg)
 		return true
 	}
 
@@ -853,6 +858,7 @@ func (s *RateLimitService) handleOpenAI403(ctx context.Context, account *Account
 		"until", until,
 		"count", count,
 		"threshold", openAI403DisableThreshold,
+		"threshold_reached", thresholdReached,
 	)
 	return true
 }

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -70,6 +70,7 @@ const (
 const (
 	openAIImageRateLimitDefaultCooldown = time.Minute
 	openAIImageRateLimitReason          = "openai_image_rate_limited"
+	openAIModelRateLimitReason          = "openai_model_rate_limited"
 )
 
 var openAIImageTryAgainPattern = regexp.MustCompile(`(?i)try again in\s+([0-9]+(?:\.[0-9]+)?)\s*(ms|s|sec|secs|second|seconds|m|min|mins|minute|minutes)`)
@@ -362,7 +363,7 @@ func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Acc
 		)
 		shouldDisable = s.handle403(ctx, account, upstreamMsg, responseBody)
 	case 429:
-		s.handle429(ctx, account, headers, responseBody)
+		s.handle429(ctx, account, headers, responseBody, firstRequestedModel(requestedModel))
 		shouldDisable = false
 	case 529:
 		s.handle529(ctx, account)
@@ -913,9 +914,16 @@ func (s *RateLimitService) handleCustomErrorCode(ctx context.Context, account *A
 	slog.Warn("account_disabled_custom_error", "account_id", account.ID, "status_code", statusCode, "error", errorMsg)
 }
 
+func firstRequestedModel(models []string) string {
+	if len(models) == 0 {
+		return ""
+	}
+	return strings.TrimSpace(models[0])
+}
+
 // handle429 处理429限流错误
 // 解析响应头获取重置时间，标记账号为限流状态
-func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte) {
+func (s *RateLimitService) handle429(ctx context.Context, account *Account, headers http.Header, responseBody []byte, requestedModel string) {
 	// Spark 影子：限流/熔断状态 100% 由 QueryUsage(/wham/usage body 的 codex_bengalfox)驱动。
 	// /responses 的 429 携带的 x-codex-*/usage_limit_reached 是 global codex 道(plan/spec §8),
 	// 套到影子会把 spark 误耦合到 global 窗口——即便 spark 仍有配额也会被冷却到 global reset,
@@ -929,6 +937,9 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		persistOpenAI429PlanType(ctx, s.accountRepo, account, responseBody)
 		s.persistOpenAICodexSnapshot(ctx, account, headers)
 		if resetAt := s.calculateOpenAI429ResetTime(headers); resetAt != nil {
+			if s.setOpenAIModelRateLimit(ctx, account, requestedModel, *resetAt, openAIModelRateLimitReason) {
+				return
+			}
 			s.notifyAccountSchedulingBlocked(account, *resetAt, "429")
 			if err := s.accountRepo.SetRateLimited(ctx, account.ID, *resetAt); err != nil {
 				slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
@@ -971,6 +982,9 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 			// 尝试解析 OpenAI 的 usage_limit_reached 错误
 			if resetAt := parseOpenAIRateLimitResetTime(responseBody); resetAt != nil {
 				resetTime := time.Unix(*resetAt, 0)
+				if s.setOpenAIModelRateLimit(ctx, account, requestedModel, resetTime, openAIModelRateLimitReason) {
+					return
+				}
 				s.notifyAccountSchedulingBlocked(account, resetTime, "429")
 				if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetTime); err != nil {
 					slog.Warn("rate_limit_set_failed", "account_id", account.ID, "error", err)
@@ -1004,7 +1018,7 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		}
 
 		// 其他平台：没有重置时间，使用可配置的秒级默认回避，避免误伤长时间不可调度。
-		s.apply429FallbackRateLimit(ctx, account, "no_reset_time")
+		s.apply429FallbackRateLimit(ctx, account, "no_reset_time", requestedModel)
 		return
 	}
 
@@ -1017,6 +1031,9 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	}
 
 	resetAt := time.Unix(ts, 0)
+	if s.setOpenAIModelRateLimit(ctx, account, requestedModel, resetAt, openAIModelRateLimitReason) {
+		return
+	}
 
 	// 标记限流状态
 	s.notifyAccountSchedulingBlocked(account, resetAt, "429")
@@ -1035,7 +1052,23 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 	slog.Info("account_rate_limited", "account_id", account.ID, "reset_at", resetAt)
 }
 
-func (s *RateLimitService) apply429FallbackRateLimit(ctx context.Context, account *Account, reason string) {
+func (s *RateLimitService) setOpenAIModelRateLimit(ctx context.Context, account *Account, requestedModel string, resetAt time.Time, reason string) bool {
+	if s == nil || account == nil || account.Platform != PlatformOpenAI || s.accountRepo == nil {
+		return false
+	}
+	modelKey := modelRateLimitKeyForUpstreamModelNotFound(ctx, account, requestedModel)
+	if strings.TrimSpace(modelKey) == "" {
+		return false
+	}
+	if err := s.accountRepo.SetModelRateLimit(ctx, account.ID, modelKey, resetAt, reason); err != nil {
+		slog.Warn("openai_model_rate_limit_set_failed", "account_id", account.ID, "model", modelKey, "reset_at", resetAt, "error", err)
+		return true
+	}
+	slog.Info("openai_model_rate_limited", "account_id", account.ID, "model", modelKey, "reset_at", resetAt, "reset_in", time.Until(resetAt).Truncate(time.Second))
+	return true
+}
+
+func (s *RateLimitService) apply429FallbackRateLimit(ctx context.Context, account *Account, reason string, requestedModel ...string) {
 	cooldown, enabled := s.get429FallbackCooldown(ctx, account)
 	if !enabled {
 		slog.Info("rate_limit_429_fallback_ignored", "account_id", account.ID, "platform", account.Platform, "reason", reason)
@@ -1043,6 +1076,9 @@ func (s *RateLimitService) apply429FallbackRateLimit(ctx context.Context, accoun
 	}
 
 	resetAt := time.Now().Add(cooldown)
+	if s.setOpenAIModelRateLimit(ctx, account, firstRequestedModel(requestedModel), resetAt, openAIModelRateLimitReason+":"+reason) {
+		return
+	}
 	slog.Warn("rate_limit_429_fallback_used", "account_id", account.ID, "platform", account.Platform, "reason", reason, "using_default", cooldown.String())
 	s.notifyAccountSchedulingBlocked(account, resetAt, "429_fallback")
 	if err := s.accountRepo.SetRateLimited(ctx, account.ID, resetAt); err != nil {

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -17,14 +17,21 @@ type rateLimitAccountRepoStub struct {
 	mockAccountRepoForGemini
 	setErrorCalls          int
 	tempCalls              int
+	rateLimitedCalls       int
+	modelRateLimitCalls    int
 	updateCredentialsCalls int
 	updateExtraCalls       int
 	lastCredentials        map[string]any
 	lastExtraUpdates       map[string]any
 	lastErrorMsg           string
 	lastTempReason         string
+	lastModelRateScope     string
+	lastModelRateReason    string
 	lastErrorID            int64
 	lastTempID             int64
+	lastRateLimitedID      int64
+	lastModelRateID        int64
+	lastModelRateResetAt   time.Time
 }
 
 func (r *rateLimitAccountRepoStub) SetError(ctx context.Context, id int64, errorMsg string) error {
@@ -38,6 +45,23 @@ func (r *rateLimitAccountRepoStub) SetTempUnschedulable(ctx context.Context, id 
 	r.tempCalls++
 	r.lastTempID = id
 	r.lastTempReason = reason
+	return nil
+}
+
+func (r *rateLimitAccountRepoStub) SetRateLimited(ctx context.Context, id int64, resetAt time.Time) error {
+	r.rateLimitedCalls++
+	r.lastRateLimitedID = id
+	return nil
+}
+
+func (r *rateLimitAccountRepoStub) SetModelRateLimit(ctx context.Context, id int64, scope string, resetAt time.Time, reason ...string) error {
+	r.modelRateLimitCalls++
+	r.lastModelRateID = id
+	r.lastModelRateScope = scope
+	r.lastModelRateResetAt = resetAt
+	if len(reason) > 0 {
+		r.lastModelRateReason = reason[0]
+	}
 	return nil
 }
 

--- a/backend/internal/service/ratelimit_service_401_test.go
+++ b/backend/internal/service/ratelimit_service_401_test.go
@@ -32,6 +32,7 @@ type rateLimitAccountRepoStub struct {
 	lastRateLimitedID      int64
 	lastModelRateID        int64
 	lastModelRateResetAt   time.Time
+	tempErr                error
 }
 
 func (r *rateLimitAccountRepoStub) SetError(ctx context.Context, id int64, errorMsg string) error {
@@ -45,7 +46,7 @@ func (r *rateLimitAccountRepoStub) SetTempUnschedulable(ctx context.Context, id 
 	r.tempCalls++
 	r.lastTempID = id
 	r.lastTempReason = reason
-	return nil
+	return r.tempErr
 }
 
 func (r *rateLimitAccountRepoStub) SetRateLimited(ctx context.Context, id int64, resetAt time.Time) error {

--- a/backend/internal/service/ratelimit_service_403_test.go
+++ b/backend/internal/service/ratelimit_service_403_test.go
@@ -61,7 +61,7 @@ func TestRateLimitService_HandleUpstreamError_OpenAI403FirstHitTempUnschedulable
 	require.True(t, blocker.until[0].After(time.Now()))
 }
 
-func TestRateLimitService_HandleUpstreamError_OpenAI403ThresholdDisables(t *testing.T) {
+func TestRateLimitService_HandleUpstreamError_OpenAI403ThresholdStaysTemporaryForOAuth(t *testing.T) {
 	repo := &rateLimitAccountRepoStub{}
 	counter := &openAI403CounterCacheStub{counts: []int64{3}}
 	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
@@ -81,8 +81,58 @@ func TestRateLimitService_HandleUpstreamError_OpenAI403ThresholdDisables(t *test
 	)
 
 	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 1, repo.tempCalls)
+	require.Equal(t, account.ID, repo.lastTempID)
+	require.Contains(t, repo.lastTempReason, "workspace forbidden by policy")
+	require.Contains(t, repo.lastTempReason, "threshold reached")
+	require.Contains(t, repo.lastTempReason, "consecutive_403=3/3")
+}
+
+func TestRateLimitService_HandleUpstreamError_OpenAI403TempWriteFailureDoesNotDisableOAuth(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{tempErr: context.Canceled}
+	counter := &openAI403CounterCacheStub{counts: []int64{3}}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	service.SetOpenAI403CounterCache(counter)
+	account := &Account{
+		ID:       303,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(`<html>Access denied</html>`),
+	)
+
+	require.True(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 1, repo.tempCalls)
+	require.Contains(t, repo.lastTempReason, "threshold reached")
+}
+
+func TestRateLimitService_HandleUpstreamError_OpenAI403NonOAuthStillDisables(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	service := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       304,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+	}
+
+	shouldDisable := service.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{},
+		[]byte(`{"error":{"message":"api key forbidden"}}`),
+	)
+
+	require.True(t, shouldDisable)
 	require.Equal(t, 1, repo.setErrorCalls)
 	require.Equal(t, 0, repo.tempCalls)
-	require.Contains(t, repo.lastErrorMsg, "workspace forbidden by policy")
-	require.Contains(t, repo.lastErrorMsg, "consecutive_403=3/3")
+	require.Contains(t, repo.lastErrorMsg, "api key forbidden")
 }

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -368,9 +368,10 @@ func TestRateLimitService_HandleUpstreamError_403PreservesOriginalUpstreamMessag
 	)
 
 	require.True(t, shouldDisable)
-	require.Equal(t, 1, repo.setErrorCalls)
-	require.Contains(t, repo.lastErrorMsg, "workspace forbidden by policy")
-	require.NotContains(t, repo.lastErrorMsg, "account may be suspended or lack permissions")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 1, repo.tempCalls)
+	require.Contains(t, repo.lastTempReason, "workspace forbidden by policy")
+	require.NotContains(t, repo.lastTempReason, "account may be suspended or lack permissions")
 }
 
 func TestRateLimitService_HandleUpstreamError_403FallsBackToRawBody(t *testing.T) {
@@ -391,10 +392,11 @@ func TestRateLimitService_HandleUpstreamError_403FallsBackToRawBody(t *testing.T
 	)
 
 	require.True(t, shouldDisable)
-	require.Equal(t, 1, repo.setErrorCalls)
-	require.Contains(t, repo.lastErrorMsg, `"access_denied"`)
-	require.Contains(t, repo.lastErrorMsg, `"ip_blocked"`)
-	require.NotContains(t, repo.lastErrorMsg, "account may be suspended or lack permissions")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 1, repo.tempCalls)
+	require.Contains(t, repo.lastTempReason, `"access_denied"`)
+	require.Contains(t, repo.lastTempReason, `"ip_blocked"`)
+	require.NotContains(t, repo.lastTempReason, "account may be suspended or lack permissions")
 }
 
 func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -184,7 +184,7 @@ func TestHandle429_OpenAIPersistsCodexSnapshotImmediately(t *testing.T) {
 	headers.Set("x-codex-secondary-reset-after-seconds", "18000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
-	svc.handle429(context.Background(), account, headers, nil)
+	svc.handle429(context.Background(), account, headers, nil, "")
 
 	if repo.rateLimitedID != account.ID {
 		t.Fatalf("rateLimitedID = %d, want %d", repo.rateLimitedID, account.ID)
@@ -211,7 +211,7 @@ func TestHandle429_OpenAISyncsObservedPlanType(t *testing.T) {
 	}
 	body := []byte(`{"error":{"type":"usage_limit_reached","message":"limit reached","plan_type":"free","resets_at":1777283883}}`)
 
-	svc.handle429(context.Background(), account, http.Header{}, body)
+	svc.handle429(context.Background(), account, http.Header{}, body, "")
 
 	require.Equal(t, []int64{account.ID}, repo.bulkUpdatedIDs)
 	require.Equal(t, "free", repo.bulkUpdatedPayload.Credentials["plan_type"])
@@ -242,7 +242,7 @@ func TestHandle429_SkipsSparkShadow(t *testing.T) {
 		QuotaDimension:  QuotaDimensionSpark,
 	}
 
-	shadowSvc.handle429(context.Background(), shadow, headers, nil)
+	shadowSvc.handle429(context.Background(), shadow, headers, nil, "")
 
 	require.Zero(t, shadowRepo.rateLimitedID, "spark shadow must not be SetRateLimited from /responses global 429")
 	require.Empty(t, shadowRepo.updatedExtra, "spark shadow must not get a codex snapshot from /responses 429")
@@ -252,9 +252,32 @@ func TestHandle429_SkipsSparkShadow(t *testing.T) {
 	normalSvc := NewRateLimitService(normalRepo, nil, nil, nil, nil)
 	normal := &Account{ID: 902, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
 
-	normalSvc.handle429(context.Background(), normal, headers, nil)
+	normalSvc.handle429(context.Background(), normal, headers, nil, "")
 
 	require.Equal(t, normal.ID, normalRepo.rateLimitedID, "normal OpenAI OAuth account should still be rate limited")
+}
+
+func TestHandle429_OpenAIRequestedModelUsesModelRateLimit(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	svc := NewRateLimitService(repo, nil, nil, nil, nil)
+	account := &Account{ID: 125, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	headers := http.Header{}
+	headers.Set("x-codex-primary-used-percent", "0")
+	headers.Set("x-codex-primary-reset-after-seconds", "604800")
+	headers.Set("x-codex-primary-window-minutes", "10080")
+	headers.Set("x-codex-secondary-used-percent", "100")
+	headers.Set("x-codex-secondary-reset-after-seconds", "1200")
+	headers.Set("x-codex-secondary-window-minutes", "300")
+
+	svc.HandleUpstreamError(context.Background(), account, http.StatusTooManyRequests, headers, nil, "gpt-5.3-codex-spark")
+
+	require.Zero(t, repo.rateLimitedCalls, "OpenAI model 429 must not globally cool down the whole account")
+	require.Equal(t, 1, repo.modelRateLimitCalls)
+	require.Equal(t, account.ID, repo.lastModelRateID)
+	require.Equal(t, "gpt-5.3-codex-spark", repo.lastModelRateScope)
+	require.Equal(t, openAIModelRateLimitReason, repo.lastModelRateReason)
+	require.True(t, repo.lastModelRateResetAt.After(time.Now()))
 }
 
 func TestNormalizedCodexLimits(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix the OpenAI `/v1/messages` Anthropic-compat streaming bridge so pre-output upstream failures are not surfaced to Claude-compatible clients as successful empty streams or generic 502s.

This patch:

- pre-estimates input tokens from the converted Responses request and uses that value in Anthropic `message_start.usage.input_tokens`
- buffers initial Anthropic SSE events until real visible assistant output or tool output starts
- treats terminal OpenAI Responses streams with no visible assistant/tool output as failover errors before any client bytes are written
- maps upstream `context_length_exceeded` / no-visible-output client failures to non-retryable Anthropic-compatible 4xx errors instead of masking them as `Upstream service temporarily unavailable`
- lets the messages failover loop retry only when no model output has actually reached the client
- adds diagnostics for terminal Responses event types, output item types, usage, and context-window errors

## Why

Claude-compatible clients can treat an Anthropic stream that only contains `message_start` / `message_stop` as a completed assistant turn even when OpenAI Responses actually ended with `response.failed`, `response.incomplete`, or reasoning-only output. In large-context sessions this hides actionable upstream errors such as `context_length_exceeded` behind an empty reply or a generic 502.

## Tests

- `go test ./internal/pkg/apicompat -run TestStreamingMessageStartUsesPrefilledInputTokens -count=1`
- `go test ./internal/service -run 'TestOpenAIMessagesAnthropicStream(ContextLengthBeforeVisibleOutputReturnsClientError|BuffersStartUntilVisibleOutput)' -count=1`
- `go test ./internal/handler -run TestOpenAIHandleAnthropicFailoverExhaustedPreservesClientError -count=1`

## Notes

I did not run the full unit/integration/lint matrix locally; the change is covered by targeted regression tests around the affected bridge path.