### PR TITLE
fix(ratelimit): Anthropic 无 reset 头的 429 也进入兜底冷却，避免账号永不冷却导致的 429 循环

### DIFF
--- a/backend/internal/service/rate_limit_429_cooldown_test.go
+++ b/backend/internal/service/rate_limit_429_cooldown_test.go
@@ -97,6 +97,45 @@ func TestHandle429_FallbackDisabledSkipsLocalMark(t *testing.T) {
 	require.Zero(t, accountRepo.rateLimitCalls)
 }
 
+// Anthropic 无 reset 头的 429（如 Extra usage required）也应走兜底冷却，
+// 否则账号永不冷却，调度器会让每个请求反复撞同一批 429 账号（旋转木马）。
+func TestHandle429_AnthropicNoResetTimeUsesFallbackCooldown(t *testing.T) {
+	accountRepo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimit429CooldownSettings{Enabled: true, CooldownSeconds: 12})
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = string(data)
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	svc := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
+	svc.SetSettingService(settingSvc)
+
+	account := &Account{ID: 45, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	before := time.Now()
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"Extra usage required"}}`))
+	after := time.Now()
+
+	require.Equal(t, 1, accountRepo.rateLimitCalls)
+	require.Equal(t, int64(45), accountRepo.lastRateLimitID)
+	require.True(t, !accountRepo.lastRateLimitReset.Before(before.Add(12*time.Second)) && !accountRepo.lastRateLimitReset.After(after.Add(12*time.Second)))
+}
+
+// 管理端关闭兜底冷却时，Anthropic 无 reset 头的 429 保持旧行为：不标记账号。
+func TestHandle429_AnthropicNoResetTimeFallbackDisabledSkipsMark(t *testing.T) {
+	accountRepo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data, _ := json.Marshal(RateLimit429CooldownSettings{Enabled: false, CooldownSeconds: 12})
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = string(data)
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	svc := NewRateLimitService(accountRepo, nil, &config.Config{}, nil, nil)
+	svc.SetSettingService(settingSvc)
+
+	account := &Account{ID: 46, Platform: PlatformAnthropic, Type: AccountTypeOAuth}
+	svc.handle429(context.Background(), account, http.Header{}, []byte(`{"error":{"type":"rate_limit_error","message":"Extra usage required"}}`))
+
+	require.Zero(t, accountRepo.rateLimitCalls)
+}
+
 func TestHandle429_FallbackUsesDefaultSecondsWhenSettingServiceMissing(t *testing.T) {
 	accountRepo := &rateLimit429AccountRepoStub{}
 	cfg := &config.Config{}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -994,12 +994,15 @@ func (s *RateLimitService) handle429(ctx context.Context, account *Account, head
 		}
 
 		// Anthropic 平台：没有限流重置时间的 429 可能是非真实限流（如 Extra usage required），
-		// 不标记账号限流状态，直接透传错误给客户端
+		// 不适合按 5h/7d 窗口长时间封禁；但完全不标记会导致账号永不冷却，
+		// 调度器让每个请求反复撞同一批持续 429 的账号（failover 预算被白白烧掉，
+		// 客户端稳定收到 429）。因此同样走可配置的秒级兜底回避，管理端可调大或关闭。
 		if account.Platform == PlatformAnthropic {
-			slog.Warn("rate_limit_429_no_reset_time_skipped",
+			slog.Warn("rate_limit_429_no_reset_time",
 				"account_id", account.ID,
 				"platform", account.Platform,
 				"reason", "no rate limit reset time in headers, likely not a real rate limit")
+			s.apply429FallbackRateLimit(ctx, account, "anthropic_no_reset_time")
 			return
 		}
 


### PR DESCRIPTION
## 问题现象

生产环境中 Claude Max（5x/20x）OAuth 账号频繁向客户端返回 429（`"Upstream rate limit exceeded, please retry later"`）。使用 Claude Code 的用户在开启 auto mode 时基本必现 `claude-opus-4-8 is temporarily unavailable` 报错（其安全分类器请求撞上网关 429）。

## 根因

`ratelimit_service.go` 的 `handle429` 对 **Anthropic 无窗口重置时间的 429**（如 Extra usage required）选择完全跳过标记（原注释：「不标记账号限流状态，直接透传错误给客户端」）。后果是一个恶性循环：

1. 账号返回无 reset 头的 429 → 不进入冷却 → `IsSchedulable()` 仍为 true
2. 调度器持续选中该账号（sticky/负载感知都无法排除它）
3. 每个新请求把同一批持续 429 的账号轮一遍，烧尽 failover 换号预算
4. `handleFailoverExhausted` 向客户端透传 429，循环往复

**生产实证**：一次请求 1.3 秒内连续 failover 4 个账号全部上游 429；事后查库，这 4 个账号的 `rate_limited_at` 停留在 4 天前、`extra->model_rate_limits` 无当日记录——当日的 429 风暴在限流状态中零痕迹，确认命中"跳过标记"分支。

## 修复

让该分支与其他平台的无 reset 头 429 保持一致，走现有的 `apply429FallbackRateLimit` 秒级兜底回避：

- 默认冷却 5s（`defaultRateLimit429CooldownSeconds`），管理端 `RateLimit429CooldownSettings` 可调 1~7200s
- **管理端关闭该设置即完全恢复现行为**（不标记），保留 opt-out——不影响担心"非真实限流被误封"的场景
- 日志 reason 标记为 `anthropic_no_reset_time`（区别于其他平台的 `no_reset_time`），运营可观测
- 带 reset 头的正常 429 路径（5h/7d 窗口解析）完全不受影响

## 测试

- 新增 `TestHandle429_AnthropicNoResetTimeUsesFallbackCooldown`（TDD：修复前 red，修复后 green）
- 新增 `TestHandle429_AnthropicNoResetTimeFallbackDisabledSkipsMark`（opt-out 行为回归保护）
- `go build ./...` / `go test -tags=unit ./...` 全量通过（基于 upstream/main 干净 cherry-pick 验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)