### PR TITLE
fix(billing): 渠道定价覆盖写穿 fallbackPrices 共享指针导致全局计费污染

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -771,6 +771,9 @@ func (s *BillingService) GetModelPricingWithChannel(model string, channelPricing
 	if channelPricing == nil {
 		return pricing, nil
 	}
+	// 防止修改 fallbackPrices 中的共享指针
+	cloned := *pricing
+	pricing = &cloned
 	if channelPricing.InputPrice != nil {
 		pricing.InputPricePerToken = *channelPricing.InputPrice
 		pricing.InputPricePerTokenPriority = *channelPricing.InputPrice

--- a/backend/internal/service/model_pricing_resolver.go
+++ b/backend/internal/service/model_pricing_resolver.go
@@ -150,6 +150,10 @@ func (r *ModelPricingResolver) applyTokenOverrides(chPricing *ChannelModelPricin
 		// 区间不匹配时回退到 BasePricing，也需要覆盖图片价格
 		if resolved.BasePricing == nil {
 			resolved.BasePricing = &ModelPricing{}
+		} else {
+			// 防止修改 fallbackPrices 中的共享指针
+			cloned := *resolved.BasePricing
+			resolved.BasePricing = &cloned
 		}
 		if chPricing.ImageOutputPrice != nil {
 			resolved.BasePricing.ImageOutputPricePerToken = *chPricing.ImageOutputPrice
@@ -163,6 +167,10 @@ func (r *ModelPricingResolver) applyTokenOverrides(chPricing *ChannelModelPricin
 	// 否则用 flat 字段覆盖 BasePricing
 	if resolved.BasePricing == nil {
 		resolved.BasePricing = &ModelPricing{}
+	} else {
+		// 防止修改 fallbackPrices 中的共享指针
+		cloned := *resolved.BasePricing
+		resolved.BasePricing = &cloned
 	}
 
 	if chPricing.InputPrice != nil {

--- a/backend/internal/service/model_pricing_resolver_test.go
+++ b/backend/internal/service/model_pricing_resolver_test.go
@@ -727,3 +727,63 @@ func TestApplyTokenOverrides_IntervalSetsImageOutputPriceExplicit(t *testing.T) 
 	require.True(t, pricing.ImageOutputPriceExplicit)
 	require.Equal(t, 0.0, pricing.ImageOutputPricePerToken)
 }
+
+// ===========================================================================
+// 10. Regression: channel overrides must not pollute fallbackPrices
+// ===========================================================================
+
+// TestApplyTokenOverrides_FlatDoesNotPolluteFallbackPrices verifies that the
+// flat-override path in applyTokenOverrides clones the BasePricing struct
+// before mutation, so the shared fallbackPrices map entry is not written through.
+func TestApplyTokenOverrides_FlatDoesNotPolluteFallbackPrices(t *testing.T) {
+	r := newResolverWithChannel(t, []ChannelModelPricing{{
+		Platform:    "anthropic",
+		Models:      []string{"claude-sonnet-4"},
+		BillingMode: BillingModeToken,
+		InputPrice:  testPtrFloat64(10e-6), // base is 3e-6
+		OutputPrice: testPtrFloat64(50e-6), // base is 15e-6
+	}})
+
+	resolved := r.Resolve(context.Background(), PricingInput{
+		Model:   "claude-sonnet-4",
+		GroupID: groupIDPtr(),
+	})
+
+	// Resolved pricing should reflect the channel override
+	require.NotNil(t, resolved)
+	require.InDelta(t, 10e-6, resolved.BasePricing.InputPricePerToken, 1e-12)
+	require.InDelta(t, 50e-6, resolved.BasePricing.OutputPricePerToken, 1e-12)
+
+	// Global fallbackPrices must NOT be polluted
+	fp := r.billingService.fallbackPrices["claude-sonnet-4"]
+	require.InDelta(t, 3e-6, fp.InputPricePerToken, 1e-12, "fallback InputPricePerToken polluted")
+	require.InDelta(t, 15e-6, fp.OutputPricePerToken, 1e-12, "fallback OutputPricePerToken polluted")
+	require.False(t, fp.ImageOutputPriceExplicit, "fallback ImageOutputPriceExplicit polluted")
+}
+
+// TestApplyTokenOverrides_IntervalDoesNotPolluteFallbackPrices verifies that
+// the interval-override path also clones before mutation.
+func TestApplyTokenOverrides_IntervalDoesNotPolluteFallbackPrices(t *testing.T) {
+	r := newResolverWithChannel(t, []ChannelModelPricing{{
+		Platform:    "anthropic",
+		Models:      []string{"claude-sonnet-4"},
+		BillingMode: BillingModeToken,
+		Intervals: []PricingInterval{
+			{MinTokens: 0, MaxTokens: testPtrInt(100000), InputPrice: testPtrFloat64(2e-6), OutputPrice: testPtrFloat64(8e-6)},
+		},
+	}})
+
+	resolved := r.Resolve(context.Background(), PricingInput{
+		Model:   "claude-sonnet-4",
+		GroupID: groupIDPtr(),
+	})
+
+	require.NotNil(t, resolved)
+	require.True(t, resolved.BasePricing.ImageOutputPriceExplicit)
+
+	// Global fallbackPrices must NOT be polluted
+	fp := r.billingService.fallbackPrices["claude-sonnet-4"]
+	require.InDelta(t, 3e-6, fp.InputPricePerToken, 1e-12, "fallback InputPricePerToken polluted")
+	require.InDelta(t, 15e-6, fp.OutputPricePerToken, 1e-12, "fallback OutputPricePerToken polluted")
+	require.False(t, fp.ImageOutputPriceExplicit, "fallback ImageOutputPriceExplicit polluted")
+}


### PR DESCRIPTION
### 问题

`applyTokenOverrides` 和 `GetModelPricingWithChannel` 在覆盖渠道定价时直接修改 `*ModelPricing` 字段。当 LiteLLM 未命中走 fallback 路径时，`GetModelPricing` 返回的是 `fallbackPrices` map 中的共享指针（`applyModelSpecificPricingPolicy` 仅对 GPT-5.4 族克隆），渠道覆盖直接写穿到全局 map，导致：

- 该模型的全局兜底定价被永久污染，后续所有分组（含未配置渠道定价的）按被篡改的价格计费
- 多 goroutine 并发读写同一 `ModelPricing` 构成 data race
- 别名共享指针（如 `claude-opus-4.5/4.6/4.7`）导致一个模型被覆盖、多个模型连带污染

### 修改

- `model_pricing_resolver.go` `applyTokenOverrides`：区间定价路径和 flat 覆盖路径均在写 `BasePricing` 前克隆，避免回写 `fallbackPrices` 共享指针
- `billing_service.go` `GetModelPricingWithChannel`：`channelPricing != nil` 时先克隆再覆盖（当前调用方始终传 nil，属防御性修复）

### 测试

新增回归测试 `TestApplyTokenOverrides_FlatDoesNotPolluteFallbackPrices` 和 `TestApplyTokenOverrides_IntervalDoesNotPolluteFallbackPrices`，验证渠道定价覆盖后 `fallbackPrices` 全局 map 不被写穿：

```bash
go test -tags unit -race ./internal/service/... -run 'TestApplyTokenOverrides_(Flat|Interval)DoesNotPolluteFallbackPrices' -v
```