### PR TITLE
fix(crs-sync): raise frontend sync timeout to 180s

### DIFF
--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -560,7 +560,9 @@ export async function syncFromCrs(params: {
       action: string
       error?: string
     }>
-  }>('/admin/accounts/sync/crs', params)
+  }>('/admin/accounts/sync/crs', params, {
+    timeout: 180000 // 180s timeout: sync refreshes each existing account's OAuth token serially
+  })
   return data
 }
 


### PR DESCRIPTION
Closes #3827

前端 axios 的默认超时(30s)会导致token刷新超时
给 syncFromCrs 单独设 180s 超时兜底。