### PR TITLE
fix(security): HTML-escape site_name 并对 doc_url 统一应用 sanitizeUrl

### DIFF
--- a/backend/internal/handler/admin/setting_handler_email.go
+++ b/backend/internal/handler/admin/setting_handler_email.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"html"
 	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/handler/dto"
@@ -163,7 +164,7 @@ func (h *SettingHandler) SendTestEmail(c *gin.Context) {
 <body>
     <div class="container">
         <div class="header">
-            <h1>` + siteName + `</h1>
+            <h1>` + html.EscapeString(siteName) + `</h1>
         </div>
         <div class="content">
             <div class="success">✓</div>

--- a/backend/internal/service/email_html_escape_test.go
+++ b/backend/internal/service/email_html_escape_test.go
@@ -1,0 +1,67 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildVerifyCodeEmailBody_EscapesSiteName(t *testing.T) {
+	svc := &EmailService{}
+
+	t.Run("escapes_script_injection", func(t *testing.T) {
+		body := svc.buildVerifyCodeEmailBody("123456", `</h1><script>alert(1)</script><h1>`)
+
+		assert.NotContains(t, body, "<script>")
+		assert.Contains(t, body, "&lt;script&gt;")
+	})
+
+	t.Run("escapes_html_entities", func(t *testing.T) {
+		body := svc.buildVerifyCodeEmailBody("123456", `A&B<C>"D`)
+
+		assert.Contains(t, body, "A&amp;B&lt;C&gt;&#34;D")
+	})
+
+	t.Run("normal_site_name_unchanged", func(t *testing.T) {
+		body := svc.buildVerifyCodeEmailBody("654321", "My Site")
+
+		assert.Contains(t, body, "<h1>My Site</h1>")
+		assert.Contains(t, body, "654321")
+	})
+}
+
+func TestBuildPasswordResetEmailBody_EscapesSiteName(t *testing.T) {
+	svc := &EmailService{}
+
+	t.Run("escapes_html_tags_in_site_name", func(t *testing.T) {
+		body := svc.buildPasswordResetEmailBody("https://example.com/reset?token=abc", `</h1><img src=x onerror=alert(1)>`)
+
+		assert.NotContains(t, body, "<img src=x")
+		assert.True(t, strings.Contains(body, "&lt;img"))
+	})
+
+	t.Run("escapes_html_entities", func(t *testing.T) {
+		body := svc.buildPasswordResetEmailBody("https://example.com/reset", `A&B<C>`)
+
+		assert.Contains(t, body, "A&amp;B&lt;C&gt;")
+	})
+
+	t.Run("normal_site_name_and_url_unchanged", func(t *testing.T) {
+		resetURL := "https://example.com/reset?token=xyz"
+		body := svc.buildPasswordResetEmailBody(resetURL, "Sub2API")
+
+		assert.Contains(t, body, "<h1>Sub2API</h1>")
+		assert.Contains(t, body, resetURL)
+	})
+
+	t.Run("escapes_ampersand_in_reset_url", func(t *testing.T) {
+		resetURL := "https://example.com/reset?a=1&b=2"
+		body := svc.buildPasswordResetEmailBody(resetURL, "Site")
+
+		assert.NotContains(t, body, `href="https://example.com/reset?a=1&b=2"`)
+		assert.Contains(t, body, `href="https://example.com/reset?a=1&amp;b=2"`)
+	})
+}

--- a/backend/internal/service/email_service.go
+++ b/backend/internal/service/email_service.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"html"
 	"log/slog"
 	"math/big"
 	"net"
@@ -454,7 +455,7 @@ func (s *EmailService) buildVerifyCodeEmailBody(code, siteName string) string {
     </div>
 </body>
 </html>
-`, siteName, code)
+`, html.EscapeString(siteName), code)
 }
 
 // TestSMTPConnectionWithConfig 使用指定配置测试SMTP连接
@@ -673,5 +674,5 @@ func (s *EmailService) buildPasswordResetEmailBody(resetURL, siteName string) st
     </div>
 </body>
 </html>
-`, siteName, resetURL, resetURL)
+`, html.EscapeString(siteName), html.EscapeString(resetURL), html.EscapeString(resetURL))
 }

--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	htmlpkg "html"
 	"io"
 	"io/fs"
 	"net/http"
@@ -230,7 +231,7 @@ func injectSiteTitle(html, settingsJSON []byte) []byte {
 		return html
 	}
 
-	newTitle := []byte("<title>" + cfg.SiteName + " - AI API Gateway</title>")
+	newTitle := []byte("<title>" + htmlpkg.EscapeString(cfg.SiteName) + " - AI API Gateway</title>")
 	var buf bytes.Buffer
 	buf.Write(html[:titleStart])
 	buf.Write(newTitle)

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -79,6 +79,25 @@ func TestInjectSiteTitle(t *testing.T) {
 		assert.Equal(t, string(html), string(result))
 	})
 
+	t.Run("escapes_html_in_site_name", func(t *testing.T) {
+		html := []byte(`<html><head><title>Sub2API - AI API Gateway</title></head><body></body></html>`)
+		settingsJSON := []byte(`{"site_name":"</title><script>alert(1)</script><title>"}`)
+
+		result := injectSiteTitle(html, settingsJSON)
+
+		assert.NotContains(t, string(result), "<script>")
+		assert.Contains(t, string(result), "&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;title&gt;")
+	})
+
+	t.Run("escapes_ampersand_in_site_name", func(t *testing.T) {
+		html := []byte(`<html><head><title>Sub2API</title></head><body></body></html>`)
+		settingsJSON := []byte(`{"site_name":"A&B"}`)
+
+		result := injectSiteTitle(html, settingsJSON)
+
+		assert.Contains(t, string(result), "<title>A&amp;B - AI API Gateway</title>")
+	})
+
 	t.Run("preserves_rest_of_html", func(t *testing.T) {
 		html := []byte(`<html><head><meta charset="UTF-8"><title>Sub2API</title><script src="app.js"></script></head><body><div id="app"></div></body></html>`)
 		settingsJSON := []byte(`{"site_name":"TestSite"}`)

--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -249,6 +249,7 @@ import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import SubscriptionProgressMini from '@/components/common/SubscriptionProgressMini.vue'
 import AnnouncementBell from '@/components/common/AnnouncementBell.vue'
 import Icon from '@/components/icons/Icon.vue'
+import { sanitizeUrl } from '@/utils/url'
 
 const router = useRouter()
 const route = useRoute()
@@ -262,7 +263,7 @@ const user = computed(() => authStore.user)
 const dropdownOpen = ref(false)
 const dropdownRef = ref<HTMLElement | null>(null)
 const contactInfo = computed(() => appStore.contactInfo)
-const docUrl = computed(() => appStore.docUrl)
+const docUrl = computed(() => sanitizeUrl(appStore.docUrl))
 const avatarUrl = computed(() => user.value?.avatar_url?.trim() || '')
 const availableBalance = computed(() => Number(user.value?.balance || 0))
 const frozenBalance = computed(() => Number(user.value?.frozen_balance || 0))

--- a/frontend/src/components/layout/__tests__/docUrlSanitization.spec.ts
+++ b/frontend/src/components/layout/__tests__/docUrlSanitization.spec.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const dir = dirname(fileURLToPath(import.meta.url))
+const headerSource = readFileSync(resolve(dir, '../AppHeader.vue'), 'utf8')
+const homeViewSource = readFileSync(resolve(dir, '../../../views/HomeView.vue'), 'utf8')
+const keyUsageViewSource = readFileSync(resolve(dir, '../../../views/KeyUsageView.vue'), 'utf8')
+
+describe('doc_url sanitization', () => {
+  it('AppHeader imports sanitizeUrl', () => {
+    expect(headerSource).toContain("import { sanitizeUrl } from '@/utils/url'")
+  })
+
+  it('AppHeader applies sanitizeUrl to docUrl', () => {
+    expect(headerSource).toContain('sanitizeUrl(appStore.docUrl)')
+  })
+
+  it('HomeView imports sanitizeUrl', () => {
+    expect(homeViewSource).toContain("import { sanitizeUrl } from '@/utils/url'")
+  })
+
+  it('HomeView applies sanitizeUrl to docUrl', () => {
+    expect(homeViewSource).toContain('sanitizeUrl(appStore.cachedPublicSettings?.doc_url || appStore.docUrl')
+  })
+
+  it('KeyUsageView imports sanitizeUrl', () => {
+    expect(keyUsageViewSource).toContain("import { sanitizeUrl } from '@/utils/url'")
+  })
+
+  it('KeyUsageView applies sanitizeUrl to docUrl', () => {
+    expect(keyUsageViewSource).toContain('sanitizeUrl(appStore.cachedPublicSettings?.doc_url || appStore.docUrl')
+  })
+})

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -410,6 +410,7 @@ import { useI18n } from 'vue-i18n'
 import { useAuthStore, useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
+import { sanitizeUrl } from '@/utils/url'
 
 const { t } = useI18n()
 
@@ -420,7 +421,7 @@ const appStore = useAppStore()
 const siteName = computed(() => appStore.cachedPublicSettings?.site_name || appStore.siteName || 'Sub2API')
 const siteLogo = computed(() => appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '')
 const siteSubtitle = computed(() => appStore.cachedPublicSettings?.site_subtitle || 'AI API Gateway Platform')
-const docUrl = computed(() => appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '')
+const docUrl = computed(() => sanitizeUrl(appStore.cachedPublicSettings?.doc_url || appStore.docUrl || ''))
 const homeContent = computed(() => appStore.cachedPublicSettings?.home_content || '')
 
 // Check if homeContent is a URL (for iframe display)

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -423,6 +423,7 @@ import { useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildGatewayUrl } from '@/api/client'
+import { sanitizeUrl } from '@/utils/url'
 
 const { t, locale } = useI18n()
 const appStore = useAppStore()
@@ -431,7 +432,7 @@ const appStore = useAppStore()
 
 const siteName = computed(() => appStore.cachedPublicSettings?.site_name || appStore.siteName || 'Sub2API')
 const siteLogo = computed(() => appStore.cachedPublicSettings?.site_logo || appStore.siteLogo || '')
-const docUrl = computed(() => appStore.cachedPublicSettings?.doc_url || appStore.docUrl || '')
+const docUrl = computed(() => sanitizeUrl(appStore.cachedPublicSettings?.doc_url || appStore.docUrl || ''))
 const githubUrl = 'https://github.com/Wei-Shaw/sub2api'
 
 // ==================== Theme (same as HomeView) ====================


### PR DESCRIPTION
## 背景

Refs #3839（第 8、12 点）

`site_name` 来自管理员设置，在以下位置被直接拼接到 HTML 中，未经转义：
- `embed_on.go:233`：`<title>` + `cfg.SiteName` — 浏览器 tab 标题注入
- `email_service.go:441,655`：验证码/密码重置邮件 `<h1>%s</h1>` — 邮件 HTML 注入
- `setting_handler_email.go:166`：测试邮件 `<h1>` + `siteName` — 同上

`doc_url` 同样来自管理员设置，在 `AppHeader.vue`、`HomeView.vue`、`KeyUsageView.vue` 中被直接绑定到 `:href`，未经过项目已有的 `sanitizeUrl` 工具函数过滤（`AuthLayout.vue:73` 已在用该函数过滤 `siteLogo`）。

## 修改

**后端（3 文件）：**
- `embed_on.go`：`import htmlpkg "html"`（避免与函数参数 `html []byte` 同名），用 `htmlpkg.EscapeString(cfg.SiteName)` 替换原始拼接
- `email_service.go`：`import "html"`，对 `buildVerifyCodeEmailBody` 和 `buildPasswordResetEmailBody` 中的 `siteName` 和 `resetURL` 使用 `html.EscapeString`
- `setting_handler_email.go`：`import "html"`，测试邮件 handler 中的 `siteName` 使用 `html.EscapeString`

**前端（3 文件）：**
- `AppHeader.vue`：`import { sanitizeUrl } from '@/utils/url'`，`docUrl` computed 值包裹 `sanitizeUrl()`
- `HomeView.vue`：同上
- `KeyUsageView.vue`：同上

## 兼容性说明

- `html.EscapeString` 仅转义 HTML 特殊字符（`< > & " '`），正常站名不受影响
- `sanitizeUrl` 只允许 `http://` / `https://` 协议的绝对 URL，无效 URL 返回空字符串 → `v-if="docUrl"` 为 falsy 不渲染链接，与原行为一致（原来空字符串也不渲染）
- 邮件中 `resetURL` 的 `&` 在 href 属性中被转义为 `&amp;`，浏览器会正确解码，不影响链接功能

## 测试

**后端新增测试：**
- `email_html_escape_test.go`（7 用例）：覆盖 `<script>` 注入、HTML 实体转义、正常站名、resetURL `&` 转义
- `embed_test.go`（+2 用例）：`escapes_html_in_site_name`、`escapes_ampersand_in_site_name`

**前端新增测试：**
- `docUrlSanitization.spec.ts`（6 用例）：源码静态检查验证 3 个组件均 import 并使用 `sanitizeUrl`

**本地验证：**
```bash
# 后端
go vet ./internal/service/ ./internal/handler/admin/
go test -tags=unit -run "TestBuildVerifyCodeEmailBody|TestBuildPasswordResetEmailBody" ./internal/service/ -v  # PASS

# 前端
pnpm run typecheck      # PASS
pnpm run lint:check      # PASS
pnpm run test:run -- src/components/layout/__tests__/docUrlSanitization.spec.ts  # 6/6 PASS
```