### PR TITLE
ci: bump Go to 1.26.5 to fix govulncheck GO-2026-5856

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Unit tests
         working-directory: backend
         run: make test-unit
@@ -60,7 +60,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
 
       # Docker setup for GoReleaser
       - name: Set up QEMU

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,7 +23,7 @@ jobs:
           cache-dependency-path: backend/go.sum
       - name: Verify Go version
         run: |
-          go version | grep -q 'go1.26.4'
+          go version | grep -q 'go1.26.5'
       - name: Run govulncheck
         working-directory: backend
         run: |

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/Wei-Shaw/sub2api
 
-go 1.26.4
+go 1.26.5
 
 require (
 	entgo.io/ent v0.14.5


### PR DESCRIPTION
CI 的 backend-security报红,报的是 Go 标准库漏洞 GO-2026-5856(crypto/tls,1.26.4 命中,1.26.5 修复)。

改动:
- backend/go.mod 的 go 指令 1.26.4 → 1.26.5
- 4 处 workflow 的 Go 版本断言同步改成 go1.26.5(backend-ci ×2 / security-scan / release)

本地验证通过, 纯CI/构建配置改动