### PR TITLE
fix(apicompat): ResponsesToAnthropicRequest 补全 instructions 字段并映射 developer role

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic_instructions_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_instructions_test.go
@@ -1,0 +1,126 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponsesToAnthropicRequest_Instructions(t *testing.T) {
+	t.Run("instructions_becomes_system", func(t *testing.T) {
+		req := &ResponsesRequest{
+			Model:        "claude-sonnet-4-20250514",
+			Instructions: "You are a helpful assistant.",
+			Input:        json.RawMessage(`[{"role":"user","content":"hello"}]`),
+		}
+
+		result, err := ResponsesToAnthropicRequest(req)
+		require.NoError(t, err)
+
+		var system string
+		require.NoError(t, json.Unmarshal(result.System, &system))
+		assert.Equal(t, "You are a helpful assistant.", system)
+		assert.NotEmpty(t, result.Messages)
+	})
+
+	t.Run("empty_instructions_no_system", func(t *testing.T) {
+		req := &ResponsesRequest{
+			Model: "claude-sonnet-4-20250514",
+			Input: json.RawMessage(`[{"role":"user","content":"hello"}]`),
+		}
+
+		result, err := ResponsesToAnthropicRequest(req)
+		require.NoError(t, err)
+		assert.Nil(t, result.System)
+	})
+
+	t.Run("instructions_and_system_item_concatenated", func(t *testing.T) {
+		req := &ResponsesRequest{
+			Model:        "claude-sonnet-4-20250514",
+			Instructions: "Top-level instruction.",
+			Input: json.RawMessage(`[
+				{"role":"system","content":"Input-level system prompt."},
+				{"role":"user","content":"hello"}
+			]`),
+		}
+
+		result, err := ResponsesToAnthropicRequest(req)
+		require.NoError(t, err)
+
+		var system string
+		require.NoError(t, json.Unmarshal(result.System, &system))
+		assert.Contains(t, system, "Top-level instruction.")
+		assert.Contains(t, system, "Input-level system prompt.")
+	})
+
+	t.Run("instructions_with_string_input", func(t *testing.T) {
+		req := &ResponsesRequest{
+			Model:        "claude-sonnet-4-20250514",
+			Instructions: "Be concise.",
+			Input:        json.RawMessage(`"What is Go?"`),
+		}
+
+		result, err := ResponsesToAnthropicRequest(req)
+		require.NoError(t, err)
+
+		var system string
+		require.NoError(t, json.Unmarshal(result.System, &system))
+		assert.Equal(t, "Be concise.", system)
+		require.Len(t, result.Messages, 1)
+		assert.Equal(t, "user", result.Messages[0].Role)
+	})
+}
+
+func TestConvertResponsesInputToAnthropic_DeveloperRole(t *testing.T) {
+	t.Run("developer_becomes_system", func(t *testing.T) {
+		input := `[
+			{"role":"developer","content":[{"type":"input_text","text":"You are a code reviewer."}]},
+			{"role":"user","content":"review this code"}
+		]`
+
+		system, messages, err := convertResponsesInputToAnthropic("", json.RawMessage(input))
+		require.NoError(t, err)
+
+		var systemText string
+		require.NoError(t, json.Unmarshal(system, &systemText))
+		assert.Equal(t, "You are a code reviewer.", systemText)
+
+		require.Len(t, messages, 1)
+		assert.Equal(t, "user", messages[0].Role)
+	})
+
+	t.Run("developer_does_not_become_user", func(t *testing.T) {
+		input := `[
+			{"role":"developer","content":[{"type":"input_text","text":"System prompt."}]},
+			{"role":"user","content":"hi"}
+		]`
+
+		_, messages, err := convertResponsesInputToAnthropic("", json.RawMessage(input))
+		require.NoError(t, err)
+
+		for _, m := range messages {
+			if m.Role == "user" {
+				var s string
+				if json.Unmarshal(m.Content, &s) == nil {
+					assert.NotContains(t, s, "System prompt.")
+				}
+			}
+		}
+	})
+
+	t.Run("instructions_and_developer_concatenated_in_order", func(t *testing.T) {
+		input := `[
+			{"role":"developer","content":"Extra context."},
+			{"role":"user","content":"hello"}
+		]`
+
+		system, _, err := convertResponsesInputToAnthropic("Main instruction.", json.RawMessage(input))
+		require.NoError(t, err)
+
+		var systemText string
+		require.NoError(t, json.Unmarshal(system, &systemText))
+		assert.Equal(t, "Main instruction.\n\nExtra context.", systemText)
+	})
+}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -11,7 +11,7 @@ import (
 // enables Anthropic platform groups to accept OpenAI Responses API requests
 // by converting them to the native /v1/messages format before forwarding upstream.
 func ResponsesToAnthropicRequest(req *ResponsesRequest) (*AnthropicRequest, error) {
-	system, messages, err := convertResponsesInputToAnthropic(req.Input)
+	system, messages, err := convertResponsesInputToAnthropic(req.Instructions, req.Input)
 	if err != nil {
 		return nil, err
 	}
@@ -98,14 +98,23 @@ func mapResponsesEffortToAnthropic(effort string) string {
 }
 
 // convertResponsesInputToAnthropic extracts system prompt and messages from
-// a Responses API input array. Returns the system as raw JSON (for Anthropic's
-// polymorphic system field) and a list of Anthropic messages.
-func convertResponsesInputToAnthropic(inputRaw json.RawMessage) (json.RawMessage, []AnthropicMessage, error) {
+// a Responses API instructions + input array. Returns the system as raw JSON
+// (for Anthropic's polymorphic system field) and a list of Anthropic messages.
+func convertResponsesInputToAnthropic(instructions string, inputRaw json.RawMessage) (json.RawMessage, []AnthropicMessage, error) {
+	var systemParts []string
+	if strings.TrimSpace(instructions) != "" {
+		systemParts = append(systemParts, strings.TrimSpace(instructions))
+	}
+
 	// Try as plain string input.
 	var inputStr string
 	if err := json.Unmarshal(inputRaw, &inputStr); err == nil {
 		content, _ := json.Marshal(inputStr)
-		return nil, []AnthropicMessage{{Role: "user", Content: content}}, nil
+		var system json.RawMessage
+		if len(systemParts) > 0 {
+			system, _ = json.Marshal(strings.Join(systemParts, "\n\n"))
+		}
+		return system, []AnthropicMessage{{Role: "user", Content: content}}, nil
 	}
 
 	var items []ResponsesInputItem
@@ -113,16 +122,14 @@ func convertResponsesInputToAnthropic(inputRaw json.RawMessage) (json.RawMessage
 		return nil, nil, fmt.Errorf("parse responses input: %w", err)
 	}
 
-	var system json.RawMessage
 	var messages []AnthropicMessage
 
 	for _, item := range items {
 		switch {
-		case item.Role == "system":
-			// System prompt → Anthropic system field
+		case item.Role == "system" || item.Role == "developer":
 			text := extractTextFromContent(item.Content)
 			if text != "" {
-				system, _ = json.Marshal(text)
+				systemParts = append(systemParts, text)
 			}
 
 		case item.Type == "function_call":
@@ -200,6 +207,11 @@ func convertResponsesInputToAnthropic(inputRaw json.RawMessage) (json.RawMessage
 	messages = mergeConsecutiveMessages(messages)
 	messages = normalizeAnthropicToolPairing(messages)
 	messages = mergeConsecutiveMessages(messages)
+
+	var system json.RawMessage
+	if len(systemParts) > 0 {
+		system, _ = json.Marshal(strings.Join(systemParts, "\n\n"))
+	}
 
 	return system, messages, nil
 }

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_tool_pairing_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_tool_pairing_test.go
@@ -58,7 +58,7 @@ func hasToolResult(blocks []AnthropicContentBlock, toolUseID string) bool {
 
 func convertAnthropic(t *testing.T, input string) []AnthropicMessage {
 	t.Helper()
-	_, messages, err := convertResponsesInputToAnthropic(json.RawMessage(input))
+	_, messages, err := convertResponsesInputToAnthropic("", json.RawMessage(input))
 	require.NoError(t, err)
 	assertAnthropicPairing(t, messages)
 	return messages


### PR DESCRIPTION
## 背景

Fixes #3850

`ResponsesToAnthropicRequest` 在将 Responses API 请求转换为 Anthropic Messages 格式时，存在两个缺陷：

1. **`instructions` 字段被静默丢弃**：`convertResponsesInputToAnthropic` 只接收 `req.Input`，从不读取 `req.Instructions`。Codex CLI / OpenAI SDK 的系统提示词放在 `instructions` 中，导致 Claude 上游收到的对话不包含任何系统提示词。
2. **`developer` role 落入 default**：input 数组中 `role: "developer"` 的 item 未被识别，落入 `default` 分支变成 `user` 消息，content 为 Responses 格式的 parts 数组（非法的 Anthropic block 类型）。

兄弟路径 `ResponsesToChatCompletionsRequest`（`chatcompletions_responses_bridge.go:18`）正确处理了两者。

## 修改

**`responses_to_anthropic_request.go`（2 处）：**
- `convertResponsesInputToAnthropic` 签名从 `(inputRaw json.RawMessage)` 改为 `(instructions string, inputRaw json.RawMessage)`。非空 `instructions` 作为第一个 system 部分，input 中的 `system`/`developer` item 追加拼接（`\n\n` 分隔）
- switch 增加 `item.Role == "developer"` 条件，与 `system` 共用同一 case，通过 `extractTextFromContent` 提取文本

**`responses_to_anthropic_tool_pairing_test.go`（1 处）：**
- 更新 `convertAnthropic` helper 的调用，传入空字符串适配新签名

## 兼容性说明

- **无 instructions 的请求**：`instructions` 为空字符串时，`systemParts` 起始为空，行为与修改前完全一致
- **plain string input 快速路径**：正确处理 instructions（非空时返回 system，空时返回 nil）
- **现有 system role item**：仍被正确处理，与 instructions 拼接而非覆盖
- **tool pairing**：developer item 不再成为 user 消息干扰 tool_use/tool_result 配对，反而改善了复杂对话的修复效果

## 测试

**新增 `responses_to_anthropic_instructions_test.go`（7 用例）：**
- `instructions_becomes_system`：instructions 转为 Anthropic system 字段
- `empty_instructions_no_system`：空 instructions 不产生 system（后向兼容）
- `instructions_and_system_item_concatenated`：instructions + input system item 拼接
- `instructions_with_string_input`：plain string input + instructions 组合
- `developer_becomes_system`：developer role 正确映射为 system
- `developer_does_not_become_user`：developer 不再落入 default 变成 user
- `instructions_and_developer_concatenated_in_order`：instructions + developer 按顺序拼接（assert.Equal 锁定顺序）

```bash
go test ./internal/pkg/apicompat/ -v -count=1  # 全量 PASS
go vet ./internal/pkg/apicompat/ ./internal/service/  # 无警告
```