### PR TITLE
fix(messages): /v1/messages 传输层错误对齐 failover 链路

### DIFF
--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -302,18 +302,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 	if err != nil {
-		safeErr := sanitizeUpstreamErrorMessage(err.Error())
-		setOpsUpstreamError(c, 0, safeErr, "")
-		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
-			Platform:           account.Platform,
-			AccountID:          account.ID,
-			AccountName:        account.Name,
-			UpstreamStatusCode: 0,
-			Kind:               "request_error",
-			Message:            safeErr,
-		})
-		writeAnthropicError(c, http.StatusBadGateway, "api_error", "Upstream request failed")
-		return nil, fmt.Errorf("upstream request failed: %s", safeErr)
+		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/openai_gateway_messages_transport_failover_test.go
+++ b/backend/internal/service/openai_gateway_messages_transport_failover_test.go
@@ -1,0 +1,92 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestForwardAsAnthropic_TransportError_ReturnsFailoverError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{
+		err: errors.New(`dial tcp 1.2.3.4:443: connect: connection refused`),
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	account := rawChatCompletionsTestAccount()
+	_, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.True(t, errors.As(err, &failoverErr), "transport error should return UpstreamFailoverError for handler failover, got: %T", err)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+}
+
+func TestForwardAsAnthropic_TransportError_DoesNotWriteResponse(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{
+		err: errors.New(`read tcp: connection reset by peer`),
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	account := rawChatCompletionsTestAccount()
+	_, _ = svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+
+	require.Equal(t, http.StatusOK, rec.Code, "transport error must not write HTTP response — handler owns the response for failover")
+	require.Empty(t, rec.Body.String(), "response body must be empty so handler can write the correct error or failover")
+}
+
+func TestForwardAsAnthropic_TransportError_ClientCanceled_NoFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":32,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body)).WithContext(cancelCtx)
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{
+		err: context.Canceled,
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	account := rawChatCompletionsTestAccount()
+	_, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "")
+
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "client-canceled transport error should NOT trigger failover")
+}


### PR DESCRIPTION
## 背景

Fixes #3854

`ForwardAsAnthropic`（`/v1/messages` 入站 → OpenAI 上游）在 `httpUpstream.Do` 返回传输层错误（代理挂、DNS 失败、连接超时等）时，直接调用 `writeAnthropicError(502)` 并返回 `fmt.Errorf` — 既不触发 failover 换号，也不临时摘除坏账号。

同类路径（CC、passthrough、grok、CC pipeline）全部调用 `handleOpenAIUpstreamTransportError`，返回 `UpstreamFailoverError` 让 handler 自动换号重试 + 持久性故障自动摘号。

## 修改

**`openai_gateway_messages.go`（1 处，-12 / +1）：**

将手动的 `setOpsUpstreamError` + `appendOpsUpstreamError` + `writeAnthropicError` + `fmt.Errorf` 替换为：
```go
return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
```

行为对齐：
- **Ops 日志**：`handleOpenAIUpstreamTransportError` 内部完成（状态码 0 + `request_error`），且额外做了 `sanitizeUpstreamErrorMessage` 防止代理凭据泄露
- **持久性故障摘号**：代理凭据过期、DNS 失败等自动调用 `tempUnscheduleOpenAITransportError`
- **Failover**：返回 `UpstreamFailoverError`，handler 在 `openai_gateway_handler.go:903` 自动换号重试
- **客户端断连**：`context.Canceled` 返回普通 error，不 failover 不摘号

## 兼容性说明

- Handler 层（`openai_gateway_handler.go:903-948`）已完整支持 `UpstreamFailoverError` 的换号循环、池模式重试、failover 耗尽写 Anthropic 格式错误 — 无需改动
- `handleOpenAIUpstreamTransportError` 不写 response（设计文档："handler owns the response"），不会与 handler 的 `writerSizeBeforeForward` 检查冲突
- 旧代码调用 `writeAnthropicError` 后返回普通 error，handler 检测到 response 已写入 → **跳过 failover** — 这恰恰是原来 bug 的根因

## 测试

**新增 `openai_gateway_messages_transport_failover_test.go`（3 用例）：**
- `TransportError_ReturnsFailoverError`：传输层错误返回 `UpstreamFailoverError`（而非 plain error）
- `TransportError_DoesNotWriteResponse`：传输层错误不写 response body（handler 拥有 response 生命周期）
- `TransportError_ClientCanceled_NoFailover`：`context.Canceled` 不触发 failover

```bash
go test -tags=unit -run "TestForwardAsAnthropic_TransportError" ./internal/service/ -v  # 3/3 PASS
go vet ./internal/service/  # 无警告
```