### PR TITLE
feat: add Feishu ops alert notifications

### DIFF
--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -292,7 +292,7 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 
 			eventsCreated++
 			if created != nil && created.ID > 0 {
-				if s.maybeSendAlertEmail(ctx, runtimeCfg, rule, created) {
+				if s.maybeSendAlertNotifications(ctx, runtimeCfg, rule, created) {
 					emailsSent++
 				}
 			}
@@ -675,8 +675,8 @@ func buildOpsAlertDescription(rule *OpsAlertRule, value float64, windowMinutes i
 	)
 }
 
-func (s *OpsAlertEvaluatorService) maybeSendAlertEmail(ctx context.Context, runtimeCfg *OpsAlertRuntimeSettings, rule *OpsAlertRule, event *OpsAlertEvent) bool {
-	if s == nil || s.emailService == nil || s.opsService == nil || event == nil || rule == nil {
+func (s *OpsAlertEvaluatorService) maybeSendAlertNotifications(ctx context.Context, runtimeCfg *OpsAlertRuntimeSettings, rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if s == nil || s.opsService == nil || event == nil || rule == nil {
 		return false
 	}
 	if event.EmailSent {
@@ -691,9 +691,6 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertEmail(ctx context.Context, runt
 		return false
 	}
 
-	if len(emailCfg.Alert.Recipients) == 0 {
-		return false
-	}
 	if !shouldSendOpsAlertEmailByMinSeverity(strings.TrimSpace(emailCfg.Alert.MinSeverity), strings.TrimSpace(rule.Severity)) {
 		return false
 	}
@@ -704,11 +701,27 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertEmail(ctx context.Context, runt
 		}
 	}
 
-	// Apply/update rate limiter.
+	// Apply/update shared notification rate limiter.
 	s.emailLimiter.SetLimit(emailCfg.Alert.RateLimitPerHour)
 
 	subject := fmt.Sprintf("[Ops Alert][%s] %s", strings.TrimSpace(rule.Severity), strings.TrimSpace(rule.Name))
 	body := buildOpsAlertEmailBody(rule, event)
+
+	anySent := s.sendOpsAlertEmails(ctx, emailCfg, rule, event, subject, body)
+	if s.sendOpsAlertFeishu(ctx, emailCfg, rule, event) {
+		anySent = true
+	}
+
+	if anySent {
+		_ = s.opsRepo.UpdateAlertEventEmailSent(context.Background(), event.ID, true)
+	}
+	return anySent
+}
+
+func (s *OpsAlertEvaluatorService) sendOpsAlertEmails(ctx context.Context, emailCfg *OpsEmailNotificationConfig, rule *OpsAlertRule, event *OpsAlertEvent, subject, body string) bool {
+	if s == nil || s.emailService == nil || emailCfg == nil || event == nil || rule == nil {
+		return false
+	}
 
 	anySent := false
 	for _, to := range emailCfg.Alert.Recipients {
@@ -740,11 +753,24 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertEmail(ctx context.Context, runt
 		}
 		anySent = true
 	}
-
-	if anySent {
-		_ = s.opsRepo.UpdateAlertEventEmailSent(context.Background(), event.ID, true)
-	}
 	return anySent
+}
+
+func (s *OpsAlertEvaluatorService) sendOpsAlertFeishu(ctx context.Context, emailCfg *OpsEmailNotificationConfig, rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if s == nil || emailCfg == nil || rule == nil || event == nil || !emailCfg.Feishu.Enabled {
+		return false
+	}
+	if strings.TrimSpace(emailCfg.Feishu.WebhookURL) == "" {
+		return false
+	}
+	if !s.emailLimiter.Allow(time.Now().UTC()) {
+		return false
+	}
+	if err := sendOpsAlertFeishuWebhook(ctx, emailCfg.Feishu, rule, event); err != nil {
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] send feishu alert failed (event=%d): %v", event.ID, err)
+		return false
+	}
+	return true
 }
 
 func opsAlertEmailVariables(rule *OpsAlertRule, event *OpsAlertEvent) map[string]string {

--- a/backend/internal/service/ops_feishu_notifier.go
+++ b/backend/internal/service/ops_feishu_notifier.go
@@ -1,0 +1,126 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const opsFeishuWebhookTimeout = 5 * time.Second
+
+type opsFeishuWebhookPayload struct {
+	Timestamp string                  `json:"timestamp,omitempty"`
+	Sign      string                  `json:"sign,omitempty"`
+	MsgType   string                  `json:"msg_type"`
+	Content   opsFeishuWebhookContent `json:"content"`
+}
+
+type opsFeishuWebhookContent struct {
+	Text string `json:"text"`
+}
+
+type opsFeishuWebhookResponse struct {
+	Code          *int   `json:"code,omitempty"`
+	Msg           string `json:"msg,omitempty"`
+	StatusCode    *int   `json:"StatusCode,omitempty"`
+	StatusMessage string `json:"StatusMessage,omitempty"`
+}
+
+func sendOpsAlertFeishuWebhook(ctx context.Context, cfg OpsFeishuAlertConfig, rule *OpsAlertRule, event *OpsAlertEvent) error {
+	webhookURL := strings.TrimSpace(cfg.WebhookURL)
+	if webhookURL == "" {
+		return fmt.Errorf("feishu webhook URL is empty")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	payload := opsFeishuWebhookPayload{
+		MsgType: "text",
+		Content: opsFeishuWebhookContent{
+			Text: buildOpsAlertFeishuText(rule, event),
+		},
+	}
+
+	if secret := strings.TrimSpace(cfg.Secret); secret != "" {
+		ts := fmt.Sprintf("%d", time.Now().Unix())
+		payload.Timestamp = ts
+		payload.Sign = signFeishuWebhook(ts, secret)
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, opsFeishuWebhookTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("feishu webhook returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var parsed opsFeishuWebhookResponse
+	if len(respBody) > 0 && json.Unmarshal(respBody, &parsed) == nil {
+		if parsed.Code != nil && *parsed.Code != 0 {
+			return fmt.Errorf("feishu webhook returned code %d: %s", *parsed.Code, parsed.Msg)
+		}
+		if parsed.StatusCode != nil && *parsed.StatusCode != 0 {
+			return fmt.Errorf("feishu webhook returned status code %d: %s", *parsed.StatusCode, parsed.StatusMessage)
+		}
+	}
+	return nil
+}
+
+func signFeishuWebhook(timestamp, secret string) string {
+	stringToSign := timestamp + "\n" + secret
+	mac := hmac.New(sha256.New, []byte(stringToSign))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func buildOpsAlertFeishuText(rule *OpsAlertRule, event *OpsAlertEvent) string {
+	var b strings.Builder
+	b.WriteString("[Sub2API Ops Alert]\n")
+	if rule != nil {
+		b.WriteString(fmt.Sprintf("Rule: %s\n", strings.TrimSpace(rule.Name)))
+		b.WriteString(fmt.Sprintf("Severity: %s\n", strings.TrimSpace(rule.Severity)))
+		b.WriteString(fmt.Sprintf("Metric: %s %s %.2f\n", strings.TrimSpace(rule.MetricType), strings.TrimSpace(rule.Operator), rule.Threshold))
+	}
+	if event != nil {
+		b.WriteString(fmt.Sprintf("Status: %s\n", strings.TrimSpace(event.Status)))
+		if event.MetricValue != nil {
+			b.WriteString(fmt.Sprintf("Value: %.2f\n", *event.MetricValue))
+		}
+		if strings.TrimSpace(event.Title) != "" {
+			b.WriteString(fmt.Sprintf("Title: %s\n", strings.TrimSpace(event.Title)))
+		}
+		if strings.TrimSpace(event.Description) != "" {
+			b.WriteString(fmt.Sprintf("Description: %s\n", strings.TrimSpace(event.Description)))
+		}
+		if !event.FiredAt.IsZero() {
+			b.WriteString(fmt.Sprintf("Fired at: %s\n", event.FiredAt.Format(time.RFC3339)))
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/backend/internal/service/ops_feishu_notifier_test.go
+++ b/backend/internal/service/ops_feishu_notifier_test.go
@@ -1,0 +1,73 @@
+//go:build unit
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignFeishuWebhook(t *testing.T) {
+	t.Parallel()
+
+	got := signFeishuWebhook("1700000000", "secret")
+
+	require.NotEmpty(t, got)
+	require.NotContains(t, got, "secret")
+}
+
+func TestSendOpsAlertFeishuWebhook(t *testing.T) {
+	t.Parallel()
+
+	var received opsFeishuWebhookPayload
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&received))
+		_, _ = w.Write([]byte(`{"code":0,"msg":"success"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	value := 12.5
+	err := sendOpsAlertFeishuWebhook(t.Context(), OpsFeishuAlertConfig{
+		WebhookURL: server.URL,
+		Secret:     "secret",
+	}, &OpsAlertRule{
+		Name:       "High upstream error rate",
+		Severity:   "warning",
+		MetricType: "upstream_error_rate",
+		Operator:   ">",
+		Threshold:  5,
+	}, &OpsAlertEvent{
+		Status:      OpsAlertStatusFiring,
+		Title:       "Alert firing",
+		Description: "upstream_error_rate > 5",
+		MetricValue: &value,
+		FiredAt:     time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "text", received.MsgType)
+	require.NotEmpty(t, received.Timestamp)
+	require.NotEmpty(t, received.Sign)
+	require.Contains(t, received.Content.Text, "High upstream error rate")
+	require.Contains(t, received.Content.Text, "upstream_error_rate")
+}
+
+func TestSendOpsAlertFeishuWebhookRejectsNonZeroCode(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":19021,"msg":"bad sign"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	err := sendOpsAlertFeishuWebhook(t.Context(), OpsFeishuAlertConfig{WebhookURL: server.URL}, &OpsAlertRule{}, &OpsAlertEvent{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "19021")
+}

--- a/backend/internal/service/ops_settings.go
+++ b/backend/internal/service/ops_settings.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"net/url"
 	"strings"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 )
 
 const (
@@ -75,6 +77,12 @@ func (s *OpsService) UpdateEmailNotificationConfig(ctx context.Context, req *Ops
 		cfg.Alert.IncludeResolvedAlerts = req.Alert.IncludeResolvedAlerts
 	}
 
+	if req.Feishu != nil {
+		cfg.Feishu.Enabled = req.Feishu.Enabled
+		cfg.Feishu.WebhookURL = strings.TrimSpace(req.Feishu.WebhookURL)
+		cfg.Feishu.Secret = strings.TrimSpace(req.Feishu.Secret)
+	}
+
 	if req.Report != nil {
 		cfg.Report.Enabled = req.Report.Enabled
 		if req.Report.Recipients != nil {
@@ -117,6 +125,11 @@ func defaultOpsEmailNotificationConfig() *OpsEmailNotificationConfig {
 			BatchingWindowSeconds: 0,
 			IncludeResolvedAlerts: false,
 		},
+		Feishu: OpsFeishuAlertConfig{
+			Enabled:    false,
+			WebhookURL: "",
+			Secret:     "",
+		},
 		Report: OpsEmailReportConfig{
 			Enabled:                         false,
 			Recipients:                      []string{},
@@ -146,6 +159,8 @@ func normalizeOpsEmailNotificationConfig(cfg *OpsEmailNotificationConfig) {
 	}
 
 	cfg.Alert.MinSeverity = strings.TrimSpace(cfg.Alert.MinSeverity)
+	cfg.Feishu.WebhookURL = strings.TrimSpace(cfg.Feishu.WebhookURL)
+	cfg.Feishu.Secret = strings.TrimSpace(cfg.Feishu.Secret)
 	cfg.Report.DailySummarySchedule = strings.TrimSpace(cfg.Report.DailySummarySchedule)
 	cfg.Report.WeeklySummarySchedule = strings.TrimSpace(cfg.Report.WeeklySummarySchedule)
 	cfg.Report.ErrorDigestSchedule = strings.TrimSpace(cfg.Report.ErrorDigestSchedule)
@@ -181,6 +196,18 @@ func validateOpsEmailNotificationConfig(cfg *OpsEmailNotificationConfig) error {
 	case "", "critical", "warning", "info":
 	default:
 		return errors.New("alert.min_severity must be one of: critical, warning, info, or empty")
+	}
+	if cfg.Feishu.Enabled {
+		if strings.TrimSpace(cfg.Feishu.WebhookURL) == "" {
+			return errors.New("feishu.webhook_url is required when feishu alerts are enabled")
+		}
+		parsed, err := url.Parse(strings.TrimSpace(cfg.Feishu.WebhookURL))
+		if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+			return errors.New("feishu.webhook_url must be a valid URL")
+		}
+		if parsed.Scheme != "https" && parsed.Scheme != "http" {
+			return errors.New("feishu.webhook_url must use http or https")
+		}
 	}
 
 	if cfg.Report.ErrorDigestMinCount < 0 {

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -4,6 +4,7 @@ package service
 
 type OpsEmailNotificationConfig struct {
 	Alert  OpsEmailAlertConfig  `json:"alert"`
+	Feishu OpsFeishuAlertConfig `json:"feishu"`
 	Report OpsEmailReportConfig `json:"report"`
 }
 
@@ -14,6 +15,12 @@ type OpsEmailAlertConfig struct {
 	RateLimitPerHour      int      `json:"rate_limit_per_hour"`
 	BatchingWindowSeconds int      `json:"batching_window_seconds"`
 	IncludeResolvedAlerts bool     `json:"include_resolved_alerts"`
+}
+
+type OpsFeishuAlertConfig struct {
+	Enabled    bool   `json:"enabled"`
+	WebhookURL string `json:"webhook_url"`
+	Secret     string `json:"secret,omitempty"`
 }
 
 type OpsEmailReportConfig struct {
@@ -35,6 +42,7 @@ type OpsEmailReportConfig struct {
 // frontend can still send the full config shape.
 type OpsEmailNotificationConfigUpdateRequest struct {
 	Alert  *OpsEmailAlertConfig  `json:"alert"`
+	Feishu *OpsFeishuAlertConfig `json:"feishu"`
 	Report *OpsEmailReportConfig `json:"report"`
 }
 

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -734,6 +734,11 @@ export interface EmailNotificationConfig {
     batching_window_seconds: number
     include_resolved_alerts: boolean
   }
+  feishu: {
+    enabled: boolean
+    webhook_url: string
+    secret?: string
+  }
   report: {
     enabled: boolean
     recipients: string[]

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -5257,7 +5257,7 @@ export default {
       },
       alertEvents: {
         title: 'Alert Events',
-        description: 'Recent alert firing/resolution records (email-only)',
+        description: 'Recent alert firing/resolution records (email/Feishu notifications)',
         loading: 'Loading...',
         empty: 'No alert events',
         loadFailed: 'Failed to load alert events',
@@ -5305,7 +5305,7 @@ export default {
       },
       alertRules: {
         title: 'Alert Rules',
-        description: 'Create and manage threshold-based system alerts (email-only)',
+        description: 'Create and manage threshold-based system alerts (email/Feishu notifications)',
         loading: 'Loading...',
         empty: 'No alert rules',
         loadFailed: 'Failed to load alert rules',
@@ -5515,6 +5515,12 @@ export default {
         emailPlaceholder: 'Enter email address',
         recipientsHint: 'If empty, the system will use the first admin email as default recipient',
         minSeverity: 'Minimum Severity',
+        enableFeishu: 'Enable Feishu notifications',
+        feishuHint: 'Send ops alerts through a Feishu/Lark custom bot.',
+        feishuWebhookUrl: 'Feishu bot webhook URL',
+        feishuSecret: 'Feishu signing secret',
+        feishuSecretPlaceholder: 'Optional: signing secret from bot security settings',
+        feishuSecretHint: 'Fill this when the Feishu bot has signature verification enabled; otherwise leave it empty.',
         reportConfig: 'Report Configuration',
         enableReport: 'Enable Reports',
         reportRecipients: 'Report Recipient Emails',
@@ -5578,7 +5584,9 @@ export default {
           ttftP99MaxRange: 'TTFT P99 maximum must be a number ≥ 0',
           requestErrorRateMaxRange: 'Request error rate maximum must be between 0 and 100',
           upstreamErrorRateMaxRange: 'Upstream error rate maximum must be between 0 and 100',
-          openaiQuotaAutoPauseRange: 'OpenAI quota auto-pause threshold must be between 0 and 100'
+          openaiQuotaAutoPauseRange: 'OpenAI quota auto-pause threshold must be between 0 and 100',
+          feishuWebhookRequired: 'Feishu webhook URL is required when Feishu notifications are enabled',
+          feishuWebhookInvalid: 'Feishu webhook URL is invalid'
         }
       },
       concurrency: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -5415,7 +5415,7 @@ export default {
       },
       alertEvents: {
         title: '告警事件',
-        description: '最近的告警触发/恢复记录（仅邮件通知）',
+        description: '最近的告警触发/恢复记录（支持邮件/飞书通知）',
         loading: '加载中...',
         empty: '暂无告警事件',
         loadFailed: '加载告警事件失败',
@@ -5463,7 +5463,7 @@ export default {
       },
       alertRules: {
         title: '告警规则',
-        description: '创建与管理系统阈值告警（仅邮件通知）',
+        description: '创建与管理系统阈值告警（支持邮件/飞书通知）',
         loading: '加载中...',
         empty: '暂无告警规则',
         loadFailed: '加载告警规则失败',
@@ -5673,6 +5673,12 @@ export default {
         emailPlaceholder: '输入邮箱地址',
         recipientsHint: '若为空，系统将使用第一个管理员邮箱作为默认收件人',
         minSeverity: '最低级别',
+        enableFeishu: '开启飞书通知',
+        feishuHint: '通过飞书/Lark 自定义机器人发送运维告警。',
+        feishuWebhookUrl: '飞书机器人 Webhook URL',
+        feishuSecret: '飞书签名密钥',
+        feishuSecretPlaceholder: '可选：机器人安全设置中的签名密钥',
+        feishuSecretHint: '如果飞书机器人开启了签名校验，请填写 Secret；未开启则留空。',
         reportConfig: '评估报告配置',
         enableReport: '开启评估报告',
         reportRecipients: '评估报告接收邮箱',
@@ -5737,7 +5743,9 @@ export default {
           ttftP99MaxRange: 'TTFT P99最大值必须大于等于0',
           requestErrorRateMaxRange: '请求错误率最大值必须在0-100之间',
           upstreamErrorRateMaxRange: '上游错误率最大值必须在0-100之间',
-          openaiQuotaAutoPauseRange: 'OpenAI 配额自动暂停阈值必须在 0-100 之间'
+          openaiQuotaAutoPauseRange: 'OpenAI 配额自动暂停阈值必须在 0-100 之间',
+          feishuWebhookRequired: '开启飞书通知时必须填写 Webhook URL',
+          feishuWebhookInvalid: '飞书 Webhook URL 格式不合法'
         }
       },
       concurrency: {

--- a/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
+++ b/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
@@ -49,6 +49,9 @@ async function loadAllSettings() {
     ])
     runtimeSettings.value = runtime
     emailConfig.value = email
+    if (emailConfig.value && !emailConfig.value.feishu) {
+      emailConfig.value.feishu = { enabled: false, webhook_url: '', secret: '' }
+    }
     advancedSettings.value = advanced
     // 兼容旧 payload：后端未返回该字段时补默认值，保证表单可绑定
     if (advancedSettings.value && !advancedSettings.value.openai_account_quota_auto_pause) {
@@ -158,6 +161,21 @@ const validation = computed(() => {
   }
 
   // 邮件配置: 启用但无收件人时不阻断保存, 保存时会自动禁用
+  if (emailConfig.value?.feishu?.enabled) {
+    const webhookURL = emailConfig.value.feishu.webhook_url?.trim() ?? ''
+    if (!webhookURL) {
+      errors.push(t('admin.ops.settings.validation.feishuWebhookRequired'))
+    } else {
+      try {
+        const parsed = new URL(webhookURL)
+        if (!['http:', 'https:'].includes(parsed.protocol)) {
+          errors.push(t('admin.ops.settings.validation.feishuWebhookInvalid'))
+        }
+      } catch {
+        errors.push(t('admin.ops.settings.validation.feishuWebhookInvalid'))
+      }
+    }
+  }
 
   // 验证高级设置
   if (advancedSettings.value) {
@@ -206,7 +224,8 @@ async function saveAllSettings() {
   try {
     // 无收件人时自动禁用邮件通知
     if (emailConfig.value) {
-      if (emailConfig.value.alert.enabled && emailConfig.value.alert.recipients.length === 0) {
+      const feishuReady = emailConfig.value.feishu?.enabled && !!emailConfig.value.feishu.webhook_url?.trim()
+      if (emailConfig.value.alert.enabled && emailConfig.value.alert.recipients.length === 0 && !feishuReady) {
         emailConfig.value.alert.enabled = false
       }
       if (emailConfig.value.report.enabled && emailConfig.value.report.recipients.length === 0) {
@@ -306,6 +325,41 @@ async function saveAllSettings() {
           <div v-if="emailConfig.alert.enabled">
             <label class="input-label">{{ t('admin.ops.settings.minSeverity') }}</label>
             <Select v-model="emailConfig.alert.min_severity" :options="severityOptions" />
+          </div>
+
+          <div v-if="emailConfig.alert.enabled" class="rounded-xl border border-gray-200 bg-white p-3 dark:border-dark-600 dark:bg-dark-800">
+            <div class="flex items-center justify-between">
+              <div>
+                <label class="font-medium text-gray-900 dark:text-white">{{ t('admin.ops.settings.enableFeishu') }}</label>
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ t('admin.ops.settings.feishuHint') }}</p>
+              </div>
+              <Toggle v-model="emailConfig.feishu.enabled" />
+            </div>
+
+            <div v-if="emailConfig.feishu.enabled" class="mt-3 space-y-3">
+              <div>
+                <label class="input-label">{{ t('admin.ops.settings.feishuWebhookUrl') }}</label>
+                <input
+                  v-model.trim="emailConfig.feishu.webhook_url"
+                  type="url"
+                  class="input"
+                  placeholder="https://open.feishu.cn/open-apis/bot/v2/hook/..."
+                />
+              </div>
+              <div>
+                <label class="input-label">{{ t('admin.ops.settings.feishuSecret') }}</label>
+                <input
+                  v-model.trim="emailConfig.feishu.secret"
+                  type="password"
+                  class="input"
+                  autocomplete="new-password"
+                  :placeholder="t('admin.ops.settings.feishuSecretPlaceholder')"
+                />
+                <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('admin.ops.settings.feishuSecretHint') }}
+                </p>
+              </div>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Add Feishu/Lark custom bot support for Ops alert notifications.
- Extend the DB-backed Ops notification config with `feishu.enabled`, `feishu.webhook_url`, and optional `feishu.secret`.
- Send signed Feishu text messages when Ops alert rules fire and Feishu is enabled.
- Add Feishu settings to the Ops Monitoring settings dialog and update i18n copy away from email-only wording.
- Keep existing email notification behavior and API compatibility.

## Testing

- `go test -tags unit ./internal/service -run 'Test(SendOpsAlertFeishuWebhook|SignFeishuWebhook)'`
- `go test -tags unit ./internal/service`

## Notes

- Frontend `pnpm typecheck` was not run because `pnpm install --frozen-lockfile` fails locally with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` for the existing overrides/lockfile configuration. I avoided running `--no-frozen-lockfile` to prevent unintended lockfile churn.
