### PR TITLE
feat(admin): 用户角色管理 + 用户 Token 排行

### DIFF
--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -675,6 +675,9 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 		}
 	}
 
+	// sort_by 由 repo 层 allowlist 校验;非法值静默回退默认排序(actual_cost)。
+	dim.SortBy = strings.TrimSpace(c.Query("sort_by"))
+
 	limit := 50
 	if v := c.Query("limit"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 200 {

--- a/backend/internal/handler/admin/dashboard_handler_user_breakdown_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_user_breakdown_test.go
@@ -59,7 +59,21 @@ func TestGetUserBreakdown_GroupIDFilter(t *testing.T) {
 	require.Equal(t, int64(42), repo.capturedDim.GroupID)
 	require.Empty(t, repo.capturedDim.Model)
 	require.Empty(t, repo.capturedDim.Endpoint)
-	require.Equal(t, 50, repo.capturedLimit) // default limit
+	require.Equal(t, 50, repo.capturedLimit)  // default limit
+	require.Empty(t, repo.capturedDim.SortBy) // no sort_by => empty (repo falls back to default)
+}
+
+func TestGetUserBreakdown_SortBy(t *testing.T) {
+	repo := &userBreakdownRepoCapture{}
+	router := newUserBreakdownRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/admin/dashboard/user-breakdown?start_date=2026-03-01&end_date=2026-03-16&sort_by=total_tokens", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Equal(t, "total_tokens", repo.capturedDim.SortBy)
 }
 
 func TestGetUserBreakdown_ModelFilter(t *testing.T) {

--- a/backend/internal/handler/admin/user_handler.go
+++ b/backend/internal/handler/admin/user_handler.go
@@ -53,6 +53,7 @@ type CreateUserRequest struct {
 	Password      string   `json:"password" binding:"required,min=6"`
 	Username      string   `json:"username"`
 	Notes         string   `json:"notes"`
+	Role          string   `json:"role" binding:"omitempty,oneof=admin user"`
 	Balance       *float64 `json:"balance"`
 	Concurrency   int      `json:"concurrency"`
 	RPMLimit      int      `json:"rpm_limit"`
@@ -66,6 +67,7 @@ type UpdateUserRequest struct {
 	Password      string   `json:"password" binding:"omitempty,min=6"`
 	Username      *string  `json:"username"`
 	Notes         *string  `json:"notes"`
+	Role          string   `json:"role" binding:"omitempty,oneof=admin user"`
 	Balance       *float64 `json:"balance"`
 	Concurrency   *int     `json:"concurrency"`
 	RPMLimit      *int     `json:"rpm_limit"`
@@ -269,6 +271,7 @@ func (h *UserHandler) Create(c *gin.Context) {
 		Password:      req.Password,
 		Username:      req.Username,
 		Notes:         req.Notes,
+		Role:          req.Role,
 		Balance:       req.Balance,
 		Concurrency:   req.Concurrency,
 		RPMLimit:      req.RPMLimit,
@@ -297,12 +300,20 @@ func (h *UserHandler) Update(c *gin.Context) {
 		return
 	}
 
+	// 防锁死保护：管理员不能把自己降级为普通用户(单管理员场景下会失去后台访问权)。
+	// 与既有"不能禁用/删除 admin"保护一致。降级其他管理员仍然允许。
+	if req.Role == service.RoleUser && userID == getAdminIDFromContext(c) {
+		response.BadRequest(c, "cannot demote yourself from admin")
+		return
+	}
+
 	// 使用指针类型直接传递，nil 表示未提供该字段
 	user, err := h.adminService.UpdateUser(c.Request.Context(), userID, &service.UpdateUserInput{
 		Email:         req.Email,
 		Password:      req.Password,
 		Username:      req.Username,
 		Notes:         req.Notes,
+		Role:          req.Role,
 		Balance:       req.Balance,
 		Concurrency:   req.Concurrency,
 		RPMLimit:      req.RPMLimit,

--- a/backend/internal/pkg/usagestats/usage_log_types.go
+++ b/backend/internal/pkg/usagestats/usage_log_types.go
@@ -164,13 +164,16 @@ type UserSpendingRankingResponse struct {
 
 // UserBreakdownItem represents per-user usage breakdown within a dimension (group, model, endpoint).
 type UserBreakdownItem struct {
-	UserID      int64   `json:"user_id"`
-	Email       string  `json:"email"`
-	Requests    int64   `json:"requests"`
-	TotalTokens int64   `json:"total_tokens"`
-	Cost        float64 `json:"cost"`         // 标准计费
-	ActualCost  float64 `json:"actual_cost"`  // 实际扣除
-	AccountCost float64 `json:"account_cost"` // 账号成本
+	UserID       int64   `json:"user_id"`
+	Email        string  `json:"email"`
+	Requests     int64   `json:"requests"`
+	InputTokens  int64   `json:"input_tokens"`  // 输入 token 累计
+	OutputTokens int64   `json:"output_tokens"` // 输出 token 累计
+	CacheTokens  int64   `json:"cache_tokens"`  // 缓存创建 + 读取 token 累计
+	TotalTokens  int64   `json:"total_tokens"`  // 输入+输出+缓存 token 累计
+	Cost         float64 `json:"cost"`          // 标准计费
+	ActualCost   float64 `json:"actual_cost"`   // 实际扣除
+	AccountCost  float64 `json:"account_cost"`  // 账号成本
 }
 
 // UserBreakdownDimension specifies the dimension to filter for user breakdown.
@@ -187,6 +190,8 @@ type UserBreakdownDimension struct {
 	RequestType *int16 // filter by request_type (non-nil to enable)
 	Stream      *bool  // filter by stream flag (non-nil to enable)
 	BillingType *int8  // filter by billing_type (non-nil to enable)
+	// SortBy 指定排序列(空 = 默认按 actual_cost)。合法值由 repo 层 allowlist 校验。
+	SortBy string
 }
 
 // APIKeyUsageTrendPoint represents API key usage trend data point

--- a/backend/internal/repository/usage_log_repo_trend.go
+++ b/backend/internal/repository/usage_log_repo_trend.go
@@ -603,6 +603,9 @@ func (r *usageLogRepository) GetUserBreakdownStats(ctx context.Context, startTim
 			COALESCE(ul.user_id, 0) as user_id,
 			COALESCE(u.email, '') as email,
 			COUNT(*) as requests,
+			COALESCE(SUM(ul.input_tokens), 0) as input_tokens,
+			COALESCE(SUM(ul.output_tokens), 0) as output_tokens,
+			COALESCE(SUM(ul.cache_creation_tokens + ul.cache_read_tokens), 0) as cache_tokens,
 			COALESCE(SUM(ul.input_tokens + ul.output_tokens + ul.cache_creation_tokens + ul.cache_read_tokens), 0) as total_tokens,
 			COALESCE(SUM(ul.total_cost), 0) as cost,
 			COALESCE(SUM(ul.actual_cost), 0) as actual_cost,
@@ -651,7 +654,13 @@ func (r *usageLogRepository) GetUserBreakdownStats(ctx context.Context, startTim
 		args = append(args, *dim.BillingType)
 	}
 
-	query += " GROUP BY ul.user_id, u.email ORDER BY actual_cost DESC"
+	// ORDER BY 列来自固定 allowlist(非用户原样字符串),避免 SQL 注入。
+	orderBy := "actual_cost"
+	switch dim.SortBy {
+	case "total_tokens", "input_tokens", "output_tokens", "cache_tokens", "requests", "cost", "actual_cost":
+		orderBy = dim.SortBy
+	}
+	query += " GROUP BY ul.user_id, u.email ORDER BY " + orderBy + " DESC"
 	if limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", limit)
 	}
@@ -674,6 +683,9 @@ func (r *usageLogRepository) GetUserBreakdownStats(ctx context.Context, startTim
 			&row.UserID,
 			&row.Email,
 			&row.Requests,
+			&row.InputTokens,
+			&row.OutputTokens,
+			&row.CacheTokens,
 			&row.TotalTokens,
 			&row.Cost,
 			&row.ActualCost,

--- a/backend/internal/service/admin_service.go
+++ b/backend/internal/service/admin_service.go
@@ -125,6 +125,7 @@ type CreateUserInput struct {
 	Password      string
 	Username      string
 	Notes         string
+	Role          string // 空字符串表示使用默认角色(user);合法值 admin/user
 	Balance       *float64
 	Concurrency   int
 	RPMLimit      int
@@ -136,6 +137,7 @@ type UpdateUserInput struct {
 	Password      string
 	Username      *string
 	Notes         *string
+	Role          string   // 空字符串表示"未提供"(不修改);合法值 admin/user
 	Balance       *float64 // 使用指针区分"未提供"和"设置为0"
 	Concurrency   *int     // 使用指针区分"未提供"和"设置为0"
 	RPMLimit      *int     // 使用指针区分"未提供"和"设置为0"

--- a/backend/internal/service/admin_service_role_test.go
+++ b/backend/internal/service/admin_service_role_test.go
@@ -1,0 +1,85 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminService_CreateUser_WithAdminRole(t *testing.T) {
+	repo := &userRepoStub{nextID: 30}
+	svc := &adminServiceImpl{userRepo: repo}
+
+	user, err := svc.CreateUser(context.Background(), &CreateUserInput{
+		Email:    "admin@test.com",
+		Password: "strong-pass",
+		Role:     RoleAdmin,
+	})
+	require.NoError(t, err)
+	require.Equal(t, RoleAdmin, user.Role)
+}
+
+func TestAdminService_CreateUser_DefaultsToUserRole(t *testing.T) {
+	repo := &userRepoStub{nextID: 31}
+	svc := &adminServiceImpl{userRepo: repo}
+
+	user, err := svc.CreateUser(context.Background(), &CreateUserInput{
+		Email:    "plain@test.com",
+		Password: "strong-pass",
+	})
+	require.NoError(t, err)
+	require.Equal(t, RoleUser, user.Role)
+}
+
+func TestAdminService_CreateUser_InvalidRoleRejected(t *testing.T) {
+	repo := &userRepoStub{nextID: 32}
+	svc := &adminServiceImpl{userRepo: repo}
+
+	_, err := svc.CreateUser(context.Background(), &CreateUserInput{
+		Email:    "bad@test.com",
+		Password: "strong-pass",
+		Role:     "superuser",
+	})
+	require.Error(t, err)
+	require.Empty(t, repo.created, "非法角色不应写入用户")
+}
+
+func TestAdminService_UpdateUser_PromoteToAdmin(t *testing.T) {
+	base := &userRepoStub{user: &User{ID: 42, Email: "u@example.com", Role: RoleUser}}
+	repo := &rpmUserRepoStub{userRepoStub: base}
+	invalidator := &authCacheInvalidatorStub{}
+	svc := &adminServiceImpl{
+		userRepo:             repo,
+		redeemCodeRepo:       &redeemRepoStub{},
+		authCacheInvalidator: invalidator,
+	}
+
+	updated, err := svc.UpdateUser(context.Background(), 42, &UpdateUserInput{Role: RoleAdmin})
+	require.NoError(t, err)
+	require.Equal(t, RoleAdmin, updated.Role)
+	require.Equal(t, []int64{42}, invalidator.userIDs, "角色变更应失效认证缓存")
+}
+
+func TestAdminService_UpdateUser_RoleOmittedKeepsExisting(t *testing.T) {
+	base := &userRepoStub{user: &User{ID: 42, Email: "u@example.com", Role: RoleAdmin}}
+	repo := &rpmUserRepoStub{userRepoStub: base}
+	svc := &adminServiceImpl{userRepo: repo, redeemCodeRepo: &redeemRepoStub{}}
+
+	newName := "renamed"
+	updated, err := svc.UpdateUser(context.Background(), 42, &UpdateUserInput{Username: &newName})
+	require.NoError(t, err)
+	require.Equal(t, RoleAdmin, updated.Role, "未提供 role 时不应改变现有角色")
+}
+
+func TestAdminService_UpdateUser_InvalidRoleRejected(t *testing.T) {
+	base := &userRepoStub{user: &User{ID: 42, Email: "u@example.com", Role: RoleUser}}
+	repo := &rpmUserRepoStub{userRepoStub: base}
+	svc := &adminServiceImpl{userRepo: repo, redeemCodeRepo: &redeemRepoStub{}}
+
+	_, err := svc.UpdateUser(context.Background(), 42, &UpdateUserInput{Role: "root"})
+	require.Error(t, err)
+	require.Nil(t, repo.lastUpdated, "非法角色不应触发持久化")
+}

--- a/backend/internal/service/admin_user.go
+++ b/backend/internal/service/admin_user.go
@@ -105,6 +105,18 @@ func (s *adminServiceImpl) GetUserIncludeDeleted(ctx context.Context, id int64) 
 	return s.userRepo.GetByIDIncludeDeleted(ctx, id)
 }
 
+// normalizeUserRole 校验并归一化角色输入。
+// 空字符串返回 fallback(未提供时的默认角色);非法值返回错误。
+func normalizeUserRole(role, fallback string) (string, error) {
+	if role == "" {
+		return fallback, nil
+	}
+	if role != RoleAdmin && role != RoleUser {
+		return "", fmt.Errorf("invalid role: %q (must be %s or %s)", role, RoleAdmin, RoleUser)
+	}
+	return role, nil
+}
+
 func (s *adminServiceImpl) CreateUser(ctx context.Context, input *CreateUserInput) (*User, error) {
 	balance := 0.0
 	if input.Balance != nil {
@@ -113,11 +125,17 @@ func (s *adminServiceImpl) CreateUser(ctx context.Context, input *CreateUserInpu
 		balance = s.settingService.GetDefaultBalance(ctx)
 	}
 
+	// 角色可由管理员在创建时指定(admin/user);未提供时默认 user。
+	role, err := normalizeUserRole(input.Role, RoleUser)
+	if err != nil {
+		return nil, err
+	}
+
 	user := &User{
 		Email:         input.Email,
 		Username:      input.Username,
 		Notes:         input.Notes,
-		Role:          RoleUser, // Always create as regular user, never admin
+		Role:          role,
 		Balance:       balance,
 		Concurrency:   input.Concurrency,
 		RPMLimit:      input.RPMLimit,
@@ -195,6 +213,15 @@ func (s *adminServiceImpl) UpdateUser(ctx context.Context, id int64, input *Upda
 
 	if input.Status != "" {
 		user.Status = input.Status
+	}
+
+	// 角色变更(admin/user);空字符串表示不修改。
+	if input.Role != "" {
+		role, err := normalizeUserRole(input.Role, user.Role)
+		if err != nil {
+			return nil, err
+		}
+		user.Role = role
 	}
 
 	if input.Concurrency != nil {

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -167,6 +167,8 @@ export interface UserBreakdownParams {
   endpoint?: string
   endpoint_type?: 'inbound' | 'upstream' | 'path'
   limit?: number
+  // Sort column for the ranking (allowlisted server-side; falls back to actual_cost)
+  sort_by?: 'total_tokens' | 'input_tokens' | 'output_tokens' | 'cache_tokens' | 'requests' | 'cost' | 'actual_cost'
   // Additional filter conditions
   user_id?: number
   api_key_id?: number

--- a/frontend/src/api/admin/users.ts
+++ b/frontend/src/api/admin/users.ts
@@ -121,6 +121,7 @@ export async function create(userData: {
   password: string
   username?: string
   notes?: string
+  role?: 'admin' | 'user'
   balance?: number
   concurrency?: number
   rpm_limit?: number

--- a/frontend/src/components/admin/usage/UserTokenRanking.vue
+++ b/frontend/src/components/admin/usage/UserTokenRanking.vue
@@ -1,0 +1,180 @@
+<template>
+  <div class="card p-4">
+    <!-- Header -->
+    <div class="mb-3 flex flex-wrap items-center gap-3">
+      <h3 class="text-sm font-semibold text-gray-800 dark:text-gray-100">
+        {{ t('admin.usage.tokenRanking.title') }}
+      </h3>
+      <span class="text-xs text-gray-400">{{ t('admin.usage.tokenRanking.subtitle') }}</span>
+      <div class="ml-auto flex flex-wrap items-center gap-2">
+        <input
+          v-model="search"
+          type="text"
+          class="input h-8 w-44 text-sm"
+          :placeholder="t('admin.usage.tokenRanking.searchPlaceholder')"
+        />
+        <div class="w-28">
+          <Select v-model="limit" :options="limitOptions" @change="load" />
+        </div>
+        <button
+          type="button"
+          class="btn btn-secondary h-8 px-2"
+          :title="t('common.refresh')"
+          @click="load"
+        >
+          <Icon name="refresh" size="sm" :class="{ 'animate-spin': loading }" />
+        </button>
+      </div>
+    </div>
+
+    <!-- Table -->
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-100 text-xs text-gray-500 dark:border-gray-700 dark:text-gray-400">
+            <th class="w-10 py-2 pr-2 text-left font-medium">#</th>
+            <th class="py-2 pr-2 text-left font-medium">{{ t('admin.usage.tokenRanking.columns.user') }}</th>
+            <th
+              v-for="col in sortableColumns"
+              :key="col.key"
+              class="cursor-pointer select-none py-2 pl-2 text-right font-medium hover:text-primary-500"
+              :class="{ 'text-primary-600 dark:text-primary-400': sortBy === col.key }"
+              @click="setSort(col.key)"
+            >
+              {{ t(col.label) }}
+              <span v-if="sortBy === col.key" aria-hidden="true">↓</span>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-if="loading">
+            <td :colspan="sortableColumns.length + 2" class="py-8 text-center">
+              <LoadingSpinner />
+            </td>
+          </tr>
+          <tr v-else-if="displayItems.length === 0">
+            <td :colspan="sortableColumns.length + 2" class="py-8 text-center text-sm text-gray-400">
+              {{ t('admin.dashboard.noDataAvailable') }}
+            </td>
+          </tr>
+          <tr
+            v-for="(item, index) in displayItems"
+            v-else
+            :key="item.user_id"
+            class="cursor-pointer border-b border-gray-50 transition-colors hover:bg-gray-50 dark:border-gray-800 dark:hover:bg-dark-700/40"
+            @click="$emit('select-user', item.user_id, item.email)"
+          >
+            <td class="py-2 pr-2 text-gray-400">{{ index + 1 }}</td>
+            <td class="max-w-[220px] truncate py-2 pr-2 text-gray-700 dark:text-gray-200" :title="item.email">
+              {{ item.email || `User #${item.user_id}` }}
+            </td>
+            <td class="py-2 pl-2 text-right text-gray-500 dark:text-gray-400">{{ item.requests.toLocaleString() }}</td>
+            <td class="py-2 pl-2 text-right text-gray-500 dark:text-gray-400">{{ fmtTokens(item.input_tokens) }}</td>
+            <td class="py-2 pl-2 text-right text-gray-500 dark:text-gray-400">{{ fmtTokens(item.output_tokens) }}</td>
+            <td class="py-2 pl-2 text-right text-gray-500 dark:text-gray-400">{{ fmtTokens(item.cache_tokens) }}</td>
+            <td class="py-2 pl-2 text-right font-medium text-gray-800 dark:text-gray-100">{{ fmtTokens(item.total_tokens) }}</td>
+            <td class="py-2 pl-2 text-right text-green-600 dark:text-green-400">${{ fmtCost(item.actual_cost) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- Footer -->
+    <div v-if="!loading && items.length > 0" class="mt-2 text-right text-xs text-gray-400">
+      {{ t('admin.usage.tokenRanking.userCount', { count: displayItems.length }) }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { getUserBreakdown, type UserBreakdownParams } from '@/api/admin/dashboard'
+import { formatCompactNumber, formatCostFixed } from '@/utils/format'
+import type { UserBreakdownItem } from '@/types'
+import Select from '@/components/common/Select.vue'
+import Icon from '@/components/icons/Icon.vue'
+import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
+
+const props = defineProps<{
+  startDate: string
+  endDate: string
+  filters: Record<string, unknown>
+  model?: string
+}>()
+
+defineEmits<{ (e: 'select-user', userId: number, email: string): void }>()
+
+const { t } = useI18n()
+
+type SortKey = NonNullable<UserBreakdownParams['sort_by']>
+const sortableColumns: { key: SortKey; label: string }[] = [
+  { key: 'requests', label: 'admin.usage.tokenRanking.columns.requests' },
+  { key: 'input_tokens', label: 'admin.usage.tokenRanking.columns.inputTokens' },
+  { key: 'output_tokens', label: 'admin.usage.tokenRanking.columns.outputTokens' },
+  { key: 'cache_tokens', label: 'admin.usage.tokenRanking.columns.cacheTokens' },
+  { key: 'total_tokens', label: 'admin.usage.tokenRanking.columns.totalTokens' },
+  { key: 'actual_cost', label: 'admin.usage.tokenRanking.columns.cost' },
+]
+
+const limitOptions = [
+  { value: 20, label: 'Top 20' },
+  { value: 50, label: 'Top 50' },
+  { value: 100, label: 'Top 100' },
+  { value: 200, label: 'Top 200' },
+]
+
+const items = ref<UserBreakdownItem[]>([])
+const loading = ref(false)
+const sortBy = ref<SortKey>('total_tokens')
+const limit = ref(50)
+const search = ref('')
+let reqSeq = 0
+
+const displayItems = computed(() => {
+  const kw = search.value.trim().toLowerCase()
+  if (!kw) return items.value
+  return items.value.filter((u) => (u.email || `user #${u.user_id}`).toLowerCase().includes(kw))
+})
+
+const fmtTokens = (v: number) => formatCompactNumber(v)
+const fmtCost = (v: number) => formatCostFixed(v, 4)
+
+const setSort = (key: SortKey) => {
+  if (sortBy.value === key) return
+  sortBy.value = key
+  load()
+}
+
+const load = async () => {
+  const seq = ++reqSeq
+  loading.value = true
+  try {
+    const params: UserBreakdownParams = {
+      ...props.filters,
+      start_date: props.startDate,
+      end_date: props.endDate,
+      sort_by: sortBy.value,
+      limit: limit.value,
+    }
+    if (props.model) params.model = props.model
+    const res = await getUserBreakdown(params)
+    if (seq !== reqSeq) return
+    items.value = res.users || []
+  } catch {
+    if (seq !== reqSeq) return
+    items.value = []
+  } finally {
+    if (seq === reqSeq) loading.value = false
+  }
+}
+
+// Reload when the shared filters / date range / model change.
+watch(
+  () => [props.startDate, props.endDate, props.model, JSON.stringify(props.filters)],
+  () => load(),
+  { immediate: true }
+)
+
+defineExpose({ reload: load })
+</script>

--- a/frontend/src/components/admin/user/UserCreateModal.vue
+++ b/frontend/src/components/admin/user/UserCreateModal.vue
@@ -25,6 +25,13 @@
         <label class="input-label">{{ t('admin.users.username') }}</label>
         <input v-model="form.username" type="text" class="input" :placeholder="t('admin.users.enterUsername')" />
       </div>
+      <div>
+        <label class="input-label">{{ t('admin.users.form.roleLabel') }}</label>
+        <select v-model="form.role" class="input">
+          <option value="user">{{ t('admin.users.roles.user') }}</option>
+          <option value="admin">{{ t('admin.users.roles.admin') }}</option>
+        </select>
+      </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label class="input-label">{{ t('admin.users.columns.balance') }}</label>
@@ -69,7 +76,7 @@ import Icon from '@/components/icons/Icon.vue'
 const props = defineProps<{ show: boolean }>()
 const emit = defineEmits(['close', 'success']); const { t } = useI18n()
 
-const form = reactive({ email: '', password: '', username: '', notes: '', balance: '', concurrency: 1, rpm_limit: 0 })
+const form = reactive({ email: '', password: '', username: '', notes: '', role: 'user' as 'user' | 'admin', balance: '', concurrency: 1, rpm_limit: 0 })
 
 const { loading, submit } = useForm({
   form,
@@ -86,7 +93,7 @@ const { loading, submit } = useForm({
   successMsg: t('admin.users.userCreated')
 })
 
-watch(() => props.show, (v) => { if(v) Object.assign(form, { email: '', password: '', username: '', notes: '', balance: '', concurrency: 1, rpm_limit: 0 }) })
+watch(() => props.show, (v) => { if(v) Object.assign(form, { email: '', password: '', username: '', notes: '', role: 'user', balance: '', concurrency: 1, rpm_limit: 0 }) })
 
 const generateRandomPassword = () => {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$%^&*'

--- a/frontend/src/components/admin/user/UserEditModal.vue
+++ b/frontend/src/components/admin/user/UserEditModal.vue
@@ -30,6 +30,13 @@
         <input v-model="form.username" type="text" class="input" />
       </div>
       <div>
+        <label class="input-label">{{ t('admin.users.form.roleLabel') }}</label>
+        <select v-model="form.role" class="input">
+          <option value="user">{{ t('admin.users.roles.user') }}</option>
+          <option value="admin">{{ t('admin.users.roles.admin') }}</option>
+        </select>
+      </div>
+      <div>
         <label class="input-label">{{ t('admin.users.notes') }}</label>
         <textarea v-model="form.notes" rows="3" class="input"></textarea>
       </div>
@@ -78,11 +85,11 @@ const emit = defineEmits(['close', 'success'])
 const { t } = useI18n(); const appStore = useAppStore(); const { copyToClipboard } = useClipboard()
 
 const submitting = ref(false); const passwordCopied = ref(false)
-const form = reactive({ email: '', password: '', username: '', notes: '', concurrency: 1, rpm_limit: 0, customAttributes: {} as UserAttributeValuesMap })
+const form = reactive({ email: '', password: '', username: '', notes: '', role: 'user', concurrency: 1, rpm_limit: 0, customAttributes: {} as UserAttributeValuesMap })
 
 watch(() => props.user, (u) => {
   if (u) {
-    Object.assign(form, { email: u.email, password: '', username: u.username || '', notes: u.notes || '', concurrency: u.concurrency, rpm_limit: u.rpm_limit ?? 0, customAttributes: {} })
+    Object.assign(form, { email: u.email, password: '', username: u.username || '', notes: u.notes || '', role: u.role || 'user', concurrency: u.concurrency, rpm_limit: u.rpm_limit ?? 0, customAttributes: {} })
     passwordCopied.value = false
   }
 }, { immediate: true })
@@ -109,7 +116,7 @@ const handleUpdateUser = async () => {
   }
   submitting.value = true
   try {
-    const data: any = { email: form.email, username: form.username, notes: form.notes, concurrency: form.concurrency, rpm_limit: form.rpm_limit }
+    const data: any = { email: form.email, username: form.username, notes: form.notes, role: form.role, concurrency: form.concurrency, rpm_limit: form.rpm_limit }
     if (form.password.trim()) data.password = form.password.trim()
     await adminAPI.users.update(props.user.id, data)
     if (Object.keys(form.customAttributes).length > 0) await adminAPI.userAttributes.updateUserAttributeValues(props.user.id, form.customAttributes)

--- a/frontend/src/i18n/locales/en/admin/resources.ts
+++ b/frontend/src/i18n/locales/en/admin/resources.ts
@@ -483,6 +483,21 @@ export default {
       clickToViewBalance: 'Click to view balance history',
       failedToLoadUser: 'Failed to load user info',
       userDeletedBadge: 'Deleted',
+      tokenRanking: {
+        title: 'User Token Ranking',
+        subtitle: 'Per-user token usage for the current filters and time range; click a row to drill down',
+        searchPlaceholder: 'Search user email...',
+        userCount: '{count} users',
+        columns: {
+          user: 'User',
+          requests: 'Requests',
+          inputTokens: 'Input Tokens',
+          outputTokens: 'Output Tokens',
+          cacheTokens: 'Cache Tokens',
+          totalTokens: 'Total Tokens',
+          cost: 'Cost'
+        }
+      },
       cleanup: {
         button: 'Cleanup',
         title: 'Cleanup Usage Records',

--- a/frontend/src/i18n/locales/zh/admin/resources.ts
+++ b/frontend/src/i18n/locales/zh/admin/resources.ts
@@ -544,6 +544,21 @@ export default {
       clickToViewBalance: '点击查看充值记录',
       failedToLoadUser: '加载用户信息失败',
       userDeletedBadge: '已删除',
+      tokenRanking: {
+        title: '用户 Token 排行',
+        subtitle: '按当前筛选与时间范围统计每个用户的 Token 用量，点击行可下钻到该用户',
+        searchPlaceholder: '搜索用户邮箱...',
+        userCount: '共 {count} 位用户',
+        columns: {
+          user: '用户',
+          requests: '请求数',
+          inputTokens: '输入 Token',
+          outputTokens: '输出 Token',
+          cacheTokens: '缓存 Token',
+          totalTokens: '总 Token',
+          cost: '费用'
+        }
+      },
       cleanup: {
         button: '清理',
         title: '清理使用记录',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1594,6 +1594,9 @@ export interface UserBreakdownItem {
   user_id: number
   email: string
   requests: number
+  input_tokens: number
+  output_tokens: number
+  cache_tokens: number
   total_tokens: number
   cost: number
   actual_cost: number

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -109,6 +109,14 @@
         </button>
       </div>
       <div v-show="activeTab === 'usage'">
+        <UserTokenRanking
+          class="mb-4"
+          :start-date="startDate"
+          :end-date="endDate"
+          :filters="breakdownFilters"
+          :model="filters.model"
+          @select-user="handleRankingSelectUser"
+        />
         <UsageTable
           :data="usageLogs"
           :loading="loading"
@@ -167,6 +175,7 @@ import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usag
 import AppLayout from '@/components/layout/AppLayout.vue'; import Pagination from '@/components/common/Pagination.vue'; import Select from '@/components/common/Select.vue'; import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import UsageStatsCards from '@/components/admin/usage/UsageStatsCards.vue'; import UsageFilters from '@/components/admin/usage/UsageFilters.vue'
 import UsageTable from '@/components/admin/usage/UsageTable.vue'; import UsageExportProgress from '@/components/admin/usage/UsageExportProgress.vue'
+import UserTokenRanking from '@/components/admin/usage/UserTokenRanking.vue'
 import UsageCleanupDialog from '@/components/admin/usage/UsageCleanupDialog.vue'
 import UserBalanceHistoryModal from '@/components/admin/user/UserBalanceHistoryModal.vue'
 import OpsErrorLogTable from '@/views/admin/ops/components/OpsErrorLogTable.vue'
@@ -233,6 +242,12 @@ const handleUserClick = async (userId: number) => {
   } catch {
     appStore.showError(t('admin.usage.failedToLoadUser'))
   }
+}
+
+// Drill down from the per-user token ranking: scope the whole usage view to that user.
+const handleRankingSelectUser = (userId: number) => {
+  filters.value = { ...filters.value, user_id: userId }
+  applyFilters()
 }
 
 const granularityOptions = computed(() => [{ value: 'day', label: t('admin.dashboard.day') }, { value: 'hour', label: t('admin.dashboard.hour') }])

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -163,7 +163,7 @@ describe('admin UsageView distribution metric toggles', () => {
         UserBalanceHistoryModal: true, AuditLogModal: true, Pagination: true, Select: true,
         DateRangePicker: true, Icon: true, TokenUsageTrend: true,
         ModelDistributionChart: ModelDistributionChartStub, GroupDistributionChart: GroupDistributionChartStub,
-        EndpointDistributionChart: true,
+        EndpointDistributionChart: true, UserTokenRanking: true,
       } },
     })
     vi.advanceTimersByTime(120)
@@ -201,6 +201,7 @@ describe('admin UsageView distribution metric toggles', () => {
           TokenUsageTrend: true,
           ModelDistributionChart: ModelDistributionChartStub,
           GroupDistributionChart: GroupDistributionChartStub,
+          UserTokenRanking: true,
         },
       },
     })
@@ -281,6 +282,7 @@ describe('admin UsageView handleUserClick', () => {
           ModelDistributionChart: true,
           GroupDistributionChart: true,
           EndpointDistributionChart: true,
+          UserTokenRanking: true,
         },
       },
     })
@@ -326,7 +328,7 @@ describe('admin UsageView errors tab filter forwarding', () => {
         UserBalanceHistoryModal: true, AuditLogModal: true, Pagination: true, Select: true,
         DateRangePicker: true, Icon: true, TokenUsageTrend: true,
         ModelDistributionChart: true, GroupDistributionChart: true, EndpointDistributionChart: true,
-        OpsErrorLogTable: true, OpsErrorDetailModal: true,
+        UserTokenRanking: true, OpsErrorLogTable: true, OpsErrorDetailModal: true,
       } },
     })
     vi.advanceTimersByTime(120)


### PR DESCRIPTION
## 概述

本 PR 为管理后台新增两项功能：**用户角色管理** 与 **用户 Token 排行**。两者都在既有页面 / 接口上做**加法扩展**，向后兼容，不改变现有行为、不重复造轮子、无数据库迁移。

---

## 功能一：用户角色管理（创建 / 编辑均可选择与修改角色）

**背景**：`user` 表本就有 `role` 字段（`admin` / `user`），用户列表也支持按角色筛选；但创建用户时角色被硬编码为 `user`，编辑时也无法修改角色。

**改动**：
- **创建用户**：可选择角色，缺省仍为 `user`（不再硬编码）。
- **编辑用户**：可在 `user` / `admin` 之间切换。
- 后端对角色做合法性校验（仅允许 `admin` / `user`）。
- **防锁死保护**：管理员不能把自己降级为普通用户（与既有「不能禁用 / 删除 admin」保护一致；降级其他管理员仍允许）。
- 前端创建 / 编辑弹窗新增角色下拉，复用既有 i18n 文案（`admin.users.form.roleLabel`、`admin.users.roles.*`）。

涉及文件：`admin_service.go`、`admin_user.go`、`user_handler.go`、`UserCreateModal.vue`、`UserEditModal.vue`、`api/admin/users.ts`。

---

## 功能二：用户 Token 排行（合并进用量记录页 `/admin/usage`）

**背景**：`/admin/usage` 已是较完整的用量看板（KPI 卡片、模型 / 分组 / 端点分布、Token 趋势、用户 / 时间 / 模型筛选、逐条日志）；`/admin/dashboard/user-breakdown` 已能按用户聚合，但只返回总 Token，排序也固定为消费额。

**改动**：
- 前端在 `/admin/usage` 用量 Tab 新增「用户 Token 排行」面板：
  - 列：排名、用户、请求数、输入 Token、输出 Token、缓存 Token、总 Token、费用。
  - 支持点表头切换排序、按邮箱搜索、Top N（20 / 50 / 100 / 200）。
  - 点击某行下钻，将整页筛选到该用户；复用既有筛选与时间范围（「全部用户」= 不选用户，时间范围由既有日期选择器控制）。
- 后端对 `user-breakdown` 做**加法扩展**（同表、同筛选，向后兼容）：
  - `UserBreakdownItem` 增加 `input_tokens` / `output_tokens` / `cache_tokens`。
  - 新增 `sort_by`（**白名单排序**，防 SQL 注入，缺省仍按 `actual_cost`）。

涉及文件：`usage_log_types.go`、`usage_log_repo_trend.go`、`dashboard_handler.go`、`UserTokenRanking.vue`（新增）、`UsageView.vue`、`api/admin/dashboard.ts`、`types/index.ts`、`i18n zh/en resources.ts`。

---

## 兼容性 / 影响面

- 纯加法改动；新增字段对既有 `user-breakdown` 消费方（后台 Dashboard）无影响。
- 无数据库迁移（仅新增聚合列，`role` 字段本就存在）。

## 测试

- **后端**：`go test -tags=unit ./...` 全绿（0 FAIL）；新增角色（创建 / 更新 / 非法值 / 防降级）与 `sort_by` 转发单元测试。
- **前端**：`lint:check` + `typecheck` + 关键 vitest（91 tests）全绿；同步更新 `UsageView.spec.ts` 稳定桩。
- 集成测试 `test-integration` 需 Postgres / Redis，本地未跑，交由 CI。

## 备注

- 建议补充运行截图（角色下拉 / Token 排行面板）。
- 首次贡献需签署 CLA（仓库 CLA 机器人会在本 PR 下引导签署）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
