### PR TITLE
[codex] Fix mapped OpenAI upstream model in ops logs

### DIFF
--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -28,7 +28,7 @@ const (
 	opsAccountIDKey              = "ops_account_id"
 	opsRoutingCapacityLimitedKey = "ops_routing_capacity_limited"
 
-	opsUpstreamModelKey = "ops_upstream_model"
+	opsUpstreamModelKey = service.OpsUpstreamModelKey
 	opsRequestTypeKey   = "ops_request_type"
 
 	// 错误过滤匹配常量 — shouldSkipOpsErrorLog 和错误分类共用

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -212,6 +212,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			markPatchSet("model", upstreamModel)
 		}
 	}
+	SetOpsUpstreamModel(c, upstreamModel)
 	if strings.TrimSpace(gjson.GetBytes(body, "reasoning.effort").String()) == "minimal" {
 		markPatchSet("reasoning.effort", "none")
 		logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized reasoning.effort: minimal -> none (account: %s)", account.Name)
@@ -247,6 +248,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			markDecodedModified()
 			if model, ok := decoded["model"].(string); ok {
 				upstreamModel = strings.TrimSpace(model)
+				SetOpsUpstreamModel(c, upstreamModel)
 			}
 			logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Normalized /responses image-only model request inbound_model=%s image_model=%s upstream_model=%s", requestView.Model, billingModel, upstreamModel)
 		}
@@ -315,6 +317,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		if codexResult.NormalizedModel != "" {
 			upstreamModel = codexResult.NormalizedModel
+			SetOpsUpstreamModel(c, upstreamModel)
 		}
 		if codexResult.PromptCacheKey != "" {
 			promptCacheKey = codexResult.PromptCacheKey

--- a/backend/internal/service/openai_gateway_service_hotpath_test.go
+++ b/backend/internal/service/openai_gateway_service_hotpath_test.go
@@ -239,6 +239,46 @@ func TestOpenAIGatewayService_Forward_TextResponsesSetsBillingModelToMappedModel
 	require.Equal(t, 0, result.ImageCount)
 }
 
+func TestOpenAIGatewayService_Forward_TextResponsesStoresMappedUpstreamModelOnError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_text_mapped_error"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"Service temporarily unavailable"}}`)),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	account := &Account{
+		ID:          4,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":       "sk-test",
+			"base_url":      "https://example.com",
+			"model_mapping": map[string]any{"gpt-5.4-mini": "gpt-5.5"},
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	result, err := svc.Forward(context.Background(), c, account, []byte(`{"model":"gpt-5.4-mini","stream":false,"input":"hello"}`))
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, "gpt-5.5", gjson.GetBytes(upstream.lastBody, "model").String())
+
+	upstreamModel, ok := c.Get(OpsUpstreamModelKey)
+	require.True(t, ok)
+	require.Equal(t, "gpt-5.5", upstreamModel)
+}
+
 func TestOpenAIGatewayService_Forward_TextResponsesWithoutMappingKeepsRequestedBillingModel(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	upstream := &httpUpstreamRecorder{

--- a/backend/internal/service/ops_upstream_context.go
+++ b/backend/internal/service/ops_upstream_context.go
@@ -11,6 +11,7 @@ import (
 // Gin context keys used by Ops error logger for capturing upstream error details.
 // These keys are set by gateway services and consumed by handler/ops_error_logger.go.
 const (
+	OpsUpstreamModelKey        = "ops_upstream_model"
 	OpsUpstreamStatusCodeKey   = "ops_upstream_status_code"
 	OpsUpstreamErrorMessageKey = "ops_upstream_error_message"
 	OpsUpstreamErrorDetailKey  = "ops_upstream_error_detail"
@@ -62,6 +63,17 @@ func IsResponseCommitted(c *gin.Context) bool {
 	}
 	b, _ := v.(bool)
 	return b
+}
+
+func SetOpsUpstreamModel(c *gin.Context, upstreamModel string) {
+	if c == nil {
+		return
+	}
+	upstreamModel = strings.TrimSpace(upstreamModel)
+	if upstreamModel == "" {
+		return
+	}
+	c.Set(OpsUpstreamModelKey, upstreamModel)
 }
 
 func SetOpsLatencyMs(c *gin.Context, key string, value int64) {


### PR DESCRIPTION
## What changed

- Share the ops upstream model context key from the service package instead of duplicating the raw string in the handler.
- Record the resolved OpenAI upstream model on the Gin context after account/compact model mapping.
- Refresh that context value if image-only normalization or Codex OAuth normalization changes the final upstream model.
- Add a regression test for mapped `/v1/responses` requests that fail upstream before an `OpenAIForwardResult` is returned.

## Why

Ops error logging initializes request context before account-level model mapping is known. On upstream errors, `Forward` may return without a result, so `ops_error_logs.upstream_model` stays empty and the UI falls back to the requested model. This makes mapped requests look like they were sent upstream with the original model even though the upstream payload was already rewritten.

## Validation

- `go test ./internal/service -run TestOpenAIGatewayService_Forward_TextResponsesStoresMappedUpstreamModelOnError -count=1`
- `go test ./internal/service -run 'TestOpenAIGatewayService_Forward_TextResponses(SetsBillingModelToMappedModel|StoresMappedUpstreamModelOnError|WithoutMappingKeepsRequestedBillingModel|BillingModelMatchesChatCompletions)' -count=1`
- `go test ./internal/handler -run 'TestSetOpsEndpointContext' -count=1`
- `go test ./internal/service ./internal/handler -count=1`
- `git diff --check`
