### PR TITLE
fix: 后台自动刷新纳入 setup-token 账号（修复 8h 后 401）

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -729,7 +729,7 @@ func (r *accountRepository) ListOAuthRefreshCandidates(ctx context.Context) ([]s
 		FROM accounts
 		WHERE deleted_at IS NULL
 			AND status = 'active'
-			AND type = 'oauth'
+			AND type IN ('oauth', 'setup-token')
 			AND platform IN ('anthropic', 'openai', 'gemini', 'antigravity')
 			AND credentials ? 'refresh_token'
 			AND btrim(credentials->>'refresh_token') <> ''

--- a/backend/internal/repository/account_repo_temp_unsched_test.go
+++ b/backend/internal/repository/account_repo_temp_unsched_test.go
@@ -43,7 +43,8 @@ func TestAccountRepository_ListOAuthRefreshCandidates_SQLFilter(t *testing.T) {
 	normalized := normalizeSQLWhitespace(capturedSQL)
 	require.Contains(t, normalized, "deleted_at IS NULL")
 	require.Contains(t, normalized, "status = 'active'")
-	require.Contains(t, normalized, "type = 'oauth'")
+	// setup-token 的 access_token 同为 8h 短期令牌，必须与 oauth 一起纳入后台刷新候选
+	require.Contains(t, normalized, "type IN ('oauth', 'setup-token')")
 	require.Contains(t, normalized, "platform IN ('anthropic', 'openai', 'gemini', 'antigravity')")
 	require.Contains(t, normalized, "credentials ? 'refresh_token'")
 	require.Contains(t, normalized, "btrim(credentials->>'refresh_token') <> ''")

--- a/backend/internal/service/token_refresher.go
+++ b/backend/internal/service/token_refresher.go
@@ -38,11 +38,13 @@ func (r *ClaudeTokenRefresher) CacheKey(account *Account) string {
 }
 
 // CanRefresh 检查是否能处理此账号
-// 只处理 anthropic 平台的 oauth 类型账号
-// setup-token 虽然也是OAuth，但有效期1年，不需要频繁刷新
+// 处理 anthropic 平台的 oauth 与 setup-token 类型账号。
+// 两者的 access_token 均为短期令牌（expires_in=28800，即 8h），到期都需刷新；
+// setup-token 之前被排除会导致其 access_token 过期后请求 401。
+// 此处与手动刷新入口（account.IsOAuth()）保持一致，实际是否刷新由 NeedsRefresh
+// 基于 expires_at 门控，并在分布式锁保护下执行，不会造成过度刷新。
 func (r *ClaudeTokenRefresher) CanRefresh(account *Account) bool {
-	return account.Platform == PlatformAnthropic &&
-		account.Type == AccountTypeOAuth
+	return account.Platform == PlatformAnthropic && account.IsOAuth()
 }
 
 // NeedsRefresh 检查token是否需要刷新

--- a/backend/internal/service/token_refresher_test.go
+++ b/backend/internal/service/token_refresher_test.go
@@ -195,6 +195,12 @@ func TestClaudeTokenRefresher_CanRefresh(t *testing.T) {
 			want:     true,
 		},
 		{
+			name:     "anthropic setup-token - can refresh",
+			platform: PlatformAnthropic,
+			accType:  AccountTypeSetupToken,
+			want:     true,
+		},
+		{
 			name:     "anthropic api-key - cannot refresh",
 			platform: PlatformAnthropic,
 			accType:  AccountTypeAPIKey,


### PR DESCRIPTION
## 问题现象

`setup-token` 类型的 Anthropic 账号在使用约 8 小时后开始返回 **401 `authentication_error`**，随后触发 failover。

## 根因

`setup-token` 的 access_token 与 `oauth` 一样是**短期令牌**——上游返回 `expires_in=28800`（即 **8 小时**），并非之前假设的「有效期 1 年」。但后台自动刷新服务**故意排除**了 setup-token：

- `service/token_refresher.go` 的 `ClaudeTokenRefresher.CanRefresh()` 只认 `Type == AccountTypeOAuth`，注释写着「setup-token 有效期1年，不需要频繁刷新」——与实际的 8h 不符。
- `repository/account_repo.go` 的 `ListOAuthRefreshCandidates` 候选查询限定 `AND type = 'oauth'`，同样把 setup-token 排除在外。

于是 setup-token 的 access_token 到期后没有任何人续期，转发路径又直接读库里的 token 照发，Anthropic 返回 401（响应带 request_id，可确认是真打到上游、非本地判过期）。

而**手动刷新是支持 setup-token 的**：`refreshSingleAccount` 的守卫用的是 `account.IsOAuth()`，它返回 `oauth || setup-token`。也就是说能力本就具备，只是后台定时路径没走到。

## 改动

让后台刷新与手动入口保持一致：

1. `ClaudeTokenRefresher.CanRefresh()`：`Type == AccountTypeOAuth` → `account.IsOAuth()`（涵盖 oauth 与 setup-token），并修正注释。
2. `ListOAuthRefreshCandidates` 候选查询：`AND type = 'oauth'` → `AND type IN ('oauth', 'setup-token')`。

## 为什么安全（不会过度刷新 / 不会打乱现有逻辑）

- 是否真正刷新仍由 `NeedsRefresh` 基于 `expires_at` 门控，只在临近到期时才刷——不是每轮强刷。
- 刷新在 `OAuthRefreshAPI.RefreshIfNeeded` 的**分布式锁 + DB 重读 + 竞争恢复**下执行，多 worker 并发安全。
- 候选查询虽对全平台放开，但 setup-token 仅存在于 anthropic；其他平台的 refresher 仍各自用 `Type == AccountTypeOAuth` 兜底，不受影响。

## 验证

- `go build ./internal/service/... ./internal/repository/...` 通过。
- 线上以等价方式（定时调用 `POST /admin/accounts/:id/refresh`）验证过 setup-token 的刷新链路可用：走代理刷新、轮换并存回新 refresh_token、同步 Postgres + Redis 快照，账号有效期回到 ~8h、401 消失。本 PR 把同一能力回归到后台定时路径。
