### PR TITLE
fix(ccswitch): default Codex imports to GPT-5.6 Sol

### DIFF
--- a/frontend/src/utils/__tests__/ccswitchImport.spec.ts
+++ b/frontend/src/utils/__tests__/ccswitchImport.spec.ts
@@ -12,7 +12,7 @@ function paramsFromDeeplink(deeplink: string): URLSearchParams {
 
 describe('ccswitchImport utils', () => {
   it('defaults OpenAI CC Switch imports to the current Codex model', () => {
-    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.5')
+    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.6-sol')
   })
 
   const baseInput = {

--- a/frontend/src/utils/ccswitchImport.ts
+++ b/frontend/src/utils/ccswitchImport.ts
@@ -1,6 +1,6 @@
 import type { GroupPlatform } from '@/types'
 
-export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.5'
+export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.6-sol'
 
 export type CcSwitchClientType = 'claude' | 'gemini'
 


### PR DESCRIPTION
## Summary

- Default OpenAI API key imports into CC-Switch Codex to `gpt-5.6-sol`.
- Update the focused regression test for the new default.

## Reasoning effort

CC-Switch V1 deep links expose a `model` field but no separate reasoning-effort field. Its Codex importer currently generates `model_reasoning_effort = "high"`, so this change keeps the requested `high` setting without adding an unsupported query parameter.

## Tests

- `pnpm exec vitest run src/utils/__tests__/ccswitchImport.spec.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/utils/ccswitchImport.ts src/utils/__tests__/ccswitchImport.spec.ts`