### PR TITLE
fix(openai): forward Codex attestation header

### DIFF
--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -49,6 +49,7 @@ const (
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
+	openAIAttestationHeader            = "x-oai-attestation"
 	codexCLIVersion                    = "0.125.0"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
@@ -68,6 +69,7 @@ var openaiAllowedHeaders = map[string]bool{
 	"session_id":            true,
 	"x-codex-turn-state":    true,
 	"x-codex-turn-metadata": true,
+	openAIAttestationHeader: true,
 }
 
 // OpenAI passthrough allowed headers whitelist.
@@ -83,6 +85,7 @@ var openaiPassthroughAllowedHeaders = map[string]bool{
 	"session_id":            true,
 	"x-codex-turn-state":    true,
 	"x-codex-turn-metadata": true,
+	openAIAttestationHeader: true,
 }
 
 // codex_cli_only 拒绝时记录的请求头白名单（仅用于诊断日志，不参与上游透传）

--- a/backend/internal/service/openai_ws_forwarder_payload.go
+++ b/backend/internal/service/openai_ws_forwarder_payload.go
@@ -75,6 +75,9 @@ func (s *OpenAIGatewayService) buildOpenAIWSHeaders(
 		if v := strings.TrimSpace(c.Request.Header.Get("accept-language")); v != "" {
 			headers.Set("accept-language", v)
 		}
+		if v := c.Request.Header.Get(openAIAttestationHeader); v != "" {
+			headers.Set(openAIAttestationHeader, v)
+		}
 	}
 	// OAuth 账号：将 apiKeyID 混入 session 标识符，防止跨用户会话碰撞。
 	if account != nil && account.Type == AccountTypeOAuth {


### PR DESCRIPTION
## Summary

- Forward Codex desktop attestation header `x-oai-attestation` through OpenAI OAuth HTTP responses paths.
- Forward the same header in OpenAI Responses websocket handshakes.
- Keep the attestation value opaque; Sub2API does not generate or mutate it.

## Checks

- `git diff --check`

## Context

Upstream Codex app-server can request desktop hosts to generate `{ "headerValue": "v1.<opaque>" }` for `x-oai-attestation`. This preserves that header when official clients send it through Sub2API.