### PR TITLE
fix(openai): 升级 Codex 客户端版本至 0.144.1，修复 gpt-5.6-luna 404

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -111,7 +111,7 @@ const (
 	apiQueryMaxJitter       = 800 * time.Millisecond // 用量查询最大随机延迟
 	windowStatsCacheTTL     = 1 * time.Minute
 	openAIProbeCacheTTL     = 10 * time.Minute
-	openAICodexProbeVersion = "0.125.0"
+	openAICodexProbeVersion = "0.144.1"
 )
 
 // UsageCache 封装账户使用量相关的缓存

--- a/backend/internal/service/openai_codex_version_consistency_test.go
+++ b/backend/internal/service/openai_codex_version_consistency_test.go
@@ -1,0 +1,21 @@
+//go:build unit
+
+package service
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCodexVersionConstants_Consistency(t *testing.T) {
+	require.Equal(t, codexCLIVersion, openAICodexProbeVersion,
+		"codexCLIVersion and openAICodexProbeVersion must stay in sync")
+
+	require.True(t, strings.Contains(codexCLIUserAgent, "codex_cli_rs/"+codexCLIVersion),
+		"codexCLIUserAgent must embed codexCLIVersion")
+
+	require.True(t, strings.Contains(DefaultOpenAICodexUserAgent, codexCLIVersion),
+		"DefaultOpenAICodexUserAgent must embed codexCLIVersion")
+}

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -35,7 +35,7 @@ const (
 	// 与真实 Codex CLI 的 User-Agent 结构对齐：
 	// {originator}/{version} ({OS} {OS_version}; {arch}) {terminal}
 	// 旧值 "codex_cli_rs/0.125.0" 缺少 OS/架构/终端后缀，易被上游指纹识别为非官方客户端。
-	codexCLIUserAgent = "codex_cli_rs/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color"
+	codexCLIUserAgent = "codex_cli_rs/0.144.1 (Ubuntu 22.4.0; x86_64) xterm-256color"
 	// codex_cli_only 拒绝时单个请求头日志长度上限（字符）
 	codexCLIOnlyHeaderValueMaxBytes = 256
 
@@ -49,7 +49,7 @@ const (
 	openAIWSRetryBackoffMaxDefault     = 2 * time.Second
 	openAIWSRetryJitterRatioDefault    = 0.2
 	openAICompactSessionSeedKey        = "openai_compact_session_seed"
-	codexCLIVersion                    = "0.125.0"
+	codexCLIVersion                    = "0.144.1"
 	// Codex 限额快照仅用于后台展示/诊断，不需要每个成功请求都立即落库。
 	openAICodexSnapshotPersistMinInterval = 30 * time.Second
 	// 配额自动暂停时，超过该时长仍未刷新的 used% 快照视为陈旧，不再据此暂停账号。

--- a/backend/internal/service/setting_gateway_runtime.go
+++ b/backend/internal/service/setting_gateway_runtime.go
@@ -83,7 +83,7 @@ const antigravityUserAgentVersionErrorTTL = 5 * time.Second
 const antigravityUserAgentVersionDBTimeout = 5 * time.Second
 
 // DefaultOpenAICodexUserAgent OpenAI Codex 默认 User-Agent（用于规避 Cloudflare 对浏览器 UA 的质询）
-const DefaultOpenAICodexUserAgent = "codex-tui/0.125.0 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.125.0)"
+const DefaultOpenAICodexUserAgent = "codex-tui/0.144.1 (Ubuntu 22.4.0; x86_64) xterm-256color (codex-tui; 0.144.1)"
 
 // cachedOpenAICodexUserAgent 缓存 OpenAI Codex UA（进程内缓存，60s TTL）
 type cachedOpenAICodexUserAgent struct {


### PR DESCRIPTION
## 背景

Fixes #3903，关联 #3895、#3893

Codex 客户端版本硬编码 `0.125.0`，低于 GPT-5.6 系列要求的 `minimal_client_version: 0.144.0`。模型清单探测（`openai_codex_models_service.go:51`）发送 `?client_version=0.125.0`，上游过滤掉了 5.6 模型；直接请求 gpt-5.6-luna 时上游返回 404。

## 修改

4 处版本常量统一从 `0.125.0` 升级到 `0.144.1`：

- `codexCLIVersion`（`openai_gateway_service.go:52`）
- `codexCLIUserAgent`（`openai_gateway_service.go:38`）
- `openAICodexProbeVersion`（`account_usage_service.go:114`）
- `DefaultOpenAICodexUserAgent`（`setting_gateway_runtime.go:86`）

新增一致性测试 `openai_codex_version_consistency_test.go`，确保这 4 个常量不会再次漂移。

## 兼容性

- 纯版本字符串升级，不改任何逻辑分支
- Sol/Terra 在新版本下仍正常（向后兼容）
- 已有管理员自定义 UA 的配置不受影响（`account.GetOpenAIUserAgent()` 优先级更高）

## 测试

```bash
go test -tags=unit -run TestCodexVersionConstants ./internal/service/...
go test -tags=unit ./internal/service/...  # 全量通过
```