### PR TITLE
fix(admin): GetUserBreakdown request_type 筛选使用字符串解析

### DIFF
--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -657,11 +657,14 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 			dim.AccountID = id
 		}
 	}
-	if v := c.Query("request_type"); v != "" {
-		if rt, err := strconv.ParseInt(v, 10, 16); err == nil {
-			rtVal := int16(rt)
-			dim.RequestType = &rtVal
+	if v := strings.TrimSpace(c.Query("request_type")); v != "" {
+		parsed, err := service.ParseUsageRequestType(v)
+		if err != nil {
+			response.BadRequest(c, err.Error())
+			return
 		}
+		rtVal := int16(parsed)
+		dim.RequestType = &rtVal
 	}
 	if v := c.Query("stream"); v != "" {
 		if s, err := strconv.ParseBool(v); err == nil {

--- a/backend/internal/handler/admin/dashboard_handler_user_breakdown_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_user_breakdown_test.go
@@ -241,3 +241,42 @@ func TestGetUserBreakdown_NoFilters(t *testing.T) {
 	require.Empty(t, repo.capturedDim.Model)
 	require.Empty(t, repo.capturedDim.Endpoint)
 }
+
+func TestGetUserBreakdown_RequestTypeStringFilter(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  int16
+	}{
+		{"ws_v2", "ws_v2", int16(service.RequestTypeWSV2)},
+		{"stream", "stream", int16(service.RequestTypeStream)},
+		{"sync", "sync", int16(service.RequestTypeSync)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := &userBreakdownRepoCapture{}
+			router := newUserBreakdownRouter(repo)
+
+			req := httptest.NewRequest(http.MethodGet,
+				"/admin/dashboard/user-breakdown?start_date=2026-03-01&end_date=2026-03-16&request_type="+tc.value, nil)
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+			require.NotNil(t, repo.capturedDim.RequestType, "request_type=%s should set filter", tc.value)
+			require.Equal(t, tc.want, *repo.capturedDim.RequestType)
+		})
+	}
+}
+
+func TestGetUserBreakdown_InvalidRequestType(t *testing.T) {
+	repo := &userBreakdownRepoCapture{}
+	router := newUserBreakdownRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/admin/dashboard/user-breakdown?start_date=2026-03-01&end_date=2026-03-16&request_type=bogus", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -173,7 +173,7 @@ export interface UserBreakdownParams {
   user_id?: number
   api_key_id?: number
   account_id?: number
-  request_type?: number
+  request_type?: UsageRequestType
   stream?: boolean
   billing_type?: number | null
 }


### PR DESCRIPTION
## 背景

Fixes #3920

`GetUserBreakdown` 解析 `request_type` 查询参数时用的是 `strconv.ParseInt`，但前端传过来的是 `ws_v2`、`stream`、`sync` 这些字符串值，导致解析失败后筛选条件不生效，返回的是未过滤的全量数据。

同一个文件里 `GetUsageTrend`、`GetModelStats` 等接口都已经用 `service.ParseUsageRequestType` 正确处理了字符串枚举值，就 `GetUserBreakdown` 漏了。

## 修改

- `dashboard_handler.go`：把 `strconv.ParseInt` 替换为 `service.ParseUsageRequestType`，解析失败时返回 400 而不是静默忽略
- `dashboard_handler_user_breakdown_test.go`：新增 4 个测试用例（ws_v2/stream/sync 正常筛选 + 非法值返回 400）

## 兼容性

- 前端已经发的是字符串值，修复后这些请求会被正确解析
- 如果有人用数字值传 request_type，修复后需要改用字符串（跟其他接口保持一致）

## 测试

```bash
go test ./internal/handler/admin/ -run TestGetUserBreakdown -count=1 -v  # 全部通过
```