### PR TITLE
fix: 修复 OpenAI 上游错误处理与定时同步可靠性问题

### DIFF
--- a/backend/internal/handler/no_account_error.go
+++ b/backend/internal/handler/no_account_error.go
@@ -17,8 +17,10 @@ import (
 //
 //   - 404 model_not_found — the group has accounts, but none of them are
 //     configured to serve the requested model (config / typo / unsupported
-//     model). Returning 503 here misleads operators and trips reverse-proxy
-//     health checks; 404 lets the client surface the real problem.
+//     model), or every supporting account recently received the same
+//     deterministic upstream model-not-found response. Returning 503 here
+//     misleads operators and trips reverse-proxy health checks; 404 lets the
+//     client surface the real problem.
 //
 //   - 503 api_error — accounts that could serve the model exist but are
 //     temporarily exhausted (rate limit, quota auto-pause, runtime block) OR
@@ -39,10 +41,8 @@ type noAccountErrorClassification struct {
 // selection layer never tells us *why* the pool came up empty (rate-limited
 // vs. unsupported model are both wrapped as ErrNoAvailableAccounts). Instead
 // we re-check pool composition through DiagnoseModelAvailabilityForPlatform,
-// which only inspects model_mapping configuration and ignores transient
-// state. That guarantees a 404 is only returned when no operator action
-// short of editing the account's model_mapping could make this request
-// succeed.
+// which inspects model_mapping and the narrowly scoped model-not-found
+// cooldown reason. Other transient states continue to return 503.
 //
 // routingModel is the model name that account selection actually compared
 // against (i.e. after group-level dispatch mapping). displayModel is the
@@ -79,7 +79,7 @@ func classifyNoAccountError(
 	}
 
 	result := diag.DiagnoseModelAvailabilityForPlatform(ctx, apiKey.GroupID, routingModel, platform)
-	if result.HasAccountsInPool && !result.HasModelSupport {
+	if result.HasAccountsInPool && (!result.HasModelSupport || result.AllSupportingAccountsModelNotFoundLimited) {
 		return noAccountErrorClassification{
 			Status:        http.StatusNotFound,
 			ErrType:       "model_not_found",

--- a/backend/internal/handler/no_account_error_test.go
+++ b/backend/internal/handler/no_account_error_test.go
@@ -126,6 +126,23 @@ func TestClassifyNoAccountError_HasModelSupport_KeepsRoutingMessageGenerationToC
 	require.False(t, cls.ModelNotFound)
 }
 
+func TestClassifyNoAccountError_AllSupportingAccountsModelNotFoundLimited_Returns404(t *testing.T) {
+	c := newTestGinContextWithRequest()
+	fd := &fakeDiagnoser{resp: service.ModelAvailabilityDiagnosis{
+		HasAccountsInPool: true,
+		HasModelSupport:   true,
+		AllSupportingAccountsModelNotFoundLimited: true,
+	}}
+	apiKey := &service.APIKey{GroupID: ptrInt64(7)}
+
+	cls := classifyNoAccountErrorFromGin(c, fd, apiKey, "gpt-5.6-luna", "gpt-5.6-luna", service.PlatformOpenAI)
+
+	require.Equal(t, http.StatusNotFound, cls.Status)
+	require.Equal(t, "model_not_found", cls.ErrType)
+	require.True(t, cls.ModelNotFound)
+	require.Contains(t, cls.Message, "gpt-5.6-luna")
+}
+
 func TestClassifyNoAccountError_NoAccountsInPool_Stays503(t *testing.T) {
 	c := newTestGinContextWithRequest()
 	fd := &fakeDiagnoser{resp: service.ModelAvailabilityDiagnosis{HasAccountsInPool: false, HasModelSupport: false}}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1897,6 +1897,15 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage(), streamStarted)
 		return
 	}
+	if service.IsOpenAIUpstreamModelNotFoundError(statusCode, responseBody) {
+		msg := strings.TrimSpace(service.ExtractUpstreamErrorMessage(responseBody))
+		if msg == "" {
+			msg = "The requested model was not found"
+		}
+		service.SetOpsUpstreamError(c, statusCode, msg, "")
+		h.handleStreamingAwareError(c, statusCode, "model_not_found", msg, streamStarted)
+		return
+	}
 
 	// 先检查透传规则
 	if h.errorPassthroughService != nil && len(responseBody) > 0 {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -133,6 +133,27 @@ func TestOpenAIHandleStreamingAwareError_NonStreaming(t *testing.T) {
 	assert.Equal(t, "test error", errorObj["message"])
 }
 
+func TestOpenAIGatewayHandler_ModelNotFoundFailoverPreservesClientError(t *testing.T) {
+	for _, statusCode := range []int{http.StatusBadRequest, http.StatusNotFound} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+			h := &OpenAIGatewayHandler{}
+			h.handleFailoverExhausted(c, &service.UpstreamFailoverError{
+				StatusCode:   statusCode,
+				ResponseBody: []byte(`{"error":{"code":"model_not_found","message":"Model gpt-5.6-luna not found"}}`),
+			}, false)
+
+			require.Equal(t, statusCode, rec.Code)
+			require.Contains(t, rec.Body.String(), "gpt-5.6-luna")
+			require.Contains(t, rec.Body.String(), "model_not_found")
+		})
+	}
+}
+
 func TestReadRequestBodyWithPrealloc(t *testing.T) {
 	payload := `{"model":"gpt-5","input":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(payload))

--- a/backend/internal/service/gateway_model_availability.go
+++ b/backend/internal/service/gateway_model_availability.go
@@ -6,10 +6,12 @@ import (
 )
 
 // ModelAvailabilityDiagnosis describes whether the requested model can be
-// served by any configured account in the group, ignoring transient state
-// (rate limits, quota auto-pause, runtime blocks). Handlers use this on the
-// "no available accounts" error path to distinguish 404 model_not_found from
-// 503 service_unavailable.
+// served by any configured account in the group. It ignores ordinary
+// transient state (rate limits, quota auto-pause, runtime blocks), while
+// separately reporting the deterministic upstream model-not-found cooldown
+// used by OpenAI-compatible accounts. Handlers use this on the "no available
+// accounts" error path to distinguish 404 model_not_found from 503
+// service_unavailable.
 type ModelAvailabilityDiagnosis struct {
 	// HasAccountsInPool is true if the group has at least one schedulable
 	// account on the queried platform (or, for Anthropic/Gemini, on the
@@ -18,6 +20,10 @@ type ModelAvailabilityDiagnosis struct {
 	// HasModelSupport is true if at least one account's model mapping admits
 	// the requested model.
 	HasModelSupport bool
+	// AllSupportingAccountsModelNotFoundLimited is true when every account
+	// that supports the requested model is currently cooling down because the
+	// upstream deterministically rejected that model as not found.
+	AllSupportingAccountsModelNotFoundLimited bool
 }
 
 // ModelAvailabilityDiagnoser is implemented by gateway services that can

--- a/backend/internal/service/model_not_found_error.go
+++ b/backend/internal/service/model_not_found_error.go
@@ -8,7 +8,7 @@ import (
 var upstreamModelNotFoundKeywords = []string{"model not found", "unknown model", "not found"}
 
 func isUpstreamModelNotFoundError(statusCode int, body []byte) bool {
-	if statusCode != http.StatusNotFound {
+	if statusCode != http.StatusBadRequest && statusCode != http.StatusNotFound {
 		return false
 	}
 	normalized := normalizeModelNotFoundBody(body)
@@ -16,6 +16,12 @@ func isUpstreamModelNotFoundError(statusCode int, body []byte) bool {
 		return false
 	}
 	return containsModelNotFoundKeyword(normalized)
+}
+
+// IsOpenAIUpstreamModelNotFoundError reports whether an OpenAI-compatible
+// upstream returned a deterministic model-not-found client error.
+func IsOpenAIUpstreamModelNotFoundError(statusCode int, body []byte) bool {
+	return isUpstreamModelNotFoundError(statusCode, body)
 }
 
 func isModelNotFoundError(statusCode int, body []byte) bool {

--- a/backend/internal/service/model_not_found_error_test.go
+++ b/backend/internal/service/model_not_found_error_test.go
@@ -43,9 +43,15 @@ func TestIsUpstreamModelNotFoundError(t *testing.T) {
 			want:       false,
 		},
 		{
-			name:       "non 404 does not match",
+			name:       "400 model_not_found code",
 			statusCode: http.StatusBadRequest,
-			body:       []byte(`{"error":{"message":"model not found"}}`),
+			body:       []byte(`{"error":{"code":"model_not_found","message":"Model gpt-5.6-luna not found"}}`),
+			want:       true,
+		},
+		{
+			name:       "400 non model error does not match",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"error":{"code":"invalid_request_error","message":"input is invalid"}}`),
 			want:       false,
 		},
 	}

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -45,6 +45,19 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 	return false
 }
 
+func (a *Account) isModelRateLimitedForReason(ctx context.Context, requestedModel, reason string) bool {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return false
+	}
+	for _, key := range a.modelRateLimitKeysForRequest(ctx, requestedModel) {
+		if a.isRateLimitActiveForKey(key) && a.modelRateLimitReason(key) == reason {
+			return true
+		}
+	}
+	return false
+}
+
 // GetModelRateLimitRemainingTime 获取模型限流剩余时间
 // 返回 0 表示未限流或已过期
 func (a *Account) GetModelRateLimitRemainingTime(requestedModel string) time.Duration {
@@ -169,4 +182,20 @@ func (a *Account) modelRateLimitResetAt(scope string) *time.Time {
 		return nil
 	}
 	return &resetAt
+}
+
+func (a *Account) modelRateLimitReason(scope string) string {
+	if a == nil || a.Extra == nil || scope == "" {
+		return ""
+	}
+	rawLimits, ok := a.Extra[modelRateLimitsKey].(map[string]any)
+	if !ok {
+		return ""
+	}
+	rawLimit, ok := rawLimits[scope].(map[string]any)
+	if !ok {
+		return ""
+	}
+	reason, _ := rawLimit["reason"].(string)
+	return strings.TrimSpace(reason)
 }

--- a/backend/internal/service/openai_compact_stream_bridge_test.go
+++ b/backend/internal/service/openai_compact_stream_bridge_test.go
@@ -318,7 +318,7 @@ func TestHandlePassthroughSSEToJSON_CompactRawOutputItemDoneRepairsEmptyTerminal
 		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -512,7 +512,7 @@ func TestHandleNonStreamingResponsePassthrough_CompactClientStreamBridgesToSSE(t
 		}`)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/backend/internal/service/openai_gateway_context_window_nonstreaming_test.go
+++ b/backend/internal/service/openai_gateway_context_window_nonstreaming_test.go
@@ -42,7 +42,7 @@ func TestOpenAINonStreamingPassthroughContextWindowFailureReturnsBadRequest(t *t
 	svc := &OpenAIGatewayService{cfg: &config.Config{}}
 	resp := openAIContextWindowFailedSSEResponse()
 
-	_, err := svc.handleNonStreamingResponsePassthrough(c.Request.Context(), resp, c, "gpt-5.5", "gpt-5.5")
+	_, err := svc.handleNonStreamingResponsePassthrough(c.Request.Context(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "gpt-5.5")
 
 	require.Error(t, err)
 	require.Equal(t, http.StatusBadRequest, rec.Code)

--- a/backend/internal/service/openai_gateway_context_window_nonstreaming_test.go
+++ b/backend/internal/service/openai_gateway_context_window_nonstreaming_test.go
@@ -1,0 +1,87 @@
+package service
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAINonStreamingContextWindowFailureReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := openAIContextWindowFailedSSEResponse()
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "gpt-5.5")
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Contains(t, rec.Body.String(), "context window")
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+func TestOpenAINonStreamingPassthroughContextWindowFailureReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := openAIContextWindowFailedSSEResponse()
+
+	_, err := svc.handleNonStreamingResponsePassthrough(c.Request.Context(), resp, c, "gpt-5.5", "gpt-5.5")
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Contains(t, rec.Body.String(), "context window")
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+func TestOpenAINonStreamingContextWindowFailureAfterKeepaliveCommitUsesBadRequestEvent(t *testing.T) {
+	c, rec := newCompactBridgeTestContext(t, true)
+	stop := StartOpenAICompactSSEKeepalive(c, keepaliveTestInterval)
+	defer stop()
+	waitForKeepaliveBeats()
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := openAIContextWindowFailedSSEResponse()
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "gpt-5.5")
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusOK, rec.Code, "心跳已提交后 HTTP 状态不可再修改")
+	events := parseCompactBridgeSSE(t, stripKeepaliveComments(rec.Body.String()))
+	require.Len(t, events, 1)
+	require.Equal(t, "response.failed", events[0][0])
+	require.Equal(t, "invalid_request_error", gjson.Get(events[0][1], "response.error.code").String())
+	streamErr, ok := GetOpsStreamError(c)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, streamErr.IntendedStatus)
+}
+
+func openAIContextWindowFailedSSEResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.failed",
+			`data: {"type":"response.failed","error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model."}}`,
+			"",
+		}, "\n"))),
+	}
+}

--- a/backend/internal/service/openai_gateway_model_availability.go
+++ b/backend/internal/service/openai_gateway_model_availability.go
@@ -35,7 +35,17 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 		return ModelAvailabilityDiagnosis{HasAccountsInPool: true, HasModelSupport: true}
 	}
 
+	return diagnoseOpenAIModelAvailability(ctx, accounts, requestedModel)
+}
+
+func diagnoseOpenAIModelAvailability(
+	ctx context.Context,
+	accounts []Account,
+	requestedModel string,
+) ModelAvailabilityDiagnosis {
 	diag := ModelAvailabilityDiagnosis{}
+	supportingAccounts := 0
+	modelNotFoundLimitedAccounts := 0
 	for i := range accounts {
 		diag.HasAccountsInPool = true
 		// Mirrors the per-candidate filter used during account selection
@@ -44,8 +54,12 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 		// mapping must match.
 		if accounts[i].IsModelSupported(requestedModel) {
 			diag.HasModelSupport = true
-			return diag
+			supportingAccounts++
+			if accounts[i].isModelRateLimitedForReason(ctx, requestedModel, upstreamModelNotFoundReason) {
+				modelNotFoundLimitedAccounts++
+			}
 		}
 	}
+	diag.AllSupportingAccountsModelNotFoundLimited = supportingAccounts > 0 && supportingAccounts == modelNotFoundLimitedAccounts
 	return diag
 }

--- a/backend/internal/service/openai_gateway_model_availability_test.go
+++ b/backend/internal/service/openai_gateway_model_availability_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnoseOpenAIModelAvailability_AllSupportingAccountsModelNotFoundLimited(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, upstreamModelNotFoundReason),
+		openAIAccountWithModelRateLimit(2, model, resetAt, upstreamModelNotFoundReason),
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasAccountsInPool)
+	require.True(t, got.HasModelSupport)
+	require.True(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func TestDiagnoseOpenAIModelAvailability_OneSupportingAccountAvailable(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, upstreamModelNotFoundReason),
+		{ID: 2, Platform: PlatformOpenAI},
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasModelSupport)
+	require.False(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func TestDiagnoseOpenAIModelAvailability_DifferentCooldownReasonStaysTransient(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, "upstream_rate_limit"),
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasModelSupport)
+	require.False(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func TestDiagnoseOpenAIModelAvailability_ExpiredModelNotFoundCooldownStaysTransient(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, upstreamModelNotFoundReason),
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasModelSupport)
+	require.False(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func openAIAccountWithModelRateLimit(id int64, model, resetAt, reason string) Account {
+	return Account{
+		ID:       id,
+		Platform: PlatformOpenAI,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				model: map[string]any{
+					"rate_limit_reset_at": resetAt,
+					"reason":              reason,
+				},
+			},
+		},
+	}
+}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -1141,7 +1141,7 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg, terminalPayload)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != "" && mappedModel != "" && originalModel != mappedModel {

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -216,7 +216,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageCount = result.imageCount
 		imageOutputSizes = result.imageOutputSizes
 	} else {
-		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, reqModel, upstreamPassthroughModel)
+		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, account, reqModel, upstreamPassthroughModel)
 		if err != nil {
 			return nil, err
 		}
@@ -1055,10 +1055,11 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 ) (*openaiNonStreamingResultPassthrough, error) {
-	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	body, err := s.readOpenAINonStreamingResponseBody(ctx, resp.Body, c, account, true)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -913,7 +913,7 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg, terminalPayload)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != mappedModel {
@@ -1028,23 +1028,29 @@ func sanitizeOpenAIResponseFailedEventForClient(payload []byte, eventType string
 	return updated, !bytes.Equal(updated, payload)
 }
 
-func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string) error {
+func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string, payload []byte) error {
+	status := http.StatusBadGateway
+	errType := "upstream_error"
+	if isOpenAIContextWindowError(message, payload) {
+		status = http.StatusBadRequest
+		errType = "invalid_request_error"
+	}
 	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
 	if message == "" {
 		message = "Upstream returned an invalid non-streaming response"
 	}
-	setOpsUpstreamError(c, http.StatusBadGateway, message, "")
+	setOpsUpstreamError(c, status, message, "")
 	// body-signal compact 心跳可能已把响应头提交为 200，此时只能以
 	// response.failed 终止事件回传错误，不能再写 JSON+状态码。
 	if openAICompactClientWantsStream(c) && StopOpenAICompactSSEKeepaliveCommitted(c) {
-		writeOpenAICompactSSEFailureMessage(c, http.StatusBadGateway, "upstream_error", message)
+		writeOpenAICompactSSEFailureMessage(c, status, errType, message)
 		return fmt.Errorf("non-streaming openai protocol error: %s", message)
 	}
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
-	c.JSON(http.StatusBadGateway, gin.H{
+	c.JSON(status, gin.H{
 		"error": gin.H{
-			"type":    "upstream_error",
+			"type":    errType,
 			"message": message,
 		},
 	})

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -742,7 +742,7 @@ func (s *OpenAIGatewayService) bindHTTPResponseAccount(ctx context.Context, c *g
 	}
 	groupID := getOpenAIGroupIDFromContext(c)
 	ttl := s.openAIWSResponseStickyTTL()
-	logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, store.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+	bindOpenAIWSResponseAccount(ctx, store, groupID, responseID, account.ID, ttl)
 }
 
 func openAIUsageFromGJSON(value gjson.Result) (OpenAIUsage, bool) {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -795,7 +796,7 @@ func openAICacheCreationTokensFromUsage(value gjson.Result) int {
 }
 
 func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
-	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	body, err := s.readOpenAINonStreamingResponseBody(ctx, resp.Body, c, account, false)
 	if err != nil {
 		return nil, err
 	}
@@ -857,6 +858,32 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 		imageCount:       countOpenAIResponseImageOutputsFromJSONBytes(body),
 		imageOutputSizes: collectOpenAIResponseImageOutputSizesFromJSONBytes(body),
 	}, nil
+}
+
+func (s *OpenAIGatewayService) readOpenAINonStreamingResponseBody(
+	ctx context.Context,
+	reader io.Reader,
+	c *gin.Context,
+	account *Account,
+	passthrough bool,
+) ([]byte, error) {
+	body, err := ReadUpstreamResponseBody(reader, s.cfg, c, openAITooLargeError)
+	if err == nil {
+		return body, nil
+	}
+
+	responseWritten := c != nil && (IsResponseCommitted(c) || (c.Writer != nil && c.Writer.Written()))
+	if errors.Is(err, ErrUpstreamResponseBodyTooLarge) || responseWritten {
+		return nil, err
+	}
+
+	return nil, s.handleOpenAIUpstreamTransportError(
+		ctx,
+		c,
+		account,
+		fmt.Errorf("read upstream response body: %w", err),
+		passthrough,
+	)
 }
 
 func isEventStreamResponse(header http.Header) bool {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -1022,7 +1022,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_CompactNetworkErrorsTriggerFailo
 				Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-compact"}},
 				Body:       passthroughErrReadCloser{err: io.ErrUnexpectedEOF},
 			},
-			expectFailover: false,
+			expectFailover: true,
 		},
 	}
 

--- a/backend/internal/service/openai_response_affinity_persistence_test.go
+++ b/backend/internal/service/openai_response_affinity_persistence_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type responseAccountBindProbe struct {
+	OpenAIWSStateStore
+	calls       int
+	ctxErr      error
+	hasDeadline bool
+	deadline    time.Time
+	value       any
+}
+
+type responseAccountBindProbeContextKey struct{}
+
+func (p *responseAccountBindProbe) BindResponseAccount(ctx context.Context, _ int64, _ string, _ int64, _ time.Duration) error {
+	p.calls++
+	p.ctxErr = ctx.Err()
+	p.deadline, p.hasDeadline = ctx.Deadline()
+	p.value = ctx.Value(responseAccountBindProbeContextKey{})
+	return p.ctxErr
+}
+
+func TestBindOpenAIWSResponseAccountDetachesCanceledRequest(t *testing.T) {
+	parent := context.WithValue(context.Background(), responseAccountBindProbeContextKey{}, "request-value")
+	parent, cancel := context.WithCancel(parent)
+	cancel()
+	probe := &responseAccountBindProbe{}
+	before := time.Now()
+
+	bindOpenAIWSResponseAccount(parent, probe, 4201, "resp_detached", 37001, time.Hour)
+
+	require.Equal(t, 1, probe.calls)
+	require.NoError(t, probe.ctxErr)
+	require.True(t, probe.hasDeadline)
+	require.Equal(t, "request-value", probe.value)
+	require.WithinDuration(t, before.Add(openAIWSBindResponseAccountTimeout), probe.deadline, time.Second)
+}
+
+func TestBindOpenAIWSResponseAccountReplacesExpiredParentDeadline(t *testing.T) {
+	parent := context.WithValue(context.Background(), responseAccountBindProbeContextKey{}, "deadline-value")
+	parent, cancel := context.WithDeadline(parent, time.Now().Add(-time.Minute))
+	defer cancel()
+	require.ErrorIs(t, parent.Err(), context.DeadlineExceeded)
+	probe := &responseAccountBindProbe{}
+	before := time.Now()
+
+	bindOpenAIWSResponseAccount(parent, probe, 4201, "resp_deadline", 37001, time.Hour)
+
+	require.Equal(t, 1, probe.calls)
+	require.NoError(t, probe.ctxErr)
+	require.True(t, probe.hasDeadline)
+	require.True(t, probe.deadline.After(before))
+	require.Equal(t, "deadline-value", probe.value)
+	require.WithinDuration(t, before.Add(openAIWSBindResponseAccountTimeout), probe.deadline, time.Second)
+}

--- a/backend/internal/service/openai_upstream_transport_error_handle_test.go
+++ b/backend/internal/service/openai_upstream_transport_error_handle_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,6 +46,13 @@ type failingOpenAIHTTPUpstream struct {
 	calls int
 }
 
+type failingResponseBody struct {
+	err error
+}
+
+func (b failingResponseBody) Read([]byte) (int, error) { return 0, b.err }
+func (b failingResponseBody) Close() error             { return nil }
+
 func (u *failingOpenAIHTTPUpstream) Do(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
 	u.calls++
 	return nil, u.err
@@ -52,6 +61,104 @@ func (u *failingOpenAIHTTPUpstream) Do(_ *http.Request, _ string, _ int64, _ int
 func (u *failingOpenAIHTTPUpstream) DoWithTLS(_ *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
 	u.calls++
 	return nil, u.err
+}
+
+func TestHandleNonStreamingResponse_HTTP2ReadErrorFailsOverBeforeWrite(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 501, Name: "h2-read", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	readErr := errors.New("stream error: stream ID 37; INTERNAL_ERROR; received from peer")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, 0, rec.Body.Len(), "下游尚未写入时必须交给 handler 切换账号")
+}
+
+func TestHandleNonStreamingResponsePassthrough_HTTP2ReadErrorFailsOverBeforeWrite(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 504, Name: "h2-read-passthrough", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	readErr := errors.New("stream error: stream ID 41; INTERNAL_ERROR; received from peer")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponsePassthrough(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, 0, rec.Body.Len())
+}
+
+func TestHandleNonStreamingResponse_ReadErrorAfterWriteDoesNotFailOver(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 502, Name: "h2-written", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	c.Data(http.StatusOK, "text/plain", []byte("already written"))
+	readErr := errors.New("stream error: stream ID 39; INTERNAL_ERROR; received from peer")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	require.ErrorIs(t, err, readErr)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "已写入下游后不能重放请求")
+	require.Equal(t, "already written", rec.Body.String())
+}
+
+func TestHandleNonStreamingResponse_ContextCanceledDoesNotFailOver(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 503, Name: "client-gone", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	readErr := fmt.Errorf("read response body: %w", context.Canceled)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	require.ErrorIs(t, err, context.Canceled)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Equal(t, 0, rec.Body.Len())
+}
+
+func TestHandleNonStreamingResponse_TooLargeDoesNotFailOver(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.UpstreamResponseReadMaxBytes = 1
+	svc := &OpenAIGatewayService{cfg: cfg}
+	account := &Account{ID: 505, Name: "too-large", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	require.ErrorIs(t, err, ErrUpstreamResponseBodyTooLarge)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "响应体超限已经写入格式化错误，不能重放请求")
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Contains(t, rec.Body.String(), "Upstream response too large")
 }
 
 // A durable proxy/credential failure must (a) temporarily unschedule the account

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -38,6 +38,7 @@ const (
 	openAIWSEventFlushIntervalDefault     = 25 * time.Millisecond
 	openAIWSPayloadLogSampleDefault       = 0.2
 	openAIWSPassthroughIdleTimeoutDefault = time.Hour
+	openAIWSBindResponseAccountTimeout    = 3 * time.Second
 
 	openAIWSStoreDisabledConnModeStrict   = "strict"
 	openAIWSStoreDisabledConnModeAdaptive = "adaptive"
@@ -286,6 +287,20 @@ func (s *OpenAIGatewayService) openAIWSResponseStickyTTL() time.Duration {
 		}
 	}
 	return time.Hour
+}
+
+func bindOpenAIWSResponseAccount(parent context.Context, store OpenAIWSStateStore, groupID int64, responseID string, accountID int64, ttl time.Duration) {
+	if store == nil {
+		return
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	bindCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), openAIWSBindResponseAccountTimeout)
+	defer cancel()
+
+	err := store.BindResponseAccount(bindCtx, groupID, responseID, accountID, ttl)
+	logOpenAIWSBindResponseAccountWarn(groupID, accountID, responseID, err)
 }
 
 func (s *OpenAIGatewayService) openAIWSIngressPreviousResponseRecoveryEnabled() bool {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -507,7 +507,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			responseID := strings.TrimSpace(result.RequestID)
 			if responseID != "" && stateStore != nil {
 				ttl := s.openAIWSResponseStickyTTL()
-				logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+				bindOpenAIWSResponseAccount(ctx, stateStore, groupID, responseID, account.ID, ttl)
 			}
 			nextClientMessage, readErr := readClientMessage()
 			if readErr != nil {
@@ -1490,7 +1490,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 
 		if responseID != "" && stateStore != nil {
 			ttl := s.openAIWSResponseStickyTTL()
-			logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+			bindOpenAIWSResponseAccount(ctx, stateStore, groupID, responseID, account.ID, ttl)
 			stateStore.BindResponseConn(responseID, connID, ttl)
 		}
 		if stateStore != nil && storeDisabled && sessionHash != "" {

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -165,7 +165,7 @@ func (s *OpenAIGatewayService) performOpenAIWSGeneratePrewarm(
 	lease.MarkPrewarmed()
 	if prewarmResponseID != "" && stateStore != nil {
 		ttl := s.openAIWSResponseStickyTTL()
-		logOpenAIWSBindResponseAccountWarn(groupID, account.ID, prewarmResponseID, stateStore.BindResponseAccount(ctx, groupID, prewarmResponseID, account.ID, ttl))
+		bindOpenAIWSResponseAccount(ctx, stateStore, groupID, prewarmResponseID, account.ID, ttl)
 		stateStore.BindResponseConn(prewarmResponseID, lease.ConnID(), ttl)
 	}
 	logOpenAIWSModeInfo(
@@ -314,12 +314,7 @@ func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 
 	result, acquireErr := s.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
 	if acquireErr == nil && result.Acquired {
-		logOpenAIWSBindResponseAccountWarn(
-			derefGroupID(groupID),
-			accountID,
-			responseID,
-			store.BindResponseAccount(ctx, derefGroupID(groupID), responseID, accountID, s.openAIWSResponseStickyTTL()),
-		)
+		bindOpenAIWSResponseAccount(ctx, store, derefGroupID(groupID), responseID, accountID, s.openAIWSResponseStickyTTL())
 		return &AccountSelectionResult{
 			Account:     account,
 			Acquired:    true,

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -656,7 +656,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 
 	if responseID != "" && stateStore != nil {
 		ttl := s.openAIWSResponseStickyTTL()
-		logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+		bindOpenAIWSResponseAccount(ctx, stateStore, groupID, responseID, account.ID, ttl)
 		stateStore.BindResponseConn(responseID, lease.ConnID(), ttl)
 	}
 	if stateStore != nil && storeDisabled && sessionHash != "" {

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -204,6 +204,11 @@ func (s *PricingService) Stop() {
 
 // startUpdateScheduler 启动定时更新调度器
 func (s *PricingService) startUpdateScheduler() {
+	if s == nil || s.cfg == nil || strings.TrimSpace(s.cfg.Pricing.RemoteURL) == "" {
+		logger.LegacyPrintf("service.pricing", "%s", "[Pricing] Remote sync disabled: pricing remote URL is empty")
+		return
+	}
+
 	// 定期检查哈希更新
 	hashInterval := time.Duration(s.cfg.Pricing.HashCheckIntervalMinutes) * time.Minute
 	if hashInterval < time.Minute {

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -5,10 +5,41 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPricingSchedulerBlankRemoteURLDoesNotStart(t *testing.T) {
+	svc := NewPricingService(&config.Config{Pricing: config.PricingConfig{RemoteURL: "  \t  "}}, nil)
+	defer svc.Stop()
+
+	svc.startUpdateScheduler()
+	done := make(chan struct{})
+	go func() {
+		svc.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("blank remote URL must not start scheduler")
+	}
+}
+
+func TestPricingNonEmptyInvalidRemoteURLStillReturnsValidationError(t *testing.T) {
+	svc := NewPricingService(&config.Config{Pricing: config.PricingConfig{
+		RemoteURL: "://invalid",
+		DataDir:   t.TempDir(),
+	}}, nil)
+
+	err := svc.ForceUpdate()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid pricing url")
+}
 
 func TestParsePricingData_ParsesPriorityAndServiceTierFields(t *testing.T) {
 	svc := &PricingService{}


### PR DESCRIPTION
## 背景

在 OpenAI Responses 请求（包括 `gpt-5.6-luna`）中，上游确定性的模型错误、非流式 SSE 协议错误和响应体读取异常会被过度归一化为 502/503；同时，请求结束时的响应账号亲和性写入可能继承已取消的请求上下文，空定价 URL 也会持续启动无效调度器。

## 修复内容

- 保留 Luna / model-not-found 错误语义：识别 OpenAI 兼容上游的 400/404 model-not-found；故障转移耗尽后保留客户端错误状态与消息。仅当所有支持该模型的账号都因确定性 model-not-found 冷却时返回 404，普通限流或临时不可用仍保持 503。
- 将非流式 SSE 的上下文窗口超限映射为 400 `invalid_request_error`；compact 心跳已经提交 200 时，通过 `response.failed` 终止事件返回同等语义，并记录 intended status 400。
- 非流式响应在写入下游前发生 HTTP/2 `INTERNAL_ERROR`、`UnexpectedEOF` 等读取错误时触发账号故障转移；已写入响应、客户端取消以及响应体超限不会重放。普通与 passthrough 路径行为一致。
- 响应账号亲和性持久化改用脱离请求取消/旧 deadline 的上下文，并设置 3 秒独立超时；覆盖 HTTP、WS v2、prewarm、previous-response 重绑定及 ingress 路径，同时保留 context value。
- 定价远程 URL 为空或仅空白时不再启动同步调度器；非空但非法 URL 仍返回原有校验错误。

## 验证

- [x] `make -C backend test-unit`
- [x] `make -C backend test-integration`
- [x] `cd backend && go test ./...`
- [x] `cd backend && go vet ./...`
- [x] `make -C backend build`
- [x] 新增关键回归用例使用 `-count=1` 与 `-race` 验证
- [x] `git diff --check origin/main...HEAD`

本 PR 不包含部署、CI/CD、依赖、lockfile、数据库 schema 或版本文件变更。
