### PR TITLE
fix(keys): default Codex config to GPT-5.6 Sol

### DIFF
--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -534,8 +534,8 @@ function generateOpenAIFiles(baseUrl: string, apiKey: string): FileConfig[] {
 
   // config.toml content
   const configContent = `model_provider = "OpenAI"
-model = "gpt-5.5"
-review_model = "gpt-5.5"
+model = "gpt-5.6-sol"
+review_model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 disable_response_storage = true
 network_access = "enabled"
@@ -574,8 +574,8 @@ function generateOpenAIWsFiles(baseUrl: string, apiKey: string): FileConfig[] {
 
   // config.toml content with WebSocket v2
   const configContent = `model_provider = "OpenAI"
-model = "gpt-5.5"
-review_model = "gpt-5.5"
+model = "gpt-5.6-sol"
+review_model = "gpt-5.6-sol"
 model_reasoning_effort = "xhigh"
 disable_response_storage = true
 network_access = "enabled"

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -17,7 +17,7 @@ vi.mock('@/composables/useClipboard', () => ({
 import UseKeyModal from '../UseKeyModal.vue'
 
 describe('UseKeyModal', () => {
-  it('renders GPT-5.5 and goals feature in OpenAI Codex config', () => {
+  it('renders GPT-5.6 Sol and goals feature in OpenAI Codex config', () => {
     const wrapper = mount(UseKeyModal, {
       props: {
         show: true,
@@ -41,15 +41,15 @@ describe('UseKeyModal', () => {
     const configToml = codeBlocks.find((content) => content.includes('model_provider = "OpenAI"'))
 
     expect(configToml).toBeDefined()
-    expect(configToml).toContain('model = "gpt-5.5"')
-    expect(configToml).toContain('review_model = "gpt-5.5"')
-    expect(configToml).not.toContain('model = "gpt-5.4"')
+    expect(configToml).toContain('model = "gpt-5.6-sol"')
+    expect(configToml).toContain('review_model = "gpt-5.6-sol"')
+    expect(configToml).not.toContain('model = "gpt-5.5"')
     expect(configToml).not.toContain('model_context_window')
     expect(configToml).not.toContain('model_auto_compact_token_limit')
     expect(configToml).toContain('[features]\ngoals = true')
   })
 
-  it('renders GPT-5.5 and goals feature in OpenAI Codex WebSocket config', async () => {
+  it('renders GPT-5.6 Sol and goals feature in OpenAI Codex WebSocket config', async () => {
     const wrapper = mount(UseKeyModal, {
       props: {
         show: true,
@@ -81,9 +81,9 @@ describe('UseKeyModal', () => {
     const configToml = codeBlocks.find((content) => content.includes('supports_websockets = true'))
 
     expect(configToml).toBeDefined()
-    expect(configToml).toContain('model = "gpt-5.5"')
-    expect(configToml).toContain('review_model = "gpt-5.5"')
-    expect(configToml).not.toContain('model = "gpt-5.4"')
+    expect(configToml).toContain('model = "gpt-5.6-sol"')
+    expect(configToml).toContain('review_model = "gpt-5.6-sol"')
+    expect(configToml).not.toContain('model = "gpt-5.5"')
     expect(configToml).not.toContain('model_context_window')
     expect(configToml).not.toContain('model_auto_compact_token_limit')
     expect(configToml).toContain('[features]\nresponses_websockets_v2 = true\ngoals = true')


### PR DESCRIPTION
## 背景

“使用密钥”弹窗生成的两套 Codex `config.toml` 仍将 `model` 和 `review_model` 固定为 `gpt-5.5`。仓库已经补齐 GPT-5.6 Sol 的模型目录与路由支持，但直接复制弹窗配置的用户仍会默认停留在旧模型。

## 修改

- 普通 Codex 配置默认使用 `gpt-5.6-sol`。
- WebSocket v2 Codex 配置默认使用 `gpt-5.6-sol`。
- 两套配置的 `review_model` 同步更新为 `gpt-5.6-sol`。
- 更新 `UseKeyModal` 回归测试，确保旧的 `gpt-5.5` 默认值不会重新出现。

## 与现有 PR 的边界

- #3948 补齐 GPT-5.6 alias、OpenCode 模型目录和 `max` variant，但未修改这两套 Codex 配置的默认模型。
- #2299 同样涉及 `UseKeyModal.vue`，但实现的是管理员可配置的文本替换规则，不修改默认模型；两者不存在功能重复。
- 本 PR 只改变生成配置的默认值，不修改后端路由、模型白名单、manifest 透传或 Codex Desktop 的 model picker。

## 官方依据

- [GPT-5.6 Sol](https://developers.openai.com/api/docs/models/gpt-5.6-sol)

## 验证

```text
pnpm run lint:check
pnpm run typecheck
pnpm run test:run
pnpm run build
git diff --check upstream/main...HEAD
```

结果：

- ESLint / TypeScript typecheck / production build：PASS
- Vitest：141 files / 914 tests PASS
- `git diff --check`：PASS