### PR TITLE
fix(openai): retry Codex manifest with another account

### DIFF
--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -36,7 +36,7 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		return
 	}
 
-	manifest, err := h.gatewayService.FetchCodexModelsManifest(c.Request.Context(), account, c.Query("client_version"), c.GetHeader("If-None-Match"))
+	manifest, err := h.gatewayService.FetchCodexModelsManifestWithFailover(c.Request.Context(), apiKey.GroupID, account, c.Query("client_version"), c.GetHeader("If-None-Match"))
 	if err != nil {
 		h.errorResponse(c, infraerrors.Code(err), "upstream_error", infraerrors.Message(err))
 		return

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -17,6 +17,7 @@ import (
 var chatgptCodexModelsURL = "https://chatgpt.com/backend-api/codex/models"
 
 const codexModelsManifestBodyLimit int64 = 8 << 20
+const codexModelsManifestMaxAccountAttempts = 2
 
 // CodexModelsManifest carries the raw upstream manifest payload plus caching
 // metadata so handlers can pass both through to the client untouched.
@@ -24,6 +25,44 @@ type CodexModelsManifest struct {
 	Body        []byte
 	ETag        string
 	NotModified bool
+}
+
+// FetchCodexModelsManifestWithFailover fetches the Codex models manifest and,
+// if the first account fails, retries once with a different schedulable account
+// from the same group. The failed account is excluded only for this request; no
+// persistent account health or scheduling state is changed.
+func (s *OpenAIGatewayService) FetchCodexModelsManifestWithFailover(ctx context.Context, groupID *int64, initialAccount *Account, clientVersion, ifNoneMatch string) (*CodexModelsManifest, error) {
+	account := initialAccount
+	excludedIDs := make(map[int64]struct{}, codexModelsManifestMaxAccountAttempts)
+	if account != nil {
+		excludedIDs[account.ID] = struct{}{}
+	}
+
+	var lastFetchErr error
+	for attempt := 0; attempt < codexModelsManifestMaxAccountAttempts; attempt++ {
+		manifest, err := s.FetchCodexModelsManifest(ctx, account, clientVersion, ifNoneMatch)
+		if err == nil {
+			return manifest, nil
+		}
+		lastFetchErr = err
+
+		if ctx.Err() != nil || attempt+1 >= codexModelsManifestMaxAccountAttempts {
+			break
+		}
+
+		nextAccount, selectErr := s.SelectAccountForModelWithExclusions(ctx, groupID, "", "", excludedIDs)
+		if selectErr != nil || nextAccount == nil {
+			break
+		}
+		if _, alreadyTried := excludedIDs[nextAccount.ID]; alreadyTried {
+			break
+		}
+
+		account = nextAccount
+		excludedIDs[account.ID] = struct{}{}
+	}
+
+	return nil, lastFetchErr
 }
 
 // FetchCodexModelsManifest fetches the live Codex models manifest from the

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -16,6 +17,186 @@ func newCodexModelsTestAccount() *Account {
 			"access_token":       "test-access-token",
 			"chatgpt_account_id": "acc-123",
 		},
+	}
+}
+
+func newSchedulableCodexModelsTestAccount(id int64, priority int, accessToken string) Account {
+	return Account{
+		ID:          id,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    priority,
+		Credentials: map[string]any{
+			"access_token":       accessToken,
+			"chatgpt_account_id": "acc-123",
+		},
+	}
+}
+
+func useCodexModelsTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	original := chatgptCodexModelsURL
+	chatgptCodexModelsURL = server.URL
+	t.Cleanup(func() {
+		chatgptCodexModelsURL = original
+		server.Close()
+	})
+}
+
+func TestFetchCodexModelsManifestWithFailoverRetriesAnotherAccountInGroup(t *testing.T) {
+	const manifestBody = `{"models":[{"slug":"gpt-5.6-sol"}]}`
+	groupID := int64(42)
+	first := newSchedulableCodexModelsTestAccount(1, 0, "first-token")
+	first.AccountGroups = []AccountGroup{{GroupID: groupID}}
+	outsideGroup := newSchedulableCodexModelsTestAccount(2, 0, "outside-token")
+	backup := newSchedulableCodexModelsTestAccount(3, 1, "backup-token")
+	backup.AccountGroups = []AccountGroup{{GroupID: groupID}}
+
+	var gotAuth []string
+	useCodexModelsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		switch r.Header.Get("Authorization") {
+		case "Bearer first-token":
+			http.Error(w, `{"detail":"first account failed"}`, http.StatusBadGateway)
+		case "Bearer backup-token":
+			w.Header().Set("ETag", `W/"backup"`)
+			_, _ = w.Write([]byte(manifestBody))
+		default:
+			http.Error(w, `{"detail":"unexpected account"}`, http.StatusBadGateway)
+		}
+	})
+
+	repo := groupAwareStubOpenAIAccountRepo{stubOpenAIAccountRepo{accounts: []Account{first, outsideGroup, backup}}}
+	s := &OpenAIGatewayService{accountRepo: repo}
+	manifest, err := s.FetchCodexModelsManifestWithFailover(context.Background(), &groupID, &first, "0.144.1", "")
+	if err != nil {
+		t.Fatalf("FetchCodexModelsManifestWithFailover returned error: %v", err)
+	}
+	if string(manifest.Body) != manifestBody {
+		t.Errorf("body not passed through from backup account: got %q", manifest.Body)
+	}
+	if manifest.ETag != `W/"backup"` {
+		t.Errorf("etag not passed through from backup account: got %q", manifest.ETag)
+	}
+	wantAuth := []string{"Bearer first-token", "Bearer backup-token"}
+	if len(gotAuth) != len(wantAuth) {
+		t.Fatalf("request count: got %d, want %d (%v)", len(gotAuth), len(wantAuth), gotAuth)
+	}
+	for i := range wantAuth {
+		if gotAuth[i] != wantAuth[i] {
+			t.Errorf("request %d authorization: got %q, want %q", i+1, gotAuth[i], wantAuth[i])
+		}
+	}
+}
+
+func TestFetchCodexModelsManifestWithFailoverStopsAfterFirstSuccess(t *testing.T) {
+	requests := 0
+	useCodexModelsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"models":[]}`))
+	})
+
+	s := &OpenAIGatewayService{}
+	if _, err := s.FetchCodexModelsManifestWithFailover(context.Background(), nil, newCodexModelsTestAccount(), "0.144.1", ""); err != nil {
+		t.Fatalf("FetchCodexModelsManifestWithFailover returned error: %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("request count: got %d, want 1", requests)
+	}
+}
+
+func TestFetchCodexModelsManifestWithFailoverSingleAccountReturnsFetchError(t *testing.T) {
+	requests := 0
+	useCodexModelsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		http.Error(w, `{"detail":"only account failed"}`, http.StatusBadGateway)
+	})
+
+	account := newSchedulableCodexModelsTestAccount(1, 0, "only-token")
+	s := &OpenAIGatewayService{accountRepo: stubOpenAIAccountRepo{accounts: []Account{account}}}
+	_, err := s.FetchCodexModelsManifestWithFailover(context.Background(), nil, &account, "0.144.1", "")
+	if err == nil || !strings.Contains(err.Error(), "only account failed") {
+		t.Fatalf("expected original manifest error, got %v", err)
+	}
+	if requests != 1 {
+		t.Fatalf("request count: got %d, want 1", requests)
+	}
+}
+
+func TestFetchCodexModelsManifestWithFailoverReturnsSecondFetchError(t *testing.T) {
+	first := newSchedulableCodexModelsTestAccount(1, 0, "first-token")
+	second := newSchedulableCodexModelsTestAccount(2, 1, "second-token")
+
+	var gotAuth []string
+	useCodexModelsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = append(gotAuth, r.Header.Get("Authorization"))
+		if r.Header.Get("Authorization") == "Bearer first-token" {
+			http.Error(w, `{"detail":"first account failed"}`, http.StatusBadGateway)
+			return
+		}
+		http.Error(w, `{"detail":"second account failed"}`, http.StatusBadGateway)
+	})
+
+	s := &OpenAIGatewayService{accountRepo: stubOpenAIAccountRepo{accounts: []Account{first, second}}}
+	_, err := s.FetchCodexModelsManifestWithFailover(context.Background(), nil, &first, "0.144.1", "")
+	if err == nil || !strings.Contains(err.Error(), "second account failed") {
+		t.Fatalf("expected second manifest error, got %v", err)
+	}
+	wantAuth := []string{"Bearer first-token", "Bearer second-token"}
+	if len(gotAuth) != len(wantAuth) {
+		t.Fatalf("request count: got %d, want %d (%v)", len(gotAuth), len(wantAuth), gotAuth)
+	}
+	for i := range wantAuth {
+		if gotAuth[i] != wantAuth[i] {
+			t.Errorf("request %d authorization: got %q, want %q", i+1, gotAuth[i], wantAuth[i])
+		}
+	}
+}
+
+func TestFetchCodexModelsManifestWithFailoverDoesNotRetryCanceledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	requests := 0
+	useCodexModelsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		cancel()
+		http.Error(w, `{"detail":"first account failed"}`, http.StatusBadGateway)
+	})
+
+	first := newSchedulableCodexModelsTestAccount(1, 0, "first-token")
+	second := newSchedulableCodexModelsTestAccount(2, 1, "second-token")
+	s := &OpenAIGatewayService{accountRepo: stubOpenAIAccountRepo{accounts: []Account{first, second}}}
+	if _, err := s.FetchCodexModelsManifestWithFailover(ctx, nil, &first, "0.144.1", ""); err == nil {
+		t.Fatal("expected error for canceled manifest request, got nil")
+	}
+	if requests != 1 {
+		t.Fatalf("request count: got %d, want 1", requests)
+	}
+}
+
+func TestFetchCodexModelsManifestWithFailoverPreservesNotModified(t *testing.T) {
+	requests := 0
+	useCodexModelsTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("ETag", `W/"abc123"`)
+		w.WriteHeader(http.StatusNotModified)
+	})
+
+	s := &OpenAIGatewayService{}
+	manifest, err := s.FetchCodexModelsManifestWithFailover(context.Background(), nil, newCodexModelsTestAccount(), "0.144.1", `W/"abc123"`)
+	if err != nil {
+		t.Fatalf("FetchCodexModelsManifestWithFailover returned error: %v", err)
+	}
+	if !manifest.NotModified || manifest.ETag != `W/"abc123"` {
+		t.Fatalf("not-modified metadata: got %+v", manifest)
+	}
+	if requests != 1 {
+		t.Fatalf("request count: got %d, want 1", requests)
 	}
 }
 


### PR DESCRIPTION
## 背景

#3800 为 Codex 客户端新增了实时 manifest 透传，但当前 handler 只选择一个组内账号：一旦该账号的代理或 manifest 上游请求失败，即使同组仍有健康 OAuth 账号，请求也会直接返回 502。

本改动保留上游失败后的客户端缓存回落，同时增加一次有界、请求级的账号故障转移，降低单个坏代理或临时网络故障造成的 manifest 间歇性失败。

## 修改

- 保留 handler 现有的首次账号选择与无可用账号 503 语义。
- 首次 manifest 拉取失败后，将该账号 ID 加入本次请求的排除集合，并从同一 group 重新调度。
- 最多尝试两个不同账号，不会无限重选同一账号。
- 排除集合仅存在于当前请求；不会暂停账号、写入错误状态或修改账号健康度。
- 父 context 已取消时不再重试。
- 没有第二个账号时返回第一次 manifest 错误；两个账号都失败时返回第二次拉取错误。
- 首次成功、ETag 和 304 Not Modified 行为保持不变。

## 与现有 PR 的边界

- 这是 #3800 的窄范围可靠性 follow-up：不修改路由识别、manifest schema 或响应透传方式；两次不同账号均失败后仍然 fast-fail。
- #3951 处理 Responses 上游错误、读取失败和账号亲和性，不修改 manifest handler/service，与本 PR 无文件交集。
- 本 PR 不修改普通 Responses 请求的账号故障转移，也不解决未请求 manifest 端点的 Codex Desktop model picker 行为。

## 测试覆盖

- 首个账号失败、同组第二账号成功。
- 首个账号成功时不触发第二次选择。
- 组内只有一个账号时只请求一次并保留原始错误。
- 两个账号都失败时返回第二次 manifest 错误。
- context 取消后不再重试。
- ETag / 304 行为不变。

## 验证

```text
go test -tags=unit ./... -count=1
go build -trimpath ./cmd/server
go vet ./internal/service ./internal/handler ./internal/server/routes
git diff --check upstream/main...HEAD
```

结果：

- Go 全仓 unit tests：PASS
- 后端 build / vet：PASS
- manifest 定向回归测试：PASS
- `git diff --check`：PASS