### PR TITLE
fix(admin): 避免代理加载失败导致创建账号分组为空

### DIFF
--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -1841,13 +1841,23 @@ const handleClickOutside = (event: MouseEvent) => {
 
 onMounted(async () => {
   load()
-  try {
-    const [p, g] = await Promise.all([adminAPI.proxies.getAll(), adminAPI.groups.getAll()])
-    proxies.value = p
-    groups.value = g
-  } catch (error) {
-    console.error('Failed to load proxies/groups:', error)
+  const [proxyResult, groupResult] = await Promise.allSettled([
+    adminAPI.proxies.getAll(),
+    adminAPI.groups.getAll()
+  ])
+
+  if (proxyResult.status === 'fulfilled') {
+    proxies.value = proxyResult.value
+  } else {
+    console.error('Failed to load proxies:', proxyResult.reason)
   }
+
+  if (groupResult.status === 'fulfilled') {
+    groups.value = groupResult.value
+  } else {
+    console.error('Failed to load groups:', groupResult.reason)
+  }
+
   window.addEventListener('scroll', handleScroll, true)
   document.addEventListener('click', handleClickOutside)
 

--- a/frontend/src/views/admin/__tests__/AccountsView.groupLoading.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.groupLoading.spec.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import AccountsView from '../AccountsView.vue'
+
+const {
+  listAccounts,
+  listWithEtag,
+  getBatchTodayStats,
+  getAllProxies,
+  getAllGroups
+} = vi.hoisted(() => ({
+  listAccounts: vi.fn(),
+  listWithEtag: vi.fn(),
+  getBatchTodayStats: vi.fn(),
+  getAllProxies: vi.fn(),
+  getAllGroups: vi.fn()
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    accounts: {
+      list: listAccounts,
+      listWithEtag,
+      getBatchTodayStats,
+      delete: vi.fn(),
+      batchClearError: vi.fn(),
+      batchRefresh: vi.fn(),
+      toggleSchedulable: vi.fn()
+    },
+    proxies: {
+      getAll: getAllProxies
+    },
+    groups: {
+      getAll: getAllGroups
+    }
+  }
+}))
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+    showInfo: vi.fn()
+  })
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    token: 'test-token'
+  })
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key
+    })
+  }
+})
+
+const DataTableStub = {
+  props: ['columns', 'data'],
+  template: '<div data-test="data-table"></div>'
+}
+
+const CreateAccountModalStub = {
+  name: 'CreateAccountModal',
+  props: ['show', 'proxies', 'groups'],
+  template: '<div data-test="create-account-modal"></div>'
+}
+
+function mountView() {
+  return mount(AccountsView, {
+    global: {
+      stubs: {
+        AppLayout: { template: '<div><slot /></div>' },
+        TablePageLayout: {
+          template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+        },
+        DataTable: DataTableStub,
+        HelpTooltip: true,
+        Pagination: true,
+        ConfirmDialog: true,
+        AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
+        AccountTableFilters: { template: '<div></div>' },
+        AccountBulkActionsBar: true,
+        AccountActionMenu: true,
+        ImportDataModal: true,
+        ReAuthAccountModal: true,
+        AccountTestModal: true,
+        AccountStatsModal: true,
+        ScheduledTestsPanel: true,
+        SyncFromCrsModal: true,
+        TempUnschedStatusModal: true,
+        ErrorPassthroughRulesModal: true,
+        TLSFingerprintProfilesModal: true,
+        CreateAccountModal: CreateAccountModalStub,
+        EditAccountModal: true,
+        BulkEditAccountModal: true,
+        PlatformTypeBadge: true,
+        AccountCapacityCell: true,
+        AccountStatusIndicator: true,
+        AccountTodayStatsCell: true,
+        AccountGroupsCell: true,
+        AccountUsageCell: true,
+        Icon: true
+      }
+    }
+  })
+}
+
+const openaiGroup = {
+  id: 1,
+  name: 'openai-default',
+  platform: 'openai',
+  status: 'active'
+}
+
+const accountProxy = {
+  id: 7,
+  name: 'proxy-a',
+  url: 'http://proxy.example',
+  status: 'active'
+}
+
+describe('admin AccountsView helper data loading', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    listAccounts.mockReset()
+    listWithEtag.mockReset()
+    getBatchTodayStats.mockReset()
+    getAllProxies.mockReset()
+    getAllGroups.mockReset()
+
+    listAccounts.mockResolvedValue({
+      items: [],
+      total: 0,
+      page: 1,
+      page_size: 20,
+      pages: 0
+    })
+    listWithEtag.mockResolvedValue({
+      notModified: true,
+      etag: null,
+      data: null
+    })
+    getBatchTodayStats.mockResolvedValue({ stats: {} })
+    getAllProxies.mockResolvedValue([])
+    getAllGroups.mockResolvedValue([])
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps groups available for account creation when proxy loading fails', async () => {
+    const proxyError = new Error('proxy unavailable')
+    getAllProxies.mockRejectedValue(proxyError)
+    getAllGroups.mockResolvedValue([openaiGroup])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const modal = wrapper.getComponent(CreateAccountModalStub)
+    expect(modal.props('groups')).toEqual([openaiGroup])
+    expect(console.error).toHaveBeenCalledWith('Failed to load proxies:', proxyError)
+  })
+
+  it('keeps proxies available when group loading fails', async () => {
+    const groupError = new Error('groups unavailable')
+    getAllProxies.mockResolvedValue([accountProxy])
+    getAllGroups.mockRejectedValue(groupError)
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const modal = wrapper.getComponent(CreateAccountModalStub)
+    expect(modal.props('proxies')).toEqual([accountProxy])
+    expect(console.error).toHaveBeenCalledWith('Failed to load groups:', groupError)
+  })
+
+  it('passes both proxies and groups through when both helper requests succeed', async () => {
+    getAllProxies.mockResolvedValue([accountProxy])
+    getAllGroups.mockResolvedValue([openaiGroup])
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const modal = wrapper.getComponent(CreateAccountModalStub)
+    expect(modal.props('proxies')).toEqual([accountProxy])
+    expect(modal.props('groups')).toEqual([openaiGroup])
+    expect(console.error).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 背景

Issue #3917 反馈：分组管理页能看到 OpenAI 分组，但创建 OpenAI 账号时分组选择器显示“无可用分组”。

## 根因

账号管理页挂载时使用同一个 `Promise.all` 并行请求代理列表和分组列表。只要代理接口异常，`Promise.all` 会整体 reject，导致即使 `/admin/groups/all` 已经成功返回，其结果也不会赋给 `groups`，`CreateAccountModal` 最终收到空数组。

## 改动

- 将代理和分组辅助数据加载改为 `Promise.allSettled`，两个请求仍并行执行。
- 分别处理代理和分组请求结果：成功则独立赋值，失败则分别记录明确错误日志。
- 新增 `AccountsView.groupLoading` 回归测试，覆盖代理失败/分组成功、分组失败/代理成功、两者都成功三种场景。

## 测试

- `cd frontend && pnpm install --frozen-lockfile`
- `cd frontend && pnpm test:run src/views/admin/__tests__/AccountsView.groupLoading.spec.ts`
- `cd frontend && pnpm test:run`
- `cd frontend && pnpm lint:check`
- `cd frontend && pnpm typecheck`
- `cd frontend && pnpm build`
- `cd backend && go build ./...`
- `cd backend && go test -tags=unit ./...`

Fixes #3917