### PR TITLE
fix(grok): drop Codex additional_tools from Responses input

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -168,6 +168,10 @@ func patchGrokResponsesBody(body []byte, upstreamModel string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	out, err = sanitizeGrokResponsesInput(out)
+	if err != nil {
+		return nil, err
+	}
 	out, err = sanitizeGrokResponsesTools(out)
 	if err != nil {
 		return nil, err
@@ -221,6 +225,41 @@ func deleteJSONFields(value any, fields map[string]struct{}) bool {
 	default:
 		return false
 	}
+}
+
+// grokResponsesUnsupportedInputTypes are Codex/OpenAI private input item types
+// that xAI Responses rejects with:
+// "Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ModelInput".
+var grokResponsesUnsupportedInputTypes = map[string]struct{}{
+	"additional_tools": {},
+}
+
+func sanitizeGrokResponsesInput(body []byte) ([]byte, error) {
+	input := gjson.GetBytes(body, "input")
+	if !input.Exists() || !input.IsArray() {
+		return body, nil
+	}
+
+	rawItems := input.Array()
+	filtered := make([]json.RawMessage, 0, len(rawItems))
+	dropped := false
+	for _, item := range rawItems {
+		itemType := strings.TrimSpace(item.Get("type").String())
+		if _, unsupported := grokResponsesUnsupportedInputTypes[itemType]; unsupported {
+			dropped = true
+			continue
+		}
+		filtered = append(filtered, json.RawMessage(item.Raw))
+	}
+	if !dropped {
+		return body, nil
+	}
+
+	encoded, err := json.Marshal(filtered)
+	if err != nil {
+		return nil, err
+	}
+	return sjson.SetRawBytes(body, "input", encoded)
 }
 
 var grokResponsesSupportedToolTypes = map[string]struct{}{

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -161,6 +161,48 @@ func TestPatchGrokResponsesBodyDropsToolChoiceWhenNoSupportedToolsRemain(t *test
 	require.False(t, gjson.GetBytes(patched, "tool_choice").Exists())
 }
 
+func TestPatchGrokResponsesBodyDropsAdditionalToolsInputItems(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model": "grok",
+		"include": ["reasoning.encrypted_content"],
+		"input": [
+			{
+				"type": "additional_tools",
+				"role": "developer",
+				"tools": [
+					{"type": "custom", "name": "exec"},
+					{"type": "function", "name": "wait"}
+				]
+			},
+			{
+				"type": "message",
+				"role": "developer",
+				"content": [{"type": "input_text", "text": "system prompt"}]
+			},
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "hello"}]
+			}
+		]
+	}`)
+
+	patched, err := patchGrokResponsesBody(body, "grok-4.3")
+	require.NoError(t, err)
+	require.True(t, json.Valid(patched))
+	require.Equal(t, "grok-4.3", gjson.GetBytes(patched, "model").String())
+	require.Equal(t, 2, len(gjson.GetBytes(patched, "input").Array()))
+	require.False(t, gjson.GetBytes(patched, `input.#(type=="additional_tools")`).Exists())
+	require.Equal(t, "message", gjson.GetBytes(patched, "input.0.type").String())
+	require.Equal(t, "developer", gjson.GetBytes(patched, "input.0.role").String())
+	require.Equal(t, "message", gjson.GetBytes(patched, "input.1.type").String())
+	require.Equal(t, "user", gjson.GetBytes(patched, "input.1.role").String())
+	require.Equal(t, "system prompt", gjson.GetBytes(patched, "input.0.content.0.text").String())
+	require.Equal(t, "hello", gjson.GetBytes(patched, "input.1.content.0.text").String())
+}
+
 func TestBuildGrokResponsesRequestUsesAccountBaseURLAndBearerToken(t *testing.T) {
 	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
 


### PR DESCRIPTION
## Summary
- Filter Codex private `input` items with `type: "additional_tools"` before forwarding Grok `/v1/responses` requests to xAI.
- Prevents xAI deserialization failures: `data did not match any variant of untagged enum ModelInput`.
- Keeps supported message items intact and adds a regression test.

## Test plan
- [x] `gofmt` on changed files
- [x] `git diff --check`
- [ ] CI: `go test ./internal/service/ -run TestPatchGrokResponsesBodyDropsAdditionalToolsInputItems`
- [ ] Manual: Codex → Grok Responses with `additional_tools` input item should no longer 400