### PR TITLE
fix(pricing): support above-272k token rates

### DIFF
--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -141,8 +141,10 @@ type PricingRemoteClient interface {
 // LiteLLMRawEntry 用于解析原始JSON数据
 type LiteLLMRawEntry struct {
 	InputCostPerToken                   *float64 `json:"input_cost_per_token"`
+	InputCostPerTokenAbove272KTokens    *float64 `json:"input_cost_per_token_above_272k_tokens"`
 	InputCostPerTokenPriority           *float64 `json:"input_cost_per_token_priority"`
 	OutputCostPerToken                  *float64 `json:"output_cost_per_token"`
+	OutputCostPerTokenAbove272KTokens   *float64 `json:"output_cost_per_token_above_272k_tokens"`
 	OutputCostPerTokenPriority          *float64 `json:"output_cost_per_token_priority"`
 	CacheCreationInputTokenCost         *float64 `json:"cache_creation_input_token_cost"`
 	CacheCreationInputTokenCostPriority *float64 `json:"cache_creation_input_token_cost_priority"`
@@ -482,6 +484,22 @@ func (s *PricingService) parsePricingData(body []byte) (map[string]*LiteLLMModel
 		}
 		if entry.LongContextOutputCostMultiplier != nil {
 			pricing.LongContextOutputCostMultiplier = *entry.LongContextOutputCostMultiplier
+		}
+		if entry.InputCostPerTokenAbove272KTokens != nil && entry.InputCostPerToken != nil && *entry.InputCostPerToken > 0 {
+			if entry.LongContextInputTokenThreshold == nil {
+				pricing.LongContextInputTokenThreshold = openAIGPT54LongContextInputThreshold
+			}
+			if entry.LongContextInputCostMultiplier == nil {
+				pricing.LongContextInputCostMultiplier = *entry.InputCostPerTokenAbove272KTokens / *entry.InputCostPerToken
+			}
+		}
+		if entry.OutputCostPerTokenAbove272KTokens != nil && entry.OutputCostPerToken != nil && *entry.OutputCostPerToken > 0 {
+			if entry.LongContextInputTokenThreshold == nil {
+				pricing.LongContextInputTokenThreshold = openAIGPT54LongContextInputThreshold
+			}
+			if entry.LongContextOutputCostMultiplier == nil {
+				pricing.LongContextOutputCostMultiplier = *entry.OutputCostPerTokenAbove272KTokens / *entry.OutputCostPerToken
+			}
 		}
 		if entry.OutputCostPerImage != nil {
 			pricing.OutputCostPerImage = *entry.OutputCostPerImage

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -46,6 +46,39 @@ func TestParsePricingData_ParsesPriorityAndServiceTierFields(t *testing.T) {
 	require.True(t, pricing.SupportsServiceTier)
 }
 
+func TestParsePricingData_DerivesLongContextPricingFromAbove272KRates(t *testing.T) {
+	pricingSvc := &PricingService{}
+	pricingData, err := pricingSvc.parsePricingData([]byte(`{
+		"gpt-5.6-terra": {
+			"input_cost_per_token": 0.0000025,
+			"input_cost_per_token_above_272k_tokens": 0.000005,
+			"output_cost_per_token": 0.000015,
+			"output_cost_per_token_above_272k_tokens": 0.0000225,
+			"cache_creation_input_token_cost": 0.000003125,
+			"cache_creation_input_token_cost_above_272k_tokens": 0.00000625,
+			"cache_read_input_token_cost": 0.00000025,
+			"cache_read_input_token_cost_above_272k_tokens": 0.0000005
+		}
+	}`))
+	require.NoError(t, err)
+
+	pricing := pricingData["gpt-5.6-terra"]
+	require.NotNil(t, pricing)
+	require.Equal(t, 272000, pricing.LongContextInputTokenThreshold)
+	require.InDelta(t, 2.0, pricing.LongContextInputCostMultiplier, 1e-12)
+	require.InDelta(t, 1.5, pricing.LongContextOutputCostMultiplier, 1e-12)
+
+	pricingSvc.pricingData = pricingData
+	billingSvc := NewBillingService(&config.Config{}, pricingSvc)
+	tokens := UsageTokens{InputTokens: 300000, OutputTokens: 4000, CacheCreationTokens: 2000, CacheReadTokens: 3000}
+	cost, err := billingSvc.CalculateCost("gpt-5.6-terra", tokens, 1)
+	require.NoError(t, err)
+	require.InDelta(t, float64(tokens.InputTokens)*5e-6, cost.InputCost, 1e-12)
+	require.InDelta(t, float64(tokens.OutputTokens)*22.5e-6, cost.OutputCost, 1e-12)
+	require.InDelta(t, float64(tokens.CacheCreationTokens)*6.25e-6, cost.CacheCreationCost, 1e-12)
+	require.InDelta(t, float64(tokens.CacheReadTokens)*0.5e-6, cost.CacheReadCost, 1e-12)
+}
+
 func TestBillingService_GPT56CacheWritePricingUsesOfficialMultiplier(t *testing.T) {
 	tests := []struct {
 		model             string


### PR DESCRIPTION
## Summary
- derive the existing long-context pricing policy from the remote model-price repository's `*_above_272k_tokens` fields
- preserve explicit `long_context_*` values when both formats are present
- cover parsing through actual GPT-5.6 Terra input, output, cache-read, and cache-write billing

## Why

The bundled fallback price file has `long_context_*` fields, but the runtime default source at `Wei-Shaw/model-price-repo` publishes GPT-5.6 long-context prices as `input_cost_per_token_above_272k_tokens` and `output_cost_per_token_above_272k_tokens`. Those fields were ignored after a successful remote sync, so requests over 272K context were billed at short-context rates.

## Test

`go test -tags unit ./internal/service -count=1`