### PR TITLE
fix(ops): use adaptive byte units for memory usage display

### DIFF
--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -9,7 +9,7 @@ import { adminAPI } from '@/api'
 import { opsAPI, type OpsDashboardOverview, type OpsMetricThresholds, type OpsRealtimeTrafficSummary } from '@/api/admin/ops'
 import type { OpsRequestDetailsPreset } from './OpsRequestDetailsModal.vue'
 import { useAdminSettingsStore } from '@/stores'
-import { formatNumber } from '@/utils/format'
+import { formatBytes, formatNumber } from '@/utils/format'
 
 type RealtimeWindow = '1min' | '5min' | '30min' | '1h'
 
@@ -1462,7 +1462,7 @@ function handleToolbarRefresh() {
             {{
               systemMetrics?.memory_used_mb == null || systemMetrics?.memory_total_mb == null
                 ? '-'
-                : `${formatNumber(systemMetrics.memory_used_mb)} / ${formatNumber(systemMetrics.memory_total_mb)} MB`
+                : `${formatBytes(systemMetrics.memory_used_mb * 1024 * 1024, 1)} / ${formatBytes(systemMetrics.memory_total_mb * 1024 * 1024, 1)}`
             }}
           </div>
         </div>


### PR DESCRIPTION
运维仪表盘的内存卡片一直用 `formatNumber` 格式化 MB 数值，中文环境下超过一万会缩写成"万"，32G 内存的机器就显示成 `6,514 / 3.2万 MB`，中文数量级混着英文存储单位，看着很别扭。

改用项目里已有的 `formatBytes` 自动换算单位，现在显示 `6.4 GB / 32 GB`，小内存机器仍然会显示 MB。

优化前:
<img width="742" height="200" alt="image" src="https://github.com/user-attachments/assets/1de5fcae-eeb1-4521-9f03-5f51cae1cc84" />

优化后:
<img width="732" height="216" alt="image" src="https://github.com/user-attachments/assets/7dee4e28-b6d5-47ac-97d5-e3854b76f6bb" />
