### PR TITLE
fix(handler): opsCaptureWriter 释放后 nil pointer panic

### DIFF
--- a/backend/internal/handler/ops_capture_writer_nil_test.go
+++ b/backend/internal/handler/ops_capture_writer_nil_test.go
@@ -1,0 +1,36 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOpsCaptureWriter_NilInnerWriter_NoPanic(t *testing.T) {
+	w := &opsCaptureWriter{}
+	w.ResponseWriter = nil
+
+	assert.NotPanics(t, func() {
+		assert.Equal(t, 0, w.Status())
+	}, "Status() on released writer must not panic")
+
+	assert.NotPanics(t, func() {
+		assert.Equal(t, -1, w.Size())
+	}, "Size() on released writer must not panic")
+
+	assert.NotPanics(t, func() {
+		assert.False(t, w.Written())
+	}, "Written() on released writer must not panic")
+
+	assert.NotPanics(t, func() {
+		n, err := w.Write([]byte("test"))
+		assert.Equal(t, 0, n)
+		assert.NoError(t, err)
+	}, "Write() on released writer must not panic")
+
+	assert.NotPanics(t, func() {
+		n, err := w.WriteString("test")
+		assert.Equal(t, 0, n)
+		assert.NoError(t, err)
+	}, "WriteString() on released writer must not panic")
+}

--- a/backend/internal/handler/ops_capture_writer_nil_test.go
+++ b/backend/internal/handler/ops_capture_writer_nil_test.go
@@ -12,25 +12,48 @@ func TestOpsCaptureWriter_NilInnerWriter_NoPanic(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		assert.Equal(t, 0, w.Status())
-	}, "Status() on released writer must not panic")
-
+	})
 	assert.NotPanics(t, func() {
 		assert.Equal(t, -1, w.Size())
-	}, "Size() on released writer must not panic")
-
+	})
 	assert.NotPanics(t, func() {
 		assert.False(t, w.Written())
-	}, "Written() on released writer must not panic")
-
+	})
 	assert.NotPanics(t, func() {
 		n, err := w.Write([]byte("test"))
 		assert.Equal(t, 0, n)
 		assert.NoError(t, err)
-	}, "Write() on released writer must not panic")
-
+	})
 	assert.NotPanics(t, func() {
 		n, err := w.WriteString("test")
 		assert.Equal(t, 0, n)
 		assert.NoError(t, err)
-	}, "WriteString() on released writer must not panic")
+	})
+	assert.NotPanics(t, func() {
+		h := w.Header()
+		assert.NotNil(t, h)
+	})
+	assert.NotPanics(t, func() {
+		w.WriteHeader(200)
+	})
+	assert.NotPanics(t, func() {
+		w.WriteHeaderNow()
+	})
+	assert.NotPanics(t, func() {
+		w.Flush()
+	})
+	assert.NotPanics(t, func() {
+		conn, rw, err := w.Hijack()
+		assert.Nil(t, conn)
+		assert.Nil(t, rw)
+		assert.Error(t, err)
+	})
+	assert.NotPanics(t, func() {
+		ch := w.CloseNotify()
+		assert.NotNil(t, ch)
+	})
+	assert.NotPanics(t, func() {
+		p := w.Pusher()
+		assert.Nil(t, p)
+	})
 }

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -498,7 +498,31 @@ func releaseOpsCaptureWriter(w *opsCaptureWriter) {
 	opsCaptureWriterPool.Put(w)
 }
 
+func (w *opsCaptureWriter) Status() int {
+	if w.ResponseWriter == nil {
+		return 0
+	}
+	return w.ResponseWriter.Status()
+}
+
+func (w *opsCaptureWriter) Size() int {
+	if w.ResponseWriter == nil {
+		return -1
+	}
+	return w.ResponseWriter.Size()
+}
+
+func (w *opsCaptureWriter) Written() bool {
+	if w.ResponseWriter == nil {
+		return false
+	}
+	return w.ResponseWriter.Written()
+}
+
 func (w *opsCaptureWriter) Write(b []byte) (int, error) {
+	if w.ResponseWriter == nil {
+		return 0, nil
+	}
 	if w.Status() >= 400 && w.limit > 0 && w.buf.Len() < w.limit {
 		remaining := w.limit - w.buf.Len()
 		if len(b) > remaining {
@@ -511,6 +535,9 @@ func (w *opsCaptureWriter) Write(b []byte) (int, error) {
 }
 
 func (w *opsCaptureWriter) WriteString(s string) (int, error) {
+	if w.ResponseWriter == nil {
+		return 0, nil
+	}
 	if w.Status() >= 400 && w.limit > 0 && w.buf.Len() < w.limit {
 		remaining := w.limit - w.buf.Len()
 		if len(s) > remaining {

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1,11 +1,14 @@
 package handler
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"log"
+	"net"
+	"net/http"
 	"runtime"
 	"runtime/debug"
 	"strconv"
@@ -517,6 +520,57 @@ func (w *opsCaptureWriter) Written() bool {
 		return false
 	}
 	return w.ResponseWriter.Written()
+}
+
+func (w *opsCaptureWriter) Header() http.Header {
+	if w.ResponseWriter == nil {
+		return http.Header{}
+	}
+	return w.ResponseWriter.Header()
+}
+
+func (w *opsCaptureWriter) WriteHeader(code int) {
+	if w.ResponseWriter == nil {
+		return
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *opsCaptureWriter) WriteHeaderNow() {
+	if w.ResponseWriter == nil {
+		return
+	}
+	w.ResponseWriter.WriteHeaderNow()
+}
+
+func (w *opsCaptureWriter) Flush() {
+	if w.ResponseWriter == nil {
+		return
+	}
+	w.ResponseWriter.Flush()
+}
+
+func (w *opsCaptureWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if w.ResponseWriter == nil {
+		return nil, nil, errors.New("response writer released")
+	}
+	return w.ResponseWriter.Hijack()
+}
+
+func (w *opsCaptureWriter) CloseNotify() <-chan bool {
+	if w.ResponseWriter == nil {
+		ch := make(chan bool)
+		close(ch)
+		return ch
+	}
+	return w.ResponseWriter.CloseNotify()
+}
+
+func (w *opsCaptureWriter) Pusher() http.Pusher {
+	if w.ResponseWriter == nil {
+		return nil
+	}
+	return w.ResponseWriter.Pusher()
 }
 
 func (w *opsCaptureWriter) Write(b []byte) (int, error) {


### PR DESCRIPTION
## 背景

Fixes #3993，关联 #3961

v0.1.150 compact 请求失败时 logger middleware 访问已释放的 opsCaptureWriter 导致 panic。多人复现，gpt-5.6/5.5 都中。

## 根因

releaseOpsCaptureWriter 把 w.ResponseWriter 设成 nil 放回 sync.Pool，但 openAICompactKeepaliveWriter 还持有对它的引用。logger middleware 在 handler 之后执行 c.Writer.Status()，调用链穿透到 nil 接口就 panic 了。

## 修改

给 opsCaptureWriter 加了 Status()、Size()、Written() 三个 nil 守卫方法，Write/WriteString 也加了守卫。释放后再调用这些方法返回零值而不是 panic。

## 测试

```bash
go test ./internal/handler/ -run TestOpsCaptureWriter_NilInnerWriter -v  # 通过
```

5 个断言覆盖了所有 5 个可能 panic 的方法。