### PR TITLE
fix(openai): securely forward Codex attestation

### DIFF
--- a/backend/internal/handler/openai_attestation_failover_test.go
+++ b/backend/internal/handler/openai_attestation_failover_test.go
@@ -1,0 +1,195 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const testOpenAIAttestationEnvelope = `{"v":1,"s":0,"t":"v1.handler-opaque"}`
+
+func TestOpenAIResponsesAttestationStopsCrossAccountFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		name        string
+		attestation string
+		wantCalls   int
+		wantStatus  int
+	}{
+		{name: "携带证明时停止跨账号切换", attestation: testOpenAIAttestationEnvelope, wantCalls: 1, wantStatus: http.StatusTooManyRequests},
+		{name: "普通请求保持既有故障转移", wantCalls: 2, wantStatus: http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accounts := []service.Account{
+				{
+					ID:          9911,
+					Name:        "oauth-rate-limited",
+					Platform:    service.PlatformOpenAI,
+					Type:        service.AccountTypeOAuth,
+					Status:      service.StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Priority:    1,
+					Credentials: map[string]any{"access_token": "oauth-first", "chatgpt_account_id": "account-first"},
+				},
+				{
+					ID:          9912,
+					Name:        "oauth-healthy",
+					Platform:    service.PlatformOpenAI,
+					Type:        service.AccountTypeOAuth,
+					Status:      service.StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Priority:    2,
+					Credentials: map[string]any{"access_token": "oauth-second", "chatgpt_account_id": "account-second"},
+				},
+			}
+			accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: accounts}
+			upstream := &openAIAttestationFailoverHTTPUpstream{}
+			cfg := &config.Config{RunMode: config.RunModeSimple}
+			cfg.Default.RateMultiplier = 1
+			cfg.Security.URLAllowlist.Enabled = false
+			cfg.Gateway.MaxAccountSwitches = 3
+
+			rateLimitSvc := service.NewRateLimitService(accountRepo, nil, cfg, nil, nil)
+			billingCacheSvc := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+			gatewaySvc := service.NewOpenAIGatewayService(
+				accountRepo,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				cfg,
+				nil,
+				nil,
+				service.NewBillingService(cfg, nil),
+				rateLimitSvc,
+				billingCacheSvc,
+				upstream,
+				&service.DeferredService{},
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+
+			cache := &concurrencyCacheMock{
+				acquireUserSlotFn:    func(context.Context, int64, int, string) (bool, error) { return true, nil },
+				acquireAccountSlotFn: func(context.Context, int64, int, string) (bool, error) { return true, nil },
+			}
+			h := &OpenAIGatewayHandler{
+				gatewayService:      gatewaySvc,
+				billingCacheService: billingCacheSvc,
+				apiKeyService:       &service.APIKeyService{},
+				concurrencyHelper:   NewConcurrencyHelper(service.NewConcurrencyService(cache), SSEPingFormatNone, time.Second),
+				maxAccountSwitches:  3,
+			}
+
+			groupID := int64(4211)
+			apiKey := &service.APIKey{
+				ID:      1811,
+				GroupID: &groupID,
+				User:    &service.User{ID: 1711, Status: service.StatusActive},
+				Group:   &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+			}
+			router := gin.New()
+			router.Use(func(c *gin.Context) {
+				c.Set(string(middleware.ContextKeyAPIKey), apiKey)
+				c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: apiKey.User.ID, Concurrency: 1})
+				c.Next()
+			})
+			router.POST("/openai/v1/responses", h.Responses)
+
+			req := httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(`{"model":"gpt-5.1","stream":false,"input":"test"}`))
+			req.Header.Set("Content-Type", "application/json")
+			if tt.attestation != "" {
+				req.Header["X-OAI-Attestation"] = []string{tt.attestation}
+			}
+			recorder := httptest.NewRecorder()
+			router.ServeHTTP(recorder, req)
+
+			require.Equal(t, tt.wantStatus, recorder.Code)
+			require.Equal(t, tt.wantCalls, upstream.CallCount())
+			requests := upstream.Requests()
+			require.Len(t, requests, tt.wantCalls)
+			if tt.attestation != "" {
+				require.Equal(t, []string{tt.attestation}, requests[0].Header.Values("X-OAI-Attestation"))
+			} else {
+				for _, upstreamReq := range requests {
+					require.Empty(t, upstreamReq.Header.Values("X-OAI-Attestation"))
+				}
+				require.Contains(t, recorder.Body.String(), "resp_second_account")
+			}
+		})
+	}
+}
+
+type openAIAttestationFailoverHTTPUpstream struct {
+	mu       sync.Mutex
+	requests []*http.Request
+}
+
+func (u *openAIAttestationFailoverHTTPUpstream) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	u.mu.Lock()
+	cloned := req.Clone(req.Context())
+	cloned.Header = req.Header.Clone()
+	u.requests = append(u.requests, cloned)
+	call := len(u.requests)
+	u.mu.Unlock()
+
+	if call == 1 {
+		return &http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"rate_limit_exceeded","message":"rate limited"}}`)),
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"resp_second_account","object":"response","model":"gpt-5.1","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`,
+		)),
+	}, nil
+}
+
+func (u *openAIAttestationFailoverHTTPUpstream) DoWithTLS(
+	req *http.Request,
+	proxyURL string,
+	accountID int64,
+	accountConcurrency int,
+	_ *tlsfingerprint.Profile,
+) (*http.Response, error) {
+	return u.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func (u *openAIAttestationFailoverHTTPUpstream) CallCount() int {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return len(u.requests)
+}
+
+func (u *openAIAttestationFailoverHTTPUpstream) Requests() []*http.Request {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	return append([]*http.Request(nil), u.requests...)
+}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -467,6 +467,11 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 							continue
 						}
 					}
+					// 同账号同请求体重试可复用证明；切换 OAuth 账号前必须交还客户端重新生成。
+					if service.IsOpenAIAttestationForwarded(c) {
+						h.handleFailoverExhausted(c, failoverErr, streamStarted)
+						return
+					}
 					h.gatewayService.RecordOpenAIAccountSwitch()
 					failedAccountIDs[account.ID] = struct{}{}
 					lastFailoverErr = failoverErr
@@ -1694,6 +1699,11 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			if errors.As(err, &failoverErr) {
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
 				releaseAccountSlot()
+				// 新账号需要新证明；保持当前客户端连接会重放旧握手头，因此直接关闭并让客户端重连。
+				if service.IsOpenAIAttestationForwarded(c) {
+					closeOpenAIWSFailoverExhausted(wsConn, failoverErr)
+					return
+				}
 				failedAccountIDs[account.ID] = struct{}{}
 				lastFailoverErr = failoverErr
 				if switchCount >= maxAccountSwitches {

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -363,10 +363,7 @@ func (s *httpUpstreamService) getClientEntryWithTLS(proxyURL string, accountID i
 		return nil, fmt.Errorf("build TLS fingerprint transport: %w", err)
 	}
 
-	client := &http.Client{Transport: transport}
-	if s.shouldValidateResolvedIP() {
-		client.CheckRedirect = s.redirectChecker
-	}
+	client := &http.Client{Transport: transport, CheckRedirect: s.redirectChecker}
 
 	entry := &upstreamClientEntry{
 		client:   client,
@@ -413,6 +410,9 @@ func (s *httpUpstreamService) validateRequestHost(req *http.Request) error {
 }
 
 func (s *httpUpstreamService) redirectChecker(req *http.Request, via []*http.Request) error {
+	if err := service.CheckOpenAIAttestationRedirect(req, via); err != nil {
+		return err
+	}
 	if len(via) >= 10 {
 		return errors.New("stopped after 10 redirects")
 	}
@@ -515,10 +515,7 @@ func (s *httpUpstreamService) getClientEntry(proxyURL string, accountID int64, a
 		s.mu.Unlock()
 		return nil, fmt.Errorf("build transport: %w", err)
 	}
-	client := &http.Client{Transport: transport}
-	if s.shouldValidateResolvedIP() {
-		client.CheckRedirect = s.redirectChecker
-	}
+	client := &http.Client{Transport: transport, CheckRedirect: s.redirectChecker}
 	entry := &upstreamClientEntry{
 		client:       client,
 		proxyKey:     proxyKey,

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -395,6 +395,39 @@ func (s *HTTPUpstreamSuite) TestDo_WithoutProxy_GoesDirect() {
 	require.Equal(s.T(), "direct", string(b), "unexpected body")
 }
 
+// TestDo_AttestationRedirectBlocked 验证证明不会被 HTTP 重定向复制到其它目标。
+func (s *HTTPUpstreamSuite) TestDo_AttestationRedirectBlocked() {
+	var targetHits atomic.Int32
+	target := newLocalTestServer(s.T(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHits.Add(1)
+		require.Empty(s.T(), r.Header.Get("X-OAI-Attestation"))
+		_, _ = io.WriteString(w, "redirect-target")
+	}))
+	s.T().Cleanup(target.Close)
+
+	redirect := newLocalTestServer(s.T(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/final", http.StatusTemporaryRedirect)
+	}))
+	s.T().Cleanup(redirect.Close)
+
+	up := NewHTTPUpstream(s.cfg)
+	attestedReq, err := http.NewRequest(http.MethodGet, redirect.URL+"/start", nil)
+	require.NoError(s.T(), err)
+	attestedReq.Header.Set("X-OAI-Attestation", `{"v":1,"s":0,"t":"v1.opaque"}`)
+
+	resp, err := up.Do(attestedReq, "", 1, 1)
+	require.Nil(s.T(), resp)
+	require.ErrorIs(s.T(), err, service.ErrOpenAIAttestationRedirect)
+	require.Zero(s.T(), targetHits.Load(), "携带证明时不应访问重定向目标")
+
+	plainReq, err := http.NewRequest(http.MethodGet, redirect.URL+"/start", nil)
+	require.NoError(s.T(), err)
+	resp, err = up.Do(plainReq, "", 1, 1)
+	require.NoError(s.T(), err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(s.T(), int32(1), targetHits.Load(), "普通请求应保持既有重定向行为")
+}
+
 // TestDo_WithHTTPProxy_UsesProxy 测试 HTTP 代理功能
 // 验证请求通过代理服务器转发，使用绝对 URI 格式
 func (s *HTTPUpstreamSuite) TestDo_WithHTTPProxy_UsesProxy() {

--- a/backend/internal/server/middleware/recovery.go
+++ b/backend/internal/server/middleware/recovery.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -9,6 +10,7 @@ import (
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/response"
+	"github.com/Wei-Shaw/sub2api/internal/util/logredact"
 	"github.com/gin-gonic/gin"
 )
 
@@ -17,7 +19,7 @@ import (
 // It preserves Gin's broken-pipe handling by not attempting to write a response
 // when the client connection is already gone.
 func Recovery() gin.HandlerFunc {
-	return gin.CustomRecoveryWithWriter(gin.DefaultErrorWriter, func(c *gin.Context, recovered any) {
+	return gin.CustomRecoveryWithWriter(recoveryRedactingWriter{dst: gin.DefaultErrorWriter}, func(c *gin.Context, recovered any) {
 		recoveredErr, _ := recovered.(error)
 
 		if isBrokenPipe(recoveredErr) {
@@ -42,6 +44,23 @@ func Recovery() gin.HandlerFunc {
 		)
 		c.Abort()
 	})
+}
+
+type recoveryRedactingWriter struct {
+	dst io.Writer
+}
+
+func (w recoveryRedactingWriter) Write(p []byte) (int, error) {
+	if w.dst == nil {
+		return len(p), nil
+	}
+	redacted := logredact.RedactText(string(p))
+	_, err := io.WriteString(w.dst, redacted)
+	if err != nil {
+		return 0, err
+	}
+	// 返回原始长度，满足 io.Writer 在内容脱敏改写后的调用约定。
+	return len(p), nil
 }
 
 func isBrokenPipe(err error) bool {

--- a/backend/internal/server/middleware/recovery_test.go
+++ b/backend/internal/server/middleware/recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
@@ -41,6 +42,30 @@ func TestRecovery_PanicLogContainsInfo(t *testing.T) {
 	logOutput := buf.String()
 	require.Contains(t, logOutput, "custom panic message for test", "日志应包含 panic 信息")
 	require.Contains(t, logOutput, "recovery_test.go", "日志应包含堆栈跟踪文件名")
+}
+
+func TestRecovery_RedactsOpenAIAttestationHeader(t *testing.T) {
+	gin.SetMode(gin.DebugMode)
+	t.Cleanup(func() { gin.SetMode(gin.TestMode) })
+
+	var buf bytes.Buffer
+	originalWriter := gin.DefaultErrorWriter
+	gin.DefaultErrorWriter = &buf
+	t.Cleanup(func() { gin.DefaultErrorWriter = originalWriter })
+
+	r := gin.New()
+	r.Use(Recovery())
+	r.GET("/panic", func(c *gin.Context) { panic("attestation panic") })
+
+	secret := `{"v":1,"s":0,"t":"v1.recovery-secret"}`
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	req.Header.Set("X-OAI-Attestation", secret)
+	r.ServeHTTP(httptest.NewRecorder(), req)
+
+	logOutput := buf.String()
+	require.NotContains(t, logOutput, "v1.recovery-secret")
+	require.Contains(t, strings.ToLower(logOutput), "x-oai-attestation")
+	require.Contains(t, logOutput, "***")
 }
 
 func TestRecovery(t *testing.T) {

--- a/backend/internal/service/account_header_override.go
+++ b/backend/internal/service/account_header_override.go
@@ -56,6 +56,7 @@ var headerOverrideBlockedNames = map[string]struct{}{
 	"conversation_id":          {},
 	"x-codex-turn-state":       {},
 	"x-codex-turn-metadata":    {},
+	"x-oai-attestation":        {},
 	"chatgpt-account-id":       {},
 	"x-claude-code-session-id": {},
 	"x-client-request-id":      {},

--- a/backend/internal/service/account_header_override_test.go
+++ b/backend/internal/service/account_header_override_test.go
@@ -280,6 +280,7 @@ func TestNormalizeHeaderOverrideCredentials(t *testing.T) {
 			"Authorization", "x-api-key", "Host", "content-length", "Transfer-Encoding",
 			"connection", "accept-encoding", "Sec-WebSocket-Key", "session_id",
 			"conversation_id", "x-codex-turn-state", "chatgpt-account-id",
+			"x-oai-attestation",
 			"Content-Type", "Cookie", "x-goog-api-key",
 			"X-Claude-Code-Session-Id", "x-client-request-id",
 		} {

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -265,6 +265,8 @@ func safeHeaderValueForLog(key string, v string) string {
 	switch key {
 	case "authorization", "x-api-key":
 		return redactAuthHeaderValue(v)
+	case "x-oai-attestation":
+		return "[redacted]"
 	default:
 		return strings.TrimSpace(v)
 	}

--- a/backend/internal/service/openai_attestation.go
+++ b/backend/internal/service/openai_attestation.go
@@ -1,0 +1,118 @@
+package service
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	openAIAttestationHeader              = "X-OAI-Attestation"
+	openAIAttestationForwardedContextKey = "openai_attestation_forwarded"
+)
+
+// ErrOpenAIAttestationRedirect 表示携带证明的请求试图跟随重定向。
+var ErrOpenAIAttestationRedirect = errors.New("openai attestation redirect blocked")
+
+// copyOpenAIAttestationHeader 仅向 OpenAI OAuth 上游复制客户端证明头。
+// 证明内容由官方客户端生成，这里不解析、不改写，也不验证其内部结构。
+func copyOpenAIAttestationHeader(dst, src http.Header, account *Account) bool {
+	if dst == nil {
+		return false
+	}
+
+	// 先清理目标头的所有大小写形式，避免调用方此前的通用复制越过账号边界。
+	deleteHeaderAllForms(dst, openAIAttestationHeader)
+	for key := range dst {
+		if strings.EqualFold(key, openAIAttestationHeader) {
+			delete(dst, key)
+		}
+	}
+	value, ok := openAIAttestationHeaderValue(src, account)
+	if !ok {
+		return false
+	}
+
+	// 直接赋值可保持 opaque 值逐字不变，避免 Get/Trim 等读取方式改动内容。
+	dst[http.CanonicalHeaderKey(openAIAttestationHeader)] = []string{value}
+	return true
+}
+
+func openAIAttestationHeaderValue(src http.Header, account *Account) (string, bool) {
+	if src == nil || account == nil || !account.IsOpenAIOAuth() {
+		return "", false
+	}
+
+	var value string
+	valueCount := 0
+	for key, values := range src {
+		if !strings.EqualFold(key, openAIAttestationHeader) {
+			continue
+		}
+		for _, candidate := range values {
+			valueCount++
+			if valueCount > 1 {
+				return "", false
+			}
+			value = candidate
+		}
+	}
+	if valueCount != 1 || value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+func isOpenAIAttestationResponsesPath(c *gin.Context) bool {
+	if c == nil || c.Request == nil || c.Request.URL == nil {
+		return false
+	}
+	path := strings.TrimRight(strings.TrimSpace(c.Request.URL.Path), "/")
+	responsesIndex := strings.LastIndex(path, "/responses")
+	if responsesIndex < 0 {
+		return false
+	}
+	suffix := path[responsesIndex+len("/responses"):]
+	return suffix == "" || suffix == "/compact"
+}
+
+func hasOpenAIAttestationHeader(headers http.Header) bool {
+	for key, values := range headers {
+		if strings.EqualFold(key, openAIAttestationHeader) && len(values) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckOpenAIAttestationRedirect 禁止携带证明的 HTTP 或 WebSocket 握手跟随重定向。
+// 上游端点不应依赖重定向；失败关闭可避免 opaque 证明被复制到其它目标。
+func CheckOpenAIAttestationRedirect(req *http.Request, via []*http.Request) error {
+	if req != nil && hasOpenAIAttestationHeader(req.Header) {
+		return ErrOpenAIAttestationRedirect
+	}
+	for _, previous := range via {
+		if previous != nil && hasOpenAIAttestationHeader(previous.Header) {
+			return ErrOpenAIAttestationRedirect
+		}
+	}
+	return nil
+}
+
+func markOpenAIAttestationForwarded(c *gin.Context) {
+	if c != nil {
+		c.Set(openAIAttestationForwardedContextKey, true)
+	}
+}
+
+// IsOpenAIAttestationForwarded 报告当前逻辑请求是否已向 OpenAI OAuth 上游发送证明。
+func IsOpenAIAttestationForwarded(c *gin.Context) bool {
+	if c == nil {
+		return false
+	}
+	forwarded, ok := c.Get(openAIAttestationForwardedContextKey)
+	value, isBool := forwarded.(bool)
+	return ok && isBool && value
+}

--- a/backend/internal/service/openai_attestation_test.go
+++ b/backend/internal/service/openai_attestation_test.go
@@ -1,0 +1,1067 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	coderws "github.com/coder/websocket"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+const testOpenAIAttestationValue = `{"v":1,"s":0,"t":"v1.test-opaque+/=_-"}`
+
+func newOpenAIAttestationTestContext(values ...string) *gin.Context {
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	if values != nil {
+		c.Request.Header[openAIAttestationHeader] = append([]string(nil), values...)
+	}
+	return c
+}
+
+func requireNoOpenAIAttestationHeader(t *testing.T, headers http.Header) {
+	t.Helper()
+	for key := range headers {
+		require.False(t, strings.EqualFold(key, openAIAttestationHeader), "不应残留证明头：%s", key)
+	}
+}
+
+func TestCopyOpenAIAttestationHeaderScopeAndCardinality(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	oauthAccount := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	t.Run("OpenAI OAuth 保持原值", func(t *testing.T) {
+		src := http.Header{"x-oai-attestation": []string{testOpenAIAttestationValue}}
+		dst := http.Header{openAIAttestationHeader: []string{"stale"}}
+
+		require.True(t, copyOpenAIAttestationHeader(dst, src, oauthAccount))
+		require.Equal(t, []string{testOpenAIAttestationValue}, dst.Values(openAIAttestationHeader))
+	})
+
+	tests := []struct {
+		name    string
+		src     http.Header
+		account *Account
+	}{
+		{name: "缺失时省略", src: http.Header{}, account: oauthAccount},
+		{name: "空值时省略", src: http.Header{openAIAttestationHeader: []string{""}}, account: oauthAccount},
+		{name: "多值时省略", src: http.Header{openAIAttestationHeader: []string{"first", "second"}}, account: oauthAccount},
+		{name: "API Key 不透传", src: http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}}, account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}},
+		{name: "非 OpenAI OAuth 不透传", src: http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}}, account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth}},
+		{name: "空账号不透传", src: http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}}, account: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dst := http.Header{openAIAttestationHeader: []string{"stale"}}
+			require.False(t, copyOpenAIAttestationHeader(dst, tt.src, tt.account))
+			requireNoOpenAIAttestationHeader(t, dst)
+		})
+	}
+}
+
+func TestOpenAIAttestationResponsesPathScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/v1/responses", want: true},
+		{path: "/openai/v1/responses/", want: true},
+		{path: "/v1/responses/compact", want: true},
+		{path: "/openai/v1/responses/compact/detail", want: false},
+		{path: "/v1/chat/completions", want: false},
+		{path: "/v1/messages", want: false},
+		{path: "/v1/images/generations", want: false},
+		{path: "/v1/responses/resp_123", want: false},
+		{path: "/v1/responses-compat", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			c := newOpenAIAttestationTestContext()
+			c.Request.URL.Path = tt.path
+			require.Equal(t, tt.want, isOpenAIAttestationResponsesPath(c))
+		})
+	}
+}
+
+func TestOpenAIAttestationHTTPBuilders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg}
+	body := []byte(`{"model":"gpt-5"}`)
+
+	builders := []struct {
+		name  string
+		build func(*gin.Context, *Account) (*http.Request, error)
+	}{
+		{
+			name: "普通 HTTP",
+			build: func(c *gin.Context, account *Account) (*http.Request, error) {
+				return svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", false, "", true)
+			},
+		},
+		{
+			name: "passthrough",
+			build: func(c *gin.Context, account *Account) (*http.Request, error) {
+				return svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "token")
+			},
+		},
+	}
+
+	for _, builder := range builders {
+		t.Run(builder.name+"/OpenAI OAuth 原样透传", func(t *testing.T) {
+			c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+			account := &Account{
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Credentials: map[string]any{"chatgpt_account_id": "test-account"},
+			}
+
+			req, err := builder.build(c, account)
+			require.NoError(t, err)
+			require.Equal(t, []string{testOpenAIAttestationValue}, req.Header.Values(openAIAttestationHeader))
+			require.True(t, IsOpenAIAttestationForwarded(c))
+		})
+
+		t.Run(builder.name+"/API Key 隔离", func(t *testing.T) {
+			c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+			account := &Account{
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Credentials: map[string]any{"base_url": "https://example.com/v1"},
+			}
+
+			req, err := builder.build(c, account)
+			require.NoError(t, err)
+			requireNoOpenAIAttestationHeader(t, req.Header)
+			require.False(t, IsOpenAIAttestationForwarded(c))
+		})
+
+		t.Run(builder.name+"/缺失时不新增", func(t *testing.T) {
+			c := newOpenAIAttestationTestContext()
+			account := &Account{
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Credentials: map[string]any{"chatgpt_account_id": "test-account"},
+			}
+
+			req, err := builder.build(c, account)
+			require.NoError(t, err)
+			requireNoOpenAIAttestationHeader(t, req.Header)
+			require.False(t, IsOpenAIAttestationForwarded(c))
+		})
+	}
+}
+
+func TestOpenAIAttestationWebSocketHeaders(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{}
+	decision := OpenAIWSProtocolDecision{Transport: OpenAIUpstreamTransportResponsesWebsocketV2}
+
+	t.Run("OpenAI OAuth 握手原样透传", func(t *testing.T) {
+		c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+		account := &Account{
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Credentials: map[string]any{"chatgpt_account_id": "test-account"},
+		}
+
+		headers, _, err := svc.buildOpenAIWSHeaders(context.Background(), c, account, "token", decision, true, "", "", "")
+		require.NoError(t, err)
+		require.Equal(t, []string{testOpenAIAttestationValue}, headers.Values(openAIAttestationHeader))
+		require.True(t, IsOpenAIAttestationForwarded(c))
+	})
+
+	t.Run("API Key 握手隔离", func(t *testing.T) {
+		c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+		account := &Account{
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Credentials: map[string]any{"base_url": "https://example.com/v1"},
+		}
+
+		headers, _, err := svc.buildOpenAIWSHeaders(context.Background(), c, account, "token", decision, true, "", "", "")
+		require.NoError(t, err)
+		requireNoOpenAIAttestationHeader(t, headers)
+		require.False(t, IsOpenAIAttestationForwarded(c))
+	})
+}
+
+func TestOpenAIAttestationWebSocketRedirectIsBlocked(t *testing.T) {
+	var targetHits atomic.Int32
+	targetHeaders := make(chan http.Header, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHits.Add(1)
+		targetHeaders <- r.Header.Clone()
+		http.Error(w, "not a websocket", http.StatusBadRequest)
+	}))
+	defer target.Close()
+
+	redirect := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/final", http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+
+	dialer := newDefaultOpenAIWSClientDialer()
+	wsURL := "ws" + strings.TrimPrefix(redirect.URL, "http") + "/start"
+
+	attestedHeaders := http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}}
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	conn, _, _, err := dialer.Dial(ctx, wsURL, attestedHeaders, "")
+	cancel()
+	require.Nil(t, conn)
+	require.ErrorIs(t, err, ErrOpenAIAttestationRedirect)
+	require.Zero(t, targetHits.Load(), "携带证明的握手不应访问重定向目标")
+
+	ctx, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+	conn, _, _, err = dialer.Dial(ctx, wsURL, http.Header{}, "")
+	cancel()
+	require.Nil(t, conn)
+	require.Error(t, err)
+	require.Equal(t, int32(1), targetHits.Load(), "普通握手应保持既有重定向行为")
+	select {
+	case headers := <-targetHeaders:
+		requireNoOpenAIAttestationHeader(t, headers)
+	default:
+		t.Fatal("普通握手未到达重定向目标")
+	}
+}
+
+func TestOpenAIAttestationDoesNotLeakToImages(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg}
+	c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"base_url": "https://example.com/v1",
+		},
+	}
+
+	req, err := svc.buildOpenAIImagesRequest(
+		context.Background(),
+		c,
+		account,
+		[]byte(`{"model":"gpt-image-1","prompt":"test"}`),
+		"application/json",
+		"token",
+		openAIImagesGenerationsEndpoint,
+	)
+	require.NoError(t, err)
+	requireNoOpenAIAttestationHeader(t, req.Header)
+}
+
+func TestOpenAIAttestationDoesNotLeakThroughCompatibilityPaths(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{}
+	account := &Account{
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "test-account"},
+	}
+	body := []byte(`{"model":"gpt-5"}`)
+	paths := []string{
+		"/v1/chat/completions",
+		"/v1/messages",
+		"/v1/images/generations",
+	}
+
+	for _, path := range paths {
+		for _, passthrough := range []bool{false, true} {
+			name := "普通"
+			if passthrough {
+				name = "passthrough"
+			}
+			t.Run(path+"/"+name, func(t *testing.T) {
+				c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+				c.Request.URL.Path = path
+				var req *http.Request
+				var err error
+				if passthrough {
+					req, err = svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "token")
+				} else {
+					req, err = svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", false, "", true)
+				}
+				require.NoError(t, err)
+				requireNoOpenAIAttestationHeader(t, req.Header)
+				require.False(t, IsOpenAIAttestationForwarded(c))
+			})
+		}
+	}
+
+	for _, passthrough := range []bool{false, true} {
+		name := "普通"
+		if passthrough {
+			name = "passthrough"
+		}
+		t.Run("/v1/responses/消息兼容桥/"+name, func(t *testing.T) {
+			c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+			setOpenAICompatMessagesBridgeContext(c, true)
+			var req *http.Request
+			var err error
+			if passthrough {
+				req, err = svc.buildUpstreamRequestOpenAIPassthrough(c.Request.Context(), c, account, body, "token")
+			} else {
+				req, err = svc.buildUpstreamRequest(c.Request.Context(), c, account, body, "token", false, "", true)
+			}
+			require.NoError(t, err)
+			requireNoOpenAIAttestationHeader(t, req.Header)
+			require.False(t, IsOpenAIAttestationForwarded(c))
+		})
+	}
+}
+
+func TestOpenAIAttestationPassthroughBuilderAllowsNilGinContext(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg}
+	account := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	req, err := svc.buildUpstreamRequestOpenAIPassthrough(
+		context.Background(),
+		nil,
+		account,
+		[]byte(`{"model":"gpt-5"}`),
+		"token",
+	)
+	require.NoError(t, err)
+	requireNoOpenAIAttestationHeader(t, req.Header)
+}
+
+func TestOpenAIAttestationWebSocketEphemeralConnections(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+
+	pool := newOpenAIWSConnPool(cfg)
+	dialer := &openAIAttestationCaptureDialer{}
+	pool.setClientDialerForTest(dialer)
+	t.Cleanup(pool.Close)
+
+	account := &Account{ID: 701, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	values := []string{
+		testOpenAIAttestationValue,
+		`{"v":1,"s":0,"t":"v1.second-client"}`,
+	}
+	for _, value := range values {
+		requestHeaders := http.Header{}
+		requestHeaders.Set(openAIAttestationHeader, value)
+		lease, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+			Account:   account,
+			WSURL:     "wss://example.com/v1/responses",
+			Headers:   requestHeaders,
+			Ephemeral: true,
+		})
+		require.NoError(t, err)
+		require.False(t, lease.Reused())
+		inflight, _, conns := pool.AccountPoolLoad(account.ID)
+		require.Equal(t, 1, inflight)
+		require.Equal(t, 1, conns)
+
+		lease.Release()
+		inflight, _, conns = pool.AccountPoolLoad(account.ID)
+		require.Equal(t, 0, inflight)
+		require.Equal(t, 0, conns)
+	}
+
+	lease, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+		Headers: http.Header{},
+	})
+	require.NoError(t, err)
+	lease.Release()
+
+	headers, connections := dialer.snapshot()
+	require.Len(t, headers, 3)
+	require.Equal(t, []string{values[0]}, headers[0].Values(openAIAttestationHeader))
+	require.Equal(t, []string{values[1]}, headers[1].Values(openAIAttestationHeader))
+	require.Empty(t, headers[2].Values(openAIAttestationHeader))
+	require.True(t, connections[0].isClosed())
+	require.True(t, connections[1].isClosed())
+	require.False(t, connections[2].isClosed())
+
+	ap, ok := pool.getAccountPool(account.ID)
+	require.True(t, ok)
+	ap.mu.Lock()
+	require.NotNil(t, ap.lastAcquire)
+	require.Empty(t, ap.lastAcquire.Headers.Values(openAIAttestationHeader))
+	ap.mu.Unlock()
+}
+
+func TestOpenAIAttestationEphemeralFailureRestoresSharedPool(t *testing.T) {
+	tests := []struct {
+		name           string
+		waitForContext bool
+		dialErr        error
+	}{
+		{name: "拨号失败", dialErr: errors.New("attestation dial failed")},
+		{name: "请求取消", waitForContext: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+			cfg.Gateway.OpenAIWS.MinIdlePerAccount = 1
+			cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+			cfg.Gateway.OpenAIWS.PrewarmCooldownMS = 300
+
+			sharedConn := &openAIAttestationFakeConn{}
+			restoredConn := &openAIAttestationFakeConn{}
+			dialer := &openAIAttestationScriptedDialer{results: []openAIAttestationDialResult{
+				{conn: sharedConn},
+				{err: tt.dialErr, waitForContext: tt.waitForContext},
+				{conn: restoredConn},
+			}}
+			pool := newOpenAIWSConnPool(cfg)
+			pool.setClientDialerForTest(dialer)
+			t.Cleanup(pool.Close)
+
+			account := &Account{ID: 710, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+			sharedLease, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+				Account: account,
+				WSURL:   "wss://example.com/v1/responses",
+				Headers: http.Header{},
+			})
+			require.NoError(t, err)
+			sharedLease.Release()
+
+			ap, ok := pool.getAccountPool(account.ID)
+			require.True(t, ok)
+			ap.mu.Lock()
+			ap.prewarmUntil = time.Now().Add(time.Hour)
+			ap.mu.Unlock()
+
+			acquireCtx := context.Background()
+			if tt.waitForContext {
+				canceledCtx, cancel := context.WithCancel(context.Background())
+				cancel()
+				acquireCtx = canceledCtx
+			}
+			_, err = pool.Acquire(acquireCtx, openAIWSAcquireRequest{
+				Account:   account,
+				WSURL:     "wss://example.com/v1/responses",
+				Headers:   http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}},
+				Ephemeral: true,
+			})
+			require.Error(t, err)
+
+			require.Eventually(t, func() bool {
+				_, _, conns := pool.AccountPoolLoad(account.ID)
+				return conns == 1 && dialer.DialCount() == 3
+			}, 2*time.Second, 10*time.Millisecond)
+			require.True(t, sharedConn.isClosed(), "让出容量的旧共享连接应关闭")
+			require.False(t, restoredConn.isClosed(), "恢复后的共享连接应保持空闲")
+
+			ap.mu.Lock()
+			require.Zero(t, ap.prewarmFails, "临时拨号失败不应污染共享预热熔断")
+			require.NotNil(t, ap.lastAcquire)
+			requireNoOpenAIAttestationHeader(t, ap.lastAcquire.Headers)
+			ap.mu.Unlock()
+		})
+	}
+}
+
+func TestOpenAIAttestationEphemeralConcurrencyAndReleaseAreBounded(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+
+	started := make(chan struct{})
+	releaseDial := make(chan struct{})
+	sharedConn := &openAIAttestationFakeConn{}
+	ephemeralConn := &openAIAttestationFakeConn{}
+	restoredConn := &openAIAttestationFakeConn{}
+	dialer := &openAIAttestationScriptedDialer{results: []openAIAttestationDialResult{
+		{conn: sharedConn},
+		{conn: ephemeralConn, started: started, release: releaseDial},
+		{conn: restoredConn},
+	}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	t.Cleanup(pool.Close)
+
+	account := &Account{ID: 711, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	sharedLease, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+	})
+	require.NoError(t, err)
+	sharedLease.Release()
+
+	type acquireResult struct {
+		lease *openAIWSConnLease
+		err   error
+	}
+	resultCh := make(chan acquireResult, 1)
+	go func() {
+		lease, acquireErr := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+			Account:   account,
+			WSURL:     "wss://example.com/v1/responses",
+			Headers:   http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}},
+			Ephemeral: true,
+		})
+		resultCh <- acquireResult{lease: lease, err: acquireErr}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("等待临时连接拨号开始超时")
+	}
+	_, err = pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account:   account,
+		WSURL:     "wss://example.com/v1/responses",
+		Headers:   http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}},
+		Ephemeral: true,
+	})
+	require.ErrorIs(t, err, errOpenAIWSConnQueueFull)
+	require.Equal(t, 2, dialer.DialCount(), "超过账号上限时不应继续拨号")
+
+	close(releaseDial)
+	var first acquireResult
+	select {
+	case first = <-resultCh:
+		require.NoError(t, first.err)
+		require.NotNil(t, first.lease)
+	case <-time.After(2 * time.Second):
+		t.Fatal("等待临时连接获取完成超时")
+	}
+	first.lease.MarkBroken()
+	first.lease.Release()
+	first.lease.Release()
+
+	require.Eventually(t, func() bool {
+		_, _, conns := pool.AccountPoolLoad(account.ID)
+		return conns == 1 && dialer.DialCount() == 3
+	}, 2*time.Second, 10*time.Millisecond)
+	require.True(t, sharedConn.isClosed())
+	require.True(t, ephemeralConn.isClosed())
+	require.False(t, restoredConn.isClosed())
+}
+
+func TestOpenAIAttestationEphemeralReleaseAfterCloseDoesNotPrewarm(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+
+	sharedConn := &openAIAttestationFakeConn{}
+	ephemeralConn := &openAIAttestationFakeConn{}
+	dialer := &openAIAttestationScriptedDialer{results: []openAIAttestationDialResult{
+		{conn: sharedConn},
+		{conn: ephemeralConn},
+		{conn: &openAIAttestationFakeConn{}},
+	}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+
+	account := &Account{ID: 712, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	sharedLease, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+	})
+	require.NoError(t, err)
+	sharedLease.Release()
+
+	ephemeralLease, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account:   account,
+		WSURL:     "wss://example.com/v1/responses",
+		Headers:   http.Header{openAIAttestationHeader: []string{testOpenAIAttestationValue}},
+		Ephemeral: true,
+	})
+	require.NoError(t, err)
+	pool.Close()
+	ephemeralLease.Release()
+	ephemeralLease.Release()
+
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, 2, dialer.DialCount(), "连接池关闭后不应重新预热")
+	_, _, conns := pool.AccountPoolLoad(account.ID)
+	require.Zero(t, conns)
+	require.True(t, sharedConn.isClosed())
+	require.True(t, ephemeralConn.isClosed())
+}
+
+func TestOpenAIAttestationWebSocketIngressOverridesHTTPBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.IngressModeDefault = OpenAIWSIngressModeCtxPool
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	upstreamConn := &openAIWSCaptureConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.completed","response":{"id":"resp_attestation_ws","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		},
+	}
+	dialer := &openAIWSCaptureDialer{conn: upstreamConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	t.Cleanup(pool.Close)
+
+	httpUpstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_unexpected_http_bridge\"}}\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     httpUpstream,
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	stateStore := NewOpenAIWSStateStore(&stubGatewayCache{})
+	svc.openaiWSStateStore = stateStore
+	account := &Account{
+		ID:          702,
+		Name:        "oauth-attestation-http-bridge",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "test-account",
+		},
+		Extra: map[string]any{
+			"openai_oauth_responses_websockets_v2_mode": OpenAIWSIngressModeHTTPBridge,
+		},
+	}
+
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		recorder := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(recorder)
+		req := r.Clone(r.Context())
+		req.Header = req.Header.Clone()
+		ginCtx.Request = req
+
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		_, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(
+			r.Context(),
+			ginCtx,
+			conn,
+			account,
+			"oauth-token",
+			firstMessage,
+			nil,
+		)
+	}))
+	defer wsServer.Close()
+
+	clientHeaders := http.Header{"User-Agent": []string{"codex_cli_rs/0.98.0"}}
+	clientHeaders[openAIAttestationHeader] = []string{testOpenAIAttestationValue}
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(
+		dialCtx,
+		"ws"+strings.TrimPrefix(wsServer.URL, "http"),
+		&coderws.DialOptions{
+			HTTPHeader:      clientHeaders,
+			CompressionMode: coderws.CompressionContextTakeover,
+		},
+	)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(
+		writeCtx,
+		coderws.MessageText,
+		[]byte(`{"type":"response.create","model":"gpt-5.1","stream":false}`),
+	)
+	cancelWrite()
+	require.NoError(t, err)
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	messageType, event, readErr := clientConn.Read(readCtx)
+	cancelRead()
+	require.NoError(t, readErr)
+	require.Equal(t, coderws.MessageText, messageType)
+	require.Equal(t, "resp_attestation_ws", gjson.GetBytes(event, "response.id").String())
+
+	inflight, _, activeConns := pool.AccountPoolLoad(account.ID)
+	require.Equal(t, 1, inflight)
+	require.Equal(t, 1, activeConns)
+
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
+	select {
+	case serverErr := <-serverErrCh:
+		if serverErr != nil {
+			require.Contains(t, serverErr.Error(), "StatusNormalClosure")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待 attestation websocket 会话结束超时")
+	}
+
+	dialer.mu.Lock()
+	handshakeHeaders := cloneHeader(dialer.lastHeaders)
+	dialer.mu.Unlock()
+	require.Equal(t, 1, dialer.DialCount())
+	require.Equal(t, []string{testOpenAIAttestationValue}, handshakeHeaders.Values(openAIAttestationHeader))
+	require.Nil(t, httpUpstream.lastReq, "携带证明时不应进入 HTTP bridge")
+
+	_, _, remainingConns := pool.AccountPoolLoad(account.ID)
+	require.Zero(t, remainingConns, "会话结束后不应残留临时连接")
+	upstreamConn.mu.Lock()
+	writeCount := len(upstreamConn.writes)
+	closed := upstreamConn.closed
+	upstreamConn.mu.Unlock()
+	require.Equal(t, 1, writeCount)
+	require.True(t, closed)
+	_, bound := stateStore.GetResponseConn("resp_attestation_ws")
+	require.False(t, bound, "临时连接不应写入 response 到 conn 的粘性映射")
+}
+
+func TestOpenAIAttestationDisablesInternalWebSocketReconnect(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+
+	firstConn := &openAIWSCaptureConn{}
+	secondConn := &openAIWSCaptureConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.completed","response":{"id":"unexpected_retry","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		},
+	}
+	dialer := &openAIWSQueueDialer{conns: []openAIWSClientConn{firstConn, secondConn}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	t.Cleanup(pool.Close)
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          703,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "test-account",
+		},
+		Extra: map[string]any{"responses_websockets_v2_enabled": true},
+	}
+	c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+	c.Request.URL.Path = "/openai/v1/responses"
+
+	result, err := svc.Forward(
+		context.Background(),
+		c,
+		account,
+		[]byte(`{"model":"gpt-5.1","stream":false,"input":"test"}`),
+	)
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Equal(t, 1, dialer.DialCount(), "新握手需要新证明，不应复用入站证明自动重连")
+}
+
+func TestOpenAIAttestationWebSocketV2DoesNotBindEphemeralConn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+
+	upstreamConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_attestation_v2","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	dialer := &openAIWSCaptureDialer{conn: upstreamConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	t.Cleanup(pool.Close)
+	stateStore := NewOpenAIWSStateStore(&stubGatewayCache{})
+	svc := &OpenAIGatewayService{
+		cfg:                cfg,
+		httpUpstream:       &httpUpstreamRecorder{},
+		cache:              &stubGatewayCache{},
+		openaiWSResolver:   NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:      NewCodexToolCorrector(),
+		openaiWSPool:       pool,
+		openaiWSStateStore: stateStore,
+	}
+	account := &Account{
+		ID:          713,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "test-account",
+		},
+		Extra: map[string]any{"responses_websockets_v2_enabled": true},
+	}
+	c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+	c.Request.URL.Path = "/openai/v1/responses"
+	body := []byte(`{"model":"gpt-5.1","stream":false,"store":false,"prompt_cache_key":"attestation-sticky-test","input":"test"}`)
+
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "resp_attestation_v2", result.RequestID)
+	_, bound := stateStore.GetResponseConn("resp_attestation_v2")
+	require.False(t, bound, "临时连接不应写入 response 到 conn 的粘性映射")
+	sessionHash, _ := openAIWSSessionHashesFromID("attestation-sticky-test")
+	_, bound = stateStore.GetSessionConn(getOpenAIGroupIDFromContext(c), sessionHash)
+	require.False(t, bound, "临时连接不应写入 session 到 conn 的粘性映射")
+	_, _, conns := pool.AccountPoolLoad(account.ID)
+	require.Zero(t, conns)
+	upstreamConn.mu.Lock()
+	closed := upstreamConn.closed
+	upstreamConn.mu.Unlock()
+	require.True(t, closed)
+}
+
+func TestOpenAIAttestationDisablesBodyMutatingHTTPRetry(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	upstream := &httpUpstreamRecorder{
+		responses: []*http.Response{
+			{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"error":{"code":"invalid_encrypted_content","type":"invalid_request_error","message":"bad encrypted content"}}`,
+				)),
+			},
+			{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":1}}`)),
+			},
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{
+		cfg:           cfg,
+		httpUpstream:  upstream,
+		cache:         &stubGatewayCache{},
+		toolCorrector: NewCodexToolCorrector(),
+	}
+	account := &Account{
+		ID:          704,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "test-account",
+		},
+	}
+	c := newOpenAIAttestationTestContext(testOpenAIAttestationValue)
+	c.Request.URL.Path = "/openai/v1/responses"
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+	body := []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"reasoning","encrypted_content":"gAAA"},{"type":"input_text","text":"hello"}]}`)
+
+	_, _ = svc.Forward(context.Background(), c, account, body)
+	require.Len(t, upstream.requests, 1, "修改请求体后的重试需要新证明，应交还客户端重新发起")
+}
+
+func TestOpenAIAttestationIsRedacted(t *testing.T) {
+	require.Equal(t, "[redacted]", safeHeaderValueForLog(openAIAttestationHeader, testOpenAIAttestationValue))
+	require.True(t, isSensitiveKey(openAIAttestationHeader))
+}
+
+func TestOpenAIAttestationHeaderOverrideDirtyDataIsIgnored(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			credKeyHeaderOverrideEnabled: true,
+			credKeyHeaderOverrides: map[string]any{
+				openAIAttestationHeader: testOpenAIAttestationValue,
+			},
+		},
+	}
+
+	require.Empty(t, account.GetHeaderOverrides())
+	headers := http.Header{}
+	account.ApplyHeaderOverrides(headers)
+	requireNoOpenAIAttestationHeader(t, headers)
+}
+
+type openAIAttestationCaptureDialer struct {
+	mu          sync.Mutex
+	headers     []http.Header
+	connections []*openAIAttestationFakeConn
+}
+
+type openAIAttestationDialResult struct {
+	conn           openAIWSClientConn
+	err            error
+	waitForContext bool
+	started        chan struct{}
+	release        <-chan struct{}
+}
+
+type openAIAttestationScriptedDialer struct {
+	mu        sync.Mutex
+	results   []openAIAttestationDialResult
+	dialCount int
+}
+
+func (d *openAIAttestationScriptedDialer) Dial(
+	ctx context.Context,
+	_ string,
+	_ http.Header,
+	_ string,
+) (openAIWSClientConn, int, http.Header, error) {
+	d.mu.Lock()
+	d.dialCount++
+	if len(d.results) == 0 {
+		d.mu.Unlock()
+		return nil, http.StatusServiceUnavailable, nil, errors.New("no scripted dial result")
+	}
+	result := d.results[0]
+	d.results = d.results[1:]
+	d.mu.Unlock()
+
+	if result.started != nil {
+		close(result.started)
+	}
+	if result.waitForContext {
+		<-ctx.Done()
+		return nil, http.StatusServiceUnavailable, nil, ctx.Err()
+	}
+	if result.release != nil {
+		select {
+		case <-result.release:
+		case <-ctx.Done():
+			return nil, http.StatusServiceUnavailable, nil, ctx.Err()
+		}
+	}
+	if result.err != nil {
+		return nil, http.StatusServiceUnavailable, nil, result.err
+	}
+	return result.conn, 0, nil, nil
+}
+
+func (d *openAIAttestationScriptedDialer) DialCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dialCount
+}
+
+func (d *openAIAttestationCaptureDialer) Dial(
+	_ context.Context,
+	_ string,
+	headers http.Header,
+	_ string,
+) (openAIWSClientConn, int, http.Header, error) {
+	conn := &openAIAttestationFakeConn{}
+	d.mu.Lock()
+	d.headers = append(d.headers, cloneHeader(headers))
+	d.connections = append(d.connections, conn)
+	d.mu.Unlock()
+	return conn, 0, nil, nil
+}
+
+func (d *openAIAttestationCaptureDialer) snapshot() ([]http.Header, []*openAIAttestationFakeConn) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	headers := make([]http.Header, len(d.headers))
+	for i := range d.headers {
+		headers[i] = cloneHeader(d.headers[i])
+	}
+	return headers, append([]*openAIAttestationFakeConn(nil), d.connections...)
+}
+
+type openAIAttestationFakeConn struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (c *openAIAttestationFakeConn) WriteJSON(context.Context, any) error { return nil }
+
+func (c *openAIAttestationFakeConn) ReadMessage(context.Context) ([]byte, error) { return nil, nil }
+
+func (c *openAIAttestationFakeConn) Ping(context.Context) error { return nil }
+
+func (c *openAIAttestationFakeConn) Close() error {
+	c.mu.Lock()
+	c.closed = true
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *openAIAttestationFakeConn) isClosed() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.closed
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -577,6 +577,15 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			if c != nil && c.Writer != nil && c.Writer.Written() {
 				break
 			}
+			// 新 WS 握手需要新证明；代理不能代客户端重新生成，因此交还客户端重试。
+			if IsOpenAIAttestationForwarded(c) {
+				logOpenAIWSModeInfo(
+					"reconnect_stop account_id=%d attempt=%d reason=attestation_requires_fresh_handshake",
+					account.ID,
+					attempt,
+				)
+				break
+			}
 
 			reason, retryable := classifyOpenAIWSReconnectReason(wsErr)
 			if reason != "" {
@@ -718,7 +727,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 			upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 			upstreamCode := extractUpstreamErrorCode(respBody)
-			if !httpInvalidEncryptedContentRetryTried && resp.StatusCode == http.StatusBadRequest && upstreamCode == "invalid_encrypted_content" {
+			if !IsOpenAIAttestationForwarded(c) && !httpInvalidEncryptedContentRetryTried && resp.StatusCode == http.StatusBadRequest && upstreamCode == "invalid_encrypted_content" {
 				decoded, decodeErr := ensureReqBody()
 				if decodeErr != nil {
 					return nil, decodeErr
@@ -889,8 +898,11 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 			}
 		}
 	}
+	compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
+	if isOpenAIAttestationResponsesPath(c) && !compatMessagesBridge && copyOpenAIAttestationHeader(req.Header, c.Request.Header, account) {
+		markOpenAIAttestationForwarded(c)
+	}
 	if account.Type == AccountTypeOAuth {
-		compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
 		// 清除客户端透传的 session 头，后续用隔离后的值重新设置，防止跨用户会话碰撞。
 		clientConversationID := strings.TrimSpace(req.Header.Get("conversation_id"))
 		req.Header.Del("conversation_id")

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -333,6 +333,10 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 			}
 		}
 	}
+	compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
+	if c != nil && c.Request != nil && isOpenAIAttestationResponsesPath(c) && !compatMessagesBridge && copyOpenAIAttestationHeader(req.Header, c.Request.Header, account) {
+		markOpenAIAttestationForwarded(c)
+	}
 
 	// 覆盖入站鉴权残留，并注入上游认证
 	req.Header.Del("authorization")

--- a/backend/internal/service/openai_ws_client.go
+++ b/backend/internal/service/openai_ws_client.go
@@ -95,6 +95,9 @@ func (d *coderOpenAIWSClientDialer) Dial(
 		}
 		opts.HTTPClient = proxyClient
 	}
+	if hasOpenAIAttestationHeader(opts.HTTPHeader) {
+		opts.HTTPClient = openAIAttestationRedirectSafeClient(opts.HTTPClient)
+	}
 
 	conn, resp, err := coderws.Dial(ctx, targetURL, opts)
 	if err != nil {
@@ -114,6 +117,24 @@ func (d *coderOpenAIWSClientDialer) Dial(
 		respHeaders = cloneHeader(resp.Header)
 	}
 	return &coderOpenAIWSClientConn{conn: conn}, 0, respHeaders, nil
+}
+
+func openAIAttestationRedirectSafeClient(base *http.Client) *http.Client {
+	if base == nil {
+		base = http.DefaultClient
+	}
+	guarded := *base
+	previousCheck := base.CheckRedirect
+	guarded.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if err := CheckOpenAIAttestationRedirect(req, via); err != nil {
+			return err
+		}
+		if previousCheck != nil {
+			return previousCheck(req, via)
+		}
+		return nil
+	}
+	return &guarded
 }
 
 func (d *coderOpenAIWSClientDialer) proxyHTTPClient(proxy string) (*http.Client, error) {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -60,6 +60,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 
 	wsDecision := s.getOpenAIWSProtocolResolver().Resolve(account)
+	_, attestationRequested := openAIAttestationHeaderValue(c.Request.Header, account)
 	forceHTTPBridge := account.Platform == PlatformGrok
 	modeRouterV2Enabled := s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIWS.ModeRouterV2Enabled
 	ingressMode := OpenAIWSIngressModeCtxPool
@@ -88,7 +89,17 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 				wsDecision,
 			)
 		case OpenAIWSIngressModeHTTPBridge:
-			forceHTTPBridge = true
+			if attestationRequested {
+				ingressMode = OpenAIWSIngressModeCtxPool
+				if wsDecision.Reason == "ws_v2_mode_http_bridge" && s.cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 {
+					wsDecision = OpenAIWSProtocolDecision{
+						Transport: OpenAIUpstreamTransportResponsesWebsocketV2,
+						Reason:    "attestation_requires_ws_v2",
+					}
+				}
+			} else {
+				forceHTTPBridge = true
+			}
 		case OpenAIWSIngressModeCtxPool, OpenAIWSIngressModeShared, OpenAIWSIngressModeDedicated:
 			// continue
 		default:
@@ -432,7 +443,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 	refreshIngressRouteState(firstPayload)
 
-	if forceHTTPBridge || s.shouldBridgeOpenAIWSHTTP(account, firstPayload.payloadBytes, firstPayload.previousResponseID) {
+	if !attestationRequested && (forceHTTPBridge || s.shouldBridgeOpenAIWSHTTP(account, firstPayload.payloadBytes, firstPayload.previousResponseID)) {
 		logOpenAIWSModeInfo(
 			"ingress_ws_http_bridge_start account_id=%d account_type=%s payload_bytes=%d threshold_bytes=%d has_session_hash=%v store_disabled=%v",
 			account.ID,
@@ -569,17 +580,19 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	if buildHdrErr != nil {
 		return fmt.Errorf("build ws headers: %w", buildHdrErr)
 	}
+	attestationForwarded := account.IsOpenAIOAuth() && hasOpenAIAttestationHeader(wsHeaders)
 	baseAcquireReq := openAIWSAcquireRequest{
-		Account: account,
-		WSURL:   wsURL,
-		Headers: wsHeaders,
+		Account:   account,
+		WSURL:     wsURL,
+		Headers:   wsHeaders,
+		Ephemeral: attestationForwarded,
 		ProxyURL: func() string {
 			if account.ProxyID != nil && account.Proxy != nil {
 				return account.Proxy.URL()
 			}
 			return ""
 		}(),
-		ForceNewConn: false,
+		ForceNewConn: attestationForwarded,
 	}
 	pool := s.getOpenAIWSConnPool()
 	if pool == nil {
@@ -641,7 +654,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		req.PreferredConnID = strings.TrimSpace(preferred)
 		req.ForcePreferredConn = forcePreferredConn
 		// dedicated 模式下每次获取均新建连接，避免跨会话复用残留上下文。
-		req.ForceNewConn = dedicatedMode
+		req.ForceNewConn = dedicatedMode || attestationForwarded
 		acquireCtx, acquireCancel := context.WithTimeout(ctx, acquireTimeout)
 		lease, acquireErr := pool.Acquire(acquireCtx, req)
 		acquireCancel()
@@ -1073,6 +1086,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if !isOpenAIWSIngressPreviousResponseNotFound(relayErr) {
 			return false
 		}
+		if attestationForwarded {
+			return false
+		}
 		if turnPrevRecoveryTried || !s.openAIWSIngressPreviousResponseRecoveryEnabled() {
 			return false
 		}
@@ -1138,6 +1154,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 	retryIngressTurn := func(relayErr error, turn int, connID string) bool {
 		if !isOpenAIWSIngressTurnRetryable(relayErr) || turnRetry >= 1 {
+			return false
+		}
+		if attestationForwarded {
 			return false
 		}
 		if isStrictAffinityTurn(currentPayload) {
@@ -1355,6 +1374,13 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 					truncateOpenAIWSLogValue(sessionConnID, openAIWSIDValueMaxLen),
 					truncateOpenAIWSLogValue(pingErr.Error(), openAIWSLogValueMaxLen),
 				)
+				if attestationForwarded {
+					return NewOpenAIWSClientCloseError(
+						coderws.StatusTryAgainLater,
+						"upstream websocket reconnect requires fresh attestation",
+						pingErr,
+					)
+				}
 				if forcePreferredConn {
 					// 携带 function_call_output 的请求不能丢弃 previous_response_id：
 					// 上游 API 需要 response chain 来匹配 tool_result 与之前的 tool_use，
@@ -1525,9 +1551,11 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		if responseID != "" && stateStore != nil {
 			ttl := s.openAIWSResponseStickyTTL()
 			logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
-			stateStore.BindResponseConn(responseID, connID, ttl)
+			if !attestationForwarded {
+				stateStore.BindResponseConn(responseID, connID, ttl)
+			}
 		}
-		if stateStore != nil && storeDisabled && sessionHash != "" {
+		if stateStore != nil && storeDisabled && sessionHash != "" && !attestationForwarded {
 			stateStore.BindSessionConn(groupID, sessionHash, connID, s.openAIWSSessionStickyTTL())
 		}
 		if connID != "" {

--- a/backend/internal/service/openai_ws_forwarder_payload.go
+++ b/backend/internal/service/openai_ws_forwarder_payload.go
@@ -79,6 +79,9 @@ func (s *OpenAIGatewayService) buildOpenAIWSHeaders(
 				headers.Add("x-codex-beta-features", value)
 			}
 		}
+		if copyOpenAIAttestationHeader(headers, c.Request.Header, account) {
+			markOpenAIAttestationForwarded(c)
+		}
 	}
 	// OAuth 账号：将 apiKeyID 混入 session 标识符，防止跨用户会话碰撞。
 	if account != nil && account.Type == AccountTypeOAuth {

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -133,11 +133,13 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	}
 	storeDisabledConnMode := s.openAIWSStoreDisabledConnMode()
 	forceNewConnByPolicy := shouldForceNewConnOnStoreDisabled(storeDisabledConnMode, lastFailureReason)
-	forceNewConn := forceNewConnByPolicy && storeDisabled && previousResponseID == "" && sessionHash != "" && preferredConnID == ""
 	wsHeaders, sessionResolution, buildHdrErr := s.buildOpenAIWSHeaders(ctx, c, account, token, decision, isCodexCLI, turnState, turnMetadata, promptCacheKey)
 	if buildHdrErr != nil {
 		return nil, fmt.Errorf("build ws headers: %w", buildHdrErr)
 	}
+	// 证明绑定当前握手：禁止复用旧连接，也不让带证明连接进入共享池或后台预热。
+	attestationForwarded := account.IsOpenAIOAuth() && hasOpenAIAttestationHeader(wsHeaders)
+	forceNewConn := attestationForwarded || (forceNewConnByPolicy && storeDisabled && previousResponseID == "" && sessionHash != "" && preferredConnID == "")
 	logOpenAIWSModeDebug(
 		"acquire_start account_id=%d account_type=%s transport=%s preferred_conn_id=%s has_previous_response_id=%v session_hash=%s has_turn_state=%v turn_state_len=%d has_turn_metadata=%v turn_metadata_len=%d store_disabled=%v store_disabled_conn_mode=%s retry_last_reason=%s force_new_conn=%v header_user_agent=%s header_openai_beta=%s header_originator=%s header_accept_language=%s header_session_id=%s header_conversation_id=%s session_id_source=%s conversation_id_source=%s has_prompt_cache_key=%v has_chatgpt_account_id=%v has_authorization=%v has_session_id=%v has_conversation_id=%v proxy_enabled=%v",
 		account.ID,
@@ -179,6 +181,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		Headers:         wsHeaders,
 		PreferredConnID: preferredConnID,
 		ForceNewConn:    forceNewConn,
+		Ephemeral:       attestationForwarded,
 		ProxyURL: func() string {
 			if account.ProxyID != nil && account.Proxy != nil {
 				return account.Proxy.URL()
@@ -656,9 +659,11 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	if responseID != "" && stateStore != nil {
 		ttl := s.openAIWSResponseStickyTTL()
 		logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
-		stateStore.BindResponseConn(responseID, lease.ConnID(), ttl)
+		if !attestationForwarded {
+			stateStore.BindResponseConn(responseID, lease.ConnID(), ttl)
+		}
 	}
-	if stateStore != nil && storeDisabled && sessionHash != "" {
+	if stateStore != nil && storeDisabled && sessionHash != "" && !attestationForwarded {
 		stateStore.BindSessionConn(groupID, sessionHash, lease.ConnID(), s.openAIWSSessionStickyTTL())
 	}
 	firstTokenMsValue := -1

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -67,6 +67,8 @@ type openAIWSAcquireRequest struct {
 	PreferredConnID string
 	// ForceNewConn: 强制本次获取新连接（避免复用导致连接内续链状态互相污染）。
 	ForceNewConn bool
+	// Ephemeral: 连接不进入共享池、不参与预热，并在租约释放时关闭。
+	Ephemeral bool
 	// ForcePreferredConn: 强制本次只使用 PreferredConnID，禁止漂移到其它连接。
 	ForcePreferredConn bool
 }
@@ -78,6 +80,7 @@ type openAIWSConnLease struct {
 	queueWait time.Duration
 	connPick  time.Duration
 	reused    bool
+	ephemeral bool
 	released  atomic.Bool
 }
 
@@ -212,7 +215,14 @@ func (l *openAIWSConnLease) SupportsIdlePingWithoutReader() bool {
 }
 
 func (l *openAIWSConnLease) MarkBroken() {
-	if l == nil || l.pool == nil || l.conn == nil || l.released.Load() {
+	if l == nil || l.conn == nil || l.released.Load() {
+		return
+	}
+	if l.ephemeral {
+		l.conn.close()
+		return
+	}
+	if l.pool == nil {
 		return
 	}
 	l.pool.evictConn(l.accountID, l.conn.id)
@@ -223,6 +233,14 @@ func (l *openAIWSConnLease) Release() {
 		return
 	}
 	if !l.released.CompareAndSwap(false, true) {
+		return
+	}
+	if l.ephemeral {
+		if l.pool != nil {
+			l.pool.releaseEphemeralConn(l.accountID, l.conn)
+		} else {
+			l.conn.close()
+		}
 		return
 	}
 	l.conn.release()
@@ -544,6 +562,7 @@ type openAIWSAccountPool struct {
 	pinnedConns   map[string]int
 	changedCh     chan struct{}
 	creating      int
+	ephemeral     int
 	lastCleanupAt time.Time
 	lastAcquire   *openAIWSAcquireRequest
 	prewarmActive bool
@@ -606,6 +625,7 @@ type openAIWSConnPool struct {
 	workerStopCh chan struct{}
 	workerWg     sync.WaitGroup
 	closeOnce    sync.Once
+	lifecycleMu  sync.RWMutex
 }
 
 func newOpenAIWSConnPool(cfg *config.Config) *openAIWSConnPool {
@@ -658,6 +678,8 @@ func (p *openAIWSConnPool) Close() {
 		return
 	}
 	p.closeOnce.Do(func() {
+		p.lifecycleMu.Lock()
+		defer p.lifecycleMu.Unlock()
 		if p.workerStopCh != nil {
 			close(p.workerStopCh)
 		}
@@ -826,6 +848,9 @@ func (p *openAIWSConnPool) acquire(ctx context.Context, req openAIWSAcquireReque
 	if p == nil || req.Account == nil || req.Account.ID <= 0 {
 		return nil, errors.New("invalid ws acquire request")
 	}
+	if p.isClosed() {
+		return nil, errOpenAIWSConnClosed
+	}
 	if stringsTrim(req.WSURL) == "" {
 		return nil, errors.New("ws url is empty")
 	}
@@ -840,14 +865,16 @@ retryAcquire:
 	var evicted []*openAIWSConn
 	ap := p.getOrCreateAccountPool(accountID)
 	ap.mu.Lock()
-	ap.lastAcquire = cloneOpenAIWSAcquireRequestPtr(&req)
+	if !req.Ephemeral {
+		ap.lastAcquire = cloneOpenAIWSAcquireRequestPtr(&req)
+	}
 	now := time.Now()
 	if ap.lastCleanupAt.IsZero() || now.Sub(ap.lastCleanupAt) >= openAIWSAcquireCleanupInterval {
 		evicted = p.cleanupAccountLocked(ap, now, effectiveMaxConns)
 		ap.lastCleanupAt = now
 	}
 	pickStartedAt := time.Now()
-	allowReuse := !req.ForceNewConn
+	allowReuse := !req.ForceNewConn && !req.Ephemeral
 	preferredConnID := stringsTrim(req.PreferredConnID)
 	forcePreferredConn := allowReuse && req.ForcePreferredConn
 
@@ -1011,7 +1038,7 @@ retryAcquire:
 		}
 	}
 
-	if !req.ForceNewConn && len(ap.conns)+ap.creating >= effectiveMaxConns {
+	if !req.ForceNewConn && !req.Ephemeral && len(ap.conns)+ap.creating+ap.ephemeral >= effectiveMaxConns {
 		compatible := p.pickLeastBusyConnLocked(ap, "", betaFeatures)
 		if idle := p.pickOldestIdleConnWithDifferentBetaFeaturesLocked(ap, betaFeatures); idle != nil {
 			delete(ap.conns, idle.id)
@@ -1025,7 +1052,7 @@ retryAcquire:
 					break
 				}
 			}
-			if !hasConnection && ap.creating == 0 {
+			if !hasConnection && ap.creating == 0 && ap.ephemeral == 0 {
 				ap.mu.Unlock()
 				closeOpenAIWSConns(evicted)
 				return nil, errOpenAIWSConnClosed
@@ -1042,7 +1069,7 @@ retryAcquire:
 		}
 	}
 
-	if req.ForceNewConn && len(ap.conns)+ap.creating >= effectiveMaxConns {
+	if (req.ForceNewConn || req.Ephemeral) && len(ap.conns)+ap.creating+ap.ephemeral >= effectiveMaxConns {
 		if idle := p.pickOldestIdleConnLocked(ap); idle != nil {
 			delete(ap.conns, idle.id)
 			evicted = append(evicted, idle)
@@ -1050,7 +1077,7 @@ retryAcquire:
 		}
 	}
 
-	if len(ap.conns)+ap.creating < effectiveMaxConns {
+	if len(ap.conns)+ap.creating+ap.ephemeral < effectiveMaxConns {
 		connPick := time.Since(pickStartedAt)
 		p.recordConnPickDuration(connPick)
 		ap.creating++
@@ -1059,35 +1086,67 @@ retryAcquire:
 
 		conn, dialErr := p.dialConn(ctx, req)
 
+		p.lifecycleMu.RLock()
 		ap = p.getOrCreateAccountPool(accountID)
 		ap.mu.Lock()
 		ap.creating--
-		if dialErr != nil {
-			ap.prewarmFails++
-			ap.prewarmFailAt = time.Now()
+		if p.isClosed() {
 			ap.signalChangedLocked()
 			ap.mu.Unlock()
+			p.lifecycleMu.RUnlock()
+			if conn != nil {
+				conn.close()
+			}
+			return nil, errOpenAIWSConnClosed
+		}
+		if dialErr != nil {
+			if !req.Ephemeral {
+				ap.prewarmFails++
+				ap.prewarmFailAt = time.Now()
+			}
+			ap.signalChangedLocked()
+			ap.mu.Unlock()
+			p.lifecycleMu.RUnlock()
+			if req.Ephemeral {
+				p.restoreSharedPoolAfterEphemeral(accountID)
+			}
 			return nil, dialErr
 		}
-		ap.conns[conn.id] = conn
-		ap.prewarmFails = 0
-		ap.prewarmFailAt = time.Time{}
+		if req.Ephemeral {
+			ap.ephemeral++
+		} else {
+			ap.conns[conn.id] = conn
+		}
+		if !req.Ephemeral {
+			ap.prewarmFails = 0
+			ap.prewarmFailAt = time.Time{}
+		}
+		ap.signalChangedLocked()
 		ap.mu.Unlock()
 		p.metrics.acquireCreateTotal.Add(1)
 
 		if !conn.tryAcquire() {
+			p.lifecycleMu.RUnlock()
 			if err := conn.acquire(ctx); err != nil {
-				conn.close()
-				p.evictConn(accountID, conn.id)
+				if req.Ephemeral {
+					p.releaseEphemeralConn(accountID, conn)
+				} else {
+					conn.close()
+					p.evictConn(accountID, conn.id)
+				}
 				return nil, err
 			}
+		} else {
+			p.lifecycleMu.RUnlock()
 		}
-		lease := &openAIWSConnLease{pool: p, accountID: accountID, conn: conn, connPick: connPick}
-		p.ensureTargetIdleAsync(accountID)
+		lease := &openAIWSConnLease{pool: p, accountID: accountID, conn: conn, connPick: connPick, ephemeral: req.Ephemeral}
+		if !req.Ephemeral {
+			p.ensureTargetIdleAsync(accountID)
+		}
 		return lease, nil
 	}
 
-	if req.ForceNewConn {
+	if req.ForceNewConn || req.Ephemeral {
 		p.recordConnPickDuration(time.Since(pickStartedAt))
 		ap.mu.Unlock()
 		closeOpenAIWSConns(evicted)
@@ -1382,11 +1441,12 @@ func (p *openAIWSConnPool) AccountPoolLoad(accountID int64) (inflight int, waite
 	ap.mu.Lock()
 	defer ap.mu.Unlock()
 	inflight, waiters = accountPoolLoadLocked(ap)
-	return inflight, waiters, len(ap.conns)
+	inflight += ap.ephemeral
+	return inflight, waiters, len(ap.conns) + ap.ephemeral
 }
 
 func (p *openAIWSConnPool) ensureTargetIdleAsync(accountID int64) {
-	if p == nil || accountID <= 0 {
+	if p == nil || accountID <= 0 || p.isClosed() {
 		return
 	}
 
@@ -1416,7 +1476,7 @@ func (p *openAIWSConnPool) ensureTargetIdleAsync(accountID int64) {
 		effectiveMaxConns = p.effectiveMaxConnsByAccount(ap.lastAcquire.Account)
 	}
 	target := p.targetConnCountLocked(ap, effectiveMaxConns)
-	current := len(ap.conns) + ap.creating
+	current := len(ap.conns) + ap.creating + ap.ephemeral
 	if current >= target {
 		return
 	}
@@ -1485,12 +1545,18 @@ func (p *openAIWSConnPool) prewarmConns(accountID int64, req openAIWSAcquireRequ
 	}()
 
 	for i := 0; i < total; i++ {
+		if p.isClosed() {
+			p.releasePrewarmCreatingSlots(accountID, total-i)
+			return
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), p.dialTimeout()+openAIWSConnPrewarmExtraDelay)
 		conn, err := p.dialConn(ctx, req)
 		cancel()
 
+		p.lifecycleMu.RLock()
 		ap, ok := p.getAccountPool(accountID)
 		if !ok || ap == nil {
+			p.lifecycleMu.RUnlock()
 			if conn != nil {
 				conn.close()
 			}
@@ -1500,16 +1566,27 @@ func (p *openAIWSConnPool) prewarmConns(accountID int64, req openAIWSAcquireRequ
 		if ap.creating > 0 {
 			ap.creating--
 		}
+		if p.isClosed() {
+			ap.mu.Unlock()
+			p.lifecycleMu.RUnlock()
+			if conn != nil {
+				conn.close()
+			}
+			p.releasePrewarmCreatingSlots(accountID, total-i-1)
+			return
+		}
 		if err != nil {
 			ap.prewarmFails++
 			ap.prewarmFailAt = time.Now()
 			ap.signalChangedLocked()
 			ap.mu.Unlock()
+			p.lifecycleMu.RUnlock()
 			continue
 		}
-		if len(ap.conns) >= p.effectiveMaxConnsByAccount(req.Account) {
+		if len(ap.conns)+ap.ephemeral >= p.effectiveMaxConnsByAccount(req.Account) {
 			ap.signalChangedLocked()
 			ap.mu.Unlock()
+			p.lifecycleMu.RUnlock()
 			conn.close()
 			continue
 		}
@@ -1518,6 +1595,79 @@ func (p *openAIWSConnPool) prewarmConns(accountID int64, req openAIWSAcquireRequ
 		ap.prewarmFailAt = time.Time{}
 		ap.signalChangedLocked()
 		ap.mu.Unlock()
+		p.lifecycleMu.RUnlock()
+	}
+}
+
+func (p *openAIWSConnPool) releasePrewarmCreatingSlots(accountID int64, count int) {
+	if p == nil || accountID <= 0 || count <= 0 {
+		return
+	}
+	ap, ok := p.getAccountPool(accountID)
+	if !ok || ap == nil {
+		return
+	}
+	ap.mu.Lock()
+	if count > ap.creating {
+		count = ap.creating
+	}
+	ap.creating -= count
+	ap.signalChangedLocked()
+	ap.mu.Unlock()
+}
+
+func (p *openAIWSConnPool) releaseEphemeralConn(accountID int64, conn *openAIWSConn) {
+	if conn != nil {
+		conn.close()
+	}
+	if p == nil || accountID <= 0 {
+		return
+	}
+	ap, ok := p.getAccountPool(accountID)
+	if !ok || ap == nil {
+		return
+	}
+	ap.mu.Lock()
+	if ap.ephemeral > 0 {
+		ap.ephemeral--
+	}
+	ap.signalChangedLocked()
+	ap.mu.Unlock()
+	p.restoreSharedPoolAfterEphemeral(accountID)
+}
+
+func (p *openAIWSConnPool) restoreSharedPoolAfterEphemeral(accountID int64) {
+	if p == nil || accountID <= 0 || p.isClosed() {
+		return
+	}
+	ap, ok := p.getAccountPool(accountID)
+	if !ok || ap == nil {
+		return
+	}
+	ap.mu.Lock()
+	effectiveMaxConns := p.maxConnsHardCap()
+	if ap.lastAcquire != nil && ap.lastAcquire.Account != nil {
+		effectiveMaxConns = p.effectiveMaxConnsByAccount(ap.lastAcquire.Account)
+	}
+	target := p.targetConnCountLocked(ap, effectiveMaxConns)
+	current := len(ap.conns) + ap.creating + ap.ephemeral
+	if current < target {
+		// 恢复被临时连接让出的共享容量，不受普通扩容冷却时间影响。
+		ap.prewarmUntil = time.Time{}
+	}
+	ap.mu.Unlock()
+	p.ensureTargetIdleAsync(accountID)
+}
+
+func (p *openAIWSConnPool) isClosed() bool {
+	if p == nil || p.workerStopCh == nil {
+		return true
+	}
+	select {
+	case <-p.workerStopCh:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -597,6 +597,7 @@ func isSensitiveKey(key string) bool {
 		"private_key",
 		"jwt",
 		"signature",
+		"x-oai-attestation",
 		"accesskeyid",
 		"secretaccesskey":
 		return true

--- a/backend/internal/service/ops_service_redaction_test.go
+++ b/backend/internal/service/ops_service_redaction_test.go
@@ -38,6 +38,7 @@ func TestIsSensitiveKey_TokenBudgetKeysNotRedacted(t *testing.T) {
 		"client_secret",
 		"private_key",
 		"signature",
+		"x-oai-attestation",
 	} {
 		if !isSensitiveKey(key) {
 			t.Fatalf("expected key %q to be treated as sensitive", key)

--- a/backend/internal/util/logredact/redact.go
+++ b/backend/internal/util/logredact/redact.go
@@ -20,6 +20,7 @@ var defaultSensitiveKeys = map[string]struct{}{
 	"id_token":           {},
 	"client_secret":      {},
 	"password":           {},
+	"x-oai-attestation":  {},
 }
 
 var defaultSensitiveKeyList = []string{
@@ -31,6 +32,7 @@ var defaultSensitiveKeyList = []string{
 	"id_token",
 	"client_secret",
 	"password",
+	"x-oai-attestation",
 }
 
 type textRedactPatterns struct {
@@ -40,8 +42,9 @@ type textRedactPatterns struct {
 }
 
 var (
-	reGOCSPX = regexp.MustCompile(`GOCSPX-[0-9A-Za-z_-]{24,}`)
-	reAIza   = regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`)
+	reGOCSPX            = regexp.MustCompile(`GOCSPX-[0-9A-Za-z_-]{24,}`)
+	reAIza              = regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`)
+	reOpenAIAttestation = regexp.MustCompile(`(?i)(\bx-oai-attestation\b\s*[:=]\s*)(\[[^\r\n]*\]|\{[^\r\n]*\}|[^\r\n]+)`)
 
 	defaultTextRedactPatterns = compileTextRedactPatterns(nil)
 	extraTextPatternCache     sync.Map // map[string]*textRedactPatterns
@@ -97,6 +100,7 @@ func RedactText(input string, extraKeys ...string) string {
 	patterns := getTextRedactPatterns(extraKeys)
 
 	out := input
+	out = reOpenAIAttestation.ReplaceAllString(out, `$1***`)
 	out = reGOCSPX.ReplaceAllString(out, "GOCSPX-***")
 	out = reAIza.ReplaceAllString(out, "AIza***")
 	out = patterns.reJSONLike.ReplaceAllString(out, `$1***$3`)

--- a/backend/internal/util/logredact/redact_test.go
+++ b/backend/internal/util/logredact/redact_test.go
@@ -38,6 +38,29 @@ func TestRedactText_GOCSPX(t *testing.T) {
 	}
 }
 
+func TestRedactText_OpenAIAttestation(t *testing.T) {
+	secret := `{"v":1,"s":0,"t":"v1.secret-attestation"}`
+	tests := []string{
+		"x-oai-attestation=" + secret,
+		"X-OAI-Attestation: " + secret,
+		"map[X-Oai-Attestation:[" + secret + "] User-Agent:[codex]]",
+	}
+	for _, input := range tests {
+		out := RedactText(input)
+		if strings.Contains(out, "v1.secret-attestation") {
+			t.Fatalf("expected attestation redacted, got %q", out)
+		}
+		if !strings.Contains(strings.ToLower(out), "x-oai-attestation") || !strings.Contains(out, "***") {
+			t.Fatalf("expected attestation key redacted, got %q", out)
+		}
+	}
+
+	jsonOut := RedactJSON([]byte(`{"x-oai-attestation":{"v":1,"s":0,"t":"v1.secret-attestation"}}`))
+	if strings.Contains(jsonOut, "v1.secret-attestation") || !strings.Contains(jsonOut, `"x-oai-attestation":"***"`) {
+		t.Fatalf("expected structured attestation redacted, got %q", jsonOut)
+	}
+}
+
 func TestRedactText_ExtraKeyCacheUsesNormalizedSortedKey(t *testing.T) {
 	clearExtraTextPatternCache()
 


### PR DESCRIPTION
## Summary

- 仅在 OpenAI OAuth 的 Responses、`/responses/compact` 和 Responses WebSocket 握手中原样转发 `x-oai-attestation`。
- 证明由官方签名桌面端生成；Sub2API 不生成、不解析、不验证、不重编码，只接受单个非空值并逐字复制。
- 客户端未提供证明时保持原行为，不新增请求头。

## Security and retry semantics

- API Key、自定义上游、Chat Completions、Messages、Images 和兼容转换路径均不会收到证明。
- 携带证明的 WebSocket 使用 ephemeral connection（临时连接）：不共享、不预热、不复用、不写 Response/Session connID 粘性映射，结束即关闭。
- 携带证明时禁止 HTTP bridge、请求体修改重试、跨账号故障转移和自动 WebSocket 新握手重放；需要新握手时交还客户端重新生成证明。
- HTTP 和 WebSocket 握手遇到 3xx 时失败关闭，避免证明被重定向到其它目标。
- 账号自定义头不能注入证明；日志、运维数据和 Gin recovery panic dump 均会脱敏。

## Validation

- `go test ./... -count=1`
- `go test -tags unit ./internal/server/middleware -count=1`
- `go test ./internal/service -run TestOpenAIAttestation -count=1`
- `go test ./internal/handler -run TestOpenAIResponsesAttestationStopsCrossAccountFailover -count=1`
- `go test ./internal/repository -run TestHTTPUpstreamSuite/TestDo_AttestationRedirectBlocked -count=1`
- `git diff --check`
- 连接池失败、取消、并发上限、重复释放、关闭后不预热和粘性映射测试重复运行通过。

`-race` 未在本地执行：当前 Windows 环境缺少 CGO 所需的 GCC；普通专项、包级和全后端测试均已通过。

Supersedes #3900.
Closes #3927.

Protocol reference: openai/codex#20619, merged as `5f4d0ec343d807f6932e6bdc5785dc5a127ac409`.