### PR TITLE
fix: require OAuth accounts for Codex models manifest

### DIFF
--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -30,11 +30,12 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		return
 	}
 
-	account, err := h.gatewayService.SelectAccountForModel(c.Request.Context(), apiKey.GroupID, "", "")
+	account, err := h.gatewayService.SelectCodexModelsAccount(c.Request.Context(), apiKey.GroupID)
 	if err != nil {
-		h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
+		h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI OAuth accounts")
 		return
 	}
+	setOpsSelectedAccount(c, account.ID, account.Platform)
 
 	manifest, err := h.gatewayService.FetchCodexModelsManifest(c.Request.Context(), account, c.Query("client_version"), c.GetHeader("If-None-Match"))
 	if err != nil {

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -26,6 +26,29 @@ type CodexModelsManifest struct {
 	NotModified bool
 }
 
+// SelectCodexModelsAccount selects a schedulable account whose resolved
+// credentials can authenticate against the ChatGPT Codex backend.
+func (s *OpenAIGatewayService) SelectCodexModelsAccount(ctx context.Context, groupID *int64) (*Account, error) {
+	accounts, err := s.listSchedulableAccounts(ctx, groupID, PlatformOpenAI)
+	if err != nil {
+		return nil, err
+	}
+
+	excludedIDs := make(map[int64]struct{})
+	for i := range accounts {
+		account := &accounts[i]
+		credentialAccount, resolveErr := resolveCredentialAccount(ctx, s.accountRepo, account)
+		if resolveErr != nil ||
+			credentialAccount == nil ||
+			!credentialAccount.IsOpenAIOAuth() ||
+			strings.TrimSpace(credentialAccount.GetOpenAIAccessToken()) == "" {
+			excludedIDs[account.ID] = struct{}{}
+		}
+	}
+
+	return s.SelectAccountForModelWithExclusions(ctx, groupID, "", "", excludedIDs)
+}
+
 // FetchCodexModelsManifest fetches the live Codex models manifest from the
 // ChatGPT backend using the account's OAuth credentials.
 //

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -19,6 +19,132 @@ func newCodexModelsTestAccount() *Account {
 	}
 }
 
+func TestSelectCodexModelsAccountSkipsNonOAuthAndMissingTokenAccounts(t *testing.T) {
+	groupID := int64(1)
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:          1,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Priority:    0,
+				Credentials: map[string]any{
+					"api_key":      "test-api-key",
+					"access_token": "stale-token-field",
+				},
+			},
+			{
+				ID:          2,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Priority:    1,
+			},
+			{
+				ID:          3,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Priority:    2,
+				Credentials: map[string]any{
+					"access_token": "oauth-access-token",
+				},
+			},
+		},
+	}
+
+	s := &OpenAIGatewayService{accountRepo: repo}
+	account, err := s.SelectCodexModelsAccount(context.Background(), &groupID)
+	if err != nil {
+		t.Fatalf("SelectCodexModelsAccount returned error: %v", err)
+	}
+	if account == nil || account.ID != 3 {
+		t.Fatalf("expected OAuth account 3, got %+v", account)
+	}
+}
+
+func TestSelectCodexModelsAccountUsesResolvedShadowCredentials(t *testing.T) {
+	groupID := int64(7)
+	parentID := int64(10)
+	repo := groupAwareStubOpenAIAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{
+			accounts: []Account{
+				{
+					ID:          parentID,
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeOAuth,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Credentials: map[string]any{
+						"access_token": "parent-access-token",
+					},
+				},
+				{
+					ID:              11,
+					Platform:        PlatformOpenAI,
+					Type:            AccountTypeOAuth,
+					Status:          StatusActive,
+					Schedulable:     true,
+					Concurrency:     1,
+					ParentAccountID: &parentID,
+					AccountGroups:   []AccountGroup{{GroupID: groupID}},
+				},
+			},
+		},
+	}
+
+	s := &OpenAIGatewayService{accountRepo: repo}
+	account, err := s.SelectCodexModelsAccount(context.Background(), &groupID)
+	if err != nil {
+		t.Fatalf("SelectCodexModelsAccount returned error: %v", err)
+	}
+	if account == nil || account.ID != 11 {
+		t.Fatalf("expected shadow account 11, got %+v", account)
+	}
+}
+
+func TestSelectCodexModelsAccountReturnsErrorWithoutEligibleOAuthAccount(t *testing.T) {
+	groupID := int64(1)
+	repo := stubOpenAIAccountRepo{
+		accounts: []Account{
+			{
+				ID:          1,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				Credentials: map[string]any{"api_key": "test-api-key"},
+			},
+			{
+				ID:          2,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+			},
+		},
+	}
+
+	s := &OpenAIGatewayService{accountRepo: repo}
+	account, err := s.SelectCodexModelsAccount(context.Background(), &groupID)
+	if err == nil {
+		t.Fatal("expected error when no OAuth account has an access token")
+	}
+	if account != nil {
+		t.Fatalf("expected nil account, got %+v", account)
+	}
+}
+
 func TestFetchCodexModelsManifestPassthrough(t *testing.T) {
 	manifestBody := `{"models":[{"slug":"gpt-5.5","display_name":"GPT-5.5"}]}`
 


### PR DESCRIPTION
## Summary

- add a Codex models-specific account selector that excludes non-OAuth accounts and OAuth accounts without a resolved access token
- preserve the existing group, priority, LRU, quota, and schedulability rules by passing the exclusions back through the normal OpenAI scheduler
- resolve shadow accounts through their OAuth parent credentials
- attach the selected account to the ops/access-log context
- return a clear `503 No available OpenAI OAuth accounts` response when the group has no eligible manifest account

## Root cause

Requests to `/v1/models?client_version=...` are routed to `CodexModels`. The handler previously used the generic `SelectAccountForModel`, which can select both OAuth and API Key accounts. `FetchCodexModelsManifest` then requires a ChatGPT Codex OAuth access token, so selecting an API Key account produced:

```json
{
  "error": {
    "message": "account has no Codex backend access token",
    "type": "upstream_error"
  }
}
```

In a mixed OAuth/API Key group, repeated model-manifest requests therefore alternated between `200` and `502` depending on the selected account.

## Validation

- `go test ./internal/service -run 'Test(SelectCodexModelsAccount|FetchCodexModelsManifest)' -count=1`
- `go test ./internal/service ./internal/handler ./internal/server/routes -count=1`
- `go vet ./internal/service ./internal/handler ./internal/server/routes`
- `go test ./... -count=1`

Regression coverage includes:

- an API Key account with a stale `access_token` field
- an OAuth account with no access token
- a valid OAuth account in the same group
- a shadow account using its OAuth parent's credentials
- a group with no eligible OAuth manifest account

Fixes #3995
