### PR TITLE
fix(codex): 剥离续链 message item 的非法 item_* id

### DIFF
--- a/backend/internal/service/openai_codex_function_call_id_test.go
+++ b/backend/internal/service/openai_codex_function_call_id_test.go
@@ -114,14 +114,15 @@ func TestFilterCodexInput_OutputTypeKeepsItemID(t *testing.T) {
 	require.Equal(t, "o1", out["id"], "output item id should be preserved")
 }
 
-// TestFilterCodexInput_NonToolCallItemKeepsID ensures non-tool-call items
-// (e.g. message) still keep their id when PreserveReferences is true.
+// TestFilterCodexInput_NonToolCallItemKeepsID ensures items subject to neither
+// the fc* (call-input) nor the msg* (message) prefix rule still keep their id
+// when PreserveReferences is true.
+// message is covered separately in openai_codex_message_item_id_test.go (#3981).
 func TestFilterCodexInput_NonToolCallItemKeepsID(t *testing.T) {
 	input := []any{
 		map[string]any{
-			"type": "message",
-			"id":   "item_msg_001",
-			"role": "user",
+			"type": "web_search_call",
+			"id":   "ws_001",
 		},
 	}
 
@@ -130,7 +131,7 @@ func TestFilterCodexInput_NonToolCallItemKeepsID(t *testing.T) {
 	})
 
 	require.Len(t, filtered, 1)
-	msg, ok := filtered[0].(map[string]any)
+	item, ok := filtered[0].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, "item_msg_001", msg["id"], "non-tool-call items keep their id in preserve mode")
+	require.Equal(t, "ws_001", item["id"], "unconstrained items keep their id in preserve mode")
 }

--- a/backend/internal/service/openai_codex_message_item_id_test.go
+++ b/backend/internal/service/openai_codex_message_item_id_test.go
@@ -1,0 +1,160 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFilterCodexInput_StripsMessageItemID_WhenPreservingReferences
+// verifies that message items with a non-msg id (e.g. item_*) have their id
+// stripped even when PreserveReferences is true. OpenAI upstream requires
+// message ids to begin with "msg" and rejects item_* with 400:
+// "Expected an ID that begins with 'msg'." (#3981)
+func TestFilterCodexInput_StripsMessageItemID_WhenPreservingReferences(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type": "message",
+			"id":   "item_3bc5a3fa8ccde25f1c0000d4",
+			"role": "user",
+			"content": []any{
+				map[string]any{"type": "input_text", "text": "hello"},
+			},
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 1)
+
+	msg, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "message", msg["type"])
+	_, hasID := msg["id"]
+	require.False(t, hasID, "item_* id should be stripped from message")
+	require.Equal(t, "user", msg["role"], "role must be preserved")
+	require.NotNil(t, msg["content"], "content must be preserved")
+}
+
+// TestFilterCodexInput_KeepsMsgID_WhenPreservingReferences
+// verifies that message items with a valid msg* id are kept when
+// PreserveReferences is true, so context references are not lost.
+func TestFilterCodexInput_KeepsMsgID_WhenPreservingReferences(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type": "message",
+			"id":   "msg_validID123",
+			"role": "assistant",
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 1)
+	msg, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "msg_validID123", msg["id"], "valid msg* id must be preserved")
+}
+
+// TestFilterCodexInput_StripsMessageIDWhenNotPreservingReferences ensures the
+// non-continuation path still drops every message id regardless of prefix.
+func TestFilterCodexInput_StripsMessageIDWhenNotPreservingReferences(t *testing.T) {
+	for _, id := range []string{"item_abc", "msg_validID123"} {
+		input := []any{
+			map[string]any{
+				"type": "message",
+				"id":   id,
+				"role": "user",
+			},
+		}
+
+		filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+			PreserveReferences: false,
+		})
+
+		require.Len(t, filtered, 1)
+		msg, ok := filtered[0].(map[string]any)
+		require.True(t, ok)
+		_, hasID := msg["id"]
+		require.False(t, hasID, "id %q should be stripped when not preserving references", id)
+	}
+}
+
+// TestFilterCodexInput_MessageIDStripDoesNotMutateInput ensures the original
+// input map is not modified in place when the id is stripped.
+func TestFilterCodexInput_MessageIDStripDoesNotMutateInput(t *testing.T) {
+	original := map[string]any{
+		"type": "message",
+		"id":   "item_abc",
+		"role": "user",
+	}
+
+	filtered := filterCodexInputWithOptions([]any{original}, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 1)
+	require.Equal(t, "item_abc", original["id"], "original input must not be mutated")
+}
+
+// TestFilterCodexInput_MessageStripKeepsFunctionCallBehavior guards against a
+// regression of #3785: message and function_call id rules are independent.
+func TestFilterCodexInput_MessageStripKeepsFunctionCallBehavior(t *testing.T) {
+	input := []any{
+		map[string]any{
+			"type": "message",
+			"id":   "item_msg_001",
+			"role": "user",
+		},
+		map[string]any{
+			"type":    "function_call",
+			"id":      "fc_validID123",
+			"call_id": "fc_validID123",
+			"name":    "bash",
+		},
+		map[string]any{
+			"type":    "function_call",
+			"id":      "item_A9v0SNfS3VaLrfX0j3y4xhyK",
+			"call_id": "fc_abc123",
+			"name":    "bash",
+		},
+		map[string]any{
+			"type":    "function_call_output",
+			"id":      "o1",
+			"call_id": "fc_abc123",
+			"output":  "done",
+		},
+	}
+
+	filtered := filterCodexInputWithOptions(input, codexInputFilterOptions{
+		PreserveReferences: true,
+	})
+
+	require.Len(t, filtered, 4)
+
+	msg, ok := filtered[0].(map[string]any)
+	require.True(t, ok)
+	_, hasID := msg["id"]
+	require.False(t, hasID, "message item_* id should be stripped")
+
+	fcValid, ok := filtered[1].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "fc_validID123", fcValid["id"], "valid fc* id must be preserved")
+
+	fcBad, ok := filtered[2].(map[string]any)
+	require.True(t, ok)
+	_, hasID = fcBad["id"]
+	require.False(t, hasID, "function_call item_* id should still be stripped")
+	require.Equal(t, "fc_abc123", fcBad["call_id"], "call_id pairing must survive")
+
+	out, ok := filtered[3].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "o1", out["id"], "output item id should be preserved")
+	require.Equal(t, "fc_abc123", out["call_id"], "call_id pairing must survive")
+}

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1405,6 +1405,15 @@ func filterCodexInputWithOptions(input []any, opts codexInputFilterOptions) []an
 				ensureCopy()
 				delete(newItem, "id")
 			}
+		} else if typ == "message" {
+			// 同理，message 类 item 的 id 必须以 "msg" 开头（上游校验
+			// "Expected an ID that begins with 'msg'"）。item_* 形式的 id
+			// 来自客户端回放，需要删除。
+			// 注意：不改写成 msg_*，改写出的 id 未必对应真实的上游对象。
+			if id, ok := m["id"].(string); ok && id != "" && !strings.HasPrefix(id, "msg") {
+				ensureCopy()
+				delete(newItem, "id")
+			}
 		}
 
 		filtered = append(filtered, newItem)


### PR DESCRIPTION
## 问题

OpenAI OAuth 转发 `/v1/responses` 续链请求时，Codex Desktop 回放的 `type=message` item 携带 `item_*` 形式的 `id`。上游严格要求 message item 的 id 以 `msg` 开头，否则返回 400：

```
Invalid 'input[177].id': 'item_3bc5a3fa8ccde25f1c0000d4'. Expected an ID that begins with 'msg'.
```

sub2api 随后向客户端返回 502 `Upstream request failed`。客户端自动重试会不断重放同一份坏上下文，导致连续失败（生产环境同一用户观测到 63 次）；新建会话可恢复。

## 根因

`filterCodexInputWithOptions` 在 `PreserveReferences=true`（续链）路径下保留 item 的 `id` 以维持上下文引用，但只对 call-input 类 item 校验了 `fc` 前缀，未覆盖 `type=message` 的 `msg` 前缀约束，于是 `item_*` 形式的 message id 被原样透传给上游。

## 改动

- `backend/internal/service/openai_codex_transform.go`：在 `PreserveReferences=true` 路径下为 `type=message` 增加一个与现有 `fc` 分支平行的 else-if 分支，`id` 非空且不以 `msg` 开头时删除该 `id`，其余字段不动。
- 不改写 `item_*` 为 `msg_*`——改写出的 id 未必对应真实的上游对象，删除后由上游重新分配更安全。
- 未改动 `isCodexToolCallInputType`，未触碰 function_call / function_call_output / reasoning / item_reference / call_id 的既有逻辑。

## 与 #3785 / `fd64d07e6` 的关系

本 issue 与 #3785 是**同一个 bug 的另一个 item 类型**：

| Issue | item 类型 | 上游要求前缀 |
|---|---|---|
| #3785 | `function_call` 等 call-input | `fc` |
| #3981（本 PR） | `message` | `msg` |

`fd64d07e6` 只覆盖了 call-input 类。本 PR 严格模仿其实现与注释风格，补上 message 类。

其中 `fd64d07e6` 引入的 `TestFilterCodexInput_NonToolCallItemKeepsID` 曾以 `message` + `id=item_msg_001` 断言"保留 id"，而该行为正是上游拒绝的对象（issue 正文也指出了这一点）。本 PR 将该用例改用 `web_search_call`（同样不受 `fc`/`msg` 前缀约束的类型）覆盖其原本意图，message 的行为则由新增测试文件专门覆盖。

## 测试

新增 `backend/internal/service/openai_codex_message_item_id_test.go`：

- `type=message` + `id=item_*` + 续链 → id 被剥离，`role`/`content` 保留
- `type=message` + `id=msg_validID123` + 续链 → id 原样保留
- `PreserveReferences=false` → `item_*` 与 `msg_*` 一律删除（维持现状）
- 剥离 id 时不就地修改原始输入 map
- 回归护栏：message 与 function_call 的 id 规则互不影响，`fc_*` 保留、`item_*` 剥离、`function_call_output.id` 与 `call_id` 配对不受影响

已确认新增测试在未打补丁的代码上失败、打上补丁后通过。

## 验证

```
cd backend && go build ./... && go test -tags=unit ./internal/service/... && golangci-lint run ./...
```

全部通过（`golangci-lint`：0 issues）。

## 备注

若 CI `backend-security` 因 govulncheck 报告 Go stdlib 漏洞而失败，那是仓库级问题，与本改动无关，本 PR 未 bump Go 版本。

Fixes #3981

🤖 Generated with [Claude Code](https://claude.com/claude-code)
