### PR TITLE
fix(ui): localize user role label in app header

### DIFF
--- a/frontend/src/components/layout/AppHeader.vue
+++ b/frontend/src/components/layout/AppHeader.vue
@@ -111,8 +111,8 @@
               <div class="text-sm font-medium text-gray-900 dark:text-white">
                 {{ displayName }}
               </div>
-              <div class="text-xs capitalize text-gray-500 dark:text-dark-400">
-                {{ user.role }}
+              <div class="text-xs text-gray-500 dark:text-dark-400">
+                {{ t('admin.users.roles.' + user.role) }}
               </div>
             </div>
             <Icon name="chevronDown" size="sm" class="hidden text-gray-400 md:block" />


### PR DESCRIPTION
顶栏用户名下面的角色一直是直接渲染 `user.role` 原始值，中文界面右上角显示英文 "Admin"，和页面里其他地方的"管理员"混着两种语言。

改成走 i18n，复用用户管理页已有的 `admin.users.roles.*` 键（admin→管理员、user→用户），顺手去掉了只对英文有意义的 `capitalize`。

优化前:
<img width="486" height="124" alt="image" src="https://github.com/user-attachments/assets/d17bf8bd-c7b1-4837-a45e-db4fcb20ff0f" />

优化后:
<img width="466" height="132" alt="image" src="https://github.com/user-attachments/assets/83f7c820-deb4-4b55-a276-df2da0f59f8f" />
