### PR TITLE
fix(ui): adapt native form controls to dark mode via color-scheme

### DIFF
--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -405,7 +405,7 @@ onUnmounted(() => {
 }
 
 .dark .date-picker-input::-webkit-calendar-picker-indicator {
-  filter: invert(0.7);
+  filter: none;
 }
 
 .date-picker-separator {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -9,6 +9,11 @@
 
   html {
     @apply scroll-smooth antialiased;
+    color-scheme: light;
+  }
+
+  .dark {
+    color-scheme: dark;
   }
 
   body {


### PR DESCRIPTION
暗色模式下浏览器原生控件一直按浅色渲染：日期输入弹出的原生日历是白底面板，复选框是亮白实心方块，日历图标在深色背景上几乎看不见。根因是页面从未声明 CSS `color-scheme`，浏览器不知道当前处于暗色主题。

修复前:
<img width="986" height="1116" alt="image" src="https://github.com/user-attachments/assets/9bc7ce3d-5eb1-497a-9eb6-d9253cd9acb1" />

修复后:
<img width="1020" height="1170" alt="image" src="https://github.com/user-attachments/assets/7cc982a5-838c-41e2-8357-b1af1f5d995a" />
