### PR TITLE
fix(auth): support current cli credential format

### DIFF
--- a/backend/internal/handler/admin/account_codex_import.go
+++ b/backend/internal/handler/admin/account_codex_import.go
@@ -487,6 +487,7 @@ func normalizeCodexImportEntry(entry codexImportEntry) (*codexImportAccount, err
 			"imported_at":   now.Format(time.RFC3339),
 		},
 	}
+	lastRefresh := now.Format(time.RFC3339)
 
 	switch raw := entry.Value.(type) {
 	case string:
@@ -540,6 +541,9 @@ func normalizeCodexImportEntry(entry codexImportEntry) (*codexImportAccount, err
 			[]string{"org_id"},
 			[]string{"orgId"},
 		)
+		if value := firstCodexString(raw, []string{"last_refresh"}, []string{"lastRefresh"}); value != "" {
+			lastRefresh = value
+		}
 		item.Name = firstCodexString(raw, []string{"name"}, []string{"user", "name"})
 		authProvider := firstCodexString(raw, []string{"auth_provider"}, []string{"authProvider"})
 		if authProvider != "" {
@@ -555,14 +559,17 @@ func normalizeCodexImportEntry(entry codexImportEntry) (*codexImportAccount, err
 		if tokenExpiresAt, ok := firstCodexTime(raw,
 			[]string{"tokens", "expires_at"},
 			[]string{"tokens", "expiresAt"},
+			[]string{"tokens", "expired"},
 			[]string{"expires_at"},
 			[]string{"expiresAt"},
+			[]string{"expired"},
 		); ok {
 			if tokenExpiresAt.Unix() <= now.Unix()-codexImportClockSkewSeconds {
 				return nil, fmt.Errorf("access_token 已过期: %s", tokenExpiresAt.Format(time.RFC3339))
 			}
 			item.TokenExpiresAt = &tokenExpiresAt
 			item.Credentials["expires_at"] = tokenExpiresAt.Format(time.RFC3339)
+			item.Credentials["expired"] = tokenExpiresAt.Format(time.RFC3339)
 		}
 		copyCodexExtraString(raw, item.Extra, "user_image", []string{"user", "image"})
 		copyCodexExtraString(raw, item.Extra, "user_picture", []string{"user", "picture"})
@@ -576,6 +583,8 @@ func normalizeCodexImportEntry(entry codexImportEntry) (*codexImportAccount, err
 	if item.AccessToken == "" {
 		return nil, errors.New("缺少 accessToken/access_token")
 	}
+	item.Credentials["type"] = "codex"
+	item.Credentials["last_refresh"] = lastRefresh
 	item.Credentials["access_token"] = item.AccessToken
 	if item.RefreshToken != "" {
 		item.Credentials["refresh_token"] = item.RefreshToken
@@ -596,6 +605,7 @@ func normalizeCodexImportEntry(entry codexImportEntry) (*codexImportAccount, err
 	}
 
 	setCodexCredentialIfNotEmpty(item.Credentials, "email", item.Email)
+	setCodexCredentialIfNotEmpty(item.Credentials, "account_id", item.AccountID)
 	setCodexCredentialIfNotEmpty(item.Credentials, "chatgpt_account_id", item.AccountID)
 	setCodexCredentialIfNotEmpty(item.Credentials, "chatgpt_user_id", item.UserID)
 	setCodexCredentialIfNotEmpty(item.Credentials, "organization_id", item.Organization)
@@ -624,6 +634,7 @@ func enrichCodexImportAccountFromJWT(item *codexImportAccount, token string, val
 		expiresAt := time.Unix(claims.Exp, 0).UTC()
 		item.TokenExpiresAt = &expiresAt
 		item.Credentials["expires_at"] = expiresAt.Format(time.RFC3339)
+		item.Credentials["expired"] = expiresAt.Format(time.RFC3339)
 	}
 	if item.Email == "" {
 		item.Email = strings.TrimSpace(claims.Email)

--- a/backend/internal/handler/admin/account_codex_import_test.go
+++ b/backend/internal/handler/admin/account_codex_import_test.go
@@ -119,8 +119,14 @@ func TestNormalizeCodexSessionJSONExtractsCredentialsAndIgnoresSessionToken(t *t
 	if item.Credentials["access_token"] != accessToken {
 		t.Fatalf("access_token not stored")
 	}
+	if item.Credentials["type"] != "codex" {
+		t.Fatalf("type = %v, want codex", item.Credentials["type"])
+	}
 	if item.Credentials["email"] != "json@example.com" {
 		t.Fatalf("email = %v, want json@example.com", item.Credentials["email"])
+	}
+	if item.Credentials["account_id"] != "acct-from-json" {
+		t.Fatalf("account_id = %v, want acct-from-json", item.Credentials["account_id"])
 	}
 	if item.Credentials["chatgpt_account_id"] != "acct-from-json" {
 		t.Fatalf("chatgpt_account_id = %v, want acct-from-json", item.Credentials["chatgpt_account_id"])
@@ -142,6 +148,57 @@ func TestNormalizeCodexSessionJSONExtractsCredentialsAndIgnoresSessionToken(t *t
 	}
 	if item.TokenExpiresAt == nil {
 		t.Fatalf("TokenExpiresAt should be parsed from accessToken")
+	}
+	if item.Credentials["expired"] != item.Credentials["expires_at"] {
+		t.Fatalf("expired = %v, want expires_at %v", item.Credentials["expired"], item.Credentials["expires_at"])
+	}
+	if _, err := time.Parse(time.RFC3339, item.Credentials["last_refresh"].(string)); err != nil {
+		t.Fatalf("last_refresh is not RFC3339: %v", err)
+	}
+}
+
+func TestNormalizeCodexSessionJSONSupportsRelayGatewayAuthFormat(t *testing.T) {
+	raw := map[string]any{
+		"type":         "codex",
+		"access_token": "opaque-access-token",
+		"account_id":   "acct-current-format",
+		"expired":      "2026-08-05T13:40:42+08:00",
+		"last_refresh": "2026-05-26T16:30:20+08:00",
+	}
+
+	item, err := normalizeCodexImportEntry(codexImportEntry{Index: 1, Value: raw})
+	if err != nil {
+		t.Fatalf("normalizeCodexImportEntry error = %v", err)
+	}
+
+	if item.Credentials["type"] != "codex" {
+		t.Fatalf("type = %v, want codex", item.Credentials["type"])
+	}
+	if item.Credentials["access_token"] != "opaque-access-token" {
+		t.Fatalf("access_token = %v", item.Credentials["access_token"])
+	}
+	if item.Credentials["account_id"] != "acct-current-format" {
+		t.Fatalf("account_id = %v, want acct-current-format", item.Credentials["account_id"])
+	}
+	if item.Credentials["chatgpt_account_id"] != "acct-current-format" {
+		t.Fatalf("chatgpt_account_id = %v, want acct-current-format", item.Credentials["chatgpt_account_id"])
+	}
+	wantExpired, err := time.Parse(time.RFC3339, "2026-08-05T13:40:42+08:00")
+	if err != nil {
+		t.Fatalf("parse expected expired: %v", err)
+	}
+	gotExpired, err := time.Parse(time.RFC3339, item.Credentials["expired"].(string))
+	if err != nil {
+		t.Fatalf("expired is not RFC3339: %v", err)
+	}
+	if !gotExpired.Equal(wantExpired) {
+		t.Fatalf("expired = %v, want %v", item.Credentials["expired"], wantExpired.Format(time.RFC3339))
+	}
+	if item.Credentials["expires_at"] != item.Credentials["expired"] {
+		t.Fatalf("expires_at = %v, want expired %v", item.Credentials["expires_at"], item.Credentials["expired"])
+	}
+	if item.Credentials["last_refresh"] != "2026-05-26T16:30:20+08:00" {
+		t.Fatalf("last_refresh = %v", item.Credentials["last_refresh"])
 	}
 }
 

--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -757,6 +757,7 @@ func enrichCredentialsFromIDToken(item *DataAccount) {
 
 	setIfMissing("email", userInfo.Email)
 	setIfMissing("plan_type", userInfo.PlanType)
+	setIfMissing("account_id", userInfo.ChatGPTAccountID)
 	setIfMissing("chatgpt_account_id", userInfo.ChatGPTAccountID)
 	setIfMissing("chatgpt_user_id", userInfo.ChatGPTUserID)
 	setIfMissing("organization_id", userInfo.OrganizationID)

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -306,6 +306,9 @@ func (a *Account) GetCredential(key string) string {
 //   - Unix 时间戳数字: 1735689600 (float64/int64/json.Number)
 func (a *Account) GetCredentialAsTime(key string) *time.Time {
 	s := a.GetCredential(key)
+	if s == "" && key == "expires_at" {
+		s = a.GetCredential("expired")
+	}
 	if s == "" {
 		return nil
 	}
@@ -1300,7 +1303,10 @@ func (a *Account) GetChatGPTAccountID() string {
 	if !a.IsOpenAIOAuth() {
 		return ""
 	}
-	return a.GetCredential("chatgpt_account_id")
+	if accountID := a.GetCredential("chatgpt_account_id"); accountID != "" {
+		return accountID
+	}
+	return a.GetCredential("account_id")
 }
 
 func (a *Account) IsChatGPTAccountFedRAMP() bool {

--- a/backend/internal/service/account_auth_format_test.go
+++ b/backend/internal/service/account_auth_format_test.go
@@ -1,0 +1,41 @@
+package service
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAccountGetCredentialAsTimeFallsBackToExpired(t *testing.T) {
+	expired := "2026-06-05T16:30:21+08:00"
+	account := &Account{
+		Credentials: map[string]any{
+			"expired": expired,
+		},
+	}
+
+	got := account.GetCredentialAsTime("expires_at")
+	if got == nil {
+		t.Fatal("GetCredentialAsTime returned nil")
+	}
+	want, err := time.Parse(time.RFC3339, expired)
+	if err != nil {
+		t.Fatalf("parse expected time: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("GetCredentialAsTime = %s, want %s", got.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+func TestAccountGetChatGPTAccountIDFallsBackToAccountID(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"account_id": "acct-current-format",
+		},
+	}
+
+	if got := account.GetChatGPTAccountID(); got != "acct-current-format" {
+		t.Fatalf("GetChatGPTAccountID = %q, want acct-current-format", got)
+	}
+}

--- a/backend/internal/service/gemini_oauth_service.go
+++ b/backend/internal/service/gemini_oauth_service.go
@@ -878,8 +878,13 @@ func (s *GeminiOAuthService) RefreshAccountToken(ctx context.Context, account *A
 
 func (s *GeminiOAuthService) BuildAccountCredentials(tokenInfo *GeminiTokenInfo) map[string]any {
 	creds := map[string]any{
+		"type":         "gemini-cli",
 		"access_token": tokenInfo.AccessToken,
 		"expires_at":   strconv.FormatInt(tokenInfo.ExpiresAt, 10),
+		"last_refresh": time.Now().Format(time.RFC3339),
+	}
+	if tokenInfo.ExpiresAt > 0 {
+		creds["expired"] = time.Unix(tokenInfo.ExpiresAt, 0).Format(time.RFC3339)
 	}
 	if tokenInfo.RefreshToken != "" {
 		creds["refresh_token"] = tokenInfo.RefreshToken

--- a/backend/internal/service/gemini_oauth_service_test.go
+++ b/backend/internal/service/gemini_oauth_service_test.go
@@ -508,7 +508,9 @@ func TestGeminiOAuthService_BuildAccountCredentials(t *testing.T) {
 		}
 
 		creds := svc.BuildAccountCredentials(tokenInfo)
+		expectedExpired := time.Unix(1700000000, 0).Format(time.RFC3339)
 
+		assertCredStr(t, creds, "type", "gemini-cli")
 		assertCredStr(t, creds, "access_token", "access-123")
 		assertCredStr(t, creds, "refresh_token", "refresh-456")
 		assertCredStr(t, creds, "token_type", "Bearer")
@@ -517,6 +519,10 @@ func TestGeminiOAuthService_BuildAccountCredentials(t *testing.T) {
 		assertCredStr(t, creds, "tier_id", "gcp_standard")
 		assertCredStr(t, creds, "oauth_type", "code_assist")
 		assertCredStr(t, creds, "expires_at", "1700000000")
+		assertCredStr(t, creds, "expired", expectedExpired)
+		if _, err := time.Parse(time.RFC3339, creds["last_refresh"].(string)); err != nil {
+			t.Fatalf("last_refresh is not RFC3339: %v", err)
+		}
 
 		if _, ok := creds["drive_storage_limit"]; !ok {
 			t.Fatal("extra 字段 drive_storage_limit 未包含在 creds 中")
@@ -531,9 +537,15 @@ func TestGeminiOAuthService_BuildAccountCredentials(t *testing.T) {
 		}
 
 		creds := svc.BuildAccountCredentials(tokenInfo)
+		expectedExpired := time.Unix(1700000000, 0).Format(time.RFC3339)
 
+		assertCredStr(t, creds, "type", "gemini-cli")
 		assertCredStr(t, creds, "access_token", "token-only")
 		assertCredStr(t, creds, "expires_at", "1700000000")
+		assertCredStr(t, creds, "expired", expectedExpired)
+		if _, err := time.Parse(time.RFC3339, creds["last_refresh"].(string)); err != nil {
+			t.Fatalf("last_refresh is not RFC3339: %v", err)
+		}
 
 		// 可选字段不应存在
 		for _, key := range []string{"refresh_token", "token_type", "scope", "project_id", "tier_id", "oauth_type"} {
@@ -584,8 +596,8 @@ func TestGeminiOAuthService_BuildAccountCredentials(t *testing.T) {
 		creds := svc.BuildAccountCredentials(tokenInfo)
 
 		// 仅包含基础字段
-		if len(creds) != 3 { // access_token, expires_at, refresh_token
-			t.Fatalf("creds 字段数量不匹配: got=%d want=3, keys=%v", len(creds), credKeys(creds))
+		if len(creds) != 6 { // type, access_token, expires_at, expired, last_refresh, refresh_token
+			t.Fatalf("creds 字段数量不匹配: got=%d want=6, keys=%v", len(creds), credKeys(creds))
 		}
 	})
 }

--- a/backend/internal/service/openai_oauth_service.go
+++ b/backend/internal/service/openai_oauth_service.go
@@ -368,10 +368,15 @@ func (s *OpenAIOAuthService) RefreshAccountToken(ctx context.Context, account *A
 // BuildAccountCredentials builds credentials map from token info
 func (s *OpenAIOAuthService) BuildAccountCredentials(tokenInfo *OpenAITokenInfo) map[string]any {
 	creds := map[string]any{
+		"type":         "codex",
 		"access_token": tokenInfo.AccessToken,
+		"last_refresh": time.Now().Format(time.RFC3339),
 	}
 	if tokenInfo.ExpiresAt > 0 {
-		creds["expires_at"] = time.Unix(tokenInfo.ExpiresAt, 0).Format(time.RFC3339)
+		expired := time.Unix(tokenInfo.ExpiresAt, 0).Format(time.RFC3339)
+		creds["expired"] = expired
+		// Keep the legacy sub2api field so existing refresh/scheduler code can continue reading it.
+		creds["expires_at"] = expired
 	}
 	// 仅在刷新响应返回了新的 refresh_token 时才更新，防止用空值覆盖已有令牌
 	if strings.TrimSpace(tokenInfo.RefreshToken) != "" {
@@ -385,6 +390,7 @@ func (s *OpenAIOAuthService) BuildAccountCredentials(tokenInfo *OpenAITokenInfo)
 		creds["email"] = tokenInfo.Email
 	}
 	if tokenInfo.ChatGPTAccountID != "" {
+		creds["account_id"] = tokenInfo.ChatGPTAccountID
 		creds["chatgpt_account_id"] = tokenInfo.ChatGPTAccountID
 	}
 	if tokenInfo.ChatGPTUserID != "" {

--- a/backend/internal/service/openai_oauth_service_refresh_test.go
+++ b/backend/internal/service/openai_oauth_service_refresh_test.go
@@ -32,6 +32,38 @@ func (s *openaiOAuthClientRefreshStub) RefreshTokenWithClientID(ctx context.Cont
 	return nil, errors.New("not implemented")
 }
 
+func TestOpenAIOAuthService_BuildAccountCredentialsUsesRelayGatewayFormat(t *testing.T) {
+	svc := NewOpenAIOAuthService(nil, &openaiOAuthClientRefreshStub{})
+	defer svc.Stop()
+
+	expiresAt := int64(1700000000)
+	creds := svc.BuildAccountCredentials(&OpenAITokenInfo{
+		AccessToken:      "access-token",
+		RefreshToken:     "refresh-token",
+		IDToken:          "id-token",
+		ExpiresAt:        expiresAt,
+		Email:            "user@example.com",
+		ChatGPTAccountID: "chatgpt-account",
+		ChatGPTUserID:    "chatgpt-user",
+	})
+
+	expired := time.Unix(expiresAt, 0).Format(time.RFC3339)
+	require.Equal(t, "codex", creds["type"])
+	require.Equal(t, "access-token", creds["access_token"])
+	require.Equal(t, "refresh-token", creds["refresh_token"])
+	require.Equal(t, "id-token", creds["id_token"])
+	require.Equal(t, "user@example.com", creds["email"])
+	require.Equal(t, "chatgpt-account", creds["account_id"])
+	require.Equal(t, "chatgpt-account", creds["chatgpt_account_id"])
+	require.Equal(t, "chatgpt-user", creds["chatgpt_user_id"])
+	require.Equal(t, expired, creds["expired"])
+	require.Equal(t, expired, creds["expires_at"])
+	lastRefresh, ok := creds["last_refresh"].(string)
+	require.True(t, ok)
+	_, err := time.Parse(time.RFC3339, lastRefresh)
+	require.NoError(t, err)
+}
+
 func TestOpenAIOAuthService_RefreshAccountToken_NoRefreshTokenUsesExistingAccessToken(t *testing.T) {
 	client := &openaiOAuthClientRefreshStub{}
 	svc := NewOpenAIOAuthService(nil, client)


### PR DESCRIPTION
## Summary
- Support current Codex/OpenAI and Gemini CLI credential fields: `type`, `expired`, `last_refresh`, `account_id`.
- Preserve legacy `expires_at` behavior while accepting `expired` as a fallback.
- Add regression coverage for relay gateway credential format.

## Tests
- `go test ./internal/handler/admin ./internal/service`