### PR TITLE
fix(openai): retry model capacity on the same account

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -235,12 +235,17 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 						return
 					}
 					h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
-					// Pool mode: retry on the same account
+					// Pool mode or model-capacity failure: pin and retry the selected account first.
 					if failoverErr.RetryableOnSameAccount {
 						retryLimit := account.GetPoolModeRetryCount()
 						if sameAccountRetryCount[account.ID] < retryLimit {
 							sameAccountRetryCount[account.ID]++
-							reqLog.Warn("openai_chat_completions.pool_mode_same_account_retry",
+							sessionHash = pinOpenAISameAccountRetrySession(c.Request.Context(), h.gatewayService, apiKey.GroupID, sessionHash, account)
+							logEvent := "openai_chat_completions.pool_mode_same_account_retry"
+							if !account.IsPoolMode() {
+								logEvent = "openai_chat_completions.model_capacity_same_account_retry"
+							}
+							reqLog.Warn(logEvent,
 								zap.Int64("account_id", account.ID),
 								zap.Int("upstream_status", failoverErr.StatusCode),
 								zap.Int("retry_limit", retryLimit),

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -448,12 +448,17 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 						return
 					}
 					h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
-					// 池模式：同账号重试
+					// 池模式或模型容量错误：先固定当前账号并原地重试。
 					if failoverErr.RetryableOnSameAccount {
 						retryLimit := account.GetPoolModeRetryCount()
 						if sameAccountRetryCount[account.ID] < retryLimit {
 							sameAccountRetryCount[account.ID]++
-							reqLog.Warn("openai.pool_mode_same_account_retry",
+							sessionHash = pinOpenAISameAccountRetrySession(c.Request.Context(), h.gatewayService, apiKey.GroupID, sessionHash, account)
+							logEvent := "openai.pool_mode_same_account_retry"
+							if !account.IsPoolMode() {
+								logEvent = "openai.model_capacity_same_account_retry"
+							}
+							reqLog.Warn(logEvent,
 								zap.Int64("account_id", account.ID),
 								zap.Int("upstream_status", failoverErr.StatusCode),
 								zap.Int("retry_limit", retryLimit),
@@ -928,12 +933,17 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 						return
 					}
 					h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
-					// 池模式：同账号重试
+					// 池模式或模型容量错误：先固定当前账号并原地重试。
 					if failoverErr.RetryableOnSameAccount {
 						retryLimit := account.GetPoolModeRetryCount()
 						if sameAccountRetryCount[account.ID] < retryLimit {
 							sameAccountRetryCount[account.ID]++
-							reqLog.Warn("openai_messages.pool_mode_same_account_retry",
+							sessionHash = pinOpenAISameAccountRetrySession(c.Request.Context(), h.gatewayService, apiKey.GroupID, sessionHash, account)
+							logEvent := "openai_messages.pool_mode_same_account_retry"
+							if !account.IsPoolMode() {
+								logEvent = "openai_messages.model_capacity_same_account_retry"
+							}
+							reqLog.Warn(logEvent,
 								zap.Int64("account_id", account.ID),
 								zap.Int("upstream_status", failoverErr.StatusCode),
 								zap.Int("retry_limit", retryLimit),
@@ -2100,6 +2110,28 @@ func ensureOpenAIPoolModeSessionHash(sessionHash string, account *service.Accoun
 	}
 	// 为当前请求生成一次性粘性会话键，确保同账号重试不会重新负载均衡到其他账号。
 	return "openai-pool-retry-" + uuid.NewString()
+}
+
+func ensureOpenAISameAccountRetrySessionHash(sessionHash string) string {
+	if sessionHash != "" {
+		return sessionHash
+	}
+	return "openai-same-account-retry-" + uuid.NewString()
+}
+
+func pinOpenAISameAccountRetrySession(
+	ctx context.Context,
+	gatewayService *service.OpenAIGatewayService,
+	groupID *int64,
+	sessionHash string,
+	account *service.Account,
+) string {
+	if gatewayService == nil || account == nil {
+		return sessionHash
+	}
+	sessionHash = ensureOpenAISameAccountRetrySessionHash(sessionHash)
+	_ = gatewayService.BindStickySession(ctx, groupID, sessionHash, account.ID)
+	return sessionHash
 }
 
 func openAIWSIngressFallbackSessionSeed(userID, apiKeyID int64, groupID *int64) string {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -24,6 +24,14 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+func TestEnsureOpenAISameAccountRetrySessionHash(t *testing.T) {
+	require.Equal(t, "existing-session", ensureOpenAISameAccountRetrySessionHash("existing-session"))
+
+	generated := ensureOpenAISameAccountRetrySessionHash("")
+	require.True(t, strings.HasPrefix(generated, "openai-same-account-retry-"))
+	require.NotEqual(t, generated, ensureOpenAISameAccountRetrySessionHash(""))
+}
+
 func TestOpenAIHandleStreamingAwareError_JSONEscaping(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -113,7 +113,7 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	return &UpstreamFailoverError{
 		StatusCode:             resp.StatusCode,
 		ResponseBody:           respBody,
-		RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+		RetryableOnSameAccount: shouldRetryOpenAIUpstreamOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody),
 	}
 }
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -759,7 +759,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				return nil, &UpstreamFailoverError{
 					StatusCode:             resp.StatusCode,
 					ResponseBody:           respBody,
-					RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+					RetryableOnSameAccount: shouldRetryOpenAIUpstreamOnSameAccount(account, resp.StatusCode, upstreamMsg, respBody),
 				}
 			}
 			return s.handleErrorResponse(ctx, resp, c, account, body, billingModel)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -191,7 +191,10 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	if resp.StatusCode >= 400 {
 		// 透传模式默认保持原样代理；但 429/529 属于网关必须兜底的
 		// 上游容量类错误，应先触发多账号 failover 以维持基础 SLA。
-		if shouldFailoverOpenAIPassthroughResponse(resp.StatusCode) {
+		// 明确的 model-capacity 400 也属于临时容量错误；读取后回卷响应体，
+		// 让后续透传/错误处理仍能消费完全相同的 payload。
+		respBody, upstreamMsg := s.readOpenAIUpstreamError(resp)
+		if shouldFailoverOpenAIPassthroughResponse(resp.StatusCode, upstreamMsg, respBody) {
 			return nil, s.handleFailoverErrorResponsePassthrough(ctx, resp, c, account, body)
 		}
 		return nil, s.handleErrorResponsePassthrough(ctx, resp, c, account, body)
@@ -417,12 +420,12 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	return req, nil
 }
 
-func shouldFailoverOpenAIPassthroughResponse(statusCode int) bool {
+func shouldFailoverOpenAIPassthroughResponse(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
 	switch statusCode {
 	case http.StatusTooManyRequests, 529:
 		return true
 	default:
-		return false
+		return isOpenAIModelCapacityError(statusCode, upstreamMsg, upstreamBody)
 	}
 }
 
@@ -462,9 +465,10 @@ func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(
 		UpstreamResponseBody: upstreamDetail,
 	})
 	return &UpstreamFailoverError{
-		StatusCode:      resp.StatusCode,
-		ResponseBody:    body,
-		ResponseHeaders: resp.Header.Clone(),
+		StatusCode:             resp.StatusCode,
+		ResponseBody:           body,
+		ResponseHeaders:        resp.Header.Clone(),
+		RetryableOnSameAccount: isOpenAIModelCapacityError(resp.StatusCode, upstreamMsg, body),
 	}
 }
 
@@ -820,8 +824,9 @@ func (s *OpenAIGatewayService) newOpenAIStreamFailoverError(
 		},
 	})
 	return &UpstreamFailoverError{
-		StatusCode:   http.StatusBadGateway,
-		ResponseBody: body,
+		StatusCode:             http.StatusBadGateway,
+		ResponseBody:           body,
+		RetryableOnSameAccount: isOpenAIModelCapacityError(http.StatusBadRequest, message, payload),
 	}
 }
 

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -299,6 +299,77 @@ func TestIsOpenAITransientProcessingError(t *testing.T) {
 	))
 }
 
+func TestIsOpenAIModelCapacityError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+		body       []byte
+		want       bool
+	}{
+		{
+			name:       "message",
+			statusCode: http.StatusBadRequest,
+			message:    "Selected model is at capacity. Please try a different model.",
+			want:       true,
+		},
+		{
+			name:       "error body",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"error":{"message":"Selected model is at capacity. Please try a different model."}}`),
+			want:       true,
+		},
+		{
+			name:       "response failed body",
+			statusCode: http.StatusBadRequest,
+			body:       []byte(`{"response":{"error":{"message":"Selected model is at capacity. Please try a different model."}}}`),
+			want:       true,
+		},
+		{
+			name:       "service unavailable status",
+			statusCode: http.StatusServiceUnavailable,
+			message:    "Selected model is at capacity. Please try a different model.",
+			want:       true,
+		},
+		{
+			name:       "success status",
+			statusCode: http.StatusOK,
+			message:    "Selected model is at capacity. Please try a different model.",
+			want:       false,
+		},
+		{
+			name:       "other transient processing error",
+			statusCode: http.StatusBadRequest,
+			message:    "An error occurred while processing your request.",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isOpenAIModelCapacityError(tt.statusCode, tt.message, tt.body))
+		})
+	}
+}
+
+func TestShouldRetryOpenAIUpstreamOnSameAccount(t *testing.T) {
+	oauthAccount := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	poolAccount := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"pool_mode": true,
+		},
+	}
+	capacityBody := []byte(`{"error":{"message":"Selected model is at capacity. Please try a different model."}}`)
+	processingBody := []byte(`{"error":{"message":"An error occurred while processing your request."}}`)
+
+	require.True(t, shouldRetryOpenAIUpstreamOnSameAccount(oauthAccount, http.StatusBadRequest, "", capacityBody))
+	require.False(t, shouldRetryOpenAIUpstreamOnSameAccount(oauthAccount, http.StatusBadRequest, "", processingBody))
+	require.True(t, shouldRetryOpenAIUpstreamOnSameAccount(poolAccount, http.StatusBadRequest, "", processingBody))
+	require.True(t, shouldRetryOpenAIUpstreamOnSameAccount(poolAccount, http.StatusTooManyRequests, "", nil))
+}
+
 func TestIsOpenAIContextWindowError(t *testing.T) {
 	require.True(t, isOpenAIContextWindowError(
 		"",
@@ -420,11 +491,12 @@ func TestOpenAIGatewayService_Forward_TransientProcessingErrorTriggersFailover(t
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusBadRequest, failoverErr.StatusCode)
+	require.False(t, failoverErr.RetryableOnSameAccount, "普通 transient 400 应继续换号，不应扩大为 OAuth 同账号重试")
 	require.Contains(t, string(failoverErr.ResponseBody), "An error occurred while processing your request")
 	require.False(t, c.Writer.Written(), "service 层应返回 failover 错误给上层换号，而不是直接向客户端写响应")
 }
 
-func TestOpenAIGatewayService_Forward_ModelCapacityErrorTriggersFailoverAndSameAccountRetry(t *testing.T) {
+func TestOpenAIGatewayService_Forward_ModelCapacityErrorRetriesOAuthSameAccount(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	rec := httptest.NewRecorder()
@@ -453,11 +525,11 @@ func TestOpenAIGatewayService_Forward_ModelCapacityErrorTriggersFailoverAndSameA
 		ID:          1001,
 		Name:        "codex max套餐",
 		Platform:    PlatformOpenAI,
-		Type:        AccountTypeAPIKey,
+		Type:        AccountTypeOAuth,
 		Concurrency: 1,
 		Credentials: map[string]any{
-			"api_key":   "sk-test",
-			"pool_mode": true,
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
 		},
 		Status:         StatusActive,
 		Schedulable:    true,

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -1285,6 +1285,7 @@ func TestOpenAIStreamingResponseFailedBeforeOutputReturnsFailover(t *testing.T) 
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.False(t, failoverErr.RetryableOnSameAccount)
 	require.Contains(t, string(failoverErr.ResponseBody), "An error occurred while processing your request")
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
@@ -1326,6 +1327,7 @@ func TestOpenAIStreamingResponseFailedBeforeOutputCapacityErrorReturnsFailover(t
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.True(t, failoverErr.RetryableOnSameAccount)
 	require.Contains(t, string(failoverErr.ResponseBody), "Selected model is at capacity")
 	require.False(t, c.Writer.Written())
 	require.Empty(t, rec.Body.String())
@@ -1363,6 +1365,7 @@ func TestOpenAIStreamingResponseFailedBeforeOutputServerOverloadedCodeReturnsFai
 	require.Error(t, err)
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
+	require.False(t, failoverErr.RetryableOnSameAccount)
 	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
 	require.Contains(t, string(failoverErr.ResponseBody), "Please retry later")
 	require.False(t, c.Writer.Written())

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -116,9 +116,36 @@ func isOpenAIInstructionsRequiredError(upstreamStatusCode int, upstreamMsg strin
 	return false
 }
 
+const openAIModelCapacityErrorMarker = "selected model is at capacity"
+
+func isOpenAIModelCapacityError(upstreamStatusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	if upstreamStatusCode < http.StatusBadRequest {
+		return false
+	}
+
+	match := func(text string) bool {
+		return strings.Contains(strings.ToLower(strings.TrimSpace(text)), openAIModelCapacityErrorMarker)
+	}
+	if match(upstreamMsg) {
+		return true
+	}
+	if len(upstreamBody) == 0 {
+		return false
+	}
+	for _, path := range []string{"error.message", "response.error.message", "message"} {
+		if match(gjson.GetBytes(upstreamBody, path).String()) {
+			return true
+		}
+	}
+	return match(string(upstreamBody))
+}
+
 func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string, upstreamBody []byte) bool {
 	if upstreamStatusCode != http.StatusBadRequest && upstreamStatusCode != http.StatusServiceUnavailable {
 		return false
+	}
+	if isOpenAIModelCapacityError(upstreamStatusCode, upstreamMsg, upstreamBody) {
+		return true
 	}
 
 	hasOpenAIServerOverloadedCode := func(payload []byte) bool {
@@ -144,9 +171,6 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 		if strings.Contains(lower, "an error occurred while processing your request") {
 			return true
 		}
-		if strings.Contains(lower, "selected model is at capacity") {
-			return true
-		}
 		return strings.Contains(lower, "you can retry your request") &&
 			strings.Contains(lower, "help.openai.com") &&
 			strings.Contains(lower, "request id")
@@ -162,6 +186,20 @@ func isOpenAITransientProcessingError(upstreamStatusCode int, upstreamMsg string
 		return true
 	}
 	return match(string(upstreamBody))
+}
+
+func shouldRetryOpenAIUpstreamOnSameAccount(account *Account, upstreamStatusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	// Model capacity is an upstream model-level condition, not evidence that the
+	// selected account is unhealthy. Retry it in place for OAuth and API-key
+	// accounts alike before falling back to the existing account switch path.
+	if isOpenAIModelCapacityError(upstreamStatusCode, upstreamMsg, upstreamBody) {
+		return true
+	}
+	if account == nil || !account.IsPoolMode() {
+		return false
+	}
+	return account.IsPoolModeRetryableStatus(upstreamStatusCode) ||
+		isOpenAITransientProcessingError(upstreamStatusCode, upstreamMsg, upstreamBody)
 }
 
 func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -843,13 +843,26 @@ func TestOpenAIGatewayService_OpenAIPassthrough_RetryableStatusesTriggerFailover
 	}
 
 	testCases := []struct {
-		name           string
-		accountType    string
-		statusCode     int
-		body           string
-		expectFailover bool
-		assertRepo     func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time)
+		name                   string
+		accountType            string
+		statusCode             int
+		body                   string
+		expectFailover         bool
+		expectSameAccountRetry bool
+		assertRepo             func(t *testing.T, repo *openAIPassthroughFailoverRepo, start time.Time)
 	}{
+		{
+			name:                   "oauth_400_model_capacity",
+			accountType:            AccountTypeOAuth,
+			statusCode:             http.StatusBadRequest,
+			body:                   `{"error":{"message":"Selected model is at capacity. Please try a different model.","type":"invalid_request_error"}}`,
+			expectFailover:         true,
+			expectSameAccountRetry: true,
+			assertRepo: func(t *testing.T, repo *openAIPassthroughFailoverRepo, _ time.Time) {
+				require.Empty(t, repo.rateLimitCalls)
+				require.Empty(t, repo.overloadCalls)
+			},
+		},
 		{
 			name:        "oauth_429_rate_limit",
 			accountType: AccountTypeOAuth,
@@ -978,6 +991,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_RetryableStatusesTriggerFailover
 			if tc.expectFailover {
 				require.ErrorAs(t, err, &failoverErr)
 				require.Equal(t, tc.statusCode, failoverErr.StatusCode)
+				require.Equal(t, tc.expectSameAccountRetry, failoverErr.RetryableOnSameAccount)
 				require.False(t, c.Writer.Written(), "retryable passthrough 错误应返回 failover 错误给上层换号，而不是直接向客户端写响应")
 			} else {
 				require.False(t, errors.As(err, &failoverErr))


### PR DESCRIPTION
## 背景

#2481 已将 OpenAI 返回的 Selected model is at capacity 识别为临时 failover 错误，但同账号短退避仍受 pool_mode 限制：

- 普通 OAuth / 非池模式 API Key 账号会立即进入换号；单账号分组没有原地重试机会。
- HTTP 200 SSE 中首个客户端输出前的 response.failed 虽能 failover，但没有携带同账号重试标记。
- 开启 OpenAI 自动透传后，HTTP 400 默认直接透传，也会绕过容量重试。

模型容量不足是模型级临时状态，不应被当成当前账号失效。本 PR 在保留现有换号兜底的前提下，先对明确的容量错误执行有界同账号重试。

## 修改

- 抽出独立的 model-capacity 语义识别，仅匹配明确容量文案，不扩大普通 transient 400。
- 原生 Responses 与 Chat Completions / Messages 共用管线对 OAuth 和 API Key 统一设置 RetryableOnSameAccount。
- 自动透传 HTTP 仅对明确的 model-capacity 错误突破原样透传，其他 4xx/5xx 语义保持不变。
- 首个客户端输出前的 SSE response.failed 容量错误携带同账号重试标记；已开始输出的流仍不重放。
- 重试前把本次请求临时粘到已选账号，确保普通 OAuth 不会在外层循环中被重新负载均衡到别的账号。
- 复用现有默认策略：最多重试 3 次、每次等待 500ms；耗尽后继续使用现有账号切换上限与错误响应。
- pool_mode 的既有行为和日志事件名保持不变；普通账号使用独立的 model_capacity_same_account_retry 日志事件。

## 边界

- 不新增管理后台设置或数据库字段。
- 不修改其他 transient processing error、server_is_overloaded 或上下文窗口错误的重试策略。
- 不包含 WS v2；该传输有独立的重连和首 token 缓冲机制，应单独处理。

## 测试覆盖

- capacity 文案在 message、error.message、response.error.message 及不同错误状态下的识别。
- 普通 OAuth capacity 可同账号重试；普通 transient 400 仍只 failover。
- pool_mode 原有 transient/status-code 重试保持不变。
- 原生 HTTP、自动透传 HTTP、首输出前 SSE capacity 路径。
- 非 capacity SSE failover 不会误设同账号重试。
- 临时重试 session hash 的生成与复用。

## 验证

    go test -tags=unit ./... -count=1
    TESTCONTAINERS_RYUK_DISABLED=true go test -tags=integration -p 1 ./... -count=1
    go build -trimpath ./cmd/server
    go vet ./internal/service ./internal/handler ./internal/server/routes
    git diff --check upstream/main...HEAD

以上均通过。integration 使用 TESTCONTAINERS_RYUK_DISABLED=true 是因为本机 Docker 会立即移除 Ryuk reaper；禁用后完整 integration suite 通过，测试残留容器已清理。

Follow-up to #2481 and #2223.