### PR TITLE
feat(openai): 支持 OAuth 账号级强制 Codex CLI 身份

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1943,6 +1943,15 @@ func (a *Account) IsCodexCLIOnlyAppServerAllowed() bool {
 	return ok && v
 }
 
+// IsForceCodexIdentityEnabled 是否强制固定上游 Codex CLI 身份（accounts.extra.force_codex_identity）。
+// 与 codex_cli_only 相互独立：该开关限制入站客户端，本开关固定出站 UA，身份配对仍由终态逻辑完成。
+func (a *Account) IsForceCodexIdentityEnabled() bool {
+	if a == nil || !a.IsOpenAIOAuth() {
+		return false
+	}
+	return resolveAccountExtraBool(a.Extra, "force_codex_identity")
+}
+
 // WindowCostSchedulability 窗口费用调度状态
 type WindowCostSchedulability int
 

--- a/backend/internal/service/account_force_codex_identity_test.go
+++ b/backend/internal/service/account_force_codex_identity_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// 类型容错（string/number 等）由 resolveAccountExtraBool 自身覆盖，这里只测
+// IsForceCodexIdentityEnabled 特有的分支：默认值、开启、账号类型门禁。
+func TestAccount_IsForceCodexIdentityEnabled(t *testing.T) {
+	cases := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name:    "字段缺失默认关闭",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth},
+			want:    false,
+		},
+		{
+			name:    "开启",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{"force_codex_identity": true}},
+			want:    true,
+		},
+		{
+			name:    "非OAuth账号-APIKey始终关闭",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{"force_codex_identity": true}},
+			want:    false,
+		},
+		{
+			name:    "非OAuth账号-setup-token始终关闭",
+			account: &Account{Platform: PlatformOpenAI, Type: AccountTypeSetupToken, Extra: map[string]any{"force_codex_identity": true}},
+			want:    false,
+		},
+		{
+			name:    "非OAuth账号-其他平台始终关闭",
+			account: &Account{Platform: PlatformAnthropic, Type: AccountTypeOAuth, Extra: map[string]any{"force_codex_identity": true}},
+			want:    false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.account.IsForceCodexIdentityEnabled())
+		})
+	}
+
+	t.Run("与codex_cli_only互相独立", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra:    map[string]any{"codex_cli_only": true, "force_codex_identity": false},
+		}
+		require.True(t, account.IsCodexCLIOnlyEnabled())
+		require.False(t, account.IsForceCodexIdentityEnabled())
+
+		account2 := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra:    map[string]any{"codex_cli_only": false, "force_codex_identity": true},
+		}
+		require.False(t, account2.IsCodexCLIOnlyEnabled())
+		require.True(t, account2.IsForceCodexIdentityEnabled())
+	})
+}

--- a/backend/internal/service/openai_codex_identity_policy.go
+++ b/backend/internal/service/openai_codex_identity_policy.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+	"net/http"
+)
+
+// resolveOpenAIForceCodexIdentityEnabled 解析账号到有效母账号（spark 影子继承母账号开关，
+// 不在影子自身 extra 复制），返回 force_codex_identity 状态。
+func resolveOpenAIForceCodexIdentityEnabled(ctx context.Context, repo AccountRepository, account *Account) (bool, error) {
+	credAccount, err := resolveCredentialAccount(ctx, repo, account)
+	if err != nil {
+		return false, err
+	}
+	return credAccount.IsForceCodexIdentityEnabled(), nil
+}
+
+// applyForcedCodexCLIUserAgent 将最终出站 UA 固定为 Codex CLI。originator 与 version
+// 继续由紧随其后的 enforceCodexIdentityHeaders 统一配对和校正。
+func applyForcedCodexCLIUserAgent(header http.Header) {
+	if header != nil {
+		header.Set("user-agent", codexCLIUserAgent)
+	}
+}

--- a/backend/internal/service/openai_codex_identity_policy_test.go
+++ b/backend/internal/service/openai_codex_identity_policy_test.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// 账号自身开关语义（默认关闭/非OAuth等）已由 TestAccount_IsForceCodexIdentityEnabled 覆盖，
+// 本测试只针对 resolveOpenAIForceCodexIdentityEnabled 自身的母账号解析分支：普通/影子/坏父。
+func TestResolveOpenAIForceCodexIdentityEnabled(t *testing.T) {
+	ctx := context.Background()
+	pid := int64(100)
+
+	t.Run("普通账号-读取自身开关", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra:    map[string]any{"force_codex_identity": true},
+		}
+		repo := newStubCredRepo(nil)
+		enabled, err := resolveOpenAIForceCodexIdentityEnabled(ctx, repo, account)
+		require.NoError(t, err)
+		require.True(t, enabled)
+	})
+
+	t.Run("spark影子继承母账号开关（影子自身无extra）", func(t *testing.T) {
+		parent := &Account{
+			ID:       100,
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Extra:    map[string]any{"force_codex_identity": true},
+		}
+		shadow := &Account{ID: 200, ParentAccountID: &pid, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: nil}
+		repo := newStubCredRepo(parent)
+		enabled, err := resolveOpenAIForceCodexIdentityEnabled(ctx, repo, shadow)
+		require.NoError(t, err)
+		require.True(t, enabled)
+	})
+
+	t.Run("母账号损坏时返回错误", func(t *testing.T) {
+		shadow := &Account{ID: 200, ParentAccountID: &pid, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+		badRepo := newStubCredRepo(&Account{ID: 100, Platform: PlatformOpenAI, Type: AccountTypeAPIKey})
+		_, err := resolveOpenAIForceCodexIdentityEnabled(ctx, badRepo, shadow)
+		require.Error(t, err)
+	})
+}
+
+func TestApplyForcedCodexCLIUserAgent(t *testing.T) {
+	header := http.Header{}
+	header.Set("user-agent", "curl/8.0")
+	header.Set("originator", "opencode")
+	header.Set("version", "0.125.0")
+
+	applyForcedCodexCLIUserAgent(header)
+
+	require.Equal(t, codexCLIUserAgent, header.Get("user-agent"))
+	require.Equal(t, "opencode", header.Get("originator"))
+
+	enforceCodexIdentityHeaders(header)
+	require.Equal(t, codexCLIUserAgent, header.Get("user-agent"))
+	require.Equal(t, "codex_cli_rs", header.Get("originator"))
+	require.Equal(t, codexCLIVersion, header.Get("version"))
+	require.NotPanics(t, func() { applyForcedCodexCLIUserAgent(nil) })
+}

--- a/backend/internal/service/openai_gateway_force_codex_identity_test.go
+++ b/backend/internal/service/openai_gateway_force_codex_identity_test.go
@@ -1,0 +1,211 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+const forceCodexIdentityTUIUserAgent = "codex-tui/0.145.0 (Mac OS X 14.0; arm64) iTerm (codex-tui; 0.145.0)"
+
+func newForceCodexIdentityGinContext(path string, headers map[string]string) *gin.Context {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, path, strings.NewReader(""))
+	for key, value := range headers {
+		c.Request.Header.Set(key, value)
+	}
+	return c
+}
+
+func newForceCodexIdentityOAuthAccount(extra map[string]any) *Account {
+	return &Account{
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Credentials: map[string]any{"chatgpt_account_id": "chatgpt-acc"},
+		Extra:       extra,
+	}
+}
+
+func newForceCodexIdentityPassthroughUpstream() *httpUpstreamRecorder {
+	return &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid"}},
+		Body:       io.NopCloser(strings.NewReader("data: [DONE]\n\n")),
+	}}
+}
+
+func newForceCodexIdentityPassthroughAccount(id int64, enabled bool) *Account {
+	extra := map[string]any{"openai_passthrough": true}
+	if enabled {
+		extra["force_codex_identity"] = true
+	}
+	return &Account{
+		ID:             id,
+		Platform:       PlatformOpenAI,
+		Type:           AccountTypeOAuth,
+		Concurrency:    1,
+		Credentials:    map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-acc"},
+		Extra:          extra,
+		Status:         StatusActive,
+		Schedulable:    true,
+		RateMultiplier: f64p(1),
+	}
+}
+
+func forceCodexIdentityInputHeaders() map[string]string {
+	return map[string]string{
+		"User-Agent": forceCodexIdentityTUIUserAgent,
+		"originator": "opencode",
+	}
+}
+
+func TestOpenAIBuildUpstreamRequest_ForceCodexIdentity(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		enabled        bool
+		wantUserAgent  string
+		wantOriginator string
+		wantVersion    string
+	}{
+		{
+			name:           "默认关闭时保留最终UA并由终态逻辑自动配对",
+			path:           "/v1/responses",
+			wantUserAgent:  forceCodexIdentityTUIUserAgent,
+			wantOriginator: "codex-tui",
+		},
+		{
+			name:           "标准Responses开启时固定UA并由终态逻辑配对",
+			path:           "/v1/responses",
+			enabled:        true,
+			wantUserAgent:  codexCLIUserAgent,
+			wantOriginator: "codex_cli_rs",
+		},
+		{
+			name:           "compact开启时固定Codex CLI UA",
+			path:           "/responses/compact",
+			enabled:        true,
+			wantUserAgent:  codexCLIUserAgent,
+			wantOriginator: "codex_cli_rs",
+			wantVersion:    codexCLIVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extra := map[string]any{}
+			if tt.enabled {
+				extra["force_codex_identity"] = true
+			}
+			c := newForceCodexIdentityGinContext(tt.path, forceCodexIdentityInputHeaders())
+			svc := &OpenAIGatewayService{cfg: &config.Config{}}
+			account := newForceCodexIdentityOAuthAccount(extra)
+
+			req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, []byte(`{"model":"gpt-5"}`), "token", false, "", false)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUserAgent, req.Header.Get("user-agent"))
+			require.Equal(t, tt.wantOriginator, req.Header.Get("originator"))
+			require.Equal(t, tt.wantVersion, req.Header.Get("version"))
+		})
+	}
+}
+
+func TestOpenAIBuildUpstreamRequest_ForceCodexIdentity_MessagesBridgeIsUnchanged(t *testing.T) {
+	c := newForceCodexIdentityGinContext("/v1/responses", map[string]string{
+		"User-Agent": "luna/1.0.0",
+		"originator": "opencode",
+	})
+	setOpenAICompatMessagesBridgeContext(c, true)
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := newForceCodexIdentityOAuthAccount(map[string]any{"force_codex_identity": true})
+
+	req, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, []byte(`{"model":"gpt-5.5"}`), "token", false, "", false)
+	require.NoError(t, err)
+	require.Equal(t, "luna/1.0.0", req.Header.Get("user-agent"))
+	require.Empty(t, req.Header.Get("originator"))
+	require.Empty(t, req.Header.Get("OpenAI-Beta"))
+}
+
+func TestOpenAIPassthrough_ForceCodexIdentity(t *testing.T) {
+	const body = `{"model":"gpt-5.2","stream":true,"store":false,"input":[{"type":"text","text":"hi"}]}`
+	tests := []struct {
+		name           string
+		enabled        bool
+		wantUserAgent  string
+		wantOriginator string
+	}{
+		{
+			name:           "默认关闭时保留最终UA并由终态逻辑自动配对",
+			wantUserAgent:  forceCodexIdentityTUIUserAgent,
+			wantOriginator: "codex-tui",
+		},
+		{
+			name:           "开启时固定Codex CLI UA",
+			enabled:        true,
+			wantUserAgent:  codexCLIUserAgent,
+			wantOriginator: "codex_cli_rs",
+		},
+	}
+
+	for i, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newForceCodexIdentityGinContext("/v1/responses", forceCodexIdentityInputHeaders())
+			upstream := newForceCodexIdentityPassthroughUpstream()
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			account := newForceCodexIdentityPassthroughAccount(int64(i+1), tt.enabled)
+
+			_, err := svc.Forward(context.Background(), c, account, []byte(body))
+			require.NoError(t, err)
+			require.NotNil(t, upstream.lastReq)
+			require.Equal(t, tt.wantUserAgent, upstream.lastReq.Header.Get("user-agent"))
+			require.Equal(t, tt.wantOriginator, upstream.lastReq.Header.Get("originator"))
+		})
+	}
+}
+
+func TestBuildOpenAIWSHeaders_ForceCodexIdentity(t *testing.T) {
+	tests := []struct {
+		name           string
+		enabled        bool
+		wantUserAgent  string
+		wantOriginator string
+	}{
+		{
+			name:           "默认关闭时保留最终UA并由终态逻辑自动配对",
+			wantUserAgent:  forceCodexIdentityTUIUserAgent,
+			wantOriginator: "codex-tui",
+		},
+		{
+			name:           "开启时固定Codex CLI UA",
+			enabled:        true,
+			wantUserAgent:  codexCLIUserAgent,
+			wantOriginator: "codex_cli_rs",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extra := map[string]any{}
+			if tt.enabled {
+				extra["force_codex_identity"] = true
+			}
+			c := newForceCodexIdentityGinContext("/v1/responses", forceCodexIdentityInputHeaders())
+			svc := &OpenAIGatewayService{cfg: &config.Config{}}
+			account := newForceCodexIdentityOAuthAccount(extra)
+
+			headers, _, err := svc.buildOpenAIWSHeaders(context.Background(), c, account, "token", OpenAIWSProtocolDecision{}, false, "", "", "")
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUserAgent, headers.Get("user-agent"))
+			require.Equal(t, tt.wantOriginator, headers.Get("originator"))
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -1102,6 +1102,17 @@ func (s *OpenAIGatewayService) buildUpstreamRequest(ctx context.Context, c *gin.
 	// （Chrome/Firefox/Safari/Edge 等），替换为后台配置的 Codex UA，避免 Cloudflare 触发 JS 质询。
 	s.overrideBrowserUserAgent(ctx, account, req)
 
+	compatMessagesBridge := isOpenAICompatMessagesBridgeContext(c) || isOpenAICompatMessagesBridgeBody(body)
+	if !compatMessagesBridge {
+		forceCodexIdentity, err := resolveOpenAIForceCodexIdentityEnabled(ctx, s.accountRepo, account)
+		if err != nil {
+			return nil, fmt.Errorf("resolve force codex identity: %w", err)
+		}
+		if forceCodexIdentity {
+			applyForcedCodexCLIUserAgent(req.Header)
+		}
+	}
+
 	// 终态收口：originator 必须与最终 User-Agent 首段配套且为官方身份，否则上游 404（issue #3901）。
 	if account.Type == AccountTypeOAuth {
 		enforceCodexIdentityHeaders(req.Header)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -447,6 +447,14 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 	// （Chrome/Firefox/Safari/Edge 等），替换为后台配置的 Codex UA，避免 Cloudflare 触发 JS 质询。
 	s.overrideBrowserUserAgent(ctx, account, req)
 
+	forceCodexIdentity, err := resolveOpenAIForceCodexIdentityEnabled(ctx, s.accountRepo, account)
+	if err != nil {
+		return nil, fmt.Errorf("resolve force codex identity: %w", err)
+	}
+	if forceCodexIdentity {
+		applyForcedCodexCLIUserAgent(req.Header)
+	}
+
 	// 终态收口：originator 必须与最终 User-Agent 首段配套且为官方身份，非官方 UA 整体回退为
 	// 默认 Codex CLI 身份（承接原「非 Codex UA 安全兜底」，并修复其把 codex-tui 等官方 UA 改写为
 	// codex_cli_rs 造成的 originator 错配 404），详见 issue #3901。

--- a/backend/internal/service/openai_ws_forwarder_payload.go
+++ b/backend/internal/service/openai_ws_forwarder_payload.go
@@ -148,6 +148,14 @@ func (s *OpenAIGatewayService) buildOpenAIWSHeaders(
 	if s != nil && s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
 		headers.Set("user-agent", codexCLIUserAgent)
 	}
+	forceCodexIdentity, err := resolveOpenAIForceCodexIdentityEnabled(ctx, s.accountRepo, account)
+	if err != nil {
+		return nil, sessionResolution, fmt.Errorf("resolve force codex identity: %w", err)
+	}
+	if forceCodexIdentity {
+		applyForcedCodexCLIUserAgent(headers)
+	}
+
 	// 终态收口：originator 必须与最终 user-agent 首段配套且为官方身份，非官方 UA 整体回退为
 	// 默认 Codex CLI 身份（承接原「非 Codex UA 兜底」，并修复其把 codex-tui 等官方 UA 改写为
 	// codex_cli_rs 造成的 originator 错配 404），详见 issue #3901。

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3003,6 +3003,27 @@
         </div>
       </div>
 
+      <!-- OpenAI OAuth 账号级固定 Codex CLI 身份开关 -->
+      <div
+        v-if="form.platform === 'openai' && form.type === 'oauth'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label for="create-openai-force-codex-identity-toggle" class="input-label mb-0">{{ t('admin.accounts.openai.forceCodexIdentity') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.forceCodexIdentityDesc') }}
+            </p>
+          </div>
+          <Toggle
+            id="create-openai-force-codex-identity-toggle"
+            v-model="forceCodexIdentityEnabled"
+            data-testid="create-openai-force-codex-identity-toggle"
+            :aria-label="t('admin.accounts.openai.forceCodexIdentity')"
+          />
+        </div>
+      </div>
+
       <!-- OpenAI Compact 能力配置 -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -3834,6 +3855,7 @@ const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
 const codexCLIOnlyAppServerEnabled = ref(false)
+const forceCodexIdentityEnabled = ref(false)
 type AnthropicAPIKeyAuthScheme = 'x_api_key' | 'authorization_bearer'
 const anthropicPassthroughEnabled = ref(false)
 const anthropicAPIKeyAuthScheme = ref<AnthropicAPIKeyAuthScheme>('x_api_key')
@@ -4284,6 +4306,7 @@ watch(
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       codexCLIOnlyEnabled.value = false
       codexCLIOnlyAppServerEnabled.value = false
+      forceCodexIdentityEnabled.value = false
     }
     if (newPlatform !== 'anthropic') {
       anthropicPassthroughEnabled.value = false
@@ -4313,6 +4336,7 @@ watch(
     if (platform === 'openai' && category !== 'oauth-based') {
       codexCLIOnlyEnabled.value = false
       codexCLIOnlyAppServerEnabled.value = false
+      forceCodexIdentityEnabled.value = false
     }
     if (platform !== 'anthropic' || category !== 'apikey') {
       anthropicPassthroughEnabled.value = false
@@ -4713,6 +4737,7 @@ const resetForm = () => {
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   codexCLIOnlyEnabled.value = false
   codexCLIOnlyAppServerEnabled.value = false
+  forceCodexIdentityEnabled.value = false
   anthropicPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
@@ -4810,6 +4835,12 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.codex_cli_only_allow_app_server = true
   } else {
     delete extra.codex_cli_only_allow_app_server
+  }
+  // 只支持真实 OpenAI OAuth；API Key 等类型不保留该字段。
+  if (form.type === 'oauth' && forceCodexIdentityEnabled.value) {
+    extra.force_codex_identity = true
+  } else {
+    delete extra.force_codex_identity
   }
   if (openAICompactMode.value !== 'auto') {
     extra.openai_compact_mode = openAICompactMode.value

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1985,6 +1985,27 @@
         </div>
       </div>
 
+      <!-- OpenAI OAuth 账号级固定 Codex CLI 身份开关 -->
+      <div
+        v-if="account?.platform === 'openai' && account?.type === 'oauth' && !isSparkShadow"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label for="edit-openai-force-codex-identity-toggle" class="input-label mb-0">{{ t('admin.accounts.openai.forceCodexIdentity') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.forceCodexIdentityDesc') }}
+            </p>
+          </div>
+          <Toggle
+            id="edit-openai-force-codex-identity-toggle"
+            v-model="forceCodexIdentityEnabled"
+            data-testid="edit-openai-force-codex-identity-toggle"
+            :aria-label="t('admin.accounts.openai.forceCodexIdentity')"
+          />
+        </div>
+      </div>
+
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
         class="border-t border-gray-200 pt-4 dark:border-dark-600 space-y-4"
@@ -2921,6 +2942,7 @@ const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
 const codexCLIOnlyAppServerEnabled = ref(false)
+const forceCodexIdentityEnabled = ref(false)
 type CodexImageToolMode = 'inherit' | 'enabled' | 'disabled' | 'block'
 const codexImageToolMode = ref<CodexImageToolMode>('inherit')
 type AnthropicAPIKeyAuthScheme = 'x_api_key' | 'authorization_bearer'
@@ -3373,6 +3395,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   codexCLIOnlyEnabled.value = false
   codexCLIOnlyAppServerEnabled.value = false
+  forceCodexIdentityEnabled.value = false
   codexImageToolMode.value = 'inherit'
   anthropicPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
@@ -3423,6 +3446,10 @@ const syncFormFromAccount = (newAccount: Account | null) => {
       codexCLIOnlyEnabled.value = extra?.codex_cli_only === true
       codexCLIOnlyAppServerEnabled.value =
         extra?.codex_cli_only_allow_app_server === true
+    }
+    // force_codex_identity 只支持真实 OpenAI OAuth（type=oauth），不包括 setup-token。
+    if (newAccount.type === 'oauth' && !isSparkShadow.value) {
+      forceCodexIdentityEnabled.value = extra?.force_codex_identity === true
     }
     const credentials = newAccount.credentials as Record<string, unknown> | undefined
     const compactMappings = credentials?.compact_model_mapping as Record<string, string> | undefined
@@ -4698,6 +4725,12 @@ const handleSubmit = async () => {
         } else {
           delete newExtra.codex_cli_only_allow_app_server
         }
+      }
+      // 仅真实 OpenAI OAuth 可保留 force_codex_identity；其余类型统一清理。
+      if (props.account.type === 'oauth' && !isSparkShadow.value && forceCodexIdentityEnabled.value) {
+        newExtra.force_codex_identity = true
+      } else {
+        delete newExtra.force_codex_identity
       }
 
       updatePayload.extra = newExtra

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -5,13 +5,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   createAccountMock,
   probeUpstreamBillingMock,
+  checkMixedChannelRiskMock,
   importCodexSessionMock,
   createOpenAICodexPATMock,
+  validateOpenAIRefreshTokenMock,
 } = vi.hoisted(() => ({
   createAccountMock: vi.fn(),
   probeUpstreamBillingMock: vi.fn(),
+  checkMixedChannelRiskMock: vi.fn().mockResolvedValue({ has_risk: false }),
   importCodexSessionMock: vi.fn(),
   createOpenAICodexPATMock: vi.fn(),
+  validateOpenAIRefreshTokenMock: vi.fn(),
 }))
 
 vi.mock('@/stores/app', () => ({
@@ -19,6 +23,7 @@ vi.mock('@/stores/app', () => ({
     showError: vi.fn(),
     showSuccess: vi.fn(),
     showWarning: vi.fn(),
+    showInfo: vi.fn(),
   }),
 }))
 
@@ -31,7 +36,7 @@ vi.mock('@/api/admin', () => ({
     accounts: {
       create: createAccountMock,
       probeUpstreamBilling: probeUpstreamBillingMock,
-      checkMixedChannelRisk: vi.fn().mockResolvedValue({ has_risk: false }),
+      checkMixedChannelRisk: checkMixedChannelRiskMock,
       importCodexSession: importCodexSessionMock,
       createOpenAICodexPAT: createOpenAICodexPATMock,
     },
@@ -48,6 +53,29 @@ vi.mock('@/api/admin', () => ({
 vi.mock('@/api/admin/accounts', () => ({
   getAntigravityDefaultModelMapping: vi.fn().mockResolvedValue([]),
 }))
+
+vi.mock('@/composables/useOpenAIOAuth', async () => {
+  const { ref } = await vi.importActual<typeof import('vue')>('vue')
+  return {
+    useOpenAIOAuth: () => ({
+      authUrl: ref(''),
+      sessionId: ref(''),
+      oauthState: ref(''),
+      loading: ref(false),
+      error: ref(''),
+      generateAuthUrl: vi.fn(),
+      exchangeAuthCode: vi.fn(),
+      validateRefreshToken: validateOpenAIRefreshTokenMock,
+      buildCredentials: (tokenInfo: Record<string, unknown>) => ({
+        access_token: tokenInfo.access_token,
+        refresh_token: tokenInfo.refresh_token,
+        chatgpt_account_id: tokenInfo.chatgpt_account_id,
+      }),
+      buildExtraInfo: () => ({}),
+      resetState: vi.fn(),
+    }),
+  }
+})
 
 vi.mock('vue-i18n', async () => {
   const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
@@ -75,9 +103,16 @@ const OAuthAuthorizationFlowStub = defineComponent({
     initialInputMethod: String,
   },
   data: () => ({ inputMethod: 'manual' }),
-  emits: ['import-codex-session', 'import-codex-pat'],
+  emits: ['validate-refresh-token', 'import-codex-session', 'import-codex-pat'],
   template: `
     <div>
+      <button
+        type="button"
+        data-testid="validate-openai-refresh-token"
+        @click="$emit('validate-refresh-token', 'refresh-token')"
+      >
+        validate
+      </button>
       <button data-testid="import-codex-session" @click="$emit('import-codex-session', 'session-json')">session</button>
       <button data-testid="import-codex-pat" @click="$emit('import-codex-pat', 'pat-token')">pat</button>
     </div>
@@ -149,6 +184,7 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
   beforeEach(() => {
     createAccountMock.mockReset().mockResolvedValue({ id: 42, platform: 'openai', type: 'apikey' })
     probeUpstreamBillingMock.mockReset().mockResolvedValue({})
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
     importCodexSessionMock.mockReset().mockResolvedValue({
       created: 1,
       updated: 0,
@@ -337,5 +373,71 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     await flushPromises()
 
     expect(createOpenAICodexPATMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBe(false)
+  })
+})
+
+describe('CreateAccountModal force_codex_identity', () => {
+  beforeEach(() => {
+    createAccountMock.mockReset().mockResolvedValue({})
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+    validateOpenAIRefreshTokenMock.mockReset().mockResolvedValue({
+      access_token: 'oauth-access-token',
+      refresh_token: 'oauth-refresh-token',
+      chatgpt_account_id: 'chatgpt-account',
+      email: 'oauth@example.com',
+    })
+  })
+
+  it('keeps the OpenAI OAuth option available after switching from Anthropic setup-token', async () => {
+    const wrapper = mountModal()
+
+    await wrapper.get('input[type="radio"][value="setup-token"]').setValue(true)
+    await selectButtonByText(wrapper, 'OpenAI')
+
+    expect(wrapper.find('input[type="radio"][value="setup-token"]').exists()).toBe(false)
+    expect(wrapper.find('[data-testid="create-openai-force-codex-identity-toggle"]').exists()).toBe(true)
+
+    await wrapper.get('form#create-account-form input[type="text"][required]').setValue('OpenAI OAuth')
+    await wrapper.get('[data-testid="create-openai-force-codex-identity-toggle"]').trigger('click')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await wrapper.get('[data-testid="validate-openai-refresh-token"]').trigger('click')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock.mock.calls[0]?.[0]).toMatchObject({
+      platform: 'openai',
+      type: 'oauth',
+      extra: { force_codex_identity: true },
+    })
+  })
+
+  it('hides and omits the option for OpenAI API Key accounts', async () => {
+    const wrapper = mountModal()
+
+    await selectButtonByText(wrapper, 'OpenAI')
+    await wrapper.get('[data-testid="create-openai-force-codex-identity-toggle"]').trigger('click')
+    await selectButtonByText(wrapper, 'API Key')
+
+    expect(wrapper.find('[data-testid="create-openai-force-codex-identity-toggle"]').exists()).toBe(false)
+
+    await wrapper.get('form#create-account-form input[type="text"][required]').setValue('OpenAI API Key')
+    await wrapper.get('form#create-account-form input[type="password"][required]').setValue('sk-test')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock.mock.calls[0]?.[0]).toMatchObject({
+      platform: 'openai',
+      type: 'apikey',
+    })
+    expect(createAccountMock.mock.calls[0]?.[0]?.extra ?? {}).not.toHaveProperty('force_codex_identity')
+  })
+
+  it('hides the OpenAI-only option for Anthropic setup-token accounts', async () => {
+    const wrapper = mountModal()
+
+    await wrapper.get('input[type="radio"][value="setup-token"]').setValue(true)
+
+    expect(wrapper.find('[data-testid="create-openai-force-codex-identity-toggle"]').exists()).toBe(false)
   })
 })

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -290,6 +290,27 @@ function buildOpenAISetupTokenAccount() {
   } as any
 }
 
+// 真实 OpenAI OAuth 账号 fixture（type=oauth，带 access_token/chatgpt_account_id），
+// 用于 force_codex_identity 等仅限 type=oauth 的开关测试，与 setup-token fixture 区分。
+function buildOpenAIOAuthAccount() {
+  return {
+    ...buildAccount(),
+    type: 'oauth',
+    credentials: {
+      access_token: 'oauth-access-token',
+      refresh_token: 'oauth-refresh-token',
+      chatgpt_account_id: 'chatgpt-acc',
+      model_mapping: {
+        'gpt-5.2': 'gpt-5.2'
+      }
+    },
+    extra: {
+      openai_oauth_responses_websockets_v2_mode: 'ctx_pool',
+      openai_oauth_responses_websockets_v2_enabled: true
+    }
+  } as any
+}
+
 function mountModal(account = buildAccount()) {
   return mount(EditAccountModal, {
     props: {
@@ -1020,6 +1041,97 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock).toHaveBeenCalledTimes(1)
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_oauth_responses_websockets_v2_mode).toBe('http_bridge')
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_oauth_responses_websockets_v2_enabled).toBe(true)
+  })
+
+  it('OpenAI OAuth 账号开启后提交 force_codex_identity 字段', async () => {
+    const account = buildOpenAIOAuthAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+
+    await wrapper.get('[data-testid="edit-openai-force-codex-identity-toggle"]').trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.force_codex_identity).toBe(true)
+  })
+
+  it('关闭已开启的 force_codex_identity 时从 extra 中删除该键（不写 false）', async () => {
+    const account = buildOpenAIOAuthAccount()
+    account.extra.force_codex_identity = true
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+
+    expect(
+      wrapper.get('[data-testid="edit-openai-force-codex-identity-toggle"]').attributes('aria-checked')
+    ).toBe('true')
+
+    await wrapper.get('[data-testid="edit-openai-force-codex-identity-toggle"]').trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty('force_codex_identity')
+  })
+
+  it('OpenAI APIKey 账号不展示 force_codex_identity 开关', async () => {
+    const account = buildAccount()
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="edit-openai-force-codex-identity-toggle"]').exists()).toBe(false)
+  })
+
+  it('OpenAI setup-token 账号不展示 force_codex_identity 开关', async () => {
+    const account = buildOpenAISetupTokenAccount()
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="edit-openai-force-codex-identity-toggle"]').exists()).toBe(false)
+  })
+
+  it('OpenAI setup-token 账号提交时不写入 force_codex_identity', async () => {
+    const account = buildOpenAISetupTokenAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty('force_codex_identity')
+  })
+
+  it('OpenAI spark shadow 不展示 force_codex_identity 开关', async () => {
+    const account = buildOpenAISparkShadowAccount()
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="edit-openai-force-codex-identity-toggle"]').exists()).toBe(false)
+  })
+
+  it('OpenAI spark shadow 提交时清理自身 extra 的 force_codex_identity', async () => {
+    const account = buildOpenAISparkShadowAccount()
+    account.extra = {
+      force_codex_identity: true
+    }
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty('force_codex_identity')
   })
 
   it('allows saving apikey account when backend redacted api_key but credentials_status reports it exists', async () => {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -562,6 +562,9 @@ export default {
         codexCLIOnlyAppServer: 'Allow Codex app-server clients',
         codexCLIOnlyAppServerDesc:
           "Effective only when the switch above is on. When enabled, this account also allows third-party clients that embed the Codex engine over the app-server protocol (e.g. Claude Code's codex plugin); they still pass the global engine-fingerprint gate. OR-combined with the global app-server toggle.",
+        forceCodexIdentity: 'Force Codex CLI identity',
+        forceCodexIdentityDesc:
+          'Only applies to OpenAI OAuth. Enable to pin the final User-Agent to Codex CLI for Responses, compact, passthrough, and WebSocket requests; the gateway then pairs originator and enforces the supported version automatically. Messages compatibility requests remain unchanged: this option does not force User-Agent or add originator. When disabled, the gateway still automatically pairs the final Codex identity.',
         codexImageTool: 'Codex image bridge policy',
         codexImageToolDesc:
           'Controls the hosted image_generation bridge and client-declared image tools on Codex /responses text requests. Hosted auto-injection applies only to non-Responses Lite requests. Account policy takes precedence over channel and global settings; standalone image-generation endpoints are unaffected.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -622,6 +622,9 @@ export default {
         codexCLIOnlyDesc: '仅对 OpenAI OAuth 生效。开启后仅允许 Codex 官方客户端家族访问；关闭后完全绕过并保持原逻辑。',
         codexCLIOnlyAppServer: '允许 Codex app-server 客户端',
         codexCLIOnlyAppServerDesc: '仅在上方开关开启时生效。开启后本账号额外放行内嵌 Codex 引擎、经 app-server 协议接入的第三方客户端（如 Claude Code 的 codex 插件），仍需通过全局引擎指纹门；与全局 app-server 开关取 OR（任一开即放行）。',
+        forceCodexIdentity: '强制固定 Codex CLI 身份',
+        forceCodexIdentityDesc:
+          '仅对 OpenAI OAuth 生效。开启后，Responses、compact、透传和 WebSocket 请求的最终 User-Agent 固定为 Codex CLI，再由网关自动配对 originator 并校正支持的 version。Messages 兼容请求完全不变：本开关不强制 User-Agent，也不新增 originator。关闭时网关仍会按最终 Codex 身份自动配对。',
         codexImageTool: 'Codex 图片桥接策略',
         codexImageToolDesc:
           '统一控制 Codex /responses 文本请求的 hosted image_generation 桥接和客户端图片工具声明。hosted 工具自动注入仅适用于非 Responses Lite 请求；账号级策略优先于渠道和全局配置，不影响独立图片生成接口。',


### PR DESCRIPTION
## 背景

#3984 已在 OpenAI OAuth 请求的最终出站阶段自动配对 User-Agent、originator 和最低 version，解决身份错配问题。但现有 `gateway.force_codex_cli` 是全局静态配置，无法按账号灰度控制；部分部署需要只将特定 OAuth 账号固定为 Codex CLI 身份，同时让其他账号继续保留 `codex-tui` 等官方客户端身份。

## 方案

- 新增账号级 `extra.force_codex_identity`，默认关闭，仅对真实 OpenAI OAuth 账号生效。
- 开启后，在 native Responses、compact、passthrough 和 WebSocket 的终态身份收口前，将最终 User-Agent 固定为 Codex CLI；originator 配对和 version 校正继续复用 #3984 的 `enforceCodexIdentityHeaders`。
- Spark 影子账号从母账号继承该策略，不在影子账号自身复制配置。
- API Key 与 setup-token 账号不受影响。
- Messages 兼容桥保持 #3984 的最小化请求行为，不强制 User-Agent，也不新增 originator。
- 在账号新增和编辑界面提供开关，并补充中英文说明及状态机测试。

## 与 #3984 的关系

本 PR 不替换或回退 #3984。开关关闭时完全沿用 #3984 的自动身份配对；开关开启时只增加账号级的 Codex CLI User-Agent 覆盖，随后仍由 #3984 做统一终态校验。

## 兼容性

- 配置保存在现有 `accounts.extra` JSON 中，无需数据库迁移。
- 字段缺失等价于关闭，默认行为不变。
- 关闭开关时删除该键，不写入冗余的 `false`。

## 验证

- `go test ./internal/service/...`
- `go test ./internal/pkg/openai/...`
- `golangci-lint run ./...`
- Create/Edit Account Modal Vitest：35 个测试通过
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm build`
- 实际 OpenAI OAuth 账号在全局 `force_codex_cli=false`、账号开关开启时调用 `gpt-5.6-luna` 的 `/v1/responses` 返回 HTTP 200；该结果作为端到端行为验证，不等同于出站 header 抓包。