### PR TITLE
fix(deploy): 修复 Redis command YAML 折叠陷阱导致 --requirepass 静默失效

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -113,13 +113,12 @@ services:
     restart: unless-stopped
     volumes:
       - ./redis_data:/data:Z
-    command: >
-        sh -c '
-          redis-server
-          --save 60 1
-          --appendonly yes
-          --appendfsync everysec
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+    command:
+      - sh
+      - -c
+      - >-
+        exec redis-server --save 60 1 --appendonly yes --appendfsync everysec
+        ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - REDISCLI_AUTH=${REDIS_PASSWORD:-}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -229,13 +229,12 @@ services:
     volumes:
       # Local directory mapping for easy migration
       - ./redis_data:/data:Z
-    command: >
-        sh -c '
-          redis-server
-          --save 60 1
-          --appendonly yes
-          --appendfsync everysec
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+    command:
+      - sh
+      - -c
+      - >-
+        exec redis-server --save 60 1 --appendonly yes --appendfsync everysec
+        ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -240,13 +240,12 @@ services:
         hard: 100000
     volumes:
       - redis_data:/data
-    command: >
-      sh -c '
-        redis-server
-        --save 60 1
-        --appendonly yes
-        --appendfsync everysec
-        ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+    command:
+      - sh
+      - -c
+      - >-
+        exec redis-server --save 60 1 --appendonly yes --appendfsync everysec
+        ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)


### PR DESCRIPTION
## 问题

三个 Docker Compose 文件中 Redis 服务的 `command` 使用 YAML folded scalar (`>`)：

```yaml
command: >
  sh -c '
    redis-server
    --save 60 1
    --appendonly yes
    --appendfsync everysec
    ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
```

`sh -c '` 行的缩进（4 空格）比后续参数行（8 空格）浅，按 YAML `>` 折叠规则，更深缩进的行之间**保留换行符**而非折叠成空格。解析结果：

```json
["sh", "-c", "\n  redis-server\n  --save 60 1\n  ..."]
```

shell 把换行当作命令分隔符，`redis-server` 以**无参数默认配置**启动，`--save`、`--appendonly`、`--requirepass` 全部静默失效。因为 `redis-server` 是前台阻塞进程，后续行永远不会执行。

**后果**：即使 `.env` 中设置了 `REDIS_PASSWORD`，Redis 仍以无密码运行。端口映射虽然已在 #18790386 移除，但若攻击者通过其他途径进入 Docker 内网，Redis 仍处于无认证状态。

## 修复

改为数组形式 `command` + `>-` 折叠标量：

```yaml
command:
  - sh
  - -c
  - >-
    exec redis-server --save 60 1 --appendonly yes --appendfsync everysec
    ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}
```

- 数组形式确保 `sh` 精确收到三个参数，无歧义
- `>-` 将同缩进行的换行折叠为空格，`sh -c` 收到完整的单行命令
- `exec` 让 `redis-server` 替换 sh 进程成为 PID 1，正确接收 Docker SIGTERM

## 验证

```bash
# 有密码
$ POSTGRES_PASSWORD=dummy REDIS_PASSWORD=testpass123 docker compose -f deploy/docker-compose.yml config
# redis.command 解析为:
# exec redis-server --save 60 1 --appendonly yes --appendfsync everysec --requirepass "testpass123" ✓

# 无密码
$ POSTGRES_PASSWORD=dummy docker compose -f deploy/docker-compose.yml config
# redis.command 解析为:
# exec redis-server --save 60 1 --appendonly yes --appendfsync everysec ✓
```

三个文件均已验证：
- `deploy/docker-compose.yml`
- `deploy/docker-compose.dev.yml`
- `deploy/docker-compose.local.yml`

Fixes #2511
Fixes #291