### PR TITLE
fix(frontend): default Codex/CC Switch key templates to gpt-5.6

### DIFF
--- a/frontend/src/components/keys/UseKeyModal.vue
+++ b/frontend/src/components/keys/UseKeyModal.vue
@@ -534,8 +534,8 @@ function generateOpenAIFiles(baseUrl: string, apiKey: string): FileConfig[] {
 
   // config.toml content
   const configContent = `model_provider = "OpenAI"
-model = "gpt-5.5"
-review_model = "gpt-5.5"
+model = "gpt-5.6"
+review_model = "gpt-5.6"
 model_reasoning_effort = "xhigh"
 disable_response_storage = true
 network_access = "enabled"
@@ -574,8 +574,8 @@ function generateOpenAIWsFiles(baseUrl: string, apiKey: string): FileConfig[] {
 
   // config.toml content with WebSocket v2
   const configContent = `model_provider = "OpenAI"
-model = "gpt-5.5"
-review_model = "gpt-5.5"
+model = "gpt-5.6"
+review_model = "gpt-5.6"
 model_reasoning_effort = "xhigh"
 disable_response_storage = true
 network_access = "enabled"

--- a/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/UseKeyModal.spec.ts
@@ -17,7 +17,7 @@ vi.mock('@/composables/useClipboard', () => ({
 import UseKeyModal from '../UseKeyModal.vue'
 
 describe('UseKeyModal', () => {
-  it('renders GPT-5.5 and goals feature in OpenAI Codex config', () => {
+  it('renders GPT-5.6 and goals feature in OpenAI Codex config', () => {
     const wrapper = mount(UseKeyModal, {
       props: {
         show: true,
@@ -41,15 +41,15 @@ describe('UseKeyModal', () => {
     const configToml = codeBlocks.find((content) => content.includes('model_provider = "OpenAI"'))
 
     expect(configToml).toBeDefined()
-    expect(configToml).toContain('model = "gpt-5.5"')
-    expect(configToml).toContain('review_model = "gpt-5.5"')
+    expect(configToml).toContain('model = "gpt-5.6"')
+    expect(configToml).toContain('review_model = "gpt-5.6"')
     expect(configToml).not.toContain('model = "gpt-5.4"')
     expect(configToml).not.toContain('model_context_window')
     expect(configToml).not.toContain('model_auto_compact_token_limit')
     expect(configToml).toContain('[features]\ngoals = true')
   })
 
-  it('renders GPT-5.5 and goals feature in OpenAI Codex WebSocket config', async () => {
+  it('renders GPT-5.6 and goals feature in OpenAI Codex WebSocket config', async () => {
     const wrapper = mount(UseKeyModal, {
       props: {
         show: true,
@@ -81,8 +81,8 @@ describe('UseKeyModal', () => {
     const configToml = codeBlocks.find((content) => content.includes('supports_websockets = true'))
 
     expect(configToml).toBeDefined()
-    expect(configToml).toContain('model = "gpt-5.5"')
-    expect(configToml).toContain('review_model = "gpt-5.5"')
+    expect(configToml).toContain('model = "gpt-5.6"')
+    expect(configToml).toContain('review_model = "gpt-5.6"')
     expect(configToml).not.toContain('model = "gpt-5.4"')
     expect(configToml).not.toContain('model_context_window')
     expect(configToml).not.toContain('model_auto_compact_token_limit')

--- a/frontend/src/utils/__tests__/ccswitchImport.spec.ts
+++ b/frontend/src/utils/__tests__/ccswitchImport.spec.ts
@@ -12,7 +12,7 @@ function paramsFromDeeplink(deeplink: string): URLSearchParams {
 
 describe('ccswitchImport utils', () => {
   it('defaults OpenAI CC Switch imports to the current Codex model', () => {
-    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.5')
+    expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.6')
   })
 
   const baseInput = {

--- a/frontend/src/utils/ccswitchImport.ts
+++ b/frontend/src/utils/ccswitchImport.ts
@@ -1,6 +1,6 @@
 import type { GroupPlatform } from '@/types'
 
-export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.5'
+export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.6'
 
 export type CcSwitchClientType = 'claude' | 'gemini'
 


### PR DESCRIPTION
Closes #4029

## English

Two frontend spots hardcoded `gpt-5.5` as the Codex default model, both stale now that GPT-5.6 is available and already present in the `openaiModels` map / backend pricing:

- `frontend/src/components/keys/UseKeyModal.vue` — `generateOpenAIFiles()` and `generateOpenAIWsFiles()` (the "Codex CLI" and "Codex CLI (WebSocket)" tabs) emitted `model = "gpt-5.5"` / `review_model = "gpt-5.5"`.
- `frontend/src/utils/ccswitchImport.ts` — `OPENAI_CC_SWITCH_CODEX_MODEL = "gpt-5.5"`, used for the CC Switch import deeplink.

Users copying the generated Codex config or importing into CC Switch got a config pinned to `gpt-5.5` with no hint that 5.6 exists, and had to edit it by hand.

### Change
Bump both defaults (`model` + `review_model`) to `gpt-5.6`, and update the corresponding specs (`UseKeyModal.spec.ts`, `ccswitchImport.spec.ts`).

This is a minimal literal bump. A follow-up could source the default from `openaiModels` so it never drifts again, but that is a larger refactor and left out here to keep the change focused.

### Testing
`vitest run` on the two affected spec files — 10 tests pass.

---

## 中文

前端有两处把 `gpt-5.5` 写死为 Codex 的默认模型，在 GPT-5.6 已可用（且已存在于 `openaiModels` 与后端定价数据）的情况下都已过时：

- `frontend/src/components/keys/UseKeyModal.vue` —— `generateOpenAIFiles()` 与 `generateOpenAIWsFiles()`（"Codex CLI" 与 "Codex CLI (WebSocket)" 分页）输出 `model = "gpt-5.5"` / `review_model = "gpt-5.5"`。
- `frontend/src/utils/ccswitchImport.ts` —— `OPENAI_CC_SWITCH_CODEX_MODEL = "gpt-5.5"`，用于 CC Switch 导入 deeplink。

用户复制生成的 Codex 配置、或导入到 CC Switch 后，得到的是写死在 `gpt-5.5` 上的配置，没有任何提示 5.6 已可用，只能手动修改。

### 改动
将两处默认值（`model` + `review_model`）提升到 `gpt-5.6`，并同步更新对应测试（`UseKeyModal.spec.ts`、`ccswitchImport.spec.ts`）。

这是最小的字面量提升。后续可以让默认值直接从 `openaiModels` 读取以彻底避免再次过时，但那是更大的重构，本 PR 为保持聚焦未纳入。

### 测试
对两个受影响的测试文件运行 `vitest run` —— 10 个测试全部通过。