### PR TITLE
fix(usage): make last-24-hours preset a true rolling window

### DIFF
--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -42,7 +42,7 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 	var startTime, endTime time.Time
 
 	if startDate != "" {
-		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
+		if t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDate, userTZ); err == nil {
 			startTime = t
 		} else {
 			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
@@ -52,8 +52,12 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 	}
 
 	if endDate != "" {
-		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
-			endTime = t.Add(24 * time.Hour) // Include the end date
+		if t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDate, userTZ); err == nil {
+			if hasTime {
+				endTime = t
+			} else {
+				endTime = t.Add(24 * time.Hour) // Include the end date
+			}
 		} else {
 			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 		}

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -146,22 +146,24 @@ func (h *UsageHandler) List(c *gin.Context) {
 	var startTime, endTime *time.Time
 	userTZ := c.Query("timezone") // Get user's timezone from request
 	if startDateStr := c.Query("start_date"); startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
 		startTime = &t
 	}
 
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		// Use half-open range [start, end), move to next calendar day start (DST-safe).
-		t = t.AddDate(0, 0, 1)
+		// Use half-open range [start, end); date-only values cover the whole end day (DST-safe).
+		if !hasTime {
+			t = t.AddDate(0, 0, 1)
+		}
 		endTime = &t
 	}
 
@@ -283,18 +285,21 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 
 	if startDateStr != "" && endDateStr != "" {
 		var err error
-		startTime, err = timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		startTime, _, err = timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		endTime, err = timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		var endHasTime bool
+		endTime, endHasTime, err = timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		// 与 SQL 条件 created_at < end 对齐，使用次日 00:00 作为上边界（DST-safe）。
-		endTime = endTime.AddDate(0, 0, 1)
+		// 与 SQL 条件 created_at < end 对齐，纯日期使用次日 00:00 作为上边界（DST-safe）。
+		if !endHasTime {
+			endTime = endTime.AddDate(0, 0, 1)
+		}
 	} else {
 		period := c.DefaultQuery("period", "today")
 		switch period {
@@ -477,17 +482,19 @@ func (h *UsageHandler) CreateCleanupTask(c *gin.Context) {
 		return
 	}
 
-	startTime, err := timezone.ParseInUserLocation("2006-01-02", req.StartDate, req.Timezone)
+	startTime, _, err := timezone.ParseDateOrDateTimeInUserLocation(req.StartDate, req.Timezone)
 	if err != nil {
-		response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+		response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 		return
 	}
-	endTime, err := timezone.ParseInUserLocation("2006-01-02", req.EndDate, req.Timezone)
+	endTime, endHasTime, err := timezone.ParseDateOrDateTimeInUserLocation(req.EndDate, req.Timezone)
 	if err != nil {
-		response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+		response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 		return
 	}
-	endTime = endTime.Add(24*time.Hour - time.Nanosecond)
+	if !endHasTime {
+		endTime = endTime.Add(24*time.Hour - time.Nanosecond)
+	}
 
 	var requestType *int16
 	stream := req.Stream

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -151,21 +151,25 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 	endDateStr := strings.TrimSpace(c.Query("end_date"))
 
 	if startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return nil, false
 		}
 		startTime = t
 		startPtr = &startTime
 	}
 	if endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return nil, false
 		}
-		endTime = t.AddDate(0, 0, 1)
+		if hasTime {
+			endTime = t
+		} else {
+			endTime = t.AddDate(0, 0, 1)
+		}
 		endPtr = &endTime
 	}
 
@@ -277,20 +281,22 @@ func (h *UsageHandler) ListErrors(c *gin.Context) {
 	// Date range (half-open [start, end)), reuse usage-list semantics.
 	userTZ := c.Query("timezone")
 	if startDateStr := c.Query("start_date"); startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, _, err := timezone.ParseDateOrDateTimeInUserLocation(startDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
 		filter.StartTime = &t
 	}
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, hasTime, err := timezone.ParseDateOrDateTimeInUserLocation(endDateStr, userTZ)
 		if err != nil {
-			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
+			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD or RFC3339")
 			return
 		}
-		t = t.AddDate(0, 0, 1)
+		if !hasTime {
+			t = t.AddDate(0, 0, 1)
+		}
 		filter.EndTime = &t
 	}
 

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -140,6 +140,17 @@ func ParseInUserLocation(layout, value, userTZ string) (time.Time, error) {
 	return time.ParseInLocation(layout, value, loc)
 }
 
+// ParseDateOrDateTimeInUserLocation parses value as either an RFC3339 datetime
+// (hasTime=true, offset taken from the value itself) or a date "2006-01-02" in
+// the user's timezone (hasTime=false).
+func ParseDateOrDateTimeInUserLocation(value, userTZ string) (t time.Time, hasTime bool, err error) {
+	if t, err = time.Parse(time.RFC3339, value); err == nil {
+		return t, true, nil
+	}
+	t, err = ParseInUserLocation("2006-01-02", value, userTZ)
+	return t, false, err
+}
+
 // NowInUserLocation returns the current time in the user's timezone.
 // If userTZ is empty or invalid, falls back to the configured server timezone.
 func NowInUserLocation(userTZ string) time.Time {

--- a/frontend/src/components/common/DateRangePicker.vue
+++ b/frontend/src/components/common/DateRangePicker.vue
@@ -42,8 +42,8 @@
             <label class="date-picker-label">{{ t('dates.startDate') }}</label>
             <input
               type="date"
-              v-model="localStartDate"
-              :max="localEndDate || tomorrow"
+              v-model="startDateInput"
+              :max="endDateInput || tomorrow"
               class="date-picker-input"
               @change="onDateChange"
             />
@@ -55,8 +55,8 @@
             <label class="date-picker-label">{{ t('dates.endDate') }}</label>
             <input
               type="date"
-              v-model="localEndDate"
-              :min="localStartDate"
+              v-model="endDateInput"
+              :min="startDateInput"
               :max="tomorrow"
               class="date-picker-input"
               @change="onDateChange"
@@ -79,6 +79,12 @@
 import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Icon from '@/components/icons/Icon.vue'
+import {
+  getLast24HourRange,
+  hasTimeComponent,
+  parseRangeBoundary,
+  toDateInputValue
+} from '@/utils/dateRange'
 
 interface DatePreset {
   labelKey: string
@@ -155,14 +161,7 @@ const presets: DatePreset[] = [
   {
     labelKey: 'dates.last24Hours',
     value: 'last24Hours',
-    getRange: () => {
-      const end = new Date()
-      const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-      return {
-        start: formatDateToString(start),
-        end: formatDateToString(end)
-      }
-    }
+    getRange: getLast24HourRange
   },
   {
     labelKey: 'dates.last7Days',
@@ -235,10 +234,31 @@ const displayValue = computed(() => {
 })
 
 const formatDate = (dateStr: string): string => {
-  const date = new Date(dateStr + 'T00:00:00')
+  const date = parseRangeBoundary(dateStr)
   const dateLocale = locale.value === 'zh' ? 'zh-CN' : 'en-US'
   return date.toLocaleDateString(dateLocale, { month: 'short', day: 'numeric' })
 }
+
+// Native date inputs only understand YYYY-MM-DD; editing either input
+// normalizes a rolling (datetime) range back to whole days
+const startDateInput = computed({
+  get: () => (localStartDate.value ? toDateInputValue(localStartDate.value) : ''),
+  set: (v: string) => {
+    localStartDate.value = v
+    if (localEndDate.value && hasTimeComponent(localEndDate.value)) {
+      localEndDate.value = toDateInputValue(localEndDate.value)
+    }
+  }
+})
+const endDateInput = computed({
+  get: () => (localEndDate.value ? toDateInputValue(localEndDate.value) : ''),
+  set: (v: string) => {
+    localEndDate.value = v
+    if (localStartDate.value && hasTimeComponent(localStartDate.value)) {
+      localStartDate.value = toDateInputValue(localStartDate.value)
+    }
+  }
+})
 
 const isPresetActive = (preset: DatePreset): boolean => {
   return activePreset.value === preset.value
@@ -252,6 +272,16 @@ const selectPreset = (preset: DatePreset) => {
 }
 
 const onDateChange = () => {
+  // Rolling ranges carry a time component; only the last24Hours preset produces them
+  if (
+    localStartDate.value &&
+    localEndDate.value &&
+    hasTimeComponent(localStartDate.value) &&
+    hasTimeComponent(localEndDate.value)
+  ) {
+    activePreset.value = 'last24Hours'
+    return
+  }
   // Check if current dates match any preset
   activePreset.value = null
   for (const preset of presets) {

--- a/frontend/src/components/common/__tests__/DateRangePicker.spec.ts
+++ b/frontend/src/components/common/__tests__/DateRangePicker.spec.ts
@@ -78,17 +78,18 @@ describe('DateRangePicker', () => {
     await presetButton!.trigger('click')
     await wrapper.find('.date-picker-apply').trigger('click')
 
-    const nowAfterClick = new Date()
-    const yesterdayAfterClick = new Date(nowAfterClick.getTime() - 24 * 60 * 60 * 1000)
-    const expectedStart = formatLocalDate(yesterdayAfterClick)
-    const expectedEnd = formatLocalDate(nowAfterClick)
-
-    expect(wrapper.emitted('update:startDate')?.[0]).toEqual([expectedStart])
-    expect(wrapper.emitted('update:endDate')?.[0]).toEqual([expectedEnd])
+    const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
+    const emittedStart = wrapper.emitted('update:startDate')?.[0]?.[0] as string
+    const emittedEnd = wrapper.emitted('update:endDate')?.[0]?.[0] as string
+    expect(emittedStart).toMatch(RFC3339_RE)
+    expect(emittedEnd).toMatch(RFC3339_RE)
+    expect(new Date(emittedEnd).getTime() - new Date(emittedStart).getTime()).toBe(
+      24 * 60 * 60 * 1000
+    )
     expect(wrapper.emitted('change')?.[0]).toEqual([
       {
-        startDate: expectedStart,
-        endDate: expectedEnd,
+        startDate: emittedStart,
+        endDate: emittedEnd,
         preset: 'last24Hours'
       }
     ])

--- a/frontend/src/utils/dateRange.ts
+++ b/frontend/src/utils/dateRange.ts
@@ -1,0 +1,40 @@
+/**
+ * 日期范围工具
+ * 后端 start_date/end_date 同时接受 YYYY-MM-DD(整天)和 RFC3339(精确时刻,半开区间上界)
+ */
+
+const pad = (n: number): string => String(n).padStart(2, '0')
+
+/** 本地时区 RFC3339(带偏移),如 2026-07-11T14:03:22+08:00 */
+export function formatDateTimeRFC3339(date: Date): string {
+  const offsetMinutes = -date.getTimezoneOffset()
+  const sign = offsetMinutes >= 0 ? '+' : '-'
+  const abs = Math.abs(offsetMinutes)
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}` +
+    `${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`
+  )
+}
+
+/** 滚动 24 小时窗口(RFC3339 边界) */
+export function getLast24HourRange(): { start: string; end: string } {
+  const end = new Date()
+  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+  return { start: formatDateTimeRFC3339(start), end: formatDateTimeRFC3339(end) }
+}
+
+/** 范围边界值是否带时间部分(RFC3339) */
+export function hasTimeComponent(value: string): boolean {
+  return value.includes('T')
+}
+
+/** 供 <input type="date"> 显示的日期部分 */
+export function toDateInputValue(value: string): string {
+  return value.slice(0, 10)
+}
+
+/** 解析范围边界(纯日期按本地 00:00) */
+export function parseRangeBoundary(value: string): Date {
+  return hasTimeComponent(value) ? new Date(value) : new Date(`${value}T00:00:00`)
+}

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -363,6 +363,7 @@ import Select from '@/components/common/Select.vue'
 import ModelDistributionChart from '@/components/charts/ModelDistributionChart.vue'
 import TokenUsageTrend from '@/components/charts/TokenUsageTrend.vue'
 import { useBatchImageAccess } from '@/composables/useBatchImageAccess'
+import { getLast24HourRange } from '@/utils/dateRange'
 
 import {
   Chart as ChartJS,
@@ -410,23 +411,9 @@ let usersTrendLoadSeq = 0
 let rankingLoadSeq = 0
 const rankingLimit = 12
 
-// Helper function to format date in local timezone
-const formatLocalDate = (date: Date): string => {
-  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-}
-
-const getLast24HoursRangeDates = (): { start: string; end: string } => {
-  const end = new Date()
-  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-  return {
-    start: formatLocalDate(start),
-    end: formatLocalDate(end)
-  }
-}
-
 // Date range
 const granularity = ref<'day' | 'hour'>('hour')
-const defaultRange = getLast24HoursRangeDates()
+const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
 

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -190,6 +190,7 @@ import { useAppStore } from '@/stores/app'; import { adminAPI } from '@/api/admi
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatReasoningEffort } from '@/utils/format'
 import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usageRequestType'
+import { getLast24HourRange, hasTimeComponent, parseRangeBoundary, toDateInputValue } from '@/utils/dateRange'
 import AppLayout from '@/components/layout/AppLayout.vue'; import Pagination from '@/components/common/Pagination.vue'; import Select from '@/components/common/Select.vue'; import DateRangePicker from '@/components/common/DateRangePicker.vue'
 import UsageStatsCards from '@/components/admin/usage/UsageStatsCards.vue'; import UsageFilters from '@/components/admin/usage/UsageFilters.vue'
 import UsageTable from '@/components/admin/usage/UsageTable.vue'; import UsageExportProgress from '@/components/admin/usage/UsageExportProgress.vue'
@@ -273,27 +274,13 @@ const handleRankingSelectUser = (userId: number, email: string) => {
 
 const granularityOptions = computed(() => [{ value: 'day', label: t('admin.dashboard.day') }, { value: 'hour', label: t('admin.dashboard.hour') }])
 // Use local timezone to avoid UTC timezone issues
-const formatLD = (d: Date) => {
-  const year = d.getFullYear()
-  const month = String(d.getMonth() + 1).padStart(2, '0')
-  const day = String(d.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-const getLast24HoursRangeDates = (): { start: string; end: string } => {
-  const end = new Date()
-  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-  return {
-    start: formatLD(start),
-    end: formatLD(end)
-  }
-}
 const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
-  const startTime = new Date(`${start}T00:00:00`).getTime()
-  const endTime = new Date(`${end}T00:00:00`).getTime()
+  const startTime = parseRangeBoundary(start).getTime()
+  const endTime = parseRangeBoundary(end).getTime()
   const daysDiff = Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24))
   return daysDiff <= 1 ? 'hour' : 'day'
 }
-const defaultRange = getLast24HoursRangeDates()
+const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start); const endDate = ref(defaultRange.end)
 const filters = ref<AdminUsageQueryParams>({ user_id: undefined, model: undefined, group_id: undefined, request_type: undefined, billing_type: null, start_date: startDate.value, end_date: endDate.value })
 const pagination = reactive({ page: 1, page_size: getPersistedPageSize(), total: 0 })
@@ -514,7 +501,7 @@ const refreshData = () => {
   if (rankingMounted.value) rankingRef.value?.reload()
 }
 const resetFilters = () => {
-  const range = getLast24HoursRangeDates()
+  const range = getLast24HourRange()
   startDate.value = range.start
   endDate.value = range.end
   filters.value = { start_date: startDate.value, end_date: endDate.value, request_type: undefined, billing_type: null, billing_mode: undefined }
@@ -593,7 +580,7 @@ const exportToExcel = async () => {
     if(!c.signal.aborted) {
       const wb = XLSX.utils.book_new()
       XLSX.utils.book_append_sheet(wb, ws, 'Usage')
-      saveAs(new Blob([XLSX.write(wb, { bookType: 'xlsx', type: 'array' })], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), `usage_${filters.value.start_date}_to_${filters.value.end_date}.xlsx`)
+      saveAs(new Blob([XLSX.write(wb, { bookType: 'xlsx', type: 'array' })], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' }), `usage_${toDateInputValue(filters.value.start_date ?? '')}_to_${toDateInputValue(filters.value.end_date ?? '')}.xlsx`)
       appStore.showSuccess(t('usage.exportSuccess'))
     }
   } catch (error) { console.error('Failed to export:', error); appStore.showError('Export Failed') }
@@ -767,8 +754,11 @@ const showErrorModal = ref(false)
 const selectedErrorId = ref<number | null>(null)
 
 // 注意：'YYYY-MM-DDT00:00:00' 无时区后缀，按本地时区解析后再转 UTC——与页面其它日期处理语义一致，刻意如此，勿改成 'T00:00:00Z'
-const toRFC3339 = (d: string | undefined, endOfDay = false): string | undefined =>
-  d ? new Date(d + (endOfDay ? 'T23:59:59.999' : 'T00:00:00')).toISOString() : undefined
+const toRFC3339 = (d: string | undefined, endOfDay = false): string | undefined => {
+  if (!d) return undefined
+  if (hasTimeComponent(d)) return new Date(d).toISOString()
+  return new Date(d + (endOfDay ? 'T23:59:59.999' : 'T00:00:00')).toISOString()
+}
 
 const loadAdminErrors = async () => {
   errLoading.value = true

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -43,12 +43,7 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
+const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
 
 const createDashboardStats = (): DashboardStats => ({
   total_users: 0,
@@ -133,14 +128,13 @@ describe('admin DashboardView', () => {
 
     await flushPromises()
 
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
-      granularity: 'hour'
-    }))
+    const snapshotParams = getSnapshotV2.mock.calls[0][0]
+    expect(snapshotParams.granularity).toBe('hour')
+    expect(snapshotParams.start_date).toMatch(RFC3339_RE)
+    expect(snapshotParams.end_date).toMatch(RFC3339_RE)
+    expect(
+      new Date(snapshotParams.end_date).getTime() - new Date(snapshotParams.start_date).getTime()
+    ).toBe(24 * 60 * 60 * 1000)
   })
 })

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -27,12 +27,7 @@ const messages: Record<string, string> = {
   'admin.usage.failedToLoadUser': 'Failed to load user',
 }
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
+const RFC3339_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/
 
 vi.mock('@/api/admin', () => ({
   adminAPI: {
@@ -214,13 +209,13 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
 
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-    expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
-      granularity: 'hour'
-    }))
+    const snapshotParams = getSnapshotV2.mock.calls[0][0]
+    expect(snapshotParams.granularity).toBe('hour')
+    expect(snapshotParams.start_date).toMatch(RFC3339_RE)
+    expect(snapshotParams.end_date).toMatch(RFC3339_RE)
+    expect(
+      new Date(snapshotParams.end_date).getTime() - new Date(snapshotParams.start_date).getTime()
+    ).toBe(24 * 60 * 60 * 1000)
 
     const modelChart = wrapper.find('[data-test="model-chart"]')
     const groupChart = wrapper.find('[data-test="group-chart"]')

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -231,6 +231,7 @@ import Icon from '@/components/icons/Icon.vue'
 import UserErrorRequestsTable from '@/components/user/UserErrorRequestsTable.vue'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { formatReasoningEffort } from '@/utils/format'
+import { getLast24HourRange, parseRangeBoundary, toDateInputValue } from '@/utils/dateRange'
 import { BILLING_MODE_IMAGE, getBillingModeLabel } from '@/utils/billingMode'
 import { resolveUsageRequestType, requestTypeToLegacyStream } from '@/utils/usageRequestType'
 import type {
@@ -324,22 +325,13 @@ let chartReqSeq = 0
 let statsReqSeq = 0
 let modelStatsReqSeq = 0
 
-const formatLocalDate = (date: Date): string =>
-  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
-
-const getLast24HoursRangeDates = () => {
-  const end = new Date()
-  const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
-  return { start: formatLocalDate(start), end: formatLocalDate(end) }
-}
-
 const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
-  const startTime = new Date(`${start}T00:00:00`).getTime()
-  const endTime = new Date(`${end}T00:00:00`).getTime()
+  const startTime = parseRangeBoundary(start).getTime()
+  const endTime = parseRangeBoundary(end).getTime()
   return Math.ceil((endTime - startTime) / (1000 * 60 * 60 * 24)) <= 1 ? 'hour' : 'day'
 }
 
-const defaultRange = getLast24HoursRangeDates()
+const defaultRange = getLast24HourRange()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
 const granularity = ref<'day' | 'hour'>(getGranularityForRange(startDate.value, endDate.value))
@@ -543,7 +535,7 @@ const refreshData = () => {
 }
 
 const resetFilters = () => {
-  const range = getLast24HoursRangeDates()
+  const range = getLast24HourRange()
   startDate.value = range.start
   endDate.value = range.end
   filters.value = {
@@ -682,7 +674,7 @@ const exportToCSV = async () => {
     const url = window.URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
-    link.download = `usage_${startDate.value}_to_${endDate.value}.csv`
+    link.download = `usage_${toDateInputValue(startDate.value)}_to_${toDateInputValue(endDate.value)}.csv`
     link.click()
     window.URL.revokeObjectURL(url)
     appStore.showSuccess(t('usage.exportSuccess'))


### PR DESCRIPTION
旧的已冲突, 故关闭重提新的解决冲突pr #5698
(同一修复,已在最新 main 上重建并重新验证;原分支与主干冲突故重提)。

「近24小时」目前实际查的是「昨天+今天」两个自然日，最长能覆盖到约 48 小时的记录。
接近24点时查看，数字比真实的 24 小时消费虚高近一倍；一过0点，昨天整天的数据瞬间掉出窗口，数字跳崖。我就是在 23:59 看到 800 多、零点后变 300 多才发现的。

影响面: ***用户使用记录页、管理端使用记录页、管理端仪表盘**三个页面的**默认值**都是`近24小时`, 
打开页面看到的总消费/总请求/图表默认的记录和显示语义不一致, 容易误导用户。

原因是预设算完 now-24h 后把时间部分丢了，只传日期到后端，后端按整数天解析。

Closed: #4703

改法：

- 预设改为发送带时区完整时间，任何时刻看到的都是过去 24 小时
- 后端相关解析点（用户/管理端统计、错误日志、清理任务、仪表盘）在原有 `YYYY-MM-DD` 整天语义完全不变的基础上，接受 RFC3339标准时间；自选日期行为不变
- 三个视图里复制粘贴的 24 小时函数收敛到新的 `utils/dateRange.ts`

修复前: 近24小时, 会显示超过24小时的记录,  实际是今天,昨天完整记录
<img width="2912" height="2440" alt="image" src="https://github.com/user-attachments/assets/9edbef1a-aa20-4414-bbb0-970700b7ae63" />

修复后: 显示准确的近24小时记录
<img width="2942" height="2572" alt="image" src="https://github.com/user-attachments/assets/6a8d3734-c7e3-4226-88f5-40316ed423ac" />

