### PR TITLE
fix(billing): priority + long context 计费不再叠加倍率

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -961,6 +961,15 @@ func (s *BillingService) computeTokenBreakdown(
 	}
 
 	if applyLongCtx && s.shouldApplySessionLongContextPricing(tokens, pricing) {
+		// OpenAI: priority processing 不支持 long context，请求会被降级为
+		// standard tier 计费。重置为标准价后再应用 long context 倍率。
+		if normalizeBillingServiceTier(serviceTier) == "priority" {
+			inputPrice = pricing.InputPricePerToken
+			outputPrice = pricing.OutputPricePerToken
+			cacheReadPrice = pricing.CacheReadPricePerToken
+			cacheCreationPrice = pricing.CacheCreationPricePerToken
+			tierMultiplier = 1.0
+		}
 		inputPrice *= pricing.LongContextInputMultiplier
 		outputPrice *= pricing.LongContextOutputMultiplier
 		// 缓存读取本质上是输入侧的复用，应与 input 一同应用长上下文倍率；

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -109,12 +109,13 @@ func TestBillingService_GPT56UsesLongContextPricingAcrossModelsAndTiers(t *testi
 		{name: "gpt-5.6-luna", input: 1e-6, cached: 0.1e-6, cacheWrite: 1.25e-6, output: 6e-6},
 	}
 	tiers := []struct {
-		name       string
-		priceScale float64
+		name            string
+		priceScale      float64
+		longCtxExpected float64
 	}{
-		{name: "standard", priceScale: 1},
-		{name: "priority", priceScale: 2},
-		{name: "flex", priceScale: 0.5},
+		{name: "standard", priceScale: 1, longCtxExpected: 1},
+		{name: "priority", priceScale: 2, longCtxExpected: 1},
+		{name: "flex", priceScale: 0.5, longCtxExpected: 0.5},
 	}
 	tokens := UsageTokens{
 		InputTokens:         100000,
@@ -133,13 +134,29 @@ func TestBillingService_GPT56UsesLongContextPricingAcrossModelsAndTiers(t *testi
 				}
 				cost, err := svc.CalculateCostWithServiceTier(model.name, tokens, 1, serviceTier)
 				require.NoError(t, err)
-				require.InDelta(t, float64(tokens.InputTokens)*model.input*tier.priceScale*2, cost.InputCost, 1e-12)
-				require.InDelta(t, float64(tokens.CacheCreationTokens)*model.cacheWrite*tier.priceScale*2, cost.CacheCreationCost, 1e-12)
-				require.InDelta(t, float64(tokens.CacheReadTokens)*model.cached*tier.priceScale*2, cost.CacheReadCost, 1e-12)
-				require.InDelta(t, float64(tokens.OutputTokens)*model.output*tier.priceScale*1.5, cost.OutputCost, 1e-12)
+				require.InDelta(t, float64(tokens.InputTokens)*model.input*tier.longCtxExpected*2, cost.InputCost, 1e-12)
+				require.InDelta(t, float64(tokens.CacheCreationTokens)*model.cacheWrite*tier.longCtxExpected*2, cost.CacheCreationCost, 1e-12)
+				require.InDelta(t, float64(tokens.CacheReadTokens)*model.cached*tier.longCtxExpected*2, cost.CacheReadCost, 1e-12)
+				require.InDelta(t, float64(tokens.OutputTokens)*model.output*tier.longCtxExpected*1.5, cost.OutputCost, 1e-12)
 			})
 		}
 	}
+}
+
+func TestBillingService_PriorityLongContextDoesNotStack(t *testing.T) {
+	svc := NewBillingService(&config.Config{}, nil)
+	longTokens := UsageTokens{InputTokens: 200000, CacheReadTokens: 73000, OutputTokens: 100}
+
+	stdCost, err := svc.CalculateCost("gpt-5.6-sol", longTokens, 1)
+	require.NoError(t, err)
+
+	priCost, err := svc.CalculateCostWithServiceTier("gpt-5.6-sol", longTokens, 1, "priority")
+	require.NoError(t, err)
+
+	require.InDelta(t, stdCost.InputCost, priCost.InputCost, 1e-12,
+		"priority long context should equal standard long context (priority not supported for long context)")
+	require.InDelta(t, stdCost.OutputCost, priCost.OutputCost, 1e-12)
+	require.InDelta(t, stdCost.CacheReadCost, priCost.CacheReadCost, 1e-12)
 }
 
 func TestBillingService_GPT56LongContextBoundaryIsExclusive(t *testing.T) {


### PR DESCRIPTION
## 背景

Fixes #4016

OpenAI 官方说明 priority processing 不支持 long context，请求会降级为 standard tier 计费。但 computeTokenBreakdown 先应用 priority 价格再叠加 long context 倍率，导致 gpt-5.6-sol 在超 272K input 时计费 $20/$90，正确应该是 $10/$45。

## 修改

`billing_service.go` computeTokenBreakdown：当 long context 触发且 service tier 是 priority 时，重置为标准价再应用 long context 倍率。

## 兼容性

- 只影响 priority + long context 同时触发的场景，其他计费路径不变
- flex + long context 不受影响（flex 仍然叠加 0.5x）
- 短上下文 priority 不受影响

## 测试

```bash
go test -tags=unit -run "TestBillingService_GPT56Uses|TestBillingService_PriorityLong" ./internal/service/ -v
# 10 个子用例全部通过
```

更新了既有的 GPT-5.6 long context 测试（priority 的 longCtxExpected 从 2 改为 1），新增 TestBillingService_PriorityLongContextDoesNotStack 断言 priority+long context 费用等于 standard+long context。