### PR TITLE
fix(dashboard): include cache tokens in token card breakdown

### DIFF
--- a/frontend/src/components/user/dashboard/UserDashboardStats.vue
+++ b/frontend/src/components/user/dashboard/UserDashboardStats.vue
@@ -78,7 +78,7 @@
         <div>
           <p class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ t('dashboard.todayTokens') }}</p>
           <p class="text-xl font-bold text-gray-900 dark:text-white">{{ formatTokens(stats?.today_tokens || 0) }}</p>
-          <p class="text-xs text-gray-500 dark:text-gray-400">{{ t('dashboard.input') }}: {{ formatTokens(stats?.today_input_tokens || 0) }} / {{ t('dashboard.output') }}: {{ formatTokens(stats?.today_output_tokens || 0) }}</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400">{{ t('dashboard.input') }}: {{ formatTokens(stats?.today_input_tokens || 0) }} / {{ t('dashboard.output') }}: {{ formatTokens(stats?.today_output_tokens || 0) }} / {{ t('dashboard.cache') }}: {{ formatTokens((stats?.today_cache_creation_tokens || 0) + (stats?.today_cache_read_tokens || 0)) }}</p>
         </div>
       </div>
     </div>
@@ -92,7 +92,7 @@
         <div>
           <p class="text-xs font-medium text-gray-500 dark:text-gray-400">{{ t('dashboard.totalTokens') }}</p>
           <p class="text-xl font-bold text-gray-900 dark:text-white">{{ formatTokens(stats?.total_tokens || 0) }}</p>
-          <p class="text-xs text-gray-500 dark:text-gray-400">{{ t('dashboard.input') }}: {{ formatTokens(stats?.total_input_tokens || 0) }} / {{ t('dashboard.output') }}: {{ formatTokens(stats?.total_output_tokens || 0) }}</p>
+          <p class="text-xs text-gray-500 dark:text-gray-400">{{ t('dashboard.input') }}: {{ formatTokens(stats?.total_input_tokens || 0) }} / {{ t('dashboard.output') }}: {{ formatTokens(stats?.total_output_tokens || 0) }} / {{ t('dashboard.cache') }}: {{ formatTokens((stats?.total_cache_creation_tokens || 0) + (stats?.total_cache_read_tokens || 0)) }}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
用户仪表盘的「今日 Token」「累计 Token」卡片，总量包含缓存 token，但下方明细只列了输入/输出两项。缺少缓存显示, 导致占比高的场景下两者严重对不上

翻了下历史：最初仪表盘有一张独立的「今日缓存」卡片，后来被 RPM/TPM 性能卡替换掉了（7d9a757a），但 Token 卡的明细行没有跟着补上缓存，矛盾从那时开始。

明细补上缓存显示

修复前:
<img width="1430" height="246" alt="image" src="https://github.com/user-attachments/assets/5c944f0c-4883-4320-b8c7-efe2acb0dcd9" />
修复后:
<img width="1422" height="236" alt="image" src="https://github.com/user-attachments/assets/d8adc489-49c3-47e7-87fe-ff35a1353dd6" />
