### PR TITLE
perf(keys): bound latest IP lookup per key

### DIFF
--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -524,17 +524,19 @@ func (r *apiKeyRepository) latestUsageLogIPs(ctx context.Context, apiKeyIDs []in
 
 func latestUsageLogIPsQuery(apiKeyIDs []int64, dialectName string) (string, []any) {
 	if dialectName == dialect.Postgres {
+		// Keep each key lookup bounded to one ordered index probe instead of ranking its full history.
 		return `
-		SELECT api_key_id, ip_address
-		FROM (
-			SELECT api_key_id, ip_address,
-				ROW_NUMBER() OVER (PARTITION BY api_key_id ORDER BY created_at DESC, id DESC) AS rn
-			FROM usage_logs
-			WHERE api_key_id = ANY($1::bigint[])
-				AND ip_address IS NOT NULL
-				AND ip_address <> ''
-		) ranked
-		WHERE rn = 1`, []any{pq.Array(apiKeyIDs)}
+		SELECT requested.api_key_id, latest.ip_address
+		FROM unnest($1::bigint[]) AS requested(api_key_id)
+		CROSS JOIN LATERAL (
+			SELECT ul.ip_address
+			FROM usage_logs AS ul
+			WHERE ul.api_key_id = requested.api_key_id
+				AND ul.ip_address IS NOT NULL
+				AND ul.ip_address <> ''
+			ORDER BY ul.created_at DESC, ul.id DESC
+			LIMIT 1
+		) AS latest`, []any{pq.Array(apiKeyIDs)}
 	}
 
 	placeholders := make([]string, len(apiKeyIDs))

--- a/backend/internal/repository/api_key_repo_last_used_unit_test.go
+++ b/backend/internal/repository/api_key_repo_last_used_unit_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 
@@ -123,6 +124,20 @@ func TestAPIKeyRepositoryListByUserIDAttachesLastUsedIP(t *testing.T) {
 	require.Equal(t, newestIP, *byID[withLogs.ID].LastUsedIP)
 	require.Nil(t, byID[emptyOnly.ID].LastUsedIP)
 	require.Nil(t, byID[noLogs.ID].LastUsedIP)
+}
+
+func TestLatestUsageLogIPsQueryPostgresUsesPerKeyLateralLookup(t *testing.T) {
+	query, args := latestUsageLogIPsQuery([]int64{11, 22}, dialect.Postgres)
+	normalizedQuery := strings.Join(strings.Fields(query), " ")
+
+	require.Contains(t, normalizedQuery, "FROM unnest($1::bigint[]) AS requested(api_key_id)")
+	require.Contains(t, normalizedQuery, "CROSS JOIN LATERAL")
+	require.Contains(t, normalizedQuery, "WHERE ul.api_key_id = requested.api_key_id")
+	require.Contains(t, normalizedQuery, "AND ul.ip_address IS NOT NULL")
+	require.Contains(t, normalizedQuery, "AND ul.ip_address <> ''")
+	require.Contains(t, normalizedQuery, "ORDER BY ul.created_at DESC, ul.id DESC LIMIT 1")
+	require.NotContains(t, normalizedQuery, "ROW_NUMBER")
+	require.Len(t, args, 1)
 }
 
 func TestAPIKeyRepository_CreateWithLastUsedAt(t *testing.T) {

--- a/backend/internal/repository/migrations_runner.go
+++ b/backend/internal/repository/migrations_runner.go
@@ -55,6 +55,8 @@ const paymentOrdersOutTradeNoUniqueMigration = "120_enforce_payment_orders_out_t
 const paymentOrdersOutTradeNoUniqueIndex = "paymentorder_out_trade_no_unique"
 const schedulerOutboxPendingDedupKeyMigration = "153_scheduler_outbox_pending_dedup_key_index_notx.sql"
 const schedulerOutboxPendingDedupKeyIndex = "idx_scheduler_outbox_pending_dedup_key"
+const latestAPIKeyIPIndexMigration = "174_add_usage_logs_api_key_latest_ip_index_notx.sql"
+const latestAPIKeyIPIndex = "idx_usage_logs_api_key_latest_ip"
 
 type migrationChecksumCompatibilityRule struct {
 	fileChecksum       string
@@ -264,6 +266,8 @@ func prepareNonTransactionalMigration(ctx context.Context, db *sql.DB, name stri
 		return preparePaymentOrdersOutTradeNoUniqueMigration(ctx, db)
 	case schedulerOutboxPendingDedupKeyMigration:
 		return dropInvalidIndexIfPresent(ctx, db, schedulerOutboxPendingDedupKeyIndex)
+	case latestAPIKeyIPIndexMigration:
+		return dropInvalidIndexIfPresent(ctx, db, latestAPIKeyIPIndex)
 	default:
 		return nil
 	}

--- a/backend/internal/repository/migrations_runner_notx_test.go
+++ b/backend/internal/repository/migrations_runner_notx_test.go
@@ -116,6 +116,45 @@ CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_t_b ON t(b);
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 
+func TestApplyMigrationsFS_NonTransactionalMigration_LatestAPIKeyIPIndexDropsInvalidIndexBeforeRetry(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	prepareMigrationsBootstrapExpectations(mock)
+	mock.ExpectQuery("SELECT checksum FROM schema_migrations WHERE filename = \\$1").
+		WithArgs(latestAPIKeyIPIndexMigration).
+		WillReturnError(sql.ErrNoRows)
+	mock.ExpectQuery("SELECT EXISTS \\(").
+		WithArgs(latestAPIKeyIPIndex).
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+	mock.ExpectExec("DROP INDEX CONCURRENTLY IF EXISTS idx_usage_logs_api_key_latest_ip").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_api_key_latest_ip").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("INSERT INTO schema_migrations \\(filename, checksum\\) VALUES \\(\\$1, \\$2\\)").
+		WithArgs(latestAPIKeyIPIndexMigration, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	mock.ExpectExec("SELECT pg_advisory_unlock\\(\\$1\\)").
+		WithArgs(migrationsAdvisoryLockID).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	fsys := fstest.MapFS{
+		latestAPIKeyIPIndexMigration: &fstest.MapFile{
+			Data: []byte(`
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_api_key_latest_ip
+    ON usage_logs (api_key_id, created_at DESC, id DESC)
+    INCLUDE (ip_address)
+    WHERE ip_address IS NOT NULL AND ip_address <> '';
+`),
+		},
+	}
+
+	err = applyMigrationsFS(context.Background(), db, fsys)
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
 func TestApplyMigrationsFS_PaymentOrdersOutTradeNoUniqueMigration_FailsFastOnDuplicatePrecheck(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)

--- a/backend/migrations/174_add_usage_logs_api_key_latest_ip_index_notx.sql
+++ b/backend/migrations/174_add_usage_logs_api_key_latest_ip_index_notx.sql
@@ -1,0 +1,5 @@
+-- Support the per-key latest non-empty source IP lookup without scanning full key history.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_api_key_latest_ip
+    ON usage_logs (api_key_id, created_at DESC, id DESC)
+    INCLUDE (ip_address)
+    WHERE ip_address IS NOT NULL AND ip_address <> '';

--- a/backend/migrations/latest_api_key_ip_index_test.go
+++ b/backend/migrations/latest_api_key_ip_index_test.go
@@ -1,0 +1,19 @@
+package migrations
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLatestAPIKeyIPIndexMigration(t *testing.T) {
+	content, err := FS.ReadFile("174_add_usage_logs_api_key_latest_ip_index_notx.sql")
+	require.NoError(t, err)
+
+	sql := strings.Join(strings.Fields(string(content)), " ")
+	require.Contains(t, sql, "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_api_key_latest_ip")
+	require.Contains(t, sql, "ON usage_logs (api_key_id, created_at DESC, id DESC)")
+	require.Contains(t, sql, "INCLUDE (ip_address)")
+	require.Contains(t, sql, "WHERE ip_address IS NOT NULL AND ip_address <> ''")
+}


### PR DESCRIPTION
## Summary

`GET /api/v1/keys` only needs the newest non-empty source IP for each API key. The PostgreSQL path currently ranks every matching historical `usage_logs` row with `ROW_NUMBER()`, so a small key page can still scan and sort the full history of high-volume keys.

This change:

- replaces the full-history window query with one bounded `LATERAL ... ORDER BY ... LIMIT 1` lookup per requested key;
- adds a partial covering index matching that lookup exactly;
- builds the index concurrently in a `*_notx.sql` migration;
- removes an invalid index left by an interrupted concurrent build before retrying the migration;
- leaves the SQLite fallback unchanged.

## Incident evidence

On the affected v0.1.151 deployment:

- `/api/v1/keys?page=1&page_size=20&group_id=2` took about 29.4 seconds;
- the same list sorted by current concurrency exceeded 90 seconds;
- other admin APIs in the same window generally completed in 0.5-1.9 seconds;
- DB pool saturation was not observed.

The regression appeared after last-used IP was added to every key-list response.

## Query shape

The PostgreSQL query now unnests only the requested key IDs and performs one ordered index probe for each ID. The index is:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_logs_api_key_latest_ip
    ON usage_logs (api_key_id, created_at DESC, id DESC)
    INCLUDE (ip_address)
    WHERE ip_address IS NOT NULL AND ip_address <> '';
```

A local PostgreSQL 18.4 plan check used 269,000 matching rows across 20 requested keys, including one key with 250,000 rows. The old plan consumed all 269,000 rows and spilled its sort to temporary storage. The new plan used 20 bounded index probes and an index-only scan. This validates the intended plan shape; the local timing is not used as a production performance claim.

## Migration safety

`CREATE INDEX CONCURRENTLY` avoids a long write-blocking index build, but it can still consume substantial I/O and the synchronous startup migration waits for it to finish.

For a large production table, either prebuild the exact index during a controlled window before deploying the application, or stage the query rewrite and index migration as separate releases. If an interrupted build leaves the index invalid, the migration runner now drops that invalid index concurrently before retrying.

The migration follows the existing concurrent `usage_logs` index migrations and assumes `usage_logs` is a regular table. PostgreSQL does not support `CREATE INDEX CONCURRENTLY` on a partitioned parent. Partitioned installations must build matching indexes concurrently on each partition and attach them to a parent index through a controlled manual migration.

Check the table kind before rollout (`r` is regular, `p` is partitioned):

```sql
SELECT relkind FROM pg_class WHERE oid = 'usage_logs'::regclass;
```

Rollback of the index is:

```sql
DROP INDEX CONCURRENTLY IF EXISTS idx_usage_logs_api_key_latest_ip;
```

The query remains correct without the new index, but may be slower when a key has many recent rows with empty IP values.

## Verification

```text
go test ./migrations ./internal/repository -run 'Test(LatestAPIKeyIPIndexMigration|APIKeyRepositoryListByUserIDAttachesLastUsedIP|LatestUsageLogIPsQueryPostgresUsesPerKeyLateralLookup|ValidateMigrationExecutionMode|ApplyMigrationsFS_NonTransactionalMigration)' -count=1
make test-unit
golangci-lint run --timeout=10m --new-from-rev=origin/main ./internal/repository ./migrations
git diff --check
```

All checks pass locally.

## Production gate

Before rollout, compare the old and new queries with `EXPLAIN (ANALYZE, BUFFERS)` against production-like cardinality, confirm `idx_usage_logs_api_key_latest_ip` is valid and selected by the planner, and verify the `usage_logs` table kind as described above.
