### PR TITLE
fix(dashboard): render full-card empty state for model distribution chart

### DIFF
--- a/frontend/src/components/user/dashboard/UserDashboardCharts.vue
+++ b/frontend/src/components/user/dashboard/UserDashboardCharts.vue
@@ -27,10 +27,12 @@
           <LoadingSpinner size="md" />
         </div>
         <h3 class="mb-4 text-sm font-semibold text-gray-900 dark:text-white">{{ t('dashboard.modelDistribution') }}</h3>
-        <div class="flex items-center gap-6">
+        <div v-if="!models.length" class="flex h-48 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+          {{ t('dashboard.noDataAvailable') }}
+        </div>
+        <div v-else class="flex items-center gap-6">
           <div class="h-48 w-48">
             <Doughnut v-if="modelData" :data="modelData" :options="doughnutOptions" />
-            <div v-else class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400">{{ t('dashboard.noDataAvailable') }}</div>
           </div>
           <div class="max-h-48 flex-1 overflow-y-auto">
             <table class="w-full text-xs">


### PR DESCRIPTION
用户仪表盘「模型分布」卡片没有数据时，「暂无数据」显示异常
修复成和其他卡片一致逻辑, 管理员仪表盘正常

修复前:
<img width="2846" height="786" alt="image" src="https://github.com/user-attachments/assets/47871646-16dc-4eba-8560-a5c6525269c6" />

修复后:
<img width="1426" height="576" alt="image" src="https://github.com/user-attachments/assets/f8f1897f-1f19-45a1-b497-d3b9871fc1f2" />
