### PR TITLE
fix(announcements): use proper empty-state copy instead of error message

### DIFF
--- a/frontend/src/i18n/locales/en/admin/resources.ts
+++ b/frontend/src/i18n/locales/en/admin/resources.ts
@@ -375,6 +375,7 @@ export default {
     announcements: {
       title: 'Announcements',
       description: 'Create announcements and target by conditions',
+      createFirstAnnouncement: 'No announcements yet. Create your first one.',
       createAnnouncement: 'Create Announcement',
       editAnnouncement: 'Edit Announcement',
       deleteAnnouncement: 'Delete Announcement',

--- a/frontend/src/i18n/locales/zh/admin/resources.ts
+++ b/frontend/src/i18n/locales/zh/admin/resources.ts
@@ -372,6 +372,7 @@ export default {
     announcements: {
       title: '公告管理',
       description: '创建公告并按条件投放',
+      createFirstAnnouncement: '还没有公告，创建您的第一条公告。',
       createAnnouncement: '创建公告',
       editAnnouncement: '编辑公告',
       deleteAnnouncement: '删除公告',

--- a/frontend/src/views/admin/AnnouncementsView.vue
+++ b/frontend/src/views/admin/AnnouncementsView.vue
@@ -141,7 +141,7 @@
           <template #empty>
             <EmptyState
               :title="t('empty.noData')"
-              :description="t('admin.announcements.failedToLoad')"
+              :description="t('admin.announcements.createFirstAnnouncement')"
               :action-text="t('admin.announcements.createAnnouncement')"
               @action="openCreateDialog"
             />


### PR DESCRIPTION
公告管理页列表为空时，空态区域显示的是「暂无数据」+「**加载公告失败**」, 容易让管理员误以为出了故障。

改法：新增i18n多语言key `createFirstAnnouncement`（还没有公告，创建您的第一条公告。）

修复前:
<img width="766" height="548" alt="image" src="https://github.com/user-attachments/assets/24d1e8a6-58ac-4110-8fab-c77024a9a832" />

修复后:
<img width="808" height="570" alt="image" src="https://github.com/user-attachments/assets/c85f0081-359f-4161-9378-731b35c53b8a" />
