### PR TITLE
fix(ops): show neutral SLA card when window has no requests

### DIFF
--- a/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
+++ b/frontend/src/views/admin/ops/components/OpsDashboardHeader.vue
@@ -393,6 +393,7 @@ const tpsAvgLabel = computed(() => {
 const slaPercent = computed(() => {
   const v = overview.value?.sla
   if (typeof v !== 'number') return null
+  if ((overview.value?.request_count_sla ?? 0) <= 0) return null
   return v * 100
 })
 
@@ -1271,7 +1272,7 @@ function handleToolbarRefresh() {
           <div class="mt-3 text-xs">
             <div class="flex justify-between">
               <span class="text-gray-500">{{ t('admin.ops.exceptions') }}:</span>
-              <span class="font-bold text-red-600 dark:text-red-400">{{ formatNumber((overview.request_count_sla ?? 0) - (overview.success_count ?? 0)) }}</span>
+              <span class="font-bold text-gray-900 dark:text-white">{{ formatNumber((overview.request_count_sla ?? 0) - (overview.success_count ?? 0)) }}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 现象

运维监控页在所选时间窗口内没有请求时，SLA 卡片会显示红色的「0.000%」，而旁边的「请求错误」卡显示绿色「0.00%」，同一排自相矛盾，容易被误导用户。


## 修改

- SLA 卡片：窗口内没有 SLA 请求时显示中性的「-」（复用已有的空值展示路径），不再显示红色 0.000%
- 「异常数」小字计数去掉写死的红色，与同排其他卡片的错误计数保持一致的中性色；报警语义仍由大号百分比和状态圆点承担

修复前:
<img width="1722" height="696" alt="image" src="https://github.com/user-attachments/assets/26b1fcf0-c50d-4a65-b9fb-2ed8434e2076" />
修复后:
<img width="1716" height="686" alt="image" src="https://github.com/user-attachments/assets/2e1f8cc4-fc29-4124-90e0-85d795f47efb" />
<img width="1732" height="680" alt="image" src="https://github.com/user-attachments/assets/d87fa95f-00c1-4d1a-aa45-c6bd20ce0c74" />
