### PR TITLE
fix: 拦截并清理异常账号过期时间

### DIFF
--- a/backend/internal/handler/admin/account_data.go
+++ b/backend/internal/handler/admin/account_data.go
@@ -701,6 +701,11 @@ func validateDataAccount(item DataAccount) error {
 	if item.Priority < 0 {
 		return errors.New("priority must be >= 0")
 	}
+	if item.ExpiresAt != nil {
+		if year := time.Unix(*item.ExpiresAt, 0).Year(); year < 0 || year > 9999 {
+			return errors.New("expires_at is invalid")
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/handler/admin/account_data_handler_test.go
+++ b/backend/internal/handler/admin/account_data_handler_test.go
@@ -6,11 +6,29 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+func TestValidateDataAccountRejectsInvalidExpiry(t *testing.T) {
+	account := DataAccount{
+		Name:        "account",
+		Platform:    service.PlatformGrok,
+		Type:        service.AccountTypeOAuth,
+		Credentials: map[string]any{"token": "test"},
+	}
+
+	valid := time.Date(2026, time.July, 11, 14, 17, 45, 0, time.UTC).Unix()
+	account.ExpiresAt = &valid
+	require.NoError(t, validateDataAccount(account))
+
+	invalid := int64(1783779465000)
+	account.ExpiresAt = &invalid
+	require.EqualError(t, validateDataAccount(account), "expires_at is invalid")
+}
 
 type dataResponse struct {
 	Code int         `json:"code"`

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -379,6 +379,7 @@ func (c *schedulerCache) writeAccounts(ctx context.Context, accounts []service.A
 	}
 
 	for _, account := range accounts {
+		clearUnencodableAccountExpiry(&account)
 		fullPayload, err := json.Marshal(account)
 		if err != nil {
 			return err
@@ -400,6 +401,15 @@ func (c *schedulerCache) writeAccounts(ctx context.Context, accounts []service.A
 	}
 
 	return flush()
+}
+
+func clearUnencodableAccountExpiry(account *service.Account) {
+	if account == nil || account.ExpiresAt == nil {
+		return
+	}
+	if year := account.ExpiresAt.Year(); year < 0 || year > 9999 {
+		account.ExpiresAt = nil
+	}
 }
 
 func (c *schedulerCache) mgetChunked(ctx context.Context, keys []string) ([]any, error) {

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -4,10 +4,20 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/stretchr/testify/require"
 )
+
+func TestClearUnencodableAccountExpiry(t *testing.T) {
+	invalid := time.Date(10000, time.January, 1, 0, 0, 0, 0, time.UTC)
+	account := service.Account{ExpiresAt: &invalid}
+
+	clearUnencodableAccountExpiry(&account)
+
+	require.Nil(t, account.ExpiresAt)
+}
 
 func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	account := service.Account{


### PR DESCRIPTION
## 问题

账号数据导入会把毫秒时间戳当作 Unix 秒写入，产生超出 JSON 可编码范围的年份，并阻塞调度缓存快照写入。

## 修复

- 在账号数据导入入口拒绝无法编码的 `expires_at`
- 调度缓存遇到历史异常值时清空缓存副本的过期时间并继续写入
- 不删除账号，也不在调度路径回写数据库

## 测试

`go test -tags=unit ./internal/handler/admin ./internal/repository -count=1`

Refs #60
Refs #1608

使用更小的处理方式替代 #4075。