### PR TITLE
[codex] add FIFO account wait queue

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -391,10 +391,11 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					}
 				}
 
-				accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+				accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeoutQueued(
 					c,
 					account.ID,
 					selection.WaitPlan.MaxConcurrency,
+					selection.WaitPlan.MaxWaiting,
 					selection.WaitPlan.Timeout,
 					reqStream,
 					&streamStarted,
@@ -687,10 +688,11 @@ func (h *GatewayHandler) Messages(c *gin.Context) {
 					}
 				}
 
-				accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+				accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeoutQueued(
 					c,
 					account.ID,
 					selection.WaitPlan.MaxConcurrency,
+					selection.WaitPlan.MaxWaiting,
 					selection.WaitPlan.Timeout,
 					reqStream,
 					&streamStarted,

--- a/backend/internal/handler/gateway_handler_chat_completions.go
+++ b/backend/internal/handler/gateway_handler_chat_completions.go
@@ -199,10 +199,11 @@ func (h *GatewayHandler) ChatCompletions(c *gin.Context) {
 				h.chatCompletionsErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
 				return
 			}
-			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeoutQueued(
 				c,
 				account.ID,
 				selection.WaitPlan.MaxConcurrency,
+				selection.WaitPlan.MaxWaiting,
 				selection.WaitPlan.Timeout,
 				reqStream,
 				&streamStarted,

--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -197,10 +197,11 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 				h.responsesErrorResponse(c, http.StatusServiceUnavailable, "api_error", "No available accounts")
 				return
 			}
-			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+			accountReleaseFunc, err = h.concurrencyHelper.AcquireAccountSlotWithWaitTimeoutQueued(
 				c,
 				account.ID,
 				selection.WaitPlan.MaxConcurrency,
+				selection.WaitPlan.MaxWaiting,
 				selection.WaitPlan.Timeout,
 				reqStream,
 				&streamStarted,

--- a/backend/internal/handler/gateway_helper.go
+++ b/backend/internal/handler/gateway_helper.go
@@ -418,6 +418,88 @@ func (h *ConcurrencyHelper) AcquireAccountSlotWithWaitTimeout(c *gin.Context, ac
 	return h.waitForSlotWithPingTimeout(c, "account", accountID, maxConcurrency, timeout, isStream, streamStarted, true)
 }
 
+// AcquireAccountSlotWithWaitTimeoutQueued uses the distributed FIFO account
+// queue when the configured cache supports it, while retaining the legacy
+// polling fallback for test and non-Redis implementations.
+func (h *ConcurrencyHelper) AcquireAccountSlotWithWaitTimeoutQueued(c *gin.Context, accountID int64, maxConcurrency, maxWaiting int, timeout time.Duration, isStream bool, streamStarted *bool) (func(), error) {
+	return h.waitForSlotWithPingTimeoutQueued(c, accountID, maxConcurrency, maxWaiting, timeout, isStream, streamStarted)
+}
+
+func (h *ConcurrencyHelper) waitForSlotWithPingTimeoutQueued(c *gin.Context, accountID int64, maxConcurrency, maxWaiting int, timeout time.Duration, isStream bool, streamStarted *bool) (func(), error) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), timeout)
+	defer cancel()
+
+	if result, err := h.concurrencyService.AcquireAccountSlot(ctx, accountID, maxConcurrency); err != nil {
+		return nil, err
+	} else if result.Acquired {
+		return result.ReleaseFunc, nil
+	}
+
+	ticket, allowed, err := h.concurrencyService.EnqueueAccountWait(ctx, accountID, maxWaiting, timeout)
+	if err != nil || ticket == "" {
+		return h.waitForSlotWithPingTimeout(c, "account", accountID, maxConcurrency, timeout, isStream, streamStarted, false)
+	}
+	if !allowed {
+		return nil, &WaitQueueFullError{SlotType: "account"}
+	}
+	defer func() {
+		if ticket != "" {
+			_ = h.concurrencyService.RemoveAccountWait(context.Background(), accountID, ticket)
+		}
+	}()
+
+	needPing := isStream && h.pingFormat != ""
+	var flusher http.Flusher
+	if needPing {
+		var ok bool
+		flusher, ok = c.Writer.(http.Flusher)
+		if !ok {
+			return nil, fmt.Errorf("streaming not supported")
+		}
+	}
+	var pingCh <-chan time.Time
+	if needPing {
+		ticker := time.NewTicker(h.pingInterval)
+		defer ticker.Stop()
+		pingCh = ticker.C
+	}
+	timer := time.NewTimer(initialBackoff)
+	defer timer.Stop()
+	backoff := initialBackoff
+	for {
+		select {
+		case <-ctx.Done():
+			if parentErr := c.Request.Context().Err(); parentErr != nil {
+				return nil, parentErr
+			}
+			return nil, &ConcurrencyError{SlotType: "account", IsTimeout: true}
+		case <-pingCh:
+			if !*streamStarted {
+				c.Header("Content-Type", "text/event-stream")
+				c.Header("Cache-Control", "no-cache")
+				c.Header("Connection", "keep-alive")
+				c.Header("X-Accel-Buffering", "no")
+				*streamStarted = true
+			}
+			if _, err := fmt.Fprint(c.Writer, string(h.pingFormat)); err != nil {
+				return nil, err
+			}
+			flusher.Flush()
+		case <-timer.C:
+			result, err := h.concurrencyService.AcquireQueuedAccountSlot(ctx, accountID, maxConcurrency, ticket)
+			if err != nil {
+				return nil, err
+			}
+			if result.Acquired {
+				ticket = ""
+				return result.ReleaseFunc, nil
+			}
+			backoff = nextBackoff(backoff)
+			timer.Reset(backoff)
+		}
+	}
+}
+
 // nextBackoff 计算下一次退避时间
 // 性能优化：使用指数退避 + 随机抖动，避免惊群效应
 // current: 当前退避时间

--- a/backend/internal/handler/gemini_v1beta_handler.go
+++ b/backend/internal/handler/gemini_v1beta_handler.go
@@ -430,10 +430,11 @@ func (h *GatewayHandler) GeminiV1BetaModels(c *gin.Context) {
 				}
 			}()
 
-			accountReleaseFunc, err = geminiConcurrency.AcquireAccountSlotWithWaitTimeout(
+			accountReleaseFunc, err = geminiConcurrency.AcquireAccountSlotWithWaitTimeoutQueued(
 				c,
 				account.ID,
 				selection.WaitPlan.MaxConcurrency,
+				selection.WaitPlan.MaxWaiting,
 				selection.WaitPlan.Timeout,
 				stream,
 				&streamStarted,

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1209,10 +1209,11 @@ func (h *OpenAIGatewayHandler) acquireResponsesAccountSlot(
 	}
 	defer releaseWait()
 
-	accountReleaseFunc, err := h.concurrencyHelper.AcquireAccountSlotWithWaitTimeout(
+	accountReleaseFunc, err := h.concurrencyHelper.AcquireAccountSlotWithWaitTimeoutQueued(
 		c,
 		account.ID,
 		selection.WaitPlan.MaxConcurrency,
+		selection.WaitPlan.MaxWaiting,
 		selection.WaitPlan.Timeout,
 		reqStream,
 		streamStarted,

--- a/backend/internal/repository/concurrency_cache.go
+++ b/backend/internal/repository/concurrency_cache.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/service"
@@ -33,7 +35,8 @@ const (
 	// 等待队列计数器格式: concurrency:wait:{userID}
 	waitQueueKeyPrefix = "concurrency:wait:"
 	// 账号级等待队列计数器格式: wait:account:{accountID}
-	accountWaitKeyPrefix = "wait:account:"
+	accountWaitKeyPrefix      = "wait:account:"
+	accountWaitQueueKeyPrefix = "wait:account:queue:"
 
 	// 默认槽位过期时间（分钟），可通过配置覆盖
 	defaultSlotTTLMinutes = 15
@@ -114,6 +117,24 @@ var (
 
 		redis.call('ZREMRANGEBYSCORE', key, '-inf', expireBefore)
 		return redis.call('ZCARD', key)
+	`)
+
+	enqueueAccountWaitScript = redis.NewScript(`
+		redis.replicate_commands()
+		local key = KEYS[1]
+		local maxWait = tonumber(ARGV[1])
+		local ttl = tonumber(ARGV[2])
+		local timeout = tonumber(ARGV[3])
+		local requestID = ARGV[4]
+		local count = redis.call('LLEN', key)
+		if maxWait > 0 and count >= maxWait then
+			return ""
+		end
+		local now = tonumber(redis.call('TIME')[1])
+		local ticket = requestID .. "|" .. tostring(now + timeout)
+		redis.call('RPUSH', key, ticket)
+		redis.call('EXPIRE', key, ttl)
+		return ticket
 	`)
 
 	// trackSlotScript 记录 stats-only 槽位，不做并发上限判断。
@@ -529,6 +550,62 @@ func (c *concurrencyCache) ReleaseAccountSlot(ctx context.Context, accountID int
 	return nil
 }
 
+func accountWaitQueueKey(accountID int64) string {
+	return accountWaitQueueKeyPrefix + strconv.FormatInt(accountID, 10)
+}
+
+func (c *concurrencyCache) EnqueueAccountWait(ctx context.Context, accountID int64, maxWait int, timeout time.Duration, requestID string) (string, bool, error) {
+	timeoutSeconds := int64(timeout / time.Second)
+	if timeoutSeconds <= 0 {
+		timeoutSeconds = 1
+	}
+	ticket, err := enqueueAccountWaitScript.Run(ctx, c.rdb, []string{accountWaitQueueKey(accountID)}, maxWait, c.slotTTLSeconds, timeoutSeconds, requestID).Text()
+	return ticket, ticket != "", err
+}
+
+func (c *concurrencyCache) RemoveAccountWait(ctx context.Context, accountID int64, requestID string) error {
+	return c.rdb.LRem(ctx, accountWaitQueueKey(accountID), 0, requestID).Err()
+}
+
+func (c *concurrencyCache) AcquireQueuedAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error) {
+	head, err := c.rdb.LIndex(ctx, accountWaitQueueKey(accountID), 0).Result()
+	if err == redis.Nil {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	parts := strings.SplitN(head, "|", 2)
+	if len(parts) != 2 {
+		if err := c.rdb.LRem(ctx, accountWaitQueueKey(accountID), 1, head).Err(); err != nil && !errors.Is(err, redis.Nil) {
+			return false, err
+		}
+		return false, nil
+	}
+	deadline, parseErr := strconv.ParseInt(parts[1], 10, 64)
+	if parseErr != nil || deadline <= time.Now().Unix() {
+		if err := c.rdb.LRem(ctx, accountWaitQueueKey(accountID), 1, head).Err(); err != nil && !errors.Is(err, redis.Nil) {
+			return false, err
+		}
+		return false, nil
+	}
+	if head != requestID {
+		return false, nil
+	}
+	acquired, err := c.AcquireAccountSlot(ctx, accountID, maxConcurrency, parts[0])
+	if err != nil {
+		return false, err
+	}
+	if !acquired {
+		return false, nil
+	}
+	if err := c.rdb.LRem(ctx, accountWaitQueueKey(accountID), 1, head).Err(); err != nil {
+		_ = c.ReleaseAccountSlot(ctx, accountID, parts[0])
+		return false, err
+	}
+	return true, nil
+}
+
 func (c *concurrencyCache) GetAccountConcurrency(ctx context.Context, accountID int64) (int, error) {
 	key := accountSlotKey(accountID)
 	// 时间戳在 Lua 脚本内使用 Redis TIME 命令获取
@@ -728,7 +805,7 @@ func (c *concurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []
 	}
 
 	// 使用 Pipeline 替代 Lua 脚本，兼容 Redis Cluster（Lua 内动态拼 key 会 CROSSSLOT）。
-	// 每个账号执行 3 个命令：ZREMRANGEBYSCORE（清理过期）、ZCARD（并发数）、GET（等待数）。
+	// 每个账号执行清理、并发数、旧计数器和 FIFO 队列长度查询。
 	now, err := c.rdb.Time(ctx).Result()
 	if err != nil {
 		return nil, fmt.Errorf("redis TIME: %w", err)
@@ -742,17 +819,20 @@ func (c *concurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []
 		maxConcurrency int
 		zcardCmd       *redis.IntCmd
 		getCmd         *redis.StringCmd
+		listLenCmd     *redis.IntCmd
 	}
 	cmds := make([]accountCmds, 0, len(accounts))
 	for _, acc := range accounts {
 		slotKey := accountSlotKeyPrefix + strconv.FormatInt(acc.ID, 10)
 		waitKey := accountWaitKeyPrefix + strconv.FormatInt(acc.ID, 10)
+		queueKey := accountWaitQueueKeyPrefix + strconv.FormatInt(acc.ID, 10)
 		pipe.ZRemRangeByScore(ctx, slotKey, "-inf", strconv.FormatInt(cutoffTime, 10))
 		ac := accountCmds{
 			id:             acc.ID,
 			maxConcurrency: acc.MaxConcurrency,
 			zcardCmd:       pipe.ZCard(ctx, slotKey),
 			getCmd:         pipe.Get(ctx, waitKey),
+			listLenCmd:     pipe.LLen(ctx, queueKey),
 		}
 		cmds = append(cmds, ac)
 	}
@@ -767,6 +847,9 @@ func (c *concurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []
 		waitingCount := 0
 		if v, err := ac.getCmd.Int(); err == nil {
 			waitingCount = v
+		}
+		if queueCount := int(ac.listLenCmd.Val()); queueCount > waitingCount {
+			waitingCount = queueCount
 		}
 		loadRate := 0
 		if ac.maxConcurrency > 0 {

--- a/backend/internal/repository/concurrency_cache_integration_test.go
+++ b/backend/internal/repository/concurrency_cache_integration_test.go
@@ -77,6 +77,48 @@ func (s *ConcurrencyCacheSuite) TestAccountSlot_AcquireAndRelease() {
 	require.Equal(s.T(), 1, cur, "expected 1 after release")
 }
 
+func (s *ConcurrencyCacheSuite) TestAccountWaitQueue_FIFOAndCapacity() {
+	accountID := int64(12)
+	queue := any(s.rawCache).(service.AccountWaitQueueCache)
+
+	first, ok, err := queue.EnqueueAccountWait(s.ctx, accountID, 2, time.Minute, "first")
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+	second, ok, err := queue.EnqueueAccountWait(s.ctx, accountID, 2, time.Minute, "second")
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+	_, ok, err = queue.EnqueueAccountWait(s.ctx, accountID, 2, time.Minute, "overflow")
+	require.NoError(s.T(), err)
+	require.False(s.T(), ok)
+
+	ok, err = queue.AcquireQueuedAccountSlot(s.ctx, accountID, 1, second)
+	require.NoError(s.T(), err)
+	require.False(s.T(), ok, "a later waiter must not overtake the queue head")
+	ok, err = queue.AcquireQueuedAccountSlot(s.ctx, accountID, 1, first)
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+
+	require.NoError(s.T(), s.rawCache.ReleaseAccountSlot(s.ctx, accountID, "first"))
+	ok, err = queue.AcquireQueuedAccountSlot(s.ctx, accountID, 1, second)
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+}
+
+func (s *ConcurrencyCacheSuite) TestAccountWaitQueue_RemoveCanceledHead() {
+	accountID := int64(13)
+	queue := any(s.rawCache).(service.AccountWaitQueueCache)
+	canceled, ok, err := queue.EnqueueAccountWait(s.ctx, accountID, 2, time.Minute, "canceled")
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+	next, ok, err := queue.EnqueueAccountWait(s.ctx, accountID, 2, time.Minute, "next")
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+	require.NoError(s.T(), queue.RemoveAccountWait(s.ctx, accountID, canceled))
+	ok, err = queue.AcquireQueuedAccountSlot(s.ctx, accountID, 1, next)
+	require.NoError(s.T(), err)
+	require.True(s.T(), ok)
+}
+
 func (s *ConcurrencyCacheSuite) TestAccountActiveIndex_AcquireAndRelease() {
 	accountID := int64(610)
 	member := strconv.FormatInt(accountID, 10)

--- a/backend/internal/service/concurrency_service.go
+++ b/backend/internal/service/concurrency_service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -51,6 +52,15 @@ type ConcurrencyCache interface {
 
 	// 启动时清理旧进程遗留槽位与等待计数
 	CleanupStaleProcessSlots(ctx context.Context, activeRequestPrefix string) error
+}
+
+// AccountWaitQueueCache is an optional FIFO wait queue implemented by the
+// distributed cache. Implementations that do not provide it keep the legacy
+// counter plus polling behavior.
+type AccountWaitQueueCache interface {
+	EnqueueAccountWait(ctx context.Context, accountID int64, maxWait int, timeout time.Duration, requestID string) (string, bool, error)
+	RemoveAccountWait(ctx context.Context, accountID int64, requestID string) error
+	AcquireQueuedAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (bool, error)
 }
 
 type APIKeyConcurrencyCache interface {
@@ -205,6 +215,48 @@ func (s *ConcurrencyService) AcquireAccountSlot(ctx context.Context, accountID i
 		Acquired:    false,
 		ReleaseFunc: nil,
 	}, nil
+}
+
+// EnqueueAccountWait adds a request to the optional FIFO account queue.
+// The returned ticket is stable for the lifetime of the wait attempt.
+func (s *ConcurrencyService) EnqueueAccountWait(ctx context.Context, accountID int64, maxWait int, timeout time.Duration) (string, bool, error) {
+	queue, ok := s.cache.(AccountWaitQueueCache)
+	if !ok {
+		return "", false, nil
+	}
+	requestID := generateRequestID()
+	ticket, allowed, err := queue.EnqueueAccountWait(ctx, accountID, maxWait, timeout, requestID)
+	return ticket, allowed, err
+}
+
+// AcquireQueuedAccountSlot only succeeds when requestID is at the head of the
+// account queue and an account slot is available. The cache makes the head
+// check authoritative, while the existing slot script keeps acquisition safe.
+func (s *ConcurrencyService) AcquireQueuedAccountSlot(ctx context.Context, accountID int64, maxConcurrency int, requestID string) (*AcquireResult, error) {
+	queue, ok := s.cache.(AccountWaitQueueCache)
+	if !ok {
+		return s.AcquireAccountSlot(ctx, accountID, maxConcurrency)
+	}
+	acquired, err := queue.AcquireQueuedAccountSlot(ctx, accountID, maxConcurrency, requestID)
+	if err != nil || !acquired {
+		return &AcquireResult{Acquired: acquired}, err
+	}
+	slotRequestID := strings.SplitN(requestID, "|", 2)[0]
+	return &AcquireResult{Acquired: true, ReleaseFunc: func() {
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := s.cache.ReleaseAccountSlot(bgCtx, accountID, slotRequestID); err != nil {
+			logger.LegacyPrintf("service.concurrency", "Warning: failed to release queued account slot for %d (req=%s): %v", accountID, requestID, err)
+		}
+	}}, nil
+}
+
+func (s *ConcurrencyService) RemoveAccountWait(ctx context.Context, accountID int64, requestID string) error {
+	queue, ok := s.cache.(AccountWaitQueueCache)
+	if !ok || requestID == "" {
+		return nil
+	}
+	return queue.RemoveAccountWait(ctx, accountID, requestID)
 }
 
 // AcquireUserSlot attempts to acquire a concurrency slot for a user.


### PR DESCRIPTION
## What changed

- Add an optional Redis-backed FIFO wait queue for account slots
- Only the queue head can acquire the next account slot
- Encode wait deadlines in tickets and remove expired or cancelled heads
- Keep the legacy counter and polling path for non-queue cache implementations
- Use the configured WaitPlan max waiting and timeout across Claude, Gemini, and OpenAI account paths
- Include integration coverage for FIFO ordering, capacity limits, and cancelled waiters

## Why

The previous account wait path only counted waiters and let every request compete to acquire a slot. That allowed later requests to overtake earlier requests and caused avoidable slot-acquisition pressure during bursts.

This first slice makes admission order deterministic and bounds stale waiters. Waiters still use the existing exponential-backoff polling loop, but only the FIFO head performs the account-slot acquisition attempt; event-driven wakeups can be added in a follow-up without changing the queue contract.

## Validation

- `go test ./internal/handler ./internal/service ./internal/repository -count=1`
- `go test -tags integration ./internal/repository -run TestConcurrencyCacheSuite/TestAccountWaitQueue -count=1`
- `git diff --check`

The queue is optional so existing cache implementations and test doubles retain the legacy behavior.