### PR TITLE
feat: add global image generation disable switch

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	Update                  UpdateConfig                  `mapstructure:"update"`
 	Idempotency             IdempotencyConfig             `mapstructure:"idempotency"`
 	BatchImage              BatchImageConfig              `mapstructure:"batch_image"`
+	DisableImageGeneration  bool                          `mapstructure:"disable_image_generation"`
 }
 
 type LogConfig struct {
@@ -1603,6 +1604,7 @@ func load(allowMissingJWTSecret bool) (*Config, error) {
 
 func setDefaults() {
 	viper.SetDefault("run_mode", RunModeStandard)
+	viper.SetDefault("disable_image_generation", false)
 
 	// Server
 	viper.SetDefault("server.host", "0.0.0.0")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -17,6 +17,27 @@ func resetViperWithJWTSecret(t *testing.T) {
 	t.Setenv("JWT_SECRET", strings.Repeat("x", 32))
 }
 
+func TestLoadDisableImageGeneration(t *testing.T) {
+	t.Run("defaults to false", func(t *testing.T) {
+		resetViperWithJWTSecret(t)
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		require.False(t, cfg.DisableImageGeneration)
+	})
+
+	t.Run("reads top level environment variable", func(t *testing.T) {
+		resetViperWithJWTSecret(t)
+		t.Setenv("DISABLE_IMAGE_GENERATION", "true")
+
+		cfg, err := Load()
+
+		require.NoError(t, err)
+		require.True(t, cfg.DisableImageGeneration)
+	})
+}
+
 func TestLoadForBootstrapAllowsMissingJWTSecret(t *testing.T) {
 	viper.Reset()
 	t.Setenv("JWT_SECRET", "")

--- a/backend/internal/handler/grok_media.go
+++ b/backend/internal/handler/grok_media.go
@@ -99,7 +99,7 @@ func (h *OpenAIGatewayHandler) handleGrokMedia(c *gin.Context, endpoint service.
 	setOpsEndpointContext(c, "", int16(service.RequestTypeSync))
 
 	if endpoint.IsGenerationRequest() {
-		if !service.GroupAllowsImageGeneration(apiKey.Group) {
+		if !h.imageGenerationAllowedForGroup(apiKey.Group) {
 			h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
 			return
 		}

--- a/backend/internal/handler/image_generation_global_disable.go
+++ b/backend/internal/handler/image_generation_global_disable.go
@@ -6,6 +6,10 @@ func (h *OpenAIGatewayHandler) imageGenerationGloballyDisabled() bool {
 	return h != nil && h.cfg != nil && h.cfg.DisableImageGeneration
 }
 
+func (h *OpenAIGatewayHandler) imageGenerationAllowedForGroup(group *service.Group) bool {
+	return !h.imageGenerationGloballyDisabled() && service.GroupAllowsImageGeneration(group)
+}
+
 func (h *OpenAIGatewayHandler) normalizeGloballyDisabledImageGeneration(payload []byte) ([]byte, bool, error) {
 	if !h.imageGenerationGloballyDisabled() {
 		return payload, false, nil

--- a/backend/internal/handler/image_generation_global_disable.go
+++ b/backend/internal/handler/image_generation_global_disable.go
@@ -1,0 +1,14 @@
+package handler
+
+import "github.com/Wei-Shaw/sub2api/internal/service"
+
+func (h *OpenAIGatewayHandler) imageGenerationGloballyDisabled() bool {
+	return h != nil && h.cfg != nil && h.cfg.DisableImageGeneration
+}
+
+func (h *OpenAIGatewayHandler) normalizeGloballyDisabledImageGeneration(payload []byte) ([]byte, bool, error) {
+	if !h.imageGenerationGloballyDisabled() {
+		return payload, false, nil
+	}
+	return service.StripOpenAIImageGenerationToolsFromRawPayload(payload)
+}

--- a/backend/internal/handler/image_generation_global_disable_test.go
+++ b/backend/internal/handler/image_generation_global_disable_test.go
@@ -38,6 +38,69 @@ func TestNormalizeGloballyDisabledImageGenerationNoOp(t *testing.T) {
 	require.Equal(t, payload, updated)
 }
 
+func TestImageGenerationAllowedForGroup(t *testing.T) {
+	allowedGroup := &service.Group{AllowImageGeneration: true}
+	tests := []struct {
+		name     string
+		disabled bool
+		want     bool
+	}{
+		{name: "existing group permission retained", disabled: false, want: true},
+		{name: "global disable overrides allowed group", disabled: true, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &OpenAIGatewayHandler{cfg: &config.Config{DisableImageGeneration: tt.disabled}}
+			require.Equal(t, tt.want, h.imageGenerationAllowedForGroup(allowedGroup))
+		})
+	}
+}
+
+func newGlobalDisableMediaContext(t *testing.T, path string, body string) (*httptest.ResponseRecorder, *gin.Context, *OpenAIGatewayHandler) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	groupID := int64(111)
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		ID:      222,
+		GroupID: &groupID,
+		Group:   &service.Group{ID: groupID, AllowImageGeneration: true},
+		User:    &service.User{ID: 333},
+	})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 333, Concurrency: 1})
+	cfg := &config.Config{RunMode: config.RunModeSimple, DisableImageGeneration: true}
+	h := &OpenAIGatewayHandler{
+		gatewayService:      &service.OpenAIGatewayService{},
+		billingCacheService: service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil),
+		apiKeyService:       &service.APIKeyService{},
+		concurrencyHelper:   &ConcurrencyHelper{concurrencyService: &service.ConcurrencyService{}},
+		cfg:                 cfg,
+		imageLimiter:        &imageConcurrencyLimiter{},
+	}
+	return rec, c, h
+}
+
+func TestOpenAIGatewayHandlerImagesGlobalDisableRejectsAllowedGroup(t *testing.T) {
+	rec, c, h := newGlobalDisableMediaContext(t, "/v1/images/generations", `{"model":"gpt-image-2","prompt":"draw"}`)
+
+	h.Images(c)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+
+func TestGrokMediaGlobalDisableRejectsAllowedGroup(t *testing.T) {
+	rec, c, h := newGlobalDisableMediaContext(t, "/v1/images/generations", `{"model":"grok-imagine","prompt":"draw"}`)
+
+	h.GrokImages(c)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+
 func newGlobalImageDisableResponsesTestContext(t *testing.T, body string) (*httptest.ResponseRecorder, *gin.Context, *OpenAIGatewayHandler) {
 	t.Helper()
 	gin.SetMode(gin.TestMode)
@@ -77,6 +140,19 @@ func TestOpenAIGatewayHandlerResponsesGlobalDisableStripsBeforeGroupGate(t *test
 func TestOpenAIGatewayHandlerResponsesGlobalDisableRejectsImageOnlyModel(t *testing.T) {
 	body := `{"model":"gpt-image-2","input":"draw"}`
 	rec, c, h := newGlobalImageDisableResponsesTestContext(t, body)
+
+	h.Responses(c)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+
+func TestOpenAIGatewayHandlerResponsesGlobalDisableRejectsImageOnlyModelForAllowedGroup(t *testing.T) {
+	body := `{"model":"gpt-image-2","input":"draw"}`
+	rec, c, h := newGlobalImageDisableResponsesTestContext(t, body)
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	require.True(t, ok)
+	apiKey.Group.AllowImageGeneration = true
 
 	h.Responses(c)
 

--- a/backend/internal/handler/image_generation_global_disable_test.go
+++ b/backend/internal/handler/image_generation_global_disable_test.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestNormalizeGloballyDisabledImageGeneration(t *testing.T) {
+	payload := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":"hello"},{"type":"additional_tools","tools":[{"type":"namespace","name":"image_gen"}]}],"tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
+	h := &OpenAIGatewayHandler{cfg: &config.Config{DisableImageGeneration: true}}
+
+	updated, changed, err := h.normalizeGloballyDisabledImageGeneration(payload)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, service.IsImageGenerationIntent("/v1/responses", "gpt-5.5", updated))
+	require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
+	require.Equal(t, "hello", gjson.GetBytes(updated, "input.0.content").String())
+}
+
+func TestNormalizeGloballyDisabledImageGenerationNoOp(t *testing.T) {
+	payload := []byte(`{"model":"gpt-5.5","tools":[{"type":"image_generation"}]}`)
+	h := &OpenAIGatewayHandler{cfg: &config.Config{}}
+
+	updated, changed, err := h.normalizeGloballyDisabledImageGeneration(payload)
+
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Equal(t, payload, updated)
+}
+
+func newGlobalImageDisableResponsesTestContext(t *testing.T, body string) (*httptest.ResponseRecorder, *gin.Context, *OpenAIGatewayHandler) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+	groupID := int64(1)
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		ID:      10,
+		GroupID: &groupID,
+		Group:   &service.Group{ID: groupID, AllowImageGeneration: false},
+		User:    &service.User{ID: 20},
+	})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 20, Concurrency: 1})
+	cfg := &config.Config{RunMode: config.RunModeSimple, DisableImageGeneration: true}
+	h := &OpenAIGatewayHandler{
+		gatewayService:      &service.OpenAIGatewayService{},
+		billingCacheService: service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil),
+		apiKeyService:       &service.APIKeyService{},
+		concurrencyHelper:   &ConcurrencyHelper{concurrencyService: service.NewConcurrencyService(&helperConcurrencyCacheStub{userSeq: []bool{true}})},
+		cfg:                 cfg,
+		imageLimiter:        &imageConcurrencyLimiter{},
+	}
+	return rec, c, h
+}
+
+func TestOpenAIGatewayHandlerResponsesGlobalDisableStripsBeforeGroupGate(t *testing.T) {
+	body := `{"model":"gpt-5.5","input":"write code","tools":[{"type":"image_generation"}]}`
+	rec, c, h := newGlobalImageDisableResponsesTestContext(t, body)
+
+	h.Responses(c)
+
+	require.NotEqual(t, http.StatusForbidden, rec.Code)
+	require.NotContains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+
+func TestOpenAIGatewayHandlerResponsesGlobalDisableRejectsImageOnlyModel(t *testing.T) {
+	body := `{"model":"gpt-image-2","input":"draw"}`
+	rec, c, h := newGlobalImageDisableResponsesTestContext(t, body)
+
+	h.Responses(c)
+
+	require.Equal(t, http.StatusForbidden, rec.Code)
+	require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -217,6 +217,16 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
 		return
 	}
+	normalizedBody, imageToolsStripped, stripErr := h.normalizeGloballyDisabledImageGeneration(body)
+	if stripErr != nil {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to normalize request body")
+		return
+	}
+	if imageToolsStripped {
+		body = normalizedBody
+		reqLog.Info("openai.image_generation_tools_stripped_global")
+	}
+	sessionHashBody = body
 
 	// 使用 gjson 只读提取字段做校验，避免完整 Unmarshal
 	modelResult := gjson.GetBytes(body, "model")

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -273,7 +273,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	}
 
 	imageIntent := service.IsImageGenerationIntent("/v1/responses", reqModel, body)
-	if imageIntent && !service.GroupAllowsImageGeneration(apiKey.Group) {
+	if imageIntent && !h.imageGenerationAllowedForGroup(apiKey.Group) {
 		h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
 		return
 	}
@@ -1358,7 +1358,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		return
 	}
 
-	imageGenerationAllowed := !h.imageGenerationGloballyDisabled() && service.GroupAllowsImageGeneration(apiKey.Group)
+	imageGenerationAllowed := h.imageGenerationAllowedForGroup(apiKey.Group)
 	if service.IsImageGenerationIntent("/v1/responses", reqModel, firstMessage) && !imageGenerationAllowed {
 		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.ImageGenerationPermissionMessage())
 		return

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1320,6 +1320,15 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, "invalid JSON payload")
 		return
 	}
+	normalizedFirstMessage, stripped, stripErr := h.normalizeGloballyDisabledImageGeneration(firstMessage)
+	if stripErr != nil {
+		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, "invalid websocket request payload")
+		return
+	}
+	if stripped {
+		firstMessage = normalizedFirstMessage
+		reqLog.Info("openai.websocket_image_generation_tools_stripped_global")
+	}
 
 	reqModel := strings.TrimSpace(gjson.GetBytes(firstMessage, "model").String())
 	if reqModel == "" {
@@ -1349,7 +1358,8 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		return
 	}
 
-	if service.IsImageGenerationIntent("/v1/responses", reqModel, firstMessage) && !service.GroupAllowsImageGeneration(apiKey.Group) {
+	imageGenerationAllowed := !h.imageGenerationGloballyDisabled() && service.GroupAllowsImageGeneration(apiKey.Group)
+	if service.IsImageGenerationIntent("/v1/responses", reqModel, firstMessage) && !imageGenerationAllowed {
 		closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, service.ImageGenerationPermissionMessage())
 		return
 	}

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -743,6 +743,45 @@ func TestOpenAIResponsesWebSocket_RejectsMessageIDAsPreviousResponseID(t *testin
 	require.Contains(t, strings.ToLower(closeErr.Reason), "previous_response_id")
 }
 
+func TestOpenAIResponsesWebSocket_GlobalDisableStripsFirstFrameBeforeGroupGate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cache := &concurrencyCacheMock{
+		acquireUserSlotFn: func(context.Context, int64, int, string) (bool, error) {
+			return false, errors.New("stop after image permission gate")
+		},
+	}
+	h := newOpenAIHandlerForPreviousResponseIDValidation(t, cache)
+	h.cfg = &config.Config{RunMode: config.RunModeSimple, DisableImageGeneration: true}
+	h.billingCacheService = service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, h.cfg, nil)
+	wsServer := newOpenAIWSHandlerTestServer(t, h, middleware.AuthSubject{UserID: 1, Concurrency: 1})
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http")+"/openai/v1/responses", nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() {
+		_ = clientConn.CloseNow()
+	}()
+
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(
+		`{"type":"response.create","model":"gpt-5.1","stream":false,"tools":[{"type":"image_generation"}]}`,
+	))
+	cancelWrite()
+	require.NoError(t, err)
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	_, _, err = clientConn.Read(readCtx)
+	cancelRead()
+	require.Error(t, err)
+	var closeErr coderws.CloseError
+	require.ErrorAs(t, err, &closeErr)
+	require.Equal(t, coderws.StatusInternalError, closeErr.Code)
+	require.NotContains(t, closeErr.Reason, service.ImageGenerationPermissionMessage())
+}
+
 func TestOpenAIResponsesWebSocket_PreviousResponseIDKindLoggedBeforeAcquireFailure(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/handler/openai_images.go
+++ b/backend/internal/handler/openai_images.go
@@ -82,7 +82,7 @@ func (h *OpenAIGatewayHandler) Images(c *gin.Context) {
 		zap.String("capability", string(parsed.RequiredCapability)),
 	)
 
-	if !service.GroupAllowsImageGeneration(apiKey.Group) {
+	if !h.imageGenerationAllowedForGroup(apiKey.Group) {
 		h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
 		return
 	}

--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -750,6 +750,12 @@ func stripOpenAIImageGenerationToolsFromRawPayload(payload []byte) ([]byte, bool
 	return rebuilt, true, nil
 }
 
+// StripOpenAIImageGenerationToolsFromRawPayload removes Responses image tool
+// declarations while preserving unrelated request fields and tools.
+func StripOpenAIImageGenerationToolsFromRawPayload(payload []byte) ([]byte, bool, error) {
+	return stripOpenAIImageGenerationToolsFromRawPayload(payload)
+}
+
 // stripCodexSparkImageGenerationTools removes image tool declarations and choices.
 // gpt-5.3-codex-spark rejects those capabilities upstream, while Codex clients may
 // advertise them by default.

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -170,11 +170,18 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	}
 
 	apiKey := getAPIKeyFromContext(c)
-	imageGenerationAllowed := GroupAllowsImageGeneration(nil)
+	globalImageDisable := s != nil && s.cfg != nil && s.cfg.DisableImageGeneration
+	imageGenerationAllowed := !globalImageDisable && GroupAllowsImageGeneration(nil)
 	if apiKey != nil {
-		imageGenerationAllowed = GroupAllowsImageGeneration(apiKey.Group)
+		imageGenerationAllowed = !globalImageDisable && GroupAllowsImageGeneration(apiKey.Group)
 	}
-	codexImageGenerationBridgeEnabled := isCodexCLI && imageGenerationAllowed && codexImageGenerationExplicitToolPolicy != codexImageGenerationExplicitToolPolicyStrip && s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey)
+	codexImageGenerationBridgeEnabled := codexImageGenerationBridgeAllowed(
+		globalImageDisable,
+		isCodexCLI,
+		imageGenerationAllowed,
+		codexImageGenerationExplicitToolPolicy,
+		s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey),
+	)
 	var imageIntent bool
 	if isCodexCLI && codexImageGenerationExplicitToolPolicy == codexImageGenerationExplicitToolPolicyStrip {
 		decoded, decodeErr := ensureReqBody()

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -18,6 +18,17 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+func (s *OpenAIGatewayService) normalizeGloballyDisabledImageGeneration(payload []byte) ([]byte, bool, error) {
+	if s == nil || s.cfg == nil || !s.cfg.DisableImageGeneration {
+		return payload, false, nil
+	}
+	return StripOpenAIImageGenerationToolsFromRawPayload(payload)
+}
+
+func codexImageGenerationBridgeAllowed(globalDisabled, isCodexCLI, imageGenerationAllowed bool, explicitPolicy string, configuredEnabled bool) bool {
+	return !globalDisabled && isCodexCLI && imageGenerationAllowed && explicitPolicy != codexImageGenerationExplicitToolPolicyStrip && configuredEnabled
+}
+
 func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	ctx context.Context,
 	c *gin.Context,
@@ -226,12 +237,29 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			normalized = next
 		}
 		apiKey := getAPIKeyFromContext(c)
-		imageGenerationAllowed := GroupAllowsImageGeneration(apiKeyGroup(apiKey))
+		globalImageDisable := s != nil && s.cfg != nil && s.cfg.DisableImageGeneration
+		if globalImageDisable {
+			strippedPayload, changed, stripErr := s.normalizeGloballyDisabledImageGeneration(normalized)
+			if stripErr != nil {
+				return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", stripErr)
+			}
+			if changed {
+				normalized = strippedPayload
+				logOpenAIWSModeInfo("ingress_ws_image_tool_stripped_global account_id=%d", account.ID)
+			}
+		}
+		imageGenerationAllowed := !globalImageDisable && GroupAllowsImageGeneration(apiKeyGroup(apiKey))
 		codexImageGenerationExplicitToolPolicy := codexImageGenerationExplicitToolPolicyAllow
 		if isCodexCLI {
 			codexImageGenerationExplicitToolPolicy = account.CodexImageGenerationExplicitToolPolicy()
 		}
-		codexBridgeEnabled := isCodexCLI && imageGenerationAllowed && codexImageGenerationExplicitToolPolicy != codexImageGenerationExplicitToolPolicyStrip && s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey)
+		codexBridgeEnabled := codexImageGenerationBridgeAllowed(
+			globalImageDisable,
+			isCodexCLI,
+			imageGenerationAllowed,
+			codexImageGenerationExplicitToolPolicy,
+			s.isCodexImageGenerationBridgeEnabled(ctx, account, apiKey),
+		)
 		if codexBridgeEnabled {
 			payloadMap := make(map[string]any)
 			if err := json.Unmarshal(normalized, &payloadMap); err != nil {

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -435,6 +435,117 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_InjectsCodexImag
 	require.Contains(t, gjson.Get(upstreamPayload, "instructions").String(), "image_generation")
 }
 
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_GlobalDisableStripsEveryTurnAndBlocksBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{DisableImageGeneration: true}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	captureConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_global_disable_1","model":"gpt-5.5","usage":{"input_tokens":1,"output_tokens":1}}}`),
+		[]byte(`{"type":"response.completed","response":{"id":"resp_global_disable_2","model":"gpt-5.5","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	captureDialer := &openAIWSCaptureDialer{conn: captureConn}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(captureDialer)
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+
+	groupID := int64(3)
+	apiKey := &APIKey{ID: 1, UserID: 1, GroupID: &groupID, Group: &Group{ID: groupID, AllowImageGeneration: true}}
+	account := &Account{
+		ID: 32, Name: "openai-global-image-disable-ws", Platform: PlatformOpenAI,
+		Type: AccountTypeOAuth, Status: StatusActive, Schedulable: true, Concurrency: 1,
+		Credentials: map[string]any{"access_token": "test-token"},
+		Extra: map[string]any{
+			"openai_oauth_responses_websockets_v2_enabled": true,
+			"codex_image_generation_bridge":                true,
+		},
+	}
+
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		req := r.Clone(r.Context())
+		req.Header = req.Header.Clone()
+		req.Header.Set("User-Agent", "codex_cli_rs/0.98.0")
+		ginCtx.Request = req
+		ginCtx.Set("api_key", apiKey)
+
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErrCh <- errors.New("unsupported websocket client message type")
+			return
+		}
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "test-token", firstMessage, nil)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	writeAndRead := func(payload string) {
+		writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+		require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(payload)))
+		cancelWrite()
+		readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+		_, _, readErr := clientConn.Read(readCtx)
+		cancelRead()
+		require.NoError(t, readErr)
+	}
+	writeAndRead(`{"type":"response.create","model":"gpt-5.5","stream":false,"tools":[{"type":"image_generation"}]}`)
+	writeAndRead(`{"type":"response.create","model":"gpt-5.5","stream":false,"previous_response_id":"resp_global_disable_1","tools":[{"type":"namespace","name":"image_gen"}]}`)
+	_ = clientConn.Close(coderws.StatusNormalClosure, "done")
+
+	select {
+	case serverErr := <-serverErrCh:
+		require.NoError(t, serverErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("waiting for ingress websocket shutdown timed out")
+	}
+
+	require.Len(t, captureConn.writes, 2)
+	for _, write := range captureConn.writes {
+		upstreamPayload := []byte(requestToJSONString(write))
+		require.False(t, IsImageGenerationIntent(openAIResponsesEndpoint, "gpt-5.5", upstreamPayload))
+		require.NotContains(t, gjson.GetBytes(upstreamPayload, "instructions").String(), "image_generation")
+	}
+}
+
 func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_DedicatedModeDoesNotReuseConnAcrossSessions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_ws_forwarder_ingress_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_test.go
@@ -256,6 +256,29 @@ func TestStripOpenAIImageGenerationToolsFromRawPayloadExported(t *testing.T) {
 	require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
 }
 
+func TestOpenAIGatewayServiceNormalizeGloballyDisabledImageGeneration(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{DisableImageGeneration: true}}
+	frames := [][]byte{
+		[]byte(`{"type":"response.create","model":"gpt-5.5","tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`),
+		[]byte(`{"type":"response.create","tools":[{"type":"function","name":"shell"},{"type":"namespace","name":"image_gen"}],"tool_choice":{"type":"namespace","name":"image_gen"}}`),
+	}
+
+	for _, frame := range frames {
+		updated, changed, err := svc.normalizeGloballyDisabledImageGeneration(frame)
+
+		require.NoError(t, err)
+		require.True(t, changed)
+		require.False(t, IsImageGenerationIntent(openAIResponsesEndpoint, "gpt-5.5", updated))
+		require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
+		require.False(t, gjson.GetBytes(updated, "tool_choice").Exists())
+	}
+}
+
+func TestCodexImageGenerationBridgeAllowedGlobalDisableWins(t *testing.T) {
+	require.False(t, codexImageGenerationBridgeAllowed(true, true, true, codexImageGenerationExplicitToolPolicyAllow, true))
+	require.True(t, codexImageGenerationBridgeAllowed(false, true, true, codexImageGenerationExplicitToolPolicyAllow, true))
+}
+
 func TestAlignStoreDisabledPreviousResponseID(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_ws_forwarder_ingress_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_test.go
@@ -245,6 +245,17 @@ func TestStripOpenAIImageGenerationToolsFromRawPayload(t *testing.T) {
 	})
 }
 
+func TestStripOpenAIImageGenerationToolsFromRawPayloadExported(t *testing.T) {
+	payload := []byte(`{"model":"gpt-5.5","tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
+
+	updated, changed, err := StripOpenAIImageGenerationToolsFromRawPayload(payload)
+
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, IsImageGenerationIntent(openAIResponsesEndpoint, "gpt-5.5", updated))
+	require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
+}
+
 func TestAlignStoreDisabledPreviousResponseID(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -310,6 +310,10 @@ GATEWAY_SCHEDULING_FULL_REBUILD_INTERVAL_SECONDS=300
 # Image Generation Stream & Concurrency (Optional)
 # 图片生成流式与并发隔离配置（可选）
 # -----------------------------------------------------------------------------
+# Remove image tools from text-capable /responses requests and reject dedicated
+# image generation endpoints. Defaults to false for backward compatibility.
+DISABLE_IMAGE_GENERATION=false
+
 # 图片流式上游数据间隔超时（秒）。0 表示禁用；非 0 时必须为 60-1800。
 GATEWAY_IMAGE_STREAM_DATA_INTERVAL_TIMEOUT=900
 # 图片流式 keepalive 间隔（秒）。0 表示禁用；非 0 时必须为 5-60。

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -103,6 +103,7 @@ services:
       # =======================================================================
       # Image Generation Stream & Concurrency
       # =======================================================================
+      - DISABLE_IMAGE_GENERATION=${DISABLE_IMAGE_GENERATION:-false}
       # OpenAI HTTP upstream protocol/timeout
       - GATEWAY_OPENAI_RESPONSE_HEADER_TIMEOUT=${GATEWAY_OPENAI_RESPONSE_HEADER_TIMEOUT:-0}
       - GATEWAY_OPENAI_HTTP2_ENABLED=${GATEWAY_OPENAI_HTTP2_ENABLED:-true}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -152,6 +152,7 @@ services:
       # =======================================================================
       # Image Generation Stream & Concurrency
       # =======================================================================
+      - DISABLE_IMAGE_GENERATION=${DISABLE_IMAGE_GENERATION:-false}
       # OpenAI HTTP upstream protocol/timeout
       - GATEWAY_OPENAI_RESPONSE_HEADER_TIMEOUT=${GATEWAY_OPENAI_RESPONSE_HEADER_TIMEOUT:-0}
       - GATEWAY_OPENAI_HTTP2_ENABLED=${GATEWAY_OPENAI_HTTP2_ENABLED:-true}

--- a/docs/superpowers/plans/2026-07-12-disable-image-generation.md
+++ b/docs/superpowers/plans/2026-07-12-disable-image-generation.md
@@ -1,0 +1,761 @@
+# Global Image Generation Disable Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (- [ ]) syntax for tracking.
+
+**Goal:** Add DISABLE_IMAGE_GENERATION=true so text-capable OpenAI /responses requests have image tools removed before the group gate while image-only and dedicated image requests remain forbidden.
+
+**Architecture:** Add one top-level Viper flag and reuse the existing canonical raw-payload image-tool stripper. Normalize at HTTP and WebSocket ingress before image-intent checks, prevent account/channel bridge logic from re-injecting tools, and make dedicated image handlers fail closed. Preserve current behavior when the flag is false.
+
+**Tech Stack:** Go 1.26, Gin, Viper, coder/websocket, testify, Docker Compose, PostgreSQL, Redis
+
+## Global Constraints
+
+- Base code and image on v0.1.151 commit deff3123ded1d14e51df1fd1286e3d43ed9ec9bd.
+- DISABLE_IMAGE_GENERATION defaults to false.
+- Text-model /responses requests continue after image declarations are removed.
+- Image-only models, OpenAI image endpoints, and Grok generation endpoints remain forbidden.
+- Cover HTTP, WebSocket first frames, and WebSocket follow-up response.create frames.
+- Never log request bodies, API keys, credentials, prompts, or generated content.
+- Do not add a database migration or modify account/group records.
+- Deploy an immutable custom image tag; never overwrite weishaw/sub2api:latest.
+
+---
+
+### Task 1: Add The Global Configuration Flag
+
+**Files:**
+- Modify: backend/internal/config/config.go
+- Test: backend/internal/config/config_test.go
+
+**Interfaces:**
+- Consumes: Viper AutomaticEnv and the existing dot-to-underscore replacer.
+- Produces: config.Config.DisableImageGeneration bool mapped from disable_image_generation and DISABLE_IMAGE_GENERATION.
+
+- [ ] **Step 1: Write the failing configuration test**
+
+~~~go
+func TestLoadDisableImageGeneration(t *testing.T) {
+    t.Run("defaults to false", func(t *testing.T) {
+        resetViperWithJWTSecret(t)
+        cfg, err := Load()
+        require.NoError(t, err)
+        require.False(t, cfg.DisableImageGeneration)
+    })
+
+    t.Run("reads top level environment variable", func(t *testing.T) {
+        resetViperWithJWTSecret(t)
+        t.Setenv("DISABLE_IMAGE_GENERATION", "true")
+        cfg, err := Load()
+        require.NoError(t, err)
+        require.True(t, cfg.DisableImageGeneration)
+    })
+}
+~~~
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+~~~bash
+cd backend
+go test ./internal/config -run '^TestLoadDisableImageGeneration$' -count=1
+~~~
+
+Expected: compilation fails because Config.DisableImageGeneration is undefined.
+
+- [ ] **Step 3: Add the field and default**
+
+Add to Config:
+
+~~~go
+DisableImageGeneration bool `mapstructure:"disable_image_generation"`
+~~~
+
+Add in setDefaults before Gateway defaults:
+
+~~~go
+viper.SetDefault("disable_image_generation", false)
+~~~
+
+- [ ] **Step 4: Verify GREEN and package regression tests**
+
+~~~bash
+cd backend
+go test ./internal/config -run '^TestLoadDisableImageGeneration$' -count=1
+go test ./internal/config -count=1
+~~~
+
+Expected: both commands pass.
+
+- [ ] **Step 5: Commit**
+
+~~~bash
+git add backend/internal/config/config.go backend/internal/config/config_test.go
+git commit -m "feat: add global image generation disable config"
+~~~
+
+---
+
+### Task 2: Expose The Canonical Payload Stripper
+
+**Files:**
+- Modify: backend/internal/service/openai_codex_transform.go
+- Test: backend/internal/service/openai_ws_forwarder_ingress_test.go
+
+**Interfaces:**
+- Consumes: private stripOpenAIImageGenerationToolsFromRawPayload.
+- Produces: service.StripOpenAIImageGenerationToolsFromRawPayload(payload []byte) ([]byte, bool, error).
+
+- [ ] **Step 1: Write the failing exported-wrapper test**
+
+~~~go
+func TestStripOpenAIImageGenerationToolsFromRawPayloadExported(t *testing.T) {
+    payload := []byte(`{"model":"gpt-5.5","tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
+
+    updated, changed, err := StripOpenAIImageGenerationToolsFromRawPayload(payload)
+
+    require.NoError(t, err)
+    require.True(t, changed)
+    require.False(t, IsImageGenerationIntent(openAIResponsesEndpoint, "gpt-5.5", updated))
+    require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
+}
+~~~
+
+- [ ] **Step 2: Verify RED**
+
+~~~bash
+cd backend
+go test ./internal/service -run '^TestStripOpenAIImageGenerationToolsFromRawPayloadExported$' -count=1
+~~~
+
+Expected: compilation fails because the exported function is undefined.
+
+- [ ] **Step 3: Add the minimal wrapper**
+
+~~~go
+// StripOpenAIImageGenerationToolsFromRawPayload removes Responses image tool
+// declarations while preserving unrelated request fields and tools.
+func StripOpenAIImageGenerationToolsFromRawPayload(payload []byte) ([]byte, bool, error) {
+    return stripOpenAIImageGenerationToolsFromRawPayload(payload)
+}
+~~~
+
+- [ ] **Step 4: Verify existing and exported stripper behavior**
+
+~~~bash
+cd backend
+go test ./internal/service -run '^(TestStripOpenAIImageGenerationToolsFromRawPayload|TestStripOpenAIImageGenerationToolsFromRawPayloadExported)$' -count=1
+~~~
+
+Expected: flat tools, namespaces, input.additional_tools, tool_choice, no-op, and exported wrapper cases pass.
+
+- [ ] **Step 5: Commit**
+
+~~~bash
+git add backend/internal/service/openai_codex_transform.go backend/internal/service/openai_ws_forwarder_ingress_test.go
+git commit -m "refactor: expose responses image tool stripper"
+~~~
+
+---
+
+### Task 3: Normalize HTTP Responses Before The Group Gate
+
+**Files:**
+- Create: backend/internal/handler/image_generation_global_disable.go
+- Create: backend/internal/handler/image_generation_global_disable_test.go
+- Modify: backend/internal/handler/openai_gateway_handler.go
+- Test: backend/internal/handler/image_concurrency_limiter_test.go
+
+**Interfaces:**
+- Consumes: Config.DisableImageGeneration and the exported service stripper.
+- Produces: imageGenerationGloballyDisabled() bool and normalizeGloballyDisabledImageGeneration([]byte) ([]byte, bool, error).
+
+- [ ] **Step 1: Write failing helper tests**
+
+~~~go
+package handler
+
+import (
+    "testing"
+
+    "github.com/Wei-Shaw/sub2api/internal/config"
+    "github.com/Wei-Shaw/sub2api/internal/service"
+    "github.com/stretchr/testify/require"
+    "github.com/tidwall/gjson"
+)
+
+func TestNormalizeGloballyDisabledImageGeneration(t *testing.T) {
+    payload := []byte(`{"model":"gpt-5.5","input":[{"type":"message","role":"user","content":"hello"},{"type":"additional_tools","tools":[{"type":"namespace","name":"image_gen"}]}],"tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`)
+    h := &OpenAIGatewayHandler{cfg: &config.Config{DisableImageGeneration: true}}
+
+    updated, changed, err := h.normalizeGloballyDisabledImageGeneration(payload)
+
+    require.NoError(t, err)
+    require.True(t, changed)
+    require.False(t, service.IsImageGenerationIntent("/v1/responses", "gpt-5.5", updated))
+    require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
+    require.Equal(t, "hello", gjson.GetBytes(updated, "input.0.content").String())
+}
+
+func TestNormalizeGloballyDisabledImageGenerationNoOp(t *testing.T) {
+    payload := []byte(`{"model":"gpt-5.5","tools":[{"type":"image_generation"}]}`)
+    h := &OpenAIGatewayHandler{cfg: &config.Config{}}
+
+    updated, changed, err := h.normalizeGloballyDisabledImageGeneration(payload)
+
+    require.NoError(t, err)
+    require.False(t, changed)
+    require.Equal(t, payload, updated)
+}
+~~~
+
+- [ ] **Step 2: Verify RED**
+
+~~~bash
+cd backend
+go test ./internal/handler -run '^TestNormalizeGloballyDisabledImageGeneration' -count=1
+~~~
+
+Expected: compilation fails because the methods are undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+~~~go
+package handler
+
+import "github.com/Wei-Shaw/sub2api/internal/service"
+
+func (h *OpenAIGatewayHandler) imageGenerationGloballyDisabled() bool {
+    return h != nil && h.cfg != nil && h.cfg.DisableImageGeneration
+}
+
+func (h *OpenAIGatewayHandler) normalizeGloballyDisabledImageGeneration(payload []byte) ([]byte, bool, error) {
+    if !h.imageGenerationGloballyDisabled() {
+        return payload, false, nil
+    }
+    return service.StripOpenAIImageGenerationToolsFromRawPayload(payload)
+}
+~~~
+
+- [ ] **Step 4: Verify helper GREEN**
+
+~~~bash
+cd backend
+go test ./internal/handler -run '^TestNormalizeGloballyDisabledImageGeneration' -count=1
+~~~
+
+Expected: both helper tests pass.
+
+- [ ] **Step 5: Write failing handler regression tests**
+
+Add this concrete fixture and the two regression tests:
+
+~~~go
+func newGlobalImageDisableResponsesTestContext(t *testing.T, body string) (*httptest.ResponseRecorder, *gin.Context, *OpenAIGatewayHandler) {
+    t.Helper()
+    gin.SetMode(gin.TestMode)
+    rec := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(rec)
+    c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+    groupID := int64(1)
+    c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+        ID: 10,
+        GroupID: &groupID,
+        Group: &service.Group{ID: groupID, AllowImageGeneration: false},
+        User: &service.User{ID: 20},
+    })
+    c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 20, Concurrency: 1})
+    cfg := &config.Config{RunMode: config.RunModeSimple, DisableImageGeneration: true}
+    h := &OpenAIGatewayHandler{
+        gatewayService: &service.OpenAIGatewayService{},
+        billingCacheService: service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil),
+        apiKeyService: &service.APIKeyService{},
+        concurrencyHelper: &ConcurrencyHelper{concurrencyService: service.NewConcurrencyService(&helperConcurrencyCacheStub{userSeq: []bool{true}})},
+        cfg: cfg,
+        imageLimiter: &imageConcurrencyLimiter{},
+    }
+    return rec, c, h
+}
+
+func TestOpenAIGatewayHandlerResponsesGlobalDisableStripsBeforeGroupGate(t *testing.T) {
+    body := `{"model":"gpt-5.5","input":"write code","tools":[{"type":"image_generation"}]}`
+    rec, c, h := newGlobalImageDisableResponsesTestContext(t, body)
+    h.Responses(c)
+    require.NotEqual(t, http.StatusForbidden, rec.Code)
+    require.NotContains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+
+func TestOpenAIGatewayHandlerResponsesGlobalDisableRejectsImageOnlyModel(t *testing.T) {
+    body := `{"model":"gpt-image-2","input":"draw"}`
+    rec, c, h := newGlobalImageDisableResponsesTestContext(t, body)
+    h.Responses(c)
+    require.Equal(t, http.StatusForbidden, rec.Code)
+    require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+~~~
+
+- [ ] **Step 6: Verify RED**
+
+~~~bash
+cd backend
+go test ./internal/handler -run '^TestOpenAIGatewayHandlerResponsesGlobalDisable' -count=1
+~~~
+
+Expected: text-model case returns the current 403; image-only case returns the intended 403.
+
+- [ ] **Step 7: Normalize in Responses before moderation and image intent**
+
+After compact normalization and JSON validation:
+
+~~~go
+normalizedBody, stripped, stripErr := h.normalizeGloballyDisabledImageGeneration(body)
+if stripErr != nil {
+    h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to normalize request body")
+    return
+}
+if stripped {
+    body = normalizedBody
+    reqLog.Info("openai.image_generation_tools_stripped_global")
+}
+sessionHashBody = body
+~~~
+
+Keep all later parsing, moderation, image-intent checks, mapping, hashing, and forwarding on the normalized body.
+
+- [ ] **Step 8: Verify focused handler tests**
+
+~~~bash
+cd backend
+go test ./internal/handler -run '^(TestNormalizeGloballyDisabledImageGeneration|TestOpenAIGatewayHandlerResponsesGlobalDisable|TestOpenAIGatewayHandlerResponses_(ImageIntentRejectedByImageConcurrency|TextOnlyNotRejectedByImageConcurrency))' -count=1
+~~~
+
+Expected: all selected tests pass.
+
+- [ ] **Step 9: Commit**
+
+~~~bash
+git add backend/internal/handler/image_generation_global_disable.go backend/internal/handler/image_generation_global_disable_test.go backend/internal/handler/openai_gateway_handler.go backend/internal/handler/image_concurrency_limiter_test.go
+git commit -m "fix: strip image tools before responses group gate"
+~~~
+
+---
+
+### Task 4: Cover WebSocket And Prevent Tool Re-Injection
+
+**Files:**
+- Modify: backend/internal/handler/openai_gateway_handler.go
+- Modify: backend/internal/service/openai_ws_forwarder_ingress.go
+- Modify: backend/internal/service/openai_gateway_forward.go
+- Test: backend/internal/handler/openai_gateway_handler_test.go
+- Test: backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+
+**Interfaces:**
+- Consumes: handler normalizer and OpenAIGatewayService.cfg.DisableImageGeneration.
+- Produces: OpenAIGatewayService.normalizeGloballyDisabledImageGeneration([]byte) plus normalized first/follow-up frames and bridge-injection guards.
+
+- [ ] **Step 1: Write a failing service normalization test**
+
+Add this table test to openai_ws_forwarder_ingress_test.go:
+
+~~~go
+func TestOpenAIGatewayServiceNormalizeGloballyDisabledImageGeneration(t *testing.T) {
+    svc := &OpenAIGatewayService{cfg: &config.Config{DisableImageGeneration: true}}
+    frames := [][]byte{
+        []byte(`{"type":"response.create","model":"gpt-5.5","tools":[{"type":"function","name":"shell"},{"type":"image_generation"}],"tool_choice":{"type":"image_generation"}}`),
+        []byte(`{"type":"response.create","tools":[{"type":"function","name":"shell"},{"type":"namespace","name":"image_gen"}],"tool_choice":{"type":"namespace","name":"image_gen"}}`),
+    }
+    for _, frame := range frames {
+        updated, changed, err := svc.normalizeGloballyDisabledImageGeneration(frame)
+        require.NoError(t, err)
+        require.True(t, changed)
+        require.False(t, IsImageGenerationIntent(openAIResponsesEndpoint, "gpt-5.5", updated))
+        require.True(t, gjson.GetBytes(updated, `tools.#(name=="shell")`).Exists())
+        require.False(t, gjson.GetBytes(updated, "tool_choice").Exists())
+    }
+}
+~~~
+
+- [ ] **Step 2: Verify RED**
+
+~~~bash
+cd backend
+go test ./internal/service -run '^TestOpenAIGatewayServiceNormalizeGloballyDisabledImageGeneration$' -count=1
+~~~
+
+Expected: compilation fails because the service method is undefined.
+
+- [ ] **Step 3: Normalize each service ingress turn**
+
+Add the method near the ingress code:
+
+~~~go
+func (s *OpenAIGatewayService) normalizeGloballyDisabledImageGeneration(payload []byte) ([]byte, bool, error) {
+    if s == nil || s.cfg == nil || !s.cfg.DisableImageGeneration {
+        return payload, false, nil
+    }
+    return StripOpenAIImageGenerationToolsFromRawPayload(payload)
+}
+~~~
+
+Before codexBridgeEnabled in openai_ws_forwarder_ingress.go:
+
+~~~go
+globalImageDisable := s != nil && s.cfg != nil && s.cfg.DisableImageGeneration
+if globalImageDisable {
+    strippedPayload, changed, stripErr := s.normalizeGloballyDisabledImageGeneration(normalized)
+    if stripErr != nil {
+        return openAIWSClientPayload{}, NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "invalid websocket request payload", stripErr)
+    }
+    if changed {
+        normalized = strippedPayload
+        logOpenAIWSModeInfo("ingress_ws_image_tool_stripped_global account_id=%d", account.ID)
+    }
+}
+~~~
+
+Require !globalImageDisable in codexBridgeEnabled.
+
+- [ ] **Step 4: Prevent HTTP forwarding from re-injecting**
+
+In openai_gateway_forward.go calculate:
+
+~~~go
+globalImageDisable := s != nil && s.cfg != nil && s.cfg.DisableImageGeneration
+~~~
+
+Require !globalImageDisable in codexImageGenerationBridgeEnabled.
+
+- [ ] **Step 5: Normalize the WebSocket first frame before its handler gate**
+
+After firstMessage JSON validation, insert:
+
+~~~go
+normalizedFirstMessage, stripped, stripErr := h.normalizeGloballyDisabledImageGeneration(firstMessage)
+if stripErr != nil {
+    closeOpenAIClientWS(wsConn, coderws.StatusPolicyViolation, "invalid websocket request payload")
+    return
+}
+if stripped {
+    firstMessage = normalizedFirstMessage
+    reqLog.Info("openai.websocket_image_generation_tools_stripped_global")
+}
+~~~
+
+Derive model, moderation input, session data, and image intent from the normalized firstMessage.
+
+- [ ] **Step 6: Verify WebSocket and bridge tests**
+
+~~~bash
+cd backend
+go test ./internal/service -run '^(TestOpenAIGatewayServiceNormalizeGloballyDisabledImageGeneration|TestStripOpenAIImageGenerationToolsFromRawPayload|TestOpenAIWSForwarderIngress)' -count=1
+go test ./internal/handler -run '^TestOpenAIResponsesWebSocket' -count=1
+~~~
+
+Expected: all selected tests pass and no global-disable payload contains an image tool upstream.
+
+- [ ] **Step 7: Commit**
+
+~~~bash
+git add backend/internal/handler/openai_gateway_handler.go backend/internal/handler/openai_gateway_handler_test.go backend/internal/service/openai_ws_forwarder_ingress.go backend/internal/service/openai_gateway_forward.go backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+git commit -m "fix: enforce global image disable on websocket turns"
+~~~
+
+---
+
+### Task 5: Fail Closed On Dedicated Generation Endpoints
+
+**Files:**
+- Modify: backend/internal/handler/openai_images.go
+- Modify: backend/internal/handler/grok_media.go
+- Test: backend/internal/handler/openai_images_controls_test.go
+- Test: backend/internal/handler/grok_media_test.go
+
+**Interfaces:**
+- Consumes: imageGenerationGloballyDisabled() and service.GroupAllowsImageGeneration().
+- Produces: imageGenerationAllowedForGroup(*service.Group) bool and global 403 enforcement independent of group permission.
+
+- [ ] **Step 1: Write the failing shared policy test**
+
+Add to image_generation_global_disable_test.go:
+
+~~~go
+func TestImageGenerationAllowedForGroup(t *testing.T) {
+    allowedGroup := &service.Group{AllowImageGeneration: true}
+    tests := []struct {
+        name string
+        disabled bool
+        want bool
+    }{
+        {name: "existing group permission retained", disabled: false, want: true},
+        {name: "global disable overrides allowed group", disabled: true, want: false},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            h := &OpenAIGatewayHandler{cfg: &config.Config{DisableImageGeneration: tt.disabled}}
+            require.Equal(t, tt.want, h.imageGenerationAllowedForGroup(allowedGroup))
+        })
+    }
+}
+
+func newGlobalDisableMediaContext(t *testing.T, path string, body string) (*httptest.ResponseRecorder, *gin.Context, *OpenAIGatewayHandler) {
+    t.Helper()
+    gin.SetMode(gin.TestMode)
+    rec := httptest.NewRecorder()
+    c, _ := gin.CreateTestContext(rec)
+    c.Request = httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+    c.Request.Header.Set("Content-Type", "application/json")
+    groupID := int64(111)
+    c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+        ID: 222,
+        GroupID: &groupID,
+        Group: &service.Group{ID: groupID, AllowImageGeneration: true},
+        User: &service.User{ID: 333},
+    })
+    c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 333, Concurrency: 1})
+    cfg := &config.Config{RunMode: config.RunModeSimple, DisableImageGeneration: true}
+    h := &OpenAIGatewayHandler{
+        gatewayService: &service.OpenAIGatewayService{},
+        billingCacheService: service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil),
+        apiKeyService: &service.APIKeyService{},
+        concurrencyHelper: &ConcurrencyHelper{concurrencyService: &service.ConcurrencyService{}},
+        cfg: cfg,
+    }
+    return rec, c, h
+}
+
+func TestOpenAIGatewayHandlerImagesGlobalDisableRejectsAllowedGroup(t *testing.T) {
+    rec, c, h := newGlobalDisableMediaContext(t, "/v1/images/generations", `{"model":"gpt-image-2","prompt":"draw"}`)
+    h.Images(c)
+    require.Equal(t, http.StatusForbidden, rec.Code)
+    require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+
+func TestGrokMediaGlobalDisableRejectsAllowedGroup(t *testing.T) {
+    rec, c, h := newGlobalDisableMediaContext(t, "/v1/images/generations", `{"model":"grok-imagine","prompt":"draw"}`)
+    h.GrokImages(c)
+    require.Equal(t, http.StatusForbidden, rec.Code)
+    require.Contains(t, rec.Body.String(), service.ImageGenerationPermissionMessage())
+}
+~~~
+
+- [ ] **Step 2: Verify RED**
+
+~~~bash
+cd backend
+go test ./internal/handler -run '^(TestImageGenerationAllowedForGroup|TestOpenAIGatewayHandlerImagesGlobalDisableRejectsAllowedGroup|TestGrokMediaGlobalDisableRejectsAllowedGroup)$' -count=1
+~~~
+
+Expected: compilation fails because imageGenerationAllowedForGroup is undefined; after adding only the helper, both direct handler tests still fail because the handlers have not called it.
+
+- [ ] **Step 3: Add global checks**
+
+Add the shared helper:
+
+~~~go
+func (h *OpenAIGatewayHandler) imageGenerationAllowedForGroup(group *service.Group) bool {
+    return !h.imageGenerationGloballyDisabled() && service.GroupAllowsImageGeneration(group)
+}
+~~~
+
+Use it in OpenAI Images:
+
+~~~go
+if !h.imageGenerationAllowedForGroup(apiKey.Group) {
+    h.errorResponse(c, http.StatusForbidden, "permission_error", service.ImageGenerationPermissionMessage())
+    return
+}
+~~~
+
+Use the exact same helper call inside Grok endpoint.IsGenerationRequest(). Do not block video-status polling.
+
+- [ ] **Step 4: Verify endpoint regressions**
+
+~~~bash
+cd backend
+go test ./internal/handler -run '^(TestImageGenerationAllowedForGroup|TestOpenAIGatewayHandlerImages|TestGrokMedia)' -count=1
+~~~
+
+Expected: global and group permission tests pass.
+
+- [ ] **Step 5: Commit**
+
+~~~bash
+git add backend/internal/handler/openai_images.go backend/internal/handler/grok_media.go backend/internal/handler/openai_images_controls_test.go backend/internal/handler/grok_media_test.go
+git commit -m "fix: block dedicated image endpoints globally"
+~~~
+
+---
+
+### Task 6: Expose The Flag In Docker Deployment Files
+
+**Files:**
+- Modify: deploy/.env.example
+- Modify: deploy/docker-compose.yml
+- Modify: deploy/docker-compose.standalone.yml
+
+**Interfaces:**
+- Consumes: deployment environment DISABLE_IMAGE_GENERATION.
+- Produces: explicit Compose propagation with false default.
+
+- [ ] **Step 1: Add the environment example**
+
+~~~dotenv
+# Remove image tools from text-capable /responses requests and reject dedicated
+# image generation endpoints. Defaults to false for backward compatibility.
+DISABLE_IMAGE_GENERATION=false
+~~~
+
+- [ ] **Step 2: Add Compose propagation under each image-generation section**
+
+~~~yaml
+- DISABLE_IMAGE_GENERATION=${DISABLE_IMAGE_GENERATION:-false}
+~~~
+
+- [ ] **Step 3: Validate both Compose files**
+
+~~~bash
+cd deploy
+POSTGRES_PASSWORD=test DISABLE_IMAGE_GENERATION=true docker compose config | rg 'DISABLE_IMAGE_GENERATION: "true"'
+DATABASE_HOST=db DATABASE_PASSWORD=test REDIS_HOST=redis DISABLE_IMAGE_GENERATION=true docker compose -f docker-compose.standalone.yml config | rg 'DISABLE_IMAGE_GENERATION: "true"'
+~~~
+
+Expected: each command prints one entry.
+
+- [ ] **Step 4: Commit**
+
+~~~bash
+git add deploy/.env.example deploy/docker-compose.yml deploy/docker-compose.standalone.yml
+git commit -m "docs: expose global image disable in compose"
+~~~
+
+---
+
+### Task 7: Full Verification And Immutable Image Build
+
+**Files:**
+- Verify all files changed in Tasks 1-6.
+- No new source files.
+
+**Interfaces:**
+- Consumes: completed feature commits.
+- Produces: tested source commit and sub2api-custom:0.1.151-disable-image-generation.1.
+
+- [ ] **Step 1: Format and inspect**
+
+~~~bash
+gofmt -w backend/internal/config/config.go backend/internal/config/config_test.go backend/internal/service/openai_codex_transform.go backend/internal/service/openai_ws_forwarder_ingress_test.go backend/internal/service/openai_ws_forwarder_ingress.go backend/internal/service/openai_ws_forwarder_ingress_session_test.go backend/internal/service/openai_gateway_forward.go backend/internal/handler/image_generation_global_disable.go backend/internal/handler/image_generation_global_disable_test.go backend/internal/handler/openai_gateway_handler.go backend/internal/handler/openai_gateway_handler_test.go backend/internal/handler/image_concurrency_limiter_test.go backend/internal/handler/openai_images.go backend/internal/handler/openai_images_controls_test.go backend/internal/handler/grok_media.go backend/internal/handler/grok_media_test.go
+git diff --check
+git status --short
+~~~
+
+Expected: no formatting or whitespace errors and only intended files differ.
+
+- [ ] **Step 2: Run focused packages**
+
+~~~bash
+cd backend
+go test ./internal/config ./internal/service ./internal/handler -count=1
+~~~
+
+Expected: all selected packages pass.
+
+- [ ] **Step 3: Run the complete backend suite**
+
+~~~bash
+cd backend
+go test ./... -count=1
+~~~
+
+Expected: zero failing packages.
+
+- [ ] **Step 4: Transfer committed source and build natively on production amd64**
+
+~~~bash
+BUILD_TAG=0.1.151-disable-image-generation.1
+COMMIT=$(git rev-parse --short HEAD)
+git archive --format=tar HEAD | ssh 101.43.35.235 "mkdir -p /opt/sub2api-builds/$BUILD_TAG && tar -xf - -C /opt/sub2api-builds/$BUILD_TAG"
+ssh 101.43.35.235 "cd /opt/sub2api-builds/$BUILD_TAG && docker build --build-arg VERSION=$BUILD_TAG --build-arg COMMIT=$COMMIT -t sub2api-custom:$BUILD_TAG ."
+ssh 101.43.35.235 "docker image inspect sub2api-custom:$BUILD_TAG --format 'id={{.Id}} created={{.Created}}'"
+~~~
+
+Expected: build succeeds and image inspection prints a non-empty ID.
+
+---
+
+### Task 8: Production Deployment, Verification, And Rollback
+
+**Files:**
+- Remote backup: /opt/sub2api/backups/docker-compose.override.yml.<timestamp>
+- Remote deployment: /opt/sub2api/docker-compose.override.yml
+- Local staging: ../production/docker-compose.override.yml
+
+**Interfaces:**
+- Consumes: sub2api-custom:0.1.151-disable-image-generation.1.
+- Produces: healthy production service with the global switch enabled and an exact rollback path.
+
+- [ ] **Step 1: Record rollback state**
+
+~~~bash
+ssh 101.43.35.235 'docker inspect sub2api --format "image={{.Config.Image}} image_id={{.Image}} started={{.State.StartedAt}}"; cd /opt/sub2api && docker compose config --images'
+~~~
+
+Expected: current upstream image and image ID are recorded before mutation.
+
+- [ ] **Step 2: Download and preserve the current override**
+
+~~~bash
+mkdir -p ../production
+scp 101.43.35.235:/opt/sub2api/docker-compose.override.yml ../production/docker-compose.override.yml
+cp ../production/docker-compose.override.yml ../production/docker-compose.override.yml.before-image-disable
+~~~
+
+Use apply_patch on the local copy, preserving existing DGC network settings, to add under services.sub2api:
+
+~~~yaml
+image: sub2api-custom:0.1.151-disable-image-generation.1
+environment:
+  DISABLE_IMAGE_GENERATION: "true"
+~~~
+
+- [ ] **Step 3: Back up, upload, and validate**
+
+~~~bash
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+ssh 101.43.35.235 "mkdir -p /opt/sub2api/backups && cp /opt/sub2api/docker-compose.override.yml /opt/sub2api/backups/docker-compose.override.yml.$TIMESTAMP"
+scp ../production/docker-compose.override.yml 101.43.35.235:/opt/sub2api/docker-compose.override.yml
+ssh 101.43.35.235 'cd /opt/sub2api && docker compose config | grep -E "sub2api-custom:0.1.151-disable-image-generation.1|DISABLE_IMAGE_GENERATION"'
+~~~
+
+Expected: custom image and true flag appear in rendered config.
+
+- [ ] **Step 4: Recreate only Sub2API**
+
+~~~bash
+ssh 101.43.35.235 'cd /opt/sub2api && docker compose up -d --no-deps --force-recreate sub2api'
+~~~
+
+Poll docker inspect every two seconds for at most 60 seconds. Expected: running|healthy.
+
+- [ ] **Step 5: Verify runtime state**
+
+~~~bash
+ssh 101.43.35.235 'docker inspect sub2api --format "image={{.Config.Image}} image_id={{.Image}} health={{.State.Health.Status}}"; docker inspect sub2api --format "{{range .Config.Env}}{{println .}}{{end}}" | grep "^DISABLE_IMAGE_GENERATION=true$"; docker logs --since 5m sub2api 2>&1 | grep -E "ERROR|FATAL|panic" || true'
+curl -fsS -o /dev/null -w 'site_http=%{http_code}
+' https://sub2api.weihub.cloud/
+~~~
+
+Expected: custom image, true flag, healthy container, no startup errors, site HTTP 200.
+
+- [ ] **Step 6: Verify behavior end to end**
+
+Send a fresh Codex gpt-5.5 text request through https://sub2api.weihub.cloud/responses and record its new request ID. Expected: log event openai.image_generation_tools_stripped_global, no image-permission 403, and a normal upstream response.
+
+Send an authenticated /images/generations request. Expected: HTTP 403 with Image generation is not enabled for this group and no upstream account selection.
+
+- [ ] **Step 7: Roll back on any failure**
+
+~~~bash
+ssh 101.43.35.235 "cp /opt/sub2api/backups/docker-compose.override.yml.$TIMESTAMP /opt/sub2api/docker-compose.override.yml && cd /opt/sub2api && docker compose up -d --no-deps --force-recreate sub2api"
+~~~
+
+Poll to running|healthy and verify the recorded upstream image ID is restored. Keep failed-deployment logs for diagnosis.

--- a/docs/superpowers/specs/2026-07-12-disable-image-generation-design.md
+++ b/docs/superpowers/specs/2026-07-12-disable-image-generation-design.md
@@ -1,0 +1,137 @@
+# Global Image Generation Disable Design
+
+## Context
+
+Sub2API v0.1.151 rejects an OpenAI `/responses` request as soon as it detects an
+`image_generation` declaration while the API key group has
+`allow_image_generation=false`. This group-level check runs before account
+selection, so the existing account policy
+`codex_image_generation_explicit_tool_policy=strip` cannot remove the tool in
+time. Codex clients attach the tool to otherwise normal text requests, causing
+those requests to fail with HTTP 403.
+
+## Goal
+
+Add a global, opt-in `DISABLE_IMAGE_GENERATION=true` setting that prevents
+image generation without rejecting ordinary text-capable `/responses`
+requests merely because the client attached an image tool.
+
+## Configuration
+
+- Add `DisableImageGeneration bool` to the top-level configuration with the
+  mapstructure key `disable_image_generation`.
+- Set its default to `false` so existing installations retain current behavior.
+- Viper's existing environment mapping exposes the setting as
+  `DISABLE_IMAGE_GENERATION`.
+- The global setting takes precedence over group, channel, and account image
+  settings when it is enabled.
+
+## Request Behavior
+
+### HTTP `/responses`
+
+When global image generation is disabled, normalize the validated request body
+before content moderation, image-intent classification, concurrency accounting,
+session hashing, model mapping, or account selection:
+
+1. Remove every `image_generation` entry from `tools`.
+2. Remove image-generation declarations embedded in `input`.
+3. Remove `tool_choice` when it explicitly selects image generation.
+4. Preserve all unrelated request fields and tools.
+5. Continue through the normal text request path using the normalized body.
+
+Reuse the existing shared image-tool stripping implementation. The operation
+must remain idempotent and must not require the request to be recognized as a
+Codex client.
+
+If the requested or mapped model is an image-only model such as `gpt-image-*`,
+the request remains an image-generation intent and returns HTTP 403. Removing a
+tool cannot turn an image-only model into a text model.
+
+### WebSocket `/responses`
+
+Apply the same normalization to the first `response.create` message before its
+image-intent gate and to subsequent `response.create` messages at WebSocket
+ingress. Forward the normalized payload. Text-capable turns continue; image-only
+models are closed with the existing policy-violation response.
+
+### Dedicated Image Endpoints
+
+When global image generation is disabled, dedicated image endpoints remain
+blocked regardless of group settings:
+
+- `/v1/images/generations`
+- `/v1/images/edits`
+- equivalent unversioned image routes
+- Grok media generation routes
+
+These endpoints return HTTP 403 with the existing stable permission message.
+
+### Existing Account Policy
+
+The account-level `strip` policy remains supported. With the global setting
+enabled it is redundant for `/responses`, because stripping occurs before
+account selection. With the global setting disabled, account policy behavior is
+unchanged.
+
+## Code Structure
+
+- `backend/internal/config/config.go`: define and default the global setting.
+- `backend/internal/service/openai_codex_transform.go`: export a small wrapper
+  around the existing raw-payload stripping implementation so handlers can use
+  one canonical parser and mutation path.
+- `backend/internal/handler/openai_gateway_handler.go`: normalize HTTP and
+  WebSocket payloads before the early image gate and propagate the normalized
+  body/message through the rest of each request.
+- Dedicated image handlers: add the global check without changing the existing
+  group check or response contract.
+- `deploy/.env.example` and Compose examples: document and pass through
+  `DISABLE_IMAGE_GENERATION`, defaulting to `false`.
+
+No database migration is required.
+
+## Error Handling And Observability
+
+- Invalid JSON remains a 400 and is never silently rewritten.
+- A stripping failure returns the existing invalid-request error path rather
+  than forwarding an unverified payload.
+- Log one structured event when a payload is changed, without logging request
+  contents.
+- Do not log when no image declaration is present.
+- Image-only and dedicated endpoint rejections retain the stable message
+  `Image generation is not enabled for this group` for client compatibility.
+
+## Tests
+
+Use test-first development and cover:
+
+1. Configuration defaults to disabled=false and reads
+   `DISABLE_IMAGE_GENERATION=true`.
+2. HTTP `/responses` with a text model and image declarations is normalized and
+   passes the early group gate when the group disallows images.
+3. HTTP normalization preserves non-image tools and unrelated fields.
+4. HTTP `/responses` with an image-only model still returns 403.
+5. WebSocket first and subsequent messages receive equivalent normalization.
+6. Dedicated OpenAI and Grok image endpoints return 403 when the global switch
+   is enabled, even if the group allows images.
+7. With the switch disabled, existing behavior and account-level policy tests
+   remain unchanged.
+
+Run focused handler, service, and config tests first, followed by the complete
+backend Go test suite.
+
+## Deployment And Rollback
+
+Build a versioned custom image from v0.1.151 plus this patch. Do not overwrite
+the upstream `latest` tag. Update production Compose to the immutable custom
+tag and add `DISABLE_IMAGE_GENERATION=true`, then recreate only the Sub2API
+application service.
+
+Before deployment, record the current upstream image digest and preserve the
+existing Compose file. Verify container health, ordinary `/responses` behavior,
+image-only rejection, dedicated endpoint rejection, and absence of new startup
+errors.
+
+Rollback consists of restoring the previous immutable image digest, removing
+the environment setting, and recreating only the application service. Database,
+Redis, and account policy data are unchanged by the deployment.


### PR DESCRIPTION
## What changed

- add a top-level `DISABLE_IMAGE_GENERATION` configuration flag with a backward-compatible `false` default
- strip image-generation tools, namespaces, additional tools, and image tool choices from text-capable `/responses` requests before the group permission gate
- apply the same normalization to WebSocket first frames and follow-up `response.create` frames
- prevent Codex image bridge logic from re-injecting image tools while the global switch is enabled
- keep image-only models and dedicated OpenAI/Grok generation endpoints fail-closed
- expose the flag in the standard and standalone Docker Compose deployments

## Why

Account-level Codex image-tool policy runs after account selection, while the HTTP and WebSocket handlers reject image intent at the group permission gate first. As a result, a text request containing an image tool could return `403 Image generation is not enabled for this group` before the account policy had a chance to strip it.

The global ingress normalization moves that decision ahead of the permission gate. Text-capable requests continue without image declarations, while actual image-generation requests remain forbidden.

## Impact

When `DISABLE_IMAGE_GENERATION=true`:

- text-capable `/responses` requests continue after image declarations are removed
- HTTP and WebSocket behavior is consistent across all turns
- `gpt-image-*`, `/images/generations`, `/images/edits`, and Grok generation requests remain blocked
- existing behavior is unchanged when the flag is omitted or set to `false`

## Validation

- `go test ./internal/config ./internal/service ./internal/handler -count=1`
- `go test ./... -count=1`
- both Compose files render `DISABLE_IMAGE_GENERATION: "true"`
- production smoke test: a text `/responses` request with an image tool returned HTTP 200 and logged the global strip event
- production smoke test: `/images/generations` returned the expected HTTP 403 permission response
