### PR TITLE
fix(openai): support variable quota window usage stats

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -144,10 +144,11 @@ type WindowStats struct {
 
 // UsageProgress 使用量进度
 type UsageProgress struct {
-	Utilization      float64      `json:"utilization"`            // 使用率百分比 (0-100+，100表示100%)
-	ResetsAt         *time.Time   `json:"resets_at"`              // 重置时间
-	RemainingSeconds int          `json:"remaining_seconds"`      // 距重置剩余秒数
-	WindowStats      *WindowStats `json:"window_stats,omitempty"` // 窗口期统计（从窗口开始到当前的使用量）
+	Utilization      float64      `json:"utilization"`              // 使用率百分比 (0-100+，100表示100%)
+	ResetsAt         *time.Time   `json:"resets_at"`                // 重置时间
+	RemainingSeconds int          `json:"remaining_seconds"`        // 距重置剩余秒数
+	WindowMinutes    int          `json:"window_minutes,omitempty"` // 上游返回的真实窗口长度
+	WindowStats      *WindowStats `json:"window_stats,omitempty"`   // 窗口期统计（从窗口开始到当前的使用量）
 	UsedRequests     int64        `json:"used_requests,omitempty"`
 	LimitRequests    int64        `json:"limit_requests,omitempty"`
 }
@@ -604,18 +605,22 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
-		if usage.FiveHour == nil {
-			usage.FiveHour = &UsageProgress{Utilization: 0}
+	if !codexWindowExplicitlyUnavailable(account.Extra, "5h") {
+		if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
+			if usage.FiveHour == nil {
+				usage.FiveHour = &UsageProgress{Utilization: 0}
+			}
+			usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 		}
-		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.SevenDay, 7*24*time.Hour, now)); err == nil {
-		if usage.SevenDay == nil {
-			usage.SevenDay = &UsageProgress{Utilization: 0}
+	if !codexWindowExplicitlyUnavailable(account.Extra, "7d") {
+		if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.SevenDay, 7*24*time.Hour, now)); err == nil {
+			if usage.SevenDay == nil {
+				usage.SevenDay = &UsageProgress{Utilization: 0}
+			}
+			usage.SevenDay.WindowStats = windowStatsFromAccountStats(stats)
 		}
-		usage.SevenDay.WindowStats = windowStatsFromAccountStats(stats)
 	}
 
 	return usage, nil
@@ -1188,6 +1193,7 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 		usedPercentKey string
 		resetAfterKey  string
 		resetAtKey     string
+		windowMinsKey  string
 	)
 
 	switch window {
@@ -1195,10 +1201,12 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 		usedPercentKey = "codex_5h_used_percent"
 		resetAfterKey = "codex_5h_reset_after_seconds"
 		resetAtKey = "codex_5h_reset_at"
+		windowMinsKey = "codex_5h_window_minutes"
 	case "7d":
 		usedPercentKey = "codex_7d_used_percent"
 		resetAfterKey = "codex_7d_reset_after_seconds"
 		resetAtKey = "codex_7d_reset_at"
+		windowMinsKey = "codex_7d_window_minutes"
 	default:
 		return nil
 	}
@@ -1208,7 +1216,18 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 		return nil
 	}
 
-	progress := &UsageProgress{Utilization: parseExtraFloat64(usedRaw)}
+	windowMinutes := 0
+	if _, ok := extra[windowMinsKey]; ok {
+		windowMinutes = parseExtraInt(extra[windowMinsKey])
+		if windowMinutes <= 0 {
+			return nil
+		}
+	}
+
+	progress := &UsageProgress{
+		Utilization:   parseExtraFloat64(usedRaw),
+		WindowMinutes: windowMinutes,
+	}
 	if resetAtRaw, ok := extra[resetAtKey]; ok {
 		if resetAt, err := parseTime(fmt.Sprint(resetAtRaw)); err == nil {
 			progress.ResetsAt = &resetAt
@@ -1243,11 +1262,21 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	return progress
 }
 
+func codexWindowExplicitlyUnavailable(extra map[string]any, window string) bool {
+	key := "codex_" + window + "_window_minutes"
+	raw, ok := extra[key]
+	return ok && parseExtraInt(raw) <= 0
+}
+
 func codexWindowStatsStart(progress *UsageProgress, fallbackWindow time.Duration, now time.Time) time.Time {
-	if progress != nil && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
-		return progress.ResetsAt.Add(-fallbackWindow)
+	window := fallbackWindow
+	if progress != nil && progress.WindowMinutes > 0 {
+		window = time.Duration(progress.WindowMinutes) * time.Minute
 	}
-	return now.Add(-fallbackWindow)
+	if progress != nil && progress.ResetsAt != nil && now.Before(*progress.ResetsAt) {
+		return progress.ResetsAt.Add(-window)
+	}
+	return now.Add(-window)
 }
 
 func (s *AccountUsageService) GetAccountUsageStats(ctx context.Context, accountID int64, startTime, endTime time.Time) (*usagestats.AccountUsageStatsResponse, error) {

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -256,3 +256,38 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildCodexUsageProgressFromExtra_UsesRealWindowLength(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 12, 13, 0, 0, 0, time.FixedZone("CST", 8*60*60))
+
+	t.Run("zero minute placeholder is unavailable", func(t *testing.T) {
+		progress := buildCodexUsageProgressFromExtra(map[string]any{
+			"codex_5h_used_percent":   0,
+			"codex_5h_window_minutes": 0,
+			"codex_5h_reset_at":       now.Format(time.RFC3339),
+		}, "5h", now)
+		if progress != nil {
+			t.Fatalf("expected zero-minute placeholder to be ignored, got %#v", progress)
+		}
+	})
+
+	t.Run("30 day window controls stats start", func(t *testing.T) {
+		resetAt := time.Date(2026, 8, 11, 9, 5, 0, 0, now.Location())
+		progress := buildCodexUsageProgressFromExtra(map[string]any{
+			"codex_7d_used_percent":   88,
+			"codex_7d_window_minutes": 43800,
+			"codex_7d_reset_at":       resetAt.Format(time.RFC3339),
+		}, "7d", now)
+		if progress == nil {
+			t.Fatal("expected 30-day progress")
+		}
+		if progress.WindowMinutes != 43800 {
+			t.Fatalf("WindowMinutes = %d, want 43800", progress.WindowMinutes)
+		}
+		wantStart := resetAt.Add(-43800 * time.Minute)
+		if got := codexWindowStatsStart(progress, 7*24*time.Hour, now); !got.Equal(wantStart) {
+			t.Fatalf("stats start = %v, want %v", got, wantStart)
+		}
+	})
+}

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -123,7 +123,7 @@
       <div v-if="hasOpenAIUsageFallback" class="space-y-1">
         <UsageProgressBar
           v-if="usageInfo?.five_hour"
-          label="5h"
+          :label="formatOpenAIWindowLabel(usageInfo.five_hour.window_minutes, '5h')"
           :utilization="usageInfo.five_hour.utilization"
           :resets-at="usageInfo.five_hour.resets_at"
           :window-stats="usageInfo.five_hour.window_stats"
@@ -132,7 +132,7 @@
         />
         <UsageProgressBar
           v-if="usageInfo?.seven_day"
-          label="7d"
+          :label="formatOpenAIWindowLabel(usageInfo.seven_day.window_minutes, '7d')"
           :utilization="usageInfo.seven_day.utilization"
           :resets-at="usageInfo.seven_day.resets_at"
           :window-stats="usageInfo.seven_day.window_stats"
@@ -694,6 +694,14 @@ const hasOpenAIUsageFallback = computed(() => {
   if (props.account.platform !== 'openai' || props.account.type !== 'oauth') return false
   return !!usageInfo.value?.five_hour || !!usageInfo.value?.seven_day
 })
+
+const formatOpenAIWindowLabel = (windowMinutes: number | undefined, fallback: string): string => {
+  if (!windowMinutes || windowMinutes <= 0) return fallback
+  if (windowMinutes < 24 * 60) {
+    return `${Math.round(windowMinutes / 60)}h`
+  }
+  return `${Math.round(windowMinutes / (24 * 60))}d`
+}
 
 const openAIUsageRefreshKey = computed(() => buildOpenAIUsageRefreshKey(props.account))
 

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -273,6 +273,44 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).toContain('7d|36|900')
   })
 
+  it('OpenAI OAuth 仅返回 30d 窗口时不显示 5h 并显示累计数据', async () => {
+    getUsage.mockResolvedValue({
+      seven_day: {
+        utilization: 88,
+        resets_at: '2026-08-11T01:05:00Z',
+        remaining_seconds: 2_576_774,
+        window_minutes: 43_800,
+        window_stats: {
+          requests: 1553,
+          tokens: 123456,
+          cost: 215.72,
+          standard_cost: 215.72,
+          user_cost: 36.31
+        }
+      }
+    })
+
+    const wrapper = mount(AccountUsageCell, {
+      props: {
+        account: makeAccount({ id: 3438, platform: 'openai', type: 'oauth', extra: {} })
+      },
+      global: {
+        stubs: {
+          UsageProgressBar: {
+            props: ['label', 'utilization', 'windowStats'],
+            template: '<div class="usage-bar">{{ label }}|{{ utilization }}|{{ windowStats?.cost }}</div>'
+          },
+          AccountQuotaInfo: true
+        }
+      }
+    })
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('30d|88|215.72')
+    expect(wrapper.text()).not.toContain('5h|')
+  })
+
   it('OpenAI OAuth 有现成快照时，手动刷新信号会触发 usage 重拉', async () => {
     getUsage.mockResolvedValue({
       five_hour: {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1004,6 +1004,7 @@ export interface UsageProgress {
   utilization: number // Percentage (0-100+, 100 = 100%)
   resets_at: string | null
   remaining_seconds: number
+  window_minutes?: number // Upstream-reported window length
   window_stats?: WindowStats | null // 窗口期统计（从窗口开始到当前的使用量）
   used_requests?: number
   limit_requests?: number


### PR DESCRIPTION
## Summary

- preserve the upstream Codex window duration in account usage responses
- ignore explicit zero-minute placeholder windows instead of rendering a synthetic 5h window
- aggregate local request, token, and cost stats using the actual upstream window duration
- derive OpenAI quota labels from the real duration, including 30d windows, while retaining legacy fallbacks

## Tests

- `go test ./internal/service -run TestBuildCodexUsageProgressFromExtra -count=1`
- `pnpm test:run -- src/components/account/__tests__/AccountUsageCell.spec.ts`
- `NODE_OPTIONS=--max-old-space-size=1536 pnpm build`

## Compatibility

Accounts without `window_minutes` retain the existing 5h/7d fallback behavior.