### PR TITLE
fix(responses): emit AI-SDK-required fields in reconstructed non-stream /v1/responses output

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -45,10 +45,7 @@ func AnthropicToResponsesResponse(resp *AnthropicResponse) *ResponsesResponse {
 			}
 		case "text":
 			if block.Text != "" {
-				msgParts = append(msgParts, ResponsesContentPart{
-					Type: "output_text",
-					Text: block.Text,
-				})
+				msgParts = append(msgParts, outputTextPart(block.Text))
 			}
 		case "tool_use":
 			args := "{}"
@@ -82,7 +79,7 @@ func AnthropicToResponsesResponse(resp *AnthropicResponse) *ResponsesResponse {
 			Type:    "message",
 			ID:      generateItemID(),
 			Role:    "assistant",
-			Content: []ResponsesContentPart{{Type: "output_text", Text: ""}},
+			Content: []ResponsesContentPart{outputTextPart("")},
 			Status:  "completed",
 		})
 	}
@@ -535,13 +532,17 @@ func makeResponsesEvent(state *AnthropicEventToResponsesState, eventType string,
 }
 
 func generateResponsesID() string {
-	b := make([]byte, 12)
-	_, _ = rand.Read(b)
-	return "resp_" + hex.EncodeToString(b)
+	return generatePrefixedID("resp_")
 }
 
 func generateItemID() string {
+	return generatePrefixedID("item_")
+}
+
+// generatePrefixedID returns prefix + 24 hex chars of randomness, matching
+// the id shapes used by the Responses API (e.g. msg_, rs_, fc_, resp_).
+func generatePrefixedID(prefix string) string {
 	b := make([]byte, 12)
 	_, _ = rand.Read(b)
-	return "item_" + hex.EncodeToString(b)
+	return prefix + hex.EncodeToString(b)
 }

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -848,14 +848,11 @@ func chatMessageToResponsesOutput(message ChatMessage, customTools map[string]bo
 	}
 	if text != "" || len(message.ToolCalls) == 0 {
 		outputs = append(outputs, ResponsesOutput{
-			Type: "message",
-			ID:   generateItemID(),
-			Role: "assistant",
-			Content: []ResponsesContentPart{{
-				Type: "output_text",
-				Text: text,
-			}},
-			Status: "completed",
+			Type:    "message",
+			ID:      generateItemID(),
+			Role:    "assistant",
+			Content: []ResponsesContentPart{outputTextPart(text)},
+			Status:  "completed",
 		})
 	}
 
@@ -930,7 +927,7 @@ func emptyResponsesMessageOutput() ResponsesOutput {
 		Type:    "message",
 		ID:      generateItemID(),
 		Role:    "assistant",
-		Content: []ResponsesContentPart{{Type: "output_text", Text: ""}},
+		Content: []ResponsesContentPart{outputTextPart("")},
 		Status:  "completed",
 	}
 }
@@ -1564,14 +1561,11 @@ func (state *ChatCompletionsToResponsesStreamState) chatOutput() []ResponsesOutp
 	}
 	if state.MessageItemID != "" || len(state.ToolCalls) == 0 {
 		outputs = append(outputs, ResponsesOutput{
-			Type: "message",
-			ID:   nonEmpty(state.MessageItemID, generateItemID()),
-			Role: "assistant",
-			Content: []ResponsesContentPart{{
-				Type: "output_text",
-				Text: state.Text.String(),
-			}},
-			Status: "completed",
+			Type:    "message",
+			ID:      nonEmpty(state.MessageItemID, generateItemID()),
+			Role:    "assistant",
+			Content: []ResponsesContentPart{outputTextPart(state.Text.String())},
+			Status:  "completed",
 		})
 	}
 	for i := 0; i < len(state.ToolCalls); i++ {

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_test.go
@@ -1671,3 +1671,132 @@ func TestBufferedResponseAccumulator_IgnoresNonFunctionCallItems(t *testing.T) {
 
 	assert.False(t, acc.HasContent())
 }
+
+// assertOutputItemsMeetAISDKRequiredFields checks the field set that the
+// @ai-sdk/openai non-streaming responses zod schema requires on output items:
+// - every item has a non-empty id
+// - message items have role=assistant and every output_text part carries a
+//   text string plus an annotations array (even when empty)
+// - reasoning items have a summary array
+// - function_call items have call_id, name and arguments
+func assertOutputItemsMeetAISDKRequiredFields(t *testing.T, output []ResponsesOutput) {
+	t.Helper()
+	raw, err := json.Marshal(output)
+	require.NoError(t, err)
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal(raw, &items))
+
+	for i, item := range items {
+		id, _ := item["id"].(string)
+		assert.NotEmpty(t, id, "output[%d].id must be non-empty", i)
+
+		switch item["type"] {
+		case "message":
+			assert.Equal(t, "assistant", item["role"], "output[%d].role", i)
+			parts, ok := item["content"].([]any)
+			require.True(t, ok, "output[%d].content must be an array", i)
+			for j, p := range parts {
+				part, ok := p.(map[string]any)
+				require.True(t, ok)
+				assert.Equal(t, "output_text", part["type"], "output[%d].content[%d].type", i, j)
+				_, hasText := part["text"].(string)
+				assert.True(t, hasText, "output[%d].content[%d].text must be a string", i, j)
+				annotations, hasAnnotations := part["annotations"].([]any)
+				assert.True(t, hasAnnotations, "output[%d].content[%d].annotations must be present and an array", i, j)
+				assert.NotNil(t, annotations)
+			}
+		case "reasoning":
+			_, hasSummary := item["summary"].([]any)
+			assert.True(t, hasSummary, "output[%d].summary must be an array", i)
+		case "function_call":
+			assert.NotEmpty(t, item["call_id"], "output[%d].call_id", i)
+			assert.NotEmpty(t, item["name"], "output[%d].name", i)
+			_, hasArgs := item["arguments"].(string)
+			assert.True(t, hasArgs, "output[%d].arguments must be a string", i)
+		}
+	}
+}
+
+func TestBufferedResponseAccumulator_BuildOutputMeetsAISDKRequiredFields(t *testing.T) {
+	acc := NewBufferedResponseAccumulator()
+
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.reasoning_summary_text.delta", Delta: "thinking"})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.output_text.delta", Delta: "Hello"})
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 2,
+		Item:        &ResponsesOutput{Type: "function_call", CallID: "call_1", Name: "verify"},
+	})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.function_call_arguments.delta", OutputIndex: 2, Delta: "{}"})
+
+	output := acc.BuildOutput()
+	require.Len(t, output, 3)
+	assertOutputItemsMeetAISDKRequiredFields(t, output)
+
+	// Generated ids use Responses API prefixes when the stream carried none.
+	assert.Regexp(t, `^rs_[0-9a-f]{24}$`, output[0].ID)
+	assert.Regexp(t, `^msg_[0-9a-f]{24}$`, output[1].ID)
+	assert.Regexp(t, `^fc_[0-9a-f]{24}$`, output[2].ID)
+	assert.Equal(t, "completed", output[1].Status)
+	assert.Equal(t, "completed", output[2].Status)
+
+	// output_text part serializes an explicit empty annotations array.
+	raw, err := json.Marshal(output[1])
+	require.NoError(t, err)
+	assert.Contains(t, string(raw), `"annotations":[]`)
+}
+
+func TestBufferedResponseAccumulator_PreservesUpstreamItemIDs(t *testing.T) {
+	acc := NewBufferedResponseAccumulator()
+
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type: "response.output_item.added",
+		Item: &ResponsesOutput{Type: "reasoning", ID: "rs_upstream"},
+	})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.reasoning_summary_text.delta", Delta: "why", ItemID: "rs_upstream"})
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 1,
+		Item:        &ResponsesOutput{Type: "message", ID: "msg_upstream"},
+	})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.output_text.delta", Delta: "Hi", ItemID: "msg_upstream"})
+	acc.ProcessEvent(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 2,
+		Item:        &ResponsesOutput{Type: "function_call", ID: "fc_upstream", CallID: "call_9", Name: "run"},
+	})
+	acc.ProcessEvent(&ResponsesStreamEvent{Type: "response.function_call_arguments.delta", OutputIndex: 2, Delta: "{}"})
+
+	output := acc.BuildOutput()
+	require.Len(t, output, 3)
+	assert.Equal(t, "rs_upstream", output[0].ID)
+	assert.Equal(t, "msg_upstream", output[1].ID)
+	assert.Equal(t, "fc_upstream", output[2].ID)
+}
+
+func TestChatCompletionsResponseToResponses_OutputMeetsAISDKRequiredFields(t *testing.T) {
+	resp := &ChatCompletionsResponse{
+		ID:    "chatcmpl-1",
+		Model: "gpt-4o",
+		Choices: []ChatChoice{{
+			Message: ChatMessage{
+				Role:             "assistant",
+				Content:          json.RawMessage(`"Hello"`),
+				ReasoningContent: "step",
+				ToolCalls: []ChatToolCall{{
+					ID:   "call_1",
+					Type: "function",
+					Function: ChatFunctionCall{
+						Name:      "verify",
+						Arguments: `{"x":1}`,
+					},
+				}},
+			},
+			FinishReason: "stop",
+		}},
+	}
+
+	out := ChatCompletionsResponseToResponses(resp, "gpt-4o", nil, false, nil)
+	require.NotEmpty(t, out.Output)
+	assertOutputItemsMeetAISDKRequiredFields(t, out.Output)
+}

--- a/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
+++ b/backend/internal/pkg/apicompat/responses_to_chatcompletions.go
@@ -431,6 +431,7 @@ func generateChatCmplID() string {
 // ---------------------------------------------------------------------------
 
 type bufferedFuncCall struct {
+	ItemID string
 	CallID string
 	Name   string
 	Args   strings.Builder
@@ -441,7 +442,9 @@ type bufferedFuncCall struct {
 // (response.completed / response.done) carries an empty output array.
 type BufferedResponseAccumulator struct {
 	text                 strings.Builder
+	textItemID           string
 	reasoning            strings.Builder
+	reasoningItemID      string
 	funcCalls            []bufferedFuncCall
 	outputIndexToFuncIdx map[int]int
 }
@@ -462,14 +465,30 @@ func (a *BufferedResponseAccumulator) ProcessEvent(event *ResponsesStreamEvent) 
 		if event.Delta != "" {
 			_, _ = a.text.WriteString(event.Delta)
 		}
+		if a.textItemID == "" && event.ItemID != "" {
+			a.textItemID = event.ItemID
+		}
 	case "response.output_item.added":
-		if event.Item != nil && (event.Item.Type == "function_call" || event.Item.Type == "custom_tool_call") {
+		if event.Item == nil {
+			return
+		}
+		switch event.Item.Type {
+		case "function_call", "custom_tool_call":
 			idx := len(a.funcCalls)
 			a.outputIndexToFuncIdx[event.OutputIndex] = idx
 			a.funcCalls = append(a.funcCalls, bufferedFuncCall{
+				ItemID: event.Item.ID,
 				CallID: event.Item.CallID,
 				Name:   event.Item.Name,
 			})
+		case "message":
+			if a.textItemID == "" && event.Item.ID != "" {
+				a.textItemID = event.Item.ID
+			}
+		case "reasoning":
+			if a.reasoningItemID == "" && event.Item.ID != "" {
+				a.reasoningItemID = event.Item.ID
+			}
 		}
 	case "response.function_call_arguments.delta", "response.custom_tool_call_input.delta":
 		if event.Delta != "" {
@@ -480,6 +499,9 @@ func (a *BufferedResponseAccumulator) ProcessEvent(event *ResponsesStreamEvent) 
 	case "response.reasoning_summary_text.delta", "response.reasoning_text.delta":
 		if event.Delta != "" {
 			_, _ = a.reasoning.WriteString(event.Delta)
+		}
+		if a.reasoningItemID == "" && event.ItemID != "" {
+			a.reasoningItemID = event.ItemID
 		}
 	}
 }
@@ -492,12 +514,18 @@ func (a *BufferedResponseAccumulator) HasContent() bool {
 // BuildOutput constructs a []ResponsesOutput from the accumulated delta
 // content. The order matches what ResponsesToChatCompletions expects:
 // reasoning → message → function_calls.
+//
+// Every item carries an id (the upstream item id when the stream provided
+// one, otherwise a generated one) and output_text parts carry an empty
+// annotations array: strict Responses API clients (e.g. @ai-sdk/openai)
+// reject non-streaming responses that miss either field.
 func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 	var out []ResponsesOutput
 
 	if a.reasoning.Len() > 0 {
 		out = append(out, ResponsesOutput{
 			Type: "reasoning",
+			ID:   nonEmptyID(a.reasoningItemID, "rs_"),
 			Summary: []ResponsesSummary{{
 				Type: "summary_text",
 				Text: a.reasoning.String(),
@@ -507,18 +535,19 @@ func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 
 	if a.text.Len() > 0 {
 		out = append(out, ResponsesOutput{
-			Type: "message",
-			Role: "assistant",
-			Content: []ResponsesContentPart{{
-				Type: "output_text",
-				Text: a.text.String(),
-			}},
+			Type:    "message",
+			ID:      nonEmptyID(a.textItemID, "msg_"),
+			Role:    "assistant",
+			Status:  "completed",
+			Content: []ResponsesContentPart{outputTextPart(a.text.String())},
 		})
 	}
 
 	for i := range a.funcCalls {
 		out = append(out, ResponsesOutput{
 			Type:      "function_call",
+			ID:        nonEmptyID(a.funcCalls[i].ItemID, "fc_"),
+			Status:    "completed",
 			CallID:    a.funcCalls[i].CallID,
 			Name:      a.funcCalls[i].Name,
 			Arguments: a.funcCalls[i].Args.String(),
@@ -526,6 +555,15 @@ func (a *BufferedResponseAccumulator) BuildOutput() []ResponsesOutput {
 	}
 
 	return out
+}
+
+// nonEmptyID returns id when set, otherwise a freshly generated id with the
+// given Responses API item prefix.
+func nonEmptyID(id, prefix string) string {
+	if id != "" {
+		return id
+	}
+	return generatePrefixedID(prefix)
 }
 
 // SupplementResponseOutput fills resp.Output from accumulated delta content

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -245,6 +245,24 @@ type ResponsesContentPart struct {
 	Type     string `json:"type"` // "input_text" | "output_text" | "input_image"
 	Text     string `json:"text,omitempty"`
 	ImageURL string `json:"image_url,omitempty"` // data URI for input_image
+
+	// Annotations must be present (even as an empty array) on output_text
+	// parts: strict Responses API clients such as @ai-sdk/openai validate
+	// non-streaming responses with a schema that requires it. It is kept as
+	// raw JSON with omitempty so request-side parts (input_text/input_image)
+	// are unaffected.
+	Annotations json.RawMessage `json:"annotations,omitempty"`
+}
+
+// outputTextPart builds an output_text content part with the annotations
+// array initialised, as required on every output_text part by strict
+// Responses API clients (e.g. the @ai-sdk/openai zod schema).
+func outputTextPart(text string) ResponsesContentPart {
+	return ResponsesContentPart{
+		Type:        "output_text",
+		Text:        text,
+		Annotations: json.RawMessage(`[]`),
+	}
 }
 
 // ResponsesTool describes a tool in the Responses API.

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -3155,3 +3155,113 @@ func TestHandleCompatErrorResponseCyberPolicyEarlyReturn(t *testing.T) {
 	require.NotContains(t, gotMsg, "Upstream request failed")
 	require.NotNil(t, GetOpsCyberPolicy(c))
 }
+
+// TestHandleSSEToJSON_ReconstructedOutputMeetsAISDKRequiredFields replays the
+// production failure behind the Eve/@ai-sdk/openai incident: a non-streaming
+// /v1/responses call is forced to stream upstream by the Codex OAuth
+// transform, the terminal response.completed event carries an empty output
+// array, and the reconstructed JSON previously missed output item ids and the
+// annotations array that @ai-sdk/openai's zod schema requires — making the
+// SDK reject the response with "Invalid JSON response".
+func TestHandleSSEToJSON_ReconstructedOutputMeetsAISDKRequiredFields(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	body := []byte(strings.Join([]string{
+		`data: {"type":"response.created","response":{"id":"resp_ai_sdk"}}`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"id":"rs_up","type":"reasoning"}}`,
+		`data: {"type":"response.reasoning_summary_text.delta","item_id":"rs_up","delta":"think"}`,
+		`data: {"type":"response.output_item.added","output_index":1,"item":{"id":"msg_up","type":"message","role":"assistant"}}`,
+		`data: {"type":"response.output_text.delta","item_id":"msg_up","output_index":1,"delta":"Hello, "}`,
+		`data: {"type":"response.output_text.delta","item_id":"msg_up","output_index":1,"delta":"world!"}`,
+		`data: {"type":"response.output_item.added","output_index":2,"item":{"id":"fc_up","type":"function_call","call_id":"call_7","name":"lookup"}}`,
+		`data: {"type":"response.function_call_arguments.delta","output_index":2,"delta":"{\"q\":1}"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_ai_sdk","object":"response","created_at":1752300000,"status":"completed","model":"gpt-5.5","output":[],"usage":{"input_tokens":11,"output_tokens":5}}}`,
+		`data: [DONE]`,
+	}, "\n"))
+
+	usage, err := svc.handleSSEToJSON(resp, c, body, "gpt-5.5", "gpt-5.5")
+	require.NoError(t, err)
+	require.NotNil(t, usage)
+
+	got := rec.Body.String()
+	require.NotContains(t, got, "data:")
+
+	// Response-level required fields survive from the terminal event.
+	require.Equal(t, "resp_ai_sdk", gjson.Get(got, "id").String())
+	require.Equal(t, "gpt-5.5", gjson.Get(got, "model").String())
+	require.EqualValues(t, 1752300000, gjson.Get(got, "created_at").Int())
+	require.True(t, gjson.Get(got, "usage.input_tokens").Exists())
+	require.True(t, gjson.Get(got, "usage.output_tokens").Exists())
+
+	// AI SDK required fields: every output item carries a non-empty id.
+	outputs := gjson.Get(got, "output").Array()
+	require.Len(t, outputs, 3)
+	for i, item := range outputs {
+		require.NotEmpty(t, item.Get("id").String(), "output[%d].id must be non-empty", i)
+	}
+
+	// reasoning item: upstream id preserved, summary array present.
+	require.Equal(t, "reasoning", outputs[0].Get("type").String())
+	require.Equal(t, "rs_up", outputs[0].Get("id").String())
+	require.True(t, outputs[0].Get("summary").IsArray())
+
+	// message item: upstream id preserved, role/status set, output_text part
+	// carries text plus an annotations array (empty but present).
+	require.Equal(t, "message", outputs[1].Get("type").String())
+	require.Equal(t, "msg_up", outputs[1].Get("id").String())
+	require.Equal(t, "assistant", outputs[1].Get("role").String())
+	require.Equal(t, "completed", outputs[1].Get("status").String())
+	part := outputs[1].Get("content.0")
+	require.Equal(t, "output_text", part.Get("type").String())
+	require.Equal(t, "Hello, world!", part.Get("text").String())
+	annotations := part.Get("annotations")
+	require.True(t, annotations.Exists(), "content[0].annotations must exist")
+	require.True(t, annotations.IsArray(), "content[0].annotations must be an array")
+	require.Len(t, annotations.Array(), 0)
+
+	// function_call item: upstream id preserved plus call_id/name/arguments.
+	require.Equal(t, "function_call", outputs[2].Get("type").String())
+	require.Equal(t, "fc_up", outputs[2].Get("id").String())
+	require.Equal(t, "call_7", outputs[2].Get("call_id").String())
+	require.Equal(t, "lookup", outputs[2].Get("name").String())
+	require.Equal(t, `{"q":1}`, outputs[2].Get("arguments").String())
+}
+
+// TestHandleSSEToJSON_ReconstructedOutputGeneratesMissingItemIDs covers the
+// degenerate stream where delta events never carried item ids: the proxy must
+// still emit non-empty generated ids so strict clients accept the response.
+func TestHandleSSEToJSON_ReconstructedOutputGeneratesMissingItemIDs(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+	}
+	body := []byte(strings.Join([]string{
+		`data: {"type":"response.output_text.delta","delta":"plain text"}`,
+		`data: {"type":"response.completed","response":{"id":"resp_gen","model":"gpt-5.5","output":[],"usage":{"input_tokens":1,"output_tokens":2}}}`,
+		`data: [DONE]`,
+	}, "\n"))
+
+	_, err := svc.handleSSEToJSON(resp, c, body, "gpt-5.5", "gpt-5.5")
+	require.NoError(t, err)
+
+	got := rec.Body.String()
+	msg := gjson.Get(got, "output.0")
+	require.Equal(t, "message", msg.Get("type").String())
+	require.Regexp(t, `^msg_[0-9a-f]{24}$`, msg.Get("id").String())
+	require.True(t, msg.Get("content.0.annotations").IsArray())
+	require.Equal(t, "plain text", msg.Get("content.0.text").String())
+}


### PR DESCRIPTION
## Problem

When a non-streaming `/v1/responses` request is relayed through the Codex OAuth transform (which forces `stream=true` upstream), the JSON response is reassembled from SSE by `handleSSEToJSON`. When the terminal `response.completed` event carries an empty `output` array, the reconstruction falls back to `BufferedResponseAccumulator.BuildOutput()`, which emitted output items **without `id`** and `output_text` parts **without `annotations`**.

Strict OpenAI SDK clients reject this shape. `@ai-sdk/openai` validates non-stream `/v1/responses` bodies with a zod schema that requires `output[*].id` and `content[*].annotations`; the missing fields surface as a misleading `Invalid JSON response` error and the client retries into the same failure. We hit this in production with an agent runtime built on the AI SDK: a large-context turn received a non-streamed body and died after 3 identical retries.

## Fix

Applied on the shared `apicompat` conversion paths (no model-specific special-casing):

- `BufferedResponseAccumulator` now captures upstream item ids from `response.output_item.added` (message / reasoning / function_call / custom_tool_call) and from delta events' `item_id`; `BuildOutput()` emits `id` for all three item kinds (upstream id preferred, `msg_`/`rs_`/`fc_` + 24-hex generated as fallback), `status: "completed"` for message/function_call, and `output_text` parts with an `annotations: []` array via a shared helper.
- `ResponsesContentPart` gains an `annotations` field (`omitempty`, request-side input parts unaffected).
- The Anthropic→Responses and ChatCompletions→Responses bridges use the same helper so their `output_text` parts also carry `annotations`.

## Tests

- `TestHandleSSEToJSON_ReconstructedOutputMeetsAISDKRequiredFields` replays the production SSE shape end-to-end and asserts every field the AI SDK schema requires.
- `TestHandleSSEToJSON_ReconstructedOutputGeneratesMissingItemIDs`, `TestBufferedResponseAccumulator_BuildOutputMeetsAISDKRequiredFields`, `_PreservesUpstreamItemIDs`, `TestChatCompletionsResponseToResponses_OutputMeetsAISDKRequiredFields`.
- `go build ./...` and `go test ./internal/pkg/apicompat/... ./internal/service/...` pass; no regressions in existing suites.

## Production verification

Deployed on our own instance (v0.1.149 + this change cherry-picked):

- Before: `output[0].id = null`, no `status`, no `annotations` → AI SDK rejects.
- After: `output[0].id = "msg_…"` (upstream id preserved), `status: "completed"`, `annotations: []` → AI SDK accepts; streaming path unchanged (full SSE event sequence verified live).