### PR TITLE
fix(web): 为嵌入式前端静态资源设置长期 Cache-Control

### DIFF
--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -109,7 +109,8 @@ func (s *FrontendServer) Middleware() gin.HandlerFunc {
 			return
 		}
 
-		// Serve static files normally
+		// Serve static files normally (hashed assets get long-lived cache headers)
+		applyStaticAssetCacheHeaders(c.Writer.Header(), cleanPath)
 		s.fileServer.ServeHTTP(c.Writer, c.Request)
 		c.Abort()
 	}
@@ -135,6 +136,7 @@ func (s *FrontendServer) tryServeOverride(c *gin.Context, cleanPath string) bool
 	if err != nil || info.IsDir() {
 		return false
 	}
+	applyStaticAssetCacheHeaders(c.Writer.Header(), cleanPath)
 	c.File(filePath)
 	c.Abort()
 	return true
@@ -273,6 +275,7 @@ func ServeEmbeddedFrontend() gin.HandlerFunc {
 			if tryServeOverrideFile(c, overrideDir, cleanPath) {
 				return
 			}
+			applyStaticAssetCacheHeaders(c.Writer.Header(), cleanPath)
 			fileServer.ServeHTTP(c.Writer, c.Request)
 			c.Abort()
 			return
@@ -292,6 +295,7 @@ func tryServeOverrideFile(c *gin.Context, overrideDir, cleanPath string) bool {
 	if err != nil || info.IsDir() {
 		return false
 	}
+	applyStaticAssetCacheHeaders(c.Writer.Header(), cleanPath)
 	c.File(filePath)
 	c.Abort()
 	return true

--- a/backend/internal/web/static_cache.go
+++ b/backend/internal/web/static_cache.go
@@ -1,0 +1,31 @@
+//go:build embed || unit
+
+package web
+
+import (
+	"net/http"
+	"strings"
+)
+
+// staticAssetsCacheControl matches deploy/Caddyfile for hashed frontend assets.
+// Vite emits content-hashed filenames under assets/, so long-lived immutable
+// caching is safe without relying on a reverse proxy.
+const staticAssetsCacheControl = "public, max-age=31536000, immutable"
+
+// isLongCacheStaticPath reports whether a cleaned URL path (no leading slash)
+// should receive long-lived Cache-Control headers. Aligned with deploy/Caddyfile.
+func isLongCacheStaticPath(cleanPath string) bool {
+	cleanPath = strings.TrimPrefix(cleanPath, "/")
+	return strings.HasPrefix(cleanPath, "assets/") ||
+		cleanPath == "logo.png" ||
+		cleanPath == "favicon.ico"
+}
+
+// applyStaticAssetCacheHeaders sets Cache-Control for long-cacheable static paths.
+// index.html / SPA routes must keep no-cache and are not handled here.
+func applyStaticAssetCacheHeaders(header http.Header, cleanPath string) {
+	if header == nil || !isLongCacheStaticPath(cleanPath) {
+		return
+	}
+	header.Set("Cache-Control", staticAssetsCacheControl)
+}

--- a/backend/internal/web/static_cache_test.go
+++ b/backend/internal/web/static_cache_test.go
@@ -1,0 +1,71 @@
+//go:build unit
+
+package web
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLongCacheStaticPath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{name: "hashed_js", path: "assets/index-abc123.js", want: true},
+		{name: "hashed_css", path: "assets/app-def456.css", want: true},
+		{name: "nested_asset", path: "assets/vendor/chunk.js", want: true},
+		{name: "leading_slash_asset", path: "/assets/index.js", want: true},
+		{name: "logo", path: "logo.png", want: true},
+		{name: "favicon", path: "favicon.ico", want: true},
+		{name: "index_html", path: "index.html", want: false},
+		{name: "spa_route", path: "dashboard", want: false},
+		{name: "assets_prefix_only", path: "assets", want: false},
+		{name: "similar_name", path: "assets-backup/x.js", want: false},
+		{name: "empty", path: "", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isLongCacheStaticPath(tc.path))
+		})
+	}
+}
+
+func TestApplyStaticAssetCacheHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets_immutable_cache_for_assets", func(t *testing.T) {
+		t.Parallel()
+		header := make(http.Header)
+		applyStaticAssetCacheHeaders(header, "assets/index-abc.js")
+		assert.Equal(t, staticAssetsCacheControl, header.Get("Cache-Control"))
+	})
+
+	t.Run("sets_immutable_cache_for_logo", func(t *testing.T) {
+		t.Parallel()
+		header := make(http.Header)
+		applyStaticAssetCacheHeaders(header, "logo.png")
+		assert.Equal(t, staticAssetsCacheControl, header.Get("Cache-Control"))
+	})
+
+	t.Run("skips_index_html", func(t *testing.T) {
+		t.Parallel()
+		header := make(http.Header)
+		applyStaticAssetCacheHeaders(header, "index.html")
+		assert.Empty(t, header.Get("Cache-Control"))
+	})
+
+	t.Run("nil_header_is_noop", func(t *testing.T) {
+		t.Parallel()
+		assert.NotPanics(t, func() {
+			applyStaticAssetCacheHeaders(nil, "assets/x.js")
+		})
+	})
+}


### PR DESCRIPTION
## Summary
- 修复直连 Go/Docker 部署时，Vite 带 hash 的 `/assets/*`（及与 `deploy/Caddyfile` 对齐的 `logo.png` / `favicon.ico`）缺少 `Cache-Control`，导致控制台静态资源无法长期缓存、重复全量下载的问题（#4129）
- 在 `embed_on.go` 静态文件响应路径设置 `Cache-Control: public, max-age=31536000, immutable`；`index.html` / SPA 回退仍保持 `no-cache` + ETag
- 与现有 Caddy 反代方案同向兼容：已在反代设置相同头时行为不变；未配置反代时 Origin 即可生效

## Test plan
- [x] `cd backend && go test -tags=unit ./internal/web/`
- [ ] 直连嵌入式前端：请求 `/assets/*.js` 响应头含 `Cache-Control: public, max-age=31536000, immutable`
- [ ] 请求 `/` 或 SPA 路由：仍为 `Cache-Control: no-cache`，且设置注入 / CSP nonce 正常
- [ ] 经官方 `deploy/Caddyfile` 反代部署：行为与改前一致（头同向或由反代覆盖）

Closes #4129