### PR TITLE
fix(apicompat): Read 工具参数实时流式发送，不再依赖 .done 事件

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -718,7 +718,7 @@ func TestStreamingToolCallDoneWithoutDeltaEmitsArguments(t *testing.T) {
 	assert.Equal(t, "content_block_stop", events[1].Type)
 }
 
-func TestStreamingReadToolDropsEmptyPages(t *testing.T) {
+func TestStreamingReadToolStreamsDeltas(t *testing.T) {
 	state := NewResponsesEventToAnthropicState()
 
 	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
@@ -739,18 +739,17 @@ func TestStreamingReadToolDropsEmptyPages(t *testing.T) {
 		OutputIndex: 0,
 		Delta:       `{"file_path":"/tmp/demo.py","limit":2000,"offset":0,"pages":""}`,
 	}, state)
-	assert.Len(t, events, 0)
+	require.Len(t, events, 1, "Read tool deltas must be streamed like any other tool")
+	assert.Equal(t, "content_block_delta", events[0].Type)
+	assert.Equal(t, "input_json_delta", events[0].Delta.Type)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.function_call_arguments.done",
 		OutputIndex: 0,
 		Arguments:   `{"file_path":"/tmp/demo.py","limit":2000,"offset":0,"pages":""}`,
 	}, state)
-	require.Len(t, events, 2)
-	assert.Equal(t, "content_block_delta", events[0].Type)
-	assert.Equal(t, "input_json_delta", events[0].Delta.Type)
-	assert.JSONEq(t, `{"file_path":"/tmp/demo.py","limit":2000,"offset":0}`, events[0].Delta.PartialJSON)
-	assert.Equal(t, "content_block_stop", events[1].Type)
+	require.Len(t, events, 1, "after streaming deltas, .done should just close the block")
+	assert.Equal(t, "content_block_stop", events[0].Type)
 }
 
 func TestStreamingReasoning(t *testing.T) {

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -413,10 +413,6 @@ func resToAnthHandleFuncArgsDelta(evt *ResponsesStreamEvent, state *ResponsesEve
 		return nil
 	}
 
-	if state.CurrentBlockType == "tool_use" && state.CurrentToolName == "Read" {
-		state.CurrentToolArgs += evt.Delta
-		return nil
-	}
 	if state.CurrentBlockType == "tool_use" {
 		state.CurrentToolHadDelta = true
 	}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_read_tool_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_read_tool_test.go
@@ -1,0 +1,84 @@
+package apicompat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResToAnthFuncArgsDelta_ReadToolStreamsDeltas(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	state.MessageStartSent = true
+	state.CurrentBlockType = "tool_use"
+	state.CurrentToolName = "Read"
+	state.OutputIndexToBlockIdx = map[int]int{0: 0}
+
+	evt := &ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 0,
+		Delta:       `{"file_path":"/tmp/test.go"}`,
+	}
+
+	events := ResponsesEventToAnthropicEvents(evt, state)
+
+	require.Len(t, events, 1, "Read tool delta must produce content_block_delta")
+	assert.Equal(t, "content_block_delta", events[0].Type)
+	assert.Equal(t, "input_json_delta", events[0].Delta.Type)
+	assert.Equal(t, `{"file_path":"/tmp/test.go"}`, events[0].Delta.PartialJSON)
+	assert.True(t, state.CurrentToolHadDelta, "Read deltas should set CurrentToolHadDelta")
+}
+
+func TestResToAnthFuncArgsDelta_ReadToolWithoutDone(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	state.MessageStartSent = true
+	state.ContentBlockIndex = 0
+	state.ContentBlockOpen = true
+	state.CurrentBlockType = "tool_use"
+	state.CurrentToolName = "Read"
+	state.OutputIndexToBlockIdx = map[int]int{0: 0}
+
+	delta := &ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 0,
+		Delta:       `{"file_path":"/tmp/test.go"}`,
+	}
+	events := ResponsesEventToAnthropicEvents(delta, state)
+	require.Len(t, events, 1, "delta should be streamed")
+
+	completed := &ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			Status: "completed",
+		},
+	}
+	events = ResponsesEventToAnthropicEvents(completed, state)
+
+	hasStop := false
+	for _, e := range events {
+		if e.Type == "content_block_stop" {
+			hasStop = true
+		}
+	}
+	assert.True(t, hasStop, "block should be closed even without .done event")
+}
+
+func TestResToAnthFuncArgsDelta_NonReadToolUnchanged(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	state.MessageStartSent = true
+	state.CurrentBlockType = "tool_use"
+	state.CurrentToolName = "Write"
+	state.OutputIndexToBlockIdx = map[int]int{0: 0}
+
+	evt := &ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 0,
+		Delta:       `{"file_path":"/tmp/out.txt","content":"hello"}`,
+	}
+
+	events := ResponsesEventToAnthropicEvents(evt, state)
+
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_delta", events[0].Type)
+	assert.True(t, state.CurrentToolHadDelta)
+}


### PR DESCRIPTION
## 背景

Fixes #4114

resToAnthHandleFuncArgsDelta 对 Read 工具做了特殊处理——把参数攒到 state.CurrentToolArgs 但不发 content_block_delta，只在 resToAnthHandleFuncArgsDone 收到 .done 时一次性 flush。原生 Claude 上游总会发 .done 所以没问题，但 GLM/DeepSeek 这些 CC 兼容上游不发 .done，导致攒的参数永远不 flush，客户端收到 input: {} 报 file_path is missing。

## 修改

去掉 resToAnthHandleFuncArgsDelta 里 Read 工具的特殊短路，让它像普通工具一样实时流式发 input_json_delta。.done 里原有的 sanitizeAnthropicToolUseInput（去除 pages:""）只在上游直接发 .done（不经 delta）时生效，不影响流式路径。

## 兼容性

- 原生 Claude 上游：仍然先发 delta 再发 .done，现在 delta 也流式发了，.done 只触发 closeCurrentBlock，行为正确
- GLM/DeepSeek 等 CC 上游：以前 Read 参数丢失，现在正确流式
- pages:"" 不再被自动清理——Claude Code 现在能容忍这个空参数

## 测试

```bash
go test ./internal/pkg/apicompat/ -run "ReadTool|StreamsDeltas" -v  # 5 个测试通过
go test ./internal/pkg/apicompat/ -count=1  # 全量通过
```