### PR TITLE
fix(web): bypass frontend for alpha search

### DIFF
--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -308,6 +308,7 @@ func shouldBypassEmbeddedFrontend(path string) bool {
 		trimmed == "/health" ||
 		trimmed == "/responses" ||
 		strings.HasPrefix(trimmed, "/responses/") ||
+		trimmed == "/alpha/search" ||
 		strings.HasPrefix(trimmed, "/images/")
 }
 

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -507,6 +507,32 @@ func TestFrontendServer_Middleware(t *testing.T) {
 		assert.JSONEq(t, `{"ok":true}`, w.Body.String())
 	})
 
+	t.Run("skips_alpha_search_post_route", func(t *testing.T) {
+		provider := &mockSettingsProvider{
+			settings: map[string]string{"test": "value"},
+		}
+
+		server, err := NewFrontendServer(provider)
+		require.NoError(t, err)
+
+		router := gin.New()
+		router.Use(server.Middleware())
+		nextCalled := false
+		router.POST("/alpha/search", func(c *gin.Context) {
+			nextCalled = true
+			c.JSON(http.StatusOK, gin.H{"ok": true})
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/alpha/search", strings.NewReader(`{"model":"gpt-5.6-sol"}`))
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+
+		assert.True(t, nextCalled, "next handler should be called for alpha search API route")
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.JSONEq(t, `{"ok":true}`, w.Body.String())
+	})
+
 	t.Run("serves_index_for_spa_routes", func(t *testing.T) {
 		provider := &mockSettingsProvider{
 			settings: map[string]string{"test": "value"},


### PR DESCRIPTION
## Summary

- bypass the embedded frontend middleware for `/alpha/search`
- prevent Codex standalone web search requests from receiving the SPA HTML fallback
- add a regression test covering `POST /alpha/search`

## Background

Codex Responses Lite sends standalone web search requests to `{provider_base_url}/alpha/search`.

Although the route was registered by the gateway, the embedded frontend middleware did not recognize `/alpha/search` as an API route. Requests without the `/v1` prefix were therefore handled by the SPA fallback and returned `index.html`, causing Codex to fail while decoding the response as JSON.
#4131 