### PR TITLE
fix(grok): strip Responses-only fields from Chat Completions upstream body

### DIFF
--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -145,6 +145,10 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 		if err != nil {
 			return nil, fmt.Errorf("remove Responses-only Grok prompt cache key: %w", err)
 		}
+		upstreamBody, err = stripGrokChatCompletionsUnsupportedFields(upstreamBody)
+		if err != nil {
+			return nil, fmt.Errorf("sanitize Grok chat completions body: %w", err)
+		}
 	}
 
 	logger.L().Debug("openai chat_completions raw: forwarding without protocol conversion",

--- a/backend/internal/service/openai_gateway_chat_completions_raw_test.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -673,4 +674,96 @@ func largeRawChatCompletionsBody() []byte {
 	return []byte(`{"model":"gpt-5.5","messages":[{"role":"user","content":"` +
 		strings.Repeat("x", openAISilentRefusalMinRequestBodyBytes) +
 		`"}],"stream":true}`)
+}
+
+// rawGrokOAuthTestAccount constructs a Grok OAuth account whose credentials
+// are sufficient for forwardAsRawChatCompletions to obtain an access token
+// without a token provider, and whose base_url points at a stub upstream.
+func rawGrokOAuthTestAccount() *Account {
+	return &Account{
+		ID:          201,
+		Name:        "raw-grok-oauth",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "grok-test-token",
+			"base_url":     "http://grok-upstream.example/v1",
+		},
+	}
+}
+
+// TestForwardAsRawChatCompletions_StripsSearchParametersForGrokUpstream locks
+// the regression fix for clients (e.g. @vibe-kit/grok-cli) that send the
+// xAI Responses-only `search_parameters` field on a Chat Completions request.
+// The field must be stripped before forwarding to the Grok CC upstream,
+// otherwise the upstream rejects the request with HTTP 410.
+func TestForwardAsRawChatCompletions_StripsSearchParametersForGrokUpstream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
+
+	body := []byte(`{"model":"grok-4.5","messages":[{"role":"user","content":"hello"}],"stream":false,"search_parameters":{"mode":"off"}}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid_grok_search_params"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"chatcmpl_grok_sp","object":"chat.completion","model":"grok-4.5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+		)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	account := rawGrokOAuthTestAccount()
+
+	result, err := svc.forwardAsRawChatCompletions(context.Background(), c, account, body, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 3, result.Usage.InputTokens)
+	// The critical assertion: search_parameters must NOT reach the upstream body.
+	require.False(t, gjson.GetBytes(upstream.lastBody, "search_parameters").Exists(),
+		"search_parameters must be stripped before forwarding to Grok CC upstream")
+	require.True(t, strings.Contains(string(upstream.lastBody), "grok-4.5"),
+		"model and the rest of the body must remain intact")
+}
+
+// TestForwardAsRawChatCompletions_GrokUpstreamURLTargetsChatCompletions ensures
+// the Grok raw CC path forwards to the /chat/completions endpoint of the
+// account base_url (not /v1/responses), which is the endpoint that rejects
+// the Responses-only search_parameters field.
+func TestForwardAsRawChatCompletions_GrokUpstreamURLTargetsChatCompletions(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
+
+	body := []byte(`{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"stream":false}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body: io.NopCloser(strings.NewReader(
+			`{"id":"x","object":"chat.completion","model":"grok-4.5","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`,
+		)),
+	}}
+
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	account := rawGrokOAuthTestAccount()
+
+	_, err := svc.forwardAsRawChatCompletions(context.Background(), c, account, body, "")
+	require.NoError(t, err)
+	require.NotNil(t, upstream.lastReq)
+	require.True(t, strings.HasSuffix(upstream.lastReq.URL.String(), "/chat/completions"),
+		"Grok raw CC upstream URL must end with /chat/completions, got: %s", upstream.lastReq.URL.String())
 }

--- a/backend/internal/service/openai_gateway_grok_cache.go
+++ b/backend/internal/service/openai_gateway_grok_cache.go
@@ -147,3 +147,34 @@ func stripGrokChatPromptCacheKey(body []byte) ([]byte, error) {
 	}
 	return sjson.DeleteBytes(body, "prompt_cache_key")
 }
+
+// grokChatCompletionsUnsupportedFields lists top-level request fields that xAI
+// Chat Completions (/v1/chat/completions) rejects even though some clients
+// (e.g. @vibe-kit/grok-cli) send them. They belong to the xAI Responses/Search
+// surface; forwarding them verbatim makes the upstream return HTTP 410.
+//
+// Entries are removed unconditionally when present. Add a field here only when
+// it has been confirmed unsupported by the Grok Chat Completions upstream and
+// there is no safer per-value handling.
+var grokChatCompletionsUnsupportedFields = []string{
+	"search_parameters",
+}
+
+// stripGrokChatCompletionsUnsupportedFields removes top-level fields that the
+// Grok Chat Completions upstream does not accept. It mirrors the sanitize
+// family already used on the Responses path (see patchGrokResponsesBody) and
+// is applied right before the raw CC body is sent upstream.
+func stripGrokChatCompletionsUnsupportedFields(body []byte) ([]byte, error) {
+	out := body
+	for _, field := range grokChatCompletionsUnsupportedFields {
+		if !gjson.GetBytes(out, field).Exists() {
+			continue
+		}
+		var err error
+		out, err = sjson.DeleteBytes(out, field)
+		if err != nil {
+			return nil, fmt.Errorf("remove unsupported grok chat completions field %s: %w", field, err)
+		}
+	}
+	return out, nil
+}

--- a/backend/internal/service/openai_gateway_grok_cache_test.go
+++ b/backend/internal/service/openai_gateway_grok_cache_test.go
@@ -3,6 +3,7 @@
 package service
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -270,4 +271,73 @@ func TestResolveGrokCacheIdentityConcurrentDeterminism(t *testing.T) {
 		require.Equal(t, first, identity)
 	}
 	require.NotEmpty(t, first)
+}
+
+func TestStripGrokChatCompletionsUnsupportedFieldsRemovesSearchParameters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "search_parameters mode off (grok-cli default)",
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"search_parameters":{"mode":"off"}}`,
+		},
+		{
+			name: "search_parameters mode auto",
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"search_parameters":{"mode":"auto","sources":[{"type":"web"},{"type":"x"}]}}`,
+		},
+		{
+			name: "search_parameters null",
+			body: `{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}],"search_parameters":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := stripGrokChatCompletionsUnsupportedFields([]byte(tt.body))
+			require.NoError(t, err)
+			require.True(t, json.Valid(out), "output must remain valid JSON")
+			require.False(t, gjson.GetBytes(out, "search_parameters").Exists(),
+				"search_parameters must be stripped before forwarding to CC upstream")
+			require.Equal(t, "grok-4.5", gjson.GetBytes(out, "model").String(),
+				"unrelated fields must be preserved")
+			require.Equal(t, "hi", gjson.GetBytes(out, "messages.0.content").String())
+		})
+	}
+}
+
+func TestStripGrokChatCompletionsUnsupportedFieldsPreservesUnrelatedBody(t *testing.T) {
+	t.Parallel()
+
+	body := `{"model":"grok-4.5","messages":[{"role":"system","content":"s"},{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"lookup"}}],"tool_choice":"auto","temperature":0.7,"max_tokens":1536,"stream":true,"stream_options":{"include_usage":true}}`
+
+	out, err := stripGrokChatCompletionsUnsupportedFields([]byte(body))
+	require.NoError(t, err)
+	require.True(t, json.Valid(out))
+	// Nothing to strip here; the body should be byte-for-byte identical.
+	require.Equal(t, body, string(out))
+}
+
+func TestStripGrokChatCompletionsUnsupportedFieldsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"grok-4.5","search_parameters":{"mode":"off"},"messages":[]}`)
+	first, err := stripGrokChatCompletionsUnsupportedFields(body)
+	require.NoError(t, err)
+	second, err := stripGrokChatCompletionsUnsupportedFields(first)
+	require.NoError(t, err)
+	require.Equal(t, string(first), string(second), "applying the sanitizer twice must be a no-op")
+}
+
+func TestStripGrokChatCompletionsUnsupportedFieldsHandlesBodyWithoutTargetFields(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"grok-4.5","messages":[{"role":"user","content":"hi"}]}`)
+	out, err := stripGrokChatCompletionsUnsupportedFields(body)
+	require.NoError(t, err)
+	require.Equal(t, string(body), string(out), "body without target fields must be untouched")
 }


### PR DESCRIPTION
## Problem

Clients such as [`@vibe-kit/grok-cli`](https://github.com/vibe-kit/grok-cli) send xAI Responses-API-only fields (e.g. `search_parameters`) on `POST /v1/chat/completions` requests. When a Grok OAuth request is **not eligible** for the CC→Responses bridge, or when the runtime **falls back** to raw Chat Completions, the field is forwarded verbatim to the upstream `/v1/chat/completions` endpoint, which rejects it with:

```
HTTP 410 "Upstream error: 410"
```

### Root cause

The eligibility guard `grokChatResponsesBridgeEligibility` only *routes* between the bridge and raw paths — it does not sanitize. When it returns `false` (which is the common case: non-empty `tools`, non-grok-4.5 model, non-OAuth account, missing cache identity, …), the request degrades to `forwardAsRawChatCompletions`, which until now had **no field-cleaning step**. The Responses-only `search_parameters` thus reached the CC upstream unchanged and triggered 410.

```
search_parameters  ∉  bridge whitelist  →  fallback to raw CC  →  verbatim forward  →  410
```

The `"Upstream error: 410"` message is generated by sub2api itself as a fallback (`openai_gateway_upstream_errors.go` `handleCompatErrorResponse`) because the upstream 410 body has no parseable error shape; `410` is also not in the `shouldFailoverUpstreamError` set, so no retry happens.

## Fix

Add `stripGrokChatCompletionsUnsupportedFields`, mirroring the existing sanitize family already used on the Responses path (`patchGrokResponsesBody`, `stripGrokChatPromptCacheKey`, `sanitizeGrokResponses*`). It removes known unsupported top-level fields right before the raw CC body is sent upstream.

- **Where**: `openai_gateway_chat_completions_raw.go`, immediately after `stripGrokChatPromptCacheKey`, inside the existing `if account.Platform == PlatformGrok` block.
- **What**: a new exported list `grokChatCompletionsUnsupportedFields` (currently only `search_parameters`) + `stripGrokChatCompletionsUnsupportedFields(body)`.
- **Why here**: this is the last body-mutation stop on the Grok raw CC path; all other sjson rewrites have already happened, and the debug log right after will reflect the sanitized body. It keeps the “Responses path has sanitizers, raw CC path now has one too” symmetry.

The list is intentionally extensible: future Responses-only fields that break the CC upstream can be added in one place.

## Why not route to Responses instead?

`search_parameters` is not a standard xAI field on any endpoint. Even if the request were routed through the CC→Responses bridge, the field would be silently dropped at three points:

1. `ChatCompletionsRequest` struct has no `SearchParameters` field → lost on `json.Unmarshal`
2. `ResponsesRequest` struct has no such field → cannot be serialized into the Responses body
3. `ChatCompletionsToResponses` has no mapping for it

xAI Responses search is expressed via `tools: [{"type":"web_search"}]`, not via `search_parameters`. Fully preserving search intent is a separate feature (mapping `search_parameters.mode` → `web_search` tool) and is out of scope for this bug fix. This PR is the necessary defensive fix that guarantees no 410 regardless of which path is taken.

## Tests

Unit tests (`openai_gateway_grok_cache_test.go`, `//go:build unit`):
- `TestStripGrokChatCompletionsUnsupportedFieldsRemovesSearchParameters` — removal across `mode: off / auto / null`
- `TestStripGrokChatCompletionsUnsupportedFieldsPreservesUnrelatedBody` — unrelated fields byte-identical
- `TestStripGrokChatCompletionsUnsupportedFieldsIdempotent` — applying twice is a no-op
- `TestStripGrokChatCompletionsUnsupportedFieldsHandlesBodyWithoutTargetFields` — no-op when field absent

Integration tests (`openai_gateway_chat_completions_raw_test.go`):
- `TestForwardAsRawChatCompletions_StripsSearchParametersForGrokUpstream` — end-to-end: `search_parameters` must NOT appear in the upstream request body
- `TestForwardAsRawChatCompletions_GrokUpstreamURLTargetsChatCompletions` — locks the upstream URL to `/chat/completions` (the endpoint that rejects the field)

All new tests pass; no regressions in the service package (the only pre-existing failure is `TestEstimateOpenAIInputTokens_CompareWithOpenAIAPI`, which requires live OpenAI API access and 403s in restricted regions).

## Checklist

- [x] `go build ./...` passes
- [x] `go vet -tags=unit ./internal/service/...` passes
- [x] `go test -tags=unit` passes for new and touched tests
- [x] Conventional commit message
- [x] No frontend / Ent schema changes