### PR TITLE
fix(admin-usage): 对齐 last24hours 为滚动 24 小时窗口

### DIFF
--- a/backend/internal/handler/admin/admin_helpers_test.go
+++ b/backend/internal/handler/admin/admin_helpers_test.go
@@ -32,6 +32,56 @@ func TestParseTimeRange(t *testing.T) {
 	require.False(t, end.IsZero())
 }
 
+func TestParseTimeRangeLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=last24hours&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseTimeRange(c)
+	after := time.Now().UTC()
+
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, 24*time.Hour, end.Sub(start))
+}
+
+func TestTimeRangeResponseMetadataLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=24h&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseTimeRange(c)
+	after := time.Now().UTC()
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "last24hours", metadata.Period)
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, start.Format(time.RFC3339), metadata.StartTime)
+	require.Equal(t, end.Format(time.RFC3339), metadata.EndTime)
+	require.Equal(t, end.Format("2006-01-02"), metadata.EndDate)
+}
+
+func TestTimeRangeResponseMetadataDateRange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
+
+	start, end := parseTimeRange(c)
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "2024-01-01", metadata.StartDate)
+	require.Equal(t, "2024-01-02", metadata.EndDate)
+	require.Empty(t, metadata.Period)
+	require.Equal(t, "2024-01-01T00:00:00Z", metadata.StartTime)
+	require.Equal(t, "2024-01-03T00:00:00Z", metadata.EndTime)
+}
+
 func TestParseOpsViewParam(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -38,8 +38,13 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 	now := timezone.NowInUserLocation(userTZ)
 	startDate := c.Query("start_date")
 	endDate := c.Query("end_date")
+	period := c.Query("period")
 
 	var startTime, endTime time.Time
+
+	if startDate == "" && endDate == "" && timezone.IsLast24HoursPeriod(period) {
+		return timezone.Last24HoursInUserLocation(userTZ)
+	}
 
 	if startDate != "" {
 		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
@@ -53,7 +58,7 @@ func parseTimeRange(c *gin.Context) (time.Time, time.Time) {
 
 	if endDate != "" {
 		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
-			endTime = t.Add(24 * time.Hour) // Include the end date
+			endTime = t.AddDate(0, 0, 1) // Include the end date
 		} else {
 			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
 		}
@@ -257,12 +262,10 @@ func (h *DashboardHandler) GetUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // GetModelStats handles getting model usage statistics
@@ -338,11 +341,9 @@ func (h *DashboardHandler) GetModelStats(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
-		"models":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"models": stats,
+	}, c, startTime, endTime))
 }
 
 // GetGroupStats handles getting group usage statistics
@@ -409,11 +410,9 @@ func (h *DashboardHandler) GetGroupStats(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
-		"groups":     stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"groups": stats,
+	}, c, startTime, endTime))
 }
 
 // GetAPIKeyUsageTrend handles getting API key usage trend data
@@ -435,12 +434,10 @@ func (h *DashboardHandler) GetAPIKeyUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // GetUserUsageTrend handles getting user usage trend data
@@ -462,12 +459,10 @@ func (h *DashboardHandler) GetUserUsageTrend(c *gin.Context) {
 	}
 	c.Header("X-Snapshot-Cache", cacheStatusValue(hit))
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  startTime.Format("2006-01-02"),
-		"end_date":    endTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, startTime, endTime))
 }
 
 // BatchUsersUsageRequest represents the request body for batch user usage stats
@@ -518,14 +513,12 @@ func (h *DashboardHandler) GetUserSpendingRanking(c *gin.Context) {
 		return
 	}
 
-	payload := gin.H{
+	payload := addTimeRangeResponseMetadata(gin.H{
 		"ranking":           ranking.Ranking,
 		"total_actual_cost": ranking.TotalActualCost,
 		"total_requests":    ranking.TotalRequests,
 		"total_tokens":      ranking.TotalTokens,
-		"start_date":        startTime.Format("2006-01-02"),
-		"end_date":          endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	}
+	}, c, startTime, endTime)
 	dashboardUsersRankingCache.Set(cacheKey, payload)
 	c.Header("X-Snapshot-Cache", "miss")
 	response.Success(c, payload)
@@ -696,9 +689,7 @@ func (h *DashboardHandler) GetUserBreakdown(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
-		"users":      stats,
-		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"users": stats,
+	}, c, startTime, endTime))
 }

--- a/backend/internal/handler/admin/dashboard_handler_request_type_test.go
+++ b/backend/internal/handler/admin/dashboard_handler_request_type_test.go
@@ -89,6 +89,8 @@ func TestDashboardTrendRequestTypePriority(t *testing.T) {
 	require.NotNil(t, repo.trendRequestType)
 	require.Equal(t, int16(service.RequestTypeWSV2), *repo.trendRequestType)
 	require.Nil(t, repo.trendStream)
+	require.Contains(t, rec.Body.String(), "\"start_time\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\"")
 }
 
 func TestDashboardTrendInvalidRequestType(t *testing.T) {
@@ -190,6 +192,8 @@ func TestDashboardUsersRankingLimitAndCache(t *testing.T) {
 	require.Contains(t, rec.Body.String(), "\"total_actual_cost\":88.8")
 	require.Contains(t, rec.Body.String(), "\"total_requests\":44")
 	require.Contains(t, rec.Body.String(), "\"total_tokens\":1234")
+	require.Contains(t, rec.Body.String(), "\"start_time\":\"2025-01-01T00:00:00")
+	require.Contains(t, rec.Body.String(), "\"end_time\":\"2025-01-03T00:00:00")
 	require.Equal(t, "miss", rec.Header().Get("X-Snapshot-Cache"))
 
 	req2 := httptest.NewRequest(http.MethodGet, "/admin/dashboard/users-ranking?limit=100&start_date=2025-01-01&end_date=2025-01-02", nil)

--- a/backend/internal/handler/admin/dashboard_snapshot_v2_handler.go
+++ b/backend/internal/handler/admin/dashboard_snapshot_v2_handler.go
@@ -25,8 +25,7 @@ type dashboardSnapshotV2Stats struct {
 type dashboardSnapshotV2Response struct {
 	GeneratedAt string `json:"generated_at"`
 
-	StartDate   string `json:"start_date"`
-	EndDate     string `json:"end_date"`
+	timeRangeResponseMetadata
 	Granularity string `json:"granularity"`
 
 	Stats      *dashboardSnapshotV2Stats        `json:"stats,omitempty"`
@@ -115,6 +114,7 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 
 	cached, hit, err := dashboardSnapshotV2Cache.GetOrLoad(cacheKey, func() (any, error) {
 		return h.buildSnapshotV2Response(
+			c,
 			c.Request.Context(),
 			startTime,
 			endTime,
@@ -145,6 +145,7 @@ func (h *DashboardHandler) GetSnapshotV2(c *gin.Context) {
 }
 
 func (h *DashboardHandler) buildSnapshotV2Response(
+	c *gin.Context,
 	ctx context.Context,
 	startTime, endTime time.Time,
 	granularity string,
@@ -153,10 +154,9 @@ func (h *DashboardHandler) buildSnapshotV2Response(
 	usersTrendLimit int,
 ) (*dashboardSnapshotV2Response, error) {
 	resp := &dashboardSnapshotV2Response{
-		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
-		StartDate:   startTime.Format("2006-01-02"),
-		EndDate:     endTime.Add(-24 * time.Hour).Format("2006-01-02"),
-		Granularity: granularity,
+		GeneratedAt:               time.Now().UTC().Format(time.RFC3339),
+		timeRangeResponseMetadata: newTimeRangeResponseMetadata(c, startTime, endTime),
+		Granularity:               granularity,
 	}
 
 	if includeStats {

--- a/backend/internal/handler/admin/time_range_response.go
+++ b/backend/internal/handler/admin/time_range_response.go
@@ -1,0 +1,65 @@
+package admin
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/gin-gonic/gin"
+)
+
+type timeRangeResponseMetadata struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	StartTime string `json:"start_time,omitempty"`
+	EndTime   string `json:"end_time,omitempty"`
+	Period    string `json:"period,omitempty"`
+}
+
+func newTimeRangeResponseMetadata(c *gin.Context, startTime, endTime time.Time) timeRangeResponseMetadata {
+	metadata := timeRangeResponseMetadata{
+		StartDate: startTime.Format("2006-01-02"),
+		EndDate:   formatResponseEndDate(c, endTime),
+		StartTime: startTime.Format(time.RFC3339),
+		EndTime:   endTime.Format(time.RFC3339),
+	}
+
+	if period := normalizeResponsePeriod(c); period != "" {
+		metadata.Period = period
+	}
+
+	return metadata
+}
+
+func addTimeRangeResponseMetadata(payload gin.H, c *gin.Context, startTime, endTime time.Time) gin.H {
+	metadata := newTimeRangeResponseMetadata(c, startTime, endTime)
+	payload["start_date"] = metadata.StartDate
+	payload["end_date"] = metadata.EndDate
+	payload["start_time"] = metadata.StartTime
+	payload["end_time"] = metadata.EndTime
+	if metadata.Period != "" {
+		payload["period"] = metadata.Period
+	}
+	return payload
+}
+
+func formatResponseEndDate(c *gin.Context, endTime time.Time) string {
+	if c != nil && c.Query("start_date") == "" && c.Query("end_date") == "" && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		return endTime.Format("2006-01-02")
+	}
+	return endTime.Add(-time.Nanosecond).Format("2006-01-02")
+}
+
+func normalizeResponsePeriod(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	period := strings.ToLower(strings.TrimSpace(c.Query("period")))
+	if period == "" {
+		return ""
+	}
+	if timezone.IsLast24HoursPeriod(period) {
+		return "last24hours"
+	}
+	return period
+}

--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -164,6 +164,13 @@ func (h *UsageHandler) List(c *gin.Context) {
 		t = t.AddDate(0, 0, 1)
 		endTime = &t
 	}
+	if startTime == nil && endTime == nil && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		now := timezone.NowInUserLocation(userTZ)
+		start := now.Add(-24 * time.Hour)
+		end := now
+		startTime = &start
+		endTime = &end
+	}
 
 	params := pagination.PaginationParams{
 		Page:      page,
@@ -297,15 +304,20 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 		endTime = endTime.AddDate(0, 0, 1)
 	} else {
 		period := c.DefaultQuery("period", "today")
-		switch period {
-		case "today":
-			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
-		case "week":
-			startTime = now.AddDate(0, 0, -7)
-		case "month":
-			startTime = now.AddDate(0, -1, 0)
+		switch {
+		case timezone.IsLast24HoursPeriod(period):
+			startTime = now.Add(-24 * time.Hour)
 		default:
-			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			switch period {
+			case "today":
+				startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			case "week":
+				startTime = now.AddDate(0, 0, -7)
+			case "month":
+				startTime = now.AddDate(0, -1, 0)
+			default:
+				startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+			}
 		}
 		endTime = now
 	}

--- a/backend/internal/handler/admin/usage_handler_request_type_test.go
+++ b/backend/internal/handler/admin/usage_handler_request_type_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
@@ -139,4 +140,40 @@ func TestAdminUsageStatsInvalidStream(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestAdminUsageListLast24HoursPeriod(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.listFilters.StartTime)
+	require.NotNil(t, repo.listFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
+	require.WithinDuration(t, *repo.listFilters.StartTime, repo.listFilters.EndTime.Add(-24*time.Hour), 2*time.Second)
+}
+
+func TestAdminUsageStatsLast24HoursPeriod(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage/stats?period=24h&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.statsFilters.StartTime)
+	require.NotNil(t, repo.statsFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.statsFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.statsFilters.EndTime, 2*time.Second)
+	require.WithinDuration(t, *repo.statsFilters.StartTime, repo.statsFilters.EndTime.Add(-24*time.Hour), 2*time.Second)
 }

--- a/backend/internal/handler/time_range_response.go
+++ b/backend/internal/handler/time_range_response.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
+	"github.com/gin-gonic/gin"
+)
+
+type timeRangeResponseMetadata struct {
+	StartDate string `json:"start_date"`
+	EndDate   string `json:"end_date"`
+	StartTime string `json:"start_time,omitempty"`
+	EndTime   string `json:"end_time,omitempty"`
+	Period    string `json:"period,omitempty"`
+}
+
+func newTimeRangeResponseMetadata(c *gin.Context, startTime, endTime time.Time) timeRangeResponseMetadata {
+	metadata := timeRangeResponseMetadata{
+		StartDate: startTime.Format("2006-01-02"),
+		EndDate:   formatResponseEndDate(c, endTime),
+		StartTime: startTime.Format(time.RFC3339),
+		EndTime:   endTime.Format(time.RFC3339),
+	}
+
+	if period := normalizeResponsePeriod(c); period != "" {
+		metadata.Period = period
+	}
+
+	return metadata
+}
+
+func addTimeRangeResponseMetadata(payload gin.H, c *gin.Context, startTime, endTime time.Time) gin.H {
+	metadata := newTimeRangeResponseMetadata(c, startTime, endTime)
+	payload["start_date"] = metadata.StartDate
+	payload["end_date"] = metadata.EndDate
+	payload["start_time"] = metadata.StartTime
+	payload["end_time"] = metadata.EndTime
+	if metadata.Period != "" {
+		payload["period"] = metadata.Period
+	}
+	return payload
+}
+
+func formatResponseEndDate(c *gin.Context, endTime time.Time) string {
+	if c != nil && c.Query("start_date") == "" && c.Query("end_date") == "" && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		return endTime.Format("2006-01-02")
+	}
+	return endTime.Add(-time.Nanosecond).Format("2006-01-02")
+}
+
+func normalizeResponsePeriod(c *gin.Context) string {
+	if c == nil {
+		return ""
+	}
+	period := strings.ToLower(strings.TrimSpace(c.Query("period")))
+	if period == "" {
+		return ""
+	}
+	if timezone.IsLast24HoursPeriod(period) {
+		return "last24hours"
+	}
+	return period
+}

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -169,6 +169,12 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 		endPtr = &endTime
 	}
 
+	if startPtr == nil && endPtr == nil && timezone.IsLast24HoursPeriod(c.Query("period")) {
+		startTime, endTime = timezone.Last24HoursInUserLocation(userTZ)
+		startPtr = &startTime
+		endPtr = &endTime
+	}
+
 	if requireRange {
 		if startPtr == nil {
 			switch c.DefaultQuery("period", "") {
@@ -435,6 +441,53 @@ func apiKeyDailyUsageRange(days int, userTZ string) (time.Time, time.Time) {
 	return startTime, endTime
 }
 
+func parseUserTimeRange(c *gin.Context) (time.Time, time.Time) {
+	userTZ := c.Query("timezone")
+	now := timezone.NowInUserLocation(userTZ)
+	startDate := strings.TrimSpace(c.Query("start_date"))
+	endDate := strings.TrimSpace(c.Query("end_date"))
+	period := strings.TrimSpace(c.Query("period"))
+
+	if startDate == "" && endDate == "" && timezone.IsLast24HoursPeriod(period) {
+		return timezone.Last24HoursInUserLocation(userTZ)
+	}
+
+	var startTime, endTime time.Time
+
+	if startDate != "" {
+		if t, err := timezone.ParseInUserLocation("2006-01-02", startDate, userTZ); err == nil {
+			startTime = t
+		} else {
+			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
+		}
+	} else {
+		switch period {
+		case "today":
+			startTime = timezone.StartOfDayInUserLocation(now, userTZ)
+		case "week":
+			startTime = now.AddDate(0, 0, -7)
+		case "month":
+			startTime = now.AddDate(0, -1, 0)
+		default:
+			startTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, -7), userTZ)
+		}
+	}
+
+	if endDate != "" {
+		if t, err := timezone.ParseInUserLocation("2006-01-02", endDate, userTZ); err == nil {
+			endTime = t.AddDate(0, 0, 1)
+		} else {
+			endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+		}
+	} else if period != "" {
+		endTime = now
+	} else {
+		endTime = timezone.StartOfDayInUserLocation(now.AddDate(0, 0, 1), userTZ)
+	}
+
+	return startTime, endTime
+}
+
 // DashboardStats handles getting user dashboard statistics
 // GET /api/v1/usage/dashboard/stats
 func (h *UsageHandler) DashboardStats(c *gin.Context) {
@@ -468,12 +521,10 @@ func (h *UsageHandler) DashboardTrend(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
 		"trend":       trend,
-		"start_date":  parsed.StartTime.Format("2006-01-02"),
-		"end_date":    parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
 		"granularity": granularity,
-	})
+	}, c, parsed.StartTime, parsed.EndTime))
 }
 
 // DashboardModels handles getting user model usage statistics
@@ -496,11 +547,9 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 		return
 	}
 
-	response.Success(c, gin.H{
-		"models":     userModelStatsFromUsageStats(stats),
-		"start_date": parsed.StartTime.Format("2006-01-02"),
-		"end_date":   parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
-	})
+	response.Success(c, addTimeRangeResponseMetadata(gin.H{
+		"models": userModelStatsFromUsageStats(stats),
+	}, c, parsed.StartTime, parsed.EndTime))
 }
 
 // DashboardSnapshotV2 returns usage-page chart data scoped to the current user.

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -17,15 +17,20 @@ import (
 
 type userUsageRepoCapture struct {
 	service.UsageLogRepository
-	listParams   pagination.PaginationParams
-	listFilters  usagestats.UsageLogFilters
-	statsFilters usagestats.UsageLogFilters
-	trendFilters usagestats.UsageLogFilters
-	groupFilters usagestats.UsageLogFilters
-	listRows     []service.UsageLog
-	stats        *usagestats.UsageStats
-	modelStats   []usagestats.ModelStat
-	groupStats   []usagestats.GroupStat
+	listParams       pagination.PaginationParams
+	listFilters      usagestats.UsageLogFilters
+	statsFilters     usagestats.UsageLogFilters
+	trendFilters     usagestats.UsageLogFilters
+	trendStart       time.Time
+	trendEnd         time.Time
+	trendGranularity string
+	modelStart       time.Time
+	modelEnd         time.Time
+	groupFilters     usagestats.UsageLogFilters
+	listRows         []service.UsageLog
+	stats            *usagestats.UsageStats
+	modelStats       []usagestats.ModelStat
+	groupStats       []usagestats.GroupStat
 }
 
 func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters usagestats.UsageLogFilters) ([]service.UsageLog, *pagination.PaginationResult, error) {
@@ -48,6 +53,9 @@ func (s *userUsageRepoCapture) GetStatsWithFilters(ctx context.Context, filters 
 }
 
 func (s *userUsageRepoCapture) GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, requestType *int16, stream *bool, billingType *int8) ([]usagestats.TrendDataPoint, error) {
+	s.trendStart = startTime
+	s.trendEnd = endTime
+	s.trendGranularity = granularity
 	s.trendFilters = usagestats.UsageLogFilters{
 		UserID:      userID,
 		APIKeyID:    apiKeyID,
@@ -62,6 +70,8 @@ func (s *userUsageRepoCapture) GetUsageTrendWithFilters(ctx context.Context, sta
 }
 
 func (s *userUsageRepoCapture) GetModelStatsWithFilters(ctx context.Context, startTime, endTime time.Time, userID, apiKeyID, accountID, groupID int64, requestType *int16, stream *bool, billingType *int8) ([]usagestats.ModelStat, error) {
+	s.modelStart = startTime
+	s.modelEnd = endTime
 	return s.modelStats, nil
 }
 
@@ -89,6 +99,7 @@ func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	})
 	router.GET("/usage", handler.List)
 	router.GET("/usage/stats", handler.Stats)
+	router.GET("/usage/dashboard/trend", handler.DashboardTrend)
 	router.GET("/usage/dashboard/models", handler.DashboardModels)
 	router.GET("/usage/dashboard/snapshot-v2", handler.DashboardSnapshotV2)
 	return router
@@ -129,6 +140,24 @@ func TestUserUsageListInvalidStream(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserUsageListLast24HoursPeriod(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/usage?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.listFilters.StartTime)
+	require.NotNil(t, repo.listFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.listFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.listFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.listFilters.EndTime.Sub(*repo.listFilters.StartTime))
 }
 
 func TestUserUsageListAdvancedFilters(t *testing.T) {
@@ -264,6 +293,40 @@ func TestUserUsageStatsUsesScopedFilters(t *testing.T) {
 	require.NotContains(t, rec.Body.String(), "endpoint_paths")
 }
 
+func TestUserUsageStatsLast24HoursPeriod(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	before := time.Now().UTC()
+	req := httptest.NewRequest(http.MethodGet, "/usage/stats?period=last24hours&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	after := time.Now().UTC()
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, repo.statsFilters.StartTime)
+	require.NotNil(t, repo.statsFilters.EndTime)
+	require.WithinDuration(t, before.Add(-24*time.Hour), *repo.statsFilters.StartTime, 2*time.Second)
+	require.WithinDuration(t, after, *repo.statsFilters.EndTime, 2*time.Second)
+	require.Equal(t, 24*time.Hour, repo.statsFilters.EndTime.Sub(*repo.statsFilters.StartTime))
+}
+
+func TestUserDashboardTrendLast24HoursResponseMetadata(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/trend?period=24h&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, int64(42), repo.trendFilters.UserID)
+	require.Equal(t, "day", repo.trendGranularity)
+	require.Contains(t, rec.Body.String(), "\"period\":\"last24hours\"")
+	require.Contains(t, rec.Body.String(), "\"start_time\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\"")
+}
+
 func TestUserUsageDashboardModelsOmitsAccountCost(t *testing.T) {
 	repo := &userUsageRepoCapture{
 		modelStats: []usagestats.ModelStat{{
@@ -286,6 +349,23 @@ func TestUserUsageDashboardModelsOmitsAccountCost(t *testing.T) {
 	require.Contains(t, body, `"cost":0.1`)
 	require.Contains(t, body, `"actual_cost":0.08`)
 	require.NotContains(t, body, "account_cost")
+}
+
+func TestUserDashboardModelsDateRangeResponseMetadata(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/models?start_date=2025-01-01&end_date=2025-01-02&timezone=UTC", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), repo.modelStart)
+	require.Equal(t, time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), repo.modelEnd)
+	require.Contains(t, rec.Body.String(), "\"start_date\":\"2025-01-01\"")
+	require.Contains(t, rec.Body.String(), "\"end_date\":\"2025-01-02\"")
+	require.Contains(t, rec.Body.String(), "\"start_time\":\"2025-01-01T00:00:00Z\"")
+	require.Contains(t, rec.Body.String(), "\"end_time\":\"2025-01-03T00:00:00Z\"")
 }
 
 func TestUserUsageDashboardModelsRejectsAdminModelSources(t *testing.T) {

--- a/backend/internal/handler/usage_handler_time_range_test.go
+++ b/backend/internal/handler/usage_handler_time_range_test.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseUserTimeRangeLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=last24hours&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseUserTimeRange(c)
+	after := time.Now().UTC()
+
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, 24*time.Hour, end.Sub(start))
+}
+
+func TestUserTimeRangeResponseMetadataLast24Hours(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?period=24h&timezone=UTC", nil)
+
+	before := time.Now().UTC()
+	start, end := parseUserTimeRange(c)
+	after := time.Now().UTC()
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "last24hours", metadata.Period)
+	require.WithinDuration(t, before.Add(-24*time.Hour), start, 2*time.Second)
+	require.WithinDuration(t, after, end, 2*time.Second)
+	require.Equal(t, start.Format(time.RFC3339), metadata.StartTime)
+	require.Equal(t, end.Format(time.RFC3339), metadata.EndTime)
+	require.Equal(t, end.Format("2006-01-02"), metadata.EndDate)
+}
+
+func TestUserTimeRangeResponseMetadataDateRange(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/?start_date=2024-01-01&end_date=2024-01-02&timezone=UTC", nil)
+
+	start, end := parseUserTimeRange(c)
+	metadata := newTimeRangeResponseMetadata(c, start, end)
+
+	require.Equal(t, "2024-01-01", metadata.StartDate)
+	require.Equal(t, "2024-01-02", metadata.EndDate)
+	require.Empty(t, metadata.Period)
+	require.Equal(t, "2024-01-01T00:00:00Z", metadata.StartTime)
+	require.Equal(t, "2024-01-03T00:00:00Z", metadata.EndTime)
+}

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -6,6 +6,7 @@ package timezone
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -163,4 +164,22 @@ func StartOfDayInUserLocation(t time.Time, userTZ string) time.Time {
 	}
 	t = t.In(loc)
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+}
+
+// IsLast24HoursPeriod reports whether the caller requested a rolling last-24-hours window.
+func IsLast24HoursPeriod(period string) bool {
+	switch strings.ToLower(strings.TrimSpace(period)) {
+	case "last24hours", "last24h", "24h":
+		return true
+	default:
+		return false
+	}
+}
+
+// Last24HoursInUserLocation returns a rolling [now-24h, now) window in the user's timezone.
+// The returned values represent the same instants regardless of timezone, but are expressed
+// in the resolved user/server location to keep downstream formatting consistent.
+func Last24HoursInUserLocation(userTZ string) (time.Time, time.Time) {
+	end := NowInUserLocation(userTZ)
+	return end.Add(-24 * time.Hour), end
 }

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -161,3 +161,45 @@ func TestStartOfWeek_Boundaries(t *testing.T) {
 		})
 	}
 }
+
+func TestIsLast24HoursPeriod(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{input: "last24hours", want: true},
+		{input: "LAST24H", want: true},
+		{input: "24h", want: true},
+		{input: "today", want: false},
+		{input: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := IsLast24HoursPeriod(tt.input); got != tt.want {
+			t.Fatalf("IsLast24HoursPeriod(%q)=%v want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLast24HoursInUserLocation(t *testing.T) {
+	if err := Init("UTC"); err != nil {
+		t.Fatalf("Init failed with UTC: %v", err)
+	}
+
+	before := time.Now().UTC()
+	start, end := Last24HoursInUserLocation("UTC")
+	after := time.Now().UTC()
+
+	if !start.Before(end) {
+		t.Fatalf("expected start before end, got start=%v end=%v", start, end)
+	}
+	if diff := end.Sub(start); diff != 24*time.Hour {
+		t.Fatalf("expected exact 24h window, got %v", diff)
+	}
+	if start.Before(before.Add(-24*time.Hour-time.Second)) || start.After(after.Add(-24*time.Hour+time.Second)) {
+		t.Fatalf("unexpected start time: %v", start)
+	}
+	if end.Before(before.Add(-time.Second)) || end.After(after.Add(time.Second)) {
+		t.Fatalf("unexpected end time: %v", end)
+	}
+}

--- a/frontend/src/api/admin/dashboard.ts
+++ b/frontend/src/api/admin/dashboard.ts
@@ -13,6 +13,7 @@ import type {
   UserUsageTrendPoint,
   UserSpendingRankingResponse,
   UserBreakdownItem,
+  TimeRangeMetadata,
   UsageRequestType
 } from '@/types'
 
@@ -45,6 +46,7 @@ export async function getRealtimeMetrics(): Promise<{
 }
 
 export interface TrendParams {
+  period?: string
   start_date?: string
   end_date?: string
   granularity?: 'day' | 'hour'
@@ -58,10 +60,8 @@ export interface TrendParams {
   billing_type?: number | null
 }
 
-export interface TrendResponse {
+export interface TrendResponse extends TimeRangeMetadata {
   trend: TrendDataPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
@@ -76,6 +76,7 @@ export async function getUsageTrend(params?: TrendParams): Promise<TrendResponse
 }
 
 export interface ModelStatsParams {
+  period?: string
   start_date?: string
   end_date?: string
   user_id?: number
@@ -89,10 +90,8 @@ export interface ModelStatsParams {
   billing_type?: number | null
 }
 
-export interface ModelStatsResponse {
+export interface ModelStatsResponse extends TimeRangeMetadata {
   models: ModelStat[]
-  start_date: string
-  end_date: string
 }
 
 /**
@@ -106,6 +105,7 @@ export async function getModelStats(params?: ModelStatsParams): Promise<ModelSta
 }
 
 export interface GroupStatsParams {
+  period?: string
   start_date?: string
   end_date?: string
   user_id?: number
@@ -117,10 +117,8 @@ export interface GroupStatsParams {
   billing_type?: number | null
 }
 
-export interface GroupStatsResponse {
+export interface GroupStatsResponse extends TimeRangeMetadata {
   groups: GroupStat[]
-  start_date: string
-  end_date: string
 }
 
 export interface DashboardSnapshotV2Params extends TrendParams {
@@ -136,10 +134,8 @@ export interface DashboardSnapshotV2Stats extends DashboardStats {
   uptime: number
 }
 
-export interface DashboardSnapshotV2Response {
+export interface DashboardSnapshotV2Response extends TimeRangeMetadata {
   generated_at: string
-  start_date: string
-  end_date: string
   granularity: string
   stats?: DashboardSnapshotV2Stats
   trend?: TrendDataPoint[]
@@ -159,6 +155,7 @@ export async function getGroupStats(params?: GroupStatsParams): Promise<GroupSta
 }
 
 export interface UserBreakdownParams {
+  period?: string
   start_date?: string
   end_date?: string
   group_id?: number
@@ -178,10 +175,8 @@ export interface UserBreakdownParams {
   billing_type?: number | null
 }
 
-export interface UserBreakdownResponse {
+export interface UserBreakdownResponse extends TimeRangeMetadata {
   users: UserBreakdownItem[]
-  start_date: string
-  end_date: string
 }
 
 export async function getUserBreakdown(params: UserBreakdownParams): Promise<UserBreakdownResponse> {
@@ -205,10 +200,8 @@ export interface ApiKeyTrendParams extends TrendParams {
   limit?: number
 }
 
-export interface ApiKeyTrendResponse {
+export interface ApiKeyTrendResponse extends TimeRangeMetadata {
   trend: ApiKeyUsageTrendPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
@@ -230,15 +223,13 @@ export interface UserTrendParams extends TrendParams {
   limit?: number
 }
 
-export interface UserTrendResponse {
+export interface UserTrendResponse extends TimeRangeMetadata {
   trend: UserUsageTrendPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
 export interface UserSpendingRankingParams
-  extends Pick<TrendParams, 'start_date' | 'end_date'> {
+  extends Pick<TrendParams, 'period' | 'start_date' | 'end_date'> {
   limit?: number
 }
 

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -15,6 +15,7 @@ import type {
   UsageRequestType,
   UserErrorRequest,
   UserErrorRequestDetail,
+  TimeRangeMetadata,
   UserErrorListParams
 } from '@/types'
 
@@ -56,6 +57,7 @@ export interface UserDashboardStats {
 }
 
 export interface TrendParams {
+  period?: string
   start_date?: string
   end_date?: string
   granularity?: 'day' | 'hour'
@@ -69,17 +71,13 @@ export interface TrendParams {
   timezone?: string
 }
 
-export interface TrendResponse {
+export interface TrendResponse extends TimeRangeMetadata {
   trend: TrendDataPoint[]
-  start_date: string
-  end_date: string
   granularity: string
 }
 
-export interface ModelStatsResponse {
+export interface ModelStatsResponse extends TimeRangeMetadata {
   models: ModelStat[]
-  start_date: string
-  end_date: string
 }
 
 export interface ApiKeyDailyUsagePoint {
@@ -277,6 +275,7 @@ export async function getDashboardTrend(params?: TrendParams): Promise<TrendResp
  * @returns Model usage statistics for current user
  */
 export async function getDashboardModels(params?: {
+  period?: string
   start_date?: string
   end_date?: string
   api_key_id?: number

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1626,13 +1626,19 @@ export interface UserSpendingRankingItem {
   tokens: number
 }
 
-export interface UserSpendingRankingResponse {
+export interface TimeRangeMetadata {
+  start_date: string
+  end_date: string
+  start_time?: string
+  end_time?: string
+  period?: string
+}
+
+export interface UserSpendingRankingResponse extends TimeRangeMetadata {
   ranking: UserSpendingRankingItem[]
   total_actual_cost: number
   total_requests: number
   total_tokens: number
-  start_date: string
-  end_date: string
 }
 
 export interface ApiKeyUsageTrendPoint {
@@ -1779,6 +1785,7 @@ export interface UsageQueryParams {
   stream?: boolean
   billing_type?: number | null
   billing_mode?: string | null
+  period?: string
   start_date?: string
   end_date?: string
   timezone?: string

--- a/frontend/src/views/admin/DashboardView.vue
+++ b/frontend/src/views/admin/DashboardView.vue
@@ -390,6 +390,7 @@ ChartJS.register(
 const appStore = useAppStore()
 const router = useRouter()
 const { canUseBatchImage, refreshBatchImageAccess } = useBatchImageAccess()
+type DateRangePreset = 'last24Hours' | null
 const stats = ref<DashboardStats | null>(null)
 const loading = ref(false)
 const chartsLoading = ref(false)
@@ -429,6 +430,25 @@ const granularity = ref<'day' | 'hour'>('hour')
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
+
+const buildRangeParams = (): { period?: string; start_date?: string; end_date?: string } => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const range = getLast24HoursRangeDates()
+    startDate.value = range.start
+    endDate.value = range.end
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
 
 // Granularity options for Select component
 const granularityOptions = computed(() => [
@@ -612,12 +632,14 @@ const formatDuration = (ms: number): string => {
 }
 
 const goToUserUsage = (item: UserSpendingRankingItem) => {
+  const rangeParams = buildRangeParams()
   void router.push({
     path: '/admin/usage',
     query: {
       user_id: String(item.user_id),
-      start_date: startDate.value,
-      end_date: endDate.value
+      ...(rangeParams.period
+        ? { period: rangeParams.period }
+        : { start_date: startDate.value, end_date: endDate.value })
     }
   })
 }
@@ -628,6 +650,9 @@ const onDateRangeChange = (range: {
   endDate: string
   preset: string | null
 }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
   // Auto-select granularity based on date range
   const start = new Date(range.startDate)
   const end = new Date(range.endDate)
@@ -652,8 +677,7 @@ const loadDashboardSnapshot = async (includeStats: boolean) => {
   chartsLoading.value = true
   try {
     const response = await adminAPI.dashboard.getSnapshotV2({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       include_stats: includeStats,
       include_trend: true,
@@ -684,8 +708,7 @@ const loadUsersTrend = async () => {
   userTrendLoading.value = true
   try {
     const response = await adminAPI.dashboard.getUserUsageTrend({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       granularity: granularity.value,
       limit: 12
     })
@@ -708,8 +731,7 @@ const loadUserSpendingRanking = async () => {
   rankingError.value = false
   try {
     const response = await adminAPI.dashboard.getUserSpendingRanking({
-      start_date: startDate.value,
-      end_date: endDate.value,
+      ...buildRangeParams(),
       limit: rankingLimit
     })
     if (currentSeq !== rankingLoadSeq) return

--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -317,8 +317,10 @@ const getNumericQueryValue = (value: string | null | Array<string | null> | unde
 const applyRouteQueryFilters = () => {
   const queryStartDate = getSingleQueryValue(route.query.start_date)
   const queryEndDate = getSingleQueryValue(route.query.end_date)
+  const queryPeriod = getSingleQueryValue(route.query.period)
   const queryUserId = getNumericQueryValue(route.query.user_id)
 
+  const useLast24Hours = queryPeriod === '24h' || queryPeriod === 'last24hours'
   if (queryStartDate) {
     startDate.value = queryStartDate
   }
@@ -329,19 +331,22 @@ const applyRouteQueryFilters = () => {
   filters.value = {
     ...filters.value,
     user_id: queryUserId,
-    start_date: startDate.value,
-    end_date: endDate.value
+    period: useLast24Hours ? 'last24hours' : undefined,
+    start_date: useLast24Hours ? undefined : startDate.value,
+    end_date: useLast24Hours ? undefined : endDate.value
   }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
 }
 
 const onDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  const isLast24Hours = range.preset === 'last24Hours'
   startDate.value = range.startDate
   endDate.value = range.endDate
   filters.value = {
     ...filters.value,
-    start_date: range.startDate,
-    end_date: range.endDate
+    period: isLast24Hours ? 'last24hours' : undefined,
+    start_date: isLast24Hours ? undefined : range.startDate,
+    end_date: isLast24Hours ? undefined : range.endDate
   }
   granularity.value = getGranularityForRange(range.startDate, range.endDate)
   applyFilters()
@@ -354,11 +359,14 @@ const buildUsageListParams = (
 ): AdminUsageQueryParams => {
   const requestType = filters.value.request_type
   const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+  const isLast24Hours = filters.value.period === 'last24hours'
   return {
     page,
     page_size: pageSize,
     exact_total: exactTotal,
     ...filters.value,
+    start_date: isLast24Hours ? undefined : filters.value.start_date,
+    end_date: isLast24Hours ? undefined : filters.value.end_date,
     stream: legacyStream === null ? undefined : legacyStream,
     sort_by: sortState.sort_by,
     sort_order: sortState.sort_order
@@ -381,8 +389,11 @@ const loadStats = async (force = false) => {
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const isLast24Hours = filters.value.period === 'last24hours'
     const s = await adminAPI.usage.getStats({
       ...filters.value,
+      start_date: isLast24Hours ? undefined : filters.value.start_date,
+      end_date: isLast24Hours ? undefined : filters.value.end_date,
       stream: legacyStream === null ? undefined : legacyStream,
       ...(force ? { nocache: 1 } : {}),
     })
@@ -419,9 +430,11 @@ const loadModelStats = async (source: ModelDistributionSource, force = false) =>
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const isLast24Hours = filters.value.period === 'last24hours'
     const baseParams = {
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
+      start_date: isLast24Hours ? undefined : (filters.value.start_date || startDate.value),
+      end_date: isLast24Hours ? undefined : (filters.value.end_date || endDate.value),
+      period: isLast24Hours ? 'last24hours' : undefined,
       user_id: filters.value.user_id,
       model: filters.value.model,
       api_key_id: filters.value.api_key_id,
@@ -467,9 +480,11 @@ const loadChartData = async () => {
   try {
     const requestType = filters.value.request_type
     const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
+    const isLast24Hours = filters.value.period === 'last24hours'
     const snapshot = await adminAPI.dashboard.getSnapshotV2({
-      start_date: filters.value.start_date || startDate.value,
-      end_date: filters.value.end_date || endDate.value,
+      start_date: isLast24Hours ? undefined : (filters.value.start_date || startDate.value),
+      end_date: isLast24Hours ? undefined : (filters.value.end_date || endDate.value),
+      period: isLast24Hours ? 'last24hours' : undefined,
       granularity: granularity.value,
       user_id: filters.value.user_id,
       model: filters.value.model,
@@ -517,7 +532,7 @@ const resetFilters = () => {
   const range = getLast24HoursRangeDates()
   startDate.value = range.start
   endDate.value = range.end
-  filters.value = { start_date: startDate.value, end_date: endDate.value, request_type: undefined, billing_type: null, billing_mode: undefined }
+  filters.value = { period: 'last24hours', request_type: undefined, billing_type: null, billing_mode: undefined }
   granularity.value = getGranularityForRange(startDate.value, endDate.value)
   applyFilters()
 }
@@ -821,6 +836,9 @@ const handleColumnClickOutside = (event: MouseEvent) => {
 
 onMounted(() => {
   applyRouteQueryFilters()
+  if (!filters.value.period) {
+    filters.value = { ...filters.value, period: 'last24hours', start_date: undefined, end_date: undefined }
+  }
   loadLogs()
   loadStats()
   loadModelStats(modelDistributionSource.value, true)

--- a/frontend/src/views/admin/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/admin/__tests__/DashboardView.spec.ts
@@ -43,13 +43,6 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 const createDashboardStats = (): DashboardStats => ({
   total_users: 0,
   today_new_users: 0,
@@ -72,6 +65,7 @@ const createDashboardStats = (): DashboardStats => ({
   total_tokens: 0,
   total_cost: 0,
   total_actual_cost: 0,
+  total_account_cost: 0,
   today_requests: 0,
   today_input_tokens: 0,
   today_output_tokens: 0,
@@ -80,6 +74,7 @@ const createDashboardStats = (): DashboardStats => ({
   today_tokens: 0,
   today_cost: 0,
   today_actual_cost: 0,
+  today_account_cost: 0,
   average_duration_ms: 0,
   uptime: 0,
   rpm: 0,
@@ -133,13 +128,11 @@ describe('admin DashboardView', () => {
 
     await flushPromises()
 
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
-
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
       granularity: 'hour'
     }))
   })

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -27,13 +27,6 @@ const messages: Record<string, string> = {
   'admin.usage.failedToLoadUser': 'Failed to load user',
 }
 
-const formatLocalDate = (date: Date): string => {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return `${year}-${month}-${day}`
-}
-
 vi.mock('@/api/admin', () => ({
   adminAPI: {
     usage: {
@@ -157,7 +150,6 @@ describe('admin UsageView distribution metric toggles', () => {
   })
 
   it('keeps previous model stats visible during refresh until new data arrives', async () => {
-    // 首次加载返回 A
     getModelStats.mockResolvedValueOnce({ models: [{ model: 'A', total_tokens: 10 }] })
 
     const wrapper = mount(UsageView, {
@@ -174,14 +166,12 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'A', total_tokens: 10 }])
 
-    // 刷新:让第二次 getModelStats 处于 pending,断言旧数据 A 仍在(不被清空成 [])
     let resolveSecond: (v: any) => void = () => {}
     getModelStats.mockReturnValueOnce(new Promise((res) => { resolveSecond = res }))
     ;(wrapper.vm as any).refreshData()
     await flushPromises()
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'A', total_tokens: 10 }])
 
-    // 新数据到达后替换为 B
     resolveSecond({ models: [{ model: 'B', total_tokens: 20 }] })
     await flushPromises()
     expect((wrapper.vm as any).requestedModelStats).toEqual([{ model: 'B', total_tokens: 20 }])
@@ -214,11 +204,10 @@ describe('admin UsageView distribution metric toggles', () => {
     await flushPromises()
 
     expect(getSnapshotV2).toHaveBeenCalledTimes(1)
-    const now = new Date()
-    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000)
     expect(getSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
-      start_date: formatLocalDate(yesterday),
-      end_date: formatLocalDate(now),
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
       granularity: 'hour'
     }))
 
@@ -338,7 +327,6 @@ describe('admin UsageView errors tab filter forwarding', () => {
     vi.advanceTimersByTime(120)
     await flushPromises()
 
-    // 模拟用户在过滤器里选择了模型/账户/分组
     const vm = wrapper.vm as any
     vm.filters.model = 'gpt-5.3-codex'
     vm.filters.account_id = 7

--- a/frontend/src/views/user/DashboardView.vue
+++ b/frontend/src/views/user/DashboardView.vue
@@ -4,7 +4,7 @@
       <div v-if="loading" class="flex items-center justify-center py-12"><LoadingSpinner /></div>
       <template v-else-if="stats">
         <UserDashboardStats :stats="stats" :balance="user?.balance || 0" :is-simple="authStore.isSimpleMode" :platform-quotas="platformQuotas" />
-        <UserDashboardCharts v-model:startDate="startDate" v-model:endDate="endDate" v-model:granularity="granularity" :loading="loadingCharts" :trend="trendData" :models="modelStats" @dateRangeChange="loadCharts" @granularityChange="loadCharts" @refresh="refreshAll" />
+        <UserDashboardCharts v-model:startDate="startDate" v-model:endDate="endDate" v-model:granularity="granularity" :loading="loadingCharts" :trend="trendData" :models="modelStats" @dateRangeChange="handleDateRangeChange" @granularityChange="loadCharts" @refresh="refreshAll" />
         <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <div class="lg:col-span-2"><UserDashboardRecentUsage :data="recentUsage" :loading="loadingUsage" /></div>
           <div class="lg:col-span-1"><UserDashboardQuickActions /></div>
@@ -19,7 +19,7 @@ import { ref, computed, onMounted } from 'vue'; import { useAuthStore } from '@/
 import AppLayout from '@/components/layout/AppLayout.vue'; import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
 import UserDashboardStats from '@/components/user/dashboard/UserDashboardStats.vue'; import UserDashboardCharts from '@/components/user/dashboard/UserDashboardCharts.vue'
 import UserDashboardRecentUsage from '@/components/user/dashboard/UserDashboardRecentUsage.vue'; import UserDashboardQuickActions from '@/components/user/dashboard/UserDashboardQuickActions.vue'
-import type { UsageLog, TrendDataPoint, ModelStat, PlatformQuotaItem } from '@/types'
+import type { UsageLog, TrendDataPoint, ModelStat, PlatformQuotaItem, UsageQueryParams } from '@/types'
 import { getMyPlatformQuotas } from '@/api/user'
 import { formatDateLocalInput } from '@/utils/format'
 
@@ -27,13 +27,45 @@ const authStore = useAuthStore(); const user = computed(() => authStore.user)
 const stats = ref<UserStatsType | null>(null); const loading = ref(false); const loadingUsage = ref(false); const loadingCharts = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const modelStats = ref<ModelStat[]>([]); const recentUsage = ref<UsageLog[]>([])
 const platformQuotas = ref<PlatformQuotaItem[] | null>(null)
+type DateRangePreset = 'last24Hours' | null
 
 const startDate = ref(formatDateLocalInput(new Date(Date.now() - 6 * 86400000))); const endDate = ref(formatDateLocalInput(new Date())); const granularity = ref('day')
+const activeDatePreset = ref<DateRangePreset>(null)
+
+const buildRangeParams = (): Pick<UsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    const end = new Date()
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000)
+    startDate.value = formatDateLocalInput(start)
+    endDate.value = formatDateLocalInput(end)
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value
+  }
+}
 
 const loadStats = async () => { loading.value = true; try { await authStore.refreshUser(); stats.value = await usageAPI.getDashboardStats() } catch (error) { console.error('Failed to load dashboard stats:', error) } finally { loading.value = false } }
-const loadCharts = async () => { loadingCharts.value = true; try { const res = await Promise.all([usageAPI.getDashboardTrend({ start_date: startDate.value, end_date: endDate.value, granularity: granularity.value as any }), usageAPI.getDashboardModels({ start_date: startDate.value, end_date: endDate.value })]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
-const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.getByDateRange(startDate.value, endDate.value); recentUsage.value = res.items.slice(0, 5) } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
+const loadCharts = async () => { loadingCharts.value = true; try { const rangeParams = buildRangeParams(); const res = await Promise.all([usageAPI.getDashboardTrend({ ...rangeParams, granularity: granularity.value as any }), usageAPI.getDashboardModels(rangeParams)]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
+const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.query({ page: 1, page_size: 5, sort_by: 'created_at', sort_order: 'desc', ...buildRangeParams() }); recentUsage.value = res.items } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
 const loadPlatformQuotas = async () => { try { const data = await getMyPlatformQuotas(); platformQuotas.value = data.platform_quotas ?? [] } catch (error) { console.warn('Failed to load platform quotas:', error); platformQuotas.value = [] } }
+const handleDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
+  startDate.value = range.startDate
+  endDate.value = range.endDate
+  const start = new Date(range.startDate)
+  const end = new Date(range.endDate)
+  const daysDiff = Math.ceil((end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24))
+  granularity.value = daysDiff <= 1 ? 'hour' : 'day'
+  loadCharts()
+  loadRecent()
+}
 const refreshAll = () => { loadStats(); loadCharts(); loadRecent(); loadPlatformQuotas() }
 
 onMounted(() => { refreshAll() })

--- a/frontend/src/views/user/UsageView.vue
+++ b/frontend/src/views/user/UsageView.vue
@@ -250,6 +250,7 @@ import { COMMON_ERROR_STATUS_CODES } from '@/utils/errorBadges'
 
 const { t } = useI18n()
 const appStore = useAppStore()
+type DateRangePreset = 'last24Hours' | null
 
 type DistributionMetric = 'tokens' | 'actual_cost'
 type EndpointSource = 'inbound' | 'upstream' | 'path'
@@ -342,6 +343,7 @@ const getGranularityForRange = (start: string, end: string): 'day' | 'hour' => {
 const defaultRange = getLast24HoursRangeDates()
 const startDate = ref(defaultRange.start)
 const endDate = ref(defaultRange.end)
+const activeDatePreset = ref<DateRangePreset>('last24Hours')
 const granularity = ref<'day' | 'hour'>(getGranularityForRange(startDate.value, endDate.value))
 
 const modelDistributionMetric = ref<DistributionMetric>('tokens')
@@ -352,6 +354,7 @@ const activeTab = ref<'usage' | 'errors'>('usage')
 const errorViewEnabled = computed(() => appStore.cachedPublicSettings?.allow_user_view_error_requests ?? false)
 
 const filters = ref<UsageQueryParams>({
+  period: 'last24hours',
   start_date: startDate.value,
   end_date: endDate.value,
   request_type: undefined,
@@ -359,6 +362,20 @@ const filters = ref<UsageQueryParams>({
   billing_mode: null,
 })
 
+const buildRangeParams = (): Pick<UsageQueryParams, 'period' | 'start_date' | 'end_date'> => {
+  if (activeDatePreset.value === 'last24Hours') {
+    return {
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }
+  }
+  return {
+    period: undefined,
+    start_date: startDate.value,
+    end_date: endDate.value,
+  }
+}
 const pagination = reactive({
   page: 1,
   page_size: getPersistedPageSize(),
@@ -414,8 +431,7 @@ const normalizedFilters = computed<UsageQueryParams>(() => {
   const legacyStream = requestType ? requestTypeToLegacyStream(requestType) : filters.value.stream
   return {
     ...filters.value,
-    start_date: startDate.value,
-    end_date: endDate.value,
+    ...buildRangeParams(),
     stream: legacyStream === null ? undefined : legacyStream,
   }
 })
@@ -544,9 +560,11 @@ const refreshData = () => {
 
 const resetFilters = () => {
   const range = getLast24HoursRangeDates()
+  activeDatePreset.value = 'last24Hours'
   startDate.value = range.start
   endDate.value = range.end
   filters.value = {
+    period: 'last24hours',
     start_date: range.start,
     end_date: range.end,
     request_type: undefined,
@@ -562,8 +580,10 @@ const resetFilters = () => {
 }
 
 const onDateRangeChange = (range: { startDate: string; endDate: string; preset: string | null }) => {
+  activeDatePreset.value = range.preset === 'last24Hours' ? 'last24Hours' : null
   startDate.value = range.startDate
   endDate.value = range.endDate
+  filters.value.period = activeDatePreset.value === 'last24Hours' ? 'last24hours' : undefined
   filters.value.start_date = range.startDate
   filters.value.end_date = range.endDate
   granularity.value = getGranularityForRange(range.startDate, range.endDate)

--- a/frontend/src/views/user/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/user/__tests__/DashboardView.spec.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import DashboardView from '../DashboardView.vue'
+
+const { refreshUser, getDashboardStats, getDashboardTrend, getDashboardModels, query, getMyPlatformQuotas } = vi.hoisted(() => ({
+  refreshUser: vi.fn(),
+  getDashboardStats: vi.fn(),
+  getDashboardTrend: vi.fn(),
+  getDashboardModels: vi.fn(),
+  query: vi.fn(),
+  getMyPlatformQuotas: vi.fn(),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { balance: 0 },
+    isSimpleMode: false,
+    refreshUser,
+  }),
+}))
+
+vi.mock('@/api/usage', () => ({
+  usageAPI: {
+    getDashboardStats,
+    getDashboardTrend,
+    getDashboardModels,
+    query,
+  },
+}))
+
+vi.mock('@/api/user', () => ({
+  getMyPlatformQuotas,
+}))
+
+const UserDashboardChartsStub = {
+  template: '<button data-test="last24hours" @click="emitPreset">last24hours</button>',
+  methods: {
+    emitPreset() {
+      this.$emit('update:startDate', '2026-03-07')
+      this.$emit('update:endDate', '2026-03-08')
+      this.$emit('dateRangeChange', {
+        startDate: '2026-03-07',
+        endDate: '2026-03-08',
+        preset: 'last24Hours'
+      })
+    }
+  }
+}
+
+describe('user DashboardView', () => {
+  beforeEach(() => {
+    refreshUser.mockReset()
+    getDashboardStats.mockReset()
+    getDashboardTrend.mockReset()
+    getDashboardModels.mockReset()
+    query.mockReset()
+    getMyPlatformQuotas.mockReset()
+
+    refreshUser.mockResolvedValue(undefined)
+    getDashboardStats.mockResolvedValue({})
+    getDashboardTrend.mockResolvedValue({ trend: [], start_date: '', end_date: '', granularity: 'day' })
+    getDashboardModels.mockResolvedValue({ models: [], start_date: '', end_date: '' })
+    query.mockResolvedValue({ items: [], total: 0, pages: 0 })
+    getMyPlatformQuotas.mockResolvedValue({ platform_quotas: [] })
+  })
+
+  it('uses rolling last24hours period for charts and recent usage when selected', async () => {
+    const wrapper = mount(DashboardView, {
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          LoadingSpinner: true,
+          UserDashboardStats: true,
+          UserDashboardCharts: UserDashboardChartsStub,
+          UserDashboardRecentUsage: true,
+          UserDashboardQuickActions: true,
+        },
+      },
+    })
+
+    await flushPromises()
+    getDashboardTrend.mockClear()
+    getDashboardModels.mockClear()
+    query.mockClear()
+
+    await wrapper.get('[data-test="last24hours"]').trigger('click')
+    await flushPromises()
+
+    expect(getDashboardTrend).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      granularity: 'hour'
+    }))
+    expect(getDashboardModels).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      page_size: 5
+    }))
+  })
+})

--- a/frontend/src/views/user/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/user/__tests__/UsageView.spec.ts
@@ -127,7 +127,7 @@ const usageLog = {
   stream: false,
 }
 
-function mountUsageView() {
+function mountUsageView(overrides: Record<string, any> = {}) {
   return mount(UsageView, {
     global: {
       stubs: {
@@ -142,6 +142,7 @@ function mountUsageView() {
         GroupDistributionChart: chartStub,
         EndpointDistributionChart: chartStub,
         TokenUsageTrend: chartStub,
+        ...overrides,
       },
     },
   })
@@ -205,6 +206,56 @@ describe('user UsageView', () => {
     }))
     expect(list).toHaveBeenCalledWith(1, 100)
     expect(getAvailable).toHaveBeenCalled()
+  })
+
+  it('uses rolling last24hours period when the date picker preset is selected', async () => {
+    const DateRangePickerStub = {
+      template: '<button data-test="last24hours" @click="emitPreset">last24hours</button>',
+      methods: {
+        emitPreset() {
+          this.$emit('update:startDate', '2026-03-07')
+          this.$emit('update:endDate', '2026-03-08')
+          this.$emit('change', {
+            startDate: '2026-03-07',
+            endDate: '2026-03-08',
+            preset: 'last24Hours',
+          })
+        },
+      },
+    }
+
+    const wrapper = mountUsageView({ DateRangePicker: DateRangePickerStub })
+    await flushPromises()
+
+    query.mockClear()
+    getStats.mockClear()
+    getDashboardModels.mockClear()
+    getDashboardSnapshotV2.mockClear()
+
+    await wrapper.get('[data-test="last24hours"]').trigger('click')
+    await flushPromises()
+
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }), expect.anything())
+    expect(getStats).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
+    expect(getDashboardModels).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+      model_source: 'requested',
+    }))
+    expect(getDashboardSnapshotV2).toHaveBeenCalledWith(expect.objectContaining({
+      period: 'last24hours',
+      start_date: undefined,
+      end_date: undefined,
+    }))
   })
 
   it('exports csv with current filters and without admin-only fields', async () => {


### PR DESCRIPTION
## 说明

- 修复 admin/user 的 usage 与 dashboard 中「最近 24 小时」时间窗口不准确的问题
- 原先前端用日历日期 `start_date/end_date` 近似 24 小时，实际会变成「今天 + 昨天」两天整段，而不是滚动的最近 24 小时
- 统一改为请求 `period=last24hours`，由后端按用户时区计算真实的滚动窗口 `[now-24h, now]`
- 响应补充 `start_time` / `end_time` / `period` 元数据，避免仅按日期展示时丢失时间精度
- 补充后端与前端回归测试

## 背景

旧 PR #1716 长期未合并且与最新 `main` 产生冲突，已关闭。本 PR 基于最新上游 `main` 重新实现同一修复。

## 验证

- `go test ./internal/pkg/timezone ./internal/handler ./internal/handler/admin`
- `pnpm exec vitest run src/views/user/__tests__/DashboardView.spec.ts src/views/user/__tests__/UsageView.spec.ts src/views/admin/__tests__/DashboardView.spec.ts src/views/admin/__tests__/UsageView.spec.ts`