### PR TITLE
修复 Codex 模型清单转发超时与账号故障切换

### DIFF
--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -25,6 +25,8 @@ const (
 	EndpointImagesEdits       = "/v1/images/edits"
 	EndpointVideosGenerations = "/v1/videos/generations"
 	EndpointVideos            = "/v1/videos"
+	EndpointModels            = "/v1/models"
+	EndpointCodexModels       = "/backend-api/codex/models"
 	EndpointGeminiModels      = "/v1beta/models"
 )
 
@@ -90,6 +92,8 @@ func NormalizeInboundEndpoint(path string) string {
 		return EndpointVideosGenerations
 	case strings.Contains(path, EndpointVideos) || strings.Contains(path, "/videos/"):
 		return EndpointVideos
+	case strings.Contains(path, EndpointModels) || isBareOrSubpathOf(strings.TrimRight(path, "/"), EndpointCodexModels):
+		return EndpointModels
 	case strings.Contains(path, EndpointResponsesCompact) || isResponsesCompactAliasPath(path):
 		return EndpointResponsesCompact
 	case strings.Contains(path, EndpointResponses) || isResponsesRootAliasPath(path):
@@ -173,6 +177,9 @@ func DeriveUpstreamEndpoint(inbound, rawRequestPath, platform string) string {
 
 	switch platform {
 	case service.PlatformOpenAI, service.PlatformGrok:
+		if inbound == EndpointModels && platform == service.PlatformOpenAI {
+			return EndpointCodexModels
+		}
 		if inbound == EndpointEmbeddings || inbound == EndpointAlphaSearch || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits || inbound == EndpointVideosGenerations || inbound == EndpointVideos {
 			return inbound
 		}
@@ -288,6 +295,9 @@ func GetInboundEndpoint(c *gin.Context) string {
 // and the account platform. Handlers call this after scheduling an
 // account, passing account.Platform.
 func GetUpstreamEndpoint(c *gin.Context, platform string) string {
+	if actual := service.GetActualOpenAIUpstreamEndpoint(c); actual != "" {
+		return actual
+	}
 	inbound := GetInboundEndpoint(c)
 	rawPath := ""
 	if c != nil && c.Request != nil && c.Request.URL != nil {

--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -33,6 +33,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/v1/images/edits", EndpointImagesEdits},
 		{"/v1/videos/generations", EndpointVideosGenerations},
 		{"/v1/videos/req_123", EndpointVideos},
+		{"/v1/models", EndpointModels},
 		{"/v1beta/models", EndpointGeminiModels},
 
 		// Prefixed paths (antigravity, openai) — root Responses.
@@ -40,6 +41,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/openai/v1/responses", EndpointResponses},
 		{"/openai/v1/images/generations", EndpointImagesGenerations},
 		{"/openai/v1/images/edits", EndpointImagesEdits},
+		{"/openai/v1/models", EndpointModels},
 		{"/antigravity/v1beta/models/gemini:generateContent", EndpointGeminiModels},
 
 		// Prefixed paths — "/responses/compact" is its OWN distinct
@@ -58,6 +60,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/backend-api/codex/responses/compact", EndpointResponsesCompact},
 		{"/backend-api/codex/responses/compact/detail", EndpointResponsesCompact},
 		{"/backend-api/codex/alpha/search", EndpointAlphaSearch},
+		{"/backend-api/codex/models", EndpointModels},
 
 		// Must NOT generalize to arbitrary paths merely ending in
 		// "/responses" (or "/responses/compact") that are unrelated to
@@ -125,6 +128,7 @@ func TestDeriveUpstreamEndpoint(t *testing.T) {
 		{"openai alpha search", EndpointAlphaSearch, "/backend-api/codex/alpha/search", service.PlatformOpenAI, EndpointAlphaSearch},
 		{"openai image generations", EndpointImagesGenerations, "/v1/images/generations", service.PlatformOpenAI, EndpointImagesGenerations},
 		{"openai image edits", EndpointImagesEdits, "/openai/v1/images/edits", service.PlatformOpenAI, EndpointImagesEdits},
+		{"openai codex models", EndpointModels, "/v1/models", service.PlatformOpenAI, EndpointCodexModels},
 		{"grok chat defaults to responses without runtime result", EndpointChatCompletions, "/v1/chat/completions", service.PlatformGrok, EndpointResponses},
 		{"grok responses", EndpointResponses, "/v1/responses", service.PlatformGrok, EndpointResponses},
 		{"grok video generations", EndpointVideosGenerations, "/v1/videos/generations", service.PlatformGrok, EndpointVideosGenerations},
@@ -393,4 +397,14 @@ func TestGetUpstreamEndpoint_FullFlow(t *testing.T) {
 
 	got := GetUpstreamEndpoint(c, service.PlatformOpenAI)
 	require.Equal(t, "/v1/responses/compact", got)
+}
+
+func TestGetUpstreamEndpoint_PrefersActualOpenAIEndpoint(t *testing.T) {
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, EndpointModels+"?client_version=0.144.0", nil)
+	c.Set(ctxKeyInboundEndpoint, EndpointModels)
+	service.SetActualOpenAIUpstreamEndpoint(c, EndpointCodexModels)
+
+	require.Equal(t, EndpointCodexModels, GetUpstreamEndpoint(c, service.PlatformOpenAI))
 }

--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -8,6 +10,7 @@ import (
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
+	"go.uber.org/zap"
 )
 
 // CodexModels serves the Codex models manifest for Codex clients.
@@ -20,6 +23,9 @@ import (
 // see the account's real, always-current model entitlements instead of a
 // frozen local cache.
 func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
+	setOpsRequestContext(c, "", false)
+	setOpsEndpointContext(c, "", int16(service.RequestTypeSync))
+
 	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
 	if !ok || apiKey.Group == nil {
 		h.errorResponse(c, http.StatusUnauthorized, "invalid_request_error", "API key group is required")
@@ -30,24 +36,77 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 		return
 	}
 
-	account, err := h.gatewayService.SelectAccountForModel(c.Request.Context(), apiKey.GroupID, "", "")
-	if err != nil {
-		h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
-		return
+	requestCtx := c.Request.Context()
+	clientVersion := c.Query("client_version")
+	ifNoneMatch := c.GetHeader("If-None-Match")
+	failedAccountIDs := make(map[int64]struct{})
+	maxSwitches := h.maxAccountSwitches
+	if maxSwitches <= 0 {
+		maxSwitches = 3
 	}
+	switchCount := 0
+	var lastErr error
+	reqLog := requestLogger(
+		c,
+		"handler.openai_gateway.codex_models",
+		zap.Int64("api_key_id", apiKey.ID),
+		zap.Any("group_id", apiKey.GroupID),
+		zap.String("client_version", truncateString(clientVersion, 64)),
+	)
 
-	manifest, err := h.gatewayService.FetchCodexModelsManifest(c.Request.Context(), account, c.Query("client_version"), c.GetHeader("If-None-Match"))
-	if err != nil {
-		h.errorResponse(c, infraerrors.Code(err), "upstream_error", infraerrors.Message(err))
-		return
-	}
+	for {
+		account, err := h.gatewayService.SelectCodexModelsAccountWithExclusions(requestCtx, apiKey.GroupID, failedAccountIDs)
+		if err != nil {
+			if lastErr != nil {
+				h.errorResponse(c, infraerrors.Code(lastErr), "upstream_error", infraerrors.Message(lastErr))
+				return
+			}
+			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI OAuth accounts")
+			return
+		}
 
-	if manifest.ETag != "" {
-		c.Header("ETag", manifest.ETag)
+		setOpsSelectedAccount(c, account.ID, account.Platform)
+		service.SetActualOpenAIUpstreamEndpoint(c, EndpointCodexModels)
+		attemptETag := ifNoneMatch
+		if len(failedAccountIDs) > 0 {
+			attemptETag = ""
+		}
+
+		manifest, err := h.gatewayService.FetchCodexModelsManifestForRequest(requestCtx, c, account, clientVersion, attemptETag)
+		if err == nil {
+			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, true, nil)
+			if manifest.ETag != "" {
+				c.Header("ETag", manifest.ETag)
+			}
+			if manifest.NotModified {
+				c.Status(http.StatusNotModified)
+				return
+			}
+			c.Data(http.StatusOK, "application/json", manifest.Body)
+			return
+		}
+
+		h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
+		if requestCtx.Err() != nil || errors.Is(err, context.Canceled) {
+			return
+		}
+		if !service.IsCodexModelsManifestRetryable(err) {
+			h.errorResponse(c, infraerrors.Code(err), "upstream_error", infraerrors.Message(err))
+			return
+		}
+
+		failedAccountIDs[account.ID] = struct{}{}
+		lastErr = err
+		if switchCount >= maxSwitches {
+			h.errorResponse(c, infraerrors.Code(err), "upstream_error", infraerrors.Message(err))
+			return
+		}
+		switchCount++
+		h.gatewayService.RecordOpenAIAccountSwitch()
+		reqLog.Warn("openai_codex_models.upstream_failover_switching",
+			zap.Int64("account_id", account.ID),
+			zap.Int("switch_count", switchCount),
+			zap.Int("max_switches", maxSwitches),
+		)
 	}
-	if manifest.NotModified {
-		c.Status(http.StatusNotModified)
-		return
-	}
-	c.Data(http.StatusOK, "application/json", manifest.Body)
 }

--- a/backend/internal/handler/openai_codex_models_handler_test.go
+++ b/backend/internal/handler/openai_codex_models_handler_test.go
@@ -1,0 +1,266 @@
+package handler
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type codexModelsHandlerAccountRepo struct {
+	service.AccountRepository
+	accounts []service.Account
+}
+
+func (r codexModelsHandlerAccountRepo) GetByID(_ context.Context, id int64) (*service.Account, error) {
+	for i := range r.accounts {
+		if r.accounts[i].ID == id {
+			account := r.accounts[i]
+			return &account, nil
+		}
+	}
+	return nil, service.ErrNoAvailableAccounts
+}
+
+func (r codexModelsHandlerAccountRepo) ListSchedulableByGroupIDAndPlatform(_ context.Context, _ int64, platform string) ([]service.Account, error) {
+	return r.accountsForPlatform(platform), nil
+}
+
+func (r codexModelsHandlerAccountRepo) ListSchedulableByPlatform(_ context.Context, platform string) ([]service.Account, error) {
+	return r.accountsForPlatform(platform), nil
+}
+
+func (r codexModelsHandlerAccountRepo) ListSchedulableUngroupedByPlatform(_ context.Context, platform string) ([]service.Account, error) {
+	return r.accountsForPlatform(platform), nil
+}
+
+func (r codexModelsHandlerAccountRepo) accountsForPlatform(platform string) []service.Account {
+	out := make([]service.Account, 0, len(r.accounts))
+	for _, account := range r.accounts {
+		if account.Platform == platform {
+			out = append(out, account)
+		}
+	}
+	return out
+}
+
+type codexModelsHandlerUpstreamCall struct {
+	accountID   int64
+	ifNoneMatch string
+}
+
+type codexModelsHandlerUpstream struct {
+	service.HTTPUpstream
+	do    func(req *http.Request, accountID int64) (*http.Response, error)
+	calls []codexModelsHandlerUpstreamCall
+}
+
+func (u *codexModelsHandlerUpstream) Do(req *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
+	u.calls = append(u.calls, codexModelsHandlerUpstreamCall{
+		accountID:   accountID,
+		ifNoneMatch: req.Header.Get("If-None-Match"),
+	})
+	return u.do(req, accountID)
+}
+
+func newCodexModelsHandlerTestAccount(id int64, accountType string, priority int) service.Account {
+	credentials := map[string]any{"access_token": "token-" + strconv.FormatInt(id, 10)}
+	if accountType == service.AccountTypeAPIKey {
+		credentials = map[string]any{"api_key": "api-key"}
+	}
+	return service.Account{
+		ID:          id,
+		Name:        "account",
+		Platform:    service.PlatformOpenAI,
+		Type:        accountType,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Priority:    priority,
+		Credentials: credentials,
+	}
+}
+
+func newCodexModelsHandlerForTest(accounts []service.Account, upstream service.HTTPUpstream) *OpenAIGatewayHandler {
+	cfg := &config.Config{RunMode: config.RunModeSimple}
+	gatewayService := service.NewOpenAIGatewayService(
+		codexModelsHandlerAccountRepo{accounts: accounts},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		cfg,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		upstream,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	return &OpenAIGatewayHandler{gatewayService: gatewayService, maxAccountSwitches: 3}
+}
+
+func newCodexModelsHandlerContext(t *testing.T) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	groupID := int64(3131)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodGet, EndpointModels+"?client_version=0.144.0", nil)
+	c.Request.Header.Set("If-None-Match", `W/"cached-account-2"`)
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		ID:      99,
+		GroupID: &groupID,
+		Group: &service.Group{
+			ID:       groupID,
+			Platform: service.PlatformOpenAI,
+		},
+	})
+	return c, rec
+}
+
+func TestOpenAIGatewayHandlerCodexModels_FailsOverAndClearsETag(t *testing.T) {
+	tests := []struct {
+		name       string
+		firstError func() (*http.Response, error)
+	}{
+		{
+			name: "response header timeout",
+			firstError: func() (*http.Response, error) {
+				return nil, context.DeadlineExceeded
+			},
+		},
+		{
+			name: "upstream 500",
+			firstError: func() (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusInternalServerError,
+					Status:     "500 Internal Server Error",
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"temporary"}}`)),
+				}, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accounts := []service.Account{
+				newCodexModelsHandlerTestAccount(1, service.AccountTypeAPIKey, 0),
+				newCodexModelsHandlerTestAccount(2, service.AccountTypeOAuth, 1),
+				newCodexModelsHandlerTestAccount(3, service.AccountTypeOAuth, 2),
+			}
+			upstream := &codexModelsHandlerUpstream{do: func(_ *http.Request, accountID int64) (*http.Response, error) {
+				if accountID == 2 {
+					return tt.firstError()
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"ETag": []string{`W/"account-3"`}},
+					Body:       io.NopCloser(strings.NewReader(`{"models":[{"slug":"gpt-5.5"}]}`)),
+				}, nil
+			}}
+			handler := newCodexModelsHandlerForTest(accounts, upstream)
+			c, rec := newCodexModelsHandlerContext(t)
+
+			handler.CodexModels(c)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.JSONEq(t, `{"models":[{"slug":"gpt-5.5"}]}`, rec.Body.String())
+			require.Equal(t, []codexModelsHandlerUpstreamCall{
+				{accountID: 2, ifNoneMatch: `W/"cached-account-2"`},
+				{accountID: 3, ifNoneMatch: ""},
+			}, upstream.calls)
+			require.Equal(t, EndpointModels, GetInboundEndpoint(c))
+			require.Equal(t, EndpointCodexModels, GetUpstreamEndpoint(c, service.PlatformOpenAI))
+			require.Equal(t, int64(3), mustContextInt64(t, c, opsAccountIDKey))
+			require.Equal(t, int16(service.RequestTypeSync), mustContextInt16(t, c, opsRequestTypeKey))
+
+			rawEvents, ok := c.Get(service.OpsUpstreamErrorsKey)
+			require.True(t, ok)
+			events, ok := rawEvents.([]*service.OpsUpstreamErrorEvent)
+			require.True(t, ok)
+			require.Len(t, events, 1)
+			require.Equal(t, int64(2), events[0].AccountID)
+		})
+	}
+}
+
+func TestOpenAIGatewayHandlerCodexModels_DoesNotFailOverCanceledRequest(t *testing.T) {
+	accounts := []service.Account{
+		newCodexModelsHandlerTestAccount(1, service.AccountTypeOAuth, 0),
+		newCodexModelsHandlerTestAccount(2, service.AccountTypeOAuth, 1),
+	}
+	upstream := &codexModelsHandlerUpstream{do: func(_ *http.Request, _ int64) (*http.Response, error) {
+		return nil, context.Canceled
+	}}
+	handler := newCodexModelsHandlerForTest(accounts, upstream)
+	c, _ := newCodexModelsHandlerContext(t)
+
+	handler.CodexModels(c)
+
+	require.Len(t, upstream.calls, 1)
+	require.Equal(t, int64(1), upstream.calls[0].accountID)
+}
+
+func TestOpenAIGatewayHandlerCodexModels_StopsAtConfiguredSwitchLimit(t *testing.T) {
+	accounts := []service.Account{
+		newCodexModelsHandlerTestAccount(1, service.AccountTypeOAuth, 0),
+		newCodexModelsHandlerTestAccount(2, service.AccountTypeOAuth, 1),
+		newCodexModelsHandlerTestAccount(3, service.AccountTypeOAuth, 2),
+	}
+	upstream := &codexModelsHandlerUpstream{do: func(_ *http.Request, _ int64) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
+	}}
+	handler := newCodexModelsHandlerForTest(accounts, upstream)
+	handler.maxAccountSwitches = 1
+	c, rec := newCodexModelsHandlerContext(t)
+
+	handler.CodexModels(c)
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Len(t, upstream.calls, 2)
+	require.Equal(t, int64(1), upstream.calls[0].accountID)
+	require.Equal(t, int64(2), upstream.calls[1].accountID)
+	require.Equal(t, int64(2), mustContextInt64(t, c, opsAccountIDKey))
+	rawEvents, ok := c.Get(service.OpsUpstreamErrorsKey)
+	require.True(t, ok)
+	events, ok := rawEvents.([]*service.OpsUpstreamErrorEvent)
+	require.True(t, ok)
+	require.Len(t, events, 2)
+}
+
+func mustContextInt64(t *testing.T, c *gin.Context, key string) int64 {
+	t.Helper()
+	value, ok := c.Get(key)
+	require.True(t, ok)
+	result, ok := value.(int64)
+	require.True(t, ok)
+	return result
+}
+
+func mustContextInt16(t *testing.T, c *gin.Context, key string) int16 {
+	t.Helper()
+	value, ok := c.Get(key)
+	require.True(t, ok)
+	result, ok := value.(int16)
+	require.True(t, ok)
+	return result
+}

--- a/backend/internal/service/openai_codex_models_scheduling_test.go
+++ b/backend/internal/service/openai_codex_models_scheduling_test.go
@@ -1,0 +1,70 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelectCodexModelsAccountWithExclusions_OnlySelectsOpenAIOAuth(t *testing.T) {
+	accounts := []Account{
+		{
+			ID:          1,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Priority:    0,
+			Credentials: map[string]any{"api_key": "test-api-key"},
+		},
+		{
+			ID:          2,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Priority:    1,
+			Credentials: map[string]any{"access_token": "test-access-token"},
+		},
+	}
+	svc := &OpenAIGatewayService{accountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts}}
+
+	account, err := svc.SelectCodexModelsAccountWithExclusions(context.Background(), nil, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(2), account.ID)
+}
+
+func TestSelectCodexModelsAccountWithExclusions_HonorsExclusions(t *testing.T) {
+	accounts := []Account{
+		{
+			ID:          1,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Priority:    0,
+			Credentials: map[string]any{"access_token": "token-1"},
+		},
+		{
+			ID:          2,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Priority:    1,
+			Credentials: map[string]any{"access_token": "token-2"},
+		},
+	}
+	svc := &OpenAIGatewayService{accountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts}}
+
+	account, err := svc.SelectCodexModelsAccountWithExclusions(
+		context.Background(),
+		nil,
+		map[int64]struct{}{1: {}},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, int64(2), account.ID)
+}

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -2,14 +2,15 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
-	"github.com/Wei-Shaw/sub2api/internal/pkg/httpclient"
+	"github.com/gin-gonic/gin"
 )
 
 // chatgptCodexModelsURL is the ChatGPT Codex models manifest endpoint.
@@ -26,6 +27,42 @@ type CodexModelsManifest struct {
 	NotModified bool
 }
 
+type codexModelsManifestError struct {
+	err       error
+	retryable bool
+}
+
+func (e *codexModelsManifestError) Error() string {
+	if e == nil || e.err == nil {
+		return "codex models manifest request failed"
+	}
+	return e.err.Error()
+}
+
+func (e *codexModelsManifestError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
+
+// IsCodexModelsManifestRetryable reports whether a models manifest failure is
+// scoped to the selected account/upstream path and may be retried on another
+// OAuth account. Client cancellation and request-wide context expiry are never
+// retryable.
+func IsCodexModelsManifestRetryable(err error) bool {
+	var manifestErr *codexModelsManifestError
+	return errors.As(err, &manifestErr) && manifestErr.retryable
+}
+
+func newCodexModelsManifestError(status int, reason, message string, retryable bool, cause error) error {
+	appErr := infraerrors.New(status, reason, message)
+	if cause != nil {
+		appErr = appErr.WithCause(cause)
+	}
+	return &codexModelsManifestError{err: appErr, retryable: retryable}
+}
+
 // FetchCodexModelsManifest fetches the live Codex models manifest from the
 // ChatGPT backend using the account's OAuth credentials.
 //
@@ -34,16 +71,52 @@ type CodexModelsManifest struct {
 // to chase upstream changes. Passing it through keeps the gateway
 // schema-agnostic and always reflects the account's real entitlements.
 func (s *OpenAIGatewayService) FetchCodexModelsManifest(ctx context.Context, account *Account, clientVersion, ifNoneMatch string) (*CodexModelsManifest, error) {
+	return s.fetchCodexModelsManifest(ctx, nil, account, clientVersion, ifNoneMatch)
+}
+
+// FetchCodexModelsManifestForRequest is the request-aware variant used by the
+// gateway handler. It records each failed upstream attempt in the shared Ops
+// context while preserving the public context-only method for other callers.
+func (s *OpenAIGatewayService) FetchCodexModelsManifestForRequest(ctx context.Context, c *gin.Context, account *Account, clientVersion, ifNoneMatch string) (*CodexModelsManifest, error) {
+	return s.fetchCodexModelsManifest(ctx, c, account, clientVersion, ifNoneMatch)
+}
+
+func (s *OpenAIGatewayService) fetchCodexModelsManifest(ctx context.Context, c *gin.Context, account *Account, clientVersion, ifNoneMatch string) (*CodexModelsManifest, error) {
 	if account == nil {
-		return nil, infraerrors.New(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_ACCOUNT_REQUIRED", "account is required")
+		return nil, newCodexModelsManifestError(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_ACCOUNT_REQUIRED", "account is required", false, nil)
 	}
 	credAccount, err := resolveCredentialAccount(ctx, s.accountRepo, account)
 	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_CREDENTIALS_FAILED", "resolve credential account: %v", err)
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:    account.Platform,
+			AccountID:   account.ID,
+			AccountName: account.Name,
+			Kind:        "request_error",
+			Message:     safeErr,
+		})
+		return nil, newCodexModelsManifestError(http.StatusBadGateway, "OPENAI_CODEX_MODELS_CREDENTIALS_FAILED", "resolve Codex models credential account failed", true, err)
 	}
-	accessToken := credAccount.GetOpenAIAccessToken()
-	if accessToken == "" {
-		return nil, infraerrors.New(http.StatusBadGateway, "OPENAI_CODEX_MODELS_TOKEN_MISSING", "account has no Codex backend access token")
+	accessToken, authType, err := s.GetAccessToken(ctx, credAccount)
+	if err != nil || authType != "oauth" || strings.TrimSpace(accessToken) == "" {
+		if err == nil {
+			err = errors.New("account has no Codex backend OAuth access token")
+		}
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:    account.Platform,
+			AccountID:   account.ID,
+			AccountName: account.Name,
+			Kind:        "request_error",
+			Message:     safeErr,
+		})
+		retryable := ctx == nil || ctx.Err() == nil
+		return nil, newCodexModelsManifestError(http.StatusBadGateway, "OPENAI_CODEX_MODELS_TOKEN_MISSING", "account has no usable Codex backend access token", retryable, err)
+	}
+	if s.httpUpstream == nil {
+		return nil, newCodexModelsManifestError(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_UPSTREAM_NOT_CONFIGURED", "Codex models upstream transport is not configured", false, nil)
 	}
 
 	clientVersion = strings.TrimSpace(clientVersion)
@@ -52,11 +125,10 @@ func (s *OpenAIGatewayService) FetchCodexModelsManifest(ctx context.Context, acc
 	}
 	requestURL := chatgptCodexModelsURL + "?client_version=" + url.QueryEscape(clientVersion)
 
-	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, requestURL, nil)
+	requestCtx := WithHTTPUpstreamProfile(ctx, HTTPUpstreamProfileOpenAI)
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, nil)
 	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_REQUEST_FAILED", "create codex models request: %v", err)
+		return nil, newCodexModelsManifestError(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_REQUEST_FAILED", "create Codex models request failed", false, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+accessToken)
 	req.Header.Set("Accept", "application/json")
@@ -69,21 +141,22 @@ func (s *OpenAIGatewayService) FetchCodexModelsManifest(ctx context.Context, acc
 	setOpenAIChatGPTAccountHeaders(req.Header, credAccount)
 
 	proxyURL := ""
-	if account.ProxyID != nil && account.Proxy != nil {
+	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	client, err := httpclient.GetClient(httpclient.Options{
-		ProxyURL:              proxyURL,
-		Timeout:               15 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
-	})
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
 	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_CODEX_MODELS_PROXY_INVALID", "invalid proxy configuration: %v", err)
+		handledErr := s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		retryable := ctx == nil || ctx.Err() == nil
+		if errors.Is(err, context.Canceled) {
+			retryable = false
+		}
+		return nil, newCodexModelsManifestError(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "codex models manifest request failed: "+safeErr, retryable, handledErr)
 	}
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "codex models manifest request failed: %v", err)
+	if resp == nil {
+		err = errors.New("upstream returned no response")
+		return nil, newCodexModelsManifestError(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "codex models manifest request failed: upstream returned no response", true, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
@@ -92,16 +165,61 @@ func (s *OpenAIGatewayService) FetchCodexModelsManifest(ctx context.Context, acc
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
-		message := strings.TrimSpace(string(body))
+		message := strings.TrimSpace(extractUpstreamErrorMessage(body))
+		if message == "" {
+			message = strings.TrimSpace(string(body))
+		}
+		message = sanitizeUpstreamErrorMessage(message)
 		if message == "" {
 			message = resp.Status
 		}
-		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "codex models manifest upstream error %d: %s", resp.StatusCode, message)
+		upstreamDetail := ""
+		if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+			maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+			if maxBytes <= 0 {
+				maxBytes = 2048
+			}
+			upstreamDetail = truncateString(string(body), maxBytes)
+		}
+		setOpsUpstreamError(c, resp.StatusCode, message, upstreamDetail)
+		retryable := resp.StatusCode == http.StatusUnauthorized ||
+			resp.StatusCode == http.StatusForbidden ||
+			resp.StatusCode == http.StatusTooManyRequests ||
+			resp.StatusCode >= http.StatusInternalServerError
+		kind := "http_error"
+		if retryable {
+			kind = "failover"
+			s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body)
+		}
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  resp.Header.Get("x-request-id"),
+			UpstreamURL:        safeUpstreamURL(requestURL),
+			Kind:               kind,
+			Message:            message,
+			Detail:             upstreamDetail,
+		})
+		clientMessage := fmt.Sprintf("codex models manifest upstream error %d: %s", resp.StatusCode, message)
+		return nil, newCodexModelsManifestError(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", clientMessage, retryable, nil)
 	}
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, codexModelsManifestBodyLimit))
 	if err != nil {
-		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "read codex models manifest response: %v", err)
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, resp.StatusCode, safeErr, "")
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamURL:        safeUpstreamURL(requestURL),
+			Kind:               "request_error",
+			Message:            safeErr,
+		})
+		return nil, newCodexModelsManifestError(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "read Codex models manifest response failed", true, err)
 	}
 	return &CodexModelsManifest{Body: body, ETag: resp.Header.Get("ETag")}, nil
 }

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -2,10 +2,36 @@ package service
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 )
+
+type codexModelsTestHTTPUpstream struct {
+	HTTPUpstream
+	do func(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error)
+}
+
+type codexModelsTokenCache struct {
+	OpenAITokenCache
+	token string
+}
+
+func (c codexModelsTokenCache) GetAccessToken(context.Context, string) (string, error) {
+	return c.token, nil
+}
+
+func (u *codexModelsTestHTTPUpstream) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	if u.do != nil {
+		return u.do(req, proxyURL, accountID, accountConcurrency)
+	}
+	return http.DefaultClient.Do(req)
+}
+
+func newCodexModelsTestService() *OpenAIGatewayService {
+	return &OpenAIGatewayService{httpUpstream: &codexModelsTestHTTPUpstream{}}
+}
 
 func newCodexModelsTestAccount() *Account {
 	return &Account{
@@ -38,7 +64,7 @@ func TestFetchCodexModelsManifestPassthrough(t *testing.T) {
 	chatgptCodexModelsURL = server.URL
 	defer func() { chatgptCodexModelsURL = original }()
 
-	s := &OpenAIGatewayService{}
+	s := newCodexModelsTestService()
 	manifest, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "0.137.0", "")
 	if err != nil {
 		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
@@ -76,7 +102,7 @@ func TestFetchCodexModelsManifestDefaultClientVersion(t *testing.T) {
 	chatgptCodexModelsURL = server.URL
 	defer func() { chatgptCodexModelsURL = original }()
 
-	s := &OpenAIGatewayService{}
+	s := newCodexModelsTestService()
 	if _, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "", ""); err != nil {
 		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
 	}
@@ -98,7 +124,7 @@ func TestFetchCodexModelsManifestNotModified(t *testing.T) {
 	chatgptCodexModelsURL = server.URL
 	defer func() { chatgptCodexModelsURL = original }()
 
-	s := &OpenAIGatewayService{}
+	s := newCodexModelsTestService()
 	manifest, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "0.137.0", `W/"abc123"`)
 	if err != nil {
 		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
@@ -121,7 +147,7 @@ func TestFetchCodexModelsManifestUpstreamError(t *testing.T) {
 	chatgptCodexModelsURL = server.URL
 	defer func() { chatgptCodexModelsURL = original }()
 
-	s := &OpenAIGatewayService{}
+	s := newCodexModelsTestService()
 	if _, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "0.137.0", ""); err == nil {
 		t.Fatal("expected error for upstream 500, got nil")
 	}
@@ -131,8 +157,176 @@ func TestFetchCodexModelsManifestMissingToken(t *testing.T) {
 	account := newCodexModelsTestAccount()
 	delete(account.Credentials, "access_token")
 
-	s := &OpenAIGatewayService{}
+	s := newCodexModelsTestService()
 	if _, err := s.FetchCodexModelsManifest(context.Background(), account, "0.137.0", ""); err == nil {
 		t.Fatal("expected error for missing access token, got nil")
+	}
+}
+
+func TestFetchCodexModelsManifestUsesOpenAIHTTPUpstreamProfile(t *testing.T) {
+	account := newCodexModelsTestAccount()
+	account.Concurrency = 7
+	account.Proxy = &Proxy{Host: "127.0.0.1", Port: 7890, Protocol: "http"}
+
+	var gotProfile HTTPUpstreamProfile
+	var gotProxyURL string
+	var gotAccountID int64
+	var gotConcurrency int
+	var hadDeadline bool
+	upstream := &codexModelsTestHTTPUpstream{do: func(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+		gotProfile = HTTPUpstreamProfileFromContext(req.Context())
+		gotProxyURL = proxyURL
+		gotAccountID = accountID
+		gotConcurrency = accountConcurrency
+		_, hadDeadline = req.Context().Deadline()
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       http.NoBody,
+		}, nil
+	}}
+	s := &OpenAIGatewayService{httpUpstream: upstream}
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), account, "0.144.0", "")
+
+	if err != nil {
+		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
+	}
+	if gotProfile != HTTPUpstreamProfileOpenAI {
+		t.Fatalf("HTTP upstream profile: got %q, want %q", gotProfile, HTTPUpstreamProfileOpenAI)
+	}
+	if gotProxyURL != account.Proxy.URL() {
+		t.Fatalf("proxy URL: got %q, want %q", gotProxyURL, account.Proxy.URL())
+	}
+	if gotAccountID != account.ID || gotConcurrency != account.Concurrency {
+		t.Fatalf("account transport identity: got id=%d concurrency=%d", gotAccountID, gotConcurrency)
+	}
+	if hadDeadline {
+		t.Fatal("models request unexpectedly installed a service-local deadline")
+	}
+}
+
+func TestFetchCodexModelsManifestTransportErrorIsRetryable(t *testing.T) {
+	upstream := &codexModelsTestHTTPUpstream{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		return nil, context.DeadlineExceeded
+	}}
+	s := &OpenAIGatewayService{httpUpstream: upstream}
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "0.144.0", "")
+
+	if err == nil {
+		t.Fatal("expected transport error, got nil")
+	}
+	if !IsCodexModelsManifestRetryable(err) {
+		t.Fatalf("expected retryable transport error, got %v", err)
+	}
+}
+
+func TestFetchCodexModelsManifestCanceledRequestIsNotRetryable(t *testing.T) {
+	upstream := &codexModelsTestHTTPUpstream{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		return nil, context.Canceled
+	}}
+	s := &OpenAIGatewayService{httpUpstream: upstream}
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "0.144.0", "")
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if IsCodexModelsManifestRetryable(err) {
+		t.Fatalf("canceled request must not be retryable: %v", err)
+	}
+}
+
+func TestFetchCodexModelsManifestUsesTokenProvider(t *testing.T) {
+	account := newCodexModelsTestAccount()
+	account.Credentials["access_token"] = "stale-account-token"
+	var gotAuthorization string
+	upstream := &codexModelsTestHTTPUpstream{do: func(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		gotAuthorization = req.Header.Get("Authorization")
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody}, nil
+	}}
+	s := &OpenAIGatewayService{
+		httpUpstream:        upstream,
+		openAITokenProvider: NewOpenAITokenProvider(nil, codexModelsTokenCache{token: "cached-provider-token"}, nil),
+	}
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), account, "0.144.0", "")
+
+	if err != nil {
+		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
+	}
+	if gotAuthorization != "Bearer cached-provider-token" {
+		t.Fatalf("authorization header: got %q", gotAuthorization)
+	}
+}
+
+func TestFetchCodexModelsManifestUsesShadowCredentialsAndSelectedTransportIdentity(t *testing.T) {
+	parent := newCodexModelsTestAccount()
+	parent.ID = 100
+	parent.Credentials["access_token"] = "parent-token"
+	parent.Credentials["chatgpt_account_id"] = "parent-chatgpt-account"
+	parentID := parent.ID
+	shadow := newCodexModelsTestAccount()
+	shadow.ID = 200
+	shadow.ParentAccountID = &parentID
+	shadow.Credentials = nil
+
+	var gotAuthorization, gotChatGPTAccountID string
+	var gotTransportAccountID int64
+	upstream := &codexModelsTestHTTPUpstream{do: func(req *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
+		gotAuthorization = req.Header.Get("Authorization")
+		gotChatGPTAccountID = req.Header.Get("chatgpt-account-id")
+		gotTransportAccountID = accountID
+		return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody}, nil
+	}}
+	s := &OpenAIGatewayService{accountRepo: newStubCredRepo(parent), httpUpstream: upstream}
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), shadow, "0.144.0", "")
+
+	if err != nil {
+		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
+	}
+	if gotAuthorization != "Bearer parent-token" || gotChatGPTAccountID != "parent-chatgpt-account" {
+		t.Fatalf("shadow credentials not resolved: auth=%q account=%q", gotAuthorization, gotChatGPTAccountID)
+	}
+	if gotTransportAccountID != shadow.ID {
+		t.Fatalf("transport account ID: got %d, want shadow ID %d", gotTransportAccountID, shadow.ID)
+	}
+}
+
+func TestFetchCodexModelsManifestHTTPRetryability(t *testing.T) {
+	tests := []struct {
+		status    int
+		retryable bool
+	}{
+		{status: http.StatusBadRequest, retryable: false},
+		{status: http.StatusUnauthorized, retryable: true},
+		{status: http.StatusForbidden, retryable: true},
+		{status: http.StatusTooManyRequests, retryable: true},
+		{status: http.StatusInternalServerError, retryable: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			upstream := &codexModelsTestHTTPUpstream{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: tt.status,
+					Status:     http.StatusText(tt.status),
+					Header:     make(http.Header),
+					Body:       http.NoBody,
+				}, nil
+			}}
+			s := &OpenAIGatewayService{httpUpstream: upstream}
+
+			_, err := s.FetchCodexModelsManifest(context.Background(), newCodexModelsTestAccount(), "0.144.0", "")
+
+			if err == nil {
+				t.Fatal("expected upstream error, got nil")
+			}
+			if got := IsCodexModelsManifestRetryable(err); got != tt.retryable {
+				t.Fatalf("retryable=%v, want %v: %v", got, tt.retryable, err)
+			}
+		})
 	}
 }

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -162,6 +162,38 @@ func (s *OpenAIGatewayService) SelectAccountForModelWithExclusions(ctx context.C
 	return s.selectAccountForModelWithExclusions(s.withOpenAIQuotaAutoPauseContext(ctx), groupID, PlatformOpenAI, sessionHash, requestedModel, excludedIDs, false, 0, "")
 }
 
+// SelectCodexModelsAccountWithExclusions selects an OpenAI OAuth account for
+// the ChatGPT Codex models manifest. API Key accounts are deliberately excluded:
+// api.openai.com credentials cannot authenticate backend-api/codex/models.
+func (s *OpenAIGatewayService) SelectCodexModelsAccountWithExclusions(ctx context.Context, groupID *int64, excludedIDs map[int64]struct{}) (*Account, error) {
+	ctx = s.withOpenAIQuotaAutoPauseContext(ctx)
+	accounts, err := s.listSchedulableAccounts(ctx, groupID, PlatformOpenAI)
+	if err != nil {
+		return nil, fmt.Errorf("query accounts failed: %w", err)
+	}
+
+	oauthAccounts := make([]Account, 0, len(accounts))
+	for i := range accounts {
+		if accounts[i].IsOpenAIOAuth() {
+			oauthAccounts = append(oauthAccounts, accounts[i])
+		}
+	}
+
+	selected, _ := s.selectBestAccount(ctx, groupID, PlatformOpenAI, oauthAccounts, "", excludedIDs, false, "")
+	if selected == nil {
+		return nil, errors.New("no available OpenAI OAuth accounts")
+	}
+
+	hydrated, err := s.hydrateSelectedAccount(ctx, selected)
+	if err != nil {
+		return nil, err
+	}
+	if hydrated == nil || !hydrated.IsOpenAIOAuth() {
+		return nil, errors.New("selected account is not an OpenAI OAuth account")
+	}
+	return hydrated, nil
+}
+
 // noAvailableOpenAISelectionError builds the standard "no account available" error
 // while preserving the compact-specific error when applicable.
 func normalizeOpenAICompatiblePlatform(platform string) string {


### PR DESCRIPTION
## 背景

Codex 客户端请求 `/v1/models?client_version=...` 时，实际需要访问：

`https://chatgpt.com/backend-api/codex/models`

当前实现存在以下问题：

- models manifest 使用独立 HTTP client，硬编码 10 秒响应头超时和 15 秒总超时。
- 单账号请求失败后直接返回 502，不会切换 OAuth 账号。
- 调度可能选中无法访问 ChatGPT Codex backend 的 API Key 账号。
- Ops 将该请求错误归因为 `/v1/responses`，并且缺少实际账号信息。

## 修改内容

- 增加 `/v1/models` 和 `/backend-api/codex/models` 的规范端点定义。
- Ops 上游端点优先使用运行时实际端点，不再错误显示为 `/v1/responses`。
- models manifest 仅选择 OpenAI OAuth 账号，排除 API Key 账号。
- 改用统一的 `HTTPUpstream`、`HTTPUpstreamProfileOpenAI` 和 token provider。
- 删除 models manifest 独立的 10 秒响应头超时和 15 秒总超时。
- 使用 `maxAccountSwitches` 实现有界换号：
  - timeout、网络错误、401、403、429、5xx 可切换账号。
  - 客户端取消、请求 context 结束和请求格式类 4xx 不切换。
- 换号后清除 `If-None-Match`，避免混用不同账号的 ETag/304 缓存。
- Ops 记录实际账号、`/backend-api/codex/models`、`sync` 请求类型及各次失败信息。
- 新增端点、OAuth 调度、token provider、影子账号、故障切换、取消请求和 ETag 回归测试。


## 兼容性

- 不带 `client_version` 的普通 `/v1/models` 仍返回本地 OpenAI 兼容模型列表。
- manifest 响应体、`ETag` 和 304 透传语义保持不变。
- 不修改 Responses、Chat Completions 等生成接口的通用调度规则。
- 不涉及数据库迁移，也未增加服务端 stale cache。

## 验证

go -C backend test ./internal/handler ./internal/service ./internal/repository
go -C backend test ./internal/server/routes
git diff --check