### PR TITLE
fix(apicompat): preserve max effort for GPT-5.6 Anthropic bridge

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -1124,19 +1124,37 @@ func TestAnthropicToResponses_OutputConfigHigh(t *testing.T) {
 }
 
 func TestAnthropicToResponses_OutputConfigMax(t *testing.T) {
-	// output_config.effort="max" → mapped to OpenAI's highest supported level "xhigh".
-	req := &AnthropicRequest{
-		Model:        "gpt-5.2",
-		MaxTokens:    1024,
-		Messages:     []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"Hello"`)}},
-		OutputConfig: &AnthropicOutputConfig{Effort: "max"},
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{name: "GPT-5.2 falls back to xhigh", model: "gpt-5.2", want: "xhigh"},
+		{name: "GPT-5.4 falls back to xhigh", model: "gpt-5.4", want: "xhigh"},
+		{name: "bare GPT-5.6 preserves max", model: "gpt-5.6", want: "max"},
+		{name: "GPT-5.6 sol preserves max", model: "gpt-5.6-sol", want: "max"},
+		{name: "GPT-5.6 terra preserves max", model: "gpt-5.6-terra", want: "max"},
+		{name: "GPT-5.6 luna preserves max", model: "gpt-5.6-luna", want: "max"},
+		{name: "provider-prefixed GPT-5.6 preserves max", model: "openai/gpt-5.6-sol", want: "max"},
+		{name: "GPT-5.60 is not treated as GPT-5.6", model: "gpt-5.60-sol", want: "xhigh"},
 	}
 
-	resp, err := AnthropicToResponses(req)
-	require.NoError(t, err)
-	require.NotNil(t, resp.Reasoning)
-	assert.Equal(t, "xhigh", resp.Reasoning.Effort)
-	assert.Equal(t, "auto", resp.Reasoning.Summary)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &AnthropicRequest{
+				Model:        tt.model,
+				MaxTokens:    1024,
+				Messages:     []AnthropicMessage{{Role: "user", Content: json.RawMessage(`"Hello"`)}},
+				OutputConfig: &AnthropicOutputConfig{Effort: "max"},
+			}
+
+			resp, err := AnthropicToResponses(req)
+			require.NoError(t, err)
+			require.NotNil(t, resp.Reasoning)
+			assert.Equal(t, tt.want, resp.Reasoning.Effort)
+			assert.Equal(t, "auto", resp.Reasoning.Summary)
+		})
+	}
 }
 
 func TestAnthropicToResponses_NoOutputConfig(t *testing.T) {

--- a/backend/internal/pkg/apicompat/anthropic_to_responses.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses.go
@@ -58,13 +58,14 @@ func AnthropicToResponses(req *AnthropicRequest) (*ResponsesRequest, error) {
 	// Determine reasoning effort: only output_config.effort controls the
 	// level; thinking.type is ignored. Default follows Codex CLI / airgate's
 	// Anthropic bridge shape, which uses medium when unset.
-	// Anthropic levels map 1:1 to OpenAI: low→low, medium→medium, high→high, max→xhigh.
+	// Anthropic levels map 1:1 to OpenAI. GPT-5.6 supports max directly;
+	// earlier models fall back from max to xhigh.
 	effort := "medium"
 	if req.OutputConfig != nil && req.OutputConfig.Effort != "" {
 		effort = req.OutputConfig.Effort
 	}
 	out.Reasoning = &ResponsesReasoning{
-		Effort:  mapAnthropicEffortToResponses(effort),
+		Effort:  mapAnthropicEffortToResponses(effort, req.Model),
 		Summary: "auto",
 	}
 
@@ -403,19 +404,30 @@ func extractAnthropicTextFromBlocks(blocks []AnthropicContentBlock) string {
 // mapAnthropicEffortToResponses converts Anthropic reasoning effort levels to
 // OpenAI Responses API effort levels.
 //
-// Both APIs default to "high". The mapping is 1:1 for shared levels;
-// only Anthropic's "max" (Opus 4.6 exclusive) maps to OpenAI's "xhigh"
-// (GPT-5.2+ exclusive) as both represent the highest reasoning tier.
+// Both APIs default to "high". The mapping is 1:1 for shared levels.
+// GPT-5.6 supports "max" as a distinct tier, while earlier OpenAI models
+// use "xhigh" as their highest supported effort.
 //
 //	low    → low
 //	medium → medium
 //	high   → high
-//	max    → xhigh
-func mapAnthropicEffortToResponses(effort string) string {
+//	max    → max (GPT-5.6), xhigh (earlier models)
+func mapAnthropicEffortToResponses(effort, model string) string {
 	if effort == "max" {
+		if isGPT56Model(model) {
+			return "max"
+		}
 		return "xhigh"
 	}
 	return effort // low→low, medium→medium, high→high, unknown→passthrough
+}
+
+func isGPT56Model(model string) bool {
+	model = strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.LastIndex(model, "/"); idx >= 0 {
+		model = strings.TrimSpace(model[idx+1:])
+	}
+	return model == "gpt-5.6" || strings.HasPrefix(model, "gpt-5.6-")
 }
 
 // convertAnthropicToolsToResponses maps Anthropic tool definitions to


### PR DESCRIPTION
## Summary

Anthropic `/v1/messages` requests can specify `output_config.effort=max`.
GPT-5.6 Responses models support `max` as a distinct reasoning tier, but the
current Anthropic bridge always converts it to `xhigh`.

This change preserves `max` for GPT-5.6 models while keeping the existing
`max → xhigh` fallback for earlier models.

## Behavior

- GPT-5.6 variants: `max → max`
- Earlier models such as GPT-5.2 and GPT-5.4: `max → xhigh`
- Other effort levels remain unchanged

## Tests

- Added coverage for bare GPT-5.6 and sol/terra/luna variants
- Added provider-prefixed model coverage
- Preserved legacy GPT-5.2/GPT-5.4 fallback coverage
- Added a GPT-5.60 boundary case to prevent false-positive matching

`go test -tags=unit ./internal/pkg/apicompat -count=1`