### PR TITLE
fix(openai): pass deterministic upstream 4xx through instead of 502

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1094,6 +1094,16 @@ func (h *OpenAIGatewayHandler) anthropicStreamingAwareError(c *gin.Context, stat
 // handleAnthropicFailoverExhausted maps upstream failover errors to Anthropic format.
 func (h *OpenAIGatewayHandler) handleAnthropicFailoverExhausted(c *gin.Context, failoverErr *service.UpstreamFailoverError, streamStarted bool) {
 	status, errType, errMsg := h.mapUpstreamError(failoverErr.StatusCode)
+	if service.IsOpenAIUpstreamRequestError(failoverErr.StatusCode) {
+		if service.ShouldPassthroughOpenAIUpstreamRequestError(failoverErr.StatusCode, failoverErr.ResponseBody) {
+			errMsg = service.OpenAIUpstreamRequestErrorMessage(failoverErr.ResponseBody)
+		} else {
+			// Transient overloads and account-shaped 400s ride request-shaped
+			// statuses but are not the client's fault; keep the retryable,
+			// opaque mapping.
+			status, errType, errMsg = http.StatusBadGateway, "upstream_error", "Upstream service temporarily unavailable"
+		}
+	}
 	h.anthropicStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }
 
@@ -1984,6 +1994,16 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 
 	// 使用默认的错误映射
 	status, errType, errMsg := h.mapUpstreamError(statusCode)
+	if service.IsOpenAIUpstreamRequestError(statusCode) {
+		if service.ShouldPassthroughOpenAIUpstreamRequestError(statusCode, responseBody) {
+			errMsg = service.OpenAIUpstreamRequestErrorMessage(responseBody)
+		} else {
+			// Transient overloads and account-shaped 400s ride request-shaped
+			// statuses but are not the client's fault; keep the retryable,
+			// opaque mapping.
+			status, errType, errMsg = http.StatusBadGateway, "upstream_error", "Upstream service temporarily unavailable"
+		}
+	}
 	h.handleStreamingAwareError(c, status, errType, errMsg, streamStarted)
 }
 
@@ -1995,6 +2015,12 @@ func (h *OpenAIGatewayHandler) handleFailoverExhaustedSimple(c *gin.Context, sta
 }
 
 func (h *OpenAIGatewayHandler) mapUpstreamError(statusCode int) (int, string, string) {
+	// Request-shaped 4xx are deterministic: pass the status through so clients
+	// stop auto-retrying what can never succeed. Callers that hold the upstream
+	// response body enrich the generic message with the real upstream cause.
+	if service.IsOpenAIUpstreamRequestError(statusCode) {
+		return statusCode, service.OpenAIUpstreamRequestErrorType(statusCode), service.OpenAIUpstreamRequestErrorFallbackMessage
+	}
 	switch statusCode {
 	case 401:
 		return http.StatusBadGateway, "upstream_error", "Upstream authentication failed, please contact administrator"

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1812,3 +1812,148 @@ data: {"type":"response.failed","error":{"message":"This content was flagged"}}
 		require.False(t, openAIForwardErrorAlreadyCommunicated(c, c.Writer.Size(), errors.New("openai cyber_policy: blocked")))
 	})
 }
+
+func TestOpenAIMapUpstreamError_RequestShaped4xxPassthrough(t *testing.T) {
+	h := &OpenAIGatewayHandler{}
+
+	tests := []struct {
+		name       string
+		statusCode int
+		wantStatus int
+		wantType   string
+	}{
+		{name: "400 passes through", statusCode: 400, wantStatus: 400, wantType: "invalid_request_error"},
+		{name: "404 passes through as not_found", statusCode: 404, wantStatus: 404, wantType: "not_found_error"},
+		{name: "409 stays 502 (time-dependent conflict)", statusCode: 409, wantStatus: 502, wantType: "upstream_error"},
+		{name: "413 passes through", statusCode: 413, wantStatus: 413, wantType: "invalid_request_error"},
+		{name: "422 passes through", statusCode: 422, wantStatus: 422, wantType: "invalid_request_error"},
+		{name: "401 stays 502", statusCode: 401, wantStatus: 502, wantType: "upstream_error"},
+		{name: "403 stays 502", statusCode: 403, wantStatus: 502, wantType: "upstream_error"},
+		{name: "429 stays 429", statusCode: 429, wantStatus: 429, wantType: "rate_limit_error"},
+		{name: "500 stays 502", statusCode: 500, wantStatus: 502, wantType: "upstream_error"},
+		{name: "unknown stays 502", statusCode: 418, wantStatus: 502, wantType: "upstream_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, errType, errMsg := h.mapUpstreamError(tt.statusCode)
+			assert.Equal(t, tt.wantStatus, status)
+			assert.Equal(t, tt.wantType, errType)
+			assert.NotEmpty(t, errMsg)
+		})
+	}
+}
+
+func TestOpenAIHandleFailoverExhausted_RequestShaped4xxKeepsUpstreamMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	h := &OpenAIGatewayHandler{}
+	h.handleFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:   400,
+		ResponseBody: []byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`),
+	}, false)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+	errorObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "invalid_request_error", errorObj["type"])
+	assert.Equal(t, "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.", errorObj["message"])
+}
+
+func TestOpenAIHandleFailoverExhausted_401StillMapsTo502(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	h := &OpenAIGatewayHandler{}
+	h.handleFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:   401,
+		ResponseBody: []byte(`{"error":{"message":"invalid bearer token"}}`),
+	}, false)
+
+	require.Equal(t, http.StatusBadGateway, w.Code)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+	errorObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "upstream_error", errorObj["type"])
+	assert.Equal(t, "Upstream authentication failed, please contact administrator", errorObj["message"])
+}
+
+func TestOpenAIHandleFailoverExhausted_Transient400StaysRetryable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	h := &OpenAIGatewayHandler{}
+	h.handleFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:   400,
+		ResponseBody: []byte(`{"error":{"code":"server_is_overloaded","message":"The server is currently overloaded"}}`),
+	}, false)
+
+	require.Equal(t, http.StatusBadGateway, w.Code, "transient overload on a 400 status must stay retryable")
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+	errorObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "upstream_error", errorObj["type"])
+}
+
+func TestOpenAIHandleAnthropicFailoverExhausted_RequestShaped4xxKeepsUpstreamMessage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+
+	h := &OpenAIGatewayHandler{}
+	h.handleAnthropicFailoverExhausted(c, &service.UpstreamFailoverError{
+		StatusCode:   400,
+		ResponseBody: []byte(`{"error":{"message":"Invalid schema for response_format 'agentic_plan'"}}`),
+	}, false)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+	errorObj, ok := parsed["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "invalid_request_error", errorObj["type"])
+	assert.Equal(t, "Invalid schema for response_format 'agentic_plan'", errorObj["message"])
+}
+
+func TestOpenAIHandleFailoverExhausted_AccountShaped400StaysOpaque502(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	bodies := []string{
+		`{"error":{"message":"Your organization has been disabled."}}`,
+		`{"error":{"message":"Your credit balance is too low to access the API."}}`,
+		`{"error":{"message":"Identity verification is required to access this model."}}`,
+	}
+	for _, body := range bodies {
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+		h := &OpenAIGatewayHandler{}
+		h.handleFailoverExhausted(c, &service.UpstreamFailoverError{
+			StatusCode:   400,
+			ResponseBody: []byte(body),
+		}, false)
+
+		require.Equal(t, http.StatusBadGateway, w.Code, "account-shaped 400 must not leak to the client: %s", body)
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &parsed))
+		errorObj, ok := parsed["error"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "upstream_error", errorObj["type"])
+		assert.NotContains(t, errorObj["message"], "organization")
+		assert.NotContains(t, errorObj["message"], "credit balance")
+		assert.NotContains(t, errorObj["message"], "verification")
+	}
+}

--- a/backend/internal/handler/stream_error_event.go
+++ b/backend/internal/handler/stream_error_event.go
@@ -156,6 +156,8 @@ func mapResponsesErrorCode(errType string) string {
 		return "rate_limit_exceeded"
 	case "invalid_request_error":
 		return "invalid_request"
+	case "not_found_error":
+		return "not_found"
 	case "permission_error":
 		return "permission_denied"
 	case "authentication_error":

--- a/backend/internal/handler/stream_error_event_test.go
+++ b/backend/internal/handler/stream_error_event_test.go
@@ -239,6 +239,7 @@ func TestMapResponsesErrorCode(t *testing.T) {
 	cases := []struct{ in, out string }{
 		{"rate_limit_error", "rate_limit_exceeded"},
 		{"invalid_request_error", "invalid_request"},
+		{"not_found_error", "not_found"},
 		{"permission_error", "permission_denied"},
 		{"authentication_error", "authentication_failed"},
 		{"upstream_error", "upstream_error"},

--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -69,9 +69,9 @@ func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	c, _ := gin.CreateTestContext(rec)
 
 	svc := &OpenAIGatewayService{}
-	respBody := []byte(`{"error":{"message":"Invalid schema for field messages"}}`)
+	respBody := []byte(`{"error":{"message":"internal upstream failure"}}`)
 	resp := &http.Response{
-		StatusCode: http.StatusUnprocessableEntity,
+		StatusCode: http.StatusNotImplemented,
 		Body:       io.NopCloser(bytes.NewReader(respBody)),
 		Header:     http.Header{},
 	}
@@ -87,6 +87,75 @@ func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "upstream_error", errField["type"])
 	assert.Equal(t, "Upstream request failed", errField["message"])
+}
+
+func TestOpenAIHandleErrorResponse_RequestShaped4xxPassesThrough(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name        string
+		status      int
+		body        string
+		wantType    string
+		wantMessage string
+	}{
+		{
+			name:        "422 invalid schema keeps status and message",
+			status:      http.StatusUnprocessableEntity,
+			body:        `{"error":{"message":"Invalid schema for field messages"}}`,
+			wantType:    "invalid_request_error",
+			wantMessage: "Invalid schema for field messages",
+		},
+		{
+			name:        "400 plan gated model keeps status and message",
+			status:      http.StatusBadRequest,
+			body:        `{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`,
+			wantType:    "invalid_request_error",
+			wantMessage: "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+		},
+		{
+			name:        "404 unknown previous response maps to not_found_error",
+			status:      http.StatusNotFound,
+			body:        `{"error":{"message":"Previous response not found"}}`,
+			wantType:    "not_found_error",
+			wantMessage: "Previous response not found",
+		},
+		{
+			name:        "400 empty body falls back to generic message",
+			status:      http.StatusBadRequest,
+			body:        ``,
+			wantType:    "invalid_request_error",
+			wantMessage: OpenAIUpstreamRequestErrorFallbackMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+
+			svc := &OpenAIGatewayService{}
+			resp := &http.Response{
+				StatusCode: tt.status,
+				Body:       io.NopCloser(bytes.NewReader([]byte(tt.body))),
+				Header:     http.Header{},
+			}
+			account := &Account{ID: 12, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+			_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+			require.Error(t, err)
+			var failoverErr *UpstreamFailoverError
+			require.False(t, errors.As(err, &failoverErr), "request-shaped 4xx must not fail over")
+			assert.Equal(t, tt.status, rec.Code)
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+			errField, ok := payload["error"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantType, errField["type"])
+			assert.Equal(t, tt.wantMessage, errField["message"])
+		})
+	}
 }
 
 func TestOpenAIHandleErrorResponse_ContextWindow502KeepsMessageWithoutFailover(t *testing.T) {
@@ -379,4 +448,29 @@ func newNonFailoverPassthroughRule(statusCode int, keyword string, respCode int,
 		PassthroughBody: false,
 		CustomMessage:   &customMessage,
 	}
+}
+
+func TestOpenAIHandleErrorResponse_Transient400StaysRetryable502(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	svc := &OpenAIGatewayService{}
+	respBody := []byte(`{"error":{"code":"server_is_overloaded","message":"The server is currently overloaded"}}`)
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Body:       io.NopCloser(bytes.NewReader(respBody)),
+		Header:     http.Header{},
+	}
+	account := &Account{ID: 15, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+	require.Error(t, err)
+	assert.Equal(t, http.StatusBadGateway, rec.Code, "transient overload on a 400 status must stay retryable")
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+	errField, ok := payload["error"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "upstream_error", errField["type"])
 }

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -365,7 +365,9 @@ func TestOpenAIGatewayService_Forward_LogsInstructionsRequiredDetails(t *testing
 
 	_, err := svc.Forward(context.Background(), c, account, body)
 	require.Error(t, err)
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	// Deterministic request-shaped 400s pass through to the client instead of
+	// being flattened to a retryable 502.
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, err.Error(), "upstream error: 400")
 
 	require.True(t, logSink.ContainsMessageAtLevel("OpenAI 上游返回 Instructions are required，已记录请求详情用于排查", "warn"))

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -432,9 +432,23 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		errType = "rate_limit_error"
 		errMsg = "Upstream rate limit exceeded, please retry later"
 	default:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream request failed"
+		if ShouldPassthroughOpenAIUpstreamRequestError(resp.StatusCode, body) {
+			// Deterministic request-shaped 4xx: pass the status through with
+			// the sanitized upstream message so clients stop retrying and can
+			// act on the real cause (mirrors handleCompatErrorResponse).
+			// Transient overloads and account-shaped errors riding a 4xx
+			// status keep the retryable, opaque 502.
+			statusCode = resp.StatusCode
+			errType = OpenAIUpstreamRequestErrorType(resp.StatusCode)
+			errMsg = upstreamMsg
+			if errMsg == "" {
+				errMsg = OpenAIUpstreamRequestErrorFallbackMessage
+			}
+		} else {
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream request failed"
+		}
 	}
 	if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
 		errMsg = upstreamMsg

--- a/backend/internal/service/openai_upstream_request_errors.go
+++ b/backend/internal/service/openai_upstream_request_errors.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"net/http"
+	"strings"
+)
+
+// OpenAIUpstreamRequestErrorFallbackMessage is returned to the client when a
+// request-shaped upstream 4xx carries no extractable message.
+const OpenAIUpstreamRequestErrorFallbackMessage = "Upstream rejected the request"
+
+// IsOpenAIUpstreamRequestError reports whether an upstream status code
+// describes a problem with the request itself, as opposed to gateway account
+// credentials (401/402/403), upstream throttling (429/529) or upstream
+// availability (5xx). These rejections are deterministic — replaying the same
+// request cannot succeed — so the gateway must pass the status through instead
+// of flattening it into 502: clients such as Codex CLI auto-retry 5xx with
+// backoff, which turns one deterministic 4xx into a sustained retry storm and
+// hides the actionable upstream message (invalid schema, context window
+// exceeded, plan-gated model, unknown previous_response_id, ...).
+func IsOpenAIUpstreamRequestError(statusCode int) bool {
+	// 409 is deliberately excluded: OpenAI uses it for time-dependent
+	// conflicts (e.g. a response still in progress) where retrying later can
+	// succeed, so it stays on the retryable 502 mapping.
+	switch statusCode {
+	case http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity:
+		return true
+	}
+	return false
+}
+
+// OpenAIUpstreamRequestErrorType maps a request-shaped upstream status to the
+// error type expected by strict OpenAI clients, mirroring the Chat Completions
+// compat path (handleCompatErrorResponse).
+func OpenAIUpstreamRequestErrorType(statusCode int) string {
+	if statusCode == http.StatusNotFound {
+		return "not_found_error"
+	}
+	return "invalid_request_error"
+}
+
+// OpenAIUpstreamRequestErrorMessage extracts the sanitized upstream message of
+// a request-shaped 4xx so the client can see why its request was rejected,
+// falling back to a generic message when the body has none.
+func OpenAIUpstreamRequestErrorMessage(body []byte) string {
+	msg := strings.TrimSpace(extractUpstreamErrorMessage(body))
+	msg = sanitizeUpstreamErrorMessage(msg)
+	if msg == "" {
+		return OpenAIUpstreamRequestErrorFallbackMessage
+	}
+	return msg
+}
+
+// openAIAccountShapedBadRequestMarkers match 400 bodies that describe the
+// gateway account's state (org disabled, billing, KYC) rather than the
+// client's request. See RateLimitService.HandleUpstreamError, which disables
+// the account on the same markers.
+var openAIAccountShapedBadRequestMarkers = []string{
+	"organization has been disabled",
+	"credit balance",
+	"identity verification is required",
+}
+
+// ShouldPassthroughOpenAIUpstreamRequestError decides whether an upstream
+// error response should be passed through to the client as a request-shaped
+// 4xx. Two classes must stay on the opaque, retryable 502 mapping even though
+// they arrive with a request-shaped status:
+//   - transient processing failures ("server_is_overloaded", "selected model
+//     is at capacity", ...), which OpenAI ships on 400/503 and which a client
+//     retry can genuinely resolve;
+//   - account-shaped 400s (org disabled, billing, KYC), which describe the
+//     gateway's account, not the client's request, and must not leak.
+func ShouldPassthroughOpenAIUpstreamRequestError(statusCode int, body []byte) bool {
+	if !IsOpenAIUpstreamRequestError(statusCode) {
+		return false
+	}
+	msg := strings.TrimSpace(extractUpstreamErrorMessage(body))
+	if isOpenAITransientProcessingError(statusCode, msg, body) {
+		return false
+	}
+	lower := strings.ToLower(msg)
+	for _, marker := range openAIAccountShapedBadRequestMarkers {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	return true
+}

--- a/backend/internal/service/openai_upstream_request_errors_test.go
+++ b/backend/internal/service/openai_upstream_request_errors_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestIsOpenAIUpstreamRequestError(t *testing.T) {
+	passthrough := []int{
+		http.StatusBadRequest,
+		http.StatusNotFound,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity,
+	}
+	for _, code := range passthrough {
+		if !IsOpenAIUpstreamRequestError(code) {
+			t.Fatalf("IsOpenAIUpstreamRequestError(%d) = false, want true", code)
+		}
+	}
+
+	flattened := []int{
+		http.StatusUnauthorized,
+		http.StatusConflict,
+		http.StatusPaymentRequired,
+		http.StatusForbidden,
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusInternalServerError,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		529,
+	}
+	for _, code := range flattened {
+		if IsOpenAIUpstreamRequestError(code) {
+			t.Fatalf("IsOpenAIUpstreamRequestError(%d) = true, want false", code)
+		}
+	}
+}
+
+func TestOpenAIUpstreamRequestErrorType(t *testing.T) {
+	if got := OpenAIUpstreamRequestErrorType(http.StatusNotFound); got != "not_found_error" {
+		t.Fatalf("OpenAIUpstreamRequestErrorType(404) = %q, want not_found_error", got)
+	}
+	for _, code := range []int{400, 413, 422} {
+		if got := OpenAIUpstreamRequestErrorType(code); got != "invalid_request_error" {
+			t.Fatalf("OpenAIUpstreamRequestErrorType(%d) = %q, want invalid_request_error", code, got)
+		}
+	}
+}
+
+func TestOpenAIUpstreamRequestErrorMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{
+			name: "error.message payload",
+			body: []byte(`{"error":{"message":"Invalid schema for response_format 'agentic_plan'"}}`),
+			want: "Invalid schema for response_format 'agentic_plan'",
+		},
+		{
+			name: "detail payload",
+			body: []byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`),
+			want: "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+		},
+		{
+			name: "empty body falls back",
+			body: nil,
+			want: OpenAIUpstreamRequestErrorFallbackMessage,
+		},
+		{
+			name: "non json body falls back",
+			body: []byte(`<html>bad gateway</html>`),
+			want: OpenAIUpstreamRequestErrorFallbackMessage,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OpenAIUpstreamRequestErrorMessage(tt.body); got != tt.want {
+				t.Fatalf("OpenAIUpstreamRequestErrorMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldPassthroughOpenAIUpstreamRequestError(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   []byte
+		want   bool
+	}{
+		{
+			name:   "deterministic schema 400 passes",
+			status: http.StatusBadRequest,
+			body:   []byte(`{"error":{"message":"Invalid schema for response_format 'agentic_plan'"}}`),
+			want:   true,
+		},
+		{
+			name:   "transient server_is_overloaded 400 does not pass",
+			status: http.StatusBadRequest,
+			body:   []byte(`{"error":{"code":"server_is_overloaded","message":"The server is currently overloaded"}}`),
+			want:   false,
+		},
+		{
+			name:   "account-shaped org disabled 400 does not pass",
+			status: http.StatusBadRequest,
+			body:   []byte(`{"error":{"message":"Your organization has been disabled."}}`),
+			want:   false,
+		},
+		{
+			name:   "account-shaped credit balance 400 does not pass",
+			status: http.StatusBadRequest,
+			body:   []byte(`{"error":{"message":"Your credit balance is too low to access the API."}}`),
+			want:   false,
+		},
+		{
+			name:   "non request-shaped status does not pass",
+			status: http.StatusUnauthorized,
+			body:   []byte(`{"error":{"message":"bad token"}}`),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ShouldPassthroughOpenAIUpstreamRequestError(tt.status, tt.body); got != tt.want {
+				t.Fatalf("ShouldPassthroughOpenAIUpstreamRequestError(%d) = %v, want %v", tt.status, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

On the OpenAI Responses path, `handleErrorResponse` and `mapUpstreamError` flatten every unrecognized upstream status — including deterministic request-shaped 4xx — into a generic client **502 "Upstream request failed"**:

- invalid `response_format` schemas (400)
- context-window exceeded (400)
- plan-gated models on ChatGPT accounts (400)
- unknown `previous_response_id` / model (404)

Clients such as Codex CLI auto-retry 5xx with backoff, so one deterministic 400 becomes a **sustained retry storm** (observed in production: ~2200 app-generated 502s in 3h from a handful of codex-tui users), and the actionable upstream message is lost — users never learn why their request failed.

The Chat Completions compat path (`handleCompatErrorResponse`) already passes upstream status + message through; this PR aligns the Responses path with that in-repo precedent.

## Fix

New shared helpers in `internal/service/openai_upstream_request_errors.go`:

- `IsOpenAIUpstreamRequestError`: request-shaped statuses = **{400, 404, 413, 422}**. 409 is deliberately excluded (OpenAI uses it for time-dependent conflicts where retry-later can succeed).
- `ShouldPassthroughOpenAIUpstreamRequestError`: two classes stay on the opaque, retryable 502 even though they ride a request-shaped status:
  - **transient processing failures** (`server_is_overloaded`, `slow_down`, "selected model is at capacity", "an error occurred while processing your request" — reusing the existing `isOpenAITransientProcessingError` classifier, i.e. exactly the errors the failover path already treats as retryable);
  - **account-shaped 400s** ("organization has been disabled", "credit balance", "identity verification is required" — the same markers `RateLimitService.HandleUpstreamError` disables accounts on), which describe the gateway's account, not the client's request, and must not leak.
- `OpenAIUpstreamRequestErrorType`: `invalid_request_error` / `not_found_error`, mirroring the compat path.
- `OpenAIUpstreamRequestErrorMessage`: sanitized upstream message with generic fallback.

Wired into:
- `handleErrorResponse` final mapping (non-failover upstream errors),
- `OpenAIGatewayHandler.mapUpstreamError` + `handleFailoverExhausted` / `handleAnthropicFailoverExhausted` (failover-exhausted path; message enriched from `UpstreamFailoverError.ResponseBody`),
- `mapResponsesErrorCode`: new `not_found_error` → `not_found` so streaming 404s emit a canonical code in `response.failed` SSE frames.

**Unchanged**: 401/402/403 stay mapped to 502 (gateway-account credential problems must not look like client auth errors), 429/529/5xx mappings untouched, error passthrough rules still take precedence, `GatewayHandler.mapUpstreamError` (Gemini/antigravity flows) untouched.

## Tests

- Helper table tests (status list, error types, message extraction/sanitization, transient + account-shaped guards).
- `handleErrorResponse`: request-shaped 4xx passthrough (422 schema / 400 plan-gated / 404 / empty body fallback), transient-400 stays 502, default mapping for unrecognized 5xx preserved.
- Handler: `mapUpstreamError` table, `handleFailoverExhausted` 400-passthrough + transient-400 + account-shaped-400 + 401 regression, Anthropic-format variant.
- Updated `TestOpenAIGatewayService_Forward_LogsInstructionsRequiredDetails` (asserted the old 502 flattening for an upstream 400) to the new passthrough behavior.
- `go test -tags=unit ./...` passes; `golangci-lint run --new-from-rev=upstream/main` reports 0 new issues.

## Out of scope (deliberate)

- 410/415 remain on the 502 mapping (conservative status list).
- Context-window errors arriving on a 5xx carrier status keep today's behavior (502 + real message).
- The upstream message exposure matches what the Chat Completions compat path already exposes today.

Related: #4169 (plan-gated model cooldown + failover) — complementary: #4169 stops selecting incapable accounts; this PR stops misreporting whatever deterministic 4xx still reaches the client. With both merged, a plan-gated request that exhausts failover now returns an honest 400 with the upstream explanation instead of a retryable 502.