### PR TITLE
fix: fail over grok token refresh failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,3 +747,7 @@ Copyright (c) 2026 Wesley Liddick
 **If you find this project useful, please give it a star!**
 
 </div>
+
+---
+
+> 👤 作者：涤生AGI | 🐙 github.com/dishenglee | 📡 公众号：涤生AGI

--- a/backend/internal/service/grok_access_token_failover.go
+++ b/backend/internal/service/grok_access_token_failover.go
@@ -1,0 +1,10 @@
+package service
+
+import "net/http"
+
+func newGrokAccessTokenFailoverError(err error) *UpstreamFailoverError {
+	return &UpstreamFailoverError{
+		StatusCode:   http.StatusBadGateway,
+		ResponseBody: []byte(`{"error":"grok access token unavailable; switching account"}`),
+	}
+}

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -124,6 +124,9 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	// 5. Build upstream request
 	token, tokenKind, err := s.GetAccessToken(ctx, account)
 	if err != nil {
+		if account.Platform == PlatformGrok {
+			return nil, newGrokAccessTokenFailoverError(err)
+		}
 		return nil, err
 	}
 	if strings.TrimSpace(token) == "" {

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -40,7 +40,7 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 
 	token, _, err := s.GetAccessToken(ctx, account)
 	if err != nil {
-		return nil, err
+		return nil, newGrokAccessTokenFailoverError(err)
 	}
 
 	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)


### PR DESCRIPTION
## Summary\n- Convert Grok access-token refresh failures into failover errors so the gateway can switch accounts instead of returning an immediate upstream failure.\n- Apply the behavior to Grok Responses forwarding and raw Chat Completions forwarding.\n\n## Test\n- go test -tags=unit ./internal/service/ -run 'TestForwardAsChatCompletionsForGrok|TestBuildGrokResponsesRequest|TestGetGrokCLIHeaders'