### PR TITLE
feat(openai): add side-effect-free quota snapshot

### DIFF
--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -424,6 +424,27 @@ func (h *OpenAIOAuthHandler) QueryQuota(c *gin.Context) {
 	response.Success(c, usage)
 }
 
+// QueryQuotaSnapshot returns a normalized, side-effect-free 5h/7d quota
+// observation for one OpenAI OAuth account.
+// GET /api/v1/admin/openai/accounts/:id/quota-snapshot
+func (h *OpenAIOAuthHandler) QueryQuotaSnapshot(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+	if h.quotaService == nil {
+		response.BadRequest(c, "openai quota service is not enabled")
+		return
+	}
+	snapshot, err := h.quotaService.QueryReadOnlySnapshot(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, snapshot)
+}
+
 // CreateShadowRequest is the request body for CreateShadow.
 type CreateShadowRequest struct {
 	Name        string  `json:"name"`

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -370,6 +370,7 @@ func registerOpenAIOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		openai.POST("/create-from-oauth", h.Admin.OpenAIOAuth.CreateAccountFromOAuth)
 		openai.POST("/create-from-codex-pat", h.Admin.OpenAIOAuth.CreateAccountFromCodexPAT)
 		openai.GET("/accounts/:id/quota", h.Admin.OpenAIOAuth.QueryQuota)
+		openai.GET("/accounts/:id/quota-snapshot", h.Admin.OpenAIOAuth.QueryQuotaSnapshot)
 		openai.POST("/accounts/:id/reset-quota", h.Admin.OpenAIOAuth.ResetQuota)
 	}
 }

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -35,6 +35,8 @@ const (
 	openaiQuotaSecFetchSite     = "none"
 	openaiQuotaSecFetchMode     = "no-cors"
 	openaiQuotaSecFetchDest     = "empty"
+	openaiQuotaFiveHourSeconds  = int64((5 * time.Hour) / time.Second)
+	openaiQuotaSevenDaySeconds  = int64((7 * 24 * time.Hour) / time.Second)
 )
 
 // OpenAIRateLimitWindow describes a single rate-limit window returned by
@@ -378,39 +380,26 @@ func canonicalOpenAIQuotaWindows(account *Account, usage *OpenAIQuotaUsage) (fiv
 	if rateLimit == nil {
 		return nil, nil
 	}
-	primary := &openAIQuotaWindowSource{window: rateLimit.PrimaryWindow, sourcePath: sourcePrefix + ".primary_window"}
-	secondary := &openAIQuotaWindowSource{window: rateLimit.SecondaryWindow, sourcePath: sourcePrefix + ".secondary_window"}
-	if primary.window == nil {
-		primary = nil
+	candidates := []*openAIQuotaWindowSource{
+		{window: rateLimit.PrimaryWindow, sourcePath: sourcePrefix + ".primary_window"},
+		{window: rateLimit.SecondaryWindow, sourcePath: sourcePrefix + ".secondary_window"},
 	}
-	if secondary.window == nil {
-		secondary = nil
-	}
-
-	switch {
-	case primary != nil && secondary != nil:
-		if primary.window.LimitWindowSeconds > 0 && secondary.window.LimitWindowSeconds > 0 && primary.window.LimitWindowSeconds != secondary.window.LimitWindowSeconds {
-			if primary.window.LimitWindowSeconds < secondary.window.LimitWindowSeconds {
-				return primary, secondary
+	for _, candidate := range candidates {
+		if candidate.window == nil {
+			continue
+		}
+		switch candidate.window.LimitWindowSeconds {
+		case openaiQuotaFiveHourSeconds:
+			if fiveHour == nil {
+				fiveHour = candidate
 			}
-			return secondary, primary
+		case openaiQuotaSevenDaySeconds:
+			if sevenDay == nil {
+				sevenDay = candidate
+			}
 		}
-		// Preserve the established legacy mapping when window lengths are absent
-		// or ambiguous: primary=7d, secondary=5h.
-		return secondary, primary
-	case primary != nil:
-		if primary.window.LimitWindowSeconds > 0 && primary.window.LimitWindowSeconds <= 6*60*60 {
-			return primary, nil
-		}
-		return nil, primary
-	case secondary != nil:
-		if secondary.window.LimitWindowSeconds > 0 && secondary.window.LimitWindowSeconds <= 6*60*60 {
-			return secondary, nil
-		}
-		return nil, secondary
-	default:
-		return nil, nil
 	}
+	return fiveHour, sevenDay
 }
 
 func projectOpenAIQuotaWindow(source *openAIQuotaWindowSource, observedAt time.Time) *OpenAIQuotaWindowSnapshot {

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -89,6 +89,53 @@ type OpenAIQuotaUsage struct {
 	FetchedAt             int64                        `json:"fetched_at"`
 }
 
+// OpenAIQuotaWindowProvenance identifies the exact fields used to project one
+// canonical quota window. ResetAtDerived is true only when reset_at was absent
+// and the absolute timestamp was derived from the same response's
+// reset_after_seconds value and ObservedAt.
+type OpenAIQuotaWindowProvenance struct {
+	SourcePath       string `json:"source_path"`
+	UsedPercentField string `json:"used_percent_field"`
+	ResetAtField     string `json:"reset_at_field"`
+	ResetAtDerived   bool   `json:"reset_at_derived"`
+}
+
+// OpenAIQuotaWindowSnapshot is a canonical 5h or 7d window from one
+// /wham/usage response.
+type OpenAIQuotaWindowSnapshot struct {
+	UsedPercent        float64                     `json:"used_percent"`
+	LimitWindowSeconds int64                       `json:"limit_window_seconds"`
+	ResetAt            string                      `json:"reset_at,omitempty"`
+	Provenance         OpenAIQuotaWindowProvenance `json:"provenance"`
+}
+
+// OpenAIQuotaSnapshotProvenance records the read-only boundary of a quota
+// observation. This endpoint never enters a model inference path and never
+// invokes token refresh or account/scheduler mutation methods.
+type OpenAIQuotaSnapshotProvenance struct {
+	Source                 string `json:"source"`
+	UpstreamEndpoint       string `json:"upstream_endpoint"`
+	UpstreamMethod         string `json:"upstream_method"`
+	CredentialSource       string `json:"credential_source"`
+	CredentialRefreshed    bool   `json:"credential_refreshed"`
+	ModelRequestSent       bool   `json:"model_request_sent"`
+	AccountStateMutated    bool   `json:"account_state_mutated"`
+	SchedulingStateMutated bool   `json:"scheduling_state_mutated"`
+}
+
+// OpenAIQuotaSnapshot contains coherent 5h/7d quota fields from one upstream
+// response. Complete is false when either canonical window or its absolute
+// reset timestamp is unavailable; callers must fail closed in that case.
+type OpenAIQuotaSnapshot struct {
+	AccountID     int64                         `json:"account_id"`
+	ObservedAt    string                        `json:"observed_at"`
+	FiveHour      *OpenAIQuotaWindowSnapshot    `json:"five_hour,omitempty"`
+	SevenDay      *OpenAIQuotaWindowSnapshot    `json:"seven_day,omitempty"`
+	Complete      bool                          `json:"complete"`
+	MissingFields []string                      `json:"missing_fields,omitempty"`
+	Provenance    OpenAIQuotaSnapshotProvenance `json:"provenance"`
+}
+
 // OpenAIQuotaResetCredit captures the redeemed credit metadata returned by the
 // reset endpoint.
 type OpenAIQuotaResetCredit struct {
@@ -175,6 +222,219 @@ func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*
 		payload.RateLimitResetCredits.Credits = s.queryResetCreditDetails(callCtx, client, accessToken, chatGPTAccountID, fedRAMP, accountID)
 	}
 	return &payload, nil
+}
+
+// QueryReadOnlySnapshot fetches one coherent quota observation without model
+// inference, credential refresh, account mutation, or scheduling mutation. It
+// intentionally uses only the access token already stored on the account. An
+// expired or missing token is reported as an error instead of entering the
+// shared token refresh path, whose error policy may alter account state.
+func (s *OpenAIQuotaService) QueryReadOnlySnapshot(ctx context.Context, accountID int64) (*OpenAIQuotaSnapshot, error) {
+	account, accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareReadOnlyUpstreamCall(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := s.privacyClientFactory(proxyURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_CLIENT_ERROR", "failed to build upstream client: %v", err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, openaiQuotaUpstreamTimeout)
+	defer cancel()
+
+	var payload OpenAIQuotaUsage
+	resp, err := client.R().
+		SetContext(callCtx).
+		SetHeaders(buildCodexCommonHeaders(accessToken, chatGPTAccountID, fedRAMP)).
+		SetSuccessResult(&payload).
+		Get(chatGPTUsageURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_SNAPSHOT_REQUEST_FAILED", "upstream request failed: %v", err)
+	}
+	if !resp.IsSuccessState() {
+		status := resp.StatusCode
+		body := truncate(resp.String(), 240)
+		slog.Warn("openai_quota_snapshot_failed", "account_id", accountID, "status", status, "body", body)
+		return nil, infraerrors.Newf(mapUpstreamStatus(status), "OPENAI_QUOTA_SNAPSHOT_UPSTREAM_ERROR", "upstream returned %d: %s", status, body)
+	}
+
+	observedAt := time.Now().UTC()
+	return buildOpenAIQuotaSnapshot(account, &payload, observedAt), nil
+}
+
+func (s *OpenAIQuotaService) prepareReadOnlyUpstreamCall(ctx context.Context, accountID int64) (account *Account, accessToken, chatGPTAccountID, proxyURL string, fedRAMP bool, err error) {
+	if s == nil || s.accountRepo == nil || s.privacyClientFactory == nil {
+		return nil, "", "", "", false, infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota service is not configured")
+	}
+
+	account, err = s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, "", "", "", false, infraerrors.Newf(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found: %v", err)
+	}
+	if account == nil {
+		return nil, "", "", "", false, infraerrors.New(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found")
+	}
+	if account.Platform != PlatformOpenAI {
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_INVALID_PLATFORM", "account is not an OpenAI account")
+	}
+	if account.Type != AccountTypeOAuth {
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_INVALID_TYPE", "account is not an OAuth account")
+	}
+
+	credentialAccount := account
+	if account.IsShadow() {
+		credentialAccount, err = resolveCredentialAccount(ctx, s.accountRepo, account)
+		if err != nil {
+			return nil, "", "", "", false, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_SHADOW_RESOLVE_FAILED", "failed to resolve shadow account: %v", err)
+		}
+	}
+
+	chatGPTAccountID = strings.TrimSpace(credentialAccount.GetCredential("chatgpt_account_id"))
+	if chatGPTAccountID == "" {
+		chatGPTAccountID = strings.TrimSpace(credentialAccount.GetCredential("organization_id"))
+	}
+	if chatGPTAccountID == "" {
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_MISSING_ACCOUNT_ID", "chatgpt_account_id is missing; please re-authorize this account")
+	}
+
+	accessToken = strings.TrimSpace(credentialAccount.GetOpenAIAccessToken())
+	if accessToken == "" {
+		return nil, "", "", "", false, infraerrors.New(http.StatusBadGateway, "OPENAI_QUOTA_TOKEN_UNAVAILABLE", "stored access token is empty")
+	}
+	fedRAMP = credentialAccount.IsChatGPTAccountFedRAMP()
+
+	if credentialAccount.ProxyID != nil {
+		switch {
+		case credentialAccount.Proxy != nil:
+			proxyURL = credentialAccount.Proxy.URL()
+		case s.proxyRepo != nil:
+			if proxy, perr := s.proxyRepo.GetByID(ctx, *credentialAccount.ProxyID); perr == nil && proxy != nil {
+				proxyURL = proxy.URL()
+			}
+		}
+	}
+
+	return account, accessToken, chatGPTAccountID, proxyURL, fedRAMP, nil
+}
+
+type openAIQuotaWindowSource struct {
+	window     *OpenAIRateLimitWindow
+	sourcePath string
+}
+
+func buildOpenAIQuotaSnapshot(account *Account, usage *OpenAIQuotaUsage, observedAt time.Time) *OpenAIQuotaSnapshot {
+	observedAt = observedAt.UTC()
+	fiveHour, sevenDay := canonicalOpenAIQuotaWindows(account, usage)
+	snapshot := &OpenAIQuotaSnapshot{
+		ObservedAt: observedAt.Format(time.RFC3339Nano),
+		Provenance: OpenAIQuotaSnapshotProvenance{
+			Source:                 "chatgpt_wham_usage",
+			UpstreamEndpoint:       chatGPTUsageURL,
+			UpstreamMethod:         http.MethodGet,
+			CredentialSource:       "stored_access_token",
+			CredentialRefreshed:    false,
+			ModelRequestSent:       false,
+			AccountStateMutated:    false,
+			SchedulingStateMutated: false,
+		},
+	}
+	if account != nil {
+		snapshot.AccountID = account.ID
+	}
+	snapshot.FiveHour = projectOpenAIQuotaWindow(fiveHour, observedAt)
+	snapshot.SevenDay = projectOpenAIQuotaWindow(sevenDay, observedAt)
+	if snapshot.FiveHour == nil {
+		snapshot.MissingFields = append(snapshot.MissingFields, "five_hour")
+	} else if snapshot.FiveHour.ResetAt == "" {
+		snapshot.MissingFields = append(snapshot.MissingFields, "five_hour.reset_at")
+	}
+	if snapshot.SevenDay == nil {
+		snapshot.MissingFields = append(snapshot.MissingFields, "seven_day")
+	} else if snapshot.SevenDay.ResetAt == "" {
+		snapshot.MissingFields = append(snapshot.MissingFields, "seven_day.reset_at")
+	}
+	snapshot.Complete = len(snapshot.MissingFields) == 0
+	return snapshot
+}
+
+func canonicalOpenAIQuotaWindows(account *Account, usage *OpenAIQuotaUsage) (fiveHour, sevenDay *openAIQuotaWindowSource) {
+	if usage == nil {
+		return nil, nil
+	}
+	rateLimit := usage.RateLimit
+	sourcePrefix := "$.rate_limit"
+	if account != nil && account.IsShadow() {
+		rateLimit = nil
+		for i := range usage.AdditionalRateLimits {
+			item := &usage.AdditionalRateLimits[i]
+			if item.MeteredFeature == "codex_bengalfox" {
+				rateLimit = item.RateLimit
+				sourcePrefix = fmt.Sprintf("$.additional_rate_limits[%d].rate_limit", i)
+				break
+			}
+		}
+	}
+	if rateLimit == nil {
+		return nil, nil
+	}
+	primary := &openAIQuotaWindowSource{window: rateLimit.PrimaryWindow, sourcePath: sourcePrefix + ".primary_window"}
+	secondary := &openAIQuotaWindowSource{window: rateLimit.SecondaryWindow, sourcePath: sourcePrefix + ".secondary_window"}
+	if primary.window == nil {
+		primary = nil
+	}
+	if secondary.window == nil {
+		secondary = nil
+	}
+
+	switch {
+	case primary != nil && secondary != nil:
+		if primary.window.LimitWindowSeconds > 0 && secondary.window.LimitWindowSeconds > 0 && primary.window.LimitWindowSeconds != secondary.window.LimitWindowSeconds {
+			if primary.window.LimitWindowSeconds < secondary.window.LimitWindowSeconds {
+				return primary, secondary
+			}
+			return secondary, primary
+		}
+		// Preserve the established legacy mapping when window lengths are absent
+		// or ambiguous: primary=7d, secondary=5h.
+		return secondary, primary
+	case primary != nil:
+		if primary.window.LimitWindowSeconds > 0 && primary.window.LimitWindowSeconds <= 6*60*60 {
+			return primary, nil
+		}
+		return nil, primary
+	case secondary != nil:
+		if secondary.window.LimitWindowSeconds > 0 && secondary.window.LimitWindowSeconds <= 6*60*60 {
+			return secondary, nil
+		}
+		return nil, secondary
+	default:
+		return nil, nil
+	}
+}
+
+func projectOpenAIQuotaWindow(source *openAIQuotaWindowSource, observedAt time.Time) *OpenAIQuotaWindowSnapshot {
+	if source == nil || source.window == nil {
+		return nil
+	}
+	window := source.window
+	result := &OpenAIQuotaWindowSnapshot{
+		UsedPercent:        window.UsedPercent,
+		LimitWindowSeconds: window.LimitWindowSeconds,
+		Provenance: OpenAIQuotaWindowProvenance{
+			SourcePath:       source.sourcePath,
+			UsedPercentField: source.sourcePath + ".used_percent",
+		},
+	}
+	if window.ResetAt > 0 {
+		result.ResetAt = time.Unix(window.ResetAt, 0).UTC().Format(time.RFC3339Nano)
+		result.Provenance.ResetAtField = source.sourcePath + ".reset_at"
+	} else if window.ResetAfterSeconds > 0 {
+		result.ResetAt = observedAt.Add(time.Duration(window.ResetAfterSeconds) * time.Second).Format(time.RFC3339Nano)
+		result.Provenance.ResetAtField = source.sourcePath + ".reset_after_seconds"
+		result.Provenance.ResetAtDerived = true
+	}
+	return result
 }
 
 func (s *OpenAIQuotaService) queryResetCreditDetails(ctx context.Context, client *req.Client, accessToken, chatGPTAccountID string, fedRAMP bool, accountID int64) []OpenAIRateLimitResetCreditDetail {

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -420,3 +420,112 @@ func TestQueryUsageShadowResolve_EndToEnd(t *testing.T) {
 	require.Equal(t, "org-e2e-parent", capturedAccountID,
 		"upstream should receive parent's chatgpt-account-id; got: %s", capturedAccountID)
 }
+
+func TestBuildOpenAIQuotaSnapshotUsesOneObservationForCanonicalWindows(t *testing.T) {
+	observedAt := time.Date(2026, time.July, 13, 8, 0, 0, 123000000, time.UTC)
+	sevenDayResetAt := observedAt.Add(4 * 24 * time.Hour).Unix()
+	account := &Account{ID: 42, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	usage := &OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{
+		PrimaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        12.5,
+			LimitWindowSeconds: 5 * 60 * 60,
+			ResetAfterSeconds:  600,
+		},
+		SecondaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        34.5,
+			LimitWindowSeconds: 7 * 24 * 60 * 60,
+			ResetAt:            sevenDayResetAt,
+		},
+	}}
+
+	snapshot := buildOpenAIQuotaSnapshot(account, usage, observedAt)
+	require.True(t, snapshot.Complete)
+	require.Empty(t, snapshot.MissingFields)
+	require.Equal(t, int64(42), snapshot.AccountID)
+	require.Equal(t, observedAt.Format(time.RFC3339Nano), snapshot.ObservedAt)
+	require.NotNil(t, snapshot.FiveHour)
+	require.NotNil(t, snapshot.SevenDay)
+	require.InDelta(t, 12.5, snapshot.FiveHour.UsedPercent, 1e-9)
+	require.InDelta(t, 34.5, snapshot.SevenDay.UsedPercent, 1e-9)
+	require.Equal(t, observedAt.Add(10*time.Minute).Format(time.RFC3339Nano), snapshot.FiveHour.ResetAt)
+	require.Equal(t, time.Unix(sevenDayResetAt, 0).UTC().Format(time.RFC3339Nano), snapshot.SevenDay.ResetAt)
+	require.True(t, snapshot.FiveHour.Provenance.ResetAtDerived)
+	require.Equal(t, "$.rate_limit.primary_window.reset_after_seconds", snapshot.FiveHour.Provenance.ResetAtField)
+	require.False(t, snapshot.SevenDay.Provenance.ResetAtDerived)
+	require.Equal(t, "$.rate_limit.secondary_window.reset_at", snapshot.SevenDay.Provenance.ResetAtField)
+	require.Equal(t, "chatgpt_wham_usage", snapshot.Provenance.Source)
+	require.False(t, snapshot.Provenance.CredentialRefreshed)
+	require.False(t, snapshot.Provenance.ModelRequestSent)
+	require.False(t, snapshot.Provenance.AccountStateMutated)
+	require.False(t, snapshot.Provenance.SchedulingStateMutated)
+}
+
+func TestBuildOpenAIQuotaSnapshotFailsClosedWhenResetIsMissing(t *testing.T) {
+	account := &Account{ID: 43, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	usage := &OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{
+		PrimaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        10,
+			LimitWindowSeconds: 5 * 60 * 60,
+		},
+		SecondaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        20,
+			LimitWindowSeconds: 7 * 24 * 60 * 60,
+			ResetAfterSeconds:  3600,
+		},
+	}}
+
+	snapshot := buildOpenAIQuotaSnapshot(account, usage, time.Now())
+	require.False(t, snapshot.Complete)
+	require.Equal(t, []string{"five_hour.reset_at"}, snapshot.MissingFields)
+	require.NotNil(t, snapshot.FiveHour)
+	require.Empty(t, snapshot.FiveHour.ResetAt)
+}
+
+func TestQueryReadOnlySnapshotUsesStoredTokenAndOnlyWhamUsage(t *testing.T) {
+	ctx := context.Background()
+	account := &Account{
+		ID:       44,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"chatgpt_account_id": "org-read-only",
+			"access_token":       "stored-token",
+		},
+	}
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{44: account}}
+
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		require.Equal(t, "Bearer stored-token", r.Header.Get("Authorization"))
+		require.Equal(t, "org-read-only", r.Header.Get("ChatGPT-Account-ID"))
+		w.Header().Set("content-type", "application/json")
+		_ = json.NewEncoder(w).Encode(OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{
+			PrimaryWindow: &OpenAIRateLimitWindow{
+				UsedPercent:        10,
+				LimitWindowSeconds: 5 * 60 * 60,
+				ResetAfterSeconds:  300,
+			},
+			SecondaryWindow: &OpenAIRateLimitWindow{
+				UsedPercent:        20,
+				LimitWindowSeconds: 7 * 24 * 60 * 60,
+				ResetAfterSeconds:  3600,
+			},
+		}})
+	}))
+	defer srv.Close()
+
+	// tokenProvider is deliberately nil. Entering the shared refresh path
+	// would fail this test before the upstream request is made.
+	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv))
+	snapshot, err := svc.QueryReadOnlySnapshot(ctx, 44)
+	require.NoError(t, err)
+	require.True(t, snapshot.Complete)
+	require.Equal(t, []string{"GET /backend-api/wham/usage"}, requests)
+	require.Equal(t, "stored_access_token", snapshot.Provenance.CredentialSource)
+	require.False(t, snapshot.Provenance.CredentialRefreshed)
+	require.False(t, snapshot.Provenance.ModelRequestSent)
+	require.False(t, snapshot.Provenance.AccountStateMutated)
+	require.False(t, snapshot.Provenance.SchedulingStateMutated)
+}

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -574,3 +574,37 @@ func TestQueryReadOnlySnapshotUsesStoredTokenAndOnlyWhamUsage(t *testing.T) {
 	require.False(t, snapshot.Provenance.AccountStateMutated)
 	require.False(t, snapshot.Provenance.SchedulingStateMutated)
 }
+
+func TestQueryReadOnlySnapshotFailsClosedOnExpiredStoredTokenWithoutRetry(t *testing.T) {
+	ctx := context.Background()
+	account := &Account{
+		ID:       47,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"chatgpt_account_id": "org-expired-token",
+			"access_token":       "expired-stored-token",
+		},
+	}
+	// The embedded nil AccountRepository makes every method except GetByID
+	// panic, so this also guards against account or scheduling writes.
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{47: account}}
+
+	requestCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		require.Equal(t, "Bearer expired-stored-token", r.Header.Get("Authorization"))
+		w.Header().Set("content-type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"expired"}`))
+	}))
+	defer srv.Close()
+
+	// A nil tokenProvider would panic if this path attempted credential refresh.
+	svc := NewOpenAIQuotaService(repo, nil, nil, newQuotaRedirectingFactory(srv))
+	snapshot, err := svc.QueryReadOnlySnapshot(ctx, 47)
+	require.Nil(t, snapshot)
+	require.ErrorContains(t, err, "upstream returned 401")
+	require.Equal(t, 1, requestCount, "expired stored tokens must not be refreshed or retried")
+}

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -481,6 +481,51 @@ func TestBuildOpenAIQuotaSnapshotFailsClosedWhenResetIsMissing(t *testing.T) {
 	require.Empty(t, snapshot.FiveHour.ResetAt)
 }
 
+func TestBuildOpenAIQuotaSnapshotFailsClosedWhenWindowDurationsAreAmbiguous(t *testing.T) {
+	account := &Account{ID: 45, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	usage := &OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{
+		PrimaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        10,
+			LimitWindowSeconds: 60 * 60,
+			ResetAfterSeconds:  300,
+		},
+		SecondaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        20,
+			LimitWindowSeconds: 30 * 24 * 60 * 60,
+			ResetAfterSeconds:  3600,
+		},
+	}}
+
+	snapshot := buildOpenAIQuotaSnapshot(account, usage, time.Now())
+	require.False(t, snapshot.Complete)
+	require.Equal(t, []string{"five_hour", "seven_day"}, snapshot.MissingFields)
+	require.Nil(t, snapshot.FiveHour)
+	require.Nil(t, snapshot.SevenDay)
+}
+
+func TestBuildOpenAIQuotaSnapshotIdentifiesExactWindowsWhenOrderIsReversed(t *testing.T) {
+	account := &Account{ID: 46, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	usage := &OpenAIQuotaUsage{RateLimit: &OpenAIRateLimit{
+		PrimaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        70,
+			LimitWindowSeconds: 7 * 24 * 60 * 60,
+			ResetAfterSeconds:  3600,
+		},
+		SecondaryWindow: &OpenAIRateLimitWindow{
+			UsedPercent:        30,
+			LimitWindowSeconds: 5 * 60 * 60,
+			ResetAfterSeconds:  300,
+		},
+	}}
+
+	snapshot := buildOpenAIQuotaSnapshot(account, usage, time.Now())
+	require.True(t, snapshot.Complete)
+	require.InDelta(t, 30, snapshot.FiveHour.UsedPercent, 1e-9)
+	require.InDelta(t, 70, snapshot.SevenDay.UsedPercent, 1e-9)
+	require.Equal(t, "$.rate_limit.secondary_window", snapshot.FiveHour.Provenance.SourcePath)
+	require.Equal(t, "$.rate_limit.primary_window", snapshot.SevenDay.Provenance.SourcePath)
+}
+
 func TestQueryReadOnlySnapshotUsesStoredTokenAndOnlyWhamUsage(t *testing.T) {
 	ctx := context.Background()
 	account := &Account{


### PR DESCRIPTION
## Summary

Add a read-only OpenAI OAuth quota snapshot endpoint:

`GET /api/v1/admin/openai/accounts/:id/quota-snapshot`

The endpoint returns canonical 5-hour and 7-day usage windows from one upstream `/backend-api/wham/usage` observation, including a shared `observed_at`, absolute reset timestamps, completeness, and field-level provenance.

Window identity is fail-closed: only exact 18,000-second and 604,800-second windows are labeled as 5-hour and 7-day data. Missing or ambiguous durations are never inferred from primary/secondary ordering.

## Why

Consumers that make quota-sensitive decisions need a coherent observation rather than a mixture of cached usage percentages and reset timestamps captured at different times. The existing quota paths also include refresh and reset workflows that are too broad for read-only observation.

## Safety boundary

This endpoint:

- uses only the access token already stored on the account
- sends exactly one `GET /backend-api/wham/usage` request
- does not send a model request
- does not refresh credentials
- does not mutate account or scheduling state
- reports incomplete snapshots explicitly so callers can fail closed

## Validation

- targeted quota service tests, including one-observation normalization and missing-reset fail-closed behavior
- admin handler and route compilation
- `gofmt` clean