### PR TITLE
fix(openai): 为 Codex HTTP/2 上游启用 PING 健康探测，剔除死连接

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/andybalholm/brotli"
 	"github.com/klauspost/compress/zstd"
+	"golang.org/x/net/http2"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyurl"
@@ -59,6 +60,13 @@ const (
 	defaultOpenAIHTTP2FallbackErrorThreshold = 2
 	defaultOpenAIHTTP2FallbackWindow         = 60 * time.Second
 	defaultOpenAIHTTP2FallbackTTL            = 10 * time.Minute
+	// OpenAI HTTP/2 连接健康探测：Codex 上游改走 HTTP/2 后，池化连接被代理/NAT
+	// 静默掐断会成为“死连接”（两端都以为存活），请求落上去会挂到 TCP 重传超时
+	// （分钟级）。Go 的 http2.Transport 默认 ReadIdleTimeout=0（不发健康 PING），
+	// 无法检测。启用主动 PING 探测：连接空闲 ReadIdleTimeout 后发 PING，PingTimeout
+	// 内无响应即判定死连接并关闭，从源头避免请求挂在死连接上。
+	openAIHTTP2ReadIdleTimeout = 15 * time.Second
+	openAIHTTP2PingTimeout     = 15 * time.Second
 
 	// The Grok CLI proxy rejects requests that do not identify a supported
 	// client version. Keep a known-good stable version in the binary while
@@ -1101,6 +1109,11 @@ func buildUpstreamTransport(settings poolSettings, proxyURL *url.URL, protocolMo
 	switch protocolMode {
 	case upstreamProtocolModeOpenAIH2:
 		transport.ForceAttemptHTTP2 = true
+		// 显式配置 http2 并启用 PING 健康探测，剔除代理/NAT 静默掐断的死连接，
+		// 避免请求挂在死连接上直到 TCP 重传超时（分钟级）。
+		if _, err := enableOpenAIHTTP2KeepAlive(transport); err != nil {
+			return nil, err
+		}
 	case upstreamProtocolModeOpenAIH1:
 		transport.ForceAttemptHTTP2 = false
 		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
@@ -1113,6 +1126,22 @@ func buildUpstreamTransport(settings poolSettings, proxyURL *url.URL, protocolMo
 		return nil, err
 	}
 	return transport, nil
+}
+
+// enableOpenAIHTTP2KeepAlive 在 http.Transport 上显式配置 HTTP/2 并启用连接健康探测。
+// Go 默认惰性配置 http2 且 ReadIdleTimeout=0（不发健康 PING），无法检测被代理/NAT
+// 静默掐断的死连接。此处主动设置 ReadIdleTimeout/PingTimeout，让死连接被提前 PING
+// 出并关闭，请求得以重建连接而非挂到 TCP 重传超时。返回底层 *http2.Transport 便于测试。
+func enableOpenAIHTTP2KeepAlive(transport *http.Transport) (*http2.Transport, error) {
+	h2, err := http2.ConfigureTransports(transport)
+	if err != nil {
+		return nil, err
+	}
+	if h2 != nil {
+		h2.ReadIdleTimeout = openAIHTTP2ReadIdleTimeout
+		h2.PingTimeout = openAIHTTP2PingTimeout
+	}
+	return h2, nil
 }
 
 // buildUpstreamTransportWithTLSFingerprint 构建带 TLS 指纹伪装的 Transport

--- a/backend/internal/repository/http_upstream_http2_keepalive_test.go
+++ b/backend/internal/repository/http_upstream_http2_keepalive_test.go
@@ -1,0 +1,67 @@
+package repository
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func http2KeepAliveTestPoolSettings() poolSettings {
+	return poolSettings{
+		maxIdleConns:          10,
+		maxIdleConnsPerHost:   5,
+		maxConnsPerHost:       10,
+		idleConnTimeout:       90 * time.Second,
+		responseHeaderTimeout: time.Minute,
+	}
+}
+
+// Codex/OpenAI 上游改走 HTTP/2 后，池化连接被代理/NAT 静默掐断会成为“死连接”：
+// 两端都以为连接存活，请求落上去会挂到 TCP 重传超时（分钟级）才失败。Go 的
+// http2.Transport 默认 ReadIdleTimeout=0（不发健康 PING），无法检测这种死连接。
+// 必须显式启用主动 PING 探测，让死连接被提前剔除，而不是只靠 ResponseHeaderTimeout
+// 事后兜底。
+func TestEnableOpenAIHTTP2KeepAlive_EnablesPingHealthCheck(t *testing.T) {
+	tr := &http.Transport{}
+
+	h2, err := enableOpenAIHTTP2KeepAlive(tr)
+	require.NoError(t, err)
+	require.NotNil(t, h2, "必须返回已配置的 *http2.Transport")
+
+	require.Positive(t, h2.ReadIdleTimeout, "必须启用空闲 PING 探测以剔除死连接")
+	require.Equal(t, openAIHTTP2ReadIdleTimeout, h2.ReadIdleTimeout)
+	require.Equal(t, openAIHTTP2PingTimeout, h2.PingTimeout, "PING 无响应必须有超时判定")
+	require.NotNil(t, tr.TLSNextProto["h2"], "http2 必须已挂到底层 http.Transport 上")
+}
+
+// openai_h2 模式构建的 Transport 必须带上 H2 PING 健康探测，从源头剔除死连接。
+func TestBuildUpstreamTransport_OpenAIH2_EnablesPingHealthCheck(t *testing.T) {
+	tr, err := buildUpstreamTransport(http2KeepAliveTestPoolSettings(), nil, upstreamProtocolModeOpenAIH2)
+	require.NoError(t, err)
+	require.True(t, tr.ForceAttemptHTTP2, "openai_h2 必须启用 HTTP/2")
+	require.NotNil(t, tr.TLSNextProto["h2"], "openai_h2 必须显式配置 http2 以启用 ReadIdleTimeout")
+}
+
+// 非 H2 模式（default/h1）不应因本次改动被误配置：default 走 Go 自动 H2（惰性配置，
+// 构建时 TLSNextProto 仍为空），h1 模式显式禁用 H2。避免波及 Claude/Gemini 热路径。
+func TestBuildUpstreamTransport_NonOpenAIH2_NotEagerlyConfigured(t *testing.T) {
+	tr, err := buildUpstreamTransport(http2KeepAliveTestPoolSettings(), nil, upstreamProtocolModeDefault)
+	require.NoError(t, err)
+	require.Nil(t, tr.TLSNextProto["h2"], "default 模式不应在构建期主动配置 http2 keepalive")
+}
+
+// 死连接在经 HTTP 代理（CONNECT 隧道）时最高发，这是带 proxy 账号的真实生产路径：
+// 显式 http2 配置须与 Transport.Proxy 同时正确生效，不能相互干扰。
+func TestBuildUpstreamTransport_OpenAIH2_WithHTTPProxy_EnablesKeepAlive(t *testing.T) {
+	proxyURL, err := url.Parse("http://127.0.0.1:8080")
+	require.NoError(t, err)
+
+	tr, err := buildUpstreamTransport(http2KeepAliveTestPoolSettings(), proxyURL, upstreamProtocolModeOpenAIH2)
+	require.NoError(t, err)
+	require.True(t, tr.ForceAttemptHTTP2)
+	require.NotNil(t, tr.TLSNextProto["h2"], "经代理的 openai_h2 也必须启用 http2 keepalive")
+	require.NotNil(t, tr.Proxy, "HTTP 代理仍须通过 Transport.Proxy 生效")
+}


### PR DESCRIPTION
## 问题

Codex/OpenAI 上游走 HTTP/2 后，出站 `http.Transport` 只设了 `ForceAttemptHTTP2=true`，**没有配置 http2 的 `ReadIdleTimeout`/`PingTimeout`**（`buildUpstreamTransport` 的 `openai_h2` 分支）。同时 OpenAI profile 把 `ResponseHeaderTimeout` 显式置 0（`applyProfilePoolSettings`）。

于是连接池里被中间代理/NAT 静默掐断的 HTTP/2 连接会变成「死连接」——两端都以为连接存活，新请求被分配到这条死连接上后，会一直挂到操作系统 TCP 重传超时（分钟级）才失败。

生产环境实测：一条 `gpt-5.x` codex 流式请求 **首字 8m37s、总耗时 8m44s，最终仍返回 200**（连接最终恢复/重试成功）。特征是**偶发**（只有请求正好落到死连接才触发）、**与分组无关**（共享的 OpenAI transport），且 idle 连接池越大越容易命中。

Go 的 `http2.Transport` 默认 `ReadIdleTimeout=0`，不发送健康 PING，无法主动发现这类死连接。

## 修复

在 `openai_h2` 的 transport 上显式调用 `http2.ConfigureTransports` 并启用主动 PING 健康探测：

- `ReadIdleTimeout = 15s`：连接空闲超过该时长后发送 HTTP/2 PING 帧；
- `PingTimeout = 15s`：PING 在该时长内无响应即判定连接失效并关闭。

死连接因此被**提前探测并剔除**，请求得以在新连接上重建，而不是挂在死连接上直到 TCP 超时。

- 仅作用于 `openai_h2` 路径；`default`（Claude/Gemini 自动 H2）与 `openai_h1`/`openai_h1_fallback` 模式不受影响。
- 抽出 `enableOpenAIHTTP2KeepAlive` 助手，返回底层 `*http2.Transport` 以便单元测试断言超时值。

## 测试

新增 `http_upstream_http2_keepalive_test.go`（4 例，自包含）：
- 助手正确设置 `ReadIdleTimeout`/`PingTimeout`；
- `openai_h2` 构建的 transport 挂上了 http2；
- `default` 模式不被主动配置（不误伤 Claude/Gemini 热路径）；
- 经 HTTP 代理的 `openai_h2` 仍正确启用 keepalive（代理与 http2 配置并存）。

`go build ./...`、`go test ./internal/repository/`、`gofmt`、`go vet` 均通过。

## 与 `openai_response_header_timeout` 的关系

`GATEWAY_OPENAI_RESPONSE_HEADER_TIMEOUT`（默认 0）是**事后兜底**：请求挂满该时长后放弃并转 failover。本 PR 是**根治**：让请求根本不落到死连接上。二者互补。