### PR TITLE
feat(ops): add Host filtering to system logs 

### DIFF
--- a/backend/internal/handler/admin/ops_system_log_handler.go
+++ b/backend/internal/handler/admin/ops_system_log_handler.go
@@ -15,6 +15,7 @@ import (
 type opsSystemLogCleanupRequest struct {
 	StartTime string `json:"start_time"`
 	EndTime   string `json:"end_time"`
+	Host      string `json:"host"`
 
 	Level           string `json:"level"`
 	Component       string `json:"component"`
@@ -56,6 +57,7 @@ func (h *OpsHandler) ListSystemLogs(c *gin.Context) {
 		PageSize:        pageSize,
 		StartTime:       &start,
 		EndTime:         &end,
+		Host:            strings.TrimSpace(c.Query("host")),
 		Level:           strings.TrimSpace(c.Query("level")),
 		Component:       strings.TrimSpace(c.Query("component")),
 		RequestID:       strings.TrimSpace(c.Query("request_id")),
@@ -153,6 +155,7 @@ func (h *OpsHandler) CleanupSystemLogs(c *gin.Context) {
 	filter := &service.OpsSystemLogCleanupFilter{
 		StartTime:       start,
 		EndTime:         end,
+		Host:            strings.TrimSpace(req.Host),
 		Level:           strings.TrimSpace(req.Level),
 		Component:       strings.TrimSpace(req.Component),
 		RequestID:       strings.TrimSpace(req.RequestID),

--- a/backend/internal/handler/admin/ops_system_log_handler_test.go
+++ b/backend/internal/handler/admin/ops_system_log_handler_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,26 @@ type responseEnvelope struct {
 	Code    int             `json:"code"`
 	Message string          `json:"message"`
 	Data    json.RawMessage `json:"data"`
+}
+
+type opsSystemLogCaptureRepo struct {
+	service.OpsRepository
+	listFilter    *service.OpsSystemLogFilter
+	cleanupFilter *service.OpsSystemLogCleanupFilter
+}
+
+func (r *opsSystemLogCaptureRepo) ListSystemLogs(_ context.Context, filter *service.OpsSystemLogFilter) (*service.OpsSystemLogList, error) {
+	r.listFilter = filter
+	return &service.OpsSystemLogList{Logs: []*service.OpsSystemLog{}, Page: filter.Page, PageSize: filter.PageSize}, nil
+}
+
+func (r *opsSystemLogCaptureRepo) DeleteSystemLogs(_ context.Context, filter *service.OpsSystemLogCleanupFilter) (int64, error) {
+	r.cleanupFilter = filter
+	return 1, nil
+}
+
+func (r *opsSystemLogCaptureRepo) InsertSystemLogCleanupAudit(_ context.Context, _ *service.OpsSystemLogCleanupAudit) error {
+	return nil
 }
 
 func newOpsSystemLogTestRouter(handler *OpsHandler, withUser bool) *gin.Engine {
@@ -121,6 +142,23 @@ func TestOpsSystemLogHandler_ListSuccess(t *testing.T) {
 	}
 }
 
+func TestOpsSystemLogHandler_ListAcceptsHost(t *testing.T) {
+	repo := &opsSystemLogCaptureRepo{}
+	svc := service.NewOpsService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := NewOpsHandler(svc)
+	r := newOpsSystemLogTestRouter(h, false)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/logs?host=api-node-1", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+	if repo.listFilter == nil || repo.listFilter.Host != "api-node-1" {
+		t.Fatalf("host filter = %+v, want api-node-1", repo.listFilter)
+	}
+}
+
 func TestOpsSystemLogHandler_CleanupUnauthorized(t *testing.T) {
 	svc := service.NewOpsService(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	h := NewOpsHandler(svc)
@@ -202,6 +240,24 @@ func TestOpsSystemLogHandler_CleanupAcceptsAPIKeyID(t *testing.T) {
 	r.ServeHTTP(w, req)
 	if w.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status=%d, want 503", w.Code)
+	}
+}
+
+func TestOpsSystemLogHandler_CleanupAcceptsHost(t *testing.T) {
+	repo := &opsSystemLogCaptureRepo{}
+	svc := service.NewOpsService(repo, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	h := NewOpsHandler(svc)
+	r := newOpsSystemLogTestRouter(h, true)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/logs/cleanup", bytes.NewBufferString(`{"host":"api-node-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d, want 200", w.Code)
+	}
+	if repo.cleanupFilter == nil || repo.cleanupFilter.Host != "api-node-1" {
+		t.Fatalf("host filter = %+v, want api-node-1", repo.cleanupFilter)
 	}
 }
 

--- a/backend/internal/repository/ops_repo.go
+++ b/backend/internal/repository/ops_repo.go
@@ -718,6 +718,7 @@ func (r *opsRepository) BatchInsertSystemLogs(ctx context.Context, inputs []*ser
 	stmt, err := tx.PrepareContext(ctx, pq.CopyIn(
 		"ops_system_logs",
 		"created_at",
+		"host",
 		"level",
 		"component",
 		"message",
@@ -760,6 +761,7 @@ func (r *opsRepository) BatchInsertSystemLogs(ctx context.Context, inputs []*ser
 		if _, err := stmt.ExecContext(
 			ctx,
 			createdAt.UTC(),
+			opsNullString(input.Host),
 			level,
 			component,
 			message,
@@ -827,6 +829,7 @@ func (r *opsRepository) ListSystemLogs(ctx context.Context, filter *service.OpsS
 SELECT
   l.id,
   l.created_at,
+  COALESCE(l.host, ''),
   l.level,
   COALESCE(l.component, ''),
   COALESCE(l.message, ''),
@@ -859,6 +862,7 @@ LIMIT $` + itoa(len(args)+1) + ` OFFSET $` + itoa(len(args)+2)
 		if err := rows.Scan(
 			&item.ID,
 			&item.CreatedAt,
+			&item.Host,
 			&item.Level,
 			&item.Component,
 			&item.Message,
@@ -1130,6 +1134,11 @@ func buildOpsSystemLogsWhere(filter *service.OpsSystemLogFilter) (string, []any,
 		hasConstraint = true
 	}
 	if filter != nil {
+		if v := strings.TrimSpace(filter.Host); v != "" {
+			args = append(args, v)
+			clauses = append(clauses, "l.host = $"+itoa(len(args)))
+			hasConstraint = true
+		}
 		if v := strings.ToLower(strings.TrimSpace(filter.Level)); v != "" {
 			args = append(args, v)
 			clauses = append(clauses, "LOWER(COALESCE(l.level,'')) = $"+itoa(len(args)))
@@ -1194,6 +1203,7 @@ func buildOpsSystemLogsCleanupWhere(filter *service.OpsSystemLogCleanupFilter) (
 	listFilter := &service.OpsSystemLogFilter{
 		StartTime:       filter.StartTime,
 		EndTime:         filter.EndTime,
+		Host:            filter.Host,
 		Level:           filter.Level,
 		Component:       filter.Component,
 		RequestID:       filter.RequestID,

--- a/backend/internal/repository/ops_repo_system_logs_test.go
+++ b/backend/internal/repository/ops_repo_system_logs_test.go
@@ -18,6 +18,7 @@ func TestBuildOpsSystemLogsWhere_WithClientRequestIDAndUserID(t *testing.T) {
 	filter := &service.OpsSystemLogFilter{
 		StartTime:       &start,
 		EndTime:         &end,
+		Host:            "api-node-1",
 		Level:           "warn",
 		Component:       "http.access",
 		RequestID:       "req-1",
@@ -37,8 +38,11 @@ func TestBuildOpsSystemLogsWhere_WithClientRequestIDAndUserID(t *testing.T) {
 	if where == "" {
 		t.Fatalf("where should not be empty")
 	}
-	if len(args) != 12 {
-		t.Fatalf("args len = %d, want 12", len(args))
+	if len(args) != 13 {
+		t.Fatalf("args len = %d, want 13", len(args))
+	}
+	if !contains(where, "l.host = $") {
+		t.Fatalf("where should include host condition: %s", where)
 	}
 	if !contains(where, "COALESCE(l.client_request_id,'') = $") {
 		t.Fatalf("where should include client_request_id condition: %s", where)
@@ -68,6 +72,7 @@ func TestBuildOpsSystemLogsCleanupWhere_WithClientRequestIDAndUserID(t *testing.
 	userID := int64(9)
 	apiKeyID := int64(10)
 	filter := &service.OpsSystemLogCleanupFilter{
+		Host:            "api-node-2",
 		ClientRequestID: "creq-9",
 		UserID:          &userID,
 		APIKeyID:        &apiKeyID,
@@ -77,8 +82,11 @@ func TestBuildOpsSystemLogsCleanupWhere_WithClientRequestIDAndUserID(t *testing.
 	if !hasConstraint {
 		t.Fatalf("expected hasConstraint=true")
 	}
-	if len(args) != 3 {
-		t.Fatalf("args len = %d, want 3", len(args))
+	if len(args) != 4 {
+		t.Fatalf("args len = %d, want 4", len(args))
+	}
+	if !contains(where, "l.host = $") {
+		t.Fatalf("where should include host condition: %s", where)
 	}
 	if !contains(where, "COALESCE(l.client_request_id,'') = $") {
 		t.Fatalf("where should include client_request_id condition: %s", where)

--- a/backend/internal/service/ops_models.go
+++ b/backend/internal/service/ops_models.go
@@ -8,6 +8,7 @@ import (
 type OpsSystemLog struct {
 	ID              int64          `json:"id"`
 	CreatedAt       time.Time      `json:"created_at"`
+	Host            string         `json:"host"`
 	Level           string         `json:"level"`
 	Component       string         `json:"component"`
 	Message         string         `json:"message"`

--- a/backend/internal/service/ops_port.go
+++ b/backend/internal/service/ops_port.go
@@ -194,6 +194,7 @@ type OpsInsertSystemMetricsInput struct {
 
 type OpsInsertSystemLogInput struct {
 	CreatedAt       time.Time
+	Host            string
 	Level           string
 	Component       string
 	Message         string
@@ -210,6 +211,7 @@ type OpsInsertSystemLogInput struct {
 type OpsSystemLogFilter struct {
 	StartTime *time.Time
 	EndTime   *time.Time
+	Host      string
 
 	Level     string
 	Component string
@@ -230,6 +232,7 @@ type OpsSystemLogFilter struct {
 type OpsSystemLogCleanupFilter struct {
 	StartTime *time.Time
 	EndTime   *time.Time
+	Host      string
 
 	Level     string
 	Component string

--- a/backend/internal/service/ops_system_log_service.go
+++ b/backend/internal/service/ops_system_log_service.go
@@ -89,6 +89,7 @@ func marshalSystemLogCleanupConditions(filter *OpsSystemLogCleanupFilter) string
 		return "{}"
 	}
 	payload := map[string]any{
+		"host":              strings.TrimSpace(filter.Host),
 		"level":             strings.TrimSpace(filter.Level),
 		"component":         strings.TrimSpace(filter.Component),
 		"request_id":        strings.TrimSpace(filter.RequestID),

--- a/backend/internal/service/ops_system_log_service_test.go
+++ b/backend/internal/service/ops_system_log_service_test.go
@@ -101,6 +101,7 @@ func TestOpsServiceCleanupSystemLogs_SuccessAndAudit(t *testing.T) {
 	now := time.Now().UTC()
 	filter := &OpsSystemLogCleanupFilter{
 		StartTime:       &now,
+		Host:            "api-node-1",
 		Level:           "warn",
 		RequestID:       "req-1",
 		ClientRequestID: "creq-1",
@@ -118,6 +119,9 @@ func TestOpsServiceCleanupSystemLogs_SuccessAndAudit(t *testing.T) {
 	}
 	if audit == nil {
 		t.Fatalf("expected cleanup audit")
+	}
+	if !strings.Contains(audit.Conditions, `"host":"api-node-1"`) {
+		t.Fatalf("audit conditions should include host: %s", audit.Conditions)
 	}
 	if !strings.Contains(audit.Conditions, `"client_request_id":"creq-1"`) {
 		t.Fatalf("audit conditions should include client_request_id: %s", audit.Conditions)

--- a/backend/internal/service/ops_system_log_sink.go
+++ b/backend/internal/service/ops_system_log_sink.go
@@ -27,6 +27,7 @@ type OpsSystemLogSinkHealth struct {
 
 type OpsSystemLogSink struct {
 	opsRepo OpsRepository
+	host    string
 
 	queue chan *logger.LogEvent
 
@@ -47,8 +48,13 @@ type OpsSystemLogSink struct {
 
 func NewOpsSystemLogSink(opsRepo OpsRepository) *OpsSystemLogSink {
 	ctx, cancel := context.WithCancel(context.Background())
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		host = "unknown"
+	}
 	s := &OpsSystemLogSink{
 		opsRepo:       opsRepo,
+		host:          strings.TrimSpace(host),
 		queue:         make(chan *logger.LogEvent, 5000),
 		batchSize:     200,
 		flushInterval: time.Second,
@@ -220,6 +226,7 @@ func (s *OpsSystemLogSink) flushBatch(baseCtx context.Context, batch []*logger.L
 
 		inputs = append(inputs, &OpsInsertSystemLogInput{
 			CreatedAt:       createdAt,
+			Host:            s.host,
 			Level:           strings.ToLower(strings.TrimSpace(event.Level)),
 			Component:       component,
 			Message:         message,

--- a/backend/internal/service/ops_system_log_sink.go
+++ b/backend/internal/service/ops_system_log_sink.go
@@ -46,15 +46,14 @@ type OpsSystemLogSink struct {
 	lastError atomic.Value
 }
 
+const maxSystemLogHostLength = 255
+
 func NewOpsSystemLogSink(opsRepo OpsRepository) *OpsSystemLogSink {
 	ctx, cancel := context.WithCancel(context.Background())
-	host, err := os.Hostname()
-	if err != nil || strings.TrimSpace(host) == "" {
-		host = "unknown"
-	}
+	rawHost, err := os.Hostname()
 	s := &OpsSystemLogSink{
 		opsRepo:       opsRepo,
-		host:          strings.TrimSpace(host),
+		host:          normalizeSystemLogHost(rawHost, err),
 		queue:         make(chan *logger.LogEvent, 5000),
 		batchSize:     200,
 		flushInterval: time.Second,
@@ -63,6 +62,18 @@ func NewOpsSystemLogSink(opsRepo OpsRepository) *OpsSystemLogSink {
 	}
 	s.lastError.Store("")
 	return s
+}
+
+func normalizeSystemLogHost(host string, err error) string {
+	host = strings.TrimSpace(host)
+	if err != nil || host == "" {
+		return "unknown"
+	}
+	runes := []rune(host)
+	if len(runes) > maxSystemLogHostLength {
+		return string(runes[:maxSystemLogHostLength])
+	}
+	return host
 }
 
 func (s *OpsSystemLogSink) Start() {

--- a/backend/internal/service/ops_system_log_sink_test.go
+++ b/backend/internal/service/ops_system_log_sink_test.go
@@ -140,6 +140,7 @@ func TestOpsSystemLogSink_StartStopAndFlushSuccess(t *testing.T) {
 	}
 
 	sink := NewOpsSystemLogSink(repo)
+	sink.host = "api-node-1"
 	sink.batchSize = 1
 	sink.flushInterval = 10 * time.Millisecond
 	sink.Start()
@@ -172,6 +173,9 @@ func TestOpsSystemLogSink_StartStopAndFlushSuccess(t *testing.T) {
 		t.Fatalf("captured len = %d, want 1", len(captured))
 	}
 	item := captured[0]
+	if item.Host != "api-node-1" {
+		t.Fatalf("host = %q, want api-node-1", item.Host)
+	}
 	if item.RequestID != "req-1" || item.ClientRequestID != "creq-1" {
 		t.Fatalf("unexpected request ids: %+v", item)
 	}

--- a/backend/internal/service/ops_system_log_sink_test.go
+++ b/backend/internal/service/ops_system_log_sink_test.go
@@ -328,3 +328,20 @@ func TestOpsSystemLogSink_HelperFunctions(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeSystemLogHost(t *testing.T) {
+	if got := normalizeSystemLogHost(" api-node-1 ", nil); got != "api-node-1" {
+		t.Fatalf("trimmed host = %q, want api-node-1", got)
+	}
+	if got := normalizeSystemLogHost("", nil); got != "unknown" {
+		t.Fatalf("empty host = %q, want unknown", got)
+	}
+	if got := normalizeSystemLogHost("api-node-1", errors.New("hostname unavailable")); got != "unknown" {
+		t.Fatalf("errored host = %q, want unknown", got)
+	}
+	longHost := strings.Repeat("节", maxSystemLogHostLength+1)
+	got := normalizeSystemLogHost(longHost, nil)
+	if runeCount := len([]rune(got)); runeCount != maxSystemLogHostLength {
+		t.Fatalf("truncated host rune count = %d, want %d", runeCount, maxSystemLogHostLength)
+	}
+}

--- a/backend/migrations/175_add_ops_system_logs_host.sql
+++ b/backend/migrations/175_add_ops_system_logs_host.sql
@@ -1,0 +1,3 @@
+-- Track the application host that emitted each indexed system log.
+ALTER TABLE ops_system_logs
+  ADD COLUMN IF NOT EXISTS host VARCHAR(255);

--- a/backend/migrations/175a_add_ops_system_logs_host_index_notx.sql
+++ b/backend/migrations/175a_add_ops_system_logs_host_index_notx.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_ops_system_logs_host_created_at
+  ON ops_system_logs (host, created_at DESC);

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -828,6 +828,7 @@ export interface OpsRuntimeLogConfig {
 export interface OpsSystemLog {
   id: number
   created_at: string
+  host: string
   level: string
   component: string
   message: string
@@ -849,6 +850,7 @@ export interface OpsSystemLogQuery {
   time_range?: '5m' | '30m' | '1h' | '6h' | '24h' | '7d' | '30d'
   start_time?: string
   end_time?: string
+  host?: string
   level?: string
   component?: string
   request_id?: string
@@ -864,6 +866,7 @@ export interface OpsSystemLogQuery {
 export interface OpsSystemLogCleanupRequest {
   start_time?: string
   end_time?: string
+  host?: string
   level?: string
   component?: string
   request_id?: string

--- a/frontend/src/i18n/locales/en/admin/ops.ts
+++ b/frontend/src/i18n/locales/en/admin/ops.ts
@@ -50,6 +50,7 @@ export default {
         timeRange: 'Time range',
         startTime: 'Start time (optional)',
         endTime: 'End time (optional)',
+        host: 'Host',
         component: 'Component',
         componentPlaceholder: 'e.g. http.access',
         keyId: 'KEY ID',

--- a/frontend/src/i18n/locales/zh/admin/ops.ts
+++ b/frontend/src/i18n/locales/zh/admin/ops.ts
@@ -50,6 +50,7 @@ export default {
         timeRange: '时间范围',
         startTime: '开始时间（可选）',
         endTime: '结束时间（可选）',
+        host: 'Host',
         component: '组件',
         componentPlaceholder: '例如 http.access',
         keyId: 'KEY ID',

--- a/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
+++ b/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
@@ -48,6 +48,7 @@ const filters = reactive({
   time_range: '1h' as '5m' | '30m' | '1h' | '6h' | '24h' | '7d' | '30d',
   start_time: '',
   end_time: '',
+  host: '',
   level: '',
   component: '',
   request_id: '',
@@ -175,6 +176,7 @@ const buildQuery = () => {
   }
   if (filters.start_time) query.start_time = toRFC3339(filters.start_time)
   if (filters.end_time) query.end_time = toRFC3339(filters.end_time)
+  if (filters.host.trim()) query.host = filters.host.trim()
   if (filters.level.trim()) query.level = filters.level.trim()
   if (filters.component.trim()) query.component = filters.component.trim()
   if (filters.request_id.trim()) query.request_id = filters.request_id.trim()
@@ -288,6 +290,7 @@ const cleanupCurrentFilter = async () => {
     const payload = {
       start_time: toRFC3339(filters.start_time),
       end_time: toRFC3339(filters.end_time),
+      host: filters.host.trim() || undefined,
       level: filters.level.trim() || undefined,
       component: filters.component.trim() || undefined,
       request_id: filters.request_id.trim() || undefined,
@@ -313,6 +316,7 @@ const resetFilters = () => {
   filters.time_range = '1h'
   filters.start_time = ''
   filters.end_time = ''
+  filters.host = ''
   filters.level = ''
   filters.component = ''
   filters.request_id = ''
@@ -455,6 +459,10 @@ onMounted(async () => {
         <input v-model="filters.component" type="text" class="input mt-1" :placeholder="t('admin.ops.systemLogs.componentPlaceholder')" />
       </label>
       <label class="text-xs text-gray-600 dark:text-gray-300">
+        {{ t('admin.ops.systemLogs.host') }}
+        <input v-model="filters.host" type="text" class="input mt-1" />
+      </label>
+      <label class="text-xs text-gray-600 dark:text-gray-300">
         request_id
         <input v-model="filters.request_id" type="text" class="input mt-1" />
       </label>
@@ -503,6 +511,7 @@ onMounted(async () => {
           <thead class="bg-gray-50 dark:bg-dark-900">
             <tr>
               <th class="w-[170px] px-3 py-2 text-left text-[11px] font-semibold text-gray-500">{{ t('admin.ops.systemLogs.time') }}</th>
+              <th class="w-[160px] px-3 py-2 text-left text-[11px] font-semibold text-gray-500">{{ t('admin.ops.systemLogs.host') }}</th>
               <th class="w-[80px] px-3 py-2 text-left text-[11px] font-semibold text-gray-500">{{ t('admin.ops.systemLogs.level') }}</th>
               <th class="px-3 py-2 text-left text-[11px] font-semibold text-gray-500">{{ t('admin.ops.systemLogs.logDetails') }}</th>
             </tr>
@@ -510,6 +519,9 @@ onMounted(async () => {
           <tbody class="divide-y divide-gray-100 dark:divide-dark-800">
             <tr v-for="row in logs" :key="row.id" class="align-top">
               <td class="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">{{ formatTime(row.created_at) }}</td>
+              <td class="px-3 py-2 text-xs text-gray-700 dark:text-gray-300">
+                <span class="block truncate" :title="row.host || '-'">{{ row.host || '-' }}</span>
+              </td>
               <td class="px-3 py-2 text-xs">
                 <span class="inline-flex rounded-full px-2 py-0.5 font-semibold" :class="levelBadgeClass(row.level)">
                   {{ row.level }}

--- a/frontend/src/views/admin/ops/components/__tests__/OpsSystemLogTable.spec.ts
+++ b/frontend/src/views/admin/ops/components/__tests__/OpsSystemLogTable.spec.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { flushPromises, mount } from '@vue/test-utils'
+import OpsSystemLogTable from '../OpsSystemLogTable.vue'
+import enLocale from '@/i18n/locales/en'
+import zhLocale from '@/i18n/locales/zh'
+
+const mockListSystemLogs = vi.fn()
+const mockCleanupSystemLogs = vi.fn()
+const mockGetSystemLogSinkHealth = vi.fn()
+const mockGetRuntimeLogConfig = vi.fn()
+
+vi.mock('@/api/admin/ops', () => ({
+  opsAPI: {
+    listSystemLogs: (...args: any[]) => mockListSystemLogs(...args),
+    cleanupSystemLogs: (...args: any[]) => mockCleanupSystemLogs(...args),
+    getSystemLogSinkHealth: (...args: any[]) => mockGetSystemLogSinkHealth(...args),
+    getRuntimeLogConfig: (...args: any[]) => mockGetRuntimeLogConfig(...args),
+  },
+}))
+
+vi.mock('@/stores', () => ({
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+  }),
+}))
+
+vi.mock('vue-i18n', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-i18n')>()
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  }
+})
+
+const SelectStub = defineComponent({
+  name: 'SelectControlStub',
+  props: {
+    modelValue: {
+      type: [String, Number],
+      default: '',
+    },
+  },
+  emits: ['update:modelValue'],
+  template: '<div class="select-stub" />',
+})
+
+const PaginationStub = defineComponent({
+  name: 'PaginationStub',
+  template: '<div class="pagination-stub" />',
+})
+
+const runtimeConfig = {
+  level: 'info',
+  enable_sampling: false,
+  sampling_initial: 100,
+  sampling_thereafter: 100,
+  caller: true,
+  stacktrace_level: 'error',
+  retention_days: 30,
+}
+
+const sinkHealth = {
+  queue_depth: 0,
+  queue_capacity: 5000,
+  dropped_count: 0,
+  write_failed_count: 0,
+  written_count: 1,
+  avg_write_delay_ms: 0,
+}
+
+describe('OpsSystemLogTable host support', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    mockListSystemLogs.mockResolvedValue({
+      items: [
+        {
+          id: 1,
+          created_at: '2026-07-14T00:10:01Z',
+          host: 'api-node-1',
+          level: 'warn',
+          component: 'app',
+          message: 'request failed',
+        },
+      ],
+      total: 1,
+      page: 1,
+      page_size: 20,
+    })
+    mockCleanupSystemLogs.mockResolvedValue({ deleted: 1 })
+    mockGetSystemLogSinkHealth.mockResolvedValue(sinkHealth)
+    mockGetRuntimeLogConfig.mockResolvedValue(runtimeConfig)
+  })
+
+  it('renders the host and sends it with list and cleanup filters', async () => {
+    const wrapper = mount(OpsSystemLogTable, {
+      global: {
+        stubs: {
+          Select: SelectStub,
+          Pagination: PaginationStub,
+        },
+      },
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('api-node-1')
+
+    const hostLabel = wrapper.findAll('label').find((label) => label.text().includes('admin.ops.systemLogs.host'))
+    expect(hostLabel).toBeDefined()
+    await hostLabel!.find('input').setValue(' api-node-2 ')
+
+    const searchButton = wrapper.findAll('button').find((button) => button.text() === 'admin.ops.systemLogs.search')
+    expect(searchButton).toBeDefined()
+    await searchButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockListSystemLogs).toHaveBeenLastCalledWith(expect.objectContaining({ host: 'api-node-2' }))
+
+    const cleanupButton = wrapper.findAll('button').find((button) => button.text() === 'admin.ops.systemLogs.cleanCurrentFilters')
+    expect(cleanupButton).toBeDefined()
+    await cleanupButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockCleanupSystemLogs).toHaveBeenCalledWith(expect.objectContaining({ host: 'api-node-2' }))
+  })
+
+  it.each([
+    ['zh', zhLocale],
+    ['en', enLocale],
+  ])('defines the Host translation for %s', (_name, locale) => {
+    expect(locale.admin.ops.systemLogs.host).toBe('Host')
+  })
+})


### PR DESCRIPTION
## Summary

- persist the emitting process hostname on newly indexed system-log rows
- expose Host as an exact, indexed filter for system-log listing and cleanup
- add the Host filter and table column to `/admin/ops`, with English and Chinese locale coverage
- add backend boundary tests and a Vue regression test for rendering, search, and cleanup behavior
- normalize and bound hostnames before ingestion so an invalid environment value cannot fail a log batch

Closes BES-14

## Testing

- `GOPROXY=https://goproxy.cn,direct go test ./internal/repository ./internal/service ./internal/handler/admin`
- `corepack pnpm@9 run test:run` (147 files, 958 tests)
- `corepack pnpm@9 run typecheck`
- changed-file ESLint check
- `corepack pnpm@9 run build`
- GitHub unit/integration tests, security scans, shell checks, frontend checks, and `golangci-lint`

## Confidence

High confidence. The Host value is covered from sink ingestion through persistence, handler mapping, indexed SQL predicates, cleanup audit data, API types, and the rendered UI. The affected backend packages, the complete frontend suite, production build, and CI all pass.

## Uncertainties

- The displayed value comes from `os.Hostname()`, so its exact shape follows the deployment environment, such as a container ID or Kubernetes pod hostname.
- Historical rows cannot be attributed reliably and therefore retain `NULL` in storage; the list query returns an empty string and the UI displays `-`.

## Additional observations

- Host was also threaded into filtered cleanup, although the request only explicitly called out filtering. Without that, using the new Host filter and then selecting "Clean current filters" could delete rows from other hosts.
- No historical backfill was added because the original emitting host cannot be reconstructed safely.

## 中文翻译

### 摘要

- 为新写入的系统日志持久化产生日志的进程主机名
- 为系统日志列表和清理接口增加精确匹配且带索引的 Host 筛选
- 在 `/admin/ops` 增加 Host 筛选项和表格列，并补齐中英文文案
- 增加后端边界测试及 Vue 回归测试，覆盖展示、搜索和清理行为
- 在入库前规范化并限制主机名长度，避免异常环境值导致整批日志写入失败

### 测试

- `GOPROXY=https://goproxy.cn,direct go test ./internal/repository ./internal/service ./internal/handler/admin`
- `corepack pnpm@9 run test:run`（147 个测试文件，共 958 个测试）
- `corepack pnpm@9 run typecheck`
- 对本次变更涉及的前端文件执行 ESLint 检查
- `corepack pnpm@9 run build`
- GitHub 单元/集成测试、安全扫描、Shell 检查、前端检查及 `golangci-lint`

### 信心说明

信心较高。Host 已从日志采集、持久化、Handler 参数映射、带索引的 SQL 条件、清理审计、API 类型一路覆盖到前端展示；相关后端包、完整前端测试、生产构建及 CI 均已通过。

### 不确定项

- Host 取自 `os.Hostname()`，具体格式由部署环境决定，例如可能是容器 ID 或 Kubernetes Pod 主机名。
- 历史日志无法可靠推断原始主机，因此数据库中保留为 `NULL`；列表接口返回空字符串，前端显示为 `-`。

### 额外说明

- 用户明确提出的是 Host 筛选，但本次也让“按当前筛选清理”支持 Host。否则设置 Host 后执行清理，可能误删其他主机的日志。
- 未对历史数据做回填，因为无法安全还原其产生日志的主机。
