### PR TITLE
feat(server): 直连部署为响应启用 gzip 压缩

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -97,6 +97,7 @@ func main() {
 func runSetupServer() {
 	r := gin.New()
 	r.Use(middleware.Recovery())
+	r.Use(middleware.Gzip())
 	r.Use(middleware.CORS(config.CORSConfig{}))
 	r.Use(middleware.SecurityHeaders(config.CSPConfig{Enabled: true, Policy: config.DefaultCSPPolicy}, nil))
 

--- a/backend/internal/server/middleware/gzip.go
+++ b/backend/internal/server/middleware/gzip.go
@@ -1,0 +1,245 @@
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Align with deploy/Caddyfile encode { gzip 6; minimum_length 256 }.
+const (
+	gzipCompressionLevel = 6
+	gzipMinLength        = 256
+)
+
+var gzipWriterPool = sync.Pool{
+	New: func() any {
+		w, _ := gzip.NewWriterLevel(nil, gzipCompressionLevel)
+		return w
+	},
+}
+
+// Gzip compresses compressible HTTP responses for direct Go/Docker deployments.
+// Gateway/streaming paths are skipped so SSE and websocket upgrades are not buffered.
+func Gzip() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !shouldOfferGzip(c.Request) {
+			c.Next()
+			return
+		}
+
+		w := &lazyGzipResponseWriter{
+			ResponseWriter: c.Writer,
+			minLength:      gzipMinLength,
+		}
+		c.Writer = w
+		defer w.finish()
+
+		c.Next()
+	}
+}
+
+func shouldOfferGzip(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	if !strings.Contains(req.Header.Get("Accept-Encoding"), "gzip") {
+		return false
+	}
+	if strings.Contains(strings.ToLower(req.Header.Get("Connection")), "upgrade") {
+		return false
+	}
+	return !isGzipExcludedPath(req.URL.Path)
+}
+
+// isGzipExcludedPath skips API gateway / streaming surfaces.
+// Kept in sync with embedded-frontend bypass prefixes that serve live upstream traffic.
+func isGzipExcludedPath(path string) bool {
+	trimmed := strings.TrimSpace(path)
+	switch {
+	case trimmed == "/v1", strings.HasPrefix(trimmed, "/v1/"),
+		trimmed == "/v1beta", strings.HasPrefix(trimmed, "/v1beta/"),
+		strings.HasPrefix(trimmed, "/backend-api/"),
+		strings.HasPrefix(trimmed, "/antigravity/"),
+		trimmed == "/responses", strings.HasPrefix(trimmed, "/responses/"),
+		trimmed == "/alpha/search", strings.HasPrefix(trimmed, "/alpha/search/"),
+		strings.HasPrefix(trimmed, "/images/"),
+		strings.HasPrefix(trimmed, "/videos/"):
+		return true
+	default:
+		return false
+	}
+}
+
+func isCompressibleContentType(contentType string) bool {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if ct == "" {
+		return false
+	}
+	if i := strings.IndexByte(ct, ';'); i >= 0 {
+		ct = strings.TrimSpace(ct[:i])
+	}
+	if ct == "text/event-stream" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(ct, "text/"),
+		strings.HasPrefix(ct, "application/json"),
+		strings.HasPrefix(ct, "application/javascript"),
+		strings.HasPrefix(ct, "application/xml"),
+		strings.HasPrefix(ct, "application/rss+xml"),
+		ct == "image/svg+xml",
+		ct == "application/xhtml+xml",
+		ct == "application/wasm":
+		return true
+	default:
+		return false
+	}
+}
+
+type lazyGzipResponseWriter struct {
+	gin.ResponseWriter
+	minLength int
+	buf       bytes.Buffer
+	gz        *gzip.Writer
+	started   bool
+	skipped   bool
+	status    int
+}
+
+func (w *lazyGzipResponseWriter) WriteHeader(statusCode int) {
+	w.status = statusCode
+	// Delay header write until we know whether to compress.
+	if w.started || w.skipped {
+		w.ResponseWriter.WriteHeader(statusCode)
+	}
+}
+
+func (w *lazyGzipResponseWriter) Write(data []byte) (int, error) {
+	if w.skipped {
+		return w.ResponseWriter.Write(data)
+	}
+	if w.started {
+		return w.gz.Write(data)
+	}
+
+	if w.status == 0 {
+		w.status = http.StatusOK
+	}
+
+	// Never compress error bodies that handlers may stream partially.
+	if w.status >= http.StatusBadRequest {
+		return w.passthrough(data)
+	}
+
+	header := w.Header()
+	if enc := header.Get("Content-Encoding"); enc != "" {
+		return w.passthrough(data)
+	}
+	if !isCompressibleContentType(header.Get("Content-Type")) {
+		return w.passthrough(data)
+	}
+
+	if _, err := w.buf.Write(data); err != nil {
+		return 0, err
+	}
+	if w.buf.Len() < w.minLength {
+		return len(data), nil
+	}
+	if err := w.startGzip(); err != nil {
+		return 0, err
+	}
+	return len(data), nil
+}
+
+func (w *lazyGzipResponseWriter) WriteString(s string) (int, error) {
+	return w.Write([]byte(s))
+}
+
+func (w *lazyGzipResponseWriter) Flush() {
+	if w.skipped {
+		w.ResponseWriter.Flush()
+		return
+	}
+	if !w.started {
+		// Streaming flush before we reached min length — avoid buffering forever.
+		_, _ = w.passthrough(nil)
+		w.ResponseWriter.Flush()
+		return
+	}
+	_ = w.gz.Flush()
+	w.ResponseWriter.Flush()
+}
+
+func (w *lazyGzipResponseWriter) passthrough(data []byte) (int, error) {
+	w.skipped = true
+	if w.status != 0 {
+		w.ResponseWriter.WriteHeader(w.status)
+	}
+	n := 0
+	if w.buf.Len() > 0 {
+		written, err := w.ResponseWriter.Write(w.buf.Bytes())
+		n += written
+		w.buf.Reset()
+		if err != nil {
+			return n, err
+		}
+	}
+	if len(data) == 0 {
+		return n, nil
+	}
+	written, err := w.ResponseWriter.Write(data)
+	return n + written, err
+}
+
+func (w *lazyGzipResponseWriter) startGzip() error {
+	w.started = true
+	header := w.Header()
+	header.Del("Content-Length")
+	header.Set("Content-Encoding", "gzip")
+	header.Add("Vary", "Accept-Encoding")
+
+	if w.status != 0 {
+		w.ResponseWriter.WriteHeader(w.status)
+	}
+
+	gz := gzipWriterPool.Get().(*gzip.Writer)
+	gz.Reset(w.ResponseWriter)
+	w.gz = gz
+
+	if w.buf.Len() > 0 {
+		if _, err := w.gz.Write(w.buf.Bytes()); err != nil {
+			return err
+		}
+		w.buf.Reset()
+	}
+	return nil
+}
+
+func (w *lazyGzipResponseWriter) finish() {
+	if w.skipped {
+		return
+	}
+	if !w.started {
+		if w.buf.Len() == 0 {
+			if w.status != 0 && !w.Written() {
+				w.ResponseWriter.WriteHeader(w.status)
+			}
+			return
+		}
+		// Below minimum length: write uncompressed.
+		_, _ = w.passthrough(nil)
+		return
+	}
+	err := w.gz.Close()
+	if err != nil {
+		// Best-effort: response may already be partially written.
+		_ = err
+	}
+	gzipWriterPool.Put(w.gz)
+	w.gz = nil
+}

--- a/backend/internal/server/middleware/gzip.go
+++ b/backend/internal/server/middleware/gzip.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"net/http"
 	"strings"
 	"sync"
@@ -207,7 +208,10 @@ func (w *lazyGzipResponseWriter) startGzip() error {
 		w.ResponseWriter.WriteHeader(w.status)
 	}
 
-	gz := gzipWriterPool.Get().(*gzip.Writer)
+	gz, ok := gzipWriterPool.Get().(*gzip.Writer)
+	if !ok || gz == nil {
+		return errors.New("gzip writer pool returned unexpected value")
+	}
 	gz.Reset(w.ResponseWriter)
 	w.gz = gz
 

--- a/backend/internal/server/middleware/gzip_test.go
+++ b/backend/internal/server/middleware/gzip_test.go
@@ -1,0 +1,198 @@
+//go:build unit
+
+package middleware
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func TestIsGzipExcludedPath(t *testing.T) {
+	excluded := []string{
+		"/v1",
+		"/v1/messages",
+		"/v1/chat/completions",
+		"/v1beta/models",
+		"/backend-api/codex/responses",
+		"/antigravity/v1/messages",
+		"/responses",
+		"/responses/abc",
+		"/alpha/search",
+		"/images/generations",
+		"/videos/request-123",
+	}
+	for _, path := range excluded {
+		assert.True(t, isGzipExcludedPath(path), "path=%s", path)
+	}
+
+	allowed := []string{
+		"/",
+		"/index.html",
+		"/assets/index.js",
+		"/api/v1/admin/settings",
+		"/api/v1/auth/me",
+		"/health",
+		"/setup/",
+	}
+	for _, path := range allowed {
+		assert.False(t, isGzipExcludedPath(path), "path=%s", path)
+	}
+}
+
+func TestIsCompressibleContentType(t *testing.T) {
+	assert.True(t, isCompressibleContentType("text/html; charset=utf-8"))
+	assert.True(t, isCompressibleContentType("application/json"))
+	assert.True(t, isCompressibleContentType("application/javascript"))
+	assert.True(t, isCompressibleContentType("image/svg+xml"))
+	assert.False(t, isCompressibleContentType("text/event-stream"))
+	assert.False(t, isCompressibleContentType("image/png"))
+	assert.False(t, isCompressibleContentType("application/octet-stream"))
+}
+
+func TestGzip_CompressesLargeJSON(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	body := strings.Repeat(`{"ok":true,"msg":"hello-world"}`, 20) // > 256 bytes
+	r.GET("/api/v1/ping", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", []byte(body))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "gzip", w.Header().Get("Content-Encoding"))
+	assert.Contains(t, w.Header().Get("Vary"), "Accept-Encoding")
+
+	gr, err := gzip.NewReader(w.Body)
+	require.NoError(t, err)
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(decoded))
+	assert.Less(t, w.Body.Len(), len(body))
+}
+
+func TestGzip_SkipsSmallResponse(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	r.GET("/api/v1/small", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/json", []byte(`{"ok":true}`))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/small", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Content-Encoding"))
+	assert.Equal(t, `{"ok":true}`, w.Body.String())
+}
+
+func TestGzip_SkipsGatewayStreamingPath(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	payload := strings.Repeat("data: hello\n\n", 40)
+	r.GET("/v1/chat/completions", func(c *gin.Context) {
+		c.Header("Content-Type", "text/event-stream")
+		c.String(http.StatusOK, payload)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Content-Encoding"))
+	assert.Equal(t, payload, w.Body.String())
+}
+
+func TestGzip_SkipsWhenAcceptEncodingMissing(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	body := strings.Repeat("x", 512)
+	r.GET("/assets/app.js", func(c *gin.Context) {
+		c.Data(http.StatusOK, "application/javascript", []byte(body))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Content-Encoding"))
+	assert.Equal(t, body, w.Body.String())
+}
+
+func TestGzip_SkipsAlreadyEncoded(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	raw := strings.Repeat("precompressed", 40)
+	r.GET("/assets/app.js", func(c *gin.Context) {
+		c.Header("Content-Encoding", "br")
+		c.Data(http.StatusOK, "application/javascript", []byte(raw))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/app.js", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "br", w.Header().Get("Content-Encoding"))
+	assert.Equal(t, raw, w.Body.String())
+}
+
+func TestGzip_SkipsEventStreamContentTypeOnNonExcludedPath(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	payload := strings.Repeat("data: x\n\n", 50)
+	r.GET("/api/v1/events", func(c *gin.Context) {
+		c.Header("Content-Type", "text/event-stream")
+		_, _ = c.Writer.Write([]byte(payload))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Content-Encoding"))
+	assert.Equal(t, payload, w.Body.String())
+}
+
+func TestGzip_PassthroughBinary(t *testing.T) {
+	r := gin.New()
+	r.Use(Gzip())
+	raw := bytes.Repeat([]byte{0x1, 0x2, 0x3, 0x4}, 128)
+	r.GET("/assets/logo.png", func(c *gin.Context) {
+		c.Data(http.StatusOK, "image/png", raw)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/assets/logo.png", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Empty(t, w.Header().Get("Content-Encoding"))
+	assert.Equal(t, raw, w.Body.Bytes())
+}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -53,6 +53,9 @@ func SetupRouter(
 	// 应用中间件
 	r.Use(middleware2.RequestLogger())
 	r.Use(middleware2.Logger())
+	// Gzip for direct deployments (Caddy encode remains the edge compressor when present).
+	// Gateway/SSE paths are excluded inside the middleware.
+	r.Use(middleware2.Gzip())
 	r.Use(middleware2.CORS(cfg.CORS))
 	r.Use(middleware2.SecurityHeaders(cfg.Security.CSP, func() []string {
 		if p := cachedFrameOrigins.Load(); p != nil {


### PR DESCRIPTION
## Summary
- 直连 Go/Docker 部署时为可压缩响应启用 gzip（级别 6、最小长度 256），与 `deploy/Caddyfile` 的 encode 策略对齐。
- 排除网关/流式路径（`/v1/`、`/v1beta/`、`/backend-api/`、`/antigravity/`、`/responses` 等）以及 `text/event-stream`，避免缓冲破坏 SSE。
- 已带 `Content-Encoding` 的响应不二次压缩；不可压缩类型（如 `image/png`）跳过。

Closes #4220

## Test plan
- [x] `go test -tags=unit ./internal/server/middleware/ ./internal/server/`
- [ ] 直连访问前端静态资源/`/api` JSON，带 `Accept-Encoding: gzip` 时响应含 `Content-Encoding: gzip`
- [ ] `/v1/chat/completions` 等 SSE 路径不被 gzip 改写
- [ ] 经 Caddy（上游 `compression off`）时客户端压缩行为正常