### PR TITLE
fix(grok): use device-code OAuth so refresh tokens stay valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,24 +694,28 @@ Sub2API supports both Grok subscription accounts through xAI OAuth and standard 
 
 ### OAuth Configuration
 
-The Grok OAuth flow uses PKCE and does not require committing private secrets. The default client details follow the public xAI OAuth flow used by compatible clients, and every value can be overridden by environment variable:
+Grok subscription OAuth uses the same **OAuth 2.0 Device Authorization Grant** as the official Grok CLI (and clandes). This is intentional: authorization-code PKCE against the public xAI client can issue refresh tokens that fail the first refresh with `invalid_grant` / `Refresh token not found or invalid`. Device-code tokens rotate and refresh correctly.
+
+The flow does not require committing private secrets. Default client details follow the public Grok CLI identity and can be overridden by environment variable:
 
 | Variable | Default |
 |----------|---------|
 | `XAI_OAUTH_CLIENT_ID` | Public xAI OAuth client ID |
-| `XAI_OAUTH_SCOPE` | `openid profile email offline_access grok-cli:access api:access` |
-| `XAI_OAUTH_REDIRECT_URI` | `http://127.0.0.1:56121/callback` |
-| `XAI_OAUTH_AUTHORIZE_URL` | `https://auth.x.ai/oauth2/authorize` |
+| `XAI_OAUTH_SCOPE` | `openid profile email offline_access grok-cli:access api:access conversations:read conversations:write` |
+| `XAI_OAUTH_REDIRECT_URI` | `http://127.0.0.1:56121/callback` (legacy; device flow does not use it) |
+| `XAI_OAUTH_AUTHORIZE_URL` | `https://auth.x.ai/oauth2/authorize` (legacy PKCE path) |
+| `XAI_OAUTH_DEVICE_CODE_URL` | `https://auth.x.ai/oauth2/device/code` |
 | `XAI_OAUTH_TOKEN_URL` | `https://auth.x.ai/oauth2/token` |
 | `XAI_BASE_URL` | `https://api.x.ai/v1`; runtime-diagnostics override (account `base_url` controls request forwarding) |
-| `XAI_GROK_CLI_VERSION` | `0.2.93`; optional override for the client identity sent to `cli-chat-proxy.grok.com` |
+| `XAI_GROK_CLI_VERSION` | `0.2.93`; optional override for the client identity sent to `cli-chat-proxy.grok.com` and auth.x.ai |
 
 Administrators can create Grok OAuth or API-key accounts from the dashboard. OAuth authorization and reauthorization are also available through the admin API:
 
 | Endpoint | Purpose |
 |----------|---------|
-| `POST /api/v1/admin/grok/oauth/auth-url` | Generate an xAI OAuth authorization URL |
-| `POST /api/v1/admin/grok/oauth/exchange-code` | Exchange a callback URL, query string, or code for OAuth credentials |
+| `POST /api/v1/admin/grok/oauth/auth-url` | Start a Grok CLI device-code session and return the verification URL + user code |
+| `POST /api/v1/admin/grok/oauth/device/poll` | Poll one device-token status (`pending` / `authorized` / …) |
+| `POST /api/v1/admin/grok/oauth/exchange-code` | Complete a pending device session (or legacy PKCE exchange) |
 | `POST /api/v1/admin/grok/oauth/refresh-token` | Validate or refresh a Grok refresh token |
 | `POST /api/v1/admin/grok/accounts/:id/refresh` | Refresh an existing Grok account |
 

--- a/backend/internal/handler/admin/grok_oauth_handler.go
+++ b/backend/internal/handler/admin/grok_oauth_handler.go
@@ -56,7 +56,7 @@ func (h *GrokOAuthHandler) GenerateAuthURL(c *gin.Context) {
 
 type GrokExchangeCodeRequest struct {
 	SessionID   string `json:"session_id" binding:"required"`
-	Code        string `json:"code" binding:"required"`
+	Code        string `json:"code"`
 	State       string `json:"state"`
 	RedirectURI string `json:"redirect_uri"`
 	ProxyID     *int64 `json:"proxy_id"`
@@ -80,6 +80,29 @@ func (h *GrokOAuthHandler) ExchangeCode(c *gin.Context) {
 		return
 	}
 	response.Success(c, tokenInfo)
+}
+
+type GrokDevicePollRequest struct {
+	SessionID string `json:"session_id" binding:"required"`
+	ProxyID   *int64 `json:"proxy_id"`
+}
+
+// PollDeviceLogin performs one device-code poll for a pending Grok OAuth session.
+func (h *GrokOAuthHandler) PollDeviceLogin(c *gin.Context) {
+	var req GrokDevicePollRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	result, err := h.grokOAuthService.PollDeviceLogin(c.Request.Context(), &service.GrokDevicePollInput{
+		SessionID: req.SessionID,
+		ProxyID:   req.ProxyID,
+	})
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, result)
 }
 
 type GrokRefreshTokenRequest struct {
@@ -161,7 +184,7 @@ func (h *GrokOAuthHandler) RefreshAccountToken(c *gin.Context) {
 func (h *GrokOAuthHandler) CreateAccountFromOAuth(c *gin.Context) {
 	var req struct {
 		SessionID   string  `json:"session_id" binding:"required"`
-		Code        string  `json:"code" binding:"required"`
+		Code        string  `json:"code"`
 		State       string  `json:"state"`
 		RedirectURI string  `json:"redirect_uri"`
 		ProxyID     *int64  `json:"proxy_id"`

--- a/backend/internal/pkg/xai/billing.go
+++ b/backend/internal/pkg/xai/billing.go
@@ -5,19 +5,26 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
 )
 
 const (
-	// CLI client identity required by cli-chat-proxy billing endpoints.
-	CLITokenAuthHeader     = "x-xai-token-auth"
-	CLITokenAuthValue      = "xai-grok-cli"
-	CLIClientVersionHeader = "x-grok-client-version"
-	// Keep in sync with https://x.ai/cli/stable.
+	// CLI client identity required by cli-chat-proxy billing endpoints and OAuth.
+	CLITokenAuthHeader          = "x-xai-token-auth"
+	CLITokenAuthValue           = "xai-grok-cli"
+	CLIClientVersionHeader      = "x-grok-client-version"
+	CLIClientSurfaceHeader      = "x-grok-client-surface"
+	CLIClientSurfaceValue       = "cli"
+	CLIClientIdentifierHeader   = "x-grok-client-identifier"
+	CLIClientIdentifierValue    = "grok-shell"
+	// Keep in sync with https://x.ai/cli/stable and clandes GrokCliVersion::DEFAULT.
 	CLIClientVersion = "0.2.93"
 	CLIUserAgent     = "grok-pager/" + CLIClientVersion + " grok-shell/" + CLIClientVersion + " (macos; aarch64)"
+	EnvCLIVersion    = "XAI_GROK_CLI_VERSION"
 
 	BillingWeeklyPath  = "/billing?format=credits"
 	BillingMonthlyPath = "/billing"
@@ -25,6 +32,34 @@ const (
 	SuperGrokLimitCents      = 15_000  // $150.00
 	SuperGrokHeavyLimitCents = 150_000 // $1,500.00
 )
+
+// EffectiveCLIVersion returns the Grok CLI version identity sent to xAI.
+// Operators can override via XAI_GROK_CLI_VERSION without waiting for a release.
+func EffectiveCLIVersion() string {
+	if value := strings.TrimSpace(os.Getenv(EnvCLIVersion)); value != "" {
+		// Reject CR/LF and oversized values to avoid header injection.
+		if !strings.ContainsAny(value, "\r\n\x00") && len(value) <= 64 {
+			return value
+		}
+	}
+	return CLIClientVersion
+}
+
+// CLIShellUserAgent matches the Grok CLI oauth/user-agent shape used by clandes.
+func CLIShellUserAgent() string {
+	return "grok-shell/" + EffectiveCLIVersion() + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
+}
+
+// ApplyCLIOAuthHeaders sets the Grok CLI identity headers required by auth.x.ai.
+func ApplyCLIOAuthHeaders(header http.Header) {
+	if header == nil {
+		return
+	}
+	header.Set("Accept", "*/*")
+	header.Set(CLIClientVersionHeader, EffectiveCLIVersion())
+	header.Set(CLIClientSurfaceHeader, CLIClientSurfaceValue)
+	header.Set("User-Agent", CLIShellUserAgent())
+}
 
 // BillingPeriod describes the current weekly/monthly window.
 type BillingPeriod struct {
@@ -106,7 +141,8 @@ func ApplyCLIBillingHeaders(req *http.Request, accessToken string) {
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(CLITokenAuthHeader, CLITokenAuthValue)
-	req.Header.Set(CLIClientVersionHeader, CLIClientVersion)
+	req.Header.Set(CLIClientVersionHeader, EffectiveCLIVersion())
+	req.Header.Set(CLIClientIdentifierHeader, CLIClientIdentifierValue)
 	req.Header.Set("User-Agent", CLIUserAgent)
 }
 

--- a/backend/internal/pkg/xai/device.go
+++ b/backend/internal/pkg/xai/device.go
@@ -1,0 +1,102 @@
+package xai
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// DeviceCodeResponse is the response from the xAI device authorization endpoint.
+type DeviceCodeResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+// DevicePollStatus is the result of a single device-token poll.
+type DevicePollStatus string
+
+const (
+	DevicePollPending    DevicePollStatus = "pending"
+	DevicePollSlowDown   DevicePollStatus = "slow_down"
+	DevicePollAuthorized DevicePollStatus = "authorized"
+	DevicePollDenied     DevicePollStatus = "denied"
+	DevicePollExpired    DevicePollStatus = "expired"
+	DevicePollError      DevicePollStatus = "error"
+)
+
+// DevicePollResult is one device-token poll outcome.
+type DevicePollResult struct {
+	Status   DevicePollStatus
+	Token    *TokenResponse
+	Error    string
+	HTTPCode int
+}
+
+// NormalizeDeviceCodeResponse fills defaults and validates required fields.
+func NormalizeDeviceCodeResponse(device *DeviceCodeResponse) error {
+	if device == nil {
+		return fmt.Errorf("device code response is nil")
+	}
+	device.DeviceCode = strings.TrimSpace(device.DeviceCode)
+	device.UserCode = strings.TrimSpace(device.UserCode)
+	device.VerificationURI = strings.TrimSpace(device.VerificationURI)
+	device.VerificationURIComplete = strings.TrimSpace(device.VerificationURIComplete)
+	if device.DeviceCode == "" || device.UserCode == "" {
+		return fmt.Errorf("device code response is incomplete")
+	}
+	if device.VerificationURIComplete == "" && device.VerificationURI == "" {
+		return fmt.Errorf("device code response missing verification URI")
+	}
+	if device.Interval <= 0 {
+		device.Interval = 5
+	}
+	if device.ExpiresIn <= 0 {
+		device.ExpiresIn = 1800
+	}
+	return nil
+}
+
+// DeviceAuthURL returns the preferred browser URL for a device session.
+func DeviceAuthURL(device *DeviceCodeResponse) string {
+	if device == nil {
+		return ""
+	}
+	if url := strings.TrimSpace(device.VerificationURIComplete); url != "" {
+		return url
+	}
+	return strings.TrimSpace(device.VerificationURI)
+}
+
+// ParseOAuthError extracts error / error_description from an OAuth error body.
+func ParseOAuthError(body string) (code, description string) {
+	var payload struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return "", strings.TrimSpace(body)
+	}
+	return strings.TrimSpace(payload.Error), strings.TrimSpace(payload.ErrorDescription)
+}
+
+// ClassifyDevicePollBody maps a non-success OAuth device poll body to a status.
+func ClassifyDevicePollBody(statusCode int, body string) DevicePollResult {
+	code, description := ParseOAuthError(body)
+	switch code {
+	case "authorization_pending":
+		return DevicePollResult{Status: DevicePollPending, HTTPCode: statusCode}
+	case "slow_down":
+		return DevicePollResult{Status: DevicePollSlowDown, HTTPCode: statusCode}
+	case "access_denied":
+		return DevicePollResult{Status: DevicePollDenied, HTTPCode: statusCode, Error: firstNonEmpty(description, code)}
+	case "expired_token":
+		return DevicePollResult{Status: DevicePollExpired, HTTPCode: statusCode, Error: firstNonEmpty(description, code)}
+	default:
+		msg := firstNonEmpty(description, code, strings.TrimSpace(body), fmt.Sprintf("status %d", statusCode))
+		return DevicePollResult{Status: DevicePollError, HTTPCode: statusCode, Error: msg}
+	}
+}

--- a/backend/internal/pkg/xai/oauth.go
+++ b/backend/internal/pkg/xai/oauth.go
@@ -21,15 +21,25 @@ const (
 	DiscoveryURL        = OAuthIssuer + "/.well-known/openid-configuration"
 	DefaultAuthorizeURL = OAuthIssuer + "/oauth2/authorize"
 	DefaultTokenURL     = OAuthIssuer + "/oauth2/token"
+	DefaultDeviceCodeURL = OAuthIssuer + "/oauth2/device/code"
 	DefaultBaseURL      = "https://api.x.ai/v1"
 	DefaultCLIBaseURL   = "https://cli-chat-proxy.grok.com/v1"
 	DefaultClientID     = "b1a00492-073a-47ea-816f-4c329264a828"
-	DefaultScope        = "openid profile email offline_access grok-cli:access api:access"
-	DefaultRedirectURI  = "http://127.0.0.1:56121/callback"
-	SessionTTL          = 30 * time.Minute
+	// DefaultScope matches the public Grok CLI / device-code grant used by
+	// compatible clients. Authorization-code PKCE against this public client
+	// can issue refresh tokens that fail the first refresh with invalid_grant.
+	DefaultScope       = "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write"
+	DefaultRedirectURI = "http://127.0.0.1:56121/callback"
+	DefaultReferrer    = "grok-build"
+	SessionTTL         = 30 * time.Minute
+
+	OAuthFlowDevice   = "device"
+	OAuthFlowAuthCode = "authorization_code"
+	DeviceGrantType   = "urn:ietf:params:oauth:grant-type:device_code"
 
 	EnvAuthorizeURL               = "XAI_OAUTH_AUTHORIZE_URL"
 	EnvTokenURL                   = "XAI_OAUTH_TOKEN_URL"
+	EnvDeviceCodeURL              = "XAI_OAUTH_DEVICE_CODE_URL"
 	EnvClientID                   = "XAI_OAUTH_CLIENT_ID"
 	EnvScope                      = "XAI_OAUTH_SCOPE"
 	EnvRedirectURI                = "XAI_OAUTH_REDIRECT_URI"
@@ -43,7 +53,7 @@ var (
 	baseURLAllowedHosts       = []string{"api.x.ai", "cli-chat-proxy.grok.com"}
 )
 
-// OAuthSession stores one PKCE OAuth flow.
+// OAuthSession stores one Grok OAuth flow (device-code preferred, PKCE legacy).
 type OAuthSession struct {
 	State         string    `json:"state"`
 	CodeVerifier  string    `json:"code_verifier"`
@@ -52,6 +62,11 @@ type OAuthSession struct {
 	Scope         string    `json:"scope,omitempty"`
 	ProxyURL      string    `json:"proxy_url,omitempty"`
 	RedirectURI   string    `json:"redirect_uri"`
+	Flow          string    `json:"flow,omitempty"`
+	DeviceCode    string    `json:"device_code,omitempty"`
+	UserCode      string    `json:"user_code,omitempty"`
+	Interval      int       `json:"interval,omitempty"`
+	ExpiresIn     int       `json:"expires_in,omitempty"`
 	CreatedAt     time.Time `json:"created_at"`
 }
 
@@ -136,6 +151,14 @@ func EffectiveTokenURL() string {
 
 func ValidatedTokenURL() (string, error) {
 	return ValidateOAuthEndpointURL(EffectiveTokenURL())
+}
+
+func EffectiveDeviceCodeURL() string {
+	return envOrDefault(EnvDeviceCodeURL, DefaultDeviceCodeURL)
+}
+
+func ValidatedDeviceCodeURL() (string, error) {
+	return ValidateOAuthEndpointURL(EffectiveDeviceCodeURL())
 }
 
 func EffectiveClientID() string {
@@ -388,7 +411,7 @@ func BuildAuthorizationURL(state, codeChallenge, redirectURI, nonce string) (str
 	params.Set("code_challenge", codeChallenge)
 	params.Set("code_challenge_method", "S256")
 	params.Set("plan", "generic")
-	params.Set("referrer", "sub2api")
+	params.Set("referrer", DefaultReferrer)
 
 	return fmt.Sprintf("%s?%s", authorizeURL, params.Encode()), nil
 }

--- a/backend/internal/pkg/xai/oauth_test.go
+++ b/backend/internal/pkg/xai/oauth_test.go
@@ -87,7 +87,24 @@ func TestBuildAuthorizationURLIncludesHermesCompatibleParameters(t *testing.T) {
 	require.Equal(t, "challenge", values.Get("code_challenge"))
 	require.Equal(t, "S256", values.Get("code_challenge_method"))
 	require.Equal(t, "generic", values.Get("plan"))
-	require.Equal(t, "sub2api", values.Get("referrer"))
+	require.Equal(t, DefaultReferrer, values.Get("referrer"))
+}
+
+func TestDefaultScopeMatchesGrokCLIDeviceGrant(t *testing.T) {
+	t.Parallel()
+	require.Contains(t, DefaultScope, "offline_access")
+	require.Contains(t, DefaultScope, "grok-cli:access")
+	require.Contains(t, DefaultScope, "conversations:read")
+	require.Contains(t, DefaultScope, "conversations:write")
+	require.Equal(t, DefaultScope, SSOBuildScope)
+}
+
+func TestClassifyDevicePollBody(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, DevicePollPending, ClassifyDevicePollBody(400, `{"error":"authorization_pending"}`).Status)
+	require.Equal(t, DevicePollSlowDown, ClassifyDevicePollBody(400, `{"error":"slow_down"}`).Status)
+	require.Equal(t, DevicePollDenied, ClassifyDevicePollBody(400, `{"error":"access_denied"}`).Status)
+	require.Equal(t, DevicePollExpired, ClassifyDevicePollBody(400, `{"error":"expired_token"}`).Status)
 }
 
 func TestValidateXAIURLsAllowOfficialOAuthAndGatewayHosts(t *testing.T) {

--- a/backend/internal/pkg/xai/sso_device.go
+++ b/backend/internal/pkg/xai/sso_device.go
@@ -16,12 +16,14 @@ import (
 )
 
 const (
-	SSOBuildScope        = "openid profile email offline_access grok-cli:access api:access conversations:read conversations:write"
+	// SSOBuildScope is the device-code scope used when converting Web SSO into
+	// Grok Build credentials. Keep in sync with DefaultScope / Grok CLI.
+	SSOBuildScope        = DefaultScope
 	SSOAccountsURL       = "https://accounts.x.ai/"
-	SSODeviceURL         = OAuthIssuer + "/oauth2/device/code"
+	SSODeviceURL         = DefaultDeviceCodeURL
 	SSOVerifyURL         = OAuthIssuer + "/oauth2/device/verify"
 	SSOApproveURL        = OAuthIssuer + "/oauth2/device/approve"
-	SSOTokenURL          = OAuthIssuer + "/oauth2/token"
+	SSOTokenURL          = DefaultTokenURL
 	SSOConversionTimeout = 90 * time.Second
 
 	ssoMaxAuthBody     = 2 << 20
@@ -105,6 +107,7 @@ func (f *ssoDeviceFlow) convert(ctx context.Context) (*TokenResponse, error) {
 	status, _, body, err := f.do(ctx, http.MethodPost, SSODeviceURL, url.Values{
 		"client_id": {DefaultClientID},
 		"scope":     {SSOBuildScope},
+		"referrer":  {DefaultReferrer},
 	})
 	if err != nil {
 		return nil, err

--- a/backend/internal/repository/grok_oauth_client.go
+++ b/backend/internal/repository/grok_oauth_client.go
@@ -17,11 +17,104 @@ import (
 )
 
 type grokOAuthClient struct {
-	tokenURL string
+	tokenURL      string
+	deviceCodeURL string
 }
 
 func NewGrokOAuthClient() service.GrokOAuthClient {
-	return &grokOAuthClient{tokenURL: xai.EffectiveTokenURL()}
+	return &grokOAuthClient{
+		tokenURL:      xai.EffectiveTokenURL(),
+		deviceCodeURL: xai.EffectiveDeviceCodeURL(),
+	}
+}
+
+func (c *grokOAuthClient) RequestDeviceCode(ctx context.Context, proxyURL, clientID, scope string) (*xai.DeviceCodeResponse, error) {
+	client, err := createGrokReqClient(proxyURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "GROK_OAUTH_CLIENT_INIT_FAILED", "create HTTP client: %v", err)
+	}
+
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		clientID = xai.EffectiveClientID()
+	}
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = xai.EffectiveScope()
+	}
+
+	formData := url.Values{}
+	formData.Set("client_id", clientID)
+	formData.Set("scope", scope)
+	formData.Set("referrer", xai.DefaultReferrer)
+
+	var device xai.DeviceCodeResponse
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeaders(grokCLIOAuthHeaders()).
+		SetFormDataFromValues(formData).
+		SetSuccessResult(&device).
+		Post(c.deviceCodeURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "GROK_OAUTH_REQUEST_FAILED", "request failed: %v", err)
+	}
+	if !resp.IsSuccessState() {
+		return nil, grokOAuthStatusError("GROK_OAUTH_DEVICE_CODE_FAILED", "device code request failed", resp)
+	}
+	if err := xai.NormalizeDeviceCodeResponse(&device); err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "GROK_OAUTH_DEVICE_CODE_INVALID", "%v", err)
+	}
+	return &device, nil
+}
+
+func (c *grokOAuthClient) PollDeviceToken(ctx context.Context, deviceCode, proxyURL, clientID string) (*xai.DevicePollResult, error) {
+	deviceCode = strings.TrimSpace(deviceCode)
+	if deviceCode == "" {
+		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_DEVICE_CODE_REQUIRED", "device_code is required")
+	}
+
+	client, err := createGrokReqClient(proxyURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "GROK_OAUTH_CLIENT_INIT_FAILED", "create HTTP client: %v", err)
+	}
+
+	clientID = strings.TrimSpace(clientID)
+	if clientID == "" {
+		clientID = xai.EffectiveClientID()
+	}
+
+	formData := url.Values{}
+	formData.Set("grant_type", xai.DeviceGrantType)
+	formData.Set("device_code", deviceCode)
+	formData.Set("client_id", clientID)
+
+	var tokenResp xai.TokenResponse
+	resp, err := client.R().
+		SetContext(ctx).
+		SetHeaders(grokCLIOAuthHeaders()).
+		SetFormDataFromValues(formData).
+		SetSuccessResult(&tokenResp).
+		Post(c.tokenURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "GROK_OAUTH_REQUEST_FAILED", "request failed: %v", err)
+	}
+	if resp.IsSuccessState() {
+		if strings.TrimSpace(tokenResp.AccessToken) == "" {
+			return nil, infraerrors.New(http.StatusBadGateway, "GROK_OAUTH_DEVICE_TOKEN_EMPTY", "device token response missing access_token")
+		}
+		return &xai.DevicePollResult{
+			Status:   xai.DevicePollAuthorized,
+			Token:    &tokenResp,
+			HTTPCode: resp.StatusCode,
+		}, nil
+	}
+
+	body := ""
+	if resp != nil {
+		body = resp.String()
+	}
+	result := xai.ClassifyDevicePollBody(resp.StatusCode, body)
+	return &result, nil
 }
 
 func (c *grokOAuthClient) ExchangeCode(ctx context.Context, code, codeVerifier, redirectURI, proxyURL, clientID string) (*xai.TokenResponse, error) {
@@ -45,7 +138,7 @@ func (c *grokOAuthClient) ExchangeCode(ctx context.Context, code, codeVerifier, 
 	var tokenResp xai.TokenResponse
 	resp, err := client.R().
 		SetContext(ctx).
-		SetHeader("User-Agent", "sub2api-grok-oauth/1.0").
+		SetHeaders(grokCLIOAuthHeaders()).
 		SetFormDataFromValues(formData).
 		SetSuccessResult(&tokenResp).
 		Post(c.tokenURL)
@@ -77,7 +170,7 @@ func (c *grokOAuthClient) RefreshToken(ctx context.Context, refreshToken, proxyU
 	var tokenResp xai.TokenResponse
 	resp, err := client.R().
 		SetContext(ctx).
-		SetHeader("User-Agent", "sub2api-grok-oauth/1.0").
+		SetHeaders(grokCLIOAuthHeaders()).
 		SetFormDataFromValues(formData).
 		SetSuccessResult(&tokenResp).
 		Post(c.tokenURL)
@@ -103,6 +196,17 @@ func (c *grokOAuthClient) ConvertSSOToBuild(ctx context.Context, ssoToken, proxy
 		return nil, grokSSOConversionError(err)
 	}
 	return tokenResp, nil
+}
+
+func grokCLIOAuthHeaders() map[string]string {
+	header := make(http.Header)
+	xai.ApplyCLIOAuthHeaders(header)
+	return map[string]string{
+		"Accept":                 header.Get("Accept"),
+		xai.CLIClientVersionHeader: header.Get(xai.CLIClientVersionHeader),
+		xai.CLIClientSurfaceHeader: header.Get(xai.CLIClientSurfaceHeader),
+		"User-Agent":             header.Get("User-Agent"),
+	}
 }
 
 func createGrokReqClient(proxyURL string) (*req.Client, error) {

--- a/backend/internal/repository/grok_oauth_client_test.go
+++ b/backend/internal/repository/grok_oauth_client_test.go
@@ -14,42 +14,86 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGrokOAuthClientExchangeAndRefreshUseFormFields(t *testing.T) {
+func TestGrokOAuthClientDeviceAndRefreshUseCLIFormAndHeaders(t *testing.T) {
+	var sawDevice, sawRefresh, sawExchange bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, http.MethodPost, r.Method)
 		require.NoError(t, r.ParseForm())
 		require.Equal(t, "client-id", r.Form.Get("client_id"))
+		require.Equal(t, xai.EffectiveCLIVersion(), r.Header.Get(xai.CLIClientVersionHeader))
+		require.Equal(t, xai.CLIClientSurfaceValue, r.Header.Get(xai.CLIClientSurfaceHeader))
+		require.Contains(t, r.Header.Get("User-Agent"), "grok-shell/")
 
-		switch r.Form.Get("grant_type") {
-		case "authorization_code":
-			require.Equal(t, "auth-code", r.Form.Get("code"))
-			require.Equal(t, "http://127.0.0.1:56121/callback", r.Form.Get("redirect_uri"))
-			require.Equal(t, "verifier", r.Form.Get("code_verifier"))
-			require.Empty(t, r.Form.Get("code_challenge"))
-			require.Empty(t, r.Form.Get("code_challenge_method"))
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"access_token":  "exchange-access",
-				"refresh_token": "exchange-refresh",
-				"token_type":    "Bearer",
-				"expires_in":    3600,
-				"scope":         "openid api:access",
-			})
-		case "refresh_token":
-			require.Equal(t, "refresh-token", r.Form.Get("refresh_token"))
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"access_token":  "refresh-access",
-				"refresh_token": "refresh-rotated",
-				"token_type":    "Bearer",
-				"expires_in":    7200,
-			})
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/device/code") || r.Form.Get("grant_type") == "":
+			if r.Form.Get("grant_type") == "" && r.Form.Get("scope") != "" {
+				sawDevice = true
+				require.Equal(t, xai.DefaultReferrer, r.Form.Get("referrer"))
+				require.Contains(t, r.Form.Get("scope"), "conversations:write")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"device_code":                "device-1",
+					"user_code":                  "USER-1",
+					"verification_uri":           "https://auth.x.ai/oauth2/device",
+					"verification_uri_complete":  "https://auth.x.ai/oauth2/device?user_code=USER-1",
+					"expires_in":                 600,
+					"interval":                   5,
+				})
+				return
+			}
+			fallthrough
 		default:
-			http.Error(w, "unexpected grant_type", http.StatusBadRequest)
+			switch r.Form.Get("grant_type") {
+			case xai.DeviceGrantType:
+				require.Equal(t, "device-1", r.Form.Get("device_code"))
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "device-access",
+					"refresh_token": "device-refresh",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+				})
+			case "authorization_code":
+				sawExchange = true
+				require.Equal(t, "auth-code", r.Form.Get("code"))
+				require.Equal(t, "http://127.0.0.1:56121/callback", r.Form.Get("redirect_uri"))
+				require.Equal(t, "verifier", r.Form.Get("code_verifier"))
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "exchange-access",
+					"refresh_token": "exchange-refresh",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+					"scope":         "openid api:access",
+				})
+			case "refresh_token":
+				sawRefresh = true
+				require.Equal(t, "refresh-token", r.Form.Get("refresh_token"))
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "refresh-access",
+					"refresh_token": "refresh-rotated",
+					"token_type":    "Bearer",
+					"expires_in":    7200,
+				})
+			default:
+				http.Error(w, "unexpected grant_type", http.StatusBadRequest)
+			}
 		}
 	}))
 	defer server.Close()
 	t.Setenv(xai.EnvTokenURL, server.URL)
+	t.Setenv(xai.EnvDeviceCodeURL, server.URL+"/device/code")
 
 	client := NewGrokOAuthClient()
+
+	device, err := client.RequestDeviceCode(context.Background(), "", "client-id", xai.DefaultScope)
+	require.NoError(t, err)
+	require.True(t, sawDevice)
+	require.Equal(t, "device-1", device.DeviceCode)
+	require.Equal(t, "USER-1", device.UserCode)
+
+	poll, err := client.PollDeviceToken(context.Background(), "device-1", "", "client-id")
+	require.NoError(t, err)
+	require.Equal(t, xai.DevicePollAuthorized, poll.Status)
+	require.Equal(t, "device-access", poll.Token.AccessToken)
+	require.Equal(t, "device-refresh", poll.Token.RefreshToken)
 
 	exchanged, err := client.ExchangeCode(
 		context.Background(),
@@ -60,16 +104,30 @@ func TestGrokOAuthClientExchangeAndRefreshUseFormFields(t *testing.T) {
 		"client-id",
 	)
 	require.NoError(t, err)
+	require.True(t, sawExchange)
 	require.Equal(t, "exchange-access", exchanged.AccessToken)
 	require.Equal(t, "exchange-refresh", exchanged.RefreshToken)
-	require.Equal(t, int64(3600), exchanged.ExpiresIn)
-	require.Equal(t, "openid api:access", exchanged.Scope)
 
 	refreshed, err := client.RefreshToken(context.Background(), "refresh-token", "", "client-id")
 	require.NoError(t, err)
+	require.True(t, sawRefresh)
 	require.Equal(t, "refresh-access", refreshed.AccessToken)
 	require.Equal(t, "refresh-rotated", refreshed.RefreshToken)
 	require.Equal(t, int64(7200), refreshed.ExpiresIn)
+}
+
+func TestGrokOAuthClientPollDevicePending(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"authorization_pending"}`))
+	}))
+	defer server.Close()
+	t.Setenv(xai.EnvTokenURL, server.URL)
+
+	client := NewGrokOAuthClient()
+	poll, err := client.PollDeviceToken(context.Background(), "device-1", "", "client-id")
+	require.NoError(t, err)
+	require.Equal(t, xai.DevicePollPending, poll.Status)
 }
 
 func TestGrokOAuthClientRefreshForbiddenClassifiesEntitlement(t *testing.T) {

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -396,6 +396,7 @@ func registerGrokOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 	grok := admin.Group("/grok")
 	{
 		grok.POST("/oauth/auth-url", h.Admin.GrokOAuth.GenerateAuthURL)
+		grok.POST("/oauth/device/poll", h.Admin.GrokOAuth.PollDeviceLogin)
 		grok.POST("/oauth/exchange-code", h.Admin.GrokOAuth.ExchangeCode)
 		grok.POST("/oauth/refresh-token", h.Admin.GrokOAuth.RefreshToken)
 		grok.POST("/oauth/create-from-oauth", h.Admin.GrokOAuth.CreateAccountFromOAuth)

--- a/backend/internal/service/grok_oauth_service.go
+++ b/backend/internal/service/grok_oauth_service.go
@@ -28,56 +28,71 @@ func NewGrokOAuthService(proxyRepo ProxyRepository, oauthClient GrokOAuthClient)
 }
 
 type GrokAuthURLResult struct {
-	AuthURL   string `json:"auth_url"`
-	SessionID string `json:"session_id"`
-	State     string `json:"state"`
+	AuthURL    string `json:"auth_url"`
+	SessionID  string `json:"session_id"`
+	State      string `json:"state"`
+	Flow       string `json:"flow,omitempty"`
+	UserCode   string `json:"user_code,omitempty"`
+	Interval   int    `json:"interval,omitempty"`
+	ExpiresIn  int    `json:"expires_in,omitempty"`
+	ExpiresAt  int64  `json:"expires_at,omitempty"`
 }
 
+// GenerateAuthURL starts a Grok CLI device-code OAuth session (matches official Grok CLI / clandes).
+// Authorization-code PKCE against the public xAI client can issue refresh tokens that fail the
+// first refresh with invalid_grant; device-code tokens refresh correctly.
 func (s *GrokOAuthService) GenerateAuthURL(ctx context.Context, proxyID *int64, redirectURI string) (*GrokAuthURLResult, error) {
-	state, err := xai.GenerateState()
-	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "GROK_OAUTH_STATE_FAILED", "failed to generate state: %v", err)
-	}
-	nonce, err := xai.GenerateNonce()
-	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "GROK_OAUTH_NONCE_FAILED", "failed to generate nonce: %v", err)
-	}
-	codeVerifier, err := xai.GenerateCodeVerifier()
-	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "GROK_OAUTH_VERIFIER_FAILED", "failed to generate code verifier: %v", err)
-	}
+	_ = redirectURI // device flow does not use redirect_uri; kept for API compatibility
+
 	sessionID, err := xai.GenerateSessionID()
 	if err != nil {
 		return nil, infraerrors.Newf(http.StatusInternalServerError, "GROK_OAUTH_SESSION_FAILED", "failed to generate session ID: %v", err)
+	}
+	state, err := xai.GenerateState()
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusInternalServerError, "GROK_OAUTH_STATE_FAILED", "failed to generate state: %v", err)
 	}
 
 	proxyURL, err := s.proxyURL(ctx, proxyID)
 	if err != nil {
 		return nil, err
 	}
-	redirectURI = xai.EffectiveRedirectURI(redirectURI)
-	codeChallenge := xai.GenerateCodeChallenge(codeVerifier)
 
-	authURL, err := xai.BuildAuthorizationURL(state, codeChallenge, redirectURI, nonce)
+	clientID := xai.EffectiveClientID()
+	scope := xai.EffectiveScope()
+	device, err := s.oauthClient.RequestDeviceCode(ctx, proxyURL, clientID, scope)
 	if err != nil {
-		return nil, infraerrors.Newf(http.StatusBadRequest, "GROK_OAUTH_INVALID_AUTHORIZE_URL", "%v", err)
+		return nil, err
 	}
 
+	authURL := xai.DeviceAuthURL(device)
+	if authURL == "" {
+		return nil, infraerrors.New(http.StatusBadGateway, "GROK_OAUTH_DEVICE_URL_MISSING", "device flow response missing verification URL")
+	}
+
+	now := time.Now()
 	s.sessionStore.Set(sessionID, &xai.OAuthSession{
-		State:         state,
-		CodeVerifier:  codeVerifier,
-		CodeChallenge: codeChallenge,
-		ClientID:      xai.EffectiveClientID(),
-		Scope:         xai.EffectiveScope(),
-		ProxyURL:      proxyURL,
-		RedirectURI:   redirectURI,
-		CreatedAt:     time.Now(),
+		State:      state,
+		ClientID:   clientID,
+		Scope:      scope,
+		ProxyURL:   proxyURL,
+		Flow:       xai.OAuthFlowDevice,
+		DeviceCode: device.DeviceCode,
+		UserCode:   device.UserCode,
+		Interval:   device.Interval,
+		ExpiresIn:  device.ExpiresIn,
+		CreatedAt:  now,
 	})
 
 	return &GrokAuthURLResult{
 		AuthURL:   authURL,
 		SessionID: sessionID,
 		State:     state,
+		Flow:      xai.OAuthFlowDevice,
+		UserCode:  device.UserCode,
+		Interval:  device.Interval,
+		ExpiresIn: device.ExpiresIn,
+		ExpiresAt: now.Add(time.Duration(device.ExpiresIn) * time.Second).Unix(),
 	}, nil
 }
 
@@ -87,6 +102,20 @@ type GrokExchangeCodeInput struct {
 	State       string
 	RedirectURI string
 	ProxyID     *int64
+}
+
+type GrokDevicePollInput struct {
+	SessionID string
+	ProxyID   *int64
+}
+
+type GrokDevicePollInfo struct {
+	Status    string         `json:"status"`
+	Interval  int            `json:"interval,omitempty"`
+	ExpiresAt int64          `json:"expires_at,omitempty"`
+	UserCode  string         `json:"user_code,omitempty"`
+	Token     *GrokTokenInfo `json:"token,omitempty"`
+	Error     string         `json:"error,omitempty"`
 }
 
 type GrokTokenInfo struct {
@@ -105,6 +134,81 @@ type GrokTokenInfo struct {
 	EntitlementStatus string `json:"entitlement_status,omitempty"`
 }
 
+// PollDeviceLogin performs a single device-token poll for a pending Grok OAuth session.
+func (s *GrokOAuthService) PollDeviceLogin(ctx context.Context, input *GrokDevicePollInput) (*GrokDevicePollInfo, error) {
+	if input == nil || strings.TrimSpace(input.SessionID) == "" {
+		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_SESSION_REQUIRED", "session_id is required")
+	}
+	session, ok := s.sessionStore.Get(input.SessionID)
+	if !ok {
+		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_SESSION_NOT_FOUND", "session not found or expired")
+	}
+	if session.Flow != "" && session.Flow != xai.OAuthFlowDevice {
+		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_NOT_DEVICE_FLOW", "session is not a device OAuth flow")
+	}
+	if strings.TrimSpace(session.DeviceCode) == "" {
+		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_DEVICE_CODE_REQUIRED", "session is missing device_code")
+	}
+
+	expiresAt := session.CreatedAt.Add(time.Duration(session.ExpiresIn) * time.Second)
+	if session.ExpiresIn > 0 && time.Now().After(expiresAt) {
+		s.sessionStore.Delete(input.SessionID)
+		return &GrokDevicePollInfo{
+			Status: string(xai.DevicePollExpired),
+			Error:  "device code expired",
+		}, nil
+	}
+
+	proxyURL := session.ProxyURL
+	if input.ProxyID != nil {
+		var err error
+		proxyURL, err = s.proxyURL(ctx, input.ProxyID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := s.oauthClient.PollDeviceToken(ctx, session.DeviceCode, proxyURL, session.ClientID)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &GrokDevicePollInfo{
+		Status:    string(result.Status),
+		Interval:  session.Interval,
+		ExpiresAt: expiresAt.Unix(),
+		UserCode:  session.UserCode,
+		Error:     result.Error,
+	}
+	if session.Interval <= 0 {
+		info.Interval = 5
+	}
+
+	switch result.Status {
+	case xai.DevicePollAuthorized:
+		if result.Token == nil {
+			return nil, infraerrors.New(http.StatusBadGateway, "GROK_OAUTH_DEVICE_TOKEN_EMPTY", "device authorization succeeded without tokens")
+		}
+		s.sessionStore.Delete(input.SessionID)
+		info.Token = s.tokenInfoFromResponse(result.Token, session.ClientID, nil)
+		return info, nil
+	case xai.DevicePollSlowDown:
+		info.Interval += 5
+		return info, nil
+	case xai.DevicePollPending:
+		return info, nil
+	case xai.DevicePollDenied, xai.DevicePollExpired:
+		s.sessionStore.Delete(input.SessionID)
+		return info, nil
+	default:
+		// Keep session for transient upstream errors so the client can retry.
+		if info.Error == "" {
+			info.Error = "device token poll failed"
+		}
+		return info, nil
+	}
+}
+
 func (s *GrokOAuthService) ExchangeCode(ctx context.Context, input *GrokExchangeCodeInput) (*GrokTokenInfo, error) {
 	if input == nil {
 		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_INVALID_INPUT", "input is required")
@@ -113,6 +217,39 @@ func (s *GrokOAuthService) ExchangeCode(ctx context.Context, input *GrokExchange
 	if !ok {
 		return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_SESSION_NOT_FOUND", "session not found or expired")
 	}
+
+	// Device-code sessions complete via PollDeviceLogin. ExchangeCode still accepts
+	// a single-shot completion (no code required) so older clients can finish login
+	// after the user authorizes in the browser.
+	if session.Flow == xai.OAuthFlowDevice || strings.TrimSpace(session.DeviceCode) != "" {
+		poll, err := s.PollDeviceLogin(ctx, &GrokDevicePollInput{
+			SessionID: input.SessionID,
+			ProxyID:   input.ProxyID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		switch poll.Status {
+		case string(xai.DevicePollAuthorized):
+			if poll.Token == nil {
+				return nil, infraerrors.New(http.StatusBadGateway, "GROK_OAUTH_DEVICE_TOKEN_EMPTY", "device authorization succeeded without tokens")
+			}
+			return poll.Token, nil
+		case string(xai.DevicePollPending), string(xai.DevicePollSlowDown):
+			return nil, infraerrors.New(http.StatusAccepted, "GROK_OAUTH_AUTHORIZATION_PENDING", "user has not completed device authorization yet")
+		case string(xai.DevicePollDenied):
+			return nil, infraerrors.New(http.StatusForbidden, "GROK_OAUTH_AUTHORIZATION_DENIED", "device authorization was denied")
+		case string(xai.DevicePollExpired):
+			return nil, infraerrors.New(http.StatusBadRequest, "GROK_OAUTH_DEVICE_CODE_EXPIRED", "device code expired")
+		default:
+			msg := poll.Error
+			if msg == "" {
+				msg = "device authorization failed"
+			}
+			return nil, infraerrors.New(http.StatusBadGateway, "GROK_OAUTH_DEVICE_POLL_FAILED", msg)
+		}
+	}
+
 	defer s.sessionStore.Delete(input.SessionID)
 
 	parsed := xai.ParseAuthorizationInput(input.Code)

--- a/backend/internal/service/grok_oauth_service_test.go
+++ b/backend/internal/service/grok_oauth_service_test.go
@@ -14,9 +14,36 @@ import (
 )
 
 type grokOAuthClientStub struct {
+	deviceResponse  *xai.DeviceCodeResponse
+	pollResponse    *xai.DevicePollResult
 	refreshResponse *xai.TokenResponse
 	ssoResponse     *xai.TokenResponse
 	exchangeCalls   int
+	deviceCalls     int
+	pollCalls       int
+}
+
+func (s *grokOAuthClientStub) RequestDeviceCode(context.Context, string, string, string) (*xai.DeviceCodeResponse, error) {
+	s.deviceCalls++
+	if s.deviceResponse != nil {
+		return s.deviceResponse, nil
+	}
+	return &xai.DeviceCodeResponse{
+		DeviceCode:              "device-code",
+		UserCode:                "ABCD-EFGH",
+		VerificationURI:         "https://auth.x.ai/oauth2/device",
+		VerificationURIComplete: "https://auth.x.ai/oauth2/device?user_code=ABCD-EFGH",
+		ExpiresIn:               600,
+		Interval:                5,
+	}, nil
+}
+
+func (s *grokOAuthClientStub) PollDeviceToken(context.Context, string, string, string) (*xai.DevicePollResult, error) {
+	s.pollCalls++
+	if s.pollResponse != nil {
+		return s.pollResponse, nil
+	}
+	return &xai.DevicePollResult{Status: xai.DevicePollPending}, nil
 }
 
 func (s *grokOAuthClientStub) ExchangeCode(context.Context, string, string, string, string, string) (*xai.TokenResponse, error) {
@@ -49,30 +76,92 @@ func TestGrokOAuthServiceRefreshTokenPreservesOriginalRefreshTokenWhenNotRotated
 	require.Equal(t, "client-id", info.ClientID)
 }
 
-func TestGrokOAuthServiceExchangeCodeRequiresStateForCallbackURLAndConsumesSession(t *testing.T) {
+func TestGrokOAuthServiceGenerateAuthURLUsesDeviceFlow(t *testing.T) {
 	client := &grokOAuthClientStub{}
 	svc := NewGrokOAuthService(nil, client)
 	defer svc.Stop()
 
 	auth, err := svc.GenerateAuthURL(context.Background(), nil, "")
 	require.NoError(t, err)
+	require.Equal(t, 1, client.deviceCalls)
+	require.Equal(t, xai.OAuthFlowDevice, auth.Flow)
+	require.Equal(t, "ABCD-EFGH", auth.UserCode)
+	require.Contains(t, auth.AuthURL, "user_code=ABCD-EFGH")
+	require.NotEmpty(t, auth.SessionID)
+	require.NotEmpty(t, auth.State)
+}
 
-	_, err = svc.ExchangeCode(context.Background(), &GrokExchangeCodeInput{
-		SessionID: auth.SessionID,
-		Code:      "http://127.0.0.1:56121/callback?code=code-without-state",
-	})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "GROK_OAUTH_STATE_REQUIRED")
-	require.Zero(t, client.exchangeCalls)
+func TestGrokOAuthServicePollDeviceLoginAuthorizesAndConsumesSession(t *testing.T) {
+	client := &grokOAuthClientStub{
+		pollResponse: &xai.DevicePollResult{
+			Status: xai.DevicePollAuthorized,
+			Token: &xai.TokenResponse{
+				AccessToken:  "access-token",
+				RefreshToken: "refresh-token",
+				TokenType:    "Bearer",
+				ExpiresIn:    3600,
+			},
+		},
+	}
+	svc := NewGrokOAuthService(nil, client)
+	defer svc.Stop()
 
-	_, err = svc.ExchangeCode(context.Background(), &GrokExchangeCodeInput{
-		SessionID: auth.SessionID,
-		Code:      "code-with-state",
-		State:     auth.State,
-	})
+	auth, err := svc.GenerateAuthURL(context.Background(), nil, "")
+	require.NoError(t, err)
+
+	poll, err := svc.PollDeviceLogin(context.Background(), &GrokDevicePollInput{SessionID: auth.SessionID})
+	require.NoError(t, err)
+	require.Equal(t, string(xai.DevicePollAuthorized), poll.Status)
+	require.NotNil(t, poll.Token)
+	require.Equal(t, "access-token", poll.Token.AccessToken)
+	require.Equal(t, "refresh-token", poll.Token.RefreshToken)
+	require.Equal(t, 1, client.pollCalls)
+
+	_, err = svc.PollDeviceLogin(context.Background(), &GrokDevicePollInput{SessionID: auth.SessionID})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "GROK_OAUTH_SESSION_NOT_FOUND")
+}
+
+func TestGrokOAuthServiceExchangeCodeCompletesDeviceSession(t *testing.T) {
+	client := &grokOAuthClientStub{
+		pollResponse: &xai.DevicePollResult{
+			Status: xai.DevicePollAuthorized,
+			Token: &xai.TokenResponse{
+				AccessToken:  "access-token",
+				RefreshToken: "refresh-token",
+				ExpiresIn:    3600,
+			},
+		},
+	}
+	svc := NewGrokOAuthService(nil, client)
+	defer svc.Stop()
+
+	auth, err := svc.GenerateAuthURL(context.Background(), nil, "")
+	require.NoError(t, err)
+
+	info, err := svc.ExchangeCode(context.Background(), &GrokExchangeCodeInput{
+		SessionID: auth.SessionID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "access-token", info.AccessToken)
+	require.Equal(t, "refresh-token", info.RefreshToken)
 	require.Zero(t, client.exchangeCalls)
+	require.Equal(t, 1, client.pollCalls)
+}
+
+func TestGrokOAuthServiceExchangeCodePendingDeviceAuthorization(t *testing.T) {
+	client := &grokOAuthClientStub{
+		pollResponse: &xai.DevicePollResult{Status: xai.DevicePollPending},
+	}
+	svc := NewGrokOAuthService(nil, client)
+	defer svc.Stop()
+
+	auth, err := svc.GenerateAuthURL(context.Background(), nil, "")
+	require.NoError(t, err)
+
+	_, err = svc.ExchangeCode(context.Background(), &GrokExchangeCodeInput{SessionID: auth.SessionID})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "GROK_OAUTH_AUTHORIZATION_PENDING")
 }
 
 func TestGrokOAuthServiceBuildAccountCredentialsDefaultsToSubscriptionProxy(t *testing.T) {

--- a/backend/internal/service/oauth_service.go
+++ b/backend/internal/service/oauth_service.go
@@ -20,6 +20,8 @@ type OpenAIOAuthClient interface {
 
 // GrokOAuthClient interface for xAI/Grok OAuth operations.
 type GrokOAuthClient interface {
+	RequestDeviceCode(ctx context.Context, proxyURL, clientID, scope string) (*xai.DeviceCodeResponse, error)
+	PollDeviceToken(ctx context.Context, deviceCode, proxyURL, clientID string) (*xai.DevicePollResult, error)
 	ExchangeCode(ctx context.Context, code, codeVerifier, redirectURI, proxyURL, clientID string) (*xai.TokenResponse, error)
 	RefreshToken(ctx context.Context, refreshToken, proxyURL, clientID string) (*xai.TokenResponse, error)
 	ConvertSSOToBuild(ctx context.Context, ssoToken, proxyURL string) (*xai.TokenResponse, error)

--- a/frontend/src/api/admin/grok.ts
+++ b/frontend/src/api/admin/grok.ts
@@ -12,6 +12,11 @@ export interface GrokAuthUrlResponse {
   auth_url: string
   session_id: string
   state: string
+  flow?: string
+  user_code?: string
+  interval?: number
+  expires_in?: number
+  expires_at?: number
 }
 
 export interface GrokAuthUrlRequest {
@@ -21,10 +26,24 @@ export interface GrokAuthUrlRequest {
 
 export interface GrokExchangeCodeRequest {
   session_id: string
-  state: string
-  code: string
+  state?: string
+  code?: string
   proxy_id?: number
   redirect_uri?: string
+}
+
+export interface GrokDevicePollRequest {
+  session_id: string
+  proxy_id?: number
+}
+
+export interface GrokDevicePollResponse {
+  status: 'pending' | 'slow_down' | 'authorized' | 'denied' | 'expired' | 'error' | string
+  interval?: number
+  expires_at?: number
+  user_code?: string
+  token?: GrokTokenInfo
+  error?: string
 }
 
 export interface GrokTokenInfo {
@@ -136,6 +155,16 @@ export async function exchangeCode(payload: GrokExchangeCodeRequest): Promise<Gr
   return data
 }
 
+export async function pollDeviceLogin(
+  payload: GrokDevicePollRequest
+): Promise<GrokDevicePollResponse> {
+  const { data } = await apiClient.post<GrokDevicePollResponse>(
+    '/admin/grok/oauth/device/poll',
+    payload
+  )
+  return data
+}
+
 export async function refreshGrokToken(
   refreshToken: string,
   proxyId?: number | null
@@ -169,4 +198,12 @@ export async function createFromSSO(payload: GrokSSOToOAuthRequest): Promise<Gro
   return data
 }
 
-export default { generateAuthUrl, exchangeCode, refreshGrokToken, queryQuota, resetQuota, createFromSSO }
+export default {
+  generateAuthUrl,
+  exchangeCode,
+  pollDeviceLogin,
+  refreshGrokToken,
+  queryQuota,
+  resetQuota,
+  createFromSSO
+}

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3103,6 +3103,10 @@
     <div v-else class="space-y-5">
       <OAuthAuthorizationFlow
         ref="oauthFlowRef"
+        :user-code="form.platform === 'grok' ? grokOAuth.userCode.value : ''"
+        :device-status="form.platform === 'grok' ? grokOAuth.deviceStatus.value : ''"
+        :device-polling="form.platform === 'grok' ? grokOAuth.polling.value : false"
+        :device-authorized="form.platform === 'grok' ? !!grokOAuth.authorizedToken.value : false"
         :add-method="form.platform === 'anthropic' ? addMethod : 'oauth'"
         :auth-url="currentAuthUrl"
         :session-id="currentSessionId"
@@ -4045,7 +4049,8 @@ const canExchangeCode = computed(() => {
     return authCode.trim() && antigravityOAuth.sessionId.value && !antigravityOAuth.loading.value
   }
   if (form.platform === 'grok') {
-    return authCode.trim() && grokOAuth.sessionId.value && !grokOAuth.loading.value
+    // Device-code flow: create is enabled once the browser authorization is detected.
+    return !!grokOAuth.authorizedToken.value && !grokOAuth.loading.value
   }
   return authCode.trim() && oauth.sessionId.value && !oauth.loading.value
 })
@@ -5868,37 +5873,25 @@ const handleAntigravityExchange = async (authCode: string) => {
 }
 
 // Grok OAuth 授权码兑换
-const handleGrokExchange = async (authCode: string) => {
-  if (!authCode.trim() || !grokOAuth.sessionId.value) return
-
-  grokOAuth.loading.value = true
-  grokOAuth.error.value = ''
+const handleGrokExchange = async (_authCode?: string) => {
+  const tokenInfo =
+    grokOAuth.authorizedToken.value ||
+    (grokOAuth.sessionId.value
+      ? await grokOAuth.exchangeAuthCode({
+          sessionId: grokOAuth.sessionId.value,
+          state: grokOAuth.state.value,
+          proxyId: form.proxy_id
+        })
+      : null)
+  if (!tokenInfo) return
 
   try {
-    const stateFromInput = oauthFlowRef.value?.oauthState || ''
-    const stateToUse = stateFromInput || grokOAuth.state.value
-    if (!stateToUse) {
-      grokOAuth.error.value = t('admin.accounts.oauth.authFailed')
-      appStore.showError(grokOAuth.error.value)
-      return
-    }
-
-    const tokenInfo = await grokOAuth.exchangeAuthCode({
-      code: authCode.trim(),
-      sessionId: grokOAuth.sessionId.value,
-      state: stateToUse,
-      proxyId: form.proxy_id
-    })
-    if (!tokenInfo) return
-
     const credentials = grokOAuth.buildCredentials(tokenInfo)
     const extra = grokOAuth.buildExtraInfo(tokenInfo)
     await createAccountAndFinish('grok', 'oauth', credentials, extra)
   } catch (error: any) {
     grokOAuth.error.value = error.response?.data?.detail || t('admin.accounts.oauth.authFailed')
     appStore.showError(grokOAuth.error.value)
-  } finally {
-    grokOAuth.loading.value = false
   }
 }
 

--- a/frontend/src/components/account/OAuthAuthorizationFlow.vue
+++ b/frontend/src/components/account/OAuthAuthorizationFlow.vue
@@ -636,6 +636,17 @@
                   {{ loading ? t('admin.accounts.oauth.generating') : oauthGenerateAuthUrl }}
                 </button>
                 <div v-else class="space-y-3">
+                  <div
+                    v-if="isGrokDeviceFlow && userCode"
+                    class="rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 dark:border-blue-700 dark:bg-blue-900/40"
+                  >
+                    <p class="text-xs text-blue-700 dark:text-blue-300">
+                      {{ t('admin.accounts.oauth.grok.userCodeLabel') }}
+                    </p>
+                    <p class="mt-1 font-mono text-lg font-semibold tracking-widest text-blue-900 dark:text-blue-100">
+                      {{ userCode }}
+                    </p>
+                  </div>
                   <div class="flex items-center gap-2">
                     <input
                       :value="authUrl"
@@ -726,7 +737,7 @@
             </div>
           </div>
 
-          <!-- Step 3: Enter authorization code -->
+          <!-- Step 3: Enter authorization code / wait for device authorization -->
           <div
             class="rounded-lg border border-blue-300 bg-white/80 p-4 dark:border-blue-600 dark:bg-gray-800/80"
           >
@@ -744,7 +755,56 @@
                   class="mb-3 text-sm text-blue-700 dark:text-blue-300"
                   v-text="oauthAuthCodeDesc"
                 ></p>
-                <div>
+
+                <div v-if="isGrokDeviceFlow" class="space-y-3">
+                  <div
+                    v-if="deviceAuthorized"
+                    class="rounded-lg border border-green-300 bg-green-50 p-3 dark:border-green-700 dark:bg-green-900/30"
+                  >
+                    <p class="text-sm font-medium text-green-800 dark:text-green-300">
+                      {{ t('admin.accounts.oauth.grok.deviceAuthorized') }}
+                    </p>
+                  </div>
+                  <div
+                    v-else
+                    class="rounded-lg border border-blue-200 bg-blue-50 p-3 dark:border-blue-700 dark:bg-blue-900/30"
+                  >
+                    <div class="flex items-center gap-2 text-sm text-blue-800 dark:text-blue-200">
+                      <svg
+                        v-if="devicePolling || loading"
+                        class="h-4 w-4 animate-spin"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                      >
+                        <circle
+                          class="opacity-25"
+                          cx="12"
+                          cy="12"
+                          r="10"
+                          stroke="currentColor"
+                          stroke-width="4"
+                        ></circle>
+                        <path
+                          class="opacity-75"
+                          fill="currentColor"
+                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                        ></path>
+                      </svg>
+                      <span>
+                        {{
+                          devicePolling || loading
+                            ? t('admin.accounts.oauth.grok.waitingForAuthorization')
+                            : t('admin.accounts.oauth.grok.waitingForAuthorizationIdle')
+                        }}
+                      </span>
+                    </div>
+                    <p v-if="deviceStatus" class="mt-1 text-xs text-blue-600 dark:text-blue-400">
+                      {{ t('admin.accounts.oauth.grok.deviceStatus', { status: deviceStatus }) }}
+                    </p>
+                  </div>
+                </div>
+
+                <div v-else>
                   <label class="input-label">
                     <Icon name="key" size="sm" class="mr-1 inline text-blue-500" />
                     {{ oauthAuthCode }}
@@ -828,6 +888,10 @@ interface Props {
   initialInputMethod?: AuthInputMethod
   platform?: AccountPlatform // Platform type for different UI/text
   showProjectId?: boolean // New prop to control project ID visibility
+  userCode?: string
+  deviceStatus?: string
+  devicePolling?: boolean
+  deviceAuthorized?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -850,7 +914,11 @@ const props = withDefaults(defineProps<Props>(), {
   showManualOption: true,
   initialInputMethod: 'manual',
   platform: 'anthropic',
-  showProjectId: true
+  showProjectId: true,
+  userCode: '',
+  deviceStatus: '',
+  devicePolling: false,
+  deviceAuthorized: false
 })
 
 const emit = defineEmits<{
@@ -869,7 +937,8 @@ const emit = defineEmits<{
 
 const { t } = useI18n()
 
-const showLocalCallbackNotice = computed(() => props.platform === 'openai' || props.platform === 'grok')
+const showLocalCallbackNotice = computed(() => props.platform === 'openai')
+const isGrokDeviceFlow = computed(() => props.platform === 'grok')
 
 // Get translation key based on platform
 const getOAuthKey = (key: string) => {

--- a/frontend/src/composables/__tests__/useGrokOAuth.spec.ts
+++ b/frontend/src/composables/__tests__/useGrokOAuth.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 vi.mock('@/stores/app', () => ({
   useAppStore: () => ({
@@ -10,9 +10,12 @@ vi.mock('vue-i18n', () => ({
   useI18n: () => ({
     t: (key: string) => {
       const messages: Record<string, string> = {
-        'admin.accounts.oauth.grok.failedToExchangeCode': 'Grok 授权码兑换失败',
+        'admin.accounts.oauth.grok.failedToExchangeCode': 'Grok 授权完成失败',
+        'admin.accounts.oauth.grok.failedToPollDevice': '轮询 Grok 设备授权状态失败',
         'admin.accounts.oauth.grok.errors.GROK_OAUTH_INVALID_STATE':
-          'Grok OAuth state 与当前会话不匹配。请粘贴同一次生成的授权链接返回的回调 URL。'
+          'Grok OAuth state 与当前会话不匹配。请重新生成授权链接。',
+        'admin.accounts.oauth.grok.errors.GROK_OAUTH_AUTHORIZATION_PENDING':
+          '用户尚未在浏览器中完成设备授权，请稍后再试。'
       }
       return messages[key] ?? key
     }
@@ -24,6 +27,7 @@ vi.mock('@/api/admin', () => ({
     grok: {
       generateAuthUrl: vi.fn(),
       exchangeCode: vi.fn(),
+      pollDeviceLogin: vi.fn(),
       refreshGrokToken: vi.fn()
     }
   }
@@ -32,8 +36,44 @@ vi.mock('@/api/admin', () => ({
 import { useGrokOAuth } from '@/composables/useGrokOAuth'
 import { adminAPI } from '@/api/admin'
 
+describe('useGrokOAuth.generateAuthUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('starts device polling after generating a device auth URL', async () => {
+    vi.mocked(adminAPI.grok.generateAuthUrl).mockResolvedValueOnce({
+      auth_url: 'https://auth.x.ai/oauth2/device?user_code=ABCD',
+      session_id: 'session-1',
+      state: 'state-1',
+      flow: 'device',
+      user_code: 'ABCD',
+      interval: 5,
+      expires_in: 600
+    })
+    vi.mocked(adminAPI.grok.pollDeviceLogin).mockResolvedValueOnce({
+      status: 'pending',
+      interval: 5
+    })
+
+    const oauth = useGrokOAuth()
+    const ok = await oauth.generateAuthUrl(null)
+    expect(ok).toBe(true)
+    expect(oauth.authUrl.value).toContain('user_code=ABCD')
+    expect(oauth.userCode.value).toBe('ABCD')
+    expect(oauth.flow.value).toBe('device')
+    expect(oauth.polling.value).toBe(true)
+
+    oauth.stopPolling()
+  })
+})
+
 describe('useGrokOAuth.exchangeAuthCode', () => {
-  it('shows a state mismatch recovery hint from structured backend errors', async () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows a structured backend recovery hint', async () => {
     vi.mocked(adminAPI.grok.exchangeCode).mockRejectedValueOnce({
       status: 400,
       reason: 'GROK_OAUTH_INVALID_STATE',
@@ -42,15 +82,26 @@ describe('useGrokOAuth.exchangeAuthCode', () => {
     const oauth = useGrokOAuth()
 
     const tokenInfo = await oauth.exchangeAuthCode({
-      code: 'code',
       sessionId: 'session-id',
       state: 'wrong-state'
     })
 
     expect(tokenInfo).toBeNull()
     expect(oauth.error.value).toBe(
-      'Grok OAuth state 与当前会话不匹配。请粘贴同一次生成的授权链接返回的回调 URL。'
+      'Grok OAuth state 与当前会话不匹配。请重新生成授权链接。'
     )
+  })
+
+  it('returns an already authorized token without calling exchange', async () => {
+    const oauth = useGrokOAuth()
+    oauth.authorizedToken.value = {
+      access_token: 'ready-access',
+      refresh_token: 'ready-refresh'
+    }
+
+    const tokenInfo = await oauth.exchangeAuthCode({ sessionId: 'session-id' })
+    expect(tokenInfo?.access_token).toBe('ready-access')
+    expect(adminAPI.grok.exchangeCode).not.toHaveBeenCalled()
   })
 })
 

--- a/frontend/src/composables/useGrokOAuth.ts
+++ b/frontend/src/composables/useGrokOAuth.ts
@@ -5,6 +5,9 @@ import { adminAPI } from '@/api/admin'
 import type { GrokTokenInfo } from '@/api/admin/grok'
 import { extractApiErrorMessage, extractI18nErrorMessage } from '@/utils/apiError'
 
+const DEFAULT_POLL_INTERVAL_MS = 5_000
+const MAX_POLL_INTERVAL_MS = 30_000
+
 export function useGrokOAuth() {
   const appStore = useAppStore()
   const { t } = useI18n()
@@ -12,15 +15,131 @@ export function useGrokOAuth() {
   const authUrl = ref('')
   const sessionId = ref('')
   const state = ref('')
+  const flow = ref('')
+  const userCode = ref('')
+  const pollIntervalSec = ref(5)
+  const deviceExpiresAt = ref<number | null>(null)
+  const deviceStatus = ref('')
+  const authorizedToken = ref<GrokTokenInfo | null>(null)
   const loading = ref(false)
+  const polling = ref(false)
   const error = ref('')
 
+  let pollTimer: ReturnType<typeof setTimeout> | null = null
+  let pollGeneration = 0
+
+  const clearPollTimer = () => {
+    if (pollTimer != null) {
+      clearTimeout(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  const stopPolling = () => {
+    pollGeneration += 1
+    clearPollTimer()
+    polling.value = false
+  }
+
   const resetState = () => {
+    stopPolling()
     authUrl.value = ''
     sessionId.value = ''
     state.value = ''
+    flow.value = ''
+    userCode.value = ''
+    pollIntervalSec.value = 5
+    deviceExpiresAt.value = null
+    deviceStatus.value = ''
+    authorizedToken.value = null
     loading.value = false
     error.value = ''
+  }
+
+  const schedulePoll = (session: string, proxyId: number | null | undefined, delayMs: number, generation: number) => {
+    clearPollTimer()
+    pollTimer = setTimeout(() => {
+      void pollOnce(session, proxyId, generation)
+    }, Math.max(1_000, delayMs))
+  }
+
+  const pollOnce = async (
+    session: string,
+    proxyId: number | null | undefined,
+    generation: number
+  ): Promise<GrokTokenInfo | null> => {
+    if (generation !== pollGeneration) return null
+    if (!session) return null
+
+    try {
+      const payload: Record<string, unknown> = { session_id: session }
+      if (proxyId) payload.proxy_id = proxyId
+      const result = await adminAPI.grok.pollDeviceLogin(payload as any)
+      if (generation !== pollGeneration) return null
+
+      deviceStatus.value = result.status || ''
+      if (result.user_code) userCode.value = result.user_code
+      if (result.expires_at) deviceExpiresAt.value = result.expires_at
+      if (result.interval && result.interval > 0) {
+        pollIntervalSec.value = result.interval
+      }
+
+      if (result.status === 'authorized' && result.token) {
+        authorizedToken.value = result.token
+        polling.value = false
+        return result.token
+      }
+
+      if (result.status === 'denied' || result.status === 'expired') {
+        polling.value = false
+        error.value =
+          result.error ||
+          (result.status === 'expired'
+            ? t('admin.accounts.oauth.grok.deviceCodeExpired')
+            : t('admin.accounts.oauth.grok.deviceAuthorizationDenied'))
+        appStore.showError(error.value)
+        return null
+      }
+
+      if (result.status === 'error') {
+        // Transient upstream error: keep polling with a modest backoff.
+        const delay = Math.min(
+          MAX_POLL_INTERVAL_MS,
+          Math.max(DEFAULT_POLL_INTERVAL_MS, (pollIntervalSec.value || 5) * 1000 + 2_000)
+        )
+        schedulePoll(session, proxyId, delay, generation)
+        return null
+      }
+
+      const intervalSec = Math.max(1, pollIntervalSec.value || 5)
+      const delay =
+        result.status === 'slow_down'
+          ? Math.min(MAX_POLL_INTERVAL_MS, (intervalSec + 5) * 1000)
+          : intervalSec * 1000
+      schedulePoll(session, proxyId, delay, generation)
+      return null
+    } catch (err: any) {
+      if (generation !== pollGeneration) return null
+      // Network blips should not kill the whole device session.
+      const delay = Math.min(MAX_POLL_INTERVAL_MS, (pollIntervalSec.value || 5) * 1000 + 2_000)
+      schedulePoll(session, proxyId, delay, generation)
+      error.value = extractI18nErrorMessage(
+        err,
+        t,
+        'admin.accounts.oauth.grok.errors',
+        t('admin.accounts.oauth.grok.failedToPollDevice')
+      )
+      return null
+    }
+  }
+
+  const startDevicePolling = (proxyId?: number | null) => {
+    if (!sessionId.value) return
+    stopPolling()
+    const generation = pollGeneration
+    polling.value = true
+    deviceStatus.value = 'pending'
+    schedulePoll(sessionId.value, proxyId, 1_500, generation)
   }
 
   const generateAuthUrl = async (proxyId: number | null | undefined): Promise<boolean> => {
@@ -28,7 +147,14 @@ export function useGrokOAuth() {
     authUrl.value = ''
     sessionId.value = ''
     state.value = ''
+    flow.value = ''
+    userCode.value = ''
+    pollIntervalSec.value = 5
+    deviceExpiresAt.value = null
+    deviceStatus.value = ''
+    authorizedToken.value = null
     error.value = ''
+    stopPolling()
 
     try {
       const payload: Record<string, unknown> = {}
@@ -38,6 +164,11 @@ export function useGrokOAuth() {
       authUrl.value = response.auth_url
       sessionId.value = response.session_id
       state.value = response.state
+      flow.value = response.flow || 'device'
+      userCode.value = response.user_code || ''
+      pollIntervalSec.value = response.interval && response.interval > 0 ? response.interval : 5
+      deviceExpiresAt.value = response.expires_at ?? null
+      startDevicePolling(proxyId)
       return true
     } catch (err: any) {
       error.value = extractApiErrorMessage(err, t('admin.accounts.oauth.grok.failedToGenerateUrl'))
@@ -49,13 +180,15 @@ export function useGrokOAuth() {
   }
 
   const exchangeAuthCode = async (params: {
-    code: string
+    code?: string
     sessionId: string
-    state: string
+    state?: string
     proxyId?: number | null
   }): Promise<GrokTokenInfo | null> => {
-    const code = params.code?.trim()
-    if (!code || !params.sessionId || !params.state) {
+    if (authorizedToken.value) {
+      return authorizedToken.value
+    }
+    if (!params.sessionId) {
       error.value = t('admin.accounts.oauth.grok.missingExchangeParams')
       return null
     }
@@ -65,13 +198,16 @@ export function useGrokOAuth() {
 
     try {
       const payload: Record<string, unknown> = {
-        session_id: params.sessionId,
-        state: params.state,
-        code
+        session_id: params.sessionId
       }
+      if (params.state) payload.state = params.state
+      if (params.code) payload.code = params.code
       if (params.proxyId) payload.proxy_id = params.proxyId
 
-      return await adminAPI.grok.exchangeCode(payload as any)
+      const token = await adminAPI.grok.exchangeCode(payload as any)
+      authorizedToken.value = token
+      stopPolling()
+      return token
     } catch (err: any) {
       error.value = extractI18nErrorMessage(
         err,
@@ -107,6 +243,7 @@ export function useGrokOAuth() {
         'admin.accounts.oauth.grok.errors',
         t('admin.accounts.oauth.grok.failedToValidateRT')
       )
+      appStore.showError(error.value)
       return null
     } finally {
       loading.value = false
@@ -144,10 +281,19 @@ export function useGrokOAuth() {
     authUrl,
     sessionId,
     state,
+    flow,
+    userCode,
+    pollIntervalSec,
+    deviceExpiresAt,
+    deviceStatus,
+    authorizedToken,
     loading,
+    polling,
     error,
     resetState,
     generateAuthUrl,
+    startDevicePolling,
+    stopPolling,
     exchangeAuthCode,
     validateRefreshToken,
     buildCredentials,

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -859,17 +859,25 @@ export default {
         },
         grok: {
           title: 'Grok Account Authorization',
-          followSteps: 'Follow these steps to authorize your xAI/Grok account:',
-          step1GenerateUrl: 'Generate the xAI authorization URL',
+          followSteps: 'Follow these steps to authorize your xAI/Grok account (same Device Code flow as the official Grok CLI):',
+          step1GenerateUrl: 'Generate the xAI device authorization URL',
           generateAuthUrl: 'Generate Auth URL',
           step2OpenUrl: 'Open the URL in your browser and complete authorization',
-          openUrlDesc: 'Open the authorization URL in a new tab, sign in to xAI, and authorize API access.',
-          importantNotice: 'When the browser reaches the local callback URL, copy the full URL or the code query parameter back here.',
-          step3EnterCode: 'Enter Authorization URL or Code',
-          authCodeDesc: 'After authorization, paste the callback URL, query string, or authorization code:',
+          openUrlDesc: 'Open the authorization URL in a new tab, sign in to xAI, and approve the device. Sub2API polls for completion automatically.',
+          importantNotice: 'Grok uses Device Code OAuth. You no longer need a local callback URL paste-back.',
+          step3EnterCode: 'Wait for browser authorization',
+          authCodeDesc: 'After you approve access in the browser, credentials appear here automatically. Then create the account.',
           authCode: 'Authorization URL or Code',
           authCodePlaceholder: 'Paste the full callback URL, ?code=... query string, or code value',
           authCodeHint: 'Full callback URLs, query strings, and bare codes are accepted.',
+          userCodeLabel: 'Device user code',
+          waitingForAuthorization: 'Waiting for browser authorization…',
+          waitingForAuthorizationIdle: 'Open the URL above to authorize, then wait for status updates.',
+          deviceAuthorized: 'Authorization succeeded. You can create the account now.',
+          deviceStatus: 'Status: {status}',
+          deviceCodeExpired: 'Device code expired. Generate a new authorization URL.',
+          deviceAuthorizationDenied: 'Device authorization was denied. Generate a new authorization URL.',
+          failedToPollDevice: 'Failed to poll Grok device authorization status',
           refreshTokenAuth: 'Manual RT Input',
           refreshTokenDesc: 'Enter existing xAI refresh token(s). Supports batch input, one per line.',
           refreshTokenPlaceholder: 'Paste your xAI refresh token...\nSupports multiple, one per line',
@@ -884,15 +892,21 @@ export default {
           validateAndCreate: 'Validate & Create Account',
           pleaseEnterRefreshToken: 'Please enter Refresh Token',
           failedToGenerateUrl: 'Failed to generate Grok auth URL',
-          missingExchangeParams: 'Missing authorization code, state, or OAuth session',
-          failedToExchangeCode: 'Failed to exchange Grok authorization code',
+          missingExchangeParams: 'Missing OAuth session',
+          failedToExchangeCode: 'Failed to complete Grok authorization',
           failedToValidateRT: 'Failed to validate Grok refresh token',
           failedToConvertSSO: 'Failed to convert Grok SSO cookie',
           errors: {
             GROK_OAUTH_SESSION_NOT_FOUND:
-              'Grok OAuth session was not found or has expired. Generate a new auth URL and paste the newest callback URL.',
+              'Grok OAuth session was not found or has expired. Generate a new auth URL and complete browser authorization again.',
             GROK_OAUTH_INVALID_STATE:
-              'Grok OAuth state does not match this session. Paste the callback URL from the same generated auth link.',
+              'Grok OAuth state does not match the current session. Generate a new auth URL.',
+            GROK_OAUTH_AUTHORIZATION_PENDING:
+              'The user has not finished device authorization in the browser yet.',
+            GROK_OAUTH_DEVICE_CODE_EXPIRED:
+              'Device code expired. Generate a new authorization URL.',
+            GROK_OAUTH_AUTHORIZATION_DENIED:
+              'Device authorization was denied. Generate a new authorization URL.',
             GROK_OAUTH_STATE_REQUIRED:
               'The callback URL is missing the OAuth state. Paste the full callback URL, not only the code.',
             GROK_OAUTH_CODE_REQUIRED:

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -945,17 +945,25 @@ export default {
         },
         grok: {
           title: 'Grok 账号授权',
-          followSteps: '请按照以下步骤授权您的 xAI/Grok 账号：',
-          step1GenerateUrl: '生成 xAI 授权链接',
+          followSteps: '请按照以下步骤授权您的 xAI/Grok 账号（与官方 Grok CLI 相同的 Device Code 流程）：',
+          step1GenerateUrl: '生成 xAI Device 授权链接',
           generateAuthUrl: '生成授权链接',
           step2OpenUrl: '在浏览器中打开链接并完成授权',
-          openUrlDesc: '在新标签页中打开授权链接，登录 xAI 并授权 API 访问。',
-          importantNotice: '当浏览器跳转到本地 callback URL 后，请复制完整 URL 或 code 参数回填到这里。',
-          step3EnterCode: '输入授权链接或 Code',
-          authCodeDesc: '授权完成后，粘贴 callback URL、查询字符串或授权码：',
+          openUrlDesc: '在新标签页中打开授权链接，登录 xAI 并确认设备授权。系统会自动轮询授权结果。',
+          importantNotice: 'Grok 使用 Device Code 授权，不再需要本地 callback 回填。打开链接完成授权即可。',
+          step3EnterCode: '等待浏览器授权完成',
+          authCodeDesc: '授权完成后页面会自动检测到凭据，然后点击创建账号。',
           authCode: '授权链接或 Code',
           authCodePlaceholder: '粘贴完整 callback URL、?code=... 查询字符串或 code 值',
           authCodeHint: '支持完整 callback URL、查询字符串或裸 code。',
+          userCodeLabel: '设备授权码（User Code）',
+          waitingForAuthorization: '正在等待浏览器完成授权…',
+          waitingForAuthorizationIdle: '请打开上方链接完成授权，然后等待状态更新。',
+          deviceAuthorized: '授权成功，可以创建账号了。',
+          deviceStatus: '当前状态：{status}',
+          deviceCodeExpired: '设备授权码已过期，请重新生成授权链接。',
+          deviceAuthorizationDenied: '设备授权被拒绝，请重新生成授权链接。',
+          failedToPollDevice: '轮询 Grok 设备授权状态失败',
           refreshTokenAuth: '手动输入 RT',
           refreshTokenDesc: '输入已有的 xAI refresh token，支持批量输入（每行一个）。',
           refreshTokenPlaceholder: '粘贴您的 xAI refresh token...\n支持多个，每行一个',
@@ -970,17 +978,23 @@ export default {
           validateAndCreate: '验证并创建账号',
           pleaseEnterRefreshToken: '请输入 Refresh Token',
           failedToGenerateUrl: '生成 Grok 授权链接失败',
-          missingExchangeParams: '缺少授权码、state 或 OAuth 会话',
-          failedToExchangeCode: 'Grok 授权码兑换失败',
+          missingExchangeParams: '缺少 OAuth 会话',
+          failedToExchangeCode: 'Grok 授权完成失败',
           failedToValidateRT: '验证 Grok refresh token 失败',
           failedToConvertSSO: 'Grok SSO 转换失败',
           errors: {
             GROK_OAUTH_SESSION_NOT_FOUND:
-              'Grok OAuth 会话不存在或已过期。请重新生成授权链接，并粘贴最新的回调链接。',
+              'Grok OAuth 会话不存在或已过期。请重新生成授权链接并完成浏览器授权。',
             GROK_OAUTH_INVALID_STATE:
-              'Grok OAuth state 与当前会话不匹配。请粘贴同一次生成的授权链接返回的回调 URL。',
+              'Grok OAuth state 与当前会话不匹配。请重新生成授权链接。',
             GROK_OAUTH_STATE_REQUIRED:
               '回调链接缺少 OAuth state。请粘贴完整 callback URL，不要只粘贴 code。',
+            GROK_OAUTH_AUTHORIZATION_PENDING:
+              '用户尚未在浏览器中完成设备授权，请稍后再试。',
+            GROK_OAUTH_DEVICE_CODE_EXPIRED:
+              '设备授权码已过期，请重新生成授权链接。',
+            GROK_OAUTH_AUTHORIZATION_DENIED:
+              '设备授权被拒绝，请重新生成授权链接。',
             GROK_OAUTH_CODE_REQUIRED:
               '缺少 Grok 授权码。请粘贴完整 callback URL、查询字符串或 code 值。',
             GROK_OAUTH_NO_REFRESH_TOKEN:


### PR DESCRIPTION
## Summary

- Switch Grok subscription OAuth from authorization-code PKCE to the same **device-code** flow used by the official Grok CLI and clandes.
- Align OAuth request headers (`x-grok-client-version`, `x-grok-client-surface`) and full CLI scope (`conversations:read/write`).
- Admin UI now shows the device user code, auto-polls authorization status, and enables account creation only after tokens are ready.

This fixes newly authorized Grok OAuth accounts failing the first refresh with:

```text
invalid_grant / Refresh token not found or invalid
```

**Note:** Accounts created with the previous PKCE path may still hold unusable refresh tokens and need re-authorization (device flow or SSO import).

Fixes #4227

## Test plan

- [x] `go test -tags=unit ./internal/pkg/xai/ ./internal/repository/ ./internal/service/ ./internal/handler/admin/`
- [x] `pnpm test:run src/composables/__tests__/useGrokOAuth.spec.ts`
- [x] `pnpm typecheck`
- [ ] Admin: generate Grok OAuth URL → open verification URL → approve → create account → refresh token succeeds
- [x] Admin: SSO cookie import still creates refreshable Grok OAuth accounts
- [x] Admin: manual RT path still works