### PR TITLE
fix(grok): sanitize null reasoning content

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -275,10 +275,12 @@ func deleteJSONFields(value any, fields map[string]struct{}) bool {
 // additional_tools is a Codex/Responses Lite private input carrier. xAI's
 // Responses schema accepts ordinary message/function-call input items but
 // rejects this carrier before inference with a ModelInput deserialization
-// error. Top-level supported tools remain available through the separate
+// error. xAI also rejects reasoning history items when content is explicitly
+// null, although Codex legitimately emits that shape on multi-turn requests.
+// Top-level supported tools remain available through the separate
 // sanitizeGrokResponsesTools path.
 func sanitizeGrokResponsesInput(body []byte) ([]byte, error) {
-	if !bytes.Contains(body, []byte(`"additional_tools"`)) {
+	if !bytes.Contains(body, []byte(`"additional_tools"`)) && !bytes.Contains(body, []byte(`"reasoning"`)) {
 		return body, nil
 	}
 	input := gjson.GetBytes(body, "input")
@@ -288,13 +290,32 @@ func sanitizeGrokResponsesInput(body []byte) ([]byte, error) {
 
 	rawItems := input.Array()
 	filtered := make([]json.RawMessage, 0, len(rawItems))
+	changed := false
 	for _, item := range rawItems {
 		if strings.TrimSpace(item.Get("type").String()) == "additional_tools" {
+			changed = true
 			continue
 		}
-		filtered = append(filtered, json.RawMessage(item.Raw))
+
+		raw := json.RawMessage(item.Raw)
+		if strings.TrimSpace(item.Get("type").String()) == "reasoning" {
+			var reasoningItem map[string]any
+			if err := json.Unmarshal(raw, &reasoningItem); err != nil {
+				return nil, err
+			}
+			if content, exists := reasoningItem["content"]; exists && content == nil {
+				delete(reasoningItem, "content")
+				encoded, err := json.Marshal(reasoningItem)
+				if err != nil {
+					return nil, err
+				}
+				raw = encoded
+				changed = true
+			}
+		}
+		filtered = append(filtered, raw)
 	}
-	if len(filtered) == len(rawItems) {
+	if !changed {
 		return body, nil
 	}
 	encoded, err := json.Marshal(filtered)

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -245,6 +245,37 @@ func TestPatchGrokResponsesBodyDropsCodexAdditionalToolsInputItems(t *testing.T)
 	require.Equal(t, "hello", gjson.GetBytes(patched, "input.1.content.0.text").String())
 }
 
+func TestPatchGrokResponsesBodyDropsNullContentFromReasoningHistory(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model": "grok",
+		"input": [
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"hi"}]},
+			{"type":"reasoning","summary":[{"type":"summary_text","text":"thinking"}],"content":null,"encrypted_content":null},
+			{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hi"}]},
+			{"type":"message","role":"user","content":[{"type":"input_text","text":"reply with ok"}]}
+		]
+	}`)
+
+	patched, err := patchGrokResponsesBody(body, "grok-4.5")
+	require.NoError(t, err)
+	require.True(t, json.Valid(patched))
+	require.False(t, gjson.GetBytes(patched, "input.1.content").Exists())
+	require.True(t, gjson.GetBytes(patched, "input.1.encrypted_content").Exists())
+	require.Equal(t, "thinking", gjson.GetBytes(patched, "input.1.summary.0.text").String())
+	require.Equal(t, "Hi", gjson.GetBytes(patched, "input.2.content.0.text").String())
+}
+
+func TestPatchGrokResponsesBodyKeepsNonNullReasoningContent(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"grok","input":[{"type":"reasoning","content":[{"type":"reasoning_text","text":"keep"}]}]}`)
+	patched, err := patchGrokResponsesBody(body, "grok-4.5")
+	require.NoError(t, err)
+	require.Equal(t, "keep", gjson.GetBytes(patched, "input.0.content.0.text").String())
+}
+
 func TestBuildGrokResponsesRequestUsesAccountBaseURLAndBearerToken(t *testing.T) {
 	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
 


### PR DESCRIPTION
## Summary

- remove only explicit `content: null` from Grok Responses `reasoning` history items
- preserve non-null reasoning content, summaries, encrypted content, and all other input items
- keep the existing Codex `additional_tools` filtering behavior

## Why

Codex multi-turn `/v1/responses` requests can include reasoning history with `content: null`. xAI rejects that otherwise valid history item while accepting the same item when the null field is omitted.

Fixes #4237.

## Validation

- `go test -tags=unit ./internal/service -run 'TestPatchGrokResponsesBody(DropsNullContentFromReasoningHistory|KeepsNonNullReasoningContent|DropsCodexAdditionalToolsInputItems)$' -count=1`
- `go vet -tags=unit ./internal/service`
- authenticated production canary with a real existing Grok OAuth account: HTTP 200, `response.completed=true`, usage recorded through `/v1/responses`
