### PR TITLE
fix: preserve safe upstream client error statuses

### DIFF
--- a/backend/internal/service/error_passthrough_runtime_test.go
+++ b/backend/internal/service/error_passthrough_runtime_test.go
@@ -63,30 +63,150 @@ func TestGatewayHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
 	assert.Equal(t, "Upstream request failed", errField["message"])
 }
 
-func TestOpenAIHandleErrorResponse_NoRuleKeepsDefault(t *testing.T) {
+func TestOpenAIHandleErrorResponse_ClientRequestErrorsKeepStatusAndHideUpstreamDetails(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		message    string
+	}{
+		{name: "bad_request", statusCode: http.StatusBadRequest, message: "Invalid request to upstream provider"},
+		{name: "payload_too_large", statusCode: http.StatusRequestEntityTooLarge, message: "Request payload is too large"},
+		{name: "unprocessable_entity", statusCode: http.StatusUnprocessableEntity, message: "Request could not be processed by upstream provider"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+
+			svc := &OpenAIGatewayService{}
+			respBody := []byte(`{"error":{"message":"synthetic-sensitive-upstream-detail"},"request_id":"synthetic-request-id"}`)
+			resp := &http.Response{
+				StatusCode: tt.statusCode,
+				Body:       io.NopCloser(bytes.NewReader(respBody)),
+				Header:     http.Header{"X-Request-Id": []string{"synthetic-request-id"}},
+			}
+			account := &Account{ID: 12, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+			_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+			require.Error(t, err)
+			assert.Equal(t, tt.statusCode, rec.Code)
+			assert.True(t, IsResponseCommitted(c))
+			assert.NotContains(t, rec.Body.String(), "synthetic-sensitive-upstream-detail")
+			assert.NotContains(t, rec.Body.String(), "synthetic-request-id")
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+			errField, ok := payload["error"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, "invalid_request_error", errField["type"])
+			assert.Equal(t, tt.message, errField["message"])
+		})
+	}
+}
+
+func TestOpenAIHandleErrorResponse_ClientRequestErrorsIgnoreCustomCodeMiss(t *testing.T) {
+	for _, statusCode := range []int{
+		http.StatusBadRequest,
+		http.StatusRequestEntityTooLarge,
+		http.StatusUnprocessableEntity,
+	} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+
+			svc := &OpenAIGatewayService{}
+			resp := &http.Response{
+				StatusCode: statusCode,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":{"message":"synthetic-sensitive-upstream-detail"}}`))),
+				Header:     http.Header{},
+			}
+			account := &Account{
+				ID:       13,
+				Platform: PlatformOpenAI,
+				Type:     AccountTypeAPIKey,
+				Credentials: map[string]any{
+					"custom_error_codes_enabled": true,
+					"custom_error_codes":         []any{float64(http.StatusTooManyRequests)},
+				},
+			}
+
+			_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+			require.Error(t, err)
+			assert.Equal(t, statusCode, rec.Code)
+			assert.NotContains(t, rec.Body.String(), "synthetic-sensitive-upstream-detail")
+		})
+	}
+}
+
+func TestOpenAIHandleErrorResponse_NonClientCustomCodeMissRemainsGatewayError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(rec)
 
 	svc := &OpenAIGatewayService{}
-	respBody := []byte(`{"error":{"message":"Invalid schema for field messages"}}`)
 	resp := &http.Response{
-		StatusCode: http.StatusUnprocessableEntity,
-		Body:       io.NopCloser(bytes.NewReader(respBody)),
+		StatusCode: http.StatusInternalServerError,
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":{"message":"synthetic-sensitive-upstream-detail"}}`))),
 		Header:     http.Header{},
 	}
-	account := &Account{ID: 12, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	account := &Account{
+		ID:       14,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"custom_error_codes_enabled": true,
+			"custom_error_codes":         []any{float64(http.StatusTooManyRequests)},
+		},
+	}
 
 	_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
 	require.Error(t, err)
-	assert.Equal(t, http.StatusBadGateway, rec.Code)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.True(t, IsResponseCommitted(c))
+	assert.NotContains(t, rec.Body.String(), "synthetic-sensitive-upstream-detail")
+}
 
-	var payload map[string]any
-	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
-	errField, ok := payload["error"].(map[string]any)
-	require.True(t, ok)
-	assert.Equal(t, "upstream_error", errField["type"])
-	assert.Equal(t, "Upstream request failed", errField["message"])
+func TestOpenAIHandleErrorResponse_NonClientDefaultsRemainWrapped(t *testing.T) {
+	tests := []struct {
+		statusCode int
+		wantStatus int
+		wantType   string
+	}{
+		{statusCode: http.StatusUnauthorized, wantStatus: http.StatusBadGateway, wantType: "upstream_error"},
+		{statusCode: http.StatusPaymentRequired, wantStatus: http.StatusBadGateway, wantType: "upstream_error"},
+		{statusCode: http.StatusForbidden, wantStatus: http.StatusBadGateway, wantType: "upstream_error"},
+		{statusCode: http.StatusTooManyRequests, wantStatus: http.StatusTooManyRequests, wantType: "rate_limit_error"},
+		{statusCode: http.StatusInternalServerError, wantStatus: http.StatusBadGateway, wantType: "upstream_error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.statusCode), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+
+			svc := &OpenAIGatewayService{}
+			resp := &http.Response{
+				StatusCode: tt.statusCode,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"error":{"message":"synthetic-upstream-error"}}`))),
+				Header:     http.Header{},
+			}
+			account := &Account{ID: 14, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+
+			_, err := svc.handleErrorResponse(context.Background(), resp, c, account, nil)
+			require.Error(t, err)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+
+			var payload map[string]any
+			require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &payload))
+			errField, ok := payload["error"].(map[string]any)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantType, errField["type"])
+		})
+	}
 }
 
 func TestOpenAIHandleErrorResponse_ContextWindow502KeepsMessageWithoutFailover(t *testing.T) {

--- a/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_cli_only_test.go
@@ -365,8 +365,10 @@ func TestOpenAIGatewayService_Forward_LogsInstructionsRequiredDetails(t *testing
 
 	_, err := svc.Forward(context.Background(), c, account, body)
 	require.Error(t, err)
-	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
 	require.Contains(t, err.Error(), "upstream error: 400")
+	require.NotContains(t, rec.Body.String(), "Missing required parameter")
+	require.NotContains(t, rec.Body.String(), "rid-upstream")
 
 	require.True(t, logSink.ContainsMessageAtLevel("OpenAI 上游返回 Instructions are required，已记录请求详情用于排查", "warn"))
 	require.True(t, logSink.ContainsFieldValue("request_user_agent", "codex_cli_rs/0.1.0"))

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -270,6 +270,19 @@ func (s *OpenAIGatewayService) handleFailoverSideEffects(ctx context.Context, re
 	s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, responseBody)
 }
 
+func openAIClientRequestErrorMessage(statusCode int) (string, bool) {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return "Invalid request to upstream provider", true
+	case http.StatusRequestEntityTooLarge:
+		return "Request payload is too large", true
+	case http.StatusUnprocessableEntity:
+		return "Request could not be processed by upstream provider", true
+	default:
+		return "", false
+	}
+}
+
 func (s *OpenAIGatewayService) handleErrorResponse(
 	ctx context.Context,
 	resp *http.Response,
@@ -352,8 +365,10 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		return nil, fmt.Errorf("upstream error: %d (passthrough rule matched) message=%s", resp.StatusCode, upstreamMsg)
 	}
 
-	// Check custom error codes
-	if !account.ShouldHandleErrorCode(resp.StatusCode) {
+	// Custom error codes control account-side handling, but must not turn safe
+	// request-shape errors into an internal gateway error for downstream clients.
+	clientRequestErrMsg, isClientRequestError := openAIClientRequestErrorMessage(resp.StatusCode)
+	if !account.ShouldHandleErrorCode(resp.StatusCode) && !isClientRequestError {
 		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 			Platform:           account.Platform,
 			AccountID:          account.ID,
@@ -414,30 +429,36 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	var errType, errMsg string
 	var statusCode int
 
-	switch resp.StatusCode {
-	case 401:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream authentication failed, please contact administrator"
-	case 402:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream payment required: insufficient balance or billing issue"
-	case 403:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream access forbidden, please contact administrator"
-	case 429:
-		statusCode = http.StatusTooManyRequests
-		errType = "rate_limit_error"
-		errMsg = "Upstream rate limit exceeded, please retry later"
-	default:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream request failed"
-	}
-	if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
-		errMsg = upstreamMsg
+	if isClientRequestError {
+		statusCode = resp.StatusCode
+		errType = "invalid_request_error"
+		errMsg = clientRequestErrMsg
+	} else {
+		switch resp.StatusCode {
+		case 401:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream authentication failed, please contact administrator"
+		case 402:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream payment required: insufficient balance or billing issue"
+		case 403:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream access forbidden, please contact administrator"
+		case 429:
+			statusCode = http.StatusTooManyRequests
+			errType = "rate_limit_error"
+			errMsg = "Upstream rate limit exceeded, please retry later"
+		default:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream request failed"
+		}
+		if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
+			errMsg = upstreamMsg
+		}
 	}
 
 	c.JSON(statusCode, gin.H{


### PR DESCRIPTION
## Summary

- preserve upstream `400`, `413`, and `422` as downstream client-request errors on the native OpenAI path
- return fixed neutral messages instead of exposing upstream response bodies or request IDs
- prevent `custom_error_codes` misses from converting these request-shape errors into `500`
- keep passthrough-rule priority and existing `401/402/403 -> 502`, `429 -> 429`, and `5xx -> 502` behavior

## Why

Native OpenAI Responses request validation errors were falling through to the default gateway mapping and becoming `502 Bad Gateway`. When custom error codes were enabled but did not include the status, the same client errors could become `500`. This made downstream gateways classify request-shape failures as provider-health failures and could unnecessarily trip shared circuit breakers.

## Safety

- no upstream response body is copied to the downstream response
- no upstream request ID is exposed
- authentication, payment, authorization, rate-limit, and server-error mappings remain unchanged
- explicit error passthrough rules still take precedence

## Tests

```text
go test ./internal/service -run 'TestOpenAIGatewayService_Forward_LogsInstructionsRequiredDetails|TestOpenAIHandleErrorResponse_(ClientRequestErrorsKeepStatusAndHideUpstreamDetails|ClientRequestErrorsIgnoreCustomCodeMiss|NonClientCustomCodeMissRemainsGatewayError|NonClientDefaultsRemainWrapped|AppliesRuleFor422|SetsResponseCommitted|ContextWindow502KeepsMessageWithoutFailover)$' -count=1
go test ./... -count=1
```

Both commands pass with Go `1.26.5` in the official `golang:1.26.5-bookworm` image.