### PR TITLE
fix(openai): handle weekly-only Codex quota snapshots

### DIFF
--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -614,11 +614,14 @@ func (s *AccountUsageService) getOpenAIUsage(ctx context.Context, account *Accou
 		return usage, nil
 	}
 
-	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
-		if usage.FiveHour == nil {
-			usage.FiveHour = &UsageProgress{Utilization: 0}
+	weeklyOnly := hasOpenAIWeeklyOnlySnapshot(account.Extra)
+	if usage.FiveHour != nil || !weeklyOnly {
+		if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.FiveHour, 5*time.Hour, now)); err == nil {
+			if usage.FiveHour == nil {
+				usage.FiveHour = &UsageProgress{Utilization: 0}
+			}
+			usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 		}
-		usage.FiveHour.WindowStats = windowStatsFromAccountStats(stats)
 	}
 
 	if stats, err := s.usageLogRepo.GetAccountWindowStats(ctx, account.ID, codexWindowStatsStart(usage.SevenDay, 7*24*time.Hour, now)); err == nil {
@@ -638,7 +641,10 @@ func shouldRefreshOpenAICodexSnapshot(account *Account, usage *UsageInfo, now ti
 	if usage == nil {
 		return true
 	}
-	if usage.FiveHour == nil || usage.SevenDay == nil {
+	if usage.SevenDay == nil {
+		return true
+	}
+	if usage.FiveHour == nil && !hasOpenAIWeeklyOnlySnapshot(account.Extra) {
 		return true
 	}
 	if account.IsRateLimited() {
@@ -803,12 +809,10 @@ func applyExtraToUsage(usage *UsageInfo, extra map[string]any, now time.Time) {
 	if usage == nil {
 		return
 	}
-	if progress := buildCodexUsageProgressFromExtra(extra, "5h", now); progress != nil {
-		usage.FiveHour = progress
-	}
-	if progress := buildCodexUsageProgressFromExtra(extra, "7d", now); progress != nil {
-		usage.SevenDay = progress
-	}
+	// Assign both fields directly so an authoritative weekly-only snapshot can
+	// remove a previously populated 5h window from the in-memory response.
+	usage.FiveHour = buildCodexUsageProgressFromExtra(extra, "5h", now)
+	usage.SevenDay = buildCodexUsageProgressFromExtra(extra, "7d", now)
 }
 
 func (s *AccountUsageService) getGeminiUsage(ctx context.Context, account *Account) (*UsageInfo, error) {
@@ -1339,7 +1343,7 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	usedRaw, ok := extra[usedPercentKey]
-	if !ok {
+	if !ok || usedRaw == nil {
 		return nil
 	}
 
@@ -1376,6 +1380,16 @@ func buildCodexUsageProgressFromExtra(extra map[string]any, window string, now t
 	}
 
 	return progress
+}
+
+func hasOpenAIWeeklyOnlySnapshot(extra map[string]any) bool {
+	weeklyMinutes, hasWeekly := resolveAccountExtraNumber(extra, "codex_7d_window_minutes")
+	if !hasWeekly || weeklyMinutes <= 360 {
+		return false
+	}
+	_, hasShortWindow := resolveAccountExtraNumber(extra, "codex_5h_window_minutes")
+	_, hasShortUsage := resolveAccountExtraNumber(extra, "codex_5h_used_percent")
+	return !hasShortWindow && !hasShortUsage
 }
 
 func codexWindowStatsStart(progress *UsageProgress, fallbackWindow time.Duration, now time.Time) time.Time {

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -5,12 +5,24 @@ import (
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 )
 
 type accountUsageCodexProbeRepo struct {
 	stubOpenAIAccountRepo
 	updateExtraCh chan map[string]any
 	rateLimitCh   chan time.Time
+}
+
+type accountUsageWindowStatsRepo struct {
+	UsageLogRepository
+	calls int
+}
+
+func (r *accountUsageWindowStatsRepo) GetAccountWindowStats(context.Context, int64, time.Time) (*usagestats.AccountStats, error) {
+	r.calls++
+	return &usagestats.AccountStats{Requests: 3}, nil
 }
 
 func (r *accountUsageCodexProbeRepo) UpdateExtra(_ context.Context, _ int64, updates map[string]any) error {
@@ -53,6 +65,16 @@ func TestShouldRefreshOpenAICodexSnapshot(t *testing.T) {
 		t.Fatal("expected missing 5h snapshot to require refresh")
 	}
 
+	weeklyOnlyAccount := &Account{Extra: map[string]any{
+		"codex_7d_used_percent":   22.0,
+		"codex_7d_window_minutes": 10080,
+		"codex_5h_used_percent":   nil,
+		"codex_5h_window_minutes": nil,
+	}}
+	if shouldRefreshOpenAICodexSnapshot(weeklyOnlyAccount, &UsageInfo{SevenDay: &UsageProgress{}}, now) {
+		t.Fatal("expected a weekly-only snapshot to be treated as complete")
+	}
+
 	staleAt := now.Add(-(openAIProbeCacheTTL + time.Minute)).Format(time.RFC3339)
 	if !shouldRefreshOpenAICodexSnapshot(&Account{
 		Platform: PlatformOpenAI,
@@ -63,6 +85,76 @@ func TestShouldRefreshOpenAICodexSnapshot(t *testing.T) {
 		},
 	}, usage, now) {
 		t.Fatal("expected stale ws snapshot to trigger refresh")
+	}
+}
+
+func TestApplyExtraToUsage_WeeklyOnlyRemovesPreviousFiveHourWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+	usage := &UsageInfo{
+		FiveHour: &UsageProgress{Utilization: 75},
+		SevenDay: &UsageProgress{Utilization: 16},
+	}
+	extra := map[string]any{
+		"codex_5h_used_percent": nil,
+		"codex_5h_reset_at":     nil,
+		"codex_7d_used_percent": 22.0,
+		"codex_7d_reset_at":     "2026-07-20T12:00:00Z",
+	}
+
+	applyExtraToUsage(usage, extra, now)
+
+	if usage.FiveHour != nil {
+		t.Fatalf("expected 5h window to be removed, got %#v", usage.FiveHour)
+	}
+	if usage.SevenDay == nil || usage.SevenDay.Utilization != 22.0 {
+		t.Fatalf("expected weekly utilization 22, got %#v", usage.SevenDay)
+	}
+}
+
+func TestAccountUsageService_GetOpenAIUsage_WeeklyOnlyDoesNotSynthesizeFiveHour(t *testing.T) {
+	t.Parallel()
+
+	usageRepo := &accountUsageWindowStatsRepo{}
+	svc := &AccountUsageService{usageLogRepo: usageRepo}
+	account := &Account{
+		ID:       42,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			"codex_7d_used_percent":   22.0,
+			"codex_7d_window_minutes": 10080,
+			"codex_7d_reset_at":       time.Now().Add(6 * 24 * time.Hour).UTC().Format(time.RFC3339),
+			"codex_5h_used_percent":   nil,
+			"codex_5h_window_minutes": nil,
+		},
+	}
+
+	usage, err := svc.getOpenAIUsage(context.Background(), account, false)
+	if err != nil {
+		t.Fatalf("getOpenAIUsage() error = %v", err)
+	}
+	if usage.FiveHour != nil {
+		t.Fatalf("expected no synthesized 5h window, got %#v", usage.FiveHour)
+	}
+	if usage.SevenDay == nil || usage.SevenDay.WindowStats == nil || usage.SevenDay.WindowStats.Requests != 3 {
+		t.Fatalf("expected weekly window stats, got %#v", usage.SevenDay)
+	}
+	if usageRepo.calls != 1 {
+		t.Fatalf("GetAccountWindowStats calls = %d, want 1 weekly query", usageRepo.calls)
+	}
+}
+
+func TestBuildCodexUsageProgressFromExtra_NullWindowIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	progress := buildCodexUsageProgressFromExtra(map[string]any{
+		"codex_5h_used_percent": nil,
+		"codex_5h_reset_at":     nil,
+	}, "5h", time.Now())
+	if progress != nil {
+		t.Fatalf("expected null 5h snapshot to be absent, got %#v", progress)
 	}
 }
 

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -223,3 +223,41 @@ func TestBuildCodexUsageExtraUpdates_WithoutNormalizedWindowFields(t *testing.T)
 		t.Fatalf("did not expect codex_7d_reset_at in updates: %v", updates["codex_7d_reset_at"])
 	}
 }
+
+func TestBuildCodexUsageExtraUpdates_WeeklyOnlyClearsShortWindow(t *testing.T) {
+	primaryUsed := 22.0
+	primaryReset := 4 * 24 * 60 * 60
+	primaryWindow := 7 * 24 * 60
+	snapshot := &OpenAICodexUsageSnapshot{
+		PrimaryUsedPercent:       &primaryUsed,
+		PrimaryResetAfterSeconds: &primaryReset,
+		PrimaryWindowMinutes:     &primaryWindow,
+		UpdatedAt:                "2026-07-13T12:00:00Z",
+	}
+
+	updates := buildCodexUsageExtraUpdates(snapshot, time.Time{})
+
+	if got := updates["codex_7d_used_percent"]; got != 22.0 {
+		t.Fatalf("codex_7d_used_percent = %v, want 22", got)
+	}
+	if got := updates["codex_7d_window_minutes"]; got != 10080 {
+		t.Fatalf("codex_7d_window_minutes = %v, want 10080", got)
+	}
+	for _, key := range []string{
+		"codex_secondary_used_percent",
+		"codex_secondary_reset_after_seconds",
+		"codex_secondary_window_minutes",
+		"codex_5h_used_percent",
+		"codex_5h_reset_after_seconds",
+		"codex_5h_window_minutes",
+		"codex_5h_reset_at",
+	} {
+		value, ok := updates[key]
+		if !ok {
+			t.Fatalf("expected %s to be explicitly cleared", key)
+		}
+		if value != nil {
+			t.Fatalf("%s = %v, want nil", key, value)
+		}
+	}
+}

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -737,56 +737,88 @@ func buildCodexUsageExtraUpdates(snapshot *OpenAICodexUsageSnapshot, fallbackNow
 
 	baseTime := codexSnapshotBaseTime(snapshot, fallbackNow)
 	updates := make(map[string]any)
+	hasWindowLayout := snapshot.PrimaryWindowMinutes != nil || snapshot.SecondaryWindowMinutes != nil
 
-	// 保存原始 primary/secondary 字段，便于排查问题
+	// 保存原始 primary/secondary 字段，便于排查问题。只要上游返回了窗口布局，
+	// 缺失的 slot 就是权威的 nil（例如 temporarily disabled 的 5h 窗口），
+	// 必须覆盖旧快照，避免调度器继续读取已经撤下的 secondary window。
 	if snapshot.PrimaryUsedPercent != nil {
 		updates["codex_primary_used_percent"] = *snapshot.PrimaryUsedPercent
+	} else if hasWindowLayout {
+		updates["codex_primary_used_percent"] = nil
 	}
 	if snapshot.PrimaryResetAfterSeconds != nil {
 		updates["codex_primary_reset_after_seconds"] = *snapshot.PrimaryResetAfterSeconds
+	} else if hasWindowLayout {
+		updates["codex_primary_reset_after_seconds"] = nil
 	}
 	if snapshot.PrimaryWindowMinutes != nil {
 		updates["codex_primary_window_minutes"] = *snapshot.PrimaryWindowMinutes
+	} else if hasWindowLayout {
+		updates["codex_primary_window_minutes"] = nil
 	}
 	if snapshot.SecondaryUsedPercent != nil {
 		updates["codex_secondary_used_percent"] = *snapshot.SecondaryUsedPercent
+	} else if hasWindowLayout {
+		updates["codex_secondary_used_percent"] = nil
 	}
 	if snapshot.SecondaryResetAfterSeconds != nil {
 		updates["codex_secondary_reset_after_seconds"] = *snapshot.SecondaryResetAfterSeconds
+	} else if hasWindowLayout {
+		updates["codex_secondary_reset_after_seconds"] = nil
 	}
 	if snapshot.SecondaryWindowMinutes != nil {
 		updates["codex_secondary_window_minutes"] = *snapshot.SecondaryWindowMinutes
+	} else if hasWindowLayout {
+		updates["codex_secondary_window_minutes"] = nil
 	}
 	if snapshot.PrimaryOverSecondaryPercent != nil {
 		updates["codex_primary_over_secondary_percent"] = *snapshot.PrimaryOverSecondaryPercent
 	}
 	updates["codex_usage_updated_at"] = baseTime.Format(time.RFC3339)
 
-	// 归一化到 5h/7d 规范字段
+	// 归一化到 5h/7d 规范字段。窗口布局已知时也写入 nil，确保从
+	// 5h+weekly 切换到 weekly-only 后，旧 codex_5h_* 不再展示或参与调度。
 	if normalized := snapshot.Normalize(); normalized != nil {
 		if normalized.Used5hPercent != nil {
 			updates["codex_5h_used_percent"] = *normalized.Used5hPercent
+		} else if hasWindowLayout {
+			updates["codex_5h_used_percent"] = nil
 		}
 		if normalized.Reset5hSeconds != nil {
 			updates["codex_5h_reset_after_seconds"] = *normalized.Reset5hSeconds
+		} else if hasWindowLayout {
+			updates["codex_5h_reset_after_seconds"] = nil
 		}
 		if normalized.Window5hMinutes != nil {
 			updates["codex_5h_window_minutes"] = *normalized.Window5hMinutes
+		} else if hasWindowLayout {
+			updates["codex_5h_window_minutes"] = nil
 		}
 		if normalized.Used7dPercent != nil {
 			updates["codex_7d_used_percent"] = *normalized.Used7dPercent
+		} else if hasWindowLayout {
+			updates["codex_7d_used_percent"] = nil
 		}
 		if normalized.Reset7dSeconds != nil {
 			updates["codex_7d_reset_after_seconds"] = *normalized.Reset7dSeconds
+		} else if hasWindowLayout {
+			updates["codex_7d_reset_after_seconds"] = nil
 		}
 		if normalized.Window7dMinutes != nil {
 			updates["codex_7d_window_minutes"] = *normalized.Window7dMinutes
+		} else if hasWindowLayout {
+			updates["codex_7d_window_minutes"] = nil
 		}
 		if reset5hAt := codexResetAtRFC3339(baseTime, normalized.Reset5hSeconds); reset5hAt != nil {
 			updates["codex_5h_reset_at"] = *reset5hAt
+		} else if hasWindowLayout {
+			updates["codex_5h_reset_at"] = nil
 		}
 		if reset7dAt := codexResetAtRFC3339(baseTime, normalized.Reset7dSeconds); reset7dAt != nil {
 			updates["codex_7d_reset_at"] = *reset7dAt
+		} else if hasWindowLayout {
+			updates["codex_7d_reset_at"] = nil
 		}
 	}
 


### PR DESCRIPTION
## Summary

- clear stale raw and canonical 5h fields when Codex returns an authoritative weekly-only window layout
- treat a 10080-minute-only snapshot as complete instead of probing repeatedly
- stop synthesizing a 5h usage row for weekly-only accounts while preserving the existing dual-window path

## Context

Codex temporarily removed the 5-hour limit for Plus, Business, and Pro accounts. The rate-limit response can now contain a 10080-minute primary window with a null secondary window. A captured transition is documented in openai/codex#32707.

Because `AccountRepository.UpdateExtra` performs a JSONB merge, absent secondary/5h fields previously left the old 300-minute snapshot in place. The stale values could continue to appear in the UI and participate in quota-aware scheduling or auto-pause decisions.

This change only clears the short-window state when upstream supplies an explicit window layout and the short window is absent. Accounts that still return both 300-minute and 10080-minute windows retain the existing behavior.

## Verification

- `go test -tags=unit ./internal/service -count=1`
- `docker compose build sub2api`

Reference: https://github.com/openai/codex/issues/32707