### PR TITLE
fix(codex): add root models compatibility alias

### DIFF
--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -42,6 +42,13 @@ func RegisterGatewayRoutes(
 	isOpenAIGatewayPlatform := func(c *gin.Context) bool {
 		return getGroupPlatform(c) == service.PlatformOpenAI
 	}
+	modelsHandler := func(c *gin.Context) {
+		if isOpenAIGatewayPlatform(c) && c.Query("client_version") != "" {
+			h.OpenAIGateway.CodexModels(c)
+			return
+		}
+		h.Gateway.Models(c)
+	}
 	imagesHandler := func(c *gin.Context) {
 		switch getGroupPlatform(c) {
 		case service.PlatformOpenAI:
@@ -140,13 +147,7 @@ func RegisterGatewayRoutes(
 		// Codex CLI / Codex app refresh their model picker from the provider's
 		// /models endpoint with a client_version query and expect the ChatGPT
 		// Codex manifest format; other clients keep the OpenAI-style list.
-		gateway.GET("/models", func(c *gin.Context) {
-			if isOpenAIGatewayPlatform(c) && c.Query("client_version") != "" {
-				h.OpenAIGateway.CodexModels(c)
-				return
-			}
-			h.Gateway.Models(c)
-		})
+		gateway.GET("/models", modelsHandler)
 		gateway.GET("/usage", h.Gateway.Usage)
 		// OpenAI Responses API: auto-route based on group platform
 		gateway.POST("/responses", func(c *gin.Context) {
@@ -235,6 +236,7 @@ func RegisterGatewayRoutes(
 	r.GET("/responses", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic, func(c *gin.Context) {
 		h.OpenAIGateway.ResponsesWebSocket(c)
 	})
+	r.GET("/models", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic, modelsHandler)
 	codexDirect := r.Group("/backend-api/codex")
 	codexDirect.Use(bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), requireGroupAnthropic)
 	{

--- a/backend/internal/server/routes/gateway_codex_models_test.go
+++ b/backend/internal/server/routes/gateway_codex_models_test.go
@@ -10,13 +10,15 @@ import (
 func TestGatewayRoutesCodexModelsManifestPathIsRegistered(t *testing.T) {
 	router := newGatewayRoutesTestRouter()
 
-	registered := make(map[string]bool)
+	registered := make(map[string]string)
 	for _, route := range router.Routes() {
 		if route.Method == http.MethodGet {
-			registered[route.Path] = true
+			registered[route.Path] = route.Handler
 		}
 	}
 
-	require.True(t, registered["/backend-api/codex/models"], "GET /backend-api/codex/models should be registered")
-	require.True(t, registered["/v1/models"], "GET /v1/models should be registered")
+	require.NotEmpty(t, registered["/backend-api/codex/models"], "GET /backend-api/codex/models should be registered")
+	require.NotEmpty(t, registered["/v1/models"], "GET /v1/models should be registered")
+	require.NotEmpty(t, registered["/models"], "GET /models should be registered")
+	require.Equal(t, registered["/v1/models"], registered["/models"], "root alias should use the same platform-aware handler")
 }

--- a/backend/internal/web/embed_on.go
+++ b/backend/internal/web/embed_on.go
@@ -310,6 +310,7 @@ func shouldBypassEmbeddedFrontend(path string) bool {
 		strings.HasPrefix(trimmed, "/antigravity/") ||
 		strings.HasPrefix(trimmed, "/setup/") ||
 		trimmed == "/health" ||
+		trimmed == "/models" ||
 		trimmed == "/responses" ||
 		strings.HasPrefix(trimmed, "/responses/") ||
 		trimmed == "/alpha/search" ||

--- a/backend/internal/web/embed_test.go
+++ b/backend/internal/web/embed_test.go
@@ -451,6 +451,7 @@ func TestFrontendServer_Middleware(t *testing.T) {
 
 		apiPaths := []string{
 			"/api/v1/users",
+			"/models",
 			"/v1/models",
 			"/v1beta/chat",
 			"/backend-api/codex/responses",
@@ -692,6 +693,7 @@ func TestServeEmbeddedFrontend(t *testing.T) {
 
 		apiPaths := []string{
 			"/api/users",
+			"/models",
 			"/v1/models",
 			"/v1beta/chat",
 			"/backend-api/codex/responses",


### PR DESCRIPTION
## 问题

Codex 自定义 provider 使用站点根地址作为 `base_url` 时，推理请求会走已有的 `POST /responses` 兼容别名，但模型清单刷新会请求 `GET /models?client_version=...`。

当前网关只有 `GET /v1/models` 和 `GET /backend-api/codex/models`，根级 `/models` 会被嵌入式前端接管或返回 404，导致 Codex 无法加载远端模型清单并静默回退到本地缓存。

## 根因

根级 Responses 兼容路由已注册 `/responses`，但模型路由只在 `/v1` 组和 `/backend-api/codex` 组内注册。嵌入式前端的 API 路径 bypass 列表也未包含 `/models`，因此缺少与根级 Responses 配置对称的模型清单入口。

## 改动

- 抽取现有 `/v1/models` 的平台感知分流 handler，并由 `/v1/models` 与新增根级 `/models` 共用。
- OpenAI 分组携带 `client_version` 时继续返回 Codex manifest；其他请求继续返回现有 OpenAI 兼容模型列表。
- 根级 `/models` 复用现有根级兼容路由的 API Key 认证、分组校验和 endpoint middleware。
- 将 `/models` 加入嵌入式前端 bypass，避免 SPA HTML 覆盖 API 响应。
- 增加路由注册/handler 一致性及两套嵌入前端 middleware 回归覆盖。

## 测试

- `cd backend && /tmp/go1.26.5/bin/go test ./internal/server/routes -count=1`
- `cd backend && /tmp/go1.26.5/bin/go vet ./internal/server/routes`
- `cd frontend && corepack pnpm@9 install --frozen-lockfile`
- `cd frontend && corepack pnpm@9 run build`
- `cd backend && /tmp/go1.26.5/bin/go test -tags=embed ./internal/web -count=1`
- `cd backend && /tmp/go1.26.5/bin/go vet -tags=embed ./internal/web`
- `git diff --check`

Fixes #4245