### PR TITLE
perf(risk): 优化内容审核关键词热路径（优化性能）

### DIFF
--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -92,6 +92,9 @@ const (
 	contentModerationCleanupInterval = 24 * time.Hour
 	contentModerationCleanupTimeout  = 30 * time.Minute
 	contentModerationCleanupDelay    = 5 * time.Minute
+
+	contentModerationRuntimeCacheTTL       = time.Second
+	contentModerationRuntimeRefreshTimeout = 5 * time.Second
 )
 
 var contentModerationCategoryOrder = []string{
@@ -512,8 +515,20 @@ type ContentModerationService struct {
 	lastCleanupUnix          atomic.Int64
 	lastCleanupDeletedHit    atomic.Int64
 	lastCleanupDeletedNonHit atomic.Int64
+	runtimeSnapshot          atomic.Pointer[contentModerationRuntimeSnapshot]
+	runtimeRefreshMu         sync.Mutex
+	runtimeCacheTTL          time.Duration
+	runtimeRefreshRetryAt    atomic.Int64
 	keyHealthMu              sync.Mutex
 	keyHealth                map[string]*contentModerationKeyHealth
+}
+
+type contentModerationRuntimeSnapshot struct {
+	riskControlEnabled bool
+	config             *ContentModerationConfig
+	keywordMatcher     *contentModerationKeywordMatcher
+	configDigest       [sha256.Size]byte
+	loadedAt           time.Time
 }
 
 type contentModerationTask struct {
@@ -700,6 +715,7 @@ func (s *ContentModerationService) UpdateConfig(ctx context.Context, input Updat
 	if err := s.settingRepo.Set(ctx, SettingKeyContentModerationConfig, string(raw)); err != nil {
 		return nil, fmt.Errorf("save content moderation config: %w", err)
 	}
+	s.replaceRuntimeConfig(cfg, raw)
 	return s.configView(cfg), nil
 }
 
@@ -776,16 +792,7 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 			"protocol", input.Protocol)
 		return allow, nil
 	}
-	if !s.isRiskControlEnabled(ctx) {
-		slog.Info("content_moderation.skip_feature_disabled",
-			"user_id", input.UserID,
-			"api_key_id", input.APIKeyID,
-			"group_id", contentModerationLogGroupID(input.GroupID),
-			"endpoint", input.Endpoint,
-			"protocol", input.Protocol)
-		return allow, nil
-	}
-	cfg, err := s.loadConfig(ctx)
+	runtimeSnapshot, err := s.loadRuntimeSnapshot(ctx)
 	if err != nil {
 		slog.Warn("content_moderation.skip_config_load_failed",
 			"user_id", input.UserID,
@@ -796,6 +803,16 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 			"error", err)
 		return allow, nil
 	}
+	if !runtimeSnapshot.riskControlEnabled {
+		slog.Info("content_moderation.skip_feature_disabled",
+			"user_id", input.UserID,
+			"api_key_id", input.APIKeyID,
+			"group_id", contentModerationLogGroupID(input.GroupID),
+			"endpoint", input.Endpoint,
+			"protocol", input.Protocol)
+		return allow, nil
+	}
+	cfg := runtimeSnapshot.config
 	inGroupScope := cfg.includesGroup(input.GroupID)
 	inModelScope := cfg.includesModel(input.Model)
 	slog.Info("content_moderation.config_loaded",
@@ -885,7 +902,7 @@ func (s *ContentModerationService) Check(ctx context.Context, input ContentModer
 	hashText := content.Hash()
 	if cfg.Mode == ContentModerationModePreBlock {
 		if cfg.KeywordBlockingMode != ContentModerationKeywordModeAPIOnly && len(cfg.BlockedKeywords) > 0 {
-			if keyword, hit := matchBlockedKeyword(content.Text, cfg.BlockedKeywords); hit {
+			if keyword, hit := runtimeSnapshot.matchBlockedKeyword(content.Text); hit {
 				s.recordPreBlockSyncMetric(0, ContentModerationActionKeywordBlock)
 				slog.Info("content_moderation.keyword_block",
 					"user_id", input.UserID,
@@ -1178,12 +1195,13 @@ func (s *ContentModerationService) enqueueRecord(input ContentModerationCheckInp
 func (s *ContentModerationService) worker(id int) {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), maxContentModerationTimeoutMS*time.Millisecond+10*time.Second)
-		cfg, err := s.loadConfig(ctx)
-		if err != nil || id >= cfg.WorkerCount {
+		runtimeSnapshot, err := s.loadRuntimeSnapshot(ctx)
+		if err != nil || runtimeSnapshot == nil || runtimeSnapshot.config == nil || id >= runtimeSnapshot.config.WorkerCount {
 			cancel()
 			time.Sleep(time.Second)
 			continue
 		}
+		cfg := runtimeSnapshot.config
 		task, ok := s.dequeueAsyncTask(ctx, time.Second)
 		if !ok {
 			cancel()
@@ -1438,15 +1456,18 @@ func (s *ContentModerationService) runCleanupOnce() {
 }
 
 func (s *ContentModerationService) loadConfig(ctx context.Context) (*ContentModerationConfig, error) {
-	cfg := defaultContentModerationConfig()
 	raw, err := s.settingRepo.GetValue(ctx, SettingKeyContentModerationConfig)
 	if err != nil {
 		if errors.Is(err, ErrSettingNotFound) {
-			cfg.normalize()
-			return cfg, nil
+			return parseContentModerationConfig("")
 		}
 		return nil, fmt.Errorf("get content moderation config: %w", err)
 	}
+	return parseContentModerationConfig(raw)
+}
+
+func parseContentModerationConfig(raw string) (*ContentModerationConfig, error) {
+	cfg := defaultContentModerationConfig()
 	if strings.TrimSpace(raw) == "" {
 		cfg.normalize()
 		return cfg, nil
@@ -1456,6 +1477,137 @@ func (s *ContentModerationService) loadConfig(ctx context.Context) (*ContentMode
 	}
 	cfg.normalize()
 	return cfg, nil
+}
+
+func (s *ContentModerationService) loadRuntimeSnapshot(ctx context.Context) (*contentModerationRuntimeSnapshot, error) {
+	if s == nil || s.settingRepo == nil {
+		return nil, errors.New("content moderation setting repository unavailable")
+	}
+	now := time.Now()
+	if snapshot := s.runtimeSnapshot.Load(); snapshot != nil {
+		if now.Sub(snapshot.loadedAt) < s.runtimeSnapshotTTL() {
+			return snapshot, nil
+		}
+		s.triggerRuntimeSnapshotRefresh()
+		return snapshot, nil
+	}
+
+	s.runtimeRefreshMu.Lock()
+	defer s.runtimeRefreshMu.Unlock()
+	if snapshot := s.runtimeSnapshot.Load(); snapshot != nil {
+		return snapshot, nil
+	}
+	return s.refreshRuntimeSnapshot(ctx)
+}
+
+func (s *ContentModerationService) runtimeSnapshotTTL() time.Duration {
+	if s != nil && s.runtimeCacheTTL > 0 {
+		return s.runtimeCacheTTL
+	}
+	return contentModerationRuntimeCacheTTL
+}
+
+func (s *ContentModerationService) triggerRuntimeSnapshotRefresh() {
+	if s == nil || s.runtimeRefreshDeferred() || !s.runtimeRefreshMu.TryLock() {
+		return
+	}
+	if s.runtimeRefreshDeferred() {
+		s.runtimeRefreshMu.Unlock()
+		return
+	}
+	go func() {
+		defer s.runtimeRefreshMu.Unlock()
+		ctx, cancel := context.WithTimeout(context.Background(), contentModerationRuntimeRefreshTimeout)
+		defer cancel()
+		if _, err := s.refreshRuntimeSnapshot(ctx); err != nil {
+			s.runtimeRefreshRetryAt.Store(time.Now().Add(s.runtimeSnapshotTTL()).UnixNano())
+			slog.Warn("content_moderation.runtime_snapshot_refresh_failed", "error", err)
+		}
+	}()
+}
+
+func (s *ContentModerationService) runtimeRefreshDeferred() bool {
+	if s == nil {
+		return false
+	}
+	return time.Now().UnixNano() < s.runtimeRefreshRetryAt.Load()
+}
+
+func (s *ContentModerationService) refreshRuntimeSnapshot(ctx context.Context) (*contentModerationRuntimeSnapshot, error) {
+	values, err := s.settingRepo.GetMultiple(ctx, []string{
+		SettingKeyRiskControlEnabled,
+		SettingKeyContentModerationConfig,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get content moderation runtime settings: %w", err)
+	}
+	rawConfig := values[SettingKeyContentModerationConfig]
+	configDigest := sha256.Sum256([]byte(rawConfig))
+	if current := s.runtimeSnapshot.Load(); current != nil && current.configDigest == configDigest {
+		snapshot := &contentModerationRuntimeSnapshot{
+			riskControlEnabled: values[SettingKeyRiskControlEnabled] == "true",
+			config:             current.config,
+			keywordMatcher:     current.keywordMatcher,
+			configDigest:       configDigest,
+			loadedAt:           time.Now(),
+		}
+		s.runtimeSnapshot.Store(snapshot)
+		s.runtimeRefreshRetryAt.Store(0)
+		return snapshot, nil
+	}
+	cfg, err := parseContentModerationConfig(rawConfig)
+	if err != nil {
+		return nil, err
+	}
+	snapshot := &contentModerationRuntimeSnapshot{
+		riskControlEnabled: values[SettingKeyRiskControlEnabled] == "true",
+		config:             cfg,
+		keywordMatcher:     newContentModerationKeywordMatcher(cfg.BlockedKeywords),
+		configDigest:       configDigest,
+		loadedAt:           time.Now(),
+	}
+	s.runtimeSnapshot.Store(snapshot)
+	s.runtimeRefreshRetryAt.Store(0)
+	return snapshot, nil
+}
+
+func (s *ContentModerationService) replaceRuntimeConfig(cfg *ContentModerationConfig, raw []byte) {
+	if s == nil || cfg == nil {
+		return
+	}
+	s.runtimeRefreshMu.Lock()
+	hasSnapshot := s.runtimeSnapshot.Load() != nil
+	s.runtimeRefreshMu.Unlock()
+	if !hasSnapshot {
+		return
+	}
+	config := cloneContentModerationConfig(cfg)
+	keywordMatcher := newContentModerationKeywordMatcher(cfg.BlockedKeywords)
+	configDigest := sha256.Sum256(raw)
+
+	s.runtimeRefreshMu.Lock()
+	defer s.runtimeRefreshMu.Unlock()
+	current := s.runtimeSnapshot.Load()
+	if current == nil {
+		return
+	}
+	s.runtimeSnapshot.Store(&contentModerationRuntimeSnapshot{
+		riskControlEnabled: current.riskControlEnabled,
+		config:             config,
+		keywordMatcher:     keywordMatcher,
+		configDigest:       configDigest,
+		loadedAt:           time.Now(),
+	})
+}
+
+func (s *contentModerationRuntimeSnapshot) matchBlockedKeyword(text string) (string, bool) {
+	if s == nil || s.config == nil {
+		return "", false
+	}
+	if s.keywordMatcher != nil {
+		return s.keywordMatcher.Match(text)
+	}
+	return matchBlockedKeyword(text, s.config.BlockedKeywords)
 }
 
 func (s *ContentModerationService) isRiskControlEnabled(ctx context.Context) bool {

--- a/backend/internal/service/content_moderation_keyword_matcher.go
+++ b/backend/internal/service/content_moderation_keyword_matcher.go
@@ -1,0 +1,222 @@
+package service
+
+import (
+	"strings"
+)
+
+type contentModerationKeywordMatcher struct {
+	nodes           []contentModerationKeywordNode
+	edges           []contentModerationKeywordEdge
+	rootTransitions [256]int32
+	keywords        []string
+}
+
+type contentModerationKeywordNode struct {
+	failure     int32
+	bestKeyword int32
+	edgeStart   uint32
+	edgeCount   uint16
+}
+
+type contentModerationKeywordEdge struct {
+	target int32
+	label  byte
+}
+
+type contentModerationKeywordBuildEdge struct {
+	target      int32
+	nextSibling int32
+	label       byte
+}
+
+func newContentModerationKeywordMatcher(keywords []string) *contentModerationKeywordMatcher {
+	if len(keywords) == 0 {
+		return nil
+	}
+
+	buildNodes := []contentModerationKeywordNode{newContentModerationKeywordNode()}
+	buildEdges := make([]contentModerationKeywordBuildEdge, 0)
+	originalKeywords := append([]string(nil), keywords...)
+
+	for keywordIndex, keyword := range keywords {
+		if keyword == "" {
+			continue
+		}
+		state := int32(0)
+		for _, label := range []byte(strings.ToLower(keyword)) {
+			next := contentModerationKeywordBuildTransition(buildNodes, buildEdges, state, label)
+			if next < 0 {
+				next = int32(len(buildNodes))
+				buildNodes = append(buildNodes, newContentModerationKeywordNode())
+				buildEdges = append(buildEdges, contentModerationKeywordBuildEdge{
+					target:      next,
+					nextSibling: contentModerationKeywordBuildFirstEdge(buildNodes[state]),
+					label:       label,
+				})
+				buildNodes[state].edgeStart = uint32(len(buildEdges))
+			}
+			state = next
+		}
+		if current := buildNodes[state].bestKeyword; current < 0 || int32(keywordIndex) < current {
+			buildNodes[state].bestKeyword = int32(keywordIndex)
+		}
+	}
+
+	if len(buildNodes) == 1 {
+		return nil
+	}
+
+	queue := make([]int32, 0, len(buildNodes)-1)
+	var rootTransitions [256]int32
+	for edgeIndex := contentModerationKeywordBuildFirstEdge(buildNodes[0]); edgeIndex >= 0; edgeIndex = buildEdges[edgeIndex].nextSibling {
+		edge := buildEdges[edgeIndex]
+		rootTransitions[edge.label] = edge.target
+		queue = append(queue, edge.target)
+	}
+
+	for queueIndex := 0; queueIndex < len(queue); queueIndex++ {
+		state := queue[queueIndex]
+		for edgeIndex := contentModerationKeywordBuildFirstEdge(buildNodes[state]); edgeIndex >= 0; edgeIndex = buildEdges[edgeIndex].nextSibling {
+			edge := buildEdges[edgeIndex]
+			failure := buildNodes[state].failure
+			fallback := contentModerationKeywordBuildTransition(buildNodes, buildEdges, failure, edge.label)
+			for fallback < 0 && failure != 0 {
+				failure = buildNodes[failure].failure
+				fallback = contentModerationKeywordBuildTransition(buildNodes, buildEdges, failure, edge.label)
+			}
+			if fallback >= 0 {
+				buildNodes[edge.target].failure = fallback
+			}
+			buildNodes[edge.target].bestKeyword = minKeywordIndex(
+				buildNodes[edge.target].bestKeyword,
+				buildNodes[buildNodes[edge.target].failure].bestKeyword,
+			)
+			queue = append(queue, edge.target)
+		}
+	}
+
+	edges := make([]contentModerationKeywordEdge, 0, len(buildEdges))
+	var outgoing [256]contentModerationKeywordEdge
+	for nodeIndex := range buildNodes {
+		count := 0
+		for edgeIndex := contentModerationKeywordBuildFirstEdge(buildNodes[nodeIndex]); edgeIndex >= 0; edgeIndex = buildEdges[edgeIndex].nextSibling {
+			edge := buildEdges[edgeIndex]
+			outgoing[count] = contentModerationKeywordEdge{target: edge.target, label: edge.label}
+			count++
+		}
+		for index := 1; index < count; index++ {
+			current := outgoing[index]
+			insertAt := index
+			for insertAt > 0 && current.label < outgoing[insertAt-1].label {
+				outgoing[insertAt] = outgoing[insertAt-1]
+				insertAt--
+			}
+			outgoing[insertAt] = current
+		}
+		buildNodes[nodeIndex].edgeStart = uint32(len(edges))
+		buildNodes[nodeIndex].edgeCount = uint16(count)
+		edges = append(edges, outgoing[:count]...)
+	}
+
+	return &contentModerationKeywordMatcher{
+		nodes:           buildNodes,
+		edges:           edges,
+		rootTransitions: rootTransitions,
+		keywords:        originalKeywords,
+	}
+}
+
+func newContentModerationKeywordNode() contentModerationKeywordNode {
+	return contentModerationKeywordNode{bestKeyword: -1}
+}
+
+func contentModerationKeywordBuildFirstEdge(node contentModerationKeywordNode) int32 {
+	if node.edgeStart == 0 {
+		return -1
+	}
+	return int32(node.edgeStart - 1)
+}
+
+func contentModerationKeywordBuildTransition(
+	nodes []contentModerationKeywordNode,
+	edges []contentModerationKeywordBuildEdge,
+	state int32,
+	label byte,
+) int32 {
+	if state < 0 || int(state) >= len(nodes) {
+		return -1
+	}
+	for edgeIndex := contentModerationKeywordBuildFirstEdge(nodes[state]); edgeIndex >= 0; edgeIndex = edges[edgeIndex].nextSibling {
+		if edges[edgeIndex].label == label {
+			return edges[edgeIndex].target
+		}
+	}
+	return -1
+}
+
+func minKeywordIndex(left, right int32) int32 {
+	if left < 0 {
+		return right
+	}
+	if right < 0 || left < right {
+		return left
+	}
+	return right
+}
+
+func (m *contentModerationKeywordMatcher) Match(text string) (string, bool) {
+	if m == nil || text == "" || len(m.nodes) == 0 || len(m.keywords) == 0 {
+		return "", false
+	}
+	lower := strings.ToLower(text)
+	state := int32(0)
+	bestKeyword := int32(-1)
+	for index := 0; index < len(lower); index++ {
+		label := lower[index]
+		for {
+			next := m.next(state, label)
+			if next != 0 {
+				state = next
+				break
+			}
+			if state == 0 {
+				break
+			}
+			state = m.nodes[state].failure
+		}
+		bestKeyword = minKeywordIndex(bestKeyword, m.nodes[state].bestKeyword)
+		if bestKeyword == 0 {
+			return m.keywords[0], true
+		}
+	}
+	if bestKeyword < 0 || int(bestKeyword) >= len(m.keywords) {
+		return "", false
+	}
+	return m.keywords[bestKeyword], true
+}
+
+func (m *contentModerationKeywordMatcher) next(state int32, label byte) int32 {
+	if state == 0 {
+		return m.rootTransitions[label]
+	}
+	if state < 0 || int(state) >= len(m.nodes) {
+		return 0
+	}
+	node := m.nodes[state]
+	left := int(node.edgeStart)
+	right := left + int(node.edgeCount)
+	for left < right {
+		middle := left + (right-left)/2
+		edge := m.edges[middle]
+		if edge.label < label {
+			left = middle + 1
+			continue
+		}
+		right = middle
+	}
+	end := int(node.edgeStart) + int(node.edgeCount)
+	if left < end && m.edges[left].label == label {
+		return m.edges[left].target
+	}
+	return 0
+}

--- a/backend/internal/service/content_moderation_keyword_matcher_test.go
+++ b/backend/internal/service/content_moderation_keyword_matcher_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContentModerationKeywordMatcherMatchesLegacyBehavior(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		keywords []string
+	}{
+		{name: "miss", text: "clean prompt", keywords: []string{"blocked", "secret"}},
+		{name: "case insensitive", text: "contains SECRET value", keywords: []string{"secret"}},
+		{name: "configured order wins", text: "early appears before later", keywords: []string{"later", "early"}},
+		{name: "overlap uses configured order", text: "abc", keywords: []string{"bc", "abc"}},
+		{name: "unicode", text: "这里包含敏感词和世界", keywords: []string{"世界", "敏感词"}},
+		{name: "duplicates", text: "duplicate", keywords: []string{"duplicate", "DUPLICATE"}},
+		{name: "empty entries", text: "blocked", keywords: []string{"", "blocked"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wantKeyword, wantHit := matchBlockedKeyword(tt.text, tt.keywords)
+			gotKeyword, gotHit := newContentModerationKeywordMatcher(tt.keywords).Match(tt.text)
+			require.Equal(t, wantHit, gotHit)
+			require.Equal(t, wantKeyword, gotKeyword)
+		})
+	}
+}
+
+func TestContentModerationKeywordMatcherRandomizedParity(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260714))
+	const alphabet = "abcXYZ"
+	for iteration := 0; iteration < 1000; iteration++ {
+		keywords := make([]string, 1+rng.Intn(30))
+		for index := range keywords {
+			length := 1 + rng.Intn(8)
+			var value strings.Builder
+			for range length {
+				_ = value.WriteByte(alphabet[rng.Intn(len(alphabet))])
+			}
+			keywords[index] = value.String()
+		}
+		var text strings.Builder
+		for range 20 + rng.Intn(100) {
+			_ = text.WriteByte(alphabet[rng.Intn(len(alphabet))])
+		}
+
+		wantKeyword, wantHit := matchBlockedKeyword(text.String(), keywords)
+		gotKeyword, gotHit := newContentModerationKeywordMatcher(keywords).Match(text.String())
+		require.Equal(t, wantHit, gotHit, "iteration %d", iteration)
+		require.Equal(t, wantKeyword, gotKeyword, "iteration %d", iteration)
+	}
+}

--- a/backend/internal/service/content_moderation_runtime_cache_test.go
+++ b/backend/internal/service/content_moderation_runtime_cache_test.go
@@ -1,0 +1,451 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type contentModerationRuntimeSettingRepo struct {
+	mu               sync.Mutex
+	values           map[string]string
+	getValueCalls    int
+	getMultipleCalls int
+	getMultipleErr   error
+	getMultipleStart chan<- struct{}
+	getMultipleWait  <-chan struct{}
+}
+
+func (r *contentModerationRuntimeSettingRepo) Get(_ context.Context, key string) (*Setting, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	value, ok := r.values[key]
+	if !ok {
+		return nil, ErrSettingNotFound
+	}
+	return &Setting{Key: key, Value: value}, nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) GetValue(_ context.Context, key string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.getValueCalls++
+	value, ok := r.values[key]
+	if !ok {
+		return "", ErrSettingNotFound
+	}
+	return value, nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) Set(_ context.Context, key, value string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.values == nil {
+		r.values = make(map[string]string)
+	}
+	r.values[key] = value
+	return nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
+	r.mu.Lock()
+	r.getMultipleCalls++
+	if err := r.getMultipleErr; err != nil {
+		r.mu.Unlock()
+		return nil, err
+	}
+	out := make(map[string]string, len(keys))
+	for _, key := range keys {
+		if value, ok := r.values[key]; ok {
+			out[key] = value
+		}
+	}
+	start := r.getMultipleStart
+	wait := r.getMultipleWait
+	r.getMultipleStart = nil
+	r.getMultipleWait = nil
+	r.mu.Unlock()
+	if start != nil {
+		start <- struct{}{}
+	}
+	if wait != nil {
+		<-wait
+	}
+	return out, nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) SetMultiple(_ context.Context, values map[string]string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.values == nil {
+		r.values = make(map[string]string)
+	}
+	for key, value := range values {
+		r.values[key] = value
+	}
+	return nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) GetAll(_ context.Context) (map[string]string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make(map[string]string, len(r.values))
+	for key, value := range r.values {
+		out[key] = value
+	}
+	return out, nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) Delete(_ context.Context, key string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.values, key)
+	return nil
+}
+
+func (r *contentModerationRuntimeSettingRepo) calls() (getValue, getMultiple int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.getValueCalls, r.getMultipleCalls
+}
+
+func (r *contentModerationRuntimeSettingRepo) failMultiple(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.getMultipleErr = err
+}
+
+func (r *contentModerationRuntimeSettingRepo) blockNextMultiple(start chan<- struct{}, wait <-chan struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.getMultipleStart = start
+	r.getMultipleWait = wait
+}
+
+func runtimeCacheTestConfig(t *testing.T, keywords ...string) string {
+	t.Helper()
+	cfg := defaultContentModerationConfig()
+	cfg.Enabled = true
+	cfg.Mode = ContentModerationModePreBlock
+	cfg.KeywordBlockingMode = ContentModerationKeywordModeKeywordOnly
+	cfg.BlockedKeywords = keywords
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func runtimeCacheTestService(repo *contentModerationRuntimeSettingRepo, ttl time.Duration) *ContentModerationService {
+	return &ContentModerationService{
+		settingRepo:     repo,
+		repo:            &contentModerationTestRepo{},
+		runtimeCacheTTL: ttl,
+	}
+}
+
+func runtimeCacheTestInput(text string) ContentModerationCheckInput {
+	return ContentModerationCheckInput{
+		Protocol: ContentModerationProtocolOpenAIChat,
+		Model:    "risk-cache-test",
+		Body:     []byte(`{"messages":[{"role":"user","content":"` + text + `"}]}`),
+	}
+}
+
+func TestContentModerationRuntimeSnapshotCachesSettings(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Hour)
+
+	for range 20 {
+		decision, err := svc.Check(context.Background(), runtimeCacheTestInput("clean prompt"))
+		require.NoError(t, err)
+		require.True(t, decision.Allowed)
+	}
+
+	getValue, getMultiple := repo.calls()
+	require.Zero(t, getValue)
+	require.Equal(t, 1, getMultiple)
+}
+
+func TestContentModerationRuntimeSnapshotUpdateConfigIsImmediate(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "old-keyword"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Hour)
+
+	decision, err := svc.Check(context.Background(), runtimeCacheTestInput("new-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+
+	keywords := []string{"new-keyword"}
+	_, err = svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{
+		BlockedKeywords: &keywords,
+	})
+	require.NoError(t, err)
+
+	decision, err = svc.Check(context.Background(), runtimeCacheTestInput("new-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+
+	_, getMultiple := repo.calls()
+	require.Equal(t, 1, getMultiple)
+}
+
+func TestContentModerationRuntimeSnapshotUpdateWinsOverInitialLoad(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "old-keyword"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Hour)
+
+	refreshStarted := make(chan struct{}, 1)
+	releaseRefresh := make(chan struct{})
+	released := false
+	defer func() {
+		if !released {
+			close(releaseRefresh)
+		}
+	}()
+	repo.blockNextMultiple(refreshStarted, releaseRefresh)
+
+	initialCheckDone := make(chan error, 1)
+	go func() {
+		decision, err := svc.Check(context.Background(), runtimeCacheTestInput("clean prompt"))
+		if err == nil && (decision == nil || !decision.Allowed) {
+			err = errors.New("unexpected initial moderation decision")
+		}
+		initialCheckDone <- err
+	}()
+	require.Eventually(t, func() bool {
+		select {
+		case <-refreshStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	updateDone := make(chan error, 1)
+	go func() {
+		keywords := []string{"new-keyword"}
+		_, updateErr := svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{
+			BlockedKeywords: &keywords,
+		})
+		updateDone <- updateErr
+	}()
+	select {
+	case updateErr := <-updateDone:
+		require.NoError(t, updateErr)
+		t.Fatal("configuration update completed before the initial load released its lock")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(releaseRefresh)
+	released = true
+	require.NoError(t, <-initialCheckDone)
+	require.NoError(t, <-updateDone)
+
+	decision, err := svc.Check(context.Background(), runtimeCacheTestInput("new-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+	decision, err = svc.Check(context.Background(), runtimeCacheTestInput("old-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+}
+
+func TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Nanosecond)
+	input := runtimeCacheTestInput("blocked")
+
+	decision, err := svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+
+	repo.failMultiple(errors.New("database unavailable"))
+	decision, err = svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+	require.Eventually(t, func() bool {
+		_, calls := repo.calls()
+		return calls >= 2
+	}, time.Second, time.Millisecond)
+}
+
+func TestContentModerationRuntimeSnapshotRefreshFailureBacksOff(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Minute)
+	input := runtimeCacheTestInput("blocked")
+
+	decision, err := svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+
+	current := svc.runtimeSnapshot.Load()
+	require.NotNil(t, current)
+	expired := *current
+	expired.loadedAt = time.Now().Add(-2 * time.Minute)
+	svc.runtimeSnapshot.Store(&expired)
+	repo.failMultiple(errors.New("database unavailable"))
+
+	decision, err = svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+	require.Eventually(t, func() bool {
+		_, calls := repo.calls()
+		return calls == 2
+	}, time.Second, time.Millisecond)
+
+	for range 100 {
+		decision, err = svc.Check(context.Background(), input)
+		require.NoError(t, err)
+		require.True(t, decision.Blocked)
+	}
+	_, calls := repo.calls()
+	require.Equal(t, 2, calls)
+}
+
+func TestContentModerationRuntimeSnapshotRefreshReusesUnchangedMatcher(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Minute)
+	input := runtimeCacheTestInput("blocked")
+
+	decision, err := svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+
+	current := svc.runtimeSnapshot.Load()
+	require.NotNil(t, current)
+	expired := *current
+	expired.loadedAt = time.Now().Add(-2 * time.Minute)
+	svc.runtimeSnapshot.Store(&expired)
+
+	decision, err = svc.Check(context.Background(), input)
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+	require.Eventually(t, func() bool {
+		refreshed := svc.runtimeSnapshot.Load()
+		return refreshed != nil && refreshed.loadedAt.After(expired.loadedAt)
+	}, time.Second, time.Millisecond)
+
+	refreshed := svc.runtimeSnapshot.Load()
+	require.Same(t, current.config, refreshed.config)
+	require.Same(t, current.keywordMatcher, refreshed.keywordMatcher)
+	_, calls := repo.calls()
+	require.Equal(t, 2, calls)
+}
+
+func TestContentModerationRuntimeSnapshotUpdateWinsOverInFlightRefresh(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "old-keyword"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Minute)
+
+	decision, err := svc.Check(context.Background(), runtimeCacheTestInput("old-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+
+	current := svc.runtimeSnapshot.Load()
+	require.NotNil(t, current)
+	expired := *current
+	expired.loadedAt = time.Now().Add(-2 * time.Minute)
+	svc.runtimeSnapshot.Store(&expired)
+
+	refreshStarted := make(chan struct{}, 1)
+	releaseRefresh := make(chan struct{})
+	repo.blockNextMultiple(refreshStarted, releaseRefresh)
+	decision, err = svc.Check(context.Background(), runtimeCacheTestInput("clean prompt"))
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	require.Eventually(t, func() bool {
+		select {
+		case <-refreshStarted:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	updateDone := make(chan error, 1)
+	go func() {
+		keywords := []string{"new-keyword"}
+		_, updateErr := svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{
+			BlockedKeywords: &keywords,
+		})
+		updateDone <- updateErr
+	}()
+	select {
+	case updateErr := <-updateDone:
+		require.NoError(t, updateErr)
+		t.Fatal("configuration update completed before the in-flight refresh released its lock")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(releaseRefresh)
+	require.NoError(t, <-updateDone)
+	decision, err = svc.Check(context.Background(), runtimeCacheTestInput("new-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+	decision, err = svc.Check(context.Background(), runtimeCacheTestInput("old-keyword"))
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+}
+
+func TestContentModerationRuntimeSnapshotConcurrentReadAndReplace(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked-0"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Hour)
+	_, err := svc.Check(context.Background(), runtimeCacheTestInput("clean prompt"))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				decision, checkErr := svc.Check(context.Background(), runtimeCacheTestInput("clean prompt"))
+				if checkErr != nil {
+					errs <- checkErr
+					return
+				}
+				if decision == nil || !decision.Allowed {
+					errs <- errors.New("unexpected moderation decision")
+					return
+				}
+			}
+		}()
+	}
+	for i := 1; i <= 20; i++ {
+		keywords := []string{"blocked-" + time.Duration(i).String()}
+		_, err := svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{
+			BlockedKeywords: &keywords,
+		})
+		require.NoError(t, err)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
## 摘要

- 使用不可变运行时快照缓存风控总开关和规范化后的内容审核配置，避免每个请求重复读取并解析两项设置
- 将禁用关键词编译为紧凑型 Aho-Corasick 匹配器，同时保持大小写不敏感和配置顺序优先语义
- 快照刷新支持旧快照继续服务、失败重试间隔、按配置摘要复用匹配器，以及与管理端配置更新互斥
- 增加匹配等价性、缓存刷新和并发安全单元测试

## 背景

风控中心使用 `pre_block` + `keyword_only` 模式时，当前每个网关请求都会：

1. 从 PostgreSQL 读取 `risk_control_enabled`；
2. 读取并反序列化 `content_moderation_config`；
3. 重新规范化全部关键词；
4. 使用 `strings.Contains` 串行扫描关键词。

异步内容审核 worker 也会重新读取配置。关键词达到数百个时，重复数据库查询和配置解析成为热路径的主要成本；达到系统支持的 10,000 个关键词上限时，串行扫描还会继续增加 CPU 开销。

本次修改为每个进程维护一份不可变快照。请求路径只执行一次原子指针读取，过期后最多由一个 goroutine 刷新。配置摘要未变化时直接复用现有配置和匹配器，因此 1 秒周期刷新不会重复构建大型自动机。刷新失败时继续使用上一份有效快照，并等待一个 TTL 后再重试。

## 兼容性与安全性

- 不修改 API、数据库结构、响应格式或内容审核策略
- 管理端 `UpdateConfig` 持久化成功后立即替换当前实例的快照
- 通过数据库或其他实例更新的配置会在 1 秒 TTL 内生效
- 正在执行的后台刷新不会覆盖更新后的管理端配置
- 匹配仍然不区分大小写，并返回配置索引最小的命中关键词，与原有循环语义一致
- 空关键词、重复关键词、重叠匹配和 UTF-8 输入保持原有行为

## 性能数据

为了分别确认“配置缓存”和“关键词匹配器”各自带来的收益，相同输入分别测试了三个版本：

| 版本 | 实现 |
| --- | --- |
| B0 | 修改前：每次请求读取两项设置、解析配置，再逐个执行 `strings.Contains` |
| B1 | 使用 1 秒不可变配置快照，关键词仍按原方式逐个扫描 |
| B2 | B1 加 Aho-Corasick 匹配器，即本 PR 的最终实现 |

指标说明：

- `µs/op`：模块每完成一次检查的平均耗时，越低越好；`1,000 µs = 1 ms`
- `p95`：95% 的 HTTP 请求能在该时间内完成，越低越好
- `QPS`：每秒完成的 HTTP 请求数，越高越好
- `reads/op`：每次内容审核检查平均触发的风控设置数据库读取次数，越低越好
- `2x` 表示相同时间内理论处理能力约为原来的 2 倍，也等价于单次耗时减半

模块基准在不同并发下会并行执行，因此并发 32 的 `µs/op` 可能低于并发 1。应在相同并发下横向比较 B0、B1、B2，不能把不同并发的数值直接当作单个 HTTP 请求延迟。

测试条件如下：

| 项目 | 固定条件 |
| --- | --- |
| 主机 | Apple M4，10 CPU，8 GiB 内存 |
| Go | 模块工具链 1.26.5 |
| 数据库 | Docker PostgreSQL 18.1，最大连接 50、空闲连接 10 |
| Redis | Docker Redis 8.4 |
| 关键词 | 500 个，顺序固定 |
| 输入 | 12,000 字符 |
| 并发 | 1、8、32 |
| 模块基准 | 每组运行 2 秒，重复 3 次，取中位数 |
| HTTP 测试 | 每组预热 500 次、正式请求 10,000 次，重复 3 次，取中位数 |

真实 PostgreSQL、完整 HTTP 和 Docker 测试代码保存在 fork 的 [`benchmark/content-moderation-keyword-hot-path`](https://github.com/lyon-le/sub2api/tree/benchmark/content-moderation-keyword-hot-path) 分支，不包含在本 PR 中。

主要结论：

- 500 个关键词全部未命中时，完整服务检查耗时降低 `87.4%` 至 `90.9%`
- 最大收益来自配置快照：它移除了每次请求的数据库读取和配置解析
- Aho-Corasick 在配置快照基础上又将未命中扫描耗时降低约 `29%` 至 `31%`
- 并发 32 的完整 HTTP 测试中，未命中请求 `p95` 降低 `20.2%`，QPS 提高 `10.9%`
- 系统允许的最大配置下，单个匹配器长期占用 `50.2 MiB`，配置替换时进程峰值 RSS 为 `271.2 MiB`

### 真实 PostgreSQL 服务路径：500 个关键词均未命中

该测试包含设置读取、配置解析、关键词规范化和关键词检查。未命中必须检查完整个关键词集合，是旧串行扫描最耗时的情况。

| 并发 | B0 µs/op | B1 µs/op | B2 µs/op | B0 -> B1 | B1 -> B2 | B0 -> B2 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 919.175 | 166.720 | 115.476 | 5.51x | 1.44x | 7.96x / -87.4% |
| 8 | 238.494 | 31.230 | 21.670 | 7.64x | 1.44x | 11.01x / -90.9% |
| 32 | 169.443 | 27.064 | 19.152 | 6.26x | 1.41x | 8.85x / -88.7% |

以并发 32 为例：

1. B0 每次检查平均需要 `169.443 µs`；
2. 只加入配置快照后降至 `27.064 µs`，说明重复访问数据库和解析配置是主要成本；
3. 再加入匹配器后降至 `19.152 µs`，关键词扫描部分继续减少 `29.2%`；
4. 最终 B2 相比 B0 减少 `88.7%`，速度提高 `8.85x`。

### 真实 PostgreSQL 服务路径：第 500 个关键词命中

把命中词放在第 500 个位置，是旧串行扫描的最晚命中情况。命中后系统还会创建内容审核记录任务，因此该表不只测关键词扫描。

| 并发 | B0 µs/op | B1 µs/op | B2 µs/op | B0 -> B2 |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 2,690.053 | 1,007.456 | 983.602 | 2.73x / -63.4% |
| 8 | 452.026 | 225.090 | 206.114 | 2.19x / -54.4% |
| 32 | 406.729 | 219.195 | 222.825 | 1.83x / -45.2% |

命中路径的总耗时仍降低 `45.2%` 至 `63.4%`。并发 32 时 B1 与 B2 分别为 `219.195 µs` 和 `222.825 µs`，差异很小，说明此时主要时间已经花在命中后的记录任务，而不是关键词扫描。

### 风控设置数据库读取

| 场景 | 并发 | B0 reads/op | B1 reads/op | B2 reads/op |
| --- | ---: | ---: | ---: | ---: |
| 未命中 | 1 | 2.024 | 0.0001416 | 0.0000973 |
| 未命中 | 8 | 2.010 | 0.0000261 | 0.0000182 |
| 未命中 | 32 | 2.005 | 0.0000339 | 0.0000164 |
| 第 500 个词命中 | 1 | 3.081 | 0.0008838 | 0.0009390 |
| 第 500 个词命中 | 8 | 3.015 | 0.0002000 | 0.0002000 |
| 第 500 个词命中 | 32 | 2.379 | 0.0002000 | 0.0002000 |

B1/B2 将风控设置读取次数至少降低约 `99.97%`。以未命中、并发 32 为例：

- B0 每次检查约读取数据库 `2` 次；
- B2 平均约每 `61,000` 次检查读取 `1` 次；
- 剩余读取来自 1 秒周期刷新，请求增加不会让设置读取按请求数同步增加。

### 仅比较关键词匹配

该基准排除了数据库、配置解析和命中后任务，只比较旧串行扫描与新匹配器本身。

| 场景 | 串行 `strings.Contains` | Aho-Corasick | 提升 | 耗时降低 |
| --- | ---: | ---: | ---: | ---: |
| 500 个关键词未命中 | 78.307 µs/op | 26.662 µs/op | 2.94x | 66.0% |
| 第 500 个关键词命中 | 88.729 µs/op | 32.827 µs/op | 2.70x | 63.0% |

这说明在相同 500 个关键词和 12,000 字符输入下，新匹配器将纯扫描时间减少约三分之二。服务路径中的提升没有达到相同比例，是因为服务还包含数据库、任务创建等其他工作。

### 完整 HTTP 测试

完整 HTTP 测试经过路由、中间件、鉴权、风控检查和错误处理，更接近真实请求。每个版本、场景和并发组合执行 500 次预热与 10,000 次正式请求，并重复 3 次；共完成 `540,000` 次正式请求，全部返回预期的本地 `403`。

关键词未命中：

| 并发 | B0 p95 / QPS | B1 p95 / QPS | B2 p95 / QPS | B0 -> B2 p95 | B0 -> B2 QPS |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2.492 ms / 914.6 | 2.413 ms / 927.3 | 2.328 ms / 961.4 | -6.6% | +5.1% |
| 8 | 5.290 ms / 2,364.1 | 4.709 ms / 2,512.4 | 5.014 ms / 2,355.4 | -5.2% | -0.4% |
| 32 | 11.530 ms / 4,591.4 | 9.355 ms / 5,071.7 | 9.200 ms / 5,090.2 | -20.2% | +10.9% |

第 500 个关键词命中：

| 并发 | B0 p95 / QPS | B1 p95 / QPS | B2 p95 / QPS | B0 -> B2 p95 | B0 -> B2 QPS |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 2.450 ms / 910.7 | 2.465 ms / 880.4 | 2.316 ms / 962.5 | -5.5% | +5.7% |
| 8 | 5.297 ms / 2,414.6 | 5.233 ms / 2,390.9 | 5.978 ms / 2,282.4 | +12.9% | -5.5% |
| 32 | 12.279 ms / 4,424.9 | 9.681 ms / 4,816.5 | 10.065 ms / 4,771.0 | -18.0% | +7.8% |

完整 HTTP 的改善小于模块基准，且个别低耗时组合会有小幅波动。原因是测试中的本地 `403` 还会进入独立的 Ops 错误日志队列，并执行通用设置查询和数据库写入；三组运行中该队列均达到容量限制。风控模块的数据库读取和关键词扫描大幅减少后，这条错误日志路径成为主要剩余成本。

### 最大配置内存

内存测试使用系统允许的最大配置：`10,000` 个关键词，每个关键词 `200` 字符。这是边界场景，不代表 500 个关键词测试时的常规占用。

| 指标 | 结果 | 含义 |
| --- | ---: | --- |
| 匹配器节点 / 边 | 1,973,282 / 1,973,281 | 最大配置编译后的自动机规模 |
| 单个匹配器长期持有量 | 50.2 MiB | 配置稳定后，每个后端进程长期保留的匹配器内存 |
| 测试进程基础 RSS | 42.7 MiB | 尚未构建最大匹配器时的进程内存 |
| 首次构建峰值 RSS | 162.7 MiB | 启动后第一次加载最大配置时的短时峰值 |
| 旧、新匹配器合计持有量 | 100.4 MiB | 最大配置更新时两份匹配器短暂共存 |
| 配置替换峰值 RSS | 271.2 MiB | 最大配置发生变化时的进程短时峰值 |
| 单次构建时间 | 0.11 秒 | 构建最大匹配器所需时间 |

配置稳定时，每个后端进程长期增加约 `50.2 MiB` 匹配器内存。多个后端进程不会共享这部分内存，例如 4 个进程都加载最大配置时，匹配器合计长期持有量约为 `200.8 MiB`，但分别位于各自进程中。

周期刷新会先比较配置摘要。配置未变化时直接复用原匹配器，不会每秒重新构建，也不会反复出现峰值；只有最大配置实际更新时，旧快照和新匹配器才会短暂同时存在。

## 测试

- `go test ./internal/service -count=1`
- `go test -race ./internal/service -run 'TestContentModeration(RuntimeSnapshot|KeywordMatcher)' -count=1`
- `go test ./cmd/server -count=1`
- `git diff --check`
