### PR TITLE
优化内容审核工作线程配置读取

### DIFF
--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -23,6 +23,7 @@ import (
 	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/pagination"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -89,10 +90,15 @@ const (
 	maxContentModerationModelFilterModels        = 1000
 	maxContentModerationModelFilterRunes         = 200
 
-	contentModerationCleanupInterval = 24 * time.Hour
-	contentModerationCleanupTimeout  = 30 * time.Minute
-	contentModerationCleanupDelay    = 5 * time.Minute
+	contentModerationCleanupInterval         = 24 * time.Hour
+	contentModerationCleanupTimeout          = 30 * time.Minute
+	contentModerationCleanupDelay            = 5 * time.Minute
+	contentModerationWorkerConfigTTL         = time.Second
+	contentModerationWorkerConfigErrorTTL    = time.Second
+	contentModerationWorkerConfigLoadTimeout = maxContentModerationTimeoutMS*time.Millisecond + 10*time.Second
 )
+
+const contentModerationWorkerConfigKey = "content_moderation_worker_config"
 
 var contentModerationCategoryOrder = []string{
 	"harassment",
@@ -512,8 +518,23 @@ type ContentModerationService struct {
 	lastCleanupUnix          atomic.Int64
 	lastCleanupDeletedHit    atomic.Int64
 	lastCleanupDeletedNonHit atomic.Int64
+	workerConfigCache        atomic.Pointer[contentModerationWorkerConfigSnapshot]
+	workerConfigError        atomic.Pointer[contentModerationWorkerConfigErrorSnapshot]
+	workerConfigSF           singleflight.Group
+	workerConfigMu           sync.Mutex
+	workerConfigVersion      uint64
 	keyHealthMu              sync.Mutex
 	keyHealth                map[string]*contentModerationKeyHealth
+}
+
+type contentModerationWorkerConfigSnapshot struct {
+	config    *ContentModerationConfig
+	expiresAt int64
+}
+
+type contentModerationWorkerConfigErrorSnapshot struct {
+	err       error
+	expiresAt int64
 }
 
 type contentModerationTask struct {
@@ -700,6 +721,7 @@ func (s *ContentModerationService) UpdateConfig(ctx context.Context, input Updat
 	if err := s.settingRepo.Set(ctx, SettingKeyContentModerationConfig, string(raw)); err != nil {
 		return nil, fmt.Errorf("save content moderation config: %w", err)
 	}
+	s.publishWorkerConfig(cfg)
 	return s.configView(cfg), nil
 }
 
@@ -1178,7 +1200,7 @@ func (s *ContentModerationService) enqueueRecord(input ContentModerationCheckInp
 func (s *ContentModerationService) worker(id int) {
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), maxContentModerationTimeoutMS*time.Millisecond+10*time.Second)
-		cfg, err := s.loadConfig(ctx)
+		cfg, err := s.loadWorkerConfig(ctx)
 		if err != nil || id >= cfg.WorkerCount {
 			cancel()
 			time.Sleep(time.Second)
@@ -1456,6 +1478,107 @@ func (s *ContentModerationService) loadConfig(ctx context.Context) (*ContentMode
 	}
 	cfg.normalize()
 	return cfg, nil
+}
+
+func (s *ContentModerationService) loadWorkerConfig(ctx context.Context) (*ContentModerationConfig, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if cfg := s.cachedWorkerConfig(time.Now()); cfg != nil {
+		return cloneContentModerationConfig(cfg), nil
+	}
+	if err := s.cachedWorkerConfigError(time.Now()); err != nil {
+		return nil, err
+	}
+
+	resultCh := s.workerConfigSF.DoChan(contentModerationWorkerConfigKey, func() (any, error) {
+		for {
+			now := time.Now()
+			if cfg := s.cachedWorkerConfig(now); cfg != nil {
+				return cfg, nil
+			}
+			if err := s.cachedWorkerConfigError(now); err != nil {
+				return nil, err
+			}
+
+			s.workerConfigMu.Lock()
+			version := s.workerConfigVersion
+			s.workerConfigMu.Unlock()
+
+			// The shared refresh keeps the original worker bound but is independent of every waiter's cancellation.
+			refreshCtx, cancel := context.WithTimeout(context.Background(), contentModerationWorkerConfigLoadTimeout)
+			cfg, refreshErr := s.loadConfig(refreshCtx)
+			cancel()
+
+			s.workerConfigMu.Lock()
+			if version != s.workerConfigVersion {
+				current := s.cachedWorkerConfig(time.Now())
+				s.workerConfigMu.Unlock()
+				if current != nil {
+					return current, nil
+				}
+				continue
+			}
+			if refreshErr != nil {
+				s.workerConfigError.Store(&contentModerationWorkerConfigErrorSnapshot{
+					err:       refreshErr,
+					expiresAt: time.Now().Add(contentModerationWorkerConfigErrorTTL).UnixNano(),
+				})
+				s.workerConfigMu.Unlock()
+				return nil, refreshErr
+			}
+			snapshot := &contentModerationWorkerConfigSnapshot{
+				config:    cloneContentModerationConfig(cfg),
+				expiresAt: time.Now().Add(contentModerationWorkerConfigTTL).UnixNano(),
+			}
+			s.workerConfigCache.Store(snapshot)
+			s.workerConfigError.Store(nil)
+			s.workerConfigMu.Unlock()
+			return snapshot.config, nil
+		}
+	})
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		cfg, ok := result.Val.(*ContentModerationConfig)
+		if !ok {
+			return nil, fmt.Errorf("load content moderation worker config: unexpected result type %T", result.Val)
+		}
+		return cloneContentModerationConfig(cfg), nil
+	}
+}
+
+func (s *ContentModerationService) cachedWorkerConfig(now time.Time) *ContentModerationConfig {
+	snapshot := s.workerConfigCache.Load()
+	if snapshot == nil || now.UnixNano() >= snapshot.expiresAt {
+		return nil
+	}
+	return snapshot.config
+}
+
+func (s *ContentModerationService) cachedWorkerConfigError(now time.Time) error {
+	snapshot := s.workerConfigError.Load()
+	if snapshot == nil || now.UnixNano() >= snapshot.expiresAt {
+		return nil
+	}
+	return snapshot.err
+}
+
+func (s *ContentModerationService) publishWorkerConfig(cfg *ContentModerationConfig) {
+	snapshot := &contentModerationWorkerConfigSnapshot{
+		config:    cloneContentModerationConfig(cfg),
+		expiresAt: time.Now().Add(contentModerationWorkerConfigTTL).UnixNano(),
+	}
+	s.workerConfigMu.Lock()
+	s.workerConfigVersion++
+	s.workerConfigCache.Store(snapshot)
+	s.workerConfigError.Store(nil)
+	s.workerConfigMu.Unlock()
 }
 
 func (s *ContentModerationService) isRiskControlEnabled(ctx context.Context) bool {

--- a/backend/internal/service/content_moderation_worker_config_test.go
+++ b/backend/internal/service/content_moderation_worker_config_test.go
@@ -1,0 +1,375 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type contentModerationWorkerConfigSettingRepo struct {
+	SettingRepository
+	mu       sync.RWMutex
+	value    string
+	getErr   error
+	getDelay time.Duration
+	getCalls atomic.Int64
+	started  chan struct{}
+	release  <-chan struct{}
+}
+
+func (r *contentModerationWorkerConfigSettingRepo) GetValue(ctx context.Context, _ string) (string, error) {
+	call := r.getCalls.Add(1)
+	r.mu.RLock()
+	value, err, delay := r.value, r.getErr, r.getDelay
+	r.mu.RUnlock()
+	if call == 1 && r.started != nil {
+		close(r.started)
+		select {
+		case <-r.release:
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+	if delay > 0 {
+		time.Sleep(delay)
+	}
+	return value, err
+}
+
+func (r *contentModerationWorkerConfigSettingRepo) Set(_ context.Context, _ string, value string) error {
+	r.setValue(value, nil)
+	return nil
+}
+
+func (r *contentModerationWorkerConfigSettingRepo) setValue(value string, err error) {
+	r.mu.Lock()
+	r.value = value
+	r.getErr = err
+	r.mu.Unlock()
+}
+
+func TestContentModerationWorkerConfig_ConcurrentMissLoadsOnceAndReturnsClones(t *testing.T) {
+	cfg := defaultContentModerationConfig()
+	cfg.Enabled = true
+	cfg.WorkerCount = 7
+	cfg.APIKeys = []string{"sk-worker"}
+	cfg.GroupIDs = []int64{11, 12}
+	cfg.AllGroups = false
+	cfg.BlockedKeywords = []string{"blocked"}
+	cfg.ModelFilter = ContentModerationModelFilter{Type: ContentModerationModelFilterInclude, Models: []string{"gpt-5"}}
+	repo := &contentModerationWorkerConfigSettingRepo{
+		value:    marshalContentModerationWorkerConfig(t, cfg),
+		getDelay: 25 * time.Millisecond,
+	}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+
+	configs := loadContentModerationWorkerConfigsConcurrently(t, svc, 32)
+
+	require.Equal(t, int64(1), repo.getCalls.Load())
+	require.NotSame(t, configs[0], configs[1])
+	configs[0].APIKeys[0] = "mutated"
+	configs[0].GroupIDs[0] = 99
+	configs[0].BlockedKeywords[0] = "mutated"
+	configs[0].Thresholds["sexual"] = 0
+	configs[0].ModelFilter.Models[0] = "mutated"
+
+	got, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+	require.Equal(t, []string{"sk-worker"}, got.APIKeys)
+	require.Equal(t, []int64{11, 12}, got.GroupIDs)
+	require.Equal(t, []string{"blocked"}, got.BlockedKeywords)
+	require.NotZero(t, got.Thresholds["sexual"])
+	require.Equal(t, []string{"gpt-5"}, got.ModelFilter.Models)
+}
+
+func TestContentModerationWorkerConfig_TTLRefreshLoadsOnce(t *testing.T) {
+	cfg := defaultContentModerationConfig()
+	repo := &contentModerationWorkerConfigSettingRepo{
+		value:    marshalContentModerationWorkerConfig(t, cfg),
+		getDelay: 25 * time.Millisecond,
+	}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+
+	_, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+
+	time.Sleep(contentModerationWorkerConfigTTL + 50*time.Millisecond)
+	loadContentModerationWorkerConfigsConcurrently(t, svc, 32)
+	require.Equal(t, int64(2), repo.getCalls.Load())
+}
+
+func TestContentModerationWorkerConfig_UpdatePublishesImmediately(t *testing.T) {
+	cfg := defaultContentModerationConfig()
+	cfg.WorkerCount = 4
+	repo := &contentModerationWorkerConfigSettingRepo{value: marshalContentModerationWorkerConfig(t, cfg)}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+
+	warm, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 4, warm.WorkerCount)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+
+	workerCount := 9
+	_, err = svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{WorkerCount: &workerCount})
+	require.NoError(t, err)
+	require.Equal(t, int64(2), repo.getCalls.Load(), "UpdateConfig must keep its direct read")
+
+	updated, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 9, updated.WorkerCount)
+	require.Equal(t, int64(2), repo.getCalls.Load(), "worker must observe the published snapshot without another read")
+
+	_, err = svc.GetConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(3), repo.getCalls.Load(), "synchronous GetConfig must keep its direct read")
+}
+
+func TestContentModerationWorkerConfig_UpdateWinsAgainstInflightRefresh(t *testing.T) {
+	initial := defaultContentModerationConfig()
+	initial.WorkerCount = 4
+	started := make(chan struct{})
+	release := make(chan struct{})
+	repo := &contentModerationWorkerConfigSettingRepo{
+		value:   marshalContentModerationWorkerConfig(t, initial),
+		started: started,
+		release: release,
+	}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+	result := make(chan *ContentModerationConfig, 1)
+	errResult := make(chan error, 1)
+	go func() {
+		cfg, err := svc.loadWorkerConfig(context.Background())
+		result <- cfg
+		errResult <- err
+	}()
+	<-started
+
+	workerCount := 9
+	_, err := svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{WorkerCount: &workerCount})
+	require.NoError(t, err)
+	close(release)
+
+	require.NoError(t, <-errResult)
+	require.Equal(t, 9, (<-result).WorkerCount, "inflight stale read must not overwrite the update")
+	got, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 9, got.WorkerCount)
+	require.Equal(t, int64(2), repo.getCalls.Load())
+}
+
+func TestContentModerationWorkerConfig_UpdateWinsAgainstInflightRefreshError(t *testing.T) {
+	initial := defaultContentModerationConfig()
+	initial.WorkerCount = 4
+	started := make(chan struct{})
+	release := make(chan struct{})
+	repo := &contentModerationWorkerConfigSettingRepo{
+		value:   marshalContentModerationWorkerConfig(t, initial),
+		getErr:  errors.New("stale read failed"),
+		started: started,
+		release: release,
+	}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+	result := make(chan *ContentModerationConfig, 1)
+	errResult := make(chan error, 1)
+	go func() {
+		cfg, err := svc.loadWorkerConfig(context.Background())
+		result <- cfg
+		errResult <- err
+	}()
+	<-started
+
+	repo.setValue(marshalContentModerationWorkerConfig(t, initial), nil)
+	workerCount := 9
+	_, err := svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{WorkerCount: &workerCount})
+	require.NoError(t, err)
+	close(release)
+
+	require.NoError(t, <-errResult)
+	require.Equal(t, 9, (<-result).WorkerCount)
+	got, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 9, got.WorkerCount)
+	require.Equal(t, int64(2), repo.getCalls.Load())
+}
+
+func TestContentModerationWorkerConfig_UpdateClearsRefreshErrorThrottle(t *testing.T) {
+	repo := &contentModerationWorkerConfigSettingRepo{getErr: errors.New("read failed")}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+
+	got, err := svc.loadWorkerConfig(context.Background())
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+
+	initial := defaultContentModerationConfig()
+	repo.setValue(marshalContentModerationWorkerConfig(t, initial), nil)
+	workerCount := 9
+	_, err = svc.UpdateConfig(context.Background(), UpdateContentModerationConfigInput{WorkerCount: &workerCount})
+	require.NoError(t, err)
+
+	got, err = svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 9, got.WorkerCount)
+	require.Equal(t, int64(2), repo.getCalls.Load())
+}
+
+func TestContentModerationWorkerConfig_FirstCallerCancellationDoesNotCancelRefresh(t *testing.T) {
+	cfg := defaultContentModerationConfig()
+	cfg.WorkerCount = 7
+	started := make(chan struct{})
+	release := make(chan struct{})
+	repo := &contentModerationWorkerConfigSettingRepo{
+		value:   marshalContentModerationWorkerConfig(t, cfg),
+		started: started,
+		release: release,
+	}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	firstResult := make(chan error, 1)
+	go func() {
+		_, err := svc.loadWorkerConfig(firstCtx)
+		firstResult <- err
+	}()
+	<-started
+	cancelFirst()
+	require.ErrorIs(t, <-firstResult, context.Canceled)
+
+	close(release)
+	got, err := svc.loadWorkerConfig(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 7, got.WorkerCount)
+	require.Equal(t, int64(1), repo.getCalls.Load())
+}
+
+func TestContentModerationWorkerConfig_RefreshErrorDoesNotServeOrPoisonCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		badValue string
+		getErr   error
+	}{
+		{name: "repository error", getErr: errors.New("read failed")},
+		{name: "parse error", badValue: "{"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initial := defaultContentModerationConfig()
+			initial.WorkerCount = 4
+			repo := &contentModerationWorkerConfigSettingRepo{value: marshalContentModerationWorkerConfig(t, initial)}
+			svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+
+			_, err := svc.loadWorkerConfig(context.Background())
+			require.NoError(t, err)
+			expireContentModerationWorkerConfig(svc)
+			repo.setValue(tt.badValue, tt.getErr)
+
+			got, err := svc.loadWorkerConfig(context.Background())
+			require.Error(t, err)
+			require.Nil(t, got, "expired config must not be served stale")
+			firstErr := err
+
+			recovered := defaultContentModerationConfig()
+			recovered.WorkerCount = 8
+			repo.setValue(marshalContentModerationWorkerConfig(t, recovered), nil)
+			for range 32 {
+				got, err = svc.loadWorkerConfig(context.Background())
+				require.Equal(t, firstErr, err, "refresh errors must be throttled for one second")
+				require.Nil(t, got)
+			}
+			require.Equal(t, int64(2), repo.getCalls.Load())
+
+			expireContentModerationWorkerConfigError(svc)
+			got, err = svc.loadWorkerConfig(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, 8, got.WorkerCount)
+			require.Equal(t, int64(3), repo.getCalls.Load(), "refresh must retry after the error throttle expires")
+		})
+	}
+}
+
+func BenchmarkContentModerationWorkerConfigLoad(b *testing.B) {
+	cfg := defaultContentModerationConfig()
+	cfg.APIKeys = []string{"sk-worker-a", "sk-worker-b"}
+	cfg.GroupIDs = []int64{11, 12}
+	cfg.BlockedKeywords = []string{"blocked-a", "blocked-b"}
+	cfg.ModelFilter = ContentModerationModelFilter{Type: ContentModerationModelFilterInclude, Models: []string{"gpt-5", "gpt-5-mini"}}
+	raw, err := json.Marshal(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	repo := &contentModerationWorkerConfigSettingRepo{value: string(raw)}
+	svc := NewContentModerationService(repo, nil, nil, nil, nil, nil, nil)
+	ctx := context.Background()
+	if _, err := svc.loadWorkerConfig(ctx); err != nil {
+		b.Fatal(err)
+	}
+	startCalls := repo.getCalls.Load()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cfg, err := svc.loadWorkerConfig(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if cfg.WorkerCount == 0 {
+			b.Fatal("unexpected zero worker count")
+		}
+	}
+	b.StopTimer()
+	loads := repo.getCalls.Load() - startCalls
+	b.ReportMetric(float64(loads)/b.Elapsed().Seconds(), "repo-loads/s")
+}
+
+func marshalContentModerationWorkerConfig(t testing.TB, cfg *ContentModerationConfig) string {
+	t.Helper()
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	return string(raw)
+}
+
+func loadContentModerationWorkerConfigsConcurrently(t *testing.T, svc *ContentModerationService, count int) []*ContentModerationConfig {
+	t.Helper()
+	start := make(chan struct{})
+	configs := make([]*ContentModerationConfig, count)
+	errs := make([]error, count)
+	var wg sync.WaitGroup
+	wg.Add(count)
+	for i := 0; i < count; i++ {
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			configs[index], errs[index] = svc.loadWorkerConfig(context.Background())
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+	return configs
+}
+
+func expireContentModerationWorkerConfig(svc *ContentModerationService) {
+	snapshot := svc.workerConfigCache.Load()
+	svc.workerConfigCache.Store(&contentModerationWorkerConfigSnapshot{
+		config:    cloneContentModerationConfig(snapshot.config),
+		expiresAt: time.Now().Add(-time.Second).UnixNano(),
+	})
+}
+
+func expireContentModerationWorkerConfigError(svc *ContentModerationService) {
+	snapshot := svc.workerConfigError.Load()
+	svc.workerConfigError.Store(&contentModerationWorkerConfigErrorSnapshot{
+		err:       snapshot.err,
+		expiresAt: time.Now().Add(-time.Second).UnixNano(),
+	})
+}


### PR DESCRIPTION
## 问题
内容审核固定启动最多 32 个 worker，每轮都直接读取并解析同一配置；空闲时也可能产生约 32 次/秒的重复回源。

## 修复
仅在 worker 路径增加 1 秒配置快照和 singleflight。shared refresh 使用独立有界 context，waiter 可按自身 context 退出；返回值深拷贝。UpdateConfig 成功立即发布新版本；失败读取使用 1 秒 error throttle，但绝不返回过期配置。

## 验证
- 覆盖 32 并发 miss、TTL refresh、深拷贝、Update/inflight 成功与错误竞态、首 caller 取消、快速错误节流及恢复。
- `go test -race ./internal/service -run '^TestContentModerationWorkerConfig_' -count=10`
- 所有 ContentModeration 相关 race 测试和 service 包回归通过。
- 10 轮串行 benchmark：`19.90us -> 0.845us`（-95.75%），setting 回源约 `50252/s -> 0.83/s`。

## 边界
`GetConfig/UpdateConfig/Check/TestAPIKeys` 等同步路径继续直接读取；不改 worker 数量、queue size、审核模式、采样、错误传播或跨实例一致性上限。