### PR TITLE
优化图片生成意图字段扫描

### DIFF
--- a/backend/internal/service/image_generation_intent.go
+++ b/backend/internal/service/image_generation_intent.go
@@ -47,16 +47,36 @@ func IsImageGenerationIntent(endpoint string, requestedModel string, body []byte
 	if len(body) == 0 || !gjson.ValidBytes(body) {
 		return false
 	}
-	if model := strings.TrimSpace(gjson.GetBytes(body, "model").String()); isOpenAIImageGenerationModel(model) {
-		return true
-	}
-	if openAIJSONToolsContainImageGeneration(gjson.GetBytes(body, "tools")) {
-		return true
-	}
-	if openAIJSONInputContainsImageGenTool(gjson.GetBytes(body, "input")) {
-		return true
-	}
-	return openAIJSONToolChoiceSelectsImageGeneration(gjson.GetBytes(body, "tool_choice"))
+
+	var modelSeen, toolsSeen, inputSeen, toolChoiceSeen bool
+	imageIntent := false
+	parseRawJSONView(body).ForEach(func(key, value gjson.Result) bool {
+		// GetBytes returns the first duplicate key; retain that behavior while walking the root once.
+		switch key.Str {
+		case "model":
+			if !modelSeen {
+				modelSeen = true
+				imageIntent = isOpenAIImageGenerationModel(strings.TrimSpace(value.String()))
+			}
+		case "tools":
+			if !toolsSeen {
+				toolsSeen = true
+				imageIntent = openAIJSONToolsContainImageGeneration(value)
+			}
+		case "input":
+			if !inputSeen {
+				inputSeen = true
+				imageIntent = openAIJSONInputContainsImageGenTool(value)
+			}
+		case "tool_choice":
+			if !toolChoiceSeen {
+				toolChoiceSeen = true
+				imageIntent = openAIJSONToolChoiceSelectsImageGeneration(value)
+			}
+		}
+		return !imageIntent && (!modelSeen || !toolsSeen || !inputSeen || !toolChoiceSeen)
+	})
+	return imageIntent
 }
 
 // IsImageGenerationIntentMap is the map-backed variant used after service-side request mutation.

--- a/backend/internal/service/image_generation_intent_benchmark_test.go
+++ b/backend/internal/service/image_generation_intent_benchmark_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+var imageGenerationIntentBenchmarkResult bool
+
+func BenchmarkIsImageGenerationIntent(b *testing.B) {
+	largeInput := strings.Repeat("x", 1<<20)
+	benchmarks := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{
+			name: "1MiBInputNoImage",
+			body: []byte(`{"model":"gpt-5.5","tools":[],"input":"` + largeInput + `","tool_choice":"auto"}`),
+			want: false,
+		},
+		{
+			name: "1MiBInputLeadingImageTool",
+			body: []byte(`{"model":"gpt-5.5","tools":[{"type":"image_generation"}],"input":"` + largeInput + `"}`),
+			want: true,
+		},
+		{
+			name: "1MiBInputTrailingToolChoice",
+			body: []byte(`{"model":"gpt-5.5","tools":[],"input":"` + largeInput + `","tool_choice":{"type":"image_generation"}}`),
+			want: true,
+		},
+		{
+			name: "Invalid1MiBJSON",
+			body: []byte(`{"model":"gpt-5.5","input":"` + largeInput),
+			want: false,
+		},
+		{
+			name: "DuplicateKeysFirstWins",
+			body: []byte(`{"model":"gpt-5.5","model":"gpt-image-2","tools":[],"tools":[{"type":"image_generation"}],"input":"` + largeInput + `","tool_choice":"auto","tool_choice":{"type":"image_generation"}}`),
+			want: false,
+		},
+	}
+
+	for _, benchmark := range benchmarks {
+		b.Run(benchmark.name, func(b *testing.B) {
+			if got := IsImageGenerationIntent("/v1/responses", "gpt-5.5", benchmark.body); got != benchmark.want {
+				b.Fatalf("IsImageGenerationIntent() = %v, want %v", got, benchmark.want)
+			}
+			b.ReportAllocs()
+			b.SetBytes(int64(len(benchmark.body)))
+			b.ResetTimer()
+			var result bool
+			for i := 0; i < b.N; i++ {
+				result = IsImageGenerationIntent("/v1/responses", "gpt-5.5", benchmark.body)
+			}
+			imageGenerationIntentBenchmarkResult = result
+		})
+	}
+}

--- a/backend/internal/service/image_generation_intent_test.go
+++ b/backend/internal/service/image_generation_intent_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,6 +103,77 @@ func TestIsImageGenerationIntent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, IsImageGenerationIntent(tt.endpoint, tt.model, tt.body))
+		})
+	}
+}
+
+func TestIsImageGenerationIntentJSONSemantics(t *testing.T) {
+	largeInput := strings.Repeat("x", 1<<20)
+	tests := []struct {
+		name     string
+		endpoint string
+		body     []byte
+		want     bool
+	}{
+		{
+			name:     "chat body image model",
+			endpoint: "/v1/chat/completions",
+			body:     []byte(`{"model":"gpt-image-2"}`),
+			want:     true,
+		},
+		{
+			name:     "large responses input with trailing namespace tool choice",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"model":"gpt-5.5","input":"` + largeInput + `","tool_choice":{"type":"namespace","name":"image_gen"}}`),
+			want:     true,
+		},
+		{
+			name:     "invalid json with image tool",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"tools":[{"type":"image_generation"}]`),
+			want:     false,
+		},
+		{
+			name:     "duplicate model uses first value",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"model":"gpt-5.5","model":"gpt-image-2"}`),
+			want:     false,
+		},
+		{
+			name:     "duplicate null model still uses first value",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"model":null,"model":"gpt-image-2"}`),
+			want:     false,
+		},
+		{
+			name:     "duplicate tools uses first value",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"tools":[],"tools":[{"type":"image_generation"}]}`),
+			want:     false,
+		},
+		{
+			name:     "duplicate input uses first value",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"input":[],"input":[{"type":"additional_tools","tools":[{"type":"namespace","name":"image_gen"}]}]}`),
+			want:     false,
+		},
+		{
+			name:     "duplicate tool choice uses first value",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"tool_choice":"required","tool_choice":{"type":"image_generation"}}`),
+			want:     false,
+		},
+		{
+			name:     "escaped top level key",
+			endpoint: "/v1/responses",
+			body:     []byte(`{"tool_\u0063hoice":{"type":"image_generation"}}`),
+			want:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsImageGenerationIntent(tt.endpoint, "gpt-5.5", tt.body))
 		})
 	}
 }


### PR DESCRIPTION
## 问题
`IsImageGenerationIntent` 在完整 JSON validity 检查后，又对大 body 分别执行多次顶层 `GetBytes` 扫描。

## 修复
保留 `gjson.ValidBytes` 完整校验，随后一次零拷贝 root walk 提取首个 `model/tools/input/tool_choice`；命中图片意图或四字段均已确定后安全早停。

## 验证
- 覆盖 1 MiB Responses body、非法 JSON、首重复键、null 首值、escaped key、flat/namespace/additional_tools 及所有既有 tool_choice 组合。
- `go test ./internal/service -run '^(TestIsImageGenerationIntent|TestOpenAIWSForwarderIngress)' -count=1`
- `go test ./internal/service -count=1`
- 10 轮串行 benchmark：无图片、尾部 tool_choice、重复键分别快 30%～35%，相关路径约 `1.008 MiB/op -> 0 B/op`；前置图片工具和非法 JSON 无显著回归。

## 边界
不改 JSON 有效性要求、图片工具定义、map-backed variant、计费解析或调用次数。