### PR TITLE
feat(admin): 账号管理页新增【订阅类型】列（默认隐藏）

### DIFF
--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -146,6 +146,7 @@ export default {
         name: 'Name',
         id: 'Account ID',
         platformType: 'Platform/Type',
+        subscriptionType: 'Subscription Type',
         platform: 'Platform',
         type: 'Type',
         capacity: 'Capacity',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -102,6 +102,7 @@ export default {
         name: '名称',
         id: '账号ID',
         platformType: '平台/类型',
+        subscriptionType: '订阅类型',
         platform: '平台',
         type: '类型',
         capacity: '容量',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -257,6 +257,11 @@
               </div>
             </div>
           </template>
+          <template #cell-subscription_type="{ row }">
+            <span class="whitespace-nowrap text-sm text-gray-700 dark:text-gray-300">
+              {{ getCredentialPlanType(row) }}
+            </span>
+          </template>
           <template #cell-capacity="{ row }">
             <AccountCapacityCell :account="row" />
           </template>
@@ -548,11 +553,19 @@ const exportingData = ref(false)
 const showAccountToolsDropdown = ref(false)
 const accountToolsDropdownRef = ref<HTMLElement | null>(null)
 const hiddenColumns = reactive<Set<string>>(new Set())
-const DEFAULT_HIDDEN_COLUMNS = ['today_stats', 'proxy', 'notes', 'priority', 'scheduler_score', 'rate_multiplier']
+const DEFAULT_HIDDEN_COLUMNS = [
+  'subscription_type',
+  'today_stats',
+  'proxy',
+  'notes',
+  'priority',
+  'scheduler_score',
+  'rate_multiplier'
+]
 const HIDDEN_COLUMNS_KEY = 'account-hidden-columns'
-// One-time migration: hide scheduler score for existing admins too, because showing it opt-ins to heavy backend scoring.
 const HIDDEN_COLUMNS_VERSION_KEY = 'account-hidden-columns-version'
-const HIDDEN_COLUMNS_CURRENT_VERSION = 'scheduler-score-hidden-by-default'
+const HIDDEN_COLUMNS_SCHEDULER_SCORE_VERSION = 'scheduler-score-hidden-by-default'
+const HIDDEN_COLUMNS_CURRENT_VERSION = 'subscription-type-hidden-by-default'
 
 // Sorting settings
 const ACCOUNT_SORT_STORAGE_KEY = 'account-table-sort'
@@ -708,9 +721,14 @@ const loadSavedColumns = () => {
       parsed.forEach(key => {
         hiddenColumns.add(key)
       })
-      // Older saved column layouts may have scheduler_score visible; migrate them to the new safe default once.
-      if (localStorage.getItem(HIDDEN_COLUMNS_VERSION_KEY) !== HIDDEN_COLUMNS_CURRENT_VERSION) {
-        hiddenColumns.add('scheduler_score')
+      const savedVersion = localStorage.getItem(HIDDEN_COLUMNS_VERSION_KEY)
+      if (savedVersion !== HIDDEN_COLUMNS_CURRENT_VERSION) {
+        // Layouts predating the scheduler-score migration still need its safe default.
+        if (savedVersion !== HIDDEN_COLUMNS_SCHEDULER_SCORE_VERSION) {
+          hiddenColumns.add('scheduler_score')
+        }
+        // Existing admins should opt in to the newly added subscription type column too.
+        hiddenColumns.add('subscription_type')
         localStorage.setItem(HIDDEN_COLUMNS_KEY, JSON.stringify([...hiddenColumns]))
         localStorage.setItem(HIDDEN_COLUMNS_VERSION_KEY, HIDDEN_COLUMNS_CURRENT_VERSION)
       }
@@ -1167,6 +1185,11 @@ function getAccountPlanType(row: any): string | undefined {
   return row.credentials?.plan_type || row.parent_plan_type || undefined
 }
 
+function getCredentialPlanType(row: Account): string {
+  const planType = row.credentials?.plan_type
+  return typeof planType === 'string' && planType.trim() ? planType.trim() : '-'
+}
+
 // Antigravity 订阅等级辅助函数
 function getAntigravityTierFromRow(row: any): string | null {
   if (row.platform !== 'antigravity') return null
@@ -1261,6 +1284,7 @@ const allColumns = computed(() => {
     { key: 'name', label: t('admin.accounts.columns.name'), sortable: true },
     { key: 'id', label: t('admin.accounts.columns.id'), sortable: true },
     { key: 'platform_type', label: t('admin.accounts.columns.platformType'), sortable: false },
+    { key: 'subscription_type', label: t('admin.accounts.columns.subscriptionType'), sortable: false },
     { key: 'capacity', label: t('admin.accounts.columns.capacity'), sortable: false },
     { key: 'status', label: t('admin.accounts.columns.status'), sortable: true },
     { key: 'schedulable', label: t('admin.accounts.columns.schedulable'), sortable: true },

--- a/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
@@ -170,9 +170,16 @@ const mountViewWithRow = () =>
         DataTable: {
           props: ['data', 'columns', 'loading'],
           template: `<div>
+            <div data-test="column-keys">{{ (columns || []).map((column) => column.key).join(',') }}</div>
             <div v-for="(row, idx) in (data || [])" :key="idx">
               <slot name="cell-name" :row="row" :value="row.name" />
               <slot name="cell-platform_type" :row="row" />
+              <div
+                v-if="(columns || []).some((column) => column.key === 'subscription_type')"
+                :data-test="'subscription-type-' + row.id"
+              >
+                <slot name="cell-subscription_type" :row="row" />
+              </div>
             </div>
           </div>`
         },
@@ -325,6 +332,57 @@ describe('admin AccountsView — 影子行 parent_* OR 兜底展示', () => {
       'BASIC',
       'SuperGrok',
     ])
+
+    wrapper.unmount()
+  })
+
+  it('migrates existing column preferences with subscription type hidden without re-hiding scheduler score', async () => {
+    localStorage.setItem('account-hidden-columns', JSON.stringify(['today_stats']))
+    localStorage.setItem('account-hidden-columns-version', 'scheduler-score-hidden-by-default')
+    listAccounts.mockResolvedValue({ items: [], total: 0, page: 1, page_size: 20, pages: 0 })
+
+    const wrapper = mountViewWithRow()
+    await flushPromises()
+
+    const columnKeys = wrapper.get('[data-test="column-keys"]').text().split(',')
+    expect(columnKeys).not.toContain('subscription_type')
+    expect(columnKeys).toContain('scheduler_score')
+    expect(JSON.parse(localStorage.getItem('account-hidden-columns') || '[]')).toContain('subscription_type')
+    expect(localStorage.getItem('account-hidden-columns-version')).toBe('subscription-type-hidden-by-default')
+
+    wrapper.unmount()
+  })
+
+  it('shows credentials.plan_type after the admin enables the subscription type column', async () => {
+    listAccounts.mockResolvedValue({
+      items: [
+        { id: 301, name: 'plus-account', platform: 'openai', type: 'oauth', credentials: { plan_type: 'Plus' } },
+        { id: 302, name: 'unknown-account', platform: 'openai', type: 'oauth', credentials: {} },
+      ],
+      total: 2,
+      page: 1,
+      page_size: 20,
+      pages: 1,
+    })
+
+    const wrapper = mountViewWithRow()
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="column-keys"]').text().split(',')).not.toContain('subscription_type')
+    expect(wrapper.find('[data-test="subscription-type-301"]').exists()).toBe(false)
+
+    await wrapper.get('button[title="admin.accounts.moreActions"]').trigger('click')
+    const toggle = wrapper
+      .findAll('button')
+      .find((button) => button.text().includes('admin.accounts.columns.subscriptionType'))
+    expect(toggle).toBeTruthy()
+    await toggle!.trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="column-keys"]').text().split(',')).toContain('subscription_type')
+    expect(wrapper.get('[data-test="subscription-type-301"]').text()).toBe('Plus')
+    expect(wrapper.get('[data-test="subscription-type-302"]').text()).toBe('-')
+    expect(JSON.parse(localStorage.getItem('account-hidden-columns') || '[]')).not.toContain('subscription_type')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## Summary
- 在账号管理表格新增 **订阅类型** 列，展示 `credentials.plan_type`（如 Pro / Free / Plus），空值显示 `-`
- 列默认隐藏，可在列设置中按需开启
- 通过本地列布局版本迁移，让已有管理员同样默认隐藏该列，且不会重复隐藏已完成 scheduler_score 迁移的用户可见的调度权值列

## Test plan
- [x] `vitest run src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts`（6 tests passed）
- [ ] 打开账号管理页，确认默认不显示「订阅类型」
- [ ] 通过列设置开启后，确认显示 `credentials.plan_type`
- [ ] 无 `plan_type` 时显示 `-`
- [ ] 刷新后列可见性偏好保持

---

I have read the CLA Document and I hereby sign the CLA