### PR TITLE
fix(openai): include proxy host in websocket_proxy_failed logs

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1739,12 +1739,23 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
 			closeStatus, closeReason := summarizeWSCloseErrorForLog(err)
-			reqLog.Warn("openai.websocket_proxy_failed",
+			proxyFailedFields := []zap.Field{
 				zap.Int64("account_id", account.ID),
 				zap.Error(err),
 				zap.String("close_status", closeStatus),
 				zap.String("close_reason", closeReason),
-			)
+			}
+			if account.Proxy != nil {
+				proxyFailedFields = append(proxyFailedFields,
+					zap.Int64("proxy_id", account.Proxy.ID),
+					zap.String("proxy_name", account.Proxy.Name),
+					zap.String("proxy_host", account.Proxy.Host),
+					zap.Int("proxy_port", account.Proxy.Port),
+				)
+			} else if account.ProxyID != nil {
+				proxyFailedFields = append(proxyFailedFields, zap.Int64p("proxy_id", account.ProxyID))
+			}
+			reqLog.Warn("openai.websocket_proxy_failed", proxyFailedFields...)
 			if errors.As(err, &closeErr) {
 				closeOpenAIClientWS(wsConn, closeErr.StatusCode(), closeErr.Reason())
 				return


### PR DESCRIPTION
## Summary
- Enrich `openai.websocket_proxy_failed` structured logs with proxy identity fields (`proxy_id`, `proxy_name`, `proxy_host`, `proxy_port`)
- When only `proxy_id` is present (proxy edge not loaded), still log `proxy_id`
- Aligns with the existing `gateway.forward_failed` logging pattern so operators can tell which outbound proxy failed during OpenAI Responses WebSocket proxying

## Test plan
- [ ] Trigger an OpenAI Responses WS path that hits `openai.websocket_proxy_failed` with an account bound to a proxy; confirm log includes `proxy_host` / related fields
- [ ] Same path with an account without proxy; confirm log still succeeds and omits proxy fields
- [ ] `go build ./internal/handler/` (or relevant package tests)