### PR TITLE
fix(openai): include proxy host in upstream_failover_switching logs

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -479,12 +479,23 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 						h.handleFailoverExhausted(c, failoverErr, streamStarted)
 						return
 					}
-					reqLog.Warn("openai.upstream_failover_switching",
+					failoverSwitchFields := []zap.Field{
 						zap.Int64("account_id", account.ID),
 						zap.Int("upstream_status", failoverErr.StatusCode),
 						zap.Int("switch_count", switchCount),
 						zap.Int("max_switches", maxAccountSwitches),
-					)
+					}
+					if account.Proxy != nil {
+						failoverSwitchFields = append(failoverSwitchFields,
+							zap.Int64("proxy_id", account.Proxy.ID),
+							zap.String("proxy_name", account.Proxy.Name),
+							zap.String("proxy_host", account.Proxy.Host),
+							zap.Int("proxy_port", account.Proxy.Port),
+						)
+					} else if account.ProxyID != nil {
+						failoverSwitchFields = append(failoverSwitchFields, zap.Int64p("proxy_id", account.ProxyID))
+					}
+					reqLog.Warn("openai.upstream_failover_switching", failoverSwitchFields...)
 					continue
 				}
 				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)


### PR DESCRIPTION
## Summary
- Enrich `openai.upstream_failover_switching` structured logs with proxy identity fields (`proxy_id`, `proxy_name`, `proxy_host`, `proxy_port`)
- When only `proxy_id` is present (proxy edge not loaded), still log `proxy_id`
- Aligns with the existing `gateway.forward_failed` / `openai.websocket_proxy_failed` logging pattern so operators can tell which outbound proxy was in use when OpenAI Responses failover switches accounts

## Test plan
- [ ] Trigger OpenAI Responses path that hits `openai.upstream_failover_switching` with an account bound to a proxy; confirm log includes `proxy_host` / related fields
- [ ] Same path with an account without proxy; confirm log still succeeds and omits proxy fields
- [ ] `go build ./internal/handler/`