### PR TITLE
fix: 修复 GPT-5.6 长上下文账号成本统计

### DIFF
--- a/backend/internal/service/account_stats_pricing.go
+++ b/backend/internal/service/account_stats_pricing.go
@@ -65,6 +65,13 @@ func tryModelFilePricing(billingService *BillingService, model string, tokens Us
 	if err != nil || pricing == nil {
 		return nil
 	}
+	if billingService.shouldApplySessionLongContextPricing(tokens, pricing) {
+		breakdown, err := billingService.CalculateCost(model, tokens, 1)
+		if err != nil || breakdown == nil || breakdown.TotalCost <= 0 {
+			return nil
+		}
+		return &breakdown.TotalCost
+	}
 	cost := float64(tokens.InputTokens)*pricing.InputPricePerToken +
 		float64(tokens.OutputTokens)*pricing.OutputPricePerToken +
 		float64(tokens.CacheCreationTokens)*pricing.CacheCreationPricePerToken +

--- a/backend/internal/service/account_stats_pricing_test.go
+++ b/backend/internal/service/account_stats_pricing_test.go
@@ -459,6 +459,26 @@ func TestTryModelFilePricing_Success(t *testing.T) {
 	require.InDelta(t, 0.2, *result, 1e-12)
 }
 
+func TestTryModelFilePricing_AppliesLongContextPricing(t *testing.T) {
+	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{
+		"gpt-5.6-sol": {
+			InputPricePerToken:          0.001,
+			OutputPricePerToken:         0.002,
+			CacheReadPricePerToken:      0.0001,
+			LongContextInputThreshold:   100,
+			LongContextInputMultiplier:  2,
+			LongContextOutputMultiplier: 1.5,
+		},
+	})
+	tokens := UsageTokens{InputTokens: 101, OutputTokens: 10, CacheReadTokens: 5}
+
+	result := tryModelFilePricing(bs, "gpt-5.6-sol", tokens)
+
+	require.NotNil(t, result)
+	// Input and cache-read use the 2x input tier; output uses the 1.5x tier.
+	require.InDelta(t, 0.233, *result, 1e-12)
+}
+
 func TestTryModelFilePricing_PricingNotFound(t *testing.T) {
 	// "nonexistent-model" does not match any fallback pattern
 	bs := newTestBillingServiceWithPrices(map[string]*ModelPricing{})


### PR DESCRIPTION
## 问题

首页模型分布中的“成本”使用账号统计定价回退路径。该路径读取模型文件后按基础单价直接计算，没有复用 GPT-5.6 超过 272K 输入时的长上下文计费规则，导致 1x 倍率下成本与标准价格不一致。

## 根因

`tryModelFilePricing` 对模型文件价格始终执行平价 token 计算，绕过了 `BillingService.CalculateCost` 中已经实现并由上游接受的长上下文倍率逻辑。

## 改动

- 当模型价格与 token 用量命中长上下文规则时，复用现有完整计费函数计算账号统计成本。
- 非长上下文及其他模型继续使用原有平价路径，保持现有行为。
- 增加 GPT-5.6 输入、输出和缓存读取长上下文倍率的回归测试。

## 测试

- `cd backend && /tmp/go1.26.5/bin/go test -tags=unit ./internal/service -run 'TestTryModelFilePricing|TestResolveAccountStatsCost' -count=1`
- `cd backend && /tmp/go1.26.5/bin/go vet -tags=unit ./internal/service`
- `git diff --check`

Fixes #4285