### PR TITLE
fix(antigravity): 保留手动输入的 refresh token

### DIFF
--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -5728,7 +5728,7 @@ const handleAntigravityValidateRT = async (refreshTokenInput: string) => {
           continue
         }
 
-        const credentials = antigravityOAuth.buildCredentials(tokenInfo)
+        const credentials = antigravityOAuth.buildCredentials(tokenInfo, refreshTokens[i])
         applyAntigravityProjectID(credentials, antigravityProjectId.value, 'create')
         
         // Generate account name with index for batch

--- a/frontend/src/composables/__tests__/useAntigravityOAuth.spec.ts
+++ b/frontend/src/composables/__tests__/useAntigravityOAuth.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({
+    showError: vi.fn()
+  })
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key
+  })
+}))
+
+vi.mock('@/api/admin', () => ({
+  adminAPI: {
+    antigravity: {
+      generateAuthUrl: vi.fn(),
+      exchangeCode: vi.fn(),
+      refreshAntigravityToken: vi.fn()
+    }
+  }
+}))
+
+import { useAntigravityOAuth } from '@/composables/useAntigravityOAuth'
+
+describe('useAntigravityOAuth.buildCredentials', () => {
+  it('falls back to the submitted refresh token when the response omits it', () => {
+    const oauth = useAntigravityOAuth()
+
+    const credentials = oauth.buildCredentials(
+      {
+        access_token: 'access-token',
+        expires_at: 1_900_000_000
+      },
+      'submitted-refresh-token'
+    )
+
+    expect(credentials.refresh_token).toBe('submitted-refresh-token')
+  })
+
+  it('prefers a new refresh token returned by the response', () => {
+    const oauth = useAntigravityOAuth()
+
+    const credentials = oauth.buildCredentials(
+      {
+        access_token: 'access-token',
+        refresh_token: 'rotated-refresh-token',
+        expires_at: 1_900_000_000
+      },
+      'submitted-refresh-token'
+    )
+
+    expect(credentials.refresh_token).toBe('rotated-refresh-token')
+  })
+})

--- a/frontend/src/composables/useAntigravityOAuth.ts
+++ b/frontend/src/composables/useAntigravityOAuth.ts
@@ -112,17 +112,23 @@ export function useAntigravityOAuth() {
     }
   }
 
-  const buildCredentials = (tokenInfo: AntigravityTokenInfo): Record<string, unknown> => {
+  const buildCredentials = (
+    tokenInfo: AntigravityTokenInfo,
+    fallbackRefreshToken?: string
+  ): Record<string, unknown> => {
     let expiresAt: string | undefined
     if (typeof tokenInfo.expires_at === 'number' && Number.isFinite(tokenInfo.expires_at)) {
       expiresAt = Math.floor(tokenInfo.expires_at).toString()
     } else if (typeof tokenInfo.expires_at === 'string' && tokenInfo.expires_at.trim()) {
       expiresAt = tokenInfo.expires_at.trim()
     }
+    const refreshToken = tokenInfo.refresh_token?.trim()
+      ? tokenInfo.refresh_token
+      : fallbackRefreshToken
 
     return {
       access_token: tokenInfo.access_token,
-      refresh_token: tokenInfo.refresh_token,
+      refresh_token: refreshToken,
       token_type: tokenInfo.token_type,
       expires_at: expiresAt,
       project_id: tokenInfo.project_id,


### PR DESCRIPTION
## 问题

通过手动输入 Refresh Token 创建 Antigravity 账号时，如果上游刷新响应没有返回新的 `refresh_token`，最终保存的账号凭据中该字段为空。Access Token 过期后，账号无法继续自动刷新并提示重新授权。

## 根因

`handleAntigravityValidateRT` 使用用户提交的 RT 完成校验，但 `buildCredentials` 只复制刷新响应中的 `refresh_token`。OAuth Provider 允许刷新响应省略未轮换的 Refresh Token，此时原始 RT 没有被保留。

## 修复

- 手动 RT 创建路径将用户提交的原始 RT 传给凭据构建函数作为回退值。
- 刷新响应返回非空新 RT 时仍优先保存新值；省略或返回空白 RT 时保存原始 RT。
- 增加单元测试覆盖“响应省略 RT 时回退”和“响应返回新 RT 时优先使用新值”。

## 测试

验证结果：

1. `corepack pnpm exec vitest run src/composables/__tests__/useAntigravityOAuth.spec.ts src/composables/__tests__/useOpenAIOAuth.spec.ts src/composables/__tests__/useGrokOAuth.spec.ts`，3 个文件、8 条测试通过
2. `corepack pnpm exec vue-tsc --noEmit`，通过
3. `corepack pnpm exec eslint src/composables/useAntigravityOAuth.ts src/composables/__tests__/useAntigravityOAuth.spec.ts src/components/account/CreateAccountModal.vue`，通过
4. `git diff --check`，通过

Fixes #4287