### PR TITLE
fix(apicompat): 并行 tool_use 幽灵 content_block_delta（index 错误）

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -452,10 +452,20 @@ func resToAnthHandleFuncArgsDone(evt *ResponsesStreamEvent, state *ResponsesEven
 		raw = string(sanitized)
 	}
 
-	idx := state.ContentBlockIndex
+	// 从事件的 OutputIndex 解析正确的 block index，与 resToAnthHandleFuncArgsDelta 对齐
+	blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
+	if !ok {
+		blockIdx = state.ContentBlockIndex
+	}
+
+	// 如果 block 已关闭（ContentBlockIndex 已越过它），说明 arguments 已通过 delta 流式发完，不再补发
+	if !state.ContentBlockOpen || blockIdx != state.ContentBlockIndex {
+		return nil
+	}
+
 	events := []AnthropicStreamEvent{{
 		Type:  "content_block_delta",
-		Index: &idx,
+		Index: &blockIdx,
 		Delta: &AnthropicDelta{
 			Type:        "input_json_delta",
 			PartialJSON: raw,

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func intPtr(v int) *int { return &v }
+func intPtr(v int) *int       { return &v }
 func strPtr(s string) *string { return &s }
 
 // TestStreamingParallelToolUseNoGhostDelta reproduces the bug from issue #4193:

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_test.go
@@ -1,0 +1,277 @@
+package apicompat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func intPtr(v int) *int { return &v }
+func strPtr(s string) *string { return &s }
+
+// TestStreamingParallelToolUseNoGhostDelta reproduces the bug from issue #4193:
+// when the CC→Responses→Anthropic bridge finalizes parallel tool calls whose
+// arguments arrived packed in function_call_arguments.done (no prior delta),
+// resToAnthHandleFuncArgsDone used state.ContentBlockIndex directly instead of
+// looking up OutputIndexToBlockIdx. After the first tool's block was closed
+// (ContentBlockIndex++), the second tool's .done emitted a content_block_delta
+// on an index that was never content_block_start'ed — Claude Code reports
+// "Content block not found".
+//
+// This test drives the full finalize path: CC chunks with two parallel
+// tool_calls → ChatCompletionsChunkToResponsesEvents → FinalizeChatCompletionsResponsesStream
+// → ResponsesEventToAnthropicEvents, and asserts every content_block_delta
+// targets a block that was previously content_block_start'ed.
+func TestStreamingParallelToolUseNoGhostDelta(t *testing.T) {
+	ccState := NewChatCompletionsToResponsesStreamState("glm-5.2")
+	anthropicState := NewResponsesEventToAnthropicState()
+	anthropicState.Model = "glm-5.2"
+
+	// Chunk 1: first tool_call arrives with id + name + packed arguments.
+	chatChunk1 := &ChatCompletionsChunk{
+		ID:    "chatcmpl-1",
+		Model: "glm-5.2",
+		Choices: []ChatChunkChoice{{
+			Index: 0,
+			Delta: ChatDelta{
+				ToolCalls: []ChatToolCall{{
+					Index: intPtr(0),
+					ID:    "call_weather",
+					Type:  "function",
+					Function: ChatFunctionCall{
+						Name:      "get_weather",
+						Arguments: `{"city":"Tokyo"}`,
+					},
+				}},
+			},
+		}},
+	}
+
+	// Chunk 2: second tool_call arrives with id + name + packed arguments.
+	chatChunk2 := &ChatCompletionsChunk{
+		ID:    "chatcmpl-1",
+		Model: "glm-5.2",
+		Choices: []ChatChunkChoice{{
+			Index: 0,
+			Delta: ChatDelta{
+				ToolCalls: []ChatToolCall{{
+					Index: intPtr(1),
+					ID:    "call_time",
+					Type:  "function",
+					Function: ChatFunctionCall{
+						Name:      "get_time",
+						Arguments: `{}`,
+					},
+				}},
+			},
+		}},
+	}
+
+	// Chunk 3: finish.
+	chatChunk3 := &ChatCompletionsChunk{
+		ID:    "chatcmpl-1",
+		Model: "glm-5.2",
+		Choices: []ChatChunkChoice{{
+			Index:        0,
+			Delta:        ChatDelta{},
+			FinishReason: strPtr("tool_calls"),
+		}},
+	}
+
+	// Feed chunks through the CC→Responses bridge, then through Responses→Anthropic.
+	var allAnthropicEvents []AnthropicStreamEvent
+	for _, chunk := range []*ChatCompletionsChunk{chatChunk1, chatChunk2, chatChunk3} {
+		responsesEvents := ChatCompletionsChunkToResponsesEvents(chunk, ccState)
+		for _, rEvent := range responsesEvents {
+			allAnthropicEvents = append(allAnthropicEvents, ResponsesEventToAnthropicEvents(&rEvent, anthropicState)...)
+		}
+	}
+
+	// Finalize: closeChatToolItems emits function_call_arguments.done for each tool.
+	finalResponsesEvents := FinalizeChatCompletionsResponsesStream(ccState)
+	for _, rEvent := range finalResponsesEvents {
+		allAnthropicEvents = append(allAnthropicEvents, ResponsesEventToAnthropicEvents(&rEvent, anthropicState)...)
+	}
+
+	// Build the set of block indices that were content_block_start'ed.
+	startedBlocks := make(map[int]string) // index → block type
+	for _, e := range allAnthropicEvents {
+		if e.Type == "content_block_start" && e.ContentBlock != nil {
+			startedBlocks[*e.Index] = e.ContentBlock.Type
+		}
+	}
+
+	// Assert: every content_block_delta targets a started block (no ghost deltas).
+	for _, e := range allAnthropicEvents {
+		if e.Type != "content_block_delta" || e.Index == nil {
+			continue
+		}
+		idx := *e.Index
+		_, ok := startedBlocks[idx]
+		require.Truef(t, ok,
+			"content_block_delta on index %d which was never content_block_start'ed (ghost delta bug #4193)", idx)
+	}
+
+	// Assert: every content_block_stop targets a started block.
+	for _, e := range allAnthropicEvents {
+		if e.Type != "content_block_stop" || e.Index == nil {
+			continue
+		}
+		idx := *e.Index
+		_, ok := startedBlocks[idx]
+		require.Truef(t, ok,
+			"content_block_stop on index %d which was never content_block_start'ed", idx)
+	}
+
+	// Assert: both tool_use blocks were opened.
+	var toolUseBlocks []int
+	for idx, blockType := range startedBlocks {
+		if blockType == "tool_use" {
+			toolUseBlocks = append(toolUseBlocks, idx)
+		}
+	}
+	assert.Len(t, toolUseBlocks, 2, "both parallel tool_use blocks should be opened")
+
+	// Assert: stop_reason is tool_use.
+	var sawMessageDelta bool
+	for _, e := range allAnthropicEvents {
+		if e.Type == "message_delta" {
+			sawMessageDelta = true
+			assert.Equal(t, "tool_use", e.Delta.StopReason)
+		}
+	}
+	assert.True(t, sawMessageDelta, "message_delta should be emitted")
+}
+
+// TestStreamingParallelToolUseSecondToolPackedArgsDone is a focused unit test
+// for the exact bug: two tools, the first streams its arguments via deltas
+// (CurrentToolHadDelta=true → closeCurrentBlock), the second has arguments
+// packed only in .done (CurrentToolHadDelta=false). Before the fix, the second
+// tool's .done emitted content_block_delta on state.ContentBlockIndex which
+// had already been incremented past the second tool's block.
+func TestStreamingParallelToolUseSecondToolPackedArgsDone(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	// response.created
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_par", Model: "glm-5.2"},
+	}, state)
+
+	// Tool 1: output_item.added (index 0)
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "function_call", CallID: "call_a", Name: "tool_a"},
+	}, state)
+
+	// Tool 1: arguments streamed via delta (CurrentToolHadDelta = true)
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 0,
+		Delta:       `{"x":1}`,
+	}, state)
+
+	// Tool 1: arguments.done → CurrentToolHadDelta=true → closeCurrentBlock
+	// ContentBlockIndex goes from 0 → 1
+	eventsTool1Done := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.done",
+		OutputIndex: 0,
+		Arguments:   `{"x":1}`,
+	}, state)
+	// Should only emit content_block_stop (delta already streamed)
+	for _, e := range eventsTool1Done {
+		assert.NotEqual(t, "content_block_delta", e.Type,
+			"tool 1 .done should not re-emit delta (args already streamed)")
+	}
+
+	// Tool 2: output_item.added (index 1) → opens block at ContentBlockIndex=1
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 1,
+		Item:        &ResponsesOutput{Type: "function_call", CallID: "call_b", Name: "tool_b"},
+	}, state)
+
+	// Tool 2: NO delta — arguments arrive packed in .done only.
+	// This is the exact scenario that triggered the ghost delta bug.
+	eventsTool2Done := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.done",
+		OutputIndex: 1,
+		Arguments:   `{"y":2}`,
+	}, state)
+
+	// The fix ensures the delta targets index 1 (the tool 2 block), not
+	// state.ContentBlockIndex (which would be 1 before close, matching by
+	// luck in this 2-tool case, but wrong in 3+ tool cases or when the
+	// block is already closed).
+	//
+	// The critical assertion: the delta must be on index 1 and must be
+	// followed by content_block_stop on the same index.
+	var sawDelta, sawStop bool
+	var deltaIndex, stopIndex int
+	for _, e := range eventsTool2Done {
+		if e.Type == "content_block_delta" && e.Index != nil {
+			sawDelta = true
+			deltaIndex = *e.Index
+			assert.Equal(t, "input_json_delta", e.Delta.Type)
+			assert.Equal(t, `{"y":2}`, e.Delta.PartialJSON)
+		}
+		if e.Type == "content_block_stop" && e.Index != nil {
+			sawStop = true
+			stopIndex = *e.Index
+		}
+	}
+	assert.True(t, sawDelta, "tool 2 .done with packed args should emit content_block_delta")
+	assert.True(t, sawStop, "tool 2 .done should close the block")
+	assert.Equal(t, 1, deltaIndex, "delta must target the tool 2 block (index 1)")
+	assert.Equal(t, deltaIndex, stopIndex, "delta and stop must be on the same block")
+}
+
+// TestStreamingThreeParallelToolsAllPackedDone tests the most extreme case:
+// three parallel tools, ALL with arguments packed in .done (no deltas at all).
+// Before the fix, tool 2 and tool 3 would emit ghost deltas on wrong indices.
+func TestStreamingThreeParallelToolsAllPackedDone(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_3par", Model: "glm-5.2"},
+	}, state)
+
+	// Open three tool blocks at indices 0, 1, 2.
+	for i, name := range []string{"tool_a", "tool_b", "tool_c"} {
+		ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+			Type:        "response.output_item.added",
+			OutputIndex: i,
+			Item:        &ResponsesOutput{Type: "function_call", CallID: "call_" + name, Name: name},
+		}, state)
+	}
+
+	// Track started blocks.
+	started := map[int]bool{0: true, 1: true, 2: true}
+
+	// All three .done events with packed arguments (no prior delta).
+	for i, args := range []string{`{"a":1}`, `{"b":2}`, `{"c":3}`} {
+		events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+			Type:        "response.function_call_arguments.done",
+			OutputIndex: i,
+			Arguments:   args,
+		}, state)
+
+		for _, e := range events {
+			if e.Type == "content_block_delta" && e.Index != nil {
+				idx := *e.Index
+				require.Truef(t, started[idx],
+					"ghost delta: tool %d .done emitted content_block_delta on index %d (never started)", i, idx)
+				require.Equal(t, i, idx,
+					"tool %d .done delta should target its own block index %d, got %d", i, i, idx)
+			}
+			if e.Type == "content_block_stop" && e.Index != nil {
+				idx := *e.Index
+				require.Truef(t, started[idx],
+					"ghost stop: tool %d .done emitted content_block_stop on index %d (never started)", i, idx)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 背景

`/v1/messages` 入站、上游为 OpenAI 兼容 `/v1/chat/completions`（GLM/DeepSeek 等国产模型）、客户端为 Claude Code 时，当上游在**一次响应中返回多个 tool_call（并行工具调用）**，Responses→Anthropic SSE 转换器会向一个从未 `content_block_start` 过的 index 发出 `content_block_delta`。Claude Code 找不到该 block，合成 `"API Error: Content block not found"`。

Fixes #4193

## 根因

`backend/internal/pkg/apicompat/responses_to_anthropic.go`，函数 `resToAnthHandleFuncArgsDone`：

```go
idx := state.ContentBlockIndex          // ← BUG: 直接用 state.ContentBlockIndex
events := []AnthropicStreamEvent{{
    Type:  "content_block_delta",
    Index: &idx,
    ...
}}
```

同文件的 `resToAnthHandleFuncArgsDelta` 正确地通过 `state.OutputIndexToBlockIdx[evt.OutputIndex]` 查找目标 block index。但 `resToAnthHandleFuncArgsDone` 直接用 `state.ContentBlockIndex`——如果前一个工具的 `.done` 已经被处理过，`closeCurrentBlock` 已经把 `ContentBlockIndex` 递增了，这个 index 就指向了一个从未 `content_block_start` 的 block。

### 触发序列（CC 回退路径下的并行工具调用）

GLM 返回 2+ 个 tool_call 时，`FinalizeChatCompletionsResponsesStream` → `closeChatToolItems` 依次为每个 tool 发 `function_call_arguments.done` + `output_item.done`。在 `ResponsesEventToAnthropicEvents` 中：

1. **Tool 1** `.done` → `resToAnthHandleFuncArgsDone` → `CurrentToolHadDelta == true` → `closeCurrentBlock` → `ContentBlockIndex++`
2. **Tool 2** `.done` → `resToAnthHandleFuncArgsDone` → `CurrentToolHadDelta == false`（arguments 是打包到达的，流中没有发过 delta）→ 走到 `idx := state.ContentBlockIndex` → 在**新** index 上发 `content_block_delta` → 然后 `closeCurrentBlock` 在同一 index 上发 `content_block_stop`

但这个 index 从未有过 `content_block_start`——block 是在之前的 index 上打开的，现在已经关闭了。Claude Code 收到一个不存在的 block 的 delta → `"Content block not found"`。

### 复现（修复前）

SSE 输出末尾：

```
event: content_block_stop     index=3                                    ← tool 2 正常关闭
event: content_block_delta    index=4  partial_json={"city":"Tokyo"}     ← 幽灵：index=4 从未 start
event: content_block_delta    index=4  partial_json={}                   ← 幽灵：同上
event: message_delta          stop_reason=tool_use
event: message_stop
```

## 修改

`backend/internal/pkg/apicompat/responses_to_anthropic.go`，函数 `resToAnthHandleFuncArgsDone`：

1. 从事件的 `OutputIndex` 解析正确的 block index（`state.OutputIndexToBlockIdx`），与 `resToAnthHandleFuncArgsDelta` 对齐
2. 如果 block 已关闭（`ContentBlockIndex` 已越过它），说明 arguments 已通过 delta 流式发完，不再补发

```go
// 从事件的 OutputIndex 解析正确的 block index，与 resToAnthHandleFuncArgsDelta 对齐
blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
if !ok {
    blockIdx = state.ContentBlockIndex
}

// 如果 block 已关闭（ContentBlockIndex 已越过它），说明 arguments 已通过 delta 流式发完，不再补发
if !state.ContentBlockOpen || blockIdx != state.ContentBlockIndex {
    return nil
}
```

## 兼容性说明

- 单个工具调用不受影响（`ContentBlockIndex` 未被递增，与原行为一致）
- 工具参数已通过 delta 流式发完的 `.done` 不再重复补发（`CurrentToolHadDelta` 检查已覆盖，本修复进一步收紧）
- `Read` 工具的 `sanitizeAnthropicToolUseInput` 清洗逻辑保持不变

## 测试

新增 `backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_test.go`，3 个回归测试：

- `TestStreamingParallelToolUseNoGhostDelta`：两个并行 tool_call 端到端，断言每个 `content_block_delta` 都指向已 `content_block_start` 的 block
- `TestStreamingParallelToolUseSecondToolPackedArgsDone`：tool 1 流式 delta + tool 2 打包 `.done` 的聚焦测试
- `TestStreamingThreeParallelToolsAllPackedDone`：三个工具全部打包 `.done`，最极端场景

### 验证结果

三个测试在**未修复代码上全部失败**（复现幽灵 delta）：

```
TestStreamingParallelToolUseNoGhostDelta:
  content_block_delta on index 2 which was never content_block_start'ed (ghost delta bug #4193)

TestStreamingThreeParallelToolsAllPackedDone:
  tool 0 .done delta should target its own block index 0, got 2
```

修复后全部通过：

```bash
go test ./internal/pkg/apicompat/... -run TestStreamingParallelToolUse -v
go test ./internal/pkg/apicompat/... -run TestStreamingThreeParallel -v
go test ./internal/pkg/apicompat/...  # 全量回归
```