### PR TITLE
fix(openai): preserve reset count on malformed details

### DIFF
--- a/backend/internal/service/openai_quota_reset_credits.go
+++ b/backend/internal/service/openai_quota_reset_credits.go
@@ -59,7 +59,7 @@ func parseOpenAIRateLimitResetCreditDetails(body []byte) (openAIRateLimitResetCr
 			payload.Data,
 		)
 		if err != nil {
-			return openAIRateLimitResetCreditDetails{}, err
+			return openAIRateLimitResetCreditDetails{AvailableCount: availableCount}, err
 		}
 	}
 

--- a/backend/internal/service/openai_quota_reset_credits_test.go
+++ b/backend/internal/service/openai_quota_reset_credits_test.go
@@ -83,6 +83,19 @@ func TestQueryUsageResetCreditCountPrecedence(t *testing.T) {
 			wantCredits: 1,
 		},
 		{
+			name:        "valid detail count survives malformed authoritative list",
+			usageBody:   `{"rate_limit_reset_credits":{"available_count":7,"credits":[{"expires_at":"usage-expiry"}]}}`,
+			detailBody:  `{"available_count":2,"credits":"malformed"}`,
+			wantCount:   2,
+			wantCredits: 1,
+		},
+		{
+			name:       "valid detail count creates quota despite malformed authoritative list",
+			usageBody:  `{}`,
+			detailBody: `{"available_count":2,"credits":"malformed"}`,
+			wantCount:  2,
+		},
+		{
 			name:       "negative detail count without list preserves usage",
 			usageBody:  `{"rate_limit_reset_credits":{"available_count":4}}`,
 			detailBody: `{"available_count":-1}`,

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -205,7 +205,9 @@ func (s *OpenAIQuotaService) queryResetCreditDetails(ctx context.Context, client
 	details, err := parseOpenAIRateLimitResetCreditDetails(resp.Bytes())
 	if err != nil {
 		slog.Warn("openai_quota_reset_credit_details_parse_failed", "account_id", accountID, "error", err)
-		return nil
+		if details.AvailableCount == nil {
+			return nil
+		}
 	}
 	if details.AvailableCount == nil && !details.CreditListPresent {
 		return nil


### PR DESCRIPTION
## Problem

The reset-credit details endpoint can contain a valid `available_count` while its `credits` field has an invalid container shape. The parser currently discards the entire details result when the list schema fails, so quota refresh either falls back to a stale usage snapshot or hides an otherwise valid reset-credit count.

This is a field-level error-path follow-up to #4225.

## Fix

- Preserve an independently parsed, valid `available_count` when parsing the authoritative credits list fails.
- Let the caller consume that partial result only when the count is present.
- Keep the malformed list fail-closed: it does not replace or clear an existing valid credit list.
- Preserve existing behavior for invalid JSON, missing/null/negative counts, explicit zero, and valid lists.

## Tests

The two new cases fail on current `main` before the implementation and pass afterward:

- a valid detail count overrides a stale usage count even when the detail list is malformed;
- a valid detail count can create quota state when no usage snapshot exists.

Verification:

- `go test ./internal/service -run TestQueryUsageResetCreditCountPrecedence -count=10`
- `go test -race ./internal/service -run TestParseOpenAIRateLimitResetCreditDetails\|TestQueryUsageResetCreditCountPrecedence -count=1`
- `go test ./internal/service -count=1`
- `golangci-lint v2.9`: 0 issues