### PR TITLE
fix(xai): reject empty base URL queries

### DIFF
--- a/backend/internal/pkg/xai/oauth.go
+++ b/backend/internal/pkg/xai/oauth.go
@@ -306,7 +306,7 @@ func normalizeKnownBaseURLPath(raw string) (string, error) {
 	if parsed.User != nil {
 		return "", errors.New("base URL must not include userinfo")
 	}
-	if parsed.RawQuery != "" {
+	if parsed.ForceQuery || parsed.RawQuery != "" {
 		return "", errors.New("base URL must not include a query")
 	}
 	if parsed.Fragment != "" {

--- a/backend/internal/pkg/xai/oauth_test.go
+++ b/backend/internal/pkg/xai/oauth_test.go
@@ -166,6 +166,14 @@ func TestValidateBaseURLAllowsPublicThirdPartyGrokAPI(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidateBaseURLsRejectEmptyQueryDelimiter(t *testing.T) {
+	_, err := ValidateBaseURL("https://grok.example.test/v1?")
+	require.Error(t, err)
+
+	_, err = ValidateTrustedBaseURL("https://api.x.ai/v1?")
+	require.Error(t, err)
+}
+
 func TestBuildResponsesURLWithValidatorUsesCallerPolicy(t *testing.T) {
 	validator := func(raw string) (string, error) {
 		return urlvalidator.ValidateURLFormat(raw, true)
@@ -192,6 +200,7 @@ func TestBuildResponsesURLWithValidatorRejectsBaseURLComponents(t *testing.T) {
 	}{
 		{name: "userinfo", raw: "https://user:secret@grok.example.test/v1"},
 		{name: "query", raw: "https://grok.example.test/v1?token=secret"},
+		{name: "empty query delimiter", raw: "https://grok.example.test/v1?"},
 		{name: "fragment", raw: "https://grok.example.test/v1#secret"},
 	}
 


### PR DESCRIPTION
## Problem

The latest `main` rejects XAI/Grok base URLs with userinfo, non-empty queries, and fragments. A bare query delimiter still bypasses that validation because Go represents `https://host/v1?` as `ForceQuery=true` with an empty `RawQuery`.

Request paths such as `/responses` are appended later, so even an empty query delimiter is not a supported base URL component and must follow the same safe-mode policy as a non-empty query.

## Fix

Treat `ForceQuery` as a query component in the shared XAI base URL normalizer:

```go
parsed.ForceQuery || parsed.RawQuery != ""
```

This keeps the current `main` behavior for public HTTPS hosts, trusted allowlisted hosts, `/v1` path normalization, and the explicit unsafe development override.

## Tests

Regression coverage verifies that a bare `?` is rejected by:

- public `ValidateBaseURL`;
- trusted `ValidateTrustedBaseURL`;
- the caller-policy URL builder.

Verification after rebasing onto current `main`:

- `go test ./... -count=1`
- `go test -tags=unit ./internal/pkg/xai -count=1`
- `go vet -tags=unit ./internal/pkg/xai`
- `git diff --check upstream/main...HEAD`
