### PR TITLE
fix(apicompat): serialize interleaved parallel tool_use blocks

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -3,6 +3,7 @@ package apicompat
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -165,19 +166,36 @@ func sanitizeAnthropicToolUseInput(name string, raw string) json.RawMessage {
 // Streaming: ResponsesStreamEvent → []AnthropicStreamEvent (stateful converter)
 // ---------------------------------------------------------------------------
 
+type pendingToolBlock struct {
+	OutputIndex int
+	CallID      string
+	Name        string
+
+	BufferedArgs string
+	FinalArgs    string
+
+	ArgsDone    bool
+	EmittedArgs string
+	Started     bool
+	Closed      bool
+}
+
 // ResponsesEventToAnthropicState tracks state for converting a sequence of
 // Responses SSE events directly into Anthropic SSE events.
 type ResponsesEventToAnthropicState struct {
 	MessageStartSent bool
 	MessageStopSent  bool
 
-	ContentBlockIndex   int
-	ContentBlockOpen    bool
-	CurrentBlockType    string // "text" | "thinking" | "tool_use"
-	CurrentToolName     string
-	CurrentToolArgs     string
-	CurrentToolHadDelta bool
-	HasToolCall         bool
+	ContentBlockIndex          int
+	ContentBlockOpen           bool
+	CurrentBlockType           string // "text" | "thinking" | "tool_use"
+	CurrentBlockOutputIndex    int
+	CurrentBlockHasOutputIndex bool
+	HasToolCall                bool
+
+	ActiveToolOutputIndex *int
+	PendingTools          map[int]*pendingToolBlock
+	ToolOrder             []int
 
 	// OutputIndexToBlockIdx maps Responses output_index → Anthropic content block index.
 	OutputIndexToBlockIdx map[int]int
@@ -196,6 +214,7 @@ type ResponsesEventToAnthropicState struct {
 func NewResponsesEventToAnthropicState() *ResponsesEventToAnthropicState {
 	return &ResponsesEventToAnthropicState{
 		OutputIndexToBlockIdx: make(map[int]int),
+		PendingTools:          make(map[int]*pendingToolBlock),
 		Created:               time.Now().Unix(),
 	}
 }
@@ -214,12 +233,13 @@ func ResponsesEventToAnthropicEvents(
 	case "response.output_text.delta":
 		return resToAnthHandleTextDelta(evt, state)
 	case "response.output_text.done":
-		return resToAnthHandleBlockDone(state)
+		return resToAnthHandleBlockDone(evt, state, "text")
 	case "response.function_call_arguments.delta",
 		// custom/freeform 工具的输入增量与 function_call 参数增量同形。
 		"response.custom_tool_call_input.delta":
 		return resToAnthHandleFuncArgsDelta(evt, state)
-	case "response.function_call_arguments.done":
+	case "response.function_call_arguments.done",
+		"response.custom_tool_call_input.done":
 		return resToAnthHandleFuncArgsDone(evt, state)
 	case "response.output_item.done":
 		return resToAnthHandleOutputItemDone(evt, state)
@@ -227,8 +247,9 @@ func ResponsesEventToAnthropicEvents(
 		// 原始推理文本增量，与 reasoning summary 一样映射为 thinking。
 		"response.reasoning_text.delta":
 		return resToAnthHandleReasoningDelta(evt, state)
-	case "response.reasoning_summary_text.done":
-		return resToAnthHandleBlockDone(state)
+	case "response.reasoning_summary_text.done",
+		"response.reasoning_text.done":
+		return resToAnthHandleBlockDone(evt, state, "thinking")
 	// response.done 是 Realtime/WS 与项目透传路径使用的终止别名；
 	// 普通 Responses HTTP SSE 的公开终止事件仍以 response.completed 为主。
 	case "response.completed", "response.done", "response.incomplete", "response.failed":
@@ -246,6 +267,10 @@ func FinalizeResponsesAnthropicStream(state *ResponsesEventToAnthropicState) []A
 	}
 
 	var events []AnthropicStreamEvent
+	if state.ContentBlockOpen && state.CurrentBlockType != "tool_use" {
+		events = append(events, closeCurrentBlock(state)...)
+	}
+	events = append(events, flushPendingToolBlocks(state, true)...)
 	events = append(events, closeCurrentBlock(state)...)
 
 	stopReason := "end_turn"
@@ -323,30 +348,29 @@ func resToAnthHandleOutputItemAdded(evt *ResponsesStreamEvent, state *ResponsesE
 	// 同样映射为 Anthropic 的 tool_use 块。
 	case "function_call", "custom_tool_call":
 		var events []AnthropicStreamEvent
-		events = append(events, closeCurrentBlock(state)...)
+		if state.ContentBlockOpen && state.CurrentBlockType != "tool_use" {
+			events = append(events, closeCurrentBlock(state)...)
+		}
 
-		idx := state.ContentBlockIndex
-		state.OutputIndexToBlockIdx[evt.OutputIndex] = idx
-		state.ContentBlockOpen = true
-		state.CurrentBlockType = "tool_use"
-		state.CurrentToolName = evt.Item.Name
-		state.CurrentToolArgs = ""
-		state.CurrentToolHadDelta = false
+		tool := ensurePendingToolBlock(state, evt.OutputIndex)
+		tool.CallID = evt.Item.CallID
+		tool.Name = evt.Item.Name
+		if evt.Item.Type == "custom_tool_call" && evt.Item.Input != "" {
+			tool.FinalArgs = evt.Item.Input
+		}
 		state.HasToolCall = true
 
-		events = append(events, AnthropicStreamEvent{
-			Type:  "content_block_start",
-			Index: &idx,
-			ContentBlock: &AnthropicContentBlock{
-				Type:  "tool_use",
-				ID:    fromResponsesCallID(evt.Item.CallID),
-				Name:  evt.Item.Name,
-				Input: json.RawMessage("{}"),
-			},
-		})
+		events = append(events, flushPendingToolBlocks(state, false)...)
 		return events
 
 	case "reasoning":
+		// A reasoning item can be followed by a late item notification after a
+		// tool block has already started. Anthropic allows only one active
+		// content block here, so never let that notification close the tool.
+		if state.ContentBlockOpen && state.CurrentBlockType == "tool_use" {
+			return nil
+		}
+
 		var events []AnthropicStreamEvent
 		events = append(events, closeCurrentBlock(state)...)
 
@@ -354,6 +378,8 @@ func resToAnthHandleOutputItemAdded(evt *ResponsesStreamEvent, state *ResponsesE
 		state.OutputIndexToBlockIdx[evt.OutputIndex] = idx
 		state.ContentBlockOpen = true
 		state.CurrentBlockType = "thinking"
+		state.CurrentBlockOutputIndex = evt.OutputIndex
+		state.CurrentBlockHasOutputIndex = true
 
 		events = append(events, AnthropicStreamEvent{
 			Type:  "content_block_start",
@@ -376,6 +402,12 @@ func resToAnthHandleTextDelta(evt *ResponsesStreamEvent, state *ResponsesEventTo
 	if evt.Delta == "" {
 		return nil
 	}
+	// A late text event must never close an active tool block. Tool blocks are
+	// serialized independently and advance only when their own arguments are
+	// complete.
+	if state.ContentBlockOpen && state.CurrentBlockType == "tool_use" {
+		return nil
+	}
 
 	var events []AnthropicStreamEvent
 
@@ -385,6 +417,8 @@ func resToAnthHandleTextDelta(evt *ResponsesStreamEvent, state *ResponsesEventTo
 		idx := state.ContentBlockIndex
 		state.ContentBlockOpen = true
 		state.CurrentBlockType = "text"
+		state.CurrentBlockOutputIndex = evt.OutputIndex
+		state.CurrentBlockHasOutputIndex = true
 
 		events = append(events, AnthropicStreamEvent{
 			Type:  "content_block_start",
@@ -408,41 +442,201 @@ func resToAnthHandleTextDelta(evt *ResponsesStreamEvent, state *ResponsesEventTo
 	return events
 }
 
+func ensurePendingToolBlock(state *ResponsesEventToAnthropicState, outputIndex int) *pendingToolBlock {
+	if state.PendingTools == nil {
+		state.PendingTools = make(map[int]*pendingToolBlock)
+	}
+	if tool, ok := state.PendingTools[outputIndex]; ok {
+		return tool
+	}
+	tool := &pendingToolBlock{OutputIndex: outputIndex}
+	state.PendingTools[outputIndex] = tool
+	state.ToolOrder = append(state.ToolOrder, outputIndex)
+	return tool
+}
+
+func findPendingToolBlock(
+	state *ResponsesEventToAnthropicState,
+	outputIndex int,
+	callID string,
+) *pendingToolBlock {
+	if tool := state.PendingTools[outputIndex]; tool != nil &&
+		(callID == "" || tool.CallID == "" || tool.CallID == callID) {
+		return tool
+	}
+	if callID != "" {
+		for _, queuedOutputIndex := range state.ToolOrder {
+			tool := state.PendingTools[queuedOutputIndex]
+			if tool != nil && tool.CallID == callID {
+				return tool
+			}
+		}
+	}
+	if tool := state.PendingTools[outputIndex]; tool != nil {
+		return tool
+	}
+	// Some compatible upstreams omit output_index on the final arguments event.
+	// If there is exactly one active tool, it is the only safe fallback.
+	if callID == "" && state.ActiveToolOutputIndex != nil {
+		return state.PendingTools[*state.ActiveToolOutputIndex]
+	}
+	return nil
+}
+
+func pendingToolArgsForEmission(tool *pendingToolBlock) string {
+	if tool.Name == "Read" {
+		if tool.EmittedArgs != "" {
+			return ""
+		}
+		raw := tool.FinalArgs
+		if raw == "" {
+			raw = tool.BufferedArgs
+		}
+		if raw == "" || !json.Valid([]byte(raw)) {
+			return ""
+		}
+		return string(sanitizeAnthropicToolUseInput(tool.Name, raw))
+	}
+
+	raw := tool.BufferedArgs
+	if tool.ArgsDone && tool.FinalArgs != "" {
+		switch {
+		case tool.EmittedArgs == "":
+			raw = tool.FinalArgs
+		case strings.HasPrefix(tool.FinalArgs, tool.EmittedArgs):
+			raw = strings.TrimPrefix(tool.FinalArgs, tool.EmittedArgs)
+		}
+	}
+	if raw == "" {
+		return ""
+	}
+	return raw
+}
+
+// flushPendingToolBlocks maintains exactly one active Anthropic tool_use block.
+// Later Grok tools remain queued until the active block is stopped; any deltas
+// received meanwhile are buffered and emitted after that tool's start event.
+func flushPendingToolBlocks(
+	state *ResponsesEventToAnthropicState,
+	force bool,
+) []AnthropicStreamEvent {
+	var events []AnthropicStreamEvent
+
+	if force {
+		for _, outputIndex := range state.ToolOrder {
+			if tool := state.PendingTools[outputIndex]; tool != nil && !tool.Closed {
+				tool.ArgsDone = true
+			}
+		}
+	}
+
+	for {
+		if state.ActiveToolOutputIndex != nil {
+			tool := state.PendingTools[*state.ActiveToolOutputIndex]
+			if tool == nil || tool.Closed {
+				state.ActiveToolOutputIndex = nil
+				continue
+			}
+
+			blockIdx, ok := state.OutputIndexToBlockIdx[tool.OutputIndex]
+			if !ok {
+				return events
+			}
+
+			raw := pendingToolArgsForEmission(tool)
+			if raw != "" {
+				events = append(events, AnthropicStreamEvent{
+					Type:  "content_block_delta",
+					Index: &blockIdx,
+					Delta: &AnthropicDelta{
+						Type:        "input_json_delta",
+						PartialJSON: raw,
+					},
+				})
+				tool.EmittedArgs += raw
+			}
+			tool.BufferedArgs = ""
+
+			if !tool.ArgsDone {
+				return events
+			}
+
+			events = append(events, closeCurrentBlock(state)...)
+			continue
+		}
+
+		if state.ContentBlockOpen {
+			return events
+		}
+
+		var next *pendingToolBlock
+		for _, outputIndex := range state.ToolOrder {
+			tool := state.PendingTools[outputIndex]
+			if tool != nil && !tool.Started && !tool.Closed {
+				next = tool
+				break
+			}
+		}
+		if next == nil {
+			return events
+		}
+
+		idx := state.ContentBlockIndex
+		state.OutputIndexToBlockIdx[next.OutputIndex] = idx
+		state.ContentBlockOpen = true
+		state.CurrentBlockType = "tool_use"
+		state.CurrentBlockOutputIndex = next.OutputIndex
+		state.CurrentBlockHasOutputIndex = true
+		activeOutputIndex := next.OutputIndex
+		state.ActiveToolOutputIndex = &activeOutputIndex
+		next.Started = true
+
+		events = append(events, AnthropicStreamEvent{
+			Type:  "content_block_start",
+			Index: &idx,
+			ContentBlock: &AnthropicContentBlock{
+				Type:  "tool_use",
+				ID:    fromResponsesCallID(next.CallID),
+				Name:  next.Name,
+				Input: json.RawMessage("{}"),
+			},
+		})
+	}
+}
+
 func resToAnthHandleFuncArgsDelta(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
 	if evt.Delta == "" {
 		return nil
 	}
 
-	if state.CurrentBlockType == "tool_use" && state.CurrentToolName == "Read" {
-		state.CurrentToolArgs += evt.Delta
-		if state.CurrentToolHadDelta || !json.Valid([]byte(state.CurrentToolArgs)) {
-			return nil
-		}
+	tool := findPendingToolBlock(state, evt.OutputIndex, evt.CallID)
+	if tool == nil {
+		tool = ensurePendingToolBlock(state, evt.OutputIndex)
+		tool.CallID = evt.CallID
+		tool.Name = evt.Name
+		state.HasToolCall = true
+	}
+	tool.FinalArgs += evt.Delta
 
-		blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
-		if !ok {
-			return nil
-		}
-		state.CurrentToolHadDelta = true
-		sanitized := sanitizeAnthropicToolUseInput(state.CurrentToolName, state.CurrentToolArgs)
-		return []AnthropicStreamEvent{{
-			Type:  "content_block_delta",
-			Index: &blockIdx,
-			Delta: &AnthropicDelta{
-				Type:        "input_json_delta",
-				PartialJSON: string(sanitized),
-			},
-		}}
+	// Read arguments must be sanitized as one complete JSON object. Keep its
+	// deltas in the pending-tool state until the accumulated input is valid;
+	// non-Read tools continue to stream partial JSON immediately.
+	if tool.Name == "Read" {
+		tool.BufferedArgs += evt.Delta
+		return flushPendingToolBlocks(state, false)
 	}
 
-	if state.CurrentBlockType == "tool_use" {
-		state.CurrentToolHadDelta = true
+	if state.ActiveToolOutputIndex == nil || *state.ActiveToolOutputIndex != tool.OutputIndex || !tool.Started || tool.Closed {
+		tool.BufferedArgs += evt.Delta
+		return flushPendingToolBlocks(state, false)
 	}
 
-	blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
+	blockIdx, ok := state.OutputIndexToBlockIdx[tool.OutputIndex]
 	if !ok {
+		tool.BufferedArgs += evt.Delta
 		return nil
 	}
+	tool.EmittedArgs += evt.Delta
 
 	return []AnthropicStreamEvent{{
 		Type:  "content_block_delta",
@@ -455,53 +649,32 @@ func resToAnthHandleFuncArgsDelta(evt *ResponsesStreamEvent, state *ResponsesEve
 }
 
 func resToAnthHandleFuncArgsDone(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
-	if !state.ContentBlockOpen {
-		return nil
-	}
-	if state.CurrentBlockType != "tool_use" {
-		return resToAnthHandleBlockDone(state)
+	tool := findPendingToolBlock(state, evt.OutputIndex, evt.CallID)
+	if tool == nil {
+		tool = ensurePendingToolBlock(state, evt.OutputIndex)
+		tool.CallID = evt.CallID
+		tool.Name = evt.Name
+		state.HasToolCall = true
 	}
 
 	raw := evt.Arguments
 	if raw == "" {
-		raw = state.CurrentToolArgs
+		raw = evt.Input
 	}
-	if raw == "" || state.CurrentToolHadDelta {
-		return closeCurrentBlock(state)
+	if raw != "" {
+		tool.FinalArgs = raw
 	}
-	if state.CurrentToolName == "Read" {
-		sanitized := sanitizeAnthropicToolUseInput(state.CurrentToolName, raw)
-		if len(sanitized) == 0 {
-			return closeCurrentBlock(state)
-		}
-		raw = string(sanitized)
-	}
-
-	// 从事件的 OutputIndex 解析正确的 block index，与 resToAnthHandleFuncArgsDelta 对齐
-	blockIdx, ok := state.OutputIndexToBlockIdx[evt.OutputIndex]
-	if !ok {
-		blockIdx = state.ContentBlockIndex
-	}
-
-	// 如果 block 已关闭（ContentBlockIndex 已越过它），说明 arguments 已通过 delta 流式发完，不再补发
-	if !state.ContentBlockOpen || blockIdx != state.ContentBlockIndex {
-		return nil
-	}
-
-	events := []AnthropicStreamEvent{{
-		Type:  "content_block_delta",
-		Index: &blockIdx,
-		Delta: &AnthropicDelta{
-			Type:        "input_json_delta",
-			PartialJSON: raw,
-		},
-	}}
-	events = append(events, closeCurrentBlock(state)...)
-	return events
+	tool.ArgsDone = true
+	return flushPendingToolBlocks(state, false)
 }
 
 func resToAnthHandleReasoningDelta(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
 	if evt.Delta == "" {
+		return nil
+	}
+	if !state.ContentBlockOpen ||
+		state.CurrentBlockType != "thinking" ||
+		(state.CurrentBlockHasOutputIndex && state.CurrentBlockOutputIndex != evt.OutputIndex) {
 		return nil
 	}
 
@@ -520,8 +693,18 @@ func resToAnthHandleReasoningDelta(evt *ResponsesStreamEvent, state *ResponsesEv
 	}}
 }
 
-func resToAnthHandleBlockDone(state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
+func resToAnthHandleBlockDone(
+	evt *ResponsesStreamEvent,
+	state *ResponsesEventToAnthropicState,
+	expectedBlockType string,
+) []AnthropicStreamEvent {
 	if !state.ContentBlockOpen {
+		return nil
+	}
+	if state.CurrentBlockType != expectedBlockType {
+		return nil
+	}
+	if state.CurrentBlockHasOutputIndex && state.CurrentBlockOutputIndex != evt.OutputIndex {
 		return nil
 	}
 	return closeCurrentBlock(state)
@@ -537,8 +720,34 @@ func resToAnthHandleOutputItemDone(evt *ResponsesStreamEvent, state *ResponsesEv
 		return resToAnthHandleWebSearchDone(evt, state)
 	}
 
-	if state.ContentBlockOpen {
-		return closeCurrentBlock(state)
+	if evt.Item.Type == "function_call" || evt.Item.Type == "custom_tool_call" {
+		tool := findPendingToolBlock(state, evt.OutputIndex, evt.Item.CallID)
+		if tool == nil {
+			tool = ensurePendingToolBlock(state, evt.OutputIndex)
+		}
+		if evt.Item.CallID != "" {
+			tool.CallID = evt.Item.CallID
+		}
+		if evt.Item.Name != "" {
+			tool.Name = evt.Item.Name
+		}
+		raw := evt.Item.Arguments
+		if raw == "" {
+			raw = evt.Item.Input
+		}
+		if raw != "" {
+			tool.FinalArgs = raw
+		}
+		tool.ArgsDone = true
+		state.HasToolCall = true
+		return flushPendingToolBlocks(state, false)
+	}
+
+	switch evt.Item.Type {
+	case "reasoning":
+		return resToAnthHandleBlockDone(evt, state, "thinking")
+	case "message":
+		return resToAnthHandleBlockDone(evt, state, "text")
 	}
 	return nil
 }
@@ -598,12 +807,50 @@ func resToAnthHandleWebSearchDone(evt *ResponsesStreamEvent, state *ResponsesEve
 	return events
 }
 
+func hydratePendingToolsFromCompletedResponse(
+	state *ResponsesEventToAnthropicState,
+	resp *ResponsesResponse,
+) {
+	if resp == nil {
+		return
+	}
+	for outputIndex, item := range resp.Output {
+		if item.Type != "function_call" && item.Type != "custom_tool_call" {
+			continue
+		}
+		tool := findPendingToolBlock(state, outputIndex, item.CallID)
+		if tool == nil {
+			tool = ensurePendingToolBlock(state, outputIndex)
+		}
+		if item.CallID != "" {
+			tool.CallID = item.CallID
+		}
+		if item.Name != "" {
+			tool.Name = item.Name
+		}
+		raw := item.Arguments
+		if raw == "" {
+			raw = item.Input
+		}
+		if raw != "" {
+			tool.FinalArgs = raw
+		}
+		tool.ArgsDone = true
+		state.HasToolCall = true
+	}
+}
+
 func resToAnthHandleCompleted(evt *ResponsesStreamEvent, state *ResponsesEventToAnthropicState) []AnthropicStreamEvent {
 	if state.MessageStopSent {
 		return nil
 	}
 
 	var events []AnthropicStreamEvent
+	hydratePendingToolsFromCompletedResponse(state, evt.Response)
+	if state.ContentBlockOpen && state.CurrentBlockType != "tool_use" {
+		events = append(events, closeCurrentBlock(state)...)
+	}
+	events = append(events, flushPendingToolBlocks(state, true)...)
 	events = append(events, closeCurrentBlock(state)...)
 
 	stopReason := "end_turn"
@@ -658,11 +905,17 @@ func closeCurrentBlock(state *ResponsesEventToAnthropicState) []AnthropicStreamE
 		return nil
 	}
 	idx := state.ContentBlockIndex
+	if state.CurrentBlockType == "tool_use" && state.ActiveToolOutputIndex != nil {
+		if tool := state.PendingTools[*state.ActiveToolOutputIndex]; tool != nil {
+			tool.Closed = true
+		}
+		state.ActiveToolOutputIndex = nil
+	}
 	state.ContentBlockOpen = false
 	state.ContentBlockIndex++
-	state.CurrentToolName = ""
-	state.CurrentToolArgs = ""
-	state.CurrentToolHadDelta = false
+	state.CurrentBlockType = ""
+	state.CurrentBlockOutputIndex = 0
+	state.CurrentBlockHasOutputIndex = false
 	return []AnthropicStreamEvent{{
 		Type:  "content_block_stop",
 		Index: &idx,

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_queue_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_parallel_tool_queue_test.go
@@ -1,0 +1,438 @@
+package apicompat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type capturedAnthropicToolBlock struct {
+	ID        string
+	Name      string
+	Arguments string
+}
+
+func assertAnthropicBlockLifecycle(
+	t *testing.T,
+	events []AnthropicStreamEvent,
+) []capturedAnthropicToolBlock {
+	t.Helper()
+
+	openBlocks := make(map[int]string)
+	toolsByBlockIndex := make(map[int]*capturedAnthropicToolBlock)
+	var toolOrder []int
+	sawMessageStop := false
+
+	for eventPosition, event := range events {
+		switch event.Type {
+		case "content_block_start":
+			require.NotNil(t, event.Index, "start event %d has no index", eventPosition)
+			require.NotNil(t, event.ContentBlock, "start event %d has no content block", eventPosition)
+			idx := *event.Index
+			_, alreadyOpen := openBlocks[idx]
+			require.False(t, alreadyOpen, "content block %d was started twice", idx)
+			openBlocks[idx] = event.ContentBlock.Type
+
+			if event.ContentBlock.Type == "tool_use" {
+				toolsByBlockIndex[idx] = &capturedAnthropicToolBlock{
+					ID:   event.ContentBlock.ID,
+					Name: event.ContentBlock.Name,
+				}
+				toolOrder = append(toolOrder, idx)
+			}
+
+		case "content_block_delta":
+			require.NotNil(t, event.Index, "delta event %d has no index", eventPosition)
+			idx := *event.Index
+			_, isOpen := openBlocks[idx]
+			require.True(t, isOpen, "delta event %d referenced closed or missing block %d", eventPosition, idx)
+
+			if event.Delta != nil && event.Delta.Type == "input_json_delta" {
+				tool := toolsByBlockIndex[idx]
+				require.NotNil(t, tool, "tool delta event %d referenced non-tool block %d", eventPosition, idx)
+				tool.Arguments += event.Delta.PartialJSON
+			}
+
+		case "content_block_stop":
+			require.NotNil(t, event.Index, "stop event %d has no index", eventPosition)
+			idx := *event.Index
+			_, isOpen := openBlocks[idx]
+			require.True(t, isOpen, "stop event %d referenced closed or missing block %d", eventPosition, idx)
+			delete(openBlocks, idx)
+
+		case "message_stop":
+			require.Empty(t, openBlocks, "message_stop emitted while content blocks remain open")
+			sawMessageStop = true
+		}
+	}
+
+	require.True(t, sawMessageStop, "stream did not emit message_stop")
+	require.Empty(t, openBlocks, "stream ended with content blocks still open")
+
+	tools := make([]capturedAnthropicToolBlock, 0, len(toolOrder))
+	for _, idx := range toolOrder {
+		tools = append(tools, *toolsByBlockIndex[idx])
+	}
+	return tools
+}
+
+func TestStreamingParallelToolsAreSerializedInAnthropicOrder(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	var allEvents []AnthropicStreamEvent
+	emit := func(event *ResponsesStreamEvent) []AnthropicStreamEvent {
+		events := ResponsesEventToAnthropicEvents(event, state)
+		allEvents = append(allEvents, events...)
+		return events
+	}
+
+	emit(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_parallel", Model: "grok-4.5"},
+	})
+
+	events := emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning"},
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.delta",
+		OutputIndex: 0,
+		Delta:       "Checking the workspace.",
+	})
+	require.Len(t, events, 1, "thinking must remain real-time")
+	assert.Equal(t, "thinking_delta", events[0].Delta.Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.done",
+		OutputIndex: 0,
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_stop", events[0].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.output_text.delta",
+		OutputIndex: 1,
+		Delta:       "I will run two tools.",
+	})
+	require.Len(t, events, 2, "text must remain real-time")
+	assert.Equal(t, "text_delta", events[1].Delta.Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.output_text.done",
+		OutputIndex: 1,
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_stop", events[0].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 2,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_first",
+			Name:   "TaskCreate",
+		},
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_start", events[0].Type)
+	assert.Equal(t, "call_first", events[0].ContentBlock.ID)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 3,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_second",
+			Name:   "Bash",
+		},
+	})
+	require.Empty(t, events, "a queued tool must not close or start over the active tool")
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 2,
+		CallID:      "call_first",
+		Delta:       `{"subject":"first"}`,
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_delta", events[0].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.done",
+		OutputIndex: 2,
+		CallID:      "call_first",
+		Arguments:   `{"subject":"first"}`,
+	})
+	require.Len(t, events, 2)
+	assert.Equal(t, "content_block_stop", events[0].Type)
+	assert.Equal(t, "content_block_start", events[1].Type)
+	assert.Equal(t, "call_second", events[1].ContentBlock.ID)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 3,
+		CallID:      "call_second",
+		Delta:       `{"command":"echo second"}`,
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_delta", events[0].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.done",
+		OutputIndex: 3,
+		CallID:      "call_second",
+		Arguments:   `{"command":"echo second"}`,
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, "content_block_stop", events[0].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			Status: "completed",
+			Usage:  &ResponsesUsage{InputTokens: 20, OutputTokens: 10},
+		},
+	})
+	require.Len(t, events, 2)
+	assert.Equal(t, "tool_use", events[0].Delta.StopReason)
+	assert.Equal(t, "message_stop", events[1].Type)
+
+	tools := assertAnthropicBlockLifecycle(t, allEvents)
+	require.Len(t, tools, 2)
+	assert.Equal(t, "call_first", tools[0].ID)
+	assert.Equal(t, "TaskCreate", tools[0].Name)
+	assert.JSONEq(t, `{"subject":"first"}`, tools[0].Arguments)
+	assert.Equal(t, "call_second", tools[1].ID)
+	assert.Equal(t, "Bash", tools[1].Name)
+	assert.JSONEq(t, `{"command":"echo second"}`, tools[1].Arguments)
+}
+
+func TestStreamingQueuedToolBuffersArgsAndIgnoresLateBlockDone(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	var allEvents []AnthropicStreamEvent
+	emit := func(event *ResponsesStreamEvent) []AnthropicStreamEvent {
+		events := ResponsesEventToAnthropicEvents(event, state)
+		allEvents = append(allEvents, events...)
+		return events
+	}
+
+	emit(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_interleaved", Model: "grok-4.5"},
+	})
+	emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "reasoning"},
+	})
+	emit(&ResponsesStreamEvent{
+		Type:        "response.reasoning_summary_text.delta",
+		OutputIndex: 0,
+		Delta:       "Planning.",
+	})
+	emit(&ResponsesStreamEvent{
+		Type:        "response.output_text.delta",
+		OutputIndex: 1,
+		Delta:       "Starting tools.",
+	})
+
+	events := emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 2,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_active",
+			Name:   "TaskCreate",
+		},
+	})
+	require.Len(t, events, 2)
+	assert.Equal(t, "content_block_stop", events[0].Type)
+	assert.Equal(t, "content_block_start", events[1].Type)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 3,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_queued",
+			Name:   "Bash",
+		},
+	})
+	require.Empty(t, events)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 3,
+		CallID:      "call_queued",
+		Delta:       `{"command":"queued"}`,
+	})
+	require.Empty(t, events, "queued tool arguments must stay in the gateway")
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.done",
+		OutputIndex: 3,
+		CallID:      "call_queued",
+		Arguments:   `{"command":"queued"}`,
+	})
+	require.Empty(t, events, "a completed queued tool must wait for the active tool")
+
+	for _, lateDone := range []*ResponsesStreamEvent{
+		{
+			Type:        "response.reasoning_summary_text.done",
+			OutputIndex: 0,
+		},
+		{
+			Type:        "response.output_text.done",
+			OutputIndex: 1,
+		},
+		{
+			Type:        "response.output_item.done",
+			OutputIndex: 0,
+			Item:        &ResponsesOutput{Type: "reasoning"},
+		},
+		{
+			Type:        "response.output_item.done",
+			OutputIndex: 1,
+			Item:        &ResponsesOutput{Type: "message"},
+		},
+	} {
+		require.Empty(t, emit(lateDone), "late thinking/text done must not close the active tool")
+		require.True(t, state.ContentBlockOpen)
+		assert.Equal(t, "tool_use", state.CurrentBlockType)
+		require.NotNil(t, state.ActiveToolOutputIndex)
+		assert.Equal(t, 2, *state.ActiveToolOutputIndex)
+	}
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 2,
+		CallID:      "call_active",
+		Delta:       `{"subject":"`,
+	})
+	require.Len(t, events, 1)
+	assert.Equal(t, `{"subject":"`, events[0].Delta.PartialJSON)
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.done",
+		OutputIndex: 2,
+		CallID:      "call_active",
+		Arguments:   `{"subject":"active"}`,
+	})
+	require.Len(t, events, 5)
+	assert.Equal(t, "content_block_delta", events[0].Type, "final arguments should fill the active prefix")
+	assert.Equal(t, `active"}`, events[0].Delta.PartialJSON)
+	assert.Equal(t, "content_block_stop", events[1].Type)
+	assert.Equal(t, "content_block_start", events[2].Type)
+	assert.Equal(t, "content_block_delta", events[3].Type)
+	assert.Equal(t, `{"command":"queued"}`, events[3].Delta.PartialJSON)
+	assert.Equal(t, "content_block_stop", events[4].Type)
+
+	emit(&ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			Status: "completed",
+		},
+	})
+
+	tools := assertAnthropicBlockLifecycle(t, allEvents)
+	require.Len(t, tools, 2)
+	assert.Equal(t, "call_active", tools[0].ID)
+	assert.Equal(t, "TaskCreate", tools[0].Name)
+	assert.JSONEq(t, `{"subject":"active"}`, tools[0].Arguments)
+	assert.Equal(t, "call_queued", tools[1].ID)
+	assert.Equal(t, "Bash", tools[1].Name)
+	assert.JSONEq(t, `{"command":"queued"}`, tools[1].Arguments)
+}
+
+func TestStreamingCompletedFlushesFinalArgumentsForPendingTools(t *testing.T) {
+	state := NewResponsesEventToAnthropicState()
+	var allEvents []AnthropicStreamEvent
+	emit := func(event *ResponsesStreamEvent) []AnthropicStreamEvent {
+		events := ResponsesEventToAnthropicEvents(event, state)
+		allEvents = append(allEvents, events...)
+		return events
+	}
+
+	emit(&ResponsesStreamEvent{
+		Type:     "response.created",
+		Response: &ResponsesResponse{ID: "resp_completed_fallback", Model: "grok-4.5"},
+	})
+	emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_read",
+			Name:   "Read",
+		},
+	})
+	emit(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 1,
+		Item: &ResponsesOutput{
+			Type:   "function_call",
+			CallID: "call_bash",
+			Name:   "Bash",
+		},
+	})
+
+	events := emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 0,
+		CallID:      "call_read",
+		Delta:       `{"file_path":"`,
+	})
+	require.Empty(t, events, "partial Read JSON must wait for terminal argument recovery")
+
+	events = emit(&ResponsesStreamEvent{
+		Type:        "response.function_call_arguments.delta",
+		OutputIndex: 1,
+		CallID:      "call_bash",
+		Delta:       `{"command":"`,
+	})
+	require.Empty(t, events)
+
+	events = emit(&ResponsesStreamEvent{
+		Type: "response.completed",
+		Response: &ResponsesResponse{
+			Status: "completed",
+			Output: []ResponsesOutput{
+				{
+					Type:      "function_call",
+					CallID:    "call_read",
+					Name:      "Read",
+					Arguments: `{"file_path":"README.md"}`,
+				},
+				{
+					Type:      "function_call",
+					CallID:    "call_bash",
+					Name:      "Bash",
+					Arguments: `{"command":"go test ./..."}`,
+				},
+			},
+		},
+	})
+	require.Len(t, events, 7)
+	assert.Equal(t, "content_block_delta", events[0].Type)
+	assert.JSONEq(t, `{"file_path":"README.md"}`, events[0].Delta.PartialJSON)
+	assert.Equal(t, "content_block_stop", events[1].Type)
+	assert.Equal(t, "content_block_start", events[2].Type)
+	assert.Equal(t, "content_block_delta", events[3].Type)
+	assert.Equal(t, "content_block_stop", events[4].Type)
+	assert.Equal(t, "message_delta", events[5].Type)
+	assert.Equal(t, "message_stop", events[6].Type)
+
+	tools := assertAnthropicBlockLifecycle(t, allEvents)
+	require.Len(t, tools, 2)
+	assert.Equal(t, "call_read", tools[0].ID)
+	assert.Equal(t, "Read", tools[0].Name)
+	assert.JSONEq(t, `{"file_path":"README.md"}`, tools[0].Arguments)
+	assert.Equal(t, "call_bash", tools[1].ID)
+	assert.Equal(t, "Bash", tools[1].Name)
+	assert.JSONEq(t, `{"command":"go test ./..."}`, tools[1].Arguments)
+}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_read_tool_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_read_tool_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestResToAnthFuncArgsDelta_ReadToolWaitsForCompleteJSON(t *testing.T) {
 	state := NewResponsesEventToAnthropicState()
-	state.MessageStartSent = true
-	state.ContentBlockOpen = true
-	state.CurrentBlockType = "tool_use"
-	state.CurrentToolName = "Read"
-	state.OutputIndexToBlockIdx = map[int]int{0: 0}
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "function_call", CallID: "call_read", Name: "Read"},
+	}, state)
 
 	events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.function_call_arguments.delta",
@@ -21,7 +21,7 @@ func TestResToAnthFuncArgsDelta_ReadToolWaitsForCompleteJSON(t *testing.T) {
 		Delta:       `{"file_path":"/tmp/te`,
 	}, state)
 	assert.Empty(t, events, "partial Read JSON must wait for sanitization")
-	assert.False(t, state.CurrentToolHadDelta)
+	assert.Empty(t, state.PendingTools[0].EmittedArgs)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.function_call_arguments.delta",
@@ -32,8 +32,8 @@ func TestResToAnthFuncArgsDelta_ReadToolWaitsForCompleteJSON(t *testing.T) {
 	assert.Equal(t, "content_block_delta", events[0].Type)
 	assert.Equal(t, "input_json_delta", events[0].Delta.Type)
 	assert.JSONEq(t, `{"file_path":"/tmp/test.go"}`, events[0].Delta.PartialJSON)
-	assert.Equal(t, `{"file_path":"/tmp/test.go","pages":""}`, state.CurrentToolArgs)
-	assert.True(t, state.CurrentToolHadDelta)
+	assert.Equal(t, `{"file_path":"/tmp/test.go","pages":""}`, state.PendingTools[0].FinalArgs)
+	assert.JSONEq(t, `{"file_path":"/tmp/test.go"}`, state.PendingTools[0].EmittedArgs)
 
 	events = ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
 		Type:        "response.function_call_arguments.done",
@@ -95,10 +95,11 @@ func TestResponsesEventToAnthropicEvents_ReadToolWithoutArgumentsDoneClosesOnCom
 
 func TestResToAnthFuncArgsDelta_NonReadToolStreamsPartialJSONImmediately(t *testing.T) {
 	state := NewResponsesEventToAnthropicState()
-	state.MessageStartSent = true
-	state.CurrentBlockType = "tool_use"
-	state.CurrentToolName = "Write"
-	state.OutputIndexToBlockIdx = map[int]int{0: 0}
+	ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+		Type:        "response.output_item.added",
+		OutputIndex: 0,
+		Item:        &ResponsesOutput{Type: "function_call", CallID: "call_write", Name: "Write"},
+	}, state)
 
 	evt := &ResponsesStreamEvent{
 		Type:        "response.function_call_arguments.delta",
@@ -111,5 +112,5 @@ func TestResToAnthFuncArgsDelta_NonReadToolStreamsPartialJSONImmediately(t *test
 	require.Len(t, events, 1)
 	assert.Equal(t, "content_block_delta", events[0].Type)
 	assert.Equal(t, `{"file_path":"/tmp/out`, events[0].Delta.PartialJSON)
-	assert.True(t, state.CurrentToolHadDelta)
+	assert.Equal(t, `{"file_path":"/tmp/out`, state.PendingTools[0].EmittedArgs)
 }


### PR DESCRIPTION
## Summary

Fix Anthropic SSE `Content block not found` errors when an OpenAI Responses-compatible upstream interleaves multiple parallel function calls.

The converter previously tracked one global current block. Starting tool 2 closed tool 1, so a later arguments delta for tool 1 could target an already-stopped Anthropic block. Late text/reasoning completion events could also stop whichever block happened to be current.

## What changed

- Track pending tools independently by Responses `output_index` and preserve their original order.
- Keep exactly one active Anthropic `tool_use` block.
- Stream arguments for the active tool immediately; buffer later tools until the active block stops.
- Reconcile final arguments with the already-streamed prefix, so `response.completed` can safely append a missing suffix without duplicating JSON.
- Only let text/reasoning done events stop a matching block type and `output_index`.
- Flush unfinished tools in order before `message_delta` / `message_stop`.
- Keep thinking and text output streaming in real time before tool execution begins.

This intentionally serializes only overlapping tool blocks; it does not buffer the whole response.

## Why this differs from #4294

#4294 prevents one ghost delta by skipping arguments that target an already-closed block. This PR prevents the premature close in the first place and retains every queued tool call's ID, name, and arguments under genuinely interleaved events. It also covers late thinking/text done events and terminal-response argument recovery.

Related: #4193, #4286, #4294.

## Tests

Added lifecycle regression coverage for:

- tool 1 added → tool 2 added → interleaved arguments → ordered tool blocks;
- queued tool arguments arriving before the active tool completes;
- late thinking/text done and output-item done events;
- final arguments available only from `response.completed`;
- every delta/stop referencing an open block and no open block before `message_stop`.

Local verification:

- `go test ./internal/pkg/apicompat -count=1`
- `go test ./... -count=1`
- `go test -tags=unit ./... -count=1`
- `go test -tags=integration ./... -count=1`
- `go vet ./internal/pkg/apicompat`