### PR TITLE
fix(openai): fail over client-restricted accounts

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -127,12 +127,17 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 
 	sessionHash := h.gatewayService.GenerateSessionHash(c, body)
 	promptCacheKey := h.gatewayService.ExtractSessionID(c, body)
+	forwardBody := body
+	if channelMapping.Mapped {
+		forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
+	}
 
 	maxAccountSwitches := h.maxAccountSwitches
 	switchCount := 0
 	failedAccountIDs := make(map[int64]struct{})
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
+	var clientRestrictionState openAIClientRestrictionFailoverState
 
 	for {
 		reqLog.Debug("openai_chat_completions.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
@@ -164,6 +169,8 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			} else {
 				if lastFailoverErr != nil {
 					h.handleFailoverExhausted(c, lastFailoverErr, streamStarted)
+				} else if clientRestrictionState.rejectIfExhausted(h, c, streamStarted) {
+					return
 				} else {
 					h.handleStreamingAwareError(c, http.StatusBadGateway, "api_error", "Upstream request failed", streamStarted)
 				}
@@ -171,12 +178,28 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			}
 		}
 		if selection == nil || selection.Account == nil {
+			if lastFailoverErr == nil && clientRestrictionState.rejectIfExhausted(h, c, streamStarted) {
+				return
+			}
 			cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel)
 			if !cls.ModelNotFound {
 				markOpsRoutingCapacityLimited(c)
 			}
 			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 			return
+		}
+		if restriction, excluded := clientRestrictionState.excludeSelection(
+			h.gatewayService,
+			c,
+			forwardBody,
+			selection,
+			failedAccountIDs,
+		); excluded {
+			reqLog.Debug("openai_chat_completions.account_client_incompatible",
+				zap.Int64("account_id", selection.Account.ID),
+				zap.String("reason", restriction.Reason),
+			)
+			continue
 		}
 		account := selection.Account
 		sessionHash = ensureOpenAIPoolModeSessionHash(sessionHash, account)
@@ -192,10 +215,6 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		service.SetOpsLatencyMs(c, service.OpsRoutingLatencyMsKey, time.Since(routingStart).Milliseconds())
 		forwardStart := time.Now()
 
-		forwardBody := body
-		if channelMapping.Mapped {
-			forwardBody = h.gatewayService.ReplaceModelInBody(body, channelMapping.MappedModel)
-		}
 		writerSizeBeforeForward := c.Writer.Size()
 		result, err := func() (*service.OpenAIForwardResult, error) {
 			defer func() {

--- a/backend/internal/handler/openai_client_restriction_failover.go
+++ b/backend/internal/handler/openai_client_restriction_failover.go
@@ -1,0 +1,69 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+)
+
+type openAIClientRestrictionFailoverState struct {
+	lastResult          *service.CodexClientRestrictionDetectionResult
+	lastAccountID       int64
+	lastAccountPlatform string
+}
+
+// excludeSelection releases any slot reserved by the scheduler and excludes
+// an account whose client policy does not allow the current request. The caller
+// can then run the normal selection loop again without consuming an upstream
+// failover attempt.
+func (s *openAIClientRestrictionFailoverState) excludeSelection(
+	gatewayService *service.OpenAIGatewayService,
+	c *gin.Context,
+	body []byte,
+	selection *service.AccountSelectionResult,
+	excludedIDs map[int64]struct{},
+) (service.CodexClientRestrictionDetectionResult, bool) {
+	if gatewayService == nil || selection == nil || selection.Account == nil {
+		return service.CodexClientRestrictionDetectionResult{}, false
+	}
+
+	result := gatewayService.DetectOpenAIClientRestriction(c, selection.Account, body)
+	if !result.Enabled || result.Matched {
+		return result, false
+	}
+
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+		selection.ReleaseFunc = nil
+	}
+	selection.Acquired = false
+	if excludedIDs != nil {
+		excludedIDs[selection.Account.ID] = struct{}{}
+	}
+	resultCopy := result
+	s.lastResult = &resultCopy
+	s.lastAccountID = selection.Account.ID
+	s.lastAccountPlatform = selection.Account.Platform
+	return result, true
+}
+
+func (s *openAIClientRestrictionFailoverState) rejectIfExhausted(
+	h *OpenAIGatewayHandler,
+	c *gin.Context,
+	streamStarted bool,
+) bool {
+	if s == nil || s.lastResult == nil || h == nil {
+		return false
+	}
+	setOpsSelectedAccount(c, s.lastAccountID, s.lastAccountPlatform)
+	service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalPolicyDenied)
+	h.handleStreamingAwareError(
+		c,
+		http.StatusForbidden,
+		"forbidden_error",
+		service.CodexClientRestrictionMessage(*s.lastResult),
+		streamStarted,
+	)
+	return true
+}

--- a/backend/internal/handler/openai_client_restriction_failover_test.go
+++ b/backend/internal/handler/openai_client_restriction_failover_test.go
@@ -1,0 +1,110 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func newOpenAIClientRestrictionTestContext(t *testing.T) (*httptest.ResponseRecorder, *gin.Context) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	c.Request.Header.Set("User-Agent", "Mozilla/5.0")
+	return recorder, c
+}
+
+func TestOpenAIClientRestrictionFailoverState_ExcludesRestrictedAccount(t *testing.T) {
+	_, c := newOpenAIClientRestrictionTestContext(t)
+	releaseCount := 0
+	selection := &service.AccountSelectionResult{
+		Account: &service.Account{
+			ID:       1001,
+			Platform: service.PlatformOpenAI,
+			Type:     service.AccountTypeOAuth,
+			Extra:    map[string]any{"codex_cli_only": true},
+		},
+		Acquired: true,
+		ReleaseFunc: func() {
+			releaseCount++
+		},
+	}
+	excludedIDs := make(map[int64]struct{})
+	var state openAIClientRestrictionFailoverState
+
+	result, excluded := state.excludeSelection(
+		&service.OpenAIGatewayService{},
+		c,
+		[]byte(`{"model":"gpt-5.4"}`),
+		selection,
+		excludedIDs,
+	)
+
+	require.True(t, excluded)
+	require.True(t, result.Enabled)
+	require.False(t, result.Matched)
+	require.Equal(t, service.CodexClientRestrictionReasonNotMatchedUA, result.Reason)
+	require.Contains(t, excludedIDs, int64(1001))
+	require.Equal(t, 1, releaseCount)
+	require.False(t, selection.Acquired)
+	require.Nil(t, selection.ReleaseFunc)
+	require.NotNil(t, state.lastResult)
+	require.Equal(t, int64(1001), state.lastAccountID)
+	require.Equal(t, service.PlatformOpenAI, state.lastAccountPlatform)
+}
+
+func TestOpenAIClientRestrictionFailoverState_KeepsCompatibleAccount(t *testing.T) {
+	_, c := newOpenAIClientRestrictionTestContext(t)
+	releaseCount := 0
+	selection := &service.AccountSelectionResult{
+		Account: &service.Account{
+			ID:       1002,
+			Platform: service.PlatformOpenAI,
+			Type:     service.AccountTypeOAuth,
+			Extra:    map[string]any{"codex_cli_only": false},
+		},
+		Acquired:    true,
+		ReleaseFunc: func() { releaseCount++ },
+	}
+	excludedIDs := make(map[int64]struct{})
+	var state openAIClientRestrictionFailoverState
+
+	result, excluded := state.excludeSelection(
+		&service.OpenAIGatewayService{},
+		c,
+		[]byte(`{"model":"gpt-5.4"}`),
+		selection,
+		excludedIDs,
+	)
+
+	require.False(t, excluded)
+	require.False(t, result.Enabled)
+	require.Empty(t, excludedIDs)
+	require.Equal(t, 0, releaseCount)
+	require.True(t, selection.Acquired)
+	require.NotNil(t, selection.ReleaseFunc)
+	require.Nil(t, state.lastResult)
+}
+
+func TestOpenAIClientRestrictionFailoverState_RejectsAfterExhaustion(t *testing.T) {
+	recorder, c := newOpenAIClientRestrictionTestContext(t)
+	state := openAIClientRestrictionFailoverState{
+		lastResult: &service.CodexClientRestrictionDetectionResult{
+			Enabled: true,
+			Matched: false,
+			Reason:  service.CodexClientRestrictionReasonNotMatchedUA,
+		},
+	}
+
+	rejected := state.rejectIfExhausted(&OpenAIGatewayHandler{}, c, false)
+
+	require.True(t, rejected)
+	require.Equal(t, http.StatusForbidden, recorder.Code)
+	require.Contains(t, recorder.Body.String(), service.CodexOfficialClientsOnlyMessage)
+}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -332,6 +332,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	failedAccountIDs := make(map[int64]struct{})
 	sameAccountRetryCount := make(map[int64]int)
 	var lastFailoverErr *service.UpstreamFailoverError
+	var clientRestrictionState openAIClientRestrictionFailoverState
 
 	for {
 		// Select account supporting the requested model
@@ -369,18 +370,36 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			}
 			if lastFailoverErr != nil {
 				h.handleFailoverExhausted(c, lastFailoverErr, streamStarted)
+			} else if clientRestrictionState.rejectIfExhausted(h, c, streamStarted) {
+				return
 			} else {
 				h.handleFailoverExhaustedSimple(c, 502, streamStarted)
 			}
 			return
 		}
 		if selection == nil || selection.Account == nil {
+			if lastFailoverErr == nil && clientRestrictionState.rejectIfExhausted(h, c, streamStarted) {
+				return
+			}
 			cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, reqModel, reqModel)
 			if !cls.ModelNotFound {
 				markOpsRoutingCapacityLimited(c)
 			}
 			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
 			return
+		}
+		if restriction, excluded := clientRestrictionState.excludeSelection(
+			h.gatewayService,
+			c,
+			forwardBody,
+			selection,
+			failedAccountIDs,
+		); excluded {
+			reqLog.Debug("openai.account_client_incompatible",
+				zap.Int64("account_id", selection.Account.ID),
+				zap.String("reason", restriction.Reason),
+			)
+			continue
 		}
 		if previousResponseID != "" && selection != nil && selection.Account != nil {
 			reqLog.Debug("openai.account_selected_with_previous_response_id", zap.Int64("account_id", selection.Account.ID))

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -961,6 +961,13 @@ func (s *OpenAIGatewayService) detectCodexClientRestriction(c *gin.Context, acco
 	return s.getCodexClientRestrictionDetector().Detect(c, account, policy, body)
 }
 
+// DetectOpenAIClientRestriction exposes the account-level client compatibility
+// check to handlers before they commit to a scheduled account. Forward paths
+// still repeat the check as a defense-in-depth guard.
+func (s *OpenAIGatewayService) DetectOpenAIClientRestriction(c *gin.Context, account *Account, body []byte) CodexClientRestrictionDetectionResult {
+	return s.detectCodexClientRestriction(c, account, body)
+}
+
 func getAPIKeyIDFromContext(c *gin.Context) int64 {
 	if c == nil {
 		return 0


### PR DESCRIPTION
## Summary

- re-run account selection when a scheduled OpenAI OAuth account rejects the current client through `codex_cli_only`
- release any scheduler-reserved concurrency slot and exclude the incompatible account without consuming an upstream failover attempt
- preserve the existing 403 response and account attribution when no client-compatible account remains
- apply the behavior to both Responses and Chat Completions requests

## Problem

Client restrictions are currently checked only after account selection. In a mixed group containing both `codex_cli_only` and unrestricted accounts, a third-party client can be assigned a restricted account and receive a terminal 403 even though another compatible account is available.

## Testing

- `go test ./... -count=1`
- `go vet ./internal/handler ./internal/service`