### PR TITLE
perf(scheduler): 完善缓存桶生命周期并复用重建批次查询

### DIFF
--- a/backend/internal/handler/gateway_handler_warmup_intercept_unit_test.go
+++ b/backend/internal/handler/gateway_handler_warmup_intercept_unit_test.go
@@ -43,6 +43,12 @@ func (f *fakeSchedulerCache) RetireBucket(_ context.Context, _ service.Scheduler
 func (f *fakeSchedulerCache) ReopenBucket(_ context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
 	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
+func (f *fakeSchedulerCache) TryAcquireGroupLifecycleLease(_ context.Context, _ int64, _ time.Duration) (service.SchedulerGroupLifecycleLease, bool, error) {
+	return service.SchedulerGroupLifecycleLease{}, false, nil
+}
+func (f *fakeSchedulerCache) ReleaseGroupLifecycleLease(_ context.Context, _ service.SchedulerGroupLifecycleLease) error {
+	return nil
+}
 func (f *fakeSchedulerCache) GetAccount(_ context.Context, id int64) (*service.Account, error) {
 	for _, account := range f.accounts {
 		if account != nil && account.ID == id {

--- a/backend/internal/handler/gateway_handler_warmup_intercept_unit_test.go
+++ b/backend/internal/handler/gateway_handler_warmup_intercept_unit_test.go
@@ -31,8 +31,17 @@ type fakeSchedulerCache struct {
 func (f *fakeSchedulerCache) GetSnapshot(_ context.Context, _ service.SchedulerBucket) ([]*service.Account, bool, error) {
 	return f.accounts, true, nil
 }
-func (f *fakeSchedulerCache) SetSnapshot(_ context.Context, _ service.SchedulerBucket, _ []service.Account) error {
+func (f *fakeSchedulerCache) CaptureBucketWriteToken(_ context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
+	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+func (f *fakeSchedulerCache) SetSnapshot(_ context.Context, _ service.SchedulerBucket, _ service.SchedulerBucketWriteToken, _ []service.Account) error {
 	return nil
+}
+func (f *fakeSchedulerCache) RetireBucket(_ context.Context, _ service.SchedulerBucket) error {
+	return nil
+}
+func (f *fakeSchedulerCache) ReopenBucket(_ context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
+	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 func (f *fakeSchedulerCache) GetAccount(_ context.Context, id int64) (*service.Account, error) {
 	for _, account := range f.accounts {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -31,8 +31,20 @@ func (s *schedulerCacheRecorder) GetSnapshot(ctx context.Context, bucket service
 	return nil, false, nil
 }
 
-func (s *schedulerCacheRecorder) SetSnapshot(ctx context.Context, bucket service.SchedulerBucket, accounts []service.Account) error {
+func (s *schedulerCacheRecorder) CaptureBucketWriteToken(ctx context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
+	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+
+func (s *schedulerCacheRecorder) SetSnapshot(ctx context.Context, bucket service.SchedulerBucket, token service.SchedulerBucketWriteToken, accounts []service.Account) error {
 	return nil
+}
+
+func (s *schedulerCacheRecorder) RetireBucket(ctx context.Context, bucket service.SchedulerBucket) error {
+	return nil
+}
+
+func (s *schedulerCacheRecorder) ReopenBucket(ctx context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
+	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
 func (s *schedulerCacheRecorder) GetAccount(ctx context.Context, accountID int64) (*service.Account, error) {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -47,6 +47,14 @@ func (s *schedulerCacheRecorder) ReopenBucket(ctx context.Context, bucket servic
 	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
+func (s *schedulerCacheRecorder) TryAcquireGroupLifecycleLease(_ context.Context, groupID int64, _ time.Duration) (service.SchedulerGroupLifecycleLease, bool, error) {
+	return service.SchedulerGroupLifecycleLease{GroupID: groupID, OwnerToken: "scheduler-cache-recorder"}, true, nil
+}
+
+func (s *schedulerCacheRecorder) ReleaseGroupLifecycleLease(context.Context, service.SchedulerGroupLifecycleLease) error {
+	return nil
+}
+
 func (s *schedulerCacheRecorder) GetAccount(ctx context.Context, accountID int64) (*service.Account, error) {
 	if s.accounts == nil {
 		return nil, nil

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -20,6 +20,8 @@ const (
 	schedulerActivePrefix       = "sched:active:"
 	schedulerReadyPrefix        = "sched:ready:"
 	schedulerVersionPrefix      = "sched:ver:"
+	schedulerEpochPrefix        = "sched:epoch:"
+	schedulerRetiredPrefix      = "sched:retired:"
 	schedulerSnapshotPrefix     = "sched:"
 	schedulerLockPrefix         = "sched:lock:"
 
@@ -32,6 +34,98 @@ const (
 )
 
 var (
+	captureBucketWriteTokenScript = redis.NewScript(`
+if redis.call('EXISTS', KEYS[2]) == 1 then
+    return -1
+end
+
+local currentEpoch = redis.call('GET', KEYS[1])
+if currentEpoch == false then
+    redis.call('SET', KEYS[1], '1')
+    return 1
+end
+
+local parsedEpoch = tonumber(currentEpoch)
+if parsedEpoch == nil or parsedEpoch < 1 then
+    return -2
+end
+return parsedEpoch
+`)
+
+	allocateSnapshotVersionScript = redis.NewScript(`
+if redis.call('EXISTS', KEYS[2]) == 1 then
+    return -1
+end
+
+local currentEpoch = tonumber(redis.call('GET', KEYS[1]))
+local expectedEpoch = tonumber(ARGV[1])
+if currentEpoch == nil or expectedEpoch == nil or currentEpoch ~= expectedEpoch then
+    return -2
+end
+
+return redis.call('INCR', KEYS[3])
+`)
+
+	retireBucketScript = redis.NewScript(`
+local retired = redis.call('GET', KEYS[2])
+local currentEpoch = tonumber(redis.call('GET', KEYS[1])) or 0
+
+if retired == false then
+    currentEpoch = currentEpoch + 1
+    if currentEpoch < 1 then
+        currentEpoch = 1
+    end
+    redis.call('SET', KEYS[1], tostring(currentEpoch))
+    redis.call('SET', KEYS[2], tostring(currentEpoch))
+elseif currentEpoch < 1 then
+    currentEpoch = tonumber(retired) or 1
+    redis.call('SET', KEYS[1], tostring(currentEpoch))
+end
+
+redis.call('SREM', KEYS[3], ARGV[1])
+local currentActive = redis.call('GET', KEYS[5])
+if currentActive ~= false then
+    redis.call('EXPIRE', ARGV[2] .. currentActive, tonumber(ARGV[3]))
+end
+redis.call('DEL', KEYS[4], KEYS[5])
+return currentEpoch
+`)
+
+	reopenBucketScript = redis.NewScript(`
+local currentEpochRaw = redis.call('GET', KEYS[1])
+local currentEpoch = tonumber(currentEpochRaw)
+local retiredEpochRaw = redis.call('GET', KEYS[2])
+
+if retiredEpochRaw == false then
+    if currentEpochRaw == false then
+        redis.call('SET', KEYS[1], '1')
+        return 1
+    end
+    if currentEpoch == nil or currentEpoch < 1 then
+        return -2
+    end
+    return currentEpoch
+end
+
+local retiredEpoch = tonumber(retiredEpochRaw)
+if retiredEpoch == nil or retiredEpoch < 1 then
+    return -2
+end
+if currentEpoch == nil or currentEpoch < retiredEpoch then
+    currentEpoch = retiredEpoch
+end
+
+redis.call('SET', KEYS[1], tostring(currentEpoch))
+redis.call('DEL', KEYS[2])
+redis.call('SREM', KEYS[3], ARGV[1])
+local currentActive = redis.call('GET', KEYS[5])
+if currentActive ~= false then
+    redis.call('EXPIRE', ARGV[2] .. currentActive, tonumber(ARGV[3]))
+end
+redis.call('DEL', KEYS[4], KEYS[5])
+return currentEpoch
+`)
+
 	// activateSnapshotScript 原子 CAS 切换快照版本。
 	// 仅当新版本号 >= 当前激活版本时才切换，防止并发写入导致版本回滚。
 	// 旧快照使用 EXPIRE 设置宽限期而非立即 DEL，避免与 reader 竞态。
@@ -40,13 +134,28 @@ var (
 	// KEYS[2] = readyKey      (sched:ready:{bucket})
 	// KEYS[3] = bucketSetKey  (sched:buckets)
 	// KEYS[4] = snapshotKey   (新写入的快照 key)
+	// KEYS[5] = epochKey
+	// KEYS[6] = retiredKey
 	// ARGV[1] = 新版本号字符串
 	// ARGV[2] = bucket 字符串 (用于 SADD)
 	// ARGV[3] = 快照 key 前缀 (用于构造旧快照 key)
 	// ARGV[4] = 宽限期 TTL 秒数
+	// ARGV[5] = writer epoch
 	//
 	// 返回 1 = 已激活, 0 = 版本过旧未激活
 	activateSnapshotScript = redis.NewScript(`
+if redis.call('EXISTS', KEYS[6]) == 1 then
+    redis.call('DEL', KEYS[4])
+    return -1
+end
+
+local currentEpoch = tonumber(redis.call('GET', KEYS[5]))
+local expectedEpoch = tonumber(ARGV[5])
+if currentEpoch == nil or expectedEpoch == nil or currentEpoch ~= expectedEpoch then
+    redis.call('DEL', KEYS[4])
+    return -2
+end
+
 local currentActive = redis.call('GET', KEYS[1])
 local newVersion = tonumber(ARGV[1])
 
@@ -151,19 +260,87 @@ func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.Schedul
 	return accounts, true, nil
 }
 
-func (c *schedulerCache) SetSnapshot(ctx context.Context, bucket service.SchedulerBucket, accounts []service.Account) error {
-	// Phase 1: 分配新版本号并写入快照数据。
-	// INCR 保证每个调用方获得唯一递增版本号。
-	// 写入的 snapshotKey 是新的版本化 key，reader 尚不知晓，因此无竞态。
-	versionKey := schedulerBucketKey(schedulerVersionPrefix, bucket)
-	version, err := c.rdb.Incr(ctx, versionKey).Result()
+func (c *schedulerCache) CaptureBucketWriteToken(ctx context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
+	result, err := captureBucketWriteTokenScript.Run(ctx, c.rdb, []string{
+		schedulerBucketKey(schedulerEpochPrefix, bucket),
+		schedulerBucketKey(schedulerRetiredPrefix, bucket),
+	}).Int64()
+	if err != nil {
+		return service.SchedulerBucketWriteToken{}, err
+	}
+	if err := schedulerBucketWriteResultError(result, bucket); err != nil {
+		return service.SchedulerBucketWriteToken{}, err
+	}
+	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: result}, nil
+}
+
+func (c *schedulerCache) RetireBucket(ctx context.Context, bucket service.SchedulerBucket) error {
+	snapshotKeyPrefix := fmt.Sprintf("%s%d:%s:%s:v", schedulerSnapshotPrefix, bucket.GroupID, bucket.Platform, bucket.Mode)
+	result, err := retireBucketScript.Run(ctx, c.rdb, []string{
+		schedulerBucketKey(schedulerEpochPrefix, bucket),
+		schedulerBucketKey(schedulerRetiredPrefix, bucket),
+		schedulerBucketSetKey,
+		schedulerBucketKey(schedulerReadyPrefix, bucket),
+		schedulerBucketKey(schedulerActivePrefix, bucket),
+	}, bucket.String(), snapshotKeyPrefix, snapshotGraceTTLSeconds).Int64()
 	if err != nil {
 		return err
 	}
+	if result < 1 {
+		return fmt.Errorf("retire scheduler bucket %s returned invalid epoch %d", bucket.String(), result)
+	}
+	return nil
+}
 
-	versionStr := strconv.FormatInt(version, 10)
-	snapshotKey := schedulerSnapshotKey(bucket, versionStr)
+func (c *schedulerCache) ReopenBucket(ctx context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
+	snapshotKeyPrefix := fmt.Sprintf("%s%d:%s:%s:v", schedulerSnapshotPrefix, bucket.GroupID, bucket.Platform, bucket.Mode)
+	result, err := reopenBucketScript.Run(ctx, c.rdb, []string{
+		schedulerBucketKey(schedulerEpochPrefix, bucket),
+		schedulerBucketKey(schedulerRetiredPrefix, bucket),
+		schedulerBucketSetKey,
+		schedulerBucketKey(schedulerReadyPrefix, bucket),
+		schedulerBucketKey(schedulerActivePrefix, bucket),
+	}, bucket.String(), snapshotKeyPrefix, snapshotGraceTTLSeconds).Int64()
+	if err != nil {
+		return service.SchedulerBucketWriteToken{}, err
+	}
+	if err := schedulerBucketWriteResultError(result, bucket); err != nil {
+		return service.SchedulerBucketWriteToken{}, err
+	}
+	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: result}, nil
+}
 
+func (c *schedulerCache) SetSnapshot(ctx context.Context, bucket service.SchedulerBucket, token service.SchedulerBucketWriteToken, accounts []service.Account) error {
+	if !token.ValidFor(bucket) {
+		return fmt.Errorf("%w: bucket=%s", service.ErrSchedulerBucketWriteFenced, bucket.String())
+	}
+	version, err := c.allocateSnapshotVersion(ctx, bucket, token)
+	if err != nil {
+		return err
+	}
+	if err := c.writeSnapshotVersion(ctx, bucket, version, accounts); err != nil {
+		return err
+	}
+	return c.activateSnapshotVersion(ctx, bucket, token, version)
+}
+
+func (c *schedulerCache) allocateSnapshotVersion(ctx context.Context, bucket service.SchedulerBucket, token service.SchedulerBucketWriteToken) (string, error) {
+	result, err := allocateSnapshotVersionScript.Run(ctx, c.rdb, []string{
+		schedulerBucketKey(schedulerEpochPrefix, bucket),
+		schedulerBucketKey(schedulerRetiredPrefix, bucket),
+		schedulerBucketKey(schedulerVersionPrefix, bucket),
+	}, token.Epoch).Int64()
+	if err != nil {
+		return "", err
+	}
+	if err := schedulerBucketWriteResultError(result, bucket); err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(result, 10), nil
+}
+
+func (c *schedulerCache) writeSnapshotVersion(ctx context.Context, bucket service.SchedulerBucket, version string, accounts []service.Account) error {
+	snapshotKey := schedulerSnapshotKey(bucket, version)
 	cacheableAccounts, err := c.writeAccounts(ctx, accounts)
 	if err != nil {
 		return err
@@ -191,7 +368,12 @@ func (c *schedulerCache) SetSnapshot(ctx context.Context, bucket service.Schedul
 		}
 	}
 
-	// Phase 2: 原子 CAS 激活版本。
+	return nil
+}
+
+func (c *schedulerCache) activateSnapshotVersion(ctx context.Context, bucket service.SchedulerBucket, token service.SchedulerBucketWriteToken, version string) error {
+	snapshotKey := schedulerSnapshotKey(bucket, version)
+	// Phase 2: 原子 CAS 切换版本，同时再次校验退休状态与 writer epoch。
 	// Lua 脚本保证：仅当新版本 >= 当前激活版本时才切换 active 指针，
 	// 防止并发写入导致版本回滚。
 	// 旧快照使用 EXPIRE 宽限期而非立即 DEL，避免 reader 竞态。
@@ -199,15 +381,32 @@ func (c *schedulerCache) SetSnapshot(ctx context.Context, bucket service.Schedul
 	readyKey := schedulerBucketKey(schedulerReadyPrefix, bucket)
 	snapshotKeyPrefix := fmt.Sprintf("%s%d:%s:%s:v", schedulerSnapshotPrefix, bucket.GroupID, bucket.Platform, bucket.Mode)
 
-	keys := []string{activeKey, readyKey, schedulerBucketSetKey, snapshotKey}
-	args := []any{versionStr, bucket.String(), snapshotKeyPrefix, snapshotGraceTTLSeconds}
+	keys := []string{
+		activeKey,
+		readyKey,
+		schedulerBucketSetKey,
+		snapshotKey,
+		schedulerBucketKey(schedulerEpochPrefix, bucket),
+		schedulerBucketKey(schedulerRetiredPrefix, bucket),
+	}
+	args := []any{version, bucket.String(), snapshotKeyPrefix, snapshotGraceTTLSeconds, token.Epoch}
 
-	_, err = activateSnapshotScript.Run(ctx, c.rdb, keys, args...).Result()
+	result, err := activateSnapshotScript.Run(ctx, c.rdb, keys, args...).Int64()
 	if err != nil {
 		return err
 	}
+	return schedulerBucketWriteResultError(result, bucket)
+}
 
-	return nil
+func schedulerBucketWriteResultError(result int64, bucket service.SchedulerBucket) error {
+	switch result {
+	case -1:
+		return fmt.Errorf("%w: bucket=%s", service.ErrSchedulerBucketRetired, bucket.String())
+	case -2:
+		return fmt.Errorf("%w: bucket=%s", service.ErrSchedulerBucketWriteFenced, bucket.String())
+	default:
+		return nil
+	}
 }
 
 func (c *schedulerCache) GetAccount(ctx context.Context, accountID int64) (*service.Account, error) {

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -2,6 +2,8 @@ package repository
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -31,6 +33,11 @@ const (
 	// snapshotGraceTTLSeconds 旧快照过期的宽限期（秒）。
 	// 替代立即 DEL，让正在读取旧版本的 reader 有足够时间完成 ZRANGE。
 	snapshotGraceTTLSeconds = 60
+)
+
+const (
+	schedulerGroupLifecycleLockPrefix      = "sched:group:lifecycle-lock:"
+	schedulerGroupLifecycleOwnerTokenBytes = 16
 )
 
 var (
@@ -124,6 +131,13 @@ if currentActive ~= false then
 end
 redis.call('DEL', KEYS[4], KEYS[5])
 return currentEpoch
+`)
+
+	releaseGroupLifecycleLeaseScript = redis.NewScript(`
+if redis.call('GET', KEYS[1]) == ARGV[1] then
+    return redis.call('DEL', KEYS[1])
+end
+return 0
 `)
 
 	// activateSnapshotScript 原子 CAS 切换快照版本。
@@ -308,6 +322,57 @@ func (c *schedulerCache) ReopenBucket(ctx context.Context, bucket service.Schedu
 		return service.SchedulerBucketWriteToken{}, err
 	}
 	return service.SchedulerBucketWriteToken{Bucket: bucket, Epoch: result}, nil
+}
+
+func (c *schedulerCache) TryAcquireGroupLifecycleLease(ctx context.Context, groupID int64, ttl time.Duration) (service.SchedulerGroupLifecycleLease, bool, error) {
+	if groupID <= 0 {
+		return service.SchedulerGroupLifecycleLease{}, false, fmt.Errorf("%w: group id must be positive", service.ErrSchedulerGroupLifecycleLeaseInvalid)
+	}
+	if ttl <= 0 {
+		return service.SchedulerGroupLifecycleLease{}, false, fmt.Errorf("%w: ttl must be positive", service.ErrSchedulerGroupLifecycleLeaseInvalid)
+	}
+	ownerToken, err := newSchedulerGroupLifecycleOwnerToken()
+	if err != nil {
+		return service.SchedulerGroupLifecycleLease{}, false, err
+	}
+	acquired, err := c.rdb.SetNX(ctx, schedulerGroupLifecycleLockKey(groupID), ownerToken, ttl).Result()
+	if err != nil {
+		return service.SchedulerGroupLifecycleLease{}, false, err
+	}
+	if !acquired {
+		return service.SchedulerGroupLifecycleLease{}, false, nil
+	}
+	return service.SchedulerGroupLifecycleLease{GroupID: groupID, OwnerToken: ownerToken}, true, nil
+}
+
+func (c *schedulerCache) ReleaseGroupLifecycleLease(ctx context.Context, lease service.SchedulerGroupLifecycleLease) error {
+	if !lease.ValidFor(lease.GroupID) {
+		return service.ErrSchedulerGroupLifecycleLeaseInvalid
+	}
+	result, err := releaseGroupLifecycleLeaseScript.Run(
+		ctx,
+		c.rdb,
+		[]string{schedulerGroupLifecycleLockKey(lease.GroupID)},
+		lease.OwnerToken,
+	).Int64()
+	if err != nil {
+		return err
+	}
+	if result == 0 {
+		return fmt.Errorf("%w: group=%d", service.ErrSchedulerGroupLifecycleLeaseLost, lease.GroupID)
+	}
+	if result != 1 {
+		return fmt.Errorf("release scheduler group lifecycle lease returned %d", result)
+	}
+	return nil
+}
+
+func newSchedulerGroupLifecycleOwnerToken() (string, error) {
+	raw := make([]byte, schedulerGroupLifecycleOwnerTokenBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate scheduler group lifecycle owner token: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
 }
 
 func (c *schedulerCache) SetSnapshot(ctx context.Context, bucket service.SchedulerBucket, token service.SchedulerBucketWriteToken, accounts []service.Account) error {
@@ -533,6 +598,10 @@ func (c *schedulerCache) SetOutboxWatermark(ctx context.Context, id int64) error
 
 func schedulerBucketKey(prefix string, bucket service.SchedulerBucket) string {
 	return fmt.Sprintf("%s%d:%s:%s", prefix, bucket.GroupID, bucket.Platform, bucket.Mode)
+}
+
+func schedulerGroupLifecycleLockKey(groupID int64) string {
+	return schedulerGroupLifecycleLockPrefix + strconv.FormatInt(groupID, 10)
 }
 
 func schedulerSnapshotKey(bucket service.SchedulerBucket, version string) string {

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -41,6 +41,10 @@ const (
 )
 
 var (
+	// epoch 标识 bucket writer 的代际，retired key 是持久退休标记。
+	// Capture、allocate、activate 都在 Lua 内同时校验两者：-1 表示已退休，-2 表示 epoch 无效或与 token 代际不匹配；
+	// allocate 与 activate 的双重校验可拦截快照写入期间发生的 Retire。
+	// Retire 仅在首次退休时推进 epoch，Reopen 只清除标记并沿用该代际，因此重复调用保持幂等。
 	captureBucketWriteTokenScript = redis.NewScript(`
 if redis.call('EXISTS', KEYS[2]) == 1 then
     return -1
@@ -133,6 +137,7 @@ redis.call('DEL', KEYS[4], KEYS[5])
 return currentEpoch
 `)
 
+	// 释放租约必须先比较所有者令牌再删除，过期持有者的延迟释放不能误删继任租约。
 	releaseGroupLifecycleLeaseScript = redis.NewScript(`
 if redis.call('GET', KEYS[1]) == ARGV[1] then
     return redis.call('DEL', KEYS[1])
@@ -379,6 +384,7 @@ func (c *schedulerCache) SetSnapshot(ctx context.Context, bucket service.Schedul
 	if !token.ValidFor(bucket) {
 		return fmt.Errorf("%w: bucket=%s", service.ErrSchedulerBucketWriteFenced, bucket.String())
 	}
+	// 分配版本与激活指针是两个 fencing 边界；中间写入的数据只有通过第二次校验才能发布。
 	version, err := c.allocateSnapshotVersion(ctx, bucket, token)
 	if err != nil {
 		return err

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -137,3 +137,40 @@ func TestSchedulerCacheRetireAndReopenFencesOldEpochIntegration(t *testing.T) {
 	require.Len(t, snapshot, 1)
 	require.Equal(t, account.ID, snapshot[0].ID)
 }
+
+func TestSchedulerCacheGroupLifecycleLeaseOwnerAndTTLIntegration(t *testing.T) {
+	ctx := context.Background()
+	rdb := testRedis(t)
+	cache := NewSchedulerCache(rdb)
+	const groupID int64 = 78
+	const ttl = 500 * time.Millisecond
+
+	first, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, ttl)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	pttl, err := rdb.PTTL(ctx, schedulerGroupLifecycleLockKey(groupID)).Result()
+	require.NoError(t, err)
+	require.Positive(t, pttl)
+	require.LessOrEqual(t, pttl, ttl)
+
+	var second service.SchedulerGroupLifecycleLease
+	require.Eventually(t, func() bool {
+		var acquireErr error
+		second, acquired, acquireErr = cache.TryAcquireGroupLifecycleLease(ctx, groupID, time.Minute)
+		return acquireErr == nil && acquired
+	}, 5*time.Second, 20*time.Millisecond)
+	require.NotEqual(t, first.OwnerToken, second.OwnerToken)
+
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, first), service.ErrSchedulerGroupLifecycleLeaseLost)
+	_, acquired, err = cache.TryAcquireGroupLifecycleLease(ctx, groupID, time.Minute)
+	require.NoError(t, err)
+	require.False(t, acquired, "a stale release must not delete the successor lease")
+
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, second))
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, second), service.ErrSchedulerGroupLifecycleLeaseLost)
+	third, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.True(t, third.ValidFor(groupID))
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, third))
+}

--- a/backend/internal/repository/scheduler_cache_integration_test.go
+++ b/backend/internal/repository/scheduler_cache_integration_test.go
@@ -67,7 +67,9 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 		},
 	}
 
-	require.NoError(t, cache.SetSnapshot(ctx, bucket, []service.Account{account}))
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
 
 	snapshot, hit, err := cache.GetSnapshot(ctx, bucket)
 	require.NoError(t, err)
@@ -101,4 +103,37 @@ func TestSchedulerCacheSnapshotUsesSlimMetadataButKeepsFullAccount(t *testing.T)
 	require.Equal(t, strings.Repeat("x", 4096), full.GetCredential("huge_blob"))
 	require.Len(t, full.AccountGroups, 1)
 	require.NotNil(t, full.AccountGroups[0].Group)
+}
+
+func TestSchedulerCacheRetireAndReopenFencesOldEpochIntegration(t *testing.T) {
+	ctx := context.Background()
+	rdb := testRedis(t)
+	cache := NewSchedulerCache(rdb)
+	bucket := service.SchedulerBucket{GroupID: 77, Platform: service.PlatformAntigravity, Mode: service.SchedulerModeForced}
+	account := service.Account{ID: 7701, Platform: service.PlatformAntigravity, Type: service.AccountTypeOAuth}
+
+	oldToken, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}))
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+
+	_, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.False(t, hit)
+	_, err = cache.CaptureBucketWriteToken(ctx, bucket)
+	require.ErrorIs(t, err, service.ErrSchedulerBucketRetired)
+	require.ErrorIs(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}), service.ErrSchedulerBucketRetired)
+
+	newToken, err := cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	require.Greater(t, newToken.Epoch, oldToken.Epoch)
+	require.ErrorIs(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}), service.ErrSchedulerBucketWriteFenced)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, newToken, []service.Account{account}))
+
+	snapshot, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, snapshot, 1)
+	require.Equal(t, account.ID, snapshot[0].ID)
 }

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -14,13 +14,18 @@ import (
 )
 
 func newSchedulerCacheUnit(t *testing.T) *schedulerCache {
+	cache, _ := newSchedulerCacheUnitWithRedis(t)
+	return cache
+}
+
+func newSchedulerCacheUnitWithRedis(t *testing.T) (*schedulerCache, *miniredis.Miniredis) {
 	t.Helper()
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = rdb.Close() })
 	cache, ok := newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize).(*schedulerCache)
 	require.True(t, ok)
-	return cache
+	return cache, mr
 }
 
 func TestSchedulerCacheWriteAccountsSkipsUnencodableTimes(t *testing.T) {
@@ -228,4 +233,208 @@ func TestBuildSchedulerMetadataAccount_KeepsSparkShadowRoutingIdentity(t *testin
 	require.Equal(t, map[string]any{"gpt-5.3-codex-spark": "gpt-5.3-codex-spark"}, got.Credentials["model_mapping"])
 	require.Equal(t, map[string]any{"gpt-5.4": "gpt-5.4-openai-compact"}, got.Credentials["compact_model_mapping"])
 	require.Nil(t, got.Credentials["access_token"])
+}
+
+func TestSchedulerCacheBucketRetirementFencesWritersAndReopen(t *testing.T) {
+	ctx := context.Background()
+	cache, mr := newSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 41, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	otherBucket := service.SchedulerBucket{GroupID: 42, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{ID: 4101, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, token.ValidFor(bucket))
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+
+	// A token is bound to the full bucket identity, not just an epoch number.
+	err = cache.SetSnapshot(ctx, otherBucket, token, []service.Account{account})
+	require.ErrorIs(t, err, service.ErrSchedulerBucketWriteFenced)
+	_, err = cache.rdb.Get(ctx, schedulerBucketKey(schedulerVersionPrefix, otherBucket)).Result()
+	require.ErrorIs(t, err, redis.Nil)
+	otherAccount := service.Account{ID: 4201, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+	otherToken, err := cache.CaptureBucketWriteToken(ctx, otherBucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, otherBucket, otherToken, []service.Account{otherAccount}))
+	otherEpoch := otherToken.Epoch
+
+	activeVersion, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket)).Result()
+	require.NoError(t, err)
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+	retiredEpoch, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerEpochPrefix, bucket)).Int64()
+	require.NoError(t, err)
+	require.Greater(t, retiredEpoch, token.Epoch)
+
+	// Retirement is idempotent and does not advance the epoch again.
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+	retiredEpochAgain, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerEpochPrefix, bucket)).Int64()
+	require.NoError(t, err)
+	require.Equal(t, retiredEpoch, retiredEpochAgain)
+
+	// New readers miss because ready/active were removed atomically. A reader that
+	// captured activeVersion before retirement may still finish against that version.
+	_, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.False(t, hit)
+	ids, err := cache.rdb.ZRange(ctx, schedulerSnapshotKey(bucket, activeVersion), 0, -1).Result()
+	require.NoError(t, err)
+	require.Equal(t, []string{"4101"}, ids)
+	ttl, err := cache.rdb.TTL(ctx, schedulerSnapshotKey(bucket, activeVersion)).Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+	require.LessOrEqual(t, ttl, time.Duration(snapshotGraceTTLSeconds)*time.Second)
+
+	buckets, err := cache.ListBuckets(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, buckets, bucket)
+	require.Contains(t, buckets, otherBucket)
+	otherSnapshot, otherHit, err := cache.GetSnapshot(ctx, otherBucket)
+	require.NoError(t, err)
+	require.True(t, otherHit)
+	require.Len(t, otherSnapshot, 1)
+	require.Equal(t, otherAccount.ID, otherSnapshot[0].ID)
+	otherEpochAfter, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerEpochPrefix, otherBucket)).Int64()
+	require.NoError(t, err)
+	require.Equal(t, otherEpoch, otherEpochAfter)
+
+	_, err = cache.CaptureBucketWriteToken(ctx, bucket)
+	require.ErrorIs(t, err, service.ErrSchedulerBucketRetired)
+	versionBeforeRejectedWrite, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerVersionPrefix, bucket)).Int64()
+	require.NoError(t, err)
+	err = cache.SetSnapshot(ctx, bucket, token, []service.Account{account})
+	require.ErrorIs(t, err, service.ErrSchedulerBucketRetired)
+	versionAfterRejectedWrite, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerVersionPrefix, bucket)).Int64()
+	require.NoError(t, err)
+	require.Equal(t, versionBeforeRejectedWrite, versionAfterRejectedWrite, "fenced writers must not allocate a new version")
+	retired, err := cache.rdb.Exists(ctx, schedulerBucketKey(schedulerRetiredPrefix, bucket)).Result()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, retired, "ordinary writers must never clear the tombstone")
+	mr.FastForward(time.Duration(snapshotGraceTTLSeconds+1) * time.Second)
+	exists, err := cache.rdb.Exists(ctx, schedulerSnapshotKey(bucket, activeVersion)).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists, "retired active snapshot must expire after the in-flight grace period")
+
+	newToken, err := cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, newToken.ValidFor(bucket))
+	require.Equal(t, retiredEpoch, newToken.Epoch)
+	reopenedAgain, err := cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	require.Equal(t, newToken, reopenedAgain, "reopen must be idempotent within one retirement generation")
+	err = cache.SetSnapshot(ctx, bucket, token, []service.Account{account})
+	require.ErrorIs(t, err, service.ErrSchedulerBucketWriteFenced)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, newToken, []service.Account{account}))
+	reopenedWhileOpen, err := cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	require.Equal(t, newToken, reopenedWhileOpen)
+
+	snapshot, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, snapshot, 1)
+	require.Equal(t, account.ID, snapshot[0].ID)
+}
+
+func TestSchedulerCacheActivationIsFencedAfterRetire(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	bucket := service.SchedulerBucket{GroupID: 51, Platform: service.PlatformAnthropic, Mode: service.SchedulerModeMixed}
+	account := service.Account{ID: 5101, Platform: service.PlatformAnthropic, Type: service.AccountTypeAPIKey}
+
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	version, err := cache.allocateSnapshotVersion(ctx, bucket, token)
+	require.NoError(t, err)
+	require.NoError(t, cache.writeSnapshotVersion(ctx, bucket, version, []service.Account{account}))
+
+	// Deterministic race C: retirement and authoritative reopen both happen after
+	// INCR/write but before the old writer activates.
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+	_, err = cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	err = cache.activateSnapshotVersion(ctx, bucket, token, version)
+	require.ErrorIs(t, err, service.ErrSchedulerBucketWriteFenced)
+
+	exists, err := cache.rdb.Exists(ctx, schedulerSnapshotKey(bucket, version)).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists, "fenced activation must delete its unpublished snapshot")
+	exists, err = cache.rdb.Exists(
+		ctx,
+		schedulerBucketKey(schedulerReadyPrefix, bucket),
+		schedulerBucketKey(schedulerActivePrefix, bucket),
+	).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists)
+	buckets, err := cache.ListBuckets(ctx)
+	require.NoError(t, err)
+	require.NotContains(t, buckets, bucket)
+}
+
+func TestSchedulerCacheConcurrentReopenReturnsSameToken(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	bucket := service.SchedulerBucket{GroupID: 53, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeForced}
+	account := service.Account{ID: 5301, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+
+	oldToken, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+
+	type reopenResult struct {
+		token service.SchedulerBucketWriteToken
+		err   error
+	}
+	start := make(chan struct{})
+	results := make(chan reopenResult, 2)
+	for range 2 {
+		go func() {
+			<-start
+			token, err := cache.ReopenBucket(ctx, bucket)
+			results <- reopenResult{token: token, err: err}
+		}()
+	}
+	close(start)
+	first := <-results
+	second := <-results
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	require.Equal(t, first.token, second.token)
+	require.Greater(t, first.token.Epoch, oldToken.Epoch)
+
+	require.ErrorIs(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}), service.ErrSchedulerBucketWriteFenced)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, first.token, []service.Account{account}))
+}
+
+func TestSchedulerCacheReopenExpiresPreviousActiveSnapshot(t *testing.T) {
+	ctx := context.Background()
+	cache, mr := newSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 52, Platform: service.PlatformGemini, Mode: service.SchedulerModeForced}
+	account := service.Account{ID: 5201, Platform: service.PlatformGemini, Type: service.AccountTypeAPIKey}
+
+	oldToken, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}))
+	oldVersion, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket)).Result()
+	require.NoError(t, err)
+	retiredEpoch := oldToken.Epoch + 1
+	require.NoError(t, cache.rdb.Set(ctx, schedulerBucketKey(schedulerEpochPrefix, bucket), retiredEpoch, 0).Err())
+	require.NoError(t, cache.rdb.Set(ctx, schedulerBucketKey(schedulerRetiredPrefix, bucket), retiredEpoch, 0).Err())
+
+	newToken, err := cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	require.Equal(t, retiredEpoch, newToken.Epoch)
+	_, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.False(t, hit)
+	ttl, err := cache.rdb.TTL(ctx, schedulerSnapshotKey(bucket, oldVersion)).Result()
+	require.NoError(t, err)
+	require.Positive(t, ttl)
+	require.LessOrEqual(t, ttl, time.Duration(snapshotGraceTTLSeconds)*time.Second)
+
+	require.ErrorIs(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}), service.ErrSchedulerBucketWriteFenced)
+	mr.FastForward(time.Duration(snapshotGraceTTLSeconds+1) * time.Second)
+	exists, err := cache.rdb.Exists(ctx, schedulerSnapshotKey(bucket, oldVersion)).Result()
+	require.NoError(t, err)
+	require.Zero(t, exists)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, newToken, []service.Account{account}))
 }

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -4,6 +4,8 @@ package repository
 
 import (
 	"context"
+	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
@@ -437,4 +439,175 @@ func TestSchedulerCacheReopenExpiresPreviousActiveSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, exists)
 	require.NoError(t, cache.SetSnapshot(ctx, bucket, newToken, []service.Account{account}))
+}
+
+func TestSchedulerCacheGroupLifecycleLeaseConcurrentAcquireSingleOwner(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	const groupID int64 = 71
+
+	type result struct {
+		lease    service.SchedulerGroupLifecycleLease
+		acquired bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 32)
+	for range 32 {
+		go func() {
+			<-start
+			lease, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, time.Minute)
+			results <- result{lease: lease, acquired: acquired, err: err}
+		}()
+	}
+	close(start)
+
+	var owner service.SchedulerGroupLifecycleLease
+	acquiredCount := 0
+	for range 32 {
+		got := <-results
+		require.NoError(t, got.err)
+		if got.acquired {
+			acquiredCount++
+			owner = got.lease
+			require.True(t, got.lease.ValidFor(groupID))
+		} else {
+			require.Equal(t, service.SchedulerGroupLifecycleLease{}, got.lease)
+		}
+	}
+	require.Equal(t, 1, acquiredCount)
+	require.Len(t, owner.OwnerToken, schedulerGroupLifecycleOwnerTokenBytes*2)
+	require.Equal(t, strings.ToLower(owner.OwnerToken), owner.OwnerToken)
+	decodedOwner, err := hex.DecodeString(owner.OwnerToken)
+	require.NoError(t, err)
+	require.Len(t, decodedOwner, schedulerGroupLifecycleOwnerTokenBytes)
+
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, owner))
+	next, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.True(t, next.ValidFor(groupID))
+	require.NotEqual(t, owner.OwnerToken, next.OwnerToken)
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, next))
+}
+
+func TestSchedulerCacheGroupLifecycleLeaseStaleReleaseCannotDeleteSuccessor(t *testing.T) {
+	ctx := context.Background()
+	cache, mr := newSchedulerCacheUnitWithRedis(t)
+	const groupID int64 = 72
+	const ttl = time.Minute
+
+	first, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, ttl)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	mr.FastForward(ttl + time.Second)
+	second, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, ttl)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.NotEqual(t, first.OwnerToken, second.OwnerToken)
+
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, first), service.ErrSchedulerGroupLifecycleLeaseLost)
+	owner, err := cache.rdb.Get(ctx, schedulerGroupLifecycleLockKey(groupID)).Result()
+	require.NoError(t, err)
+	require.Equal(t, second.OwnerToken, owner)
+
+	_, acquired, err = cache.TryAcquireGroupLifecycleLease(ctx, groupID, ttl)
+	require.NoError(t, err)
+	require.False(t, acquired)
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, second))
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, second), service.ErrSchedulerGroupLifecycleLeaseLost)
+}
+
+func TestSchedulerCacheGroupLifecycleLeaseExpiredReleaseIsLost(t *testing.T) {
+	ctx := context.Background()
+	cache, mr := newSchedulerCacheUnitWithRedis(t)
+	const groupID int64 = 73
+	const ttl = time.Minute
+
+	lease, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, groupID, ttl)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	mr.FastForward(ttl + time.Second)
+
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, lease), service.ErrSchedulerGroupLifecycleLeaseLost)
+}
+
+func TestSchedulerCacheGroupLifecycleLeaseWrongOwnerAndCrossGroupAreLost(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	const firstGroupID int64 = 74
+	const secondGroupID int64 = 75
+
+	first, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, firstGroupID, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	second, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, secondGroupID, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired, "different groups must acquire independently")
+	require.NotEqual(t, first.OwnerToken, second.OwnerToken)
+
+	wrongOwner := first
+	wrongOwner.OwnerToken = strings.Repeat("0", schedulerGroupLifecycleOwnerTokenBytes*2)
+	if wrongOwner.OwnerToken == first.OwnerToken {
+		wrongOwner.OwnerToken = strings.Repeat("1", schedulerGroupLifecycleOwnerTokenBytes*2)
+	}
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, wrongOwner), service.ErrSchedulerGroupLifecycleLeaseLost)
+
+	crossGroup := first
+	crossGroup.GroupID = secondGroupID
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(ctx, crossGroup), service.ErrSchedulerGroupLifecycleLeaseLost)
+
+	firstOwner, err := cache.rdb.Get(ctx, schedulerGroupLifecycleLockKey(firstGroupID)).Result()
+	require.NoError(t, err)
+	require.Equal(t, first.OwnerToken, firstOwner)
+	secondOwner, err := cache.rdb.Get(ctx, schedulerGroupLifecycleLockKey(secondGroupID)).Result()
+	require.NoError(t, err)
+	require.Equal(t, second.OwnerToken, secondOwner)
+
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, first))
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, second))
+}
+
+func TestSchedulerCacheGroupLifecycleLeaseCanceledContextFailsClosed(t *testing.T) {
+	cache := newSchedulerCacheUnit(t)
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	lease, acquired, err := cache.TryAcquireGroupLifecycleLease(canceledCtx, 76, time.Minute)
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, acquired)
+	require.Equal(t, service.SchedulerGroupLifecycleLease{}, lease)
+
+	ctx := context.Background()
+	lease, acquired, err = cache.TryAcquireGroupLifecycleLease(ctx, 76, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(canceledCtx, lease), context.Canceled)
+	owner, err := cache.rdb.Get(ctx, schedulerGroupLifecycleLockKey(lease.GroupID)).Result()
+	require.NoError(t, err)
+	require.Equal(t, lease.OwnerToken, owner)
+	require.NoError(t, cache.ReleaseGroupLifecycleLease(ctx, lease))
+}
+
+func TestSchedulerCacheGroupLifecycleLeaseRejectsInvalidInput(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+
+	lease, acquired, err := cache.TryAcquireGroupLifecycleLease(ctx, 0, time.Minute)
+	require.ErrorIs(t, err, service.ErrSchedulerGroupLifecycleLeaseInvalid)
+	require.False(t, acquired)
+	require.Equal(t, service.SchedulerGroupLifecycleLease{}, lease)
+
+	lease, acquired, err = cache.TryAcquireGroupLifecycleLease(ctx, 73, 0)
+	require.ErrorIs(t, err, service.ErrSchedulerGroupLifecycleLeaseInvalid)
+	require.False(t, acquired)
+	require.Equal(t, service.SchedulerGroupLifecycleLease{}, lease)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, cache.ReleaseGroupLifecycleLease(canceledCtx, service.SchedulerGroupLifecycleLease{}), service.ErrSchedulerGroupLifecycleLeaseInvalid)
+	keys, err := cache.rdb.DBSize(ctx).Result()
+	require.NoError(t, err)
+	require.Zero(t, keys)
 }

--- a/backend/internal/service/scheduler_cache.go
+++ b/backend/internal/service/scheduler_cache.go
@@ -16,8 +16,10 @@ const (
 )
 
 var (
-	ErrSchedulerBucketRetired     = errors.New("scheduler bucket retired")
-	ErrSchedulerBucketWriteFenced = errors.New("scheduler bucket write fenced")
+	ErrSchedulerBucketRetired              = errors.New("scheduler bucket retired")
+	ErrSchedulerBucketWriteFenced          = errors.New("scheduler bucket write fenced")
+	ErrSchedulerGroupLifecycleLeaseInvalid = errors.New("scheduler group lifecycle lease invalid")
+	ErrSchedulerGroupLifecycleLeaseLost    = errors.New("scheduler group lifecycle lease lost")
 )
 
 // SchedulerBucketWriteToken fences a snapshot writer to one bucket epoch.
@@ -29,6 +31,17 @@ type SchedulerBucketWriteToken struct {
 
 func (t SchedulerBucketWriteToken) ValidFor(bucket SchedulerBucket) bool {
 	return t.Epoch > 0 && t.Bucket == bucket
+}
+
+// SchedulerGroupLifecycleLease identifies one owner of a group's short-lived
+// retirement/reopen critical section.
+type SchedulerGroupLifecycleLease struct {
+	GroupID    int64
+	OwnerToken string
+}
+
+func (l SchedulerGroupLifecycleLease) ValidFor(groupID int64) bool {
+	return groupID > 0 && l.GroupID == groupID && l.OwnerToken != ""
 }
 
 type SchedulerBucket struct {
@@ -76,9 +89,17 @@ type SchedulerCache interface {
 	// ReopenBucket is the only operation allowed to clear a tombstone. It returns
 	// the retirement generation established by RetireBucket; repeated calls for
 	// the same generation are idempotent. Callers must serialize a fresh authority
-	// check through ReopenBucket with RetireBucket under the same bucket lifecycle
-	// lock; ordinary rebuild paths never call ReopenBucket.
+	// check through ReopenBucket with RetireBucket under the same group lifecycle
+	// lease; ordinary rebuild paths never call ReopenBucket.
 	ReopenBucket(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error)
+	// TryAcquireGroupLifecycleLease serializes authoritative retirement/reopen
+	// decisions for one non-zero group across instances.
+	TryAcquireGroupLifecycleLease(ctx context.Context, groupID int64, ttl time.Duration) (SchedulerGroupLifecycleLease, bool, error)
+	// ReleaseGroupLifecycleLease releases the lease only if its owner token still
+	// matches, so an expired holder cannot delete a successor's lease. Missing,
+	// expired, mismatched, and already released leases return
+	// ErrSchedulerGroupLifecycleLeaseLost.
+	ReleaseGroupLifecycleLease(ctx context.Context, lease SchedulerGroupLifecycleLease) error
 	// GetAccount 获取单账号快照。
 	GetAccount(ctx context.Context, accountID int64) (*Account, error)
 	// SetAccount 写入单账号快照（包含不可调度状态）。

--- a/backend/internal/service/scheduler_cache.go
+++ b/backend/internal/service/scheduler_cache.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -13,6 +14,22 @@ const (
 	SchedulerModeMixed  = "mixed"
 	SchedulerModeForced = "forced"
 )
+
+var (
+	ErrSchedulerBucketRetired     = errors.New("scheduler bucket retired")
+	ErrSchedulerBucketWriteFenced = errors.New("scheduler bucket write fenced")
+)
+
+// SchedulerBucketWriteToken fences a snapshot writer to one bucket epoch.
+// Tokens must be captured before any database load or queued rebuild work.
+type SchedulerBucketWriteToken struct {
+	Bucket SchedulerBucket
+	Epoch  int64
+}
+
+func (t SchedulerBucketWriteToken) ValidFor(bucket SchedulerBucket) bool {
+	return t.Epoch > 0 && t.Bucket == bucket
+}
 
 type SchedulerBucket struct {
 	GroupID  int64
@@ -47,8 +64,21 @@ func ParseSchedulerBucket(raw string) (SchedulerBucket, bool) {
 type SchedulerCache interface {
 	// GetSnapshot 读取快照并返回命中与否（ready + active + 数据完整）。
 	GetSnapshot(ctx context.Context, bucket SchedulerBucket) ([]*Account, bool, error)
-	// SetSnapshot 写入快照并切换激活版本。
-	SetSnapshot(ctx context.Context, bucket SchedulerBucket, accounts []Account) error
+	// CaptureBucketWriteToken captures the current open epoch without changing
+	// retirement state. A tombstoned bucket returns ErrSchedulerBucketRetired.
+	CaptureBucketWriteToken(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error)
+	// SetSnapshot 写入快照并切换激活版本。token 必须在 DB load/任务排队前取得。
+	SetSnapshot(ctx context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accounts []Account) error
+	// RetireBucket persistently tombstones a bucket and fences every older writer.
+	// Readers that captured the active version before retirement may finish; new
+	// readers observe ready/active as absent.
+	RetireBucket(ctx context.Context, bucket SchedulerBucket) error
+	// ReopenBucket is the only operation allowed to clear a tombstone. It returns
+	// the retirement generation established by RetireBucket; repeated calls for
+	// the same generation are idempotent. Callers must serialize a fresh authority
+	// check through ReopenBucket with RetireBucket under the same bucket lifecycle
+	// lock; ordinary rebuild paths never call ReopenBucket.
+	ReopenBucket(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error)
 	// GetAccount 获取单账号快照。
 	GetAccount(ctx context.Context, accountID int64) (*Account, error)
 	// SetAccount 写入单账号快照（包含不可调度状态）。

--- a/backend/internal/service/scheduler_snapshot_batch_query_test.go
+++ b/backend/internal/service/scheduler_snapshot_batch_query_test.go
@@ -1,0 +1,534 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type batchAccountQueryKey struct {
+	groupID  int64
+	platform string
+	mixed    bool
+}
+
+type batchAccountQueryResult struct {
+	accounts []Account
+	err      error
+}
+
+type batchAccountQueryRepo struct {
+	AccountRepository
+
+	mu        sync.Mutex
+	calls     map[batchAccountQueryKey]int
+	results   map[batchAccountQueryKey][]batchAccountQueryResult
+	beforeRun func(batchAccountQueryKey)
+}
+
+func newBatchAccountQueryRepo() *batchAccountQueryRepo {
+	return &batchAccountQueryRepo{
+		calls:   make(map[batchAccountQueryKey]int),
+		results: make(map[batchAccountQueryKey][]batchAccountQueryResult),
+	}
+}
+
+func (r *batchAccountQueryRepo) ListSchedulableByGroupIDAndPlatform(_ context.Context, groupID int64, platform string) ([]Account, error) {
+	return r.run(batchAccountQueryKey{groupID: groupID, platform: platform})
+}
+
+func (r *batchAccountQueryRepo) ListSchedulableByGroupIDAndPlatforms(_ context.Context, groupID int64, platforms []string) ([]Account, error) {
+	return r.run(batchAccountQueryKey{groupID: groupID, platform: platforms[0], mixed: true})
+}
+
+func (r *batchAccountQueryRepo) ListSchedulableUngroupedByPlatform(_ context.Context, platform string) ([]Account, error) {
+	return r.run(batchAccountQueryKey{platform: platform})
+}
+
+func (r *batchAccountQueryRepo) ListSchedulableUngroupedByPlatforms(_ context.Context, platforms []string) ([]Account, error) {
+	return r.run(batchAccountQueryKey{platform: platforms[0], mixed: true})
+}
+
+func (r *batchAccountQueryRepo) ListSchedulableByPlatform(_ context.Context, platform string) ([]Account, error) {
+	return r.run(batchAccountQueryKey{platform: platform})
+}
+
+func (r *batchAccountQueryRepo) ListSchedulableByPlatforms(_ context.Context, platforms []string) ([]Account, error) {
+	return r.run(batchAccountQueryKey{platform: platforms[0], mixed: true})
+}
+
+func (r *batchAccountQueryRepo) run(key batchAccountQueryKey) ([]Account, error) {
+	r.mu.Lock()
+	r.calls[key]++
+	call := r.calls[key]
+	results := r.results[key]
+	beforeRun := r.beforeRun
+	r.mu.Unlock()
+
+	if beforeRun != nil {
+		beforeRun(key)
+	}
+	if call <= len(results) {
+		result := results[call-1]
+		return append([]Account(nil), result.accounts...), result.err
+	}
+	return []Account{{
+		ID:          int64(call),
+		Name:        "source",
+		Platform:    key.platform,
+		Status:      StatusActive,
+		Schedulable: true,
+	}}, nil
+}
+
+func (r *batchAccountQueryRepo) callCount(key batchAccountQueryKey) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls[key]
+}
+
+type batchSnapshotWrite struct {
+	token    SchedulerBucketWriteToken
+	accounts []Account
+}
+
+type batchSnapshotCache struct {
+	SchedulerCache
+
+	mu          sync.Mutex
+	nextEpoch   int64
+	captures    []SchedulerBucket
+	captured    map[SchedulerBucket]SchedulerBucketWriteToken
+	locks       map[SchedulerBucket]int
+	lockBusy    map[SchedulerBucket]bool
+	lockErrors  map[SchedulerBucket]error
+	setErrors   map[SchedulerBucket]error
+	setAttempts map[SchedulerBucket]int
+	writes      map[SchedulerBucket][]batchSnapshotWrite
+	versions    map[SchedulerBucket]int
+	beforeSet   func()
+}
+
+func newBatchSnapshotCache() *batchSnapshotCache {
+	return &batchSnapshotCache{
+		captured:    make(map[SchedulerBucket]SchedulerBucketWriteToken),
+		locks:       make(map[SchedulerBucket]int),
+		lockBusy:    make(map[SchedulerBucket]bool),
+		lockErrors:  make(map[SchedulerBucket]error),
+		setErrors:   make(map[SchedulerBucket]error),
+		setAttempts: make(map[SchedulerBucket]int),
+		writes:      make(map[SchedulerBucket][]batchSnapshotWrite),
+		versions:    make(map[SchedulerBucket]int),
+	}
+}
+
+func (c *batchSnapshotCache) CaptureBucketWriteToken(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextEpoch++
+	token := SchedulerBucketWriteToken{Bucket: bucket, Epoch: c.nextEpoch}
+	c.captures = append(c.captures, bucket)
+	c.captured[bucket] = token
+	return token, nil
+}
+
+func (c *batchSnapshotCache) TryLockBucket(_ context.Context, bucket SchedulerBucket, _ time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.locks[bucket]++
+	if err := c.lockErrors[bucket]; err != nil {
+		return false, err
+	}
+	return !c.lockBusy[bucket], nil
+}
+
+func (c *batchSnapshotCache) UnlockBucket(context.Context, SchedulerBucket) error {
+	return nil
+}
+
+func (c *batchSnapshotCache) SetSnapshot(_ context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accounts []Account) error {
+	if c.beforeSet != nil {
+		c.beforeSet()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.setAttempts[bucket]++
+	if token != c.captured[bucket] || !token.ValidFor(bucket) {
+		return ErrSchedulerBucketWriteFenced
+	}
+	if err := c.setErrors[bucket]; err != nil {
+		return err
+	}
+	c.versions[bucket]++
+	c.writes[bucket] = append(c.writes[bucket], batchSnapshotWrite{
+		token:    token,
+		accounts: append([]Account(nil), accounts...),
+	})
+	return nil
+}
+
+func (c *batchSnapshotCache) captureCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.captures)
+}
+
+func (c *batchSnapshotCache) bucketState(bucket SchedulerBucket) (locks, attempts, version int, writes []batchSnapshotWrite) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.locks[bucket], c.setAttempts[bucket], c.versions[bucket], append([]batchSnapshotWrite(nil), c.writes[bucket]...)
+}
+
+func newBatchQueryTestService(cache SchedulerCache, accounts AccountRepository, runMode string) *SchedulerSnapshotService {
+	return NewSchedulerSnapshotService(cache, nil, accounts, nil, &config.Config{RunMode: runMode})
+}
+
+func TestSchedulerRebuildBatchReusesSingleForcedQueryAndKeepsSnapshotsIndependent(t *testing.T) {
+	const groupID int64 = 201
+	single := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	forced := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+	cache := newBatchSnapshotCache()
+	repo := newBatchAccountQueryRepo()
+	wantCaptures := 2
+	repo.beforeRun = func(batchAccountQueryKey) {
+		require.Equal(t, wantCaptures, cache.captureCount(), "all tokens must be prepared before the first DB query")
+		wantCaptures += 2
+	}
+	svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildBuckets(context.Background(), []SchedulerBucket{single, forced}, "first"))
+	queryKey := batchAccountQueryKey{groupID: groupID, platform: PlatformOpenAI}
+	require.Equal(t, 1, repo.callCount(queryKey))
+	for _, bucket := range []SchedulerBucket{single, forced} {
+		locks, attempts, version, writes := cache.bucketState(bucket)
+		require.Equal(t, 1, locks, bucket.String())
+		require.Equal(t, 1, attempts, bucket.String())
+		require.Equal(t, 1, version, bucket.String())
+		require.Len(t, writes, 1, bucket.String())
+		require.Equal(t, "source", writes[0].accounts[0].Name, bucket.String())
+		require.Equal(t, bucket, writes[0].token.Bucket)
+	}
+	_, _, _, singleWrites := cache.bucketState(single)
+	_, _, _, forcedWrites := cache.bucketState(forced)
+	require.NotEqual(t, singleWrites[0].token.Epoch, forcedWrites[0].token.Epoch)
+
+	require.NoError(t, svc.rebuildBuckets(context.Background(), []SchedulerBucket{single, forced}, "second"))
+	require.Equal(t, 2, repo.callCount(queryKey), "successful results must not be cached across rebuild batches")
+	for _, bucket := range []SchedulerBucket{single, forced} {
+		locks, attempts, version, writes := cache.bucketState(bucket)
+		require.Equal(t, 2, locks, bucket.String())
+		require.Equal(t, 2, attempts, bucket.String())
+		require.Equal(t, 2, version, bucket.String())
+		require.Len(t, writes, 2, bucket.String())
+		require.Equal(t, "source", writes[1].accounts[0].Name, bucket.String())
+	}
+}
+
+func TestSchedulerRebuildBatchKeepsMixedAndDifferentKeysIndependent(t *testing.T) {
+	const groupID int64 = 202
+	buckets := []SchedulerBucket{
+		{GroupID: groupID, Platform: PlatformAnthropic, Mode: SchedulerModeSingle},
+		{GroupID: groupID, Platform: PlatformAnthropic, Mode: SchedulerModeForced},
+		{GroupID: groupID, Platform: PlatformAnthropic, Mode: SchedulerModeMixed},
+		{GroupID: groupID + 1, Platform: PlatformAnthropic, Mode: SchedulerModeSingle},
+		{GroupID: groupID, Platform: PlatformGemini, Mode: SchedulerModeForced},
+		{GroupID: 0, Platform: PlatformOpenAI, Mode: SchedulerModeSingle},
+		{GroupID: -1, Platform: PlatformOpenAI, Mode: SchedulerModeForced},
+	}
+	cache := newBatchSnapshotCache()
+	repo := newBatchAccountQueryRepo()
+	svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildBuckets(context.Background(), buckets, "test"))
+	require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformAnthropic}))
+	require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformAnthropic, mixed: true}))
+	require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID + 1, platform: PlatformAnthropic}))
+	require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformGemini}))
+	require.Equal(t, 2, repo.callCount(batchAccountQueryKey{platform: PlatformOpenAI}), "group0 and a negative historical group must not share")
+	for _, bucket := range buckets {
+		locks, attempts, version, _ := cache.bucketState(bucket)
+		require.Equal(t, 1, locks, bucket.String())
+		require.Equal(t, 1, attempts, bucket.String())
+		require.Equal(t, 1, version, bucket.String())
+	}
+}
+
+func TestSchedulerRebuildBatchKeepsSimpleModeBucketGroupsIndependent(t *testing.T) {
+	single := SchedulerBucket{GroupID: 204, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	forced := SchedulerBucket{GroupID: 0, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+	cache := newBatchSnapshotCache()
+	repo := newBatchAccountQueryRepo()
+	svc := newBatchQueryTestService(cache, repo, config.RunModeSimple)
+
+	require.NoError(t, svc.rebuildBuckets(context.Background(), []SchedulerBucket{single, forced}, "test"))
+	require.Equal(t, 2, repo.callCount(batchAccountQueryKey{platform: PlatformOpenAI}))
+}
+
+func TestSchedulerRebuildBatchDoesNotCacheMixedOrHistoricalQueries(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		bucket SchedulerBucket
+		key    batchAccountQueryKey
+	}{
+		{
+			name:   "mixed",
+			bucket: SchedulerBucket{GroupID: 204, Platform: PlatformAnthropic, Mode: SchedulerModeMixed},
+			key:    batchAccountQueryKey{groupID: 204, platform: PlatformAnthropic, mixed: true},
+		},
+		{
+			name:   "historical",
+			bucket: SchedulerBucket{GroupID: 204, Platform: PlatformOpenAI, Mode: "unknown"},
+			key:    batchAccountQueryKey{groupID: 204, platform: PlatformOpenAI},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cache := newBatchSnapshotCache()
+			token, err := cache.CaptureBucketWriteToken(context.Background(), tc.bucket)
+			require.NoError(t, err)
+			repo := newBatchAccountQueryRepo()
+			svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+			tasks := []schedulerBucketWriteTask{
+				{bucket: tc.bucket, token: token},
+				{bucket: tc.bucket, token: token},
+			}
+			queries := newSchedulerAccountQueryCache(tasks)
+
+			require.NoError(t, svc.rebuildPreparedBucketTasks(context.Background(), tasks, "test", false, queries))
+			require.Equal(t, 2, repo.callCount(tc.key))
+			require.Empty(t, queries.accounts)
+			locks, attempts, version, _ := cache.bucketState(tc.bucket)
+			require.Equal(t, 2, locks)
+			require.Equal(t, 2, attempts)
+			require.Equal(t, 2, version)
+		})
+	}
+}
+
+func TestSchedulerRebuildBatchRetriesQueryFailureForFollowingBucket(t *testing.T) {
+	const groupID int64 = 205
+	single := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	forced := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+	wantErr := errors.New("first query failed")
+	key := batchAccountQueryKey{groupID: groupID, platform: PlatformOpenAI}
+	repo := newBatchAccountQueryRepo()
+	repo.results[key] = []batchAccountQueryResult{
+		{err: wantErr},
+		{accounts: []Account{{ID: 2051, Name: "retry", Platform: PlatformOpenAI}}},
+	}
+	cache := newBatchSnapshotCache()
+	svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+	err := svc.rebuildBuckets(context.Background(), []SchedulerBucket{single, forced}, "test")
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 2, repo.callCount(key), "failed queries must not enter the batch cache")
+	_, singleAttempts, singleVersion, _ := cache.bucketState(single)
+	_, forcedAttempts, forcedVersion, forcedWrites := cache.bucketState(forced)
+	require.Zero(t, singleAttempts)
+	require.Zero(t, singleVersion)
+	require.Equal(t, 1, forcedAttempts)
+	require.Equal(t, 1, forcedVersion)
+	require.Equal(t, "retry", forcedWrites[0].accounts[0].Name)
+}
+
+func TestSchedulerFullRebuildSharesSuccessfulQueryAcrossStrictAndOrdinarySegments(t *testing.T) {
+	const groupID int64 = 206
+	single := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	forced := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+	cache := newBatchSnapshotCache()
+	cache.setErrors[single] = ErrSchedulerBucketWriteFenced
+	singleToken, err := cache.CaptureBucketWriteToken(context.Background(), single)
+	require.NoError(t, err)
+	forcedToken, err := cache.CaptureBucketWriteToken(context.Background(), forced)
+	require.NoError(t, err)
+	repo := newBatchAccountQueryRepo()
+	svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+	err = svc.prepareAndRebuildFullSnapshot(
+		context.Background(),
+		[]schedulerBucketWriteTask{{bucket: forced, token: forcedToken}},
+		[]schedulerBucketWriteTask{{bucket: single, token: singleToken}},
+		nil,
+		"test",
+	)
+	require.ErrorIs(t, err, ErrSchedulerBucketWriteFenced)
+	require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformOpenAI}), "SetSnapshot failure must not discard a successful query")
+	_, singleAttempts, singleVersion, _ := cache.bucketState(single)
+	_, forcedAttempts, forcedVersion, _ := cache.bucketState(forced)
+	require.Equal(t, 1, singleAttempts)
+	require.Zero(t, singleVersion)
+	require.Equal(t, 1, forcedAttempts)
+	require.Equal(t, 1, forcedVersion)
+}
+
+func TestSchedulerRebuildBatchPreservesLockBusyAndFencingPolicy(t *testing.T) {
+	const groupID int64 = 207
+	single := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	forced := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+
+	t.Run("ordinary lock busy skips only that bucket", func(t *testing.T) {
+		cache := newBatchSnapshotCache()
+		cache.lockBusy[single] = true
+		repo := newBatchAccountQueryRepo()
+		svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+		require.NoError(t, svc.rebuildBuckets(context.Background(), []SchedulerBucket{single, forced}, "test"))
+		require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformOpenAI}))
+		_, singleAttempts, _, _ := cache.bucketState(single)
+		_, forcedAttempts, forcedVersion, _ := cache.bucketState(forced)
+		require.Zero(t, singleAttempts)
+		require.Equal(t, 1, forcedAttempts)
+		require.Equal(t, 1, forcedVersion)
+	})
+
+	t.Run("strict lock busy is returned while ordinary work continues", func(t *testing.T) {
+		cache := newBatchSnapshotCache()
+		cache.lockBusy[single] = true
+		singleToken, err := cache.CaptureBucketWriteToken(context.Background(), single)
+		require.NoError(t, err)
+		forcedToken, err := cache.CaptureBucketWriteToken(context.Background(), forced)
+		require.NoError(t, err)
+		repo := newBatchAccountQueryRepo()
+		svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+		err = svc.prepareAndRebuildFullSnapshot(
+			context.Background(),
+			[]schedulerBucketWriteTask{{bucket: forced, token: forcedToken}},
+			[]schedulerBucketWriteTask{{bucket: single, token: singleToken}},
+			nil,
+			"test",
+		)
+		require.ErrorIs(t, err, ErrSchedulerBucketRebuildBusy)
+		require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformOpenAI}))
+		_, forcedAttempts, forcedVersion, _ := cache.bucketState(forced)
+		require.Equal(t, 1, forcedAttempts)
+		require.Equal(t, 1, forcedVersion)
+	})
+
+	t.Run("ordinary fencing stays non-fatal", func(t *testing.T) {
+		cache := newBatchSnapshotCache()
+		cache.setErrors[single] = ErrSchedulerBucketWriteFenced
+		repo := newBatchAccountQueryRepo()
+		svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+		require.NoError(t, svc.rebuildBuckets(context.Background(), []SchedulerBucket{single, forced}, "test"))
+		require.Equal(t, 1, repo.callCount(batchAccountQueryKey{groupID: groupID, platform: PlatformOpenAI}))
+		_, singleAttempts, singleVersion, _ := cache.bucketState(single)
+		_, forcedAttempts, forcedVersion, _ := cache.bucketState(forced)
+		require.Equal(t, 1, singleAttempts)
+		require.Zero(t, singleVersion)
+		require.Equal(t, 1, forcedAttempts)
+		require.Equal(t, 1, forcedVersion)
+	})
+}
+
+func TestSchedulerRebuildBatchReleasesResultsAfterLastConsumer(t *testing.T) {
+	const groups = 128
+	cache := newBatchSnapshotCache()
+	repo := newBatchAccountQueryRepo()
+	tasks := make([]schedulerBucketWriteTask, 0, groups*2)
+	wantLockErr := errors.New("lock failed")
+	for i := 1; i <= groups; i++ {
+		groupID := int64(300 + i)
+		single := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+		forced := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+		if i == 1 {
+			cache.lockBusy[single] = true
+		}
+		if i == 2 {
+			cache.lockErrors[single] = wantLockErr
+		}
+		for _, bucket := range []SchedulerBucket{single, forced} {
+			token, err := cache.CaptureBucketWriteToken(context.Background(), bucket)
+			require.NoError(t, err)
+			tasks = append(tasks, schedulerBucketWriteTask{bucket: bucket, token: token})
+		}
+	}
+	queries := newSchedulerAccountQueryCache(tasks)
+	maxResident := 0
+	cache.beforeSet = func() {
+		if resident := len(queries.accounts); resident > maxResident {
+			maxResident = resident
+		}
+	}
+	svc := newBatchQueryTestService(cache, repo, config.RunModeStandard)
+
+	err := svc.rebuildPreparedBucketTasks(context.Background(), tasks, "test", false, queries)
+	require.ErrorIs(t, err, wantLockErr)
+	require.LessOrEqual(t, maxResident, 1, "adjacent single/forced pairs must not accumulate full-batch results")
+	require.Empty(t, queries.accounts)
+	require.Empty(t, queries.remaining)
+	for i := 1; i <= groups; i++ {
+		key := batchAccountQueryKey{groupID: int64(300 + i), platform: PlatformOpenAI}
+		require.Equal(t, 1, repo.callCount(key), key)
+	}
+}
+
+type batchQueryBenchmarkRepo struct {
+	AccountRepository
+	accounts []Account
+}
+
+func (r *batchQueryBenchmarkRepo) ListSchedulableByGroupIDAndPlatform(context.Context, int64, string) ([]Account, error) {
+	return r.accounts, nil
+}
+
+type batchQueryBenchmarkCache struct {
+	SchedulerCache
+}
+
+func (c *batchQueryBenchmarkCache) CaptureBucketWriteToken(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+
+func (c *batchQueryBenchmarkCache) TryLockBucket(context.Context, SchedulerBucket, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (c *batchQueryBenchmarkCache) UnlockBucket(context.Context, SchedulerBucket) error {
+	return nil
+}
+
+var batchQueryBenchmarkAccountCount int
+
+func (c *batchQueryBenchmarkCache) SetSnapshot(_ context.Context, _ SchedulerBucket, _ SchedulerBucketWriteToken, accounts []Account) error {
+	batchQueryBenchmarkAccountCount = len(accounts)
+	return nil
+}
+
+func BenchmarkSchedulerRebuildBatchQueryReuse(b *testing.B) {
+	const groupID int64 = 208
+	buckets := []SchedulerBucket{
+		{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeSingle},
+		{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced},
+	}
+	for _, tc := range []struct {
+		name string
+		size int
+	}{
+		{name: "1_account", size: 1},
+		{name: "10000_accounts", size: 10_000},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			accounts := make([]Account, tc.size)
+			svc := newBatchQueryTestService(
+				&batchQueryBenchmarkCache{},
+				&batchQueryBenchmarkRepo{accounts: accounts},
+				config.RunModeStandard,
+			)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if err := svc.rebuildBuckets(context.Background(), buckets, "benchmark"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/service/scheduler_snapshot_full_rebuild_lifecycle_test.go
+++ b/backend/internal/service/scheduler_snapshot_full_rebuild_lifecycle_test.go
@@ -1,0 +1,666 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type fullRebuildLifecycleCache struct {
+	*groupLifecycleTestCache
+
+	mu              sync.Mutex
+	captureAttempts []SchedulerBucket
+	captureErrors   map[string]error
+	lockBusyOnce    map[string]bool
+	watermark       int64
+	watermarkWrites []int64
+}
+
+func newFullRebuildLifecycleCache(buckets ...SchedulerBucket) *fullRebuildLifecycleCache {
+	return &fullRebuildLifecycleCache{
+		groupLifecycleTestCache: newGroupLifecycleTestCache(buckets...),
+		captureErrors:           make(map[string]error),
+		lockBusyOnce:            make(map[string]bool),
+	}
+}
+
+func (c *fullRebuildLifecycleCache) CaptureBucketWriteToken(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	c.mu.Lock()
+	c.captureAttempts = append(c.captureAttempts, bucket)
+	err := c.captureErrors[bucket.String()]
+	c.mu.Unlock()
+	if err != nil {
+		return SchedulerBucketWriteToken{}, err
+	}
+	return c.retirementRaceCache.CaptureBucketWriteToken(ctx, bucket)
+}
+
+func (c *fullRebuildLifecycleCache) ListBuckets(ctx context.Context) ([]SchedulerBucket, error) {
+	buckets, err := c.groupLifecycleTestCache.ListBuckets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.retirementRaceCache.mu.Lock()
+	defer c.retirementRaceCache.mu.Unlock()
+	registered := make([]SchedulerBucket, 0, len(buckets))
+	for _, bucket := range buckets {
+		if !c.retirementRaceCache.retired[bucket.String()] {
+			registered = append(registered, bucket)
+		}
+	}
+	return registered, nil
+}
+
+func (c *fullRebuildLifecycleCache) TryLockBucket(ctx context.Context, bucket SchedulerBucket, ttl time.Duration) (bool, error) {
+	c.mu.Lock()
+	busy := c.lockBusyOnce[bucket.String()]
+	if busy {
+		delete(c.lockBusyOnce, bucket.String())
+	}
+	c.mu.Unlock()
+	if busy {
+		return false, nil
+	}
+	return c.groupLifecycleTestCache.TryLockBucket(ctx, bucket, ttl)
+}
+
+func (c *fullRebuildLifecycleCache) GetOutboxWatermark(context.Context) (int64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.watermark, nil
+}
+
+func (c *fullRebuildLifecycleCache) SetOutboxWatermark(_ context.Context, id int64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.watermark = id
+	c.watermarkWrites = append(c.watermarkWrites, id)
+	return nil
+}
+
+func (c *fullRebuildLifecycleCache) captureAttemptCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.captureAttempts)
+}
+
+func (c *fullRebuildLifecycleCache) currentWatermark() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.watermark
+}
+
+func (c *fullRebuildLifecycleCache) totalSetAttempts() int {
+	c.retirementRaceCache.mu.Lock()
+	defer c.retirementRaceCache.mu.Unlock()
+	var total int
+	for _, attempts := range c.retirementRaceCache.setAttempts {
+		total += attempts
+	}
+	return total
+}
+
+type fullRebuildLifecycleGroupRepo struct {
+	GroupRepository
+
+	mu              sync.Mutex
+	activeIDs       []int64
+	activeIDsErr    error
+	listActiveErr   error
+	fresh           map[int64]*Group
+	freshErr        map[int64]error
+	activeIDCalls   int
+	listActiveCalls int
+	freshCalls      []int64
+}
+
+func (r *fullRebuildLifecycleGroupRepo) ListActiveIDs(context.Context) ([]int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.activeIDCalls++
+	return append([]int64(nil), r.activeIDs...), r.activeIDsErr
+}
+
+func (r *fullRebuildLifecycleGroupRepo) ListActive(context.Context) ([]Group, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.listActiveCalls++
+	return nil, r.listActiveErr
+}
+
+func (r *fullRebuildLifecycleGroupRepo) GetByIDLite(_ context.Context, id int64) (*Group, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.freshCalls = append(r.freshCalls, id)
+	if err := r.freshErr[id]; err != nil {
+		return nil, err
+	}
+	group := r.fresh[id]
+	if group == nil {
+		return nil, ErrGroupNotFound
+	}
+	copyGroup := *group
+	return &copyGroup, nil
+}
+
+func (r *fullRebuildLifecycleGroupRepo) stats() (activeIDs, listActive int, fresh []int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.activeIDCalls, r.listActiveCalls, append([]int64(nil), r.freshCalls...)
+}
+
+type fullRebuildFallbackGroupRepo struct {
+	GroupRepository
+
+	mu        sync.Mutex
+	groups    []Group
+	err       error
+	listCalls int
+}
+
+func (r *fullRebuildFallbackGroupRepo) ListActive(context.Context) ([]Group, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.listCalls++
+	return append([]Group(nil), r.groups...), r.err
+}
+
+type fullRebuildAccountCall struct {
+	groupID  int64
+	platform string
+}
+
+type fullRebuildAccountRepo struct {
+	AccountRepository
+
+	mu          sync.Mutex
+	calls       []fullRebuildAccountCall
+	beforeFirst func()
+	once        sync.Once
+}
+
+func (r *fullRebuildAccountRepo) record(groupID int64, platform string) ([]Account, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, fullRebuildAccountCall{groupID: groupID, platform: platform})
+	beforeFirst := r.beforeFirst
+	r.mu.Unlock()
+	if beforeFirst != nil {
+		r.once.Do(beforeFirst)
+	}
+	return []Account{{ID: 1, Platform: platform, Status: StatusActive, Schedulable: true}}, nil
+}
+
+func (r *fullRebuildAccountRepo) ListSchedulableByGroupIDAndPlatform(_ context.Context, groupID int64, platform string) ([]Account, error) {
+	return r.record(groupID, platform)
+}
+
+func (r *fullRebuildAccountRepo) ListSchedulableByGroupIDAndPlatforms(_ context.Context, groupID int64, platforms []string) ([]Account, error) {
+	return r.record(groupID, firstPlatform(platforms))
+}
+
+func (r *fullRebuildAccountRepo) ListSchedulableUngroupedByPlatform(_ context.Context, platform string) ([]Account, error) {
+	return r.record(0, platform)
+}
+
+func (r *fullRebuildAccountRepo) ListSchedulableUngroupedByPlatforms(_ context.Context, platforms []string) ([]Account, error) {
+	return r.record(0, firstPlatform(platforms))
+}
+
+func (r *fullRebuildAccountRepo) ListSchedulableByPlatform(_ context.Context, platform string) ([]Account, error) {
+	return r.record(0, platform)
+}
+
+func (r *fullRebuildAccountRepo) ListSchedulableByPlatforms(_ context.Context, platforms []string) ([]Account, error) {
+	return r.record(0, firstPlatform(platforms))
+}
+
+func (r *fullRebuildAccountRepo) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+func (r *fullRebuildAccountRepo) groupCallCount(groupID int64) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var count int
+	for _, call := range r.calls {
+		if call.groupID == groupID {
+			count++
+		}
+	}
+	return count
+}
+
+func firstPlatform(platforms []string) string {
+	if len(platforms) == 0 {
+		return ""
+	}
+	return platforms[0]
+}
+
+func newFullRebuildLifecycleService(
+	cache SchedulerCache,
+	outbox SchedulerOutboxRepository,
+	accounts AccountRepository,
+	groups GroupRepository,
+	runMode string,
+) *SchedulerSnapshotService {
+	return NewSchedulerSnapshotService(cache, outbox, accounts, groups, &config.Config{RunMode: runMode})
+}
+
+func TestSchedulerFullRebuildActiveTombstoneDoesNotBlockFollowingGroupEvent(t *testing.T) {
+	const groupID int64 = 101
+	canonical := schedulerBucketsForGroup(groupID)
+	cache := newFullRebuildLifecycleCache()
+	require.NoError(t, cache.retirementRaceCache.RetireBucket(context.Background(), canonical[0]))
+	groups := &fullRebuildLifecycleGroupRepo{
+		activeIDs: []int64{groupID},
+		fresh: map[int64]*Group{
+			groupID: {ID: groupID, Status: StatusActive, Hydrated: true},
+		},
+		freshErr: make(map[int64]error),
+	}
+	accounts := &fullRebuildAccountRepo{}
+	outbox := &outboxCleanupRepo{events: []SchedulerOutboxEvent{
+		{ID: 1, EventType: SchedulerOutboxEventFullRebuild},
+		{ID: 2, EventType: SchedulerOutboxEventGroupChanged, GroupID: ptrInt64(groupID)},
+	}}
+	svc := newFullRebuildLifecycleService(cache, outbox, accounts, groups, config.RunModeStandard)
+
+	svc.pollOutbox()
+
+	require.Equal(t, int64(2), cache.currentWatermark())
+	cache.mu.Lock()
+	require.Equal(t, []int64{2}, cache.watermarkWrites)
+	cache.mu.Unlock()
+	activeCalls, fallbackCalls, freshCalls := groups.stats()
+	require.Equal(t, 1, activeCalls)
+	require.Zero(t, fallbackCalls)
+	require.Equal(t, []int64{groupID, groupID}, freshCalls)
+	require.Len(t, cache.tokens(), 24, "full rebuild and the following group event must each run fresh authority")
+	_, reopenHeld := cache.lifecycleMutationLeaseStates()
+	require.Len(t, reopenHeld, 24)
+	for _, held := range reopenHeld {
+		require.True(t, held)
+	}
+	require.Equal(t, 36, accounts.callCount())
+}
+
+func TestSchedulerFullRebuildGlobalReadErrorsFailBeforeMutationOrDB(t *testing.T) {
+	t.Run("list buckets", func(t *testing.T) {
+		cache := newFullRebuildLifecycleCache()
+		cache.listErr = errors.New("registry failed")
+		groups := &fullRebuildLifecycleGroupRepo{fresh: make(map[int64]*Group), freshErr: make(map[int64]error)}
+		accounts := &fullRebuildAccountRepo{}
+		svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+		err := svc.rebuildFullSnapshot(context.Background(), "test")
+		require.ErrorIs(t, err, cache.listErr)
+		activeCalls, fallbackCalls, freshCalls := groups.stats()
+		require.Zero(t, activeCalls)
+		require.Zero(t, fallbackCalls)
+		require.Empty(t, freshCalls)
+		requireFullRebuildNoMutationOrDB(t, cache, accounts)
+	})
+
+	t.Run("list active ids without fallback", func(t *testing.T) {
+		cache := newFullRebuildLifecycleCache()
+		groups := &fullRebuildLifecycleGroupRepo{
+			activeIDsErr:  errors.New("active ids failed"),
+			listActiveErr: errors.New("fallback must not run"),
+			fresh:         make(map[int64]*Group),
+			freshErr:      make(map[int64]error),
+		}
+		accounts := &fullRebuildAccountRepo{}
+		svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+		err := svc.rebuildFullSnapshot(context.Background(), "test")
+		require.ErrorIs(t, err, groups.activeIDsErr)
+		activeCalls, fallbackCalls, freshCalls := groups.stats()
+		require.Equal(t, 1, activeCalls)
+		require.Zero(t, fallbackCalls)
+		require.Empty(t, freshCalls)
+		requireFullRebuildNoMutationOrDB(t, cache, accounts)
+	})
+
+	t.Run("list active fallback", func(t *testing.T) {
+		cache := newFullRebuildLifecycleCache()
+		groups := &fullRebuildFallbackGroupRepo{err: errors.New("active groups failed")}
+		accounts := &fullRebuildAccountRepo{}
+		svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+		err := svc.rebuildFullSnapshot(context.Background(), "test")
+		require.ErrorIs(t, err, groups.err)
+		groups.mu.Lock()
+		require.Equal(t, 1, groups.listCalls)
+		groups.mu.Unlock()
+		requireFullRebuildNoMutationOrDB(t, cache, accounts)
+	})
+}
+
+func TestSchedulerFullRebuildFreshActivePreparesEveryTokenBeforeFirstDB(t *testing.T) {
+	const groupID int64 = 102
+	historical := SchedulerBucket{GroupID: groupID, Platform: "legacy", Mode: "unknown"}
+	cache := newFullRebuildLifecycleCache(historical)
+	groups := &fullRebuildLifecycleGroupRepo{
+		fresh: map[int64]*Group{
+			groupID: {ID: groupID, Status: StatusActive, Hydrated: true},
+		},
+		freshErr: make(map[int64]error),
+	}
+	accounts := &fullRebuildAccountRepo{}
+	var capturesAtFirstDB int
+	accounts.beforeFirst = func() {
+		capturesAtFirstDB = cache.captureAttemptCount()
+		held, reopenCount := cache.leaseHeldAndTokenCount()
+		require.False(t, held)
+		require.Equal(t, 12, reopenCount)
+		require.Equal(t, 13, capturesAtFirstDB, "C(0) and the historical bucket must be captured before DB")
+	}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
+	require.Equal(t, capturesAtFirstDB, cache.captureAttemptCount())
+	require.Equal(t, 25, accounts.callCount())
+	require.Equal(t, 13, accounts.groupCallCount(groupID))
+	_, historicalPublished := cache.counts(historical)
+	require.Equal(t, 1, historicalPublished)
+	activeCalls, fallbackCalls, freshCalls := groups.stats()
+	require.Equal(t, 1, activeCalls)
+	require.Zero(t, fallbackCalls)
+	require.Equal(t, []int64{groupID}, freshCalls)
+	_, _, listCalls := cache.lifecycleCounts()
+	require.Equal(t, 1, listCalls, "known Rg must prevent a second registry read")
+}
+
+func TestSchedulerFullRebuildOrdinaryCaptureErrorReturnsBeforeFirstDB(t *testing.T) {
+	first := SchedulerBucket{GroupID: 0, Platform: "legacy-a", Mode: "unknown"}
+	last := SchedulerBucket{GroupID: 0, Platform: "legacy-b", Mode: "unknown"}
+	cache := newFullRebuildLifecycleCache(first, last)
+	wantErr := errors.New("capture failed")
+	cache.captureErrors[last.String()] = wantErr
+	groups := &fullRebuildLifecycleGroupRepo{fresh: make(map[int64]*Group), freshErr: make(map[int64]error)}
+	accounts := &fullRebuildAccountRepo{}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	err := svc.rebuildFullSnapshot(context.Background(), "test")
+	require.ErrorIs(t, err, wantErr)
+	require.Equal(t, 14, cache.captureAttemptCount(), "all canonical and ordinary captures must be attempted before returning")
+	require.Zero(t, accounts.callCount())
+	require.Zero(t, cache.totalSetAttempts())
+}
+
+func TestSchedulerFullRebuildPreservesGroupZeroActiveHistoricalAndInvalidRegistryBuckets(t *testing.T) {
+	const groupID int64 = 103
+	groupZeroHistorical := SchedulerBucket{GroupID: 0, Platform: "legacy-zero", Mode: "unknown"}
+	activeHistorical := SchedulerBucket{GroupID: groupID, Platform: "legacy-active", Mode: "unknown"}
+	activeForced := SchedulerBucket{GroupID: groupID, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+	activeMixed := SchedulerBucket{GroupID: groupID, Platform: PlatformAnthropic, Mode: SchedulerModeMixed}
+	invalidHistorical := SchedulerBucket{GroupID: -7, Platform: "legacy-invalid", Mode: "unknown"}
+	cache := newFullRebuildLifecycleCache(groupZeroHistorical, activeHistorical, activeForced, activeMixed, invalidHistorical)
+	groups := &fullRebuildFallbackGroupRepo{groups: []Group{{ID: groupID, Status: StatusActive}}}
+	accounts := &fullRebuildAccountRepo{}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
+	require.Equal(t, 27, cache.captureAttemptCount())
+	require.Equal(t, 27, accounts.callCount())
+	groups.mu.Lock()
+	require.Equal(t, 1, groups.listCalls)
+	groups.mu.Unlock()
+	require.Empty(t, cache.retiredBuckets())
+	require.Empty(t, cache.tokens())
+	for _, bucket := range []SchedulerBucket{groupZeroHistorical, activeHistorical, activeForced, activeMixed, invalidHistorical} {
+		_, published := cache.counts(bucket)
+		require.Equal(t, 1, published, bucket.String())
+	}
+}
+
+func TestSchedulerFullRebuildActiveTombstoneFreshInactiveOrMissingFiltersAllGroupTasks(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		group *Group
+	}{
+		{name: "inactive", group: &Group{ID: 104, Status: StatusDisabled, Hydrated: true}},
+		{name: "missing"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const groupID int64 = 104
+			canonical := schedulerBucketsForGroup(groupID)
+			historical := SchedulerBucket{GroupID: groupID, Platform: "legacy", Mode: "unknown"}
+			cache := newFullRebuildLifecycleCache(historical)
+			require.NoError(t, cache.retirementRaceCache.RetireBucket(context.Background(), canonical[5]))
+			groups := &fullRebuildLifecycleGroupRepo{
+				activeIDs: []int64{groupID},
+				fresh:     make(map[int64]*Group),
+				freshErr:  make(map[int64]error),
+			}
+			if tc.group != nil {
+				groups.fresh[groupID] = tc.group
+			}
+			accounts := &fullRebuildAccountRepo{}
+			svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+			require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
+			require.Zero(t, accounts.groupCallCount(groupID))
+			require.Equal(t, 12, accounts.groupCallCount(0))
+			require.Empty(t, cache.tokens())
+			require.Equal(t, bucketStrings(append(canonical, historical)), bucketStrings(cache.retiredBuckets()))
+			for _, bucket := range append(canonical, historical) {
+				attempts, published := cache.counts(bucket)
+				require.Zero(t, attempts, bucket.String())
+				require.Zero(t, published, bucket.String())
+			}
+			_, _, listCalls := cache.lifecycleCounts()
+			require.Equal(t, 1, listCalls)
+		})
+	}
+}
+
+func TestSchedulerFullRebuildStaleCandidatesAreSortedAndNeverReopenedAcrossRounds(t *testing.T) {
+	historical := []SchedulerBucket{
+		{GroupID: 3, Platform: "legacy", Mode: "unknown"},
+		{GroupID: 1, Platform: "legacy", Mode: "unknown"},
+		{GroupID: 2, Platform: "legacy", Mode: "unknown"},
+	}
+	cache := newFullRebuildLifecycleCache(historical...)
+	groups := &fullRebuildLifecycleGroupRepo{
+		fresh: map[int64]*Group{
+			1: {ID: 1, Status: StatusDisabled, Hydrated: true},
+			3: {ID: 3, Status: StatusDisabled, Hydrated: true},
+		},
+		freshErr: make(map[int64]error),
+	}
+	accounts := &fullRebuildAccountRepo{}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "first"))
+	retireCallsAfterFirst := len(cache.retiredBuckets())
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "second"))
+	_, _, freshCalls := groups.stats()
+	require.Equal(t, []int64{1, 2, 3}, freshCalls)
+	require.Equal(t, retireCallsAfterFirst, len(cache.retiredBuckets()))
+	require.Empty(t, cache.tokens())
+	require.Zero(t, accounts.groupCallCount(1))
+	require.Zero(t, accounts.groupCallCount(2))
+	require.Zero(t, accounts.groupCallCount(3))
+	_, _, listCalls := cache.lifecycleCounts()
+	require.Equal(t, 2, listCalls, "each round must use only its one global registry snapshot")
+	for _, bucket := range historical {
+		require.Contains(t, bucketStrings(cache.retiredBuckets()), bucket.String())
+	}
+}
+
+func TestSchedulerFullRebuildPartialLifecycleFailureReturnsBeforeDBAndRetries(t *testing.T) {
+	historical := []SchedulerBucket{
+		{GroupID: 1, Platform: "legacy", Mode: "unknown"},
+		{GroupID: 2, Platform: "legacy", Mode: "unknown"},
+		{GroupID: 3, Platform: "legacy", Mode: "unknown"},
+	}
+	wantErr := errors.New("fresh group query failed")
+	cache := newFullRebuildLifecycleCache(historical...)
+	groups := &fullRebuildLifecycleGroupRepo{
+		fresh: map[int64]*Group{
+			1: {ID: 1, Status: StatusDisabled, Hydrated: true},
+			3: {ID: 3, Status: StatusDisabled, Hydrated: true},
+		},
+		freshErr: map[int64]error{2: wantErr},
+	}
+	accounts := &fullRebuildAccountRepo{}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	err := svc.triggerFullRebuild("first")
+	require.ErrorIs(t, err, wantErr)
+	_, _, freshCalls := groups.stats()
+	require.Equal(t, []int64{1, 2}, freshCalls)
+	require.Zero(t, accounts.callCount())
+	require.Zero(t, cache.totalSetAttempts())
+	require.Equal(t, 13, len(cache.retiredBuckets()))
+
+	groups.mu.Lock()
+	delete(groups.freshErr, 2)
+	groups.fresh[2] = &Group{ID: 2, Status: StatusDisabled, Hydrated: true}
+	groups.mu.Unlock()
+	require.NoError(t, svc.triggerFullRebuild("retry"))
+	_, _, freshCalls = groups.stats()
+	require.Equal(t, []int64{1, 2, 2, 3}, freshCalls)
+	require.Equal(t, 39, len(cache.retiredBuckets()))
+	require.Equal(t, 12, accounts.callCount())
+	require.Empty(t, cache.tokens())
+}
+
+func TestSchedulerFullRebuildActiveTombstoneLazyRecoveryDiscardsPartialCaptureTasks(t *testing.T) {
+	const groupID int64 = 105
+	canonical := schedulerBucketsForGroup(groupID)
+	historical := SchedulerBucket{GroupID: groupID, Platform: "legacy", Mode: "unknown"}
+	cache := newFullRebuildLifecycleCache(canonical[0], canonical[4], historical)
+	require.NoError(t, cache.retirementRaceCache.RetireBucket(context.Background(), canonical[5]))
+	groups := &fullRebuildLifecycleGroupRepo{
+		activeIDs: []int64{groupID},
+		fresh: map[int64]*Group{
+			groupID: {ID: groupID, Status: StatusActive, Hydrated: true},
+		},
+		freshErr: make(map[int64]error),
+	}
+	accounts := &fullRebuildAccountRepo{}
+	var capturesAtFirstDB int
+	accounts.beforeFirst = func() {
+		capturesAtFirstDB = cache.captureAttemptCount()
+		held, reopenCount := cache.leaseHeldAndTokenCount()
+		require.False(t, held)
+		require.Equal(t, 12, reopenCount)
+		require.Equal(t, 19, capturesAtFirstDB)
+	}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
+	require.Equal(t, capturesAtFirstDB, cache.captureAttemptCount())
+	require.Equal(t, 25, accounts.callCount())
+	for _, bucket := range canonical {
+		attempts, published := cache.counts(bucket)
+		require.Equal(t, 1, attempts, "discarded pre-recovery tokens must never publish: %s", bucket.String())
+		require.Equal(t, 1, published, bucket.String())
+	}
+	_, published := cache.counts(historical)
+	require.Equal(t, 1, published)
+	_, _, listCalls := cache.lifecycleCounts()
+	require.Equal(t, 1, listCalls)
+}
+
+func TestSchedulerFullRebuildSimpleModePreservesRegistryWithoutLifecycleAuthority(t *testing.T) {
+	registered := []SchedulerBucket{
+		{GroupID: 0, Platform: "legacy-zero", Mode: "unknown"},
+		{GroupID: 106, Platform: "legacy-positive", Mode: "unknown"},
+		{GroupID: -8, Platform: "legacy-negative", Mode: "unknown"},
+	}
+	cache := newFullRebuildLifecycleCache(registered...)
+	groups := &fullRebuildLifecycleGroupRepo{
+		activeIDsErr: errors.New("simple mode must not query groups"),
+		fresh:        make(map[int64]*Group),
+		freshErr:     make(map[int64]error),
+	}
+	accounts := &fullRebuildAccountRepo{}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeSimple)
+
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
+	activeCalls, fallbackCalls, freshCalls := groups.stats()
+	require.Zero(t, activeCalls)
+	require.Zero(t, fallbackCalls)
+	require.Empty(t, freshCalls)
+	require.Equal(t, 15, cache.captureAttemptCount())
+	require.Equal(t, 15, accounts.callCount())
+	require.Equal(t, 15, accounts.groupCallCount(0))
+	require.Empty(t, cache.retiredBuckets())
+	require.Empty(t, cache.tokens())
+	for _, bucket := range registered {
+		_, published := cache.counts(bucket)
+		require.Equal(t, 1, published, bucket.String())
+	}
+}
+
+func TestSchedulerFullRebuildFreshReopenLockBusyRetriesWithoutBlockingOrdinaryTasks(t *testing.T) {
+	const groupID int64 = 107
+	canonical := schedulerBucketsForGroup(groupID)
+	cache := newFullRebuildLifecycleCache()
+	require.NoError(t, cache.retirementRaceCache.RetireBucket(context.Background(), canonical[0]))
+	cache.lockBusyOnce[canonical[0].String()] = true
+	groups := &fullRebuildLifecycleGroupRepo{
+		activeIDs: []int64{groupID},
+		fresh: map[int64]*Group{
+			groupID: {ID: groupID, Status: StatusActive, Hydrated: true},
+		},
+		freshErr: make(map[int64]error),
+	}
+	accounts := &fullRebuildAccountRepo{}
+	outbox := &outboxCleanupRepo{events: []SchedulerOutboxEvent{{ID: 1, EventType: SchedulerOutboxEventFullRebuild}}}
+	svc := newFullRebuildLifecycleService(cache, outbox, accounts, groups, config.RunModeStandard)
+
+	svc.pollOutbox()
+	require.Zero(t, cache.currentWatermark())
+	_, groupZeroPublished := cache.counts(schedulerCanonicalBuckets(0)[0])
+	require.Equal(t, 1, groupZeroPublished, "ordinary tasks must still run when one strict Reopen task is busy")
+	require.Equal(t, 23, accounts.callCount())
+
+	svc.pollOutbox()
+	require.Equal(t, int64(1), cache.currentWatermark())
+	require.Equal(t, 47, accounts.callCount())
+	_, busyBucketPublished := cache.counts(canonical[0])
+	require.Equal(t, 1, busyBucketPublished)
+	activeCalls, fallbackCalls, freshCalls := groups.stats()
+	require.Equal(t, 2, activeCalls)
+	require.Zero(t, fallbackCalls)
+	require.Equal(t, []int64{groupID}, freshCalls)
+}
+
+func TestSchedulerFullRebuildOrdinaryLockBusyKeepsExistingSkipSemantics(t *testing.T) {
+	busyBucket := schedulerCanonicalBuckets(0)[0]
+	cache := newFullRebuildLifecycleCache()
+	cache.lockBusyOnce[busyBucket.String()] = true
+	groups := &fullRebuildLifecycleGroupRepo{fresh: make(map[int64]*Group), freshErr: make(map[int64]error)}
+	accounts := &fullRebuildAccountRepo{}
+	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
+	require.Equal(t, 11, accounts.callCount())
+	attempts, published := cache.counts(busyBucket)
+	require.Zero(t, attempts)
+	require.Zero(t, published)
+}
+
+func requireFullRebuildNoMutationOrDB(t *testing.T, cache *fullRebuildLifecycleCache, accounts *fullRebuildAccountRepo) {
+	t.Helper()
+	require.Zero(t, cache.captureAttemptCount())
+	require.Empty(t, cache.retiredBuckets())
+	require.Empty(t, cache.tokens())
+	require.Zero(t, accounts.callCount())
+	require.Zero(t, cache.totalSetAttempts())
+}

--- a/backend/internal/service/scheduler_snapshot_full_rebuild_lifecycle_test.go
+++ b/backend/internal/service/scheduler_snapshot_full_rebuild_lifecycle_test.go
@@ -292,7 +292,7 @@ func TestSchedulerFullRebuildActiveTombstoneDoesNotBlockFollowingGroupEvent(t *t
 	for _, held := range reopenHeld {
 		require.True(t, held)
 	}
-	require.Equal(t, 36, accounts.callCount())
+	require.Equal(t, 21, accounts.callCount())
 }
 
 func TestSchedulerFullRebuildGlobalReadErrorsFailBeforeMutationOrDB(t *testing.T) {
@@ -370,8 +370,8 @@ func TestSchedulerFullRebuildFreshActivePreparesEveryTokenBeforeFirstDB(t *testi
 
 	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
 	require.Equal(t, capturesAtFirstDB, cache.captureAttemptCount())
-	require.Equal(t, 25, accounts.callCount())
-	require.Equal(t, 13, accounts.groupCallCount(groupID))
+	require.Equal(t, 15, accounts.callCount())
+	require.Equal(t, 8, accounts.groupCallCount(groupID))
 	_, historicalPublished := cache.counts(historical)
 	require.Equal(t, 1, historicalPublished)
 	activeCalls, fallbackCalls, freshCalls := groups.stats()
@@ -413,7 +413,7 @@ func TestSchedulerFullRebuildPreservesGroupZeroActiveHistoricalAndInvalidRegistr
 
 	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
 	require.Equal(t, 27, cache.captureAttemptCount())
-	require.Equal(t, 27, accounts.callCount())
+	require.Equal(t, 17, accounts.callCount())
 	groups.mu.Lock()
 	require.Equal(t, 1, groups.listCalls)
 	groups.mu.Unlock()
@@ -452,7 +452,7 @@ func TestSchedulerFullRebuildActiveTombstoneFreshInactiveOrMissingFiltersAllGrou
 
 			require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
 			require.Zero(t, accounts.groupCallCount(groupID))
-			require.Equal(t, 12, accounts.groupCallCount(0))
+			require.Equal(t, 7, accounts.groupCallCount(0))
 			require.Empty(t, cache.tokens())
 			require.Equal(t, bucketStrings(append(canonical, historical)), bucketStrings(cache.retiredBuckets()))
 			for _, bucket := range append(canonical, historical) {
@@ -534,7 +534,7 @@ func TestSchedulerFullRebuildPartialLifecycleFailureReturnsBeforeDBAndRetries(t 
 	_, _, freshCalls = groups.stats()
 	require.Equal(t, []int64{1, 2, 2, 3}, freshCalls)
 	require.Equal(t, 39, len(cache.retiredBuckets()))
-	require.Equal(t, 12, accounts.callCount())
+	require.Equal(t, 7, accounts.callCount())
 	require.Empty(t, cache.tokens())
 }
 
@@ -564,7 +564,7 @@ func TestSchedulerFullRebuildActiveTombstoneLazyRecoveryDiscardsPartialCaptureTa
 
 	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
 	require.Equal(t, capturesAtFirstDB, cache.captureAttemptCount())
-	require.Equal(t, 25, accounts.callCount())
+	require.Equal(t, 15, accounts.callCount())
 	for _, bucket := range canonical {
 		attempts, published := cache.counts(bucket)
 		require.Equal(t, 1, attempts, "discarded pre-recovery tokens must never publish: %s", bucket.String())
@@ -597,8 +597,8 @@ func TestSchedulerFullRebuildSimpleModePreservesRegistryWithoutLifecycleAuthorit
 	require.Zero(t, fallbackCalls)
 	require.Empty(t, freshCalls)
 	require.Equal(t, 15, cache.captureAttemptCount())
-	require.Equal(t, 15, accounts.callCount())
-	require.Equal(t, 15, accounts.groupCallCount(0))
+	require.Equal(t, 10, accounts.callCount())
+	require.Equal(t, 10, accounts.groupCallCount(0))
 	require.Empty(t, cache.retiredBuckets())
 	require.Empty(t, cache.tokens())
 	for _, bucket := range registered {
@@ -628,11 +628,11 @@ func TestSchedulerFullRebuildFreshReopenLockBusyRetriesWithoutBlockingOrdinaryTa
 	require.Zero(t, cache.currentWatermark())
 	_, groupZeroPublished := cache.counts(schedulerCanonicalBuckets(0)[0])
 	require.Equal(t, 1, groupZeroPublished, "ordinary tasks must still run when one strict Reopen task is busy")
-	require.Equal(t, 23, accounts.callCount())
+	require.Equal(t, 14, accounts.callCount())
 
 	svc.pollOutbox()
 	require.Equal(t, int64(1), cache.currentWatermark())
-	require.Equal(t, 47, accounts.callCount())
+	require.Equal(t, 28, accounts.callCount())
 	_, busyBucketPublished := cache.counts(canonical[0])
 	require.Equal(t, 1, busyBucketPublished)
 	activeCalls, fallbackCalls, freshCalls := groups.stats()
@@ -650,7 +650,7 @@ func TestSchedulerFullRebuildOrdinaryLockBusyKeepsExistingSkipSemantics(t *testi
 	svc := newFullRebuildLifecycleService(cache, nil, accounts, groups, config.RunModeStandard)
 
 	require.NoError(t, svc.rebuildFullSnapshot(context.Background(), "test"))
-	require.Equal(t, 11, accounts.callCount())
+	require.Equal(t, 7, accounts.callCount())
 	attempts, published := cache.counts(busyBucket)
 	require.Zero(t, attempts)
 	require.Zero(t, published)

--- a/backend/internal/service/scheduler_snapshot_full_rebuild_test.go
+++ b/backend/internal/service/scheduler_snapshot_full_rebuild_test.go
@@ -17,6 +17,7 @@ type schedulerFullRebuildTestCache struct {
 	mu        sync.Mutex
 	listErr   error
 	listCalls int
+	captures  int
 	lockCalls int
 }
 
@@ -35,6 +36,9 @@ func (c *schedulerFullRebuildTestCache) TryLockBucket(context.Context, Scheduler
 }
 
 func (c *schedulerFullRebuildTestCache) CaptureBucketWriteToken(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	c.mu.Lock()
+	c.captures++
+	c.mu.Unlock()
 	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
@@ -129,7 +133,7 @@ func TestSchedulerSnapshotServiceFullRebuildRunsAgainForSequentialRequest(t *tes
 	require.Equal(t, requested, completed)
 }
 
-func TestSchedulerSnapshotServiceInitialFullRebuildFallsBackWhenListBucketsFails(t *testing.T) {
+func TestSchedulerSnapshotServiceInitialFullRebuildFailsClosedWhenListBucketsFails(t *testing.T) {
 	cache := &schedulerFullRebuildTestCache{listErr: errors.New("list buckets failed")}
 	svc := NewSchedulerSnapshotService(cache, nil, nil, nil, nil)
 
@@ -137,13 +141,18 @@ func TestSchedulerSnapshotServiceInitialFullRebuildFallsBackWhenListBucketsFails
 
 	cache.mu.Lock()
 	listCalls := cache.listCalls
+	captures := cache.captures
 	lockCalls := cache.lockCalls
 	cache.mu.Unlock()
 	require.Equal(t, 1, listCalls)
-	require.Positive(t, lockCalls, "startup should rebuild default buckets after ListBuckets fails")
+	require.Zero(t, captures)
+	require.Zero(t, lockCalls)
 	requested, completed := schedulerFullRebuildState(svc)
 	require.EqualValues(t, 1, requested)
 	require.Equal(t, requested, completed)
+	svc.fullRebuildStateMu.Lock()
+	require.ErrorIs(t, svc.fullRebuildLastErr, cache.listErr)
+	svc.fullRebuildStateMu.Unlock()
 }
 
 func schedulerFullRebuildState(svc *SchedulerSnapshotService) (requested uint64, completed uint64) {

--- a/backend/internal/service/scheduler_snapshot_full_rebuild_test.go
+++ b/backend/internal/service/scheduler_snapshot_full_rebuild_test.go
@@ -34,6 +34,14 @@ func (c *schedulerFullRebuildTestCache) TryLockBucket(context.Context, Scheduler
 	return false, nil
 }
 
+func (c *schedulerFullRebuildTestCache) CaptureBucketWriteToken(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+
+func (c *schedulerFullRebuildTestCache) ReopenBucket(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+
 func TestSchedulerSnapshotServiceFullRebuildCoalescesConcurrentRequestsIntoTrailingRun(t *testing.T) {
 	svc := &SchedulerSnapshotService{}
 	wantTrailingErr := errors.New("trailing rebuild failed")

--- a/backend/internal/service/scheduler_snapshot_group_lifecycle_test.go
+++ b/backend/internal/service/scheduler_snapshot_group_lifecycle_test.go
@@ -1,0 +1,782 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type groupLifecycleTestCache struct {
+	*retirementRaceCache
+
+	stateMu sync.Mutex
+
+	leaseHeld       bool
+	lease           SchedulerGroupLifecycleLease
+	leaseSequence   int
+	leaseBusy       bool
+	leaseAcquireErr error
+	leaseReleaseErr error
+	acquireCalls    int
+	releaseCalls    int
+	acquireTTL      time.Duration
+	acquireDeadline bool
+	releaseDeadline bool
+	releaseCtxErr   error
+
+	listErr   error
+	listCalls int
+
+	retireCalls  []SchedulerBucket
+	reopenTokens []SchedulerBucketWriteToken
+	retireHeld   []bool
+	reopenHeld   []bool
+	retireErr    error
+	retireErrAt  int
+	reopenErr    error
+	reopenErrAt  int
+
+	bucketLockBusy bool
+	bucketLockErr  error
+	bucketLockTTLs []time.Duration
+	unlockCalls    int
+	setErr         error
+}
+
+func newGroupLifecycleTestCache(buckets ...SchedulerBucket) *groupLifecycleTestCache {
+	return &groupLifecycleTestCache{retirementRaceCache: newRetirementRaceCache(buckets...)}
+}
+
+func (c *groupLifecycleTestCache) TryAcquireGroupLifecycleLease(ctx context.Context, groupID int64, ttl time.Duration) (SchedulerGroupLifecycleLease, bool, error) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.acquireCalls++
+	c.acquireTTL = ttl
+	_, c.acquireDeadline = ctx.Deadline()
+	if c.leaseAcquireErr != nil {
+		return SchedulerGroupLifecycleLease{}, false, c.leaseAcquireErr
+	}
+	if c.leaseBusy || c.leaseHeld {
+		return SchedulerGroupLifecycleLease{}, false, nil
+	}
+	c.leaseSequence++
+	c.lease = SchedulerGroupLifecycleLease{GroupID: groupID, OwnerToken: fmt.Sprintf("owner-%d", c.leaseSequence)}
+	c.leaseHeld = true
+	return c.lease, true, nil
+}
+
+func (c *groupLifecycleTestCache) ReleaseGroupLifecycleLease(ctx context.Context, lease SchedulerGroupLifecycleLease) error {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.releaseCalls++
+	_, c.releaseDeadline = ctx.Deadline()
+	c.releaseCtxErr = ctx.Err()
+	if c.leaseReleaseErr != nil {
+		return c.leaseReleaseErr
+	}
+	if !c.leaseHeld || lease != c.lease {
+		return ErrSchedulerGroupLifecycleLeaseLost
+	}
+	c.leaseHeld = false
+	return nil
+}
+
+func (c *groupLifecycleTestCache) RetireBucket(ctx context.Context, bucket SchedulerBucket) error {
+	c.stateMu.Lock()
+	c.retireCalls = append(c.retireCalls, bucket)
+	c.retireHeld = append(c.retireHeld, c.leaseHeld)
+	held := c.leaseHeld
+	call := len(c.retireCalls)
+	err := c.retireErr
+	errAt := c.retireErrAt
+	c.stateMu.Unlock()
+	if !held {
+		return errors.New("retire called outside group lifecycle lease")
+	}
+	if err != nil && (errAt <= 0 || call == errAt) {
+		return err
+	}
+	return c.retirementRaceCache.RetireBucket(ctx, bucket)
+}
+
+func (c *groupLifecycleTestCache) ReopenBucket(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	if err := ctx.Err(); err != nil {
+		return SchedulerBucketWriteToken{}, err
+	}
+	c.stateMu.Lock()
+	c.reopenHeld = append(c.reopenHeld, c.leaseHeld)
+	held := c.leaseHeld
+	call := len(c.reopenHeld)
+	reopenErr := c.reopenErr
+	reopenErrAt := c.reopenErrAt
+	c.stateMu.Unlock()
+	if !held {
+		return SchedulerBucketWriteToken{}, errors.New("reopen called outside group lifecycle lease")
+	}
+	if reopenErr != nil && (reopenErrAt <= 0 || call == reopenErrAt) {
+		return SchedulerBucketWriteToken{}, reopenErr
+	}
+	token, err := c.retirementRaceCache.ReopenBucket(ctx, bucket)
+	if err != nil {
+		return SchedulerBucketWriteToken{}, err
+	}
+	c.stateMu.Lock()
+	c.reopenTokens = append(c.reopenTokens, token)
+	c.stateMu.Unlock()
+	return token, nil
+}
+
+func (c *groupLifecycleTestCache) ListBuckets(ctx context.Context) ([]SchedulerBucket, error) {
+	c.stateMu.Lock()
+	c.listCalls++
+	err := c.listErr
+	c.stateMu.Unlock()
+	if err != nil {
+		return nil, err
+	}
+	return c.retirementRaceCache.ListBuckets(ctx)
+}
+
+func (c *groupLifecycleTestCache) TryLockBucket(_ context.Context, _ SchedulerBucket, ttl time.Duration) (bool, error) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	c.bucketLockTTLs = append(c.bucketLockTTLs, ttl)
+	if c.bucketLockErr != nil {
+		return false, c.bucketLockErr
+	}
+	return !c.bucketLockBusy, nil
+}
+
+func (c *groupLifecycleTestCache) UnlockBucket(context.Context, SchedulerBucket) error {
+	c.stateMu.Lock()
+	c.unlockCalls++
+	c.stateMu.Unlock()
+	return nil
+}
+
+func (c *groupLifecycleTestCache) SetSnapshot(ctx context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accounts []Account) error {
+	c.stateMu.Lock()
+	err := c.setErr
+	c.stateMu.Unlock()
+	if err != nil {
+		return err
+	}
+	return c.retirementRaceCache.SetSnapshot(ctx, bucket, token, accounts)
+}
+
+func (c *groupLifecycleTestCache) lifecycleCounts() (acquires, releases, listCalls int) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.acquireCalls, c.releaseCalls, c.listCalls
+}
+
+func (c *groupLifecycleTestCache) retiredBuckets() []SchedulerBucket {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return append([]SchedulerBucket(nil), c.retireCalls...)
+}
+
+func (c *groupLifecycleTestCache) tokens() []SchedulerBucketWriteToken {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return append([]SchedulerBucketWriteToken(nil), c.reopenTokens...)
+}
+
+func (c *groupLifecycleTestCache) leaseHeldAndTokenCount() (bool, int) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return c.leaseHeld, len(c.reopenTokens)
+}
+
+func (c *groupLifecycleTestCache) lockStats() ([]time.Duration, int) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return append([]time.Duration(nil), c.bucketLockTTLs...), c.unlockCalls
+}
+
+func (c *groupLifecycleTestCache) lifecycleMutationLeaseStates() (retire, reopen []bool) {
+	c.stateMu.Lock()
+	defer c.stateMu.Unlock()
+	return append([]bool(nil), c.retireHeld...), append([]bool(nil), c.reopenHeld...)
+}
+
+type groupLifecycleTestGroupRepo struct {
+	GroupRepository
+
+	mu       sync.Mutex
+	group    *Group
+	err      error
+	calls    int
+	afterGet func()
+}
+
+func (r *groupLifecycleTestGroupRepo) GetByIDLite(context.Context, int64) (*Group, error) {
+	r.mu.Lock()
+	r.calls++
+	if r.err != nil {
+		err := r.err
+		r.mu.Unlock()
+		return nil, err
+	}
+	if r.group == nil {
+		r.mu.Unlock()
+		return nil, ErrGroupNotFound
+	}
+	copyGroup := *r.group
+	afterGet := r.afterGet
+	r.mu.Unlock()
+	if afterGet != nil {
+		afterGet()
+	}
+	return &copyGroup, nil
+}
+
+func (r *groupLifecycleTestGroupRepo) set(group *Group, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.group = group
+	r.err = err
+}
+
+func (r *groupLifecycleTestGroupRepo) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+type groupLifecycleTestAccountRepo struct {
+	AccountRepository
+
+	mu             sync.Mutex
+	calls          int
+	err            error
+	started        chan struct{}
+	release        chan struct{}
+	once           sync.Once
+	beforeLoad     func()
+	beforeLoadOnce sync.Once
+}
+
+func (r *groupLifecycleTestAccountRepo) load(ctx context.Context, platform string) ([]Account, error) {
+	r.mu.Lock()
+	r.calls++
+	err := r.err
+	started := r.started
+	release := r.release
+	r.mu.Unlock()
+	if started != nil {
+		r.once.Do(func() { close(started) })
+	}
+	if r.beforeLoad != nil {
+		r.beforeLoadOnce.Do(r.beforeLoad)
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []Account{{ID: 9001, Platform: platform, Status: StatusActive, Schedulable: true}}, nil
+}
+
+func (r *groupLifecycleTestAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, _ int64, platform string) ([]Account, error) {
+	return r.load(ctx, platform)
+}
+
+func (r *groupLifecycleTestAccountRepo) ListSchedulableByGroupIDAndPlatforms(ctx context.Context, _ int64, platforms []string) ([]Account, error) {
+	platform := "mixed"
+	if len(platforms) > 0 {
+		platform = platforms[0]
+	}
+	return r.load(ctx, platform)
+}
+
+func (r *groupLifecycleTestAccountRepo) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func newGroupLifecycleTestService(cache SchedulerCache, accounts AccountRepository, groups GroupRepository, runMode string) *SchedulerSnapshotService {
+	return NewSchedulerSnapshotService(cache, nil, accounts, groups, &config.Config{RunMode: runMode})
+}
+
+func expectedGroupLifecycleBuckets(groupID int64) []SchedulerBucket {
+	platforms := []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok}
+	buckets := make([]SchedulerBucket, 0, 12)
+	for _, platform := range platforms {
+		buckets = append(buckets,
+			SchedulerBucket{GroupID: groupID, Platform: platform, Mode: SchedulerModeSingle},
+			SchedulerBucket{GroupID: groupID, Platform: platform, Mode: SchedulerModeForced},
+		)
+		if platform == PlatformAnthropic || platform == PlatformGemini {
+			buckets = append(buckets, SchedulerBucket{GroupID: groupID, Platform: platform, Mode: SchedulerModeMixed})
+		}
+	}
+	return buckets
+}
+
+func bucketStrings(buckets []SchedulerBucket) map[string]struct{} {
+	out := make(map[string]struct{}, len(buckets))
+	for _, bucket := range buckets {
+		out[bucket.String()] = struct{}{}
+	}
+	return out
+}
+
+func requireLifecycleSeen(t *testing.T, seen map[batchSeenKey]struct{}, groupID int64) {
+	t.Helper()
+	_, ok := seen[batchSeenKey{groupID: groupID, lifecycle: true}]
+	require.True(t, ok)
+	for _, platform := range schedulerSnapshotPlatforms() {
+		_, ok = seen[batchSeenKey{groupID: groupID, platform: platform}]
+		require.True(t, ok)
+	}
+}
+
+func requireLifecycleNotSeen(t *testing.T, seen map[batchSeenKey]struct{}, groupID int64) {
+	t.Helper()
+	_, ok := seen[batchSeenKey{groupID: groupID, lifecycle: true}]
+	require.False(t, ok)
+	for _, platform := range schedulerSnapshotPlatforms() {
+		_, ok = seen[batchSeenKey{groupID: groupID, platform: platform}]
+		require.False(t, ok)
+	}
+}
+
+func TestSchedulerGroupLifecycleInactiveAndMissingRetireAllHistoricalBucketsWithoutAccountReads(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		group *Group
+		err   error
+	}{
+		{name: "inactive", group: &Group{ID: 81, Status: StatusDisabled, Hydrated: true}},
+		{name: "missing", err: ErrGroupNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const groupID int64 = 81
+			current := expectedGroupLifecycleBuckets(groupID)
+			historical := SchedulerBucket{GroupID: groupID, Platform: "legacy", Mode: "obsolete"}
+			other := SchedulerBucket{GroupID: groupID + 1, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+			groupZero := SchedulerBucket{GroupID: 0, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+			cache := newGroupLifecycleTestCache(current[0], historical, other, groupZero)
+			groups := &groupLifecycleTestGroupRepo{group: tc.group, err: tc.err}
+			accounts := &groupLifecycleTestAccountRepo{}
+			svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+			seen := make(map[batchSeenKey]struct{})
+
+			require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen))
+
+			expected := bucketStrings(append(current, historical))
+			got := bucketStrings(cache.retiredBuckets())
+			require.Equal(t, expected, got)
+			retireHeld, _ := cache.lifecycleMutationLeaseStates()
+			require.Len(t, retireHeld, len(expected))
+			for _, held := range retireHeld {
+				require.True(t, held)
+			}
+			require.NotContains(t, got, other.String())
+			require.NotContains(t, got, groupZero.String())
+			require.Zero(t, accounts.callCount())
+			require.Equal(t, 1, groups.callCount())
+			_, _, listCalls := cache.lifecycleCounts()
+			require.Equal(t, 1, listCalls)
+			requireLifecycleSeen(t, seen, groupID)
+		})
+	}
+}
+
+func TestSchedulerPrepareGroupLifecycleUsesKnownHistoricalBucketsWithoutListingRegistry(t *testing.T) {
+	const groupID int64 = 811
+	historical := SchedulerBucket{GroupID: groupID, Platform: "legacy", Mode: "obsolete"}
+	cache := newGroupLifecycleTestCache()
+	cache.listErr = errors.New("registry must not be listed")
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Status: StatusDisabled, Hydrated: true}}
+	accounts := &groupLifecycleTestAccountRepo{}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+
+	plan, err := svc.prepareGroupLifecycle(context.Background(), groupID, []SchedulerBucket{historical})
+	require.NoError(t, err)
+	require.False(t, plan.active)
+	require.Empty(t, plan.tasks)
+	_, _, listCalls := cache.lifecycleCounts()
+	require.Zero(t, listCalls)
+	require.Contains(t, bucketStrings(cache.retiredBuckets()), historical.String())
+	require.Zero(t, accounts.callCount())
+}
+
+func TestSchedulerGroupLifecycleActiveReopensAndRebuildsAllCurrentBuckets(t *testing.T) {
+	const groupID int64 = 82
+	current := expectedGroupLifecycleBuckets(groupID)
+	historical := SchedulerBucket{GroupID: groupID, Platform: "legacy", Mode: "obsolete"}
+	cache := newGroupLifecycleTestCache(historical)
+	for _, bucket := range current {
+		require.NoError(t, cache.retirementRaceCache.RetireBucket(context.Background(), bucket))
+	}
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Platform: PlatformOpenAI, Status: StatusActive, Hydrated: true}}
+	accounts := &groupLifecycleTestAccountRepo{}
+	accounts.beforeLoad = func() {
+		held, tokenCount := cache.leaseHeldAndTokenCount()
+		require.False(t, held, "the group lifecycle lease must be released before the first account query")
+		require.Equal(t, 12, tokenCount, "all reopen tokens must be prepared before the first account query")
+	}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+	seen := make(map[batchSeenKey]struct{})
+
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen))
+
+	require.Equal(t, bucketStrings(current), bucketStrings(cache.reopens))
+	require.Empty(t, cache.retiredBuckets())
+	registered, err := cache.retirementRaceCache.ListBuckets(context.Background())
+	require.NoError(t, err)
+	require.Contains(t, bucketStrings(registered), historical.String())
+	require.Len(t, cache.tokens(), 12)
+	require.Equal(t, 12, accounts.callCount())
+	for _, bucket := range current {
+		_, published := cache.counts(bucket)
+		require.Equal(t, 1, published, bucket.String())
+	}
+	require.Contains(t, bucketStrings(current), SchedulerBucket{GroupID: groupID, Platform: PlatformAntigravity, Mode: SchedulerModeForced}.String())
+	require.Contains(t, bucketStrings(current), SchedulerBucket{GroupID: groupID, Platform: PlatformAnthropic, Mode: SchedulerModeMixed}.String())
+	require.Contains(t, bucketStrings(current), SchedulerBucket{GroupID: groupID, Platform: PlatformGemini, Mode: SchedulerModeMixed}.String())
+	acquires, releases, listCalls := cache.lifecycleCounts()
+	require.Equal(t, 1, acquires)
+	require.Equal(t, 1, releases)
+	require.Zero(t, listCalls)
+	require.Equal(t, schedulerGroupLifecycleLeaseTTL, cache.acquireTTL)
+	require.True(t, cache.acquireDeadline)
+	require.True(t, cache.releaseDeadline)
+	require.NoError(t, cache.releaseCtxErr)
+	_, reopenHeld := cache.lifecycleMutationLeaseStates()
+	require.Len(t, reopenHeld, 12)
+	for _, held := range reopenHeld {
+		require.True(t, held)
+	}
+	lockTTLs, unlockCalls := cache.lockStats()
+	require.Len(t, lockTTLs, 12)
+	for _, ttl := range lockTTLs {
+		require.Equal(t, 30*time.Second, ttl)
+	}
+	require.Equal(t, 12, unlockCalls)
+	requireLifecycleSeen(t, seen, groupID)
+}
+
+func TestSchedulerGroupLifecycleInactiveThenActiveAuthoritativelyReopens(t *testing.T) {
+	const groupID int64 = 83
+	cache := newGroupLifecycleTestCache()
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Status: StatusDisabled, Hydrated: true}}
+	accounts := &groupLifecycleTestAccountRepo{}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
+	require.Zero(t, accounts.callCount())
+	groups.set(&Group{ID: groupID, Status: StatusActive, Hydrated: true}, nil)
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
+
+	require.Len(t, cache.tokens(), 12)
+	require.Equal(t, 12, accounts.callCount())
+	for _, bucket := range expectedGroupLifecycleBuckets(groupID) {
+		_, published := cache.counts(bucket)
+		require.Equal(t, 1, published, bucket.String())
+	}
+}
+
+func TestSchedulerGroupLifecycleLaterInactiveFencesLongActiveRebuild(t *testing.T) {
+	const groupID int64 = 84
+	cache := newGroupLifecycleTestCache()
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Status: StatusActive, Hydrated: true}}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	accounts := &groupLifecycleTestAccountRepo{started: started, release: release}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+	activeSeen := make(map[batchSeenKey]struct{})
+	inactiveSeen := make(map[batchSeenKey]struct{})
+	activeResult := make(chan error, 1)
+
+	go func() {
+		activeResult <- svc.handleGroupEvent(context.Background(), ptrInt64(groupID), activeSeen)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("active rebuild did not reach the account load")
+	}
+
+	groups.set(&Group{ID: groupID, Status: StatusDisabled, Hydrated: true}, nil)
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), inactiveSeen))
+	close(release)
+	err := <-activeResult
+	require.ErrorIs(t, err, ErrSchedulerBucketRetired)
+	requireLifecycleNotSeen(t, activeSeen, groupID)
+	requireLifecycleSeen(t, inactiveSeen, groupID)
+}
+
+func TestSchedulerGroupLifecycleEpochPreventsABA(t *testing.T) {
+	const groupID int64 = 85
+	cache := newGroupLifecycleTestCache()
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Status: StatusDisabled, Hydrated: true}}
+	accounts := &groupLifecycleTestAccountRepo{}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
+	groups.set(&Group{ID: groupID, Status: StatusActive, Hydrated: true}, nil)
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
+	firstActiveTokens := cache.tokens()
+	require.Len(t, firstActiveTokens, 12)
+
+	groups.set(&Group{ID: groupID, Status: StatusDisabled, Hydrated: true}, nil)
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
+	groups.set(&Group{ID: groupID, Status: StatusActive, Hydrated: true}, nil)
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
+	allTokens := cache.tokens()
+	require.Len(t, allTokens, 24)
+	require.Greater(t, allTokens[12].Epoch, firstActiveTokens[0].Epoch)
+	require.ErrorIs(t, cache.SetSnapshot(context.Background(), firstActiveTokens[0].Bucket, firstActiveTokens[0], nil), ErrSchedulerBucketWriteFenced)
+}
+
+func TestSchedulerGroupLifecycleSeenIsIndependentAndDeduplicatesGroupEvents(t *testing.T) {
+	const groupID int64 = 86
+	cache := newGroupLifecycleTestCache()
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Status: StatusActive, Hydrated: true}}
+	accounts := &groupLifecycleTestAccountRepo{}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+	seen := make(map[batchSeenKey]struct{})
+	for _, platform := range schedulerSnapshotPlatforms() {
+		seen[batchSeenKey{groupID: groupID, platform: platform}] = struct{}{}
+	}
+
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen))
+	require.Equal(t, 1, groups.callCount())
+	require.Equal(t, 12, accounts.callCount())
+	requireLifecycleSeen(t, seen, groupID)
+	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen))
+	require.Equal(t, 1, groups.callCount())
+	require.Equal(t, 12, accounts.callCount())
+}
+
+func TestSchedulerGroupLifecycleFailuresDoNotMarkSeen(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*groupLifecycleTestCache, *groupLifecycleTestGroupRepo, *groupLifecycleTestAccountRepo)
+		check   func(*testing.T, error)
+	}{
+		{
+			name: "lease busy",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.leaseBusy = true
+			},
+			check: func(t *testing.T, err error) { require.ErrorIs(t, err, ErrSchedulerGroupLifecycleLeaseBusy) },
+		},
+		{
+			name: "lease error",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.leaseAcquireErr = errors.New("lease failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "lease failed") },
+		},
+		{
+			name: "release lost",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.leaseReleaseErr = ErrSchedulerGroupLifecycleLeaseLost
+			},
+			check: func(t *testing.T, err error) { require.ErrorIs(t, err, ErrSchedulerGroupLifecycleLeaseLost) },
+		},
+		{
+			name: "release error",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.leaseReleaseErr = errors.New("release failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "release failed") },
+		},
+		{
+			name: "group query error",
+			prepare: func(_ *groupLifecycleTestCache, groups *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				groups.err = errors.New("group query failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "group query failed") },
+		},
+		{
+			name: "list buckets error",
+			prepare: func(cache *groupLifecycleTestCache, groups *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				groups.group.Status = StatusDisabled
+				cache.listErr = errors.New("list buckets failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "list buckets failed") },
+		},
+		{
+			name: "retire bucket error",
+			prepare: func(cache *groupLifecycleTestCache, groups *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				groups.group.Status = StatusDisabled
+				cache.retireErr = errors.New("retire bucket failed")
+				cache.retireErrAt = 2
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "retire bucket failed") },
+		},
+		{
+			name: "reopen bucket error",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.reopenErr = errors.New("reopen bucket failed")
+				cache.reopenErrAt = 2
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "reopen bucket failed") },
+		},
+		{
+			name: "account rebuild error",
+			prepare: func(_ *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, accounts *groupLifecycleTestAccountRepo) {
+				accounts.err = errors.New("account load failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "account load failed") },
+		},
+		{
+			name: "bucket lock busy",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.bucketLockBusy = true
+			},
+			check: func(t *testing.T, err error) { require.ErrorIs(t, err, ErrSchedulerBucketRebuildBusy) },
+		},
+		{
+			name: "bucket lock error",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.bucketLockErr = errors.New("bucket lock failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "bucket lock failed") },
+		},
+		{
+			name: "set snapshot error",
+			prepare: func(cache *groupLifecycleTestCache, _ *groupLifecycleTestGroupRepo, _ *groupLifecycleTestAccountRepo) {
+				cache.setErr = errors.New("set snapshot failed")
+			},
+			check: func(t *testing.T, err error) { require.EqualError(t, err, "set snapshot failed") },
+		},
+	}
+
+	for index, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			groupID := int64(870 + index)
+			cache := newGroupLifecycleTestCache()
+			groups := &groupLifecycleTestGroupRepo{group: &Group{ID: groupID, Status: StatusActive, Hydrated: true}}
+			accounts := &groupLifecycleTestAccountRepo{}
+			tc.prepare(cache, groups, accounts)
+			svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+			seen := make(map[batchSeenKey]struct{})
+
+			err := svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen)
+			tc.check(t, err)
+			requireLifecycleNotSeen(t, seen, groupID)
+			if tc.name == "release lost" || tc.name == "release error" {
+				require.Zero(t, accounts.callCount())
+			}
+			if tc.name == "retire bucket error" || tc.name == "reopen bucket error" {
+				_, releases, _ := cache.lifecycleCounts()
+				require.Equal(t, 1, releases)
+				require.Zero(t, accounts.callCount())
+			}
+			if tc.name == "account rebuild error" || tc.name == "set snapshot error" {
+				_, unlockCalls := cache.lockStats()
+				require.Equal(t, 1, unlockCalls)
+			}
+		})
+	}
+}
+
+func TestSchedulerGroupLifecycleOperationAndReleaseErrorsPreserveBothCauses(t *testing.T) {
+	const groupID int64 = 880
+	operationErr := errors.New("group query failed")
+	cache := newGroupLifecycleTestCache()
+	cache.leaseReleaseErr = ErrSchedulerGroupLifecycleLeaseLost
+	groups := &groupLifecycleTestGroupRepo{err: operationErr}
+	accounts := &groupLifecycleTestAccountRepo{}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+	seen := make(map[batchSeenKey]struct{})
+
+	err := svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen)
+	require.ErrorIs(t, err, operationErr)
+	require.ErrorIs(t, err, ErrSchedulerGroupLifecycleLeaseLost)
+	requireLifecycleNotSeen(t, seen, groupID)
+	require.Zero(t, accounts.callCount())
+}
+
+func TestSchedulerGroupLifecycleUntrustedGroupStateFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		group *Group
+	}{
+		{name: "not hydrated", group: &Group{ID: 88, Status: StatusActive}},
+		{name: "mismatched id", group: &Group{ID: 89, Status: StatusActive, Hydrated: true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			const eventGroupID int64 = 88
+			cache := newGroupLifecycleTestCache()
+			groups := &groupLifecycleTestGroupRepo{group: tc.group}
+			accounts := &groupLifecycleTestAccountRepo{}
+			svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+			seen := make(map[batchSeenKey]struct{})
+
+			err := svc.handleGroupEvent(context.Background(), ptrInt64(eventGroupID), seen)
+			require.Error(t, err)
+			require.Empty(t, cache.retiredBuckets())
+			require.Empty(t, cache.tokens())
+			require.Zero(t, accounts.callCount())
+			requireLifecycleNotSeen(t, seen, eventGroupID)
+			acquires, releases, listCalls := cache.lifecycleCounts()
+			require.Equal(t, 1, acquires)
+			require.Equal(t, 1, releases)
+			require.Zero(t, listCalls)
+		})
+	}
+}
+
+func TestSchedulerGroupLifecycleCanceledAfterFreshQueryUsesIndependentReleaseContext(t *testing.T) {
+	const groupID int64 = 89
+	ctx, cancel := context.WithCancel(context.Background())
+	cache := newGroupLifecycleTestCache()
+	groups := &groupLifecycleTestGroupRepo{
+		group:    &Group{ID: groupID, Status: StatusActive, Hydrated: true},
+		afterGet: cancel,
+	}
+	accounts := &groupLifecycleTestAccountRepo{}
+	svc := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+	seen := make(map[batchSeenKey]struct{})
+
+	err := svc.handleGroupEvent(ctx, ptrInt64(groupID), seen)
+	require.ErrorIs(t, err, context.Canceled)
+	requireLifecycleNotSeen(t, seen, groupID)
+	require.Empty(t, cache.tokens())
+	require.Zero(t, accounts.callCount())
+	acquires, releases, _ := cache.lifecycleCounts()
+	require.Equal(t, 1, acquires)
+	require.Equal(t, 1, releases)
+	require.True(t, cache.releaseDeadline)
+	require.NoError(t, cache.releaseCtxErr)
+}
+
+func TestSchedulerGroupLifecycleGroupZeroAndSimpleModeAreNoOps(t *testing.T) {
+	cache := newGroupLifecycleTestCache()
+	groups := &groupLifecycleTestGroupRepo{group: &Group{ID: 88, Status: StatusActive, Hydrated: true}}
+	accounts := &groupLifecycleTestAccountRepo{}
+	standard := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeStandard)
+	simple := newGroupLifecycleTestService(cache, accounts, groups, config.RunModeSimple)
+
+	require.NoError(t, standard.handleGroupEvent(context.Background(), nil, make(map[batchSeenKey]struct{})))
+	require.NoError(t, standard.handleGroupEvent(context.Background(), ptrInt64(0), make(map[batchSeenKey]struct{})))
+	require.NoError(t, simple.handleGroupEvent(context.Background(), ptrInt64(88), make(map[batchSeenKey]struct{})))
+
+	acquires, releases, listCalls := cache.lifecycleCounts()
+	require.Zero(t, acquires)
+	require.Zero(t, releases)
+	require.Zero(t, listCalls)
+	require.Zero(t, groups.callCount())
+	require.Zero(t, accounts.callCount())
+}

--- a/backend/internal/service/scheduler_snapshot_group_lifecycle_test.go
+++ b/backend/internal/service/scheduler_snapshot_group_lifecycle_test.go
@@ -255,19 +255,24 @@ func (r *groupLifecycleTestGroupRepo) callCount() int {
 type groupLifecycleTestAccountRepo struct {
 	AccountRepository
 
-	mu             sync.Mutex
-	calls          int
-	err            error
-	started        chan struct{}
-	release        chan struct{}
-	once           sync.Once
-	beforeLoad     func()
-	beforeLoadOnce sync.Once
+	mu              sync.Mutex
+	calls           int
+	callsByPlatform map[string]int
+	err             error
+	started         chan struct{}
+	release         chan struct{}
+	once            sync.Once
+	beforeLoad      func()
+	beforeLoadOnce  sync.Once
 }
 
 func (r *groupLifecycleTestAccountRepo) load(ctx context.Context, platform string) ([]Account, error) {
 	r.mu.Lock()
 	r.calls++
+	if r.callsByPlatform == nil {
+		r.callsByPlatform = make(map[string]int)
+	}
+	r.callsByPlatform[platform]++
 	err := r.err
 	started := r.started
 	release := r.release
@@ -307,6 +312,12 @@ func (r *groupLifecycleTestAccountRepo) callCount() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.calls
+}
+
+func (r *groupLifecycleTestAccountRepo) platformCallCount(platform string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.callsByPlatform[platform]
 }
 
 func newGroupLifecycleTestService(cache SchedulerCache, accounts AccountRepository, groups GroupRepository, runMode string) *SchedulerSnapshotService {
@@ -443,7 +454,8 @@ func TestSchedulerGroupLifecycleActiveReopensAndRebuildsAllCurrentBuckets(t *tes
 	require.NoError(t, err)
 	require.Contains(t, bucketStrings(registered), historical.String())
 	require.Len(t, cache.tokens(), 12)
-	require.Equal(t, 12, accounts.callCount())
+	require.Equal(t, 7, accounts.callCount())
+	require.Equal(t, 1, accounts.platformCallCount(PlatformOpenAI))
 	for _, bucket := range current {
 		_, published := cache.counts(bucket)
 		require.Equal(t, 1, published, bucket.String())
@@ -486,7 +498,7 @@ func TestSchedulerGroupLifecycleInactiveThenActiveAuthoritativelyReopens(t *test
 	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), make(map[batchSeenKey]struct{})))
 
 	require.Len(t, cache.tokens(), 12)
-	require.Equal(t, 12, accounts.callCount())
+	require.Equal(t, 7, accounts.callCount())
 	for _, bucket := range expectedGroupLifecycleBuckets(groupID) {
 		_, published := cache.counts(bucket)
 		require.Equal(t, 1, published, bucket.String())
@@ -559,11 +571,11 @@ func TestSchedulerGroupLifecycleSeenIsIndependentAndDeduplicatesGroupEvents(t *t
 
 	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen))
 	require.Equal(t, 1, groups.callCount())
-	require.Equal(t, 12, accounts.callCount())
+	require.Equal(t, 7, accounts.callCount())
 	requireLifecycleSeen(t, seen, groupID)
 	require.NoError(t, svc.handleGroupEvent(context.Background(), ptrInt64(groupID), seen))
 	require.Equal(t, 1, groups.callCount())
-	require.Equal(t, 12, accounts.callCount())
+	require.Equal(t, 7, accounts.callCount())
 }
 
 func TestSchedulerGroupLifecycleFailuresDoNotMarkSeen(t *testing.T) {
@@ -684,8 +696,10 @@ func TestSchedulerGroupLifecycleFailuresDoNotMarkSeen(t *testing.T) {
 				require.Zero(t, accounts.callCount())
 			}
 			if tc.name == "account rebuild error" || tc.name == "set snapshot error" {
-				_, unlockCalls := cache.lockStats()
+				lockTTLs, unlockCalls := cache.lockStats()
+				require.Len(t, lockTTLs, 1)
 				require.Equal(t, 1, unlockCalls)
+				require.Equal(t, 1, accounts.callCount())
 			}
 		})
 	}

--- a/backend/internal/service/scheduler_snapshot_hydration_test.go
+++ b/backend/internal/service/scheduler_snapshot_hydration_test.go
@@ -35,6 +35,14 @@ func (c *snapshotHydrationCache) ReopenBucket(ctx context.Context, bucket Schedu
 	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
+func (c *snapshotHydrationCache) TryAcquireGroupLifecycleLease(context.Context, int64, time.Duration) (SchedulerGroupLifecycleLease, bool, error) {
+	return SchedulerGroupLifecycleLease{}, false, nil
+}
+
+func (c *snapshotHydrationCache) ReleaseGroupLifecycleLease(context.Context, SchedulerGroupLifecycleLease) error {
+	return nil
+}
+
 func (c *snapshotHydrationCache) GetAccount(ctx context.Context, accountID int64) (*Account, error) {
 	if c.accounts == nil {
 		return nil, nil

--- a/backend/internal/service/scheduler_snapshot_hydration_test.go
+++ b/backend/internal/service/scheduler_snapshot_hydration_test.go
@@ -19,8 +19,20 @@ func (c *snapshotHydrationCache) GetSnapshot(ctx context.Context, bucket Schedul
 	return c.snapshot, true, nil
 }
 
-func (c *snapshotHydrationCache) SetSnapshot(ctx context.Context, bucket SchedulerBucket, accounts []Account) error {
+func (c *snapshotHydrationCache) CaptureBucketWriteToken(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+
+func (c *snapshotHydrationCache) SetSnapshot(ctx context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accounts []Account) error {
 	return nil
+}
+
+func (c *snapshotHydrationCache) RetireBucket(ctx context.Context, bucket SchedulerBucket) error {
+	return nil
+}
+
+func (c *snapshotHydrationCache) ReopenBucket(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
 func (c *snapshotHydrationCache) GetAccount(ctx context.Context, accountID int64) (*Account, error) {

--- a/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
+++ b/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
@@ -21,8 +21,20 @@ func (c *outboxCleanupCache) GetSnapshot(ctx context.Context, bucket SchedulerBu
 	return nil, false, nil
 }
 
-func (c *outboxCleanupCache) SetSnapshot(ctx context.Context, bucket SchedulerBucket, accounts []Account) error {
+func (c *outboxCleanupCache) CaptureBucketWriteToken(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
+}
+
+func (c *outboxCleanupCache) SetSnapshot(ctx context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accounts []Account) error {
 	return nil
+}
+
+func (c *outboxCleanupCache) RetireBucket(ctx context.Context, bucket SchedulerBucket) error {
+	return nil
+}
+
+func (c *outboxCleanupCache) ReopenBucket(ctx context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
 func (c *outboxCleanupCache) GetAccount(ctx context.Context, accountID int64) (*Account, error) {

--- a/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
+++ b/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
@@ -37,6 +37,14 @@ func (c *outboxCleanupCache) ReopenBucket(ctx context.Context, bucket SchedulerB
 	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: 1}, nil
 }
 
+func (c *outboxCleanupCache) TryAcquireGroupLifecycleLease(context.Context, int64, time.Duration) (SchedulerGroupLifecycleLease, bool, error) {
+	return SchedulerGroupLifecycleLease{}, false, nil
+}
+
+func (c *outboxCleanupCache) ReleaseGroupLifecycleLease(context.Context, SchedulerGroupLifecycleLease) error {
+	return nil
+}
+
 func (c *outboxCleanupCache) GetAccount(ctx context.Context, accountID int64) (*Account, error) {
 	return nil, nil
 }

--- a/backend/internal/service/scheduler_snapshot_retirement_test.go
+++ b/backend/internal/service/scheduler_snapshot_retirement_test.go
@@ -4,7 +4,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -161,7 +160,7 @@ func TestSchedulerFullRebuildCapturesAllRegistryTokensBeforeDBLoad(t *testing.T)
 			return []Account{{ID: 6101, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true}}, nil
 		},
 	}
-	svc := NewSchedulerSnapshotService(cache, nil, repo, nil, &config.Config{
+	svc := NewSchedulerSnapshotService(cache, nil, repo, &retirementGroupRepo{groups: []Group{{ID: 61, Status: StatusActive}}}, &config.Config{
 		RunMode: config.RunModeStandard,
 		Gateway: config.GatewayConfig{Scheduling: config.GatewaySchedulingConfig{
 			DbFallbackEnabled: true,
@@ -177,7 +176,7 @@ func TestSchedulerFullRebuildCapturesAllRegistryTokensBeforeDBLoad(t *testing.T)
 	}
 
 	captures, reopens := cache.captureAndReopenCounts()
-	require.Equal(t, 2, captures, "all registry tokens must be captured before the first DB load")
+	require.Equal(t, 24, captures, "group0 and active-group canonical tokens must be captured before the first DB load")
 	require.Zero(t, reopens)
 	require.NoError(t, cache.RetireBucket(context.Background(), queued))
 	_, err := cache.ReopenBucket(context.Background(), queued)
@@ -261,29 +260,4 @@ func TestSchedulerFallbackReturnsDBAccountsWhenBucketRetired(t *testing.T) {
 	setAttempts, published := cache.counts(bucket)
 	require.Zero(t, setAttempts)
 	require.Zero(t, published)
-}
-
-func TestSchedulerDefaultBucketsUseCaptureAndListActiveFailureKeepsGroupZero(t *testing.T) {
-	cache := newRetirementRaceCache()
-	svc := NewSchedulerSnapshotService(
-		cache,
-		nil,
-		nil,
-		&retirementGroupRepo{err: errors.New("list active failed")},
-		testConfig(),
-	)
-
-	buckets, err := svc.defaultBuckets(context.Background())
-	require.NoError(t, err)
-	require.NotEmpty(t, buckets)
-	for _, bucket := range buckets {
-		require.Zero(t, bucket.GroupID)
-	}
-
-	tasks, err := svc.prepareBucketWriteTasks(context.Background(), buckets)
-	require.NoError(t, err)
-	require.Len(t, tasks, len(buckets))
-	captures, reopens := cache.captureAndReopenCounts()
-	require.Equal(t, len(buckets), captures)
-	require.Zero(t, reopens)
 }

--- a/backend/internal/service/scheduler_snapshot_retirement_test.go
+++ b/backend/internal/service/scheduler_snapshot_retirement_test.go
@@ -1,0 +1,289 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type retirementRaceCache struct {
+	SchedulerCache
+
+	mu          sync.Mutex
+	epochs      map[string]int64
+	retired     map[string]bool
+	listBuckets []SchedulerBucket
+	captures    []SchedulerBucket
+	reopens     []SchedulerBucket
+	setAttempts map[string]int
+	published   map[string]int
+	versions    map[string]int
+	beforeSet   func()
+}
+
+func newRetirementRaceCache(buckets ...SchedulerBucket) *retirementRaceCache {
+	return &retirementRaceCache{
+		epochs:      make(map[string]int64),
+		retired:     make(map[string]bool),
+		listBuckets: buckets,
+		setAttempts: make(map[string]int),
+		published:   make(map[string]int),
+		versions:    make(map[string]int),
+	}
+}
+
+func (c *retirementRaceCache) GetSnapshot(context.Context, SchedulerBucket) ([]*Account, bool, error) {
+	return nil, false, nil
+}
+
+func (c *retirementRaceCache) CaptureBucketWriteToken(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := bucket.String()
+	c.captures = append(c.captures, bucket)
+	if c.retired[key] {
+		return SchedulerBucketWriteToken{}, ErrSchedulerBucketRetired
+	}
+	if c.epochs[key] == 0 {
+		c.epochs[key] = 1
+	}
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: c.epochs[key]}, nil
+}
+
+func (c *retirementRaceCache) SetSnapshot(_ context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, _ []Account) error {
+	if c.beforeSet != nil {
+		c.beforeSet()
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := bucket.String()
+	c.setAttempts[key]++
+	if !token.ValidFor(bucket) {
+		return ErrSchedulerBucketWriteFenced
+	}
+	if c.retired[key] {
+		return ErrSchedulerBucketRetired
+	}
+	if c.epochs[key] != token.Epoch {
+		return ErrSchedulerBucketWriteFenced
+	}
+	c.versions[key]++
+	c.published[key]++
+	return nil
+}
+
+func (c *retirementRaceCache) RetireBucket(_ context.Context, bucket SchedulerBucket) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := bucket.String()
+	if !c.retired[key] {
+		c.epochs[key]++
+		if c.epochs[key] < 1 {
+			c.epochs[key] = 1
+		}
+		c.retired[key] = true
+	}
+	return nil
+}
+
+func (c *retirementRaceCache) ReopenBucket(_ context.Context, bucket SchedulerBucket) (SchedulerBucketWriteToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := bucket.String()
+	if c.epochs[key] == 0 {
+		c.epochs[key] = 1
+	}
+	delete(c.retired, key)
+	c.reopens = append(c.reopens, bucket)
+	return SchedulerBucketWriteToken{Bucket: bucket, Epoch: c.epochs[key]}, nil
+}
+
+func (c *retirementRaceCache) TryLockBucket(context.Context, SchedulerBucket, time.Duration) (bool, error) {
+	return true, nil
+}
+
+func (c *retirementRaceCache) UnlockBucket(context.Context, SchedulerBucket) error {
+	return nil
+}
+
+func (c *retirementRaceCache) ListBuckets(context.Context) ([]SchedulerBucket, error) {
+	return append([]SchedulerBucket(nil), c.listBuckets...), nil
+}
+
+func (c *retirementRaceCache) counts(bucket SchedulerBucket) (setAttempts, published int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.setAttempts[bucket.String()], c.published[bucket.String()]
+}
+
+func (c *retirementRaceCache) captureAndReopenCounts() (captures, reopens int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.captures), len(c.reopens)
+}
+
+func (c *retirementRaceCache) version(bucket SchedulerBucket) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.versions[bucket.String()]
+}
+
+type retirementGroupRepo struct {
+	GroupRepository
+	groups []Group
+	err    error
+}
+
+func (r *retirementGroupRepo) ListActive(context.Context) ([]Group, error) {
+	return r.groups, r.err
+}
+
+func TestSchedulerFullRebuildCapturesAllRegistryTokensBeforeDBLoad(t *testing.T) {
+	first := SchedulerBucket{GroupID: 61, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	queued := SchedulerBucket{GroupID: 61, Platform: PlatformOpenAI, Mode: SchedulerModeForced}
+	cache := newRetirementRaceCache(first, queued)
+	dbStarted := make(chan struct{})
+	releaseDB := make(chan struct{})
+	var firstDB sync.Once
+	repo := &mockAccountRepoForPlatform{
+		listPlatformFunc: func(context.Context, string) ([]Account, error) {
+			firstDB.Do(func() {
+				close(dbStarted)
+				<-releaseDB
+			})
+			return []Account{{ID: 6101, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true}}, nil
+		},
+	}
+	svc := NewSchedulerSnapshotService(cache, nil, repo, nil, &config.Config{
+		RunMode: config.RunModeStandard,
+		Gateway: config.GatewayConfig{Scheduling: config.GatewaySchedulingConfig{
+			DbFallbackEnabled: true,
+		}},
+	})
+
+	result := make(chan error, 1)
+	go func() { result <- svc.triggerFullRebuild("retirement_race_a") }()
+	select {
+	case <-dbStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first DB load did not start")
+	}
+
+	captures, reopens := cache.captureAndReopenCounts()
+	require.Equal(t, 2, captures, "all registry tokens must be captured before the first DB load")
+	require.Zero(t, reopens)
+	require.NoError(t, cache.RetireBucket(context.Background(), queued))
+	_, err := cache.ReopenBucket(context.Background(), queued)
+	require.NoError(t, err)
+	close(releaseDB)
+	require.NoError(t, <-result)
+
+	_, firstPublished := cache.counts(first)
+	queuedAttempts, queuedPublished := cache.counts(queued)
+	require.Equal(t, 1, firstPublished)
+	require.Equal(t, 1, queuedAttempts)
+	require.Zero(t, queuedPublished, "queued registry task must not adopt the reopened epoch")
+}
+
+func TestSchedulerRebuildRetireAfterDBLoadFencesPublish(t *testing.T) {
+	bucket := SchedulerBucket{GroupID: 62, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	cache := newRetirementRaceCache()
+	dbReturned := make(chan struct{})
+	setEntered := make(chan struct{})
+	releaseSet := make(chan struct{})
+	cache.beforeSet = func() {
+		close(setEntered)
+		<-releaseSet
+	}
+	repo := &mockAccountRepoForPlatform{
+		listPlatformFunc: func(context.Context, string) ([]Account, error) {
+			close(dbReturned)
+			return []Account{{ID: 6201, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true}}, nil
+		},
+	}
+	svc := NewSchedulerSnapshotService(cache, nil, repo, nil, &config.Config{
+		RunMode: config.RunModeStandard,
+		Gateway: config.GatewayConfig{Scheduling: config.GatewaySchedulingConfig{
+			DbFallbackEnabled: true,
+		}},
+	})
+
+	result := make(chan error, 1)
+	go func() {
+		result <- svc.rebuildBuckets(context.Background(), []SchedulerBucket{bucket}, "retirement_race_b")
+	}()
+	select {
+	case <-dbReturned:
+	case <-time.After(time.Second):
+		t.Fatal("DB load did not return")
+	}
+	select {
+	case <-setEntered:
+	case <-time.After(time.Second):
+		t.Fatal("snapshot writer did not reach allocation boundary")
+	}
+	require.NoError(t, cache.RetireBucket(context.Background(), bucket))
+	close(releaseSet)
+	require.NoError(t, <-result)
+
+	setAttempts, published := cache.counts(bucket)
+	require.Equal(t, 1, setAttempts)
+	require.Zero(t, published)
+	require.Zero(t, cache.version(bucket), "retirement before allocation must not advance the snapshot version")
+}
+
+func TestSchedulerFallbackReturnsDBAccountsWhenBucketRetired(t *testing.T) {
+	bucket := SchedulerBucket{GroupID: 63, Platform: PlatformOpenAI, Mode: SchedulerModeSingle}
+	cache := newRetirementRaceCache()
+	require.NoError(t, cache.RetireBucket(context.Background(), bucket))
+	repo := &mockAccountRepoForPlatform{
+		accounts: []Account{{ID: 6301, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true}},
+	}
+	svc := NewSchedulerSnapshotService(cache, nil, repo, nil, &config.Config{
+		RunMode: config.RunModeStandard,
+		Gateway: config.GatewayConfig{Scheduling: config.GatewaySchedulingConfig{
+			DbFallbackEnabled: true,
+		}},
+	})
+	groupID := bucket.GroupID
+
+	accounts, useMixed, err := svc.ListSchedulableAccounts(context.Background(), &groupID, bucket.Platform, false)
+	require.NoError(t, err)
+	require.False(t, useMixed)
+	require.Len(t, accounts, 1)
+	setAttempts, published := cache.counts(bucket)
+	require.Zero(t, setAttempts)
+	require.Zero(t, published)
+}
+
+func TestSchedulerDefaultBucketsUseCaptureAndListActiveFailureKeepsGroupZero(t *testing.T) {
+	cache := newRetirementRaceCache()
+	svc := NewSchedulerSnapshotService(
+		cache,
+		nil,
+		nil,
+		&retirementGroupRepo{err: errors.New("list active failed")},
+		testConfig(),
+	)
+
+	buckets, err := svc.defaultBuckets(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, buckets)
+	for _, bucket := range buckets {
+		require.Zero(t, bucket.GroupID)
+	}
+
+	tasks, err := svc.prepareBucketWriteTasks(context.Background(), buckets)
+	require.NoError(t, err)
+	require.Len(t, tasks, len(buckets))
+	captures, reopens := cache.captureAndReopenCounts()
+	require.Equal(t, len(buckets), captures)
+	require.Zero(t, reopens)
+}

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strconv"
 	"sync"
@@ -14,26 +15,36 @@ import (
 )
 
 var (
-	ErrSchedulerCacheNotReady   = errors.New("scheduler cache not ready")
-	ErrSchedulerFallbackLimited = errors.New("scheduler db fallback limited")
+	ErrSchedulerCacheNotReady           = errors.New("scheduler cache not ready")
+	ErrSchedulerFallbackLimited         = errors.New("scheduler db fallback limited")
+	ErrSchedulerGroupLifecycleLeaseBusy = errors.New("scheduler group lifecycle lease busy")
+	ErrSchedulerBucketRebuildBusy       = errors.New("scheduler bucket rebuild busy")
 )
 
 const (
-	outboxEventTimeout          = 2 * time.Minute
-	schedulerOutboxCleanupBatch = 5000
+	outboxEventTimeout                    = 2 * time.Minute
+	schedulerOutboxCleanupBatch           = 5000
+	schedulerGroupLifecycleTimeout        = 30 * time.Second
+	schedulerGroupLifecycleLeaseTTL       = 60 * time.Second
+	schedulerGroupLifecycleReleaseTimeout = 2 * time.Second
 )
 
-// batchSeenKey tracks which (groupID, platform) bucket sets have already been
-// rebuilt within a single pollOutbox call, to avoid redundant work when multiple
-// account_changed events share the same groups.
+// batchSeenKey tracks completed per-platform rebuilds and group lifecycle work
+// within one pollOutbox call.
 type batchSeenKey struct {
-	groupID  int64
-	platform string
+	groupID   int64
+	platform  string
+	lifecycle bool
 }
 
 type schedulerBucketWriteTask struct {
 	bucket SchedulerBucket
 	token  SchedulerBucketWriteToken
+}
+
+type schedulerGroupLifecyclePlan struct {
+	active bool
+	tasks  []schedulerBucketWriteTask
 }
 
 type SchedulerSnapshotService struct {
@@ -513,11 +524,120 @@ func (s *SchedulerSnapshotService) handleAccountEvent(ctx context.Context, accou
 }
 
 func (s *SchedulerSnapshotService) handleGroupEvent(ctx context.Context, groupID *int64, seen map[batchSeenKey]struct{}) error {
-	if groupID == nil || *groupID <= 0 {
+	if groupID == nil || *groupID <= 0 || s.isRunModeSimple() {
 		return nil
 	}
-	groupIDs := []int64{*groupID}
-	return s.rebuildByGroupIDs(ctx, groupIDs, "group_change", seen)
+	if seen != nil {
+		if _, ok := seen[batchSeenKey{groupID: *groupID, lifecycle: true}]; ok {
+			return nil
+		}
+	}
+	return s.reconcileGroupLifecycle(ctx, *groupID, seen)
+}
+
+func (s *SchedulerSnapshotService) reconcileGroupLifecycle(ctx context.Context, groupID int64, seen map[batchSeenKey]struct{}) error {
+	plan, err := s.prepareGroupLifecycle(ctx, groupID, nil)
+	if err != nil {
+		return err
+	}
+	if plan.active {
+		for _, task := range plan.tasks {
+			if err := s.rebuildBucketWithTokenPolicy(ctx, task, "group_change", true); err != nil {
+				return err
+			}
+		}
+	}
+	markGroupLifecycleSeen(seen, groupID)
+	return nil
+}
+
+func (s *SchedulerSnapshotService) prepareGroupLifecycle(ctx context.Context, groupID int64, knownHistorical []SchedulerBucket) (plan schedulerGroupLifecyclePlan, retErr error) {
+	if groupID <= 0 || s.isRunModeSimple() {
+		return schedulerGroupLifecyclePlan{}, nil
+	}
+	if s.cache == nil || s.groupRepo == nil {
+		return schedulerGroupLifecyclePlan{}, ErrSchedulerCacheNotReady
+	}
+
+	lifecycleCtx, cancel := context.WithTimeout(ctx, schedulerGroupLifecycleTimeout)
+	defer cancel()
+	lease, acquired, err := s.cache.TryAcquireGroupLifecycleLease(lifecycleCtx, groupID, schedulerGroupLifecycleLeaseTTL)
+	if err != nil {
+		return schedulerGroupLifecyclePlan{}, err
+	}
+	if !acquired {
+		return schedulerGroupLifecyclePlan{}, fmt.Errorf("%w: group=%d", ErrSchedulerGroupLifecycleLeaseBusy, groupID)
+	}
+	leaseHeld := true
+	defer func() {
+		if leaseHeld {
+			retErr = errors.Join(retErr, s.releaseGroupLifecycleLease(lease))
+		}
+	}()
+
+	group, err := s.groupRepo.GetByIDLite(lifecycleCtx, groupID)
+	missing := errors.Is(err, ErrGroupNotFound)
+	if err != nil && !missing {
+		return schedulerGroupLifecyclePlan{}, err
+	}
+	if err == nil && (group == nil || group.ID != groupID || !group.Hydrated) {
+		return schedulerGroupLifecyclePlan{}, fmt.Errorf("untrusted scheduler group lifecycle state: group=%d", groupID)
+	}
+
+	plan = schedulerGroupLifecyclePlan{active: !missing && group.IsActive()}
+	if plan.active {
+		buckets := schedulerBucketsForGroup(groupID)
+		plan.tasks = make([]schedulerBucketWriteTask, 0, len(buckets))
+		for _, bucket := range buckets {
+			token, err := s.cache.ReopenBucket(lifecycleCtx, bucket)
+			if err != nil {
+				return schedulerGroupLifecyclePlan{}, err
+			}
+			plan.tasks = append(plan.tasks, schedulerBucketWriteTask{bucket: bucket, token: token})
+		}
+	} else {
+		registered := knownHistorical
+		if registered == nil {
+			registered, err = s.cache.ListBuckets(lifecycleCtx)
+			if err != nil {
+				return schedulerGroupLifecyclePlan{}, err
+			}
+		}
+		buckets := schedulerBucketsForGroup(groupID)
+		for _, bucket := range registered {
+			if bucket.GroupID == groupID {
+				buckets = append(buckets, bucket)
+			}
+		}
+		for _, bucket := range dedupeBuckets(buckets) {
+			if err := s.cache.RetireBucket(lifecycleCtx, bucket); err != nil {
+				return schedulerGroupLifecyclePlan{}, err
+			}
+		}
+	}
+
+	releaseErr := s.releaseGroupLifecycleLease(lease)
+	leaseHeld = false
+	if releaseErr != nil {
+		return schedulerGroupLifecyclePlan{}, releaseErr
+	}
+	return plan, nil
+}
+
+func (s *SchedulerSnapshotService) releaseGroupLifecycleLease(lease SchedulerGroupLifecycleLease) error {
+	releaseCtx, cancel := context.WithTimeout(context.Background(), schedulerGroupLifecycleReleaseTimeout)
+	defer cancel()
+	return s.cache.ReleaseGroupLifecycleLease(releaseCtx, lease)
+}
+
+func markGroupLifecycleSeen(seen map[batchSeenKey]struct{}, groupID int64) {
+	if seen == nil {
+		return
+	}
+	seen[batchSeenKey{groupID: groupID, lifecycle: true}] = struct{}{}
+	for _, platform := range schedulerSnapshotPlatforms() {
+		seen[batchSeenKey{groupID: groupID, platform: platform}] = struct{}{}
+	}
 }
 
 func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account *Account, groupIDs []int64, reason string, seen map[batchSeenKey]struct{}) error {
@@ -537,14 +657,34 @@ func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account
 	return s.rebuildBuckets(ctx, buckets, reason)
 }
 
+func schedulerSnapshotPlatforms() [5]string {
+	return [5]string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok}
+}
+
+func schedulerBucketsForGroup(groupID int64) []SchedulerBucket {
+	if groupID <= 0 {
+		return nil
+	}
+	buckets := make([]SchedulerBucket, 0, 12)
+	for _, platform := range schedulerSnapshotPlatforms() {
+		buckets = append(buckets,
+			SchedulerBucket{GroupID: groupID, Platform: platform, Mode: SchedulerModeSingle},
+			SchedulerBucket{GroupID: groupID, Platform: platform, Mode: SchedulerModeForced},
+		)
+		if platform == PlatformAnthropic || platform == PlatformGemini {
+			buckets = append(buckets, SchedulerBucket{GroupID: groupID, Platform: platform, Mode: SchedulerModeMixed})
+		}
+	}
+	return buckets
+}
+
 func (s *SchedulerSnapshotService) rebuildByGroupIDs(ctx context.Context, groupIDs []int64, reason string, seen map[batchSeenKey]struct{}) error {
 	groupIDs = s.normalizeGroupIDs(groupIDs)
 	if len(groupIDs) == 0 {
 		return nil
 	}
-	platforms := []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok}
 	buckets := make([]SchedulerBucket, 0, len(groupIDs)*12)
-	for _, platform := range platforms {
+	for _, platform := range schedulerSnapshotPlatforms() {
 		buckets = append(buckets, s.bucketsForPlatform(platform, groupIDs, seen)...)
 	}
 	return s.rebuildBuckets(ctx, buckets, reason)
@@ -561,7 +701,7 @@ func (s *SchedulerSnapshotService) bucketsForPlatform(platform string, groupIDs 
 		// in the group, so subsequent rebuilds for the same group+platform within
 		// the same batch are redundant.
 		if seen != nil {
-			key := batchSeenKey{gid, platform}
+			key := batchSeenKey{groupID: gid, platform: platform}
 			if _, exists := seen[key]; exists {
 				continue
 			}
@@ -609,6 +749,10 @@ func (s *SchedulerSnapshotService) prepareBucketWriteTasks(ctx context.Context, 
 }
 
 func (s *SchedulerSnapshotService) rebuildBucketWithToken(ctx context.Context, task schedulerBucketWriteTask, reason string) error {
+	return s.rebuildBucketWithTokenPolicy(ctx, task, reason, false)
+}
+
+func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicy(ctx context.Context, task schedulerBucketWriteTask, reason string, strict bool) error {
 	if s.cache == nil {
 		return ErrSchedulerCacheNotReady
 	}
@@ -618,6 +762,9 @@ func (s *SchedulerSnapshotService) rebuildBucketWithToken(ctx context.Context, t
 		return err
 	}
 	if !ok {
+		if strict {
+			return fmt.Errorf("%w: bucket=%s", ErrSchedulerBucketRebuildBusy, bucket.String())
+		}
 		return nil
 	}
 	defer func() {
@@ -635,6 +782,9 @@ func (s *SchedulerSnapshotService) rebuildBucketWithToken(ctx context.Context, t
 	if err := s.cache.SetSnapshot(rebuildCtx, bucket, task.token, accounts); err != nil {
 		if errors.Is(err, ErrSchedulerBucketRetired) || errors.Is(err, ErrSchedulerBucketWriteFenced) {
 			slog.Debug("[Scheduler] rebuild fenced", "bucket", bucket.String(), "reason", reason)
+			if strict {
+				return err
+			}
 			return nil
 		}
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild cache failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"sync"
 	"time"
@@ -45,6 +46,10 @@ type schedulerBucketWriteTask struct {
 type schedulerGroupLifecyclePlan struct {
 	active bool
 	tasks  []schedulerBucketWriteTask
+}
+
+type schedulerActiveGroupIDLister interface {
+	ListActiveIDs(ctx context.Context) ([]int64, error)
 }
 
 type SchedulerSnapshotService struct {
@@ -225,18 +230,7 @@ func (s *SchedulerSnapshotService) runInitialRebuild() {
 	_ = s.coalesceFullRebuild(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
-		buckets, err := s.cache.ListBuckets(ctx)
-		if err != nil {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] list buckets failed: %v", err)
-		}
-		if len(buckets) == 0 {
-			buckets, err = s.defaultBuckets(ctx)
-			if err != nil {
-				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] default buckets failed: %v", err)
-				return err
-			}
-		}
-		if err := s.rebuildBuckets(ctx, buckets, "startup"); err != nil {
+		if err := s.rebuildFullSnapshot(ctx, "startup"); err != nil {
 			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild startup failed: %v", err)
 			return err
 		}
@@ -665,6 +659,10 @@ func schedulerBucketsForGroup(groupID int64) []SchedulerBucket {
 	if groupID <= 0 {
 		return nil
 	}
+	return schedulerCanonicalBuckets(groupID)
+}
+
+func schedulerCanonicalBuckets(groupID int64) []SchedulerBucket {
 	buckets := make([]SchedulerBucket, 0, 12)
 	for _, platform := range schedulerSnapshotPlatforms() {
 		buckets = append(buckets,
@@ -718,10 +716,8 @@ func (s *SchedulerSnapshotService) bucketsForPlatform(platform string, groupIDs 
 
 func (s *SchedulerSnapshotService) rebuildBuckets(ctx context.Context, buckets []SchedulerBucket, reason string) error {
 	tasks, firstErr := s.prepareBucketWriteTasks(ctx, buckets)
-	for _, task := range tasks {
-		if err := s.rebuildBucketWithToken(ctx, task, reason); err != nil && firstErr == nil {
-			firstErr = err
-		}
+	if err := s.rebuildPreparedBucketTasks(ctx, tasks, reason, false); err != nil && firstErr == nil {
+		firstErr = err
 	}
 	return firstErr
 }
@@ -748,8 +744,14 @@ func (s *SchedulerSnapshotService) prepareBucketWriteTasks(ctx context.Context, 
 	return tasks, firstErr
 }
 
-func (s *SchedulerSnapshotService) rebuildBucketWithToken(ctx context.Context, task schedulerBucketWriteTask, reason string) error {
-	return s.rebuildBucketWithTokenPolicy(ctx, task, reason, false)
+func (s *SchedulerSnapshotService) rebuildPreparedBucketTasks(ctx context.Context, tasks []schedulerBucketWriteTask, reason string, strict bool) error {
+	var firstErr error
+	for _, task := range tasks {
+		if err := s.rebuildBucketWithTokenPolicy(ctx, task, reason, strict); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
 }
 
 func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicy(ctx context.Context, task schedulerBucketWriteTask, reason string, strict bool) error {
@@ -801,21 +803,213 @@ func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) error {
 	return s.coalesceFullRebuild(func() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
+		return s.rebuildFullSnapshot(ctx, reason)
+	})
+}
 
-		buckets, err := s.cache.ListBuckets(ctx)
+func (s *SchedulerSnapshotService) rebuildFullSnapshot(ctx context.Context, reason string) error {
+	if s.cache == nil {
+		return ErrSchedulerCacheNotReady
+	}
+
+	registered, err := s.cache.ListBuckets(ctx)
+	if err != nil {
+		return err
+	}
+	registered = dedupeBuckets(registered)
+
+	if s.isRunModeSimple() {
+		canonical := schedulerCanonicalBuckets(0)
+		captured, err := s.captureFullRebuildCanonicalTasks(ctx, canonical)
 		if err != nil {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] list buckets failed: %v", err)
 			return err
 		}
-		if len(buckets) == 0 {
-			buckets, err = s.defaultBuckets(ctx)
-			if err != nil {
-				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] default buckets failed: %v", err)
-				return err
-			}
+		ordinary := appendBucketsExcept(nil, registered, canonical)
+		return s.prepareAndRebuildFullSnapshot(ctx, captured, nil, ordinary, reason)
+	}
+
+	activeGroupIDs, err := s.listActiveSchedulerGroupIDs(ctx)
+	if err != nil {
+		return err
+	}
+	activeGroups := make(map[int64]struct{}, len(activeGroupIDs))
+	for _, groupID := range activeGroupIDs {
+		activeGroups[groupID] = struct{}{}
+	}
+
+	registeredByGroup := make(map[int64][]SchedulerBucket)
+	for _, bucket := range registered {
+		registeredByGroup[bucket.GroupID] = append(registeredByGroup[bucket.GroupID], bucket)
+	}
+
+	groupZeroCanonical := schedulerCanonicalBuckets(0)
+	capturedTasks, err := s.captureFullRebuildCanonicalTasks(ctx, groupZeroCanonical)
+	if err != nil {
+		return err
+	}
+	ordinaryBuckets := appendBucketsExcept(nil, registeredByGroup[0], groupZeroCanonical)
+	for groupID, buckets := range registeredByGroup {
+		if groupID < 0 {
+			ordinaryBuckets = append(ordinaryBuckets, buckets...)
 		}
-		return s.rebuildBuckets(ctx, buckets, reason)
-	})
+	}
+
+	reopenedTasks := make([]schedulerBucketWriteTask, 0)
+	for _, groupID := range activeGroupIDs {
+		canonical := schedulerBucketsForGroup(groupID)
+		canonicalTasks, captureErr := s.captureFullRebuildCanonicalTasks(ctx, canonical)
+		if captureErr == nil {
+			capturedTasks = append(capturedTasks, canonicalTasks...)
+			ordinaryBuckets = appendBucketsExcept(ordinaryBuckets, registeredByGroup[groupID], canonical)
+			continue
+		}
+		if !errors.Is(captureErr, ErrSchedulerBucketRetired) && !errors.Is(captureErr, ErrSchedulerBucketWriteFenced) {
+			return captureErr
+		}
+
+		// A prior full_rebuild event can observe the active state committed for a
+		// later group_changed event. Recover here under fresh authority so the
+		// earlier event cannot block the outbox watermark before that event runs.
+		knownHistorical := registeredByGroup[groupID]
+		if knownHistorical == nil {
+			knownHistorical = []SchedulerBucket{}
+		}
+		plan, err := s.prepareGroupLifecycle(ctx, groupID, knownHistorical)
+		if err != nil {
+			return err
+		}
+		if plan.active {
+			reopenedTasks = append(reopenedTasks, plan.tasks...)
+			ordinaryBuckets = appendBucketsExcept(ordinaryBuckets, registeredByGroup[groupID], canonical)
+		}
+	}
+
+	staleGroupIDs := make([]int64, 0)
+	for groupID := range registeredByGroup {
+		if groupID <= 0 {
+			continue
+		}
+		if _, active := activeGroups[groupID]; !active {
+			staleGroupIDs = append(staleGroupIDs, groupID)
+		}
+	}
+	sort.Slice(staleGroupIDs, func(i, j int) bool { return staleGroupIDs[i] < staleGroupIDs[j] })
+
+	for _, groupID := range staleGroupIDs {
+		plan, err := s.prepareGroupLifecycle(ctx, groupID, registeredByGroup[groupID])
+		if err != nil {
+			return err
+		}
+		if plan.active {
+			reopenedTasks = append(reopenedTasks, plan.tasks...)
+			ordinaryBuckets = appendBucketsExcept(ordinaryBuckets, registeredByGroup[groupID], schedulerBucketsForGroup(groupID))
+		}
+	}
+
+	return s.prepareAndRebuildFullSnapshot(ctx, capturedTasks, reopenedTasks, ordinaryBuckets, reason)
+}
+
+func (s *SchedulerSnapshotService) listActiveSchedulerGroupIDs(ctx context.Context) ([]int64, error) {
+	if s.groupRepo == nil {
+		return nil, ErrSchedulerCacheNotReady
+	}
+
+	var groupIDs []int64
+	if lister, ok := s.groupRepo.(schedulerActiveGroupIDLister); ok {
+		ids, err := lister.ListActiveIDs(ctx)
+		if err != nil {
+			return nil, err
+		}
+		groupIDs = ids
+	} else {
+		groups, err := s.groupRepo.ListActive(ctx)
+		if err != nil {
+			return nil, err
+		}
+		groupIDs = make([]int64, 0, len(groups))
+		for _, group := range groups {
+			groupIDs = append(groupIDs, group.ID)
+		}
+	}
+
+	seen := make(map[int64]struct{}, len(groupIDs))
+	normalized := make([]int64, 0, len(groupIDs))
+	for _, groupID := range groupIDs {
+		if groupID <= 0 {
+			continue
+		}
+		if _, ok := seen[groupID]; ok {
+			continue
+		}
+		seen[groupID] = struct{}{}
+		normalized = append(normalized, groupID)
+	}
+	sort.Slice(normalized, func(i, j int) bool { return normalized[i] < normalized[j] })
+	return normalized, nil
+}
+
+func (s *SchedulerSnapshotService) prepareAndRebuildFullSnapshot(
+	ctx context.Context,
+	captured []schedulerBucketWriteTask,
+	reopened []schedulerBucketWriteTask,
+	ordinaryBuckets []SchedulerBucket,
+	reason string,
+) error {
+	preparedBuckets := make(map[SchedulerBucket]struct{}, len(captured)+len(reopened))
+	for _, task := range captured {
+		preparedBuckets[task.bucket] = struct{}{}
+	}
+	for _, task := range reopened {
+		preparedBuckets[task.bucket] = struct{}{}
+	}
+
+	ordinaryBuckets = dedupeBuckets(ordinaryBuckets)
+	toCapture := make([]SchedulerBucket, 0, len(ordinaryBuckets))
+	for _, bucket := range ordinaryBuckets {
+		if _, ok := preparedBuckets[bucket]; !ok {
+			toCapture = append(toCapture, bucket)
+		}
+	}
+	ordinary, firstErr := s.prepareBucketWriteTasks(ctx, toCapture)
+	if firstErr != nil {
+		return firstErr
+	}
+	captured = append(captured, ordinary...)
+	if err := s.rebuildPreparedBucketTasks(ctx, reopened, reason, true); err != nil {
+		firstErr = err
+	}
+	if err := s.rebuildPreparedBucketTasks(ctx, captured, reason, false); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
+}
+
+func (s *SchedulerSnapshotService) captureFullRebuildCanonicalTasks(ctx context.Context, buckets []SchedulerBucket) ([]schedulerBucketWriteTask, error) {
+	if s.cache == nil {
+		return nil, ErrSchedulerCacheNotReady
+	}
+	tasks := make([]schedulerBucketWriteTask, 0, len(buckets))
+	for _, bucket := range buckets {
+		token, err := s.cache.CaptureBucketWriteToken(ctx, bucket)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, schedulerBucketWriteTask{bucket: bucket, token: token})
+	}
+	return tasks, nil
+}
+
+func appendBucketsExcept(dst, buckets, excluded []SchedulerBucket) []SchedulerBucket {
+	excludedKeys := make(map[SchedulerBucket]struct{}, len(excluded))
+	for _, bucket := range excluded {
+		excludedKeys[bucket] = struct{}{}
+	}
+	for _, bucket := range buckets {
+		if _, ok := excludedKeys[bucket]; !ok {
+			dst = append(dst, bucket)
+		}
+	}
+	return dst
 }
 
 func (s *SchedulerSnapshotService) coalesceFullRebuild(run func() error) error {
@@ -1051,38 +1245,6 @@ func (s *SchedulerSnapshotService) fullRebuildInterval() time.Duration {
 		return 0
 	}
 	return time.Duration(sec) * time.Second
-}
-
-func (s *SchedulerSnapshotService) defaultBuckets(ctx context.Context) ([]SchedulerBucket, error) {
-	buckets := make([]SchedulerBucket, 0)
-	platforms := []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok}
-	for _, platform := range platforms {
-		buckets = append(buckets, SchedulerBucket{GroupID: 0, Platform: platform, Mode: SchedulerModeSingle})
-		buckets = append(buckets, SchedulerBucket{GroupID: 0, Platform: platform, Mode: SchedulerModeForced})
-		if platform == PlatformAnthropic || platform == PlatformGemini {
-			buckets = append(buckets, SchedulerBucket{GroupID: 0, Platform: platform, Mode: SchedulerModeMixed})
-		}
-	}
-
-	if s.isRunModeSimple() || s.groupRepo == nil {
-		return dedupeBuckets(buckets), nil
-	}
-
-	groups, err := s.groupRepo.ListActive(ctx)
-	if err != nil {
-		return dedupeBuckets(buckets), nil
-	}
-	for _, group := range groups {
-		if group.Platform == "" {
-			continue
-		}
-		buckets = append(buckets, SchedulerBucket{GroupID: group.ID, Platform: group.Platform, Mode: SchedulerModeSingle})
-		buckets = append(buckets, SchedulerBucket{GroupID: group.ID, Platform: group.Platform, Mode: SchedulerModeForced})
-		if group.Platform == PlatformAnthropic || group.Platform == PlatformGemini {
-			buckets = append(buckets, SchedulerBucket{GroupID: group.ID, Platform: group.Platform, Mode: SchedulerModeMixed})
-		}
-	}
-	return dedupeBuckets(buckets), nil
 }
 
 func dedupeBuckets(in []SchedulerBucket) []SchedulerBucket {

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -43,6 +43,55 @@ type schedulerBucketWriteTask struct {
 	token  SchedulerBucketWriteToken
 }
 
+type schedulerAccountQueryKey struct {
+	groupID  int64
+	platform string
+}
+
+type schedulerAccountQueryCache struct {
+	remaining map[schedulerAccountQueryKey]int
+	accounts  map[schedulerAccountQueryKey][]Account
+}
+
+func newSchedulerAccountQueryCache(taskSets ...[]schedulerBucketWriteTask) *schedulerAccountQueryCache {
+	queries := &schedulerAccountQueryCache{
+		remaining: make(map[schedulerAccountQueryKey]int),
+		accounts:  make(map[schedulerAccountQueryKey][]Account),
+	}
+	for _, tasks := range taskSets {
+		for _, task := range tasks {
+			if key, ok := schedulerAccountQueryKeyForBucket(task.bucket); ok {
+				queries.remaining[key]++
+			}
+		}
+	}
+	return queries
+}
+
+func schedulerAccountQueryKeyForBucket(bucket SchedulerBucket) (schedulerAccountQueryKey, bool) {
+	if bucket.Mode != SchedulerModeSingle && bucket.Mode != SchedulerModeForced {
+		return schedulerAccountQueryKey{}, false
+	}
+	return schedulerAccountQueryKey{groupID: bucket.GroupID, platform: bucket.Platform}, true
+}
+
+func (c *schedulerAccountQueryCache) release(bucket SchedulerBucket) {
+	if c == nil {
+		return
+	}
+	key, ok := schedulerAccountQueryKeyForBucket(bucket)
+	if !ok {
+		return
+	}
+	remaining := c.remaining[key] - 1
+	if remaining <= 0 {
+		delete(c.remaining, key)
+		delete(c.accounts, key)
+		return
+	}
+	c.remaining[key] = remaining
+}
+
 type schedulerGroupLifecyclePlan struct {
 	active bool
 	tasks  []schedulerBucketWriteTask
@@ -535,8 +584,9 @@ func (s *SchedulerSnapshotService) reconcileGroupLifecycle(ctx context.Context, 
 		return err
 	}
 	if plan.active {
+		queries := newSchedulerAccountQueryCache(plan.tasks)
 		for _, task := range plan.tasks {
-			if err := s.rebuildBucketWithTokenPolicy(ctx, task, "group_change", true); err != nil {
+			if err := s.rebuildBucketWithTokenPolicyAndQueryCache(ctx, task, "group_change", true, queries); err != nil {
 				return err
 			}
 		}
@@ -716,7 +766,8 @@ func (s *SchedulerSnapshotService) bucketsForPlatform(platform string, groupIDs 
 
 func (s *SchedulerSnapshotService) rebuildBuckets(ctx context.Context, buckets []SchedulerBucket, reason string) error {
 	tasks, firstErr := s.prepareBucketWriteTasks(ctx, buckets)
-	if err := s.rebuildPreparedBucketTasks(ctx, tasks, reason, false); err != nil && firstErr == nil {
+	queries := newSchedulerAccountQueryCache(tasks)
+	if err := s.rebuildPreparedBucketTasks(ctx, tasks, reason, false, queries); err != nil && firstErr == nil {
 		firstErr = err
 	}
 	return firstErr
@@ -744,17 +795,32 @@ func (s *SchedulerSnapshotService) prepareBucketWriteTasks(ctx context.Context, 
 	return tasks, firstErr
 }
 
-func (s *SchedulerSnapshotService) rebuildPreparedBucketTasks(ctx context.Context, tasks []schedulerBucketWriteTask, reason string, strict bool) error {
+func (s *SchedulerSnapshotService) rebuildPreparedBucketTasks(
+	ctx context.Context,
+	tasks []schedulerBucketWriteTask,
+	reason string,
+	strict bool,
+	queries *schedulerAccountQueryCache,
+) error {
 	var firstErr error
 	for _, task := range tasks {
-		if err := s.rebuildBucketWithTokenPolicy(ctx, task, reason, strict); err != nil && firstErr == nil {
+		if err := s.rebuildBucketWithTokenPolicyAndQueryCache(ctx, task, reason, strict, queries); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
 }
 
-func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicy(ctx context.Context, task schedulerBucketWriteTask, reason string, strict bool) error {
+func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicyAndQueryCache(
+	ctx context.Context,
+	task schedulerBucketWriteTask,
+	reason string,
+	strict bool,
+	queries *schedulerAccountQueryCache,
+) error {
+	if queries != nil {
+		defer queries.release(task.bucket)
+	}
 	if s.cache == nil {
 		return ErrSchedulerCacheNotReady
 	}
@@ -776,7 +842,7 @@ func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicy(ctx context.Cont
 	rebuildCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	accounts, err := s.loadAccountsFromDB(rebuildCtx, bucket, bucket.Mode == SchedulerModeMixed)
+	accounts, err := s.loadAccountsForRebuild(rebuildCtx, bucket, queries)
 	if err != nil {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
@@ -975,10 +1041,11 @@ func (s *SchedulerSnapshotService) prepareAndRebuildFullSnapshot(
 		return firstErr
 	}
 	captured = append(captured, ordinary...)
-	if err := s.rebuildPreparedBucketTasks(ctx, reopened, reason, true); err != nil {
+	queries := newSchedulerAccountQueryCache(reopened, captured)
+	if err := s.rebuildPreparedBucketTasks(ctx, reopened, reason, true, queries); err != nil {
 		firstErr = err
 	}
-	if err := s.rebuildPreparedBucketTasks(ctx, captured, reason, false); err != nil && firstErr == nil {
+	if err := s.rebuildPreparedBucketTasks(ctx, captured, reason, false, queries); err != nil && firstErr == nil {
 		firstErr = err
 	}
 	return firstErr
@@ -1139,6 +1206,30 @@ func (s *SchedulerSnapshotService) loadAccountsFromDB(ctx context.Context, bucke
 		return s.accountRepo.ListSchedulableByPlatform(ctx, bucket.Platform)
 	}
 	return s.accountRepo.ListSchedulableUngroupedByPlatform(ctx, bucket.Platform)
+}
+
+func (s *SchedulerSnapshotService) loadAccountsForRebuild(
+	ctx context.Context,
+	bucket SchedulerBucket,
+	queries *schedulerAccountQueryCache,
+) ([]Account, error) {
+	key, cacheable := schedulerAccountQueryKeyForBucket(bucket)
+	if queries == nil || !cacheable {
+		return s.loadAccountsFromDB(ctx, bucket, bucket.Mode == SchedulerModeMixed)
+	}
+
+	if accounts, ok := queries.accounts[key]; ok {
+		return accounts, nil
+	}
+	if queries.remaining[key] <= 1 {
+		return s.loadAccountsFromDB(ctx, bucket, false)
+	}
+	accounts, err := s.loadAccountsFromDB(ctx, bucket, false)
+	if err != nil {
+		return nil, err
+	}
+	queries.accounts[key] = accounts
+	return accounts, nil
 }
 
 func (s *SchedulerSnapshotService) bucketFor(groupID *int64, platform string, mode string) SchedulerBucket {

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -31,6 +31,11 @@ type batchSeenKey struct {
 	platform string
 }
 
+type schedulerBucketWriteTask struct {
+	bucket SchedulerBucket
+	token  SchedulerBucketWriteToken
+}
+
 type SchedulerSnapshotService struct {
 	cache         SchedulerCache
 	outboxRepo    SchedulerOutboxRepository
@@ -117,6 +122,8 @@ func (s *SchedulerSnapshotService) ListSchedulableAccounts(ctx context.Context, 
 	useMixed := (platform == PlatformAnthropic || platform == PlatformGemini) && !hasForcePlatform
 	mode := s.resolveMode(platform, hasForcePlatform)
 	bucket := s.bucketFor(groupID, platform, mode)
+	var writeToken SchedulerBucketWriteToken
+	canPublish := false
 
 	if s.cache != nil {
 		cached, hit, err := s.cache.GetSnapshot(ctx, bucket)
@@ -124,6 +131,17 @@ func (s *SchedulerSnapshotService) ListSchedulableAccounts(ctx context.Context, 
 			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] cache read failed: bucket=%s err=%v", bucket.String(), err)
 		} else if hit {
 			return derefAccounts(cached), useMixed, nil
+		}
+		token, err := s.cache.CaptureBucketWriteToken(ctx, bucket)
+		if err != nil {
+			if errors.Is(err, ErrSchedulerBucketRetired) || errors.Is(err, ErrSchedulerBucketWriteFenced) {
+				slog.Debug("[Scheduler] cache publish fenced", "bucket", bucket.String())
+			} else {
+				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] cache publish token failed: bucket=%s err=%v", bucket.String(), err)
+			}
+		} else {
+			writeToken = token
+			canPublish = true
 		}
 	}
 
@@ -139,9 +157,13 @@ func (s *SchedulerSnapshotService) ListSchedulableAccounts(ctx context.Context, 
 		return nil, useMixed, err
 	}
 
-	if s.cache != nil {
-		if err := s.cache.SetSnapshot(fallbackCtx, bucket, accounts); err != nil {
-			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] cache write failed: bucket=%s err=%v", bucket.String(), err)
+	if s.cache != nil && canPublish {
+		if err := s.cache.SetSnapshot(fallbackCtx, bucket, writeToken, accounts); err != nil {
+			if errors.Is(err, ErrSchedulerBucketRetired) || errors.Is(err, ErrSchedulerBucketWriteFenced) {
+				slog.Debug("[Scheduler] cache publish fenced", "bucket", bucket.String())
+			} else {
+				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] cache write failed: bucket=%s err=%v", bucket.String(), err)
+			}
 		}
 	}
 
@@ -507,19 +529,12 @@ func (s *SchedulerSnapshotService) rebuildByAccount(ctx context.Context, account
 		return nil
 	}
 
-	var firstErr error
-	if err := s.rebuildBucketsForPlatform(ctx, account.Platform, groupIDs, reason, seen); err != nil && firstErr == nil {
-		firstErr = err
-	}
+	buckets := s.bucketsForPlatform(account.Platform, groupIDs, seen)
 	if account.Platform == PlatformAntigravity && account.IsMixedSchedulingEnabled() {
-		if err := s.rebuildBucketsForPlatform(ctx, PlatformAnthropic, groupIDs, reason, seen); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		if err := s.rebuildBucketsForPlatform(ctx, PlatformGemini, groupIDs, reason, seen); err != nil && firstErr == nil {
-			firstErr = err
-		}
+		buckets = append(buckets, s.bucketsForPlatform(PlatformAnthropic, groupIDs, seen)...)
+		buckets = append(buckets, s.bucketsForPlatform(PlatformGemini, groupIDs, seen)...)
 	}
-	return firstErr
+	return s.rebuildBuckets(ctx, buckets, reason)
 }
 
 func (s *SchedulerSnapshotService) rebuildByGroupIDs(ctx context.Context, groupIDs []int64, reason string, seen map[batchSeenKey]struct{}) error {
@@ -528,20 +543,18 @@ func (s *SchedulerSnapshotService) rebuildByGroupIDs(ctx context.Context, groupI
 		return nil
 	}
 	platforms := []string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok}
-	var firstErr error
+	buckets := make([]SchedulerBucket, 0, len(groupIDs)*12)
 	for _, platform := range platforms {
-		if err := s.rebuildBucketsForPlatform(ctx, platform, groupIDs, reason, seen); err != nil && firstErr == nil {
-			firstErr = err
-		}
+		buckets = append(buckets, s.bucketsForPlatform(platform, groupIDs, seen)...)
 	}
-	return firstErr
+	return s.rebuildBuckets(ctx, buckets, reason)
 }
 
-func (s *SchedulerSnapshotService) rebuildBucketsForPlatform(ctx context.Context, platform string, groupIDs []int64, reason string, seen map[batchSeenKey]struct{}) error {
+func (s *SchedulerSnapshotService) bucketsForPlatform(platform string, groupIDs []int64, seen map[batchSeenKey]struct{}) []SchedulerBucket {
 	if platform == "" {
 		return nil
 	}
-	var firstErr error
+	buckets := make([]SchedulerBucket, 0, len(groupIDs)*3)
 	for _, gid := range groupIDs {
 		// Within a single poll batch, skip (groupID, platform) pairs that were
 		// already rebuilt. The first rebuild loads fresh DB data for all accounts
@@ -554,35 +567,52 @@ func (s *SchedulerSnapshotService) rebuildBucketsForPlatform(ctx context.Context
 			}
 			seen[key] = struct{}{}
 		}
-		if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeSingle}, reason); err != nil && firstErr == nil {
-			firstErr = err
-		}
-		if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeForced}, reason); err != nil && firstErr == nil {
-			firstErr = err
-		}
+		buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeSingle})
+		buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeForced})
 		if platform == PlatformAnthropic || platform == PlatformGemini {
-			if err := s.rebuildBucket(ctx, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeMixed}, reason); err != nil && firstErr == nil {
-				firstErr = err
-			}
+			buckets = append(buckets, SchedulerBucket{GroupID: gid, Platform: platform, Mode: SchedulerModeMixed})
 		}
 	}
-	return firstErr
+	return buckets
 }
 
 func (s *SchedulerSnapshotService) rebuildBuckets(ctx context.Context, buckets []SchedulerBucket, reason string) error {
-	var firstErr error
-	for _, bucket := range buckets {
-		if err := s.rebuildBucket(ctx, bucket, reason); err != nil && firstErr == nil {
+	tasks, firstErr := s.prepareBucketWriteTasks(ctx, buckets)
+	for _, task := range tasks {
+		if err := s.rebuildBucketWithToken(ctx, task, reason); err != nil && firstErr == nil {
 			firstErr = err
 		}
 	}
 	return firstErr
 }
 
-func (s *SchedulerSnapshotService) rebuildBucket(ctx context.Context, bucket SchedulerBucket, reason string) error {
+func (s *SchedulerSnapshotService) prepareBucketWriteTasks(ctx context.Context, buckets []SchedulerBucket) ([]schedulerBucketWriteTask, error) {
+	if s.cache == nil {
+		return nil, ErrSchedulerCacheNotReady
+	}
+	tasks := make([]schedulerBucketWriteTask, 0, len(buckets))
+	var firstErr error
+	for _, bucket := range buckets {
+		token, err := s.cache.CaptureBucketWriteToken(ctx, bucket)
+		if err != nil {
+			if errors.Is(err, ErrSchedulerBucketRetired) || errors.Is(err, ErrSchedulerBucketWriteFenced) {
+				continue
+			}
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		tasks = append(tasks, schedulerBucketWriteTask{bucket: bucket, token: token})
+	}
+	return tasks, firstErr
+}
+
+func (s *SchedulerSnapshotService) rebuildBucketWithToken(ctx context.Context, task schedulerBucketWriteTask, reason string) error {
 	if s.cache == nil {
 		return ErrSchedulerCacheNotReady
 	}
+	bucket := task.bucket
 	ok, err := s.cache.TryLockBucket(ctx, bucket, 30*time.Second)
 	if err != nil {
 		return err
@@ -602,7 +632,11 @@ func (s *SchedulerSnapshotService) rebuildBucket(ctx context.Context, bucket Sch
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
 	}
-	if err := s.cache.SetSnapshot(rebuildCtx, bucket, accounts); err != nil {
+	if err := s.cache.SetSnapshot(rebuildCtx, bucket, task.token, accounts); err != nil {
+		if errors.Is(err, ErrSchedulerBucketRetired) || errors.Is(err, ErrSchedulerBucketWriteFenced) {
+			slog.Debug("[Scheduler] rebuild fenced", "bucket", bucket.String(), "reason", reason)
+			return nil
+		}
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild cache failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
 	}

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -48,6 +48,9 @@ type schedulerAccountQueryKey struct {
 	platform string
 }
 
+// 查询结果只在一次 rebuild batch 内，按原始 groupID+platform 复用成功的 single/forced 查询；
+// mixed 与历史模式保持独立。每个 task 都用 defer 消费 remaining，最后一个消费者会立即释放结果，
+// 避免把账号切片的生命周期扩大到整轮 full rebuild。
 type schedulerAccountQueryCache struct {
 	remaining map[schedulerAccountQueryKey]int
 	accounts  map[schedulerAccountQueryKey][]Account
@@ -595,6 +598,9 @@ func (s *SchedulerSnapshotService) reconcileGroupLifecycle(ctx context.Context, 
 	return nil
 }
 
+// 生命周期决策必须在所有者安全的租约内读取 fresh 且完整的分组权威状态。
+// active 仅 Reopen canonical bucket；missing/inactive 同时 Retire canonical 与已登记历史 bucket；
+// group event 路径只有在权威决策和后续重建全部成功后才会标记 seen。
 func (s *SchedulerSnapshotService) prepareGroupLifecycle(ctx context.Context, groupID int64, knownHistorical []SchedulerBucket) (plan schedulerGroupLifecyclePlan, retErr error) {
 	if groupID <= 0 || s.isRunModeSimple() {
 		return schedulerGroupLifecyclePlan{}, nil
@@ -669,6 +675,7 @@ func (s *SchedulerSnapshotService) prepareGroupLifecycle(ctx context.Context, gr
 }
 
 func (s *SchedulerSnapshotService) releaseGroupLifecycleLease(lease SchedulerGroupLifecycleLease) error {
+	// 请求取消后仍需尝试释放自己的租约，因此使用独立且有界的后台上下文。
 	releaseCtx, cancel := context.WithTimeout(context.Background(), schedulerGroupLifecycleReleaseTimeout)
 	defer cancel()
 	return s.cache.ReleaseGroupLifecycleLease(releaseCtx, lease)
@@ -705,6 +712,7 @@ func schedulerSnapshotPlatforms() [5]string {
 	return [5]string{PlatformAnthropic, PlatformGemini, PlatformOpenAI, PlatformAntigravity, PlatformGrok}
 }
 
+// 生命周期辅助函数有意排除 group0；full rebuild 构造 group0 canonical 集时必须显式调用 canonical helper。
 func schedulerBucketsForGroup(groupID int64) []SchedulerBucket {
 	if groupID <= 0 {
 		return nil
@@ -878,6 +886,9 @@ func (s *SchedulerSnapshotService) rebuildFullSnapshot(ctx context.Context, reas
 		return ErrSchedulerCacheNotReady
 	}
 
+	// 当前模式所需的全局读取必须先成功：桶注册表始终必需，standard 还需活跃分组 ID；
+	// 失败时不执行 Capture/Retire/Reopen 或 DB 查询。
+	// simple 模式不获取分组生命周期权威；standard 的 stale candidate 仍须在租约内 fresh 确认后才能退休。
 	registered, err := s.cache.ListBuckets(ctx)
 	if err != nil {
 		return err
@@ -980,6 +991,7 @@ func (s *SchedulerSnapshotService) listActiveSchedulerGroupIDs(ctx context.Conte
 		return nil, ErrSchedulerCacheNotReady
 	}
 
+	// 轻量接口一旦实现，其错误直接失败；只有仓储不支持该接口时才回退完整 ListActive。
 	var groupIDs []int64
 	if lister, ok := s.groupRepo.(schedulerActiveGroupIDLister); ok {
 		ids, err := lister.ListActiveIDs(ctx)
@@ -1021,6 +1033,8 @@ func (s *SchedulerSnapshotService) prepareAndRebuildFullSnapshot(
 	ordinaryBuckets []SchedulerBucket,
 	reason string,
 ) error {
+	// 首个 DB 查询前必须完成全部普通 bucket 的 token 预备；任何预备错误都不会留下部分发布。
+	// fresh Reopen task 保持严格锁与 fencing 语义，普通 captured task 继续沿用 lock busy/fence 跳过语义。
 	preparedBuckets := make(map[SchedulerBucket]struct{}, len(captured)+len(reopened))
 	for _, task := range captured {
 		preparedBuckets[task.bucket] = struct{}{}


### PR DESCRIPTION
## 背景

调度快照重建与分组状态变更并发时，旧 writer 可能在 bucket 退休后继续发布；全量重建也可能保留已停用分组的历史 bucket，并对 single/forced 重复执行相同账号查询。

## 依赖链说明

按项目负责人要求，本 PR 直接提交完整 scheduler 依赖链，保留 5 个分步提交：

1. U06：bucket epoch、持久 tombstone 与写入 token
2. U06L：owner-safe group lifecycle lease
3. U07：删除或停用分组时退休历史 bucket
4. U08：full rebuild 对账 missing/inactive group
5. U09：batch 内复用 single/forced 查询

后四步依赖前置的 token、tombstone 和 lease API，不应脱离本 PR 单独 cherry-pick。

## 主要改动

- 在版本分配与 active 指针激活阶段分别校验 epoch/tombstone，阻止退休期间的旧 writer 发布。
- Retire 幂等推进代际并为旧快照保留读取宽限期；Reopen 仅允许在 fresh authority 下执行。
- 使用随机 owner token 的分组生命周期租约，并通过 compare-and-delete 安全释放。
- active 分组只重开 canonical bucket；missing/inactive 分组退休 canonical 与历史 bucket。
- full rebuild 在 mutation 或 DB 查询前完成全局读取和 token 预备。
- stale group 按顺序逐个进行 fresh authority 复核，避免依据过期列表直接退休。
- 同一 rebuild batch 内复用成功的 single/forced 查询；mixed、历史模式及不同 group/platform 不共享。
- 查询失败不缓存；最后 consumer 结束后立即释放结果，不形成跨 batch 缓存。
- 在 epoch、fencing、lease、fresh authority 和 batch cache 关键路径补充中文注释。

## 保持不变

- 每个 bucket 仍独立加锁、使用自己的 token/epoch、发布版本并处理 fencing。
- fresh Reopen 保持 strict 错误语义。
- 普通 rebuild 保持 lock busy 与 retired/fenced 跳过语义。
- 不新增并行 SQL，不修改日志、配置或业务路由。

## 性能

- 每个 canonical group 的账号查询由 12 次降至 7 次。
- 10,000 个账号的 benchmark 仍约 1 KB/op，没有引入随账号数线性增长的复制。

## 验证

- focused scheduler tests
- race tests，count=10
- 完整 service/repository/handler unit tests
- go vet
- Redis retirement/lifecycle lease integration
- PostgreSQL account routing integration
- golangci-lint v2.9.0：0 issues
