### PR TITLE
fix(grok): 拦截图片模型发往 Responses 端点，返回明确 400

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -442,6 +442,11 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
 		if err != nil {
+			var grokImageErr *service.GrokImageModelOnResponsesError
+			if errors.As(err, &grokImageErr) {
+				h.handleStreamingAwareError(c, http.StatusBadRequest, "invalid_request_error", grokImageErr.Error(), streamStarted)
+				return
+			}
 			if result != nil && result.ImageCount > 0 {
 				reqLog.Warn("openai.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -49,6 +49,9 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 	if strings.TrimSpace(upstreamModel) == "" {
 		upstreamModel = grokDefaultResponsesModel
 	}
+	if isGrokImageGenerationModel(upstreamModel) {
+		return nil, &GrokImageModelOnResponsesError{Model: upstreamModel}
+	}
 	cacheIdentity := resolveGrokCacheIdentity(c, body, "", upstreamModel)
 	patchedBody, err := patchGrokResponsesBody(body, upstreamModel)
 	if err != nil {
@@ -1062,4 +1065,14 @@ func (s *OpenAIGatewayService) tempUnscheduleGrok(ctx context.Context, account *
 		defer cancel()
 		_ = s.accountRepo.SetTempUnschedulable(stateCtx, account.ID, until, reason)
 	}
+}
+
+// GrokImageModelOnResponsesError xAI Responses API 不支持图片模型，
+// 需走 /v1/images/generations。
+type GrokImageModelOnResponsesError struct {
+	Model string
+}
+
+func (e *GrokImageModelOnResponsesError) Error() string {
+	return fmt.Sprintf("grok image model %s is not available on the Responses endpoint; use /v1/images/generations instead", e.Model)
 }

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -2037,3 +2037,34 @@ func TestPatchGrokResponsesBody_MultipleReasoningContentNull(t *testing.T) {
 	require.False(t, items[0].Get("content").Exists())
 	require.False(t, items[2].Get("content").Exists())
 }
+
+func TestGrokImageModelOnResponsesError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		{"grok-imagine", "grok-imagine", true},
+		{"grok-imagine-image-quality", "grok-imagine-image-quality", true},
+		{"grok-imagine-edit", "grok-imagine-edit", true},
+		{"grok-imagine-image-hd", "grok-imagine-image-hd", true},
+		{"grok-4.5 text model", "grok-4.5", false},
+		{"grok-composer", "grok-composer", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isGrokImageGenerationModel(tt.model)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGrokImageModelOnResponsesErrorMessage(t *testing.T) {
+	t.Parallel()
+	err := &GrokImageModelOnResponsesError{Model: "grok-imagine-image-quality"}
+	require.Contains(t, err.Error(), "grok-imagine-image-quality")
+	require.Contains(t, err.Error(), "/v1/images/generations")
+}


### PR DESCRIPTION
## 背景

Grok 图片模型（如 `grok-imagine`、`grok-imagine-image-quality`）通过 `/v1/responses` 请求时，`forwardGrokResponses` 直接将其发往 xAI 的 Responses 端点。但 xAI Responses API 不支持图片模型，返回 400：

```
The model grok-imagine-image-quality is an image model and is therefore not available on this endpoint.
Please use a compatible endpoint such as https://api.x.ai/v1/images/generations.
```

由于 400 不触发 failover，后续账号选择失败，最终映射为 502 返回客户端。

Fixes #4301

## 根因

`openai_gateway_forward.go:65-67` 的 Grok 分流在所有生图检查之前执行，图片模型请求没机会被路由到 images 端点。

## 修改

- `backend/internal/service/openai_gateway_grok.go`：在 `forwardGrokResponses` 中，确定 `upstreamModel` 后检查 `isGrokImageGenerationModel`，命中则返回 `GrokImageModelOnResponsesError`
- `backend/internal/handler/openai_gateway_handler.go`：在 forward 错误处理中识别 `GrokImageModelOnResponsesError`，返回 400 + 清晰错误信息，不触发 failover

## 兼容性说明

- 文本模型（`grok-4.5`、`grok-composer` 等）不受影响
- 通过 `/v1/images/generations` 端点的 Grok 生图请求不受影响
- 将原来的 502（需要用户排查）转为 400 + 明确指引

## 测试

- `TestGrokImageModelOnResponsesError`：6 个子用例覆盖图片模型识别（grok-imagine、grok-imagine-image-quality、grok-imagine-edit、grok-imagine-image-hd）和非图片模型排除（grok-4.5、grok-composer）
- `TestGrokImageModelOnResponsesErrorMessage`：错误消息包含模型名和替代端点

```bash
go test -tags=unit ./internal/service/ -run "TestGrokImageModel" -v
```