### PR TITLE
fix(grok): 拦截图片模型发往 Responses 端点，返回明确错误

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -49,6 +49,9 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 	if strings.TrimSpace(upstreamModel) == "" {
 		upstreamModel = grokDefaultResponsesModel
 	}
+	if isGrokImageGenerationModel(upstreamModel) {
+		return nil, fmt.Errorf("model %s is an image model and is not available on the Responses endpoint; use /v1/images/generations instead", upstreamModel)
+	}
 	cacheIdentity := resolveGrokCacheIdentity(c, body, "", upstreamModel)
 	patchedBody, err := patchGrokResponsesBody(body, upstreamModel)
 	if err != nil {

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -2037,3 +2037,25 @@ func TestPatchGrokResponsesBody_MultipleReasoningContentNull(t *testing.T) {
 	require.False(t, items[0].Get("content").Exists())
 	require.False(t, items[2].Get("content").Exists())
 }
+
+func TestIsGrokImageGenerationModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model string
+		want  bool
+	}{
+		{"grok-imagine", true},
+		{"grok-imagine-image-quality", true},
+		{"grok-imagine-edit", true},
+		{"grok-imagine-image-hd", true},
+		{"grok-4.5", false},
+		{"grok-composer", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			require.Equal(t, tt.want, isGrokImageGenerationModel(tt.model))
+		})
+	}
+}
+


### PR DESCRIPTION
## 背景

Grok 图片模型（如 `grok-imagine`）通过 `/v1/responses` 请求时，`forwardGrokResponses` 直接发往 xAI Responses 端点。但 xAI Responses API 不支持图片模型，返回 400 后触发 failover 耗尽，最终客户端收到 502。

网关已有 `/v1/images/generations` 端点可正确处理 Grok 生图请求。

Fixes #4301

## 根因

`openai_gateway_forward.go:65-67` 的 Grok 分流在所有生图检查之前执行，图片模型直接走 Responses 路径，xAI 返回 400 后 failover 循环最终变成 502。

## 修改

- `backend/internal/service/openai_gateway_grok.go`：在 `forwardGrokResponses` 中，确定 `upstreamModel` 后检查 `isGrokImageGenerationModel`，命中则返回明确错误信息指引用户走 `/v1/images/generations`

## 兼容性说明

- 文本模型（`grok-4.5`、`grok-composer` 等）不受影响
- 通过 `/v1/images/generations` 端点的 Grok 生图请求不受影响
- 将原来的 502（failover 耗尽）转为明确的错误提示

## 测试

- `TestIsGrokImageGenerationModel`：6 个子用例覆盖图片模型识别和排除

```bash
go build ./...
go test -tags=unit ./internal/service/ -run "TestIsGrokImageGenerationModel" -v
```