### PR TITLE
fix(grok): bridge image_url content parts through Responses API for vision models

### DIFF
--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 )
 
 const (
@@ -141,17 +142,60 @@ func grokChatResponsesBridgeEligibility(body []byte) (bool, string) {
 		default:
 			return false, "unsupported_message_role_" + role
 		}
-		var content string
-		if raw, exists := message["content"]; !exists || json.Unmarshal(raw, &content) != nil {
-			// Structured content includes image_url and other parts whose exact
-			// behavior is not guaranteed by this bridge.
+		raw, exists := message["content"]
+		if !exists {
 			return false, "non_text_message_content"
 		}
-		if strings.TrimSpace(content) == "" {
-			return false, "empty_message_content"
+		var content string
+		if json.Unmarshal(raw, &content) == nil {
+			if strings.TrimSpace(content) == "" {
+				return false, "empty_message_content"
+			}
+			continue
+		}
+		// Structured content: only allow arrays whose parts are text or
+		// image_url. These are losslessly convertible to Responses input_text/
+		// input_image parts, so the bridge preserves Chat Completions semantics.
+		if ok, reason := grokChatStructuredContentBridgeable(raw); !ok {
+			return false, reason
 		}
 	}
 
+	return true, ""
+}
+
+func grokChatStructuredContentBridgeable(raw json.RawMessage) (bool, string) {
+	var parts []map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &parts); err != nil {
+		return false, "non_text_message_content"
+	}
+	if len(parts) == 0 {
+		return false, "empty_message_content"
+	}
+	hasContent := false
+	for _, part := range parts {
+		var partType string
+		rawType, ok := part["type"]
+		if !ok || json.Unmarshal(rawType, &partType) != nil {
+			return false, "non_text_message_content"
+		}
+		switch strings.TrimSpace(partType) {
+		case "text":
+			var text string
+			if raw, ok := part["text"]; ok && json.Unmarshal(raw, &text) == nil {
+				if strings.TrimSpace(text) != "" {
+					hasContent = true
+				}
+			}
+		case "image_url", "input_image":
+			hasContent = true
+		default:
+			return false, "unsupported_content_part_" + strings.TrimSpace(partType)
+		}
+	}
+	if !hasContent {
+		return false, "empty_message_content"
+	}
 	return true, ""
 }
 
@@ -209,7 +253,12 @@ func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(
 	billingModel := resolveOpenAIForwardModel(account, originalModel, defaultMappedModel)
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	cacheIdentity := resolveGrokCacheIdentity(c, body, promptCacheKey, upstreamModel)
-	if !grokChatResponsesRuntimeEligible(upstreamModel, cacheIdentity) {
+	// Image inputs must go through the Responses bridge: the raw Chat
+	// Completions path cannot forward image_url parts to Grok's native vision
+	// for non-composer models, so they would be silently dropped. Route them to
+	// Responses even when no prompt-cache identity is available.
+	hasImageInput := openAIJSONValueMayContainImageInput(gjson.GetBytes(body, "messages"))
+	if !grokChatResponsesRuntimeEligible(upstreamModel, cacheIdentity) && !(hasImageInput && strings.TrimSpace(upstreamModel) == "grok-4.5") {
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
 

--- a/backend/internal/service/openai_gateway_grok_chat_bridge.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge.go
@@ -258,7 +258,7 @@ func (s *OpenAIGatewayService) forwardGrokChatCompletionsViaResponses(
 	// for non-composer models, so they would be silently dropped. Route them to
 	// Responses even when no prompt-cache identity is available.
 	hasImageInput := openAIJSONValueMayContainImageInput(gjson.GetBytes(body, "messages"))
-	if !grokChatResponsesRuntimeEligible(upstreamModel, cacheIdentity) && !(hasImageInput && strings.TrimSpace(upstreamModel) == "grok-4.5") {
+	if !grokChatResponsesRuntimeEligible(upstreamModel, cacheIdentity) && (!hasImageInput || strings.TrimSpace(upstreamModel) != "grok-4.5") {
 		return s.forwardAsRawChatCompletions(ctx, c, account, body, defaultMappedModel)
 	}
 

--- a/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
+++ b/backend/internal/service/openai_gateway_grok_chat_bridge_test.go
@@ -50,9 +50,29 @@ func TestGrokChatResponsesBridgeEligibility(t *testing.T) {
 			reason: "unsupported_message_role_developer",
 		},
 		{
-			name:   "image content falls back",
-			body:   `{"model":"grok","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,QQ=="}}]}]}`,
-			reason: "non_text_message_content",
+			name: "image content is bridgeable",
+			body: `{"model":"grok","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,QQ=="}}]}]}`,
+			want: true,
+		},
+		{
+			name: "text and image parts are bridgeable",
+			body: `{"model":"grok","messages":[{"role":"user","content":[{"type":"text","text":"what is this"},{"type":"image_url","image_url":{"url":"data:image/png;base64,QQ=="}}]}]}`,
+			want: true,
+		},
+		{
+			name: "text only parts are bridgeable",
+			body: `{"model":"grok","messages":[{"role":"user","content":[{"type":"text","text":"hello"}]}]}`,
+			want: true,
+		},
+		{
+			name:   "unknown content part falls back",
+			body:   `{"model":"grok","messages":[{"role":"user","content":[{"type":"input_audio","input_audio":{"data":"AA=="}}]}]}`,
+			reason: "unsupported_content_part_input_audio",
+		},
+		{
+			name:   "empty content array falls back",
+			body:   `{"model":"grok","messages":[{"role":"user","content":[]}]}`,
+			reason: "empty_message_content",
 		},
 		{
 			name:   "function tools fall back",


### PR DESCRIPTION
## Problem

When a client (e.g. OpenCode) sends a `/v1/chat/completions` request with `image_url` content parts to a Grok OAuth account using a non-Composer vision model like `grok-4.5`, the images are silently dropped or cause upstream errors.

### Root cause

1. **Eligibility gate rejects structured content** (`openai_gateway_grok_chat_bridge.go:144`): `grokChatResponsesBridgeEligibility` tries to unmarshal `content` as a plain string. When it is a structured array (required for `image_url` parts), unmarshaling fails and the function returns `false, "non_text_message_content"`, forcing a fallback to raw Chat Completions forwarding.

2. **Raw path has no image bridge for non-Composer models**: `bridgeGrokComposerImageInputs` only triggers for models whose name contains `composer` (`isGrokComposerModel`). For `grok-4.5` and similar vision-capable models, the image content is forwarded as-is in OpenAI CC format to `cli-chat-proxy.grok.com/v1/chat/completions`, which does not process `image_url` parts.

3. **Runtime gate may block even after eligibility** (`grokChatResponsesRuntimeEligible`): requires both `upstreamModel == "grok-4.5"` and non-empty `cacheIdentity`. First-turn requests without a stable prefix seed would still fall back to raw, losing images.

### Irony

`ChatCompletionsToResponses` (`chatcompletions_to_responses.go:374-380`) already correctly converts `image_url` → `input_image` for Grok Responses API. The conversion logic exists and works — it just never gets executed because the eligibility gate blocks the request before reaching it.

## Fix

- **Relax eligibility**: accept structured content arrays whose parts are exclusively `text`, `image_url`, or `input_image`. Unknown part types (e.g. `input_audio`) still cause a conservative fallback.
- **Force Responses for image inputs**: when the request contains image parts and the model is `grok-4.5`, bypass the `cacheIdentity` requirement in the runtime gate, since the raw path cannot forward images for non-Composer models.
- Add `grokChatStructuredContentBridgeable` helper with strict validation.

## Tests

```bash
go test -tags=unit ./internal/service/ -run TestGrokChatResponsesBridgeEligibility -v -count=1
```

Updated and new test cases:
- `image_content_is_bridgeable`: image_url array content now passes eligibility
- `text_and_image_parts_are_bridgeable`: mixed text + image_url passes
- `text_only_parts_are_bridgeable`: text-only structured array passes
- `unknown_content_part_falls_back`: `input_audio` etc. still rejected
- `empty_content_array_falls_back`: empty array rejected

Fixes a regression where PR #3774 (Composer image bridge) inadvertently left non-Composer vision models without any image forwarding path.

Related: #3766