### PR TITLE
fix(apicompat): preserve incomplete stream finalization

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -211,8 +211,8 @@ func FinalizeAnthropicResponsesStream(state *AnthropicEventToResponsesState) []R
 	// Close any open item
 	events = append(events, closeCurrentResponsesItem(state)...)
 
-	// Emit response.completed
-	events = append(events, makeResponsesCompletedEvent(state, "completed", nil))
+	status, incompleteDetails := anthropicResponsesStreamTerminalState(state.StopReason)
+	events = append(events, makeResponsesCompletedEvent(state, status, incompleteDetails))
 	state.CompletedSent = true
 	return events
 }
@@ -434,19 +434,20 @@ func anthToResHandleMessageStop(state *AnthropicEventToResponsesState) []Respons
 	var events []ResponsesStreamEvent
 	events = append(events, closeCurrentResponsesItem(state)...)
 
-	status := "completed"
-	var incompleteDetails *ResponsesIncompleteDetails
-	if state.StopReason == "max_tokens" {
-		status = "incomplete"
-		incompleteDetails = &ResponsesIncompleteDetails{Reason: "max_output_tokens"}
-	}
-
+	status, incompleteDetails := anthropicResponsesStreamTerminalState(state.StopReason)
 	events = append(events, makeResponsesCompletedEvent(state, status, incompleteDetails))
 	state.CompletedSent = true
 	return events
 }
 
 // --- helper functions ---
+
+func anthropicResponsesStreamTerminalState(stopReason string) (string, *ResponsesIncompleteDetails) {
+	if stopReason == "max_tokens" {
+		return "incomplete", &ResponsesIncompleteDetails{Reason: "max_output_tokens"}
+	}
+	return "completed", nil
+}
 
 func closeCurrentResponsesItem(state *AnthropicEventToResponsesState) []ResponsesStreamEvent {
 	if state.CurrentItemType == "" {

--- a/backend/internal/pkg/apicompat/streaming_stop_reason_test.go
+++ b/backend/internal/pkg/apicompat/streaming_stop_reason_test.go
@@ -44,6 +44,29 @@ func TestAnthropicStreamingMaxTokens_MapsToIncomplete(t *testing.T) {
 	assert.Equal(t, "max_output_tokens", completed.Response.IncompleteDetails.Reason)
 }
 
+func TestAnthropicStreamingMaxTokens_FinalizeMapsToIncompleteWithoutMessageStop(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+
+	AnthropicEventToResponsesEvents(&AnthropicStreamEvent{
+		Type:    "message_start",
+		Message: &AnthropicResponse{ID: "msg_test", Model: "claude-opus-4-6", Role: "assistant"},
+	}, state)
+	AnthropicEventToResponsesEvents(&AnthropicStreamEvent{
+		Type:  "message_delta",
+		Delta: &AnthropicDelta{StopReason: "max_tokens"},
+		Usage: &AnthropicUsage{OutputTokens: 4096},
+	}, state)
+
+	events := FinalizeAnthropicResponsesStream(state)
+	require.Len(t, events, 1)
+	assert.Equal(t, "response.incomplete", events[0].Type)
+	require.NotNil(t, events[0].Response)
+	assert.Equal(t, "incomplete", events[0].Response.Status)
+	require.NotNil(t, events[0].Response.IncompleteDetails)
+	assert.Equal(t, "max_output_tokens", events[0].Response.IncompleteDetails.Reason)
+	assert.Empty(t, FinalizeAnthropicResponsesStream(state), "repeated finalization must be idempotent")
+}
+
 func TestAnthropicStreamingEndTurn_MapsToCompleted(t *testing.T) {
 	state := NewAnthropicEventToResponsesState()
 


### PR DESCRIPTION
## Summary

Preserve Anthropic `max_tokens` semantics when an Anthropic-to-Responses stream is finalized after the upstream omits `message_stop`.

## Problem

The converter records `message_delta.stop_reason`, but its synthetic EOF finalizer always emits `response.completed`. If the upstream already reported `max_tokens` and then closed before `message_stop`, downstream Responses clients receive a successful completion instead of an incomplete response.

## Root cause

The normal `message_stop` handler contained the `max_tokens` to `max_output_tokens` mapping inline. `FinalizeAnthropicResponsesStream` used a separate unconditional completed path, so the two terminal paths diverged.

## Fix

- Extract the terminal status mapping into one private helper.
- Use the same mapping from normal `message_stop` handling and synthetic finalization.
- Emit `response.incomplete` with `incomplete_details.reason=max_output_tokens` for `max_tokens`.
- Preserve the existing `CompletedSent` guard so repeated finalization remains idempotent.

All other stop reasons retain their existing completed behavior.

## Verification

- Confirmed the new regression test fails on the base revision with `response.completed`, status `completed`, and no incomplete details.
- `go test ./internal/pkg/apicompat -run 'TestAnthropicStreaming(MaxTokens_FinalizeMapsToIncompleteWithoutMessageStop|MaxTokens_MapsToIncomplete|EndTurn_MapsToCompleted)' -count=1`
- `go test ./internal/pkg/apicompat -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check upstream/main..HEAD`

