### PR TITLE
fix(apicompat): scope additional tools parsing

### DIFF
--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -91,16 +91,22 @@ func EffectiveResponsesTools(req *ResponsesRequest) ([]ResponsesTool, error) {
 		if len(raw) == 0 || raw[0] != '{' {
 			continue
 		}
+		var discriminator struct {
+			Type string `json:"type"`
+		}
+		if err := json.Unmarshal(raw, &discriminator); err != nil {
+			return nil, fmt.Errorf("parse responses additional tools item: %w", err)
+		}
+		if discriminator.Type != "additional_tools" {
+			continue
+		}
 		var item struct {
-			Type  string          `json:"type"`
 			Tools []ResponsesTool `json:"tools"`
 		}
 		if err := json.Unmarshal(raw, &item); err != nil {
 			return nil, fmt.Errorf("parse responses additional tools item: %w", err)
 		}
-		if item.Type == "additional_tools" {
-			tools = append(tools, item.Tools...)
-		}
+		tools = append(tools, item.Tools...)
 	}
 	return tools, nil
 }

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_custom_tools_test.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge_custom_tools_test.go
@@ -79,6 +79,31 @@ func TestEffectiveResponsesTools_SkipsStringInputItems(t *testing.T) {
 	assert.Equal(t, "exec", tools[0].Name)
 }
 
+func TestEffectiveResponsesTools_IgnoresMalformedToolsOnNonAdditionalItem(t *testing.T) {
+	req := &ResponsesRequest{
+		Input: json.RawMessage(`[
+			{"type":"message","role":"user","tools":"not-an-array","content":[{"type":"input_text","text":"hello"}]},
+			{"type":"additional_tools","tools":[{"type":"custom","name":"exec"}]}
+		]`),
+	}
+
+	tools, err := EffectiveResponsesTools(req)
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	assert.Equal(t, "exec", tools[0].Name)
+}
+
+func TestEffectiveResponsesTools_RejectsMalformedAdditionalTools(t *testing.T) {
+	req := &ResponsesRequest{
+		Input: json.RawMessage(`[{"type":"additional_tools","tools":"not-an-array"}]`),
+	}
+
+	tools, err := EffectiveResponsesTools(req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse responses additional tools item")
+	assert.Empty(t, tools)
+}
+
 func TestResponsesToChatCompletionsRequest_DropsToolChoiceWhenNoConvertibleTools(t *testing.T) {
 	req := &ResponsesRequest{
 		Model: "glm-5.2",


### PR DESCRIPTION
## Summary

Restrict `tools` decoding in Responses input items to objects whose type is actually `additional_tools`.

## Problem

`EffectiveResponsesTools` scans the Responses input array for Codex `additional_tools` items. A normal message object can legally contain unrelated extension fields. If such an object contains a non-array field named `tools`, the current scanner tries to decode it as `[]ResponsesTool` before checking the item type and rejects the entire request.

## Root cause

Each object was decoded into a combined `{type, tools}` structure in one pass. JSON decoding therefore validated the shape of `tools` even for objects that were not `additional_tools` items.

## Fix

- Decode only the `type` discriminator first.
- Skip non-`additional_tools` objects before touching their `tools` field.
- Decode and validate `tools` only for actual `additional_tools` items.

Malformed `tools` on a real `additional_tools` item still returns the existing contextual error. No request conversion refactor is included.

## Verification

- Confirmed the non-target-item regression test fails on the base revision with `cannot unmarshal string into ... []apicompat.ResponsesTool`.
- Added the complementary assertion that malformed actual `additional_tools` items are still rejected.
- `go test ./internal/pkg/apicompat -run 'TestEffectiveResponsesTools_(IgnoresMalformedToolsOnNonAdditionalItem|RejectsMalformedAdditionalTools)' -count=1`
- `go test ./internal/pkg/apicompat -count=1`
- `go test ./... -count=1`
- `go vet ./...`
- `git diff --check upstream/main..HEAD`

