### PR TITLE
fix(openai-ws): dead-conn health check, write retry, response.failed before close

### DIFF
--- a/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
+++ b/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
@@ -23,6 +23,7 @@ import (
 	coderws "github.com/coder/websocket"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 type grokCredentialHandlerRepo struct {
@@ -776,11 +777,20 @@ func TestResponsesWebSocketCredentialFailoverLoop(t *testing.T) {
 		defer closeConn()
 		writeFirst(t, conn)
 
+		// 失败出口会先发 response.failed 再 Close，避免 Codex 盲重连。
 		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		_, _, err := conn.Read(readCtx)
+		msgType, payload, err := conn.Read(readCtx)
 		cancel()
+		require.NoError(t, err)
+		require.Equal(t, coderws.MessageText, msgType)
+		require.Equal(t, "response.failed", gjson.GetBytes(payload, "type").String())
+		require.Contains(t, gjson.GetBytes(payload, "response.error.message").String(), service.GrokCredentialUnavailableClientMessage)
+
+		closeCtx, cancelClose := context.WithTimeout(context.Background(), 3*time.Second)
+		_, _, closeErrRaw := conn.Read(closeCtx)
+		cancelClose()
 		var closeErr coderws.CloseError
-		require.ErrorAs(t, err, &closeErr)
+		require.ErrorAs(t, closeErrRaw, &closeErr)
 		require.Contains(t, closeErr.Reason, service.GrokCredentialUnavailableClientMessage)
 		require.Equal(t, 1, repo.selectorCalls())
 		require.Empty(t, upstream.accountHits())

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -1841,11 +1841,16 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 
 			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, false, nil)
 			closeStatus, closeReason := summarizeWSCloseErrorForLog(err)
+			stage, retried, wroteDownstream, hasTurnMeta := service.OpenAIWSIngressTurnErrorMeta(err)
 			proxyFailedFields := []zap.Field{
 				zap.Int64("account_id", account.ID),
 				zap.Error(err),
 				zap.String("close_status", closeStatus),
 				zap.String("close_reason", closeReason),
+				zap.String("stage", stage),
+				zap.Bool("retried", retried),
+				zap.Bool("wrote_downstream", wroteDownstream),
+				zap.Bool("has_turn_meta", hasTurnMeta),
 			}
 			if account.Proxy != nil {
 				proxyFailedFields = append(proxyFailedFields,
@@ -1858,11 +1863,17 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				proxyFailedFields = append(proxyFailedFields, zap.Int64p("proxy_id", account.ProxyID))
 			}
 			reqLog.Warn("openai.websocket_proxy_failed", proxyFailedFields...)
+			// Codex 严格要求先收到 response.failed/completed，否则会把 Close 当成
+			// "websocket closed by server before response.completed" 并盲重连。
+			failedMsg := strings.TrimSpace(err.Error())
+			if failedMsg == "" {
+				failedMsg = "upstream websocket proxy failed"
+			}
 			if errors.As(err, &closeErr) {
-				closeOpenAIClientWS(wsConn, closeErr.StatusCode(), closeErr.Reason())
+				closeOpenAIClientWSWithFailedEvent(ctx, wsConn, closeErr.StatusCode(), closeErr.Reason(), failedMsg)
 				return
 			}
-			closeOpenAIClientWS(wsConn, coderws.StatusInternalError, "upstream websocket proxy failed")
+			closeOpenAIClientWSWithFailedEvent(ctx, wsConn, coderws.StatusInternalError, "upstream websocket proxy failed", failedMsg)
 			return
 		}
 		reqLog.Info("openai.websocket_ingress_closed", zap.Int64("account_id", account.ID))
@@ -2357,24 +2368,68 @@ func closeOpenAIClientWS(conn *coderws.Conn, status coderws.StatusCode, reason s
 	_ = conn.CloseNow()
 }
 
+// writeOpenAIWSResponsesFailedEvent emits a Responses-protocol terminal event so Codex
+// does not treat a subsequent Close as "websocket closed by server before response.completed".
+func writeOpenAIWSResponsesFailedEvent(ctx context.Context, conn *coderws.Conn, message string) {
+	if conn == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "upstream websocket proxy failed"
+	}
+	if len(message) > 500 {
+		message = message[:500]
+	}
+	respID := "resp_" + strings.ReplaceAll(uuid.NewString(), "-", "")
+	payload, err := json.Marshal(gin.H{
+		"type": "response.failed",
+		"response": gin.H{
+			"id":     respID,
+			"object": "response",
+			"status": "failed",
+			"output": []any{},
+			"error": gin.H{
+				"code":    "upstream_error",
+				"message": message,
+			},
+		},
+	})
+	if err != nil {
+		payload = []byte(`{"type":"response.failed","response":{"id":"resp_ws_proxy_failed","object":"response","status":"failed","output":[],"error":{"code":"upstream_error","message":"upstream websocket proxy failed"}}}`)
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	_ = conn.Write(writeCtx, coderws.MessageText, payload)
+}
+
+// closeOpenAIClientWSWithFailedEvent sends response.failed then closes the client websocket.
+func closeOpenAIClientWSWithFailedEvent(ctx context.Context, conn *coderws.Conn, status coderws.StatusCode, reason, message string) {
+	writeOpenAIWSResponsesFailedEvent(ctx, conn, message)
+	closeOpenAIClientWS(conn, status, reason)
+}
+
 func closeOpenAIWSFailoverExhausted(conn *coderws.Conn, failoverErr *service.UpstreamFailoverError) {
 	if failoverErr == nil {
-		closeOpenAIClientWS(conn, coderws.StatusInternalError, "upstream websocket proxy failed")
+		closeOpenAIClientWSWithFailedEvent(context.Background(), conn, coderws.StatusInternalError, "upstream websocket proxy failed", "upstream websocket proxy failed")
 		return
 	}
 	if failoverErr.Stage == service.GatewayFailureStageAccountAuth {
-		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, service.GrokCredentialUnavailableClientMessage)
+		closeOpenAIClientWSWithFailedEvent(context.Background(), conn, coderws.StatusTryAgainLater, service.GrokCredentialUnavailableClientMessage, service.GrokCredentialUnavailableClientMessage)
 		return
 	}
 	switch failoverErr.StatusCode {
 	case http.StatusTooManyRequests:
-		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, "upstream rate limit exceeded, please retry later")
+		closeOpenAIClientWSWithFailedEvent(context.Background(), conn, coderws.StatusTryAgainLater, "upstream rate limit exceeded, please retry later", "upstream rate limit exceeded, please retry later")
 	case 529, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
-		closeOpenAIClientWS(conn, coderws.StatusTryAgainLater, "upstream service temporarily unavailable")
+		closeOpenAIClientWSWithFailedEvent(context.Background(), conn, coderws.StatusTryAgainLater, "upstream service temporarily unavailable", "upstream service temporarily unavailable")
 	case http.StatusUnauthorized, http.StatusForbidden:
-		closeOpenAIClientWS(conn, coderws.StatusPolicyViolation, "upstream websocket authentication failed")
+		closeOpenAIClientWSWithFailedEvent(context.Background(), conn, coderws.StatusPolicyViolation, "upstream websocket authentication failed", "upstream websocket authentication failed")
 	default:
-		closeOpenAIClientWS(conn, coderws.StatusInternalError, "upstream websocket proxy failed")
+		closeOpenAIClientWSWithFailedEvent(context.Background(), conn, coderws.StatusInternalError, "upstream websocket proxy failed", "upstream websocket proxy failed")
 	}
 }
 

--- a/backend/internal/handler/openai_ws_terminal_event_test.go
+++ b/backend/internal/handler/openai_ws_terminal_event_test.go
@@ -1,0 +1,66 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	coderws "github.com/coder/websocket"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestWriteOpenAIWSResponsesFailedEvent_EmitsTerminalBeforeClose(t *testing.T) {
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{
+			CompressionMode: coderws.CompressionDisabled,
+		})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		closeOpenAIClientWSWithFailedEvent(
+			r.Context(),
+			conn,
+			coderws.StatusInternalError,
+			"upstream websocket proxy failed",
+			"write upstream websocket request: write: broken pipe",
+		)
+		serverErrCh <- nil
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelRead()
+	msgType, payload, readErr := clientConn.Read(readCtx)
+	require.NoError(t, readErr)
+	require.Equal(t, coderws.MessageText, msgType)
+	require.Equal(t, "response.failed", gjson.GetBytes(payload, "type").String())
+	require.Equal(t, "failed", gjson.GetBytes(payload, "response.status").String())
+	require.Contains(t, gjson.GetBytes(payload, "response.error.message").String(), "broken pipe")
+
+	// Close frame should follow the terminal event.
+	closeCtx, cancelClose := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancelClose()
+	_, _, closeReadErr := clientConn.Read(closeCtx)
+	require.Error(t, closeReadErr)
+
+	select {
+	case serverErr := <-serverErrCh:
+		require.NoError(t, serverErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("server handler timed out")
+	}
+}

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"math/rand"
+	"net"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
@@ -94,6 +97,7 @@ type openAIWSIngressTurnError struct {
 	stage           string
 	cause           error
 	wroteDownstream bool
+	retried         bool
 }
 
 func (e *openAIWSIngressTurnError) Error() string {
@@ -113,6 +117,24 @@ func (e *openAIWSIngressTurnError) Unwrap() error {
 	return e.cause
 }
 
+// Stage returns the ingress turn failure stage (e.g. write_upstream). Empty if not a turn error.
+func (e *openAIWSIngressTurnError) Stage() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.stage)
+}
+
+// WroteDownstream reports whether any business frame was already written to the client.
+func (e *openAIWSIngressTurnError) WroteDownstream() bool {
+	return e != nil && e.wroteDownstream
+}
+
+// Retried reports whether the ingress layer already attempted a same-turn recovery.
+func (e *openAIWSIngressTurnError) Retried() bool {
+	return e != nil && e.retried
+}
+
 func wrapOpenAIWSIngressTurnError(stage string, cause error, wroteDownstream bool) error {
 	if cause == nil {
 		return nil
@@ -124,15 +146,69 @@ func wrapOpenAIWSIngressTurnError(stage string, cause error, wroteDownstream boo
 	}
 }
 
+// markOpenAIWSIngressTurnRetried attaches a retried=true flag when err is an ingress turn error.
+func markOpenAIWSIngressTurnRetried(err error) error {
+	var turnErr *openAIWSIngressTurnError
+	if !errors.As(err, &turnErr) || turnErr == nil {
+		return err
+	}
+	turnErr.retried = true
+	return turnErr
+}
+
+// OpenAIWSIngressTurnErrorMeta extracts stage/retried/wrote_downstream for structured logs.
+func OpenAIWSIngressTurnErrorMeta(err error) (stage string, retried bool, wroteDownstream bool, ok bool) {
+	var turnErr *openAIWSIngressTurnError
+	if !errors.As(err, &turnErr) || turnErr == nil {
+		return "", false, false, false
+	}
+	return turnErr.Stage(), turnErr.Retried(), turnErr.WroteDownstream(), true
+}
+
+// isOpenAIWSDeadUpstreamConnError reports transport-level dead upstream connections that are safe to
+// recover by marking the lease broken and forcing a new connection.
+func isOpenAIWSDeadUpstreamConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, net.ErrClosed) || errors.Is(err, errOpenAIWSConnClosed) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && opErr != nil {
+		if errors.Is(opErr.Err, syscall.EPIPE) || errors.Is(opErr.Err, syscall.ECONNRESET) || errors.Is(opErr.Err, syscall.ETIMEDOUT) {
+			return true
+		}
+	}
+	message := strings.ToLower(strings.TrimSpace(err.Error()))
+	if message == "" {
+		return false
+	}
+	return strings.Contains(message, "broken pipe") ||
+		strings.Contains(message, "connection reset by peer") ||
+		strings.Contains(message, "connection timed out") ||
+		strings.Contains(message, "use of closed network connection") ||
+		strings.Contains(message, "an existing connection was forcibly closed by the remote host") ||
+		strings.Contains(message, "an established connection was aborted") ||
+		strings.Contains(message, "unexpected eof") ||
+		strings.Contains(message, "failed to write frame") ||
+		strings.Contains(message, "failed to flush flate")
+}
+
 func isOpenAIWSIngressTurnRetryable(err error) bool {
 	var turnErr *openAIWSIngressTurnError
 	if !errors.As(err, &turnErr) || turnErr == nil {
 		return false
 	}
-	if errors.Is(turnErr.cause, context.Canceled) || errors.Is(turnErr.cause, context.DeadlineExceeded) {
+	if turnErr.wroteDownstream {
 		return false
 	}
-	if turnErr.wroteDownstream {
+	// write_upstream on a dead pooled connection must retry even if a write deadline is nested
+	// in the error chain — OS ETIMEDOUT/broken pipe is recoverable by forcing a new conn.
+	if turnErr.stage == "write_upstream" && isOpenAIWSDeadUpstreamConnError(turnErr.cause) {
+		return true
+	}
+	if errors.Is(turnErr.cause, context.Canceled) || errors.Is(turnErr.cause, context.DeadlineExceeded) {
 		return false
 	}
 	switch turnErr.stage {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -644,16 +644,22 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 
 	agentTaskRecoveryTried := false
+	// write_upstream 重试时置 true，下一次 acquire 强制新连。
+	forceNewConnOnNextAcquire := false
 	var acquireTurnLease func(int, string, bool) (*openAIWSConnLease, error)
 	acquireTurnLease = func(turn int, preferred string, forcePreferredConn bool) (*openAIWSConnLease, error) {
 		req := cloneOpenAIWSAcquireRequest(baseAcquireReq)
 		req.PreferredConnID = strings.TrimSpace(preferred)
 		req.ForcePreferredConn = forcePreferredConn
 		// dedicated 模式下每次获取均新建连接，避免跨会话复用残留上下文。
-		req.ForceNewConn = dedicatedMode
+		// write_upstream 重试时强制新连，避免再拿到同一条半死连接。
+		req.ForceNewConn = dedicatedMode || forceNewConnOnNextAcquire
 		acquireCtx, acquireCancel := context.WithTimeout(ctx, acquireTimeout)
 		lease, acquireErr := pool.Acquire(acquireCtx, req)
 		acquireCancel()
+		if acquireErr == nil {
+			forceNewConnOnNextAcquire = false
+		}
 		var dialErr *openAIWSDialError
 		if acquireErr != nil && s.isAgentIdentityAccount(ctx, account) && errors.As(acquireErr, &dialErr) && isAgentIdentityTaskInvalidWSDialError(dialErr) && !agentTaskRecoveryTried {
 			agentTaskRecoveryTried = true
@@ -741,6 +747,8 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 		turnStart := time.Now()
 		wroteDownstream := false
 		if err := lease.WriteJSONWithContextTimeout(ctx, json.RawMessage(payload), s.openAIWSWriteTimeout()); err != nil {
+			// 写失败后连接不可复用（半死/对端已关），立即 MarkBroken 避免回池。
+			lease.MarkBroken()
 			return nil, wrapOpenAIWSIngressTurnError(
 				"write_upstream",
 				fmt.Errorf("write upstream websocket request: %w", err),
@@ -1155,25 +1163,49 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 	}
 	retryIngressTurn := func(relayErr error, turn int, connID string) bool {
 		if !isOpenAIWSIngressTurnRetryable(relayErr) || turnRetry >= 1 {
+			if !isOpenAIWSIngressTurnRetryable(relayErr) {
+				logOpenAIWSModeInfo(
+					"ingress_ws_turn_retry_skip account_id=%d turn=%d conn_id=%s reason=not_retryable stage=%s",
+					account.ID,
+					turn,
+					truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+					truncateOpenAIWSLogValue(openAIWSIngressTurnRetryReason(relayErr), openAIWSLogValueMaxLen),
+				)
+			} else {
+				logOpenAIWSModeInfo(
+					"ingress_ws_turn_retry_skip account_id=%d turn=%d conn_id=%s reason=retry_budget_exhausted stage=%s",
+					account.ID,
+					turn,
+					truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+					truncateOpenAIWSLogValue(openAIWSIngressTurnRetryReason(relayErr), openAIWSLogValueMaxLen),
+				)
+			}
 			return false
 		}
-		if isStrictAffinityTurn(currentPayload) {
+		// write 死连接重试优先换新连，不能被 strict affinity 卡住在坏连接上。
+		retryReason := openAIWSIngressTurnRetryReason(relayErr)
+		if isStrictAffinityTurn(currentPayload) && retryReason != "write_upstream" {
 			logOpenAIWSModeInfo(
-				"ingress_ws_turn_retry_skip account_id=%d turn=%d conn_id=%s reason=strict_affinity",
+				"ingress_ws_turn_retry_skip account_id=%d turn=%d conn_id=%s reason=strict_affinity stage=%s",
 				account.ID,
 				turn,
 				truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+				truncateOpenAIWSLogValue(retryReason, openAIWSLogValueMaxLen),
 			)
 			return false
 		}
 		turnRetry++
+		if retryReason == "write_upstream" || isOpenAIWSDeadUpstreamConnError(relayErr) {
+			forceNewConnOnNextAcquire = true
+		}
 		logOpenAIWSModeInfo(
-			"ingress_ws_turn_retry account_id=%d turn=%d retry=%d reason=%s conn_id=%s",
+			"ingress_ws_turn_retry account_id=%d turn=%d retry=%d reason=%s conn_id=%s force_new_conn=%v",
 			account.ID,
 			turn,
 			turnRetry,
-			truncateOpenAIWSLogValue(openAIWSIngressTurnRetryReason(relayErr), openAIWSLogValueMaxLen),
+			truncateOpenAIWSLogValue(retryReason, openAIWSLogValueMaxLen),
 			truncateOpenAIWSLogValue(connID, openAIWSIDValueMaxLen),
+			forceNewConnOnNextAcquire,
 		)
 		resetSessionLease(true)
 		skipBeforeTurn = true
@@ -1496,17 +1528,25 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			if retryIngressTurn(relayErr, turn, connID) {
 				continue
 			}
+			// 保留 openAIWSIngressTurnError 包装，供 handler 打 stage/retried 结构化字段。
 			finalErr := relayErr
-			if unwrapped := errors.Unwrap(relayErr); unwrapped != nil {
-				finalErr = unwrapped
+			if turnRetry > 0 {
+				finalErr = markOpenAIWSIngressTurnRetried(relayErr)
 			}
 			if hooks != nil && hooks.AfterTurn != nil {
-				hooks.AfterTurn(turn, nil, finalErr)
+				hookErr := finalErr
+				if unwrapped := errors.Unwrap(finalErr); unwrapped != nil {
+					hookErr = unwrapped
+				}
+				hooks.AfterTurn(turn, nil, hookErr)
 			}
-			sessionLease.MarkBroken()
+			if sessionLease != nil {
+				sessionLease.MarkBroken()
+			}
 			return finalErr
 		}
 		turnRetry = 0
+		forceNewConnOnNextAcquire = false
 		turnPrevRecoveryTried = false
 		lastTurnFinishedAt = time.Now()
 		lastTurnClean = true

--- a/backend/internal/service/openai_ws_forwarder_ingress_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"testing"
@@ -60,6 +61,42 @@ func TestIsOpenAIWSIngressPreviousResponseNotFound(t *testing.T) {
 	require.True(t, isOpenAIWSIngressPreviousResponseNotFound(
 		wrapOpenAIWSIngressTurnError(openAIWSIngressStagePreviousResponseNotFound, errors.New("previous response not found"), false),
 	))
+}
+
+func TestIsOpenAIWSDeadUpstreamConnError(t *testing.T) {
+	t.Parallel()
+
+	require.False(t, isOpenAIWSDeadUpstreamConnError(nil))
+	require.False(t, isOpenAIWSDeadUpstreamConnError(errors.New("validation failed")))
+	require.True(t, isOpenAIWSDeadUpstreamConnError(errors.New("write tcp 1:1->2:2: write: broken pipe")))
+	require.True(t, isOpenAIWSDeadUpstreamConnError(errors.New("write tcp 1:1->2:2: write: connection timed out")))
+	require.True(t, isOpenAIWSDeadUpstreamConnError(errors.New("failed to flush flate: failed to write data frame")))
+	require.True(t, isOpenAIWSDeadUpstreamConnError(io.EOF))
+}
+
+func TestIsOpenAIWSIngressTurnRetryable_DeadWriteUpstream(t *testing.T) {
+	t.Parallel()
+
+	deadWrite := wrapOpenAIWSIngressTurnError(
+		"write_upstream",
+		fmt.Errorf("write upstream websocket request: %w", errors.New("write: broken pipe")),
+		false,
+	)
+	require.True(t, isOpenAIWSIngressTurnRetryable(deadWrite))
+	require.Equal(t, "write_upstream", openAIWSIngressTurnRetryReason(deadWrite))
+
+	alreadyWrote := wrapOpenAIWSIngressTurnError(
+		"write_upstream",
+		errors.New("write: broken pipe"),
+		true,
+	)
+	require.False(t, isOpenAIWSIngressTurnRetryable(alreadyWrote))
+
+	stage, retried, wroteDownstream, ok := OpenAIWSIngressTurnErrorMeta(markOpenAIWSIngressTurnRetried(deadWrite))
+	require.True(t, ok)
+	require.Equal(t, "write_upstream", stage)
+	require.True(t, retried)
+	require.False(t, wroteDownstream)
 }
 
 func TestOpenAIWSIngressPreviousResponseRecoveryEnabled(t *testing.T) {

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -21,8 +21,8 @@ const (
 	openAIWSConnMaxAge = 60 * time.Minute
 	// openAIWSConnHealthCheckIdle: 复用前健康检查的最小空闲时长。
 	// 0 表示只要复用连接就 ping（现网 broken pipe 多由 idle 不足原 90s 阈值的半死连接引起）。
-	openAIWSConnHealthCheckIdle = 0
-	openAIWSConnHealthCheckTO   = 2 * time.Second
+	openAIWSConnHealthCheckIdle    = 0
+	openAIWSConnHealthCheckTO      = 2 * time.Second
 	openAIWSConnPrewarmExtraDelay  = 2 * time.Second
 	openAIWSAcquireCleanupInterval = 3 * time.Second
 	openAIWSBackgroundPingInterval = 30 * time.Second

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -18,9 +18,11 @@ import (
 )
 
 const (
-	openAIWSConnMaxAge             = 60 * time.Minute
-	openAIWSConnHealthCheckIdle    = 90 * time.Second
-	openAIWSConnHealthCheckTO      = 2 * time.Second
+	openAIWSConnMaxAge = 60 * time.Minute
+	// openAIWSConnHealthCheckIdle: 复用前健康检查的最小空闲时长。
+	// 0 表示只要复用连接就 ping（现网 broken pipe 多由 idle 不足原 90s 阈值的半死连接引起）。
+	openAIWSConnHealthCheckIdle = 0
+	openAIWSConnHealthCheckTO   = 2 * time.Second
 	openAIWSConnPrewarmExtraDelay  = 2 * time.Second
 	openAIWSAcquireCleanupInterval = 3 * time.Second
 	openAIWSBackgroundPingInterval = 30 * time.Second
@@ -1693,6 +1695,10 @@ func (p *openAIWSConnPool) nextConnID(accountID int64) string {
 func (p *openAIWSConnPool) shouldHealthCheckConn(conn *openAIWSConn) bool {
 	if conn == nil || !conn.supportsIdlePingWithoutReader() {
 		return false
+	}
+	// 阈值 0：每次 reuse 都做 ping，避免拿半死连接去 Write。
+	if openAIWSConnHealthCheckIdle <= 0 {
+		return true
 	}
 	return conn.idleDuration(time.Now()) >= openAIWSConnHealthCheckIdle
 }

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -1314,13 +1314,13 @@ func TestOpenAIWSConnPool_UtilityBranches(t *testing.T) {
 	_, ok = pool.getAccountPool(8)
 	require.False(t, ok)
 
-	// health check 条件
+	// health check 条件：阈值 0 时，只要支持 idle ping 的连接在 reuse 前都应检查。
 	require.False(t, pool.shouldHealthCheckConn(nil))
 	conn := newOpenAIWSConn("health", 1, &openAIWSFakeConn{}, nil)
-	conn.lastUsedNano.Store(time.Now().Add(-openAIWSConnHealthCheckIdle - time.Second).UnixNano())
-	require.True(t, pool.shouldHealthCheckConn(conn))
+	conn.lastUsedNano.Store(time.Now().UnixNano())
+	require.True(t, pool.shouldHealthCheckConn(conn), "health check idle=0 时应在每次 reuse 前 ping")
 	unsafeConn := newOpenAIWSConn("unsafe_health", 1, &openAIWSIdlePingUnsupportedConn{}, nil)
-	unsafeConn.lastUsedNano.Store(time.Now().Add(-openAIWSConnHealthCheckIdle - time.Second).UnixNano())
+	unsafeConn.lastUsedNano.Store(time.Now().UnixNano())
 	require.False(t, pool.shouldHealthCheckConn(unsafeConn))
 }
 


### PR DESCRIPTION
## Summary

Fixes Codex reconnect storms (`websocket closed by server before response.completed` / `Reconnecting... n/n`) when sub2api logs `openai.websocket_proxy_failed` with:

```text
write upstream websocket request: ... write: broken pipe
write upstream websocket request: ... write: connection timed out
```

Root cause (BES-29): pooled upstream WS connections to Cloudflare edges are half-open; Write fails; client WS is closed **without** a Responses terminal event → Codex blind-reconnects.

### A — Stricter reuse health check
- `openAIWSConnHealthCheckIdle`: `90s` → `0` (ping **every** reused upstream conn before lease)
- Evicts half-open connections that previously skipped health check when idle < 90s

### B — Write failure recovery
- MarkBroken immediately on `write_upstream` failure
- Dead-conn errors (`broken pipe` / `connection timed out` / flate write frame failures, etc.) are always turn-retryable once
- Retry forces `ForceNewConn=true` so we do not reuse the same dead pool entry
- `write_upstream` retries are **not** blocked by strict affinity
- Always log `ingress_ws_turn_retry` / `ingress_ws_turn_retry_skip` with `stage` / `force_new_conn`
- Preserve `openAIWSIngressTurnError` wrapper on return (no silent unwrap) so handler can log `stage` / `retried`

### C — Terminal event before Close
- On `websocket_proxy_failed` (and failover exhausted), emit WS text `response.failed` **then** Close
- Prevents Codex from treating Close as mid-stream disconnect

### Observability
`openai.websocket_proxy_failed` now includes:
- `stage` (e.g. `write_upstream`)
- `retried`
- `wrote_downstream`
- `has_turn_meta`

## Test plan
- [x] `go test ./internal/service/ -run 'IsOpenAIWSDeadUpstream|IsOpenAIWSIngressTurnRetryable_Dead|WriteFailBeforeDownstreamRetriesOnce|TestOpenAIWSConnPool_'`
- [x] `go test ./internal/handler/ -run 'TestWriteOpenAIWSResponsesFailedEvent'`
- [ ] Deploy / canary: confirm `websocket_proxy_failed` with `stage=write_upstream` and reduced Codex reconnects
- [ ] Confirm `ingress_ws_turn_retry ... force_new_conn=true` appears when write dies and recovery succeeds

Related: Wei-Shaw/sub2api#1807, #3349, BES-29