### PR TITLE
fix(openai): allow Agent Identity Codex JSON import

### DIFF
--- a/backend/internal/handler/admin/account_codex_agent_identity_import_test.go
+++ b/backend/internal/handler/admin/account_codex_agent_identity_import_test.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/x509"
@@ -44,4 +45,39 @@ func TestNormalizeCodexImportEntryAcceptsAgentIdentityAuthJSON(t *testing.T) {
 	require.NotContains(t, item.Credentials, "access_token")
 	require.NotContains(t, item.Credentials, "refresh_token")
 	require.NotEmpty(t, item.WarningTexts)
+}
+
+func TestImportCodexSessionsCreatesAgentIdentityWithoutOAuthExpiry(t *testing.T) {
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(privateKey)
+	require.NoError(t, err)
+
+	svc := newCodexImportMemoryAdminService(nil)
+	handler := NewAccountHandler(svc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	result, err := handler.importCodexSessions(context.Background(), CodexSessionImportRequest{
+		SkipDefaultGroupBind: boolPtr(true),
+	}, []codexImportEntry{{
+		Index: 1,
+		Value: map[string]any{
+			"auth_mode": "agentIdentity",
+			"agent_identity": map[string]any{
+				"agent_runtime_id":  "runtime-import",
+				"agent_private_key": base64.StdEncoding.EncodeToString(der),
+				"task_id":           "task-import",
+				"account_id":        "account-import",
+				"chatgpt_user_id":   "user-import",
+			},
+		},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Created)
+	require.Zero(t, result.Failed)
+	require.Len(t, svc.createdAccounts, 1)
+	created := svc.createdAccounts[0]
+	require.Nil(t, created.ExpiresAt)
+	require.Nil(t, created.AutoPauseOnExpired)
+	require.Equal(t, service.OpenAIAuthModeAgentIdentity, created.Credentials["auth_mode"])
+	require.NotContains(t, created.Credentials, "access_token")
+	require.NotContains(t, created.Credentials, "refresh_token")
 }

--- a/backend/internal/handler/admin/account_codex_import.go
+++ b/backend/internal/handler/admin/account_codex_import.go
@@ -774,6 +774,12 @@ func resolveCodexImportExpiry(req CodexSessionImportRequest, item *codexImportAc
 	if item == nil {
 		return nil, nil, nil, nil, errors.New("导入项为空")
 	}
+	// Agent Identity has no OAuth access-token lifetime. Its runtime/task
+	// lifecycle is handled by the upstream task recovery path, so it must not
+	// be rejected or auto-paused by the OAuth import expiry policy.
+	if item.IsAgentIdentity {
+		return nil, nil, nil, nil, nil
+	}
 
 	var requestExpiresAt *time.Time
 	if req.ExpiresAt != nil && *req.ExpiresAt > 0 {


### PR DESCRIPTION
## Problem

The Codex JSON importer recognizes `auth_mode=agentIdentity`, but then applies the OAuth access-token expiry policy unconditionally. Agent Identity has neither an OAuth `refresh_token` nor an access-token expiry, so a valid Agent Identity JSON is rejected before an account can be created.

## Fix

Skip OAuth expiry and auto-pause handling for recognized Agent Identity imports. Runtime/task lifecycle remains handled by the existing Agent Identity task recovery path.

## Verification

- Added an import-flow test that creates an Agent Identity account from Codex auth JSON without OAuth credentials.
- `go test ./internal/handler/admin -count=1`
