### PR TITLE
fix(gateway): bound default SSE max_line_size to 40MiB (#4365)

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -838,7 +838,7 @@ type GatewayConfig struct {
 	ImageStreamKeepaliveInterval int `mapstructure:"image_stream_keepalive_interval"`
 	// ImageNonstreamKeepaliveInterval: 图片非流式 JSON keepalive 间隔（秒），0表示禁用
 	ImageNonstreamKeepaliveInterval int `mapstructure:"image_nonstream_keepalive_interval"`
-	// MaxLineSize: 上游 SSE 单行最大字节数（0使用默认值）
+	// MaxLineSize: 上游 SSE 单行最大字节数（0 使用默认值 40MiB；勿再回退到数百 MiB，见 #4365）
 	MaxLineSize int `mapstructure:"max_line_size"`
 
 	// 是否记录上游错误响应体摘要（避免输出请求内容）
@@ -2066,7 +2066,10 @@ func setDefaults() {
 	viper.SetDefault("gateway.image_stream_data_interval_timeout", 900)
 	viper.SetDefault("gateway.image_stream_keepalive_interval", 10)
 	viper.SetDefault("gateway.image_nonstream_keepalive_interval", 0)
-	viper.SetDefault("gateway.max_line_size", 500*1024*1024)
+	// Keep in sync with service.defaultMaxLineSize and deploy/config.example.yaml.
+	// 40 MiB is enough for large tool-result SSE lines without allowing multi-GiB
+	// per-request growth under concurrent Codex traffic (#4365).
+	viper.SetDefault("gateway.max_line_size", 40*1024*1024)
 	viper.SetDefault("gateway.scheduling.sticky_session_max_waiting", 3)
 	viper.SetDefault("gateway.scheduling.sticky_session_wait_timeout", 120*time.Second)
 	viper.SetDefault("gateway.scheduling.fallback_wait_timeout", 30*time.Second)

--- a/backend/internal/service/gateway_max_line_size_test.go
+++ b/backend/internal/service/gateway_max_line_size_test.go
@@ -1,0 +1,20 @@
+package service
+
+import "testing"
+
+// Guard against reintroducing multi-hundred-MiB SSE line defaults that let
+// concurrent Codex streams allocate multi-GiB anonymous memory (#4365).
+func TestDefaultMaxLineSizeIsBoundedForLowMemoryHosts(t *testing.T) {
+	const maxAcceptableDefault = 64 * 1024 * 1024 // 64 MiB hard ceiling for the built-in default
+
+	if defaultMaxLineSize <= 0 {
+		t.Fatalf("defaultMaxLineSize must be positive, got %d", defaultMaxLineSize)
+	}
+	if defaultMaxLineSize > maxAcceptableDefault {
+		t.Fatalf("defaultMaxLineSize=%d exceeds safe ceiling %d (see #4365)", defaultMaxLineSize, maxAcceptableDefault)
+	}
+	// Documented project default is 40 MiB (config.example.yaml).
+	if defaultMaxLineSize != 40*1024*1024 {
+		t.Fatalf("defaultMaxLineSize=%d, want 40 MiB to match deploy/config.example.yaml", defaultMaxLineSize)
+	}
+}

--- a/backend/internal/service/gateway_service.go
+++ b/backend/internal/service/gateway_service.go
@@ -31,7 +31,11 @@ const (
 	claudeAPIURL            = "https://api.anthropic.com/v1/messages?beta=true"
 	claudeAPICountTokensURL = "https://api.anthropic.com/v1/messages/count_tokens?beta=true"
 	stickySessionTTL        = time.Hour // 粘性会话TTL
-	defaultMaxLineSize      = 500 * 1024 * 1024
+	// defaultMaxLineSize bounds a single upstream SSE line (bufio.Scanner max token).
+	// Keep this aligned with the documented config default (40 MiB). The previous
+	// 500 MiB default let concurrent Codex/long-context streams allocate multi-GiB
+	// anonymous memory under light load (see #4365).
+	defaultMaxLineSize = 40 * 1024 * 1024
 	// Canonical Claude Code banner. Keep it EXACT (no trailing whitespace/newlines)
 	// to match real Claude CLI traffic as closely as possible. When we need a visual
 	// separator between system blocks, we add "\n\n" at concatenation time.


### PR DESCRIPTION
## Summary

- Lower the built-in `gateway.max_line_size` default from **500 MiB** to **40 MiB**, matching `deploy/config.example.yaml`.
- Keep `service.defaultMaxLineSize` and the viper default in sync so Docker installs that omit the key no longer allow multi-hundred-MiB SSE scanner growth per concurrent stream.
- Add a regression test so the default cannot silently climb above 64 MiB again.

Fixes / mitigates https://github.com/Wei-Shaw/sub2api/issues/4365

### Why

`bufio.Scanner` grows its token buffer up to `MaxLineSize`. With the old 500 MiB default, a few concurrent Codex/long-context streams could allocate multi-GiB private anonymous memory. Restart temporarily frees RSS, but normal traffic recreates the growth within minutes.

### Notes for operators

- Existing configs that already set `gateway.max_line_size` are unchanged.
- Hosts that intentionally need larger single SSE lines can still raise the config value (minimum validated size remains 1 MiB).
- This is a defensive default bound; further request-body lifecycle work may still help on very small hosts.

## Test plan

- [x] Unit test `TestDefaultMaxLineSizeIsBoundedForLowMemoryHosts`
- [ ] `go test ./internal/service/ -run TestDefaultMaxLineSize`
- [ ] Deploy on a low-memory host previously hit by #4365 and confirm RSS no longer climbs to multi-GiB under light Codex traffic
- [ ] Confirm large tool-result SSE lines under 40 MiB still stream successfully