### PR TITLE
[codex] preserve typed Responses SSE event boundaries

### DIFF
--- a/backend/internal/service/openai_sse_concatenated_json_test.go
+++ b/backend/internal/service/openai_sse_concatenated_json_test.go
@@ -28,6 +28,235 @@ func TestOpenAIStreamingPassthroughRepairsConcatenatedJSONDocumentsInSingleDataL
 	testOpenAIStreamingRepairsConcatenatedJSONDocuments(t, true, 0)
 }
 
+func TestOpenAISSEScannerRepairsMultipleTypedDataLinesInSingleFrame(t *testing.T) {
+	largeInProgress, outputItemAdded, completed := openAIConcatenatedJSONTestEvents(t)
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + largeInProgress,
+		"data: " + outputItemAdded,
+		"",
+		"event: response.completed",
+		"data: " + completed,
+		"",
+	}, "\n")
+
+	assertOpenAISSEFrames(t, scanOpenAISSEJSONDocumentsForTest(t, input), []string{
+		"response.in_progress",
+		"response.output_item.added",
+		"response.completed",
+	})
+}
+
+func TestOpenAISSEScannerRepairsMissingBlankLineBetweenTypedEvents(t *testing.T) {
+	largeInProgress, outputItemAdded, completed := openAIConcatenatedJSONTestEvents(t)
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + largeInProgress,
+		"event: response.output_item.added",
+		"data: " + outputItemAdded,
+		"",
+		"event: response.completed",
+		"data: " + completed,
+		"",
+	}, "\n")
+
+	assertOpenAISSEFrames(t, scanOpenAISSEJSONDocumentsForTest(t, input), []string{
+		"response.in_progress",
+		"response.output_item.added",
+		"response.completed",
+	})
+}
+
+func TestOpenAISSEScannerPreservesEventOverrideBeforeDispatch(t *testing.T) {
+	data := `data: {"type":"response.in_progress","response":{"id":"resp_override"}}`
+	eventOverride := "event: response.completed"
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		data,
+		eventOverride,
+		"",
+		"",
+	}, "\n")
+
+	out := scanOpenAISSEJSONDocumentsForTest(t, input)
+	require.Equal(t, strings.TrimSuffix(input, "\n"), out)
+	require.NotContains(t, out, data+"\n\n"+eventOverride)
+}
+
+func TestOpenAISSEScannerPreservesDeferredFieldGroupAtEOF(t *testing.T) {
+	input := strings.Join([]string{
+		"event: response.created",
+		`data: {"type":"response.in_progress","response":{"id":"resp_eof"}}`,
+		"event: response.in_progress",
+		"event: response.completed",
+		"id: event-2",
+		": upstream keepalive",
+	}, "\n")
+
+	require.Equal(t, input, scanOpenAISSEJSONDocumentsForTest(t, input))
+}
+
+func TestOpenAISSEScannerMovesDeferredFieldGroupBeforeNextTypedData(t *testing.T) {
+	inProgress := `{"type":"response.in_progress","response":{"id":"resp_fields"}}`
+	outputItemAdded := `{"type":"response.output_item.added","output_index":0}`
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + inProgress,
+		"event: response.output_item.added",
+		"id: item-1",
+		": upstream keepalive",
+		"retry: 1000",
+		"data: " + outputItemAdded,
+		"",
+		"",
+	}, "\n")
+	want := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + inProgress,
+		"",
+		"event: response.output_item.added",
+		"id: item-1",
+		": upstream keepalive",
+		"retry: 1000",
+		"data: " + outputItemAdded,
+		"",
+	}, "\n")
+
+	require.Equal(t, want, scanOpenAISSEJSONDocumentsForTest(t, input))
+}
+
+func TestOpenAISSEScannerMovesDeferredFieldGroupBeforeDoneMarker(t *testing.T) {
+	inProgress := `{"type":"response.in_progress","response":{"id":"resp_done"}}`
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + inProgress,
+		"event: response.completed",
+		"id: terminal-1",
+		": upstream keepalive",
+		"data: [DONE]",
+		"",
+		"",
+	}, "\n")
+	want := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + inProgress,
+		"",
+		"event: response.completed",
+		"id: terminal-1",
+		": upstream keepalive",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	require.Equal(t, want, scanOpenAISSEJSONDocumentsForTest(t, input))
+}
+
+func TestOpenAISSEScannerRejectsDeferredFieldGroupOverLimit(t *testing.T) {
+	inProgress := `{"type":"response.in_progress","response":{"id":"resp_limit"}}`
+
+	t.Run("line count", func(t *testing.T) {
+		const deferredFieldLineLimit = 256
+		lines := []string{
+			"event: response.in_progress",
+			"data: " + inProgress,
+		}
+		for i := 0; i <= deferredFieldLineLimit; i++ {
+			lines = append(lines, "event: response.in_progress")
+		}
+
+		input := strings.Join(lines, "\n")
+		documentScanner := newOpenAISSEJSONDocumentScanner(newOpenAISSEScannerForTest(input, len(input)+1))
+		for documentScanner.Scan() {
+		}
+		require.ErrorIs(t, documentScanner.Err(), errOpenAIDeferredSSEFieldsLimit)
+	})
+
+	t.Run("byte count", func(t *testing.T) {
+		const deferredFieldByteLimit = 16 * 1024 * 1024
+		input := strings.Join([]string{
+			"event: response.in_progress",
+			"data: " + inProgress,
+			":" + strings.Repeat("x", deferredFieldByteLimit),
+		}, "\n")
+
+		documentScanner := newOpenAISSEJSONDocumentScanner(newOpenAISSEScannerForTest(input, len(input)+1))
+		for documentScanner.Scan() {
+		}
+		require.ErrorIs(t, documentScanner.Err(), errOpenAIDeferredSSEFieldsLimit)
+	})
+}
+
+func TestOpenAISSEScannerRepairsDataPrefixStuckAfterJSONDocument(t *testing.T) {
+	largeInProgress, outputItemAdded, completed := openAIConcatenatedJSONTestEvents(t)
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + largeInProgress + "data: " + outputItemAdded,
+		"",
+		"event: response.completed",
+		"data: " + completed,
+		"",
+	}, "\n")
+
+	assertOpenAISSEFrames(t, scanOpenAISSEJSONDocumentsForTest(t, input), []string{
+		"response.in_progress",
+		"response.output_item.added",
+		"response.completed",
+	})
+}
+
+func TestOpenAISSEScannerRepairsEventAndDataPrefixStuckAfterJSONDocument(t *testing.T) {
+	largeInProgress, outputItemAdded, completed := openAIConcatenatedJSONTestEvents(t)
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + largeInProgress + "event: response.output_item.addeddata: " + outputItemAdded,
+		"",
+		"event: response.completed",
+		"data: " + completed,
+		"",
+	}, "\n")
+
+	assertOpenAISSEFrames(t, scanOpenAISSEJSONDocumentsForTest(t, input), []string{
+		"response.in_progress",
+		"response.output_item.added",
+		"response.completed",
+	})
+}
+
+func TestOpenAISSEScannerSeparatesDoneMarkerAfterTypedDataLine(t *testing.T) {
+	largeInProgress, _, _ := openAIConcatenatedJSONTestEvents(t)
+	input := strings.Join([]string{
+		"event: response.in_progress",
+		"data: " + largeInProgress,
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	out := scanOpenAISSEJSONDocumentsForTest(t, input)
+	frames := strings.Split(strings.TrimSpace(out), "\n\n")
+	require.Len(t, frames, 2)
+	require.Contains(t, frames[0], largeInProgress)
+	require.Equal(t, "data: [DONE]", frames[1])
+}
+
+func TestOpenAISSEScannerSeparatesDoneMarkerStuckAfterTypedJSON(t *testing.T) {
+	largeInProgress, _, _ := openAIConcatenatedJSONTestEvents(t)
+	for _, suffix := range []string{"[DONE]", "data: [DONE]", "event: response.completeddata: [DONE]"} {
+		t.Run(suffix, func(t *testing.T) {
+			input := strings.Join([]string{
+				"event: response.in_progress",
+				"data: " + largeInProgress + suffix,
+				"",
+			}, "\n")
+
+			out := scanOpenAISSEJSONDocumentsForTest(t, input)
+			frames := strings.Split(strings.TrimSpace(out), "\n\n")
+			require.Len(t, frames, 2)
+			require.Contains(t, frames[0], largeInProgress)
+			require.Equal(t, "data: [DONE]", frames[1])
+		})
+	}
+}
+
 func TestOpenAIWSv2StreamingRepairsConcatenatedJSONDocumentsInSingleMessage(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -107,6 +336,40 @@ func TestSplitOpenAIConcatenatedJSONDocumentsRejectsPayloadOverRepairLimit(t *te
 	require.Equal(t, line, documentScanner.Text())
 	require.False(t, documentScanner.Scan())
 	require.NoError(t, documentScanner.Err())
+
+	t.Run("second typed data", func(t *testing.T) {
+		input := strings.Join([]string{
+			"event: response.in_progress",
+			"data: " + first,
+			"data: " + second,
+			"",
+		}, "\n")
+		assertOpenAISSEFrames(t, scanOpenAISSEJSONDocumentsForTest(t, input), []string{"response.in_progress", "response.completed"})
+	})
+
+	t.Run("missing blank before event", func(t *testing.T) {
+		input := strings.Join([]string{
+			"event: response.in_progress",
+			"data: " + first,
+			"event: response.completed",
+			"data: " + second,
+			"",
+		}, "\n")
+		assertOpenAISSEFrames(t, scanOpenAISSEJSONDocumentsForTest(t, input), []string{"response.in_progress", "response.completed"})
+	})
+
+	t.Run("done marker", func(t *testing.T) {
+		input := strings.Join([]string{
+			"event: response.in_progress",
+			"data: " + first,
+			"data: [DONE]",
+			"",
+		}, "\n")
+		frames := strings.Split(strings.TrimSpace(scanOpenAISSEJSONDocumentsForTest(t, input)), "\n\n")
+		require.Len(t, frames, 2)
+		require.Contains(t, frames[0], first)
+		require.Equal(t, "data: [DONE]", frames[1])
+	})
 }
 
 func TestOpenAIWSv2StreamingBreaksConnectionWhenTerminalHasTrailingDocument(t *testing.T) {
@@ -249,6 +512,24 @@ func assertOpenAISSEFrames(t *testing.T, body string, expectedTypes []string) {
 		eventTypes = append(eventTypes, event.Type)
 	}
 	require.Equal(t, expectedTypes, eventTypes)
+}
+
+func scanOpenAISSEJSONDocumentsForTest(t *testing.T, input string) string {
+	t.Helper()
+	scanner := newOpenAISSEScannerForTest(input, len(input)+1)
+	documentScanner := newOpenAISSEJSONDocumentScanner(scanner)
+	var lines []string
+	for documentScanner.Scan() {
+		lines = append(lines, documentScanner.Text())
+	}
+	require.NoError(t, documentScanner.Err())
+	return strings.Join(lines, "\n")
+}
+
+func newOpenAISSEScannerForTest(input string, maxTokenSize int) *bufio.Scanner {
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Buffer(make([]byte, 1024), maxTokenSize)
+	return scanner
 }
 
 func openAIConcatenatedJSONTestEvents(t *testing.T) (string, string, string) {

--- a/backend/internal/service/openai_sse_json_documents.go
+++ b/backend/internal/service/openai_sse_json_documents.go
@@ -4,14 +4,18 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
-	"io"
+	"errors"
 	"strings"
 )
 
 const (
 	maxOpenAIConcatenatedJSONDocuments = 16
 	maxOpenAIConcatenatedJSONBytes     = 16 * 1024 * 1024
+	maxOpenAIDeferredSSEFieldLines     = 256
+	maxOpenAIDeferredSSEFieldBytes     = maxOpenAIConcatenatedJSONBytes
 )
+
+var errOpenAIDeferredSSEFieldsLimit = errors.New("OpenAI deferred SSE field group exceeds repair limit")
 
 // splitOpenAIConcatenatedJSONDocuments recognizes the narrow corruption shape
 // produced when multiple complete Responses events arrive in one transport
@@ -22,39 +26,109 @@ func splitOpenAIConcatenatedJSONDocuments(payload []byte) ([][]byte, bool) {
 		return nil, false
 	}
 
-	decoder := json.NewDecoder(bytes.NewReader(payload))
 	documents := make([][]byte, 0, 2)
-	for {
-		var raw json.RawMessage
-		err := decoder.Decode(&raw)
-		if err != nil {
-			if err == io.EOF && len(documents) > 1 {
-				return documents, true
+	remaining := payload
+	for len(remaining) > 0 {
+		if len(documents) > 0 {
+			remaining = trimOpenAIEmbeddedSSEPrefix(remaining)
+			if len(remaining) == 0 {
+				return nil, false
 			}
+		}
+		decoder := json.NewDecoder(bytes.NewReader(remaining))
+		var raw json.RawMessage
+		if err := decoder.Decode(&raw); err != nil {
+			return nil, false
+		}
+		consumed := decoder.InputOffset()
+		if consumed <= 0 || consumed > int64(len(remaining)) {
 			return nil, false
 		}
 		raw = bytes.TrimSpace(raw)
-		var envelope struct {
-			Type string `json:"type"`
-		}
-		if err := json.Unmarshal(raw, &envelope); err != nil {
-			return nil, false
-		}
-		eventType := strings.TrimSpace(envelope.Type)
-		if eventType == "" || strings.ContainsAny(eventType, "\r\n") {
+		if _, ok := openAITypedEventJSON(raw); !ok {
 			return nil, false
 		}
 		if len(documents) == maxOpenAIConcatenatedJSONDocuments {
 			return nil, false
 		}
 		documents = append(documents, raw)
+		remaining = bytes.TrimSpace(remaining[consumed:])
 	}
+	if len(documents) > 1 {
+		return documents, true
+	}
+	return nil, false
+}
+
+func trimOpenAIEmbeddedSSEPrefix(payload []byte) []byte {
+	payload = bytes.TrimSpace(payload)
+	if bytes.HasPrefix(payload, []byte("data:")) {
+		return bytes.TrimLeft(payload[len("data:"):], " \t")
+	}
+	if !bytes.HasPrefix(payload, []byte("event:")) {
+		return payload
+	}
+	dataIndex := bytes.Index(payload[len("event:"):], []byte("data:"))
+	if dataIndex < 0 {
+		return payload
+	}
+	dataIndex += len("event:")
+	eventType := strings.TrimSpace(string(payload[len("event:"):dataIndex]))
+	if eventType == "" || strings.ContainsAny(eventType, "\r\n{}[]") {
+		return payload
+	}
+	return bytes.TrimLeft(payload[dataIndex+len("data:"):], " \t")
+}
+
+func openAITypedEventJSON(payload []byte) (string, bool) {
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err != nil {
+		return "", false
+	}
+	eventType := strings.TrimSpace(envelope.Type)
+	if eventType == "" || strings.ContainsAny(eventType, "\r\n") {
+		return "", false
+	}
+	return eventType, true
+}
+
+func splitOpenAITypedJSONAndDoneMarker(payload []byte) ([]byte, bool) {
+	payload = bytes.TrimSpace(payload)
+	if len(payload) == 0 || len(payload) > maxOpenAIConcatenatedJSONBytes || json.Valid(payload) {
+		return nil, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	var raw json.RawMessage
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, false
+	}
+	raw = bytes.TrimSpace(raw)
+	if _, ok := openAITypedEventJSON(raw); !ok {
+		return nil, false
+	}
+	consumed := decoder.InputOffset()
+	if consumed <= 0 || consumed > int64(len(payload)) {
+		return nil, false
+	}
+	tail := bytes.TrimSpace(trimOpenAIEmbeddedSSEPrefix(payload[consumed:]))
+	if !bytes.Equal(tail, []byte("[DONE]")) {
+		return nil, false
+	}
+	return raw, true
 }
 
 type openAISSEJSONDocumentScanner struct {
-	scanner *bufio.Scanner
-	pending []string
-	current string
+	scanner                   *bufio.Scanner
+	pending                   []string
+	current                   string
+	deferredFieldLines        []string
+	deferredFieldBytes        int
+	frameHasExplicitEvent     bool
+	frameHasCompleteTypedData bool
+	frameRepairDisabled       bool
+	err                       error
 }
 
 func newOpenAISSEJSONDocumentScanner(scanner *bufio.Scanner) *openAISSEJSONDocumentScanner {
@@ -67,39 +141,185 @@ func (s *openAISSEJSONDocumentScanner) Scan() bool {
 		s.pending = s.pending[1:]
 		return true
 	}
-	if s.scanner == nil || !s.scanner.Scan() {
+
+	for {
+		if s.scanner == nil || !s.scanner.Scan() {
+			if s.scanner != nil && s.scanner.Err() != nil {
+				return false
+			}
+			if len(s.deferredFieldLines) > 0 {
+				return s.emitDeferredFieldLines()
+			}
+			return false
+		}
+
+		line := s.scanner.Text()
+		if line == "" {
+			s.frameHasExplicitEvent = false
+			s.frameHasCompleteTypedData = false
+			s.frameRepairDisabled = false
+			if len(s.deferredFieldLines) > 0 {
+				return s.emitDeferredFieldLines(line)
+			}
+			s.current = line
+			return true
+		}
+		data, ok := extractOpenAISSEDataLine(line)
+		if !ok {
+			if s.frameHasCompleteTypedData || len(s.deferredFieldLines) > 0 {
+				if !s.deferSSEFieldLine(line) {
+					return false
+				}
+				continue
+			}
+			if _, isEvent := extractOpenAISSEEventLine(line); isEvent {
+				s.frameHasExplicitEvent = true
+			}
+			s.current = line
+			return true
+		}
+		if strings.TrimSpace(data) == "[DONE]" {
+			if !s.frameHasCompleteTypedData {
+				if len(s.deferredFieldLines) > 0 {
+					s.frameHasCompleteTypedData = false
+					s.frameRepairDisabled = true
+					return s.emitDeferredFieldLines(line)
+				}
+				s.current = line
+				return true
+			}
+			expanded := make([]string, 0, 2+len(s.deferredFieldLines))
+			expanded = append(expanded, "")
+			expanded = append(expanded, s.deferredFieldLines...)
+			expanded = append(expanded, line)
+			s.clearDeferredFieldLines()
+			s.frameHasExplicitEvent = false
+			s.frameHasCompleteTypedData = false
+			s.frameRepairDisabled = false
+			s.current = expanded[0]
+			s.pending = append(s.pending, expanded[1:]...)
+			return true
+		}
+
+		dataBytes := []byte(data)
+		if eventType, typed := openAITypedEventJSON(dataBytes); typed {
+			if s.frameRepairDisabled {
+				s.current = line
+				return true
+			}
+			if s.frameHasCompleteTypedData {
+				expanded := make([]string, 0, 3+len(s.deferredFieldLines))
+				expanded = append(expanded, "")
+				expanded = append(expanded, s.deferredFieldLines...)
+				if !s.deferredFieldsHaveEvent() {
+					expanded = append(expanded, "event: "+eventType)
+				}
+				expanded = append(expanded, "data: "+data)
+				s.clearDeferredFieldLines()
+				s.current = expanded[0]
+				s.pending = append(s.pending, expanded[1:]...)
+				s.frameHasExplicitEvent = true
+				s.frameHasCompleteTypedData = true
+				s.frameRepairDisabled = false
+				return true
+			}
+			s.frameHasCompleteTypedData = s.frameHasExplicitEvent
+			s.current = line
+			return true
+		}
+		if len(data) > maxOpenAIConcatenatedJSONBytes {
+			if len(s.deferredFieldLines) > 0 {
+				s.frameHasCompleteTypedData = false
+				s.frameRepairDisabled = true
+				return s.emitDeferredFieldLines(line)
+			}
+			s.current = line
+			return true
+		}
+		if document, repaired := splitOpenAITypedJSONAndDoneMarker(dataBytes); repaired {
+			eventType, _ := openAITypedEventJSON(document)
+			expanded := make([]string, 0, 6+len(s.deferredFieldLines))
+			if s.frameHasCompleteTypedData {
+				expanded = append(expanded, "")
+				expanded = append(expanded, s.deferredFieldLines...)
+				if !s.deferredFieldsHaveEvent() {
+					expanded = append(expanded, "event: "+eventType)
+				}
+			}
+			expanded = append(expanded, "data: "+string(document), "", "data: [DONE]")
+			s.clearDeferredFieldLines()
+			s.frameHasExplicitEvent = false
+			s.frameHasCompleteTypedData = false
+			s.frameRepairDisabled = false
+			s.current = expanded[0]
+			s.pending = expanded[1:]
+			return true
+		}
+		documents, repaired := splitOpenAIConcatenatedJSONDocuments(dataBytes)
+		if !repaired {
+			if len(s.deferredFieldLines) > 0 {
+				s.frameHasCompleteTypedData = false
+				s.frameRepairDisabled = true
+				return s.emitDeferredFieldLines(line)
+			}
+			s.current = line
+			return true
+		}
+
+		expanded := make([]string, 0, len(documents)*3+1+len(s.deferredFieldLines))
+		if s.frameHasCompleteTypedData {
+			expanded = append(expanded, "")
+			expanded = append(expanded, s.deferredFieldLines...)
+		}
+		for i, document := range documents {
+			eventType, _ := openAITypedEventJSON(document)
+			if i > 0 || (s.frameHasCompleteTypedData && !s.deferredFieldsHaveEvent()) {
+				expanded = append(expanded, "event: "+eventType)
+			}
+			expanded = append(expanded, "data: "+string(document), "")
+		}
+		s.clearDeferredFieldLines()
+		s.frameHasExplicitEvent = false
+		s.frameHasCompleteTypedData = false
+		s.frameRepairDisabled = false
+		s.current = expanded[0]
+		s.pending = expanded[1:]
+		return true
+	}
+}
+
+func (s *openAISSEJSONDocumentScanner) deferSSEFieldLine(line string) bool {
+	lineBytes := len(line) + 1
+	if len(s.deferredFieldLines) >= maxOpenAIDeferredSSEFieldLines || lineBytes > maxOpenAIDeferredSSEFieldBytes-s.deferredFieldBytes {
+		s.err = errOpenAIDeferredSSEFieldsLimit
 		return false
 	}
+	s.deferredFieldLines = append(s.deferredFieldLines, line)
+	s.deferredFieldBytes += lineBytes
+	return true
+}
 
-	line := s.scanner.Text()
-	data, ok := extractOpenAISSEDataLine(line)
-	if !ok {
-		s.current = line
-		return true
-	}
-	if len(data) > maxOpenAIConcatenatedJSONBytes {
-		s.current = line
-		return true
-	}
-	documents, repaired := splitOpenAIConcatenatedJSONDocuments([]byte(data))
-	if !repaired {
-		s.current = line
-		return true
-	}
-
-	expanded := make([]string, 0, len(documents)*3)
-	for i, document := range documents {
-		if i > 0 {
-			var envelope struct {
-				Type string `json:"type"`
-			}
-			_ = json.Unmarshal(document, &envelope)
-			expanded = append(expanded, "event: "+strings.TrimSpace(envelope.Type))
+func (s *openAISSEJSONDocumentScanner) deferredFieldsHaveEvent() bool {
+	for _, line := range s.deferredFieldLines {
+		if _, ok := extractOpenAISSEEventLine(line); ok {
+			return true
 		}
-		expanded = append(expanded, "data: "+string(document), "")
 	}
+	return false
+}
+
+func (s *openAISSEJSONDocumentScanner) clearDeferredFieldLines() {
+	s.deferredFieldLines = nil
+	s.deferredFieldBytes = 0
+}
+
+func (s *openAISSEJSONDocumentScanner) emitDeferredFieldLines(lines ...string) bool {
+	expanded := make([]string, 0, len(s.deferredFieldLines)+len(lines))
+	expanded = append(expanded, s.deferredFieldLines...)
+	expanded = append(expanded, lines...)
+	s.clearDeferredFieldLines()
 	s.current = expanded[0]
-	s.pending = expanded[1:]
+	s.pending = append(s.pending, expanded[1:]...)
 	return true
 }
 
@@ -108,6 +328,9 @@ func (s *openAISSEJSONDocumentScanner) Text() string {
 }
 
 func (s *openAISSEJSONDocumentScanner) Err() error {
+	if s.err != nil {
+		return s.err
+	}
 	if s.scanner == nil {
 		return nil
 	}


### PR DESCRIPTION
## Problem

Responses transports do not always preserve one logical event per physical SSE frame. In production we observed large `response.in_progress` payloads near 68 KiB arrive with another typed event, an SSE prefix, or `[DONE]` attached without the expected blank boundary. Official OpenAI SDKs parse each `data:` value as one JSON document, so the stream fails with `Unexpected non-whitespace character after JSON` before application code can recover.

PR #4296 repairs the narrow `{json1}{json2}` shape, but the scanner still forwards several equivalent boundary corruptions unchanged:

- multiple complete typed `data:` lines in one frame;
- a missing blank line before the next `event:`;
- `data:` or `event: ... data:` text attached after a complete JSON document;
- a typed JSON document immediately followed by `[DONE]`;
- the same frame-state transitions after a data line exceeds the 16 MiB repair limit.

## Root cause

The document scanner was line-local. After forwarding one complete typed payload, it did not retain enough frame state to recognize that a following typed line or event header belonged to a new logical event. Oversized valid typed payloads bypassed repair without updating that state at all.

## Fix

- Track the current typed event and whether its complete JSON payload has already been seen.
- Buffer ambiguous post-data SSE fields as one bounded group, and restore a missing boundary only when another typed payload or `[DONE]` proves that a new logical event started.
- Recognize bounded embedded SSE prefixes and `[DONE]` tails after a complete typed JSON document.
- Preserve legal `event:` overrides and exact blank-line / EOF behavior.
- Bound candidate field groups to 256 lines and 16 MiB; fail closed instead of allowing ambiguous unbounded buffering.
- Preserve the existing 16-document and 16 MiB concatenated-document repair bounds.
- Keep data-only open-event behavior compatible with the current first-output staging and flush logic.

This is a focused follow-up to #4296. It does not change downstream flush scheduling (#4275), first-output staging (#4307), or the configured scanner line limit (#4368).

## Tests

New regression coverage includes multiple typed data lines, missing blank boundaries, embedded `data:` / `event:` prefixes, JSON plus `[DONE]`, legal event-type overrides, event/id/comment field groups, EOF replay, field-group safety limits, and oversized typed events followed by another typed event or terminator.

Verification:

- `go test ./internal/service -count=1`
- `go vet ./internal/service`
- focused SSE boundary tests
- `git diff --check`
