### PR TITLE
[codex] preserve usage ranges in the user timezone

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1259,7 +1259,7 @@ func (h *GatewayHandler) Usage(c *gin.Context) {
 	}
 
 	// Best-effort: 获取用量统计（按当前 API Key 过滤），失败不影响基础响应
-	usageData := h.buildUsageData(ctx, apiKey.ID)
+	usageData := h.buildUsageData(ctx, apiKey.ID, apiKeyTodayStart(c, time.Now()))
 	dailyUsage := h.buildAPIKeyDailyUsage(c, subject.UserID, apiKey.ID, days)
 
 	// Best-effort: 获取模型统计
@@ -1283,29 +1283,38 @@ func (h *GatewayHandler) Usage(c *gin.Context) {
 
 // parseUsageDateRange 解析 start_date / end_date query params，默认返回近 30 天范围
 func (h *GatewayHandler) parseUsageDateRange(c *gin.Context) (time.Time, time.Time) {
-	now := timezone.Now()
+	userTZ := c.Query("timezone")
+	now := timezone.NowInUserLocation(userTZ)
 	endTime := now
 	startTime := now.AddDate(0, 0, -30)
 
 	if s := c.Query("start_date"); s != "" {
-		if t, err := timezone.ParseInLocation("2006-01-02", s); err == nil {
+		if t, err := timezone.ParseCivilDateStart(s, userTZ); err == nil {
 			startTime = t
 		}
 	}
 	if s := c.Query("end_date"); s != "" {
-		if t, err := timezone.ParseInLocation("2006-01-02", s); err == nil {
-			endTime = t.AddDate(0, 0, 1) // half-open range upper bound
+		if t, err := timezone.NextCivilDateStart(s, userTZ); err == nil {
+			endTime = t
 		}
 	}
 	return startTime, endTime
 }
 
 // buildUsageData 构建 today/total 用量摘要
-func (h *GatewayHandler) buildUsageData(ctx context.Context, apiKeyID int64) gin.H {
+func apiKeyTodayStart(c *gin.Context, now time.Time) time.Time {
+	start, err := timezone.StartOfCivilDate(now, c.Query("timezone"))
+	if err != nil {
+		return now
+	}
+	return start
+}
+
+func (h *GatewayHandler) buildUsageData(ctx context.Context, apiKeyID int64, todayStart time.Time) gin.H {
 	if h.usageService == nil {
 		return nil
 	}
-	dashStats, err := h.usageService.GetAPIKeyDashboardStats(ctx, apiKeyID)
+	dashStats, err := h.usageService.GetAPIKeyDashboardStats(ctx, apiKeyID, todayStart)
 	if err != nil || dashStats == nil {
 		return nil
 	}
@@ -1341,7 +1350,7 @@ func (h *GatewayHandler) buildAPIKeyDailyUsage(c *gin.Context, userID, apiKeyID 
 		return nil
 	}
 	startTime, endTime := apiKeyDailyUsageRange(days, c.Query("timezone"))
-	stats, err := h.usageService.GetAPIKeyDailyUsage(c.Request.Context(), userID, apiKeyID, startTime, endTime)
+	stats, err := h.usageService.GetAPIKeyDailyUsage(c.Request.Context(), userID, apiKeyID, startTime, endTime, startTime.Location().String())
 	if err != nil {
 		return nil
 	}

--- a/backend/internal/handler/gateway_handler_usage_test.go
+++ b/backend/internal/handler/gateway_handler_usage_test.go
@@ -8,11 +8,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/usagestats"
 	"github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
+
+type apiKeyTodayUsageRepo struct {
+	service.UsageLogRepository
+	todayStart time.Time
+}
+
+func (r *apiKeyTodayUsageRepo) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64, todayStart time.Time) (*usagestats.UserDashboardStats, error) {
+	r.todayStart = todayStart
+	return &usagestats.UserDashboardStats{}, nil
+}
 
 func TestUsageUnrestrictedIncludesWeeklyWindowStart(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -48,4 +59,49 @@ func TestUsageUnrestrictedIncludesWeeklyWindowStart(t *testing.T) {
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
 	require.NotNil(t, response.Subscription.WeeklyWindowStart)
 	require.True(t, weeklyWindowStart.Equal(*response.Subscription.WeeklyWindowStart))
+}
+
+func TestParseUsageDateRangeUsesRequestedTimezone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/usage?start_date=2026-03-08&end_date=2026-03-08&timezone=America%2FNew_York", nil)
+
+	location, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+
+	startTime, endTime := (&GatewayHandler{}).parseUsageDateRange(c)
+	require.Equal(t, time.Date(2026, time.March, 8, 0, 0, 0, 0, location), startTime)
+	require.Equal(t, time.Date(2026, time.March, 9, 0, 0, 0, 0, location), endTime)
+	require.Equal(t, 23*time.Hour, endTime.Sub(startTime))
+}
+
+func TestParseUsageDateRangeUsesFirstValidInstantAfterMidnightGap(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/usage?start_date=2026-09-06&end_date=2026-09-06&timezone=America%2FSantiago", nil)
+
+	startTime, endTime := (&GatewayHandler{}).parseUsageDateRange(c)
+	require.Equal(t, "2026-09-06 01:00 -03:00", startTime.Format("2006-01-02 15:04 -07:00"))
+	require.Equal(t, "2026-09-07 00:00 -03:00", endTime.Format("2006-01-02 15:04 -07:00"))
+}
+
+func TestAPIKeyTodayStartUsesRequestedTimezone(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/usage?timezone=America%2FSantiago", nil)
+
+	location, err := time.LoadLocation("America/Santiago")
+	require.NoError(t, err)
+	now := time.Date(2026, time.September, 6, 12, 30, 0, 0, location)
+
+	start := apiKeyTodayStart(c, now)
+	require.Equal(t, "2026-09-06 01:00 -03:00", start.Format("2006-01-02 15:04 -07:00"))
+
+	repo := &apiKeyTodayUsageRepo{}
+	handler := &GatewayHandler{usageService: service.NewUsageService(repo, nil, nil, nil)}
+	require.NotNil(t, handler.buildUsageData(context.Background(), 7, start))
+	require.Equal(t, start, repo.todayStart)
 }

--- a/backend/internal/handler/usage_handler.go
+++ b/backend/internal/handler/usage_handler.go
@@ -21,6 +21,7 @@ type userUsageFilters struct {
 	Filters   usagestats.UsageLogFilters
 	StartTime time.Time
 	EndTime   time.Time
+	Timezone  string
 }
 
 type userModelStat struct {
@@ -151,7 +152,7 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 	endDateStr := strings.TrimSpace(c.Query("end_date"))
 
 	if startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, err := timezone.ParseCivilDateStart(startDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
 			return nil, false
@@ -160,12 +161,12 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 		startPtr = &startTime
 	}
 	if endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, err := timezone.NextCivilDateStart(endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
 			return nil, false
 		}
-		endTime = t.AddDate(0, 0, 1)
+		endTime = t
 		endPtr = &endTime
 	}
 
@@ -209,6 +210,7 @@ func (h *UsageHandler) parseUserUsageFilters(c *gin.Context, requireRange bool) 
 		},
 		StartTime: derefTime(startPtr),
 		EndTime:   derefTime(endPtr),
+		Timezone:  derefTime(startPtr).Location().String(),
 	}, true
 }
 
@@ -277,7 +279,7 @@ func (h *UsageHandler) ListErrors(c *gin.Context) {
 	// Date range (half-open [start, end)), reuse usage-list semantics.
 	userTZ := c.Query("timezone")
 	if startDateStr := c.Query("start_date"); startDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", startDateStr, userTZ)
+		t, err := timezone.ParseCivilDateStart(startDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid start_date format, use YYYY-MM-DD")
 			return
@@ -285,12 +287,11 @@ func (h *UsageHandler) ListErrors(c *gin.Context) {
 		filter.StartTime = &t
 	}
 	if endDateStr := c.Query("end_date"); endDateStr != "" {
-		t, err := timezone.ParseInUserLocation("2006-01-02", endDateStr, userTZ)
+		t, err := timezone.NextCivilDateStart(endDateStr, userTZ)
 		if err != nil {
 			response.BadRequest(c, "Invalid end_date format, use YYYY-MM-DD")
 			return
 		}
-		t = t.AddDate(0, 0, 1)
 		filter.EndTime = &t
 	}
 
@@ -462,7 +463,7 @@ func (h *UsageHandler) DashboardTrend(c *gin.Context) {
 	}
 	granularity := c.DefaultQuery("granularity", "day")
 
-	trend, err := h.usageService.GetUsageTrendWithFilters(c.Request.Context(), parsed.StartTime, parsed.EndTime, granularity, parsed.Filters)
+	trend, err := h.usageService.GetUsageTrendWithFilters(c.Request.Context(), parsed.StartTime, parsed.EndTime, granularity, parsed.Timezone, parsed.Filters)
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
@@ -471,7 +472,7 @@ func (h *UsageHandler) DashboardTrend(c *gin.Context) {
 	response.Success(c, gin.H{
 		"trend":       trend,
 		"start_date":  parsed.StartTime.Format("2006-01-02"),
-		"end_date":    parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"end_date":    parsed.EndTime.Add(-time.Nanosecond).Format("2006-01-02"),
 		"granularity": granularity,
 	})
 }
@@ -499,7 +500,7 @@ func (h *UsageHandler) DashboardModels(c *gin.Context) {
 	response.Success(c, gin.H{
 		"models":     userModelStatsFromUsageStats(stats),
 		"start_date": parsed.StartTime.Format("2006-01-02"),
-		"end_date":   parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"end_date":   parsed.EndTime.Add(-time.Nanosecond).Format("2006-01-02"),
 	})
 }
 
@@ -531,12 +532,12 @@ func (h *UsageHandler) DashboardSnapshotV2(c *gin.Context) {
 	resp := gin.H{
 		"generated_at": time.Now().UTC().Format(time.RFC3339),
 		"start_date":   parsed.StartTime.Format("2006-01-02"),
-		"end_date":     parsed.EndTime.Add(-24 * time.Hour).Format("2006-01-02"),
+		"end_date":     parsed.EndTime.Add(-time.Nanosecond).Format("2006-01-02"),
 		"granularity":  granularity,
 	}
 
 	if includeTrend {
-		trend, err := h.usageService.GetUsageTrendWithFilters(c.Request.Context(), parsed.StartTime, parsed.EndTime, granularity, parsed.Filters)
+		trend, err := h.usageService.GetUsageTrendWithFilters(c.Request.Context(), parsed.StartTime, parsed.EndTime, granularity, parsed.Timezone, parsed.Filters)
 		if err != nil {
 			response.ErrorFrom(c, err)
 			return
@@ -698,7 +699,7 @@ func (h *UsageHandler) GetMyAPIKeyDailyUsage(c *gin.Context) {
 
 	userTZ := c.Query("timezone")
 	startTime, endTime := apiKeyDailyUsageRange(days, userTZ)
-	items, err := h.usageService.GetAPIKeyDailyUsage(c.Request.Context(), subject.UserID, apiKeyID, startTime, endTime)
+	items, err := h.usageService.GetAPIKeyDailyUsage(c.Request.Context(), subject.UserID, apiKeyID, startTime, endTime, startTime.Location().String())
 	if err != nil {
 		response.ErrorFrom(c, err)
 		return
@@ -708,6 +709,6 @@ func (h *UsageHandler) GetMyAPIKeyDailyUsage(c *gin.Context) {
 		"items":      items,
 		"days":       days,
 		"start_date": startTime.Format("2006-01-02"),
-		"end_date":   endTime.AddDate(0, 0, -1).Format("2006-01-02"),
+		"end_date":   endTime.Add(-time.Nanosecond).Format("2006-01-02"),
 	})
 }

--- a/backend/internal/handler/usage_handler_daily_test.go
+++ b/backend/internal/handler/usage_handler_daily_test.go
@@ -19,12 +19,29 @@ type dailyUsageRepoStub struct {
 	service.UsageLogRepository
 	trend []usagestats.TrendDataPoint
 
-	called      bool
-	startTime   time.Time
-	endTime     time.Time
-	granularity string
-	userID      int64
-	apiKeyID    int64
+	called       bool
+	startTime    time.Time
+	endTime      time.Time
+	granularity  string
+	userTimezone string
+	userID       int64
+	apiKeyID     int64
+}
+
+func (s *dailyUsageRepoStub) GetUsageTrendWithUsageFilters(
+	ctx context.Context,
+	startTime, endTime time.Time,
+	granularity, userTimezone string,
+	filters usagestats.UsageLogFilters,
+) ([]usagestats.TrendDataPoint, error) {
+	s.called = true
+	s.startTime = startTime
+	s.endTime = endTime
+	s.granularity = granularity
+	s.userTimezone = userTimezone
+	s.userID = filters.UserID
+	s.apiKeyID = filters.APIKeyID
+	return s.trend, nil
 }
 
 func (s *dailyUsageRepoStub) GetUsageTrendWithFilters(
@@ -166,13 +183,14 @@ func TestGetMyAPIKeyDailyUsageAggregatesByDayForOwnedKey(t *testing.T) {
 	}
 	router := newDailyUsageTestRouter(usageRepo, apiKeyRepo, 42)
 
-	req := httptest.NewRequest(http.MethodGet, "/user/api-keys/7/usage/daily?days=7", nil)
+	req := httptest.NewRequest(http.MethodGet, "/user/api-keys/7/usage/daily?days=7&timezone=America%2FNew_York", nil)
 	rec := httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.True(t, usageRepo.called)
 	require.Equal(t, "day", usageRepo.granularity)
+	require.Equal(t, "America/New_York", usageRepo.userTimezone)
 	require.Equal(t, int64(42), usageRepo.userID)
 	require.Equal(t, int64(7), usageRepo.apiKeyID)
 	require.True(t, usageRepo.startTime.Before(usageRepo.endTime))

--- a/backend/internal/handler/usage_handler_request_type_test.go
+++ b/backend/internal/handler/usage_handler_request_type_test.go
@@ -17,15 +17,18 @@ import (
 
 type userUsageRepoCapture struct {
 	service.UsageLogRepository
-	listParams   pagination.PaginationParams
-	listFilters  usagestats.UsageLogFilters
-	statsFilters usagestats.UsageLogFilters
-	trendFilters usagestats.UsageLogFilters
-	groupFilters usagestats.UsageLogFilters
-	listRows     []service.UsageLog
-	stats        *usagestats.UsageStats
-	modelStats   []usagestats.ModelStat
-	groupStats   []usagestats.GroupStat
+	listParams    pagination.PaginationParams
+	listFilters   usagestats.UsageLogFilters
+	statsFilters  usagestats.UsageLogFilters
+	trendFilters  usagestats.UsageLogFilters
+	trendTimezone string
+	trendStart    time.Time
+	trendEnd      time.Time
+	groupFilters  usagestats.UsageLogFilters
+	listRows      []service.UsageLog
+	stats         *usagestats.UsageStats
+	modelStats    []usagestats.ModelStat
+	groupStats    []usagestats.GroupStat
 }
 
 func (s *userUsageRepoCapture) ListWithFilters(ctx context.Context, params pagination.PaginationParams, filters usagestats.UsageLogFilters) ([]service.UsageLog, *pagination.PaginationResult, error) {
@@ -61,6 +64,14 @@ func (s *userUsageRepoCapture) GetUsageTrendWithFilters(ctx context.Context, sta
 	return []usagestats.TrendDataPoint{}, nil
 }
 
+func (s *userUsageRepoCapture) GetUsageTrendWithUsageFilters(ctx context.Context, startTime, endTime time.Time, granularity, userTimezone string, filters usagestats.UsageLogFilters) ([]usagestats.TrendDataPoint, error) {
+	s.trendTimezone = userTimezone
+	s.trendStart = startTime
+	s.trendEnd = endTime
+	s.trendFilters = filters
+	return []usagestats.TrendDataPoint{}, nil
+}
+
 func (s *userUsageRepoCapture) GetModelStatsWithFilters(ctx context.Context, startTime, endTime time.Time, userID, apiKeyID, accountID, groupID int64, requestType *int16, stream *bool, billingType *int8) ([]usagestats.ModelStat, error) {
 	return s.modelStats, nil
 }
@@ -89,6 +100,7 @@ func newUserUsageRequestTypeTestRouter(repo *userUsageRepoCapture) *gin.Engine {
 	})
 	router.GET("/usage", handler.List)
 	router.GET("/usage/stats", handler.Stats)
+	router.GET("/usage/dashboard/trend", handler.DashboardTrend)
 	router.GET("/usage/dashboard/models", handler.DashboardModels)
 	router.GET("/usage/dashboard/snapshot-v2", handler.DashboardSnapshotV2)
 	return router
@@ -297,6 +309,52 @@ func TestUserUsageDashboardModelsRejectsAdminModelSources(t *testing.T) {
 	router.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestUserUsageDashboardTrendUsesRequestedTimezoneAcrossDST(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/trend?start_date=2026-03-08&end_date=2026-03-08&timezone=America%2FNew_York", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "America/New_York", repo.trendTimezone)
+	require.Contains(t, rec.Body.String(), `"end_date":"2026-03-08"`)
+}
+
+func TestUserUsageDashboardTrendUsesMidnightGapBoundaries(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/usage/dashboard/trend?start_date=2026-09-06&end_date=2026-09-06&timezone=America%2FSantiago", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "America/Santiago", repo.trendTimezone)
+	require.Equal(t, "2026-09-06 01:00 -03:00", repo.trendStart.Format("2006-01-02 15:04 -07:00"))
+	require.Equal(t, "2026-09-07 00:00 -03:00", repo.trendEnd.Format("2006-01-02 15:04 -07:00"))
+	require.Contains(t, rec.Body.String(), `"end_date":"2026-09-06"`)
+}
+
+func TestUserUsageDashboardResponsesKeepInclusiveEndDateAcrossDST(t *testing.T) {
+	repo := &userUsageRepoCapture{}
+	router := newUserUsageRequestTypeTestRouter(repo)
+
+	paths := []string{
+		"/usage/dashboard/models?start_date=2026-03-08&end_date=2026-03-08&timezone=America%2FNew_York",
+		"/usage/dashboard/snapshot-v2?include_trend=false&include_model_stats=false&include_group_stats=false&start_date=2026-03-08&end_date=2026-03-08&timezone=America%2FNew_York",
+	}
+	for _, path := range paths {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		require.Equal(t, http.StatusOK, rec.Code, path)
+		require.Contains(t, rec.Body.String(), `"end_date":"2026-03-08"`, path)
+	}
 }
 
 func TestUserUsageSnapshotUsesScopedFilters(t *testing.T) {

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -9,6 +9,11 @@ import (
 	"time"
 )
 
+const (
+	civilDateLayout              = "2006-01-02"
+	maxSkippedCivilDateLookahead = 7
+)
+
 var (
 	// location is the global timezone location
 	location *time.Location
@@ -140,6 +145,98 @@ func ParseInUserLocation(layout, value, userTZ string) (time.Time, error) {
 	return time.ParseInLocation(layout, value, loc)
 }
 
+// ParseCivilDateStart returns the first real instant belonging to the requested
+// civil date. It rejects dates that do not exist in the selected timezone.
+func ParseCivilDateStart(value, userTZ string) (time.Time, error) {
+	civilDate, err := time.Parse(civilDateLayout, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	loc := userLocation(userTZ)
+	if start, ok := firstValidCivilDateInstant(civilDate.Year(), civilDate.Month(), civilDate.Day(), loc); ok {
+		return start, nil
+	}
+	return time.Time{}, fmt.Errorf("civil date %s does not exist in timezone %s", value, loc)
+}
+
+// NextCivilDateStart returns the first real instant after the requested civil
+// date. Entirely skipped dates are crossed without normalizing into a prior day.
+func NextCivilDateStart(value, userTZ string) (time.Time, error) {
+	civilDate, err := time.Parse(civilDateLayout, value)
+	if err != nil {
+		return time.Time{}, err
+	}
+	loc := userLocation(userTZ)
+	for offset := 1; offset <= maxSkippedCivilDateLookahead; offset++ {
+		next := civilDate.AddDate(0, 0, offset)
+		if start, ok := firstValidCivilDateInstant(next.Year(), next.Month(), next.Day(), loc); ok {
+			return start, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("no valid civil date found after %s in timezone %s", value, loc)
+}
+
+// StartOfCivilDate returns the first real instant of t's civil date in userTZ.
+func StartOfCivilDate(t time.Time, userTZ string) (time.Time, error) {
+	loc := userLocation(userTZ)
+	local := t.In(loc)
+	if start, ok := firstValidCivilDateInstant(local.Year(), local.Month(), local.Day(), loc); ok {
+		return start, nil
+	}
+	return time.Time{}, fmt.Errorf("civil date %s does not exist in timezone %s", local.Format(civilDateLayout), loc)
+}
+
+func userLocation(userTZ string) *time.Location {
+	if userTZ != "" {
+		if loc, err := time.LoadLocation(userTZ); err == nil {
+			return loc
+		}
+	}
+	return Location()
+}
+
+func firstValidCivilDateInstant(year int, month time.Month, day int, loc *time.Location) (time.Time, bool) {
+	target := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	searchStart := target.Add(-36 * time.Hour)
+	searchEnd := target.Add(60 * time.Hour)
+	previous := searchStart
+
+	for probe := searchStart; !probe.After(searchEnd); probe = probe.Add(time.Minute) {
+		local := probe.In(loc)
+		if local.Year() != year || local.Month() != month || local.Day() != day {
+			previous = probe
+			continue
+		}
+
+		low, high := previous.Unix(), probe.Unix()
+		for low+1 < high {
+			mid := low + (high-low)/2
+			candidate := time.Unix(mid, 0).In(loc)
+			if civilDateBefore(candidate, year, month, day) {
+				low = mid
+			} else {
+				high = mid
+			}
+		}
+		start := time.Unix(high, 0).In(loc)
+		if start.Year() == year && start.Month() == month && start.Day() == day {
+			return start, true
+		}
+		return time.Time{}, false
+	}
+	return time.Time{}, false
+}
+
+func civilDateBefore(t time.Time, year int, month time.Month, day int) bool {
+	if t.Year() != year {
+		return t.Year() < year
+	}
+	if t.Month() != month {
+		return t.Month() < month
+	}
+	return t.Day() < day
+}
+
 // NowInUserLocation returns the current time in the user's timezone.
 // If userTZ is empty or invalid, falls back to the configured server timezone.
 func NowInUserLocation(userTZ string) time.Time {
@@ -155,12 +252,10 @@ func NowInUserLocation(userTZ string) time.Time {
 // StartOfDayInUserLocation returns the start of the given day in the user's timezone.
 // If userTZ is empty or invalid, falls back to the configured server timezone.
 func StartOfDayInUserLocation(t time.Time, userTZ string) time.Time {
-	loc := Location()
-	if userTZ != "" {
-		if userLoc, err := time.LoadLocation(userTZ); err == nil {
-			loc = userLoc
-		}
+	if start, err := StartOfCivilDate(t, userTZ); err == nil {
+		return start
 	}
+	loc := userLocation(userTZ)
 	t = t.In(loc)
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
 }

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -136,6 +136,42 @@ func TestDSTAwareness(t *testing.T) {
 	_ = StartOfDay(Now())
 }
 
+func TestParseCivilDateStartUsesFirstValidInstantAfterMidnightGap(t *testing.T) {
+	start, err := ParseCivilDateStart("2026-09-06", "America/Santiago")
+	if err != nil {
+		t.Fatalf("ParseCivilDateStart: %v", err)
+	}
+
+	if got := start.Format("2006-01-02 15:04 -07:00"); got != "2026-09-06 01:00 -03:00" {
+		t.Fatalf("unexpected civil date start: %s", got)
+	}
+}
+
+func TestNextCivilDateStartUsesFirstValidInstantAfterMidnightGap(t *testing.T) {
+	start, err := NextCivilDateStart("2026-09-05", "America/Santiago")
+	if err != nil {
+		t.Fatalf("NextCivilDateStart: %v", err)
+	}
+
+	if got := start.Format("2006-01-02 15:04 -07:00"); got != "2026-09-06 01:00 -03:00" {
+		t.Fatalf("unexpected next civil date start: %s", got)
+	}
+}
+
+func TestCivilDateHelpersHandleSkippedDates(t *testing.T) {
+	if _, err := ParseCivilDateStart("2011-12-30", "Pacific/Apia"); err == nil {
+		t.Fatal("expected a skipped civil date to be rejected")
+	}
+
+	start, err := NextCivilDateStart("2011-12-29", "Pacific/Apia")
+	if err != nil {
+		t.Fatalf("NextCivilDateStart: %v", err)
+	}
+	if got := start.Format("2006-01-02 15:04 -07:00"); got != "2011-12-31 00:00 +14:00" {
+		t.Fatalf("unexpected first instant after skipped date: %s", got)
+	}
+}
+
 func TestStartOfWeek_Boundaries(t *testing.T) {
 	if err := Init("Asia/Shanghai"); err != nil {
 		t.Fatalf("Init: %v", err)

--- a/backend/internal/repository/usage_log_repo_dashboard.go
+++ b/backend/internal/repository/usage_log_repo_dashboard.go
@@ -546,9 +546,8 @@ func (r *usageLogRepository) getPerformanceStatsByAPIKey(ctx context.Context, ap
 }
 
 // GetAPIKeyDashboardStats 获取指定 API Key 的仪表盘统计（按 api_key_id 过滤）
-func (r *usageLogRepository) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*UserDashboardStats, error) {
+func (r *usageLogRepository) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64, today time.Time) (*UserDashboardStats, error) {
 	stats := &UserDashboardStats{}
-	today := timezone.Today()
 
 	// API Key 维度不需要统计 key 数量，设为 1
 	stats.TotalAPIKeys = 1

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -411,18 +411,20 @@ func TestUsageLogRepositoryGetUsageTrendWithUsageFiltersRequestedModelSource(t *
 	db, mock := newSQLMock(t)
 	repo := &usageLogRepository{sql: db}
 
-	start := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	end := start.Add(24 * time.Hour)
+	location, err := time.LoadLocation("America/New_York")
+	require.NoError(t, err)
+	start := time.Date(2026, 3, 8, 0, 0, 0, 0, location)
+	end := start.AddDate(0, 0, 1)
 	filters := usagestats.UsageLogFilters{
 		Model:             "gpt-5",
 		ModelFilterSource: usagestats.ModelSourceRequested,
 	}
 
-	mock.ExpectQuery("AND COALESCE\\(NULLIF\\(TRIM\\(requested_model\\), ''\\), model\\) = \\$3").
-		WithArgs(start, end, "gpt-5").
+	mock.ExpectQuery("(?s)TO_CHAR\\(created_at AT TIME ZONE \\$3, 'YYYY-MM-DD'\\).+AND COALESCE\\(NULLIF\\(TRIM\\(requested_model\\), ''\\), model\\) = \\$4").
+		WithArgs(start, end, "America/New_York", "gpt-5").
 		WillReturnRows(sqlmock.NewRows([]string{"date", "requests", "input_tokens", "output_tokens", "cache_creation_tokens", "cache_read_tokens", "total_tokens", "cost", "actual_cost"}))
 
-	trend, err := repo.GetUsageTrendWithUsageFilters(context.Background(), start, end, "day", filters)
+	trend, err := repo.GetUsageTrendWithUsageFilters(context.Background(), start, end, "day", "America/New_York", filters)
 	require.NoError(t, err)
 	require.Empty(t, trend)
 	require.NoError(t, mock.ExpectationsWereMet())

--- a/backend/internal/repository/usage_log_repo_trend.go
+++ b/backend/internal/repository/usage_log_repo_trend.go
@@ -267,14 +267,14 @@ func (r *usageLogRepository) GetUserModelStats(ctx context.Context, userID int64
 
 // GetUsageTrendWithFilters returns usage trend data with optional filters
 func (r *usageLogRepository) GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, requestType *int16, stream *bool, billingType *int8) (results []TrendDataPoint, err error) {
-	return r.getUsageTrendWithFilters(ctx, startTime, endTime, granularity, userID, apiKeyID, accountID, groupID, model, "", requestType, stream, billingType, "")
+	return r.getUsageTrendWithFilters(ctx, startTime, endTime, granularity, userID, apiKeyID, accountID, groupID, model, "", requestType, stream, billingType, "", "")
 }
 
-func (r *usageLogRepository) GetUsageTrendWithUsageFilters(ctx context.Context, startTime, endTime time.Time, granularity string, filters UsageLogFilters) (results []TrendDataPoint, err error) {
-	return r.getUsageTrendWithFilters(ctx, startTime, endTime, granularity, filters.UserID, filters.APIKeyID, filters.AccountID, filters.GroupID, filters.Model, filters.ModelFilterSource, filters.RequestType, filters.Stream, filters.BillingType, filters.BillingMode)
+func (r *usageLogRepository) GetUsageTrendWithUsageFilters(ctx context.Context, startTime, endTime time.Time, granularity, userTimezone string, filters UsageLogFilters) (results []TrendDataPoint, err error) {
+	return r.getUsageTrendWithFilters(ctx, startTime, endTime, granularity, filters.UserID, filters.APIKeyID, filters.AccountID, filters.GroupID, filters.Model, filters.ModelFilterSource, filters.RequestType, filters.Stream, filters.BillingType, filters.BillingMode, userTimezone)
 }
 
-func (r *usageLogRepository) getUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, modelSource string, requestType *int16, stream *bool, billingType *int8, billingMode string) (results []TrendDataPoint, err error) {
+func (r *usageLogRepository) getUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, userID, apiKeyID, accountID, groupID int64, model string, modelSource string, requestType *int16, stream *bool, billingType *int8, billingMode, userTimezone string) (results []TrendDataPoint, err error) {
 	if shouldUsePreaggregatedTrend(granularity, userID, apiKeyID, accountID, groupID, model, requestType, stream, billingType, billingMode) {
 		aggregated, aggregatedErr := r.getUsageTrendFromAggregates(ctx, startTime, endTime, granularity)
 		if aggregatedErr == nil && len(aggregated) > 0 {
@@ -283,10 +283,16 @@ func (r *usageLogRepository) getUsageTrendWithFilters(ctx context.Context, start
 	}
 
 	dateFormat := safeDateFormat(granularity)
+	dateExpression := "created_at"
+	args := []any{startTime, endTime}
+	if userTimezone != "" {
+		args = append(args, userTimezone)
+		dateExpression = fmt.Sprintf("created_at AT TIME ZONE $%d", len(args))
+	}
 
 	query := fmt.Sprintf(`
 		SELECT
-			TO_CHAR(created_at, '%s') as date,
+			TO_CHAR(%s, '%s') as date,
 			COUNT(*) as requests,
 			COALESCE(SUM(input_tokens), 0) as input_tokens,
 			COALESCE(SUM(output_tokens), 0) as output_tokens,
@@ -297,9 +303,8 @@ func (r *usageLogRepository) getUsageTrendWithFilters(ctx context.Context, start
 			COALESCE(SUM(actual_cost), 0) as actual_cost
 		FROM usage_logs
 		WHERE created_at >= $1 AND created_at < $2
-	`, dateFormat)
+	`, dateExpression, dateFormat)
 
-	args := []any{startTime, endTime}
 	if userID > 0 {
 		query += fmt.Sprintf(" AND user_id = $%d", len(args)+1)
 		args = append(args, userID)

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -2579,7 +2579,7 @@ func (r *stubUsageLogRepo) GetUserDashboardStats(ctx context.Context, userID int
 	return nil, errors.New("not implemented")
 }
 
-func (r *stubUsageLogRepo) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*usagestats.UserDashboardStats, error) {
+func (r *stubUsageLogRepo) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64, todayStart time.Time) (*usagestats.UserDashboardStats, error) {
 	return nil, errors.New("not implemented")
 }
 

--- a/backend/internal/service/account_usage_service.go
+++ b/backend/internal/service/account_usage_service.go
@@ -60,7 +60,7 @@ type UsageLogRepository interface {
 
 	// User dashboard stats
 	GetUserDashboardStats(ctx context.Context, userID int64) (*usagestats.UserDashboardStats, error)
-	GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*usagestats.UserDashboardStats, error)
+	GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64, todayStart time.Time) (*usagestats.UserDashboardStats, error)
 	GetUserUsageTrendByUserID(ctx context.Context, userID int64, startTime, endTime time.Time, granularity string) ([]usagestats.TrendDataPoint, error)
 	GetUserModelStats(ctx context.Context, userID int64, startTime, endTime time.Time) ([]usagestats.ModelStat, error)
 

--- a/backend/internal/service/usage_service.go
+++ b/backend/internal/service/usage_service.go
@@ -299,8 +299,8 @@ func (s *UsageService) GetUserDashboardStats(ctx context.Context, userID int64) 
 }
 
 // GetAPIKeyDashboardStats returns dashboard summary stats filtered by API Key.
-func (s *UsageService) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64) (*usagestats.UserDashboardStats, error) {
-	stats, err := s.usageRepo.GetAPIKeyDashboardStats(ctx, apiKeyID)
+func (s *UsageService) GetAPIKeyDashboardStats(ctx context.Context, apiKeyID int64, todayStart time.Time) (*usagestats.UserDashboardStats, error) {
+	stats, err := s.usageRepo.GetAPIKeyDashboardStats(ctx, apiKeyID, todayStart)
 	if err != nil {
 		return nil, fmt.Errorf("get api key dashboard stats: %w", err)
 	}
@@ -317,12 +317,12 @@ func (s *UsageService) GetUserUsageTrendByUserID(ctx context.Context, userID int
 }
 
 // GetUsageTrendWithFilters returns trend data using the shared usage filter shape.
-func (s *UsageService) GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity string, filters usagestats.UsageLogFilters) ([]usagestats.TrendDataPoint, error) {
+func (s *UsageService) GetUsageTrendWithFilters(ctx context.Context, startTime, endTime time.Time, granularity, userTimezone string, filters usagestats.UsageLogFilters) ([]usagestats.TrendDataPoint, error) {
 	type usageTrendWithFiltersRepo interface {
-		GetUsageTrendWithUsageFilters(ctx context.Context, startTime, endTime time.Time, granularity string, filters usagestats.UsageLogFilters) ([]usagestats.TrendDataPoint, error)
+		GetUsageTrendWithUsageFilters(ctx context.Context, startTime, endTime time.Time, granularity, userTimezone string, filters usagestats.UsageLogFilters) ([]usagestats.TrendDataPoint, error)
 	}
 	if filterRepo, ok := s.usageRepo.(usageTrendWithFiltersRepo); ok {
-		trend, err := filterRepo.GetUsageTrendWithUsageFilters(ctx, startTime, endTime, granularity, filters)
+		trend, err := filterRepo.GetUsageTrendWithUsageFilters(ctx, startTime, endTime, granularity, userTimezone, filters)
 		if err != nil {
 			return nil, fmt.Errorf("get usage trend with filters: %w", err)
 		}
@@ -403,8 +403,11 @@ func (s *UsageService) GetAPIKeyModelStats(ctx context.Context, apiKeyID int64, 
 }
 
 // GetAPIKeyDailyUsage returns daily usage stats for a user's API key.
-func (s *UsageService) GetAPIKeyDailyUsage(ctx context.Context, userID, apiKeyID int64, startTime, endTime time.Time) ([]usagestats.APIKeyDailyUsagePoint, error) {
-	trend, err := s.usageRepo.GetUsageTrendWithFilters(ctx, startTime, endTime, "day", userID, apiKeyID, 0, 0, "", nil, nil, nil)
+func (s *UsageService) GetAPIKeyDailyUsage(ctx context.Context, userID, apiKeyID int64, startTime, endTime time.Time, userTimezone string) ([]usagestats.APIKeyDailyUsagePoint, error) {
+	trend, err := s.GetUsageTrendWithFilters(ctx, startTime, endTime, "day", userTimezone, usagestats.UsageLogFilters{
+		UserID:   userID,
+		APIKeyID: apiKeyID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("get api key daily usage: %w", err)
 	}

--- a/frontend/src/api/__tests__/client.spec.ts
+++ b/frontend/src/api/__tests__/client.spec.ts
@@ -90,6 +90,22 @@ describe('API Client', () => {
       expect(config.params).toHaveProperty('timezone')
     })
 
+    it('GET 请求保留调用方明确指定的 timezone 参数', async () => {
+      const adapter = vi.fn().mockResolvedValue({
+        status: 200,
+        data: { code: 0, data: {} },
+        headers: {},
+        config: {},
+        statusText: 'OK',
+      })
+      apiClient.defaults.adapter = adapter
+
+      await apiClient.get('/test', { params: { timezone: 'America/New_York' } })
+
+      const config = adapter.mock.calls[0][0]
+      expect(config.params.timezone).toBe('America/New_York')
+    })
+
     it('POST 请求不附加 timezone 参数', async () => {
       const adapter = vi.fn().mockResolvedValue({
         status: 200,

--- a/frontend/src/api/__tests__/usage.spec.ts
+++ b/frontend/src/api/__tests__/usage.spec.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }))
+
+vi.mock('../client', () => ({ apiClient: { get } }))
+
+import { getByDateRange } from '../usage'
+
+describe('usage API date ranges', () => {
+  beforeEach(() => {
+    get.mockReset().mockResolvedValue({ data: { items: [] } })
+  })
+
+  it('includes the caller IANA timezone in recent usage requests', async () => {
+    await getByDateRange('2026-03-03', '2026-03-09', undefined, 'America/New_York')
+
+    expect(get).toHaveBeenCalledWith('/usage', {
+      params: {
+        start_date: '2026-03-03',
+        end_date: '2026-03-09',
+        page: 1,
+        page_size: 100,
+        timezone: 'America/New_York',
+      },
+    })
+  })
+})

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -77,7 +77,9 @@ apiClient.interceptors.request.use(
       if (!config.params) {
         config.params = {}
       }
-      config.params.timezone = getUserTimezone()
+      if (!config.params.timezone) {
+        config.params.timezone = getUserTimezone()
+      }
     }
 
     if (config.headers) {

--- a/frontend/src/api/usage.ts
+++ b/frontend/src/api/usage.ts
@@ -216,12 +216,14 @@ export async function getStatsByDateRange(
  * @param startDate - Start date (YYYY-MM-DD format)
  * @param endDate - End date (YYYY-MM-DD format)
  * @param apiKeyId - Optional API key ID filter
+ * @param timezone - Optional IANA timezone for parsing local dates
  * @returns Usage logs within date range
  */
 export async function getByDateRange(
   startDate: string,
   endDate: string,
-  apiKeyId?: number
+  apiKeyId?: number,
+  timezone?: string
 ): Promise<PaginatedResponse<UsageLog>> {
   const params: UsageQueryParams = {
     start_date: startDate,
@@ -232,6 +234,10 @@ export async function getByDateRange(
 
   if (apiKeyId !== undefined) {
     params.api_key_id = apiKeyId
+  }
+
+  if (timezone) {
+    params.timezone = timezone
   }
 
   const { data } = await apiClient.get<PaginatedResponse<UsageLog>>('/usage', {

--- a/frontend/src/utils/__tests__/formatDateLocalInput.spec.ts
+++ b/frontend/src/utils/__tests__/formatDateLocalInput.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { formatDateLocalInput } from '../format'
+import { addLocalCalendarDays, formatDateLocalInput } from '../format'
 
 describe('formatDateLocalInput', () => {
   it('formats the calendar date in local time', () => {
@@ -14,5 +14,24 @@ describe('formatDateLocalInput', () => {
 
   it('returns an empty string for an invalid date', () => {
     expect(formatDateLocalInput(new Date('invalid'))).toBe('')
+  })
+
+  it('moves by local calendar days across daylight saving time', () => {
+    const originalTimezone = process.env.TZ
+    process.env.TZ = 'America/New_York'
+    try {
+      const end = new Date(2026, 2, 9, 0, 30)
+      const start = addLocalCalendarDays(end, -6)
+
+      expect(formatDateLocalInput(start)).toBe('2026-03-03')
+      expect(start.getHours()).toBe(0)
+      expect(start.getMinutes()).toBe(30)
+    } finally {
+      if (originalTimezone === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTimezone
+      }
+    }
   })
 })

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -160,6 +160,13 @@ export function formatDateLocalInput(date: Date): string {
   return `${year}-${month}-${day}`
 }
 
+/** Move by local calendar days without drifting across daylight saving changes. */
+export function addLocalCalendarDays(date: Date, days: number): Date {
+  const result = new Date(date)
+  result.setDate(result.getDate() + days)
+  return result
+}
+
 /**
  * 格式化为 datetime-local 控件值（YYYY-MM-DDTHH:mm，使用本地时间）
  */

--- a/frontend/src/views/KeyUsageView.vue
+++ b/frontend/src/views/KeyUsageView.vue
@@ -423,7 +423,7 @@ import { useAppStore } from '@/stores'
 import LocaleSwitcher from '@/components/common/LocaleSwitcher.vue'
 import Icon from '@/components/icons/Icon.vue'
 import { buildGatewayUrl } from '@/api/client'
-import { formatDateLocalInput } from '@/utils/format'
+import { addLocalCalendarDays, formatDateLocalInput } from '@/utils/format'
 import { sanitizeUrl } from '@/utils/url'
 
 const { t, locale } = useI18n()
@@ -503,9 +503,9 @@ function getDateParams(): string {
     let start: string
     switch (currentRange.value) {
       case 'today': start = end; break
-      case '7d': start = formatDateLocalInput(new Date(now.getTime() - 7 * 86400000)); break
-      case '30d': start = formatDateLocalInput(new Date(now.getTime() - 30 * 86400000)); break
-      default: start = formatDateLocalInput(new Date(now.getTime() - 30 * 86400000))
+      case '7d': start = formatDateLocalInput(addLocalCalendarDays(now, -6)); break
+      case '30d': start = formatDateLocalInput(addLocalCalendarDays(now, -29)); break
+      default: start = formatDateLocalInput(addLocalCalendarDays(now, -29))
     }
     params.set('start_date', start)
     params.set('end_date', end)

--- a/frontend/src/views/__tests__/KeyUsageView.spec.ts
+++ b/frontend/src/views/__tests__/KeyUsageView.spec.ts
@@ -231,4 +231,55 @@ describe('KeyUsageView daily detail', () => {
 
     wrapper.unmount()
   })
+
+  it('moves preset ranges by local calendar days across daylight saving time', async () => {
+    const originalTimezone = process.env.TZ
+    process.env.TZ = 'America/New_York'
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 2, 9, 0, 30))
+
+    try {
+      const wrapper = mount(KeyUsageView, {
+        global: {
+          stubs: {
+            RouterLink: { template: '<a><slot /></a>' },
+            LocaleSwitcher: true,
+            Icon: true,
+          },
+        },
+      })
+
+      await wrapper.find('input').setValue('sk-test-key')
+      await wrapper.find('input').trigger('keydown.enter')
+      await flushPromises()
+      vi.mocked(fetch).mockClear()
+
+      const sevenDayButton = wrapper.findAll('button').find((button) => button.text() === '7 Days')
+      expect(sevenDayButton).toBeDefined()
+      await sevenDayButton!.trigger('click')
+      await flushPromises()
+
+      let requestUrl = String(vi.mocked(fetch).mock.calls[0][0])
+      expect(requestUrl).toContain('start_date=2026-03-03')
+      expect(requestUrl).toContain('end_date=2026-03-09')
+
+      vi.mocked(fetch).mockClear()
+      const thirtyDayButton = wrapper.findAll('button').find((button) => button.text() === '30 Days')
+      expect(thirtyDayButton).toBeDefined()
+      await thirtyDayButton!.trigger('click')
+      await flushPromises()
+
+      requestUrl = String(vi.mocked(fetch).mock.calls[0][0])
+      expect(requestUrl).toContain('start_date=2026-02-08')
+      expect(requestUrl).toContain('end_date=2026-03-09')
+
+      wrapper.unmount()
+    } finally {
+      if (originalTimezone === undefined) {
+        delete process.env.TZ
+      } else {
+        process.env.TZ = originalTimezone
+      }
+    }
+  })
 })

--- a/frontend/src/views/user/DashboardView.vue
+++ b/frontend/src/views/user/DashboardView.vue
@@ -21,18 +21,20 @@ import UserDashboardStats from '@/components/user/dashboard/UserDashboardStats.v
 import UserDashboardRecentUsage from '@/components/user/dashboard/UserDashboardRecentUsage.vue'; import UserDashboardQuickActions from '@/components/user/dashboard/UserDashboardQuickActions.vue'
 import type { UsageLog, TrendDataPoint, ModelStat, PlatformQuotaItem } from '@/types'
 import { getMyPlatformQuotas } from '@/api/user'
-import { formatDateLocalInput } from '@/utils/format'
+import { addLocalCalendarDays, formatDateLocalInput } from '@/utils/format'
 
 const authStore = useAuthStore(); const user = computed(() => authStore.user)
 const stats = ref<UserStatsType | null>(null); const loading = ref(false); const loadingUsage = ref(false); const loadingCharts = ref(false)
 const trendData = ref<TrendDataPoint[]>([]); const modelStats = ref<ModelStat[]>([]); const recentUsage = ref<UsageLog[]>([])
 const platformQuotas = ref<PlatformQuotaItem[] | null>(null)
 
-const startDate = ref(formatDateLocalInput(new Date(Date.now() - 6 * 86400000))); const endDate = ref(formatDateLocalInput(new Date())); const granularity = ref('day')
+const getBrowserTimezone = () => { try { return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC' } catch { return 'UTC' } }
+const now = new Date(); const userTimezone = getBrowserTimezone()
+const startDate = ref(formatDateLocalInput(addLocalCalendarDays(now, -6))); const endDate = ref(formatDateLocalInput(now)); const granularity = ref('day')
 
 const loadStats = async () => { loading.value = true; try { await authStore.refreshUser(); stats.value = await usageAPI.getDashboardStats() } catch (error) { console.error('Failed to load dashboard stats:', error) } finally { loading.value = false } }
-const loadCharts = async () => { loadingCharts.value = true; try { const res = await Promise.all([usageAPI.getDashboardTrend({ start_date: startDate.value, end_date: endDate.value, granularity: granularity.value as any }), usageAPI.getDashboardModels({ start_date: startDate.value, end_date: endDate.value })]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
-const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.getByDateRange(startDate.value, endDate.value); recentUsage.value = res.items.slice(0, 5) } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
+const loadCharts = async () => { loadingCharts.value = true; try { const res = await Promise.all([usageAPI.getDashboardTrend({ start_date: startDate.value, end_date: endDate.value, granularity: granularity.value as any, timezone: userTimezone }), usageAPI.getDashboardModels({ start_date: startDate.value, end_date: endDate.value, timezone: userTimezone })]); trendData.value = res[0].trend || []; modelStats.value = res[1].models || [] } catch (error) { console.error('Failed to load charts:', error) } finally { loadingCharts.value = false } }
+const loadRecent = async () => { loadingUsage.value = true; try { const res = await usageAPI.getByDateRange(startDate.value, endDate.value, undefined, userTimezone); recentUsage.value = res.items.slice(0, 5) } catch (error) { console.error('Failed to load recent usage:', error) } finally { loadingUsage.value = false } }
 const loadPlatformQuotas = async () => { try { const data = await getMyPlatformQuotas(); platformQuotas.value = data.platform_quotas ?? [] } catch (error) { console.warn('Failed to load platform quotas:', error); platformQuotas.value = [] } }
 const refreshAll = () => { loadStats(); loadCharts(); loadRecent(); loadPlatformQuotas() }
 

--- a/frontend/src/views/user/__tests__/DashboardView.spec.ts
+++ b/frontend/src/views/user/__tests__/DashboardView.spec.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+const {
+  refreshUser,
+  getDashboardStats,
+  getDashboardTrend,
+  getDashboardModels,
+  getByDateRange,
+  getMyPlatformQuotas,
+} = vi.hoisted(() => ({
+  refreshUser: vi.fn(),
+  getDashboardStats: vi.fn(),
+  getDashboardTrend: vi.fn(),
+  getDashboardModels: vi.fn(),
+  getByDateRange: vi.fn(),
+  getMyPlatformQuotas: vi.fn(),
+}))
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => ({
+    user: { balance: 0 },
+    isSimpleMode: false,
+    refreshUser,
+  }),
+}))
+
+vi.mock('@/api/usage', () => ({
+  usageAPI: {
+    getDashboardStats,
+    getDashboardTrend,
+    getDashboardModels,
+    getByDateRange,
+  },
+}))
+
+vi.mock('@/api/user', () => ({ getMyPlatformQuotas }))
+
+const simpleStub = { template: '<div><slot /></div>' }
+const originalTimezone = process.env.TZ
+
+describe('user DashboardView date range', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    process.env.TZ = 'America/New_York'
+    vi.setSystemTime(new Date(2026, 2, 9, 0, 30))
+
+    refreshUser.mockReset().mockResolvedValue(undefined)
+    getDashboardStats.mockReset().mockResolvedValue({})
+    getDashboardTrend.mockReset().mockResolvedValue({ trend: [] })
+    getDashboardModels.mockReset().mockResolvedValue({ models: [] })
+    getByDateRange.mockReset().mockResolvedValue({ items: [] })
+    getMyPlatformQuotas.mockReset().mockResolvedValue({ platform_quotas: [] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    if (originalTimezone === undefined) {
+      delete process.env.TZ
+    } else {
+      process.env.TZ = originalTimezone
+    }
+  })
+
+  it('uses a seven-calendar-day range and sends the IANA timezone to every usage request', async () => {
+    const { default: DashboardView } = await import('../DashboardView.vue')
+    const wrapper = mount(DashboardView, {
+      global: {
+        stubs: {
+          AppLayout: simpleStub,
+          LoadingSpinner: true,
+          UserDashboardStats: true,
+          UserDashboardCharts: true,
+          UserDashboardRecentUsage: true,
+          UserDashboardQuickActions: true,
+        },
+      },
+    })
+
+    await flushPromises()
+
+    expect(getDashboardTrend).toHaveBeenCalledWith({
+      start_date: '2026-03-03',
+      end_date: '2026-03-09',
+      granularity: 'day',
+      timezone: 'America/New_York',
+    })
+    expect(getDashboardModels).toHaveBeenCalledWith({
+      start_date: '2026-03-03',
+      end_date: '2026-03-09',
+      timezone: 'America/New_York',
+    })
+    expect(getByDateRange).toHaveBeenCalledWith(
+      '2026-03-03',
+      '2026-03-09',
+      undefined,
+      'America/New_York'
+    )
+
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## Problem

Usage dashboards currently mix browser-local dates, server-local timestamps, and fixed 24-hour arithmetic. This causes visible date drift for users outside the server timezone and incorrect ranges across daylight-saving transitions, where a local calendar day can be 23 or 25 hours.

Examples include seven-day and thirty-day ranges computed with `86400000`, daily trend buckets formatted directly from `created_at`, and inclusive end dates recovered with `EndTime.Add(-24h)`.

## Root cause

The frontend did not consistently send the user's IANA timezone, while the backend parsed and grouped several usage queries without an explicit timezone contract. Fixed-duration subtraction was also used where the product semantics are calendar days.

## Fix

- Compute local date ranges with calendar-day operations instead of fixed milliseconds.
- Preserve an explicitly supplied timezone in the GET client interceptor.
- Send the browser's IANA timezone for dashboard and key-usage requests.
- Parse gateway and user usage ranges from civil dates in the requested timezone, including zones whose first valid instant is after midnight.
- Reject a directly requested civil date that does not exist because the zone skipped the entire day, while safely finding the next valid boundary for surrounding ranges.
- Group PostgreSQL daily trends with a parameterized `AT TIME ZONE` expression.
- Use calendar-day subtraction for inclusive end dates across DST boundaries.
- Reuse the same timezone for daily usage aggregation.
- Pass the same civil-day lower bound through API-key Today summaries so cards, trends, models, and recent usage share one timezone contract.

The API remains backward compatible: callers that omit `timezone` retain the existing default behavior.

## Tests

Regression coverage includes 23-hour and 25-hour DST days, Santiago's midnight DST gap, Apia's skipped civil date, explicit timezone preservation, browser timezone propagation, timezone-aware backend range parsing and trend grouping, API-key Today boundaries, and inclusive end-date behavior.

Verification:

- `go test ./internal/handler ./internal/repository ./internal/service -count=1`
- targeted frontend tests: 5 files, 27 tests
- `pnpm typecheck`
- `pnpm lint:check`
- `git diff --check`
