### PR TITLE
fix(frontend): preserve horizontal table scrolling on tablets

### DIFF
--- a/frontend/src/components/layout/TablePageLayout.vue
+++ b/frontend/src/components/layout/TablePageLayout.vue
@@ -100,10 +100,6 @@ onUnmounted(() => {
   @apply flex-none min-h-fit;
 }
 
-.table-page-layout.mobile-mode .table-scroll-container :deep(.table-wrapper) {
-  @apply overflow-visible;
-}
-
 .table-page-layout.mobile-mode .table-scroll-container :deep(table) {
   @apply flex-none;
   display: table;

--- a/frontend/src/components/layout/__tests__/TablePageLayout.spec.ts
+++ b/frontend/src/components/layout/__tests__/TablePageLayout.spec.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const componentPath = resolve(dirname(fileURLToPath(import.meta.url)), '../TablePageLayout.vue')
+const componentSource = readFileSync(componentPath, 'utf8')
+
+describe('TablePageLayout responsive table scrolling', () => {
+  it('does not disable the table horizontal scroll container in mobile mode', () => {
+    const tableWrapperBlocks = Array.from(
+      componentSource.matchAll(/([^{}]*:deep\(\.table-wrapper\)[^{}]*)\{([^{}]*)\}/g)
+    )
+
+    expect(tableWrapperBlocks.length).toBeGreaterThan(0)
+
+    const baseBlock = tableWrapperBlocks.find(([selector]) => !selector.includes('.mobile-mode'))
+    const mobileBlocks = tableWrapperBlocks.filter(([selector]) => selector.includes('.mobile-mode'))
+
+    expect(baseBlock?.[2]).toContain('overflow-x-auto')
+    expect(mobileBlocks.every(([, , declarations]) => !declarations.includes('overflow-visible'))).toBe(
+      true
+    )
+  })
+})


### PR DESCRIPTION
Closes #4374

## Summary

- keep `DataTable`'s horizontal scroll container active in the `768–1023px` responsive range
- add a regression test that prevents `mobile-mode` from overriding `.table-wrapper` with `overflow-visible`

## Root cause

`DataTable` switches to the desktop table at `min-width: 768px`, while `TablePageLayout` enables `mobile-mode` below `1024px`.

In that overlapping range, `mobile-mode` changed `.table-wrapper` to `overflow: visible`. The account table's immediate parent uses `overflow-hidden`, so the wide table was clipped instead of becoming horizontally scrollable.

## Why this change is safe

Below `768px`, `DataTable` renders the card layout and does not render `.table-wrapper`. Removing this override therefore only restores the existing `overflow-x-auto` behavior for desktop tables in the tablet/foldable range.

## Verification

- reproduced the failure at a 900 CSS px viewport: `scrollWidth > clientWidth`, but setting `scrollLeft` remained `0`
- verified the fix at 900 CSS px: `scrollLeft` changes and right-side columns are reachable
- deployed the patch on a `v0.1.156` instance and confirmed the fix on an unfolded OPPO Find N6
- `pnpm test:run`: 156 test files, 1101 tests passed
- `pnpm typecheck`: passed
- `pnpm lint:check`: passed
- `pnpm build`: passed
