### PR TITLE
fix(openai): reject explicit_cache for GPT-5.6 responses

### DIFF
--- a/backend/internal/handler/gateway_handler_responses.go
+++ b/backend/internal/handler/gateway_handler_responses.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/ip"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -88,6 +89,16 @@ func (h *GatewayHandler) Responses(c *gin.Context) {
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
 
 	setOpsRequestContext(c, reqModel, reqStream)
+	if openai_compat.ShouldRejectGPT56ResponsesExplicitCache(reqModel, body) {
+		h.responsesInvalidRequestParamErrorResponse(
+			c,
+			http.StatusBadRequest,
+			"unsupported_parameter",
+			"Unsupported parameter: 'explicit_cache' is not supported for GPT-5.6 Responses requests.",
+			openai_compat.ExplicitCacheParam,
+		)
+		return
+	}
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(reqStream, false)))
 	requestCtx := c.Request.Context()
 	if service.IsImageGenerationIntentForPlatform("/v1/responses", reqModel, body, openAICompatibleRequestPlatform(c.Request.Context(), apiKey)) {
@@ -324,6 +335,17 @@ func (h *GatewayHandler) responsesErrorResponse(c *gin.Context, status int, code
 		"error": gin.H{
 			"code":    code,
 			"message": message,
+		},
+	})
+}
+
+func (h *GatewayHandler) responsesInvalidRequestParamErrorResponse(c *gin.Context, status int, code, message, param string) {
+	c.JSON(status, gin.H{
+		"error": gin.H{
+			"code":    code,
+			"message": message,
+			"param":   param,
+			"type":    "invalid_request_error",
 		},
 	})
 }

--- a/backend/internal/handler/gateway_handler_responses_explicit_cache_test.go
+++ b/backend/internal/handler/gateway_handler_responses_explicit_cache_test.go
@@ -1,0 +1,55 @@
+package handler
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	middleware2 "github.com/Wei-Shaw/sub2api/internal/server/middleware"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestGatewayHandlerResponsesRejectsGPT56ExplicitCacheBeforeFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","stream":false,"input":"hello","explicit_cache":{"ttl":"30m"}}`)
+	c, rec := newResponsesExplicitCacheTestContext(t, body)
+
+	handler := &GatewayHandler{}
+	require.NotPanics(t, func() {
+		handler.Responses(c)
+	})
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	responseBody := rec.Body.Bytes()
+	require.Equal(t, "invalid_request_error", gjson.GetBytes(responseBody, "error.type").String())
+	require.Equal(t, "unsupported_parameter", gjson.GetBytes(responseBody, "error.code").String())
+	require.Equal(t, "explicit_cache", gjson.GetBytes(responseBody, "error.param").String())
+	require.Contains(t, gjson.GetBytes(responseBody, "error.message").String(), "explicit_cache")
+}
+
+func newResponsesExplicitCacheTestContext(t *testing.T, body []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	groupID := int64(3131)
+	req := httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	c.Set(string(middleware2.ContextKeyAPIKey), &service.APIKey{
+		ID:      99,
+		GroupID: &groupID,
+		Group: &service.Group{
+			ID:       groupID,
+			Platform: service.PlatformOpenAI,
+		},
+		User: &service.User{ID: 100},
+	})
+	c.Set(string(middleware2.ContextKeyUser), middleware2.AuthSubject{UserID: 100, Concurrency: 0})
+	return c, rec
+}

--- a/backend/internal/pkg/openai_compat/explicit_cache.go
+++ b/backend/internal/pkg/openai_compat/explicit_cache.go
@@ -1,0 +1,26 @@
+package openai_compat
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+)
+
+const ExplicitCacheParam = "explicit_cache"
+
+// ShouldRejectGPT56ResponsesExplicitCache reports whether a Responses request
+// uses the legacy top-level explicit_cache field with GPT-5.6 series models.
+func ShouldRejectGPT56ResponsesExplicitCache(model string, body []byte) bool {
+	return IsGPT56SeriesModel(model) && gjson.GetBytes(body, ExplicitCacheParam).Exists()
+}
+
+// IsGPT56SeriesModel matches GPT-5.6 model names, including provider-prefixed
+// aliases such as "openai/gpt-5.6-sol".
+func IsGPT56SeriesModel(model string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(model))
+	if slash := strings.LastIndex(normalized, "/"); slash >= 0 {
+		normalized = normalized[slash+1:]
+	}
+
+	return normalized == "gpt-5.6" || strings.HasPrefix(normalized, "gpt-5.6-")
+}

--- a/backend/internal/pkg/openai_compat/explicit_cache_test.go
+++ b/backend/internal/pkg/openai_compat/explicit_cache_test.go
@@ -1,0 +1,64 @@
+package openai_compat
+
+import "testing"
+
+func TestShouldRejectGPT56ResponsesExplicitCache(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		body  []byte
+		want  bool
+	}{
+		{
+			name:  "rejects sol",
+			model: "gpt-5.6-sol",
+			body:  []byte(`{"model":"gpt-5.6-sol","input":"hello","explicit_cache":{"ttl":"30m"}}`),
+			want:  true,
+		},
+		{
+			name:  "rejects provider prefixed terra",
+			model: "openai/gpt-5.6-terra",
+			body:  []byte(`{"model":"openai/gpt-5.6-terra","input":"hello","explicit_cache":true}`),
+			want:  true,
+		},
+		{
+			name:  "rejects case insensitive dated luna",
+			model: "GPT-5.6-LUNA-2026-07-09",
+			body:  []byte(`{"model":"GPT-5.6-LUNA-2026-07-09","input":"hello","explicit_cache":null}`),
+			want:  true,
+		},
+		{
+			name:  "rejects alias",
+			model: "gpt-5.6",
+			body:  []byte(`{"model":"gpt-5.6","input":"hello","explicit_cache":{}}`),
+			want:  true,
+		},
+		{
+			name:  "does not reject older model",
+			model: "gpt-5.5",
+			body:  []byte(`{"model":"gpt-5.5","input":"hello","explicit_cache":{}}`),
+			want:  false,
+		},
+		{
+			name:  "does not reject missing explicit cache",
+			model: "gpt-5.6-sol",
+			body:  []byte(`{"model":"gpt-5.6-sol","input":"hello"}`),
+			want:  false,
+		},
+		{
+			name:  "does not reject nested explicit cache",
+			model: "gpt-5.6-sol",
+			body:  []byte(`{"model":"gpt-5.6-sol","input":[{"role":"user","content":[{"type":"input_text","text":"hello","explicit_cache":true}]}]}`),
+			want:  false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShouldRejectGPT56ResponsesExplicitCache(tc.model, tc.body)
+			if got != tc.want {
+				t.Fatalf("ShouldRejectGPT56ResponsesExplicitCache(%q, body) = %v, want %v", tc.model, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 背景

GPT-5.6 系列（例如 `gpt-5.6-luna`、`gpt-5.6-terra`、`gpt-5.6-sol`）的显式缓存能力应使用官方文档中的 `prompt_cache_options` 和内容块上的 `prompt_cache_breakpoint`。顶层 `explicit_cache` 不是 Responses API 的有效参数。

目前这类请求可能被透传到上游并表现为 502，随后进入账号切换 / failover。这里更适合在本地按客户端参数错误返回 400，避免误判为上游或账号故障。

Closes #4388

## 改动

- 在 `/v1/responses` 解析 `model` 和 `stream` 后、账号选择与 failover 前检查请求体。
- 命中 GPT-5.6 系列（含 `gpt-5.6`、`gpt-5.6-*`、provider prefix）且顶层存在 `explicit_cache` 时，直接返回 HTTP 400：
  - `error.type: invalid_request_error`
  - `error.code: unsupported_parameter`
  - `error.param: explicit_cache`
- Chat Completions 路径保持现有行为，不额外拦截。
- 不修改 `prompt_cache_options` 的现有转发逻辑，避免扩大本 PR 范围。
- 增加 `openai_compat` 判定单测和 Responses handler 回归测试，确保请求不会进入账号选择 / failover。

## 最新同步与测试

- 2026-07-31 已 rebase 到当时最新 `main`：`26d894ef4f50645a4bf1030e378ac892f17d0223`，无冲突。
- `go test ./internal/pkg/openai_compat -run ExplicitCache -count=1`
- `go test ./internal/handler -run ExplicitCache -count=1 -v`
- `go test ./internal/pkg/openai_compat ./internal/handler -count=1`
- `go test ./...`

以上测试均在 rebase 后通过。

## 参考

- OpenAI Prompt Caching 文档：https://developers.openai.com/api/docs/guides/prompt-caching
- OpenAI Responses API 文档：https://platform.openai.com/docs/api-reference/responses/create
