### PR TITLE
fix(openai): route PAT alpha search via responses web_search

### DIFF
--- a/backend/internal/handler/openai_alpha_search.go
+++ b/backend/internal/handler/openai_alpha_search.go
@@ -118,7 +118,7 @@ func (h *OpenAIGatewayHandler) AlphaSearch(c *gin.Context) {
 			requestedModel,
 			failedAccountIDs,
 			service.OpenAIUpstreamTransportHTTPSSE,
-			service.OpenAIEndpointCapabilityChatCompletions,
+			service.OpenAIEndpointCapabilityAlphaSearch,
 			false,
 			false,
 			service.PlatformOpenAI,

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -87,6 +87,7 @@ const openAILongContextBillingEnabledKey = "openai_long_context_billing_enabled"
 const (
 	OpenAIEndpointCapabilityChatCompletions OpenAIEndpointCapability = "chat_completions"
 	OpenAIEndpointCapabilityEmbeddings      OpenAIEndpointCapability = "embeddings"
+	OpenAIEndpointCapabilityAlphaSearch     OpenAIEndpointCapability = "alpha_search"
 )
 
 const openAIEndpointCapabilitiesCredentialKey = "openai_capabilities"
@@ -1397,6 +1398,13 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 	}
 	switch capability {
 	case OpenAIEndpointCapabilityChatCompletions:
+	case OpenAIEndpointCapabilityAlphaSearch:
+		// Codex alpha/search 是 ChatGPT/Codex 后端工具端点，必须使用
+		// OAuth/PAT/AgentIdentity 这类 ChatGPT 账号凭据；API key 被发往
+		// chatgpt.com/backend-api/codex/alpha/search 会稳定 401。
+		if a.Type != AccountTypeOAuth {
+			return false
+		}
 	case OpenAIEndpointCapabilityEmbeddings:
 		if a.Type != AccountTypeAPIKey {
 			return false
@@ -1407,6 +1415,9 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 
 	configured, found := a.openAIEndpointCapabilitySet()
 	if !found {
+		return true
+	}
+	if capability == OpenAIEndpointCapabilityAlphaSearch && configured[string(OpenAIEndpointCapabilityChatCompletions)] {
 		return true
 	}
 	return configured[string(capability)]

--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -303,20 +303,20 @@ func buildOpenAIAlphaSearchResponsesWebSearchBody(alphaBody []byte, model string
 
 func openAIAlphaSearchResponsesWebSearchPrompt(alphaBody []byte) string {
 	var b strings.Builder
-	b.WriteString("Execute this Codex standalone web.run request for another model.\n")
-	b.WriteString("Use the hosted web_search tool when web/current information is needed.\n")
-	b.WriteString("Return concise source-backed results. Include titles, URLs, dates, and direct answers when available.\n")
+	_, _ = b.WriteString("Execute this Codex standalone web.run request for another model.\n")
+	_, _ = b.WriteString("Use the hosted web_search tool when web/current information is needed.\n")
+	_, _ = b.WriteString("Return concise source-backed results. Include titles, URLs, dates, and direct answers when available.\n")
 	if commands := strings.TrimSpace(gjson.GetBytes(alphaBody, "commands").Raw); commands != "" {
-		b.WriteString("\nCommands JSON:\n")
-		b.WriteString(truncateOpenAIAlphaSearchPromptJSON(commands, 12000))
+		_, _ = b.WriteString("\nCommands JSON:\n")
+		_, _ = b.WriteString(truncateOpenAIAlphaSearchPromptJSON(commands, 12000))
 	}
 	if settings := strings.TrimSpace(gjson.GetBytes(alphaBody, "settings").Raw); settings != "" {
-		b.WriteString("\n\nSearch settings JSON:\n")
-		b.WriteString(truncateOpenAIAlphaSearchPromptJSON(settings, 4000))
+		_, _ = b.WriteString("\n\nSearch settings JSON:\n")
+		_, _ = b.WriteString(truncateOpenAIAlphaSearchPromptJSON(settings, 4000))
 	}
 	if input := strings.TrimSpace(gjson.GetBytes(alphaBody, "input").Raw); input != "" {
-		b.WriteString("\n\nRecent conversation/input JSON:\n")
-		b.WriteString(truncateOpenAIAlphaSearchPromptJSON(input, 8000))
+		_, _ = b.WriteString("\n\nRecent conversation/input JSON:\n")
+		_, _ = b.WriteString(truncateOpenAIAlphaSearchPromptJSON(input, 8000))
 	}
 	if b.Len() == 0 {
 		return "Execute the requested web search and return concise source-backed results."
@@ -537,7 +537,7 @@ func parseOpenAIResponsesSSEForAlphaSearch(body []byte) (string, []any) {
 			continue
 		}
 		if delta, _ := event["delta"].(string); delta != "" && event["type"] == "response.output_text.delta" {
-			output.WriteString(delta)
+			_, _ = output.WriteString(delta)
 		}
 		if event["type"] == "response.completed" {
 			completedResponse = event["response"]
@@ -585,7 +585,7 @@ func extractOpenAIResponsesCompletedText(response any) string {
 			}
 			if contentMap["type"] == "output_text" {
 				if text, _ := contentMap["text"].(string); text != "" {
-					b.WriteString(text)
+					_, _ = b.WriteString(text)
 				}
 			}
 		}

--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -59,6 +59,14 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 		return nil, err
 	}
 
+	// Codex Personal Access Token（at-...）目前可访问 ChatGPT Codex
+	// /responses，但会被 standalone /alpha/search 的 access enforcement
+	// 拒绝为 no_matching_rule。对 PAT 账号使用等价的 hosted web_search
+	// Responses 路径兜底，避免把可用账号误判为搜索不可用。
+	if account.IsOpenAIPersonalAccessToken() {
+		return s.forwardAlphaSearchViaResponsesWebSearch(ctx, c, account, body, token, proxyURL, requestedModel, upstreamModel)
+	}
+
 	req, err := s.buildOpenAIAlphaSearchRequest(ctx, c, account, body, token)
 	if err != nil {
 		return nil, err
@@ -117,6 +125,211 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 		Duration:       time.Since(upstreamStart),
 		WebSearchCalls: 1,
 	}, nil
+}
+
+func (s *OpenAIGatewayService) forwardAlphaSearchViaResponsesWebSearch(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	alphaBody []byte,
+	token string,
+	proxyURL string,
+	requestedModel string,
+	upstreamModel string,
+) (*OpenAIForwardResult, error) {
+	if upstreamModel == "" {
+		upstreamModel = requestedModel
+	}
+	responsesBody, err := buildOpenAIAlphaSearchResponsesWebSearchBody(alphaBody, upstreamModel)
+	if err != nil {
+		return nil, err
+	}
+	req, err := s.buildOpenAIAlphaSearchResponsesWebSearchRequest(ctx, c, account, alphaBody, responsesBody, token)
+	if err != nil {
+		return nil, err
+	}
+	SetActualOpenAIUpstreamEndpoint(c, "/v1/responses")
+
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, true)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return nil, fmt.Errorf("read alpha search responses fallback response: %w", err)
+	}
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		upstreamMessage := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+		if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMessage, respBody) {
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			// 仍按 alpha/search 工具请求处理：PAT 的工具链路失败不能直接永久置错。
+			if shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(resp.StatusCode) {
+				s.handleFailoverSideEffects(ctx, resp, account, respBody, upstreamModel)
+			}
+			return nil, &UpstreamFailoverError{
+				StatusCode:             resp.StatusCode,
+				ResponseBody:           respBody,
+				RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+			}
+		}
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+		contentType := resp.Header.Get("Content-Type")
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		c.Data(resp.StatusCode, contentType, respBody)
+		return nil, nil
+	}
+
+	if !account.IsShadow() {
+		s.UpdateCodexUsageSnapshotFromHeaders(ctx, account.ID, resp.Header)
+	}
+	alphaRespBody, err := openAIAlphaSearchResponseFromResponsesSSE(respBody)
+	if err != nil {
+		return nil, err
+	}
+	c.Data(http.StatusOK, "application/json", alphaRespBody)
+	return &OpenAIForwardResult{
+		RequestID:        strings.TrimSpace(resp.Header.Get("x-request-id")),
+		Model:            requestedModel,
+		UpstreamModel:    upstreamModel,
+		UpstreamEndpoint: "/v1/responses",
+		ResponseHeaders:  resp.Header.Clone(),
+		Duration:         time.Since(upstreamStart),
+		WebSearchCalls:   1,
+	}, nil
+}
+
+func (s *OpenAIGatewayService) buildOpenAIAlphaSearchResponsesWebSearchRequest(ctx context.Context, c *gin.Context, account *Account, alphaBody []byte, body []byte, token string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, chatgptCodexURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+
+	authHeaders, err := s.buildOpenAIAuthenticationHeaders(ctx, account, token)
+	if err != nil {
+		return nil, fmt.Errorf("build openai authentication headers: %w", err)
+	}
+	for key, values := range authHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+	req.Host = "chatgpt.com"
+	if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
+		return nil, fmt.Errorf("resolve chatgpt account headers: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("OpenAI-Beta", "responses=experimental")
+	if turnMetadata := openAIAlphaSearchInboundHeader(c, "X-Codex-Turn-Metadata"); turnMetadata != "" {
+		req.Header.Set("X-Codex-Turn-Metadata", turnMetadata)
+	}
+	if version := openAIAlphaSearchInboundHeader(c, "Version"); version != "" {
+		req.Header.Set("Version", version)
+	} else {
+		req.Header.Set("Version", codexCLIVersion)
+	}
+	if originator := openAIAlphaSearchInboundHeader(c, "Originator"); originator != "" {
+		req.Header.Set("Originator", originator)
+	} else {
+		req.Header.Set("Originator", "codex_cli_rs")
+	}
+	if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+		req.Header.Set("User-Agent", customUA)
+	} else if userAgent := openAIAlphaSearchInboundHeader(c, "User-Agent"); userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	} else {
+		req.Header.Set("User-Agent", codexCLIUserAgent)
+	}
+	if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+		req.Header.Set("User-Agent", codexCLIUserAgent)
+	}
+	apiKeyID := getAPIKeyIDFromContext(c)
+	if sessionID := strings.TrimSpace(gjson.GetBytes(alphaBody, "id").String()); sessionID != "" {
+		isolated := isolateOpenAISessionID(apiKeyID, sessionID)
+		req.Header.Set("Session_ID", isolated)
+		req.Header.Set("Conversation_ID", isolated)
+	}
+	s.overrideBrowserUserAgent(ctx, account, req)
+	enforceCodexIdentityHeaders(req.Header)
+	account.ApplyHeaderOverrides(req.Header)
+	return req, nil
+}
+
+func buildOpenAIAlphaSearchResponsesWebSearchBody(alphaBody []byte, model string) ([]byte, error) {
+	if strings.TrimSpace(model) == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	tool := map[string]any{"type": "web_search"}
+	if contextSize := strings.TrimSpace(gjson.GetBytes(alphaBody, "settings.search_context_size").String()); contextSize != "" {
+		tool["search_context_size"] = contextSize
+	}
+	if userLocation := gjson.GetBytes(alphaBody, "settings.user_location"); userLocation.IsObject() {
+		var loc map[string]any
+		if err := json.Unmarshal([]byte(userLocation.Raw), &loc); err == nil && len(loc) > 0 {
+			tool["user_location"] = loc
+		}
+	}
+	payload := map[string]any{
+		"model":  model,
+		"stream": true,
+		"store":  false,
+		"input": []any{
+			map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{
+						"type": "input_text",
+						"text": openAIAlphaSearchResponsesWebSearchPrompt(alphaBody),
+					},
+				},
+			},
+		},
+		"tools": []any{tool},
+	}
+	return json.Marshal(payload)
+}
+
+func openAIAlphaSearchResponsesWebSearchPrompt(alphaBody []byte) string {
+	var b strings.Builder
+	b.WriteString("Execute this Codex standalone web.run request for another model.\n")
+	b.WriteString("Use the hosted web_search tool when web/current information is needed.\n")
+	b.WriteString("Return concise source-backed results. Include titles, URLs, dates, and direct answers when available.\n")
+	if commands := strings.TrimSpace(gjson.GetBytes(alphaBody, "commands").Raw); commands != "" {
+		b.WriteString("\nCommands JSON:\n")
+		b.WriteString(truncateOpenAIAlphaSearchPromptJSON(commands, 12000))
+	}
+	if settings := strings.TrimSpace(gjson.GetBytes(alphaBody, "settings").Raw); settings != "" {
+		b.WriteString("\n\nSearch settings JSON:\n")
+		b.WriteString(truncateOpenAIAlphaSearchPromptJSON(settings, 4000))
+	}
+	if input := strings.TrimSpace(gjson.GetBytes(alphaBody, "input").Raw); input != "" {
+		b.WriteString("\n\nRecent conversation/input JSON:\n")
+		b.WriteString(truncateOpenAIAlphaSearchPromptJSON(input, 8000))
+	}
+	if b.Len() == 0 {
+		return "Execute the requested web search and return concise source-backed results."
+	}
+	return b.String()
+}
+
+func truncateOpenAIAlphaSearchPromptJSON(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "\n...<truncated>"
 }
 
 func (s *OpenAIGatewayService) buildOpenAIAlphaSearchRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string) (*http.Request, error) {
@@ -294,6 +507,120 @@ func (s *OpenAIGatewayService) ensureOpenAIAlphaSearchAuthMetadata(ctx context.C
 
 func shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(statusCode int) bool {
 	return statusCode != http.StatusUnauthorized
+}
+
+func openAIAlphaSearchResponseFromResponsesSSE(body []byte) ([]byte, error) {
+	output, results := parseOpenAIResponsesSSEForAlphaSearch(body)
+	resp := map[string]any{
+		"output": output,
+	}
+	if len(results) > 0 {
+		resp["results"] = results
+	}
+	return json.Marshal(resp)
+}
+
+func parseOpenAIResponsesSSEForAlphaSearch(body []byte) (string, []any) {
+	text := strings.ReplaceAll(string(body), "\r\n", "\n")
+	var output strings.Builder
+	var completedResponse any
+	results := make([]any, 0)
+	seenURLs := make(map[string]struct{})
+
+	for _, block := range strings.Split(text, "\n\n") {
+		data := openAIAlphaSearchSSEData(block)
+		if data == "" || data == "[DONE]" {
+			continue
+		}
+		var event map[string]any
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+		if delta, _ := event["delta"].(string); delta != "" && event["type"] == "response.output_text.delta" {
+			output.WriteString(delta)
+		}
+		if event["type"] == "response.completed" {
+			completedResponse = event["response"]
+		}
+		collectOpenAIAlphaSearchURLCitations(event, &results, seenURLs)
+	}
+
+	out := output.String()
+	if strings.TrimSpace(out) == "" && completedResponse != nil {
+		out = extractOpenAIResponsesCompletedText(completedResponse)
+		collectOpenAIAlphaSearchURLCitations(completedResponse, &results, seenURLs)
+	}
+	return out, results
+}
+
+func openAIAlphaSearchSSEData(block string) string {
+	var lines []string
+	for _, line := range strings.Split(block, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		lines = append(lines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}
+
+func extractOpenAIResponsesCompletedText(response any) string {
+	resp, ok := response.(map[string]any)
+	if !ok {
+		return ""
+	}
+	outputItems, _ := resp["output"].([]any)
+	var b strings.Builder
+	for _, item := range outputItems {
+		itemMap, ok := item.(map[string]any)
+		if !ok || itemMap["type"] != "message" {
+			continue
+		}
+		contentItems, _ := itemMap["content"].([]any)
+		for _, content := range contentItems {
+			contentMap, ok := content.(map[string]any)
+			if !ok {
+				continue
+			}
+			if contentMap["type"] == "output_text" {
+				if text, _ := contentMap["text"].(string); text != "" {
+					b.WriteString(text)
+				}
+			}
+		}
+	}
+	return b.String()
+}
+
+func collectOpenAIAlphaSearchURLCitations(value any, results *[]any, seen map[string]struct{}) {
+	switch typed := value.(type) {
+	case map[string]any:
+		if typed["type"] == "url_citation" {
+			if urlValue, _ := typed["url"].(string); strings.TrimSpace(urlValue) != "" {
+				urlValue = strings.TrimSpace(urlValue)
+				if _, exists := seen[urlValue]; !exists {
+					seen[urlValue] = struct{}{}
+					result := map[string]any{
+						"type":   "text_result",
+						"ref_id": fmt.Sprintf("turn0search%d", len(*results)),
+						"url":    urlValue,
+					}
+					if title, _ := typed["title"].(string); strings.TrimSpace(title) != "" {
+						result["title"] = strings.TrimSpace(title)
+					}
+					*results = append(*results, result)
+				}
+			}
+		}
+		for _, child := range typed {
+			collectOpenAIAlphaSearchURLCitations(child, results, seen)
+		}
+	case []any:
+		for _, child := range typed {
+			collectOpenAIAlphaSearchURLCitations(child, results, seen)
+		}
+	}
 }
 
 func (s *OpenAIGatewayService) openAIAlphaSearchURL(account *Account) (string, error) {

--- a/backend/internal/service/openai_alpha_search.go
+++ b/backend/internal/service/openai_alpha_search.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -39,13 +40,13 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 	if upstreamModel != "" && upstreamModel != requestedModel {
 		body = ReplaceModelInBody(body, upstreamModel)
 	}
+	sanitizedBody, err := sanitizeOpenAIAlphaSearchBody(body)
+	if err != nil {
+		return nil, fmt.Errorf("sanitize alpha search request body: %w", err)
+	}
+	body = sanitizedBody
 
 	token, _, err := s.GetAccessToken(ctx, account)
-	if err != nil {
-		return nil, err
-	}
-
-	req, err := s.buildOpenAIAlphaSearchRequest(ctx, c, account, body, token)
 	if err != nil {
 		return nil, err
 	}
@@ -54,6 +55,15 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 	if account.ProxyID != nil && account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
+	if err := s.ensureOpenAIAlphaSearchAuthMetadata(ctx, account, token, proxyURL); err != nil {
+		return nil, err
+	}
+
+	req, err := s.buildOpenAIAlphaSearchRequest(ctx, c, account, body, token)
+	if err != nil {
+		return nil, err
+	}
+
 	upstreamStart := time.Now()
 	resp, err := s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
 	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
@@ -71,7 +81,14 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 		upstreamMessage := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
 		if s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMessage, respBody) {
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
-			s.handleFailoverSideEffects(ctx, resp, account, respBody, upstreamModel)
+			// alpha/search 是独立的工具端点，单次 401 不能证明账号的模型调用
+			// 凭据全局失效。若沿用通用 401 逻辑，PAT 会因没有 refresh_token
+			// 被永久标记为 error；历史导入且缺少 auth_mode 标记的 at- token 也会
+			// 漏过 PAT 类型判断。这里仍允许本次请求换号，但不修改任何账号状态；
+			// 真正的凭据失效由普通 Responses 请求或 whoami 校验判定。
+			if shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(resp.StatusCode) {
+				s.handleFailoverSideEffects(ctx, resp, account, respBody, upstreamModel)
+			}
 			return nil, &UpstreamFailoverError{
 				StatusCode:             resp.StatusCode,
 				ResponseBody:           respBody,
@@ -103,15 +120,6 @@ func (s *OpenAIGatewayService) ForwardAlphaSearch(ctx context.Context, c *gin.Co
 }
 
 func (s *OpenAIGatewayService) buildOpenAIAlphaSearchRequest(ctx context.Context, c *gin.Context, account *Account, body []byte, token string) (*http.Request, error) {
-	clientBeta := ""
-	if c != nil {
-		clientBeta = c.GetHeader("OpenAI-Beta")
-	}
-	req, err := s.buildUpstreamRequestOpenAIPassthrough(ctx, c, account, body, token)
-	if err != nil {
-		return nil, err
-	}
-
 	targetURL, err := s.openAIAlphaSearchURL(account)
 	if err != nil {
 		return nil, err
@@ -129,17 +137,163 @@ func (s *OpenAIGatewayService) buildOpenAIAlphaSearchRequest(ctx context.Context
 		}
 		parsedURL.RawQuery = query.Encode()
 	}
-	req.URL = parsedURL
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, parsedURL.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI))
+
+	authHeaders, err := s.buildOpenAIAuthenticationHeaders(ctx, account, token)
+	if err != nil {
+		return nil, fmt.Errorf("build openai authentication headers: %w", err)
+	}
+	for key, values := range authHeaders {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
-	if clientBeta == "" {
-		req.Header.Del("OpenAI-Beta")
+
+	if account.Type == AccountTypeOAuth {
+		req.Host = "chatgpt.com"
+		if err := resolveAndSetOpenAIChatGPTAccountHeaders(ctx, s.accountRepo, req.Header, account); err != nil {
+			return nil, fmt.Errorf("resolve chatgpt account headers: %w", err)
+		}
+
+		if turnMetadata := openAIAlphaSearchInboundHeader(c, "X-Codex-Turn-Metadata"); turnMetadata != "" {
+			req.Header.Set("X-Codex-Turn-Metadata", turnMetadata)
+		}
+		if version := openAIAlphaSearchInboundHeader(c, "Version"); version != "" {
+			req.Header.Set("Version", version)
+		} else {
+			req.Header.Set("Version", codexCLIVersion)
+		}
+		if originator := openAIAlphaSearchInboundHeader(c, "Originator"); originator != "" {
+			req.Header.Set("Originator", originator)
+		} else {
+			req.Header.Set("Originator", "codex_cli_rs")
+		}
+		if customUA := account.GetOpenAIUserAgent(); customUA != "" {
+			req.Header.Set("User-Agent", customUA)
+		} else if userAgent := openAIAlphaSearchInboundHeader(c, "User-Agent"); userAgent != "" {
+			req.Header.Set("User-Agent", userAgent)
+		} else {
+			req.Header.Set("User-Agent", codexCLIUserAgent)
+		}
+		if s.cfg != nil && s.cfg.Gateway.ForceCodexCLI {
+			req.Header.Set("User-Agent", codexCLIUserAgent)
+		}
+		s.overrideBrowserUserAgent(ctx, account, req)
+		enforceCodexIdentityHeaders(req.Header)
 	}
-	if version := strings.TrimSpace(c.GetHeader("Version")); version != "" {
-		req.Header.Set("Version", version)
-	} else if account.Type == AccountTypeOAuth {
-		req.Header.Set("Version", codexCLIVersion)
-	}
+
+	account.ApplyHeaderOverrides(req.Header)
+	stripOpenAIAlphaSearchResponsesHeaders(req.Header)
 	return req, nil
+}
+
+// stripOpenAIAlphaSearchResponsesHeaders 让独立搜索请求与官方 Codex
+// SearchClient 的线协议保持一致。alpha/search 不是 /responses 的子请求：官方
+// 客户端仅在 Provider/Auth 基础头之外附加 x-codex-turn-metadata，不发送
+// OpenAI-Beta、会话隔离或 Responses Lite 状态头。originator 与 User-Agent
+// 属于官方默认客户端头，必须保留。
+//
+// alpha/search 使用专用构造器生成官方 SearchClient 的最小线协议形态；
+// 该函数作为最后一道防线，避免账号 header 覆写或后续改动重新带入
+// Responses 专用头，使 PAT 的 alpha/search 被上游按错误认证路径处理。
+func stripOpenAIAlphaSearchResponsesHeaders(headers http.Header) {
+	if headers == nil {
+		return
+	}
+	for _, key := range []string{
+		"OpenAI-Beta",
+		"Session_ID",
+		"Conversation_ID",
+		"X-Codex-Beta-Features",
+		"X-Codex-Turn-State",
+		responsesLiteHeaderKey,
+	} {
+		headers.Del(key)
+	}
+}
+
+func openAIAlphaSearchInboundHeader(c *gin.Context, key string) string {
+	if c == nil {
+		return ""
+	}
+	return strings.TrimSpace(c.GetHeader(key))
+}
+
+var openAIAlphaSearchUnsupportedBodyFields = [...]string{
+	// Codex alpha/search 是 SearchRequest 独立协议，不是 /responses 子请求。
+	// 新版 Codex/第三方代理可能把 Responses 公共字段误带到搜索请求里；ChatGPT
+	// alpha/search 会对这些字段返回 Unknown parameter（例如 prompt_cache_key）。
+	"prompt_cache_key",
+	"prompt_cache_retention",
+}
+
+func sanitizeOpenAIAlphaSearchBody(body []byte) ([]byte, error) {
+	if len(body) == 0 {
+		return body, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(body, &obj); err != nil || obj == nil {
+		return body, nil
+	}
+	changed := false
+	for _, field := range openAIAlphaSearchUnsupportedBodyFields {
+		if _, ok := obj[field]; ok {
+			delete(obj, field)
+			changed = true
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *OpenAIGatewayService) ensureOpenAIAlphaSearchAuthMetadata(ctx context.Context, account *Account, token string, proxyURL string) error {
+	if s == nil || account == nil || !account.IsOpenAIPersonalAccessToken() {
+		return nil
+	}
+	if strings.TrimSpace(account.GetChatGPTAccountID()) != "" {
+		return nil
+	}
+	var oauthService *OpenAIOAuthService
+	if s.openAITokenProvider != nil {
+		oauthService = s.openAITokenProvider.openAIOAuthService
+	}
+	if oauthService == nil {
+		return nil
+	}
+	tokenInfo, err := oauthService.ValidateCodexPersonalAccessToken(ctx, token, proxyURL)
+	if err != nil {
+		return fmt.Errorf("validate Codex PAT metadata for alpha/search: %w", err)
+	}
+	credentials := shallowCopyMap(account.Credentials)
+	for key, value := range oauthService.BuildAccountCredentials(tokenInfo) {
+		credentials[key] = value
+	}
+	credentials = NormalizeOpenAIPersonalAccessTokenCredentials(account, tokenInfo, credentials)
+	account.Credentials = shallowCopyMap(credentials)
+	if s.accountRepo != nil {
+		if err := persistAccountCredentials(ctx, s.accountRepo, account, credentials); err != nil {
+			return fmt.Errorf("persist Codex PAT metadata for alpha/search: %w", err)
+		}
+	}
+	return nil
+}
+
+func shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(statusCode int) bool {
+	return statusCode != http.StatusUnauthorized
 }
 
 func (s *OpenAIGatewayService) openAIAlphaSearchURL(account *Account) (string, error) {

--- a/backend/internal/service/openai_alpha_search_test.go
+++ b/backend/internal/service/openai_alpha_search_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -26,6 +27,15 @@ func (r *alphaSearchAccountStateRepo) SetError(_ context.Context, _ int64, error
 	r.setErrorCalls++
 	r.lastError = errorMsg
 	return nil
+}
+
+func alphaSearchResponsesSSE(output string) string {
+	return "event: response.output_text.delta\n" +
+		`data: {"type":"response.output_text.delta","delta":` + strconv.Quote(output) + `}` + "\n\n" +
+		"event: response.output_text.annotation.added\n" +
+		`data: {"type":"response.output_text.annotation.added","annotation":{"type":"url_citation","url":"https://example.com/news","title":"Example News"}}` + "\n\n" +
+		"event: response.completed\n" +
+		`data: {"type":"response.completed","response":{"output":[{"type":"message","content":[{"type":"output_text","text":` + strconv.Quote(output) + `}]}]}}` + "\n\n"
 }
 
 func TestForwardAlphaSearchOAuthPreservesWire(t *testing.T) {
@@ -83,7 +93,7 @@ func TestForwardAlphaSearchOAuthPreservesWire(t *testing.T) {
 	require.JSONEq(t, string(body), string(upstream.lastBody))
 }
 
-func TestForwardAlphaSearchPATUsesStandaloneHeaderShape(t *testing.T) {
+func TestForwardAlphaSearchPATUsesResponsesWebSearchFallback(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	body := []byte(`{
 		"id":"search-session",
@@ -111,8 +121,8 @@ func TestForwardAlphaSearchPATUsesStandaloneHeaderShape(t *testing.T) {
 
 	upstream := &httpUpstreamRecorder{resp: &http.Response{
 		StatusCode: http.StatusOK,
-		Header:     http.Header{"Content-Type": []string{"application/json"}},
-		Body:       io.NopCloser(strings.NewReader(`{"output":"search result"}`)),
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"req-search"}},
+		Body:       io.NopCloser(strings.NewReader(alphaSearchResponsesSSE("search result"))),
 	}}
 	service := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
 	account := &Account{
@@ -132,17 +142,20 @@ func TestForwardAlphaSearchPATUsesStandaloneHeaderShape(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
+	require.Equal(t, 1, result.WebSearchCalls)
+	require.Equal(t, "/v1/responses", result.UpstreamEndpoint)
+	require.Equal(t, http.StatusOK, recorder.Code)
+	require.JSONEq(t, `{"output":"search result","results":[{"type":"text_result","ref_id":"turn0search0","url":"https://example.com/news","title":"Example News"}]}`, recorder.Body.String())
+	require.Equal(t, chatgptCodexURL, upstream.lastReq.URL.String())
 	require.Equal(t, "Bearer at-test-token", upstream.lastReq.Header.Get("Authorization"))
 	require.Equal(t, "chatgpt-account", upstream.lastReq.Header.Get("ChatGPT-Account-ID"))
 	require.Equal(t, "true", upstream.lastReq.Header.Get("X-OpenAI-Fedramp"))
 	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
-	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "responses=experimental", upstream.lastReq.Header.Get("OpenAI-Beta"))
 	require.Equal(t, "0.144.1", upstream.lastReq.Header.Get("Version"))
 	require.Equal(t, `{"turn_id":"turn-1"}`, upstream.lastReq.Header.Get("X-Codex-Turn-Metadata"))
 	require.Equal(t, "codex_cli_rs", upstream.lastReq.Header.Get("Originator"))
-	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
-	require.Empty(t, upstream.lastReq.Header.Get("Session_ID"))
-	require.Empty(t, upstream.lastReq.Header.Get("Conversation_ID"))
 	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Beta-Features"))
 	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Turn-State"))
 	require.Empty(t, upstream.lastReq.Header.Get(responsesLiteHeaderKey))
@@ -150,6 +163,10 @@ func TestForwardAlphaSearchPATUsesStandaloneHeaderShape(t *testing.T) {
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_retention").Exists())
 	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(upstream.lastBody, "model").String())
+	require.True(t, gjson.GetBytes(upstream.lastBody, "stream").Bool())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "store").Bool())
+	require.Equal(t, "web_search", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
+	require.Contains(t, gjson.GetBytes(upstream.lastBody, "input.0.content.0.text").String(), `"search_query"`)
 }
 
 func TestForwardAlphaSearchPATBackfillsMissingChatGPTAccountMetadata(t *testing.T) {
@@ -325,6 +342,52 @@ func TestForwardAlphaSearchUnauthorizedDoesNotMarkAccountError(t *testing.T) {
 	var failoverErr *UpstreamFailoverError
 	require.ErrorAs(t, err, &failoverErr)
 	require.Equal(t, http.StatusUnauthorized, failoverErr.StatusCode)
+	require.Zero(t, repo.setErrorCalls)
+	require.Empty(t, repo.lastError)
+	require.False(t, c.Writer.Written())
+}
+
+func TestForwardAlphaSearchPATResponsesFallbackUnauthorizedDoesNotMarkAccountError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"id":"search-session","model":"gpt-5.6-sol","commands":{"search_query":[{"q":"news"}]}}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/alpha/search", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"detail":"Unauthorized"}`)),
+	}}
+	repo := &alphaSearchAccountStateRepo{}
+	cfg := &config.Config{}
+	service := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     upstream,
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, cfg, nil, nil),
+	}
+	account := &Account{
+		ID:          46,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "at-test-token",
+			"auth_mode":          OpenAIAuthModePersonalAccessToken,
+			"chatgpt_account_id": "chatgpt-account",
+		},
+	}
+
+	result, err := service.ForwardAlphaSearch(context.Background(), c, account, body)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusUnauthorized, failoverErr.StatusCode)
+	require.Equal(t, chatgptCodexURL, upstream.lastReq.URL.String())
+	require.Equal(t, "text/event-stream", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "responses=experimental", upstream.lastReq.Header.Get("OpenAI-Beta"))
 	require.Zero(t, repo.setErrorCalls)
 	require.Empty(t, repo.lastError)
 	require.False(t, c.Writer.Written())

--- a/backend/internal/service/openai_alpha_search_test.go
+++ b/backend/internal/service/openai_alpha_search_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -14,6 +15,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+type alphaSearchAccountStateRepo struct {
+	AccountRepository
+	setErrorCalls int
+	lastError     string
+}
+
+func (r *alphaSearchAccountStateRepo) SetError(_ context.Context, _ int64, errorMsg string) error {
+	r.setErrorCalls++
+	r.lastError = errorMsg
+	return nil
+}
 
 func TestForwardAlphaSearchOAuthPreservesWire(t *testing.T) {
 	gin.SetMode(gin.TestMode)
@@ -68,6 +81,136 @@ func TestForwardAlphaSearchOAuthPreservesWire(t *testing.T) {
 	require.Equal(t, "0.144.1", upstream.lastReq.Header.Get("Version"))
 	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
 	require.JSONEq(t, string(body), string(upstream.lastBody))
+}
+
+func TestForwardAlphaSearchPATUsesStandaloneHeaderShape(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{
+		"id":"search-session",
+		"model":"gpt-5.6-sol",
+		"commands":{"search_query":[{"q":"OpenAI news"}]},
+		"prompt_cache_key":"responses-cache-key",
+		"prompt_cache_retention":"24h"
+	}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/alpha/search", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", codexCLIUserAgent)
+	c.Request.Header.Set("Originator", "codex_cli_rs")
+	c.Request.Header.Set("Version", "0.144.1")
+	c.Request.Header.Set("OpenAI-Beta", "responses=experimental")
+	c.Request.Header.Set("Accept-Language", "zh-CN")
+	c.Request.Header.Set("Authorization", "Bearer client-token")
+	c.Request.Header.Set("Session_ID", "session-client")
+	c.Request.Header.Set("Conversation_ID", "conversation-client")
+	c.Request.Header.Set("X-Codex-Beta-Features", "feature-a")
+	c.Request.Header.Set("X-Codex-Turn-State", "turn-state")
+	c.Request.Header.Set(responsesLiteHeaderKey, "true")
+	c.Request.Header.Set("X-Codex-Turn-Metadata", `{"turn_id":"turn-1"}`)
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"output":"search result"}`)),
+	}}
+	service := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+	account := &Account{
+		ID:          43,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":               "at-test-token",
+			"auth_mode":                  OpenAIAuthModePersonalAccessToken,
+			"chatgpt_account_id":         "chatgpt-account",
+			"chatgpt_account_is_fedramp": true,
+		},
+	}
+
+	result, err := service.ForwardAlphaSearch(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Bearer at-test-token", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "chatgpt-account", upstream.lastReq.Header.Get("ChatGPT-Account-ID"))
+	require.Equal(t, "true", upstream.lastReq.Header.Get("X-OpenAI-Fedramp"))
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Content-Type"))
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "0.144.1", upstream.lastReq.Header.Get("Version"))
+	require.Equal(t, `{"turn_id":"turn-1"}`, upstream.lastReq.Header.Get("X-Codex-Turn-Metadata"))
+	require.Equal(t, "codex_cli_rs", upstream.lastReq.Header.Get("Originator"))
+	require.Empty(t, upstream.lastReq.Header.Get("OpenAI-Beta"))
+	require.Empty(t, upstream.lastReq.Header.Get("Session_ID"))
+	require.Empty(t, upstream.lastReq.Header.Get("Conversation_ID"))
+	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Beta-Features"))
+	require.Empty(t, upstream.lastReq.Header.Get("X-Codex-Turn-State"))
+	require.Empty(t, upstream.lastReq.Header.Get(responsesLiteHeaderKey))
+	require.Empty(t, upstream.lastReq.Header.Get("Accept-Language"))
+	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_key").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "prompt_cache_retention").Exists())
+	require.Equal(t, "gpt-5.6-sol", gjson.GetBytes(upstream.lastBody, "model").String())
+}
+
+func TestForwardAlphaSearchPATBackfillsMissingChatGPTAccountMetadata(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"id":"search-session","model":"gpt-5.6-sol","commands":{"search_query":[{"q":"OpenAI news"}]}}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/alpha/search", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	var whoamiCalls int32
+	whoamiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&whoamiCalls, 1)
+		require.Equal(t, "Bearer at-test-token", r.Header.Get("Authorization"))
+		require.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"email":"pat@example.com",
+			"chatgpt_user_id":"user-123",
+			"chatgpt_account_id":"acct-123",
+			"chatgpt_plan_type":"plus",
+			"chatgpt_account_is_fedramp":true
+		}`))
+	}))
+	defer whoamiServer.Close()
+	oldWhoamiURL := openAICodexPATWhoamiURL
+	openAICodexPATWhoamiURL = whoamiServer.URL
+	defer func() { openAICodexPATWhoamiURL = oldWhoamiURL }()
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"output":"search result"}`)),
+	}}
+	oauthService := NewOpenAIOAuthService(nil, nil)
+	service := &OpenAIGatewayService{
+		cfg:                 &config.Config{},
+		httpUpstream:        upstream,
+		openAITokenProvider: NewOpenAITokenProvider(nil, nil, oauthService),
+	}
+	account := &Account{
+		ID:          45,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "at-test-token",
+			"auth_mode":    OpenAIAuthModePersonalAccessToken,
+		},
+	}
+
+	result, err := service.ForwardAlphaSearch(context.Background(), c, account, body)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, int32(1), atomic.LoadInt32(&whoamiCalls))
+	require.Equal(t, "acct-123", upstream.lastReq.Header.Get("ChatGPT-Account-ID"))
+	require.Equal(t, "true", upstream.lastReq.Header.Get("X-OpenAI-Fedramp"))
+	require.Equal(t, "acct-123", account.Credentials["chatgpt_account_id"])
+	require.Equal(t, "user-123", account.Credentials["chatgpt_user_id"])
+	require.Equal(t, OpenAIAuthModePersonalAccessToken, account.Credentials["auth_mode"])
 }
 
 func TestForwardAlphaSearchAPIKeyMapsModelAndPassesThroughError(t *testing.T) {
@@ -142,4 +285,53 @@ func TestForwardAlphaSearchReturnsFailoverBeforeWriting(t *testing.T) {
 	require.Equal(t, openAIPlatformAlphaSearchURL, upstream.lastReq.URL.String())
 	require.False(t, c.Writer.Written())
 	require.Empty(t, recorder.Body.String())
+}
+
+func TestForwardAlphaSearchUnauthorizedDoesNotMarkAccountError(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	body := []byte(`{"id":"search-session","model":"gpt-5.6-sol","commands":{"search_query":[{"q":"news"}]}}`)
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/alpha/search", bytes.NewReader(body))
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusUnauthorized,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"detail":"Unauthorized"}`)),
+	}}
+	repo := &alphaSearchAccountStateRepo{}
+	cfg := &config.Config{}
+	service := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     upstream,
+		accountRepo:      repo,
+		rateLimitService: NewRateLimitService(repo, nil, cfg, nil, nil),
+	}
+	account := &Account{
+		ID:          44,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			// 刻意不设置 auth_mode：覆盖历史上把 at- token 当普通 OAuth 导入的账号。
+			"access_token":       "at-test-token",
+			"chatgpt_account_id": "chatgpt-account",
+		},
+	}
+
+	result, err := service.ForwardAlphaSearch(context.Background(), c, account, body)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusUnauthorized, failoverErr.StatusCode)
+	require.Zero(t, repo.setErrorCalls)
+	require.Empty(t, repo.lastError)
+	require.False(t, c.Writer.Written())
+}
+
+func TestShouldApplyOpenAIAlphaSearchAccountErrorSideEffects(t *testing.T) {
+	require.False(t, shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(http.StatusUnauthorized))
+	require.True(t, shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(http.StatusForbidden))
+	require.True(t, shouldApplyOpenAIAlphaSearchAccountErrorSideEffects(http.StatusTooManyRequests))
 }

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -492,7 +492,22 @@ func TestAccountSupportsOpenAIEndpointCapability(t *testing.T) {
 		}
 
 		require.True(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityChatCompletions))
+		require.True(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAlphaSearch))
 		require.False(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityEmbeddings))
+	})
+
+	t.Run("alpha search 仅允许 OpenAI OAuth/PAT 类账号", func(t *testing.T) {
+		apiKey := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeAPIKey,
+		}
+		oauth := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+		}
+
+		require.False(t, apiKey.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAlphaSearch))
+		require.True(t, oauth.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAlphaSearch))
 	})
 
 	t.Run("显式列表支持同时声明 chat 和 embeddings", func(t *testing.T) {
@@ -518,7 +533,20 @@ func TestAccountSupportsOpenAIEndpointCapability(t *testing.T) {
 		}
 
 		require.True(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityChatCompletions))
+		require.False(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAlphaSearch))
 		require.False(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityEmbeddings))
+	})
+
+	t.Run("OAuth 显式列表沿用 chat 能力放行 alpha search", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"openai_capabilities": []any{"chat_completions"},
+			},
+		}
+
+		require.True(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAlphaSearch))
 	})
 
 	t.Run("显式 map 支持单独关闭 chat 并开启 embeddings", func(t *testing.T) {


### PR DESCRIPTION
## 背景 / 问题

Codex/GPT-5.6 在触发 standalone `/v1/alpha/search` 网页检索时，使用 Codex Personal Access Token（`at-*` / `auth_mode=personalAccessToken`）的账号会被 ChatGPT 上游拒绝：

```text
HTTP 401 Unauthorized
rejected_by_access_enforcement / no_matching_rule
```

但同一个账号仍然可以正常调用 ChatGPT Codex `/backend-api/codex/responses`，并且 hosted `web_search` 工具可用。因此这个 401 不是账号整体失效，而是 `/backend-api/codex/alpha/search` 这个独立工具端点对 PAT 的 endpoint-scoped access enforcement。

线上表现通常是：

- `/alpha/search` 对客户端返回 502，内部上游状态为 401；
- 后续普通 `/responses` 请求仍然 200；
- 如果沿用通用 OAuth 401 处理逻辑，历史上还可能把可用账号误判为凭据失效 / disabled。

## 根因

1. Codex standalone `alpha/search` 是独立 SearchRequest 协议，不是 `/responses` 的子请求。
2. Codex PAT 当前可访问 ChatGPT Codex `/responses`，但会被 standalone `/backend-api/codex/alpha/search` 的 access enforcement 拒绝。
3. 部分 Responses Lite 公共 header/body 字段如果透传到 alpha/search，也会让上游按错误路径处理或返回 unknown parameter。
4. 历史导入的 PAT 账号可能使用 `personal_access_token` 旧标记，之前的类型判断不够兼容。

## 解决方案

本 PR 做了以下处理：

- 兼容识别 PAT：同时支持 `auth_mode=personalAccessToken` 和 `openai_auth_mode=personal_access_token`。
- PAT 账号走 fallback：把 standalone alpha search 转换为 ChatGPT Codex `/backend-api/codex/responses` 请求，并使用 hosted `web_search` 工具完成搜索。
- 将 `/responses` 的 SSE 输出转换回 alpha/search 期望的 JSON 结构，并收集 URL citations/results。
- 对缺少 ChatGPT account metadata 的 PAT 账号，在 alpha/search 前尝试补全并持久化元数据，避免请求头缺失。
- 非 PAT OAuth/API key 继续使用原 alpha/search 路径，但会剥离 Responses 专用 header/body 字段，保持官方 SearchClient 的最小线协议。
- alpha/search 的 401 只作为本次请求 failover 信号处理，不再触发账号永久错误/禁用副作用；真正的凭据失效仍交给普通 `/responses` 或 whoami 校验判断。

## 测试

已新增/更新覆盖：

- PAT alpha/search 会走 `/v1/responses` + `tools:[{"type":"web_search"}]` fallback；
- fallback 响应 SSE 可转换成 alpha/search JSON；
- PAT 账号缺少 metadata 时会补全 ChatGPT account headers；
- alpha/search 上游 401 不会标记账号 error；
- API key / OAuth 原有 alpha/search 行为保持兼容；
- body/header sanitize 行为保持稳定。

本地验证：

```bash
go test ./internal/service -run 'TestForwardAlphaSearch|TestShouldApplyOpenAIAlphaSearchAccountErrorSideEffects|TestOpenAIAlphaSearch|TestBuildOpenAIAlphaSearch|TestOpenAIAlphaSearchResponse' -count=1 -v
```

结果：PASS。
