### PR TITLE
[codex] fail over account-specific OpenAI body limits

### DIFF
--- a/backend/internal/handler/openai_body_limit_failover_test.go
+++ b/backend/internal/handler/openai_body_limit_failover_test.go
@@ -1,0 +1,58 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIBodyLimitFailoverExhausted_ReturnsRedactedJSON413(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+
+	(&OpenAIGatewayHandler{}).handleFailoverExhausted(c, bodyLimitFailoverTestError(), false)
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	var envelope map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
+	errBody := envelope["error"].(map[string]any)
+	require.Equal(t, "invalid_request_error", errBody["type"])
+	require.Equal(t, "Request payload is too large", errBody["message"])
+	require.NotContains(t, rec.Body.String(), "must-not-leak")
+}
+
+func TestOpenAIBodyLimitFailoverExhausted_ReturnsRedactedResponsesSSE(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+
+	(&OpenAIGatewayHandler{}).handleFailoverExhausted(c, bodyLimitFailoverTestError(), true)
+
+	body := rec.Body.String()
+	require.True(t, strings.HasPrefix(body, "event: response.failed\n"))
+	require.Contains(t, body, `"code":"invalid_request"`)
+	require.Contains(t, body, `"message":"Request payload is too large"`)
+	require.NotContains(t, body, "must-not-leak")
+}
+
+func bodyLimitFailoverTestError() *service.UpstreamFailoverError {
+	return &service.UpstreamFailoverError{
+		StatusCode:        http.StatusRequestEntityTooLarge,
+		ResponseBody:      []byte(`{"error":{"message":"proxy limit secret=must-not-leak"}}`),
+		Scope:             service.GatewayFailureScopeAccount,
+		Reason:            service.GatewayFailureReason("openai_request_body_too_large"),
+		NextAccountAction: service.NextAccountRetry,
+		ClientStatusCode:  http.StatusRequestEntityTooLarge,
+		ClientMessage:     "Request payload is too large",
+	}
+}

--- a/backend/internal/handler/openai_body_limit_failover_test.go
+++ b/backend/internal/handler/openai_body_limit_failover_test.go
@@ -24,7 +24,8 @@ func TestOpenAIBodyLimitFailoverExhausted_ReturnsRedactedJSON413(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 	var envelope map[string]any
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &envelope))
-	errBody := envelope["error"].(map[string]any)
+	errBody, ok := envelope["error"].(map[string]any)
+	require.True(t, ok)
 	require.Equal(t, "invalid_request_error", errBody["type"])
 	require.Equal(t, "Request payload is too large", errBody["message"])
 	require.NotContains(t, rec.Body.String(), "must-not-leak")

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2077,6 +2077,17 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 		h.handleFailoverExhaustedSimple(c, http.StatusBadGateway, streamStarted)
 		return
 	}
+	if failoverErr.IsOpenAIRequestBodyTooLarge() {
+		service.SetOpsUpstreamError(c, http.StatusRequestEntityTooLarge, service.OpenAIRequestBodyTooLargeClientMessage, "")
+		h.handleStreamingAwareError(
+			c,
+			http.StatusRequestEntityTooLarge,
+			"invalid_request_error",
+			service.OpenAIRequestBodyTooLargeClientMessage,
+			streamStarted,
+		)
+		return
+	}
 	copyFailoverRetryAfter(c, failoverErr.ResponseHeaders)
 	if failoverErr.IsCredentialFailure() {
 		status, message := credentialFailoverClientResponse(failoverErr)

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -115,12 +115,13 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	if account.Platform != PlatformGrok {
 		s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)
 	}
-	return &UpstreamFailoverError{
-		StatusCode:             resp.StatusCode,
-		ResponseBody:           respBody,
-		ResponseHeaders:        resp.Header.Clone(),
-		RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
-	}
+	return newOpenAIUpstreamFailoverError(
+		resp.StatusCode,
+		resp.Header,
+		respBody,
+		upstreamMsg,
+		account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+	)
 }
 
 // openAIChatCompletionsTargetURL 解析账号的（非 Grok）Chat Completions 上游端点。

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -856,11 +856,13 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				})
 
 				s.handleFailoverSideEffects(ctx, resp, account, respBody, upstreamModel)
-				return nil, &UpstreamFailoverError{
-					StatusCode:             resp.StatusCode,
-					ResponseBody:           respBody,
-					RetryableOnSameAccount: account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
-				}
+				return nil, newOpenAIUpstreamFailoverError(
+					resp.StatusCode,
+					resp.Header,
+					respBody,
+					upstreamMsg,
+					account.IsPoolMode() && (account.IsPoolModeRetryableStatus(resp.StatusCode) || isOpenAITransientProcessingError(resp.StatusCode, upstreamMsg, respBody)),
+				)
 			}
 			return s.handleErrorResponse(ctx, resp, c, account, body, billingModel)
 		}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -461,6 +461,9 @@ func shouldFailoverOpenAIPassthroughResponse(account *Account, statusCode int, r
 	if isOpenAIContextWindowError("", responseBody) {
 		return false
 	}
+	if isOpenAIRequestBodyTooLargeError(statusCode, "", responseBody) {
+		return true
+	}
 	switch statusCode {
 	case http.StatusTooManyRequests, 529:
 		return true
@@ -589,12 +592,13 @@ func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(
 		Detail:               upstreamDetail,
 		UpstreamResponseBody: upstreamDetail,
 	})
-	return &UpstreamFailoverError{
-		StatusCode:             resp.StatusCode,
-		ResponseBody:           body,
-		ResponseHeaders:        resp.Header.Clone(),
-		RetryableOnSameAccount: account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
-	}
+	return newOpenAIUpstreamFailoverError(
+		resp.StatusCode,
+		resp.Header,
+		body,
+		upstreamMsg,
+		account.IsPoolMode() && account.IsPoolModeRetryableStatus(resp.StatusCode),
+	)
 }
 
 func (s *OpenAIGatewayService) handleErrorResponsePassthrough(

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -222,10 +222,53 @@ func (s *OpenAIGatewayService) shouldFailoverOpenAIUpstreamResponse(statusCode i
 	if isOpenAIContextWindowError(upstreamMsg, upstreamBody) {
 		return false
 	}
+	if isOpenAIRequestBodyTooLargeError(statusCode, upstreamMsg, upstreamBody) {
+		return true
+	}
 	if s.shouldFailoverUpstreamError(statusCode) {
 		return true
 	}
 	return isOpenAITransientProcessingError(statusCode, upstreamMsg, upstreamBody)
+}
+
+// OpenAIRequestBodyTooLargeClientMessage is the fixed downstream message used
+// after all account-specific request body limit failovers are exhausted.
+const OpenAIRequestBodyTooLargeClientMessage = "Request payload is too large"
+
+const openAIRequestBodyTooLargeReason = GatewayFailureReason("openai_request_body_too_large")
+
+func isOpenAIRequestBodyTooLargeError(statusCode int, upstreamMsg string, upstreamBody []byte) bool {
+	return statusCode == http.StatusRequestEntityTooLarge && !isOpenAIContextWindowError(upstreamMsg, upstreamBody)
+}
+
+func newOpenAIUpstreamFailoverError(
+	statusCode int,
+	responseHeaders http.Header,
+	responseBody []byte,
+	upstreamMsg string,
+	retryableOnSameAccount bool,
+) *UpstreamFailoverError {
+	failoverErr := &UpstreamFailoverError{
+		StatusCode:             statusCode,
+		ResponseBody:           responseBody,
+		ResponseHeaders:        responseHeaders.Clone(),
+		RetryableOnSameAccount: retryableOnSameAccount,
+	}
+	if isOpenAIRequestBodyTooLargeError(statusCode, upstreamMsg, responseBody) {
+		failoverErr.RetryableOnSameAccount = false
+		failoverErr.Scope = GatewayFailureScopeAccount
+		failoverErr.Reason = openAIRequestBodyTooLargeReason
+		failoverErr.NextAccountAction = NextAccountRetry
+		failoverErr.ClientStatusCode = http.StatusRequestEntityTooLarge
+		failoverErr.ClientMessage = OpenAIRequestBodyTooLargeClientMessage
+	}
+	return failoverErr
+}
+
+// IsOpenAIRequestBodyTooLarge reports whether another account may accept the
+// same request even though the selected account rejected its serialized size.
+func (e *UpstreamFailoverError) IsOpenAIRequestBodyTooLarge() bool {
+	return e != nil && e.Reason == openAIRequestBodyTooLargeReason
 }
 
 func marshalOpenAIUpstreamJSON(v any) ([]byte, error) {
@@ -325,6 +368,27 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 			account.Platform,
 			account.Type,
 			truncateForLog(body, s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes),
+		)
+	}
+
+	if isOpenAIRequestBodyTooLargeError(resp.StatusCode, upstreamMsg, body) {
+		appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
+			Platform:           account.Platform,
+			AccountID:          account.ID,
+			AccountName:        account.Name,
+			UpstreamStatusCode: resp.StatusCode,
+			UpstreamRequestID:  resp.Header.Get("x-request-id"),
+			Kind:               "failover",
+			Message:            upstreamMsg,
+			Detail:             upstreamDetail,
+		})
+		s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, requestedModel...)
+		return nil, newOpenAIUpstreamFailoverError(
+			resp.StatusCode,
+			resp.Header,
+			body,
+			upstreamMsg,
+			false,
 		)
 	}
 

--- a/backend/internal/service/openai_request_body_limit_failover_test.go
+++ b/backend/internal/service/openai_request_body_limit_failover_test.go
@@ -1,0 +1,135 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIRequestBodyLimitFailover_HTTP413SwitchesAccountsBeforeWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestBody := []byte(`{"model":"gpt-5.2","stream":false,"input":"hello"}`)
+
+	for _, passthrough := range []bool{false, true} {
+		name := "native_responses"
+		if passthrough {
+			name = "api_key_passthrough"
+		}
+		t.Run(name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+
+			const upstreamBody = `{"error":{"message":"request body exceeds this account's 16MB proxy limit; secret=must-not-leak","type":"invalid_request_error"}}`
+			body := &passthroughCloseTrackingReadCloser{Reader: strings.NewReader(upstreamBody)}
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusRequestEntityTooLarge,
+				Header: http.Header{
+					"Content-Type": []string{"application/json"},
+					"X-Request-Id": []string{"rid-body-limit"},
+				},
+				Body: body,
+			}}
+			svc := &OpenAIGatewayService{
+				cfg:          &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+				httpUpstream: upstream,
+			}
+			account := &Account{
+				ID:          161,
+				Name:        name,
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":   "sk-test",
+					"base_url":  "https://api.example.test",
+					"pool_mode": true,
+					"pool_mode_retry_status_codes": []any{
+						float64(http.StatusRequestEntityTooLarge),
+					},
+				},
+				Extra: map[string]any{
+					"openai_passthrough":         passthrough,
+					"openai_responses_supported": true,
+				},
+				Status:      StatusActive,
+				Schedulable: true,
+			}
+
+			result, err := svc.Forward(context.Background(), c, account, requestBody)
+
+			require.Nil(t, result)
+			var failoverErr *UpstreamFailoverError
+			require.ErrorAs(t, err, &failoverErr)
+			require.Equal(t, http.StatusRequestEntityTooLarge, failoverErr.StatusCode)
+			require.Equal(t, GatewayFailureScopeAccount, failoverErr.Scope)
+			require.Equal(t, GatewayFailureReason("openai_request_body_too_large"), failoverErr.Reason)
+			require.Equal(t, NextAccountRetry, failoverErr.NextAccountAction)
+			require.Equal(t, http.StatusRequestEntityTooLarge, failoverErr.ClientStatusCode)
+			require.Equal(t, "Request payload is too large", failoverErr.ClientMessage)
+			require.False(t, failoverErr.RetryableOnSameAccount, "a body limit requires another account, not another attempt on the same account")
+			require.False(t, c.Writer.Written(), "account failover must happen before downstream output is committed")
+			require.Empty(t, rec.Body.String())
+			require.True(t, body.closed)
+			if passthrough {
+				require.Equal(t, requestBody, upstream.lastBody)
+			} else {
+				require.Equal(t, "gpt-5.2", gjson.GetBytes(upstream.lastBody, "model").String())
+				require.Equal(t, "hello", gjson.GetBytes(upstream.lastBody, "input").String())
+			}
+		})
+	}
+}
+
+func TestOpenAIRequestBodyLimitFailover_ContextWindow413DoesNotSwitchAccounts(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	requestBody := []byte(`{"model":"gpt-5.2","stream":false,"input":"hello"}`)
+
+	for _, passthrough := range []bool{false, true} {
+		t.Run(fmt.Sprintf("passthrough_%t", passthrough), func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(nil))
+
+			const upstreamBody = `{"error":{"message":"Your input exceeds the context window of this model. Please adjust your input and try again.","type":"invalid_request_error"}}`
+			body := &passthroughCloseTrackingReadCloser{Reader: strings.NewReader(upstreamBody)}
+			svc := &OpenAIGatewayService{
+				cfg: &config.Config{Gateway: config.GatewayConfig{ForceCodexCLI: false}},
+				httpUpstream: &httpUpstreamRecorder{resp: &http.Response{
+					StatusCode: http.StatusRequestEntityTooLarge,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body:       body,
+				}},
+			}
+			account := &Account{
+				ID: 162, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Concurrency: 1,
+				Credentials: map[string]any{"api_key": "sk-test", "base_url": "https://api.example.test"},
+				Extra: map[string]any{
+					"openai_passthrough":         passthrough,
+					"openai_responses_supported": true,
+				},
+				Status: StatusActive, Schedulable: true,
+			}
+
+			result, err := svc.Forward(context.Background(), c, account, requestBody)
+
+			require.Nil(t, result)
+			require.Error(t, err)
+			var failoverErr *UpstreamFailoverError
+			require.False(t, errors.As(err, &failoverErr), "context-window failures are deterministic request errors")
+			require.True(t, c.Writer.Written())
+			require.Contains(t, rec.Body.String(), "exceeds the context window")
+			require.True(t, body.closed)
+		})
+	}
+}


### PR DESCRIPTION
## Issue

OpenAI-compatible accounts can enforce different serialized request-body limits. When one selected account returned HTTP 413 for its proxy/body limit, the gateway treated the response as a terminal client error. Native Responses and API-key passthrough requests therefore stopped on the first undersized route instead of trying another eligible account, and exhaustion could be surfaced as a generic 502.

This is distinct from a model context-window error: changing accounts may help with an account-specific transport/body limit, but it cannot make a model accept more context.

## Root cause

The OpenAI HTTP failover classifiers did not include non-context-window 413 responses. The generic exhausted-failover path also had no typed metadata for preserving a safe downstream 413 after all accounts had been tried.

## Fix

- Classify HTTP 413 as a request-body-limit failure only when the upstream payload does not match the existing context-window detector.
- Mark that failure as account-scoped and retry the next account before downstream output is committed.
- Explicitly disable same-account retries for body-limit failures, including pool-mode configurations that list 413 as retryable.
- Apply the behavior to native OpenAI forwarding and API-key passthrough forwarding.
- After account exhaustion, return a fixed, redacted HTTP 413 with `Request payload is too large`.
- When a Responses SSE stream has already started, emit the same safe failure as a terminal `response.failed` event.

This PR intentionally does not add persistent/runtime body-limit learning, static account limits, or scheduler capability gates. Those are separate scheduling concerns and would substantially widen the review surface.

## Compatibility and safety

- Context-window 413 responses remain deterministic request errors and do not trigger account failover.
- Existing 5xx failover and passthrough sanitization behavior from #4304 and #4306 is preserved.
- Upstream bodies and request IDs are not exposed in the exhausted response.
- This complements rather than duplicates #4250: the special case here is a 413 that may be resolved by selecting another account; once accounts are exhausted, the downstream result is still a safe, redacted 413.

## Verification

TDD regression tests first reproduced the previous behavior: native and passthrough 413 responses did not produce a failover, JSON exhaustion returned 502, and SSE exhaustion returned a generic upstream error.

The final branch passes:

```text
go test ./internal/service ./internal/handler -count=1
go test -race ./internal/service -run 'TestOpenAIRequestBodyLimitFailover' -count=1
go test -race ./internal/handler -run 'TestOpenAIBodyLimitFailoverExhausted' -count=1
go vet ./internal/service ./internal/handler
git diff --check upstream/main...HEAD
```

The regression coverage includes native Responses, API-key passthrough, pool-mode same-account retry suppression, context-window 413 exclusion, redacted JSON exhaustion, and redacted Responses SSE exhaustion.
