### PR TITLE
fix(openai): allow disabling PAT web search routing

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1417,9 +1417,6 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 	if !found {
 		return true
 	}
-	if capability == OpenAIEndpointCapabilityAlphaSearch && configured[string(OpenAIEndpointCapabilityChatCompletions)] {
-		return true
-	}
 	return configured[string(capability)]
 }
 

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -599,6 +599,64 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_Embeddi
 	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
 }
 
+func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_AlphaSearchSkipsDisabledPAT(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(10114)
+	accounts := []Account{
+		{
+			ID:          36051,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    0,
+			Credentials: map[string]any{
+				"auth_mode":           OpenAIAuthModePersonalAccessToken,
+				"openai_capabilities": []any{"chat_completions"},
+			},
+		},
+		{
+			ID:          36052,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeOAuth,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    5,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = false
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              &schedulerTestGatewayCache{},
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	selection, decision, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportHTTPSSE,
+		OpenAIEndpointCapabilityAlphaSearch,
+		false,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(36052), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+}
+
 func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_AllowsGrokChatAccount(t *testing.T) {
 	resetOpenAIAdvancedSchedulerSettingCacheForTest()
 

--- a/backend/internal/service/openai_images_test.go
+++ b/backend/internal/service/openai_images_test.go
@@ -537,12 +537,25 @@ func TestAccountSupportsOpenAIEndpointCapability(t *testing.T) {
 		require.False(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityEmbeddings))
 	})
 
-	t.Run("OAuth 显式列表沿用 chat 能力放行 alpha search", func(t *testing.T) {
+	t.Run("OAuth 显式列表可独立关闭 alpha search", func(t *testing.T) {
 		account := &Account{
 			Platform: PlatformOpenAI,
 			Type:     AccountTypeOAuth,
 			Credentials: map[string]any{
 				"openai_capabilities": []any{"chat_completions"},
+			},
+		}
+
+		require.True(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityChatCompletions))
+		require.False(t, account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityAlphaSearch))
+	})
+
+	t.Run("OAuth 显式列表可开启 alpha search", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+			Credentials: map[string]any{
+				"openai_capabilities": []any{"chat_completions", "alpha_search"},
 			},
 		}
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1455,6 +1455,24 @@
         </div>
       </div>
 
+      <!-- Codex PAT standalone web search capability -->
+      <div
+        v-if="isOpenAIPersonalAccessTokenAccount"
+        class="flex items-center justify-between gap-4 border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div>
+          <label class="input-label mb-0">{{ t('admin.accounts.openai.codexWebSearch') }}</label>
+          <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {{ t('admin.accounts.openai.codexWebSearchDesc') }}
+          </p>
+        </div>
+        <Toggle
+          v-model="codexWebSearchEnabled"
+          data-testid="codex-pat-web-search"
+          :aria-label="t('admin.accounts.openai.codexWebSearch')"
+        />
+      </div>
+
       <!-- OpenAI Codex 图片工具统一策略（自动注入 + 客户端显式携带） -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -2804,6 +2822,7 @@ const editPlanType = ref<string>('')
 const openAICompactMode = ref<OpenAICompactMode>('auto')
 const openAIResponsesMode = ref<OpenAIResponsesMode>('auto')
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>(['chat_completions', 'embeddings'])
+const codexWebSearchEnabled = ref(true)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
@@ -2960,6 +2979,38 @@ const openAIEndpointCapabilityOptions = computed<{ value: OpenAIEndpointCapabili
 const openAITextGenerationCapabilityEnabled = computed(() =>
   openAIEndpointCapabilities.value.includes('chat_completions')
 )
+
+const isOpenAIPersonalAccessTokenCredentials = (credentials?: Record<string, unknown>) => {
+  const authMode = String(credentials?.auth_mode ?? credentials?.openai_auth_mode ?? '')
+    .trim()
+    .toLowerCase()
+  return authMode === 'personalaccesstoken' || authMode === 'personal_access_token'
+}
+
+const isOpenAIPersonalAccessTokenAccount = computed(() =>
+  props.account?.platform === 'openai' &&
+  props.account?.type === 'oauth' &&
+  isOpenAIPersonalAccessTokenCredentials(props.account.credentials as Record<string, unknown> | undefined)
+)
+
+const readCodexWebSearchEnabled = (credentials?: Record<string, unknown>) => {
+  const raw = credentials?.openai_capabilities
+  if (Array.isArray(raw)) {
+    return raw.includes('alpha_search')
+  }
+  if (raw !== null && typeof raw === 'object') {
+    return (raw as Record<string, unknown>).alpha_search === true
+  }
+  return true
+}
+
+const applyCodexWebSearchCapability = (credentials: Record<string, unknown>) => {
+  if (codexWebSearchEnabled.value) {
+    delete credentials.openai_capabilities
+    return
+  }
+  credentials.openai_capabilities = ['chat_completions']
+}
 
 const normalizeOpenAIEndpointCapabilities = (values: OpenAIEndpointCapability[]) => {
   const allowed: OpenAIEndpointCapability[] = ['chat_completions', 'embeddings']
@@ -3238,6 +3289,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   openAICompactMode.value = 'auto'
   openAIResponsesMode.value = 'auto'
   openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
+  codexWebSearchEnabled.value = true
   openAICompactModelMappings.value = []
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -3293,6 +3345,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
         extra?.codex_cli_only_allow_app_server === true
     }
     const credentials = newAccount.credentials as Record<string, unknown> | undefined
+    if (newAccount.type === 'oauth' && isOpenAIPersonalAccessTokenCredentials(credentials)) {
+      codexWebSearchEnabled.value = readCodexWebSearchEnabled(credentials)
+    }
     const compactMappings = credentials?.compact_model_mapping as Record<string, string> | undefined
     if (compactMappings && typeof compactMappings === 'object') {
       openAICompactModelMappings.value = Object.entries(compactMappings).map(([from, to]) => ({ from, to }))
@@ -4236,6 +4291,9 @@ const handleSubmit = async () => {
       const newCredentials: Record<string, unknown> = { ...currentCredentials }
       if (props.account.platform === 'openai') {
         applyOpenAIModelMappingCredentials(newCredentials)
+        if (isOpenAIPersonalAccessTokenAccount.value) {
+          applyCodexWebSearchCapability(newCredentials)
+        }
       } else {
         const modelMapping = buildModelRestrictionMapping()
         if (modelMapping) {

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -190,6 +190,23 @@ function buildOpenAISparkShadowAccount() {
   } as any
 }
 
+function buildOpenAIPATAccount() {
+  const account = buildAccount()
+  return {
+    ...account,
+    id: 6,
+    name: 'Codex PAT',
+    type: 'oauth',
+    credentials: {
+      auth_mode: 'personalAccessToken',
+      openai_auth_mode: 'personal_access_token'
+    },
+    credentials_status: {
+      has_access_token: true
+    }
+  } as any
+}
+
 function buildVertexAccount() {
   return {
     id: 2,
@@ -645,6 +662,35 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock.mock.calls[0]?.[1]?.credentials?.openai_capabilities).toEqual([
       'chat_completions'
     ])
+  })
+
+  it('disables Codex web search routing for a PAT account', async () => {
+    const account = buildOpenAIPATAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="codex-pat-web-search"]')
+
+    expect(toggle.attributes('aria-checked')).toBe('true')
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.credentials?.openai_capabilities).toEqual([
+      'chat_completions'
+    ])
+  })
+
+  it('does not show the Codex web search switch for regular OpenAI OAuth', async () => {
+    const account = buildOpenAIPATAccount()
+    account.credentials = { auth_mode: 'oauth' }
+
+    const wrapper = mountModal(account)
+
+    expect(wrapper.find('[data-testid="codex-pat-web-search"]').exists()).toBe(false)
   })
 
 	it('submits OpenAI quota auto-pause thresholds in extra', async () => {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -489,6 +489,9 @@ export default {
         codexCLIOnlyAppServer: 'Allow Codex app-server clients',
         codexCLIOnlyAppServerDesc:
           "Effective only when the switch above is on. When enabled, this account also allows third-party clients that embed the Codex engine over the app-server protocol (e.g. Claude Code's codex plugin); they still pass the global engine-fingerprint gate. OR-combined with the global app-server toggle.",
+        codexWebSearch: 'Codex web search',
+        codexWebSearchDesc:
+          'When disabled, this PAT account is excluded from /alpha/search routing, avoiding repeated 401 responses when the PAT cannot use web search.',
         codexImageTool: 'Codex image tool',
         codexImageToolDesc:
           'One policy for the image_generation tool on Codex /responses text requests: whether it is auto-injected, and whether client-provided tools pass through. Account policy takes precedence over channel and global settings; standalone image-generation endpoints are unaffected.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -587,6 +587,8 @@ export default {
         codexCLIOnlyDesc: '仅对 OpenAI OAuth 生效。开启后仅允许 Codex 官方客户端家族访问；关闭后完全绕过并保持原逻辑。',
         codexCLIOnlyAppServer: '允许 Codex app-server 客户端',
         codexCLIOnlyAppServerDesc: '仅在上方开关开启时生效。开启后本账号额外放行内嵌 Codex 引擎、经 app-server 协议接入的第三方客户端（如 Claude Code 的 codex 插件），仍需通过全局引擎指纹门；与全局 app-server 开关取 OR（任一开即放行）。',
+        codexWebSearch: 'Codex 网页搜索',
+        codexWebSearchDesc: '关闭后，此 PAT 账号不会参与 /alpha/search 调度，可避免 PAT 不支持网页搜索时连续产生 401。',
         codexImageTool: 'Codex 图片工具',
         codexImageToolDesc:
           '统一控制 Codex /responses 文本请求的 image_generation 图片工具：是否自动注入，以及客户端自带该工具时是否放行。账号级策略优先于渠道和全局配置，不影响独立图片生成接口。',

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1176,7 +1176,7 @@ export interface CodexUsageSnapshot {
 
 export type OpenAICompactMode = 'auto' | 'force_on' | 'force_off'
 export type OpenAIResponsesMode = 'auto' | 'force_responses' | 'force_chat_completions'
-export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings'
+export type OpenAIEndpointCapability = 'chat_completions' | 'embeddings' | 'alpha_search'
 
 export interface OpenAICompactState {
   openai_compact_mode?: OpenAICompactMode


### PR DESCRIPTION
## Summary

- allow OpenAI account capabilities to explicitly disable `alpha_search`
- add a Codex web search toggle for Personal Access Token accounts
- exclude PAT accounts with web search disabled from `/alpha/search` scheduling
- add backend scheduler and frontend interaction regression tests

## Problem

Codex Personal Access Token accounts may not support `/v1/alpha/search`.
Search requests could therefore cycle through PAT accounts and produce repeated
401 responses before finding a compatible account.

## Testing

- `go test ./internal/service ./internal/handler ./internal/server/routes`
- `pnpm exec vitest run src/components/account/__tests__/EditAccountModal.spec.ts`
- `pnpm run typecheck`
- `pnpm run build`