### PR TITLE
fix(i18n): 代理"失败回退"改名"到期回退"，与实际行为一致

### DIFF
--- a/frontend/src/i18n/locales/en/admin/resources.ts
+++ b/frontend/src/i18n/locales/en/admin/resources.ts
@@ -231,7 +231,7 @@ export default {
       nDays: '{days}d',
       expiryDaysPlaceholder: 'Custom days, empty = never',
       expiryWarnDays: 'Expiry warning (days)',
-      fallbackMode: 'Failure fallback',
+      fallbackMode: 'Expiry fallback',
       fallbackNone: 'No fallback',
       fallbackProxy: 'Backup proxy',
       fallbackDirect: 'Direct connection',

--- a/frontend/src/i18n/locales/zh/admin/resources.ts
+++ b/frontend/src/i18n/locales/zh/admin/resources.ts
@@ -229,7 +229,7 @@ export default {
       nDays: '{days} 天',
       expiryDaysPlaceholder: '自定义天数，留空 = 永不过期',
       expiryWarnDays: '到期提醒提前天数',
-      fallbackMode: '失败回退',
+      fallbackMode: '到期回退',
       fallbackNone: '不回退',
       fallbackProxy: '指定备用代理',
       fallbackDirect: '回退直连',


### PR DESCRIPTION
代理编辑框里的"失败回退"实际上只在代理**有效期到期**时生效：后台任务 `SweepExpiredProxies` 每分钟扫描一次，把到期代理上绑定的账号改投到备用代理或直连。代理连不上（连接失败）不会触发切换。

叫"失败回退"容易让人以为主代理挂了会自动切备用，实测切不了还以为是 bug（我就是这么踩的, 还测了好几次看了源码才理解）。
所以把标签改成"到期回退"（英文 Failure fallback → Expiry fallback），只改文案，不动逻辑。