### PR TITLE
feat(keys): add has-usage/no-usage filters to API key status dropdown

### DIFF
--- a/backend/internal/handler/api_key_handler.go
+++ b/backend/internal/handler/api_key_handler.go
@@ -62,6 +62,36 @@ type UpdateAPIKeyRequest struct {
 	ResetRateLimitUsage *bool    `json:"reset_rate_limit_usage"` // 重置限速用量
 }
 
+// parseAPIKeyListFilters extracts list filters from query parameters.
+// status supports real key statuses plus pseudo-values has_usage / no_usage
+// for filtering by whether the key has ever been used (last_used_at).
+func parseAPIKeyListFilters(c *gin.Context) service.APIKeyListFilters {
+	var filters service.APIKeyListFilters
+	if search := strings.TrimSpace(c.Query("search")); search != "" {
+		if len(search) > 100 {
+			search = search[:100]
+		}
+		filters.Search = search
+	}
+	switch status := c.Query("status"); status {
+	case service.APIKeyFilterStatusHasUsage:
+		hasUsage := true
+		filters.HasUsage = &hasUsage
+	case service.APIKeyFilterStatusNoUsage:
+		hasUsage := false
+		filters.HasUsage = &hasUsage
+	default:
+		filters.Status = status
+	}
+	if groupIDStr := c.Query("group_id"); groupIDStr != "" {
+		gid, err := strconv.ParseInt(groupIDStr, 10, 64)
+		if err == nil {
+			filters.GroupID = &gid
+		}
+	}
+	return filters
+}
+
 // List handles listing user's API keys with pagination
 // GET /api/v1/api-keys
 func (h *APIKeyHandler) List(c *gin.Context) {
@@ -79,21 +109,7 @@ func (h *APIKeyHandler) List(c *gin.Context) {
 		SortOrder: c.DefaultQuery("sort_order", "desc"),
 	}
 
-	// Parse filter parameters
-	var filters service.APIKeyListFilters
-	if search := strings.TrimSpace(c.Query("search")); search != "" {
-		if len(search) > 100 {
-			search = search[:100]
-		}
-		filters.Search = search
-	}
-	filters.Status = c.Query("status")
-	if groupIDStr := c.Query("group_id"); groupIDStr != "" {
-		gid, err := strconv.ParseInt(groupIDStr, 10, 64)
-		if err == nil {
-			filters.GroupID = &gid
-		}
-	}
+	filters := parseAPIKeyListFilters(c)
 
 	keys, result, err := h.apiKeyService.List(c.Request.Context(), subject.UserID, params, filters)
 	if err != nil {

--- a/backend/internal/handler/api_key_list_filters_test.go
+++ b/backend/internal/handler/api_key_list_filters_test.go
@@ -1,0 +1,68 @@
+//go:build unit
+
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAPIKeyListStatusFilter(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name           string
+		statusQuery    string
+		wantStatus     string
+		wantHasUsage   *bool
+	}{
+		{
+			name:        "empty status",
+			statusQuery: "",
+			wantStatus:  "",
+		},
+		{
+			name:        "real status active",
+			statusQuery: "active",
+			wantStatus:  "active",
+		},
+		{
+			name:         "has_usage pseudo status",
+			statusQuery:  service.APIKeyFilterStatusHasUsage,
+			wantStatus:   "",
+			wantHasUsage: boolPtr(true),
+		},
+		{
+			name:         "no_usage pseudo status",
+			statusQuery:  service.APIKeyFilterStatusNoUsage,
+			wantStatus:   "",
+			wantHasUsage: boolPtr(false),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := gin.CreateTestContext(httptest.NewRecorder())
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/api-keys?status="+tt.statusQuery, nil)
+			c.Request = req
+
+			filters := parseAPIKeyListFilters(c)
+			require.Equal(t, tt.wantStatus, filters.Status)
+			if tt.wantHasUsage == nil {
+				require.Nil(t, filters.HasUsage)
+			} else {
+				require.NotNil(t, filters.HasUsage)
+				require.Equal(t, *tt.wantHasUsage, *filters.HasUsage)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/backend/internal/repository/api_key_repo.go
+++ b/backend/internal/repository/api_key_repo.go
@@ -415,6 +415,13 @@ func (r *apiKeyRepository) apiKeyListByUserIDQuery(userID int64, filters service
 			q = q.Where(apikey.GroupIDEQ(*filters.GroupID))
 		}
 	}
+	if filters.HasUsage != nil {
+		if *filters.HasUsage {
+			q = q.Where(apikey.LastUsedAtNotNil())
+		} else {
+			q = q.Where(apikey.LastUsedAtIsNil())
+		}
+	}
 
 	return q
 }

--- a/backend/internal/service/api_key.go
+++ b/backend/internal/service/api_key.go
@@ -137,9 +137,16 @@ func (k *APIKey) EffectiveUsage7d() float64 {
 	return k.Usage7d
 }
 
+// API key list pseudo-status values for usage filtering (not real key statuses).
+const (
+	APIKeyFilterStatusHasUsage = "has_usage"
+	APIKeyFilterStatusNoUsage  = "no_usage"
+)
+
 // APIKeyListFilters holds optional filtering parameters for listing API keys.
 type APIKeyListFilters struct {
-	Search  string
-	Status  string
-	GroupID *int64 // nil=不筛选, 0=无分组, >0=指定分组
+	Search   string
+	Status   string
+	GroupID  *int64 // nil=不筛选, 0=无分组, >0=指定分组
+	HasUsage *bool  // nil=不筛选, true=有用量(last_used_at 非空), false=无用量(last_used_at 为空)
 }

--- a/backend/internal/service/api_key_service_delete_test.go
+++ b/backend/internal/service/api_key_service_delete_test.go
@@ -114,7 +114,7 @@ func (s *apiKeyRepoStub) ListByUserID(ctx context.Context, userID int64, params 
 	if s.listByUserIDErr != nil {
 		return nil, nil, s.listByUserIDErr
 	}
-	keys := append([]APIKey(nil), s.listByUserIDKeys...)
+	keys := filterAPIKeyStubKeys(userID, s.listByUserIDKeys, filters)
 	return keys, &pagination.PaginationResult{
 		Total:    int64(len(keys)),
 		Page:     params.Page,
@@ -160,6 +160,12 @@ func filterAPIKeyStubKeys(userID int64, keys []APIKey, filters APIKeyListFilters
 					continue
 				}
 			} else if key.GroupID == nil || *key.GroupID != *filters.GroupID {
+				continue
+			}
+		}
+		if filters.HasUsage != nil {
+			hasUsage := key.LastUsedAt != nil
+			if *filters.HasUsage != hasUsage {
 				continue
 			}
 		}
@@ -351,6 +357,39 @@ func TestApiKeyService_Delete_NotFound(t *testing.T) {
 	require.Empty(t, repo.deletedIDs)
 	require.Empty(t, cache.invalidated)
 	require.Empty(t, cache.deleteAuthKeys)
+}
+
+func TestAPIKeyService_List_FiltersByHasUsage(t *testing.T) {
+	usedAt := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	keys := []APIKey{
+		{ID: 1, UserID: 7, Key: "sk-used", Name: "used", Status: StatusActive, LastUsedAt: &usedAt},
+		{ID: 2, UserID: 7, Key: "sk-unused", Name: "unused", Status: StatusActive},
+		{ID: 3, UserID: 7, Key: "sk-used-2", Name: "used-2", Status: StatusDisabled, LastUsedAt: &usedAt},
+	}
+	repo := &apiKeyRepoStub{
+		allowListByUserID: true,
+		listByUserIDKeys:  keys,
+	}
+	svc := &APIKeyService{apiKeyRepo: repo}
+
+	hasUsage := true
+	got, page, err := svc.List(context.Background(), 7, pagination.PaginationParams{Page: 1, PageSize: 20}, APIKeyListFilters{
+		HasUsage: &hasUsage,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 3}, apiKeyTestIDs(got))
+	require.Equal(t, int64(2), page.Total)
+	require.Len(t, repo.listByUserIDFilters, 1)
+	require.NotNil(t, repo.listByUserIDFilters[0].HasUsage)
+	require.True(t, *repo.listByUserIDFilters[0].HasUsage)
+
+	noUsage := false
+	got, page, err = svc.List(context.Background(), 7, pagination.PaginationParams{Page: 1, PageSize: 20}, APIKeyListFilters{
+		HasUsage: &noUsage,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []int64{2}, apiKeyTestIDs(got))
+	require.Equal(t, int64(1), page.Total)
 }
 
 func TestAPIKeyService_List_FillsCurrentConcurrency(t *testing.T) {

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -248,6 +248,8 @@ export default {
       inactive: 'Inactive',
       quota_exhausted: 'Quota Exhausted',
       expired: 'Expired',
+      has_usage: 'Has Usage',
+      no_usage: 'No Usage',
     },
   },
 

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -252,7 +252,9 @@ export default {
       active: '活跃',
       inactive: '已停用',
       quota_exhausted: '额度耗尽',
-      expired: '已过期'
+      expired: '已过期',
+      has_usage: '有用量',
+      no_usage: '无用量'
     }
   },
 

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -1389,7 +1389,9 @@ const statusFilterOptions = computed(() => [
   { value: 'active', label: t('keys.status.active') },
   { value: 'inactive', label: t('keys.status.inactive') },
   { value: 'quota_exhausted', label: t('keys.status.quota_exhausted') },
-  { value: 'expired', label: t('keys.status.expired') }
+  { value: 'expired', label: t('keys.status.expired') },
+  { value: 'has_usage', label: t('keys.status.has_usage') },
+  { value: 'no_usage', label: t('keys.status.no_usage') }
 ])
 
 const onFilterChange = () => {

--- a/frontend/src/views/user/__tests__/KeysView.spec.ts
+++ b/frontend/src/views/user/__tests__/KeysView.spec.ts
@@ -52,6 +52,8 @@ const messages: Record<string, string> = {
   'keys.status.expired': 'Expired',
   'keys.status.inactive': 'Inactive',
   'keys.status.quota_exhausted': 'Quota exhausted',
+  'keys.status.has_usage': 'Has Usage',
+  'keys.status.no_usage': 'No Usage',
   'keys.usage': 'Usage',
 }
 
@@ -435,6 +437,49 @@ describe('user KeysView column settings', () => {
         sort_by: 'current_concurrency',
         sort_order: 'asc',
       },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+  })
+
+  it('supports filtering by has_usage and no_usage status options', async () => {
+    const wrapper = await mountView()
+    const selects = wrapper.findAllComponents({ name: 'Select' })
+    const statusSelect = selects[1]
+
+    expect(statusSelect.props('options')).toEqual(
+      expect.arrayContaining([
+        { value: 'has_usage', label: 'Has Usage' },
+        { value: 'no_usage', label: 'No Usage' },
+      ])
+    )
+
+    listKeys.mockClear()
+    await statusSelect.vm.$emit('update:modelValue', 'has_usage')
+    await flushPromises()
+
+    expect(listKeys).toHaveBeenLastCalledWith(
+      1,
+      20,
+      expect.objectContaining({
+        status: 'has_usage',
+        sort_by: 'created_at',
+        sort_order: 'desc',
+      }),
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+
+    listKeys.mockClear()
+    await statusSelect.vm.$emit('update:modelValue', 'no_usage')
+    await flushPromises()
+
+    expect(listKeys).toHaveBeenLastCalledWith(
+      1,
+      20,
+      expect.objectContaining({
+        status: 'no_usage',
+        sort_by: 'created_at',
+        sort_order: 'desc',
+      }),
       expect.objectContaining({ signal: expect.any(AbortSignal) })
     )
   })


### PR DESCRIPTION
## Summary
- Add **有用量 / 无用量** (Has Usage / No Usage) options to the API key status filter dropdown on the user Keys page.
- Backend maps these pseudo-status values to `last_used_at IS NOT NULL` / `IS NULL` filters so users can find used or unused keys alongside existing group/status filters.
- Cover handler status parsing, service list filtering, and frontend dropdown behavior with unit tests.

## Changes
- **Backend**
  - `APIKeyListFilters.HasUsage *bool` for usage filtering
  - `status=has_usage` / `status=no_usage` query values (pseudo-status, not real key statuses)
  - Repository filters on `last_used_at`
- **Frontend**
  - Status dropdown options: 有用量 / 无用量 (zh) and Has Usage / No Usage (en)
  - Passes through existing `status` query param (no API shape change for clients)

## Test plan
- [x] Frontend: `pnpm test:run src/views/user/__tests__/KeysView.spec.ts` (10 passed)
- [ ] Backend unit tests (local Go install unavailable in this environment):
  - `go test -tags=unit ./internal/handler/ -run TestParseAPIKeyListStatusFilter`
  - `go test -tags=unit ./internal/service/ -run TestAPIKeyService_List_FiltersByHasUsage`
- [ ] Manual: open Keys page → status dropdown → select 有用量 / 无用量 and confirm list updates
- [ ] Manual: combine with group filter and search
- [ ] Manual: confirm real statuses (active/inactive/quota_exhausted/expired) still work