### PR TITLE
fix(openai): strip unsupported input namespace fields

### DIFF
--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -563,6 +563,13 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 	normalized := body
 	changed := false
 
+	if next, patched, err := stripOpenAIInputNamespaceFields(normalized); err != nil {
+		return body, false, err
+	} else if patched {
+		normalized = next
+		changed = true
+	}
+
 	for _, field := range openAIChatGPTInternalUnsupportedFields {
 		if value := gjson.GetBytes(normalized, field); !value.Exists() {
 			continue
@@ -612,6 +619,56 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 	}
 
 	return normalized, changed, nil
+}
+
+func stripOpenAIInputNamespaceFields(body []byte) ([]byte, bool, error) {
+	if len(body) == 0 || !bytes.Contains(body, []byte(`"namespace"`)) {
+		return body, false, nil
+	}
+
+	var req map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	decoder.UseNumber()
+	if err := decoder.Decode(&req); err != nil {
+		return body, false, fmt.Errorf("parse passthrough body for namespace cleanup: %w", err)
+	}
+	input, ok := req["input"]
+	if !ok || !stripNamespaceFields(input) {
+		return body, false, nil
+	}
+
+	normalized, err := json.Marshal(req)
+	if err != nil {
+		return body, false, fmt.Errorf("marshal passthrough body after namespace cleanup: %w", err)
+	}
+	return normalized, true, nil
+}
+
+func stripNamespaceFields(value any) bool {
+	switch typed := value.(type) {
+	case map[string]any:
+		changed := false
+		if _, ok := typed["namespace"]; ok {
+			delete(typed, "namespace")
+			changed = true
+		}
+		for _, child := range typed {
+			if stripNamespaceFields(child) {
+				changed = true
+			}
+		}
+		return changed
+	case []any:
+		changed := false
+		for _, child := range typed {
+			if stripNamespaceFields(child) {
+				changed = true
+			}
+		}
+		return changed
+	default:
+		return false
+	}
 }
 
 func detectOpenAIPassthroughInstructionsRejectReason(reqModel string, body []byte) string {

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -31,3 +31,17 @@ func TestNormalizeOpenAIPassthroughOAuthBody_CompactRemovesUnsupportedUser(t *te
 	require.False(t, gjson.GetBytes(normalized, "stream").Exists())
 	require.False(t, gjson.GetBytes(normalized, "store").Exists())
 }
+
+func TestNormalizeOpenAIPassthroughOAuthBody_StripsInputNamespaceOnly(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.6-sol","input":[{"type":"message","role":"user","namespace":"codex","sequence_number":9007199254740993,"content":[{"type":"input_text","text":"namespace stays in text","namespace":"inner"}]},{"type":"function_call","namespace":"shell","arguments":"{}"}],"tools":[{"type":"namespace","namespace":"functions"}]}`)
+
+	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.False(t, gjson.GetBytes(normalized, "input.0.namespace").Exists())
+	require.False(t, gjson.GetBytes(normalized, "input.0.content.0.namespace").Exists())
+	require.False(t, gjson.GetBytes(normalized, "input.1.namespace").Exists())
+	require.Equal(t, "9007199254740993", gjson.GetBytes(normalized, "input.0.sequence_number").Raw)
+	require.Equal(t, "namespace stays in text", gjson.GetBytes(normalized, "input.0.content.0.text").String())
+	require.Equal(t, "functions", gjson.GetBytes(normalized, "tools.0.namespace").String())
+}


### PR DESCRIPTION
## Summary
Fix OAuth passthrough requests that contain unsupported `namespace` fields inside the Responses `input` payload.

## Behavior
- Recursively removes `namespace` only below the top-level `input` field.
- Preserves namespaces in `tools` and other top-level fields.
- Uses `json.Decoder.UseNumber()` so large JSON numbers are not rounded during normalization.
- Leaves the request unchanged when no input namespace is present.

This targets the OAuth passthrough path and complements the native Responses namespace handling.

## Validation
- `go test -p 2 -tags=unit ./internal/service -run TestNormalizeOpenAIPassthroughOAuthBody -count=1`