### PR TITLE
fix(frontend): lazy-load Stripe payment dependency

### DIFF
--- a/frontend/src/components/payment/StripePaymentInline.vue
+++ b/frontend/src/components/payment/StripePaymentInline.vue
@@ -111,7 +111,7 @@ let elementsInstance: StripeElements | null = null
 
 onMounted(async () => {
   try {
-    const { loadStripe } = await import('@stripe/stripe-js')
+    const { loadStripe } = await import('@stripe/stripe-js/pure')
     const stripe = await loadStripe(props.publishableKey)
     if (!stripe) { initError.value = t('payment.stripeLoadFailed'); return }
 

--- a/frontend/src/views/user/StripePaymentView.vue
+++ b/frontend/src/views/user/StripePaymentView.vue
@@ -165,7 +165,7 @@ onMounted(async () => {
     const publishableKey = paymentStore.config?.stripe_publishable_key
     if (!publishableKey) { initError.value = t('payment.stripeNotConfigured'); return }
 
-    const { loadStripe } = await import('@stripe/stripe-js')
+    const { loadStripe } = await import('@stripe/stripe-js/pure')
     const stripe = await loadStripe(publishableKey)
     if (!stripe) { initError.value = t('payment.stripeLoadFailed'); return }
 

--- a/frontend/src/views/user/StripePopupView.vue
+++ b/frontend/src/views/user/StripePopupView.vue
@@ -137,7 +137,7 @@ async function initStripe(clientSecret: string, publishableKey: string) {
     return
   }
   try {
-    const { loadStripe } = await import('@stripe/stripe-js')
+    const { loadStripe } = await import('@stripe/stripe-js/pure')
     const stripe = await loadStripe(publishableKey)
     if (!stripe) { error.value = t('payment.stripeLoadFailed'); return }
 

--- a/frontend/src/views/user/__tests__/StripePaymentView.spec.ts
+++ b/frontend/src/views/user/__tests__/StripePaymentView.spec.ts
@@ -56,7 +56,7 @@ vi.mock('@/api/payment', () => ({
   },
 }))
 
-vi.mock('@stripe/stripe-js', () => ({
+vi.mock('@stripe/stripe-js/pure', () => ({
   loadStripe,
 }))
 

--- a/frontend/src/views/user/__tests__/stripeLazyLoading.spec.ts
+++ b/frontend/src/views/user/__tests__/stripeLazyLoading.spec.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const frontendRoot = resolve(__dirname, '../../../..')
+const stripeConsumers = [
+  'src/views/user/StripePaymentView.vue',
+  'src/views/user/StripePopupView.vue',
+  'src/components/payment/StripePaymentInline.vue',
+]
+
+function readFrontendFile(path: string): string {
+  return readFileSync(resolve(frontendRoot, path), 'utf8')
+}
+
+describe('Stripe lazy-loading contract', () => {
+  it.each(stripeConsumers)('%s uses the side-effect-free Stripe loader', (path) => {
+    const source = readFrontendFile(path)
+
+    expect(source).toContain("await import('@stripe/stripe-js/pure')")
+    expect(source).not.toMatch(/await import\(['"]@stripe\/stripe-js['"]\)/)
+  })
+
+  it('keeps Stripe out of the shared vendor chunk', () => {
+    const viteConfig = readFrontendFile('vite.config.ts')
+    const stripeRule = viteConfig.indexOf("id.includes('/@stripe/stripe-js/')")
+    const miscFallback = viteConfig.indexOf("return 'vendor-misc'")
+
+    expect(stripeRule).toBeGreaterThan(-1)
+    expect(viteConfig.slice(stripeRule, miscFallback)).toContain("return 'vendor-stripe'")
+    expect(stripeRule).toBeLessThan(miscFallback)
+  })
+})

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -96,6 +96,11 @@ export default defineConfig(({ mode }) => {
               return 'vendor-i18n'
             }
 
+            // Stripe 仅在支付流程中按需加载，避免进入首页公共依赖。
+            if (id.includes('/@stripe/stripe-js/')) {
+              return 'vendor-stripe'
+            }
+
             // 其他小型第三方库合并
             return 'vendor-misc'
           }


### PR DESCRIPTION
## 问题

首页公共 `vendor-misc` 包含 `@stripe/stripe-js` 默认入口。该入口在模块执行时会主动加载远程 Stripe.js，即使支付功能未启用，也可能因网络波动阻塞页面加载。

## 根因

三个支付入口虽然使用动态导入，但目标仍是带自动加载副作用的 `@stripe/stripe-js` 默认入口；同时 Vite 将 Stripe 合并进公共 `vendor-misc`，使非支付页面也会下载该依赖。

## 改动

- 三个 Stripe 支付入口改为动态导入无副作用的 `@stripe/stripe-js/pure`
- 将 Stripe 单独拆分为按需加载的 `vendor-stripe` chunk
- 更新现有 Stripe 组件测试 mock
- 增加构建契约测试，防止默认入口或公共分包回归

## 测试

- 新增测试先在旧实现上确认 4 个预期失败，再完成修复
- `vitest` 支付相关测试：5 个文件、27 个测试全部通过
- `vue-tsc --noEmit` 通过
- 变更文件 ESLint 通过
- `pnpm run build` 通过，921 个模块完成转换
- 构建产物生成独立 `vendor-stripe`，首页入口无静态引用，`vendor-misc` 不含 Stripe loader
- `git diff --check` 通过

Fixes #4442
