### PR TITLE
feat: 支持从 API Key 账号名称跳转上游站点主页

### DIFF
--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -252,7 +252,24 @@
           </template>
           <template #cell-name="{ row, value }">
             <div class="flex flex-col">
-              <span class="font-medium text-gray-900 dark:text-white">{{ value }}</span>
+              <HelpTooltip
+                v-if="accountHomepageUrl(row)"
+                :content="accountHomepageUrl(row)"
+                width-class="w-max max-w-sm break-all"
+                class="-ml-1 self-start"
+              >
+                <template #trigger>
+                  <a
+                    :href="accountHomepageUrl(row)"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="border-b border-dotted border-gray-300 font-medium text-gray-900 dark:border-gray-600 dark:text-white"
+                  >
+                    {{ value }}
+                  </a>
+                </template>
+              </HelpTooltip>
+              <span v-else class="font-medium text-gray-900 dark:text-white">{{ value }}</span>
               <span
                 v-if="accountDisplayEmail(row)"
                 class="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[200px]"
@@ -520,6 +537,7 @@ import { buildOpenAIUsageRefreshKey } from '@/utils/accountUsageRefresh'
 import { formatDateTime, formatRelativeTime } from '@/utils/format'
 import { proxyExpiryBadgeClass, proxyExpiryLabelKey } from '@/utils/proxyExpiry'
 import { extractApiErrorMessage } from '@/utils/apiError'
+import { sanitizeUrl } from '@/utils/url'
 import type { Account, AccountPlatform, AccountSchedulerGroupScore, AccountType, Proxy as AccountProxy, AdminGroup, WindowStats, ClaudeModel, UpstreamBillingProbeSettings, UpstreamBillingProbeSnapshot } from '@/types'
 
 const { t } = useI18n()
@@ -1290,6 +1308,12 @@ function getAntigravityTierLabel(row: any): string | null {
 // 供名称单元格 v-if/标题/文本三处共用,避免同一回退链在模板里重复三次。
 function accountDisplayEmail(row: any): string {
   return row.extra?.email_address || row.extra?.email || row.credentials?.email || row.parent_email || ''
+}
+
+function accountHomepageUrl(row: Account): string {
+  if (row.type !== 'apikey' || typeof row.credentials?.base_url !== 'string') return ''
+  const baseUrl = sanitizeUrl(row.credentials.base_url)
+  return baseUrl ? new URL(baseUrl).origin : ''
 }
 
 type OpenAICompactBadgeState = 'active' | 'blocked' | 'auto'

--- a/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.sparkShadow.spec.ts
@@ -5,6 +5,7 @@ import AccountsView from '../AccountsView.vue'
 import AccountActionMenu from '@/components/admin/account/AccountActionMenu.vue'
 import PlatformTypeBadge from '@/components/common/PlatformTypeBadge.vue'
 import ConfirmDialog from '@/components/common/ConfirmDialog.vue'
+import HelpTooltip from '@/components/common/HelpTooltip.vue'
 
 // 外审 F2:AccountActionMenu emit 'create-spark-shadow',但 AccountsView 此前未监听,
 // 导致按钮点击无效。本测试通过真实组件引用 emit 该事件,断言父页面接线调用 API。
@@ -207,7 +208,7 @@ describe('admin AccountsView — 外审 F2:spark 影子创建接线', () => {
   })
 })
 
-// Task 6: 影子行 parent_* OR 兜底展示
+// 账号行展示
 const mountViewWithRow = () =>
   mount(AccountsView, {
     global: {
@@ -255,7 +256,7 @@ const mountViewWithRow = () =>
     }
   })
 
-describe('admin AccountsView — 影子行 parent_* OR 兜底展示', () => {
+describe('admin AccountsView — 账号行展示', () => {
   beforeEach(() => {
     localStorage.clear()
     for (const fn of [listAccounts, listWithEtag, getBatchTodayStats, getAllProxies, getAllGroups, duplicateAccount, createSparkShadow, showSuccess, showError]) {
@@ -300,6 +301,47 @@ describe('admin AccountsView — 影子行 parent_* OR 兜底展示', () => {
     expect(badge.props('planType')).toBe('plus')
     expect(badge.props('privacyMode')).toBe('false')
     expect(badge.props('subscriptionExpiresAt')).toBe('2027-01-01T00:00:00Z')
+
+    wrapper.unmount()
+  })
+
+  it('仅将具有安全 base_url 的 API Key 账号名称链接到站点主页', async () => {
+    listAccounts.mockResolvedValue({
+      items: [
+        { id: 101, name: 'relay-account', platform: 'openai', type: 'apikey', credentials: { base_url: 'https://relay.example.com/api/v1/' } },
+        { id: 102, name: 'oauth-account', platform: 'openai', type: 'oauth', credentials: { base_url: 'https://oauth.example.com/v1' } },
+        { id: 103, name: 'invalid-url', platform: 'openai', type: 'apikey', credentials: { base_url: 'javascript:alert(1)' } },
+      ],
+      total: 3,
+      page: 1,
+      page_size: 20,
+      pages: 1,
+    })
+
+    const wrapper = mountViewWithRow()
+    await flushPromises()
+
+    const links = wrapper.findAll('a')
+    expect(links).toHaveLength(1)
+    const [link] = links
+    expect(link.text()).toBe('relay-account')
+    expect(link.attributes()).toMatchObject({
+      href: 'https://relay.example.com',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    })
+    expect(link.classes()).toEqual(expect.arrayContaining([
+      'border-dotted',
+      'text-gray-900',
+      'dark:text-white',
+    ]))
+    expect(link.classes()).not.toContain('text-primary-600')
+    const tooltip = wrapper.findComponent(HelpTooltip)
+    expect(tooltip.props('content')).toBe('https://relay.example.com')
+    expect(tooltip.props('widthClass')).toBe('w-max max-w-sm break-all')
+    expect(tooltip.classes()).toEqual(expect.arrayContaining(['self-start']))
+    expect(wrapper.text()).toContain('oauth-account')
+    expect(wrapper.text()).toContain('invalid-url')
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## 变更背景

账号管理页中的 API Key 账号名称目前只是普通文本。管理多个上游中转站时，管理员需要另行维护书签或手动查找对应站点，无法从账号列表直接进入上游主页。

本 PR 将具有合法 Base URL 的 API Key 账号名称变为站点主页链接，并保留 OAuth、无 Base URL 和非法 URL 账号的现有展示行为。

## 修改内容

- 仅为 `type = apikey` 且 `credentials.base_url` 是合法 HTTP(S) URL 的账号生成名称链接；
- 复用现有 `sanitizeUrl` 校验 URL，并通过标准 `URL.origin` 只保留站点协议、主机和端口；
- 点击名称后在新标签页打开上游站点主页；
- 链接使用与普通名称相同的文字颜色，通过灰色点状下划线提示可点击状态；
- 复用项目现有 `HelpTooltip`，悬浮时显示实际目标 URL；
- Tooltip 根据内容自适应宽度，超长地址最多显示到 `max-w-sm` 后换行；
- 使用 `self-start` 将触发和点击区域限制在名称文本范围内。

## 安全与行为边界

| 账号或 URL 状态 | 页面行为 |
| --- | --- |
| API Key + 合法 HTTP(S) Base URL | 名称链接到该 URL 的 `origin` |
| OAuth 账号 | 保持普通文本 |
| Base URL 缺失、非字符串或格式错误 | 保持普通文本 |
| `javascript:`、`data:`、`file:`、`blob:` | 拒绝生成链接 |
| 协议相对地址或相对路径 | 拒绝生成链接 |
| URL 包含路径、查询参数或 fragment | 全部移除，只跳转站点主页 |
| URL 包含 userinfo | 不带 userinfo 跳转，只保留 `origin` |

新标签页链接使用：

```html
target="_blank"
rel="noopener noreferrer"
```

因此目标页面不能通过 `window.opener` 控制账号管理页，也不会收到来源页面地址。账号名称继续由 Vue 文本插值转义，不作为 HTML 渲染。

## 兼容性与非目标

本 PR：

- 不修改后端接口或数据库结构；
- 不修改账号凭据和 Base URL；
- 不改变账号调度、状态、用量或计费行为；
- 不为 OAuth 账号生成站点链接；
- 不在悬浮或页面加载时主动请求上游站点；
- 不尝试判断上游站点身份或可信度，Tooltip 只用于让管理员确认实际目标地址。

## 回归测试

自动化测试覆盖：

- 合法 API Key Base URL 生成唯一链接并移除 `/api/v1/` 路径；
- OAuth 账号保持普通文本；
- `javascript:` URL 不生成链接；
- 新标签页隔离属性完整；
- 名称颜色、点状下划线和 Tooltip 自适应宽度配置保持预期。

已通过：

```text
AccountsView 定向测试：8/8
TypeScript 类型检查
AccountsView 及对应测试 ESLint
前端生产构建
```

额外对抗测试覆盖危险协议、相对地址、畸形 URL、超长输入、XSS 名称、userinfo、路径、查询参数和 fragment；浏览器验证确认没有自动外部请求，打开后的 `window.opener` 为 `null`，`document.referrer` 为空。

浏览器实际悬浮验证中，示例 URL `https://relay.example.com` 的 Tooltip 宽度约为 172px，最大宽度为 384px，完整位于视口内；OAuth 账号名称保持不可点击。
