### PR TITLE
fix(auth): avoid binding sessions to untrusted proxy IPs

### DIFF
--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -47,14 +47,8 @@ func ProvideRouter(
 
 	r := gin.New()
 	r.Use(middleware2.Recovery())
-	if len(cfg.Server.TrustedProxies) > 0 {
-		if err := r.SetTrustedProxies(cfg.Server.TrustedProxies); err != nil {
-			log.Printf("Failed to set trusted proxies: %v", err)
-		}
-	} else {
-		if err := r.SetTrustedProxies(nil); err != nil {
-			log.Printf("Failed to disable trusted proxies: %v", err)
-		}
+	includeSessionBindingIP := configureTrustedProxies(r, cfg.Server.TrustedProxies)
+	if len(cfg.Server.TrustedProxies) == 0 {
 		if cfg.Server.Mode == "release" {
 			log.Printf("Warning: server.trusted_proxies is empty in release mode; client IP trust chain is disabled")
 		}
@@ -96,7 +90,26 @@ func ProvideRouter(
 		service.SetWebSearchManager(websearch.NewManager(configs, redisClient))
 	})
 
-	return SetupRouter(r, handlers, jwtAuth, adminAuth, apiKeyAuth, auditLog, stepUpAuth, apiKeyService, subscriptionService, opsService, settingService, cfg, redisClient)
+	return SetupRouter(r, handlers, jwtAuth, adminAuth, apiKeyAuth, auditLog, stepUpAuth, apiKeyService, subscriptionService, opsService, settingService, cfg, includeSessionBindingIP, redisClient)
+}
+
+func configureTrustedProxies(r *gin.Engine, trustedProxies []string) bool {
+	if len(trustedProxies) == 0 {
+		if err := r.SetTrustedProxies(nil); err != nil {
+			log.Printf("Failed to disable trusted proxies: %v", err)
+		}
+		return false
+	}
+
+	if err := r.SetTrustedProxies(trustedProxies); err == nil {
+		return true
+	} else {
+		log.Printf("Failed to set trusted proxies: %v", err)
+	}
+	if err := r.SetTrustedProxies(nil); err != nil {
+		log.Printf("Failed to disable trusted proxies after configuration failure: %v", err)
+	}
+	return false
 }
 
 // ProvideHTTPServer 提供 HTTP 服务器

--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -1,0 +1,52 @@
+//go:build unit
+
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func clientIPForTrustedProxyTest(t *testing.T, r *gin.Engine) string {
+	t.Helper()
+
+	var clientIP string
+	r.GET("/", func(c *gin.Context) {
+		clientIP = c.ClientIP()
+		c.Status(http.StatusNoContent)
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "10.0.0.2:1234"
+	request.Header.Set("X-Forwarded-For", "9.9.9.9")
+	recorder := httptest.NewRecorder()
+	r.ServeHTTP(recorder, request)
+
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	return clientIP
+}
+
+func TestConfigureTrustedProxiesDisablesForwardedHeadersWhenEmpty(t *testing.T) {
+	r := gin.New()
+
+	assert.False(t, configureTrustedProxies(r, nil))
+	assert.Equal(t, "10.0.0.2", clientIPForTrustedProxyTest(t, r))
+}
+
+func TestConfigureTrustedProxiesTrustsForwardedHeadersForConfiguredPeer(t *testing.T) {
+	r := gin.New()
+
+	assert.True(t, configureTrustedProxies(r, []string{"10.0.0.0/8"}))
+	assert.Equal(t, "9.9.9.9", clientIPForTrustedProxyTest(t, r))
+}
+
+func TestConfigureTrustedProxiesFallsBackWhenConfigurationIsInvalid(t *testing.T) {
+	r := gin.New()
+
+	assert.False(t, configureTrustedProxies(r, []string{"not-a-cidr"}))
+	assert.Equal(t, "10.0.0.2", clientIPForTrustedProxyTest(t, r))
+}

--- a/backend/internal/server/middleware/admin_auth.go
+++ b/backend/internal/server/middleware/admin_auth.go
@@ -192,7 +192,7 @@ func validateJWTForAdmin(
 		return false
 	}
 
-	// 会话绑定校验：IP/UA 任一变化即撤销会话（功能可在系统设置中关闭）
+	// 会话绑定校验：始终绑定 UA，按可信代理配置可选绑定 IP（功能可在系统设置中关闭）
 	if !enforceSessionBinding(c, authService, settingService, auditService, claims) {
 		return false
 	}

--- a/backend/internal/server/middleware/jwt_auth.go
+++ b/backend/internal/server/middleware/jwt_auth.go
@@ -88,7 +88,7 @@ func jwtAuth(
 			return
 		}
 
-		// 会话绑定校验：IP/UA 任一变化即撤销会话（功能可在系统设置中关闭）
+		// 会话绑定校验：始终绑定 UA，按可信代理配置可选绑定 IP（功能可在系统设置中关闭）
 		if !enforceSessionBinding(c, authService, settingService, auditService, claims) {
 			return
 		}

--- a/backend/internal/server/middleware/session_binding.go
+++ b/backend/internal/server/middleware/session_binding.go
@@ -7,30 +7,31 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// SessionBindingContext 全局中间件：将请求的可信客户端 IP 与 User-Agent 注入
-// request context，供 token 签发路径（登录 / 刷新 / OAuth 回调）读取并写入会话绑定。
-// 必须使用 GetTrustedClientIP（走 trusted_proxies 链），不可信头会导致绑定被伪造绕过。
-func SessionBindingContext() gin.HandlerFunc {
+// SessionBindingContext 全局中间件：将请求会话绑定注入 request context，供 token
+// 签发路径（登录 / 刷新 / OAuth 回调）读取并写入会话绑定。trusted_proxies 为空时仅绑定
+// User-Agent；成功配置后才通过 GetTrustedClientIP（走 trusted_proxies 链）绑定客户端 IP。
+func SessionBindingContext(includeIP bool) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		binding := &service.SessionBinding{
-			IP:        ip.GetTrustedClientIP(c),
-			UserAgent: c.Request.UserAgent(),
-		}
+		binding := newSessionBinding(c, includeIP)
 		c.Request = c.Request.WithContext(service.WithSessionBinding(c.Request.Context(), binding))
 		c.Next()
 	}
 }
 
-// currentSessionBindingHash 计算当前请求的会话指纹哈希。
-func currentSessionBindingHash(c *gin.Context) string {
-	binding := &service.SessionBinding{
-		IP:        ip.GetTrustedClientIP(c),
-		UserAgent: c.Request.UserAgent(),
+func newSessionBinding(c *gin.Context, includeIP bool) *service.SessionBinding {
+	binding := &service.SessionBinding{UserAgent: c.Request.UserAgent()}
+	if includeIP {
+		binding.IP = ip.GetTrustedClientIP(c)
 	}
-	return binding.Hash()
+	return binding
 }
 
-// enforceSessionBinding 校验 access token 的会话指纹（IP/UA 绑定）。
+// currentSessionBindingHash 返回当前请求会话绑定的哈希。
+func currentSessionBindingHash(c *gin.Context) string {
+	return service.SessionBindingFromContext(c.Request.Context()).Hash()
+}
+
+// enforceSessionBinding 校验 access token 的会话指纹（始终绑定 UA，按可信代理配置可选绑定 IP）。
 // 指纹不匹配时：撤销该会话家族的所有 refresh token、写入审计安全事件、返回 401。
 // 返回 false 表示请求已被中断。
 //

--- a/backend/internal/server/middleware/session_binding_test.go
+++ b/backend/internal/server/middleware/session_binding_test.go
@@ -1,0 +1,120 @@
+//go:build unit
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func requestSessionBinding(
+	t *testing.T,
+	includeIP bool,
+	trustedProxies []string,
+	remoteAddr string,
+	userAgent string,
+	forwardedFor string,
+) *service.SessionBinding {
+	t.Helper()
+
+	engine := gin.New()
+	require.NoError(t, engine.SetTrustedProxies(trustedProxies))
+	engine.Use(SessionBindingContext(includeIP))
+
+	var binding *service.SessionBinding
+	engine.GET("/", func(c *gin.Context) {
+		binding = service.SessionBindingFromContext(c.Request.Context())
+		c.Status(http.StatusNoContent)
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = remoteAddr
+	request.Header.Set("User-Agent", userAgent)
+	if forwardedFor != "" {
+		request.Header.Set("X-Forwarded-For", forwardedFor)
+	}
+
+	recorder := httptest.NewRecorder()
+	engine.ServeHTTP(recorder, request)
+
+	require.Equal(t, http.StatusNoContent, recorder.Code)
+	require.NotNil(t, binding)
+	return binding
+}
+
+func TestSessionBindingContextIncludesIPWhenEnabled(t *testing.T) {
+	first := requestSessionBinding(t, true, []string{"10.0.0.0/8"}, "10.0.0.2:1234", "test-agent", "9.9.9.9")
+	second := requestSessionBinding(t, true, []string{"10.0.0.0/8"}, "10.0.0.2:1234", "test-agent", "8.8.8.8")
+
+	assert.Equal(t, "9.9.9.9", first.IP)
+	assert.Equal(t, "8.8.8.8", second.IP)
+	assert.Equal(t, "test-agent", first.UserAgent)
+	assert.Equal(t, "test-agent", second.UserAgent)
+	assert.Equal(t, (&service.SessionBinding{IP: "9.9.9.9", UserAgent: "test-agent"}).Hash(), first.Hash())
+	assert.Equal(t, (&service.SessionBinding{IP: "8.8.8.8", UserAgent: "test-agent"}).Hash(), second.Hash())
+	assert.NotEqual(t, first.Hash(), second.Hash())
+}
+
+func TestSessionBindingContextIgnoresTrustedProxyPeerChanges(t *testing.T) {
+	first := requestSessionBinding(t, true, []string{"10.0.0.0/8"}, "10.0.0.2:1234", "test-agent", "9.9.9.9")
+	second := requestSessionBinding(t, true, []string{"10.0.0.0/8"}, "10.0.0.3:1234", "test-agent", "9.9.9.9")
+
+	assert.Equal(t, "9.9.9.9", first.IP)
+	assert.Equal(t, first.IP, second.IP)
+	assert.Equal(t, first.Hash(), second.Hash())
+}
+
+func TestSessionBindingContextOmitsIPWhenDisabled(t *testing.T) {
+	first := requestSessionBinding(t, false, nil, "10.0.0.2:1234", "test-agent", "9.9.9.9")
+	second := requestSessionBinding(t, false, nil, "10.0.0.3:1234", "test-agent", "8.8.8.8")
+
+	assert.Empty(t, first.IP)
+	assert.Empty(t, second.IP)
+	assert.Equal(t, "test-agent", first.UserAgent)
+	assert.Equal(t, "test-agent", second.UserAgent)
+	assert.Equal(t, first.Hash(), second.Hash())
+}
+
+func TestSessionBindingContextStillBindsUserAgentWhenIPDisabled(t *testing.T) {
+	first := requestSessionBinding(t, false, nil, "10.0.0.2:1234", "first-agent", "9.9.9.9")
+	second := requestSessionBinding(t, false, nil, "10.0.0.2:1234", "second-agent", "9.9.9.9")
+
+	assert.NotEqual(t, first.Hash(), second.Hash())
+}
+
+func TestCurrentSessionBindingHashUsesRequestContext(t *testing.T) {
+	engine := gin.New()
+	require.NoError(t, engine.SetTrustedProxies(nil))
+	engine.Use(SessionBindingContext(false))
+
+	var got string
+	engine.GET("/", func(c *gin.Context) {
+		got = currentSessionBindingHash(c)
+		c.Status(http.StatusNoContent)
+	})
+
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+	request.RemoteAddr = "9.9.9.9:1234"
+	request.Header.Set("User-Agent", "Mozilla/5.0")
+	recorder := httptest.NewRecorder()
+
+	engine.ServeHTTP(recorder, request)
+
+	want := (&service.SessionBinding{UserAgent: "Mozilla/5.0"}).Hash()
+	assert.Equal(t, http.StatusNoContent, recorder.Code)
+	assert.Equal(t, want, got)
+	assert.NotEqual(t, (&service.SessionBinding{IP: "9.9.9.9", UserAgent: "Mozilla/5.0"}).Hash(), got)
+}
+
+func TestCurrentSessionBindingHashAllowsMissingContextBinding(t *testing.T) {
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodGet, "/", nil)
+
+	assert.Empty(t, currentSessionBindingHash(context))
+}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -33,6 +33,7 @@ func SetupRouter(
 	opsService *service.OpsService,
 	settingService *service.SettingService,
 	cfg *config.Config,
+	includeSessionBindingIP bool,
 	redisClient *redis.Client,
 ) *gin.Engine {
 	// 缓存 iframe 页面的 origin 列表，用于动态注入 CSP frame-src
@@ -54,8 +55,8 @@ func SetupRouter(
 
 	// 应用中间件
 	r.Use(middleware2.RequestLogger())
-	// 将可信客户端 IP + UA 注入 request context，供 token 签发路径写入会话绑定
-	r.Use(middleware2.SessionBindingContext())
+	// 可信代理成功配置时将 IP 和 UA 注入 request context，否则仅注入 UA。
+	r.Use(middleware2.SessionBindingContext(includeSessionBindingIP))
 	r.Use(middleware2.Logger())
 	r.Use(middleware2.CORS(cfg.CORS))
 	r.Use(middleware2.SecurityHeaders(cfg.Security.CSP, func() []string {


### PR DESCRIPTION
## Summary

- include the client IP in the session fingerprint only when Gin successfully configures an explicit trusted proxy chain
- fall back to User-Agent-only session binding when `server.trusted_proxies` is empty or invalid
- reuse the request-context binding for both token issuance and validation
- add regression tests for trusted proxy resolution, proxy peer changes, and User-Agent-only fallback

## Root cause

When `server.trusted_proxies` is empty, Gin returns the direct peer address instead of a verified client address.

Behind a distributed reverse proxy such as Cloudflare, consecutive requests may arrive through different edge nodes. The login request can therefore issue a token using one edge address, while the first authenticated request computes the session fingerprint using another. This causes an immediate `SESSION_BINDING_MISMATCH` and revokes the newly created session family.

A similar inconsistency could occur when `server.trusted_proxies` is non-empty but Gin rejects the configuration. The configuration previously remained non-empty even though the trusted proxy chain was not active.

## Behavior

| Trusted proxy state | Session binding |
| --- | --- |
| Successfully configured | Resolved client IP + User-Agent |
| Empty | User-Agent only |
| Invalid or rejected by Gin | User-Agent only |

If trusted proxy configuration fails, the server explicitly disables Gin's trusted proxy chain before falling back to User-Agent-only binding.

This change does not directly trust `CF-Connecting-IP`, `X-Forwarded-For`, or any other forwarding header without a successfully configured Gin trusted proxy chain.

Existing behavior for genuine binding mismatches is unchanged: the session family is revoked, a security audit event is recorded, and the request returns `SESSION_BINDING_MISMATCH`.

## Related work

This complements #4462. That PR unifies security-sensitive client IP selection behind the existing forwarded-IP trust toggle. With the toggle disabled by default, the direct proxy peer can still be unstable. This PR provides the safe fallback for that state by excluding IP from the session fingerprint unless Gin has successfully configured an explicit trusted proxy chain.

## Validation

Passed:

- `cd backend && make test-unit`
- `cd backend && go test -tags=unit ./internal/server -run '^TestConfigureTrustedProxies' -count=1`
- `cd backend && go test -tags=unit ./internal/server/middleware -run 'SessionBinding' -count=1`
- `cd backend && GOTOOLCHAIN=go1.26.5 go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.9.0 run --timeout=30m`
- `pnpm install --frozen-lockfile`
- `make test-frontend`
- `git diff --check`

Integration tests were attempted but could not complete because Docker Hub image pulls for `redis:8.4-alpine` and `postgres:18.1-alpine3.23` failed with TLS handshake timeouts. The failures occurred while Testcontainers was obtaining its dependencies, before the affected assertions could run.

Fixes #4452
