### PR TITLE
fix(frontend): saveS3Config 接入 step-up TOTP 门控

### DIFF
--- a/frontend/src/views/admin/BackupView.vue
+++ b/frontend/src/views/admin/BackupView.vue
@@ -471,10 +471,14 @@ async function loadS3Config() {
 async function saveS3Config() {
   savingS3.value = true
   try {
-    await adminAPI.backup.updateS3Config(s3Form.value)
+    await backupStepUp.run(() => adminAPI.backup.updateS3Config(s3Form.value))
     appStore.showSuccess(t('admin.backup.s3.saved'))
     await loadS3Config()
   } catch (error) {
+    if (isStepUpCancelled(error)) {
+      savingS3.value = false
+      return
+    }
     appStore.showError((error as { message?: string })?.message || t('errors.networkError'))
   } finally {
     savingS3.value = false


### PR DESCRIPTION
## 背景

BackupView 中三个需要 step-up 2FA 门控的操作，`createBackup` 和 `downloadBackup` 已正确使用 `backupStepUp.run()` 包装，但 `saveS3Config` 漏了。

后端 `PUT /api/v1/admin/backups/s3-config` 返回 `STEP_UP_REQUIRED` 时，前端应弹出 TOTP 对话框并重试，但 `saveS3Config` 直接把它当成普通错误弹 toast，导致 S3 配置永远无法保存。

Fixes #4445

## 修改

- `frontend/src/views/admin/BackupView.vue`：`saveS3Config` 用 `backupStepUp.run()` 包装 `adminAPI.backup.updateS3Config` 调用，与 `createBackup`/`downloadBackup` 对齐。用户取消 TOTP 验证时恢复按钮状态。

## 兼容性说明

- 未启用 TOTP 的管理员不受影响（不会触发 step-up 门控）
- `createBackup` 和 `downloadBackup` 的行为不变

## 测试

```bash
pnpm run typecheck
```