### PR TITLE
fix(grok): preserve media eligibility in scheduler cache

### DIFF
--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -961,6 +961,8 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"auto_pause_7d_disabled",
 		"model_rate_limits",
 		service.UpstreamBillingProbeExtraKey,
+		service.GrokMediaEligibleExtraKey,
+		"grok_billing_snapshot",
 	}
 	filtered := make(map[string]any)
 	for _, key := range keys {

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -276,6 +276,50 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 	require.Nil(t, got.Extra["unused_large_field"])
 }
 
+func TestBuildSchedulerMetadataAccount_KeepsGrokMediaEligibility(t *testing.T) {
+	t.Run("explicit override", func(t *testing.T) {
+		account := service.Account{
+			ID:       43,
+			Platform: service.PlatformGrok,
+			Type:     service.AccountTypeOAuth,
+			Extra: map[string]any{
+				service.GrokMediaEligibleExtraKey: false,
+				"unused_large_field":              "drop-me",
+			},
+		}
+
+		got := buildSchedulerMetadataAccount(account)
+
+		eligible, reason := got.GrokMediaGenerationEligibility()
+		require.False(t, eligible)
+		require.Equal(t, "override_disabled", reason)
+		require.Equal(t, false, got.Extra[service.GrokMediaEligibleExtraKey])
+		require.Nil(t, got.Extra["unused_large_field"])
+	})
+
+	t.Run("forbidden billing observation", func(t *testing.T) {
+		account := service.Account{
+			ID:       44,
+			Platform: service.PlatformGrok,
+			Type:     service.AccountTypeOAuth,
+			Extra: map[string]any{
+				"grok_billing_snapshot": map[string]any{
+					"status_code":         200,
+					"weekly_status_code":  403,
+					"monthly_status_code": 200,
+				},
+			},
+		}
+
+		got := buildSchedulerMetadataAccount(account)
+
+		eligible, reason := got.GrokMediaGenerationEligibility()
+		require.False(t, eligible)
+		require.Equal(t, "billing_forbidden", reason)
+		require.NotNil(t, got.Extra["grok_billing_snapshot"])
+	})
+}
+
 func TestBuildSchedulerMetadataAccount_KeepsSlimGroupMembership(t *testing.T) {
 	account := service.Account{
 		ID:       42,


### PR DESCRIPTION
## Summary

- Preserve `grok_media_eligible` and `grok_billing_snapshot` in the scheduler's slim Redis account metadata.
- Keep Grok media eligibility decisions consistent between fresh database reads and cached scheduler reads.
- Add regression coverage for an explicit media override and for a forbidden weekly/monthly billing observation.

## Why

#4474 added Grok media eligibility filtering, but `filterSchedulerExtra` still dropped the two fields consumed by `GrokMediaGenerationEligibility`. After the scheduler cache warmed, an OAuth account could therefore become eligible for media again even though the database record still marked it ineligible.

This follow-up keeps only the two small routing fields needed by the scheduler; unrelated account metadata remains filtered out.

## Verification

- `go test -tags=unit ./internal/repository ./internal/service`
- `go vet -tags=unit ./internal/repository ./internal/service`
- `git diff --check origin/main..HEAD`
- `gitleaks git --log-opts='origin/main..HEAD'`
- Controlled cache-path E2E: text remained available, ineligible OAuth image/video requests were rejected before upstream dispatch, API-key media remained routable, and account/cache state was restored afterward.

Follow-up to #4474.

Related reports: #4420, #4471, #4421, #4419, #4412, #4433.
