### PR TITLE
fix(deploy): make the redis command flags take effect

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -241,12 +241,16 @@ services:
         hard: 100000
     volumes:
       - redis_data:/data
+    # The command is one quoted script for the inner `sh -c`. Compose keeps
+    # the newlines inside the quoted string, so every line needs a trailing
+    # `\` — without it, `redis-server` on the first line runs with no flags
+    # at all, and the --save/--appendonly/--appendfsync lines are never read.
     command: >
       sh -c '
-        redis-server
-        --save 60 1
-        --appendonly yes
-        --appendfsync everysec
+        redis-server \
+        --save 60 1 \
+        --appendonly yes \
+        --appendfsync everysec \
         ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}


### PR DESCRIPTION
In `deploy/docker-compose.yml`, the redis `command` is one quoted script given to the inner `sh -c`. Docker compose keeps the newlines inside the quoted string, so `redis-server` on the first line runs as a complete command with no flags at all — the `--save` / `--appendonly` / `--appendfsync` lines after it are silently never applied.

You can see it on any deploy of this file: `redis-cli CONFIG GET appendonly` says "no", though `--appendonly yes` is right there in the command.

The fix is trailing `\` line continuations, which fold the script back into one command. Checked with redis:7-alpine: `appendonly` is now "yes" and `save` is "60 1".

🤖 Generated with [Claude Code](https://claude.com/claude-code)