### PR TITLE
feat(gateway): 归一化 thinking 参数使思考摘要对客户端可见

### DIFF
--- a/backend/internal/handler/admin/setting_handler_runtime.go
+++ b/backend/internal/handler/admin/setting_handler_runtime.go
@@ -189,6 +189,7 @@ func (h *SettingHandler) GetRectifierSettings(c *gin.Context) {
 		Enabled:                  settings.Enabled,
 		ThinkingSignatureEnabled: settings.ThinkingSignatureEnabled,
 		ThinkingBudgetEnabled:    settings.ThinkingBudgetEnabled,
+		ThinkingDisplayMode:      settings.ThinkingDisplayMode,
 		APIKeySignatureEnabled:   settings.APIKeySignatureEnabled,
 		APIKeySignaturePatterns:  patterns,
 	})
@@ -199,6 +200,7 @@ type UpdateRectifierSettingsRequest struct {
 	Enabled                  bool     `json:"enabled"`
 	ThinkingSignatureEnabled bool     `json:"thinking_signature_enabled"`
 	ThinkingBudgetEnabled    bool     `json:"thinking_budget_enabled"`
+	ThinkingDisplayMode      string   `json:"thinking_display_mode"`
 	APIKeySignatureEnabled   bool     `json:"apikey_signature_enabled"`
 	APIKeySignaturePatterns  []string `json:"apikey_signature_patterns"`
 }
@@ -232,10 +234,22 @@ func (h *SettingHandler) UpdateRectifierSettings(c *gin.Context) {
 		cleanedPatterns = append(cleanedPatterns, p)
 	}
 
+	displayMode := strings.TrimSpace(req.ThinkingDisplayMode)
+	if displayMode == "" {
+		displayMode = service.ThinkingDisplayModeDisplayOnly
+	}
+	switch displayMode {
+	case service.ThinkingDisplayModeOff, service.ThinkingDisplayModeDisplayOnly, service.ThinkingDisplayModeForce:
+	default:
+		response.BadRequest(c, "Invalid thinking_display_mode (expected off, display_only or force)")
+		return
+	}
+
 	settings := &service.RectifierSettings{
 		Enabled:                  req.Enabled,
 		ThinkingSignatureEnabled: req.ThinkingSignatureEnabled,
 		ThinkingBudgetEnabled:    req.ThinkingBudgetEnabled,
+		ThinkingDisplayMode:      displayMode,
 		APIKeySignatureEnabled:   req.APIKeySignatureEnabled,
 		APIKeySignaturePatterns:  cleanedPatterns,
 	}
@@ -260,6 +274,7 @@ func (h *SettingHandler) UpdateRectifierSettings(c *gin.Context) {
 		Enabled:                  updatedSettings.Enabled,
 		ThinkingSignatureEnabled: updatedSettings.ThinkingSignatureEnabled,
 		ThinkingBudgetEnabled:    updatedSettings.ThinkingBudgetEnabled,
+		ThinkingDisplayMode:      updatedSettings.ThinkingDisplayMode,
 		APIKeySignatureEnabled:   updatedSettings.APIKeySignatureEnabled,
 		APIKeySignaturePatterns:  updatedPatterns,
 	})

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -404,6 +404,7 @@ type RectifierSettings struct {
 	Enabled                  bool     `json:"enabled"`
 	ThinkingSignatureEnabled bool     `json:"thinking_signature_enabled"`
 	ThinkingBudgetEnabled    bool     `json:"thinking_budget_enabled"`
+	ThinkingDisplayMode      string   `json:"thinking_display_mode"`
 	APIKeySignatureEnabled   bool     `json:"apikey_signature_enabled"`
 	APIKeySignaturePatterns  []string `json:"apikey_signature_patterns"`
 }

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -108,6 +108,14 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				passthroughModel = mappedModel
 			}
 		}
+		// 直通路径在此提前 return，走不到下方的整流链，因此思考摘要归一化需在这里单独做一次，
+		// 否则直通账号的流量看不到思考摘要 —— 同一个用户会因调度到的账号不同而时有时无。
+		if mode := s.settingService.GetThinkingDisplayMode(ctx); mode != ThinkingDisplayModeOff {
+			if rewritten, applied := NormalizeAnthropicThinkingDisplay(passthroughBody, passthroughModel, mode, parsed.Stream); applied {
+				passthroughBody = rewritten
+				logger.LegacyPrintf("service.gateway", "Passthrough: normalized thinking display for %s (mode=%s, account: %s)", passthroughModel, mode, account.Name)
+			}
+		}
 		return s.forwardAnthropicAPIKeyPassthroughWithInput(ctx, c, account, anthropicPassthroughForwardInput{
 			Body:          passthroughBody,
 			Parsed:        parsed,
@@ -345,6 +353,19 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 				return nil, err
 			}
 			logger.LegacyPrintf("service.gateway", "Account %d: rewrote thinking.type for %s (Anthropic-SDK default 'enabled' -> vendor-specific)", account.ID, reqModel)
+		}
+	}
+	// 思考摘要可见性归一化：Opus 4.8/4.7、Sonnet 5、Fable 5 上 thinking.display 默认为
+	// "omitted" —— 思考照常发生并计费，但返回的 thinking block 文本为空，客户端无从展示，
+	// 终端用户会误以为上游不支持思考。同时把这些模型上必定 400 的老写法
+	// （thinking.type="enabled" / budget_tokens）归一到 adaptive。
+	// reqModel 此时已是映射后的模型 ID —— 决定 display 行为的是真正执行请求的模型。
+	if mode := s.settingService.GetThinkingDisplayMode(ctx); mode != ThinkingDisplayModeOff {
+		if rewritten, applied := NormalizeAnthropicThinkingDisplay(body, reqModel, mode, reqStream); applied {
+			if err := replaceBody(rewritten); err != nil {
+				return nil, err
+			}
+			logger.LegacyPrintf("service.gateway", "Account %d: normalized thinking display for %s (mode=%s)", account.ID, reqModel, mode)
 		}
 	}
 

--- a/backend/internal/service/setting_features.go
+++ b/backend/internal/service/setting_features.go
@@ -724,6 +724,31 @@ func (s *SettingService) IsBudgetRectifierEnabled(ctx context.Context) bool {
 	return settings.Enabled && settings.ThinkingBudgetEnabled
 }
 
+// GetThinkingDisplayMode 返回思考摘要注入模式（总开关关闭时视为 off）。
+// 空值/未知值归一到 display_only —— 该档只做零成本的摘要取消隐藏，是安全的保底。
+//
+// 本方法在网关热路径上被调用，因此必须对未装配 settingService/settingRepo 的
+// GatewayService 保持安全（GetRectifierSettings 会直接解引用 settingRepo）。
+// 读不到配置时返回 off：不确定该不该改写流量时，就不改写。
+func (s *SettingService) GetThinkingDisplayMode(ctx context.Context) string {
+	if s == nil || s.settingRepo == nil {
+		return ThinkingDisplayModeOff
+	}
+	settings, err := s.GetRectifierSettings(ctx)
+	if err != nil {
+		return ThinkingDisplayModeDisplayOnly // fail-safe: 保底不做有成本的注入
+	}
+	if !settings.Enabled {
+		return ThinkingDisplayModeOff
+	}
+	switch settings.ThinkingDisplayMode {
+	case ThinkingDisplayModeOff, ThinkingDisplayModeDisplayOnly, ThinkingDisplayModeForce:
+		return settings.ThinkingDisplayMode
+	default:
+		return ThinkingDisplayModeDisplayOnly
+	}
+}
+
 // GetBetaPolicySettings 获取 Beta 策略配置
 func (s *SettingService) GetBetaPolicySettings(ctx context.Context) (*BetaPolicySettings, error) {
 	value, err := s.settingRepo.GetValue(ctx, SettingKeyBetaPolicySettings)

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -444,16 +444,22 @@ type RectifierSettings struct {
 	Enabled                  bool     `json:"enabled"`                    // 总开关
 	ThinkingSignatureEnabled bool     `json:"thinking_signature_enabled"` // Thinking 签名整流
 	ThinkingBudgetEnabled    bool     `json:"thinking_budget_enabled"`    // Thinking Budget 整流
+	ThinkingDisplayMode      string   `json:"thinking_display_mode"`      // 思考摘要注入：off | display_only | force
 	APIKeySignatureEnabled   bool     `json:"apikey_signature_enabled"`   // API Key 签名整流开关
 	APIKeySignaturePatterns  []string `json:"apikey_signature_patterns"`  // API Key 自定义匹配关键词
 }
 
 // DefaultRectifierSettings 返回默认的整流器配置（全部启用）
+//
+// ThinkingDisplayMode 默认取 display_only 而非 force：display_only 只是把已经发生、
+// 已经计费的思考摘要取消隐藏，零成本零风险；force 会为未开启思考的请求真正开启思考，
+// 属于成本与缓存行为的改变，应由运维显式选择。
 func DefaultRectifierSettings() *RectifierSettings {
 	return &RectifierSettings{
 		Enabled:                  true,
 		ThinkingSignatureEnabled: true,
 		ThinkingBudgetEnabled:    true,
+		ThinkingDisplayMode:      ThinkingDisplayModeDisplayOnly,
 	}
 }
 

--- a/backend/internal/service/thinking_display.go
+++ b/backend/internal/service/thinking_display.go
@@ -1,0 +1,160 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// ThinkingDisplayMode 取值：思考摘要注入的三档强度。
+const (
+	// ThinkingDisplayModeOff 不做任何 thinking 归一化。
+	ThinkingDisplayModeOff = "off"
+	// ThinkingDisplayModeDisplayOnly 只处理「已经在思考、但摘要被隐藏」的请求。
+	// 不改变是否思考，因此不增加 token、不影响 messages 层缓存。
+	ThinkingDisplayModeDisplayOnly = "display_only"
+	// ThinkingDisplayModeForce 额外为完全未携带 thinking 的请求注入思考。
+	// 这会真正开启思考：增加 token 消耗，并使 messages 层 prompt 缓存失效。
+	ThinkingDisplayModeForce = "force"
+)
+
+const (
+	// thinkingForceMaxTokens 是 force 模式为流式请求保底的 max_tokens。
+	thinkingForceMaxTokens = 32000
+	// thinkingForceMaxTokensNonStream 是非流式请求的保底值。非流式请求的 max_tokens
+	// 过高会拉长单次响应时间并撞上 HTTP 超时，因此比流式保守。
+	thinkingForceMaxTokensNonStream = 16000
+)
+
+// thinkingDisplayOptInPrefixes 列出 thinking.display 默认为 "omitted" 的模型族。
+// 这些模型上：
+//   - thinking 的唯一开启写法是 {type:"adaptive"}；{type:"enabled"} 与 budget_tokens 一律 400。
+//   - display 不填则思考块文本为空字符串（思考仍然发生并计费，只是不可见）。
+//
+// Opus 4.6 / Sonnet 4.6 的 display 默认就是 "summarized"，无需补齐，故不在此列。
+// 更老的模型（Sonnet 4.5 / Haiku 4.5 / Opus 4.5 等）不认识 adaptive，更不能碰。
+var thinkingDisplayOptInPrefixes = []string{
+	"claude-opus-4-8",
+	"claude-opus-4-7",
+	"claude-sonnet-5",
+	"claude-fable-5",
+	"claude-mythos-5",
+}
+
+// thinkingDisplayNeedsOptIn 报告 model 是否属于需要显式 display 才能看到思考摘要的模型族。
+// 必须精确到 minor 版本：claude-opus-4-6 与 claude-opus-4-8 行为不同，
+// 任何 "claude-opus-4" 级别的前缀匹配都会把两者混为一谈。
+func thinkingDisplayNeedsOptIn(model string) bool {
+	m := strings.ToLower(strings.TrimSpace(model))
+	m = strings.TrimPrefix(m, "anthropic.") // Bedrock 风格的 provider 前缀
+	for _, prefix := range thinkingDisplayOptInPrefixes {
+		if strings.HasPrefix(m, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureMaxTokensForThinking 在注入思考时抬高 max_tokens。
+//
+// max_tokens 是「思考 + 正文」的总上限，不是正文的上限。在一个按无思考调校过
+// max_tokens 的请求上强开思考，思考会挤占正文预算，正文被截断并以
+// stop_reason="max_tokens" 结束 —— 上游不报错，只有终端用户看得见。
+//
+// 已有先例：RectifyThinkingBudget（gateway_request.go）与 Antigravity 的
+// ensureMaxTokensGreaterThanBudget 都用同样的手法。
+func ensureMaxTokensForThinking(body []byte, stream bool) ([]byte, bool) {
+	target := int64(thinkingForceMaxTokens)
+	if !stream {
+		target = thinkingForceMaxTokensNonStream
+	}
+	if gjson.GetBytes(body, "max_tokens").Int() >= target {
+		return body, false
+	}
+	out, err := sjson.SetBytes(body, "max_tokens", target)
+	if err != nil {
+		return body, false
+	}
+	return out, true
+}
+
+// NormalizeAnthropicThinkingDisplay 归一化新模型族的 thinking 参数，让思考摘要对客户端可见。
+//
+// 按输入分三种情形处理：
+//
+//  1. type=="adaptive" 且未设置 display —— 补 display="summarized"。模型本来就在思考、
+//     本来就在计费，只是文本被默认值 "omitted" 隐藏；补齐不增加任何 token，也不动缓存。
+//  2. type=="enabled"（Anthropic SDK 的老写法）—— 这些模型上必定 400。改写为 adaptive
+//     并删除 budget_tokens，属于纯修复：原样转发本来就是失败的。
+//  3. 缺少 thinking 字段 —— 仅 force 模式注入。这会真正开启思考，故同时抬高 max_tokens。
+//
+// 客户端显式设置的 display 一律尊重；显式 {type:"disabled"} 也不覆盖 —— 那是用户的明确意图。
+// 任何一步出错都返回原 body（fail-safe，与本链路其余整流器一致）。
+//
+// model 必须是映射后的上游模型 ID —— 决定 display 行为的是真正执行请求的那个模型。
+func NormalizeAnthropicThinkingDisplay(body []byte, model, mode string, stream bool) ([]byte, bool) {
+	if mode != ThinkingDisplayModeDisplayOnly && mode != ThinkingDisplayModeForce {
+		return body, false
+	}
+	if !thinkingDisplayNeedsOptIn(model) {
+		return body, false
+	}
+
+	thinking := gjson.GetBytes(body, "thinking")
+
+	switch {
+	case !thinking.Exists():
+		if mode != ThinkingDisplayModeForce {
+			return body, false
+		}
+		// 逐字段 set 而非一次性写入 map：Go 的 map 迭代顺序不确定，会让相同请求
+		// 每次产生不同的 JSON 字节序，破坏本链路对 body 字节序的既有假设。
+		modified, err := sjson.SetBytes(body, "thinking.type", "adaptive")
+		if err != nil {
+			return body, false
+		}
+		modified, err = sjson.SetBytes(modified, "thinking.display", "summarized")
+		if err != nil {
+			return body, false
+		}
+		if bumped, ok := ensureMaxTokensForThinking(modified, stream); ok {
+			modified = bumped
+		}
+		return modified, true
+
+	case thinking.Get("type").String() == "enabled":
+		// 这些模型既不接受 enabled 也不接受 budget_tokens，原样转发必 400。
+		// 注意 RectifyThinkingBudget 的 400 后重试在此无效：它只调整 budget_tokens 的
+		// 取值，而这里的模型是整个拒绝该字段，重试照样 400。
+		modified, err := sjson.SetBytes(body, "thinking.type", "adaptive")
+		if err != nil {
+			return body, false
+		}
+		if next, err := sjson.DeleteBytes(modified, "thinking.budget_tokens"); err == nil {
+			modified = next
+		}
+		if !thinking.Get("display").Exists() {
+			if next, err := sjson.SetBytes(modified, "thinking.display", "summarized"); err == nil {
+				modified = next
+			}
+		}
+		// 老写法的 max_tokens 本就为思考留过余量（budget_tokens < max_tokens 是硬约束），
+		// 不需要抬高。
+		return modified, true
+
+	case thinking.Get("type").String() == "adaptive":
+		if thinking.Get("display").Exists() {
+			return body, false // 客户端显式设过，尊重之
+		}
+		modified, err := sjson.SetBytes(body, "thinking.display", "summarized")
+		if err != nil {
+			return body, false
+		}
+		return modified, true
+
+	default:
+		// disabled 或未知取值：不干预。
+		return body, false
+	}
+}

--- a/backend/internal/service/thinking_display_test.go
+++ b/backend/internal/service/thinking_display_test.go
@@ -1,0 +1,229 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+)
+
+func TestThinkingDisplayNeedsOptIn(t *testing.T) {
+	tests := []struct {
+		name    string
+		modelID string
+		want    bool
+	}{
+		// display 默认 omitted 的模型族：必须显式补 summarized
+		{"opus-4-8", "claude-opus-4-8", true},
+		{"opus-4-7", "claude-opus-4-7", true},
+		{"sonnet-5", "claude-sonnet-5", true},
+		{"fable-5", "claude-fable-5", true},
+		{"mythos-5", "claude-mythos-5", true},
+		{"大写", "Claude-Opus-4-8", true},
+		{"带空格", "  claude-sonnet-5  ", true},
+		{"Bedrock 前缀", "anthropic.claude-opus-4-8", true},
+		{"带部署后缀", "claude-opus-4-8[1m]", true},
+
+		// display 默认已是 summarized，不需要也不应该改
+		{"opus-4-6", "claude-opus-4-6", false},
+		{"sonnet-4-6", "claude-sonnet-4-6", false},
+
+		// 更老的模型：不认识 adaptive，绝不能碰
+		{"sonnet-4-5", "claude-sonnet-4-5", false},
+		{"opus-4-5 带日期", "claude-opus-4-5-20251101", false},
+		{"haiku-4-5", "claude-haiku-4-5-20251001", false},
+		{"opus-4-1", "claude-opus-4-1", false},
+
+		// 非 Anthropic / 空
+		{"空", "", false},
+		{"gpt", "gpt-5.1", false},
+		{"deepseek", "deepseek-v4-pro", false},
+		{"gemini", "gemini-3-pro-preview", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := thinkingDisplayNeedsOptIn(tt.modelID); got != tt.want {
+				t.Errorf("thinkingDisplayNeedsOptIn(%q) = %v, want %v", tt.modelID, got, tt.want)
+			}
+		})
+	}
+}
+
+// 4-6 与 4-8 只差一个字符，任何 "claude-opus-4" 级别的前缀匹配都会把两者混为一谈，
+// 而它们的 display 默认值恰好相反。单独立一个测试钉住这条边界。
+func TestThinkingDisplayNeedsOptIn_MinorVersionBoundary(t *testing.T) {
+	if !thinkingDisplayNeedsOptIn("claude-opus-4-8") {
+		t.Fatal("claude-opus-4-8 必须命中")
+	}
+	if thinkingDisplayNeedsOptIn("claude-opus-4-6") {
+		t.Fatal("claude-opus-4-6 的 display 默认已是 summarized，不得命中")
+	}
+}
+
+func TestNormalizeAnthropicThinkingDisplay(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		model   string
+		mode    string
+		stream  bool
+		applied bool
+		// 断言：改写后 body 上各字段的期望值（"" 表示期望该字段不存在）
+		wantType    string
+		wantDisplay string
+		wantBudget  string // "" = 必须已被删除
+		wantMax     int64  // 0 = 不校验
+	}{
+		// —— 免费档：已经在思考，只是摘要被隐藏 ——
+		{
+			name:  "adaptive 缺 display：补齐（零成本）",
+			body:  `{"model":"claude-opus-4-8","max_tokens":1024,"thinking":{"type":"adaptive"}}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeDisplayOnly, stream: true,
+			applied: true, wantType: "adaptive", wantDisplay: "summarized",
+			wantMax: 1024, // display_only 不得改动 max_tokens
+		},
+		{
+			name:  "客户端显式设了 display：尊重，不覆盖",
+			body:  `{"model":"claude-opus-4-8","thinking":{"type":"adaptive","display":"omitted"}}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeForce, stream: true,
+			applied: false, wantType: "adaptive", wantDisplay: "omitted",
+		},
+
+		// —— 老写法归一化：原样转发必 400 ——
+		{
+			name:  "enabled+budget_tokens：改写为 adaptive 并删除 budget",
+			body:  `{"model":"claude-opus-4-8","max_tokens":64000,"thinking":{"type":"enabled","budget_tokens":32000}}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeDisplayOnly, stream: true,
+			applied: true, wantType: "adaptive", wantDisplay: "summarized", wantBudget: "",
+			wantMax: 64000, // 老写法本就为思考留过余量，不必抬高
+		},
+
+		// —— force 档：真正开启思考 ——
+		{
+			name:  "无 thinking + display_only：不注入",
+			body:  `{"model":"claude-opus-4-8","max_tokens":1024}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeDisplayOnly, stream: true,
+			applied: false, wantMax: 1024,
+		},
+		{
+			name:  "无 thinking + force：注入并抬高 max_tokens（流式）",
+			body:  `{"model":"claude-opus-4-8","max_tokens":1024}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeForce, stream: true,
+			applied: true, wantType: "adaptive", wantDisplay: "summarized",
+			wantMax: thinkingForceMaxTokens,
+		},
+		{
+			name:  "无 thinking + force：非流式抬高到更保守的上限",
+			body:  `{"model":"claude-opus-4-8","max_tokens":1024}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeForce, stream: false,
+			applied: true, wantType: "adaptive", wantDisplay: "summarized",
+			wantMax: thinkingForceMaxTokensNonStream,
+		},
+		{
+			name:  "无 thinking + force：不得下调已经够大的 max_tokens",
+			body:  `{"model":"claude-opus-4-8","max_tokens":128000}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeForce, stream: true,
+			applied: true, wantType: "adaptive", wantDisplay: "summarized",
+			wantMax: 128000,
+		},
+		{
+			name:  "显式 disabled + force：尊重用户意图，不覆盖",
+			body:  `{"model":"claude-opus-4-8","max_tokens":1024,"thinking":{"type":"disabled"}}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeForce, stream: true,
+			applied: false, wantType: "disabled", wantMax: 1024,
+		},
+
+		// —— 模式与模型的门禁 ——
+		{
+			name:  "off 模式：什么都不做",
+			body:  `{"model":"claude-opus-4-8","thinking":{"type":"adaptive"}}`,
+			model: "claude-opus-4-8", mode: ThinkingDisplayModeOff, stream: true,
+			applied: false, wantType: "adaptive", wantDisplay: "",
+		},
+		{
+			name:  "未知模式：视为不启用",
+			body:  `{"model":"claude-opus-4-8","thinking":{"type":"adaptive"}}`,
+			model: "claude-opus-4-8", mode: "bogus", stream: true,
+			applied: false, wantDisplay: "",
+		},
+		{
+			name:  "opus-4-6：display 默认已是 summarized，不得改",
+			body:  `{"model":"claude-opus-4-6","thinking":{"type":"adaptive"}}`,
+			model: "claude-opus-4-6", mode: ThinkingDisplayModeForce, stream: true,
+			applied: false, wantDisplay: "",
+		},
+		{
+			name:  "sonnet-4-5：不认识 adaptive，force 也不得注入",
+			body:  `{"model":"claude-sonnet-4-5","max_tokens":1024}`,
+			model: "claude-sonnet-4-5", mode: ThinkingDisplayModeForce, stream: true,
+			applied: false, wantType: "", wantMax: 1024,
+		},
+		{
+			name:  "非 Anthropic 上游：不得注入",
+			body:  `{"model":"deepseek-v4-pro","max_tokens":1024}`,
+			model: "deepseek-v4-pro", mode: ThinkingDisplayModeForce, stream: true,
+			applied: false, wantType: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, applied := NormalizeAnthropicThinkingDisplay([]byte(tt.body), tt.model, tt.mode, tt.stream)
+			if applied != tt.applied {
+				t.Fatalf("applied = %v, want %v (body=%s)", applied, tt.applied, got)
+			}
+			if !applied && string(got) != tt.body {
+				t.Fatalf("applied=false 时必须原样返回\n got: %s\nwant: %s", got, tt.body)
+			}
+			if tt.wantType != "" {
+				if v := gjson.GetBytes(got, "thinking.type").String(); v != tt.wantType {
+					t.Errorf("thinking.type = %q, want %q", v, tt.wantType)
+				}
+			}
+			if tt.wantDisplay != "" {
+				if v := gjson.GetBytes(got, "thinking.display").String(); v != tt.wantDisplay {
+					t.Errorf("thinking.display = %q, want %q", v, tt.wantDisplay)
+				}
+			} else if tt.applied && tt.wantType == "adaptive" {
+				t.Errorf("注入 adaptive 时必须同时写入 display")
+			}
+			if tt.wantBudget == "" && gjson.GetBytes(got, "thinking.budget_tokens").Exists() {
+				t.Errorf("budget_tokens 必须被删除，实得 %s", gjson.GetBytes(got, "thinking.budget_tokens").Raw)
+			}
+			if tt.wantMax != 0 {
+				if v := gjson.GetBytes(got, "max_tokens").Int(); v != tt.wantMax {
+					t.Errorf("max_tokens = %d, want %d", v, tt.wantMax)
+				}
+			}
+		})
+	}
+}
+
+// 出错/异常输入时必须 fail-safe 返回原 body，与本链路其余整流器一致。
+func TestNormalizeAnthropicThinkingDisplay_FailSafe(t *testing.T) {
+	for _, body := range []string{
+		``,
+		`not json at all`,
+		`{"model":"claude-opus-4-8"`,
+	} {
+		got, applied := NormalizeAnthropicThinkingDisplay([]byte(body), "claude-opus-4-8", ThinkingDisplayModeDisplayOnly, true)
+		if applied {
+			t.Errorf("畸形 body %q 不应报告 applied=true（得到 %s）", body, got)
+		}
+	}
+}
+
+// 相同输入必须产生逐字节相同的输出：本链路对 body 字节序有既有依赖
+// （见 gateway_body_order_test.go 与 400 重试对已签名 body 的处理）。
+func TestNormalizeAnthropicThinkingDisplay_Deterministic(t *testing.T) {
+	const body = `{"model":"claude-opus-4-8","max_tokens":1024,"messages":[]}`
+	first, applied := NormalizeAnthropicThinkingDisplay([]byte(body), "claude-opus-4-8", ThinkingDisplayModeForce, true)
+	if !applied {
+		t.Fatal("force 模式应注入")
+	}
+	for i := 0; i < 50; i++ {
+		next, _ := NormalizeAnthropicThinkingDisplay([]byte(body), "claude-opus-4-8", ThinkingDisplayModeForce, true)
+		if string(next) != string(first) {
+			t.Fatalf("输出字节序不稳定\n第一次: %s\n第 %d 次: %s", first, i+2, next)
+		}
+	}
+}

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -1242,12 +1242,21 @@ export async function updateStreamTimeoutSettings(
 // ==================== Rectifier Settings ====================
 
 /**
+ * Thinking summary injection mode.
+ * - off: forward the client's thinking parameter untouched
+ * - display_only: reveal summaries that are already being generated and billed (no extra cost)
+ * - force: additionally enable thinking on requests that did not ask for it
+ */
+export type ThinkingDisplayMode = "off" | "display_only" | "force";
+
+/**
  * Rectifier settings interface
  */
 export interface RectifierSettings {
   enabled: boolean;
   thinking_signature_enabled: boolean;
   thinking_budget_enabled: boolean;
+  thinking_display_mode: ThinkingDisplayMode;
   apikey_signature_enabled: boolean;
   apikey_signature_patterns: string[];
 }

--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -964,6 +964,14 @@ export default {
         thinkingSignatureHint: 'Automatically strip signatures and retry when upstream returns thinking block signature validation errors',
         thinkingBudget: 'Thinking Budget Rectifier',
         thinkingBudgetHint: 'Automatically set budget to 32000 and retry when upstream returns budget_tokens constraint error (≥1024)',
+        thinkingDisplay: 'Thinking Summary Visibility',
+        thinkingDisplayHint:
+          'On Opus 4.8/4.7, Sonnet 5 and Fable 5 thinking summaries are hidden by default: the model still thinks and is still billed, but clients receive thinking blocks with empty text and users assume the upstream cannot think. Also rewrites the legacy thinking.type="enabled" / budget_tokens form, which these models reject outright.',
+        thinkingDisplayOff: 'Off — forward unchanged',
+        thinkingDisplayOnlyMode: 'Reveal summaries only (no extra cost)',
+        thinkingDisplayForce: 'Force thinking on every request',
+        thinkingDisplayForceWarning:
+          'Force also turns thinking on for requests that never asked for it: extra tokens, message-level prompt cache invalidation, and max_tokens is raised so thinking cannot truncate the answer.',
         apikeySignature: 'API Key Signature Rectifier',
         apikeySignatureHint:
           'Automatically strip signatures and retry when API Key accounts receive signature-related errors (built-in patterns always apply)',

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -958,6 +958,14 @@ export default {
         thinkingSignatureHint: '当上游返回 thinking block 签名校验错误时，自动去除签名并重试',
         thinkingBudget: 'Thinking Budget 整流',
         thinkingBudgetHint: '当上游返回 budget_tokens 约束错误（≥1024）时，自动将 budget 设为 32000 并重试',
+        thinkingDisplay: '思考摘要可见性',
+        thinkingDisplayHint:
+          'Opus 4.8/4.7、Sonnet 5、Fable 5 上思考摘要默认隐藏：模型照常思考、照常计费，但客户端收到的思考块文本为空，用户会误以为上游不支持思考。同时会改写这些模型直接拒绝的老写法（thinking.type="enabled" / budget_tokens）。',
+        thinkingDisplayOff: '关闭 —— 原样转发',
+        thinkingDisplayOnlyMode: '仅取消隐藏摘要（不额外花费）',
+        thinkingDisplayForce: '强制所有请求开启思考',
+        thinkingDisplayForceWarning:
+          '强制模式会为未请求思考的请求也开启思考：额外消耗 token、messages 层 prompt 缓存失效，并会抬高 max_tokens 以防思考挤占正文导致截断。',
         apikeySignature: 'API Key 签名整流',
         apikeySignatureHint:
           '当 API Key 账号的上游返回签名相关错误时，自动去除签名并重试（内置规则始终生效）',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -670,6 +670,42 @@
                     <Toggle v-model="rectifierForm.thinking_budget_enabled" />
                   </div>
 
+                  <!-- Thinking Summary Visibility -->
+                  <div>
+                    <label
+                      class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                    >
+                      {{ t("admin.settings.rectifier.thinkingDisplay") }}
+                    </label>
+                    <select
+                      v-model="rectifierForm.thinking_display_mode"
+                      class="input w-64"
+                    >
+                      <option value="off">
+                        {{ t("admin.settings.rectifier.thinkingDisplayOff") }}
+                      </option>
+                      <option value="display_only">
+                        {{
+                          t("admin.settings.rectifier.thinkingDisplayOnlyMode")
+                        }}
+                      </option>
+                      <option value="force">
+                        {{ t("admin.settings.rectifier.thinkingDisplayForce") }}
+                      </option>
+                    </select>
+                    <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {{ t("admin.settings.rectifier.thinkingDisplayHint") }}
+                    </p>
+                    <p
+                      v-if="rectifierForm.thinking_display_mode === 'force'"
+                      class="mt-1.5 text-xs text-amber-600 dark:text-amber-400"
+                    >
+                      {{
+                        t("admin.settings.rectifier.thinkingDisplayForceWarning")
+                      }}
+                    </p>
+                  </div>
+
                   <!-- API Key Signature Rectifier -->
                   <div class="flex items-center justify-between">
                     <div>
@@ -7492,6 +7528,7 @@ import type {
   DefaultSubscriptionSetting,
   DefaultPlatformQuotasMap,
   OpenAIFastPolicyRule,
+  ThinkingDisplayMode,
   WeChatConnectMode,
   WebSearchEmulationConfig,
   WebSearchProviderConfig,
@@ -7686,6 +7723,9 @@ const rectifierForm = reactive({
   enabled: true,
   thinking_signature_enabled: true,
   thinking_budget_enabled: true,
+  // 与后端 DefaultRectifierSettings 保持一致：display_only 只取消隐藏已经产生并
+  // 计费的思考摘要，零成本；force 会改变成本与缓存行为，须由运维显式选择。
+  thinking_display_mode: "display_only" as ThinkingDisplayMode,
   apikey_signature_enabled: false,
   apikey_signature_patterns: [] as string[],
 });
@@ -10187,6 +10227,7 @@ async function saveRectifierSettings() {
       enabled: rectifierForm.enabled,
       thinking_signature_enabled: rectifierForm.thinking_signature_enabled,
       thinking_budget_enabled: rectifierForm.thinking_budget_enabled,
+      thinking_display_mode: rectifierForm.thinking_display_mode,
       apikey_signature_enabled: rectifierForm.apikey_signature_enabled,
       apikey_signature_patterns: rectifierForm.apikey_signature_patterns.filter(
         (p) => p.trim() !== "",


### PR DESCRIPTION
## 问题

Opus 4.8 / 4.7、Sonnet 5、Fable 5 上 `thinking.display` 默认为 `"omitted"`：模型照常思考、照常计费，但返回的 thinking block 文本为空字符串。客户端拿不到摘要，终端用户会误以为上游不支持思考、或是网关提供的服务被降级了。

这是相对 Opus 4.6 / Sonnet 4.6 的静默变更 —— 后两者的 `display` 默认就是 `"summarized"`，所以同一份客户端代码换了模型就"没有思考了"，且不报任何错。

## 方案

在整流器（`RectifierSettings`）下新增系统级三态开关 `ThinkingDisplayMode`：

| 档位 | 行为 | 成本 |
|---|---|---|
| `display_only`（默认） | 仅为已带 `thinking.type=adaptive` 的请求补 `display=summarized` | **零**。思考本来就在发生并计费，这只是取消隐藏 |
| `force` | 额外为完全未携带 thinking 的请求注入思考 | 真开销：额外 token + messages 层 prompt 缓存失效 |
| `off` | 完全不干预 | — |

默认取 `display_only` 而非 `force`：前者不改变任何成本与缓存行为，升级上来的部署不会平白多花钱；`force` 属于运维应当显式选择的决策。

### 顺带修复：`enabled` / `budget_tokens` 老写法

客户端发 `thinking.type="enabled"` 或 `budget_tokens` 给这些模型必定 400。现有的 `RectifyThinkingBudget` 400 后重试救不了它 —— 它只调整 `budget_tokens` 的**取值**，而这些模型是整个拒绝该**字段**，重试照样 400，白烧一次上游请求。本 PR 将其归一化为 `adaptive`。

### `max_tokens` 挤压

`max_tokens` 是「思考 + 正文」的总上限。在按无思考调校过 `max_tokens` 的请求上强开思考，会让思考挤占正文预算，正文被截断并以 `stop_reason="max_tokens"` 结束 —— 上游不报错，只有终端用户看得见。故 `force` 档同时抬高 `max_tokens`，并对流式/非流式取不同上限（非流式过高会撞 HTTP 超时）。

## 实现要点

- **注入点有两处**：主转发链路（`gateway_forward.go`）与 Anthropic API-key 直通链路（后者提前 `return`，不经过整流链）。只做一处会让同一用户因调度到的账号不同而时有时无 —— 比一直没有更像故障。
- **模型判定精确到 minor 版本**：`claude-opus-4-6` 与 `claude-opus-4-8` 的 `display` 默认值相反，任何 `claude-opus-4` 级别的前缀匹配都会把两者混为一谈。更老的模型（Sonnet 4.5 / Haiku 4.5 等）不认识 `adaptive`，一律不碰。
- **尊重客户端显式意图**：显式设过的 `display`、显式的 `{type:"disabled"}` 都不覆盖。
- **`GetThinkingDisplayMode` 带 nil 接收者守卫**：`GetRectifierSettings` 直接解引用 `settingRepo`，而本方法在网关热路径上调用（既有的 `IsBudgetRectifierEnabled` 有同样的隐患，只是它埋在 400 分支里）。
- **输出字节序确定**：逐字段 `sjson.Set` 而非一次性写入 map，避免 Go map 迭代顺序导致相同请求产生不同字节序。
- **全程 fail-safe**：任何一步出错都返回原 body，与本链路其余整流器一致。

## 测试

新增 `thinking_display_test.go`，38 个子测试，覆盖模型分层边界（4-6 vs 4-8）、三档模式门禁、`max_tokens` 抬高与不下调、显式意图保护、畸形 body fail-safe、输出确定性。

后端 `go build` / `go vet` / `internal/service` + `internal/handler/...` 全量测试通过；前端 `vue-tsc --noEmit`、`eslint`、`SettingsView.spec.ts`(22)、i18n specs(26) 全部通过。

## 界面

后台「请求整流器」区块新增三态下拉，选中 `force` 时动态展示成本警告（额外 token / 缓存失效 / max_tokens 抬高）。en / zh 文案均已补齐。
