### PR TITLE
feat: 支持从上游供应商同步 API Key 配额

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -2136,6 +2136,27 @@ func (h *AccountHandler) GetUsage(c *gin.Context) {
 	response.Success(c, usage)
 }
 
+// RefreshUpstreamQuota fetches a configured API-key provider quota and returns
+// the account with its existing quota fields refreshed.
+// POST /api/v1/admin/accounts/:id/upstream-quota
+func (h *AccountHandler) RefreshUpstreamQuota(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil || accountID <= 0 {
+		response.Error(c, http.StatusBadRequest, "invalid account ID")
+		return
+	}
+	if h.accountTestService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "upstream quota service is unavailable")
+		return
+	}
+	account, err := h.accountTestService.RefreshUpstreamQuota(c.Request.Context(), accountID)
+	if err != nil {
+		response.Error(c, http.StatusBadGateway, err.Error())
+		return
+	}
+	response.Success(c, h.buildAccountResponseWithRuntime(c.Request.Context(), account))
+}
+
 // ClearRateLimit handles clearing account rate limit status
 // POST /api/v1/admin/accounts/:id/clear-rate-limit
 func (h *AccountHandler) ClearRateLimit(c *gin.Context) {

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -338,6 +338,7 @@ func registerAccountRoutes(admin *gin.RouterGroup, h *handler.Handlers, stepUpAu
 		accounts.POST("/:id/clear-error", h.Admin.Account.ClearError)
 		accounts.POST("/:id/revert-proxy-fallback", h.Admin.Account.RevertProxyFallback)
 		accounts.GET("/:id/usage", h.Admin.Account.GetUsage)
+		accounts.POST("/:id/upstream-quota", h.Admin.Account.RefreshUpstreamQuota)
 		accounts.GET("/:id/today-stats", h.Admin.Account.GetTodayStats)
 		accounts.POST("/today-stats/batch", h.Admin.Account.GetBatchTodayStats)
 		accounts.POST("/:id/clear-rate-limit", h.Admin.Account.ClearRateLimit)

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -474,6 +474,9 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 		if err := ValidateQuotaResetConfig(account.Extra); err != nil {
 			return nil, err
 		}
+		if err := ValidateUpstreamQuotaProviderConfig(account.Type, account.Extra); err != nil {
+			return nil, err
+		}
 		ComputeQuotaResetAt(account.Extra)
 		NormalizeFixedQuotaWindows(account.Extra)
 	}
@@ -702,6 +705,9 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 		}
 		// 校验并预计算固定时间重置的下次重置时间
 		if err := ValidateQuotaResetConfig(account.Extra); err != nil {
+			return nil, err
+		}
+		if err := ValidateUpstreamQuotaProviderConfig(account.Type, account.Extra); err != nil {
 			return nil, err
 		}
 		ComputeQuotaResetAt(account.Extra)

--- a/backend/internal/service/upstream_quota_provider.go
+++ b/backend/internal/service/upstream_quota_provider.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	UpstreamQuotaProviderExtraKey = "upstream_quota_provider"
+	UpstreamQuotaSyncedAtExtraKey = "upstream_quota_synced_at"
+	UpstreamQuotaManual           = "manual"
+	UpstreamQuotaSub2API          = "sub2api"
+	UpstreamQuotaNewAPI           = "new-api"
+
+	upstreamQuotaTimeout      = 10 * time.Second
+	upstreamQuotaMaxBodyBytes = 64 * 1024
+	newAPIQuotaPerUSD         = 500000.0
+)
+
+// UpstreamQuota is the provider-neutral representation persisted into the
+// existing account quota fields. Keeping this model small lets new providers
+// be added without changing quota enforcement or the admin UI.
+type UpstreamQuota struct {
+	Limit float64 `json:"limit"`
+	Used  float64 `json:"used"`
+}
+
+// UpstreamQuotaProvider implements one upstream quota protocol (Strategy pattern).
+type UpstreamQuotaProvider interface {
+	Name() string
+	Path() string
+	Parse([]byte) (*UpstreamQuota, error)
+}
+
+type upstreamQuotaProviderRegistry struct {
+	providers map[string]UpstreamQuotaProvider
+}
+
+func newUpstreamQuotaProviderRegistry() *upstreamQuotaProviderRegistry {
+	providers := []UpstreamQuotaProvider{sub2APIQuotaProvider{}, newAPIQuotaProvider{}}
+	registry := &upstreamQuotaProviderRegistry{providers: make(map[string]UpstreamQuotaProvider, len(providers))}
+	for _, provider := range providers {
+		registry.providers[provider.Name()] = provider
+	}
+	return registry
+}
+
+func (r *upstreamQuotaProviderRegistry) Get(name string) (UpstreamQuotaProvider, bool) {
+	provider, ok := r.providers[strings.ToLower(strings.TrimSpace(name))]
+	return provider, ok
+}
+
+type sub2APIQuotaProvider struct{}
+
+func (sub2APIQuotaProvider) Name() string { return UpstreamQuotaSub2API }
+func (sub2APIQuotaProvider) Path() string { return "/v1/usage" }
+func (sub2APIQuotaProvider) Parse(body []byte) (*UpstreamQuota, error) {
+	var response struct {
+		Quota *struct {
+			Limit float64 `json:"limit"`
+			Used  float64 `json:"used"`
+		} `json:"quota"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode sub2api quota: %w", err)
+	}
+	if response.Quota == nil {
+		return nil, fmt.Errorf("sub2api response does not contain a limited API key quota")
+	}
+	return validateUpstreamQuota(response.Quota.Limit, response.Quota.Used)
+}
+
+type newAPIQuotaProvider struct{}
+
+func (newAPIQuotaProvider) Name() string { return UpstreamQuotaNewAPI }
+func (newAPIQuotaProvider) Path() string { return "/api/usage/token" }
+func (newAPIQuotaProvider) Parse(body []byte) (*UpstreamQuota, error) {
+	var response struct {
+		Code any `json:"code"`
+		Data *struct {
+			TotalGranted float64 `json:"total_granted"`
+			TotalUsed    float64 `json:"total_used"`
+			Unlimited    bool    `json:"unlimited_quota"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("decode new-api quota: %w", err)
+	}
+	if response.Data == nil || response.Data.Unlimited {
+		return nil, fmt.Errorf("new-api response does not contain a limited token quota")
+	}
+	return validateUpstreamQuota(response.Data.TotalGranted/newAPIQuotaPerUSD, response.Data.TotalUsed/newAPIQuotaPerUSD)
+}
+
+func validateUpstreamQuota(limit, used float64) (*UpstreamQuota, error) {
+	if limit <= 0 || used < 0 || math.IsNaN(limit) || math.IsNaN(used) || math.IsInf(limit, 0) || math.IsInf(used, 0) {
+		return nil, fmt.Errorf("invalid upstream quota values")
+	}
+	return &UpstreamQuota{Limit: limit, Used: used}, nil
+}
+
+func ValidateUpstreamQuotaProviderConfig(accountType string, extra map[string]any) error {
+	if extra == nil {
+		return nil
+	}
+	raw, exists := extra[UpstreamQuotaProviderExtraKey]
+	if !exists {
+		return nil
+	}
+	name, ok := raw.(string)
+	if !ok {
+		return fmt.Errorf("%s must be a string", UpstreamQuotaProviderExtraKey)
+	}
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" || name == UpstreamQuotaManual {
+		extra[UpstreamQuotaProviderExtraKey] = UpstreamQuotaManual
+		return nil
+	}
+	if accountType != AccountTypeAPIKey {
+		return fmt.Errorf("upstream quota providers are only supported for API key accounts")
+	}
+	if _, ok := newUpstreamQuotaProviderRegistry().Get(name); !ok {
+		return fmt.Errorf("unsupported upstream quota provider %q", name)
+	}
+	if parseExtraFloat64(extra["quota_limit"]) <= 0 {
+		return fmt.Errorf("quota_limit must be enabled before selecting an upstream quota provider")
+	}
+	extra[UpstreamQuotaProviderExtraKey] = name
+	return nil
+}
+
+// RefreshUpstreamQuota fetches and persists a configured API-key account quota.
+// Manual accounts deliberately bypass all network work and retain existing values.
+func (s *AccountTestService) RefreshUpstreamQuota(ctx context.Context, accountID int64) (*Account, error) {
+	account, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+	if account.Type != AccountTypeAPIKey {
+		return nil, fmt.Errorf("upstream quota is only supported for API key accounts")
+	}
+	providerName := account.getExtraString(UpstreamQuotaProviderExtraKey)
+	if providerName == "" || providerName == UpstreamQuotaManual {
+		return account, nil
+	}
+	provider, ok := newUpstreamQuotaProviderRegistry().Get(providerName)
+	if !ok {
+		return nil, fmt.Errorf("unsupported upstream quota provider %q", providerName)
+	}
+	if s.httpUpstream == nil {
+		return nil, fmt.Errorf("upstream transport is unavailable")
+	}
+	apiKey := account.GetCredential("api_key")
+	if apiKey == "" {
+		return nil, fmt.Errorf("API key is missing")
+	}
+	baseURL := account.GetCredential("base_url")
+	if baseURL == "" {
+		return nil, fmt.Errorf("base URL is required for upstream quota providers")
+	}
+	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+
+	requestCtx, cancel := context.WithTimeout(ctx, upstreamQuotaTimeout)
+	defer cancel()
+	requestURL := buildOpenAIEndpointURL(normalizedBaseURL, provider.Path())
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, requestURL, bytes.NewReader(nil))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	account.ApplyHeaderOverrides(req.Header)
+	req = req.WithContext(WithHTTPUpstreamRedirectsDisabled(WithHTTPUpstreamProfile(req.Context(), HTTPUpstreamProfileOpenAI)))
+
+	proxyURL := ""
+	if account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	var resp *http.Response
+	if s.tlsFPProfileService != nil {
+		resp, err = s.httpUpstream.DoWithTLS(req, proxyURL, account.ID, account.Concurrency, s.tlsFPProfileService.ResolveTLSProfile(account))
+	} else {
+		resp, err = s.httpUpstream.Do(req, proxyURL, account.ID, account.Concurrency)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("query %s quota: %w", provider.Name(), err)
+	}
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("query %s quota: empty response", provider.Name())
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, upstreamQuotaMaxBodyBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s quota: %w", provider.Name(), err)
+	}
+	if len(body) > upstreamQuotaMaxBodyBytes {
+		return nil, fmt.Errorf("%s quota response is too large", provider.Name())
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("%s quota request returned HTTP %d", provider.Name(), resp.StatusCode)
+	}
+	quota, err := provider.Parse(body)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.accountRepo.UpdateExtra(ctx, account.ID, map[string]any{
+		"quota_limit":                 quota.Limit,
+		"quota_used":                  quota.Used,
+		UpstreamQuotaSyncedAtExtraKey: time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		return nil, err
+	}
+	return s.accountRepo.GetByID(ctx, account.ID)
+}

--- a/backend/internal/service/upstream_quota_provider_test.go
+++ b/backend/internal/service/upstream_quota_provider_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpstreamQuotaProviderRegistry(t *testing.T) {
+	registry := newUpstreamQuotaProviderRegistry()
+	for _, name := range []string{UpstreamQuotaSub2API, UpstreamQuotaNewAPI} {
+		provider, ok := registry.Get(name)
+		require.True(t, ok)
+		require.Equal(t, name, provider.Name())
+	}
+	_, ok := registry.Get("unknown")
+	require.False(t, ok)
+}
+
+func TestSub2APIQuotaProviderParse(t *testing.T) {
+	quota, err := (sub2APIQuotaProvider{}).Parse([]byte(`{
+		"mode":"quota_limited",
+		"quota":{"limit":100,"used":23.5,"remaining":76.5,"unit":"USD"}
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, 100.0, quota.Limit)
+	require.Equal(t, 23.5, quota.Used)
+}
+
+func TestSub2APIQuotaProviderRejectsUnlimitedResponse(t *testing.T) {
+	_, err := (sub2APIQuotaProvider{}).Parse([]byte(`{"mode":"unrestricted","balance":20}`))
+	require.ErrorContains(t, err, "limited API key quota")
+}
+
+func TestNewAPIQuotaProviderParseAndNormalize(t *testing.T) {
+	quota, err := (newAPIQuotaProvider{}).Parse([]byte(`{
+		"code":true,
+		"data":{"object":"token_usage","total_granted":1000000,"total_used":125000,"total_available":875000,"unlimited_quota":false}
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, 2.0, quota.Limit)
+	require.Equal(t, 0.25, quota.Used)
+}
+
+func TestNewAPIQuotaProviderRejectsUnlimitedQuota(t *testing.T) {
+	_, err := (newAPIQuotaProvider{}).Parse([]byte(`{"code":true,"data":{"unlimited_quota":true}}`))
+	require.ErrorContains(t, err, "limited token quota")
+}
+
+func TestValidateUpstreamQuotaProviderConfig(t *testing.T) {
+	extra := map[string]any{
+		UpstreamQuotaProviderExtraKey: "NEW-API",
+		"quota_limit":                 1.0,
+	}
+	require.NoError(t, ValidateUpstreamQuotaProviderConfig(AccountTypeAPIKey, extra))
+	require.Equal(t, UpstreamQuotaNewAPI, extra[UpstreamQuotaProviderExtraKey])
+
+	require.Error(t, ValidateUpstreamQuotaProviderConfig(AccountTypeOAuth, extra))
+	require.Error(t, ValidateUpstreamQuotaProviderConfig(AccountTypeAPIKey, map[string]any{
+		UpstreamQuotaProviderExtraKey: UpstreamQuotaSub2API,
+	}))
+}

--- a/frontend/src/api/admin/accounts.ts
+++ b/frontend/src/api/admin/accounts.ts
@@ -349,6 +349,12 @@ export async function resetAccountQuota(id: number): Promise<Account> {
   return data
 }
 
+/** Synchronize quota_limit/quota_used from the configured upstream provider. */
+export async function refreshUpstreamQuota(id: number): Promise<Account> {
+  const { data } = await apiClient.post<Account>(`/admin/accounts/${id}/upstream-quota`)
+  return data
+}
+
 /**
  * Get temporary unschedulable status
  * @param id - Account ID

--- a/frontend/src/components/account/AccountCapacityCell.vue
+++ b/frontend/src/components/account/AccountCapacityCell.vue
@@ -31,22 +31,27 @@
     <!-- API Key 账号配额限制 -->
     <QuotaBadge v-if="showDailyQuota" :used="account.quota_daily_used ?? 0" :limit="account.quota_daily_limit!" label="D" />
     <QuotaBadge v-if="showWeeklyQuota" :used="account.quota_weekly_used ?? 0" :limit="account.quota_weekly_limit!" label="W" />
-    <QuotaBadge v-if="showTotalQuota" :used="account.quota_used ?? 0" :limit="account.quota_limit!" />
+    <QuotaBadge v-if="showTotalQuota" :used="displayQuotaUsed" :limit="displayQuotaLimit!" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import type { Account } from '@/types'
 import CapacityBadge from '@/components/account/CapacityBadge.vue'
 import QuotaBadge from '@/components/account/QuotaBadge.vue'
+import { refreshUpstreamQuota } from '@/api/admin/accounts'
 
 const props = defineProps<{
   account: Account
 }>()
 
 const { t } = useI18n()
+const syncedQuotaLimit = ref<number | null>(null)
+const syncedQuotaUsed = ref<number | null>(null)
+const displayQuotaLimit = computed(() => syncedQuotaLimit.value ?? props.account.quota_limit ?? null)
+const displayQuotaUsed = computed(() => syncedQuotaUsed.value ?? props.account.quota_used ?? 0)
 
 // ====== 并发 ======
 const currentConcurrency = computed(() => props.account.current_concurrency || 0)
@@ -185,6 +190,20 @@ const showWeeklyQuota = computed(() =>
   isQuotaEligible.value && props.account.quota_weekly_limit != null && props.account.quota_weekly_limit > 0
 )
 const showTotalQuota = computed(() =>
-  isQuotaEligible.value && props.account.quota_limit != null && props.account.quota_limit > 0
+  isQuotaEligible.value && displayQuotaLimit.value != null && displayQuotaLimit.value > 0
 )
+
+onMounted(async () => {
+  const provider = String(props.account.extra?.upstream_quota_provider ?? 'manual')
+  if (props.account.type !== 'apikey' || provider === 'manual') return
+  const syncedAt = Date.parse(String(props.account.extra?.upstream_quota_synced_at ?? ''))
+  if (Number.isFinite(syncedAt) && Date.now() - syncedAt < 3 * 60 * 1000) return
+  try {
+    const refreshed = await refreshUpstreamQuota(props.account.id)
+    syncedQuotaLimit.value = refreshed.quota_limit ?? null
+    syncedQuotaUsed.value = refreshed.quota_used ?? null
+  } catch {
+    // Keep displaying the last persisted quota when the upstream is unavailable.
+  }
+})
 </script>

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -1855,6 +1855,15 @@
           @update:weeklyResetHour="editWeeklyResetHour = $event"
           @update:resetTimezone="editResetTimezone = $event"
         />
+        <div v-if="form.type === 'apikey' && quotaLimitEnabled" class="rounded-lg border border-gray-200 p-3 dark:border-dark-600">
+          <label class="input-label">{{ t('admin.accounts.quotaControl.provider') }}</label>
+          <select v-model="upstreamQuotaProvider" class="input" data-testid="upstream-quota-provider">
+            <option value="manual">{{ t('admin.accounts.quotaControl.providerManual') }}</option>
+            <option value="sub2api">sub2api</option>
+            <option value="new-api">new-api</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.quotaControl.providerHint') }}</p>
+        </div>
       </div>
 
       <!-- 配额控制 (非 Anthropic apikey/bedrock) -->
@@ -1907,6 +1916,15 @@
           @update:weeklyResetHour="editWeeklyResetHour = $event"
           @update:resetTimezone="editResetTimezone = $event"
         />
+        <div v-if="form.type === 'apikey' && quotaLimitEnabled" class="rounded-lg border border-gray-200 p-3 dark:border-dark-600">
+          <label class="input-label">{{ t('admin.accounts.quotaControl.provider') }}</label>
+          <select v-model="upstreamQuotaProvider" class="input" data-testid="upstream-quota-provider">
+            <option value="manual">{{ t('admin.accounts.quotaControl.providerManual') }}</option>
+            <option value="sub2api">sub2api</option>
+            <option value="new-api">new-api</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.quotaControl.providerHint') }}</p>
+        </div>
       </div>
 
       <!-- Grok OAuth Custom Upstream URL (仅改写转发端点，OAuth 授权/刷新不受影响) -->
@@ -3682,6 +3700,8 @@ const syncPreviewCredentials = computed(() => {
 const editQuotaLimit = ref<number | null>(null)
 const editQuotaDailyLimit = ref<number | null>(null)
 const editQuotaWeeklyLimit = ref<number | null>(null)
+const upstreamQuotaProvider = ref<'manual' | 'sub2api' | 'new-api'>('manual')
+const quotaLimitEnabled = computed(() => (editQuotaLimit.value ?? 0) > 0)
 const editDailyResetMode = ref<'rolling' | 'fixed' | null>(null)
 const editDailyResetHour = ref<number | null>(null)
 const editWeeklyResetMode = ref<'rolling' | 'fixed' | null>(null)
@@ -4594,6 +4614,7 @@ const resetForm = () => {
   apiKeyBaseUrl.value = 'https://api.anthropic.com'
   apiKeyValue.value = ''
   editQuotaLimit.value = null
+  upstreamQuotaProvider.value = 'manual'
   editQuotaDailyLimit.value = null
   editQuotaWeeklyLimit.value = null
   editDailyResetMode.value = null
@@ -5164,6 +5185,9 @@ const createAccountAndFinish = async (
     }
     if (editQuotaWeeklyLimit.value != null && editQuotaWeeklyLimit.value > 0) {
       quotaExtra.quota_weekly_limit = editQuotaWeeklyLimit.value
+    }
+    if (type === 'apikey' && quotaLimitEnabled.value) {
+      quotaExtra.upstream_quota_provider = upstreamQuotaProvider.value
     }
     // Quota reset mode config
     if (editDailyResetMode.value === 'fixed') {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1733,6 +1733,15 @@
           @update:quotaNotifyTotalThreshold="quotaNotifyState.total.threshold = $event"
           @update:quotaNotifyTotalThresholdType="quotaNotifyState.total.thresholdType = $event"
         />
+        <div v-if="account?.type === 'apikey' && quotaLimitEnabled" class="rounded-lg border border-gray-200 p-3 dark:border-dark-600">
+          <label class="input-label">{{ t('admin.accounts.quotaControl.provider') }}</label>
+          <select v-model="upstreamQuotaProvider" class="input" data-testid="upstream-quota-provider">
+            <option value="manual">{{ t('admin.accounts.quotaControl.providerManual') }}</option>
+            <option value="sub2api">sub2api</option>
+            <option value="new-api">new-api</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.quotaControl.providerHint') }}</p>
+        </div>
       </div>
       <!-- 配额控制 (非 Anthropic apikey/bedrock) -->
       <div
@@ -1784,6 +1793,15 @@
           @update:quotaNotifyTotalThreshold="quotaNotifyState.total.threshold = $event"
           @update:quotaNotifyTotalThresholdType="quotaNotifyState.total.thresholdType = $event"
         />
+        <div v-if="account?.type === 'apikey' && quotaLimitEnabled" class="rounded-lg border border-gray-200 p-3 dark:border-dark-600">
+          <label class="input-label">{{ t('admin.accounts.quotaControl.provider') }}</label>
+          <select v-model="upstreamQuotaProvider" class="input" data-testid="upstream-quota-provider">
+            <option value="manual">{{ t('admin.accounts.quotaControl.providerManual') }}</option>
+            <option value="sub2api">sub2api</option>
+            <option value="new-api">new-api</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.quotaControl.providerHint') }}</p>
+        </div>
       </div>
 
       <!-- OpenAI API 长上下文计费开关 -->
@@ -2838,6 +2856,8 @@ adminAPI.settings.getWebSearchEmulationConfig().then(cfg => {
 
 loadQuotaNotifyGlobal()
 const editQuotaLimit = ref<number | null>(null)
+const upstreamQuotaProvider = ref<'manual' | 'sub2api' | 'new-api'>('manual')
+const quotaLimitEnabled = computed(() => (editQuotaLimit.value ?? 0) > 0)
 const editQuotaDailyLimit = ref<number | null>(null)
 const editQuotaWeeklyLimit = ref<number | null>(null)
 const editDailyResetMode = ref<'rolling' | 'fixed' | null>(null)
@@ -3324,6 +3344,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Load quota limit for apikey/bedrock accounts (bedrock quota is also loaded in its own branch above)
   if (newAccount.type === 'apikey' || newAccount.type === 'bedrock') {
     const quotaVal = extra?.quota_limit as number | undefined
+    upstreamQuotaProvider.value = (['sub2api', 'new-api'].includes(String(extra?.upstream_quota_provider))
+      ? extra?.upstream_quota_provider
+      : 'manual') as 'manual' | 'sub2api' | 'new-api'
     editQuotaLimit.value = (quotaVal && quotaVal > 0) ? quotaVal : null
     const dailyVal = extra?.quota_daily_limit as number | undefined
     editQuotaDailyLimit.value = (dailyVal && dailyVal > 0) ? dailyVal : null
@@ -4560,6 +4583,15 @@ const handleSubmit = async () => {
         newExtra.quota_limit = editQuotaLimit.value
       } else {
         delete newExtra.quota_limit
+      }
+      if (props.account.type === 'apikey' && quotaLimitEnabled.value) {
+        newExtra.upstream_quota_provider = upstreamQuotaProvider.value
+        if (upstreamQuotaProvider.value !== props.account.extra?.upstream_quota_provider) {
+          delete newExtra.upstream_quota_synced_at
+        }
+      } else {
+        delete newExtra.upstream_quota_provider
+        delete newExtra.upstream_quota_synced_at
       }
       // Daily quota
       if (editQuotaDailyLimit.value != null && editQuotaDailyLimit.value > 0) {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -644,6 +644,9 @@ export default {
       quotaControl: {
         title: 'Quota Control',
         hint: 'Configure cost window, session limits, client affinity and other scheduling controls.',
+        provider: 'Upstream quota provider',
+        providerManual: 'Manual',
+        providerHint: 'sub2api or new-api synchronizes the total and used quota while reusing the existing display and scheduling logic.',
         windowCost: {
           label: '5h Window Cost Limit',
           hint: 'Limit account cost usage within the 5-hour window',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -737,6 +737,9 @@ export default {
       quotaControl: {
         title: '配额控制',
         hint: '配置费用窗口、会话限制、客户端亲和等调度控制。',
+        provider: '上游额度供应商',
+        providerManual: '手动配置',
+        providerHint: 'sub2api 或 new-api 会从上游同步总额度和已用额度，并继续复用当前配额展示与调度逻辑。',
         windowCost: {
           label: '5h窗口费用控制',
           hint: '限制账号在5小时窗口内的费用使用',


### PR DESCRIPTION
## 变更内容

- 为 API Key 类型账号增加可扩展的上游额度供应商策略与注册机制
- 支持 `manual`、`sub2api` 和 `new-api` 三种额度供应商
- 将上游额度统一转换并写入现有的 `quota_limit`、`quota_used` 字段
- 复用现有账号容量徽标、配额限制及调度逻辑，无需增加平行的数据展示与判定分支
- 在 API Key 账号的创建和编辑页面增加上游额度供应商选项
- 增加管理员额度同步接口，并复用现有的上游代理、TLS 指纹、请求超时、禁止重定向和响应大小限制

## 供应商行为

- `manual`：保持当前手动配置逻辑，不发起任何上游请求
- `sub2api`：读取经过 API Key 认证的 `/v1/usage` 配额数据
- `new-api`：读取 `/api/usage/token`，并将内部 quota 单位统一转换为 USD

供应商通过策略接口和注册表管理，后续添加其他供应商时，不需要修改现有配额限制和页面展示逻辑。

上游同步失败时不会清空当前额度，页面继续展示最后一次成功保存的数据。

## 验证情况

- `vue-tsc --noEmit`：通过
- 变更涉及的前端文件 ESLint：通过
- `CreateAccountModal.spec.ts` 与 `EditAccountModal.spec.ts`：共 44 项测试通过
- 已增加后端单元测试，覆盖供应商注册、响应解析、额度单位转换、无限额度拒绝和配置校验

本机 Go 版本为 1.26.4，项目要求 Go 1.26.5，自动下载新工具链时网络超时，因此本地未能执行后端测试；新增测试将由 CI 使用项目要求的工具链继续验证。

Closes #4331
