### PR TITLE
fix(grok): retry CLI chat permission denial

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -323,7 +324,7 @@ func (t *grokAccessDeniedFallbackTransport) RoundTrip(req *http.Request) (*http.
 	}
 
 	body, ok := bufferSmallResponseBody(resp, grokFallbackBodyLimit)
-	if !ok || !bytes.Contains(bytes.ToLower(body), []byte("access denied")) {
+	if !ok || !isGrokCLICompatibilityAccessDenied(body) {
 		return resp, nil
 	}
 
@@ -348,6 +349,22 @@ func (t *grokAccessDeniedFallbackTransport) RoundTrip(req *http.Request) (*http.
 	}
 	slog.Warn("grok_cli_access_denied_api_fallback_succeeded", "method", req.Method, "path", req.URL.EscapedPath())
 	return fallbackResp, nil
+}
+
+func isGrokCLICompatibilityAccessDenied(body []byte) bool {
+	lower := bytes.ToLower(body)
+	if bytes.Contains(lower, []byte("access denied")) {
+		return true
+	}
+	var payload struct {
+		Code  string `json:"code"`
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil || !strings.EqualFold(strings.TrimSpace(payload.Code), "permission_denied") {
+		return false
+	}
+	const chatEndpointDeniedPrefix = "access to the chat endpoint is denied. please ensure you're using the correct credentials. if you believe this is a mistake, please"
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(payload.Error)), chatEndpointDeniedPrefix)
 }
 
 func isGrokCLIAccessDeniedFallbackCandidate(req *http.Request, resp *http.Response) bool {

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -311,6 +311,119 @@ func TestHTTPUpstreamDoFallsBackToOfficialGrokAPIOnCLIAccessDenied(t *testing.T)
 	require.Empty(t, fallbackHeaders.Get("User-Agent"))
 }
 
+func TestGrokAccessDeniedFallbackRecognizesChatEndpointPermissionDenied(t *testing.T) {
+	var hosts []string
+	transport := &grokAccessDeniedFallbackTransport{
+		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			hosts = append(hosts, req.URL.Hostname())
+			if req.URL.Hostname() == grokCLIProxyHost {
+				return &http.Response{
+					StatusCode: http.StatusForbidden,
+					Header:     make(http.Header),
+					Body: io.NopCloser(strings.NewReader(
+						`{"code":"permission_denied","error":"Access to the chat endpoint is denied. Please ensure you're using the correct credentials. If you believe this is a mistake, please contact support."}`,
+					)),
+					Request: req,
+				}, nil
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"id":"response-ok"}`)),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", strings.NewReader(`{"model":"grok-4.5"}`))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer oauth-token")
+	req.Header.Set("X-XAI-Token-Auth", "xai-grok-cli")
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, []string{grokCLIProxyHost, grokOfficialAPIHost}, hosts)
+}
+
+func TestIsGrokCLICompatibilityAccessDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "legacy compatibility wording", body: `{"error":"Access denied"}`, want: true},
+		{
+			name: "observed chat endpoint permission denial",
+			body: `{"code":"permission_denied","error":"Access to the chat endpoint is denied. Please ensure you're using the correct credentials. If you believe this is a mistake, please contact support."}`,
+			want: true,
+		},
+		{
+			name: "entitlement denial using the same broad terms",
+			body: `{"code":"permission_denied","error":"Access to the chat endpoint is denied because a subscription is required"}`,
+			want: false,
+		},
+		{
+			name: "different permission denied endpoint",
+			body: `{"code":"permission_denied","error":"Access to the billing endpoint is denied."}`,
+			want: false,
+		},
+		{
+			name: "wrong structured error code",
+			body: `{"code":"subscription_required","error":"Access to the chat endpoint is denied. Please ensure you're using the correct credentials. If you believe this is a mistake, please contact support."}`,
+			want: false,
+		},
+		{name: "malformed response", body: `permission_denied: chat endpoint denied`, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isGrokCLICompatibilityAccessDenied([]byte(tt.body)))
+		})
+	}
+}
+
+func TestIsGrokCLIAccessDeniedFallbackCandidateRequiresAuthenticatedReplayableCLI403(t *testing.T) {
+	newRequest := func() *http.Request {
+		req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", strings.NewReader(`{"model":"grok-4.5"}`))
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer oauth-token")
+		req.Header.Set("X-XAI-Token-Auth", "xai-grok-cli")
+		return req
+	}
+	newResponse := func() *http.Response { return &http.Response{StatusCode: http.StatusForbidden} }
+
+	t.Run("valid candidate", func(t *testing.T) {
+		require.True(t, isGrokCLIAccessDeniedFallbackCandidate(newRequest(), newResponse()))
+	})
+	t.Run("non CLI host", func(t *testing.T) {
+		req := newRequest()
+		req.URL.Host = "api.x.ai"
+		require.False(t, isGrokCLIAccessDeniedFallbackCandidate(req, newResponse()))
+	})
+	t.Run("missing CLI identity", func(t *testing.T) {
+		req := newRequest()
+		req.Header.Del("X-XAI-Token-Auth")
+		require.False(t, isGrokCLIAccessDeniedFallbackCandidate(req, newResponse()))
+	})
+	t.Run("missing bearer authentication", func(t *testing.T) {
+		req := newRequest()
+		req.Header.Del("Authorization")
+		require.False(t, isGrokCLIAccessDeniedFallbackCandidate(req, newResponse()))
+	})
+	t.Run("non forbidden response", func(t *testing.T) {
+		resp := newResponse()
+		resp.StatusCode = http.StatusUnauthorized
+		require.False(t, isGrokCLIAccessDeniedFallbackCandidate(newRequest(), resp))
+	})
+	t.Run("non replayable request", func(t *testing.T) {
+		req := newRequest()
+		req.GetBody = nil
+		require.False(t, isGrokCLIAccessDeniedFallbackCandidate(req, newResponse()))
+	})
+}
+
 func TestHTTPUpstreamDoDoesNotFallbackForGrokEntitlementDenial(t *testing.T) {
 	transport := &grokAccessDeniedFallbackTransport{
 		base: roundTripFunc(func(req *http.Request) (*http.Response, error) {


### PR DESCRIPTION
## Summary

- recognize the structured Grok CLI 403 reported in #4525 as the newer compatibility-denial wording
- reuse the existing authenticated, replayable fallback from the CLI proxy to the official xAI API
- keep unrelated entitlement denials on the original CLI response

## Root cause

The account-test path already routes OAuth traffic to the CLI subscription endpoint and the shared transport already supplies the required CLI identity headers. The existing compatibility fallback, however, only recognized the older contiguous phrase `access denied`.

The reported response uses `code: permission_denied` with `Access to the chat endpoint is denied...`, so the fallback was never attempted even though this is the same compatibility boundary.

This change parses that structured response and requires the observed code and message prefix. It does not broaden fallback to generic permission or subscription failures. The existing transport still retries only authenticated, replayable CLI-proxy 403 requests and only substitutes the official API response when that response is successful.

## Version diagnosis

No CLI version bump is included. The current pinned version may be overridden by operators, but the issue does not prove that version drift caused this permission denial.

## Validation

- regression reproduces the exact #4525 response wording and confirms the official API retry
- entitlement and near-miss permission denials do not retry
- non-CLI, unauthenticated, non-403, and non-replayable requests cannot trigger credential replay
- `go test -tags=unit ./internal/repository -count=1`
- `git diff --check`
- independent changed-path review found no actionable issues

Live success with the reporter's credential remains unverified because no affected OAuth credential was available to this change.

Addresses #4525
