### PR TITLE
feat(auth): show "Last time used" badge on the last OAuth provider

### DIFF
--- a/frontend/src/components/auth/DingTalkOAuthSection.vue
+++ b/frontend/src/components/auth/DingTalkOAuthSection.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="space-y-4">
-    <button type="button" :disabled="disabled" class="btn btn-secondary w-full" @click="startLogin">
+    <button type="button" :disabled="disabled" class="btn btn-secondary relative w-full" @click="startLogin">
+      <LastUsedBadge v-if="lastUsedProvider === 'dingtalk'" />
       <svg
         class="icon mr-2"
         viewBox="0 0 24 24"
@@ -38,13 +39,17 @@
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { resolveAffiliateReferralCode, storeOAuthAffiliateCode } from '@/utils/oauthAffiliate'
+import { setPendingOAuthProvider, type OAuthProviderId } from '@/utils/lastUsedOAuth'
+import LastUsedBadge from './LastUsedBadge.vue'
 
 const props = withDefaults(defineProps<{
   disabled?: boolean
   affCode?: string
   showDivider?: boolean
+  lastUsedProvider?: OAuthProviderId | null
 }>(), {
-  showDivider: true
+  showDivider: true,
+  lastUsedProvider: null
 })
 
 const route = useRoute()
@@ -53,6 +58,7 @@ const { t } = useI18n()
 function startLogin(): void {
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   storeOAuthAffiliateCode(resolveAffiliateReferralCode(props.affCode, route.query.aff, route.query.aff_code))
+  setPendingOAuthProvider('dingtalk')
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')
   const startURL = `${normalized}/auth/oauth/dingtalk/start?redirect=${encodeURIComponent(redirectTo)}`

--- a/frontend/src/components/auth/EmailOAuthButtons.vue
+++ b/frontend/src/components/auth/EmailOAuthButtons.vue
@@ -14,9 +14,10 @@
         :key="provider"
         type="button"
         :disabled="disabled"
-        class="btn btn-secondary h-12 w-full justify-center gap-2"
+        class="btn btn-secondary relative h-12 w-full justify-center gap-2"
         @click="startLogin(provider)"
       >
+        <LastUsedBadge v-if="lastUsedProvider === provider" />
         <GitHubMark v-if="provider === 'github'" class="h-5 w-5 text-gray-800 dark:text-gray-100" />
         <GoogleMark v-else class="h-5 w-5" />
         <span class="font-medium">{{ providerLabel(provider) }}</span>
@@ -32,6 +33,8 @@ import { useI18n } from 'vue-i18n'
 import GitHubMark from './GitHubMark.vue'
 import GoogleMark from './GoogleMark.vue'
 import { resolveAffiliateReferralCode, storeOAuthAffiliateCode } from '@/utils/oauthAffiliate'
+import { setPendingOAuthProvider, type OAuthProviderId } from '@/utils/lastUsedOAuth'
+import LastUsedBadge from './LastUsedBadge.vue'
 
 type EmailOAuthProvider = 'github' | 'google'
 const EMAIL_OAUTH_PENDING_PROVIDER_KEY = 'email_oauth_pending_provider'
@@ -42,8 +45,10 @@ const props = withDefaults(defineProps<{
   githubEnabled?: boolean
   googleEnabled?: boolean
   showDivider?: boolean
+  lastUsedProvider?: OAuthProviderId | null
 }>(), {
-  showDivider: true
+  showDivider: true,
+  lastUsedProvider: null
 })
 
 const route = useRoute()
@@ -75,6 +80,7 @@ function startLogin(provider: EmailOAuthProvider): void {
   const affiliateCode = resolveAffiliateReferralCode(props.affCode, route.query.aff, route.query.aff_code)
   storeOAuthAffiliateCode(affiliateCode)
   window.sessionStorage.setItem(EMAIL_OAUTH_PENDING_PROVIDER_KEY, provider)
+  setPendingOAuthProvider(provider)
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')
   const params = new URLSearchParams({ redirect: redirectTo })

--- a/frontend/src/components/auth/LastUsedBadge.vue
+++ b/frontend/src/components/auth/LastUsedBadge.vue
@@ -1,0 +1,13 @@
+<template>
+  <span
+    class="pointer-events-none absolute -right-2 -top-2 z-10 rounded-full bg-primary-500 px-2 py-0.5 text-[10px] font-medium leading-tight text-white shadow-sm shadow-primary-500/30"
+  >
+    {{ t('auth.lastTimeUsed') }}
+  </span>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n()
+</script>

--- a/frontend/src/components/auth/LinuxDoOAuthSection.vue
+++ b/frontend/src/components/auth/LinuxDoOAuthSection.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="space-y-4">
-    <button type="button" :disabled="disabled" class="btn btn-secondary w-full" @click="startLogin">
+    <button type="button" :disabled="disabled" class="btn btn-secondary relative w-full" @click="startLogin">
+      <LastUsedBadge v-if="lastUsedProvider === 'linuxdo'" />
       <svg
         class="icon mr-2"
         viewBox="0 0 16 16"
@@ -43,13 +44,17 @@
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { resolveAffiliateReferralCode, storeOAuthAffiliateCode } from '@/utils/oauthAffiliate'
+import { setPendingOAuthProvider, type OAuthProviderId } from '@/utils/lastUsedOAuth'
+import LastUsedBadge from './LastUsedBadge.vue'
 
 const props = withDefaults(defineProps<{
   disabled?: boolean
   affCode?: string
   showDivider?: boolean
+  lastUsedProvider?: OAuthProviderId | null
 }>(), {
-  showDivider: true
+  showDivider: true,
+  lastUsedProvider: null
 })
 
 const route = useRoute()
@@ -58,6 +63,7 @@ const { t } = useI18n()
 function startLogin(): void {
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   storeOAuthAffiliateCode(resolveAffiliateReferralCode(props.affCode, route.query.aff, route.query.aff_code))
+  setPendingOAuthProvider('linuxdo')
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')
   const startURL = `${normalized}/auth/oauth/linuxdo/start?redirect=${encodeURIComponent(redirectTo)}`

--- a/frontend/src/components/auth/OidcOAuthSection.vue
+++ b/frontend/src/components/auth/OidcOAuthSection.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="space-y-4">
-    <button type="button" :disabled="disabled" class="btn btn-secondary w-full" @click="startLogin">
+    <button type="button" :disabled="disabled" class="btn btn-secondary relative w-full" @click="startLogin">
+      <LastUsedBadge v-if="lastUsedProvider === 'oidc'" />
       <span
         class="mr-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary-100 text-xs font-semibold text-primary-700 dark:bg-primary-900/30 dark:text-primary-300"
       >
@@ -24,15 +25,19 @@ import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { resolveAffiliateReferralCode, storeOAuthAffiliateCode } from '@/utils/oauthAffiliate'
+import { setPendingOAuthProvider, type OAuthProviderId } from '@/utils/lastUsedOAuth'
+import LastUsedBadge from './LastUsedBadge.vue'
 
 const props = withDefaults(defineProps<{
   disabled?: boolean
   affCode?: string
   providerName?: string
   showDivider?: boolean
+  lastUsedProvider?: OAuthProviderId | null
 }>(), {
   providerName: 'OIDC',
-  showDivider: true
+  showDivider: true,
+  lastUsedProvider: null
 })
 
 const route = useRoute()
@@ -48,6 +53,7 @@ const providerInitial = computed(() => normalizedProviderName.value.charAt(0).to
 function startLogin(): void {
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   storeOAuthAffiliateCode(resolveAffiliateReferralCode(props.affCode, route.query.aff, route.query.aff_code))
+  setPendingOAuthProvider('oidc')
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')
   const startURL = `${normalized}/auth/oauth/oidc/start?redirect=${encodeURIComponent(redirectTo)}`

--- a/frontend/src/components/auth/WechatOAuthSection.vue
+++ b/frontend/src/components/auth/WechatOAuthSection.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="space-y-4">
-    <button type="button" :disabled="buttonDisabled" class="btn btn-secondary w-full" @click="startLogin">
+    <button type="button" :disabled="buttonDisabled" class="btn btn-secondary relative w-full" @click="startLogin">
+      <LastUsedBadge v-if="lastUsedProvider === 'wechat'" />
       <span
         class="mr-2 inline-flex h-5 w-5 items-center justify-center rounded-full bg-green-100 text-xs font-semibold text-green-700 dark:bg-green-900/30 dark:text-green-300"
       >
@@ -34,13 +35,17 @@ import { useI18n } from 'vue-i18n'
 import { resolveWeChatOAuthStart } from '@/api/auth'
 import { useAppStore } from '@/stores'
 import { resolveAffiliateReferralCode, storeOAuthAffiliateCode } from '@/utils/oauthAffiliate'
+import { setPendingOAuthProvider, type OAuthProviderId } from '@/utils/lastUsedOAuth'
+import LastUsedBadge from './LastUsedBadge.vue'
 
 const props = withDefaults(defineProps<{
   disabled?: boolean
   affCode?: string
   showDivider?: boolean
+  lastUsedProvider?: OAuthProviderId | null
 }>(), {
   showDivider: true,
+  lastUsedProvider: null,
 })
 
 const appStore = useAppStore()
@@ -87,6 +92,7 @@ function startLogin(): void {
   }
   const redirectTo = (route.query.redirect as string) || '/dashboard'
   storeOAuthAffiliateCode(resolveAffiliateReferralCode(props.affCode, route.query.aff, route.query.aff_code))
+  setPendingOAuthProvider('wechat')
   const apiBase = (import.meta.env.VITE_API_BASE_URL as string | undefined) || '/api/v1'
   const normalized = apiBase.replace(/\/$/, '')
   const mode = resolvedStart.value.mode

--- a/frontend/src/components/auth/__tests__/lastUsedBadge.render.spec.ts
+++ b/frontend/src/components/auth/__tests__/lastUsedBadge.render.spec.ts
@@ -1,0 +1,66 @@
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import EmailOAuthButtons from '@/components/auth/EmailOAuthButtons.vue'
+
+const routeState = vi.hoisted(() => ({
+  query: {} as Record<string, unknown>,
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => routeState,
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    // return the key so the badge renders a stable, assertable string
+    t: (key: string) => key,
+  }),
+}))
+
+const BADGE_TEXT = 'auth.lastTimeUsed'
+
+function mountButtons(lastUsedProvider: string | null) {
+  return mount(EmailOAuthButtons, {
+    props: {
+      githubEnabled: true,
+      googleEnabled: true,
+      lastUsedProvider,
+    },
+    global: {
+      stubs: { GitHubMark: true, GoogleMark: true },
+    },
+  })
+}
+
+describe('LastUsedBadge rendering on OAuth buttons', () => {
+  beforeEach(() => {
+    routeState.query = {}
+    window.localStorage.clear()
+    window.sessionStorage.clear()
+  })
+
+  it('renders the badge only on the last-used provider button', () => {
+    const wrapper = mountButtons('google')
+    const buttons = wrapper.findAll('button')
+    expect(buttons).toHaveLength(2)
+
+    const githubBtn = buttons.find((b) => b.text().includes('GitHub'))!
+    const googleBtn = buttons.find((b) => b.text().includes('Google'))!
+
+    expect(googleBtn.text()).toContain(BADGE_TEXT)
+    expect(githubBtn.text()).not.toContain(BADGE_TEXT)
+    // exactly one badge on the page
+    expect(wrapper.html().split(BADGE_TEXT).length - 1).toBe(1)
+  })
+
+  it('renders no badge when there is no last-used provider', () => {
+    const wrapper = mountButtons(null)
+    expect(wrapper.text()).not.toContain(BADGE_TEXT)
+  })
+
+  it('renders no badge when the last-used provider is not shown here', () => {
+    // e.g. last login was linuxdo, which is not one of these email buttons
+    const wrapper = mountButtons('linuxdo')
+    expect(wrapper.text()).not.toContain(BADGE_TEXT)
+  })
+})

--- a/frontend/src/i18n/locales/en/common.ts
+++ b/frontend/src/i18n/locales/en/common.ts
@@ -274,6 +274,7 @@ export default {
     invitationCodeValidating: 'Validating invitation code...',
     invitationCodeInvalidCannotRegister: 'Invalid invitation code. Please check and try again',
     oauthOrContinue: 'or continue with others',
+    lastTimeUsed: 'Last time used',
     linuxdo: {
       signIn: 'Continue with Linux.do',
       orContinue: 'or continue with email',

--- a/frontend/src/i18n/locales/zh/common.ts
+++ b/frontend/src/i18n/locales/zh/common.ts
@@ -273,6 +273,7 @@ export default {
     invitationCodeValidating: '正在验证邀请码...',
     invitationCodeInvalidCannotRegister: '邀请码无效，请检查后重试',
     oauthOrContinue: '或使用其他继续',
+    lastTimeUsed: '上次使用',
     linuxdo: {
       signIn: '使用 Linux.do 登录',
       orContinue: '或使用邮箱密码继续',

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -7,6 +7,7 @@ import { defineStore } from 'pinia'
 import { ref, computed, readonly } from 'vue'
 import { authAPI, isTotp2FARequired, type LoginResponse } from '@/api'
 import type { User, LoginRequest, RegisterRequest, AuthResponse } from '@/types'
+import { clearLastUsedOAuthProvider, promotePendingOAuthProvider } from '@/utils/lastUsedOAuth'
 
 const AUTH_TOKEN_KEY = 'auth_token'
 const AUTH_USER_KEY = 'auth_user'
@@ -300,6 +301,9 @@ export const useAuthStore = defineStore('auth', () => {
     localStorage.setItem(AUTH_TOKEN_KEY, response.access_token)
     localStorage.setItem(AUTH_USER_KEY, JSON.stringify(userData))
     clearPendingAuthSession()
+    // Password / 2FA / register login: the last login was not an OAuth provider,
+    // so drop any "last time used" OAuth hint shown on the login page.
+    clearLastUsedOAuthProvider()
 
     // Start auto-refresh interval for user data
     startAutoRefresh()
@@ -370,6 +374,9 @@ export const useAuthStore = defineStore('auth', () => {
       }
 
       clearPendingAuthSession()
+      // OAuth / SSO callback succeeded: promote the provider stashed on click
+      // to the persisted "last time used" hint for the login page.
+      promotePendingOAuthProvider()
       return userData
     } catch (error) {
       clearAuth({ preservePendingAuthSession: pendingAuthSession.value !== null })

--- a/frontend/src/utils/__tests__/lastUsedOAuth.spec.ts
+++ b/frontend/src/utils/__tests__/lastUsedOAuth.spec.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearLastUsedOAuthProvider,
+  getLastUsedOAuthProvider,
+  promotePendingOAuthProvider,
+  setPendingOAuthProvider
+} from '../lastUsedOAuth'
+
+const PENDING_KEY = 'sub2api_pending_oauth_provider'
+const LAST_USED_KEY = 'sub2api_last_used_oauth'
+const NINETY_DAYS_MS = 90 * 24 * 60 * 60 * 1000
+
+describe('lastUsedOAuth', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('promotes a pending provider to the last-used slot on success', () => {
+    setPendingOAuthProvider('github')
+    expect(sessionStorage.getItem(PENDING_KEY)).toBe('github')
+
+    promotePendingOAuthProvider()
+
+    expect(getLastUsedOAuthProvider()).toBe('github')
+    // pending is consumed after promotion
+    expect(sessionStorage.getItem(PENDING_KEY)).toBeNull()
+  })
+
+  it('is a no-op when there is no pending provider (does not clobber existing value)', () => {
+    setPendingOAuthProvider('linuxdo')
+    promotePendingOAuthProvider()
+    expect(getLastUsedOAuthProvider()).toBe('linuxdo')
+
+    // e.g. an email-verification link hits setToken with nothing pending
+    promotePendingOAuthProvider()
+    expect(getLastUsedOAuthProvider()).toBe('linuxdo')
+  })
+
+  it('clears the last-used hint (password / 2FA / register path)', () => {
+    setPendingOAuthProvider('google')
+    promotePendingOAuthProvider()
+    expect(getLastUsedOAuthProvider()).toBe('google')
+
+    clearLastUsedOAuthProvider()
+
+    expect(getLastUsedOAuthProvider()).toBeNull()
+    expect(localStorage.getItem(LAST_USED_KEY)).toBeNull()
+    expect(sessionStorage.getItem(PENDING_KEY)).toBeNull()
+  })
+
+  it('expires and prunes a record older than 90 days', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+
+    setPendingOAuthProvider('oidc')
+    promotePendingOAuthProvider()
+    expect(getLastUsedOAuthProvider()).toBe('oidc')
+
+    // just under 90 days: still valid
+    vi.setSystemTime(new Date(Date.now() + NINETY_DAYS_MS - 1000))
+    expect(getLastUsedOAuthProvider()).toBe('oidc')
+
+    // just over 90 days: expired and pruned
+    vi.setSystemTime(new Date(Date.now() + 2000))
+    expect(getLastUsedOAuthProvider()).toBeNull()
+    expect(localStorage.getItem(LAST_USED_KEY)).toBeNull()
+  })
+
+  it('ignores an unknown pending provider value', () => {
+    sessionStorage.setItem(PENDING_KEY, 'myspace')
+    promotePendingOAuthProvider()
+    expect(getLastUsedOAuthProvider()).toBeNull()
+  })
+
+  it('returns null for a malformed stored record', () => {
+    localStorage.setItem(LAST_USED_KEY, 'not-json')
+    expect(getLastUsedOAuthProvider()).toBeNull()
+    expect(localStorage.getItem(LAST_USED_KEY)).toBeNull()
+  })
+})

--- a/frontend/src/utils/lastUsedOAuth.ts
+++ b/frontend/src/utils/lastUsedOAuth.ts
@@ -1,0 +1,120 @@
+/**
+ * "Last time used" OAuth hint.
+ *
+ * Purely browser-local (per device / per browser): the login page is
+ * unauthenticated, so the server cannot tell us which provider this visitor
+ * used last. We record the provider the user actually completed a login with
+ * and surface it on the login page as a subtle badge, similar to Google's
+ * account chooser "Last used" marker.
+ *
+ * Flow:
+ *  - On click, before redirecting to the provider, the button calls
+ *    {@link setPendingOAuthProvider}.
+ *  - On a successful OAuth callback (auth store `setToken`), we call
+ *    {@link promotePendingOAuthProvider} to persist the pending provider as the
+ *    last-used one.
+ *  - On a password / 2FA / register success (auth store `setAuthFromResponse`),
+ *    we call {@link clearLastUsedOAuthProvider} so the badge never shows stale
+ *    info: the last login was not an OAuth provider.
+ *
+ * The value expires after 90 days so a shared/public browser does not leak a
+ * previous visitor's provider forever.
+ */
+
+export type OAuthProviderId = 'github' | 'google' | 'linuxdo' | 'dingtalk' | 'wechat' | 'oidc'
+
+const VALID_PROVIDERS: readonly OAuthProviderId[] = [
+  'github',
+  'google',
+  'linuxdo',
+  'dingtalk',
+  'wechat',
+  'oidc'
+]
+
+const PENDING_KEY = 'sub2api_pending_oauth_provider'
+const LAST_USED_KEY = 'sub2api_last_used_oauth'
+const MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000 // 90 days
+
+interface LastUsedRecord {
+  provider: OAuthProviderId
+  ts: number
+}
+
+function isValidProvider(value: unknown): value is OAuthProviderId {
+  return typeof value === 'string' && (VALID_PROVIDERS as readonly string[]).includes(value)
+}
+
+/** Record which provider the user is about to authenticate with (call on click). */
+export function setPendingOAuthProvider(provider: OAuthProviderId): void {
+  try {
+    window.sessionStorage.setItem(PENDING_KEY, provider)
+  } catch {
+    // storage unavailable (private mode / disabled) — degrade silently
+  }
+}
+
+/**
+ * Promote a pending provider to the persisted "last used" slot.
+ * Call on a successful OAuth login. No-op when there is no pending provider
+ * (e.g. an email-verification link), so it never clobbers an existing value.
+ */
+export function promotePendingOAuthProvider(): void {
+  try {
+    const pending = window.sessionStorage.getItem(PENDING_KEY)
+    if (!isValidProvider(pending)) return
+    window.sessionStorage.removeItem(PENDING_KEY)
+    const record: LastUsedRecord = { provider: pending, ts: Date.now() }
+    window.localStorage.setItem(LAST_USED_KEY, JSON.stringify(record))
+  } catch {
+    // storage unavailable — degrade silently
+  }
+}
+
+/**
+ * Forget the last-used provider. Call on a password / 2FA / register success so
+ * the badge reflects the true last login method.
+ */
+export function clearLastUsedOAuthProvider(): void {
+  try {
+    window.localStorage.removeItem(LAST_USED_KEY)
+    window.sessionStorage.removeItem(PENDING_KEY)
+  } catch {
+    // storage unavailable — degrade silently
+  }
+}
+
+/**
+ * Read the last-used provider for display, or null when there is none or it has
+ * expired. Expired / malformed records are pruned as a side effect.
+ */
+export function getLastUsedOAuthProvider(): OAuthProviderId | null {
+  let raw: string | null = null
+  try {
+    raw = window.localStorage.getItem(LAST_USED_KEY)
+  } catch {
+    return null
+  }
+  if (!raw) return null
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<LastUsedRecord>
+    if (
+      isValidProvider(parsed.provider) &&
+      typeof parsed.ts === 'number' &&
+      Date.now() - parsed.ts <= MAX_AGE_MS
+    ) {
+      return parsed.provider
+    }
+  } catch {
+    // malformed JSON — fall through and prune below
+  }
+
+  // expired, malformed, or invalid: prune and report nothing
+  try {
+    window.localStorage.removeItem(LAST_USED_KEY)
+  } catch {
+    // ignore
+  }
+  return null
+}

--- a/frontend/src/views/auth/LoginView.vue
+++ b/frontend/src/views/auth/LoginView.vue
@@ -145,28 +145,33 @@
             :github-enabled="githubOAuthEnabled"
             :google-enabled="googleOAuthEnabled"
             :show-divider="false"
+            :last-used-provider="lastUsedOAuthProvider"
           />
 
           <LinuxDoOAuthSection
             v-if="linuxdoOAuthEnabled"
             :disabled="authActionDisabled"
             :show-divider="false"
+            :last-used-provider="lastUsedOAuthProvider"
           />
           <DingTalkOAuthSection
             v-if="dingtalkOAuthEnabled"
             :disabled="authActionDisabled"
             :show-divider="false"
+            :last-used-provider="lastUsedOAuthProvider"
           />
           <WechatOAuthSection
             v-if="wechatOAuthEnabled"
             :disabled="authActionDisabled"
             :show-divider="false"
+            :last-used-provider="lastUsedOAuthProvider"
           />
           <OidcOAuthSection
             v-if="oidcOAuthEnabled"
             :disabled="authActionDisabled"
             :provider-name="oidcOAuthProviderName"
             :show-divider="false"
+            :last-used-provider="lastUsedOAuthProvider"
           />
         </div>
       </form>
@@ -216,6 +221,7 @@ import { getPublicSettings, isTotp2FARequired, isWeChatWebOAuthEnabled } from '@
 import type { LoginAgreementDocument, TotpLoginResponse } from '@/types'
 import { extractI18nErrorMessage } from '@/utils/apiError'
 import { clearAllAffiliateReferralCodes } from '@/utils/oauthAffiliate'
+import { getLastUsedOAuthProvider } from '@/utils/lastUsedOAuth'
 
 const { t } = useI18n()
 const LOGIN_AGREEMENT_STORAGE_KEY = 'sub2api_login_agreement_consent'
@@ -244,6 +250,8 @@ const oidcOAuthEnabled = ref<boolean>(false)
 const oidcOAuthProviderName = ref<string>('OIDC')
 const githubOAuthEnabled = ref<boolean>(false)
 const googleOAuthEnabled = ref<boolean>(false)
+// Per-device "last time used" OAuth hint, read once from local storage.
+const lastUsedOAuthProvider = ref(getLastUsedOAuthProvider())
 const passwordResetEnabled = ref<boolean>(false)
 const loginAgreementEnabled = ref<boolean>(false)
 const loginAgreementMode = ref<'modal' | 'checkbox' | string>('modal')


### PR DESCRIPTION
## What

Adds a **"Last time used"** badge to the login page, marking the OAuth provider the visitor most recently completed a login with — much like Google's account chooser. When several OAuth providers are configured, only the one the user last used gets the badge, so returning users can pick the right button at a glance.

Password / 2FA logins intentionally get **no** badge.

## Why it's browser-local (not server-side)

The login page is unauthenticated, so the server can't tell the page which provider *this* visitor used last. The hint is therefore stored **per browser/device** in local storage (same model as Google's "Last used"). New device / cleared storage → no badge.

## How

- **`utils/lastUsedOAuth.ts`** — the whole mechanism in one place:
  - `setPendingOAuthProvider(id)` — stashed in `sessionStorage` at click, before the redirect.
  - `promotePendingOAuthProvider()` — on a successful OAuth login, promote the pending provider into a persisted "last used" record (`{ provider, ts }`). No-op when nothing is pending, so it never clobbers an existing value (e.g. email-verification links).
  - `clearLastUsedOAuthProvider()` — on password/2FA/register login, so the badge never shows stale info.
  - `getLastUsedOAuthProvider()` — read for display; **expires after 90 days** and prunes malformed/expired records, so a shared/public browser doesn't leak a previous visitor's provider indefinitely.
- **`stores/auth.ts`** — two one-line hooks at the existing choke points: promote in `setToken` (all OAuth/SSO callbacks funnel here), clear in `setAuthFromResponse` (password/2FA/register funnel here).
- **OAuth sections** (GitHub/Google, Linux.do, DingTalk, WeChat, OIDC) — each records its provider on click and renders a small `LastUsedBadge` in the button's top-right corner when it matches. `LoginView` reads the hint once and passes it down.
- **i18n** — `auth.lastTimeUsed` added to `en` and `zh`.

## Tests

- `utils/__tests__/lastUsedOAuth.spec.ts` — promote / no-op-without-pending / clear / 90-day expiry / invalid & malformed handling.
- `components/auth/__tests__/lastUsedBadge.render.spec.ts` — badge renders only on the matching provider button, and not at all when the last-used provider isn't shown.

Full frontend suite green (1209 tests), `typecheck`, `lint`, and `build` all pass.

## Notes

The change surface is intentionally small and localized (one util + two auth-store lines + a badge per provider button) to stay easy to review and to keep future merges clean.

---

## Screenshots

Real login page in local dev. OAuth providers are off in a fresh dev seed, so they were toggled on just for the demo — the **badge itself and the `localStorage` last-used logic are the real code path** (the hint is seeded exactly as a successful OAuth login writes it).

**Last login = GitHub** — badge on the GitHub button:

![Last time used — GitHub](https://raw.githubusercontent.com/broven/sub2api-upstream/assets/last-used-screenshots/last-used-github.png)

**Last login = Linux.do** — the badge moves to the Linux.do button:

![Last time used — Linux.do](https://raw.githubusercontent.com/broven/sub2api-upstream/assets/last-used-screenshots/last-used-linuxdo.png)

**Password login / no history** — no badge shown:

![No badge](https://raw.githubusercontent.com/broven/sub2api-upstream/assets/last-used-screenshots/last-used-none.png)
