### PR TITLE
修复 Grok 免费额度耗尽识别与限流冷却

### DIFF
--- a/backend/internal/pkg/xai/quota.go
+++ b/backend/internal/pkg/xai/quota.go
@@ -18,6 +18,7 @@ type QuotaSnapshot struct {
 	Requests          *QuotaWindow      `json:"requests,omitempty"`
 	Tokens            *QuotaWindow      `json:"tokens,omitempty"`
 	RetryAfterSeconds *int              `json:"retry_after_seconds,omitempty"`
+	ProviderErrorCode string            `json:"provider_error_code,omitempty"`
 	SubscriptionTier  string            `json:"subscription_tier,omitempty"`
 	EntitlementStatus string            `json:"entitlement_status,omitempty"`
 	StatusCode        int               `json:"status_code,omitempty"`

--- a/backend/internal/service/gateway_upstream_response.go
+++ b/backend/internal/service/gateway_upstream_response.go
@@ -311,6 +311,9 @@ func extractUpstreamErrorCode(body []byte) string {
 	if code := strings.TrimSpace(gjson.GetBytes(body, "error.code").String()); code != "" {
 		return code
 	}
+	if code := strings.TrimSpace(gjson.GetBytes(body, "code").String()); code != "" {
+		return code
+	}
 
 	inner := strings.TrimSpace(gjson.GetBytes(body, "error.message").String())
 	if !strings.HasPrefix(inner, "{") {

--- a/backend/internal/service/grok_free_usage.go
+++ b/backend/internal/service/grok_free_usage.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	grokFreeUsageExhaustedErrorCode = "subscription:free-usage-exhausted"
+	grokFreeUsageExhaustedCooldown  = time.Hour
+)
+
+var grokFreeUsageTokensPattern = regexp.MustCompile(`(?i)tokens\s*\(actual/limit\)\s*:\s*([0-9][0-9,]*)\s*/\s*([0-9][0-9,]*)`)
+
+type grokFreeUsageExhaustedDetails struct {
+	Actual int64
+	Limit  int64
+}
+
+func isGrokFreeUsageExhaustedError(body []byte) bool {
+	return strings.TrimSpace(gjson.GetBytes(body, "code").String()) == grokFreeUsageExhaustedErrorCode
+}
+
+func parseGrokFreeUsageExhausted(body []byte) (grokFreeUsageExhaustedDetails, bool) {
+	if !isGrokFreeUsageExhaustedError(body) {
+		return grokFreeUsageExhaustedDetails{}, false
+	}
+
+	message := strings.TrimSpace(gjson.GetBytes(body, "error").String())
+	if message == "" {
+		message = strings.TrimSpace(gjson.GetBytes(body, "message").String())
+	}
+	matches := grokFreeUsageTokensPattern.FindStringSubmatch(message)
+	if len(matches) != 3 {
+		return grokFreeUsageExhaustedDetails{}, false
+	}
+
+	actual, actualErr := strconv.ParseInt(strings.ReplaceAll(matches[1], ",", ""), 10, 64)
+	limit, limitErr := strconv.ParseInt(strings.ReplaceAll(matches[2], ",", ""), 10, 64)
+	if actualErr != nil || limitErr != nil || actual < 0 || limit <= 0 {
+		return grokFreeUsageExhaustedDetails{}, false
+	}
+	return grokFreeUsageExhaustedDetails{Actual: actual, Limit: limit}, true
+}
+
+func enrichGrokQuotaSnapshotFromError(snapshot *xai.QuotaSnapshot, body []byte, statusCode int, now time.Time) *xai.QuotaSnapshot {
+	if !isGrokFreeUsageExhaustedError(body) {
+		return snapshot
+	}
+	if snapshot == nil {
+		snapshot = &xai.QuotaSnapshot{StatusCode: statusCode}
+	}
+	if details, ok := parseGrokFreeUsageExhausted(body); ok {
+		if snapshot.Tokens == nil {
+			snapshot.Tokens = &xai.QuotaWindow{}
+		}
+		limit := details.Limit
+		remaining := int64(0)
+		snapshot.Tokens.Limit = &limit
+		snapshot.Tokens.Remaining = &remaining
+	}
+	snapshot.SubscriptionTier = "free"
+	snapshot.ProviderErrorCode = grokFreeUsageExhaustedErrorCode
+	if strings.TrimSpace(snapshot.ObservationSource) == "" {
+		snapshot.ObservationSource = "error_body"
+	}
+	if strings.TrimSpace(snapshot.UpdatedAt) == "" {
+		snapshot.UpdatedAt = now.UTC().Format(time.RFC3339)
+	}
+	return snapshot
+}

--- a/backend/internal/service/grok_free_usage_test.go
+++ b/backend/internal/service/grok_free_usage_test.go
@@ -1,0 +1,181 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+)
+
+func grokFreeUsageExhaustedBody() []byte {
+	return []byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"You've used all the included free usage for model grok-4.5-build-free for now. Usage resets over a rolling 24-hour window - tokens (actual/limit): 1065554/1000000."
+	}`)
+}
+
+func TestParseGrokFreeUsageExhausted(t *testing.T) {
+	t.Parallel()
+
+	details, ok := parseGrokFreeUsageExhausted([]byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"Usage resets over a rolling 24-hour window - tokens (actual/limit): 1,065,554/1,000,000."
+	}`))
+
+	require.True(t, ok)
+	require.EqualValues(t, 1_065_554, details.Actual)
+	require.EqualValues(t, 1_000_000, details.Limit)
+}
+
+func TestParseGrokFreeUsageExhaustedRejectsUnrelatedOrMalformedPayloads(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range [][]byte{
+		[]byte(`{"code":"other","error":"tokens (actual/limit): 10/5"}`),
+		[]byte(`{"code":"subscription:free-usage-exhausted","error":"missing usage values"}`),
+		[]byte(`{"code":"subscription:free-usage-exhausted","error":"tokens (actual/limit): 10/0"}`),
+		[]byte(`not-json`),
+	} {
+		_, ok := parseGrokFreeUsageExhausted(body)
+		require.False(t, ok, string(body))
+	}
+}
+
+func TestEnrichGrokQuotaSnapshotFromFreeUsageError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 7, 0, 0, 0, time.UTC)
+	resetAt := now.Add(45 * time.Minute).Unix()
+	snapshot := &xai.QuotaSnapshot{
+		StatusCode: http.StatusTooManyRequests,
+		Tokens:     &xai.QuotaWindow{ResetUnix: &resetAt},
+		UpdatedAt:  now.Format(time.RFC3339),
+	}
+
+	got := enrichGrokQuotaSnapshotFromError(snapshot, []byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"tokens (actual/limit): 1065554/1000000"
+	}`), http.StatusTooManyRequests, now)
+
+	require.Same(t, snapshot, got)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, got.ProviderErrorCode)
+	require.Equal(t, "free", got.SubscriptionTier)
+	require.Equal(t, "error_body", got.ObservationSource)
+	require.EqualValues(t, 1_000_000, *got.Tokens.Limit)
+	require.Zero(t, *got.Tokens.Remaining)
+	require.Equal(t, resetAt, *got.Tokens.ResetUnix)
+}
+
+func TestEnrichGrokQuotaSnapshotKeepsFreeUsageCodeWhenUsageValuesAreMissing(t *testing.T) {
+	t.Parallel()
+
+	snapshot := enrichGrokQuotaSnapshotFromError(nil, []byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"free allowance exhausted"
+	}`), http.StatusForbidden, time.Now())
+
+	require.NotNil(t, snapshot)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, snapshot.ProviderErrorCode)
+	require.Equal(t, "free", snapshot.SubscriptionTier)
+	require.Equal(t, http.StatusForbidden, snapshot.StatusCode)
+	require.Nil(t, snapshot.Tokens)
+}
+
+func TestGrokFreeUsageExhaustedCooldownPolicy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 7, 0, 0, 0, time.UTC)
+	freeSnapshot := func() *xai.QuotaSnapshot {
+		return &xai.QuotaSnapshot{
+			StatusCode:        http.StatusTooManyRequests,
+			ProviderErrorCode: grokFreeUsageExhaustedErrorCode,
+			UpdatedAt:         now.Format(time.RFC3339),
+		}
+	}
+
+	t.Run("uses dedicated fallback without upstream boundary", func(t *testing.T) {
+		resetAt, limited := grokRateLimitResetAt(freeSnapshot(), now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(grokFreeUsageExhaustedCooldown), resetAt)
+	})
+
+	t.Run("prefers retry-after", func(t *testing.T) {
+		retryAfter := 45
+		snapshot := freeSnapshot()
+		snapshot.RetryAfterSeconds = &retryAfter
+		resetAt, limited := grokRateLimitResetAt(snapshot, now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(45*time.Second), resetAt)
+	})
+
+	t.Run("prefers future token reset", func(t *testing.T) {
+		remaining := int64(0)
+		resetUnix := now.Add(2 * time.Hour).Unix()
+		snapshot := freeSnapshot()
+		snapshot.Tokens = &xai.QuotaWindow{Remaining: &remaining, ResetUnix: &resetUnix}
+		resetAt, limited := grokRateLimitResetAt(snapshot, now)
+		require.True(t, limited)
+		require.Equal(t, time.Unix(resetUnix, 0), resetAt)
+	})
+
+	t.Run("keeps generic headerless 429 fallback", func(t *testing.T) {
+		resetAt, limited := grokRateLimitResetAt(&xai.QuotaSnapshot{StatusCode: http.StatusTooManyRequests}, now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(grokRateLimitFallbackCooldown), resetAt)
+	})
+
+	t.Run("keeps repeated exhaustion at the one-hour cap", func(t *testing.T) {
+		previousReset := now.Add(-time.Second)
+		previousLimited := previousReset.Add(-grokFreeUsageExhaustedCooldown)
+		account := &Account{
+			Platform:         PlatformGrok,
+			Type:             AccountTypeOAuth,
+			RateLimitedAt:    &previousLimited,
+			RateLimitResetAt: &previousReset,
+		}
+		resetAt, limited := grokRateLimitResetAtForAccount(account, freeSnapshot(), now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(grokRateLimitMaxAdaptiveCooldown), resetAt)
+	})
+}
+
+func TestHandleGrokAccountUpstreamErrorPersistsFreeUsageExhaustion(t *testing.T) {
+	t.Parallel()
+
+	account := healthyGrokQuotaOAuthAccount(701)
+	repo := &grokQuotaAccountRepo{mockAccountRepoForPlatform: &mockAccountRepoForPlatform{
+		accountsByID: map[int64]*Account{account.ID: account},
+	}}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	before := time.Now()
+
+	svc.handleGrokAccountUpstreamError(
+		context.Background(), account, http.StatusTooManyRequests, nil, grokFreeUsageExhaustedBody(),
+	)
+
+	require.Equal(t, 1, repo.rateLimitedCalls)
+	require.WithinDuration(t, before.Add(grokFreeUsageExhaustedCooldown), repo.lastRateLimitResetAt, time.Second)
+	stored, ok := repo.updates[account.ID][grokQuotaSnapshotExtraKey].(*xai.QuotaSnapshot)
+	require.True(t, ok)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, stored.ProviderErrorCode)
+	require.Equal(t, "free", stored.SubscriptionTier)
+	require.EqualValues(t, 1_000_000, *stored.Tokens.Limit)
+	require.Zero(t, *stored.Tokens.Remaining)
+	require.NotNil(t, stored.Tokens.ResetUnix)
+	require.WithinDuration(t, repo.lastRateLimitResetAt, time.Unix(*stored.Tokens.ResetUnix, 0), time.Second)
+}
+
+func TestExtractUpstreamErrorCodeSupportsTopLevelCode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		grokFreeUsageExhaustedErrorCode,
+		extractUpstreamErrorCode([]byte(`{"code":"subscription:free-usage-exhausted","error":"exhausted"}`)),
+	)
+}

--- a/backend/internal/service/grok_quota_service.go
+++ b/backend/internal/service/grok_quota_service.go
@@ -166,6 +166,10 @@ func (s *GrokQuotaService) probeUsage(ctx context.Context, accountID int64) (*Gr
 	defer func() { _ = resp.Body.Close() }()
 
 	snapshot := xai.ObserveQuotaHeaders(resp.Header, resp.StatusCode, "active_probe")
+	if resp.StatusCode == http.StatusTooManyRequests {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, openAIUpstreamErrorBodyReadLimit))
+		snapshot = enrichGrokQuotaSnapshotFromError(snapshot, responseBody, resp.StatusCode, time.Now())
+	}
 	resetAt, limited := grokRateLimitResetAtForAccount(account, snapshot, time.Now())
 	if limited {
 		normalizeGrokExhaustedWindowResets(snapshot, resetAt, time.Now())

--- a/backend/internal/service/grok_quota_service_test.go
+++ b/backend/internal/service/grok_quota_service_test.go
@@ -451,6 +451,34 @@ func TestGrokQuotaServiceProbeUsageReturnsRateLimitedSnapshot(t *testing.T) {
 	require.Zero(t, repo.tempUnschedCalls)
 }
 
+func TestGrokQuotaServiceProbeUsagePersistsFreeUsageExhaustion(t *testing.T) {
+	t.Parallel()
+
+	account := healthyGrokQuotaOAuthAccount(49)
+	repo := &grokQuotaAccountRepo{
+		mockAccountRepoForPlatform: &mockAccountRepoForPlatform{
+			accountsByID: map[int64]*Account{account.ID: account},
+		},
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(string(grokFreeUsageExhaustedBody()))),
+	}}
+	svc := NewGrokQuotaService(repo, nil, NewGrokTokenProvider(repo, nil), upstream, nil)
+	before := time.Now()
+
+	result, err := svc.ProbeUsage(context.Background(), account.ID)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTooManyRequests, result.StatusCode)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, result.Snapshot.ProviderErrorCode)
+	require.EqualValues(t, 1_000_000, *result.Snapshot.Tokens.Limit)
+	require.Zero(t, *result.Snapshot.Tokens.Remaining)
+	require.Equal(t, 1, repo.rateLimitedCalls)
+	require.WithinDuration(t, before.Add(grokFreeUsageExhaustedCooldown), repo.lastRateLimitResetAt, time.Second)
+}
+
 func TestGrokQuotaServiceQueryQuotaFreeFallsBackToGrok45(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -930,7 +930,11 @@ func grokRateLimitResetAt(snapshot *xai.QuotaSnapshot, now time.Time) (time.Time
 		return time.Time{}, false
 	}
 	if exhausted || snapshot.StatusCode == http.StatusTooManyRequests {
-		return now.Add(grokRateLimitFallbackCooldown), true
+		cooldown := grokRateLimitFallbackCooldown
+		if snapshot.ProviderErrorCode == grokFreeUsageExhaustedErrorCode {
+			cooldown = grokFreeUsageExhaustedCooldown
+		}
+		return now.Add(cooldown), true
 	}
 	return time.Time{}, false
 }
@@ -1044,7 +1048,9 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		return
 	}
 	now := time.Now()
-	s.updateGrokUsageSnapshot(ctx, account, parseGrokQuotaSnapshot(headers, statusCode, now))
+	snapshot := parseGrokQuotaSnapshot(headers, statusCode, now)
+	snapshot = enrichGrokQuotaSnapshotFromError(snapshot, responseBody, statusCode, now)
+	s.updateGrokUsageSnapshot(ctx, account, snapshot)
 	switch statusCode {
 	case http.StatusUnauthorized:
 		s.tempUnscheduleGrok(ctx, account, 10*time.Minute, "grok credentials unauthorized")

--- a/backend/internal/service/openai_gateway_grok_cache.go
+++ b/backend/internal/service/openai_gateway_grok_cache.go
@@ -15,7 +15,8 @@ const (
 	grokConversationIDHeader        = "X-Grok-Conv-Id"
 	grokFreeCacheNativeToolsJSON    = `[{"type":"web_search"},{"type":"x_search"}]`
 	grokFreeCacheDisabledToolChoice = "none"
-	grokFreeRolling24hTokenLimit    = int64(2_000_000)
+	grokFreeRolling24hTokenLimit    = int64(1_000_000)
+	grokLegacyFree24hTokenLimit     = int64(2_000_000)
 )
 
 // resolveGrokCacheIdentity derives one stable, tenant-isolated routing identity
@@ -187,7 +188,7 @@ func isKnownGrokFreeAccount(account *Account) bool {
 			}
 		}
 		if snapshot.Tokens != nil && snapshot.Tokens.Limit != nil &&
-			*snapshot.Tokens.Limit == grokFreeRolling24hTokenLimit {
+			isKnownGrokFreeTokenLimit(*snapshot.Tokens.Limit) {
 			inferredFreeSignal = true
 		}
 	}
@@ -202,6 +203,10 @@ func isKnownGrokFreeAccount(account *Account) bool {
 	// protects upgraded/stale accounts whose previous quota snapshot still
 	// carries the historical 2M Free token limit.
 	return !paidSignal && (freeSignal || inferredFreeSignal)
+}
+
+func isKnownGrokFreeTokenLimit(limit int64) bool {
+	return limit == grokFreeRolling24hTokenLimit || limit == grokLegacyFree24hTokenLimit
 }
 
 func isGrokFreeSubscriptionTier(tier string) bool {

--- a/backend/internal/service/openai_gateway_grok_cache_test.go
+++ b/backend/internal/service/openai_gateway_grok_cache_test.go
@@ -322,6 +322,18 @@ func TestGrokFreeMessagesFunctionToolCacheRouteRequiresKnownFreeTier(t *testing.
 			wantMix: true,
 		},
 		{
+			name: "legacy free rolling token quota",
+			account: func() *Account {
+				a := healthyGrokOAuthGatewayTestAccount(9113, "access-token")
+				a.Extra = map[string]any{grokQuotaSnapshotExtraKey: map[string]any{
+					"headers_observed": true,
+					"tokens":           map[string]any{"limit": grokLegacyFree24hTokenLimit},
+				}}
+				return a
+			}(),
+			wantMix: true,
+		},
+		{
 			name: "supergrok remains unchanged",
 			account: func() *Account {
 				a := healthyGrokOAuthGatewayTestAccount(912, "access-token")

--- a/frontend/src/api/admin/grok.ts
+++ b/frontend/src/api/admin/grok.ts
@@ -86,6 +86,7 @@ export interface GrokQuotaSnapshot {
   requests?: GrokQuotaWindow | null
   tokens?: GrokQuotaWindow | null
   retry_after_seconds?: number | null
+  provider_error_code?: string
   subscription_tier?: string
   entitlement_status?: string
   status_code?: number

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -632,7 +632,7 @@ import GrokQuotaProbeCell from './GrokQuotaProbeCell.vue'
 const _usageCache = new Map<number, { data: AccountUsageInfo; ts: number }>()
 const USAGE_CACHE_TTL = 5 * 60 * 1000 // 5 minutes
 // xAI Free billing exposes a window without usage_percent, so estimate it from local tokens.
-const GROK_FREE_TOKEN_LIMIT = 2_000_000
+const GROK_DEFAULT_FREE_TOKEN_LIMIT = 1_000_000
 
 const props = withDefaults(
   defineProps<{
@@ -1102,6 +1102,12 @@ const grokIsFree = computed(() => {
   return billing != null
 })
 const grokFreeQuotaUsage = computed(() => usageInfo.value?.grok_local_usage_24h || null)
+const grokFreeTokenLimit = computed(() => {
+  const observed = usageInfo.value?.grok_token_quota?.limit
+  return typeof observed === 'number' && observed > 0
+    ? observed
+    : GROK_DEFAULT_FREE_TOKEN_LIMIT
+})
 const grokLocalUsage = computed(() => {
   if (grokIsFree.value) return grokFreeQuotaUsage.value
   return props.todayStats ||
@@ -1113,7 +1119,7 @@ const grokLocalUsage = computed(() => {
 const grokFreeTokenBar = computed(() => {
   if (!grokIsFree.value || !grokFreeQuotaUsage.value) return null
   const used = Math.max(0, grokFreeQuotaUsage.value.tokens || 0)
-  return { utilization: Math.min(100, (used / GROK_FREE_TOKEN_LIMIT) * 100) }
+  return { utilization: Math.min(100, (used / grokFreeTokenLimit.value) * 100) }
 })
 const grokQuotaUnknown = computed(() => {
   if (props.account.platform !== 'grok') return false

--- a/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountUsageCell.spec.ts
@@ -708,7 +708,7 @@ describe('AccountUsageCell', () => {
     { tokens: 1_000_000, expected: 50, compact: '1.0M' },
     { tokens: 2_000_000, expected: 100, compact: '2.0M' },
     { tokens: 2_200_000, expected: 100, compact: '2.2M' }
-  ])('Grok Free derives its 2M quota from local tokens: $tokens -> $expected%', async ({ tokens, expected, compact }) => {
+  ])('Grok Free uses an observed legacy 2M quota: $tokens -> $expected%', async ({ tokens, expected, compact }) => {
     getUsage.mockResolvedValue({
       grok_billing: {
         period_type: 'weekly',
@@ -762,7 +762,7 @@ describe('AccountUsageCell', () => {
       },
       grok_local_usage_24h: {
         requests: 12,
-        tokens: 1_500_000,
+        tokens: 500_000,
         cost: 0,
         standard_cost: 0
       }
@@ -792,8 +792,8 @@ describe('AccountUsageCell', () => {
 
     await flushPromises()
 
-    expect(wrapper.text()).toContain('24h|75|admin.accounts.usageWindow.grokFreeQuota24hHint')
-    expect(wrapper.text()).toContain('1.5M')
+    expect(wrapper.text()).toContain('24h|50|admin.accounts.usageWindow.grokFreeQuota24hHint')
+    expect(wrapper.text()).toContain('500.0K')
     expect(wrapper.text()).not.toContain('7d|')
     expect(wrapper.text()).not.toContain('200.0K')
     expect(wrapper.text()).not.toContain('250.0K')
@@ -921,7 +921,7 @@ describe('AccountUsageCell', () => {
     expect(wrapper.text()).not.toContain('2M|')
   })
 
-  it('Grok credential Free tier keeps the 2M fallback when billing is unavailable', async () => {
+  it('Grok credential Free tier uses the current 1M fallback when billing is unavailable', async () => {
     getUsage.mockResolvedValue({
       subscription_tier: 'FREE',
       grok_local_usage_24h: {
@@ -950,7 +950,7 @@ describe('AccountUsageCell', () => {
 
     await flushPromises()
 
-    expect(wrapper.text()).toContain('24h|50')
+    expect(wrapper.text()).toContain('24h|100')
   })
 
   it('Grok paid manual probes keep the weekly/local summary when 24h usage is returned', async () => {
@@ -1040,7 +1040,7 @@ describe('AccountUsageCell', () => {
     await flushPromises()
     await wrapper.get('.probe').trigger('click')
 
-    expect(wrapper.text()).toContain('24h|75')
+    expect(wrapper.text()).toContain('24h|100')
     expect(wrapper.text()).toContain('1.5M')
     expect(wrapper.text()).not.toContain('7d|')
   })


### PR DESCRIPTION
Closes #4568

## 变更说明

- 识别 Grok 返回的 `subscription:free-usage-exhausted` 错误，并将服务端报告的 token 上限持久化为已耗尽的 Free 配额快照
- 使用当前 1,000,000 token 的滚动 24 小时 Free 上限，同时兼容历史 2,000,000 token 配额快照
- 服务端未提供明确重置时间时，为该错误应用专用的 1 小时兜底冷却
- 前端 Free 配额进度根据实际观测到的上限计算，未观测到时回退为 1,000,000 token

## 限流行为

- `Retry-After` 和配额 reset header 仍具有最高优先级
- 明确的 Free 用量耗尽错误使用 1 小时兜底冷却
- 普通无 header 的 429 继续使用现有的 2 分钟兜底冷却
- 现有 Grok 账号故障转移行为保持不变

## 测试

- `go test -tags=unit ./...`
- Grok service 与配额回归测试
- AccountUsageCell 测试（28/28）
- 前端 TypeScript 类型检查
- 前端 ESLint
- 前端生产构建
- `git diff --check`