### PR TITLE
[codex] isolate compact transient cooldowns

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -48,6 +48,30 @@ func openAIForwardSucceededForScheduling(result *service.OpenAIForwardResult) bo
 	return result.SucceededForScheduling()
 }
 
+func openAIAccountScheduleModelForCapability(account *service.Account, requestedModel string, result *service.OpenAIForwardResult, requireCompact bool) string {
+	if result != nil {
+		if upstreamModel := strings.TrimSpace(result.UpstreamModel); upstreamModel != "" {
+			return upstreamModel
+		}
+	}
+
+	model := strings.TrimSpace(requestedModel)
+	if account == nil || model == "" {
+		return model
+	}
+	if mappedModel := strings.TrimSpace(account.GetMappedModel(model)); mappedModel != "" {
+		model = mappedModel
+	}
+	if requireCompact {
+		if compactModel, matched := account.ResolveCompactMappedModel(model); matched {
+			if compactModel = strings.TrimSpace(compactModel); compactModel != "" {
+				model = compactModel
+			}
+		}
+	}
+	return model
+}
+
 func resolveOpenAIMessagesDispatchMappedModel(apiKey *service.APIKey, requestedModel string) string {
 	if apiKey == nil || apiKey.Group == nil {
 		return ""
@@ -501,7 +525,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 						streamStarted = true
 					}
 					if failoverErr.ShouldReportAccountScheduleFailure() {
-						h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), false, nil)
+						h.gatewayService.ReportOpenAIAccountScheduleResultForCapability(account.ID, openAIAccountScheduleModelForCapability(account, reqModel, result, requireCompact), false, nil, requireCompact)
 					}
 					if !failoverErr.ShouldRetryNextAccount() {
 						h.handleFailoverExhausted(c, failoverErr, streamStarted)
@@ -561,7 +585,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 					reqLog.Warn("openai.upstream_failover_switching", failoverSwitchFields...)
 					continue
 				}
-				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), false, nil)
+				h.gatewayService.ReportOpenAIAccountScheduleResultForCapability(account.ID, openAIAccountScheduleModelForCapability(account, reqModel, result, requireCompact), false, nil, requireCompact)
 				upstreamErrorAlreadyCommunicated := openAIForwardErrorAlreadyCommunicated(c, writerSizeBeforeForward, err)
 				wroteFallback := false
 				if !upstreamErrorAlreadyCommunicated {
@@ -586,9 +610,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			if account.Type == service.AccountTypeOAuth && !account.IsShadow() {
 				h.gatewayService.UpdateCodexUsageSnapshotFromHeaders(c.Request.Context(), account.ID, result.ResponseHeaders)
 			}
-			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
+			h.gatewayService.ReportOpenAIAccountScheduleResultForCapability(account.ID, openAIAccountScheduleModelForCapability(account, reqModel, result, requireCompact), openAIForwardSucceededForScheduling(result), result.FirstTokenMs, requireCompact)
 		} else {
-			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(reqModel), openAIForwardSucceededForScheduling(result), nil)
+			h.gatewayService.ReportOpenAIAccountScheduleResultForCapability(account.ID, openAIAccountScheduleModelForCapability(account, reqModel, result, requireCompact), openAIForwardSucceededForScheduling(result), nil, requireCompact)
 		}
 
 		// 捕获请求信息（用于异步记录，避免在 goroutine 中访问 gin.Context）

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -109,6 +109,26 @@ func TestOpenAIForwardSucceededForScheduling(t *testing.T) {
 	}))
 }
 
+func TestOpenAIAccountScheduleModelForCapability_UsesActualCompactModel(t *testing.T) {
+	account := &service.Account{
+		Platform: service.PlatformOpenAI,
+		Type:     service.AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"public-alias":  "upstream-base",
+				"upstream-base": "must-not-double-map",
+			},
+			"compact_model_mapping": map[string]any{
+				"upstream-base": "upstream-compact",
+			},
+		},
+	}
+
+	require.Equal(t, "upstream-compact", openAIAccountScheduleModelForCapability(account, "public-alias", nil, true))
+	require.Equal(t, "upstream-base", openAIAccountScheduleModelForCapability(account, "public-alias", nil, false))
+	require.Equal(t, "result-upstream", openAIAccountScheduleModelForCapability(account, "public-alias", &service.OpenAIForwardResult{UpstreamModel: "result-upstream"}, true))
+}
+
 func TestResolveOpenAIMessagesMetadataSession_DoesNotDerivePromptCacheKey(t *testing.T) {
 	body := []byte(`{"model":"claude-sonnet-4-5","metadata":{"user_id":"claude-code-session"},"messages":[{"role":"user","content":"hello"}]}`)
 

--- a/backend/internal/service/openai_account_model_transient.go
+++ b/backend/internal/service/openai_account_model_transient.go
@@ -14,9 +14,17 @@ const (
 	openAIModelTransientMaxModelBytes = 512
 )
 
+type openAIModelTransientScope string
+
+const (
+	openAIModelTransientScopeRegular openAIModelTransientScope = "regular"
+	openAIModelTransientScopeCompact openAIModelTransientScope = "compact"
+)
+
 type openAIAccountModelKey struct {
 	AccountID int64
 	Model     string
+	Scope     openAIModelTransientScope
 }
 
 type openAIAccountModelTransientEntry struct {
@@ -56,16 +64,34 @@ func normalizeOpenAIAccountModelTransientModel(model string) string {
 	return strings.ToLower(model)
 }
 
-func openAIAccountModelTransientKey(accountID int64, model string) (openAIAccountModelKey, bool) {
+func normalizeOpenAIModelTransientScope(scope openAIModelTransientScope) openAIModelTransientScope {
+	if scope == openAIModelTransientScopeCompact {
+		return openAIModelTransientScopeCompact
+	}
+	return openAIModelTransientScopeRegular
+}
+
+func openAIModelTransientScopeForCapability(requireCompact bool) openAIModelTransientScope {
+	if requireCompact {
+		return openAIModelTransientScopeCompact
+	}
+	return openAIModelTransientScopeRegular
+}
+
+func openAIAccountModelTransientKeyForScope(accountID int64, model string, scope openAIModelTransientScope) (openAIAccountModelKey, bool) {
 	model = normalizeOpenAIAccountModelTransientModel(model)
 	if accountID <= 0 || model == "" {
 		return openAIAccountModelKey{}, false
 	}
-	return openAIAccountModelKey{AccountID: accountID, Model: model}, true
+	return openAIAccountModelKey{AccountID: accountID, Model: model, Scope: normalizeOpenAIModelTransientScope(scope)}, true
 }
 
 func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model string, now time.Time) openAIAccountModelTransientDecision {
-	key, ok := openAIAccountModelTransientKey(accountID, model)
+	return s.recordFailureForScope(accountID, model, openAIModelTransientScopeRegular, now)
+}
+
+func (s *openAIAccountModelTransientState) recordFailureForScope(accountID int64, model string, scope openAIModelTransientScope, now time.Time) openAIAccountModelTransientDecision {
+	key, ok := openAIAccountModelTransientKeyForScope(accountID, model, scope)
 	if s == nil || !ok {
 		return openAIAccountModelTransientDecision{}
 	}
@@ -115,7 +141,11 @@ func (s *openAIAccountModelTransientState) recordFailure(accountID int64, model 
 }
 
 func (s *openAIAccountModelTransientState) recordSuccess(accountID int64, model string) {
-	key, ok := openAIAccountModelTransientKey(accountID, model)
+	s.recordSuccessForScope(accountID, model, openAIModelTransientScopeRegular)
+}
+
+func (s *openAIAccountModelTransientState) recordSuccessForScope(accountID int64, model string, scope openAIModelTransientScope) {
+	key, ok := openAIAccountModelTransientKeyForScope(accountID, model, scope)
 	if s == nil || !ok {
 		return
 	}
@@ -125,7 +155,11 @@ func (s *openAIAccountModelTransientState) recordSuccess(accountID int64, model 
 }
 
 func (s *openAIAccountModelTransientState) isBlocked(accountID int64, model string, now time.Time) bool {
-	key, ok := openAIAccountModelTransientKey(accountID, model)
+	return s.isBlockedForScope(accountID, model, openAIModelTransientScopeRegular, now)
+}
+
+func (s *openAIAccountModelTransientState) isBlockedForScope(accountID int64, model string, scope openAIModelTransientScope, now time.Time) bool {
+	key, ok := openAIAccountModelTransientKeyForScope(accountID, model, scope)
 	if s == nil || !ok {
 		return false
 	}

--- a/backend/internal/service/openai_account_model_transient_test.go
+++ b/backend/internal/service/openai_account_model_transient_test.go
@@ -60,6 +60,31 @@ func TestOpenAIModelTransient_BlockIsIsolatedByModel(t *testing.T) {
 	assert.False(t, state.isBlocked(47, "gpt-5.6-terra", now.Add(2*time.Second)))
 }
 
+func TestOpenAIModelTransient_CapabilityScopeIsolation(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(128)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+
+	state.recordFailureForScope(61, "gpt-5.5-compact", openAIModelTransientScopeCompact, now)
+	state.recordFailureForScope(61, "gpt-5.5-compact", openAIModelTransientScopeCompact, now.Add(time.Millisecond))
+
+	assert.True(t, state.isBlockedForScope(61, "gpt-5.5-compact", openAIModelTransientScopeCompact, now.Add(2*time.Millisecond)))
+	assert.False(t, state.isBlockedForScope(61, "gpt-5.5-compact", openAIModelTransientScopeRegular, now.Add(2*time.Millisecond)))
+}
+
+func TestOpenAIModelTransient_SuccessClearsOnlyMatchingCapability(t *testing.T) {
+	state := newOpenAIAccountModelTransientState(128)
+	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)
+	for _, scope := range []openAIModelTransientScope{openAIModelTransientScopeRegular, openAIModelTransientScopeCompact} {
+		state.recordFailureForScope(61, "gpt-5.5", scope, now)
+		state.recordFailureForScope(61, "gpt-5.5", scope, now.Add(time.Millisecond))
+	}
+
+	state.recordSuccessForScope(61, "gpt-5.5", openAIModelTransientScopeCompact)
+
+	require.False(t, state.isBlockedForScope(61, "gpt-5.5", openAIModelTransientScopeCompact, now.Add(2*time.Millisecond)))
+	require.True(t, state.isBlockedForScope(61, "gpt-5.5", openAIModelTransientScopeRegular, now.Add(2*time.Millisecond)))
+}
+
 func TestOpenAIModelTransient_SuccessClearsStreakAndBlock(t *testing.T) {
 	state := newOpenAIAccountModelTransientState(128)
 	now := time.Date(2026, 7, 10, 10, 0, 0, 0, time.UTC)

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -18,6 +18,24 @@ const (
 	openAIOAuth429StormMaxAccountSwitches = 1
 )
 
+type openAIModelTransientScopeContextKey struct{}
+
+func withOpenAIModelTransientScope(ctx context.Context, scope openAIModelTransientScope) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, openAIModelTransientScopeContextKey{}, normalizeOpenAIModelTransientScope(scope))
+}
+
+func openAIModelTransientScopeFromContext(ctx context.Context) openAIModelTransientScope {
+	if ctx != nil {
+		if scope, ok := ctx.Value(openAIModelTransientScopeContextKey{}).(openAIModelTransientScope); ok {
+			return normalizeOpenAIModelTransientScope(scope)
+		}
+	}
+	return openAIModelTransientScopeRegular
+}
+
 // OpenAIOAuth429FailoverState tracks the request-local follow-up budget after
 // the first Grok OAuth 429. Once that 429 occurs, exactly one different account
 // may be attempted; any failure from that follow-up account ends failover.
@@ -80,14 +98,15 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 		if len(canonicalModel) > 0 {
 			model = canonicalModel[0]
 		}
-		decision := s.recordOpenAIAccountModelTransientFailure(account, model, time.Now())
+		scope := openAIModelTransientScopeFromContext(stateCtx)
+		decision := s.recordOpenAIAccountModelTransientFailure(account, model, time.Now(), scope)
 		if decision.FailureStreak > 0 {
 			slog.Warn("openai_model_transient_state",
 				"account_id", account.ID,
 				"model", openAIAccountModelTransientModel(model),
 				"failure_streak", decision.FailureStreak,
 				"cooldown_ms", decision.Cooldown.Milliseconds(),
-				"block_scope", "account_model",
+				"block_scope", "account_model_"+string(scope),
 			)
 		}
 	}
@@ -249,7 +268,7 @@ func openAIAccountModelTransientModel(canonicalModel string) string {
 	return normalizeOpenAIAccountModelTransientModel(canonicalModel)
 }
 
-func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account *Account, canonicalModel string, now time.Time) openAIAccountModelTransientDecision {
+func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account *Account, canonicalModel string, now time.Time, scopes ...openAIModelTransientScope) openAIAccountModelTransientDecision {
 	if s == nil || account == nil {
 		return openAIAccountModelTransientDecision{}
 	}
@@ -257,18 +276,30 @@ func (s *OpenAIGatewayService) recordOpenAIAccountModelTransientFailure(account 
 	if state == nil {
 		return openAIAccountModelTransientDecision{}
 	}
-	return state.recordFailure(account.ID, openAIAccountModelTransientModel(canonicalModel), now)
+	scope := openAIModelTransientScopeRegular
+	if len(scopes) > 0 {
+		scope = normalizeOpenAIModelTransientScope(scopes[0])
+	}
+	return state.recordFailureForScope(account.ID, openAIAccountModelTransientModel(canonicalModel), scope, now)
 }
 
-func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientState(accountID int64, model string) {
+func (s *OpenAIGatewayService) clearOpenAIAccountModelTransientState(accountID int64, model string, scopes ...openAIModelTransientScope) {
 	state := s.getOpenAIAccountModelTransientState()
 	if state == nil {
 		return
 	}
-	state.recordSuccess(accountID, model)
+	scope := openAIModelTransientScopeRegular
+	if len(scopes) > 0 {
+		scope = normalizeOpenAIModelTransientScope(scopes[0])
+	}
+	state.recordSuccessForScope(accountID, model, scope)
 }
 
 func (s *OpenAIGatewayService) isOpenAIAccountModelRuntimeBlocked(account *Account, requestedModel string) bool {
+	return s.isOpenAIAccountModelRuntimeBlockedForCapability(account, requestedModel, false)
+}
+
+func (s *OpenAIGatewayService) isOpenAIAccountModelRuntimeBlockedForCapability(account *Account, requestedModel string, requireCompact bool) bool {
 	if s == nil || account == nil {
 		return false
 	}
@@ -276,12 +307,16 @@ func (s *OpenAIGatewayService) isOpenAIAccountModelRuntimeBlocked(account *Accou
 	if state == nil {
 		return false
 	}
-	canonicalModel := canonicalOpenAIAccountSchedulingModel(account, requestedModel)
-	return state.isBlocked(account.ID, openAIAccountModelTransientModel(canonicalModel), time.Now())
+	canonicalModel := resolveOpenAIAccountUpstreamModelForRequest(account, requestedModel, requireCompact)
+	return state.isBlockedForScope(account.ID, openAIAccountModelTransientModel(canonicalModel), openAIModelTransientScopeForCapability(requireCompact), time.Now())
 }
 
 func (s *OpenAIGatewayService) isOpenAIAccountRequestRuntimeBlocked(account *Account, requestedModel string) bool {
-	return s != nil && (s.isOpenAIAccountRuntimeBlocked(account) || s.isOpenAIAccountModelRuntimeBlocked(account, requestedModel))
+	return s.isOpenAIAccountRequestRuntimeBlockedForCapability(account, requestedModel, false)
+}
+
+func (s *OpenAIGatewayService) isOpenAIAccountRequestRuntimeBlockedForCapability(account *Account, requestedModel string, requireCompact bool) bool {
+	return s != nil && (s.isOpenAIAccountRuntimeBlocked(account) || s.isOpenAIAccountModelRuntimeBlockedForCapability(account, requestedModel, requireCompact))
 }
 
 func (s *OpenAIGatewayService) recordOpenAIOAuth429() {

--- a/backend/internal/service/openai_account_runtime_transient_test.go
+++ b/backend/internal/service/openai_account_runtime_transient_test.go
@@ -89,6 +89,35 @@ func TestHandleOpenAITransientError_CanonicalModelIsNotMappedTwice(t *testing.T)
 	require.False(t, svc.isOpenAIAccountModelRuntimeBlocked(account, "public-alias"))
 }
 
+func TestHandleOpenAITransientError_CompactScopeUsesCompactCanonicalModel(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, &config.Config{}, nil, nil)
+	account := &Account{
+		ID:       5108,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"public-alias":  "upstream-base",
+				"upstream-base": "must-not-double-map",
+			},
+			"compact_model_mapping": map[string]any{
+				"upstream-base": "upstream-compact",
+			},
+		},
+	}
+	canonicalModel := resolveOpenAIAccountUpstreamModelForRequest(account, "public-alias", true)
+	require.Equal(t, "upstream-compact", canonicalModel)
+	ctx := withOpenAIModelTransientScope(context.Background(), openAIModelTransientScopeCompact)
+
+	for range 2 {
+		svc.handleOpenAIAccountUpstreamError(ctx, account, http.StatusBadGateway, http.Header{}, []byte(`{"error":{"message":"temporary compact failure"}}`), canonicalModel)
+	}
+
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", true))
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", false))
+}
+
 func TestHandleOpenAITransientError_DoesNotBlockParameter400(t *testing.T) {
 	svc := &OpenAIGatewayService{}
 	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, &config.Config{}, nil, nil)

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1133,7 +1133,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			continue
 		}
 
-		fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+		fresh := s.service.resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequireCompact, req.RequiredCapability)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1142,7 +1142,7 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			release(result)
 			break
 		}
-		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+		fresh = s.service.recheckSelectedOpenAIAccountFromDBWithRuntimeScope(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequireCompact, req.RequiredCapability)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1301,7 +1301,7 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 		if !account.IsSchedulable() || account.Platform != normalizeOpenAICompatiblePlatform(req.Platform) || !account.IsOpenAICompatible() {
 			continue
 		}
-		if s.service.isOpenAIAccountRequestRuntimeBlocked(account, req.RequestedModel) {
+		if s.service.isOpenAIAccountRequestRuntimeBlockedForCapability(account, req.RequestedModel, req.RequireCompact) {
 			continue
 		}
 		// require_privacy_set: 跳过 privacy 未设置的账号并标记异常
@@ -1547,14 +1547,14 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 					continue
 				}
 			}
-			fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+			fresh := s.service.resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequireCompact, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}
 			if !s.consumeOpenAISelectionDBRecheck(budget) {
 				return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked)
 			}
-			fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+			fresh = s.service.recheckSelectedOpenAIAccountFromDBWithRuntimeScope(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequireCompact, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}
@@ -1607,7 +1607,7 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatible(ctx context.C
 	if account == nil {
 		return false
 	}
-	if s != nil && s.service != nil && s.service.isOpenAIAccountRequestRuntimeBlocked(account, req.RequestedModel) {
+	if s != nil && s.service != nil && s.service.isOpenAIAccountRequestRuntimeBlockedForCapability(account, req.RequestedModel, req.RequireCompact) {
 		return false
 	}
 	// Quota auto-pause must be evaluated during the initial filter too. Without it the
@@ -2112,8 +2112,12 @@ func (s *OpenAIGatewayService) isOpenAIAccountTransportCompatible(account *Accou
 }
 
 func (s *OpenAIGatewayService) ReportOpenAIAccountScheduleResult(accountID int64, model string, success bool, firstTokenMs *int) {
+	s.ReportOpenAIAccountScheduleResultForCapability(accountID, model, success, firstTokenMs, false)
+}
+
+func (s *OpenAIGatewayService) ReportOpenAIAccountScheduleResultForCapability(accountID int64, model string, success bool, firstTokenMs *int, requireCompact bool) {
 	if success {
-		s.clearOpenAIAccountModelTransientState(accountID, normalizeOpenAIAccountModelTransientModel(model))
+		s.clearOpenAIAccountModelTransientState(accountID, normalizeOpenAIAccountModelTransientModel(model), openAIModelTransientScopeForCapability(requireCompact))
 	}
 	scheduler := s.getOpenAIAccountScheduler(context.Background())
 	if scheduler == nil {

--- a/backend/internal/service/openai_account_scheduler_compact_test.go
+++ b/backend/internal/service/openai_account_scheduler_compact_test.go
@@ -4,10 +4,153 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/stretchr/testify/require"
 )
+
+func newCompactRuntimeScopeTestAccounts(regularBlockedID, compactBlockedID int64) []Account {
+	regularBlocked := Account{
+		ID:          regularBlockedID,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    1,
+		Extra: map[string]any{
+			"openai_compact_mode": OpenAICompactModeForceOn,
+		},
+	}
+	compactBlocked := regularBlocked
+	compactBlocked.ID = compactBlockedID
+	compactBlocked.Priority = 0
+	return []Account{regularBlocked, compactBlocked}
+}
+
+func seedCompactRuntimeScopeTestCooldowns(svc *OpenAIGatewayService, accounts []Account, model string) {
+	now := time.Now()
+	for range 2 {
+		svc.openaiModelTransient.recordFailureForScope(accounts[0].ID, model, openAIModelTransientScopeRegular, now)
+		svc.openaiModelTransient.recordFailureForScope(accounts[1].ID, model, openAIModelTransientScopeCompact, now)
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_AdvancedAcquisitionUsesCompactRuntimeScope(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(91004)
+	accounts := newCompactRuntimeScopeTestAccounts(71031, 71032)
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = true
+	svc := &OpenAIGatewayService{
+		accountRepo:          schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:                &schedulerTestGatewayCache{},
+		cfg:                  cfg,
+		rateLimitService:     newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService:   NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		openaiModelTransient: newOpenAIAccountModelTransientState(128),
+	}
+	seedCompactRuntimeScopeTestCooldowns(svc, accounts, "gpt-5.5")
+
+	selection, _, err := svc.SelectAccountWithScheduler(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.5",
+		nil,
+		OpenAIUpstreamTransportAny,
+		true,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.True(t, selection.Acquired)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_AdvancedFallbackUsesCompactRuntimeScope(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(91005)
+	accounts := newCompactRuntimeScopeTestAccounts(71041, 71042)
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = true
+	svc := &OpenAIGatewayService{
+		accountRepo:      schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:            &schedulerTestGatewayCache{},
+		cfg:              cfg,
+		rateLimitService: newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{acquireResults: map[int64]bool{
+			accounts[0].ID: false,
+			accounts[1].ID: false,
+		}}),
+		openaiModelTransient: newOpenAIAccountModelTransientState(128),
+	}
+	seedCompactRuntimeScopeTestCooldowns(svc, accounts, "gpt-5.5")
+
+	selection, _, err := svc.SelectAccountWithScheduler(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.5",
+		nil,
+		OpenAIUpstreamTransportAny,
+		true,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.False(t, selection.Acquired)
+	require.NotNil(t, selection.WaitPlan)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	require.Equal(t, accounts[0].ID, selection.WaitPlan.AccountID)
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_LegacyLoadAwareUsesCompactRuntimeScope(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(91006)
+	accounts := newCompactRuntimeScopeTestAccounts(71051, 71052)
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.LoadBatchEnabled = true
+	svc := &OpenAIGatewayService{
+		accountRepo:          schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:                &schedulerTestGatewayCache{},
+		cfg:                  cfg,
+		concurrencyService:   NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		openaiModelTransient: newOpenAIAccountModelTransientState(128),
+	}
+	seedCompactRuntimeScopeTestCooldowns(svc, accounts, "gpt-5.5")
+
+	selection, _, err := svc.SelectAccountWithScheduler(
+		ctx,
+		&groupID,
+		"",
+		"",
+		"gpt-5.5",
+		nil,
+		OpenAIUpstreamTransportAny,
+		true,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.True(t, selection.Acquired)
+	require.Equal(t, accounts[0].ID, selection.Account.ID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
 
 // TestOpenAIGatewayService_SelectAccountWithScheduler_CompactPrefersSupportedOverUnknown
 // 验证 compact 调度时显式支持 (tier=2) 优先于未探测 (tier=1)。

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -840,6 +840,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_EnabledUsesAdvancedPrev
 			Schedulable: true,
 			Concurrency: 1,
 			Priority:    5,
+			GroupIDs:    []int64{groupID},
 			Extra: map[string]any{
 				"openai_apikey_responses_websockets_v2_enabled": true,
 			},
@@ -1824,6 +1825,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_PreviousResponseSticky(
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 2,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 		},
@@ -2442,6 +2444,89 @@ func TestReportOpenAIAccountScheduleResult_SuccessClearsModelTransientState(t *t
 	svc.ReportOpenAIAccountScheduleResult(21636, "gpt-5.5", true, nil)
 
 	require.False(t, svc.openaiModelTransient.isBlocked(21636, "gpt-5.5", now.Add(2*time.Millisecond)))
+}
+
+func TestOpenAIAccountScheduler_CompactTransientScopeDoesNotBlockRegular(t *testing.T) {
+	now := time.Now()
+	account := &Account{
+		ID:       21643,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"compact_model_mapping": map[string]any{"gpt-5.5": "gpt-5.5-compact"},
+		},
+	}
+	svc := &OpenAIGatewayService{openaiModelTransient: newOpenAIAccountModelTransientState(128)}
+	svc.openaiModelTransient.recordFailureForScope(account.ID, "gpt-5.5-compact", openAIModelTransientScopeCompact, now)
+	svc.openaiModelTransient.recordFailureForScope(account.ID, "gpt-5.5-compact", openAIModelTransientScopeCompact, now.Add(time.Millisecond))
+	scheduler := &defaultOpenAIAccountScheduler{service: svc}
+
+	require.False(t, scheduler.isAccountRequestCompatible(context.Background(), account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.5", RequireCompact: true}))
+	require.True(t, scheduler.isAccountRequestCompatible(context.Background(), account, OpenAIAccountScheduleRequest{RequestedModel: "gpt-5.5", RequireCompact: false}))
+}
+
+func TestOpenAIGatewayService_SelectBestAccount_UsesCompactRuntimeScope(t *testing.T) {
+	now := time.Now()
+	regularBlocked := Account{
+		ID:          21645,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		Extra: map[string]any{
+			"openai_compact_mode": OpenAICompactModeForceOn,
+		},
+	}
+	compactBlocked := regularBlocked
+	compactBlocked.ID = 21646
+	compactBlocked.Priority = 1
+
+	svc := &OpenAIGatewayService{openaiModelTransient: newOpenAIAccountModelTransientState(128)}
+	for range 2 {
+		svc.openaiModelTransient.recordFailureForScope(
+			regularBlocked.ID,
+			"gpt-5.5",
+			openAIModelTransientScopeRegular,
+			now,
+		)
+		svc.openaiModelTransient.recordFailureForScope(
+			compactBlocked.ID,
+			"gpt-5.5",
+			openAIModelTransientScopeCompact,
+			now,
+		)
+	}
+
+	selected, _ := svc.selectBestAccount(
+		context.Background(),
+		nil,
+		PlatformOpenAI,
+		[]Account{regularBlocked, compactBlocked},
+		"gpt-5.5",
+		nil,
+		true,
+		"",
+		false,
+	)
+
+	require.NotNil(t, selected)
+	require.Equal(t, regularBlocked.ID, selected.ID)
+}
+
+func TestReportOpenAIAccountScheduleResult_CompactSuccessClearsCompactOnly(t *testing.T) {
+	now := time.Now()
+	svc := &OpenAIGatewayService{openaiModelTransient: newOpenAIAccountModelTransientState(128)}
+	for _, scope := range []openAIModelTransientScope{openAIModelTransientScopeRegular, openAIModelTransientScopeCompact} {
+		svc.openaiModelTransient.recordFailureForScope(21644, "gpt-5.5-compact", scope, now)
+		svc.openaiModelTransient.recordFailureForScope(21644, "gpt-5.5-compact", scope, now.Add(time.Millisecond))
+	}
+
+	svc.ReportOpenAIAccountScheduleResultForCapability(21644, "gpt-5.5-compact", true, nil, true)
+
+	require.False(t, svc.openaiModelTransient.isBlockedForScope(21644, "gpt-5.5-compact", openAIModelTransientScopeCompact, now.Add(2*time.Millisecond)))
+	require.True(t, svc.openaiModelTransient.isBlockedForScope(21644, "gpt-5.5-compact", openAIModelTransientScopeRegular, now.Add(2*time.Millisecond)))
 }
 
 func TestDefaultOpenAIAccountScheduler_ShouldEscapeStickyAccount_ThresholdBoundary(t *testing.T) {

--- a/backend/internal/service/openai_compact_model_mapping_test.go
+++ b/backend/internal/service/openai_compact_model_mapping_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -90,6 +91,208 @@ func TestOpenAIGatewayService_Forward_NonCompactRequestIgnoresCompactOnlyModelMa
 	require.Equal(t, "gpt-5.4", result.Model)
 	require.Equal(t, "gpt-5.4", result.UpstreamModel)
 	require.Equal(t, "gpt-5.4", gjson.GetBytes(upstream.lastBody, "model").String())
+}
+
+func TestOpenAIGatewayService_Forward_CompactTransientFailureDoesNotBlockRegularCapability(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	responses := make([]*http.Response, 2)
+	for i := range responses {
+		responses[i] = &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"temporary compact failure","type":"upstream_error"}}`)),
+		}
+	}
+	upstream := &httpUpstreamRecorder{responses: responses}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, cfg, nil, nil)
+	account := &Account{
+		ID:          4,
+		Name:        "openai-apikey-compact",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+			"model_mapping": map[string]any{
+				"public-alias":  "upstream-base",
+				"upstream-base": "must-not-double-map",
+			},
+			"compact_model_mapping": map[string]any{"upstream-base": "upstream-compact"},
+		},
+		Extra:       map[string]any{"use_responses_api": true},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	body := []byte(`{"model":"public-alias","stream":false,"instructions":"compact-test","input":"hello"}`)
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses/compact", bytes.NewReader(body))
+		SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+		result, err := svc.Forward(context.Background(), c, account, body)
+		require.Nil(t, result)
+		require.Error(t, err)
+	}
+
+	require.Len(t, upstream.bodies, 2)
+	for _, requestBody := range upstream.bodies {
+		require.Equal(t, "upstream-compact", gjson.GetBytes(requestBody, "model").String())
+	}
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", true))
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", false))
+}
+
+func TestOpenAIGatewayService_Forward_NestedCompactPathUsesRegularTransientScope(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	responses := make([]*http.Response, 2)
+	for i := range responses {
+		responses[i] = &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"temporary upstream failure","type":"upstream_error"}}`)),
+		}
+	}
+	upstream := &httpUpstreamRecorder{responses: responses}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, cfg, nil, nil)
+	account := &Account{
+		ID:          5,
+		Name:        "openai-apikey-nested-compact",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+			"model_mapping": map[string]any{
+				"public-alias": "upstream-base",
+			},
+			"compact_model_mapping": map[string]any{
+				"upstream-base": "upstream-compact",
+			},
+		},
+		Extra:       map[string]any{"use_responses_api": true},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	body := []byte(`{"model":"public-alias","stream":false,"input":"hello"}`)
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses/compact/detail", bytes.NewReader(body))
+		SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+		result, err := svc.Forward(context.Background(), c, account, body)
+		require.Nil(t, result)
+		require.Error(t, err)
+	}
+
+	require.Len(t, upstream.bodies, 2)
+	for _, requestBody := range upstream.bodies {
+		require.Equal(t, "upstream-base", gjson.GetBytes(requestBody, "model").String())
+	}
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", false))
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", true))
+}
+
+func TestOpenAIGatewayService_APIKeyPassthrough_CompactCooldownUsesActualUpstreamModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	responses := make([]*http.Response, 3)
+	for i := range responses[:2] {
+		responses[i] = &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"temporary compact failure","type":"upstream_error"}}`)),
+		}
+	}
+	responses[2] = &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"id":"resp_passthrough_success","status":"completed","model":"public-alias","output":[],"usage":{"input_tokens":1,"output_tokens":1}}`)),
+	}
+	upstream := &httpUpstreamRecorder{responses: responses}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, cfg, nil, nil)
+	account := &Account{
+		ID:          6,
+		Name:        "openai-apikey-passthrough",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+			"model_mapping": map[string]any{
+				"public-alias": "upstream-base",
+			},
+			"compact_model_mapping": map[string]any{
+				"upstream-base": "upstream-compact",
+			},
+		},
+		Extra: map[string]any{
+			"openai_passthrough": true,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	body := []byte(`{"model":"public-alias","stream":false,"input":"hello"}`)
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body))
+		SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+		result, err := svc.Forward(context.Background(), c, account, body)
+		require.Nil(t, result)
+		require.Error(t, err)
+	}
+
+	require.Len(t, upstream.bodies, 2)
+	for _, requestBody := range upstream.bodies {
+		require.Equal(t, "public-alias", gjson.GetBytes(requestBody, "model").String())
+	}
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", true))
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", false))
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body))
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+	result, err := svc.Forward(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "public-alias", result.UpstreamModel)
+	svc.ReportOpenAIAccountScheduleResultForCapability(account.ID, result.UpstreamModel, true, nil, true)
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", true))
+}
+
+func TestResolveOpenAIAccountUpstreamModelForRequest_CompactMappingSkipsOAuthNormalization(t *testing.T) {
+	account := &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"compact_model_mapping": map[string]any{
+				"public-alias": "gpt-5.3",
+			},
+		},
+	}
+
+	require.Equal(t, "gpt-5.3", resolveOpenAIAccountUpstreamModelForRequest(account, "public-alias", true))
 }
 
 func TestOpenAIGatewayService_OAuthPassthrough_CompactOnlyModelMappingOverridesUpstreamModel(t *testing.T) {

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -20,6 +20,7 @@ import (
 // Forward forwards request to OpenAI API
 func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, account *Account, body []byte) (*OpenAIForwardResult, error) {
 	startTime := time.Now()
+	ctx = withOpenAIModelTransientScope(ctx, openAIModelTransientScopeForCapability(isOpenAIResponsesCompactCapabilityPath(c)))
 	// 固定渠道映射后的请求级 canonical body；账号 normalize/strip 不得改写跨 failover hint。
 	canonicalImageIntentBody := body
 
@@ -249,7 +250,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		markPatchSet("model", billingModel)
 	}
 	upstreamModel := billingModel
-	isCompactRequest := isOpenAIResponsesCompactPath(c)
+	isCompactRequest := isOpenAIResponsesCompactCapabilityPath(c)
 	compactMapped := false
 	if isCompactRequest {
 		compactMappedModel := resolveOpenAICompactForwardModel(account, billingModel)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -36,8 +36,8 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	reqStream bool,
 	startTime time.Time,
 ) (*OpenAIForwardResult, error) {
-	upstreamPassthroughModel := ""
-	if isOpenAIResponsesCompactPath(c) {
+	upstreamPassthroughModel := strings.TrimSpace(reqModel)
+	if isOpenAIResponsesCompactCapabilityPath(c) {
 		compactMappedModel := resolveOpenAICompactForwardModel(account, reqModel)
 		if compactMappedModel != "" && compactMappedModel != reqModel {
 			nextBody, setErr := sjson.SetBytes(body, "model", compactMappedModel)
@@ -579,7 +579,7 @@ func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(
 	setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
 	reqModel, _, _ := extractOpenAIRequestMetaFromBody(requestBody)
-	canonicalModel := canonicalOpenAIAccountSchedulingModel(account, reqModel)
+	canonicalModel := strings.TrimSpace(reqModel)
 	_ = s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, canonicalModel)
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:             account.Platform,
@@ -642,7 +642,7 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 	// 刚被限流的账号。cyber 例外：不冷却账号。
 	if !cyberHit {
 		reqModel, _, _ := extractOpenAIRequestMetaFromBody(requestBody)
-		canonicalModel := canonicalOpenAIAccountSchedulingModel(account, reqModel)
+		canonicalModel := strings.TrimSpace(reqModel)
 		_ = s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, canonicalModel)
 	}
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -173,6 +173,11 @@ func isOpenAIResponsesCompactPath(c *gin.Context) bool {
 	return suffix == "/compact" || strings.HasPrefix(suffix, "/compact/")
 }
 
+func isOpenAIResponsesCompactCapabilityPath(c *gin.Context) bool {
+	suffix := strings.TrimRight(strings.TrimSpace(openAIResponsesRequestPathSuffix(c)), "/")
+	return suffix == "/compact"
+}
+
 func normalizeOpenAICompactRequestBody(body []byte) ([]byte, bool, error) {
 	if len(body) == 0 {
 		return body, false, nil

--- a/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback_test.go
@@ -53,6 +53,50 @@ func TestForwardResponses_ForceChatCompletionsRoutesNonStreamingToChatCompletion
 	require.False(t, result.Stream)
 }
 
+func TestForwardResponses_ForceChatCompletionsCompactCooldownUsesRawUpstreamModel(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"public-alias","input":"hello","stream":false}`)
+	responses := make([]*http.Response, 2)
+	for i := range responses {
+		responses[i] = &http.Response{
+			StatusCode: http.StatusBadGateway,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"temporary compact fallback failure","type":"upstream_error"}}`)),
+		}
+	}
+	upstream := &httpUpstreamRecorder{responses: responses}
+	cfg := rawChatCompletionsTestConfig()
+	svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+	svc.rateLimitService = NewRateLimitService(transientCooldownAccountRepo{}, nil, cfg, nil, nil)
+	account := forceChatResponsesFallbackAccount()
+	account.Extra["openai_passthrough"] = true
+	account.Credentials["model_mapping"] = map[string]any{
+		"public-alias": "upstream-base",
+	}
+	account.Credentials["compact_model_mapping"] = map[string]any{
+		"upstream-base": "upstream-compact",
+	}
+
+	for range 2 {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/compact", bytes.NewReader(body))
+		c.Request.Header.Set("Content-Type", "application/json")
+
+		result, err := svc.Forward(context.Background(), c, account, body)
+		require.Nil(t, result)
+		require.Error(t, err)
+	}
+
+	require.Len(t, upstream.bodies, 2)
+	for _, requestBody := range upstream.bodies {
+		require.Equal(t, "upstream-base", gjson.GetBytes(requestBody, "model").String())
+	}
+	require.True(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", true))
+	require.False(t, svc.isOpenAIAccountModelRuntimeBlockedForCapability(account, "public-alias", false))
+}
+
 func TestForwardResponses_ForceChatCompletionsRoutesStreamingToChatCompletions(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
@@ -575,14 +576,33 @@ func prioritizeOpenAICompactAccounts(accounts []*Account) []*Account {
 // would be sent for a given request, honouring compact-only mappings when the
 // caller is on the /responses/compact path.
 func resolveOpenAIAccountUpstreamModelForRequest(account *Account, requestedModel string, requireCompact bool) string {
+	if account == nil {
+		return strings.TrimSpace(requestedModel)
+	}
+	if account.Type == AccountTypeAPIKey && !openai_compat.ShouldUseResponsesAPI(account.Extra) {
+		upstreamModel := resolveOpenAIForwardModel(account, requestedModel, "")
+		return normalizeOpenAIModelForUpstream(account, upstreamModel)
+	}
+	if account.IsOpenAIPassthroughEnabled() {
+		upstreamModel := strings.TrimSpace(requestedModel)
+		if requireCompact {
+			upstreamModel = resolveOpenAICompactForwardModel(account, upstreamModel)
+		}
+		return upstreamModel
+	}
+
 	upstreamModel := resolveOpenAIForwardModel(account, requestedModel, "")
 	if upstreamModel == "" {
 		return ""
 	}
 	if requireCompact {
-		return resolveOpenAICompactForwardModel(account, upstreamModel)
+		compactModel, matched := account.ResolveCompactMappedModel(upstreamModel)
+		compactModel = strings.TrimSpace(compactModel)
+		if matched && compactModel != "" && compactModel != upstreamModel {
+			return compactModel
+		}
 	}
-	return upstreamModel
+	return normalizeOpenAIModelForUpstream(account, upstreamModel)
 }
 
 func (s *OpenAIGatewayService) selectAccountForModelWithExclusions(ctx context.Context, groupID *int64, platform string, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, stickyAccountID int64, requiredCapability OpenAIEndpointCapability, preferLowUpstreamRate bool) (*Account, error) {
@@ -674,7 +694,7 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
-	if s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
+	if s.isOpenAIAccountRequestRuntimeBlockedForCapability(account, requestedModel, requireCompact) {
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
 	}
@@ -718,11 +738,11 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 			continue
 		}
 
-		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+		fresh := s.resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx, acc, platform, requestedModel, false, requireCompact, requiredCapability)
 		if fresh == nil {
 			continue
 		}
-		fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, false, requiredCapability)
+		fresh = s.recheckSelectedOpenAIAccountFromDBWithRuntimeScope(ctx, fresh, groupID, platform, requestedModel, false, requireCompact, requiredCapability)
 		if fresh == nil {
 			continue
 		}
@@ -878,7 +898,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if !s.openAIAccountMatchesSchedulingGroup(account, groupID) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
-					} else if s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
+					} else if s.isOpenAIAccountRequestRuntimeBlockedForCapability(account, requestedModel, requireCompact) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, account, requestedModel, requireCompact) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
@@ -941,7 +961,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		if !parentHealthyForShadow(acc, parentLookupL2) {
 			continue
 		}
-		if s.isOpenAIAccountRequestRuntimeBlocked(acc, requestedModel) {
+		if s.isOpenAIAccountRequestRuntimeBlockedForCapability(acc, requestedModel, requireCompact) {
 			continue
 		}
 		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, acc, requestedModel, requireCompact) {
@@ -1032,7 +1052,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		}
 
 		for _, item := range selectionOrder {
-			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, item.account, platform, requestedModel, false, requiredCapability)
+			fresh := s.resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx, item.account, platform, requestedModel, false, requireCompact, requiredCapability)
 			if fresh == nil {
 				continue
 			}
@@ -1071,7 +1091,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			ordered = prioritizeOpenAICompactAccounts(ordered)
 		}
 		for _, acc := range ordered {
-			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+			fresh := s.resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx, acc, platform, requestedModel, false, requireCompact, requiredCapability)
 			if fresh == nil {
 				continue
 			}
@@ -1121,7 +1141,7 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		candidates = prioritizeOpenAICompactAccounts(candidates)
 	}
 	for _, acc := range candidates {
-		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+		fresh := s.resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx, acc, platform, requestedModel, false, requireCompact, requiredCapability)
 		if fresh == nil {
 			continue
 		}
@@ -1174,7 +1194,7 @@ func (s *OpenAIGatewayService) tryAcquireAccountSlot(ctx context.Context, accoun
 	return s.concurrencyService.AcquireAccountSlot(ctx, accountID, maxConcurrency)
 }
 
-func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
+func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccountWithRuntimeScope(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact, runtimeRequireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
 	if account == nil {
 		return nil
 	}
@@ -1195,7 +1215,7 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.
 	if !parentHealthyForShadow(fresh, s.parentAccountLookup(ctx)) {
 		return nil
 	}
-	if s.isOpenAIAccountRequestRuntimeBlocked(fresh, requestedModel) {
+	if s.isOpenAIAccountRequestRuntimeBlockedForCapability(fresh, requestedModel, runtimeRequireCompact) {
 		return nil
 	}
 	return fresh
@@ -1216,6 +1236,10 @@ func (s *OpenAIGatewayService) parentAccountLookup(ctx context.Context) func(int
 }
 
 func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
+	return s.recheckSelectedOpenAIAccountFromDBWithRuntimeScope(ctx, account, groupID, platform, requestedModel, requireCompact, requireCompact, requiredCapability)
+}
+
+func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBWithRuntimeScope(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact, runtimeRequireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
 	if account == nil {
 		return nil
 	}
@@ -1225,6 +1249,9 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 			return nil
 		}
 		if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
+			return nil
+		}
+		if s.isOpenAIAccountRequestRuntimeBlockedForCapability(account, requestedModel, runtimeRequireCompact) {
 			return nil
 		}
 		return account
@@ -1243,7 +1270,7 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
 		return nil
 	}
-	if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
+	if s.isOpenAIAccountRequestRuntimeBlockedForCapability(latest, requestedModel, runtimeRequireCompact) {
 		return nil
 	}
 	return latest

--- a/backend/internal/service/openai_ws_account_sticky_test.go
+++ b/backend/internal/service/openai_ws_account_sticky_test.go
@@ -19,6 +19,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_Hit(t *testing.T
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 2,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 		},
@@ -123,6 +124,128 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_RateLimitedMiss(
 	boundAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_prev_rl")
 	require.NoError(t, getErr)
 	require.Zero(t, boundAccountID)
+}
+
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_RepoOnlyCompactCooldownMiss(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(26)
+	account := Account{
+		ID:          32,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+			"openai_compact_mode":                           OpenAICompactModeForceOn,
+		},
+	}
+	cache := &stubGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	svc := &OpenAIGatewayService{
+		accountRepo:          stubOpenAIAccountRepo{accounts: []Account{account}},
+		cache:                cache,
+		cfg:                  newOpenAIWSV2TestConfig(),
+		concurrencyService:   NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore:   store,
+		openaiModelTransient: newOpenAIAccountModelTransientState(128),
+	}
+	for range 2 {
+		svc.openaiModelTransient.recordFailureForScope(
+			account.ID,
+			"gpt-5.1",
+			openAIModelTransientScopeCompact,
+			time.Now(),
+		)
+	}
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_prev_compact_cooldown", account.ID, time.Hour))
+
+	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &groupID, "resp_prev_compact_cooldown", "gpt-5.1", nil, true)
+
+	require.NoError(t, err)
+	require.Nil(t, selection)
+	boundAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_prev_compact_cooldown")
+	require.NoError(t, getErr)
+	require.Zero(t, boundAccountID)
+}
+
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_RepoOnlyMovedGroupMiss(t *testing.T) {
+	ctx := context.Background()
+	boundGroupID := int64(27)
+	account := Account{
+		ID:          33,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		GroupIDs:    []int64{28},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	cache := &stubGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                newOpenAIWSV2TestConfig(),
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore: store,
+	}
+	require.NoError(t, store.BindResponseAccount(ctx, boundGroupID, "resp_prev_moved_group", account.ID, time.Hour))
+
+	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &boundGroupID, "resp_prev_moved_group", "gpt-5.1", nil, false)
+
+	require.NoError(t, err)
+	require.Nil(t, selection)
+	boundAccountID, getErr := store.GetResponseAccount(ctx, boundGroupID, "resp_prev_moved_group")
+	require.NoError(t, getErr)
+	require.Zero(t, boundAccountID)
+}
+
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_SimpleModeIgnoresGroupMismatch(t *testing.T) {
+	ctx := context.Background()
+	boundGroupID := int64(29)
+	account := Account{
+		ID:          34,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		GroupIDs:    []int64{30},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	cache := &stubGatewayCache{}
+	store := NewOpenAIWSStateStore(cache)
+	cfg := newOpenAIWSV2TestConfig()
+	cfg.RunMode = config.RunModeSimple
+	svc := &OpenAIGatewayService{
+		accountRepo:        stubOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+		openaiWSStateStore: store,
+	}
+	require.NoError(t, store.BindResponseAccount(ctx, boundGroupID, "resp_prev_simple_mode", account.ID, time.Hour))
+
+	selection, err := svc.SelectAccountByPreviousResponseID(ctx, &boundGroupID, "resp_prev_simple_mode", "gpt-5.1", nil, false)
+
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, account.ID, selection.Account.ID)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+	boundAccountID, getErr := store.GetResponseAccount(ctx, boundGroupID, "resp_prev_simple_mode")
+	require.NoError(t, getErr)
+	require.Equal(t, account.ID, boundAccountID)
 }
 
 func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_DBRuntimeRecheckRateLimitedMiss(t *testing.T) {
@@ -254,6 +377,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_BusyKeepsSticky(
 			Schedulable: true,
 			Concurrency: 1,
 			Priority:    0,
+			GroupIDs:    []int64{groupID},
 			Extra: map[string]any{
 				"openai_apikey_responses_websockets_v2_enabled": true,
 			},

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -532,11 +532,15 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, latest); paused {
 			return 0, nil, "", nil
 		}
-		if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
-			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
-			return 0, nil, "", nil
-		}
 		account = latest
+	}
+	if s.isOpenAIAccountRequestRuntimeBlockedForCapability(account, requestedModel, requireCompact) {
+		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
+		return 0, nil, "", nil
+	}
+	if !s.openAIAccountMatchesSchedulingGroup(account, groupID) {
+		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
+		return 0, nil, "", nil
 	}
 	if requireCompact && openAICompactSupportTier(account) == 0 {
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)


### PR DESCRIPTION
## Problem

OpenAI regular Responses traffic and compact traffic can share the same canonical upstream model name while requiring different account capabilities. The existing model-scoped transient cooldown state therefore lets a transient failure on one capability block the other capability as well.

This is especially visible when an account maps both a regular model and its compact route to the same upstream model: a compact-only failure can temporarily remove an otherwise healthy regular route, and a later success can clear the wrong failure state.

## Root cause

Transient failure recording, runtime-block checks, success clears, and sticky-account reuse were keyed only by account and canonical model. They did not carry the regular-versus-compact capability scope through every HTTP, scheduler, and WebSocket path.

The scheduler also assumed every request used the native Responses mapping pipeline. API-key passthrough and Responses-to-Chat fallback resolve their actual upstream model differently, so their failure, selection, and success-clear keys could diverge.

## Fix

- Split transient cooldown state into regular and compact scopes.
- Resolve the cooldown key from the actual native, passthrough, or raw fallback model pipeline, and use the same key for failure recording, scheduling, and success clearing.
- Carry the requested capability through failure recording, runtime-block gates, success clears, load-aware selection, and WebSocket support helpers.
- Revalidate previous-response sticky accounts against both their current group membership and the capability-scoped runtime state before reuse.
- Keep SimpleMode's existing full-pool semantics when revalidating previous-response bindings.
- Preserve the current terminal error behavior, concurrency probe budget, slot release paths, and account transport checks.

## Verification

- `go test ./internal/service -run 'Test.*(Compact|Transient|Sticky|RuntimeBlock)' -count=1`
- `go test -tags=unit ./internal/service -run 'Test.*(Compact|Transient|Sticky|RuntimeBlock)' -count=1`
- `go test ./internal/handler -run 'Test.*(Compact|Transient|RuntimeBlock)' -count=1`
- `go test -tags=unit ./...`
- `go test ./...`
- `go vet ./...`
- `golangci-lint v2.9.0 run --timeout=30m ./...`
