### PR TITLE
fix(antigravity): 保留付费 tier 的 PlanType，IneligibleTiers 仅标记异常状态

### DIFF
--- a/backend/internal/service/antigravity_subscription_service.go
+++ b/backend/internal/service/antigravity_subscription_service.go
@@ -21,9 +21,14 @@ func NormalizeAntigravitySubscription(resp *antigravity.LoadCodeAssistResponse) 
 	if resp == nil {
 		return AntigravitySubscriptionResult{PlanType: "Free"}
 	}
+	tierID := resp.GetTier()
+	planType := antigravity.TierIDToPlanType(tierID)
 	if len(resp.IneligibleTiers) > 0 {
+		if planType == "" || planType == "Free" {
+			planType = "Abnormal"
+		}
 		result := AntigravitySubscriptionResult{
-			PlanType:           "Abnormal",
+			PlanType:           planType,
 			SubscriptionStatus: antigravitySubscriptionAbnormal,
 		}
 		if resp.IneligibleTiers[0] != nil {
@@ -31,8 +36,7 @@ func NormalizeAntigravitySubscription(resp *antigravity.LoadCodeAssistResponse) 
 		}
 		return result
 	}
-	tierID := resp.GetTier()
 	return AntigravitySubscriptionResult{
-		PlanType: antigravity.TierIDToPlanType(tierID),
+		PlanType: planType,
 	}
 }

--- a/backend/internal/service/antigravity_subscription_test.go
+++ b/backend/internal/service/antigravity_subscription_test.go
@@ -1,0 +1,66 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/antigravity"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeAntigravitySubscription_PaidTierWithIneligible(t *testing.T) {
+	resp := &antigravity.LoadCodeAssistResponse{
+		PaidTier: &antigravity.PaidTierInfo{ID: "g1-pro-tier"},
+		IneligibleTiers: []*antigravity.IneligibleTier{
+			{ReasonMessage: "location validation required"},
+		},
+	}
+
+	result := NormalizeAntigravitySubscription(resp)
+
+	assert.Equal(t, "Pro", result.PlanType, "paid tier should preserve Pro even with ineligible tiers")
+	assert.Equal(t, "abnormal", result.SubscriptionStatus)
+	assert.Equal(t, "location validation required", result.SubscriptionError)
+}
+
+func TestNormalizeAntigravitySubscription_FreeTierWithIneligible(t *testing.T) {
+	resp := &antigravity.LoadCodeAssistResponse{
+		PaidTier: &antigravity.PaidTierInfo{ID: "free-tier"},
+		IneligibleTiers: []*antigravity.IneligibleTier{
+			{ReasonMessage: "some warning"},
+		},
+	}
+
+	result := NormalizeAntigravitySubscription(resp)
+
+	assert.Equal(t, "Abnormal", result.PlanType, "free tier with ineligible should be Abnormal")
+	assert.Equal(t, "abnormal", result.SubscriptionStatus)
+}
+
+func TestNormalizeAntigravitySubscription_NoIneligible(t *testing.T) {
+	resp := &antigravity.LoadCodeAssistResponse{
+		PaidTier: &antigravity.PaidTierInfo{ID: "g1-ultra-tier"},
+	}
+
+	result := NormalizeAntigravitySubscription(resp)
+
+	assert.Equal(t, "Ultra", result.PlanType)
+	assert.Empty(t, result.SubscriptionStatus)
+}
+
+func TestNormalizeAntigravitySubscription_NilResponse(t *testing.T) {
+	result := NormalizeAntigravitySubscription(nil)
+	assert.Equal(t, "Free", result.PlanType)
+}
+
+func TestNormalizeAntigravitySubscription_NoTierWithIneligible(t *testing.T) {
+	resp := &antigravity.LoadCodeAssistResponse{
+		IneligibleTiers: []*antigravity.IneligibleTier{
+			{ReasonMessage: "unknown issue"},
+		},
+	}
+
+	result := NormalizeAntigravitySubscription(resp)
+
+	assert.Equal(t, "Abnormal", result.PlanType, "no tier + ineligible should be Abnormal")
+	assert.Equal(t, "abnormal", result.SubscriptionStatus)
+}


### PR DESCRIPTION
## 背景

`NormalizeAntigravitySubscription` 在 `IneligibleTiers` 非空时直接返回 `PlanType: "Abnormal"`，完全忽略了 `GetTier()` 返回的实际付费层级。

实际场景中，一个 Antigravity Pro 账号可能同时携带 `paidTier.id = g1-pro-tier` 和 `ineligibleTiers`（如地区验证要求）。当前逻辑将其标记为"异常"而非"Pro"，导致管理员误判账号状态。

Fixes #4519

## 修改

- `backend/internal/service/antigravity_subscription_service.go`：先通过 `GetTier()` + `TierIDToPlanType` 确定实际套餐类型，仅当 tier 为空或 Free 时才回退到 `Abnormal`。`IneligibleTiers` 只影响 `SubscriptionStatus`，不覆盖有效的付费 `PlanType`

## 兼容性说明

- 无 `IneligibleTiers` 的账号行为不变
- 无 tier 或 Free tier + `IneligibleTiers` 仍显示 `Abnormal`（保持原行为）
- Pro/Ultra + `IneligibleTiers` 现在显示 `Pro`/`Ultra` + `SubscriptionStatus=abnormal`

## 测试

5 个测试覆盖：Pro + ineligible、Free + ineligible、无 ineligible、nil 响应、无 tier + ineligible

```bash
go test ./internal/service/ -run "TestNormalizeAntigravitySubscription" -v
```