### PR TITLE
fix(openai): accept standard OpenAI model list for Codex model discovery

### DIFF
--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -463,6 +463,9 @@ func (s *OpenAIGatewayService) fetchCodexModelsManifestUpstream(ctx context.Cont
 			retryable: isRetryableCodexModelsManifestTransportError(err),
 		}
 	}
+	if request.useAPIKeyUpstream {
+		body = convertOpenAIModelListToCodexManifest(body)
+	}
 	if err := validateCodexModelsManifestEnvelope(body); err != nil {
 		return nil, &codexModelsManifestUpstreamError{
 			err: infraerrors.Newf(
@@ -475,6 +478,52 @@ func (s *OpenAIGatewayService) fetchCodexModelsManifestUpstream(ctx context.Cont
 		}
 	}
 	return &CodexModelsManifest{Body: body, ETag: resp.Header.Get("ETag")}, nil
+}
+
+// convertOpenAIModelListToCodexManifest rewrites a standard OpenAI
+// GET /v1/models response ({"object":"list","data":[{"id":...},...]}) into the
+// Codex manifest envelope ({"models":[{"slug":...},...]}) so custom API key
+// upstreams that only implement the standard endpoint can serve Codex model
+// discovery. Bodies that already carry a top-level models field, are not the
+// standard list shape, or yield no usable model IDs are returned unchanged so
+// envelope validation reports the original payload.
+func convertOpenAIModelListToCodexManifest(body []byte) []byte {
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil || envelope == nil {
+		return body
+	}
+	if _, ok := envelope["models"]; ok {
+		return body
+	}
+	data, ok := envelope["data"]
+	if !ok {
+		return body
+	}
+	var entries []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(data, &entries); err != nil {
+		return body
+	}
+	type codexModelEntry struct {
+		Slug string `json:"slug"`
+	}
+	models := make([]codexModelEntry, 0, len(entries))
+	for _, entry := range entries {
+		id := strings.TrimSpace(entry.ID)
+		if id == "" {
+			continue
+		}
+		models = append(models, codexModelEntry{Slug: id})
+	}
+	if len(models) == 0 {
+		return body
+	}
+	converted, err := json.Marshal(map[string][]codexModelEntry{"models": models})
+	if err != nil {
+		return body
+	}
+	return converted
 }
 
 func validateCodexModelsManifestEnvelope(body []byte) error {

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -470,6 +470,88 @@ func TestFetchCodexModelsManifestAPIKeyCustomUpstream(t *testing.T) {
 	}
 }
 
+func TestFetchCodexModelsManifestAPIKeyConvertsStandardOpenAIModelList(t *testing.T) {
+	upstreamBody := `{"object":"list","data":[{"id":"gpt-5.6","object":"model"},{"id":"  ","object":"model"},{"id":"gpt-5.6-codex","object":"model"}]}`
+	upstream := &codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set("ETag", `W/"openai-list"`)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+		}, nil
+	}}
+
+	s := newCodexModelsAPIKeyTestService(upstream)
+	manifest, err := s.FetchCodexModelsManifest(
+		context.Background(),
+		newCodexModelsAPIKeyTestAccount("https://upstream.example/v1"),
+		"0.144.0",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("FetchCodexModelsManifest returned error: %v", err)
+	}
+	if got, want := string(manifest.Body), `{"models":[{"slug":"gpt-5.6"},{"slug":"gpt-5.6-codex"}]}`; got != want {
+		t.Errorf("converted body: got %q, want %q", got, want)
+	}
+	if manifest.ETag != `W/"openai-list"` {
+		t.Errorf("etag not passed through: got %q", manifest.ETag)
+	}
+}
+
+func TestConvertOpenAIModelListToCodexManifest(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "standard list",
+			body: `{"object":"list","data":[{"id":"m-1"},{"id":"m-2"}]}`,
+			want: `{"models":[{"slug":"m-1"},{"slug":"m-2"}]}`,
+		},
+		{
+			name: "codex manifest unchanged",
+			body: `{"models":[{"slug":"m-1"}]}`,
+			want: `{"models":[{"slug":"m-1"}]}`,
+		},
+		{
+			name: "empty data unchanged",
+			body: `{"object":"list","data":[]}`,
+			want: `{"object":"list","data":[]}`,
+		},
+		{
+			name: "data not an array unchanged",
+			body: `{"object":"list","data":{"id":"m-1"}}`,
+			want: `{"object":"list","data":{"id":"m-1"}}`,
+		},
+		{
+			name: "entries without usable IDs unchanged",
+			body: `{"object":"list","data":[{"id":""},{"object":"model"}]}`,
+			want: `{"object":"list","data":[{"id":""},{"object":"model"}]}`,
+		},
+		{
+			name: "invalid JSON unchanged",
+			body: `{"data":`,
+			want: `{"data":`,
+		},
+		{
+			name: "non-object unchanged",
+			body: `[]`,
+			want: `[]`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(convertOpenAIModelListToCodexManifest([]byte(tt.body))); got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFetchCodexModelsManifestRejectsInvalidEnvelope(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## 问题

Fixes #4490

Codex 客户端通过 `GET /models?client_version=...` 做模型发现时,对 API Key 类型账号,Sub2API 会请求账号自定义上游的模型列表,并要求响应顶层必须存在 `models` 数组(Codex 专用清单格式)。

但许多能正常推理的 OpenAI 兼容上游,`GET /v1/models` 返回的是标准 OpenAI 格式:

```json
{"object": "list", "data": [{"id": "example-model", "object": "model"}]}
```

该响应被 `validateCodexModelsManifestEnvelope` 拒绝,报错 `missing top-level models array`,最终给客户端返回 502,Codex Desktop 持续重试模型发现请求。

## 修复

在 `fetchCodexModelsManifestUpstream` 中,对 **API Key 自定义上游**的响应,在校验前先尝试将标准 OpenAI 列表格式转换为 Codex 清单格式:

- `{"object":"list","data":[{"id":"m"}]}` → `{"models":[{"slug":"m"}]}`
- 已包含顶层 `models` 字段的响应原样透传(不影响已兼容 Codex 格式的上游)
- 非标准列表形状、`data` 非数组、或提取不到任何可用模型 ID 的响应保持原样,走原有校验报错 + 账号切换逻辑(行为不变)
- 仅作用于 API Key 上游;OAuth 走 ChatGPT 官方后端的路径完全不受影响

转换发生在缓存写入之前,ETag 语义不变。

## 测试

- 新增 `TestFetchCodexModelsManifestAPIKeyConvertsStandardOpenAIModelList`:端到端验证标准格式被转换、空白 ID 被跳过、ETag 透传
- 新增 `TestConvertOpenAIModelListToCodexManifest`:表驱动覆盖转换/透传/降级各分支
- 现有全部测试(含 `TestFetchCodexModelsManifestRejectsInvalidEnvelope` 中空 `data` 列表仍视为无效清单)不做任何修改,全部通过:

```
ok  	github.com/Wei-Shaw/sub2api/internal/service
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)