### PR TITLE
fix(frontend): 修复可用渠道页面内容过多时无法滚动的问题

### DIFF
--- a/frontend/src/components/channels/AvailableChannelsTable.vue
+++ b/frontend/src/components/channels/AvailableChannelsTable.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="card overflow-hidden">
+  <!-- .table-wrapper 是 TablePageLayout 滚动链的挂载点：外层 .table-scroll-container
+       负责卡片外观并 overflow-hidden，本层接收 overflow-y-auto 才能在内容超高时滚动。 -->
+  <div class="table-wrapper">
     <table class="w-full table-fixed border-collapse text-sm">
       <thead>
         <tr class="border-b border-gray-100 bg-gray-50/50 text-xs font-medium uppercase tracking-wide text-gray-500 dark:border-dark-700 dark:bg-dark-800/50 dark:text-gray-400">

--- a/frontend/src/components/channels/__tests__/AvailableChannelsTable.spec.ts
+++ b/frontend/src/components/channels/__tests__/AvailableChannelsTable.spec.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const componentPath = resolve(dirname(fileURLToPath(import.meta.url)), '../AvailableChannelsTable.vue')
+const componentSource = readFileSync(componentPath, 'utf8')
+
+describe('AvailableChannelsTable scroll integration', () => {
+  // #4555：根元素必须是 TablePageLayout 滚动链约定的 .table-wrapper，
+  // 否则内容超出视口高度时被外层 overflow-hidden 裁剪且没有滚动条。
+  it('mounts the table on the .table-wrapper scroll hook', () => {
+    expect(componentSource).toMatch(/<div class="table-wrapper">\s*<table/)
+  })
+
+  it('does not clip content with its own overflow-hidden card wrapper', () => {
+    expect(componentSource).not.toMatch(/<div class="card overflow-hidden">/)
+  })
+})


### PR DESCRIPTION
## 问题

Fixes #4555

可用渠道页面内容较多时,超出视口的部分被直接裁剪,没有滚动条,只能看到一部分内容。

## 原因

`TablePageLayout` 的滚动机制约定:外层 `.table-scroll-container` 负责卡片外观并设置 `overflow-hidden`,表格插槽内容需要挂载在 `.table-wrapper` 元素上,由布局通过 `:deep(.table-wrapper)` 赋予 `overflow-y-auto` 才能滚动(项目里其他表格页均通过 `DataTable` 的 `.table-wrapper` 根元素遵循此约定)。

`AvailableChannelsTable` 是唯一的例外——它把表格包在自己的 `<div class="card overflow-hidden">` 里,没有 `.table-wrapper`,于是:

1. 内容超高时被外层 `overflow-hidden` 裁剪,且无任何滚动条(本 issue);
2. 布局的卡片外观 + 组件自己的 `card` 类叠加,出现双重边框。

## 修复

将组件根元素从 `card overflow-hidden` 改为约定的 `table-wrapper`,与项目其他表格页保持一致。卡片外观由 `TablePageLayout` 统一提供,双重边框问题一并消除;移动端(<1024px)布局本就切换为整页滚动,不受影响。

## 测试

- 新增 `AvailableChannelsTable.spec.ts` 回归测试(沿用 `TablePageLayout.spec.ts` 的源码约定断言风格):根元素必须是 `.table-wrapper`,不得再引入自己的 `overflow-hidden` 包裹层
- `vue-tsc --noEmit` 通过,eslint 通过,相关 vitest 全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)