### PR TITLE
fix(frontend): 修复余额弹窗暗色模式下用户邮箱不可读

### DIFF
--- a/frontend/src/components/admin/user/UserBalanceModal.vue
+++ b/frontend/src/components/admin/user/UserBalanceModal.vue
@@ -3,7 +3,7 @@
     <form v-if="user" id="balance-form" @submit.prevent="handleBalanceSubmit" class="space-y-5">
       <div class="flex items-center gap-3 rounded-xl bg-gray-50 p-4 dark:bg-dark-700">
         <div class="flex h-10 w-10 items-center justify-center rounded-full bg-primary-100"><span class="text-lg font-medium text-primary-700">{{ user.email.charAt(0).toUpperCase() }}</span></div>
-        <div class="flex-1"><p class="font-medium text-gray-900">{{ user.email }}</p><p class="text-sm text-gray-500">{{ t('admin.users.currentBalance') }}: ${{ formatBalance(user.balance) }}</p></div>
+        <div class="flex-1"><p class="font-medium text-gray-900 dark:text-gray-100">{{ user.email }}</p><p class="text-sm text-gray-500 dark:text-gray-400">{{ t('admin.users.currentBalance') }}: ${{ formatBalance(user.balance) }}</p></div>
       </div>
       <div>
         <label class="input-label">{{ operation === 'add' ? t('admin.users.depositAmount') : t('admin.users.withdrawAmount') }}</label>


### PR DESCRIPTION
## 问题

管理端「用户充值/扣款」弹窗（UserBalanceModal）顶部的用户信息条,容器是 `bg-gray-50 dark:bg-dark-700`,但其中:

- 邮箱一行是 `text-gray-900`,**没有暗色变体**——暗色模式下深底配近黑文字,基本不可见
- 余额一行是 `text-gray-500`,同样没有暗色变体,在深底上对比度不足

## 修复

对齐同一弹窗内已有的正确写法(第 16 行「新余额」区域 `text-gray-900 dark:text-gray-100`):

- 邮箱: `text-gray-900` → `text-gray-900 dark:text-gray-100`
- 余额: `text-gray-500` → `text-gray-500 dark:text-gray-400`

单行改动。`vue-tsc --noEmit` 与 eslint 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)