### PR TITLE
fix(deploy): make the redis command flags take effect in dev and local compose

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -114,12 +114,16 @@ services:
     restart: unless-stopped
     volumes:
       - ./redis_data:/data:Z
+    # The command is one quoted script for the inner `sh -c`. Compose keeps
+    # the newlines inside the quoted string, so every line needs a trailing
+    # `\` — without it, `redis-server` on the first line runs with no flags
+    # at all, and the --save/--appendonly/--appendfsync lines are never read.
     command: >
         sh -c '
-          redis-server
-          --save 60 1
-          --appendonly yes
-          --appendfsync everysec
+          redis-server \
+          --save 60 1 \
+          --appendonly yes \
+          --appendfsync everysec \
           ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -230,12 +230,16 @@ services:
     volumes:
       # Local directory mapping for easy migration
       - ./redis_data:/data:Z
+    # The command is one quoted script for the inner `sh -c`. Compose keeps
+    # the newlines inside the quoted string, so every line needs a trailing
+    # `\` — without it, `redis-server` on the first line runs with no flags
+    # at all, and the --save/--appendonly/--appendfsync lines are never read.
     command: >
         sh -c '
-          redis-server
-          --save 60 1
-          --appendonly yes
-          --appendfsync everysec
+          redis-server \
+          --save 60 1 \
+          --appendonly yes \
+          --appendfsync everysec \
           ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}


### PR DESCRIPTION
#4506 fixed this in `deploy/docker-compose.yml`, but the same broken form is still in `docker-compose.dev.yml` and `docker-compose.local.yml`. The redis `command` is one quoted script given to the inner `sh -c`, and compose keeps the newlines inside the quoted string, so `redis-server` on the first line runs as a complete command with no flags at all.

Two effects, in both files:

1. `--save` / `--appendonly` / `--appendfsync` are silently never applied.
2. `${REDIS_PASSWORD:+--requirepass ...}` is dead too — **redis takes no password even when `REDIS_PASSWORD` is set**. A no-auth `PING` gets `PONG`, and redis itself says no password is configured.

The fix is the same trailing `\` line continuations as #4506, with the same comment, so the three compose files read the same way.

Checked with both files on `redis:8-alpine`, `REDIS_PASSWORD` set. Before: no-auth `PING` said `PONG`, `appendonly` was "no", `save` was the stock "3600 1 300 100 60 10000". After: no-auth `PING` gets `NOAUTH`, `appendonly` is "yes", `save` is "60 1". With `REDIS_PASSWORD` unset the server still starts open, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)