### PR TITLE
fix(deploy): pass the documented postgres tuning values to postgres

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -202,6 +202,15 @@ services:
       nofile:
         soft: 100000
         hard: 100000
+    # Pass the tuning values documented in .env.example to postgres. The
+    # fallbacks are the postgres:18 stock defaults, so nothing changes when
+    # the variables are not set.
+    command: >
+      postgres
+      -c max_connections=${POSTGRES_MAX_CONNECTIONS:-100}
+      -c shared_buffers=${POSTGRES_SHARED_BUFFERS:-128MB}
+      -c effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-4GB}
+      -c maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-64MB}
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
`deploy/.env.example` documents `POSTGRES_MAX_CONNECTIONS`, `POSTGRES_SHARED_BUFFERS`, `POSTGRES_EFFECTIVE_CACHE_SIZE` and `POSTGRES_MAINTENANCE_WORK_MEM`, with notes on how to size them (and ships with values set). But no compose file ever passes them to the postgres container — a user who sets them in `.env` gets nothing, silently. Same family of bug as #4506: the config looks live but is dead.

This wires them into the postgres `command` in `deploy/docker-compose.yml`. The fallbacks are the postgres:18 stock defaults (100 / 128MB / 4GB / 64MB), so a deploy that does not set the variables behaves exactly as before.

Scope note: `docker-compose.standalone.yml` has no postgres service, and the dev/local files are for development boxes where tuning matters less — so only the main file is changed here.

Checked with `postgres:18-alpine`: with the variables unset, `SHOW` gives the stock values; with them set (1024 / 1GB / 6GB / 128MB), `SHOW` gives the set values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)