### PR TITLE
fix(openai): mark OAuth accounts unschedulable on Codex models manifest 401

### DIFF
--- a/backend/internal/handler/openai_codex_models_handler.go
+++ b/backend/internal/handler/openai_codex_models_handler.go
@@ -53,6 +53,8 @@ func (h *OpenAIGatewayHandler) CodexModels(c *gin.Context) {
 			h.errorResponse(c, http.StatusServiceUnavailable, "upstream_error", "No available OpenAI accounts")
 			return
 		}
+		// 让 ops 错误日志携带实际选中的上游账号，便于定位失效账号（#4544）。
+		setOpsSelectedAccount(c, account.ID, account.Platform)
 
 		manifest, err := h.gatewayService.FetchCodexModelsManifest(c.Request.Context(), account, c.Query("client_version"), c.GetHeader("If-None-Match"))
 		if err != nil {

--- a/backend/internal/service/openai_codex_models_service.go
+++ b/backend/internal/service/openai_codex_models_service.go
@@ -47,6 +47,7 @@ type codexModelsManifestUpstreamError struct {
 	err        error
 	retryable  bool
 	statusCode int
+	headers    http.Header
 	body       []byte
 }
 
@@ -56,7 +57,13 @@ func (e *codexModelsManifestUpstreamError) Unwrap() error { return e.err }
 
 // IsRetryableCodexModelsManifestError reports whether another selected account
 // may succeed without changing the request. Configuration and upstream 4xx
-// responses, except 429, are intentionally not retried.
+// responses, except 429 and ChatGPT-backend 401, are intentionally not
+// retried. A manifest 401 from the ChatGPT Codex backend reflects the selected
+// OAuth account's upstream token rather than the client request (the client's
+// own API key was already validated locally), so a different account may still
+// serve the manifest. Custom API key upstreams keep the old no-failover 401
+// behavior because their /models auth semantics are not authoritative for the
+// account.
 func IsRetryableCodexModelsManifestError(err error) bool {
 	var upstreamErr *codexModelsManifestUpstreamError
 	return errors.As(err, &upstreamErr) && upstreamErr.retryable
@@ -322,6 +329,7 @@ func (s *OpenAIGatewayService) FetchCodexModelsManifest(ctx context.Context, acc
 	}
 	manifest, fetchErr := s.fetchCodexModelsManifestUpstream(ctx, request, ifNoneMatch)
 	if !credAccount.IsOpenAIAgentIdentity() || !isAgentIdentityTaskInvalidCodexModelsError(fetchErr) {
+		s.handleCodexModelsManifestAccountAuthError(ctx, account, credAccount, fetchErr)
 		return manifest, fetchErr
 	}
 	expectedTaskID := strings.TrimSpace(credAccount.GetCredential("task_id"))
@@ -347,6 +355,37 @@ func isAgentIdentityTaskInvalidCodexModelsError(err error) bool {
 	var upstreamErr *codexModelsManifestUpstreamError
 	return errors.As(err, &upstreamErr) &&
 		isAgentIdentityTaskInvalidHTTPResponse(upstreamErr.statusCode, upstreamErr.body)
+}
+
+// handleCodexModelsManifestAccountAuthError feeds manifest 401s from the
+// ChatGPT Codex backend into the shared upstream-error state machinery
+// (token cache invalidation, temp-unschedulable cooldown, or permanent
+// disable for token_revoked/token_invalidated). Without this, an account
+// whose OAuth token was revoked upstream stays active and schedulable and
+// keeps being selected for every subsequent /models request (#4544).
+//
+// Scope is deliberately limited to plain OAuth accounts: the manifest
+// endpoint authenticates with the same token as /responses forwarding, so a
+// 401 is authoritative for the account. Agent Identity accounts are excluded
+// because their 401s can be task-scoped and have a dedicated recovery flow,
+// and API key manifests come from custom upstreams whose /models auth may
+// diverge from their chat endpoints.
+func (s *OpenAIGatewayService) handleCodexModelsManifestAccountAuthError(ctx context.Context, account, credAccount *Account, err error) {
+	if s == nil || account == nil || err == nil {
+		return
+	}
+	if credAccount == nil || !credAccount.IsOpenAIOAuth() || credAccount.IsOpenAIAgentIdentity() {
+		return
+	}
+	var upstreamErr *codexModelsManifestUpstreamError
+	if !errors.As(err, &upstreamErr) || upstreamErr.statusCode != http.StatusUnauthorized {
+		return
+	}
+	headers := upstreamErr.headers
+	if headers == nil {
+		headers = http.Header{}
+	}
+	s.handleOpenAIAccountUpstreamError(ctx, account, upstreamErr.statusCode, headers, upstreamErr.body)
 }
 
 func (s *OpenAIGatewayService) fetchCachedAPIKeyCodexModelsManifest(ctx context.Context, request codexModelsManifestRequest, ifNoneMatch string) (*CodexModelsManifest, error) {
@@ -450,8 +489,10 @@ func (s *OpenAIGatewayService) fetchCodexModelsManifestUpstream(ctx context.Cont
 		return nil, &codexModelsManifestUpstreamError{
 			err:        infraerrors.Newf(http.StatusBadGateway, "OPENAI_CODEX_MODELS_UPSTREAM_FAILED", "codex models manifest upstream error %d: %s", resp.StatusCode, message),
 			statusCode: resp.StatusCode,
+			headers:    resp.Header.Clone(),
 			body:       body,
-			retryable: resp.StatusCode == http.StatusTooManyRequests ||
+			retryable: (resp.StatusCode == http.StatusUnauthorized && !request.useAPIKeyUpstream) ||
+				resp.StatusCode == http.StatusTooManyRequests ||
 				(resp.StatusCode >= http.StatusInternalServerError && resp.StatusCode < 600),
 		}
 	}

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -1094,6 +1094,147 @@ func TestFetchCodexModelsManifestAPIKeyRejectsBaseURLFragment(t *testing.T) {
 	}
 }
 
+// codexModelsAccountStateRepo records account state transitions triggered by
+// manifest upstream errors (#4544).
+type codexModelsAccountStateRepo struct {
+	AccountRepository
+	mu                  sync.Mutex
+	setErrorCalls       int
+	lastErrorMsg        string
+	setTempUnschedCalls int
+	lastTempReason      string
+}
+
+func (r *codexModelsAccountStateRepo) SetError(_ context.Context, _ int64, errorMsg string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setErrorCalls++
+	r.lastErrorMsg = errorMsg
+	return nil
+}
+
+func (r *codexModelsAccountStateRepo) SetTempUnschedulable(_ context.Context, _ int64, _ time.Time, reason string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.setTempUnschedCalls++
+	r.lastTempReason = reason
+	return nil
+}
+
+func newCodexModels401TestService(repo AccountRepository) *OpenAIGatewayService {
+	rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	s := &OpenAIGatewayService{rateLimitService: rateLimitService}
+	rateLimitService.SetAccountRuntimeBlocker(s)
+	return s
+}
+
+func TestFetchCodexModelsManifestOAuth401MarksAccountUnschedulable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":{"message":"invalid token"}}`))
+	}))
+	defer server.Close()
+
+	original := chatgptCodexModelsURL
+	chatgptCodexModelsURL = server.URL
+	defer func() { chatgptCodexModelsURL = original }()
+
+	repo := &codexModelsAccountStateRepo{}
+	s := newCodexModels401TestService(repo)
+	account := newCodexModelsTestAccount()
+	account.Credentials["refresh_token"] = "test-refresh-token"
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), account, "0.137.0", "")
+	require.Error(t, err)
+	require.True(t, IsRetryableCodexModelsManifestError(err), "manifest 401 should allow account failover")
+	require.Equal(t, 1, repo.setTempUnschedCalls, "OAuth 401 should temp-unschedule the account")
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.True(t, s.isOpenAIAccountRuntimeBlocked(account), "account should be runtime-blocked after manifest 401")
+}
+
+func TestFetchCodexModelsManifestOAuth401TokenRevokedDisablesAccount(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":{"code":"token_revoked","message":"token has been revoked"}}`))
+	}))
+	defer server.Close()
+
+	original := chatgptCodexModelsURL
+	chatgptCodexModelsURL = server.URL
+	defer func() { chatgptCodexModelsURL = original }()
+
+	repo := &codexModelsAccountStateRepo{}
+	s := newCodexModels401TestService(repo)
+	account := newCodexModelsTestAccount()
+	account.Credentials["refresh_token"] = "test-refresh-token"
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), account, "0.137.0", "")
+	require.Error(t, err)
+	require.True(t, IsRetryableCodexModelsManifestError(err))
+	require.Equal(t, 1, repo.setErrorCalls, "revoked token should permanently disable the account")
+	require.Contains(t, repo.lastErrorMsg, "Token revoked")
+	require.Equal(t, 0, repo.setTempUnschedCalls)
+}
+
+func TestFetchCodexModelsManifestAgentIdentity401DoesNotDisableAccount(t *testing.T) {
+	key, privateKey := newTestAgentIdentityKey(t)
+	account := &Account{
+		ID:       6,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"auth_mode":          OpenAIAuthModeAgentIdentity,
+			"agent_runtime_id":   key.runtimeID,
+			"agent_private_key":  privateKey,
+			"task_id":            key.taskID,
+			"chatgpt_account_id": "acc-agent-401",
+		},
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"detail":"some non-task 401"}`))
+	}))
+	defer server.Close()
+
+	original := chatgptCodexModelsURL
+	chatgptCodexModelsURL = server.URL
+	defer func() { chatgptCodexModelsURL = original }()
+
+	repo := &codexModelsAccountStateRepo{}
+	s := newCodexModels401TestService(repo)
+
+	_, err := s.FetchCodexModelsManifest(context.Background(), account, "0.137.0", "")
+	require.Error(t, err)
+	require.Equal(t, 0, repo.setErrorCalls, "agent identity 401s must not disable the account")
+	require.Equal(t, 0, repo.setTempUnschedCalls)
+}
+
+func TestFetchCodexModelsManifestAPIKey401KeepsNoFailoverAndNoDisable(t *testing.T) {
+	upstream := &codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"error":"invalid api key"}`)),
+		}, nil
+	}}
+
+	repo := &codexModelsAccountStateRepo{}
+	s := newCodexModelsAPIKeyTestService(upstream)
+	s.rateLimitService = NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+
+	_, err := s.FetchCodexModelsManifest(
+		context.Background(),
+		newCodexModelsAPIKeyTestAccount("https://upstream.example"),
+		"0.144.0",
+		"",
+	)
+	require.Error(t, err)
+	require.False(t, IsRetryableCodexModelsManifestError(err), "custom upstream manifest 401 keeps the no-failover behavior")
+	require.Equal(t, 0, repo.setErrorCalls, "custom upstream manifest 401 must not disable the account")
+	require.Equal(t, 0, repo.setTempUnschedCalls)
+}
+
 func TestFetchCodexModelsManifestAPIKeyUpstreamError(t *testing.T) {
 	upstream := &codexModelsHTTPUpstreamStub{do: func(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
 		return &http.Response{


### PR DESCRIPTION
## 问题

Fixes #4544

Codex 客户端请求 `GET /models?client_version=...` 时，网关会转发 ChatGPT Codex models manifest。当选中的 OAuth 账号 token 已被上游撤销（`token_revoked` / `token_invalidated`）时：

- 上游 401 只是原样包装成 502 返回给客户端；
- 账号仍保持 `status=active`、`schedulable=true`，后续 `/models` 请求继续选中同一个失效账号，重复产生 502（Codex Desktop 会连续重试，错误记录刷屏）；
- manifest 401 不在可失败切换（failover）状态列表里，当前请求也不会尝试其他账号；
- ops 错误记录里 `account_id` 为空，无法定位是哪个账号失效。

与之对照：同一账号手动“测试连接”遇到 401 会正确标记 `status=error`、`schedulable=false`；正常 `/responses` 转发路径的 401 也会走 `HandleUpstreamError` 的账号状态机。唯独 manifest 路径两头都不沾。

## 修改

`backend/internal/service/openai_codex_models_service.go`

- `codexModelsManifestUpstreamError` 新增 `headers` 字段，保留上游响应头供状态机使用。
- 新增 `handleCodexModelsManifestAccountAuthError`：把 ChatGPT backend 的 manifest 401 送入既有的 `handleOpenAIAccountUpstreamError` 共享状态机，行为与 `/responses` 转发路径一致——
  - 失效 token 缓存；
  - 有 `refresh_token` 的 OAuth 账号 → 临时不可调度冷却（保持 `active`，让后台刷新服务拾取自愈）；
  - `token_revoked` / `token_invalidated` / `detail:"Unauthorized"` / 无 `refresh_token` → `SetError` 永久停止调度；
  - 同步写入内存 runtime block，避免 DB 状态生效前的选中竞态。
- ChatGPT backend 的 manifest 401 标记为可失败切换：当前请求即可换号成功，而不是直接 502。
- **范围限定**：
  - Agent Identity 账号跳过——其 401 可能是 task 级失效，已有独立的 task recovery 流程；
  - API Key 自定义上游的 manifest 401 保持原行为（不切换、不禁用）——自定义上游 `/models` 的鉴权语义未必能代表该账号的转发可用性，避免误杀转发正常的账号。

`backend/internal/handler/openai_codex_models_handler.go`

- 选中账号后调用 `setOpsSelectedAccount`，让 `/models` 的 ops 错误日志携带 `account_id`/platform（issue 中“错误记录无法确认被选择的上游账号”）。

## 测试

新增 4 个单元测试（`openai_codex_models_service_test.go`，同时覆盖默认与 `-tags=unit`）：

- OAuth manifest 401（一般 401 体）→ `SetTempUnschedulable` 一次、错误可失败切换、账号进入 runtime block；
- OAuth manifest 401（`token_revoked`）→ `SetError` 永久禁用；
- Agent Identity 非 task 类 401 → 不触碰账号状态；
- API Key 自定义上游 401 → 保持不可切换、不禁用。

```text
go build ./...                                            ok
go test ./internal/handler/ -count=1                      ok（全量）
go test ./internal/service/ -run 'TestFetchCodexModelsManifest|TestIsRetryableCodexModelsManifest' -count=1   ok
go test -tags=unit ./internal/service/ -run 'TestFetchCodexModelsManifest|TestRateLimitService_HandleUpstreamError' -count=1  ok
```

`./internal/service/` 全量跑时 `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` 偶发失败，在未打补丁的 main 上同样可复现（time-based flake），与本改动无关。

## 行为变化说明

- `/models` 请求遇到 ChatGPT backend 401 时：之前固定 502，现在会在 `maxAccountSwitches` 预算内换号重试，并把失效账号按 401 语义移出调度池（临时冷却或永久禁用，取决于 401 类型）。
- 若分组内所有账号都 401，客户端仍收到最后一个上游 502 错误，与现有 429/5xx 耗尽行为一致。
