### PR TITLE
fix(subscription): round remaining days up

### DIFF
--- a/backend/internal/service/subscription_calculate_progress_test.go
+++ b/backend/internal/service/subscription_calculate_progress_test.go
@@ -34,7 +34,7 @@ func TestCalculateProgress_BasicFields(t *testing.T) {
 	assert.Equal(t, int64(100), progress.ID)
 	assert.Equal(t, "Premium", progress.GroupName)
 	assert.Equal(t, sub.ExpiresAt, progress.ExpiresAt)
-	assert.True(t, progress.ExpiresInDays == 29 || progress.ExpiresInDays == 30, "ExpiresInDays should be 29 or 30, got %d", progress.ExpiresInDays)
+	assert.Equal(t, 30, progress.ExpiresInDays)
 	assert.Nil(t, progress.Daily, "无日限额时 Daily 应为 nil")
 	assert.Nil(t, progress.Weekly, "无周限额时 Weekly 应为 nil")
 	assert.Nil(t, progress.Monthly, "无月限额时 Monthly 应为 nil")

--- a/backend/internal/service/user_subscription.go
+++ b/backend/internal/service/user_subscription.go
@@ -2,6 +2,8 @@ package service
 
 import "time"
 
+const subscriptionDayDuration = 24 * time.Hour
+
 type UserSubscription struct {
 	ID      int64
 	UserID  int64
@@ -41,10 +43,20 @@ func (s *UserSubscription) IsExpired() bool {
 }
 
 func (s *UserSubscription) DaysRemaining() int {
-	if s.IsExpired() {
+	return s.daysRemainingAt(time.Now())
+}
+
+func (s *UserSubscription) daysRemainingAt(now time.Time) int {
+	remaining := s.ExpiresAt.Sub(now)
+	if remaining <= 0 {
 		return 0
 	}
-	return int(time.Until(s.ExpiresAt).Hours() / 24)
+
+	days := int(remaining / subscriptionDayDuration)
+	if remaining%subscriptionDayDuration != 0 {
+		days++
+	}
+	return days
 }
 
 func (s *UserSubscription) IsWindowActivated() bool {

--- a/backend/internal/service/user_subscription_days_remaining_test.go
+++ b/backend/internal/service/user_subscription_days_remaining_test.go
@@ -1,0 +1,37 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserSubscriptionDaysRemainingAt(t *testing.T) {
+	now := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      int
+	}{
+		{name: "expired", expiresAt: now.Add(-time.Nanosecond), want: 0},
+		{name: "expires now", expiresAt: now, want: 0},
+		{name: "less than one day", expiresAt: now.Add(subscriptionDayDuration - time.Nanosecond), want: 1},
+		{name: "exactly one day", expiresAt: now.Add(subscriptionDayDuration), want: 1},
+		{name: "over one day", expiresAt: now.Add(subscriptionDayDuration + time.Nanosecond), want: 2},
+		{name: "less than two days", expiresAt: now.Add(2*subscriptionDayDuration - time.Nanosecond), want: 2},
+		{name: "exactly two days", expiresAt: now.Add(2 * subscriptionDayDuration), want: 2},
+		{name: "over two days", expiresAt: now.Add(2*subscriptionDayDuration + time.Nanosecond), want: 3},
+		{name: "exactly seven days", expiresAt: now.Add(7 * subscriptionDayDuration), want: 7},
+		{name: "over seven days", expiresAt: now.Add(7*subscriptionDayDuration + time.Nanosecond), want: 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sub := &UserSubscription{ExpiresAt: tt.expiresAt}
+			require.Equal(t, tt.want, sub.daysRemainingAt(now))
+		})
+	}
+}


### PR DESCRIPTION
## 背景 / Background

订阅剩余天数原先通过完整小时数除以 24 后向下取整。剩余接近两天时会得到 1，导致系统提前发送“剩余 1 天”的订阅到期提醒，同时与前端向上取整的展示口径不一致。

Subscription remaining days were calculated by truncating complete 24-hour periods. A subscription with nearly two days left was reported as 1 day, causing the 1-day expiry reminder to be sent early and disagreeing with the frontend rounding behavior.

## 目的 / Purpose

统一订阅剩余天数为向上取整：任何未满一天的有效剩余时间均计为 1 天，使 7 天、3 天和 1 天邮件提醒在正确的时间窗口发送。

Round positive remaining subscription time up to whole days so that 7-day, 3-day, and 1-day expiry reminders are sent in the intended windows.

## 改动内容 / Changes

### 后端 / Backend

- 修改 `UserSubscription.DaysRemaining`，对正数剩余时间按 24 小时向上取整，已过期或恰好到期仍返回 0。
- 使用可注入固定时间的内部计算函数，避免边界测试受 `time.Now()` 波动影响。
- 增加 0、1、2、3、7、8 天及纳秒级边界测试。
- 收紧订阅进度测试，30 天有效期固定返回 30，不再容许 29。
- 影响范围：订阅到期提醒邮件，以及 `GET /api/v1/subscriptions/progress` 和 `GET /api/v1/admin/subscriptions/:id/progress` 返回的 `expires_in_days`。
- 当前第一方前端未读取 `expires_in_days`，而是根据 `expires_at` 使用 `Math.ceil` 自行计算，因此没有前端行为变化。

- Update `UserSubscription.DaysRemaining` to round positive 24-hour periods up while preserving 0 for expired or exactly expiring subscriptions.
- Use an internal calculation method with an explicit clock value for deterministic boundary tests.
- Add nanosecond-level boundary coverage for 0, 1, 2, 3, 7, and 8 days.
- Tighten the subscription progress expectation so a 30-day term consistently reports 30.
- Affected surfaces: subscription expiry reminder emails and the `expires_in_days` field returned by `GET /api/v1/subscriptions/progress` and `GET /api/v1/admin/subscriptions/:id/progress`.
- The first-party frontend does not consume `expires_in_days`; it already calculates from `expires_at` with `Math.ceil`, so frontend behavior is unchanged.

## 验证 / Verification

- `make test-unit`
- `make test-integration`
- `go vet ./...`
- `gofmt` and `git diff --check`

Local unit tests, integration tests, and vet passed. The PR CI also passed for this backend-only commit.