### PR TITLE
fix(grok): let manual connection tests bypass the scheduling gate

### DIFF
--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -711,7 +711,9 @@ func (s *AccountTestService) testGrokAccountConnection(c *gin.Context, account *
 			return s.sendErrorAndEnd(c, "Grok token provider not configured")
 		}
 		var err error
-		authToken, err = s.grokTokenProvider.GetAccessToken(ctx, account)
+		// 手动测试不走生产调度资格门：关闭调度、限流/过载/临时冷却中的账号
+		// 也应能被管理员探测（#4598），与 Codex/OpenAI 测试行为一致。
+		authToken, err = s.grokTokenProvider.GetAccessTokenForManualTest(ctx, account)
 		if err != nil {
 			return s.sendErrorAndEnd(c, fmt.Sprintf("Failed to get Grok access token: %s", err.Error()))
 		}

--- a/backend/internal/service/grok_token_provider.go
+++ b/backend/internal/service/grok_token_provider.go
@@ -167,6 +167,77 @@ func (p *GrokTokenProvider) GetAccessToken(ctx context.Context, account *Account
 	return accessToken, nil
 }
 
+// GetAccessTokenForManualTest returns an access token for an admin-initiated
+// "test connection" probe. Unlike GetAccessToken it does not apply the
+// request-path scheduling eligibility gate (manual Schedulable switch,
+// rate-limit / overload / temp-unschedulable cooldowns): a manual test exists
+// precisely to check accounts in those states, matching how Codex/OpenAI
+// account tests read credentials regardless of scheduling state (#4598).
+//
+// Credential integrity still applies: the configured-proxy-missing check, the
+// shared refresh lock protocol, and the refresh API's own account re-read.
+// Credential rotation for non-active (disabled/error) accounts remains
+// blocked inside RefreshIfNeeded; their still-valid tokens are probed as-is.
+func (p *GrokTokenProvider) GetAccessTokenForManualTest(ctx context.Context, account *Account) (string, error) {
+	if account == nil {
+		return "", errors.New("account is nil")
+	}
+	if account.Platform != PlatformGrok || account.Type != AccountTypeOAuth {
+		return "", errors.New("not a grok oauth account")
+	}
+	if account.ProxyID != nil && account.Proxy == nil {
+		return "", errGrokOAuthConfiguredProxyMiss
+	}
+	if strings.TrimSpace(account.GetGrokRefreshToken()) == "" {
+		return "", errGrokOAuthRefreshTokenMissing
+	}
+
+	accessToken := strings.TrimSpace(account.GetGrokAccessToken())
+	expiresAt := account.GetCredentialAsTime("expires_at")
+	tokenValid := accessToken != "" && expiresAt != nil && time.Now().Before(*expiresAt)
+	if accessToken != "" && expiresAt != nil && time.Until(*expiresAt) > grokTokenRefreshSkew {
+		return accessToken, nil
+	}
+
+	if p.refreshAPI == nil || p.executor == nil {
+		if tokenValid {
+			return accessToken, nil
+		}
+		return "", errGrokOAuthRefreshNotConfigured
+	}
+
+	// Deliberately not marked as a request-path refresh: the request path
+	// re-applies scheduling eligibility inside RefreshIfNeeded, which is
+	// exactly what a manual test must bypass.
+	refreshCtx, cancel := context.WithTimeout(ctx, grokRequestRefreshTimeout)
+	defer cancel()
+	result, err := p.refreshAPI.RefreshIfNeeded(refreshCtx, account, p.executor, grokTokenRefreshSkew)
+	if err != nil {
+		if tokenValid {
+			return accessToken, nil
+		}
+		return "", err
+	}
+	if result != nil && result.LockHeld {
+		if tokenValid {
+			return accessToken, nil
+		}
+		return "", errors.New("token refresh is already in progress on another worker; retry in a few seconds")
+	}
+	if result != nil && result.Account != nil {
+		account = result.Account
+	}
+
+	accessToken = strings.TrimSpace(account.GetGrokAccessToken())
+	if accessToken == "" {
+		return "", errGrokOAuthAccessTokenMissing
+	}
+	if latestExpiry := account.GetCredentialAsTime("expires_at"); latestExpiry != nil && !time.Now().Before(*latestExpiry) {
+		return "", errGrokOAuthAccessTokenExpired
+	}
+	return accessToken, nil
+}
+
 func (p *GrokTokenProvider) waitForRefreshedToken(ctx context.Context, account *Account, cacheKey string) (string, error) {
 	waitCtx, cancel := context.WithTimeout(ctx, grokRefreshLockWaitTimeout)
 	defer cancel()

--- a/backend/internal/service/grok_token_provider_test.go
+++ b/backend/internal/service/grok_token_provider_test.go
@@ -287,6 +287,150 @@ func TestGrokTokenProviderRejectsStaleDBTokenWithoutExpiry(t *testing.T) {
 	require.Empty(t, token)
 }
 
+// TestGrokTokenProviderManualTestBypassesSchedulingGate reproduces #4598:
+// admins must be able to run "test connection" against accounts that the
+// scheduler currently excludes (manual switch off, rate limited, overloaded,
+// temporarily cooled down). The production request path keeps rejecting them.
+func TestGrokTokenProviderManualTestBypassesSchedulingGate(t *testing.T) {
+	future := time.Now().Add(time.Hour)
+	tests := []struct {
+		name   string
+		mutate func(*Account)
+	}{
+		{name: "not schedulable", mutate: func(account *Account) { account.Schedulable = false }},
+		{name: "temporarily unschedulable", mutate: func(account *Account) { account.TempUnschedulableUntil = &future }},
+		{name: "rate limited", mutate: func(account *Account) { account.RateLimitResetAt = &future }},
+		{name: "overloaded", mutate: func(account *Account) { account.OverloadUntil = &future }},
+		{name: "disabled by error", mutate: func(account *Account) { account.Status = StatusError }},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account := expiredGrokOAuthAccountForCredentialTest(int64(120 + index))
+			account.Credentials["access_token"] = "still-valid-token"
+			account.Credentials["expires_at"] = time.Now().Add(2 * grokTokenRefreshSkew).UTC().Format(time.RFC3339)
+			tt.mutate(account)
+			provider := NewGrokTokenProvider(&tokenRefreshAccountRepo{}, &grokTokenCacheForProviderTest{})
+
+			// Production request path keeps excluding this account.
+			_, requestErr := provider.GetAccessToken(context.Background(), account)
+			require.ErrorIs(t, requestErr, errOAuthRefreshAccountStateChanged)
+
+			// Manual test path returns the valid credential for probing.
+			token, err := provider.GetAccessTokenForManualTest(context.Background(), account)
+			require.NoError(t, err)
+			require.Equal(t, "still-valid-token", token)
+		})
+	}
+}
+
+func TestGrokTokenProviderManualTestRefreshesExpiredTokenWhileUnschedulable(t *testing.T) {
+	t.Setenv(xai.EnvBaseURL, xai.DefaultCLIBaseURL)
+
+	expiredAt := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	account := &Account{
+		ID:          130,
+		Platform:    PlatformGrok,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: false,
+		Credentials: map[string]any{
+			"access_token":  "expired-access-token",
+			"refresh_token": "refresh-token",
+			"expires_at":    expiredAt,
+			"base_url":      xai.DefaultCLIBaseURL,
+			"client_id":     "client-id",
+		},
+	}
+	repo := &tokenRefreshAccountRepo{}
+	repo.accountsByID = map[int64]*Account{130: account}
+	cache := &grokTokenCacheForProviderTest{lockResult: true}
+	oauthSvc := NewGrokOAuthService(nil, &grokOAuthClientStub{
+		refreshResponse: &xai.TokenResponse{
+			AccessToken: "manual-test-refreshed-token",
+			TokenType:   "Bearer",
+			ExpiresIn:   3600,
+		},
+	})
+	defer oauthSvc.Stop()
+
+	provider := NewGrokTokenProvider(repo, cache)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), NewGrokTokenRefresher(oauthSvc))
+
+	token, err := provider.GetAccessTokenForManualTest(context.Background(), account)
+	require.NoError(t, err)
+	require.Equal(t, "manual-test-refreshed-token", token)
+	require.Equal(t, 1, repo.updateCredentialsCalls)
+}
+
+func TestGrokTokenProviderManualTestFallsBackToValidTokenOnRefreshFailure(t *testing.T) {
+	account := &Account{
+		ID:          131,
+		Platform:    PlatformGrok,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: false,
+		Credentials: map[string]any{
+			"access_token":  "near-expiry-token",
+			"refresh_token": "refresh-token",
+			// Inside the refresh window but not expired yet.
+			"expires_at": time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339),
+		},
+	}
+	repo := &tokenRefreshAccountRepo{}
+	repo.accountsByID = map[int64]*Account{131: account}
+	cache := &grokTokenCacheForProviderTest{lockResult: true}
+	provider := NewGrokTokenProvider(repo, cache)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), &tokenRefresherStub{
+		err: errors.New("upstream refresh unavailable"),
+	})
+
+	token, err := provider.GetAccessTokenForManualTest(context.Background(), account)
+	require.NoError(t, err)
+	require.Equal(t, "near-expiry-token", token)
+}
+
+func TestGrokTokenProviderManualTestReportsRefreshFailureWhenTokenExpired(t *testing.T) {
+	account := expiredGrokOAuthAccountForCredentialTest(132)
+	account.Schedulable = false
+	repo := &tokenRefreshAccountRepo{}
+	repo.accountsByID = map[int64]*Account{account.ID: account}
+	cache := &grokTokenCacheForProviderTest{lockResult: true}
+	provider := NewGrokTokenProvider(repo, cache)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), &tokenRefresherStub{
+		err: errors.New("invalid_client: client credentials rejected"),
+	})
+
+	token, err := provider.GetAccessTokenForManualTest(context.Background(), account)
+	require.Error(t, err)
+	require.Empty(t, token)
+	require.Contains(t, err.Error(), "invalid_client")
+}
+
+func TestGrokTokenProviderManualTestLockHeldWithExpiredTokenReturnsSpecificError(t *testing.T) {
+	account := expiredGrokOAuthAccountForCredentialTest(133)
+	repo := &tokenRefreshAccountRepo{}
+	repo.accountsByID = map[int64]*Account{account.ID: account}
+	cache := &grokTokenCacheForProviderTest{lockResult: false}
+	provider := NewGrokTokenProvider(repo, cache)
+	provider.SetRefreshAPI(NewOAuthRefreshAPI(repo, cache), &tokenRefresherStub{})
+
+	token, err := provider.GetAccessTokenForManualTest(context.Background(), account)
+	require.Error(t, err)
+	require.Empty(t, token)
+	require.Contains(t, err.Error(), "refresh is already in progress")
+}
+
+func TestGrokTokenProviderManualTestRequiresRefreshToken(t *testing.T) {
+	account := expiredGrokOAuthAccountForCredentialTest(134)
+	delete(account.Credentials, "refresh_token")
+	provider := NewGrokTokenProvider(&tokenRefreshAccountRepo{}, &grokTokenCacheForProviderTest{})
+
+	token, err := provider.GetAccessTokenForManualTest(context.Background(), account)
+	require.ErrorIs(t, err, errGrokOAuthRefreshTokenMissing)
+	require.Empty(t, token)
+}
+
 func TestGrokTokenProviderRejectsIneligibleSelectedAccountBeforeWarmCache(t *testing.T) {
 	future := time.Now().Add(time.Hour)
 	tests := []struct {


### PR DESCRIPTION
## 问题

Fixes #4598

Grok OAuth 账号只要处于任何不可调度状态——手动关闭调度开关、限流冷却、过载、临时不可调度、以及 token 正被其他 worker 刷新——管理后台「测试连接」都会在请求 xAI 之前直接失败，且只有一句笼统的：

```text
Failed to get Grok access token: oauth refresh account state changed
```

而 Codex/OpenAI 账号测试直接读取凭据、不受调度状态影响（`account_test_service.go` 的 OpenAI 分支）。管理员恰恰需要对这些被排除调度的账号做探活，行为不一致且无法排障。

## 根因

`testGrokAccountConnection` 复用了生产转发路径的 `GrokTokenProvider.GetAccessToken()`：

- 入口处 `grokOAuthRequestAccountEligibilityError` 要求 `account.IsSchedulable()`，把所有冷却/关闭调度的账号直接拒掉；
- 刷新走 `withOAuthRefreshRequestPath` 标记的请求路径，`RefreshIfNeeded` 内部对 Grok 会再做一次同样的资格检查；
- 锁被其他 worker 持有时，`waitForRefreshedToken` 轮询中同样反复做资格检查。

这套门槛对生产流量是正确的（不可调度账号不该服务请求），但手动测试的目的就是检查这些账号。

## 修改

`backend/internal/service/grok_token_provider.go`

- 新增 `GetAccessTokenForManualTest`：
  - **跳过调度资格门**（Schedulable 开关、限流/过载/临时冷却、账号状态），与 Codex/OpenAI 测试的语义对齐；
  - **保留凭据完整性检查**：配置的代理缺失（`errGrokOAuthConfiguredProxyMiss`）、refresh_token 缺失仍然拒绝并给出具体错误；
  - token 过期时仍通过共享的 `OAuthRefreshAPI.RefreshIfNeeded` 刷新（不带 request-path 标记），分布式锁协议、DB 重读、invalid_grant 竞争恢复全部保留；**非 active（已禁用/错误）账号的凭据轮换仍被 `RefreshIfNeeded` 内部拦截**，只探测其现有有效 token；
  - 刷新失败或锁被占用时，若当前 token 尚未过期则回退使用当前 token（测试“现在是否可用”）；否则把**具体的刷新错误**透传给管理员，锁占用场景返回明确的 "token refresh is already in progress on another worker; retry in a few seconds"。

`backend/internal/service/account_test_service.go`

- `testGrokAccountConnection` 的 OAuth 分支改用 `GetAccessTokenForManualTest`。

生产转发路径的 `GetAccessToken` 行为完全不变（既有用例 `TestGrokTokenProviderRejectsIneligibleSelectedAccountBeforeWarmCache` 继续通过）。

## 测试

新增 6 个单测（`grok_token_provider_test.go`，`-tags=unit`）：

- 表驱动：关闭调度 / 临时冷却 / 限流 / 过载 / error 状态账号，生产路径拒绝、手动测试路径返回有效 token；
- 关闭调度 + token 过期 → 手动测试成功走完整刷新并持久化新凭据；
- 刷新失败但 token 未过期 → 回退当前 token；
- 刷新失败且 token 已过期 → 透传具体刷新错误（不再是笼统的 state changed）;
- 刷新锁被其他 worker 持有且 token 已过期 → 返回明确的 in-progress 错误；
- refresh_token 缺失 → 明确的 missing 错误。

```text
go build ./...                                                        ok
go test -tags=unit ./internal/service/ -run "TestGrokTokenProvider"    ok（新旧全部通过）
go test -tags=unit ./internal/service/ -run "TestAccountTestService|TestGrok"  ok
gofmt / go vet                                                        干净
```
