### PR TITLE
feat(subscription): show expiry times to minute

### DIFF
--- a/frontend/src/utils/__tests__/formatDateTimeToMinute.spec.ts
+++ b/frontend/src/utils/__tests__/formatDateTimeToMinute.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatDateTimeToMinute } from '../format'
+
+describe('formatDateTimeToMinute', () => {
+  it('formats local date and time without seconds', () => {
+    const value = new Date(2026, 6, 19, 20, 30, 45)
+
+    expect(formatDateTimeToMinute(value, 'en-GB')).toBe('19/07/2026, 20:30')
+  })
+
+  it('returns an empty string for an invalid date', () => {
+    expect(formatDateTimeToMinute(new Date('invalid'), 'en-GB')).toBe('')
+  })
+})

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -150,6 +150,27 @@ export function formatDateTime(
 }
 
 /**
+ * 格式化日期时间（精确到分钟）
+ */
+export function formatDateTimeToMinute(
+  date: string | Date | null | undefined,
+  localeOverride?: string
+): string {
+  return formatDate(
+    date,
+    {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    },
+    localeOverride
+  )
+}
+
+/**
  * 格式化为 date 控件值（YYYY-MM-DD，使用本地时间）
  */
 export function formatDateLocalInput(date: Date): string {

--- a/frontend/src/views/admin/SubscriptionsView.vue
+++ b/frontend/src/views/admin/SubscriptionsView.vue
@@ -351,7 +351,7 @@
                     : 'text-gray-700 dark:text-gray-300'
                 "
               >
-                {{ formatDateOnly(value) }}
+                {{ formatDateTimeToMinute(value) }}
               </span>
               <div v-if="getDaysRemaining(value) !== null" class="text-xs text-gray-500">
                 {{ getDaysRemaining(value) }} {{ t('admin.subscriptions.daysRemaining') }}
@@ -598,7 +598,7 @@
             <span class="font-medium text-gray-900 dark:text-white">
               {{
                 extendingSubscription.expires_at
-                  ? formatDateOnly(extendingSubscription.expires_at)
+                  ? formatDateTimeToMinute(extendingSubscription.expires_at)
                   : t('admin.subscriptions.noExpiration')
               }}
             </span>
@@ -764,7 +764,7 @@ import { adminAPI } from '@/api/admin'
 import type { UserSubscription, Group, GroupPlatform, SubscriptionType } from '@/types'
 import type { SimpleUser } from '@/api/admin/usage'
 import type { Column } from '@/components/common/types'
-import { formatDateOnly } from '@/utils/format'
+import { formatDateTimeToMinute } from '@/utils/format'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import TablePageLayout from '@/components/layout/TablePageLayout.vue'

--- a/frontend/src/views/user/SubscriptionsView.vue
+++ b/frontend/src/views/user/SubscriptionsView.vue
@@ -256,7 +256,7 @@ import subscriptionsAPI from '@/api/subscriptions'
 import type { UserSubscription } from '@/types'
 import AppLayout from '@/components/layout/AppLayout.vue'
 import Icon from '@/components/icons/Icon.vue'
-import { formatDateOnly } from '@/utils/format'
+import { formatDateTimeToMinute } from '@/utils/format'
 import { hasPeakRate, formatPeakRateWindow, serverTimezoneLabel } from '@/utils/peak-rate'
 import { platformBorderClass, platformBadgeClass, platformButtonClass, platformLabel } from '@/utils/platformColors'
 import { getRemainingDurationParts, isOneTimeDailyQuota, type RemainingDurationParts } from '@/utils/subscriptionQuota'
@@ -322,7 +322,7 @@ function formatExpirationDate(expiresAt: string): string {
     return t('userSubscriptions.status.expired')
   }
 
-  const dateStr = formatDateOnly(expires)
+  const dateStr = formatDateTimeToMinute(expires)
 
   if (days === 0) {
     return `${dateStr} (${t('common.today')})`


### PR DESCRIPTION
## 背景 / Background

用户和管理员订阅页面只展示订阅到期日期，无法判断当天的具体到期时间。

The user and admin subscription pages showed only the expiry date, making the exact expiry time within that day unavailable.

## 目的 / Purpose

在订阅相关页面将到期时间精确展示到分钟，并保持所有页面使用一致的本地时间格式。

Show subscription expiry timestamps to the minute and keep the local-time format consistent across subscription views.

## 改动内容 / Changes

### 前端 / Frontend

- 新增共享的 `formatDateTimeToMinute` 格式化函数，按浏览器本地时区显示日期、小时和分钟，不显示秒。
- “我的订阅”页面保留剩余天数/今天/明天文案，并将到期日期改为精确到分钟。
- 管理员“订阅管理”列表的到期时间改为精确到分钟。
- 管理员续期弹窗中的当前到期时间改为精确到分钟。
- 增加格式化函数测试，覆盖秒字段移除和无效日期。

- Add a shared `formatDateTimeToMinute` formatter that displays local date, hour, and minute without seconds.
- Keep the remaining-days/today/tomorrow label on My Subscriptions while showing the expiry timestamp to the minute.
- Show expiry timestamps to the minute in the admin subscription list.
- Show the current expiry timestamp to the minute in the admin extension dialog.
- Add formatter tests covering second removal and invalid dates.

## 验证 / Verification

- `pnpm test:run` — 176 files, 1221 tests passed
- `pnpm exec eslint src/utils/format.ts src/utils/__tests__/formatDateTimeToMinute.spec.ts src/views/user/SubscriptionsView.vue src/views/admin/SubscriptionsView.vue`
- `pnpm build`
- `git diff --check`

## 截图 / Screenshot

```text
我的订阅 / My Subscriptions
Before: 剩余 2 天 (2026/07/21)
After:  剩余 2 天 (2026/07/21 20:30)

管理员订阅列表 / Admin Subscription List
Before: 2026/07/21
After:  2026/07/21 20:30

续期弹窗 / Extension Dialog
Before: 当前到期时间: 2026/07/21
After:  当前到期时间: 2026/07/21 20:30
```