### PR TITLE
feat(gateway): add bounded pre-stream Anthropic OAuth 529 retries

### DIFF
--- a/backend/internal/handler/admin/setting_handler_runtime.go
+++ b/backend/internal/handler/admin/setting_handler_runtime.go
@@ -50,7 +50,7 @@ func (h *SettingHandler) DeleteAdminAPIKey(c *gin.Context) {
 	response.Success(c, gin.H{"message": "Admin API key deleted"})
 }
 
-// GetOverloadCooldownSettings 获取529过载冷却配置
+// GetOverloadCooldownSettings 获取529过载处理配置
 // GET /api/v1/admin/settings/overload-cooldown
 func (h *SettingHandler) GetOverloadCooldownSettings(c *gin.Context) {
 	settings, err := h.settingService.GetOverloadCooldownSettings(c.Request.Context())
@@ -62,16 +62,18 @@ func (h *SettingHandler) GetOverloadCooldownSettings(c *gin.Context) {
 	response.Success(c, dto.OverloadCooldownSettings{
 		Enabled:         settings.Enabled,
 		CooldownMinutes: settings.CooldownMinutes,
+		OAuthRetryCount: settings.OAuthRetryCount,
 	})
 }
 
-// UpdateOverloadCooldownSettingsRequest 更新529过载冷却配置请求
+// UpdateOverloadCooldownSettingsRequest 更新529过载处理配置请求
 type UpdateOverloadCooldownSettingsRequest struct {
 	Enabled         bool `json:"enabled"`
 	CooldownMinutes int  `json:"cooldown_minutes"`
+	OAuthRetryCount int  `json:"oauth_retry_count"`
 }
 
-// UpdateOverloadCooldownSettings 更新529过载冷却配置
+// UpdateOverloadCooldownSettings 更新529过载处理配置
 // PUT /api/v1/admin/settings/overload-cooldown
 func (h *SettingHandler) UpdateOverloadCooldownSettings(c *gin.Context) {
 	var req UpdateOverloadCooldownSettingsRequest
@@ -83,6 +85,7 @@ func (h *SettingHandler) UpdateOverloadCooldownSettings(c *gin.Context) {
 	settings := &service.OverloadCooldownSettings{
 		Enabled:         req.Enabled,
 		CooldownMinutes: req.CooldownMinutes,
+		OAuthRetryCount: req.OAuthRetryCount,
 	}
 
 	if err := h.settingService.SetOverloadCooldownSettings(c.Request.Context(), settings); err != nil {
@@ -99,6 +102,7 @@ func (h *SettingHandler) UpdateOverloadCooldownSettings(c *gin.Context) {
 	response.Success(c, dto.OverloadCooldownSettings{
 		Enabled:         updatedSettings.Enabled,
 		CooldownMinutes: updatedSettings.CooldownMinutes,
+		OAuthRetryCount: updatedSettings.OAuthRetryCount,
 	})
 }
 

--- a/backend/internal/handler/dto/settings.go
+++ b/backend/internal/handler/dto/settings.go
@@ -380,10 +380,11 @@ type LoginAgreementDocument struct {
 	ContentMD string `json:"content_md"`
 }
 
-// OverloadCooldownSettings 529过载冷却配置 DTO
+// OverloadCooldownSettings 529过载处理配置 DTO
 type OverloadCooldownSettings struct {
 	Enabled         bool `json:"enabled"`
 	CooldownMinutes int  `json:"cooldown_minutes"`
+	OAuthRetryCount int  `json:"oauth_retry_count"`
 }
 
 // RateLimit429CooldownSettings 429默认回避配置 DTO

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -42,6 +42,19 @@ func (s *GatewayService) shouldRetryUpstreamError(account *Account, statusCode i
 	return !account.ShouldHandleErrorCode(statusCode)
 }
 
+func (s *GatewayService) getOAuth529RetryCount(ctx context.Context, account *Account) int {
+	if account == nil || !account.IsAnthropicOAuthOrSetupToken() || s.settingService == nil {
+		return 0
+	}
+
+	settings, err := s.settingService.GetOverloadCooldownSettings(ctx)
+	if err != nil {
+		slog.Warn("oauth_529_retry_settings_read_failed", "account_id", account.ID, "error", err)
+		return 0
+	}
+	return settings.OAuthRetryCount
+}
+
 // shouldFailoverUpstreamError determines whether an upstream error should trigger account failover.
 func (s *GatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
@@ -352,6 +365,19 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	var resp *http.Response
 	lastWireBody := body
 	retryStart := time.Now()
+	oauth529RetryCount := 0
+	oauth529RetriesUsed := 0
+	oauth529RetrySettingsLoaded := false
+	shouldRetryForwardError := func(statusCode int) bool {
+		if statusCode == 529 && account.IsAnthropicOAuthOrSetupToken() {
+			if !oauth529RetrySettingsLoaded {
+				oauth529RetryCount = s.getOAuth529RetryCount(ctx, account)
+				oauth529RetrySettingsLoaded = true
+			}
+			return oauth529RetryCount > 0
+		}
+		return s.shouldRetryUpstreamError(account, statusCode)
+	}
 	for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
 		// 构建上游请求（每次重试需要重新构建，因为请求体需要重新读取）
 		upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, reqStream)
@@ -590,8 +616,16 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		}
 
 		// 检查是否需要通用重试（排除400，因为400已经在上面特殊处理过了）
-		if resp.StatusCode >= 400 && resp.StatusCode != 400 && s.shouldRetryUpstreamError(account, resp.StatusCode) {
-			if attempt < maxRetryAttempts {
+		if resp.StatusCode >= 400 && resp.StatusCode != 400 && shouldRetryForwardError(resp.StatusCode) {
+			canRetry := attempt < maxRetryAttempts
+			retryNumber := attempt
+			retryLimit := maxRetryAttempts
+			if resp.StatusCode == 529 && account.IsAnthropicOAuthOrSetupToken() {
+				canRetry = canRetry && oauth529RetriesUsed < oauth529RetryCount
+				retryNumber = oauth529RetriesUsed + 1
+				retryLimit = oauth529RetryCount
+			}
+			if canRetry {
 				elapsed := time.Since(retryStart)
 				if elapsed >= maxRetryElapsed {
 					break
@@ -608,6 +642,9 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 
 				respBody, _ := s.readUpstreamErrorBody(resp)
 				_ = resp.Body.Close()
+				if resp.StatusCode == 529 && account.IsAnthropicOAuthOrSetupToken() {
+					oauth529RetriesUsed++
+				}
 				appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 					Platform:           account.Platform,
 					AccountID:          account.ID,
@@ -625,7 +662,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 					}(),
 				})
 				logger.LegacyPrintf("service.gateway", "Account %d: upstream error %d, retry %d/%d after %v (elapsed=%v/%v)",
-					account.ID, resp.StatusCode, attempt, maxRetryAttempts, delay, elapsed, maxRetryElapsed)
+					account.ID, resp.StatusCode, retryNumber, retryLimit, delay, elapsed, maxRetryElapsed)
 				if err := sleepWithContext(ctx, delay); err != nil {
 					return nil, err
 				}
@@ -651,7 +688,7 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 	defer func() { _ = resp.Body.Close() }()
 
 	// 处理重试耗尽的情况
-	if resp.StatusCode >= 400 && s.shouldRetryUpstreamError(account, resp.StatusCode) {
+	if resp.StatusCode >= 400 && shouldRetryForwardError(resp.StatusCode) {
 		if s.shouldFailoverUpstreamError(resp.StatusCode) {
 			respBody, _ := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()

--- a/backend/internal/service/gateway_upstream_response.go
+++ b/backend/internal/service/gateway_upstream_response.go
@@ -520,10 +520,10 @@ func (s *GatewayService) handleRetryExhaustedSideEffects(ctx context.Context, re
 	body, _ := s.readUpstreamErrorBody(resp)
 	statusCode := resp.StatusCode
 
-	// OAuth/Setup Token 账号的 403：标记账号异常
-	if account.IsOAuth() && statusCode == 403 {
+	// OAuth/Setup Token 账号的 403/529：重试耗尽后执行原有账号状态处理
+	if account.IsOAuth() && (statusCode == 403 || statusCode == 529) {
 		s.rateLimitService.HandleUpstreamError(ctx, account, statusCode, resp.Header, body)
-		logger.LegacyPrintf("service.gateway", "Account %d: marked as error after %d retries for status %d", account.ID, maxRetryAttempts, statusCode)
+		logger.LegacyPrintf("service.gateway", "Account %d: applied account state after retries exhausted for status %d", account.ID, statusCode)
 	} else {
 		// API Key 未配置错误码：不标记账号状态
 		logger.LegacyPrintf("service.gateway", "Account %d: upstream error %d after %d retries (not marking account)", account.ID, statusCode, maxRetryAttempts)

--- a/backend/internal/service/overload_cooldown_test.go
+++ b/backend/internal/service/overload_cooldown_test.go
@@ -5,10 +5,16 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,11 +65,12 @@ func TestGetOverloadCooldownSettings_DefaultsWhenNotSet(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, settings.Enabled)
 	require.Equal(t, 10, settings.CooldownMinutes)
+	require.Zero(t, settings.OAuthRetryCount)
 }
 
 func TestGetOverloadCooldownSettings_ReadsFromDB(t *testing.T) {
 	repo := newMockSettingRepo()
-	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: false, CooldownMinutes: 30})
+	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: false, CooldownMinutes: 30, OAuthRetryCount: 2})
 	repo.data[SettingKeyOverloadCooldownSettings] = string(data)
 	svc := NewSettingService(repo, &config.Config{})
 
@@ -71,28 +78,31 @@ func TestGetOverloadCooldownSettings_ReadsFromDB(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, settings.Enabled)
 	require.Equal(t, 30, settings.CooldownMinutes)
+	require.Equal(t, 2, settings.OAuthRetryCount)
 }
 
 func TestGetOverloadCooldownSettings_ClampsMinValue(t *testing.T) {
 	repo := newMockSettingRepo()
-	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: true, CooldownMinutes: 0})
+	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: true, CooldownMinutes: 0, OAuthRetryCount: -1})
 	repo.data[SettingKeyOverloadCooldownSettings] = string(data)
 	svc := NewSettingService(repo, &config.Config{})
 
 	settings, err := svc.GetOverloadCooldownSettings(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 1, settings.CooldownMinutes)
+	require.Zero(t, settings.OAuthRetryCount)
 }
 
 func TestGetOverloadCooldownSettings_ClampsMaxValue(t *testing.T) {
 	repo := newMockSettingRepo()
-	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: true, CooldownMinutes: 999})
+	data, _ := json.Marshal(OverloadCooldownSettings{Enabled: true, CooldownMinutes: 999, OAuthRetryCount: 999})
 	repo.data[SettingKeyOverloadCooldownSettings] = string(data)
 	svc := NewSettingService(repo, &config.Config{})
 
 	settings, err := svc.GetOverloadCooldownSettings(context.Background())
 	require.NoError(t, err)
 	require.Equal(t, 120, settings.CooldownMinutes)
+	require.Equal(t, maxOAuth529RetryCount, settings.OAuthRetryCount)
 }
 
 func TestGetOverloadCooldownSettings_InvalidJSON_ReturnsDefaults(t *testing.T) {
@@ -128,6 +138,7 @@ func TestSetOverloadCooldownSettings_Success(t *testing.T) {
 	err := svc.SetOverloadCooldownSettings(context.Background(), &OverloadCooldownSettings{
 		Enabled:         false,
 		CooldownMinutes: 25,
+		OAuthRetryCount: 2,
 	})
 	require.NoError(t, err)
 
@@ -136,6 +147,7 @@ func TestSetOverloadCooldownSettings_Success(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, settings.Enabled)
 	require.Equal(t, 25, settings.CooldownMinutes)
+	require.Equal(t, 2, settings.OAuthRetryCount)
 }
 
 func TestSetOverloadCooldownSettings_RejectsNil(t *testing.T) {
@@ -153,6 +165,18 @@ func TestSetOverloadCooldownSettings_EnabledRejectsOutOfRange(t *testing.T) {
 		})
 		require.Error(t, err, "should reject enabled=true + cooldown_minutes=%d", minutes)
 		require.Contains(t, err.Error(), "cooldown_minutes must be between 1-120")
+	}
+}
+
+func TestSetOverloadCooldownSettings_RejectsOAuthRetryCountOutOfRange(t *testing.T) {
+	svc := NewSettingService(newMockSettingRepo(), &config.Config{})
+
+	for _, retryCount := range []int{-1, maxOAuth529RetryCount + 1, 999} {
+		err := svc.SetOverloadCooldownSettings(context.Background(), &OverloadCooldownSettings{
+			Enabled: true, CooldownMinutes: 10, OAuthRetryCount: retryCount,
+		})
+		require.Error(t, err, "should reject oauth_retry_count=%d", retryCount)
+		require.Contains(t, err.Error(), "oauth_retry_count must be between 0-2")
 	}
 }
 
@@ -277,10 +301,11 @@ func TestDefaultOverloadCooldownSettings(t *testing.T) {
 	d := DefaultOverloadCooldownSettings()
 	require.True(t, d.Enabled)
 	require.Equal(t, 10, d.CooldownMinutes)
+	require.Zero(t, d.OAuthRetryCount)
 }
 
 func TestOverloadCooldownSettings_JSONRoundTrip(t *testing.T) {
-	original := OverloadCooldownSettings{Enabled: false, CooldownMinutes: 42}
+	original := OverloadCooldownSettings{Enabled: false, CooldownMinutes: 42, OAuthRetryCount: 2}
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
 
@@ -293,6 +318,149 @@ func TestOverloadCooldownSettings_JSONRoundTrip(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &raw))
 	_, hasEnabled := raw["enabled"]
 	_, hasCooldown := raw["cooldown_minutes"]
+	_, hasOAuthRetryCount := raw["oauth_retry_count"]
 	require.True(t, hasEnabled, "JSON must use 'enabled'")
 	require.True(t, hasCooldown, "JSON must use 'cooldown_minutes'")
+	require.True(t, hasOAuthRetryCount, "JSON must use 'oauth_retry_count'")
+}
+
+type oauth529HTTPUpstreamStub struct {
+	statusCodes []int
+	bodies      [][]byte
+}
+
+func (s *oauth529HTTPUpstreamStub) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	return s.DoWithTLS(req, proxyURL, accountID, accountConcurrency, nil)
+}
+
+func (s *oauth529HTTPUpstreamStub) DoWithTLS(req *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	s.bodies = append(s.bodies, body)
+
+	index := len(s.bodies) - 1
+	statusCode := s.statusCodes[index]
+	responseBody := `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`
+	if statusCode == http.StatusOK {
+		responseBody = `{"id":"msg_test","type":"message","model":"claude-sonnet-4-5","usage":{"input_tokens":1,"output_tokens":1},"content":[]}`
+	}
+
+	return &http.Response{
+		StatusCode: statusCode,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"x-request-id": []string{"req-test"},
+		},
+		Body: io.NopCloser(strings.NewReader(responseBody)),
+	}, nil
+}
+
+func newOAuth529ForwardTest(t *testing.T, retryCount int, statusCodes ...int) (*GatewayService, *gin.Context, *Account, *ParsedRequest, *oauth529HTTPUpstreamStub, *overloadAccountRepoStub) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{Gateway: config.GatewayConfig{MaxLineSize: defaultMaxLineSize}}
+	settingRepo := newMockSettingRepo()
+	data, err := json.Marshal(OverloadCooldownSettings{
+		Enabled:         true,
+		CooldownMinutes: 10,
+		OAuthRetryCount: retryCount,
+	})
+	require.NoError(t, err)
+	settingRepo.data[SettingKeyOverloadCooldownSettings] = string(data)
+	settingSvc := NewSettingService(settingRepo, cfg)
+
+	accountRepo := &overloadAccountRepoStub{}
+	rateLimitSvc := &RateLimitService{
+		accountRepo:    accountRepo,
+		cfg:            cfg,
+		settingService: settingSvc,
+	}
+	upstream := &oauth529HTTPUpstreamStub{statusCodes: statusCodes}
+	svc := &GatewayService{
+		cfg:                  cfg,
+		httpUpstream:         upstream,
+		rateLimitService:     rateLimitSvc,
+		settingService:       settingSvc,
+		tlsFPProfileService:  &TLSFingerprintProfileService{},
+		responseHeaderFilter: compileResponseHeaderFilter(cfg),
+	}
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	c.Request.Header.Set("User-Agent", "claude-cli/2.1.78")
+
+	body := []byte(`{"model":"claude-sonnet-4-5","stream":false,"max_tokens":32,"metadata":{"user_id":"session_123e4567-e89b-12d3-a456-426614174000"},"messages":[{"role":"user","content":"hello"}]}`)
+	parsed, err := ParseGatewayRequest(NewRequestBodyRef(body), PlatformAnthropic)
+	require.NoError(t, err)
+	account := &Account{
+		ID:          529,
+		Name:        "oauth-529-test",
+		Platform:    PlatformAnthropic,
+		Type:        AccountTypeSetupToken,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "test-token"},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	return svc, c, account, parsed, upstream, accountRepo
+}
+
+func TestGatewayForwardOAuth529_DefaultDoesNotRetry(t *testing.T) {
+	svc, c, account, parsed, upstream, accountRepo := newOAuth529ForwardTest(t, 0, 529, http.StatusOK)
+
+	result, err := svc.Forward(context.Background(), c, account, parsed)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, 529, failoverErr.StatusCode)
+	require.Len(t, upstream.bodies, 1)
+	require.Equal(t, 1, accountRepo.overloadCalls)
+}
+
+func TestGatewayForwardOAuth529_RetriesConfiguredCountAndReplaysBody(t *testing.T) {
+	svc, c, account, parsed, upstream, accountRepo := newOAuth529ForwardTest(t, 2, 529, 529, http.StatusOK)
+
+	result, err := svc.Forward(context.Background(), c, account, parsed)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 3)
+	require.Equal(t, upstream.bodies[0], upstream.bodies[1])
+	require.Equal(t, upstream.bodies[0], upstream.bodies[2])
+	require.Zero(t, accountRepo.overloadCalls)
+}
+
+func TestGatewayForwardOAuth529_ExhaustionStillAppliesCooldownAndFailover(t *testing.T) {
+	svc, c, account, parsed, upstream, accountRepo := newOAuth529ForwardTest(t, 2, 529, 529, 529, http.StatusOK)
+
+	result, err := svc.Forward(context.Background(), c, account, parsed)
+
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, 529, failoverErr.StatusCode)
+	require.Len(t, upstream.bodies, 3)
+	require.Equal(t, upstream.bodies[0], upstream.bodies[1])
+	require.Equal(t, upstream.bodies[0], upstream.bodies[2])
+	require.Equal(t, 1, accountRepo.overloadCalls)
+}
+
+func TestGatewayOAuth529RetrySettingIsAnthropicSubscriptionOnly(t *testing.T) {
+	settingRepo := newMockSettingRepo()
+	data, err := json.Marshal(OverloadCooldownSettings{Enabled: true, CooldownMinutes: 10, OAuthRetryCount: 2})
+	require.NoError(t, err)
+	settingRepo.data[SettingKeyOverloadCooldownSettings] = string(data)
+	svc := &GatewayService{settingService: NewSettingService(settingRepo, &config.Config{})}
+
+	require.Equal(t, 2, svc.getOAuth529RetryCount(context.Background(), &Account{Platform: PlatformAnthropic, Type: AccountTypeOAuth}))
+	require.Zero(t, svc.getOAuth529RetryCount(context.Background(), &Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey}))
+	require.Zero(t, svc.getOAuth529RetryCount(context.Background(), &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}))
+	require.True(t, svc.shouldRetryUpstreamError(&Account{Platform: PlatformAnthropic, Type: AccountTypeOAuth}, http.StatusForbidden))
+	require.False(t, svc.shouldRetryUpstreamError(&Account{Platform: PlatformAnthropic, Type: AccountTypeAPIKey}, 529))
 }

--- a/backend/internal/service/setting_features.go
+++ b/backend/internal/service/setting_features.go
@@ -550,6 +550,12 @@ func (s *SettingService) GetOverloadCooldownSettings(ctx context.Context) (*Over
 	if settings.CooldownMinutes > 120 {
 		settings.CooldownMinutes = 120
 	}
+	if settings.OAuthRetryCount < 0 {
+		settings.OAuthRetryCount = 0
+	}
+	if settings.OAuthRetryCount > maxOAuth529RetryCount {
+		settings.OAuthRetryCount = maxOAuth529RetryCount
+	}
 
 	return &settings, nil
 }
@@ -558,6 +564,9 @@ func (s *SettingService) GetOverloadCooldownSettings(ctx context.Context) (*Over
 func (s *SettingService) SetOverloadCooldownSettings(ctx context.Context, settings *OverloadCooldownSettings) error {
 	if settings == nil {
 		return fmt.Errorf("settings cannot be nil")
+	}
+	if settings.OAuthRetryCount < 0 || settings.OAuthRetryCount > maxOAuth529RetryCount {
+		return fmt.Errorf("oauth_retry_count must be between 0-%d", maxOAuth529RetryCount)
 	}
 
 	// 禁用时修正为合法值即可，不拒绝请求

--- a/backend/internal/service/settings_view.go
+++ b/backend/internal/service/settings_view.go
@@ -487,13 +487,17 @@ type BetaPolicySettings struct {
 	Rules []BetaPolicyRule `json:"rules"`
 }
 
-// OverloadCooldownSettings 529过载冷却配置
+// OverloadCooldownSettings 529过载处理配置
 type OverloadCooldownSettings struct {
 	// Enabled 是否在收到529时暂停账号调度
 	Enabled bool `json:"enabled"`
 	// CooldownMinutes 冷却时长（分钟）
 	CooldownMinutes int `json:"cooldown_minutes"`
+	// OAuthRetryCount Anthropic OAuth/SetupToken 账号在冷却和切换前的同账号重试次数
+	OAuthRetryCount int `json:"oauth_retry_count"`
 }
+
+const maxOAuth529RetryCount = 2
 
 // RateLimit429CooldownSettings 429默认回避配置
 type RateLimit429CooldownSettings struct {
@@ -508,6 +512,7 @@ func DefaultOverloadCooldownSettings() *OverloadCooldownSettings {
 	return &OverloadCooldownSettings{
 		Enabled:         true,
 		CooldownMinutes: 10,
+		OAuthRetryCount: 0,
 	}
 }
 

--- a/frontend/src/api/admin/settings.ts
+++ b/frontend/src/api/admin/settings.ts
@@ -1161,6 +1161,7 @@ export async function deleteAdminApiKey(): Promise<{ message: string }> {
 export interface OverloadCooldownSettings {
   enabled: boolean;
   cooldown_minutes: number;
+  oauth_retry_count: number;
 }
 
 export async function getOverloadCooldownSettings(): Promise<OverloadCooldownSettings> {

--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -935,14 +935,16 @@ export default {
         }
       },
       overloadCooldown: {
-        title: '529 Overload Cooldown',
-        description: 'Configure account scheduling pause strategy when upstream returns 529 (overloaded)',
+        title: '529 Overload Handling',
+        description: 'Configure bounded retries and account scheduling pause when upstream returns 529 (overloaded)',
         enabled: 'Enable Overload Cooldown',
         enabledHint: 'Pause account scheduling on 529 errors, auto-recover after cooldown',
         cooldownMinutes: 'Cooldown Duration (minutes)',
         cooldownMinutesHint: 'Duration to pause account scheduling (1-120 minutes)',
-        saved: 'Overload cooldown settings saved',
-        saveFailed: 'Failed to save overload cooldown settings'
+        oauthRetryCount: 'Anthropic OAuth 529 Retries',
+        oauthRetryCountHint: 'Same-account pre-stream retries for Anthropic OAuth/setup-token requests before cooldown and failover (0-2; 0 keeps existing behavior)',
+        saved: '529 overload settings saved',
+        saveFailed: 'Failed to save 529 overload settings'
       },
       rateLimit429Cooldown: {
         title: '429 Default Cooldown',

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -929,14 +929,16 @@ export default {
         }
       },
       overloadCooldown: {
-        title: '529 过载冷却',
-        description: '配置上游返回 529（过载）时的账号调度暂停策略',
+        title: '529 过载处理',
+        description: '配置上游返回 529（过载）时的有界重试与账号调度暂停策略',
         enabled: '启用过载冷却',
         enabledHint: '收到 529 错误时暂停该账号的调度，冷却后自动恢复',
         cooldownMinutes: '冷却时长（分钟）',
         cooldownMinutesHint: '账号暂停调度的持续时间（1-120 分钟）',
-        saved: '过载冷却设置保存成功',
-        saveFailed: '保存过载冷却设置失败'
+        oauthRetryCount: 'Anthropic OAuth 529 重试次数',
+        oauthRetryCountHint: 'Anthropic OAuth/setup-token 请求在冷却和切换账号前进行的同账号流前重试（0-2；0 保持现有行为）',
+        saved: '529 过载设置保存成功',
+        saveFailed: '保存 529 过载设置失败'
       },
       rateLimit429Cooldown: {
         title: '429 默认回避',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -265,6 +265,29 @@
                 </div>
 
                 <div
+                  class="border-t border-gray-100 pt-4 dark:border-dark-700"
+                >
+                  <label
+                    class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {{ t("admin.settings.overloadCooldown.oauthRetryCount") }}
+                  </label>
+                  <input
+                    v-model.number="overloadCooldownForm.oauth_retry_count"
+                    data-testid="oauth-529-retry-count"
+                    type="number"
+                    min="0"
+                    max="2"
+                    class="input w-32"
+                  />
+                  <p class="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                    {{
+                      t("admin.settings.overloadCooldown.oauthRetryCountHint")
+                    }}
+                  </p>
+                </div>
+
+                <div
                   class="flex justify-end border-t border-gray-100 pt-4 dark:border-dark-700"
                 >
                   <button
@@ -7839,6 +7862,7 @@ const overloadCooldownSaving = ref(false);
 const overloadCooldownForm = reactive({
   enabled: true,
   cooldown_minutes: 10,
+  oauth_retry_count: 0,
 });
 
 // Rate Limit Cooldown (429) 状态
@@ -10465,6 +10489,7 @@ async function saveOverloadCooldownSettings() {
     const updated = await adminAPI.settings.updateOverloadCooldownSettings({
       enabled: overloadCooldownForm.enabled,
       cooldown_minutes: overloadCooldownForm.cooldown_minutes,
+      oauth_retry_count: overloadCooldownForm.oauth_retry_count,
     });
     Object.assign(overloadCooldownForm, updated);
     appStore.showSuccess(t("admin.settings.overloadCooldown.saved"));

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -11,6 +11,7 @@ const {
   updateWebSearchEmulationConfig,
   getAdminApiKey,
   getOverloadCooldownSettings,
+  updateOverloadCooldownSettings,
   getRateLimit429CooldownSettings,
   updateRateLimit429CooldownSettings,
   getStreamTimeoutSettings,
@@ -35,6 +36,7 @@ const {
   updateWebSearchEmulationConfig: vi.fn(),
   getAdminApiKey: vi.fn(),
   getOverloadCooldownSettings: vi.fn(),
+  updateOverloadCooldownSettings: vi.fn(),
   getRateLimit429CooldownSettings: vi.fn(),
   updateRateLimit429CooldownSettings: vi.fn(),
   getStreamTimeoutSettings: vi.fn(),
@@ -68,6 +70,7 @@ vi.mock("@/api", () => ({
       updateWebSearchEmulationConfig,
       getAdminApiKey,
       getOverloadCooldownSettings,
+      updateOverloadCooldownSettings,
       getRateLimit429CooldownSettings,
       updateRateLimit429CooldownSettings,
       getStreamTimeoutSettings,
@@ -566,6 +569,7 @@ describe("admin SettingsView payment visible method controls", () => {
     updateWebSearchEmulationConfig.mockReset();
     getAdminApiKey.mockReset();
     getOverloadCooldownSettings.mockReset();
+    updateOverloadCooldownSettings.mockReset();
     getRateLimit429CooldownSettings.mockReset();
     updateRateLimit429CooldownSettings.mockReset();
     getStreamTimeoutSettings.mockReset();
@@ -605,7 +609,9 @@ describe("admin SettingsView payment visible method controls", () => {
     getOverloadCooldownSettings.mockResolvedValue({
       enabled: true,
       cooldown_minutes: 10,
+      oauth_retry_count: 0,
     });
+    updateOverloadCooldownSettings.mockImplementation(async (payload) => payload);
     getRateLimit429CooldownSettings.mockResolvedValue({
       enabled: true,
       cooldown_seconds: 5,
@@ -652,6 +658,37 @@ describe("admin SettingsView payment visible method controls", () => {
 
     expect(wrapper.text()).not.toContain("可见方式");
     expect(wrapper.text()).not.toContain("支付来源");
+  });
+
+  it("loads and saves the bounded OAuth 529 retry count", async () => {
+    getOverloadCooldownSettings.mockResolvedValueOnce({
+      enabled: true,
+      cooldown_minutes: 10,
+      oauth_retry_count: 2,
+    });
+    const wrapper = mountView();
+
+    await flushPromises();
+    await openGatewayTab(wrapper);
+
+    const retryInput = wrapper.get('[data-testid="oauth-529-retry-count"]');
+    expect((retryInput.element as HTMLInputElement).value).toBe("2");
+    await retryInput.setValue("1");
+
+    const card = retryInput.element.closest(".card");
+    expect(card).not.toBeNull();
+    const saveButton = wrapper
+      .findAll("button")
+      .find((node) => card?.contains(node.element) && node.text().includes("common.save"));
+    expect(saveButton).toBeDefined();
+    await saveButton?.trigger("click");
+    await flushPromises();
+
+    expect(updateOverloadCooldownSettings).toHaveBeenCalledWith({
+      enabled: true,
+      cooldown_minutes: 10,
+      oauth_retry_count: 1,
+    });
   });
 
   it("loads, edits, validates, and saves forwarded client-IP headers", async () => {
@@ -1127,6 +1164,7 @@ describe("admin SettingsView wechat connect controls", () => {
     updateWebSearchEmulationConfig.mockReset();
     getAdminApiKey.mockReset();
     getOverloadCooldownSettings.mockReset();
+    updateOverloadCooldownSettings.mockReset();
     getRateLimit429CooldownSettings.mockReset();
     updateRateLimit429CooldownSettings.mockReset();
     getStreamTimeoutSettings.mockReset();
@@ -1167,7 +1205,9 @@ describe("admin SettingsView wechat connect controls", () => {
     getOverloadCooldownSettings.mockResolvedValue({
       enabled: true,
       cooldown_minutes: 10,
+      oauth_retry_count: 0,
     });
+    updateOverloadCooldownSettings.mockImplementation(async (payload) => payload);
     getRateLimit429CooldownSettings.mockResolvedValue({
       enabled: true,
       cooldown_seconds: 5,
@@ -1373,6 +1413,7 @@ describe("admin SettingsView platform quota matrix", () => {
     updateWebSearchEmulationConfig.mockReset();
     getAdminApiKey.mockReset();
     getOverloadCooldownSettings.mockReset();
+    updateOverloadCooldownSettings.mockReset();
     getRateLimit429CooldownSettings.mockReset();
     updateRateLimit429CooldownSettings.mockReset();
     getStreamTimeoutSettings.mockReset();


### PR DESCRIPTION
## Problem

When Anthropic OAuth/setup-token forwarding receives a pre-stream HTTP 529 (`overloaded_error`), Sub2API immediately applies the configured cooldown and moves to account failover. That conservative behavior is appropriate as the default, but it provides no way to absorb a brief upstream overload:

- a single-account deployment returns a downstream 503 immediately;
- a pooled deployment rotates away from an otherwise healthy account for a transient response.

Issue #1348 includes several overload reports, including an explicit HTTP 529 report. This change addresses only that transient 529 recovery gap. It does not claim to address the account-restriction or ban reports discussed in the same issue.

## Why bounded and opt-in

Adding 529 to the existing generic retry predicate would allow up to five attempts and could amplify load while Anthropic is already overloaded. It would also bypass the existing 529 cooldown unless retry exhaustion were handled explicitly.

This PR therefore adds a separate operator-controlled budget:

- `0` retries remains the default, preserving current behavior;
- operators may enable at most `1` or `2` same-account retries;
- retries use the existing exponential backoff and 10-second elapsed-time budget;
- only responses received before streaming begins are replayed;
- exhaustion still applies the existing cooldown and failover behavior.

Keeping this policy upstream makes the behavior reusable and reviewable without requiring deployments to carry a long-lived gateway patch.

## Changes

- Add `oauth_retry_count` to the existing 529 overload settings, constrained to `0-2` and defaulting to `0`.
- Apply the setting only to pre-stream HTTP 529 responses from Anthropic OAuth/setup-token accounts.
- Load the setting lazily on the first matching 529, so successful requests do not add a settings lookup.
- Rebuild and replay the request through the existing retry loop.
- Apply the existing 529 account-state handling after the configured retries are exhausted, then return the normal failover error.
- Expose the setting in the admin UI with explicit scope and compatibility wording in English and Chinese.

| `oauth_retry_count` | Total attempts after consecutive 529 responses |
| --- | --- |
| `0` (default) | 1 |
| `1` | 2 |
| `2` | 3 |

## Compatibility and scope

- Existing stored JSON and older API clients omit the new field and retain the current behavior (`0` retries).
- API-key accounts, OAuth 403 handling, non-529 status handling, and post-stream/SSE errors are unchanged.
- No database migration is required.

## Tests

- [x] Default `0` performs no same-account retry.
- [x] `529 -> 529 -> 200` succeeds with `oauth_retry_count=2` and replays the same request body.
- [x] A third consecutive 529 applies the configured cooldown and returns the existing failover error.
- [x] API-key and non-Anthropic OAuth accounts remain outside the new policy.
- [x] Settings defaults, range validation, JSON compatibility, admin UI load/save, and i18n are covered.

Verification run:

```text
env -u OPENAI_API_KEY go test -tags unit ./... -count=1
go vet ./internal/service ./internal/handler
pnpm exec vitest run src/views/admin/__tests__/SettingsView.spec.ts
pnpm typecheck
pnpm exec eslint src/views/admin/SettingsView.vue src/views/admin/__tests__/SettingsView.spec.ts src/api/admin/settings.ts src/i18n/locales/en/admin/settings.ts src/i18n/locales/zh/admin/settings.ts
```

The integration suite was not run locally because its PostgreSQL/Redis test environment was not provisioned.

## Risk

Retrying an overloaded account can increase upstream pressure. The feature is therefore disabled by default, capped at two retries, restricted to pre-stream responses, and followed by the existing cooldown/failover path when retries are exhausted.
