### PR TITLE
fix(grok): free 额度耗尽识别/冷却 + bot_flag 媒体资格 (#4568/#4578)

### DIFF
--- a/backend/internal/pkg/xai/quota.go
+++ b/backend/internal/pkg/xai/quota.go
@@ -30,6 +30,7 @@ type QuotaSnapshot struct {
 	Requests          *QuotaWindow      `json:"requests,omitempty"`
 	Tokens            *QuotaWindow      `json:"tokens,omitempty"`
 	RetryAfterSeconds *int              `json:"retry_after_seconds,omitempty"`
+	ProviderErrorCode string            `json:"provider_error_code,omitempty"`
 	SubscriptionTier  string            `json:"subscription_tier,omitempty"`
 	EntitlementStatus string            `json:"entitlement_status,omitempty"`
 	StatusCode        int               `json:"status_code,omitempty"`

--- a/backend/internal/pkg/xai/sso_device.go
+++ b/backend/internal/pkg/xai/sso_device.go
@@ -387,6 +387,55 @@ func JWTClaimString(claims map[string]any, key string) string {
 	return strings.TrimSpace(value)
 }
 
+// JWTClaimInt64 reads a numeric claim as int64. JSON numbers decode as float64
+// into map[string]any; integer and string forms are also accepted.
+func JWTClaimInt64(claims map[string]any, key string) (int64, bool) {
+	if claims == nil {
+		return 0, false
+	}
+	raw, ok := claims[key]
+	if !ok || raw == nil {
+		return 0, false
+	}
+	switch value := raw.(type) {
+	case float64:
+		return int64(value), true
+	case float32:
+		return int64(value), true
+	case int64:
+		return value, true
+	case int:
+		return int64(value), true
+	case int32:
+		return int64(value), true
+	case json.Number:
+		parsed, err := value.Int64()
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// AccessTokenBotFlagSource returns the bot_flag_source claim from an access
+// token JWT when present. A value of 1 is treated as xAI risk-control marking
+// (see community reports of degraded image/video generation).
+func AccessTokenBotFlagSource(token string) (int64, bool) {
+	claims := DecodeJWTClaims(token)
+	if claims == nil {
+		return 0, false
+	}
+	return JWTClaimInt64(claims, "bot_flag_source")
+}
+
+// IsBotFlaggedToken reports whether the JWT carries bot_flag_source == 1.
+func IsBotFlaggedToken(token string) bool {
+	flag, ok := AccessTokenBotFlagSource(token)
+	return ok && flag == 1
+}
+
 func sleepContext(ctx context.Context, d time.Duration) error {
 	timer := time.NewTimer(d)
 	defer timer.Stop()

--- a/backend/internal/pkg/xai/sso_device_test.go
+++ b/backend/internal/pkg/xai/sso_device_test.go
@@ -4,6 +4,7 @@ package xai
 
 import (
 	"context"
+	"encoding/base64"
 	"io"
 	"net/http"
 	"net/url"
@@ -92,6 +93,36 @@ func TestNormalizeSSOTokenAcceptsCookieHeader(t *testing.T) {
 	require.Equal(t, "token-1", NormalizeSSOToken("Cookie: foo=bar; sso=token-1; sso-rw=token-2"))
 	require.Equal(t, "token-2", NormalizeSSOToken("sso-rw=token-2; foo=bar"))
 	require.Equal(t, "raw-token", NormalizeSSOToken(" raw-token ; ignored=1"))
+}
+
+func TestAccessTokenBotFlagSource(t *testing.T) {
+	t.Parallel()
+
+	flagged := testJWTWithClaims(t, `{"bot_flag_source":1,"sub":"user-1"}`)
+	flag, ok := AccessTokenBotFlagSource(flagged)
+	require.True(t, ok)
+	require.EqualValues(t, 1, flag)
+	require.True(t, IsBotFlaggedToken(flagged))
+
+	clean := testJWTWithClaims(t, `{"bot_flag_source":0,"sub":"user-2"}`)
+	flag, ok = AccessTokenBotFlagSource(clean)
+	require.True(t, ok)
+	require.EqualValues(t, 0, flag)
+	require.False(t, IsBotFlaggedToken(clean))
+
+	missing := testJWTWithClaims(t, `{"sub":"user-3"}`)
+	_, ok = AccessTokenBotFlagSource(missing)
+	require.False(t, ok)
+	require.False(t, IsBotFlaggedToken(missing))
+	require.False(t, IsBotFlaggedToken("not-a-jwt"))
+}
+
+func testJWTWithClaims(t *testing.T, payloadJSON string) string {
+	t.Helper()
+	// header.payload.signature — signature is not validated by DecodeJWTClaims.
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	return header + "." + payload + ".sig"
 }
 
 func ssoDeviceResponse(status int, header http.Header, body string) *http.Response {

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1476,6 +1476,10 @@ func (a *Account) SupportsOpenAIEndpointCapability(capability OpenAIEndpointCapa
 // new image/video generation requests. OAuth media fails closed unless billing
 // observations provide positive paid-entitlement evidence. An explicit
 // operator override takes precedence over probe data.
+//
+// Accounts whose access_token JWT carries bot_flag_source=1 are also rejected:
+// xAI still returns 200 for media calls, but degrades output to random/cached
+// assets (issue #4578).
 func (a *Account) GrokMediaGenerationEligibility() (bool, string) {
 	if a == nil || !a.IsGrok() {
 		return false, "not_grok"
@@ -1503,7 +1507,52 @@ func (a *Account) GrokMediaGenerationEligibility() (bool, string) {
 	if !grokBillingHasAuthoritativeQuota(billing) {
 		return false, "billing_inconclusive"
 	}
+	if isGrokOAuthBotFlagged(a) {
+		return false, "token_bot_flagged"
+	}
 	return true, "eligible"
+}
+
+// isGrokOAuthBotFlagged reports whether the account's current access token (or
+// last-persisted bot_flag_source credential) indicates xAI risk-control marking.
+func isGrokOAuthBotFlagged(account *Account) bool {
+	if account == nil {
+		return false
+	}
+	if token := strings.TrimSpace(account.GetCredential("access_token")); token != "" {
+		claims := xai.DecodeJWTClaims(token)
+		if claims != nil {
+			flag, ok := xai.JWTClaimInt64(claims, "bot_flag_source")
+			return ok && flag == 1
+		}
+	}
+	if account.Credentials == nil {
+		return false
+	}
+	raw, exists := account.Credentials["bot_flag_source"]
+	if !exists || raw == nil {
+		return false
+	}
+	switch value := raw.(type) {
+	case float64:
+		return int64(value) == 1
+	case float32:
+		return int64(value) == 1
+	case int64:
+		return value == 1
+	case int:
+		return value == 1
+	case int32:
+		return int64(value) == 1
+	case json.Number:
+		parsed, err := value.Int64()
+		return err == nil && parsed == 1
+	case string:
+		parsed, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+		return err == nil && parsed == 1
+	default:
+		return false
+	}
 }
 
 func grokMediaEligibilityOverride(extra map[string]any) (bool, bool) {

--- a/backend/internal/service/account_grok_media_eligibility_test.go
+++ b/backend/internal/service/account_grok_media_eligibility_test.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"testing"
 
@@ -70,6 +71,58 @@ func TestGrokMediaGenerationEligibility(t *testing.T) {
 		{name: "malformed override falls back to observations", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Extra: map[string]any{GrokMediaEligibleExtraKey: "false", grokBillingExtraKey: weeklyAllowance}}, want: true, wantReason: "eligible"},
 		{name: "explicit disable wins", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Extra: map[string]any{GrokMediaEligibleExtraKey: false}}, want: false, wantReason: "override_disabled"},
 		{name: "explicit enable wins over forbidden probe", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Extra: map[string]any{GrokMediaEligibleExtraKey: true, grokBillingExtraKey: forbiddenBilling}}, want: true, wantReason: "override_enabled"},
+		{
+			name: "bot_flag_source=1 rejects otherwise eligible oauth media",
+			account: &Account{
+				Platform: PlatformGrok,
+				Type:     AccountTypeOAuth,
+				Credentials: map[string]any{
+					"access_token": testGrokJWTWithClaims(`{"bot_flag_source":1,"sub":"user-flagged"}`),
+				},
+				Extra: map[string]any{grokBillingExtraKey: weeklyAllowance},
+			},
+			want: false, wantReason: "token_bot_flagged",
+		},
+		{
+			name: "bot_flag_source=0 keeps eligible oauth media",
+			account: &Account{
+				Platform: PlatformGrok,
+				Type:     AccountTypeOAuth,
+				Credentials: map[string]any{
+					"access_token": testGrokJWTWithClaims(`{"bot_flag_source":0,"sub":"user-clean"}`),
+				},
+				Extra: map[string]any{grokBillingExtraKey: weeklyAllowance},
+			},
+			want: true, wantReason: "eligible",
+		},
+		{
+			name: "persisted bot_flag_source credential rejects when access token is not a JWT",
+			account: &Account{
+				Platform: PlatformGrok,
+				Type:     AccountTypeOAuth,
+				Credentials: map[string]any{
+					"access_token":    "opaque-token",
+					"bot_flag_source": float64(1),
+				},
+				Extra: map[string]any{grokBillingExtraKey: weeklyAllowance},
+			},
+			want: false, wantReason: "token_bot_flagged",
+		},
+		{
+			name: "explicit enable wins over bot_flag_source",
+			account: &Account{
+				Platform: PlatformGrok,
+				Type:     AccountTypeOAuth,
+				Credentials: map[string]any{
+					"access_token": testGrokJWTWithClaims(`{"bot_flag_source":1}`),
+				},
+				Extra: map[string]any{
+					GrokMediaEligibleExtraKey: true,
+					grokBillingExtraKey:       weeklyAllowance,
+				},
+			},
+			want: true, wantReason: "override_enabled",
+		},
 	}
 
 	for _, tt := range tests {
@@ -116,6 +169,12 @@ func TestGrokMediaCapabilityFiltersOnlyGeneration(t *testing.T) {
 		context.Background(), account, PlatformGrok, "grok-imagine-video", false,
 		OpenAIEndpointCapabilityGrokMediaGeneration,
 	))
+}
+
+func testGrokJWTWithClaims(payloadJSON string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(payloadJSON))
+	return header + "." + payload + ".sig"
 }
 
 func TestNormalizeGrokMediaEligibilityExtra(t *testing.T) {

--- a/backend/internal/service/gateway_upstream_response.go
+++ b/backend/internal/service/gateway_upstream_response.go
@@ -286,7 +286,7 @@ func ExtractUpstreamErrorMessage(body []byte) string {
 }
 
 func extractUpstreamErrorMessage(body []byte) string {
-	// Claude 风格：{"type":"error","error":{"type":"...","message":"..."}}
+	// Claude / OpenAI 风格：{"type":"error","error":{"type":"...","message":"..."}}
 	if m := gjson.GetBytes(body, "error.message").String(); strings.TrimSpace(m) != "" {
 		inner := strings.TrimSpace(m)
 		// 有些上游会把完整 JSON 作为字符串塞进 message
@@ -296,6 +296,14 @@ func extractUpstreamErrorMessage(body []byte) string {
 			}
 		}
 		return m
+	}
+
+	// xAI / Grok 风格：{"code":"...","error":"plain string"}
+	// error 可能是字符串而不是对象；此时 error.message 为空，需要回退读顶层 error。
+	if errField := gjson.GetBytes(body, "error"); errField.Exists() && errField.Type == gjson.String {
+		if m := strings.TrimSpace(errField.String()); m != "" {
+			return m
+		}
 	}
 
 	// ChatGPT 内部 API 风格：{"detail":"..."}
@@ -309,6 +317,9 @@ func extractUpstreamErrorMessage(body []byte) string {
 
 func extractUpstreamErrorCode(body []byte) string {
 	if code := strings.TrimSpace(gjson.GetBytes(body, "error.code").String()); code != "" {
+		return code
+	}
+	if code := strings.TrimSpace(gjson.GetBytes(body, "code").String()); code != "" {
 		return code
 	}
 

--- a/backend/internal/service/grok_free_usage.go
+++ b/backend/internal/service/grok_free_usage.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	grokFreeUsageExhaustedErrorCode = "subscription:free-usage-exhausted"
+	grokFreeUsageExhaustedCooldown  = time.Hour
+)
+
+var grokFreeUsageTokensPattern = regexp.MustCompile(`(?i)tokens\s*\(actual/limit\)\s*:\s*([0-9][0-9,]*)\s*/\s*([0-9][0-9,]*)`)
+
+type grokFreeUsageExhaustedDetails struct {
+	Actual int64
+	Limit  int64
+}
+
+func isGrokFreeUsageExhaustedError(body []byte) bool {
+	return strings.TrimSpace(gjson.GetBytes(body, "code").String()) == grokFreeUsageExhaustedErrorCode
+}
+
+func parseGrokFreeUsageExhausted(body []byte) (grokFreeUsageExhaustedDetails, bool) {
+	if !isGrokFreeUsageExhaustedError(body) {
+		return grokFreeUsageExhaustedDetails{}, false
+	}
+
+	message := strings.TrimSpace(gjson.GetBytes(body, "error").String())
+	if message == "" {
+		message = strings.TrimSpace(gjson.GetBytes(body, "message").String())
+	}
+	matches := grokFreeUsageTokensPattern.FindStringSubmatch(message)
+	if len(matches) != 3 {
+		return grokFreeUsageExhaustedDetails{}, false
+	}
+
+	actual, actualErr := strconv.ParseInt(strings.ReplaceAll(matches[1], ",", ""), 10, 64)
+	limit, limitErr := strconv.ParseInt(strings.ReplaceAll(matches[2], ",", ""), 10, 64)
+	if actualErr != nil || limitErr != nil || actual < 0 || limit <= 0 {
+		return grokFreeUsageExhaustedDetails{}, false
+	}
+	return grokFreeUsageExhaustedDetails{Actual: actual, Limit: limit}, true
+}
+
+func enrichGrokQuotaSnapshotFromError(snapshot *xai.QuotaSnapshot, body []byte, statusCode int, now time.Time) *xai.QuotaSnapshot {
+	if !isGrokFreeUsageExhaustedError(body) {
+		return snapshot
+	}
+	if snapshot == nil {
+		snapshot = &xai.QuotaSnapshot{StatusCode: statusCode}
+	}
+	if details, ok := parseGrokFreeUsageExhausted(body); ok {
+		if snapshot.Tokens == nil {
+			snapshot.Tokens = &xai.QuotaWindow{}
+		}
+		limit := details.Limit
+		remaining := int64(0)
+		snapshot.Tokens.Limit = &limit
+		snapshot.Tokens.Remaining = &remaining
+	}
+	snapshot.SubscriptionTier = "free"
+	snapshot.ProviderErrorCode = grokFreeUsageExhaustedErrorCode
+	if strings.TrimSpace(snapshot.ObservationSource) == "" {
+		snapshot.ObservationSource = "error_body"
+	}
+	if strings.TrimSpace(snapshot.UpdatedAt) == "" {
+		snapshot.UpdatedAt = now.UTC().Format(time.RFC3339)
+	}
+	return snapshot
+}

--- a/backend/internal/service/grok_free_usage.go
+++ b/backend/internal/service/grok_free_usage.go
@@ -12,7 +12,10 @@ import (
 
 const (
 	grokFreeUsageExhaustedErrorCode = "subscription:free-usage-exhausted"
-	grokFreeUsageExhaustedCooldown  = time.Hour
+	// Free OAuth rolling quota is a 24h window; when upstream reports
+	// free-usage-exhausted without an explicit reset boundary, keep the
+	// account out of scheduling for a full day instead of retrying hourly.
+	grokFreeUsageExhaustedCooldown = 24 * time.Hour
 )
 
 var grokFreeUsageTokensPattern = regexp.MustCompile(`(?i)tokens\s*\(actual/limit\)\s*:\s*([0-9][0-9,]*)\s*/\s*([0-9][0-9,]*)`)

--- a/backend/internal/service/grok_free_usage.go
+++ b/backend/internal/service/grok_free_usage.go
@@ -12,10 +12,7 @@ import (
 
 const (
 	grokFreeUsageExhaustedErrorCode = "subscription:free-usage-exhausted"
-	// Free OAuth rolling quota is a 24h window; when upstream reports
-	// free-usage-exhausted without an explicit reset boundary, keep the
-	// account out of scheduling for a full day instead of retrying hourly.
-	grokFreeUsageExhaustedCooldown = 24 * time.Hour
+	grokFreeUsageExhaustedCooldown  = time.Hour
 )
 
 var grokFreeUsageTokensPattern = regexp.MustCompile(`(?i)tokens\s*\(actual/limit\)\s*:\s*([0-9][0-9,]*)\s*/\s*([0-9][0-9,]*)`)

--- a/backend/internal/service/grok_free_usage_test.go
+++ b/backend/internal/service/grok_free_usage_test.go
@@ -129,7 +129,7 @@ func TestGrokFreeUsageExhaustedCooldownPolicy(t *testing.T) {
 		require.Equal(t, now.Add(grokRateLimitFallbackCooldown), resetAt)
 	})
 
-	t.Run("keeps free exhaustion above generic adaptive cap", func(t *testing.T) {
+	t.Run("keeps repeated exhaustion at the one-hour cap", func(t *testing.T) {
 		previousReset := now.Add(-time.Second)
 		previousLimited := previousReset.Add(-grokFreeUsageExhaustedCooldown)
 		account := &Account{
@@ -140,10 +140,7 @@ func TestGrokFreeUsageExhaustedCooldownPolicy(t *testing.T) {
 		}
 		resetAt, limited := grokRateLimitResetAtForAccount(account, freeSnapshot(), now)
 		require.True(t, limited)
-		// Free exhaustion uses a dedicated 24h fallback; adaptive 429 backoff
-		// (capped at 1h) must not shorten that window.
-		require.Equal(t, now.Add(grokFreeUsageExhaustedCooldown), resetAt)
-		require.True(t, resetAt.After(now.Add(grokRateLimitMaxAdaptiveCooldown)))
+		require.Equal(t, now.Add(grokRateLimitMaxAdaptiveCooldown), resetAt)
 	})
 }
 

--- a/backend/internal/service/grok_free_usage_test.go
+++ b/backend/internal/service/grok_free_usage_test.go
@@ -1,0 +1,181 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
+	"github.com/stretchr/testify/require"
+)
+
+func grokFreeUsageExhaustedBody() []byte {
+	return []byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"You've used all the included free usage for model grok-4.5-build-free for now. Usage resets over a rolling 24-hour window - tokens (actual/limit): 1065554/1000000."
+	}`)
+}
+
+func TestParseGrokFreeUsageExhausted(t *testing.T) {
+	t.Parallel()
+
+	details, ok := parseGrokFreeUsageExhausted([]byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"Usage resets over a rolling 24-hour window - tokens (actual/limit): 1,065,554/1,000,000."
+	}`))
+
+	require.True(t, ok)
+	require.EqualValues(t, 1_065_554, details.Actual)
+	require.EqualValues(t, 1_000_000, details.Limit)
+}
+
+func TestParseGrokFreeUsageExhaustedRejectsUnrelatedOrMalformedPayloads(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range [][]byte{
+		[]byte(`{"code":"other","error":"tokens (actual/limit): 10/5"}`),
+		[]byte(`{"code":"subscription:free-usage-exhausted","error":"missing usage values"}`),
+		[]byte(`{"code":"subscription:free-usage-exhausted","error":"tokens (actual/limit): 10/0"}`),
+		[]byte(`not-json`),
+	} {
+		_, ok := parseGrokFreeUsageExhausted(body)
+		require.False(t, ok, string(body))
+	}
+}
+
+func TestEnrichGrokQuotaSnapshotFromFreeUsageError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 7, 0, 0, 0, time.UTC)
+	resetAt := now.Add(45 * time.Minute).Unix()
+	snapshot := &xai.QuotaSnapshot{
+		StatusCode: http.StatusTooManyRequests,
+		Tokens:     &xai.QuotaWindow{ResetUnix: &resetAt},
+		UpdatedAt:  now.Format(time.RFC3339),
+	}
+
+	got := enrichGrokQuotaSnapshotFromError(snapshot, []byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"tokens (actual/limit): 1065554/1000000"
+	}`), http.StatusTooManyRequests, now)
+
+	require.Same(t, snapshot, got)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, got.ProviderErrorCode)
+	require.Equal(t, "free", got.SubscriptionTier)
+	require.Equal(t, "error_body", got.ObservationSource)
+	require.EqualValues(t, 1_000_000, *got.Tokens.Limit)
+	require.Zero(t, *got.Tokens.Remaining)
+	require.Equal(t, resetAt, *got.Tokens.ResetUnix)
+}
+
+func TestEnrichGrokQuotaSnapshotKeepsFreeUsageCodeWhenUsageValuesAreMissing(t *testing.T) {
+	t.Parallel()
+
+	snapshot := enrichGrokQuotaSnapshotFromError(nil, []byte(`{
+		"code":"subscription:free-usage-exhausted",
+		"error":"free allowance exhausted"
+	}`), http.StatusForbidden, time.Now())
+
+	require.NotNil(t, snapshot)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, snapshot.ProviderErrorCode)
+	require.Equal(t, "free", snapshot.SubscriptionTier)
+	require.Equal(t, http.StatusForbidden, snapshot.StatusCode)
+	require.Nil(t, snapshot.Tokens)
+}
+
+func TestGrokFreeUsageExhaustedCooldownPolicy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 18, 7, 0, 0, 0, time.UTC)
+	freeSnapshot := func() *xai.QuotaSnapshot {
+		return &xai.QuotaSnapshot{
+			StatusCode:        http.StatusTooManyRequests,
+			ProviderErrorCode: grokFreeUsageExhaustedErrorCode,
+			UpdatedAt:         now.Format(time.RFC3339),
+		}
+	}
+
+	t.Run("uses dedicated fallback without upstream boundary", func(t *testing.T) {
+		resetAt, limited := grokRateLimitResetAt(freeSnapshot(), now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(grokFreeUsageExhaustedCooldown), resetAt)
+	})
+
+	t.Run("prefers retry-after", func(t *testing.T) {
+		retryAfter := 45
+		snapshot := freeSnapshot()
+		snapshot.RetryAfterSeconds = &retryAfter
+		resetAt, limited := grokRateLimitResetAt(snapshot, now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(45*time.Second), resetAt)
+	})
+
+	t.Run("prefers future token reset", func(t *testing.T) {
+		remaining := int64(0)
+		resetUnix := now.Add(2 * time.Hour).Unix()
+		snapshot := freeSnapshot()
+		snapshot.Tokens = &xai.QuotaWindow{Remaining: &remaining, ResetUnix: &resetUnix}
+		resetAt, limited := grokRateLimitResetAt(snapshot, now)
+		require.True(t, limited)
+		require.Equal(t, time.Unix(resetUnix, 0), resetAt)
+	})
+
+	t.Run("keeps generic headerless 429 fallback", func(t *testing.T) {
+		resetAt, limited := grokRateLimitResetAt(&xai.QuotaSnapshot{StatusCode: http.StatusTooManyRequests}, now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(grokRateLimitFallbackCooldown), resetAt)
+	})
+
+	t.Run("keeps repeated exhaustion at the one-hour cap", func(t *testing.T) {
+		previousReset := now.Add(-time.Second)
+		previousLimited := previousReset.Add(-grokFreeUsageExhaustedCooldown)
+		account := &Account{
+			Platform:         PlatformGrok,
+			Type:             AccountTypeOAuth,
+			RateLimitedAt:    &previousLimited,
+			RateLimitResetAt: &previousReset,
+		}
+		resetAt, limited := grokRateLimitResetAtForAccount(account, freeSnapshot(), now)
+		require.True(t, limited)
+		require.Equal(t, now.Add(grokRateLimitMaxAdaptiveCooldown), resetAt)
+	})
+}
+
+func TestHandleGrokAccountUpstreamErrorPersistsFreeUsageExhaustion(t *testing.T) {
+	t.Parallel()
+
+	account := healthyGrokQuotaOAuthAccount(701)
+	repo := &grokQuotaAccountRepo{mockAccountRepoForPlatform: &mockAccountRepoForPlatform{
+		accountsByID: map[int64]*Account{account.ID: account},
+	}}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+	before := time.Now()
+
+	svc.handleGrokAccountUpstreamError(
+		context.Background(), account, http.StatusTooManyRequests, nil, grokFreeUsageExhaustedBody(),
+	)
+
+	require.Equal(t, 1, repo.rateLimitedCalls)
+	require.WithinDuration(t, before.Add(grokFreeUsageExhaustedCooldown), repo.lastRateLimitResetAt, time.Second)
+	stored, ok := repo.updates[account.ID][grokQuotaSnapshotExtraKey].(*xai.QuotaSnapshot)
+	require.True(t, ok)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, stored.ProviderErrorCode)
+	require.Equal(t, "free", stored.SubscriptionTier)
+	require.EqualValues(t, 1_000_000, *stored.Tokens.Limit)
+	require.Zero(t, *stored.Tokens.Remaining)
+	require.NotNil(t, stored.Tokens.ResetUnix)
+	require.WithinDuration(t, repo.lastRateLimitResetAt, time.Unix(*stored.Tokens.ResetUnix, 0), time.Second)
+}
+
+func TestExtractUpstreamErrorCodeSupportsTopLevelCode(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(
+		t,
+		grokFreeUsageExhaustedErrorCode,
+		extractUpstreamErrorCode([]byte(`{"code":"subscription:free-usage-exhausted","error":"exhausted"}`)),
+	)
+}

--- a/backend/internal/service/grok_free_usage_test.go
+++ b/backend/internal/service/grok_free_usage_test.go
@@ -129,7 +129,7 @@ func TestGrokFreeUsageExhaustedCooldownPolicy(t *testing.T) {
 		require.Equal(t, now.Add(grokRateLimitFallbackCooldown), resetAt)
 	})
 
-	t.Run("keeps repeated exhaustion at the one-hour cap", func(t *testing.T) {
+	t.Run("keeps free exhaustion above generic adaptive cap", func(t *testing.T) {
 		previousReset := now.Add(-time.Second)
 		previousLimited := previousReset.Add(-grokFreeUsageExhaustedCooldown)
 		account := &Account{
@@ -140,7 +140,10 @@ func TestGrokFreeUsageExhaustedCooldownPolicy(t *testing.T) {
 		}
 		resetAt, limited := grokRateLimitResetAtForAccount(account, freeSnapshot(), now)
 		require.True(t, limited)
-		require.Equal(t, now.Add(grokRateLimitMaxAdaptiveCooldown), resetAt)
+		// Free exhaustion uses a dedicated 24h fallback; adaptive 429 backoff
+		// (capped at 1h) must not shorten that window.
+		require.Equal(t, now.Add(grokFreeUsageExhaustedCooldown), resetAt)
+		require.True(t, resetAt.After(now.Add(grokRateLimitMaxAdaptiveCooldown)))
 	})
 }
 

--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -744,19 +744,46 @@ func sanitizeGrokMediaForwardBody(endpoint GrokMediaEndpoint, body []byte, conte
 	if !endpoint.RequiresRequestBody() || !gjson.ValidBytes(body) {
 		return body, contentType, nil
 	}
+	out := body
 	switch endpoint {
 	case GrokMediaEndpointImagesGenerations, GrokMediaEndpointImagesEdits:
-		if !gjson.GetBytes(body, "size").Exists() {
-			return body, contentType, nil
+		if gjson.GetBytes(out, "size").Exists() {
+			sanitized, err := sjson.DeleteBytes(out, "size")
+			if err != nil {
+				return nil, "", fmt.Errorf("sanitize grok media size: %w", err)
+			}
+			out = sanitized
 		}
-		out, err := sjson.DeleteBytes(body, "size")
-		if err != nil {
-			return nil, "", fmt.Errorf("sanitize grok media size: %w", err)
-		}
-		return out, contentType, nil
-	default:
-		return body, contentType, nil
+	case GrokMediaEndpointVideosGenerations, GrokMediaEndpointVideosEdits, GrokMediaEndpointVideosExtensions:
+		// xAI documents prompt as optional for image-to-video. Drop null/blank
+		// prompt keys so we never forward "", null, or whitespace-only values
+		// that can make create succeed while later status polling returns 400.
+		out = stripEmptyGrokMediaPrompt(out)
 	}
+	return out, contentType, nil
+}
+
+func stripEmptyGrokMediaPrompt(body []byte) []byte {
+	prompt := gjson.GetBytes(body, "prompt")
+	if !prompt.Exists() {
+		return body
+	}
+	switch prompt.Type {
+	case gjson.Null:
+		// drop
+	case gjson.String:
+		if strings.TrimSpace(prompt.String()) != "" {
+			return body
+		}
+	default:
+		// Non-string prompts (arrays/objects) are left to the upstream.
+		return body
+	}
+	out, err := sjson.DeleteBytes(body, "prompt")
+	if err != nil {
+		return body
+	}
+	return out
 }
 
 func (r GrokMediaRequestInfo) HasInputImage() bool {

--- a/backend/internal/service/grok_oauth_service.go
+++ b/backend/internal/service/grok_oauth_service.go
@@ -104,6 +104,9 @@ type GrokTokenInfo struct {
 	TeamID            string `json:"team_id,omitempty"`
 	SubscriptionTier  string `json:"subscription_tier,omitempty"`
 	EntitlementStatus string `json:"entitlement_status,omitempty"`
+	// BotFlagSource mirrors the access_token JWT claim bot_flag_source when present.
+	// 1 indicates xAI risk-control marking that degrades media generation quality.
+	BotFlagSource *int64 `json:"bot_flag_source,omitempty"`
 }
 
 func (s *GrokOAuthService) ExchangeCode(ctx context.Context, input *GrokExchangeCodeInput) (*GrokTokenInfo, error) {
@@ -254,6 +257,9 @@ func (s *GrokOAuthService) BuildAccountCredentials(tokenInfo *GrokTokenInfo) map
 	if tokenInfo.EntitlementStatus != "" {
 		creds["entitlement_status"] = tokenInfo.EntitlementStatus
 	}
+	if tokenInfo.BotFlagSource != nil {
+		creds["bot_flag_source"] = *tokenInfo.BotFlagSource
+	}
 	creds["base_url"] = xai.DefaultCLIBaseURL
 	return creds
 }
@@ -342,5 +348,11 @@ func applyGrokTokenClaims(info *GrokTokenInfo, token string) {
 	}
 	if info.TeamID == "" {
 		info.TeamID = xai.JWTClaimString(claims, "team_id")
+	}
+	// Prefer access-token claims for risk flags: access tokens are what media
+	// requests actually present to xAI.
+	if flag, ok := xai.JWTClaimInt64(claims, "bot_flag_source"); ok {
+		value := flag
+		info.BotFlagSource = &value
 	}
 }

--- a/backend/internal/service/grok_oauth_service_test.go
+++ b/backend/internal/service/grok_oauth_service_test.go
@@ -87,6 +87,34 @@ func TestGrokOAuthServiceBuildAccountCredentialsDefaultsToSubscriptionProxy(t *t
 	require.Equal(t, xai.DefaultCLIBaseURL, credentials["base_url"])
 }
 
+func TestGrokOAuthServiceBuildAccountCredentialsStoresBotFlagSource(t *testing.T) {
+	t.Parallel()
+	svc := NewGrokOAuthService(nil, &grokOAuthClientStub{})
+	defer svc.Stop()
+
+	flag := int64(1)
+	credentials := svc.BuildAccountCredentials(&GrokTokenInfo{
+		AccessToken:   "access-token",
+		ExpiresAt:     time.Now().Add(time.Hour).Unix(),
+		BotFlagSource: &flag,
+	})
+	require.EqualValues(t, int64(1), credentials["bot_flag_source"])
+}
+
+func TestApplyGrokTokenClaimsReadsBotFlagSource(t *testing.T) {
+	t.Parallel()
+	info := &GrokTokenInfo{}
+	applyGrokTokenClaims(info, makeGrokOAuthJWT(map[string]any{
+		"bot_flag_source": float64(1),
+		"email":           "a@x.ai",
+		"sub":             "user-1",
+	}))
+	require.NotNil(t, info.BotFlagSource)
+	require.EqualValues(t, 1, *info.BotFlagSource)
+	require.Equal(t, "a@x.ai", info.Email)
+	require.Equal(t, "user-1", info.Subject)
+}
+
 func TestGrokOAuthServiceConvertFromSSOExtractsBuildClaims(t *testing.T) {
 	svc := NewGrokOAuthService(nil, &grokOAuthClientStub{
 		ssoResponse: &xai.TokenResponse{

--- a/backend/internal/service/grok_quota_fetcher.go
+++ b/backend/internal/service/grok_quota_fetcher.go
@@ -78,6 +78,12 @@ func (f *GrokQuotaFetcher) BuildUsageInfo(account *Account) *UsageInfo {
 	usage.GrokRequestQuota = snapshot.Requests
 	usage.GrokTokenQuota = snapshot.Tokens
 	usage.GrokRetryAfterSeconds = snapshot.RetryAfterSeconds
+	// Prefer the observed Free rolling-window limit (current 1M or legacy 2M)
+	// so the UI progress bar matches the server-reported exhaustion payload.
+	if snapshot.Tokens != nil && snapshot.Tokens.Limit != nil &&
+		xai.IsGrokFreeRolling24hTokenLimit(*snapshot.Tokens.Limit) {
+		usage.GrokFreeTokenLimit = *snapshot.Tokens.Limit
+	}
 	if usage.SubscriptionTier == "" {
 		usage.SubscriptionTier = snapshot.SubscriptionTier
 		usage.SubscriptionTierRaw = snapshot.SubscriptionTier
@@ -122,6 +128,15 @@ func (f *GrokQuotaFetcher) BuildUsageInfo(account *Account) *UsageInfo {
 			}
 		case 429:
 			usage.ErrorCode = "rate_limited"
+		}
+	}
+	// free-usage-exhausted is a durable Free quota exhaustion signal even when
+	// the last HTTP status on the snapshot is not 429 (e.g. subsequent probes).
+	if strings.TrimSpace(snapshot.ProviderErrorCode) == grokFreeUsageExhaustedErrorCode {
+		usage.ErrorCode = "rate_limited"
+		if usage.SubscriptionTier == "" {
+			usage.SubscriptionTier = "free"
+			usage.SubscriptionTierRaw = "free"
 		}
 	}
 	applyGrokCredentialUsageFallback(usage, account)

--- a/backend/internal/service/grok_quota_service.go
+++ b/backend/internal/service/grok_quota_service.go
@@ -168,6 +168,10 @@ func (s *GrokQuotaService) probeUsage(ctx context.Context, accountID int64) (*Gr
 	defer func() { _ = resp.Body.Close() }()
 
 	snapshot := xai.ObserveQuotaHeaders(resp.Header, resp.StatusCode, "active_probe")
+	if resp.StatusCode == http.StatusTooManyRequests {
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, openAIUpstreamErrorBodyReadLimit))
+		snapshot = enrichGrokQuotaSnapshotFromError(snapshot, responseBody, resp.StatusCode, time.Now())
+	}
 	resetAt, limited := grokRateLimitResetAtForAccount(account, snapshot, time.Now())
 	if limited {
 		normalizeGrokExhaustedWindowResets(snapshot, resetAt, time.Now())

--- a/backend/internal/service/grok_quota_service_test.go
+++ b/backend/internal/service/grok_quota_service_test.go
@@ -638,6 +638,34 @@ func TestGrokQuotaServiceProbeUsageReturnsRateLimitedSnapshot(t *testing.T) {
 	require.Zero(t, repo.tempUnschedCalls)
 }
 
+func TestGrokQuotaServiceProbeUsagePersistsFreeUsageExhaustion(t *testing.T) {
+	t.Parallel()
+
+	account := healthyGrokQuotaOAuthAccount(49)
+	repo := &grokQuotaAccountRepo{
+		mockAccountRepoForPlatform: &mockAccountRepoForPlatform{
+			accountsByID: map[int64]*Account{account.ID: account},
+		},
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(string(grokFreeUsageExhaustedBody()))),
+	}}
+	svc := NewGrokQuotaService(repo, nil, NewGrokTokenProvider(repo, nil), upstream, nil)
+	before := time.Now()
+
+	result, err := svc.ProbeUsage(context.Background(), account.ID)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusTooManyRequests, result.StatusCode)
+	require.Equal(t, grokFreeUsageExhaustedErrorCode, result.Snapshot.ProviderErrorCode)
+	require.EqualValues(t, 1_000_000, *result.Snapshot.Tokens.Limit)
+	require.Zero(t, *result.Snapshot.Tokens.Remaining)
+	require.Equal(t, 1, repo.rateLimitedCalls)
+	require.WithinDuration(t, before.Add(grokFreeUsageExhaustedCooldown), repo.lastRateLimitResetAt, time.Second)
+}
+
 func TestGrokQuotaServiceQueryQuotaFreeFallsBackToGrok45(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -1175,7 +1175,11 @@ func grokRateLimitResetAt(snapshot *xai.QuotaSnapshot, now time.Time) (time.Time
 		return time.Time{}, false
 	}
 	if exhausted || snapshot.StatusCode == http.StatusTooManyRequests {
-		return now.Add(grokRateLimitFallbackCooldown), true
+		cooldown := grokRateLimitFallbackCooldown
+		if snapshot.ProviderErrorCode == grokFreeUsageExhaustedErrorCode {
+			cooldown = grokFreeUsageExhaustedCooldown
+		}
+		return now.Add(cooldown), true
 	}
 	return time.Time{}, false
 }
@@ -1289,7 +1293,9 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		return
 	}
 	now := time.Now()
-	s.updateGrokUsageSnapshot(ctx, account, parseGrokQuotaSnapshot(headers, statusCode, now))
+	snapshot := parseGrokQuotaSnapshot(headers, statusCode, now)
+	snapshot = enrichGrokQuotaSnapshotFromError(snapshot, responseBody, statusCode, now)
+	s.updateGrokUsageSnapshot(ctx, account, snapshot)
 	switch statusCode {
 	case http.StatusUnauthorized:
 		s.tempUnscheduleGrok(ctx, account, 10*time.Minute, "grok credentials unauthorized")
@@ -1297,12 +1303,12 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok access or entitlement denied")
 	case http.StatusTooManyRequests:
 		// updateGrokUsageSnapshot installs both runtime and durable rate-limit state.
+		// free-usage-exhausted is parsed from responseBody into the snapshot first.
 	default:
 		if statusCode >= 500 {
 			s.tempUnscheduleGrok(ctx, account, 2*time.Minute, "grok upstream temporary error")
 		}
 	}
-	_ = responseBody
 }
 
 func (s *OpenAIGatewayService) tempUnscheduleGrok(ctx context.Context, account *Account, cooldown time.Duration, reason string) {

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -1132,6 +1132,124 @@ func TestForwardGrokMediaVideoGenerationPreservesImageToVideoModel(t *testing.T)
 	require.Equal(t, VideoBillingDefaultDurationSeconds, result.VideoDurationSeconds)
 }
 
+func TestForwardGrokMediaImageToVideoOmitsPromptField(t *testing.T) {
+	t.Setenv(xai.EnvAllowUnsafeURLOverrides, "true")
+	gin.SetMode(gin.TestMode)
+
+	// Issue #4546: I2V with image.url and no prompt must stay optional-shape.
+	// Do not inject prompt / serialize null / empty string.
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "missing prompt key",
+			body: `{"model":"grok-imagine-video-1.5","image":{"url":"data:image/jpeg;base64,/9j/4AAQ"},"duration":10,"resolution":"480p"}`,
+			want: `{"model":"grok-imagine-video-1.5","image":{"url":"data:image/jpeg;base64,/9j/4AAQ"},"duration":10,"resolution":"480p"}`,
+		},
+		{
+			name: "blank prompt is stripped",
+			body: `{"model":"grok-imagine-video-1.5","prompt":"   ","image":{"url":"data:image/jpeg;base64,/9j/4AAQ"},"duration":10,"resolution":"480p"}`,
+			want: `{"model":"grok-imagine-video-1.5","image":{"url":"data:image/jpeg;base64,/9j/4AAQ"},"duration":10,"resolution":"480p"}`,
+		},
+		{
+			name: "null prompt is stripped",
+			body: `{"model":"grok-imagine-video-1.5","prompt":null,"image":{"url":"data:image/jpeg;base64,/9j/4AAQ"},"duration":10,"resolution":"480p"}`,
+			want: `{"model":"grok-imagine-video-1.5","image":{"url":"data:image/jpeg;base64,/9j/4AAQ"},"duration":10,"resolution":"480p"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			body := []byte(tc.body)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/videos/generations", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			account := &Account{
+				ID:          64,
+				Name:        "grok",
+				Platform:    PlatformGrok,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":  "api-key",
+					"base_url": "https://xai.test/v1",
+				},
+			}
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"request_id":"video-request-i2v"}`)),
+			}}
+			svc := &OpenAIGatewayService{httpUpstream: upstream}
+
+			result, err := svc.ForwardGrokMedia(context.Background(), c, account, GrokMediaEndpointVideosGenerations, "", body, "application/json")
+			require.NoError(t, err)
+			require.JSONEq(t, tc.want, string(upstream.lastBody))
+			require.False(t, gjson.GetBytes(upstream.lastBody, "prompt").Exists(), "prompt must be omitted for optional I2V")
+			require.Equal(t, "video-request-i2v", result.ResponseID)
+			require.Equal(t, "grok-imagine-video-1.5", result.BillingModel)
+			require.Equal(t, 10, result.VideoDurationSeconds)
+			require.Equal(t, "480p", result.VideoResolution)
+		})
+	}
+}
+
+func TestHandleGrokMediaErrorResponseSurfacesTopLevelErrorString(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodGet, "/v1/videos/task-1", nil)
+
+	account := &Account{
+		ID:          65,
+		Name:        "grok",
+		Platform:    PlatformGrok,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "api-key"},
+		Extra: map[string]any{
+			// Treat 400 as a terminal client error (not failover).
+			"custom_error_codes_enabled": true,
+			"custom_error_codes":         []any{float64(http.StatusBadRequest)},
+		},
+	}
+	svc := &OpenAIGatewayService{}
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{},
+		Body: io.NopCloser(strings.NewReader(
+			`{"code":"Client specified an invalid argument","error":"prompt may not be empty when no image is provided"}`,
+		)),
+	}
+
+	result, err := svc.handleGrokMediaErrorResponse(context.Background(), resp, c, account, "request-id", "grok-imagine-video")
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "prompt may not be empty when no image is provided")
+	require.Contains(t, recorder.Body.String(), "prompt may not be empty when no image is provided")
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+func TestExtractUpstreamErrorMessageSupportsTopLevelErrorString(t *testing.T) {
+	t.Parallel()
+	require.Equal(
+		t,
+		"prompt may not be empty when no image is provided",
+		extractUpstreamErrorMessage([]byte(`{"code":"bad_request","error":"prompt may not be empty when no image is provided"}`)),
+	)
+	require.Equal(
+		t,
+		"nested message wins",
+		extractUpstreamErrorMessage([]byte(`{"error":{"message":"nested message wins"}}`)),
+	)
+}
+
 func TestForwardGrokMediaOAuthImageToVideoUsesOfficialAPIForLargeBody(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/frontend/src/api/admin/grok.ts
+++ b/frontend/src/api/admin/grok.ts
@@ -41,6 +41,8 @@ export interface GrokTokenInfo {
   team_id?: string
   subscription_tier?: string
   entitlement_status?: string
+  /** xAI access-token claim; 1 means risk-control marking that degrades media. */
+  bot_flag_source?: number
   [key: string]: unknown
 }
 
@@ -86,6 +88,7 @@ export interface GrokQuotaSnapshot {
   requests?: GrokQuotaWindow | null
   tokens?: GrokQuotaWindow | null
   retry_after_seconds?: number | null
+  provider_error_code?: string
   subscription_tier?: string
   entitlement_status?: string
   status_code?: number


### PR DESCRIPTION
## Summary
- **#4568**: 识别上游 `subscription:free-usage-exhausted`，写入配额快照并应用约 1h 冷却，避免耗尽账号被反复选中
- **#4578**: 解析 access_token JWT 的 `bot_flag_source=1`，媒体生成资格 fail-closed，避免风控号继续被调度出图/出视频
- 顺带保留 I2V 空 prompt 剥离与错误体透传相关改动（与现有 gateway 行为对齐）

## Context
自用分支 `abbzbb/self/main` 已验证可部署。基于最新 `main` cherry-pick 提交。

相关讨论/相近 PR：
- Issue #4568
- Issue #4578
- 相近：#4549（free-usage 识别，实现路径不同）

## Test plan
- [x] `go test -tags=unit ./internal/service/ -run 'FreeUsage|BotFlag|GrokMediaEligib|GrokFree'`
- [x] `go test -tags=unit ./internal/pkg/xai/`
- [ ] 集成：Free 账号打到 free-usage-exhausted 后不再进入调度；bot_flag=1 号媒体请求被拒绝