### PR TITLE
fix(antigravity): 补全模型列表与计费别名，修复无法计费 (#3701)

### DIFF
--- a/backend/internal/handler/gateway_handler.go
+++ b/backend/internal/handler/gateway_handler.go
@@ -1047,6 +1047,13 @@ func (h *GatewayHandler) Models(c *gin.Context) {
 		writeGrokModelsList(c, xai.DefaultModelIDs())
 		return
 	}
+	if platform == service.PlatformAntigravity {
+		c.JSON(http.StatusOK, gin.H{
+			"object": "list",
+			"data":   antigravity.DefaultModels(),
+		})
+		return
+	}
 
 	c.JSON(http.StatusOK, gin.H{
 		"object": "list",

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -152,34 +152,52 @@ type modelDef struct {
 }
 
 // Antigravity 支持的 Claude 模型
+// 须覆盖 domain.DefaultAntigravityModelMapping 中的客户端可见 ID（#3701）。
 var claudeModels = []modelDef{
 	{ID: "claude-fable-5", DisplayName: "Claude Fable 5", CreatedAt: "2026-06-09T00:00:00Z"},
 	{ID: "claude-opus-4-5-thinking", DisplayName: "Claude Opus 4.5 Thinking", CreatedAt: "2025-11-01T00:00:00Z"},
+	{ID: "claude-opus-4-5-20251101", DisplayName: "Claude Opus 4.5 (20251101)", CreatedAt: "2025-11-01T00:00:00Z"},
 	{ID: "claude-sonnet-4-5", DisplayName: "Claude Sonnet 4.5", CreatedAt: "2025-09-29T00:00:00Z"},
 	{ID: "claude-sonnet-4-5-thinking", DisplayName: "Claude Sonnet 4.5 Thinking", CreatedAt: "2025-09-29T00:00:00Z"},
+	{ID: "claude-sonnet-4-5-20250929", DisplayName: "Claude Sonnet 4.5 (20250929)", CreatedAt: "2025-09-29T00:00:00Z"},
 	{ID: "claude-opus-4-6", DisplayName: "Claude Opus 4.6", CreatedAt: "2026-02-05T00:00:00Z"},
 	{ID: "claude-opus-4-6-thinking", DisplayName: "Claude Opus 4.6 Thinking", CreatedAt: "2026-02-05T00:00:00Z"},
 	{ID: "claude-opus-4-7", DisplayName: "Claude Opus 4.7", CreatedAt: "2026-04-17T00:00:00Z"},
 	{ID: "claude-opus-4-8", DisplayName: "Claude Opus 4.8", CreatedAt: "2026-05-29T00:00:00Z"},
 	{ID: "claude-sonnet-4-6", DisplayName: "Claude Sonnet 4.6", CreatedAt: "2026-02-17T00:00:00Z"},
+	{ID: "claude-haiku-4-5", DisplayName: "Claude Haiku 4.5", CreatedAt: "2025-10-01T00:00:00Z"},
+	{ID: "claude-haiku-4-5-20251001", DisplayName: "Claude Haiku 4.5 (20251001)", CreatedAt: "2025-10-01T00:00:00Z"},
 }
 
 // Antigravity 支持的 Gemini 模型
+// 须覆盖 domain.DefaultAntigravityModelMapping 中的客户端可见 ID（#3701）。
 var geminiModels = []modelDef{
 	{ID: "gemini-2.5-flash", DisplayName: "Gemini 2.5 Flash", CreatedAt: "2025-01-01T00:00:00Z"},
 	{ID: "gemini-2.5-flash-image", DisplayName: "Gemini 2.5 Flash Image", CreatedAt: "2025-01-01T00:00:00Z"},
 	{ID: "gemini-2.5-flash-image-preview", DisplayName: "Gemini 2.5 Flash Image Preview", CreatedAt: "2025-01-01T00:00:00Z"},
 	{ID: "gemini-2.5-flash-lite", DisplayName: "Gemini 2.5 Flash Lite", CreatedAt: "2025-01-01T00:00:00Z"},
 	{ID: "gemini-2.5-flash-thinking", DisplayName: "Gemini 2.5 Flash Thinking", CreatedAt: "2025-01-01T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-2.5-pro", DisplayName: "Gemini 2.5 Pro", CreatedAt: "2025-01-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3-flash", DisplayName: "Gemini 3 Flash", CreatedAt: "2025-06-01T00:00:00Z"},
+	{ID: "gemini-3-flash-preview", DisplayName: "Gemini 3 Flash Preview", CreatedAt: "2025-06-01T00:00:00Z"},
 	{ID: "gemini-3-pro-low", DisplayName: "Gemini 3 Pro Low", CreatedAt: "2025-06-01T00:00:00Z"},
 	{ID: "gemini-3-pro-high", DisplayName: "Gemini 3 Pro High", CreatedAt: "2025-06-01T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3-pro-preview", DisplayName: "Gemini 3 Pro Preview", CreatedAt: "2025-06-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.1-pro-low", DisplayName: "Gemini 3.1 Pro Low", CreatedAt: "2026-02-19T00:00:00Z"},
 	{ID: "gemini-3.1-pro-high", DisplayName: "Gemini 3.1 Pro High", CreatedAt: "2026-02-19T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.1-pro", DisplayName: "Gemini 3.1 Pro", CreatedAt: "2026-02-19T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-3.1-pro-preview", DisplayName: "Gemini 3.1 Pro Preview", CreatedAt: "2026-02-19T00:00:00Z", IsReasoning: true},
+	{ID: "gemini-pro-agent", DisplayName: "Gemini Pro Agent", CreatedAt: "2026-02-19T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3.1-flash-image", DisplayName: "Gemini 3.1 Flash Image", CreatedAt: "2026-02-19T00:00:00Z"},
 	{ID: "gemini-3.1-flash-image-preview", DisplayName: "Gemini 3.1 Flash Image Preview", CreatedAt: "2026-02-19T00:00:00Z"},
-	{ID: "gemini-3-pro-preview", DisplayName: "Gemini 3 Pro Preview", CreatedAt: "2025-06-01T00:00:00Z", IsReasoning: true},
 	{ID: "gemini-3-pro-image", DisplayName: "Gemini 3 Pro Image", CreatedAt: "2025-06-01T00:00:00Z"},
+	{ID: "gemini-3-pro-image-preview", DisplayName: "Gemini 3 Pro Image Preview", CreatedAt: "2025-06-01T00:00:00Z"},
+}
+
+// Antigravity 其它官方模型（非 Claude/Gemini 主线）
+var otherModels = []modelDef{
+	{ID: "gpt-oss-120b-medium", DisplayName: "GPT OSS 120B Medium", CreatedAt: "2025-06-01T00:00:00Z"},
+	{ID: "tab_flash_lite_preview", DisplayName: "Tab Flash Lite Preview", CreatedAt: "2025-06-01T00:00:00Z"},
 }
 
 // ========== Claude API 格式 (/v1/models) ==========
@@ -192,9 +210,12 @@ type ClaudeModel struct {
 	CreatedAt   string `json:"created_at"`
 }
 
-// DefaultModels 返回 Claude API 格式的模型列表（Claude + Gemini）
+// DefaultModels 返回 Claude API 格式的模型列表（Claude + Gemini + 其它）
 func DefaultModels() []ClaudeModel {
-	all := append(claudeModels, geminiModels...)
+	all := make([]modelDef, 0, len(claudeModels)+len(geminiModels)+len(otherModels))
+	all = append(all, claudeModels...)
+	all = append(all, geminiModels...)
+	all = append(all, otherModels...)
 	result := make([]ClaudeModel, len(all))
 	for i, m := range all {
 		result[i] = ClaudeModel{ID: m.ID, Type: "model", DisplayName: m.DisplayName, CreatedAt: m.CreatedAt}

--- a/backend/internal/pkg/antigravity/claude_types_test.go
+++ b/backend/internal/pkg/antigravity/claude_types_test.go
@@ -1,6 +1,10 @@
 package antigravity
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+)
 
 func TestDefaultModels_ContainsNewAndLegacyImageModels(t *testing.T) {
 	t.Parallel()
@@ -17,14 +21,36 @@ func TestDefaultModels_ContainsNewAndLegacyImageModels(t *testing.T) {
 		"claude-opus-4-6-thinking",
 		"gemini-2.5-flash-image",
 		"gemini-2.5-flash-image-preview",
+		"gemini-2.5-pro",
 		"gemini-3.1-flash-image",
 		"gemini-3.1-flash-image-preview",
 		"gemini-3-pro-image", // legacy compatibility
+		"gemini-pro-agent",
+		"gpt-oss-120b-medium",
+		"tab_flash_lite_preview",
 	}
 
 	for _, id := range requiredIDs {
 		if _, ok := byID[id]; !ok {
 			t.Fatalf("expected model %q to be exposed in DefaultModels", id)
+		}
+	}
+}
+
+// DefaultModels must expose every client-facing key from the default mapping so
+// /v1/models and /antigravity/models stay aligned with schedulable models (#3701).
+func TestDefaultModels_CoversDefaultAntigravityMappingKeys(t *testing.T) {
+	t.Parallel()
+
+	models := DefaultModels()
+	byID := make(map[string]struct{}, len(models))
+	for _, m := range models {
+		byID[m.ID] = struct{}{}
+	}
+
+	for id := range domain.DefaultAntigravityModelMapping {
+		if _, ok := byID[id]; !ok {
+			t.Fatalf("DefaultModels missing mapping key %q (issue #3701)", id)
 		}
 	}
 }

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -603,6 +603,10 @@ func (a *Account) resolveModelMapping(rawMapping map[string]any) map[string]stri
 	}
 	if len(result) > 0 {
 		if a.Platform == domain.PlatformAntigravity {
+			// 旧账号/迁移写入的部分 mapping 不会随默认表演进；合并缺失的默认项，
+			// 避免 client /v1/models 列表残缺、可调用模型无映射导致计费失败（#3701）。
+			// 已有精确项与通配符覆盖的模型不会被覆盖。
+			mergeAntigravityDefaultMapping(result)
 			ensureAntigravityDefaultPassthroughs(result, []string{
 				"gemini-3-flash",
 				"gemini-3.1-pro-high",
@@ -673,6 +677,47 @@ func ensureAntigravityDefaultPassthroughs(mapping map[string]string, models []st
 	for _, model := range models {
 		ensureAntigravityDefaultPassthrough(mapping, model)
 	}
+}
+
+// mergeAntigravityDefaultMapping fills missing DefaultAntigravityModelMapping
+// entries when the account mapping looks like an outdated default snapshot
+// (subset of current defaults, no wildcards, no custom remaps). Custom
+// allowlists and wildcards are left untouched (#3701).
+func mergeAntigravityDefaultMapping(mapping map[string]string) {
+	if mapping == nil || !isAntigravityDefaultMappingSubset(mapping) {
+		return
+	}
+	for from, to := range domain.DefaultAntigravityModelMapping {
+		from = strings.TrimSpace(from)
+		to = strings.TrimSpace(to)
+		if from == "" || to == "" {
+			continue
+		}
+		if _, exists := mapping[from]; exists {
+			continue
+		}
+		mapping[from] = to
+	}
+}
+
+// isAntigravityDefaultMappingSubset reports whether every entry is an exact
+// default mapping key→target pair (no wildcards, no custom models/remaps).
+func isAntigravityDefaultMappingSubset(mapping map[string]string) bool {
+	if len(mapping) == 0 {
+		return false
+	}
+	for from, to := range mapping {
+		from = strings.TrimSpace(from)
+		to = strings.TrimSpace(to)
+		if from == "" || strings.Contains(from, "*") {
+			return false
+		}
+		def, ok := domain.DefaultAntigravityModelMapping[from]
+		if !ok || strings.TrimSpace(def) != to {
+			return false
+		}
+	}
+	return true
 }
 
 func applyAntigravityGemini31ProAliases(mapping map[string]string) {

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -681,8 +681,9 @@ func ensureAntigravityDefaultPassthroughs(mapping map[string]string, models []st
 
 // mergeAntigravityDefaultMapping fills missing DefaultAntigravityModelMapping
 // entries when the account mapping looks like an outdated default snapshot
-// (subset of current defaults, no wildcards, no custom remaps). Custom
-// allowlists and wildcards are left untouched (#3701).
+// (substantial subset of current defaults, no wildcards, no custom remaps).
+// Small intentional allowlists that only list a few default models are left
+// alone so thinking/non-thinking whitelist scheduling stays fail-closed (#3701).
 func mergeAntigravityDefaultMapping(mapping map[string]string) {
 	if mapping == nil || !isAntigravityDefaultMappingSubset(mapping) {
 		return
@@ -700,10 +701,26 @@ func mergeAntigravityDefaultMapping(mapping map[string]string) {
 	}
 }
 
-// isAntigravityDefaultMappingSubset reports whether every entry is an exact
-// default mapping key→target pair (no wildcards, no custom models/remaps).
+// antigravityDefaultSnapshotMinKeys is how many exact default entries an
+// account mapping must already contain before we treat it as a stale default
+// snapshot worth bulk-merging. Below this threshold the mapping is treated as
+// an intentional partial allowlist (common for thinking-only / single-model
+// accounts) and must not be expanded.
+func antigravityDefaultSnapshotMinKeys() int {
+	n := len(domain.DefaultAntigravityModelMapping)
+	minKeys := n / 2
+	if minKeys < 8 {
+		minKeys = 8
+	}
+	return minKeys
+}
+
+// isAntigravityDefaultMappingSubset reports whether mapping looks like a
+// substantial outdated default snapshot: every entry is an exact default
+// key→target pair (no wildcards, no custom remaps), and the entry count is
+// large enough that a partial allowlist is unlikely.
 func isAntigravityDefaultMappingSubset(mapping map[string]string) bool {
-	if len(mapping) == 0 {
+	if len(mapping) < antigravityDefaultSnapshotMinKeys() {
 		return false
 	}
 	for from, to := range mapping {

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -512,6 +512,39 @@ func TestAccountGetModelMapping_AntigravityEnsuresGeminiDefaultPassthroughs(t *t
 	if mapping["gemini-3.1-pro-low"] != "gemini-3.1-pro-low" {
 		t.Fatalf("expected gemini-3.1-pro-low passthrough to be auto-filled, got: %q", mapping["gemini-3.1-pro-low"])
 	}
+	// Remapped high target means this is not a pure default subset — defaults
+	// must not bulk-merge (would clobber intentional custom allowlists).
+	if _, ok := mapping["claude-opus-4-8"]; ok {
+		t.Fatalf("did not expect full default merge when mapping remaps gemini-3-pro-high")
+	}
+}
+
+// Partial/outdated account mappings must still surface default Antigravity models
+// so /v1/models and scheduling stay complete (#3701).
+func TestAccountGetModelMapping_AntigravityMergesMissingDefaultKeys(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				// Simulate a legacy migration snapshot that only listed Claude.
+				"claude-sonnet-4-5": "claude-sonnet-4-5",
+			},
+		},
+	}
+
+	mapping := account.GetModelMapping()
+	if mapping["claude-sonnet-4-5"] != "claude-sonnet-4-5" {
+		t.Fatalf("expected existing key preserved, got: %q", mapping["claude-sonnet-4-5"])
+	}
+	if mapping["claude-opus-4-8"] != "claude-opus-4-8" {
+		t.Fatalf("expected missing default key merged, got: %q", mapping["claude-opus-4-8"])
+	}
+	if mapping["gemini-2.5-pro"] != "gemini-2.5-pro" {
+		t.Fatalf("expected gemini-2.5-pro default merged, got: %q", mapping["gemini-2.5-pro"])
+	}
+	if mapping["gemini-3.1-pro-high"] == "" {
+		t.Fatalf("expected gemini-3.1-pro-high present after merge, mapping=%v", mapping)
+	}
 }
 
 func TestAccountGetModelMapping_AntigravityRespectsWildcardOverride(t *testing.T) {

--- a/backend/internal/service/account_wildcard_test.go
+++ b/backend/internal/service/account_wildcard_test.go
@@ -519,16 +519,30 @@ func TestAccountGetModelMapping_AntigravityEnsuresGeminiDefaultPassthroughs(t *t
 	}
 }
 
-// Partial/outdated account mappings must still surface default Antigravity models
-// so /v1/models and scheduling stay complete (#3701).
+// Substantial outdated default snapshots must still surface newer default
+// Antigravity models so /v1/models and scheduling stay complete (#3701).
+// Small intentional allowlists must not be expanded — see
+// TestAccountGetModelMapping_AntigravityDoesNotMergeSmallAllowlist.
 func TestAccountGetModelMapping_AntigravityMergesMissingDefaultKeys(t *testing.T) {
+	// Simulate a legacy migration snapshot that already carried most of the
+	// default table but is missing a few models added later.
+	raw := make(map[string]any, len(domain.DefaultAntigravityModelMapping))
+	for from, to := range domain.DefaultAntigravityModelMapping {
+		switch from {
+		case "claude-opus-4-8", "gemini-2.5-pro":
+			continue
+		default:
+			raw[from] = to
+		}
+	}
+	if len(raw) < antigravityDefaultSnapshotMinKeys() {
+		t.Fatalf("fixture too small for snapshot merge: got %d want >= %d", len(raw), antigravityDefaultSnapshotMinKeys())
+	}
+
 	account := &Account{
 		Platform: PlatformAntigravity,
 		Credentials: map[string]any{
-			"model_mapping": map[string]any{
-				// Simulate a legacy migration snapshot that only listed Claude.
-				"claude-sonnet-4-5": "claude-sonnet-4-5",
-			},
+			"model_mapping": raw,
 		},
 	}
 
@@ -544,6 +558,31 @@ func TestAccountGetModelMapping_AntigravityMergesMissingDefaultKeys(t *testing.T
 	}
 	if mapping["gemini-3.1-pro-high"] == "" {
 		t.Fatalf("expected gemini-3.1-pro-high present after merge, mapping=%v", mapping)
+	}
+}
+
+// A handful of exact default entries is an intentional allowlist, not a stale
+// full default snapshot. Bulk-merging would break thinking/non-thinking
+// whitelist scheduling.
+func TestAccountGetModelMapping_AntigravityDoesNotMergeSmallAllowlist(t *testing.T) {
+	account := &Account{
+		Platform: PlatformAntigravity,
+		Credentials: map[string]any{
+			"model_mapping": map[string]any{
+				"claude-sonnet-4-5-thinking": "claude-sonnet-4-5-thinking",
+			},
+		},
+	}
+
+	mapping := account.GetModelMapping()
+	if mapping["claude-sonnet-4-5-thinking"] != "claude-sonnet-4-5-thinking" {
+		t.Fatalf("expected allowlist entry preserved, got: %q", mapping["claude-sonnet-4-5-thinking"])
+	}
+	if _, ok := mapping["claude-sonnet-4-5"]; ok {
+		t.Fatalf("did not expect base model bulk-merged into small thinking-only allowlist")
+	}
+	if _, ok := mapping["claude-opus-4-8"]; ok {
+		t.Fatalf("did not expect unrelated defaults bulk-merged into small allowlist")
 	}
 }
 

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -258,12 +258,21 @@ func (s *BillingService) initFallbackPricing() {
 	// Claude 4.7 Opus (暂与4.6同价，待官方定价更新)
 	s.fallbackPrices["claude-opus-4.7"] = s.fallbackPrices["claude-opus-4.6"]
 
-	// Gemini 3.1 Pro
+	// Gemini 3.1 Pro（亦覆盖 Antigravity gemini-3-pro-* / gemini-pro-agent 别名）
 	s.fallbackPrices["gemini-3.1-pro"] = &ModelPricing{
 		InputPricePerToken:         2e-6,   // $2 per MTok
 		OutputPricePerToken:        12e-6,  // $12 per MTok
 		CacheCreationPricePerToken: 2e-6,   // $2 per MTok
 		CacheReadPricePerToken:     0.2e-6, // $0.20 per MTok
+		SupportsCacheBreakdown:     false,
+	}
+
+	// Gemini 2.5 Flash（Antigravity flash / image / thinking 系列兜底）
+	s.fallbackPrices["gemini-2.5-flash"] = &ModelPricing{
+		InputPricePerToken:         0.3e-6,  // $0.30 per MTok
+		OutputPricePerToken:        2.5e-6,  // $2.50 per MTok
+		CacheCreationPricePerToken: 0.3e-6,  // $0.30 per MTok
+		CacheReadPricePerToken:     0.03e-6, // $0.03 per MTok
 		SupportsCacheBreakdown:     false,
 	}
 
@@ -583,6 +592,40 @@ func (s *BillingService) initFallbackPricing() {
 }
 
 // getFallbackPricing 根据模型系列获取回退价格
+// canonicalizeAntigravityBillingModel maps Antigravity upstream model IDs to
+// publicly priced equivalents so CalculateCost can resolve LiteLLM / fallback
+// rates. Request routing still uses the original mapped upstream name.
+func canonicalizeAntigravityBillingModel(model string) string {
+	switch model {
+	case "gemini-pro-agent", "gemini-3.1-pro", "gemini-3.1-pro-preview", "gemini-3-pro-high", "gemini-3-pro-preview":
+		return "gemini-3.1-pro-high"
+	case "gemini-3-pro-low":
+		return "gemini-3.1-pro-low"
+	case "gemini-3-flash-preview":
+		return "gemini-3-flash"
+	case "gemini-2.5-flash-thinking":
+		return "gemini-2.5-flash"
+	case "gemini-2.5-flash-image-preview":
+		return "gemini-2.5-flash-image"
+	case "gemini-3.1-flash-image-preview", "gemini-3-pro-image", "gemini-3-pro-image-preview":
+		return "gemini-3.1-flash-image"
+	case "claude-opus-4-5-thinking", "claude-opus-4-5-20251101":
+		return "claude-opus-4-5"
+	case "claude-sonnet-4-5-thinking", "claude-sonnet-4-5-20250929":
+		return "claude-sonnet-4-5"
+	case "claude-haiku-4-5", "claude-haiku-4-5-20251001":
+		// Default Antigravity mapping routes Haiku → Sonnet 4.6 for inference;
+		// bill at Sonnet rates so usage is not zero-priced.
+		return "claude-sonnet-4-6"
+	case "claude-fable-5":
+		return "claude-opus-4-6"
+	case "gpt-oss-120b-medium", "tab_flash_lite_preview":
+		return "gemini-2.5-flash"
+	default:
+		return model
+	}
+}
+
 func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	modelLower := strings.ToLower(model)
 
@@ -615,8 +658,26 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	if strings.Contains(modelLower, "claude") {
 		return s.fallbackPrices["claude-sonnet-4"]
 	}
-	if strings.Contains(modelLower, "gemini-3.1-pro") || strings.Contains(modelLower, "gemini-3-1-pro") {
+	// Antigravity Gemini 系列：上游映射名（gemini-3-pro-high / gemini-pro-agent 等）
+	// 常不在 LiteLLM 表中，必须有 fallback 否则可调用却无法计费（#3701）。
+	if strings.Contains(modelLower, "gemini-pro-agent") ||
+		strings.Contains(modelLower, "gemini-3.1-pro") ||
+		strings.Contains(modelLower, "gemini-3-1-pro") ||
+		strings.Contains(modelLower, "gemini-3-pro") {
 		return s.fallbackPrices["gemini-3.1-pro"]
+	}
+	if strings.Contains(modelLower, "gemini-2.5-pro") {
+		return s.fallbackPrices["gemini-3.1-pro"]
+	}
+	if strings.Contains(modelLower, "gemini-2.5-flash") ||
+		strings.Contains(modelLower, "gemini-3-flash") ||
+		strings.Contains(modelLower, "gemini-3.1-flash") ||
+		strings.Contains(modelLower, "gemini-flash") {
+		return s.fallbackPrices["gemini-2.5-flash"]
+	}
+	if strings.Contains(modelLower, "gpt-oss") || strings.Contains(modelLower, "tab_flash") {
+		// Antigravity 附带模型：无独立公开价卡时按 Flash 档兜底，避免计费中断。
+		return s.fallbackPrices["gemini-2.5-flash"]
 	}
 
 	// DeepSeek V4 系列：仅匹配已知 V4 Pro/Flash 与官方兼容别名
@@ -769,6 +830,8 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 func (s *BillingService) GetModelPricing(model string) (*ModelPricing, error) {
 	// 标准化模型名称（转小写）
 	model = strings.ToLower(model)
+	// Antigravity 上游映射名 → 可计费的公开模型 ID（#3701）
+	model = canonicalizeAntigravityBillingModel(model)
 
 	// 1. 优先从动态价格服务获取
 	if s.pricingService != nil {

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -180,6 +180,28 @@ func TestGetModelPricing_UnknownClaudeModelFallsBackToSonnet(t *testing.T) {
 	require.InDelta(t, 3e-6, pricing.InputPricePerToken, 1e-12)
 }
 
+// Antigravity upstream model IDs must resolve to billable rates (#3701).
+func TestGetModelPricing_AntigravityMappedModelsAreBillable(t *testing.T) {
+	svc := newTestBillingService()
+
+	models := []string{
+		"gemini-3-pro-high",
+		"gemini-3-pro-low",
+		"gemini-pro-agent",
+		"gemini-2.5-flash-thinking",
+		"claude-opus-4-5-thinking",
+		"claude-fable-5",
+		"gpt-oss-120b-medium",
+		"tab_flash_lite_preview",
+	}
+	for _, model := range models {
+		pricing, err := svc.GetModelPricing(model)
+		require.NoError(t, err, "model %s", model)
+		require.NotNil(t, pricing, "model %s", model)
+		require.Greater(t, pricing.InputPricePerToken+pricing.OutputPricePerToken, 0.0, "model %s", model)
+	}
+}
+
 func TestGetModelPricing_UnknownOpenAIModelReturnsError(t *testing.T) {
 	svc := newTestBillingService()
 


### PR DESCRIPTION
## Summary
- DefaultModels 对齐 DefaultAntigravityModelMapping 客户端可见 ID
- `/v1/models` 在 `platform=antigravity` 时回退到 Antigravity 默认列表
- 过时默认 mapping 子集自动合并缺失项（不覆盖自定义白名单/通配符）
- 为 `gemini-3-pro-*` / `gemini-pro-agent` 等上游映射名增加定价规范化与 fallback

Fixes #3701

## Test plan
- [x] `go test -tags=unit ./internal/service/ -run 'Antigravity|Billing|Wildcard|DefaultModels'`
- [x] `go test -tags=unit ./internal/pkg/antigravity/`
- [x] `go test -tags=unit ./internal/handler/ -run 'Models|Gateway'`
- [ ] 集成：Antigravity 账号模型列表完整且 usage 可正常计费