### PR TITLE
fix(scheduler): 修复大账号池调度的 I/O 放大与缓存一致性问题

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1303,10 +1303,16 @@ type GatewaySchedulingConfig struct {
 	// 负载计算
 	LoadBatchEnabled    bool `mapstructure:"load_batch_enabled"`
 	LoadBatchCacheTTLMS int  `mapstructure:"load_batch_cache_ttl_ms"`
+	// 是否启用有界 Redis 脚本批量读取；失败时自动回退 Pipeline
+	LoadBatchScriptEnabled bool `mapstructure:"load_batch_script_enabled"`
 	// 快照桶读取时的 MGET 分块大小
 	SnapshotMGetChunkSize int `mapstructure:"snapshot_mget_chunk_size"`
 	// 快照重建时的缓存写入分块大小
 	SnapshotWriteChunkSize int `mapstructure:"snapshot_write_chunk_size"`
+	// 是否启用进程内完整调度 metadata 快照缓存；异常时可关闭并回退 Redis 读取
+	SnapshotLocalCacheEnabled bool `mapstructure:"snapshot_local_cache_enabled"`
+	// 是否启用账号事件的单成员 bucket 增量维护；关闭时回退到完整 bucket 重建
+	IncrementalBucketUpdateEnabled bool `mapstructure:"incremental_bucket_update_enabled"`
 
 	// 过期槽位清理周期（0 表示禁用）
 	SlotCleanupInterval time.Duration `mapstructure:"slot_cleanup_interval"`
@@ -2273,8 +2279,11 @@ func setDefaults() {
 	viper.SetDefault("gateway.scheduling.prefer_soonest_reset", false)
 	viper.SetDefault("gateway.scheduling.load_batch_enabled", true)
 	viper.SetDefault("gateway.scheduling.load_batch_cache_ttl_ms", 200)
+	viper.SetDefault("gateway.scheduling.load_batch_script_enabled", true)
 	viper.SetDefault("gateway.scheduling.snapshot_mget_chunk_size", 128)
 	viper.SetDefault("gateway.scheduling.snapshot_write_chunk_size", 256)
+	viper.SetDefault("gateway.scheduling.snapshot_local_cache_enabled", true)
+	viper.SetDefault("gateway.scheduling.incremental_bucket_update_enabled", true)
 	viper.SetDefault("gateway.scheduling.slot_cleanup_interval", 30*time.Second)
 	viper.SetDefault("gateway.scheduling.db_fallback_enabled", true)
 	viper.SetDefault("gateway.scheduling.db_fallback_timeout_seconds", 0)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -312,8 +312,38 @@ func TestLoadDefaultSchedulingConfig(t *testing.T) {
 	if cfg.Gateway.Scheduling.LoadBatchCacheTTLMS != 200 {
 		t.Fatalf("LoadBatchCacheTTLMS = %d, want 200", cfg.Gateway.Scheduling.LoadBatchCacheTTLMS)
 	}
+	if !cfg.Gateway.Scheduling.LoadBatchScriptEnabled {
+		t.Fatalf("LoadBatchScriptEnabled = false, want true")
+	}
+	if !cfg.Gateway.Scheduling.SnapshotLocalCacheEnabled {
+		t.Fatalf("SnapshotLocalCacheEnabled = false, want true")
+	}
+	if !cfg.Gateway.Scheduling.IncrementalBucketUpdateEnabled {
+		t.Fatalf("IncrementalBucketUpdateEnabled = false, want true")
+	}
 	if cfg.Gateway.Scheduling.SlotCleanupInterval != 30*time.Second {
 		t.Fatalf("SlotCleanupInterval = %v, want 30s", cfg.Gateway.Scheduling.SlotCleanupInterval)
+	}
+}
+
+func TestLoadSchedulingOptimizationsCanBeDisabled(t *testing.T) {
+	resetViperWithJWTSecret(t)
+	t.Setenv("GATEWAY_SCHEDULING_LOAD_BATCH_SCRIPT_ENABLED", "false")
+	t.Setenv("GATEWAY_SCHEDULING_SNAPSHOT_LOCAL_CACHE_ENABLED", "false")
+	t.Setenv("GATEWAY_SCHEDULING_INCREMENTAL_BUCKET_UPDATE_ENABLED", "false")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Gateway.Scheduling.LoadBatchScriptEnabled {
+		t.Fatal("LoadBatchScriptEnabled = true, want false from environment")
+	}
+	if cfg.Gateway.Scheduling.SnapshotLocalCacheEnabled {
+		t.Fatal("SnapshotLocalCacheEnabled = true, want false from environment")
+	}
+	if cfg.Gateway.Scheduling.IncrementalBucketUpdateEnabled {
+		t.Fatal("IncrementalBucketUpdateEnabled = true, want false from environment")
 	}
 }
 

--- a/backend/internal/handler/admin/admin_basic_handlers_test.go
+++ b/backend/internal/handler/admin/admin_basic_handlers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 )
@@ -318,4 +319,25 @@ func TestRedeemHandlerEndpoints(t *testing.T) {
 	req = httptest.NewRequest(http.MethodGet, "/api/v1/admin/redeem-codes/5/stats", nil)
 	router.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestDashboardRealtimeIncludesLiveSchedulerMetrics(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	before := service.GetSchedulerOptimizationMetricsSnapshot()
+	service.RecordSchedulerLoadCache(true, false)
+	router := gin.New()
+	router.GET("/realtime", NewDashboardHandler(nil, nil).GetRealtimeMetrics)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/realtime", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Data struct {
+			Scheduler service.SchedulerOptimizationMetricsSnapshot `json:"scheduler"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.GreaterOrEqual(t, body.Data.Scheduler.Load.RequestTotal, before.Load.RequestTotal+1)
 }

--- a/backend/internal/handler/admin/dashboard_handler.go
+++ b/backend/internal/handler/admin/dashboard_handler.go
@@ -178,12 +178,13 @@ func (h *DashboardHandler) BackfillAggregation(c *gin.Context) {
 // GetRealtimeMetrics handles getting real-time system metrics
 // GET /api/v1/admin/dashboard/realtime
 func (h *DashboardHandler) GetRealtimeMetrics(c *gin.Context) {
-	// Return mock data for now
+	// Legacy dashboard fields remain placeholders; scheduler metrics are live process-local counters.
 	response.Success(c, gin.H{
 		"active_requests":       0,
 		"requests_per_minute":   0,
 		"average_response_time": 0,
 		"error_rate":            0.0,
+		"scheduler":             service.GetSchedulerOptimizationMetricsSnapshot(),
 	})
 }
 

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -1643,24 +1643,19 @@ func (r *accountRepository) BindGroups(ctx context.Context, accountID int64, gro
 		return err
 	}
 
-	if len(groupIDs) == 0 {
-		if tx != nil {
-			return tx.Commit()
+	if len(groupIDs) > 0 {
+		builders := make([]*dbent.AccountGroupCreate, 0, len(groupIDs))
+		for i, groupID := range groupIDs {
+			builders = append(builders, txClient.AccountGroup.Create().
+				SetAccountID(accountID).
+				SetGroupID(groupID).
+				SetPriority(i+1),
+			)
 		}
-		return nil
-	}
 
-	builders := make([]*dbent.AccountGroupCreate, 0, len(groupIDs))
-	for i, groupID := range groupIDs {
-		builders = append(builders, txClient.AccountGroup.Create().
-			SetAccountID(accountID).
-			SetGroupID(groupID).
-			SetPriority(i+1),
-		)
-	}
-
-	if _, err := txClient.AccountGroup.CreateBulk(builders...).Save(ctx); err != nil {
-		return err
+		if _, err := txClient.AccountGroup.CreateBulk(builders...).Save(ctx); err != nil {
+			return err
+		}
 	}
 
 	if tx != nil {

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -5,6 +5,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -721,6 +722,19 @@ func (s *AccountRepoSuite) TestBindGroups_EmptyList() {
 	groups, err := s.repo.GetGroups(s.ctx, account.ID)
 	s.Require().NoError(err)
 	s.Require().Empty(groups, "expected 0 groups after binding empty list")
+
+	var payloadRaw []byte
+	err = scanSingleRow(s.ctx, s.repo.sql, `
+		SELECT payload
+		FROM scheduler_outbox
+		WHERE event_type = $1 AND account_id = $2
+		ORDER BY id DESC
+		LIMIT 1
+	`, []any{service.SchedulerOutboxEventAccountGroupsChanged, account.ID}, &payloadRaw)
+	s.Require().NoError(err, "expected outbox event for clearing account groups")
+	var payload map[string][]int64
+	s.Require().NoError(json.Unmarshal(payloadRaw, &payload))
+	s.Require().ElementsMatch([]int64{group.ID}, payload["group_ids"])
 }
 
 // --- Schedulable ---

--- a/backend/internal/repository/concurrency_cache.go
+++ b/backend/internal/repository/concurrency_cache.go
@@ -4,12 +4,51 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strconv"
+	"sync/atomic"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/redis/go-redis/v9"
 )
+
+// accountLoadBatchLua keeps the exact per-account cleanup and load calculation
+// while grouping a bounded number of accounts into one Redis pipeline command.
+// The caller still supplies one cutoff for the whole read, matching the legacy
+// TIME + Pipeline semantics.
+const accountLoadBatchLua = `
+local cutoff = ARGV[1]
+local accountCount = #KEYS / 2
+local result = {}
+for i = 1, accountCount do
+  local slotKey = KEYS[(i - 1) * 2 + 1]
+  local waitKey = KEYS[(i - 1) * 2 + 2]
+  redis.call('ZREMRANGEBYSCORE', slotKey, '-inf', cutoff)
+  local current = redis.call('ZCARD', slotKey)
+  local waitingValue = redis.call('GET', waitKey)
+  local waiting = 0
+  if waitingValue then
+    waiting = tonumber(waitingValue) or 0
+  end
+  local maxConcurrency = tonumber(ARGV[i + 1]) or 0
+  local loadRate = 0
+  if maxConcurrency > 0 then
+    local numerator = (current + waiting) * 100
+    if numerator >= 0 then
+      loadRate = math.floor(numerator / maxConcurrency)
+    else
+      -- Go integer division truncates toward zero; Lua floor does not.
+      loadRate = math.ceil(numerator / maxConcurrency)
+    end
+  end
+  result[#result + 1] = current
+  result[#result + 1] = waiting
+  result[#result + 1] = loadRate
+end
+return result
+`
 
 // 并发控制缓存常量定义
 //
@@ -295,15 +334,24 @@ var (
 )
 
 type concurrencyCache struct {
-	rdb                 *redis.Client
-	slotTTLSeconds      int // 槽位过期时间（秒）
-	waitQueueTTLSeconds int // 等待队列过期时间（秒）
+	rdb                      *redis.Client
+	slotTTLSeconds           int // 槽位过期时间（秒）
+	waitQueueTTLSeconds      int // 等待队列过期时间（秒）
+	loadBatchScriptEnabled   bool
+	loadBatchScriptChunkSize int
+	loadBatchScriptDisabled  atomic.Bool
 }
+
+const defaultAccountLoadBatchScriptChunkSize = 256
 
 // NewConcurrencyCache 创建并发控制缓存
 // slotTTLMinutes: 槽位过期时间（分钟），0 或负数使用默认值 15 分钟
 // waitQueueTTLSeconds: 等待队列过期时间（秒），0 或负数使用 slot TTL
 func NewConcurrencyCache(rdb *redis.Client, slotTTLMinutes int, waitQueueTTLSeconds int) service.ConcurrencyCache {
+	return newConcurrencyCache(rdb, slotTTLMinutes, waitQueueTTLSeconds)
+}
+
+func newConcurrencyCache(rdb *redis.Client, slotTTLMinutes int, waitQueueTTLSeconds int) *concurrencyCache {
 	if slotTTLMinutes <= 0 {
 		slotTTLMinutes = defaultSlotTTLMinutes
 	}
@@ -311,9 +359,10 @@ func NewConcurrencyCache(rdb *redis.Client, slotTTLMinutes int, waitQueueTTLSeco
 		waitQueueTTLSeconds = slotTTLMinutes * 60
 	}
 	return &concurrencyCache{
-		rdb:                 rdb,
-		slotTTLSeconds:      slotTTLMinutes * 60,
-		waitQueueTTLSeconds: waitQueueTTLSeconds,
+		rdb:                      rdb,
+		slotTTLSeconds:           slotTTLMinutes * 60,
+		waitQueueTTLSeconds:      waitQueueTTLSeconds,
+		loadBatchScriptChunkSize: defaultAccountLoadBatchScriptChunkSize,
 	}
 }
 
@@ -815,13 +864,115 @@ func (c *concurrencyCache) GetAccountWaitingCount(ctx context.Context, accountID
 	return val, nil
 }
 
-func (c *concurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []service.AccountWithConcurrency) (map[int64]*service.AccountLoadInfo, error) {
+func (c *concurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []service.AccountWithConcurrency) (loadMap map[int64]*service.AccountLoadInfo, err error) {
 	if len(accounts) == 0 {
 		return map[int64]*service.AccountLoadInfo{}, nil
 	}
 
-	// 使用 Pipeline 替代 Lua 脚本，兼容 Redis Cluster（Lua 内动态拼 key 会 CROSSSLOT）。
-	// 每个账号执行 3 个命令：ZREMRANGEBYSCORE（清理过期）、ZCARD（并发数）、GET（等待数）。
+	startedAt := time.Now()
+	path := "pipeline"
+	batchCount := 1
+	defer func() {
+		debugAccountLoadBatch(ctx, path, len(accounts), batchCount, startedAt, err)
+	}()
+
+	if c.loadBatchScriptEnabled && !c.loadBatchScriptDisabled.Load() {
+		path = "script"
+		chunkSize := c.loadBatchScriptChunkSize
+		if chunkSize <= 0 {
+			chunkSize = defaultAccountLoadBatchScriptChunkSize
+		}
+		batchCount = (len(accounts) + chunkSize - 1) / chunkSize
+		loadMap, err = c.getAccountsLoadBatchScript(ctx, accounts, chunkSize)
+		if err == nil {
+			return loadMap, nil
+		}
+		if ctx != nil && ctx.Err() != nil {
+			return nil, err
+		}
+		if c.loadBatchScriptDisabled.CompareAndSwap(false, true) {
+			logCtx := ctx
+			if logCtx == nil {
+				logCtx = context.Background()
+			}
+			slog.WarnContext(logCtx, "scheduler load batch script disabled; using pipeline fallback", "error", err)
+		}
+		path = "pipeline_fallback"
+		batchCount = 1
+	}
+
+	return c.getAccountsLoadBatchPipeline(ctx, accounts)
+}
+
+func (c *concurrencyCache) getAccountsLoadBatchScript(ctx context.Context, accounts []service.AccountWithConcurrency, chunkSize int) (map[int64]*service.AccountLoadInfo, error) {
+	now, err := c.rdb.Time(ctx).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis TIME: %w", err)
+	}
+	cutoffTime := now.Unix() - int64(c.slotTTLSeconds)
+
+	pipe := c.rdb.Pipeline()
+	type accountLoadBatchCmd struct {
+		accounts []service.AccountWithConcurrency
+		cmd      *redis.Cmd
+	}
+	cmds := make([]accountLoadBatchCmd, 0, (len(accounts)+chunkSize-1)/chunkSize)
+	for start := 0; start < len(accounts); start += chunkSize {
+		end := min(start+chunkSize, len(accounts))
+		batch := accounts[start:end]
+		keys := make([]string, 0, len(batch)*2)
+		args := make([]any, 1, len(batch)+1)
+		args[0] = cutoffTime
+		for _, acc := range batch {
+			id := strconv.FormatInt(acc.ID, 10)
+			keys = append(keys, accountSlotKeyPrefix+id, accountWaitKeyPrefix+id)
+			args = append(args, acc.MaxConcurrency)
+		}
+		cmds = append(cmds, accountLoadBatchCmd{
+			accounts: batch,
+			cmd:      pipe.Eval(ctx, accountLoadBatchLua, keys, args...),
+		})
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return nil, fmt.Errorf("load batch script pipeline: %w", err)
+	}
+
+	loadMap := make(map[int64]*service.AccountLoadInfo, len(accounts))
+	for _, batchCmd := range cmds {
+		values, err := batchCmd.cmd.Slice()
+		if err != nil {
+			return nil, fmt.Errorf("load batch script result: %w", err)
+		}
+		if len(values) != len(batchCmd.accounts)*3 {
+			return nil, fmt.Errorf("load batch script result count: got %d, want %d", len(values), len(batchCmd.accounts)*3)
+		}
+		for i, acc := range batchCmd.accounts {
+			currentConcurrency, err := redisScriptInt(values[i*3])
+			if err != nil {
+				return nil, fmt.Errorf("load batch script concurrency for account %d: %w", acc.ID, err)
+			}
+			waitingCount, err := redisScriptInt(values[i*3+1])
+			if err != nil {
+				return nil, fmt.Errorf("load batch script wait count for account %d: %w", acc.ID, err)
+			}
+			loadRate, err := redisScriptInt(values[i*3+2])
+			if err != nil {
+				return nil, fmt.Errorf("load batch script load rate for account %d: %w", acc.ID, err)
+			}
+			loadMap[acc.ID] = &service.AccountLoadInfo{
+				AccountID:          acc.ID,
+				CurrentConcurrency: currentConcurrency,
+				WaitingCount:       waitingCount,
+				LoadRate:           loadRate,
+			}
+		}
+	}
+	return loadMap, nil
+}
+
+func (c *concurrencyCache) getAccountsLoadBatchPipeline(ctx context.Context, accounts []service.AccountWithConcurrency) (map[int64]*service.AccountLoadInfo, error) {
+	// Pipeline remains the compatibility path for Redis Cluster/proxies that reject multi-key EVAL.
+	// Each account executes ZREMRANGEBYSCORE, ZCARD and GET.
 	now, err := c.rdb.Time(ctx).Result()
 	if err != nil {
 		return nil, fmt.Errorf("redis TIME: %w", err)
@@ -874,6 +1025,41 @@ func (c *concurrencyCache) GetAccountsLoadBatch(ctx context.Context, accounts []
 	}
 
 	return loadMap, nil
+}
+
+func redisScriptInt(value any) (int, error) {
+	switch v := value.(type) {
+	case int64:
+		return int(v), nil
+	case string:
+		return strconv.Atoi(v)
+	case []byte:
+		return strconv.Atoi(string(v))
+	default:
+		return 0, fmt.Errorf("unexpected Redis value %T", value)
+	}
+}
+
+func debugAccountLoadBatch(ctx context.Context, path string, accountCount, batchCount int, startedAt time.Time, err error) {
+	duration := time.Since(startedAt)
+	service.RecordSchedulerLoadRedis(path, accountCount, batchCount, duration, err)
+	logCtx := ctx
+	if logCtx == nil {
+		logCtx = context.Background()
+	}
+	if !slog.Default().Enabled(logCtx, slog.LevelDebug) {
+		return
+	}
+	attrs := []any{
+		"path", path,
+		"accounts", accountCount,
+		"batches", batchCount,
+		"duration", duration,
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+	}
+	slog.DebugContext(logCtx, "scheduler load batch", attrs...)
 }
 
 func (c *concurrencyCache) GetUsersLoadBatch(ctx context.Context, users []service.UserWithConcurrency) (map[int64]*service.UserLoadInfo, error) {

--- a/backend/internal/repository/concurrency_cache_benchmark_test.go
+++ b/backend/internal/repository/concurrency_cache_benchmark_test.go
@@ -110,17 +110,17 @@ func scanSlotCount(ctx context.Context, rdb *redis.Client, pattern string) (int,
 	return count, nil
 }
 
-func newBenchmarkRedisClient(b *testing.B) *redis.Client {
-	b.Helper()
+func newBenchmarkRedisClient(tb testing.TB) *redis.Client {
+	tb.Helper()
 
 	redisURL := os.Getenv("TEST_REDIS_URL")
 	if redisURL == "" {
-		b.Skip("未设置 TEST_REDIS_URL，跳过 Redis 基准测试")
+		tb.Skip("未设置 TEST_REDIS_URL，跳过 Redis 基准测试")
 	}
 
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
-		b.Fatalf("解析 TEST_REDIS_URL 失败: %v", err)
+		tb.Fatalf("解析 TEST_REDIS_URL 失败: %v", err)
 	}
 
 	client := redis.NewClient(opt)
@@ -128,7 +128,7 @@ func newBenchmarkRedisClient(b *testing.B) *redis.Client {
 	defer cancel()
 
 	if err := client.Ping(ctx).Err(); err != nil {
-		b.Fatalf("Redis 连接失败: %v", err)
+		tb.Fatalf("Redis 连接失败: %v", err)
 	}
 
 	return client

--- a/backend/internal/repository/concurrency_cache_unit_test.go
+++ b/backend/internal/repository/concurrency_cache_unit_test.go
@@ -1,0 +1,211 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+)
+
+type accountLoadBatchPipelineHook struct {
+	evalCommands atomic.Int64
+	rejectEval   bool
+}
+
+func (h *accountLoadBatchPipelineHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h *accountLoadBatchPipelineHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return next
+}
+
+func (h *accountLoadBatchPipelineHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return func(ctx context.Context, cmds []redis.Cmder) error {
+		for _, cmd := range cmds {
+			if cmd.Name() != "eval" {
+				continue
+			}
+			h.evalCommands.Add(1)
+			if h.rejectEval {
+				return errors.New("NOPERM this user has no permissions to run the 'eval' command")
+			}
+		}
+		return next(ctx, cmds)
+	}
+}
+
+func newAccountLoadBatchUnitCache(t *testing.T, now time.Time) (*concurrencyCache, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	mr.SetTime(now)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	cache := NewConcurrencyCache(rdb, 1, 60).(*concurrencyCache)
+	return cache, mr
+}
+
+func seedAccountLoadBatchUnitData(t *testing.T, cache *concurrencyCache, now time.Time) []service.AccountWithConcurrency {
+	t.Helper()
+	ctx := context.Background()
+	accounts := []service.AccountWithConcurrency{
+		{ID: 101, MaxConcurrency: 4},
+		{ID: 102, MaxConcurrency: 2},
+		{ID: 103, MaxConcurrency: 0},
+	}
+	require.NoError(t, cache.rdb.ZAdd(ctx, accountSlotKey(101),
+		redis.Z{Score: float64(now.Unix()), Member: "live-101"},
+		redis.Z{Score: float64(now.Unix() - 61), Member: "expired-101"},
+	).Err())
+	require.NoError(t, cache.rdb.Set(ctx, accountWaitKey(101), "2", time.Minute).Err())
+	require.NoError(t, cache.rdb.ZAdd(ctx, accountSlotKey(102),
+		redis.Z{Score: float64(now.Unix()), Member: "live-102-a"},
+		redis.Z{Score: float64(now.Unix()), Member: "live-102-b"},
+	).Err())
+	require.NoError(t, cache.rdb.Set(ctx, accountWaitKey(103), "invalid", time.Minute).Err())
+	return accounts
+}
+
+func TestConcurrencyCacheAccountLoadBatchScriptMatchesPipeline(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	legacy, _ := newAccountLoadBatchUnitCache(t, now)
+	legacyAccounts := seedAccountLoadBatchUnitData(t, legacy, now)
+	want, err := legacy.getAccountsLoadBatchPipeline(context.Background(), legacyAccounts)
+	require.NoError(t, err)
+
+	scripted, _ := newAccountLoadBatchUnitCache(t, now)
+	scriptedAccounts := seedAccountLoadBatchUnitData(t, scripted, now)
+	got, err := scripted.getAccountsLoadBatchScript(context.Background(), scriptedAccounts, 2)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	require.Equal(t, int64(1), scripted.rdb.ZCard(context.Background(), accountSlotKey(101)).Val())
+}
+
+func TestConcurrencyCacheAccountLoadBatchScriptMatchesPipelineAcrossChunks(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	seed := func(t *testing.T, cache *concurrencyCache, size int) []service.AccountWithConcurrency {
+		t.Helper()
+		accounts := make([]service.AccountWithConcurrency, size)
+		for start := 0; start < size; start += 1_000 {
+			end := min(start+1_000, size)
+			pipe := cache.rdb.Pipeline()
+			for i := start; i < end; i++ {
+				id := int64(i + 1)
+				maxConcurrency := i%8 + 1
+				if i%31 == 0 {
+					maxConcurrency = 0
+				}
+				accounts[i] = service.AccountWithConcurrency{ID: id, MaxConcurrency: maxConcurrency}
+
+				members := []redis.Z{{Score: float64(now.Unix() - 61), Member: "expired"}}
+				for slot := 0; slot < i%4; slot++ {
+					members = append(members, redis.Z{Score: float64(now.Unix()), Member: fmt.Sprintf("live-%d", slot)})
+				}
+				pipe.ZAdd(context.Background(), accountSlotKey(id), members...)
+				switch i % 5 {
+				case 1:
+					pipe.Set(context.Background(), accountWaitKey(id), "2", time.Minute)
+				case 2:
+					pipe.Set(context.Background(), accountWaitKey(id), "-1", time.Minute)
+				case 3:
+					pipe.Set(context.Background(), accountWaitKey(id), "invalid", time.Minute)
+				}
+			}
+			_, err := pipe.Exec(context.Background())
+			require.NoError(t, err)
+		}
+		return accounts
+	}
+
+	legacy, _ := newAccountLoadBatchUnitCache(t, now)
+	legacyAccounts := seed(t, legacy, 1_000)
+	want, err := legacy.getAccountsLoadBatchPipeline(context.Background(), legacyAccounts)
+	require.NoError(t, err)
+
+	scripted, _ := newAccountLoadBatchUnitCache(t, now)
+	scriptedAccounts := seed(t, scripted, 1_000)
+	got, err := scripted.getAccountsLoadBatchScript(context.Background(), scriptedAccounts, defaultAccountLoadBatchScriptChunkSize)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+	for _, index := range []int{0, 256, len(scriptedAccounts) - 1} {
+		id := scriptedAccounts[index].ID
+		require.Equal(t, int64(index%4), scripted.rdb.ZCard(context.Background(), accountSlotKey(id)).Val())
+	}
+}
+
+func TestConcurrencyCacheAccountLoadBatchScriptMatchesNegativeWaitingCount(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	account := service.AccountWithConcurrency{ID: 104, MaxConcurrency: 3}
+
+	legacy, _ := newAccountLoadBatchUnitCache(t, now)
+	require.NoError(t, legacy.rdb.Set(context.Background(), accountWaitKey(account.ID), "-1", time.Minute).Err())
+	want, err := legacy.getAccountsLoadBatchPipeline(context.Background(), []service.AccountWithConcurrency{account})
+	require.NoError(t, err)
+
+	scripted, _ := newAccountLoadBatchUnitCache(t, now)
+	require.NoError(t, scripted.rdb.Set(context.Background(), accountWaitKey(account.ID), "-1", time.Minute).Err())
+	got, err := scripted.getAccountsLoadBatchScript(context.Background(), []service.AccountWithConcurrency{account}, 1)
+	require.NoError(t, err)
+
+	require.Equal(t, want, got)
+	require.Equal(t, -33, got[account.ID].LoadRate)
+}
+
+func TestConcurrencyCacheAccountLoadBatchScriptUsesBoundedChunks(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	cache, _ := newAccountLoadBatchUnitCache(t, now)
+	cache.loadBatchScriptEnabled = true
+	cache.loadBatchScriptChunkSize = 2
+	hook := &accountLoadBatchPipelineHook{}
+	cache.rdb.AddHook(hook)
+	accounts := []service.AccountWithConcurrency{
+		{ID: 201, MaxConcurrency: 1},
+		{ID: 202, MaxConcurrency: 1},
+		{ID: 203, MaxConcurrency: 1},
+		{ID: 204, MaxConcurrency: 1},
+		{ID: 205, MaxConcurrency: 1},
+	}
+
+	got, err := cache.GetAccountsLoadBatch(context.Background(), accounts)
+	require.NoError(t, err)
+	require.Len(t, got, len(accounts))
+	require.Equal(t, int64(3), hook.evalCommands.Load())
+}
+
+func TestConcurrencyCacheAccountLoadBatchScriptFallsBackOnce(t *testing.T) {
+	now := time.Unix(1_800_000_000, 0)
+	cache, _ := newAccountLoadBatchUnitCache(t, now)
+	cache.loadBatchScriptEnabled = true
+	hook := &accountLoadBatchPipelineHook{rejectEval: true}
+	cache.rdb.AddHook(hook)
+	accounts := seedAccountLoadBatchUnitData(t, cache, now)
+
+	for range 2 {
+		got, err := cache.GetAccountsLoadBatch(context.Background(), accounts)
+		require.NoError(t, err)
+		require.Len(t, got, len(accounts))
+	}
+	require.True(t, cache.loadBatchScriptDisabled.Load())
+	require.Equal(t, int64(1), hook.evalCommands.Load())
+}
+
+func TestProvideConcurrencyCacheReadsLoadBatchScriptConfig(t *testing.T) {
+	cache, _ := newAccountLoadBatchUnitCache(t, time.Now())
+	cfg := &config.Config{}
+	cfg.Gateway.ConcurrencySlotTTLMinutes = 1
+	cfg.Gateway.Scheduling.LoadBatchScriptEnabled = true
+
+	provided := ProvideConcurrencyCache(cache.rdb, cfg).(*concurrencyCache)
+	require.True(t, provided.loadBatchScriptEnabled)
+	require.Equal(t, defaultAccountLoadBatchScriptChunkSize, provided.loadBatchScriptChunkSize)
+}

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -5,27 +5,31 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/redis/go-redis/v9"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
-	schedulerBucketSetKey       = "sched:buckets"
-	schedulerOutboxWatermarkKey = "sched:outbox:watermark"
-	schedulerAccountPrefix      = "sched:acc:"
-	schedulerAccountMetaPrefix  = "sched:meta:"
-	schedulerActivePrefix       = "sched:active:"
-	schedulerReadyPrefix        = "sched:ready:"
-	schedulerVersionPrefix      = "sched:ver:"
-	schedulerEpochPrefix        = "sched:epoch:"
-	schedulerRetiredPrefix      = "sched:retired:"
-	schedulerSnapshotPrefix     = "sched:"
-	schedulerLockPrefix         = "sched:lock:"
+	schedulerBucketSetKey        = "sched:buckets"
+	schedulerOutboxWatermarkKey  = "sched:outbox:watermark"
+	schedulerAccountPrefix       = "sched:acc:"
+	schedulerAccountMetaPrefix   = "sched:meta:"
+	schedulerMetadataRevisionKey = "sched:meta:revision"
+	schedulerActivePrefix        = "sched:active:"
+	schedulerReadyPrefix         = "sched:ready:"
+	schedulerVersionPrefix       = "sched:ver:"
+	schedulerEpochPrefix         = "sched:epoch:"
+	schedulerRetiredPrefix       = "sched:retired:"
+	schedulerSnapshotPrefix      = "sched:"
+	schedulerLockPrefix          = "sched:lock:"
 
 	defaultSchedulerSnapshotMGetChunkSize  = 128
 	defaultSchedulerSnapshotWriteChunkSize = 256
@@ -33,6 +37,12 @@ const (
 	// snapshotGraceTTLSeconds 旧快照过期的宽限期（秒）。
 	// 替代立即 DEL，让正在读取旧版本的 reader 有足够时间完成 ZRANGE。
 	snapshotGraceTTLSeconds = 60
+
+	// localSnapshotCacheTTL bounds the local-hit lifetime; version/revision checks control freshness.
+	localSnapshotCacheTTL = 30 * time.Second
+	// ponytail: arbitrary eviction under a 20k-account ceiling; add a cost-aware
+	// LRU only if multiple giant buckets measurably thrash this cache.
+	maxLocalSnapshotAccounts = 20_000
 )
 
 const (
@@ -196,19 +206,72 @@ end
 
 return 1
 `)
+
+	removeSnapshotAccountScript = redis.NewScript(`
+if redis.call('EXISTS', KEYS[4]) == 1 then
+	return -1
+end
+local currentEpoch = tonumber(redis.call('GET', KEYS[3]))
+local expectedEpoch = tonumber(ARGV[2])
+if currentEpoch == nil or expectedEpoch == nil or currentEpoch ~= expectedEpoch then
+	return -2
+end
+redis.call('SET', KEYS[3], tostring(currentEpoch + 1))
+if redis.call('GET', KEYS[2]) ~= '1' then
+	return 0
+end
+local version = redis.call('GET', KEYS[1])
+if version == false then
+	return 0
+end
+return redis.call('ZREM', ARGV[1] .. version, ARGV[3])
+`)
+
+	setOutboxWatermarkScript = redis.NewScript(`
+local current = tonumber(redis.call('GET', KEYS[1])) or 0
+local next = tonumber(ARGV[1]) or 0
+if next > current then
+	redis.call('SET', KEYS[1], tostring(next))
+	return next
+end
+return current
+`)
 )
 
 type schedulerCache struct {
 	rdb            *redis.Client
 	mgetChunkSize  int
 	writeChunkSize int
+
+	localSnapshotEnabled  bool
+	localSnapshotMu       sync.Mutex
+	localSnapshots        map[service.SchedulerBucket]localSnapshotEntry
+	localSnapshotAccounts int
+	localSnapshotGroup    singleflight.Group
+}
+
+type schedulerSnapshotState struct {
+	version          string
+	epoch            int64
+	metadataRevision int64
+}
+
+type localSnapshotEntry struct {
+	state     schedulerSnapshotState
+	accounts  []*service.Account
+	expiresAt time.Time
+}
+
+type snapshotLoadResult struct {
+	accounts []*service.Account
+	hit      bool
 }
 
 func NewSchedulerCache(rdb *redis.Client) service.SchedulerCache {
 	return newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
 }
 
-func newSchedulerCacheWithChunkSizes(rdb *redis.Client, mgetChunkSize, writeChunkSize int) service.SchedulerCache {
+func newSchedulerCacheWithChunkSizes(rdb *redis.Client, mgetChunkSize, writeChunkSize int) *schedulerCache {
 	if mgetChunkSize <= 0 {
 		mgetChunkSize = defaultSchedulerSnapshotMGetChunkSize
 	}
@@ -219,10 +282,28 @@ func newSchedulerCacheWithChunkSizes(rdb *redis.Client, mgetChunkSize, writeChun
 		rdb:            rdb,
 		mgetChunkSize:  mgetChunkSize,
 		writeChunkSize: writeChunkSize,
+		localSnapshots: make(map[service.SchedulerBucket]localSnapshotEntry),
 	}
 }
 
 func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.SchedulerBucket) ([]*service.Account, bool, error) {
+	startedAt := time.Now()
+	path := "redis"
+	var (
+		accounts []*service.Account
+		hit      bool
+		err      error
+	)
+	if c.localSnapshotEnabled {
+		accounts, hit, path, err = c.getSnapshotWithLocalCache(ctx, bucket)
+	} else {
+		accounts, hit, err = c.getSnapshotLegacy(ctx, bucket)
+	}
+	service.RecordSchedulerSnapshotRead(path, len(accounts), hit, time.Since(startedAt), err)
+	return accounts, hit, err
+}
+
+func (c *schedulerCache) getSnapshotLegacy(ctx context.Context, bucket service.SchedulerBucket) ([]*service.Account, bool, error) {
 	readyKey := schedulerBucketKey(schedulerReadyPrefix, bucket)
 	readyVal, err := c.rdb.Get(ctx, readyKey).Result()
 	if err == redis.Nil {
@@ -244,7 +325,11 @@ func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.Schedul
 		return nil, false, err
 	}
 
-	snapshotKey := schedulerSnapshotKey(bucket, activeVal)
+	return c.getSnapshotVersion(ctx, bucket, activeVal)
+}
+
+func (c *schedulerCache) getSnapshotVersion(ctx context.Context, bucket service.SchedulerBucket, version string) ([]*service.Account, bool, error) {
+	snapshotKey := schedulerSnapshotKey(bucket, version)
 	ids, err := c.rdb.ZRange(ctx, snapshotKey, 0, -1).Result()
 	if err != nil {
 		return nil, false, err
@@ -277,6 +362,189 @@ func (c *schedulerCache) GetSnapshot(ctx context.Context, bucket service.Schedul
 	}
 
 	return accounts, true, nil
+}
+
+func (c *schedulerCache) getSnapshotWithLocalCache(ctx context.Context, bucket service.SchedulerBucket) ([]*service.Account, bool, string, error) {
+	state, ready, cacheable, err := c.readSnapshotState(ctx, bucket)
+	if err != nil {
+		return nil, false, "local_miss", err
+	}
+	if !ready {
+		c.dropLocalSnapshot(bucket)
+		return nil, false, "local_miss", nil
+	}
+	if !cacheable {
+		c.dropLocalSnapshot(bucket)
+		accounts, hit, err := c.getSnapshotLegacy(ctx, bucket)
+		return accounts, hit, "local_bypass", err
+	}
+	if accounts, ok := c.getLocalSnapshot(bucket, state); ok {
+		return accounts, true, "local_hit", nil
+	}
+
+	flightKey := fmt.Sprintf("%s|%d|%s|%d", bucket.String(), state.epoch, state.version, state.metadataRevision)
+	value, err, _ := c.localSnapshotGroup.Do(flightKey, func() (any, error) {
+		if accounts, ok := c.getLocalSnapshot(bucket, state); ok {
+			return snapshotLoadResult{accounts: accounts, hit: true}, nil
+		}
+
+		accounts, hit, err := c.getSnapshotVersion(ctx, bucket, state.version)
+		if err != nil || !hit {
+			return snapshotLoadResult{accounts: accounts, hit: hit}, err
+		}
+
+		after, afterReady, afterCacheable, stateErr := c.readSnapshotState(ctx, bucket)
+		if stateErr == nil && afterReady && afterCacheable && after == state {
+			c.storeLocalSnapshot(bucket, state, accounts)
+		}
+		// A control read failure or a concurrent publish must not turn this
+		// request into a new error; the existing reader may finish its old version,
+		// but the result is never retained as a local entry.
+		return snapshotLoadResult{accounts: accounts, hit: true}, nil
+	})
+	if err != nil {
+		return nil, false, "local_miss", err
+	}
+	result, ok := value.(snapshotLoadResult)
+	if !ok {
+		return nil, false, "local_miss", nil
+	}
+	return copySnapshotAccountPointers(result.accounts), result.hit, "local_miss", nil
+}
+
+func (c *schedulerCache) readSnapshotState(ctx context.Context, bucket service.SchedulerBucket) (schedulerSnapshotState, bool, bool, error) {
+	pipe := c.rdb.Pipeline()
+	readyCmd := pipe.Get(ctx, schedulerBucketKey(schedulerReadyPrefix, bucket))
+	activeCmd := pipe.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket))
+	epochCmd := pipe.Get(ctx, schedulerBucketKey(schedulerEpochPrefix, bucket))
+	revisionCmd := pipe.Get(ctx, schedulerMetadataRevisionKey)
+	if _, err := pipe.Exec(ctx); err != nil && !errors.Is(err, redis.Nil) {
+		return schedulerSnapshotState{}, false, false, err
+	}
+
+	ready, err := readyCmd.Result()
+	if errors.Is(err, redis.Nil) {
+		return schedulerSnapshotState{}, false, false, nil
+	}
+	if err != nil {
+		return schedulerSnapshotState{}, false, false, err
+	}
+	if ready != "1" {
+		return schedulerSnapshotState{}, false, false, nil
+	}
+
+	version, err := activeCmd.Result()
+	if errors.Is(err, redis.Nil) {
+		return schedulerSnapshotState{}, false, false, nil
+	}
+	if err != nil {
+		return schedulerSnapshotState{}, false, false, err
+	}
+
+	epochRaw, err := epochCmd.Result()
+	if errors.Is(err, redis.Nil) {
+		return schedulerSnapshotState{}, true, false, nil
+	}
+	if err != nil {
+		return schedulerSnapshotState{}, false, false, err
+	}
+	epoch, err := strconv.ParseInt(epochRaw, 10, 64)
+	if err != nil || epoch < 1 {
+		return schedulerSnapshotState{}, true, false, nil
+	}
+
+	metadataRevision := int64(0)
+	if revisionRaw, revisionErr := revisionCmd.Result(); revisionErr == nil {
+		metadataRevision, err = strconv.ParseInt(revisionRaw, 10, 64)
+		if err != nil || metadataRevision < 0 {
+			return schedulerSnapshotState{}, true, false, nil
+		}
+	} else if !errors.Is(revisionErr, redis.Nil) {
+		return schedulerSnapshotState{}, false, false, revisionErr
+	}
+
+	return schedulerSnapshotState{
+		version:          version,
+		epoch:            epoch,
+		metadataRevision: metadataRevision,
+	}, true, true, nil
+}
+
+func (c *schedulerCache) getLocalSnapshot(bucket service.SchedulerBucket, state schedulerSnapshotState) ([]*service.Account, bool) {
+	now := time.Now()
+	c.localSnapshotMu.Lock()
+	defer c.localSnapshotMu.Unlock()
+
+	entry, ok := c.localSnapshots[bucket]
+	if !ok {
+		return nil, false
+	}
+	if entry.state == state && now.Before(entry.expiresAt) {
+		return copySnapshotAccountPointers(entry.accounts), true
+	}
+	c.removeLocalSnapshotLocked(bucket)
+	return nil, false
+}
+
+func (c *schedulerCache) storeLocalSnapshot(bucket service.SchedulerBucket, state schedulerSnapshotState, accounts []*service.Account) {
+	if len(accounts) == 0 || len(accounts) > maxLocalSnapshotAccounts {
+		return
+	}
+
+	c.localSnapshotMu.Lock()
+	defer c.localSnapshotMu.Unlock()
+	if c.localSnapshots == nil {
+		c.localSnapshots = make(map[service.SchedulerBucket]localSnapshotEntry)
+	}
+	c.removeLocalSnapshotLocked(bucket)
+
+	now := time.Now()
+	for key, entry := range c.localSnapshots {
+		if !now.Before(entry.expiresAt) {
+			c.removeLocalSnapshotLocked(key)
+		}
+	}
+	for c.localSnapshotAccounts+len(accounts) > maxLocalSnapshotAccounts && len(c.localSnapshots) > 0 {
+		for key := range c.localSnapshots {
+			c.removeLocalSnapshotLocked(key)
+			break
+		}
+	}
+	if c.localSnapshotAccounts+len(accounts) > maxLocalSnapshotAccounts {
+		return
+	}
+	c.localSnapshots[bucket] = localSnapshotEntry{
+		state:     state,
+		accounts:  copySnapshotAccountPointers(accounts),
+		expiresAt: now.Add(localSnapshotCacheTTL),
+	}
+	c.localSnapshotAccounts += len(accounts)
+}
+
+func (c *schedulerCache) dropLocalSnapshot(bucket service.SchedulerBucket) {
+	c.localSnapshotMu.Lock()
+	c.removeLocalSnapshotLocked(bucket)
+	c.localSnapshotMu.Unlock()
+}
+
+func (c *schedulerCache) removeLocalSnapshotLocked(bucket service.SchedulerBucket) bool {
+	entry, ok := c.localSnapshots[bucket]
+	if !ok {
+		return false
+	}
+	delete(c.localSnapshots, bucket)
+	c.localSnapshotAccounts -= len(entry.accounts)
+	if c.localSnapshotAccounts < 0 {
+		c.localSnapshotAccounts = 0
+	}
+	service.RecordSchedulerSnapshotLocalInvalidation()
+	return true
+}
+
+func copySnapshotAccountPointers(accounts []*service.Account) []*service.Account {
+	// Decoded account values are immutable in the scheduling read path. Copy the
+	// pointer slice so caller sorting/replacement cannot mutate the cached order.
+	return append([]*service.Account(nil), accounts...)
 }
 
 func (c *schedulerCache) CaptureBucketWriteToken(ctx context.Context, bucket service.SchedulerBucket) (service.SchedulerBucketWriteToken, error) {
@@ -567,7 +835,11 @@ func (c *schedulerCache) DeleteAccount(ctx context.Context, accountID int64) err
 		return nil
 	}
 	id := strconv.FormatInt(accountID, 10)
-	return c.rdb.Del(ctx, schedulerAccountKey(id), schedulerAccountMetaKey(id)).Err()
+	pipe := c.rdb.TxPipeline()
+	pipe.Del(ctx, schedulerAccountKey(id), schedulerAccountMetaKey(id))
+	pipe.Incr(ctx, schedulerMetadataRevisionKey)
+	_, err := pipe.Exec(ctx)
+	return err
 }
 
 func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]time.Time) error {
@@ -587,7 +859,8 @@ func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]t
 		return err
 	}
 
-	pipe := c.rdb.Pipeline()
+	pipe := c.rdb.TxPipeline()
+	changed := false
 	for i, val := range values {
 		if val == nil {
 			continue
@@ -596,7 +869,11 @@ func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]t
 		if err != nil {
 			return err
 		}
-		account.LastUsedAt = ptrTime(updates[ids[i]])
+		lastUsed := updates[ids[i]]
+		if account.LastUsedAt != nil && !lastUsed.After(*account.LastUsedAt) {
+			continue
+		}
+		account.LastUsedAt = ptrTime(lastUsed)
 		updated, metaPayload, err := marshalSchedulerCacheAccount(*account)
 		if err != nil {
 			slog.Warn("scheduler cache removes account with unencodable payload",
@@ -604,11 +881,17 @@ func (c *schedulerCache) UpdateLastUsed(ctx context.Context, updates map[int64]t
 				"error", err,
 			)
 			pipe.Del(ctx, keys[i], schedulerAccountMetaKey(strconv.FormatInt(ids[i], 10)))
+			changed = true
 			continue
 		}
 		pipe.Set(ctx, keys[i], updated, 0)
 		pipe.Set(ctx, schedulerAccountMetaKey(strconv.FormatInt(ids[i], 10)), metaPayload, 0)
+		changed = true
 	}
+	if !changed {
+		return nil
+	}
+	pipe.Incr(ctx, schedulerMetadataRevisionKey)
 	_, err = pipe.Exec(ctx)
 	return err
 }
@@ -655,7 +938,31 @@ func (c *schedulerCache) GetOutboxWatermark(ctx context.Context) (int64, error) 
 }
 
 func (c *schedulerCache) SetOutboxWatermark(ctx context.Context, id int64) error {
-	return c.rdb.Set(ctx, schedulerOutboxWatermarkKey, strconv.FormatInt(id, 10), 0).Err()
+	if id <= 0 {
+		return nil
+	}
+	return setOutboxWatermarkScript.Run(ctx, c.rdb, []string{schedulerOutboxWatermarkKey}, id).Err()
+}
+
+func (c *schedulerCache) RemoveAccountFromBucket(ctx context.Context, bucket service.SchedulerBucket, token service.SchedulerBucketWriteToken, accountID int64) (bool, error) {
+	if accountID <= 0 || !token.ValidFor(bucket) {
+		return false, fmt.Errorf("%w: bucket=%s", service.ErrSchedulerBucketWriteFenced, bucket.String())
+	}
+	snapshotKeyPrefix := fmt.Sprintf("%s%d:%s:%s:v", schedulerSnapshotPrefix, bucket.GroupID, bucket.Platform, bucket.Mode)
+	result, err := removeSnapshotAccountScript.Run(ctx, c.rdb, []string{
+		schedulerBucketKey(schedulerActivePrefix, bucket),
+		schedulerBucketKey(schedulerReadyPrefix, bucket),
+		schedulerBucketKey(schedulerEpochPrefix, bucket),
+		schedulerBucketKey(schedulerRetiredPrefix, bucket),
+	}, snapshotKeyPrefix, token.Epoch, accountID).Int64()
+	if err != nil {
+		return false, err
+	}
+	if err := schedulerBucketWriteResultError(result, bucket); err != nil {
+		return false, err
+	}
+	c.dropLocalSnapshot(bucket)
+	return result > 0, nil
 }
 
 func schedulerBucketKey(prefix string, bucket service.SchedulerBucket) string {
@@ -704,17 +1011,20 @@ func (c *schedulerCache) writeAccountIDs(ctx context.Context, accounts []service
 		return nil, nil
 	}
 
-	pipe := c.rdb.Pipeline()
+	pipe := c.rdb.TxPipeline()
 	accountIDs := make([]int64, 0, len(accounts))
 	pending := 0
 	flush := func() error {
 		if pending == 0 {
 			return nil
 		}
+		// Keep the invalidation marker in the same transaction as the metadata writes.
+		// Readers then observe either the old batch/revision or the new batch/revision.
+		pipe.Incr(ctx, schedulerMetadataRevisionKey)
 		if _, err := pipe.Exec(ctx); err != nil {
 			return err
 		}
-		pipe = c.rdb.Pipeline()
+		pipe = c.rdb.TxPipeline()
 		pending = 0
 		return nil
 	}

--- a/backend/internal/repository/scheduler_cache_incremental_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_incremental_unit_test.go
@@ -1,0 +1,95 @@
+//go:build unit
+
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchedulerCacheRemoveAccountFromBucketFencesOlderWriter(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	bucket := service.SchedulerBucket{GroupID: 81, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{ID: 8101, Platform: service.PlatformOpenAI, Status: service.StatusActive, Schedulable: true}
+
+	oldToken, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account}))
+
+	removed, err := cache.RemoveAccountFromBucket(ctx, bucket, oldToken, account.ID)
+	require.NoError(t, err)
+	require.True(t, removed)
+
+	err = cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{account})
+	require.ErrorIs(t, err, service.ErrSchedulerBucketWriteFenced)
+
+	freshToken, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.Greater(t, freshToken.Epoch, oldToken.Epoch)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, freshToken, []service.Account{account}))
+}
+
+func TestSchedulerCacheRemoveAccountFromUnreadyBucketStillFencesWriter(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	bucket := service.SchedulerBucket{GroupID: 82, Platform: service.PlatformGrok, Mode: service.SchedulerModeForced}
+
+	oldToken, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	removed, err := cache.RemoveAccountFromBucket(ctx, bucket, oldToken, 8201)
+	require.NoError(t, err)
+	require.False(t, removed)
+
+	err = cache.SetSnapshot(ctx, bucket, oldToken, []service.Account{{ID: 8201, Platform: service.PlatformGrok}})
+	require.ErrorIs(t, err, service.ErrSchedulerBucketWriteFenced)
+}
+
+func TestSchedulerCacheOutboxWatermarkNeverMovesBackward(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+
+	require.NoError(t, cache.SetOutboxWatermark(ctx, 20))
+	require.NoError(t, cache.SetOutboxWatermark(ctx, 12))
+	watermark, err := cache.GetOutboxWatermark(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 20, watermark)
+
+	require.NoError(t, cache.SetOutboxWatermark(ctx, 21))
+	watermark, err = cache.GetOutboxWatermark(ctx)
+	require.NoError(t, err)
+	require.EqualValues(t, 21, watermark)
+}
+
+func TestSchedulerCacheUpdateLastUsedIsMonotonic(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	initial := time.Unix(200, 0).UTC()
+	account := service.Account{ID: 8301, Platform: service.PlatformOpenAI, LastUsedAt: &initial}
+	require.NoError(t, cache.SetAccount(ctx, &account))
+	revisionBefore, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+
+	require.NoError(t, cache.UpdateLastUsed(ctx, map[int64]time.Time{account.ID: time.Unix(100, 0).UTC()}))
+	unchanged, err := cache.GetAccount(ctx, account.ID)
+	require.NoError(t, err)
+	require.NotNil(t, unchanged)
+	require.Equal(t, initial, *unchanged.LastUsedAt)
+	revisionAfterOldUpdate, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Equal(t, revisionBefore, revisionAfterOldUpdate)
+
+	newer := time.Unix(300, 0).UTC()
+	require.NoError(t, cache.UpdateLastUsed(ctx, map[int64]time.Time{account.ID: newer}))
+	updated, err := cache.GetAccount(ctx, account.ID)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	require.Equal(t, newer, *updated.LastUsedAt)
+	revisionAfterNewUpdate, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Greater(t, revisionAfterNewUpdate, revisionAfterOldUpdate)
+}

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -7,11 +7,15 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/config"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
@@ -28,9 +32,373 @@ func newSchedulerCacheUnitWithRedis(t *testing.T) (*schedulerCache, *miniredis.M
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	t.Cleanup(func() { _ = rdb.Close() })
-	cache, ok := newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize).(*schedulerCache)
-	require.True(t, ok)
+	cache := newSchedulerCacheWithChunkSizes(rdb, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
 	return cache, mr
+}
+
+func newLocalSchedulerCacheUnitWithRedis(t *testing.T) (*schedulerCache, *miniredis.Miniredis) {
+	cache, mr := newSchedulerCacheUnitWithRedis(t)
+	cache.localSnapshotEnabled = true
+	return cache, mr
+}
+
+type blockingZRangeHook struct {
+	once        sync.Once
+	entered     chan struct{}
+	release     chan struct{}
+	zrangeCalls atomic.Int64
+}
+
+func (h *blockingZRangeHook) DialHook(next redis.DialHook) redis.DialHook {
+	return next
+}
+
+func (h *blockingZRangeHook) ProcessHook(next redis.ProcessHook) redis.ProcessHook {
+	return func(ctx context.Context, cmd redis.Cmder) error {
+		if cmd.Name() == "zrange" {
+			h.zrangeCalls.Add(1)
+			h.once.Do(func() {
+				close(h.entered)
+				select {
+				case <-h.release:
+				case <-ctx.Done():
+				}
+			})
+		}
+		return next(ctx, cmd)
+	}
+}
+
+func (h *blockingZRangeHook) ProcessPipelineHook(next redis.ProcessPipelineHook) redis.ProcessPipelineHook {
+	return next
+}
+
+func TestSchedulerCacheLocalSnapshotInvalidatesAcrossInstancesOnMetadataRevision(t *testing.T) {
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdbA := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	rdbB := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		_ = rdbA.Close()
+		_ = rdbB.Close()
+	})
+	cacheA := newSchedulerCacheWithChunkSizes(rdbA, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
+	cacheB := newSchedulerCacheWithChunkSizes(rdbB, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
+	cacheA.localSnapshotEnabled = true
+	cacheB.localSnapshotEnabled = true
+
+	bucket := service.SchedulerBucket{GroupID: 1001, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{ID: 1002, Name: "before", Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey, Priority: 1}
+	token, err := cacheA.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cacheA.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+	require.NoError(t, rdbA.Del(ctx, schedulerMetadataRevisionKey).Err(), "existing Redis data may not have a revision key")
+	beforeMetrics := service.GetSchedulerOptimizationMetricsSnapshot()
+
+	first, hit, err := cacheB.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, "before", first[0].Name)
+	require.Len(t, cacheB.localSnapshots, 1)
+	first[0] = nil
+	unchanged, hit, err := cacheB.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.NotNil(t, unchanged[0], "caller slice mutation must not alter the retained snapshot")
+	require.Equal(t, "before", unchanged[0].Name)
+
+	activeBefore, err := rdbA.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket)).Result()
+	require.NoError(t, err)
+	account.Name = "after"
+	account.Priority = 9
+	require.NoError(t, cacheA.SetAccount(ctx, &account))
+	activeAfter, err := rdbA.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket)).Result()
+	require.NoError(t, err)
+	require.Equal(t, activeBefore, activeAfter, "metadata-only update must not require a bucket version change")
+
+	second, hit, err := cacheB.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Equal(t, "after", second[0].Name)
+	require.Equal(t, 9, second[0].Priority)
+	afterMetrics := service.GetSchedulerOptimizationMetricsSnapshot()
+	require.Equal(t, beforeMetrics.Snapshot.ReadTotal+3, afterMetrics.Snapshot.ReadTotal)
+	require.Equal(t, beforeMetrics.Snapshot.LocalMissTotal+2, afterMetrics.Snapshot.LocalMissTotal)
+	require.Equal(t, beforeMetrics.Snapshot.LocalHitTotal+1, afterMetrics.Snapshot.LocalHitTotal)
+	require.Equal(t, beforeMetrics.Snapshot.LocalInvalidationTotal+1, afterMetrics.Snapshot.LocalInvalidationTotal)
+}
+
+func TestSchedulerCacheLocalSnapshotPreservesFullPoolAtScale(t *testing.T) {
+	if os.Getenv("SCHEDULER_STRESS_TEST") != "1" {
+		t.Skip("set SCHEDULER_STRESS_TEST=1 to run the 20,000-account snapshot test")
+	}
+
+	ctx := context.Background()
+	mr := miniredis.RunT(t)
+	rdbA := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	rdbB := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		_ = rdbA.Close()
+		_ = rdbB.Close()
+	})
+	cacheA := newSchedulerCacheWithChunkSizes(rdbA, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
+	cacheB := newSchedulerCacheWithChunkSizes(rdbB, defaultSchedulerSnapshotMGetChunkSize, defaultSchedulerSnapshotWriteChunkSize)
+	cacheA.localSnapshotEnabled = true
+	cacheB.localSnapshotEnabled = true
+
+	bucket := service.SchedulerBucket{GroupID: 1061, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	accounts := make([]service.Account, maxLocalSnapshotAccounts)
+	for i := range accounts {
+		accounts[i] = service.Account{
+			ID:          int64(i + 1),
+			Name:        fmt.Sprintf("account-%d", i+1),
+			Platform:    service.PlatformOpenAI,
+			Type:        service.AccountTypeAPIKey,
+			Status:      service.StatusActive,
+			Schedulable: true,
+			Priority:    i,
+		}
+	}
+	token, err := cacheA.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cacheA.SetSnapshot(ctx, bucket, token, accounts))
+
+	redisStarted := time.Now()
+	first, hit, err := cacheB.GetSnapshot(ctx, bucket)
+	redisDuration := time.Since(redisStarted)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, first, maxLocalSnapshotAccounts)
+	require.Equal(t, int64(257), first[256].ID)
+	require.Equal(t, int64(maxLocalSnapshotAccounts), first[len(first)-1].ID)
+
+	localStarted := time.Now()
+	second, hit, err := cacheB.GetSnapshot(ctx, bucket)
+	localDuration := time.Since(localStarted)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, second, maxLocalSnapshotAccounts)
+
+	last := accounts[len(accounts)-1]
+	last.Name = "updated-by-other-instance"
+	require.NoError(t, cacheA.SetAccount(ctx, &last))
+	invalidatedStarted := time.Now()
+	refreshed, hit, err := cacheB.GetSnapshot(ctx, bucket)
+	invalidatedDuration := time.Since(invalidatedStarted)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, refreshed, maxLocalSnapshotAccounts)
+	require.Equal(t, "updated-by-other-instance", refreshed[len(refreshed)-1].Name)
+	t.Logf("accounts=%d redis_read=%s local_hit=%s invalidated_read=%s", maxLocalSnapshotAccounts, redisDuration, localDuration, invalidatedDuration)
+}
+
+func TestSchedulerCacheMetadataRevisionAdvancesForDirectWrites(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	account := service.Account{ID: 1003, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+
+	require.NoError(t, cache.SetAccount(ctx, &account))
+	afterSet, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Positive(t, afterSet)
+
+	require.NoError(t, cache.UpdateLastUsed(ctx, map[int64]time.Time{account.ID: time.Now()}))
+	afterLastUsed, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Greater(t, afterLastUsed, afterSet)
+
+	require.NoError(t, cache.DeleteAccount(ctx, account.ID))
+	afterDelete, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Greater(t, afterDelete, afterLastUsed)
+}
+
+func TestSchedulerCacheMetadataRevisionAdvancesWithEachWriteBatch(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	cache.writeChunkSize = 1
+
+	_, err := cache.writeAccountIDs(ctx, []service.Account{
+		{ID: 1004, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey},
+		{ID: 1005, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey},
+	})
+	require.NoError(t, err)
+
+	revision, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Equal(t, int64(2), revision)
+}
+
+func TestSchedulerCacheLocalSnapshotDoesNotSurviveRetire(t *testing.T) {
+	ctx := context.Background()
+	cache, _ := newLocalSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 1011, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{ID: 1012, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+	_, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+
+	require.NoError(t, cache.RetireBucket(ctx, bucket))
+	_, hit, err = cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.False(t, hit)
+	require.Empty(t, cache.localSnapshots)
+
+	reopened, err := cache.ReopenBucket(ctx, bucket)
+	require.NoError(t, err)
+	require.Greater(t, reopened.Epoch, token.Epoch)
+	require.NoError(t, cache.SetSnapshotByAccountIDs(ctx, bucket, reopened, []int64{account.ID}))
+	_, hit, err = cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+}
+
+func TestSchedulerCacheLocalSnapshotInvalidatesOnActiveVersionChange(t *testing.T) {
+	ctx := context.Background()
+	cache, _ := newLocalSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 1041, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	accounts := []service.Account{
+		{ID: 1042, Name: "first", Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey},
+		{ID: 1043, Name: "second", Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey},
+	}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, accounts))
+	first, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, first, 2)
+
+	activeVersion, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket)).Result()
+	require.NoError(t, err)
+	revisionBefore, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshotByAccountIDs(ctx, bucket, token, []int64{accounts[1].ID}))
+	newVersion, err := cache.rdb.Get(ctx, schedulerBucketKey(schedulerActivePrefix, bucket)).Result()
+	require.NoError(t, err)
+	require.NotEqual(t, activeVersion, newVersion)
+	revisionAfter, err := cache.rdb.Get(ctx, schedulerMetadataRevisionKey).Int64()
+	require.NoError(t, err)
+	require.Equal(t, revisionBefore, revisionAfter, "ID-only publish should invalidate by active version, not metadata revision")
+
+	second, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.Len(t, second, 1)
+	require.Equal(t, accounts[1].ID, second[0].ID)
+}
+
+func TestSchedulerCacheLocalSnapshotControlReadErrorDoesNotServeStaleData(t *testing.T) {
+	ctx := context.Background()
+	cache, _ := newLocalSchedulerCacheUnitWithRedis(t)
+	bucket := service.SchedulerBucket{GroupID: 1021, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{ID: 1022, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+	_, hit, err := cache.GetSnapshot(ctx, bucket)
+	require.NoError(t, err)
+	require.True(t, hit)
+	require.NoError(t, cache.rdb.Close())
+
+	_, hit, err = cache.GetSnapshot(ctx, bucket)
+	require.Error(t, err)
+	require.False(t, hit)
+}
+
+func TestSchedulerCacheLocalSnapshotSkipsOversizedEntry(t *testing.T) {
+	cache := &schedulerCache{
+		localSnapshots: make(map[service.SchedulerBucket]localSnapshotEntry),
+	}
+	accounts := make([]*service.Account, maxLocalSnapshotAccounts+1)
+	for i := range accounts {
+		accounts[i] = &service.Account{ID: int64(i + 1)}
+	}
+	bucket := service.SchedulerBucket{GroupID: 1031, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	cache.storeLocalSnapshot(bucket, schedulerSnapshotState{version: "1", epoch: 1}, accounts)
+	require.Empty(t, cache.localSnapshots)
+	require.Zero(t, cache.localSnapshotAccounts)
+}
+
+func TestSchedulerCacheLocalSnapshotExpires(t *testing.T) {
+	bucket := service.SchedulerBucket{GroupID: 1032, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	state := schedulerSnapshotState{version: "1", epoch: 1, metadataRevision: 1}
+	cache := &schedulerCache{
+		localSnapshots: map[service.SchedulerBucket]localSnapshotEntry{
+			bucket: {state: state, accounts: []*service.Account{{ID: 1033}}, expiresAt: time.Now().Add(-time.Second)},
+		},
+		localSnapshotAccounts: 1,
+	}
+
+	accounts, ok := cache.getLocalSnapshot(bucket, state)
+	require.False(t, ok)
+	require.Nil(t, accounts)
+	require.Empty(t, cache.localSnapshots)
+	require.Zero(t, cache.localSnapshotAccounts)
+}
+
+func TestSchedulerCacheLocalSnapshotCoalescesConcurrentMisses(t *testing.T) {
+	ctx := context.Background()
+	cache := newSchedulerCacheUnit(t)
+	bucket := service.SchedulerBucket{GroupID: 1051, Platform: service.PlatformOpenAI, Mode: service.SchedulerModeSingle}
+	account := service.Account{ID: 1052, Platform: service.PlatformOpenAI, Type: service.AccountTypeAPIKey}
+	token, err := cache.CaptureBucketWriteToken(ctx, bucket)
+	require.NoError(t, err)
+	require.NoError(t, cache.SetSnapshot(ctx, bucket, token, []service.Account{account}))
+	cache.localSnapshotEnabled = true
+
+	hook := &blockingZRangeHook{entered: make(chan struct{}), release: make(chan struct{})}
+	cache.rdb.AddHook(hook)
+	const callers = 16
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	results := make([][]*service.Account, callers)
+	var wg sync.WaitGroup
+	for i := range callers {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			accounts, hit, err := cache.GetSnapshot(ctx, bucket)
+			if err == nil && (!hit || len(accounts) != 1) {
+				err = fmt.Errorf("snapshot result: hit=%v count=%d", hit, len(accounts))
+			}
+			results[index] = accounts
+			errs <- err
+		}(i)
+	}
+	close(start)
+	select {
+	case <-hook.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot load")
+	}
+	close(hook.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(1), hook.zrangeCalls.Load())
+	results[0][0] = nil
+	require.NotNil(t, results[1][0], "singleflight callers must receive independent result slices")
+}
+
+func TestProvideSchedulerCacheReadsLocalSnapshotConfig(t *testing.T) {
+	cache := newSchedulerCacheUnit(t)
+	cfg := &config.Config{}
+	cfg.Gateway.Scheduling.SnapshotLocalCacheEnabled = true
+	cfg.Gateway.Scheduling.SnapshotMGetChunkSize = 17
+	cfg.Gateway.Scheduling.SnapshotWriteChunkSize = 19
+
+	provided, ok := ProvideSchedulerCache(cache.rdb, cfg).(*schedulerCache)
+	require.True(t, ok)
+	require.True(t, provided.localSnapshotEnabled)
+	require.Equal(t, 17, provided.mgetChunkSize)
+	require.Equal(t, 19, provided.writeChunkSize)
 }
 
 func TestSchedulerCacheWriteAccountIDsSkipsUnencodableTimes(t *testing.T) {

--- a/backend/internal/repository/scheduler_load_batch_benchmark_test.go
+++ b/backend/internal/repository/scheduler_load_batch_benchmark_test.go
@@ -1,0 +1,235 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/redis/go-redis/v9"
+)
+
+var schedulerLoadBatchBenchmarkSink int
+
+func TestSchedulerLoadBatchRealRedisParity(t *testing.T) {
+	rdb := newBenchmarkRedisClient(t)
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	for _, size := range []int{1_000, 8_000, 20_000} {
+		t.Run(fmt.Sprintf("n_%d", size), func(t *testing.T) {
+			baseID := time.Now().UnixNano()
+			accounts := make([]service.AccountWithConcurrency, size)
+			for start := 0; start < size; start += 1_000 {
+				end := min(start+1_000, size)
+				pipe := rdb.Pipeline()
+				for i := start; i < end; i++ {
+					id := baseID + int64(i) + 1
+					accounts[i] = service.AccountWithConcurrency{ID: id, MaxConcurrency: i%8 + 1}
+					members := []redis.Z{{Score: float64(time.Now().Add(-benchSlotTTL - time.Second).Unix()), Member: "expired"}}
+					for slot := 0; slot < i%4; slot++ {
+						members = append(members, redis.Z{Score: float64(time.Now().Unix()), Member: fmt.Sprintf("live-%d", slot)})
+					}
+					pipe.ZAdd(ctx, accountSlotKey(id), members...)
+					if i%5 != 0 {
+						pipe.Set(ctx, accountWaitKey(id), strconv.Itoa(i%5-1), benchSlotTTL)
+					}
+				}
+				if _, err := pipe.Exec(ctx); err != nil {
+					t.Fatalf("seed Redis data: %v", err)
+				}
+			}
+			defer cleanupSchedulerLoadBatchBenchmark(ctx, rdb, accounts)
+
+			pipelineCache := newConcurrencyCache(rdb, benchSlotTTLMinutes, int(benchSlotTTL.Seconds()))
+			pipelineStarted := time.Now()
+			want, err := pipelineCache.getAccountsLoadBatchPipeline(ctx, accounts)
+			if err != nil {
+				t.Fatalf("pipeline load: %v", err)
+			}
+			pipelineDuration := time.Since(pipelineStarted)
+
+			for start := 0; start < size; start += 1_000 {
+				end := min(start+1_000, size)
+				pipe := rdb.Pipeline()
+				for _, account := range accounts[start:end] {
+					pipe.ZAdd(ctx, accountSlotKey(account.ID), redis.Z{
+						Score:  float64(time.Now().Add(-benchSlotTTL - time.Second).Unix()),
+						Member: "expired-script",
+					})
+				}
+				if _, err := pipe.Exec(ctx); err != nil {
+					t.Fatalf("reseed expired slots: %v", err)
+				}
+			}
+
+			scriptCache := newConcurrencyCache(rdb, benchSlotTTLMinutes, int(benchSlotTTL.Seconds()))
+			scriptStarted := time.Now()
+			got, err := scriptCache.getAccountsLoadBatchScript(ctx, accounts, defaultAccountLoadBatchScriptChunkSize)
+			if err != nil {
+				t.Fatalf("script load: %v", err)
+			}
+			scriptDuration := time.Since(scriptStarted)
+			if len(got) != len(want) {
+				t.Fatalf("result size: script=%d pipeline=%d", len(got), len(want))
+			}
+			for _, account := range accounts {
+				if *got[account.ID] != *want[account.ID] {
+					t.Fatalf("account %d mismatch: script=%+v pipeline=%+v", account.ID, got[account.ID], want[account.ID])
+				}
+			}
+			t.Logf("accounts=%d pipeline=%s script256=%s speedup=%.2fx", size, pipelineDuration, scriptDuration, float64(pipelineDuration)/float64(scriptDuration))
+		})
+	}
+}
+
+func BenchmarkSchedulerLoadBatch(b *testing.B) {
+	rdb := newBenchmarkRedisClient(b)
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	for _, size := range []int{64, 256, 1_000, 3_131, 8_000, 20_000} {
+		size := size
+		b.Run(fmt.Sprintf("pipeline/n_%d", size), func(b *testing.B) {
+			cache, accounts := prepareSchedulerLoadBatchBenchmark(b, rdb, size, false, 0)
+			defer cleanupSchedulerLoadBatchBenchmark(ctx, rdb, accounts)
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.ReportMetric(float64(1+3*size), "redis_cmds/op")
+			for range b.N {
+				result, err := cache.GetAccountsLoadBatch(ctx, accounts)
+				if err != nil || len(result) != size {
+					b.Fatalf("pipeline load: count=%d err=%v", len(result), err)
+				}
+				schedulerLoadBatchBenchmarkSink = len(result)
+			}
+		})
+
+		for _, chunkSize := range []int{128, 256, 500, 1_000} {
+			chunkSize := chunkSize
+			b.Run(fmt.Sprintf("script%d/n_%d", chunkSize, size), func(b *testing.B) {
+				cache, accounts := prepareSchedulerLoadBatchBenchmark(b, rdb, size, true, chunkSize)
+				defer cleanupSchedulerLoadBatchBenchmark(ctx, rdb, accounts)
+				b.ReportAllocs()
+				b.ResetTimer()
+				b.ReportMetric(float64(1+(size+chunkSize-1)/chunkSize), "redis_cmds/op")
+				for range b.N {
+					result, err := cache.GetAccountsLoadBatch(ctx, accounts)
+					if err != nil || len(result) != size {
+						b.Fatalf("script load: count=%d err=%v", len(result), err)
+					}
+					schedulerLoadBatchBenchmarkSink = len(result)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkSchedulerLoadBatchConcurrent(b *testing.B) {
+	rdb := newBenchmarkRedisClient(b)
+	defer func() { _ = rdb.Close() }()
+	ctx := context.Background()
+
+	for _, size := range []int{1_000, 8_000, 20_000} {
+		for _, scriptEnabled := range []bool{false, true} {
+			path := "pipeline"
+			if scriptEnabled {
+				path = "script256"
+			}
+			for _, concurrency := range []int{1, 4, 16} {
+				b.Run(fmt.Sprintf("%s/n_%d/c_%d", path, size, concurrency), func(b *testing.B) {
+					cache, accounts := prepareSchedulerLoadBatchBenchmark(b, rdb, size, scriptEnabled, 256)
+					defer cleanupSchedulerLoadBatchBenchmark(ctx, rdb, accounts)
+					durations := make([]time.Duration, 0, b.N*concurrency)
+					b.ReportAllocs()
+					b.ResetTimer()
+					for range b.N {
+						start := make(chan struct{})
+						results := make(chan time.Duration, concurrency)
+						errs := make(chan error, concurrency)
+						var wg sync.WaitGroup
+						for range concurrency {
+							wg.Add(1)
+							go func() {
+								defer wg.Done()
+								<-start
+								startedAt := time.Now()
+								result, err := cache.GetAccountsLoadBatch(ctx, accounts)
+								results <- time.Since(startedAt)
+								if err != nil {
+									errs <- err
+									return
+								}
+								if len(result) != size {
+									errs <- fmt.Errorf("count=%d want=%d", len(result), size)
+								}
+							}()
+						}
+						close(start)
+						wg.Wait()
+						close(results)
+						close(errs)
+						for err := range errs {
+							b.Fatalf("concurrent load: %v", err)
+						}
+						for duration := range results {
+							durations = append(durations, duration)
+						}
+					}
+					b.StopTimer()
+					sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+					b.ReportMetric(float64(concurrency), "requests/op")
+					b.ReportMetric(durationPercentileMillis(durations, 50), "p50_ms")
+					b.ReportMetric(durationPercentileMillis(durations, 95), "p95_ms")
+					b.ReportMetric(durationPercentileMillis(durations, 99), "p99_ms")
+				})
+			}
+		}
+	}
+}
+
+func durationPercentileMillis(values []time.Duration, percentile int) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	index := (len(values)*percentile + 99) / 100
+	index = min(max(index, 1), len(values)) - 1
+	return float64(values[index]) / float64(time.Millisecond)
+}
+
+func prepareSchedulerLoadBatchBenchmark(b *testing.B, rdb *redis.Client, size int, scriptEnabled bool, chunkSize int) (*concurrencyCache, []service.AccountWithConcurrency) {
+	b.Helper()
+	baseID := time.Now().UnixNano()
+	accounts := make([]service.AccountWithConcurrency, size)
+	pipe := rdb.Pipeline()
+	for i := range accounts {
+		id := baseID + int64(i) + 1
+		accounts[i] = service.AccountWithConcurrency{ID: id, MaxConcurrency: 10}
+		pipe.ZAdd(context.Background(), accountSlotKey(id), redis.Z{Score: float64(time.Now().Unix()), Member: "benchmark-live"})
+	}
+	if _, err := pipe.Exec(context.Background()); err != nil {
+		b.Fatalf("seed load keys: %v", err)
+	}
+	cache := newConcurrencyCache(rdb, benchSlotTTLMinutes, int(benchSlotTTL.Seconds()))
+	cache.loadBatchScriptEnabled = scriptEnabled
+	if chunkSize > 0 {
+		cache.loadBatchScriptChunkSize = chunkSize
+	}
+	return cache, accounts
+}
+
+func cleanupSchedulerLoadBatchBenchmark(ctx context.Context, rdb *redis.Client, accounts []service.AccountWithConcurrency) {
+	keys := make([]string, 0, len(accounts)*2)
+	for _, account := range accounts {
+		id := strconv.FormatInt(account.ID, 10)
+		keys = append(keys, accountSlotKeyPrefix+id, accountWaitKeyPrefix+id)
+	}
+	for start := 0; start < len(keys); start += 1_000 {
+		end := min(start+1_000, len(keys))
+		_ = rdb.Unlink(ctx, keys[start:end]...).Err()
+	}
+}

--- a/backend/internal/repository/wire.go
+++ b/backend/internal/repository/wire.go
@@ -23,7 +23,9 @@ func ProvideConcurrencyCache(rdb *redis.Client, cfg *config.Config) service.Conc
 	if waitTTLSeconds <= 0 {
 		waitTTLSeconds = cfg.Gateway.ConcurrencySlotTTLMinutes * 60
 	}
-	return NewConcurrencyCache(rdb, cfg.Gateway.ConcurrencySlotTTLMinutes, waitTTLSeconds)
+	cache := newConcurrencyCache(rdb, cfg.Gateway.ConcurrencySlotTTLMinutes, waitTTLSeconds)
+	cache.loadBatchScriptEnabled = cfg.Gateway.Scheduling.LoadBatchScriptEnabled
+	return cache
 }
 
 // ProvideGitHubReleaseClient 创建 GitHub Release 客户端
@@ -52,6 +54,7 @@ func ProvideSessionLimitCache(rdb *redis.Client, cfg *config.Config) service.Ses
 func ProvideSchedulerCache(rdb *redis.Client, cfg *config.Config) service.SchedulerCache {
 	mgetChunkSize := defaultSchedulerSnapshotMGetChunkSize
 	writeChunkSize := defaultSchedulerSnapshotWriteChunkSize
+	localSnapshotEnabled := false
 	if cfg != nil {
 		if cfg.Gateway.Scheduling.SnapshotMGetChunkSize > 0 {
 			mgetChunkSize = cfg.Gateway.Scheduling.SnapshotMGetChunkSize
@@ -59,8 +62,11 @@ func ProvideSchedulerCache(rdb *redis.Client, cfg *config.Config) service.Schedu
 		if cfg.Gateway.Scheduling.SnapshotWriteChunkSize > 0 {
 			writeChunkSize = cfg.Gateway.Scheduling.SnapshotWriteChunkSize
 		}
+		localSnapshotEnabled = cfg.Gateway.Scheduling.SnapshotLocalCacheEnabled
 	}
-	return newSchedulerCacheWithChunkSizes(rdb, mgetChunkSize, writeChunkSize)
+	cache := newSchedulerCacheWithChunkSizes(rdb, mgetChunkSize, writeChunkSize)
+	cache.localSnapshotEnabled = localSnapshotEnabled
+	return cache
 }
 
 // ProviderSet is the Wire provider set for all repositories

--- a/backend/internal/service/concurrency_service.go
+++ b/backend/internal/service/concurrency_service.go
@@ -583,18 +583,22 @@ func (s *ConcurrencyService) getAccountsLoadBatch(ctx context.Context, accounts 
 		return map[int64]*AccountLoadInfo{}, nil
 	}
 	if s.cache == nil {
+		RecordSchedulerLoadCache(false, true)
 		return map[int64]*AccountLoadInfo{}, nil
 	}
 
 	ttl := time.Duration(s.accountLoadCacheTTL.Load())
 	if !allowCache || ttl <= 0 {
+		RecordSchedulerLoadCache(false, true)
 		return s.fetchAccountsLoadBatch(ctx, accounts)
 	}
 
 	key := accountLoadBatchCacheKey(accounts)
 	if cached, ok := s.getCachedAccountLoadBatch(key, time.Now()); ok {
+		RecordSchedulerLoadCache(true, false)
 		return cached, nil
 	}
+	RecordSchedulerLoadCache(false, false)
 
 	value, err, _ := s.accountLoadGroup.Do(key, func() (any, error) {
 		now := time.Now()
@@ -606,7 +610,7 @@ func (s *ConcurrencyService) getAccountsLoadBatch(ctx context.Context, accounts 
 			return nil, fetchErr
 		}
 		cached := cloneAccountLoadMap(loadMap)
-		s.storeCachedAccountLoadBatch(key, cached, now.Add(ttl))
+		s.storeCachedAccountLoadBatch(key, cached, time.Now().Add(ttl))
 		return cached, nil
 	})
 	if err != nil {
@@ -623,13 +627,16 @@ func (s *ConcurrencyService) fetchAccountsLoadBatch(ctx context.Context, account
 	if s.cache == nil {
 		return map[int64]*AccountLoadInfo{}, nil
 	}
+	startedAt := time.Now()
 	baseCtx := context.Background()
 	if ctx != nil {
 		baseCtx = context.WithoutCancel(ctx)
 	}
 	redisCtx, cancel := context.WithTimeout(baseCtx, accountLoadBatchFetchTimeout)
 	defer cancel()
-	return s.cache.GetAccountsLoadBatch(redisCtx, accounts)
+	loadMap, err := s.cache.GetAccountsLoadBatch(redisCtx, accounts)
+	RecordSchedulerLoadBackend(len(accounts), time.Since(startedAt), err)
+	return loadMap, err
 }
 
 func (s *ConcurrencyService) getCachedAccountLoadBatch(key string, now time.Time) (map[int64]*AccountLoadInfo, bool) {

--- a/backend/internal/service/concurrency_service_test.go
+++ b/backend/internal/service/concurrency_service_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ type stubConcurrencyCacheForTest struct {
 	waitCountErr         error
 	loadBatch            map[int64]*AccountLoadInfo
 	loadBatchErr         error
+	loadBatchDelay       time.Duration
 	usersLoadBatch       map[int64]*UserLoadInfo
 	usersLoadErr         error
 	cleanupErr           error
@@ -152,8 +154,17 @@ func (c *stubConcurrencyCacheForTest) IncrementWaitCount(_ context.Context, _ in
 func (c *stubConcurrencyCacheForTest) DecrementWaitCount(_ context.Context, _ int64) error {
 	return nil
 }
-func (c *stubConcurrencyCacheForTest) GetAccountsLoadBatch(_ context.Context, _ []AccountWithConcurrency) (map[int64]*AccountLoadInfo, error) {
+func (c *stubConcurrencyCacheForTest) GetAccountsLoadBatch(ctx context.Context, _ []AccountWithConcurrency) (map[int64]*AccountLoadInfo, error) {
 	c.loadBatchCalls.Add(1)
+	if c.loadBatchDelay > 0 {
+		timer := time.NewTimer(c.loadBatchDelay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
 	return c.loadBatch, c.loadBatchErr
 }
 func (c *stubConcurrencyCacheForTest) GetUsersLoadBatch(_ context.Context, _ []UserWithConcurrency) (map[int64]*UserLoadInfo, error) {
@@ -485,6 +496,7 @@ func TestGetAccountsLoadBatch_UsesShortTTLCache(t *testing.T) {
 	}
 	svc := NewConcurrencyService(cache)
 	svc.SetAccountLoadBatchCacheTTL(time.Second)
+	before := GetSchedulerOptimizationMetricsSnapshot()
 
 	accounts := []AccountWithConcurrency{{ID: 1, MaxConcurrency: 5}}
 	first, err := svc.GetAccountsLoadBatch(context.Background(), accounts)
@@ -495,6 +507,59 @@ func TestGetAccountsLoadBatch_UsesShortTTLCache(t *testing.T) {
 	second, err := svc.GetAccountsLoadBatch(context.Background(), accounts)
 	require.NoError(t, err)
 	require.Equal(t, 1, second[int64(1)].CurrentConcurrency)
+	require.Equal(t, int64(1), cache.loadBatchCalls.Load())
+	after := GetSchedulerOptimizationMetricsSnapshot()
+	require.Equal(t, before.Load.RequestTotal+2, after.Load.RequestTotal)
+	require.Equal(t, before.Load.CacheMissTotal+1, after.Load.CacheMissTotal)
+	require.Equal(t, before.Load.CacheHitTotal+1, after.Load.CacheHitTotal)
+	require.Equal(t, before.Load.BackendFetchTotal+1, after.Load.BackendFetchTotal)
+}
+
+func TestGetAccountsLoadBatch_TTLStartsAfterSlowFetch(t *testing.T) {
+	cache := &stubConcurrencyCacheForTest{
+		loadBatch: map[int64]*AccountLoadInfo{
+			1: {AccountID: 1, CurrentConcurrency: 1, LoadRate: 20},
+		},
+		loadBatchDelay: 40 * time.Millisecond,
+	}
+	svc := NewConcurrencyService(cache)
+	svc.SetAccountLoadBatchCacheTTL(20 * time.Millisecond)
+	accounts := []AccountWithConcurrency{{ID: 1, MaxConcurrency: 5}}
+
+	_, err := svc.GetAccountsLoadBatch(context.Background(), accounts)
+	require.NoError(t, err)
+	_, err = svc.GetAccountsLoadBatch(context.Background(), accounts)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), cache.loadBatchCalls.Load())
+}
+
+func TestGetAccountsLoadBatch_CoalescesConcurrentMisses(t *testing.T) {
+	cache := &stubConcurrencyCacheForTest{
+		loadBatch:      map[int64]*AccountLoadInfo{1: {AccountID: 1, LoadRate: 20}},
+		loadBatchDelay: 40 * time.Millisecond,
+	}
+	svc := NewConcurrencyService(cache)
+	svc.SetAccountLoadBatchCacheTTL(time.Second)
+	accounts := []AccountWithConcurrency{{ID: 1, MaxConcurrency: 5}}
+	const callers = 8
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := svc.GetAccountsLoadBatch(context.Background(), accounts)
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
 	require.Equal(t, int64(1), cache.loadBatchCalls.Load())
 }
 

--- a/backend/internal/service/openai_account_db_batch_test.go
+++ b/backend/internal/service/openai_account_db_batch_test.go
@@ -1,0 +1,104 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type openAIAccountDBBatchRepo struct {
+	AccountRepository
+	accounts   map[int64]*Account
+	batchCalls [][]int64
+	errOnCall  int
+}
+
+func (r *openAIAccountDBBatchRepo) GetByIDs(_ context.Context, ids []int64) ([]*Account, error) {
+	r.batchCalls = append(r.batchCalls, append([]int64(nil), ids...))
+	if r.errOnCall == len(r.batchCalls) {
+		return nil, errors.New("db unavailable")
+	}
+	accounts := make([]*Account, 0, len(ids))
+	for _, id := range ids {
+		if account := r.accounts[id]; account != nil {
+			copy := *account
+			accounts = append(accounts, &copy)
+		}
+	}
+	return accounts, nil
+}
+
+func TestLoadOpenAIAccountDBBatchLoadsParentsOnce(t *testing.T) {
+	parentID := int64(10)
+	repo := &openAIAccountDBBatchRepo{accounts: map[int64]*Account{
+		1:  {ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, ParentAccountID: &parentID},
+		2:  {ID: 2, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, ParentAccountID: &parentID},
+		10: {ID: 10, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Status: StatusActive, Schedulable: true},
+	}}
+	service := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: &SchedulerSnapshotService{}}
+	before := GetSchedulerOptimizationMetricsSnapshot()
+
+	batch := service.loadOpenAIAccountDBBatch(context.Background(), []*Account{{ID: 1}, {ID: 2}, {ID: 1}})
+	require.NotNil(t, batch)
+	require.Equal(t, [][]int64{{1, 2}, {10}}, repo.batchCalls)
+	require.NotNil(t, batch.accounts[1])
+	require.NotNil(t, batch.parentLookup(10))
+	after := GetSchedulerOptimizationMetricsSnapshot()
+	require.Equal(t, before.Database.BatchTotal+1, after.Database.BatchTotal)
+	require.Equal(t, before.Database.QueryTotal+2, after.Database.QueryTotal)
+	require.Equal(t, before.Database.CandidateIDTotal+2, after.Database.CandidateIDTotal)
+	require.Equal(t, before.Database.ParentIDTotal+1, after.Database.ParentIDTotal)
+	require.Equal(t, before.Database.ReturnedAccountTotal+3, after.Database.ReturnedAccountTotal)
+}
+
+func TestLoadOpenAIAccountDBBatchParentFailureFailsClosed(t *testing.T) {
+	parentID := int64(10)
+	repo := &openAIAccountDBBatchRepo{
+		accounts: map[int64]*Account{
+			1: {ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, ParentAccountID: &parentID},
+		},
+		errOnCall: 2,
+	}
+	service := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: &SchedulerSnapshotService{}}
+	before := GetSchedulerOptimizationMetricsSnapshot()
+	batch := service.loadOpenAIAccountDBBatch(context.Background(), []*Account{{ID: 1}})
+
+	require.True(t, batch.failed)
+	require.Nil(t, service.recheckSelectedOpenAIAccountFromDBBatch(
+		context.Background(),
+		&Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey},
+		nil,
+		PlatformOpenAI,
+		"",
+		false,
+		OpenAIEndpointCapabilityChatCompletions,
+		batch,
+	))
+	after := GetSchedulerOptimizationMetricsSnapshot()
+	require.Equal(t, before.Database.ErrorTotal+1, after.Database.ErrorTotal)
+}
+
+func TestLoadOpenAIAccountDBBatchBoundsCandidateQueries(t *testing.T) {
+	accounts := make(map[int64]*Account, openAIAccountSelectionProbeLimit+1)
+	candidates := make([]*Account, 0, len(accounts))
+	for id := int64(1); id <= int64(openAIAccountSelectionProbeLimit+1); id++ {
+		account := &Account{ID: id, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+		accounts[id] = account
+		candidates = append(candidates, account)
+	}
+	repo := &openAIAccountDBBatchRepo{accounts: accounts}
+	service := &OpenAIGatewayService{accountRepo: repo, schedulerSnapshot: &SchedulerSnapshotService{}}
+
+	batch := service.loadOpenAIAccountDBBatch(context.Background(), candidates)
+	require.NotNil(t, batch)
+	require.Len(t, repo.batchCalls, 2)
+	require.Len(t, repo.batchCalls[0], openAIAccountSelectionProbeLimit)
+	require.Len(t, repo.batchCalls[1], 1)
+	for _, candidate := range candidates {
+		account, covered := batch.account(candidate.ID)
+		require.True(t, covered)
+		require.NotNil(t, account)
+	}
+}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -1107,6 +1107,8 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 	budget *openAISelectionProbeBudget,
 ) (*AccountSelectionResult, bool, error) {
 	compactBlocked := false
+	var dbBatch *openAIAccountDBBatch
+	dbBatchEnd := 0
 	release := func(result *AcquireResult) {
 		if result != nil && result.ReleaseFunc != nil {
 			result.ReleaseFunc()
@@ -1142,7 +1144,15 @@ func (s *defaultOpenAIAccountScheduler) tryAcquireOpenAISelectionOrderWithBudget
 			release(result)
 			break
 		}
-		fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+		if dbBatch == nil || i >= dbBatchEnd {
+			dbBatchEnd = min(i+openAIAccountSelectionProbeLimit, len(selectionOrder))
+			batchCandidates := make([]*Account, 0, dbBatchEnd-i)
+			for _, item := range selectionOrder[i:dbBatchEnd] {
+				batchCandidates = append(batchCandidates, item.account)
+			}
+			dbBatch = s.service.loadOpenAIAccountDBBatch(ctx, batchCandidates)
+		}
+		fresh = s.service.recheckSelectedOpenAIAccountFromDBBatch(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability, dbBatch)
 		if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 			release(result)
 			continue
@@ -1595,16 +1605,21 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 	for pass := 0; pass < passes; pass++ {
 		wantAttempted := pass == 1 || pass == 3
 		wantKnownFull := pass >= 2
-		for _, candidate := range attempt.selectionOrder {
+		matchesPass := func(candidate openAIAccountCandidateScore) bool {
 			if candidate.account == nil {
-				continue
+				return false
 			}
-			if budget != nil && budget.limited {
-				knownFull := candidate.loadKnown && candidate.account.Concurrency > 0 &&
-					candidate.loadInfo.CurrentConcurrency >= candidate.account.Concurrency
-				if budget.wasAttempted(candidate.account.ID) != wantAttempted || knownFull != wantKnownFull {
-					continue
-				}
+			if budget == nil || !budget.limited {
+				return true
+			}
+			knownFull := candidate.loadKnown && candidate.account.Concurrency > 0 &&
+				candidate.loadInfo.CurrentConcurrency >= candidate.account.Concurrency
+			return budget.wasAttempted(candidate.account.ID) == wantAttempted && knownFull == wantKnownFull
+		}
+		var dbBatch *openAIAccountDBBatch
+		for _, candidate := range attempt.selectionOrder {
+			if !matchesPass(candidate) {
+				continue
 			}
 			fresh := s.service.resolveFreshSchedulableOpenAIAccount(ctx, candidate.account, req.Platform, req.RequestedModel, false, req.RequiredCapability)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
@@ -1613,7 +1628,19 @@ func (s *defaultOpenAIAccountScheduler) finishLoadBalanceSelectionFallback(
 			if !s.consumeOpenAISelectionDBRecheck(budget) {
 				return nil, candidateCount, topK, loadSkew, noAvailableOpenAISelectionError(req.RequestedModel, compactBlocked, filterStats.summary("selection_order_exhausted"))
 			}
-			fresh = s.service.recheckSelectedOpenAIAccountFromDB(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability)
+			if dbBatch == nil {
+				batchCandidates := make([]*Account, 0, openAIAccountSelectionProbeLimit)
+				for _, item := range attempt.selectionOrder {
+					if matchesPass(item) {
+						batchCandidates = append(batchCandidates, item.account)
+						if len(batchCandidates) == openAIAccountSelectionProbeLimit {
+							break
+						}
+					}
+				}
+				dbBatch = s.service.loadOpenAIAccountDBBatch(ctx, batchCandidates)
+			}
+			fresh = s.service.recheckSelectedOpenAIAccountFromDBBatch(ctx, fresh, req.GroupID, req.Platform, req.RequestedModel, false, req.RequiredCapability, dbBatch)
 			if fresh == nil || !s.isAccountTransportCompatible(fresh, req.RequiredTransport) || !s.isAccountRequestCompatible(ctx, fresh, req) {
 				continue
 			}

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -34,6 +34,16 @@ func (r schedulerTestOpenAIAccountRepo) GetByID(ctx context.Context, id int64) (
 	return nil, errors.New("account not found")
 }
 
+func (r schedulerTestOpenAIAccountRepo) GetByIDs(ctx context.Context, ids []int64) ([]*Account, error) {
+	result := make([]*Account, 0, len(ids))
+	for _, id := range ids {
+		if account, err := r.GetByID(ctx, id); err == nil {
+			result = append(result, account)
+		}
+	}
+	return result, nil
+}
+
 func (r schedulerTestOpenAIAccountRepo) ListSchedulableByGroupIDAndPlatform(ctx context.Context, groupID int64, platform string) ([]Account, error) {
 	var result []Account
 	for _, acc := range r.accounts {
@@ -3154,6 +3164,79 @@ func TestSelectTopKOpenAICandidates(t *testing.T) {
 	require.Equal(t, int64(11), topAll[1].account.ID)
 	require.Equal(t, int64(12), topAll[2].account.ID)
 	require.Equal(t, int64(14), topAll[3].account.ID)
+}
+
+func TestOpenAIAccountSchedulerScoresTheEntirePoolBeforeTopK(t *testing.T) {
+	tests := []struct {
+		name               string
+		size               int
+		bestIndex          int
+		onlyBestEligible   bool
+		wantCandidateCount int
+	}{
+		{name: "best_is_257th", size: 20_000, bestIndex: 256, wantCandidateCount: 20_000},
+		{name: "best_is_last", size: 20_000, bestIndex: 19_999, wantCandidateCount: 20_000},
+		{name: "first_256_are_ineligible", size: 1_000, bestIndex: 256, onlyBestEligible: true, wantCandidateCount: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupID := int64(10124)
+			accounts := make([]Account, tt.size)
+			for i := range accounts {
+				eligible := !tt.onlyBestEligible || i == tt.bestIndex
+				status := StatusDisabled
+				if eligible {
+					status = StatusActive
+				}
+				priority := 100
+				if i == tt.bestIndex {
+					priority = 0
+				}
+				accounts[i] = Account{
+					ID:          int64(i + 1),
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeAPIKey,
+					Status:      status,
+					Schedulable: eligible,
+					Concurrency: 1,
+					Priority:    priority,
+					GroupIDs:    []int64{groupID},
+				}
+			}
+
+			cfg := &config.Config{}
+			cfg.Gateway.OpenAIWS.LBTopK = 1
+			cfg.Gateway.OpenAIWS.SchedulerScoreWeights.Priority = 1
+			svc := &OpenAIGatewayService{
+				accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+				cache:              &schedulerTestGatewayCache{},
+				cfg:                cfg,
+				rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+				concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+			}
+
+			selection, decision, err := svc.SelectAccountWithScheduler(
+				context.Background(),
+				&groupID,
+				"",
+				"full_pool_"+tt.name,
+				"gpt-5.1",
+				nil,
+				OpenAIUpstreamTransportAny,
+				false,
+			)
+			require.NoError(t, err)
+			require.NotNil(t, selection)
+			require.NotNil(t, selection.Account)
+			require.Equal(t, int64(tt.bestIndex+1), selection.Account.ID)
+			require.Equal(t, tt.wantCandidateCount, decision.CandidateCount)
+			require.Equal(t, 1, decision.TopK)
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+		})
+	}
 }
 
 func TestBuildOpenAIWeightedSelectionOrder_DeterministicBySessionSeed(t *testing.T) {

--- a/backend/internal/service/openai_account_scheduler_upstream_cost_test.go
+++ b/backend/internal/service/openai_account_scheduler_upstream_cost_test.go
@@ -65,8 +65,9 @@ func (c *upstreamCostTrackingConcurrencyCache) totalAcquires() int {
 
 type upstreamCostCountingAccountRepo struct {
 	AccountRepository
-	accounts map[int64]*Account
-	getCalls int
+	accounts      map[int64]*Account
+	getCalls      int
+	getBatchCalls int
 }
 
 func (r *upstreamCostCountingAccountRepo) GetByID(_ context.Context, accountID int64) (*Account, error) {
@@ -79,9 +80,26 @@ func (r *upstreamCostCountingAccountRepo) GetByID(_ context.Context, accountID i
 	return &cloned, nil
 }
 
-func (r *upstreamCostCountingAccountRepo) calls() int {
-	return r.getCalls
+func (r *upstreamCostCountingAccountRepo) GetByIDs(_ context.Context, accountIDs []int64) ([]*Account, error) {
+	r.getBatchCalls++
+	accounts := make([]*Account, 0, len(accountIDs))
+	for _, accountID := range accountIDs {
+		account := r.accounts[accountID]
+		if account == nil {
+			continue
+		}
+		cloned := *account
+		accounts = append(accounts, &cloned)
+	}
+	return accounts, nil
 }
+
+func (r *upstreamCostCountingAccountRepo) calls() int {
+	return r.getCalls + r.getBatchCalls
+}
+
+func (r *upstreamCostCountingAccountRepo) individualCalls() int { return r.getCalls }
+func (r *upstreamCostCountingAccountRepo) batchCalls() int      { return r.getBatchCalls }
 
 func upstreamCostTestAccount(id int64, status string, rate float64, receivedAt time.Time, interval time.Duration) *Account {
 	return &Account{
@@ -250,7 +268,8 @@ func TestAdvancedSchedulerSharesProbeBudgetWithFallbackDBRechecks(t *testing.T) 
 	require.Error(t, err)
 	require.Nil(t, selection)
 	require.Equal(t, openAIAccountSelectionProbeLimit, cache.totalAcquires())
-	require.Equal(t, openAIAccountSelectionProbeLimit, repo.calls())
+	require.Zero(t, repo.individualCalls())
+	require.Equal(t, 1, repo.batchCalls())
 }
 
 func TestAdvancedCostSchedulerKeepsCompactSupportedOverflowAheadOfUnknown(t *testing.T) {

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -686,10 +686,6 @@ func (s *OpenAIGatewayService) tryStickySessionHit(ctx context.Context, groupID 
 	if !isOpenAICompatibleAccountEligibleForRequest(ctx, account, platform, requestedModel, false, requiredCapability) {
 		return nil
 	}
-	if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
-		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
-		return nil
-	}
 	if s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
 		_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 		return nil
@@ -724,6 +720,7 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 	needsUpstreamCheck := s.needsUpstreamChannelRestrictionCheck(ctx, groupID)
 	eligible := make([]*Account, 0, len(accounts))
 	compactTiers := make(map[int64]int, len(accounts))
+	batchCandidates := make([]*Account, 0, len(accounts))
 
 	for i := range accounts {
 		acc := &accounts[i]
@@ -738,7 +735,12 @@ func (s *OpenAIGatewayService) selectBestAccount(ctx context.Context, groupID *i
 		if fresh == nil {
 			continue
 		}
-		fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, false, requiredCapability)
+		batchCandidates = append(batchCandidates, fresh)
+	}
+
+	dbBatch := s.loadOpenAIAccountDBBatch(ctx, batchCandidates)
+	for _, candidate := range batchCandidates {
+		fresh := s.recheckSelectedOpenAIAccountFromDBBatch(ctx, candidate, groupID, platform, requestedModel, false, requiredCapability, dbBatch)
 		if fresh == nil {
 			continue
 		}
@@ -898,8 +900,6 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, account, requestedModel, requireCompact) {
 						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
-					} else if !parentHealthyForShadow(account, s.parentAccountLookup(ctx)) {
-						_ = s.deleteStickySessionAccountID(ctx, groupID, sessionHash)
 					} else {
 						result, err := s.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
 						if err == nil && result != nil && result.Acquired {
@@ -927,20 +927,39 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	}
 
 	// ============ Layer 2: Load-aware selection ============
-	// Per-pass parent-health cache to avoid repeated DB calls when multiple shadow
-	// accounts share the same parent.
 	parentCacheL2 := make(map[int64]*Account)
-	parentLookupL2 := func(id int64) *Account {
-		if a, ok := parentCacheL2[id]; ok {
-			return a
+	if s.accountRepo != nil {
+		parentIDs := make([]int64, 0)
+		seenParentIDs := make(map[int64]struct{})
+		for i := range accounts {
+			if accounts[i].ParentAccountID == nil || *accounts[i].ParentAccountID <= 0 {
+				continue
+			}
+			parentID := *accounts[i].ParentAccountID
+			if _, exists := seenParentIDs[parentID]; exists {
+				continue
+			}
+			seenParentIDs[parentID] = struct{}{}
+			parentIDs = append(parentIDs, parentID)
 		}
-		if s.accountRepo == nil {
-			return nil
+		if len(parentIDs) > 0 {
+			startedAt := time.Now()
+			parents, queryCount, parentErr := s.loadOpenAIAccountIDsBounded(ctx, parentIDs)
+			missingCount := len(parentIDs) - len(parents)
+			if missingCount < 0 {
+				missingCount = 0
+			}
+			RecordSchedulerDBBatch(0, len(parentIDs), queryCount, len(parents), missingCount, time.Since(startedAt), parentErr)
+			if parentErr == nil {
+				for _, parent := range parents {
+					if parent != nil {
+						parentCacheL2[parent.ID] = parent
+					}
+				}
+			}
 		}
-		a, _ := s.accountRepo.GetByID(ctx, id)
-		parentCacheL2[id] = a
-		return a
 	}
+	parentLookupL2 := func(id int64) *Account { return parentCacheL2[id] }
 	baseCandidateCount := 0
 	candidates := make([]*Account, 0, len(accounts))
 	for i := range accounts {
@@ -1047,12 +1066,22 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 			selectionOrder = append(selectionOrder, available...)
 		}
 
-		for _, item := range selectionOrder {
+		var dbBatch *openAIAccountDBBatch
+		dbBatchEnd := 0
+		for i, item := range selectionOrder {
 			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, item.account, platform, requestedModel, false, requiredCapability)
 			if fresh == nil {
 				continue
 			}
-			fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability)
+			if dbBatch == nil || i >= dbBatchEnd {
+				dbBatchEnd = min(i+openAIAccountSelectionProbeLimit, len(selectionOrder))
+				batchCandidates := make([]*Account, 0, dbBatchEnd-i)
+				for _, candidate := range selectionOrder[i:dbBatchEnd] {
+					batchCandidates = append(batchCandidates, candidate.account)
+				}
+				dbBatch = s.loadOpenAIAccountDBBatch(ctx, batchCandidates)
+			}
+			fresh = s.recheckSelectedOpenAIAccountFromDBBatch(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability, dbBatch)
 			if fresh == nil {
 				continue
 			}
@@ -1086,28 +1115,32 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 		if requireCompact {
 			ordered = prioritizeOpenAICompactAccounts(ordered)
 		}
-		for _, acc := range ordered {
-			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
-			if fresh == nil {
-				continue
-			}
-			fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability)
-			if fresh == nil {
-				continue
-			}
-			if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
-				continue
-			}
-			result, err := s.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
-			if err == nil && result != nil && result.Acquired {
-				selection, selectErr := s.newAcquiredSelectionResult(ctx, fresh, result.ReleaseFunc)
-				if selectErr != nil {
-					return nil, selectErr
+		for start := 0; start < len(ordered); start += openAIAccountSelectionProbeLimit {
+			end := min(start+openAIAccountSelectionProbeLimit, len(ordered))
+			dbBatch := s.loadOpenAIAccountDBBatch(ctx, ordered[start:end])
+			for _, acc := range ordered[start:end] {
+				fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+				if fresh == nil {
+					continue
 				}
-				if sessionHash != "" {
-					_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, fresh.ID, openaiStickySessionTTL)
+				fresh = s.recheckSelectedOpenAIAccountFromDBBatch(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability, dbBatch)
+				if fresh == nil {
+					continue
 				}
-				return selection, nil
+				if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+					continue
+				}
+				result, err := s.tryAcquireAccountSlot(ctx, fresh.ID, fresh.Concurrency)
+				if err == nil && result != nil && result.Acquired {
+					selection, selectErr := s.newAcquiredSelectionResult(ctx, fresh, result.ReleaseFunc)
+					if selectErr != nil {
+						return nil, selectErr
+					}
+					if sessionHash != "" {
+						_ = s.setStickySessionAccountID(ctx, groupID, sessionHash, fresh.ID, openaiStickySessionTTL)
+					}
+					return selection, nil
+				}
 			}
 		}
 	} else {
@@ -1136,24 +1169,28 @@ func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Contex
 	if requireCompact {
 		candidates = prioritizeOpenAICompactAccounts(candidates)
 	}
-	for _, acc := range candidates {
-		fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
-		if fresh == nil {
-			continue
+	for start := 0; start < len(candidates); start += openAIAccountSelectionProbeLimit {
+		end := min(start+openAIAccountSelectionProbeLimit, len(candidates))
+		dbBatch := s.loadOpenAIAccountDBBatch(ctx, candidates[start:end])
+		for _, acc := range candidates[start:end] {
+			fresh := s.resolveFreshSchedulableOpenAIAccount(ctx, acc, platform, requestedModel, false, requiredCapability)
+			if fresh == nil {
+				continue
+			}
+			fresh = s.recheckSelectedOpenAIAccountFromDBBatch(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability, dbBatch)
+			if fresh == nil {
+				continue
+			}
+			if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
+				continue
+			}
+			return s.newSelectionResult(ctx, fresh, false, nil, &AccountWaitPlan{
+				AccountID:      fresh.ID,
+				MaxConcurrency: fresh.Concurrency,
+				Timeout:        cfg.FallbackWaitTimeout,
+				MaxWaiting:     cfg.FallbackMaxWaiting,
+			})
 		}
-		fresh = s.recheckSelectedOpenAIAccountFromDB(ctx, fresh, groupID, platform, requestedModel, requireCompact, requiredCapability)
-		if fresh == nil {
-			continue
-		}
-		if needsUpstreamCheck && s.isUpstreamModelRestrictedByChannel(ctx, *groupID, fresh, requestedModel, requireCompact) {
-			continue
-		}
-		return s.newSelectionResult(ctx, fresh, false, nil, &AccountWaitPlan{
-			AccountID:      fresh.ID,
-			MaxConcurrency: fresh.Concurrency,
-			Timeout:        cfg.FallbackWaitTimeout,
-			MaxWaiting:     cfg.FallbackMaxWaiting,
-		})
 	}
 
 	if requireCompact && baseCandidateCount > 0 {
@@ -1208,9 +1245,6 @@ func (s *OpenAIGatewayService) resolveFreshSchedulableOpenAIAccount(ctx context.
 	if !isOpenAICompatibleAccountEligibleForRequest(ctx, fresh, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
-	if !parentHealthyForShadow(fresh, s.parentAccountLookup(ctx)) {
-		return nil
-	}
 	if s.isOpenAIAccountRequestRuntimeBlocked(fresh, requestedModel) {
 		return nil
 	}
@@ -1231,7 +1265,151 @@ func (s *OpenAIGatewayService) parentAccountLookup(ctx context.Context) func(int
 	}
 }
 
+type openAIAccountDBBatch struct {
+	accounts map[int64]*Account
+	covered  map[int64]struct{}
+	failed   bool
+}
+
+func (s *OpenAIGatewayService) loadOpenAIAccountIDsBounded(ctx context.Context, ids []int64) ([]*Account, int, error) {
+	if s == nil || s.accountRepo == nil || len(ids) == 0 {
+		return nil, 0, nil
+	}
+	uniqueIDs := make([]int64, 0, len(ids))
+	seen := make(map[int64]struct{}, len(ids))
+	for _, id := range ids {
+		if id <= 0 {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		uniqueIDs = append(uniqueIDs, id)
+	}
+	accounts := make([]*Account, 0, len(uniqueIDs))
+	queryCount := 0
+	for start := 0; start < len(uniqueIDs); start += openAIAccountSelectionProbeLimit {
+		end := min(start+openAIAccountSelectionProbeLimit, len(uniqueIDs))
+		queryCount++
+		batch, err := s.accountRepo.GetByIDs(ctx, uniqueIDs[start:end])
+		if err != nil {
+			return nil, queryCount, err
+		}
+		accounts = append(accounts, batch...)
+	}
+	return accounts, queryCount, nil
+}
+
+func (b *openAIAccountDBBatch) account(id int64) (*Account, bool) {
+	if b == nil {
+		return nil, false
+	}
+	if _, ok := b.covered[id]; !ok {
+		return nil, false
+	}
+	if b.failed {
+		return nil, true
+	}
+	return b.accounts[id], true
+}
+
+func (b *openAIAccountDBBatch) parentLookup(id int64) *Account {
+	account, covered := b.account(id)
+	if !covered {
+		return nil
+	}
+	return account
+}
+
+func (s *OpenAIGatewayService) loadOpenAIAccountDBBatch(ctx context.Context, candidates []*Account) *openAIAccountDBBatch {
+	if s == nil || s.schedulerSnapshot == nil || s.accountRepo == nil || len(candidates) == 0 {
+		return nil
+	}
+	startedAt := time.Now()
+	batch := &openAIAccountDBBatch{
+		accounts: make(map[int64]*Account, len(candidates)),
+		covered:  make(map[int64]struct{}, len(candidates)),
+	}
+	ids := make([]int64, 0, len(candidates))
+	parentIDs := make([]int64, 0)
+	queryCount := 0
+	var batchErr error
+	defer func() {
+		missingCount := 0
+		if !batch.failed && len(batch.covered) > len(batch.accounts) {
+			missingCount = len(batch.covered) - len(batch.accounts)
+		}
+		RecordSchedulerDBBatch(len(ids), len(parentIDs), queryCount, len(batch.accounts), missingCount, time.Since(startedAt), batchErr)
+		slog.Debug("scheduler db authority batch",
+			"candidates", len(ids),
+			"parents", len(parentIDs),
+			"queries", queryCount,
+			"returned", len(batch.accounts),
+			"missing", missingCount,
+			"duration", time.Since(startedAt),
+			"failed", batch.failed,
+		)
+	}()
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.ID <= 0 {
+			continue
+		}
+		if _, exists := batch.covered[candidate.ID]; exists {
+			continue
+		}
+		batch.covered[candidate.ID] = struct{}{}
+		ids = append(ids, candidate.ID)
+	}
+	if len(ids) == 0 {
+		return batch
+	}
+
+	latest, candidateQueries, err := s.loadOpenAIAccountIDsBounded(ctx, ids)
+	queryCount += candidateQueries
+	if err != nil {
+		batchErr = err
+		batch.failed = true
+		return batch
+	}
+	for _, account := range latest {
+		if account == nil {
+			continue
+		}
+		batch.accounts[account.ID] = account
+		if account.ParentAccountID == nil || *account.ParentAccountID <= 0 {
+			continue
+		}
+		parentID := *account.ParentAccountID
+		if _, exists := batch.covered[parentID]; exists {
+			continue
+		}
+		batch.covered[parentID] = struct{}{}
+		parentIDs = append(parentIDs, parentID)
+	}
+	if len(parentIDs) == 0 {
+		return batch
+	}
+	parents, parentQueries, err := s.loadOpenAIAccountIDsBounded(ctx, parentIDs)
+	queryCount += parentQueries
+	if err != nil {
+		batchErr = err
+		batch.failed = true
+		return batch
+	}
+	for _, parent := range parents {
+		if parent != nil {
+			batch.accounts[parent.ID] = parent
+		}
+	}
+	return batch
+}
+
 func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) *Account {
+	return s.recheckSelectedOpenAIAccountFromDBBatch(ctx, account, groupID, platform, requestedModel, requireCompact, requiredCapability, nil)
+}
+
+func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDBBatch(ctx context.Context, account *Account, groupID *int64, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability, batch *openAIAccountDBBatch) *Account {
 	if account == nil {
 		return nil
 	}
@@ -1246,8 +1424,15 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 		return account
 	}
 
-	latest, err := s.accountRepo.GetByID(ctx, account.ID)
-	if err != nil || latest == nil {
+	latest, covered := batch.account(account.ID)
+	if !covered {
+		var err error
+		latest, err = s.accountRepo.GetByID(ctx, account.ID)
+		if err != nil {
+			return nil
+		}
+	}
+	if latest == nil {
 		return nil
 	}
 	if !s.openAIAccountMatchesSchedulingGroup(latest, groupID) {
@@ -1256,7 +1441,11 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 	if !isOpenAICompatibleAccountEligibleForRequest(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
-	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
+	parentLookup := s.parentAccountLookup(ctx)
+	if covered {
+		parentLookup = batch.parentLookup
+	}
+	if !parentHealthyForShadow(latest, parentLookup) {
 		return nil
 	}
 	if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {

--- a/backend/internal/service/scheduler_optimization_observability.go
+++ b/backend/internal/service/scheduler_optimization_observability.go
@@ -1,0 +1,429 @@
+package service
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// SchedulerOptimizationMetricsSnapshot is a process-local diagnostic view of
+// the lossless scheduler optimizations. It is intentionally cumulative; a
+// caller can take two snapshots and use their difference as a test window.
+type SchedulerOptimizationMetricsSnapshot struct {
+	Snapshot    SchedulerSnapshotMetricsSnapshot    `json:"snapshot"`
+	Load        SchedulerLoadMetricsSnapshot        `json:"load"`
+	Database    SchedulerDBBatchMetricsSnapshot     `json:"database"`
+	Incremental SchedulerIncrementalMetricsSnapshot `json:"incremental"`
+	Rebuild     SchedulerRebuildMetricsSnapshot     `json:"rebuild"`
+	Drift       SchedulerDriftMetricsSnapshot       `json:"drift"`
+}
+
+type SchedulerSnapshotMetricsSnapshot struct {
+	ReadTotal                 uint64  `json:"read_total"`
+	LocalHitTotal             uint64  `json:"local_hit_total"`
+	LocalMissTotal            uint64  `json:"local_miss_total"`
+	LocalInvalidationTotal    uint64  `json:"local_invalidation_total"`
+	RedisHitTotal             uint64  `json:"redis_hit_total"`
+	EmptyMissTotal            uint64  `json:"empty_miss_total"`
+	ErrorTotal                uint64  `json:"error_total"`
+	AccountTotal              uint64  `json:"account_total"`
+	DurationTotalMs           float64 `json:"duration_total_ms"`
+	DBFallbackTotal           uint64  `json:"db_fallback_total"`
+	DBFallbackErrorTotal      uint64  `json:"db_fallback_error_total"`
+	DBFallbackLimitedTotal    uint64  `json:"db_fallback_limited_total"`
+	DBFallbackDisabledTotal   uint64  `json:"db_fallback_disabled_total"`
+	DBFallbackAccountTotal    uint64  `json:"db_fallback_account_total"`
+	DBFallbackDurationTotalMs float64 `json:"db_fallback_duration_total_ms"`
+}
+
+type SchedulerLoadMetricsSnapshot struct {
+	RequestTotal           uint64  `json:"request_total"`
+	CacheHitTotal          uint64  `json:"cache_hit_total"`
+	CacheMissTotal         uint64  `json:"cache_miss_total"`
+	CacheBypassTotal       uint64  `json:"cache_bypass_total"`
+	BackendFetchTotal      uint64  `json:"backend_fetch_total"`
+	BackendFetchErrorTotal uint64  `json:"backend_fetch_error_total"`
+	BackendAccountTotal    uint64  `json:"backend_account_total"`
+	BackendDurationTotalMs float64 `json:"backend_duration_total_ms"`
+	ScriptTotal            uint64  `json:"script_total"`
+	PipelineTotal          uint64  `json:"pipeline_total"`
+	PipelineFallbackTotal  uint64  `json:"pipeline_fallback_total"`
+	RedisErrorTotal        uint64  `json:"redis_error_total"`
+	RedisAccountTotal      uint64  `json:"redis_account_total"`
+	RedisBatchTotal        uint64  `json:"redis_batch_total"`
+	RedisDurationTotalMs   float64 `json:"redis_duration_total_ms"`
+}
+
+type SchedulerDBBatchMetricsSnapshot struct {
+	BatchTotal           uint64  `json:"batch_total"`
+	QueryTotal           uint64  `json:"query_total"`
+	CandidateIDTotal     uint64  `json:"candidate_id_total"`
+	ParentIDTotal        uint64  `json:"parent_id_total"`
+	ReturnedAccountTotal uint64  `json:"returned_account_total"`
+	MissingAccountTotal  uint64  `json:"missing_account_total"`
+	ErrorTotal           uint64  `json:"error_total"`
+	DurationTotalMs      float64 `json:"duration_total_ms"`
+}
+
+type SchedulerIncrementalMetricsSnapshot struct {
+	EventAttemptTotal    uint64  `json:"event_attempt_total"`
+	EventCommittedTotal  uint64  `json:"event_committed_total"`
+	EventReplayTotal     uint64  `json:"event_replay_total"`
+	EventFailureTotal    uint64  `json:"event_failure_total"`
+	BucketAttemptTotal   uint64  `json:"bucket_attempt_total"`
+	BucketRemovedTotal   uint64  `json:"bucket_removed_total"`
+	BucketNoopTotal      uint64  `json:"bucket_noop_total"`
+	BucketErrorTotal     uint64  `json:"bucket_error_total"`
+	FallbackRebuildTotal uint64  `json:"fallback_rebuild_total"`
+	DurationTotalMs      float64 `json:"duration_total_ms"`
+}
+
+type SchedulerRebuildMetricsSnapshot struct {
+	BucketAttemptTotal    uint64  `json:"bucket_attempt_total"`
+	BucketSuccessTotal    uint64  `json:"bucket_success_total"`
+	BucketErrorTotal      uint64  `json:"bucket_error_total"`
+	BucketFencedTotal     uint64  `json:"bucket_fenced_total"`
+	BucketBusyTotal       uint64  `json:"bucket_busy_total"`
+	AccountTotal          uint64  `json:"account_total"`
+	DurationTotalMs       float64 `json:"duration_total_ms"`
+	FullRebuildTotal      uint64  `json:"full_rebuild_total"`
+	FullRebuildErrorTotal uint64  `json:"full_rebuild_error_total"`
+	FullRebuildDurationMs float64 `json:"full_rebuild_duration_total_ms"`
+}
+
+type SchedulerDriftMetricsSnapshot struct {
+	LagWarningTotal    uint64 `json:"lag_warning_total"`
+	CheckErrorTotal    uint64 `json:"check_error_total"`
+	RepairTotal        uint64 `json:"repair_total"`
+	RepairErrorTotal   uint64 `json:"repair_error_total"`
+	CurrentLagSeconds  int64  `json:"current_lag_seconds"`
+	CurrentBacklogRows int64  `json:"current_backlog_rows"`
+}
+
+type schedulerOptimizationMetrics struct {
+	snapshotReadTotal                atomic.Uint64
+	snapshotLocalHitTotal            atomic.Uint64
+	snapshotLocalMissTotal           atomic.Uint64
+	snapshotLocalInvalidationTotal   atomic.Uint64
+	snapshotRedisHitTotal            atomic.Uint64
+	snapshotEmptyMissTotal           atomic.Uint64
+	snapshotErrorTotal               atomic.Uint64
+	snapshotAccountTotal             atomic.Uint64
+	snapshotDurationMicros           atomic.Uint64
+	snapshotDBFallbackTotal          atomic.Uint64
+	snapshotDBFallbackErrorTotal     atomic.Uint64
+	snapshotDBFallbackLimitedTotal   atomic.Uint64
+	snapshotDBFallbackDisabledTotal  atomic.Uint64
+	snapshotDBFallbackAccountTotal   atomic.Uint64
+	snapshotDBFallbackDurationMicros atomic.Uint64
+
+	loadRequestTotal           atomic.Uint64
+	loadCacheHitTotal          atomic.Uint64
+	loadCacheMissTotal         atomic.Uint64
+	loadCacheBypassTotal       atomic.Uint64
+	loadBackendFetchTotal      atomic.Uint64
+	loadBackendFetchErrorTotal atomic.Uint64
+	loadBackendAccountTotal    atomic.Uint64
+	loadBackendDurationMicros  atomic.Uint64
+	loadScriptTotal            atomic.Uint64
+	loadPipelineTotal          atomic.Uint64
+	loadPipelineFallbackTotal  atomic.Uint64
+	loadRedisErrorTotal        atomic.Uint64
+	loadRedisAccountTotal      atomic.Uint64
+	loadRedisBatchTotal        atomic.Uint64
+	loadRedisDurationMicros    atomic.Uint64
+
+	dbBatchTotal           atomic.Uint64
+	dbQueryTotal           atomic.Uint64
+	dbCandidateIDTotal     atomic.Uint64
+	dbParentIDTotal        atomic.Uint64
+	dbReturnedAccountTotal atomic.Uint64
+	dbMissingAccountTotal  atomic.Uint64
+	dbErrorTotal           atomic.Uint64
+	dbDurationMicros       atomic.Uint64
+
+	incrementalEventAttemptTotal    atomic.Uint64
+	incrementalEventCommittedTotal  atomic.Uint64
+	incrementalEventReplayTotal     atomic.Uint64
+	incrementalEventFailureTotal    atomic.Uint64
+	incrementalBucketAttemptTotal   atomic.Uint64
+	incrementalBucketRemovedTotal   atomic.Uint64
+	incrementalBucketNoopTotal      atomic.Uint64
+	incrementalBucketErrorTotal     atomic.Uint64
+	incrementalFallbackRebuildTotal atomic.Uint64
+	incrementalDurationMicros       atomic.Uint64
+
+	rebuildBucketAttemptTotal atomic.Uint64
+	rebuildBucketSuccessTotal atomic.Uint64
+	rebuildBucketErrorTotal   atomic.Uint64
+	rebuildBucketFencedTotal  atomic.Uint64
+	rebuildBucketBusyTotal    atomic.Uint64
+	rebuildAccountTotal       atomic.Uint64
+	rebuildDurationMicros     atomic.Uint64
+	fullRebuildTotal          atomic.Uint64
+	fullRebuildErrorTotal     atomic.Uint64
+	fullRebuildDurationMicros atomic.Uint64
+
+	driftLagWarningTotal    atomic.Uint64
+	driftCheckErrorTotal    atomic.Uint64
+	driftRepairTotal        atomic.Uint64
+	driftRepairErrorTotal   atomic.Uint64
+	driftCurrentLagSeconds  atomic.Int64
+	driftCurrentBacklogRows atomic.Int64
+}
+
+var defaultSchedulerOptimizationMetrics schedulerOptimizationMetrics
+
+// GetSchedulerOptimizationMetricsSnapshot returns cumulative process-local
+// scheduler optimization counters for diagnostics and the admin dashboard.
+func GetSchedulerOptimizationMetricsSnapshot() SchedulerOptimizationMetricsSnapshot {
+	m := &defaultSchedulerOptimizationMetrics
+	return SchedulerOptimizationMetricsSnapshot{
+		Snapshot: SchedulerSnapshotMetricsSnapshot{
+			ReadTotal: m.snapshotReadTotal.Load(), LocalHitTotal: m.snapshotLocalHitTotal.Load(),
+			LocalMissTotal: m.snapshotLocalMissTotal.Load(), LocalInvalidationTotal: m.snapshotLocalInvalidationTotal.Load(),
+			RedisHitTotal: m.snapshotRedisHitTotal.Load(), EmptyMissTotal: m.snapshotEmptyMissTotal.Load(),
+			ErrorTotal: m.snapshotErrorTotal.Load(), AccountTotal: m.snapshotAccountTotal.Load(),
+			DurationTotalMs: microsToMillis(m.snapshotDurationMicros.Load()),
+			DBFallbackTotal: m.snapshotDBFallbackTotal.Load(), DBFallbackErrorTotal: m.snapshotDBFallbackErrorTotal.Load(),
+			DBFallbackLimitedTotal: m.snapshotDBFallbackLimitedTotal.Load(), DBFallbackDisabledTotal: m.snapshotDBFallbackDisabledTotal.Load(),
+			DBFallbackAccountTotal: m.snapshotDBFallbackAccountTotal.Load(), DBFallbackDurationTotalMs: microsToMillis(m.snapshotDBFallbackDurationMicros.Load()),
+		},
+		Load: SchedulerLoadMetricsSnapshot{
+			RequestTotal: m.loadRequestTotal.Load(), CacheHitTotal: m.loadCacheHitTotal.Load(), CacheMissTotal: m.loadCacheMissTotal.Load(),
+			CacheBypassTotal: m.loadCacheBypassTotal.Load(), BackendFetchTotal: m.loadBackendFetchTotal.Load(),
+			BackendFetchErrorTotal: m.loadBackendFetchErrorTotal.Load(), BackendAccountTotal: m.loadBackendAccountTotal.Load(),
+			BackendDurationTotalMs: microsToMillis(m.loadBackendDurationMicros.Load()), ScriptTotal: m.loadScriptTotal.Load(),
+			PipelineTotal: m.loadPipelineTotal.Load(), PipelineFallbackTotal: m.loadPipelineFallbackTotal.Load(),
+			RedisErrorTotal: m.loadRedisErrorTotal.Load(), RedisAccountTotal: m.loadRedisAccountTotal.Load(),
+			RedisBatchTotal: m.loadRedisBatchTotal.Load(), RedisDurationTotalMs: microsToMillis(m.loadRedisDurationMicros.Load()),
+		},
+		Database: SchedulerDBBatchMetricsSnapshot{
+			BatchTotal: m.dbBatchTotal.Load(), QueryTotal: m.dbQueryTotal.Load(), CandidateIDTotal: m.dbCandidateIDTotal.Load(),
+			ParentIDTotal: m.dbParentIDTotal.Load(), ReturnedAccountTotal: m.dbReturnedAccountTotal.Load(), MissingAccountTotal: m.dbMissingAccountTotal.Load(),
+			ErrorTotal: m.dbErrorTotal.Load(), DurationTotalMs: microsToMillis(m.dbDurationMicros.Load()),
+		},
+		Incremental: SchedulerIncrementalMetricsSnapshot{
+			EventAttemptTotal: m.incrementalEventAttemptTotal.Load(), EventCommittedTotal: m.incrementalEventCommittedTotal.Load(),
+			EventReplayTotal: m.incrementalEventReplayTotal.Load(), EventFailureTotal: m.incrementalEventFailureTotal.Load(),
+			BucketAttemptTotal: m.incrementalBucketAttemptTotal.Load(), BucketRemovedTotal: m.incrementalBucketRemovedTotal.Load(),
+			BucketNoopTotal: m.incrementalBucketNoopTotal.Load(), BucketErrorTotal: m.incrementalBucketErrorTotal.Load(),
+			FallbackRebuildTotal: m.incrementalFallbackRebuildTotal.Load(), DurationTotalMs: microsToMillis(m.incrementalDurationMicros.Load()),
+		},
+		Rebuild: SchedulerRebuildMetricsSnapshot{
+			BucketAttemptTotal: m.rebuildBucketAttemptTotal.Load(), BucketSuccessTotal: m.rebuildBucketSuccessTotal.Load(),
+			BucketErrorTotal: m.rebuildBucketErrorTotal.Load(), BucketFencedTotal: m.rebuildBucketFencedTotal.Load(),
+			BucketBusyTotal: m.rebuildBucketBusyTotal.Load(), AccountTotal: m.rebuildAccountTotal.Load(),
+			DurationTotalMs: microsToMillis(m.rebuildDurationMicros.Load()), FullRebuildTotal: m.fullRebuildTotal.Load(),
+			FullRebuildErrorTotal: m.fullRebuildErrorTotal.Load(), FullRebuildDurationMs: microsToMillis(m.fullRebuildDurationMicros.Load()),
+		},
+		Drift: SchedulerDriftMetricsSnapshot{
+			LagWarningTotal: m.driftLagWarningTotal.Load(), CheckErrorTotal: m.driftCheckErrorTotal.Load(),
+			RepairTotal: m.driftRepairTotal.Load(), RepairErrorTotal: m.driftRepairErrorTotal.Load(),
+			CurrentLagSeconds: m.driftCurrentLagSeconds.Load(), CurrentBacklogRows: m.driftCurrentBacklogRows.Load(),
+		},
+	}
+}
+
+func RecordSchedulerSnapshotRead(path string, accountCount int, hit bool, duration time.Duration, err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.snapshotReadTotal.Add(1)
+	m.snapshotAccountTotal.Add(uint64(maxMetricCount(accountCount)))
+	m.snapshotDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.snapshotErrorTotal.Add(1)
+	}
+	switch path {
+	case "local_hit":
+		m.snapshotLocalHitTotal.Add(1)
+	case "local_miss", "local_bypass":
+		m.snapshotLocalMissTotal.Add(1)
+	}
+	if path != "local_hit" && hit {
+		m.snapshotRedisHitTotal.Add(1)
+	}
+	if !hit && err == nil {
+		m.snapshotEmptyMissTotal.Add(1)
+	}
+}
+
+func RecordSchedulerSnapshotLocalInvalidation() {
+	defaultSchedulerOptimizationMetrics.snapshotLocalInvalidationTotal.Add(1)
+}
+
+func RecordSchedulerSnapshotDBFallback(accountCount int, duration time.Duration, err error, limited, disabled bool) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.snapshotDBFallbackTotal.Add(1)
+	m.snapshotDBFallbackAccountTotal.Add(uint64(maxMetricCount(accountCount)))
+	m.snapshotDBFallbackDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.snapshotDBFallbackErrorTotal.Add(1)
+	}
+	if limited {
+		m.snapshotDBFallbackLimitedTotal.Add(1)
+	}
+	if disabled {
+		m.snapshotDBFallbackDisabledTotal.Add(1)
+	}
+}
+
+func RecordSchedulerLoadCache(hit, bypass bool) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.loadRequestTotal.Add(1)
+	if hit {
+		m.loadCacheHitTotal.Add(1)
+	} else {
+		m.loadCacheMissTotal.Add(1)
+	}
+	if bypass {
+		m.loadCacheBypassTotal.Add(1)
+	}
+}
+
+func RecordSchedulerLoadBackend(accountCount int, duration time.Duration, err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.loadBackendFetchTotal.Add(1)
+	m.loadBackendAccountTotal.Add(uint64(maxMetricCount(accountCount)))
+	m.loadBackendDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.loadBackendFetchErrorTotal.Add(1)
+	}
+}
+
+// RecordSchedulerLoadRedis records the concrete Redis implementation path.
+// path is one of script, pipeline, or pipeline_fallback.
+func RecordSchedulerLoadRedis(path string, accountCount, batchCount int, duration time.Duration, err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	switch path {
+	case "script":
+		m.loadScriptTotal.Add(1)
+	case "pipeline_fallback":
+		m.loadPipelineFallbackTotal.Add(1)
+		m.loadPipelineTotal.Add(1)
+	default:
+		m.loadPipelineTotal.Add(1)
+	}
+	m.loadRedisAccountTotal.Add(uint64(maxMetricCount(accountCount)))
+	m.loadRedisBatchTotal.Add(uint64(maxMetricCount(batchCount)))
+	m.loadRedisDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.loadRedisErrorTotal.Add(1)
+	}
+}
+
+func RecordSchedulerDBBatch(candidateCount, parentCount, queryCount, returnedCount, missingCount int, duration time.Duration, err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.dbBatchTotal.Add(1)
+	m.dbQueryTotal.Add(uint64(maxMetricCount(queryCount)))
+	m.dbCandidateIDTotal.Add(uint64(maxMetricCount(candidateCount)))
+	m.dbParentIDTotal.Add(uint64(maxMetricCount(parentCount)))
+	m.dbReturnedAccountTotal.Add(uint64(maxMetricCount(returnedCount)))
+	m.dbMissingAccountTotal.Add(uint64(maxMetricCount(missingCount)))
+	m.dbDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.dbErrorTotal.Add(1)
+	}
+}
+
+func RecordSchedulerOutboxEventAttempt(replay bool) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.incrementalEventAttemptTotal.Add(1)
+	if replay {
+		m.incrementalEventReplayTotal.Add(1)
+	}
+}
+
+func RecordSchedulerOutboxEventsCommitted(count int) {
+	defaultSchedulerOptimizationMetrics.incrementalEventCommittedTotal.Add(uint64(maxMetricCount(count)))
+}
+
+func RecordSchedulerOutboxEventFailure() {
+	defaultSchedulerOptimizationMetrics.incrementalEventFailureTotal.Add(1)
+}
+
+func RecordSchedulerIncrementalBucket(removed bool, duration time.Duration, err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.incrementalBucketAttemptTotal.Add(1)
+	m.incrementalDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.incrementalBucketErrorTotal.Add(1)
+	} else if removed {
+		m.incrementalBucketRemovedTotal.Add(1)
+	} else {
+		m.incrementalBucketNoopTotal.Add(1)
+	}
+}
+
+func RecordSchedulerIncrementalFallback() {
+	defaultSchedulerOptimizationMetrics.incrementalFallbackRebuildTotal.Add(1)
+}
+
+// outcome is success, error, fenced, or busy.
+func RecordSchedulerBucketRebuild(outcome string, accountCount int, duration time.Duration) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.rebuildBucketAttemptTotal.Add(1)
+	m.rebuildAccountTotal.Add(uint64(maxMetricCount(accountCount)))
+	m.rebuildDurationMicros.Add(durationMicros(duration))
+	switch outcome {
+	case "success":
+		m.rebuildBucketSuccessTotal.Add(1)
+	case "fenced":
+		m.rebuildBucketFencedTotal.Add(1)
+	case "busy":
+		m.rebuildBucketBusyTotal.Add(1)
+	default:
+		m.rebuildBucketErrorTotal.Add(1)
+	}
+}
+
+func RecordSchedulerFullRebuild(duration time.Duration, err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.fullRebuildTotal.Add(1)
+	m.fullRebuildDurationMicros.Add(durationMicros(duration))
+	if err != nil {
+		m.fullRebuildErrorTotal.Add(1)
+	}
+}
+
+func RecordSchedulerOutboxState(lagSeconds, backlogRows int64, warning, checkError bool) {
+	m := &defaultSchedulerOptimizationMetrics
+	if lagSeconds < 0 {
+		lagSeconds = 0
+	}
+	if backlogRows < 0 {
+		backlogRows = 0
+	}
+	m.driftCurrentLagSeconds.Store(lagSeconds)
+	m.driftCurrentBacklogRows.Store(backlogRows)
+	if warning {
+		m.driftLagWarningTotal.Add(1)
+	}
+	if checkError {
+		m.driftCheckErrorTotal.Add(1)
+	}
+}
+
+func RecordSchedulerOutboxRepair(err error) {
+	m := &defaultSchedulerOptimizationMetrics
+	m.driftRepairTotal.Add(1)
+	if err != nil {
+		m.driftRepairErrorTotal.Add(1)
+	}
+}
+
+func durationMicros(duration time.Duration) uint64 {
+	if duration <= 0 {
+		return 0
+	}
+	return uint64(duration.Microseconds())
+}
+
+func microsToMillis(micros uint64) float64 {
+	return float64(micros) / 1000
+}
+
+func maxMetricCount(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/backend/internal/service/scheduler_snapshot_incremental_test.go
+++ b/backend/internal/service/scheduler_snapshot_incremental_test.go
@@ -1,0 +1,243 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type incrementalAccountRepo struct {
+	*batchAccountQueryRepo
+	account *Account
+	getErr  error
+}
+
+func newIncrementalAccountRepo(account *Account) *incrementalAccountRepo {
+	return &incrementalAccountRepo{batchAccountQueryRepo: newBatchAccountQueryRepo(), account: account}
+}
+
+func (r *incrementalAccountRepo) GetByID(context.Context, int64) (*Account, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+	if r.account == nil {
+		return nil, ErrAccountNotFound
+	}
+	copy := *r.account
+	copy.GroupIDs = append([]int64(nil), r.account.GroupIDs...)
+	return &copy, nil
+}
+
+type incrementalRemoval struct {
+	bucket    SchedulerBucket
+	accountID int64
+}
+
+type incrementalSnapshotCache struct {
+	*bulkEventSnapshotCache
+
+	removeMu    sync.Mutex
+	removals    []incrementalRemoval
+	removeError map[SchedulerBucket]error
+}
+
+func newIncrementalSnapshotCache() *incrementalSnapshotCache {
+	return &incrementalSnapshotCache{
+		bulkEventSnapshotCache: newBulkEventSnapshotCache(),
+		removeError:            make(map[SchedulerBucket]error),
+	}
+}
+
+func (c *incrementalSnapshotCache) RemoveAccountFromBucket(_ context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accountID int64) (bool, error) {
+	c.batchSnapshotCache.mu.Lock()
+	valid := token.ValidFor(bucket) && token == c.batchSnapshotCache.captured[bucket]
+	c.batchSnapshotCache.mu.Unlock()
+	if !valid {
+		return false, ErrSchedulerBucketWriteFenced
+	}
+	c.removeMu.Lock()
+	defer c.removeMu.Unlock()
+	if err := c.removeError[bucket]; err != nil {
+		return false, err
+	}
+	c.removals = append(c.removals, incrementalRemoval{bucket: bucket, accountID: accountID})
+	return true, nil
+}
+
+func (c *incrementalSnapshotCache) removedBuckets() []SchedulerBucket {
+	c.removeMu.Lock()
+	defer c.removeMu.Unlock()
+	buckets := make([]SchedulerBucket, 0, len(c.removals))
+	for _, removal := range c.removals {
+		buckets = append(buckets, removal.bucket)
+	}
+	return buckets
+}
+
+func newIncrementalTestService(cache SchedulerCache, repo AccountRepository) *SchedulerSnapshotService {
+	cfg := &config.Config{RunMode: config.RunModeStandard}
+	cfg.Gateway.Scheduling.IncrementalBucketUpdateEnabled = true
+	return NewSchedulerSnapshotService(cache, nil, repo, nil, cfg)
+}
+
+func TestSchedulerAccountEventDisabledAccountOnlyRemovesMembers(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	repo := newIncrementalAccountRepo(&Account{ID: 91, Platform: PlatformOpenAI, Status: StatusDisabled, GroupIDs: []int64{7}})
+	svc := newIncrementalTestService(cache, repo)
+	id := int64(91)
+
+	err := svc.handleAccountEvent(context.Background(), &id, nil, make(map[batchSeenKey]struct{}), false)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, schedulerCanonicalBuckets(7), cache.removedBuckets())
+	require.Empty(t, cache.batchSnapshotCache.writes)
+	set, deleted := cache.accountWrites()
+	require.Equal(t, []int64{id, id}, set)
+	require.Empty(t, deleted)
+}
+
+func TestSchedulerAccountEventRebuildsOnlyCurrentPlatformAfterCleanup(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	repo := newIncrementalAccountRepo(&Account{ID: 92, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, GroupIDs: []int64{8}})
+	svc := newIncrementalTestService(cache, repo)
+	id := int64(92)
+
+	err := svc.handleAccountEvent(context.Background(), &id, map[string]any{"group_ids": []any{float64(8)}}, make(map[batchSeenKey]struct{}), false)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, schedulerCanonicalBuckets(8), cache.removedBuckets())
+	written := make([]SchedulerBucket, 0, len(cache.batchSnapshotCache.writes))
+	for bucket := range cache.batchSnapshotCache.writes {
+		written = append(written, bucket)
+	}
+	require.ElementsMatch(t, schedulerBucketsForTest([]int64{8}, PlatformOpenAI), written)
+}
+
+func TestSchedulerAccountGroupEventAlsoCleansUngroupedBuckets(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	repo := newIncrementalAccountRepo(&Account{ID: 93, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, GroupIDs: []int64{9}})
+	svc := newIncrementalTestService(cache, repo)
+	id := int64(93)
+
+	err := svc.handleAccountEvent(context.Background(), &id, map[string]any{"group_ids": []any{float64(9)}}, make(map[batchSeenKey]struct{}), true)
+
+	require.NoError(t, err)
+	wantRemoved := append(schedulerCanonicalBuckets(0), schedulerCanonicalBuckets(9)...)
+	require.ElementsMatch(t, wantRemoved, cache.removedBuckets())
+}
+
+func TestSchedulerAccountDeleteRemovesPayloadBucketsAndDeletesMetadataLast(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	repo := newIncrementalAccountRepo(nil)
+	repo.getErr = ErrAccountNotFound
+	svc := newIncrementalTestService(cache, repo)
+	id := int64(94)
+
+	err := svc.handleAccountEvent(context.Background(), &id, map[string]any{"group_ids": []any{float64(10)}}, make(map[batchSeenKey]struct{}), false)
+
+	require.NoError(t, err)
+	require.ElementsMatch(t, schedulerCanonicalBuckets(10), cache.removedBuckets())
+	set, deleted := cache.accountWrites()
+	require.Empty(t, set)
+	require.Equal(t, []int64{id, id}, deleted)
+}
+
+func TestSchedulerAccountEventSkipsRemovalForBucketRebuiltEarlierInBatch(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	repo := newIncrementalAccountRepo(&Account{ID: 95, Platform: PlatformOpenAI, Status: StatusDisabled, GroupIDs: []int64{11}})
+	svc := newIncrementalTestService(cache, repo)
+	id := int64(95)
+	seen := map[batchSeenKey]struct{}{{groupID: 11, platform: PlatformOpenAI}: {}}
+
+	err := svc.handleAccountEvent(context.Background(), &id, nil, seen, false)
+
+	require.NoError(t, err)
+	removed := cache.removedBuckets()
+	for _, bucket := range removed {
+		require.NotEqual(t, PlatformOpenAI, bucket.Platform)
+	}
+	require.Len(t, removed, len(schedulerCanonicalBuckets(11))-2)
+}
+
+func TestSchedulerAccountEventStopsBeforeRebuildOnRemovalError(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	failedBucket := SchedulerBucket{GroupID: 12, Platform: PlatformAnthropic, Mode: SchedulerModeSingle}
+	cache.removeError[failedBucket] = errors.New("remove failed")
+	repo := newIncrementalAccountRepo(&Account{ID: 96, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, GroupIDs: []int64{12}})
+	svc := newIncrementalTestService(cache, repo)
+	id := int64(96)
+
+	err := svc.handleAccountEvent(context.Background(), &id, nil, make(map[batchSeenKey]struct{}), false)
+
+	require.EqualError(t, err, "remove failed")
+	require.Empty(t, cache.batchSnapshotCache.writes)
+}
+
+func TestSchedulerAccountEventFallsBackToFullBucketRebuildWhenIncrementalDisabled(t *testing.T) {
+	cache := newIncrementalSnapshotCache()
+	repo := newIncrementalAccountRepo(&Account{ID: 97, Platform: PlatformOpenAI, Status: StatusActive, Schedulable: true, GroupIDs: []int64{13}})
+	svc := newIncrementalTestService(cache, repo)
+	svc.cfg.Gateway.Scheduling.IncrementalBucketUpdateEnabled = false
+	id := int64(97)
+	before := GetSchedulerOptimizationMetricsSnapshot()
+
+	err := svc.handleAccountEvent(context.Background(), &id, nil, make(map[batchSeenKey]struct{}), false)
+
+	require.NoError(t, err)
+	require.Empty(t, cache.removedBuckets())
+	written := make([]SchedulerBucket, 0, len(cache.batchSnapshotCache.writes))
+	for bucket := range cache.batchSnapshotCache.writes {
+		written = append(written, bucket)
+	}
+	require.ElementsMatch(t, schedulerCanonicalBuckets(13), written)
+	after := GetSchedulerOptimizationMetricsSnapshot()
+	require.Equal(t, before.Incremental.FallbackRebuildTotal+1, after.Incremental.FallbackRebuildTotal)
+}
+
+func TestDerefAccountsClonesMutableSnapshotFields(t *testing.T) {
+	group := &Group{ID: 7}
+	accountGroup := AccountGroup{AccountID: 1, GroupID: 7}
+	source := &Account{
+		ID: 1,
+		Credentials: map[string]any{
+			"project_id": "cached-project",
+			"nested":     map[string]any{"value": "cached-credential"},
+			"nested_list": []any{
+				map[string]any{"value": "cached-list-item"},
+			},
+		},
+		Extra: map[string]any{
+			"plan_type":         "cached-plan",
+			"model_rate_limits": map[string]any{"AICredits": "cached-limit"},
+		},
+		AccountGroups: []AccountGroup{accountGroup},
+		GroupIDs:      []int64{7},
+		Groups:        []*Group{group},
+	}
+
+	result := derefAccounts([]*Account{source})
+	require.Len(t, result, 1)
+	result[0].Credentials["project_id"] = "request-project"
+	result[0].Credentials["nested"].(map[string]any)["value"] = "request-credential"
+	result[0].Credentials["nested_list"].([]any)[0].(map[string]any)["value"] = "request-list-item"
+	result[0].Extra["plan_type"] = "request-plan"
+	result[0].Extra["model_rate_limits"].(map[string]any)["AICredits"] = "request-limit"
+	result[0].AccountGroups[0].GroupID = 8
+	result[0].GroupIDs[0] = 8
+	result[0].Groups[0] = nil
+
+	require.Equal(t, "cached-project", source.Credentials["project_id"])
+	require.Equal(t, "cached-credential", source.Credentials["nested"].(map[string]any)["value"])
+	require.Equal(t, "cached-list-item", source.Credentials["nested_list"].([]any)[0].(map[string]any)["value"])
+	require.Equal(t, "cached-plan", source.Extra["plan_type"])
+	require.Equal(t, "cached-limit", source.Extra["model_rate_limits"].(map[string]any)["AICredits"])
+	require.Equal(t, int64(7), source.AccountGroups[0].GroupID)
+	require.Equal(t, int64(7), source.GroupIDs[0])
+	require.Same(t, group, source.Groups[0])
+}

--- a/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
+++ b/backend/internal/service/scheduler_snapshot_outbox_cleanup_test.go
@@ -301,6 +301,7 @@ func TestSchedulerSnapshotServicePollOutboxDoesNotCleanupOnHandleFailure(t *test
 		lockAcquired: true,
 	}
 	svc := NewSchedulerSnapshotService(cache, repo, nil, nil, nil)
+	beforeMetrics := GetSchedulerOptimizationMetricsSnapshot()
 
 	svc.pollOutbox()
 
@@ -315,6 +316,20 @@ func TestSchedulerSnapshotServicePollOutboxDoesNotCleanupOnHandleFailure(t *test
 	}
 	if !reflect.DeepEqual(repo.rows, []int64{1, 2, 3, 4, 5, 6}) {
 		t.Fatalf("expected rows unchanged, got %#v", repo.rows)
+	}
+	afterFailure := GetSchedulerOptimizationMetricsSnapshot()
+	if afterFailure.Incremental.EventAttemptTotal != beforeMetrics.Incremental.EventAttemptTotal+1 ||
+		afterFailure.Incremental.EventFailureTotal != beforeMetrics.Incremental.EventFailureTotal+1 ||
+		afterFailure.Incremental.EventCommittedTotal != beforeMetrics.Incremental.EventCommittedTotal {
+		t.Fatalf("unexpected failed-event metrics: before=%+v after=%+v", beforeMetrics.Incremental, afterFailure.Incremental)
+	}
+
+	cache.updateErr = nil
+	svc.pollOutbox()
+	afterReplay := GetSchedulerOptimizationMetricsSnapshot()
+	if afterReplay.Incremental.EventReplayTotal != beforeMetrics.Incremental.EventReplayTotal+1 ||
+		afterReplay.Incremental.EventCommittedTotal != beforeMetrics.Incremental.EventCommittedTotal+1 {
+		t.Fatalf("unexpected replay metrics: before=%+v after=%+v", beforeMetrics.Incremental, afterReplay.Incremental)
 	}
 }
 
@@ -402,6 +417,7 @@ func TestSchedulerSnapshotServiceCheckOutboxLagLatchesPersistentDegradation(t *t
 				},
 			}
 			svc := NewSchedulerSnapshotService(cache, repo, &outboxCleanupAccountRepo{}, nil, cfg)
+			beforeMetrics := GetSchedulerOptimizationMetricsSnapshot()
 
 			for range 3 {
 				svc.checkOutboxLag(context.Background(), 0)
@@ -409,6 +425,10 @@ func TestSchedulerSnapshotServiceCheckOutboxLagLatchesPersistentDegradation(t *t
 
 			if cache.listBucketCalls != 1 {
 				t.Fatalf("expected one rebuild attempt during a persistent degraded episode, got %d", cache.listBucketCalls)
+			}
+			afterMetrics := GetSchedulerOptimizationMetricsSnapshot()
+			if afterMetrics.Drift.RepairTotal != beforeMetrics.Drift.RepairTotal+1 || afterMetrics.Rebuild.FullRebuildTotal != beforeMetrics.Rebuild.FullRebuildTotal+1 {
+				t.Fatalf("expected one observable drift repair/full rebuild, before=%+v after=%+v", beforeMetrics, afterMetrics)
 			}
 		})
 	}

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -68,6 +68,10 @@ type schedulerSnapshotAccountIDWriter interface {
 	SetSnapshotByAccountIDs(ctx context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accountIDs []int64) error
 }
 
+type schedulerSnapshotAccountRemover interface {
+	RemoveAccountFromBucket(ctx context.Context, bucket SchedulerBucket, token SchedulerBucketWriteToken, accountID int64) (bool, error)
+}
+
 func newSchedulerAccountQueryCache(taskSets ...[]schedulerBucketWriteTask) *schedulerAccountQueryCache {
 	queries := &schedulerAccountQueryCache{
 		remaining:          make(map[schedulerAccountQueryKey]int),
@@ -137,6 +141,7 @@ type SchedulerSnapshotService struct {
 	outboxRebuildRetryReason     string
 	outboxLagWarningActive       bool
 	outboxMaxIDErrorLastLoggedAt time.Time
+	outboxReplayUntilID          int64
 
 	fullRebuildRunMu     sync.Mutex
 	fullRebuildStateMu   sync.Mutex
@@ -234,7 +239,9 @@ func (s *SchedulerSnapshotService) ListSchedulableAccounts(ctx context.Context, 
 		}
 	}
 
+	fallbackStartedAt := time.Now()
 	if err := s.guardFallback(ctx); err != nil {
+		s.recordSchedulerDBFallback(0, time.Since(fallbackStartedAt), err)
 		return nil, useMixed, err
 	}
 
@@ -242,6 +249,7 @@ func (s *SchedulerSnapshotService) ListSchedulableAccounts(ctx context.Context, 
 	defer cancel()
 
 	accounts, err := s.loadAccountsFromDB(fallbackCtx, bucket, useMixed)
+	s.recordSchedulerDBFallback(len(accounts), time.Since(fallbackStartedAt), err)
 	if err != nil {
 		return nil, useMixed, err
 	}
@@ -272,12 +280,26 @@ func (s *SchedulerSnapshotService) GetAccount(ctx context.Context, accountID int
 		}
 	}
 
+	fallbackStartedAt := time.Now()
 	if err := s.guardFallback(ctx); err != nil {
+		s.recordSchedulerDBFallback(0, time.Since(fallbackStartedAt), err)
 		return nil, err
 	}
 	fallbackCtx, cancel := s.withFallbackTimeout(ctx)
 	defer cancel()
-	return s.accountRepo.GetByID(fallbackCtx, accountID)
+	account, err := s.accountRepo.GetByID(fallbackCtx, accountID)
+	accountCount := 0
+	if account != nil {
+		accountCount = 1
+	}
+	s.recordSchedulerDBFallback(accountCount, time.Since(fallbackStartedAt), err)
+	return account, err
+}
+
+func (s *SchedulerSnapshotService) recordSchedulerDBFallback(accountCount int, duration time.Duration, err error) {
+	limited := errors.Is(err, ErrSchedulerFallbackLimited)
+	disabled := s != nil && s.cfg != nil && !s.cfg.Gateway.Scheduling.DbFallbackEnabled
+	RecordSchedulerSnapshotDBFallback(accountCount, duration, err, limited, disabled)
 }
 
 // GetGroupByID 获取分组信息（供调度器使用）
@@ -365,15 +387,19 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 		// Clear degraded/retry state without adding two more repository queries to
 		// the healthy one-second poll path.
 		s.clearOutboxDegradedEpisode()
+		RecordSchedulerOutboxState(0, 0, false, false)
 		return
 	}
 
 	seen := make(map[batchSeenKey]struct{})
 	for _, event := range events {
+		RecordSchedulerOutboxEventAttempt(s.outboxReplayUntilID > 0 && event.ID <= s.outboxReplayUntilID)
 		eventCtx, cancel := context.WithTimeout(context.Background(), outboxEventTimeout)
 		err := s.handleOutboxEvent(eventCtx, event, seen)
 		cancel()
 		if err != nil {
+			RecordSchedulerOutboxEventFailure()
+			s.outboxReplayUntilID = event.ID
 			logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox handle failed: id=%d type=%s err=%v", event.ID, event.EventType, err)
 			return
 		}
@@ -393,9 +419,12 @@ func (s *SchedulerSnapshotService) pollOutbox() {
 		}
 	}
 	if wmErr != nil {
+		s.outboxReplayUntilID = lastID
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox watermark write failed: %v", wmErr)
 		return
 	}
+	s.outboxReplayUntilID = 0
+	RecordSchedulerOutboxEventsCommitted(len(events))
 	s.cleanupConsumedOutbox(lastID)
 
 	// 只有 watermark 成功推进后，当前批次才算已消费。延迟必须按下一条待消费事件计算，
@@ -442,9 +471,9 @@ func (s *SchedulerSnapshotService) handleOutboxEvent(ctx context.Context, event 
 	case SchedulerOutboxEventAccountBulkChanged:
 		return s.handleBulkAccountEvent(ctx, event.Payload, seen)
 	case SchedulerOutboxEventAccountGroupsChanged:
-		return s.handleAccountEvent(ctx, event.AccountID, event.Payload, seen)
+		return s.handleAccountEvent(ctx, event.AccountID, event.Payload, seen, true)
 	case SchedulerOutboxEventAccountChanged:
-		return s.handleAccountEvent(ctx, event.AccountID, event.Payload, seen)
+		return s.handleAccountEvent(ctx, event.AccountID, event.Payload, seen, false)
 	case SchedulerOutboxEventGroupChanged:
 		return s.handleGroupEvent(ctx, event.GroupID, seen)
 	case SchedulerOutboxEventFullRebuild:
@@ -486,6 +515,9 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 	}
 	if s.accountRepo == nil {
 		return nil
+	}
+	if s.cache == nil {
+		return ErrSchedulerCacheNotReady
 	}
 
 	rawIDs := parseInt64Slice(payload["account_ids"])
@@ -620,40 +652,160 @@ func (s *SchedulerSnapshotService) handleBulkAccountEvent(ctx context.Context, p
 	return s.rebuildBuckets(ctx, buckets, "account_bulk_change")
 }
 
-func (s *SchedulerSnapshotService) handleAccountEvent(ctx context.Context, accountID *int64, payload map[string]any, seen map[batchSeenKey]struct{}) error {
+func (s *SchedulerSnapshotService) handleAccountEvent(ctx context.Context, accountID *int64, payload map[string]any, seen map[batchSeenKey]struct{}, groupsChanged bool) error {
 	if accountID == nil || *accountID <= 0 {
 		return nil
 	}
 	if s.accountRepo == nil {
 		return nil
 	}
+	if s.cache == nil {
+		return ErrSchedulerCacheNotReady
+	}
 
-	var groupIDs []int64
+	var payloadGroupIDs []int64
 	if payload != nil {
-		groupIDs = parseInt64Slice(payload["group_ids"])
+		payloadGroupIDs = parseInt64Slice(payload["group_ids"])
 	}
 
 	account, err := s.accountRepo.GetByID(ctx, *accountID)
 	if err != nil {
 		if errors.Is(err, ErrAccountNotFound) {
-			if s.cache != nil {
-				if err := s.cache.DeleteAccount(ctx, *accountID); err != nil {
-					return err
-				}
+			if err := s.cache.DeleteAccount(ctx, *accountID); err != nil {
+				return err
 			}
-			return s.rebuildByGroupIDs(ctx, groupIDs, "account_miss", seen)
+			if err := s.removeAccountFromGroupBuckets(ctx, *accountID, payloadGroupIDs, seen, false); err != nil {
+				return err
+			}
+			return s.cache.DeleteAccount(ctx, *accountID)
 		}
 		return err
 	}
-	if s.cache != nil {
-		if err := s.cache.SetAccount(ctx, account); err != nil {
+	if err := s.cache.SetAccount(ctx, account); err != nil {
+		return err
+	}
+
+	affectedGroupIDs := append(append([]int64(nil), payloadGroupIDs...), account.GroupIDs...)
+	if err := s.removeAccountFromGroupBuckets(ctx, account.ID, affectedGroupIDs, seen, groupsChanged); err != nil {
+		return err
+	}
+	if !schedulerAccountInSnapshot(account, time.Now()) {
+		return s.cache.SetAccount(ctx, account)
+	}
+	if err := s.rebuildByAccount(ctx, account, account.GroupIDs, "account_change", seen); err != nil {
+		return err
+	}
+	// A writer fenced above may already have written stale account metadata
+	// before its snapshot activation was rejected. Publish the DB state last.
+	return s.cache.SetAccount(ctx, account)
+}
+
+func schedulerAccountInSnapshot(account *Account, now time.Time) bool {
+	if account == nil || account.Status != StatusActive || !account.Schedulable {
+		return false
+	}
+	if account.TempUnschedulableUntil != nil && now.Before(*account.TempUnschedulableUntil) {
+		return false
+	}
+	if account.AutoPauseOnExpired && account.ExpiresAt != nil && !now.Before(*account.ExpiresAt) {
+		return false
+	}
+	if account.OverloadUntil != nil && now.Before(*account.OverloadUntil) {
+		return false
+	}
+	return account.RateLimitResetAt == nil || !now.Before(*account.RateLimitResetAt)
+}
+
+func (s *SchedulerSnapshotService) removeAccountFromGroupBuckets(ctx context.Context, accountID int64, groupIDs []int64, seen map[batchSeenKey]struct{}, includeUngrouped bool) error {
+	remover, ok := s.cache.(schedulerSnapshotAccountRemover)
+	normalizedGroups := s.normalizeIncrementalGroupIDs(groupIDs, includeUngrouped)
+	if !s.incrementalBucketUpdateEnabled() || !ok {
+		RecordSchedulerIncrementalFallback()
+		buckets := make([]SchedulerBucket, 0, len(normalizedGroups)*12)
+		for _, platform := range schedulerSnapshotPlatforms() {
+			buckets = append(buckets, s.bucketsForPlatform(platform, normalizedGroups, seen)...)
+		}
+		slog.DebugContext(ctx, "scheduler account event uses bucket rebuild fallback",
+			"incremental_enabled", s.incrementalBucketUpdateEnabled(),
+			"incremental_supported", ok,
+			"buckets", len(buckets),
+		)
+		return s.rebuildBuckets(ctx, buckets, "account_remove_fallback")
+	}
+	buckets := make([]SchedulerBucket, 0, len(normalizedGroups)*12)
+	for _, groupID := range normalizedGroups {
+		buckets = append(buckets, schedulerCanonicalBuckets(groupID)...)
+	}
+	buckets = dedupeBuckets(buckets)
+	for _, bucket := range buckets {
+		if seen != nil {
+			if _, rebuilt := seen[batchSeenKey{groupID: bucket.GroupID, platform: bucket.Platform}]; rebuilt {
+				continue
+			}
+		}
+		startedAt := time.Now()
+		token, err := s.cache.CaptureBucketWriteToken(ctx, bucket)
+		if err != nil {
+			if errors.Is(err, ErrSchedulerBucketRetired) {
+				RecordSchedulerIncrementalBucket(false, time.Since(startedAt), nil)
+				continue
+			}
+			RecordSchedulerIncrementalBucket(false, time.Since(startedAt), err)
 			return err
 		}
+		locked, err := s.cache.TryLockBucket(ctx, bucket, 30*time.Second)
+		if err != nil {
+			RecordSchedulerIncrementalBucket(false, time.Since(startedAt), err)
+			return err
+		}
+		if !locked {
+			err = fmt.Errorf("%w: bucket=%s", ErrSchedulerBucketRebuildBusy, bucket.String())
+			RecordSchedulerIncrementalBucket(false, time.Since(startedAt), err)
+			return err
+		}
+		removed, removeErr := remover.RemoveAccountFromBucket(ctx, bucket, token, accountID)
+		unlockErr := s.cache.UnlockBucket(ctx, bucket)
+		if removeErr != nil {
+			RecordSchedulerIncrementalBucket(false, time.Since(startedAt), removeErr)
+			return removeErr
+		}
+		if unlockErr != nil {
+			RecordSchedulerIncrementalBucket(removed, time.Since(startedAt), unlockErr)
+			return unlockErr
+		}
+		RecordSchedulerIncrementalBucket(removed, time.Since(startedAt), nil)
 	}
-	if len(groupIDs) == 0 {
-		groupIDs = account.GroupIDs
+	slog.DebugContext(ctx, "scheduler account buckets updated incrementally",
+		"account_id", accountID,
+		"groups", len(normalizedGroups),
+		"buckets", len(buckets),
+	)
+	return nil
+}
+
+func (s *SchedulerSnapshotService) incrementalBucketUpdateEnabled() bool {
+	return s != nil && s.cfg != nil && s.cfg.Gateway.Scheduling.IncrementalBucketUpdateEnabled
+}
+
+func (s *SchedulerSnapshotService) normalizeIncrementalGroupIDs(groupIDs []int64, includeUngrouped bool) []int64 {
+	if s.isRunModeSimple() {
+		return []int64{0}
 	}
-	return s.rebuildByAccount(ctx, account, groupIDs, "account_change", seen)
+	unique := make(map[int64]struct{}, len(groupIDs)+1)
+	for _, groupID := range groupIDs {
+		if groupID > 0 {
+			unique[groupID] = struct{}{}
+		}
+	}
+	if includeUngrouped || len(unique) == 0 {
+		unique[0] = struct{}{}
+	}
+	out := make([]int64, 0, len(unique))
+	for groupID := range unique {
+		out = append(out, groupID)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }
 
 func (s *SchedulerSnapshotService) handleGroupEvent(ctx context.Context, groupID *int64, seen map[batchSeenKey]struct{}) error {
@@ -912,7 +1064,13 @@ func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicyAndQueryCache(
 	reason string,
 	strict bool,
 	queries *schedulerAccountQueryCache,
-) error {
+) (resultErr error) {
+	startedAt := time.Now()
+	outcome := "error"
+	accountCount := 0
+	defer func() {
+		RecordSchedulerBucketRebuild(outcome, accountCount, time.Since(startedAt))
+	}()
 	if queries != nil {
 		defer queries.release(task.bucket)
 	}
@@ -925,6 +1083,7 @@ func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicyAndQueryCache(
 		return err
 	}
 	if !ok {
+		outcome = "busy"
 		if strict {
 			return fmt.Errorf("%w: bucket=%s", ErrSchedulerBucketRebuildBusy, bucket.String())
 		}
@@ -942,8 +1101,10 @@ func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicyAndQueryCache(
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
 	}
+	accountCount = len(accounts)
 	if err := s.setRebuildSnapshot(rebuildCtx, task, accounts, queries); err != nil {
 		if errors.Is(err, ErrSchedulerBucketRetired) || errors.Is(err, ErrSchedulerBucketWriteFenced) {
+			outcome = "fenced"
 			slog.Debug("[Scheduler] rebuild fenced", "bucket", bucket.String(), "reason", reason)
 			if strict {
 				return err
@@ -953,6 +1114,7 @@ func (s *SchedulerSnapshotService) rebuildBucketWithTokenPolicyAndQueryCache(
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] rebuild cache failed: bucket=%s reason=%s err=%v", bucket.String(), reason, err)
 		return err
 	}
+	outcome = "success"
 	slog.Debug("[Scheduler] rebuild ok", "bucket", bucket.String(), "reason", reason, "size", len(accounts))
 	return nil
 }
@@ -989,7 +1151,11 @@ func (s *SchedulerSnapshotService) setRebuildSnapshot(
 	return nil
 }
 
-func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) error {
+func (s *SchedulerSnapshotService) triggerFullRebuild(reason string) (resultErr error) {
+	startedAt := time.Now()
+	defer func() {
+		RecordSchedulerFullRebuild(time.Since(startedAt), resultErr)
+	}()
 	if s.cache == nil {
 		return ErrSchedulerCacheNotReady
 	}
@@ -1248,6 +1414,7 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, watermark
 	now := time.Now()
 	oldestCreatedAt, ok, err := s.outboxRepo.FirstCreatedAtAfter(ctx, watermark)
 	if err != nil {
+		RecordSchedulerOutboxState(0, 0, false, true)
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox pending event read failed: %v", err)
 		return
 	}
@@ -1266,11 +1433,13 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, watermark
 
 	backlogThreshold := s.cfg.Gateway.Scheduling.OutboxBacklogRebuildRows
 	backlogKnown := true
+	checkError := false
 	var backlog int64
 	if backlogThreshold > 0 {
 		maxID, maxErr := s.outboxRepo.MaxID(ctx)
 		if maxErr != nil {
 			backlogKnown = false
+			checkError = true
 			if s.shouldLogOutboxMaxIDError(now) {
 				logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox max id read failed: %v", maxErr)
 			}
@@ -1339,6 +1508,7 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, watermark
 		}
 	}
 	s.lagMu.Unlock()
+	RecordSchedulerOutboxState(int64(lagSeconds), backlog, logLagWarning, checkError)
 
 	if logLagWarning {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] outbox lag warning: %ds", lagSeconds)
@@ -1372,6 +1542,7 @@ func (s *SchedulerSnapshotService) checkOutboxLag(ctx context.Context, watermark
 		s.outboxRebuildRetryReason = reason
 	}
 	s.lagMu.Unlock()
+	RecordSchedulerOutboxRepair(rebuildErr)
 
 	if rebuildErr != nil {
 		logger.LegacyPrintf("service.scheduler_snapshot", "[Scheduler] %s rebuild failed: %v", reason, rebuildErr)
@@ -1620,9 +1791,47 @@ func derefAccounts(accounts []*Account) []Account {
 		if account == nil {
 			continue
 		}
-		out = append(out, *account)
+		copy := *account
+		// Snapshot readers return value copies, but Credentials/Extra and the
+		// group slices are reference fields. Clone their containers so token
+		// refresh or request-specific enrichment cannot mutate a local snapshot.
+		copy.Credentials = cloneSchedulerSnapshotJSONMap(account.Credentials)
+		copy.Extra = cloneSchedulerSnapshotJSONMap(account.Extra)
+		copy.AccountGroups = append([]AccountGroup(nil), account.AccountGroups...)
+		copy.GroupIDs = append([]int64(nil), account.GroupIDs...)
+		copy.Groups = append([]*Group(nil), account.Groups...)
+		out = append(out, copy)
 	}
 	return out
+}
+
+// cloneSchedulerSnapshotJSONMap recursively copies the JSON-shaped maps stored
+// in the scheduler metadata cache. A shallow map copy is insufficient for
+// nested values such as model_rate_limits, which some request paths update.
+func cloneSchedulerSnapshotJSONMap(source map[string]any) map[string]any {
+	if source == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(source))
+	for key, value := range source {
+		cloned[key] = cloneSchedulerSnapshotJSONValue(value)
+	}
+	return cloned
+}
+
+func cloneSchedulerSnapshotJSONValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return cloneSchedulerSnapshotJSONMap(typed)
+	case []any:
+		cloned := make([]any, len(typed))
+		for i, item := range typed {
+			cloned[i] = cloneSchedulerSnapshotJSONValue(item)
+		}
+		return cloned
+	default:
+		return value
+	}
 }
 
 func parseInt64Slice(value any) []int64 {

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -499,6 +499,13 @@ gateway:
     # Tiny in-process TTL for batch load reads in milliseconds (0 disables)
     # 调度批量负载读取的进程内短缓存 TTL（毫秒，0 表示禁用）
     load_batch_cache_ttl_ms: 200
+    # Bounded Redis script load reads; set false only for emergency Pipeline fallback
+    # 有界 Redis 脚本负载读取；仅在异常时设为 false 回退 Pipeline
+    load_batch_script_enabled: true
+    # 进程内完整调度 metadata 快照缓存；异常时可关闭并回退 Redis 读取
+    snapshot_local_cache_enabled: true
+    # 账号事件单成员 bucket 增量维护；异常时可关闭并回退完整重建
+    incremental_bucket_update_enabled: true
     # Slot cleanup interval (duration)
     # 并发槽位清理周期（时间段）
     slot_cleanup_interval: 30s


### PR DESCRIPTION
## 变更背景

当前调度器在大账号池下有三类与选号规则无关的 I/O 放大：

- metadata snapshot 每次都需要读取完整 bucket、批量取值并重新 JSON 解码；
- 冷负载读取执行一次 `TIME`，再为每个账号执行 `ZREMRANGEBYSCORE + ZCARD + GET`，总计 `1 + 3N` 个 Redis 命令；
- OpenAI 候选和 spark 父账号在最终权威校验阶段存在逐账号 `GetByID`，账号池增大后形成 N+1。

20,000 个账号下，旧冷负载路径一次产生 60,001 个 Redis 命令；而完整高级评分本身只需要约 1.5-3.6ms。瓶颈主要在 snapshot、Redis 往返、JSON 分配和 DB authority check，不需要通过截断候选改变调度语义。

本 PR 延续 @jianjianai 在 #4112 中提出的候选快照、增量维护和基准验证方向，并保留署名。实现基于当前 `main` 重新落地，明确不采用固定 Top 64 / scan 256 候选窗口，因此：

Supersedes #4112

## 修改内容

### 1. 修正负载缓存 TTL，并复用进程内 metadata snapshot

- 负载缓存 TTL 从后端读取和结果复制成功后开始计算，避免慢 Redis 请求刚返回就已经过期；
- 本地 snapshot 命中必须同时满足 `ready + active version + bucket epoch + metadata revision + TTL`；
- 并发 miss 使用 singleflight 合并，控制状态读取失败或任一版本不一致时回到 Redis/DB，不返回旧本地数据；
- 对返回账号递归复制 JSON map/list 和账号关系切片，避免 token refresh、配额更新等请求内修改污染后续请求；
- 本地缓存最多接纳 20,000 个账号。超过上限时完整回读 Redis，不丢弃账号，也不缩小候选池。

### 2. 将冷负载读取改为有界 Lua 批处理

- 保留一次 Redis `TIME` 作为统一 cutoff；
- 每个 Lua 批次最多处理 256 个账号，所有批次通过一个 Pipeline 发送；
- Lua 仍逐账号执行原有过期槽清理、并发数、等待数和 load rate 计算，负等待数按 Go 的向零截断语义处理；
- 任一批次失败时丢弃全部脚本结果，并用旧 Pipeline 完整重读，不混用部分新旧结果；
- Redis Cluster / proxy 因 CROSSSLOT 或脚本策略拒绝多 key EVAL 时自动停用当前进程的脚本路径，继续使用兼容 Pipeline。

这里的 256 是单次 Redis 脚本工作量上限，不是调度候选窗口。

### 3. 批量执行 OpenAI DB 权威校验

- 候选账号和必要的 spark 父账号先去重，再调用现有 `GetByIDs`；
- 每次查询最多 64 个 ID，所有 OpenAI 选号、抢槽、fallback wait 和高级调度入口共用同一批量结果；
- 缺失账号、缺失父账号或任一批查询失败时继续 fail-closed，不接受未经 DB 确认的账号；
- sticky session 仍只校验其单个命中账号，不改变原有路径。

这里的 64 是 DB 查询参数边界，不是候选数量或 TopK。

### 4. 增量维护受影响 bucket

- 删除、禁用、移组和平台变化先在旧/新相关 canonical bucket 中做 epoch-fenced 单成员移除；
- 当前账号仍可调度时，只重建其当前平台和当前分组；新增、优先级变化等无法无损插入的情况继续走精确 full bucket rebuild；
- 复用现有 bucket lock、epoch、retire/reopen 和旧 rebuild fencing，不引入第二套 activation 状态机；
- 事件失败不推进 outbox watermark，重复/乱序事件可重放，周期 full rebuild 继续承担最终漂移修复；
- 修复 `BindGroups(accountID, [])` 清空关系后提前返回、漏发旧分组 outbox 的问题；
- `last_used` 仍推进 metadata revision，因为它参与同分账号的 LRU，不能为了提高缓存命中率改变轮转语义。

### 5. 增加观测和紧急回退

- 在现有 `GET /api/v1/admin/dashboard/realtime` 的 `data.scheduler` 下暴露进程内累计指标；
- 指标覆盖 snapshot hit/miss/invalidation、load cache/script/Pipeline/fallback、DB batch、incremental event、rebuild 和 drift repair；
- `load_batch_script_enabled`、`snapshot_local_cache_enabled`、`incremental_bucket_update_enabled` 默认开启；
- 三项配置均可显式设为 `false` 回到旧路径，用于事故回退，不新增管理 UI。

## 调度语义与兼容性

- OpenAI 高级调度仍对完整 bucket 做资格过滤和全量评分；
- 未修改 priority、LRU、load、模型能力、quota、sticky、并发抢槽、等待和错误语义；
- 唯一最优账号位于第 257 个、最后一个，或前 256 个全部不可用时，仍能选中正确账号；
- 没有新增数据库迁移、第三方依赖或前端设置项；
- 阶段 1B 的汇总计数器未实现：1A 后冷路径已不再主导，没有证据支持增加第二套持久状态和修复成本；
- 固定候选窗口/近似索引未实现：全量评分成本显著低于 I/O，当前没有必要牺牲最优账号可达性。

## 性能结果

真实 Redis 逐账号结果完全一致：

| 账号数 | 旧 Pipeline | Lua-256 | 改善 |
| ---: | ---: | ---: | ---: |
| 1,000 | 6.966ms | 4.690ms | 1.49x |
| 8,000 | 47.088ms | 25.411ms | 1.85x |
| 20,000 | 77.334ms | 47.025ms | 1.64x |

20,000 账号下：

- Redis 命令数从 60,001 降到 80；
- Go 分配从约 21.35MB / 360,124 allocs 降到 8.02MB / 140,895 allocs；
- Redis 压力期间最差 command latency 为 9ms，未观察到脚本失败或拒绝；
- 100 请求、并发 20 的同机对照中，默认开启和显式关闭均为 100/100 成功；p95 从 411.024ms 降到 356.224ms，p99 从 465.540ms 降到 404.978ms；
- 完整 metadata `ZRANGE/MGET` 读取次数减少 95%。

端到端延迟会受宿主负载、GC 和账号状态影响，因此这里只承诺结果等价和 Redis 工作量下降，不承诺固定延迟倍数。

## 回归测试

### 自动化检查

```text
go test -tags=unit ./...                                                     PASS
go test -tags=integration ./...                                              PASS
go test -race ./internal/repository ./internal/service -run 'Scheduler|Concurrency|OpenAI'  PASS
golangci-lint v2.9.0 run --timeout=30m ./...                                 0 issues
govulncheck ./...                                                            0 called vulnerabilities
make test-frontend                                                           6 files / 95 tests PASS
pnpm audit --prod --audit-level=high + audit exceptions                      PASS
docker compose build app                                                     PASS
```

integration 使用 `CI=true`、真实 Docker socket/CLI 启动 PostgreSQL 18.1 和 Redis 8.4，不是 Docker 不可用时的 skip。macOS Apple lifecycle 依赖 BSD `stat`，本地只能确认 `bash -n`；完整脚本由 PR 的 macOS runner 验证。

### 等价性与故障矩阵

- 覆盖 64、256、1,000、3,131、8,000、20,000 账号；
- 覆盖第 257 个和池尾唯一最优、前 256 个不可用、开关开/关结果一致；
- 覆盖过期槽清理、缺失/非法/负等待数、Lua 整体 fallback 和 context cancel；
- 覆盖 65 个 ID 分为 64 + 1、父账号去重、DB 缺行和查询失败 fail-closed；
- 覆盖本地控制读取失败、revision/version/epoch 失效、并发 miss 合并、20k 容量边界和嵌套 JSON mutation 隔离；
- 覆盖 outbox 重复/乱序、删除、禁用、移组、retire/reopen、旧 rebuild 晚到、锁失败重放和 watermark 单调性。

### 隔离部署与真实调用

- 20,000 合成账号的双实例全栈使用真实 PostgreSQL/Redis 和生产调度器；禁用/恢复 100 个账号、Redis 重启、应用滚动重启后，DB 与 active snapshot 的 20,000 个 ID 哈希一致；
- 8081 上使用现有 19 个真实 OpenAI 账号和生产 snapshot 序列化，通过正式 `/v1/responses` 发起 `gpt-5.4` 请求；首账号远程 502 后 failover 到第二账号并返回 HTTP 200，usage log 和 Responses 协议字段一致；
- 随后用最终 `db4295d64` 镜像 `sha256:99e50472c13507e956c52bb403e51a5b76d507d435cb35f85e2365c78f388772` 重建 app，health 为 200；启动日志实际记录 `path=script accounts=19 batches=1` 和增量 bucket 更新；
- 替换前后 PostgreSQL/Redis 容器与数据卷未重建，数据仍为 19 个账号、0 API key、1 个分组、0 绑定；真实调用创建的临时 key、分组和绑定均已清理。
