### PR TITLE
fix(openai): preserve 路径 call_id 超长时压缩至 64 字符上限

### DIFF
--- a/backend/internal/service/openai_codex_transform.go
+++ b/backend/internal/service/openai_codex_transform.go
@@ -1409,7 +1409,15 @@ func filterCodexInputWithOptions(input []any, opts codexInputFilterOptions) []an
 		// 若 item_reference 指向 legacy call_* 标识，则仅修正该引用本身。
 		fixCallIDPrefix := func(id string) string {
 			if opts.PreserveCallIDs {
-				return id
+				// preserve 模式尽量原样透传客户端 id 以维持 tool_use/tool_result
+				// 配对，但上游对 call_id 有 64 字符硬上限，超长原样透传必然被
+				// 400 拒绝（"Invalid 'input[N].call_id': string too long"）。
+				// 超长时退回确定性压缩：同一逻辑 id 在 function_call 与
+				// function_call_output 两侧结果一致，配对不受影响。
+				if len(id) <= codexCallIDMaxLength {
+					return id
+				}
+				return compactCodexCallID(id)
 			}
 			return normalizeCodexCallID(id)
 		}

--- a/backend/internal/service/openai_codex_transform_test.go
+++ b/backend/internal/service/openai_codex_transform_test.go
@@ -167,8 +167,48 @@ func TestApplyCodexOAuthTransform_BoundsLongCallIDsAndPreservesPairing(t *testin
 	}
 }
 
-func TestApplyCodexOAuthTransform_PreservesLongCallIDsWhenRequested(t *testing.T) {
-	callID := "call-" + strings.Repeat("x", 70)
+func TestApplyCodexOAuthTransform_PreservesCallIDsWithinLimitWhenRequested(t *testing.T) {
+	// preserve 模式下 ≤64 字符的 id 必须原样透传（含 64 字符等长边界），
+	// 不做任何前缀改写或压缩。
+	for _, tc := range []struct {
+		name   string
+		callID string
+	}{
+		{name: "anthropic toolu id", callID: "toolu_01ABCdefGHIjklMNOpqrsTUV"},
+		{name: "boundary 64 chars", callID: "toolu_" + strings.Repeat("x", codexCallIDMaxLength-len("toolu_"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.LessOrEqual(t, len(tc.callID), codexCallIDMaxLength)
+			reqBody := map[string]any{
+				"model": "gpt-5.2",
+				"input": []any{
+					map[string]any{"type": "function_call", "call_id": tc.callID, "name": "shell"},
+					map[string]any{"type": "function_call_output", "call_id": tc.callID, "output": "done"},
+				},
+			}
+
+			applyCodexOAuthTransformWithOptions(reqBody, codexOAuthTransformOptions{
+				PreserveToolCallIDs: true,
+			})
+
+			input, ok := reqBody["input"].([]any)
+			require.True(t, ok)
+			call, ok := input[0].(map[string]any)
+			require.True(t, ok)
+			output, ok := input[1].(map[string]any)
+			require.True(t, ok)
+			require.Equal(t, tc.callID, call["call_id"])
+			require.Equal(t, tc.callID, output["call_id"])
+		})
+	}
+}
+
+func TestApplyCodexOAuthTransform_CompactsOverlongCallIDsWhenPreserveRequested(t *testing.T) {
+	// preserve 模式下超过 64 字符的 id 若原样透传，上游必然 400
+	// （"Invalid 'input[N].call_id': string too long"），需退回确定性压缩；
+	// function_call 与 function_call_output 两侧压缩结果一致，配对保持。
+	callID := "srvtoolu_" + strings.Repeat("x", 69) // 78 字符，对应生产环境真实报错长度
+	require.Len(t, callID, 78)
 	reqBody := map[string]any{
 		"model": "gpt-5.2",
 		"input": []any{
@@ -187,8 +227,13 @@ func TestApplyCodexOAuthTransform_PreservesLongCallIDsWhenRequested(t *testing.T
 	require.True(t, ok)
 	output, ok := input[1].(map[string]any)
 	require.True(t, ok)
-	require.Equal(t, callID, call["call_id"])
-	require.Equal(t, callID, output["call_id"])
+
+	compacted, ok := call["call_id"].(string)
+	require.True(t, ok)
+	require.Len(t, compacted, codexCallIDMaxLength)
+	require.True(t, strings.HasPrefix(compacted, codexCallIDPrefix))
+	require.Equal(t, compacted, output["call_id"], "两侧压缩结果必须一致以保持配对")
+	require.Equal(t, compactCodexCallID(callID), compacted, "压缩必须是确定性的")
 }
 
 func TestApplyCodexOAuthTransform_ToolSearchOutputPreservesCallID(t *testing.T) {


### PR DESCRIPTION
## 变更说明

生产环境真实报错：客户端走 `/v1/messages`（Anthropic Messages 格式）入站，由 OAuth 账号转发上游 OpenAI `/v1/responses` 时，一旦客户端会话历史里出现超过 64 字符的工具 ID（例如嵌套代理拼接产生的 78 字符 `srvtoolu_*` ID），上游直接 400，整个会话无法继续：

```
Invalid 'input[614].call_id': string too long. Expected a string with maximum length 64, but got a string with length 78 instead.
```

根因：#4612 为 Codex 路径引入了 `call_id` 归一化 + 超长压缩（`normalizeCodexCallID` / `compactCodexCallID`），但有意将 `PreserveToolCallIDs=true` 的路径排除在外（保持原样以维持 `tool_use`/`tool_result` 配对）。而 Messages 桥接（`openai_gateway_messages.go`）与原生 `/v1/responses` 透传（`openai_gateway_forward.go`）两条链路恰好都以 `PreserveToolCallIDs: true` 调用 transform，导致超长 ID 毫无护栏地透传给上游，撞上 OpenAI 对 `call_id` 的 64 字符硬上限。

本 PR 是对已合并 #4612 的补全：在 preserve 路径上补一道长度护栏。

## 修复方式

单点修改 `filterCodexInputWithOptions` 内的 `fixCallIDPrefix`（该闭包是 `function_call`、`function_call_output` 等所有 tool-call 类 item 以及 `call_*` 形式 `item_reference` 的 `call_id` 修正唯一入口）：

- `PreserveCallIDs=true` 且 `len(id) <= 64`：仍原样透传，完全保持 #4612 承诺的"保持原样"语义，存量行为零变化；
- `PreserveCallIDs=true` 且 `len(id) > 64`：复用已有的 `compactCodexCallID` 做确定性 SHA-256 压缩（`fc_` 前缀 + 截断到 64 字符）。

配对不受影响：压缩是确定性的，同一逻辑 ID 在 `function_call` 与 `function_call_output` 两侧必然得到相同结果；OAuth 路径 `store=false` 每轮全量重放历史，跨轮压缩结果也一致。

不改 apicompat 层的 `toResponsesCallID` / `fromResponsesCallID`（保持纯粹的格式转换职责），在 transform 层单点修复即可同时覆盖 Messages 桥接与 `/v1/responses` 透传两条 preserve 路径。

## 兼容性

- ≤64 字符的 ID（含 64 字符等长边界）在 preserve 路径下依旧原样透传，Claude Code 等客户端的 `toolu_*` ID 正常配对，行为与 #4612 合并后完全一致；
- 仅当 ID 超过 64 字符（原样透传必然被上游 400 拒绝）时才触发压缩，属于"必挂"场景的兜底，不存在回退风险；
- 非 preserve 路径行为不变（仍走 `normalizeCodexCallID`）。

## 测试

- `go build ./...` 通过；
- 新增用例（`openai_codex_transform_test.go`）：
  - `TestApplyCodexOAuthTransform_PreservesCallIDsWithinLimitWhenRequested`：preserve 模式下常规 `toolu_*` ID 与 64 字符等长边界 ID 原样透传；
  - `TestApplyCodexOAuthTransform_CompactsOverlongCallIDsWhenPreserveRequested`：78 字符 `srvtoolu_*` ID（对应生产报错长度）被压缩到 64 字符、带 `fc_` 前缀，且 `function_call` 与 `function_call_output` 两侧结果一致、压缩确定性可复现；
- `go test -tags=unit ./internal/service -run "Codex|CallID|CallIDs" -count=1` 通过；
- `go test -tags=unit ./internal/service -count=1` 全量运行，除 `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` 外全部通过；该用例在未打本补丁的干净 `origin/main`（e625ce3）上以相同命令复现同样失败，与本次改动无关。
