### PR TITLE
docs (dcoker-cpmpose): 修正示例 compose 中错误的镜像地址

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -16,7 +16,7 @@ services:
   # Sub2API Application
   # ===========================================================================
   sub2api:
-    image: sub2api:latest
+    image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
     ulimits:


### PR DESCRIPTION
当前正是示例 compose 文件中指向的镜像位置不存在，调整为和 `deploy/docker-compose.standalone.yml` 一致的坐标
```
 # 错误的地址
  sub2api:
    image: sub2api:latest
```

```
  sub2api:
    image: weishaw/sub2api:latest
```