### PR TITLE
fix(gateway): Chat Completions 桥接受 Anthropic 上游的 SSE 紧凑格式

### DIFF
--- a/backend/internal/service/gateway_forward_as_chat_completions.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions.go
@@ -240,18 +240,19 @@ func (s *GatewayService) handleCCBufferedFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		// SSE 规范允许 `event:xxx`（冒号后无空格）：Kimi 等 Anthropic 兼容上游
+		// 返回紧凑格式，严格匹配 "event: " 会丢弃全部事件（#4653 同根因）。
+		if _, ok := extractOpenAISSEEventLine(line); !ok {
 			continue
 		}
 
 		if !scanner.Scan() {
 			break
 		}
-		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := extractOpenAISSEDataLine(scanner.Text())
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {
@@ -447,18 +448,18 @@ func (s *GatewayService) handleCCStreamingFromAnthropic(
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if !strings.HasPrefix(line, "event: ") {
+		// 与缓冲路径一致：接受 SSE 紧凑格式（冒号后无空格，#4653 同根因）。
+		if _, ok := extractOpenAISSEEventLine(line); !ok {
 			continue
 		}
 
 		if !scanner.Scan() {
 			break
 		}
-		dataLine := scanner.Text()
-		if !strings.HasPrefix(dataLine, "data: ") {
+		payload, ok := extractOpenAISSEDataLine(scanner.Text())
+		if !ok {
 			continue
 		}
-		payload := dataLine[6:]
 
 		var event apicompat.AnthropicStreamEvent
 		if err := json.Unmarshal([]byte(payload), &event); err != nil {

--- a/backend/internal/service/gateway_forward_as_chat_completions_test.go
+++ b/backend/internal/service/gateway_forward_as_chat_completions_test.go
@@ -75,6 +75,78 @@ func TestHandleCCBufferedFromAnthropic_PreservesMessageStartCacheUsageAndReasoni
 	require.Equal(t, "high", *result.ReasoningEffort)
 }
 
+// Kimi 等 Anthropic 兼容上游返回 SSE 紧凑格式（冒号后无空格），CC 桥此前按
+// "event: " / "data: " 严格匹配会丢弃全部事件，最终报 "Upstream stream ended
+// without a response"（#4653 同根因；#4657 只修了 /v1/responses 桥）。
+func TestHandleCCBufferedFromAnthropic_CompactSSEFormat(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := &http.Response{
+		Header: http.Header{"x-request-id": []string{"rid_cc_buffered_compact"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`event:message_start`,
+			`data:{"type":"message_start","message":{"id":"msg_c1","type":"message","role":"assistant","content":[],"model":"k3","stop_reason":"","usage":{"input_tokens":15,"cache_read_input_tokens":5,"cache_creation_input_tokens":2}}}`,
+			``,
+			`event:content_block_start`,
+			`data:{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"OK"}}`,
+			``,
+			`event:message_delta`,
+			`data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":3}}`,
+			``,
+		}, "\n"))),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCBufferedFromAnthropic(resp, c, "k3", "k3", nil, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 15, result.Usage.InputTokens)
+	require.Equal(t, 3, result.Usage.OutputTokens)
+	require.Equal(t, 5, result.Usage.CacheReadInputTokens)
+	require.Equal(t, 2, result.Usage.CacheCreationInputTokens)
+	require.Contains(t, rec.Body.String(), `"OK"`, "紧凑格式事件必须被解析并产出响应内容")
+}
+
+func TestHandleCCStreamingFromAnthropic_CompactSSEFormat(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+
+	resp := &http.Response{
+		Header: http.Header{"x-request-id": []string{"rid_cc_stream_compact"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			`event:message_start`,
+			`data:{"type":"message_start","message":{"id":"msg_c2","type":"message","role":"assistant","content":[],"model":"k3","stop_reason":"","usage":{"input_tokens":21,"cache_read_input_tokens":6,"cache_creation_input_tokens":1}}}`,
+			``,
+			`event:content_block_start`,
+			`data:{"type":"content_block_start","index":0,"content_block":{"type":"text","text":"OK"}}`,
+			``,
+			`event:message_delta`,
+			`data:{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":4}}`,
+			``,
+			`event:message_stop`,
+			`data:{"type":"message_stop"}`,
+			``,
+		}, "\n"))),
+	}
+
+	svc := &GatewayService{}
+	result, err := svc.handleCCStreamingFromAnthropic(resp, c, "k3", "k3", nil, time.Now(), true)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 21, result.Usage.InputTokens)
+	require.Equal(t, 4, result.Usage.OutputTokens)
+	require.Equal(t, 6, result.Usage.CacheReadInputTokens)
+	require.Equal(t, 1, result.Usage.CacheCreationInputTokens)
+	require.Contains(t, rec.Body.String(), `[DONE]`)
+}
+
 func TestHandleCCStreamingFromAnthropic_PreservesMessageStartCacheUsageAndReasoning(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)


### PR DESCRIPTION
## 问题（#4653 同根因，补齐 #4657 未覆盖的对称链路）

Issue #4653 报告：Kimi（`api.kimi.com/coding`）等 Anthropic 兼容上游返回 **SSE 紧凑格式**（冒号后无空格，[规范允许](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation)）时，经 sub2api 桥接调用报 `Upstream stream ended without a response`。

PR #4657 修复了 **Anthropic → `/v1/responses`** 桥（`gateway_forward_as_responses.go`）。但完全对称的 **Anthropic → `/v1/chat/completions`** 桥（`gateway_forward_as_chat_completions.go`）存在一模一样的缺陷，未被覆盖——同样的 Kimi 上游走 `/v1/chat/completions` 依旧复现：

```go
// 流式与缓冲两条路径各一份（共 4 处严格匹配 + 2 处硬切）
if !strings.HasPrefix(line, "event: ") { continue }      // 紧凑格式被整段丢弃
...
if !strings.HasPrefix(dataLine, "data: ") { continue }
payload := dataLine[6:]                                   // 按带空格前缀硬切 6 字符
```

事件全部被丢弃后，两条路径都产不出任何响应：缓冲路径 `finalResp == nil`，流式路径直接走 Finalize 输出空流。

## 修复

不新增解析器：复用 OpenAI 链路既有的 `extractOpenAISSEEventLine` / `extractOpenAISSEDataLine`（同包，正确处理 `field:` 后可选空格/tab），把 `handleCCBufferedFromAnthropic` 与 `handleCCStreamingFromAnthropic` 的严格匹配和 `dataLine[6:]` 硬切统一替换。

- 与 #4657 无冲突：不同文件、不同函数（该 PR 在 responses 桥内新增了自己的 helper）；两者合并后 Anthropic 两条桥的行为一致；
- 标准带空格格式行为不变（helper 兼容两种形式），现有用例继续通过。

## 测试

- 新增 `TestHandleCCBufferedFromAnthropic_CompactSSEFormat`、`TestHandleCCStreamingFromAnthropic_CompactSSEFormat`：紧凑格式下 usage（input/output/cache read/cache creation）完整提取、内容产出、`[DONE]` 收尾；
- 存量带空格格式用例（`TestHandleCC*_PreservesMessageStartCacheUsageAndReasoning`）不改动、继续通过；
- `go build`、`go vet`、`gofmt` 通过；`go test -tags=unit -run TestHandleCC ./internal/service/` 全绿。

## 去重说明

已核对 open/closed PR：#4657 仅改 `gateway_forward_as_responses.go`；无任何 PR 涉及 `gateway_forward_as_chat_completions.go` 的 SSE 解析。CC 桥与 responses 桥的重复解析代码源自 #3807 的管线拆分，后续可考虑统一收敛（不在本 PR 范围）。
