### PR TITLE
fix: 优雅关停超时不再跳过 Cleanup，避免缓冲的用量/计费记录丢失

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -183,7 +183,7 @@ func runMainServer() {
 	defer cancel()
 
 	if err := app.Server.Shutdown(ctx); err != nil {
-		log.Fatalf("Server forced to shutdown: %v", err)
+		log.Printf("Server forced to shutdown: %v", err)
 	}
 
 	log.Println("Server exited")


### PR DESCRIPTION
## 问题

`runMainServer` 用 `defer app.Cleanup()` 注册清理，但 `app.Server.Shutdown(ctx)` 失败时走 `log.Fatalf`，其内部调用 `os.Exit`，**不会执行 defer**，`app.Cleanup()` 被跳过

Shutdown目前是5s超时, 流式回复正常几十s, 很容易触发

## 修复

`Shutdown` 失败时改用 `log.Printf` 记录错误，然后正常返回，让 defer 的 `app.Cleanup()` 正常执行
