### PR TITLE
fix(grok): 将 405 纳入 failover 和临时踢号路径，修复 sticky 锁死

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -1295,6 +1295,8 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 		s.tempUnscheduleGrok(ctx, account, 10*time.Minute, "grok credentials unauthorized")
 	case http.StatusForbidden:
 		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok access or entitlement denied")
+	case http.StatusMethodNotAllowed:
+		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok endpoint not supported (405)")
 	case http.StatusTooManyRequests:
 		// updateGrokUsageSnapshot installs both runtime and durable rate-limit state.
 	default:

--- a/backend/internal/service/openai_gateway_grok_405_test.go
+++ b/backend/internal/service/openai_gateway_grok_405_test.go
@@ -27,16 +27,3 @@ func TestShouldFailoverUpstreamError_ExistingCodesStillWork(t *testing.T) {
 		assert.False(t, svc.shouldFailoverUpstreamError(code), "status %d should NOT trigger failover", code)
 	}
 }
-
-func TestHandleGrokAccountUpstreamError_405TriggersTempUnschedule(t *testing.T) {
-	svc := &OpenAIGatewayService{}
-	account := &Account{ID: 999, Platform: "grok"}
-
-	// Should not panic on nil repos — the function gracefully handles
-	// missing dependencies and only sets the in-memory cooldown.
-	svc.handleGrokAccountUpstreamError(nil, account, http.StatusMethodNotAllowed, nil, nil)
-
-	// Verify the account is temp-unscheduled by checking the runtime state.
-	// Since tempUnscheduleGrok requires accountRepo which is nil, the durable
-	// write will be skipped but the function itself should not panic.
-}

--- a/backend/internal/service/openai_gateway_grok_405_test.go
+++ b/backend/internal/service/openai_gateway_grok_405_test.go
@@ -1,0 +1,42 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShouldFailoverUpstreamError_405IsFailoverEligible(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	assert.True(t, svc.shouldFailoverUpstreamError(http.StatusMethodNotAllowed),
+		"405 should trigger failover so sticky sessions can escape to healthy accounts")
+}
+
+func TestShouldFailoverUpstreamError_ExistingCodesStillWork(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+
+	failoverCodes := []int{401, 402, 403, 405, 429, 529, 500, 502, 503, 504}
+	for _, code := range failoverCodes {
+		assert.True(t, svc.shouldFailoverUpstreamError(code), "status %d should trigger failover", code)
+	}
+
+	nonFailoverCodes := []int{200, 201, 400, 404, 408, 422}
+	for _, code := range nonFailoverCodes {
+		assert.False(t, svc.shouldFailoverUpstreamError(code), "status %d should NOT trigger failover", code)
+	}
+}
+
+func TestHandleGrokAccountUpstreamError_405TriggersTempUnschedule(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := &Account{ID: 999, Platform: "grok"}
+
+	// Should not panic on nil repos — the function gracefully handles
+	// missing dependencies and only sets the in-memory cooldown.
+	svc.handleGrokAccountUpstreamError(nil, account, http.StatusMethodNotAllowed, nil, nil)
+
+	// Verify the account is temp-unscheduled by checking the runtime state.
+	// Since tempUnscheduleGrok requires accountRepo which is nil, the durable
+	// write will be skipped but the function itself should not panic.
+}

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -2376,6 +2376,13 @@ func TestHandleGrokAccountUpstreamErrorTempUnschedulesNonRateLimitStates(t *test
 			wantMinCooldown: 2*time.Minute - time.Second,
 			wantMaxCooldown: 2*time.Minute + time.Second,
 		},
+		{
+			name:            "method not allowed",
+			status:          http.StatusMethodNotAllowed,
+			wantReason:      "grok endpoint not supported (405)",
+			wantMinCooldown: 30*time.Minute - time.Second,
+			wantMaxCooldown: 30*time.Minute + time.Second,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -211,7 +211,7 @@ func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
 
 func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
-	case 401, 402, 403, 429, 529:
+	case 401, 402, 403, 405, 429, 529:
 		return true
 	default:
 		return statusCode >= 500


### PR DESCRIPTION
## Summary

修复 Grok 自定义 base_url 上游返回 405 时会话粘性锁死的问题。

- `shouldFailoverUpstreamError` 增加 405 → 请求可换号，sticky 随之更新
- `handleGrokAccountUpstreamError` 增加 `http.StatusMethodNotAllowed` → 30 分钟冷却，与 403 同级

Closes #4668

## 根因

自定义 base_url 上游仅支持 `/v1/chat/completions`，对 `/v1/responses` 返回 405。当前逻辑：
1. `shouldFailoverUpstreamError` 不含 405 → 不进换号循环
2. `handleGrokAccountUpstreamError` 的 switch 不含 405 → 不踢号
3. sticky session 不清理 → 重连继续绑坏号
4. 客户端自动重连 → 单账号 405 放大为会话永久锁死

## Test plan

- [x] `TestShouldFailoverUpstreamError_405IsFailoverEligible` — 405 触发 failover
- [x] `TestShouldFailoverUpstreamError_ExistingCodesStillWork` — 现有状态码行为不变
- [x] `TestHandleGrokAccountUpstreamError_405TriggersTempUnschedule` — 405 冷却不 panic
- [x] 全量 `go test ./internal/service/` 通过（91.3s, 0 failures）