### PR TITLE
fix(gateway): handle response.in_progress to emit message_start

### DIFF
--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -215,7 +215,7 @@ func ResponsesEventToAnthropicEvents(
 	state *ResponsesEventToAnthropicState,
 ) []AnthropicStreamEvent {
 	switch evt.Type {
-	case "response.created":
+	case "response.created", "response.in_progress":
 		return resToAnthHandleCreated(evt, state)
 	case "response.output_item.added":
 		return resToAnthHandleOutputItemAdded(evt, state)


### PR DESCRIPTION
## 问题

通过 `/v1/messages` 接口（Anthropic Messages 桥接）访问 GPT-5.6 系列模型进行多轮工具调用时，第二轮请求触发 Claude Code SDK 报错：

```
Cannot read properties of undefined (reading 'input_tokens')
```

随后表现为"失忆"（丢失上下文）。

## 根因

`ResponsesEventToAnthropicEvents` 只处理 `response.created` 事件来发送 `message_start`。但在使用 `previous_response_id` 续轮时，OpenAI Responses API 可以直接从 `response.in_progress` 开始流（跳过 `response.created`）。此时 `message_start` Anthropic 事件从未发出，SDK 尝试读取 `message_start.message.usage.input_tokens` 时得到 `undefined` 而崩溃。

## 修复

将 `response.in_progress` 加入 `resToAnthHandleCreated` 的处理路径。`resToAnthHandleCreated` 内部已有 `MessageStartSent` 幂等保护，即使同一流中同时收到 `response.created` 和 `response.in_progress` 也只发一次 `message_start`。

## 测试

- 无损现有测试（`go test ./internal/pkg/apicompat`）
- 新场景：API Key 账号用 GPT-5.6 模型进行带工具调用的多轮对话，第二轮不再崩溃，上下文正常保留