### PR TITLE
fix(frontend): allow replacing account concurrency values

### DIFF
--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -605,11 +605,11 @@
             id="bulk-edit-concurrency"
             type="number"
             min="1"
+            :required="enableConcurrency"
             :disabled="!enableConcurrency"
             class="input"
             :class="!enableConcurrency && 'cursor-not-allowed opacity-50'"
             aria-labelledby="bulk-edit-concurrency-label"
-            @input="concurrency = Math.max(1, concurrency || 1)"
           />
         </div>
         <div>

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2718,8 +2718,7 @@
       <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <div>
           <label class="input-label">{{ t('admin.accounts.concurrency') }}</label>
-          <input v-model.number="form.concurrency" type="number" min="1" class="input"
-            @input="form.concurrency = Math.max(1, form.concurrency || 1)" />
+          <input v-model.number="form.concurrency" type="number" min="1" required class="input" />
         </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.loadFactor') }}</label>

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1418,8 +1418,14 @@
       <div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
         <div>
           <label class="input-label">{{ t('admin.accounts.concurrency') }}</label>
-          <input v-model.number="form.concurrency" type="number" min="1" class="input"
-            @input="form.concurrency = Math.max(1, form.concurrency || 1)" />
+          <input
+            v-model.number="form.concurrency"
+            type="number"
+            min="1"
+            required
+            class="input"
+            data-testid="account-concurrency-input"
+          />
         </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.loadFactor') }}</label>

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -316,6 +316,24 @@ describe('EditAccountModal', () => {
     authIsSimpleMode.value = true
   })
 
+  it('allows replacing the concurrency value after clearing the input', async () => {
+    const account = buildAccount()
+    account.concurrency = 10
+    const wrapper = mountModal(account)
+    const input = wrapper.get<HTMLInputElement>('[data-testid="account-concurrency-input"]')
+
+    expect(input.element.value).toBe('10')
+
+    await input.setValue('')
+    expect(input.element.value).toBe('')
+    expect(input.element.validity.valueMissing).toBe(true)
+
+    await input.setValue('2')
+    await input.setValue('24')
+    expect(input.element.value).toBe('24')
+    expect(input.element.validity.valid).toBe(true)
+  })
+
   it('reopening the same account rehydrates the OpenAI whitelist from props', async () => {
     const account = buildAccount()
     updateAccountMock.mockReset()


### PR DESCRIPTION
## Summary

- allow account concurrency inputs to be temporarily empty while users replace the current value
- keep empty and sub-1 values from being submitted with `required` and the existing `min="1"` constraint
- apply the behavior consistently to create, edit, and bulk-edit account forms
- add a regression test for the `10 → empty → 2 → 24` editing sequence

Fixes #4685

## Verification

- `pnpm exec vitest run src/components/account/__tests__/EditAccountModal.spec.ts` (33 tests passed)
- `pnpm run typecheck`
- ESLint on the four changed files
- `pnpm run build`

## Existing unrelated test failures

A full Vitest run executes 1243 tests: 1241 pass, while two existing assertions in `src/api/__tests__/admin.system.rollback.spec.ts` fail because the current implementation passes `{ timeout: 900000 }` as a third argument and the tests still expect two arguments. The focused account-modal suite passes.