### PR TITLE
fix(ops): 系统日志清理被拒绝时展示具体原因

### DIFF
--- a/frontend/src/i18n/locales/en/admin/ops.ts
+++ b/frontend/src/i18n/locales/en/admin/ops.ts
@@ -72,6 +72,7 @@ export default {
         runtimeConfigResetFailed: 'Failed to reset log configuration',
         cleanupConfirm: 'Clean up system logs matching the current filters? This cannot be undone.',
         cleanupSuccess: 'Cleanup complete. Deleted {count} log entries.',
+        cleanupFilterRequired: 'Cleanup requires at least one filter condition (start/end time or another field)',
         cleanupFailed: 'Failed to clean up system logs'
       },
       requestsTotal: 'Requests (total)',

--- a/frontend/src/i18n/locales/zh/admin/ops.ts
+++ b/frontend/src/i18n/locales/zh/admin/ops.ts
@@ -72,6 +72,7 @@ export default {
         runtimeConfigResetFailed: '重置日志配置失败',
         cleanupConfirm: '确定要清理匹配当前筛选条件的系统日志吗？此操作不可撤销。',
         cleanupSuccess: '清理完成，已删除 {count} 条日志。',
+        cleanupFilterRequired: '清理需要至少一个筛选条件（起止时间或其他字段）',
         cleanupFailed: '清理系统日志失败'
       },
       requestsTotal: '请求（总计）',

--- a/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
+++ b/frontend/src/views/admin/ops/components/OpsSystemLogTable.vue
@@ -6,6 +6,7 @@ import { opsAPI, type OpsRuntimeLogConfig, type OpsSystemLog, type OpsSystemLogS
 import Pagination from '@/components/common/Pagination.vue'
 import Select from '@/components/common/Select.vue'
 import { useAppStore } from '@/stores'
+import { extractApiErrorMessage } from '@/utils/apiError'
 
 const appStore = useAppStore()
 const { t } = useI18n()
@@ -312,7 +313,11 @@ const cleanupCurrentFilter = async () => {
     await Promise.all([fetchLogs(), fetchHealth()])
   } catch (err: any) {
     console.error('[OpsSystemLogTable] Failed to cleanup logs', err)
-    appStore.showError(err?.response?.data?.detail || t('admin.ops.systemLogs.cleanupFailed'))
+    appStore.showError(
+      extractApiErrorMessage(err, t('admin.ops.systemLogs.cleanupFailed'), {
+        OPS_SYSTEM_LOG_CLEANUP_FILTER_REQUIRED: t('admin.ops.systemLogs.cleanupFilterRequired')
+      })
+    )
   }
 }
 


### PR DESCRIPTION
## 问题

系统日志「清理当前筛选结果」在未设置任何筛选条件时，后端会返回 400（`reason: OPS_SYSTEM_LOG_CLEANUP_FILTER_REQUIRED`，`message: cleanup requires at least one filter condition`），但前端只弹出笼统的「清理系统日志失败」，用户无法得知失败原因和处理方式。

## 原因

axios 响应拦截器（`frontend/src/api/client.ts`）reject 的是扁平对象 `{status, code, reason, message, ...}`，而组件里取的是 `err?.response?.data?.detail`——该字段在此错误形态上永远不存在，因此始终落到兜底文案。

## 修改

- 清理失败的 catch 改用已有的共享工具 `extractApiErrorMessage`（`@/utils/apiError`），通过 `i18nMap` 把 `OPS_SYSTEM_LOG_CLEANUP_FILTER_REQUIRED` 映射为本地化提示「清理需要至少一个筛选条件（起止时间或其他字段）」；其余错误按 `message` → `error` → `response.data.detail` 链路兜底。
- zh/en 语言包新增 `cleanupFilterRequired` 文案。

## 验证
修复前:
<img width="4634" height="1556" alt="image" src="https://github.com/user-attachments/assets/2b21881e-479b-4638-8363-8eb693243829" />
修复后:
<img width="4598" height="1618" alt="image" src="https://github.com/user-attachments/assets/ba28815c-cbaf-4dc4-9b9a-c82958e1d790" />
