### PR TITLE
fix(promo): 优惠码编辑弹窗过期时间改用本地时间预填

### DIFF
--- a/frontend/src/views/admin/PromoCodesView.vue
+++ b/frontend/src/views/admin/PromoCodesView.vue
@@ -392,7 +392,7 @@ import { useAppStore } from '@/stores/app'
 import { useClipboard } from '@/composables/useClipboard'
 import { getPersistedPageSize } from '@/composables/usePersistedPageSize'
 import { adminAPI } from '@/api/admin'
-import { formatDateTime } from '@/utils/format'
+import { formatDateTime, formatDateTimeLocalInput } from '@/utils/format'
 import type { PromoCode, PromoCodeUsage } from '@/types'
 import type { Column } from '@/components/common/types'
 import AppLayout from '@/components/layout/AppLayout.vue'
@@ -628,7 +628,9 @@ const handleEdit = (code: PromoCode) => {
   editForm.bonus_amount = code.bonus_amount
   editForm.max_uses = code.max_uses
   editForm.status = code.status
-  editForm.expires_at_str = code.expires_at ? new Date(code.expires_at).toISOString().slice(0, 16) : ''
+  editForm.expires_at_str = code.expires_at
+    ? formatDateTimeLocalInput(Math.floor(new Date(code.expires_at).getTime() / 1000))
+    : ''
   editForm.notes = code.notes || ''
   showEditDialog.value = true
 }


### PR DESCRIPTION
## 问题描述

优惠码过期时间显示和编辑使用时间格式不一致
在 UTC+8 时区下,列表显示 00:00 的过期时间,编辑弹窗会显示成 16:00;**打开编辑弹窗不修改任何字段直接点保存,过期时间就会静默提前 8 小时,且每保存一次累积偏移一次**。

## 解决方案

预填改用项目已有的 `formatDateTimeLocalInput`(utils/format.ts,按本地时间拆字段),与 AnnouncementsView 的既有用法保持一致,使预填与保存解析对称。

## 验证
设置过期时间为00点
<img width="2182" height="722" alt="image" src="https://github.com/user-attachments/assets/b09b8f74-e36c-41d8-a655-c8f7dab0b453" />
点击编辑
修复前:
<img width="1226" height="1450" alt="image" src="https://github.com/user-attachments/assets/6083e97a-8ee4-4552-a8d6-1b2bb4306024" />
修复后:
<img width="1096" height="1442" alt="image" src="https://github.com/user-attachments/assets/a43ac396-b5c7-477e-b7a5-f6b06ae38ed9" />
