### PR TITLE
fix(usage): 统一后台使用记录模型筛选口径，解决 grok 相关模型无法过滤问题

### DIFF
--- a/backend/internal/handler/admin/usage_handler.go
+++ b/backend/internal/handler/admin/usage_handler.go
@@ -172,18 +172,19 @@ func (h *UsageHandler) List(c *gin.Context) {
 		SortOrder: c.DefaultQuery("sort_order", "desc"),
 	}
 	filters := usagestats.UsageLogFilters{
-		UserID:      userID,
-		APIKeyID:    apiKeyID,
-		AccountID:   accountID,
-		GroupID:     groupID,
-		Model:       model,
-		RequestType: requestType,
-		Stream:      stream,
-		BillingType: billingType,
-		BillingMode: billingMode,
-		StartTime:   startTime,
-		EndTime:     endTime,
-		ExactTotal:  exactTotal,
+		UserID:            userID,
+		APIKeyID:          apiKeyID,
+		AccountID:         accountID,
+		GroupID:           groupID,
+		Model:             model,
+		ModelFilterSource: usagestats.ModelSourceRequested,
+		RequestType:       requestType,
+		Stream:            stream,
+		BillingType:       billingType,
+		BillingMode:       billingMode,
+		StartTime:         startTime,
+		EndTime:           endTime,
+		ExactTotal:        exactTotal,
 	}
 
 	records, result, err := h.usageService.ListWithFilters(c.Request.Context(), params, filters)
@@ -312,17 +313,18 @@ func (h *UsageHandler) Stats(c *gin.Context) {
 
 	// Build filters and call GetStatsWithFilters
 	filters := usagestats.UsageLogFilters{
-		UserID:      userID,
-		APIKeyID:    apiKeyID,
-		AccountID:   accountID,
-		GroupID:     groupID,
-		Model:       model,
-		RequestType: requestType,
-		Stream:      stream,
-		BillingType: billingType,
-		BillingMode: billingMode,
-		StartTime:   &startTime,
-		EndTime:     &endTime,
+		UserID:            userID,
+		APIKeyID:          apiKeyID,
+		AccountID:         accountID,
+		GroupID:           groupID,
+		Model:             model,
+		ModelFilterSource: usagestats.ModelSourceRequested,
+		RequestType:       requestType,
+		Stream:            stream,
+		BillingType:       billingType,
+		BillingMode:       billingMode,
+		StartTime:         &startTime,
+		EndTime:           &endTime,
 	}
 
 	var stats *usagestats.UsageStats

--- a/backend/internal/handler/admin/usage_handler_request_type_test.go
+++ b/backend/internal/handler/admin/usage_handler_request_type_test.go
@@ -60,6 +60,19 @@ func TestAdminUsageListRequestTypePriority(t *testing.T) {
 	require.Nil(t, repo.listFilters.Stream)
 }
 
+func TestAdminUsageListUsesRequestedModelForDisplayModelFilter(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage?model=grok-imagine-video-1.5", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "grok-imagine-video-1.5", repo.listFilters.Model)
+	require.Equal(t, usagestats.ModelSourceRequested, repo.listFilters.ModelFilterSource)
+}
+
 func TestAdminUsageListInvalidRequestType(t *testing.T) {
 	repo := &adminUsageRepoCapture{}
 	router := newAdminUsageRequestTypeTestRouter(repo)
@@ -117,6 +130,19 @@ func TestAdminUsageStatsRequestTypePriority(t *testing.T) {
 	require.NotNil(t, repo.statsFilters.RequestType)
 	require.Equal(t, int16(service.RequestTypeStream), *repo.statsFilters.RequestType)
 	require.Nil(t, repo.statsFilters.Stream)
+}
+
+func TestAdminUsageStatsUsesRequestedModelForDisplayModelFilter(t *testing.T) {
+	repo := &adminUsageRepoCapture{}
+	router := newAdminUsageRequestTypeTestRouter(repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/admin/usage/stats?model=grok-imagine-video-1.5", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "grok-imagine-video-1.5", repo.statsFilters.Model)
+	require.Equal(t, usagestats.ModelSourceRequested, repo.statsFilters.ModelFilterSource)
 }
 
 func TestAdminUsageStatsInvalidRequestType(t *testing.T) {


### PR DESCRIPTION
问题说明：

使用 grok-imagine-video-1.5 模型后，无法在【使用记录】中通过模型名称过滤该模型，但可以通过计费模式过滤

该问题只出现在 /api/v1/admin/usage
普通用户侧 /api/v1/usage 无问题

<img width="2107" height="527" alt="image" src="https://github.com/user-attachments/assets/753a0a69-87e2-4cbf-aa1c-fbecbccb4f2b" />
。
<img width="1698" height="532" alt="image" src="https://github.com/user-attachments/assets/e9b9b516-00ae-4893-b761-6322550eed2c" />



管理端用量明细接口返回的 model 字段优先展示 requested_model，
但旧的模型筛选直接比较 usage_logs.model，导致展示模型与筛选字段
口径不一致。

以 Grok 纯文本视频为例：

- 用户请求：grok-imagine-video-1.5
- 网关为兼容上游归一化为：grok-imagine-video
归一化处理的代码：
<img width="800" height="410" alt="image" src="https://github.com/user-attachments/assets/1ae5d9a5-2af1-4ac0-bf5a-202cc031a64a" />

- 落库：
  - requested_model = grok-imagine-video-1.5
  - model = grok-imagine-video
- 管理端列表展示 requested_model，因此页面显示
  grok-imagine-video-1.5。
- 旧筛选使用 WHERE model = 'grok-imagine-video-1.5'，
  无法命中该记录；按 billing_mode=video 则可查询到。

修复：

管理端用量列表和统计接口将模型筛选指定为请求模型维度，
查询优先匹配 requested_model；历史记录 requested_model 为空时
自动回退到 model。

影响范围：

- /api/v1/admin/usage
- /api/v1/admin/usage/stats
- 不修改既有用量数据、Grok 模型归一化、计费逻辑或错误请求记录。
- 增加管理端请求模型筛选的回归测试。