### PR TITLE
功能：支持中转站异步生图任务

### DIFF
--- a/backend/internal/handler/image_task_handler.go
+++ b/backend/internal/handler/image_task_handler.go
@@ -261,6 +261,7 @@ func (h *AsyncImageHandler) failTask(taskID string, statusCode int, taskErr json
 func newAsyncImageContext(c *gin.Context, body []byte, timeoutDuration time.Duration) (*gin.Context, *httptest.ResponseRecorder, context.CancelFunc) {
 	base := context.WithoutCancel(c.Request.Context())
 	executionCtx, cancel := context.WithTimeout(base, timeoutDuration)
+	executionCtx = service.WithAsyncImageTask(executionCtx)
 	request := c.Request.Clone(executionCtx)
 	request.Body = io.NopCloser(bytes.NewReader(body))
 	request.GetBody = func() (io.ReadCloser, error) {

--- a/backend/internal/service/grok_media.go
+++ b/backend/internal/service/grok_media.go
@@ -419,6 +419,19 @@ func (s *OpenAIGatewayService) ForwardGrokMedia(
 		return nil, err
 	}
 	if endpoint == GrokMediaEndpointImagesGenerations || endpoint == GrokMediaEndpointImagesEdits {
+		if account.AsyncImageTaskRelayEnabled() && IsAsyncImageTask(ctx) {
+			relayed, relayErr := s.pollImageTaskRelay(ctx, c, account, account.GetGrokMediaBaseURL(), upstreamReq.Header, respBody)
+			if relayErr != nil {
+				return nil, relayErr
+			}
+			if relayed.relayed {
+				respBody = relayed.body
+				resp.StatusCode = http.StatusOK
+				if relayed.responseHeader != nil {
+					resp.Header = relayed.responseHeader
+				}
+			}
+		}
 		if countOpenAIResponseImageOutputsFromJSONBytes(respBody) <= 0 {
 			setOpsUpstreamError(c, http.StatusBadGateway, "xAI upstream returned no image output", truncateString(string(respBody), 512))
 			return nil, &UpstreamFailoverError{

--- a/backend/internal/service/image_storage.go
+++ b/backend/internal/service/image_storage.go
@@ -95,6 +95,7 @@ func (u *ImageResultUploader) Rewrite(ctx context.Context, taskID string, result
 		}
 		item["url"] = urlRaw
 		delete(item, "b64_json")
+		delete(item, "image_url")
 		items[i] = item
 	}
 	newData, err := json.Marshal(items)
@@ -123,6 +124,14 @@ func (u *ImageResultUploader) fetchImageBytes(ctx context.Context, item map[stri
 		}
 	}
 	if raw, ok := item["url"]; ok {
+		var rawURL string
+		if err := json.Unmarshal(raw, &rawURL); err == nil {
+			if rawURL = strings.TrimSpace(rawURL); rawURL != "" {
+				return u.download(ctx, rawURL)
+			}
+		}
+	}
+	if raw, ok := item["image_url"]; ok {
 		var rawURL string
 		if err := json.Unmarshal(raw, &rawURL); err == nil {
 			if rawURL = strings.TrimSpace(rawURL); rawURL != "" {

--- a/backend/internal/service/image_task_relay.go
+++ b/backend/internal/service/image_task_relay.go
@@ -1,0 +1,482 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	imageAsyncTaskRelayEnabledKey  = "async_image_task_relay_enabled"
+	imageAsyncTaskStatusURLKey     = "async_image_task_status_url"
+	imageAsyncTaskPollIntervalKey  = "async_image_task_poll_interval_seconds"
+	imageAsyncTaskUpstreamAsyncKey = "async_image_task_upstream_async_enabled"
+	defaultImageTaskPollInterval   = 3 * time.Second
+	defaultImageTaskStatusPath     = "/v1/image-tasks/{task_id}"
+)
+
+type asyncImageTaskContextKey struct{}
+
+// WithAsyncImageTask marks a request executed by the local asynchronous image
+// task worker. The marker prevents the upstream task relay from changing the
+// normal synchronous images API behavior.
+func WithAsyncImageTask(ctx context.Context) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, asyncImageTaskContextKey{}, true)
+}
+
+func IsAsyncImageTask(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	marked, _ := ctx.Value(asyncImageTaskContextKey{}).(bool)
+	return marked
+}
+
+// AsyncImageTaskRelayEnabled returns the account-level opt-in for upstream
+// providers that return a task ID instead of an image immediately.
+func (a *Account) AsyncImageTaskRelayEnabled() bool {
+	if a == nil {
+		return false
+	}
+	return accountBoolSetting(a, imageAsyncTaskRelayEnabledKey)
+}
+
+func (a *Account) AsyncImageTaskStatusURL() string {
+	if a == nil {
+		return ""
+	}
+	return strings.TrimSpace(accountStringSetting(a, imageAsyncTaskStatusURLKey))
+}
+
+// AsyncImageTaskUpstreamAsyncEnabled controls whether an opted-in JSON image
+// request asks the upstream relay to create its own asynchronous task. Missing
+// configuration defaults to true for OpenAI-compatible providers.
+func (a *Account) AsyncImageTaskUpstreamAsyncEnabled() bool {
+	return accountBoolSettingWithDefault(a, imageAsyncTaskUpstreamAsyncKey, true)
+}
+
+func (a *Account) AsyncImageTaskPollInterval() time.Duration {
+	if a == nil {
+		return defaultImageTaskPollInterval
+	}
+	seconds := accountIntSetting(a, imageAsyncTaskPollIntervalKey)
+	if seconds < 1 {
+		return defaultImageTaskPollInterval
+	}
+	if seconds > 60 {
+		seconds = 60
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func accountBoolSetting(a *Account, key string) bool {
+	return accountBoolSettingWithDefault(a, key, false)
+}
+
+func accountBoolSettingWithDefault(a *Account, key string, fallback bool) bool {
+	if a == nil || a.Extra == nil {
+		return fallback
+	}
+	if value, ok := a.Extra[key].(bool); ok {
+		return value
+	}
+	if nested, ok := a.Extra[a.Platform].(map[string]any); ok {
+		if value, ok := nested[key].(bool); ok {
+			return value
+		}
+	}
+	return fallback
+}
+
+func accountStringSetting(a *Account, key string) string {
+	if a == nil || a.Extra == nil {
+		return ""
+	}
+	if value, ok := a.Extra[key].(string); ok {
+		return value
+	}
+	if nested, ok := a.Extra[a.Platform].(map[string]any); ok {
+		value, _ := nested[key].(string)
+		return value
+	}
+	return ""
+}
+
+func accountIntSetting(a *Account, key string) int {
+	if a == nil || a.Extra == nil {
+		return 0
+	}
+	value, ok := a.Extra[key]
+	if !ok {
+		if nested, nestedOK := a.Extra[a.Platform].(map[string]any); nestedOK {
+			value, ok = nested[key]
+		}
+	}
+	if !ok {
+		return 0
+	}
+	switch typed := value.(type) {
+	case int:
+		return typed
+	case int8:
+		return int(typed)
+	case int16:
+		return int(typed)
+	case int32:
+		return int(typed)
+	case int64:
+		return int(typed)
+	case float32:
+		return int(typed)
+	case float64:
+		return int(typed)
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(typed))
+		if err == nil {
+			return parsed
+		}
+	}
+	return 0
+}
+
+type imageTaskRelayResult struct {
+	body           []byte
+	responseHeader http.Header
+	relayed        bool
+}
+
+// pollImageTaskRelay handles the small protocol shared by most OpenAI-style
+// image relays: the create response contains task_id (or id), and a later GET
+// returns either a processing state or an image result.
+func (s *OpenAIGatewayService) pollImageTaskRelay(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	baseURL string,
+	requestHeaders http.Header,
+	initialBody []byte,
+) (*imageTaskRelayResult, error) {
+	if s == nil || s.httpUpstream == nil {
+		return nil, fmt.Errorf("upstream image task relay is unavailable")
+	}
+	if result, ok := normalizeImageTaskRelayResult(initialBody); ok {
+		return &imageTaskRelayResult{body: result, relayed: true}, nil
+	}
+	taskID, found := imageTaskRelayID(initialBody)
+	if !found {
+		return &imageTaskRelayResult{body: initialBody}, nil
+	}
+
+	statusPath := account.AsyncImageTaskStatusURL()
+	if statusPath == "" {
+		statusPath = imageTaskRelayStatusURL(initialBody)
+	}
+	statusURL, err := buildImageTaskRelayStatusURL(baseURL, statusPath, taskID)
+	if err != nil {
+		return nil, err
+	}
+	requestHeaders = requestHeaders.Clone()
+	requestHeaders.Set("Accept", "application/json")
+	requestHeaders.Del("Content-Type")
+	requestHeaders.Del("Content-Length")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(account.AsyncImageTaskPollInterval()):
+		}
+
+		pollReq, err := http.NewRequestWithContext(
+			WithHTTPUpstreamRedirectsDisabled(ctx),
+			http.MethodGet,
+			statusURL,
+			nil,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("build upstream image task status request: %w", err)
+		}
+		pollReq = pollReq.WithContext(WithHTTPUpstreamProfile(pollReq.Context(), HTTPUpstreamProfileOpenAI))
+		pollReq.Header = requestHeaders.Clone()
+
+		proxyURL := ""
+		if account.ProxyID != nil && account.Proxy != nil {
+			proxyURL = account.Proxy.URL()
+		}
+		resp, err := s.httpUpstream.Do(pollReq, proxyURL, account.ID, account.Concurrency)
+		if err != nil {
+			return nil, fmt.Errorf("poll upstream image task: %w", err)
+		}
+		body, readErr := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+		_ = resp.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return nil, fmt.Errorf("upstream image task status returned HTTP %d: %s", resp.StatusCode, truncateString(string(body), 512))
+		}
+
+		status := imageTaskRelayStatus(body)
+		if imageTaskRelayFailed(status) {
+			return nil, fmt.Errorf("upstream image task failed: %s", imageTaskRelayErrorMessage(body))
+		}
+		if result, ok := normalizeImageTaskRelayResult(body); ok {
+			return &imageTaskRelayResult{
+				body:           result,
+				responseHeader: resp.Header.Clone(),
+				relayed:        true,
+			}, nil
+		}
+		if status != "" && !imageTaskRelayPending(status) {
+			return nil, fmt.Errorf("upstream image task returned unsupported status %q", status)
+		}
+	}
+}
+
+func imageTaskRelayID(body []byte) (string, bool) {
+	if len(body) == 0 || !gjson.ValidBytes(body) || imageTaskRelayHasImage(body) {
+		return "", false
+	}
+	for _, path := range []string{
+		"task_id", "taskId", "data.task_id", "data.taskId", "data.id",
+		"result.task_id", "result.taskId", "result.id",
+	} {
+		if value := strings.TrimSpace(gjson.GetBytes(body, path).String()); value != "" {
+			return value, true
+		}
+	}
+	status := imageTaskRelayStatus(body)
+	if status == "" || imageTaskRelayPending(status) {
+		if value := strings.TrimSpace(gjson.GetBytes(body, "id").String()); value != "" {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func imageTaskRelayStatusURL(body []byte) string {
+	if !gjson.ValidBytes(body) {
+		return ""
+	}
+	for _, path := range []string{
+		"poll_url", "status_url", "data.poll_url", "data.status_url",
+		"result.poll_url", "result.status_url",
+	} {
+		if value := strings.TrimSpace(gjson.GetBytes(body, path).String()); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func imageTaskRelayStatus(body []byte) string {
+	for _, path := range []string{"status", "state", "data.status", "result.status", "result.state", "output.status"} {
+		if value := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, path).String())); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func imageTaskRelayPending(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "created", "accepted", "submitted", "scheduled", "queued", "in_queue", "in-queue", "pending", "waiting", "processing", "running", "started", "generating", "in_progress", "in-progress", "not_started":
+		return true
+	default:
+		return false
+	}
+}
+
+func imageTaskRelayFailed(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed", "failure", "error", "cancelled", "canceled", "expired":
+		return true
+	default:
+		return false
+	}
+}
+
+func imageTaskRelayHasImage(body []byte) bool {
+	if !gjson.ValidBytes(body) {
+		return false
+	}
+	if strings.HasPrefix(strings.TrimSpace(string(body)), "[") && imageTaskRelayArrayHasImage(body, "") {
+		return true
+	}
+	for _, path := range []string{"data", "result.data", "output", "result.output"} {
+		if imageTaskRelayArrayHasImage(body, path) {
+			return true
+		}
+	}
+	for _, path := range []string{"url", "image_url", "result.url", "result.image_url", "output.url", "output.image_url"} {
+		if strings.TrimSpace(gjson.GetBytes(body, path).String()) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeImageTaskRelayResult(body []byte) ([]byte, bool) {
+	if !gjson.ValidBytes(body) {
+		return nil, false
+	}
+	if imageTaskRelayArrayHasImage(body, "data") {
+		return stripImageTaskRelayMetadata(normalizeImageTaskRelayImageFields(body)), true
+	}
+	for _, path := range []string{"result", "output", "response"} {
+		raw := gjson.GetBytes(body, path)
+		if raw.Exists() && imageTaskRelayHasImage([]byte(raw.Raw)) {
+			if imageTaskRelayArrayHasImage([]byte(raw.Raw), "") {
+				return wrapImageTaskArray(normalizeImageTaskRelayImageFields([]byte(raw.Raw))), true
+			}
+			if imageTaskRelayArrayHasImage([]byte(raw.Raw), "data") {
+				return stripImageTaskRelayMetadata(normalizeImageTaskRelayImageFields([]byte(raw.Raw))), true
+			}
+			if urlValue := strings.TrimSpace(gjson.GetBytes([]byte(raw.Raw), "url").String()); urlValue != "" {
+				return wrapImageTaskURL(urlValue), true
+			}
+			if urlValue := strings.TrimSpace(gjson.GetBytes([]byte(raw.Raw), "image_url").String()); urlValue != "" {
+				return wrapImageTaskURL(urlValue), true
+			}
+		}
+	}
+	for _, path := range []string{"url", "image_url"} {
+		if urlValue := strings.TrimSpace(gjson.GetBytes(body, path).String()); urlValue != "" {
+			return wrapImageTaskURL(urlValue), true
+		}
+	}
+	return nil, false
+}
+
+func imageTaskRelayArrayHasImage(body []byte, path string) bool {
+	value := gjson.GetBytes(body, path)
+	if path == "" {
+		value = gjson.ParseBytes(body)
+	}
+	for _, item := range value.Array() {
+		if strings.TrimSpace(item.Get("url").String()) != "" ||
+			strings.TrimSpace(item.Get("image_url").String()) != "" ||
+			strings.TrimSpace(item.Get("b64_json").String()) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeImageTaskRelayImageFields(body []byte) []byte {
+	var envelope map[string]json.RawMessage
+	if json.Unmarshal(body, &envelope) == nil {
+		if rawData, ok := envelope["data"]; ok {
+			var items []map[string]json.RawMessage
+			if json.Unmarshal(rawData, &items) == nil {
+				for _, item := range items {
+					if _, hasURL := item["url"]; hasURL {
+						continue
+					}
+					if imageURL, ok := item["image_url"]; ok {
+						item["url"] = imageURL
+						delete(item, "image_url")
+					}
+				}
+				if normalized, err := json.Marshal(items); err == nil {
+					envelope["data"] = normalized
+					if normalizedBody, err := json.Marshal(envelope); err == nil {
+						return normalizedBody
+					}
+				}
+			}
+		}
+	}
+
+	var items []map[string]json.RawMessage
+	if json.Unmarshal(body, &items) != nil {
+		return body
+	}
+	for _, item := range items {
+		if _, hasURL := item["url"]; hasURL {
+			continue
+		}
+		if imageURL, ok := item["image_url"]; ok {
+			item["url"] = imageURL
+			delete(item, "image_url")
+		}
+	}
+	normalized, err := json.Marshal(items)
+	if err != nil {
+		return body
+	}
+	return normalized
+}
+
+func stripImageTaskRelayMetadata(body []byte) []byte {
+	var envelope map[string]json.RawMessage
+	if json.Unmarshal(body, &envelope) != nil {
+		return body
+	}
+	for _, key := range []string{"id", "task_id", "taskId", "status", "state", "poll_url", "status_url"} {
+		delete(envelope, key)
+	}
+	cleaned, err := json.Marshal(envelope)
+	if err != nil {
+		return body
+	}
+	return cleaned
+}
+
+func wrapImageTaskURL(imageURL string) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"created": time.Now().Unix(),
+		"data":    []map[string]string{{"url": imageURL}},
+	})
+	return body
+}
+
+func wrapImageTaskArray(items []byte) []byte {
+	body, _ := json.Marshal(map[string]any{
+		"created": time.Now().Unix(),
+		"data":    json.RawMessage(items),
+	})
+	return body
+}
+
+func imageTaskRelayErrorMessage(body []byte) string {
+	for _, path := range []string{"error.message", "message", "result.error.message"} {
+		if value := strings.TrimSpace(gjson.GetBytes(body, path).String()); value != "" {
+			return value
+		}
+	}
+	return "unknown upstream image task error"
+}
+
+func buildImageTaskRelayStatusURL(baseURL, template, taskID string) (string, error) {
+	taskID = url.PathEscape(strings.TrimSpace(taskID))
+	if taskID == "" {
+		return "", fmt.Errorf("upstream image task id is empty")
+	}
+	path := strings.TrimSpace(template)
+	if path == "" {
+		path = defaultImageTaskStatusPath
+	}
+	path = strings.ReplaceAll(path, "{task_id}", taskID)
+	if parsed, err := url.Parse(path); err == nil && parsed.IsAbs() {
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return "", fmt.Errorf("upstream image task status URL must use HTTP or HTTPS")
+		}
+		return parsed.String(), nil
+	}
+	if strings.TrimSpace(baseURL) == "" {
+		return "", fmt.Errorf("upstream image task status URL requires a base URL")
+	}
+	return buildOpenAIEndpointURL(baseURL, path), nil
+}

--- a/backend/internal/service/image_task_relay_test.go
+++ b/backend/internal/service/image_task_relay_test.go
@@ -1,0 +1,195 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+type imageTaskRelayHTTPStub struct {
+	responses []*http.Response
+	requests  []*http.Request
+}
+
+func (s *imageTaskRelayHTTPStub) Do(req *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
+	s.requests = append(s.requests, req)
+	if len(s.responses) == 0 {
+		return nil, io.EOF
+	}
+	response := s.responses[0]
+	s.responses = s.responses[1:]
+	return response, nil
+}
+
+func (s *imageTaskRelayHTTPStub) DoWithTLS(req *http.Request, proxyURL string, accountID int64, accountConcurrency int, _ *tlsfingerprint.Profile) (*http.Response, error) {
+	return s.Do(req, proxyURL, accountID, accountConcurrency)
+}
+
+func imageTaskRelayResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestPollImageTaskRelayPollsUntilCompleted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	stub := &imageTaskRelayHTTPStub{responses: []*http.Response{
+		imageTaskRelayResponse(http.StatusOK, `{"status":"processing","task_id":"up-task-1"}`),
+		imageTaskRelayResponse(http.StatusOK, `{"status":"completed","result":{"data":[{"url":"https://upstream.test/a.png"}]}}`),
+	}}
+	svc := &OpenAIGatewayService{httpUpstream: stub}
+	account := &Account{
+		ID:       7,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+		Extra: map[string]any{
+			imageAsyncTaskRelayEnabledKey: true,
+			imageAsyncTaskStatusURLKey:    "/v1/images/status/{task_id}",
+			imageAsyncTaskPollIntervalKey: "1",
+		},
+	}
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := svc.pollImageTaskRelay(
+		ctx,
+		ginContext,
+		account,
+		"https://relay.test",
+		http.Header{"Authorization": []string{"Bearer secret"}},
+		[]byte(`{"task_id":"up-task-1","status":"queued"}`),
+	)
+	require.NoError(t, err)
+	require.True(t, result.relayed)
+	require.JSONEq(t, `{"data":[{"url":"https://upstream.test/a.png"}]}`, string(result.body))
+	require.Len(t, stub.requests, 2)
+	require.Equal(t, http.MethodGet, stub.requests[0].Method)
+	require.Equal(t, "https://relay.test/v1/images/status/up-task-1", stub.requests[0].URL.String())
+	require.Equal(t, "Bearer secret", stub.requests[0].Header.Get("Authorization"))
+}
+
+func TestPollImageTaskRelayLeavesSynchronousImageResponseUntouched(t *testing.T) {
+	stub := &imageTaskRelayHTTPStub{}
+	svc := &OpenAIGatewayService{httpUpstream: stub}
+	account := &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	initial := []byte(`{"created":123,"data":[{"b64_json":"aW1hZ2U="}]}`)
+
+	result, err := svc.pollImageTaskRelay(
+		context.Background(),
+		nil,
+		account,
+		"https://relay.test",
+		nil,
+		initial,
+	)
+	require.NoError(t, err)
+	require.True(t, result.relayed)
+	require.Equal(t, string(initial), string(result.body))
+	require.Empty(t, stub.requests)
+}
+
+func TestImageTaskRelayAccountSettings(t *testing.T) {
+	account := &Account{Platform: PlatformOpenAI, Extra: map[string]any{
+		imageAsyncTaskRelayEnabledKey: true,
+		imageAsyncTaskPollIntervalKey: 90,
+	}}
+	require.True(t, account.AsyncImageTaskRelayEnabled())
+	require.True(t, account.AsyncImageTaskUpstreamAsyncEnabled())
+	require.Equal(t, 60*time.Second, account.AsyncImageTaskPollInterval())
+	require.False(t, (&Account{Platform: PlatformOpenAI}).AsyncImageTaskRelayEnabled())
+	require.True(t, (&Account{Platform: PlatformOpenAI}).AsyncImageTaskUpstreamAsyncEnabled())
+	require.False(t, (&Account{Platform: PlatformOpenAI, Extra: map[string]any{
+		imageAsyncTaskUpstreamAsyncKey: false,
+	}}).AsyncImageTaskUpstreamAsyncEnabled())
+}
+
+func TestPollImageTaskRelayPrefersUpstreamPollURL(t *testing.T) {
+	stub := &imageTaskRelayHTTPStub{responses: []*http.Response{
+		imageTaskRelayResponse(http.StatusOK, `{"status":"completed","data":[{"url":"https://upstream.test/a.png"}]}`),
+	}}
+	svc := &OpenAIGatewayService{httpUpstream: stub}
+	account := &Account{ID: 7, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{
+		imageAsyncTaskPollIntervalKey: 1,
+	}}
+	recorder := httptest.NewRecorder()
+	ginContext, _ := gin.CreateTestContext(recorder)
+	ginContext.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", bytes.NewReader(nil))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	result, err := svc.pollImageTaskRelay(
+		ctx,
+		ginContext,
+		account,
+		"https://relay.test",
+		http.Header{"Authorization": []string{"Bearer secret"}},
+		[]byte(`{"task_id":"up-task-1","status":"queued","poll_url":"/v1/image-tasks/{task_id}"}`),
+	)
+	require.NoError(t, err)
+	require.True(t, result.relayed)
+	require.Len(t, stub.requests, 1)
+	require.Equal(t, "https://relay.test/v1/image-tasks/up-task-1", stub.requests[0].URL.String())
+}
+
+func TestImageTaskRelayAcceptsCommonQueuedStatuses(t *testing.T) {
+	for _, status := range []string{"accepted", "submitted", "scheduled", "in_queue", "waiting", "started", "generating", "not_started"} {
+		require.True(t, imageTaskRelayPending(status), status)
+	}
+	require.False(t, imageTaskRelayPending("completed"))
+}
+
+func TestImageTaskRelayFindsNestedTaskID(t *testing.T) {
+	for _, body := range []string{
+		`{"data":{"id":"data-task"},"status":"submitted"}`,
+		`{"result":{"task_id":"result-task"},"state":"queued"}`,
+	} {
+		taskID, ok := imageTaskRelayID([]byte(body))
+		require.True(t, ok)
+		require.NotEmpty(t, taskID)
+	}
+}
+
+func TestNormalizeImageTaskRelayResultRemovesUpstreamTaskMetadata(t *testing.T) {
+	result, ok := normalizeImageTaskRelayResult([]byte(`{"id":"up-task-1","status":"completed","data":[{"url":"https://upstream.test/a.png"}]}`))
+	require.True(t, ok)
+	require.JSONEq(t, `{"data":[{"url":"https://upstream.test/a.png"}]}`, string(result))
+}
+
+func TestNormalizeImageTaskRelayResultWrapsOutputArray(t *testing.T) {
+	result, ok := normalizeImageTaskRelayResult([]byte(`{"status":"completed","output":[{"image_url":"https://upstream.test/a.png"}]}`))
+	require.True(t, ok)
+	require.JSONEq(t, `{"created":`+strings.TrimSpace(gjson.GetBytes(result, "created").String())+`,"data":[{"url":"https://upstream.test/a.png"}]}`, string(result))
+}
+
+func TestMarkOpenAIImagesRequestAsync(t *testing.T) {
+	rewritten, contentType, err := markOpenAIImagesRequestAsync(
+		[]byte(`{"model":"gpt-image-2","async":false}`),
+		"application/json",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "application/json", contentType)
+	require.JSONEq(t, `{"model":"gpt-image-2","async":true}`, string(rewritten))
+}
+
+func TestMarkOpenAIImagesRequestAsyncLeavesMultipartUntouched(t *testing.T) {
+	body := []byte("multipart body")
+	rewritten, contentType, err := markOpenAIImagesRequestAsync(body, "multipart/form-data; boundary=test")
+	require.NoError(t, err)
+	require.Equal(t, string(body), string(rewritten))
+	require.Equal(t, "multipart/form-data; boundary=test", contentType)
+}

--- a/backend/internal/service/openai_images.go
+++ b/backend/internal/service/openai_images.go
@@ -603,6 +603,12 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 	}
 	upstreamCtx, releaseUpstreamCtx := detachStreamUpstreamContext(ctx, parsed.Stream)
 	defer releaseUpstreamCtx()
+	if account.AsyncImageTaskRelayEnabled() && account.AsyncImageTaskUpstreamAsyncEnabled() && IsAsyncImageTask(upstreamCtx) {
+		forwardBody, forwardContentType, err = markOpenAIImagesRequestAsync(forwardBody, forwardContentType)
+		if err != nil {
+			return nil, err
+		}
+	}
 
 	token, _, err := s.GetAccessToken(upstreamCtx, account)
 	if err != nil {
@@ -706,7 +712,16 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 			ImageOutputSizes: imageOutputSizes,
 		}, nil
 	} else {
-		nonStreamUsage, nonStreamCount, nonStreamSizes, err := s.handleOpenAIImagesNonStreamingResponse(resp, c)
+		var nonStreamUsage OpenAIUsage
+		var nonStreamCount int
+		var nonStreamSizes []string
+		if account.AsyncImageTaskRelayEnabled() && IsAsyncImageTask(upstreamCtx) {
+			nonStreamUsage, nonStreamCount, nonStreamSizes, err = s.handleOpenAIImagesNonStreamingResponseWithTaskRelay(
+				resp, c, upstreamCtx, account, account.GetOpenAIBaseURL(), upstreamReq.Header,
+			)
+		} else {
+			nonStreamUsage, nonStreamCount, nonStreamSizes, err = s.handleOpenAIImagesNonStreamingResponse(resp, c)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -729,6 +744,21 @@ func (s *OpenAIGatewayService) forwardOpenAIImagesAPIKey(
 			ImageOutputSizes: nonStreamSizes,
 		}, nil
 	}
+}
+
+// markOpenAIImagesRequestAsync asks an opted-in upstream relay to create its
+// own task. This only runs inside the local async worker; synchronous callers
+// keep the original request body unchanged.
+func markOpenAIImagesRequestAsync(body []byte, contentType string) ([]byte, string, error) {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err == nil && strings.EqualFold(mediaType, "multipart/form-data") {
+		return body, contentType, nil
+	}
+	rewritten, err := sjson.SetBytes(body, "async", true)
+	if err != nil {
+		return nil, "", fmt.Errorf("mark image request async: %w", err)
+	}
+	return rewritten, contentType, nil
 }
 
 func (s *OpenAIGatewayService) buildOpenAIImagesRequest(
@@ -882,17 +912,54 @@ func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponse(resp *http
 	if err != nil {
 		return OpenAIUsage{}, 0, nil, err
 	}
-	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
-	contentType := "application/json"
-	if s.cfg != nil && !s.cfg.Security.ResponseHeaders.Enabled {
-		if upstreamType := resp.Header.Get("Content-Type"); upstreamType != "" {
-			contentType = upstreamType
-		}
-	}
-	c.Data(resp.StatusCode, contentType, body)
+	s.writeOpenAIImagesJSONResponse(c, resp.StatusCode, resp.Header, body)
 
 	usage, _ := extractOpenAIUsageFromJSONBytes(body)
 	return usage, extractOpenAIImageCountFromJSONBytes(body), collectOpenAIResponseImageOutputSizesFromJSONBytes(body), nil
+}
+
+func (s *OpenAIGatewayService) handleOpenAIImagesNonStreamingResponseWithTaskRelay(
+	resp *http.Response,
+	c *gin.Context,
+	ctx context.Context,
+	account *Account,
+	baseURL string,
+	requestHeaders http.Header,
+) (OpenAIUsage, int, []string, error) {
+	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, err
+	}
+	relayed, err := s.pollImageTaskRelay(ctx, c, account, baseURL, requestHeaders, body)
+	if err != nil {
+		return OpenAIUsage{}, 0, nil, err
+	}
+	statusCode := resp.StatusCode
+	responseHeaders := resp.Header
+	if relayed.relayed {
+		statusCode = http.StatusOK
+		if relayed.responseHeader != nil {
+			responseHeaders = relayed.responseHeader
+		}
+	}
+	s.writeOpenAIImagesJSONResponse(c, statusCode, responseHeaders, relayed.body)
+
+	usage, _ := extractOpenAIUsageFromJSONBytes(relayed.body)
+	return usage, extractOpenAIImageCountFromJSONBytes(relayed.body), collectOpenAIResponseImageOutputSizesFromJSONBytes(relayed.body), nil
+}
+
+func (s *OpenAIGatewayService) writeOpenAIImagesJSONResponse(c *gin.Context, statusCode int, headers http.Header, body []byte) {
+	if c == nil {
+		return
+	}
+	responseheaders.WriteFilteredHeaders(c.Writer.Header(), headers, s.responseHeaderFilter)
+	contentType := "application/json"
+	if s.cfg != nil && !s.cfg.Security.ResponseHeaders.Enabled {
+		if upstreamType := headers.Get("Content-Type"); upstreamType != "" {
+			contentType = upstreamType
+		}
+	}
+	c.Data(statusCode, contentType, body)
 }
 
 func (s *OpenAIGatewayService) handleOpenAIImagesStreamingResponse(

--- a/docs/ASYNC_IMAGE_TASKS.md
+++ b/docs/ASYNC_IMAGE_TASKS.md
@@ -53,6 +53,14 @@ image_storage:
 
 When a task completes, each generated image is uploaded to the bucket and the result is rewritten to a compact form: `data[].url` points at the stored object (a permanent `public_base_url/key` link, or a time-limited presigned URL) and `b64_json` is removed. Only this small JSON is stored in Redis. If an upload fails, the task is marked `failed` rather than persisting the raw base64.
 
+### Relaying an upstream async image task
+
+For an OpenAI/Grok API-key account whose image endpoint is itself a relay, enable **Relay upstream async image tasks** in the account settings. The setting is account-scoped and only applies while the local async worker is executing; synchronous image requests keep their existing behavior.
+
+The upstream create response may contain `task_id` (or `id`) with a processing status. For an opted-in JSON Images request, the gateway adds `async: true` by default so an upstream relay can return its own task immediately. Disable this per account with `async_image_task_upstream_async_enabled: false` when the provider always creates tasks or rejects the field. It polls `GET /v1/image-tasks/{task_id}` by default, using the same account credentials, proxy and request-header overrides. If the create response contains `poll_url` or `status_url`, that URL is preferred. Set `async_image_task_status_url` in the account extra configuration when the provider uses another path, for example `/v1/images/generations/{task_id}`. The value may be an absolute HTTP(S) URL or a path containing `{task_id}`. `async_image_task_poll_interval_seconds` controls polling frequency from 1 to 60 seconds and defaults to 3.
+
+The poller accepts common `processing`/`pending`/`queued` and `completed`/`succeeded` states. A completed OpenAI-compatible `data` response, a nested `result.data` response, or a direct `url`/`image_url` is normalized before the existing S3 uploader stores it. The local task response never exposes the upstream task ID.
+
 To support a different vendor beyond the S3-compatible client, implement the `service.ImageStorage` interface (`Save(ctx, key, contentType, data) (url, error)`) and provide it in place of the S3 implementation.
 
 ### Troubleshooting: the endpoints return 404 after enabling

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2781,6 +2781,56 @@
         </div>
       </div>
 
+      <!-- Upstream async image task relay (API key image relays) -->
+      <div
+        v-if="(form.platform === 'openai' || form.platform === 'grok') && accountCategory === 'apikey'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.asyncImageTaskRelay.title') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.asyncImageTaskRelay.description') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            @click="asyncImageTaskRelayEnabled = !asyncImageTaskRelayEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              asyncImageTaskRelayEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                asyncImageTaskRelayEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+        <div v-if="asyncImageTaskRelayEnabled" class="mt-3">
+          <label class="input-label">{{ t('admin.accounts.asyncImageTaskRelay.statusURL') }}</label>
+          <input
+            v-model="asyncImageTaskStatusURL"
+            type="text"
+            class="input font-mono text-sm"
+            :placeholder="t('admin.accounts.asyncImageTaskRelay.statusURLPlaceholder')"
+          />
+          <p class="input-hint">{{ t('admin.accounts.asyncImageTaskRelay.statusURLHint') }}</p>
+          <label class="mt-3 inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <input v-model="asyncImageTaskUpstreamAsync" type="checkbox" />
+            <span>{{ t('admin.accounts.asyncImageTaskRelay.upstreamAsync') }}</span>
+          </label>
+          <p class="input-hint">{{ t('admin.accounts.asyncImageTaskRelay.upstreamAsyncHint') }}</p>
+          <div class="mt-3 max-w-xs">
+            <label class="input-label">{{ t('admin.accounts.asyncImageTaskRelay.pollInterval') }}</label>
+            <input v-model.number="asyncImageTaskPollInterval" type="number" min="1" max="60" class="input" />
+            <p class="input-hint">{{ t('admin.accounts.asyncImageTaskRelay.pollIntervalHint') }}</p>
+          </div>
+        </div>
+      </div>
+
       <!-- OpenAI WS Mode 三态（off/ctx_pool/passthrough） -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -3778,6 +3828,10 @@ const applyGrokOAuthUpstreamConfig = (credentials: Record<string, unknown>) => {
 const interceptWarmupRequests = ref(false)
 const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
+const asyncImageTaskRelayEnabled = ref(false)
+const asyncImageTaskStatusURL = ref('')
+const asyncImageTaskUpstreamAsync = ref(true)
+const asyncImageTaskPollInterval = ref(3)
 const openAILongContextBillingEnabled = ref(false)
 const openAILongContextBillingTouched = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
@@ -4656,6 +4710,10 @@ const resetForm = () => {
   interceptWarmupRequests.value = false
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
+  asyncImageTaskRelayEnabled.value = false
+  asyncImageTaskStatusURL.value = ''
+  asyncImageTaskUpstreamAsync.value = true
+  asyncImageTaskPollInterval.value = 3
   openAILongContextBillingEnabled.value = false
   openAILongContextBillingTouched.value = false
   openAICompactMode.value = 'auto'
@@ -5216,6 +5274,31 @@ const createAccountAndFinish = async (
     if (Object.keys(quotaExtra).length > 0) {
       finalExtra = quotaExtra
     }
+  }
+  if ((platform === 'openai' || platform === 'grok') && type === 'apikey') {
+    const asyncExtra: Record<string, unknown> = { ...(finalExtra || {}) }
+    if (asyncImageTaskRelayEnabled.value) {
+      asyncExtra.async_image_task_relay_enabled = true
+      if (asyncImageTaskStatusURL.value.trim()) {
+        asyncExtra.async_image_task_status_url = asyncImageTaskStatusURL.value.trim()
+      }
+      if (!asyncImageTaskUpstreamAsync.value) {
+        asyncExtra.async_image_task_upstream_async_enabled = false
+      } else {
+        delete asyncExtra.async_image_task_upstream_async_enabled
+      }
+      if (asyncImageTaskPollInterval.value !== 3) {
+        asyncExtra.async_image_task_poll_interval_seconds = Math.min(60, Math.max(1, asyncImageTaskPollInterval.value || 3))
+      } else {
+        delete asyncExtra.async_image_task_poll_interval_seconds
+      }
+    } else {
+      delete asyncExtra.async_image_task_relay_enabled
+      delete asyncExtra.async_image_task_status_url
+      delete asyncExtra.async_image_task_upstream_async_enabled
+      delete asyncExtra.async_image_task_poll_interval_seconds
+    }
+    finalExtra = Object.keys(asyncExtra).length > 0 ? asyncExtra : undefined
   }
   if (platform === 'openai') {
     if (type === 'apikey') {

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1481,6 +1481,57 @@
         </div>
       </div>
 
+      <!-- Upstream async image task relay (API key image relays) -->
+      <div
+        v-if="(account?.platform === 'openai' || account?.platform === 'grok') && account?.type === 'apikey'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.asyncImageTaskRelay.title') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.asyncImageTaskRelay.description') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="async-image-task-relay-toggle"
+            @click="asyncImageTaskRelayEnabled = !asyncImageTaskRelayEnabled"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              asyncImageTaskRelayEnabled ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                asyncImageTaskRelayEnabled ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+        <div v-if="asyncImageTaskRelayEnabled" class="mt-3">
+          <label class="input-label">{{ t('admin.accounts.asyncImageTaskRelay.statusURL') }}</label>
+          <input
+            v-model="asyncImageTaskStatusURL"
+            type="text"
+            class="input font-mono text-sm"
+            :placeholder="t('admin.accounts.asyncImageTaskRelay.statusURLPlaceholder')"
+          />
+          <p class="input-hint">{{ t('admin.accounts.asyncImageTaskRelay.statusURLHint') }}</p>
+          <label class="mt-3 inline-flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <input v-model="asyncImageTaskUpstreamAsync" type="checkbox" />
+            <span>{{ t('admin.accounts.asyncImageTaskRelay.upstreamAsync') }}</span>
+          </label>
+          <p class="input-hint">{{ t('admin.accounts.asyncImageTaskRelay.upstreamAsyncHint') }}</p>
+          <div class="mt-3 max-w-xs">
+            <label class="input-label">{{ t('admin.accounts.asyncImageTaskRelay.pollInterval') }}</label>
+            <input v-model.number="asyncImageTaskPollInterval" type="number" min="1" max="60" class="input" />
+            <p class="input-hint">{{ t('admin.accounts.asyncImageTaskRelay.pollIntervalHint') }}</p>
+          </div>
+        </div>
+      </div>
+
       <!-- OpenAI Codex hosted image_generation bridge policy -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -2829,6 +2880,10 @@ const customBaseUrl = ref('')
 
 // OpenAI 自动透传开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
+const asyncImageTaskRelayEnabled = ref(false)
+const asyncImageTaskStatusURL = ref('')
+const asyncImageTaskUpstreamAsync = ref(true)
+const asyncImageTaskPollInterval = ref(3)
 const openAILongContextBillingEnabled = ref(false)
 // OpenAI 订阅档位（Plus/Pro/Free）手动覆盖值,存于 credentials.plan_type;'' 表示清空/自动识别
 const editPlanType = ref<string>('')
@@ -3264,6 +3319,18 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 
   // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
   openaiPassthroughEnabled.value = false
+  asyncImageTaskRelayEnabled.value = false
+  asyncImageTaskStatusURL.value = ''
+  asyncImageTaskUpstreamAsync.value = true
+  asyncImageTaskPollInterval.value = 3
+  asyncImageTaskRelayEnabled.value = extra?.async_image_task_relay_enabled === true
+  asyncImageTaskStatusURL.value = typeof extra?.async_image_task_status_url === 'string'
+    ? extra.async_image_task_status_url
+    : ''
+  asyncImageTaskUpstreamAsync.value = extra?.async_image_task_upstream_async_enabled !== false
+  asyncImageTaskPollInterval.value = typeof extra?.async_image_task_poll_interval_seconds === 'number'
+    ? Math.min(60, Math.max(1, extra.async_image_task_poll_interval_seconds))
+    : 3
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
@@ -4330,6 +4397,37 @@ const handleSubmit = async () => {
       updatePayload.extra = newExtra
     }
 
+    // Third-party OpenAI/Grok image relays: keep the switch in account extra so
+    // the async task worker can apply it to the selected upstream account.
+    if ((props.account.platform === 'openai' || props.account.platform === 'grok') && props.account.type === 'apikey') {
+      const currentExtra = (updatePayload.extra as Record<string, unknown>) || (props.account.extra as Record<string, unknown>) || {}
+      const newExtra: Record<string, unknown> = { ...currentExtra }
+      if (asyncImageTaskRelayEnabled.value) {
+        newExtra.async_image_task_relay_enabled = true
+        if (asyncImageTaskStatusURL.value.trim()) {
+          newExtra.async_image_task_status_url = asyncImageTaskStatusURL.value.trim()
+        } else {
+          delete newExtra.async_image_task_status_url
+        }
+        if (!asyncImageTaskUpstreamAsync.value) {
+          newExtra.async_image_task_upstream_async_enabled = false
+        } else {
+          delete newExtra.async_image_task_upstream_async_enabled
+        }
+        if (asyncImageTaskPollInterval.value !== 3) {
+          newExtra.async_image_task_poll_interval_seconds = Math.min(60, Math.max(1, asyncImageTaskPollInterval.value || 3))
+        } else {
+          delete newExtra.async_image_task_poll_interval_seconds
+        }
+      } else {
+        delete newExtra.async_image_task_relay_enabled
+        delete newExtra.async_image_task_status_url
+        delete newExtra.async_image_task_upstream_async_enabled
+        delete newExtra.async_image_task_poll_interval_seconds
+      }
+      updatePayload.extra = newExtra
+    }
+
     // OpenAI: 手动覆盖订阅档位 plan_type（Plus/Pro/Free）。仅 OAuth 非影子账号：
     // 影子账号凭据由母账号管理(且后端会 sanitize),setup-token 无订阅调度语义。
     if (props.account.platform === 'openai' && props.account.type === 'oauth' && !isSparkShadow.value) {
@@ -4496,7 +4594,10 @@ const handleSubmit = async () => {
 
     // For OpenAI OAuth/SetupToken/API Key accounts, handle passthrough mode in extra
     if (props.account.platform === 'openai' && (props.account.type === 'oauth' || props.account.type === 'setup-token' || props.account.type === 'apikey')) {
-      const currentExtra = (props.account.extra as Record<string, unknown>) || {}
+      // Preserve settings assembled earlier in this submit, including the
+      // account-level async image task relay toggle.
+      const currentExtra = (updatePayload.extra as Record<string, unknown>) ||
+        (props.account.extra as Record<string, unknown>) || {}
       const newExtra: Record<string, unknown> = { ...currentExtra }
       const hadCodexCLIOnlyEnabled = currentExtra.codex_cli_only === true
       if (props.account.type === 'oauth' || props.account.type === 'setup-token') {

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -474,6 +474,21 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_long_context_billing_enabled).toBe(false)
   })
 
+  it('preserves the async image relay toggle when saving OpenAI API key settings', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    await wrapper.get('[data-testid="async-image-task-relay-toggle"]').trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.async_image_task_relay_enabled).toBe(true)
+  })
+
   it('fails closed for malformed OpenAI long-context billing values', async () => {
     const account = buildAccount()
     account.extra = {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -532,6 +532,17 @@ export default {
         testModeCompact: 'Compact probe',
         modelRestrictionDisabledByPassthrough: 'Automatic passthrough is enabled: model whitelist/mapping will not take effect.',
       },
+      asyncImageTaskRelay: {
+        title: 'Relay upstream async image tasks',
+        description: 'For an async local image task, poll a third-party upstream task and store the final image in this gateway S3 before returning it.',
+        statusURL: 'Upstream task status URL (optional)',
+        statusURLPlaceholder: 'Leave blank for /v1/image-tasks/{task_id}',
+        statusURLHint: 'Use an absolute URL or a path template containing {task_id}. This setting only affects local async image endpoints.',
+        upstreamAsync: 'Ask the upstream for an async task (async=true)',
+        upstreamAsyncHint: 'Enabled by default for OpenAI-compatible relays. Disable it when the provider always returns a task ID or rejects the async field.',
+        pollInterval: 'Polling interval (seconds)',
+        pollIntervalHint: 'The gateway polls the upstream task at this interval. Allowed range: 1-60 seconds.'
+      },
       grok: {
         baseUrlHint: 'Grok OAuth accounts forward to the official xAI API base URL.',
         apiKeyHint: 'Grok subscription support uses OAuth refresh tokens; API keys are out of scope for this account type.'

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -592,6 +592,17 @@ export default {
         testModeCompact: 'Compact 探测',
         modelRestrictionDisabledByPassthrough: '已开启自动透传：模型白名单/映射不会生效。',
       },
+      asyncImageTaskRelay: {
+        title: '透传上游异步生图任务',
+        description: '本地异步生图时轮询第三方上游任务，完成后将图片保存到本网关 S3，再返回本地链接。',
+        statusURL: '上游任务查询地址（可选）',
+        statusURLPlaceholder: '留空使用 /v1/image-tasks/{task_id}',
+        statusURLHint: '可填写完整 URL 或包含 {task_id} 的路径模板，仅影响本地异步生图接口。',
+        upstreamAsync: '向上游请求异步任务（async=true）',
+        upstreamAsyncHint: 'OpenAI 兼容中转默认开启；如果上游始终返回 task_id 或不接受 async 字段，可以关闭。',
+        pollInterval: '轮询间隔（秒）',
+        pollIntervalHint: '网关按此间隔查询上游任务，允许范围为 1-60 秒。'
+      },
       grok: {
         baseUrlHint: 'Grok OAuth 账号会转发到官方 xAI API Base URL。',
         apiKeyHint: 'Grok 订阅支持使用 OAuth refresh token；API Key 账号不在本次范围内。'


### PR DESCRIPTION
描述：

  ## 功能说明

  新增第三方 OpenAI 兼容中转服务的异步生图任务处理能力。

  ## 主要改动

  - 增加账号级“透传上游异步生图任务”开关
  - 支持 OpenAI 和 Grok API Key 账号
  - 根据配置向上游发送 `async: true`
  - 自动提取并轮询上游返回的 `task_id`
  - 支持自定义任务查询地址和轮询间隔
  - 支持处理中、已完成、失败和已取消等常见状态
  - 兼容 `data`、`result.data`、`url`、`image_url` 和 Base64 等结果格式
  - 使用网关现有的 S3 对象存储保存最终图片
  - 最终返回网关自己的图片链接，不暴露上游任务 ID
  - 不影响现有同步生图请求
  - 增加管理端配置界面、使用文档和单元测试

  ## 验证情况

  - Go 异步生图中继测试通过
  - 前端类型检查通过
  - 前端 ESLint 检查通过
  - 编辑账号组件测试通过：33/33
  - 已使用 OpenAI 兼容上游和 S3 兼容对象存储完成手动测试