### PR TITLE
fix(frontend): import Grok keys into Grok Build

### DIFF
--- a/frontend/src/utils/__tests__/ccswitchImport.spec.ts
+++ b/frontend/src/utils/__tests__/ccswitchImport.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  GROK_CC_SWITCH_MODEL,
   OPENAI_CC_SWITCH_CODEX_MODEL,
   buildCcSwitchImportDeeplink
 } from '@/utils/ccswitchImport'
@@ -13,6 +14,10 @@ function paramsFromDeeplink(deeplink: string): URLSearchParams {
 describe('ccswitchImport utils', () => {
   it('defaults OpenAI CC Switch imports to the current Codex model', () => {
     expect(OPENAI_CC_SWITCH_CODEX_MODEL).toBe('gpt-5.5')
+  })
+
+  it('defaults Grok Build imports to the current Grok model', () => {
+    expect(GROK_CC_SWITCH_MODEL).toBe('grok-4.5')
   })
 
   const baseInput = {
@@ -36,6 +41,26 @@ describe('ccswitchImport utils', () => {
     expect(params.get('endpoint')).toBe(baseInput.baseUrl)
     expect(params.get('model')).toBe(OPENAI_CC_SWITCH_CODEX_MODEL)
     expect(atob(params.get('usageScript') || '')).toBe(baseInput.usageScript)
+  })
+
+  it.each([
+    'https://api.example.com',
+    'https://api.example.com/',
+    'https://api.example.com/v1',
+    'https://api.example.com/v1/'
+  ])('imports Grok Build with one /v1 suffix for base URL %s', (baseUrl) => {
+    const params = paramsFromDeeplink(
+      buildCcSwitchImportDeeplink({
+        ...baseInput,
+        baseUrl,
+        platform: 'grok',
+        clientType: 'claude'
+      })
+    )
+
+    expect(params.get('app')).toBe('grokbuild')
+    expect(params.get('endpoint')).toBe('https://api.example.com/v1')
+    expect(params.get('model')).toBe(GROK_CC_SWITCH_MODEL)
   })
 
   it.each([

--- a/frontend/src/utils/ccswitchImport.ts
+++ b/frontend/src/utils/ccswitchImport.ts
@@ -1,6 +1,7 @@
 import type { GroupPlatform } from '@/types'
 
 export const OPENAI_CC_SWITCH_CODEX_MODEL = 'gpt-5.5'
+export const GROK_CC_SWITCH_MODEL = 'grok-4.5'
 
 export type CcSwitchClientType = 'claude' | 'gemini'
 
@@ -17,6 +18,11 @@ export interface CcSwitchImportDeeplinkInput {
   providerName: string
   apiKey: string
   usageScript: string
+}
+
+function withV1Endpoint(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '')
+  return normalizedBaseUrl.endsWith('/v1') ? normalizedBaseUrl : `${normalizedBaseUrl}/v1`
 }
 
 export function resolveCcSwitchImportConfig(
@@ -40,6 +46,12 @@ export function resolveCcSwitchImportConfig(
       return {
         app: 'gemini',
         endpoint: baseUrl
+      }
+    case 'grok':
+      return {
+        app: 'grokbuild',
+        endpoint: withV1Endpoint(baseUrl),
+        model: GROK_CC_SWITCH_MODEL
       }
     default:
       return {


### PR DESCRIPTION
## Summary

- import Grok platform keys into CC Switch's Grok Build app instead of Claude
- normalize Grok endpoints to exactly one `/v1` suffix
- set the imported Grok Build model to `grok-4.5`
- cover base URLs with and without trailing slashes or an existing `/v1`

## Compatibility

This integration requires CC Switch v3.18.0 or newer, where the `grokbuild` deep-link target is supported.

## Testing

- `pnpm exec vitest run src/utils/__tests__/ccswitchImport.spec.ts`
- `pnpm exec eslint src/utils/ccswitchImport.ts src/utils/__tests__/ccswitchImport.spec.ts`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

Fixes #4720