### PR TITLE
feat(openai): prefer accounts by reasoning effort

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -85,6 +85,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			body = cappedBody
 		}
 	}
+	reasoningEffort := service.ExtractOpenAIReasoningEffortForRouting(body, reqModel)
 	reqStream, ok := parseOpenAICompatibleStream(body)
 	if !ok {
 		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", invalidStreamFieldTypeMessage)
@@ -117,6 +118,9 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 	requestPlatform := openAICompatibleRequestPlatform(c.Request.Context(), apiKey)
+	if requestPlatform != service.PlatformOpenAI {
+		reasoningEffort = ""
+	}
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -154,7 +158,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			return
 		}
 		reqLog.Debug("openai_chat_completions.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
-		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
 			c.Request.Context(),
 			apiKey.GroupID,
 			"",
@@ -166,6 +170,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 			false,
 			false,
 			true,
+			reasoningEffort,
 			requestPlatform,
 		)
 		if err != nil {

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -273,6 +273,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			body = cappedBody
 		}
 	}
+	reasoningEffort := service.ExtractOpenAIReasoningEffortForRouting(body, reqModel)
 
 	reqStream, ok := parseOpenAICompatibleStream(body)
 	if !ok {
@@ -348,6 +349,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// Get subscription info (may be nil)
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 	requestPlatform := openAICompatibleRequestPlatform(c.Request.Context(), apiKey)
+	if requestPlatform != service.PlatformOpenAI {
+		reasoningEffort = ""
+	}
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -403,7 +407,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		// Select account supporting the requested model
 		reqLog.Debug("openai.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
-		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
 			c.Request.Context(),
 			apiKey.GroupID,
 			previousResponseID,
@@ -415,6 +419,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			requireCompact,
 			false,
 			!imageIntent,
+			reasoningEffort,
 			requestPlatform,
 		)
 		if err != nil {
@@ -1663,13 +1668,23 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 	if service.IsExplicitImageGenerationIntent("/v1/responses", reqModel, firstMessage) && requestPlatform == service.PlatformOpenAI {
 		requiredCapability = service.OpenAIEndpointCapabilityResponses
 	}
+	routingMessage := firstMessage
+	if apiKey.Group != nil && apiKey.Group.Platform == service.PlatformOpenAI {
+		if policyBody, changed := service.ApplyOpenAIReasoningEffortPolicy(routingMessage, apiKey.Group.MaxReasoningEffort, apiKey.Group.ReasoningEffortMappings); changed {
+			routingMessage = policyBody
+		}
+	}
+	reasoningEffort := ""
+	if requestPlatform == service.PlatformOpenAI {
+		reasoningEffort = service.ExtractOpenAIReasoningEffortForRouting(routingMessage, reqModel)
+	}
 
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 		reqLog.Debug("openai.websocket_account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
-		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
 			ctx,
 			apiKey.GroupID,
 			previousResponseID,
@@ -1681,6 +1696,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			false,
 			previousResponseCanMove,
 			!imageIntent,
+			reasoningEffort,
 			requestPlatform,
 		)
 		if err != nil {

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -1000,6 +1000,7 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"openai_ws_force_http",
 		"openai_responses_mode",
 		"openai_responses_supported",
+		service.OpenAIReasoningEffortPreferencesExtraKey,
 		"codex_5h_used_percent",
 		"codex_7d_used_percent",
 		"codex_5h_reset_at",

--- a/backend/internal/repository/scheduler_cache_reasoning_effort_test.go
+++ b/backend/internal/repository/scheduler_cache_reasoning_effort_test.go
@@ -1,0 +1,19 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterSchedulerExtraPreservesReasoningEffortPreferences(t *testing.T) {
+	preferences := []any{"low", "high"}
+	filtered := filterSchedulerExtra(map[string]any{
+		service.OpenAIReasoningEffortPreferencesExtraKey: preferences,
+		"unrelated_setting": true,
+	})
+
+	require.Equal(t, preferences, filtered[service.OpenAIReasoningEffortPreferencesExtraKey])
+	require.NotContains(t, filtered, "unrelated_setting")
+}

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -3,6 +3,7 @@ package service
 import (
 	"container/heap"
 	"context"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"log/slog"
@@ -66,23 +67,24 @@ var openAIAdvancedSchedulerSettingCache atomic.Value // *cachedOpenAIAdvancedSch
 var openAIAdvancedSchedulerSettingSF singleflight.Group
 
 type OpenAIAccountScheduleRequest struct {
-	GroupID                 *int64
-	Platform                string
-	SessionHash             string
-	StickyAccountID         int64
-	StickyPreviousAccountID int64
-	StickyWeighted          bool
-	SubscriptionPriority    bool
-	PreserveStickyBinding   bool
-	PreviousResponseID      string
-	PreviousResponseCanMove bool
-	UseUpstreamTokenCost    bool
-	RequestedModel          string
-	RequiredTransport       OpenAIUpstreamTransport
-	RequiredCapability      OpenAIEndpointCapability
-	RequiredImageCapability OpenAIImagesCapability
-	RequireCompact          bool
-	ExcludedIDs             map[int64]struct{}
+	GroupID                   *int64
+	Platform                  string
+	SessionHash               string
+	StickyAccountID           int64
+	StickyPreviousAccountID   int64
+	StickyWeighted            bool
+	SubscriptionPriority      bool
+	PreserveStickyBinding     bool
+	PreviousResponseID        string
+	PreviousResponseCanMove   bool
+	UseUpstreamTokenCost      bool
+	RequestedModel            string
+	ReasoningEffortPreference string
+	RequiredTransport         OpenAIUpstreamTransport
+	RequiredCapability        OpenAIEndpointCapability
+	RequiredImageCapability   OpenAIImagesCapability
+	RequireCompact            bool
+	ExcludedIDs               map[int64]struct{}
 }
 
 type OpenAIAccountScheduleDecision struct {
@@ -429,6 +431,30 @@ func (s *defaultOpenAIAccountScheduler) Select(
 	}
 
 	selection, candidateCount, topK, loadSkew, err := s.selectByLoadBalance(ctx, req)
+	if req.ReasoningEffortPreference != "" &&
+		(selection == nil || selection.Account == nil) &&
+		(err == nil || errors.Is(err, ErrNoAvailableAccounts) || errors.Is(err, ErrNoAvailableCompactAccounts)) {
+		// No preferred account can serve the request. Retry the existing scheduler
+		// pool without the preference, preserving legacy availability semantics.
+		req.ReasoningEffortPreference = ""
+		if !req.StickyWeighted {
+			fallbackSticky, escapedSticky, stickyErr := s.selectBySessionHash(ctx, req)
+			if stickyErr != nil {
+				return nil, decision, stickyErr
+			}
+			if fallbackSticky != nil && fallbackSticky.Account != nil {
+				decision.Layer = openAIAccountScheduleLayerSessionSticky
+				decision.StickySessionHit = true
+				decision.SelectedAccountID = fallbackSticky.Account.ID
+				decision.SelectedAccountType = fallbackSticky.Account.Type
+				return fallbackSticky, decision, nil
+			}
+			if escapedSticky {
+				req.PreserveStickyBinding = true
+			}
+		}
+		selection, candidateCount, topK, loadSkew, err = s.selectByLoadBalance(ctx, req)
+	}
 	decision.Layer = openAIAccountScheduleLayerLoadBalance
 	decision.CandidateCount = candidateCount
 	decision.TopK = topK
@@ -1703,6 +1729,9 @@ func (s *defaultOpenAIAccountScheduler) isAccountRequestCompatibleReason(ctx con
 	if req.RequestedModel != "" && !account.IsModelSupported(req.RequestedModel) {
 		return false, "model_not_supported"
 	}
+	if req.ReasoningEffortPreference != "" && !accountMatchesOpenAIReasoningEffortPreference(account, req.ReasoningEffortPreference) {
+		return false, "reasoning_effort_preference_mismatch"
+	}
 	if req.GroupID != nil && s != nil && s.service != nil &&
 		s.service.needsUpstreamChannelRestrictionCheck(ctx, req.GroupID) &&
 		s.service.isUpstreamModelRestrictedByChannel(ctx, *req.GroupID, account, req.RequestedModel, req.RequireCompact) {
@@ -1989,7 +2018,7 @@ func (s *OpenAIGatewayService) SelectAccountWithScheduler(
 	requiredTransport OpenAIUpstreamTransport,
 	requireCompact bool,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
-	return s.selectAccountWithScheduler(ctx, groupID, previousResponseID, sessionHash, requestedModel, excludedIDs, requiredTransport, "", "", requireCompact, PlatformOpenAI, false, true)
+	return s.selectAccountWithScheduler(ctx, groupID, previousResponseID, sessionHash, requestedModel, excludedIDs, requiredTransport, "", "", requireCompact, PlatformOpenAI, false, true, "")
 }
 
 // SelectAccountWithSchedulerForCapability 按能力要求调度账号。
@@ -2013,7 +2042,47 @@ func (s *OpenAIGatewayService) SelectAccountWithSchedulerForCapability(
 	if len(platformOverride) > 0 {
 		platform = platformOverride[0]
 	}
-	return s.selectAccountWithScheduler(ctx, groupID, previousResponseID, sessionHash, requestedModel, excludedIDs, requiredTransport, requiredCapability, "", requireCompact, platform, previousResponseCanMove, useUpstreamTokenCost)
+	return s.selectAccountWithScheduler(ctx, groupID, previousResponseID, sessionHash, requestedModel, excludedIDs, requiredTransport, requiredCapability, "", requireCompact, platform, previousResponseCanMove, useUpstreamTokenCost, "")
+}
+
+// SelectAccountWithSchedulerForCapabilityAndReasoningEffort applies an optional
+// per-account reasoning-effort preference before falling back to the existing
+// candidate pool when no preferred account is available.
+func (s *OpenAIGatewayService) SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	sessionHash string,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requiredTransport OpenAIUpstreamTransport,
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+	previousResponseCanMove bool,
+	useUpstreamTokenCost bool,
+	reasoningEffort string,
+	platformOverride ...string,
+) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
+	platform := PlatformOpenAI
+	if len(platformOverride) > 0 {
+		platform = platformOverride[0]
+	}
+	return s.selectAccountWithScheduler(
+		ctx,
+		groupID,
+		previousResponseID,
+		sessionHash,
+		requestedModel,
+		excludedIDs,
+		requiredTransport,
+		requiredCapability,
+		"",
+		requireCompact,
+		platform,
+		previousResponseCanMove,
+		useUpstreamTokenCost,
+		reasoningEffort,
+	)
 }
 
 func (s *OpenAIGatewayService) SelectAccountWithSchedulerForImages(
@@ -2024,13 +2093,13 @@ func (s *OpenAIGatewayService) SelectAccountWithSchedulerForImages(
 	excludedIDs map[int64]struct{},
 	requiredCapability OpenAIImagesCapability,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
-	selection, decision, err := s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", requiredCapability, false, PlatformOpenAI, false, false)
+	selection, decision, err := s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", requiredCapability, false, PlatformOpenAI, false, false, "")
 	if err == nil && selection != nil && selection.Account != nil {
 		return selection, decision, nil
 	}
 	// 如果要求 native 能力（如指定了模型）但没有可用的 APIKey 账号，回退到 basic（OAuth 账号）
 	if requiredCapability == OpenAIImagesCapabilityNative {
-		return s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", OpenAIImagesCapabilityBasic, false, PlatformOpenAI, false, false)
+		return s.selectAccountWithScheduler(ctx, groupID, "", sessionHash, requestedModel, excludedIDs, OpenAIUpstreamTransportHTTPSSE, "", OpenAIImagesCapabilityBasic, false, PlatformOpenAI, false, false, "")
 	}
 	return selection, decision, err
 }
@@ -2049,9 +2118,11 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 	platform string,
 	previousResponseCanMove bool,
 	useUpstreamTokenCost bool,
+	reasoningEffortPreference string,
 ) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
 	ctx = s.withOpenAIQuotaAutoPauseContext(ctx)
 	platform = normalizeOpenAICompatiblePlatform(platform)
+	reasoningEffortPreference = NormalizeMaxReasoningEffort(reasoningEffortPreference)
 	decision := OpenAIAccountScheduleDecision{}
 	scheduler := s.getOpenAIAccountScheduler(ctx)
 	if scheduler == nil {
@@ -2059,7 +2130,7 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 		if requiredTransport == OpenAIUpstreamTransportAny || requiredTransport == OpenAIUpstreamTransportHTTPSSE {
 			effectiveExcludedIDs := cloneExcludedAccountIDs(excludedIDs)
 			for {
-				selection, err := s.selectAccountWithLoadAwareness(ctx, groupID, platform, sessionHash, requestedModel, effectiveExcludedIDs, requireCompact, requiredCapability, useUpstreamTokenCost)
+				selection, err := s.selectAccountWithLoadAwarenessForReasoningEffort(ctx, groupID, platform, sessionHash, requestedModel, effectiveExcludedIDs, requireCompact, requiredCapability, useUpstreamTokenCost, reasoningEffortPreference)
 				if err != nil {
 					return nil, decision, err
 				}
@@ -2084,7 +2155,7 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 
 		effectiveExcludedIDs := cloneExcludedAccountIDs(excludedIDs)
 		for {
-			selection, err := s.selectAccountWithLoadAwareness(ctx, groupID, platform, sessionHash, requestedModel, effectiveExcludedIDs, requireCompact, requiredCapability, useUpstreamTokenCost)
+			selection, err := s.selectAccountWithLoadAwarenessForReasoningEffort(ctx, groupID, platform, sessionHash, requestedModel, effectiveExcludedIDs, requireCompact, requiredCapability, useUpstreamTokenCost, reasoningEffortPreference)
 			if err != nil {
 				return nil, decision, err
 			}
@@ -2129,22 +2200,23 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 	}
 
 	return scheduler.Select(ctx, OpenAIAccountScheduleRequest{
-		GroupID:                 groupID,
-		Platform:                platform,
-		SessionHash:             sessionHash,
-		StickyAccountID:         stickyAccountID,
-		StickyPreviousAccountID: stickyPreviousAccountID,
-		StickyWeighted:          stickyWeighted,
-		SubscriptionPriority:    subscriptionPriority,
-		PreviousResponseID:      previousResponseID,
-		PreviousResponseCanMove: previousResponseCanMove,
-		UseUpstreamTokenCost:    useUpstreamTokenCost,
-		RequestedModel:          requestedModel,
-		RequiredTransport:       requiredTransport,
-		RequiredCapability:      requiredCapability,
-		RequiredImageCapability: requiredImageCapability,
-		RequireCompact:          requireCompact,
-		ExcludedIDs:             excludedIDs,
+		GroupID:                   groupID,
+		Platform:                  platform,
+		SessionHash:               sessionHash,
+		StickyAccountID:           stickyAccountID,
+		StickyPreviousAccountID:   stickyPreviousAccountID,
+		StickyWeighted:            stickyWeighted,
+		SubscriptionPriority:      subscriptionPriority,
+		PreviousResponseID:        previousResponseID,
+		PreviousResponseCanMove:   previousResponseCanMove,
+		UseUpstreamTokenCost:      useUpstreamTokenCost,
+		RequestedModel:            requestedModel,
+		ReasoningEffortPreference: reasoningEffortPreference,
+		RequiredTransport:         requiredTransport,
+		RequiredCapability:        requiredCapability,
+		RequiredImageCapability:   requiredImageCapability,
+		RequireCompact:            requireCompact,
+		ExcludedIDs:               excludedIDs,
 	})
 }
 

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -259,6 +260,9 @@ func openAICompactSupportTier(account *Account) int {
 func isOpenAICompatibleAccountEligibleForRequest(ctx context.Context, account *Account, platform string, requestedModel string, requireCompact bool, requiredCapability OpenAIEndpointCapability) bool {
 	platform = normalizeOpenAICompatiblePlatform(platform)
 	if account == nil || account.Platform != platform || !account.IsOpenAICompatible() || !account.IsSchedulableForModelWithContext(ctx, requestedModel) {
+		return false
+	}
+	if effort := openAIReasoningEffortPreferenceFromContext(ctx); effort != "" && !accountMatchesOpenAIReasoningEffortPreference(account, effort) {
 		return false
 	}
 	if account.IsOpenAI() {
@@ -841,6 +845,32 @@ func (s *OpenAIGatewayService) isBetterAccount(candidate, current *Account) bool
 // SelectAccountWithLoadAwareness selects an account with load-awareness and wait plan.
 func (s *OpenAIGatewayService) SelectAccountWithLoadAwareness(ctx context.Context, groupID *int64, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}) (*AccountSelectionResult, error) {
 	return s.selectAccountWithLoadAwareness(s.withOpenAIQuotaAutoPauseContext(ctx), groupID, PlatformOpenAI, sessionHash, requestedModel, excludedIDs, false, "", true)
+}
+
+func (s *OpenAIGatewayService) selectAccountWithLoadAwarenessForReasoningEffort(
+	ctx context.Context,
+	groupID *int64,
+	platform string,
+	sessionHash string,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requireCompact bool,
+	requiredCapability OpenAIEndpointCapability,
+	useUpstreamTokenCost bool,
+	reasoningEffort string,
+) (*AccountSelectionResult, error) {
+	reasoningEffort = NormalizeMaxReasoningEffort(reasoningEffort)
+	if reasoningEffort != "" {
+		preferredCtx := withOpenAIReasoningEffortPreference(ctx, reasoningEffort)
+		selection, err := s.selectAccountWithLoadAwareness(preferredCtx, groupID, platform, sessionHash, requestedModel, excludedIDs, requireCompact, requiredCapability, useUpstreamTokenCost)
+		if err == nil && selection != nil && selection.Account != nil {
+			return selection, nil
+		}
+		if err != nil && !errors.Is(err, ErrNoAvailableAccounts) && !errors.Is(err, ErrNoAvailableCompactAccounts) {
+			return nil, err
+		}
+	}
+	return s.selectAccountWithLoadAwareness(ctx, groupID, platform, sessionHash, requestedModel, excludedIDs, requireCompact, requiredCapability, useUpstreamTokenCost)
 }
 
 func (s *OpenAIGatewayService) selectAccountWithLoadAwareness(ctx context.Context, groupID *int64, platform string, sessionHash string, requestedModel string, excludedIDs map[int64]struct{}, requireCompact bool, requiredCapability OpenAIEndpointCapability, useUpstreamTokenCost bool) (*AccountSelectionResult, error) {

--- a/backend/internal/service/openai_reasoning_effort_policy.go
+++ b/backend/internal/service/openai_reasoning_effort_policy.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,10 @@ const (
 )
 
 var openAIReasoningEffortValues = []string{"minimal", "low", "medium", "high", "xhigh", "max"}
+
+const OpenAIReasoningEffortPreferencesExtraKey = "reasoning_effort_preferences"
+
+type openAIReasoningEffortPreferenceContextKey struct{}
 
 // NormalizeMaxReasoningEffort validates and canonicalizes a group policy value.
 // Empty means that the group does not impose a ceiling.
@@ -38,6 +43,89 @@ func NormalizeMaxReasoningEffort(raw string) string {
 	default:
 		return ""
 	}
+}
+
+// ExtractOpenAIReasoningEffortForRouting resolves the effective explicit effort
+// used for account routing. Callers should apply group mappings/ceilings to body
+// first so routing and forwarding observe the same value. Model-name suffixes
+// are intentionally ignored: requests without a reasoning field must preserve
+// the existing account-selection behavior.
+func ExtractOpenAIReasoningEffortForRouting(body []byte, _ string) string {
+	for _, path := range []string{"reasoning.effort", "reasoning_effort"} {
+		field := gjson.GetBytes(body, path)
+		if !field.Exists() || field.Type != gjson.String {
+			continue
+		}
+		return NormalizeMaxReasoningEffort(field.String())
+	}
+
+	return ""
+}
+
+func normalizeOpenAIReasoningEffortPreferences(raw any) []string {
+	var values []string
+	switch typed := raw.(type) {
+	case []string:
+		values = typed
+	case []any:
+		values = make([]string, 0, len(typed))
+		for _, value := range typed {
+			if stringValue, ok := value.(string); ok {
+				values = append(values, stringValue)
+			}
+		}
+	case string:
+		values = strings.Split(typed, ",")
+	default:
+		return nil
+	}
+
+	normalized := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, rawValue := range values {
+		value := NormalizeMaxReasoningEffort(rawValue)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		normalized = append(normalized, value)
+	}
+	return normalized
+}
+
+func accountMatchesOpenAIReasoningEffortPreference(account *Account, effort string) bool {
+	effort = NormalizeMaxReasoningEffort(effort)
+	if account == nil || effort == "" || !account.IsOpenAI() {
+		return false
+	}
+	for _, preferred := range normalizeOpenAIReasoningEffortPreferences(account.Extra[OpenAIReasoningEffortPreferencesExtraKey]) {
+		if preferred == effort {
+			return true
+		}
+	}
+	return false
+}
+
+func withOpenAIReasoningEffortPreference(ctx context.Context, effort string) context.Context {
+	effort = NormalizeMaxReasoningEffort(effort)
+	if effort == "" {
+		return ctx
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, openAIReasoningEffortPreferenceContextKey{}, effort)
+}
+
+func openAIReasoningEffortPreferenceFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	effort, _ := ctx.Value(openAIReasoningEffortPreferenceContextKey{}).(string)
+	return NormalizeMaxReasoningEffort(effort)
 }
 
 func reasoningEffortValuesForPlatform(platform string) []string {

--- a/backend/internal/service/openai_reasoning_effort_routing_test.go
+++ b/backend/internal/service/openai_reasoning_effort_routing_test.go
@@ -1,0 +1,216 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractOpenAIReasoningEffortForRouting(t *testing.T) {
+	tests := []struct {
+		name  string
+		body  string
+		model string
+		want  string
+	}{
+		{name: "responses nested effort", body: `{"reasoning":{"effort":" high "}}`, model: "gpt-5.4", want: "high"},
+		{name: "chat completions flat effort", body: `{"reasoning_effort":"x-high"}`, model: "gpt-5.4", want: "xhigh"},
+		{name: "model suffix without field stays unchanged", body: `{}`, model: "gpt-5.4-low", want: ""},
+		{name: "omitted effort", body: `{}`, model: "gpt-5.4", want: ""},
+		{name: "unknown explicit effort does not infer model", body: `{"reasoning":{"effort":"turbo"}}`, model: "gpt-5.4-high", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ExtractOpenAIReasoningEffortForRouting([]byte(tt.body), tt.model))
+		})
+	}
+}
+
+func TestNormalizeOpenAIReasoningEffortPreferences(t *testing.T) {
+	require.Equal(
+		t,
+		[]string{"low", "xhigh", "max"},
+		normalizeOpenAIReasoningEffortPreferences([]any{" low ", "x-high", "LOW", "unknown", 42, "max"}),
+	)
+	require.Equal(
+		t,
+		[]string{"minimal", "high"},
+		normalizeOpenAIReasoningEffortPreferences("minimal, HIGH"),
+	)
+}
+
+func TestOpenAIGatewayService_ReasoningEffortAccountPreference(t *testing.T) {
+	for _, advanced := range []bool{false, true} {
+		name := "legacy"
+		if advanced {
+			name = "advanced"
+		}
+		t.Run(name, func(t *testing.T) {
+			resetOpenAIAdvancedSchedulerSettingCacheForTest()
+			defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+			accounts := []Account{
+				{
+					ID:          51001,
+					Name:        "default-priority",
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeAPIKey,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Priority:    0,
+				},
+				{
+					ID:          51002,
+					Name:        "high-effort",
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeAPIKey,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Priority:    10,
+					Extra: map[string]any{
+						OpenAIReasoningEffortPreferencesExtraKey: []any{"high", "xhigh"},
+					},
+				},
+			}
+			cfg := &config.Config{}
+			cfg.Gateway.Scheduling.LoadBatchEnabled = false
+			svc := &OpenAIGatewayService{
+				accountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts},
+				cache: &schedulerTestGatewayCache{
+					sessionBindings: map[string]int64{
+						"reasoning-preference": 51001,
+						"reasoning-baseline":   51001,
+					},
+				},
+				cfg:                cfg,
+				concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+			}
+			if advanced {
+				svc.rateLimitService = newOpenAIAdvancedSchedulerRateLimitService("true")
+			}
+
+			selection, _, err := svc.SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
+				context.Background(),
+				nil,
+				"",
+				"reasoning-preference",
+				"gpt-5.4",
+				nil,
+				OpenAIUpstreamTransportAny,
+				OpenAIEndpointCapabilityChatCompletions,
+				false,
+				false,
+				true,
+				"high",
+			)
+			require.NoError(t, err)
+			require.NotNil(t, selection)
+			require.NotNil(t, selection.Account)
+			require.Equal(t, int64(51002), selection.Account.ID)
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+
+			baselineSelection, _, err := svc.SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
+				context.Background(),
+				nil,
+				"",
+				"reasoning-baseline",
+				"gpt-5.4",
+				nil,
+				OpenAIUpstreamTransportAny,
+				OpenAIEndpointCapabilityChatCompletions,
+				false,
+				false,
+				true,
+				"",
+			)
+			require.NoError(t, err)
+			require.NotNil(t, baselineSelection)
+			require.NotNil(t, baselineSelection.Account)
+			require.Equal(t, int64(51001), baselineSelection.Account.ID)
+			if baselineSelection.ReleaseFunc != nil {
+				baselineSelection.ReleaseFunc()
+			}
+		})
+	}
+}
+
+func TestOpenAIGatewayService_ReasoningEffortPreferenceFallsBack(t *testing.T) {
+	for _, advanced := range []bool{false, true} {
+		name := "legacy"
+		if advanced {
+			name = "advanced"
+		}
+		t.Run(name, func(t *testing.T) {
+			resetOpenAIAdvancedSchedulerSettingCacheForTest()
+			defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+			accounts := []Account{
+				{
+					ID:          52001,
+					Name:        "unconfigured",
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeAPIKey,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Priority:    0,
+				},
+				{
+					ID:          52002,
+					Name:        "low-only",
+					Platform:    PlatformOpenAI,
+					Type:        AccountTypeAPIKey,
+					Status:      StatusActive,
+					Schedulable: true,
+					Concurrency: 1,
+					Priority:    10,
+					Extra: map[string]any{
+						OpenAIReasoningEffortPreferencesExtraKey: []string{"low"},
+					},
+				},
+			}
+			cfg := &config.Config{}
+			cfg.Gateway.Scheduling.LoadBatchEnabled = false
+			svc := &OpenAIGatewayService{
+				accountRepo: schedulerTestOpenAIAccountRepo{accounts: accounts},
+				cache: &schedulerTestGatewayCache{
+					sessionBindings: map[string]int64{"reasoning-fallback": 52001},
+				},
+				cfg:                cfg,
+				concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+			}
+			if advanced {
+				svc.rateLimitService = newOpenAIAdvancedSchedulerRateLimitService("true")
+			}
+
+			selection, _, err := svc.SelectAccountWithSchedulerForCapabilityAndReasoningEffort(
+				context.Background(),
+				nil,
+				"",
+				"reasoning-fallback",
+				"gpt-5.4",
+				nil,
+				OpenAIUpstreamTransportAny,
+				OpenAIEndpointCapabilityChatCompletions,
+				false,
+				false,
+				true,
+				"xhigh",
+			)
+			require.NoError(t, err)
+			require.NotNil(t, selection)
+			require.NotNil(t, selection.Account)
+			require.Equal(t, int64(52001), selection.Account.ID)
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+		})
+	}
+}

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1481,6 +1481,34 @@
         </div>
       </div>
 
+      <!-- OpenAI reasoning-effort account routing preference -->
+      <div
+        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <label class="input-label mb-0">{{ t('admin.accounts.openai.reasoningEffortPreferences') }}</label>
+        <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+          {{ t('admin.accounts.openai.reasoningEffortPreferencesDesc') }}
+        </p>
+        <div class="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+          <label
+            v-for="option in openAIReasoningEffortPreferenceOptions"
+            :key="option.value"
+            class="flex cursor-pointer items-center gap-2 rounded-lg border border-gray-200 px-3 py-2 text-sm dark:border-dark-600"
+          >
+            <input
+              type="checkbox"
+              class="rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-dark-500"
+              :data-testid="`openai-reasoning-effort-${option.value}`"
+              :checked="openAIReasoningEffortPreferences.includes(option.value)"
+              @change="toggleOpenAIReasoningEffortPreference(option.value)"
+            />
+            <span class="text-gray-700 dark:text-gray-200">{{ option.label }}</span>
+          </label>
+        </div>
+        <p class="input-hint">{{ t('admin.accounts.openai.reasoningEffortPreferencesHint') }}</p>
+      </div>
+
       <!-- OpenAI Codex hosted image_generation bridge policy -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -2641,6 +2669,11 @@ import {
   resolveOpenAIWSModeFromExtra
 } from '@/utils/openaiWsMode'
 import {
+  OPENAI_REASONING_EFFORT_PREFERENCES,
+  normalizeOpenAIReasoningEffortPreferences,
+  type OpenAIReasoningEffortPreference
+} from '@/utils/openaiReasoningEffortPreferences'
+import {
   getPresetMappingsByPlatform,
   commonErrorCodes,
   buildModelMappingObject,
@@ -2829,6 +2862,7 @@ const customBaseUrl = ref('')
 
 // OpenAI 自动透传开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
+const openAIReasoningEffortPreferences = ref<OpenAIReasoningEffortPreference[]>([])
 const openAILongContextBillingEnabled = ref(false)
 // OpenAI 订阅档位（Plus/Pro/Free）手动覆盖值,存于 credentials.plan_type;'' 表示清空/自动识别
 const editPlanType = ref<string>('')
@@ -2870,6 +2904,23 @@ const editWeeklyResetMode = ref<'rolling' | 'fixed' | null>(null)
 const editWeeklyResetDay = ref<number | null>(null)
 const editWeeklyResetHour = ref<number | null>(null)
 const editResetTimezone = ref<string | null>(null)
+const openAIReasoningEffortPreferenceOptions = computed(() =>
+  OPENAI_REASONING_EFFORT_PREFERENCES.map((value) => ({
+    value,
+    label: t(`admin.accounts.openai.reasoningEffort${value.charAt(0).toUpperCase()}${value.slice(1)}`)
+  }))
+)
+const toggleOpenAIReasoningEffortPreference = (effort: OpenAIReasoningEffortPreference) => {
+  if (openAIReasoningEffortPreferences.value.includes(effort)) {
+    openAIReasoningEffortPreferences.value = openAIReasoningEffortPreferences.value.filter(
+      (value) => value !== effort
+    )
+    return
+  }
+  openAIReasoningEffortPreferences.value = OPENAI_REASONING_EFFORT_PREFERENCES.filter(
+    (value) => value === effort || openAIReasoningEffortPreferences.value.includes(value)
+  )
+}
 const openAIWSModeOptions = computed(() => [
   { value: OPENAI_WS_MODE_OFF, label: t('admin.accounts.openai.wsModeOff') },
   { value: OPENAI_WS_MODE_CTX_POOL, label: t('admin.accounts.openai.wsModeCtxPool') },
@@ -3264,6 +3315,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 
   // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
   openaiPassthroughEnabled.value = false
+  openAIReasoningEffortPreferences.value = []
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
@@ -3280,6 +3332,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   webSearchEmulationMode.value = 'default'
   if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
+    openAIReasoningEffortPreferences.value = normalizeOpenAIReasoningEffortPreferences(
+      extra?.reasoning_effort_preferences
+    )
     const longContextBillingValue = extra?.openai_long_context_billing_enabled
     openAILongContextBillingEnabled.value = longContextBillingValue === true
     // plan_type 手动覆盖仅 OAuth 有实际调度语义(IsOpenAIChatGPTSubscription 要求 oauth),故只对 oauth 回填
@@ -4513,6 +4568,11 @@ const handleSubmit = async () => {
       } else {
         delete newExtra.openai_passthrough
         delete newExtra.openai_oauth_passthrough
+      }
+      if (openAIReasoningEffortPreferences.value.length > 0) {
+        newExtra.reasoning_effort_preferences = [...openAIReasoningEffortPreferences.value]
+      } else {
+        delete newExtra.reasoning_effort_preferences
       }
       if (isSparkShadow.value) {
         delete newExtra.openai_long_context_billing_enabled

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -588,6 +588,35 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_responses_supported).toBe(false)
   })
 
+  it('loads and submits OpenAI reasoning effort preferences', async () => {
+    const account = buildAccount()
+    account.extra = {
+      reasoning_effort_preferences: ['low'],
+      preserved_setting: true
+    }
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    const low = wrapper.get<HTMLInputElement>('[data-testid="openai-reasoning-effort-low"]')
+    const high = wrapper.get<HTMLInputElement>('[data-testid="openai-reasoning-effort-high"]')
+
+    expect(low.element.checked).toBe(true)
+    expect(high.element.checked).toBe(false)
+
+    await high.setValue(true)
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.reasoning_effort_preferences).toEqual([
+      'low',
+      'high'
+    ])
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.preserved_setting).toBe(true)
+  })
+
   it('submits the account upstream billing auto-probe setting', async () => {
     const account = buildAccount()
     updateAccountMock.mockReset()

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -440,6 +440,17 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        reasoningEffortPreferences: 'Reasoning effort preferences',
+        reasoningEffortPreferencesDesc:
+          'Select the reasoning efforts this account should serve first. Matching accounts still use the existing priority, load, and sticky routing rules.',
+        reasoningEffortPreferencesHint:
+          'No selection means a regular account. If no matching account is available, routing automatically falls back to the existing account pool.',
+        reasoningEffortMinimal: 'Minimal',
+        reasoningEffortLow: 'Low',
+        reasoningEffortMedium: 'Medium',
+        reasoningEffortHigh: 'High',
+        reasoningEffortXhigh: 'XHigh',
+        reasoningEffortMax: 'Max',
         longContextBilling: 'API long-context pricing',
         longContextBillingDesc:
           'Disabled by default. Enable only when this account\'s upstream charges OpenAI API long-context rates above the model threshold.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -507,6 +507,17 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        reasoningEffortPreferences: '推理强度偏好',
+        reasoningEffortPreferencesDesc:
+          '勾选本账号优先承接的推理强度。请求会先在匹配账号池中按原有优先级、负载和粘性规则调度。',
+        reasoningEffortPreferencesHint:
+          '不勾选表示普通账号；没有可用匹配账号时会自动回退到原账号池，不影响现有可用性。',
+        reasoningEffortMinimal: 'Minimal（最小）',
+        reasoningEffortLow: 'Low（低）',
+        reasoningEffortMedium: 'Medium（中）',
+        reasoningEffortHigh: 'High（高）',
+        reasoningEffortXhigh: 'XHigh（超高）',
+        reasoningEffortMax: 'Max（最大）',
         longContextBilling: 'API 长上下文计费',
         longContextBillingDesc: '默认关闭。仅当该账号的上游会按模型阈值收取 OpenAI API 长上下文费率时开启。',
         responsesWebsocketsV2: 'Responses WebSocket v2',

--- a/frontend/src/utils/__tests__/openaiReasoningEffortPreferences.spec.ts
+++ b/frontend/src/utils/__tests__/openaiReasoningEffortPreferences.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeOpenAIReasoningEffortPreferences
+} from '../openaiReasoningEffortPreferences'
+
+describe('normalizeOpenAIReasoningEffortPreferences', () => {
+  it('normalizes aliases, removes invalid values, and preserves canonical order', () => {
+    expect(
+      normalizeOpenAIReasoningEffortPreferences([' HIGH ', 'x-high', 'low', 'HIGH', 'turbo', 42])
+    ).toEqual(['low', 'high', 'xhigh'])
+  })
+
+  it('loads backend-compatible comma-separated strings and aliases', () => {
+    expect(normalizeOpenAIReasoningEffortPreferences('high, extra-high, LOW, unknown')).toEqual([
+      'low',
+      'high',
+      'xhigh'
+    ])
+  })
+
+  it('returns an empty selection for missing or malformed config', () => {
+    expect(normalizeOpenAIReasoningEffortPreferences(undefined)).toEqual([])
+    expect(normalizeOpenAIReasoningEffortPreferences(42)).toEqual([])
+  })
+})

--- a/frontend/src/utils/openaiReasoningEffortPreferences.ts
+++ b/frontend/src/utils/openaiReasoningEffortPreferences.ts
@@ -1,0 +1,42 @@
+export const OPENAI_REASONING_EFFORT_PREFERENCES = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max'
+] as const
+
+export type OpenAIReasoningEffortPreference = (typeof OPENAI_REASONING_EFFORT_PREFERENCES)[number]
+
+const aliases: Record<string, OpenAIReasoningEffortPreference> = {
+  minimal: 'minimal',
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+  extrahigh: 'xhigh',
+  max: 'max'
+}
+
+function normalizeEffort(value: string): OpenAIReasoningEffortPreference | undefined {
+  return aliases[value.trim().toLowerCase().replace(/[-_\s]/g, '')]
+}
+
+export function normalizeOpenAIReasoningEffortPreferences(
+  value: unknown
+): OpenAIReasoningEffortPreference[] {
+  const values = Array.isArray(value)
+    ? value
+    : typeof value === 'string'
+      ? value.split(',')
+      : []
+
+  const normalized = new Set<OpenAIReasoningEffortPreference>()
+  for (const item of values) {
+    if (typeof item !== 'string') continue
+    const effort = normalizeEffort(item)
+    if (effort) normalized.add(effort)
+  }
+  return OPENAI_REASONING_EFFORT_PREFERENCES.filter((effort) => normalized.has(effort))
+}


### PR DESCRIPTION
## Why this is needed

The existing group-level reasoning-effort policy controls **what effort may be forwarded**, but it does not control **which account serves that effort**. Pools can contain OpenAI accounts with different plans, quotas, rollout eligibility, or capacity profiles, so treating every account as interchangeable can waste premium capacity or send expensive requests to accounts not intended for them.

Typical use cases:

- **Capacity tiering:** route `minimal`/`low`/`medium` traffic to standard accounts and reserve high-quota accounts for `high`/`xhigh`/`max` workloads.
- **Mixed account capabilities:** prefer accounts known to support or sustain higher reasoning levels while keeping all accounts available as overflow capacity.
- **Graceful failover:** preferences are soft, not hard eligibility rules. If no preferred account is schedulable, selection falls back to the existing pool instead of failing the request.

For example:

```text
standard-account: [minimal, low, medium]
premium-account:  [high, xhigh, max]
```

A group ceiling or mapping is applied first, and account routing uses that final effective effort. Therefore group policy and account preference are complementary: one controls the request, the other allocates capacity.

## Summary

- add per-account OpenAI reasoning-effort preferences in the account editor
- route requests to matching OpenAI accounts in both legacy and advanced schedulers, while falling back to the existing pool when no preferred account is available
- preserve existing behavior for requests without an explicit effort and for non-OpenAI accounts
- apply group effort mappings/ceilings before account selection so routing and the forwarded payload use the same effective value
- preserve hard `previous_response_id` affinity and keep fallback stickiness backward-compatible
- retain the preference field in advanced-scheduler snapshots

Preferences are stored in `account.extra.reasoning_effort_preferences`, so no schema migration is required.

## Validation

- `go test ./internal/service -run "ReasoningEffort" -count=20`
- `go test ./internal/repository -run "TestFilterSchedulerExtraPreservesReasoningEffortPreferences" -count=1`
- `go test ./internal/handler -run "ReasoningEffort|ResponsesWebSocket" -count=1`
- frontend typecheck
- 38 focused Vitest tests across account editing, preference normalization, and locale compilation
- frontend production build
- full Docker image build
- isolated PostgreSQL/Redis/two-upstream E2E:
  - explicit `high` selects the `high`-preferred account
  - explicit `low` selects the default account
  - unmatched `minimal` falls back to the existing pool
  - missing effort preserves legacy selection
  - group ceiling `high -> low` changes both selected account and upstream payload to `low`
