### PR TITLE
feat(payment): expose GET /payment/public/plans for unauthenticated pricing pages

### DIFF
--- a/backend/internal/server/routes/payment.go
+++ b/backend/internal/server/routes/payment.go
@@ -49,6 +49,10 @@ func RegisterPaymentRoutes(
 	// persisted-state compatibility path for staggered upgrades.
 	public := v1.Group("/payment/public")
 	{
+		// Public plan listing lets unauthenticated marketing/pricing pages
+		// show real prices. GetPlans only reads for_sale plans - no user
+		// context, so exposing it publicly leaks no private data.
+		public.GET("/plans", paymentHandler.GetPlans)
 		public.POST("/orders/verify", paymentHandler.VerifyOrderPublic)
 		public.POST("/orders/resolve", paymentHandler.ResolveOrderPublicByResumeToken)
 	}


### PR DESCRIPTION
## What

Adds `GET /payment/public/plans` to the public (no-auth) payment route group, reusing the existing `PaymentHandler.GetPlans` handler.

## Why

Marketing/pricing pages that show plan prices to **anonymous visitors** currently have no way to fetch real prices:

- `GET /payment/plans` is behind `jwtAuth` → anonymous visitors get 401.
- The frontend HTTP interceptor (on a public page) turns that 401 into a login modal — wrong UX for an unauthenticated marketing page.
- The only other public payment endpoints are `/payment/public/orders/verify` and `/payment/public/orders/resolve`, neither of which returns plan pricing.

This forces the public pricing page to **hardcode prices**, which drift out of sync whenever plans change in admin. Exposing a read-only public plan list fixes that.

## Safety

`GetPlans` is safe to expose publicly — it reads no user context:

```go
func (h *PaymentHandler) GetPlans(c *gin.Context) {
    plans, err := h.configService.ListPlansForSale(c.Request.Context())  // for_sale plans only
    // ...
    groupInfo := h.configService.GetGroupInfoMap(c.Request.Context(), plans)  // group metadata
    // ... returns name/description/price/original_price/currency/features/validity
}
```

It only calls `ListPlansForSale` (reads `for_sale = true` plans) and `GetGroupInfoMap` (group platform/name metadata). No user balances, limits, orders, or private data are touched. The response shape is identical to the authenticated `GET /payment/plans`.

## Change

One line in `backend/internal/server/routes/payment.go` — mount the existing handler under the public group:

```go
public := v1.Group("/payment/public")
{
    public.GET("/plans", paymentHandler.GetPlans)   // ← new
    public.POST("/orders/verify", paymentHandler.VerifyOrderPublic)
    public.POST("/orders/resolve", paymentHandler.ResolveOrderPublicByResumeToken)
}
```

No handler/service/type changes — pure route mounting.

## Checklist

- [x] Reuses existing handler (no new logic)
- [x] No user-context access (verified `GetPlans` body)
- [x] Response shape unchanged from authenticated endpoint
- [ ] Backend tests pass (CI)