### PR TITLE
fix(grok): cool down accounts after upstream 402

### DIFF
--- a/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
+++ b/backend/internal/handler/openai_gateway_credential_failover_loop_test.go
@@ -594,6 +594,32 @@ func TestResponsesGrok429FailoverIsBounded(t *testing.T) {
 	})
 }
 
+func TestResponsesGrok402FailoverCooldown(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	_, repo, upstream, router, cleanup := newGrokCredentialFailoverHandler(t, "first_402")
+	defer cleanup()
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/responses", bytes.NewBufferString(`{"model":"grok","input":"hello","stream":false}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Contains(t, recorder.Body.String(), "resp_healthy")
+	require.Equal(t, []int64{801, 802}, upstream.accountHits())
+	require.Equal(t, []int64{801}, repo.setTempIDs)
+	before := repo.selectorCalls()
+
+	second := httptest.NewRecorder()
+	secondReq := httptest.NewRequest(http.MethodPost, "/openai/v1/responses", bytes.NewBufferString(`{"model":"grok","input":"again","stream":false}`))
+	secondReq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(second, secondReq)
+
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	require.Equal(t, before+1, repo.selectorCalls())
+	require.Equal(t, []int64{801, 802, 802}, upstream.accountHits(), "cooldown must exclude the 402 account from later requests")
+}
+
 func TestResponsesGrok429FailoverHandlesMixedStatuses(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -836,7 +862,7 @@ func newGrokCredentialFailoverHandler(t *testing.T, mode string) (*OpenAIGateway
 			Extra: map[string]any{service.GrokMediaEligibleExtraKey: true},
 		},
 	}
-	if mode == "postmap_cancel" || mode == "first_429" || mode == "all_429" || mode == "mixed_429_500" || mode == "mixed_500_429" || mode == "oauth_429_apikey_500" {
+	if mode == "postmap_cancel" || mode == "first_402" || mode == "first_429" || mode == "all_429" || mode == "mixed_429_500" || mode == "mixed_500_429" || mode == "oauth_429_apikey_500" {
 		accounts[0].Credentials["expires_at"] = time.Now().Add(2 * time.Hour).UTC().Format(time.RFC3339)
 	}
 	if mode == "all_429" || mode == "mixed_429_500" || mode == "mixed_500_429" || mode == "oauth_429_apikey_500" {
@@ -879,6 +905,8 @@ func newGrokCredentialFailoverHandler(t *testing.T, mode string) (*OpenAIGateway
 	}
 	upstream := &grokCredentialHandlerUpstream{}
 	switch mode {
+	case "first_402":
+		upstream.failAccountID = 801
 	case "first_429":
 		upstream.rateLimitIDs = map[int64]bool{801: true}
 	case "all_429":

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -1353,6 +1353,8 @@ func (s *OpenAIGatewayService) handleGrokAccountUpstreamError(ctx context.Contex
 	switch statusCode {
 	case http.StatusUnauthorized:
 		s.tempUnscheduleGrok(ctx, account, 10*time.Minute, "grok credentials unauthorized")
+	case http.StatusPaymentRequired:
+		s.tempUnscheduleGrok(ctx, account, 30*time.Minute, "grok payment required")
 	case http.StatusForbidden:
 		if s.applyGrokForbiddenPolicy(ctx, account, responseBody) {
 			return

--- a/backend/internal/service/openai_gateway_grok_test.go
+++ b/backend/internal/service/openai_gateway_grok_test.go
@@ -2440,6 +2440,13 @@ func TestHandleGrokAccountUpstreamErrorTempUnschedulesNonRateLimitStates(t *test
 			wantMaxCooldown: 30*time.Minute + time.Second,
 		},
 		{
+			name:            "payment required",
+			status:          http.StatusPaymentRequired,
+			wantReason:      "grok payment required",
+			wantMinCooldown: 30*time.Minute - time.Second,
+			wantMaxCooldown: 30*time.Minute + time.Second,
+		},
+		{
 			name:            "upstream temporary error",
 			status:          http.StatusInternalServerError,
 			wantReason:      "grok upstream temporary error",
@@ -2481,6 +2488,26 @@ func TestHandleGrokAccountUpstreamError429SetsRateLimitedFromRetryAfter(t *testi
 	require.Equal(t, account.ID, repo.lastRateLimitedID)
 	require.WithinDuration(t, before.Add(45*time.Second), repo.lastRateLimitResetAt, time.Second)
 	require.Zero(t, repo.tempUnschedCalls)
+}
+
+func TestHandleGrokAccountUpstreamError402RecoversAfterCooldownExpiry(t *testing.T) {
+	account := &Account{
+		ID: 610, Platform: PlatformGrok, Type: AccountTypeOAuth,
+		Status: StatusActive, Schedulable: true,
+	}
+	repo := &grokQuotaAccountRepo{}
+	svc := &OpenAIGatewayService{accountRepo: repo}
+
+	svc.handleGrokAccountUpstreamError(context.Background(), account, http.StatusPaymentRequired, nil, nil)
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.Equal(t, 1, repo.tempUnschedCalls)
+
+	expired := time.Now().Add(-time.Second)
+	account.TempUnschedulableUntil = &expired
+	svc.openaiAccountRuntimeBlockUntil.Store(account.ID, expired)
+
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+	require.True(t, account.IsSchedulable())
 }
 
 func TestHandleGrokAccountUpstreamError429UsesLatestExhaustedWindowReset(t *testing.T) {


### PR DESCRIPTION
## Summary

Put a Grok account into the existing temporary cooldown path after an upstream HTTP 402 so later requests do not immediately select the same account again.

Closes #4737.

## Root cause

HTTP 402 was already eligible for request failover, but Grok account-health handling did not install a cooldown. The current request could reach a healthy account, while the next request could immediately reselect the account that had just returned `payment_required`.

## What changed

- Treat HTTP 402 as a temporary account-health failure.
- Persist and mirror a 30-minute temporary unschedule using the existing account-health path.
- Leave HTTP 429 handling, OAuth refresh, model routing, and other provider behavior unchanged.

## Verification

Regression coverage verifies:

- a 402 account receives the persisted 30-minute cooldown;
- the same request fails over to a healthy Grok account;
- a second request excludes the cooled-down account;
- the account becomes schedulable again after cooldown expiry.

Focused service/handler tests and broader relevant suites passed. GitHub CI, frontend, lint, CLA, and both security scans are green.

## Production canary

The commit was deployed as an exact candidate before being included in the final combined `v0.1.163` production integration build. Public health and version probes passed, and the application remained healthy with zero restarts.

The complete 402 failover/exclusion/recovery behavior was exercised with a disposable group, key, and isolated deterministic 402 upstream:

- The 402 account was selected first and received exactly one upstream hit. The same request failed over to the healthy Grok account and returned HTTP 200.
- The database recorded `grok payment required` with a 30-minute temporary unschedule.
- A second request returned HTTP 200 while the 402 upstream hit count remained unchanged, proving next-request exclusion.
- After deliberately expiring the cooldown and restarting the application to clear process-local state, the account was selected again. The 402 upstream hit count advanced to two and the 30-minute cooldown was reapplied.
- The two minimal healthy Grok text requests produced two usage rows with total actual cost `$0.0008062`.
- The disposable key, group, account, route, and mock were removed. Production configuration and the original image were restored exactly, and the application returned healthy.

No real production account was intentionally forced into a billing failure.

## Rollback

Revert this commit or restore the previous application image. No migration is involved.
