### PR TITLE
feat(openai): 支持账号级禁用默认 Codex Instructions 注入

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1660,6 +1660,17 @@ func (a *Account) IsOpenAIPassthroughEnabled() bool {
 	return false
 }
 
+// IsOpenAIDefaultCodexInstructionsDisabled 返回账号是否禁用 Sub2API 内置的
+// Codex base instructions 默认注入。该开关不影响客户端显式传入的 instructions。
+// 字段：accounts.extra.openai_disable_default_codex_instructions。
+func (a *Account) IsOpenAIDefaultCodexInstructionsDisabled() bool {
+	if a == nil || !a.IsOpenAI() || a.Extra == nil {
+		return false
+	}
+	disabled, ok := a.Extra["openai_disable_default_codex_instructions"].(bool)
+	return ok && disabled
+}
+
 // IsOpenAIResponsesWebSocketV2Enabled 返回 OpenAI 账号是否开启 Responses WebSocket v2。
 //
 // 分类型新字段：

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1972,6 +1972,17 @@ func (a *Account) IsOpenAIPassthroughEnabled() bool {
 	return false
 }
 
+// IsOpenAIDefaultCodexInstructionsDisabled 返回账号是否禁用 Sub2API 内置的
+// Codex base instructions 默认注入。该开关不影响客户端显式传入的 instructions。
+// 字段：accounts.extra.openai_disable_default_codex_instructions。
+func (a *Account) IsOpenAIDefaultCodexInstructionsDisabled() bool {
+	if a == nil || !a.IsOpenAI() || a.Extra == nil {
+		return false
+	}
+	disabled, ok := a.Extra["openai_disable_default_codex_instructions"].(bool)
+	return ok && disabled
+}
+
 // IsOpenAIResponsesWebSocketV2Enabled 返回 OpenAI 账号是否开启 Responses WebSocket v2。
 //
 // 分类型新字段：

--- a/backend/internal/service/openai_default_codex_instructions_test.go
+++ b/backend/internal/service/openai_default_codex_instructions_test.go
@@ -1,0 +1,207 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestAccount_IsOpenAIDefaultCodexInstructionsDisabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{
+			name: "enabled for OpenAI",
+			account: &Account{Platform: PlatformOpenAI, Extra: map[string]any{
+				"openai_disable_default_codex_instructions": true,
+			}},
+			want: true,
+		},
+		{
+			name: "explicit false",
+			account: &Account{Platform: PlatformOpenAI, Extra: map[string]any{
+				"openai_disable_default_codex_instructions": false,
+			}},
+		},
+		{
+			name: "invalid value type",
+			account: &Account{Platform: PlatformOpenAI, Extra: map[string]any{
+				"openai_disable_default_codex_instructions": "true",
+			}},
+		},
+		{
+			name: "other platform",
+			account: &Account{Platform: PlatformAnthropic, Extra: map[string]any{
+				"openai_disable_default_codex_instructions": true,
+			}},
+		},
+		{name: "nil account"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, tt.account.IsOpenAIDefaultCodexInstructionsDisabled())
+		})
+	}
+}
+
+func TestOpenAIGatewayService_DefaultCodexInstructionsAccountPolicy_APIKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name             string
+		disableInjection any
+		body             string
+		wantInstructions string
+		wantExists       bool
+	}{
+		{
+			name:             "default behavior remains enabled",
+			body:             `{"model":"gpt-5.4","stream":false,"input":"hello"}`,
+			wantInstructions: defaultCodexSynthInstructions("gpt-5.4"),
+			wantExists:       true,
+		},
+		{
+			name:             "disabled leaves missing instructions absent",
+			disableInjection: true,
+			body:             `{"model":"gpt-5.4","stream":false,"input":"hello"}`,
+			wantExists:       false,
+		},
+		{
+			name:             "disabled preserves blank client instructions",
+			disableInjection: true,
+			body:             `{"model":"gpt-5.4","stream":false,"instructions":"   ","input":"hello"}`,
+			wantInstructions: "   ",
+			wantExists:       true,
+		},
+		{
+			name:             "disabled preserves explicit client instructions",
+			disableInjection: true,
+			body:             `{"model":"gpt-5.4","stream":false,"instructions":"client guidance","input":"hello"}`,
+			wantInstructions: "client guidance",
+			wantExists:       true,
+		},
+		{
+			name:             "invalid policy type keeps default behavior",
+			disableInjection: "true",
+			body:             `{"model":"gpt-5.4","stream":false,"input":"hello"}`,
+			wantInstructions: defaultCodexSynthInstructions("gpt-5.4"),
+			wantExists:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":1}}`)),
+			}}
+			cfg := &config.Config{}
+			cfg.Security.URLAllowlist.Enabled = false
+			svc := &OpenAIGatewayService{cfg: cfg, httpUpstream: upstream}
+			extra := map[string]any{"use_responses_api": true}
+			if tt.disableInjection != nil {
+				extra["openai_disable_default_codex_instructions"] = tt.disableInjection
+			}
+			account := &Account{
+				ID:          1,
+				Name:        "openai-apikey",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{"api_key": "sk-test", "base_url": "https://example.com"},
+				Extra:       extra,
+			}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", bytes.NewBufferString(tt.body))
+			SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+			result, err := svc.Forward(context.Background(), c, account, []byte(tt.body))
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.NotNil(t, upstream.lastReq)
+
+			instructions := gjson.GetBytes(upstream.lastBody, "instructions")
+			require.Equal(t, tt.wantExists, instructions.Exists())
+			if tt.wantExists {
+				require.Equal(t, tt.wantInstructions, instructions.String())
+			}
+		})
+	}
+}
+
+func TestOpenAIGatewayService_DefaultCodexInstructionsAccountPolicy_OAuth(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name             string
+		body             string
+		wantInstructions string
+		wantInputRole    string
+	}{
+		{
+			name:             "missing instructions becomes empty compatibility field",
+			body:             `{"model":"gpt-5.4","stream":true,"input":[{"type":"message","role":"user","content":"hello"}]}`,
+			wantInstructions: "",
+			wantInputRole:    "user",
+		},
+		{
+			name:             "client system guidance is promoted without base prompt",
+			body:             `{"model":"gpt-5.4","stream":true,"input":[{"type":"message","role":"system","content":"client guidance"},{"type":"message","role":"user","content":"hello"}]}`,
+			wantInstructions: "client guidance",
+			wantInputRole:    "developer",
+		},
+		{
+			name:             "explicit instructions are preserved",
+			body:             `{"model":"gpt-5.4","stream":true,"instructions":"client instructions","input":[{"type":"message","role":"user","content":"hello"}]}`,
+			wantInstructions: "client instructions",
+			wantInputRole:    "user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"message":"stop after capture"}}`)),
+			}}
+			svc := &OpenAIGatewayService{cfg: &config.Config{}, httpUpstream: upstream}
+			account := &Account{
+				ID:          2,
+				Name:        "openai-oauth",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeOAuth,
+				Concurrency: 1,
+				Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "chatgpt-account"},
+				Extra:       map[string]any{"openai_disable_default_codex_instructions": true},
+			}
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewBufferString(tt.body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			result, err := svc.Forward(context.Background(), c, account, []byte(tt.body))
+			require.Error(t, err)
+			require.Nil(t, result)
+			require.NotNil(t, upstream.lastReq)
+			require.True(t, gjson.GetBytes(upstream.lastBody, "instructions").Exists())
+			require.Equal(t, tt.wantInstructions, gjson.GetBytes(upstream.lastBody, "instructions").String())
+			require.Equal(t, tt.wantInputRole, gjson.GetBytes(upstream.lastBody, "input.0.role").String())
+			require.NotContains(t, string(upstream.lastBody), defaultCodexSynthInstructions("gpt-5.4"))
+		})
+	}
+}

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -237,9 +237,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return nil, errors.New("image generation disabled for group")
 	}
 
+	disableDefaultCodexInstructions := account.IsOpenAIDefaultCodexInstructionsDisabled()
 	instructions := gjson.GetBytes(body, "instructions")
 	instructionsEmpty := !instructions.Exists() || instructions.Type != gjson.String || strings.TrimSpace(instructions.String()) == ""
-	if instructionsEmpty && !compatMessagesBridge {
+	if instructionsEmpty && !compatMessagesBridge && !disableDefaultCodexInstructions {
 		markPatchSet("instructions", defaultCodexSynthInstructions(reqModel))
 	}
 
@@ -360,13 +361,17 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		if decodeErr != nil {
 			return nil, decodeErr
 		}
-		codexResult := codexTransformResult{}
-		if compatMessagesBridge {
-			codexResult = applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{IsCodexCLI: isCodexCLI, IsCompact: isCompactRequest, SkipDefaultInstructions: true, PreserveToolCallIDs: true})
+		codexResult := applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{
+			IsCodexCLI:              isCodexCLI,
+			IsCompact:               isCompactRequest,
+			SkipDefaultInstructions: compatMessagesBridge || disableDefaultCodexInstructions,
+			PreserveToolCallIDs:     compatMessagesBridge,
+		})
+		if compatMessagesBridge || disableDefaultCodexInstructions {
+			// ChatGPT internal endpoints expect the field to exist even when the
+			// account opts out of Sub2API's embedded Codex base prompt.
 			ensureCodexOAuthInstructionsField(decoded)
 			markDecodedModified()
-		} else {
-			codexResult = applyCodexOAuthTransform(decoded, isCodexCLI, isCompactRequest)
 		}
 		if codexResult.Modified {
 			markDecodedModified()

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -286,9 +286,10 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		return nil, errors.New("image generation disabled for group")
 	}
 
+	disableDefaultCodexInstructions := account.IsOpenAIDefaultCodexInstructionsDisabled()
 	instructions := gjson.GetBytes(body, "instructions")
 	instructionsEmpty := !instructions.Exists() || instructions.Type != gjson.String || strings.TrimSpace(instructions.String()) == ""
-	if instructionsEmpty && !compatMessagesBridge && !nativeDeepSeekResponses {
+	if instructionsEmpty && !compatMessagesBridge && !nativeDeepSeekResponses && !disableDefaultCodexInstructions {
 		markPatchSet("instructions", defaultCodexSynthInstructions(reqModel))
 	}
 
@@ -409,13 +410,17 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		if decodeErr != nil {
 			return nil, decodeErr
 		}
-		codexResult := codexTransformResult{}
-		if compatMessagesBridge {
-			codexResult = applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{IsCodexCLI: isCodexCLI, IsCompact: isCompactRequest, SkipDefaultInstructions: true, PreserveToolCallIDs: true})
+		codexResult := applyCodexOAuthTransformWithOptions(decoded, codexOAuthTransformOptions{
+			IsCodexCLI:              isCodexCLI,
+			IsCompact:               isCompactRequest,
+			SkipDefaultInstructions: compatMessagesBridge || disableDefaultCodexInstructions,
+			PreserveToolCallIDs:     compatMessagesBridge,
+		})
+		if compatMessagesBridge || disableDefaultCodexInstructions {
+			// ChatGPT internal endpoints expect the field to exist even when the
+			// account opts out of Sub2API's embedded Codex base prompt.
 			ensureCodexOAuthInstructionsField(decoded)
 			markDecodedModified()
-		} else {
-			codexResult = applyCodexOAuthTransform(decoded, isCodexCLI, isCompactRequest)
 		}
 		if codexResult.Modified {
 			markDecodedModified()

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -82,6 +82,57 @@
         </div>
       </div>
 
+      <!-- OpenAI default Codex instructions -->
+      <div
+        v-if="allOpenAIPassthroughCapable"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="mb-3 flex items-center justify-between">
+          <div class="flex-1 pr-4">
+            <label
+              id="bulk-edit-openai-disable-default-codex-instructions-label"
+              class="input-label mb-0"
+              for="bulk-edit-openai-disable-default-codex-instructions-enabled"
+            >
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructions') }}
+            </label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructionsDesc') }}
+            </p>
+          </div>
+          <input
+            v-model="enableDisableDefaultCodexInstructions"
+            id="bulk-edit-openai-disable-default-codex-instructions-enabled"
+            type="checkbox"
+            aria-controls="bulk-edit-openai-disable-default-codex-instructions-body"
+            class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+        </div>
+        <div
+          id="bulk-edit-openai-disable-default-codex-instructions-body"
+          :class="!enableDisableDefaultCodexInstructions && 'pointer-events-none opacity-50'"
+          role="group"
+          aria-labelledby="bulk-edit-openai-disable-default-codex-instructions-label"
+        >
+          <button
+            id="bulk-edit-openai-disable-default-codex-instructions-toggle"
+            type="button"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              disableDefaultCodexInstructions ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+            @click="disableDefaultCodexInstructions = !disableDefaultCodexInstructions"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                disableDefaultCodexInstructions ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- Base URL (API Key only) -->
       <div class="border-t border-gray-200 pt-4 dark:border-dark-600">
         <div class="mb-3 flex items-center justify-between">
@@ -1398,6 +1449,7 @@ const enableRateMultiplier = ref(false)
 const enableStatus = ref(false)
 const enableGroups = ref(false)
 const enableOpenAIPassthrough = ref(false)
+const enableDisableDefaultCodexInstructions = ref(false)
 const enableOpenAIWSMode = ref(false)
 const enableOpenAIAPIKeyWSMode = ref(false)
 const enableUpstreamBillingAutoProbe = ref(false)
@@ -1429,6 +1481,7 @@ const rateMultiplier = ref(1)
 const status = ref<'active' | 'inactive'>('active')
 const groupIds = ref<number[]>([])
 const openaiPassthroughEnabled = ref(false)
+const disableDefaultCodexInstructions = ref(false)
 const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const upstreamBillingAutoProbeMode = ref<'enabled' | 'disabled'>('enabled')
@@ -1638,6 +1691,11 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
     }
   }
 
+  if (enableDisableDefaultCodexInstructions.value) {
+    const extra = ensureExtra()
+    extra.openai_disable_default_codex_instructions = disableDefaultCodexInstructions.value
+  }
+
   if (enableModelRestriction.value && !isOpenAIModelRestrictionDisabled.value) {
     // 统一使用 model_mapping 字段
     if (modelRestrictionMode.value === 'whitelist') {
@@ -1806,6 +1864,7 @@ const handleSubmit = async () => {
   const hasAnyFieldEnabled =
     enableBaseUrl.value ||
     enableOpenAIPassthrough.value ||
+    enableDisableDefaultCodexInstructions.value ||
     enableModelRestriction.value ||
     enableCustomErrorCodes.value ||
     enableInterceptWarmup.value ||
@@ -1946,6 +2005,7 @@ watch(
       enableStatus.value = false
       enableGroups.value = false
       enableOpenAIPassthrough.value = false
+      enableDisableDefaultCodexInstructions.value = false
       enableOpenAIWSMode.value = false
       enableOpenAIAPIKeyWSMode.value = false
       enableUpstreamBillingAutoProbe.value = false
@@ -1958,6 +2018,7 @@ watch(
       // Reset all values
       baseUrl.value = ''
       openaiPassthroughEnabled.value = false
+      disableDefaultCodexInstructions.value = false
       modelRestrictionMode.value = 'whitelist'
       allowedModels.value = []
       modelMappings.value = []

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -133,6 +133,57 @@
         </div>
       </div>
 
+      <!-- OpenAI default Codex instructions -->
+      <div
+        v-if="allOpenAIPassthroughCapable"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="mb-3 flex items-center justify-between">
+          <div class="flex-1 pr-4">
+            <label
+              id="bulk-edit-openai-disable-default-codex-instructions-label"
+              class="input-label mb-0"
+              for="bulk-edit-openai-disable-default-codex-instructions-enabled"
+            >
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructions') }}
+            </label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructionsDesc') }}
+            </p>
+          </div>
+          <input
+            v-model="enableDisableDefaultCodexInstructions"
+            id="bulk-edit-openai-disable-default-codex-instructions-enabled"
+            type="checkbox"
+            aria-controls="bulk-edit-openai-disable-default-codex-instructions-body"
+            class="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+        </div>
+        <div
+          id="bulk-edit-openai-disable-default-codex-instructions-body"
+          :class="!enableDisableDefaultCodexInstructions && 'pointer-events-none opacity-50'"
+          role="group"
+          aria-labelledby="bulk-edit-openai-disable-default-codex-instructions-label"
+        >
+          <button
+            id="bulk-edit-openai-disable-default-codex-instructions-toggle"
+            type="button"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              disableDefaultCodexInstructions ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+            @click="disableDefaultCodexInstructions = !disableDefaultCodexInstructions"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                disableDefaultCodexInstructions ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI API long-context billing -->
       <div
         v-if="allOpenAIPassthroughCapable"
@@ -1658,6 +1709,7 @@ const enableStatus = ref(false)
 const enableGroups = ref(false)
 const enableOpenAIPassthrough = ref(false)
 const enableOpenAIFlattenNamespaces = ref(false)
+const enableDisableDefaultCodexInstructions = ref(false)
 const enableOpenAILongContextBilling = ref(false)
 const enableOpenAIEndpointCapabilities = ref(false)
 const enableOpenAIResponsesMode = ref(false)
@@ -1694,6 +1746,7 @@ const groupIds = ref<number[]>([])
 const openaiPassthroughEnabled = ref(false)
 // Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+const disableDefaultCodexInstructions = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 const openAIEndpointCapabilities = ref<OpenAIEndpointCapability[]>([
   'chat_completions',
@@ -1988,6 +2041,11 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
     extra.openai_responses_flatten_namespaces = openaiFlattenNamespacesEnabled.value
   }
 
+  if (enableDisableDefaultCodexInstructions.value) {
+    const extra = ensureExtra()
+    extra.openai_disable_default_codex_instructions = disableDefaultCodexInstructions.value
+  }
+
   if (applyOpenAILongContextBilling) {
     const extra = ensureExtra()
     extra.openai_long_context_billing_enabled = openAILongContextBillingEnabled.value
@@ -2191,6 +2249,7 @@ const handleSubmit = async () => {
     enableBaseUrl.value ||
     enableOpenAIPassthrough.value ||
     enableOpenAIFlattenNamespaces.value ||
+    enableDisableDefaultCodexInstructions.value ||
     (enableOpenAILongContextBilling.value && allOpenAIPassthroughCapable.value) ||
     (enableOpenAIEndpointCapabilities.value && allOpenAIAPIKey.value) ||
     (enableOpenAIResponsesMode.value && allOpenAIAPIKey.value) ||
@@ -2353,6 +2412,7 @@ watch(
       enableGroups.value = false
       enableOpenAIPassthrough.value = false
       enableOpenAIFlattenNamespaces.value = false
+      enableDisableDefaultCodexInstructions.value = false
       enableOpenAILongContextBilling.value = false
       enableOpenAIEndpointCapabilities.value = false
       enableOpenAIResponsesMode.value = false
@@ -2371,6 +2431,7 @@ watch(
       baseUrl.value = ''
       openaiPassthroughEnabled.value = false
       openaiFlattenNamespacesEnabled.value = false
+      disableDefaultCodexInstructions.value = false
       openAILongContextBillingEnabled.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openAIResponsesMode.value = 'auto'

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2781,6 +2781,39 @@
         </div>
       </div>
 
+      <!-- OpenAI 默认 Codex instructions 注入开关 -->
+      <div
+        v-if="form.platform === 'openai'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.disableDefaultCodexInstructions') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructionsDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            data-testid="openai-disable-default-codex-instructions-toggle"
+            :aria-checked="disableDefaultCodexInstructions"
+            @click="disableDefaultCodexInstructions = !disableDefaultCodexInstructions"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              disableDefaultCodexInstructions ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                disableDefaultCodexInstructions ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI WS Mode 三态（off/ctx_pool/passthrough） -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -3778,6 +3811,7 @@ const applyGrokOAuthUpstreamConfig = (credentials: Record<string, unknown>) => {
 const interceptWarmupRequests = ref(false)
 const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
+const disableDefaultCodexInstructions = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 const openAILongContextBillingTouched = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
@@ -4231,6 +4265,7 @@ watch(
     }
     if (newPlatform !== 'openai') {
       openaiPassthroughEnabled.value = false
+      disableDefaultCodexInstructions.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -4656,6 +4691,7 @@ const resetForm = () => {
   interceptWarmupRequests.value = false
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
+  disableDefaultCodexInstructions.value = false
   openAILongContextBillingEnabled.value = false
   openAILongContextBillingTouched.value = false
   openAICompactMode.value = 'auto'
@@ -4739,6 +4775,11 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
   } else {
     delete extra.openai_passthrough
     delete extra.openai_oauth_passthrough
+  }
+  if (disableDefaultCodexInstructions.value) {
+    extra.openai_disable_default_codex_instructions = true
+  } else {
+    delete extra.openai_disable_default_codex_instructions
   }
   extra.openai_long_context_billing_enabled = openAILongContextBillingEnabled.value
 

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -2974,6 +2974,39 @@
         </div>
       </div>
 
+      <!-- OpenAI 默认 Codex instructions 注入开关 -->
+      <div
+        v-if="form.platform === 'openai'"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.disableDefaultCodexInstructions') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructionsDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            data-testid="openai-disable-default-codex-instructions-toggle"
+            :aria-checked="disableDefaultCodexInstructions"
+            @click="disableDefaultCodexInstructions = !disableDefaultCodexInstructions"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              disableDefaultCodexInstructions ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                disableDefaultCodexInstructions ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI WS Mode 三态（off/ctx_pool/passthrough） -->
       <div
         v-if="form.platform === 'openai' && (accountCategory === 'oauth-based' || accountCategory === 'apikey')"
@@ -4162,6 +4195,7 @@ const autoPauseOnExpired = ref(true)
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+const disableDefaultCodexInstructions = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 const openAILongContextBillingTouched = ref(false)
 const openAICompactMode = ref<OpenAICompactMode>('auto')
@@ -4628,6 +4662,7 @@ watch(
     if (newPlatform !== 'openai') {
       openaiPassthroughEnabled.value = false
       openaiFlattenNamespacesEnabled.value = false
+      disableDefaultCodexInstructions.value = false
       openAIEndpointCapabilities.value = ['chat_completions', 'embeddings']
       openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
       openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
@@ -5056,6 +5091,7 @@ const resetForm = () => {
   autoPauseOnExpired.value = true
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
+  disableDefaultCodexInstructions.value = false
   openAILongContextBillingEnabled.value = false
   openAILongContextBillingTouched.value = false
   openAICompactMode.value = 'auto'
@@ -5146,6 +5182,11 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
     extra.openai_responses_flatten_namespaces = true
   } else {
     delete extra.openai_responses_flatten_namespaces
+  }
+  if (disableDefaultCodexInstructions.value) {
+    extra.openai_disable_default_codex_instructions = true
+  } else {
+    delete extra.openai_disable_default_codex_instructions
   }
   extra.openai_long_context_billing_enabled = openAILongContextBillingEnabled.value
 

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1481,6 +1481,39 @@
         </div>
       </div>
 
+      <!-- OpenAI 默认 Codex instructions 注入开关 -->
+      <div
+        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.disableDefaultCodexInstructions') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructionsDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            data-testid="openai-disable-default-codex-instructions-toggle"
+            :aria-checked="disableDefaultCodexInstructions"
+            @click="disableDefaultCodexInstructions = !disableDefaultCodexInstructions"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              disableDefaultCodexInstructions ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                disableDefaultCodexInstructions ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI Codex hosted image_generation bridge policy -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -2827,8 +2860,9 @@ const cacheTTLOverrideTarget = ref<string>('5m')
 const customBaseUrlEnabled = ref(false)
 const customBaseUrl = ref('')
 
-// OpenAI 自动透传开关（OAuth/API Key）
+// OpenAI 账号级转发开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
+const disableDefaultCodexInstructions = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 // OpenAI 订阅档位（Plus/Pro/Free）手动覆盖值,存于 credentials.plan_type;'' 表示清空/自动识别
 const editPlanType = ref<string>('')
@@ -3262,8 +3296,9 @@ const syncFormFromAccount = (newAccount: Account | null) => {
 	autoPause7dDisabled.value = extra?.auto_pause_7d_disabled === true
 	upstreamBillingAutoProbeEnabled.value = extra?.upstream_billing_probe_enabled === true
 
-  // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
+  // Load OpenAI account toggles (OpenAI OAuth/SetupToken/API Key)
   openaiPassthroughEnabled.value = false
+  disableDefaultCodexInstructions.value = false
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
@@ -3280,6 +3315,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   webSearchEmulationMode.value = 'default'
   if (newAccount.platform === 'openai' && (newAccount.type === 'oauth' || newAccount.type === 'setup-token' || newAccount.type === 'apikey')) {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
+    disableDefaultCodexInstructions.value = extra?.openai_disable_default_codex_instructions === true
     const longContextBillingValue = extra?.openai_long_context_billing_enabled
     openAILongContextBillingEnabled.value = longContextBillingValue === true
     // plan_type 手动覆盖仅 OAuth 有实际调度语义(IsOpenAIChatGPTSubscription 要求 oauth),故只对 oauth 回填
@@ -4513,6 +4549,11 @@ const handleSubmit = async () => {
       } else {
         delete newExtra.openai_passthrough
         delete newExtra.openai_oauth_passthrough
+      }
+      if (disableDefaultCodexInstructions.value) {
+        newExtra.openai_disable_default_codex_instructions = true
+      } else {
+        delete newExtra.openai_disable_default_codex_instructions
       }
       if (isSparkShadow.value) {
         delete newExtra.openai_long_context_billing_enabled

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -1646,6 +1646,39 @@
         </div>
       </div>
 
+      <!-- OpenAI 默认 Codex instructions 注入开关 -->
+      <div
+        v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
+        class="border-t border-gray-200 pt-4 dark:border-dark-600"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <label class="input-label mb-0">{{ t('admin.accounts.openai.disableDefaultCodexInstructions') }}</label>
+            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ t('admin.accounts.openai.disableDefaultCodexInstructionsDesc') }}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            data-testid="openai-disable-default-codex-instructions-toggle"
+            :aria-checked="disableDefaultCodexInstructions"
+            @click="disableDefaultCodexInstructions = !disableDefaultCodexInstructions"
+            :class="[
+              'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+              disableDefaultCodexInstructions ? 'bg-primary-600' : 'bg-gray-200 dark:bg-dark-600'
+            ]"
+          >
+            <span
+              :class="[
+                'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
+                disableDefaultCodexInstructions ? 'translate-x-5' : 'translate-x-0'
+              ]"
+            />
+          </button>
+        </div>
+      </div>
+
       <!-- OpenAI Codex hosted image_generation bridge policy -->
       <div
         v-if="account?.platform === 'openai' && (account?.type === 'oauth' || account?.type === 'setup-token' || account?.type === 'apikey')"
@@ -3154,10 +3187,11 @@ const cacheTTLOverrideTarget = ref<string>('5m')
 const customBaseUrlEnabled = ref(false)
 const customBaseUrl = ref('')
 
-// OpenAI 自动透传开关（OAuth/API Key）
+// OpenAI 账号级转发开关（OAuth/API Key）
 const openaiPassthroughEnabled = ref(false)
 // OpenAI Codex namespace 工具摊平兼容开关（仅 OAuth），缺省关闭即原样保留
 const openaiFlattenNamespacesEnabled = ref(false)
+const disableDefaultCodexInstructions = ref(false)
 const openAILongContextBillingEnabled = ref(false)
 // OpenAI 订阅档位（Plus/Pro/Free）手动覆盖值,存于 credentials.plan_type;'' 表示清空/自动识别
 const editPlanType = ref<string>('')
@@ -3630,9 +3664,10 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   upstreamBillingRateSyncEnabled.value =
     upstreamBillingAutoProbeEnabled.value && extra?.upstream_billing_rate_sync_enabled === true
 
-  // Load OpenAI passthrough toggle (OpenAI OAuth/SetupToken/API Key)
+  // Load OpenAI account toggles (OpenAI OAuth/SetupToken/API Key)
   openaiPassthroughEnabled.value = false
   openaiFlattenNamespacesEnabled.value = false
+  disableDefaultCodexInstructions.value = false
   openAILongContextBillingEnabled.value = false
   editPlanType.value = ''
   openAICompactMode.value = 'auto'
@@ -3652,6 +3687,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     openaiPassthroughEnabled.value = extra?.openai_passthrough === true || extra?.openai_oauth_passthrough === true
     openaiFlattenNamespacesEnabled.value =
       newAccount.type === 'oauth' && extra?.openai_responses_flatten_namespaces === true
+    disableDefaultCodexInstructions.value = extra?.openai_disable_default_codex_instructions === true
     const longContextBillingValue = extra?.openai_long_context_billing_enabled
     openAILongContextBillingEnabled.value = longContextBillingValue === true
     // plan_type 手动覆盖仅 OAuth 有实际调度语义(IsOpenAIChatGPTSubscription 要求 oauth),故只对 oauth 回填
@@ -5044,6 +5080,11 @@ const handleSubmit = async () => {
         newExtra.openai_responses_flatten_namespaces = true
       } else {
         delete newExtra.openai_responses_flatten_namespaces
+      }
+      if (disableDefaultCodexInstructions.value) {
+        newExtra.openai_disable_default_codex_instructions = true
+      } else {
+        delete newExtra.openai_disable_default_codex_instructions
       }
       if (isSparkShadow.value) {
         delete newExtra.openai_long_context_billing_enabled

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -237,6 +237,52 @@ describe('BulkEditAccountModal', () => {
     })
   })
 
+  it('OpenAI 账号批量编辑可禁用默认 Codex instructions 注入', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-openai-disable-default-codex-instructions-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-openai-disable-default-codex-instructions-toggle').trigger('click')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        openai_disable_default_codex_instructions: true
+      }
+    })
+  })
+
+  it('OpenAI 账号批量编辑可恢复默认 Codex instructions 注入', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['apikey']
+    })
+
+    await wrapper.get('#bulk-edit-openai-disable-default-codex-instructions-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        openai_disable_default_codex_instructions: false
+      }
+    })
+  })
+
+  it('非 OpenAI 账号不显示默认 Codex instructions 批量开关', () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['anthropic'],
+      selectedTypes: ['apikey']
+    })
+
+    expect(wrapper.find('#bulk-edit-openai-disable-default-codex-instructions-enabled').exists()).toBe(false)
+  })
+
   it('OpenAI OAuth 批量编辑应提交 OAuth 专属 WS mode 字段（含 http_bridge）', async () => {
     const wrapper = mountModal({
       selectedPlatforms: ['openai'],

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -320,6 +320,52 @@ describe('BulkEditAccountModal', () => {
     expect(wrapper.find('#bulk-edit-openai-flatten-namespaces-enabled').exists()).toBe(false)
   })
 
+  it('OpenAI 账号批量编辑可禁用默认 Codex instructions 注入', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['oauth']
+    })
+
+    await wrapper.get('#bulk-edit-openai-disable-default-codex-instructions-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-openai-disable-default-codex-instructions-toggle').trigger('click')
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        openai_disable_default_codex_instructions: true
+      }
+    })
+  })
+
+  it('OpenAI 账号批量编辑可恢复默认 Codex instructions 注入', async () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['apikey']
+    })
+
+    await wrapper.get('#bulk-edit-openai-disable-default-codex-instructions-enabled').setValue(true)
+    await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledTimes(1)
+    expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
+      extra: {
+        openai_disable_default_codex_instructions: false
+      }
+    })
+  })
+
+  it('非 OpenAI 账号不显示默认 Codex instructions 批量开关', () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['anthropic'],
+      selectedTypes: ['apikey']
+    })
+
+    expect(wrapper.find('#bulk-edit-openai-disable-default-codex-instructions-enabled').exists()).toBe(false)
+  })
+
   it('OpenAI OAuth 批量编辑应提交 OAuth 专属 WS mode 字段（含 http_bridge）', async () => {
     const wrapper = mountModal({
       selectedPlatforms: ['openai'],

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -167,6 +167,30 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     expect(createAccountMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBe(false)
   })
 
+  it('omits the default Codex instructions opt-out for new OpenAI accounts', async () => {
+    await submitApiKeyAccount('openai')
+
+    expect(createAccountMock.mock.calls[0]?.[0]?.extra).not.toHaveProperty(
+      'openai_disable_default_codex_instructions'
+    )
+  })
+
+  it('submits the default Codex instructions opt-out when enabled', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI account')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+    await wrapper.get('[data-testid="openai-disable-default-codex-instructions-toggle"]').trigger('click')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(
+      createAccountMock.mock.calls[0]?.[0]?.extra?.openai_disable_default_codex_instructions
+    ).toBe(true)
+  })
+
   it('enables upstream billing probes by default for new OpenAI API key accounts', async () => {
     await submitApiKeyAccount('openai')
 

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -251,6 +251,30 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     )
   })
 
+  it('omits the default Codex instructions opt-out for new OpenAI accounts', async () => {
+    await submitApiKeyAccount('openai')
+
+    expect(createAccountMock.mock.calls[0]?.[0]?.extra).not.toHaveProperty(
+      'openai_disable_default_codex_instructions'
+    )
+  })
+
+  it('submits the default Codex instructions opt-out when enabled', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'OpenAI')
+    await selectButtonByText(wrapper, 'API Key')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('OpenAI account')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('test-api-key')
+    await wrapper.get('[data-testid="openai-disable-default-codex-instructions-toggle"]').trigger('click')
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(
+      createAccountMock.mock.calls[0]?.[0]?.extra?.openai_disable_default_codex_instructions
+    ).toBe(true)
+  })
+
   it('enables upstream billing probes by default for new OpenAI API key accounts', async () => {
     await submitApiKeyAccount('openai')
 

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -395,6 +395,45 @@ describe('EditAccountModal', () => {
     })
   })
 
+  it('loads and clears the default Codex instructions opt-out', async () => {
+    const account = buildAccount()
+    account.extra = {
+      openai_disable_default_codex_instructions: true
+    }
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="openai-disable-default-codex-instructions-toggle"]')
+    expect(toggle.attributes('aria-checked')).toBe('true')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty(
+      'openai_disable_default_codex_instructions'
+    )
+  })
+
+  it('enables the default Codex instructions opt-out for a legacy account', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="openai-disable-default-codex-instructions-toggle"]')
+    expect(toggle.attributes('aria-checked')).toBe('false')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(
+      updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_disable_default_codex_instructions
+    ).toBe(true)
+  })
+
   it('loads and submits the per-account OpenAI long-context billing toggle', async () => {
     const account = buildAccount()
     account.extra = {

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -567,6 +567,45 @@ describe('EditAccountModal', () => {
     })
   })
 
+  it('loads and clears the default Codex instructions opt-out', async () => {
+    const account = buildAccount()
+    account.extra = {
+      openai_disable_default_codex_instructions: true
+    }
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="openai-disable-default-codex-instructions-toggle"]')
+    expect(toggle.attributes('aria-checked')).toBe('true')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty(
+      'openai_disable_default_codex_instructions'
+    )
+  })
+
+  it('enables the default Codex instructions opt-out for a legacy account', async () => {
+    const account = buildAccount()
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    const toggle = wrapper.get('[data-testid="openai-disable-default-codex-instructions-toggle"]')
+    expect(toggle.attributes('aria-checked')).toBe('false')
+
+    await toggle.trigger('click')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(
+      updateAccountMock.mock.calls[0]?.[1]?.extra?.openai_disable_default_codex_instructions
+    ).toBe(true)
+  })
+
   it('loads and submits the per-account OpenAI long-context billing toggle', async () => {
     const account = buildAccount()
     account.extra = {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -440,6 +440,9 @@ export default {
         oauthPassthrough: 'Auto passthrough (auth only)',
         oauthPassthroughDesc:
           'When enabled, this OpenAI account uses automatic passthrough: the gateway forwards request/response as-is and only swaps auth, while keeping billing/concurrency/audit and necessary safety filtering.',
+        disableDefaultCodexInstructions: 'Disable default Codex Instructions injection',
+        disableDefaultCodexInstructionsDesc:
+          'When enabled, Sub2API does not inject its embedded Codex Base Prompt when instructions are missing. Client-provided instructions and system guidance are preserved.',
         longContextBilling: 'API long-context pricing',
         longContextBillingDesc:
           'Disabled by default. Enable only when this account\'s upstream charges OpenAI API long-context rates above the model threshold.',

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -552,6 +552,9 @@ export default {
         flattenNamespaces: 'Flatten Codex namespace tools (compatibility)',
         flattenNamespacesDesc:
           'Disabled by default: Codex namespace tool declarations are forwarded as-is on /responses, which is what the ChatGPT Codex backend expects. Enable only when this OAuth account is routed to a relay that rejects namespace tools — flattening renames them to namespace__tool, which breaks models that address collaboration tools as functions.<namespace>.<tool>. Compaction requests always flatten regardless of this switch.',
+        disableDefaultCodexInstructions: 'Disable default Codex Instructions injection',
+        disableDefaultCodexInstructionsDesc:
+          'When enabled, Sub2API does not inject its embedded Codex Base Prompt when instructions are missing. Client-provided instructions and system guidance are preserved.',
         longContextBilling: 'API long-context pricing',
         longContextBillingDesc:
           'Disabled by default. Enable only when this account\'s upstream charges OpenAI API long-context rates above the model threshold.',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -507,6 +507,9 @@ export default {
         oauthPassthrough: '自动透传（仅替换认证）',
         oauthPassthroughDesc:
           '开启后，该 OpenAI 账号将自动透传请求与响应，仅替换认证并保留计费/并发/审计及必要安全过滤；如遇兼容性问题可随时关闭回滚。',
+        disableDefaultCodexInstructions: '禁用默认 Codex Instructions 注入',
+        disableDefaultCodexInstructionsDesc:
+          '开启后，请求未提供 instructions 时不再注入 Sub2API 内置的 Codex Base Prompt；客户端自行提供的 instructions 和 system 指令不受影响。',
         longContextBilling: 'API 长上下文计费',
         longContextBillingDesc: '默认关闭。仅当该账号的上游会按模型阈值收取 OpenAI API 长上下文费率时开启。',
         responsesWebsocketsV2: 'Responses WebSocket v2',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -629,6 +629,9 @@ export default {
         flattenNamespaces: '摊平 Codex namespace 工具（兼容）',
         flattenNamespacesDesc:
           '默认关闭：/responses 上的 namespace 工具声明原样转发，这正是 ChatGPT Codex 后端期望的形态。仅当该 OAuth 账号指向不认识 namespace 的兼容上游时才开启——摊平会把工具改名为 namespace__tool，使按 functions.<命名空间>.<工具> 寻址的模型（如 gpt-5.6 多智能体）无法调用。压缩（compact）请求不受该开关影响，始终摊平。',
+        disableDefaultCodexInstructions: '禁用默认 Codex Instructions 注入',
+        disableDefaultCodexInstructionsDesc:
+          '开启后，请求未提供 instructions 时不再注入 Sub2API 内置的 Codex Base Prompt；客户端自行提供的 instructions 和 system 指令不受影响。',
         longContextBilling: 'API 长上下文计费',
         longContextBillingDesc: '默认关闭。仅当该账号的上游会按模型阈值收取 OpenAI API 长上下文费率时开启。',
         responsesWebsocketsV2: 'Responses WebSocket v2',


### PR DESCRIPTION
## Summary

   为 OpenAI 账号新增 `openai_disable_default_codex_instructions` 开关，用于禁用 Sub2API 在 `/v1/responses` 请求缺少、为空或格式非法的 `instructions` 时自动注入的内置 Codex Base Prompt。

   该开关主要面向 PiAgent、OpenCode 等非 Codex CLI 客户端。这些客户端的工具集合和工作流与 Codex CLI 并不完全一致，注入 Codex CLI 默认 Instructions 后，模型可能错误地认为客户端提供了 `apply_patch` 等工具，进而发
 起不存在的工具调用或导致任务执行失败。

   ## Root cause

   当前非透传 `/v1/responses` 路径会在客户端没有提供有效 `instructions` 时，自动注入 Sub2API 内嵌的 Codex Base Prompt。

   这套 Prompt 面向 Codex CLI，包含与 Codex CLI 本地工具和执行流程相关的指引。PiAgent、OpenCode 等客户端虽然同样通过 OpenAI Responses API 访问上游，但不一定实现 Codex CLI 的完整工具协议。

   因此，自动注入该 Prompt 可能让模型对客户端能力产生错误假设，例如尝试调用客户端未声明或未实现的 `apply_patch` 工具。

   这项默认注入最初用于兼容早期 Codex 上游端点对非空 `instructions` 的校验。当前上游已经取消该非空校验，因此可以在不注入 Codex Base Prompt 的情况下正常发送请求。

   ## What changed

   - 新增 OpenAI 账号级配置：
     - `extra.openai_disable_default_codex_instructions`
   - 该配置默认关闭，现有账号行为保持不变。
   - 开启后，仅跳过 Sub2API 内置 Codex Base Prompt 的默认注入：
     - 不删除或覆盖客户端显式提供的 `instructions`。
     - 客户端提供的空白 `instructions` 保持原值，不替换为 Codex Base Prompt。
     - 不影响 OAuth 路径将客户端 `role: "system"` 转换为 `developer`，并将其文本提升到 `instructions` 的现有兼容逻辑。
     - OAuth 请求未提供指令时仍保留 `instructions: ""` 的现有请求字段形状，但不会填入 Codex Base Prompt。
   - 在 OpenAI 账号的以下界面中增加开关：
     - 创建账号
     - 编辑账号
     - 批量编辑账号
   - 补充中英文界面文案。
   - 自动透传、图片生成桥接、Spark 图片能力限制和强制 Instructions 模板等其他逻辑不受影响。

   ## Behavior

   | 场景 | 默认配置 | 开启新开关 |
   |---|---|---|
   | API Key 请求缺少 `instructions` | 注入 Codex Base Prompt | 不添加 `instructions` |
   | API Key 请求携带空白 `instructions` | 注入 Codex Base Prompt | 保留客户端原值 |
   | 客户端显式提供 `instructions` | 保留客户端值 | 保留客户端值 |
   | OAuth 请求缺少 `instructions` | 注入 Codex Base Prompt | 仅保留 `instructions: ""` |
   | OAuth 请求包含 `role: "system"` | 转换并提升到 `instructions` | 保持相同转换，不注入 Base Prompt |
   | 配置缺失、为 `false` 或类型非法 | 保持现有默认注入 | 不适用 |

   ## Verification

   ### Backend

   ```bash
   cd backend
   go test ./internal/service -count=1
 ```

 完整 internal/service 测试通过。

 新增的请求链路测试使用真实 OpenAIGatewayService.Forward 和 HTTP upstream recorder，直接检查最终发送给上游的 JSON，而不是仅测试配置判断函数。

 覆盖以下边界：

 - 默认配置继续注入 Codex Base Prompt。
 - 开关开启后，API Key /responses 请求缺少 instructions 时，最终上游 payload 不包含该字段。
 - 开关开启后，客户端的空白 instructions 保持原值。
 - 开关开启后，客户端显式提供的 instructions 保持不变。
 - 非布尔配置值安全回退到现有默认行为。
 - 非 OpenAI 账号忽略该配置。
 - OAuth 请求缺少指令时仅保留 instructions: ""。
 - OAuth system 消息继续转换为 developer 并提升到 instructions。
 - OAuth 最终上游 payload 不包含默认 Codex Base Prompt。

 ### Frontend

 ```bash
   cd frontend

   npm exec -- vitest run \
     src/components/account/__tests__/CreateAccountModal.spec.ts \
     src/components/account/__tests__/EditAccountModal.spec.ts \
     src/components/account/__tests__/BulkEditAccountModal.spec.ts
 ```

 相关前端测试共 77 个，全部通过。

 ```bash
   npm run typecheck

   npm exec -- eslint \
     src/components/account/CreateAccountModal.vue \
     src/components/account/EditAccountModal.vue \
     src/components/account/BulkEditAccountModal.vue \
     src/components/account/__tests__/CreateAccountModal.spec.ts \
     src/components/account/__tests__/EditAccountModal.spec.ts \
     src/components/account/__tests__/BulkEditAccountModal.spec.ts \
     src/i18n/locales/en/admin/accounts.ts \
     src/i18n/locales/zh/admin/accounts.ts

   npm run build
 ```

 以上检查均通过。

 ```bash
   git diff --check origin/main...HEAD
 ```

 无格式错误。

 ## Compatibility

 - 开关默认关闭，升级后不会改变现有 OpenAI 账号行为。
 - 配置存储在账号现有的 extra 字段中，不需要数据库迁移。
 - 该开关只控制 Sub2API 内置 Codex Base Prompt 的默认注入，不是“删除所有 instructions”：
     - 客户端自定义 instructions 会继续保留。
     - 客户端 system 指令的 OAuth 兼容转换继续生效。
     - 其他功能所需的 instructions 修改逻辑不受影响。
 - 自动透传路径维持现有行为，本次变更不调整其本地校验和转发策略。