### PR TITLE
feat(admin): 账号管理支持筛选全选以便批量操作

### DIFF
--- a/frontend/src/components/admin/account/AccountBulkActionsBar.vue
+++ b/frontend/src/components/admin/account/AccountBulkActionsBar.vue
@@ -7,33 +7,47 @@
       <span v-else class="text-sm font-medium text-primary-900 dark:text-primary-100">
         {{ t('admin.accounts.bulkEdit.title') }}
       </span>
-      <template v-if="selectedIds.length > 0">
       <button
-        @click="$emit('select-page')"
+        type="button"
+        data-test="select-page"
         class="text-xs font-medium text-primary-700 hover:text-primary-800 dark:text-primary-300 dark:hover:text-primary-200"
+        @click="$emit('select-page')"
       >
         {{ t('admin.accounts.bulkActions.selectCurrentPage') }}
       </button>
       <span class="text-gray-300 dark:text-primary-800">•</span>
       <button
-        @click="$emit('clear')"
-        class="text-xs font-medium text-primary-700 hover:text-primary-800 dark:text-primary-300 dark:hover:text-primary-200"
+        type="button"
+        data-test="select-filtered"
+        class="text-xs font-medium text-primary-700 hover:text-primary-800 disabled:cursor-not-allowed disabled:opacity-60 dark:text-primary-300 dark:hover:text-primary-200"
+        :disabled="selectingFiltered"
+        @click="$emit('select-filtered')"
       >
-        {{ t('admin.accounts.bulkActions.clear') }}
+        {{ selectingFiltered ? t('admin.accounts.bulkActions.selectingFiltered') : t('admin.accounts.bulkActions.selectFiltered') }}
       </button>
+      <template v-if="selectedIds.length > 0">
+        <span class="text-gray-300 dark:text-primary-800">•</span>
+        <button
+          type="button"
+          data-test="clear-selection"
+          class="text-xs font-medium text-primary-700 hover:text-primary-800 dark:text-primary-300 dark:hover:text-primary-200"
+          @click="$emit('clear')"
+        >
+          {{ t('admin.accounts.bulkActions.clear') }}
+        </button>
       </template>
     </div>
-    <div class="flex gap-2">
+    <div class="flex flex-wrap gap-2">
       <template v-if="selectedIds.length > 0">
-        <button @click="$emit('delete')" class="btn btn-danger btn-sm">{{ t('admin.accounts.bulkActions.delete') }}</button>
-        <button @click="$emit('reset-status')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
-        <button @click="$emit('refresh-token')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
-        <button @click="$emit('probe-upstream-billing')" class="btn btn-secondary btn-sm">{{ t('admin.accounts.bulkActions.probeUpstreamBilling') }}</button>
-        <button @click="$emit('toggle-schedulable', true)" class="btn btn-success btn-sm">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
-        <button @click="$emit('toggle-schedulable', false)" class="btn btn-warning btn-sm">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
-        <button @click="$emit('edit-selected')" class="btn btn-primary btn-sm">{{ t('admin.accounts.bulkActions.edit') }}</button>
+        <button type="button" class="btn btn-danger btn-sm" @click="$emit('delete')">{{ t('admin.accounts.bulkActions.delete') }}</button>
+        <button type="button" class="btn btn-secondary btn-sm" @click="$emit('reset-status')">{{ t('admin.accounts.bulkActions.resetStatus') }}</button>
+        <button type="button" class="btn btn-secondary btn-sm" @click="$emit('refresh-token')">{{ t('admin.accounts.bulkActions.refreshToken') }}</button>
+        <button type="button" class="btn btn-secondary btn-sm" @click="$emit('probe-upstream-billing')">{{ t('admin.accounts.bulkActions.probeUpstreamBilling') }}</button>
+        <button type="button" class="btn btn-success btn-sm" @click="$emit('toggle-schedulable', true)">{{ t('admin.accounts.bulkActions.enableScheduling') }}</button>
+        <button type="button" class="btn btn-warning btn-sm" @click="$emit('toggle-schedulable', false)">{{ t('admin.accounts.bulkActions.disableScheduling') }}</button>
+        <button type="button" class="btn btn-primary btn-sm" @click="$emit('edit-selected')">{{ t('admin.accounts.bulkActions.edit') }}</button>
       </template>
-      <button @click="$emit('edit-filtered')" class="btn btn-primary btn-sm">
+      <button type="button" class="btn btn-primary btn-sm" @click="$emit('edit-filtered')">
         {{ t('admin.accounts.bulkEdit.submit') }}
       </button>
     </div>
@@ -43,13 +57,16 @@
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n'
 
-defineProps<{ selectedIds: number[] }>()
+withDefaults(defineProps<{ selectedIds: number[]; selectingFiltered?: boolean }>(), {
+  selectingFiltered: false
+})
 defineEmits([
   'delete',
   'edit-selected',
   'edit-filtered',
   'clear',
   'select-page',
+  'select-filtered',
   'toggle-schedulable',
   'reset-status',
   'refresh-token',

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -389,6 +389,11 @@ export default {
       bulkActions: {
         selected: '{count} account(s) selected',
         selectCurrentPage: 'Select this page',
+        selectFiltered: 'Select all filtered',
+        selectingFiltered: 'Selecting…',
+        selectFilteredSuccess: 'Selected {count} account(s) matching filters',
+        selectFilteredEmpty: 'No accounts match the current filters',
+        selectFilteredFailed: 'Failed to select filtered accounts',
         clear: 'Clear selection',
         edit: 'Bulk Edit',
         delete: 'Bulk Delete',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -458,6 +458,11 @@ export default {
       bulkActions: {
         selected: '已选择 {count} 个账号',
         selectCurrentPage: '本页全选',
+        selectFiltered: '筛选全选',
+        selectingFiltered: '选择中…',
+        selectFilteredSuccess: '已选中筛选结果 {count} 个账号',
+        selectFilteredEmpty: '当前筛选条件下没有可选择的账号',
+        selectFilteredFailed: '筛选全选失败',
         clear: '清除选择',
         edit: '批量编辑账号',
         delete: '批量删除',

--- a/frontend/src/views/admin/AccountsView.vue
+++ b/frontend/src/views/admin/AccountsView.vue
@@ -177,6 +177,7 @@
       <template #table>
         <AccountBulkActionsBar
           :selected-ids="selIds"
+          :selecting-filtered="selectingFiltered"
           @delete="handleBulkDelete"
           @reset-status="handleBulkResetStatus"
           @refresh-token="handleBulkRefreshToken"
@@ -185,6 +186,7 @@
           @edit-filtered="openBulkEditFiltered"
           @clear="clearSelection"
           @select-page="selectPage"
+          @select-filtered="selectFiltered"
           @toggle-schedulable="handleBulkToggleSchedulable"
         />
         <div ref="accountTableRef" class="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -1491,6 +1493,7 @@ const toggleSelectAllVisible = (event: Event) => {
   const target = event.target as HTMLInputElement
   toggleVisible(target.checked)
 }
+
 const handleBulkDelete = async () => { if(!confirm(t('common.confirm'))) return; try { await Promise.all(selIds.value.map(id => adminAPI.accounts.delete(id))); clearSelection(); reload() } catch (error) { console.error('Failed to bulk delete accounts:', error) } }
 const handleBulkResetStatus = async () => {
   if (!confirm(t('common.confirm'))) return
@@ -1672,6 +1675,47 @@ const buildBulkEditFilterSnapshot = () => {
     privacy_mode: typeof rawParams.privacy_mode === 'string' ? rawParams.privacy_mode : '',
     sort_by: typeof rawParams.sort_by === 'string' ? rawParams.sort_by : '',
     sort_order: sortOrder
+  }
+}
+
+const SELECT_FILTERED_PAGE_SIZE = 1000
+const SELECT_FILTERED_MAX_PAGES = 200
+const selectingFiltered = ref(false)
+
+const selectFiltered = async () => {
+  if (selectingFiltered.value) return
+  selectingFiltered.value = true
+  try {
+    const filters = {
+      ...buildBulkEditFilterSnapshot(),
+      include_scheduler_score: '0'
+    }
+    const ids: number[] = []
+    let page = 1
+    let total = Number.POSITIVE_INFINITY
+
+    while (ids.length < total && page <= SELECT_FILTERED_MAX_PAGES) {
+      const response = await adminAPI.accounts.list(page, SELECT_FILTERED_PAGE_SIZE, filters)
+      total = Number(response.total || 0)
+      const items = Array.isArray(response.items) ? response.items : []
+      for (const account of items) {
+        if (typeof account?.id === 'number') ids.push(account.id)
+      }
+      if (items.length === 0 || items.length < SELECT_FILTERED_PAGE_SIZE) break
+      page += 1
+    }
+
+    setSelectedIds(ids)
+    if (ids.length === 0) {
+      appStore.showInfo(t('admin.accounts.bulkActions.selectFilteredEmpty'))
+    } else {
+      appStore.showSuccess(t('admin.accounts.bulkActions.selectFilteredSuccess', { count: ids.length }))
+    }
+  } catch (error) {
+    console.error('Failed to select filtered accounts:', error)
+    appStore.showError(extractApiErrorMessage(error, t('admin.accounts.bulkActions.selectFilteredFailed')))
+  } finally {
+    selectingFiltered.value = false
   }
 }
 

--- a/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
+++ b/frontend/src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts
@@ -81,12 +81,14 @@ const DataTableStub = {
 }
 
 const AccountBulkActionsBarStub = {
-  props: ['selectedIds'],
-  emits: ['edit-filtered', 'probe-upstream-billing'],
+  props: ['selectedIds', 'selectingFiltered'],
+  emits: ['edit-filtered', 'probe-upstream-billing', 'select-filtered'],
   template: `
     <div>
+      <span data-test="selected-count">{{ selectedIds?.length || 0 }}</span>
       <button data-test="edit-filtered" @click="$emit('edit-filtered')">edit filtered</button>
       <button data-test="probe-upstream-billing" @click="$emit('probe-upstream-billing')">probe</button>
+      <button data-test="select-filtered" @click="$emit('select-filtered')">select filtered</button>
     </div>
   `
 }
@@ -445,5 +447,94 @@ describe('admin AccountsView bulk edit scope', () => {
 
     expect(probeUpstreamBillingBatch).toHaveBeenCalledWith([7])
     expect(listAccounts).toHaveBeenCalledTimes(2)
+  })
+
+  it('selects all filtered account ids across pages for batch actions', async () => {
+    const account = (id: number) => ({
+      id,
+      name: `account-${id}`,
+      platform: 'anthropic',
+      type: 'oauth',
+      status: 'error',
+      schedulable: true,
+      created_at: '2026-07-13T00:00:00Z',
+      updated_at: '2026-07-13T00:00:00Z'
+    })
+
+    // Initial table load (page size from persisted settings, default 20)
+    listAccounts.mockImplementation(async (page: number, pageSize: number) => {
+      if (pageSize === 1000) {
+        if (page === 1) {
+          return {
+            items: Array.from({ length: 1000 }, (_, index) => account(index + 1)),
+            total: 1005,
+            page: 1,
+            page_size: 1000,
+            pages: 2
+          }
+        }
+        return {
+          items: [account(1001), account(1002), account(1003), account(1004), account(1005)],
+          total: 1005,
+          page: 2,
+          page_size: 1000,
+          pages: 2
+        }
+      }
+      return {
+        items: [account(1)],
+        total: 1005,
+        page: 1,
+        page_size: pageSize,
+        pages: Math.ceil(1005 / pageSize)
+      }
+    })
+
+    const wrapper = mount(AccountsView, {
+      global: {
+        stubs: {
+          AppLayout: { template: '<div><slot /></div>' },
+          TablePageLayout: {
+            template: '<div><slot name="filters" /><slot name="table" /><slot name="pagination" /></div>'
+          },
+          DataTable: DataTableStub,
+          Pagination: true,
+          ConfirmDialog: true,
+          AccountTableActions: { template: '<div><slot name="beforeCreate" /><slot name="after" /></div>' },
+          AccountTableFilters: { template: '<div></div>' },
+          AccountBulkActionsBar: AccountBulkActionsBarStub,
+          AccountActionMenu: true,
+          ImportDataModal: true,
+          ReAuthAccountModal: true,
+          AccountTestModal: true,
+          AccountStatsModal: true,
+          ScheduledTestsPanel: true,
+          SyncFromCrsModal: true,
+          TempUnschedStatusModal: true,
+          ErrorPassthroughRulesModal: true,
+          TLSFingerprintProfilesModal: true,
+          CreateAccountModal: true,
+          EditAccountModal: true,
+          BulkEditAccountModal: BulkEditAccountModalStub,
+          PlatformTypeBadge: true,
+          AccountCapacityCell: true,
+          AccountStatusIndicator: true,
+          AccountTodayStatsCell: true,
+          AccountGroupsCell: true,
+          AccountUsageCell: true,
+          Icon: true
+        }
+      }
+    })
+
+    await flushPromises()
+    await wrapper.get('[data-test="select-filtered"]').trigger('click')
+    await flushPromises()
+
+    expect(wrapper.get('[data-test="selected-count"]').text()).toBe('1005')
+    const filteredCalls = listAccounts.mock.calls.filter(([, pageSize]) => pageSize === 1000)
+    expect(filteredCalls).toHaveLength(2)
+    expect(filteredCalls[0][0]).toBe(1)
+    expect(filteredCalls[1][0]).toBe(2)
   })
 })


### PR DESCRIPTION
## Summary
- 账号管理批量操作栏新增 **筛选全选**，按当前筛选条件跨页选中全部匹配账号
- **本页全选 / 筛选全选** 始终可见，无需先勾选后才显示
- 选中后可继续使用现有批量删除、重置状态、刷新令牌、启停调度、批量编辑等操作
- 补充中英文文案与跨页筛选全选单元测试

## Motivation
筛选出大量账号后，原先只能「本页全选」，无法对筛选结果整体做批量操作。本次补齐筛选全选能力。

## Implementation notes
- 前端按当前筛选条件分页请求 `/admin/accounts`（`page_size=1000`）收集全部 ID
- 关闭 scheduler score 以降低筛选全选请求开销
- 不改后端接口

## Test plan
- [x] `frontend`: `vitest run src/views/admin/__tests__/AccountsView.bulkEdit.spec.ts`（6 passed）
- [x] 管理后台账号页：设置平台/状态等筛选后点击「筛选全选」
- [x] 确认选中数量等于筛选总数（跨分页）
- [x] 对选中项执行批量重置状态 / 启停调度等操作
- [x] 确认「本页全选」「清除选择」行为正常
- [x] 中英文界面文案显示正确