### PR TITLE
fix(openai): fail over OAuth workspace mismatch 409

### DIFF
--- a/backend/internal/service/openai_chatgpt_headers.go
+++ b/backend/internal/service/openai_chatgpt_headers.go
@@ -3,7 +3,33 @@ package service
 import (
 	"context"
 	"net/http"
+	"strings"
+	"time"
 )
+
+// isChatGPTWorkspaceAccountMismatch identifies the ChatGPT upstream response
+// emitted when an OAuth token is paired with a stale or unrelated workspace
+// id. The account can still be valid without the optional workspace header, so
+// callers may safely retry once after removing chatgpt-account-id.
+func isChatGPTWorkspaceAccountMismatch(statusCode int, responseBody []byte) bool {
+	if statusCode != http.StatusConflict || len(responseBody) == 0 {
+		return false
+	}
+	lower := strings.ToLower(string(responseBody))
+	return strings.Contains(lower, "sa_server_user_does_not_belong_to_workspace") ||
+		(strings.Contains(lower, "does not belong to") && strings.Contains(lower, "workspace"))
+}
+
+// blockChatGPTWorkspaceMismatch keeps an OAuth account whose workspace
+// metadata is incompatible with its token out of the scheduler briefly. The
+// persisted credentials are intentionally left untouched because the account
+// may still be valid for a different workspace after an operator refresh.
+func (s *OpenAIGatewayService) blockChatGPTWorkspaceMismatch(account *Account) {
+	if s == nil || account == nil || account.Platform != PlatformOpenAI || !account.IsOpenAIOAuth() {
+		return
+	}
+	s.BlockAccountScheduling(account, time.Time{}, "workspace_mismatch")
+}
 
 func setOpenAIChatGPTAccountHeaders(headers http.Header, account *Account) {
 	if headers == nil || account == nil || !account.IsOpenAIOAuth() {

--- a/backend/internal/service/openai_chatgpt_workspace_retry_test.go
+++ b/backend/internal/service/openai_chatgpt_workspace_retry_test.go
@@ -136,6 +136,40 @@ func TestOpenAIGatewayServiceDoesNotRetryUnrelatedConflict(t *testing.T) {
 	require.Equal(t, "workspace-id", upstream.requests[0].Header.Get("chatgpt-account-id"))
 }
 
+func TestOpenAIGatewayServiceBlocksAccountWhenWorkspaceRetryStillFails(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"Reply OK","input":[]}`)
+	workspaceError := `{"detail":{"error_code":"sa_server_user_does_not_belong_to_workspace"}}`
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusConflict, workspaceError),
+		newOpenAIRejectedFieldTestResponse(http.StatusConflict, workspaceError),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          5112,
+		Name:        "workspace-header-block",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "workspace-id",
+		},
+	}
+
+	_, err := svc.Forward(context.Background(), newOpenAIRejectedFieldTestContext(body), account, body)
+	require.Error(t, err)
+	require.Len(t, upstream.requests, 2)
+	require.Empty(t, upstream.requests[1].Header.Get("chatgpt-account-id"))
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+}
+
 func TestOpenAIGatewayServiceBlocksAccountAfterWorkspaceRetryFails(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"Reply OK","input":[]}`)
 	workspaceError := `{"detail":{"error_code":"sa_server_user_does_not_belong_to_workspace","error":"User user-123 does not belong to declared workspace ws-456"}}`

--- a/backend/internal/service/openai_chatgpt_workspace_retry_test.go
+++ b/backend/internal/service/openai_chatgpt_workspace_retry_test.go
@@ -1,0 +1,169 @@
+package service
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsChatGPTWorkspaceAccountMismatch(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{
+			name:   "declared workspace code",
+			status: http.StatusConflict,
+			body:   `{"error":{"code":"sa_server_user_does_not_belong_to_workspace","message":"User does not belong to declared workspace"}}`,
+			want:   true,
+		},
+		{
+			name:   "nested detail code",
+			status: http.StatusConflict,
+			body:   `{"detail":{"code":"sa_server_user_does_not_belong_to_workspace"}}`,
+			want:   true,
+		},
+		{
+			name:   "nested detail error code",
+			status: http.StatusConflict,
+			body:   `{"detail":{"error_code":"sa_server_user_does_not_belong_to_workspace"}}`,
+			want:   true,
+		},
+		{
+			name:   "workspace membership message",
+			status: http.StatusConflict,
+			body:   `{"error":{"message":"User user-123 does not belong to declared workspace ws-456"}}`,
+			want:   true,
+		},
+		{
+			name:   "same body with bad request status",
+			status: http.StatusBadRequest,
+			body:   `{"error":{"code":"sa_server_user_does_not_belong_to_workspace"}}`,
+			want:   false,
+		},
+		{
+			name:   "unrelated conflict",
+			status: http.StatusConflict,
+			body:   `{"error":{"code":"content_policy_violation","message":"request rejected"}}`,
+			want:   false,
+		},
+		{
+			name:   "malformed body",
+			status: http.StatusConflict,
+			body:   "not-json",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isChatGPTWorkspaceAccountMismatch(tt.status, []byte(tt.body)))
+		})
+	}
+}
+
+func TestOpenAIGatewayServiceRetriesWorkspaceHeaderMismatchWithoutHeader(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"Reply OK","input":[]}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusConflict, `{"error":{"code":"sa_server_user_does_not_belong_to_workspace","message":"User user-123 does not belong to declared workspace ws-456"}}`),
+		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp-workspace-retry","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          5110,
+		Name:        "workspace-header-retry",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "stale-workspace",
+		},
+	}
+
+	result, err := svc.Forward(context.Background(), newOpenAIRejectedFieldTestContext(body), account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.requests, 2)
+	require.Equal(t, "stale-workspace", upstream.requests[0].Header.Get("chatgpt-account-id"))
+	require.Empty(t, upstream.requests[1].Header.Get("chatgpt-account-id"))
+}
+
+func TestOpenAIGatewayServiceDoesNotRetryUnrelatedConflict(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"Reply OK","input":[]}`)
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusConflict,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"code":"content_policy_violation","message":"request rejected"}}`)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          5111,
+		Name:        "workspace-header-no-retry",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "workspace-id",
+		},
+	}
+
+	_, err := svc.Forward(context.Background(), newOpenAIRejectedFieldTestContext(body), account, body)
+	require.Error(t, err)
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "workspace-id", upstream.requests[0].Header.Get("chatgpt-account-id"))
+}
+
+func TestOpenAIGatewayServiceBlocksAccountAfterWorkspaceRetryFails(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"Reply OK","input":[]}`)
+	workspaceError := `{"detail":{"error_code":"sa_server_user_does_not_belong_to_workspace","error":"User user-123 does not belong to declared workspace ws-456"}}`
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusConflict, workspaceError),
+		newOpenAIRejectedFieldTestResponse(http.StatusConflict, workspaceError),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg: &config.Config{Security: config.SecurityConfig{
+			URLAllowlist: config.URLAllowlistConfig{Enabled: false},
+		}},
+		httpUpstream: upstream,
+	}
+	account := &Account{
+		ID:          5112,
+		Name:        "workspace-header-block",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token", "chatgpt_account_id": "workspace-id"},
+	}
+
+	_, err := svc.Forward(context.Background(), newOpenAIRejectedFieldTestContext(body), account, body)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.False(t, failoverErr.RetryableOnSameAccount)
+	require.Len(t, upstream.requests, 2)
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+}

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -88,7 +88,9 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	upstreamMsg string,
 	upstreamModel string,
 ) *UpstreamFailoverError {
-	shouldFailover := s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody)
+	workspaceMismatch := account != nil && account.Platform == PlatformOpenAI && account.IsOpenAIOAuth() &&
+		isChatGPTWorkspaceAccountMismatch(resp.StatusCode, respBody)
+	shouldFailover := workspaceMismatch || s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody)
 	if account != nil && account.Platform == PlatformGrok {
 		shouldFailover = s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody)
 	}
@@ -116,9 +118,12 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 		Message:            upstreamMsg,
 		Detail:             upstreamDetail,
 	})
-	shouldDisable := false
-	if account.Platform != PlatformGrok {
+	shouldDisable := workspaceMismatch
+	if account.Platform != PlatformGrok && !workspaceMismatch {
 		shouldDisable = s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, respBody, upstreamModel)
+	}
+	if workspaceMismatch {
+		s.blockChatGPTWorkspaceMismatch(account)
 	}
 	return newOpenAIUpstreamFailoverError(
 		resp.StatusCode,

--- a/backend/internal/service/openai_gateway_chat_completions.go
+++ b/backend/internal/service/openai_gateway_chat_completions.go
@@ -1,10 +1,12 @@
 package service
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"sync/atomic"
@@ -252,27 +254,45 @@ func (s *OpenAIGatewayService) ForwardAsChatCompletions(
 		return nil, fmt.Errorf("get access token: %w", err)
 	}
 
-	// 6. Build upstream request
-	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
-	upstreamReq, err := s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, true, promptCacheKey, false)
-	releaseUpstreamCtx()
-	if err != nil {
-		return nil, fmt.Errorf("build upstream request: %w", err)
-	}
-
-	if promptCacheKey != "" {
-		apiKeyID := getAPIKeyIDFromContext(c)
-		upstreamReq.Header.Set("session_id", generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey)))
-	}
-
 	// 7. Send request
 	proxyURL := ""
 	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
-	if err != nil {
-		return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+	chatGPTWorkspaceHeaderRetryTried := false
+	var resp *http.Response
+	for {
+		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+		upstreamReq, buildErr := s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, true, promptCacheKey, false)
+		releaseUpstreamCtx()
+		if buildErr != nil {
+			return nil, fmt.Errorf("build upstream request: %w", buildErr)
+		}
+		if promptCacheKey != "" {
+			apiKeyID := getAPIKeyIDFromContext(c)
+			upstreamReq.Header.Set("session_id", generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey)))
+		}
+		if chatGPTWorkspaceHeaderRetryTried {
+			upstreamReq.Header.Del("chatgpt-account-id")
+		}
+		resp, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+		if err != nil {
+			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
+		}
+		if resp.StatusCode >= 400 && !chatGPTWorkspaceHeaderRetryTried && account.IsOpenAIOAuth() &&
+			strings.TrimSpace(upstreamReq.Header.Get("chatgpt-account-id")) != "" {
+			probeBody := s.readUpstreamErrorBody(resp)
+			_ = resp.Body.Close()
+			resp.Body = io.NopCloser(bytes.NewReader(probeBody))
+			if isChatGPTWorkspaceAccountMismatch(resp.StatusCode, probeBody) {
+				chatGPTWorkspaceHeaderRetryTried = true
+				logger.L().Info("openai chat_completions: retrying without stale chatgpt-account-id",
+					zap.Int64("account_id", account.ID),
+				)
+				continue
+			}
+		}
+		break
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -757,6 +757,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	httpInvalidEncryptedContentRetryTried := false
 	agentTaskRecoveryTried := false
 	rejectedFieldRetryState := newOpenAIResponsesRejectedFieldRetryState(body)
+	chatGPTWorkspaceHeaderRetryTried := false
 	for {
 		// Build upstream request
 		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
@@ -775,6 +776,11 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 				headerGuard.close()
 			}
 			return nil, err
+		}
+		if chatGPTWorkspaceHeaderRetryTried {
+			// A stale workspace id can be attached to an otherwise valid OAuth
+			// token. The retry is deliberately request-local and single-use.
+			upstreamReq.Header.Del("chatgpt-account-id")
 		}
 
 		// Get proxy URL
@@ -822,6 +828,18 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 			upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
 			upstreamCode := extractUpstreamErrorCode(respBody)
+			if !chatGPTWorkspaceHeaderRetryTried && account.IsOpenAIOAuth() &&
+				strings.TrimSpace(upstreamReq.Header.Get("chatgpt-account-id")) != "" &&
+				isChatGPTWorkspaceAccountMismatch(resp.StatusCode, respBody) {
+				chatGPTWorkspaceHeaderRetryTried = true
+				logger.LegacyPrintf("service.openai_gateway", "[OpenAI] Retrying once without stale chatgpt-account-id (account: %s)", account.Name)
+				continue
+			}
+			if chatGPTWorkspaceHeaderRetryTried && account.IsOpenAIOAuth() &&
+				isChatGPTWorkspaceAccountMismatch(resp.StatusCode, respBody) {
+				s.blockChatGPTWorkspaceMismatch(account)
+				return nil, newOpenAIUpstreamFailoverError(resp.StatusCode, resp.Header, respBody, upstreamMsg, false)
+			}
 			if !agentTaskRecoveryTried && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, respBody) {
 				agentTaskRecoveryTried = true
 				expectedTaskID := account.GetCredential("task_id")

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -337,28 +337,66 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// account/cache identity. Match forwardGrokResponses: one strip+retry before
 	// treating the 400 as a hard failure / failover trigger.
 	var resp *http.Response
+	chatGPTWorkspaceHeaderRetryTried := false
 	for attempt := 0; ; attempt++ {
 		if attempt > 0 {
-			if account.Platform != PlatformGrok {
+			upstreamCtxRetry, releaseRetry := detachUpstreamContext(ctx)
+			if account.Platform == PlatformGrok {
+				upstreamReq, err = buildGrokResponsesRequest(upstreamCtxRetry, c, account, responsesBody, token, grokCacheIdentity, s.cfg)
+			} else if chatGPTWorkspaceHeaderRetryTried {
+				upstreamReq, err = s.buildUpstreamRequest(upstreamCtxRetry, c, account, responsesBody, token, isStream, promptCacheKey, false)
+			} else {
+				releaseRetry()
 				break
 			}
-			upstreamCtxRetry, releaseRetry := detachUpstreamContext(ctx)
-			upstreamReq, err = buildGrokResponsesRequest(upstreamCtxRetry, c, account, responsesBody, token, grokCacheIdentity, s.cfg)
 			releaseRetry()
 			if err != nil {
 				return nil, fmt.Errorf("build grok retry request: %w", err)
+			}
+			if chatGPTWorkspaceHeaderRetryTried && account.Platform != PlatformGrok {
+				upstreamReq.Header.Del("chatgpt-account-id")
+				if promptCacheKey != "" {
+					isolatedSessionID := generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey))
+					upstreamReq.Header.Set("session_id", isolatedSessionID)
+					if upstreamReq.Header.Get("conversation_id") != "" {
+						upstreamReq.Header.Set("conversation_id", isolatedSessionID)
+					}
+				}
+				if account.Type == AccountTypeOAuth {
+					ensureCodexIdentityHeaders(upstreamReq.Header)
+					enforceCodexIdentityHeaders(upstreamReq.Header)
+				}
+				if account.Type == AccountTypeOAuth && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
+					upstreamReq.Header.Del("conversation_id")
+				}
+				if compatTurnState != "" && upstreamReq.Header.Get("x-codex-turn-state") == "" {
+					upstreamReq.Header.Set("x-codex-turn-state", compatTurnState)
+				}
 			}
 		}
 		resp, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 		if err != nil {
 			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 		}
-		if account.Platform != PlatformGrok || attempt > 0 || resp.StatusCode != http.StatusBadRequest {
+		if account.Platform == PlatformGrok && (attempt > 0 || resp.StatusCode != http.StatusBadRequest) {
 			break
 		}
 		respBody := s.readUpstreamErrorBody(resp)
 		if resp.Body != nil {
 			_ = resp.Body.Close()
+		}
+		if !chatGPTWorkspaceHeaderRetryTried && account.IsOpenAIOAuth() && account.Platform != PlatformGrok &&
+			strings.TrimSpace(upstreamReq.Header.Get("chatgpt-account-id")) != "" &&
+			isChatGPTWorkspaceAccountMismatch(resp.StatusCode, respBody) {
+			chatGPTWorkspaceHeaderRetryTried = true
+			logger.L().Info("openai messages: retrying without stale chatgpt-account-id",
+				zap.Int64("account_id", account.ID),
+			)
+			continue
+		}
+		if account.Platform != PlatformGrok {
+			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			break
 		}
 		// Prefer explicit decrypt errors; also strip once on any 400 when the
 		// outbound body still carries reasoning.encrypted_content (account
@@ -389,6 +427,11 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// 8. Handle error response with failover
 	if resp.StatusCode >= 400 {
 		respBody, upstreamMsg := s.readOpenAIUpstreamError(resp)
+		if chatGPTWorkspaceHeaderRetryTried && account.IsOpenAIOAuth() &&
+			isChatGPTWorkspaceAccountMismatch(resp.StatusCode, respBody) {
+			s.blockChatGPTWorkspaceMismatch(account)
+			return nil, newOpenAIUpstreamFailoverError(resp.StatusCode, resp.Header, respBody, upstreamMsg, false)
+		}
 		if !agentIdentityTaskRecoveryWasTried(ctx) && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, respBody) {
 			expectedTaskID := account.GetCredential("task_id")
 			if err := s.recoverAgentIdentityTask(ctx, account, expectedTaskID); err != nil {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -378,6 +378,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		if err != nil {
 			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 		}
+		if account.Platform != PlatformGrok && resp.StatusCode < 400 {
+			break
+		}
 		if account.Platform == PlatformGrok && (attempt > 0 || resp.StatusCode != http.StatusBadRequest) {
 			break
 		}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -184,6 +184,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 	}
 
 	agentTaskRecoveryTried := false
+	chatGPTWorkspaceHeaderRetryTried := false
 	var resp *http.Response
 	for {
 		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
@@ -191,6 +192,9 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		releaseUpstreamCtx()
 		if buildErr != nil {
 			return nil, buildErr
+		}
+		if chatGPTWorkspaceHeaderRetryTried {
+			upstreamReq.Header.Del("chatgpt-account-id")
 		}
 
 		upstreamStart := time.Now()
@@ -210,6 +214,13 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		probeBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(probeBody))
+		if !chatGPTWorkspaceHeaderRetryTried && account.IsOpenAIOAuth() &&
+			strings.TrimSpace(upstreamReq.Header.Get("chatgpt-account-id")) != "" &&
+			isChatGPTWorkspaceAccountMismatch(resp.StatusCode, probeBody) {
+			chatGPTWorkspaceHeaderRetryTried = true
+			logger.LegacyPrintf("service.openai_gateway", "[OpenAI passthrough] Retrying once without stale chatgpt-account-id (account: %s)", account.Name)
+			continue
+		}
 		if !agentTaskRecoveryTried && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, probeBody) {
 			agentTaskRecoveryTried = true
 			expectedTaskID := account.GetCredential("task_id")
@@ -458,6 +469,10 @@ func (s *OpenAIGatewayService) buildUpstreamRequestOpenAIPassthrough(
 }
 
 func shouldFailoverOpenAIPassthroughResponse(account *Account, statusCode int, responseBody []byte) bool {
+	if account != nil && account.Platform == PlatformOpenAI && account.IsOpenAIOAuth() &&
+		isChatGPTWorkspaceAccountMismatch(statusCode, responseBody) {
+		return true
+	}
 	if isOpenAIContextWindowError("", responseBody) {
 		return false
 	}
@@ -580,7 +595,14 @@ func (s *OpenAIGatewayService) handleFailoverErrorResponsePassthrough(
 	logOpenAIInstructionsRequiredDebug(ctx, c, account, resp.StatusCode, upstreamMsg, requestBody, body)
 	reqModel, _, _ := extractOpenAIRequestMetaFromBody(requestBody)
 	canonicalModel := canonicalOpenAIAccountSchedulingModel(account, reqModel)
-	shouldDisable := s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, canonicalModel)
+	workspaceMismatch := account != nil && account.Platform == PlatformOpenAI && account.IsOpenAIOAuth() &&
+		isChatGPTWorkspaceAccountMismatch(resp.StatusCode, body)
+	shouldDisable := workspaceMismatch
+	if !workspaceMismatch {
+		shouldDisable = s.handleOpenAIAccountUpstreamError(ctx, account, resp.StatusCode, resp.Header, body, canonicalModel)
+	} else {
+		s.blockChatGPTWorkspaceMismatch(account)
+	}
 	appendOpsUpstreamError(c, OpsUpstreamErrorEvent{
 		Platform:             account.Platform,
 		AccountID:            account.ID,


### PR DESCRIPTION
Fixes #4784

## Root Cause

OpenAI OAuth accounts can carry a stale `chatgpt-account-id` workspace header. ChatGPT returns HTTP 409 with `sa_server_user_does_not_belong_to_workspace`, but the gateway previously treated this as a normal error and kept selecting the same account, producing repeated downstream 502 responses.

## Changes

- Detect only the specific workspace mismatch for OpenAI OAuth accounts.
- Retry once without `chatgpt-account-id` across Responses, Chat Completions, Messages compatibility, and passthrough paths.
- If the retry still fails, temporarily block the account and return the existing failover signal so scheduling switches accounts.
- Leave unrelated HTTP 409 responses unchanged.
- Preserve terminal SSE handling for successful Messages responses.
- Add regression coverage for retry, non-retry, and account blocking behavior.

## Verification

- `go test ./internal/service -tags unit -run 'Test(IsChatGPTWorkspaceAccountMismatch|OpenAIGatewayService.*Workspace)' -count=1`
- `go test ./internal/service -tags unit -run 'TestForwardAsAnthropic_(TerminalUsageWithoutUpstreamCloseReturns|EventNamedTerminalWithoutUpstreamCloseReturns|EventNamedTerminalWithKeepaliveReturns|BufferedTerminalWithoutUpstreamCloseReturns|BufferedEventNamedTerminalWithoutUpstreamCloseReturns)' -count=1`
- `go test ./internal/handler/admin -count=1`
