### PR TITLE
fix(antigravity): align OAuth login with official Antigravity CLI

### DIFF
--- a/backend/internal/pkg/antigravity/oauth.go
+++ b/backend/internal/pkg/antigravity/oauth.go
@@ -36,15 +36,20 @@ const (
 	// DefaultUserAgentVersion 是未通过环境变量或后台设置覆盖时使用的默认版本号。
 	DefaultUserAgentVersion = "1.23.2"
 
-	// 固定的 redirect_uri（用户需手动复制 code）
-	RedirectURI = "http://localhost:8085/callback"
+	// RedirectURI 对齐官方 Antigravity CLI（agy）OAuth 回调页。
+	// 用户授权后浏览器跳转到该页面并展示 code，再粘贴回 Sub2API 完成交换。
+	// 参考：https://github.com/google-antigravity/antigravity-cli/issues/315
+	// 注意：不再使用旧的 localhost:8085/callback（早期 IDE 回调），
+	// 否则与当前 CLI 客户端登记的 redirect_uri 不一致会导致登录失败。
+	RedirectURI = "https://antigravity.google/oauth-callback"
 
-	// OAuth scopes
+	// OAuth scopes（与官方 Antigravity CLI 授权 URL 一致，含 openid）
 	Scopes = "https://www.googleapis.com/auth/cloud-platform " +
 		"https://www.googleapis.com/auth/userinfo.email " +
 		"https://www.googleapis.com/auth/userinfo.profile " +
 		"https://www.googleapis.com/auth/cclog " +
-		"https://www.googleapis.com/auth/experimentsandconfigs"
+		"https://www.googleapis.com/auth/experimentsandconfigs " +
+		"openid"
 
 	// Session 过期时间
 	SessionTTL = 30 * time.Minute

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -687,7 +687,7 @@ func TestConstants_值正确(t *testing.T) {
 	if secret != "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" {
 		t.Errorf("默认 client_secret 不匹配: got %s", secret)
 	}
-	if RedirectURI != "http://localhost:8085/callback" {
+	if RedirectURI != "https://antigravity.google/oauth-callback" {
 		t.Errorf("RedirectURI 不匹配: got %s", RedirectURI)
 	}
 	if GetUserAgent() != "antigravity/1.23.2 windows/amd64" {
@@ -708,6 +708,7 @@ func TestScopes_包含必要范围(t *testing.T) {
 		"https://www.googleapis.com/auth/userinfo.profile",
 		"https://www.googleapis.com/auth/cclog",
 		"https://www.googleapis.com/auth/experimentsandconfigs",
+		"openid", // Antigravity CLI 授权 URL 包含 openid
 	}
 
 	for _, scope := range expectedScopes {

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -557,23 +557,36 @@
         <!-- OAuth Type Selection (only show when oauth-based is selected) -->
         <div v-if="accountCategory === 'oauth-based'" class="mt-4">
           <label class="input-label">{{ t('admin.accounts.oauth.gemini.oauthTypeLabel') }}</label>
+          <div
+            v-if="geminiOAuthType === 'google_one'"
+            class="mt-2 rounded-lg border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-700/50 dark:bg-amber-900/20 dark:text-amber-100"
+          >
+            <p>{{ t('admin.accounts.gemini.oauthType.googleOneDeprecatedBanner') }}</p>
+            <button
+              type="button"
+              class="mt-2 font-medium text-purple-700 underline hover:text-purple-900 dark:text-purple-300 dark:hover:text-purple-100"
+              @click="form.platform = 'antigravity'; antigravityAccountType = 'oauth'"
+            >
+              → {{ t('admin.accounts.types.antigravityOauth') }}
+            </button>
+          </div>
           <div class="mt-2 grid grid-cols-2 gap-3">
-            <!-- Google One OAuth -->
+            <!-- Google One OAuth (deprecated: Gemini CLI consumer shutdown) -->
             <button
               type="button"
               @click="handleSelectGeminiOAuthType('google_one')"
               :class="[
                 'flex items-center gap-3 rounded-lg border-2 p-3 text-left transition-all',
                 geminiOAuthType === 'google_one'
-                  ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20'
-                  : 'border-gray-200 hover:border-purple-300 dark:border-dark-600 dark:hover:border-purple-700'
+                  ? 'border-amber-500 bg-amber-50 dark:bg-amber-900/20'
+                  : 'border-gray-200 hover:border-amber-300 dark:border-dark-600 dark:hover:border-amber-700'
               ]"
             >
               <div
                 :class="[
                   'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
                   geminiOAuthType === 'google_one'
-                    ? 'bg-purple-500 text-white'
+                    ? 'bg-amber-500 text-white'
                     : 'bg-gray-100 text-gray-500 dark:bg-dark-600 dark:text-gray-400'
                 ]"
               >
@@ -582,18 +595,23 @@
               <div class="min-w-0">
                 <span class="block text-sm font-medium text-gray-900 dark:text-white">
                   Google One
+                  <span
+                    class="ml-1 rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-900/50 dark:text-amber-200"
+                  >
+                    deprecated
+                  </span>
                 </span>
                 <span class="text-xs text-gray-500 dark:text-gray-400">
                   {{ t('admin.accounts.gemini.oauthType.googleOneDesc') }}
                 </span>
                 <div class="mt-2 flex flex-wrap gap-1">
                   <span
-                    class="rounded bg-purple-100 px-2 py-0.5 text-[10px] font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-300"
+                    class="rounded bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-200"
                   >
                     {{ t('admin.accounts.gemini.oauthType.badges.individuals') }}
                   </span>
                   <span
-                    class="rounded bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300"
+                    class="rounded bg-gray-100 px-2 py-0.5 text-[10px] font-semibold text-gray-600 dark:bg-gray-700 dark:text-gray-300"
                   >
                     {{ t('admin.accounts.gemini.oauthType.badges.noGcp') }}
                   </span>

--- a/frontend/src/components/account/OAuthAuthorizationFlow.vue
+++ b/frontend/src/components/account/OAuthAuthorizationFlow.vue
@@ -987,7 +987,8 @@ watch(inputMethod, (newVal) => {
 })
 
 // Auto-extract code from callback URL (OpenAI/Gemini/Antigravity/Grok)
-// e.g., http://localhost:8085/callback?code=xxx...&state=...
+// e.g., https://antigravity.google/oauth-callback?code=xxx...&state=...
+// also supports legacy localhost callbacks
 watch(authCodeInput, (newVal) => {
   if (props.platform !== 'openai' && props.platform !== 'gemini' && props.platform !== 'antigravity' && props.platform !== 'grok') return
 

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -1074,20 +1074,22 @@ export default {
         // Antigravity specific
         antigravity: {
           title: 'Antigravity Account Authorization',
-          followSteps: 'Follow these steps to authorize your Antigravity account:',
+          followSteps:
+            'Follow these steps to authorize your Antigravity account (aligned with official Antigravity CLI login):',
           step1GenerateUrl: 'Generate the authorization URL',
           generateAuthUrl: 'Generate Auth URL',
           step2OpenUrl: 'Open the URL in your browser and complete authorization',
           openUrlDesc: 'Open the authorization URL in a new tab, log in to your Google account and authorize.',
           importantNotice:
-            'Important: The page may take a while to load after authorization. Please wait patiently. When the browser address bar shows http://localhost..., authorization is complete.',
+            'Important: After authorization the browser redirects to https://antigravity.google/oauth-callback?... The page shows an auth code (or full callback URL) — copy and paste it here. Google AI Pro/Ultra personal subscriptions should use this Antigravity login (Gemini CLI consumer access has been shut down).',
           step3EnterCode: 'Enter Authorization URL or Code',
           authCodeDesc:
-            'After authorization, when the page URL becomes http://localhost:xxx/auth/callback?code=...:',
+            'After authorization, when the page URL becomes https://antigravity.google/oauth-callback?code=...:',
           authCode: 'Authorization URL or Code',
           authCodePlaceholder:
-            'Option 1: Copy the complete URL\n(http://localhost:xxx/auth/callback?code=...)\nOption 2: Copy only the code parameter value',
-                    authCodeHint: 'You can copy the entire URL or just the code parameter value, the system will auto-detect',
+            'Option 1: Copy the complete URL\n(https://antigravity.google/oauth-callback?code=...)\nOption 2: Copy only the code parameter value',
+          authCodeHint:
+            'You can copy the entire callback URL or just the code parameter value; the system will auto-detect',
                     failedToGenerateUrl: 'Failed to generate Antigravity auth URL',
                     missingExchangeParams: 'Missing code, session ID, or state',
                     failedToExchangeCode: 'Failed to exchange Antigravity auth code',
@@ -1145,7 +1147,10 @@ export default {
           builtInTitle: 'Built-in OAuth (Gemini CLI / Code Assist)',
           builtInDesc: 'Uses Google built-in client ID. No admin configuration required.',
           builtInRequirement: 'Requires a GCP project and Project ID.',
-          googleOneDesc: 'Personal account with Google One subscription quota',
+          googleOneDesc:
+            'Deprecated: Gemini CLI consumer access has been shut down. Use Antigravity platform OAuth for Google AI Pro/Ultra',
+          googleOneDeprecatedBanner:
+            'As of 2026-06-18 Google stopped Gemini CLI for Google AI Pro/Ultra and free individual accounts. Add personal subscriptions under the Antigravity platform. Enterprise Code Assist / API keys are unaffected.',
           codeAssistDesc: 'Enterprise-grade, requires a GCP project',
           codeAssistRequirement: 'Requires an active GCP project with billing enabled',
           showAdvanced: 'Show advanced options (custom OAuth Client)',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -1119,20 +1119,20 @@ export default {
         // Antigravity specific
         antigravity: {
           title: 'Antigravity 账户授权',
-          followSteps: '请按照以下步骤完成 Antigravity 账户的授权：',
+          followSteps: '请按照以下步骤完成 Antigravity 账户的授权（对齐官方 Antigravity CLI 登录）：',
           step1GenerateUrl: '生成授权链接',
           generateAuthUrl: '生成授权链接',
           step2OpenUrl: '在浏览器中打开链接并完成授权',
           openUrlDesc: '请在新标签页中打开授权链接，登录您的 Google 账户并授权。',
           importantNotice:
-            '重要提示：授权后页面可能会加载较长时间，请耐心等待。当浏览器地址栏变为 http://localhost... 开头时，表示授权已完成。',
+            '重要提示：授权完成后浏览器会跳转到 https://antigravity.google/oauth-callback?... 。该页面会展示授权码（或完整回调链接），请复制后粘贴回此处。Google AI Pro/Ultra 个人订阅请使用此 Antigravity 登录（Gemini CLI 个人通道已停服）。',
           step3EnterCode: '输入授权链接或 Code',
           authCodeDesc:
-            '授权完成后，当页面地址变为 http://localhost:xxx/auth/callback?code=... 时：',
+            '授权完成后，当页面地址变为 https://antigravity.google/oauth-callback?code=... 时：',
           authCode: '授权链接或 Code',
           authCodePlaceholder:
-            '方式1：复制完整的链接\n(http://localhost:xxx/auth/callback?code=...)\n方式2：仅复制 code 参数的值',
-          authCodeHint: '您可以直接复制整个链接或仅复制 code 参数值，系统会自动识别',
+            '方式1：复制完整的链接\n(https://antigravity.google/oauth-callback?code=...)\n方式2：仅复制 code 参数的值',
+          authCodeHint: '您可以直接复制整个回调链接或仅复制 code 参数值，系统会自动识别',
           failedToGenerateUrl: '生成 Antigravity 授权链接失败',
           missingExchangeParams: '缺少 code / session_id / state',
           failedToExchangeCode: 'Antigravity 授权码兑换失败',
@@ -1189,7 +1189,10 @@ export default {
           builtInTitle: '内置授权（Gemini CLI / Code Assist）',
           builtInDesc: '使用 Google 内置客户端 ID，无需管理员配置。',
           builtInRequirement: '需要 GCP 项目并填写 Project ID。',
-          googleOneDesc: '个人账号，享受 Google One 订阅配额',
+          googleOneDesc:
+            '已废弃：Gemini CLI 个人通道已停服，Google AI Pro/Ultra 请改用 Antigravity 平台 OAuth 登录',
+          googleOneDeprecatedBanner:
+            'Google 已于 2026-06-18 停止 Gemini CLI 对 Google AI Pro/Ultra 及个人免费账号的服务。个人订阅请改用「Antigravity」平台添加账号；企业 Code Assist / API Key 不受影响。',
           codeAssistDesc: '企业级，需要 GCP 项目',
           codeAssistRequirement: '需要激活 GCP 项目并绑定信用卡',
           showAdvanced: '显示高级选项（自建 OAuth Client）',


### PR DESCRIPTION
## Summary

Gemini CLI has stopped serving **Google AI Pro / Ultra** and free individual accounts (effective 2026-06-18). Personal subscriptions need to log in via **Antigravity CLI** OAuth instead.

This PR aligns Sub2API's Antigravity OAuth with the official Antigravity CLI (gy) authorization parameters so Google AI Pro accounts can authorize successfully again.

Closes / related: #3379

## Changes

### Backend (ackend/internal/pkg/antigravity)
- **redirect_uri**: http://localhost:8085/callback → ` https://antigravity.google/oauth-callback `
  - Matches the official CLI OAuth URL captured in [google-antigravity/antigravity-cli#315](https://github.com/google-antigravity/antigravity-cli/issues/315)
  - Hosted callback page shows the code for copy/paste (same pattern as Gemini CLI's codeassist.google.com/authcode)
- **scopes**: append ` openid ` (present on the official CLI auth URL)
- client_id / client_secret unchanged (same public Antigravity OAuth client)

### Frontend
- Update Antigravity OAuth step copy for the new callback URL
- Mark Gemini **Google One** OAuth as deprecated and surface a migration banner that switches users to the Antigravity platform

## Compatibility
- Existing Antigravity **refresh tokens** remain valid (token refresh does not depend on redirect_uri)
- New authorizations must use the new redirect_uri; old mid-flight sessions with the localhost callback will not exchange

## Test plan
- [ ] Backend: go test ./internal/pkg/antigravity/ -count=1
- [ ] Admin → Add Account → **Antigravity** → Generate Auth URL
  - Auth URL contains ` edirect_uri=https://antigravity.google/oauth-callback `
  - Browser completes Google login and lands on antigravity.google oauth-callback page
  - Paste full callback URL or code → account created with email/project_id
- [ ] Google AI Pro account: Antigravity OAuth succeeds; Gemini platform Google One shows deprecation notice
- [ ] Existing Antigravity accounts: token refresh / request still works

## Notes
- User-Agent version remains configurable via ANTIGRAVITY_USER_AGENT_VERSION / settings (not changed here)