### PR TITLE
fix(openai): strip input item namespaces before HTTP forwarding / HTTP 转发前移除 input 项 namespace

### DIFF
--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -71,6 +71,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}})
 			return nil, err
 		}
+		body, err = stripOpenAIResponsesInputNamespaces(body)
+		if err != nil {
+			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")
+			c.JSON(http.StatusBadRequest, gin.H{"error": gin.H{
+				"type": "invalid_request_error", "message": err.Error(), "param": "input",
+			}})
+			return nil, err
+		}
 	}
 
 	originalBody := body

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -71,6 +71,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}})
 			return nil, err
 		}
+	}
+	if shouldStripOpenAIResponsesInputNamespaces(account, wsDecision.Transport, passthroughEnabled) {
 		body, err = stripOpenAIResponsesInputNamespaces(body)
 		if err != nil {
 			setOpsUpstreamError(c, http.StatusBadRequest, err.Error(), "")

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -450,7 +450,10 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse
 			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","description":"spawn","parameters":{"type":"object"}}]}
 		],
 		"tool_choice":{"type":"function","name":"spawn_agent","namespace":"collaboration"},
-		"input":[{"type":"function_call","call_id":"call_old","name":"spawn_agent","namespace":"collaboration","arguments":"{}"}]
+		"input":[
+			{"type":"function_call","call_id":"call_old","name":"spawn_agent","namespace":"collaboration","arguments":"{}"},
+			{"type":"message","role":"user","namespace":"residual","content":[{"type":"input_text","text":"keep","namespace":"nested"}]}
+		]
 	}`)
 
 	upstreamSSE := strings.Join([]string{
@@ -488,6 +491,9 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse
 	require.False(t, gjson.GetBytes(upstream.lastBody, "tool_choice.namespace").Exists())
 	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.namespace").Exists())
+	require.False(t, gjson.GetBytes(upstream.lastBody, "input.1.namespace").Exists())
+	require.Equal(t, "nested", gjson.GetBytes(upstream.lastBody, "input.1.content.0.namespace").String())
+	require.Len(t, upstream.bodies, 1)
 
 	downstream := rec.Body.String()
 	require.NotContains(t, downstream, "collaboration__spawn_agent")

--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -28,6 +28,19 @@ func shouldFlattenOpenAIResponsesNamespaces(account *Account, transport OpenAIUp
 	return true
 }
 
+// shouldStripOpenAIResponsesInputNamespaces removes residual input item
+// namespaces for OpenAI OAuth and API Key HTTP forwarding. Native WSv2 keeps
+// namespaces because that protocol supports them and does not restore payloads.
+func shouldStripOpenAIResponsesInputNamespaces(account *Account, transport OpenAIUpstreamTransport, passthroughEnabled bool) bool {
+	if account == nil || (!account.IsOpenAIOAuth() && !account.IsOpenAIApiKey()) {
+		return false
+	}
+	if transport == OpenAIUpstreamTransportResponsesWebsocketV2 && !passthroughEnabled {
+		return false
+	}
+	return true
+}
+
 func flattenOpenAIResponsesNamespaces(c *gin.Context, body []byte) ([]byte, error) {
 	if !bytes.Contains(body, []byte(`"namespace"`)) {
 		return body, nil

--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
 )
 
 const openAIResponsesNamespaceNamesContextKey = "openai_responses_namespace_names"
@@ -47,6 +49,55 @@ func flattenOpenAIResponsesNamespaces(c *gin.Context, body []byte) ([]byte, erro
 	}
 	setOpenAIResponsesNamespaceNames(c, names)
 	return rebuilt, nil
+}
+
+// stripOpenAIResponsesInputNamespaces removes namespace only from direct input
+// array items. Namespace declarations and nested namespace fields are left
+// untouched. Rebuilding the input array once keeps this linear for long
+// histories and avoids decoding JSON numbers through float64.
+func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
+	if !bytes.Contains(body, []byte(`"namespace"`)) {
+		return body, nil
+	}
+	input := gjson.GetBytes(body, "input")
+	if !input.IsArray() {
+		return body, nil
+	}
+
+	var rebuilt bytes.Buffer
+	rebuilt.Grow(len(input.Raw))
+	rebuilt.WriteByte('[')
+	changed := false
+	first := true
+	var stripErr error
+	input.ForEach(func(_, item gjson.Result) bool {
+		if !first {
+			rebuilt.WriteByte(',')
+		}
+		first = false
+		itemBody := []byte(item.Raw)
+		if item.IsObject() && item.Get("namespace").Exists() {
+			itemBody, stripErr = sjson.DeleteBytes(itemBody, "namespace")
+			if stripErr != nil {
+				return false
+			}
+			changed = true
+		}
+		rebuilt.Write(itemBody)
+		return true
+	})
+	if stripErr != nil {
+		return body, fmt.Errorf("delete OpenAI input namespace: %w", stripErr)
+	}
+	if !changed {
+		return body, nil
+	}
+	rebuilt.WriteByte(']')
+	stripped, err := sjson.SetRawBytes(body, "input", rebuilt.Bytes())
+	if err != nil {
+		return body, fmt.Errorf("replace OpenAI input after namespace deletion: %w", err)
+	}
+	return stripped, nil
 }
 
 func setOpenAIResponsesNamespaceNames(c *gin.Context, names map[string]apicompat.ResponsesNamespaceName) {

--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -79,13 +79,13 @@ func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 
 	var rebuilt bytes.Buffer
 	rebuilt.Grow(len(input.Raw))
-	rebuilt.WriteByte('[')
+	_ = rebuilt.WriteByte('[')
 	changed := false
 	first := true
 	var stripErr error
 	input.ForEach(func(_, item gjson.Result) bool {
 		if !first {
-			rebuilt.WriteByte(',')
+			_ = rebuilt.WriteByte(',')
 		}
 		first = false
 		itemBody := []byte(item.Raw)
@@ -96,7 +96,7 @@ func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 			}
 			changed = true
 		}
-		rebuilt.Write(itemBody)
+		_, _ = rebuilt.Write(itemBody)
 		return true
 	})
 	if stripErr != nil {
@@ -105,7 +105,7 @@ func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 	if !changed {
 		return body, nil
 	}
-	rebuilt.WriteByte(']')
+	_ = rebuilt.WriteByte(']')
 	stripped, err := sjson.SetRawBytes(body, "input", rebuilt.Bytes())
 	if err != nil {
 		return body, fmt.Errorf("replace OpenAI input after namespace deletion: %w", err)

--- a/backend/internal/service/openai_responses_namespace_test.go
+++ b/backend/internal/service/openai_responses_namespace_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
 )
 
 func TestShouldFlattenOpenAIResponsesNamespaces(t *testing.T) {
@@ -32,5 +34,50 @@ func TestShouldFlattenOpenAIResponsesNamespaces(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require.Equal(t, tt.want, shouldFlattenOpenAIResponsesNamespaces(tt.account, tt.transport, tt.passthroughEnabled))
 		})
+	}
+}
+
+func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
+	body := []byte(`{
+		"meta":9007199254740993,
+		"scientific":1.25e+42,
+		"escaped":"line\\n\\u003ctag\\u003e",
+		"tools":[{"type":"function","name":"keep","namespace":"tool-namespace"}],
+		"input":[
+			{"type":"function_call","namespace":"n0","name":"one","content":{"namespace":"nested"},"large":9007199254740993},
+			{"type":"message","namespace":"n1","content":[{"type":"input_text","text":"hello","namespace":"nested-content"}]},
+			{"type":"custom_tool_call","namespace":"n2","input":"{}"},
+			{"type":"function_call_output","namespace":"n3","output":"ok"},
+			{"type":"item","namespace":"n4"},
+			{"type":"item","namespace":"n5"},
+			{"type":"item","namespace":"n6"},
+			{"type":"item","namespace":"n7"}
+		]
+	}`)
+
+	stripped, err := stripOpenAIResponsesInputNamespaces(body)
+	require.NoError(t, err)
+	for index := 0; index < 8; index++ {
+		require.False(t, gjson.GetBytes(stripped, "input."+strconv.Itoa(index)+".namespace").Exists())
+	}
+	require.Equal(t, "nested", gjson.GetBytes(stripped, "input.0.content.namespace").String())
+	require.Equal(t, "nested-content", gjson.GetBytes(stripped, "input.1.content.0.namespace").String())
+	require.Equal(t, "tool-namespace", gjson.GetBytes(stripped, "tools.0.namespace").String())
+	require.Equal(t, gjson.GetBytes(body, "meta").Raw, gjson.GetBytes(stripped, "meta").Raw)
+	require.Equal(t, gjson.GetBytes(body, "scientific").Raw, gjson.GetBytes(stripped, "scientific").Raw)
+	require.Equal(t, gjson.GetBytes(body, "escaped").Raw, gjson.GetBytes(stripped, "escaped").Raw)
+	require.Equal(t, gjson.GetBytes(body, "input.0.large").Raw, gjson.GetBytes(stripped, "input.0.large").Raw)
+}
+
+func TestStripOpenAIResponsesInputNamespacesLeavesOtherShapesByteExact(t *testing.T) {
+	tests := [][]byte{
+		[]byte(`{"input":"text","namespace":"top-level"}`),
+		[]byte(`{"input":{"namespace":"single-object"}}`),
+		[]byte(`{"input":[{"content":{"namespace":"nested-only"}}],"tools":[{"namespace":"keep"}]}`),
+	}
+	for _, body := range tests {
+		stripped, err := stripOpenAIResponsesInputNamespaces(body)
+		require.NoError(t, err)
+		require.Equal(t, body, stripped)
 	}
 }

--- a/backend/internal/service/openai_responses_namespace_test.go
+++ b/backend/internal/service/openai_responses_namespace_test.go
@@ -37,6 +37,36 @@ func TestShouldFlattenOpenAIResponsesNamespaces(t *testing.T) {
 	}
 }
 
+func TestShouldStripOpenAIResponsesInputNamespaces(t *testing.T) {
+	oauth := &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	apiKey := &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey}
+	setupToken := &Account{Platform: PlatformOpenAI, Type: AccountTypeSetupToken}
+	grokOAuth := &Account{Platform: PlatformGrok, Type: AccountTypeOAuth}
+
+	tests := []struct {
+		name               string
+		account            *Account
+		transport          OpenAIUpstreamTransport
+		passthroughEnabled bool
+		want               bool
+	}{
+		{name: "oauth_http", account: oauth, transport: OpenAIUpstreamTransportHTTPSSE, want: true},
+		{name: "apikey_http", account: apiKey, transport: OpenAIUpstreamTransportHTTPSSE, want: true},
+		{name: "oauth_wsv2", account: oauth, transport: OpenAIUpstreamTransportResponsesWebsocketV2, want: false},
+		{name: "apikey_wsv2", account: apiKey, transport: OpenAIUpstreamTransportResponsesWebsocketV2, want: false},
+		{name: "oauth_wsv2_passthrough", account: oauth, transport: OpenAIUpstreamTransportResponsesWebsocketV2, passthroughEnabled: true, want: true},
+		{name: "apikey_wsv2_passthrough", account: apiKey, transport: OpenAIUpstreamTransportResponsesWebsocketV2, passthroughEnabled: true, want: true},
+		{name: "setup_token_http", account: setupToken, transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+		{name: "grok_oauth_http", account: grokOAuth, transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+		{name: "nil_account", account: nil, transport: OpenAIUpstreamTransportHTTPSSE, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shouldStripOpenAIResponsesInputNamespaces(tt.account, tt.transport, tt.passthroughEnabled))
+		})
+	}
+}
+
 func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
 	body := []byte(`{
 		"meta":9007199254740993,

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -135,6 +135,32 @@ func TestOpenAIGatewayService_RetriesRejectedIndexedNamespaceField(t *testing.T)
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "input.1.namespace").Exists())
 }
 
+func TestOpenAIGatewayService_OAuthHTTPStripsInputNamespacesBeforeFirstForward(t *testing.T) {
+	for _, path := range []string{"/v1/responses", "/v1/responses/compact"} {
+		t.Run(path, func(t *testing.T) {
+			body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"test","input":[{"type":"message","role":"user","namespace":"remove","content":[{"type":"input_text","text":"hello","namespace":"nested-keep"}]}]}`)
+			upstream := &httpUpstreamRecorder{responses: []*http.Response{
+				newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp_namespace_ok","output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+			}}
+			c := newOpenAIRejectedFieldTestContext(body)
+			c.Request.URL.Path = path
+
+			result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+				context.Background(),
+				c,
+				newOpenAIOAuthNamespaceTestAccount(),
+				body,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Len(t, upstream.bodies, 1, "namespace must be removed before the first upstream request")
+			require.False(t, gjson.GetBytes(upstream.bodies[0], "input.0.namespace").Exists())
+			require.Equal(t, "nested-keep", gjson.GetBytes(upstream.bodies[0], "input.0.content.0.namespace").String())
+		})
+	}
+}
+
 func TestOpenAIGatewayService_RetriesExplicitMaxOutputTokensRejection(t *testing.T) {
 	body := []byte(`{"model":"gpt-5.5","stream":false,"max_output_tokens":4096,"input":[{"type":"message","role":"user","content":{"max_output_tokens":"keep"}}]}`)
 	upstream := &httpUpstreamRecorder{responses: []*http.Response{
@@ -215,6 +241,22 @@ func newOpenAIRejectedFieldTestAccount() *Account {
 		Extra: map[string]any{
 			openai_compat.ExtraKeyResponsesMode:      string(openai_compat.ResponsesSupportModeAuto),
 			openai_compat.ExtraKeyResponsesSupported: true,
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+}
+
+func newOpenAIOAuthNamespaceTestAccount() *Account {
+	return &Account{
+		ID:          5108,
+		Name:        "openai-oauth-namespace",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-account",
 		},
 		Status:      StatusActive,
 		Schedulable: true,

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -114,10 +114,9 @@ func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyBindsMaxOutputTokensToRej
 	require.False(t, gjson.GetBytes(retryBody, "max_output_tokens").Exists())
 }
 
-func TestOpenAIGatewayService_RetriesRejectedIndexedNamespaceField(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","name":"first","namespace":"keep","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove","input":"{}"}]}`)
+func TestOpenAIGatewayService_APIKeyStripsAllIndexedNamespacesBeforeFirstForward(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","name":"first","namespace":"remove-first","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove-second","input":"{}"}]}`)
 	upstream := &httpUpstreamRecorder{responses: []*http.Response{
-		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[1].namespace'.","param":"input[1].namespace","type":"invalid_request_error"}}`),
 		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
 	}}
 
@@ -130,34 +129,43 @@ func TestOpenAIGatewayService_RetriesRejectedIndexedNamespaceField(t *testing.T)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Len(t, upstream.bodies, 2)
-	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.0.namespace").String())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "input.1.namespace").Exists())
+	require.Len(t, upstream.bodies, 1)
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "input.0.namespace").Exists())
+	require.False(t, gjson.GetBytes(upstream.bodies[0], "input.1.namespace").Exists())
 }
 
-func TestOpenAIGatewayService_OAuthHTTPStripsInputNamespacesBeforeFirstForward(t *testing.T) {
-	for _, path := range []string{"/v1/responses", "/v1/responses/compact"} {
-		t.Run(path, func(t *testing.T) {
-			body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"test","input":[{"type":"message","role":"user","namespace":"remove","content":[{"type":"input_text","text":"hello","namespace":"nested-keep"}]}]}`)
-			upstream := &httpUpstreamRecorder{responses: []*http.Response{
-				newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp_namespace_ok","output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
-			}}
-			c := newOpenAIRejectedFieldTestContext(body)
-			c.Request.URL.Path = path
+func TestOpenAIGatewayService_OpenAIHTTPStripsInputNamespacesBeforeFirstForward(t *testing.T) {
+	accounts := []struct {
+		name    string
+		account *Account
+	}{
+		{name: "oauth", account: newOpenAIOAuthNamespaceTestAccount()},
+		{name: "apikey", account: newOpenAIRejectedFieldTestAccount()},
+	}
+	for _, tt := range accounts {
+		for _, path := range []string{"/v1/responses", "/v1/responses/compact"} {
+			t.Run(tt.name+path, func(t *testing.T) {
+				body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"test","input":[{"type":"message","role":"user","namespace":"remove","content":[{"type":"input_text","text":"hello","namespace":"nested-keep"}]}]}`)
+				upstream := &httpUpstreamRecorder{responses: []*http.Response{
+					newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp_namespace_ok","output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
+				}}
+				c := newOpenAIRejectedFieldTestContext(body)
+				c.Request.URL.Path = path
 
-			result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
-				context.Background(),
-				c,
-				newOpenAIOAuthNamespaceTestAccount(),
-				body,
-			)
+				result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+					context.Background(),
+					c,
+					tt.account,
+					body,
+				)
 
-			require.NoError(t, err)
-			require.NotNil(t, result)
-			require.Len(t, upstream.bodies, 1, "namespace must be removed before the first upstream request")
-			require.False(t, gjson.GetBytes(upstream.bodies[0], "input.0.namespace").Exists())
-			require.Equal(t, "nested-keep", gjson.GetBytes(upstream.bodies[0], "input.0.content.0.namespace").String())
-		})
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Len(t, upstream.bodies, 1, "namespace must be removed before the first upstream request")
+				require.False(t, gjson.GetBytes(upstream.bodies[0], "input.0.namespace").Exists())
+				require.Equal(t, "nested-keep", gjson.GetBytes(upstream.bodies[0], "input.0.content.0.namespace").String())
+			})
+		}
 	}
 }
 
@@ -183,10 +191,9 @@ func TestOpenAIGatewayService_RetriesExplicitMaxOutputTokensRejection(t *testing
 	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.0.content.max_output_tokens").String())
 }
 
-func TestOpenAIGatewayService_ComposesDistinctRejectedFieldRetries(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","stream":false,"max_output_tokens":2048,"input":[{"type":"function_call","name":"first","namespace":"keep","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove","input":"{}"}]}`)
+func TestOpenAIGatewayService_ComposesProactiveNamespaceStripWithRejectedFieldRetry(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"max_output_tokens":2048,"input":[{"type":"function_call","name":"first","namespace":"remove-first","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove-second","input":"{}"}]}`)
 	upstream := &httpUpstreamRecorder{responses: []*http.Response{
-		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[1].namespace'.","param":"input[1].namespace"}}`),
 		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: max_output_tokens","param":"max_output_tokens"}}`),
 		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
 	}}
@@ -200,12 +207,13 @@ func TestOpenAIGatewayService_ComposesDistinctRejectedFieldRetries(t *testing.T)
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.Len(t, upstream.bodies, 3)
-	require.True(t, gjson.GetBytes(upstream.bodies[0], "input.1.namespace").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[1], "input.1.namespace").Exists())
-	require.Equal(t, int64(2048), gjson.GetBytes(upstream.bodies[1], "max_output_tokens").Int())
-	require.False(t, gjson.GetBytes(upstream.bodies[2], "input.1.namespace").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[2], "max_output_tokens").Exists())
+	require.Len(t, upstream.bodies, 2)
+	for _, forwardedBody := range upstream.bodies {
+		require.False(t, gjson.GetBytes(forwardedBody, "input.0.namespace").Exists())
+		require.False(t, gjson.GetBytes(forwardedBody, "input.1.namespace").Exists())
+	}
+	require.Equal(t, int64(2048), gjson.GetBytes(upstream.bodies[0], "max_output_tokens").Int())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], "max_output_tokens").Exists())
 }
 
 func newOpenAIRejectedFieldTestService(upstream *httpUpstreamRecorder) *OpenAIGatewayService {

--- a/backend/internal/service/openai_ws_forwarder_success_test.go
+++ b/backend/internal/service/openai_ws_forwarder_success_test.go
@@ -733,7 +733,7 @@ func TestOpenAIGatewayService_Forward_WSv2_OAuthStoreFalseByDefault(t *testing.T
 		},
 	}
 
-	body := []byte(`{"model":"gpt-5.1","stream":false,"store":true,"input":[{"type":"input_text","text":"hello"}]}`)
+	body := []byte(`{"model":"gpt-5.1","stream":false,"store":true,"input":[{"type":"input_text","text":"hello","namespace":"native-wsv2"}]}`)
 	result, err := svc.Forward(context.Background(), c, account, body)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -745,6 +745,7 @@ func TestOpenAIGatewayService_Forward_WSv2_OAuthStoreFalseByDefault(t *testing.T
 	require.False(t, gjson.Get(requestJSON, "store").Bool(), "默认策略应将 OAuth store 置为 false")
 	require.True(t, gjson.Get(requestJSON, "stream").Exists(), "WSv2 payload 应保留 stream 字段")
 	require.True(t, gjson.Get(requestJSON, "stream").Bool(), "OAuth Codex 规范化后应强制 stream=true")
+	require.Equal(t, "native-wsv2", gjson.Get(requestJSON, "input.0.namespace").String(), "OAuth WSv2 应保留原生 namespace")
 	require.Equal(t, openAIWSBetaV2Value, captureDialer.lastHeaders.Get("OpenAI-Beta"))
 	require.Equal(t, "remote_compaction_v2", captureDialer.lastHeaders.Get("x-codex-beta-features"))
 	// OAuth 账号的 session_id/conversation_id 应被 isolateOpenAISessionID 隔离，


### PR DESCRIPTION
## Summary / 变更说明

### English

- Proactively remove `namespace` from direct items in the OpenAI Responses API `input` array before the first upstream HTTP request for both OAuth and API Key accounts.
- Apply the behavior to Responses and Compact HTTP forwarding while preserving native Responses WebSocket v2 payloads.
- Keep namespace declarations outside direct input items, including tool namespaces and nested content namespaces.
- Preserve the existing rejected-field retry flow for unrelated unsupported parameters.
- Rebuild only the `input` array with `gjson`/`sjson` so untouched JSON values retain their original representation.

### 中文

- 对 OpenAI OAuth 和 API Key 账号，在第一次 HTTP 上游请求前主动移除 Responses API `input` 数组直接子项中的 `namespace`。
- 覆盖 Responses 和 Compact 的 HTTP 转发路径，同时保留原生 Responses WebSocket v2 请求中的字段。
- 不修改直接 input 项以外的命名空间声明，包括工具 namespace 和嵌套 content namespace。
- 保留现有的拒绝字段重试机制，用于处理其他不受支持的参数。
- 使用 `gjson`/`sjson` 仅重建 `input` 数组，确保未修改的 JSON 值保持原始表示。

## Tests / 测试

### English

- Added unit coverage for OAuth and API Key account gating, HTTP and WebSocket v2 transport behavior, and Responses/Compact forwarding.
- Verified that eight direct input-item namespace fields are removed before the first upstream request.
- Verified preservation of nested namespaces, tool namespaces, large integers, scientific notation, escaped strings, and unrelated input shapes.
- Verified composition with the existing rejected-field retry flow.
- Relevant `internal/service` unit tests pass.

### 中文

- 新增单元测试，覆盖 OAuth/API Key 账号判断、HTTP/WebSocket v2 传输行为，以及 Responses/Compact 转发路径。
- 验证 8 个直接 input 项的 namespace 均在第一次上游请求前被移除。
- 验证嵌套 namespace、工具 namespace、大整数、科学计数法、转义字符串及其他 input 结构保持不变。
- 验证该逻辑可与现有拒绝字段重试机制正确组合。
- 相关 `internal/service` 单元测试已通过。

## End-to-end validation / 实机验证

### English

A built image containing this change was validated end-to-end on a running instance. Non-streaming Responses, streaming Responses, and Responses Compact requests containing eight direct input-item namespace fields all completed successfully. The streaming request reached `response.completed`, and no namespace rejection occurred.

### 中文

已将包含此改动的构建镜像用于运行实例的端到端验证。携带 8 个直接 input 项 namespace 字段的非流式 Responses、流式 Responses 和 Responses Compact 请求均成功完成；流式请求正常到达 `response.completed`，未出现 namespace 字段拒绝。

Related to #4135.