### PR TITLE
faet: 优化提示词审计发送消息内容

### DIFF
--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -233,12 +233,14 @@ func extractResponses(extracted *promptExtraction, value any) {
 func extractResponseEntry(extracted *promptExtraction, entry map[string]any) {
 	typeName := strings.ToLower(stringValue(entry["type"]))
 	switch typeName {
-	case "function_call_output":
+	case "function_call_output", "custom_tool_call_output", "mcp_tool_call_output", "tool_search_output", "mcp_call":
+		// All supported Responses/Codex result items expose the model-visible
+		// payload through output. Do not inspect tool definitions or call inputs.
 		extracted.appendToolResult(entry["output"])
 		return
-	case "function_call":
-		// Function calls are assistant history, not a tool result. In particular,
-		// never send their arguments to the guard model.
+	case "function_call", "tool_call", "local_shell_call", "tool_search_call", "custom_tool_call", "mcp_tool_call":
+		// Calls are assistant history, not a tool result. In particular, never
+		// send their arguments or freeform input to the guard model.
 		extracted.hasHistory = true
 		return
 	}

--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ErrNoPromptText = errors.New("prompt audit request contains no user text")
+	ErrNoPromptText = errors.New("prompt audit request contains no auditable text")
 
 	bearerPattern = regexp.MustCompile(`(?i)\bBearer\s+[A-Za-z0-9._~+\-/]+=*`)
 	apiKeyPattern = regexp.MustCompile(`(?i)\b(sk|rk|pk|api[_-]?key|token|secret|password)[-_:=\s]+[A-Za-z0-9._~+\-/]{8,}`)
@@ -24,8 +24,46 @@ var (
 const promptAuditPrioritySeparator = "\x00SUB2API_PROMPT_AUDIT_PRIORITY_END\x00"
 
 type promptSegment struct {
-	text string
-	user bool
+	text    string
+	kind    promptSegmentKind
+	message int
+}
+
+type promptSegmentKind uint8
+
+const (
+	promptSegmentSystem promptSegmentKind = iota
+	promptSegmentUser
+	promptSegmentToolResult
+	promptSegmentHistory
+)
+
+type promptExtraction struct {
+	segments      []promptSegment
+	nextMessage   int
+	hasHistory    bool
+	hasToolResult bool
+}
+
+func (e *promptExtraction) newMessage() int {
+	message := e.nextMessage
+	e.nextMessage++
+	return message
+}
+
+func (e *promptExtraction) appendTexts(kind promptSegmentKind, texts []string) {
+	e.appendTextsToMessage(kind, e.newMessage(), texts)
+}
+
+func (e *promptExtraction) appendTextsToMessage(kind promptSegmentKind, message int, texts []string) {
+	for _, text := range texts {
+		e.segments = append(e.segments, promptSegment{text: text, kind: kind, message: message})
+	}
+}
+
+func (e *promptExtraction) appendToolResult(value any) {
+	e.hasToolResult = true
+	e.appendTexts(promptSegmentToolResult, toolResultTexts(value))
 }
 
 func ExtractPromptSnapshot(req Request) (PromptSnapshot, error) {
@@ -34,7 +72,7 @@ func ExtractPromptSnapshot(req Request) (PromptSnapshot, error) {
 		return PromptSnapshot{}, errors.New("prompt audit request JSON is invalid")
 	}
 	extracted := extractProtocolSegments(req.Protocol, document)
-	segments := normalizeSegmentsLatestUserFirst(extracted)
+	segments := selectAuditSegments(req.Stage, extracted)
 	if len(segments) == 0 {
 		return PromptSnapshot{}, ErrNoPromptText
 	}
@@ -65,159 +103,171 @@ const DefaultPromptPreviewMaxRunes = 96
 // prompts are kept intact while bounding per-row storage.
 const DefaultFullPromptMaxRunes = 65536
 
-func extractProtocolSegments(protocol string, document any) []promptSegment {
+func extractProtocolSegments(protocol string, document any) promptExtraction {
+	var extracted promptExtraction
 	root, _ := document.(map[string]any)
 	protocol = strings.ToLower(strings.TrimSpace(protocol))
 	switch protocol {
 	case "openai_chat_completions", "openai_chat", "chat_completions":
-		return extractChatLikeSegments(root)
+		extractChatLikeSegments(&extracted, root)
 	case "anthropic_messages", "claude_messages", "messages":
-		return append(extractAnthropicSystem(root["system"]), extractMessages(root["messages"], clientInstructionRoles...)...)
+		extractAnthropicSystem(&extracted, root["system"])
+		extractMessages(&extracted, root["messages"])
 	case "gemini", "gemini_generate_content":
-		return extractGeminiRoot(root)
+		extractGeminiRoot(&extracted, root)
 	case "openai_responses", "responses", "responses_websocket":
 		if frameType := stringValue(root["type"]); frameType != "" || protocol == "responses_websocket" {
 			if frameType != "response.create" {
-				return nil
+				return extracted
 			}
 			if input, exists := root["input"]; exists && input != nil {
-				return append(extractInstructions(root["instructions"]), extractResponses(input)...)
+				extractInstructions(&extracted, root["instructions"])
+				extractResponses(&extracted, input)
+				return extracted
 			}
 			if response, ok := root["response"].(map[string]any); ok {
-				return append(extractInstructions(response["instructions"]), extractResponses(response["input"])...)
+				extractInstructions(&extracted, response["instructions"])
+				extractResponses(&extracted, response["input"])
+				return extracted
 			}
-			return extractInstructions(root["instructions"])
+			extractInstructions(&extracted, root["instructions"])
+			return extracted
 		}
-		return append(extractInstructions(root["instructions"]), extractResponses(root["input"])...)
+		extractInstructions(&extracted, root["instructions"])
+		extractResponses(&extracted, root["input"])
 	case "openai_images", "grok_media", "media", "images":
-		return userPromptSegments(extractMediaPrompts(root))
+		extracted.appendTexts(promptSegmentUser, extractMediaPrompts(root))
 	default:
-		if segments := extractChatLikeSegments(root); len(segments) > 0 {
-			return segments
+		extractChatLikeSegments(&extracted, root)
+		if len(extracted.segments) > 0 || extracted.hasHistory || extracted.hasToolResult {
+			return extracted
 		}
-		if responses := append(extractInstructions(root["instructions"]), extractResponses(root["input"])...); len(responses) > 0 {
-			return responses
+		extractInstructions(&extracted, root["instructions"])
+		extractResponses(&extracted, root["input"])
+		if len(extracted.segments) > 0 || extracted.hasHistory || extracted.hasToolResult {
+			return extracted
 		}
-		if gemini := extractGeminiRoot(root); len(gemini) > 0 {
-			return gemini
+		extractGeminiRoot(&extracted, root)
+		if len(extracted.segments) > 0 || extracted.hasHistory || extracted.hasToolResult {
+			return extracted
 		}
-		return userPromptSegments(extractMediaPrompts(root))
+		extracted.appendTexts(promptSegmentUser, extractMediaPrompts(root))
 	}
+	return extracted
 }
 
-// clientInstructionRoles are roles a client may freely populate. Attackers can
-// place jailbreak/PII text in assistant/tool turns, so blocking audit must scan
-// them too—not only user/system/developer instructions.
-var clientInstructionRoles = []string{"user", "system", "developer", "assistant", "tool"}
-
-func extractChatLikeSegments(root map[string]any) []promptSegment {
+func extractChatLikeSegments(extracted *promptExtraction, root map[string]any) {
 	if root == nil {
-		return nil
+		return
 	}
-	return extractMessages(root["messages"], clientInstructionRoles...)
+	extractMessages(extracted, root["messages"])
 }
 
-func extractMessages(value any, wantedRoles ...string) []promptSegment {
+func extractMessages(extracted *promptExtraction, value any) {
 	items, ok := value.([]any)
 	if !ok {
-		return nil
+		return
 	}
-	wanted := make(map[string]struct{}, len(wantedRoles))
-	for _, role := range wantedRoles {
-		wanted[strings.ToLower(strings.TrimSpace(role))] = struct{}{}
-	}
-	result := make([]promptSegment, 0, len(items))
 	for _, item := range items {
 		message, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
 		role := strings.ToLower(stringValue(message["role"]))
-		if _, match := wanted[role]; !match {
+		switch role {
+		case "system", "developer":
+			extracted.appendTexts(promptSegmentSystem, contentTexts(message["content"]))
+		case "user":
+			extractUserMessageContent(extracted, message["content"])
+		case "tool":
+			extracted.appendToolResult(message["content"])
+		case "assistant", "model":
+			extracted.hasHistory = true
+			extracted.appendTexts(promptSegmentHistory, contentTexts(message["content"]))
+		}
+	}
+}
+
+func extractUserMessageContent(extracted *promptExtraction, value any) {
+	message := extracted.newMessage()
+	extracted.appendTextsToMessage(promptSegmentUser, message, contentTexts(value))
+	blocks, ok := value.([]any)
+	if !ok {
+		return
+	}
+	for _, block := range blocks {
+		object, ok := block.(map[string]any)
+		if !ok || strings.ToLower(stringValue(object["type"])) != "tool_result" {
 			continue
 		}
-		texts := contentTexts(message["content"])
-		for _, text := range texts {
-			result = append(result, promptSegment{text: text, user: role == "user"})
-		}
+		extracted.appendToolResult(object["content"])
 	}
-	return result
 }
 
-func extractInstructions(value any) []promptSegment {
-	switch typed := value.(type) {
-	case string:
-		if text := strings.TrimSpace(typed); text != "" {
-			return []promptSegment{{text: text}}
-		}
-	case []any:
-		return systemPromptSegments(contentTexts(typed))
-	case map[string]any:
-		return systemPromptSegments(contentTexts(typed))
-	}
-	return nil
+func extractInstructions(extracted *promptExtraction, value any) {
+	extracted.appendTexts(promptSegmentSystem, contentTexts(value))
 }
 
-func extractAnthropicSystem(value any) []promptSegment {
-	switch typed := value.(type) {
-	case string:
-		if text := strings.TrimSpace(typed); text != "" {
-			return []promptSegment{{text: text}}
-		}
-	case []any:
-		return systemPromptSegments(contentTexts(typed))
-	case map[string]any:
-		return systemPromptSegments(contentTexts(typed))
-	}
-	return nil
+func extractAnthropicSystem(extracted *promptExtraction, value any) {
+	extracted.appendTexts(promptSegmentSystem, contentTexts(value))
 }
 
-func extractResponses(value any) []promptSegment {
+func extractResponses(extracted *promptExtraction, value any) {
 	switch typed := value.(type) {
 	case string:
-		return []promptSegment{{text: typed, user: true}}
+		extracted.appendTexts(promptSegmentUser, []string{typed})
 	case []any:
-		result := make([]promptSegment, 0, len(typed))
 		for _, item := range typed {
 			switch entry := item.(type) {
 			case string:
-				result = append(result, promptSegment{text: entry, user: true})
+				extracted.appendTexts(promptSegmentUser, []string{entry})
 			case map[string]any:
-				role := strings.ToLower(stringValue(entry["role"]))
-				if role != "" && !isClientInstructionRole(role) {
-					continue
-				}
-				if content, exists := entry["content"]; exists {
-					for _, text := range contentTexts(content) {
-						result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
-					}
-				} else if text := stringValue(entry["text"]); text != "" {
-					result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
-				}
+				extractResponseEntry(extracted, entry)
 			}
 		}
-		return result
 	case map[string]any:
-		role := strings.ToLower(stringValue(typed["role"]))
-		if role != "" && !isClientInstructionRole(role) {
-			return nil
+		extractResponseEntry(extracted, typed)
+	}
+}
+
+func extractResponseEntry(extracted *promptExtraction, entry map[string]any) {
+	typeName := strings.ToLower(stringValue(entry["type"]))
+	switch typeName {
+	case "function_call_output":
+		extracted.appendToolResult(entry["output"])
+		return
+	case "function_call":
+		// Function calls are assistant history, not a tool result. In particular,
+		// never send their arguments to the guard model.
+		extracted.hasHistory = true
+		return
+	}
+	role := strings.ToLower(stringValue(entry["role"]))
+	switch role {
+	case "system", "developer":
+		extracted.appendTexts(promptSegmentSystem, contentTexts(entry["content"]))
+	case "user":
+		extractUserMessageContent(extracted, entry["content"])
+		if _, exists := entry["content"]; !exists {
+			extracted.appendTexts(promptSegmentUser, []string{stringValue(entry["text"])})
 		}
-		return promptSegmentsForRole(contentTexts(typed["content"]), role)
+	case "tool":
+		extracted.appendToolResult(entry["content"])
+	case "assistant", "model":
+		extracted.hasHistory = true
+		if content, exists := entry["content"]; exists {
+			extracted.appendTexts(promptSegmentHistory, contentTexts(content))
+		} else {
+			extracted.appendTexts(promptSegmentHistory, []string{stringValue(entry["text"])})
+		}
 	default:
-		return nil
+		if text := stringValue(entry["text"]); text != "" {
+			extracted.appendTexts(promptSegmentUser, []string{text})
+		}
 	}
 }
 
-func isClientInstructionRole(role string) bool {
-	switch strings.ToLower(strings.TrimSpace(role)) {
-	case "user", "system", "developer", "assistant", "tool", "model":
-		return true
-	default:
-		return false
-	}
-}
-
-func extractGemini(value any) []promptSegment {
+func extractGemini(extracted *promptExtraction, value any) {
 	var contents []any
 	switch typed := value.(type) {
 	case []any:
@@ -225,98 +275,102 @@ func extractGemini(value any) []promptSegment {
 	case map[string]any:
 		contents = []any{typed}
 	default:
-		return nil
+		return
 	}
-	result := make([]promptSegment, 0, len(contents))
 	for _, item := range contents {
 		content, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
 		role := strings.ToLower(stringValue(content["role"]))
-		if role != "" && !isClientInstructionRole(role) {
+		kind := promptSegmentUser
+		if role == "model" || role == "assistant" {
+			extracted.hasHistory = true
+			kind = promptSegmentHistory
+		}
+		if role != "" && role != "user" && role != "model" && role != "assistant" {
 			continue
 		}
+		message := extracted.newMessage()
 		parts, _ := content["parts"].([]any)
 		for _, part := range parts {
 			if object, ok := part.(map[string]any); ok {
+				if response, ok := object["functionResponse"].(map[string]any); ok {
+					extracted.appendToolResult(response["response"])
+					continue
+				}
+				if _, exists := object["functionCall"]; exists {
+					extracted.hasHistory = true
+					continue
+				}
 				if text := stringValue(object["text"]); text != "" {
-					result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
+					extracted.appendTextsToMessage(kind, message, []string{text})
 				}
 			}
 		}
 	}
-	return result
 }
 
-func extractGeminiRoot(root map[string]any) []promptSegment {
+func extractGeminiRoot(extracted *promptExtraction, root map[string]any) {
 	if root == nil {
-		return nil
+		return
 	}
-	result := extractGeminiSystemInstruction(root["systemInstruction"])
-	result = append(result, extractGeminiSystemInstruction(root["system_instruction"])...)
-	result = append(result, extractGemini(root["contents"])...)
-	result = append(result, extractGemini(root["content"])...)
-	result = append(result, extractGeminiInstances(root["instances"])...)
+	extractGeminiSystemInstruction(extracted, root["systemInstruction"])
+	extractGeminiSystemInstruction(extracted, root["system_instruction"])
+	extractGemini(extracted, root["contents"])
+	extractGemini(extracted, root["content"])
+	extractGeminiInstances(extracted, root["instances"])
 	if requests, ok := root["requests"].([]any); ok {
 		for _, item := range requests {
 			request, ok := item.(map[string]any)
 			if !ok {
 				continue
 			}
-			result = append(result, extractGeminiSystemInstruction(request["systemInstruction"])...)
-			result = append(result, extractGeminiSystemInstruction(request["system_instruction"])...)
-			result = append(result, extractGemini(request["contents"])...)
-			result = append(result, extractGemini(request["content"])...)
-			result = append(result, extractGeminiInstances(request["instances"])...)
+			extractGeminiSystemInstruction(extracted, request["systemInstruction"])
+			extractGeminiSystemInstruction(extracted, request["system_instruction"])
+			extractGemini(extracted, request["contents"])
+			extractGemini(extracted, request["content"])
+			extractGeminiInstances(extracted, request["instances"])
 		}
 	}
-	return result
 }
 
-func extractGeminiSystemInstruction(value any) []promptSegment {
+func extractGeminiSystemInstruction(extracted *promptExtraction, value any) {
 	switch typed := value.(type) {
 	case string:
-		if text := strings.TrimSpace(typed); text != "" {
-			return []promptSegment{{text: text}}
-		}
+		extracted.appendTexts(promptSegmentSystem, []string{typed})
 	case map[string]any:
 		if parts, ok := typed["parts"].([]any); ok {
-			result := make([]promptSegment, 0, len(parts))
+			message := extracted.newMessage()
 			for _, part := range parts {
 				if object, ok := part.(map[string]any); ok {
 					if text := stringValue(object["text"]); text != "" {
-						result = append(result, promptSegment{text: text})
+						extracted.appendTextsToMessage(promptSegmentSystem, message, []string{text})
 					}
 				}
 			}
-			return result
+			return
 		}
-		return systemPromptSegments(contentTexts(typed))
+		extracted.appendTexts(promptSegmentSystem, contentTexts(typed))
 	case []any:
-		segments := extractGemini(typed)
-		for index := range segments {
-			segments[index].user = false
+		for _, text := range contentTexts(typed) {
+			extracted.appendTexts(promptSegmentSystem, []string{text})
 		}
-		return segments
 	}
-	return nil
 }
 
-func extractGeminiInstances(value any) []promptSegment {
+func extractGeminiInstances(extracted *promptExtraction, value any) {
 	instances, ok := value.([]any)
 	if !ok {
-		return nil
+		return
 	}
-	result := make([]promptSegment, 0, len(instances))
 	for _, item := range instances {
 		if instance, ok := item.(map[string]any); ok {
 			if prompt := stringValue(instance["prompt"]); prompt != "" {
-				result = append(result, promptSegment{text: prompt, user: true})
+				extracted.appendTexts(promptSegmentUser, []string{prompt})
 			}
 		}
 	}
-	return result
 }
 
 func extractMediaPrompts(root map[string]any) []string {
@@ -375,7 +429,7 @@ func isMediaPromptKey(key string) bool {
 func looksLikeMediaPayload(value string) bool {
 	trimmed := strings.TrimSpace(value)
 	lower := strings.ToLower(trimmed)
-	if strings.HasPrefix(lower, "data:image/") || strings.HasPrefix(lower, "data:video/") ||
+	if strings.HasPrefix(lower, "data:") ||
 		strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
 		return true
 	}
@@ -419,7 +473,50 @@ func contentTexts(value any) []string {
 	return nil
 }
 
-func normalizeSegmentsLatestUserFirst(values []promptSegment) []string {
+func selectAuditSegments(stage string, extracted promptExtraction) []string {
+	values := normalizedPromptSegments(extracted.segments)
+	if len(values) == 0 {
+		return nil
+	}
+	latestUserMessage, latestUserEnd := -1, -1
+	for index, value := range values {
+		if value.kind != promptSegmentUser {
+			continue
+		}
+		latestUserMessage, latestUserEnd = value.message, index
+	}
+	priority := make([]string, 0, 2)
+	for _, value := range values {
+		if value.kind == promptSegmentUser && value.message == latestUserMessage {
+			priority = append(priority, value.text)
+		}
+	}
+	remaining := make([]string, 0, len(values))
+	if isSubsequentPromptAuditTurn(stage, extracted) {
+		for index, value := range values {
+			if value.kind != promptSegmentToolResult {
+				continue
+			}
+			if latestUserMessage == -1 || index > latestUserEnd {
+				remaining = append(remaining, value.text)
+			}
+		}
+	} else {
+		for _, value := range values {
+			if value.kind == promptSegmentSystem {
+				remaining = append(remaining, value.text)
+			}
+		}
+	}
+	if len(priority) == 0 {
+		return remaining
+	}
+	result := make([]string, 0, len(remaining)+1)
+	result = append(result, strings.Join(priority, "\n\n"))
+	return append(result, remaining...)
+}
+
+func normalizedPromptSegments(values []promptSegment) []promptSegment {
 	normalized := make([]promptSegment, 0, len(values))
 	for _, value := range values {
 		value.text = strings.TrimSpace(value.text)
@@ -427,24 +524,18 @@ func normalizeSegmentsLatestUserFirst(values []promptSegment) []string {
 			normalized = append(normalized, value)
 		}
 	}
-	if len(normalized) == 0 {
-		return nil
+	return normalized
+}
+
+func isSubsequentPromptAuditTurn(stage string, extracted promptExtraction) bool {
+	switch strings.TrimSpace(stage) {
+	case "first_turn":
+		return false
+	case "subsequent_turn":
+		return true
+	default:
+		return extracted.hasHistory || extracted.hasToolResult
 	}
-	priorityIndex := len(normalized) - 1
-	for index := len(normalized) - 1; index >= 0; index-- {
-		if normalized[index].user {
-			priorityIndex = index
-			break
-		}
-	}
-	result := make([]string, 0, len(normalized))
-	result = append(result, normalized[priorityIndex].text)
-	for index, segment := range normalized {
-		if index != priorityIndex {
-			result = append(result, segment.text)
-		}
-	}
-	return result
 }
 
 func buildPrioritizedScanText(segments []string) (scanText string, metadataText string) {
@@ -455,20 +546,45 @@ func buildPrioritizedScanText(segments []string) (scanText string, metadataText 
 	return segments[0] + promptAuditPrioritySeparator + strings.Join(segments[1:], "\n\n"), metadataText
 }
 
-func promptSegmentsForRole(texts []string, role string) []promptSegment {
-	result := make([]promptSegment, 0, len(texts))
-	for _, text := range texts {
-		result = append(result, promptSegment{text: text, user: role == "" || role == "user"})
+func toolResultTexts(value any) []string {
+	result := make([]string, 0, 4)
+	var walk func(any, string)
+	walk = func(current any, key string) {
+		switch typed := current.(type) {
+		case string:
+			if text := strings.TrimSpace(typed); text != "" && !looksLikeMediaPayload(text) {
+				result = append(result, text)
+			}
+		case []any:
+			for _, item := range typed {
+				walk(item, key)
+			}
+		case map[string]any:
+			keys := make([]string, 0, len(typed))
+			for childKey := range typed {
+				keys = append(keys, childKey)
+			}
+			sort.Strings(keys)
+			for _, childKey := range keys {
+				if isToolResultMetadataKey(childKey) {
+					continue
+				}
+				walk(typed[childKey], childKey)
+			}
+		}
 	}
+	walk(value, "")
 	return result
 }
 
-func userPromptSegments(texts []string) []promptSegment {
-	return promptSegmentsForRole(texts, "user")
-}
-
-func systemPromptSegments(texts []string) []promptSegment {
-	return promptSegmentsForRole(texts, "system")
+func isToolResultMetadataKey(key string) bool {
+	normalized := strings.NewReplacer("_", "", "-", "").Replace(strings.ToLower(strings.TrimSpace(key)))
+	switch normalized {
+	case "type", "name", "id", "callid", "tooluseid", "mimetype", "mime", "url", "image", "imageurl", "binary", "base64", "bytes", "blob", "arguments", "input", "functioncall":
+		return true
+	default:
+		return false
+	}
 }
 
 func RedactPreview(value string, maxRunes int) string {

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -373,6 +373,37 @@ func TestPromptSnapshotConversationTurnSelectionByProtocol(t *testing.T) {
 	}
 }
 
+func TestPromptSnapshotResponsesCodexAndMCPToolOutputs(t *testing.T) {
+	body := []byte(`{
+		"input":[
+			{"role":"user","content":"old user"},
+			{"type":"function_call","arguments":"FUNCTION_ARGUMENTS_CANARY"},
+			{"type":"custom_tool_call","input":"CUSTOM_INPUT_CANARY"},
+			{"type":"mcp_tool_call","arguments":"MCP_ARGUMENTS_CANARY"},
+			{"type":"tool_search_call","arguments":{"query":"SEARCH_ARGUMENTS_CANARY"}},
+			{"role":"user","content":"latest user"},
+			{"type":"custom_tool_call_output","call_id":"call_custom","output":"custom tool result"},
+			{"type":"mcp_tool_call_output","call_id":"call_mcp","output":{"content":[{"type":"text","text":"mcp text result"},{"type":"image","data":"data:image/png;base64,IMAGE_CANARY"}],"structuredContent":{"summary":"mcp structured result"}}},
+			{"type":"tool_search_output","call_id":"call_search","output":{"groups":["loaded tool group"]},"tools":[{"name":"TOOL_SCHEMA_CANARY","description":"TOOL_SCHEMA_DESCRIPTION_CANARY"}]},
+			{"type":"mcp_call","name":"hosted_mcp","arguments":"HOSTED_MCP_ARGUMENTS_CANARY","output":"hosted mcp result"}
+		]
+	}`)
+
+	snapshot, err := ExtractPromptSnapshot(Request{
+		Protocol: "openai_responses", Stage: "subsequent_turn", Body: body,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "latest user\n\ncustom tool result\n\nmcp text result\n\nmcp structured result\n\nloaded tool group\n\nhosted mcp result", metadataTextForTest(snapshot.ScanText))
+	for _, excluded := range []string{
+		"old user", "FUNCTION_ARGUMENTS_CANARY", "CUSTOM_INPUT_CANARY", "MCP_ARGUMENTS_CANARY",
+		"SEARCH_ARGUMENTS_CANARY", "HOSTED_MCP_ARGUMENTS_CANARY", "TOOL_SCHEMA_CANARY",
+		"TOOL_SCHEMA_DESCRIPTION_CANARY", "IMAGE_CANARY",
+	} {
+		require.NotContains(t, snapshot.ScanText, excluded)
+		require.NotContains(t, snapshot.FullPrompt, excluded)
+	}
+}
+
 func TestPromptSnapshotWebSocketStageOverridesHistoryDetection(t *testing.T) {
 	body := []byte(`{"type":"response.create","response":{"instructions":"websocket system","input":[{"role":"assistant","content":"old assistant"},{"role":"user","content":"latest websocket"}]}}`)
 	first, err := ExtractPromptSnapshot(Request{Protocol: "responses_websocket", Stage: "first_turn", Body: body})
@@ -382,6 +413,18 @@ func TestPromptSnapshotWebSocketStageOverridesHistoryDetection(t *testing.T) {
 	subsequent, err := ExtractPromptSnapshot(Request{Protocol: "responses_websocket", Stage: "subsequent_turn", Body: body})
 	require.NoError(t, err)
 	require.Equal(t, "latest websocket", subsequent.ScanText)
+}
+
+func TestPromptSnapshotWebSocketIncludesCodexToolOutputs(t *testing.T) {
+	body := []byte(`{"type":"response.create","response":{"input":[
+		{"role":"user","content":"latest websocket"},
+		{"type":"custom_tool_call_output","call_id":"call_custom","output":"websocket custom result"},
+		{"type":"mcp_tool_call_output","call_id":"call_mcp","output":"websocket mcp result"}
+	]}}`)
+
+	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "responses_websocket", Stage: "subsequent_turn", Body: body})
+	require.NoError(t, err)
+	require.Equal(t, "latest websocket\n\nwebsocket custom result\n\nwebsocket mcp result", metadataTextForTest(snapshot.ScanText))
 }
 
 func TestPromptSnapshotToolResultWithoutUserAndAssistantHistoryOnly(t *testing.T) {

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -17,7 +17,7 @@ func TestExtractPromptSnapshotProtocols(t *testing.T) {
 		protocol, body, first string
 		count                 int
 	}{
-		{"openai_chat_completions", `{"messages":[{"role":"user","content":"old"},{"role":"assistant","content":"assistant turn"},{"role":"user","content":[{"type":"text","text":"最新😀"}]}]}`, "最新😀", 3},
+		{"openai_chat_completions", `{"messages":[{"role":"user","content":"old"},{"role":"assistant","content":"assistant turn"},{"role":"user","content":[{"type":"text","text":"最新😀"}]}]}`, "最新😀", 1},
 		{"openai_responses", `{"input":[{"role":"user","content":[{"type":"input_text","text":"response text"}]}]}`, "response text", 1},
 		{"anthropic_messages", `{"messages":[{"role":"user","content":[{"type":"text","text":"claude"}]}]}`, "claude", 1},
 		{"gemini", `{"contents":[{"role":"user","parts":[{"text":"gemini"},{"inline_data":{"data":"BASE64"}}]}]}`, "gemini", 1},
@@ -118,12 +118,12 @@ func TestPromptSnapshotLatestUserTextBlockIsOnePrioritizedSegment(t *testing.T) 
 	}`)
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: body})
 	require.NoError(t, err)
-	require.Equal(t, 5, snapshot.MessageCount)
-	require.True(t, strings.HasPrefix(snapshot.ScanText, "最新第二块é"+promptAuditPrioritySeparator))
+	require.Equal(t, 1, snapshot.MessageCount)
+	require.Equal(t, "最新第一块😀\n\n最新第二块é", snapshot.ScanText)
 	require.Contains(t, snapshot.ScanText, "最新第一块😀")
-	require.Contains(t, snapshot.ScanText, "历史输入")
-	require.Contains(t, snapshot.ScanText, "assistant client injection")
-	require.Contains(t, snapshot.ScanText, "tool client injection")
+	require.NotContains(t, snapshot.ScanText, "历史输入")
+	require.NotContains(t, snapshot.ScanText, "assistant client injection")
+	require.NotContains(t, snapshot.ScanText, "tool client injection")
 	require.NotContains(t, snapshot.ScanText, "IMAGE_CANARY_BASE64")
 	require.Equal(t, utf8.RuneCountInString(metadataTextForTest(snapshot.ScanText)), snapshot.PromptLength)
 }
@@ -140,14 +140,13 @@ func TestPromptSnapshotSeparatesAnthropicUserPromptFromHarnessBlocks(t *testing.
 
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "anthropic_messages", Body: body})
 	require.NoError(t, err)
-	require.Equal(t, 4, snapshot.MessageCount)
-	require.True(t, strings.HasPrefix(snapshot.ScanText, latest+promptAuditPrioritySeparator))
-	require.True(t, strings.HasPrefix(snapshot.RedactedPreview, "请帮我编写一篇黄色小说"))
+	require.Equal(t, 2, snapshot.MessageCount)
+	require.Contains(t, snapshot.ScanText, latest)
+	require.Contains(t, snapshot.ScanText, "system policy")
 
 	chunks := SplitRunes(snapshot.ScanText, 128)
-	require.Equal(t, latest, chunks[0])
-	require.Contains(t, strings.Join(chunks[1:], ""), "# AGENTS.md instructions")
-	require.Contains(t, strings.Join(chunks[1:], ""), "<environment_context>")
+	require.Contains(t, strings.Join(chunks, ""), "# AGENTS.md instructions")
+	require.Contains(t, strings.Join(chunks, ""), "<environment_context>")
 	require.NotContains(t, strings.Join(chunks, ""), promptAuditPrioritySeparator)
 }
 
@@ -158,7 +157,7 @@ func TestPromptSnapshotResponsesShapes(t *testing.T) {
 		want string
 	}{
 		{name: "string", body: `{"input":"plain response input"}`, want: "plain response input"},
-		{name: "message array", body: `{"input":[{"role":"assistant","content":"assistant turn"},{"role":"user","content":[{"type":"input_text","text":"message block"}]}]}`, want: "message block\n\nassistant turn"},
+		{name: "message array", body: `{"input":[{"role":"assistant","content":"assistant turn"},{"role":"user","content":[{"type":"input_text","text":"message block"}]}]}`, want: "message block"},
 		{name: "direct input text", body: `{"input":[{"type":"input_text","text":"direct block"}]}`, want: "direct block"},
 		{name: "single object", body: `{"input":{"role":"user","content":[{"type":"input_text","text":"single object"}]}}`, want: "single object"},
 	}
@@ -183,11 +182,9 @@ func TestPromptSnapshotGeminiBatchShapesAndMediaExclusion(t *testing.T) {
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "gemini", Body: body})
 	require.NoError(t, err)
 	require.True(t, strings.HasPrefix(snapshot.ScanText, "nested instance"))
-	for _, expected := range []string{"root content", "instance prompt", "nested user", "nested instance"} {
-		require.Contains(t, snapshot.ScanText, expected)
-	}
+	require.Equal(t, "nested instance", snapshot.ScanText)
 	require.NotContains(t, snapshot.ScanText, "ROOT_BASE64")
-	require.Contains(t, snapshot.ScanText, "ignore model")
+	require.NotContains(t, snapshot.ScanText, "ignore model")
 }
 
 func TestPromptSnapshotMediaOnlyExtractsDeterministicTextPrompts(t *testing.T) {
@@ -200,7 +197,7 @@ func TestPromptSnapshotMediaOnlyExtractsDeterministicTextPrompts(t *testing.T) {
 	}`)
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "grok_media", Body: body})
 	require.NoError(t, err)
-	require.Equal(t, 4, snapshot.MessageCount)
+	require.Equal(t, 1, snapshot.MessageCount)
 	for _, expected := range []string{"draw a lighthouse", "no fog", "ocean song", "nested textual direction"} {
 		require.Contains(t, snapshot.ScanText, expected)
 	}
@@ -246,16 +243,32 @@ func TestPromptSnapshotEmptyAndLongUnicodeInput(t *testing.T) {
 	}
 }
 
+func TestPromptSnapshotSelectedUnicodeTextSplitsWithoutTruncation(t *testing.T) {
+	latest := strings.Repeat("最新😀é", 90)
+	system := strings.Repeat("系统约束。", 90)
+	body := []byte(`{"messages":[{"role":"system","content":` + string(mustJSON(t, system)) + `},{"role":"user","content":"old user"},{"role":"user","content":` + string(mustJSON(t, latest)) + `}]}`)
+	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: body})
+	require.NoError(t, err)
+	require.Equal(t, latest+"\n\n"+system, snapshot.FullPrompt)
+
+	chunks := SplitRunes(snapshot.ScanText, 127)
+	require.Equal(t, strings.ReplaceAll(snapshot.ScanText, promptAuditPrioritySeparator, ""), strings.Join(chunks, ""))
+	for _, chunk := range chunks {
+		require.LessOrEqual(t, len([]rune(chunk)), 127)
+		require.True(t, utf8.ValidString(chunk))
+	}
+}
+
 func TestPromptSnapshotIncludesClientControlledInstructions(t *testing.T) {
 	tests := []struct {
 		name, protocol, body string
 		want                 []string
 	}{
 		{
-			name:     "openai system developer assistant tool",
+			name:     "openai subsequent turn keeps latest user only",
 			protocol: "openai_chat_completions",
-			body:     `{"messages":[{"role":"system","content":"system jailbreak"},{"role":"developer","content":"developer policy"},{"role":"assistant","content":"assistant jailbreak"},{"role":"tool","content":"tool payload"},{"role":"user","content":"hello"}]}`,
-			want:     []string{"system jailbreak", "developer policy", "assistant jailbreak", "tool payload", "hello"},
+			body:     `{"messages":[{"role":"system","content":"system jailbreak"},{"role":"developer","content":"developer policy"},{"role":"assistant","content":"assistant jailbreak"},{"role":"tool","content":"old tool payload"},{"role":"user","content":"hello"}]}`,
+			want:     []string{"hello"},
 		},
 		{
 			name:     "openai system only",
@@ -289,8 +302,101 @@ func TestPromptSnapshotIncludesClientControlledInstructions(t *testing.T) {
 			for _, expected := range tt.want {
 				require.Contains(t, snapshot.ScanText, expected)
 			}
+			if tt.name == "openai subsequent turn keeps latest user only" {
+				for _, excluded := range []string{"system jailbreak", "developer policy", "assistant jailbreak", "old tool payload"} {
+					require.NotContains(t, snapshot.ScanText, excluded)
+				}
+			}
 		})
 	}
+}
+
+func TestPromptSnapshotConversationTurnSelectionByProtocol(t *testing.T) {
+	tests := []struct {
+		name, protocol, stage, body, want string
+		excluded                          []string
+	}{
+		{
+			name:     "chat first turn",
+			protocol: "openai_chat_completions",
+			body:     `{"messages":[{"role":"system","content":"chat system"},{"role":"developer","content":"chat developer"},{"role":"user","content":"old user"},{"role":"user","content":[{"type":"text","text":"latest one"},{"type":"text","text":"latest two"}]}]}`,
+			want:     "latest one\n\nlatest two\n\nchat system\n\nchat developer",
+			excluded: []string{"old user"},
+		},
+		{
+			name:     "chat subsequent turn",
+			protocol: "openai_chat_completions",
+			body:     `{"messages":[{"role":"system","content":"chat system"},{"role":"user","content":"old user"},{"role":"assistant","content":"old assistant"},{"role":"user","content":"latest user"},{"role":"tool","content":"tool one"},{"role":"tool","content":"tool two"}]}`,
+			want:     "latest user\n\ntool one\n\ntool two",
+			excluded: []string{"chat system", "old user", "old assistant"},
+		},
+		{
+			name:     "responses first turn",
+			protocol: "openai_responses",
+			body:     `{"instructions":"response instructions","input":[{"role":"user","content":"old user"},{"role":"user","content":[{"type":"input_text","text":"latest response"}]}]}`,
+			want:     "latest response\n\nresponse instructions",
+			excluded: []string{"old user"},
+		},
+		{
+			name:     "responses subsequent turn",
+			protocol: "openai_responses",
+			body:     `{"instructions":"response instructions","input":[{"role":"user","content":"old user"},{"role":"assistant","content":"old assistant"},{"role":"user","content":"latest response"},{"type":"function_call","name":"dangerous","arguments":"CALL_ARGUMENTS_CANARY"},{"type":"function_call_output","call_id":"call_1","output":"response tool output"}]}`,
+			want:     "latest response\n\nresponse tool output",
+			excluded: []string{"response instructions", "old user", "old assistant", "CALL_ARGUMENTS_CANARY"},
+		},
+		{
+			name:     "anthropic subsequent turn",
+			protocol: "anthropic_messages",
+			body:     `{"system":"anthropic system","messages":[{"role":"user","content":"old user"},{"role":"assistant","content":"old assistant"},{"role":"user","content":"latest anthropic"},{"role":"assistant","content":[{"type":"tool_use","name":"dangerous","input":{"secret":"TOOL_INPUT_CANARY"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_1","content":[{"type":"text","text":"anthropic tool output"}]}]}]}`,
+			want:     "latest anthropic\n\nanthropic tool output",
+			excluded: []string{"anthropic system", "old user", "old assistant", "TOOL_INPUT_CANARY"},
+		},
+		{
+			name:     "gemini subsequent turn",
+			protocol: "gemini",
+			body:     `{"systemInstruction":{"parts":[{"text":"gemini system"}]},"contents":[{"role":"user","parts":[{"text":"old user"}]},{"role":"model","parts":[{"text":"old model"},{"functionCall":{"name":"dangerous","args":{"secret":"FUNCTION_ARGUMENTS_CANARY"}}}]},{"role":"user","parts":[{"text":"latest gemini"}]},{"role":"user","parts":[{"functionResponse":{"name":"dangerous","response":{"result":"gemini tool output","data":"gemini data text","image":"data:image/png;base64,IMAGE_CANARY","binary":"QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo="}}}]}]}`,
+			want:     "latest gemini\n\ngemini data text\n\ngemini tool output",
+			excluded: []string{"gemini system", "old user", "old model", "FUNCTION_ARGUMENTS_CANARY", "IMAGE_CANARY"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			snapshot, err := ExtractPromptSnapshot(Request{Protocol: tt.protocol, Stage: tt.stage, Body: []byte(tt.body)})
+			require.NoError(t, err)
+			require.Equal(t, tt.want, metadataTextForTest(snapshot.ScanText))
+			require.Equal(t, snapshot.FullPrompt, metadataTextForTest(snapshot.ScanText))
+			for _, excluded := range tt.excluded {
+				require.NotContains(t, snapshot.ScanText, excluded)
+				require.NotContains(t, snapshot.FullPrompt, excluded)
+			}
+		})
+	}
+}
+
+func TestPromptSnapshotWebSocketStageOverridesHistoryDetection(t *testing.T) {
+	body := []byte(`{"type":"response.create","response":{"instructions":"websocket system","input":[{"role":"assistant","content":"old assistant"},{"role":"user","content":"latest websocket"}]}}`)
+	first, err := ExtractPromptSnapshot(Request{Protocol: "responses_websocket", Stage: "first_turn", Body: body})
+	require.NoError(t, err)
+	require.Equal(t, "latest websocket\n\nwebsocket system", metadataTextForTest(first.ScanText))
+
+	subsequent, err := ExtractPromptSnapshot(Request{Protocol: "responses_websocket", Stage: "subsequent_turn", Body: body})
+	require.NoError(t, err)
+	require.Equal(t, "latest websocket", subsequent.ScanText)
+}
+
+func TestPromptSnapshotToolResultWithoutUserAndAssistantHistoryOnly(t *testing.T) {
+	toolOnly, err := ExtractPromptSnapshot(Request{
+		Protocol: "openai_responses",
+		Body:     []byte(`{"input":[{"type":"function_call_output","call_id":"call_1","output":"standalone tool output"}]}`),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "standalone tool output", toolOnly.ScanText)
+
+	_, err = ExtractPromptSnapshot(Request{
+		Protocol: "openai_chat_completions",
+		Body:     []byte(`{"messages":[{"role":"assistant","content":"history only"}]}`),
+	})
+	require.ErrorIs(t, err, ErrNoPromptText)
 }
 
 func TestBuildPromptPreviewWithholdsMajorityOfOrdinaryText(t *testing.T) {


### PR DESCRIPTION
当前问题：多轮对话，重复审计已审计内容，造成重复审计/排队/浪费算力等

## Summary

将 Qwen3Guard 输入从“请求体内所有角色文本”改为按当前对话轮次筛选：

- 首轮：所有 system 等价指令 + 最新一条 user 消息。
- 后续轮：最新一条 user 消息 + 该 user 之后的当前轮工具结果。
- 选中内容不截断；超过节点 `input_limit` 时继续按 Unicode 字符分片发送。

## Implementation Changes

- 重构 `backend/internal/securityaudit/prompt_snapshot.go` 的协议提取结果，保留语义角色与消息归属，而非仅以 `user bool` 标记文本。
- 首轮判断：
  - WebSocket 的 `first_turn` / `subsequent_turn` 阶段优先作为确定信号。
  - 普通 HTTP 请求中，存在 assistant/model 历史或已识别工具结果即判定为后续轮；否则判定为首轮。
- 首轮仅保留 system 等价文本（`system`、`developer`、OpenAI `instructions`、Anthropic `system`、Gemini `systemInstruction`）和最后一个 user 消息的全部文本块。
- 后续轮仅保留最后一个 user 消息的全部文本块，以及它之后出现的工具结果；历史 user、assistant/model 文本、工具调用参数与早期工具结果全部排除。
- 覆盖原生工具结果的文本提取：
  - Chat Completions：`role: tool` 的 `content`
  - Responses：`function_call_output.output`
  - Anthropic：`tool_result.content`
  - Gemini：`functionResponse.response` 的文本值
  仅提取工具结果中的文本，不发送图片、二进制、data URL 或工具调用参数。
- 保持最新 user 消息作为首个优先扫描段；其余被选中的 system 或工具结果按原始顺序拼接。现有 `SplitRunes` 继续将选中内容按 `input_limit` 分片，命中 `Block` 或扫描失败后停止后续分片。
- 审计事件的哈希、预览、完整提示词、长度和 Redis 临时 payload 均改为反映筛选后的内容。

## Test Plan

- 为 Chat、Responses、Anthropic、Gemini 分别覆盖首轮和后续轮，断言只保留指定 system 等价指令、最新 user 消息和当前轮工具结果。
- 覆盖多文本块 user 消息、多个并行工具结果、无 user 的工具结果轮、仅 assistant 历史、图片/二进制工具内容，以及 WebSocket 首轮/后续阶段。
- 验证历史 system、历史 user、assistant/model 内容和早期工具结果不会进入快照、Redis payload 或 Qwen3Guard 扫描调用。
- 验证筛选后的超长 user/system/tool 文本按 `input_limit` 完整分片，Unicode 不损坏，且阻断仍停止后续分片。
- 运行 `go test ./internal/securityaudit ./internal/handler ./internal/server/routes`，并执行 `git diff --check`。

## Assumptions

- 普通 HTTP 的“首轮”按本次请求的历史角色结构判断；客户端若每轮只重复发送 `system + user` 而不携带 assistant/tool 历史，无法识别其为同一会话，会按首轮处理。
- `developer`、`instructions` 与各协议 system 指令按 system 等价内容处理，仅首轮发送。
