### PR TITLE
fix(auth): register synthetic DingTalk users

### DIFF
--- a/backend/internal/handler/auth_oauth_pending_flow.go
+++ b/backend/internal/handler/auth_oauth_pending_flow.go
@@ -1937,6 +1937,59 @@ func (h *AuthHandler) ExchangePendingOAuthCompletion(c *gin.Context) {
 	}
 	applySuggestedProfileToCompletionResponse(payload, session.UpstreamIdentityClaims)
 
+	if pendingDingTalkSyntheticSignup(session, payload) {
+		if err := h.ensureBackendModeAllowsNewUserLogin(c.Request.Context()); err != nil {
+			response.ErrorFrom(c, err)
+			return
+		}
+
+		email := strings.TrimSpace(session.ResolvedEmail)
+		username := pendingSessionStringValue(session.UpstreamIdentityClaims, "username")
+		if username == "" {
+			username = strings.TrimSuffix(strings.TrimPrefix(email, "dingtalk-"), service.DingTalkConnectSyntheticEmailDomain)
+		}
+		tokenPair, user, err := h.authService.LoginOrRegisterOAuthWithTokenPairAndPromoCode(
+			c.Request.Context(),
+			email,
+			username,
+			"",
+			"",
+			pendingOAuthPromoCode(session),
+			"dingtalk",
+		)
+		if err != nil {
+			response.ErrorFrom(c, err)
+			return
+		}
+		decision, err := h.ensurePendingOAuthAdoptionDecision(c, session.ID, adoptionDecision)
+		if err != nil {
+			response.ErrorFrom(c, err)
+			return
+		}
+		if err := applyPendingOAuthAdoptionAndConsumeSession(
+			c.Request.Context(),
+			h.entClient(),
+			h.authService,
+			h.userService,
+			session,
+			decision,
+			user.ID,
+		); err != nil {
+			respondPendingOAuthBindingApplyError(c, err)
+			return
+		}
+
+		h.authService.RecordSuccessfulLogin(c.Request.Context(), user.ID)
+		h.maybeSyncDingTalkAfterRegistration(c.Request.Context(), session, user.ID)
+		payload["access_token"] = tokenPair.AccessToken
+		payload["refresh_token"] = tokenPair.RefreshToken
+		payload["expires_in"] = tokenPair.ExpiresIn
+		payload["token_type"] = "Bearer"
+		clearCookies()
+		response.Success(c, payload)
+		return
+	}
+
 	canIssueTokenPair := pendingOAuthCompletionCanIssueTokenPair(session, payload)
 	var loginUser *service.User
 	if canIssueTokenPair {
@@ -2037,4 +2090,19 @@ func (h *AuthHandler) ExchangePendingOAuthCompletion(c *gin.Context) {
 
 	clearCookies()
 	response.Success(c, payload)
+}
+
+func pendingDingTalkSyntheticSignup(session *dbent.PendingAuthSession, payload map[string]any) bool {
+	if session == nil || session.TargetUserID != nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(session.ProviderType), "dingtalk") {
+		return false
+	}
+	email := strings.ToLower(strings.TrimSpace(session.ResolvedEmail))
+	syntheticEmail, _ := payload["synthetic_email"].(string)
+	return email != "" &&
+		email == strings.ToLower(strings.TrimSpace(syntheticEmail)) &&
+		strings.HasPrefix(email, "dingtalk-") &&
+		strings.HasSuffix(email, service.DingTalkConnectSyntheticEmailDomain)
 }

--- a/backend/internal/handler/auth_oauth_pending_flow_test.go
+++ b/backend/internal/handler/auth_oauth_pending_flow_test.go
@@ -538,6 +538,86 @@ func TestExchangePendingOAuthCompletionLoginFalseFalseBindsIdentityWithoutAdopti
 	require.NotNil(t, storedSession.ConsumedAt)
 }
 
+func TestExchangePendingOAuthCompletionRegistersDingTalkSyntheticUser(t *testing.T) {
+	handler, client := newOAuthPendingFlowTestHandlerWithDependencies(t, oauthPendingFlowTestHandlerOptions{
+		dingTalkConfig: config.DingTalkConnectConfig{
+			ClientID:            "test-client",
+			ClientSecret:        "test-secret",
+			AuthorizeURL:        "https://example.com/oauth2/auth",
+			TokenURL:            "https://example.com/oauth2/token",
+			UserInfoURL:         "https://example.com/oauth2/userinfo",
+			RedirectURL:         "https://example.com/callback",
+			FrontendRedirectURL: "https://example.com/auth/callback",
+			DingTalkAppKind:     "internal_app",
+			AppType:             "internal",
+		},
+		settingValues: map[string]string{
+			service.SettingKeyRegistrationEnabled:                  "false",
+			service.SettingKeyDingTalkConnectEnabled:               "true",
+			service.SettingKeyDingTalkConnectBypassRegistration:    "true",
+			service.SettingKeyDingTalkConnectCorpRestrictionPolicy: "internal_only",
+		},
+	})
+	ctx := context.Background()
+	email := "dingtalk-new-user@dingtalk-connect.invalid"
+
+	session, err := client.PendingAuthSession.Create().
+		SetSessionToken("dingtalk-synthetic-session-token").
+		SetIntent("login").
+		SetProviderType("dingtalk").
+		SetProviderKey("dingtalk").
+		SetProviderSubject("new-user").
+		SetResolvedEmail(email).
+		SetBrowserSessionKey("dingtalk-synthetic-browser-session-key").
+		SetUpstreamIdentityClaims(map[string]any{
+			"username":               "DingTalk User",
+			"suggested_display_name": "DingTalk User",
+		}).
+		SetLocalFlowState(map[string]any{
+			oauthCompletionResponseKey: map[string]any{
+				"redirect":        "/dashboard",
+				"synthetic_email": email,
+			},
+		}).
+		SetExpiresAt(time.Now().UTC().Add(10 * time.Minute)).
+		Save(ctx)
+	require.NoError(t, err)
+
+	recorder := httptest.NewRecorder()
+	ginCtx, _ := gin.CreateTestContext(recorder)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/oauth/pending/exchange", bytes.NewBufferString(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: oauthPendingSessionCookieName, Value: encodeCookieValue(session.SessionToken)})
+	req.AddCookie(&http.Cookie{Name: oauthPendingBrowserCookieName, Value: encodeCookieValue(session.BrowserSessionKey)})
+	ginCtx.Request = req
+
+	handler.ExchangePendingOAuthCompletion(ginCtx)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	payload := decodeJSONResponseData(t, recorder)
+	require.NotEmpty(t, payload["access_token"])
+	require.Equal(t, "/dashboard", payload["redirect"])
+
+	userEntity, err := client.User.Query().Where(dbuser.EmailEQ(email)).Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "DingTalk User", userEntity.Username)
+	require.Equal(t, "dingtalk", userEntity.SignupSource)
+
+	identity, err := client.AuthIdentity.Query().
+		Where(
+			authidentity.ProviderTypeEQ("dingtalk"),
+			authidentity.ProviderKeyEQ("dingtalk"),
+			authidentity.ProviderSubjectEQ("new-user"),
+		).
+		Only(ctx)
+	require.NoError(t, err)
+	require.Equal(t, userEntity.ID, identity.UserID)
+
+	storedSession, err := client.PendingAuthSession.Get(ctx, session.ID)
+	require.NoError(t, err)
+	require.NotNil(t, storedSession.ConsumedAt)
+}
+
 func TestExchangePendingOAuthCompletionLoginReassignsExistingDecisionIdentityReference(t *testing.T) {
 	handler, client := newOAuthPendingFlowTestHandler(t, false)
 	ctx := context.Background()
@@ -2375,6 +2455,7 @@ type oauthPendingFlowTestHandlerOptions struct {
 	totpCache          service.TotpCache
 	totpEncryptor      service.SecretEncryptor
 	userRepoOptions    oauthPendingFlowUserRepoOptions
+	dingTalkConfig     config.DingTalkConnectConfig
 }
 
 func newOAuthPendingFlowTestHandlerWithDependencies(
@@ -2441,6 +2522,7 @@ CREATE TABLE IF NOT EXISTS user_affiliates (
 			UserBalance:     0,
 			UserConcurrency: 1,
 		},
+		DingTalk: options.dingTalkConfig,
 	}
 	settingValues := map[string]string{
 		service.SettingKeyRegistrationEnabled:              "true",


### PR DESCRIPTION
## Summary

- auto-register DingTalk synthetic-email users during pending OAuth exchange
- bind the DingTalk identity and consume the pending session before returning tokens
- cover the `registration_enabled=false` + `internal_only` bypass flow

## Problem

With `dingtalk_connect.require_email=false`, the callback creates a login pending session with a synthetic email but no target user. The pending exchange then attempts identity adoption without a user and returns `PENDING_AUTH_ADOPTION_APPLY_FAILED`.

## Testing

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`