### PR TITLE
fix(frontend): 修复首页公告弹窗显示异常问题

### DIFF
--- a/frontend/src/components/common/AnnouncementBell.vue
+++ b/frontend/src/components/common/AnnouncementBell.vue
@@ -322,6 +322,7 @@ import { useAnnouncementStore } from '@/stores/announcements'
 import { formatRelativeTime, formatRelativeWithDateTime } from '@/utils/format'
 import type { UserAnnouncement } from '@/types'
 import Icon from '@/components/icons/Icon.vue'
+import '@/styles/announcement-markdown.css'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -469,122 +470,5 @@ watch(
 
 .dark .overflow-y-auto::-webkit-scrollbar-thumb:hover {
   background: linear-gradient(to bottom, #6b7280, #4b5563);
-}
-</style>
-
-<style>
-/* Enhanced Markdown Styles */
-.markdown-body {
-  @apply text-[15px] leading-[1.75];
-  @apply text-gray-700 dark:text-gray-300;
-}
-
-.markdown-body h1 {
-  @apply mb-6 mt-8 border-b border-gray-200 pb-3 text-3xl font-bold text-gray-900 dark:border-dark-600 dark:text-white;
-}
-
-.markdown-body h2 {
-  @apply mb-4 mt-7 border-b border-gray-100 pb-2 text-2xl font-bold text-gray-900 dark:border-dark-700 dark:text-white;
-}
-
-.markdown-body h3 {
-  @apply mb-3 mt-6 text-xl font-semibold text-gray-900 dark:text-white;
-}
-
-.markdown-body h4 {
-  @apply mb-2 mt-5 text-lg font-semibold text-gray-900 dark:text-white;
-}
-
-.markdown-body p {
-  @apply mb-4 leading-relaxed;
-}
-
-.markdown-body a {
-  @apply font-medium text-blue-600 underline decoration-blue-600/30 decoration-2 underline-offset-2 transition-all hover:decoration-blue-600 dark:text-blue-400 dark:decoration-blue-400/30 dark:hover:decoration-blue-400;
-}
-
-.markdown-body ul,
-.markdown-body ol {
-  @apply mb-4 ml-6 space-y-2;
-}
-
-.markdown-body ul {
-  @apply list-disc;
-}
-
-.markdown-body ol {
-  @apply list-decimal;
-}
-
-.markdown-body li {
-  @apply leading-relaxed;
-  @apply pl-2;
-}
-
-.markdown-body li::marker {
-  @apply text-blue-600 dark:text-blue-400;
-}
-
-.markdown-body blockquote {
-  @apply relative my-5 border-l-4 border-blue-500 bg-blue-50/50 py-3 pl-5 pr-4 italic text-gray-700 dark:border-blue-400 dark:bg-blue-900/10 dark:text-gray-300;
-}
-
-.markdown-body blockquote::before {
-  content: '"';
-  @apply absolute -left-1 top-0 text-5xl font-serif text-blue-500/20 dark:text-blue-400/20;
-}
-
-.markdown-body code {
-  @apply rounded-lg bg-gray-100 px-2 py-1 text-[13px] font-mono text-pink-600 dark:bg-dark-700 dark:text-pink-400;
-}
-
-.markdown-body pre {
-  @apply my-5 overflow-x-auto rounded-xl border border-gray-200 bg-gray-50 p-5 dark:border-dark-600 dark:bg-dark-900/50;
-}
-
-.markdown-body pre code {
-  @apply bg-transparent p-0 text-[13px] text-gray-800 dark:text-gray-200;
-}
-
-.markdown-body hr {
-  @apply my-8 border-0 border-t-2 border-gray-200 dark:border-dark-700;
-}
-
-.markdown-body table {
-  @apply mb-5 w-full overflow-hidden rounded-lg border border-gray-200 dark:border-dark-600;
-}
-
-.markdown-body th,
-.markdown-body td {
-  @apply border-r border-b border-gray-200 px-4 py-3 text-left dark:border-dark-600;
-}
-
-.markdown-body th:last-child,
-.markdown-body td:last-child {
-  @apply border-r-0;
-}
-
-.markdown-body tr:last-child td {
-  @apply border-b-0;
-}
-
-.markdown-body th {
-  @apply bg-gradient-to-br from-blue-50 to-indigo-50 font-semibold text-gray-900 dark:from-blue-900/20 dark:to-indigo-900/10 dark:text-white;
-}
-
-.markdown-body tbody tr {
-  @apply transition-colors hover:bg-gray-50 dark:hover:bg-dark-700/30;
-}
-
-.markdown-body img {
-  @apply my-5 max-w-full rounded-xl border border-gray-200 shadow-md dark:border-dark-600;
-}
-
-.markdown-body strong {
-  @apply font-semibold text-gray-900 dark:text-white;
-}
-
-.markdown-body em {
-  @apply italic text-gray-600 dark:text-gray-400;
 }
 </style>

--- a/frontend/src/components/common/AnnouncementPopup.vue
+++ b/frontend/src/components/common/AnnouncementPopup.vue
@@ -90,6 +90,7 @@ import { marked } from 'marked'
 import DOMPurify from 'dompurify'
 import { useAnnouncementStore } from '@/stores/announcements'
 import { formatRelativeWithDateTime } from '@/utils/format'
+import '@/styles/announcement-markdown.css'
 
 const { t } = useI18n()
 const announcementStore = useAnnouncementStore()

--- a/frontend/src/components/common/__tests__/AnnouncementPopup.spec.ts
+++ b/frontend/src/components/common/__tests__/AnnouncementPopup.spec.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import AnnouncementPopup from '../AnnouncementPopup.vue'
+import { useAnnouncementStore } from '@/stores/announcements'
+
+const announcementMarkdownStyles = readFileSync(
+  resolve(process.cwd(), 'src/styles/announcement-markdown.css'),
+  'utf8',
+)
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+describe('AnnouncementPopup', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    document.body.style.overflow = ''
+  })
+
+  it('renders mixed Markdown and HTML inside the shared styled container', async () => {
+    const store = useAnnouncementStore()
+    store.currentPopup = {
+      id: 1,
+      title: 'Mixed content announcement',
+      content: [
+        '## Markdown heading',
+        '',
+        '<div><h3>HTML heading</h3><ul><li>HTML list item</li></ul></div>',
+        '',
+        '<table><thead><tr><th>Status</th></tr></thead><tbody><tr><td>OK</td></tr></tbody></table>',
+        '<script>window.__announcementXss = true</script>',
+      ].join('\n'),
+      notify_mode: 'popup',
+      created_at: '2026-07-24T07:30:00Z',
+      updated_at: '2026-07-24T07:30:00Z',
+    }
+
+    const wrapper = mount(AnnouncementPopup)
+    await wrapper.vm.$nextTick()
+
+    const content = document.body.querySelector('.markdown-body')
+    expect(content?.querySelector('h2')?.textContent).toBe('Markdown heading')
+    expect(content?.querySelector('h3')?.textContent).toBe('HTML heading')
+    expect(content?.querySelector('li')?.textContent).toBe('HTML list item')
+    expect(content?.querySelector('table td')?.textContent).toBe('OK')
+    expect(content?.querySelector('script')).toBeNull()
+
+    wrapper.unmount()
+  })
+
+  it.each(['h2', 'h3', 'ul', 'li', 'blockquote', 'table', 'th', 'td', 'code'])(
+    'loads a shared style rule for mixed-content <%s> elements',
+    (element) => {
+      expect(announcementMarkdownStyles).toContain(`.markdown-body ${element}`)
+    },
+  )
+})

--- a/frontend/src/styles/announcement-markdown.css
+++ b/frontend/src/styles/announcement-markdown.css
@@ -1,0 +1,113 @@
+/* Shared rich-text styles for announcement popup and bell detail content. */
+.markdown-body {
+  @apply text-[15px] leading-[1.75];
+  @apply text-gray-700 dark:text-gray-300;
+}
+
+.markdown-body h1 {
+  @apply mb-6 mt-8 border-b border-gray-200 pb-3 text-3xl font-bold text-gray-900 dark:border-dark-600 dark:text-white;
+}
+
+.markdown-body h2 {
+  @apply mb-4 mt-7 border-b border-gray-100 pb-2 text-2xl font-bold text-gray-900 dark:border-dark-700 dark:text-white;
+}
+
+.markdown-body h3 {
+  @apply mb-3 mt-6 text-xl font-semibold text-gray-900 dark:text-white;
+}
+
+.markdown-body h4 {
+  @apply mb-2 mt-5 text-lg font-semibold text-gray-900 dark:text-white;
+}
+
+.markdown-body p {
+  @apply mb-4 leading-relaxed;
+}
+
+.markdown-body a {
+  @apply font-medium text-blue-600 underline decoration-blue-600/30 decoration-2 underline-offset-2 transition-all hover:decoration-blue-600 dark:text-blue-400 dark:decoration-blue-400/30 dark:hover:decoration-blue-400;
+}
+
+.markdown-body ul,
+.markdown-body ol {
+  @apply mb-4 ml-6 space-y-2;
+}
+
+.markdown-body ul {
+  @apply list-disc;
+}
+
+.markdown-body ol {
+  @apply list-decimal;
+}
+
+.markdown-body li {
+  @apply pl-2 leading-relaxed;
+}
+
+.markdown-body li::marker {
+  @apply text-blue-600 dark:text-blue-400;
+}
+
+.markdown-body blockquote {
+  @apply relative my-5 border-l-4 border-blue-500 bg-blue-50/50 py-3 pl-5 pr-4 italic text-gray-700 dark:border-blue-400 dark:bg-blue-900/10 dark:text-gray-300;
+}
+
+.markdown-body blockquote::before {
+  content: '"';
+  @apply absolute -left-1 top-0 font-serif text-5xl text-blue-500/20 dark:text-blue-400/20;
+}
+
+.markdown-body code {
+  @apply rounded-lg bg-gray-100 px-2 py-1 font-mono text-[13px] text-pink-600 dark:bg-dark-700 dark:text-pink-400;
+}
+
+.markdown-body pre {
+  @apply my-5 overflow-x-auto rounded-xl border border-gray-200 bg-gray-50 p-5 dark:border-dark-600 dark:bg-dark-900/50;
+}
+
+.markdown-body pre code {
+  @apply bg-transparent p-0 text-[13px] text-gray-800 dark:text-gray-200;
+}
+
+.markdown-body hr {
+  @apply my-8 border-0 border-t-2 border-gray-200 dark:border-dark-700;
+}
+
+.markdown-body table {
+  @apply mb-5 w-full overflow-hidden rounded-lg border border-gray-200 dark:border-dark-600;
+}
+
+.markdown-body th,
+.markdown-body td {
+  @apply border-b border-r border-gray-200 px-4 py-3 text-left dark:border-dark-600;
+}
+
+.markdown-body th:last-child,
+.markdown-body td:last-child {
+  @apply border-r-0;
+}
+
+.markdown-body tr:last-child td {
+  @apply border-b-0;
+}
+
+.markdown-body th {
+  @apply bg-gradient-to-br from-blue-50 to-indigo-50 font-semibold text-gray-900 dark:from-blue-900/20 dark:to-indigo-900/10 dark:text-white;
+}
+
+.markdown-body tbody tr {
+  @apply transition-colors hover:bg-gray-50 dark:hover:bg-dark-700/30;
+}
+
+.markdown-body img {
+  @apply my-5 max-w-full rounded-xl border border-gray-200 shadow-md dark:border-dark-600;
+}
+
+.markdown-body strong {
+  @apply font-semibold text-gray-900 dark:text-white;
+}
+
+.markdown-body em {
+  @apply italic text-gray-600 dark:text-gray-400;
+}


### PR DESCRIPTION
## 问题说明

修复首页与管理控制台中公告弹窗样式不一致的问题。

当公告内容同时包含 Markdown 和原生 HTML 元素时，例如标题、列表、引用块、表格或行内代码，直接在 `/home` 打开公告会出现排版错乱；进入管理控制台后，同一条公告的样式又会恢复正常。

## 问题原因

公告正文使用 `.markdown-body` 进行富文本排版，但相关全局样式原本定义在 `AnnouncementBell.vue` 中。

`AnnouncementBell` 只会随已登录控制台布局加载，因此：

1. 直接访问 `/home` 时，公告正文样式尚未加载。
2. 部分 HTML 元素会受到 Tailwind 基础重置样式影响，出现标题被压平、列表符号消失、表格无样式等问题。
3. 进入管理控制台后，`AnnouncementBell` 被加载并注入全局样式，因此同一条公告的显示效果发生变化。

## 修复方式

- 将公告富文本样式提取到独立的共享样式文件。
- 在以下两个公告组件中显式加载共享样式：
- `AnnouncementPopup.vue`
- `AnnouncementBell.vue`
- 保持现有公告视觉设计不变。
- 新增 Markdown 与原生 HTML 混排场景的回归测试。
- 验证 DOMPurify 仍会过滤不安全的 `<script>` 内容。

修复后，无论首先访问首页还是管理控制台，公告弹窗都会使用同一套富文本样式。

## 复现步骤

1. 创建一条弹窗公告。
2. 在公告内容中混合使用 Markdown 和 HTML，例如 `<h3>`、`<ul>`、`<blockquote>` 或 `<table>`。
3. 登录后直接访问 `/home` 并查看公告。
4. 进入管理控制台后再次查看同一公告。
5. 修复前，两处的富文本排版会出现差异。

## 验证结果

已通过以下检查：

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm test:run -- src/components/common/__tests__/AnnouncementPopup.spec.ts`

新增的回归测试共 10 项，全部通过
<img width="726" height="493" alt="image" src="https://github.com/user-attachments/assets/3694a2dd-f5bf-486d-aaad-1a430b8a4426" />
