### PR TITLE
feat(channel): passthrough original model in wildcard mapping prefix mode

### DIFF
--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -397,16 +397,44 @@ func (c *channelCache) matchWildcard(groupID int64, platform, modelLower string)
 	return nil
 }
 
-// matchWildcardMapping 在通配符映射中查找匹配项（最先匹配到优先）
-func (c *channelCache) matchWildcardMapping(groupID int64, platform, modelLower string) string {
+// matchWildcardMapping 在通配符映射中查找匹配项（最先匹配到优先）。
+// model 是原始大小写的请求模型名，modelLower 是其小写形式（前缀匹配用）。
+func (c *channelCache) matchWildcardMapping(groupID int64, platform, model, modelLower string) string {
 	gpKey := channelGroupPlatformKey{groupID: groupID, platform: platform}
 	wildcards := c.wildcardMappingByGP[gpKey]
 	for _, wc := range wildcards {
 		if strings.HasPrefix(modelLower, wc.prefix) {
-			return wc.target
+			return resolveWildcardMappingTarget(wc, model)
 		}
 	}
 	return ""
+}
+
+// resolveWildcardMappingTarget 计算命中通配符映射后转发给上游的模型名。
+//
+// 当目标本身是通配符（以 "*" 结尾）时，保留具体的请求模型：把源前缀替换为
+// 目标前缀，其余部分沿用原始请求模型（保持大小写）。这样管理员配置
+// "deepseek-v4* → deepseek-v4*"（或 "deepseek-v4* → *"）后，调用
+// deepseek-v4-flash / deepseek-v4-pro 都会各自原样转发，而不是被写成固定的
+// 某一个上游模型，也不会把字面量 "deepseek-v4*" 发给上游。
+//
+// 目标为非通配符时保持原有行为：所有命中该前缀的请求都改写为同一个固定模型。
+func resolveWildcardMappingTarget(wc *wildcardMappingEntry, model string) string {
+	if !strings.HasSuffix(wc.target, "*") {
+		return wc.target
+	}
+	targetPrefix := wc.target[:len(wc.target)-1]
+	if targetPrefix == "" {
+		// 目标为裸 "*"：整体透传原始请求模型（等价于把请求模型直接作为上游模型）。
+		return model
+	}
+	// wc.prefix 是源前缀的小写形式；modelLower 已确认以它为前缀，ASCII 小写不改变
+	// 长度，因此可直接在原始 model 上按同长度切片，保留后缀的原始大小写。
+	suffix := model
+	if len(wc.prefix) <= len(model) {
+		suffix = model[len(wc.prefix):]
+	}
+	return targetPrefix + suffix
 }
 
 // lookupPricingAcrossPlatforms 在分组平台内查找模型定价。
@@ -430,7 +458,7 @@ func lookupPricingAcrossPlatforms(cache *channelCache, groupID int64, groupPlatf
 
 // lookupMappingAcrossPlatforms 在分组平台内查找模型映射。
 // 逻辑与 lookupPricingAcrossPlatforms 相同：先精确查找，再通配符。
-func lookupMappingAcrossPlatforms(cache *channelCache, groupID int64, groupPlatform, modelLower string) string {
+func lookupMappingAcrossPlatforms(cache *channelCache, groupID int64, groupPlatform, model, modelLower string) string {
 	for _, p := range matchingPlatforms(groupPlatform) {
 		key := channelModelKey{groupID: groupID, platform: p, model: modelLower}
 		if mapped, ok := cache.mappingByGroupModel[key]; ok {
@@ -438,7 +466,7 @@ func lookupMappingAcrossPlatforms(cache *channelCache, groupID int64, groupPlatf
 		}
 	}
 	for _, p := range matchingPlatforms(groupPlatform) {
-		if mapped := cache.matchWildcardMapping(groupID, p, modelLower); mapped != "" {
+		if mapped := cache.matchWildcardMapping(groupID, p, model, modelLower); mapped != "" {
 			return mapped
 		}
 	}
@@ -569,7 +597,7 @@ func resolveMapping(lk *channelLookup, groupID int64, model string) ChannelMappi
 	}
 
 	modelLower := strings.ToLower(model)
-	if mapped := lookupMappingAcrossPlatforms(lk.cache, groupID, lk.platform, modelLower); mapped != "" {
+	if mapped := lookupMappingAcrossPlatforms(lk.cache, groupID, lk.platform, model, modelLower); mapped != "" {
 		result.MappedModel = mapped
 		result.Mapped = true
 	}

--- a/backend/internal/service/channel_service_test.go
+++ b/backend/internal/service/channel_service_test.go
@@ -902,6 +902,117 @@ func TestResolveChannelMapping_WildcardFirstMatch(t *testing.T) {
 	require.Contains(t, []string{"target1", "target2"}, result.MappedModel)
 }
 
+// TestResolveChannelMapping_WildcardTargetPassthrough 验证：当通配符映射的目标
+// 也是通配符时，保留具体的请求模型作为上游模型（前缀匹配透传）。
+// 这样 "deepseek-v4* → deepseek-v4*" 下，deepseek-v4-flash 与 deepseek-v4-pro
+// 都能各自原样转发，而不是被写成固定模型或字面量 "deepseek-v4*"。
+func TestResolveChannelMapping_WildcardTargetPassthrough(t *testing.T) {
+	ch := Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{10},
+		ModelMapping: map[string]map[string]string{
+			"anthropic": {
+				"deepseek-v4*": "deepseek-v4*",
+			},
+		},
+	}
+	repo := makeStandardRepo(ch, map[int64]string{10: "anthropic"})
+	svc := newTestChannelService(repo)
+
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4"} {
+		result := svc.ResolveChannelMapping(context.Background(), 10, model)
+		require.True(t, result.Mapped, "model %q should be mapped", model)
+		require.Equal(t, model, result.MappedModel, "model %q should pass through verbatim", model)
+	}
+}
+
+// TestResolveChannelMapping_WildcardTargetBareStar 验证目标为裸 "*" 时整体透传。
+func TestResolveChannelMapping_WildcardTargetBareStar(t *testing.T) {
+	ch := Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{10},
+		ModelMapping: map[string]map[string]string{
+			"anthropic": {
+				"deepseek-v4*": "*",
+			},
+		},
+	}
+	repo := makeStandardRepo(ch, map[int64]string{10: "anthropic"})
+	svc := newTestChannelService(repo)
+
+	result := svc.ResolveChannelMapping(context.Background(), 10, "deepseek-v4-pro")
+	require.True(t, result.Mapped)
+	require.Equal(t, "deepseek-v4-pro", result.MappedModel)
+}
+
+// TestResolveChannelMapping_WildcardTargetPrefixRewrite 验证目标通配符会做前缀替换：
+// 源前缀被替换为目标前缀，其余部分沿用请求模型。
+func TestResolveChannelMapping_WildcardTargetPrefixRewrite(t *testing.T) {
+	ch := Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{10},
+		ModelMapping: map[string]map[string]string{
+			"anthropic": {
+				"deepseek-*": "ds-*",
+			},
+		},
+	}
+	repo := makeStandardRepo(ch, map[int64]string{10: "anthropic"})
+	svc := newTestChannelService(repo)
+
+	result := svc.ResolveChannelMapping(context.Background(), 10, "deepseek-v4-flash")
+	require.True(t, result.Mapped)
+	require.Equal(t, "ds-v4-flash", result.MappedModel)
+}
+
+// TestResolveChannelMapping_WildcardTargetPreservesSuffixCase 验证透传时保留请求模型
+// 后缀的原始大小写（前缀部分沿用管理员在目标里配置的写法）。
+func TestResolveChannelMapping_WildcardTargetPreservesSuffixCase(t *testing.T) {
+	ch := Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{10},
+		ModelMapping: map[string]map[string]string{
+			"anthropic": {
+				"deepseek-v4*": "deepseek-v4*",
+			},
+		},
+	}
+	repo := makeStandardRepo(ch, map[int64]string{10: "anthropic"})
+	svc := newTestChannelService(repo)
+
+	// 大小写不敏感命中前缀；后缀 "-Flash" 的大小写按请求原样保留。
+	result := svc.ResolveChannelMapping(context.Background(), 10, "deepseek-v4-Flash")
+	require.True(t, result.Mapped)
+	require.Equal(t, "deepseek-v4-Flash", result.MappedModel)
+}
+
+// TestResolveChannelMapping_WildcardTargetExactUnchanged 验证目标为非通配符时行为不变：
+// 命中同一前缀的所有请求都改写为固定模型。
+func TestResolveChannelMapping_WildcardTargetExactUnchanged(t *testing.T) {
+	ch := Channel{
+		ID:       1,
+		Status:   StatusActive,
+		GroupIDs: []int64{10},
+		ModelMapping: map[string]map[string]string{
+			"anthropic": {
+				"deepseek-v4*": "deepseek-v4-flash",
+			},
+		},
+	}
+	repo := makeStandardRepo(ch, map[int64]string{10: "anthropic"})
+	svc := newTestChannelService(repo)
+
+	for _, model := range []string{"deepseek-v4-flash", "deepseek-v4-pro"} {
+		result := svc.ResolveChannelMapping(context.Background(), 10, model)
+		require.True(t, result.Mapped)
+		require.Equal(t, "deepseek-v4-flash", result.MappedModel)
+	}
+}
+
 func TestResolveChannelMapping_NoMapping(t *testing.T) {
 	ch := Channel{
 		ID:       1,

--- a/frontend/src/i18n/locales/en/admin/channels.ts
+++ b/frontend/src/i18n/locales/en/admin/channels.ts
@@ -135,7 +135,7 @@ export default {
         tierLabel: 'Tier',
         resolution: 'Resolution',
         modelMapping: 'Model Mapping',
-        modelMappingHint: 'Map request model names to actual model names. Runs before account-level mapping.',
+        modelMappingHint: 'Map request model names to actual model names. Runs before account-level mapping. Both source and target support a trailing wildcard *: when the target is also a wildcard (e.g. deepseek-v4* → deepseek-v4*, or just *), the concrete requested model is preserved as the upstream model (deepseek-v4-flash and deepseek-v4-pro each forward verbatim).',
         noMappingRules: 'No mapping rules. Click "Add" to create one.',
         mappingSource: 'Source model',
         mappingTarget: 'Target model',

--- a/frontend/src/i18n/locales/zh/admin/channels.ts
+++ b/frontend/src/i18n/locales/zh/admin/channels.ts
@@ -135,7 +135,7 @@ export default {
         tierLabel: '层级',
         resolution: '分辨率',
         modelMapping: '模型映射',
-        modelMappingHint: '将请求中的模型名映射为实际模型名。在账号级别映射之前执行。',
+        modelMappingHint: '将请求中的模型名映射为实际模型名。在账号级别映射之前执行。源和目标都支持末尾通配符 *：当目标也是通配符时（如 deepseek-v4* → deepseek-v4*，或直接填 *），会保留具体请求模型作为上游模型（deepseek-v4-flash、deepseek-v4-pro 各自原样转发）。',
         noMappingRules: '暂无映射规则，点击"添加"创建',
         mappingSource: '源模型',
         mappingTarget: '目标模型',


### PR DESCRIPTION
## 背景 / Motivation

渠道（channel）模型映射支持源前缀通配符（`deepseek-v4*`），但命中通配符规则时总是转发**固定的**目标字符串。若把目标也设为通配符（`deepseek-v4* → deepseek-v4*`），当前会把字面量 `deepseek-v4*` 发给上游——因此一条前缀匹配规则无法让每个具体模型各自路由到自身。

Composite / prefix-match routing needs a way to keep the concrete requested model as the upstream model, so a single rule like `deepseek-v4*` can serve both `deepseek-v4-flash` and `deepseek-v4-pro`.

## 改动 / Change

当映射目标本身是通配符（以 `*` 结尾）时，通过前缀替换保留具体请求模型作为上游模型：

- `deepseek-v4* → deepseek-v4*`：`deepseek-v4-flash` / `deepseek-v4-pro` 各自原样转发
- `deepseek-v4* → *`：整体透传请求模型
- `deepseek-* → ds-*`：前缀替换，保留请求后缀（`deepseek-v4-flash → ds-v4-flash`）

非通配符目标保持原有「固定改写」行为，**完全向后兼容**。请求后缀的大小写按原样保留。同时更新了渠道模型映射的中/英文提示文案。

## 影响面 / Scope

- `backend/internal/service/channel_service.go`：`matchWildcardMapping` 新增 `resolveWildcardMappingTarget`，并把原始大小写模型名沿调用链透传。
- 计费不受影响：`channel_mapped` 计费基准本就按映射后的具体模型计费，透传后即为具体请求模型。

## 测试 / Tests

新增 `channel_service_test.go` 用例覆盖：通配符透传、裸 `*`、前缀替换、后缀大小写保留、非通配符目标不变。`go test -tags unit ./internal/service/` 全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)