### PR TITLE
feat(model): 支持 Claude Opus 5

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -78,6 +78,7 @@ const AntigravityGemini31ProAgentModel = "gemini-pro-agent"
 var DefaultAntigravityModelMapping = map[string]string{
 	// Claude 白名单
 	"claude-fable-5":             "claude-fable-5",           // 官方模型
+	"claude-opus-5":              "claude-opus-5",            // 官方模型
 	"claude-opus-4-8":            "claude-opus-4-8",          // 官方模型
 	"claude-opus-4-7":            "claude-opus-4-7",          // 官方模型
 	"claude-opus-4-6-thinking":   "claude-opus-4-6-thinking", // 官方模型
@@ -133,6 +134,7 @@ var DefaultBedrockModelMapping = map[string]string{
 	// Claude Fable
 	"claude-fable-5": "anthropic.claude-fable-5",
 	// Claude Opus
+	"claude-opus-5":            "us.anthropic.claude-opus-5",
 	"claude-opus-4-8":          "us.anthropic.claude-opus-4-8-v1",
 	"claude-opus-4-7":          "us.anthropic.claude-opus-4-7-v1",
 	"claude-opus-4-6-thinking": "us.anthropic.claude-opus-4-6-v1",

--- a/backend/internal/domain/constants_test.go
+++ b/backend/internal/domain/constants_test.go
@@ -30,6 +30,7 @@ func TestDefaultAntigravityModelMapping_ContainsNewClaudeModels(t *testing.T) {
 
 	cases := map[string]string{
 		"claude-fable-5":  "claude-fable-5",
+		"claude-opus-5":   "claude-opus-5",
 		"claude-opus-4-8": "claude-opus-4-8",
 	}
 	for from, want := range cases {
@@ -70,6 +71,7 @@ func TestDefaultBedrockModelMapping_ContainsNewClaudeModels(t *testing.T) {
 
 	cases := map[string]string{
 		"claude-fable-5":  "anthropic.claude-fable-5",
+		"claude-opus-5":   "us.anthropic.claude-opus-5",
 		"claude-opus-4-8": "us.anthropic.claude-opus-4-8-v1",
 	}
 	for from, want := range cases {

--- a/backend/internal/pkg/antigravity/claude_types.go
+++ b/backend/internal/pkg/antigravity/claude_types.go
@@ -161,6 +161,7 @@ var claudeModels = []modelDef{
 	{ID: "claude-opus-4-6-thinking", DisplayName: "Claude Opus 4.6 Thinking", CreatedAt: "2026-02-05T00:00:00Z"},
 	{ID: "claude-opus-4-7", DisplayName: "Claude Opus 4.7", CreatedAt: "2026-04-17T00:00:00Z"},
 	{ID: "claude-opus-4-8", DisplayName: "Claude Opus 4.8", CreatedAt: "2026-05-29T00:00:00Z"},
+	{ID: "claude-opus-5", DisplayName: "Claude Opus 5", CreatedAt: "2026-07-24T00:00:00Z"},
 	{ID: "claude-sonnet-4-6", DisplayName: "Claude Sonnet 4.6", CreatedAt: "2026-02-17T00:00:00Z"},
 }
 

--- a/backend/internal/pkg/antigravity/claude_types_test.go
+++ b/backend/internal/pkg/antigravity/claude_types_test.go
@@ -13,6 +13,7 @@ func TestDefaultModels_ContainsNewAndLegacyImageModels(t *testing.T) {
 
 	requiredIDs := []string{
 		"claude-fable-5",
+		"claude-opus-5",
 		"claude-opus-4-8",
 		"claude-opus-4-6-thinking",
 		"gemini-2.5-flash-image",

--- a/backend/internal/pkg/antigravity/request_transformer.go
+++ b/backend/internal/pkg/antigravity/request_transformer.go
@@ -216,6 +216,7 @@ type modelInfo struct {
 // 注意：模型映射逻辑在网关层完成；这里仅用于按模型前缀判断是否注入身份提示词。
 var modelInfoMap = map[string]modelInfo{
 	"claude-fable-5":    {DisplayName: "Claude Fable 5", CanonicalID: "claude-fable-5"},
+	"claude-opus-5":     {DisplayName: "Claude Opus 5", CanonicalID: "claude-opus-5"},
 	"claude-opus-4-8":   {DisplayName: "Claude Opus 4.8", CanonicalID: "claude-opus-4-8"},
 	"claude-opus-4-7":   {DisplayName: "Claude Opus 4.7", CanonicalID: "claude-opus-4-7"},
 	"claude-opus-4-5":   {DisplayName: "Claude Opus 4.5", CanonicalID: "claude-opus-4-5-20250929"},
@@ -608,7 +609,8 @@ func isAntigravityOpusHighTierModel(model string) bool {
 	lower := strings.ToLower(model)
 	return strings.HasPrefix(lower, "claude-opus-4-6") ||
 		strings.HasPrefix(lower, "claude-opus-4-7") ||
-		strings.HasPrefix(lower, "claude-opus-4-8")
+		strings.HasPrefix(lower, "claude-opus-4-8") ||
+		strings.HasPrefix(lower, "claude-opus-5")
 }
 
 func buildGenerationConfig(req *ClaudeRequest) *GeminiGenerationConfig {

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -148,6 +148,12 @@ var DefaultModels = []Model{
 		CreatedAt:   "2026-05-29T00:00:00Z",
 	},
 	{
+		ID:          "claude-opus-5",
+		Type:        "model",
+		DisplayName: "Claude Opus 5",
+		CreatedAt:   "2026-07-24T00:00:00Z",
+	},
+	{
 		ID:          "claude-sonnet-5",
 		Type:        "model",
 		DisplayName: "Claude Sonnet 5",

--- a/backend/internal/service/antigravity_model_mapping_test.go
+++ b/backend/internal/service/antigravity_model_mapping_test.go
@@ -95,6 +95,12 @@ func TestAntigravityGatewayService_GetMappedModel(t *testing.T) {
 			expected:       "claude-sonnet-4-5",
 		},
 		{
+			name:           "默认映射透传 - claude-opus-5",
+			requestedModel: "claude-opus-5",
+			accountMapping: nil,
+			expected:       "claude-opus-5",
+		},
+		{
 			name:           "默认映射透传 - claude-opus-4-8",
 			requestedModel: "claude-opus-4-8",
 			accountMapping: nil,
@@ -229,6 +235,7 @@ func TestAntigravityGatewayService_IsModelSupported(t *testing.T) {
 		{"直接支持 - gemini-3-flash", "gemini-3-flash", true},
 
 		// 可映射（有明确前缀映射）
+		{"可映射 - claude-opus-5", "claude-opus-5", true},
 		{"可映射 - claude-opus-4-8", "claude-opus-4-8", true},
 		{"可映射 - claude-opus-4-6", "claude-opus-4-6", true},
 

--- a/backend/internal/service/bedrock_request.go
+++ b/backend/internal/service/bedrock_request.go
@@ -347,8 +347,10 @@ func removeCustomFieldFromTools(body []byte) []byte {
 }
 
 // claudeVersionRe 匹配 Claude 模型 ID 中的版本号部分
-// 支持 claude-{tier}-{major}-{minor} 和 claude-{tier}-{major}.{minor} 格式
-var claudeVersionRe = regexp.MustCompile(`claude-(?:haiku|sonnet|opus)-(\d+)[-.](\d+)`)
+// 支持：
+//   - claude-{tier}-{major}-{minor} / claude-{tier}-{major}.{minor}
+//   - major-only 形式：claude-{tier}-{major}、claude-{tier}-{major}-v1（minor 视为 0）
+var claudeVersionRe = regexp.MustCompile(`claude-(?:haiku|sonnet|opus)-(\d+)(?:[-.](\d+))?`)
 
 // isBedrockClaude45OrNewer 判断 Bedrock 模型 ID 是否为 Claude 4.5 或更新版本
 // Claude 4.5+ 支持 cache_control 中的 ttl 字段（"5m" 和 "1h"）

--- a/backend/internal/service/bedrock_request_test.go
+++ b/backend/internal/service/bedrock_request_test.go
@@ -527,6 +527,20 @@ func TestResolveBedrockModelID(t *testing.T) {
 		assert.Equal(t, "eu.anthropic.claude-opus-4-8-v1", modelID)
 	})
 
+	t.Run("default opus 5 mapping uses regional Bedrock model id", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformAnthropic,
+			Type:     AccountTypeBedrock,
+			Credentials: map[string]any{
+				"aws_region": "eu-west-1",
+			},
+		}
+
+		modelID, ok := ResolveBedrockModelID(account, "claude-opus-5")
+		require.True(t, ok)
+		assert.Equal(t, "eu.anthropic.claude-opus-5", modelID)
+	})
+
 	t.Run("默认 Fable 5 映射使用官方 Bedrock 模型 ID", func(t *testing.T) {
 		account := &Account{
 			Platform: PlatformAnthropic,
@@ -748,7 +762,9 @@ func TestIsBedrockOpus47OrNewer(t *testing.T) {
 		{"us.anthropic.claude-opus-4-7-v1", true},
 		{"us.anthropic.claude-opus-4-6-v1", false},
 		{"us.anthropic.claude-opus-4-5-20251101-v1:0", false},
-		{"us.anthropic.claude-opus-5-0-v1", true},
+		{"us.anthropic.claude-opus-5", true},
+		{"claude-opus-5", true},
+		{"us.anthropic.claude-opus-5-0-v1", true}, // major.minor parse compat
 		// Sonnet 4.7 is not Opus → false
 		{"us.anthropic.claude-sonnet-4-7-v1", false},
 		{"us.anthropic.claude-sonnet-4-6", false},
@@ -938,6 +954,7 @@ func TestIsBedrockOpus47OrNewer_EdgeCases(t *testing.T) {
 		// Forward() passes parsed.Model (standard names), not Bedrock IDs
 		{"claude-opus-4-8", true},
 		{"claude-opus-4-7", true},
+		{"claude-opus-5", true},
 		{"claude-opus-4-6", false},
 		{"claude-sonnet-4-7", false},
 	}

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -258,6 +258,10 @@ func (s *BillingService) initFallbackPricing() {
 	// Claude 4.7 Opus (暂与4.6同价，待官方定价更新)
 	s.fallbackPrices["claude-opus-4.7"] = s.fallbackPrices["claude-opus-4.6"]
 
+	// Claude 4.8 / 5 Opus（官方 $5/$25，与 4.5+ 同价）
+	s.fallbackPrices["claude-opus-4.8"] = s.fallbackPrices["claude-opus-4.7"]
+	s.fallbackPrices["claude-opus-5"] = s.fallbackPrices["claude-opus-4.8"]
+
 	// Gemini 3.1 Pro
 	s.fallbackPrices["gemini-3.1-pro"] = &ModelPricing{
 		InputPricePerToken:         2e-6,   // $2 per MTok
@@ -588,6 +592,13 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 
 	// 按模型系列匹配
 	if strings.Contains(modelLower, "opus") {
+		// 更具体 ID 优先，避免 "opus-4" 类子串误匹配更高版本。
+		if strings.Contains(modelLower, "opus-5") || strings.Contains(modelLower, "opus-5.0") {
+			return s.fallbackPrices["claude-opus-5"]
+		}
+		if strings.Contains(modelLower, "4.8") || strings.Contains(modelLower, "4-8") {
+			return s.fallbackPrices["claude-opus-4.8"]
+		}
 		if strings.Contains(modelLower, "4.7") || strings.Contains(modelLower, "4-7") {
 			return s.fallbackPrices["claude-opus-4.7"]
 		}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -448,6 +448,9 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 		{name: "empty model", model: "   ", expectNilPricing: true},
 		{name: "claude opus 4.6", model: "claude-opus-4.6-20260201", expectedInput: 5e-6},
 		{name: "claude opus 4.5 alt separator", model: "claude-opus-4-5-20260101", expectedInput: 5e-6},
+		{name: "claude opus 4.8", model: "claude-opus-4-8", expectedInput: 5e-6},
+		{name: "claude opus 5", model: "claude-opus-5", expectedInput: 5e-6},
+		{name: "claude opus 5 output price", model: "claude-opus-5", expectedInput: 5e-6, expectedOutput: floatPtr(25e-6)},
 		{name: "claude generic model fallback sonnet", model: "claude-foo-bar", expectedInput: 3e-6},
 		{name: "gemini explicit fallback", model: "gemini-3-1-pro", expectedInput: 2e-6},
 		{name: "gemini unknown no fallback", model: "gemini-2.0-pro", expectNilPricing: true},
@@ -810,8 +813,8 @@ func TestComputeTokenBreakdown_GptImage2ImageEditIssue4386(t *testing.T) {
 
 	cost := svc.computeTokenBreakdown(pricing, tokens, 1.0, "", false)
 
-	wantTextInput := float64(19) * 5e-6    // 0.000095
-	wantImageInput := float64(352) * 8e-6  // 0.002816
+	wantTextInput := float64(19) * 5e-6     // 0.000095
+	wantImageInput := float64(352) * 8e-6   // 0.002816
 	wantImageOutput := float64(439) * 30e-6 // 0.013170
 	require.InDelta(t, wantTextInput, cost.InputCost, 1e-15, "InputCost 仅含文本输入")
 	require.InDelta(t, wantImageInput, cost.ImageInputCost, 1e-15, "图片输入按 $8/1M 独立计费")

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -789,6 +789,8 @@ func (s *PricingService) matchByModelFamily(model string) *LiteLLMModelPricing {
 	// 因子串关系误匹配 "claude-opus-4-7"（opus-4.7 系列）。
 	// 注意：原 map 实现存在 Go map 迭代随机性导致的同类 bug，此处改为有序切片修复。
 	families := []modelFamily{
+		{name: "opus-5", match: []string{"claude-opus-5", "claude-opus-5.0"}, pricing: []string{"claude-opus-5", "claude-opus-4-8", "claude-opus-4-7"}},
+		{name: "opus-4.8", match: []string{"claude-opus-4-8", "claude-opus-4.8"}, pricing: []string{"claude-opus-4-8", "claude-opus-4-7", "claude-opus-4.7", "claude-opus-4-6"}},
 		{name: "opus-4.7", match: []string{"claude-opus-4-7", "claude-opus-4.7"}, pricing: []string{"claude-opus-4-7", "claude-opus-4.7", "claude-opus-4-6"}},
 		{name: "opus-4.6", match: []string{"claude-opus-4-6", "claude-opus-4.6"}},
 		{name: "opus-4.5", match: []string{"claude-opus-4-5", "claude-opus-4.5"}},
@@ -821,6 +823,10 @@ func (s *PricingService) matchByModelFamily(model string) *LiteLLMModelPricing {
 		switch {
 		case strings.Contains(model, "opus"):
 			switch {
+			case strings.Contains(model, "opus-5") || strings.Contains(model, "opus-5.0"):
+				fallbackName = "opus-5"
+			case strings.Contains(model, "4.8") || strings.Contains(model, "4-8"):
+				fallbackName = "opus-4.8"
 			case strings.Contains(model, "4.7") || strings.Contains(model, "4-7"):
 				fallbackName = "opus-4.7"
 			case strings.Contains(model, "4.6") || strings.Contains(model, "4-6"):

--- a/backend/internal/service/pricing_service_test.go
+++ b/backend/internal/service/pricing_service_test.go
@@ -601,3 +601,44 @@ func TestListModelNamesByProvider_EmptyCatalog(t *testing.T) {
 	require.NotNil(t, got)
 	require.Empty(t, got)
 }
+
+func TestDefaultPricingIncludesClaudeOpus5(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "resources", "model-pricing", "model_prices_and_context_window.json"))
+	require.NoError(t, err)
+
+	pricingSvc := &PricingService{}
+	pricingData, err := pricingSvc.parsePricingData(data)
+	require.NoError(t, err)
+	pricingSvc.pricingData = pricingData
+
+	got := pricingSvc.GetModelPricing("claude-opus-5")
+	require.NotNil(t, got)
+	require.InDelta(t, 5e-6, got.InputCostPerToken, 1e-12)
+	require.InDelta(t, 2.5e-5, got.OutputCostPerToken, 1e-12)
+	require.InDelta(t, 6.25e-6, got.CacheCreationInputTokenCost, 1e-12)
+	require.InDelta(t, 5e-7, got.CacheReadInputTokenCost, 1e-12)
+	require.Equal(t, "anthropic", got.LiteLLMProvider)
+}
+
+func TestGetModelPricing_ClaudeOpus5FamilyMatchOrder(t *testing.T) {
+	opus5 := &LiteLLMModelPricing{InputCostPerToken: 5e-6, OutputCostPerToken: 25e-6}
+	opus48 := &LiteLLMModelPricing{InputCostPerToken: 5e-6, OutputCostPerToken: 25e-6}
+	opus47 := &LiteLLMModelPricing{InputCostPerToken: 5e-6, OutputCostPerToken: 25e-6}
+	opus3 := &LiteLLMModelPricing{InputCostPerToken: 15e-6, OutputCostPerToken: 75e-6}
+
+	svc := &PricingService{
+		pricingData: map[string]*LiteLLMModelPricing{
+			"claude-opus-5":   opus5,
+			"claude-opus-4-8": opus48,
+			"claude-opus-4-7": opus47,
+			"claude-3-opus":   opus3,
+		},
+	}
+
+	// exact
+	require.Same(t, opus5, svc.GetModelPricing("claude-opus-5"))
+	// family match for unknown dated variant prefers opus-5 over older families
+	require.Same(t, opus5, svc.GetModelPricing("claude-opus-5-20260725"))
+	// more specific 4.8 must not fall through to generic opus-4 / 3-opus
+	require.Same(t, opus48, svc.GetModelPricing("claude-opus-4-8-preview"))
+}

--- a/backend/migrations/187_add_opus5_to_model_mapping.sql
+++ b/backend/migrations/187_add_opus5_to_model_mapping.sql
@@ -1,0 +1,16 @@
+-- 为已持久化的 Antigravity model_mapping 添加 claude-opus-5。
+--
+-- 未持久化 model_mapping 的账号会直接使用 DefaultAntigravityModelMapping，
+-- 因此这里只需要回填已有映射对象。
+
+UPDATE accounts
+SET credentials = jsonb_set(
+    credentials,
+    '{model_mapping,claude-opus-5}',
+    '"claude-opus-5"'::jsonb,
+    true
+)
+WHERE platform = 'antigravity'
+  AND deleted_at IS NULL
+  AND jsonb_typeof(credentials->'model_mapping') = 'object'
+  AND credentials->'model_mapping'->>'claude-opus-5' IS NULL;

--- a/backend/resources/model-pricing/model_prices_and_context_window.json
+++ b/backend/resources/model-pricing/model_prices_and_context_window.json
@@ -520,6 +520,42 @@
     "supports_xhigh_reasoning_effort": true,
     "tool_use_system_prompt_tokens": 346
   },
+  "claude-opus-5": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_creation_input_token_cost_above_1hr": 1e-05,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "litellm_provider": "anthropic",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "mode": "chat",
+    "output_cost_per_token": 2.5e-05,
+    "provider_specific_entry": {
+      "fast": 6.0,
+      "us": 1.1
+    },
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "supports_adaptive_thinking": true,
+    "supports_assistant_prefill": false,
+    "supports_computer_use": true,
+    "supports_function_calling": true,
+    "supports_max_reasoning_effort": true,
+    "supports_minimal_reasoning_effort": true,
+    "supports_output_config": true,
+    "supports_pdf_input": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_xhigh_reasoning_effort": true,
+    "tool_use_system_prompt_tokens": 346
+  },
   "claude-sonnet-4-20250514": {
     "cache_creation_input_token_cost": 3.75e-06,
     "cache_creation_input_token_cost_above_1hr": 6e-06,

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -225,6 +225,7 @@ const formatScopeName = (scope: string): string => {
     'claude-opus-4-6-thinking': 'COpus46T',
     'claude-opus-4-7': 'COpus47',
     'claude-opus-4-8': 'COpus48',
+    'claude-opus-5': 'COpus5',
     'claude-sonnet-4-6': 'CSon46',
     'claude-sonnet-4-5': 'CSon45',
     'claude-sonnet-4-5-thinking': 'CSon45T',

--- a/frontend/src/components/account/AccountUsageCell.vue
+++ b/frontend/src/components/account/AccountUsageCell.vue
@@ -800,7 +800,7 @@ const antigravityClaudeUsageFromAPI = computed(() =>
     'claude-fable-5',
     'claude-sonnet-4-5', 'claude-opus-4-5-thinking',
     'claude-sonnet-4-6', 'claude-opus-4-6', 'claude-opus-4-6-thinking',
-    'claude-opus-4-7', 'claude-opus-4-8',
+    'claude-opus-4-7', 'claude-opus-4-8', 'claude-opus-5',
   ])
 )
 

--- a/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
+++ b/frontend/src/composables/__tests__/useModelWhitelist.spec.ts
@@ -41,6 +41,8 @@ describe('useModelWhitelist', () => {
     expect(getModelsByPlatform('antigravity')).toContain('claude-fable-5')
     expect(getModelsByPlatform('claude')).toContain('claude-opus-4-8')
     expect(getModelsByPlatform('antigravity')).toContain('claude-opus-4-8')
+    expect(getModelsByPlatform('claude')).toContain('claude-opus-5')
+    expect(getModelsByPlatform('antigravity')).toContain('claude-opus-5')
   })
 
   it('xAI 模型列表包含 Grok 4.5 官方模型和别名', () => {

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -32,6 +32,7 @@ export const claudeModels = [
   'claude-opus-4-6',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-opus-5',
   'claude-sonnet-4-6',
   'claude-sonnet-5',
   'claude-fable-5'
@@ -60,6 +61,7 @@ const antigravityModels = [
   'claude-opus-4-6-thinking',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-opus-5',
   'claude-opus-4-5-thinking',
   'claude-sonnet-4-6',
   'claude-sonnet-4-5',
@@ -267,6 +269,7 @@ const anthropicPresetMappings = [
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'claude-opus-4-6', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'claude-opus-4-7', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'claude-opus-4-8', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
+  { label: 'Opus 5', from: 'claude-opus-5', to: 'claude-opus-5', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Haiku 3.5', from: 'claude-3-5-haiku-20241022', to: 'claude-3-5-haiku-20241022', color: 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400' },
   { label: 'Haiku 4.5', from: 'claude-haiku-4-5-20251001', to: 'claude-haiku-4-5-20251001', color: 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400' },
   { label: 'Opus->Sonnet', from: 'claude-opus-4-6', to: 'claude-sonnet-4-5-20250929', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' }
@@ -351,7 +354,8 @@ const antigravityPresetMappings = [
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'claude-opus-4-6-thinking', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.6-thinking', from: 'claude-opus-4-6-thinking', to: 'claude-opus-4-6-thinking', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'claude-opus-4-7', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
-  { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'claude-opus-4-8', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' }
+  { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'claude-opus-4-8', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 5', from: 'claude-opus-5', to: 'claude-opus-5', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' }
 ]
 
 // Bedrock 预设映射（与后端 DefaultBedrockModelMapping 保持一致）
@@ -360,6 +364,7 @@ const bedrockPresetMappings = [
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'us.anthropic.claude-opus-4-6-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'us.anthropic.claude-opus-4-7-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'us.anthropic.claude-opus-4-8-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 5', from: 'claude-opus-5', to: 'us.anthropic.claude-opus-5', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Sonnet 5', from: 'claude-sonnet-5', to: 'us.anthropic.claude-sonnet-5-v1', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: 'Sonnet 4.6', from: 'claude-sonnet-4-6', to: 'us.anthropic.claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
   { label: 'Opus 4.5', from: 'claude-opus-4-5-thinking', to: 'us.anthropic.claude-opus-4-5-20251101-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },


### PR DESCRIPTION
## 背景

Anthropic 已发布 Claude Opus 5（API ID：`claude-opus-5`）。当前 sub2api 尚未在模型列表、映射与计价链路中注册该模型，导致 `/v1/models` 不展示、默认映射与回退计价不完整。

官方规格（Anthropic）：
- API ID：`claude-opus-5`
- 输入 $5 / MTok，输出 $25 / MTok
- Context 1M；同步 max output 128k
- Adaptive thinking
- 训练/可靠知识截止：May 2026

## 实现

按既有 `claude-opus-4-8` 接入模式做对称注册：

- Claude / Antigravity 默认模型列表与前端白名单
- Antigravity / Bedrock 默认模型映射 + 持久化 mapping 回填迁移
- 价格表 `model_prices_and_context_window.json` 增加 `claude-opus-5`
- `matchByModelFamily` / billing fallback 增加更具体 ID 匹配（opus-5、opus-4.8 优先于低版本）
- Bedrock 版本识别支持 major-only 形式（`claude-opus-5` / `...-opus-5-v1`），以正确走 adaptive thinking 兼容路径
- 补齐与 Opus 4.8 对称的单元测试

## 测试

- `go test ./internal/domain/ ./internal/pkg/antigravity/ ./internal/service/ -count=1`
- 聚焦：`Opus5|ContainsNewClaude|GetFallbackPricing_Family|IsBedrockOpus47|DefaultPricingIncludesClaudeOpus5|ClaudeOpus5Family...`
- `go build ./cmd/server/`

## 生产实测证据（2026-07-25）

在当前 sub2api 生产外部网关：
- `POST /v1/messages` 指定 `claude-opus-5` 返回 200，`model=claude-opus-5`，文本 `OPUS5_OK`
- `GET /v1/models` 200 的 9 个模型中尚未列出 `claude-opus-5`（本 PR 补齐列表注册）

## 说明

- 价格与能力元数据以 Anthropic 官方规格为准，不额外推断未公开字段
- 不包含 integration 重建 / 发版 / tag