### PR TITLE
fix(apicompat): emit rs-prefixed Responses reasoning item IDs

### DIFF
--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -36,7 +36,7 @@ func AnthropicToResponsesResponse(resp *AnthropicResponse) *ResponsesResponse {
 			if block.Thinking != "" {
 				outputs = append(outputs, ResponsesOutput{
 					Type: "reasoning",
-					ID:   generateItemID(),
+					ID:   generateReasoningItemID(),
 					Summary: []ResponsesSummary{{
 						Type: "summary_text",
 						Text: block.Thinking,
@@ -277,7 +277,7 @@ func anthToResHandleContentBlockStart(evt *AnthropicStreamEvent, state *Anthropi
 
 	switch evt.ContentBlock.Type {
 	case "thinking":
-		state.CurrentItemID = generateItemID()
+		state.CurrentItemID = generateReasoningItemID()
 		state.CurrentItemType = "reasoning"
 		state.ContentIndex = 0
 
@@ -628,7 +628,15 @@ func generateResponsesID() string {
 }
 
 func generateItemID() string {
+	return generateItemIDWithPrefix("item")
+}
+
+func generateReasoningItemID() string {
+	return generateItemIDWithPrefix("rs")
+}
+
+func generateItemIDWithPrefix(prefix string) string {
 	b := make([]byte, 12)
 	_, _ = rand.Read(b)
-	return "item_" + hex.EncodeToString(b)
+	return prefix + "_" + hex.EncodeToString(b)
 }

--- a/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
+++ b/backend/internal/pkg/apicompat/anthropic_to_responses_response.go
@@ -39,7 +39,7 @@ func AnthropicToResponsesResponse(resp *AnthropicResponse) *ResponsesResponse {
 			if block.Thinking != "" {
 				outputs = append(outputs, ResponsesOutput{
 					Type: "reasoning",
-					ID:   generateItemID(),
+					ID:   generateReasoningItemID(),
 					Summary: []ResponsesSummary{{
 						Type: "summary_text",
 						Text: block.Thinking,
@@ -290,7 +290,7 @@ func anthToResHandleContentBlockStart(evt *AnthropicStreamEvent, state *Anthropi
 		// 会稳定产生 text → thinking 这个顺序。
 		events = append(events, closeCurrentResponsesItem(state)...)
 
-		state.CurrentItemID = generateItemID()
+		state.CurrentItemID = generateReasoningItemID()
 		state.CurrentItemType = "reasoning"
 		state.ContentIndex = 0
 
@@ -656,7 +656,15 @@ func generateResponsesID() string {
 }
 
 func generateItemID() string {
+	return generateItemIDWithPrefix("item")
+}
+
+func generateReasoningItemID() string {
+	return generateItemIDWithPrefix("rs")
+}
+
+func generateItemIDWithPrefix(prefix string) string {
 	b := make([]byte, 12)
 	_, _ = rand.Read(b)
-	return "item_" + hex.EncodeToString(b)
+	return prefix + "_" + hex.EncodeToString(b)
 }

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -882,7 +882,7 @@ func chatMessageToResponsesOutput(message ChatMessage, customTools map[string]bo
 	if message.ReasoningContent != "" {
 		outputs = append(outputs, ResponsesOutput{
 			Type: "reasoning",
-			ID:   generateItemID(),
+			ID:   generateReasoningItemID(),
 			Summary: []ResponsesSummary{{
 				Type: "summary_text",
 				Text: message.ReasoningContent,
@@ -1329,7 +1329,7 @@ func ensureChatReasoningItem(state *ChatCompletionsToResponsesStreamState) []Res
 		return nil
 	}
 	state.ReasoningOpen = true
-	state.ReasoningItemID = generateItemID()
+	state.ReasoningItemID = generateReasoningItemID()
 	state.ReasoningIndex = state.allocOutputIndex()
 	return []ResponsesStreamEvent{
 		chatToResponsesEvent(state, "response.output_item.added", &ResponsesStreamEvent{
@@ -1603,7 +1603,7 @@ func (state *ChatCompletionsToResponsesStreamState) chatOutput() []ResponsesOutp
 	if state.Reasoning.Len() > 0 {
 		outputs = append(outputs, ResponsesOutput{
 			Type: "reasoning",
-			ID:   generateItemID(),
+			ID:   nonEmpty(state.ReasoningItemID, generateReasoningItemID()),
 			Summary: []ResponsesSummary{{
 				Type: "summary_text",
 				Text: state.Reasoning.String(),

--- a/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
+++ b/backend/internal/pkg/apicompat/chatcompletions_responses_bridge.go
@@ -1302,7 +1302,7 @@ func chatMessageToResponsesOutput(message ChatMessage, customTools, functionTool
 	if reasoning != "" {
 		outputs = append(outputs, ResponsesOutput{
 			Type: "reasoning",
-			ID:   generateItemID(),
+			ID:   generateReasoningItemID(),
 			Summary: []ResponsesSummary{{
 				Type: "summary_text",
 				Text: reasoning,
@@ -1795,7 +1795,7 @@ func ensureChatReasoningItem(state *ChatCompletionsToResponsesStreamState) []Res
 		return nil
 	}
 	state.ReasoningOpen = true
-	state.ReasoningItemID = generateItemID()
+	state.ReasoningItemID = generateReasoningItemID()
 	state.ReasoningIndex = state.allocOutputIndex()
 	return []ResponsesStreamEvent{
 		chatToResponsesEvent(state, "response.output_item.added", &ResponsesStreamEvent{
@@ -2072,7 +2072,7 @@ func (state *ChatCompletionsToResponsesStreamState) chatOutput() []ResponsesOutp
 	if state.Reasoning.Len() > 0 {
 		outputs = append(outputs, ResponsesOutput{
 			Type: "reasoning",
-			ID:   generateItemID(),
+			ID:   nonEmpty(state.ReasoningItemID, generateReasoningItemID()),
 			Summary: []ResponsesSummary{{
 				Type: "summary_text",
 				Text: state.Reasoning.String(),

--- a/backend/internal/pkg/apicompat/responses_reasoning_item_id_test.go
+++ b/backend/internal/pkg/apicompat/responses_reasoning_item_id_test.go
@@ -1,0 +1,118 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireReasoningItemID(t *testing.T, id string) {
+	t.Helper()
+	require.True(t, strings.HasPrefix(id, "rs_"), "reasoning item id %q must use the rs_ prefix", id)
+	require.False(t, strings.HasPrefix(id, "item_"), "reasoning item id must not use the generic item_ prefix")
+}
+
+func TestAnthropicToResponsesResponse_ReasoningIDPrefix(t *testing.T) {
+	resp := AnthropicToResponsesResponse(&AnthropicResponse{
+		Model: "claude-sonnet-4-5",
+		Content: []AnthropicContentBlock{{
+			Type:     "thinking",
+			Thinking: "consider the options",
+		}},
+	})
+
+	require.Len(t, resp.Output, 1)
+	require.Equal(t, "reasoning", resp.Output[0].Type)
+	requireReasoningItemID(t, resp.Output[0].ID)
+}
+
+func TestAnthropicEventToResponses_ReasoningIDPrefixAndLifecycle(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+	idx := 0
+	var events []ResponsesStreamEvent
+	feed := func(evt *AnthropicStreamEvent) {
+		events = append(events, AnthropicEventToResponsesEvents(evt, state)...)
+	}
+
+	feed(&AnthropicStreamEvent{Type: "message_start", Message: &AnthropicResponse{ID: "msg_1", Model: "claude-sonnet-4-5"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &idx, ContentBlock: &AnthropicContentBlock{Type: "thinking"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &idx, Delta: &AnthropicDelta{Type: "thinking_delta", Thinking: "plan"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &idx})
+	feed(&AnthropicStreamEvent{Type: "message_stop"})
+
+	var reasoningID string
+	for _, event := range events {
+		switch event.Type {
+		case "response.output_item.added":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				reasoningID = event.Item.ID
+				requireReasoningItemID(t, reasoningID)
+			}
+		case "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done":
+			require.NotEmpty(t, reasoningID)
+			require.Equal(t, reasoningID, event.ItemID)
+		case "response.output_item.done":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				require.Equal(t, reasoningID, event.Item.ID)
+			}
+		case "response.completed":
+			require.NotNil(t, event.Response)
+			require.Len(t, event.Response.Output, 1)
+			require.Equal(t, reasoningID, event.Response.Output[0].ID)
+		}
+	}
+	require.NotEmpty(t, reasoningID)
+}
+
+func TestChatCompletionsResponseToResponses_ReasoningIDPrefix(t *testing.T) {
+	resp := ChatCompletionsResponseToResponses(&ChatCompletionsResponse{
+		Choices: []ChatChoice{{
+			Message: ChatMessage{
+				Role:             "assistant",
+				Content:          json.RawMessage(`"answer"`),
+				ReasoningContent: "plan",
+			},
+		}},
+	}, "deepseek-v4-pro", nil, false, nil)
+
+	require.NotEmpty(t, resp.Output)
+	require.Equal(t, "reasoning", resp.Output[0].Type)
+	requireReasoningItemID(t, resp.Output[0].ID)
+}
+
+func TestChatCompletionsChunkToResponses_ReasoningIDPrefixAndLifecycle(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"plan"}}]}`,
+		`{"choices":[{"index":0,"delta":{"content":"answer"}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+	})
+
+	var reasoningID string
+	for _, event := range events {
+		switch event.Type {
+		case "response.output_item.added":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				reasoningID = event.Item.ID
+				requireReasoningItemID(t, reasoningID)
+			}
+		case "response.reasoning_summary_part.added",
+			"response.reasoning_summary_text.delta",
+			"response.reasoning_summary_text.done",
+			"response.reasoning_summary_part.done":
+			require.NotEmpty(t, reasoningID)
+			require.Equal(t, reasoningID, event.ItemID)
+		case "response.output_item.done":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				require.Equal(t, reasoningID, event.Item.ID)
+			}
+		case "response.completed":
+			require.NotNil(t, event.Response)
+			require.NotEmpty(t, event.Response.Output)
+			require.Equal(t, "reasoning", event.Response.Output[0].Type)
+			require.Equal(t, reasoningID, event.Response.Output[0].ID)
+		}
+	}
+	require.NotEmpty(t, reasoningID)
+}

--- a/backend/internal/pkg/apicompat/responses_reasoning_item_id_test.go
+++ b/backend/internal/pkg/apicompat/responses_reasoning_item_id_test.go
@@ -1,0 +1,118 @@
+package apicompat
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireReasoningItemID(t *testing.T, id string) {
+	t.Helper()
+	require.True(t, strings.HasPrefix(id, "rs_"), "reasoning item id %q must use the rs_ prefix", id)
+	require.False(t, strings.HasPrefix(id, "item_"), "reasoning item id must not use the generic item_ prefix")
+}
+
+func TestAnthropicToResponsesResponse_ReasoningIDPrefix(t *testing.T) {
+	resp := AnthropicToResponsesResponse(&AnthropicResponse{
+		Model: "claude-sonnet-4-5",
+		Content: []AnthropicContentBlock{{
+			Type:     "thinking",
+			Thinking: "consider the options",
+		}},
+	})
+
+	require.Len(t, resp.Output, 1)
+	require.Equal(t, "reasoning", resp.Output[0].Type)
+	requireReasoningItemID(t, resp.Output[0].ID)
+}
+
+func TestAnthropicEventToResponses_ReasoningIDPrefixAndLifecycle(t *testing.T) {
+	state := NewAnthropicEventToResponsesState()
+	idx := 0
+	var events []ResponsesStreamEvent
+	feed := func(evt *AnthropicStreamEvent) {
+		events = append(events, AnthropicEventToResponsesEvents(evt, state)...)
+	}
+
+	feed(&AnthropicStreamEvent{Type: "message_start", Message: &AnthropicResponse{ID: "msg_1", Model: "claude-sonnet-4-5"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_start", Index: &idx, ContentBlock: &AnthropicContentBlock{Type: "thinking"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_delta", Index: &idx, Delta: &AnthropicDelta{Type: "thinking_delta", Thinking: "plan"}})
+	feed(&AnthropicStreamEvent{Type: "content_block_stop", Index: &idx})
+	feed(&AnthropicStreamEvent{Type: "message_stop"})
+
+	var reasoningID string
+	for _, event := range events {
+		switch event.Type {
+		case "response.output_item.added":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				reasoningID = event.Item.ID
+				requireReasoningItemID(t, reasoningID)
+			}
+		case "response.reasoning_summary_text.delta", "response.reasoning_summary_text.done":
+			require.NotEmpty(t, reasoningID)
+			require.Equal(t, reasoningID, event.ItemID)
+		case "response.output_item.done":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				require.Equal(t, reasoningID, event.Item.ID)
+			}
+		case "response.completed":
+			require.NotNil(t, event.Response)
+			require.Len(t, event.Response.Output, 1)
+			require.Equal(t, reasoningID, event.Response.Output[0].ID)
+		}
+	}
+	require.NotEmpty(t, reasoningID)
+}
+
+func TestChatCompletionsResponseToResponses_ReasoningIDPrefix(t *testing.T) {
+	resp := ChatCompletionsResponseToResponses(&ChatCompletionsResponse{
+		Choices: []ChatChoice{{
+			Message: ChatMessage{
+				Role:             "assistant",
+				Content:          json.RawMessage(`"answer"`),
+				ReasoningContent: "plan",
+			},
+		}},
+	}, "deepseek-v4-pro", nil, nil, false, nil)
+
+	require.NotEmpty(t, resp.Output)
+	require.Equal(t, "reasoning", resp.Output[0].Type)
+	requireReasoningItemID(t, resp.Output[0].ID)
+}
+
+func TestChatCompletionsChunkToResponses_ReasoningIDPrefixAndLifecycle(t *testing.T) {
+	events := collectStreamEvents(t, []string{
+		`{"choices":[{"index":0,"delta":{"reasoning_content":"plan"}}]}`,
+		`{"choices":[{"index":0,"delta":{"content":"answer"}}]}`,
+		`{"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+	})
+
+	var reasoningID string
+	for _, event := range events {
+		switch event.Type {
+		case "response.output_item.added":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				reasoningID = event.Item.ID
+				requireReasoningItemID(t, reasoningID)
+			}
+		case "response.reasoning_summary_part.added",
+			"response.reasoning_summary_text.delta",
+			"response.reasoning_summary_text.done",
+			"response.reasoning_summary_part.done":
+			require.NotEmpty(t, reasoningID)
+			require.Equal(t, reasoningID, event.ItemID)
+		case "response.output_item.done":
+			if event.Item != nil && event.Item.Type == "reasoning" {
+				require.Equal(t, reasoningID, event.Item.ID)
+			}
+		case "response.completed":
+			require.NotNil(t, event.Response)
+			require.NotEmpty(t, event.Response.Output)
+			require.Equal(t, "reasoning", event.Response.Output[0].Type)
+			require.Equal(t, reasoningID, event.Response.Output[0].ID)
+		}
+	}
+	require.NotEmpty(t, reasoningID)
+}

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -603,6 +603,27 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		}
 	}
 
+	if !compact {
+		// Non-compact OAuth passthrough forces store=false below. Under that
+		// contract, replaying a reasoning item by id makes the ChatGPT backend
+		// look up an item that was never stored. Strip the id while preserving
+		// encrypted_content, summary, and all other reasoning fields. This
+		// mirrors filterCodexInputWithOptions on the transformed OAuth path and
+		// also recovers histories polluted by compatibility bridges that emitted
+		// a generic item_* reasoning id.
+		for i, item := range gjson.GetBytes(normalized, "input").Array() {
+			if item.Get("type").String() != "reasoning" || !item.Get("id").Exists() {
+				continue
+			}
+			next, err := sjson.DeleteBytes(normalized, fmt.Sprintf("input.%d.id", i))
+			if err != nil {
+				return body, false, fmt.Errorf("normalize passthrough body delete reasoning id: %w", err)
+			}
+			normalized = next
+			changed = true
+		}
+	}
+
 	if compact {
 		if store := gjson.GetBytes(normalized, "store"); store.Exists() {
 			next, err := sjson.DeleteBytes(normalized, "store")

--- a/backend/internal/service/openai_gateway_request_body.go
+++ b/backend/internal/service/openai_gateway_request_body.go
@@ -1276,6 +1276,27 @@ func normalizeOpenAIPassthroughOAuthBody(body []byte, compact bool) ([]byte, boo
 		}
 	}
 
+	if !compact {
+		// Non-compact OAuth passthrough forces store=false below. Under that
+		// contract, replaying a reasoning item by id makes the ChatGPT backend
+		// look up an item that was never stored. Strip the id while preserving
+		// encrypted_content, summary, and all other reasoning fields. This
+		// mirrors filterCodexInputWithOptions on the transformed OAuth path and
+		// also recovers histories polluted by compatibility bridges that emitted
+		// a generic item_* reasoning id.
+		for i, item := range gjson.GetBytes(normalized, "input").Array() {
+			if item.Get("type").String() != "reasoning" || !item.Get("id").Exists() {
+				continue
+			}
+			next, err := sjson.DeleteBytes(normalized, fmt.Sprintf("input.%d.id", i))
+			if err != nil {
+				return body, false, fmt.Errorf("normalize passthrough body delete reasoning id: %w", err)
+			}
+			normalized = next
+			changed = true
+		}
+	}
+
 	if compact {
 		if store := gjson.GetBytes(normalized, "store"); store.Exists() {
 			next, err := sjson.DeleteBytes(normalized, "store")

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -85,3 +85,27 @@ func TestNormalizeOpenAIPassthroughOAuthBody_ArrayInputUnchanged(t *testing.T) {
 	require.Len(t, input.Array(), 1)
 	require.Equal(t, "message", input.Array()[0].Get("type").String())
 }
+
+func TestNormalizeOpenAIPassthroughOAuthBody_StripsReasoningID(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","id":"item_badprefix","encrypted_content":"cipher","summary":[]},{"type":"message","id":"msg_valid","role":"user","content":"continue"}]}`)
+
+	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	input := gjson.GetBytes(normalized, "input").Array()
+	require.Len(t, input, 2)
+	require.Equal(t, "reasoning", input[0].Get("type").String())
+	require.False(t, input[0].Get("id").Exists())
+	require.Equal(t, "cipher", input[0].Get("encrypted_content").String())
+	require.True(t, input[0].Get("summary").IsArray())
+	require.Equal(t, "msg_valid", input[1].Get("id").String(), "non-reasoning ids must remain unchanged")
+}
+
+func TestNormalizeOpenAIPassthroughOAuthBody_CompactPreservesReasoningID(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","id":"rs_valid","encrypted_content":"cipher","summary":[]}]}`)
+
+	normalized, _, err := normalizeOpenAIPassthroughOAuthBody(body, true)
+	require.NoError(t, err)
+	require.Equal(t, "rs_valid", gjson.GetBytes(normalized, "input.0.id").String())
+}

--- a/backend/internal/service/openai_passthrough_normalization_test.go
+++ b/backend/internal/service/openai_passthrough_normalization_test.go
@@ -375,3 +375,27 @@ func TestDetectOpenAIPassthroughInstructionsRejectReason(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeOpenAIPassthroughOAuthBody_StripsReasoningID(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","id":"item_badprefix","encrypted_content":"cipher","summary":[]},{"type":"message","id":"msg_valid","role":"user","content":"continue"}]}`)
+
+	normalized, changed, err := normalizeOpenAIPassthroughOAuthBody(body, false)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	input := gjson.GetBytes(normalized, "input").Array()
+	require.Len(t, input, 2)
+	require.Equal(t, "reasoning", input[0].Get("type").String())
+	require.False(t, input[0].Get("id").Exists())
+	require.Equal(t, "cipher", input[0].Get("encrypted_content").String())
+	require.True(t, input[0].Get("summary").IsArray())
+	require.Equal(t, "msg_valid", input[1].Get("id").String(), "non-reasoning ids must remain unchanged")
+}
+
+func TestNormalizeOpenAIPassthroughOAuthBody_CompactPreservesReasoningID(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","input":[{"type":"reasoning","id":"rs_valid","encrypted_content":"cipher","summary":[]}]}`)
+
+	normalized, _, err := normalizeOpenAIPassthroughOAuthBody(body, true)
+	require.NoError(t, err)
+	require.Equal(t, "rs_valid", gjson.GetBytes(normalized, "input.0.id").String())
+}


### PR DESCRIPTION
Responses compatibility bridges generate generic `item_*` IDs for reasoning output, which strict Responses upstreams reject when that history is replayed. The Chat Completions stream also generates a different reasoning ID in `response.completed` from the one announced earlier.

Generate `rs_*` reasoning IDs in both Anthropic and Chat Completions conversions, and reuse the announced ID through the Chat Completions stream lifecycle. Non-compact OAuth passthrough removes reasoning input IDs under its existing `store=false` contract, preserving encrypted content, summaries, other fields, and non-reasoning IDs. Compact requests retain their IDs.

Rebased onto current main, preserving its Anthropic interleaved-thinking closure and request normalization. The newer API-key-side invalid-ID repair does not fix bridge output IDs or this OAuth normalization seam. Existing regression coverage now uses the current converter signature.

Validation on Go 1.27.1: `go test -tags=unit ./internal/pkg/apicompat ./internal/service -count=1` passed both complete packages; `go vet -tags=unit ./internal/pkg/apicompat ./internal/service`, gofmt, and `git diff --check` passed. `golangci-lint` was unavailable locally and its release download was refused by the local publication guard, so no fresh golangci-lint result is claimed.
