### PR TITLE
feat: 适配 Anthropic 新模型 claude-opus-5

### DIFF
--- a/backend/internal/domain/constants.go
+++ b/backend/internal/domain/constants.go
@@ -133,6 +133,7 @@ var DefaultBedrockModelMapping = map[string]string{
 	// Claude Fable
 	"claude-fable-5": "anthropic.claude-fable-5",
 	// Claude Opus
+	"claude-opus-5":            "us.anthropic.claude-opus-5-v1",
 	"claude-opus-4-8":          "us.anthropic.claude-opus-4-8-v1",
 	"claude-opus-4-7":          "us.anthropic.claude-opus-4-7-v1",
 	"claude-opus-4-6-thinking": "us.anthropic.claude-opus-4-6-v1",

--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -148,6 +148,12 @@ var DefaultModels = []Model{
 		CreatedAt:   "2026-05-29T00:00:00Z",
 	},
 	{
+		ID:          "claude-opus-5",
+		Type:        "model",
+		DisplayName: "Claude Opus 5",
+		CreatedAt:   "2026-07-25T00:00:00Z",
+	},
+	{
 		ID:          "claude-sonnet-5",
 		Type:        "model",
 		DisplayName: "Claude Sonnet 5",

--- a/backend/internal/service/bedrock_request.go
+++ b/backend/internal/service/bedrock_request.go
@@ -347,8 +347,13 @@ func removeCustomFieldFromTools(body []byte) []byte {
 }
 
 // claudeVersionRe 匹配 Claude 模型 ID 中的版本号部分
-// 支持 claude-{tier}-{major}-{minor} 和 claude-{tier}-{major}.{minor} 格式
-var claudeVersionRe = regexp.MustCompile(`claude-(?:haiku|sonnet|opus)-(\d+)[-.](\d+)`)
+// 支持 claude-{tier}-{major}-{minor} 和 claude-{tier}-{major}.{minor} 格式；
+// minor 可选，用于覆盖只有主版本号的新模型 ID（claude-opus-5 / claude-sonnet-5），
+// 此时 matches[2] 为空串，调用方 strconv.Atoi 得到 minor=0。
+// 缺少可选 minor 时这类 ID 完全不匹配，会被当作"旧模型"降级处理：
+// thinking.enabled 不转 adaptive（Opus 5 上游已移除 budget_tokens，直接 400）、
+// cache_control.ttl 被剥离、tool search 被过滤。
+var claudeVersionRe = regexp.MustCompile(`claude-(?:haiku|sonnet|opus)-(\d+)(?:[-.](\d+))?`)
 
 // isBedrockClaude45OrNewer 判断 Bedrock 模型 ID 是否为 Claude 4.5 或更新版本
 // Claude 4.5+ 支持 cache_control 中的 ttl 字段（"5m" 和 "1h"）

--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -258,6 +258,11 @@ func (s *BillingService) initFallbackPricing() {
 	// Claude 4.7 Opus (暂与4.6同价，待官方定价更新)
 	s.fallbackPrices["claude-opus-4.7"] = s.fallbackPrices["claude-opus-4.6"]
 
+	// Claude 4.8 Opus / Claude Opus 5（官方同价：$5 输入 / $25 输出 per MTok）。
+	// 缺少这两条时 getFallbackPricing 会掉到 claude-3-opus（$15/$75），造成 3 倍超收。
+	s.fallbackPrices["claude-opus-4.8"] = s.fallbackPrices["claude-opus-4.7"]
+	s.fallbackPrices["claude-opus-5"] = s.fallbackPrices["claude-opus-4.8"]
+
 	// Gemini 3.1 Pro
 	s.fallbackPrices["gemini-3.1-pro"] = &ModelPricing{
 		InputPricePerToken:         2e-6,   // $2 per MTok
@@ -588,6 +593,13 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 
 	// 按模型系列匹配
 	if strings.Contains(modelLower, "opus") {
+		// "opus-5" 必须先判：不能用裸 "5" 匹配，否则 claude-opus-4-5 会被误判。
+		if strings.Contains(modelLower, "opus-5") || strings.Contains(modelLower, "opus5") {
+			return s.fallbackPrices["claude-opus-5"]
+		}
+		if strings.Contains(modelLower, "4.8") || strings.Contains(modelLower, "4-8") {
+			return s.fallbackPrices["claude-opus-4.8"]
+		}
 		if strings.Contains(modelLower, "4.7") || strings.Contains(modelLower, "4-7") {
 			return s.fallbackPrices["claude-opus-4.7"]
 		}

--- a/backend/internal/service/claude_opus5_test.go
+++ b/backend/internal/service/claude_opus5_test.go
@@ -1,0 +1,139 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/domain"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/claude"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Claude Opus 5 官方定价（USD per token）：$5 输入 / $25 输出 per MTok。
+const (
+	opus5InputPricePerToken         = 5e-6
+	opus5OutputPricePerToken        = 25e-6
+	opus5CacheCreationPricePerToken = 6.25e-6
+	opus5CacheReadPricePerToken     = 0.5e-6
+)
+
+// TestClaudeOpus5_FamilyFallbackDoesNotUseOpus4Rates 覆盖定价数据里还没有
+// claude-opus-5 条目的场景（远端价格表滞后于模型发布）。
+// 修复前 matchByModelFamily 会把 claude-opus-5 归到 "opus-4" 系列，
+// 按 $15/$75 计费 —— 输入与输出双双 3 倍超收。
+func TestClaudeOpus5_FamilyFallbackDoesNotUseOpus4Rates(t *testing.T) {
+	svc := NewBillingService(&config.Config{}, &PricingService{
+		pricingData: map[string]*LiteLLMModelPricing{
+			// 有 4.8（同价），故意不放 claude-opus-5
+			"claude-opus-4-8": {
+				InputCostPerToken:           opus5InputPricePerToken,
+				OutputCostPerToken:          opus5OutputPricePerToken,
+				CacheCreationInputTokenCost: opus5CacheCreationPricePerToken,
+				CacheReadInputTokenCost:     opus5CacheReadPricePerToken,
+			},
+			// 修复前会被误命中的旧 Opus 条目（$15/$75）
+			"claude-opus-4-1":        {InputCostPerToken: 15e-6, OutputCostPerToken: 75e-6},
+			"claude-opus-4-20250514": {InputCostPerToken: 15e-6, OutputCostPerToken: 75e-6},
+			"claude-3-opus-20240229": {InputCostPerToken: 15e-6, OutputCostPerToken: 75e-6},
+		},
+	})
+
+	for _, model := range []string{"claude-opus-5", "us.anthropic.claude-opus-5-v1"} {
+		t.Run(model, func(t *testing.T) {
+			pricing, err := svc.GetModelPricing(model)
+			require.NoError(t, err)
+			require.NotNil(t, pricing)
+			assert.InDelta(t, opus5InputPricePerToken, pricing.InputPricePerToken, 1e-12)
+			assert.InDelta(t, opus5OutputPricePerToken, pricing.OutputPricePerToken, 1e-12)
+		})
+	}
+}
+
+// TestClaudeOpus5_HardcodedFallbackPricing 覆盖动态价格服务完全不可用时的
+// 硬编码兜底表。同时锁定不能被 "opus-5" 子串误伤的相邻型号。
+func TestClaudeOpus5_HardcodedFallbackPricing(t *testing.T) {
+	// pricingService 为 nil，强制走硬编码兜底表
+	svc := NewBillingService(&config.Config{}, nil)
+
+	tests := []struct {
+		model  string
+		input  float64
+		output float64
+	}{
+		{"claude-opus-5", opus5InputPricePerToken, opus5OutputPricePerToken},
+		{"us.anthropic.claude-opus-5-v1", opus5InputPricePerToken, opus5OutputPricePerToken},
+		// 4.8 与 5 同价；修复前兜底表缺失，会掉到 claude-3-opus 的 $15/$75
+		{"claude-opus-4-8", opus5InputPricePerToken, opus5OutputPricePerToken},
+		// 相邻型号不能被 "opus-5" 误匹配
+		{"claude-opus-4-5-20251101", 5e-6, 25e-6},
+		{"claude-opus-4-1-20250805", 15e-6, 75e-6},
+		{"claude-3-opus-20240229", 15e-6, 75e-6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			pricing, err := svc.GetModelPricing(tt.model)
+			require.NoError(t, err)
+			require.NotNil(t, pricing)
+			assert.InDelta(t, tt.input, pricing.InputPricePerToken, 1e-12)
+			assert.InDelta(t, tt.output, pricing.OutputPricePerToken, 1e-12)
+		})
+	}
+
+	opus5, err := svc.GetModelPricing("claude-opus-5")
+	require.NoError(t, err)
+	assert.InDelta(t, opus5CacheCreationPricePerToken, opus5.CacheCreationPricePerToken, 1e-12)
+	assert.InDelta(t, opus5CacheReadPricePerToken, opus5.CacheReadPricePerToken, 1e-12)
+}
+
+// TestClaudeOpus5_BedrockCapabilityGates 锁定只有主版本号的模型 ID
+// （claude-opus-5 / claude-sonnet-5）能被版本闸门识别。
+// 修复前 claudeVersionRe 强制要求 major-minor，这类 ID 完全不匹配，
+// 会被当成旧模型降级。
+func TestClaudeOpus5_BedrockCapabilityGates(t *testing.T) {
+	tests := []struct {
+		modelID       string
+		claude45Newer bool
+		toolSearch    bool
+		opus47Newer   bool
+	}{
+		{"claude-opus-5", true, true, true},
+		{"us.anthropic.claude-opus-5-v1", true, true, true},
+		{"eu.anthropic.claude-opus-5-v1", true, true, true},
+		{"claude-sonnet-5", true, true, false},
+		{"us.anthropic.claude-sonnet-5-v1", true, true, false},
+		// 回归保护：旧模型不能因为 minor 可选而被误判为新版本
+		{"anthropic.claude-opus-4-1-v1", false, false, false},
+		{"anthropic.claude-sonnet-4-0-v1", false, false, false},
+		{"anthropic.claude-3-opus-20240229-v1:0", false, false, false},
+		{"us.anthropic.claude-opus-4-8-v1", true, true, true},
+		// Haiku 不支持 tool search
+		{"us.anthropic.claude-haiku-4-5-20251001-v1:0", true, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.modelID, func(t *testing.T) {
+			assert.Equal(t, tt.claude45Newer, isBedrockClaude45OrNewer(tt.modelID), "isBedrockClaude45OrNewer")
+			assert.Equal(t, tt.toolSearch, bedrockModelSupportsToolSearch(tt.modelID), "bedrockModelSupportsToolSearch")
+			assert.Equal(t, tt.opus47Newer, isBedrockOpus47OrNewer(tt.modelID), "isBedrockOpus47OrNewer")
+		})
+	}
+}
+
+// TestClaudeOpus5_BedrockThinkingConvertedToAdaptive 验证 Opus 5 在 Bedrock 路径上
+// 会把 thinking.type=enabled 转成 adaptive 并移除 budget_tokens。
+// 上游 Opus 5 已移除 budget_tokens，透传过去会直接 400。
+func TestClaudeOpus5_BedrockThinkingConvertedToAdaptive(t *testing.T) {
+	body := []byte(`{"thinking":{"type":"enabled","budget_tokens":10000}}`)
+	got := sanitizeBedrockThinking(body, "us.anthropic.claude-opus-5-v1")
+
+	assert.JSONEq(t, `{"thinking":{"type":"adaptive"}}`, string(got))
+}
+
+// TestClaudeOpus5_CatalogAndBedrockMapping 锁定模型清单与 Bedrock 默认映射。
+func TestClaudeOpus5_CatalogAndBedrockMapping(t *testing.T) {
+	assert.Contains(t, claude.DefaultModelIDs(), "claude-opus-5")
+
+	mapped, ok := domain.DefaultBedrockModelMapping["claude-opus-5"]
+	require.True(t, ok, "claude-opus-5 missing from DefaultBedrockModelMapping")
+	assert.Equal(t, "us.anthropic.claude-opus-5-v1", mapped)
+}

--- a/backend/internal/service/pricing_service.go
+++ b/backend/internal/service/pricing_service.go
@@ -789,6 +789,10 @@ func (s *PricingService) matchByModelFamily(model string) *LiteLLMModelPricing {
 	// 因子串关系误匹配 "claude-opus-4-7"（opus-4.7 系列）。
 	// 注意：原 map 实现存在 Go map 迭代随机性导致的同类 bug，此处改为有序切片修复。
 	families := []modelFamily{
+		// Opus 5 与 Opus 4.8 同价（$5/$25 per MTok）。定价数据缺失 claude-opus-5 时
+		// 必须回退到 4.8，否则会掉进 "opus-4" 系列按 $15/$75 计费（3 倍超收）。
+		{name: "opus-5", match: []string{"claude-opus-5"}, pricing: []string{"claude-opus-5", "claude-opus-4-8"}},
+		{name: "opus-4.8", match: []string{"claude-opus-4-8", "claude-opus-4.8"}, pricing: []string{"claude-opus-4-8", "claude-opus-4.8", "claude-opus-4-7"}},
 		{name: "opus-4.7", match: []string{"claude-opus-4-7", "claude-opus-4.7"}, pricing: []string{"claude-opus-4-7", "claude-opus-4.7", "claude-opus-4-6"}},
 		{name: "opus-4.6", match: []string{"claude-opus-4-6", "claude-opus-4.6"}},
 		{name: "opus-4.5", match: []string{"claude-opus-4-5", "claude-opus-4.5"}},
@@ -821,6 +825,11 @@ func (s *PricingService) matchByModelFamily(model string) *LiteLLMModelPricing {
 		switch {
 		case strings.Contains(model, "opus"):
 			switch {
+			// "opus-5" 必须先判：不能用裸 "5" 匹配，否则 claude-opus-4-5 会被误判。
+			case strings.Contains(model, "opus-5") || strings.Contains(model, "opus5"):
+				fallbackName = "opus-5"
+			case strings.Contains(model, "4.8") || strings.Contains(model, "4-8"):
+				fallbackName = "opus-4.8"
 			case strings.Contains(model, "4.7") || strings.Contains(model, "4-7"):
 				fallbackName = "opus-4.7"
 			case strings.Contains(model, "4.6") || strings.Contains(model, "4-6"):

--- a/backend/resources/model-pricing/model_prices_and_context_window.json
+++ b/backend/resources/model-pricing/model_prices_and_context_window.json
@@ -520,6 +520,42 @@
     "supports_xhigh_reasoning_effort": true,
     "tool_use_system_prompt_tokens": 346
   },
+  "claude-opus-5": {
+    "cache_creation_input_token_cost": 6.25e-06,
+    "cache_creation_input_token_cost_above_1hr": 1e-05,
+    "cache_read_input_token_cost": 5e-07,
+    "input_cost_per_token": 5e-06,
+    "litellm_provider": "anthropic",
+    "max_input_tokens": 1000000,
+    "max_output_tokens": 128000,
+    "max_tokens": 128000,
+    "mode": "chat",
+    "output_cost_per_token": 2.5e-05,
+    "provider_specific_entry": {
+      "fast": 6.0,
+      "us": 1.1
+    },
+    "search_context_cost_per_query": {
+      "search_context_size_high": 0.01,
+      "search_context_size_low": 0.01,
+      "search_context_size_medium": 0.01
+    },
+    "supports_adaptive_thinking": true,
+    "supports_assistant_prefill": false,
+    "supports_computer_use": true,
+    "supports_function_calling": true,
+    "supports_max_reasoning_effort": true,
+    "supports_minimal_reasoning_effort": true,
+    "supports_output_config": true,
+    "supports_pdf_input": true,
+    "supports_prompt_caching": true,
+    "supports_reasoning": true,
+    "supports_response_schema": true,
+    "supports_tool_choice": true,
+    "supports_vision": true,
+    "supports_xhigh_reasoning_effort": true,
+    "tool_use_system_prompt_tokens": 346
+  },
   "claude-sonnet-4-20250514": {
     "cache_creation_input_token_cost": 3.75e-06,
     "cache_creation_input_token_cost_above_1hr": 6e-06,

--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -225,6 +225,7 @@ const formatScopeName = (scope: string): string => {
     'claude-opus-4-6-thinking': 'COpus46T',
     'claude-opus-4-7': 'COpus47',
     'claude-opus-4-8': 'COpus48',
+    'claude-opus-5': 'COpus5',
     'claude-sonnet-4-6': 'CSon46',
     'claude-sonnet-4-5': 'CSon45',
     'claude-sonnet-4-5-thinking': 'CSon45T',

--- a/frontend/src/composables/useModelWhitelist.ts
+++ b/frontend/src/composables/useModelWhitelist.ts
@@ -32,6 +32,7 @@ export const claudeModels = [
   'claude-opus-4-6',
   'claude-opus-4-7',
   'claude-opus-4-8',
+  'claude-opus-5',
   'claude-sonnet-4-6',
   'claude-sonnet-5',
   'claude-fable-5'
@@ -267,6 +268,7 @@ const anthropicPresetMappings = [
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'claude-opus-4-6', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'claude-opus-4-7', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'claude-opus-4-8', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
+  { label: 'Opus 5', from: 'claude-opus-5', to: 'claude-opus-5', color: 'bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/30 dark:text-purple-400' },
   { label: 'Haiku 3.5', from: 'claude-3-5-haiku-20241022', to: 'claude-3-5-haiku-20241022', color: 'bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400' },
   { label: 'Haiku 4.5', from: 'claude-haiku-4-5-20251001', to: 'claude-haiku-4-5-20251001', color: 'bg-emerald-100 text-emerald-700 hover:bg-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-400' },
   { label: 'Opus->Sonnet', from: 'claude-opus-4-6', to: 'claude-sonnet-4-5-20250929', color: 'bg-amber-100 text-amber-700 hover:bg-amber-200 dark:bg-amber-900/30 dark:text-amber-400' }
@@ -360,6 +362,7 @@ const bedrockPresetMappings = [
   { label: 'Opus 4.6', from: 'claude-opus-4-6', to: 'us.anthropic.claude-opus-4-6-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.7', from: 'claude-opus-4-7', to: 'us.anthropic.claude-opus-4-7-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Opus 4.8', from: 'claude-opus-4-8', to: 'us.anthropic.claude-opus-4-8-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
+  { label: 'Opus 5', from: 'claude-opus-5', to: 'us.anthropic.claude-opus-5-v1', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },
   { label: 'Sonnet 5', from: 'claude-sonnet-5', to: 'us.anthropic.claude-sonnet-5-v1', color: 'bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-400' },
   { label: 'Sonnet 4.6', from: 'claude-sonnet-4-6', to: 'us.anthropic.claude-sonnet-4-6', color: 'bg-cyan-100 text-cyan-700 hover:bg-cyan-200 dark:bg-cyan-900/30 dark:text-cyan-400' },
   { label: 'Opus 4.5', from: 'claude-opus-4-5-thinking', to: 'us.anthropic.claude-opus-4-5-20251101-v1:0', color: 'bg-pink-100 text-pink-700 hover:bg-pink-200 dark:bg-pink-900/30 dark:text-pink-400' },


### PR DESCRIPTION
## 背景

Anthropic 发布 `claude-opus-5`（$5/$25 per MTok、1M 上下文默认即最大、128K 输出、thinking 默认开启且已移除 `budget_tokens`）。本 PR 完成网关侧适配。

除常规模型登记外，梳理过程中发现两个**会静默出错**的问题，一并修复。

## 一、模型登记

| 落点 | 内容 |
|---|---|
| `pkg/claude/constants.go` | `DefaultModels` 加 Opus 5，驱动 `/v1/models` 与 admin 模型选择器 |
| `domain/constants.go` | Bedrock 默认映射 → `us.anthropic.claude-opus-5-v1`（沿用本仓 4.8/Sonnet 5 的跨区推理约定，`ResolveBedrockModelID` 按 `aws_region` 换前缀） |
| `resources/model-pricing/*.json` | 离线兜底定价条目（$5/$25、1M/128K、`supports_assistant_prefill: false`） |
| `useModelWhitelist.ts` | `claudeModels` + Anthropic/Bedrock 预设映射 |
| `AccountStatusIndicator.vue` | 限流 scope 简称 `COpus5` |

## 二、修复：定价家族兜底 3 倍超收

定价数据缺 `claude-opus-5` 条目时（远端价格表滞后于模型发布是常态）：

- `PricingService.matchByModelFamily` 的 Phase 2 关键字兜底 → 落到 `opus-4` 系列
- `BillingService.getFallbackPricing` → 落到 `claude-3-opus`

两条路都按 **$15/$75** 计费，官方价 **$5/$25**，输入输出双双 3 倍超收，且没有任何报错或日志异常。

修复：两处补 `opus-5` 家族并回退到同价的 4.8。判断刻意用 `opus-5`/`opus5` 子串而非裸 `"5"` —— 后者会误伤 `claude-opus-4-5`。

顺带补齐兜底表缺失的 `claude-opus-4.8`（此前同样会掉到 `claude-3-opus`）。**这改动了 4.8 在降级路径上的计价，请留意。**

## 三、修复：Bedrock 版本闸门降级

`claudeVersionRe` 强制要求 `major-minor` 两段版本号，只有主版本号的 `claude-opus-5` / `claude-sonnet-5` **完全不匹配**，于是被当作旧模型：

| 闸门 | 后果 |
|---|---|
| `isBedrockOpus47OrNewer` 假 | `thinking.enabled` 不转 `adaptive` —— Opus 5 上游已移除 `budget_tokens`，透传过去**直接 400** |
| `isBedrockClaude45OrNewer` 假 | `cache_control.ttl` 被剥离 |
| `bedrockModelSupportsToolSearch` 假 | tool search 被过滤 |

修复：minor 改为可选（缺省 `minor=0`）。**`claude-sonnet-5` 此前就存在同一问题，一并修复。**

回归保护：`claude-opus-4-1` / `claude-sonnet-4-0` / `claude-3-opus` 不会因 minor 可选被误判为新版本（已在测试中锁定）。

## 四、刻意未改动

- **Antigravity 不接入**：无上游支持证据。`mapAntigravityModel` 对未映射模型返回空字符串即"该账号不支持"，fails closed 安全。确认后再动 5 处（映射表、`antigravity/claude_types.go`、`modelInfoMap`、前端 `antigravityModels`、迁移脚本）。
- **Vertex 无需改动**：`normalizeVertexAnthropicModelID` 只处理 `-YYYYMMDD`→`@YYYYMMDD`，无日期后缀的裸 ID 原样透传即正确。
- **`context-1m-2025-08-07` 白名单不动**：Opus 系上游不接受该 beta，且 Opus 5 的 1M 上下文是默认能力，继续过滤才对。
- **`UseKeyModal.vue` 的 models.dev 风格清单不动**：该表是手工精选子集（未含 4.7/4.8/Sonnet 5），非完整注册表。

## 待确认

`DefaultModels` 的 `CreatedAt` 填了 `2026-07-25`（适配当日）—— 真实发布日期未知，仅影响 `/v1/models` 返回值，如有确切日期改一行即可。

## 测试

新增 `backend/internal/service/claude_opus5_test.go`（无 build tag，默认构建即跑）：定价两层兜底、Bedrock 三闸门、thinking 转换、模型清单与 Bedrock 映射。

**逐个回退上述三处修复，确认测试会红**，恢复后全绿 —— 测试确实咬住了缺陷。

其他：`go build ./...` + `go vet` 通过；bedrock/pricing/billing/handler 定向测试（含 `-tags unit`）全绿；前端 `vue-tsc --noEmit` 干净，`useModelWhitelist` + `UseKeyModal` 26 用例通过。全量套件交给 CI。