### PR TITLE
feat(openai): support Anthropic /v1/messages over Responses WebSocket v2

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1115,12 +1115,13 @@ type GatewayOpenAIWSConfig struct {
 	// OAuthMaxConnsFactor: OAuth 账号连接池系数（effective=ceil(concurrency*factor)）
 	OAuthMaxConnsFactor float64 `mapstructure:"oauth_max_conns_factor"`
 	// APIKeyMaxConnsFactor: API Key 账号连接池系数（effective=ceil(concurrency*factor)）
-	APIKeyMaxConnsFactor  float64 `mapstructure:"apikey_max_conns_factor"`
-	DialTimeoutSeconds    int     `mapstructure:"dial_timeout_seconds"`
-	ReadTimeoutSeconds    int     `mapstructure:"read_timeout_seconds"`
-	WriteTimeoutSeconds   int     `mapstructure:"write_timeout_seconds"`
-	PoolTargetUtilization float64 `mapstructure:"pool_target_utilization"`
-	QueueLimitPerConn     int     `mapstructure:"queue_limit_per_conn"`
+	APIKeyMaxConnsFactor        float64 `mapstructure:"apikey_max_conns_factor"`
+	DialTimeoutSeconds          int     `mapstructure:"dial_timeout_seconds"`
+	ReadTimeoutSeconds          int     `mapstructure:"read_timeout_seconds"`
+	WriteTimeoutSeconds         int     `mapstructure:"write_timeout_seconds"`
+	MessagesDrainTimeoutSeconds int     `mapstructure:"messages_drain_timeout_seconds"`
+	PoolTargetUtilization       float64 `mapstructure:"pool_target_utilization"`
+	QueueLimitPerConn           int     `mapstructure:"queue_limit_per_conn"`
 	// EventFlushBatchSize: WS 流式写出批量 flush 阈值（事件条数）
 	EventFlushBatchSize int `mapstructure:"event_flush_batch_size"`
 	// EventFlushIntervalMS: WS 流式写出最大等待时间（毫秒）；0 表示仅按 batch 触发
@@ -2204,6 +2205,7 @@ func setDefaults() {
 	viper.SetDefault("gateway.openai_ws.dial_timeout_seconds", 10)
 	viper.SetDefault("gateway.openai_ws.read_timeout_seconds", 900)
 	viper.SetDefault("gateway.openai_ws.write_timeout_seconds", 120)
+	viper.SetDefault("gateway.openai_ws.messages_drain_timeout_seconds", 30)
 	viper.SetDefault("gateway.openai_ws.pool_target_utilization", 0.7)
 	viper.SetDefault("gateway.openai_ws.queue_limit_per_conn", 64)
 	viper.SetDefault("gateway.openai_ws.event_flush_batch_size", 1)
@@ -3147,6 +3149,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Gateway.OpenAIWS.WriteTimeoutSeconds <= 0 {
 		return fmt.Errorf("gateway.openai_ws.write_timeout_seconds must be positive")
+	}
+	if c.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds <= 0 {
+		return fmt.Errorf("gateway.openai_ws.messages_drain_timeout_seconds must be positive")
 	}
 	if c.Gateway.OpenAIWS.PoolTargetUtilization <= 0 || c.Gateway.OpenAIWS.PoolTargetUtilization > 1 {
 		return fmt.Errorf("gateway.openai_ws.pool_target_utilization must be within (0,1]")

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1730,6 +1730,11 @@ func TestValidateConfigErrors(t *testing.T) {
 			wantErr: "gateway.openai_ws.apikey_max_conns_factor",
 		},
 		{
+			name:    "gateway openai ws messages drain timeout",
+			mutate:  func(c *Config) { c.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds = 0 },
+			wantErr: "gateway.openai_ws.messages_drain_timeout_seconds",
+		},
+		{
 			name:    "gateway openai http2 fallback threshold",
 			mutate:  func(c *Config) { c.Gateway.OpenAIHTTP2.FallbackErrorThreshold = -1 },
 			wantErr: "gateway.openai_http2.fallback_error_threshold",
@@ -2402,6 +2407,9 @@ func TestLoad_DefaultGatewayImageStreamConfig(t *testing.T) {
 	}
 	if cfg.Gateway.StreamDataIntervalTimeout != 180 {
 		t.Fatalf("stream_data_interval_timeout = %d, want 180", cfg.Gateway.StreamDataIntervalTimeout)
+	}
+	if cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds != 30 {
+		t.Fatalf("openai_ws.messages_drain_timeout_seconds = %d, want 30", cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds)
 	}
 	if cfg.Gateway.StreamKeepaliveInterval != 10 {
 		t.Fatalf("stream_keepalive_interval = %d, want 10", cfg.Gateway.StreamKeepaliveInterval)

--- a/backend/internal/handler/dto/mappers.go
+++ b/backend/internal/handler/dto/mappers.go
@@ -595,7 +595,15 @@ func AccountSummaryFromService(a *service.Account) *AccountSummary {
 func usageLogFromServiceUser(l *service.UsageLog) UsageLog {
 	// 普通用户 DTO：严禁包含管理员字段（例如 account_rate_multiplier、account、upstream_model）。
 	requestType := l.EffectiveRequestType()
+	// Messages HTTP 兼容路径可能同时保留下游 stream/sync 语义与上游 WS 标记。
+	// 展示层强制 WS 优先：只要上游走了 Responses WSv2，就按 ws_v2 输出。
+	if l.OpenAIWSMode && requestType != service.RequestTypeCyberBlocked {
+		requestType = service.RequestTypeWSV2
+	}
 	stream, openAIWSMode := service.ApplyLegacyRequestFields(requestType, l.Stream, l.OpenAIWSMode)
+	if l.OpenAIWSMode {
+		openAIWSMode = true
+	}
 	requestedModel := l.RequestedModel
 	if requestedModel == "" {
 		requestedModel = l.Model

--- a/backend/internal/handler/dto/mappers_usage_test.go
+++ b/backend/internal/handler/dto/mappers_usage_test.go
@@ -50,6 +50,35 @@ func TestUsageLogFromService_PrefersRequestTypeForLegacyFields(t *testing.T) {
 	require.True(t, adminDTO.OpenAIWSMode)
 }
 
+func TestUsageLogFromService_PrefersOpenAIWSModeOverStreamSync(t *testing.T) {
+	t.Parallel()
+
+	streamLog := &service.UsageLog{
+		RequestID:    "req_ws_stream",
+		Model:        "gpt-5.6-sol",
+		RequestType:  service.RequestTypeStream,
+		Stream:       true,
+		OpenAIWSMode: true,
+	}
+	syncLog := &service.UsageLog{
+		RequestID:    "req_ws_sync",
+		Model:        "gpt-5.6-sol",
+		RequestType:  service.RequestTypeSync,
+		Stream:       false,
+		OpenAIWSMode: true,
+	}
+
+	streamDTO := UsageLogFromService(streamLog)
+	syncDTO := UsageLogFromServiceAdmin(syncLog)
+
+	require.Equal(t, "ws_v2", streamDTO.RequestType)
+	require.True(t, streamDTO.OpenAIWSMode)
+	require.True(t, streamDTO.Stream)
+	require.Equal(t, "ws_v2", syncDTO.RequestType)
+	require.True(t, syncDTO.OpenAIWSMode)
+	require.True(t, syncDTO.Stream)
+}
+
 func TestUsageCleanupTaskFromService_RequestTypeMapping(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -53,6 +53,17 @@ func openAIForwardSucceededForScheduling(result *service.OpenAIForwardResult) bo
 	return result.SucceededForScheduling()
 }
 
+func settleOpenAIMessagesUsageOnce(result *service.OpenAIForwardResult, submit func()) func() {
+	settled := false
+	return func() {
+		if settled || result == nil || submit == nil {
+			return
+		}
+		settled = true
+		submit()
+	}
+}
+
 func resolveOpenAIMessagesDispatchMappedModel(apiKey *service.APIKey, requestedModel string) string {
 	if apiKey == nil || apiKey.Group == nil {
 		return ""
@@ -1022,8 +1033,46 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		if err == nil && result != nil && result.FirstTokenMs != nil {
 			service.SetOpsLatencyMs(c, service.OpsTimeToFirstTokenMsKey, int64(*result.FirstTokenMs))
 		}
+
+		settleUsage := settleOpenAIMessagesUsageOnce(result, func() {
+			userAgent := c.GetHeader("User-Agent")
+			clientIP := ip.GetClientIP(c)
+			requestPayloadHash := service.HashUsageRequestPayload(body)
+			inboundEndpoint := GetInboundEndpoint(c)
+			upstreamEndpoint := resolveOpenAIUpstreamEndpoint(c, account, result)
+			quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
+			cyberBlocked := service.GetOpsCyberPolicy(c) != nil
+			h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
+				if recordErr := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
+					Result:             result,
+					APIKey:             apiKey,
+					User:               apiKey.User,
+					Account:            account,
+					Subscription:       subscription,
+					InboundEndpoint:    inboundEndpoint,
+					UpstreamEndpoint:   upstreamEndpoint,
+					UserAgent:          userAgent,
+					IPAddress:          clientIP,
+					RequestPayloadHash: requestPayloadHash,
+					APIKeyService:      h.apiKeyService,
+					QuotaPlatform:      quotaPlatform,
+					ChannelUsageFields: channelMappingMsg.ToUsageFields(reqModel, result.UpstreamModel),
+					CyberBlocked:       cyberBlocked,
+				}); recordErr != nil {
+					logger.L().With(
+						zap.String("component", "handler.openai_gateway.messages"),
+						zap.Int64("user_id", subject.UserID),
+						zap.Int64("api_key_id", apiKey.ID),
+						zap.Any("group_id", apiKey.GroupID),
+						zap.String("model", reqModel),
+						zap.Int64("account_id", account.ID),
+					).Error("openai_messages.record_usage_failed", zap.Error(recordErr))
+				}
+			})
+		})
 		if err != nil {
 			if result != nil && result.ImageCount > 0 {
+				settleUsage()
 				reqLog.Warn("openai_messages.forward_partial_error_with_image_result",
 					zap.Int64("account_id", account.ID),
 					zap.Int("image_count", result.ImageCount),
@@ -1090,13 +1139,20 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 					continue
 				}
 				if result != nil && result.ClientDisconnect {
+					settleUsage()
+					h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
 					reqLog.Info("openai_messages.client_disconnected",
 						zap.Int64("account_id", account.ID),
 						zap.Error(err),
 					)
 					return
 				}
-				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), false, nil)
+				settleUsage()
+				var firstTokenMs *int
+				if result != nil {
+					firstTokenMs = result.FirstTokenMs
+				}
+				h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), openAIForwardSucceededForScheduling(result), firstTokenMs)
 				wroteFallback := h.ensureAnthropicErrorResponse(c, streamStarted)
 				reqLog.Warn("openai_messages.forward_failed",
 					zap.Int64("account_id", account.ID),
@@ -1107,46 +1163,11 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 			}
 		}
 		if result != nil {
-			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), true, result.FirstTokenMs)
+			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), openAIForwardSucceededForScheduling(result), result.FirstTokenMs)
 		} else {
-			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), true, nil)
+			h.gatewayService.ReportOpenAIAccountScheduleResult(account.ID, account.GetMappedModel(currentRoutingModel), openAIForwardSucceededForScheduling(result), nil)
 		}
-
-		userAgent := c.GetHeader("User-Agent")
-		clientIP := ip.GetClientIP(c)
-		requestPayloadHash := service.HashUsageRequestPayload(body)
-		inboundEndpoint := GetInboundEndpoint(c)
-		upstreamEndpoint := resolveOpenAIUpstreamEndpoint(c, account, result)
-		quotaPlatform := service.QuotaPlatform(c.Request.Context(), apiKey)
-
-		cyberBlocked := service.GetOpsCyberPolicy(c) != nil
-		h.submitOpenAIUsageRecordTask(c.Request.Context(), result, func(ctx context.Context) {
-			if err := h.gatewayService.RecordUsage(ctx, &service.OpenAIRecordUsageInput{
-				Result:             result,
-				APIKey:             apiKey,
-				User:               apiKey.User,
-				Account:            account,
-				Subscription:       subscription,
-				InboundEndpoint:    inboundEndpoint,
-				UpstreamEndpoint:   upstreamEndpoint,
-				UserAgent:          userAgent,
-				IPAddress:          clientIP,
-				RequestPayloadHash: requestPayloadHash,
-				APIKeyService:      h.apiKeyService,
-				QuotaPlatform:      quotaPlatform,
-				ChannelUsageFields: channelMappingMsg.ToUsageFields(reqModel, result.UpstreamModel),
-				CyberBlocked:       cyberBlocked,
-			}); err != nil {
-				logger.L().With(
-					zap.String("component", "handler.openai_gateway.messages"),
-					zap.Int64("user_id", subject.UserID),
-					zap.Int64("api_key_id", apiKey.ID),
-					zap.Any("group_id", apiKey.GroupID),
-					zap.String("model", reqModel),
-					zap.Int64("account_id", account.ID),
-				).Error("openai_messages.record_usage_failed", zap.Error(err))
-			}
-		})
+		settleUsage()
 		reqLog.Debug("openai_messages.request_completed",
 			zap.Int64("account_id", account.ID),
 			zap.Int("switch_count", switchCount),

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -125,6 +125,29 @@ func TestOpenAIHandleStreamingAwareErrorWithCode_EmitsStableClassification(t *te
 	require.Equal(t, http.StatusBadGateway, streamErr.IntendedStatus)
 }
 
+func TestSettleOpenAIMessagesUsageOnceFailedResultExactlyOnce(t *testing.T) {
+	result := &service.OpenAIForwardResult{
+		OpenAIWSMode:          true,
+		UpstreamTerminalEvent: "response.failed",
+		Usage:                 service.OpenAIUsage{InputTokens: 3},
+	}
+	calls := 0
+	settleUsage := settleOpenAIMessagesUsageOnce(result, func() {
+		calls++
+		require.Equal(t, 3, result.Usage.InputTokens)
+	})
+	settleUsage()
+	settleUsage()
+	require.Equal(t, 1, calls)
+}
+
+func TestSettleOpenAIMessagesUsageOnceSkipsNilResult(t *testing.T) {
+	calls := 0
+	settleUsage := settleOpenAIMessagesUsageOnce(nil, func() { calls++ })
+	settleUsage()
+	require.Zero(t, calls)
+}
+
 func TestOpenAIForwardSucceededForScheduling(t *testing.T) {
 	require.True(t, openAIForwardSucceededForScheduling(nil))
 	require.True(t, openAIForwardSucceededForScheduling(&service.OpenAIForwardResult{}))
@@ -132,10 +155,12 @@ func TestOpenAIForwardSucceededForScheduling(t *testing.T) {
 		OpenAIWSMode:          true,
 		UpstreamTerminalEvent: "response.completed",
 	}))
-	require.False(t, openAIForwardSucceededForScheduling(&service.OpenAIForwardResult{
-		OpenAIWSMode:          true,
-		UpstreamTerminalEvent: "response.failed",
-	}))
+	for _, terminal := range []string{"response.failed", "response.incomplete", "response.cancelled", "response.canceled"} {
+		require.False(t, openAIForwardSucceededForScheduling(&service.OpenAIForwardResult{
+			OpenAIWSMode:          true,
+			UpstreamTerminalEvent: terminal,
+		}), terminal)
+	}
 }
 
 func TestOpenAIResponsesRequiredCapability(t *testing.T) {

--- a/backend/internal/pkg/apicompat/anthropic_responses_test.go
+++ b/backend/internal/pkg/apicompat/anthropic_responses_test.go
@@ -8,6 +8,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestResponsesEventToAnthropicEventsHandlesWSCancelledTerminal(t *testing.T) {
+	for _, eventType := range []string{"response.cancelled", "response.canceled"} {
+		t.Run(eventType, func(t *testing.T) {
+			state := NewResponsesEventToAnthropicState()
+			state.MessageStartSent = true
+			events := ResponsesEventToAnthropicEvents(&ResponsesStreamEvent{
+				Type: eventType,
+				Response: &ResponsesResponse{
+					Status: "cancelled",
+					Usage:  &ResponsesUsage{InputTokens: 3, OutputTokens: 1},
+				},
+			}, state)
+
+			require.Len(t, events, 2)
+			assert.Equal(t, "message_delta", events[0].Type)
+			assert.Equal(t, 3, events[0].Usage.InputTokens)
+			assert.Equal(t, 1, events[0].Usage.OutputTokens)
+			assert.Equal(t, "message_stop", events[1].Type)
+			assert.True(t, state.MessageStopSent)
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // AnthropicToResponses tests
 // ---------------------------------------------------------------------------

--- a/backend/internal/pkg/apicompat/responses_to_anthropic.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic.go
@@ -242,7 +242,7 @@ func ResponsesEventToAnthropicEvents(
 		return nil
 	// response.done 是 Realtime/WS 与项目透传路径使用的终止别名；
 	// 普通 Responses HTTP SSE 的公开终止事件仍以 response.completed 为主。
-	case "response.completed", "response.done", "response.incomplete", "response.failed":
+	case "response.completed", "response.done", "response.incomplete", "response.failed", "response.cancelled", "response.canceled":
 		return resToAnthHandleCompleted(evt, state)
 	default:
 		return nil

--- a/backend/internal/repository/scheduler_cache.go
+++ b/backend/internal/repository/scheduler_cache.go
@@ -991,6 +991,7 @@ func filterSchedulerExtra(extra map[string]any) map[string]any {
 		"window_cost_sticky_reserve",
 		"max_sessions",
 		"session_idle_timeout_minutes",
+		service.OpenAIMessagesWebSocketV2ExtraKey,
 		"openai_oauth_responses_websockets_v2_enabled",
 		"openai_oauth_responses_websockets_v2_mode",
 		"openai_apikey_responses_websockets_v2_enabled",

--- a/backend/internal/repository/scheduler_cache_unit_test.go
+++ b/backend/internal/repository/scheduler_cache_unit_test.go
@@ -304,6 +304,7 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 		Platform: service.PlatformOpenAI,
 		Type:     service.AccountTypeOAuth,
 		Extra: map[string]any{
+			service.OpenAIMessagesWebSocketV2ExtraKey:      true,
 			"openai_oauth_responses_websockets_v2_enabled": true,
 			"openai_oauth_responses_websockets_v2_mode":    service.OpenAIWSIngressModePassthrough,
 			"openai_ws_force_http":                         true,
@@ -316,6 +317,7 @@ func TestBuildSchedulerMetadataAccount_KeepsOpenAIWSFlags(t *testing.T) {
 
 	got := buildSchedulerMetadataAccount(account)
 
+	require.Equal(t, true, got.Extra[service.OpenAIMessagesWebSocketV2ExtraKey])
 	require.Equal(t, true, got.Extra["openai_oauth_responses_websockets_v2_enabled"])
 	require.Equal(t, service.OpenAIWSIngressModePassthrough, got.Extra["openai_oauth_responses_websockets_v2_mode"])
 	require.Equal(t, true, got.Extra["openai_ws_force_http"])

--- a/backend/internal/repository/usage_log_repo_query.go
+++ b/backend/internal/repository/usage_log_repo_query.go
@@ -579,11 +579,13 @@ func scanUsageLog(scanner interface{ Scan(...any) error }) (*service.UsageLog, e
 		LongContextBillingApplied: longContextBillingApplied,
 		CreatedAt:                 createdAt,
 	}
-	// 先回填 legacy 字段，再基于 legacy + request_type 计算最终请求类型，保证历史数据兼容。
+	// 先回填 legacy 字段，再同步 request_type/legacy。
+	// 兼容路径可能同时保留下游 stream/sync 与上游 openai_ws_mode=true，
+	// 必须走 SyncRequestTypeAndLegacyFields，避免 ApplyLegacyRequestFields 在
+	// request_type=stream/sync 时把 openai_ws_mode 冲掉。
 	log.Stream = stream
 	log.OpenAIWSMode = openaiWSMode
-	log.RequestType = log.EffectiveRequestType()
-	log.Stream, log.OpenAIWSMode = service.ApplyLegacyRequestFields(log.RequestType, stream, openaiWSMode)
+	log.SyncRequestTypeAndLegacyFields()
 
 	if requestID.Valid {
 		log.RequestID = requestID.String

--- a/backend/internal/repository/usage_log_repo_request_type_test.go
+++ b/backend/internal/repository/usage_log_repo_request_type_test.go
@@ -967,6 +967,63 @@ func TestScanUsageLogRequestTypeAndLegacyFallback(t *testing.T) {
 		require.False(t, log.OpenAIWSMode)
 	})
 
+	t.Run("stream_request_type_preserves_openai_ws_mode", func(t *testing.T) {
+		now := time.Now().UTC()
+		log, err := scanUsageLog(usageLogScannerStub{values: []any{
+			int64(5),
+			int64(14),
+			int64(24),
+			int64(34),
+			sql.NullString{Valid: true, String: "req-ws-stream"},
+			"gpt-5.6-sol",
+			sql.NullString{Valid: true, String: "gpt-5.6-sol"},
+			sql.NullString{},
+			sql.NullInt64{},
+			sql.NullInt64{},
+			1, 2, 3, 4, 5, 6,
+			0, 0.0,
+			0, 0.0,
+			0.1, 0.2, 0.3, 0.4, 1.0, 0.9,
+			1.0,
+			sql.NullFloat64{},
+			int16(service.BillingTypeBalance),
+			int16(service.RequestTypeStream),
+			true,  // downstream stream
+			true,  // upstream openai ws
+			sql.NullInt64{},
+			sql.NullInt64{},
+			sql.NullString{},
+			sql.NullString{},
+			0,
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			0,
+			sql.NullString{},
+			sql.NullInt64{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{Valid: true, String: "/v1/messages"},
+			sql.NullString{Valid: true, String: "/v1/responses"},
+			false,
+			false,
+			sql.NullInt64{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullString{},
+			sql.NullFloat64{},
+			now,
+		}})
+		require.NoError(t, err)
+		// DB 可能同时保留 request_type=stream 与 openai_ws_mode=true。
+		// scan 后必须保留 WS 标记，展示层再强制 ws_v2 优先。
+		require.Equal(t, service.RequestTypeStream, log.RequestType)
+		require.True(t, log.Stream)
+		require.True(t, log.OpenAIWSMode)
+	})
+
 	t.Run("service_tier_is_scanned", func(t *testing.T) {
 		now := time.Now().UTC()
 		log, err := scanUsageLog(usageLogScannerStub{values: []any{

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1660,6 +1660,19 @@ func (a *Account) IsOpenAIPassthroughEnabled() bool {
 	return false
 }
 
+const OpenAIMessagesWebSocketV2ExtraKey = "openai_oauth_messages_websockets_v2_enabled"
+
+// IsOpenAIMessagesWebSocketV2Enabled 返回 OpenAI OAuth 账号是否为
+// Anthropic Messages 兼容入口启用单轮 Responses WebSocket v2 上游。
+// 字段缺失、类型错误、非 OAuth 或非 OpenAI 账号均按关闭处理。
+func (a *Account) IsOpenAIMessagesWebSocketV2Enabled() bool {
+	if a == nil || !a.IsOpenAIOAuth() || a.Extra == nil {
+		return false
+	}
+	enabled, ok := a.Extra[OpenAIMessagesWebSocketV2ExtraKey].(bool)
+	return ok && enabled
+}
+
 // IsOpenAIResponsesWebSocketV2Enabled 返回 OpenAI 账号是否开启 Responses WebSocket v2。
 //
 // 分类型新字段：

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -42,6 +42,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	startTime := time.Now()
+	messagesWSEnabled := account.IsOpenAIMessagesWebSocketV2Enabled()
 
 	// 1. Parse Anthropic request
 	var anthropicReq apicompat.AnthropicRequest
@@ -92,7 +93,7 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 	compatReplayTrimmed := false
 	compatReplayGuardEnabled := shouldAutoInjectPromptCacheKeyForCompat(upstreamModel)
-	compatContinuationEnabled := openAICompatContinuationEnabled(account, upstreamModel)
+	compatContinuationEnabled := !messagesWSEnabled && openAICompatContinuationEnabled(account, upstreamModel)
 	previousResponseID := ""
 	if compatContinuationEnabled {
 		previousResponseID = s.getOpenAICompatSessionResponseID(ctx, c, account, promptCacheKey)
@@ -278,7 +279,46 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	// 5. Get access token
 	token, _, err := s.getRequestCredential(ctx, c, account)
 	if err != nil {
-		return nil, fmt.Errorf("get access token: %w", err)
+		credentialErr := fmt.Errorf("get access token: %w", err)
+		if messagesWSEnabled {
+			return nil, openAIMessagesWSPrewriteFailover(credentialErr, http.StatusBadGateway, nil, nil)
+		}
+		return nil, credentialErr
+	}
+
+	if messagesWSEnabled {
+		result, forwardErr := s.forwardOpenAIMessagesSingleTurnWS(
+			ctx,
+			c,
+			account,
+			responsesBody,
+			token,
+			promptCacheKey,
+			clientStream,
+			originalModel,
+			billingModel,
+			upstreamModel,
+			startTime,
+		)
+		if forwardErr == nil && result != nil {
+			if responsesReq.ServiceTier != "" {
+				st := responsesReq.ServiceTier
+				result.ServiceTier = &st
+			}
+			if responsesReq.Reasoning != nil && responsesReq.Reasoning.Effort != "" {
+				re := responsesReq.Reasoning.Effort
+				result.ReasoningEffort = &re
+			}
+			if promptCacheKey != "" && anthropicDigestChain != "" {
+				s.bindOpenAICompatAnthropicDigestPromptCacheKey(account, apiKeyID, anthropicDigestChain, promptCacheKey, anthropicMatchedDigestChain)
+			}
+			if account.Type == AccountTypeOAuth && !account.IsShadow() {
+				if snapshot := ParseCodexRateLimitHeaders(result.ResponseHeaders); snapshot != nil {
+					s.updateCodexUsageSnapshot(ctx, account.ID, snapshot)
+				}
+			}
+		}
+		return result, forwardErr
 	}
 
 	// 6. Build upstream request
@@ -603,7 +643,7 @@ func (s *OpenAIGatewayService) handleAnthropicBufferedStreamingResponse(
 
 func isOpenAICompatResponsesTerminalEvent(eventType string) bool {
 	switch strings.TrimSpace(eventType) {
-	case "response.completed", "response.done", "response.incomplete", "response.failed":
+	case "response.completed", "response.done", "response.incomplete", "response.failed", "response.cancelled", "response.canceled":
 		return true
 	default:
 		return false

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -2524,6 +2524,48 @@ func TestRecordUsageMarksCyberRequestType(t *testing.T) {
 	require.Equal(t, 100, logStub.lastLog.InputTokens, "计费 token 不变(正常计费)")
 }
 
+func TestOpenAIGatewayServiceRecordUsage_PreservesMessagesWSRequestType(t *testing.T) {
+	tests := []struct {
+		name        string
+		requestType RequestType
+		stream      bool
+	}{
+		{name: "sync", requestType: RequestTypeSync, stream: false},
+		{name: "stream", requestType: RequestTypeStream, stream: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logStub := &openAIRecordUsageLogRepoStub{inserted: true}
+			svc := newOpenAIRecordUsageServiceForTest(
+				logStub,
+				&openAIRecordUsageUserRepoStub{},
+				&openAIRecordUsageSubRepoStub{},
+				nil,
+			)
+			err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+				Result: &OpenAIForwardResult{
+					Model:        "gpt-5",
+					Duration:     time.Second,
+					Stream:       test.stream,
+					RequestType:  test.requestType,
+					OpenAIWSMode: true,
+					Usage:        OpenAIUsage{InputTokens: 1, OutputTokens: 1},
+				},
+				APIKey:  &APIKey{ID: 2},
+				User:    &User{ID: 1},
+				Account: &Account{ID: 3},
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, logStub.lastLog)
+			require.Equal(t, test.requestType, logStub.lastLog.RequestType)
+			require.Equal(t, test.stream, logStub.lastLog.Stream)
+			require.True(t, logStub.lastLog.OpenAIWSMode)
+		})
+	}
+}
+
 func TestGatewayServiceCalculateRecordUsageCost_ChannelImageBillingNormalizesMissingSizeTier(t *testing.T) {
 	groupID := int64(128)
 	defaultPrice := 0.10

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -243,6 +243,9 @@ type OpenAIForwardResult struct {
 	ReasoningEffort *string
 	Stream          bool
 	OpenAIWSMode    bool
+	// RequestType overrides legacy transport-derived request classification when
+	// the downstream request shape and upstream transport differ.
+	RequestType RequestType
 	// UpstreamTerminalEvent is the normalized terminal event observed on an
 	// upstream Responses WebSocket turn. Empty preserves legacy/non-WS success.
 	UpstreamTerminalEvent string

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -301,6 +301,8 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 	usageLog.Stream = result.Stream
 	if input.CyberBlocked {
 		usageLog.RequestType = RequestTypeCyberBlocked
+	} else if result.RequestType.Normalize() != RequestTypeUnknown {
+		usageLog.RequestType = result.RequestType.Normalize()
 	}
 	usageLog.OpenAIWSMode = result.OpenAIWSMode
 	usageLog.DurationMs = &durationMs

--- a/backend/internal/service/openai_messages_ws_single_turn.go
+++ b/backend/internal/service/openai_messages_ws_single_turn.go
@@ -1,0 +1,343 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+const openAIMessagesResponsesUpstreamEndpoint = "/v1/responses"
+
+type openAIMessagesWSReadOutcome struct {
+	responseID    string
+	terminalEvent string
+	usage         OpenAIUsage
+	firstTokenMs  *int
+	err           error
+}
+
+// forwardOpenAIMessagesSingleTurnWS performs one direct-dial Responses WSv2
+// turn. Starting WriteJSON is the no-failover boundary: every error after that
+// point is returned as a normal error so the handler cannot resend the request.
+func (s *OpenAIGatewayService) forwardOpenAIMessagesSingleTurnWS(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	responsesBody []byte,
+	token string,
+	promptCacheKey string,
+	clientStream bool,
+	originalModel string,
+	billingModel string,
+	upstreamModel string,
+	startTime time.Time,
+) (*OpenAIForwardResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	SetActualOpenAIUpstreamEndpoint(c, openAIMessagesResponsesUpstreamEndpoint)
+
+	if err := validateOpenAIWSBearerToken(account, token); err != nil && (account == nil || !account.IsShadow()) {
+		return nil, openAIMessagesWSPrewriteFailover(err, http.StatusBadGateway, nil, nil)
+	}
+	var reqBody map[string]any
+	if err := json.Unmarshal(responsesBody, &reqBody); err != nil {
+		return nil, openAIMessagesWSPrewriteFailover(fmt.Errorf("decode response.create body: %w", err), http.StatusBadGateway, nil, nil)
+	}
+	if reqBody == nil {
+		return nil, openAIMessagesWSPrewriteFailover(errors.New("response.create body must be an object"), http.StatusBadGateway, nil, nil)
+	}
+	// This bridge is intentionally single-turn and never participates in OAuth
+	// response continuation, even if a caller supplied this field unexpectedly.
+	delete(reqBody, "previous_response_id")
+	payload := s.buildOpenAIWSCreatePayload(reqBody, account)
+	payload["store"] = false
+
+	wsURL, err := s.buildOpenAIResponsesWSURL(account)
+	if err != nil {
+		return nil, openAIMessagesWSPrewriteFailover(fmt.Errorf("build websocket url: %w", err), http.StatusBadGateway, nil, nil)
+	}
+	decision := OpenAIWSProtocolDecision{
+		Transport: OpenAIUpstreamTransportResponsesWebsocketV2,
+		Reason:    "messages_account_enabled",
+	}
+	headers, _, err := s.buildOpenAIWSHeaders(ctx, c, account, token, decision, false, "", "", promptCacheKey)
+	if err != nil {
+		return nil, openAIMessagesWSPrewriteFailover(fmt.Errorf("build websocket headers: %w", err), http.StatusBadGateway, nil, nil)
+	}
+	headers, err = s.refreshOpenAIAgentIdentityHeaders(ctx, account, headers)
+	if err != nil {
+		return nil, openAIMessagesWSPrewriteFailover(fmt.Errorf("refresh websocket authentication headers: %w", err), http.StatusBadGateway, nil, nil)
+	}
+
+	proxyURL := ""
+	if account != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	dialer := s.getOpenAIWSPassthroughDialer()
+	if dialer == nil {
+		return nil, openAIMessagesWSPrewriteFailover(errors.New("openai websocket dialer is nil"), http.StatusBadGateway, nil, nil)
+	}
+	dialCtx, cancelDial := context.WithTimeout(ctx, s.openAIWSDialTimeout())
+	conn, statusCode, handshakeHeaders, dialErr := dialer.Dial(dialCtx, wsURL, headers, proxyURL)
+	cancelDial()
+	if dialErr != nil {
+		var handshakeErr *openAIWSHandshakeError
+		var responseBody []byte
+		if errors.As(dialErr, &handshakeErr) && handshakeErr != nil {
+			responseBody = append([]byte(nil), handshakeErr.Body...)
+		}
+		wrapped := &openAIWSDialError{
+			StatusCode:      statusCode,
+			ResponseHeaders: cloneHeader(handshakeHeaders),
+			ResponseBody:    responseBody,
+			Err:             dialErr,
+		}
+		s.handleOpenAIWSDialTransientFailure(ctx, account, canonicalOpenAIAccountSchedulingModel(account, originalModel), wrapped)
+		if errors.Is(dialErr, context.Canceled) {
+			return nil, dialErr
+		}
+		if statusCode == 0 {
+			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, wrapped, false)
+		}
+		return nil, openAIMessagesWSPrewriteFailover(wrapped, statusCode, handshakeHeaders, responseBody)
+	}
+	if conn == nil {
+		return nil, openAIMessagesWSPrewriteFailover(errors.New("openai websocket dial returned a nil connection"), http.StatusBadGateway, handshakeHeaders, nil)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// A cancellation observed before WriteJSON is invoked means no upstream frame
+	// can have been sent. Return it directly rather than turning it into failover.
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	// The upstream may have begun consuming this frame as soon as WriteJSON is
+	// called. Never wrap this or any later error as UpstreamFailoverError.
+	writeCtx, cancelWrite := context.WithTimeout(ctx, s.openAIWSWriteTimeout())
+	writeErr := conn.WriteJSON(writeCtx, payload)
+	cancelWrite()
+	if writeErr != nil {
+		return nil, fmt.Errorf("write openai messages websocket request: %v", writeErr)
+	}
+
+	pipeReader, pipeWriter := io.Pipe()
+	outcomes := make(chan openAIMessagesWSReadOutcome, 1)
+	drain := make(chan struct{})
+	go s.readOpenAIMessagesSingleTurnWS(ctx, conn, pipeWriter, account, originalModel, handshakeHeaders, startTime, drain, outcomes)
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     cloneHeader(handshakeHeaders),
+		Body:       pipeReader,
+	}
+	var result *OpenAIForwardResult
+	var handleErr error
+	if clientStream {
+		result, handleErr = s.handleAnthropicStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+	} else {
+		result, handleErr = s.handleAnthropicBufferedStreamingResponse(resp, c, account, originalModel, billingModel, upstreamModel, startTime)
+	}
+	_ = pipeReader.Close()
+	close(drain)
+	outcome := <-outcomes
+
+	if result == nil {
+		result = &OpenAIForwardResult{
+			Model:         originalModel,
+			BillingModel:  billingModel,
+			UpstreamModel: upstreamModel,
+		}
+	}
+	if result.RequestID == "" {
+		result.RequestID = strings.TrimSpace(handshakeHeaders.Get("x-request-id"))
+	}
+	if outcome.responseID != "" {
+		result.ResponseID = outcome.responseID
+	}
+	result.Usage = outcome.usage
+	result.Stream = clientStream
+	if ctx.Err() != nil {
+		result.ClientDisconnect = true
+	}
+	if clientStream {
+		result.RequestType = RequestTypeStream
+	} else {
+		result.RequestType = RequestTypeSync
+	}
+	result.OpenAIWSMode = true
+	result.UpstreamEndpoint = openAIMessagesResponsesUpstreamEndpoint
+	result.UpstreamTerminalEvent = outcome.terminalEvent
+	result.ResponseHeaders = cloneHeader(handshakeHeaders)
+	result.Duration = time.Since(startTime)
+	// The SSE converter treats its first input chunk as TTFT. Only the WS reader
+	// knows whether that chunk contained a real token event, so always overwrite.
+	result.FirstTokenMs = outcome.firstTokenMs
+
+	if handleErr != nil && !(result.ClientDisconnect && outcome.terminalEvent != "") {
+		var failoverErr *UpstreamFailoverError
+		if errors.As(handleErr, &failoverErr) {
+			return result, fmt.Errorf("openai messages websocket response failed after request write: %v", failoverErr)
+		}
+		return result, handleErr
+	}
+	if outcome.err != nil {
+		return result, fmt.Errorf("read openai messages websocket response: %v", outcome.err)
+	}
+	if GetOpsCyberPolicy(c) != nil {
+		return nil, errOpenAICyberPolicyForwarded
+	}
+	return result, nil
+}
+
+func (s *OpenAIGatewayService) readOpenAIMessagesSingleTurnWS(
+	requestCtx context.Context,
+	conn openAIWSClientConn,
+	writer *io.PipeWriter,
+	account *Account,
+	originalModel string,
+	handshakeHeaders http.Header,
+	startTime time.Time,
+	drain <-chan struct{},
+	outcomes chan<- openAIMessagesWSReadOutcome,
+) {
+	outcome := openAIMessagesWSReadOutcome{}
+	deliveryOpen := true
+	requestDetached := false
+	draining := false
+	var drainCtx context.Context
+	var cancelDrain context.CancelFunc
+	normalReadCtx, cancelNormalReads := context.WithCancel(requestCtx)
+	readerDone := make(chan struct{})
+	go func() {
+		select {
+		case <-drain:
+			cancelNormalReads()
+		case <-readerDone:
+		}
+	}()
+	defer func() {
+		close(readerDone)
+		cancelNormalReads()
+		if cancelDrain != nil {
+			cancelDrain()
+		}
+		_ = writer.CloseWithError(outcome.err)
+		outcomes <- outcome
+	}()
+
+	startDrain := func() {
+		if draining {
+			return
+		}
+		draining = true
+		deliveryOpen = false
+		drainCtx, cancelDrain = context.WithTimeout(context.Background(), s.openAIMessagesWSDrainTimeout())
+	}
+
+	for {
+		if !draining {
+			select {
+			case <-requestCtx.Done():
+				requestDetached = true
+				startDrain()
+			case <-drain:
+				startDrain()
+			default:
+			}
+		}
+
+		baseCtx := normalReadCtx
+		if draining {
+			baseCtx = drainCtx
+		}
+		readCtx, cancelRead := context.WithTimeout(baseCtx, s.openAIWSReadTimeout())
+		message, err := conn.ReadMessage(readCtx)
+		cancelRead()
+		if err != nil {
+			if !draining {
+				select {
+				case <-requestCtx.Done():
+					requestDetached = true
+					startDrain()
+					continue
+				case <-drain:
+					startDrain()
+					continue
+				default:
+				}
+			}
+			outcome.err = err
+			return
+		}
+
+		documents := [][]byte{message}
+		if repaired, ok := splitOpenAIConcatenatedJSONDocuments(message); ok {
+			documents = repaired
+		}
+		for _, document := range documents {
+			eventType, responseID, _ := parseOpenAIWSEventEnvelope(document)
+			if outcome.responseID == "" && responseID != "" {
+				outcome.responseID = responseID
+			}
+			if outcome.firstTokenMs == nil && isOpenAIWSTokenEvent(eventType) {
+				ms := int(time.Since(startTime).Milliseconds())
+				outcome.firstTokenMs = &ms
+			}
+			if openAIWSEventShouldParseUsage(eventType) {
+				parseOpenAIWSResponseUsageFromCompletedEvent(document, &outcome.usage)
+			}
+
+			if deliveryOpen {
+				if _, err := fmt.Fprintf(writer, "data: %s\n\n", document); err != nil {
+					startDrain()
+				}
+			}
+			if isOpenAIWSTerminalEvent(eventType) {
+				failureCtx := requestCtx
+				if requestDetached {
+					failureCtx = context.Background()
+				}
+				outcome.terminalEvent = s.handleOpenAIWSTerminalTransientFailure(failureCtx, account, canonicalOpenAIAccountSchedulingModel(account, originalModel), handshakeHeaders, document)
+				return
+			}
+			if eventType == "error" {
+				failureCtx := requestCtx
+				if requestDetached {
+					failureCtx = context.Background()
+				}
+				s.handleOpenAIWSErrorEventTransientFailure(failureCtx, account, canonicalOpenAIAccountSchedulingModel(account, originalModel), handshakeHeaders, document)
+				_, _, messageText := parseOpenAIWSErrorEventFields(document)
+				if strings.TrimSpace(messageText) == "" {
+					messageText = "upstream websocket error event"
+				}
+				outcome.err = errors.New(messageText)
+				return
+			}
+		}
+	}
+}
+
+func openAIMessagesWSPrewriteFailover(err error, statusCode int, headers http.Header, body []byte) error {
+	if err == nil {
+		return nil
+	}
+	var failoverErr *UpstreamFailoverError
+	if errors.As(err, &failoverErr) {
+		return err
+	}
+	if statusCode <= 0 {
+		statusCode = http.StatusBadGateway
+	}
+	if len(body) == 0 {
+		body, _ = json.Marshal(gin.H{"error": gin.H{"type": "upstream_error", "message": sanitizeUpstreamErrorMessage(err.Error())}})
+	}
+	return newOpenAIUpstreamFailoverError(statusCode, headers, body, err.Error(), false)
+}

--- a/backend/internal/service/openai_messages_ws_single_turn_test.go
+++ b/backend/internal/service/openai_messages_ws_single_turn_test.go
@@ -1,0 +1,630 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+type openAIMessagesWSConn struct {
+	mu               sync.Mutex
+	events           [][]byte
+	read             int
+	writes           []map[string]any
+	writeErr         error
+	readErr          error
+	onWrite          func()
+	onRead           func(read int)
+	blockAfterEvents bool
+	closed           bool
+}
+
+func (c *openAIMessagesWSConn) WriteJSON(_ context.Context, value any) error {
+	body, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.writes = append(c.writes, payload)
+	writeErr := c.writeErr
+	onWrite := c.onWrite
+	c.mu.Unlock()
+	if onWrite != nil {
+		onWrite()
+	}
+	return writeErr
+}
+
+func (c *openAIMessagesWSConn) ReadMessage(ctx context.Context) ([]byte, error) {
+	c.mu.Lock()
+	if c.read < len(c.events) {
+		message := append([]byte(nil), c.events[c.read]...)
+		c.read++
+		read := c.read
+		onRead := c.onRead
+		c.mu.Unlock()
+		if onRead != nil {
+			onRead(read)
+		}
+		return message, nil
+	}
+	readErr := c.readErr
+	blockAfterEvents := c.blockAfterEvents
+	c.mu.Unlock()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if blockAfterEvents {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	return nil, errors.New("unexpected end of websocket events")
+}
+
+func (c *openAIMessagesWSConn) Ping(context.Context) error { return nil }
+
+func (c *openAIMessagesWSConn) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = true
+	return nil
+}
+
+type openAIMessagesWSDialer struct {
+	mu         sync.Mutex
+	conn       openAIWSClientConn
+	err        error
+	statusCode int
+	headers    http.Header
+	calls      int
+	url        string
+	dialHeader http.Header
+}
+
+func (d *openAIMessagesWSDialer) Dial(_ context.Context, wsURL string, headers http.Header, _ string) (openAIWSClientConn, int, http.Header, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls++
+	d.url = wsURL
+	d.dialHeader = cloneHeader(headers)
+	return d.conn, d.statusCode, cloneHeader(d.headers), d.err
+}
+
+func newOpenAIMessagesWSTestContext(t *testing.T, body []byte) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "claude-code/test")
+	return c, rec
+}
+
+func newOpenAIMessagesWSAccount(enabled bool) *Account {
+	return &Account{
+		ID:          901,
+		Name:        "messages-ws-test",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-account",
+		},
+		Extra: map[string]any{OpenAIMessagesWebSocketV2ExtraKey: enabled},
+	}
+}
+
+func newOpenAIMessagesWSService(dialer openAIWSClientDialer) *OpenAIGatewayService {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 2
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 2
+	cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds = 1
+	return &OpenAIGatewayService{
+		cfg:                       cfg,
+		openaiWSPassthroughDialer: dialer,
+	}
+}
+
+func openAIMessagesWSEvents() [][]byte {
+	return [][]byte{
+		[]byte(`{"type":"response.created","response":{"id":"resp_ws","model":"gpt-5.4","status":"in_progress"}}`),
+		[]byte(`{"type":"response.output_item.added","output_index":0,"item":{"id":"msg_ws","type":"message","role":"assistant","content":[]}}`),
+		[]byte(`{"type":"response.content_part.added","output_index":0,"content_index":0,"part":{"type":"output_text","text":""}}`),
+		[]byte(`{"type":"response.output_text.delta","output_index":0,"content_index":0,"delta":"ok"}`),
+		[]byte(`{"type":"response.output_text.done","output_index":0,"content_index":0,"text":"ok"}`),
+		[]byte(`{"type":"response.completed","response":{"id":"resp_ws","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"message","id":"msg_ws","role":"assistant","status":"completed","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`),
+	}
+}
+
+func TestAccountIsOpenAIMessagesWebSocketV2Enabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		account *Account
+		want    bool
+	}{
+		{name: "nil", account: nil},
+		{name: "missing", account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth}},
+		{name: "false", account: newOpenAIMessagesWSAccount(false)},
+		{name: "wrong type", account: &Account{Platform: PlatformOpenAI, Type: AccountTypeOAuth, Extra: map[string]any{OpenAIMessagesWebSocketV2ExtraKey: "true"}}},
+		{name: "api key rejected", account: &Account{Platform: PlatformOpenAI, Type: AccountTypeAPIKey, Extra: map[string]any{OpenAIMessagesWebSocketV2ExtraKey: true}}},
+		{name: "other platform rejected", account: &Account{Platform: PlatformGrok, Type: AccountTypeOAuth, Extra: map[string]any{OpenAIMessagesWebSocketV2ExtraKey: true}}},
+		{name: "oauth enabled", account: newOpenAIMessagesWSAccount(true), want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.want, test.account.IsOpenAIMessagesWebSocketV2Enabled())
+		})
+	}
+}
+
+func TestMessagesWSFlagDoesNotChangeResponsesOrNativeIngressProtocolSelection(t *testing.T) {
+	account := newOpenAIMessagesWSAccount(true)
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+
+	decision := NewOpenAIWSProtocolResolver(cfg).Resolve(account)
+	require.Equal(t, OpenAIUpstreamTransportHTTPSSE, decision.Transport)
+	require.Equal(t, "account_disabled", decision.Reason)
+	require.Equal(t, OpenAIWSIngressModeOff, account.ResolveOpenAIResponsesWebSocketV2Mode(OpenAIWSIngressModeOff))
+}
+
+func TestForwardAsAnthropicMessagesWSDisabledUsesExistingHTTPPath(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	dialer := &openAIMessagesWSDialer{err: errors.New("must not dial")}
+	upstreamBody := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_http\",\"model\":\"gpt-5.4\",\"status\":\"completed\",\"output\":[{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"http\"}]}],\"usage\":{\"input_tokens\":1,\"output_tokens\":1}}}\n\n"
+	httpUpstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := newOpenAIMessagesWSService(dialer)
+	svc.httpUpstream = httpUpstream
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(false), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 0, dialer.calls)
+	require.Len(t, httpUpstream.requests, 1)
+	require.False(t, result.OpenAIWSMode)
+}
+
+func TestOpenAIMessagesWSDrainTimeoutDefaultOverrideAndReadCap(t *testing.T) {
+	t.Parallel()
+
+	defaultSvc := &OpenAIGatewayService{}
+	require.Equal(t, 30*time.Second, defaultSvc.openAIMessagesWSDrainTimeout())
+
+	overrideSvc := &OpenAIGatewayService{cfg: &config.Config{}}
+	overrideSvc.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 90
+	overrideSvc.cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds = 12
+	require.Equal(t, 12*time.Second, overrideSvc.openAIMessagesWSDrainTimeout())
+
+	overrideSvc.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 5
+	require.Equal(t, 5*time.Second, overrideSvc.openAIMessagesWSDrainTimeout())
+}
+
+func TestForwardAsAnthropicMessagesWSBufferedSingleTurn(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, rec := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: openAIMessagesWSEvents()}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols, headers: http.Header{"x-request-id": []string{"rid-ws"}}}
+	svc := newOpenAIMessagesWSService(dialer)
+	svc.cfg.Gateway.OpenAIWS.AllowStoreRecovery = true
+	account := newOpenAIMessagesWSAccount(true)
+	account.Extra["openai_ws_allow_store_recovery"] = true
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "cache-key", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, 1, dialer.calls)
+	require.Equal(t, "wss://chatgpt.com/backend-api/codex/responses", dialer.url)
+	require.Equal(t, openAIWSBetaV2Value, dialer.dialHeader.Get("OpenAI-Beta"))
+	require.Len(t, conn.writes, 1)
+	require.Equal(t, "response.create", conn.writes[0]["type"])
+	require.Equal(t, false, conn.writes[0]["store"])
+	require.NotContains(t, conn.writes[0], "previous_response_id")
+	require.True(t, conn.closed)
+	require.False(t, result.Stream)
+	require.Equal(t, RequestTypeSync, result.RequestType)
+	require.True(t, result.OpenAIWSMode)
+	require.Equal(t, openAIMessagesResponsesUpstreamEndpoint, result.UpstreamEndpoint)
+	require.Equal(t, "response.completed", result.UpstreamTerminalEvent)
+	require.Equal(t, "resp_ws", result.ResponseID)
+	require.Equal(t, 5, result.Usage.InputTokens)
+	require.Equal(t, 2, result.Usage.OutputTokens)
+	require.NotEmpty(t, bytes.TrimSpace(rec.Body.Bytes()))
+	require.Equal(t, "ok", jsonResponseText(t, rec.Body.Bytes()))
+}
+
+func TestForwardAsAnthropicMessagesWSCancelledTerminalConversion(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, rec := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: [][]byte{
+		[]byte(`{"type":"response.created","response":{"id":"resp_cancelled","model":"gpt-5.4","status":"in_progress"}}`),
+		[]byte(`{"type":"response.cancelled","response":{"id":"resp_cancelled","model":"gpt-5.4","status":"cancelled","usage":{"input_tokens":2,"output_tokens":0}}}`),
+	}}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "response.cancelled", result.UpstreamTerminalEvent)
+	require.Nil(t, result.FirstTokenMs)
+	require.Contains(t, rec.Body.String(), "event: message_stop")
+}
+
+func TestForwardAsAnthropicMessagesWSStreamingConversion(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, rec := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: openAIMessagesWSEvents()}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.True(t, result.Stream)
+	require.Equal(t, RequestTypeStream, result.RequestType)
+	require.True(t, result.OpenAIWSMode)
+	require.Contains(t, rec.Body.String(), "event: message_start")
+	require.Contains(t, rec.Body.String(), "event: content_block_delta")
+	require.Contains(t, rec.Body.String(), "event: message_stop")
+}
+
+func TestForwardAsAnthropicMessagesWSClientDisconnectDrainsTerminalUsage(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	c.Writer = &openAICompatFailingWriter{ResponseWriter: c.Writer, failAfter: 0}
+	ctx, cancel := context.WithCancel(context.Background())
+	conn := &openAIMessagesWSConn{
+		events: openAIMessagesWSEvents(),
+		onRead: func(read int) {
+			if read == 1 {
+				cancel()
+			}
+		},
+	}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(ctx, c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.ClientDisconnect)
+	require.Equal(t, "response.completed", result.UpstreamTerminalEvent)
+	require.Equal(t, 5, result.Usage.InputTokens)
+	require.Equal(t, 2, result.Usage.OutputTokens)
+	require.Equal(t, len(openAIMessagesWSEvents()), conn.read)
+	require.True(t, conn.closed)
+}
+
+func TestForwardAsAnthropicMessagesWSConcatenatedDeltaAndCompleted(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, rec := newOpenAIMessagesWSTestContext(t, body)
+	events := openAIMessagesWSEvents()
+	concatenated := append(append([]byte(nil), events[3]...), events[5]...)
+	conn := &openAIMessagesWSConn{events: [][]byte{events[0], events[1], events[2], concatenated}}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", result.UpstreamTerminalEvent)
+	require.Equal(t, 5, result.Usage.InputTokens)
+	require.Equal(t, 2, result.Usage.OutputTokens)
+	require.Contains(t, rec.Body.String(), `"text":"ok"`)
+	require.Contains(t, rec.Body.String(), "event: message_stop")
+}
+
+func TestForwardAsAnthropicMessagesWSLateDisconnectGetsFreshDrainDeadline(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events := openAIMessagesWSEvents()
+	conn := &openAIMessagesWSConn{events: events}
+	conn.onRead = func(read int) {
+		if read == len(events)-1 {
+			cancel()
+			time.Sleep(1100 * time.Millisecond)
+		}
+	}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+	svc.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 1
+	svc.cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds = 1
+
+	result, err := svc.ForwardAsAnthropic(ctx, c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.True(t, result.ClientDisconnect)
+	require.Equal(t, "response.completed", result.UpstreamTerminalEvent)
+	require.Equal(t, len(events), conn.read)
+}
+
+func TestForwardAsAnthropicMessagesWSReadDrainIsBounded(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	ctx, cancel := context.WithCancel(context.Background())
+	conn := &openAIMessagesWSConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.created","response":{"id":"resp_bounded","model":"gpt-5.4","status":"in_progress"}}`),
+		},
+		onWrite:          cancel,
+		blockAfterEvents: true,
+	}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+	svc.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 900
+	svc.cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds = 1
+
+	started := time.Now()
+	result, err := svc.ForwardAsAnthropic(ctx, c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.Error(t, err)
+	require.NotNil(t, result)
+	require.True(t, result.ClientDisconnect)
+	require.Contains(t, err.Error(), context.DeadlineExceeded.Error())
+	require.Less(t, time.Since(started), 3*time.Second)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.True(t, conn.closed)
+}
+
+func TestForwardAsAnthropicMessagesWSConverterTimeoutTriggersBoundedDrain(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":true}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{
+		events: [][]byte{
+			[]byte(`{"type":"response.created","response":{"id":"resp_timeout","model":"gpt-5.4","status":"in_progress"}}`),
+		},
+		blockAfterEvents: true,
+	}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+	svc.cfg.Gateway.StreamDataIntervalTimeout = 1
+	svc.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 900
+	svc.cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds = 1
+
+	started := time.Now()
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.Error(t, err)
+	require.NotNil(t, result)
+	require.Contains(t, err.Error(), "stream data interval timeout")
+	require.Less(t, time.Since(started), 4*time.Second)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.True(t, conn.closed)
+}
+
+func TestForwardAsAnthropicMessagesWSPrewriteCancellationWritesNothing(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	ctx, cancel := context.WithCancel(context.Background())
+	conn := &openAIMessagesWSConn{}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	dialer.conn = conn
+	svc := newOpenAIMessagesWSService(dialer)
+	originalDialer := svc.openaiWSPassthroughDialer
+	svc.openaiWSPassthroughDialer = openAIMessagesWSDialerFunc(func(ctx context.Context, wsURL string, headers http.Header, proxyURL string) (openAIWSClientConn, int, http.Header, error) {
+		cancel()
+		return originalDialer.Dial(ctx, wsURL, headers, proxyURL)
+	})
+
+	result, err := svc.ForwardAsAnthropic(ctx, c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.Nil(t, result)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Empty(t, conn.writes)
+	require.True(t, conn.closed)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+type openAIMessagesWSDialerFunc func(context.Context, string, http.Header, string) (openAIWSClientConn, int, http.Header, error)
+
+func (f openAIMessagesWSDialerFunc) Dial(ctx context.Context, wsURL string, headers http.Header, proxyURL string) (openAIWSClientConn, int, http.Header, error) {
+	return f(ctx, wsURL, headers, proxyURL)
+}
+
+func TestForwardAsAnthropicMessagesWSWriteErrorNeverFailover(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{writeErr: errors.New("partial write")}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.Nil(t, result)
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Len(t, conn.writes, 1)
+	require.True(t, conn.closed)
+}
+
+func TestForwardAsAnthropicMessagesWSReadErrorNeverFailover(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{
+		events:  openAIMessagesWSEvents()[:1],
+		readErr: errors.New("read failed"),
+	}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NotNil(t, result)
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Len(t, conn.writes, 1)
+	require.True(t, conn.closed)
+}
+
+func TestForwardAsAnthropicMessagesWSFailedTerminalNeverFailover(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: [][]byte{
+		[]byte(`{"type":"response.created","response":{"id":"resp_failed","model":"gpt-5.4","status":"in_progress"}}`),
+		[]byte(`{"type":"response.failed","response":{"id":"resp_failed","model":"gpt-5.4","status":"failed","error":{"code":"server_error","message":"failed"},"usage":{"input_tokens":3,"output_tokens":0}}}`),
+	}}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NotNil(t, result)
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Equal(t, "response.failed", result.UpstreamTerminalEvent)
+	require.Equal(t, 3, result.Usage.InputTokens)
+	require.Nil(t, result.FirstTokenMs)
+}
+
+func TestOpenAIMessagesWSCredentialErrorCanFailover(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	dialer := &openAIMessagesWSDialer{err: errors.New("must not dial")}
+	svc := newOpenAIMessagesWSService(dialer)
+	account := newOpenAIMessagesWSAccount(true)
+	delete(account.Credentials, "access_token")
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.4")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, 0, dialer.calls)
+}
+
+func TestForwardAsAnthropicMessagesWSNilDialConnectionCanFailover(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	dialer := &openAIMessagesWSDialer{statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, 1, dialer.calls)
+}
+
+func TestForwardAsAnthropicMessagesWSDialErrorCanFailover(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	dialer := &openAIMessagesWSDialer{err: errors.New("unauthorized"), statusCode: http.StatusUnauthorized}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.Nil(t, result)
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusUnauthorized, failoverErr.StatusCode)
+}
+
+func TestForwardAsAnthropicMessagesWSOAuthKeepsBearerAuthorization(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: openAIMessagesWSEvents()}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, newOpenAIMessagesWSAccount(true), body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, "Bearer oauth-token", dialer.dialHeader.Get("Authorization"))
+	require.Equal(t, "chatgpt-account", dialer.dialHeader.Get("ChatGPT-Account-Id"))
+}
+
+func TestForwardAsAnthropicMessagesWSAgentIdentityRefreshesAuthorization(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: openAIMessagesWSEvents()}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	key, privateKey := newTestAgentIdentityKey(t)
+	account := newOpenAIMessagesWSAccount(true)
+	account.ID = 903
+	account.Credentials = map[string]any{
+		"auth_mode":          OpenAIAuthModeAgentIdentity,
+		"agent_runtime_id":   key.runtimeID,
+		"agent_private_key":  privateKey,
+		"task_id":            key.taskID,
+		"chatgpt_account_id": "agent-account",
+	}
+	svc := newOpenAIMessagesWSService(dialer)
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	authorization := dialer.dialHeader.Get("Authorization")
+	require.True(t, strings.HasPrefix(authorization, "AgentAssertion "))
+	require.NotContains(t, authorization, "Bearer ")
+	require.Equal(t, "agent-account", dialer.dialHeader.Get("ChatGPT-Account-Id"))
+}
+
+func TestForwardAsAnthropicMessagesWSShadowAgentIdentityUsesParentHeaders(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.4","max_tokens":16,"messages":[{"role":"user","content":"hello"}],"stream":false}`)
+	c, _ := newOpenAIMessagesWSTestContext(t, body)
+	conn := &openAIMessagesWSConn{events: openAIMessagesWSEvents()}
+	dialer := &openAIMessagesWSDialer{conn: conn, statusCode: http.StatusSwitchingProtocols}
+	key, privateKey := newTestAgentIdentityKey(t)
+	parent := newOpenAIMessagesWSAccount(true)
+	parent.ID = 904
+	parent.Credentials = map[string]any{
+		"auth_mode":          OpenAIAuthModeAgentIdentity,
+		"agent_runtime_id":   key.runtimeID,
+		"agent_private_key":  privateKey,
+		"task_id":            key.taskID,
+		"chatgpt_account_id": "parent-agent-account",
+	}
+	parentID := parent.ID
+	shadow := newOpenAIMessagesWSAccount(true)
+	shadow.ID = 905
+	shadow.ParentAccountID = &parentID
+	shadow.Credentials = map[string]any{}
+	svc := newOpenAIMessagesWSService(dialer)
+	svc.accountRepo = &agentIdentityCredentialsRepo{account: parent}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, shadow, body, "", "gpt-5.4")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	authorization := dialer.dialHeader.Get("Authorization")
+	require.True(t, strings.HasPrefix(authorization, "AgentAssertion "))
+	require.NotContains(t, authorization, "Bearer ")
+	require.Equal(t, "parent-agent-account", dialer.dialHeader.Get("ChatGPT-Account-Id"))
+}
+
+func jsonResponseText(t *testing.T, body []byte) string {
+	t.Helper()
+	var response struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	require.NoError(t, json.Unmarshal(body, &response))
+	require.NotEmpty(t, response.Content)
+	return response.Content[0].Text
+}

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -306,6 +306,17 @@ func (s *OpenAIGatewayService) openAIWSReadTimeout() time.Duration {
 	return 15 * time.Minute
 }
 
+func (s *OpenAIGatewayService) openAIMessagesWSDrainTimeout() time.Duration {
+	timeout := 30 * time.Second
+	if s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds > 0 {
+		timeout = time.Duration(s.cfg.Gateway.OpenAIWS.MessagesDrainTimeoutSeconds) * time.Second
+	}
+	if readTimeout := s.openAIWSReadTimeout(); readTimeout > 0 && timeout > readTimeout {
+		return readTimeout
+	}
+	return timeout
+}
+
 func (s *OpenAIGatewayService) openAIWSPassthroughIdleTimeout() time.Duration {
 	if timeout := s.openAIWSReadTimeout(); timeout > 0 {
 		return timeout

--- a/backend/internal/service/scheduler_snapshot_hydration_test.go
+++ b/backend/internal/service/scheduler_snapshot_hydration_test.go
@@ -113,6 +113,9 @@ func TestOpenAISelectAccountWithLoadAwareness_HydratesSelectedAccountFromSchedul
 					"api_key":       "sk-live",
 					"model_mapping": map[string]any{"gpt-4": "gpt-4"},
 				},
+				Extra: map[string]any{
+					OpenAIMessagesWebSocketV2ExtraKey: true,
+				},
 			},
 		},
 	}
@@ -133,6 +136,9 @@ func TestOpenAISelectAccountWithLoadAwareness_HydratesSelectedAccountFromSchedul
 	}
 	if got := selection.Account.GetOpenAIApiKey(); got != "sk-live" {
 		t.Fatalf("expected hydrated api key, got %q", got)
+	}
+	if enabled, _ := selection.Account.Extra[OpenAIMessagesWebSocketV2ExtraKey].(bool); !enabled {
+		t.Fatalf("expected hydrated messages websocket flag")
 	}
 }
 

--- a/backend/internal/service/usage_log.go
+++ b/backend/internal/service/usage_log.go
@@ -212,5 +212,13 @@ func (u *UsageLog) SyncRequestTypeAndLegacyFields() {
 	}
 	requestType := u.EffectiveRequestType()
 	u.RequestType = requestType
+	if requestType == RequestTypeSync || requestType == RequestTypeStream {
+		// Some compatibility routes use WS upstream while remaining sync/stream
+		// HTTP requests downstream. Preserve that independent transport marker.
+		if u.OpenAIWSMode {
+			u.Stream = requestType == RequestTypeStream
+			return
+		}
+	}
 	u.Stream, u.OpenAIWSMode = ApplyLegacyRequestFields(requestType, u.Stream, u.OpenAIWSMode)
 }

--- a/backend/internal/service/usage_log_test.go
+++ b/backend/internal/service/usage_log_test.go
@@ -90,6 +90,22 @@ func TestUsageLogSyncRequestTypeAndLegacyFields(t *testing.T) {
 	require.True(t, log.OpenAIWSMode)
 }
 
+func TestUsageLogSyncRequestTypePreservesWSUpstreamMarker(t *testing.T) {
+	t.Parallel()
+
+	streamLog := &UsageLog{RequestType: RequestTypeStream, Stream: true, OpenAIWSMode: true}
+	streamLog.SyncRequestTypeAndLegacyFields()
+	require.Equal(t, RequestTypeStream, streamLog.RequestType)
+	require.True(t, streamLog.Stream)
+	require.True(t, streamLog.OpenAIWSMode)
+
+	syncLog := &UsageLog{RequestType: RequestTypeSync, Stream: false, OpenAIWSMode: true}
+	syncLog.SyncRequestTypeAndLegacyFields()
+	require.Equal(t, RequestTypeSync, syncLog.RequestType)
+	require.False(t, syncLog.Stream)
+	require.True(t, syncLog.OpenAIWSMode)
+}
+
 func TestUsageLogEffectiveRequestTypeFallback(t *testing.T) {
 	t.Parallel()
 

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -342,6 +342,8 @@ gateway:
     dial_timeout_seconds: 10
     read_timeout_seconds: 900
     write_timeout_seconds: 120
+    # Messages 客户端断开或 converter 结束后，等待上游 terminal usage 的最长时间（秒）；实际值不超过 read_timeout_seconds。
+    messages_drain_timeout_seconds: 30
     pool_target_utilization: 0.7
     queue_limit_per_conn: 64
     # 流式写出批量 flush 参数

--- a/frontend/src/utils/usageRequestType.ts
+++ b/frontend/src/utils/usageRequestType.ts
@@ -13,11 +13,16 @@ export const isUsageRequestType = (value: unknown): value is UsageRequestType =>
 }
 
 export const resolveUsageRequestType = (value: UsageRequestTypeLike): UsageRequestType => {
-  if (isUsageRequestType(value.request_type)) {
-    return value.request_type
+  // cyber 与 transport 正交，始终优先保留。
+  if (value.request_type === 'cyber') {
+    return 'cyber'
   }
+  // 上游 Responses WSv2 标记优先于下游 stream/sync 展示。
   if (value.openai_ws_mode) {
     return 'ws_v2'
+  }
+  if (isUsageRequestType(value.request_type)) {
+    return value.request_type
   }
   return value.stream ? 'stream' : 'sync'
 }


### PR DESCRIPTION
## Summary
- Add an account-level opt-in for OpenAI OAuth accounts to forward Claude Code `/v1/messages` through a single-turn Responses WebSocket v2 path, while keeping the downstream Anthropic SSE/JSON contract.
- Prefer `openai_ws_mode` when rendering usage request types so admin/user usage logs show WS instead of stream/sync for WS-backed traffic.
- Fix `scanUsageLog` so mixed `request_type=stream/sync` + `openai_ws_mode=true` rows no longer lose the WS flag via `ApplyLegacyRequestFields`.

## Scope notes
- Feature is **default off** and only applies to OpenAI OAuth accounts.
- First phase is single-turn direct-dial WS (`store=false`, no `previous_response_id` continuation / connection pooling).
- Includes unit coverage for the single-turn forwarder, DTO request-type preference, and repository scan legacy-field sync.

## Test plan
- [ ] Unit: `go test` for messages WS single-turn, DTO usage mapping, and `scanUsageLog` request-type cases
- [ ] Enable the account extra flag on one OpenAI OAuth account only
- [ ] Send Claude Code `/v1/messages` stream/sync requests and confirm upstream `/v1/responses` WS path + usage settlement
- [ ] Confirm usage API/admin UI shows `ws_v2` / WS for those rows
- [ ] Confirm non-WS accounts still show stream/sync