### PR TITLE
fix(openai): estimate CC stream usage when upstream omits include_usage

### DIFF
--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
@@ -227,6 +228,9 @@ type ccStreamScanState struct {
 	// Usage 为 include_usage chunk 中最近一次出现的用量（上游可能重复发送，
 	// 总是保留最新值）；终态事件中的用量由调用方在 finalize 阶段自行覆盖。
 	Usage OpenAIUsage
+	// OutputText 累计上游 delta 中的 content / reasoning_content / tool 参数，
+	// 供上游忽略 stream_options.include_usage 时本地估算 output_tokens。
+	OutputText strings.Builder
 	// FirstTokenMs 为首个实际输出 chunk（排除 usage-only chunk）的到达时延。
 	FirstTokenMs *int
 	// SawDone 表示上游发出了 [DONE] 哨兵。
@@ -278,6 +282,7 @@ func (s *OpenAIGatewayService) scanCCStream(
 			)
 			continue
 		}
+		appendCCStreamOutputText(&st.OutputText, &chunk)
 		if st.FirstTokenMs == nil && !isOpenAIChatUsageOnlyStreamChunk(payload) && chatChunkStartsResponsesOutput(&chunk) {
 			ms := int(time.Since(startTime).Milliseconds())
 			st.FirstTokenMs = &ms
@@ -295,6 +300,200 @@ func (s *OpenAIGatewayService) scanCCStream(
 		st.Err = err
 	}
 	return st
+}
+
+// openAIUsageIsEmpty reports whether usage has no billable token counters.
+// Some upstreams ignore stream_options.include_usage and leave every field at 0.
+func openAIUsageIsEmpty(u OpenAIUsage) bool {
+	return u.InputTokens == 0 &&
+		u.OutputTokens == 0 &&
+		u.CacheCreationInputTokens == 0 &&
+		u.CacheReadInputTokens == 0 &&
+		u.ImageInputTokens == 0 &&
+		u.ImageOutputTokens == 0
+}
+
+// appendCCStreamOutputText accumulates assistant-visible stream text for local
+// token estimation when the upstream omits a terminal usage chunk.
+func appendCCStreamOutputText(b *strings.Builder, chunk *apicompat.ChatCompletionsChunk) {
+	if b == nil || chunk == nil {
+		return
+	}
+	for _, choice := range chunk.Choices {
+		if choice.Delta.Content != nil {
+			b.WriteString(*choice.Delta.Content)
+		}
+		if choice.Delta.ReasoningContent != nil {
+			b.WriteString(*choice.Delta.ReasoningContent)
+		}
+		for _, toolCall := range choice.Delta.ToolCalls {
+			if toolCall.Function.Name != "" {
+				b.WriteString(toolCall.Function.Name)
+			}
+			if toolCall.Function.Arguments != "" {
+				b.WriteString(toolCall.Function.Arguments)
+			}
+		}
+	}
+}
+
+// resolveCCStreamUsage returns upstream usage when present; otherwise estimates
+// input/output tokens from the request body and accumulated stream text.
+// Estimation is intentionally conservative and only used as a billing fallback
+// for vendors that ignore stream_options.include_usage.
+func resolveCCStreamUsage(
+	usage OpenAIUsage,
+	requestBody []byte,
+	outputText string,
+	model string,
+	logPrefix string,
+	requestID string,
+) OpenAIUsage {
+	if !openAIUsageIsEmpty(usage) {
+		return usage
+	}
+
+	estimated := estimateMissingCCStreamUsage(requestBody, outputText, model)
+	if openAIUsageIsEmpty(estimated) {
+		return usage
+	}
+
+	logger.L().Warn(logPrefix+": upstream stream omitted usage; using local token estimate",
+		zap.String("request_id", requestID),
+		zap.String("model", model),
+		zap.Int("input_tokens", estimated.InputTokens),
+		zap.Int("output_tokens", estimated.OutputTokens),
+		zap.Int("output_chars", len(outputText)),
+	)
+	return estimated
+}
+
+func estimateMissingCCStreamUsage(requestBody []byte, outputText, model string) OpenAIUsage {
+	inputTokens := estimateCCRequestInputTokens(requestBody, model)
+	outputTokens := estimateCCTextTokens(outputText, model)
+	if inputTokens == 0 && outputTokens == 0 {
+		return OpenAIUsage{}
+	}
+	if inputTokens == 0 {
+		// Keep settlement rows non-zero when the model produced output but the
+		// request text extractor found nothing useful.
+		inputTokens = openAIInputTokensFallbackMinimum
+	}
+	return OpenAIUsage{
+		InputTokens:  inputTokens,
+		OutputTokens: outputTokens,
+	}
+}
+
+func estimateCCRequestInputTokens(requestBody []byte, model string) int {
+	text := extractCCRequestTextForEstimate(requestBody)
+	return estimateCCTextTokens(text, model)
+}
+
+func extractCCRequestTextForEstimate(requestBody []byte) string {
+	if len(bytes.TrimSpace(requestBody)) == 0 {
+		return ""
+	}
+
+	var parts []string
+	appendText := func(s string) {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			parts = append(parts, s)
+		}
+	}
+	appendContent := func(content gjson.Result) {
+		if !content.Exists() {
+			return
+		}
+		if content.Type == gjson.String {
+			appendText(content.String())
+			return
+		}
+		if content.IsArray() {
+			content.ForEach(func(_, part gjson.Result) bool {
+				if t := part.Get("text").String(); t != "" {
+					appendText(t)
+				}
+				if t := part.Get("content").String(); t != "" {
+					appendText(t)
+				}
+				if t := part.Get("input_text").String(); t != "" {
+					appendText(t)
+				}
+				if t := part.Get("thinking").String(); t != "" {
+					appendText(t)
+				}
+				return true
+			})
+			return
+		}
+		if content.IsObject() {
+			if t := content.Get("text").String(); t != "" {
+				appendText(t)
+			}
+		}
+	}
+
+	if system := gjson.GetBytes(requestBody, "system"); system.Exists() {
+		appendContent(system)
+	}
+	if instructions := gjson.GetBytes(requestBody, "instructions").String(); instructions != "" {
+		appendText(instructions)
+	}
+
+	gjson.GetBytes(requestBody, "messages").ForEach(func(_, msg gjson.Result) bool {
+		appendContent(msg.Get("content"))
+		appendText(msg.Get("reasoning_content").String())
+		msg.Get("tool_calls").ForEach(func(_, tool gjson.Result) bool {
+			appendText(tool.Get("function.name").String())
+			appendText(tool.Get("function.arguments").String())
+			return true
+		})
+		appendText(msg.Get("name").String())
+		return true
+	})
+
+	// Responses-shaped bodies (rare on pure CC path, but cheap to support).
+	if input := gjson.GetBytes(requestBody, "input"); input.Exists() {
+		if input.Type == gjson.String {
+			appendText(input.String())
+		} else if input.IsArray() {
+			input.ForEach(func(_, item gjson.Result) bool {
+				appendContent(item.Get("content"))
+				appendText(item.Get("text").String())
+				return true
+			})
+		}
+	}
+
+	gjson.GetBytes(requestBody, "tools").ForEach(func(_, tool gjson.Result) bool {
+		appendText(tool.Get("function.name").String())
+		appendText(tool.Get("function.description").String())
+		if params := tool.Get("function.parameters").Raw; params != "" {
+			appendText(params)
+		}
+		return true
+	})
+
+	return strings.Join(parts, "\n")
+}
+
+func estimateCCTextTokens(text, model string) int {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return 0
+	}
+	if codec, err := openAIInputTokensCodecForModel(model); err == nil {
+		if n, err := codec.Count(text); err == nil && n > 0 {
+			return n
+		}
+	}
+	n := estimateTokensForText(text)
+	if n < 1 {
+		return 1
+	}
+	return n
 }
 
 // logCCStreamMissingDoneSentinel 记录"上游未发 [DONE] 哨兵即结束"的 debug 日志。

--- a/backend/internal/service/openai_gateway_cc_stream_usage_fallback_test.go
+++ b/backend/internal/service/openai_gateway_cc_stream_usage_fallback_test.go
@@ -1,0 +1,187 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAIUsageIsEmpty(t *testing.T) {
+	t.Parallel()
+	require.True(t, openAIUsageIsEmpty(OpenAIUsage{}))
+	require.False(t, openAIUsageIsEmpty(OpenAIUsage{InputTokens: 1}))
+	require.False(t, openAIUsageIsEmpty(OpenAIUsage{OutputTokens: 1}))
+	require.False(t, openAIUsageIsEmpty(OpenAIUsage{CacheReadInputTokens: 1}))
+}
+
+func TestResolveCCStreamUsage_KeepsUpstreamUsage(t *testing.T) {
+	t.Parallel()
+	upstream := OpenAIUsage{InputTokens: 10, OutputTokens: 4, CacheReadInputTokens: 2}
+	got := resolveCCStreamUsage(upstream, []byte(`{"messages":[{"role":"user","content":"hello"}]}`), "ignored", "gpt-5.4", "test", "rid")
+	require.Equal(t, upstream, got)
+}
+
+func TestResolveCCStreamUsage_EstimatesWhenUpstreamOmitsUsage(t *testing.T) {
+	t.Parallel()
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello world from the client"}]}`)
+	got := resolveCCStreamUsage(OpenAIUsage{}, body, "hello from the assistant reply", "gpt-5.4", "test", "rid")
+	require.Greater(t, got.InputTokens, 0)
+	require.Greater(t, got.OutputTokens, 0)
+}
+
+func TestAppendCCStreamOutputText_CollectsContentReasoningAndTools(t *testing.T) {
+	t.Parallel()
+	content := "hi"
+	reasoning := "plan"
+	var b strings.Builder
+	appendCCStreamOutputText(&b, &apicompat.ChatCompletionsChunk{
+		Choices: []apicompat.ChatChunkChoice{
+			{
+				Delta: apicompat.ChatDelta{
+					Content:          &content,
+					ReasoningContent: &reasoning,
+					ToolCalls: []apicompat.ChatToolCall{
+						{Function: apicompat.ChatFunctionCall{Name: "lookup", Arguments: `{"q":"x"}`}},
+					},
+				},
+			},
+		},
+	})
+	require.Equal(t, `hiplanlookup{"q":"x"}`, b.String())
+}
+
+func TestForwardAsAnthropic_ForceChatCompletionsStreamingEstimatesMissingUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","max_tokens":32,"messages":[{"role":"user","content":"hello from client"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	// Upstream ignores include_usage: stream completes with content but no usage chunk.
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_missing","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_missing","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_missing","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_missing","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_msg_missing_usage"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, forceChatMessagesFallbackAccount(), body, "", "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.True(t, gjson.GetBytes(upstream.lastBody, "stream_options.include_usage").Bool())
+	require.Greater(t, result.Usage.InputTokens, 0, "input tokens should be estimated from request")
+	require.Greater(t, result.Usage.OutputTokens, 0, "output tokens should be estimated from stream text")
+	require.True(t, result.Stream)
+
+	out := rec.Body.String()
+	require.Contains(t, out, `"text":"hello"`)
+	require.Contains(t, out, "event: message_delta")
+	require.Contains(t, out, "event: message_stop")
+	// message_delta should carry estimated usage for clients that bill on stream.
+	require.Regexp(t, `"input_tokens":[1-9]`, out)
+	require.Regexp(t, `"output_tokens":[1-9]`, out)
+}
+
+func TestForwardResponses_ForceChatCompletionsStreamingEstimatesMissingUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","input":"hello from client","stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_missing_resp","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_missing_resp","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"content":"reply text"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl_missing_resp","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_resp_missing_usage"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+
+	result, err := svc.Forward(context.Background(), c, forceChatResponsesFallbackAccount(), body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, result.Usage.InputTokens, 0)
+	require.Greater(t, result.Usage.OutputTokens, 0)
+	require.Contains(t, rec.Body.String(), "event: response.completed")
+	require.Regexp(t, `"input_tokens":[1-9]`, rec.Body.String())
+	require.Regexp(t, `"output_tokens":[1-9]`, rec.Body.String())
+}
+
+func TestForwardAsRawChatCompletions_EstimatesMissingStreamUsage(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.4","messages":[{"role":"user","content":"hello from client"}],"stream":true}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstreamBody := strings.Join([]string{
+		`data: {"id":"chatcmpl_raw_missing","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{"content":"ok there"}}]}`,
+		"",
+		`data: {"id":"chatcmpl_raw_missing","object":"chat.completion.chunk","model":"gpt-5.4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_raw_missing_usage"}},
+		Body:       io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	account := rawChatCompletionsTestAccount()
+
+	result, err := svc.forwardAsRawChatCompletions(context.Background(), c, account, body, "")
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Greater(t, result.Usage.InputTokens, 0)
+	require.Greater(t, result.Usage.OutputTokens, 0)
+	// Raw path still passes through upstream chunks as-is; billing uses estimated usage.
+	require.Contains(t, rec.Body.String(), `"content":"ok there"`)
+}

--- a/backend/internal/service/openai_gateway_chat_completions_raw.go
+++ b/backend/internal/service/openai_gateway_chat_completions_raw.go
@@ -2,12 +2,14 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 	"github.com/Wei-Shaw/sub2api/internal/util/responseheaders"
 	"github.com/gin-gonic/gin"
@@ -212,7 +214,7 @@ func (s *OpenAIGatewayService) forwardAsRawChatCompletions(
 	var result *OpenAIForwardResult
 	var forwardErr error
 	if clientStream {
-		result, forwardErr = s.streamRawChatCompletions(c, resp, account, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime, len(body))
+		result, forwardErr = s.streamRawChatCompletions(c, resp, account, upstreamBody, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime, len(body))
 	} else {
 		result, forwardErr = s.bufferRawChatCompletions(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
@@ -245,6 +247,7 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 	c *gin.Context,
 	resp *http.Response,
 	account *Account,
+	requestBody []byte,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -258,6 +261,7 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 	scanner := s.newUpstreamSSEScanner(resp.Body)
 
 	var usage OpenAIUsage
+	var outputText strings.Builder
 	var firstTokenMs *int
 	clientDisconnected := false
 	clientOutputStarted := false
@@ -305,6 +309,13 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 				usageOnlyChunk := isOpenAIChatUsageOnlyStreamChunk(payload)
 				if u := extractCCStreamUsage(payload); u != nil {
 					usage = *u
+				}
+				// Accumulate deltas for local estimate when upstream omits usage.
+				if !usageOnlyChunk {
+					var chunk apicompat.ChatCompletionsChunk
+					if err := json.Unmarshal([]byte(payload), &chunk); err == nil {
+						appendCCStreamOutputText(&outputText, &chunk)
+					}
 				}
 				if firstTokenMs == nil && !usageOnlyChunk {
 					elapsed := int(time.Since(startTime).Milliseconds())
@@ -354,6 +365,15 @@ func (s *OpenAIGatewayService) streamRawChatCompletions(
 			}
 		}
 	}
+
+	usage = resolveCCStreamUsage(
+		usage,
+		requestBody,
+		outputText.String(),
+		billingModel,
+		"openai chat_completions raw",
+		requestID,
+	)
 
 	return &OpenAIForwardResult{
 		RequestID:       requestID,

--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -113,7 +113,7 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 
 	// 5. Convert response
 	if clientStream {
-		return s.streamChatCompletionsAsAnthropic(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+		return s.streamChatCompletionsAsAnthropic(c, resp, chatBody, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
 	return s.bufferChatCompletionsAsAnthropic(c, resp, originalModel, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 }
@@ -156,6 +156,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsAnthropic(
 func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 	c *gin.Context,
 	resp *http.Response,
+	requestBody []byte,
 	originalModel string,
 	billingModel string,
 	upstreamModel string,
@@ -194,7 +195,14 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 	}
 
 	scan := s.scanCCStream(resp, "openai messages chat fallback", requestID, startTime, emitChunk)
-	usage := scan.Usage
+	usage := resolveCCStreamUsage(
+		scan.Usage,
+		requestBody,
+		scan.OutputText.String(),
+		billingModel,
+		"openai messages chat fallback",
+		requestID,
+	)
 
 	if scan.Err != nil {
 		// Broken upstream read: skip finalization so no synthetic message_stop
@@ -213,6 +221,15 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsAnthropic(
 			FirstTokenMs:     scan.FirstTokenMs,
 			ClientDisconnect: clientDisconnected,
 		}, fmt.Errorf("stream usage incomplete: %w", scan.Err)
+	}
+
+	// Inject estimated usage into the Anthropic finalize path when upstream
+	// omitted include_usage, so message_delta also carries non-zero tokens.
+	if openAIUsageIsEmpty(scan.Usage) && !openAIUsageIsEmpty(usage) {
+		anthropicState.InputTokens = usage.InputTokens
+		anthropicState.OutputTokens = usage.OutputTokens
+		anthropicState.CacheReadInputTokens = usage.CacheReadInputTokens
+		anthropicState.CacheCreationInputTokens = usage.CacheCreationInputTokens
 	}
 
 	// Finalize: close open blocks + emit message_delta/message_stop.

--- a/backend/internal/service/openai_gateway_responses_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_responses_chat_fallback.go
@@ -112,7 +112,7 @@ func (s *OpenAIGatewayService) forwardResponsesViaRawChatCompletions(
 	}
 
 	if clientStream {
-		return s.streamChatCompletionsAsResponses(c, resp, originalModel, customTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
+		return s.streamChatCompletionsAsResponses(c, resp, chatBody, originalModel, customTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 	}
 	return s.bufferChatCompletionsAsResponses(c, resp, originalModel, customTools, toolSearch, namespaceTools, billingModel, upstreamModel, reasoningEffort, serviceTier, startTime)
 }
@@ -158,6 +158,7 @@ func (s *OpenAIGatewayService) bufferChatCompletionsAsResponses(
 func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 	c *gin.Context,
 	resp *http.Response,
+	requestBody []byte,
 	originalModel string,
 	customTools map[string]bool,
 	toolSearch bool,
@@ -206,11 +207,19 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 	scan := s.scanCCStream(resp, "openai responses chat fallback", requestID, startTime, func(chunk *apicompat.ChatCompletionsChunk) {
 		writeEvents(apicompat.ChatCompletionsChunkToResponsesEvents(chunk, state))
 	})
+	usage := resolveCCStreamUsage(
+		scan.Usage,
+		requestBody,
+		scan.OutputText.String(),
+		billingModel,
+		"openai responses chat fallback",
+		requestID,
+	)
 
 	if scan.Err != nil {
 		return &OpenAIForwardResult{
 			RequestID:       requestID,
-			Usage:           scan.Usage,
+			Usage:           usage,
 			Model:           originalModel,
 			BillingModel:    billingModel,
 			UpstreamModel:   upstreamModel,
@@ -220,6 +229,23 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 			Duration:        time.Since(startTime),
 			FirstTokenMs:    scan.FirstTokenMs,
 		}, fmt.Errorf("stream usage incomplete: %w", scan.Err)
+	}
+
+	// Inject estimated usage into finalize so response.completed also reports tokens.
+	if openAIUsageIsEmpty(scan.Usage) && !openAIUsageIsEmpty(usage) {
+		state.Usage = &apicompat.ResponsesUsage{
+			InputTokens:  usage.InputTokens,
+			OutputTokens: usage.OutputTokens,
+			TotalTokens:  usage.InputTokens + usage.OutputTokens,
+		}
+		if usage.CacheReadInputTokens > 0 {
+			state.Usage.InputTokensDetails = &apicompat.ResponsesInputTokensDetails{
+				CachedTokens: usage.CacheReadInputTokens,
+			}
+		}
+		if usage.CacheCreationInputTokens > 0 {
+			state.Usage.CacheCreationInputTokens = usage.CacheCreationInputTokens
+		}
 	}
 
 	writeEvents(apicompat.FinalizeChatCompletionsResponsesStream(state))
@@ -238,7 +264,7 @@ func (s *OpenAIGatewayService) streamChatCompletionsAsResponses(
 
 	return &OpenAIForwardResult{
 		RequestID:       requestID,
-		Usage:           scan.Usage,
+		Usage:           usage,
 		Model:           originalModel,
 		BillingModel:    billingModel,
 		UpstreamModel:   upstreamModel,


### PR DESCRIPTION
## Summary
Some OpenAI-compatible vendors (e.g. fengwind) ignore `stream_options.include_usage` on `/v1/chat/completions` streams, so Sub2API settled stream requests as **0 tokens / 0 cost** even though content was returned.

This PR adds a local fallback for the three CC stream paths:
- `/v1/messages` → CC fallback
- `/v1/responses` → CC fallback
- raw `/v1/chat/completions`

When the upstream stream ends without any usage counters, the gateway estimates:
- **input_tokens** from the request body text (messages / system / tools / instructions)
- **output_tokens** from accumulated `content` + `reasoning_content` + tool call args

Upstream-provided usage is always preferred; estimation only runs when every usage field is zero.

## Test plan
- [x] unit: keeps real upstream usage unchanged
- [x] unit: estimates when usage chunk is missing (messages / responses / raw CC)
- [x] unit: existing include_usage happy-path tests still pass
- [ ] production: accounts that must stay on force_chat_completions no longer log 0 for successful streams