### PR TITLE
fix(backup): keep the S3 secret encrypted when a save inherits it

### DIFF
--- a/backend/internal/service/backup_service.go
+++ b/backend/internal/service/backup_service.go
@@ -276,19 +276,25 @@ func (s *BackupService) GetS3Config(ctx context.Context) (*BackupS3Config, error
 }
 
 func (s *BackupService) UpdateS3Config(ctx context.Context, cfg BackupS3Config) (*BackupS3Config, error) {
-	// 如果没提供 secret，保留原有值
+	// 如果没提供 secret，保留原有值。loadS3Config 会解密，所以这里拿到的是明文，
+	// 和调用方新填的 secret 一样，都必须走下面的加密再落库。
 	if cfg.SecretAccessKey == "" {
 		old, _ := s.loadS3Config(ctx)
 		if old != nil {
 			cfg.SecretAccessKey = old.SecretAccessKey
 		}
-	} else {
+	}
+
+	// 加密 SecretAccessKey。这一步不能只在“调用方填了新 secret”时做：表单保存成功
+	// 后本函数会清空返回值里的 secret，所以第二次保存（改端点、存定时配置）送上来的
+	// secret 是空的，会走上面的分支继承旧值。若那条路径跳过加密，明文就会覆盖掉库里
+	// 的密文，而读取侧“兼容未加密旧数据”的回退会把这件事永久掩盖成一条日志。
+	if cfg.SecretAccessKey != "" {
 		// 拒绝用自动生成的临时密钥加密：该密钥每次重启都会变化，落库的密文在
 		// 重启/升级后无法解密（#4524）。与支付、TOTP 的处理保持一致。
 		if !s.encryptionKeyConfigured {
 			return nil, ErrSecretEncryptionKeyNotConfigured
 		}
-		// 加密 SecretAccessKey
 		encrypted, err := s.encryptor.Encrypt(cfg.SecretAccessKey)
 		if err != nil {
 			return nil, fmt.Errorf("encrypt secret: %w", err)

--- a/backend/internal/service/backup_service_test.go
+++ b/backend/internal/service/backup_service_test.go
@@ -304,6 +304,53 @@ func TestBackupService_S3ConfigKeepExistingSecret(t *testing.T) {
 	require.Equal(t, "AKID-NEW", internal.AccessKeyID)
 }
 
+// 一次不带 secret 的保存（表单第二次提交、改端点、存定时配置）继承的是 loadS3Config
+// 解密后的明文。若那条路径跳过加密，明文就会覆盖库里的密文，而读取侧“兼容未加密旧
+// 数据”的回退会把它掩盖成一条日志，功能照常，密钥却是明文落库的。
+func TestBackupService_S3ConfigStaysEncryptedAfterSecondSave(t *testing.T) {
+	repo := newMockSettingRepo()
+	svc := newTestBackupService(repo, &mockDumper{}, newMockObjectStore())
+
+	_, err := svc.UpdateS3Config(context.Background(), BackupS3Config{
+		Bucket:          "my-bucket",
+		AccessKeyID:     "AKID",
+		SecretAccessKey: "original-secret",
+	})
+	require.NoError(t, err)
+
+	storedSecret := func() string {
+		raw, _ := repo.GetValue(context.Background(), settingKeyBackupS3Config)
+		var stored BackupS3Config
+		require.NoError(t, json.Unmarshal([]byte(raw), &stored))
+		return stored.SecretAccessKey
+	}
+	require.Equal(t, "ENC:original-secret", storedSecret())
+
+	// 第二次保存不带 secret，只改别的字段。
+	_, err = svc.UpdateS3Config(context.Background(), BackupS3Config{
+		Bucket:      "my-bucket",
+		AccessKeyID: "AKID-NEW",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, "ENC:original-secret", storedSecret(),
+		"secret must stay encrypted at rest after a save that inherits it")
+	require.NotEqual(t, "original-secret", storedSecret(), "secret must never be stored as plaintext")
+
+	// 第三次保存，确认不会反复套壳加密。
+	_, err = svc.UpdateS3Config(context.Background(), BackupS3Config{
+		Bucket:      "my-bucket",
+		AccessKeyID: "AKID-THIRD",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "ENC:original-secret", storedSecret(), "secret must not be double-encrypted")
+
+	internal, err := svc.loadS3Config(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "original-secret", internal.SecretAccessKey)
+	require.Equal(t, "AKID-THIRD", internal.AccessKeyID)
+}
+
 func TestBackupService_UpdateS3Config_RejectsEphemeralKey(t *testing.T) {
 	repo := newMockSettingRepo()
 	svc := newTestBackupServiceEphemeralKey(repo)


### PR DESCRIPTION
`UpdateS3Config` only encrypts the `SecretAccessKey` on the branch where the caller supplied a new one:

```go
if cfg.SecretAccessKey == "" {
    old, _ := s.loadS3Config(ctx)          // loadS3Config DECRYPTS
    cfg.SecretAccessKey = old.SecretAccessKey   // → plaintext
} else {
    encrypted, _ := s.encryptor.Encrypt(...)    // only this branch encrypts
}
```

The inheriting branch takes its value from `loadS3Config`, which decrypts, and then writes it back unencrypted — overwriting the ciphertext in the settings row with plaintext.

**This is the normal path, not an edge case.** `UpdateS3Config` clears the secret in its own return value (`cfg.SecretAccessKey = ""`), so the admin form field is empty after a successful save. Any later save — changing the endpoint, saving the schedule, pressing save twice — submits an empty secret and takes the inheriting branch. One extra save leaves the secret in plaintext at rest.

**Why it goes unnoticed.** `loadS3Config` keeps the raw value when decryption fails, for compatibility with rows written before encryption existed. Backups keep working, and the only trace is one line per read:

```
[Backup] S3 SecretAccessKey 解密失败（可能是旧的未加密数据）:
decrypt: cipher: message authentication failed
```

Observed on a live install: the stored value was **64 characters**, exactly the plaintext length of a Cloudflare R2 secret, where AES-GCM + base64 would be **124**. The compatibility fallback turns a one-time write bug into a permanently plaintext secret.

**It also feeds itself:** `pg_dump` includes the `settings` table, so the backup uploaded to the bucket carries the write credentials for that same bucket.

## Fix

Hoist the encryption out of the `if`/`else` so it runs for any non-empty secret, whichever way it arrived. The ephemeral-key guard from #4524 moves with it, and the genuinely-no-secret case still skips encryption, so an update with no stored secret keeps working under an auto-generated key (`TestBackupService_UpdateS3Config_NoSecretAllowedWithEphemeralKey` still passes).

## Test

`TestBackupService_S3ConfigKeepExistingSecret` passed with the bug present, because it only asserted that `loadS3Config` returns the plaintext — which the fallback also satisfies. The new test asserts on the stored row instead: still ciphertext after a second save, and not double-wrapped after a third.

Verified the new test fails without the fix and passes with it. `go test -tags=unit ./internal/service/` and `golangci-lint run ./internal/service/...` are both clean.