### PR TITLE
feat(pool): support unlimited same-account retry via -1

### DIFF
--- a/backend/internal/handler/failover_loop.go
+++ b/backend/internal/handler/failover_loop.go
@@ -84,14 +84,15 @@ func (s *FailoverState) HandleFailoverError(
 	}
 
 	// 同账号重试不算切换账号，粘性会话仅在实际切换时强制缓存计费。
-	sameAccountRetry := failoverErr.RetryableOnSameAccount && s.SameAccountRetryCount[accountID] < retryLimit
+	// retryLimit < 0（pool_mode_retry_count=-1）表示无限同账号重试。
+	sameAccountRetry := failoverErr.RetryableOnSameAccount && allowsSameAccountRetry(s.SameAccountRetryCount[accountID], retryLimit)
 	if needForceCacheBilling(s.hasBoundSession, failoverErr, sameAccountRetry) {
 		s.ForceCacheBilling = true
 	}
 
 	// 同账号重试：对 RetryableOnSameAccount 的临时性错误，先在同一账号上重试。
-	// 重试次数上限 retryLimit 由调用方传入（账号级 pool_mode_retry_count 配置）。
-	if failoverErr.RetryableOnSameAccount && s.SameAccountRetryCount[accountID] < retryLimit {
+	// 重试次数上限 retryLimit 由调用方传入（账号级 pool_mode_retry_count 配置；-1=无限）。
+	if sameAccountRetry {
 		s.SameAccountRetryCount[accountID]++
 		logger.FromContext(ctx).Warn("gateway.failover_same_account_retry",
 			zap.Int64("account_id", accountID),
@@ -172,6 +173,15 @@ func (s *FailoverState) HandleSelectionExhausted(ctx context.Context) FailoverAc
 		return FailoverContinue
 	}
 	return FailoverExhausted
+}
+
+// allowsSameAccountRetry 判断当前已用次数是否仍可在同账号上重试。
+// retryLimit < 0 表示无限重试（pool_mode_retry_count=-1）。
+func allowsSameAccountRetry(used, retryLimit int) bool {
+	if retryLimit < 0 {
+		return true
+	}
+	return used < retryLimit
 }
 
 // needForceCacheBilling 判断 failover 时是否需要强制缓存计费。

--- a/backend/internal/handler/failover_loop_test.go
+++ b/backend/internal/handler/failover_loop_test.go
@@ -483,6 +483,23 @@ func TestHandleFailoverError_SameAccountRetry(t *testing.T) {
 		require.Equal(t, 1, fs.SwitchCount, "应立即切换账号")
 		require.Len(t, mock.calls, 1, "应立即 TempUnschedule")
 	})
+
+	t.Run("retryLimit为负数时无限同账号重试", func(t *testing.T) {
+		// pool_mode_retry_count=-1 表示无限原地重试，不切换、不 TempUnschedule。
+		mock := &mockTempUnscheduler{}
+		fs := NewFailoverState(5, false)
+		err := newTestFailoverErr(429, true, false)
+		const retryLimit = -1
+
+		for i := 1; i <= 20; i++ {
+			action := fs.HandleFailoverError(context.Background(), mock, 100, "openai", retryLimit, err)
+			require.Equal(t, FailoverContinue, action, "第 %d 次应继续同账号重试", i)
+			require.Equal(t, i, fs.SameAccountRetryCount[100])
+			require.Equal(t, 0, fs.SwitchCount, "无限重试不应切换账号")
+			require.Empty(t, mock.calls, "无限重试不应 TempUnschedule")
+			require.NotContains(t, fs.FailedAccountIDs, int64(100))
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -1016,12 +1016,13 @@ func (a *Account) IsPoolMode() bool {
 }
 
 const (
-	defaultPoolModeRetryCount = 3
-	maxPoolModeRetryCount     = 10
+	defaultPoolModeRetryCount   = 3
+	maxPoolModeRetryCount       = 10
+	poolModeRetryCountUnlimited = -1 // 无限同账号重试（直至客户端断开或错误不再可原地重试）
 )
 
 // GetPoolModeRetryCount 返回池模式同账号重试次数。
-// 未配置或配置非法时回退为默认值 3；小于 0 按 0 处理；过大则截断到 10。
+// 未配置或配置非法时回退为默认值 3；-1 表示无限重试；小于 -1 按 0 处理；过大则截断到 10。
 func (a *Account) GetPoolModeRetryCount() int {
 	if a == nil || !a.IsPoolMode() || a.Credentials == nil {
 		return defaultPoolModeRetryCount
@@ -1031,6 +1032,9 @@ func (a *Account) GetPoolModeRetryCount() int {
 		return defaultPoolModeRetryCount
 	}
 	count := parsePoolModeRetryCount(raw)
+	if count == poolModeRetryCountUnlimited {
+		return poolModeRetryCountUnlimited
+	}
 	if count < 0 {
 		return 0
 	}

--- a/backend/internal/service/account_pool_mode_test.go
+++ b/backend/internal/service/account_pool_mode_test.go
@@ -72,13 +72,37 @@ func TestGetPoolModeRetryCount(t *testing.T) {
 			expected: 2,
 		},
 		{
-			name: "negative_value_is_clamped_to_zero",
+			name: "negative_one_means_unlimited",
 			account: &Account{
 				Type:     AccountTypeAPIKey,
 				Platform: PlatformOpenAI,
 				Credentials: map[string]any{
 					"pool_mode":             true,
 					"pool_mode_retry_count": -1,
+				},
+			},
+			expected: poolModeRetryCountUnlimited,
+		},
+		{
+			name: "negative_one_string_means_unlimited",
+			account: &Account{
+				Type:     AccountTypeAPIKey,
+				Platform: PlatformOpenAI,
+				Credentials: map[string]any{
+					"pool_mode":             true,
+					"pool_mode_retry_count": "-1",
+				},
+			},
+			expected: poolModeRetryCountUnlimited,
+		},
+		{
+			name: "other_negative_values_are_clamped_to_zero",
+			account: &Account{
+				Type:     AccountTypeAPIKey,
+				Platform: PlatformOpenAI,
+				Credentials: map[string]any{
+					"pool_mode":             true,
+					"pool_mode_retry_count": -2,
 				},
 			},
 			expected: 0,

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -1392,7 +1392,7 @@
             <input
               v-model.number="poolModeRetryCount"
               type="number"
-              min="0"
+              min="-1"
               :max="MAX_POOL_MODE_RETRY_COUNT"
               step="1"
               class="input"
@@ -1793,7 +1793,7 @@
             <input
               v-model.number="poolModeRetryCount"
               type="number"
-              min="0"
+              min="-1"
               :max="MAX_POOL_MODE_RETRY_COUNT"
               step="1"
               class="input"
@@ -4843,11 +4843,16 @@ const handleMixedChannelCancel = () => {
   clearMixedChannelDialog()
 }
 
+const UNLIMITED_POOL_MODE_RETRY_COUNT = -1
 const normalizePoolModeRetryCount = (value: number) => {
   if (!Number.isFinite(value)) {
     return DEFAULT_POOL_MODE_RETRY_COUNT
   }
   const normalized = Math.trunc(value)
+  // -1 means unlimited same-account retries in pool mode.
+  if (normalized === UNLIMITED_POOL_MODE_RETRY_COUNT) {
+    return UNLIMITED_POOL_MODE_RETRY_COUNT
+  }
   if (normalized < 0) {
     return 0
   }

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -300,7 +300,7 @@
             <input
               v-model.number="poolModeRetryCount"
               type="number"
-              min="0"
+              min="-1"
               :max="MAX_POOL_MODE_RETRY_COUNT"
               step="1"
               class="input"
@@ -1082,7 +1082,7 @@
             <input
               v-model.number="poolModeRetryCount"
               type="number"
-              min="0"
+              min="-1"
               :max="MAX_POOL_MODE_RETRY_COUNT"
               step="1"
               class="input"
@@ -3177,11 +3177,16 @@ const expiresAtInput = computed({
 })
 
 // Watchers
+const UNLIMITED_POOL_MODE_RETRY_COUNT = -1
 const normalizePoolModeRetryCount = (value: number) => {
   if (!Number.isFinite(value)) {
     return DEFAULT_POOL_MODE_RETRY_COUNT
   }
   const normalized = Math.trunc(value)
+  // -1 means unlimited same-account retries in pool mode.
+  if (normalized === UNLIMITED_POOL_MODE_RETRY_COUNT) {
+    return UNLIMITED_POOL_MODE_RETRY_COUNT
+  }
   if (normalized < 0) {
     return 0
   }
@@ -3503,7 +3508,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     // Load pool mode for bedrock
     poolModeEnabled.value = bedrockCreds.pool_mode === true
     const retryCount = bedrockCreds.pool_mode_retry_count
-    poolModeRetryCount.value = (typeof retryCount === 'number' && retryCount >= 0) ? retryCount : DEFAULT_POOL_MODE_RETRY_COUNT
+    poolModeRetryCount.value = (typeof retryCount === 'number' && (retryCount === UNLIMITED_POOL_MODE_RETRY_COUNT || retryCount >= 0)) ? retryCount : DEFAULT_POOL_MODE_RETRY_COUNT
     poolModeRetryStatusCodesInput.value = formatPoolModeRetryStatusCodes(bedrockCreds.pool_mode_retry_status_codes)
 
     // Load quota limits for bedrock

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -636,7 +636,7 @@ export default {
         'When enabled, upstream 429/403/401 errors will auto-retry without marking the account as rate-limited or errored. Suitable for upstream pointing to another sub2api instance.',
       poolModeRetryCount: 'Same-Account Retries',
       poolModeRetryCountHint:
-        'Only applies in pool mode. Use 0 to disable in-place retry. Default {default}, maximum {max}.',
+        'Only applies in pool mode. Use 0 to disable in-place retry; -1 for unlimited retries. Default {default}, maximum {max}.',
       poolModeRetryStatusCodes: 'Retry Status Codes',
       poolModeRetryStatusCodesHint:
         'Comma-separated HTTP status codes (100-599) that trigger same-account retry in pool mode. Leave blank to use defaults ({default}).',

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -694,7 +694,7 @@ export default {
       poolModeInfo:
         '启用后，上游 429/403/401 错误将自动重试而不标记账号限流或错误，适用于上游指向另一个 sub2api 实例的场景。',
       poolModeRetryCount: '同账号重试次数',
-      poolModeRetryCountHint: '仅在池模式下生效。0 表示不原地重试；默认 {default}，最大 {max}。',
+      poolModeRetryCountHint: '仅在池模式下生效。0 表示不原地重试；-1 表示无限重试；默认 {default}，最大 {max}。',
       poolModeRetryStatusCodes: '同账号重试状态码',
       poolModeRetryStatusCodesHint: '仅在池模式下生效。以英文逗号分隔的 HTTP 状态码（100-599），命中时触发同账号重试。留空使用默认值（{default}）。',
       customErrorCodes: '自定义错误码',


### PR DESCRIPTION
## Summary
- `pool_mode_retry_count = -1` now means unlimited same-account retries in pool mode (until the client disconnects or the error is no longer same-account-retryable).
- `0` still disables in-place retry; `1..10` remain finite limits (values `>10` still clamp to 10; other negatives clamp to 0).
- Admin create/edit UI accepts `-1` and updates zh/en hints accordingly.

## Why
Some pooled upstreams need continuous same-account retry instead of failing over after a small fixed budget. The previous max was 10, and `0` meant "no retry" rather than "infinite".

## Test plan
- [x] `go test -tags=unit ./internal/service/ -run TestGetPoolModeRetryCount`
- [x] `go test -tags=unit ./internal/handler/ -run TestHandleFailoverError`
- [ ] Set an account `pool_mode=true`, `pool_mode_retry_count=-1`, trigger retryable upstream status; confirm continuous same-account retries without switch/temp-unschedule until client cancel
- [ ] Set `0` and confirm immediate switch; set `1` and confirm single retry then switch
