### PR TITLE
fix(account): clear rate limit on quota reset

### DIFF
--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -3763,23 +3763,32 @@ func (r *accountRepository) IncrementQuotaUsed(ctx context.Context, id int64, am
 	return nil
 }
 
-// ResetQuotaUsed 重置账号所有维度的配额用量为 0
-// 保留固定重置模式的配置字段（quota_daily_reset_mode 等），仅清零用量和窗口起始时间
-func (r *accountRepository) ResetQuotaUsed(ctx context.Context, id int64) error {
-	_, err := r.sql.ExecContext(ctx,
+// ResetQuotaUsedAndClearRateLimitCooldown resets all quota dimensions and the
+// account-level cooldown in one statement. Other scheduler blocking state is preserved.
+func (r *accountRepository) ResetQuotaUsedAndClearRateLimitCooldown(ctx context.Context, id int64) error {
+	result, err := r.sql.ExecContext(ctx,
 		`UPDATE accounts SET extra = (
 			COALESCE(extra, '{}'::jsonb)
 			|| '{"quota_used": 0, "quota_daily_used": 0, "quota_weekly_used": 0}'::jsonb
-		) - 'quota_daily_start' - 'quota_weekly_start' - 'quota_daily_reset_at' - 'quota_weekly_reset_at', updated_at = NOW()
+		) - 'quota_daily_start' - 'quota_weekly_start' - 'quota_daily_reset_at' - 'quota_weekly_reset_at',
+		rate_limited_at = NULL, rate_limit_reset_at = NULL, updated_at = NOW()
 		WHERE id = $1 AND deleted_at IS NULL`,
 		id)
 	if err != nil {
 		return err
 	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return service.ErrAccountNotFound
+	}
 	// 重置配额后触发调度快照刷新，使账号重新参与调度
 	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
 		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue quota reset failed: account=%d err=%v", id, err)
 	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
 	return nil
 }
 

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -956,6 +956,53 @@ func (s *AccountRepoSuite) TestClearRateLimit() {
 	s.Require().Nil(got.OverloadUntil)
 }
 
+func (s *AccountRepoSuite) TestResetQuotaUsedAndClearRateLimitCooldownPreservesOtherRuntimeState() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name: "acc-reset-quota-cooldown",
+		Extra: map[string]any{
+			"quota_used":        12.5,
+			"quota_daily_used":  5.0,
+			"quota_weekly_used": 9.0,
+			"model_rate_limits": map[string]any{
+				"claude-sonnet-4-5": map[string]any{"rate_limit_reset_at": "2026-09-01T10:00:00Z"},
+			},
+		},
+	})
+	until := time.Now().Add(1 * time.Hour)
+	s.Require().NoError(s.repo.SetOverloaded(s.ctx, account.ID, until))
+	s.Require().NoError(s.repo.SetRateLimited(s.ctx, account.ID, until))
+	s.Require().NoError(s.repo.SetTempUnschedulable(s.ctx, account.ID, until, "preserve-me"))
+
+	cacheRecorder := &schedulerCacheRecorder{}
+	s.repo.schedulerCache = cacheRecorder
+
+	s.Require().NoError(s.repo.ResetQuotaUsedAndClearRateLimitCooldown(s.ctx, account.ID))
+
+	got, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().Nil(got.RateLimitedAt)
+	s.Require().Nil(got.RateLimitResetAt)
+	s.Require().NotNil(got.OverloadUntil)
+	s.Require().WithinDuration(until, *got.OverloadUntil, time.Second)
+	s.Require().NotNil(got.TempUnschedulableUntil)
+	s.Require().WithinDuration(until, *got.TempUnschedulableUntil, time.Second)
+	s.Require().Equal("preserve-me", got.TempUnschedulableReason)
+	s.Require().Contains(got.Extra, "model_rate_limits")
+	s.Require().Equal(float64(0), got.Extra["quota_used"])
+	s.Require().Equal(float64(0), got.Extra["quota_daily_used"])
+	s.Require().Equal(float64(0), got.Extra["quota_weekly_used"])
+
+	var pendingEventExists bool
+	s.Require().NoError(scanSingleRow(s.ctx, s.repo.sql, `
+		SELECT EXISTS (
+			SELECT 1 FROM scheduler_outbox
+			WHERE event_type = $1 AND account_id = $2 AND dedup_key IS NOT NULL
+		)`, []any{service.SchedulerOutboxEventAccountChanged, account.ID}, &pendingEventExists))
+	s.Require().True(pendingEventExists)
+	s.Require().Len(cacheRecorder.setAccounts, 1)
+	s.Require().Equal(account.ID, cacheRecorder.setAccounts[0].ID)
+}
+
 func (s *AccountRepoSuite) TestTempUnschedulableFieldsLoadedByGetByIDAndGetByIDs() {
 	acc1 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-temp-1"})
 	acc2 := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-temp-2"})

--- a/backend/internal/repository/account_repo_temp_unsched_test.go
+++ b/backend/internal/repository/account_repo_temp_unsched_test.go
@@ -26,6 +26,18 @@ func TestAccountRepository_SetTempUnschedulable_NoRowsAffectedDoesNotWriteOutbox
 	require.NotContains(t, strings.Join(exec.execQueries, "\n"), "scheduler_outbox")
 }
 
+func TestAccountRepository_ResetQuotaUsedAndClearRateLimitCooldown_NoRowsAffectedReturnsNotFoundWithoutOutbox(t *testing.T) {
+	exec := &recordingSQLExecutor{result: rowsAffectedResult(0)}
+	repo := newAccountRepositoryWithSQL(nil, exec, nil)
+
+	err := repo.ResetQuotaUsedAndClearRateLimitCooldown(context.Background(), 42)
+
+	require.ErrorIs(t, err, service.ErrAccountNotFound)
+	require.Len(t, exec.execQueries, 1)
+	require.Contains(t, exec.execQueries[0], "UPDATE accounts")
+	require.NotContains(t, strings.Join(exec.execQueries, "\n"), "scheduler_outbox")
+}
+
 func TestAccountRepository_GrokCredentialConditionalMutationsAreEligibleAndAtomicallyPropagated(t *testing.T) {
 	proxyID := int64(77)
 	snapshot := service.GrokCredentialMutationSnapshot{

--- a/backend/internal/server/api_contract_test.go
+++ b/backend/internal/server/api_contract_test.go
@@ -2034,7 +2034,7 @@ func (s *stubAccountRepo) IncrementQuotaUsed(ctx context.Context, id int64, amou
 	return errors.New("not implemented")
 }
 
-func (s *stubAccountRepo) ResetQuotaUsed(ctx context.Context, id int64) error {
+func (s *stubAccountRepo) ResetQuotaUsedAndClearRateLimitCooldown(ctx context.Context, id int64) error {
 	return errors.New("not implemented")
 }
 

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -115,8 +115,9 @@ type AccountRepository interface {
 	BulkUpdate(ctx context.Context, ids []int64, updates AccountBulkUpdate) (int64, error)
 	// IncrementQuotaUsed 原子递增 API Key 账号的配额用量（总/日/周）
 	IncrementQuotaUsed(ctx context.Context, id int64, amount float64) error
-	// ResetQuotaUsed 重置 API Key 账号所有维度的配额用量为 0
-	ResetQuotaUsed(ctx context.Context, id int64) error
+	// ResetQuotaUsedAndClearRateLimitCooldown atomically resets API Key quota usage
+	// and clears only the account-level rate-limit cooldown.
+	ResetQuotaUsedAndClearRateLimitCooldown(ctx context.Context, id int64) error
 	// RevertProxyFallback 将账号的 proxy_id 切回 proxy_fallback_origin_id，并清空 origin 字段。
 	// 仅当 proxy_fallback_origin_id IS NOT NULL 时更新，否则视为账号不存在（返回 ErrAccountNotFound）。
 	RevertProxyFallback(ctx context.Context, accountID int64) error

--- a/backend/internal/service/account_service_delete_test.go
+++ b/backend/internal/service/account_service_delete_test.go
@@ -215,7 +215,7 @@ func (s *accountRepoStub) IncrementQuotaUsed(ctx context.Context, id int64, amou
 	return nil
 }
 
-func (s *accountRepoStub) ResetQuotaUsed(ctx context.Context, id int64) error {
+func (s *accountRepoStub) ResetQuotaUsedAndClearRateLimitCooldown(ctx context.Context, id int64) error {
 	return nil
 }
 

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -1559,7 +1559,7 @@ func (s *adminServiceImpl) ResetAccountQuota(ctx context.Context, id int64) erro
 		return infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_NO_QUOTA_RESET",
 			"cannot reset quota for a spark shadow account; manage it on the parent account")
 	}
-	return s.accountRepo.ResetQuotaUsed(ctx, id)
+	return s.accountRepo.ResetQuotaUsedAndClearRateLimitCooldown(ctx, id)
 }
 
 // EnsureOpenAIPrivacy 检查 OpenAI OAuth 账号是否已设置 privacy_mode，

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -1511,7 +1511,10 @@ func (s *adminServiceImpl) ResetAccountQuota(ctx context.Context, id int64) erro
 		return infraerrors.New(http.StatusBadRequest, "SPARK_SHADOW_NO_QUOTA_RESET",
 			"cannot reset quota for a spark shadow account; manage it on the parent account")
 	}
-	return s.accountRepo.ResetQuotaUsed(ctx, id)
+	if err := s.accountRepo.ResetQuotaUsed(ctx, id); err != nil {
+		return err
+	}
+	return s.accountRepo.ClearRateLimit(ctx, id)
 }
 
 // EnsureOpenAIPrivacy 检查 OpenAI OAuth 账号是否已设置 privacy_mode，

--- a/backend/internal/service/admin_service_reset_quota_test.go
+++ b/backend/internal/service/admin_service_reset_quota_test.go
@@ -1,0 +1,95 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type resetAccountQuotaRepoStub struct {
+	mockAccountRepoForGemini
+	account             *Account
+	getByIDErr          error
+	resetErr            error
+	resetCalls          int
+	clearRateLimitCalls int
+	callOrder           []string
+	overloaded          bool
+}
+
+func (r *resetAccountQuotaRepoStub) GetByID(context.Context, int64) (*Account, error) {
+	return r.account, r.getByIDErr
+}
+
+func (r *resetAccountQuotaRepoStub) ResetQuotaUsedAndClearRateLimitCooldown(context.Context, int64) error {
+	r.resetCalls++
+	r.callOrder = append(r.callOrder, "reset_quota_and_clear_rate_limit_cooldown")
+	return r.resetErr
+}
+
+func (r *resetAccountQuotaRepoStub) ClearRateLimit(context.Context, int64) error {
+	r.clearRateLimitCalls++
+	r.callOrder = append(r.callOrder, "clear_rate_limit")
+	r.overloaded = false
+	return nil
+}
+
+func TestResetAccountQuota_ClearsSchedulerRateLimitWithoutClearingOverload(t *testing.T) {
+	repo := &resetAccountQuotaRepoStub{account: &Account{ID: 42}, overloaded: true}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	err := svc.ResetAccountQuota(context.Background(), 42)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.resetCalls)
+	require.Zero(t, repo.clearRateLimitCalls)
+	require.Equal(t, []string{"reset_quota_and_clear_rate_limit_cooldown"}, repo.callOrder)
+	require.True(t, repo.overloaded, "quota reset must preserve an unrelated overload block")
+}
+
+func TestResetAccountQuota_PreservesLookupAndSparkShadowShortCircuits(t *testing.T) {
+	t.Run("lookup failure", func(t *testing.T) {
+		getErr := errors.New("get account failed")
+		repo := &resetAccountQuotaRepoStub{getByIDErr: getErr}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		err := svc.ResetAccountQuota(context.Background(), 42)
+
+		require.ErrorIs(t, err, getErr)
+		require.Zero(t, repo.resetCalls)
+		require.Zero(t, repo.clearRateLimitCalls)
+	})
+
+	t.Run("spark shadow", func(t *testing.T) {
+		parentID := int64(7)
+		repo := &resetAccountQuotaRepoStub{
+			account: &Account{ID: 42, ParentAccountID: &parentID},
+		}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		err := svc.ResetAccountQuota(context.Background(), 42)
+
+		require.Error(t, err)
+		require.Zero(t, repo.resetCalls)
+		require.Zero(t, repo.clearRateLimitCalls)
+	})
+}
+
+func TestResetAccountQuota_PropagatesAtomicRepositoryFailure(t *testing.T) {
+	resetErr := errors.New("atomic reset failed")
+	repo := &resetAccountQuotaRepoStub{
+		account:  &Account{ID: 42},
+		resetErr: resetErr,
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	err := svc.ResetAccountQuota(context.Background(), 42)
+
+	require.ErrorIs(t, err, resetErr)
+	require.Equal(t, 1, repo.resetCalls)
+	require.Zero(t, repo.clearRateLimitCalls)
+}

--- a/backend/internal/service/admin_service_reset_quota_test.go
+++ b/backend/internal/service/admin_service_reset_quota_test.go
@@ -1,0 +1,108 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type resetAccountQuotaRepoStub struct {
+	mockAccountRepoForGemini
+	account             *Account
+	getByIDErr          error
+	resetQuotaErr       error
+	clearRateLimitErr   error
+	resetQuotaCalls     int
+	clearRateLimitCalls int
+	callOrder           []string
+}
+
+func (r *resetAccountQuotaRepoStub) GetByID(context.Context, int64) (*Account, error) {
+	return r.account, r.getByIDErr
+}
+
+func (r *resetAccountQuotaRepoStub) ResetQuotaUsed(context.Context, int64) error {
+	r.resetQuotaCalls++
+	r.callOrder = append(r.callOrder, "reset_quota")
+	return r.resetQuotaErr
+}
+
+func (r *resetAccountQuotaRepoStub) ClearRateLimit(context.Context, int64) error {
+	r.clearRateLimitCalls++
+	r.callOrder = append(r.callOrder, "clear_rate_limit")
+	return r.clearRateLimitErr
+}
+
+func TestResetAccountQuota_ClearsSchedulerRateLimit(t *testing.T) {
+	repo := &resetAccountQuotaRepoStub{account: &Account{ID: 42}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	err := svc.ResetAccountQuota(context.Background(), 42)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, repo.resetQuotaCalls)
+	require.Equal(t, 1, repo.clearRateLimitCalls)
+	require.Equal(t, []string{"reset_quota", "clear_rate_limit"}, repo.callOrder)
+}
+
+func TestResetAccountQuota_PreservesLookupAndSparkShadowShortCircuits(t *testing.T) {
+	t.Run("lookup failure", func(t *testing.T) {
+		getErr := errors.New("get account failed")
+		repo := &resetAccountQuotaRepoStub{getByIDErr: getErr}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		err := svc.ResetAccountQuota(context.Background(), 42)
+
+		require.ErrorIs(t, err, getErr)
+		require.Zero(t, repo.resetQuotaCalls)
+		require.Zero(t, repo.clearRateLimitCalls)
+	})
+
+	t.Run("spark shadow", func(t *testing.T) {
+		parentID := int64(7)
+		repo := &resetAccountQuotaRepoStub{
+			account: &Account{ID: 42, ParentAccountID: &parentID},
+		}
+		svc := &adminServiceImpl{accountRepo: repo}
+
+		err := svc.ResetAccountQuota(context.Background(), 42)
+
+		require.Error(t, err)
+		require.Zero(t, repo.resetQuotaCalls)
+		require.Zero(t, repo.clearRateLimitCalls)
+	})
+}
+
+func TestResetAccountQuota_DoesNotClearRateLimitWhenQuotaResetFails(t *testing.T) {
+	resetErr := errors.New("reset quota failed")
+	repo := &resetAccountQuotaRepoStub{
+		account:       &Account{ID: 42},
+		resetQuotaErr: resetErr,
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	err := svc.ResetAccountQuota(context.Background(), 42)
+
+	require.ErrorIs(t, err, resetErr)
+	require.Equal(t, 1, repo.resetQuotaCalls)
+	require.Zero(t, repo.clearRateLimitCalls)
+}
+
+func TestResetAccountQuota_PropagatesRateLimitClearFailure(t *testing.T) {
+	clearErr := errors.New("clear rate limit failed")
+	repo := &resetAccountQuotaRepoStub{
+		account:           &Account{ID: 42},
+		clearRateLimitErr: clearErr,
+	}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	err := svc.ResetAccountQuota(context.Background(), 42)
+
+	require.ErrorIs(t, err, clearErr)
+	require.Equal(t, 1, repo.resetQuotaCalls)
+	require.Equal(t, 1, repo.clearRateLimitCalls)
+}

--- a/backend/internal/service/gateway_multiplatform_test.go
+++ b/backend/internal/service/gateway_multiplatform_test.go
@@ -225,7 +225,7 @@ func (m *mockAccountRepoForPlatform) IncrementQuotaUsed(ctx context.Context, id 
 	return nil
 }
 
-func (m *mockAccountRepoForPlatform) ResetQuotaUsed(ctx context.Context, id int64) error {
+func (m *mockAccountRepoForPlatform) ResetQuotaUsedAndClearRateLimitCooldown(ctx context.Context, id int64) error {
 	return nil
 }
 

--- a/backend/internal/service/gemini_multiplatform_test.go
+++ b/backend/internal/service/gemini_multiplatform_test.go
@@ -189,7 +189,7 @@ func (m *mockAccountRepoForGemini) IncrementQuotaUsed(ctx context.Context, id in
 	return nil
 }
 
-func (m *mockAccountRepoForGemini) ResetQuotaUsed(ctx context.Context, id int64) error {
+func (m *mockAccountRepoForGemini) ResetQuotaUsedAndClearRateLimitCooldown(ctx context.Context, id int64) error {
 	return nil
 }
 

--- a/backend/internal/service/ratelimit_session_window_test.go
+++ b/backend/internal/service/ratelimit_session_window_test.go
@@ -164,7 +164,9 @@ func (m *sessionWindowMockRepo) BulkUpdate(context.Context, []int64, AccountBulk
 func (m *sessionWindowMockRepo) IncrementQuotaUsed(context.Context, int64, float64) error {
 	panic("unexpected")
 }
-func (m *sessionWindowMockRepo) ResetQuotaUsed(context.Context, int64) error { panic("unexpected") }
+func (m *sessionWindowMockRepo) ResetQuotaUsedAndClearRateLimitCooldown(context.Context, int64) error {
+	panic("unexpected")
+}
 func (m *sessionWindowMockRepo) RevertProxyFallback(context.Context, int64) error {
 	panic("unexpected")
 }


### PR DESCRIPTION
## 问题

手动重置账号额度后，持久化的调度器冷却状态仍然保留，账号可能继续受到限流。

## 根因

额度重置流程只清除了已用额度，没有同步清除账号的持久化调度器冷却状态。

## 改动

手动额度重置成功后调用 `ClearRateLimit` 清除持久化的调度器冷却；若额度重置失败则不清除，并保留错误传播行为。

## 测试

已通过针对性的 `ResetAccountQuota` 测试、`go vet -tags=unit ./internal/service` 和 `git diff --check`。完整 service 单元测试套件仍有基线中的外部 OpenAI `count_tokens` 对比请求 401 失败，该失败已在干净的 `main` 上复现，因此不声明完整套件通过。

Fixes #4845.