### PR TITLE
fix(moderation): bound cold snapshot loading

### DIFF
--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -518,6 +518,7 @@ type ContentModerationService struct {
 	runtimeSnapshot          atomic.Pointer[contentModerationRuntimeSnapshot]
 	runtimeRefreshMu         sync.Mutex
 	runtimeCacheTTL          time.Duration
+	runtimeRefreshTimeout    time.Duration
 	runtimeRefreshRetryAt    atomic.Int64
 	keyHealthMu              sync.Mutex
 	keyHealth                map[string]*contentModerationKeyHealth
@@ -1497,7 +1498,9 @@ func (s *ContentModerationService) loadRuntimeSnapshot(ctx context.Context) (*co
 	if snapshot := s.runtimeSnapshot.Load(); snapshot != nil {
 		return snapshot, nil
 	}
-	return s.refreshRuntimeSnapshot(ctx)
+	refreshCtx, cancel := context.WithTimeout(ctx, s.runtimeSnapshotRefreshTimeout())
+	defer cancel()
+	return s.refreshRuntimeSnapshot(refreshCtx)
 }
 
 func (s *ContentModerationService) runtimeSnapshotTTL() time.Duration {
@@ -1505,6 +1508,13 @@ func (s *ContentModerationService) runtimeSnapshotTTL() time.Duration {
 		return s.runtimeCacheTTL
 	}
 	return contentModerationRuntimeCacheTTL
+}
+
+func (s *ContentModerationService) runtimeSnapshotRefreshTimeout() time.Duration {
+	if s != nil && s.runtimeRefreshTimeout > 0 {
+		return s.runtimeRefreshTimeout
+	}
+	return contentModerationRuntimeRefreshTimeout
 }
 
 func (s *ContentModerationService) triggerRuntimeSnapshotRefresh() {
@@ -1517,7 +1527,7 @@ func (s *ContentModerationService) triggerRuntimeSnapshotRefresh() {
 	}
 	go func() {
 		defer s.runtimeRefreshMu.Unlock()
-		ctx, cancel := context.WithTimeout(context.Background(), contentModerationRuntimeRefreshTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), s.runtimeSnapshotRefreshTimeout())
 		defer cancel()
 		if _, err := s.refreshRuntimeSnapshot(ctx); err != nil {
 			s.runtimeRefreshRetryAt.Store(time.Now().Add(s.runtimeSnapshotTTL()).UnixNano())

--- a/backend/internal/service/content_moderation_runtime_cache_test.go
+++ b/backend/internal/service/content_moderation_runtime_cache_test.go
@@ -52,7 +52,7 @@ func (r *contentModerationRuntimeSettingRepo) Set(_ context.Context, key, value 
 	return nil
 }
 
-func (r *contentModerationRuntimeSettingRepo) GetMultiple(_ context.Context, keys []string) (map[string]string, error) {
+func (r *contentModerationRuntimeSettingRepo) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
 	r.mu.Lock()
 	r.getMultipleCalls++
 	if err := r.getMultipleErr; err != nil {
@@ -74,7 +74,11 @@ func (r *contentModerationRuntimeSettingRepo) GetMultiple(_ context.Context, key
 		start <- struct{}{}
 	}
 	if wait != nil {
-		<-wait
+		select {
+		case <-wait:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
 	}
 	return out, nil
 }
@@ -141,9 +145,10 @@ func runtimeCacheTestConfig(t *testing.T, keywords ...string) string {
 
 func runtimeCacheTestService(repo *contentModerationRuntimeSettingRepo, ttl time.Duration) *ContentModerationService {
 	return &ContentModerationService{
-		settingRepo:     repo,
-		repo:            &contentModerationTestRepo{},
-		runtimeCacheTTL: ttl,
+		settingRepo:           repo,
+		repo:                  &contentModerationTestRepo{},
+		runtimeCacheTTL:       ttl,
+		runtimeRefreshTimeout: 20 * time.Millisecond,
 	}
 }
 
@@ -171,6 +176,29 @@ func TestContentModerationRuntimeSnapshotCachesSettings(t *testing.T) {
 	getValue, getMultiple := repo.calls()
 	require.Zero(t, getValue)
 	require.Equal(t, 1, getMultiple)
+}
+
+func TestContentModerationRuntimeSnapshotInitialLoadIsBounded(t *testing.T) {
+	repo := &contentModerationRuntimeSettingRepo{values: map[string]string{
+		SettingKeyRiskControlEnabled:      "true",
+		SettingKeyContentModerationConfig: runtimeCacheTestConfig(t, "blocked"),
+	}}
+	svc := runtimeCacheTestService(repo, time.Hour)
+	refreshStarted := make(chan struct{}, 1)
+	releaseRefresh := make(chan struct{})
+	repo.blockNextMultiple(refreshStarted, releaseRefresh)
+
+	startedAt := time.Now()
+	decision, err := svc.Check(context.Background(), runtimeCacheTestInput("clean prompt"))
+	require.NoError(t, err)
+	require.True(t, decision.Allowed)
+	require.Less(t, time.Since(startedAt), 200*time.Millisecond)
+	require.Nil(t, svc.runtimeSnapshot.Load())
+	select {
+	case <-refreshStarted:
+	default:
+		t.Fatal("initial runtime snapshot load did not reach the repository")
+	}
 }
 
 func TestContentModerationRuntimeSnapshotUpdateConfigIsImmediate(t *testing.T) {


### PR DESCRIPTION
Bound the first runtime-snapshot database load with the same timeout used by background refreshes. A cold request now follows the existing fail-open policy instead of blocking for the full request lifetime during a database outage. Includes timeout and concurrency coverage.