### PR TITLE
fix: show optional affiliate code on registration

### DIFF
--- a/frontend/src/views/auth/RegisterView.vue
+++ b/frontend/src/views/auth/RegisterView.vue
@@ -134,6 +134,27 @@
           </transition>
         </div>
 
+        <!-- Affiliate Invitation Code Input (Optional) -->
+        <div v-else-if="affiliateEnabled" data-testid="affiliate-invitation-field">
+          <label for="affiliate_code" class="input-label">
+            {{ t('auth.invitationCodeLabel') }}
+            <span class="ml-1 text-xs font-normal text-gray-400 dark:text-dark-500">({{ t('common.optional') }})</span>
+          </label>
+          <div class="relative">
+            <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3.5">
+              <Icon name="key" size="md" class="text-gray-400 dark:text-dark-500" />
+            </div>
+            <input
+              id="affiliate_code"
+              v-model="formData.aff_code"
+              type="text"
+              :disabled="registrationActionDisabled"
+              class="input pl-11"
+              :placeholder="t('auth.invitationCodePlaceholder')"
+            />
+          </div>
+        </div>
+
         <!-- Promo Code Input (Optional) -->
         <div v-if="promoCodeEnabled">
           <label for="promo_code" class="input-label">
@@ -183,7 +204,7 @@
         </div>
 
         <!-- Turnstile Widget -->
-        <div v-if="turnstileEnabled && turnstileSiteKey">
+        <div v-if="turnstileEnabled && turnstileSiteKey" data-testid="registration-turnstile">
           <TurnstileWidget
             ref="turnstileRef"
             :site-key="turnstileSiteKey"
@@ -351,6 +372,7 @@ const registrationEnabled = ref<boolean>(true)
 const emailVerifyEnabled = ref<boolean>(false)
 const promoCodeEnabled = ref<boolean>(true)
 const invitationCodeEnabled = ref<boolean>(false)
+const affiliateEnabled = ref<boolean>(false)
 const turnstileEnabled = ref<boolean>(false)
 const turnstileSiteKey = ref<string>('')
 const siteName = ref<string>('Sub2API')
@@ -459,6 +481,7 @@ onMounted(async () => {
     emailVerifyEnabled.value = settings.email_verify_enabled
     promoCodeEnabled.value = settings.promo_code_enabled
     invitationCodeEnabled.value = settings.invitation_code_enabled
+    affiliateEnabled.value = settings.affiliate_enabled
     turnstileEnabled.value = settings.turnstile_enabled
     turnstileSiteKey.value = settings.turnstile_site_key || ''
     siteName.value = settings.site_name || 'Sub2API'

--- a/frontend/src/views/auth/__tests__/RegisterView.spec.ts
+++ b/frontend/src/views/auth/__tests__/RegisterView.spec.ts
@@ -1,0 +1,112 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import RegisterView from '@/views/auth/RegisterView.vue'
+
+const { getPublicSettingsMock } = vi.hoisted(() => ({
+  getPublicSettingsMock: vi.fn()
+}))
+
+const publicSettings = {
+  registration_enabled: true,
+  email_verify_enabled: false,
+  promo_code_enabled: false,
+  invitation_code_enabled: false,
+  affiliate_enabled: true,
+  turnstile_enabled: true,
+  turnstile_site_key: 'site-key',
+  site_name: 'Sub2API',
+  registration_email_suffix_whitelist: [],
+  linuxdo_oauth_enabled: false,
+  wechat_oauth_enabled: false,
+  oidc_oauth_enabled: false,
+  github_oauth_enabled: false,
+  google_oauth_enabled: false
+}
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ query: {} })
+}))
+
+vi.mock('vue-i18n', () => ({
+  createI18n: () => ({
+    global: {
+      t: (key: string) => key
+    }
+  }),
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: { value: 'en' }
+  })
+}))
+
+vi.mock('@/stores', () => ({
+  useAuthStore: () => ({ register: vi.fn() }),
+  useAppStore: () => ({
+    showError: vi.fn(),
+    showSuccess: vi.fn(),
+    showWarning: vi.fn()
+  })
+}))
+
+vi.mock('@/api/auth', async () => {
+  const actual = await vi.importActual<typeof import('@/api/auth')>('@/api/auth')
+  return {
+    ...actual,
+    getPublicSettings: (...args: unknown[]) => getPublicSettingsMock(...args)
+  }
+})
+
+function mountRegister() {
+  return mount(RegisterView, {
+    global: {
+      stubs: {
+        AuthLayout: { template: '<div><slot /><slot name="footer" /></div>' },
+        Icon: true,
+        TurnstileWidget: { template: '<div data-testid="turnstile-widget" />' },
+        LoginAgreementPrompt: true,
+        EmailOAuthButtons: true,
+        LinuxDoOAuthSection: true,
+        WechatOAuthSection: true,
+        OidcOAuthSection: true,
+        RouterLink: true,
+        transition: false
+      }
+    }
+  })
+}
+
+describe('RegisterView invitation layout', () => {
+  beforeEach(() => {
+    getPublicSettingsMock.mockReset()
+    getPublicSettingsMock.mockResolvedValue(publicSettings)
+  })
+
+  it('keeps the optional affiliate invitation field before Turnstile', async () => {
+    const wrapper = mountRegister()
+    await flushPromises()
+
+    const invitationField = wrapper.get('[data-testid="affiliate-invitation-field"]')
+    const turnstile = wrapper.get('[data-testid="registration-turnstile"]')
+
+    expect(invitationField.get('input').attributes('id')).toBe('affiliate_code')
+    expect(invitationField.text()).toContain('common.optional')
+    expect(
+      invitationField.element.compareDocumentPosition(turnstile.element) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it('uses the mandatory invitation field without duplicating the affiliate field', async () => {
+    getPublicSettingsMock.mockResolvedValueOnce({
+      ...publicSettings,
+      invitation_code_enabled: true
+    })
+
+    const wrapper = mountRegister()
+    await flushPromises()
+
+    expect(wrapper.find('[data-testid="affiliate-invitation-field"]').exists()).toBe(false)
+    expect(wrapper.get('#invitation_code').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## 背景

注册页同时启用联盟邀请和 Turnstile、但未启用强制邀请码时，应在 Turnstile 前显示可选的联盟邀请码输入框。未发现与 #4863 重叠的 PR。

## 根因

注册页没有从公开设置中加载 `affiliate_enabled`，也没有在 `invitation_code_enabled` 为 `false` 时渲染绑定 `formData.aff_code` 的可选输入框。因此 Turnstile 成为下一项可见内容，看起来占据了邀请码输入框应在的位置。

## 改动

- 加载并使用 `affiliate_enabled`。
- 在 Turnstile 前渲染一个绑定 `formData.aff_code` 的可选联盟邀请码输入框。
- 保留强制邀请码字段的优先级：启用 `invitation_code_enabled` 时只显示强制字段，不重复显示可选联盟字段。
- 添加注册页回归测试，覆盖字段顺序和强制字段优先级。

## 测试

- Vitest `RegisterView.spec.ts`：通过（1 个文件，2 个测试）。
- `vue-tsc --noEmit`：通过。
- ESLint（批准的两个文件）：通过。
- `npm run build`：通过；仅有既存的 chunk/dynamic-import 警告。
- 静态扫描：无发现。
- 独立审查：通过，未发现安全或逻辑错误。
- `git diff --check`：通过。

Fixes #4863
