### PR TITLE
fix(openai): preserve namespaced Codex calls

### DIFF
--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/gin-gonic/gin"
@@ -65,9 +66,11 @@ func flattenOpenAIResponsesNamespaces(c *gin.Context, body []byte) ([]byte, erro
 }
 
 // stripOpenAIResponsesInputNamespaces removes namespace only from direct input
-// array items. Namespace declarations and nested namespace fields are left
-// untouched. Rebuilding the input array once keeps this linear for long
-// histories and avoids decoding JSON numbers through float64.
+// array items whose Responses schema does not carry it. Function and custom
+// tool calls must retain namespace so Codex can round-trip namespaced tools.
+// Namespace declarations and nested namespace fields are left untouched.
+// Rebuilding the input array once keeps this linear for long histories and
+// avoids decoding JSON numbers through float64.
 func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 	if !bytes.Contains(body, []byte(`"namespace"`)) {
 		return body, nil
@@ -89,7 +92,7 @@ func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 		}
 		first = false
 		itemBody := []byte(item.Raw)
-		if item.IsObject() && item.Get("namespace").Exists() {
+		if item.IsObject() && item.Get("namespace").Exists() && !openAIResponsesInputItemSupportsNamespace(item) {
 			itemBody, stripErr = sjson.DeleteBytes(itemBody, "namespace")
 			if stripErr != nil {
 				return false
@@ -111,6 +114,15 @@ func stripOpenAIResponsesInputNamespaces(body []byte) ([]byte, error) {
 		return body, fmt.Errorf("replace OpenAI input after namespace deletion: %w", err)
 	}
 	return stripped, nil
+}
+
+func openAIResponsesInputItemSupportsNamespace(item gjson.Result) bool {
+	switch strings.TrimSpace(item.Get("type").String()) {
+	case "function_call", "custom_tool_call":
+		return true
+	default:
+		return false
+	}
 }
 
 func setOpenAIResponsesNamespaceNames(c *gin.Context, names map[string]apicompat.ResponsesNamespaceName) {

--- a/backend/internal/service/openai_responses_namespace_test.go
+++ b/backend/internal/service/openai_responses_namespace_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -81,14 +80,27 @@ func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
 			{"type":"item","namespace":"n4"},
 			{"type":"item","namespace":"n5"},
 			{"type":"item","namespace":"n6"},
-			{"type":"item","namespace":"n7"}
+			{"type":"item","namespace":"n7"},
+			{"type":"item","namespace":"n8"},
+			{"type":"item","namespace":"n9"}
 		]
 	}`)
 
 	stripped, err := stripOpenAIResponsesInputNamespaces(body)
 	require.NoError(t, err)
-	for index := 0; index < 8; index++ {
-		require.False(t, gjson.GetBytes(stripped, "input."+strconv.Itoa(index)+".namespace").Exists())
+	require.Equal(t, "n0", gjson.GetBytes(stripped, "input.0.namespace").String())
+	require.Equal(t, "n2", gjson.GetBytes(stripped, "input.2.namespace").String())
+	for _, path := range []string{
+		"input.1.namespace",
+		"input.3.namespace",
+		"input.4.namespace",
+		"input.5.namespace",
+		"input.6.namespace",
+		"input.7.namespace",
+		"input.8.namespace",
+		"input.9.namespace",
+	} {
+		require.False(t, gjson.GetBytes(stripped, path).Exists())
 	}
 	require.Equal(t, "nested", gjson.GetBytes(stripped, "input.0.content.namespace").String())
 	require.Equal(t, "nested-content", gjson.GetBytes(stripped, "input.1.content.0.namespace").String())
@@ -97,6 +109,15 @@ func TestStripOpenAIResponsesInputNamespaces(t *testing.T) {
 	require.Equal(t, gjson.GetBytes(body, "scientific").Raw, gjson.GetBytes(stripped, "scientific").Raw)
 	require.Equal(t, gjson.GetBytes(body, "escaped").Raw, gjson.GetBytes(stripped, "escaped").Raw)
 	require.Equal(t, gjson.GetBytes(body, "input.0.large").Raw, gjson.GetBytes(stripped, "input.0.large").Raw)
+}
+
+func TestStripOpenAIResponsesInputNamespacesLeavesNamespaceBearingCallsByteExact(t *testing.T) {
+	body := []byte(`{"input":[{"type":"function_call","call_id":"call_1","name":"list_agents","namespace":"collaboration","arguments":"{}"},{"type":"custom_tool_call","call_id":"call_2","name":"exec","namespace":"mcp__python","input":"print(1)"}]}`)
+
+	stripped, err := stripOpenAIResponsesInputNamespaces(body)
+
+	require.NoError(t, err)
+	require.Equal(t, body, stripped)
 }
 
 func TestStripOpenAIResponsesInputNamespacesLeavesOtherShapesByteExact(t *testing.T) {

--- a/backend/internal/service/openai_responses_rejected_field_retry.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry.go
@@ -114,9 +114,13 @@ func openAIResponsesRejectedNamespaceIndex(param string) (int, bool) {
 
 func removeOpenAIResponsesRejectedNamespaceAtIndex(body []byte, index int) ([]byte, string, bool, error) {
 	itemPath := fmt.Sprintf("input.%d", index)
+	item := gjson.GetBytes(body, itemPath)
+	if openAIResponsesInputItemSupportsNamespace(item) {
+		return nil, "", false, nil
+	}
 	itemType := strings.ToLower(strings.TrimSpace(gjson.GetBytes(body, itemPath+".type").String()))
 	switch itemType {
-	case "function_call", "tool_call", "custom_tool_call", "mcp_tool_call":
+	case "tool_call", "mcp_tool_call":
 	default:
 		return nil, "", false, nil
 	}

--- a/backend/internal/service/openai_responses_rejected_field_retry_test.go
+++ b/backend/internal/service/openai_responses_rejected_field_retry_test.go
@@ -68,9 +68,20 @@ func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyRejectsAmbiguousErrors(t 
 	}
 }
 
-func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyFindsNamespacePathInMessage(t *testing.T) {
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyPreservesCodexNamespaceFromMessage(t *testing.T) {
 	body := []byte(`{"input":[{"type":"function_call","namespace":"keep","arguments":"{}"},{"type":"function_call","namespace":"remove","arguments":"{}"}]}`)
 	responseBody := []byte(`{"error":{"code":"unknown_parameter","message":"input[0] was accepted; Unknown parameter: 'input[1].namespace'."}}`)
+
+	retryBody, _, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
+
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Nil(t, retryBody)
+}
+
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyBindsLegacyNamespacePathToRejectionPhrase(t *testing.T) {
+	body := []byte(`{"input":[{"type":"tool_call","namespace":"keep","arguments":"{}"},{"type":"tool_call","namespace":"remove","arguments":"{}"}]}`)
+	responseBody := []byte(`{"error":{"code":"unknown_parameter","message":"input[0].namespace is supported; Unknown parameter: input[1].namespace."}}`)
 
 	retryBody, _, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
 
@@ -80,16 +91,15 @@ func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyFindsNamespacePathInMessa
 	require.False(t, gjson.GetBytes(retryBody, "input.1.namespace").Exists())
 }
 
-func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyBindsNamespacePathToRejectionPhrase(t *testing.T) {
-	body := []byte(`{"input":[{"type":"function_call","namespace":"keep","arguments":"{}"},{"type":"function_call","namespace":"remove","arguments":"{}"}]}`)
-	responseBody := []byte(`{"error":{"code":"unknown_parameter","message":"input[0].namespace is supported; Unknown parameter: input[1].namespace."}}`)
+func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyPreservesCodexCustomToolCallNamespace(t *testing.T) {
+	body := []byte(`{"input":[{"type":"custom_tool_call","call_id":"call_1","name":"exec","namespace":"mcp__python","input":"print(1)"}]}`)
+	responseBody := []byte(`{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[0].namespace'.","param":"input[0].namespace"}}`)
 
 	retryBody, _, changed, err := normalizeOpenAIResponsesRejectedFieldRetryBody(http.StatusBadRequest, body, responseBody)
 
 	require.NoError(t, err)
-	require.True(t, changed)
-	require.Equal(t, "keep", gjson.GetBytes(retryBody, "input.0.namespace").String())
-	require.False(t, gjson.GetBytes(retryBody, "input.1.namespace").Exists())
+	require.False(t, changed)
+	require.Nil(t, retryBody)
 }
 
 func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyDoesNotTreatMaxOutputTokensSuggestionAsRejection(t *testing.T) {
@@ -114,8 +124,8 @@ func TestNormalizeOpenAIResponsesRejectedFieldRetryBodyBindsMaxOutputTokensToRej
 	require.False(t, gjson.GetBytes(retryBody, "max_output_tokens").Exists())
 }
 
-func TestOpenAIGatewayService_APIKeyStripsAllIndexedNamespacesBeforeFirstForward(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","name":"first","namespace":"remove-first","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove-second","input":"{}"}]}`)
+func TestOpenAIGatewayService_APIKeyPreservesCodexCallNamespacesBeforeFirstForward(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","call_id":"call_1","name":"first","namespace":"keep-first","arguments":"{}"},{"type":"custom_tool_call","call_id":"call_2","name":"second","namespace":"keep-second","input":"{}"}]}`)
 	upstream := &httpUpstreamRecorder{responses: []*http.Response{
 		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
 	}}
@@ -130,8 +140,27 @@ func TestOpenAIGatewayService_APIKeyStripsAllIndexedNamespacesBeforeFirstForward
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Len(t, upstream.bodies, 1)
-	require.False(t, gjson.GetBytes(upstream.bodies[0], "input.0.namespace").Exists())
-	require.False(t, gjson.GetBytes(upstream.bodies[0], "input.1.namespace").Exists())
+	require.Equal(t, "keep-first", gjson.GetBytes(upstream.bodies[0], "input.0.namespace").String())
+	require.Equal(t, "keep-second", gjson.GetBytes(upstream.bodies[0], "input.1.namespace").String())
+}
+
+func TestOpenAIGatewayService_DoesNotRetryRejectedCodexCallNamespace(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"input":[{"type":"function_call","call_id":"call_1","name":"list_agents","namespace":"collaboration","arguments":"{}"}]}`)
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unknown_parameter","message":"Unknown parameter: 'input[0].namespace'.","param":"input[0].namespace"}}`),
+	}}
+
+	result, err := newOpenAIRejectedFieldTestService(upstream).Forward(
+		context.Background(),
+		newOpenAIRejectedFieldTestContext(body),
+		newOpenAIRejectedFieldTestAccount(),
+		body,
+	)
+
+	require.Error(t, err)
+	require.Nil(t, result)
+	require.Len(t, upstream.bodies, 1)
+	require.Equal(t, "collaboration", gjson.GetBytes(upstream.bodies[0], "input.0.namespace").String())
 }
 
 func TestOpenAIGatewayService_OpenAIHTTPStripsInputNamespacesBeforeFirstForward(t *testing.T) {
@@ -145,7 +174,7 @@ func TestOpenAIGatewayService_OpenAIHTTPStripsInputNamespacesBeforeFirstForward(
 	for _, tt := range accounts {
 		for _, path := range []string{"/v1/responses", "/v1/responses/compact"} {
 			t.Run(tt.name+path, func(t *testing.T) {
-				body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"test","input":[{"type":"message","role":"user","namespace":"remove","content":[{"type":"input_text","text":"hello","namespace":"nested-keep"}]}]}`)
+				body := []byte(`{"model":"gpt-5.5","stream":false,"instructions":"test","input":[{"type":"message","role":"user","namespace":"remove","content":[{"type":"input_text","text":"hello","namespace":"nested-keep"}]},{"type":"function_call","call_id":"call_1","name":"list_agents","namespace":"collaboration","arguments":"{}"},{"type":"custom_tool_call","call_id":"call_2","name":"exec","namespace":"mcp__python","input":"print(1)"}]}`)
 				upstream := &httpUpstreamRecorder{responses: []*http.Response{
 					newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"id":"resp_namespace_ok","output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
 				}}
@@ -164,6 +193,8 @@ func TestOpenAIGatewayService_OpenAIHTTPStripsInputNamespacesBeforeFirstForward(
 				require.Len(t, upstream.bodies, 1, "namespace must be removed before the first upstream request")
 				require.False(t, gjson.GetBytes(upstream.bodies[0], "input.0.namespace").Exists())
 				require.Equal(t, "nested-keep", gjson.GetBytes(upstream.bodies[0], "input.0.content.0.namespace").String())
+				require.Equal(t, "collaboration", gjson.GetBytes(upstream.bodies[0], "input.1.namespace").String())
+				require.Equal(t, "mcp__python", gjson.GetBytes(upstream.bodies[0], "input.2.namespace").String())
 			})
 		}
 	}
@@ -191,8 +222,8 @@ func TestOpenAIGatewayService_RetriesExplicitMaxOutputTokensRejection(t *testing
 	require.Equal(t, "keep", gjson.GetBytes(upstream.bodies[1], "input.0.content.max_output_tokens").String())
 }
 
-func TestOpenAIGatewayService_ComposesProactiveNamespaceStripWithRejectedFieldRetry(t *testing.T) {
-	body := []byte(`{"model":"gpt-5.5","stream":false,"max_output_tokens":2048,"input":[{"type":"function_call","name":"first","namespace":"remove-first","arguments":"{}"},{"type":"custom_tool_call","name":"second","namespace":"remove-second","input":"{}"}]}`)
+func TestOpenAIGatewayService_ComposesNamespaceNormalizationWithRejectedFieldRetry(t *testing.T) {
+	body := []byte(`{"model":"gpt-5.5","stream":false,"max_output_tokens":2048,"input":[{"type":"function_call","call_id":"call_1","name":"first","namespace":"keep-first","arguments":"{}"},{"type":"custom_tool_call","call_id":"call_2","name":"second","namespace":"keep-second","input":"{}"}]}`)
 	upstream := &httpUpstreamRecorder{responses: []*http.Response{
 		newOpenAIRejectedFieldTestResponse(http.StatusBadRequest, `{"error":{"code":"unsupported_parameter","message":"Unsupported parameter: max_output_tokens","param":"max_output_tokens"}}`),
 		newOpenAIRejectedFieldTestResponse(http.StatusOK, `{"output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`),
@@ -209,8 +240,8 @@ func TestOpenAIGatewayService_ComposesProactiveNamespaceStripWithRejectedFieldRe
 	require.NotNil(t, result)
 	require.Len(t, upstream.bodies, 2)
 	for _, forwardedBody := range upstream.bodies {
-		require.False(t, gjson.GetBytes(forwardedBody, "input.0.namespace").Exists())
-		require.False(t, gjson.GetBytes(forwardedBody, "input.1.namespace").Exists())
+		require.Equal(t, "keep-first", gjson.GetBytes(forwardedBody, "input.0.namespace").String())
+		require.Equal(t, "keep-second", gjson.GetBytes(forwardedBody, "input.1.namespace").String())
 	}
 	require.Equal(t, int64(2048), gjson.GetBytes(upstream.bodies[0], "max_output_tokens").Int())
 	require.False(t, gjson.GetBytes(upstream.bodies[1], "max_output_tokens").Exists())


### PR DESCRIPTION
## Summary

- Fix the P0 regression introduced by #4804 while retaining its linear cleanup for unsupported direct `input[]` namespace fields.
- Preserve `namespace` on `function_call` and `custom_tool_call` items so Codex can round-trip the tool identity.
- Do not let the rejected-field retry remove those protocol fields after an upstream 400.
- Keep existing namespace declaration flattening, response restoration, nested-field handling, HTTP account gating, and native WSv2 behavior unchanged.

Fixes #4761.

## Why #4804 is incorrect

#4804 deletes `namespace` from every direct Responses `input[]` object. That includes historical namespaced tool calls. The upstream then cannot resolve calls such as `collaboration/list_agents` and returns `Missing namespace ... Round-trip the model function_call item with its namespace field included`.

This is not only a historical Codex behavior. The latest `openai/codex` main checked for this PR is commit `61a44880a85d2fd0d8770908dea5733495e571c8`:

- [`ResponseItem::FunctionCall` and `ResponseItem::CustomToolCall` both serialize an optional namespace](https://github.com/openai/codex/blob/61a44880a85d2fd0d8770908dea5733495e571c8/codex-rs/protocol/src/models.rs#L861-L923).
- [The Responses request builder clones and forwards the prompt input without stripping call namespaces](https://github.com/openai/codex/blob/61a44880a85d2fd0d8770908dea5733495e571c8/codex-rs/core/src/client_common.rs#L20-L60).
- [The tool router combines namespace and name to identify both function and custom tool calls](https://github.com/openai/codex/blob/61a44880a85d2fd0d8770908dea5733495e571c8/codex-rs/core/src/tools/router.rs#L130-L174).

Therefore the cleanup must be type-aware: remove schema-invalid residual namespaces from messages, outputs, and unknown direct items, but preserve them on the two call item types defined by current Codex.

## Regression coverage

- Removes eight unsupported direct item namespaces in one pass, beyond the old six-retry limit.
- Preserves function and custom tool call namespaces byte-for-byte when no cleanup is needed.
- Covers OAuth and API Key forwarding for both `/v1/responses` and `/v1/responses/compact` without requiring current tool declarations.
- Verifies an unrelated `max_output_tokens` retry keeps the call namespaces on every attempt.
- Verifies an explicit namespace rejection does not trigger a destructive retry.

## Validation

- `go test -tags=unit ./internal/service -run <namespace-and-rejected-field-tests> -count=1`
- `go test -tags=unit ./internal/service -count=1`
- `go test -tags=unit ./internal/pkg/apicompat -count=1`
- `golangci-lint run ./internal/service ./internal/pkg/apicompat` (`0 issues`)
- `git diff --check`
