### PR TITLE
fix(security-audit): reject unavailable prompt config

### DIFF
--- a/backend/internal/securityaudit/prompt_config.go
+++ b/backend/internal/securityaudit/prompt_config.go
@@ -44,7 +44,7 @@ type ConfigStore interface {
 	// It must stay false when blocking is not intended, even if config is
 	// untrusted—otherwise default-off deployments fail closed for all traffic.
 	BlockingActivationDegraded() bool
-	Public() PublicConfig
+	Public() (PublicConfig, error)
 	Save(ctx context.Context, req UpdateConfigRequest, actorID int64) (PublicConfig, error)
 	RuntimeState() (expected int64, active int64, loadedAt *time.Time, loadError string)
 	Encrypt(value string) (string, error)

--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -194,15 +194,15 @@ func (m *ConfigManager) markUntrustedIfNoActiveSnapshot() {
 	}
 }
 
-func (m *ConfigManager) Public() PublicConfig {
+func (m *ConfigManager) Public() (PublicConfig, error) {
 	if m == nil {
-		return PublicFromStorage(DefaultStorageConfig(), false)
+		return PublicConfig{}, infraerrors.ServiceUnavailable(ErrorCodeConfigUnavailable, "提示词审计配置暂不可用")
 	}
 	snapshot := m.snapshot.Load()
 	if snapshot == nil {
-		return PublicFromStorage(DefaultStorageConfig(), false)
+		return PublicConfig{}, infraerrors.ServiceUnavailable(ErrorCodeConfigUnavailable, "提示词审计配置暂不可用")
 	}
-	return PublicFromStorage(cloneStorageConfig(snapshot.storage), snapshot.active.RiskControlEnabled)
+	return PublicFromStorage(cloneStorageConfig(snapshot.storage), snapshot.active.RiskControlEnabled), nil
 }
 
 func (m *ConfigManager) Save(ctx context.Context, req UpdateConfigRequest, actorID int64) (PublicConfig, error) {

--- a/backend/internal/securityaudit/prompt_config_test.go
+++ b/backend/internal/securityaudit/prompt_config_test.go
@@ -56,6 +56,57 @@ func TestConfigRuntimeLoadErrorIsStableBoundedAndSecretFree(t *testing.T) {
 	require.LessOrEqual(t, len([]rune(message)), 160)
 }
 
+func TestConfigManagerPublicRequiresSuccessfullyLoadedSnapshot(t *testing.T) {
+	t.Run("absent persisted setting is legitimate default", func(t *testing.T) {
+		manager := NewConfigManager(nil, staticSettingRepository{values: map[string]string{
+			SettingKeyPromptAuditConfig: "",
+			SettingKeyRiskControl:       "false",
+		}}, nil, prefixEncryptor{})
+		require.NoError(t, manager.Reload(context.Background()))
+
+		public, err := manager.Public()
+		require.NoError(t, err)
+		require.Equal(t, int64(1), public.ConfigVersion)
+		require.False(t, public.Enabled)
+	})
+
+	t.Run("persisted config activation failure is unavailable", func(t *testing.T) {
+		const canary = "persisted-token-canary"
+		manager := NewConfigManager(nil, staticSettingRepository{values: map[string]string{
+			SettingKeyPromptAuditConfig: `{"enabled":true,"config_version":9,"endpoints":[{"token_ciphertext":"` + canary + `"}]}`,
+			SettingKeyRiskControl:       "true",
+		}}, nil, prefixEncryptor{})
+		require.Error(t, manager.Reload(context.Background()))
+
+		public, err := manager.Public()
+		require.Error(t, err)
+		require.Empty(t, public)
+		require.Equal(t, ErrorCodeConfigUnavailable, infraerrors.Reason(err))
+		require.NotContains(t, err.Error(), canary)
+	})
+
+	t.Run("reload failure preserves last successfully loaded snapshot", func(t *testing.T) {
+		storage := DefaultStorageConfig()
+		storage.ConfigVersion = 4
+		storage.ChangeSummary = "trusted snapshot"
+		raw, err := json.Marshal(storage)
+		require.NoError(t, err)
+		repository := &switchableSettingRepository{staticSettingRepository: staticSettingRepository{values: map[string]string{
+			SettingKeyPromptAuditConfig: string(raw),
+			SettingKeyRiskControl:       "false",
+		}}}
+		manager := NewConfigManager(nil, repository, nil, prefixEncryptor{})
+		require.NoError(t, manager.Reload(context.Background()))
+		repository.loadErr = errors.New("settings unavailable")
+		require.Error(t, manager.Reload(context.Background()))
+
+		public, err := manager.Public()
+		require.NoError(t, err)
+		require.Equal(t, int64(4), public.ConfigVersion)
+		require.Equal(t, "trusted snapshot", public.ChangeSummary)
+	})
+}
+
 func TestBuildNextStoragePreserveReplaceAndClearToken(t *testing.T) {
 	manager := &ConfigManager{encryptor: prefixEncryptor{}}
 	current := DefaultStorageConfig()
@@ -135,6 +186,18 @@ type errorSettingRepository struct{ staticSettingRepository }
 
 func (errorSettingRepository) GetMultiple(context.Context, []string) (map[string]string, error) {
 	return nil, errors.New("settings unavailable")
+}
+
+type switchableSettingRepository struct {
+	staticSettingRepository
+	loadErr error
+}
+
+func (r *switchableSettingRepository) GetMultiple(ctx context.Context, keys []string) (map[string]string, error) {
+	if r.loadErr != nil {
+		return nil, r.loadErr
+	}
+	return r.staticSettingRepository.GetMultiple(ctx, keys)
 }
 
 func TestConfigManagerStartupLoadFailureDoesNotBlockWhenBlockingNotIntended(t *testing.T) {

--- a/backend/internal/securityaudit/prompt_handler.go
+++ b/backend/internal/securityaudit/prompt_handler.go
@@ -13,7 +13,7 @@ import (
 )
 
 type PromptAdminService interface {
-	GetConfig() PublicConfig
+	GetConfig() (PublicConfig, error)
 	SaveConfig(context.Context, UpdateConfigRequest, int64) (PublicConfig, error)
 	Probe(context.Context, ProbeRequest) ProbeResult
 	Runtime(context.Context) RuntimeSnapshot
@@ -31,7 +31,14 @@ func NewPromptAdminHandler(service PromptAdminService) *PromptAdminHandler {
 	return &PromptAdminHandler{service: service}
 }
 
-func (h *PromptAdminHandler) GetConfig(c *gin.Context) { response.Success(c, h.service.GetConfig()) }
+func (h *PromptAdminHandler) GetConfig(c *gin.Context) {
+	config, err := h.service.GetConfig()
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, config)
+}
 
 func (h *PromptAdminHandler) UpdateConfig(c *gin.Context) {
 	var request UpdateConfigRequest

--- a/backend/internal/securityaudit/prompt_handler_test.go
+++ b/backend/internal/securityaudit/prompt_handler_test.go
@@ -29,7 +29,9 @@ type fakePromptAdminService struct {
 	deleteFilter func(context.Context, DeleteByFilterRequest, int64) (*DeleteResult, error)
 }
 
-func (s *fakePromptAdminService) GetConfig() PublicConfig { return s.config }
+func (s *fakePromptAdminService) GetConfig() (PublicConfig, error) {
+	return s.config, nil
+}
 func (s *fakePromptAdminService) SaveConfig(ctx context.Context, req UpdateConfigRequest, actorID int64) (PublicConfig, error) {
 	if s.save == nil {
 		return PublicConfig{}, errors.New("unexpected SaveConfig call")
@@ -154,6 +156,21 @@ func TestPromptAdminConfigRequiresVersionMapsConflictAndNeverEchoesToken(t *test
 		require.NotContains(t, body, `"token":`)
 		require.Contains(t, body, `"has_token":true`)
 	})
+}
+
+func TestPromptAdminGetConfigReturnsSecretFreeUnavailableError(t *testing.T) {
+	const canary = "persisted-config-secret-canary"
+	repository := &switchableSettingRepository{loadErr: errors.New("failed to load token " + canary)}
+	manager := NewConfigManager(nil, repository, nil, prefixEncryptor{})
+	require.Error(t, manager.Reload(context.Background()))
+	service := &PromptService{config: manager}
+
+	response := promptAdminRequest(t, promptAdminRouter(service), http.MethodGet, "/admin/prompt-audit/config", nil)
+	require.Equal(t, http.StatusServiceUnavailable, response.Code)
+	require.Contains(t, response.Body.String(), ErrorCodeConfigUnavailable)
+	require.NotContains(t, response.Body.String(), canary)
+	require.NotContains(t, response.Body.String(), `"config_version"`)
+	require.NotContains(t, response.Body.String(), `"token"`)
 }
 
 func TestPromptAdminProbeSupportsTemporaryOrSavedTokenWithoutEcho(t *testing.T) {

--- a/backend/internal/securityaudit/prompt_service.go
+++ b/backend/internal/securityaudit/prompt_service.go
@@ -166,7 +166,7 @@ func (s *PromptService) Evaluate(ctx context.Context, req Request) (*PromptDecis
 	return s.evaluator.Evaluate(ctx, cfg, snapshot)
 }
 
-func (s *PromptService) GetConfig() PublicConfig { return s.config.Public() }
+func (s *PromptService) GetConfig() (PublicConfig, error) { return s.config.Public() }
 
 func (s *PromptService) SaveConfig(ctx context.Context, req UpdateConfigRequest, actorID int64) (PublicConfig, error) {
 	return s.config.Save(ctx, req, actorID)

--- a/backend/internal/securityaudit/prompt_types.go
+++ b/backend/internal/securityaudit/prompt_types.go
@@ -12,11 +12,12 @@ const (
 	ConfigInvalidationChannel = "sub2api:prompt_guard:config:invalidate"
 	PayloadKeyPrefix          = "sub2api:prompt_audit:payload:"
 
-	ErrorCodeBlocked         = "prompt_guard_blocked"
-	ErrorCodeUnavailable     = "prompt_guard_unavailable"
-	ErrorCodeInvalidResponse = "prompt_guard_invalid_response"
-	ErrorCodeConfigConflict  = "prompt_audit_config_conflict"
-	ErrorCodeRequiresEnabled = "prompt_guard_requires_audit_enabled"
+	ErrorCodeBlocked           = "prompt_guard_blocked"
+	ErrorCodeUnavailable       = "prompt_guard_unavailable"
+	ErrorCodeInvalidResponse   = "prompt_guard_invalid_response"
+	ErrorCodeConfigConflict    = "prompt_audit_config_conflict"
+	ErrorCodeConfigUnavailable = "prompt_audit_config_unavailable"
+	ErrorCodeRequiresEnabled   = "prompt_guard_requires_audit_enabled"
 
 	DefaultGuardModel = "sileader/qwen3guard:0.6b"
 )

--- a/backend/internal/securityaudit/prompt_worker_test.go
+++ b/backend/internal/securityaudit/prompt_worker_test.go
@@ -48,7 +48,7 @@ func (s *fakeConfigStore) EffectiveMode() Mode {
 	return s.cfg.EffectiveMode()
 }
 func (s *fakeConfigStore) BlockingActivationDegraded() bool { return false }
-func (s *fakeConfigStore) Public() PublicConfig             { return PublicConfig{} }
+func (s *fakeConfigStore) Public() (PublicConfig, error)    { return PublicConfig{}, nil }
 func (s *fakeConfigStore) Save(context.Context, UpdateConfigRequest, int64) (PublicConfig, error) {
 	return PublicConfig{}, nil
 }


### PR DESCRIPTION
## 问题

升级后若提示词审计配置在启动阶段加载失败，管理端仍会收到一份内存生成的默认 v1 配置。页面因此看起来像配置消失；管理员保存时，后端事务又会读取数据库中的真实版本并触发 CAS 冲突。

## 根因

`ConfigManager.Public` 在没有任何成功加载的可信快照时返回 `DefaultStorageConfig()`，把“配置尚不可用”伪装成可编辑的默认配置。保存路径以数据库为事实源，两个读取语义不一致。

## 改动

- 配置管理器从未成功加载快照时，管理端配置 GET 返回固定且不含敏感信息的 `prompt_audit_config_unavailable` 503。
- 正常成功加载且确实没有持久化配置时仍返回合法默认 v1。
- 后续瞬时重载失败时继续展示上一次可信快照，不扩大可用性影响；保存仍由数据库事务和 CAS 保护。
- 补充配置管理器与 handler 回归测试，覆盖默认配置、冷启动失败、敏感信息不泄露和可信快照保留。

## 测试

```text
cd backend && go test ./internal/securityaudit -count=1
cd backend && go vet ./internal/securityaudit
cd backend && go test ./internal/server/routes -run PromptAudit -count=1
git diff --check
```

以上命令均通过；独立复核未发现安全或逻辑错误。

Fixes #4887