### PR TITLE
fix(openai): retry dead passthrough websocket

### DIFF
--- a/backend/internal/service/openai_ws_v2/passthrough_relay.go
+++ b/backend/internal/service/openai_ws_v2/passthrough_relay.go
@@ -62,6 +62,7 @@ type RelayOptions struct {
 	UpstreamDrainTimeout            time.Duration
 	FirstMessageType                coderws.MessageType
 	FirstMessageSent                bool
+	FailOnInitialUpstreamDisconnect bool
 	StartClientAfterFirstDownstream bool
 	OnUsageParseFailure             func(eventType string, usageRaw string)
 	OnTurnComplete                  func(turn RelayTurnResult)
@@ -331,6 +332,25 @@ func Relay(
 			Stage:           stage,
 			Err:             exitErr,
 			WroteDownstream: combinedWroteDownstream,
+		}
+	}
+	if options.FailOnInitialUpstreamDisconnect &&
+		firstExit.stage == "read_upstream" &&
+		!combinedWroteDownstream {
+		exitErr := firstExit.err
+		if exitErr == nil {
+			exitErr = io.EOF
+		}
+		emitRelayTrace(onTrace, RelayTraceEvent{
+			Stage:           "relay_exit",
+			Direction:       relayDirectionFromStage(firstExit.stage),
+			Graceful:        false,
+			WroteDownstream: false,
+			Error:           relayErrorString(exitErr),
+		})
+		return result, &RelayExit{
+			Stage: "read_upstream",
+			Err:   exitErr,
 		}
 	}
 	if firstExit.graceful && (!hasSecondExit || secondExit.graceful) {

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -201,6 +202,26 @@ const openaiWSV2PassthroughModeFields = "ws_mode=passthrough ws_router=v2"
 
 var errOpenAIWSPassthroughFirstOutputTimeout = errors.New("openai websocket passthrough first output timeout")
 var errOpenAIWSPassthroughActiveTurnTimeout = errors.New("openai websocket passthrough active turn read timeout")
+
+const openAIWSPassthroughInitialRetryLimit = 1
+
+type openAIWSPassthroughPreOutputUpstreamError struct {
+	err error
+}
+
+func (e *openAIWSPassthroughPreOutputUpstreamError) Error() string {
+	if e == nil || e.err == nil {
+		return "openai websocket passthrough upstream error before output"
+	}
+	return e.err.Error()
+}
+
+func (e *openAIWSPassthroughPreOutputUpstreamError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.err
+}
 
 type openAIWSPassthroughDeadlinePhase uint8
 
@@ -608,6 +629,30 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	hooks *OpenAIWSIngressHooks,
 	wsDecision OpenAIWSProtocolDecision,
 ) error {
+	return s.proxyResponsesWebSocketV2PassthroughAttempt(
+		ctx,
+		c,
+		clientConn,
+		account,
+		token,
+		firstClientMessage,
+		hooks,
+		wsDecision,
+		openAIWSPassthroughInitialRetryLimit,
+	)
+}
+
+func (s *OpenAIGatewayService) proxyResponsesWebSocketV2PassthroughAttempt(
+	ctx context.Context,
+	c *gin.Context,
+	clientConn *coderws.Conn,
+	account *Account,
+	token string,
+	firstClientMessage []byte,
+	hooks *OpenAIWSIngressHooks,
+	wsDecision OpenAIWSProtocolDecision,
+	remainingInitialRetries int,
+) error {
 	if s == nil {
 		return errors.New("service is nil")
 	}
@@ -952,6 +997,33 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	firstWriteErr := relayUpstreamFrameConn.WriteFrame(firstWriteCtx, coderws.MessageText, firstClientMessage)
 	cancelFirstWrite()
 	if firstWriteErr != nil {
+		if remainingInitialRetries > 0 && isOpenAIWSPassthroughInitialRetryableError(firstWriteErr) {
+			logOpenAIWSV2Passthrough(
+				"relay_initial_retry account_id=%d retry=%d reason=write_upstream",
+				account.ID,
+				openAIWSPassthroughInitialRetryLimit-remainingInitialRetries+1,
+			)
+			_ = upstreamConn.Close()
+			return s.proxyResponsesWebSocketV2PassthroughAttempt(
+				ctx,
+				c,
+				clientConn,
+				account,
+				token,
+				firstClientMessage,
+				hooks,
+				wsDecision,
+				remainingInitialRetries-1,
+			)
+		}
+		if isOpenAIWSPassthroughInitialRetryableError(firstWriteErr) {
+			writeOpenAIWSPassthroughInitialFailure(clientConn, requestModel)
+			return NewOpenAIWSClientCloseError(
+				coderws.StatusInternalError,
+				"upstream websocket proxy failed",
+				firstWriteErr,
+			)
+		}
 		return wrapOpenAIWSIngressTurnError(
 			"write_upstream",
 			fmt.Errorf("write first upstream websocket request: %w", firstWriteErr),
@@ -988,6 +1060,7 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			IdleTimeout:                     0,
 			FirstMessageType:                coderws.MessageText,
 			FirstMessageSent:                upstreamFirstMessageSent,
+			FailOnInitialUpstreamDisconnect: true,
 			StartClientAfterFirstDownstream: true,
 			ReadClientFrame:                 readNextClientFrame,
 			OnUsageParseFailure: func(eventType string, usageRaw string) {
@@ -1048,6 +1121,13 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				if context.Cause(ctx) != nil {
 					return
 				}
+				// A fresh passthrough connection can be accepted by the upstream
+				// and still be dead before the first request is consumed. Keep the
+				// downstream connection open here so the caller can retire this
+				// upstream socket and make one safe replay attempt.
+				if isOpenAIWSPassthroughInitialRetryableRelayExit(&exit) {
+					return
+				}
 				status, reason, ok := openAIWSPassthroughRelayClientClose(exit, int(completedTurns.Load()))
 				if !ok {
 					return
@@ -1066,26 +1146,32 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 				if eventType == "error" {
 					s.handleOpenAIWSErrorEventTransientFailure(ctx, account, capturedSessionModel, handshakeHeaders, payload)
 				}
-				if wroteDownstream || eventType != "error" {
+				if eventType != "error" {
 					return nil
 				}
 				errCodeRaw, errTypeRaw, errMsgRaw := parseOpenAIWSErrorEventFields(payload)
-				if !isOpenAIWSRateLimitError(errCodeRaw, errTypeRaw, errMsgRaw) {
-					return nil
+				if isOpenAIWSRateLimitError(errCodeRaw, errTypeRaw, errMsgRaw) {
+					s.persistOpenAIWSRateLimitSignal(ctx, account, handshakeHeaders, payload, errCodeRaw, errTypeRaw, errMsgRaw)
+					logOpenAIWSV2Passthrough(
+						"relay_rate_limit_failover account_id=%d err_code=%s err_type=%s err_message=%s",
+						account.ID,
+						truncateOpenAIWSLogValue(errCodeRaw, openAIWSLogValueMaxLen),
+						truncateOpenAIWSLogValue(errTypeRaw, openAIWSLogValueMaxLen),
+						truncateOpenAIWSLogValue(errMsgRaw, openAIWSLogValueMaxLen),
+					)
+					return &UpstreamFailoverError{
+						StatusCode:      http.StatusTooManyRequests,
+						ResponseBody:    append([]byte(nil), payload...),
+						ResponseHeaders: cloneHeader(handshakeHeaders),
+					}
 				}
-				s.persistOpenAIWSRateLimitSignal(ctx, account, handshakeHeaders, payload, errCodeRaw, errTypeRaw, errMsgRaw)
-				logOpenAIWSV2Passthrough(
-					"relay_rate_limit_failover account_id=%d err_code=%s err_type=%s err_message=%s",
-					account.ID,
-					truncateOpenAIWSLogValue(errCodeRaw, openAIWSLogValueMaxLen),
-					truncateOpenAIWSLogValue(errTypeRaw, openAIWSLogValueMaxLen),
-					truncateOpenAIWSLogValue(errMsgRaw, openAIWSLogValueMaxLen),
-				)
-				return &UpstreamFailoverError{
-					StatusCode:      http.StatusTooManyRequests,
-					ResponseBody:    append([]byte(nil), payload...),
-					ResponseHeaders: cloneHeader(handshakeHeaders),
+				fallbackReason, canRetry := classifyOpenAIWSErrorEventFromRaw(errCodeRaw, errTypeRaw, errMsgRaw)
+				if !wroteDownstream && canRetry && fallbackReason == "upstream_error_event" {
+					return &openAIWSPassthroughPreOutputUpstreamError{
+						err: fmt.Errorf("upstream websocket error event: %s", strings.TrimSpace(errMsgRaw)),
+					}
 				}
+				return nil
 			},
 			OnTrace: func(event openaiwsv2.RelayTraceEvent) {
 				logOpenAIWSV2Passthrough(
@@ -1102,6 +1188,26 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			},
 		},
 	})
+	if remainingInitialRetries > 0 && isOpenAIWSPassthroughInitialRetryableRelayExit(relayExit) {
+		logOpenAIWSV2Passthrough(
+			"relay_initial_retry account_id=%d retry=%d reason=%s",
+			account.ID,
+			openAIWSPassthroughInitialRetryLimit-remainingInitialRetries+1,
+			truncateOpenAIWSLogValue(relayExit.Stage, openAIWSLogValueMaxLen),
+		)
+		_ = upstreamConn.Close()
+		return s.proxyResponsesWebSocketV2PassthroughAttempt(
+			ctx,
+			c,
+			clientConn,
+			account,
+			token,
+			firstClientMessage,
+			hooks,
+			wsDecision,
+			remainingInitialRetries-1,
+		)
+	}
 	if cause := context.Cause(ctx); cause != nil {
 		status := coderws.StatusGoingAway
 		reason := "websocket request canceled"
@@ -1167,6 +1273,18 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 	)
 
 	relayErr := relayExit.Err
+	if isOpenAIWSPassthroughInitialRetryableRelayExit(relayExit) {
+		// Both safe attempts failed before any downstream frame was emitted.
+		// Surface a protocol terminal event before the close handshake so
+		// Responses WS clients receive a structured failure instead of a
+		// bare 1011 transport error.
+		writeOpenAIWSPassthroughInitialFailure(clientConn, requestModel)
+		relayErr = NewOpenAIWSClientCloseError(
+			coderws.StatusInternalError,
+			"upstream websocket proxy failed",
+			relayExit.Err,
+		)
+	}
 	var firstOutputTimeoutErr *openAIWSPassthroughFirstOutputTimeoutError
 	if errors.As(relayErr, &firstOutputTimeoutErr) {
 		deadline := firstOutputTimeoutErr.deadline
@@ -1240,6 +1358,52 @@ func openAIWSPassthroughRelayClientClose(exit openaiwsv2.RelayExit, completedTur
 		return coderws.StatusInternalError, "upstream websocket proxy failed", true
 	}
 	return 0, "", false
+}
+
+func isOpenAIWSPassthroughInitialRetryableError(err error) bool {
+	return err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded)
+}
+
+func isOpenAIWSPassthroughInitialRetryableRelayExit(exit *openaiwsv2.RelayExit) bool {
+	if exit == nil || exit.WroteDownstream || !isOpenAIWSPassthroughInitialRetryableError(exit.Err) {
+		return false
+	}
+	switch exit.Stage {
+	case "read_upstream":
+		return true
+	case "upstream_message":
+		var preOutputErr *openAIWSPassthroughPreOutputUpstreamError
+		return errors.As(exit.Err, &preOutputErr)
+	default:
+		return false
+	}
+}
+
+func writeOpenAIWSPassthroughInitialFailure(clientConn *coderws.Conn, model string) {
+	if clientConn == nil {
+		return
+	}
+	payload, err := json.Marshal(map[string]any{
+		"type": "response.failed",
+		"response": map[string]any{
+			"object": "response",
+			"model":  strings.TrimSpace(model),
+			"status": "failed",
+			"output": []any{},
+			"error": map[string]any{
+				"code":    "upstream_connection_error",
+				"type":    "server_error",
+				"message": "upstream websocket connection failed before producing output",
+			},
+		},
+	})
+	if err == nil {
+		writeCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = clientConn.Write(writeCtx, coderws.MessageText, payload)
+		cancel()
+	}
+	_ = clientConn.Close(coderws.StatusInternalError, "upstream websocket proxy failed")
+	_ = clientConn.CloseNow()
 }
 
 func (s *OpenAIGatewayService) mapOpenAIWSPassthroughDialError(

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -1370,6 +1370,18 @@ func isOpenAIWSPassthroughInitialRetryableRelayExit(exit *openaiwsv2.RelayExit) 
 	}
 	switch exit.Stage {
 	case "read_upstream":
+		// A first-output timeout already has a dedicated cross-account
+		// failover path. Retrying the same upstream connection here delays
+		// that path and, after the retry budget is spent, closes the client
+		// with 1011 instead of allowing the handler to select the next account.
+		var firstOutputTimeoutErr *openAIWSPassthroughFirstOutputTimeoutError
+		if errors.As(exit.Err, &firstOutputTimeoutErr) {
+			return false
+		}
+		var activeTurnTimeoutErr *openAIWSPassthroughActiveTurnTimeoutError
+		if errors.As(exit.Err, &activeTurnTimeoutErr) {
+			return false
+		}
 		return true
 	case "upstream_message":
 		var preOutputErr *openAIWSPassthroughPreOutputUpstreamError

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -257,7 +257,8 @@ func TestPassthroughLifecycle_PreOutputUpstreamFailureRetriesOnce(t *testing.T) 
 	secondUpstream.Send(`{"type":"response.completed","response":{"id":"resp_retry","status":"completed","output":[]}}`)
 
 	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), firstUpstream)
-	dialer := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	dialer, ok := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	require.True(t, ok)
 	dialer.conns = []openAIWSClientConn{firstUpstream, secondUpstream}
 	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, svc, passthroughLifecycleAccount())
 	defer server.Close()
@@ -293,7 +294,8 @@ func TestPassthroughLifecycle_PreOutputEOFRetriesOnce(t *testing.T) {
 	secondUpstream.Send(`{"type":"response.completed","response":{"id":"resp_eof_retry","status":"completed","output":[]}}`)
 
 	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), firstUpstream)
-	dialer := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	dialer, ok := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	require.True(t, ok)
 	dialer.conns = []openAIWSClientConn{firstUpstream, secondUpstream}
 	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, svc, passthroughLifecycleAccount())
 	defer server.Close()
@@ -326,7 +328,8 @@ func TestPassthroughLifecycle_PreOutputFailureWritesResponseFailedAfterRetryExha
 	secondUpstream.Send(`{"type":"error","error":{"code":"server_error","message":"second socket failed"}}`)
 
 	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), firstUpstream)
-	dialer := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	dialer, ok := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	require.True(t, ok)
 	dialer.conns = []openAIWSClientConn{firstUpstream, secondUpstream}
 	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, svc, passthroughLifecycleAccount())
 	defer server.Close()

--- a/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -21,6 +22,7 @@ import (
 type stagedPassthroughFrame struct {
 	messageType coderws.MessageType
 	payload     []byte
+	err         error
 }
 
 type stagedPassthroughConn struct {
@@ -42,6 +44,10 @@ func (c *stagedPassthroughConn) Send(payload string) {
 	c.frames <- stagedPassthroughFrame{messageType: coderws.MessageText, payload: []byte(payload)}
 }
 
+func (c *stagedPassthroughConn) Fail(err error) {
+	c.frames <- stagedPassthroughFrame{err: err}
+}
+
 func (c *stagedPassthroughConn) WriteJSON(context.Context, any) error { return nil }
 
 func (c *stagedPassthroughConn) ReadMessage(ctx context.Context) ([]byte, error) {
@@ -61,6 +67,9 @@ func (c *stagedPassthroughConn) ReadFrame(ctx context.Context) (coderws.MessageT
 	case <-c.closed:
 		return coderws.MessageText, nil, errOpenAIWSConnClosed
 	case frame := <-c.frames:
+		if frame.err != nil {
+			return frame.messageType, nil, frame.err
+		}
 		return frame.messageType, append([]byte(nil), frame.payload...), nil
 	}
 }
@@ -96,11 +105,28 @@ func (c *stagedPassthroughConn) Close() error {
 }
 
 type stagedPassthroughDialer struct {
-	conn openAIWSClientConn
+	mu    sync.Mutex
+	conn  openAIWSClientConn
+	conns []openAIWSClientConn
+	calls int
 }
 
 func (d *stagedPassthroughDialer) Dial(context.Context, string, http.Header, string) (openAIWSClientConn, int, http.Header, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.calls++
+	if len(d.conns) > 0 {
+		conn := d.conns[0]
+		d.conns = d.conns[1:]
+		return conn, http.StatusSwitchingProtocols, http.Header{}, nil
+	}
 	return d.conn, http.StatusSwitchingProtocols, http.Header{}, nil
+}
+
+func (d *stagedPassthroughDialer) CallCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
 }
 
 func newPassthroughLifecycleService(cfg *config.Config, upstream *stagedPassthroughConn) *OpenAIGatewayService {
@@ -218,6 +244,114 @@ func requirePassthroughUpstreamWrite(t *testing.T, upstream *stagedPassthroughCo
 	case <-time.After(timeout):
 		t.Fatal("passthrough request was not forwarded upstream")
 		return nil
+	}
+}
+
+func TestPassthroughLifecycle_PreOutputUpstreamFailureRetriesOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancel(context.Background())
+	defer cancelControl()
+	firstUpstream := newStagedPassthroughConn()
+	secondUpstream := newStagedPassthroughConn()
+	firstUpstream.Send(`{"type":"error","error":{"code":"server_error","message":"stale upstream socket"}}`)
+	secondUpstream.Send(`{"type":"response.completed","response":{"id":"resp_retry","status":"completed","output":[]}}`)
+
+	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), firstUpstream)
+	dialer := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	dialer.conns = []openAIWSClientConn{firstUpstream, secondUpstream}
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, svc, passthroughLifecycleAccount())
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	firstWrite := requirePassthroughUpstreamWrite(t, firstUpstream, time.Second)
+	retryWrite := requirePassthroughUpstreamWrite(t, secondUpstream, time.Second)
+	require.Equal(t, "response.create", gjson.GetBytes(firstWrite, "type").String())
+	require.Equal(t, firstWrite, retryWrite, "retry must replay the exact first request")
+
+	event, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, 2, dialer.CallCount())
+
+	_ = clientConn.CloseNow()
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough relay did not finish after client disconnect")
+	}
+}
+
+func TestPassthroughLifecycle_PreOutputEOFRetriesOnce(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancel(context.Background())
+	defer cancelControl()
+	firstUpstream := newStagedPassthroughConn()
+	secondUpstream := newStagedPassthroughConn()
+	firstUpstream.Fail(io.EOF)
+	secondUpstream.Send(`{"type":"response.completed","response":{"id":"resp_eof_retry","status":"completed","output":[]}}`)
+
+	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), firstUpstream)
+	dialer := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	dialer.conns = []openAIWSClientConn{firstUpstream, secondUpstream}
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, svc, passthroughLifecycleAccount())
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	_ = requirePassthroughUpstreamWrite(t, firstUpstream, time.Second)
+	_ = requirePassthroughUpstreamWrite(t, secondUpstream, time.Second)
+	event, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, 2, dialer.CallCount())
+
+	_ = clientConn.CloseNow()
+	select {
+	case err := <-serverErr:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough relay did not finish after client disconnect")
+	}
+}
+
+func TestPassthroughLifecycle_PreOutputFailureWritesResponseFailedAfterRetryExhausted(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancel(context.Background())
+	defer cancelControl()
+	firstUpstream := newStagedPassthroughConn()
+	secondUpstream := newStagedPassthroughConn()
+	firstUpstream.Send(`{"type":"error","error":{"code":"server_error","message":"first socket failed"}}`)
+	secondUpstream.Send(`{"type":"error","error":{"code":"server_error","message":"second socket failed"}}`)
+
+	svc := newPassthroughLifecycleService(passthroughLifecycleConfig(), firstUpstream)
+	dialer := svc.openaiWSPassthroughDialer.(*stagedPassthroughDialer)
+	dialer.conns = []openAIWSClientConn{firstUpstream, secondUpstream}
+	server, serverErr := startPassthroughLifecycleServer(t, controlCtx, svc, passthroughLifecycleAccount())
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	_ = requirePassthroughUpstreamWrite(t, firstUpstream, time.Second)
+	_ = requirePassthroughUpstreamWrite(t, secondUpstream, time.Second)
+	event, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.failed", gjson.GetBytes(event, "type").String())
+	require.Equal(t, "upstream_connection_error", gjson.GetBytes(event, "response.error.code").String())
+
+	_, err = readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	var closeErr coderws.CloseError
+	require.ErrorAs(t, err, &closeErr)
+	require.Equal(t, coderws.StatusInternalError, closeErr.Code)
+	require.Equal(t, 2, dialer.CallCount())
+	select {
+	case err := <-serverErr:
+		var serverCloseErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, err, &serverCloseErr)
+		require.Equal(t, coderws.StatusInternalError, serverCloseErr.StatusCode())
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough relay did not report exhausted retries")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Retry a newly accepted passthrough upstream WebSocket once when it fails before the initial `response.create` emits any downstream frame.
- Retire the failed upstream connection before replaying, so a stale socket cannot cause an immediate client-facing 1011.
- Emit a protocol-level `response.failed` event before the 1011 close when the retry is exhausted.

## Root cause

The passthrough adapter forwarded an initial upstream `error` event and treated an early EOF as a graceful relay completion. Both paths bypassed the safe pre-output retry used by other ingress modes, so clients received a generic error followed by `1011 upstream websocket proxy failed`.

## Impact

New passthrough connections now recover from one transient pre-output upstream failure without replaying requests after downstream output has begun. Exhausted retries give Responses WebSocket clients a terminal protocol event they can handle.

## Validation

- `go test ./internal/service ./internal/service/openai_ws_v2`

Fixes #4880
