### PR TITLE
fix(ratelimit): skip cooldown for image models rejected by Codex text endpoints

### DIFF
--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -2047,6 +2047,14 @@ func (s *RateLimitService) HandleUpstreamModelNotFound(ctx context.Context, acco
 	case isUpstreamModelNotFoundError(statusCode, responseBody):
 		cooldown, reason = upstreamModelNotFoundCooldown, upstreamModelNotFoundReason
 	case isOpenAIOAuthAccount(account) && isOpenAICodexPlanGatedModelError(statusCode, responseBody):
+		// Image models rejected by the Codex text endpoints are a deterministic
+		// endpoint mismatch, not an account capability gap: the same account still
+		// serves them over /v1/images/*. Cooling down the model here would take the
+		// whole pool offline for correct image requests, so fail the attempt over
+		// without recording a per-model cooldown.
+		if IsGPTImageGenerationModel(requestedModel) {
+			return true
+		}
 		cooldown, reason = upstreamCodexPlanGatedModelCooldown, upstreamCodexPlanGatedModelReason
 	default:
 		return false

--- a/backend/internal/service/ratelimit_service_model_not_found_test.go
+++ b/backend/internal/service/ratelimit_service_model_not_found_test.go
@@ -382,6 +382,49 @@ func TestRateLimitService_HandleUpstreamError_CodexPlanGatedModelIgnoresAPIKeyAc
 	require.Empty(t, repo.modelRateLimitCalls)
 }
 
+func TestRateLimitService_HandleUpstreamError_CodexPlanGatedImageModelSkipsCooldown(t *testing.T) {
+	for _, model := range []string{"gpt-image-1", "gpt-image-1.5", "gpt-image-2"} {
+		t.Run(model, func(t *testing.T) {
+			repo := &modelNotFoundAccountRepoStub{}
+			svc := &RateLimitService{accountRepo: repo}
+			account := openAICodexPlanGatedOAuthAccount()
+
+			handled := svc.HandleUpstreamError(
+				context.Background(),
+				account,
+				http.StatusBadRequest,
+				http.Header{},
+				[]byte(`{"detail":"The '`+model+`' model is not supported when using Codex with a ChatGPT account."}`),
+				model,
+			)
+
+			require.True(t, handled, "attempt should still fail over")
+			require.Empty(t, repo.modelRateLimitCalls,
+				"image models must not be cooled down: the account still serves them over /v1/images/*")
+			require.Zero(t, repo.tempCalls)
+		})
+	}
+}
+
+func TestRateLimitService_HandleUpstreamError_CodexPlanGatedTextModelStillCoolsDown(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := openAICodexPlanGatedOAuthAccount()
+
+	handled := svc.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusBadRequest,
+		http.Header{},
+		[]byte(`{"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}`),
+		"gpt-5.6-sol",
+	)
+
+	require.True(t, handled)
+	require.Len(t, repo.modelRateLimitCalls, 1, "non-image plan-gated models keep the existing cooldown")
+	require.Equal(t, upstreamCodexPlanGatedModelReason, repo.modelRateLimitCalls[0].reason)
+}
+
 func openAICodexPlanGatedOAuthAccount() *Account {
 	return &Account{
 		ID:          202,


### PR DESCRIPTION
Fixes #4828

## Problem

When `gpt-image-*` models are mistakenly requested via `/v1/chat/completions` or `/v1/responses` (text endpoints), OpenAI Codex returns a deterministic `400 codex_plan_gated_model` error. `HandleUpstreamModelNotFound` in `ratelimit_service.go` was treating this as an account capability gap and writing a 30-minute `model_rate_limits` cooldown per account.

After failover exhausted all accounts, every account had the image model cooled down—so subsequent **correct** `/v1/images/generations` requests also failed with `503 no available accounts`.

## Solution

Added an early return inside the Codex plan-gated branch (`ratelimit_service.go` ~line 2055):

```go
// Image models rejected by the Codex text endpoints are a deterministic
// endpoint mismatch, not an account capability gap: the same account still
// serves them over /v1/images/*. Cooling down the model here would take the
// whole pool offline for correct image requests, so fail the attempt over
// without recording a per-model cooldown.
if IsGPTImageGenerationModel(requestedModel) {
    return true
}
```

Returning `true` still fails the attempt over to another account but skips the `SetModelRateLimit` write, preventing the pool from being taken offline for correct image endpoint requests.

## Tests

- `TestRateLimitService_HandleUpstreamError_CodexPlanGatedImageModelSkipsCooldown` — table over `gpt-image-1`, `gpt-image-1.5`, `gpt-image-2`; asserts `handled=true`, no `modelRateLimitCalls`, no `tempCalls`
- `TestRateLimitService_HandleUpstreamError_CodexPlanGatedTextModelStillCoolsDown` — regression guard that non-image plan-gated models keep the existing cooldown behavior

All existing unit tests pass.