### PR TITLE
fix(openai): bound scheduler database rechecks

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1337,6 +1337,12 @@ type GatewaySchedulingConfig struct {
 	DbFallbackTimeoutSeconds int `mapstructure:"db_fallback_timeout_seconds"`
 	// 受控回源限流（实例级 QPS），0 表示不限制
 	DbFallbackMaxQPS int `mapstructure:"db_fallback_max_qps"`
+	// 最终账号 DB 校验的单次超时（毫秒）。该校验不应继承整个模型请求的长超时。
+	DBRecheckTimeoutMS int `mapstructure:"db_recheck_timeout_ms"`
+	// 已成功校验账号的短缓存时间（毫秒），用于合并正常流量下的重复 DB 读取。
+	DBRecheckFreshTTLMS int `mapstructure:"db_recheck_fresh_ttl_ms"`
+	// DB 瞬时不可用时，允许使用最近一次成功校验账号的最长时间（秒）。
+	DBRecheckStaleIfErrorSeconds int `mapstructure:"db_recheck_stale_if_error_seconds"`
 
 	// Outbox 轮询与滞后阈值配置
 	// Outbox 轮询周期（秒）
@@ -2303,6 +2309,9 @@ func setDefaults() {
 	viper.SetDefault("gateway.scheduling.db_fallback_enabled", true)
 	viper.SetDefault("gateway.scheduling.db_fallback_timeout_seconds", 0)
 	viper.SetDefault("gateway.scheduling.db_fallback_max_qps", 0)
+	viper.SetDefault("gateway.scheduling.db_recheck_timeout_ms", 750)
+	viper.SetDefault("gateway.scheduling.db_recheck_fresh_ttl_ms", 1000)
+	viper.SetDefault("gateway.scheduling.db_recheck_stale_if_error_seconds", 120)
 	viper.SetDefault("gateway.scheduling.outbox_poll_interval_seconds", 1)
 	viper.SetDefault("gateway.scheduling.outbox_lag_warn_seconds", 5)
 	viper.SetDefault("gateway.scheduling.outbox_lag_rebuild_seconds", 10)
@@ -3392,6 +3401,15 @@ func (c *Config) Validate() error {
 	}
 	if c.Gateway.Scheduling.DbFallbackMaxQPS < 0 {
 		return fmt.Errorf("gateway.scheduling.db_fallback_max_qps must be non-negative")
+	}
+	if c.Gateway.Scheduling.DBRecheckTimeoutMS < 0 {
+		return fmt.Errorf("gateway.scheduling.db_recheck_timeout_ms must be non-negative")
+	}
+	if c.Gateway.Scheduling.DBRecheckFreshTTLMS < 0 {
+		return fmt.Errorf("gateway.scheduling.db_recheck_fresh_ttl_ms must be non-negative")
+	}
+	if c.Gateway.Scheduling.DBRecheckStaleIfErrorSeconds < 0 {
+		return fmt.Errorf("gateway.scheduling.db_recheck_stale_if_error_seconds must be non-negative")
 	}
 	if c.Gateway.Scheduling.OutboxPollIntervalSeconds <= 0 {
 		return fmt.Errorf("gateway.scheduling.outbox_poll_interval_seconds must be positive")

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -52,6 +52,68 @@ type cachedOpenAIAdvancedSchedulerSetting struct {
 	expiresAt                      int64
 }
 
+type openAIAccountDBRecheckEntry struct {
+	account    *Account
+	freshUntil time.Time
+	staleUntil time.Time
+	nextProbe  time.Time
+}
+
+type openAIAccountDBRecheckCache struct {
+	mu      sync.Mutex
+	entries map[int64]openAIAccountDBRecheckEntry
+	sf      singleflight.Group
+}
+
+func (c *openAIAccountDBRecheckCache) fresh(accountID int64, now time.Time) *Account {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[accountID]
+	fresh := now.Before(entry.freshUntil)
+	retrySuppressed := now.Before(entry.nextProbe) && now.Before(entry.staleUntil)
+	if !ok || entry.account == nil || (!fresh && !retrySuppressed) {
+		return nil
+	}
+	cloned := *entry.account
+	return &cloned
+}
+
+func (c *openAIAccountDBRecheckCache) stale(accountID int64, now time.Time) *Account {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[accountID]
+	if !ok || entry.account == nil || !now.Before(entry.staleUntil) {
+		return nil
+	}
+	entry.nextProbe = now.Add(time.Second)
+	c.entries[accountID] = entry
+	cloned := *entry.account
+	return &cloned
+}
+
+func (c *openAIAccountDBRecheckCache) store(account *Account, now time.Time, freshTTL, staleTTL time.Duration) {
+	if account == nil || account.ID <= 0 {
+		return
+	}
+	cloned := *account
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.entries == nil {
+		c.entries = make(map[int64]openAIAccountDBRecheckEntry)
+	}
+	c.entries[account.ID] = openAIAccountDBRecheckEntry{
+		account:    &cloned,
+		freshUntil: now.Add(freshTTL),
+		staleUntil: now.Add(staleTTL),
+	}
+}
+
+func (c *openAIAccountDBRecheckCache) remove(accountID int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.entries, accountID)
+}
+
 type openAIAdvancedSchedulerRuntimeSettings struct {
 	lowUpstreamRatePriorityEnabled bool
 	oauthSchedulingRateMultiplier  float64
@@ -1333,7 +1395,14 @@ func (s *defaultOpenAIAccountScheduler) selectByLoadBalance(
 	// require_privacy_set: 获取分组信息
 	var schedGroup *Group
 	if req.GroupID != nil && s.service.schedulerSnapshot != nil {
-		schedGroup, _ = s.service.schedulerSnapshot.GetGroupByID(ctx, *req.GroupID)
+		var groupErr error
+		schedGroup, groupErr = s.service.schedulerSnapshot.GetGroupByID(ctx, *req.GroupID)
+		if groupErr != nil {
+			return nil, 0, 0, 0, fmt.Errorf("resolve scheduling group: %w", groupErr)
+		}
+		if schedGroup == nil && s.service.schedulerSnapshot.groupRepo != nil {
+			return nil, 0, 0, 0, fmt.Errorf("resolve scheduling group %d: not found", *req.GroupID)
+		}
 	}
 
 	filterStats := openAISelectionFilterStats{pool: len(accounts)}

--- a/backend/internal/service/openai_db_recheck_resilience_test.go
+++ b/backend/internal/service/openai_db_recheck_resilience_test.go
@@ -1,0 +1,196 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
+	"github.com/stretchr/testify/require"
+)
+
+type openAIDBRecheckRepoStub struct {
+	AccountRepository
+	mu      sync.Mutex
+	account *Account
+	err     error
+	delay   time.Duration
+	calls   int
+}
+
+func (r *openAIDBRecheckRepoStub) GetByID(ctx context.Context, _ int64) (*Account, error) {
+	r.mu.Lock()
+	r.calls++
+	delay, err, account := r.delay, r.err, r.account
+	r.mu.Unlock()
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if account == nil {
+		return nil, ErrAccountNotFound
+	}
+	cloned := *account
+	return &cloned, nil
+}
+
+func (r *openAIDBRecheckRepoStub) setResult(account *Account, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.account, r.err = account, err
+}
+
+func (r *openAIDBRecheckRepoStub) callCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func newOpenAIDBRecheckTestService(repo AccountRepository, freshMS, staleSeconds int) *OpenAIGatewayService {
+	cfg := &config.Config{RunMode: config.RunModeStandard}
+	cfg.Gateway.Scheduling.DBRecheckTimeoutMS = 20
+	cfg.Gateway.Scheduling.DBRecheckFreshTTLMS = freshMS
+	cfg.Gateway.Scheduling.DBRecheckStaleIfErrorSeconds = staleSeconds
+	return &OpenAIGatewayService{
+		accountRepo:       repo,
+		cfg:               cfg,
+		schedulerSnapshot: &SchedulerSnapshotService{},
+	}
+}
+
+func eligibleOpenAIDBRecheckAccount() *Account {
+	return &Account{
+		ID:          44001,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 2,
+	}
+}
+
+func recheckTestAccount(svc *OpenAIGatewayService, account *Account, groupID *int64) *Account {
+	return svc.recheckSelectedOpenAIAccountFromDB(
+		context.Background(),
+		account,
+		groupID,
+		PlatformOpenAI,
+		"gpt-test",
+		false,
+		"",
+	)
+}
+
+func TestOpenAIAccountDBRecheckCoalescesHealthyReads(t *testing.T) {
+	account := eligibleOpenAIDBRecheckAccount()
+	repo := &openAIDBRecheckRepoStub{account: account, delay: 10 * time.Millisecond}
+	svc := newOpenAIDBRecheckTestService(repo, 1000, 120)
+
+	var wg sync.WaitGroup
+	results := make(chan *Account, 24)
+	for range 24 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results <- recheckTestAccount(svc, account, nil)
+		}()
+	}
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NotNil(t, result)
+		require.Equal(t, account.ID, result.ID)
+	}
+	require.Equal(t, 1, repo.callCount())
+}
+
+func TestOpenAIAccountDBRecheckUsesOnlyRecentlyValidatedStaleAccount(t *testing.T) {
+	account := eligibleOpenAIDBRecheckAccount()
+	repo := &openAIDBRecheckRepoStub{account: account}
+	svc := newOpenAIDBRecheckTestService(repo, 1, 1)
+
+	require.NotNil(t, recheckTestAccount(svc, account, nil))
+	time.Sleep(5 * time.Millisecond)
+	repo.setResult(nil, context.DeadlineExceeded)
+	require.NotNil(t, recheckTestAccount(svc, account, nil))
+	require.Equal(t, 2, repo.callCount())
+
+	// Retry suppression must prevent a DB failure storm without extending stale TTL.
+	require.NotNil(t, recheckTestAccount(svc, account, nil))
+	require.Equal(t, 2, repo.callCount())
+}
+
+func TestOpenAIAccountDBRecheckFailsClosedWithoutValidatedHistory(t *testing.T) {
+	account := eligibleOpenAIDBRecheckAccount()
+	repo := &openAIDBRecheckRepoStub{err: context.DeadlineExceeded}
+	svc := newOpenAIDBRecheckTestService(repo, 1, 120)
+
+	require.Nil(t, recheckTestAccount(svc, account, nil))
+	require.Equal(t, 1, repo.callCount())
+}
+
+func TestOpenAIAccountDBRecheckDoesNotMaskDeletionOrGroupMove(t *testing.T) {
+	groupID, otherGroupID := int64(91), int64(92)
+	account := eligibleOpenAIDBRecheckAccount()
+	account.GroupIDs = []int64{groupID}
+	repo := &openAIDBRecheckRepoStub{account: account}
+	svc := newOpenAIDBRecheckTestService(repo, 1, 120)
+
+	require.NotNil(t, recheckTestAccount(svc, account, &groupID))
+	time.Sleep(5 * time.Millisecond)
+	moved := *account
+	moved.GroupIDs = []int64{otherGroupID}
+	repo.setResult(&moved, nil)
+	require.Nil(t, recheckTestAccount(svc, account, &groupID))
+
+	time.Sleep(5 * time.Millisecond)
+	repo.setResult(nil, ErrAccountNotFound)
+	require.Nil(t, recheckTestAccount(svc, account, &groupID))
+}
+
+func TestOpenAIAccountDBRecheckRetrySuppressionNeverExtendsStaleWindow(t *testing.T) {
+	account := eligibleOpenAIDBRecheckAccount()
+	var cache openAIAccountDBRecheckCache
+	now := time.Now()
+	cache.store(account, now, time.Millisecond, 10*time.Millisecond)
+
+	require.NotNil(t, cache.stale(account.ID, now.Add(2*time.Millisecond)))
+	require.Nil(t, cache.fresh(account.ID, now.Add(11*time.Millisecond)))
+	require.Nil(t, cache.stale(account.ID, now.Add(11*time.Millisecond)))
+}
+
+type schedulerGroupRepoNoRead struct {
+	GroupRepository
+	called bool
+}
+
+func (r *schedulerGroupRepoNoRead) GetByID(context.Context, int64) (*Group, error) {
+	r.called = true
+	return nil, context.DeadlineExceeded
+}
+
+func TestSchedulerSnapshotUsesAuthenticatedGroupContextWithoutDB(t *testing.T) {
+	group := &Group{
+		ID:          77,
+		Platform:    PlatformOpenAI,
+		Status:      StatusActive,
+		Hydrated:    true,
+		IsExclusive: true,
+	}
+	repo := &schedulerGroupRepoNoRead{}
+	svc := &SchedulerSnapshotService{groupRepo: repo}
+	ctx := context.WithValue(context.Background(), ctxkey.Group, group)
+
+	resolved, err := svc.GetGroupByID(ctx, group.ID)
+	require.NoError(t, err)
+	require.Same(t, group, resolved)
+	require.False(t, repo.called)
+}

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -6,6 +6,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -1281,8 +1282,8 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 		return account
 	}
 
-	latest, err := s.accountRepo.GetByID(ctx, account.ID)
-	if err != nil || latest == nil {
+	latest := s.loadDBRecheckedOpenAIAccount(ctx, account.ID)
+	if latest == nil {
 		return nil
 	}
 	if !s.openAIAccountMatchesSchedulingGroup(latest, groupID) {
@@ -1291,7 +1292,9 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 	if !isOpenAICompatibleAccountEligibleForRequest(ctx, latest, platform, requestedModel, requireCompact, requiredCapability) {
 		return nil
 	}
-	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
+	if !parentHealthyForShadow(latest, func(parentID int64) *Account {
+		return s.loadDBRecheckedOpenAIAccount(ctx, parentID)
+	}) {
 		return nil
 	}
 	if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
@@ -1301,6 +1304,80 @@ func (s *OpenAIGatewayService) recheckSelectedOpenAIAccountFromDB(ctx context.Co
 		return nil
 	}
 	return latest
+}
+
+func (s *OpenAIGatewayService) loadDBRecheckedOpenAIAccount(ctx context.Context, accountID int64) *Account {
+	if s == nil || s.accountRepo == nil || accountID <= 0 {
+		return nil
+	}
+
+	now := time.Now()
+	if cached := s.openaiAccountDBRecheck.fresh(accountID, now); cached != nil {
+		return cached
+	}
+
+	key := strconv.FormatInt(accountID, 10)
+	value, _, _ := s.openaiAccountDBRecheck.sf.Do(key, func() (any, error) {
+		now := time.Now()
+		if cached := s.openaiAccountDBRecheck.fresh(accountID, now); cached != nil {
+			return cached, nil
+		}
+
+		timeout, freshTTL, staleTTL := s.openAIAccountDBRecheckDurations()
+		dbCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+
+		latest, err := s.accountRepo.GetByID(dbCtx, accountID)
+		if err == nil && latest != nil {
+			s.openaiAccountDBRecheck.store(latest, now, freshTTL, staleTTL)
+			return latest, nil
+		}
+		if errors.Is(err, ErrAccountNotFound) || (err == nil && latest == nil) {
+			s.openaiAccountDBRecheck.remove(accountID)
+			return (*Account)(nil), nil
+		}
+
+		stale := s.openaiAccountDBRecheck.stale(accountID, now)
+		if stale == nil {
+			slog.Warn("openai_account_db_recheck_failed_closed",
+				"account_id", accountID,
+				"error", err,
+			)
+			return (*Account)(nil), nil
+		}
+		slog.Warn("openai_account_db_recheck_stale_used",
+			"account_id", accountID,
+			"error", err,
+			"stale_window_seconds", int64(staleTTL/time.Second),
+		)
+		return stale, nil
+	})
+
+	account, _ := value.(*Account)
+	if account == nil {
+		return nil
+	}
+	cloned := *account
+	return &cloned
+}
+
+func (s *OpenAIGatewayService) openAIAccountDBRecheckDurations() (time.Duration, time.Duration, time.Duration) {
+	timeout := 750 * time.Millisecond
+	freshTTL := time.Second
+	staleTTL := 2 * time.Minute
+	if s != nil && s.cfg != nil {
+		cfg := s.cfg.Gateway.Scheduling
+		if cfg.DBRecheckTimeoutMS > 0 {
+			timeout = time.Duration(cfg.DBRecheckTimeoutMS) * time.Millisecond
+		}
+		if cfg.DBRecheckFreshTTLMS > 0 {
+			freshTTL = time.Duration(cfg.DBRecheckFreshTTLMS) * time.Millisecond
+		}
+		if cfg.DBRecheckStaleIfErrorSeconds > 0 {
+			staleTTL = time.Duration(cfg.DBRecheckStaleIfErrorSeconds) * time.Second
+		}
+	}
+	return timeout, freshTTL, staleTTL
 }
 
 func (s *OpenAIGatewayService) openAIAccountMatchesSchedulingGroup(account *Account, groupID *int64) bool {

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -431,6 +431,7 @@ type OpenAIGatewayService struct {
 
 	openaiWSFallbackUntil               sync.Map // key: int64(accountID), value: time.Time
 	openaiAccountRuntimeBlockUntil      sync.Map // key: int64(accountID), value: time.Time
+	openaiAccountDBRecheck              openAIAccountDBRecheckCache
 	openaiAccountRuntimeBlockLocks      sync.Map // key: int64(accountID), value: *sync.Mutex
 	openaiAccountRuntimeBlockGeneration sync.Map // key: int64(accountID), value: uint64
 	openaiAccountRuntimeBlockSequence   atomic.Uint64

--- a/backend/internal/service/scheduler_snapshot_service.go
+++ b/backend/internal/service/scheduler_snapshot_service.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/ctxkey"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
 )
 
@@ -282,10 +283,18 @@ func (s *SchedulerSnapshotService) GetAccount(ctx context.Context, accountID int
 
 // GetGroupByID 获取分组信息（供调度器使用）
 func (s *SchedulerSnapshotService) GetGroupByID(ctx context.Context, groupID int64) (*Group, error) {
+	if group, ok := ctx.Value(ctxkey.Group).(*Group); ok && IsGroupContextValid(group) && group.ID == groupID {
+		return group, nil
+	}
 	if s.groupRepo == nil {
 		return nil, nil
 	}
-	return s.groupRepo.GetByID(ctx, groupID)
+	if err := s.guardFallback(ctx); err != nil {
+		return nil, err
+	}
+	fallbackCtx, cancel := s.withFallbackTimeout(ctx)
+	defer cancel()
+	return s.groupRepo.GetByID(fallbackCtx, groupID)
 }
 
 // UpdateAccountInCache 立即更新 Redis 中单个账号的数据（用于模型限流后立即生效）

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -516,6 +516,13 @@ gateway:
     db_fallback_timeout_seconds: 0
     # 受控回源限流（实例级 QPS），0 表示不限制
     db_fallback_max_qps: 0
+    # Final account DB recheck timeout in milliseconds.
+    db_recheck_timeout_ms: 750
+    # Coalesce repeated successful account checks for this many milliseconds.
+    db_recheck_fresh_ttl_ms: 1000
+    # During a transient DB outage, reuse only an account successfully validated
+    # by this process within this bounded window.
+    db_recheck_stale_if_error_seconds: 120
     # outbox 轮询周期（秒）
     outbox_poll_interval_seconds: 1
     # outbox 滞后告警阈值（秒）


### PR DESCRIPTION
Bound final account DB rechecks with per-account singleflight and a short fresh cache. During transient database failures, only accounts recently validated by the same process may use a bounded stale window; missing, deleted, moved, and never-validated accounts fail closed.

Also reuses the authenticated group context before database fallback.

Tests cover concurrency, deletion/group movement, stale expiry, fail-closed behavior, and race safety.