### PR TITLE
fix(ws): enable first-turn read_upstream failover in passthrough mode

### DIFF
--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -1237,6 +1237,14 @@ func openAIWSPassthroughRelayClientClose(exit openaiwsv2.RelayExit, completedTur
 		return 0, "", false
 	}
 	if !exit.Graceful && exit.Stage == "read_upstream" {
+		// First-turn upstream dead connection: WriteFrame succeeded but ReadFrame
+		// immediately failed (EOF/broken pipe/reset), and no content was written
+		// downstream yet. Return empty close signal so the caller's failover logic
+		// (line 1184) can retry with another account. Only the first turn is safe
+		// to replay — later turns would duplicate already-delivered content.
+		if completedTurns == 0 && !exit.WroteDownstream {
+			return 0, "", false
+		}
 		return coderws.StatusInternalError, "upstream websocket proxy failed", true
 	}
 	return 0, "", false

--- a/backend/internal/service/openai_ws_v2_passthrough_first_read_failover_test.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_first_read_failover_test.go
@@ -1,0 +1,88 @@
+//go:build unit
+
+package service
+
+import (
+	"errors"
+	"io"
+	"testing"
+
+	openaiwsv2 "github.com/Wei-Shaw/sub2api/internal/service/openai_ws_v2"
+	coderws "github.com/coder/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenAIWSPassthroughRelayClientClose_FirstReadFailureWithoutDownstreamWrite(t *testing.T) {
+	exit := openaiwsv2.RelayExit{
+		Stage:           "read_upstream",
+		Err:             io.EOF,
+		Graceful:        false,
+		WroteDownstream: false,
+	}
+
+	code, reason, shouldClose := openAIWSPassthroughRelayClientClose(exit, 0)
+
+	require.Zero(t, code, "first-turn read_upstream failure without downstream write should return 0 to trigger failover")
+	require.Empty(t, reason)
+	require.False(t, shouldClose)
+}
+
+func TestOpenAIWSPassthroughRelayClientClose_FirstReadFailureAfterDownstreamWrite(t *testing.T) {
+	exit := openaiwsv2.RelayExit{
+		Stage:           "read_upstream",
+		Err:             io.EOF,
+		Graceful:        false,
+		WroteDownstream: true,
+	}
+
+	code, reason, shouldClose := openAIWSPassthroughRelayClientClose(exit, 0)
+
+	require.Equal(t, coderws.StatusInternalError, code)
+	require.Equal(t, "upstream websocket proxy failed", reason)
+	require.True(t, shouldClose)
+}
+
+func TestOpenAIWSPassthroughRelayClientClose_LaterTurnReadFailureWithoutDownstreamWrite(t *testing.T) {
+	exit := openaiwsv2.RelayExit{
+		Stage:           "read_upstream",
+		Err:             io.EOF,
+		Graceful:        false,
+		WroteDownstream: false,
+	}
+
+	code, reason, shouldClose := openAIWSPassthroughRelayClientClose(exit, 1)
+
+	require.Equal(t, coderws.StatusInternalError, code)
+	require.Equal(t, "upstream websocket proxy failed", reason)
+	require.True(t, shouldClose, "later turns cannot be replayed even without downstream write")
+}
+
+func TestOpenAIWSPassthroughRelayClientClose_GracefulReadUpstreamDoesNotTrigger1011(t *testing.T) {
+	exit := openaiwsv2.RelayExit{
+		Stage:           "read_upstream",
+		Err:             io.EOF,
+		Graceful:        true,
+		WroteDownstream: false,
+	}
+
+	code, reason, shouldClose := openAIWSPassthroughRelayClientClose(exit, 0)
+
+	require.Zero(t, code, "graceful read_upstream should not return 1011")
+	require.Empty(t, reason)
+	require.False(t, shouldClose)
+}
+
+func TestOpenAIWSPassthroughRelayClientClose_WriteUpstreamFailurePreservesFailover(t *testing.T) {
+	exit := openaiwsv2.RelayExit{
+		Stage:           "write_upstream",
+		Err:             errors.New("connection reset by peer"),
+		Graceful:        false,
+		WroteDownstream: false,
+	}
+
+	code, reason, shouldClose := openAIWSPassthroughRelayClientClose(exit, 0)
+
+	require.Zero(t, code, "write_upstream stage is not read_upstream so should not return 1011")
+	require.Empty(t, reason)
+	require.False(t, shouldClose)
+}


### PR DESCRIPTION
## Problem

When `ws_mode=passthrough` and the upstream connection pool reuses a dead connection (TCP FIN/RST already sent but not yet detected), the first `WriteFrame` succeeds (OS send buffer accepts the data), but the first `ReadFrame` immediately fails with EOF or broken pipe. 

Previously, this scenario returned `1011 upstream websocket proxy failed` directly to the client without any retry, even though the account itself is healthy (next connection works fine).

## Root Cause

`openAIWSPassthroughRelayClientClose` at line 1239-1241 unconditionally returned `1011` for all `read_upstream` stage failures, bypassing the existing failover logic at line 1184.

## Solution

When `completedTurns == 0 && !exit.WroteDownstream`, return empty close signal `(0, "", false)` to trigger the existing account failover mechanism. Later turns or cases where content was already written downstream still return `1011` immediately (not safe to replay).

## Testing

- **5 new test cases** covering first-turn/later-turn, with/without downstream write, graceful/non-graceful exits
- **All tests pass**, no regression in existing adapter behavior

Fixes #4880