### PR TITLE
fix(claude): 伪装的 Claude Code CLI 版本号升级到 2.1.220

### DIFF
--- a/backend/internal/pkg/claude/constants.go
+++ b/backend/internal/pkg/claude/constants.go
@@ -66,7 +66,7 @@ const DefaultCacheControlTTL = "5m"
 // CLICurrentVersion 是 sub2api 当前对外伪装的 Claude Code CLI 版本号（三段 semver）。
 // 用于 billing attribution block 中的 cc_version=X.Y.Z.{fp} 前缀以及 fingerprint 计算。
 // 必须与 DefaultHeaders["User-Agent"] 中的版本号严格一致；不一致会被 Anthropic 判第三方。
-const CLICurrentVersion = "2.1.161"
+const CLICurrentVersion = "2.1.220"
 
 // FullClaudeCodeMimicryBetas 返回最"像"真实 Claude Code CLI 的完整 beta 列表，
 // 用于 OAuth 账号伪装成 Claude Code 时使用。


### PR DESCRIPTION
## 问题

`CLICurrentVersion` 停留在 `2.1.161`，而 npm `@anthropic-ai/claude-code` 的 latest 已经是 `2.1.220`。

因为197版本的后门问题, 很多sub2都把最小版本设置到了197,  这样调用测试的会被拒提示

```
Your Claude Code version (2.1.161) is below the minimum required version (2.1.197).
```

<img width="916" height="1104" alt="image" src="https://github.com/user-attachments/assets/27e2c0c1-ebba-486f-8339-221d2769f437" />

## 改动

把 `CLICurrentVersion` 升到 `2.1.220`。
