### PR TITLE
fix(openai): support previous_response_id on REST responses

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -280,7 +280,18 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		return
 	}
 	reqLog = reqLog.With(zap.String("model", reqModel), zap.Bool("stream", reqStream))
-	previousResponseID := strings.TrimSpace(gjson.GetBytes(body, "previous_response_id").String())
+	previousResponseResult := gjson.GetBytes(body, "previous_response_id")
+	previousResponseID := ""
+	if previousResponseResult.Exists() {
+		switch previousResponseResult.Type {
+		case gjson.Null:
+		case gjson.String:
+			previousResponseID = strings.TrimSpace(previousResponseResult.String())
+		default:
+			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a string or null")
+			return
+		}
+	}
 	if previousResponseID != "" {
 		previousResponseIDKind := service.ClassifyOpenAIPreviousResponseIDKind(previousResponseID)
 		reqLog = reqLog.With(
@@ -295,11 +306,6 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 			h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id must be a response.id (resp_*), not a message id")
 			return
 		}
-		reqLog.Warn("openai.request_validation_failed",
-			zap.String("reason", "previous_response_id_requires_wsv2"),
-		)
-		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "previous_response_id is only supported on Responses WebSocket v2")
-		return
 	}
 
 	setOpsRequestContext(c, reqModel, reqStream)
@@ -348,6 +354,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// Get subscription info (may be nil)
 	subscription, _ := middleware2.GetSubscriptionFromContext(c)
 	requestPlatform := openAICompatibleRequestPlatform(c.Request.Context(), apiKey)
+	strictHTTPResponseContinuation := previousResponseID != "" && requestPlatform == service.PlatformOpenAI
 
 	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
 	routingStart := time.Now()
@@ -393,6 +400,9 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 	// 复用前置权限与并发阶段在未修改 body 上确认的显式生图意图，避免大 tools 请求重复扫描。
 	// 该判断已排除 Codex 被动 image_gen namespace，避免 CC-only 账号被误过滤（#4476）。
 	requiredCapability := openAIResponsesRequiredCapability(imageIntent, requestPlatform)
+	if strictHTTPResponseContinuation {
+		requiredCapability = service.OpenAIEndpointCapabilityResponses
+	}
 
 	for {
 		// Streaming Forward intentionally detaches the upstream request so usage can
@@ -403,20 +413,37 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		}
 		// Select account supporting the requested model
 		reqLog.Debug("openai.account_selecting", zap.Int("excluded_account_count", len(failedAccountIDs)))
-		selection, scheduleDecision, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
-			c.Request.Context(),
-			apiKey.GroupID,
-			previousResponseID,
-			sessionHash,
-			reqModel,
-			failedAccountIDs,
-			service.OpenAIUpstreamTransportAny,
-			requiredCapability,
-			requireCompact,
-			false,
-			!imageIntent,
-			requestPlatform,
+		var (
+			selection        *service.AccountSelectionResult
+			scheduleDecision service.OpenAIAccountScheduleDecision
+			err              error
 		)
+		if strictHTTPResponseContinuation {
+			selection, scheduleDecision, err = h.gatewayService.SelectAccountForHTTPResponseContinuation(
+				c.Request.Context(),
+				apiKey.GroupID,
+				previousResponseID,
+				sessionHash,
+				reqModel,
+				requiredCapability,
+				requireCompact,
+			)
+		} else {
+			selection, scheduleDecision, err = h.gatewayService.SelectAccountWithSchedulerForCapability(
+				c.Request.Context(),
+				apiKey.GroupID,
+				previousResponseID,
+				sessionHash,
+				reqModel,
+				failedAccountIDs,
+				service.OpenAIUpstreamTransportAny,
+				requiredCapability,
+				requireCompact,
+				false,
+				!imageIntent,
+				requestPlatform,
+			)
+		}
 		if err != nil {
 			if failoverClientGone(c) {
 				reqLog.Info("openai.account_select_aborted_client_disconnected", zap.Error(err))
@@ -426,6 +453,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				zap.Error(openAICompatibleSelectionErrorForLog(err, requestPlatform)),
 				zap.Int("excluded_account_count", len(failedAccountIDs)),
 			)
+			if errors.Is(err, service.ErrOpenAIHTTPPreviousResponseNotFound) {
+				h.openAIPreviousResponseNotFound(c)
+				return
+			}
 			if len(failedAccountIDs) == 0 {
 				if errors.Is(err, service.ErrNoAvailableCompactAccounts) {
 					markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
@@ -452,6 +483,13 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 				markOpsRoutingCapacityLimited(c)
 			}
 			h.handleStreamingAwareError(c, cls.Status, cls.ErrType, cls.Message, streamStarted)
+			return
+		}
+		if strictHTTPResponseContinuation && !scheduleDecision.StickyPreviousHit {
+			if selection.ReleaseFunc != nil {
+				selection.ReleaseFunc()
+			}
+			h.openAIPreviousResponseNotFound(c)
 			return
 		}
 		if previousResponseID != "" && selection != nil && selection.Account != nil {
@@ -558,6 +596,10 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 							}
 							continue
 						}
+					}
+					if strictHTTPResponseContinuation {
+						h.handleFailoverExhausted(c, failoverErr, streamStarted)
+						return
 					}
 					h.gatewayService.RecordOpenAIAccountSwitch()
 					failedAccountIDs[account.ID] = struct{}{}
@@ -1258,17 +1300,17 @@ func (h *OpenAIGatewayHandler) validateFunctionCallOutputRequest(c *gin.Context,
 		return true
 	}
 
-	previousResponseID := gjson.GetBytes(body, "previous_response_id").String()
-	if strings.TrimSpace(previousResponseID) != "" || validation.HasToolCallContext {
-		return true
-	}
-
 	if validation.HasFunctionCallOutputMissingCallID {
 		reqLog.Warn("openai.request_validation_failed",
 			zap.String("reason", "function_call_output_missing_call_id"),
 		)
-		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "function_call_output requires call_id on HTTP requests; continuation via previous_response_id is only supported on Responses WebSocket v2")
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "function_call_output requires a non-empty call_id")
 		return false
+	}
+
+	previousResponseID := gjson.GetBytes(body, "previous_response_id").String()
+	if strings.TrimSpace(previousResponseID) != "" || validation.HasToolCallContext {
+		return true
 	}
 	if validation.HasItemReferenceForAllCallIDs {
 		return true
@@ -1277,7 +1319,7 @@ func (h *OpenAIGatewayHandler) validateFunctionCallOutputRequest(c *gin.Context,
 	reqLog.Warn("openai.request_validation_failed",
 		zap.String("reason", "function_call_output_missing_item_reference"),
 	)
-	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "function_call_output requires item_reference ids matching each call_id on HTTP requests; continuation via previous_response_id is only supported on Responses WebSocket v2")
+	h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "function_call_output requires item_reference ids matching each call_id when previous_response_id is not provided")
 	return false
 }
 
@@ -2485,6 +2527,24 @@ func (h *OpenAIGatewayHandler) errorResponse(c *gin.Context, status int, errType
 	c.JSON(status, gin.H{
 		"error": gin.H{
 			"type":    errType,
+			"message": message,
+		},
+	})
+}
+
+func (h *OpenAIGatewayHandler) openAIPreviousResponseNotFound(c *gin.Context) {
+	const message = "Previous response not found."
+	if service.StopOpenAICompactSSEKeepaliveCommitted(c) {
+		service.MarkOpsStreamError(c, "invalid_request_error", message, http.StatusBadRequest)
+		if writeResponsesFailedSSE(c, "invalid_request_error", message) {
+			return
+		}
+	}
+	c.JSON(http.StatusBadRequest, gin.H{
+		"error": gin.H{
+			"type":    "invalid_request_error",
+			"code":    "previous_response_not_found",
+			"param":   "previous_response_id",
 			"message": message,
 		},
 	})

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
+	"go.uber.org/zap"
 )
 
 func TestOpenAIHandleStreamingAwareError_JSONEscaping(t *testing.T) {
@@ -830,62 +831,72 @@ func TestOpenAIResponses_RejectsMessageIDAsPreviousResponseID(t *testing.T) {
 	require.Contains(t, w.Body.String(), "previous_response_id must be a response.id")
 }
 
-func TestOpenAIResponses_RejectsHTTPContinuationPreviousResponseID(t *testing.T) {
+func TestOpenAIResponses_RejectsNonStringPreviousResponseID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(
-		`{"model":"gpt-5.1","stream":false,"previous_response_id":"resp_123456","input":[{"type":"input_text","text":"hello"}]}`,
-	))
-	c.Request.Header.Set("Content-Type", "application/json")
+	for _, value := range []string{`123`, `true`, `{}`, `[]`} {
+		t.Run(value, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(
+				`{"model":"gpt-5.1","stream":false,"previous_response_id":`+value+`,"input":"hello"}`,
+			))
+			c.Request.Header.Set("Content-Type", "application/json")
 
-	groupID := int64(2)
-	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
-		ID:      101,
-		GroupID: &groupID,
-		User:    &service.User{ID: 1},
-	})
-	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{
-		UserID:      1,
-		Concurrency: 1,
-	})
+			groupID := int64(2)
+			c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
+				ID:      101,
+				GroupID: &groupID,
+				User:    &service.User{ID: 1},
+			})
+			c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{
+				UserID:      1,
+				Concurrency: 1,
+			})
 
-	h := newOpenAIHandlerForPreviousResponseIDValidation(t, nil)
-	h.Responses(c)
+			newOpenAIHandlerForPreviousResponseIDValidation(t, nil).Responses(c)
 
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "Responses WebSocket v2")
-	require.Contains(t, w.Body.String(), "previous_response_id")
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "previous_response_id must be a string or null")
+		})
+	}
 }
 
-func TestOpenAIResponses_FunctionCallOutputHTTPGuidanceDoesNotSuggestPreviousResponseReuse(t *testing.T) {
+func TestOpenAIResponses_FunctionCallOutputWithPreviousResponseIDRequiresCallID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(
-		`{"model":"gpt-5.1","stream":false,"input":[{"type":"function_call_output","output":"{}"}]}`,
-	))
-	c.Request.Header.Set("Content-Type", "application/json")
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "missing call_id is rejected",
+			body: `{"model":"gpt-5.1","previous_response_id":"resp_123456","input":[{"type":"function_call_output","output":"{}"}]}`,
+			want: false,
+		},
+		{
+			name: "valid call_id is accepted",
+			body: `{"model":"gpt-5.1","previous_response_id":"resp_123456","input":[{"type":"function_call_output","call_id":"call_123","output":"{}"}]}`,
+			want: true,
+		},
+	}
 
-	groupID := int64(2)
-	c.Set(string(middleware.ContextKeyAPIKey), &service.APIKey{
-		ID:      101,
-		GroupID: &groupID,
-		User:    &service.User{ID: 1},
-	})
-	c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{
-		UserID:      1,
-		Concurrency: 1,
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			accepted := (&OpenAIGatewayHandler{}).validateFunctionCallOutputRequest(c, []byte(tt.body), zap.NewNop())
 
-	h := newOpenAIHandlerForPreviousResponseIDValidation(t, nil)
-	h.Responses(c)
-
-	require.Equal(t, http.StatusBadRequest, w.Code)
-	require.Contains(t, w.Body.String(), "Responses WebSocket v2")
-	require.NotContains(t, w.Body.String(), "reuse previous_response_id")
+			require.Equal(t, tt.want, accepted)
+			if tt.want {
+				require.False(t, c.Writer.Written())
+				return
+			}
+			require.Equal(t, http.StatusBadRequest, w.Code)
+			require.Contains(t, w.Body.String(), "call_id")
+		})
+	}
 }
 
 func TestOpenAIResponsesWebSocket_SetsClientTransportWSWhenUpgradeValid(t *testing.T) {
@@ -1562,6 +1573,14 @@ type openAIHTTPPassthroughFailoverUpstream struct {
 	accountIDs []int64
 }
 
+type openAIHTTPContinuationFailoverUpstream struct {
+	service.HTTPUpstream
+	mu            sync.Mutex
+	accountIDs    []int64
+	bodies        [][]byte
+	failureStatus int
+}
+
 func (u *openAIHTTPPassthroughFailoverUpstream) Do(_ *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
 	u.mu.Lock()
 	u.accountIDs = append(u.accountIDs, accountID)
@@ -1577,6 +1596,50 @@ func (u *openAIHTTPPassthroughFailoverUpstream) calls() []int64 {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	return append([]int64(nil), u.accountIDs...)
+}
+
+func (u *openAIHTTPContinuationFailoverUpstream) Do(req *http.Request, _ string, accountID int64, _ int) (*http.Response, error) {
+	var body []byte
+	if req != nil && req.Body != nil {
+		body, _ = io.ReadAll(req.Body)
+	}
+
+	u.mu.Lock()
+	u.accountIDs = append(u.accountIDs, accountID)
+	u.bodies = append(u.bodies, append([]byte(nil), body...))
+	callCount := len(u.accountIDs)
+	u.mu.Unlock()
+
+	if callCount == 1 {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"id":"resp_http_bound","object":"response","status":"completed","model":"gpt-5.2","output":[],"usage":{"input_tokens":1,"output_tokens":1,"input_tokens_details":{"cached_tokens":0}}}`,
+			)),
+		}, nil
+	}
+
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	if u.failureStatus == http.StatusTooManyRequests {
+		header.Set("Retry-After", "7")
+	}
+	return &http.Response{
+		StatusCode: u.failureStatus,
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"upstream_error","message":"temporary upstream failure"}}`)),
+	}, nil
+}
+
+func (u *openAIHTTPContinuationFailoverUpstream) snapshot() ([]int64, [][]byte) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	accountIDs := append([]int64(nil), u.accountIDs...)
+	bodies := make([][]byte, len(u.bodies))
+	for i := range u.bodies {
+		bodies[i] = append([]byte(nil), u.bodies[i]...)
+	}
+	return accountIDs, bodies
 }
 
 func (s *openAIWSFailoverHandlerAccountRepoStub) ListSchedulableByPlatform(ctx context.Context, platform string) ([]service.Account, error) {
@@ -1739,6 +1802,113 @@ func TestOpenAIResponses_APIKeyPassthroughPool5xxRetriesThenExhaustsMaxSwitches(
 	require.Equal(t, http.StatusBadGateway, rec.Code)
 	require.Equal(t, "upstream_error", gjson.GetBytes(rec.Body.Bytes(), "error.type").String())
 	require.Equal(t, "Upstream service temporarily unavailable", gjson.GetBytes(rec.Body.Bytes(), "error.message").String())
+}
+
+func TestOpenAIResponses_HTTPContinuationDoesNotFailOverToAnotherAccount(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name   string
+		status int
+	}{
+		{name: "429", status: http.StatusTooManyRequests},
+		{name: "5xx", status: http.StatusBadGateway},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			groupID := int64(4204)
+			accounts := []service.Account{
+				{
+					ID: 9920, Name: "bound-api-key", Platform: service.PlatformOpenAI,
+					Type: service.AccountTypeAPIKey, Status: service.StatusActive, Schedulable: true, Priority: 1,
+					Credentials: map[string]any{"api_key": "sk-bound", "base_url": "https://api.example.test"},
+					Extra:       map[string]any{"openai_responses_supported": true},
+				},
+				{
+					ID: 9921, Name: "fallback-api-key", Platform: service.PlatformOpenAI,
+					Type: service.AccountTypeAPIKey, Status: service.StatusActive, Schedulable: true, Priority: 2,
+					Credentials: map[string]any{"api_key": "sk-fallback", "base_url": "https://api.example.test"},
+					Extra:       map[string]any{"openai_responses_supported": true},
+				},
+			}
+			cfg := &config.Config{RunMode: config.RunModeSimple}
+			cfg.Default.RateMultiplier = 1
+			cfg.Security.URLAllowlist.Enabled = false
+			cfg.Gateway.MaxAccountSwitches = 3
+
+			accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: accounts}
+			upstream := &openAIHTTPContinuationFailoverUpstream{failureStatus: tt.status}
+			billingCacheSvc := service.NewBillingCacheService(nil, nil, nil, nil, nil, nil, cfg, nil)
+			t.Cleanup(billingCacheSvc.Stop)
+			gatewaySvc := service.NewOpenAIGatewayService(
+				accountRepo,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				cfg,
+				nil,
+				nil,
+				service.NewBillingService(cfg, nil),
+				nil,
+				billingCacheSvc,
+				upstream,
+				&service.DeferredService{},
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			h := NewOpenAIGatewayHandler(
+				gatewaySvc,
+				service.NewConcurrencyService(nil),
+				billingCacheSvc,
+				service.NewAPIKeyService(nil, nil, nil, nil, nil, nil, cfg),
+				nil,
+				nil,
+				nil,
+				nil,
+				cfg,
+			)
+
+			apiKey := &service.APIKey{
+				ID: 1804, GroupID: &groupID,
+				User:  &service.User{ID: 1704, Status: service.StatusActive},
+				Group: &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+			}
+			request := func(body string) *httptest.ResponseRecorder {
+				rec := httptest.NewRecorder()
+				c, _ := gin.CreateTestContext(rec)
+				c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", strings.NewReader(body))
+				c.Request.Header.Set("Content-Type", "application/json")
+				c.Set(string(middleware.ContextKeyAPIKey), apiKey)
+				c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: 1704, Concurrency: 0})
+				h.Responses(c)
+				return rec
+			}
+
+			first := request(`{"model":"gpt-5.2","input":"hello","stream":false}`)
+			require.Equal(t, http.StatusOK, first.Code)
+			require.Equal(t, "resp_http_bound", gjson.GetBytes(first.Body.Bytes(), "id").String())
+
+			continuation := request(`{"model":"gpt-5.2","previous_response_id":"resp_http_bound","input":"continue","stream":false}`)
+			require.Equal(t, tt.status, continuation.Code)
+			if tt.status == http.StatusTooManyRequests {
+				require.Equal(t, "7", continuation.Header().Get("Retry-After"))
+			}
+
+			accountIDs, bodies := upstream.snapshot()
+			require.Equal(t, []int64{9920, 9920}, accountIDs, "the bound continuation must not probe account B")
+			require.Len(t, bodies, 2)
+			require.Equal(t, "resp_http_bound", gjson.GetBytes(bodies[1], "previous_response_id").String())
+		})
+	}
 }
 
 func TestOpenAIResponsesWebSocket_FailoverOnUpstreamUsageLimitEvent(t *testing.T) {

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -2016,6 +2016,48 @@ func (s *OpenAIGatewayService) SelectAccountWithSchedulerForCapability(
 	return s.selectAccountWithScheduler(ctx, groupID, previousResponseID, sessionHash, requestedModel, excludedIDs, requiredTransport, requiredCapability, "", requireCompact, platform, previousResponseCanMove, useUpstreamTokenCost)
 }
 
+// SelectAccountForHTTPResponseContinuation hard-pins a REST continuation to
+// the account that emitted the prior response. A missing binding is terminal:
+// probing another account would either mask the real error or send a
+// connection-local OAuth response ID to an unrelated upstream session.
+func (s *OpenAIGatewayService) SelectAccountForHTTPResponseContinuation(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	sessionHash string,
+	requestedModel string,
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+) (*AccountSelectionResult, OpenAIAccountScheduleDecision, error) {
+	decision := OpenAIAccountScheduleDecision{Layer: openAIAccountScheduleLayerPreviousResponse}
+	startedAt := time.Now()
+
+	ctx = s.withOpenAIQuotaAutoPauseContext(ctx)
+	selection, err := s.selectAccountByPreviousResponseIDForHTTPContinuation(
+		ctx,
+		groupID,
+		previousResponseID,
+		requestedModel,
+		requiredCapability,
+		requireCompact,
+	)
+	decision.LatencyMs = time.Since(startedAt).Milliseconds()
+	if err != nil {
+		return nil, decision, err
+	}
+	if selection == nil || selection.Account == nil {
+		return nil, decision, ErrOpenAIHTTPPreviousResponseNotFound
+	}
+
+	decision.StickyPreviousHit = true
+	decision.SelectedAccountID = selection.Account.ID
+	decision.SelectedAccountType = selection.Account.Type
+	if strings.TrimSpace(sessionHash) != "" {
+		_ = s.BindStickySession(ctx, groupID, sessionHash, selection.Account.ID)
+	}
+	return selection, decision, nil
+}
+
 func (s *OpenAIGatewayService) SelectAccountWithSchedulerForImages(
 	ctx context.Context,
 	groupID *int64,

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -445,6 +445,142 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabledUsesLega
 	require.False(t, decision.StickyPreviousHit)
 }
 
+func TestOpenAIGatewayService_SelectAccountForHTTPResponseContinuation_PinsNativeAPIKey(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(10107)
+	accounts := []Account{
+		{
+			ID:          36101,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    5,
+			Extra:       map[string]any{"openai_responses_supported": true},
+		},
+		{
+			ID:          36102,
+			Platform:    PlatformOpenAI,
+			Type:        AccountTypeAPIKey,
+			Status:      StatusActive,
+			Schedulable: true,
+			Concurrency: 1,
+			Priority:    0,
+			Extra:       map[string]any{"openai_responses_supported": true},
+		},
+	}
+	cache := &schedulerTestGatewayCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: accounts},
+		cache:              cache,
+		cfg:                &config.Config{},
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+
+	store := svc.getOpenAIWSStateStore()
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_http_native_001", 36101, time.Hour))
+
+	selection, decision, err := svc.SelectAccountForHTTPResponseContinuation(
+		ctx,
+		&groupID,
+		"resp_http_native_001",
+		"",
+		"gpt-5.1",
+		OpenAIEndpointCapabilityResponses,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.NotNil(t, selection.Account)
+	require.Equal(t, int64(36101), selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerPreviousResponse, decision.Layer)
+	require.True(t, decision.StickyPreviousHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountForHTTPResponseContinuation_OAuthRequiresBoundConnection(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(10108)
+	account := Account{
+		ID:          36201,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Extra: map[string]any{
+			"responses_websockets_v2_enabled": true,
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cache := &schedulerTestGatewayCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo:        schedulerTestOpenAIAccountRepo{accounts: []Account{account}},
+		cache:              cache,
+		cfg:                cfg,
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		openaiWSResolver:   NewOpenAIWSProtocolResolver(cfg),
+	}
+
+	store := svc.getOpenAIWSStateStore()
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_http_oauth_001", account.ID, time.Hour))
+
+	selection, _, err := svc.SelectAccountForHTTPResponseContinuation(
+		ctx,
+		&groupID,
+		"resp_http_oauth_001",
+		"",
+		"gpt-5.1",
+		OpenAIEndpointCapabilityResponses,
+		false,
+	)
+	require.ErrorIs(t, err, ErrOpenAIHTTPPreviousResponseNotFound)
+	require.Nil(t, selection)
+
+	store.BindResponseConn("resp_http_oauth_001", "conn_http_oauth_001", time.Hour)
+	selection, decision, err := svc.SelectAccountForHTTPResponseContinuation(
+		ctx,
+		&groupID,
+		"resp_http_oauth_001",
+		"",
+		"gpt-5.1",
+		OpenAIEndpointCapabilityResponses,
+		false,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, account.ID, selection.Account.ID)
+	require.True(t, decision.StickyPreviousHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountForHTTPResponseContinuation_UnknownIDIsTerminal(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}, cache: &schedulerTestGatewayCache{}}
+	groupID := int64(10109)
+
+	selection, _, err := svc.SelectAccountForHTTPResponseContinuation(
+		context.Background(),
+		&groupID,
+		"resp_unknown_001",
+		"",
+		"gpt-5.1",
+		OpenAIEndpointCapabilityResponses,
+		false,
+	)
+	require.ErrorIs(t, err, ErrOpenAIHTTPPreviousResponseNotFound)
+	require.Nil(t, selection)
+}
+
 func TestOpenAIGatewayService_SelectAccountWithScheduler_DefaultDisabled_RequiredWSV2_SkipsHTTPOnlyAccount(t *testing.T) {
 	resetOpenAIAdvancedSchedulerSettingCacheForTest()
 

--- a/backend/internal/service/openai_client_transport.go
+++ b/backend/internal/service/openai_client_transport.go
@@ -63,9 +63,22 @@ func normalizeOpenAIClientTransport(transport OpenAIClientTransport) OpenAIClien
 func resolveOpenAIWSDecisionByClientTransport(
 	decision OpenAIWSProtocolDecision,
 	clientTransport OpenAIClientTransport,
+	account *Account,
 ) OpenAIWSProtocolDecision {
 	if clientTransport == OpenAIClientTransportHTTP {
+		if shouldBridgeOpenAIResponsesHTTPToWSV2(decision, account) {
+			decision.Reason = "http_responses_facade_" + decision.Reason
+			return decision
+		}
 		return openAIWSHTTPDecision("client_protocol_http")
 	}
 	return decision
+}
+
+func shouldBridgeOpenAIResponsesHTTPToWSV2(decision OpenAIWSProtocolDecision, account *Account) bool {
+	return decision.Transport == OpenAIUpstreamTransportResponsesWebsocketV2 &&
+		account != nil &&
+		account.IsOpenAIOAuth() &&
+		!account.IsOpenAIPersonalAccessToken() &&
+		!account.IsOpenAIAgentIdentity()
 }

--- a/backend/internal/service/openai_client_transport_test.go
+++ b/backend/internal/service/openai_client_transport_test.go
@@ -89,19 +89,29 @@ func TestOpenAIClientTransport_NilAndUnknownInput(t *testing.T) {
 	require.False(t, exists)
 }
 
-func TestResolveOpenAIWSDecisionByClientTransport(t *testing.T) {
+func TestResolveOpenAIWSDecisionByClientTransport_HTTP(t *testing.T) {
 	base := OpenAIWSProtocolDecision{
 		Transport: OpenAIUpstreamTransportResponsesWebsocketV2,
 		Reason:    "ws_v2_enabled",
 	}
 
-	httpDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportHTTP)
-	require.Equal(t, OpenAIUpstreamTransportHTTPSSE, httpDecision.Transport)
-	require.Equal(t, "client_protocol_http", httpDecision.Reason)
+	apiKeyDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportHTTP, &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeAPIKey,
+	})
+	require.Equal(t, OpenAIUpstreamTransportHTTPSSE, apiKeyDecision.Transport)
+	require.Equal(t, "client_protocol_http", apiKeyDecision.Reason)
 
-	wsDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportWS)
+	oauthDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportHTTP, &Account{
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+	})
+	require.Equal(t, OpenAIUpstreamTransportResponsesWebsocketV2, oauthDecision.Transport)
+	require.Equal(t, "http_responses_facade_ws_v2_enabled", oauthDecision.Reason)
+
+	wsDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportWS, nil)
 	require.Equal(t, base, wsDecision)
 
-	unknownDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportUnknown)
+	unknownDecision := resolveOpenAIWSDecisionByClientTransport(base, OpenAIClientTransportUnknown, nil)
 	require.Equal(t, base, unknownDecision)
 }

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -59,8 +59,12 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 	}
 	wsDecision := s.getOpenAIWSProtocolResolver().Resolve(account)
-	// 仅允许 WS 入站请求走 WS 上游，避免出现 HTTP -> WS 协议混用。
-	wsDecision = resolveOpenAIWSDecisionByClientTransport(wsDecision, GetOpenAIClientTransport(c))
+	clientTransport := GetOpenAIClientTransport(c)
+	httpResponsesWSBridge := clientTransport == OpenAIClientTransportHTTP && shouldBridgeOpenAIResponsesHTTPToWSV2(wsDecision, account)
+	// Native Responses API-key accounts remain on HTTP. Standard OAuth accounts
+	// with WSv2 enabled use the existing WS forwarder as a REST JSON/SSE facade so
+	// their store=false response IDs remain attached to a reusable connection.
+	wsDecision = resolveOpenAIWSDecisionByClientTransport(wsDecision, clientTransport, account)
 	passthroughEnabled := account.IsOpenAIPassthroughEnabled()
 	if shouldFlattenOpenAIResponsesNamespaces(account, wsDecision.Transport, passthroughEnabled) {
 		body, err = flattenOpenAIResponsesNamespaces(c, body)
@@ -87,6 +91,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 	requestView := newOpenAIRequestView(body)
 	reqModel, reqStream, promptCacheKey := requestView.Model, requestView.Stream, requestView.PromptCacheKey
 	originalModel := reqModel
+	httpResponseContinuation := clientTransport == OpenAIClientTransportHTTP && requestView.PreviousResponseID != ""
 
 	if account.Platform == PlatformGrok {
 		return s.forwardGrokResponses(ctx, c, account, body, originalModel, reqStream, startTime)
@@ -145,7 +150,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		return nil, errors.New("openai ws v1 is temporarily unsupported; use ws v2")
 	}
-	if passthroughEnabled {
+	if passthroughEnabled && !httpResponsesWSBridge {
 		attemptImageIntentInvalidated := false
 		if isCodexCLI && codexImageGenerationExplicitToolPolicy == codexImageGenerationExplicitToolPolicyStrip {
 			strippedBody, changed, stripErr := stripOpenAIImageGenerationToolsFromRawPayload(body)
@@ -454,7 +459,8 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			}
 		}
 	}
-	if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 && gjson.GetBytes(body, "previous_response_id").Exists() {
+	if previousResponse := gjson.GetBytes(body, "previous_response_id"); previousResponse.Exists() &&
+		(previousResponse.Type != gjson.String || strings.TrimSpace(previousResponse.String()) == "") {
 		markPatchDelete("previous_response_id")
 	}
 	if openAIRequestBodyMayContainEmptyBase64InputImage(body) {
@@ -570,6 +576,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			if wsPrevResponseRecoveryTried {
 				return false
 			}
+			if httpResponseContinuation {
+				logOpenAIWSModeInfo(
+					"reconnect_prev_response_recovery_skip account_id=%d attempt=%d reason=http_rest_continuation",
+					account.ID,
+					attempt,
+				)
+				return false
+			}
 			previousResponseID := openAIWSPayloadString(wsReqBody, "previous_response_id")
 			if previousResponseID == "" {
 				logOpenAIWSModeInfo(
@@ -600,6 +614,14 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 		}
 		recoverInvalidEncryptedContent := func(attempt int) bool {
 			if wsInvalidEncryptedContentRecoveryTried {
+				return false
+			}
+			if httpResponseContinuation {
+				logOpenAIWSModeInfo(
+					"reconnect_invalid_encrypted_content_recovery_skip account_id=%d attempt=%d reason=http_rest_continuation",
+					account.ID,
+					attempt,
+				)
 				return false
 			}
 			removedReasoningItems := trimOpenAIEncryptedReasoningItems(wsReqBody)

--- a/backend/internal/service/openai_gateway_service.go
+++ b/backend/internal/service/openai_gateway_service.go
@@ -846,12 +846,17 @@ func (s *OpenAIGatewayService) writeOpenAIWSFallbackErrorResponse(c *gin.Context
 			Message:            upstreamMessage,
 		})
 	}
-	c.JSON(statusCode, gin.H{
-		"error": gin.H{
-			"type":    errType,
-			"message": clientMessage,
-		},
-	})
+	errorPayload := gin.H{
+		"type":    errType,
+		"message": clientMessage,
+	}
+	var fallbackErr *openAIWSFallbackError
+	if errors.As(wsErr, &fallbackErr) && fallbackErr != nil &&
+		strings.TrimPrefix(strings.TrimSpace(fallbackErr.Reason), "prewarm_") == "previous_response_not_found" {
+		errorPayload["code"] = "previous_response_not_found"
+		errorPayload["param"] = "previous_response_id"
+	}
+	c.JSON(statusCode, gin.H{"error": errorPayload})
 	return true
 }
 

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -14,6 +14,10 @@ import (
 	"github.com/tidwall/sjson"
 )
 
+// ErrOpenAIHTTPPreviousResponseNotFound reports a REST continuation whose
+// response ID cannot be resolved to its original upstream account or session.
+var ErrOpenAIHTTPPreviousResponseNotFound = errors.New("openai previous response binding not found")
+
 func (s *OpenAIGatewayService) isOpenAIWSGeneratePrewarmEnabled() bool {
 	return s != nil && s.cfg != nil && s.cfg.Gateway.OpenAIWS.PrewarmGenerateEnabled
 }
@@ -396,10 +400,34 @@ func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 	requiredCapability OpenAIEndpointCapability,
 	requireCompact bool,
 ) (*AccountSelectionResult, error) {
+	return s.selectAccountByPreviousResponseIDForMode(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact, false)
+}
+
+func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForHTTPContinuation(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	requestedModel string,
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+) (*AccountSelectionResult, error) {
+	return s.selectAccountByPreviousResponseIDForMode(ctx, groupID, previousResponseID, requestedModel, nil, requiredCapability, requireCompact, true)
+}
+
+func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForMode(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+	httpContinuation bool,
+) (*AccountSelectionResult, error) {
 	if s == nil {
 		return nil, nil
 	}
-	accountID, account, responseID, store := s.resolveAccountByPreviousResponseIDForCapability(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact)
+	accountID, account, responseID, store := s.resolveAccountByPreviousResponseIDForMode(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact, httpContinuation)
 	if accountID <= 0 || account == nil || store == nil {
 		return nil, nil
 	}
@@ -456,6 +484,19 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	requiredCapability OpenAIEndpointCapability,
 	requireCompact bool,
 ) (int64, *Account, string, OpenAIWSStateStore) {
+	return s.resolveAccountByPreviousResponseIDForMode(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact, false)
+}
+
+func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForMode(
+	ctx context.Context,
+	groupID *int64,
+	previousResponseID string,
+	requestedModel string,
+	excludedIDs map[int64]struct{},
+	requiredCapability OpenAIEndpointCapability,
+	requireCompact bool,
+	httpContinuation bool,
+) (int64, *Account, string, OpenAIWSStateStore) {
 	if s == nil {
 		return 0, nil, "", nil
 	}
@@ -483,10 +524,13 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil
 	}
-	// 非 WSv2 场景（如 force_http/全局关闭）不应使用 previous_response_id 粘连，
-	// 以保持“回滚到 HTTP”后的历史行为一致性。
-	if s.getOpenAIWSProtocolResolver().Resolve(account).Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
+	if !s.openAIPreviousResponseAccountSupportsMode(account, httpContinuation) {
 		return 0, nil, "", nil
+	}
+	if httpContinuation && account.IsOpenAIOAuth() {
+		if _, ok := store.GetResponseConn(responseID); !ok {
+			return 0, nil, "", nil
+		}
 	}
 	if shouldClearStickySession(account, requestedModel) || !account.IsOpenAI() || !account.IsSchedulable() {
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
@@ -529,6 +573,9 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		if !latest.SupportsOpenAIEndpointCapability(requiredCapability) {
 			return 0, nil, "", nil
 		}
+		if !s.openAIPreviousResponseAccountSupportsMode(latest, httpContinuation) {
+			return 0, nil, "", nil
+		}
 		if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, latest); paused {
 			return 0, nil, "", nil
 		}
@@ -543,6 +590,23 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		return 0, nil, "", nil
 	}
 	return accountID, account, responseID, store
+}
+
+func (s *OpenAIGatewayService) openAIPreviousResponseAccountSupportsMode(account *Account, httpContinuation bool) bool {
+	if account == nil {
+		return false
+	}
+	wsV2 := s.getOpenAIWSProtocolResolver().Resolve(account).Transport == OpenAIUpstreamTransportResponsesWebsocketV2
+	if !httpContinuation {
+		return wsV2
+	}
+	if account.IsOpenAIApiKey() {
+		return account.SupportsOpenAIEndpointCapability(OpenAIEndpointCapabilityResponses)
+	}
+	return account.IsOpenAIOAuth() &&
+		!account.IsOpenAIPersonalAccessToken() &&
+		!account.IsOpenAIAgentIdentity() &&
+		wsV2
 }
 
 func classifyOpenAIWSAcquireError(err error) string {

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -128,6 +128,17 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		}
 	}
 	storeDisabled := s.isOpenAIWSStoreDisabledInRequest(reqBody, account)
+	httpOAuthFacade := GetOpenAIClientTransport(c) == OpenAIClientTransportHTTP &&
+		account.IsOpenAIOAuth() &&
+		storeDisabled
+	strictHTTPContinuation := httpOAuthFacade &&
+		previousResponseID != ""
+	if strictHTTPContinuation && preferredConnID == "" {
+		return nil, wrapOpenAIWSFallback(
+			"previous_response_not_found",
+			errors.New("the connection for the previous response is unavailable"),
+		)
+	}
 	if stateStore != nil && storeDisabled && previousResponseID == "" && sessionHash != "" {
 		if connID, ok := stateStore.GetSessionConn(groupID, sessionHash); ok {
 			preferredConnID = connID
@@ -182,8 +193,10 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		HeadersFactory: func(factoryCtx context.Context, headers http.Header) (http.Header, error) {
 			return s.refreshOpenAIAgentIdentityHeaders(factoryCtx, account, headers)
 		},
-		PreferredConnID: preferredConnID,
-		ForceNewConn:    forceNewConn,
+		PreferredConnID:     preferredConnID,
+		ForceNewConn:        forceNewConn,
+		ForcePreferredConn:  strictHTTPContinuation,
+		AllowPinnedOverflow: httpOAuthFacade && forceNewConn,
 		ProxyURL: func() string {
 			if account.ProxyID != nil && account.Proxy != nil {
 				return account.Proxy.URL()
@@ -192,6 +205,12 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		}(),
 	})
 	if err != nil {
+		if strictHTTPContinuation && errors.Is(err, errOpenAIWSPreferredConnUnavailable) {
+			return nil, wrapOpenAIWSFallback(
+				"previous_response_not_found",
+				errors.New("the connection for the previous response is unavailable"),
+			)
+		}
 		var agentDialErr *openAIWSDialError
 		if s.isAgentIdentityAccount(ctx, account) && errors.As(err, &agentDialErr) && isAgentIdentityTaskInvalidWSDialError(agentDialErr) && agentTaskRecoveryTried != nil && !*agentTaskRecoveryTried {
 			*agentTaskRecoveryTried = true
@@ -338,6 +357,25 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 	imageCounter := newOpenAIImageOutputCounter()
 	var firstTokenMs *int
 	responseID := ""
+	responseAffinityBound := false
+	bindResponseAffinity := func(refresh bool) error {
+		if responseAffinityBound && !refresh {
+			return nil
+		}
+		ttl := s.openAIWSResponseStickyTTL()
+		if responseID != "" && stateStore != nil {
+			if httpOAuthFacade && !s.getOpenAIWSConnPool().PinResponseConn(account.ID, responseID, lease.ConnID(), ttl) {
+				return errors.New("failed to retain the connection for the response")
+			}
+			logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+			stateStore.BindResponseConn(responseID, lease.ConnID(), ttl)
+		}
+		if stateStore != nil && storeDisabled && sessionHash != "" {
+			stateStore.BindSessionConn(groupID, sessionHash, lease.ConnID(), s.openAIWSSessionStickyTTL())
+		}
+		responseAffinityBound = true
+		return nil
+	}
 	var finalResponse []byte
 	wroteDownstream := false
 	needModelReplace := originalModel != mappedModel
@@ -666,6 +704,12 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 					)
 				}
 			} else {
+				if isTerminalEvent || (httpOAuthFacade && responseID != "") {
+					if bindErr := bindResponseAffinity(isTerminalEvent); bindErr != nil {
+						lease.MarkBroken()
+						return nil, wrapOpenAIWSFallback("response_affinity", bindErr)
+					}
+				}
 				flushBufferedStreamEvents(eventType)
 				emitStreamMessage(message, isTerminalEvent)
 			}
@@ -710,19 +754,14 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 		if responseID == "" {
 			responseID = strings.TrimSpace(gjson.GetBytes(finalResponse, "id").String())
 		}
+		if bindErr := bindResponseAffinity(true); bindErr != nil {
+			lease.MarkBroken()
+			return nil, wrapOpenAIWSFallback("response_affinity", bindErr)
+		}
 
 		c.Data(http.StatusOK, "application/json", finalResponse)
 	} else {
 		flushStreamWriter(true)
-	}
-
-	if responseID != "" && stateStore != nil {
-		ttl := s.openAIWSResponseStickyTTL()
-		logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
-		stateStore.BindResponseConn(responseID, lease.ConnID(), ttl)
-	}
-	if stateStore != nil && storeDisabled && sessionHash != "" {
-		stateStore.BindSessionConn(groupID, sessionHash, lease.ConnID(), s.openAIWSSessionStickyTTL())
 	}
 	firstTokenMsValue := -1
 	if firstTokenMs != nil {

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -74,6 +74,10 @@ type openAIWSAcquireRequest struct {
 	ForceNewConn bool
 	// ForcePreferredConn: 强制本次只使用 PreferredConnID，禁止漂移到其它连接。
 	ForcePreferredConn bool
+	// AllowPinnedOverflow permits a forced-new REST session to exceed the
+	// account's concurrency-derived soft limit when pinned idle sessions
+	// prevent eviction. The pool-wide hard cap still applies.
+	AllowPinnedOverflow bool
 }
 
 type openAIWSConnLease struct {
@@ -544,18 +548,19 @@ func (c *openAIWSConn) markPrewarmed() {
 }
 
 type openAIWSAccountPool struct {
-	mu            sync.Mutex
-	conns         map[string]*openAIWSConn
-	pinnedConns   map[string]int
-	changedCh     chan struct{}
-	creating      int
-	generation    uint64
-	lastCleanupAt time.Time
-	lastAcquire   *openAIWSAcquireRequest
-	prewarmActive bool
-	prewarmUntil  time.Time
-	prewarmFails  int
-	prewarmFailAt time.Time
+	mu                sync.Mutex
+	conns             map[string]*openAIWSConn
+	pinnedConns       map[string]int
+	timedResponsePins map[string]time.Time
+	changedCh         chan struct{}
+	creating          int
+	generation        uint64
+	lastCleanupAt     time.Time
+	lastAcquire       *openAIWSAcquireRequest
+	prewarmActive     bool
+	prewarmUntil      time.Time
+	prewarmFails      int
+	prewarmFailAt     time.Time
 }
 
 func (ap *openAIWSAccountPool) changeChannelLocked() chan struct{} {
@@ -680,6 +685,8 @@ func (p *openAIWSConnPool) Close() {
 					conn.close()
 				}
 			}
+			ap.timedResponsePins = make(map[string]time.Time)
+			ap.pinnedConns = make(map[string]int)
 			ap.mu.Unlock()
 			return true
 		})
@@ -848,6 +855,9 @@ retryAcquire:
 	ap.mu.Lock()
 	ap.lastAcquire = cloneOpenAIWSAcquireRequestPtr(&req)
 	now := time.Now()
+	if p.cleanupExpiredTimedResponsePinsLocked(ap, now) {
+		ap.signalChangedLocked()
+	}
 	if ap.lastCleanupAt.IsZero() || now.Sub(ap.lastCleanupAt) >= openAIWSAcquireCleanupInterval {
 		evicted = p.cleanupAccountLocked(ap, now, effectiveMaxConns)
 		ap.lastCleanupAt = now
@@ -1048,15 +1058,29 @@ retryAcquire:
 		}
 	}
 
+	createLimit := effectiveMaxConns
 	if req.ForceNewConn && len(ap.conns)+ap.creating >= effectiveMaxConns {
-		if idle := p.pickOldestIdleConnLocked(ap); idle != nil {
+		for len(ap.conns)+ap.creating >= effectiveMaxConns {
+			idle := p.pickOldestIdleConnLocked(ap)
+			if idle == nil {
+				break
+			}
 			delete(ap.conns, idle.id)
+			removeOpenAIWSConnPinsLocked(ap, idle.id)
 			evicted = append(evicted, idle)
 			p.metrics.scaleDownTotal.Add(1)
 		}
+		if req.AllowPinnedOverflow &&
+			(p.dynamicMaxConnsEnabled() || p.modeRouterV2Enabled()) &&
+			effectiveMaxConns < p.maxConnsHardCap() &&
+			len(ap.conns)+ap.creating >= effectiveMaxConns &&
+			len(ap.conns)+ap.creating < p.maxConnsHardCap() &&
+			p.hasPinnedIdleConnLocked(ap) {
+			createLimit = p.maxConnsHardCap()
+		}
 	}
 
-	if len(ap.conns)+ap.creating < effectiveMaxConns {
+	if len(ap.conns)+ap.creating < createLimit {
 		connPick := time.Since(pickStartedAt)
 		p.recordConnPickDuration(connPick)
 		ap.creating++
@@ -1199,9 +1223,10 @@ func (p *openAIWSConnPool) getOrCreateAccountPool(accountID int64) *openAIWSAcco
 		}
 	}
 	ap := &openAIWSAccountPool{
-		conns:       make(map[string]*openAIWSConn),
-		pinnedConns: make(map[string]int),
-		changedCh:   make(chan struct{}),
+		conns:             make(map[string]*openAIWSConn),
+		pinnedConns:       make(map[string]int),
+		timedResponsePins: make(map[string]time.Time),
+		changedCh:         make(chan struct{}),
 	}
 	actual, _ := p.accounts.LoadOrStore(accountID, ap)
 	if typed, ok := actual.(*openAIWSAccountPool); ok && typed != nil {
@@ -1238,10 +1263,70 @@ func (p *openAIWSConnPool) notifyAccountPoolChanged(accountID int64) {
 }
 
 func (p *openAIWSConnPool) isConnPinnedLocked(ap *openAIWSAccountPool, connID string) bool {
-	if ap == nil || connID == "" || len(ap.pinnedConns) == 0 {
+	if ap == nil || connID == "" {
 		return false
 	}
-	return ap.pinnedConns[connID] > 0
+	if ap.pinnedConns[connID] > 0 {
+		return true
+	}
+	expiresAt, ok := ap.timedResponsePins[connID]
+	return ok && time.Now().Before(expiresAt)
+}
+
+func decrementOpenAIWSConnPinLocked(ap *openAIWSAccountPool, connID string) {
+	if ap == nil || connID == "" || len(ap.pinnedConns) == 0 {
+		return
+	}
+	count := ap.pinnedConns[connID]
+	if count <= 1 {
+		delete(ap.pinnedConns, connID)
+		return
+	}
+	ap.pinnedConns[connID] = count - 1
+}
+
+func removeOpenAIWSConnPinsLocked(ap *openAIWSAccountPool, connID string) bool {
+	if ap == nil || connID == "" {
+		return false
+	}
+	_, timedPinned := ap.timedResponsePins[connID]
+	delete(ap.timedResponsePins, connID)
+	changed := timedPinned
+	if _, ok := ap.pinnedConns[connID]; ok {
+		delete(ap.pinnedConns, connID)
+		changed = true
+	}
+	return changed
+}
+
+func (p *openAIWSConnPool) cleanupExpiredTimedResponsePinsLocked(ap *openAIWSAccountPool, now time.Time) bool {
+	if ap == nil || len(ap.timedResponsePins) == 0 {
+		return false
+	}
+	changed := false
+	for connID, expiresAt := range ap.timedResponsePins {
+		if !expiresAt.IsZero() && now.Before(expiresAt) {
+			continue
+		}
+		delete(ap.timedResponsePins, connID)
+		changed = true
+	}
+	return changed
+}
+
+func (p *openAIWSConnPool) hasPinnedIdleConnLocked(ap *openAIWSAccountPool) bool {
+	if ap == nil {
+		return false
+	}
+	for _, conn := range ap.conns {
+		if conn == nil || conn.isLeased() || conn.waiters.Load() > 0 {
+			continue
+		}
+		if p.isConnPinnedLocked(ap, conn.id) {
+			return true
+		}
+	}
+	return false
 }
 
 func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now time.Time, maxConns int) []*openAIWSConn {
@@ -1249,22 +1334,19 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 		return nil
 	}
 	maxAge := p.maxConnAge()
+	changed := p.cleanupExpiredTimedResponsePinsLocked(ap, now)
 
 	evicted := make([]*openAIWSConn, 0)
 	for id, conn := range ap.conns {
 		if conn == nil {
 			delete(ap.conns, id)
-			if len(ap.pinnedConns) > 0 {
-				delete(ap.pinnedConns, id)
-			}
+			changed = removeOpenAIWSConnPinsLocked(ap, id) || changed
 			continue
 		}
 		select {
 		case <-conn.closedCh:
 			delete(ap.conns, id)
-			if len(ap.pinnedConns) > 0 {
-				delete(ap.pinnedConns, id)
-			}
+			changed = removeOpenAIWSConnPinsLocked(ap, id) || changed
 			evicted = append(evicted, conn)
 			continue
 		default:
@@ -1274,9 +1356,7 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 		}
 		if maxAge > 0 && !conn.isLeased() && conn.age(now) > maxAge {
 			delete(ap.conns, id)
-			if len(ap.pinnedConns) > 0 {
-				delete(ap.pinnedConns, id)
-			}
+			changed = removeOpenAIWSConnPinsLocked(ap, id) || changed
 			evicted = append(evicted, conn)
 		}
 	}
@@ -1293,9 +1373,7 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 		for id, conn := range ap.conns {
 			if conn == nil {
 				delete(ap.conns, id)
-				if len(ap.pinnedConns) > 0 {
-					delete(ap.pinnedConns, id)
-				}
+				changed = removeOpenAIWSConnPinsLocked(ap, id) || changed
 				continue
 			}
 			// 有等待者的连接不能在清理阶段被淘汰，否则等待中的 acquire 会收到 closed 错误。
@@ -1314,16 +1392,14 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 		for i := 0; i < redundant; i++ {
 			conn := idleConns[i]
 			delete(ap.conns, conn.id)
-			if len(ap.pinnedConns) > 0 {
-				delete(ap.pinnedConns, conn.id)
-			}
+			changed = removeOpenAIWSConnPinsLocked(ap, conn.id) || changed
 			evicted = append(evicted, conn)
 		}
 		if redundant > 0 {
 			p.metrics.scaleDownTotal.Add(int64(redundant))
 		}
 	}
-	if len(evicted) > 0 {
+	if len(evicted) > 0 || changed {
 		ap.signalChangedLocked()
 	}
 
@@ -1554,15 +1630,17 @@ func (p *openAIWSConnPool) ClearAccount(accountID int64) {
 	conns := make([]*openAIWSConn, 0, len(ap.conns))
 	for id, conn := range ap.conns {
 		delete(ap.conns, id)
-		delete(ap.pinnedConns, id)
 		if conn != nil {
 			conns = append(conns, conn)
 		}
 	}
+	ap.timedResponsePins = make(map[string]time.Time)
+	ap.pinnedConns = make(map[string]int)
 	ap.lastAcquire = nil
 	ap.prewarmUntil = time.Time{}
 	ap.prewarmFails = 0
 	ap.prewarmFailAt = time.Time{}
+	ap.signalChangedLocked()
 	ap.mu.Unlock()
 	closeOpenAIWSConns(conns)
 }
@@ -1575,12 +1653,13 @@ func (p *openAIWSConnPool) evictConn(accountID int64, connID string) {
 	ap, ok := p.getAccountPool(accountID)
 	if ok && ap != nil {
 		ap.mu.Lock()
+		changed := removeOpenAIWSConnPinsLocked(ap, connID)
 		if c, exists := ap.conns[connID]; exists {
 			conn = c
 			delete(ap.conns, connID)
-			if len(ap.pinnedConns) > 0 {
-				delete(ap.pinnedConns, connID)
-			}
+			changed = true
+		}
+		if changed {
 			ap.signalChangedLocked()
 		}
 		ap.mu.Unlock()
@@ -1614,6 +1693,47 @@ func (p *openAIWSConnPool) PinConn(accountID int64, connID string) bool {
 	return true
 }
 
+// PinResponseConn protects the connection that owns a store=false response ID.
+// Retention is tracked per connection, so its cardinality is bounded by the
+// pool hard cap even when a connection produces many response IDs.
+func (p *openAIWSConnPool) PinResponseConn(accountID int64, responseID, connID string, ttl time.Duration) bool {
+	if p == nil || accountID <= 0 {
+		return false
+	}
+	responseID = stringsTrim(responseID)
+	connID = stringsTrim(connID)
+	if responseID == "" || connID == "" {
+		return false
+	}
+	ap, ok := p.getAccountPool(accountID)
+	if !ok || ap == nil {
+		return false
+	}
+
+	now := time.Now()
+	expiresAt := now.Add(normalizeOpenAIWSTTL(ttl))
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	conn, exists := ap.conns[connID]
+	if !exists || conn == nil {
+		return false
+	}
+	select {
+	case <-conn.closedCh:
+		return false
+	default:
+	}
+
+	if ap.timedResponsePins == nil {
+		ap.timedResponsePins = make(map[string]time.Time)
+	}
+	if existing := ap.timedResponsePins[connID]; existing.After(expiresAt) {
+		expiresAt = existing
+	}
+	ap.timedResponsePins[connID] = expiresAt
+	return true
+}
+
 func (p *openAIWSConnPool) UnpinConn(accountID int64, connID string) {
 	if p == nil || accountID <= 0 {
 		return
@@ -1631,13 +1751,7 @@ func (p *openAIWSConnPool) UnpinConn(accountID int64, connID string) {
 	if len(ap.pinnedConns) == 0 {
 		return
 	}
-	count := ap.pinnedConns[connID]
-	if count <= 1 {
-		delete(ap.pinnedConns, connID)
-		ap.signalChangedLocked()
-		return
-	}
-	ap.pinnedConns[connID] = count - 1
+	decrementOpenAIWSConnPinLocked(ap, connID)
 	ap.signalChangedLocked()
 }
 

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
@@ -340,6 +341,245 @@ func TestOpenAIWSConnPool_ForceNewConnSkipsReuse(t *testing.T) {
 	lease2.Release()
 
 	require.Equal(t, 2, dialer.DialCount(), "ForceNewConn=true 时应跳过空闲连接复用并新建连接")
+}
+
+func TestOpenAIWSConnPool_AllowPinnedOverflowRespectsDynamicAndHardCaps(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 3
+	cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
+	cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 3
+
+	pool := newOpenAIWSConnPool(cfg)
+	t.Cleanup(pool.Close)
+	dialer := &openAIWSCountingDialer{}
+	pool.setClientDialerForTest(dialer)
+	account := &Account{ID: 124, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 1}
+	baseReq := openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+	}
+
+	leaseA, err := pool.Acquire(context.Background(), baseReq)
+	require.NoError(t, err)
+	connA := leaseA.ConnID()
+
+	_, err = pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account:             account,
+		WSURL:               baseReq.WSURL,
+		ForceNewConn:        true,
+		AllowPinnedOverflow: true,
+	})
+	require.ErrorIs(t, err, errOpenAIWSConnQueueFull, "busy but unpinned capacity must not enable overflow")
+	leaseA.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_a", connA, time.Hour))
+
+	_, err = pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account:      account,
+		WSURL:        baseReq.WSURL,
+		ForceNewConn: true,
+	})
+	require.ErrorIs(t, err, errOpenAIWSConnQueueFull, "overflow must be explicitly enabled")
+
+	reusedA, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account:             account,
+		WSURL:               baseReq.WSURL,
+		AllowPinnedOverflow: true,
+	})
+	require.NoError(t, err)
+	require.True(t, reusedA.Reused(), "overflow flag without ForceNewConn must retain normal reuse")
+	require.Equal(t, connA, reusedA.ConnID())
+	reusedA.Release()
+
+	newSessionReq := openAIWSAcquireRequest{
+		Account:             account,
+		WSURL:               baseReq.WSURL,
+		ForceNewConn:        true,
+		AllowPinnedOverflow: true,
+	}
+	leaseB, err := pool.Acquire(context.Background(), newSessionReq)
+	require.NoError(t, err)
+	connB := leaseB.ConnID()
+	require.NotEqual(t, connA, connB)
+	leaseB.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_b", connB, time.Hour))
+
+	leaseC, err := pool.Acquire(context.Background(), newSessionReq)
+	require.NoError(t, err)
+	connC := leaseC.ConnID()
+	require.NotEqual(t, connA, connC)
+	require.NotEqual(t, connB, connC)
+	leaseC.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_c", connC, time.Hour))
+
+	_, err = pool.Acquire(context.Background(), newSessionReq)
+	require.ErrorIs(t, err, errOpenAIWSConnQueueFull, "hard cap must reject when every connection is pinned")
+	require.Equal(t, 3, dialer.DialCount())
+
+	ap, ok := pool.getAccountPool(account.ID)
+	require.True(t, ok)
+	ap.mu.Lock()
+	require.Contains(t, ap.conns, connA)
+	require.Contains(t, ap.conns, connB)
+	require.Contains(t, ap.conns, connC)
+	ap.mu.Unlock()
+
+	continuationA, err := pool.Acquire(context.Background(), openAIWSAcquireRequest{
+		Account:            account,
+		WSURL:              baseReq.WSURL,
+		PreferredConnID:    connA,
+		ForcePreferredConn: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, connA, continuationA.ConnID(), "A must remain available after creating B and C")
+	continuationA.Release()
+}
+
+func TestOpenAIWSConnPool_AllowPinnedOverflowEvictsUnpinnedIdleFirst(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 3
+	cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
+	cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 3
+
+	pool := newOpenAIWSConnPool(cfg)
+	t.Cleanup(pool.Close)
+	pool.setClientDialerForTest(&openAIWSCountingDialer{})
+	account := &Account{ID: 125, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 1}
+	request := openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+	}
+
+	leaseA, err := pool.Acquire(context.Background(), request)
+	require.NoError(t, err)
+	connA := leaseA.ConnID()
+	leaseA.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_a", connA, time.Hour))
+
+	request.ForceNewConn = true
+	request.AllowPinnedOverflow = true
+	leaseB, err := pool.Acquire(context.Background(), request)
+	require.NoError(t, err)
+	connB := leaseB.ConnID()
+	leaseB.Release()
+
+	leaseC, err := pool.Acquire(context.Background(), request)
+	require.NoError(t, err)
+	connC := leaseC.ConnID()
+	leaseC.Release()
+
+	ap, ok := pool.getAccountPool(account.ID)
+	require.True(t, ok)
+	ap.mu.Lock()
+	require.Len(t, ap.conns, 2, "an unpinned idle connection should be replaced before overflowing further")
+	require.Contains(t, ap.conns, connA)
+	require.NotContains(t, ap.conns, connB)
+	require.Contains(t, ap.conns, connC)
+	ap.mu.Unlock()
+}
+
+func TestOpenAIWSConnPool_AllowPinnedOverflowConcurrentAcquireStopsAtHardCap(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
+	cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+
+	pool := newOpenAIWSConnPool(cfg)
+	t.Cleanup(pool.Close)
+	dialer := &openAIWSCountingDialer{}
+	pool.setClientDialerForTest(dialer)
+	account := &Account{ID: 126, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 1}
+	request := openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+	}
+
+	leaseA, err := pool.Acquire(context.Background(), request)
+	require.NoError(t, err)
+	connA := leaseA.ConnID()
+	leaseA.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_concurrent_a", connA, time.Hour))
+
+	request.ForceNewConn = true
+	request.AllowPinnedOverflow = true
+	const contenders = 8
+	type acquireResult struct {
+		lease *openAIWSConnLease
+		err   error
+	}
+	start := make(chan struct{})
+	release := make(chan struct{})
+	results := make(chan acquireResult, contenders)
+	var wg sync.WaitGroup
+	for i := 0; i < contenders; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			lease, acquireErr := pool.Acquire(context.Background(), request)
+			results <- acquireResult{lease: lease, err: acquireErr}
+			if lease != nil {
+				<-release
+				lease.Release()
+			}
+		}()
+	}
+	close(start)
+
+	successes := 0
+	for i := 0; i < contenders; i++ {
+		result := <-results
+		if result.err == nil {
+			successes++
+			continue
+		}
+		require.ErrorIs(t, result.err, errOpenAIWSConnQueueFull)
+	}
+	require.Equal(t, 1, successes)
+	require.Equal(t, 2, dialer.DialCount(), "creating slots and live conns must share the hard cap")
+	close(release)
+	wg.Wait()
+}
+
+func TestOpenAIWSConnPool_AllowPinnedOverflowUsesHardCapInModeRouter(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+
+	pool := newOpenAIWSConnPool(cfg)
+	t.Cleanup(pool.Close)
+	pool.setClientDialerForTest(&openAIWSCountingDialer{})
+	account := &Account{ID: 127, Platform: PlatformOpenAI, Type: AccountTypeOAuth, Concurrency: 1}
+	request := openAIWSAcquireRequest{
+		Account: account,
+		WSURL:   "wss://example.com/v1/responses",
+	}
+
+	lease, err := pool.Acquire(context.Background(), request)
+	require.NoError(t, err)
+	connID := lease.ConnID()
+	lease.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_mode_router", connID, time.Hour))
+
+	request.ForceNewConn = true
+	request.AllowPinnedOverflow = true
+	secondLease, err := pool.Acquire(context.Background(), request)
+	require.NoError(t, err)
+	require.NotEqual(t, connID, secondLease.ConnID())
+	secondConnID := secondLease.ConnID()
+	secondLease.Release()
+	require.True(t, pool.PinResponseConn(account.ID, "resp_mode_router_second", secondConnID, time.Hour))
+
+	_, err = pool.Acquire(context.Background(), request)
+	require.ErrorIs(t, err, errOpenAIWSConnQueueFull, "mode router overflow must still respect the pool hard cap")
 }
 
 func TestOpenAIWSConnPool_AcquireReusesOnlyMatchingBetaFeatures(t *testing.T) {
@@ -698,6 +938,190 @@ func TestOpenAIWSConnPool_PinUnpinConnBranches(t *testing.T) {
 	pool.UnpinConn(accountID, "")
 	pool.UnpinConn(0, conn.id)
 	pool.UnpinConn(999, conn.id)
+}
+
+func TestOpenAIWSConnPool_TimedResponsePinRefreshAndCardinalityBound(t *testing.T) {
+	var nilPool *openAIWSConnPool
+	require.False(t, nilPool.PinResponseConn(1, "resp_nil", "conn", time.Hour))
+
+	pool := newOpenAIWSConnPool(&config.Config{})
+	t.Cleanup(pool.Close)
+	accountID := int64(129)
+	ap := pool.getOrCreateAccountPool(accountID)
+	connA := newOpenAIWSConn("timed_a", accountID, &openAIWSFakeConn{}, nil)
+	connB := newOpenAIWSConn("timed_b", accountID, &openAIWSFakeConn{}, nil)
+	closedConn := newOpenAIWSConn("timed_closed", accountID, &openAIWSFakeConn{}, nil)
+	closedConn.close()
+	ap.mu.Lock()
+	ap.conns[connA.id] = connA
+	ap.conns[connB.id] = connB
+	ap.conns[closedConn.id] = closedConn
+	ap.mu.Unlock()
+
+	require.False(t, pool.PinResponseConn(0, "resp", connA.id, time.Hour))
+	require.False(t, pool.PinResponseConn(accountID, "", connA.id, time.Hour))
+	require.False(t, pool.PinResponseConn(accountID, "resp", "", time.Hour))
+	require.False(t, pool.PinResponseConn(accountID, "resp", "missing", time.Hour))
+	require.False(t, pool.PinResponseConn(accountID, "resp", closedConn.id, time.Hour))
+
+	require.True(t, pool.PinResponseConn(accountID, " resp_shared ", connA.id, time.Minute))
+	ap.mu.Lock()
+	firstExpiry := ap.timedResponsePins[connA.id]
+	require.Len(t, ap.timedResponsePins, 1)
+	require.Empty(t, ap.pinnedConns)
+	ap.mu.Unlock()
+
+	require.True(t, pool.PinResponseConn(accountID, "resp_shared", connA.id, 2*time.Hour))
+	ap.mu.Lock()
+	refreshedExpiry := ap.timedResponsePins[connA.id]
+	require.True(t, refreshedExpiry.After(firstExpiry))
+	ap.mu.Unlock()
+
+	for i := 0; i < 10_000; i++ {
+		require.True(t, pool.PinResponseConn(accountID, fmt.Sprintf("resp_many_%d", i), connA.id, time.Hour))
+	}
+	ap.mu.Lock()
+	require.Len(t, ap.timedResponsePins, 1, "response volume must not grow retention state beyond live connections")
+	ap.mu.Unlock()
+
+	require.True(t, pool.PinConn(accountID, connA.id), "permanent and timed pins must coexist")
+	require.True(t, pool.PinResponseConn(accountID, "resp_shared", connB.id, time.Hour))
+	ap.mu.Lock()
+	require.Equal(t, 1, ap.pinnedConns[connA.id])
+	require.Len(t, ap.timedResponsePins, 2)
+	ap.mu.Unlock()
+
+	pool.cleanupAccountLocked(ap, time.Now().Add(90*time.Minute), pool.maxConnsHardCap())
+	ap.mu.Lock()
+	_, connATimed := ap.timedResponsePins[connA.id]
+	_, connBTimed := ap.timedResponsePins[connB.id]
+	require.True(t, connATimed)
+	require.False(t, connBTimed)
+	require.Equal(t, 1, ap.pinnedConns[connA.id])
+	ap.mu.Unlock()
+
+	pool.cleanupAccountLocked(ap, time.Now().Add(3*time.Hour), pool.maxConnsHardCap())
+	ap.mu.Lock()
+	_, connATimed = ap.timedResponsePins[connA.id]
+	require.False(t, connATimed)
+	require.Equal(t, 1, ap.pinnedConns[connA.id], "timed expiry must not clear a permanent pin")
+	ap.mu.Unlock()
+	pool.UnpinConn(accountID, connA.id)
+}
+
+func TestOpenAIWSConnPool_TimedResponsePinExpiryAllowsCleanup(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 0
+	pool := newOpenAIWSConnPool(cfg)
+	t.Cleanup(pool.Close)
+
+	accountID := int64(130)
+	ap := pool.getOrCreateAccountPool(accountID)
+	conn := newOpenAIWSConn("timed_expiry", accountID, &openAIWSFakeConn{}, nil)
+	ap.mu.Lock()
+	ap.conns[conn.id] = conn
+	ap.mu.Unlock()
+	require.True(t, pool.PinResponseConn(accountID, "resp_expiry", conn.id, time.Hour))
+
+	evicted := pool.cleanupAccountLocked(ap, time.Now(), pool.maxConnsHardCap())
+	require.Empty(t, evicted)
+	ap.mu.Lock()
+	require.Contains(t, ap.conns, conn.id, "a live timed pin must protect maxIdle=0")
+	expiresAt := ap.timedResponsePins[conn.id]
+	ap.mu.Unlock()
+
+	evicted = pool.cleanupAccountLocked(ap, expiresAt, pool.maxConnsHardCap())
+	closeOpenAIWSConns(evicted)
+	ap.mu.Lock()
+	require.NotContains(t, ap.conns, conn.id, "expiresAt == now must release the pin before idle cleanup")
+	require.NotContains(t, ap.timedResponsePins, conn.id)
+	require.NotContains(t, ap.pinnedConns, conn.id)
+	ap.mu.Unlock()
+}
+
+func TestOpenAIWSConnPool_TimedResponsePinsClearedWithConnectionLifecycle(t *testing.T) {
+	t.Run("closed cleanup", func(t *testing.T) {
+		pool := newOpenAIWSConnPool(&config.Config{})
+		t.Cleanup(pool.Close)
+		accountID := int64(131)
+		ap := pool.getOrCreateAccountPool(accountID)
+		conn := newOpenAIWSConn("timed_closed_cleanup", accountID, &openAIWSFakeConn{}, nil)
+		ap.mu.Lock()
+		ap.conns[conn.id] = conn
+		ap.mu.Unlock()
+		require.True(t, pool.PinResponseConn(accountID, "resp_closed", conn.id, time.Hour))
+		conn.close()
+
+		pool.cleanupAccountLocked(ap, time.Now(), pool.maxConnsHardCap())
+		ap.mu.Lock()
+		require.NotContains(t, ap.conns, conn.id)
+		require.Empty(t, ap.timedResponsePins)
+		require.Empty(t, ap.pinnedConns)
+		ap.mu.Unlock()
+	})
+
+	t.Run("evict", func(t *testing.T) {
+		pool := newOpenAIWSConnPool(&config.Config{})
+		t.Cleanup(pool.Close)
+		accountID := int64(132)
+		ap := pool.getOrCreateAccountPool(accountID)
+		conn := newOpenAIWSConn("timed_evict", accountID, &openAIWSFakeConn{}, nil)
+		ap.mu.Lock()
+		ap.conns[conn.id] = conn
+		ap.mu.Unlock()
+		require.True(t, pool.PinResponseConn(accountID, "resp_evict_1", conn.id, time.Hour))
+		require.True(t, pool.PinResponseConn(accountID, "resp_evict_2", conn.id, time.Hour))
+		pool.evictConn(accountID, conn.id)
+
+		ap.mu.Lock()
+		require.NotContains(t, ap.conns, conn.id)
+		require.Empty(t, ap.timedResponsePins)
+		require.Empty(t, ap.pinnedConns)
+		ap.mu.Unlock()
+	})
+
+	t.Run("clear account", func(t *testing.T) {
+		pool := newOpenAIWSConnPool(&config.Config{})
+		t.Cleanup(pool.Close)
+		accountID := int64(133)
+		ap := pool.getOrCreateAccountPool(accountID)
+		conn := newOpenAIWSConn("timed_clear", accountID, &openAIWSFakeConn{}, nil)
+		ap.mu.Lock()
+		ap.conns[conn.id] = conn
+		changedCh := ap.changeChannelLocked()
+		ap.mu.Unlock()
+		require.True(t, pool.PinResponseConn(accountID, "resp_clear", conn.id, time.Hour))
+		pool.ClearAccount(accountID)
+		select {
+		case <-changedCh:
+		default:
+			t.Fatal("ClearAccount must wake acquires waiting for pool state changes")
+		}
+
+		ap.mu.Lock()
+		require.Empty(t, ap.conns)
+		require.Empty(t, ap.timedResponsePins)
+		require.Empty(t, ap.pinnedConns)
+		ap.mu.Unlock()
+	})
+
+	t.Run("pool close", func(t *testing.T) {
+		pool := newOpenAIWSConnPool(&config.Config{})
+		accountID := int64(134)
+		ap := pool.getOrCreateAccountPool(accountID)
+		conn := newOpenAIWSConn("timed_pool_close", accountID, &openAIWSFakeConn{}, nil)
+		ap.mu.Lock()
+		ap.conns[conn.id] = conn
+		ap.mu.Unlock()
+		require.True(t, pool.PinResponseConn(accountID, "resp_pool_close", conn.id, time.Hour))
+		pool.Close()
+
+		ap.mu.Lock()
+		require.Empty(t, ap.timedResponsePins)
+		require.Empty(t, ap.pinnedConns)
+		ap.mu.Unlock()
+	})
 }
 
 func TestOpenAIWSConnPool_EffectiveMaxConnsByAccount(t *testing.T) {

--- a/backend/internal/service/openai_ws_protocol_forward_test.go
+++ b/backend/internal/service/openai_ws_protocol_forward_test.go
@@ -31,6 +31,54 @@ type httpUpstreamSequenceRecorder struct {
 	callCount int
 }
 
+type openAIWSSequenceCaptureDialer struct {
+	mu        sync.Mutex
+	conns     []*openAIWSCaptureConn
+	dialCount int
+}
+
+type openAIWSWriteProbeRecorder struct {
+	*httptest.ResponseRecorder
+	once             sync.Once
+	beforeFirstWrite func()
+}
+
+func (r *openAIWSWriteProbeRecorder) Write(payload []byte) (int, error) {
+	r.once.Do(func() {
+		if r.beforeFirstWrite != nil {
+			r.beforeFirstWrite()
+		}
+	})
+	return r.ResponseRecorder.Write(payload)
+}
+
+func (d *openAIWSSequenceCaptureDialer) Dial(
+	ctx context.Context,
+	wsURL string,
+	headers http.Header,
+	proxyURL string,
+) (openAIWSClientConn, int, http.Header, error) {
+	_ = ctx
+	_ = wsURL
+	_ = headers
+	_ = proxyURL
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.dialCount >= len(d.conns) {
+		return nil, 0, nil, io.ErrUnexpectedEOF
+	}
+	conn := d.conns[d.dialCount]
+	d.dialCount++
+	return conn, 0, nil, nil
+}
+
+func (d *openAIWSSequenceCaptureDialer) DialCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dialCount
+}
+
 func (u *httpUpstreamSequenceRecorder) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
@@ -120,70 +168,377 @@ func TestOpenAIGatewayService_Forward_PreservePreviousResponseIDWhenWSEnabled(t 
 	require.Nil(t, upstream.lastReq, "WS 模式下失败时不应回退 HTTP")
 }
 
-func TestOpenAIGatewayService_Forward_HTTPIngressStaysHTTPWhenWSEnabled(t *testing.T) {
+func TestOpenAIGatewayService_Forward_HTTPAPIKeyPreviousResponseID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	wsFallbackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 	}))
 	defer wsFallbackServer.Close()
 
-	rec := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(rec)
-	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
-	c.Request.Header.Set("User-Agent", "custom-client/1.0")
-	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
-
-	upstream := &httpUpstreamRecorder{
-		resp: &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     http.Header{"Content-Type": []string{"application/json"}},
-			Body: io.NopCloser(strings.NewReader(
-				`{"usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`,
-			)),
-		},
-	}
-
 	cfg := &config.Config{}
 	cfg.Security.URLAllowlist.Enabled = false
 	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = false
+
+	tests := []struct {
+		name       string
+		field      string
+		wantExists bool
+		wantID     string
+	}{
+		{
+			name:       "nonempty is preserved",
+			field:      `"previous_response_id":"resp_http_keep",`,
+			wantExists: true,
+			wantID:     "resp_http_keep",
+		},
+		{
+			name:  "empty string is removed",
+			field: `"previous_response_id":"",`,
+		},
+		{
+			name:  "null is removed",
+			field: `"previous_response_id":null,`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+			c.Request.Header.Set("User-Agent", "custom-client/1.0")
+			SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+			upstream := &httpUpstreamRecorder{
+				resp: &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Body: io.NopCloser(strings.NewReader(
+						`{"usage":{"input_tokens":1,"output_tokens":2,"input_tokens_details":{"cached_tokens":0}}}`,
+					)),
+				},
+			}
+			svc := &OpenAIGatewayService{
+				cfg:              cfg,
+				httpUpstream:     upstream,
+				openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+			}
+			account := &Account{
+				ID:          101,
+				Name:        "openai-apikey",
+				Platform:    PlatformOpenAI,
+				Type:        AccountTypeAPIKey,
+				Concurrency: 1,
+				Credentials: map[string]any{
+					"api_key":  "sk-test",
+					"base_url": wsFallbackServer.URL,
+				},
+				Extra: map[string]any{
+					"openai_responses_supported": true,
+				},
+			}
+
+			body := []byte(`{"model":"gpt-5.1","stream":false,` + tt.field + `"input":[{"type":"input_text","text":"hello"}]}`)
+			result, err := svc.Forward(context.Background(), c, account, body)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.False(t, result.OpenAIWSMode)
+			require.NotNil(t, upstream.lastReq, "API-key native Responses should use the HTTP upstream")
+
+			previousResponseID := gjson.GetBytes(upstream.lastBody, "previous_response_id")
+			require.Equal(t, tt.wantExists, previousResponseID.Exists())
+			require.Equal(t, tt.wantID, previousResponseID.String())
+		})
+	}
+}
+
+func TestOpenAIGatewayService_Forward_HTTPIngressOAuthKeepsWSv2Decision(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newHTTPContext := func() (*gin.Context, *httptest.ResponseRecorder) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+		c.Request.Header.Set("User-Agent", "custom-client/1.0")
+		SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+		return c, rec
+	}
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"usage":{"input_tokens":1,"output_tokens":2}}`)),
+	}}
+	captureConn := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_oauth_first","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":2}}}`),
+		[]byte(`{"type":"response.completed","response":{"id":"resp_oauth_second","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":2}}}`),
+	}}
+	captureDialer := &openAIWSCaptureDialer{conn: captureConn}
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
 	cfg.Gateway.OpenAIWS.Enabled = true
 	cfg.Gateway.OpenAIWS.OAuthEnabled = true
-	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
 	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
 
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(captureDialer)
 	svc := &OpenAIGatewayService{
 		cfg:              cfg,
 		httpUpstream:     upstream,
+		cache:            &stubGatewayCache{},
 		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		openaiWSPool:     pool,
+		toolCorrector:    NewCodexToolCorrector(),
 	}
-
 	account := &Account{
-		ID:          101,
-		Name:        "openai-apikey",
+		ID:          102,
+		Name:        "openai-oauth",
 		Platform:    PlatformOpenAI,
-		Type:        AccountTypeAPIKey,
+		Type:        AccountTypeOAuth,
 		Concurrency: 1,
-		Credentials: map[string]any{
-			"api_key":  "sk-test",
-			"base_url": wsFallbackServer.URL,
-		},
+		Credentials: map[string]any{"access_token": "oauth-token"},
 		Extra: map[string]any{
 			"responses_websockets_v2_enabled": true,
 		},
 	}
 
-	body := []byte(`{"model":"gpt-5.1","stream":false,"previous_response_id":"resp_http_keep","input":[{"type":"input_text","text":"hello"}]}`)
-	result, err := svc.Forward(context.Background(), c, account, body)
+	firstContext, _ := newHTTPContext()
+	firstBody := []byte(`{"model":"gpt-5.1","stream":false,"input":[{"type":"input_text","text":"hello"}]}`)
+	firstResult, err := svc.Forward(context.Background(), firstContext, account, firstBody)
+	require.NoError(t, err)
+	require.NotNil(t, firstResult)
+	require.True(t, firstResult.OpenAIWSMode)
+	require.Equal(t, "resp_oauth_first", firstResult.RequestID)
+
+	continuationContext, continuationRecorder := newHTTPContext()
+	continuationBody := []byte(`{"model":"gpt-5.1","stream":true,"previous_response_id":"resp_oauth_first","input":[{"type":"input_text","text":"continue"}]}`)
+	continuationResult, err := svc.Forward(context.Background(), continuationContext, account, continuationBody)
+	require.NoError(t, err)
+	require.NotNil(t, continuationResult)
+	require.True(t, continuationResult.OpenAIWSMode)
+	require.True(t, continuationResult.Stream)
+	require.Equal(t, "resp_oauth_second", continuationResult.RequestID)
+	require.Contains(t, continuationRecorder.Header().Get("Content-Type"), "text/event-stream")
+	require.Contains(t, continuationRecorder.Body.String(), `"type":"response.completed"`)
+	require.Nil(t, upstream.lastReq, "OAuth HTTP ingress should use the WSv2 forwarder when enabled")
+	require.Equal(t, 1, captureDialer.DialCount())
+	require.Equal(t, "resp_oauth_first", gjson.Get(requestToJSONString(captureConn.lastWrite), "previous_response_id").String())
+
+	decision, _ := continuationContext.Get("openai_ws_transport_decision")
+	reason, _ := continuationContext.Get("openai_ws_transport_reason")
+	require.Equal(t, string(OpenAIUpstreamTransportResponsesWebsocketV2), decision)
+	require.Equal(t, "http_responses_facade_ws_v2_enabled", reason)
+
+	store := svc.getOpenAIWSStateStore()
+	connID, ok := store.GetResponseConn("resp_oauth_second")
+	require.True(t, ok)
+	pool.evictConn(account.ID, connID)
+
+	lostContext, lostRecorder := newHTTPContext()
+	lostResult, lostErr := svc.Forward(
+		context.Background(),
+		lostContext,
+		account,
+		[]byte(`{"model":"gpt-5.1","stream":false,"previous_response_id":"resp_oauth_second","input":"continue again"}`),
+	)
+	require.Error(t, lostErr)
+	require.Nil(t, lostResult)
+	require.Equal(t, http.StatusBadRequest, lostRecorder.Code)
+	require.Equal(t, "previous_response_not_found", gjson.GetBytes(lostRecorder.Body.Bytes(), "error.code").String())
+	require.Equal(t, "previous_response_id", gjson.GetBytes(lostRecorder.Body.Bytes(), "error.param").String())
+	require.Equal(t, 1, captureDialer.DialCount(), "a connection-local continuation must not drift to a new WS connection")
+}
+
+func TestOpenAIGatewayService_Forward_HTTPIngressOAuthRetainsConnectionAcrossIndependentSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	newHTTPContext := func(sessionID string) (*gin.Context, *httptest.ResponseRecorder) {
+		rec := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(rec)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+		c.Request.Header.Set("User-Agent", "custom-client/1.0")
+		c.Request.Header.Set("session_id", sessionID)
+		SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+		return c, rec
+	}
+
+	connA := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_session_a_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":2}}}`),
+		[]byte(`{"type":"response.completed","response":{"id":"resp_session_a_2","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":2}}}`),
+	}}
+	connB := &openAIWSCaptureConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_session_b_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":2}}}`),
+	}}
+	dialer := &openAIWSSequenceCaptureDialer{conns: []*openAIWSCaptureConn{connA, connB}}
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.StoreDisabledConnMode = openAIWSStoreDisabledConnModeStrict
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+	cfg.Gateway.OpenAIWS.DynamicMaxConnsByAccountConcurrencyEnabled = true
+	cfg.Gateway.OpenAIWS.OAuthMaxConnsFactor = 1
+	cfg.Gateway.OpenAIWS.StickyResponseIDTTLSeconds = 3600
+
+	pool := newOpenAIWSConnPool(cfg)
+	defer pool.Close()
+	pool.setClientDialerForTest(dialer)
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		openaiWSPool:     pool,
+		toolCorrector:    NewCodexToolCorrector(),
+	}
+	account := &Account{
+		ID:          103,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token"},
+		Extra: map[string]any{
+			"responses_websockets_v2_enabled": true,
+		},
+	}
+
+	contextA1, _ := newHTTPContext("session-a")
+	resultA1, err := svc.Forward(
+		context.Background(),
+		contextA1,
+		account,
+		[]byte(`{"model":"gpt-5.1","stream":false,"input":"session A first turn"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "resp_session_a_1", resultA1.RequestID)
+
+	contextB1, _ := newHTTPContext("session-b")
+	resultB1, err := svc.Forward(
+		context.Background(),
+		contextB1,
+		account,
+		[]byte(`{"model":"gpt-5.1","stream":false,"input":"session B first turn"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "resp_session_b_1", resultB1.RequestID)
+	require.Equal(t, 2, dialer.DialCount(), "session B should get a separate upstream connection")
+	require.False(t, connA.closed, "session B must not evict session A's retained connection")
+
+	contextA2, _ := newHTTPContext("session-a")
+	resultA2, err := svc.Forward(
+		context.Background(),
+		contextA2,
+		account,
+		[]byte(`{"model":"gpt-5.1","stream":false,"previous_response_id":"resp_session_a_1","input":"session A second turn"}`),
+	)
+	require.NoError(t, err)
+	require.Equal(t, "resp_session_a_2", resultA2.RequestID)
+	require.Equal(t, 2, dialer.DialCount(), "session A continuation must reuse its original connection")
+	require.Equal(t, "resp_session_a_1", gjson.Get(requestToJSONString(connA.lastWrite), "previous_response_id").String())
+	require.False(t, gjson.Get(requestToJSONString(connB.lastWrite), "previous_response_id").Exists())
+}
+
+func TestOpenAIGatewayService_Forward_HTTPIngressOAuthBindsBeforeSSEWriteAndRefreshesAtTerminal(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	captureConn := &openAIWSCaptureConn{
+		readDelays: []time.Duration{0, 0, 1250 * time.Millisecond},
+		events: [][]byte{
+			[]byte(`{"type":"response.created","response":{"id":"resp_sse_visible","model":"gpt-5.1","status":"in_progress"}}`),
+			[]byte(`{"type":"response.output_text.delta","response":{"id":"resp_sse_visible"},"delta":"ready"}`),
+			[]byte(`{"type":"response.completed","response":{"id":"resp_sse_visible","model":"gpt-5.1","status":"completed","usage":{"input_tokens":1,"output_tokens":2}}}`),
+		},
+	}
+	dialer := &openAIWSCaptureDialer{conn: captureConn}
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.StoreDisabledConnMode = openAIWSStoreDisabledConnModeStrict
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+	cfg.Gateway.OpenAIWS.StickyResponseIDTTLSeconds = 1
+
+	pool := newOpenAIWSConnPool(cfg)
+	defer pool.Close()
+	pool.setClientDialerForTest(dialer)
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		openaiWSPool:     pool,
+		toolCorrector:    NewCodexToolCorrector(),
+	}
+	account := &Account{
+		ID:          104,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{"access_token": "oauth-token"},
+		Extra: map[string]any{
+			"responses_websockets_v2_enabled": true,
+		},
+	}
+	store := svc.getOpenAIWSStateStore()
+	probeCalled := false
+	probeRecorder := &openAIWSWriteProbeRecorder{ResponseRecorder: httptest.NewRecorder()}
+	probeRecorder.beforeFirstWrite = func() {
+		probeCalled = true
+		boundAccountID, err := store.GetResponseAccount(context.Background(), 0, "resp_sse_visible")
+		require.NoError(t, err)
+		require.Equal(t, account.ID, boundAccountID, "response account affinity must exist before the ID becomes visible")
+		connID, ok := store.GetResponseConn("resp_sse_visible")
+		require.True(t, ok, "response connection affinity must exist before the ID becomes visible")
+
+		ap, ok := pool.getAccountPool(account.ID)
+		require.True(t, ok)
+		ap.mu.Lock()
+		expiresAt, pinned := ap.timedResponsePins[connID]
+		ap.mu.Unlock()
+		require.True(t, pinned, "the owning connection must be retained before the ID becomes visible")
+		require.True(t, expiresAt.After(time.Now()))
+	}
+
+	c, _ := gin.CreateTestContext(probeRecorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+	c.Request.Header.Set("User-Agent", "custom-client/1.0")
+	c.Request.Header.Set("session_id", "sse-session")
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	result, err := svc.Forward(
+		context.Background(),
+		c,
+		account,
+		[]byte(`{"model":"gpt-5.1","stream":true,"input":"hello"}`),
+	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.False(t, result.OpenAIWSMode, "HTTP 入站应保持 HTTP 转发")
-	require.NotNil(t, upstream.lastReq, "HTTP 入站应命中 HTTP 上游")
-	require.False(t, gjson.GetBytes(upstream.lastBody, "previous_response_id").Exists(), "HTTP 路径应沿用原逻辑移除 previous_response_id")
-
-	decision, _ := c.Get("openai_ws_transport_decision")
-	reason, _ := c.Get("openai_ws_transport_reason")
-	require.Equal(t, string(OpenAIUpstreamTransportHTTPSSE), decision)
-	require.Equal(t, "client_protocol_http", reason)
+	require.Equal(t, "resp_sse_visible", result.RequestID)
+	require.True(t, probeCalled)
+	require.Contains(t, probeRecorder.Body.String(), `"type":"response.created"`)
+	require.Contains(t, probeRecorder.Body.String(), `"type":"response.completed"`)
+	boundAccountID, err := store.GetResponseAccount(context.Background(), 0, "resp_sse_visible")
+	require.NoError(t, err)
+	require.Equal(t, account.ID, boundAccountID, "terminal completion must refresh the provisional account binding")
+	connID, ok := store.GetResponseConn("resp_sse_visible")
+	require.True(t, ok, "terminal completion must refresh the provisional connection binding")
+	ap, ok := pool.getAccountPool(account.ID)
+	require.True(t, ok)
+	ap.mu.Lock()
+	expiresAt := ap.timedResponsePins[connID]
+	ap.mu.Unlock()
+	require.True(t, expiresAt.After(time.Now()), "terminal completion must refresh the connection retention TTL")
 }
 
 func TestOpenAIGatewayService_Forward_HTTPIngressRetriesInvalidEncryptedContentOnce(t *testing.T) {
@@ -257,11 +612,11 @@ func TestOpenAIGatewayService_Forward_HTTPIngressRetriesInvalidEncryptedContentO
 
 	firstBody := upstream.bodies[0]
 	secondBody := upstream.bodies[1]
-	require.False(t, gjson.GetBytes(firstBody, "previous_response_id").Exists(), "HTTP 首次请求仍应沿用原逻辑移除 previous_response_id")
+	require.Equal(t, "resp_http_retry", gjson.GetBytes(firstBody, "previous_response_id").String(), "HTTP 首次请求应保留 previous_response_id")
 	require.True(t, gjson.GetBytes(firstBody, "input.0.encrypted_content").Exists(), "首次请求不应做发送前预清理")
 	require.Equal(t, "keep me", gjson.GetBytes(firstBody, "input.0.summary.0.text").String())
 
-	require.False(t, gjson.GetBytes(secondBody, "previous_response_id").Exists(), "HTTP 精确重试不应重新带回 previous_response_id")
+	require.Equal(t, "resp_http_retry", gjson.GetBytes(secondBody, "previous_response_id").String(), "HTTP 精确重试应保留 previous_response_id")
 	require.False(t, gjson.GetBytes(secondBody, "input.0.encrypted_content").Exists(), "精确重试应移除 reasoning.encrypted_content")
 	require.Equal(t, "keep me", gjson.GetBytes(secondBody, "input.0.summary.0.text").String(), "精确重试应保留有效 reasoning summary")
 	require.Equal(t, "input_text", gjson.GetBytes(secondBody, "input.1.type").String(), "非 reasoning input 应保持原样")
@@ -356,7 +711,7 @@ func TestOpenAIGatewayService_Forward_HTTPIngressRetriesWrappedInvalidEncryptedC
 	require.Equal(t, "client_protocol_http", reason)
 }
 
-func TestOpenAIGatewayService_Forward_RemovePreviousResponseIDWhenWSDisabled(t *testing.T) {
+func TestOpenAIGatewayService_Forward_PreservePreviousResponseIDWhenWSDisabled(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	wsFallbackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
@@ -409,7 +764,7 @@ func TestOpenAIGatewayService_Forward_RemovePreviousResponseIDWhenWSDisabled(t *
 	result, err := svc.Forward(context.Background(), c, account, body)
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	require.False(t, gjson.GetBytes(upstream.lastBody, "previous_response_id").Exists())
+	require.Equal(t, "resp_123", gjson.GetBytes(upstream.lastBody, "previous_response_id").String())
 }
 
 func TestOpenAIGatewayService_Forward_WSv2Dial426FallbackHTTP(t *testing.T) {


### PR DESCRIPTION
## Summary

- accept string or `null` `previous_response_id` values on REST `POST /v1/responses` while continuing to reject message/item IDs and invalid JSON types
- preserve non-empty IDs for native Responses API-key accounts over HTTP JSON/SSE
- expose eligible standard OAuth WSv2 accounts through the existing REST JSON/SSE facade from the first turn, keeping each continuation on the account and connection that produced the ID
- return `400 previous_response_not_found` for unknown, expired, cross-group, or connection-lost IDs instead of dropping the ID or failing over to another account
- retain OAuth response connections for the response-affinity TTL, bounded by `max_conns_per_account`, including independent REST sessions when the concurrency-derived pool limit is lower than the hard cap
- keep `function_call_output.call_id` validation strict when a continuation ID is present

This fixes the downstream regression reported in Lingtai-AI/lingtai-kernel#859, where LingTai had to replay the complete canonical history because sub2api rejected REST continuation IDs as WSv2-only.

OpenAI documents `previous_response_id` as the HTTP conversation-state mechanism, with WebSocket mode using the same continuation semantics: https://developers.openai.com/api/docs/guides/conversation-state#passing-context-from-the-previous-response

## Compatibility

| Account path | REST behavior |
| --- | --- |
| Native Responses API key | Keep HTTP JSON/SSE and forward the non-empty ID |
| Standard OAuth with Responses WSv2 enabled | Bridge REST JSON/SSE to the existing WSv2 forwarder and enforce account/connection affinity |
| OAuth PAT or Agent Identity | Do not opt into the REST-to-WSv2 bridge |

OAuth connection bindings remain process-local because the upstream response state is owned by a live WebSocket connection. A missing local connection therefore fails explicitly with `previous_response_not_found`; it never drifts to a new connection or account. Deployments with multiple sub2api instances should keep an active response chain on the same instance.

## Validation

- `go test ./internal/handler ./internal/service -count=1`
- `go test -tags=unit ./internal/handler ./internal/service -count=1`
- `go vet ./internal/handler ./internal/service`
- focused `go test -race` coverage for response connection retention, TTL refresh/cleanup, dynamic and Mode Router pool limits, and REST OAuth `A -> B -> A` continuation
- `git diff --check`

Fixes #2133
