### PR TITLE
修复分组描述换行与下拉框溢出

### DIFF
--- a/frontend/src/components/common/GroupOptionItem.vue
+++ b/frontend/src/components/common/GroupOptionItem.vue
@@ -16,7 +16,7 @@
       <!-- Row 2: description with top spacing -->
       <span
         v-if="description"
-        class="mt-1.5 w-full text-left text-xs leading-relaxed text-gray-500 dark:text-gray-400 line-clamp-2"
+        class="mt-1.5 w-full whitespace-pre-line [overflow-wrap:anywhere] text-left text-xs leading-relaxed text-gray-500 dark:text-gray-400 line-clamp-3"
       >
         {{ description }}
       </span>

--- a/frontend/src/components/common/Select.vue
+++ b/frontend/src/components/common/Select.vue
@@ -184,6 +184,7 @@ const dropdownRef = ref<HTMLElement | null>(null)
 const optionsListRef = ref<HTMLElement | null>(null)
 const dropdownPosition = ref<'bottom' | 'top'>('bottom')
 const triggerRect = ref<DOMRect | null>(null)
+const dropdownViewportPadding = 8
 
 // i18n placeholders
 const placeholderText = computed(() => props.placeholder ?? t('common.selectOption'))
@@ -200,10 +201,14 @@ const dropdownStyle = computed(() => {
   if (!triggerRect.value) return {}
 
   const rect = triggerRect.value
+  const left = Math.max(dropdownViewportPadding, rect.left)
+  const availableWidth = Math.max(0, window.innerWidth - left - dropdownViewportPadding)
+  const minWidth = Math.min(rect.width, availableWidth)
   const style: Record<string, string> = {
     position: 'fixed',
-    left: `${rect.left}px`,
-    minWidth: `${rect.width}px`,
+    left: `${left}px`,
+    minWidth: `${minWidth}px`,
+    maxWidth: `${availableWidth}px`,
     zIndex: '100000020'
   }
 

--- a/frontend/src/components/common/Select.vue
+++ b/frontend/src/components/common/Select.vue
@@ -185,6 +185,7 @@ const optionsListRef = ref<HTMLElement | null>(null)
 const dropdownPosition = ref<'bottom' | 'top'>('bottom')
 const triggerRect = ref<DOMRect | null>(null)
 const dropdownViewportPadding = 8
+const dropdownMinimumWidth = 200
 
 // i18n placeholders
 const placeholderText = computed(() => props.placeholder ?? t('common.selectOption'))
@@ -201,9 +202,14 @@ const dropdownStyle = computed(() => {
   if (!triggerRect.value) return {}
 
   const rect = triggerRect.value
-  const left = Math.max(dropdownViewportPadding, rect.left)
-  const availableWidth = Math.max(0, window.innerWidth - left - dropdownViewportPadding)
-  const minWidth = Math.min(rect.width, availableWidth)
+  const viewportRight = Math.max(dropdownViewportPadding, window.innerWidth - dropdownViewportPadding)
+  const left = Math.min(
+    Math.max(dropdownViewportPadding, rect.left),
+    viewportRight
+  )
+  const availableWidth = Math.max(0, viewportRight - left)
+  const preferredMinWidth = Math.max(dropdownMinimumWidth, rect.width)
+  const minWidth = Math.min(preferredMinWidth, availableWidth)
   const style: Record<string, string> = {
     position: 'fixed',
     left: `${left}px`,

--- a/frontend/src/components/common/__tests__/GroupOptionItem.spec.ts
+++ b/frontend/src/components/common/__tests__/GroupOptionItem.spec.ts
@@ -1,0 +1,44 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it, vi } from 'vitest'
+
+import GroupOptionItem from '../GroupOptionItem.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  }
+})
+
+vi.mock('@/stores/app', () => ({
+  useAppStore: () => ({ cachedPublicSettings: null }),
+}))
+
+describe('GroupOptionItem description layout', () => {
+  it('applies multiline and overflow-safe text styles', () => {
+    const description = 'First section\nvery-long-unbroken-description-value-that-must-not-overflow'
+    const wrapper = mount(GroupOptionItem, {
+      props: {
+        name: 'Example group',
+        platform: 'openai',
+        description,
+      },
+      global: {
+        stubs: {
+          GroupBadge: true,
+        },
+      },
+    })
+
+    const descriptionElement = wrapper
+      .findAll('span')
+      .find((element) => element.text() === description)
+
+    expect(descriptionElement).toBeDefined()
+    expect(descriptionElement?.classes()).toContain('whitespace-pre-line')
+    expect(descriptionElement?.classes()).toContain('[overflow-wrap:anywhere]')
+    expect(descriptionElement?.classes()).toContain('line-clamp-3')
+    expect(wrapper.find('[title]').attributes('title')).toBe(description)
+  })
+})

--- a/frontend/src/components/common/__tests__/Select.spec.ts
+++ b/frontend/src/components/common/__tests__/Select.spec.ts
@@ -1,0 +1,63 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { nextTick } from 'vue'
+
+import Select from '../Select.vue'
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  }
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+})
+
+describe('Select dropdown viewport constraints', () => {
+  it('limits the teleported dropdown to the available viewport width', async () => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      value: 320,
+    })
+
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+      x: 220,
+      y: 20,
+      top: 20,
+      right: 300,
+      bottom: 60,
+      left: 220,
+      width: 80,
+      height: 40,
+      toJSON: () => ({}),
+    })
+
+    const wrapper = mount(Select, {
+      props: {
+        modelValue: null,
+        options: [
+          {
+            value: 'example',
+            label: 'very-long-unbroken-option-value-that-must-not-overflow',
+          },
+        ],
+      },
+    })
+
+    await wrapper.get('button').trigger('click')
+    await nextTick()
+
+    const dropdown = document.body.querySelector<HTMLElement>('.select-dropdown-portal')
+
+    expect(dropdown).not.toBeNull()
+    expect(dropdown?.style.left).toBe('220px')
+    expect(dropdown?.style.minWidth).toBe('80px')
+    expect(dropdown?.style.maxWidth).toBe('92px')
+
+    wrapper.unmount()
+  })
+})

--- a/frontend/src/components/common/__tests__/Select.spec.ts
+++ b/frontend/src/components/common/__tests__/Select.spec.ts
@@ -12,52 +12,104 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
+const originalInnerWidth = window.innerWidth
+let unmountWrapper: (() => void) | undefined
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    value: width,
+  })
+}
+
+const mockTriggerRect = (left: number, width: number) => {
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    x: left,
+    y: 20,
+    top: 20,
+    right: left + width,
+    bottom: 60,
+    left,
+    width,
+    height: 40,
+    toJSON: () => ({}),
+  })
+}
+
+const openSelect = async () => {
+  const wrapper = mount(Select, {
+    props: {
+      modelValue: null,
+      options: [
+        {
+          value: 'example',
+          label: 'very-long-unbroken-option-value-that-must-not-overflow',
+        },
+      ],
+    },
+  })
+  unmountWrapper = () => wrapper.unmount()
+
+  await wrapper.get('button').trigger('click')
+  await nextTick()
+
+  return document.body.querySelector<HTMLElement>('.select-dropdown-portal')
+}
+
 afterEach(() => {
+  unmountWrapper?.()
+  unmountWrapper = undefined
   document.body.innerHTML = ''
+  setViewportWidth(originalInnerWidth)
   vi.restoreAllMocks()
 })
 
 describe('Select dropdown viewport constraints', () => {
-  it('limits the teleported dropdown to the available viewport width', async () => {
-    Object.defineProperty(window, 'innerWidth', {
-      configurable: true,
-      value: 320,
-    })
+  it('preserves the existing 200px minimum width when space is available', async () => {
+    setViewportWidth(1024)
+    mockTriggerRect(20, 80)
 
-    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
-      x: 220,
-      y: 20,
-      top: 20,
-      right: 300,
-      bottom: 60,
-      left: 220,
-      width: 80,
-      height: 40,
-      toJSON: () => ({}),
-    })
+    const dropdown = await openSelect()
 
-    const wrapper = mount(Select, {
-      props: {
-        modelValue: null,
-        options: [
-          {
-            value: 'example',
-            label: 'very-long-unbroken-option-value-that-must-not-overflow',
-          },
-        ],
-      },
-    })
+    expect(dropdown).not.toBeNull()
+    expect(dropdown?.style.left).toBe('20px')
+    expect(dropdown?.style.minWidth).toBe('200px')
+    expect(dropdown?.style.maxWidth).toBe('996px')
+  })
 
-    await wrapper.get('button').trigger('click')
-    await nextTick()
+  it('shrinks the minimum width to fit near the right viewport edge', async () => {
+    setViewportWidth(320)
+    mockTriggerRect(220, 80)
 
-    const dropdown = document.body.querySelector<HTMLElement>('.select-dropdown-portal')
+    const dropdown = await openSelect()
 
     expect(dropdown).not.toBeNull()
     expect(dropdown?.style.left).toBe('220px')
-    expect(dropdown?.style.minWidth).toBe('80px')
+    expect(dropdown?.style.minWidth).toBe('92px')
     expect(dropdown?.style.maxWidth).toBe('92px')
+  })
 
-    wrapper.unmount()
+  it('clamps a trigger left of the viewport to the safe padding', async () => {
+    setViewportWidth(320)
+    mockTriggerRect(-20, 80)
+
+    const dropdown = await openSelect()
+
+    expect(dropdown).not.toBeNull()
+    expect(dropdown?.style.left).toBe('8px')
+    expect(dropdown?.style.minWidth).toBe('200px')
+    expect(dropdown?.style.maxWidth).toBe('304px')
+  })
+
+  it('clamps an offscreen-right trigger position to the viewport boundary', async () => {
+    setViewportWidth(320)
+    mockTriggerRect(400, 80)
+
+    const dropdown = await openSelect()
+
+    expect(dropdown).not.toBeNull()
+    expect(dropdown?.style.left).toBe('312px')
+    expect(dropdown?.style.minWidth).toBe('0px')
+    expect(dropdown?.style.maxWidth).toBe('0px')
   })
 })


### PR DESCRIPTION
## 修改内容

- 保留分组描述中管理员输入的换行；
- 让没有空格的长字符串在分组选项内安全换行；
- 将分组描述由两行调整为最多三行，并保留现有完整文本提示；
- 根据触发框位置和视口右边界动态限制通用下拉框宽度；
- 新增分组描述样式和下拉框视口边界回归测试。

## 实现说明

分组描述仍使用 Vue 普通文本插值，仅增加以下排版样式：

- `whitespace-pre-line`；
- `[overflow-wrap:anywhere]`；
- `line-clamp-3`。

通用 `Select` 下拉框保留原有按内容自适应宽度的行为，但增加 8px 视口安全边距，并确保 `minWidth` 不会覆盖可用的 `maxWidth`。

没有引入 Markdown/HTML 解析器、`v-html`、新依赖或数据结构变更。

## 验证

- `pnpm exec vitest run src/components/common/__tests__/Select.spec.ts src/components/common/__tests__/GroupOptionItem.spec.ts`
- `pnpm exec eslint src/components/common/Select.vue src/components/common/GroupOptionItem.vue src/components/common/__tests__/Select.spec.ts src/components/common/__tests__/GroupOptionItem.spec.ts`
- `pnpm run typecheck`
- `pnpm run build`

Closes #4923
