### PR TITLE
fix(gateway): 识别被代理的 Claude Code 流量，避免 mimicry 重写破坏 prompt cache

### DIFF
--- a/backend/internal/service/gateway_claude_oauth_body.go
+++ b/backend/internal/service/gateway_claude_oauth_body.go
@@ -1208,3 +1208,28 @@ func (s *GatewayService) claudeOAuthSystemPromptInjectionSettings(ctx context.Co
 	}
 	return s.settingService.GetClaudeOAuthSystemPromptInjectionSettings(ctx)
 }
+
+// systemHasBillingAttributionBlock 检查请求体的 system 字段中是否包含真实 Claude Code
+// 客户端注入的 billing attribution block。该 block 格式稳定（见 gateway_billing_block.go），
+// 仅由真实 Claude Code CLI 生成；第三方客户端（opencode 等）不会生成此 block。
+//
+// 用于识别被上游 API 网关代理的真实 Claude Code 流量：此类请求的 User-Agent 被网关替换
+// 为 Go-http-client，但 body 保留了完整的客户端特征。如果不识别这类请求而走 mimicry
+// 重写 system，会破坏 Anthropic prompt cache 的前缀一致性，导致 messages 级缓存永不命中。
+func systemHasBillingAttributionBlock(body []byte) bool {
+	system := gjson.GetBytes(body, "system")
+	if !system.IsArray() {
+		return false
+	}
+	found := false
+	system.ForEach(func(_, item gjson.Result) bool {
+		text := item.Get("text").String()
+		if strings.HasPrefix(text, claudeCodeBillingHeaderPrefix) &&
+			strings.Contains(text, claudeCodeEntrypointMarker) {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}

--- a/backend/internal/service/gateway_forward.go
+++ b/backend/internal/service/gateway_forward.go
@@ -170,6 +170,17 @@ func (s *GatewayService) Forward(ctx context.Context, c *gin.Context, account *A
 		clientUserAgent = c.GetHeader("User-Agent")
 	}
 	isClaudeCode := IsClaudeCodeClient(ctx) || isClaudeCodeClient(clientUserAgent, parsed.MetadataUserID)
+
+	// 补充判定：上游 API 网关（如 new-api）转发真实 Claude Code 流量时，
+	// UA 会变成 Go-http-client 但 body 保留了完整的 Claude Code 特征
+	// （billing attribution block + metadata.user_id）。此时如果仍走 mimicry
+	// 重写 system prompt，会破坏 Anthropic prompt cache 的前缀匹配——
+	// 导致 messages 级缓存永远 miss、cache_creation 每轮全量重写。
+	// 通过检查 body 中的 billing attribution block 来识别被代理的真实 CC 流量。
+	if !isClaudeCode && parsed.MetadataUserID != "" {
+		isClaudeCode = systemHasBillingAttributionBlock(body)
+	}
+
 	shouldMimicClaudeCode := account.IsOAuth() && !isClaudeCode
 
 	if shouldMimicClaudeCode {


### PR DESCRIPTION
## 问题

当上游 API 网关转发真实 Claude Code 请求到 sub2api 时，`User-Agent` 会变成 `Go-http-client/2.0`（Go 默认 HTTP client），但请求体保留了完整的 Claude Code 特征（billing attribution block、`metadata.user_id`、`cache_control` 断点）。

当前 OAuth mimicry 路径仅通过 UA 判断是否为 Claude Code 客户端。UA 不匹配时，网关会重写 `system` 字段——替换客户端精心构造的 system blocks 和 `cache_control` 断点。

**这会彻底破坏 Anthropic prompt cache 的前缀匹配。** 因为缓存 key 的评估顺序是 `tools → system → messages`，system 一旦变化，后面所有 messages 的缓存全部失效。

### 影响

- `cache_read` 永远锁死在 ~25K tokens（仅 tools 部分被缓存命中）
- `cache_creation` 每轮单调递增，对话历史全量重写
- 单次请求费用远超正常水平

### 根因

```
客户端 Claude Code → 上游网关（UA 变成 Go-http-client）→ sub2api
                                                           ↓
                                             UA 不匹配 → 判定为第三方客户端
                                                           ↓
                                             重写 system（替换为 billing+短版 CC prompt）
                                                           ↓
                                             system 字节不同 → Anthropic cache prefix 断裂
                                                           ↓
                                             messages 缓存永远不命中 → 每轮全量 cache_creation
```

## 修复

在 `isClaudeCode` 判定链中增加 body 级检测：当 UA 不匹配但 `metadata.user_id` 存在时，检查 system 字段是否包含有效的 billing attribution block（`x-anthropic-billing-header` + `cc_entrypoint=`）。如果包含，说明是被网关代理的真实 Claude Code 流量，跳过 mimicry 分支。

这样做是安全的，因为：
- billing attribution block 只有真实 Claude Code CLI 会生成
- 第三方客户端（opencode 等）不会生成此 block，仍然走正常 mimicry 流程
- 不依赖 UA 这种容易被中间环节覆盖的信号

## 改动

- `gateway_forward.go`：在 UA 检测之后增加 body 级 Claude Code 识别
- `gateway_claude_oauth_body.go`：新增 `systemHasBillingAttributionBlock()` helper

## 测试验证

1. UA = `claude-cli/*` 的请求继续跳过 mimicry（无回归）
2. UA = `Go-http-client` + 带 billing attribution block → 正确跳过 mimicry
3. UA = `Go-http-client` + 无 billing block（真正的第三方客户端）→ 仍进入 mimicry