### PR TITLE
feat(openai): support targeted reset credit redemption

### DIFF
--- a/backend/internal/handler/admin/openai_oauth_handler.go
+++ b/backend/internal/handler/admin/openai_oauth_handler.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
@@ -426,6 +427,75 @@ func (h *OpenAIOAuthHandler) QueryQuota(c *gin.Context) {
 		return
 	}
 	response.Success(c, usage)
+}
+
+// QueryResetCredits returns admin-only reset-credit details, including the
+// opaque IDs required for targeted redemption.
+// GET /api/v1/admin/openai/accounts/:id/reset-credits
+func (h *OpenAIOAuthHandler) QueryResetCredits(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+	if h.quotaService == nil {
+		response.BadRequest(c, "openai quota service is not enabled")
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	credits, err := h.quotaService.QueryResetCredits(c.Request.Context(), accountID)
+	if err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	response.Success(c, credits)
+}
+
+// ConsumeResetCreditRequest selects the opaque reset-credit ID to redeem.
+type ConsumeResetCreditRequest struct {
+	CreditID string `json:"credit_id"`
+}
+
+// ConsumeResetCredit consumes a selected reset credit using a caller-provided
+// idempotency key. The same key must be reused when retrying the request.
+// POST /api/v1/admin/openai/accounts/:id/reset-credits/consume
+func (h *OpenAIOAuthHandler) ConsumeResetCredit(c *gin.Context) {
+	accountID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+	if err != nil {
+		response.BadRequest(c, "Invalid account ID")
+		return
+	}
+	if h.quotaService == nil {
+		response.BadRequest(c, "openai quota service is not enabled")
+		return
+	}
+	c.Header("Cache-Control", "no-store")
+	idempotencyKey := strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	if idempotencyKey == "" {
+		response.BadRequest(c, "Idempotency-Key header is required")
+		return
+	}
+	var req ConsumeResetCreditRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request: "+err.Error())
+		return
+	}
+	idempotencyPayload := struct {
+		AccountID int64  `json:"account_id"`
+		CreditID  string `json:"credit_id"`
+	}{
+		AccountID: accountID,
+		CreditID:  strings.TrimSpace(req.CreditID),
+	}
+	executeAdminIdempotentJSONFailOpenOnStoreUnavailable(
+		c,
+		"admin.openai.reset_credit.consume",
+		idempotencyPayload,
+		service.DefaultWriteIdempotencyTTL(),
+		func(ctx context.Context) (any, error) {
+			return h.quotaService.ResetCreditByID(ctx, accountID, req.CreditID, idempotencyKey)
+		},
+	)
 }
 
 // CreateShadowRequest is the request body for CreateShadow.

--- a/backend/internal/handler/admin/openai_oauth_handler_spark_shadow_test.go
+++ b/backend/internal/handler/admin/openai_oauth_handler_spark_shadow_test.go
@@ -104,3 +104,36 @@ func TestCreateShadow_BadBody(t *testing.T) {
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
 }
+
+func TestConsumeResetCreditRequiresIdempotencyKey(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIOAuthHandler(nil, &stubAdminService{}, service.NewOpenAIQuotaService(nil, nil, nil, nil))
+	router := gin.New()
+	router.POST("/api/v1/admin/openai/accounts/:id/reset-credits/consume", h.ConsumeResetCredit)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/openai/accounts/42/reset-credits/consume", strings.NewReader(`{"credit_id":"credit-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+}
+
+func TestConsumeResetCreditRequiresCreditID(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	h := NewOpenAIOAuthHandler(nil, &stubAdminService{}, service.NewOpenAIQuotaService(nil, nil, nil, nil))
+	router := gin.New()
+	router.POST("/api/v1/admin/openai/accounts/:id/reset-credits/consume", h.ConsumeResetCredit)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/admin/openai/accounts/42/reset-credits/consume", strings.NewReader(`{"credit_id":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "550e8400-e29b-41d4-a716-446655440000")
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+}

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -434,6 +434,8 @@ func registerOpenAIOAuthRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		openai.POST("/create-from-codex-pat", h.Admin.OpenAIOAuth.CreateAccountFromCodexPAT)
 		openai.GET("/accounts/:id/quota", h.Admin.OpenAIOAuth.QueryQuota)
 		openai.POST("/accounts/:id/reset-quota", h.Admin.OpenAIOAuth.ResetQuota)
+		openai.GET("/accounts/:id/reset-credits", h.Admin.OpenAIOAuth.QueryResetCredits)
+		openai.POST("/accounts/:id/reset-credits/consume", h.Admin.OpenAIOAuth.ConsumeResetCredit)
 	}
 }
 

--- a/backend/internal/service/openai_quota_reset_credits.go
+++ b/backend/internal/service/openai_quota_reset_credits.go
@@ -8,11 +8,16 @@ import (
 )
 
 type openAIRateLimitResetCreditDetailPayload struct {
+	ID             string `json:"id,omitempty"`
 	ExpiresAt      string `json:"expires_at,omitempty"`
 	ExpiresAtCamel string `json:"expiresAt,omitempty"`
+	GrantedAt      string `json:"granted_at,omitempty"`
+	GrantedAtCamel string `json:"grantedAt,omitempty"`
 	ResetType      string `json:"reset_type,omitempty"`
 	ResetTypeCamel string `json:"resetType,omitempty"`
 	Status         string `json:"status,omitempty"`
+	Title          string `json:"title,omitempty"`
+	Description    string `json:"description,omitempty"`
 }
 
 type openAIRateLimitResetCreditDetailsPayload struct {
@@ -29,6 +34,7 @@ type openAIRateLimitResetCreditDetails struct {
 	AvailableCreditCount int
 	CreditListPresent    bool
 	Credits              []OpenAIRateLimitResetCreditDetail
+	SelectableCredits    []OpenAIRateLimitResetCredit
 }
 
 func parseOpenAIRateLimitResetCreditDetails(body []byte) (openAIRateLimitResetCreditDetails, error) {
@@ -64,6 +70,7 @@ func parseOpenAIRateLimitResetCreditDetails(body []byte) (openAIRateLimitResetCr
 	}
 
 	credits := make([]OpenAIRateLimitResetCreditDetail, 0, len(rawCredits))
+	selectableCredits := make([]OpenAIRateLimitResetCredit, 0, len(rawCredits))
 	availableCreditCount := 0
 	for _, raw := range rawCredits {
 		if raw == nil {
@@ -76,25 +83,57 @@ func parseOpenAIRateLimitResetCreditDetails(body []byte) (openAIRateLimitResetCr
 		if resetType != "" && !strings.EqualFold(resetType, "codex_rate_limits") {
 			continue
 		}
-		if status := strings.TrimSpace(raw.Status); status != "" && !strings.EqualFold(status, "available") {
+		status := strings.TrimSpace(raw.Status)
+		if status != "" && !strings.EqualFold(status, "available") {
 			continue
+		}
+		if resetType == "" {
+			resetType = "codex_rate_limits"
+		}
+		if status == "" {
+			status = "available"
 		}
 		availableCreditCount++
 		expiresAt := strings.TrimSpace(raw.ExpiresAt)
 		if expiresAt == "" {
 			expiresAt = strings.TrimSpace(raw.ExpiresAtCamel)
 		}
-		if expiresAt == "" {
+		if expiresAt != "" {
+			credits = append(credits, OpenAIRateLimitResetCreditDetail{ExpiresAt: expiresAt})
+		}
+
+		id := strings.TrimSpace(raw.ID)
+		if id == "" {
 			continue
 		}
-		credits = append(credits, OpenAIRateLimitResetCreditDetail{ExpiresAt: expiresAt})
+		grantedAt := strings.TrimSpace(raw.GrantedAt)
+		if grantedAt == "" {
+			grantedAt = strings.TrimSpace(raw.GrantedAtCamel)
+		}
+		selectableCredits = append(selectableCredits, OpenAIRateLimitResetCredit{
+			ID:          id,
+			ResetType:   resetType,
+			Status:      status,
+			GrantedAt:   grantedAt,
+			ExpiresAt:   optionalString(expiresAt),
+			Title:       strings.TrimSpace(raw.Title),
+			Description: strings.TrimSpace(raw.Description),
+		})
 	}
 	return openAIRateLimitResetCreditDetails{
 		AvailableCount:       availableCount,
 		AvailableCreditCount: availableCreditCount,
 		CreditListPresent:    creditListPresent,
 		Credits:              credits,
+		SelectableCredits:    selectableCredits,
 	}, nil
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
 }
 
 func parseOpenAIResetCreditAvailableCount(values ...json.RawMessage) *int {

--- a/backend/internal/service/openai_quota_reset_credits_test.go
+++ b/backend/internal/service/openai_quota_reset_credits_test.go
@@ -14,8 +14,8 @@ func TestParseOpenAIRateLimitResetCreditDetails_PreservesAvailableCreditOrder(t 
 		"availableCount":"2",
 		"credits":[
 			{"reset_type":"codex_rate_limits","status":"redeemed","expires_at":"2026-07-01T04:05:06Z"},
-			{"reset_type":"codex_rate_limits","status":"available","expires_at":"2026-07-04T04:05:06Z"},
-			{"resetType":"codex_rate_limits","status":"available","expiresAt":"2026-07-03T04:05:06Z"},
+			{"id":"credit-2","reset_type":"codex_rate_limits","status":"available","granted_at":"2026-06-04T04:05:06Z","expires_at":"2026-07-04T04:05:06Z","title":"Weekly reset"},
+			{"id":"credit-1","resetType":"codex_rate_limits","status":"available","grantedAt":"2026-06-03T04:05:06Z","expiresAt":"2026-07-03T04:05:06Z","description":"Ready"},
 			{"reset_type":"other","status":"available","expires_at":"2026-07-02T04:05:06Z"}
 		]
 	}`)
@@ -28,6 +28,13 @@ func TestParseOpenAIRateLimitResetCreditDetails_PreservesAvailableCreditOrder(t 
 		{ExpiresAt: "2026-07-04T04:05:06Z"},
 		{ExpiresAt: "2026-07-03T04:05:06Z"},
 	}, details.Credits)
+	require.Len(t, details.SelectableCredits, 2)
+	require.Equal(t, "credit-2", details.SelectableCredits[0].ID)
+	require.Equal(t, "2026-06-04T04:05:06Z", details.SelectableCredits[0].GrantedAt)
+	require.Equal(t, "2026-07-04T04:05:06Z", *details.SelectableCredits[0].ExpiresAt)
+	require.Equal(t, "Weekly reset", details.SelectableCredits[0].Title)
+	require.Equal(t, "credit-1", details.SelectableCredits[1].ID)
+	require.Equal(t, "Ready", details.SelectableCredits[1].Description)
 }
 
 func TestQueryUsageResetCreditCountPrecedence(t *testing.T) {

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -74,6 +74,28 @@ type OpenAIRateLimitResetCredits struct {
 	Credits        []OpenAIRateLimitResetCreditDetail `json:"credits,omitempty"`
 }
 
+// OpenAIRateLimitResetCredit is the admin-only projection of an available
+// reset credit. Its opaque ID is intentionally excluded from OpenAIQuotaUsage.
+type OpenAIRateLimitResetCredit struct {
+	ID          string  `json:"id"`
+	ResetType   string  `json:"reset_type"`
+	Status      string  `json:"status"`
+	GrantedAt   string  `json:"granted_at,omitempty"`
+	ExpiresAt   *string `json:"expires_at"`
+	Title       string  `json:"title,omitempty"`
+	Description string  `json:"description,omitempty"`
+}
+
+// OpenAIRateLimitResetCreditList is returned only by the dedicated admin API.
+// DetailsComplete is false when upstream reports more available credits than
+// it returned, or when an available row lacks the opaque ID needed to consume it.
+type OpenAIRateLimitResetCreditList struct {
+	AvailableCount  int                          `json:"available_count"`
+	Credits         []OpenAIRateLimitResetCredit `json:"credits"`
+	DetailsComplete bool                         `json:"details_complete"`
+	FetchedAt       int64                        `json:"fetched_at"`
+}
+
 // OpenAIQuotaUsage is the typed projection of /wham/usage we expose to the UI.
 // Fields not relevant to the quota card are intentionally omitted to keep the
 // surface narrow; full upstream payload preservation is unnecessary.
@@ -206,28 +228,56 @@ func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*
 	return &payload, nil
 }
 
-func (s *OpenAIQuotaService) queryResetCreditDetails(ctx context.Context, client *req.Client, accessToken, chatGPTAccountID string, fedRAMP bool, accountID int64) *openAIRateLimitResetCreditDetails {
-	quotaHeaders, _, headerErr := s.buildCodexQuotaHeaders(ctx, accountID, accessToken, chatGPTAccountID, fedRAMP)
-	if headerErr != nil {
-		slog.Warn("openai_quota_reset_credit_details_auth_failed", "account_id", accountID, "error", headerErr)
-		return nil
-	}
-	resp, err := client.R().
-		SetContext(ctx).
-		SetHeaders(quotaHeaders).
-		Get(chatGPTRateLimitCreditsURL)
-	if err != nil {
-		slog.Warn("openai_quota_reset_credit_details_failed", "account_id", accountID, "error", err)
-		return nil
-	}
-	if !resp.IsSuccessState() {
-		slog.Warn("openai_quota_reset_credit_details_failed", "account_id", accountID, "status", resp.StatusCode)
-		return nil
+// QueryResetCredits returns available reset-credit details for automation and
+// other admin clients. Unlike QueryUsage, this method fails closed when the
+// upstream detail list is unavailable or malformed.
+func (s *OpenAIQuotaService) QueryResetCredits(ctx context.Context, accountID int64) (*OpenAIRateLimitResetCreditList, error) {
+	if err := s.validateResetCreditAccount(ctx, accountID); err != nil {
+		return nil, err
 	}
 
-	details, err := parseOpenAIRateLimitResetCreditDetails(resp.Bytes())
+	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
 	if err != nil {
-		slog.Warn("openai_quota_reset_credit_details_parse_failed", "account_id", accountID, "error", err)
+		return nil, err
+	}
+	client, err := s.privacyClientFactory(proxyURL)
+	if err != nil {
+		return nil, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_CLIENT_ERROR", "failed to build upstream client: %v", err)
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, openaiQuotaUpstreamTimeout)
+	defer cancel()
+	details, err := s.requestResetCreditDetails(callCtx, client, accessToken, chatGPTAccountID, fedRAMP, accountID)
+	if err != nil {
+		slog.Warn("openai_quota_reset_credit_details_failed", "account_id", accountID, "error", err)
+		return nil, err
+	}
+	if !details.CreditListPresent {
+		return nil, infraerrors.New(http.StatusBadGateway, "OPENAI_QUOTA_RESET_CREDITS_INCOMPLETE", "upstream did not return reset-credit details")
+	}
+
+	availableCount := details.AvailableCreditCount
+	detailsComplete := details.AvailableCreditCount == len(details.SelectableCredits)
+	if details.AvailableCount != nil {
+		availableCount = *details.AvailableCount
+		detailsComplete = detailsComplete && availableCount == details.AvailableCreditCount
+	}
+	credits := details.SelectableCredits
+	if credits == nil {
+		credits = make([]OpenAIRateLimitResetCredit, 0)
+	}
+	return &OpenAIRateLimitResetCreditList{
+		AvailableCount:  availableCount,
+		Credits:         credits,
+		DetailsComplete: detailsComplete,
+		FetchedAt:       time.Now().Unix(),
+	}, nil
+}
+
+func (s *OpenAIQuotaService) queryResetCreditDetails(ctx context.Context, client *req.Client, accessToken, chatGPTAccountID string, fedRAMP bool, accountID int64) *openAIRateLimitResetCreditDetails {
+	details, err := s.requestResetCreditDetails(ctx, client, accessToken, chatGPTAccountID, fedRAMP, accountID)
+	if err != nil {
+		slog.Warn("openai_quota_reset_credit_details_failed", "account_id", accountID, "error", err)
 		if details.AvailableCount == nil {
 			return nil
 		}
@@ -238,10 +288,85 @@ func (s *OpenAIQuotaService) queryResetCreditDetails(ctx context.Context, client
 	return &details
 }
 
+func (s *OpenAIQuotaService) requestResetCreditDetails(ctx context.Context, client *req.Client, accessToken, chatGPTAccountID string, fedRAMP bool, accountID int64) (openAIRateLimitResetCreditDetails, error) {
+	agentIdentity := s.isAgentIdentityAccount(ctx, accountID)
+	for recovered := false; ; {
+		quotaHeaders, expectedTaskID, headerErr := s.buildCodexQuotaHeaders(ctx, accountID, accessToken, chatGPTAccountID, fedRAMP)
+		if headerErr != nil {
+			return openAIRateLimitResetCreditDetails{}, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_AUTH_FAILED", "failed to build upstream authentication: %v", headerErr)
+		}
+		resp, err := client.R().
+			SetContext(ctx).
+			SetHeaders(quotaHeaders).
+			Get(chatGPTRateLimitCreditsURL)
+		if err != nil {
+			return openAIRateLimitResetCreditDetails{}, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_RESET_CREDITS_REQUEST_FAILED", "upstream request failed: %v", err)
+		}
+		if !resp.IsSuccessState() {
+			if agentIdentity && !recovered && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, []byte(resp.String())) {
+				recovered = true
+				if err := s.recoverAgentIdentityTask(ctx, accountID, expectedTaskID); err != nil {
+					return openAIRateLimitResetCreditDetails{}, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_AUTH_FAILED", "agent identity task recovery failed: %v", err)
+				}
+				continue
+			}
+			status := resp.StatusCode
+			body := truncate(s.redactQuotaErrorBody(ctx, accountID, resp.String()), 240)
+			return openAIRateLimitResetCreditDetails{}, infraerrors.Newf(mapUpstreamStatus(status), "OPENAI_QUOTA_RESET_CREDITS_UPSTREAM_ERROR", "upstream returned %d: %s", status, body)
+		}
+
+		details, err := parseOpenAIRateLimitResetCreditDetails(resp.Bytes())
+		if err != nil {
+			return details, infraerrors.Newf(http.StatusBadGateway, "OPENAI_QUOTA_RESET_CREDITS_PARSE_ERROR", "failed to parse upstream reset-credit details: %v", err)
+		}
+		return details, nil
+	}
+}
+
 // ResetCredit consumes one rate_limit_reset_credit for the given OpenAI account.
 // The redeem_request_id is auto-generated (uuid-like) — upstream uses it for
 // idempotency. Returns the consumed credit metadata so the UI can refresh.
 func (s *OpenAIQuotaService) ResetCredit(ctx context.Context, accountID int64) (*OpenAIQuotaResetResult, error) {
+	return s.consumeResetCredit(ctx, accountID, "", "")
+}
+
+// ResetCreditByID consumes the selected credit and forwards the caller's
+// idempotency key unchanged. Callers must reuse that key for retries of the
+// same logical redemption attempt.
+func (s *OpenAIQuotaService) ResetCreditByID(ctx context.Context, accountID int64, creditID, redeemRequestID string) (*OpenAIQuotaResetResult, error) {
+	creditID = strings.TrimSpace(creditID)
+	if creditID == "" {
+		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_CREDIT_ID_REQUIRED", "credit_id is required")
+	}
+	var err error
+	redeemRequestID, err = NormalizeIdempotencyKey(redeemRequestID)
+	if err != nil {
+		return nil, err
+	}
+	if redeemRequestID == "" {
+		return nil, infraerrors.New(http.StatusBadRequest, "OPENAI_QUOTA_IDEMPOTENCY_KEY_REQUIRED", "Idempotency-Key is required")
+	}
+	return s.consumeResetCredit(ctx, accountID, redeemRequestID, creditID)
+}
+
+func (s *OpenAIQuotaService) validateResetCreditAccount(ctx context.Context, accountID int64) error {
+	if s == nil || s.accountRepo == nil {
+		return infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota service is not configured")
+	}
+	acc, err := s.accountRepo.GetByID(ctx, accountID)
+	if err != nil {
+		return infraerrors.Newf(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found: %v", err)
+	}
+	if acc == nil {
+		return infraerrors.New(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found")
+	}
+	if acc.IsShadow() {
+		return ErrSparkShadowResetNotSupported
+	}
+	return nil
+}
+
+func (s *OpenAIQuotaService) consumeResetCredit(ctx context.Context, accountID int64, redeemRequestID, creditID string) (*OpenAIQuotaResetResult, error) {
 	// Shadow guard: resetting credits via a shadow account would silently
 	// operate on the parent's quota; that is surprising and unwanted. Callers
 	// must reset the parent account directly.
@@ -250,24 +375,19 @@ func (s *OpenAIQuotaService) ResetCredit(ctx context.Context, accountID int64) (
 	// must NOT fall through to prepareUpstreamCall. That function resolves a
 	// shadow to its parent and would perform a parent-level reset — exactly
 	// what this guard must prevent. Return the load error instead.
-	if s.accountRepo != nil {
-		acc, loadErr := s.accountRepo.GetByID(ctx, accountID)
-		if loadErr != nil {
-			return nil, infraerrors.Newf(http.StatusNotFound, "OPENAI_QUOTA_ACCOUNT_NOT_FOUND", "account not found: %v", loadErr)
-		}
-		if acc.IsShadow() {
-			return nil, ErrSparkShadowResetNotSupported
-		}
+	if err := s.validateResetCreditAccount(ctx, accountID); err != nil {
+		return nil, err
 	}
 
 	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
 	if err != nil {
 		return nil, err
 	}
-
-	redeemRequestID, err := generateRedeemRequestID()
-	if err != nil {
-		return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_QUOTA_REDEEM_ID_FAILED", "failed to generate redeem id: %v", err)
+	if redeemRequestID == "" {
+		redeemRequestID, err = generateRedeemRequestID()
+		if err != nil {
+			return nil, infraerrors.Newf(http.StatusInternalServerError, "OPENAI_QUOTA_REDEEM_ID_FAILED", "failed to generate redeem id: %v", err)
+		}
 	}
 
 	client, err := s.privacyClientFactory(proxyURL)
@@ -278,6 +398,10 @@ func (s *OpenAIQuotaService) ResetCredit(ctx context.Context, accountID int64) (
 	callCtx, cancel := context.WithTimeout(ctx, openaiQuotaUpstreamTimeout)
 	defer cancel()
 	agentIdentity := s.isAgentIdentityAccount(ctx, accountID)
+	body := map[string]string{"redeem_request_id": redeemRequestID}
+	if creditID != "" {
+		body["credit_id"] = creditID
+	}
 
 	var payload OpenAIQuotaResetResult
 	for recovered := false; ; {
@@ -289,7 +413,7 @@ func (s *OpenAIQuotaService) ResetCredit(ctx context.Context, accountID int64) (
 		resp, err := client.R().
 			SetContext(callCtx).
 			SetHeaders(headers).
-			SetBody(map[string]string{"redeem_request_id": redeemRequestID}).
+			SetBody(body).
 			SetSuccessResult(&payload).
 			Post(chatGPTRateLimitResetURL)
 		if err != nil {
@@ -321,7 +445,7 @@ func (s *OpenAIQuotaService) ResetCredit(ctx context.Context, accountID int64) (
 
 // prepareUpstreamCall loads the account, validates it, obtains a fresh access
 // token via the shared TokenProvider, and resolves the chatgpt-account-id and
-// proxy URL. Centralized so QueryUsage / ResetCredit share validation.
+// proxy URL. Centralized so quota query and reset operations share validation.
 func (s *OpenAIQuotaService) prepareUpstreamCall(ctx context.Context, accountID int64) (accessToken, chatGPTAccountID, proxyURL string, fedRAMP bool, err error) {
 	if s == nil || s.accountRepo == nil || s.privacyClientFactory == nil {
 		return "", "", "", false, infraerrors.New(http.StatusInternalServerError, "OPENAI_QUOTA_NOT_CONFIGURED", "openai quota service is not configured")

--- a/backend/internal/service/openai_quota_targeted_reset_test.go
+++ b/backend/internal/service/openai_quota_targeted_reset_test.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func newTargetedResetTestService(t *testing.T, handler http.HandlerFunc) *OpenAIQuotaService {
+	t.Helper()
+	account := &Account{
+		ID:       100,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"chatgpt_account_id": "account-targeted-reset",
+		},
+	}
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{account.ID: account}}
+	tokenCache := &stubQuotaTokenCache{tokens: map[string]string{
+		OpenAITokenCacheKey(account): "fake-token",
+	}}
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return NewOpenAIQuotaService(repo, nil, NewOpenAITokenProvider(repo, tokenCache, nil), newQuotaRedirectingFactory(server))
+}
+
+func TestQueryResetCreditsReturnsAdminDetails(t *testing.T) {
+	service := newTargetedResetTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/wham/rate-limit-reset-credits", r.URL.Path)
+		require.Equal(t, "account-targeted-reset", r.Header.Get("ChatGPT-Account-ID"))
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"available_count":2,
+			"credits":[
+				{"id":"credit-earliest","reset_type":"codex_rate_limits","status":"available","granted_at":"2026-06-17T00:00:00Z","expires_at":"2026-07-17T00:00:00Z","title":"Full reset","description":"Ready"},
+				{"id":"credit-no-expiry","reset_type":"codex_rate_limits","status":"available","granted_at":"2026-06-18T00:00:00Z","expires_at":null}
+			]
+		}`))
+	})
+
+	result, err := service.QueryResetCredits(context.Background(), 100)
+	require.NoError(t, err)
+	require.Equal(t, 2, result.AvailableCount)
+	require.True(t, result.DetailsComplete)
+	require.Positive(t, result.FetchedAt)
+	require.Len(t, result.Credits, 2)
+	require.Equal(t, "credit-earliest", result.Credits[0].ID)
+	require.Equal(t, "available", result.Credits[0].Status)
+	require.Equal(t, "2026-07-17T00:00:00Z", *result.Credits[0].ExpiresAt)
+	require.Equal(t, "Full reset", result.Credits[0].Title)
+	require.Nil(t, result.Credits[1].ExpiresAt)
+}
+
+func TestQueryResetCreditsMarksIncompleteDetails(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "upstream caps detail rows",
+			body: `{"available_count":2,"credits":[{"id":"credit-1","status":"available"}]}`,
+		},
+		{
+			name: "available row lacks id",
+			body: `{"available_count":1,"credits":[{"status":"available","expires_at":"2026-07-17T00:00:00Z"}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := newTargetedResetTestService(t, func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("content-type", "application/json")
+				_, _ = w.Write([]byte(test.body))
+			})
+			result, err := service.QueryResetCredits(context.Background(), 100)
+			require.NoError(t, err)
+			require.False(t, result.DetailsComplete)
+		})
+	}
+}
+
+func TestQueryResetCreditsFailsClosedWithoutDetailList(t *testing.T) {
+	service := newTargetedResetTestService(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"available_count":1}`))
+	})
+
+	result, err := service.QueryResetCredits(context.Background(), 100)
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadGateway, infraerrors.Code(err))
+}
+
+func TestResetCreditByIDForwardsStableIdempotencyKey(t *testing.T) {
+	var bodies []map[string]string
+	service := newTargetedResetTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/backend-api/wham/rate-limit-reset-credits/consume", r.URL.Path)
+		var body map[string]string
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		bodies = append(bodies, body)
+		w.Header().Set("content-type", "application/json")
+		if len(bodies) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"error":"temporary"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"code":"reset","windows_reset":2}`))
+	})
+
+	const idempotencyKey = "550e8400-e29b-41d4-a716-446655440000"
+	_, err := service.ResetCreditByID(context.Background(), 100, "credit-earliest", idempotencyKey)
+	require.Error(t, err)
+	result, err := service.ResetCreditByID(context.Background(), 100, "credit-earliest", idempotencyKey)
+	require.NoError(t, err)
+	require.Equal(t, "reset", result.Code)
+	require.Equal(t, 2, result.WindowsReset)
+	require.Equal(t, []map[string]string{
+		{"redeem_request_id": idempotencyKey, "credit_id": "credit-earliest"},
+		{"redeem_request_id": idempotencyKey, "credit_id": "credit-earliest"},
+	}, bodies)
+}
+
+func TestResetCreditLegacyRequestOmitsCreditID(t *testing.T) {
+	var body map[string]string
+	service := newTargetedResetTestService(t, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(`{"code":"reset","windows_reset":1}`))
+	})
+
+	_, err := service.ResetCredit(context.Background(), 100)
+	require.NoError(t, err)
+	require.NotEmpty(t, body["redeem_request_id"])
+	require.NotContains(t, body, "credit_id")
+}
+
+func TestResetCreditByIDValidatesInputs(t *testing.T) {
+	tests := []struct {
+		name           string
+		creditID       string
+		idempotencyKey string
+	}{
+		{name: "missing credit id", idempotencyKey: "key"},
+		{name: "missing idempotency key", creditID: "credit"},
+		{name: "idempotency key too long", creditID: "credit", idempotencyKey: strings.Repeat("k", 129)},
+		{name: "idempotency key contains whitespace", creditID: "credit", idempotencyKey: "key\nvalue"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			service := &OpenAIQuotaService{}
+			_, err := service.ResetCreditByID(context.Background(), 100, test.creditID, test.idempotencyKey)
+			require.Error(t, err)
+			require.Equal(t, http.StatusBadRequest, infraerrors.Code(err))
+		})
+	}
+}
+
+func TestTargetedResetOperationsRejectShadowAccount(t *testing.T) {
+	parentID := int64(100)
+	shadow := &Account{
+		ID:              200,
+		ParentAccountID: &parentID,
+		Platform:        PlatformOpenAI,
+		Type:            AccountTypeOAuth,
+		QuotaDimension:  QuotaDimensionSpark,
+	}
+	service := &OpenAIQuotaService{accountRepo: &stubQuotaAccountRepo{accounts: map[int64]*Account{shadow.ID: shadow}}}
+
+	_, err := service.QueryResetCredits(context.Background(), shadow.ID)
+	require.ErrorIs(t, err, ErrSparkShadowResetNotSupported)
+	_, err = service.ResetCreditByID(context.Background(), shadow.ID, "credit", "key")
+	require.ErrorIs(t, err, ErrSparkShadowResetNotSupported)
+}


### PR DESCRIPTION
## Summary

- add an admin-only endpoint that returns available Codex reset credits with their opaque IDs and expiration metadata
- add targeted reset-credit redemption with a caller-provided `Idempotency-Key` forwarded as the upstream `redeem_request_id`
- reuse the existing admin idempotency coordinator while failing open to the upstream idempotency contract if the local store is unavailable
- preserve the existing quota response sanitization and legacy `/reset-quota` behavior

## Notes

- no database migration or frontend change is required
- `details_complete` is false when upstream caps the returned rows or an available credit lacks the ID required for targeted redemption
- reset-credit IDs are exposed only through the authenticated admin route, responses use `Cache-Control: no-store`, and IDs/idempotency keys are not logged
- the request and response fields follow the official Codex reset-credit client contract: https://github.com/openai/codex/blob/main/codex-rs/backend-client/src/client/rate_limit_resets.rs

## Tests

- `go test -tags=unit ./internal/service -run 'Test(QueryResetCredits|ResetCreditByID|ResetCreditLegacyRequest|TargetedResetOperations|ParseOpenAIRateLimitResetCreditDetails|QueryUsageResetCredit)' -count=1`
- `go test -tags=unit ./internal/handler/admin ./internal/server/routes ./internal/server -count=1`
- `go vet -tags=unit ./internal/service ./internal/handler/admin ./internal/server/routes`
- `git diff --check`

Full `go test -tags=unit ./... -count=1` was also attempted on Windows. The changed packages pass, but the repository baseline still has a Windows path failure in `TestResolvePageImagePath`; the unrelated timing-sensitive `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig` can fail under package-wide load and passes when rerun alone.
