### PR TITLE
fix: isolate OAuth responses input token counting

### DIFF
--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -15,20 +15,21 @@ import (
 // ──────────────────────────────────────────────────────────
 
 const (
-	EndpointMessages          = "/v1/messages"
-	EndpointChatCompletions   = "/v1/chat/completions"
-	EndpointEmbeddings        = "/v1/embeddings"
-	EndpointAlphaSearch       = "/v1/alpha/search"
-	EndpointResponses         = "/v1/responses"
-	EndpointResponsesCompact  = "/v1/responses/compact"
-	EndpointImagesGenerations = "/v1/images/generations"
-	EndpointImagesEdits       = "/v1/images/edits"
-	EndpointImageTasks        = "/v1/images/tasks"
-	EndpointVideosGenerations = "/v1/videos/generations"
-	EndpointVideosEdits       = "/v1/videos/edits"
-	EndpointVideosExtensions  = "/v1/videos/extensions"
-	EndpointVideos            = "/v1/videos"
-	EndpointGeminiModels      = "/v1beta/models"
+	EndpointMessages             = "/v1/messages"
+	EndpointChatCompletions      = "/v1/chat/completions"
+	EndpointEmbeddings           = "/v1/embeddings"
+	EndpointAlphaSearch          = "/v1/alpha/search"
+	EndpointResponses            = "/v1/responses"
+	EndpointResponsesInputTokens = "/v1/responses/input_tokens"
+	EndpointResponsesCompact     = "/v1/responses/compact"
+	EndpointImagesGenerations    = "/v1/images/generations"
+	EndpointImagesEdits          = "/v1/images/edits"
+	EndpointImageTasks           = "/v1/images/tasks"
+	EndpointVideosGenerations    = "/v1/videos/generations"
+	EndpointVideosEdits          = "/v1/videos/edits"
+	EndpointVideosExtensions     = "/v1/videos/extensions"
+	EndpointVideos               = "/v1/videos"
+	EndpointGeminiModels         = "/v1beta/models"
 )
 
 // gin.Context keys used by the middleware and helpers below.
@@ -99,6 +100,8 @@ func NormalizeInboundEndpoint(path string) string {
 		return EndpointVideosExtensions
 	case strings.Contains(path, EndpointVideos) || strings.Contains(path, "/videos/"):
 		return EndpointVideos
+	case strings.Contains(path, EndpointResponsesInputTokens) || isResponsesInputTokensAliasPath(path):
+		return EndpointResponsesInputTokens
 	case strings.Contains(path, EndpointResponsesCompact) || isResponsesCompactAliasPath(path):
 		return EndpointResponsesCompact
 	case strings.Contains(path, EndpointResponses) || isResponsesRootAliasPath(path):
@@ -108,6 +111,18 @@ func NormalizeInboundEndpoint(path string) string {
 	default:
 		return path
 	}
+}
+
+// isResponsesInputTokensAliasPath reports whether path is one of the
+// Responses input-token count aliases exposed without the canonical /v1
+// prefix.
+func isResponsesInputTokensAliasPath(path string) bool {
+	trimmed := strings.TrimRight(strings.TrimSpace(path), "/")
+	if trimmed == "" {
+		return false
+	}
+	return trimmed == "/responses/input_tokens" ||
+		trimmed == "/backend-api/codex/responses/input_tokens"
 }
 
 // isResponsesCompactAliasPath reports whether path is the bare/alias
@@ -182,7 +197,7 @@ func DeriveUpstreamEndpoint(inbound, rawRequestPath, platform string) string {
 
 	switch platform {
 	case service.PlatformOpenAI, service.PlatformGrok:
-		if inbound == EndpointEmbeddings || inbound == EndpointAlphaSearch || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits || inbound == EndpointVideosGenerations || inbound == EndpointVideosEdits || inbound == EndpointVideosExtensions || inbound == EndpointVideos {
+		if inbound == EndpointEmbeddings || inbound == EndpointAlphaSearch || inbound == EndpointResponsesInputTokens || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits || inbound == EndpointVideosGenerations || inbound == EndpointVideosEdits || inbound == EndpointVideosExtensions || inbound == EndpointVideos {
 			return inbound
 		}
 		// OpenAI forwards everything to the Responses API.

--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -27,6 +27,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/v1/embeddings", EndpointEmbeddings},
 		{"/v1/alpha/search", EndpointAlphaSearch},
 		{"/v1/responses", EndpointResponses},
+		{"/v1/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/v1/responses/compact", EndpointResponsesCompact},
 		{"/v1/responses/compact/detail", EndpointResponsesCompact},
 		{"/v1/images/generations", EndpointImagesGenerations},
@@ -39,6 +40,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		// Prefixed paths (antigravity, openai) — root Responses.
 		{"/antigravity/v1/messages", EndpointMessages},
 		{"/openai/v1/responses", EndpointResponses},
+		{"/openai/v1/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/openai/v1/images/generations", EndpointImagesGenerations},
 		{"/openai/v1/images/edits", EndpointImagesEdits},
 		{"/antigravity/v1beta/models/gemini:generateContent", EndpointGeminiModels},
@@ -50,6 +52,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 
 		// Bare top-level alias route "/responses" — root vs. compact.
 		{"/responses", EndpointResponses},
+		{"/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/responses/compact", EndpointResponsesCompact},
 		{"/responses/compact/detail", EndpointResponsesCompact},
 		{"/alpha/search", EndpointAlphaSearch},
@@ -57,6 +60,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 
 		// Bare Codex direct alias route — root vs. compact.
 		{"/backend-api/codex/responses", EndpointResponses},
+		{"/backend-api/codex/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/backend-api/codex/responses/compact", EndpointResponsesCompact},
 		{"/backend-api/codex/responses/compact/detail", EndpointResponsesCompact},
 		{"/backend-api/codex/alpha/search", EndpointAlphaSearch},
@@ -100,6 +104,9 @@ func TestDeriveUpstreamEndpoint(t *testing.T) {
 
 		// OpenAI — root Responses.
 		{"openai responses root", EndpointResponses, "/v1/responses", service.PlatformOpenAI, EndpointResponses},
+		{"openai responses input tokens", EndpointResponsesInputTokens, "/v1/responses/input_tokens", service.PlatformOpenAI, EndpointResponsesInputTokens},
+		{"openai bare responses input tokens", EndpointResponsesInputTokens, "/responses/input_tokens", service.PlatformOpenAI, EndpointResponsesInputTokens},
+		{"openai codex direct input tokens", EndpointResponsesInputTokens, "/backend-api/codex/responses/input_tokens", service.PlatformOpenAI, EndpointResponsesInputTokens},
 
 		// OpenAI — compact, raw path carries the derivable "/compact"
 		// (or nested) suffix, which must be preserved on the upstream
@@ -211,12 +218,15 @@ func TestResponsesSubpathSuffix(t *testing.T) {
 		{"/v1/responses", ""},
 		{"/v1/responses/", ""},
 		{"/v1/responses/compact", "/compact"},
+		{"/v1/responses/input_tokens", "/input_tokens"},
 		{"/openai/v1/responses/compact/detail", "/compact/detail"},
 		{"/responses", ""},
 		{"/responses/compact", "/compact"},
+		{"/responses/input_tokens", "/input_tokens"},
 		{"/responses/compact/detail", "/compact/detail"},
 		{"/backend-api/codex/responses", ""},
 		{"/backend-api/codex/responses/compact", "/compact"},
+		{"/backend-api/codex/responses/input_tokens", "/input_tokens"},
 		{"/backend-api/codex/responses/compact/detail", "/compact/detail"},
 		{"/v1/messages", ""},
 		{"", ""},

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
@@ -53,6 +54,129 @@ func (h *OpenAIGatewayHandler) GrokCountTokens(c *gin.Context) {
 	setOpsRequestContext(c, parsedReq.Model, false)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(false, false)))
 	c.JSON(http.StatusOK, gin.H{"input_tokens": estimated})
+}
+
+// InputTokens handles OpenAI-compatible POST /v1/responses/input_tokens.
+// It deliberately selects and calls only one account: token counting is an
+// auxiliary request and must not fan out across accounts or mutate account
+// scheduling state when an OAuth upstream rejects the endpoint.
+func (h *OpenAIGatewayHandler) InputTokens(c *gin.Context) {
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusUnauthorized, "authentication_error", "Invalid API key")
+		return
+	}
+
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusInternalServerError, "api_error", "User context not found")
+		return
+	}
+	reqLog := requestLogger(
+		c,
+		"handler.openai_gateway.input_tokens",
+		zap.Int64("user_id", subject.UserID),
+		zap.Int64("api_key_id", apiKey.ID),
+		zap.Any("group_id", apiKey.GroupID),
+	)
+	if !h.ensureResponsesDependencies(c, reqLog) {
+		return
+	}
+
+	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
+	if err != nil {
+		if maxErr, ok := extractMaxBytesError(err); ok {
+			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
+			return
+		}
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body")
+		return
+	}
+	if len(body) == 0 {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Request body is empty")
+		return
+	}
+	if !gjson.ValidBytes(body) {
+		logRequestBodyParseFailure(reqLog, body, nil)
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+		return
+	}
+
+	modelResult := gjson.GetBytes(body, "model")
+	if !modelResult.Exists() || modelResult.Type != gjson.String || modelResult.String() == "" {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "model is required")
+		return
+	}
+	reqModel := modelResult.String()
+	ensureCompositeTargetPlatform(c, apiKey, reqModel)
+	if !compositeTargetPlatformAllowed(c, apiKey, reqModel, service.PlatformOpenAI) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Model is not supported by this OpenAI endpoint for composite groups")
+		return
+	}
+
+	reqLog = reqLog.With(zap.String("model", reqModel))
+	setOpsRequestContext(c, reqModel, false)
+	setOpsEndpointContext(c, "", int16(service.RequestTypeSync))
+
+	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
+	forwardBody := openAIModelMappedBody(body, channelMapping.Mapped, channelMapping.MappedModel, h.gatewayService.ReplaceModelInBody)
+
+	subscription, _ := middleware2.GetSubscriptionFromContext(c)
+	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription, service.QuotaPlatform(c.Request.Context(), apiKey)); err != nil {
+		reqLog.Info("openai_input_tokens.billing_eligibility_check_failed", zap.Error(err))
+		status, code, message, retryAfter := billingErrorDetails(err)
+		if retryAfter > 0 {
+			c.Header("Retry-After", strconv.Itoa(retryAfter))
+		}
+		h.errorResponse(c, status, code, message)
+		return
+	}
+
+	requestStart := time.Now()
+	sessionHash := h.gatewayService.GenerateSessionHash(c, body)
+	routingModel := service.NormalizeOpenAICompatRequestedModel(reqModel)
+	selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+		c.Request.Context(),
+		apiKey.GroupID,
+		"",
+		sessionHash,
+		routingModel,
+		nil,
+		service.OpenAIUpstreamTransportAny,
+		service.OpenAIEndpointCapabilityChatCompletions,
+		false,
+		false,
+		false,
+		service.PlatformOpenAI,
+	)
+	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+	if err != nil {
+		reqLog.Warn("openai_input_tokens.account_select_failed", zap.Error(openAICompatibleSelectionErrorForLog(err, service.PlatformOpenAI)))
+		cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, routingModel, reqModel)
+		if !cls.ModelNotFound {
+			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+		}
+		h.errorResponse(c, cls.Status, cls.ErrType, cls.Message)
+		return
+	}
+	if selection == nil || selection.Account == nil {
+		cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, routingModel, reqModel)
+		if !cls.ModelNotFound {
+			markOpsRoutingCapacityLimited(c)
+		}
+		h.errorResponse(c, cls.Status, cls.ErrType, cls.Message)
+		return
+	}
+
+	account := selection.Account
+	setOpsSelectedAccount(c, account.ID, account.Platform)
+	if selection.Acquired && selection.ReleaseFunc != nil {
+		defer selection.ReleaseFunc()
+	}
+
+	if err := h.gatewayService.ForwardInputTokens(c.Request.Context(), c, account, forwardBody); err != nil {
+		reqLog.Warn("openai_input_tokens.forward_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+	}
 }
 
 // CountTokens handles Anthropic-compatible POST /v1/messages/count_tokens for OpenAI groups.

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1249,7 +1249,13 @@ func isCountTokensRequest(c *gin.Context) bool {
 	if c == nil || c.Request == nil || c.Request.URL == nil {
 		return false
 	}
-	return strings.Contains(c.Request.URL.Path, "/count_tokens")
+	return isCountTokensPath(c.Request.URL.Path)
+}
+
+func isCountTokensPath(path string) bool {
+	normalized := strings.TrimRight(strings.TrimSpace(path), "/")
+	return strings.Contains(normalized, "/count_tokens") ||
+		strings.HasSuffix(normalized, "/responses/input_tokens")
 }
 
 func applyOpsLatencyFieldsFromContext(c *gin.Context, entry *service.OpsInsertErrorLogInput) {
@@ -1774,7 +1780,7 @@ func shouldSkipOpsErrorLog(ctx context.Context, ops *service.OpsService, message
 	bodyLower := strings.ToLower(body)
 
 	// Check if count_tokens errors should be ignored
-	if settings.IgnoreCountTokensErrors && strings.Contains(requestPath, "/count_tokens") {
+	if settings.IgnoreCountTokensErrors && isCountTokensPath(requestPath) {
 		return true
 	}
 

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -1191,6 +1191,19 @@ func TestSetOpsEndpointContext_NilContext(t *testing.T) {
 	})
 }
 
+func TestIsCountTokensPathIncludesResponsesInputTokensAliases(t *testing.T) {
+	for _, path := range []string{
+		"/v1/messages/count_tokens",
+		"/v1/responses/input_tokens",
+		"/responses/input_tokens",
+		"/backend-api/codex/responses/input_tokens",
+		"/v1/responses/input_tokens/",
+	} {
+		require.True(t, isCountTokensPath(path), "path=%s", path)
+	}
+	require.False(t, isCountTokensPath("/v1/responses"), "normal Responses requests are not token-count probes")
+}
+
 func TestGetOpsAPIKeyFallsBackToOpsFallbackKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -66,6 +66,19 @@ func RegisterGatewayRoutes(
 			h.Gateway.CountTokens(c)
 		}
 	}
+	responsesInputTokensHandler := func(c *gin.Context) {
+		if isOpenAIGatewayPlatform(c) {
+			h.OpenAIGateway.InputTokens(c)
+			return
+		}
+		service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": gin.H{
+				"type":    "not_found_error",
+				"message": "Responses input token counting is only available for OpenAI groups",
+			},
+		})
+	}
 	modelsHandler := func(c *gin.Context) {
 		if isOpenAIGatewayPlatform(c) && c.Query("client_version") != "" {
 			h.OpenAIGateway.CodexModels(c)
@@ -191,6 +204,10 @@ func RegisterGatewayRoutes(
 			h.Gateway.Responses(c)
 		})
 		gateway.POST("/responses/*subpath", func(c *gin.Context) {
+			if handler.GetInboundEndpoint(c) == handler.EndpointResponsesInputTokens {
+				responsesInputTokensHandler(c)
+				return
+			}
 			if isOpenAIResponsesCompatibleGatewayPlatform(c) {
 				h.OpenAIGateway.Responses(c)
 				return
@@ -268,8 +285,15 @@ func RegisterGatewayRoutes(
 		}
 		h.Gateway.Responses(c)
 	}
+	responsesSubpathHandler := func(c *gin.Context) {
+		if handler.GetInboundEndpoint(c) == handler.EndpointResponsesInputTokens {
+			responsesInputTokensHandler(c)
+			return
+		}
+		responsesHandler(c)
+	}
 	r.POST("/responses", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, responsesHandler)
-	r.POST("/responses/*subpath", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, responsesHandler)
+	r.POST("/responses/*subpath", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, responsesSubpathHandler)
 	r.POST("/alpha/search", textBodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, h.OpenAIGateway.AlphaSearch)
 	r.GET("/responses", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, func(c *gin.Context) {
 		h.OpenAIGateway.ResponsesWebSocket(c)
@@ -282,7 +306,7 @@ func RegisterGatewayRoutes(
 		codexDirect.POST("/realtime/calls", h.OpenAIGateway.Live)
 		codexDirect.GET("/:call_id", h.OpenAIGateway.LiveSideband)
 		codexDirect.POST("/responses", responsesHandler)
-		codexDirect.POST("/responses/*subpath", responsesHandler)
+		codexDirect.POST("/responses/*subpath", responsesSubpathHandler)
 		codexDirect.POST("/alpha/search", textBodyLimit, h.OpenAIGateway.AlphaSearch)
 		codexDirect.GET("/responses", func(c *gin.Context) {
 			h.OpenAIGateway.ResponsesWebSocket(c)

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -76,6 +76,24 @@ func TestGatewayRoutesOpenAIResponsesCompactPathIsRegistered(t *testing.T) {
 	}
 }
 
+func TestGatewayRoutesOpenAIResponsesInputTokensPathsUseDedicatedHandler(t *testing.T) {
+	router := newGatewayRoutesTestRouter(service.PlatformGrok)
+
+	for _, path := range []string{
+		"/v1/responses/input_tokens",
+		"/responses/input_tokens",
+		"/backend-api/codex/responses/input_tokens",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"gpt-5"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, "path=%s should reach the dedicated input_tokens handler", path)
+		require.Contains(t, w.Body.String(), "only available for OpenAI groups")
+	}
+}
+
 func TestGatewayRoutesOpenAIAlphaSearchPathsAreRegistered(t *testing.T) {
 	router := newGatewayRoutesTestRouter()
 	registered := make(map[string]bool)

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -8,9 +8,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 	"github.com/tiktoken-go/tokenizer"
@@ -21,6 +23,9 @@ const (
 	openAIResponsesInputItemTokenOverhead = 3
 	openAIResponsesContentPartOverhead    = 1
 	openAIInputTokensFallbackMinimum      = 1
+	openAIInputTokensSourceHeader         = "X-Sub2API-Input-Tokens-Source"
+	openAIInputTokensSourceUpstream       = "upstream"
+	openAIInputTokensSourceLocalFallback  = "local-fallback"
 )
 
 type openAIInputTokensCountRequest struct {
@@ -37,6 +42,180 @@ type openAIInputTokensCountPrepared struct {
 	NormalizedModel string
 	BillingModel    string
 	UpstreamModel   string
+}
+
+type openAIDirectInputTokensPrepared struct {
+	Request       openAIInputTokensCountRequest
+	UpstreamBody  []byte
+	OriginalModel string
+	UpstreamModel string
+}
+
+// ForwardInputTokens forwards a direct Responses input-token count request
+// through exactly one selected account. OAuth 401/403/404 responses fall back
+// locally without invoking generic rate-limit/account-state handling.
+func (s *OpenAIGatewayService) ForwardInputTokens(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+) error {
+	if account == nil {
+		writeOpenAIInputTokensError(c, http.StatusServiceUnavailable, "api_error", "No available OpenAI accounts")
+		return fmt.Errorf("input_tokens: missing account")
+	}
+
+	prepared, err := s.prepareDirectOpenAIInputTokensRequest(body, account)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+		return err
+	}
+
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to get access token")
+		return fmt.Errorf("get input_tokens access token: %w", err)
+	}
+
+	isCodexCLI := openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator")) ||
+		(s.cfg != nil && s.cfg.Gateway.ForceCodexCLI)
+	promptCacheKey := strings.TrimSpace(gjson.GetBytes(prepared.UpstreamBody, "prompt_cache_key").String())
+	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, prepared.UpstreamBody, token, false, promptCacheKey, isCodexCLI)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusInternalServerError, "api_error", "Failed to build request")
+		return fmt.Errorf("build direct input_tokens request: %w", err)
+	}
+	// The generic Responses builder defaults OAuth requests to SSE. This
+	// subresource is unary JSON, so override Accept after all common headers
+	// have been assembled.
+	upstreamReq.Header.Set("accept", "application/json")
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		writeOpenAIInputTokensError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+		return fmt.Errorf("direct input_tokens upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to read response")
+		return fmt.Errorf("read direct input_tokens response: %w", err)
+	}
+
+	if account.Type == AccountTypeOAuth && isOpenAIDirectInputTokensFallbackStatus(resp.StatusCode) {
+		writeOpenAIDirectInputTokensFallback(c, account, prepared, resp.StatusCode)
+		return nil
+	}
+
+	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Header(openAIInputTokensSourceHeader, openAIInputTokensSourceUpstream)
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	c.Data(resp.StatusCode, contentType, respBody)
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+		upstreamDetail := ""
+		if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+			maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+			if maxBytes <= 0 {
+				maxBytes = 2048
+			}
+			upstreamDetail = truncateString(string(respBody), maxBytes)
+		}
+		setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
+		if upstreamMsg == "" {
+			return fmt.Errorf("direct input_tokens upstream error: %d", resp.StatusCode)
+		}
+		return fmt.Errorf("direct input_tokens upstream error: %d message=%s", resp.StatusCode, upstreamMsg)
+	}
+
+	return nil
+}
+
+func (s *OpenAIGatewayService) prepareDirectOpenAIInputTokensRequest(body []byte, account *Account) (*openAIDirectInputTokensPrepared, error) {
+	var req openAIInputTokensCountRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("parse direct input_tokens request: %w", err)
+	}
+	req.Model = strings.TrimSpace(req.Model)
+	if req.Model == "" {
+		return nil, fmt.Errorf("parse direct input_tokens request: model is required")
+	}
+
+	originalModel := req.Model
+	normalizedModel := NormalizeOpenAICompatRequestedModel(originalModel)
+	billingModel := resolveOpenAIForwardModel(account, normalizedModel, "")
+	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
+	if strings.TrimSpace(upstreamModel) == "" {
+		upstreamModel = normalizedModel
+	}
+	req.Model = upstreamModel
+
+	return &openAIDirectInputTokensPrepared{
+		Request:       req,
+		UpstreamBody:  s.ReplaceModelInBody(body, upstreamModel),
+		OriginalModel: originalModel,
+		UpstreamModel: upstreamModel,
+	}, nil
+}
+
+func isOpenAIDirectInputTokensFallbackStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func writeOpenAIDirectInputTokensFallback(c *gin.Context, account *Account, prepared *openAIDirectInputTokensPrepared, statusCode int) {
+	estimated := openAIInputTokensFallbackMinimum
+	if got, err := estimateOpenAIInputTokens(prepared.Request); err == nil {
+		if got > 0 {
+			estimated = got
+		}
+		logger.L().Info("openai direct input_tokens: oauth fallback to local tiktoken estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("upstream_status", statusCode),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+		)
+	} else {
+		logger.L().Warn("openai direct input_tokens: oauth local tiktoken fallback failed, using minimum estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("upstream_status", statusCode),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+			zap.Error(err),
+		)
+	}
+
+	c.Header(openAIInputTokensSourceHeader, openAIInputTokensSourceLocalFallback)
+	c.JSON(http.StatusOK, gin.H{
+		"object":       "response.input_tokens",
+		"input_tokens": estimated,
+	})
+}
+
+func writeOpenAIInputTokensError(c *gin.Context, status int, errType, message string) {
+	c.JSON(status, gin.H{
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	})
 }
 
 // EstimateGrokCountTokens estimates an Anthropic-compatible count_tokens request

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -37,6 +37,181 @@ func (r *countTokensRuntimeStateRepo) SetError(_ context.Context, _ int64, _ str
 	return nil
 }
 
+func TestOpenAIGatewayService_ForwardInputTokens_OAuthUsesCodexEndpointOnceAndPreservesResult(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","instructions":"Be concise.","input":"hello"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/1.0.0")
+
+	upstreamBody := `{"object":"response.input_tokens","input_tokens":42}`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"X-Request-Id": []string{"req_input_tokens"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	proxyID := int64(901)
+	account := &Account{
+		ID:          401,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-account",
+		},
+		ProxyID: &proxyID,
+		Proxy: &Proxy{
+			ID:       proxyID,
+			Protocol: "http",
+			Host:     "172.31.250.1",
+			Port:     3129,
+			Username: "proxy0001",
+			Password: "proxy-password",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+
+	err := svc.ForwardInputTokens(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, upstreamBody, rec.Body.String())
+	require.Equal(t, openAIInputTokensSourceUpstream, rec.Header().Get(openAIInputTokensSourceHeader))
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "https://chatgpt.com/backend-api/codex/responses/input_tokens", upstream.lastReq.URL.String())
+	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "chatgpt-account", upstream.lastReq.Header.Get("Chatgpt-Account-Id"))
+	require.Equal(t, "http://proxy0001:proxy-password@172.31.250.1:3129", upstream.lastProxyURL)
+}
+
+func TestOpenAIGatewayService_ForwardInputTokens_OAuthAuthAndUnsupportedStatusesFallbackWithoutAccountMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","instructions":"Be concise.","input":"hello"}`)
+	account := &Account{
+		ID:          402,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "oauth-token",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "401",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"missing scope"}}`,
+		},
+		{
+			name:       "generic_html_403",
+			statusCode: http.StatusForbidden,
+			body:       `<html><head><meta http-equiv="refresh" content="360"></head></html>`,
+		},
+		{
+			name:       "404",
+			statusCode: http.StatusNotFound,
+			body:       `{"detail":"Not Found"}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: tt.statusCode,
+				Header:     http.Header{"Content-Type": []string{"text/html"}},
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+			}}
+			repo := &countTokensRuntimeStateRepo{}
+			svc := &OpenAIGatewayService{
+				cfg:              &config.Config{},
+				httpUpstream:     upstream,
+				rateLimitService: &RateLimitService{accountRepo: repo, cfg: &config.Config{}},
+			}
+			prepared, err := svc.prepareDirectOpenAIInputTokensRequest(body, account)
+			require.NoError(t, err)
+			expectedEstimate, err := estimateOpenAIInputTokens(prepared.Request)
+			require.NoError(t, err)
+
+			err = svc.ForwardInputTokens(context.Background(), c, account, body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.JSONEq(t, `{"object":"response.input_tokens","input_tokens":`+strconv.Itoa(expectedEstimate)+`}`, rec.Body.String())
+			require.Equal(t, openAIInputTokensSourceLocalFallback, rec.Header().Get(openAIInputTokensSourceHeader))
+			require.Len(t, upstream.requests, 1, "input_tokens must never switch accounts or retry upstream")
+			require.Zero(t, repo.tempUnschedCalls, "direct OAuth input_tokens errors must not temp-unschedule the account")
+			require.Zero(t, repo.setErrorCalls, "direct OAuth input_tokens errors must not mark the account error")
+		})
+	}
+}
+
+func TestOpenAIGatewayService_ForwardInputTokens_APIKeyUsesPlatformEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hello"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"object":"response.input_tokens","input_tokens":9}`)),
+	}}
+	account := &Account{
+		ID:          403,
+		Name:        "openai-api-key",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-test",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+
+	err := svc.ForwardInputTokens(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, openAIInputTokensSourceUpstream, rec.Header().Get(openAIInputTokensSourceHeader))
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "https://api.openai.com/v1/responses/input_tokens", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer sk-test", upstream.lastReq.Header.Get("Authorization"))
+}
+
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesInputTokens(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## Summary

- route direct Responses `input_tokens` requests to a dedicated OpenAI handler instead of the generic Responses failover loop
- make a single upstream attempt and preserve a successful upstream response
- fall back to local tiktoken estimation for OpenAI OAuth 401/403/404 responses without mutating account scheduling state
- keep API-key accounts on the official `/v1/responses/input_tokens` endpoint
- cover canonical, bare, and Codex-direct aliases and exclude token-counting failures from ops error logging when configured

Gin cannot register an exact child route beside the existing `responses/*subpath` catch-all, so the wildcard remains registered and dispatches `input_tokens` to the dedicated handler after endpoint normalization.

## Behavior

- OAuth upstream success: passed through unchanged
- OAuth 401/403/404: local estimate with `X-Sub2API-Input-Tokens-Source: local-fallback`
- API-key success: passed through with `X-Sub2API-Input-Tokens-Source: upstream`
- no cross-account retry, 403 counter increment, temporary unschedulable state, or usage billing

## Validation

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `golangci-lint run ./...` (v2.9.0)

Fixes #4491
