### PR TITLE
fix(usage): report channel-mapped requests under their real upstream model

### DIFF
--- a/backend/internal/repository/usage_log_repo_breakdown_test.go
+++ b/backend/internal/repository/usage_log_repo_breakdown_test.go
@@ -40,8 +40,8 @@ func TestResolveModelDimensionExpression(t *testing.T) {
 		want      string
 	}{
 		{usagestats.ModelSourceRequested, "COALESCE(NULLIF(TRIM(requested_model), ''), model)"},
-		{usagestats.ModelSourceUpstream, "COALESCE(NULLIF(TRIM(upstream_model), ''), COALESCE(NULLIF(TRIM(requested_model), ''), model))"},
-		{usagestats.ModelSourceMapping, "(COALESCE(NULLIF(TRIM(requested_model), ''), model) || ' -> ' || COALESCE(NULLIF(TRIM(upstream_model), ''), COALESCE(NULLIF(TRIM(requested_model), ''), model)))"},
+		{usagestats.ModelSourceUpstream, "COALESCE(NULLIF(TRIM(upstream_model), ''), model)"},
+		{usagestats.ModelSourceMapping, "(COALESCE(NULLIF(TRIM(requested_model), ''), model) || ' -> ' || COALESCE(NULLIF(TRIM(upstream_model), ''), model))"},
 		{"", "COALESCE(NULLIF(TRIM(requested_model), ''), model)"},
 		{"invalid", "COALESCE(NULLIF(TRIM(requested_model), ''), model)"},
 	}

--- a/backend/internal/repository/usage_log_repo_trend.go
+++ b/backend/internal/repository/usage_log_repo_trend.go
@@ -750,11 +750,12 @@ func resolveModelDimensionExpressionWithAlias(modelType, alias string) string {
 		return alias + "." + name
 	}
 	requestedExpr := fmt.Sprintf("COALESCE(NULLIF(TRIM(%s), ''), %s)", column("requested_model"), column("model"))
+	upstreamExpr := fmt.Sprintf("COALESCE(NULLIF(TRIM(%s), ''), %s)", column("upstream_model"), column("model"))
 	switch usagestats.NormalizeModelSource(modelType) {
 	case usagestats.ModelSourceUpstream:
-		return fmt.Sprintf("COALESCE(NULLIF(TRIM(%s), ''), %s)", column("upstream_model"), requestedExpr)
+		return upstreamExpr
 	case usagestats.ModelSourceMapping:
-		return fmt.Sprintf("(%s || ' -> ' || COALESCE(NULLIF(TRIM(%s), ''), %s))", requestedExpr, column("upstream_model"), requestedExpr)
+		return fmt.Sprintf("(%s || ' -> ' || %s)", requestedExpr, upstreamExpr)
 	default:
 		return requestedExpr
 	}

--- a/backend/internal/service/gateway_record_usage_test.go
+++ b/backend/internal/service/gateway_record_usage_test.go
@@ -223,6 +223,35 @@ func TestGatewayServiceRecordUsage_PreservesChannelMappedUpstreamModel(t *testin
 	require.Equal(t, "gpt-5.6-terra", *usageRepo.lastLog.UpstreamModel)
 }
 
+func TestGatewayServiceRecordUsage_PreservesLoopedChannelAndAccountUpstreamModel(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})
+
+	err := svc.RecordUsage(context.Background(), &RecordUsageInput{
+		Result: &ForwardResult{
+			RequestID:     "gateway_looped_mapping_models",
+			Usage:         ClaudeUsage{InputTokens: 10, OutputTokens: 6},
+			Model:         "gpt-5.6-terra",
+			UpstreamModel: "gpt-5.6-sol",
+			Duration:      time.Second,
+		},
+		APIKey:  &APIKey{ID: 501, Quota: 100},
+		User:    &User{ID: 601},
+		Account: &Account{ID: 701},
+		ChannelUsageFields: ChannelUsageFields{
+			OriginalModel:      "gpt-5.6-sol",
+			ChannelMappedModel: "gpt-5.6-terra",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, "gpt-5.6-sol", usageRepo.lastLog.RequestedModel)
+	require.Equal(t, "gpt-5.6-terra", usageRepo.lastLog.Model)
+	require.NotNil(t, usageRepo.lastLog.UpstreamModel)
+	require.Equal(t, "gpt-5.6-sol", *usageRepo.lastLog.UpstreamModel)
+}
+
 func TestGatewayServiceRecordUsage_EmptyImageSizeDefaultsBeforeBillingAndPersistence(t *testing.T) {
 	imagePrice2K := 0.19
 	groupID := int64(901)

--- a/backend/internal/service/gateway_record_usage_test.go
+++ b/backend/internal/service/gateway_record_usage_test.go
@@ -194,6 +194,35 @@ func TestGatewayServiceRecordUsage_PreservesRequestedAndUpstreamModels(t *testin
 	require.Equal(t, mappedModel, *usageRepo.lastLog.UpstreamModel)
 }
 
+func TestGatewayServiceRecordUsage_PreservesChannelMappedUpstreamModel(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	svc := newGatewayRecordUsageServiceForTest(usageRepo, &openAIRecordUsageUserRepoStub{}, &openAIRecordUsageSubRepoStub{})
+
+	err := svc.RecordUsage(context.Background(), &RecordUsageInput{
+		Result: &ForwardResult{
+			RequestID:     "gateway_channel_mapping_models",
+			Usage:         ClaudeUsage{InputTokens: 10, OutputTokens: 6},
+			Model:         "gpt-5.6-terra",
+			UpstreamModel: "gpt-5.6-terra",
+			Duration:      time.Second,
+		},
+		APIKey:  &APIKey{ID: 501, Quota: 100},
+		User:    &User{ID: 601},
+		Account: &Account{ID: 701},
+		ChannelUsageFields: ChannelUsageFields{
+			OriginalModel:      "gpt-5.6-sol",
+			ChannelMappedModel: "gpt-5.6-terra",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, "gpt-5.6-sol", usageRepo.lastLog.RequestedModel)
+	require.Equal(t, "gpt-5.6-terra", usageRepo.lastLog.Model)
+	require.NotNil(t, usageRepo.lastLog.UpstreamModel)
+	require.Equal(t, "gpt-5.6-terra", *usageRepo.lastLog.UpstreamModel)
+}
+
 func TestGatewayServiceRecordUsage_EmptyImageSizeDefaultsBeforeBillingAndPersistence(t *testing.T) {
 	imagePrice2K := 0.19
 	groupID := int64(901)

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -986,7 +986,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		RequestID:             requestID,
 		Model:                 result.Model,
 		RequestedModel:        requestedModel,
-		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
+		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, requestedModel),
 		ReasoningEffort:       result.ReasoningEffort,
 		InboundEndpoint:       optionalTrimmedStringPtr(input.InboundEndpoint),
 		UpstreamEndpoint:      optionalTrimmedStringPtr(input.UpstreamEndpoint),

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -986,7 +986,7 @@ func (s *GatewayService) buildRecordUsageLog(
 		RequestID:             requestID,
 		Model:                 result.Model,
 		RequestedModel:        requestedModel,
-		UpstreamModel:         optionalNonEqualStringPtr(result.UpstreamModel, requestedModel),
+		UpstreamModel:         optionalTrimmedStringPtr(result.UpstreamModel),
 		ReasoningEffort:       result.ReasoningEffort,
 		InboundEndpoint:       optionalTrimmedStringPtr(input.InboundEndpoint),
 		UpstreamEndpoint:      optionalTrimmedStringPtr(input.UpstreamEndpoint),

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -1335,6 +1335,40 @@ func TestOpenAIGatewayServiceRecordUsage_UsesRequestedModelAndUpstreamModelMetad
 	require.Equal(t, 1, userRepo.deductCalls)
 }
 
+func TestOpenAIGatewayServiceRecordUsage_PreservesChannelMappedUpstreamModel(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	userRepo := &openAIRecordUsageUserRepoStub{}
+	subRepo := &openAIRecordUsageSubRepoStub{}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, userRepo, subRepo, nil)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:     "openai_channel_mapping_models",
+			Model:         "gpt-5.6-terra",
+			UpstreamModel: "gpt-5.6-terra",
+			Usage: OpenAIUsage{
+				InputTokens:  20,
+				OutputTokens: 10,
+			},
+			Duration: time.Second,
+		},
+		APIKey:  &APIKey{ID: 10},
+		User:    &User{ID: 20},
+		Account: &Account{ID: 30},
+		ChannelUsageFields: ChannelUsageFields{
+			OriginalModel:      "gpt-5.6-sol",
+			ChannelMappedModel: "gpt-5.6-terra",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, "gpt-5.6-sol", usageRepo.lastLog.RequestedModel)
+	require.Equal(t, "gpt-5.6-terra", usageRepo.lastLog.Model)
+	require.NotNil(t, usageRepo.lastLog.UpstreamModel)
+	require.Equal(t, "gpt-5.6-terra", *usageRepo.lastLog.UpstreamModel)
+}
+
 func TestOpenAIGatewayServiceRecordUsage_BillsMappedRequestsUsingRequestedModel(t *testing.T) {
 	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
 	userRepo := &openAIRecordUsageUserRepoStub{}

--- a/backend/internal/service/openai_gateway_record_usage_test.go
+++ b/backend/internal/service/openai_gateway_record_usage_test.go
@@ -1369,6 +1369,37 @@ func TestOpenAIGatewayServiceRecordUsage_PreservesChannelMappedUpstreamModel(t *
 	require.Equal(t, "gpt-5.6-terra", *usageRepo.lastLog.UpstreamModel)
 }
 
+func TestOpenAIGatewayServiceRecordUsage_PreservesLoopedChannelAndAccountUpstreamModel(t *testing.T) {
+	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
+	userRepo := &openAIRecordUsageUserRepoStub{}
+	subRepo := &openAIRecordUsageSubRepoStub{}
+	svc := newOpenAIRecordUsageServiceForTest(usageRepo, userRepo, subRepo, nil)
+
+	err := svc.RecordUsage(context.Background(), &OpenAIRecordUsageInput{
+		Result: &OpenAIForwardResult{
+			RequestID:     "openai_looped_mapping_models",
+			Model:         "gpt-5.6-terra",
+			UpstreamModel: "gpt-5.6-sol",
+			Usage:         OpenAIUsage{InputTokens: 20, OutputTokens: 10},
+			Duration:      time.Second,
+		},
+		APIKey:  &APIKey{ID: 10},
+		User:    &User{ID: 20},
+		Account: &Account{ID: 30},
+		ChannelUsageFields: ChannelUsageFields{
+			OriginalModel:      "gpt-5.6-sol",
+			ChannelMappedModel: "gpt-5.6-terra",
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, usageRepo.lastLog)
+	require.Equal(t, "gpt-5.6-sol", usageRepo.lastLog.RequestedModel)
+	require.Equal(t, "gpt-5.6-terra", usageRepo.lastLog.Model)
+	require.NotNil(t, usageRepo.lastLog.UpstreamModel)
+	require.Equal(t, "gpt-5.6-sol", *usageRepo.lastLog.UpstreamModel)
+}
+
 func TestOpenAIGatewayServiceRecordUsage_BillsMappedRequestsUsingRequestedModel(t *testing.T) {
 	usageRepo := &openAIRecordUsageLogRepoStub{inserted: true}
 	userRepo := &openAIRecordUsageUserRepoStub{}

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -256,7 +256,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		RequestID:           requestID,
 		Model:               result.Model,
 		RequestedModel:      requestedModel,
-		UpstreamModel:       optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
+		UpstreamModel:       optionalNonEqualStringPtr(result.UpstreamModel, requestedModel),
 		ServiceTier:         result.ServiceTier,
 		ReasoningEffort:     result.ReasoningEffort,
 		InboundEndpoint:     optionalTrimmedStringPtr(input.InboundEndpoint),

--- a/backend/internal/service/openai_gateway_usage.go
+++ b/backend/internal/service/openai_gateway_usage.go
@@ -256,7 +256,7 @@ func (s *OpenAIGatewayService) RecordUsage(ctx context.Context, input *OpenAIRec
 		RequestID:           requestID,
 		Model:               result.Model,
 		RequestedModel:      requestedModel,
-		UpstreamModel:       optionalNonEqualStringPtr(result.UpstreamModel, requestedModel),
+		UpstreamModel:       optionalTrimmedStringPtr(result.UpstreamModel),
 		ServiceTier:         result.ServiceTier,
 		ReasoningEffort:     result.ReasoningEffort,
 		InboundEndpoint:     optionalTrimmedStringPtr(input.InboundEndpoint),

--- a/backend/internal/service/usage_log_helpers.go
+++ b/backend/internal/service/usage_log_helpers.go
@@ -11,8 +11,8 @@ func optionalTrimmedStringPtr(raw string) *string {
 }
 
 // optionalNonEqualStringPtr returns a pointer to value if it is non-empty and
-// differs from compare; otherwise nil. Used to store upstream_model only when
-// it differs from the requested model.
+// differs from compare; otherwise nil. Usage logging passes the requested
+// model as compare so a channel mapping still records its effective upstream.
 func optionalNonEqualStringPtr(value, compare string) *string {
 	if value == "" || value == compare {
 		return nil

--- a/backend/internal/service/usage_log_helpers.go
+++ b/backend/internal/service/usage_log_helpers.go
@@ -10,16 +10,6 @@ func optionalTrimmedStringPtr(raw string) *string {
 	return &trimmed
 }
 
-// optionalNonEqualStringPtr returns a pointer to value if it is non-empty and
-// differs from compare; otherwise nil. Usage logging passes the requested
-// model as compare so a channel mapping still records its effective upstream.
-func optionalNonEqualStringPtr(value, compare string) *string {
-	if value == "" || value == compare {
-		return nil
-	}
-	return &value
-}
-
 func forwardResultBillingModel(requestedModel, upstreamModel string) string {
 	if trimmed := strings.TrimSpace(requestedModel); trimmed != "" {
 		return trimmed


### PR DESCRIPTION
## Problem

With a channel model mapping configured (`gpt-5.6-sol` → `gpt-5.6-terra`),
requests route and price correctly, but the admin usage breakdowns disagree with
what actually happened upstream. "By upstream model" attributes the traffic to
`gpt-5.6-sol`, and "by mapping" renders it as `gpt-5.6-sol -> gpt-5.6-sol` — as
if no mapping had taken place at all.

The rows behind those aggregates look like this:

```text
requested_model = gpt-5.6-sol     -- what the client asked for
model           = gpt-5.6-terra   -- what was actually forwarded
upstream_model  = NULL            -- dropped
```

`model` already holds the truth. Two independent bugs — one on the write path,
one on the read path — conspire to hide it.

## Root cause 1: the writer drops `upstream_model` exactly when a mapping applied

Both usage-log writers (`GatewayService.buildRecordUsageLog` and
`OpenAIGatewayService.RecordUsage`) stored the column through an equality trim:

```go
UpstreamModel: optionalNonEqualStringPtr(result.UpstreamModel, result.Model),
```

The helper's own comment described the intent as "store `upstream_model` only
when it differs from the requested model", but the value being compared against
is `result.Model` — and after a channel mapping, `result.Model` *is* the mapped
model. So `result.UpstreamModel == result.Model`, and the column is written NULL
in precisely the case where it carries information.

The comparison was harmless while account-level mapping was the only mapping:
there `result.Model` is the requested model and the two readings coincide.
Channel mapping made them diverge, and the guard silently kept following the
wrong one.

## Root cause 2: the read expression falls back to the requested model

`resolveModelDimensionExpressionWithAlias` resolved a missing `upstream_model`
by reaching for `requested_model`:

```sql
-- upstream dimension
COALESCE(NULLIF(TRIM(upstream_model), ''),
         COALESCE(NULLIF(TRIM(requested_model), ''), model))
```

For a channel-mapped row that fallback returns the one value the upstream
model is guaranteed *not* to be, which is what turns the mapping dimension into
`sol -> sol`.

## Fix

**Write path** — store any non-empty `result.UpstreamModel` verbatim:

```go
UpstreamModel: optionalTrimmedStringPtr(result.UpstreamModel),
```

The equality trim is dropped rather than re-based, and the now-unused
`optionalNonEqualStringPtr` helper is deleted. Re-basing it on `requestedModel`
looks like the smaller change, but no comparison basis is correct in every
mapping shape: with channel `sol → terra` followed by an account mapping
`terra → sol`, the final upstream model *is* `sol`, and any equality trim
against the requested model would discard it again — this time irrecoverably,
since the read-path fallback would then resolve it to `terra`. Storing the value
unconditionally removes the question. The column is a nullable text field and
the trim only ever saved bytes.

**Read path** — the upstream and mapping dimensions now fall back to `model`:

```sql
-- upstream dimension
COALESCE(NULLIF(TRIM(upstream_model), ''), model)
-- mapping dimension
(COALESCE(NULLIF(TRIM(requested_model), ''), model) || ' -> ' ||
 COALESCE(NULLIF(TRIM(upstream_model), ''), model))
```

The requested dimension is untouched.

### Blast radius of the read change

The two expressions differ only for rows where `upstream_model` is NULL/empty
**and** `requested_model` differs from `model` — otherwise both branches of the
`COALESCE` resolve to the same string. That set is exactly the channel-mapped
historical rows this PR is about:

- Of the six `&UsageLog{}` construction sites, only the two gateway writers can
  produce `requested_model != model`. The other four (`usage_service`,
  `openai_live`, `batch_image_settlement`, and the query-layer mapper) write
  `model == requested_model` with a NULL upstream, so their dimension values are
  bit-for-bit unchanged.
- `usage_logs.model` is always the forwarded model — post-channel-mapping,
  pre-account-mapping — on both gateway paths. The billing model is computed
  into a separate local (`billingModel`, including the `billing_model_source =
  requested` and composite-alias fallbacks) and never reaches this column, so
  the new fallback cannot pick up a pricing alias.

Two smaller consequences worth stating:

- `resolveModelDimensionExpression` backs both the aggregate and the drill-down
  filter (`WHERE <expr> = $n`), so the chart and the click-through stay
  consistent. A filter on the upstream dimension will now match historical
  channel-mapped rows under `gpt-5.6-terra` rather than `gpt-5.6-sol` — the
  point of the fix, but it is a visible change to what a saved filter returns.
- Direct filters on the raw `model` column keep using
  `appendRawUsageLogModelWhereCondition` and are not affected.

### What does not change

`requested_model`, `model`, billing model selection, cost, and the frontend
usage table. `UsageTable.vue` only renders the `↳ upstream` line when
`upstream_model !== model`, so rows that now store an upstream model equal to
`model` render exactly as before. Admin CSV export does change shape: the
upstream model column is populated on every row instead of being blank when no
mapping occurred.

## Not covered

- **No data backfill.** Historical rows keep their NULL `upstream_model` and are
  read correctly through the fallback. New rows no longer depend on it.
- **WebSocket multi-turn frames.** Follow-up `response.create` frames on a
  long-lived WS connection can reach the upstream without the channel mapping
  applied, which produces a different wrong row. That is a forwarding bug rather
  than a statistics bug and is fixed separately.

## Tests

- `TestResolveModelDimensionExpression` — updated to pin both SQL expressions.
  Red without the fix (both the upstream and the mapping expression still carry
  the `requested_model` fallback).
- `TestGatewayServiceRecordUsage_PreservesChannelMappedUpstreamModel` and
  `TestOpenAIGatewayServiceRecordUsage_PreservesChannelMappedUpstreamModel` —
  `requested=sol, model=terra, upstream=terra` must persist
  `upstream_model=terra`. Both are red without the fix (`Expected value not to
  be nil`).
- `TestGatewayServiceRecordUsage_PreservesLoopedChannelAndAccountUpstreamModel`
  and its OpenAI counterpart — channel `sol → terra` followed by account
  `terra → sol` must persist `upstream_model=sol`. These pin the shape that
  makes an equality trim against the requested model wrong, so the guard cannot
  be reintroduced on a different basis without failing.
- Existing `TestGatewayServiceRecordUsage_PreservesRequestedAndUpstreamModels`
  (account mapping only) stays green, confirming the non-channel path is
  unchanged.
- `go test -tags unit ./internal/repository/... ./internal/service/...` — pass.
- `go vet ./internal/repository/... ./internal/service/...` — clean.
- `go build ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
