### PR TITLE
fix(frontend): 修复渠道监控时间线在窄卡片下溢出

### DIFF
--- a/frontend/src/components/user/monitor/MonitorTimeline.vue
+++ b/frontend/src/components/user/monitor/MonitorTimeline.vue
@@ -17,7 +17,7 @@
       <div
         v-for="(bar, idx) in displayBars"
         :key="idx"
-        class="flex-1 min-w-[3px] rounded-sm"
+        class="flex-1 min-w-0 rounded-sm"
         :class="bar.colorClass"
         :style="{ height: bar.heightPct + '%' }"
         :title="bar.title"


### PR DESCRIPTION
## 问题

用户端渠道状态页（/monitor）的监控卡片中，「近 60 次记录」时间线在部分浏览器缩放比例（如 100%）下会整体溢出卡片右边缘。

## 原因

`MonitorTimeline.vue` 中每根柱子设置了 `min-w-[3px]`，加上柱子间 `gap-[2px]`，60 根柱子的最小总宽度为 60×3 + 59×2 = **298px**。当卡片内容区宽度低于该值时，flex 无法继续压缩柱子，整行溢出容器。是否触发取决于实际 CSS 像素宽度，因此不同缩放比例下表现不一致。

## 修复

将 `min-w-[3px]` 改为 `min-w-0`，柱子随容器宽度等分压缩，任意宽度下均不再溢出；正常宽度下渲染效果与原来一致。

## 验证

复刻组件 DOM 做了修复前后对比（同宽度、同数据）：容器 250px 时，修复前柱子冲出卡片边缘，修复后正常收纳；容器足够宽时两者渲染一致。