### PR TITLE
fix(openai): 正确处理 input_tokens 并避免 Cloudflare 403 误封账号

### DIFF
--- a/backend/internal/handler/endpoint.go
+++ b/backend/internal/handler/endpoint.go
@@ -15,20 +15,21 @@ import (
 // ──────────────────────────────────────────────────────────
 
 const (
-	EndpointMessages          = "/v1/messages"
-	EndpointChatCompletions   = "/v1/chat/completions"
-	EndpointEmbeddings        = "/v1/embeddings"
-	EndpointAlphaSearch       = "/v1/alpha/search"
-	EndpointResponses         = "/v1/responses"
-	EndpointResponsesCompact  = "/v1/responses/compact"
-	EndpointImagesGenerations = "/v1/images/generations"
-	EndpointImagesEdits       = "/v1/images/edits"
-	EndpointImageTasks        = "/v1/images/tasks"
-	EndpointVideosGenerations = "/v1/videos/generations"
-	EndpointVideosEdits       = "/v1/videos/edits"
-	EndpointVideosExtensions  = "/v1/videos/extensions"
-	EndpointVideos            = "/v1/videos"
-	EndpointGeminiModels      = "/v1beta/models"
+	EndpointMessages             = "/v1/messages"
+	EndpointChatCompletions      = "/v1/chat/completions"
+	EndpointEmbeddings           = "/v1/embeddings"
+	EndpointAlphaSearch          = "/v1/alpha/search"
+	EndpointResponses            = "/v1/responses"
+	EndpointResponsesInputTokens = "/v1/responses/input_tokens"
+	EndpointResponsesCompact     = "/v1/responses/compact"
+	EndpointImagesGenerations    = "/v1/images/generations"
+	EndpointImagesEdits          = "/v1/images/edits"
+	EndpointImageTasks           = "/v1/images/tasks"
+	EndpointVideosGenerations    = "/v1/videos/generations"
+	EndpointVideosEdits          = "/v1/videos/edits"
+	EndpointVideosExtensions     = "/v1/videos/extensions"
+	EndpointVideos               = "/v1/videos"
+	EndpointGeminiModels         = "/v1beta/models"
 )
 
 // gin.Context keys used by the middleware and helpers below.
@@ -99,6 +100,8 @@ func NormalizeInboundEndpoint(path string) string {
 		return EndpointVideosExtensions
 	case strings.Contains(path, EndpointVideos) || strings.Contains(path, "/videos/"):
 		return EndpointVideos
+	case strings.Contains(path, EndpointResponsesInputTokens) || isResponsesInputTokensAliasPath(path):
+		return EndpointResponsesInputTokens
 	case strings.Contains(path, EndpointResponsesCompact) || isResponsesCompactAliasPath(path):
 		return EndpointResponsesCompact
 	case strings.Contains(path, EndpointResponses) || isResponsesRootAliasPath(path):
@@ -108,6 +111,18 @@ func NormalizeInboundEndpoint(path string) string {
 	default:
 		return path
 	}
+}
+
+// isResponsesInputTokensAliasPath reports whether path is one of the
+// Responses input-token count aliases exposed without the canonical /v1
+// prefix.
+func isResponsesInputTokensAliasPath(path string) bool {
+	trimmed := strings.TrimRight(strings.TrimSpace(path), "/")
+	if trimmed == "" {
+		return false
+	}
+	return trimmed == "/responses/input_tokens" ||
+		trimmed == "/backend-api/codex/responses/input_tokens"
 }
 
 // isResponsesCompactAliasPath reports whether path is the bare/alias
@@ -182,7 +197,7 @@ func DeriveUpstreamEndpoint(inbound, rawRequestPath, platform string) string {
 
 	switch platform {
 	case service.PlatformOpenAI, service.PlatformGrok:
-		if inbound == EndpointEmbeddings || inbound == EndpointAlphaSearch || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits || inbound == EndpointVideosGenerations || inbound == EndpointVideosEdits || inbound == EndpointVideosExtensions || inbound == EndpointVideos {
+		if inbound == EndpointEmbeddings || inbound == EndpointAlphaSearch || inbound == EndpointResponsesInputTokens || inbound == EndpointImagesGenerations || inbound == EndpointImagesEdits || inbound == EndpointVideosGenerations || inbound == EndpointVideosEdits || inbound == EndpointVideosExtensions || inbound == EndpointVideos {
 			return inbound
 		}
 		// OpenAI forwards everything to the Responses API.

--- a/backend/internal/handler/endpoint_test.go
+++ b/backend/internal/handler/endpoint_test.go
@@ -27,6 +27,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		{"/v1/embeddings", EndpointEmbeddings},
 		{"/v1/alpha/search", EndpointAlphaSearch},
 		{"/v1/responses", EndpointResponses},
+		{"/v1/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/v1/responses/compact", EndpointResponsesCompact},
 		{"/v1/responses/compact/detail", EndpointResponsesCompact},
 		{"/v1/images/generations", EndpointImagesGenerations},
@@ -39,6 +40,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 		// Prefixed paths (antigravity, openai) — root Responses.
 		{"/antigravity/v1/messages", EndpointMessages},
 		{"/openai/v1/responses", EndpointResponses},
+		{"/openai/v1/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/openai/v1/images/generations", EndpointImagesGenerations},
 		{"/openai/v1/images/edits", EndpointImagesEdits},
 		{"/antigravity/v1beta/models/gemini:generateContent", EndpointGeminiModels},
@@ -50,6 +52,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 
 		// Bare top-level alias route "/responses" — root vs. compact.
 		{"/responses", EndpointResponses},
+		{"/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/responses/compact", EndpointResponsesCompact},
 		{"/responses/compact/detail", EndpointResponsesCompact},
 		{"/alpha/search", EndpointAlphaSearch},
@@ -57,6 +60,7 @@ func TestNormalizeInboundEndpoint(t *testing.T) {
 
 		// Bare Codex direct alias route — root vs. compact.
 		{"/backend-api/codex/responses", EndpointResponses},
+		{"/backend-api/codex/responses/input_tokens", EndpointResponsesInputTokens},
 		{"/backend-api/codex/responses/compact", EndpointResponsesCompact},
 		{"/backend-api/codex/responses/compact/detail", EndpointResponsesCompact},
 		{"/backend-api/codex/alpha/search", EndpointAlphaSearch},
@@ -100,6 +104,9 @@ func TestDeriveUpstreamEndpoint(t *testing.T) {
 
 		// OpenAI — root Responses.
 		{"openai responses root", EndpointResponses, "/v1/responses", service.PlatformOpenAI, EndpointResponses},
+		{"openai responses input tokens", EndpointResponsesInputTokens, "/v1/responses/input_tokens", service.PlatformOpenAI, EndpointResponsesInputTokens},
+		{"openai bare responses input tokens", EndpointResponsesInputTokens, "/responses/input_tokens", service.PlatformOpenAI, EndpointResponsesInputTokens},
+		{"openai codex direct input tokens", EndpointResponsesInputTokens, "/backend-api/codex/responses/input_tokens", service.PlatformOpenAI, EndpointResponsesInputTokens},
 
 		// OpenAI — compact, raw path carries the derivable "/compact"
 		// (or nested) suffix, which must be preserved on the upstream
@@ -211,12 +218,15 @@ func TestResponsesSubpathSuffix(t *testing.T) {
 		{"/v1/responses", ""},
 		{"/v1/responses/", ""},
 		{"/v1/responses/compact", "/compact"},
+		{"/v1/responses/input_tokens", "/input_tokens"},
 		{"/openai/v1/responses/compact/detail", "/compact/detail"},
 		{"/responses", ""},
 		{"/responses/compact", "/compact"},
+		{"/responses/input_tokens", "/input_tokens"},
 		{"/responses/compact/detail", "/compact/detail"},
 		{"/backend-api/codex/responses", ""},
 		{"/backend-api/codex/responses/compact", "/compact"},
+		{"/backend-api/codex/responses/input_tokens", "/input_tokens"},
 		{"/backend-api/codex/responses/compact/detail", "/compact/detail"},
 		{"/v1/messages", ""},
 		{"", ""},

--- a/backend/internal/handler/openai_gateway_count_tokens.go
+++ b/backend/internal/handler/openai_gateway_count_tokens.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/service"
 
 	"github.com/gin-gonic/gin"
+	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
 )
 
@@ -53,6 +54,129 @@ func (h *OpenAIGatewayHandler) GrokCountTokens(c *gin.Context) {
 	setOpsRequestContext(c, parsedReq.Model, false)
 	setOpsEndpointContext(c, "", int16(service.RequestTypeFromLegacy(false, false)))
 	c.JSON(http.StatusOK, gin.H{"input_tokens": estimated})
+}
+
+// InputTokens handles OpenAI-compatible POST /v1/responses/input_tokens.
+// It deliberately selects and calls only one account: token counting is an
+// auxiliary request and must not fan out across accounts or mutate account
+// scheduling state when an OAuth upstream rejects the endpoint.
+func (h *OpenAIGatewayHandler) InputTokens(c *gin.Context) {
+	apiKey, ok := middleware2.GetAPIKeyFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusUnauthorized, "authentication_error", "Invalid API key")
+		return
+	}
+
+	subject, ok := middleware2.GetAuthSubjectFromContext(c)
+	if !ok {
+		h.errorResponse(c, http.StatusInternalServerError, "api_error", "User context not found")
+		return
+	}
+	reqLog := requestLogger(
+		c,
+		"handler.openai_gateway.input_tokens",
+		zap.Int64("user_id", subject.UserID),
+		zap.Int64("api_key_id", apiKey.ID),
+		zap.Any("group_id", apiKey.GroupID),
+	)
+	if !h.ensureResponsesDependencies(c, reqLog) {
+		return
+	}
+
+	body, err := readLenientJSONRequestBodyWithPrealloc(c.Request, h.cfg)
+	if err != nil {
+		if maxErr, ok := extractMaxBytesError(err); ok {
+			h.errorResponse(c, http.StatusRequestEntityTooLarge, "invalid_request_error", buildBodyTooLargeMessage(maxErr.Limit))
+			return
+		}
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to read request body")
+		return
+	}
+	if len(body) == 0 {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Request body is empty")
+		return
+	}
+	if !gjson.ValidBytes(body) {
+		logRequestBodyParseFailure(reqLog, body, nil)
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+		return
+	}
+
+	modelResult := gjson.GetBytes(body, "model")
+	if !modelResult.Exists() || modelResult.Type != gjson.String || modelResult.String() == "" {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "model is required")
+		return
+	}
+	reqModel := modelResult.String()
+	ensureCompositeTargetPlatform(c, apiKey, reqModel)
+	if !compositeTargetPlatformAllowed(c, apiKey, reqModel, service.PlatformOpenAI) {
+		h.errorResponse(c, http.StatusBadRequest, "invalid_request_error", "Model is not supported by this OpenAI endpoint for composite groups")
+		return
+	}
+
+	reqLog = reqLog.With(zap.String("model", reqModel))
+	setOpsRequestContext(c, reqModel, false)
+	setOpsEndpointContext(c, "", int16(service.RequestTypeSync))
+
+	channelMapping, _ := h.gatewayService.ResolveChannelMappingAndRestrict(c.Request.Context(), apiKey.GroupID, reqModel)
+	forwardBody := openAIModelMappedBody(body, channelMapping.Mapped, channelMapping.MappedModel, h.gatewayService.ReplaceModelInBody)
+
+	subscription, _ := middleware2.GetSubscriptionFromContext(c)
+	if err := h.billingCacheService.CheckBillingEligibility(c.Request.Context(), apiKey.User, apiKey, apiKey.Group, subscription, service.QuotaPlatform(c.Request.Context(), apiKey)); err != nil {
+		reqLog.Info("openai_input_tokens.billing_eligibility_check_failed", zap.Error(err))
+		status, code, message, retryAfter := billingErrorDetails(err)
+		if retryAfter > 0 {
+			c.Header("Retry-After", strconv.Itoa(retryAfter))
+		}
+		h.errorResponse(c, status, code, message)
+		return
+	}
+
+	requestStart := time.Now()
+	sessionHash := h.gatewayService.GenerateSessionHash(c, body)
+	routingModel := service.NormalizeOpenAICompatRequestedModel(reqModel)
+	selection, _, err := h.gatewayService.SelectAccountWithSchedulerForCapability(
+		c.Request.Context(),
+		apiKey.GroupID,
+		"",
+		sessionHash,
+		routingModel,
+		nil,
+		service.OpenAIUpstreamTransportAny,
+		service.OpenAIEndpointCapabilityResponses,
+		false,
+		false,
+		false,
+		service.PlatformOpenAI,
+	)
+	service.SetOpsLatencyMs(c, service.OpsAuthLatencyMsKey, time.Since(requestStart).Milliseconds())
+	if err != nil {
+		reqLog.Warn("openai_input_tokens.account_select_failed", zap.Error(openAICompatibleSelectionErrorForLog(err, service.PlatformOpenAI)))
+		cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, routingModel, reqModel)
+		if !cls.ModelNotFound {
+			markOpsRoutingCapacityLimitedIfNoAvailable(c, err)
+		}
+		h.errorResponse(c, cls.Status, cls.ErrType, cls.Message)
+		return
+	}
+	if selection == nil || selection.Account == nil {
+		cls := classifyOpenAICompatibleNoAccountErrorFromGin(c, h.gatewayService, apiKey, routingModel, reqModel)
+		if !cls.ModelNotFound {
+			markOpsRoutingCapacityLimited(c)
+		}
+		h.errorResponse(c, cls.Status, cls.ErrType, cls.Message)
+		return
+	}
+
+	account := selection.Account
+	setOpsSelectedAccount(c, account.ID, account.Platform)
+	if selection.Acquired && selection.ReleaseFunc != nil {
+		defer selection.ReleaseFunc()
+	}
+
+	if err := h.gatewayService.ForwardInputTokens(c.Request.Context(), c, account, forwardBody); err != nil {
+		reqLog.Warn("openai_input_tokens.forward_failed", zap.Int64("account_id", account.ID), zap.Error(err))
+	}
 }
 
 // CountTokens handles Anthropic-compatible POST /v1/messages/count_tokens for OpenAI groups.

--- a/backend/internal/handler/ops_error_logger.go
+++ b/backend/internal/handler/ops_error_logger.go
@@ -1249,7 +1249,13 @@ func isCountTokensRequest(c *gin.Context) bool {
 	if c == nil || c.Request == nil || c.Request.URL == nil {
 		return false
 	}
-	return strings.Contains(c.Request.URL.Path, "/count_tokens")
+	return isCountTokensPath(c.Request.URL.Path)
+}
+
+func isCountTokensPath(path string) bool {
+	normalized := strings.TrimRight(strings.TrimSpace(path), "/")
+	return strings.Contains(normalized, "/count_tokens") ||
+		strings.HasSuffix(normalized, "/responses/input_tokens")
 }
 
 func applyOpsLatencyFieldsFromContext(c *gin.Context, entry *service.OpsInsertErrorLogInput) {
@@ -1774,7 +1780,7 @@ func shouldSkipOpsErrorLog(ctx context.Context, ops *service.OpsService, message
 	bodyLower := strings.ToLower(body)
 
 	// Check if count_tokens errors should be ignored
-	if settings.IgnoreCountTokensErrors && strings.Contains(requestPath, "/count_tokens") {
+	if settings.IgnoreCountTokensErrors && isCountTokensPath(requestPath) {
 		return true
 	}
 

--- a/backend/internal/handler/ops_error_logger_test.go
+++ b/backend/internal/handler/ops_error_logger_test.go
@@ -1191,6 +1191,19 @@ func TestSetOpsEndpointContext_NilContext(t *testing.T) {
 	})
 }
 
+func TestIsCountTokensPathIncludesResponsesInputTokensAliases(t *testing.T) {
+	for _, path := range []string{
+		"/v1/messages/count_tokens",
+		"/v1/responses/input_tokens",
+		"/responses/input_tokens",
+		"/backend-api/codex/responses/input_tokens",
+		"/v1/responses/input_tokens/",
+	} {
+		require.True(t, isCountTokensPath(path), "path=%s", path)
+	}
+	require.False(t, isCountTokensPath("/v1/responses"), "normal Responses requests are not token-count probes")
+}
+
 func TestGetOpsAPIKeyFallsBackToOpsFallbackKey(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rec := httptest.NewRecorder()

--- a/backend/internal/server/routes/gateway.go
+++ b/backend/internal/server/routes/gateway.go
@@ -66,6 +66,19 @@ func RegisterGatewayRoutes(
 			h.Gateway.CountTokens(c)
 		}
 	}
+	responsesInputTokensHandler := func(c *gin.Context) {
+		if isOpenAIGatewayPlatform(c) {
+			h.OpenAIGateway.InputTokens(c)
+			return
+		}
+		service.MarkOpsClientBusinessLimited(c, service.OpsClientBusinessLimitedReasonLocalFeatureGate)
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": gin.H{
+				"type":    "not_found_error",
+				"message": "Responses input token counting is only available for OpenAI groups",
+			},
+		})
+	}
 	modelsHandler := func(c *gin.Context) {
 		if isOpenAIGatewayPlatform(c) && c.Query("client_version") != "" {
 			h.OpenAIGateway.CodexModels(c)
@@ -191,6 +204,10 @@ func RegisterGatewayRoutes(
 			h.Gateway.Responses(c)
 		})
 		gateway.POST("/responses/*subpath", func(c *gin.Context) {
+			if handler.GetInboundEndpoint(c) == handler.EndpointResponsesInputTokens {
+				responsesInputTokensHandler(c)
+				return
+			}
 			if isOpenAIResponsesCompatibleGatewayPlatform(c) {
 				h.OpenAIGateway.Responses(c)
 				return
@@ -268,8 +285,15 @@ func RegisterGatewayRoutes(
 		}
 		h.Gateway.Responses(c)
 	}
+	responsesSubpathHandler := func(c *gin.Context) {
+		if handler.GetInboundEndpoint(c) == handler.EndpointResponsesInputTokens {
+			responsesInputTokensHandler(c)
+			return
+		}
+		responsesHandler(c)
+	}
 	r.POST("/responses", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, responsesHandler)
-	r.POST("/responses/*subpath", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, responsesHandler)
+	r.POST("/responses/*subpath", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, responsesSubpathHandler)
 	r.POST("/alpha/search", textBodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, h.OpenAIGateway.AlphaSearch)
 	r.GET("/responses", bodyLimit, clientRequestID, opsErrorLogger, endpointNorm, gin.HandlerFunc(apiKeyAuth), compositeTarget, requireGroupAnthropic, func(c *gin.Context) {
 		h.OpenAIGateway.ResponsesWebSocket(c)
@@ -282,7 +306,7 @@ func RegisterGatewayRoutes(
 		codexDirect.POST("/realtime/calls", h.OpenAIGateway.Live)
 		codexDirect.GET("/:call_id", h.OpenAIGateway.LiveSideband)
 		codexDirect.POST("/responses", responsesHandler)
-		codexDirect.POST("/responses/*subpath", responsesHandler)
+		codexDirect.POST("/responses/*subpath", responsesSubpathHandler)
 		codexDirect.POST("/alpha/search", textBodyLimit, h.OpenAIGateway.AlphaSearch)
 		codexDirect.GET("/responses", func(c *gin.Context) {
 			h.OpenAIGateway.ResponsesWebSocket(c)

--- a/backend/internal/server/routes/gateway_test.go
+++ b/backend/internal/server/routes/gateway_test.go
@@ -76,6 +76,24 @@ func TestGatewayRoutesOpenAIResponsesCompactPathIsRegistered(t *testing.T) {
 	}
 }
 
+func TestGatewayRoutesOpenAIResponsesInputTokensPathsUseDedicatedHandler(t *testing.T) {
+	router := newGatewayRoutesTestRouter(service.PlatformGrok)
+
+	for _, path := range []string{
+		"/v1/responses/input_tokens",
+		"/responses/input_tokens",
+		"/backend-api/codex/responses/input_tokens",
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"gpt-5"}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+
+		router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code, "path=%s should reach the dedicated input_tokens handler", path)
+		require.Contains(t, w.Body.String(), "only available for OpenAI groups")
+	}
+}
+
 func TestGatewayRoutesOpenAIAlphaSearchPathsAreRegistered(t *testing.T) {
 	router := newGatewayRoutesTestRouter()
 	registered := make(map[string]bool)

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -51,6 +51,9 @@ func (s *OpenAIGatewayService) handleOpenAIAccountUpstreamError(ctx context.Cont
 	if account != nil && account.Platform == PlatformGrok && isGrokContentPolicyRejection(statusCode, responseBody) {
 		return false
 	}
+	if isOpenAICloudflareForbiddenResponse(account, statusCode, headers, responseBody) {
+		return false
+	}
 	// Any non-2xx upstream HTTP response means the model request was actually sent.
 	if s != nil {
 		scheduleOllamaCloudUsageActivity(s.deferredService, account)

--- a/backend/internal/service/openai_cloudflare_error.go
+++ b/backend/internal/service/openai_cloudflare_error.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/Wei-Shaw/sub2api/internal/util/httputil"
+)
+
+var openAICloudflareNotFoundBody = []byte(`{"error":{"type":"not_found_error","message":"Not found"}}`)
+
+func isOpenAICloudflareForbiddenResponse(account *Account, statusCode int, headers http.Header, body []byte) bool {
+	return account != nil &&
+		account.Platform == PlatformOpenAI &&
+		statusCode == http.StatusForbidden &&
+		httputil.IsCloudflareGeneratedErrorResponse(statusCode, headers, body)
+}
+
+// normalizeOpenAICloudflareForbiddenResponse converts a Cloudflare-generated
+// 403 into a local OpenAI-shaped 404. The original response body is replaced so
+// Cloudflare HTML is never exposed and later error handlers cannot mistake the
+// response for an OpenAI account-permission failure.
+func normalizeOpenAICloudflareForbiddenResponse(account *Account, resp *http.Response, body []byte) ([]byte, bool) {
+	if resp == nil || !isOpenAICloudflareForbiddenResponse(account, resp.StatusCode, resp.Header, body) {
+		return body, false
+	}
+
+	normalizedBody := append([]byte(nil), openAICloudflareNotFoundBody...)
+	resp.StatusCode = http.StatusNotFound
+	resp.Status = fmt.Sprintf("%d %s", http.StatusNotFound, http.StatusText(http.StatusNotFound))
+	if resp.Header == nil {
+		resp.Header = make(http.Header)
+	}
+	resp.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp.Header.Del("Content-Encoding")
+	resp.Header.Del("Content-Length")
+	resp.Header.Del("Transfer-Encoding")
+	resp.ContentLength = int64(len(normalizedBody))
+	resp.Body = io.NopCloser(bytes.NewReader(normalizedBody))
+	return normalizedBody, true
+}

--- a/backend/internal/service/openai_cloudflare_error_test.go
+++ b/backend/internal/service/openai_cloudflare_error_test.go
@@ -1,0 +1,206 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeOpenAICloudflareForbiddenResponse(t *testing.T) {
+	account := &Account{ID: 401, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	originalBody := []byte("<!doctype html><html>Cloudflare error</html>")
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Status:     "403 Forbidden",
+		Header: http.Header{
+			"Cf-Error-Type":    []string{"waf"},
+			"Cf-Ray":           []string{"abc123-SJC"},
+			"Content-Type":     []string{"text/html"},
+			"Content-Length":   []string{"49"},
+			"Content-Encoding": []string{"gzip"},
+		},
+		Body: io.NopCloser(bytes.NewReader(originalBody)),
+	}
+
+	body, normalized := normalizeOpenAICloudflareForbiddenResponse(account, resp, originalBody)
+
+	require.True(t, normalized)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.Equal(t, "404 Not Found", resp.Status)
+	require.JSONEq(t, `{"error":{"type":"not_found_error","message":"Not found"}}`, string(body))
+	require.Equal(t, "application/json; charset=utf-8", resp.Header.Get("Content-Type"))
+	require.Empty(t, resp.Header.Get("Content-Length"))
+	require.Empty(t, resp.Header.Get("Content-Encoding"))
+	require.Equal(t, "abc123-SJC", resp.Header.Get("Cf-Ray"))
+	rewound, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, body, rewound)
+}
+
+func TestNormalizeOpenAICloudflareForbiddenResponseDoesNotRewriteOrigin403(t *testing.T) {
+	account := &Account{ID: 402, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	originalBody := []byte(`{"error":{"message":"workspace access forbidden"}}`)
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header: http.Header{
+			"Cf-Ray": []string{"origin403-SJC"},
+			"Server": []string{"cloudflare"},
+		},
+		Body: io.NopCloser(bytes.NewReader(originalBody)),
+	}
+
+	body, normalized := normalizeOpenAICloudflareForbiddenResponse(account, resp, originalBody)
+
+	require.False(t, normalized)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.Equal(t, originalBody, body)
+}
+
+func TestOpenAICloudflare403Returns404WithoutAccountPenalty(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rateLimitService.SetOpenAI403CounterCache(counter)
+	gateway := &OpenAIGatewayService{
+		cfg:              &config.Config{},
+		rateLimitService: rateLimitService,
+	}
+	account := &Account{ID: 403, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+	cfBody := []byte("<!doctype html><html><title>Cloudflare</title></html>")
+	resp := &http.Response{
+		StatusCode: http.StatusForbidden,
+		Header: http.Header{
+			"Cf-Error-Origin": []string{"edge"},
+			"Cf-Ray":          []string{"cf403-SJC"},
+			"Content-Type":    []string{"text/html"},
+		},
+		Body: io.NopCloser(bytes.NewReader(cfBody)),
+	}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/not-exist", nil)
+
+	result, err := gateway.handleErrorResponse(
+		context.Background(),
+		resp,
+		c,
+		account,
+		[]byte(`{"model":"gpt-5"}`),
+	)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	require.JSONEq(t, `{"error":{"type":"not_found_error","message":"Not found"}}`, recorder.Body.String())
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 0, repo.tempCalls)
+	require.Len(t, counter.counts, 1, "Cloudflare 403 must not increment the OpenAI 403 counter")
+}
+
+func TestOpenAIForwardCloudflare403DoesNotFailover(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rateLimitService.SetOpenAI403CounterCache(counter)
+	upstream := &httpUpstreamRecorder{
+		resp: &http.Response{
+			StatusCode: http.StatusForbidden,
+			Header: http.Header{
+				"Cf-Error-Type": []string{"waf"},
+				"Cf-Ray":        []string{"forward403-SJC"},
+				"Content-Type":  []string{"text/html"},
+			},
+			Body: io.NopCloser(strings.NewReader("<!doctype html><html>Cloudflare</html>")),
+		},
+	}
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	gateway := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     upstream,
+		rateLimitService: rateLimitService,
+	}
+	account := &Account{
+		ID:          405,
+		Name:        "openai-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":  "sk-test",
+			"base_url": "https://example.com",
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+	recorder := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(recorder)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/not-exist", nil)
+	SetOpenAIClientTransport(c, OpenAIClientTransportHTTP)
+
+	result, err := gateway.Forward(
+		context.Background(),
+		c,
+		account,
+		[]byte(`{"model":"gpt-5","stream":false,"input":"hello"}`),
+	)
+
+	require.Nil(t, result)
+	require.Error(t, err)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "Cloudflare 403 must terminate locally instead of switching accounts")
+	require.Equal(t, http.StatusNotFound, recorder.Code)
+	require.JSONEq(t, `{"error":{"type":"not_found_error","message":"Not found"}}`, recorder.Body.String())
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "/v1/responses/not-exist", upstream.lastReq.URL.Path)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 0, repo.tempCalls)
+	require.Len(t, counter.counts, 1)
+}
+
+func TestRateLimitServiceCloudflare403SkipsCustomTempRules(t *testing.T) {
+	repo := &rateLimitAccountRepoStub{}
+	counter := &openAI403CounterCacheStub{counts: []int64{1}}
+	rateLimitService := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rateLimitService.SetOpenAI403CounterCache(counter)
+	account := &Account{
+		ID:       404,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"temp_unschedulable_enabled": true,
+			"temp_unschedulable_rules": []any{
+				map[string]any{
+					"error_code":       http.StatusForbidden,
+					"keywords":         []any{"cloudflare"},
+					"duration_minutes": 60,
+				},
+			},
+		},
+	}
+
+	shouldDisable := rateLimitService.HandleUpstreamError(
+		context.Background(),
+		account,
+		http.StatusForbidden,
+		http.Header{"Cf-Mitigated": []string{"challenge"}},
+		[]byte("<html>Cloudflare challenge</html>"),
+	)
+
+	require.False(t, shouldDisable)
+	require.Equal(t, 0, repo.setErrorCalls)
+	require.Equal(t, 0, repo.tempCalls)
+	require.Len(t, counter.counts, 1)
+}

--- a/backend/internal/service/openai_gateway_cc_pipeline.go
+++ b/backend/internal/service/openai_gateway_cc_pipeline.go
@@ -88,6 +88,11 @@ func (s *OpenAIGatewayService) failoverOpenAIUpstreamHTTPError(
 	upstreamMsg string,
 	upstreamModel string,
 ) *UpstreamFailoverError {
+	if normalizedBody, normalized := normalizeOpenAICloudflareForbiddenResponse(account, resp, respBody); normalized {
+		respBody = normalizedBody
+		upstreamMsg = strings.TrimSpace(extractUpstreamErrorMessage(respBody))
+		upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)
+	}
 	shouldFailover := s.shouldFailoverOpenAIUpstreamResponse(resp.StatusCode, upstreamMsg, respBody)
 	if account != nil && account.Platform == PlatformGrok {
 		shouldFailover = s.shouldFailoverGrokUpstreamError(resp.StatusCode, respBody)

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -8,9 +8,11 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/pkg/apicompat"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/logger"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai"
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 	"github.com/tiktoken-go/tokenizer"
@@ -21,6 +23,9 @@ const (
 	openAIResponsesInputItemTokenOverhead = 3
 	openAIResponsesContentPartOverhead    = 1
 	openAIInputTokensFallbackMinimum      = 1
+	openAIInputTokensSourceHeader         = "X-Sub2API-Input-Tokens-Source"
+	openAIInputTokensSourceUpstream       = "upstream"
+	openAIInputTokensSourceLocalFallback  = "local-fallback"
 )
 
 type openAIInputTokensCountRequest struct {
@@ -37,6 +42,180 @@ type openAIInputTokensCountPrepared struct {
 	NormalizedModel string
 	BillingModel    string
 	UpstreamModel   string
+}
+
+type openAIDirectInputTokensPrepared struct {
+	Request       openAIInputTokensCountRequest
+	UpstreamBody  []byte
+	OriginalModel string
+	UpstreamModel string
+}
+
+// ForwardInputTokens forwards a direct Responses input-token count request
+// through exactly one selected account. OAuth 401/403/404 responses fall back
+// locally without invoking generic rate-limit/account-state handling.
+func (s *OpenAIGatewayService) ForwardInputTokens(
+	ctx context.Context,
+	c *gin.Context,
+	account *Account,
+	body []byte,
+) error {
+	if account == nil {
+		writeOpenAIInputTokensError(c, http.StatusServiceUnavailable, "api_error", "No available OpenAI accounts")
+		return fmt.Errorf("input_tokens: missing account")
+	}
+
+	prepared, err := s.prepareDirectOpenAIInputTokensRequest(body, account)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusBadRequest, "invalid_request_error", "Failed to parse request body")
+		return err
+	}
+
+	token, _, err := s.GetAccessToken(ctx, account)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to get access token")
+		return fmt.Errorf("get input_tokens access token: %w", err)
+	}
+
+	isCodexCLI := openai.IsCodexOfficialClientByHeaders(c.GetHeader("User-Agent"), c.GetHeader("originator")) ||
+		(s.cfg != nil && s.cfg.Gateway.ForceCodexCLI)
+	promptCacheKey := strings.TrimSpace(gjson.GetBytes(prepared.UpstreamBody, "prompt_cache_key").String())
+	upstreamReq, err := s.buildUpstreamRequest(ctx, c, account, prepared.UpstreamBody, token, false, promptCacheKey, isCodexCLI)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusInternalServerError, "api_error", "Failed to build request")
+		return fmt.Errorf("build direct input_tokens request: %w", err)
+	}
+	// The generic Responses builder defaults OAuth requests to SSE. This
+	// subresource is unary JSON, so override Accept after all common headers
+	// have been assembled.
+	upstreamReq.Header.Set("accept", "application/json")
+
+	proxyURL := ""
+	if account.ProxyID != nil && account.Proxy != nil {
+		proxyURL = account.Proxy.URL()
+	}
+	upstreamStart := time.Now()
+	resp, err := s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
+	SetOpsLatencyMs(c, OpsUpstreamLatencyMsKey, time.Since(upstreamStart).Milliseconds())
+	if err != nil {
+		safeErr := sanitizeUpstreamErrorMessage(err.Error())
+		setOpsUpstreamError(c, 0, safeErr, "")
+		writeOpenAIInputTokensError(c, http.StatusBadGateway, "upstream_error", "Upstream request failed")
+		return fmt.Errorf("direct input_tokens upstream request failed: %s", safeErr)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		writeOpenAIInputTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to read response")
+		return fmt.Errorf("read direct input_tokens response: %w", err)
+	}
+
+	if account.Type == AccountTypeOAuth && isOpenAIDirectInputTokensFallbackStatus(resp.StatusCode) {
+		writeOpenAIDirectInputTokensFallback(c, account, prepared, resp.StatusCode)
+		return nil
+	}
+
+	writeOpenAIPassthroughResponseHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
+	c.Header(openAIInputTokensSourceHeader, openAIInputTokensSourceUpstream)
+	contentType := strings.TrimSpace(resp.Header.Get("Content-Type"))
+	if contentType == "" {
+		contentType = "application/json"
+	}
+	c.Data(resp.StatusCode, contentType, respBody)
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))
+		upstreamDetail := ""
+		if s.cfg != nil && s.cfg.Gateway.LogUpstreamErrorBody {
+			maxBytes := s.cfg.Gateway.LogUpstreamErrorBodyMaxBytes
+			if maxBytes <= 0 {
+				maxBytes = 2048
+			}
+			upstreamDetail = truncateString(string(respBody), maxBytes)
+		}
+		setOpsUpstreamError(c, resp.StatusCode, upstreamMsg, upstreamDetail)
+		if upstreamMsg == "" {
+			return fmt.Errorf("direct input_tokens upstream error: %d", resp.StatusCode)
+		}
+		return fmt.Errorf("direct input_tokens upstream error: %d message=%s", resp.StatusCode, upstreamMsg)
+	}
+
+	return nil
+}
+
+func (s *OpenAIGatewayService) prepareDirectOpenAIInputTokensRequest(body []byte, account *Account) (*openAIDirectInputTokensPrepared, error) {
+	var req openAIInputTokensCountRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, fmt.Errorf("parse direct input_tokens request: %w", err)
+	}
+	req.Model = strings.TrimSpace(req.Model)
+	if req.Model == "" {
+		return nil, fmt.Errorf("parse direct input_tokens request: model is required")
+	}
+
+	originalModel := req.Model
+	normalizedModel := NormalizeOpenAICompatRequestedModel(originalModel)
+	billingModel := resolveOpenAIForwardModel(account, normalizedModel, "")
+	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
+	if strings.TrimSpace(upstreamModel) == "" {
+		upstreamModel = normalizedModel
+	}
+	req.Model = upstreamModel
+
+	return &openAIDirectInputTokensPrepared{
+		Request:       req,
+		UpstreamBody:  s.ReplaceModelInBody(body, upstreamModel),
+		OriginalModel: originalModel,
+		UpstreamModel: upstreamModel,
+	}, nil
+}
+
+func isOpenAIDirectInputTokensFallbackStatus(statusCode int) bool {
+	switch statusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return true
+	default:
+		return false
+	}
+}
+
+func writeOpenAIDirectInputTokensFallback(c *gin.Context, account *Account, prepared *openAIDirectInputTokensPrepared, statusCode int) {
+	estimated := openAIInputTokensFallbackMinimum
+	if got, err := estimateOpenAIInputTokens(prepared.Request); err == nil {
+		if got > 0 {
+			estimated = got
+		}
+		logger.L().Info("openai direct input_tokens: oauth fallback to local tiktoken estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("upstream_status", statusCode),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+		)
+	} else {
+		logger.L().Warn("openai direct input_tokens: oauth local tiktoken fallback failed, using minimum estimate",
+			zap.Int64("account_id", account.ID),
+			zap.Int("upstream_status", statusCode),
+			zap.Int("estimated_input_tokens", estimated),
+			zap.String("upstream_model", prepared.UpstreamModel),
+			zap.Error(err),
+		)
+	}
+
+	c.Header(openAIInputTokensSourceHeader, openAIInputTokensSourceLocalFallback)
+	c.JSON(http.StatusOK, gin.H{
+		"object":       "response.input_tokens",
+		"input_tokens": estimated,
+	})
+}
+
+func writeOpenAIInputTokensError(c *gin.Context, status int, errType, message string) {
+	c.JSON(status, gin.H{
+		"error": gin.H{
+			"type":    errType,
+			"message": message,
+		},
+	})
 }
 
 // EstimateGrokCountTokens estimates an Anthropic-compatible count_tokens request

--- a/backend/internal/service/openai_gateway_count_tokens.go
+++ b/backend/internal/service/openai_gateway_count_tokens.go
@@ -315,6 +315,7 @@ func (s *OpenAIGatewayService) ForwardCountTokensAsAnthropic(
 		writeAnthropicCountTokensError(c, http.StatusBadGateway, "upstream_error", "Failed to read response")
 		return fmt.Errorf("read input_tokens response: %w", err)
 	}
+	respBody, _ = normalizeOpenAICloudflareForbiddenResponse(account, resp, respBody)
 
 	if resp.StatusCode >= 400 {
 		upstreamMsg := sanitizeUpstreamErrorMessage(strings.TrimSpace(extractUpstreamErrorMessage(respBody)))

--- a/backend/internal/service/openai_gateway_count_tokens_test.go
+++ b/backend/internal/service/openai_gateway_count_tokens_test.go
@@ -37,6 +37,181 @@ func (r *countTokensRuntimeStateRepo) SetError(_ context.Context, _ int64, _ str
 	return nil
 }
 
+func TestOpenAIGatewayService_ForwardInputTokens_OAuthUsesCodexEndpointOnceAndPreservesResult(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","instructions":"Be concise.","input":"hello"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request.Header.Set("User-Agent", "codex_cli_rs/1.0.0")
+
+	upstreamBody := `{"object":"response.input_tokens","input_tokens":42}`
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type": []string{"application/json"},
+			"X-Request-Id": []string{"req_input_tokens"},
+		},
+		Body: io.NopCloser(strings.NewReader(upstreamBody)),
+	}}
+	proxyID := int64(901)
+	account := &Account{
+		ID:          401,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-account",
+		},
+		ProxyID: &proxyID,
+		Proxy: &Proxy{
+			ID:       proxyID,
+			Protocol: "http",
+			Host:     "172.31.250.1",
+			Port:     3129,
+			Username: "proxy0001",
+			Password: "proxy-password",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+
+	err := svc.ForwardInputTokens(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.JSONEq(t, upstreamBody, rec.Body.String())
+	require.Equal(t, openAIInputTokensSourceUpstream, rec.Header().Get(openAIInputTokensSourceHeader))
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "https://chatgpt.com/backend-api/codex/responses/input_tokens", upstream.lastReq.URL.String())
+	require.Equal(t, "chatgpt.com", upstream.lastReq.Host)
+	require.Equal(t, "application/json", upstream.lastReq.Header.Get("Accept"))
+	require.Equal(t, "Bearer oauth-token", upstream.lastReq.Header.Get("Authorization"))
+	require.Equal(t, "chatgpt-account", upstream.lastReq.Header.Get("Chatgpt-Account-Id"))
+	require.Equal(t, "http://proxy0001:proxy-password@172.31.250.1:3129", upstream.lastProxyURL)
+}
+
+func TestOpenAIGatewayService_ForwardInputTokens_OAuthAuthAndUnsupportedStatusesFallbackWithoutAccountMutation(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","instructions":"Be concise.","input":"hello"}`)
+	account := &Account{
+		ID:          402,
+		Name:        "openai-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token": "oauth-token",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+
+	cases := []struct {
+		name       string
+		statusCode int
+		body       string
+	}{
+		{
+			name:       "401",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"error":{"message":"missing scope"}}`,
+		},
+		{
+			name:       "generic_html_403",
+			statusCode: http.StatusForbidden,
+			body:       `<html><head><meta http-equiv="refresh" content="360"></head></html>`,
+		},
+		{
+			name:       "404",
+			statusCode: http.StatusNotFound,
+			body:       `{"detail":"Not Found"}`,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", bytes.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: tt.statusCode,
+				Header:     http.Header{"Content-Type": []string{"text/html"}},
+				Body:       io.NopCloser(strings.NewReader(tt.body)),
+			}}
+			repo := &countTokensRuntimeStateRepo{}
+			svc := &OpenAIGatewayService{
+				cfg:              &config.Config{},
+				httpUpstream:     upstream,
+				rateLimitService: &RateLimitService{accountRepo: repo, cfg: &config.Config{}},
+			}
+			prepared, err := svc.prepareDirectOpenAIInputTokensRequest(body, account)
+			require.NoError(t, err)
+			expectedEstimate, err := estimateOpenAIInputTokens(prepared.Request)
+			require.NoError(t, err)
+
+			err = svc.ForwardInputTokens(context.Background(), c, account, body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, rec.Code)
+			require.JSONEq(t, `{"object":"response.input_tokens","input_tokens":`+strconv.Itoa(expectedEstimate)+`}`, rec.Body.String())
+			require.Equal(t, openAIInputTokensSourceLocalFallback, rec.Header().Get(openAIInputTokensSourceHeader))
+			require.Len(t, upstream.requests, 1, "input_tokens must never switch accounts or retry upstream")
+			require.Zero(t, repo.tempUnschedCalls, "direct OAuth input_tokens errors must not temp-unschedule the account")
+			require.Zero(t, repo.setErrorCalls, "direct OAuth input_tokens errors must not mark the account error")
+		})
+	}
+}
+
+func TestOpenAIGatewayService_ForwardInputTokens_APIKeyUsesPlatformEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{"model":"gpt-5.6-sol","input":"hello"}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses/input_tokens", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(`{"object":"response.input_tokens","input_tokens":9}`)),
+	}}
+	account := &Account{
+		ID:          403,
+		Name:        "openai-api-key",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key": "sk-test",
+		},
+		Status:      StatusActive,
+		Schedulable: true,
+	}
+	svc := &OpenAIGatewayService{
+		cfg:          &config.Config{},
+		httpUpstream: upstream,
+	}
+
+	err := svc.ForwardInputTokens(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, openAIInputTokensSourceUpstream, rec.Header().Get(openAIInputTokensSourceHeader))
+	require.Len(t, upstream.requests, 1)
+	require.Equal(t, "https://api.openai.com/v1/responses/input_tokens", upstream.lastReq.URL.String())
+	require.Equal(t, "Bearer sk-test", upstream.lastReq.Header.Get("Authorization"))
+}
+
 func TestOpenAIGatewayService_ForwardCountTokensAsAnthropic_APIKeyUsesResponsesInputTokens(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/openai_gateway_forward.go
+++ b/backend/internal/service/openai_gateway_forward.go
@@ -841,6 +841,7 @@ func (s *OpenAIGatewayService) Forward(ctx context.Context, c *gin.Context, acco
 			respBody := s.readUpstreamErrorBody(resp)
 			_ = resp.Body.Close()
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
+			respBody, _ = normalizeOpenAICloudflareForbiddenResponse(account, resp, respBody)
 
 			upstreamMsg := strings.TrimSpace(extractUpstreamErrorMessage(respBody))
 			upstreamMsg = sanitizeUpstreamErrorMessage(upstreamMsg)

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -210,6 +210,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		probeBody := s.readUpstreamErrorBody(resp)
 		_ = resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewReader(probeBody))
+		probeBody, _ = normalizeOpenAICloudflareForbiddenResponse(account, resp, probeBody)
 		if !agentTaskRecoveryTried && s.isAgentIdentityAccount(ctx, account) && isAgentIdentityTaskInvalidHTTPResponse(resp.StatusCode, probeBody) {
 			agentTaskRecoveryTried = true
 			expectedTaskID := account.GetCredential("task_id")
@@ -612,6 +613,7 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 ) error {
 	MarkResponseCommitted(c)
 	body := s.redactAgentIdentitySensitiveBody(ctx, account, responseBody)
+	body, _ = normalizeOpenAICloudflareForbiddenResponse(account, resp, body)
 
 	// cyber_policy 仍按原始 body 打内部标记，供 handler 事后写风控/邮件；面向客户端的
 	// 错误体在下方统一重建。cyber 是上游网络安全策略拦截，不冷却账号，

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -322,6 +322,7 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 ) (*OpenAIForwardResult, error) {
 	body := s.readUpstreamErrorBody(resp)
 	body = s.redactAgentIdentitySensitiveBody(ctx, account, body)
+	body, _ = normalizeOpenAICloudflareForbiddenResponse(account, resp, body)
 
 	// cyber_policy 硬阻断：透传上游原始错误体给客户端（不重包成通用 502），不冷却账号。
 	// 当前请求恒透传（需求1）；标记供 handler 事后写风控/邮件。400 cyber 不可 failover
@@ -505,6 +506,10 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 		statusCode = http.StatusBadGateway
 		errType = "upstream_error"
 		errMsg = "Upstream access forbidden, please contact administrator"
+	case 404:
+		statusCode = http.StatusNotFound
+		errType = "not_found_error"
+		errMsg = "Not found"
 	case 429:
 		statusCode = http.StatusTooManyRequests
 		errType = "rate_limit_error"
@@ -549,6 +554,7 @@ func (s *OpenAIGatewayService) handleCompatErrorResponse(
 ) (*OpenAIForwardResult, error) {
 	body := s.readUpstreamErrorBody(resp)
 	body = s.redactAgentIdentitySensitiveBody(context.Background(), account, body)
+	body, _ = normalizeOpenAICloudflareForbiddenResponse(account, resp, body)
 
 	// cyber_policy：兼容路径（Chat Completions / Anthropic）以各自格式回写错误，
 	// 不原样透传 responses 格式的 cyber body（否则对下游格式不合法）。cyber 是上游网络

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -177,6 +177,10 @@ func (s *RateLimitService) CheckErrorPolicy(ctx context.Context, account *Accoun
 // 返回是否应该停止该账号的调度
 func (s *RateLimitService) HandleUpstreamError(ctx context.Context, account *Account, statusCode int, headers http.Header, responseBody []byte, requestedModel ...string) (shouldDisable bool) {
 	ctx = withTempUnschedulableModel(ctx, requestedModel)
+	if isOpenAICloudflareForbiddenResponse(account, statusCode, headers, responseBody) {
+		slog.Info("openai_cloudflare_403_ignored", "account_id", account.ID, "cf_ray", strings.TrimSpace(headers.Get("cf-ray")))
+		return false
+	}
 	customErrorCodesEnabled := account.IsCustomErrorCodesEnabled()
 
 	// 池模式默认不标记本地账号状态；但管理员显式配置的临时不可调度规则优先。

--- a/backend/internal/util/httputil/httputil.go
+++ b/backend/internal/util/httputil/httputil.go
@@ -50,6 +50,26 @@ func IsCloudflareChallengeResponse(statusCode int, headers http.Header, body []b
 	return false
 }
 
+// IsCloudflareGeneratedErrorResponse reports whether the response was generated
+// by Cloudflare itself rather than merely proxied through Cloudflare.
+//
+// cf-ray and Server: cloudflare are intentionally not sufficient: both can be
+// present on an origin-generated response. Cloudflare's diagnostic error
+// headers and unmistakable challenge responses are safe signals.
+func IsCloudflareGeneratedErrorResponse(statusCode int, headers http.Header, body []byte) bool {
+	if statusCode != http.StatusForbidden && statusCode != http.StatusTooManyRequests {
+		return false
+	}
+
+	if headers != nil &&
+		(strings.TrimSpace(headers.Get("cf-error-type")) != "" ||
+			strings.TrimSpace(headers.Get("cf-error-origin")) != "") {
+		return true
+	}
+
+	return IsCloudflareChallengeResponse(statusCode, headers, body)
+}
+
 // ExtractCloudflareRayID extracts cf-ray from headers or response body.
 func ExtractCloudflareRayID(headers http.Header, body []byte) string {
 	if headers != nil {

--- a/backend/internal/util/httputil/httputil_test.go
+++ b/backend/internal/util/httputil/httputil_test.go
@@ -1,0 +1,41 @@
+//go:build unit
+
+package httputil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsCloudflareGeneratedErrorResponse(t *testing.T) {
+	t.Run("cf-error-type identifies Cloudflare generated 403", func(t *testing.T) {
+		headers := http.Header{"Cf-Error-Type": []string{"waf"}}
+		require.True(t, IsCloudflareGeneratedErrorResponse(http.StatusForbidden, headers, []byte("blocked")))
+	})
+
+	t.Run("cf-error-origin identifies Cloudflare generated 403", func(t *testing.T) {
+		headers := http.Header{"Cf-Error-Origin": []string{"edge"}}
+		require.True(t, IsCloudflareGeneratedErrorResponse(http.StatusForbidden, headers, []byte("blocked")))
+	})
+
+	t.Run("challenge marker identifies Cloudflare generated 403", func(t *testing.T) {
+		headers := http.Header{"Cf-Mitigated": []string{"challenge"}}
+		require.True(t, IsCloudflareGeneratedErrorResponse(http.StatusForbidden, headers, nil))
+	})
+
+	t.Run("cf-ray alone does not classify an origin 403 as Cloudflare generated", func(t *testing.T) {
+		headers := http.Header{
+			"Cf-Ray": []string{"abc123-SJC"},
+			"Server": []string{"cloudflare"},
+		}
+		body := []byte(`{"error":{"message":"workspace access forbidden"}}`)
+		require.False(t, IsCloudflareGeneratedErrorResponse(http.StatusForbidden, headers, body))
+	})
+
+	t.Run("diagnostic headers do not remap non Cloudflare error statuses", func(t *testing.T) {
+		headers := http.Header{"Cf-Error-Type": []string{"waf"}}
+		require.False(t, IsCloudflareGeneratedErrorResponse(http.StatusNotFound, headers, nil))
+	})
+}


### PR DESCRIPTION
## 问题

OpenAI 网关存在两条相关的账号池可用性问题：

1. 客户端直接请求 `POST /v1/responses/input_tokens` 时，会命中 `/responses/*subpath` 通配路由并进入普通 Responses 转发链路。OpenAI OAuth 上游对该路径常返回 HTML 403/404，随后被通用 403 策略当作账号权限故障，触发 403 计数、跨账号重试和临时不可调度。
2. 客户端构造不存在的 Responses 子路径时，OpenAI 边缘 Cloudflare 可能返回生成的 HTML 403。该响应同样会进入账号错误策略，从而把“请求路径不存在”错误放大为账号池状态变更。

这两类请求本身都不能证明账号凭据或权限失效，不应改变账号调度状态。

## 严重性

**高危 / P1 可用性风险。**

- 利用前提只是持有一个绑定 OpenAI 分组的有效 Sub2API API Key；在多租户部署中普通用户通常已满足该条件。
- 每个并发构造请求都可能选择并冷却一个不同账号。若号池有 N 个账号，攻击者可用约 N 个并发请求快速耗尽整个池；例如 10 个并发请求即可让 10 账号池整体不可用。
- 默认 403 冷却会造成分钟级拒绝服务；若部署配置了自定义 403 临时不可调度规则，影响时长可能更长，并可能需要管理员介入恢复。
- 影响集中在可用性，不涉及数据泄露或权限提升，因此不评为 Critical；但其攻击成本低、放大效果明显，按生产运营风险应视为 High/P1。

## 根因

1. `responses/input_tokens` 没有独立端点语义，被当作普通 Responses 子路径处理，因而复用了生成请求的账号选择、failover 和错误惩罚链路。
2. OpenAI 错误处理只看到 403 状态码时，无法区分：
   - OpenAI 源站返回的真实权限/凭据 403；
   - Cloudflare 边缘针对无效路径生成的 HTML/WAF 403。
3. Cloudflare 403 在进入自定义临时不可调度规则和 OpenAI 403 连续计数前没有被归一化。

## 修复

### 1. 隔离 Responses `input_tokens`

- 将以下路径识别为独立的 `responses_input_tokens` 端点：
  - `/v1/responses/input_tokens`
  - `/responses/input_tokens`
  - `/backend-api/codex/responses/input_tokens`
- 使用 Responses 能力选择且只选择一个账号，不进入普通 Responses failover。
- OpenAI OAuth 上游返回 401/403/404 时，使用本地 tiktoken 估算并返回标准 `response.input_tokens` 结果。
- OpenAI API Key 账号继续正常转发官方 `/v1/responses/input_tokens`。
- 辅助计数请求失败不会触发通用 RateLimit、403 连续计数、临时不可调度或永久错误状态。

### 2. 区分 Cloudflare 生成的 OpenAI 403

- 根据 Cloudflare 特征响应头、HTML/内容类型等信号识别边缘生成错误。
- 仅对 **OpenAI 平台 + Cloudflare 生成的 403** 归一化为：

```json
{"error":{"type":"not_found_error","message":"Not found"}}
```

- 下游状态码返回 404，并在账号惩罚、failover、自定义临时不可调度规则和 403 计数前终止处理。
- OpenAI 源站 JSON 403 保持原行为，不做宽泛的 403→404 改写。

## 行为变化

| 场景 | 修复前 | 修复后 |
|---|---|---|
| OAuth `/responses/input_tokens` 上游 401/403/404 | 502/404，可能冷却账号并跨账号重试 | 200，本地 token 估算，账号状态不变 |
| API Key `/responses/input_tokens` | 混入普通 Responses 子路径链路 | 正常转发官方计数端点 |
| 不存在路径触发 Cloudflare HTML 403 | 403 策略可能冷却/错误化账号 | 标准 JSON 404，账号状态不变 |
| OpenAI 源站真实 JSON 403 | 403 账号策略 | 保持原有 403 账号策略 |

## 与现有 PR 的关系

- #1373 通过对 OAuth 非 compact 子路径快速返回 502 来避免上游调用，能缓解误封，但没有实现 #4491 要求的正式 `input_tokens` 200 计数语义，也不覆盖 API Key 转发。
- 本 PR 对正式 `input_tokens` 端点提供完整处理，同时补充更窄的 Cloudflare 生成 403 识别，避免任意不存在路径影响账号状态。
- 已检查当前开放 PR；除上述 #1373 的局部重叠外，未发现其他覆盖 #4491 预期行为的实现。

## 验证

### 自动化测试

- 新增端点识别、三种路由入口及专用 handler 回归测试。
- 新增 OAuth 401/403/404 本地估算、API Key 转发、单账号选择与无 failover 测试。
- 新增 Cloudflare 403 识别、响应归一化、真实源站 403 保留测试。
- 新增账号状态保护测试：不增加 403 计数、不设置临时不可调度、不命中自定义 403 冷却规则。
- 定向单元测试通过：

```bash
go test -tags=unit ./internal/util/httputil ./internal/service ./internal/handler ./internal/server/routes -count=1
```

- 同一补丁已通过完整 GitHub Actions：后端单元测试、集成测试、golangci-lint、前端检查、部署脚本检查及安全扫描。
- `git diff --check` 通过。

### 实机回归

在自有实例使用同一个 OpenAI OAuth 账号连续执行：

1. `POST /v1/responses/input_tokens` → 200，`input_tokens=2`，来源 `local-fallback`；
2. `POST /v1/responses/not-exist-*` → 404，标准 `not_found_error`；
3. 再次调用 `POST /v1/responses/input_tokens` → 200，仍由同一个账号正常处理。

测试前后 OpenAI 账号状态指纹完全一致，活动临时不可调度账号数保持为 0，证明不存在路径不会再消耗号池。

Fixes #4491
