### PR TITLE
fix(openai): honor passthrough over non-empty model_mapping in account selection (#4936)

### DIFF
--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -779,9 +779,16 @@ func resolveRequestedModelInMapping(mapping map[string]string, requestedModel st
 // 请求卡死在该账号上、无法 failover 到真正支持该模型的 API Key 账号（#3662）。
 // 未知/自定义别名仍保持允许（兼容渠道级映射），见 isOpenAIOAuthServableModel。
 func (a *Account) IsModelSupported(requestedModel string) bool {
+	// 透传模式仅替换认证、模型语义完全交由上游决定，因此放行所有模型。
+	// 该短路必须在 model_mapping 判定之前：账号从"白名单模式"切换到透传后，
+	// credentials 里常残留旧的非空 model_mapping，若不在此放行，透传账号会被
+	// model_mapping 白名单错误排除出候选集，导致 no available accounts / 404（issue #4936）。
+	if a.IsOpenAIPassthroughEnabled() {
+		return true
+	}
 	mapping := a.GetModelMapping()
 	if len(mapping) == 0 {
-		if a.IsOpenAIOAuth() && !a.IsOpenAIPassthroughEnabled() {
+		if a.IsOpenAIOAuth() {
 			return isOpenAIOAuthServableModel(requestedModel)
 		}
 		return true // 无映射 = 允许所有

--- a/backend/internal/service/openai_oauth_model_support_test.go
+++ b/backend/internal/service/openai_oauth_model_support_test.go
@@ -81,6 +81,20 @@ func TestIsModelSupported_OpenAIOAuthPassthroughAllowsAll(t *testing.T) {
 	require.True(t, account.IsModelSupported("deepseek-v4"))
 }
 
+func TestIsModelSupported_OpenAIOAuthPassthroughIgnoresLeftoverMapping(t *testing.T) {
+	account := newOpenAIOAuthAccountForModelTest()
+	account.Extra = map[string]any{"openai_passthrough": true}
+	// 账号从"白名单模式"切到透传后，credentials 里常残留旧的非空 model_mapping。
+	// 透传应无视该白名单，放行不在其中的模型（issue #4936）；否则透传账号会被
+	// 调度期的 IsModelSupported 排除，客户端收到 404 "not supported by any account"。
+	account.Credentials = map[string]any{
+		"model_mapping": map[string]any{"gpt-5.4": "gpt-5.4"},
+	}
+
+	require.True(t, account.IsModelSupported("gpt-5.6-sol"), "透传应放行不在残留白名单中的新模型")
+	require.True(t, account.IsModelSupported("deepseek-v4"), "透传应放行任意模型")
+}
+
 func TestIsModelSupported_OpenAIAPIKeyEmptyMappingAllowsAll(t *testing.T) {
 	account := &Account{
 		ID:       2,


### PR DESCRIPTION
Fixes #4936.

## Problem

An OpenAI account with auto-passthrough enabled (`extra.openai_passthrough = true`, "replace auth only, allow all models") is still filtered out during account selection when it carries a **non-empty** `credentials.model_mapping` that does not list the requested model. The client then gets:

```
404 Model "<model>" is not supported by any configured account in this group
```

…even though a direct admin "test account connection" with the same model **succeeds** (that path goes through `isModelSupportedByAccount`, which already honors passthrough).

## Root cause

Account selection (`isOpenAICompatibleAccountEligibleForRequest`, `openai_gateway_scheduling.go:290`) calls `Account.IsModelSupported(requestedModel)` directly. In `account.go`, `IsModelSupported` only bypasses the `model_mapping` whitelist for passthrough accounts **when the mapping is empty**:

```go
func (a *Account) IsModelSupported(requestedModel string) bool {
    mapping := a.GetModelMapping()
    if len(mapping) == 0 {
        if a.IsOpenAIOAuth() && !a.IsOpenAIPassthroughEnabled() {
            return isOpenAIOAuthServableModel(requestedModel)
        }
        return true
    }
    // mapping is non-empty -> whitelist enforced, passthrough ignored  <-- bug
    ...
}
```

A leftover non-empty mapping (common after switching an account from whitelist mode to passthrough) therefore excludes the account → zero candidates → `ErrNoAvailableAccounts` → 404. This is inconsistent with `isModelSupportedByAccount`, which short-circuits passthrough before the whitelist.

## Fix

Short-circuit passthrough at the top of `Account.IsModelSupported`, before the `model_mapping` check, so account selection is consistent with `isModelSupportedByAccount`. `IsOpenAIPassthroughEnabled()` is platform-guarded (returns false unless `IsOpenAI()`), so non-OpenAI accounts are unaffected. The now-redundant `&& !a.IsOpenAIPassthroughEnabled()` in the empty-mapping branch is removed.

## Test

Adds `TestIsModelSupported_OpenAIOAuthPassthroughIgnoresLeftoverMapping` covering passthrough + non-empty leftover mapping (the previously untested case). Existing `Passthrough|Wildcard|ModelSupport|Eligible|ModelMapping|Servable` tests still pass.

## Workaround (for operators on affected versions)

Clear `credentials.model_mapping` on passthrough OpenAI accounts. Note the admin UI edit form may resubmit the existing mapping; clearing it directly in the DB (`credentials = credentials - 'model_mapping'`) and restarting the backend (to drop the cached account) is reliable.