### PR TITLE
fix(openai): preserve GPT-5.6 max effort in messages bridges

### DIFF
--- a/backend/internal/service/openai_compat_model.go
+++ b/backend/internal/service/openai_compat_model.go
@@ -101,3 +101,17 @@ func openAIReasoningEffortToClaudeOutputEffort(effort string) string {
 		return ""
 	}
 }
+
+// openAICompatAnthropicReasoningEffort resolves the effort emitted by the
+// Anthropic bridge after the final upstream model is known. Anthropic's max is
+// normally translated to OpenAI xhigh, but GPT-5.6 accepts the original max
+// value on Responses and Chat Completions.
+func openAICompatAnthropicReasoningEffort(req *apicompat.AnthropicRequest, upstreamModel, convertedEffort string) string {
+	if req == nil || req.OutputConfig == nil || !strings.EqualFold(strings.TrimSpace(req.OutputConfig.Effort), "max") {
+		return convertedEffort
+	}
+	if normalized := normalizeOpenAIReasoningEffortForModel(req.OutputConfig.Effort, upstreamModel); normalized != "" {
+		return normalized
+	}
+	return convertedEffort
+}

--- a/backend/internal/service/openai_compat_model_test.go
+++ b/backend/internal/service/openai_compat_model_test.go
@@ -233,6 +233,116 @@ func TestForwardAsAnthropic_NormalizesRoutingAndEffortForGpt54XHigh(t *testing.T
 	t.Logf("response body: %s", rec.Body.String())
 }
 
+func TestForwardAsAnthropic_PreservesMaxForFinalGPT56ResponsesModel(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name          string
+		account       *Account
+		model         string
+		defaultMapped string
+		effort        string
+		wantModel     string
+		wantEffort    string
+	}{
+		{
+			name:          "API Key mapping wins and keeps Luna max",
+			account:       rawGPT56ResponsesAPIKeyAccount("luna", "gpt-5.6-luna"),
+			model:         "luna",
+			defaultMapped: "gpt-5.6-sol",
+			effort:        "max",
+			wantModel:     "gpt-5.6-luna",
+			wantEffort:    "max",
+		},
+		{
+			name:          "OAuth mapping wins and keeps Sol max",
+			account:       rawGPT56ResponsesOAuthAccount("sol", "gpt-5.6-sol"),
+			model:         "sol",
+			defaultMapped: "gpt-5.6-terra",
+			effort:        "max",
+			wantModel:     "gpt-5.6-sol",
+			wantEffort:    "max",
+		},
+		{
+			name:       "old model still maps max to xhigh",
+			account:    rawGPT56ResponsesAPIKeyAccount("gpt-5.5", "gpt-5.5"),
+			model:      "gpt-5.5",
+			effort:     "max",
+			wantModel:  "gpt-5.5",
+			wantEffort: "xhigh",
+		},
+		{
+			name:       "GPT56 default remains medium",
+			account:    rawGPT56ResponsesAPIKeyAccount("gpt-5.6-sol", "gpt-5.6-sol"),
+			model:      "gpt-5.6-sol",
+			wantModel:  "gpt-5.6-sol",
+			wantEffort: "medium",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := `{"model":"` + tt.model + `","max_tokens":16,"messages":[{"role":"user","content":"hello"}`
+			if tt.effort != "" {
+				body += `],"output_config":{"effort":"` + tt.effort + `"},"stream":false}`
+			} else {
+				body += `],"stream":false}`
+			}
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: openAICompatSSECompletedResponse("resp_gpt56_"+tt.name, tt.wantModel)}
+			svc := &OpenAIGatewayService{
+				httpUpstream: upstream,
+				cfg:          &config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+			}
+
+			result, err := svc.ForwardAsAnthropic(context.Background(), c, tt.account, []byte(body), "", tt.defaultMapped)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.wantModel, result.UpstreamModel)
+			require.Equal(t, tt.wantModel, gjson.GetBytes(upstream.lastBody, "model").String())
+			require.Equal(t, tt.wantEffort, gjson.GetBytes(upstream.lastBody, "reasoning.effort").String())
+			require.NotNil(t, result.ReasoningEffort)
+			require.Equal(t, tt.wantEffort, *result.ReasoningEffort)
+		})
+	}
+}
+
+func rawGPT56ResponsesAPIKeyAccount(requestedModel, mappedModel string) *Account {
+	return &Account{
+		ID:          501,
+		Name:        "gpt56-apikey",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"api_key":       "sk-test",
+			"base_url":      "https://api.example.com/v1",
+			"model_mapping": map[string]any{requestedModel: mappedModel},
+		},
+		Extra: map[string]any{"use_responses_api": true},
+	}
+}
+
+func rawGPT56ResponsesOAuthAccount(requestedModel, mappedModel string) *Account {
+	return &Account{
+		ID:          502,
+		Name:        "gpt56-oauth",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+			"model_mapping":      map[string]any{requestedModel: mappedModel},
+		},
+	}
+}
+
 func TestForwardAsAnthropic_MappedClaudeModelAcceptsChatUsageShape(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -124,6 +124,9 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	responsesReq.Model = upstreamModel
+	if responsesReq.Reasoning != nil {
+		responsesReq.Reasoning.Effort = openAICompatAnthropicReasoningEffort(&anthropicReq, upstreamModel, responsesReq.Reasoning.Effort)
+	}
 	if previousResponseID != "" {
 		responsesReq.PreviousResponseID = previousResponseID
 		trimAnthropicCompatResponsesInputToLatestTurn(responsesReq)

--- a/backend/internal/service/openai_gateway_messages_chat_fallback.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback.go
@@ -60,12 +60,14 @@ func (s *OpenAIGatewayService) forwardAnthropicViaRawChatCompletions(
 	billingModel := resolveOpenAIForwardModel(account, anthropicReq.Model, defaultMappedModel)
 	upstreamModel := normalizeOpenAIModelForUpstream(account, billingModel)
 	chatReq.Model = upstreamModel
+	chatReq.ReasoningEffort = openAICompatAnthropicReasoningEffort(&anthropicReq, upstreamModel, chatReq.ReasoningEffort)
 	chatReq.Stream = clientStream
 	if clientStream {
 		chatReq.StreamOptions = &apicompat.ChatStreamOptions{IncludeUsage: true}
 	}
 
-	reasoningEffort := extractOpenAIReasoningEffortFromBody(body, upstreamModel, billingModel, originalModel)
+	convertedEffort := chatReq.ReasoningEffort
+	reasoningEffort := &convertedEffort
 	reasoningEffort = ApplyThinkingEnabledFallback(reasoningEffort, body, billingModel)
 	serviceTier := extractOpenAIServiceTierFromBody(body)
 

--- a/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
+++ b/backend/internal/service/openai_gateway_messages_chat_fallback_test.go
@@ -45,6 +45,75 @@ func (r *errTailReader) Read(p []byte) (int, error) {
 
 func (r *errTailReader) Close() error { return nil }
 
+func TestForwardAsAnthropic_ForceChatCompletionsPreservesFinalModelReasoningEffort(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		model      string
+		mapped     string
+		effortJSON string
+		wantEffort string
+	}{
+		{
+			name:       "GPT56 max",
+			model:      "luna",
+			mapped:     "gpt-5.6-luna",
+			effortJSON: `,"output_config":{"effort":"max"}`,
+			wantEffort: "max",
+		},
+		{
+			name:       "old model max",
+			model:      "gpt-5.5",
+			mapped:     "gpt-5.5",
+			effortJSON: `,"output_config":{"effort":"max"}`,
+			wantEffort: "xhigh",
+		},
+		{
+			name:       "high remains high",
+			model:      "gpt-5.6-luna",
+			mapped:     "gpt-5.6-luna",
+			effortJSON: `,"output_config":{"effort":"high"}`,
+			wantEffort: "high",
+		},
+		{
+			name:       "omitted defaults medium",
+			model:      "gpt-5.6-luna",
+			mapped:     "gpt-5.6-luna",
+			wantEffort: "medium",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			body := `{"model":"` + tt.model + `","max_tokens":16,"messages":[{"role":"user","content":"hello"}]` + tt.effortJSON + `,"stream":false}`
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader([]byte(body)))
+			c.Request.Header.Set("Content-Type", "application/json")
+
+			upstream := &httpUpstreamRecorder{resp: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body: io.NopCloser(strings.NewReader(
+					`{"id":"chatcmpl_effort","object":"chat.completion","model":"` + tt.mapped + `","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}`,
+				)),
+			}}
+			account := forceChatMessagesFallbackAccount()
+			account.Credentials["model_mapping"] = map[string]any{tt.model: tt.mapped}
+
+			svc := &OpenAIGatewayService{cfg: rawChatCompletionsTestConfig(), httpUpstream: upstream}
+			result, err := svc.ForwardAsAnthropic(context.Background(), c, account, []byte(body), "", "")
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tt.mapped, gjson.GetBytes(upstream.lastBody, "model").String())
+			require.Equal(t, tt.wantEffort, gjson.GetBytes(upstream.lastBody, "reasoning_effort").String())
+			require.NotNil(t, result.ReasoningEffort)
+			require.Equal(t, tt.wantEffort, *result.ReasoningEffort)
+		})
+	}
+}
+
 func TestForwardAsAnthropic_ForceChatCompletionsNonStreaming(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
## 问题

Anthropic `/v1/messages` 桥接会在最终模型映射完成前，将显式 `output_config.effort=max` 通用转换为 OpenAI `xhigh`。当分组 Messages 调度、渠道映射或账号级映射最终选择 `gpt-5.6-sol`、`gpt-5.6-terra` 或 `gpt-5.6-luna` 时，实际 Responses/Chat Completions 请求因此无法使用 GPT-5.6 支持的独立 `max` 档位。

## 根因

通用 Anthropic converter 不知道账号与分组路由产生的最终 `upstreamModel`，只能执行兼容性的 `max -> xhigh`。随后 service 层虽然替换了请求模型，却没有依据最终模型重新校正 effort。Responses bridge 和 API Key direct Chat Completions fallback 都存在相同的顺序问题。

## 修复

- 在最终 `upstreamModel` 确定后，对两条 Anthropic Messages bridge 统一执行模型感知的 effort 校正。
- 仅当入站 `output_config.effort` 明确为 `max` 且最终模型属于 GPT-5.6 系列时恢复为 `max`。
- 非 GPT-5.6 模型继续使用 `xhigh`；缺失 effort 继续使用 converter 默认的 `medium`；其他显式 effort 保持不变。
- 复用现有 `normalizeOpenAIReasoningEffortForModel` 和 GPT-5.6 模型识别逻辑，不将模型路由知识下沉到通用 converter。
- 同步使用校正后的请求 effort 记录 usage/result 元数据，确保实际 wire body 与记录一致。

## 范围

本 PR 覆盖：

- Anthropic Messages -> OpenAI Responses/Codex Responses
- Anthropic Messages -> direct Chat Completions fallback

本 PR 不改变：

- 通用 `apicompat` 的 `max -> xhigh` fallback
- `/responses/compact` 的既有兼容规则
- 从 `gpt-5.6-luna-max` 等模型名后缀推导 effort 的行为
- 原生 `/v1/responses`、WebSocket、GLM 或 Grok 路径

## 测试

新增回归测试覆盖：

- API Key Responses 最终映射到 GPT-5.6 时保留 `max`
- OAuth `/v1/messages` 最终映射到 GPT-5.6 时保留 `max`
- 账号级映射优先于分组默认映射，且 effort 依据最终模型判断
- direct Chat Completions fallback 最终输出 `reasoning_effort=max`
- 非 GPT-5.6 的显式 `max` 仍输出 `xhigh`
- GPT-5.6 缺失 effort 仍为 `medium`
- 非 `max` effort 保持不变

验证命令：

```bash
cd backend
go test -tags=unit ./internal/service ./internal/pkg/apicompat -count=1
```

结果：通过。

Fixes #3942