### PR TITLE
fix(gemini): preserve response_format for structured output

### DIFF
--- a/backend/internal/pkg/apicompat/response_format.go
+++ b/backend/internal/pkg/apicompat/response_format.go
@@ -70,6 +70,37 @@ func responsesTextFormatToChatResponseFormat(raw json.RawMessage) json.RawMessag
 	return out
 }
 
+func responsesTextFormatToAnthropicJSONOutputFormat(raw json.RawMessage) *AnthropicJSONOutputFormat {
+	raw = normalizedRawJSON(raw)
+	if len(raw) == 0 {
+		return nil
+	}
+
+	obj, ok := rawJSONObject(raw)
+	if !ok {
+		return nil
+	}
+
+	switch rawString(obj["type"]) {
+	case "json_object":
+		return &AnthropicJSONOutputFormat{
+			Type:   "json_schema",
+			Schema: json.RawMessage(`{"type":"object"}`),
+		}
+	case "json_schema":
+		schema := normalizedRawJSON(obj["schema"])
+		if len(schema) == 0 {
+			return nil
+		}
+		return &AnthropicJSONOutputFormat{
+			Type:   "json_schema",
+			Schema: schema,
+		}
+	default:
+		return nil
+	}
+}
+
 func normalizedRawJSON(raw json.RawMessage) json.RawMessage {
 	raw = bytesTrimSpace(raw)
 	if len(raw) == 0 || string(raw) == "null" {

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_cc_chain_test.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_cc_chain_test.go
@@ -100,3 +100,40 @@ func TestCCChain_WellFormedMultiRound(t *testing.T) {
 	}
 	require.True(t, sawA && sawB, "both well-formed calls should be preserved")
 }
+
+func TestCCChain_PreservesStructuredOutputFormat(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseFormat json.RawMessage
+		expectedSchema string
+	}{
+		{
+			name:           "json_schema",
+			responseFormat: json.RawMessage(`{"type":"json_schema","json_schema":{"name":"cities","strict":true,"schema":{"type":"object","properties":{"cities":{"type":"array"}},"additionalProperties":false}}}`),
+			expectedSchema: `{"type":"object","properties":{"cities":{"type":"array"}},"additionalProperties":false}`,
+		},
+		{
+			name:           "json_object",
+			responseFormat: json.RawMessage(`{"type":"json_object"}`),
+			expectedSchema: `{"type":"object"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			responsesReq, err := ChatCompletionsToResponses(&ChatCompletionsRequest{
+				Model:          "gemini-2.5-flash",
+				Messages:       []ChatMessage{{Role: "user", Content: json.RawMessage(`"Return JSON"`)}},
+				ResponseFormat: tt.responseFormat,
+			})
+			require.NoError(t, err)
+
+			anthropicReq, err := ResponsesToAnthropicRequest(responsesReq)
+			require.NoError(t, err)
+			require.NotNil(t, anthropicReq.OutputConfig)
+			require.NotNil(t, anthropicReq.OutputConfig.Format)
+			require.Equal(t, "json_schema", anthropicReq.OutputConfig.Format.Type)
+			require.JSONEq(t, tt.expectedSchema, string(anthropicReq.OutputConfig.Format.Schema))
+		})
+	}
+}

--- a/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
+++ b/backend/internal/pkg/apicompat/responses_to_anthropic_request.go
@@ -51,10 +51,22 @@ func ResponsesToAnthropicRequest(req *ResponsesRequest) (*AnthropicRequest, erro
 		out.ToolChoice = tc
 	}
 
+	if req.Text != nil {
+		if format := responsesTextFormatToAnthropicJSONOutputFormat(req.Text.Format); format != nil {
+			if out.OutputConfig == nil {
+				out.OutputConfig = &AnthropicOutputConfig{}
+			}
+			out.OutputConfig.Format = format
+		}
+	}
+
 	// reasoning.effort → output_config.effort + thinking
 	if req.Reasoning != nil && req.Reasoning.Effort != "" {
 		effort := mapResponsesEffortToAnthropic(req.Reasoning.Effort)
-		out.OutputConfig = &AnthropicOutputConfig{Effort: effort}
+		if out.OutputConfig == nil {
+			out.OutputConfig = &AnthropicOutputConfig{}
+		}
+		out.OutputConfig.Effort = effort
 		// Enable thinking for non-low efforts
 		if effort != "low" {
 			out.Thinking = &AnthropicThinking{

--- a/backend/internal/pkg/apicompat/types.go
+++ b/backend/internal/pkg/apicompat/types.go
@@ -33,11 +33,21 @@ type AnthropicRequest struct {
 	// user_id，进而导致请求被归类为第三方 app。
 	Metadata     json.RawMessage        `json:"metadata,omitempty"`
 	OutputConfig *AnthropicOutputConfig `json:"output_config,omitempty"`
+	// OutputFormat preserves the deprecated top-level structured-output field
+	// when an Anthropic request is parsed and re-serialized.
+	OutputFormat *AnthropicJSONOutputFormat `json:"output_format,omitempty"`
 }
 
 // AnthropicOutputConfig controls output generation parameters.
 type AnthropicOutputConfig struct {
-	Effort string `json:"effort,omitempty"` // "low" | "medium" | "high" | "max"
+	Effort string                     `json:"effort,omitempty"` // "low" | "medium" | "high" | "max"
+	Format *AnthropicJSONOutputFormat `json:"format,omitempty"`
+}
+
+// AnthropicJSONOutputFormat configures schema-constrained JSON output.
+type AnthropicJSONOutputFormat struct {
+	Type   string          `json:"type"`
+	Schema json.RawMessage `json:"schema,omitempty"`
 }
 
 // AnthropicThinking configures extended thinking in the Anthropic API.

--- a/backend/internal/service/bedrock_request.go
+++ b/backend/internal/service/bedrock_request.go
@@ -269,17 +269,21 @@ func ResolveBedrockBetaTokens(betaHeader string, body []byte, modelID string) []
 	return filterBedrockBetaTokens(betaTokens)
 }
 
-// convertOutputFormatToInlineSchema 将 output_format 中的 JSON schema 内联到最后一条 user message
+// convertOutputFormatToInlineSchema 将结构化输出的 JSON schema 内联到最后一条 user message。
 // Bedrock Invoke 不支持 output_format 参数，litellm 的做法是将 schema 追加到用户消息中
 // 参考: litellm AmazonAnthropicClaudeMessagesConfig._convert_output_format_to_inline_schema()
 func convertOutputFormatToInlineSchema(body []byte) []byte {
-	outputFormat := gjson.GetBytes(body, "output_format")
+	outputFormat := gjson.GetBytes(body, "output_config.format")
+	if !outputFormat.Exists() {
+		outputFormat = gjson.GetBytes(body, "output_format")
+	}
 	if !outputFormat.Exists() || !outputFormat.IsObject() {
 		return body
 	}
 
-	// 先从请求体中移除 output_format
+	// 先从请求体中移除两个版本的结构化输出字段。
 	body, _ = sjson.DeleteBytes(body, "output_format")
+	body, _ = sjson.DeleteBytes(body, "output_config.format")
 
 	schema := outputFormat.Get("schema")
 	if !schema.Exists() {

--- a/backend/internal/service/bedrock_request_test.go
+++ b/backend/internal/service/bedrock_request_test.go
@@ -48,6 +48,17 @@ func TestPrepareBedrockRequestBody_OutputFormatInlineSchema(t *testing.T) {
 		assert.Contains(t, contentArr[1].Get("text").String(), `"result":"number"`)
 	})
 
+	t.Run("schema in output_config format is inlined", func(t *testing.T) {
+		input := `{"model":"claude-sonnet-4-5","output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"result":{"type":"number"}}}}},"messages":[{"role":"user","content":"compute this"}]}`
+		result, err := PrepareBedrockRequestBody([]byte(input), "us.anthropic.claude-sonnet-4-5-v1", "")
+		require.NoError(t, err)
+
+		assert.False(t, gjson.GetBytes(result, "output_config").Exists())
+		contentArr := gjson.GetBytes(result, "messages.0.content").Array()
+		require.Len(t, contentArr, 2)
+		assert.Contains(t, contentArr[1].Get("text").String(), `"result":{"type":"number"}`)
+	})
+
 	t.Run("no schema field just removes output_format", func(t *testing.T) {
 		input := `{"model":"claude-sonnet-4-5","output_format":{"type":"json"},"messages":[{"role":"user","content":"hi"}]}`
 		result, err := PrepareBedrockRequestBody([]byte(input), "us.anthropic.claude-sonnet-4-5-v1", "")

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -3536,10 +3536,42 @@ func convertClaudeGenerationConfig(req map[string]any) map[string]any {
 	if stopSeq, ok := req["stop_sequences"].([]any); ok && len(stopSeq) > 0 {
 		out["stopSequences"] = stopSeq
 	}
+	if schema := claudeStructuredOutputSchema(req); schema != nil {
+		out["responseMimeType"] = "application/json"
+		out["responseSchema"] = cleanToolSchema(schema)
+	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+func claudeStructuredOutputSchema(req map[string]any) map[string]any {
+	format := claudeOutputFormat(req["output_config"])
+	if format == nil {
+		format = claudeOutputFormat(req["output_format"])
+	}
+	if format == nil {
+		return nil
+	}
+
+	formatType, _ := format["type"].(string)
+	if !strings.EqualFold(formatType, "json_schema") && !strings.EqualFold(formatType, "json") {
+		return nil
+	}
+	schema, _ := format["schema"].(map[string]any)
+	return schema
+}
+
+func claudeOutputFormat(outputConfig any) map[string]any {
+	config, ok := outputConfig.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if format, ok := config["format"].(map[string]any); ok {
+		return format
+	}
+	return config
 }
 
 func (s *GeminiMessagesCompatService) extractImageInputSize(body []byte) string {

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -117,6 +117,67 @@ func TestGeminiForwardAsChatCompletions_OAuthRoutesToGeminiAndReturnsChatFormat(
 	require.Equal(t, float64(10), usage["total_tokens"])
 }
 
+func TestGeminiForwardAsChatCompletions_PreservesStructuredOutput(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	httpStub := &geminiCompatHTTPUpstreamStub{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: io.NopCloser(strings.NewReader(
+				`data: {"response":{"candidates":[{"content":{"parts":[{"text":"{\"cities\":[]}"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":7,"candidatesTokenCount":3}}}` + "\n\n" +
+					"data: [DONE]\n\n",
+			)),
+		},
+	}
+	svc := &GeminiMessagesCompatService{
+		tokenProvider: &GeminiTokenProvider{},
+		httpUpstream:  httpStub,
+		cfg:           &config.Config{},
+	}
+	account := &Account{
+		ID:       103,
+		Platform: PlatformGemini,
+		Type:     AccountTypeOAuth,
+		Credentials: map[string]any{
+			"access_token": "ya29.test-token",
+			"project_id":   "project-1",
+		},
+		Concurrency: 1,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"List cities"}],"response_format":{"type":"json_schema","json_schema":{"name":"cities","strict":true,"schema":{"type":"object","properties":{"cities":{"type":"array","items":{"type":"object","properties":{"name":{"type":"string"}},"additionalProperties":false}}},"required":["cities"],"additionalProperties":false}}}}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	_, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, httpStub.lastReq)
+
+	var sent map[string]any
+	sentBody, err := io.ReadAll(httpStub.lastReq.Body)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(sentBody, &sent))
+	request, ok := sent["request"].(map[string]any)
+	require.True(t, ok)
+	generationConfig, ok := request["generationConfig"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "application/json", generationConfig["responseMimeType"])
+
+	schema, ok := generationConfig["responseSchema"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "OBJECT", schema["type"])
+	require.NotContains(t, schema, "additionalProperties")
+	cities, ok := schema["properties"].(map[string]any)["cities"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "ARRAY", cities["type"])
+	items, ok := cities["items"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "OBJECT", items["type"])
+	require.NotContains(t, items, "additionalProperties")
+}
+
 func TestGeminiForwardAsChatCompletions_StreamsOpenAIChunksFromGeminiSSE(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
# Summary

Fixes the silent loss of OpenAI-compatible `response_format` on the Gemini Chat Completions path.

The conversion now carries structured-output settings through the Responses-to-Anthropic compatibility layer and maps them to Gemini `generationConfig.responseMimeType` and `generationConfig.responseSchema`.

# Root cause

`response_format` was converted to `ResponsesRequest.text.format`, but the subsequent `ResponsesToAnthropicRequest` conversion had no structured-output carrier. Gemini therefore received no JSON MIME type or schema and returned unconstrained text.

# Changes

- Preserve JSON schema and JSON object formats in `output_config.format`.
- Convert structured output to Gemini generation config after removing Gemini-unsupported JSON Schema keywords.
- Preserve legacy top-level `output_format` on Anthropic request round trips.
- Inline `output_config.format` schemas for Bedrock requests, which do not support that field.

# Validation

- `go test ./internal/service -count=1`
- `go test ./internal/pkg/apicompat -count=1`

Fix issue #4940
