### PR TITLE
feat(security-audit): allow Qwen3Guard auxiliary fields

### DIFF
--- a/backend/internal/securityaudit/prompt_qwen3guard.go
+++ b/backend/internal/securityaudit/prompt_qwen3guard.go
@@ -86,19 +86,13 @@ func NormalizeCategory(value string) string {
 }
 
 func ParseQwen3Guard(content string, enabledScanners []string) (*NormalizedResult, error) {
-	lines := make([]string, 0, 2)
-	for _, line := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			lines = append(lines, line)
-		}
-	}
-	if len(lines) != 2 {
-		return nil, &GuardError{Code: ErrorCodeInvalidResponse, Retryable: false}
-	}
 	var safety string
 	var categoryLine string
-	for _, line := range lines {
+	for _, line := range strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
 		lower := strings.ToLower(line)
 		switch {
 		case strings.HasPrefix(lower, "safety:"):
@@ -112,7 +106,7 @@ func ParseQwen3Guard(content string, enabledScanners []string) (*NormalizedResul
 			}
 			categoryLine = strings.TrimSpace(line[len("categories:"):])
 		default:
-			return nil, &GuardError{Code: ErrorCodeInvalidResponse}
+			// Auxiliary Guard fields, such as Refusal, do not affect audit decisions.
 		}
 	}
 	switch strings.ToLower(safety) {

--- a/backend/internal/securityaudit/prompt_qwen3guard_test.go
+++ b/backend/internal/securityaudit/prompt_qwen3guard_test.go
@@ -22,7 +22,7 @@ func TestParseQwen3GuardStrictAndPolicy(t *testing.T) {
 		{"unsafe", "Safety: Unsafe\nCategories: Jailbreak", AllScannerIDs, EventCritical, ActionBlock, false},
 		{"unknown unsafe", "Safety: Unsafe\nCategories: Future Risk", AllScannerIDs, EventCritical, ActionBlock, false},
 		{"disabled unsafe warns", "Safety: Unsafe\nCategories: Violent", []string{"PII"}, EventFlag, ActionWarn, false},
-		{"extra explanation", "Safety: Safe\nCategories: None\nThis is safe", AllScannerIDs, "", "", true},
+		{"extra explanation", "Safety: Safe\nCategories: None\nThis is safe", AllScannerIDs, EventPass, ActionAllow, false},
 		{"duplicate", "Safety: Safe\nSafety: Safe", AllScannerIDs, "", "", true},
 		{"duplicate categories", "Safety: Safe\nCategories: None\nCategories: PII", AllScannerIDs, "", "", true},
 		{"missing categories", "Safety: Safe\n", AllScannerIDs, "", "", true},
@@ -40,6 +40,18 @@ func TestParseQwen3GuardStrictAndPolicy(t *testing.T) {
 			require.Equal(t, tt.action, result.Action)
 		})
 	}
+}
+
+func TestParseQwen3GuardIgnoresAuxiliaryResponseFields(t *testing.T) {
+	result, err := ParseQwen3Guard("Safety: Unsafe\nCategories: Jailbreak\nRefusal: No", AllScannerIDs)
+	require.NoError(t, err)
+	require.Equal(t, "Unsafe", result.Safety)
+	require.Equal(t, []string{"jailbreak"}, result.Categories)
+
+	serialized, err := json.Marshal(result)
+	require.NoError(t, err)
+	require.NotContains(t, string(serialized), "Refusal")
+	require.NotContains(t, string(serialized), "No")
 }
 
 func TestQwen3GuardOfficialCategoriesAliasesAndUnknownAreStable(t *testing.T) {


### PR DESCRIPTION
背景：
使用 qwen3guard:0.6b，输出结构：
```
Safety: Safe/Unsafe
Categories: <Categories>
```
但是0.6b模型能力太弱，容易误判，所以改用qwen3guard:8b模型，输出结构：
```
Safety: Safe/Unsafe
Categories: <Categories>
Refusal: Yes/No
```

目前0.6b的两行结构才是合法的，期望只要有Safety和Categories两行即是合法，反序列化时忽略其它字段即可
两种参数模型对于Categories分类完全一致


已经过测试，能够达到期望目的