### PR TITLE
refactor(service): declare the TokenProvider interface the five providers already satisfy

### DIFF
--- a/backend/internal/service/token_provider.go
+++ b/backend/internal/service/token_provider.go
@@ -1,0 +1,27 @@
+package service
+
+import "context"
+
+// TokenProvider 定义"为某个账号取得可用 access token"的能力。
+//
+// 五个平台的 *TokenProvider 早已实现同一套方法，只是没有声明接口：
+// Claude / OpenAI / Gemini / Antigravity / Grok 的 GetAccessToken 签名逐字相同。
+// 这里只把已经存在的事实写出来，不改变任何行为。
+//
+// 与 TokenRefresher 一样，接口只包含行为方法。SetRefreshAPI 和 SetRefreshPolicy
+// 是 wire 期的接线，调用方（16 处）无一使用，因此不放进接口。
+type TokenProvider interface {
+	// GetAccessToken 返回该账号当前可用的 access token，必要时先刷新。
+	GetAccessToken(ctx context.Context, account *Account) (string, error)
+}
+
+// 编译期断言：五个平台的 provider 都满足 TokenProvider。
+// 任何一个的 GetAccessToken 签名漂移，都会在这里编译失败，而不是等到
+// 有人试图把它们放进同一个容器时才发现。
+var (
+	_ TokenProvider = (*ClaudeTokenProvider)(nil)
+	_ TokenProvider = (*OpenAITokenProvider)(nil)
+	_ TokenProvider = (*GeminiTokenProvider)(nil)
+	_ TokenProvider = (*AntigravityTokenProvider)(nil)
+	_ TokenProvider = (*GrokTokenProvider)(nil)
+)


### PR DESCRIPTION
Follow-up to #4961, and the smallest piece of it.

Claude, OpenAI, Gemini, Antigravity and Grok each have a `*TokenProvider`, and all five declare the same method:

```go
GetAccessToken(ctx context.Context, account *Account) (string, error)
```

byte for byte. Nothing names that. This adds the interface and five compile-time assertions — **27 lines, one new file, nothing existing changes.** The types already satisfy it, so there is no behaviour change and no call site moves.

## Shaped after `TokenRefresher`

`TokenRefresher` in the same package does this job one layer down, for the same five platforms, and holds only behaviour methods. This follows it.

That is also why `SetRefreshAPI` and `SetRefreshPolicy` are left off, although #4961 mentioned all three: of the 16 call sites on these providers, **every one calls `GetAccessToken` and none calls a setter**. The setters are wire-time wiring, not something a consumer needs.

## What is deliberately not in here

The four services that hold a provider still hold the concrete type. Migrating them is the actual payoff, but it is not a safe drop-in:

Changing `AntigravityGatewayService.GetTokenProvider()` to return the interface would quietly break the guard at `internal/service/upstream_models.go:420`, which compares the result against `nil` — a non-nil interface holding a nil pointer is not nil. That wants doing per service, with the trap in mind, and only if you want the direction at all.

## Verification

- Assertions are not decorative: giving `GrokTokenProvider.GetAccessToken` an extra parameter fails the build at `token_provider.go:26`, which is what they are for.
- `go vet` clean on `unit`, `integration` and `e2e`.
- `golangci-lint run` — 0 issues.
- `internal/service` unit tests pass.

Happy to close this if the direction in #4961 is not one you want — it is meant as the cheapest possible way to find that out.