### PR TITLE
feat(security-audit): 提示词审计支持仅审核最后一条user消息

### DIFF
--- a/backend/internal/securityaudit/prompt_config.go
+++ b/backend/internal/securityaudit/prompt_config.go
@@ -67,6 +67,7 @@ type storageConfig struct {
 	Enabled         bool              `json:"enabled"`
 	BlockingEnabled bool              `json:"blocking_enabled"`
 	StorePassEvents bool              `json:"store_pass_events"`
+	LastUserOnly    bool              `json:"last_user_only"`
 	Strategy        string            `json:"strategy"`
 	WorkerCount     int               `json:"worker_count"`
 	QueueCapacity   int               `json:"queue_capacity"`
@@ -97,6 +98,7 @@ type ActiveConfig struct {
 	Enabled            bool
 	BlockingEnabled    bool
 	StorePassEvents    bool
+	LastUserOnly       bool
 	Strategy           string
 	WorkerCount        int
 	QueueCapacity      int
@@ -127,6 +129,7 @@ type PublicConfig struct {
 	Enabled         bool             `json:"enabled"`
 	BlockingEnabled bool             `json:"blocking_enabled"`
 	StorePassEvents bool             `json:"store_pass_events"`
+	LastUserOnly    bool             `json:"last_user_only"`
 	EffectiveMode   Mode             `json:"effective_mode"`
 	Strategy        string           `json:"strategy"`
 	WorkerCount     int              `json:"worker_count"`
@@ -159,6 +162,7 @@ type UpdateConfigRequest struct {
 	Enabled               bool             `json:"enabled"`
 	BlockingEnabled       bool             `json:"blocking_enabled"`
 	StorePassEvents       bool             `json:"store_pass_events"`
+	LastUserOnly          bool             `json:"last_user_only"`
 	Strategy              string           `json:"strategy"`
 	WorkerCount           int              `json:"worker_count"`
 	QueueCapacity         int              `json:"queue_capacity"`
@@ -173,6 +177,7 @@ func DefaultStorageConfig() storageConfig {
 		Enabled:         false,
 		BlockingEnabled: false,
 		StorePassEvents: false,
+		LastUserOnly:    false,
 		Strategy:        "priority",
 		WorkerCount:     DefaultWorkerCount,
 		QueueCapacity:   DefaultQueueCapacity,
@@ -383,7 +388,7 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool) PublicConfig 
 	}
 	active := ActiveConfig{RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled}
 	return PublicConfig{
-		Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, StorePassEvents: cfg.StorePassEvents,
+		Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled, StorePassEvents: cfg.StorePassEvents, LastUserOnly: cfg.LastUserOnly,
 		EffectiveMode: active.EffectiveMode(), Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: scanners, AllGroups: cfg.AllGroups,
 		GroupIDs: groupIDs, Endpoints: endpoints, ConfigVersion: cfg.ConfigVersion,
@@ -394,7 +399,7 @@ func PublicFromStorage(cfg storageConfig, riskControlEnabled bool) PublicConfig 
 func ActiveFromStorage(cfg storageConfig, riskControlEnabled bool, encryptor SecretEncryptor) (ActiveConfig, error) {
 	active := ActiveConfig{
 		RiskControlEnabled: riskControlEnabled, Enabled: cfg.Enabled, BlockingEnabled: cfg.BlockingEnabled,
-		StorePassEvents: cfg.StorePassEvents, Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
+		StorePassEvents: cfg.StorePassEvents, LastUserOnly: cfg.LastUserOnly, Strategy: cfg.Strategy, WorkerCount: cfg.WorkerCount,
 		QueueCapacity: cfg.QueueCapacity, Scanners: append([]string(nil), cfg.Scanners...), AllGroups: cfg.AllGroups,
 		GroupIDs: append([]int64(nil), cfg.GroupIDs...), ConfigVersion: cfg.ConfigVersion,
 		UpdatedAt: cfg.UpdatedAt, UpdatedBy: cfg.UpdatedBy, ChangeSummary: cfg.ChangeSummary,
@@ -425,12 +430,13 @@ func changeSummary(cfg storageConfig) string {
 		Enabled         bool   `json:"enabled"`
 		BlockingEnabled bool   `json:"blocking_enabled"`
 		StorePassEvents bool   `json:"store_pass_events"`
+		LastUserOnly    bool   `json:"last_user_only"`
 		EndpointCount   int    `json:"endpoint_count"`
 		ScannerCount    int    `json:"scanner_count"`
 		AllGroups       bool   `json:"all_groups"`
 		GroupCount      int    `json:"group_count"`
 		GroupHash       string `json:"group_hash"`
-	}{cfg.Enabled, cfg.BlockingEnabled, cfg.StorePassEvents, len(cfg.Endpoints), len(cfg.Scanners), cfg.AllGroups, len(cfg.GroupIDs), ""}
+	}{cfg.Enabled, cfg.BlockingEnabled, cfg.StorePassEvents, cfg.LastUserOnly, len(cfg.Endpoints), len(cfg.Scanners), cfg.AllGroups, len(cfg.GroupIDs), ""}
 	rawGroups, _ := json.Marshal(cfg.GroupIDs)
 	digest := sha256.Sum256(rawGroups)
 	summary.GroupHash = hex.EncodeToString(digest[:])

--- a/backend/internal/securityaudit/prompt_config_store.go
+++ b/backend/internal/securityaudit/prompt_config_store.go
@@ -295,7 +295,7 @@ func (m *ConfigManager) buildNextStorage(current storageConfig, req UpdateConfig
 		currentByID[endpoint.ID] = endpoint
 	}
 	next := storageConfig{
-		Enabled: req.Enabled, BlockingEnabled: req.BlockingEnabled, StorePassEvents: req.StorePassEvents,
+		Enabled: req.Enabled, BlockingEnabled: req.BlockingEnabled, StorePassEvents: req.StorePassEvents, LastUserOnly: req.LastUserOnly,
 		Strategy: strings.TrimSpace(req.Strategy), WorkerCount: req.WorkerCount,
 		QueueCapacity: req.QueueCapacity, Scanners: append([]string(nil), req.Scanners...),
 		AllGroups: req.AllGroups, GroupIDs: append([]int64(nil), req.GroupIDs...),

--- a/backend/internal/securityaudit/prompt_config_test.go
+++ b/backend/internal/securityaudit/prompt_config_test.go
@@ -19,6 +19,7 @@ func TestDefaultConfigIsOff(t *testing.T) {
 	storage, err := ParseStorageConfig("")
 	require.NoError(t, err)
 	require.False(t, storage.Enabled)
+	require.False(t, storage.LastUserOnly)
 	active, err := ActiveFromStorage(storage, true, prefixEncryptor{})
 	require.NoError(t, err)
 	require.Equal(t, ModeOff, active.EffectiveMode())
@@ -27,6 +28,7 @@ func TestDefaultConfigIsOff(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(publicJSON), `"group_ids":[]`)
 	require.Contains(t, string(publicJSON), `"endpoints":[]`)
+	require.Contains(t, string(publicJSON), `"last_user_only":false`)
 }
 
 func TestConfigRejectsBlockingWithoutAudit(t *testing.T) {
@@ -111,11 +113,12 @@ func TestBuildNextStoragePreserveReplaceAndClearToken(t *testing.T) {
 	manager := &ConfigManager{encryptor: prefixEncryptor{}}
 	current := DefaultStorageConfig()
 	current.Endpoints = []StorageEndpoint{{ID: "one", Name: "One", Protocol: "openai_compatible", BaseURL: "http://127.0.0.1:8080", Model: DefaultGuardModel, TokenCiphertext: "enc:old", TimeoutMS: 1000, InputLimit: 1000}}
-	base := UpdateConfigRequest{ExpectedConfigVersion: 1, Strategy: "priority", WorkerCount: 1, QueueCapacity: 10, Scanners: []string{"PII"}, AllGroups: true,
+	base := UpdateConfigRequest{ExpectedConfigVersion: 1, LastUserOnly: true, Strategy: "priority", WorkerCount: 1, QueueCapacity: 10, Scanners: []string{"PII"}, AllGroups: true,
 		Endpoints: []UpdateEndpoint{{ID: "one", Name: "One", Protocol: "openai_compatible", BaseURL: "http://127.0.0.1:8080", TimeoutMS: 1000, InputLimit: 1000}}}
 	preserved, err := manager.buildNextStorage(current, base, 9)
 	require.NoError(t, err)
 	require.Equal(t, "enc:old", preserved.Endpoints[0].TokenCiphertext)
+	require.True(t, preserved.LastUserOnly)
 	replacedReq := base
 	replacedReq.Endpoints = append([]UpdateEndpoint(nil), base.Endpoints...)
 	replacedReq.Endpoints[0].Token = "new"

--- a/backend/internal/securityaudit/prompt_enqueue.go
+++ b/backend/internal/securityaudit/prompt_enqueue.go
@@ -40,7 +40,7 @@ func (e *Enqueuer) Enqueue(ctx context.Context, req Request) error {
 		LogWarn(EventEnqueueDropped, mergeLogFields(baseFields, map[string]any{"status": "dropped", "error_code": "no_enabled_endpoint"}))
 		return nil
 	}
-	snapshot, err := ExtractPromptSnapshot(req)
+	snapshot, err := ExtractPromptSnapshotWithLastUserOnly(req, cfg.LastUserOnly)
 	if errors.Is(err, ErrNoPromptText) {
 		LogInfo(EventEnqueueSkipped, mergeLogFields(baseFields, map[string]any{"status": "skipped", "error_code": "no_user_text"}))
 		return nil

--- a/backend/internal/securityaudit/prompt_handler.go
+++ b/backend/internal/securityaudit/prompt_handler.go
@@ -228,6 +228,7 @@ func configAuditFields(request UpdateConfigRequest, saved *PublicConfig) map[str
 	}
 	return map[string]any{
 		"enabled": request.Enabled, "blocking_enabled": request.BlockingEnabled,
+		"last_user_only": request.LastUserOnly,
 		"config_version": version, "endpoint_count": len(request.Endpoints),
 		"scanner_count": len(request.Scanners), "all_groups": request.AllGroups,
 		"group_count": len(request.GroupIDs),

--- a/backend/internal/securityaudit/prompt_service.go
+++ b/backend/internal/securityaudit/prompt_service.go
@@ -156,7 +156,7 @@ func (s *PromptService) Evaluate(ctx context.Context, req Request) (*PromptDecis
 	if cfg.EffectiveMode() != ModeBlocking || !cfg.IncludesGroup(req.GroupID) {
 		return &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}, nil
 	}
-	snapshot, err := ExtractPromptSnapshot(req)
+	snapshot, err := ExtractPromptSnapshotWithLastUserOnly(req, cfg.LastUserOnly)
 	if errors.Is(err, ErrNoPromptText) {
 		return &PromptDecision{Kind: DecisionAllow, AllowNextStage: true}, nil
 	}

--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf8"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
 )
 
 var (
@@ -29,11 +31,22 @@ type promptSegment struct {
 }
 
 func ExtractPromptSnapshot(req Request) (PromptSnapshot, error) {
+	return ExtractPromptSnapshotWithLastUserOnly(req, false)
+}
+
+func ExtractPromptSnapshotWithLastUserOnly(req Request, lastUserOnly bool) (PromptSnapshot, error) {
 	var document any
 	if err := json.Unmarshal(req.Body, &document); err != nil {
 		return PromptSnapshot{}, errors.New("prompt audit request JSON is invalid")
 	}
 	extracted := extractProtocolSegments(req.Protocol, document)
+	if lastUserOnly {
+		extracted = userPromptSegments([]string{service.ExtractContentModerationText(req.Protocol, req.Body)})
+	}
+	return extractPromptSnapshot(req, extracted)
+}
+
+func extractPromptSnapshot(req Request, extracted []promptSegment) (PromptSnapshot, error) {
 	segments := normalizeSegmentsLatestUserFirst(extracted)
 	if len(segments) == 0 {
 		return PromptSnapshot{}, ErrNoPromptText

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -37,6 +37,20 @@ func TestExtractPromptSnapshotProtocols(t *testing.T) {
 	}
 }
 
+func TestExtractPromptSnapshotWithLastUserOnly(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":"historical user input"},{"role":"assistant","content":"historical assistant output"},{"role":"user","content":"final user input"}]}`)
+	snapshot, err := ExtractPromptSnapshotWithLastUserOnly(Request{Protocol: "openai_chat_completions", Body: body}, true)
+	require.NoError(t, err)
+	require.Equal(t, "final user input", snapshot.ScanText)
+	require.Equal(t, 1, snapshot.MessageCount)
+
+	_, err = ExtractPromptSnapshotWithLastUserOnly(Request{
+		Protocol: "openai_chat_completions",
+		Body:     []byte(`{"messages":[{"role":"user","content":"historical user input"},{"role":"assistant","content":"tool loop"}]}`),
+	}, true)
+	require.ErrorIs(t, err, ErrNoPromptText)
+}
+
 func TestSnapshotRedactsCanariesAndPreservesHashOfScanText(t *testing.T) {
 	body := `{"messages":[{"role":"user","content":"PROMPT_CANARY_ABC123 email@example.com +86 138 0013 8000 Bearer AUTH_CANARY_XYZ sk-secretvalue123 password=supersecret123"}]}`
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(body)})

--- a/frontend/src/features/prompt-audit/PromptAuditView.vue
+++ b/frontend/src/features/prompt-audit/PromptAuditView.vue
@@ -96,6 +96,7 @@
           <SaveToggle :label="t('admin.promptAudit.saveBar.enabled')" :model-value="draft.enabled" data-test="enabled-toggle" @update:model-value="setEnabled" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.blocking')" :model-value="draft.blocking_enabled" :disabled="!draft.enabled" data-test="blocking-toggle" @update:model-value="setBlocking" />
           <SaveToggle :label="t('admin.promptAudit.saveBar.storePass')" :model-value="draft.store_pass_events" data-test="store-pass-toggle" @update:model-value="replaceDraft({ ...draft!, store_pass_events: $event })" />
+          <SaveToggle :label="t('admin.promptAudit.saveBar.lastUserOnly')" :model-value="draft.last_user_only" data-test="last-user-only-toggle" @update:model-value="replaceDraft({ ...draft!, last_user_only: $event })" />
         </div>
         <div class="flex items-center gap-3">
           <span class="text-sm" :class="dirty ? 'text-amber-700 dark:text-amber-300' : 'text-gray-500 dark:text-dark-400'">

--- a/frontend/src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/PromptAuditView.spec.ts
@@ -19,7 +19,7 @@ vi.mock('vue-i18n', async () => {
 })
 
 const baseConfig = (): PromptAuditConfig => ({
-  enabled: true, blocking_enabled: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+  enabled: true, blocking_enabled: false, store_pass_events: false, last_user_only: false, effective_mode: 'async_audit', strategy: 'priority',
   worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: true, group_ids: [],
   endpoints: [{ id: 'guard-1', name: 'Guard One', protocol: 'openai_compatible', base_url: 'http://127.0.0.1:8000', model: 'guard-model', timeout_ms: 3000, input_limit: 4000, enabled: true, has_token: true, token_status: 'configured' }],
   config_version: 7, updated_at: '2026-07-16T00:00:00Z', updated_by: 1, change_summary: '{}',
@@ -175,7 +175,7 @@ describe('PromptAuditView', () => {
     await flushPromises()
     await wrapper.get('[data-test="tab-config"]').trigger('click')
     const switches = wrapper.findAll('[role="switch"]')
-    expect(switches).toHaveLength(3)
+    expect(switches).toHaveLength(4)
     expect(switches.every((item) => Boolean(item.attributes('aria-label')))).toBe(true)
     expect(wrapper.html()).toContain('fixed inset-x-0 bottom-0')
     expect(wrapper.html()).toContain('flex-wrap')

--- a/frontend/src/features/prompt-audit/__tests__/components.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/components.spec.ts
@@ -52,7 +52,7 @@ describe('Prompt Audit components', () => {
 
   it('supports group search, stale configured groups, nine scanners, and bounded worker inputs', async () => {
     const draft: PromptAuditDraft = {
-      enabled: true, blocking_enabled: false, store_pass_events: false, effective_mode: 'async_audit', strategy: 'priority',
+      enabled: true, blocking_enabled: false, store_pass_events: false, last_user_only: false, effective_mode: 'async_audit', strategy: 'priority',
       worker_count: 4, queue_capacity: 100, scanners: SCANNER_CATALOG.map((item) => item.id), all_groups: false, group_ids: [1, 99],
       endpoints: [endpoint()], config_version: 1, updated_at: '', updated_by: 0, change_summary: '',
     }

--- a/frontend/src/features/prompt-audit/__tests__/viewModel.spec.ts
+++ b/frontend/src/features/prompt-audit/__tests__/viewModel.spec.ts
@@ -14,6 +14,7 @@ const config = (): PromptAuditConfig => ({
   enabled: true,
   blocking_enabled: false,
   store_pass_events: false,
+  last_user_only: false,
   effective_mode: 'async_audit',
   strategy: 'priority',
   worker_count: 4,
@@ -62,6 +63,8 @@ describe('Prompt Audit view model', () => {
     expect(draftFingerprint(changed)).toBe(draftFingerprint(original))
     changed.queue_capacity += 1
     expect(draftFingerprint(changed)).not.toBe(draftFingerprint(original))
+    changed.last_user_only = true
+    expect(buildUpdateRequest(changed)).toMatchObject({ last_user_only: true })
   })
 
   it('requires a valid explicit range and sends canonical ISO timestamps for filter deletion', () => {

--- a/frontend/src/features/prompt-audit/types.ts
+++ b/frontend/src/features/prompt-audit/types.ts
@@ -24,6 +24,7 @@ export interface PromptAuditConfig {
   enabled: boolean
   blocking_enabled: boolean
   store_pass_events: boolean
+  last_user_only: boolean
   effective_mode: PromptAuditMode
   strategy: 'priority'
   worker_count: number
@@ -47,6 +48,7 @@ export interface PromptAuditUpdateRequest {
   enabled: boolean
   blocking_enabled: boolean
   store_pass_events: boolean
+  last_user_only: boolean
   strategy: 'priority'
   worker_count: number
   queue_capacity: number

--- a/frontend/src/features/prompt-audit/viewModel.ts
+++ b/frontend/src/features/prompt-audit/viewModel.ts
@@ -63,6 +63,7 @@ export function buildUpdateRequest(draft: PromptAuditDraft): PromptAuditUpdateRe
     enabled: draft.enabled,
     blocking_enabled: draft.enabled && draft.blocking_enabled,
     store_pass_events: draft.store_pass_events,
+    last_user_only: draft.last_user_only,
     strategy: 'priority',
     worker_count: Number(draft.worker_count),
     queue_capacity: Number(draft.queue_capacity),

--- a/frontend/src/i18n/locales/en/admin/promptAudit.ts
+++ b/frontend/src/i18n/locales/en/admin/promptAudit.ts
@@ -55,7 +55,7 @@ export default {
       searchGroups: 'Search groups', noGroups: 'No matching groups', missingGroups: 'Configured IDs for groups that no longer exist', selectedCount: '{count} groups selected',
       scanners: 'Qwen3Guard input-risk categories', workerCount: 'Worker count', queueCapacity: 'Persistent queue capacity', strategy: 'Node strategy', strategyHint: 'Try nodes in configuration order and fail over when allowed.',
     },
-    saveBar: { enabled: 'Enable prompt audit', blocking: 'Synchronous blocking', storePass: 'Store safe events', dirty: 'Unsaved changes', synced: 'Configuration synced' },
+    saveBar: { enabled: 'Enable prompt audit', blocking: 'Synchronous blocking', storePass: 'Store safe events', lastUserOnly: 'Audit only the final user message', dirty: 'Unsaved changes', synced: 'Configuration synced' },
     blockingConfirm: {
       title: 'Enable synchronous blocking?',
       message: 'Applicable requests wait for Guard before account selection, billing, or upstream access. Block, unavailable Guard, and invalid responses all prevent upstream access.',

--- a/frontend/src/i18n/locales/zh/admin/promptAudit.ts
+++ b/frontend/src/i18n/locales/zh/admin/promptAudit.ts
@@ -55,7 +55,7 @@ export default {
       searchGroups: '搜索分组', noGroups: '没有匹配分组', missingGroups: '配置中包含已删除的分组 ID', selectedCount: '已选择 {count} 个分组',
       scanners: 'Qwen3Guard 输入风险分类', workerCount: 'Worker 数量', queueCapacity: '持久队列容量', strategy: '节点策略', strategyHint: '按配置顺序优先尝试，必要时故障切换。',
     },
-    saveBar: { enabled: '启用提示词审计', blocking: '同步阻止', storePass: '保存安全事件', dirty: '有未保存的更改', synced: '配置已同步' },
+    saveBar: { enabled: '启用提示词审计', blocking: '同步阻止', storePass: '保存安全事件', lastUserOnly: '仅审核末条用户消息', dirty: '有未保存的更改', synced: '配置已同步' },
     blockingConfirm: {
       title: '开启同步阻止？',
       message: '适用请求会在账号选择、计费和访问上游之前等待 Guard。命中 Block、Guard 不可用或响应非法时，请求都不会访问上游。',


### PR DESCRIPTION
背景：
当前提示词审计，使用qwen3guard模型，多轮消息会重复发送完整的上下文
经128GB内存，3090 GPU物理机部署qwen3guard实际测试，当前完整上下文模式，上下文太长，被拆分为trunk发送请求进行审核，请求量会非常爆炸，延迟达到10s以上，完全不能开启【同步阻止】进行使用

举例：
160k的消息，如果完整审核上下文，当前sub2分片大小默认为4000，那么需要同步发送40条审核请求，推理➕网络延迟一条请求200ms已经很快了，200ms✖️40=8s，完全不能用到同步阻止中去
如果是并发40请求，那对推理服务器的要求也更高了

改动：
支持以配置的方式，启用只审核最后一条user消息。行为同当前 【内容审核】中使用openai模型omni-moderation-latest

后续可研究：
1. 如何准确识别首轮/后续轮消息，选择性发送system消息，以及工具调用消息
2. 以分片hash匹配的方式，不再审核相同hash的分片


提示词审计相关优化：#4953

已经过测试，能够达到改动目的