### PR TITLE
fix(openai): preserve native Codex namespaces

### DIFF
--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -447,21 +447,21 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse
 		"instructions":"local-test-instructions",
 		"tools":[
 			{"type":"function","name":"plain","description":"keep","parameters":{"type":"object"}},
-			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","description":"spawn","parameters":{"type":"object"}}]}
+			{"type":"namespace","name":"other","tools":[{"type":"function","name":"spawn_agent","description":"spawn","parameters":{"type":"object"}}]}
 		],
-		"tool_choice":{"type":"function","name":"spawn_agent","namespace":"collaboration"},
+		"tool_choice":{"type":"function","name":"spawn_agent","namespace":"other"},
 		"input":[
-			{"type":"function_call","call_id":"call_old","name":"spawn_agent","namespace":"collaboration","arguments":"{}"},
+			{"type":"function_call","call_id":"call_old","name":"spawn_agent","namespace":"other","arguments":"{}"},
 			{"type":"message","role":"user","namespace":"residual","content":[{"type":"input_text","text":"keep","namespace":"nested"}]}
 		]
 	}`)
 
 	upstreamSSE := strings.Join([]string{
-		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":""}}`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"other__spawn_agent","arguments":""}}`,
 		"",
-		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":"{}"}}`,
+		`data: {"type":"response.output_item.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"other__spawn_agent","arguments":"{}"}}`,
 		"",
-		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":"{}"}],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"other__spawn_agent","arguments":"{}"}],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
 		"",
 		"data: [DONE]",
 		"",
@@ -485,20 +485,20 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceRequestAndStreamResponse
 	require.Len(t, gjson.GetBytes(upstream.lastBody, "tools").Array(), 2)
 	require.Equal(t, "plain", gjson.GetBytes(upstream.lastBody, "tools.0.name").String())
 	require.Equal(t, "function", gjson.GetBytes(upstream.lastBody, "tools.1.type").String())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.1.name").String())
+	require.Equal(t, "other__spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.1.name").String())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "tools.1.tools").Exists())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
+	require.Equal(t, "other__spawn_agent", gjson.GetBytes(upstream.lastBody, "tool_choice.name").String())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "tool_choice.namespace").Exists())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
+	require.Equal(t, "other__spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.namespace").Exists())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "input.1.namespace").Exists())
 	require.Equal(t, "nested", gjson.GetBytes(upstream.lastBody, "input.1.content.0.namespace").String())
 	require.Len(t, upstream.bodies, 1)
 
 	downstream := rec.Body.String()
-	require.NotContains(t, downstream, "collaboration__spawn_agent")
+	require.NotContains(t, downstream, "other__spawn_agent")
 	require.Contains(t, downstream, `"name":"spawn_agent"`)
-	require.Contains(t, downstream, `"namespace":"collaboration"`)
+	require.Contains(t, downstream, `"namespace":"other"`)
 }
 
 func TestOpenAIGatewayService_NativeOAuth_NamespaceRequestAndStreamResponse(t *testing.T) {
@@ -509,13 +509,13 @@ func TestOpenAIGatewayService_NativeOAuth_NamespaceRequestAndStreamResponse(t *t
 	c.Request.Header.Set("User-Agent", "codex_cli_rs/0.144.1")
 	body := []byte(`{
 		"model":"gpt-5.5","stream":true,"instructions":"test",
-		"tools":[{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}],
-		"input":[{"type":"function_call","call_id":"call_old","name":"spawn_agent","namespace":"collaboration","arguments":"{}"}]
+		"tools":[{"type":"namespace","name":"other","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}],
+		"input":[{"type":"function_call","call_id":"call_old","name":"spawn_agent","namespace":"other","arguments":"{}"}]
 	}`)
 	upstreamSSE := strings.Join([]string{
-		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":""}}`,
+		`data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"other__spawn_agent","arguments":""}}`,
 		"",
-		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"collaboration__spawn_agent","arguments":"{}"}],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
+		`data: {"type":"response.completed","response":{"id":"resp_1","status":"completed","output":[{"type":"function_call","id":"fc_1","call_id":"call_1","name":"other__spawn_agent","arguments":"{}"}],"usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}}`,
 		"",
 		"data: [DONE]",
 		"",
@@ -536,12 +536,12 @@ func TestOpenAIGatewayService_NativeOAuth_NamespaceRequestAndStreamResponse(t *t
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	require.Equal(t, "function", gjson.GetBytes(upstream.lastBody, "tools.0.type").String())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.0.name").String())
-	require.Equal(t, "collaboration__spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
+	require.Equal(t, "other__spawn_agent", gjson.GetBytes(upstream.lastBody, "tools.0.name").String())
+	require.Equal(t, "other__spawn_agent", gjson.GetBytes(upstream.lastBody, "input.0.name").String())
 	require.False(t, gjson.GetBytes(upstream.lastBody, "input.0.namespace").Exists())
-	require.NotContains(t, rec.Body.String(), "collaboration__spawn_agent")
+	require.NotContains(t, rec.Body.String(), "other__spawn_agent")
 	require.Contains(t, rec.Body.String(), `"name":"spawn_agent"`)
-	require.Contains(t, rec.Body.String(), `"namespace":"collaboration"`)
+	require.Contains(t, rec.Body.String(), `"namespace":"other"`)
 }
 
 func TestOpenAIGatewayService_NativeOAuth_NamespaceNonStreamingResponse(t *testing.T) {
@@ -605,8 +605,8 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceCollisionReturnsBadReque
 	body := []byte(`{
 		"model":"gpt-5.5","stream":true,"instructions":"test",
 		"tools":[
-			{"type":"function","name":"collaboration__spawn_agent","parameters":{"type":"object"}},
-			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}
+			{"type":"function","name":"other__spawn_agent","parameters":{"type":"object"}},
+			{"type":"namespace","name":"other","tools":[{"type":"function","name":"spawn_agent","parameters":{"type":"object"}}]}
 		],"input":"hi"
 	}`)
 	upstream := &httpUpstreamRecorder{}

--- a/backend/internal/service/openai_responses_namespace.go
+++ b/backend/internal/service/openai_responses_namespace.go
@@ -49,7 +49,11 @@ func flattenOpenAIResponsesNamespaces(c *gin.Context, body []byte) ([]byte, erro
 	if err := json.Unmarshal(body, &requestBody); err != nil {
 		return body, fmt.Errorf("decode OpenAI namespace body: %w", err)
 	}
-	names, changed, err := apicompat.FlattenResponsesNamespacesExcept(requestBody, map[string]bool{"image_gen": true})
+	names, changed, err := apicompat.FlattenResponsesNamespacesExcept(requestBody, map[string]bool{
+		"image_gen":     true,
+		"collaboration": true,
+		"codex_app":     true,
+	})
 	if err != nil {
 		return body, err
 	}

--- a/backend/internal/service/openai_responses_namespace_test.go
+++ b/backend/internal/service/openai_responses_namespace_test.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
@@ -35,6 +36,37 @@ func TestShouldFlattenOpenAIResponsesNamespaces(t *testing.T) {
 			require.Equal(t, tt.want, shouldFlattenOpenAIResponsesNamespaces(tt.account, tt.transport, tt.passthroughEnabled))
 		})
 	}
+}
+
+func TestFlattenOpenAIResponsesNamespacesPreservesNativeCodexNamespaces(t *testing.T) {
+	c := &gin.Context{}
+	body := []byte(`{
+		"tools":[
+			{"type":"namespace","name":"image_gen","tools":[{"type":"function","name":"imagegen"}]},
+			{"type":"namespace","name":"collaboration","tools":[{"type":"function","name":"spawn_agent"}]},
+			{"type":"namespace","name":"codex_app","tools":[{"type":"function","name":"read_thread"}]},
+			{"type":"namespace","name":"other","tools":[{"type":"function","name":"lookup"}]}
+		],
+		"input":[{"type":"function_call","namespace":"other","name":"lookup","arguments":"{}"}]
+	}`)
+
+	flattened, err := flattenOpenAIResponsesNamespaces(c, body)
+	require.NoError(t, err)
+	require.Equal(t, "namespace", gjson.GetBytes(flattened, `tools.#(name=="image_gen").type`).String())
+	require.Equal(t, "imagegen", gjson.GetBytes(flattened, `tools.#(name=="image_gen").tools.0.name`).String())
+	require.Equal(t, "namespace", gjson.GetBytes(flattened, `tools.#(name=="collaboration").type`).String())
+	require.Equal(t, "spawn_agent", gjson.GetBytes(flattened, `tools.#(name=="collaboration").tools.0.name`).String())
+	require.Equal(t, "namespace", gjson.GetBytes(flattened, `tools.#(name=="codex_app").type`).String())
+	require.Equal(t, "read_thread", gjson.GetBytes(flattened, `tools.#(name=="codex_app").tools.0.name`).String())
+	require.Equal(t, "function", gjson.GetBytes(flattened, `tools.#(name=="other__lookup").type`).String())
+	require.False(t, gjson.GetBytes(flattened, `tools.#(name=="other")`).Exists())
+	require.Equal(t, "other__lookup", gjson.GetBytes(flattened, "input.0.name").String())
+	require.False(t, gjson.GetBytes(flattened, "input.0.namespace").Exists())
+
+	restored, err := restoreOpenAIResponsesNamespacePayload(c, []byte(`{"type":"response.completed","response":{"output":[{"type":"function_call","name":"other__lookup","arguments":"{}"}]}}`))
+	require.NoError(t, err)
+	require.Equal(t, "lookup", gjson.GetBytes(restored, "response.output.0.name").String())
+	require.Equal(t, "other", gjson.GetBytes(restored, "response.output.0.namespace").String())
 }
 
 func TestShouldStripOpenAIResponsesInputNamespaces(t *testing.T) {


### PR DESCRIPTION
## 问题

OpenAI Responses 请求中的原生 Codex 命名空间声明会被扁平化，导致模型看到的工具声明结构发生变化。

## 根因

服务层在处理 Responses 命名空间时仅排除了 `image_gen`，未将 Codex 原生的 `collaboration` 和 `codex_app` 命名空间纳入保留列表。

已检查仍处于 open 状态的 PR #4888：该 PR 只在历史输入调用项上保留 namespace，同时明确继续扁平化工具声明，因此与本次修复模型可见声明的改动不重叠。

## 改动

在 Responses 命名空间扁平化的排除列表中加入 `collaboration` 和 `codex_app`，保留这些原生 Codex 工具声明；其他命名空间仍按现有逻辑扁平化。补充单元测试，覆盖原生命名空间保留、其他命名空间扁平化以及调用结果恢复。

## 验证

以下命令均已通过：

1. `cd backend && go test -tags=unit ./internal/service -run Test(ShouldFlattenOpenAIResponsesNamespaces|FlattenOpenAIResponsesNamespacesPreservesNativeCodexNamespaces|ShouldStripOpenAIResponsesInputNamespaces|StripOpenAIResponsesInputNamespaces) -count=1`
2. `cd backend && go test -tags=unit ./internal/pkg/apicompat -run Test(FlattenResponsesNamespaces|RestoreResponsesNamespaceCalls) -count=1`
3. `cd backend && go vet ./internal/service ./internal/pkg/apicompat`
4. `git diff --check`

Fixes #4978.