### PR TITLE
feat(keys): show effective models for API keys

### DIFF
--- a/frontend/src/api/__tests__/keys.models.spec.ts
+++ b/frontend/src/api/__tests__/keys.models.spec.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { listModels } from '../keys'
+
+describe('keys API model list', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the selected API key and normalizes the effective model list', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        object: 'list',
+        data: [
+          { id: 'gpt-5.6', display_name: 'GPT-5.6' },
+          { id: ' gpt-5-mini ' },
+          { id: 'gpt-5.6' },
+          { display_name: 'missing-id' },
+        ],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const controller = new AbortController()
+
+    await expect(
+      listModels('sk-test-key', { signal: controller.signal })
+    ).resolves.toEqual([
+      { id: 'gpt-5.6', display_name: 'GPT-5.6' },
+      { id: 'gpt-5-mini', display_name: undefined },
+    ])
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/v1\/models$/),
+      expect.objectContaining({
+        credentials: 'omit',
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer sk-test-key',
+        },
+        signal: controller.signal,
+      })
+    )
+  })
+
+  it('rejects failed gateway responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    }))
+
+    await expect(listModels('sk-disabled-key')).rejects.toThrow(
+      'Failed to load models (401)'
+    )
+  })
+
+  it('rejects malformed model responses', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({ data: null }),
+    }))
+
+    await expect(listModels('sk-test-key')).rejects.toThrow(
+      'Invalid models response'
+    )
+  })
+})

--- a/frontend/src/api/keys.ts
+++ b/frontend/src/api/keys.ts
@@ -3,8 +3,17 @@
  * Handles CRUD operations for user API keys
  */
 
-import { apiClient } from './client'
+import { apiClient, buildGatewayUrl } from './client'
 import type { ApiKey, CreateApiKeyRequest, UpdateApiKeyRequest, PaginatedResponse } from '@/types'
+
+export interface ApiKeyModel {
+  id: string
+  display_name?: string
+}
+
+interface ModelsResponse {
+  data?: unknown
+}
 
 /**
  * List all API keys for current user
@@ -131,13 +140,63 @@ export async function toggleStatus(id: number, status: 'active' | 'inactive'): P
   return update(id, { status })
 }
 
+/**
+ * Fetch the effective /v1/models response for an API key.
+ * This deliberately uses the key itself instead of the signed-in user's token,
+ * so the result matches what API clients receive for the key's current group.
+ */
+export async function listModels(
+  apiKey: string,
+  options?: { signal?: AbortSignal }
+): Promise<ApiKeyModel[]> {
+  const response = await fetch(buildGatewayUrl('/v1/models'), {
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Bearer ${apiKey}`
+    },
+    credentials: 'omit',
+    signal: options?.signal
+  })
+
+  if (!response.ok) {
+    throw new Error(`Failed to load models (${response.status})`)
+  }
+
+  const payload = await response.json() as ModelsResponse
+  if (!Array.isArray(payload.data)) {
+    throw new Error('Invalid models response')
+  }
+
+  const seen = new Set<string>()
+  const models: ApiKeyModel[] = []
+  for (const item of payload.data) {
+    if (!item || typeof item !== 'object') continue
+
+    const record = item as Record<string, unknown>
+    const id = typeof record.id === 'string' ? record.id.trim() : ''
+    if (!id || seen.has(id)) continue
+
+    seen.add(id)
+    models.push({
+      id,
+      display_name:
+        typeof record.display_name === 'string' && record.display_name.trim()
+          ? record.display_name.trim()
+          : undefined
+    })
+  }
+
+  return models
+}
+
 export const keysAPI = {
   list,
   getById,
   create,
   update,
   delete: deleteKey,
-  toggleStatus
+  toggleStatus,
+  listModels
 }
 
 export default keysAPI

--- a/frontend/src/components/keys/KeyModelsModal.vue
+++ b/frontend/src/components/keys/KeyModelsModal.vue
@@ -1,0 +1,199 @@
+<template>
+  <BaseDialog
+    :show="show"
+    :title="t('keys.modelsModal.title', { name: keyName })"
+    width="wide"
+    @close="emit('close')"
+  >
+    <div class="space-y-4">
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        {{ t('keys.modelsModal.description') }}
+      </p>
+
+      <div v-if="loading" class="flex min-h-48 items-center justify-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <Icon name="refresh" size="sm" class="animate-spin" />
+        <span>{{ t('keys.modelsModal.loading') }}</span>
+      </div>
+
+      <div
+        v-else-if="loadError"
+        class="flex min-h-48 flex-col items-center justify-center gap-3 rounded-xl border border-red-200 bg-red-50 px-6 text-center dark:border-red-900/60 dark:bg-red-950/20"
+      >
+        <Icon name="exclamationCircle" size="lg" class="text-red-500" />
+        <p class="max-w-lg text-sm text-red-700 dark:text-red-300">
+          {{ t('keys.modelsModal.failedToLoad') }}
+        </p>
+        <button type="button" class="btn btn-secondary text-sm" @click="loadModels">
+          {{ t('keys.modelsModal.retry') }}
+        </button>
+      </div>
+
+      <template v-else>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div class="relative min-w-0 flex-1">
+            <Icon
+              name="search"
+              size="sm"
+              class="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+            />
+            <input
+              v-model="searchQuery"
+              data-testid="model-search"
+              type="search"
+              class="input w-full pl-9"
+              :placeholder="t('keys.modelsModal.searchPlaceholder')"
+              :aria-label="t('keys.modelsModal.searchPlaceholder')"
+            />
+          </div>
+          <span class="shrink-0 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('keys.modelsModal.count', { count: models.length }) }}
+          </span>
+        </div>
+
+        <div
+          v-if="filteredModels.length > 0"
+          class="max-h-96 divide-y divide-gray-100 overflow-y-auto rounded-xl border border-gray-200 dark:divide-dark-700 dark:border-dark-600"
+        >
+          <div
+            v-for="model in filteredModels"
+            :key="model.id"
+            data-testid="model-row"
+            class="group flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-dark-700"
+          >
+            <ModelIcon :model="model.id" size="18px" class="shrink-0" />
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-mono text-sm text-gray-900 dark:text-white">
+                {{ model.id }}
+              </p>
+              <p
+                v-if="model.display_name && model.display_name !== model.id"
+                class="mt-0.5 truncate text-xs text-gray-400 dark:text-gray-500"
+              >
+                {{ model.display_name }}
+              </p>
+            </div>
+            <button
+              type="button"
+              data-testid="copy-model-id"
+              class="shrink-0 rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-200 hover:text-primary-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:hover:bg-dark-600 dark:hover:text-primary-400"
+              :title="t('keys.modelsModal.copy')"
+              :aria-label="`${t('keys.modelsModal.copy')}: ${model.id}`"
+              @click="copyModelId(model.id)"
+            >
+              <Icon name="copy" size="sm" />
+            </button>
+          </div>
+        </div>
+
+        <div
+          v-else
+          class="flex min-h-48 items-center justify-center rounded-xl border border-dashed border-gray-200 px-6 text-center text-sm text-gray-400 dark:border-dark-600 dark:text-gray-500"
+        >
+          {{ models.length === 0 ? t('keys.modelsModal.empty') : t('keys.modelsModal.noMatches') }}
+        </div>
+      </template>
+    </div>
+
+    <template #footer>
+      <div class="flex justify-end">
+        <button type="button" class="btn btn-secondary" @click="emit('close')">
+          {{ t('common.close') }}
+        </button>
+      </div>
+    </template>
+  </BaseDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { keysAPI } from '@/api'
+import type { ApiKeyModel } from '@/api/keys'
+import { useClipboard } from '@/composables/useClipboard'
+import BaseDialog from '@/components/common/BaseDialog.vue'
+import ModelIcon from '@/components/common/ModelIcon.vue'
+import Icon from '@/components/icons/Icon.vue'
+
+const props = defineProps<{
+  show: boolean
+  apiKey: string
+  keyName: string
+}>()
+
+const emit = defineEmits<{
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+const { copyToClipboard } = useClipboard()
+const models = ref<ApiKeyModel[]>([])
+const searchQuery = ref('')
+const loading = ref(false)
+const loadError = ref(false)
+let abortController: AbortController | null = null
+
+const filteredModels = computed(() => {
+  const query = searchQuery.value.trim().toLowerCase()
+  if (!query) return models.value
+
+  return models.value.filter((model) =>
+    model.id.toLowerCase().includes(query) ||
+    model.display_name?.toLowerCase().includes(query)
+  )
+})
+
+const isAbortError = (error: unknown) => {
+  if (!error || typeof error !== 'object') return false
+  return (error as { name?: string }).name === 'AbortError'
+}
+
+const loadModels = async () => {
+  abortController?.abort()
+  loadError.value = false
+  models.value = []
+  searchQuery.value = ''
+
+  if (!props.apiKey) {
+    loadError.value = true
+    return
+  }
+
+  const controller = new AbortController()
+  abortController = controller
+  loading.value = true
+
+  try {
+    models.value = await keysAPI.listModels(props.apiKey, { signal: controller.signal })
+  } catch (error) {
+    if (!isAbortError(error)) {
+      loadError.value = true
+    }
+  } finally {
+    if (abortController === controller) {
+      loading.value = false
+    }
+  }
+}
+
+const copyModelId = async (modelId: string) => {
+  await copyToClipboard(modelId)
+}
+
+watch(
+  () => [props.show, props.apiKey] as const,
+  ([show]) => {
+    if (show) {
+      void loadModels()
+    } else {
+      abortController?.abort()
+      abortController = null
+      loading.value = false
+    }
+  },
+  { immediate: true }
+)
+
+onUnmounted(() => {
+  abortController?.abort()
+})
+</script>

--- a/frontend/src/components/keys/__tests__/KeyModelsModal.spec.ts
+++ b/frontend/src/components/keys/__tests__/KeyModelsModal.spec.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+
+import KeyModelsModal from '../KeyModelsModal.vue'
+
+const { listModels, copyToClipboard } = vi.hoisted(() => ({
+  listModels: vi.fn(),
+  copyToClipboard: vi.fn(),
+}))
+
+const messages: Record<string, string> = {
+  'common.close': 'Close',
+  'keys.modelsModal.title': 'Available Models - {name}',
+  'keys.modelsModal.description': 'Live model list',
+  'keys.modelsModal.loading': 'Loading models...',
+  'keys.modelsModal.searchPlaceholder': 'Search model IDs...',
+  'keys.modelsModal.count': '{count} models',
+  'keys.modelsModal.copy': 'Copy model ID',
+  'keys.modelsModal.empty': 'No available models',
+  'keys.modelsModal.noMatches': 'No matching models',
+  'keys.modelsModal.failedToLoad': 'Unable to load models',
+  'keys.modelsModal.retry': 'Retry',
+}
+
+vi.mock('@/api', () => ({
+  keysAPI: {
+    listModels,
+  },
+}))
+
+vi.mock('@/composables/useClipboard', () => ({
+  useClipboard: () => ({
+    copyToClipboard,
+  }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const message = messages[key] ?? key
+      return Object.entries(params ?? {}).reduce(
+        (result, [name, value]) => result.replaceAll(`{${name}}`, String(value)),
+        message
+      )
+    },
+  }),
+}))
+
+const BaseDialogStub = {
+  props: ['show', 'title'],
+  emits: ['close'],
+  template: `
+    <div v-if="show">
+      <div data-testid="dialog-title">{{ title }}</div>
+      <slot />
+      <slot name="footer" />
+    </div>
+  `,
+}
+
+const mountModal = () =>
+  mount(KeyModelsModal, {
+    props: {
+      show: true,
+      apiKey: 'sk-test-key',
+      keyName: 'test-key',
+    },
+    global: {
+      stubs: {
+        BaseDialog: BaseDialogStub,
+        ModelIcon: true,
+        Icon: true,
+      },
+    },
+  })
+
+describe('KeyModelsModal', () => {
+  beforeEach(() => {
+    listModels.mockReset()
+    copyToClipboard.mockReset()
+    copyToClipboard.mockResolvedValue(true)
+  })
+
+  it('loads, searches, and copies effective model IDs', async () => {
+    listModels.mockResolvedValue([
+      { id: 'gpt-5.6', display_name: 'GPT-5.6' },
+      { id: 'gpt-5-mini' },
+    ])
+
+    const wrapper = mountModal()
+    await flushPromises()
+
+    expect(listModels).toHaveBeenCalledWith(
+      'sk-test-key',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+    expect(wrapper.get('[data-testid="dialog-title"]').text()).toBe(
+      'Available Models - test-key'
+    )
+    expect(wrapper.findAll('[data-testid="model-row"]')).toHaveLength(2)
+    expect(wrapper.text()).toContain('2 models')
+
+    await wrapper.get('[data-testid="model-search"]').setValue('mini')
+
+    expect(wrapper.findAll('[data-testid="model-row"]')).toHaveLength(1)
+    expect(wrapper.text()).toContain('gpt-5-mini')
+    expect(wrapper.text()).not.toContain('gpt-5.6')
+
+    await wrapper.get('[data-testid="copy-model-id"]').trigger('click')
+
+    expect(copyToClipboard).toHaveBeenCalledWith('gpt-5-mini')
+  })
+
+  it('shows a generic error and can retry', async () => {
+    listModels
+      .mockRejectedValueOnce(new Error('private upstream detail'))
+      .mockResolvedValueOnce([{ id: 'gpt-5.6' }])
+
+    const wrapper = mountModal()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Unable to load models')
+    expect(wrapper.text()).not.toContain('private upstream detail')
+
+    await wrapper.get('button').trigger('click')
+    await flushPromises()
+
+    expect(listModels).toHaveBeenCalledTimes(2)
+    expect(wrapper.text()).toContain('gpt-5.6')
+  })
+
+  it('shows a distinct empty search result', async () => {
+    listModels.mockResolvedValue([{ id: 'gpt-5.6' }])
+
+    const wrapper = mountModal()
+    await flushPromises()
+    await wrapper.get('[data-testid="model-search"]').setValue('claude')
+
+    expect(wrapper.text()).toContain('No matching models')
+  })
+})

--- a/frontend/src/i18n/locales/en/dashboard.ts
+++ b/frontend/src/i18n/locales/en/dashboard.ts
@@ -127,6 +127,19 @@ export default {
     lastUsedAt: 'Last Used',
     lastUsedIP: 'Last Used IP',
     useKey: 'Use Key',
+    models: 'Models',
+    modelsModal: {
+      title: 'Available Models - {name}',
+      description: 'Fetches this API key’s live /v1/models response, matching the model list seen by API clients.',
+      loading: 'Loading models...',
+      searchPlaceholder: 'Search model IDs...',
+      count: '{count} models',
+      copy: 'Copy model ID',
+      empty: 'This API key returned no available models',
+      noMatches: 'No matching models',
+      failedToLoad: 'Unable to load models. Make sure the key is enabled and assigned to a valid group.',
+      retry: 'Retry'
+    },
     useKeyModal: {
       title: 'Use API Key',
       description:

--- a/frontend/src/i18n/locales/zh/dashboard.ts
+++ b/frontend/src/i18n/locales/zh/dashboard.ts
@@ -127,6 +127,19 @@ export default {
     lastUsedAt: '上次使用时间',
     lastUsedIP: '最近使用 IP',
     useKey: '使用密钥',
+    models: '模型',
+    modelsModal: {
+      title: '可用模型 - {name}',
+      description: '实时读取此 API 密钥的 /v1/models 结果，与客户端实际看到的模型列表一致。',
+      loading: '正在加载模型...',
+      searchPlaceholder: '搜索模型 ID...',
+      count: '共 {count} 个模型',
+      copy: '复制模型 ID',
+      empty: '当前密钥没有返回可用模型',
+      noMatches: '没有匹配的模型',
+      failedToLoad: '无法加载模型列表，请确认密钥已启用并已绑定有效分组。',
+      retry: '重试'
+    },
     useKeyModal: {
       title: '使用 API 密钥',
       description: '将以下环境变量添加到您的终端配置文件或直接在终端中运行。',

--- a/frontend/src/views/user/KeysView.vue
+++ b/frontend/src/views/user/KeysView.vue
@@ -379,6 +379,15 @@
                 <Icon name="terminal" size="sm" />
                 <span class="text-xs">{{ t('keys.useKey') }}</span>
               </button>
+              <!-- View Models Button -->
+              <button
+                type="button"
+                @click="openModelsModal(row)"
+                class="flex flex-col items-center gap-0.5 rounded-lg p-1.5 text-gray-500 transition-colors hover:bg-purple-50 hover:text-purple-600 dark:hover:bg-purple-900/20 dark:hover:text-purple-400"
+              >
+                <Icon name="cube" size="sm" />
+                <span class="text-xs">{{ t('keys.models') }}</span>
+              </button>
               <!-- Import to CC Switch Button -->
               <button
                 v-if="!publicSettings?.hide_ccs_import_button"
@@ -998,6 +1007,14 @@
       @close="closeUseKeyModal"
     />
 
+    <!-- Effective Models Modal -->
+    <KeyModelsModal
+      :show="showModelsModal"
+      :api-key="modelListKey?.key || ''"
+      :key-name="modelListKey?.name || ''"
+      @close="closeModelsModal"
+    />
+
     <!-- CCS Client Selection Dialog for Antigravity -->
     <BaseDialog
       :show="showCcsClientSelect"
@@ -1137,6 +1154,7 @@ import TablePageLayout from '@/components/layout/TablePageLayout.vue'
 	import SearchInput from '@/components/common/SearchInput.vue'
 	import Icon from '@/components/icons/Icon.vue'
 	import UseKeyModal from '@/components/keys/UseKeyModal.vue'
+	import KeyModelsModal from '@/components/keys/KeyModelsModal.vue'
 	import EndpointPopover from '@/components/keys/EndpointPopover.vue'
 	import GroupBadge from '@/components/common/GroupBadge.vue'
 	import GroupOptionItem from '@/components/common/GroupOptionItem.vue'
@@ -1300,10 +1318,12 @@ const showDeleteDialog = ref(false)
 const showResetQuotaDialog = ref(false)
 const showResetRateLimitDialog = ref(false)
 const showUseKeyModal = ref(false)
+const showModelsModal = ref(false)
 const showCcsClientSelect = ref(false)
 const showColumnDropdown = ref(false)
 const pendingCcsRow = ref<ApiKey | null>(null)
 const selectedKey = ref<ApiKey | null>(null)
+const modelListKey = ref<ApiKey | null>(null)
 const copiedKeyId = ref<number | null>(null)
 const groupSelectorKeyId = ref<number | null>(null)
 const publicSettings = ref<PublicSettings | null>(null)
@@ -1537,6 +1557,16 @@ const openUseKeyModal = (key: ApiKey) => {
 const closeUseKeyModal = () => {
   showUseKeyModal.value = false
   selectedKey.value = null
+}
+
+const openModelsModal = (key: ApiKey) => {
+  modelListKey.value = key
+  showModelsModal.value = true
+}
+
+const closeModelsModal = () => {
+  showModelsModal.value = false
+  modelListKey.value = null
 }
 
 const handlePageChange = (page: number) => {

--- a/frontend/src/views/user/__tests__/KeysView.spec.ts
+++ b/frontend/src/views/user/__tests__/KeysView.spec.ts
@@ -46,6 +46,7 @@ const messages: Record<string, string> = {
   'keys.currentConcurrency': 'Current Concurrency',
   'keys.lastUsedAt': 'Last Used',
   'keys.lastUsedIP': 'Last Used IP',
+  'keys.models': 'Models',
   'keys.rateLimitColumn': 'Rate Limit',
   'keys.searchPlaceholder': 'Search name or key...',
   'keys.status.active': 'Active',
@@ -179,6 +180,9 @@ const DataTableStub = {
         >
           <slot name="cell-last_used_ip" :value="row.last_used_ip" :row="row" />
         </div>
+        <div data-test="key-actions">
+          <slot name="cell-actions" :value="row" :row="row" />
+        </div>
       </div>
       <slot name="empty" />
     </div>
@@ -215,6 +219,13 @@ const IconStub = {
   template: '<span data-test="icon">{{ name }}</span>',
 }
 
+const KeyModelsModalStub = {
+  name: 'KeyModelsModal',
+  props: ['show', 'apiKey', 'keyName'],
+  emits: ['close'],
+  template: '<div data-test="key-models-modal">{{ show }}|{{ apiKey }}|{{ keyName }}</div>',
+}
+
 const mountView = async () => {
   const wrapper = mount(KeysView, {
     global: {
@@ -230,6 +241,7 @@ const mountView = async () => {
         SearchInput: SearchInputStub,
         Icon: IconStub,
         UseKeyModal: true,
+        KeyModelsModal: KeyModelsModalStub,
         EndpointPopover: true,
         GroupBadge: true,
         GroupOptionItem: true,
@@ -392,6 +404,23 @@ describe('user KeysView column settings', () => {
     const wrapper = await mountView()
 
     expect(wrapper.get('[data-test="current-concurrency"]').text()).toBe('3')
+  })
+
+  it('opens the effective model list for the selected API key', async () => {
+    const wrapper = await mountView()
+
+    await getButtonByText(wrapper, 'Models').trigger('click')
+    await nextTick()
+
+    const modal = wrapper.findComponent({ name: 'KeyModelsModal' })
+    expect(modal.props('show')).toBe(true)
+    expect(modal.props('apiKey')).toBe('sk-test-key')
+    expect(modal.props('keyName')).toBe('test-key')
+
+    modal.vm.$emit('close')
+    await nextTick()
+
+    expect(modal.props('show')).toBe(false)
   })
 
   it('marks current concurrency as sortable', async () => {


### PR DESCRIPTION
## Summary

- add a Models action to each user API key
- query the existing `/v1/models` endpoint with the selected key so the list matches real client behavior
- provide search, per-model copy, loading, empty, error, retry, and request-cancellation states
- add English and Chinese copy plus focused API/component/view tests

## Scope

This implements the per-key model-list portion of #2274 only. Candidate-group model previews are intentionally deferred because the current group metadata cannot represent the effective account-aware model list without a new backend contract.

No backend, database, or dependency changes.

## Verification

- `pnpm exec vitest run src/api/__tests__/keys.models.spec.ts src/components/keys/__tests__/KeyModelsModal.spec.ts src/views/user/__tests__/KeysView.spec.ts` — 16 passed
- `pnpm run typecheck` — passed
- `pnpm run lint:check` — passed
- `pnpm run build` — passed
- Playwright desktop flow — Models action, live list, exact search, and copy action verified

The full frontend suite currently reports 1326 passing and 2 unrelated failures in `admin.system.rollback.spec.ts`: upstream implementation passes a 15-minute timeout config while those assertions still expect only two arguments. Existing group-view mocks also emit unrelated `getLiveCapability` warnings.

Related to #2274.