### PR TITLE
fix(openai): recover foreign encrypted reasoning in messages bridge

### DIFF
--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -127,7 +127,7 @@ func (s *OpenAIGatewayService) forwardGrokResponses(
 			break
 		}
 
-		retryBody, changed, trimErr := trimGrokInvalidEncryptedContentRetryBody(patchedBody)
+		retryBody, changed, trimErr := trimOpenAIInvalidEncryptedContentRetryBody(patchedBody)
 		if trimErr != nil {
 			return nil, fmt.Errorf("prepare Grok invalid encrypted_content retry: %w", trimErr)
 		}
@@ -264,9 +264,9 @@ func isGrokInvalidEncryptedContentResponse(statusCode int, body []byte) bool {
 			strings.Contains(normalizedMessage, "unmodified"))
 }
 
-// requestHasGrokEncryptedReasoning reports whether the outbound Responses body
+// requestHasOpenAIEncryptedReasoning reports whether the outbound Responses body
 // still carries reasoning.encrypted_content that can be stripped for retry.
-func requestHasGrokEncryptedReasoning(body []byte) bool {
+func requestHasOpenAIEncryptedReasoning(body []byte) bool {
 	input := gjson.GetBytes(body, "input")
 	if !input.Exists() {
 		return false
@@ -347,7 +347,7 @@ func stripAnthropicThinkingSignatures(body []byte) ([]byte, bool) {
 	return out, true
 }
 
-func trimGrokInvalidEncryptedContentRetryBody(body []byte) ([]byte, bool, error) {
+func trimOpenAIInvalidEncryptedContentRetryBody(body []byte) ([]byte, bool, error) {
 	input := gjson.GetBytes(body, "input")
 	items := input.Array()
 	if input.IsObject() {

--- a/backend/internal/service/openai_gateway_messages.go
+++ b/backend/internal/service/openai_gateway_messages.go
@@ -288,44 +288,54 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 		// 既有 body/session/conversation 行为。身份头在 post-build 阶段统一恢复。
 		setOpenAICompatMessagesBridgeContext(c, true)
 	}
-	upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
-	var upstreamReq *http.Request
-	if account.Platform == PlatformGrok {
-		upstreamReq, err = buildGrokResponsesRequest(upstreamCtx, c, account, responsesBody, token, grokCacheIdentity, s.cfg)
-	} else {
-		upstreamReq, err = s.buildUpstreamRequest(upstreamCtx, c, account, responsesBody, token, isStream, promptCacheKey, false)
-	}
-	releaseUpstreamCtx()
-	if err != nil {
-		return nil, fmt.Errorf("build upstream request: %w", err)
+	buildMessagesUpstreamRequest := func(requestBody []byte) (*http.Request, error) {
+		upstreamCtx, releaseUpstreamCtx := detachUpstreamContext(ctx)
+		defer releaseUpstreamCtx()
+
+		var upstreamReq *http.Request
+		var buildErr error
+		if account.Platform == PlatformGrok {
+			upstreamReq, buildErr = buildGrokResponsesRequest(upstreamCtx, c, account, requestBody, token, grokCacheIdentity, s.cfg)
+		} else {
+			upstreamReq, buildErr = s.buildUpstreamRequest(upstreamCtx, c, account, requestBody, token, isStream, promptCacheKey, false)
+		}
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		// Override session_id with a deterministic UUID derived from the isolated
+		// session key, ensuring different API keys produce different upstream sessions.
+		if account.Platform != PlatformGrok && promptCacheKey != "" {
+			isolatedSessionID := generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey))
+			upstreamReq.Header.Set("session_id", isolatedSessionID)
+			if upstreamReq.Header.Get("conversation_id") != "" {
+				upstreamReq.Header.Set("conversation_id", isolatedSessionID)
+			}
+		}
+		if account.Type == AccountTypeOAuth && account.Platform != PlatformGrok {
+			// buildUpstreamRequest 保留 Messages bridge 的 body/session 兼容行为，并会先
+			// 清除身份头。真正发送前恢复完整 Codex 身份，避免 ChatGPT Codex 上游因缺失
+			// originator/OpenAI-Beta 返回 404（issue #3901）。
+			ensureCodexIdentityHeaders(upstreamReq.Header)
+			enforceCodexIdentityHeaders(upstreamReq.Header)
+			logger.L().Debug("openai messages: upstream identity restored",
+				zap.Int64("account_id", account.ID),
+				zap.String("upstream_model", upstreamModel),
+				zap.Bool("compat_identity_restored", true),
+			)
+		}
+		if account.Type == AccountTypeOAuth && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
+			upstreamReq.Header.Del("conversation_id")
+		}
+		if compatTurnState != "" && upstreamReq.Header.Get("x-codex-turn-state") == "" {
+			upstreamReq.Header.Set("x-codex-turn-state", compatTurnState)
+		}
+		return upstreamReq, nil
 	}
 
-	// Override session_id with a deterministic UUID derived from the isolated
-	// session key, ensuring different API keys produce different upstream sessions.
-	if account.Platform != PlatformGrok && promptCacheKey != "" {
-		isolatedSessionID := generateSessionUUID(isolateOpenAISessionID(apiKeyID, promptCacheKey))
-		upstreamReq.Header.Set("session_id", isolatedSessionID)
-		if upstreamReq.Header.Get("conversation_id") != "" {
-			upstreamReq.Header.Set("conversation_id", isolatedSessionID)
-		}
-	}
-	if account.Type == AccountTypeOAuth && account.Platform != PlatformGrok {
-		// buildUpstreamRequest 保留 Messages bridge 的 body/session 兼容行为，并会先
-		// 清除身份头。真正发送前恢复完整 Codex 身份，避免 ChatGPT Codex 上游因缺失
-		// originator/OpenAI-Beta 返回 404（issue #3901）。
-		ensureCodexIdentityHeaders(upstreamReq.Header)
-		enforceCodexIdentityHeaders(upstreamReq.Header)
-		logger.L().Debug("openai messages: upstream identity restored",
-			zap.Int64("account_id", account.ID),
-			zap.String("upstream_model", upstreamModel),
-			zap.Bool("compat_identity_restored", true),
-		)
-	}
-	if account.Type == AccountTypeOAuth && promptCacheKey != "" && strings.TrimSpace(c.GetHeader("conversation_id")) == "" {
-		upstreamReq.Header.Del("conversation_id")
-	}
-	if compatTurnState != "" && upstreamReq.Header.Get("x-codex-turn-state") == "" {
-		upstreamReq.Header.Set("x-codex-turn-state", compatTurnState)
+	upstreamReq, err := buildMessagesUpstreamRequest(responsesBody)
+	if err != nil {
+		return nil, fmt.Errorf("build upstream request: %w", err)
 	}
 
 	// 7. Send request
@@ -333,52 +343,53 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	if account.Proxy != nil {
 		proxyURL = account.Proxy.URL()
 	}
-	// Grok may reject encrypted reasoning replayed under a different OAuth
-	// account/cache identity. Match forwardGrokResponses: one strip+retry before
-	// treating the 400 as a hard failure / failover trigger.
+	// Encrypted reasoning is provider-bound. When history crosses providers or
+	// account identities, retry once without that opaque payload while preserving
+	// the readable summary and the rest of the conversation.
 	var resp *http.Response
-	for attempt := 0; ; attempt++ {
-		if attempt > 0 {
-			if account.Platform != PlatformGrok {
-				break
-			}
-			upstreamCtxRetry, releaseRetry := detachUpstreamContext(ctx)
-			upstreamReq, err = buildGrokResponsesRequest(upstreamCtxRetry, c, account, responsesBody, token, grokCacheIdentity, s.cfg)
-			releaseRetry()
-			if err != nil {
-				return nil, fmt.Errorf("build grok retry request: %w", err)
-			}
-		}
+	invalidEncryptedContentRetryTried := false
+	for {
 		resp, err = s.httpUpstream.Do(upstreamReq, proxyURL, account.ID, account.Concurrency)
 		if err != nil {
 			return nil, s.handleOpenAIUpstreamTransportError(ctx, c, account, err, false)
 		}
-		if account.Platform != PlatformGrok || attempt > 0 || resp.StatusCode != http.StatusBadRequest {
+		if invalidEncryptedContentRetryTried ||
+			resp.StatusCode != http.StatusBadRequest ||
+			(account.Platform != PlatformGrok && account.Platform != PlatformOpenAI) {
 			break
 		}
 		respBody := s.readUpstreamErrorBody(resp)
 		if resp.Body != nil {
 			_ = resp.Body.Close()
 		}
-		// Prefer explicit decrypt errors; also strip once on any 400 when the
-		// outbound body still carries reasoning.encrypted_content (account
-		// switch often returns opaque "Upstream error: 400").
-		shouldStrip := isGrokInvalidEncryptedContentResponse(resp.StatusCode, respBody) ||
-			requestHasGrokEncryptedReasoning(responsesBody)
+		hasEncryptedReasoning := requestHasOpenAIEncryptedReasoning(responsesBody)
+		shouldStrip := false
+		switch account.Platform {
+		case PlatformGrok:
+			// Grok account switches often return only an opaque 400.
+			shouldStrip = isGrokInvalidEncryptedContentResponse(resp.StatusCode, respBody) || hasEncryptedReasoning
+		case PlatformOpenAI:
+			shouldStrip = isOpenAIInvalidEncryptedContentResponse(resp.StatusCode, respBody)
+		}
 		if !shouldStrip {
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 			break
 		}
-		retryBody, changed, trimErr := trimGrokInvalidEncryptedContentRetryBody(responsesBody)
+		retryBody, changed, trimErr := trimOpenAIInvalidEncryptedContentRetryBody(responsesBody)
 		if trimErr != nil {
-			return nil, fmt.Errorf("prepare Grok invalid encrypted_content retry: %w", trimErr)
+			return nil, fmt.Errorf("prepare invalid encrypted_content retry: %w", trimErr)
 		}
 		if !changed {
 			resp.Body = io.NopCloser(bytes.NewReader(respBody))
 			break
 		}
 		responsesBody = retryBody
-		logger.L().Info("openai messages: retrying after stripping invalid Grok encrypted_content",
+		invalidEncryptedContentRetryTried = true
+		upstreamReq, err = buildMessagesUpstreamRequest(responsesBody)
+		if err != nil {
+			return nil, fmt.Errorf("build invalid encrypted_content retry request: %w", err)
+		}
+		logger.L().Info("openai messages: retrying after stripping invalid encrypted_content",
 			zap.Int64("account_id", account.ID),
 			zap.Bool("cache_identity_present", strings.TrimSpace(grokCacheIdentity) != ""),
 			zap.String("upstream_error_preview", truncateOpenAIWSLogValue(string(respBody), 240)),
@@ -485,6 +496,21 @@ func (s *OpenAIGatewayService) ForwardAsAnthropic(
 	}
 
 	return result, handleErr
+}
+
+func isOpenAIInvalidEncryptedContentResponse(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(extractUpstreamErrorCode(body)), "invalid_encrypted_content") {
+		return true
+	}
+
+	message := strings.ToLower(strings.TrimSpace(extractUpstreamErrorMessage(body)))
+	compactMessage := strings.Join(strings.Fields(message), "")
+	return strings.Contains(message, "encrypted content") &&
+		strings.Contains(message, "could not be verified") &&
+		strings.Contains(compactMessage, "couldnotbedecryptedorparsed")
 }
 
 func ensureCodexOAuthInstructionsField(reqBody map[string]any) {

--- a/backend/internal/service/openai_gateway_messages_encrypted_content_test.go
+++ b/backend/internal/service/openai_gateway_messages_encrypted_content_test.go
@@ -1,0 +1,113 @@
+//go:build unit
+
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/openai_compat"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestForwardAsAnthropic_OpenAIInvalidEncryptedContentRetriesWithoutForeignReasoning(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{
+		"model":"claude-sonnet-4-5",
+		"max_tokens":32,
+		"messages":[
+			{"role":"user","content":"first"},
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"keep this summary","signature":"CAIS.AQ=="},
+				{"type":"text","text":"first answer"}
+			]},
+			{"role":"user","content":"continue"}
+		],
+		"stream":false
+	}`)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", bytes.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	completed := strings.Join([]string{
+		`data: {"type":"response.completed","response":{"id":"resp_recovered","object":"response","model":"gpt-5.4","status":"completed","output":[{"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"recovered"}]}],"usage":{"input_tokens":5,"output_tokens":2,"total_tokens":7}}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+	upstream := &httpUpstreamRecorder{responses: []*http.Response{
+		{
+			StatusCode: http.StatusBadRequest,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"error":{"type":"invalid_request_error","message":"The encrypted content CAIS.AQ== could not be Verified. Reason: Encrypted content could not be decrypted or parsed."}}`,
+			)),
+		},
+		{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}, "x-request-id": []string{"rid_recovered"}},
+			Body:       io.NopCloser(strings.NewReader(completed)),
+		},
+	}}
+	svc := &OpenAIGatewayService{
+		cfg:          rawChatCompletionsTestConfig(),
+		httpUpstream: upstream,
+	}
+	account := rawChatCompletionsTestAccount()
+	account.Extra = map[string]any{
+		openai_compat.ExtraKeyResponsesMode:      string(openai_compat.ResponsesSupportModeAuto),
+		openai_compat.ExtraKeyResponsesSupported: true,
+	}
+
+	result, err := svc.ForwardAsAnthropic(context.Background(), c, account, body, "", "gpt-5.4")
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.Len(t, upstream.bodies, 2)
+	require.Equal(t, "CAIS.AQ==", gjson.GetBytes(upstream.bodies[0], `input.#(type=="reasoning").encrypted_content`).String())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], `input.#(type=="reasoning").encrypted_content`).Exists())
+	require.False(t, gjson.GetBytes(upstream.bodies[1], `input.#(type=="reasoning")`).Exists())
+	require.Equal(t, "first answer", gjson.GetBytes(upstream.bodies[1], `input.#(role=="assistant").content.0.text`).String())
+	require.Contains(t, string(upstream.bodies[1]), `"text":"continue"`)
+	require.Equal(t, "recovered", gjson.Get(rec.Body.String(), "content.0.text").String())
+}
+
+func TestIsOpenAIInvalidEncryptedContentResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "error code",
+			body: `{"error":{"code":"invalid_encrypted_content","message":"bad encrypted content"}}`,
+			want: true,
+		},
+		{
+			name: "verification message without code",
+			body: `{"error":{"message":"The encrypted content CAIS.AQ== could not be Verified. Reason: Encrypted content could not bedecrypted or parsed."}}`,
+			want: true,
+		},
+		{
+			name: "unrelated bad request",
+			body: `{"error":{"code":"invalid_request_error","message":"input is too long"}}`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isOpenAIInvalidEncryptedContentResponse(http.StatusBadRequest, []byte(tt.body)))
+		})
+	}
+	require.False(t, isOpenAIInvalidEncryptedContentResponse(http.StatusInternalServerError, []byte(tests[0].body)))
+}


### PR DESCRIPTION
## Summary

- retry the Anthropic Messages to OpenAI Responses bridge once when upstream rejects provider-bound `reasoning.encrypted_content`
- keep the original signed reasoning on the first attempt, then strip only the rejected opaque payload while preserving the rest of the conversation
- reuse the same generic request-body sanitizer for the existing Grok recovery path

## Root cause

Anthropic assistant `thinking.signature` blocks are converted to Responses `reasoning.encrypted_content` so same-provider continuations can reuse signed reasoning. When a conversation is routed from Claude to an OpenAI-compatible model, that foreign ciphertext can be forwarded unchanged.

The native `/v1/responses` path already recovers from `invalid_encrypted_content`, but `ForwardAsAnthropic` only performed this recovery for Grok. OpenAI-compatible accounts therefore returned the upstream 400 directly:

`The encrypted content CAIS... could not be Verified. Reason: Encrypted content could not be decrypted or parsed.`

## Fix

The Messages bridge now:

1. recognizes either the `invalid_encrypted_content` error code or the specific verify/decrypt error text
2. removes `encrypted_content` from reasoning input, dropping an empty reasoning skeleton when necessary
3. rebuilds the upstream request with the same session and identity headers
4. retries at most once

Unrelated 400 responses are not retried, and valid same-provider signed reasoning is still sent unchanged on the first attempt.

## Tests

- added a red-to-green regression covering a Claude `CAIS...` signature routed to an OpenAI Responses account
- `go test -tags unit ./internal/service -count=1`
- `go test ./internal/pkg/apicompat -count=1`
