### PR TITLE
fix(cache): synchronize runtime invalidation across replicas

### DIFF
--- a/backend/internal/handler/admin/channel_handler.go
+++ b/backend/internal/handler/admin/channel_handler.go
@@ -25,6 +25,24 @@ func NewChannelHandler(channelService *service.ChannelService, billingService *s
 	return &ChannelHandler{channelService: channelService, billingService: billingService, pricingService: pricingService}
 }
 
+// InvalidateRuntimeCache clears the process-local channel routing snapshot.
+// The server calls this when another replica broadcasts a configuration write.
+func (h *ChannelHandler) InvalidateRuntimeCache() {
+	if h == nil || h.channelService == nil {
+		return
+	}
+	h.channelService.InvalidateRuntimeCache()
+}
+
+// SetOnUpdateCallback connects channel CRUD writes to the server's
+// cross-replica configuration invalidation broadcaster.
+func (h *ChannelHandler) SetOnUpdateCallback(callback func()) {
+	if h == nil || h.channelService == nil {
+		return
+	}
+	h.channelService.SetOnUpdateCallback(callback)
+}
+
 // --- Request / Response types ---
 
 type createChannelRequest struct {

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -70,23 +70,44 @@ func SetupRouter(
 	}))
 	r.Use(middleware2.ServerTiming(cfg.Server.EnableServerTiming))
 
-	// Serve embedded frontend with settings injection if available
+	// Serve embedded frontend with settings injection if available.
+	// Keep the server reference so a settings broadcast can invalidate the
+	// process-local HTML cache on every replica.
+	var frontendServer *web.FrontendServer
 	if web.HasEmbeddedFrontend() {
-		frontendServer, err := web.NewFrontendServer(settingService) //nolint:staticcheck // SA4023: the !embed stub always errors; embed builds can return nil
-		if err != nil {                                              //nolint:staticcheck // SA4023: see above
+		var err error
+		frontendServer, err = web.NewFrontendServer(settingService) //nolint:staticcheck // SA4023: the !embed stub always errors; embed builds can return nil
+		if err != nil {                                             //nolint:staticcheck // SA4023: see above
 			log.Printf("Warning: Failed to create frontend server with settings injection: %v, using legacy mode", err)
 			r.Use(web.ServeEmbeddedFrontend())
-			settingService.SetOnUpdateCallback(refreshFrameOrigins)
+			frontendServer = nil
 		} else {
-			// Register combined callback: invalidate HTML cache + refresh frame origins
-			settingService.SetOnUpdateCallback(func() {
-				frontendServer.InvalidateCache()
-				refreshFrameOrigins()
-			})
 			r.Use(frontendServer.Middleware())
 		}
-	} else {
-		settingService.SetOnUpdateCallback(refreshFrameOrigins)
+	}
+
+	invalidateLocalSettings := func() {
+		settingService.InvalidateRuntimeCaches()
+		if handlers != nil && handlers.Admin != nil && handlers.Admin.Channel != nil {
+			handlers.Admin.Channel.InvalidateRuntimeCache()
+		}
+		if frontendServer != nil {
+			frontendServer.InvalidateCache()
+		}
+		refreshFrameOrigins()
+	}
+	settingsBus := newRedisSettingsInvalidationBus(redisClient)
+	notifyConfigurationUpdate := configureSettingsInvalidation(
+		context.Background(),
+		settingsBus,
+		invalidateLocalSettings,
+		func(err error) {
+			log.Printf("Warning: settings cache invalidation unavailable: %v", err)
+		},
+	)
+	settingService.SetOnUpdateCallback(notifyConfigurationUpdate)
+	if handlers != nil && handlers.Admin != nil && handlers.Admin.Channel != nil {
+		handlers.Admin.Channel.SetOnUpdateCallback(notifyConfigurationUpdate)
 	}
 
 	// 注册路由

--- a/backend/internal/server/settings_invalidation.go
+++ b/backend/internal/server/settings_invalidation.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	settingsInvalidationChannel = "settings:cache:invalidate"
+	settingsPublishTimeout      = 3 * time.Second
+	settingsSubscribeTimeout    = 3 * time.Second
+)
+
+type settingsInvalidationBus interface {
+	Publish(ctx context.Context) error
+	Subscribe(ctx context.Context, handler func()) error
+}
+
+type redisSettingsInvalidationBus struct {
+	rdb *redis.Client
+}
+
+func newRedisSettingsInvalidationBus(rdb *redis.Client) settingsInvalidationBus {
+	if rdb == nil {
+		return nil
+	}
+	return &redisSettingsInvalidationBus{rdb: rdb}
+}
+
+func (b *redisSettingsInvalidationBus) Publish(ctx context.Context) error {
+	if b == nil || b.rdb == nil {
+		return nil
+	}
+	return b.rdb.Publish(ctx, settingsInvalidationChannel, time.Now().UnixNano()).Err()
+}
+
+func (b *redisSettingsInvalidationBus) Subscribe(ctx context.Context, handler func()) error {
+	if b == nil || b.rdb == nil {
+		return nil
+	}
+	if handler == nil {
+		return fmt.Errorf("settings invalidation handler is nil")
+	}
+
+	pubsub := b.rdb.Subscribe(ctx, settingsInvalidationChannel)
+	subscribeCtx, cancel := context.WithTimeout(ctx, settingsSubscribeTimeout)
+	defer cancel()
+	if _, err := pubsub.Receive(subscribeCtx); err != nil {
+		_ = pubsub.Close()
+		return fmt.Errorf("subscribe to settings invalidation: %w", err)
+	}
+
+	go func() {
+		defer func() {
+			if err := pubsub.Close(); err != nil {
+				log.Printf("Warning: failed to close settings invalidation subscriber: %v", err)
+			}
+		}()
+
+		ch := pubsub.Channel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				if msg != nil {
+					handler()
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+// configureSettingsInvalidation connects a local cache invalidator to the
+// shared invalidation bus and returns the callback used after a settings write.
+// The callback always clears local caches first, then broadcasts to peers.
+func configureSettingsInvalidation(
+	ctx context.Context,
+	bus settingsInvalidationBus,
+	invalidateLocal func(),
+	onError func(error),
+) func() {
+	if invalidateLocal == nil {
+		invalidateLocal = func() {}
+	}
+	if onError == nil {
+		onError = func(error) {}
+	}
+
+	if bus != nil {
+		if err := bus.Subscribe(ctx, invalidateLocal); err != nil {
+			onError(err)
+		}
+	}
+
+	return func() {
+		invalidateLocal()
+		if bus == nil {
+			return
+		}
+		publishCtx, cancel := context.WithTimeout(context.Background(), settingsPublishTimeout)
+		defer cancel()
+		if err := bus.Publish(publishCtx); err != nil {
+			onError(fmt.Errorf("publish settings invalidation: %w", err))
+		}
+	}
+}

--- a/backend/internal/server/settings_invalidation_test.go
+++ b/backend/internal/server/settings_invalidation_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeSettingsInvalidationBus struct {
+	mu           sync.Mutex
+	subscribers  []func()
+	publishErr   error
+	subscribeErr error
+}
+
+func (b *fakeSettingsInvalidationBus) Publish(context.Context) error {
+	if b.publishErr != nil {
+		return b.publishErr
+	}
+	b.mu.Lock()
+	subscribers := append([]func(){}, b.subscribers...)
+	b.mu.Unlock()
+	for _, subscriber := range subscribers {
+		subscriber()
+	}
+	return nil
+}
+
+func (b *fakeSettingsInvalidationBus) Subscribe(_ context.Context, handler func()) error {
+	if b.subscribeErr != nil {
+		return b.subscribeErr
+	}
+	b.mu.Lock()
+	b.subscribers = append(b.subscribers, handler)
+	b.mu.Unlock()
+	return nil
+}
+
+func TestConfigureSettingsInvalidation_BroadcastsToEveryReplica(t *testing.T) {
+	bus := &fakeSettingsInvalidationBus{}
+	var replicaAInvalidations int
+	var replicaBInvalidations int
+
+	notifyA := configureSettingsInvalidation(context.Background(), bus, func() {
+		replicaAInvalidations++
+	}, nil)
+	_ = configureSettingsInvalidation(context.Background(), bus, func() {
+		replicaBInvalidations++
+	}, nil)
+
+	notifyA()
+
+	require.Equal(t, 2, replicaAInvalidations)
+	require.Equal(t, 1, replicaBInvalidations)
+}
+
+func TestConfigureSettingsInvalidation_PublishFailureKeepsLocalInvalidation(t *testing.T) {
+	bus := &fakeSettingsInvalidationBus{publishErr: errors.New("redis unavailable")}
+	var invalidations int
+	var receivedErr error
+
+	notify := configureSettingsInvalidation(context.Background(), bus, func() {
+		invalidations++
+	}, func(err error) {
+		receivedErr = err
+	})
+	notify()
+
+	require.Equal(t, 1, invalidations)
+	require.ErrorContains(t, receivedErr, "publish settings invalidation")
+}
+
+func TestConfigureSettingsInvalidation_SubscribeFailureIsReported(t *testing.T) {
+	bus := &fakeSettingsInvalidationBus{subscribeErr: errors.New("subscribe failed")}
+	var receivedErr error
+
+	_ = configureSettingsInvalidation(context.Background(), bus, nil, func(err error) {
+		receivedErr = err
+	})
+
+	require.ErrorContains(t, receivedErr, "subscribe failed")
+}

--- a/backend/internal/service/channel_service.go
+++ b/backend/internal/service/channel_service.go
@@ -144,7 +144,7 @@ func (r ChannelMappingResult) ToUsageFields(reqModel, upstreamModel string) Chan
 }
 
 const (
-	channelCacheTTL       = 10 * time.Minute
+	channelCacheTTL       = 30 * time.Second
 	channelErrorTTL       = 5 * time.Second // DB 错误时的短缓存
 	channelCacheDBTimeout = 10 * time.Second
 )
@@ -155,6 +155,7 @@ type ChannelService struct {
 	groupRepo            GroupRepository
 	authCacheInvalidator APIKeyAuthCacheInvalidator
 	pricingService       *PricingService // 用于「可用渠道」展示时回落到全局定价；可为 nil（测试场景）
+	onUpdate             func()
 
 	cache   atomic.Value // *channelCache
 	cacheSF singleflight.Group
@@ -340,7 +341,32 @@ func populateChannelCache(channels []Channel, groupPlatforms map[int64]string) *
 	return cache
 }
 
-// invalidateCache 使缓存失效，让下次读取时自然重建
+// SetOnUpdateCallback registers the cross-replica invalidation callback.
+// It is configured once during server startup.
+func (s *ChannelService) SetOnUpdateCallback(callback func()) {
+	s.onUpdate = callback
+}
+
+// InvalidateRuntimeCache clears and rebuilds only this process' channel
+// snapshot. It is safe to call from a distributed invalidation subscriber.
+func (s *ChannelService) InvalidateRuntimeCache() {
+	s.cache.Store((*channelCache)(nil))
+	s.cacheSF.Forget("channel_cache")
+
+	if _, err := s.buildCache(context.Background()); err != nil {
+		slog.Warn("failed to rebuild channel cache after invalidation", "error", err)
+	}
+}
+
+// invalidateCache invalidates the local process and, when configured by the
+// server, broadcasts the same invalidation to every replica.
+func (s *ChannelService) invalidateCache() {
+	if s.onUpdate != nil {
+		s.onUpdate()
+		return
+	}
+	s.InvalidateRuntimeCache()
+}
 
 // isPlatformPricingMatch 判断定价条目的平台是否匹配分组平台。
 // Concrete platforms stay isolated; composite groups may carry concrete-provider
@@ -361,7 +387,6 @@ func matchingPlatforms(groupPlatform string) []string {
 	}
 	return []string{groupPlatform}
 }
-
 func channelLookupPlatform(ctx context.Context, groupPlatform string) string {
 	if ctx != nil {
 		if forcePlatform, ok := ctx.Value(ctxkey.ForcePlatform).(string); ok && strings.TrimSpace(forcePlatform) != "" {
@@ -374,15 +399,6 @@ func channelLookupPlatform(ctx context.Context, groupPlatform string) string {
 		}
 	}
 	return groupPlatform
-}
-func (s *ChannelService) invalidateCache() {
-	s.cache.Store((*channelCache)(nil))
-	s.cacheSF.Forget("channel_cache")
-
-	// 主动重建缓存，确保 CRUD 后立即生效
-	if _, err := s.buildCache(context.Background()); err != nil {
-		slog.Warn("failed to rebuild channel cache after invalidation", "error", err)
-	}
 }
 
 // matchWildcard 在通配符定价中查找匹配项（最先匹配到优先）

--- a/backend/internal/service/channel_service_test.go
+++ b/backend/internal/service/channel_service_test.go
@@ -1334,6 +1334,18 @@ func TestInvalidateCache(t *testing.T) {
 	require.Equal(t, 2, callCount) // rebuilt
 }
 
+func TestInvalidateCache_UsesConfiguredCrossReplicaCallback(t *testing.T) {
+	svc := newTestChannelService(&mockChannelRepository{})
+	var invalidations int
+	svc.SetOnUpdateCallback(func() {
+		invalidations++
+	})
+
+	svc.invalidateCache()
+
+	require.Equal(t, 1, invalidations)
+}
+
 // ===========================================================================
 // 5. CRUD Methods
 // ===========================================================================

--- a/backend/internal/service/setting_gateway_runtime.go
+++ b/backend/internal/service/setting_gateway_runtime.go
@@ -16,7 +16,7 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-// cachedVersionBounds 缓存 Claude Code 版本号上下限（进程内缓存，60s TTL）
+// cachedVersionBounds 缓存 Claude Code 版本号上下限（进程内缓存，30s TTL）
 type cachedVersionBounds struct {
 	min       string // 空字符串 = 不检查
 	max       string // 空字符串 = 不检查
@@ -30,7 +30,7 @@ var versionBoundsCache atomic.Value // *cachedVersionBounds
 var versionBoundsSF singleflight.Group
 
 // versionBoundsCacheTTL 缓存有效期
-const versionBoundsCacheTTL = 60 * time.Second
+const versionBoundsCacheTTL = 30 * time.Second
 
 // versionBoundsErrorTTL DB 错误时的短缓存，快速重试
 const versionBoundsErrorTTL = 5 * time.Second
@@ -38,7 +38,7 @@ const versionBoundsErrorTTL = 5 * time.Second
 // versionBoundsDBTimeout singleflight 内 DB 查询超时，独立于请求 context
 const versionBoundsDBTimeout = 5 * time.Second
 
-// cachedBackendMode Backend Mode cache (in-process, 60s TTL)
+// cachedBackendMode Backend Mode cache (in-process, 30s TTL)
 type cachedBackendMode struct {
 	value     bool
 	expiresAt int64 // unix nano
@@ -47,11 +47,11 @@ type cachedBackendMode struct {
 var backendModeCache atomic.Value // *cachedBackendMode
 var backendModeSF singleflight.Group
 
-const backendModeCacheTTL = 60 * time.Second
+const backendModeCacheTTL = 30 * time.Second
 const backendModeErrorTTL = 5 * time.Second
 const backendModeDBTimeout = 5 * time.Second
 
-// cachedGatewayForwardingSettings 缓存网关转发行为设置（进程内缓存，60s TTL）
+// cachedGatewayForwardingSettings 缓存网关转发行为设置（进程内缓存，30s TTL）
 type cachedGatewayForwardingSettings struct {
 	fingerprintUnification           bool
 	metadataPassthrough              bool
@@ -68,7 +68,7 @@ type cachedGatewayForwardingSettings struct {
 var gatewayForwardingCache atomic.Value // *cachedGatewayForwardingSettings
 var gatewayForwardingSF singleflight.Group
 
-const gatewayForwardingCacheTTL = 60 * time.Second
+const gatewayForwardingCacheTTL = 30 * time.Second
 const gatewayForwardingErrorTTL = 5 * time.Second
 const gatewayForwardingDBTimeout = 5 * time.Second
 

--- a/backend/internal/service/setting_service.go
+++ b/backend/internal/service/setting_service.go
@@ -422,6 +422,20 @@ func (s *SettingService) notifyChannelMonitorRuntimeListeners() {
 	}
 }
 
+// InvalidateRuntimeCaches clears process-local setting snapshots. PostgreSQL
+// stores the shared values, but every application replica keeps these hot-path
+// caches independently.
+func (s *SettingService) InvalidateRuntimeCaches() {
+	versionBoundsSF.Forget("version_bounds")
+	versionBoundsCache.Store(&cachedVersionBounds{expiresAt: 0})
+
+	backendModeSF.Forget("backend_mode")
+	backendModeCache.Store(&cachedBackendMode{expiresAt: 0})
+
+	gatewayForwardingSF.Forget("gateway_forwarding")
+	gatewayForwardingCache.Store(&cachedGatewayForwardingSettings{expiresAt: 0})
+}
+
 // SetVersion sets the application version for injection into public settings
 func (s *SettingService) SetVersion(version string) {
 	s.version = version

--- a/backend/internal/service/setting_service_invalidation_test.go
+++ b/backend/internal/service/setting_service_invalidation_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidateRuntimeCaches_ExpiresAllProcessLocalSnapshots(t *testing.T) {
+	future := time.Now().Add(time.Hour).UnixNano()
+	versionBoundsCache.Store(&cachedVersionBounds{min: "1.0.0", max: "2.0.0", expiresAt: future})
+	backendModeCache.Store(&cachedBackendMode{value: true, expiresAt: future})
+	gatewayForwardingCache.Store(&cachedGatewayForwardingSettings{
+		fingerprintUnification: true,
+		metadataPassthrough:    true,
+		cchSigning:             true,
+		expiresAt:              future,
+	})
+
+	service := &SettingService{}
+	service.InvalidateRuntimeCaches()
+
+	versionBounds := versionBoundsCache.Load().(*cachedVersionBounds)
+	backendMode := backendModeCache.Load().(*cachedBackendMode)
+	gatewayForwarding := gatewayForwardingCache.Load().(*cachedGatewayForwardingSettings)
+	require.Equal(t, int64(0), versionBounds.expiresAt)
+	require.Equal(t, int64(0), backendMode.expiresAt)
+	require.Equal(t, int64(0), gatewayForwarding.expiresAt)
+}

--- a/backend/internal/web/html_cache.go
+++ b/backend/internal/web/html_cache.go
@@ -6,7 +6,10 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"sync"
+	"time"
 )
+
+const defaultHTMLCacheTTL = 30 * time.Second
 
 // HTMLCache manages the cached index.html with injected settings
 type HTMLCache struct {
@@ -15,6 +18,8 @@ type HTMLCache struct {
 	etag            string
 	baseHTMLHash    string // Hash of the original index.html (immutable after build)
 	settingsVersion uint64 // Incremented when settings change
+	cachedAt        time.Time
+	ttl             time.Duration
 }
 
 // CachedHTML represents the cache state
@@ -25,7 +30,11 @@ type CachedHTML struct {
 
 // NewHTMLCache creates a new HTML cache instance
 func NewHTMLCache() *HTMLCache {
-	return &HTMLCache{}
+	return newHTMLCache(defaultHTMLCacheTTL)
+}
+
+func newHTMLCache(ttl time.Duration) *HTMLCache {
+	return &HTMLCache{ttl: ttl}
 }
 
 // SetBaseHTML initializes the cache with the base HTML template
@@ -45,6 +54,7 @@ func (c *HTMLCache) Invalidate() {
 	c.settingsVersion++
 	c.cachedHTML = nil
 	c.etag = ""
+	c.cachedAt = time.Time{}
 }
 
 // Get returns the cached HTML or nil if cache is stale
@@ -53,6 +63,9 @@ func (c *HTMLCache) Get() *CachedHTML {
 	defer c.mu.RUnlock()
 
 	if c.cachedHTML == nil {
+		return nil
+	}
+	if c.ttl > 0 && time.Since(c.cachedAt) >= c.ttl {
 		return nil
 	}
 	return &CachedHTML{
@@ -68,6 +81,7 @@ func (c *HTMLCache) Set(html []byte, settingsJSON []byte) {
 
 	c.cachedHTML = html
 	c.etag = c.generateETag(settingsJSON)
+	c.cachedAt = time.Now()
 }
 
 // generateETag creates an ETag from base HTML hash + settings hash

--- a/backend/internal/web/html_cache_ttl_test.go
+++ b/backend/internal/web/html_cache_ttl_test.go
@@ -1,0 +1,21 @@
+//go:build embed
+
+package web
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTMLCache_ExpiresAsMissedInvalidationFallback(t *testing.T) {
+	cache := newHTMLCache(10 * time.Millisecond)
+	cache.SetBaseHTML([]byte("<html></html>"))
+	cache.Set([]byte("rendered"), []byte(`{"backend_mode_enabled":true}`))
+
+	require.NotNil(t, cache.Get())
+	require.Eventually(t, func() bool {
+		return cache.Get() == nil
+	}, time.Second, 5*time.Millisecond)
+}


### PR DESCRIPTION
## Problem

Several hot-path caches are process-local while their source of truth is shared in PostgreSQL. In a multi-replica deployment, an admin write handled by replica A only invalidates replica A, so requests routed to replica B can continue using stale state.

Affected state includes:

- channel routing, model mappings, and channel pricing snapshots (10-minute TTL)
- gateway forwarding/runtime settings such as metadata passthrough and version bounds (60-second TTL)
- embedded frontend settings/ETag and CSP frame origins

This makes the same operation appear to work or fail depending on which replica receives the next request.

## Solution

- add a Redis Pub/Sub invalidation bus on `settings:cache:invalidate`
- subscribe every replica during router startup
- after a settings or channel write, invalidate the local process first and broadcast to peers
- clear runtime setting snapshots, eagerly rebuild the channel snapshot, invalidate embedded HTML/ETag state, and refresh CSP frame origins
- bound channel, runtime-setting, and embedded HTML caches to a 30-second TTL as a fallback if a Pub/Sub notification is missed
- keep local invalidation working and report an error if Redis publish/subscribe fails

The existing subscription-cache invalidation mechanism is unchanged.

## Verification

Added tests cover:

- invalidation broadcast reaching peer replicas
- local invalidation when publish fails
- subscribe failure reporting
- channel CRUD using the cross-replica callback
- expiration of all process-local settings snapshots
- HTML TTL fallback

```bash
go test ./internal/server ./internal/service ./internal/web
```

All listed packages pass against the current upstream `main`.