### PR TITLE
[codex] support Vertex API key routing for Gemini

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -1886,6 +1886,7 @@ func setDefaults() {
 		"open.bigmodel.cn",
 		"api.minimaxi.com",
 		"generativelanguage.googleapis.com",
+		"aiplatform.googleapis.com",
 		"cloudcode-pa.googleapis.com",
 		"*.openai.azure.com",
 	})

--- a/backend/internal/pkg/geminicli/constants.go
+++ b/backend/internal/pkg/geminicli/constants.go
@@ -4,8 +4,9 @@ package geminicli
 import "time"
 
 const (
-	AIStudioBaseURL  = "https://generativelanguage.googleapis.com"
-	GeminiCliBaseURL = "https://cloudcode-pa.googleapis.com"
+	AIStudioBaseURL      = "https://generativelanguage.googleapis.com"
+	VertexExpressBaseURL = "https://aiplatform.googleapis.com"
+	GeminiCliBaseURL     = "https://cloudcode-pa.googleapis.com"
 
 	AuthorizeURL = "https://accounts.google.com/o/oauth2/v2/auth"
 	TokenURL     = "https://oauth2.googleapis.com/token"

--- a/backend/internal/service/account.go
+++ b/backend/internal/service/account.go
@@ -261,6 +261,29 @@ func (a *Account) IsGemini() bool {
 	return a.Platform == PlatformGemini
 }
 
+const (
+	GeminiAPIModeAIStudio = "ai_studio"
+	GeminiAPIModeVertex   = "vertex"
+)
+
+// GeminiAPIMode returns the upstream API family used by a Gemini API-key
+// account. Legacy accounts do not have api_mode and remain on AI Studio.
+func (a *Account) GeminiAPIMode() string {
+	if a == nil || a.Platform != PlatformGemini || a.Type != AccountTypeAPIKey {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(a.GetCredential("api_mode"))) {
+	case GeminiAPIModeVertex:
+		return GeminiAPIModeVertex
+	default:
+		return GeminiAPIModeAIStudio
+	}
+}
+
+func (a *Account) IsGeminiVertexAPIKey() bool {
+	return a != nil && a.GeminiAPIMode() == GeminiAPIModeVertex
+}
+
 func (a *Account) IsGrok() bool {
 	return a.Platform == PlatformGrok
 }

--- a/backend/internal/service/account_base_url_test.go
+++ b/backend/internal/service/account_base_url_test.go
@@ -162,6 +162,65 @@ func TestGetGeminiBaseURL(t *testing.T) {
 	}
 }
 
+func TestGeminiAPIMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		account  *Account
+		expected string
+		vertex   bool
+	}{
+		{
+			name: "legacy gemini api key defaults to ai studio",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{},
+			},
+			expected: GeminiAPIModeAIStudio,
+		},
+		{
+			name: "vertex mode is case insensitive and trimmed",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": " Vertex "},
+			},
+			expected: GeminiAPIModeVertex,
+			vertex:   true,
+		},
+		{
+			name: "unknown mode remains backward compatible",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "unknown"},
+			},
+			expected: GeminiAPIModeAIStudio,
+		},
+		{
+			name: "service account is not an api key mode",
+			account: &Account{
+				Type:        AccountTypeServiceAccount,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			expected: "",
+		},
+		{
+			name:     "nil account is safe",
+			account:  nil,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.account.GeminiAPIMode())
+			require.Equal(t, tt.vertex, tt.account.IsGeminiVertexAPIKey())
+		})
+	}
+}
+
 func TestGetGrokBaseURLUsesSubscriptionProxyForOAuth(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -1199,18 +1199,10 @@ func (s *AccountTestService) buildGeminiAPIKeyRequest(ctx context.Context, accou
 		return nil, fmt.Errorf("no API key available")
 	}
 
-	baseURL := account.GetCredential("base_url")
-	if baseURL == "" {
-		baseURL = geminicli.AIStudioBaseURL
-	}
-	normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+	fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, modelID, "streamGenerateContent", true)
 	if err != nil {
 		return nil, err
 	}
-
-	// Use streamGenerateContent for real-time feedback
-	fullURL := fmt.Sprintf("%s/v1beta/models/%s:streamGenerateContent?alt=sse",
-		strings.TrimRight(normalizedBaseURL, "/"), modelID)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", fullURL, bytes.NewReader(payload))
 	if err != nil {

--- a/backend/internal/service/gemini_api_key_upstream.go
+++ b/backend/internal/service/gemini_api_key_upstream.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Wei-Shaw/sub2api/internal/pkg/gemini"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/geminicli"
+)
+
+func geminiAPIKeyDefaultBaseURL(account *Account) string {
+	if account != nil && account.IsGeminiVertexAPIKey() {
+		return geminicli.VertexExpressBaseURL
+	}
+	return geminicli.AIStudioBaseURL
+}
+
+func buildGeminiAPIKeyUpstreamURL(
+	account *Account,
+	validateBaseURL func(string) (string, error),
+	model string,
+	action string,
+	stream bool,
+) (string, error) {
+	if account == nil {
+		return "", errors.New("account is nil")
+	}
+	if validateBaseURL == nil {
+		return "", errors.New("base URL validator is nil")
+	}
+
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "", errors.New("missing model")
+	}
+	switch action {
+	case "generateContent", "streamGenerateContent", "countTokens":
+	default:
+		return "", fmt.Errorf("unsupported gemini action: %s", action)
+	}
+
+	baseURL := account.GetGeminiBaseURL(geminiAPIKeyDefaultBaseURL(account))
+	normalizedBaseURL, err := validateBaseURL(baseURL)
+	if err != nil {
+		return "", err
+	}
+
+	trimmedBaseURL := strings.TrimRight(normalizedBaseURL, "/")
+	var fullURL string
+	if account.IsGeminiVertexAPIKey() {
+		model = normalizeGeminiAPIKeyModelID(model)
+		if model == "" {
+			return "", errors.New("missing model")
+		}
+		escapedModel := strings.ReplaceAll(url.PathEscape(model), "%40", "@")
+		fullURL = fmt.Sprintf("%s/v1/publishers/google/models/%s:%s", trimmedBaseURL, escapedModel, action)
+	} else {
+		// Preserve legacy AI Studio model paths exactly as configured.
+		fullURL = fmt.Sprintf("%s/v1beta/models/%s:%s", trimmedBaseURL, model, action)
+	}
+	if stream {
+		fullURL += "?alt=sse"
+	}
+	return fullURL, nil
+}
+
+func normalizeGeminiAPIKeyModelID(model string) string {
+	model = strings.Trim(strings.TrimSpace(model), "/")
+	model = strings.TrimPrefix(model, "publishers/google/models/")
+	model = strings.TrimPrefix(model, "models/")
+	return strings.TrimSpace(model)
+}
+
+func buildGeminiVertexModelsFallback(path string) (*UpstreamHTTPResult, bool, error) {
+	path = strings.TrimSpace(path)
+	headers := http.Header{"Content-Type": []string{"application/json; charset=utf-8"}}
+
+	switch {
+	case path == "/v1beta/models":
+		body, err := json.Marshal(gemini.FallbackModelsList())
+		if err != nil {
+			return nil, true, err
+		}
+		return &UpstreamHTTPResult{StatusCode: http.StatusOK, Headers: headers, Body: body}, true, nil
+	case strings.HasPrefix(path, "/v1beta/models/"):
+		model := strings.TrimSpace(strings.TrimPrefix(path, "/v1beta/models/"))
+		if model == "" {
+			return nil, true, errors.New("invalid path")
+		}
+		body, err := json.Marshal(gemini.FallbackModel(model))
+		if err != nil {
+			return nil, true, err
+		}
+		return &UpstreamHTTPResult{StatusCode: http.StatusOK, Headers: headers, Body: body}, true, nil
+	default:
+		return nil, false, nil
+	}
+}

--- a/backend/internal/service/gemini_api_key_upstream_test.go
+++ b/backend/internal/service/gemini_api_key_upstream_test.go
@@ -1,0 +1,139 @@
+//go:build unit
+
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildGeminiAPIKeyUpstreamURL(t *testing.T) {
+	validate := func(raw string) (string, error) { return raw, nil }
+
+	tests := []struct {
+		name     string
+		account  *Account
+		model    string
+		action   string
+		stream   bool
+		expected string
+	}{
+		{
+			name: "legacy api key keeps ai studio endpoint",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{},
+			},
+			model:    "gemini-2.5-flash",
+			action:   "generateContent",
+			expected: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent",
+		},
+		{
+			name: "legacy ai studio custom model path remains unchanged",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{},
+			},
+			model:    "custom/models/gemini-relay",
+			action:   "generateContent",
+			expected: "https://generativelanguage.googleapis.com/v1beta/models/custom/models/gemini-relay:generateContent",
+		},
+		{
+			name: "vertex api key uses stable express endpoint",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			model:    "gemini-2.5-flash",
+			action:   "generateContent",
+			expected: "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash:generateContent",
+		},
+		{
+			name: "vertex streaming uses sse query",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			model:    "models/gemini-2.5-pro",
+			action:   "streamGenerateContent",
+			stream:   true,
+			expected: "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-pro:streamGenerateContent?alt=sse",
+		},
+		{
+			name: "vertex accepts full publisher model resource",
+			account: &Account{
+				Type:        AccountTypeAPIKey,
+				Platform:    PlatformGemini,
+				Credentials: map[string]any{"api_mode": "vertex"},
+			},
+			model:    "publishers/google/models/gemini-2.5-flash",
+			action:   "countTokens",
+			expected: "https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash:countTokens",
+		},
+		{
+			name: "custom vertex relay base url is preserved",
+			account: &Account{
+				Type:     AccountTypeAPIKey,
+				Platform: PlatformGemini,
+				Credentials: map[string]any{
+					"api_mode": "vertex",
+					"base_url": "https://relay.example.com/root/",
+				},
+			},
+			model:    "gemini-2.5-flash",
+			action:   "generateContent",
+			expected: "https://relay.example.com/root/v1/publishers/google/models/gemini-2.5-flash:generateContent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildGeminiAPIKeyUpstreamURL(tt.account, validate, tt.model, tt.action, tt.stream)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBuildGeminiAPIKeyUpstreamURLRejectsInvalidInput(t *testing.T) {
+	validate := func(raw string) (string, error) { return raw, nil }
+	account := &Account{
+		Type:        AccountTypeAPIKey,
+		Platform:    PlatformGemini,
+		Credentials: map[string]any{"api_mode": "vertex"},
+	}
+
+	_, err := buildGeminiAPIKeyUpstreamURL(nil, validate, "gemini-2.5-flash", "generateContent", false)
+	require.ErrorContains(t, err, "account is nil")
+
+	_, err = buildGeminiAPIKeyUpstreamURL(account, validate, "", "generateContent", false)
+	require.ErrorContains(t, err, "missing model")
+
+	_, err = buildGeminiAPIKeyUpstreamURL(account, validate, "gemini-2.5-flash", "deleteModel", false)
+	require.ErrorContains(t, err, "unsupported gemini action")
+}
+
+func TestBuildGeminiVertexModelsFallback(t *testing.T) {
+	result, handled, err := buildGeminiVertexModelsFallback("/v1beta/models")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, result.StatusCode)
+	require.Contains(t, string(result.Body), `"models"`)
+
+	result, handled, err = buildGeminiVertexModelsFallback("/v1beta/models/gemini-2.5-flash")
+	require.NoError(t, err)
+	require.True(t, handled)
+	require.Equal(t, http.StatusOK, result.StatusCode)
+	require.Contains(t, string(result.Body), `"models/gemini-2.5-flash"`)
+
+	result, handled, err = buildGeminiVertexModelsFallback("/v1beta/files")
+	require.NoError(t, err)
+	require.False(t, handled)
+	require.Nil(t, result)
+}

--- a/backend/internal/service/gemini_chat_completions_compat_service.go
+++ b/backend/internal/service/gemini_chat_completions_compat_service.go
@@ -312,19 +312,13 @@ func (s *GeminiMessagesCompatService) buildGeminiChatCompletionsUpstreamRequestF
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
-			if err != nil {
-				return nil, "", err
-			}
-
 			action := "generateContent"
 			if clientStream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
-			if clientStream {
-				fullURL += "?alt=sse"
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, action, clientStream)
+			if err != nil {
+				return nil, "", err
 			}
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -499,7 +499,8 @@ func (s *GeminiMessagesCompatService) HasAntigravityAccounts(ctx context.Context
 // 1) API key accounts (AI Studio)
 // 2) OAuth accounts without project_id (AI Studio OAuth)
 // 3) OAuth accounts explicitly marked as ai_studio
-// 4) Any remaining Gemini accounts (fallback)
+// 4) API key accounts (Vertex Express; model metadata is served locally)
+// 5) Any remaining Gemini accounts (fallback)
 func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx context.Context, groupID *int64) (*Account, error) {
 	accounts, err := s.listSchedulableAccountsOnce(ctx, groupID, PlatformGemini, true)
 	if err != nil {
@@ -516,6 +517,9 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 		switch a.Type {
 		case AccountTypeAPIKey:
 			if strings.TrimSpace(a.GetCredential("api_key")) != "" {
+				if a.IsGeminiVertexAPIKey() {
+					return 3
+				}
 				return 0
 			}
 			return 9
@@ -527,7 +531,7 @@ func (s *GeminiMessagesCompatService) SelectAccountForAIStudioEndpoints(ctx cont
 				return 2
 			}
 			// Code Assist OAuth tokens often lack AI Studio scopes for models listing.
-			return 3
+			return 4
 		case AccountTypeServiceAccount:
 			// Vertex service accounts use aiplatform.googleapis.com, not the AI Studio
 			// endpoint (generativelanguage.googleapis.com), so they cannot serve these requests.
@@ -628,19 +632,13 @@ func (s *GeminiMessagesCompatService) Forward(ctx context.Context, c *gin.Contex
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
-			if err != nil {
-				return nil, "", err
-			}
-
 			action := "generateContent"
 			if req.Stream {
 				action = "streamGenerateContent"
 			}
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, action)
-			if req.Stream {
-				fullURL += "?alt=sse"
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, action, req.Stream)
+			if err != nil {
+				return nil, "", err
 			}
 
 			restGeminiReq := normalizeGeminiRequestForAIStudio(geminiReq)
@@ -1175,15 +1173,9 @@ func (s *GeminiMessagesCompatService) ForwardNative(ctx context.Context, c *gin.
 				return nil, "", errors.New("gemini api_key not configured")
 			}
 
-			baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)
-			normalizedBaseURL, err := s.validateUpstreamBaseURL(baseURL)
+			fullURL, err := buildGeminiAPIKeyUpstreamURL(account, s.validateUpstreamBaseURL, mappedModel, upstreamAction, useUpstreamStream)
 			if err != nil {
 				return nil, "", err
-			}
-
-			fullURL := fmt.Sprintf("%s/v1beta/models/%s:%s", strings.TrimRight(normalizedBaseURL, "/"), mappedModel, upstreamAction)
-			if useUpstreamStream {
-				fullURL += "?alt=sse"
 			}
 
 			upstreamReq, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(body))
@@ -2704,6 +2696,11 @@ func (s *GeminiMessagesCompatService) ForwardAIStudioGET(ctx context.Context, ac
 	path = strings.TrimSpace(path)
 	if path == "" || !strings.HasPrefix(path, "/") {
 		return nil, errors.New("invalid path")
+	}
+	if account.IsGeminiVertexAPIKey() {
+		if result, handled, err := buildGeminiVertexModelsFallback(path); handled || err != nil {
+			return result, err
+		}
 	}
 
 	baseURL := account.GetGeminiBaseURL(geminicli.AIStudioBaseURL)

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -170,6 +170,51 @@ func TestGeminiForwardAsChatCompletions_StreamsOpenAIChunksFromGeminiSSE(t *test
 	require.Contains(t, out, "data: [DONE]")
 }
 
+func TestGeminiForwardAsChatCompletions_VertexAPIKeyUsesExpressEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	httpStub := &geminiCompatHTTPUpstreamStub{
+		response: &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(
+				`{"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":2,"candidatesTokenCount":1}}`,
+			)),
+		},
+	}
+	svc := &GeminiMessagesCompatService{
+		httpUpstream: httpStub,
+		cfg:          &config.Config{},
+	}
+	account := &Account{
+		ID:       360,
+		Platform: PlatformGemini,
+		Type:     AccountTypeAPIKey,
+		Credentials: map[string]any{
+			"api_key":  "vertex-api-key",
+			"api_mode": "vertex",
+		},
+		Concurrency: 1,
+	}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	body := []byte(`{"model":"gemini-2.5-flash","messages":[{"role":"user","content":"hi"}]}`)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+
+	result, err := svc.ForwardAsChatCompletions(context.Background(), c, account, body)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, httpStub.lastReq)
+	require.Equal(t, "vertex-api-key", httpStub.lastReq.Header.Get("x-goog-api-key"))
+	require.Empty(t, httpStub.lastReq.Header.Get("Authorization"))
+	require.Equal(
+		t,
+		"https://aiplatform.googleapis.com/v1/publishers/google/models/gemini-2.5-flash:generateContent",
+		httpStub.lastReq.URL.String(),
+	)
+}
+
 func TestGeminiForwardAsChatCompletions_FunctionNamedWebSearchStaysClientSide(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 

--- a/backend/internal/service/gemini_quota.go
+++ b/backend/internal/service/gemini_quota.go
@@ -373,6 +373,12 @@ func geminiQuotaTierKeyForAccount(account *Account) string {
 	if account == nil || account.Platform != PlatformGemini {
 		return ""
 	}
+	if account.Type == AccountTypeAPIKey && account.IsGeminiVertexAPIKey() {
+		if tierID := normalizeGeminiTierID(account.GeminiTierID()); tierID != "" {
+			return tierID
+		}
+		return GeminiTierGCPStandard
+	}
 
 	// Note: GeminiOAuthType() already defaults legacy (project_id present) to code_assist.
 	oauthType := strings.ToLower(strings.TrimSpace(account.GeminiOAuthType()))

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -1100,17 +1100,26 @@
 
       <!-- API Key input (only for apikey type, excluding Antigravity which has its own fields) -->
       <div v-if="form.type === 'apikey' && form.platform !== 'antigravity'" class="space-y-4">
+        <div v-if="form.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.apiModeLabel') }}</label>
+          <select v-model="geminiApiMode" class="input" data-testid="gemini-api-mode">
+            <option value="ai_studio">{{ t('admin.accounts.gemini.apiMode.aiStudio') }}</option>
+            <option value="vertex">{{ t('admin.accounts.gemini.apiMode.vertex') }}</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.gemini.apiModeHint') }}</p>
+        </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
           <input
             v-model="apiKeyBaseUrl"
             type="text"
             class="input"
+            data-testid="api-key-base-url"
             :placeholder="
               form.platform === 'openai'
                 ? 'https://api.openai.com'
                 : form.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
+                  ? geminiAPIKeyBaseURL(geminiApiMode)
                   : form.platform === 'grok'
                     ? 'https://api.x.ai/v1'
                     : 'https://api.anthropic.com'
@@ -1163,11 +1172,21 @@
         <!-- Gemini API Key tier selection -->
         <div v-if="form.platform === 'gemini'">
           <label class="input-label">{{ t('admin.accounts.gemini.tier.label') }}</label>
-          <select v-model="geminiTierAIStudio" class="input">
+          <select v-if="geminiApiMode === 'vertex'" v-model="geminiTierGcp" class="input">
+            <option value="gcp_standard">{{ t('admin.accounts.gemini.tier.vertex.standard') }}</option>
+            <option value="gcp_enterprise">{{ t('admin.accounts.gemini.tier.vertex.enterprise') }}</option>
+          </select>
+          <select v-else v-model="geminiTierAIStudio" class="input">
             <option value="aistudio_free">{{ t('admin.accounts.gemini.tier.aiStudio.free') }}</option>
             <option value="aistudio_paid">{{ t('admin.accounts.gemini.tier.aiStudio.paid') }}</option>
           </select>
-          <p class="input-hint">{{ t('admin.accounts.gemini.tier.aiStudioHint') }}</p>
+          <p class="input-hint">
+            {{
+              geminiApiMode === 'vertex'
+                ? t('admin.accounts.gemini.tier.vertexHint')
+                : t('admin.accounts.gemini.tier.aiStudioHint')
+            }}
+          </p>
         </div>
 
         <!-- Model Restriction Section (Antigravity 已在上层条件排除) -->
@@ -3555,6 +3574,10 @@ import {
 } from '@/components/account/credentialsBuilder'
 import { formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
+import {
+  geminiAPIKeyBaseURL,
+  type GeminiAPIMode
+} from '@/utils/geminiApiMode'
 import { VERTEX_LOCATION_OPTIONS } from '@/constants/account'
 import {
   OPENAI_WS_MODE_CTX_POOL,
@@ -3597,7 +3620,11 @@ const oauthStepTitle = computed(() => {
 // Platform-specific hints for API Key type
 const baseUrlHint = computed(() => {
   if (form.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (form.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (form.platform === 'gemini') {
+    return geminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.baseUrlHintVertex')
+      : t('admin.accounts.gemini.baseUrlHint')
+  }
   if (form.platform === 'grok') return ''
   return t('admin.accounts.baseUrlHint')
 })
@@ -3686,6 +3713,7 @@ const accountCategory = ref<'oauth-based' | 'apikey' | 'bedrock' | 'service_acco
 const addMethod = ref<AddMethod>('oauth') // For oauth-based: 'oauth' or 'setup-token'
 const apiKeyBaseUrl = ref('https://api.anthropic.com')
 const apiKeyValue = ref('')
+const geminiApiMode = ref<GeminiAPIMode>('ai_studio')
 const upstreamBillingAutoProbeEnabled = ref(true)
 
 const syncPreviewCredentials = computed(() => {
@@ -3694,7 +3722,8 @@ const syncPreviewCredentials = computed(() => {
     platform: form.platform,
     type: form.type,
     base_url: apiKeyBaseUrl.value || undefined,
-    api_key: apiKeyValue.value
+    api_key: apiKeyValue.value,
+    api_mode: form.platform === 'gemini' ? geminiApiMode.value : undefined
   }
 })
 
@@ -3960,7 +3989,9 @@ const geminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free
 
 const geminiSelectedTier = computed(() => {
   if (form.platform !== 'gemini') return ''
-  if (accountCategory.value === 'apikey') return geminiTierAIStudio.value
+  if (accountCategory.value === 'apikey') {
+    return geminiApiMode.value === 'vertex' ? geminiTierGcp.value : geminiTierAIStudio.value
+  }
   switch (geminiOAuthType.value) {
     case 'google_one':
       return geminiTierGoogleOne.value
@@ -4172,6 +4203,7 @@ watch(
 watch(
   () => form.platform,
   (newPlatform) => {
+    geminiApiMode.value = 'ai_studio'
     // Reset base URL based on platform
     apiKeyBaseUrl.value =
       (newPlatform === 'openai')
@@ -4257,6 +4289,13 @@ watch(
     grokOAuth.resetState()
   }
 )
+
+watch(geminiApiMode, (newMode, oldMode) => {
+  const current = apiKeyBaseUrl.value.trim()
+  if (form.platform === 'gemini' && (!current || current === geminiAPIKeyBaseURL(oldMode))) {
+    apiKeyBaseUrl.value = geminiAPIKeyBaseURL(newMode)
+  }
+})
 
 // Gemini AI Studio OAuth availability (requires operator-configured OAuth client)
 watch(
@@ -4702,6 +4741,7 @@ const resetForm = () => {
   geminiTierGoogleOne.value = 'google_one_free'
   geminiTierGcp.value = 'gcp_standard'
   geminiTierAIStudio.value = 'aistudio_free'
+  geminiApiMode.value = 'ai_studio'
   oauth.resetState()
   openaiOAuth.resetState()
   geminiOAuth.resetState()
@@ -5054,7 +5094,7 @@ const handleSubmit = async () => {
     form.platform === 'openai'
       ? 'https://api.openai.com'
       : form.platform === 'gemini'
-        ? 'https://generativelanguage.googleapis.com'
+        ? geminiAPIKeyBaseURL(geminiApiMode.value)
         : form.platform === 'grok'
           ? 'https://api.x.ai/v1'
           : 'https://api.anthropic.com'
@@ -5065,7 +5105,8 @@ const handleSubmit = async () => {
     api_key: apiKeyValue.value.trim()
   }
   if (form.platform === 'gemini') {
-    credentials.tier_id = geminiTierAIStudio.value
+    credentials.api_mode = geminiApiMode.value
+    credentials.tier_id = geminiSelectedTier.value
   }
 
   // Add model mapping if configured（OpenAI 开启自动透传时不应用）

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -28,17 +28,26 @@
 
       <!-- API Key fields (only for apikey type) -->
       <div v-if="account.type === 'apikey'" class="space-y-4">
+        <div v-if="account.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.apiModeLabel') }}</label>
+          <select v-model="editGeminiApiMode" class="input" data-testid="edit-gemini-api-mode">
+            <option value="ai_studio">{{ t('admin.accounts.gemini.apiMode.aiStudio') }}</option>
+            <option value="vertex">{{ t('admin.accounts.gemini.apiMode.vertex') }}</option>
+          </select>
+          <p class="input-hint">{{ t('admin.accounts.gemini.apiModeHint') }}</p>
+        </div>
         <div>
           <label class="input-label">{{ t('admin.accounts.baseUrl') }}</label>
           <input
             v-model="editBaseUrl"
             type="text"
             class="input"
+            data-testid="edit-api-key-base-url"
             :placeholder="
               account.platform === 'openai'
                 ? 'https://api.openai.com'
                 : account.platform === 'gemini'
-                  ? 'https://generativelanguage.googleapis.com'
+                  ? geminiAPIKeyBaseURL(editGeminiApiMode)
                   : account.platform === 'antigravity'
                     ? 'https://cloudcode-pa.googleapis.com'
                     : account.platform === 'grok'
@@ -76,6 +85,24 @@
             "
           />
           <p class="input-hint">{{ t('admin.accounts.leaveEmptyToKeep') }}</p>
+        </div>
+        <div v-if="account.platform === 'gemini'">
+          <label class="input-label">{{ t('admin.accounts.gemini.tier.label') }}</label>
+          <select v-if="editGeminiApiMode === 'vertex'" v-model="editGeminiTierVertex" class="input">
+            <option value="gcp_standard">{{ t('admin.accounts.gemini.tier.vertex.standard') }}</option>
+            <option value="gcp_enterprise">{{ t('admin.accounts.gemini.tier.vertex.enterprise') }}</option>
+          </select>
+          <select v-else v-model="editGeminiTierAIStudio" class="input">
+            <option value="aistudio_free">{{ t('admin.accounts.gemini.tier.aiStudio.free') }}</option>
+            <option value="aistudio_paid">{{ t('admin.accounts.gemini.tier.aiStudio.paid') }}</option>
+          </select>
+          <p class="input-hint">
+            {{
+              editGeminiApiMode === 'vertex'
+                ? t('admin.accounts.gemini.tier.vertexHint')
+                : t('admin.accounts.gemini.tier.aiStudioHint')
+            }}
+          </p>
         </div>
 
         <!-- Model Restriction Section (不适用于 Antigravity) -->
@@ -2637,6 +2664,11 @@ import {
 } from '@/components/account/credentialsBuilder'
 import { formatDateTime, formatDateTimeLocalInput, parseDateTimeLocalInput } from '@/utils/format'
 import { createStableObjectKeyResolver } from '@/utils/stableObjectKey'
+import {
+  geminiAPIKeyBaseURL,
+  normalizeGeminiAPIMode,
+  type GeminiAPIMode
+} from '@/utils/geminiApiMode'
 import { VERTEX_LOCATION_OPTIONS } from '@/constants/account'
 import {
   OPENAI_WS_MODE_CTX_POOL,
@@ -2685,7 +2717,11 @@ const handleOllamaCloudUsageUpdated = (state: OllamaCloudUsageState) => {
 const baseUrlHint = computed(() => {
   if (!props.account) return t('admin.accounts.baseUrlHint')
   if (props.account.platform === 'openai') return t('admin.accounts.openai.baseUrlHint')
-  if (props.account.platform === 'gemini') return t('admin.accounts.gemini.baseUrlHint')
+  if (props.account.platform === 'gemini') {
+    return editGeminiApiMode.value === 'vertex'
+      ? t('admin.accounts.gemini.baseUrlHintVertex')
+      : t('admin.accounts.gemini.baseUrlHint')
+  }
   if (props.account.platform === 'grok') return ''
   return t('admin.accounts.baseUrlHint')
 })
@@ -2710,6 +2746,20 @@ interface TempUnschedRuleForm {
 const submitting = ref(false)
 const editBaseUrl = ref('https://api.anthropic.com')
 const editApiKey = ref('')
+const editGeminiApiMode = ref<GeminiAPIMode>('ai_studio')
+const editGeminiTierAIStudio = ref<'aistudio_free' | 'aistudio_paid'>('aistudio_free')
+const editGeminiTierVertex = ref<'gcp_standard' | 'gcp_enterprise'>('gcp_standard')
+
+watch(editGeminiApiMode, (newMode, oldMode) => {
+  const current = editBaseUrl.value.trim()
+  if (
+    props.account?.platform === 'gemini' &&
+    (!current || current === geminiAPIKeyBaseURL(oldMode))
+  ) {
+    editBaseUrl.value = geminiAPIKeyBaseURL(newMode)
+  }
+})
+
 // Bedrock credentials
 const editBedrockAccessKeyId = ref('')
 const editBedrockSecretAccessKey = ref('')
@@ -3133,7 +3183,7 @@ const tempUnschedPresets = computed(() => [
 // Computed: default base URL based on platform
 const defaultBaseUrl = computed(() => {
   if (props.account?.platform === 'openai') return 'https://api.openai.com'
-  if (props.account?.platform === 'gemini') return 'https://generativelanguage.googleapis.com'
+  if (props.account?.platform === 'gemini') return geminiAPIKeyBaseURL(editGeminiApiMode.value)
   if (props.account?.platform === 'grok') return 'https://api.x.ai/v1'
   return 'https://api.anthropic.com'
 })
@@ -3457,11 +3507,22 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   // Initialize API Key fields for apikey type
   if (newAccount.type === 'apikey' && newAccount.credentials) {
     const credentials = newAccount.credentials as Record<string, unknown>
+    if (newAccount.platform === 'gemini') {
+      editGeminiApiMode.value = normalizeGeminiAPIMode(credentials.api_mode)
+      editGeminiTierAIStudio.value =
+        credentials.tier_id === 'aistudio_paid' ? 'aistudio_paid' : 'aistudio_free'
+      editGeminiTierVertex.value =
+        credentials.tier_id === 'gcp_enterprise' ? 'gcp_enterprise' : 'gcp_standard'
+    } else {
+      editGeminiApiMode.value = 'ai_studio'
+      editGeminiTierAIStudio.value = 'aistudio_free'
+      editGeminiTierVertex.value = 'gcp_standard'
+    }
     const platformDefaultUrl =
       newAccount.platform === 'openai'
         ? 'https://api.openai.com'
         : newAccount.platform === 'gemini'
-          ? 'https://generativelanguage.googleapis.com'
+          ? geminiAPIKeyBaseURL(editGeminiApiMode.value)
           : newAccount.platform === 'grok'
             ? 'https://api.x.ai/v1'
             : 'https://api.anthropic.com'
@@ -4061,6 +4122,13 @@ const handleSubmit = async () => {
       const newCredentials: Record<string, unknown> = {
         ...currentCredentials,
         base_url: newBaseUrl
+      }
+      if (props.account.platform === 'gemini') {
+        newCredentials.api_mode = editGeminiApiMode.value
+        newCredentials.tier_id =
+          editGeminiApiMode.value === 'vertex'
+            ? editGeminiTierVertex.value
+            : editGeminiTierAIStudio.value
       }
 
       // Handle API key

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -242,6 +242,33 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     expect(createAccountMock.mock.calls[0]?.[0]?.upstream_billing_probe_enabled).toBeUndefined()
   })
 
+  it('creates a Gemini Vertex API key account with the Express endpoint and GCP tier', async () => {
+    const wrapper = mountModal()
+    await selectButtonByText(wrapper, 'Gemini')
+    await selectButtonByText(wrapper, 'admin.accounts.gemini.accountType.apiKeyTitle')
+    await wrapper.get('form#create-account-form input[type="text"]').setValue('Vertex API Key')
+    await wrapper.get('form#create-account-form input[type="password"]').setValue('vertex-api-key')
+    await wrapper.get('[data-testid="gemini-api-mode"]').setValue('vertex')
+
+    expect((wrapper.get('[data-testid="api-key-base-url"]').element as HTMLInputElement).value)
+      .toBe('https://aiplatform.googleapis.com')
+
+    await wrapper.get('form#create-account-form').trigger('submit.prevent')
+    await flushPromises()
+
+    expect(createAccountMock).toHaveBeenCalledTimes(1)
+    expect(createAccountMock.mock.calls[0]?.[0]).toMatchObject({
+      platform: 'gemini',
+      type: 'apikey',
+      credentials: {
+        api_key: 'vertex-api-key',
+        api_mode: 'vertex',
+        base_url: 'https://aiplatform.googleapis.com',
+        tier_id: 'gcp_standard'
+      }
+    })
+  })
+
   it('leaves Codex session import billing ownership to the backend', async () => {
     const wrapper = await openCodexImportStep()
     await wrapper.get('[data-testid="import-codex-session"]').trigger('click')

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -216,6 +216,21 @@ function buildVertexAccount() {
   } as any
 }
 
+function buildVertexAPIKeyAccount() {
+  return {
+    ...buildAccount(),
+    id: 7,
+    name: 'Vertex API Key',
+    platform: 'gemini',
+    credentials: {
+      api_key: 'vertex-api-key',
+      api_mode: 'vertex',
+      base_url: 'https://aiplatform.googleapis.com',
+      tier_id: 'gcp_enterprise'
+    }
+  } as any
+}
+
 function buildAntigravityAccount(projectId = 'configured-project') {
   return {
     id: 3,
@@ -314,6 +329,28 @@ function mountModal(account = buildAccount()) {
 describe('EditAccountModal', () => {
   beforeEach(() => {
     authIsSimpleMode.value = true
+  })
+
+  it('rehydrates and updates the Gemini API key routing mode', async () => {
+    const account = buildVertexAPIKeyAccount()
+    updateAccountMock.mockReset().mockResolvedValue(account)
+    checkMixedChannelRiskMock.mockReset().mockResolvedValue({ has_risk: false })
+
+    const wrapper = mountModal(account)
+    expect((wrapper.get('[data-testid="edit-gemini-api-mode"]').element as HTMLSelectElement).value)
+      .toBe('vertex')
+    expect((wrapper.get('[data-testid="edit-api-key-base-url"]').element as HTMLInputElement).value)
+      .toBe('https://aiplatform.googleapis.com')
+
+    await wrapper.get('[data-testid="edit-gemini-api-mode"]').setValue('ai_studio')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.credentials).toMatchObject({
+      api_mode: 'ai_studio',
+      base_url: 'https://generativelanguage.googleapis.com',
+      tier_id: 'aistudio_free'
+    })
   })
 
   it('reopening the same account rehydrates the OpenAI whitelist from props', async () => {

--- a/frontend/src/i18n/__tests__/geminiVertexAPIKeyLocales.spec.ts
+++ b/frontend/src/i18n/__tests__/geminiVertexAPIKeyLocales.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import en from '../locales/en'
+import zh from '../locales/zh'
+
+describe('Gemini Vertex API key locale keys', () => {
+  it('contains Chinese labels', () => {
+    expect(zh.admin.accounts.gemini.apiModeLabel).toBeTruthy()
+    expect(zh.admin.accounts.gemini.apiMode.aiStudio).toBeTruthy()
+    expect(zh.admin.accounts.gemini.apiMode.vertex).toBeTruthy()
+    expect(zh.admin.accounts.gemini.baseUrlHintVertex).toBeTruthy()
+    expect(zh.admin.accounts.gemini.tier.vertexHint).toBeTruthy()
+  })
+
+  it('contains English labels', () => {
+    expect(en.admin.accounts.gemini.apiModeLabel).toBeTruthy()
+    expect(en.admin.accounts.gemini.apiMode.aiStudio).toBeTruthy()
+    expect(en.admin.accounts.gemini.apiMode.vertex).toBeTruthy()
+    expect(en.admin.accounts.gemini.baseUrlHintVertex).toBeTruthy()
+    expect(en.admin.accounts.gemini.tier.vertexHint).toBeTruthy()
+  })
+})

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -1111,12 +1111,24 @@ export default {
         modelPassthroughDesc:
           'All model requests are forwarded directly to the Gemini API without model restrictions or mappings.',
         baseUrlHint: 'Leave default for official Gemini API',
+        baseUrlHintVertex: 'Leave default for the official Vertex AI Express Mode endpoint',
         apiKeyHint: 'Your Gemini API Key (starts with AIza)',
+        apiModeLabel: 'API Mode',
+        apiModeHint: 'AI Studio and Vertex AI Express Mode use different upstream resource paths.',
+        apiMode: {
+          aiStudio: 'Google AI Studio',
+          vertex: 'Vertex AI API Key'
+        },
         tier: {
           label: 'Account Tier',
           hint: 'Tip: The system will try to auto-detect the tier first; if auto-detection is unavailable or fails, your selected tier is used as a fallback (simulated quota).',
           aiStudioHint:
             'AI Studio quotas are per-model (Pro/Flash are limited independently). If billing is enabled, choose Pay-as-you-go.',
+          vertexHint: 'Vertex AI API keys use GCP quota tiers.',
+          vertex: {
+            standard: 'GCP Standard',
+            enterprise: 'GCP Enterprise'
+          },
           googleOne: {
             free: 'Google One Free',
             pro: 'Google One Pro',
@@ -1134,10 +1146,10 @@ export default {
         accountType: {
           oauthTitle: 'OAuth (Gemini)',
           oauthDesc: 'Authorize with your Google account and choose an OAuth type.',
-          apiKeyTitle: 'API Key (AI Studio)',
-          apiKeyDesc: 'Fastest setup. Use an AIza API key.',
+          apiKeyTitle: 'API Key (AI Studio / Vertex)',
+          apiKeyDesc: 'Use an AIza API key with either AI Studio or Vertex AI routing.',
           apiKeyNote:
-            'Best for light testing. Free tier has strict rate limits and data may be used for training.',
+            'AI Studio and Vertex AI Express Mode use different request endpoints; choose the matching mode below.',
           apiKeyLink: 'Get API Key',
           quotaLink: 'Quota guide'
         },

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -1156,12 +1156,24 @@ export default {
         modelPassthrough: 'Gemini 直接转发模型',
         modelPassthroughDesc: '所有模型请求将直接转发至 Gemini API，不进行模型限制或映射。',
         baseUrlHint: '留空使用官方 Gemini API',
+        baseUrlHintVertex: '留空使用 Vertex AI Express Mode 官方地址',
         apiKeyHint: '您的 Gemini API Key（以 AIza 开头）',
+        apiModeLabel: 'API 模式',
+        apiModeHint: 'AI Studio 与 Vertex AI Express Mode 使用不同的上游资源路径。',
+        apiMode: {
+          aiStudio: 'Google AI Studio',
+          vertex: 'Vertex AI API Key'
+        },
         tier: {
           label: '账号等级',
           hint: '提示：系统会优先尝试自动识别账号等级；若自动识别不可用或失败，则使用你选择的等级作为回退（本地模拟配额）。',
           aiStudioHint:
             'AI Studio 的配额是按模型分别限流（Pro/Flash 独立）。若已绑卡（按量付费），请选 Pay-as-you-go。',
+          vertexHint: 'Vertex AI API Key 使用 GCP 配额档位。',
+          vertex: {
+            standard: 'GCP Standard',
+            enterprise: 'GCP Enterprise'
+          },
           googleOne: {
             free: 'Google One Free',
             pro: 'Google One Pro',
@@ -1179,9 +1191,9 @@ export default {
         accountType: {
           oauthTitle: 'OAuth 授权（Gemini）',
           oauthDesc: '使用 Google 账号授权，并选择 OAuth 子类型。',
-          apiKeyTitle: 'API 密钥（AI Studio）',
-          apiKeyDesc: '最快接入方式，使用 AIza API Key。',
-          apiKeyNote: '适合轻量测试。免费层限流严格，数据可能用于训练。',
+          apiKeyTitle: 'API 密钥（AI Studio / Vertex）',
+          apiKeyDesc: '使用 AIza API Key，并选择 AI Studio 或 Vertex AI 路由。',
+          apiKeyNote: 'AI Studio 与 Vertex AI Express Mode 使用不同的请求地址，请在下方选择对应模式。',
           apiKeyLink: '获取 API Key',
           quotaLink: '配额说明'
         },

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -892,6 +892,7 @@ export interface ProxyQualityCheckResult {
 export interface GeminiCredentials {
   // API Key authentication
   api_key?: string
+  api_mode?: 'ai_studio' | 'vertex'
 
   // OAuth authentication
   access_token?: string

--- a/frontend/src/utils/__tests__/geminiApiMode.spec.ts
+++ b/frontend/src/utils/__tests__/geminiApiMode.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GEMINI_AI_STUDIO_BASE_URL,
+  GEMINI_VERTEX_EXPRESS_BASE_URL,
+  geminiAPIKeyBaseURL,
+  normalizeGeminiAPIMode
+} from '../geminiApiMode'
+
+describe('Gemini API key mode', () => {
+  it('keeps legacy and unknown values on AI Studio', () => {
+    expect(normalizeGeminiAPIMode(undefined)).toBe('ai_studio')
+    expect(normalizeGeminiAPIMode('unknown')).toBe('ai_studio')
+    expect(geminiAPIKeyBaseURL('ai_studio')).toBe(GEMINI_AI_STUDIO_BASE_URL)
+  })
+
+  it('selects the Vertex Express endpoint explicitly', () => {
+    expect(normalizeGeminiAPIMode('vertex')).toBe('vertex')
+    expect(geminiAPIKeyBaseURL('vertex')).toBe(GEMINI_VERTEX_EXPRESS_BASE_URL)
+    expect(GEMINI_VERTEX_EXPRESS_BASE_URL).toBe('https://aiplatform.googleapis.com')
+  })
+})

--- a/frontend/src/utils/geminiApiMode.ts
+++ b/frontend/src/utils/geminiApiMode.ts
@@ -1,0 +1,12 @@
+export const GEMINI_AI_STUDIO_BASE_URL = 'https://generativelanguage.googleapis.com'
+export const GEMINI_VERTEX_EXPRESS_BASE_URL = 'https://aiplatform.googleapis.com'
+
+export type GeminiAPIMode = 'ai_studio' | 'vertex'
+
+export const normalizeGeminiAPIMode = (value: unknown): GeminiAPIMode =>
+  typeof value === 'string' && value.trim().toLowerCase() === 'vertex'
+    ? 'vertex'
+    : 'ai_studio'
+
+export const geminiAPIKeyBaseURL = (mode: GeminiAPIMode): string =>
+  mode === 'vertex' ? GEMINI_VERTEX_EXPRESS_BASE_URL : GEMINI_AI_STUDIO_BASE_URL


### PR DESCRIPTION
## Summary

- add an explicit `api_mode` (`ai_studio` or `vertex`) for Gemini API-key accounts
- route Vertex API keys through the Vertex AI Express endpoint:
  `https://aiplatform.googleapis.com/v1/publishers/google/models/{model}:{action}`
- keep `x-goog-api-key` authentication and preserve all legacy AI Studio account behavior by default
- cover Chat Completions compatibility, Messages compatibility, native Gemini forwarding, account connection tests, model metadata fallback, quota tier selection, SSRF allowlisting, and create/edit UI

## Root cause

Gemini `apikey` accounts were always formatted as AI Studio requests (`/v1beta/models/...`). Changing only `base_url` to `aiplatform.googleapis.com` therefore produced an invalid Vertex path. Service-account accounts already had a separate project/location-based Vertex path, but API-key Express Mode had no account-level routing discriminator.

## Compatibility

Existing accounts without `credentials.api_mode` continue to resolve to `ai_studio`. Vertex mode is opt-in and stores:

```json
{
  "api_mode": "vertex",
  "base_url": "https://aiplatform.googleapis.com",
  "tier_id": "gcp_standard"
}
```

Service-account Vertex routing is unchanged. Custom AI Studio model paths are also preserved unchanged.

## Validation

- `go test ./...`
- `go test -tags=unit ./internal/service`
- full frontend ESLint check
- frontend TypeScript check (`vue-tsc --noEmit`)
- 150 CI-critical and feature-focused Vitest tests
- production frontend build (`vue-tsc -b && vite build`)

Related to #3203; this implementation is rebased on the current `main` structure and uses the stable Vertex Express `v1` route.
