### PR TITLE
fix(payment): keep inline success on purchase page

### DIFF
--- a/frontend/src/views/user/PaymentView.vue
+++ b/frontend/src/views/user/PaymentView.vue
@@ -485,14 +485,12 @@ function onPaymentDone() {
   }
 }
 
-async function onPaymentSuccess() {
-  const completedPayment = { ...paymentState.value }
+function onPaymentSuccess() {
   removeRecoverySnapshot()
   authStore.refreshUser()
   if (paymentState.value.orderType === 'subscription') {
     subscriptionStore.fetchActiveSubscriptions(true).catch(() => {})
   }
-  await redirectToPaymentResult(completedPayment)
 }
 
 function onPaymentSettled() {

--- a/frontend/src/views/user/__tests__/PaymentView.spec.ts
+++ b/frontend/src/views/user/__tests__/PaymentView.spec.ts
@@ -406,6 +406,55 @@ describe('PaymentView payment recovery', () => {
 
     expect(wrapper.find('[data-test="method-selector"]').text()).toBe('ldc')
   })
+
+  it('does not redirect when an inline payment reports success', async () => {
+    getCheckoutInfo.mockResolvedValue(checkoutInfoFixture())
+    window.localStorage.setItem(PAYMENT_RECOVERY_STORAGE_KEY, JSON.stringify({
+      orderId: 889,
+      amount: 66,
+      qrCode: 'weixin://wxpay/bizpayurl?pr=inline-success',
+      expiresAt: '2099-01-01T00:10:00.000Z',
+      paymentType: 'wxpay',
+      payUrl: '',
+      outTradeNo: 'sub2_inline_889',
+      clientSecret: '',
+      intentId: '',
+      currency: '',
+      countryCode: '',
+      paymentEnv: '',
+      payAmount: 66,
+      orderType: 'balance',
+      paymentMode: 'popup',
+      resumeToken: '',
+      createdAt: Date.now(),
+    }))
+
+    const wrapper = shallowMount(PaymentView, {
+      global: {
+        stubs: {
+          AppLayout: {
+            template: '<div><slot /></div>',
+          },
+          PaymentStatusPanel: {
+            emits: ['success'],
+            template: '<button data-test="payment-success" @click="$emit(\'success\')" />',
+          },
+          Teleport: true,
+          Transition: false,
+        },
+      },
+    })
+    await flushPromises()
+    await flushPromises()
+
+    await wrapper.find('[data-test="payment-success"]').trigger('click')
+    await flushPromises()
+
+    expect(routerPush).not.toHaveBeenCalled()
+    expect(refreshUser).toHaveBeenCalledTimes(1)
+    expect(window.localStorage.getItem(PAYMENT_RECOVERY_STORAGE_KEY)).toBeNull()
+    expect(wrapper.find('[data-test="payment-success"]').exists()).toBe(true)
+  })
 })
 
 describe('PaymentView WeChat JSAPI flow', () => {


### PR DESCRIPTION
Fixes #4996

## Summary

- keep successful inline QR/popup payments on `/purchase` instead of redirecting to the standalone result route
- preserve recovery-snapshot cleanup, user-balance refresh, and subscription refresh
- add a regression test for the `PaymentStatusPanel` success event

## Root cause

`PaymentStatusPanel` already switches to its inline success card after polling reaches a successful terminal state. Its parent `onPaymentSuccess` handler nevertheless copied the payment state and unconditionally called `redirectToPaymentResult`, so every inline success left the page.

The dedicated `/payment/result` flow is still used by WeChat JSAPI and provider return/recovery paths; this change only removes the redirect from the generic inline panel callback.

## Verification

- `corepack pnpm exec vitest run src/views/user/__tests__/PaymentView.spec.ts src/components/payment/__tests__/PaymentStatusPanel.spec.ts` — 18 passed
- `corepack pnpm exec eslint src/views/user/PaymentView.vue src/views/user/__tests__/PaymentView.spec.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`

## Additional test context

A full frontend-suite invocation also reached two existing failures in `admin.system.rollback.spec.ts`: current `main` passes a third timeout option while those tests still expect only two request arguments. The payment suites covered by this change passed, and this PR does not touch the rollback API.
