### PR TITLE
feat(deploy): make Redis persistence settings configurable

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Check Compose deployment configs
+        run: /bin/bash deploy/tests/compose-config-test.sh
       - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -187,6 +187,11 @@ REDIS_PASSWORD=
 REDIS_DB=0
 # Redis 服务端最大客户端连接数（可选）
 REDIS_MAXCLIENTS=50000
+# Redis RDB snapshot rule: save after this many seconds when at least this many keys changed.
+REDIS_SAVE_SECONDS=60
+REDIS_SAVE_CHANGES=1
+# Redis latency monitor threshold in milliseconds; 0 disables latency monitoring.
+REDIS_LATENCY_MONITOR_THRESHOLD_MS=0
 # Redis 连接池大小（默认 1024）
 REDIS_POOL_SIZE=4096
 # Redis 最小空闲连接数（默认 10）

--- a/deploy/APPLE_CONTAINER.md
+++ b/deploy/APPLE_CONTAINER.md
@@ -117,6 +117,8 @@ Apple-specific handling of shared settings:
 | `BIND_HOST`, `SERVER_PORT` | Used for the macOS published port |
 | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` | PostgreSQL first initialization only |
 | `REDIS_PASSWORD` | Applied to Redis and Sub2API |
+| `REDIS_SAVE_SECONDS`, `REDIS_SAVE_CHANGES` | Configure the Redis RDB snapshot rule |
+| `REDIS_LATENCY_MONITOR_THRESHOLD_MS` | Configures Redis latency monitoring; `0` disables it |
 | `DATABASE_PORT`, `REDIS_PORT` | Internal ports are fixed to 5432 and 6379 |
 | `POSTGRES_MAX_*`, `REDIS_MAXCLIENTS` | Not currently applied to the database/cache server |
 

--- a/deploy/apple-container.sh
+++ b/deploy/apple-container.sh
@@ -30,6 +30,9 @@ POSTGRES_USER=""
 POSTGRES_PASSWORD=""
 POSTGRES_DB=""
 REDIS_PASSWORD=""
+REDIS_SAVE_SECONDS=""
+REDIS_SAVE_CHANGES=""
+REDIS_LATENCY_MONITOR_THRESHOLD_MS=""
 TZ_VALUE=""
 POSTGRES_ADDRESS=""
 REDIS_ADDRESS=""
@@ -371,6 +374,20 @@ validate_port() {
         die "SERVER_PORT must be between 1025 and 65535 for Apple container port forwarding."
 }
 
+validate_positive_integer() {
+    local key=$1
+    local value=$2
+
+    [[ "${value}" =~ ^[1-9][0-9]*$ ]] || die "${key} must be a positive integer: ${value}"
+}
+
+validate_nonnegative_integer() {
+    local key=$1
+    local value=$2
+
+    [[ "${value}" =~ ^(0|[1-9][0-9]*)$ ]] || die "${key} must be a non-negative integer: ${value}"
+}
+
 validate_ipv4_address() {
     local address=$1
     local first second third fourth extra octet
@@ -409,6 +426,9 @@ prepare_environment() {
     POSTGRES_PASSWORD="$(read_env_value POSTGRES_PASSWORD)"
     POSTGRES_DB="$(read_env_value POSTGRES_DB sub2api)"
     REDIS_PASSWORD="$(read_env_value REDIS_PASSWORD)"
+    REDIS_SAVE_SECONDS="$(read_env_value REDIS_SAVE_SECONDS 60)"
+    REDIS_SAVE_CHANGES="$(read_env_value REDIS_SAVE_CHANGES 1)"
+    REDIS_LATENCY_MONITOR_THRESHOLD_MS="$(read_env_value REDIS_LATENCY_MONITOR_THRESHOLD_MS 0)"
     TZ_VALUE="$(read_env_value TZ Asia/Shanghai)"
 
     [[ -n "${BIND_HOST}" ]] || die "BIND_HOST must not be empty."
@@ -421,6 +441,9 @@ prepare_environment() {
     fi
     [[ -n "${POSTGRES_USER}" ]] || die "POSTGRES_USER must not be empty."
     [[ -n "${POSTGRES_DB}" ]] || die "POSTGRES_DB must not be empty."
+    validate_positive_integer REDIS_SAVE_SECONDS "${REDIS_SAVE_SECONDS}"
+    validate_positive_integer REDIS_SAVE_CHANGES "${REDIS_SAVE_CHANGES}"
+    validate_nonnegative_integer REDIS_LATENCY_MONITOR_THRESHOLD_MS "${REDIS_LATENCY_MONITOR_THRESHOLD_MS}"
     if [[ -z "${POSTGRES_PASSWORD}" || "${POSTGRES_PASSWORD}" == "change_this_secure_password" ]]; then
         die "Set a secure POSTGRES_PASSWORD in ${ENV_FILE}."
     fi
@@ -444,6 +467,9 @@ EOF
 
     cat >"${REDIS_ENV_FILE}" <<EOF
 REDIS_PASSWORD=${REDIS_PASSWORD}
+REDIS_SAVE_SECONDS=${REDIS_SAVE_SECONDS}
+REDIS_SAVE_CHANGES=${REDIS_SAVE_CHANGES}
+REDIS_LATENCY_MONITOR_THRESHOLD_MS=${REDIS_LATENCY_MONITOR_THRESHOLD_MS}
 TZ=${TZ_VALUE}
 EOF
     if [[ -n "${REDIS_PASSWORD}" ]]; then
@@ -501,7 +527,7 @@ create_redis_container() {
         --env-file "${REDIS_ENV_FILE}" \
         --volume "${REDIS_VOLUME}:/var/lib/redis" \
         "${REDIS_IMAGE}" \
-        sh -c 'set -e; mkdir -p /var/lib/redis/data; chown redis:redis /var/lib/redis/data; exec /usr/local/bin/docker-entrypoint.sh redis-server --dir /var/lib/redis/data --save 60 1 --appendonly yes --appendfsync everysec ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}' \
+        sh -c 'set -e; mkdir -p /var/lib/redis/data; chown redis:redis /var/lib/redis/data; exec /usr/local/bin/docker-entrypoint.sh redis-server --dir /var/lib/redis/data --save "${REDIS_SAVE_SECONDS:-60}" "${REDIS_SAVE_CHANGES:-1}" --appendonly yes --appendfsync everysec --latency-monitor-threshold "${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0}" ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}' \
         >/dev/null
 }
 

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -118,18 +118,19 @@ services:
     restart: unless-stopped
     volumes:
       - ./redis_data:/data:Z
-    # The command is one quoted script for the inner `sh -c`. Compose keeps
-    # the newlines inside the quoted string, so every line needs a trailing
-    # `\` — without it, `redis-server` on the first line runs with no flags
-    # at all, and the Redis server flags below are never read.
-    command: >
-        sh -c '
-          redis-server \
-          --save ${REDIS_SAVE_SECONDS:-60} ${REDIS_SAVE_CHANGES:-1} \
-          --appendonly yes \
-          --appendfsync everysec \
-          --latency-monitor-threshold ${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0} \
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+    command:
+      - redis-server
+      - --save
+      - "${REDIS_SAVE_SECONDS:-60}"
+      - "${REDIS_SAVE_CHANGES:-1}"
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --latency-monitor-threshold
+      - "${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0}"
+      - --requirepass
+      - "${REDIS_PASSWORD:-}"
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       - REDISCLI_AUTH=${REDIS_PASSWORD:-}

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -121,13 +121,14 @@ services:
     # The command is one quoted script for the inner `sh -c`. Compose keeps
     # the newlines inside the quoted string, so every line needs a trailing
     # `\` — without it, `redis-server` on the first line runs with no flags
-    # at all, and the --save/--appendonly/--appendfsync lines are never read.
+    # at all, and the Redis server flags below are never read.
     command: >
         sh -c '
           redis-server \
-          --save 60 1 \
+          --save ${REDIS_SAVE_SECONDS:-60} ${REDIS_SAVE_CHANGES:-1} \
           --appendonly yes \
           --appendfsync everysec \
+          --latency-monitor-threshold ${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0} \
           ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -238,13 +238,14 @@ services:
     # The command is one quoted script for the inner `sh -c`. Compose keeps
     # the newlines inside the quoted string, so every line needs a trailing
     # `\` — without it, `redis-server` on the first line runs with no flags
-    # at all, and the --save/--appendonly/--appendfsync lines are never read.
+    # at all, and the Redis server flags below are never read.
     command: >
         sh -c '
           redis-server \
-          --save 60 1 \
+          --save ${REDIS_SAVE_SECONDS:-60} ${REDIS_SAVE_CHANGES:-1} \
           --appendonly yes \
           --appendfsync everysec \
+          --latency-monitor-threshold ${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0} \
           ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -235,18 +235,19 @@ services:
     volumes:
       # Local directory mapping for easy migration
       - ./redis_data:/data:Z
-    # The command is one quoted script for the inner `sh -c`. Compose keeps
-    # the newlines inside the quoted string, so every line needs a trailing
-    # `\` — without it, `redis-server` on the first line runs with no flags
-    # at all, and the Redis server flags below are never read.
-    command: >
-        sh -c '
-          redis-server \
-          --save ${REDIS_SAVE_SECONDS:-60} ${REDIS_SAVE_CHANGES:-1} \
-          --appendonly yes \
-          --appendfsync everysec \
-          --latency-monitor-threshold ${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0} \
-          ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+    command:
+      - redis-server
+      - --save
+      - "${REDIS_SAVE_SECONDS:-60}"
+      - "${REDIS_SAVE_CHANGES:-1}"
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --latency-monitor-threshold
+      - "${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0}"
+      - --requirepass
+      - "${REDIS_PASSWORD:-}"
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -259,13 +259,14 @@ services:
     # The command is one quoted script for the inner `sh -c`. Compose keeps
     # the newlines inside the quoted string, so every line needs a trailing
     # `\` — without it, `redis-server` on the first line runs with no flags
-    # at all, and the --save/--appendonly/--appendfsync lines are never read.
+    # at all, and the Redis server flags below are never read.
     command: >
       sh -c '
         redis-server \
-        --save 60 1 \
+        --save ${REDIS_SAVE_SECONDS:-60} ${REDIS_SAVE_CHANGES:-1} \
         --appendonly yes \
         --appendfsync everysec \
+        --latency-monitor-threshold ${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0} \
         ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
     environment:
       - TZ=${TZ:-Asia/Shanghai}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -256,18 +256,19 @@ services:
         hard: 100000
     volumes:
       - redis_data:/data
-    # The command is one quoted script for the inner `sh -c`. Compose keeps
-    # the newlines inside the quoted string, so every line needs a trailing
-    # `\` — without it, `redis-server` on the first line runs with no flags
-    # at all, and the Redis server flags below are never read.
-    command: >
-      sh -c '
-        redis-server \
-        --save ${REDIS_SAVE_SECONDS:-60} ${REDIS_SAVE_CHANGES:-1} \
-        --appendonly yes \
-        --appendfsync everysec \
-        --latency-monitor-threshold ${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0} \
-        ${REDIS_PASSWORD:+--requirepass "$REDIS_PASSWORD"}'
+    command:
+      - redis-server
+      - --save
+      - "${REDIS_SAVE_SECONDS:-60}"
+      - "${REDIS_SAVE_CHANGES:-1}"
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --latency-monitor-threshold
+      - "${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0}"
+      - --requirepass
+      - "${REDIS_PASSWORD:-}"
     environment:
       - TZ=${TZ:-Asia/Shanghai}
       # REDISCLI_AUTH is used by redis-cli for authentication (safer than -a flag)

--- a/deploy/tests/apple-container-test.sh
+++ b/deploy/tests/apple-container-test.sh
@@ -36,6 +36,11 @@ mkdir -p "${STATE_DIR}"
 "${SCRIPT}" init
 [[ "$(stat -f '%Lp' "${ENV_FILE}")" == "600" ]] || fail "init did not create a mode-600 env file"
 grep -q '^POSTGRES_PASSWORD=change_this_secure_password$' "${ENV_FILE}" && fail "init retained the placeholder password"
+cat >>"${ENV_FILE}" <<'EOF'
+REDIS_SAVE_SECONDS=900
+REDIS_SAVE_CHANGES=2
+REDIS_LATENCY_MONITOR_THRESHOLD_MS=100
+EOF
 
 chmod 644 "${ENV_FILE}"
 if "${SCRIPT}" up >/dev/null 2>&1; then
@@ -48,6 +53,11 @@ assert_exists "${STATE_DIR}/containers/sub2api-apple"
 assert_exists "${STATE_DIR}/containers/sub2api-apple-postgres"
 assert_exists "${STATE_DIR}/containers/sub2api-apple-redis"
 assert_exists "${STATE_DIR}/running/sub2api-apple"
+grep -q '^REDIS_SAVE_SECONDS=900$' "${STATE_DIR}/env-files/sub2api-apple-redis" || fail "Redis save interval was not propagated"
+grep -q '^REDIS_SAVE_CHANGES=2$' "${STATE_DIR}/env-files/sub2api-apple-redis" || fail "Redis save change threshold was not propagated"
+grep -q '^REDIS_LATENCY_MONITOR_THRESHOLD_MS=100$' "${STATE_DIR}/env-files/sub2api-apple-redis" || fail "Redis latency threshold was not propagated"
+grep -Fq '${REDIS_SAVE_SECONDS:-60}' "${STATE_DIR}/create-args/sub2api-apple-redis" || fail "Redis save interval is missing from the runtime command"
+grep -Fq '${REDIS_LATENCY_MONITOR_THRESHOLD_MS:-0}' "${STATE_DIR}/create-args/sub2api-apple-redis" || fail "Redis latency threshold is missing from the runtime command"
 "${SCRIPT}" status >/dev/null
 
 "${SCRIPT}" up --recreate

--- a/deploy/tests/compose-config-test.sh
+++ b/deploy/tests/compose-config-test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+deploy_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$deploy_dir"
+
+compose_files=(
+  docker-compose.yml
+  docker-compose.local.yml
+  docker-compose.dev.yml
+)
+
+assert_redis_command() {
+  local file=$1
+  local expected=$2
+  local config
+
+  config="$(docker compose -f "$file" config --format json)"
+  if ! jq -e --argjson expected "$expected" \
+    '.services.redis.command == $expected' <<<"$config" >/dev/null; then
+    printf 'unexpected Redis command in %s: ' "$file" >&2
+    jq -c '.services.redis.command' <<<"$config" >&2
+    return 1
+  fi
+}
+
+export POSTGRES_PASSWORD=fixture-postgres
+export REDIS_PASSWORD=
+unset REDIS_SAVE_SECONDS REDIS_SAVE_CHANGES REDIS_LATENCY_MONITOR_THRESHOLD_MS
+
+default_command='["redis-server","--save","60","1","--appendonly","yes","--appendfsync","everysec","--latency-monitor-threshold","0","--requirepass",""]'
+for file in "${compose_files[@]}"; do
+  assert_redis_command "$file" "$default_command"
+done
+
+export REDIS_PASSWORD=fixture-redis
+export REDIS_SAVE_SECONDS=900
+export REDIS_SAVE_CHANGES=2
+export REDIS_LATENCY_MONITOR_THRESHOLD_MS=100
+
+custom_command='["redis-server","--save","900","2","--appendonly","yes","--appendfsync","everysec","--latency-monitor-threshold","100","--requirepass","fixture-redis"]'
+for file in "${compose_files[@]}"; do
+  assert_redis_command "$file" "$custom_command"
+done
+
+printf 'Compose Redis command fixtures passed for %s files.\n' "${#compose_files[@]}"

--- a/deploy/tests/fixtures/bin/container
+++ b/deploy/tests/fixtures/bin/container
@@ -8,6 +8,8 @@ mkdir -p \
     "${STATE_DIR}/running" \
     "${STATE_DIR}/networks" \
     "${STATE_DIR}/volumes" \
+    "${STATE_DIR}/create-args" \
+    "${STATE_DIR}/env-files" \
     "${STATE_DIR}/unowned/container" \
     "${STATE_DIR}/unowned/network" \
     "${STATE_DIR}/unowned/volume"
@@ -108,13 +110,19 @@ case "${command}" in
         ;;
     create)
         name=""
+        env_file=""
+        original_arguments=("$@")
         while [[ $# -gt 0 ]]; do
             case "$1" in
                 --name)
                     name=$2
                     shift 2
                     ;;
-                --label|--network|--platform|--ulimit|--env-file|--volume|--entrypoint|--publish)
+                --env-file)
+                    env_file=$2
+                    shift 2
+                    ;;
+                --label|--network|--platform|--ulimit|--volume|--entrypoint|--publish)
                     shift 2
                     ;;
                 *)
@@ -123,6 +131,10 @@ case "${command}" in
             esac
         done
         [[ -n "${name}" ]]
+        printf '%s\n' "${original_arguments[@]}" >"${STATE_DIR}/create-args/${name}"
+        if [[ -n "${env_file}" ]]; then
+            cp "${env_file}" "${STATE_DIR}/env-files/${name}"
+        fi
         touch "${STATE_DIR}/containers/${name}"
         ;;
     inspect)


### PR DESCRIPTION
## Summary

- make the Redis RDB snapshot interval and change threshold configurable in all Compose deployment variants
- expose the Redis latency monitor threshold while preserving the current disabled default
- pass Compose Redis arguments directly instead of through `sh -c`, allowing the official entrypoint to drop privileges to the `redis` user
- propagate and validate the same persistence settings in the Apple Container workflow
- add CI fixtures for default and custom Redis Compose argv across production, local, and development files

## Compatibility

Existing deployments keep the current defaults: `save 60 1` and latency monitoring disabled (`0`). Empty `REDIS_PASSWORD` remains supported; Redis receives an empty `--requirepass` value and keeps authentication disabled. No application, PostgreSQL, Redis data format, or persistence format changes are introduced.

## Verification

- `git diff --check`
- Compose config validation for production, local, and development files
- default argv: `--save 60 1`, latency threshold `0`, empty password
- custom argv: `--save 900 2`, latency threshold `100`, configured password
- isolated `redis:8-alpine` runtime check: Redis PID 1 runs as UID 999 and empty-password `PING` returns `PONG`
- `bash -n deploy/apple-container.sh`

The Apple Container lifecycle and Compose argv fixtures are covered by repository CI.
- refreshed `v0.1.168` rebase: shell, backend unit/integration tests, golangci-lint, frontend, backend/frontend security, and CLA all pass