### PR TITLE
fix(openai-ws): retire pooled connections before 60-minute limit

### DIFF
--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -1385,6 +1385,40 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			}
 		}
 		forcePreferredConn := isStrictAffinityTurn(currentPayload)
+		if sessionLease != nil && !sessionLease.HasTurnLifetimeBudget(time.Now()) {
+			now := time.Now()
+			remainingLifetime := sessionLease.RemainingLifetime(now)
+			retiringConnID := strings.TrimSpace(sessionLease.ConnID())
+			if forcePreferredConn {
+				logOpenAIWSModeInfo(
+					"ingress_ws_conn_lifetime_exhausted account_id=%d turn=%d conn_id=%s action=fail_close remaining_ms=%d reserve_ms=%d previous_response_id=%s store_disabled=%v",
+					account.ID,
+					turn,
+					truncateOpenAIWSLogValue(retiringConnID, openAIWSIDValueMaxLen),
+					remainingLifetime.Milliseconds(),
+					pool.turnLifetimeReserve().Milliseconds(),
+					truncateOpenAIWSLogValue(currentPreviousResponseID, openAIWSIDValueMaxLen),
+					storeDisabled,
+				)
+				resetSessionLease(true)
+				return NewOpenAIWSClientCloseError(
+					coderws.StatusTryAgainLater,
+					"upstream websocket connection is nearing its lifetime limit; please reconnect",
+					errOpenAIWSConnLifetimeExhausted,
+				)
+			}
+			logOpenAIWSModeInfo(
+				"ingress_ws_conn_lifetime_exhausted account_id=%d turn=%d conn_id=%s action=rotate remaining_ms=%d reserve_ms=%d has_previous_response_id=%v store_disabled=%v",
+				account.ID,
+				turn,
+				truncateOpenAIWSLogValue(retiringConnID, openAIWSIDValueMaxLen),
+				remainingLifetime.Milliseconds(),
+				pool.turnLifetimeReserve().Milliseconds(),
+				currentPreviousResponseID != "",
+				storeDisabled,
+			)
+			resetSessionLease(true)
+		}
 		if sessionLease == nil {
 			acquiredLease, acquireErr := acquireTurnLease(turn, preferredConnID, forcePreferredConn)
 			if acquireErr != nil {

--- a/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress_session_test.go
@@ -3953,6 +3953,232 @@ func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_RejectsMessageID
 	}
 }
 
+func ageOpenAIWSPoolConnForTest(t *testing.T, pool *openAIWSConnPool, accountID int64, age time.Duration) {
+	t.Helper()
+	ap, ok := pool.getAccountPool(accountID)
+	require.True(t, ok)
+	require.NotNil(t, ap)
+	ap.mu.Lock()
+	defer ap.mu.Unlock()
+	require.Len(t, ap.conns, 1)
+	for _, conn := range ap.conns {
+		conn.createdAtNano.Store(time.Now().Add(-age).UnixNano())
+	}
+}
+
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_RotatesStoredContinuationBeforeConnLifetimeLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 2
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 2
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 15 * 60
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	firstConn := &openAIWSPreflightFailConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_lifetime_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	secondConn := &openAIWSPreflightFailConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_lifetime_2","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	dialer := &openAIWSQueueDialer{conns: []openAIWSClientConn{firstConn, secondConn}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          460,
+		Name:        "openai-ingress-lifetime-rotate",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 2,
+		Credentials: map[string]any{"api_key": "sk-test"},
+		Extra:       map[string]any{"responses_websockets_v2_enabled": true},
+	}
+
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		ginCtx.Request = r.Clone(r.Context())
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErrCh <- errors.New("unsupported websocket client message type")
+			return
+		}
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, nil)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+	writeMessage := func(payload string) {
+		writeCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(payload)))
+	}
+	readMessage := func() []byte {
+		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		msgType, message, readErr := clientConn.Read(readCtx)
+		require.NoError(t, readErr)
+		require.Equal(t, coderws.MessageText, msgType)
+		return message
+	}
+
+	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":true,"input":"hello"}`)
+	require.Equal(t, "resp_lifetime_1", gjson.GetBytes(readMessage(), "response.id").String())
+	ageOpenAIWSPoolConnForTest(t, pool, account.ID, 59*time.Minute)
+	writeMessage(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":true,"previous_response_id":"resp_lifetime_1","input":"world"}`)
+	require.Equal(t, "resp_lifetime_2", gjson.GetBytes(readMessage(), "response.id").String())
+
+	require.NoError(t, clientConn.Close(coderws.StatusNormalClosure, "done"))
+	select {
+	case serverErr := <-serverErrCh:
+		require.NoError(t, serverErr)
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待 ingress websocket 结束超时")
+	}
+	require.Equal(t, 2, dialer.DialCount(), "near-expiry leased connection should be replaced before the next stored turn")
+	require.Equal(t, 1, firstConn.WriteCount())
+	require.Equal(t, 1, secondConn.WriteCount())
+}
+
+func TestOpenAIGatewayService_ProxyResponsesWebSocketFromClient_FailsClosedForStrictContinuationNearConnLifetimeLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	cfg := &config.Config{}
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.OAuthEnabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 1
+	cfg.Gateway.OpenAIWS.MinIdlePerAccount = 0
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 1
+	cfg.Gateway.OpenAIWS.QueueLimitPerConn = 8
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 15 * 60
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	firstConn := &openAIWSPreflightFailConn{events: [][]byte{
+		[]byte(`{"type":"response.completed","response":{"id":"resp_lifetime_strict_1","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`),
+	}}
+	dialer := &openAIWSQueueDialer{conns: []openAIWSClientConn{firstConn}}
+	pool := newOpenAIWSConnPool(cfg)
+	pool.setClientDialerForTest(dialer)
+	svc := &OpenAIGatewayService{
+		cfg:              cfg,
+		httpUpstream:     &httpUpstreamRecorder{},
+		cache:            &stubGatewayCache{},
+		openaiWSResolver: NewOpenAIWSProtocolResolver(cfg),
+		toolCorrector:    NewCodexToolCorrector(),
+		openaiWSPool:     pool,
+	}
+	account := &Account{
+		ID:          461,
+		Name:        "openai-ingress-lifetime-strict",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{"api_key": "sk-test"},
+		Extra:       map[string]any{"responses_websockets_v2_enabled": true},
+	}
+
+	serverErrCh := make(chan error, 1)
+	wsServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+		rec := httptest.NewRecorder()
+		ginCtx, _ := gin.CreateTestContext(rec)
+		ginCtx.Request = r.Clone(r.Context())
+		readCtx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		msgType, firstMessage, readErr := conn.Read(readCtx)
+		cancel()
+		if readErr != nil {
+			serverErrCh <- readErr
+			return
+		}
+		if msgType != coderws.MessageText && msgType != coderws.MessageBinary {
+			serverErrCh <- errors.New("unsupported websocket client message type")
+			return
+		}
+		serverErrCh <- svc.ProxyResponsesWebSocketFromClient(r.Context(), ginCtx, conn, account, "sk-test", firstMessage, nil)
+	}))
+	defer wsServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(dialCtx, "ws"+strings.TrimPrefix(wsServer.URL, "http"), nil)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"input":"run tool"}`)))
+	cancelWrite()
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	_, firstEvent, readErr := clientConn.Read(readCtx)
+	cancelRead()
+	require.NoError(t, readErr)
+	require.Equal(t, "resp_lifetime_strict_1", gjson.GetBytes(firstEvent, "response.id").String())
+
+	ageOpenAIWSPoolConnForTest(t, pool, account.ID, 59*time.Minute)
+	writeCtx, cancelWrite = context.WithTimeout(context.Background(), 3*time.Second)
+	require.NoError(t, clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false,"store":false,"previous_response_id":"resp_lifetime_strict_1","input":[{"type":"function_call_output","call_id":"call_lifetime","output":"ok"}]}`)))
+	cancelWrite()
+
+	select {
+	case serverErr := <-serverErrCh:
+		var closeErr *OpenAIWSClientCloseError
+		require.ErrorAs(t, serverErr, &closeErr)
+		require.Equal(t, coderws.StatusTryAgainLater, closeErr.StatusCode())
+		require.Contains(t, closeErr.Reason(), "lifetime limit")
+		require.ErrorIs(t, closeErr, errOpenAIWSConnLifetimeExhausted)
+	case <-time.After(5 * time.Second):
+		t.Fatal("等待 lifetime fail-close 超时")
+	}
+	require.Equal(t, 1, dialer.DialCount(), "strict store-disabled continuation must not migrate to another upstream connection")
+	require.Equal(t, 1, firstConn.WriteCount(), "the expiring connection must be rejected before the second turn is sent upstream")
+}
+
 type openAIWSQueueDialer struct {
 	mu        sync.Mutex
 	conns     []openAIWSClientConn

--- a/backend/internal/service/openai_ws_pool.go
+++ b/backend/internal/service/openai_ws_pool.go
@@ -18,7 +18,13 @@ import (
 )
 
 const (
-	openAIWSConnMaxAge             = 60 * time.Minute
+	openAIWSConnMaxAge = 60 * time.Minute
+	// OpenAI hard-closes Responses WebSocket connections after 60 minutes.
+	// Reserve the configured upstream read timeout plus a small scheduling
+	// buffer so a newly-started turn is not expected to cross that boundary.
+	openAIWSConnDefaultTurnTimeout = 15 * time.Minute
+	openAIWSConnExpirySafetyBuffer = 30 * time.Second
+
 	openAIWSConnHealthCheckIdle    = 90 * time.Second
 	openAIWSConnHealthCheckTO      = 2 * time.Second
 	openAIWSConnPrewarmExtraDelay  = 2 * time.Second
@@ -34,6 +40,7 @@ var (
 	errOpenAIWSConnClosed               = errors.New("openai ws connection closed")
 	errOpenAIWSConnQueueFull            = errors.New("openai ws connection queue full")
 	errOpenAIWSPreferredConnUnavailable = errors.New("openai ws preferred connection unavailable")
+	errOpenAIWSConnLifetimeExhausted    = errors.New("openai ws connection lifetime budget exhausted")
 )
 
 type openAIWSDialError struct {
@@ -122,6 +129,25 @@ func (l *openAIWSConnLease) Reused() bool {
 		return false
 	}
 	return l.reused
+}
+
+func (l *openAIWSConnLease) RemainingLifetime(now time.Time) time.Duration {
+	conn, err := l.activeConn()
+	if err != nil || l.pool == nil {
+		return 0
+	}
+	return l.pool.connRemainingLifetime(conn, now)
+}
+
+func (l *openAIWSConnLease) HasTurnLifetimeBudget(now time.Time) bool {
+	conn, err := l.activeConn()
+	if err != nil {
+		return false
+	}
+	if l.pool == nil {
+		return true
+	}
+	return l.pool.connHasTurnLifetimeBudget(conn, now)
 }
 
 func (l *openAIWSConnLease) HandshakeHeader(name string) string {
@@ -1248,7 +1274,6 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 	if ap == nil {
 		return nil
 	}
-	maxAge := p.maxConnAge()
 
 	evicted := make([]*openAIWSConn, 0)
 	for id, conn := range ap.conns {
@@ -1269,15 +1294,19 @@ func (p *openAIWSConnPool) cleanupAccountLocked(ap *openAIWSAccountPool, now tim
 			continue
 		default:
 		}
-		if p.isConnPinnedLocked(ap, id) {
-			continue
-		}
-		if maxAge > 0 && !conn.isLeased() && conn.age(now) > maxAge {
+		// Retire idle connections before the upstream 60-minute hard limit.
+		// Pinned-but-idle connections are also retired: keeping one here would
+		// only defer the inevitable continuation failure to the next turn.
+		if !conn.isLeased() && !p.connHasTurnLifetimeBudget(conn, now) {
 			delete(ap.conns, id)
 			if len(ap.pinnedConns) > 0 {
 				delete(ap.pinnedConns, id)
 			}
 			evicted = append(evicted, conn)
+			continue
+		}
+		if p.isConnPinnedLocked(ap, id) {
+			continue
 		}
 	}
 
@@ -1786,6 +1815,45 @@ func (p *openAIWSConnPool) maxIdlePerAccount() int {
 
 func (p *openAIWSConnPool) maxConnAge() time.Duration {
 	return openAIWSConnMaxAge
+}
+
+func (p *openAIWSConnPool) turnLifetimeReserve() time.Duration {
+	maxAge := p.maxConnAge()
+	if maxAge <= 0 {
+		return 0
+	}
+	turnTimeout := openAIWSConnDefaultTurnTimeout
+	if p != nil && p.cfg != nil && p.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds > 0 {
+		turnTimeout = time.Duration(p.cfg.Gateway.OpenAIWS.ReadTimeoutSeconds) * time.Second
+	}
+	reserve := turnTimeout + openAIWSConnExpirySafetyBuffer
+	if reserve > maxAge {
+		return maxAge
+	}
+	return reserve
+}
+
+func (p *openAIWSConnPool) connRemainingLifetime(conn *openAIWSConn, now time.Time) time.Duration {
+	maxAge := p.maxConnAge()
+	if conn == nil || maxAge <= 0 {
+		return 0
+	}
+	remaining := maxAge - conn.age(now)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func (p *openAIWSConnPool) connHasTurnLifetimeBudget(conn *openAIWSConn, now time.Time) bool {
+	if conn == nil {
+		return false
+	}
+	maxAge := p.maxConnAge()
+	if maxAge <= 0 || conn.createdAt().IsZero() {
+		return true
+	}
+	return p.connRemainingLifetime(conn, now) > p.turnLifetimeReserve()
 }
 
 func (p *openAIWSConnPool) queueLimitPerConn() int {

--- a/backend/internal/service/openai_ws_pool_test.go
+++ b/backend/internal/service/openai_ws_pool_test.go
@@ -44,6 +44,64 @@ func TestOpenAIWSConnPool_CleanupStaleAndTrimIdle(t *testing.T) {
 	require.NotNil(t, ap.conns["idle_new"], "newer idle should be kept")
 }
 
+func TestOpenAIWSConnPool_CleanupRetiresConnectionsWithoutTurnLifetimeBudget(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 5 * 60
+	cfg.Gateway.OpenAIWS.MaxConnsPerAccount = 4
+	cfg.Gateway.OpenAIWS.MaxIdlePerAccount = 4
+	pool := newOpenAIWSConnPool(cfg)
+
+	now := time.Now()
+	retireAge := pool.maxConnAge() - pool.turnLifetimeReserve()
+	require.Equal(t, 5*time.Minute+openAIWSConnExpirySafetyBuffer, pool.turnLifetimeReserve())
+	require.Greater(t, retireAge, time.Duration(0))
+
+	accountID := int64(11)
+	ap := pool.getOrCreateAccountPool(accountID)
+	young := newOpenAIWSConn("young", accountID, &openAIWSFakeConn{}, nil)
+	young.createdAtNano.Store(now.Add(-(retireAge - time.Second)).UnixNano())
+	expiring := newOpenAIWSConn("expiring", accountID, &openAIWSFakeConn{}, nil)
+	expiring.createdAtNano.Store(now.Add(-(retireAge + time.Second)).UnixNano())
+	ap.conns[young.id] = young
+	ap.conns[expiring.id] = expiring
+	ap.pinnedConns[expiring.id] = 1
+
+	evicted := pool.cleanupAccountLocked(ap, now, pool.maxConnsHardCap())
+	closeOpenAIWSConns(evicted)
+
+	require.NotNil(t, ap.conns[young.id], "connection with enough lifetime budget should remain reusable")
+	require.Nil(t, ap.conns[expiring.id], "near-expiry connection must be retired before reuse")
+	_, stillPinned := ap.pinnedConns[expiring.id]
+	require.False(t, stillPinned, "retired connection must not retain a stale pin")
+	require.Len(t, evicted, 1)
+}
+
+func TestOpenAIWSConnLease_HasTurnLifetimeBudget(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 5 * 60
+	pool := newOpenAIWSConnPool(cfg)
+	now := time.Now()
+	retireAge := pool.maxConnAge() - pool.turnLifetimeReserve()
+
+	conn := newOpenAIWSConn("lease_lifetime", 12, &openAIWSFakeConn{}, nil)
+	lease := &openAIWSConnLease{pool: pool, accountID: 12, conn: conn}
+	conn.createdAtNano.Store(now.Add(-(retireAge - time.Second)).UnixNano())
+	require.True(t, lease.HasTurnLifetimeBudget(now))
+	conn.createdAtNano.Store(now.Add(-(retireAge + time.Second)).UnixNano())
+	require.False(t, lease.HasTurnLifetimeBudget(now))
+	require.Less(t, lease.RemainingLifetime(now), pool.turnLifetimeReserve())
+}
+
+func TestOpenAIWSConnPool_DefaultTurnLifetimeReserveProtectsMinute59(t *testing.T) {
+	pool := newOpenAIWSConnPool(&config.Config{})
+	now := time.Now()
+	conn := newOpenAIWSConn("minute_59", 13, &openAIWSFakeConn{}, nil)
+	conn.createdAtNano.Store(now.Add(-59 * time.Minute).UnixNano())
+
+	require.Equal(t, openAIWSConnDefaultTurnTimeout+openAIWSConnExpirySafetyBuffer, pool.turnLifetimeReserve())
+	require.False(t, pool.connHasTurnLifetimeBudget(conn, now), "a minute-59 connection must not start another turn")
+}
+
 func TestOpenAIWSConnPool_NextConnIDFormat(t *testing.T) {
 	pool := newOpenAIWSConnPool(&config.Config{})
 	id1 := pool.nextConnID(42)


### PR DESCRIPTION
## Summary

- retire idle `ctx_pool` connections before OpenAI's 60-minute WebSocket lifetime limit
- reserve the configured upstream read timeout plus a 30-second scheduling buffer before assigning a connection to a new turn
- check long-lived session leases before every turn
- transparently rotate non-strict/store-backed continuations; fail closed with WebSocket 1013 for strict `store=false` continuations before sending the turn upstream
- add pool and ingress regression coverage for near-expiry, pinned, stored, and strict-affinity sessions

## Problem

OpenAI Responses WebSocket connections have a hard 60-minute lifetime. The pool used the same 60-minute maximum age and only removed a connection after it was already over that age and idle. A connection acquired or still leased near minute 59 could therefore start another turn and be closed by the upstream in the middle of the response.

This patch distinguishes the hard connection age from the minimum lifetime needed to safely start a turn. With the default 15-minute upstream read timeout, pooled connections stop accepting new turns at approximately 44m30s instead of running directly into the upstream limit.

For strict `store=false` continuation affinity, the connection is not silently migrated. The client receives a retryable 1013 close before the next turn is sent upstream, avoiding partial output or duplicated side effects.

## Test plan

```bash
go test ./internal/service -count=1
```

Result on current `main`: pass (`96.243s`).
