### PR TITLE
fix(ci): suppress embed build staticcheck false positive

### DIFF
--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -71,7 +71,9 @@ func SetupRouter(
 
 	// Serve embedded frontend with settings injection if available
 	if web.HasEmbeddedFrontend() {
+		//nolint:staticcheck // Build-tag-specific implementations make this result non-constant.
 		frontendServer, err := web.NewFrontendServer(settingService)
+		//nolint:staticcheck // The error can be nil in embed-tag builds.
 		if err != nil {
 			log.Printf("Warning: Failed to create frontend server with settings injection: %v, using legacy mode", err)
 			r.Use(web.ServeEmbeddedFrontend())


### PR DESCRIPTION
## Summary

- suppress the two `SA4023` report locations with line-scoped golangci directives
- document why the result is not constant across build tags
- leave runtime behavior unchanged

## Context

`web.NewFrontendServer` has build-tag-specific implementations. The default `!embed` stub always returns an error, while the `embed` implementation can return either `nil` or an initialization error. Staticcheck sometimes analyzes the guarded block using only the `!embed` implementation and reports both the call site and `err != nil` comparison.

This surfaced in PR #4998 even though its GitHub merge ref has no differences from `main` under `backend/`; the same `main` SHA passed the push CI. Line-local suppressions are preferable to disabling `SA4023` globally.

## Verification

- `git diff --check`
- no production code or build-tag behavior changes
- repository CI verifies lint and all test suites