### PR TITLE
fix: preserve admin weekly quota reset boundaries

### DIFF
--- a/backend/internal/handler/quotaview/helpers.go
+++ b/backend/internal/handler/quotaview/helpers.go
@@ -13,7 +13,7 @@ import (
 // includeWindowStart=true 时输出 *_window_start 字段（admin 视角调试用）
 func LazyZeroQuotaForResponse(r service.UserPlatformQuotaRecord, now time.Time, includeWindowStart bool) map[string]any {
 	daily := buildWindowSlice(r.DailyUsageUSD, r.DailyLimitUSD, r.DailyWindowStart, NeedsDailyReset(r.DailyWindowStart, now), nextDailyResetTime(now), includeWindowStart)
-	weekly := buildWindowSlice(r.WeeklyUsageUSD, r.WeeklyLimitUSD, r.WeeklyWindowStart, NeedsWeeklyReset(r.WeeklyWindowStart, now), nextWeeklyResetTime(now), includeWindowStart)
+	weekly := buildWindowSlice(r.WeeklyUsageUSD, r.WeeklyLimitUSD, r.WeeklyWindowStart, NeedsWeeklyReset(r.WeeklyWindowStart, now), nextWeeklyResetTime(r.WeeklyWindowStart, now), includeWindowStart)
 	monthly := buildWindowSlice(r.MonthlyUsageUSD, r.MonthlyLimitUSD, r.MonthlyWindowStart, NeedsMonthlyReset(r.MonthlyWindowStart, now), NextMonthlyResetTimeFrom(r.MonthlyWindowStart, now), includeWindowStart)
 	out := map[string]any{
 		"platform":                 r.Platform,
@@ -71,7 +71,8 @@ func NeedsWeeklyReset(start *time.Time, now time.Time) bool {
 	if start == nil {
 		return false
 	}
-	return start.Before(timezone.StartOfWeek(now))
+	_, needsReset := timezone.EffectiveWeeklyWindowStart(start, now)
+	return needsReset
 }
 
 // NeedsMonthlyReset 30 天滚动窗口语义（与订阅模式 NeedsMonthlyReset 一致）。
@@ -86,8 +87,9 @@ func nextDailyResetTime(now time.Time) time.Time {
 	return timezone.StartOfDay(now).AddDate(0, 0, 1)
 }
 
-func nextWeeklyResetTime(now time.Time) time.Time {
-	return timezone.StartOfWeek(now).AddDate(0, 0, 7)
+func nextWeeklyResetTime(start *time.Time, now time.Time) time.Time {
+	effective, _ := timezone.EffectiveWeeklyWindowStart(start, now)
+	return effective.Add(7 * 24 * time.Hour)
 }
 
 // NextMonthlyResetTimeFrom 计算 30 天滚动月度窗口的下次重置时间。

--- a/backend/internal/handler/quotaview/helpers_test.go
+++ b/backend/internal/handler/quotaview/helpers_test.go
@@ -127,7 +127,35 @@ func TestNextWeeklyResetTime_FollowsServerTimezone(t *testing.T) {
 	// 北京 2026-05-26（周二）→ 下周一是 2026-06-01
 	now := time.Date(2026, 5, 25, 23, 0, 0, 0, time.UTC) // 北京 5/26 07:00 周二
 	want := time.Date(2026, 6, 1, 0, 0, 0, 0, timezone.Location())
-	if got := nextWeeklyResetTime(now); !got.Equal(want) {
+	if got := nextWeeklyResetTime(nil, now); !got.Equal(want) {
 		t.Errorf("nextWeeklyResetTime = %v, want %v", got, want)
+	}
+}
+
+func TestLazyZeroQuotaForResponse_WeeklyAdminResetSurvivesCalendarBoundary(t *testing.T) {
+	if err := timezone.Init("UTC"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	adminReset := time.Date(2026, 7, 26, 18, 30, 0, 0, time.UTC) // Sunday
+	nextMonday := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	r := service.UserPlatformQuotaRecord{
+		Platform:          "openai",
+		WeeklyUsageUSD:    2.5,
+		WeeklyWindowStart: &adminReset,
+	}
+
+	out := LazyZeroQuotaForResponse(r, nextMonday, false)
+	if got := out["weekly_usage_usd"]; got != 2.5 {
+		t.Fatalf("weekly_usage_usd=%v, want preserved usage 2.5", got)
+	}
+
+	resetsAt, ok := out["weekly_window_resets_at"].(*string)
+	if !ok || resetsAt == nil {
+		t.Fatal("weekly_window_resets_at should be set for an active admin-reset window")
+	}
+	want := adminReset.Add(7 * 24 * time.Hour).Format(time.RFC3339)
+	if *resetsAt != want {
+		t.Fatalf("weekly_window_resets_at=%s, want %s", *resetsAt, want)
 	}
 }

--- a/backend/internal/pkg/timezone/timezone.go
+++ b/backend/internal/pkg/timezone/timezone.go
@@ -116,6 +116,24 @@ func StartOfWeek(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day()-weekday+1, 0, 0, 0, 0, loc)
 }
 
+// EffectiveWeeklyWindowStart returns the active weekly window boundary and
+// whether usage must reset. A valid stored boundary may come from an explicit
+// admin reset, so it advances in seven-day periods instead of snapping back to
+// the next calendar Monday.
+func EffectiveWeeklyWindowStart(start *time.Time, now time.Time) (time.Time, bool) {
+	if start == nil || start.After(now) {
+		return StartOfWeek(now), true
+	}
+
+	const window = 7 * 24 * time.Hour
+	elapsed := now.Sub(*start)
+	if elapsed < window {
+		return *start, false
+	}
+
+	return start.Add((elapsed / window) * window), true
+}
+
 // StartOfMonth returns the start of the month (1st day 00:00:00) for the given time.
 func StartOfMonth(t time.Time) time.Time {
 	loc := Location()

--- a/backend/internal/pkg/timezone/timezone_test.go
+++ b/backend/internal/pkg/timezone/timezone_test.go
@@ -161,3 +161,42 @@ func TestStartOfWeek_Boundaries(t *testing.T) {
 		})
 	}
 }
+
+func TestEffectiveWeeklyWindowStart(t *testing.T) {
+	if err := Init("UTC"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	adminReset := time.Date(2026, 7, 26, 18, 30, 0, 0, time.UTC) // Sunday
+	nextMonday := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	calendarMonday := StartOfWeek(nextMonday)
+
+	t.Run("admin reset survives the next calendar boundary", func(t *testing.T) {
+		start, needsReset := EffectiveWeeklyWindowStart(&adminReset, nextMonday)
+		if needsReset || !start.Equal(adminReset) {
+			t.Fatalf("start=%v needsReset=%v, want preserved start=%v", start, needsReset, adminReset)
+		}
+	})
+
+	t.Run("rolling window advances in seven day periods", func(t *testing.T) {
+		now := adminReset.Add(8 * 24 * time.Hour)
+		start, needsReset := EffectiveWeeklyWindowStart(&adminReset, now)
+		want := adminReset.Add(7 * 24 * time.Hour)
+		if !needsReset || !start.Equal(want) {
+			t.Fatalf("start=%v needsReset=%v, want advanced start=%v", start, needsReset, want)
+		}
+	})
+
+	t.Run("missing or future start falls back to calendar week", func(t *testing.T) {
+		start, needsReset := EffectiveWeeklyWindowStart(nil, nextMonday)
+		if !needsReset || !start.Equal(calendarMonday) {
+			t.Fatalf("nil start=%v needsReset=%v, want calendar start=%v", start, needsReset, calendarMonday)
+		}
+
+		future := nextMonday.Add(time.Hour)
+		start, needsReset = EffectiveWeeklyWindowStart(&future, nextMonday)
+		if !needsReset || !start.Equal(calendarMonday) {
+			t.Fatalf("future start=%v needsReset=%v, want calendar start=%v", start, needsReset, calendarMonday)
+		}
+	})
+}

--- a/backend/internal/repository/user_platform_quota_repo.go
+++ b/backend/internal/repository/user_platform_quota_repo.go
@@ -169,8 +169,8 @@ func (r *userPlatformQuotaRepository) ListByUser(ctx context.Context, userID int
 
 // IncrementUsageWithReset 原子累加 cost 到 (user, platform) 三个窗口的 *_usage_usd。
 // 行为：
-//   - 若记录存在：在事务内 SELECT FOR UPDATE，按 (prev_window_start vs current_window_start)
-//     判断是否需要重置（不同 = 重置为 cost；相同 = 累加 cost）
+//   - 若记录存在：在事务内 SELECT FOR UPDATE；日窗口按自然日、周窗口从已保存起点按 7 天、
+//     月窗口从已保存起点按 30 天判断是否需要重置
 //   - 若记录不存在（fail-open create 分支）：插入新记录，**limit 字段保留 nil（无限制）**
 //     —— 这是预期行为：billing 链路不能因 quota 表缺失而阻断请求，未注册路径
 //     的用户 quota 默认放行，由调度层指标观测 + 后台对账补建 limit
@@ -212,7 +212,11 @@ func (r *userPlatformQuotaRepository) IncrementUsageWithReset(ctx context.Contex
 		}
 
 		newDaily := maybeReset(existing.DailyUsageUsd, existing.DailyWindowStart, timezone.StartOfDay(now), cost)
-		newWeekly := maybeReset(existing.WeeklyUsageUsd, existing.WeeklyWindowStart, timezone.StartOfWeek(now), cost)
+		weeklyStart, weeklyNeedsReset := timezone.EffectiveWeeklyWindowStart(existing.WeeklyWindowStart, now)
+		newWeekly := existing.WeeklyUsageUsd + cost
+		if weeklyNeedsReset {
+			newWeekly = cost
+		}
 		// 30 天滚动月度窗口：过期时重置为 cost 并以 now 为新起始，否则累加保留原起始
 		newMonthly, newMonthlyStart := monthlyMaybeReset(existing.MonthlyUsageUsd, existing.MonthlyWindowStart, cost, now)
 
@@ -221,7 +225,7 @@ func (r *userPlatformQuotaRepository) IncrementUsageWithReset(ctx context.Contex
 			SetWeeklyUsageUsd(newWeekly).
 			SetMonthlyUsageUsd(newMonthly).
 			SetDailyWindowStart(timezone.StartOfDay(now)).
-			SetWeeklyWindowStart(timezone.StartOfWeek(now)).
+			SetWeeklyWindowStart(weeklyStart).
 			SetMonthlyWindowStart(newMonthlyStart). // 30 天滚动：仅过期时更新起始
 			Save(txCtx)
 		return e

--- a/backend/internal/repository/user_platform_quota_repo_integration_test.go
+++ b/backend/internal/repository/user_platform_quota_repo_integration_test.go
@@ -200,6 +200,28 @@ func TestUserPlatformQuotaRepository_IncrementUsageWithReset_WeeklyReset(t *test
 	require.InDelta(t, 7.0, rec.MonthlyUsageUSD, 1e-9, "monthly accumulates (same month)")
 }
 
+func TestUserPlatformQuotaRepository_IncrementUsageWithReset_PreservesAdminWeeklyReset(t *testing.T) {
+	ctx := context.Background()
+	client := testEntClient(t)
+	userID := mustCreateUserForQuota(t, client)
+	repo := NewUserPlatformQuotaRepository(client)
+
+	adminReset := time.Date(2026, 7, 26, 18, 30, 0, 0, time.UTC) // Sunday
+	nextMonday := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+
+	require.NoError(t, repo.IncrementUsageWithReset(ctx, userID, "openai", 5.0, adminReset.Add(-time.Hour)))
+	require.NoError(t, repo.ResetExpiredWindow(ctx, userID, "openai", "weekly", adminReset))
+	require.NoError(t, repo.IncrementUsageWithReset(ctx, userID, "openai", 2.0, nextMonday))
+
+	rec, err := repo.GetByUserPlatform(ctx, userID, "openai")
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	require.InDelta(t, 2.0, rec.WeeklyUsageUSD, 1e-9, "usage after admin reset")
+	require.NotNil(t, rec.WeeklyWindowStart)
+	require.True(t, rec.WeeklyWindowStart.Equal(adminReset),
+		"billing must preserve admin reset start %v, got %v", adminReset, rec.WeeklyWindowStart)
+}
+
 func TestUserPlatformQuotaRepository_ResetExpiredWindow(t *testing.T) {
 	ctx := context.Background()
 	tx := testEntTx(t)

--- a/backend/internal/service/billing_cache_service.go
+++ b/backend/internal/service/billing_cache_service.go
@@ -1120,11 +1120,11 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 			dayStart := timezone.StartOfDay(now)
 			newDailyStart = &dayStart
 		}
-		if quotaWindowExpired(entry.WeeklyWindowStart, timezone.StartOfWeek(now)) {
+		effectiveWeeklyStart, weeklyNeedsReset := timezone.EffectiveWeeklyWindowStart(entry.WeeklyWindowStart, now)
+		if weeklyNeedsReset {
 			weeklyUsage = 0
 			windowExpired = true
-			weekStart := timezone.StartOfWeek(now)
-			newWeeklyStart = &weekStart
+			newWeeklyStart = &effectiveWeeklyStart
 		}
 		if monthlyQuotaWindowExpired(entry.MonthlyWindowStart, now) {
 			monthlyUsage = 0
@@ -1170,7 +1170,7 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 			return withWindowResetsMetadata(ErrUserPlatformDailyQuotaExhausted, nextDailyReset(now))
 		}
 		if entry.WeeklyLimitUSD != nil && weeklyUsage >= *entry.WeeklyLimitUSD {
-			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyReset(now))
+			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyResetFrom(newWeeklyStart, now))
 		}
 		if entry.MonthlyLimitUSD != nil && monthlyUsage >= *entry.MonthlyLimitUSD {
 			return withWindowResetsMetadata(ErrUserPlatformMonthlyQuotaExhausted, nextMonthlyResetFrom(entry.MonthlyWindowStart, now))
@@ -1241,11 +1241,14 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 	dailyUsage := rec.DailyUsageUSD
 	weeklyUsage := rec.WeeklyUsageUSD
 	monthlyUsage := rec.MonthlyUsageUSD
+	weeklyWindowStart := rec.WeeklyWindowStart
 	if quotaWindowExpired(rec.DailyWindowStart, timezone.StartOfDay(now)) {
 		dailyUsage = 0
 	}
-	if quotaWindowExpired(rec.WeeklyWindowStart, timezone.StartOfWeek(now)) {
+	effectiveWeeklyStart, weeklyNeedsReset := timezone.EffectiveWeeklyWindowStart(rec.WeeklyWindowStart, now)
+	if weeklyNeedsReset {
 		weeklyUsage = 0
+		weeklyWindowStart = &effectiveWeeklyStart
 	}
 	if monthlyQuotaWindowExpired(rec.MonthlyWindowStart, now) {
 		monthlyUsage = 0
@@ -1257,7 +1260,7 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 			return withWindowResetsMetadata(ErrUserPlatformDailyQuotaExhausted, nextDailyReset(now))
 		}
 		if rec.WeeklyLimitUSD != nil && weeklyUsage >= *rec.WeeklyLimitUSD {
-			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyReset(now))
+			return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyResetFrom(weeklyWindowStart, now))
 		}
 		if rec.MonthlyLimitUSD != nil && monthlyUsage >= *rec.MonthlyLimitUSD {
 			return withWindowResetsMetadata(ErrUserPlatformMonthlyQuotaExhausted, nextMonthlyResetFrom(rec.MonthlyWindowStart, now))
@@ -1275,7 +1278,7 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 		WeeklyLimitUSD:     rec.WeeklyLimitUSD,
 		MonthlyLimitUSD:    rec.MonthlyLimitUSD,
 		DailyWindowStart:   rec.DailyWindowStart,
-		WeeklyWindowStart:  rec.WeeklyWindowStart,
+		WeeklyWindowStart:  weeklyWindowStart,
 		MonthlyWindowStart: rec.MonthlyWindowStart,
 	}
 	if s.cache != nil {
@@ -1294,7 +1297,7 @@ func (s *BillingCacheService) checkUserPlatformQuotaEligibility(
 		return withWindowResetsMetadata(ErrUserPlatformDailyQuotaExhausted, nextDailyReset(now))
 	}
 	if rec.WeeklyLimitUSD != nil && weeklyUsage >= *rec.WeeklyLimitUSD {
-		return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyReset(now))
+		return withWindowResetsMetadata(ErrUserPlatformWeeklyQuotaExhausted, nextWeeklyResetFrom(weeklyWindowStart, now))
 	}
 	if rec.MonthlyLimitUSD != nil && monthlyUsage >= *rec.MonthlyLimitUSD {
 		return withWindowResetsMetadata(ErrUserPlatformMonthlyQuotaExhausted, nextMonthlyResetFrom(rec.MonthlyWindowStart, now))
@@ -1319,10 +1322,11 @@ func nextDailyReset(now time.Time) time.Time {
 	return timezone.StartOfDay(now).AddDate(0, 0, 1)
 }
 
-// nextWeeklyReset 计算下一个周窗口起点（下周一全局时区 0 点）。
-// 必须与 timezone.StartOfWeek 同口径，否则 Retry-After 会偏差。
-func nextWeeklyReset(now time.Time) time.Time {
-	return timezone.StartOfWeek(now).AddDate(0, 0, 7)
+// nextWeeklyResetFrom returns the end of the active seven-day window. This
+// keeps Retry-After aligned with an explicit admin reset boundary.
+func nextWeeklyResetFrom(start *time.Time, now time.Time) time.Time {
+	effective, _ := timezone.EffectiveWeeklyWindowStart(start, now)
+	return effective.Add(7 * 24 * time.Hour)
 }
 
 // nextMonthlyResetFrom 返回 30 天滚动窗口的下次重置时间（start + 30d）。

--- a/backend/internal/service/billing_cache_service_user_platform_quota_test.go
+++ b/backend/internal/service/billing_cache_service_user_platform_quota_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
+	infraerrors "github.com/Wei-Shaw/sub2api/internal/pkg/errors"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/timezone"
 )
 
@@ -760,6 +761,98 @@ func TestCheckUserPlatformQuotaEligibility_SentinelCrossDay_NoRefresh(t *testing
 	}
 	if cache.getSetCalls() != 0 {
 		t.Errorf("sentinel cross-window must NOT trigger refresh SetCache, got %d calls", cache.getSetCalls())
+	}
+}
+
+func TestNextWeeklyResetFromPreservesAdminBoundary(t *testing.T) {
+	adminReset := time.Date(2026, 7, 26, 18, 30, 0, 0, time.UTC) // Sunday
+	nextMonday := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+
+	got := nextWeeklyResetFrom(&adminReset, nextMonday)
+	want := adminReset.Add(7 * 24 * time.Hour)
+	if !got.Equal(want) {
+		t.Fatalf("next reset=%v, want admin boundary + 7d=%v", got, want)
+	}
+}
+
+func TestCheckUserPlatformQuotaEligibility_PreservesAdminWeeklyBoundary(t *testing.T) {
+	previousTZ := timezone.Name()
+	if err := timezone.Init("UTC"); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	t.Cleanup(func() { _ = timezone.Init(previousTZ) })
+
+	limit := 5.0
+	adminReset := timezone.StartOfWeek(time.Now()).Add(-time.Nanosecond)
+	wantReset := adminReset.Add(7 * 24 * time.Hour).Format(time.RFC3339)
+
+	for _, tc := range []struct {
+		name  string
+		repo  *fakeQuotaRepo
+		cache *fakeFullCache
+	}{
+		{
+			name: "cache hit",
+			repo: &fakeQuotaRepo{},
+			cache: &fakeFullCache{entry: &UserPlatformQuotaCacheEntry{
+				SchemaVersion:     UserPlatformQuotaCacheSchemaV1,
+				WeeklyUsageUSD:    limit,
+				WeeklyLimitUSD:    &limit,
+				WeeklyWindowStart: &adminReset,
+			}},
+		},
+		{
+			name: "cache miss",
+			repo: &fakeQuotaRepo{rec: &UserPlatformQuotaRecord{
+				WeeklyUsageUSD:    limit,
+				WeeklyLimitUSD:    &limit,
+				WeeklyWindowStart: &adminReset,
+			}},
+			cache: &fakeFullCache{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newServiceForPreflight(t, tc.repo, tc.cache)
+			err := svc.checkUserPlatformQuotaEligibility(context.Background(), 1, "openai")
+			if !errors.Is(err, ErrUserPlatformWeeklyQuotaExhausted) {
+				t.Fatalf("expected weekly quota rejection, got %v", err)
+			}
+			if got := infraerrors.FromError(err).Metadata["window_resets_at"]; got != wantReset {
+				t.Fatalf("window_resets_at=%q, want %q", got, wantReset)
+			}
+			entry := tc.cache.getEntry()
+			if entry == nil || entry.WeeklyWindowStart == nil || !entry.WeeklyWindowStart.Equal(adminReset) {
+				t.Fatalf("cache must preserve admin weekly start %v, got %+v", adminReset, entry)
+			}
+		})
+	}
+}
+
+func TestCheckUserPlatformQuotaEligibility_AdvancesExpiredAdminWeeklyBoundary(t *testing.T) {
+	limit := 5.0
+	now := time.Now()
+	adminReset := now.Add(-8 * 24 * time.Hour)
+	wantStart := adminReset.Add(7 * 24 * time.Hour)
+	dayStart := timezone.StartOfDay(now)
+	cache := &fakeFullCache{entry: &UserPlatformQuotaCacheEntry{
+		SchemaVersion:      UserPlatformQuotaCacheSchemaV1,
+		WeeklyUsageUSD:     limit,
+		WeeklyLimitUSD:     &limit,
+		DailyWindowStart:   &dayStart,
+		WeeklyWindowStart:  &adminReset,
+		MonthlyWindowStart: &now,
+	}}
+	svc := newServiceForPreflight(t, &fakeQuotaRepo{}, cache)
+
+	if err := svc.checkUserPlatformQuotaEligibility(context.Background(), 1, "openai"); err != nil {
+		t.Fatalf("expired weekly usage should reset before eligibility check, got %v", err)
+	}
+	entry := cache.getEntry()
+	if entry == nil || entry.WeeklyWindowStart == nil || !entry.WeeklyWindowStart.Equal(wantStart) {
+		t.Fatalf("weekly start=%v, want advanced start %v", entry.WeeklyWindowStart, wantStart)
+	}
+	if entry.WeeklyUsageUSD != 0 {
+		t.Fatalf("weekly usage=%v, want 0 after reset", entry.WeeklyUsageUSD)
 	}
 }
 


### PR DESCRIPTION
## What changed

- preserve a manually reset weekly quota boundary for the full seven-day window
- advance expired weekly boundaries in seven-day periods instead of snapping them back to Monday
- use the same effective boundary for repository accounting, Redis quota checks, quota responses, and `window_resets_at`

## Why

`POST /api/v1/admin/users/:id/platform-quotas/reset` stores the reset time in `weekly_window_start`. The next billed request previously compared that value with `timezone.StartOfWeek(now)` and then always wrote the calendar-week start back to the row.

As a result, an admin reset outside Monday 00:00 could be shortened at the next calendar boundary. Weekly usage could also be cleared again on the next billed request, while cache eligibility checks and retry metadata continued to use the calendar week.

This change treats the persisted weekly boundary as the source of truth. Missing or future boundaries still fall back to the current calendar-week start, preserving the initialization behavior.

## Impact

After an admin weekly reset, subsequent billing and quota reads keep the reset timestamp and accumulated usage until seven days have elapsed. Weekly limit values are not changed. Daily and monthly quota behavior is unchanged.

## Validation

- `make test-unit`
- `go vet ./internal/pkg/timezone ./internal/handler/quotaview ./internal/repository`
- `go vet -tags unit ./internal/service`
- focused weekly-boundary service tests, repeated 10 times
- `git diff --check`

The PostgreSQL integration test was compiled with `-tags integration`, but the local integration harness skipped execution because Docker was unavailable. GitHub CI is expected to execute that test with its PostgreSQL test environment.
