### PR TITLE
fix(openai): reconcile stale rate-limit state

### DIFF
--- a/backend/cmd/server/wire.go
+++ b/backend/cmd/server/wire.go
@@ -86,6 +86,7 @@ func provideCleanup(
 	apiKeyService *service.APIKeyService,
 	authCacheInvalidationWorker *service.AuthCacheInvalidationWorker,
 	schedulerSnapshot *service.SchedulerSnapshotService,
+	openAIRateLimitReconciler *service.OpenAIRateLimitReconcilerService,
 	tokenRefresh *service.TokenRefreshService,
 	accountExpiry *service.AccountExpiryService,
 	proxyExpiry *service.ProxyExpiryService,
@@ -201,6 +202,12 @@ func provideCleanup(
 			{"SchedulerSnapshotService", func() error {
 				if schedulerSnapshot != nil {
 					schedulerSnapshot.Stop()
+				}
+				return nil
+			}},
+			{"OpenAIRateLimitReconcilerService", func() error {
+				if openAIRateLimitReconciler != nil {
+					openAIRateLimitReconciler.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen.go
+++ b/backend/cmd/server/wire_gen.go
@@ -46,10 +46,8 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 		return nil, err
 	}
 	userRepository := repository.NewUserRepository(client, db)
-	passkeyRepository := repository.NewPasskeyRepository(db)
 	redeemCodeRepository := repository.NewRedeemCodeRepository(client)
 	redisClient := repository.ProvideRedis(configConfig)
-	passkeySessionStore := repository.NewPasskeySessionStore(redisClient)
 	refreshTokenCache := repository.NewRefreshTokenCache(redisClient)
 	settingRepository := repository.NewSettingRepository(client)
 	groupRepository := repository.NewGroupRepository(client, db)
@@ -81,10 +79,6 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	affiliateRepository := repository.NewAffiliateRepository(client, db)
 	affiliateService := service.NewAffiliateService(affiliateRepository, settingService, apiKeyAuthCacheInvalidator, billingCacheService)
 	authService := service.NewAuthService(client, userRepository, redeemCodeRepository, refreshTokenCache, configConfig, settingService, emailService, turnstileService, emailQueueService, promoService, subscriptionService, affiliateService, serviceUserPlatformQuotaRepository)
-	passkeyService, err := service.NewPasskeyService(configConfig, passkeyRepository, passkeySessionStore, userRepository)
-	if err != nil {
-		return nil, err
-	}
 	userService := service.NewUserService(userRepository, settingRepository, apiKeyAuthCacheInvalidator, billingCache)
 	redeemCache := repository.NewRedeemCache(redisClient)
 	redeemService := service.NewRedeemService(redeemCodeRepository, userRepository, subscriptionService, redeemCache, billingCacheService, client, apiKeyAuthCacheInvalidator, affiliateService)
@@ -98,7 +92,6 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	userAttributeValueRepository := repository.NewUserAttributeValueRepository(client)
 	userAttributeService := service.NewUserAttributeService(userAttributeDefinitionRepository, userAttributeValueRepository)
 	authHandler := handler.NewAuthHandler(configConfig, authService, userService, settingService, promoService, redeemService, totpService, userAttributeService)
-	passkeyHandler := handler.NewPasskeyHandler(passkeyService, authService, settingService)
 	userHandler := handler.NewUserHandler(userService, authService, emailService, emailCache, affiliateService, serviceUserPlatformQuotaRepository)
 	apiKeyHandler := handler.NewAPIKeyHandler(apiKeyService)
 	usageLogRepository := repository.NewUsageLogRepository(client, db)
@@ -287,6 +280,13 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	openAIGatewayHandler := handler.ProvideOpenAIGatewayHandler(openAIGatewayService, concurrencyService, billingCacheService, apiKeyService, usageRecordWorkerPool, errorPassthroughService, contentModerationService, opsService, grokQuotaService, configConfig, coordinator)
 	handlerSettingHandler := handler.ProvideSettingHandler(settingService, buildInfo, notificationEmailService)
 	totpHandler := handler.NewTotpHandler(totpService)
+	passkeyRepository := repository.NewPasskeyRepository(db)
+	passkeySessionStore := repository.NewPasskeySessionStore(redisClient)
+	passkeyService, err := service.NewPasskeyService(configConfig, passkeyRepository, passkeySessionStore, userRepository)
+	if err != nil {
+		return nil, err
+	}
+	passkeyHandler := handler.NewPasskeyHandler(passkeyService, authService, settingService)
 	handlerPaymentHandler := handler.NewPaymentHandler(paymentService, paymentConfigService)
 	paymentWebhookHandler := handler.NewPaymentWebhookHandler(paymentService, registry)
 	availableChannelHandler := handler.NewAvailableChannelHandler(channelService, apiKeyService, settingService)
@@ -317,6 +317,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	opsCleanupService := service.ProvideOpsCleanupService(opsRepository, db, redisClient, configConfig, channelMonitorService, settingRepository, opsService)
 	opsScheduledReportService := service.ProvideOpsScheduledReportService(opsService, userService, emailService, redisClient, configConfig)
 	opsIngressRejectAggregator := service.ProvideOpsIngressRejectAggregator(opsRepository, opsService)
+	openAIRateLimitReconcilerService := service.ProvideOpenAIRateLimitReconcilerService(accountRepository, openAIQuotaService, openAIGatewayService, configConfig, leaderLockCache, db)
 	accountExpiryService := service.ProvideAccountExpiryService(accountRepository)
 	proxyExpiryService := service.ProvideProxyExpiryService(proxyRepository)
 	subscriptionExpiryService := service.ProvideSubscriptionExpiryService(userSubscriptionRepository, settingRepository, notificationEmailService, leaderLockCache, db)
@@ -325,7 +326,7 @@ func initializeApplication(buildInfo handler.BuildInfo) (*Application, error) {
 	paymentOrderExpiryService := service.ProvidePaymentOrderExpiryService(paymentService, leaderLockCache, db)
 	channelMonitorRunner := service.ProvideChannelMonitorRunner(channelMonitorService, settingService)
 	userPlatformQuotaUsageFlusher := service.ProvideUserPlatformQuotaUsageFlusher(configConfig, billingCache, serviceUserPlatformQuotaRepository, timingWheelService)
-	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, opsService, opsIngressRejectAggregator, apiKeyService, authCacheInvalidationWorker, schedulerSnapshotService, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, batchImageCleanupService, batchImageWorkerRuntime, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, userPlatformQuotaUsageFlusher, upstreamBillingProbeService, ollamaCloudUsageService, auditLogService, promptService)
+	v := provideCleanup(client, redisClient, opsMetricsCollector, opsAggregationService, opsAlertEvaluatorService, opsCleanupService, opsScheduledReportService, opsSystemLogSink, opsService, opsIngressRejectAggregator, apiKeyService, authCacheInvalidationWorker, schedulerSnapshotService, openAIRateLimitReconcilerService, tokenRefreshService, accountExpiryService, proxyExpiryService, subscriptionExpiryService, usageCleanupService, idempotencyCleanupService, batchImageCleanupService, batchImageWorkerRuntime, pricingService, emailQueueService, billingCacheService, usageRecordWorkerPool, subscriptionService, oAuthService, openAIOAuthService, geminiOAuthService, antigravityOAuthService, grokOAuthService, openAIGatewayService, scheduledTestRunnerService, backupService, paymentOrderExpiryService, channelMonitorRunner, userPlatformQuotaUsageFlusher, upstreamBillingProbeService, ollamaCloudUsageService, auditLogService, promptService)
 	application := &Application{
 		Server:      httpServer,
 		PromptAudit: promptService,
@@ -367,6 +368,7 @@ func provideCleanup(
 	apiKeyService *service.APIKeyService,
 	authCacheInvalidationWorker *service.AuthCacheInvalidationWorker,
 	schedulerSnapshot *service.SchedulerSnapshotService,
+	openAIRateLimitReconciler *service.OpenAIRateLimitReconcilerService,
 	tokenRefresh *service.TokenRefreshService,
 	accountExpiry *service.AccountExpiryService,
 	proxyExpiry *service.ProxyExpiryService,
@@ -481,6 +483,12 @@ func provideCleanup(
 			{"SchedulerSnapshotService", func() error {
 				if schedulerSnapshot != nil {
 					schedulerSnapshot.Stop()
+				}
+				return nil
+			}},
+			{"OpenAIRateLimitReconcilerService", func() error {
+				if openAIRateLimitReconciler != nil {
+					openAIRateLimitReconciler.Stop()
 				}
 				return nil
 			}},

--- a/backend/cmd/server/wire_gen_test.go
+++ b/backend/cmd/server/wire_gen_test.go
@@ -63,6 +63,7 @@ func TestProvideCleanup_WithMinimalDependencies_NoPanic(t *testing.T) {
 		nil, // apiKeyService
 		nil, // authCacheInvalidationWorker
 		schedulerSnapshotSvc,
+		nil, // openAIRateLimitReconciler
 		tokenRefreshSvc,
 		accountExpirySvc,
 		proxyExpirySvc,

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -922,6 +922,8 @@ type GatewayConfig struct {
 	// OpenAICompactModel: /responses/compact 上游使用的模型。
 	// compact 端点支持模型滞后于普通 /responses 时，可用该配置降级规避上游错误。
 	OpenAICompactModel string `mapstructure:"openai_compact_model"`
+	// OpenAIRateLimitReconcile: OpenAI OAuth 账号陈旧限流状态的后台纠偏配置。
+	OpenAIRateLimitReconcile GatewayOpenAIRateLimitReconcileConfig `mapstructure:"openai_rate_limit_reconcile"`
 	// OpenAIWS: OpenAI Responses WebSocket 配置（默认开启，可按需回滚到 HTTP）
 	OpenAIWS GatewayOpenAIWSConfig `mapstructure:"openai_ws"`
 	// Live: ChatGPT Frameless Live 会话配置。
@@ -1010,6 +1012,15 @@ type GatewayConfig struct {
 	// UserMessageQueue: 用户消息串行队列配置
 	// 对 role:"user" 的真实用户消息实施账号级串行化 + RPM 自适应延迟
 	UserMessageQueue UserMessageQueueConfig `mapstructure:"user_message_queue"`
+}
+
+// GatewayOpenAIRateLimitReconcileConfig controls the opt-in background worker
+// that verifies rate-limited OpenAI OAuth accounts against /backend-api/wham/usage.
+type GatewayOpenAIRateLimitReconcileConfig struct {
+	Enabled             bool `mapstructure:"enabled"`
+	IntervalSeconds     int  `mapstructure:"interval_seconds"`
+	MaxAccountsPerCycle int  `mapstructure:"max_accounts_per_cycle"`
+	Concurrency         int  `mapstructure:"concurrency"`
 }
 
 type GatewayLiveConfig struct {
@@ -2218,6 +2229,10 @@ func setDefaults() {
 	viper.SetDefault("gateway.codex_image_generation_bridge_enabled", false)
 	viper.SetDefault("gateway.openai_passthrough_allow_timeout_headers", false)
 	viper.SetDefault("gateway.openai_compact_model", "gpt-5.4")
+	viper.SetDefault("gateway.openai_rate_limit_reconcile.enabled", false)
+	viper.SetDefault("gateway.openai_rate_limit_reconcile.interval_seconds", 300)
+	viper.SetDefault("gateway.openai_rate_limit_reconcile.max_accounts_per_cycle", 20)
+	viper.SetDefault("gateway.openai_rate_limit_reconcile.concurrency", 2)
 	viper.SetDefault("gateway.live.max_session_duration_seconds", 3600)
 	// OpenAI Responses WebSocket（默认开启；可通过 force_http 紧急回滚）
 	viper.SetDefault("gateway.openai_ws.enabled", true)
@@ -3106,6 +3121,15 @@ func (c *Config) Validate() error {
 	if c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds < 0 || c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds > 1800 ||
 		(c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds > 0 && c.Gateway.OpenAIHighEffortFirstOutputTimeoutSeconds < 30) {
 		return fmt.Errorf("gateway.openai_high_effort_first_output_timeout_seconds must be 0 or between 30-1800 seconds")
+	}
+	if c.Gateway.OpenAIRateLimitReconcile.IntervalSeconds < 60 || c.Gateway.OpenAIRateLimitReconcile.IntervalSeconds > 86400 {
+		return fmt.Errorf("gateway.openai_rate_limit_reconcile.interval_seconds must be between 60-86400")
+	}
+	if c.Gateway.OpenAIRateLimitReconcile.MaxAccountsPerCycle <= 0 || c.Gateway.OpenAIRateLimitReconcile.MaxAccountsPerCycle > 500 {
+		return fmt.Errorf("gateway.openai_rate_limit_reconcile.max_accounts_per_cycle must be between 1-500")
+	}
+	if c.Gateway.OpenAIRateLimitReconcile.Concurrency <= 0 || c.Gateway.OpenAIRateLimitReconcile.Concurrency > 20 {
+		return fmt.Errorf("gateway.openai_rate_limit_reconcile.concurrency must be between 1-20")
 	}
 	if c.Gateway.Live.MaxSessionDurationSeconds <= 0 {
 		c.Gateway.Live.MaxSessionDurationSeconds = 3600

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -2128,6 +2128,81 @@ func (r *accountRepository) ClearRateLimitIfObserved(ctx context.Context, id int
 	return true, nil
 }
 
+// ListOpenAIRateLimitRecoveryCandidates returns a bounded set of active parent
+// OAuth accounts that are still hidden by a future account-level rate limit.
+// The service layer applies the remaining JSON model-limit guard before probing.
+func (r *accountRepository) ListOpenAIRateLimitRecoveryCandidates(ctx context.Context, now time.Time, limit int) ([]service.Account, error) {
+	if limit <= 0 {
+		return []service.Account{}, nil
+	}
+	accounts, err := r.client.Account.Query().
+		Where(
+			dbaccount.PlatformEQ(service.PlatformOpenAI),
+			dbaccount.TypeEQ(service.AccountTypeOAuth),
+			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.SchedulableEQ(true),
+			dbaccount.ParentAccountIDIsNil(),
+			dbaccount.RateLimitedAtNotNil(),
+			dbaccount.RateLimitResetAtNotNil(),
+			dbaccount.RateLimitResetAtGT(now),
+			tempUnschedulablePredicate(),
+			notExpiredPredicate(now),
+			dbaccount.Or(dbaccount.OverloadUntilIsNil(), dbaccount.OverloadUntilLTE(now)),
+		).
+		Order(
+			dbent.Asc(dbaccount.FieldRateLimitedAt),
+			dbent.Asc(dbaccount.FieldID),
+		).
+		Limit(limit).
+		All(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return r.accountsToService(ctx, accounts)
+}
+
+// ClearOpenAIRateLimitIfObserved atomically clears only the OpenAI account-level
+// rate-limit generation observed before a quota probe. A concurrent 429 changes
+// at least rate_limited_at and makes this a no-op.
+func (r *accountRepository) ClearOpenAIRateLimitIfObserved(
+	ctx context.Context,
+	id int64,
+	observedLimitedAt time.Time,
+	observedResetAt time.Time,
+) (bool, error) {
+	now := time.Now()
+	updated, err := r.client.Account.Update().
+		Where(
+			dbaccount.IDEQ(id),
+			dbaccount.PlatformEQ(service.PlatformOpenAI),
+			dbaccount.TypeEQ(service.AccountTypeOAuth),
+			dbaccount.StatusEQ(service.StatusActive),
+			dbaccount.SchedulableEQ(true),
+			dbaccount.ParentAccountIDIsNil(),
+			dbaccount.RateLimitedAtEQ(observedLimitedAt),
+			dbaccount.RateLimitResetAtEQ(observedResetAt),
+			dbaccount.RateLimitResetAtGT(now),
+			tempUnschedulablePredicate(),
+			notExpiredPredicate(now),
+			dbaccount.Or(dbaccount.OverloadUntilIsNil(), dbaccount.OverloadUntilLTE(now)),
+		).
+		ClearRateLimitedAt().
+		ClearRateLimitResetAt().
+		Save(ctx)
+	if err != nil {
+		return false, err
+	}
+	if updated == 0 {
+		r.syncSchedulerAccountSnapshot(ctx, id)
+		return false, nil
+	}
+	if err := enqueueSchedulerOutbox(ctx, r.sql, service.SchedulerOutboxEventAccountChanged, &id, nil, nil); err != nil {
+		logger.LegacyPrintf("repository.account", "[SchedulerOutbox] enqueue conditional OpenAI rate-limit clear failed: account=%d err=%v", id, err)
+	}
+	r.syncSchedulerAccountSnapshot(ctx, id)
+	return true, nil
+}
+
 func (r *accountRepository) SetModelRateLimit(ctx context.Context, id int64, scope string, resetAt time.Time, reason ...string) error {
 	if scope == "" {
 		return nil

--- a/backend/internal/repository/account_repo_integration_test.go
+++ b/backend/internal/repository/account_repo_integration_test.go
@@ -932,6 +932,60 @@ func (s *AccountRepoSuite) TestClearRateLimitIfObservedProtectsRearmed429Generat
 	s.Require().WithinDuration(rearmedReset, *retyped.RateLimitResetAt, time.Second)
 }
 
+func (s *AccountRepoSuite) TestOpenAIRateLimitRecoveryCandidateAndConditionalClear() {
+	account := mustCreateAccount(s.T(), s.client, &service.Account{
+		Name:        "openai-rl-reconcile",
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeOAuth,
+		Status:      service.StatusActive,
+		Schedulable: true,
+	})
+	firstReset := time.Now().Add(4 * 24 * time.Hour).UTC()
+	s.Require().NoError(s.repo.SetRateLimited(s.ctx, account.ID, firstReset))
+
+	candidates, err := s.repo.ListOpenAIRateLimitRecoveryCandidates(s.ctx, time.Now(), 10)
+	s.Require().NoError(err)
+	s.Require().Len(candidates, 1)
+	s.Require().Equal(account.ID, candidates[0].ID)
+	staleGeneration := candidates[0]
+
+	time.Sleep(time.Millisecond)
+	rearmedReset := time.Now().Add(7 * 24 * time.Hour).UTC()
+	s.Require().NoError(s.repo.SetRateLimited(s.ctx, account.ID, rearmedReset))
+	cleared, err := s.repo.ClearOpenAIRateLimitIfObserved(
+		s.ctx,
+		account.ID,
+		*staleGeneration.RateLimitedAt,
+		*staleGeneration.RateLimitResetAt,
+	)
+	s.Require().NoError(err)
+	s.Require().False(cleared)
+
+	current, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().NotNil(current.RateLimitedAt)
+	s.Require().NotNil(current.RateLimitResetAt)
+	s.Require().WithinDuration(rearmedReset, *current.RateLimitResetAt, time.Second)
+
+	_, err = s.client.Account.UpdateOneID(account.ID).
+		SetType(service.AccountTypeAPIKey).
+		Save(s.ctx)
+	s.Require().NoError(err)
+	cleared, err = s.repo.ClearOpenAIRateLimitIfObserved(
+		s.ctx,
+		account.ID,
+		*current.RateLimitedAt,
+		*current.RateLimitResetAt,
+	)
+	s.Require().NoError(err)
+	s.Require().False(cleared)
+
+	retyped, err := s.repo.GetByID(s.ctx, account.ID)
+	s.Require().NoError(err)
+	s.Require().Equal(service.AccountTypeAPIKey, retyped.Type)
+	s.Require().NotNil(retyped.RateLimitResetAt)
+}
+
 func (s *AccountRepoSuite) TestClearRateLimit() {
 	account := mustCreateAccount(s.T(), s.client, &service.Account{Name: "acc-clear"})
 	until := time.Now().Add(1 * time.Hour)

--- a/backend/internal/service/openai_account_runtime_block_fastpath.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath.go
@@ -222,6 +222,40 @@ func (s *OpenAIGatewayService) ClearAccountSchedulingBlock(accountID int64) {
 	s.openaiAccountRuntimeBlockGeneration.Store(accountID, s.openaiAccountRuntimeBlockSequence.Add(1))
 }
 
+// AccountSchedulingBlockGeneration returns an opaque generation that changes
+// whenever this process installs or clears an account-level runtime block.
+func (s *OpenAIGatewayService) AccountSchedulingBlockGeneration(accountID int64) uint64 {
+	if s == nil || accountID <= 0 {
+		return 0
+	}
+	mu := s.openAIAccountRuntimeBlockLock(accountID)
+	mu.Lock()
+	defer mu.Unlock()
+	raw, _ := s.openaiAccountRuntimeBlockGeneration.Load(accountID)
+	generation, _ := raw.(uint64)
+	return generation
+}
+
+// ClearAccountSchedulingBlockIfGeneration removes the runtime block only when
+// no newer block/clear happened after the caller captured observedGeneration.
+func (s *OpenAIGatewayService) ClearAccountSchedulingBlockIfGeneration(accountID int64, observedGeneration uint64) bool {
+	if s == nil || accountID <= 0 {
+		return false
+	}
+	mu := s.openAIAccountRuntimeBlockLock(accountID)
+	mu.Lock()
+	defer mu.Unlock()
+
+	raw, _ := s.openaiAccountRuntimeBlockGeneration.Load(accountID)
+	current, _ := raw.(uint64)
+	if current != observedGeneration {
+		return false
+	}
+	s.openaiAccountRuntimeBlockUntil.Delete(accountID)
+	s.openaiAccountRuntimeBlockGeneration.Store(accountID, s.openaiAccountRuntimeBlockSequence.Add(1))
+	return true
+}
+
 func (s *OpenAIGatewayService) isOpenAIAccountRuntimeBlocked(account *Account) bool {
 	if s == nil || !isOpenAIAccount(account) {
 		return false

--- a/backend/internal/service/openai_account_runtime_block_fastpath_test.go
+++ b/backend/internal/service/openai_account_runtime_block_fastpath_test.go
@@ -71,6 +71,23 @@ func TestOpenAIRuntimeBlock_DoesNotApplyToOtherPlatforms(t *testing.T) {
 	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
 }
 
+func TestOpenAIRuntimeBlock_ConditionalClearPreservesNewer429(t *testing.T) {
+	svc := &OpenAIGatewayService{}
+	account := &Account{ID: 46, Platform: PlatformOpenAI, Type: AccountTypeOAuth}
+
+	svc.BlockAccountScheduling(account, time.Now().Add(time.Hour), "429")
+	observedGeneration := svc.AccountSchedulingBlockGeneration(account.ID)
+	require.NotZero(t, observedGeneration)
+
+	svc.BlockAccountScheduling(account, time.Now().Add(2*time.Hour), "429")
+	require.False(t, svc.ClearAccountSchedulingBlockIfGeneration(account.ID, observedGeneration))
+	require.True(t, svc.isOpenAIAccountRuntimeBlocked(account))
+
+	latestGeneration := svc.AccountSchedulingBlockGeneration(account.ID)
+	require.True(t, svc.ClearAccountSchedulingBlockIfGeneration(account.ID, latestGeneration))
+	require.False(t, svc.isOpenAIAccountRuntimeBlocked(account))
+}
+
 func TestOpenAIRuntimeBlocker_IgnoresNonOpenAIFromRateLimitService(t *testing.T) {
 	gateway := &OpenAIGatewayService{}
 	repo := &rateLimitAccountRepoStub{}

--- a/backend/internal/service/openai_quota_service.go
+++ b/backend/internal/service/openai_quota_service.go
@@ -142,6 +142,17 @@ func NewOpenAIQuotaService(
 // OAuth account. Returns infraerrors so the handler layer can map them to
 // stable error codes / HTTP statuses.
 func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*OpenAIQuotaUsage, error) {
+	return s.queryUsage(ctx, accountID, true)
+}
+
+// QueryUsageForReconciliation fetches only the authoritative quota snapshot
+// needed by the background rate-limit reconciler. It deliberately skips reset
+// credit metadata so one candidate produces exactly one read-only upstream call.
+func (s *OpenAIQuotaService) QueryUsageForReconciliation(ctx context.Context, accountID int64) (*OpenAIQuotaUsage, error) {
+	return s.queryUsage(ctx, accountID, false)
+}
+
+func (s *OpenAIQuotaService) queryUsage(ctx context.Context, accountID int64, includeResetCreditDetails bool) (*OpenAIQuotaUsage, error) {
 	accessToken, chatGPTAccountID, proxyURL, fedRAMP, err := s.prepareUpstreamCall(ctx, accountID)
 	if err != nil {
 		return nil, err
@@ -187,20 +198,22 @@ func (s *OpenAIQuotaService) QueryUsage(ctx context.Context, accountID int64) (*
 	}
 
 	payload.FetchedAt = time.Now().Unix()
-	details := s.queryResetCreditDetails(callCtx, client, accessToken, chatGPTAccountID, fedRAMP, accountID)
-	if details != nil {
-		hasDetailCount := details.AvailableCount != nil
-		if payload.RateLimitResetCredits == nil {
-			payload.RateLimitResetCredits = &OpenAIRateLimitResetCredits{}
-		}
-		if details.CreditListPresent {
-			payload.RateLimitResetCredits.Credits = details.Credits
-		}
-		switch {
-		case hasDetailCount:
-			payload.RateLimitResetCredits.AvailableCount = *details.AvailableCount
-		case details.CreditListPresent:
-			payload.RateLimitResetCredits.AvailableCount = details.AvailableCreditCount
+	if includeResetCreditDetails {
+		details := s.queryResetCreditDetails(callCtx, client, accessToken, chatGPTAccountID, fedRAMP, accountID)
+		if details != nil {
+			hasDetailCount := details.AvailableCount != nil
+			if payload.RateLimitResetCredits == nil {
+				payload.RateLimitResetCredits = &OpenAIRateLimitResetCredits{}
+			}
+			if details.CreditListPresent {
+				payload.RateLimitResetCredits.Credits = details.Credits
+			}
+			switch {
+			case hasDetailCount:
+				payload.RateLimitResetCredits.AvailableCount = *details.AvailableCount
+			case details.CreditListPresent:
+				payload.RateLimitResetCredits.AvailableCount = details.AvailableCreditCount
+			}
 		}
 	}
 	return &payload, nil

--- a/backend/internal/service/openai_quota_spark_window_test.go
+++ b/backend/internal/service/openai_quota_spark_window_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -643,4 +644,46 @@ func TestQueryUsageShadowResolve_EndToEnd(t *testing.T) {
 	require.NotNil(t, usage)
 	require.Equal(t, "org-e2e-parent", capturedAccountID,
 		"upstream should receive parent's chatgpt-account-id; got: %s", capturedAccountID)
+}
+
+func TestQueryUsageForReconciliationSkipsResetCreditRequest(t *testing.T) {
+	ctx := context.Background()
+	account := &Account{
+		ID:       100,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Status:   StatusActive,
+		Credentials: map[string]any{
+			"chatgpt_account_id": "org-reconcile",
+		},
+	}
+	repo := &stubQuotaAccountRepo{accounts: map[int64]*Account{100: account}}
+	tokenCache := &stubQuotaTokenCache{tokens: map[string]string{
+		OpenAITokenCacheKey(account): "fake-token",
+	}}
+	tokenProvider := NewOpenAITokenProvider(repo, tokenCache, nil)
+
+	var requestCount atomic.Int32
+	var resetCreditCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.Header().Set("content-type", "application/json")
+		switch r.URL.Path {
+		case "/backend-api/wham/usage":
+			_ = json.NewEncoder(w).Encode(availableOpenAIQuotaUsage())
+		case "/backend-api/wham/rate-limit-reset-credits":
+			resetCreditCount.Add(1)
+			_, _ = w.Write([]byte(`{"credits":[]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc := NewOpenAIQuotaService(repo, nil, tokenProvider, newQuotaRedirectingFactory(srv))
+	usage, err := svc.QueryUsageForReconciliation(ctx, 100)
+	require.NoError(t, err)
+	require.True(t, openAIQuotaUsageConfirmsAvailable(usage))
+	require.Equal(t, int32(1), requestCount.Load())
+	require.Zero(t, resetCreditCount.Load())
 }

--- a/backend/internal/service/openai_rate_limit_reconciler_service.go
+++ b/backend/internal/service/openai_rate_limit_reconciler_service.go
@@ -1,0 +1,424 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/google/uuid"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	openAIRateLimitReconcileLeaderLockKey  = "openai:rate-limit:reconcile:leader"
+	openAIRateLimitReconcileOverscanFactor = 4
+	openAIRateLimitReconcileLockGrace      = 30 * time.Second
+)
+
+var errOpenAIRateLimitReconcileRepositoryUnavailable = errors.New("openai rate-limit reconciliation repository is unavailable")
+
+// OpenAIQuotaUsageQuerier is the narrow read-only quota surface required by the
+// reconciler. The concrete implementation calls ChatGPT's /backend-api/wham/usage.
+type OpenAIQuotaUsageQuerier interface {
+	QueryUsageForReconciliation(ctx context.Context, accountID int64) (*OpenAIQuotaUsage, error)
+}
+
+// OpenAIRateLimitRecoveryRepository exposes bounded candidate selection and an
+// exact-generation compare-and-clear mutation.
+type OpenAIRateLimitRecoveryRepository interface {
+	ListOpenAIRateLimitRecoveryCandidates(ctx context.Context, now time.Time, limit int) ([]Account, error)
+	ClearOpenAIRateLimitIfObserved(
+		ctx context.Context,
+		accountID int64,
+		observedRateLimitedAt time.Time,
+		observedResetAt time.Time,
+	) (bool, error)
+}
+
+// OpenAIRateLimitRecoveryRuntimeBlocker protects the process-local scheduling
+// fast path with an opaque generation, so a concurrent 429 always wins.
+type OpenAIRateLimitRecoveryRuntimeBlocker interface {
+	AccountSchedulingBlockGeneration(accountID int64) uint64
+	ClearAccountSchedulingBlockIfGeneration(accountID int64, observedGeneration uint64) bool
+}
+
+// OpenAIRateLimitReconcilerService periodically verifies future-dated,
+// account-level OpenAI OAuth rate limits against the authoritative quota
+// endpoint. It never sends model traffic and never clears independent blocks.
+type OpenAIRateLimitReconcilerService struct {
+	accountRepo    AccountRepository
+	quotaQuerier   OpenAIQuotaUsageQuerier
+	runtimeBlocker OpenAIRateLimitRecoveryRuntimeBlocker
+	cfg            config.GatewayOpenAIRateLimitReconcileConfig
+
+	parentCtx    context.Context
+	parentCancel context.CancelFunc
+	wg           sync.WaitGroup
+	mu           sync.Mutex
+	cycleMu      sync.Mutex
+	started      bool
+	stopped      bool
+
+	lockCache  LeaderLockCache
+	db         *sql.DB
+	instanceID string
+	now        func() time.Time
+}
+
+func NewOpenAIRateLimitReconcilerService(
+	accountRepo AccountRepository,
+	quotaQuerier OpenAIQuotaUsageQuerier,
+	runtimeBlocker OpenAIRateLimitRecoveryRuntimeBlocker,
+	cfg *config.Config,
+) *OpenAIRateLimitReconcilerService {
+	reconcileCfg := config.GatewayOpenAIRateLimitReconcileConfig{
+		IntervalSeconds:     300,
+		MaxAccountsPerCycle: 20,
+		Concurrency:         2,
+	}
+	if cfg != nil {
+		reconcileCfg = cfg.Gateway.OpenAIRateLimitReconcile
+	}
+	normalizeOpenAIRateLimitReconcileConfig(&reconcileCfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	return &OpenAIRateLimitReconcilerService{
+		accountRepo:    accountRepo,
+		quotaQuerier:   quotaQuerier,
+		runtimeBlocker: runtimeBlocker,
+		cfg:            reconcileCfg,
+		parentCtx:      ctx,
+		parentCancel:   cancel,
+		instanceID:     uuid.NewString(),
+		now:            time.Now,
+	}
+}
+
+func normalizeOpenAIRateLimitReconcileConfig(cfg *config.GatewayOpenAIRateLimitReconcileConfig) {
+	if cfg.IntervalSeconds <= 0 {
+		cfg.IntervalSeconds = 300
+	}
+	if cfg.MaxAccountsPerCycle <= 0 {
+		cfg.MaxAccountsPerCycle = 20
+	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = 2
+	}
+}
+
+func (s *OpenAIRateLimitReconcilerService) SetLeaderLock(lockCache LeaderLockCache, db *sql.DB) {
+	if s == nil {
+		return
+	}
+	s.lockCache = lockCache
+	s.db = db
+}
+
+func (s *OpenAIRateLimitReconcilerService) Start() {
+	if s == nil || !s.cfg.Enabled {
+		return
+	}
+	s.mu.Lock()
+	if s.started || s.stopped {
+		s.mu.Unlock()
+		return
+	}
+	s.started = true
+	s.wg.Add(1)
+	s.mu.Unlock()
+
+	go s.runLoop()
+	slog.Info("openai_rate_limit_reconciler_started",
+		"interval_seconds", s.cfg.IntervalSeconds,
+		"max_accounts_per_cycle", s.cfg.MaxAccountsPerCycle,
+		"concurrency", s.cfg.Concurrency,
+	)
+}
+
+func (s *OpenAIRateLimitReconcilerService) Stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if !s.stopped {
+		s.stopped = true
+		s.parentCancel()
+	}
+	s.mu.Unlock()
+	s.wg.Wait()
+}
+
+func (s *OpenAIRateLimitReconcilerService) runLoop() {
+	defer s.wg.Done()
+	if err := s.RunOnce(s.parentCtx); err != nil && s.parentCtx.Err() == nil {
+		slog.Warn("openai_rate_limit_reconcile_cycle_failed", "error", err)
+	}
+
+	ticker := time.NewTicker(s.interval())
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.parentCtx.Done():
+			return
+		case <-ticker.C:
+			if err := s.RunOnce(s.parentCtx); err != nil && s.parentCtx.Err() == nil {
+				slog.Warn("openai_rate_limit_reconcile_cycle_failed", "error", err)
+			}
+		}
+	}
+}
+
+// RunOnce executes one bounded scheduled cycle. It is exported for deterministic
+// tests and operational diagnostics; the feature switch still applies.
+func (s *OpenAIRateLimitReconcilerService) RunOnce(ctx context.Context) error {
+	if s == nil || !s.cfg.Enabled || s.accountRepo == nil || s.quotaQuerier == nil {
+		return nil
+	}
+	recoveryRepo, ok := s.accountRepo.(OpenAIRateLimitRecoveryRepository)
+	if !ok {
+		return errOpenAIRateLimitReconcileRepositoryUnavailable
+	}
+
+	s.cycleMu.Lock()
+	defer s.cycleMu.Unlock()
+
+	now := s.currentTime()
+	release, acquired := s.acquireCycleLeadership(ctx, now)
+	if !acquired {
+		return nil
+	}
+	defer release()
+
+	queryLimit := s.cfg.MaxAccountsPerCycle * openAIRateLimitReconcileOverscanFactor
+	accounts, err := recoveryRepo.ListOpenAIRateLimitRecoveryCandidates(ctx, now, queryLimit)
+	if err != nil {
+		return fmt.Errorf("list OpenAI rate-limit recovery candidates: %w", err)
+	}
+
+	eligible := make([]Account, 0, min(len(accounts), s.cfg.MaxAccountsPerCycle))
+	for i := range accounts {
+		if shouldProbeOpenAIRateLimitRecovery(&accounts[i], now) {
+			eligible = append(eligible, accounts[i])
+			if len(eligible) == s.cfg.MaxAccountsPerCycle {
+				break
+			}
+		}
+	}
+
+	var group errgroup.Group
+	group.SetLimit(s.cfg.Concurrency)
+	for i := range eligible {
+		account := eligible[i]
+		group.Go(func() error {
+			s.reconcileAccount(ctx, recoveryRepo, &account)
+			return nil
+		})
+	}
+	return group.Wait()
+}
+
+func (s *OpenAIRateLimitReconcilerService) acquireCycleLeadership(ctx context.Context, now time.Time) (func(), bool) {
+	lockCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	runRelease, acquired := tryAcquireSingletonLeaderLock(
+		lockCtx,
+		s.lockCache,
+		s.db,
+		openAIRateLimitReconcileLeaderLockKey,
+		s.instanceID,
+		s.lockTTL(),
+	)
+	if !acquired {
+		return nil, false
+	}
+
+	cadenceKey := fmt.Sprintf("%s:%d", openAIRateLimitReconcileLeaderLockKey, now.Unix()/int64(s.interval()/time.Second))
+	cadenceRelease, acquired := tryAcquireSingletonLeaderLock(
+		lockCtx,
+		s.lockCache,
+		s.db,
+		cadenceKey,
+		s.instanceID,
+		s.lockTTL(),
+	)
+	if !acquired {
+		runRelease()
+		return nil, false
+	}
+
+	nextBoundary := now.Truncate(s.interval()).Add(s.interval())
+	return func() {
+		runRelease()
+		releaseOpenAIRateLimitCadenceLock(cadenceRelease, nextBoundary)
+	}, true
+}
+
+func releaseOpenAIRateLimitCadenceLock(release func(), releaseAt time.Time) {
+	if release == nil {
+		return
+	}
+	delay := time.Until(releaseAt)
+	if delay <= 0 {
+		release()
+		return
+	}
+	time.AfterFunc(delay, release)
+}
+
+func (s *OpenAIRateLimitReconcilerService) reconcileAccount(
+	ctx context.Context,
+	recoveryRepo OpenAIRateLimitRecoveryRepository,
+	observed *Account,
+) {
+	if observed == nil || observed.RateLimitedAt == nil || observed.RateLimitResetAt == nil {
+		return
+	}
+	runtimeGeneration := uint64(0)
+	if s.runtimeBlocker != nil {
+		runtimeGeneration = s.runtimeBlocker.AccountSchedulingBlockGeneration(observed.ID)
+	}
+
+	usage, err := s.quotaQuerier.QueryUsageForReconciliation(ctx, observed.ID)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.Debug("openai_rate_limit_reconcile_probe_failed", "account_id", observed.ID, "error", err)
+		}
+		return
+	}
+	if !openAIQuotaUsageConfirmsAvailable(usage) {
+		return
+	}
+
+	cleared, err := recoveryRepo.ClearOpenAIRateLimitIfObserved(
+		ctx,
+		observed.ID,
+		*observed.RateLimitedAt,
+		*observed.RateLimitResetAt,
+	)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.Warn("openai_rate_limit_reconcile_clear_failed", "account_id", observed.ID, "error", err)
+		}
+		return
+	}
+	if !cleared {
+		return
+	}
+
+	if s.runtimeBlocker != nil &&
+		!s.runtimeBlocker.ClearAccountSchedulingBlockIfGeneration(observed.ID, runtimeGeneration) {
+		slog.Info("openai_rate_limit_reconcile_runtime_clear_skipped_newer_block", "account_id", observed.ID)
+		return
+	}
+	slog.Info("openai_rate_limit_reconciled",
+		"account_id", observed.ID,
+		"previous_reset_at", observed.RateLimitResetAt.UTC(),
+		"quota_fetched_at", usage.FetchedAt,
+	)
+}
+
+func (s *OpenAIRateLimitReconcilerService) interval() time.Duration {
+	return time.Duration(s.cfg.IntervalSeconds) * time.Second
+}
+
+func (s *OpenAIRateLimitReconcilerService) lockTTL() time.Duration {
+	batches := (s.cfg.MaxAccountsPerCycle + s.cfg.Concurrency - 1) / s.cfg.Concurrency
+	worstCase := time.Duration(batches) * openaiQuotaUpstreamTimeout
+	ttl := worstCase + openAIRateLimitReconcileLockGrace
+	if minimum := s.interval() + openAIRateLimitReconcileLockGrace; ttl < minimum {
+		ttl = minimum
+	}
+	return ttl
+}
+
+func (s *OpenAIRateLimitReconcilerService) currentTime() time.Time {
+	if s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+func shouldProbeOpenAIRateLimitRecovery(account *Account, now time.Time) bool {
+	if account == nil ||
+		account.Platform != PlatformOpenAI ||
+		account.Type != AccountTypeOAuth ||
+		account.IsShadow() ||
+		account.Status != StatusActive ||
+		!account.Schedulable ||
+		account.RateLimitedAt == nil ||
+		account.RateLimitResetAt == nil ||
+		!now.Before(*account.RateLimitResetAt) {
+		return false
+	}
+	if account.AutoPauseOnExpired && account.ExpiresAt != nil && !now.Before(*account.ExpiresAt) {
+		return false
+	}
+	if account.OverloadUntil != nil && now.Before(*account.OverloadUntil) {
+		return false
+	}
+	if account.TempUnschedulableUntil != nil && now.Before(*account.TempUnschedulableUntil) {
+		return false
+	}
+	return !hasActiveModelRateLimitAt(account, now)
+}
+
+func hasActiveModelRateLimitAt(account *Account, now time.Time) bool {
+	if account == nil || account.Extra == nil {
+		return false
+	}
+	rawLimits, ok := account.Extra[modelRateLimitsKey]
+	if !ok || rawLimits == nil {
+		return false
+	}
+	limits, ok := rawLimits.(map[string]any)
+	if !ok {
+		// Unknown persisted shapes fail closed instead of weakening a separate
+		// scheduler guard.
+		return true
+	}
+	for _, rawLimit := range limits {
+		limit, ok := rawLimit.(map[string]any)
+		if !ok {
+			return true
+		}
+		resetAtRaw, ok := limit["rate_limit_reset_at"].(string)
+		if !ok {
+			return true
+		}
+		resetAt, err := time.Parse(time.RFC3339, resetAtRaw)
+		if err != nil {
+			return true
+		}
+		if now.Before(resetAt) {
+			return true
+		}
+	}
+	return false
+}
+
+func openAIQuotaUsageConfirmsAvailable(usage *OpenAIQuotaUsage) bool {
+	if usage == nil || usage.RateLimit == nil {
+		return false
+	}
+	limit := usage.RateLimit
+	if !limit.Allowed || limit.LimitReached {
+		return false
+	}
+
+	windowCount := 0
+	for _, window := range []*OpenAIRateLimitWindow{limit.PrimaryWindow, limit.SecondaryWindow} {
+		if window == nil {
+			continue
+		}
+		windowCount++
+		if window.UsedPercent < 0 || window.UsedPercent >= 100 {
+			return false
+		}
+	}
+	return windowCount > 0
+}

--- a/backend/internal/service/openai_rate_limit_reconciler_service_test.go
+++ b/backend/internal/service/openai_rate_limit_reconciler_service_test.go
@@ -1,0 +1,385 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+type openAIRateLimitReconcileRepo struct {
+	AccountRepository
+	mu         sync.Mutex
+	accounts   map[int64]*Account
+	listErr    error
+	clearErr   error
+	clearCalls int
+}
+
+func (r *openAIRateLimitReconcileRepo) ListOpenAIRateLimitRecoveryCandidates(_ context.Context, _ time.Time, limit int) ([]Account, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.listErr != nil {
+		return nil, r.listErr
+	}
+	result := make([]Account, 0, min(limit, len(r.accounts)))
+	for id := int64(1); len(result) < limit; id++ {
+		account, ok := r.accounts[id]
+		if !ok {
+			if id > 10000 {
+				break
+			}
+			continue
+		}
+		result = append(result, cloneOpenAIRateLimitReconcileAccount(account))
+	}
+	return result, nil
+}
+
+func (r *openAIRateLimitReconcileRepo) ClearOpenAIRateLimitIfObserved(
+	_ context.Context,
+	accountID int64,
+	observedRateLimitedAt time.Time,
+	observedResetAt time.Time,
+) (bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.clearCalls++
+	if r.clearErr != nil {
+		return false, r.clearErr
+	}
+	account := r.accounts[accountID]
+	if account == nil || account.RateLimitedAt == nil || account.RateLimitResetAt == nil ||
+		!account.RateLimitedAt.Equal(observedRateLimitedAt) ||
+		!account.RateLimitResetAt.Equal(observedResetAt) {
+		return false, nil
+	}
+	account.RateLimitedAt = nil
+	account.RateLimitResetAt = nil
+	return true, nil
+}
+
+func cloneOpenAIRateLimitReconcileAccount(account *Account) Account {
+	copy := *account
+	if account.Extra != nil {
+		copy.Extra = make(map[string]any, len(account.Extra))
+		for key, value := range account.Extra {
+			copy.Extra[key] = value
+		}
+	}
+	return copy
+}
+
+type openAIRateLimitQuotaQuerierStub struct {
+	mu        sync.Mutex
+	usage     *OpenAIQuotaUsage
+	err       error
+	onQuery   func(int64)
+	queried   []int64
+	started   chan struct{}
+	continueC chan struct{}
+}
+
+func (q *openAIRateLimitQuotaQuerierStub) QueryUsageForReconciliation(_ context.Context, accountID int64) (*OpenAIQuotaUsage, error) {
+	q.mu.Lock()
+	q.queried = append(q.queried, accountID)
+	started := q.started
+	continueC := q.continueC
+	onQuery := q.onQuery
+	q.mu.Unlock()
+	if onQuery != nil {
+		onQuery(accountID)
+	}
+	if started != nil {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	}
+	if continueC != nil {
+		<-continueC
+	}
+	return q.usage, q.err
+}
+
+func (q *openAIRateLimitQuotaQuerierStub) queriedIDs() []int64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return append([]int64(nil), q.queried...)
+}
+
+type openAIRateLimitRuntimeBlockerStub struct {
+	mu         sync.Mutex
+	generation map[int64]uint64
+	clearCalls int
+}
+
+func (b *openAIRateLimitRuntimeBlockerStub) AccountSchedulingBlockGeneration(accountID int64) uint64 {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.generation[accountID]
+}
+
+func (b *openAIRateLimitRuntimeBlockerStub) ClearAccountSchedulingBlockIfGeneration(accountID int64, observedGeneration uint64) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.generation[accountID] != observedGeneration {
+		return false
+	}
+	b.clearCalls++
+	b.generation[accountID]++
+	return true
+}
+
+func (b *openAIRateLimitRuntimeBlockerStub) installNewBlock(accountID int64) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.generation[accountID]++
+}
+
+type openAIRateLimitLeaderLockStub struct {
+	mu    sync.Mutex
+	owner map[string]string
+}
+
+func (c *openAIRateLimitLeaderLockStub) TryAcquireLeaderLock(_ context.Context, key, owner string, _ time.Duration) (bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.owner == nil {
+		c.owner = make(map[string]string)
+	}
+	if _, exists := c.owner[key]; exists {
+		return false, nil
+	}
+	c.owner[key] = owner
+	return true, nil
+}
+
+func (c *openAIRateLimitLeaderLockStub) ReleaseLeaderLock(_ context.Context, key, owner string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.owner[key] == owner {
+		delete(c.owner, key)
+	}
+	return nil
+}
+
+func availableOpenAIQuotaUsage() *OpenAIQuotaUsage {
+	return &OpenAIQuotaUsage{
+		FetchedAt: time.Now().Unix(),
+		RateLimit: &OpenAIRateLimit{
+			Allowed:      true,
+			LimitReached: false,
+			PrimaryWindow: &OpenAIRateLimitWindow{
+				UsedPercent:        20,
+				LimitWindowSeconds: 18000,
+			},
+			SecondaryWindow: &OpenAIRateLimitWindow{
+				UsedPercent:        40,
+				LimitWindowSeconds: 604800,
+			},
+		},
+	}
+}
+
+func rateLimitedOpenAIAccount(id int64, now time.Time) *Account {
+	rateLimitedAt := now.Add(-time.Hour)
+	resetAt := now.Add(4 * 24 * time.Hour)
+	return &Account{
+		ID:               id,
+		Platform:         PlatformOpenAI,
+		Type:             AccountTypeOAuth,
+		Status:           StatusActive,
+		Schedulable:      true,
+		RateLimitedAt:    &rateLimitedAt,
+		RateLimitResetAt: &resetAt,
+	}
+}
+
+func enabledOpenAIRateLimitReconcileConfig(maxAccounts, concurrency int) *config.Config {
+	return &config.Config{Gateway: config.GatewayConfig{
+		OpenAIRateLimitReconcile: config.GatewayOpenAIRateLimitReconcileConfig{
+			Enabled:             true,
+			IntervalSeconds:     300,
+			MaxAccountsPerCycle: maxAccounts,
+			Concurrency:         concurrency,
+		},
+	}}
+}
+
+func TestOpenAIQuotaUsageConfirmsAvailable(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage *OpenAIQuotaUsage
+		want  bool
+	}{
+		{name: "fresh available quota", usage: availableOpenAIQuotaUsage(), want: true},
+		{name: "missing rate limit", usage: &OpenAIQuotaUsage{}, want: false},
+		{name: "allowed without windows is insufficient", usage: &OpenAIQuotaUsage{
+			RateLimit: &OpenAIRateLimit{Allowed: true},
+		}},
+		{name: "upstream denies requests", usage: &OpenAIQuotaUsage{
+			RateLimit: &OpenAIRateLimit{Allowed: false, PrimaryWindow: &OpenAIRateLimitWindow{UsedPercent: 0}},
+		}},
+		{name: "limit reached flag wins", usage: &OpenAIQuotaUsage{
+			RateLimit: &OpenAIRateLimit{Allowed: true, LimitReached: true, PrimaryWindow: &OpenAIRateLimitWindow{UsedPercent: 0}},
+		}},
+		{name: "any exhausted window blocks recovery", usage: &OpenAIQuotaUsage{
+			RateLimit: &OpenAIRateLimit{
+				Allowed:         true,
+				PrimaryWindow:   &OpenAIRateLimitWindow{UsedPercent: 20},
+				SecondaryWindow: &OpenAIRateLimitWindow{UsedPercent: 100},
+			},
+		}},
+		{name: "negative usage is insufficient", usage: &OpenAIQuotaUsage{
+			RateLimit: &OpenAIRateLimit{Allowed: true, PrimaryWindow: &OpenAIRateLimitWindow{UsedPercent: -1}},
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, openAIQuotaUsageConfirmsAvailable(tt.usage))
+		})
+	}
+}
+
+func TestOpenAIRateLimitReconcilerIsOptIn(t *testing.T) {
+	now := time.Now()
+	repo := &openAIRateLimitReconcileRepo{accounts: map[int64]*Account{1: rateLimitedOpenAIAccount(1, now)}}
+	querier := &openAIRateLimitQuotaQuerierStub{usage: availableOpenAIQuotaUsage()}
+	service := NewOpenAIRateLimitReconcilerService(repo, querier, nil, &config.Config{})
+
+	require.NoError(t, service.RunOnce(context.Background()))
+	require.Empty(t, querier.queriedIDs())
+	require.NotNil(t, repo.accounts[1].RateLimitResetAt)
+}
+
+func TestOpenAIRateLimitReconcilerRecoversOnlyEligibleAccounts(t *testing.T) {
+	now := time.Now()
+	eligible := rateLimitedOpenAIAccount(1, now)
+	healthy := rateLimitedOpenAIAccount(2, now)
+	healthy.RateLimitedAt = nil
+	healthy.RateLimitResetAt = nil
+	apiKey := rateLimitedOpenAIAccount(3, now)
+	apiKey.Type = AccountTypeAPIKey
+	modelLimited := rateLimitedOpenAIAccount(4, now)
+	modelLimited.Extra = map[string]any{
+		modelRateLimitsKey: map[string]any{
+			"gpt-5.4": map[string]any{"rate_limit_reset_at": now.Add(time.Hour).Format(time.RFC3339)},
+		},
+	}
+	expiredModelLimit := rateLimitedOpenAIAccount(5, now)
+	expiredModelLimit.Extra = map[string]any{
+		modelRateLimitsKey: map[string]any{
+			"gpt-5.4": map[string]any{"rate_limit_reset_at": now.Add(-time.Hour).Format(time.RFC3339)},
+		},
+	}
+	malformedModelLimit := rateLimitedOpenAIAccount(6, now)
+	malformedModelLimit.Extra = map[string]any{
+		modelRateLimitsKey: map[string]any{
+			"gpt-5.4": map[string]any{"rate_limit_reset_at": "not-a-timestamp"},
+		},
+	}
+	repo := &openAIRateLimitReconcileRepo{accounts: map[int64]*Account{
+		1: eligible,
+		2: healthy,
+		3: apiKey,
+		4: modelLimited,
+		5: expiredModelLimit,
+		6: malformedModelLimit,
+	}}
+	querier := &openAIRateLimitQuotaQuerierStub{usage: availableOpenAIQuotaUsage()}
+	blocker := &openAIRateLimitRuntimeBlockerStub{generation: map[int64]uint64{1: 7, 5: 9}}
+	service := NewOpenAIRateLimitReconcilerService(repo, querier, blocker, enabledOpenAIRateLimitReconcileConfig(20, 2))
+
+	require.NoError(t, service.RunOnce(context.Background()))
+	require.ElementsMatch(t, []int64{1, 5}, querier.queriedIDs())
+	require.Equal(t, 2, repo.clearCalls)
+	require.Equal(t, 2, blocker.clearCalls)
+	require.Nil(t, repo.accounts[1].RateLimitResetAt)
+	require.NotNil(t, repo.accounts[4].RateLimitResetAt)
+}
+
+func TestOpenAIRateLimitReconcilerDoesNotClearExhaustedQuota(t *testing.T) {
+	now := time.Now()
+	account := rateLimitedOpenAIAccount(1, now)
+	usage := availableOpenAIQuotaUsage()
+	usage.RateLimit.PrimaryWindow.UsedPercent = 100
+	usage.RateLimit.LimitReached = true
+	repo := &openAIRateLimitReconcileRepo{accounts: map[int64]*Account{1: account}}
+	blocker := &openAIRateLimitRuntimeBlockerStub{generation: map[int64]uint64{1: 3}}
+	service := NewOpenAIRateLimitReconcilerService(
+		repo,
+		&openAIRateLimitQuotaQuerierStub{usage: usage},
+		blocker,
+		enabledOpenAIRateLimitReconcileConfig(20, 2),
+	)
+
+	require.NoError(t, service.RunOnce(context.Background()))
+	require.Zero(t, repo.clearCalls)
+	require.Zero(t, blocker.clearCalls)
+	require.NotNil(t, repo.accounts[1].RateLimitResetAt)
+}
+
+func TestOpenAIRateLimitReconcilerConcurrent429WinsBothCASGuards(t *testing.T) {
+	now := time.Now()
+	account := rateLimitedOpenAIAccount(1, now)
+	repo := &openAIRateLimitReconcileRepo{accounts: map[int64]*Account{1: account}}
+	blocker := &openAIRateLimitRuntimeBlockerStub{generation: map[int64]uint64{1: 11}}
+	querier := &openAIRateLimitQuotaQuerierStub{usage: availableOpenAIQuotaUsage()}
+	querier.onQuery = func(accountID int64) {
+		blocker.installNewBlock(accountID)
+		repo.mu.Lock()
+		newLimitedAt := time.Now()
+		newResetAt := time.Now().Add(7 * 24 * time.Hour)
+		repo.accounts[accountID].RateLimitedAt = &newLimitedAt
+		repo.accounts[accountID].RateLimitResetAt = &newResetAt
+		repo.mu.Unlock()
+	}
+	service := NewOpenAIRateLimitReconcilerService(repo, querier, blocker, enabledOpenAIRateLimitReconcileConfig(20, 2))
+
+	require.NoError(t, service.RunOnce(context.Background()))
+	require.Equal(t, 1, repo.clearCalls)
+	require.Zero(t, blocker.clearCalls)
+	require.NotNil(t, repo.accounts[1].RateLimitResetAt)
+}
+
+func TestOpenAIRateLimitReconcilerOnlyOneInstanceRunsPerCadence(t *testing.T) {
+	now := time.Now()
+	repo := &openAIRateLimitReconcileRepo{accounts: map[int64]*Account{1: rateLimitedOpenAIAccount(1, now)}}
+	querier := &openAIRateLimitQuotaQuerierStub{
+		usage:     availableOpenAIQuotaUsage(),
+		started:   make(chan struct{}, 1),
+		continueC: make(chan struct{}),
+	}
+	cache := &openAIRateLimitLeaderLockStub{}
+	first := NewOpenAIRateLimitReconcilerService(repo, querier, nil, enabledOpenAIRateLimitReconcileConfig(20, 2))
+	second := NewOpenAIRateLimitReconcilerService(repo, querier, nil, enabledOpenAIRateLimitReconcileConfig(20, 2))
+	first.SetLeaderLock(cache, nil)
+	second.SetLeaderLock(cache, nil)
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- first.RunOnce(context.Background()) }()
+	<-querier.started
+
+	require.NoError(t, second.RunOnce(context.Background()))
+	close(querier.continueC)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, second.RunOnce(context.Background()))
+	require.Equal(t, []int64{1}, querier.queriedIDs())
+}
+
+func TestOpenAIRateLimitReconcilerPropagatesCandidateListFailure(t *testing.T) {
+	repo := &openAIRateLimitReconcileRepo{listErr: errors.New("database unavailable")}
+	service := NewOpenAIRateLimitReconcilerService(
+		repo,
+		&openAIRateLimitQuotaQuerierStub{usage: availableOpenAIQuotaUsage()},
+		nil,
+		enabledOpenAIRateLimitReconcileConfig(20, 2),
+	)
+	require.ErrorContains(t, service.RunOnce(context.Background()), "database unavailable")
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -1123,20 +1123,10 @@ func calculateOpenAI429ResetTime(headers http.Header) *time.Time {
 		return &resetAt
 	}
 
-	// 都未达到100%但收到429，使用较长的重置时间
-	var maxResetSecs int
-	if normalized.Reset7dSeconds != nil && *normalized.Reset7dSeconds > maxResetSecs {
-		maxResetSecs = *normalized.Reset7dSeconds
-	}
-	if normalized.Reset5hSeconds != nil && *normalized.Reset5hSeconds > maxResetSecs {
-		maxResetSecs = *normalized.Reset5hSeconds
-	}
-	if maxResetSecs > 0 {
-		resetAt := now.Add(time.Duration(maxResetSecs) * time.Second)
-		slog.Info("openai_429_using_max_reset", "max_reset_seconds", maxResetSecs, "reset_at", resetAt)
-		return &resetAt
-	}
-
+	// Neither quota window is exhausted. This is commonly a transient RPM/TPM
+	// burst 429; using the 5h/7d window reset would incorrectly hide an account
+	// for hours or days. Return nil so the caller uses the bounded fallback
+	// cooldown instead.
 	return nil
 }
 

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -73,10 +73,11 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 	}
 }
 
-func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
+func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesFallback(t *testing.T) {
 	svc := &RateLimitService{}
 
-	// Neither limit at 100%, should use the longer reset time
+	// Neither quota window is exhausted. The 429 can be a short RPM/TPM burst,
+	// so the long quota reset values must not become the account cooldown.
 	headers := http.Header{}
 	headers.Set("x-codex-primary-used-percent", "80")
 	headers.Set("x-codex-primary-reset-after-seconds", "100000")
@@ -85,21 +86,9 @@ func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
 	headers.Set("x-codex-secondary-reset-after-seconds", "5000")
 	headers.Set("x-codex-secondary-window-minutes", "300")
 
-	before := time.Now()
 	resetAt := svc.calculateOpenAI429ResetTime(headers)
-	after := time.Now()
-
-	if resetAt == nil {
-		t.Fatal("expected non-nil resetAt")
-	}
-
-	// Should use the max (100000 seconds from 7d window)
-	expectedDuration := 100000 * time.Second
-	minExpected := before.Add(expectedDuration)
-	maxExpected := after.Add(expectedDuration)
-
-	if resetAt.Before(minExpected) || resetAt.After(maxExpected) {
-		t.Errorf("resetAt %v not in expected range [%v, %v]", resetAt, minExpected, maxExpected)
+	if resetAt != nil {
+		t.Fatalf("expected nil so caller uses bounded fallback cooldown, got %v", resetAt)
 	}
 }
 

--- a/backend/internal/service/wire.go
+++ b/backend/internal/service/wire.go
@@ -139,6 +139,20 @@ func ProvideOpenAIQuotaService(
 	return service
 }
 
+func ProvideOpenAIRateLimitReconcilerService(
+	accountRepo AccountRepository,
+	openAIQuotaService *OpenAIQuotaService,
+	openAIGatewayService *OpenAIGatewayService,
+	cfg *config.Config,
+	lockCache LeaderLockCache,
+	db *sql.DB,
+) *OpenAIRateLimitReconcilerService {
+	service := NewOpenAIRateLimitReconcilerService(accountRepo, openAIQuotaService, openAIGatewayService, cfg)
+	service.SetLeaderLock(lockCache, db)
+	service.Start()
+	return service
+}
+
 func ProvideAccountUsageService(
 	accountRepo AccountRepository,
 	usageLogRepo UsageLogRepository,
@@ -720,6 +734,7 @@ var ProviderSet = wire.NewSet(
 	ProvideGrokTokenProvider,
 	ProvideOpenAITokenProvider,
 	ProvideOpenAIQuotaService,
+	ProvideOpenAIRateLimitReconcilerService,
 	ProvideGrokQuotaService,
 	ProvideClaudeTokenProvider,
 	NewAntigravityGatewayService,

--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -311,6 +311,22 @@ gateway:
   # Use this to avoid compact failures when newer models are not yet supported by the compact endpoint.
   # 当 compact 端点暂未支持更新模型时，可通过这里降级规避失败。
   openai_compact_model: "gpt-5.4"
+  # Opt-in reconciliation for OpenAI OAuth accounts whose persisted 429 window
+  # is still in the future even though /backend-api/wham/usage reports capacity.
+  # OpenAI OAuth 账号陈旧 429 状态自动纠偏（默认关闭，避免额外上游请求）。
+  # Environment override example:
+  # GATEWAY_OPENAI_RATE_LIMIT_RECONCILE_ENABLED=true
+  openai_rate_limit_reconcile:
+    enabled: false
+    # Minimum 60 seconds. One leader instance runs each cycle.
+    # 最小 60 秒；多实例部署中每轮仅一个 Leader 执行。
+    interval_seconds: 300
+    # Maximum authoritative quota probes per cycle (1-500).
+    # 每轮最多探测的候选账号数（1-500）。
+    max_accounts_per_cycle: 20
+    # Concurrent read-only quota probes (1-20).
+    # 只读额度探测并发数（1-20）。
+    concurrency: 2
   # ChatGPT Frameless Live 单会话硬上限（秒）。
   live:
     max_session_duration_seconds: 3600


### PR DESCRIPTION
## Summary

- avoid turning transient OpenAI 429s into 5h/7d account blocks when neither quota window is exhausted
- add an opt-in background reconciler for stale OpenAI OAuth account-level rate limits
- verify recovery with one read-only `/backend-api/wham/usage` request per candidate (no model traffic and no reset-credit request)
- protect recovery with exact persisted-state CAS plus a process-local runtime-block generation guard, so a concurrent newer 429 always wins
- coordinate cycles across instances through the existing Redis leader lock with PostgreSQL advisory-lock fallback

Fixes #1981.
Fixes #2258.

## Behavior and safety

The worker is disabled by default. When enabled, it considers only active, schedulable, parent OpenAI OAuth accounts whose persisted account-level reset is still in the future. It skips shadow accounts and independent expiry, overload, temporary-unschedulable, or model-level blocks. Recovery requires an authoritative quota response with `allowed=true`, `limit_reached=false`, at least one quota window, and every present window below 100% usage.

Candidate selection, probes, and concurrency are bounded. A compare-and-clear update prevents a stale probe from deleting a newer database 429, and an opaque runtime generation prevents the same race in the scheduler fast path.

~~~yaml
gateway:
  openai_rate_limit_reconcile:
    enabled: false
    interval_seconds: 300
    max_accounts_per_cycle: 20
    concurrency: 2
~~~

The feature can be enabled with `GATEWAY_OPENAI_RATE_LIMIT_RECONCILE_ENABLED=true`.

## Validation

- targeted reconciler, quota, runtime-generation, and 429 fallback unit tests
- repository integration test with PostgreSQL/Redis test containers
- full unit and integration suites (excluding one pre-existing Windows timing test independently reproduced on unchanged `origin/main`)
- `go vet ./...`
- `go build ./cmd/server`
- golangci-lint v2.9: 0 issues
- `git diff --check`