### PR TITLE
fix(frontend): 补充 Claude Sonnet 5 模型状态别名

### DIFF
--- a/frontend/src/components/account/AccountStatusIndicator.vue
+++ b/frontend/src/components/account/AccountStatusIndicator.vue
@@ -229,6 +229,7 @@ const formatScopeName = (scope: string): string => {
     'claude-sonnet-4-6': 'CSon46',
     'claude-sonnet-4-5': 'CSon45',
     'claude-sonnet-4-5-thinking': 'CSon45T',
+    'claude-sonnet-5': 'CSon5',
     // Gemini 2.5 系列
     'gemini-2.5-flash': 'G25F',
     'gemini-2.5-flash-lite': 'G25FL',

--- a/frontend/src/components/account/__tests__/AccountStatusIndicator.spec.ts
+++ b/frontend/src/components/account/__tests__/AccountStatusIndicator.spec.ts
@@ -51,6 +51,36 @@ function makeAccount(overrides: Partial<Account>): Account {
 }
 
 describe('AccountStatusIndicator', () => {
+  it('Claude 5 模型限流时显示 Opus 和 Sonnet 的短别名', () => {
+    const wrapper = mount(AccountStatusIndicator, {
+      props: {
+        account: makeAccount({
+          extra: {
+            model_rate_limits: {
+              'claude-opus-5': {
+                rate_limited_at: '2026-07-28T00:00:00Z',
+                rate_limit_reset_at: '2099-07-28T00:00:00Z'
+              },
+              'claude-sonnet-5': {
+                rate_limited_at: '2026-07-28T00:00:00Z',
+                rate_limit_reset_at: '2099-07-28T00:00:00Z'
+              }
+            }
+          }
+        })
+      },
+      global: {
+        stubs: {
+          Icon: true
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('COpus5')
+    expect(wrapper.text()).toContain('CSon5')
+    expect(wrapper.text()).not.toContain('claude-sonnet-5')
+  })
+
   it('Grok 账号额度限流时显示自动恢复时间而非临时不可调度', () => {
     const wrapper = mount(AccountStatusIndicator, {
       props: {


### PR DESCRIPTION
## 问题

账号列表的模型限流状态会通过短别名展示 Claude 模型。`claude-opus-5` 已映射为 `COpus5`，但 `claude-sonnet-5` 缺少映射，页面会回退显示完整模型 ID。

## 改动

- 新增 `claude-sonnet-5` → `CSon5` 的状态短别名，与现有 `CSon46`、`CSon45` 命名保持一致。
- 补充组件回归测试，同时覆盖 `COpus5` 和 `CSon5` 的展示。

## 验证

- `pnpm test:run src/components/account/__tests__/AccountStatusIndicator.spec.ts`
- `pnpm typecheck`
- `pnpm exec eslint src/components/account/AccountStatusIndicator.vue src/components/account/__tests__/AccountStatusIndicator.spec.ts`
- `git diff --check`