### PR TITLE
fix(vertex): avoid daily lockout for transient service-account 429s

### DIFF
--- a/backend/internal/service/gemini_error_policy_test.go
+++ b/backend/internal/service/gemini_error_policy_test.go
@@ -489,6 +489,97 @@ func TestHandleGeminiUpstreamError_GoogleOneCapacityExhaustedUsesTierCooldown(t 
 	require.True(t, repo.lastRateLimitReset.Before(after.Add(5*time.Minute).Add(2*time.Second)))
 }
 
+func TestHandleGeminiUpstreamError_VertexServiceAccountTransient429UsesConfiguredFallback(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data := `{"enabled":true,"cooldown_seconds":12}`
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = data
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	rlSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rlSvc.SetSettingService(settingSvc)
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: rlSvc,
+	}
+	account := &Account{ID: 512, Platform: PlatformGemini, Type: AccountTypeServiceAccount}
+	body := []byte(`{"error":{"code":429,"message":"Resource exhausted, please try again later","status":"RESOURCE_EXHAUSTED"}}`)
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	after := time.Now()
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.Equal(t, int64(512), repo.lastRateLimitID)
+	require.True(t, !repo.lastRateLimitReset.Before(before.Add(12*time.Second)) && !repo.lastRateLimitReset.After(after.Add(12*time.Second)))
+}
+
+func TestHandleGeminiUpstreamError_VertexServiceAccountTransient429UsesDefaultFallback(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	rlSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: rlSvc,
+	}
+	account := &Account{ID: 513, Platform: PlatformGemini, Type: AccountTypeServiceAccount}
+	body := []byte(`{"error":{"code":429,"message":"Resource exhausted, please try again later","status":"RESOURCE_EXHAUSTED"}}`)
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	after := time.Now()
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.Equal(t, int64(513), repo.lastRateLimitID)
+	require.True(t, !repo.lastRateLimitReset.Before(before.Add(5*time.Second)) && !repo.lastRateLimitReset.After(after.Add(5*time.Second)))
+}
+
+func TestHandleGeminiUpstreamError_VertexServiceAccountTransient429HonorsDisabledFallback(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data := `{"enabled":false,"cooldown_seconds":12}`
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = data
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	rlSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rlSvc.SetSettingService(settingSvc)
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: rlSvc,
+	}
+	account := &Account{ID: 514, Platform: PlatformGemini, Type: AccountTypeServiceAccount}
+	body := []byte(`{"error":{"code":429,"message":"Resource exhausted, please try again later","status":"RESOURCE_EXHAUSTED"}}`)
+
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+
+	require.Zero(t, repo.rateLimitCalls)
+}
+
+func TestHandleGeminiUpstreamError_VertexServiceAccountUsesExplicitResetHint(t *testing.T) {
+	repo := &rateLimit429AccountRepoStub{}
+	settingRepo := newMockSettingRepo()
+	data := `{"enabled":true,"cooldown_seconds":12}`
+	settingRepo.data[SettingKeyRateLimit429CooldownSettings] = data
+
+	settingSvc := NewSettingService(settingRepo, &config.Config{})
+	rlSvc := NewRateLimitService(repo, nil, &config.Config{}, nil, nil)
+	rlSvc.SetSettingService(settingSvc)
+	svc := &GeminiMessagesCompatService{
+		accountRepo:      repo,
+		rateLimitService: rlSvc,
+	}
+	account := &Account{ID: 515, Platform: PlatformGemini, Type: AccountTypeServiceAccount}
+	body := []byte(`{"error":{"code":429,"message":"Please retry in 30s","status":"RESOURCE_EXHAUSTED"}}`)
+
+	before := time.Now()
+	svc.handleGeminiUpstreamError(context.Background(), account, http.StatusTooManyRequests, http.Header{}, body)
+	after := time.Now()
+
+	require.Equal(t, 1, repo.rateLimitCalls)
+	require.Equal(t, int64(515), repo.lastRateLimitID)
+	require.WithinDuration(t, before.Add(30*time.Second), repo.lastRateLimitReset, 2*time.Second)
+	require.True(t, repo.lastRateLimitReset.Before(after.Add(30*time.Second).Add(2*time.Second)))
+}
+
 type geminiErrorPolicyRepo struct {
 	mockAccountRepoForGemini
 	setErrorCalls            int

--- a/backend/internal/service/gemini_messages_compat_service.go
+++ b/backend/internal/service/gemini_messages_compat_service.go
@@ -2936,6 +2936,21 @@ func (s *GeminiMessagesCompatService) handleGeminiUpstreamError(ctx context.Cont
 
 	resetAt := ParseGeminiRateLimitResetTime(body)
 	if resetAt == nil {
+		// Vertex service accounts can return transient RESOURCE_EXHAUSTED errors
+		// without an upstream reset hint. Do not treat those as daily quota
+		// exhaustion: use the configurable short 429 fallback instead.
+		if account.Type == AccountTypeServiceAccount {
+			if s.rateLimitService != nil {
+				s.rateLimitService.apply429FallbackRateLimit(ctx, account, "vertex_service_account_no_reset_time")
+				return
+			}
+
+			ra := time.Now().Add(time.Duration(defaultRateLimit429CooldownSeconds) * time.Second)
+			logger.LegacyPrintf("service.gemini_messages_compat", "[Gemini 429] Vertex service account %d rate limited without reset hint, fallback cooldown=%v", account.ID, time.Until(ra).Truncate(time.Second))
+			_ = s.accountRepo.SetRateLimited(ctx, account.ID, ra)
+			return
+		}
+
 		// 根据账号类型使用不同的默认重置时间
 		var ra time.Time
 		if isCodeAssist || oauthType == "google_one" {


### PR DESCRIPTION
## Summary

- use the existing configurable seconds-level 429 fallback for resetless Vertex service-account `RESOURCE_EXHAUSTED` responses
- keep explicit upstream reset hints and daily-quota handling unchanged
- keep the existing Code Assist, Google One, API key, and AI Studio policies unchanged
- add regression coverage for configured cooldown, the default 5-second cooldown, disabled fallback, and explicit reset hints

## Why

`handleGeminiUpstreamError` currently has no `service_account` branch. When Vertex returns a transient 429 without `quotaResetDelay`, `Please retry in`, or daily-quota text, the account falls through to the API key / AI Studio fallback and is marked rate-limited until the next PST midnight.

That turns a temporary Vertex capacity or rate-limit response into an hours-long local lockout. The generic rate-limit service already has `rate_limit_429_cooldown_settings`, but the Gemini compatibility handler bypasses that fallback for 429 responses.

## Behavior after this change

- Vertex service account with an explicit reset hint: continue using the upstream reset time
- Vertex service account without a reset hint: use `rate_limit_429_cooldown_settings` (enabled with a 5-second default)
- disabled fallback setting: do not add a local rate-limit mark
- other Gemini account types: unchanged

## Relation to existing PRs

- #1254 changes the resetless fallback for Google One OAuth accounts.
- #2408 detects specific model-capacity error text.
- This PR is scoped to Vertex service accounts and covers any resetless transient 429 while reusing the existing administrator-configurable fallback.

## Testing

- `go test -tags=unit ./...`
- `go test -tags=integration ./...`
- `go vet ./...`

All commands passed locally with Go 1.26.5.
