### PR TITLE
feat(admin): show token throughput in usage records

### DIFF
--- a/frontend/src/views/admin/UsageView.vue
+++ b/frontend/src/views/admin/UsageView.vue
@@ -626,6 +626,20 @@ const ALWAYS_VISIBLE = ['user', 'created_at']
 const DEFAULT_HIDDEN_COLUMNS = ['reasoning_effort', 'user_agent']
 const HIDDEN_COLUMNS_KEY = 'usage-hidden-columns'
 
+const formatTokenSpeed = (_value: unknown, row: AdminUsageLog): string => {
+  if (
+    row.image_count > 0
+    || row.image_output_tokens > 0
+    || !Number.isFinite(row.output_tokens)
+    || row.output_tokens <= 0
+    || !Number.isFinite(row.duration_ms)
+    || row.duration_ms == null
+    || row.duration_ms <= 0
+  ) return '-'
+
+  return (row.output_tokens * 1000 / row.duration_ms).toFixed(2)
+}
+
 const allColumns = computed(() => [
   { key: 'user', label: t('admin.usage.user'), sortable: false },
   { key: 'api_key', label: t('usage.apiKeyFilter'), sortable: false },
@@ -637,6 +651,7 @@ const allColumns = computed(() => [
   { key: 'stream', label: t('usage.type'), sortable: false },
   { key: 'billing_mode', label: t('admin.usage.billingMode'), sortable: false },
   { key: 'tokens', label: t('usage.tokens'), sortable: false },
+  { key: 'token_speed', label: 'Token/s', sortable: false, formatter: formatTokenSpeed },
   { key: 'cost', label: t('usage.cost'), sortable: false },
   { key: 'latency', label: t('usage.latency'), sortable: false },
   { key: 'created_at', label: t('usage.time'), sortable: true },

--- a/frontend/src/views/admin/__tests__/UsageView.spec.ts
+++ b/frontend/src/views/admin/__tests__/UsageView.spec.ts
@@ -244,6 +244,27 @@ describe('admin UsageView route filters', () => {
     expect(list).toHaveBeenCalledWith(expect.objectContaining({ user_id: 42 }), expect.anything())
     expect(wrapper.find('[data-test="user-filter-label"]').text()).toBe('42')
   })
+
+  it('includes a dedicated Token/s column with safe output throughput formatting', async () => {
+    const wrapper = mountRouteFilteredUsageView()
+    await flushPromises()
+
+    const column = (wrapper.vm as any).allColumns.find((item: { key: string }) => item.key === 'token_speed')
+    expect(column.label).toBe('Token/s')
+    expect(column.formatter(undefined, { output_tokens: 101, duration_ms: 345, image_count: 0 })).toBe('292.75')
+    for (const row of [
+      { output_tokens: 101, duration_ms: -345, image_count: 0 },
+      { output_tokens: 101, duration_ms: 0, image_count: 0 },
+      { output_tokens: 101, duration_ms: null, image_count: 0 },
+      { output_tokens: 101, duration_ms: Number.POSITIVE_INFINITY, image_count: 0 },
+      { output_tokens: 0, duration_ms: 345, image_count: 0 },
+      { output_tokens: Number.POSITIVE_INFINITY, duration_ms: 345, image_count: 0 },
+      { output_tokens: 101, duration_ms: 345, image_count: 1, billing_mode: 'token' },
+      { output_tokens: 101, duration_ms: 345, image_count: 0, image_output_tokens: 1 },
+    ]) {
+      expect(column.formatter(undefined, row)).toBe('-')
+    }
+  })
 })
 
 describe('admin UsageView distribution metric toggles', () => {


### PR DESCRIPTION
## Summary

- add a dedicated `Token/s` column to the admin usage records table
- calculate output throughput as `output_tokens * 1000 / duration_ms`
- render `-` for invalid/zero durations, non-positive output tokens, and image-generation rows

This is intentionally limited to the admin usage page. It does not change the shared user usage table or the backend/database contract.

## Relation to #4453

#4453 adds throughput inside a shared token detail tooltip. This PR keeps the requested admin record metric as an independently scannable column and avoids changing the shared component.

## Verification

- `pnpm --dir frontend exec vitest run src/views/admin/__tests__/UsageView.spec.ts` (11/11)
- `pnpm --dir frontend exec eslint src/views/admin/UsageView.vue src/views/admin/__tests__/UsageView.spec.ts`
- `pnpm --dir frontend run typecheck`
- `pnpm --dir frontend run build`
- local browser verification on `/admin/usage`, with no console errors

Closes #5012
