### PR TITLE
修复(gateway)：限制断开连接后的上游请求排空时间

### DIFF
--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -183,6 +183,17 @@ func NewHTTPUpstream(cfg *config.Config) service.HTTPUpstream {
 //   - 调用方必须关闭 resp.Body，否则会导致 inFlight 计数泄漏
 //   - inFlight > 0 的客户端不会被淘汰，确保活跃请求不被中断
 func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID int64, accountConcurrency int) (*http.Response, error) {
+	var requestCtx context.Context
+	if req != nil {
+		requestCtx = req.Context()
+	}
+	finishContextOnReturn := true
+	defer func() {
+		if finishContextOnReturn {
+			service.FinishDetachedUpstreamContext(requestCtx)
+		}
+	}()
+
 	applyGrokCLIProxyHeaders(req)
 	if err := s.validateRequestHost(req); err != nil {
 		return nil, err
@@ -219,7 +230,12 @@ func (s *httpUpstreamService) Do(req *http.Request, proxyURL string, accountID i
 	resp.Body = wrapTrackedBody(resp.Body, func() {
 		atomic.AddInt64(&entry.inFlight, -1)
 		atomic.StoreInt64(&entry.lastUsed, time.Now().UnixNano())
+		service.FinishDetachedUpstreamContext(requestCtx)
 	})
+	if resp.Body == nil {
+		service.FinishDetachedUpstreamContext(requestCtx)
+	}
+	finishContextOnReturn = false
 
 	return resp, nil
 }
@@ -237,6 +253,17 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 	if req != nil && req.URL != nil && strings.EqualFold(req.URL.Scheme, "http") {
 		return s.Do(req, proxyURL, accountID, accountConcurrency)
 	}
+	var requestCtx context.Context
+	if req != nil {
+		requestCtx = req.Context()
+	}
+	finishContextOnReturn := true
+	defer func() {
+		if finishContextOnReturn {
+			service.FinishDetachedUpstreamContext(requestCtx)
+		}
+	}()
+
 	applyGrokCLIProxyHeaders(req)
 	upstreamProfile := service.HTTPUpstreamProfileDefault
 	if req != nil {
@@ -278,7 +305,12 @@ func (s *httpUpstreamService) DoWithTLS(req *http.Request, proxyURL string, acco
 	resp.Body = wrapTrackedBody(resp.Body, func() {
 		atomic.AddInt64(&entry.inFlight, -1)
 		atomic.StoreInt64(&entry.lastUsed, time.Now().UnixNano())
+		service.FinishDetachedUpstreamContext(requestCtx)
 	})
+	if resp.Body == nil {
+		service.FinishDetachedUpstreamContext(requestCtx)
+	}
+	finishContextOnReturn = false
 
 	return resp, nil
 }

--- a/backend/internal/service/gateway_service_streaming_test.go
+++ b/backend/internal/service/gateway_service_streaming_test.go
@@ -175,13 +175,26 @@ func TestGatewayService_StreamingKeepaliveKeepsPingForOlderClaudeCodeVersion(t *
 	require.NotContains(t, body, `"delta":{"type":"text_delta","text":""}`)
 }
 
-func TestDetachUpstreamContextIgnoresClientCancel(t *testing.T) {
+func TestDetachUpstreamContextAllowsBoundedDrainAfterClientCancel(t *testing.T) {
 	parent, cancel := context.WithCancel(context.WithValue(context.Background(), upstreamContextTestKey("test-key"), "test-value"))
-	upstreamCtx, release := detachUpstreamContext(parent)
+	upstreamCtx, release := detachUpstreamContextWithDrainGrace(parent, 20*time.Millisecond)
 	defer release()
 
 	cancel()
 
 	require.NoError(t, upstreamCtx.Err())
 	require.Equal(t, "test-value", upstreamCtx.Value(upstreamContextTestKey("test-key")))
+	require.Eventually(t, func() bool {
+		return upstreamCtx.Err() != nil
+	}, time.Second, 10*time.Millisecond)
+	require.ErrorIs(t, upstreamCtx.Err(), context.Canceled)
+}
+
+func TestFinishDetachedUpstreamContextCancelsImmediately(t *testing.T) {
+	upstreamCtx, release := detachUpstreamContextWithDrainGrace(context.Background(), time.Minute)
+	defer release()
+
+	FinishDetachedUpstreamContext(upstreamCtx)
+
+	require.ErrorIs(t, upstreamCtx.Err(), context.Canceled)
 }

--- a/backend/internal/service/gateway_usage_billing.go
+++ b/backend/internal/service/gateway_usage_billing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/config"
@@ -354,7 +355,7 @@ func finalizePostUsageBilling(ctx context.Context, p *postUsageBillingParams, de
 			deps.billingCacheService.IncrementUserPlatformQuotaUsage(p.User.ID, p.Platform, p.Cost.ActualCost)
 			if deps.cfg == nil || !deps.cfg.Database.UserPlatformQuotaFlusherEnabled {
 				// 降级路径:flusher 未启用时保留原有异步直写 DB
-				dbCtx, dbCancel := detachUpstreamContext(ctx)
+				dbCtx, dbCancel := detachedBillingContext(ctx)
 				userID, platform, cost := p.User.ID, p.Platform, p.Cost.ActualCost
 				go func() {
 					defer func() {
@@ -480,6 +481,82 @@ func detachedBillingContext(ctx context.Context) (context.Context, context.Cance
 	return context.WithTimeout(base, postUsageBillingTimeout)
 }
 
+const detachedUpstreamDrainGrace = 2 * time.Minute
+
+type detachedUpstreamContextKey struct{}
+
+type detachedUpstreamContextState struct {
+	mu         sync.Mutex
+	cancel     context.CancelFunc
+	stopParent func() bool
+	timer      *time.Timer
+	finished   bool
+}
+
+func (s *detachedUpstreamContextState) cancelAfter(grace time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.finished {
+		return
+	}
+	if grace <= 0 {
+		s.cancel()
+		return
+	}
+	s.timer = time.AfterFunc(grace, s.cancel)
+}
+
+func (s *detachedUpstreamContextState) finish() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	if s.finished {
+		s.mu.Unlock()
+		return
+	}
+	s.finished = true
+	timer := s.timer
+	stopParent := s.stopParent
+	s.mu.Unlock()
+
+	if stopParent != nil {
+		stopParent()
+	}
+	if timer != nil {
+		timer.Stop()
+	}
+	s.cancel()
+}
+
+func detachUpstreamContextWithDrainGrace(ctx context.Context, grace time.Duration) (context.Context, context.CancelFunc) {
+	if ctx == nil {
+		return context.Background(), func() {}
+	}
+
+	detached, cancel := context.WithCancel(context.WithoutCancel(ctx))
+	state := &detachedUpstreamContextState{cancel: cancel}
+	detached = context.WithValue(detached, detachedUpstreamContextKey{}, state)
+	if ctx.Done() != nil {
+		state.stopParent = context.AfterFunc(ctx, func() {
+			state.cancelAfter(grace)
+		})
+	}
+
+	// HTTPUpstream owns the detached context until the response body closes.
+	return detached, func() {}
+}
+
+// FinishDetachedUpstreamContext releases a detached request context after the
+// transport fails or its response body closes.
+func FinishDetachedUpstreamContext(ctx context.Context) {
+	if ctx == nil {
+		return
+	}
+	state, _ := ctx.Value(detachedUpstreamContextKey{}).(*detachedUpstreamContextState)
+	state.finish()
+}
+
 func detachStreamUpstreamContext(ctx context.Context, stream bool) (context.Context, context.CancelFunc) {
 	if ctx == nil {
 		return context.Background(), func() {}
@@ -487,14 +564,11 @@ func detachStreamUpstreamContext(ctx context.Context, stream bool) (context.Cont
 	if !stream {
 		return ctx, func() {}
 	}
-	return context.WithoutCancel(ctx), func() {}
+	return detachUpstreamContextWithDrainGrace(ctx, detachedUpstreamDrainGrace)
 }
 
 func detachUpstreamContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	if ctx == nil {
-		return context.Background(), func() {}
-	}
-	return context.WithoutCancel(ctx), func() {}
+	return detachUpstreamContextWithDrainGrace(ctx, detachedUpstreamDrainGrace)
 }
 
 // billingDeps 扣费逻辑依赖的服务（由各 gateway service 提供）


### PR DESCRIPTION
## 概要

- 客户端断开后，允许上游请求在 2 分钟窗口内完成排空
- 传输失败或响应体关闭时，取消并清理断开后的上下文
- 使用既有计费超时限制额度数据库回退操作

## 问题

断开后的流式和 OpenAI 请求使用了 `context.WithoutCancel`，但没有后续的取消路径。下游客户端断开后，如果上游响应头或数据流卡住，HTTP 客户端缓存条目会持续处于 in-flight 状态，无法淘汰。积累到足够数量后会耗尽 5,000 个条目的缓存，使无关账号同样报出 `upstream client cache limit reached`。

## 测试

- `go test -tags=unit ./internal/service ./internal/repository -count=1`