### PR TITLE
fix(billing): 补上 glm-5.2 兜底价，避免被 glm-5 子串匹配抢走

### DIFF
--- a/backend/internal/service/billing_service.go
+++ b/backend/internal/service/billing_service.go
@@ -403,6 +403,13 @@ func (s *BillingService) initFallbackPricing() {
 	// Source: https://docs.z.ai/guides/overview/pricing (USD per 1M tokens)
 	// 注意：CacheReadPricePerToken 即"缓存命中"价格，CacheCreationPricePerToken 留空（智谱未公开写入价，按 0 处理）。
 	// GLM-4.6 与 GLM-4.5 在 z.ai 国际版上定价一致；GLM-4.5 国内按 ¥0.8/¥2，汇率换算后约 $0.112/$0.28，与国际版 $0.6/$2.2 不同，本分支采用国际版 USD 口径与现有 Claude/GPT 一致。
+	// GLM-5.2 与 GLM-5.1 在 z.ai 上同价。
+	s.fallbackPrices["glm-5.2"] = &ModelPricing{
+		InputPricePerToken:     1.4e-6, // $1.40 per MTok
+		OutputPricePerToken:    4.4e-6, // $4.40 per MTok
+		CacheReadPricePerToken: 0.26e-6,
+		SupportsCacheBreakdown: false,
+	}
 	s.fallbackPrices["glm-5.1"] = &ModelPricing{
 		InputPricePerToken:     1.4e-6, // $1.40 per MTok
 		OutputPricePerToken:    4.4e-6, // $4.40 per MTok
@@ -670,8 +677,12 @@ func (s *BillingService) getFallbackPricing(model string) *ModelPricing {
 	// 匹配策略：长 key 优先（具体模型 → 系列 / 厂商），未知型号不回退以避免误计价。
 	// 与 DeepSeek 一样采用"白名单"语义：未在本表命中的国产模型 alias 一律不返回兜底价。
 
-	// 智谱 GLM（z.ai 公开 SKU：glm-5.1 / glm-5 / glm-5-turbo / glm-4.7 / glm-4.6 / glm-4.5 等）
+	// 智谱 GLM（z.ai 公开 SKU：glm-5.2 / glm-5.1 / glm-5 / glm-5-turbo / glm-4.7 / glm-4.6 / glm-4.5 等）
 	// 匹配顺序：先判别最高 tier，再依次降级。
+	// 注意：带小数点的型号必须排在裸 "glm-5" 之前，否则会被 strings.Contains 抢走。
+	if strings.Contains(modelLower, "glm-5.2") {
+		return s.fallbackPrices["glm-5.2"]
+	}
 	if strings.Contains(modelLower, "glm-5.1") {
 		return s.fallbackPrices["glm-5.1"]
 	}

--- a/backend/internal/service/billing_service_test.go
+++ b/backend/internal/service/billing_service_test.go
@@ -158,17 +158,19 @@ func TestGetModelPricing_FallbackWarnPerModelNotGlobal(t *testing.T) {
 	require.Equal(t, 0, strings.Count(out, "model: GLM-5.2"), out) // 大写经 ToLower 归一,不应单独成行
 }
 
-// 回归:glm-5.2 仍解析到 glm-5 兜底价(计费金额不变,防止日志改动掩盖未来计费回归)。
-func TestGetModelPricing_GLM52FallsBackToGLM5Price(t *testing.T) {
+// 回归:glm-5.2 必须命中自己的兜底价,不能被 strings.Contains("glm-5") 抢成 glm-5 价。
+// 历史 bug:兜底表缺 glm-5.2 条目,使用记录按 $1.00/$3.20 计费,比官方 $1.40/$4.40 少收约 27%。
+func TestGetModelPricing_GLM52UsesOwnPrice(t *testing.T) {
 	svc := newTestBillingService()
 
 	got, err := svc.GetModelPricing("glm-5.2")
 	require.NoError(t, err)
 	require.NotNil(t, got)
 
-	// glm-5 base：Input 1e-6 / Output 3.2e-6(见 TestGetFallbackPricing_FamilyMatching)。
-	require.InDelta(t, 1e-6, got.InputPricePerToken, 1e-12)
-	require.InDelta(t, 3.2e-6, got.OutputPricePerToken, 1e-12)
+	// 官方 z.ai 口径:与 glm-5.1 同价(见 TestGetFallbackPricing_FamilyMatching)。
+	require.InDelta(t, 1.4e-6, got.InputPricePerToken, 1e-12)
+	require.InDelta(t, 4.4e-6, got.OutputPricePerToken, 1e-12)
+	require.InDelta(t, 0.26e-6, got.CacheReadPricePerToken, 1e-12)
 }
 
 func TestGetModelPricing_UnknownClaudeModelFallsBackToSonnet(t *testing.T) {
@@ -490,6 +492,13 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 
 		// ---- 智谱 GLM（z.ai USD 口径）----
 		{
+			name:              "glm 5.2 flagship",
+			model:             "glm-5.2",
+			expectedInput:     1.4e-6,
+			expectedOutput:    floatPtr(4.4e-6),
+			expectedCacheRead: floatPtr(0.26e-6),
+		},
+		{
 			name:              "glm 5.1 flagship",
 			model:             "glm-5.1",
 			expectedInput:     1.4e-6,
@@ -572,11 +581,18 @@ func TestGetFallbackPricing_FamilyMatching(t *testing.T) {
 			expectedInput:  0.1e-6,
 			expectedOutput: floatPtr(0.1e-6),
 		},
-		// 关键：5.1 必须先于 5 匹配（避免被 glm-5 抢走）
+		// 关键：5.1 / 5.2 必须先于 5 匹配（避免被 glm-5 抢走）
 		{
 			name:              "glm 5.1 vs glm 5 ordering (verbatim 5.1)",
 			model:             "glm-5.1",
 			expectedInput:     1.4e-6, // = glm-5.1 价格
+			expectedOutput:    floatPtr(4.4e-6),
+			expectedCacheRead: floatPtr(0.26e-6),
+		},
+		{
+			name:              "glm 5.2 vs glm 5 ordering (verbatim 5.2)",
+			model:             "glm-5.2",
+			expectedInput:     1.4e-6, // = glm-5.2 价格（不是 glm-5 的 1e-6）
 			expectedOutput:    floatPtr(4.4e-6),
 			expectedCacheRead: floatPtr(0.26e-6),
 		},


### PR DESCRIPTION
## 问题

`getFallbackPricing` 的 GLM 兜底价表里没有 `glm-5.2` 条目，匹配时会穿透到裸 `strings.Contains(modelLower, "glm-5")` 分支，按 **GLM-5 的价** 计费：

| | 实际计费（glm-5 价） | z.ai 官方 | 偏差 |
|---|---|---|---|
| Input | $1.00 /MTok | **$1.40** | 少收 28.6% |
| Output | $3.20 /MTok | **$4.40** | 少收 27.3% |
| Cache read | $0.20 /MTok | **$0.26** | 少收 23.1% |

LiteLLM 那边也兜不住：数据里没有裸 `glm-5.2` key，只有带 provider 前缀的 `cloudflare/@cf/zai-org/glm-5.2` 和 `fireworks_ai/accounts/.../glm-5p2`，`buildModelLookupCandidates` 生成的候选都匹配不上。所以 `glm-5.2` 请求**必然**落到兜底路径，偏差会直接体现在使用记录的费用里。

## 改动

1. 兜底价表新增 `glm-5.2` 条目：$1.40 in / $4.40 out / $0.26 cache read —— 按官方文档与 GLM-5.1 同价
2. 匹配分支加在裸 `glm-5` **之前**，并补注释说明「带小数点的型号必须排在裸 `glm-5` 前面」，避免以后加 `glm-5.3` 再踩同一个坑

定价来源：https://docs.z.ai/guides/overview/pricing

## 测试

原有的 `TestGetModelPricing_GLM52FallsBackToGLM5Price` 把「glm-5.2 = glm-5 价」当成期望行为固化了下来（这也是这个 bug 一直没被发现的原因），本 PR 将其改名为 `TestGetModelPricing_GLM52UsesOwnPrice` 并改成断言官方价，另外补了 cache read 断言。

`TestGetFallbackPricing_FamilyMatching` 补两个 case：`glm 5.2 flagship` 和 `glm 5.2 vs glm 5 ordering`（守住匹配顺序）。

先改测试跑出红（拿到 `1e-6`，正是 glm-5 价），再改实现转绿。

## 验证

均在本分支（基于当前 main）本地跑过：

- `go build ./...` ✅
- `go test -tags=unit ./...` ✅ 全过
- `go test ./...` ✅ 全过
- `golangci-lint run --new-from-rev=main ./...` ✅ 0 issues（本次改动零新增）
- 前端 `lint:check` / `typecheck` / CI critical vitest（6 files, 99 tests）✅ 全过

## 备注

已产生的 `usage_logs` 记录不受影响 —— 表里存的是算好的 `input_cost` / `output_cost` / `total_cost` 金额快照，不会按新价重算，本 PR 只影响后续请求的计费。

🤖 Generated with [Claude Code](https://claude.com/claude-code)