### PR TITLE
fix(openai): preserve model-not-found semantics after failover

### DIFF
--- a/backend/internal/handler/no_account_error.go
+++ b/backend/internal/handler/no_account_error.go
@@ -17,8 +17,10 @@ import (
 //
 //   - 404 model_not_found — the group has accounts, but none of them are
 //     configured to serve the requested model (config / typo / unsupported
-//     model). Returning 503 here misleads operators and trips reverse-proxy
-//     health checks; 404 lets the client surface the real problem.
+//     model), or every supporting account recently received the same
+//     deterministic upstream model-not-found response. Returning 503 here
+//     misleads operators and trips reverse-proxy health checks; 404 lets the
+//     client surface the real problem.
 //
 //   - 503 api_error — accounts that could serve the model exist but are
 //     temporarily exhausted (rate limit, quota auto-pause, runtime block) OR
@@ -41,9 +43,9 @@ type noAccountErrorClassification struct {
 // we re-check pool composition through DiagnoseModelAvailabilityForPlatform.
 // Its dedicated database query considers only persistent eligibility
 // (active status + schedulable setting) and model_mapping, bypassing scheduler
-// snapshots and transient filters. That guarantees a 404 is only returned
-// when persistent account/group/model configuration must change before the
-// request can succeed.
+// snapshots and transient filters. OpenAI-compatible diagnosis also inspects
+// the narrowly scoped model-not-found cooldown reason. Other transient states
+// continue to return 503.
 //
 // routingModel is the model name that account selection actually compared
 // against (i.e. after group-level dispatch mapping). displayModel is the
@@ -80,7 +82,7 @@ func classifyNoAccountError(
 	}
 
 	result := diag.DiagnoseModelAvailabilityForPlatform(ctx, apiKey.GroupID, routingModel, platform)
-	if result.HasAccountsInPool && !result.HasModelSupport {
+	if result.HasAccountsInPool && (!result.HasModelSupport || result.AllSupportingAccountsModelNotFoundLimited) {
 		return noAccountErrorClassification{
 			Status:        http.StatusNotFound,
 			ErrType:       "model_not_found",

--- a/backend/internal/handler/no_account_error_test.go
+++ b/backend/internal/handler/no_account_error_test.go
@@ -168,6 +168,23 @@ func TestClassifyNoAccountError_ModelSupportedOnlyByRateLimitedAccount_Returns50
 	require.False(t, cls.ModelNotFound, "temporary account cooldown must remain retryable")
 }
 
+func TestClassifyNoAccountError_AllSupportingAccountsModelNotFoundLimited_Returns404(t *testing.T) {
+	c := newTestGinContextWithRequest()
+	fd := &fakeDiagnoser{resp: service.ModelAvailabilityDiagnosis{
+		HasAccountsInPool: true,
+		HasModelSupport:   true,
+		AllSupportingAccountsModelNotFoundLimited: true,
+	}}
+	apiKey := &service.APIKey{GroupID: ptrInt64(7)}
+
+	cls := classifyNoAccountErrorFromGin(c, fd, apiKey, "gpt-5.6-luna", "gpt-5.6-luna", service.PlatformOpenAI)
+
+	require.Equal(t, http.StatusNotFound, cls.Status)
+	require.Equal(t, "model_not_found", cls.ErrType)
+	require.True(t, cls.ModelNotFound)
+	require.Contains(t, cls.Message, "gpt-5.6-luna")
+}
+
 func TestClassifyNoAccountError_NoAccountsInPool_Stays503(t *testing.T) {
 	c := newTestGinContextWithRequest()
 	fd := &fakeDiagnoser{resp: service.ModelAvailabilityDiagnosis{HasAccountsInPool: false, HasModelSupport: false}}

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -2290,6 +2290,15 @@ func (h *OpenAIGatewayHandler) handleFailoverExhausted(c *gin.Context, failoverE
 		h.handleStreamingAwareError(c, http.StatusBadGateway, "upstream_error", service.OpenAISilentRefusalClientMessage(), streamStarted)
 		return
 	}
+	if service.IsOpenAIUpstreamModelNotFoundError(statusCode, responseBody) {
+		msg := strings.TrimSpace(service.ExtractUpstreamErrorMessage(responseBody))
+		if msg == "" {
+			msg = "The requested model was not found"
+		}
+		service.SetOpsUpstreamError(c, statusCode, msg, "")
+		h.handleStreamingAwareError(c, statusCode, "model_not_found", msg, streamStarted)
+		return
+	}
 
 	// 先检查透传规则
 	if h.errorPassthroughService != nil && len(responseBody) > 0 {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -211,6 +211,27 @@ func TestOpenAIHandleStreamingAwareError_NonStreaming(t *testing.T) {
 	assert.Equal(t, "test error", errorObj["message"])
 }
 
+func TestOpenAIGatewayHandler_ModelNotFoundFailoverPreservesClientError(t *testing.T) {
+	for _, statusCode := range []int{http.StatusBadRequest, http.StatusNotFound} {
+		t.Run(http.StatusText(statusCode), func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			rec := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(rec)
+			c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+			h := &OpenAIGatewayHandler{}
+			h.handleFailoverExhausted(c, &service.UpstreamFailoverError{
+				StatusCode:   statusCode,
+				ResponseBody: []byte(`{"error":{"code":"model_not_found","message":"Model gpt-5.6-luna not found"}}`),
+			}, false)
+
+			require.Equal(t, statusCode, rec.Code)
+			require.Contains(t, rec.Body.String(), "gpt-5.6-luna")
+			require.Contains(t, rec.Body.String(), "model_not_found")
+		})
+	}
+}
+
 func TestReadRequestBodyWithPrealloc(t *testing.T) {
 	payload := `{"model":"gpt-5","input":"hello"}`
 	req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(payload))

--- a/backend/internal/service/gateway_model_availability.go
+++ b/backend/internal/service/gateway_model_availability.go
@@ -10,9 +10,10 @@ import (
 // ModelAvailabilityDiagnosis describes whether the requested model can be
 // served by any persistently eligible account in the group (active with its
 // schedulable setting enabled), ignoring transient state such as rate limits,
-// overload, temporary unschedulability, and runtime blocks. Handlers use this
-// on the "no available accounts" error path to distinguish 404
-// model_not_found from 503 service_unavailable.
+// overload, temporary unschedulability, and runtime blocks. OpenAI-compatible
+// diagnosis separately reports the deterministic upstream model-not-found
+// cooldown. Handlers use this on the "no available accounts" error path to
+// distinguish 404 model_not_found from 503 service_unavailable.
 type ModelAvailabilityDiagnosis struct {
 	// HasAccountsInPool is true if the group has at least one persistently
 	// eligible account on the queried platform (or, for Anthropic/Gemini, on
@@ -21,6 +22,10 @@ type ModelAvailabilityDiagnosis struct {
 	// HasModelSupport is true if at least one account's model mapping admits
 	// the requested model.
 	HasModelSupport bool
+	// AllSupportingAccountsModelNotFoundLimited is true when every account
+	// that supports the requested model is currently cooling down because the
+	// upstream deterministically rejected that model as not found.
+	AllSupportingAccountsModelNotFoundLimited bool
 }
 
 // ModelAvailabilityDiagnoser is implemented by gateway services that can

--- a/backend/internal/service/model_not_found_error.go
+++ b/backend/internal/service/model_not_found_error.go
@@ -11,6 +11,19 @@ func isUpstreamModelNotFoundError(statusCode int, body []byte) bool {
 	if statusCode != http.StatusNotFound {
 		return false
 	}
+	return isModelNotFoundErrorBody(body)
+}
+
+// IsOpenAIUpstreamModelNotFoundError reports whether an OpenAI-compatible
+// upstream returned a deterministic model-not-found client error.
+func IsOpenAIUpstreamModelNotFoundError(statusCode int, body []byte) bool {
+	if statusCode != http.StatusBadRequest && statusCode != http.StatusNotFound {
+		return false
+	}
+	return isModelNotFoundErrorBody(body)
+}
+
+func isModelNotFoundErrorBody(body []byte) bool {
 	normalized := normalizeModelNotFoundBody(body)
 	if normalized == "" || !strings.Contains(normalized, "model") {
 		return false

--- a/backend/internal/service/model_not_found_error_test.go
+++ b/backend/internal/service/model_not_found_error_test.go
@@ -3,6 +3,8 @@ package service
 import (
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsUpstreamModelNotFoundError(t *testing.T) {
@@ -45,7 +47,7 @@ func TestIsUpstreamModelNotFoundError(t *testing.T) {
 		{
 			name:       "non 404 does not match",
 			statusCode: http.StatusBadRequest,
-			body:       []byte(`{"error":{"message":"model not found"}}`),
+			body:       []byte(`{"error":{"code":"model_not_found","message":"Model gpt-5.6-luna not found"}}`),
 			want:       false,
 		},
 	}
@@ -57,6 +59,17 @@ func TestIsUpstreamModelNotFoundError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsOpenAIUpstreamModelNotFoundError(t *testing.T) {
+	require.True(t, IsOpenAIUpstreamModelNotFoundError(
+		http.StatusBadRequest,
+		[]byte(`{"error":{"code":"model_not_found","message":"Model gpt-5.6-luna not found"}}`),
+	))
+	require.False(t, IsOpenAIUpstreamModelNotFoundError(
+		http.StatusBadRequest,
+		[]byte(`{"error":{"code":"invalid_request_error","message":"input is invalid"}}`),
+	))
 }
 
 func TestAntigravityModelNotFoundKeepsBare404Fallback(t *testing.T) {

--- a/backend/internal/service/model_rate_limit.go
+++ b/backend/internal/service/model_rate_limit.go
@@ -45,6 +45,19 @@ func (a *Account) isModelRateLimitedWithContext(ctx context.Context, requestedMo
 	return false
 }
 
+func (a *Account) isModelRateLimitedForReason(ctx context.Context, requestedModel, reason string) bool {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return false
+	}
+	for _, key := range a.modelRateLimitKeysForRequest(ctx, requestedModel) {
+		if a.isRateLimitActiveForKey(key) && a.modelRateLimitReason(key) == reason {
+			return true
+		}
+	}
+	return false
+}
+
 // GetModelRateLimitRemainingTime 获取模型限流剩余时间
 // 返回 0 表示未限流或已过期
 func (a *Account) GetModelRateLimitRemainingTime(requestedModel string) time.Duration {
@@ -169,4 +182,20 @@ func (a *Account) modelRateLimitResetAt(scope string) *time.Time {
 		return nil
 	}
 	return &resetAt
+}
+
+func (a *Account) modelRateLimitReason(scope string) string {
+	if a == nil || a.Extra == nil || scope == "" {
+		return ""
+	}
+	rawLimits, ok := a.Extra[modelRateLimitsKey].(map[string]any)
+	if !ok {
+		return ""
+	}
+	rawLimit, ok := rawLimits[scope].(map[string]any)
+	if !ok {
+		return ""
+	}
+	reason, _ := rawLimit["reason"].(string)
+	return strings.TrimSpace(reason)
 }

--- a/backend/internal/service/openai_gateway_model_availability.go
+++ b/backend/internal/service/openai_gateway_model_availability.go
@@ -53,7 +53,17 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 		return ModelAvailabilityDiagnosis{HasAccountsInPool: true, HasModelSupport: true}
 	}
 
+	return diagnoseOpenAIModelAvailability(ctx, accounts, requestedModel)
+}
+
+func diagnoseOpenAIModelAvailability(
+	ctx context.Context,
+	accounts []Account,
+	requestedModel string,
+) ModelAvailabilityDiagnosis {
 	diag := ModelAvailabilityDiagnosis{}
+	supportingAccounts := 0
+	modelNotFoundLimitedAccounts := 0
 	for i := range accounts {
 		diag.HasAccountsInPool = true
 		// Mirrors the per-candidate filter used during account selection
@@ -62,8 +72,12 @@ func (s *OpenAIGatewayService) DiagnoseModelAvailabilityForPlatform(
 		// mapping must match.
 		if accounts[i].IsModelSupported(requestedModel) {
 			diag.HasModelSupport = true
-			return diag
+			supportingAccounts++
+			if accounts[i].isModelRateLimitedForReason(ctx, requestedModel, upstreamModelNotFoundReason) {
+				modelNotFoundLimitedAccounts++
+			}
 		}
 	}
+	diag.AllSupportingAccountsModelNotFoundLimited = supportingAccounts > 0 && supportingAccounts == modelNotFoundLimitedAccounts
 	return diag
 }

--- a/backend/internal/service/openai_gateway_model_availability_test.go
+++ b/backend/internal/service/openai_gateway_model_availability_test.go
@@ -1,0 +1,79 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiagnoseOpenAIModelAvailability_AllSupportingAccountsModelNotFoundLimited(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, upstreamModelNotFoundReason),
+		openAIAccountWithModelRateLimit(2, model, resetAt, upstreamModelNotFoundReason),
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasAccountsInPool)
+	require.True(t, got.HasModelSupport)
+	require.True(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func TestDiagnoseOpenAIModelAvailability_OneSupportingAccountAvailable(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, upstreamModelNotFoundReason),
+		{ID: 2, Platform: PlatformOpenAI},
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasModelSupport)
+	require.False(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func TestDiagnoseOpenAIModelAvailability_DifferentCooldownReasonStaysTransient(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(10 * time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, "upstream_rate_limit"),
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasModelSupport)
+	require.False(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func TestDiagnoseOpenAIModelAvailability_ExpiredModelNotFoundCooldownStaysTransient(t *testing.T) {
+	model := "gpt-5.6-luna"
+	resetAt := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	accounts := []Account{
+		openAIAccountWithModelRateLimit(1, model, resetAt, upstreamModelNotFoundReason),
+	}
+
+	got := diagnoseOpenAIModelAvailability(context.Background(), accounts, model)
+
+	require.True(t, got.HasModelSupport)
+	require.False(t, got.AllSupportingAccountsModelNotFoundLimited)
+}
+
+func openAIAccountWithModelRateLimit(id int64, model, resetAt, reason string) Account {
+	return Account{
+		ID:       id,
+		Platform: PlatformOpenAI,
+		Extra: map[string]any{
+			modelRateLimitsKey: map[string]any{
+				model: map[string]any{
+					"rate_limit_reset_at": resetAt,
+					"reason":              reason,
+				},
+			},
+		},
+	}
+}

--- a/backend/internal/service/ratelimit_service.go
+++ b/backend/internal/service/ratelimit_service.go
@@ -2028,12 +2028,12 @@ const tempUnschedMessageMaxBytes = 2048
 
 // HandleUpstreamModelNotFound marks the requested model as temporarily
 // unavailable on the account when the upstream deterministically reports it
-// cannot serve that model: a 404 model-not-found, or the Codex 400 rejecting a
-// plan-gated model on a ChatGPT OAuth account. Returning true tells the caller
-// to fail the current attempt over to another account; the scheduler skips the
-// (account, model) pair via IsSchedulableForModelWithContext until the
-// cooldown expires, instead of re-selecting an account that can never serve
-// the model.
+// cannot serve that model: a 404 model-not-found, an OpenAI-compatible 400
+// model-not-found, or the Codex 400 rejecting a plan-gated model on a ChatGPT
+// OAuth account. Returning true tells the caller to fail the current attempt
+// over to another account; the scheduler skips the (account, model) pair via
+// IsSchedulableForModelWithContext until the cooldown expires, instead of
+// re-selecting an account that can never serve the model.
 func (s *RateLimitService) HandleUpstreamModelNotFound(ctx context.Context, account *Account, requestedModel string, statusCode int, responseBody []byte) bool {
 	if s == nil || account == nil || s.accountRepo == nil {
 		return false
@@ -2045,6 +2045,8 @@ func (s *RateLimitService) HandleUpstreamModelNotFound(ctx context.Context, acco
 	var reason string
 	switch {
 	case isUpstreamModelNotFoundError(statusCode, responseBody):
+		cooldown, reason = upstreamModelNotFoundCooldown, upstreamModelNotFoundReason
+	case account.IsOpenAICompatible() && IsOpenAIUpstreamModelNotFoundError(statusCode, responseBody):
 		cooldown, reason = upstreamModelNotFoundCooldown, upstreamModelNotFoundReason
 	case isOpenAIOAuthAccount(account) && isOpenAICodexPlanGatedModelError(statusCode, responseBody):
 		cooldown, reason = upstreamCodexPlanGatedModelCooldown, upstreamCodexPlanGatedModelReason

--- a/backend/internal/service/ratelimit_service_model_not_found_test.go
+++ b/backend/internal/service/ratelimit_service_model_not_found_test.go
@@ -69,6 +69,42 @@ func TestRateLimitService_HandleUpstreamError_ModelNotFoundUsesModelRateLimit(t 
 	require.WithinDuration(t, time.Now().Add(upstreamModelNotFoundCooldown), call.resetAt, 5*time.Second)
 }
 
+func TestRateLimitService_HandleUpstreamModelNotFound_OpenAI400UsesModelRateLimit(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := openAIModelNotFoundTempAccount()
+
+	handled := svc.HandleUpstreamModelNotFound(
+		context.Background(),
+		account,
+		"gpt-5.6-luna",
+		http.StatusBadRequest,
+		[]byte(`{"error":{"code":"model_not_found","message":"Model gpt-5.6-luna not found"}}`),
+	)
+
+	require.True(t, handled)
+	require.Len(t, repo.modelRateLimitCalls, 1)
+	require.Equal(t, upstreamModelNotFoundReason, repo.modelRateLimitCalls[0].reason)
+}
+
+func TestRateLimitService_HandleUpstreamModelNotFound_NonOpenAI400IsIgnored(t *testing.T) {
+	repo := &modelNotFoundAccountRepoStub{}
+	svc := &RateLimitService{accountRepo: repo}
+	account := openAIModelNotFoundTempAccount()
+	account.Platform = PlatformAnthropic
+
+	handled := svc.HandleUpstreamModelNotFound(
+		context.Background(),
+		account,
+		"claude-opus-4-8",
+		http.StatusBadRequest,
+		[]byte(`{"error":{"code":"model_not_found","message":"Model claude-opus-4-8 not found"}}`),
+	)
+
+	require.False(t, handled)
+	require.Empty(t, repo.modelRateLimitCalls)
+}
+
 func TestRateLimitService_HandleUpstreamError_ModelNotFoundWriteFailureDoesNotTempUnschedule(t *testing.T) {
 	repo := &modelNotFoundAccountRepoStub{modelRateLimitErr: errors.New("write failed")}
 	svc := &RateLimitService{accountRepo: repo}


### PR DESCRIPTION
## Summary

- preserve OpenAI-compatible `400/404 model_not_found` responses after failover exhaustion instead of rewriting them as a generic gateway error
- diagnose the no-account path as `404 model_not_found` when every model-supporting account is cooling down for the same deterministic upstream rejection
- scope the new HTTP 400 handling to OpenAI-compatible accounts so other platforms keep their existing behavior

This is the Luna/model-error portion split out of #3951.

## Why

GPT-5.6 model availability errors can arrive as HTTP 400. After all candidate accounts reject the model, the current handler loses the deterministic client error and returns a retryable 502/503, which causes unnecessary retries and account churn.

## Test plan

- [x] `go test -tags=unit ./internal/handler ./internal/service -count=1`
- [x] `go test -tags=integration ./internal/handler ./internal/service -run '^$' -count=1`
- [x] Verified non-OpenAI HTTP 400 model errors remain unaffected
