### PR TITLE
fix(openai): fail over pre-write response read errors

### DIFF
--- a/backend/internal/service/openai_compact_stream_bridge_test.go
+++ b/backend/internal/service/openai_compact_stream_bridge_test.go
@@ -318,7 +318,7 @@ func TestHandlePassthroughSSEToJSON_CompactRawOutputItemDoneRepairsEmptyTerminal
 		Body:       io.NopCloser(strings.NewReader(upstreamSSE)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 
@@ -512,7 +512,7 @@ func TestHandleNonStreamingResponsePassthrough_CompactClientStreamBridgesToSSE(t
 		}`)),
 	}
 
-	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, "gpt-5.5", "")
+	result, err := svc.handleNonStreamingResponsePassthrough(context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "")
 	require.NoError(t, err)
 	require.NotNil(t, result)
 

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -247,7 +247,7 @@ func (s *OpenAIGatewayService) forwardOpenAIPassthrough(
 		imageCount = result.imageCount
 		imageOutputSizes = result.imageOutputSizes
 	} else {
-		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, reqModel, upstreamPassthroughModel)
+		result, err := s.handleNonStreamingResponsePassthrough(ctx, resp, c, account, reqModel, upstreamPassthroughModel)
 		if err != nil {
 			return nil, err
 		}
@@ -1227,10 +1227,11 @@ func (s *OpenAIGatewayService) handleNonStreamingResponsePassthrough(
 	ctx context.Context,
 	resp *http.Response,
 	c *gin.Context,
+	account *Account,
 	originalModel string,
 	mappedModel string,
 ) (*openaiNonStreamingResultPassthrough, error) {
-	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	body, err := s.readOpenAINonStreamingResponseBody(ctx, resp.Body, c, account, true)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1106,7 +1107,7 @@ func openAICacheCreationTokensFromUsage(value gjson.Result) int {
 }
 
 func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, resp *http.Response, c *gin.Context, account *Account, originalModel, mappedModel string) (*openaiNonStreamingResult, error) {
-	body, err := ReadUpstreamResponseBody(resp.Body, s.cfg, c, openAITooLargeError)
+	body, err := s.readOpenAINonStreamingResponseBody(ctx, resp.Body, c, account, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1181,6 +1182,32 @@ func (s *OpenAIGatewayService) handleNonStreamingResponse(ctx context.Context, r
 		imageCount:       countOpenAIResponseImageOutputsFromJSONBytes(body),
 		imageOutputSizes: collectOpenAIResponseImageOutputSizesFromJSONBytes(body),
 	}, nil
+}
+
+func (s *OpenAIGatewayService) readOpenAINonStreamingResponseBody(
+	ctx context.Context,
+	reader io.Reader,
+	c *gin.Context,
+	account *Account,
+	passthrough bool,
+) ([]byte, error) {
+	body, err := ReadUpstreamResponseBody(reader, s.cfg, c, openAITooLargeError)
+	if err == nil {
+		return body, nil
+	}
+
+	responseWritten := c != nil && (IsResponseCommitted(c) || (c.Writer != nil && c.Writer.Written()))
+	if errors.Is(err, ErrUpstreamResponseBodyTooLarge) || responseWritten {
+		return nil, err
+	}
+
+	return nil, s.handleOpenAIUpstreamTransportError(
+		ctx,
+		c,
+		account,
+		fmt.Errorf("read upstream response body: %w", err),
+		passthrough,
+	)
 }
 
 func isEventStreamResponse(header http.Header) bool {

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -587,7 +587,7 @@ func TestOpenAIGatewayService_OAuthPassthrough_NamespaceNonStreamingResponse(t *
 	setOpenAIResponsesNamespaceNames(c, names)
 
 	result, err := (&OpenAIGatewayService{cfg: &config.Config{}}).handleNonStreamingResponsePassthrough(
-		context.Background(), resp, c, "gpt-5.5", "",
+		context.Background(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.5", "",
 	)
 	require.NoError(t, err)
 	require.NotNil(t, result)
@@ -1616,7 +1616,7 @@ func TestOpenAIGatewayService_OpenAIPassthrough_CompactNetworkErrorsTriggerFailo
 				Header:     http.Header{"Content-Type": []string{"application/json"}, "x-request-id": []string{"rid-compact"}},
 				Body:       passthroughErrReadCloser{err: io.ErrUnexpectedEOF},
 			},
-			expectFailover: false,
+			expectFailover: true,
 		},
 	}
 

--- a/backend/internal/service/openai_upstream_transport_error_handle_test.go
+++ b/backend/internal/service/openai_upstream_transport_error_handle_test.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -44,6 +46,13 @@ type failingOpenAIHTTPUpstream struct {
 	calls int
 }
 
+type failingResponseBody struct {
+	err error
+}
+
+func (b failingResponseBody) Read([]byte) (int, error) { return 0, b.err }
+func (b failingResponseBody) Close() error             { return nil }
+
 func (u *failingOpenAIHTTPUpstream) Do(_ *http.Request, _ string, _ int64, _ int) (*http.Response, error) {
 	u.calls++
 	return nil, u.err
@@ -52,6 +61,104 @@ func (u *failingOpenAIHTTPUpstream) Do(_ *http.Request, _ string, _ int64, _ int
 func (u *failingOpenAIHTTPUpstream) DoWithTLS(_ *http.Request, _ string, _ int64, _ int, _ *tlsfingerprint.Profile) (*http.Response, error) {
 	u.calls++
 	return nil, u.err
+}
+
+func TestHandleNonStreamingResponse_HTTP2ReadErrorFailsOverBeforeWrite(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 501, Name: "h2-read", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	readErr := errors.New("stream error: stream ID 37; INTERNAL_ERROR; received from peer")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, 0, rec.Body.Len(), "下游尚未写入时必须交给 handler 切换账号")
+}
+
+func TestHandleNonStreamingResponsePassthrough_HTTP2ReadErrorFailsOverBeforeWrite(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 504, Name: "h2-read-passthrough", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	readErr := errors.New("stream error: stream ID 41; INTERNAL_ERROR; received from peer")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponsePassthrough(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	var failoverErr *UpstreamFailoverError
+	require.ErrorAs(t, err, &failoverErr)
+	require.Equal(t, http.StatusBadGateway, failoverErr.StatusCode)
+	require.Equal(t, 0, rec.Body.Len())
+}
+
+func TestHandleNonStreamingResponse_ReadErrorAfterWriteDoesNotFailOver(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 502, Name: "h2-written", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	c.Data(http.StatusOK, "text/plain", []byte("already written"))
+	readErr := errors.New("stream error: stream ID 39; INTERNAL_ERROR; received from peer")
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	require.ErrorIs(t, err, readErr)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "已写入下游后不能重放请求")
+	require.Equal(t, "already written", rec.Body.String())
+}
+
+func TestHandleNonStreamingResponse_ContextCanceledDoesNotFailOver(t *testing.T) {
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	account := &Account{ID: 503, Name: "client-gone", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	readErr := fmt.Errorf("read response body: %w", context.Canceled)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       failingResponseBody{err: readErr},
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	require.ErrorIs(t, err, context.Canceled)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+	require.Equal(t, 0, rec.Body.Len())
+}
+
+func TestHandleNonStreamingResponse_TooLargeDoesNotFailOver(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Gateway.UpstreamResponseReadMaxBytes = 1
+	svc := &OpenAIGatewayService{cfg: cfg}
+	account := &Account{ID: 505, Name: "too-large", Platform: PlatformOpenAI}
+	c, rec := newOpenAITransportErrTestContext()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader("{}")),
+	}
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, account, "gpt-5.4", "gpt-5.4")
+
+	require.ErrorIs(t, err, ErrUpstreamResponseBodyTooLarge)
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr), "响应体超限已经写入格式化错误，不能重放请求")
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Contains(t, rec.Body.String(), "Upstream response too large")
 }
 
 // A durable proxy/credential failure must (a) temporarily unschedule the account


### PR DESCRIPTION
## Summary

- treat non-streaming upstream body read failures as transport failures while no downstream bytes have been committed
- trigger account failover for managed and passthrough OpenAI responses
- avoid replay after downstream output, on client cancellation, or when the response exceeds the configured size limit

This is the response-read portion split out of #3951.

## Why

HTTP/2 stream resets can happen after upstream headers are received but before the non-streaming response body is read. The current path returns a hard 502 without trying another account even though the downstream response is still untouched.

## Test plan

- [x] `go test -tags=unit ./internal/service -count=1`
- [x] `go test -tags=integration ./internal/service -run '^$' -count=1`
- [x] Covered HTTP/2 read failure, passthrough, post-write, cancellation, and body-size-limit cases
