### PR TITLE
fix(openai): detach response affinity persistence

### DIFF
--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1030,7 +1030,7 @@ func (s *OpenAIGatewayService) bindHTTPResponseAccount(ctx context.Context, c *g
 	}
 	groupID := getOpenAIGroupIDFromContext(c)
 	ttl := s.openAIWSResponseStickyTTL()
-	logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, store.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+	bindOpenAIWSResponseAccount(ctx, store, groupID, responseID, account.ID, ttl)
 }
 
 func openAIUsageFromGJSON(value gjson.Result) (OpenAIUsage, bool) {

--- a/backend/internal/service/openai_response_affinity_persistence_test.go
+++ b/backend/internal/service/openai_response_affinity_persistence_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type responseAccountBindProbe struct {
+	OpenAIWSStateStore
+	calls       int
+	ctxErr      error
+	hasDeadline bool
+	deadline    time.Time
+	value       any
+}
+
+type responseAccountBindProbeContextKey struct{}
+
+func (p *responseAccountBindProbe) BindResponseAccount(ctx context.Context, _ int64, _ string, _ int64, _ time.Duration) error {
+	p.calls++
+	p.ctxErr = ctx.Err()
+	p.deadline, p.hasDeadline = ctx.Deadline()
+	p.value = ctx.Value(responseAccountBindProbeContextKey{})
+	return p.ctxErr
+}
+
+func TestBindOpenAIWSResponseAccountDetachesCanceledRequest(t *testing.T) {
+	parent := context.WithValue(context.Background(), responseAccountBindProbeContextKey{}, "request-value")
+	parent, cancel := context.WithCancel(parent)
+	cancel()
+	probe := &responseAccountBindProbe{}
+	before := time.Now()
+
+	bindOpenAIWSResponseAccount(parent, probe, 4201, "resp_detached", 37001, time.Hour)
+
+	require.Equal(t, 1, probe.calls)
+	require.NoError(t, probe.ctxErr)
+	require.True(t, probe.hasDeadline)
+	require.Equal(t, "request-value", probe.value)
+	require.WithinDuration(t, before.Add(openAIWSBindResponseAccountTimeout), probe.deadline, time.Second)
+}
+
+func TestBindOpenAIWSResponseAccountReplacesExpiredParentDeadline(t *testing.T) {
+	parent := context.WithValue(context.Background(), responseAccountBindProbeContextKey{}, "deadline-value")
+	parent, cancel := context.WithDeadline(parent, time.Now().Add(-time.Minute))
+	defer cancel()
+	require.ErrorIs(t, parent.Err(), context.DeadlineExceeded)
+	probe := &responseAccountBindProbe{}
+	before := time.Now()
+
+	bindOpenAIWSResponseAccount(parent, probe, 4201, "resp_deadline", 37001, time.Hour)
+
+	require.Equal(t, 1, probe.calls)
+	require.NoError(t, probe.ctxErr)
+	require.True(t, probe.hasDeadline)
+	require.True(t, probe.deadline.After(before))
+	require.Equal(t, "deadline-value", probe.value)
+	require.WithinDuration(t, before.Add(openAIWSBindResponseAccountTimeout), probe.deadline, time.Second)
+}

--- a/backend/internal/service/openai_ws_forwarder.go
+++ b/backend/internal/service/openai_ws_forwarder.go
@@ -38,6 +38,7 @@ const (
 	openAIWSEventFlushIntervalDefault     = 25 * time.Millisecond
 	openAIWSPayloadLogSampleDefault       = 0.2
 	openAIWSPassthroughIdleTimeoutDefault = time.Hour
+	openAIWSBindResponseAccountTimeout    = 3 * time.Second
 
 	openAIWSStoreDisabledConnModeStrict   = "strict"
 	openAIWSStoreDisabledConnModeAdaptive = "adaptive"
@@ -294,6 +295,20 @@ func (s *OpenAIGatewayService) openAIWSResponseStickyTTL() time.Duration {
 		}
 	}
 	return time.Hour
+}
+
+func bindOpenAIWSResponseAccount(parent context.Context, store OpenAIWSStateStore, groupID int64, responseID string, accountID int64, ttl time.Duration) {
+	if store == nil {
+		return
+	}
+	if parent == nil {
+		parent = context.Background()
+	}
+	bindCtx, cancel := context.WithTimeout(context.WithoutCancel(parent), openAIWSBindResponseAccountTimeout)
+	defer cancel()
+
+	err := store.BindResponseAccount(bindCtx, groupID, responseID, accountID, ttl)
+	logOpenAIWSBindResponseAccountWarn(groupID, accountID, responseID, err)
 }
 
 func (s *OpenAIGatewayService) openAIWSIngressPreviousResponseRecoveryEnabled() bool {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -573,7 +573,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			responseID := strings.TrimSpace(result.RequestID)
 			if responseID != "" && stateStore != nil {
 				ttl := s.openAIWSResponseStickyTTL()
-				logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+				bindOpenAIWSResponseAccount(ctx, stateStore, groupID, responseID, account.ID, ttl)
 			}
 			nextClientMessage, readErr := readClientMessage()
 			if readErr != nil {
@@ -1582,7 +1582,7 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 
 		if responseID != "" && stateStore != nil {
 			ttl := s.openAIWSResponseStickyTTL()
-			logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+			bindOpenAIWSResponseAccount(ctx, stateStore, groupID, responseID, account.ID, ttl)
 			stateStore.BindResponseConn(responseID, connID, ttl)
 		}
 		if stateStore != nil && storeDisabled && sessionHash != "" {

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -165,7 +165,7 @@ func (s *OpenAIGatewayService) performOpenAIWSGeneratePrewarm(
 	lease.MarkPrewarmed()
 	if prewarmResponseID != "" && stateStore != nil {
 		ttl := s.openAIWSResponseStickyTTL()
-		logOpenAIWSBindResponseAccountWarn(groupID, account.ID, prewarmResponseID, stateStore.BindResponseAccount(ctx, groupID, prewarmResponseID, account.ID, ttl))
+		bindOpenAIWSResponseAccount(ctx, stateStore, groupID, prewarmResponseID, account.ID, ttl)
 		stateStore.BindResponseConn(prewarmResponseID, lease.ConnID(), ttl)
 	}
 	logOpenAIWSModeInfo(
@@ -406,12 +406,7 @@ func (s *OpenAIGatewayService) selectAccountByPreviousResponseIDForCapability(
 
 	result, acquireErr := s.tryAcquireAccountSlot(ctx, accountID, account.Concurrency)
 	if acquireErr == nil && result.Acquired {
-		logOpenAIWSBindResponseAccountWarn(
-			derefGroupID(groupID),
-			accountID,
-			responseID,
-			store.BindResponseAccount(ctx, derefGroupID(groupID), responseID, accountID, s.openAIWSResponseStickyTTL()),
-		)
+		bindOpenAIWSResponseAccount(ctx, store, derefGroupID(groupID), responseID, accountID, s.openAIWSResponseStickyTTL())
 		return &AccountSelectionResult{
 			Account:     account,
 			Acquired:    true,

--- a/backend/internal/service/openai_ws_forwarder_v2.go
+++ b/backend/internal/service/openai_ws_forwarder_v2.go
@@ -718,7 +718,7 @@ func (s *OpenAIGatewayService) forwardOpenAIWSV2(
 
 	if responseID != "" && stateStore != nil {
 		ttl := s.openAIWSResponseStickyTTL()
-		logOpenAIWSBindResponseAccountWarn(groupID, account.ID, responseID, stateStore.BindResponseAccount(ctx, groupID, responseID, account.ID, ttl))
+		bindOpenAIWSResponseAccount(ctx, stateStore, groupID, responseID, account.ID, ttl)
 		stateStore.BindResponseConn(responseID, lease.ConnID(), ttl)
 	}
 	if stateStore != nil && storeDisabled && sessionHash != "" {


### PR DESCRIPTION
## Summary

- persist response-to-account affinity with a context detached from request cancellation
- retain request-scoped values while replacing expired deadlines with a bounded 3-second timeout
- apply the helper consistently across HTTP responses, WS turns, prewarm responses, and sticky-account refreshes

This is the response-affinity portion split out of #3951.

## Why

Response affinity is written after the upstream turn completes. At that point the request context may already be canceled, causing the state-store write to fail and later `previous_response_id` requests to lose account affinity.

## Test plan

- [x] `go test -tags=unit ./internal/service -count=1`
- [x] `go test -tags=integration ./internal/service -run '^$' -count=1`
- [x] Verified canceled and already-expired parent contexts are replaced by a live bounded context
