### PR TITLE
fix(openai): preserve invalid JSON schema errors

### DIFF
--- a/backend/internal/service/openai_gateway_invalid_json_schema_test.go
+++ b/backend/internal/service/openai_gateway_invalid_json_schema_test.go
@@ -1,0 +1,139 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Wei-Shaw/sub2api/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestOpenAINonStreamingInvalidJSONSchemaFailureReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := openAIInvalidJSONSchemaFailedSSEResponse(false)
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.6-sol", "gpt-5.6-sol")
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Contains(t, rec.Body.String(), "additionalProperties")
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+func TestOpenAINonStreamingPassthroughInvalidJSONSchemaFailureReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := openAIInvalidJSONSchemaFailedSSEResponse(true)
+
+	_, err := svc.handleNonStreamingResponsePassthrough(c.Request.Context(), resp, c, "gpt-5.6-sol", "gpt-5.6-sol")
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Contains(t, rec.Body.String(), "additionalProperties")
+	var failoverErr *UpstreamFailoverError
+	require.False(t, errors.As(err, &failoverErr))
+}
+
+func TestOpenAINonStreamingInvalidJSONSchemaFailureAfterKeepaliveCommitUsesBadRequestEvent(t *testing.T) {
+	c, rec := newCompactBridgeTestContext(t, true)
+	stop := StartOpenAICompactSSEKeepalive(c, keepaliveTestInterval)
+	defer stop()
+	waitForKeepaliveBeats()
+
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+	resp := openAIInvalidJSONSchemaFailedSSEResponse(true)
+
+	_, err := svc.handleNonStreamingResponse(c.Request.Context(), resp, c, &Account{Platform: PlatformOpenAI}, "gpt-5.6-sol", "gpt-5.6-sol")
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusOK, rec.Code, "心跳已提交后 HTTP 状态不可再修改")
+	events := parseCompactBridgeSSE(t, stripKeepaliveComments(rec.Body.String()))
+	require.Len(t, events, 1)
+	require.Equal(t, "response.failed", events[0][0])
+	require.Equal(t, "invalid_request_error", gjson.Get(events[0][1], "response.error.code").String())
+	streamErr, ok := GetOpsStreamError(c)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, streamErr.IntendedStatus)
+}
+
+func TestOpenAIHTTPInvalidJSONSchemaFailureReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	body := openAIInvalidJSONSchemaErrorBody()
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(string(body))),
+	}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+
+	_, err := svc.handleErrorResponse(context.Background(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}, nil)
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Contains(t, rec.Body.String(), "additionalProperties")
+}
+
+func TestOpenAIHTTPPassthroughInvalidJSONSchemaFailureReturnsBadRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+
+	body := openAIInvalidJSONSchemaErrorBody()
+	resp := &http.Response{
+		StatusCode: http.StatusBadRequest,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+	svc := &OpenAIGatewayService{cfg: &config.Config{}}
+
+	err := svc.handleErrorResponsePassthrough(context.Background(), resp, c, &Account{ID: 1, Platform: PlatformOpenAI, Type: AccountTypeOAuth}, nil, body)
+
+	require.Error(t, err)
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	require.Equal(t, "invalid_request_error", gjson.Get(rec.Body.String(), "error.type").String())
+	require.Contains(t, rec.Body.String(), "additionalProperties")
+}
+
+func openAIInvalidJSONSchemaFailedSSEResponse(nested bool) *http.Response {
+	payload := `{"type":"response.failed","error":{"code":"invalid_json_schema","message":"Invalid schema for response_format 'codex_output_schema': 'additionalProperties' is required to be supplied and to be false."}}`
+	if nested {
+		payload = `{"type":"response.failed","response":{"status":"failed","error":{"type":"invalid_request_error","code":"invalid_json_schema","message":"Invalid schema for response_format 'codex_output_schema': 'additionalProperties' is required to be supplied and to be false."}}}`
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body: io.NopCloser(strings.NewReader(strings.Join([]string{
+			"event: response.failed",
+			"data: " + payload,
+			"",
+		}, "\n"))),
+	}
+}
+
+func openAIInvalidJSONSchemaErrorBody() []byte {
+	return []byte(`{"error":{"type":"invalid_request_error","code":"invalid_json_schema","message":"Invalid schema for response_format 'codex_output_schema': 'additionalProperties' is required to be supplied and to be false."}}`)
+}

--- a/backend/internal/service/openai_gateway_passthrough.go
+++ b/backend/internal/service/openai_gateway_passthrough.go
@@ -540,12 +540,19 @@ func writeSanitizedOpenAIPassthroughError(c *gin.Context, upstreamStatus int, up
 // writeOpenAIPassthroughErrorEnvelope 以本地 JSON 信封 + 净化后的头策略写出
 // 错误响应；message 由调用方决定（净化通用文案或脱敏后的上游消息）。
 func writeOpenAIPassthroughErrorEnvelope(c *gin.Context, downstreamStatus int, upstreamHeaders http.Header, message string) {
+	writeOpenAIPassthroughErrorEnvelopeWithType(c, downstreamStatus, upstreamHeaders, "upstream_error", message)
+}
+
+func writeOpenAIPassthroughErrorEnvelopeWithType(c *gin.Context, downstreamStatus int, upstreamHeaders http.Header, errType, message string) {
 	if c == nil {
 		return
 	}
+	if strings.TrimSpace(errType) == "" {
+		errType = "upstream_error"
+	}
 	body, _ := json.Marshal(gin.H{
 		"error": gin.H{
-			"type":    "upstream_error",
+			"type":    errType,
 			"message": message,
 		},
 	})
@@ -660,7 +667,12 @@ func (s *OpenAIGatewayService) handleErrorResponsePassthrough(
 	// context-window 超限是确定性请求失败（shouldFailoverOpenAIPassthroughResponse
 	// 已保证不切号），其文案对客户端可操作（如触发自动压缩）；在净化信封内保留
 	// 脱敏后的上游消息，而不是抹成通用文案。
-	if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
+	if isOpenAIInvalidJSONSchemaErrorPayload(body) {
+		if upstreamMsg == "" {
+			upstreamMsg = "Invalid request"
+		}
+		writeOpenAIPassthroughErrorEnvelopeWithType(c, resp.StatusCode, resp.Header, "invalid_request_error", upstreamMsg)
+	} else if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
 		writeOpenAIPassthroughErrorEnvelope(c, resp.StatusCode, resp.Header, upstreamMsg)
 	} else {
 		writeSanitizedOpenAIPassthroughError(c, resp.StatusCode, resp.Header)
@@ -1322,7 +1334,7 @@ func (s *OpenAIGatewayService) handlePassthroughSSEToJSON(resp *http.Response, c
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg, terminalPayload)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != "" && mappedModel != "" && originalModel != mappedModel {

--- a/backend/internal/service/openai_gateway_response_handling.go
+++ b/backend/internal/service/openai_gateway_response_handling.go
@@ -1246,7 +1246,7 @@ func (s *OpenAIGatewayService) handleSSEToJSON(resp *http.Response, c *gin.Conte
 			if msg == "" {
 				msg = "Upstream compact response failed"
 			}
-			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg)
+			return nil, s.writeOpenAINonStreamingProtocolError(resp, c, msg, terminalPayload)
 		}
 		usage = s.parseSSEUsageFromBody(bodyText)
 		if originalModel != mappedModel {
@@ -1361,23 +1361,29 @@ func sanitizeOpenAIResponseFailedEventForClient(payload []byte, eventType string
 	return updated, !bytes.Equal(updated, payload)
 }
 
-func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string) error {
+func (s *OpenAIGatewayService) writeOpenAINonStreamingProtocolError(resp *http.Response, c *gin.Context, message string, payload []byte) error {
+	status := http.StatusBadGateway
+	errType := "upstream_error"
+	if isOpenAIInvalidJSONSchemaErrorPayload(payload) {
+		status = http.StatusBadRequest
+		errType = "invalid_request_error"
+	}
 	message = sanitizeUpstreamErrorMessage(strings.TrimSpace(message))
 	if message == "" {
 		message = "Upstream returned an invalid non-streaming response"
 	}
-	setOpsUpstreamError(c, http.StatusBadGateway, message, "")
+	setOpsUpstreamError(c, status, message, "")
 	// body-signal compact 心跳可能已把响应头提交为 200，此时只能以
 	// response.failed 终止事件回传错误，不能再写 JSON+状态码。
 	if openAICompactClientWantsStream(c) && StopOpenAICompactSSEKeepaliveCommitted(c) {
-		writeOpenAICompactSSEFailureMessage(c, http.StatusBadGateway, "upstream_error", message)
+		writeOpenAICompactSSEFailureMessage(c, status, errType, message)
 		return fmt.Errorf("non-streaming openai protocol error: %s", message)
 	}
 	responseheaders.WriteFilteredHeaders(c.Writer.Header(), resp.Header, s.responseHeaderFilter)
 	c.Writer.Header().Set("Content-Type", "application/json; charset=utf-8")
-	c.JSON(http.StatusBadGateway, gin.H{
+	c.JSON(status, gin.H{
 		"error": gin.H{
-			"type":    "upstream_error",
+			"type":    errType,
 			"message": message,
 		},
 	})

--- a/backend/internal/service/openai_gateway_upstream_errors.go
+++ b/backend/internal/service/openai_gateway_upstream_errors.go
@@ -209,6 +209,22 @@ func isOpenAIContextWindowError(upstreamMsg string, upstreamBody []byte) bool {
 	return match(string(upstreamBody))
 }
 
+// isOpenAIInvalidJSONSchemaErrorPayload only trusts the exact structured code.
+// Generic upstream 4xx responses must keep using the sanitized error envelope.
+func isOpenAIInvalidJSONSchemaErrorPayload(upstreamBody []byte) bool {
+	if len(upstreamBody) == 0 || !gjson.ValidBytes(upstreamBody) {
+		return false
+	}
+
+	for _, path := range []string{"error.code", "response.error.code"} {
+		code := strings.ToLower(strings.TrimSpace(gjson.GetBytes(upstreamBody, path).String()))
+		if code == "invalid_json_schema" {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *OpenAIGatewayService) shouldFailoverUpstreamError(statusCode int) bool {
 	switch statusCode {
 	case 401, 402, 403, 429, 529:
@@ -492,27 +508,36 @@ func (s *OpenAIGatewayService) handleErrorResponse(
 	var errType, errMsg string
 	var statusCode int
 
-	switch resp.StatusCode {
-	case 401:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream authentication failed, please contact administrator"
-	case 402:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream payment required: insufficient balance or billing issue"
-	case 403:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream access forbidden, please contact administrator"
-	case 429:
-		statusCode = http.StatusTooManyRequests
-		errType = "rate_limit_error"
-		errMsg = "Upstream rate limit exceeded, please retry later"
-	default:
-		statusCode = http.StatusBadGateway
-		errType = "upstream_error"
-		errMsg = "Upstream request failed"
+	if resp.StatusCode == http.StatusBadRequest && isOpenAIInvalidJSONSchemaErrorPayload(body) {
+		statusCode = http.StatusBadRequest
+		errType = "invalid_request_error"
+		errMsg = upstreamMsg
+		if errMsg == "" {
+			errMsg = "Invalid request"
+		}
+	} else {
+		switch resp.StatusCode {
+		case 401:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream authentication failed, please contact administrator"
+		case 402:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream payment required: insufficient balance or billing issue"
+		case 403:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream access forbidden, please contact administrator"
+		case 429:
+			statusCode = http.StatusTooManyRequests
+			errType = "rate_limit_error"
+			errMsg = "Upstream rate limit exceeded, please retry later"
+		default:
+			statusCode = http.StatusBadGateway
+			errType = "upstream_error"
+			errMsg = "Upstream request failed"
+		}
 	}
 	if isOpenAIContextWindowError(upstreamMsg, body) && upstreamMsg != "" {
 		errMsg = upstreamMsg


### PR DESCRIPTION
## Summary

- recognize the exact structured OpenAI `invalid_json_schema` error code
- return HTTP 400 `invalid_request_error` with the sanitized upstream message instead of a generic 502
- preserve the behavior across managed HTTP, passthrough HTTP, non-streaming SSE conversion, and compact keepalive output
- keep generic upstream 4xx responses on the existing sanitized error path

## Why

Schema validation failures are deterministic client errors. Rewriting them as HTTP 502 makes clients retry or rotate accounts even though the request must be corrected.

## Test plan

- [x] `go test -tags=unit ./internal/service -count=1`
- [x] `go test -tags=integration ./internal/service -run '^$' -count=1`
- [x] Covered top-level and nested `response.failed` envelopes plus managed and passthrough HTTP errors
