### PR TITLE
fix(profile): 修复未配置 Passkey 时 /profile 每次访问都弹「加载 Passkey 失败」

### DIFF
--- a/frontend/src/components/user/profile/ProfilePasskeyCard.vue
+++ b/frontend/src/components/user/profile/ProfilePasskeyCard.vue
@@ -205,12 +205,18 @@ function extractErrorMessage(error: unknown, fallback: string): string {
 }
 
 async function loadCredentials(): Promise<void> {
+  if (!props.enabled) {
+    credentials.value = []
+    return
+  }
   loading.value = true
   try {
     credentials.value = await passkeyAPI.list()
   } catch (error) {
-    const code = (error as { code?: string }).code
-    if (code !== 'PASSKEY_DISABLED') {
+    // 字符串错误码在 reason 字段（code 是数字状态码）；
+    // 设置变更竞态下后端仍可能返回 PASSKEY_DISABLED，静默处理
+    const reason = (error as { reason?: string }).reason
+    if (reason !== 'PASSKEY_DISABLED') {
       appStore.showError(t('profile.passkey.loadFailed'))
     }
   } finally {


### PR DESCRIPTION
## 问题

未配置 WebAuthn（Passkey）的部署，每次访问 /profile 都会弹「加载 Passkey 失败」toast。

## 根因

`ProfilePasskeyCard` 的加载逻辑本来就设计为静默忽略 `PASSKEY_DISABLED` 错误，但比对了错误对象的错误字段：后端错误信封是 `{ code: 403, reason: "PASSKEY_DISABLED", message: ... }` —— 字符串错误码在 `reason`，`code` 是数字状态码。组件用 `error.code !== 'PASSKEY_DISABLED'` 判断，永远成立，静默逻辑完全失效。

此外组件在 `enabled=false`（公开设置 `passkey_enabled` 为 false）时也会发起 `GET /user/passkeys` 请求，注定 403，纯属无谓开销。

## 修复

- 静默判断改为读 `error.reason`
- `enabled=false` 时直接跳过请求；保留 `reason` 判断以覆盖设置变更竞态（前端认为已启用但后端刚关闭）

修复后：未配置 Passkey 时卡片只显示「功能未启用」提示，不发请求、不弹错误。

## 验证

- ESLint 单文件检查通过
- 静态核对了 `api/client.ts` 错误拦截器 reject 的结构（`{ status, code, reason, message }`）与后端 `response.ErrorFrom` 信封字段一一对应