### PR TITLE
test: make nil guards explicit for staticcheck

### DIFF
--- a/backend/internal/handler/admin/payment_handler_test.go
+++ b/backend/internal/handler/admin/payment_handler_test.go
@@ -34,6 +34,7 @@ func TestSanitizeAdminPaymentOrderForResponseAddsCurrency(t *testing.T) {
 	got := sanitizeAdminPaymentOrderForResponse(order)
 	if got == nil {
 		t.Fatal("expected sanitized order")
+		return
 	}
 	if got.Currency != "USD" {
 		t.Fatalf("expected currency USD, got %q", got.Currency)

--- a/backend/internal/pkg/proxyurl/parse_test.go
+++ b/backend/internal/pkg/proxyurl/parse_test.go
@@ -41,6 +41,7 @@ func TestParse_有效HTTP代理(t *testing.T) {
 	}
 	if parsed == nil {
 		t.Fatal("parsed 不应为 nil")
+		return
 	}
 	if parsed.Host != "proxy.example.com:8080" {
 		t.Errorf("Host 不匹配: got %q", parsed.Host)

--- a/backend/internal/service/openai_images_incomplete_test.go
+++ b/backend/internal/service/openai_images_incomplete_test.go
@@ -40,6 +40,7 @@ func TestExtractImagesUpstreamError_IncompleteContentFilterNotRetryable(t *testi
 	got := extractOpenAIImagesUpstreamError([]byte(body))
 	if got == nil {
 		t.Fatal("content_filter incomplete should produce error")
+		return
 	}
 	if got.StatusCode != http.StatusBadRequest {
 		t.Fatalf("content_filter should be 400 (non-retryable), got %d", got.StatusCode)

--- a/backend/internal/service/openai_images_incomplete_test.go
+++ b/backend/internal/service/openai_images_incomplete_test.go
@@ -18,6 +18,7 @@ func TestExtractImagesUpstreamError_IncompleteIsRetryable(t *testing.T) {
 	got := extractOpenAIImagesUpstreamError([]byte(body))
 	if got == nil {
 		t.Fatal("incomplete event should produce an upstream error, got nil")
+		return
 	}
 	if got.StatusCode != http.StatusBadGateway {
 		t.Fatalf("incomplete(max_output_tokens) should be 502 retryable, got %d", got.StatusCode)

--- a/backend/internal/service/ops_service_user_error_test.go
+++ b/backend/internal/service/ops_service_user_error_test.go
@@ -121,6 +121,7 @@ func TestGetUserErrorRequestDetail_OwnershipEnforced(t *testing.T) {
 	}
 	if got2 == nil {
 		t.Fatal("expected non-nil detail for legitimate access")
+		return
 	}
 	if got2.ID != 42 {
 		t.Errorf("want ID=42, got %d", got2.ID)

--- a/backend/internal/service/ops_user_error_test.go
+++ b/backend/internal/service/ops_user_error_test.go
@@ -134,6 +134,7 @@ func TestToUserErrorRequestDetail_WhitelistAndRedacts(t *testing.T) {
 	out := ToUserErrorRequestDetail(src)
 	if out == nil {
 		t.Fatal("expected non-nil detail")
+		return
 	}
 
 	// 基础字段正确映射


### PR DESCRIPTION
## Summary
- add explicit returns after six fatal nil guards across five test files
- satisfy staticcheck SA5011 without changing test behavior
- unblock lint checks for unrelated pull requests based on current main

## Validation
- targeted tests for all affected cases
- full tests for the affected packages
- unit-tag tests and integration-tag compile checks
- golangci-lint v2.9 with Go 1.26.5, cache cleared and same-issue limit disabled: 0 issues