### PR TITLE
fix(risk-control): record latest cyber policy input

### DIFF
--- a/backend/internal/handler/openai_chat_completions.go
+++ b/backend/internal/handler/openai_chat_completions.go
@@ -232,7 +232,7 @@ func (h *OpenAIGatewayHandler) ChatCompletions(c *gin.Context) {
 		if service.GetOpsCyberPolicy(c) != nil {
 			cyberBlockKeyChat = service.CyberSessionBlockKey(apiKey.ID, c, body)
 		}
-		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyChat, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body))
+		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyChat, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body), body, service.ContentModerationProtocolOpenAIChat, "")
 
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)

--- a/backend/internal/handler/openai_gateway_cyber_test.go
+++ b/backend/internal/handler/openai_gateway_cyber_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/gin-gonic/gin"
@@ -24,7 +25,7 @@ func TestRecordCyberPolicyIfMarked_NoMark(t *testing.T) {
 	c := newTestGinContext()
 	h := &OpenAIGatewayHandler{}
 
-	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "")
+	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "", nil, "", "")
 
 	// Flag must NOT be set when there was no mark.
 	require.False(t, c.GetBool(cyberPolicyRecordedKey),
@@ -47,14 +48,14 @@ func TestRecordCyberPolicyIfMarked_WithMark(t *testing.T) {
 
 	// First call: should set the flag.
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "", nil, "", "")
 	})
 	require.True(t, c.GetBool(cyberPolicyRecordedKey),
 		"cyberPolicyRecordedKey must be true after first call with a mark")
 
 	// Second call: flag already set — must be a no-op (idempotent).
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "", nil, "", "")
 	})
 	// Flag should still be true (not toggled or cleared).
 	require.True(t, c.GetBool(cyberPolicyRecordedKey),
@@ -75,7 +76,7 @@ func TestRecordCyberPolicyIfMarked_ForwardSuccessSkipsUsageLog(t *testing.T) {
 	h := &OpenAIGatewayHandler{}
 
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false /* forwardErrored=false */, "", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false /* forwardErrored=false */, "", service.ChannelUsageFields{}, "", nil, "", "")
 	})
 	require.True(t, c.GetBool(cyberPolicyRecordedKey))
 }
@@ -88,7 +89,7 @@ func TestClearCyberPolicyTurnState(t *testing.T) {
 	h := &OpenAIGatewayHandler{}
 
 	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "turn1", UpstreamStatus: 200})
-	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "")
+	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "", nil, "", "")
 	require.True(t, c.GetBool(cyberPolicyRecordedKey))
 
 	clearCyberPolicyTurnState(c)
@@ -97,7 +98,7 @@ func TestClearCyberPolicyTurnState(t *testing.T) {
 
 	// turn2: a fresh cyber hit must be recordable again.
 	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "turn2", UpstreamStatus: 200})
-	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "")
+	h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", false, "", service.ChannelUsageFields{}, "", nil, "", "")
 	require.True(t, c.GetBool(cyberPolicyRecordedKey))
 	require.Equal(t, "turn2", service.GetOpsCyberPolicy(c).Message)
 }
@@ -147,8 +148,94 @@ func TestRecordCyberPolicyIfMarked_BlockKeyPlumbed(t *testing.T) {
 	service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "x", UpstreamStatus: 400})
 	h := &OpenAIGatewayHandler{}
 	require.NotPanics(t, func() {
-		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "deadbeef", service.ChannelUsageFields{}, "")
+		h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "deadbeef", service.ChannelUsageFields{}, "", nil, "", "")
 	})
+}
+
+func TestRecordCyberPolicyIfMarked_PersistsExtractedInputExcerpt(t *testing.T) {
+	tests := []struct {
+		name, protocol, body, wantExcerpt string
+	}{
+		{
+			name:     "responses latest user skips instructions",
+			protocol: service.ContentModerationProtocolOpenAIResponses,
+			body: `{"instructions":"FIXED SYSTEM PROMPT","input":[
+				{"type":"message","role":"developer","content":[{"type":"input_text","text":"FIXED DEVELOPER PROMPT"}]},
+				{"type":"message","role":"user","content":[{"type":"input_text","text":"earlier user input"}]},
+				{"type":"message","role":"user","content":[{"type":"input_text","text":"actual latest user input"}]}
+			]}`,
+			wantExcerpt: "actual latest user input",
+		},
+		{
+			name:     "chat latest user skips system",
+			protocol: service.ContentModerationProtocolOpenAIChat,
+			body: `{"messages":[
+				{"role":"system","content":"FIXED SYSTEM PROMPT"},
+				{"role":"user","content":"actual latest chat input"}
+			]}`,
+			wantExcerpt: "actual latest chat input",
+		},
+		{
+			name:     "messages latest user skips system",
+			protocol: service.ContentModerationProtocolAnthropicMessages,
+			body: `{"system":"FIXED SYSTEM PROMPT","messages":[
+				{"role":"user","content":[{"type":"text","text":"actual latest message input"}]}
+			]}`,
+			wantExcerpt: "actual latest message input",
+		},
+		{
+			name:     "tool continuation records latest user input",
+			protocol: service.ContentModerationProtocolOpenAIChat,
+			body: `{"messages":[
+				{"role":"system","content":"FIXED SYSTEM PROMPT"},
+				{"role":"user","content":"previous user input"},
+				{"role":"tool","content":"tool result"}
+			]}`,
+			wantExcerpt: "previous user input",
+		},
+		{
+			name:     "no user input keeps excerpt empty",
+			protocol: service.ContentModerationProtocolOpenAIChat,
+			body: `{"messages":[
+				{"role":"system","content":"FIXED SYSTEM PROMPT"},
+				{"role":"tool","content":"tool result"}
+			]}`,
+			wantExcerpt: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &contentModerationHandlerTestRepo{}
+			moderationSvc := service.NewContentModerationService(
+				&contentModerationHandlerSettingRepo{values: map[string]string{
+					service.SettingKeyRiskControlEnabled: "true",
+				}},
+				repo,
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+			)
+			h := &OpenAIGatewayHandler{contentModerationService: moderationSvc}
+			c := newTestGinContext()
+			c.Request = httptest.NewRequest("POST", "/openai/v1/responses", nil)
+			service.MarkOpsCyberPolicy(c, service.CyberPolicyMark{Message: "FIXED SYSTEM PROMPT", UpstreamStatus: 400})
+
+			h.recordCyberPolicyIfMarked(c, nil, nil, nil, "gpt-5", true, "", service.ChannelUsageFields{}, "", []byte(tt.body), tt.protocol, "")
+
+			var logs []service.ContentModerationLog
+			require.Eventually(t, func() bool {
+				logs = repo.logSnapshot()
+				return len(logs) == 1
+			}, time.Second, 10*time.Millisecond)
+			require.Equal(t, tt.wantExcerpt, logs[0].InputExcerpt)
+			if tt.wantExcerpt == "" {
+				require.Contains(t, logs[0].Error, "FIXED SYSTEM PROMPT")
+			}
+		})
+	}
 }
 
 // TestBuildCyberPolicyOpsErrorEntry_StatusCode verifies F6: the ops error log

--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -49,6 +49,10 @@ type openAIWSTurnChannelMappingSnapshot struct {
 	mapping service.ChannelMappingResult
 }
 
+type openAIWSTurnInputExcerptSnapshot struct {
+	excerpt string
+}
+
 var errOpenAIWSUnsupportedModelSwitch = errors.New("selected account does not support websocket model switch")
 
 func newOpenAIWSUnsupportedModelSwitchError(model string) error {
@@ -543,7 +547,7 @@ func (h *OpenAIGatewayHandler) Responses(c *gin.Context) {
 		if service.GetOpsCyberPolicy(c) != nil {
 			cyberBlockKeyHTTP = service.CyberSessionBlockKey(apiKey.ID, c, sessionHashBody)
 		}
-		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyHTTP, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body))
+		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyHTTP, clientRequestedUsageFields(c, channelMapping, reqModel, ""), service.HashUsageRequestPayload(body), body, service.ContentModerationProtocolOpenAIResponses, "")
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
 		responseLatencyMs := forwardDurationMs
@@ -1082,7 +1086,7 @@ func (h *OpenAIGatewayHandler) Messages(c *gin.Context) {
 		if service.GetOpsCyberPolicy(c) != nil {
 			cyberBlockKeyMsg = service.CyberSessionBlockKey(apiKey.ID, c, body)
 		}
-		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyMsg, clientRequestedUsageFields(c, channelMappingMsg, reqModel, ""), service.HashUsageRequestPayload(body))
+		h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, reqModel, err != nil, cyberBlockKeyMsg, clientRequestedUsageFields(c, channelMappingMsg, reqModel, ""), service.HashUsageRequestPayload(body), body, service.ContentModerationProtocolAnthropicMessages, "")
 		forwardDurationMs := time.Since(forwardStart).Milliseconds()
 		upstreamLatencyMs, _ := getContextInt64(c, service.OpsUpstreamLatencyMsKey)
 		responseLatencyMs := forwardDurationMs
@@ -1820,6 +1824,12 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 			reasoningEffortMappings = apiKey.Group.ReasoningEffortMappings
 		}
 		var requestPayloadHash string
+		// Retain only a scalar excerpt in the hooks. The original firstMessage can be
+		// large and must not be captured by AfterTurn for the connection lifetime.
+		var turnInputExcerpt atomic.Pointer[openAIWSTurnInputExcerptSnapshot]
+		turnInputExcerpt.Store(&openAIWSTurnInputExcerptSnapshot{
+			excerpt: securityaudit.ExtractLatestUserInput(service.ContentModerationProtocolOpenAIResponses, firstMessage),
+		})
 		// Passthrough rejects overlapping response.create frames, so one immutable
 		// turn-tagged slot preserves the exact mapping used for the in-flight request.
 		var turnChannelMapping atomic.Pointer[openAIWSTurnChannelMappingSnapshot]
@@ -1846,6 +1856,9 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					writeSecurityAuditWSError(ctx, wsConn, decision)
 					return service.NewOpenAIWSClientCloseError(securityAuditWSCloseStatus(decision), securityAuditWSCloseReason(decision), nil)
 				}
+				turnInputExcerpt.Store(&openAIWSTurnInputExcerptSnapshot{
+					excerpt: securityaudit.ExtractLatestUserInput(service.ContentModerationProtocolOpenAIResponses, payload),
+				})
 				return nil
 			},
 			MapRequestModel: func(turn int, originalModel string) (string, error) {
@@ -1925,7 +1938,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					turnUpstreamModel = turnRequestedModel
 				}
 				turnUsageFields := turnMapping.ToUsageFields(turnRequestedModel, turnUpstreamModel)
-				h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, turnRequestedModel, turnErr != nil, cyberBlockKey, turnUsageFields, requestPayloadHash)
+				inputExcerpt := ""
+				if snapshot := turnInputExcerpt.Load(); snapshot != nil {
+					// Some transport exits invoke AfterTurn without BeforeRequest for the
+					// failed turn. The cyber event records the most recent known user input.
+					inputExcerpt = snapshot.excerpt
+				}
+				h.recordCyberPolicyIfMarked(c, apiKey, account, subscription, turnRequestedModel, turnErr != nil, cyberBlockKey, turnUsageFields, requestPayloadHash, nil, "", inputExcerpt)
 				if service.GetOpsCyberPolicy(c) != nil {
 					cyberBlockedThisConn = true
 				}
@@ -2931,7 +2950,7 @@ func (h *OpenAIGatewayHandler) enqueueCyberSessionBlockedOpsEntry(c *gin.Context
 // 并在 forward 返回错误时写一条 tokens=0 用量行。标记由 gateway 服务层在透传 cyber 后设置；
 // 当前请求已发给用户，本方法只做事后记录，不影响响应。forwardErrored 为 true 时才写用量行，
 // 避免与正常 RecordUsage(forward 成功路径)重复。每请求至多记录一次。
-func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey *service.APIKey, account *service.Account, subscription *service.UserSubscription, model string, forwardErrored bool, cyberBlockKey string, channelFields service.ChannelUsageFields, requestPayloadHash string) {
+func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey *service.APIKey, account *service.Account, subscription *service.UserSubscription, model string, forwardErrored bool, cyberBlockKey string, channelFields service.ChannelUsageFields, requestPayloadHash string, moderationBody []byte, moderationProtocol, inputExcerpt string) {
 	mark := service.GetOpsCyberPolicy(c)
 	if mark == nil {
 		return
@@ -2941,6 +2960,10 @@ func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey 
 	}
 	c.Set(cyberPolicyRecordedKey, true)
 	model = clientRequestedModel(c, model)
+	if len(moderationBody) > 0 {
+		// Extract only after a cyber hit; normal requests do not pay another body scan.
+		inputExcerpt = securityaudit.ExtractLatestUserInput(moderationProtocol, moderationBody)
+	}
 
 	requestID := c.Writer.Header().Get("X-Request-Id")
 	var userID, apiKeyID int64
@@ -3027,6 +3050,7 @@ func (h *OpenAIGatewayHandler) recordCyberPolicyIfMarked(c *gin.Context, apiKey 
 				GroupName:       groupName,
 				Endpoint:        inboundEndpoint,
 				Model:           model,
+				InputExcerpt:    inputExcerpt,
 				UpstreamMessage: mark.Message,
 				UpstreamBody:    mark.Body,
 				UpstreamStatus:  mark.UpstreamStatus,

--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -56,6 +56,21 @@ func ExtractPromptSnapshot(req Request) (PromptSnapshot, error) {
 	}, nil
 }
 
+// ExtractLatestUserInput returns the latest user-controlled text segment using
+// the same protocol parsing and priority rules as prompt audit. It intentionally
+// excludes system, developer, assistant, and tool content.
+func ExtractLatestUserInput(protocol string, body []byte) string {
+	var document any
+	if err := json.Unmarshal(body, &document); err != nil {
+		return ""
+	}
+	segments := extractProtocolSegments(protocol, document)
+	if index := latestUserSegmentIndex(segments); index >= 0 {
+		return strings.TrimSpace(segments[index].text)
+	}
+	return ""
+}
+
 // DefaultPromptPreviewMaxRunes caps how much sanitized prompt text may be
 // considered before BuildPromptPreview withholds the majority for storage/UI.
 const DefaultPromptPreviewMaxRunes = 96
@@ -430,12 +445,9 @@ func normalizeSegmentsLatestUserFirst(values []promptSegment) []string {
 	if len(normalized) == 0 {
 		return nil
 	}
-	priorityIndex := len(normalized) - 1
-	for index := len(normalized) - 1; index >= 0; index-- {
-		if normalized[index].user {
-			priorityIndex = index
-			break
-		}
+	priorityIndex := latestUserSegmentIndex(normalized)
+	if priorityIndex < 0 {
+		priorityIndex = len(normalized) - 1
 	}
 	result := make([]string, 0, len(normalized))
 	result = append(result, normalized[priorityIndex].text)
@@ -445,6 +457,15 @@ func normalizeSegmentsLatestUserFirst(values []promptSegment) []string {
 		}
 	}
 	return result
+}
+
+func latestUserSegmentIndex(segments []promptSegment) int {
+	for index := len(segments) - 1; index >= 0; index-- {
+		if segments[index].user && strings.TrimSpace(segments[index].text) != "" {
+			return index
+		}
+	}
+	return -1
 }
 
 func buildPrioritizedScanText(segments []string) (scanText string, metadataText string) {

--- a/backend/internal/securityaudit/prompt_snapshot_test.go
+++ b/backend/internal/securityaudit/prompt_snapshot_test.go
@@ -37,6 +37,48 @@ func TestExtractPromptSnapshotProtocols(t *testing.T) {
 	}
 }
 
+func TestExtractLatestUserInput(t *testing.T) {
+	tests := []struct {
+		name, protocol, body, want string
+	}{
+		{
+			name:     "chat skips system and tool continuation",
+			protocol: "openai_chat_completions",
+			body:     `{"messages":[{"role":"system","content":"fixed system prompt"},{"role":"user","content":"actual user request"},{"role":"tool","content":"tool result"}]}`,
+			want:     "actual user request",
+		},
+		{
+			name:     "responses skips instructions and assistant",
+			protocol: "openai_responses",
+			body:     `{"instructions":"fixed system prompt","input":[{"role":"user","content":"earlier user request"},{"role":"user","content":"actual latest user request"},{"role":"assistant","content":"assistant continuation"}]}`,
+			want:     "actual latest user request",
+		},
+		{
+			name:     "messages skips system",
+			protocol: "anthropic_messages",
+			body:     `{"system":"fixed system prompt","messages":[{"role":"user","content":[{"type":"text","text":"actual message request"}]}]}`,
+			want:     "actual message request",
+		},
+		{
+			name:     "no user input",
+			protocol: "openai_chat_completions",
+			body:     `{"messages":[{"role":"system","content":"fixed system prompt"},{"role":"tool","content":"tool result"}]}`,
+			want:     "",
+		},
+		{
+			name:     "invalid JSON",
+			protocol: "openai_chat_completions",
+			body:     `{`,
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ExtractLatestUserInput(tt.protocol, []byte(tt.body)))
+		})
+	}
+}
+
 func TestSnapshotRedactsCanariesAndPreservesHashOfScanText(t *testing.T) {
 	body := `{"messages":[{"role":"user","content":"PROMPT_CANARY_ABC123 email@example.com +86 138 0013 8000 Bearer AUTH_CANARY_XYZ sk-secretvalue123 password=supersecret123"}]}`
 	snapshot, err := ExtractPromptSnapshot(Request{Protocol: "openai_chat_completions", Body: []byte(body)})

--- a/backend/internal/service/content_moderation.go
+++ b/backend/internal/service/content_moderation.go
@@ -2871,6 +2871,7 @@ type CyberPolicyRecordInput struct {
 	GroupName       string
 	Endpoint        string
 	Model           string
+	InputExcerpt    string
 	UpstreamMessage string
 	UpstreamBody    string
 	UpstreamStatus  int
@@ -2925,6 +2926,7 @@ func (s *ContentModerationService) RecordCyberPolicyEvent(ctx context.Context, i
 		Flagged:         true,
 		HighestCategory: "cyber_policy",
 		HighestScore:    1.0,
+		InputExcerpt:    trimRunes(redactContentModerationSecrets(in.InputExcerpt), maxModerationExcerptRunes),
 		Error:           trimRunes(redactContentModerationSecrets(errBody), maxModerationExcerptRunes*4),
 		CreatedAt:       time.Now(),
 	}

--- a/backend/internal/service/content_moderation_cyber_test.go
+++ b/backend/internal/service/content_moderation_cyber_test.go
@@ -110,6 +110,7 @@ func TestRecordCyberPolicyEvent_WritesLogWhenEnabled(t *testing.T) {
 		UserEmail:       "u@x.com",
 		Model:           "gpt-5",
 		Endpoint:        "/v1/responses",
+		InputExcerpt:    "latest user input",
 		UpstreamMessage: "flagged",
 		UpstreamBody:    `{"error":{"code":"cyber_policy"}}`,
 		UpstreamStatus:  400,
@@ -145,6 +146,7 @@ func TestRecordCyberPolicyEvent_WritesLogWhenEnabled(t *testing.T) {
 
 	// endpoint
 	require.Equal(t, "/v1/responses", log.Endpoint)
+	require.Equal(t, "latest user input", log.InputExcerpt)
 
 	// violation count >= 1 (side-effects ran)
 	require.GreaterOrEqual(t, log.ViolationCount, 1)
@@ -152,6 +154,35 @@ func TestRecordCyberPolicyEvent_WritesLogWhenEnabled(t *testing.T) {
 	// Error field should also contain the upstream body JSON
 	require.True(t, strings.Contains(log.Error, "cyber_policy") || strings.Contains(log.Error, "flagged"),
 		"Error should mention flagged or cyber_policy")
+}
+
+func TestRecordCyberPolicyEvent_RedactsAndLimitsInputExcerpt(t *testing.T) {
+	repo := &contentModerationTestRepo{}
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{
+			SettingKeyRiskControlEnabled: "true",
+		}},
+		repo,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	secret := "sk-proj-1234567890abcdef"
+	svc.RecordCyberPolicyEvent(context.Background(), CyberPolicyRecordInput{
+		UserID:       1,
+		Model:        "gpt-5",
+		Endpoint:     "/v1/responses",
+		InputExcerpt: secret + " " + strings.Repeat("普通用户请求内容 ", maxModerationExcerptRunes),
+	})
+
+	logs := repo.snapshotLogs()
+	require.Len(t, logs, 1)
+	require.NotContains(t, logs[0].InputExcerpt, secret)
+	require.Contains(t, logs[0].InputExcerpt, "[已脱敏]")
+	require.Len(t, []rune(logs[0].InputExcerpt), maxModerationExcerptRunes)
 }
 
 // TestRecordCyberPolicyEvent_CreateLogBeforeEmail verifies F7: the moderation


### PR DESCRIPTION
## Summary

- Persist the latest user-controlled text segment in `cyber_policy` risk-control logs through the existing `input_excerpt` field.
- Reuse Prompt Audit protocol parsing and latest-user priority selection for OpenAI Responses, Chat Completions, Anthropic Messages, and Responses WebSocket turns.
- Keep content moderation extraction unchanged: its tool-continuation behavior prevents repeated moderation scans, while cyber logging needs the most recent user input for diagnosis.
- Parse HTTP bodies only after a `cyber_policy` hit and retain only a scalar excerpt across WebSocket hooks.
- Apply the existing service-layer secret redaction and 240-rune excerpt limit before persistence.

## Why

When an upstream request is blocked by `cyber_policy`, the legacy risk-control log had no `input_excerpt`. The UI therefore fell back to the upstream error body, whose leading content is commonly a fixed system or developer prompt. That makes the actual triggering request hard to identify.

Prompt Audit already has the intended selection semantics: parse each supported protocol, walk backward to the latest user-controlled text segment, and exclude system, developer, assistant, and tool content. Exposing that selection through `securityaudit.ExtractLatestUserInput` keeps the two paths aligned without changing normal content-moderation behavior.

For a tool continuation, the logged excerpt remains the previous latest user segment. Requests with no user segment keep an empty excerpt rather than treating upstream error text as user input.

## Test plan

- [x] `go test ./internal/handler -count=1`
- [x] `go test ./internal/securityaudit -count=1`
- [x] `go test ./internal/service -run "^TestRecordCyberPolicyEvent_" -count=1`
- [x] `go test -race ./internal/handler -run "^(TestRecordCyberPolicyIfMarked_|TestClearCyberPolicyTurnState)$" -count=1`
- [x] Cover Responses, Chat Completions, Anthropic Messages, tool continuations, no-user requests, secret redaction, and rune truncation