### PR TITLE
fix(tests): make nil guards explicit for staticcheck

### DIFF
--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -847,6 +847,7 @@ func TestValidateLinuxDoFrontendRedirectURL(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for javascript scheme, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "linuxdo_connect.frontend_redirect_url") {
 		t.Fatalf("Validate() expected frontend_redirect_url error, got: %v", err)
@@ -898,6 +899,7 @@ func TestValidateOIDCScopesMustContainOpenID(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error when scopes do not include openid, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "oidc_connect.scopes") {
 		t.Fatalf("Validate() expected oidc_connect.scopes error, got: %v", err)
@@ -999,6 +1001,7 @@ func TestValidateDashboardCacheConfigEnabled(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for stats_fresh_ttl_seconds > stats_ttl_seconds, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "dashboard_cache.stats_fresh_ttl_seconds") {
 		t.Fatalf("Validate() expected stats_fresh_ttl_seconds error, got: %v", err)
@@ -1018,6 +1021,7 @@ func TestValidateDashboardCacheConfigDisabled(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for negative stats_ttl_seconds, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "dashboard_cache.stats_ttl_seconds") {
 		t.Fatalf("Validate() expected stats_ttl_seconds error, got: %v", err)
@@ -1077,6 +1081,7 @@ func TestValidateDashboardAggregationConfigDisabled(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for negative dashboard_aggregation.interval_seconds, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "dashboard_aggregation.interval_seconds") {
 		t.Fatalf("Validate() expected interval_seconds error, got: %v", err)
@@ -1096,6 +1101,7 @@ func TestValidateDashboardAggregationBackfillMaxDays(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for dashboard_aggregation.backfill_max_days, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "dashboard_aggregation.backfill_max_days") {
 		t.Fatalf("Validate() expected backfill_max_days error, got: %v", err)
@@ -1140,6 +1146,7 @@ func TestValidateUsageCleanupConfigEnabled(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for usage_cleanup.max_range_days, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "usage_cleanup.max_range_days") {
 		t.Fatalf("Validate() expected max_range_days error, got: %v", err)
@@ -1159,6 +1166,7 @@ func TestValidateUsageCleanupConfigDisabled(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for usage_cleanup.batch_size, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "usage_cleanup.batch_size") {
 		t.Fatalf("Validate() expected batch_size error, got: %v", err)
@@ -1338,6 +1346,7 @@ func TestValidateOpsCleanupScheduleRequired(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for ops.cleanup.schedule")
+		return
 	}
 	if !strings.Contains(err.Error(), "ops.cleanup.schedule") {
 		t.Fatalf("Validate() expected ops.cleanup.schedule error, got: %v", err)
@@ -1355,6 +1364,7 @@ func TestValidateConcurrencyPingInterval(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() expected error for concurrency.ping_interval")
+		return
 	}
 	if !strings.Contains(err.Error(), "concurrency.ping_interval") {
 		t.Fatalf("Validate() expected concurrency.ping_interval error, got: %v", err)
@@ -1466,6 +1476,7 @@ func TestValidateJWTSecret_UTF8Bytes(t *testing.T) {
 	err = cfg.Validate()
 	if err == nil {
 		t.Fatalf("Validate() should reject 31-byte secret")
+		return
 	}
 	if !strings.Contains(err.Error(), "at least 32 bytes") {
 		t.Fatalf("Validate() error = %v", err)

--- a/backend/internal/handler/admin/account_codex_import_test.go
+++ b/backend/internal/handler/admin/account_codex_import_test.go
@@ -226,6 +226,7 @@ func TestNormalizeCodexImportRejectsExpiredAccessToken(t *testing.T) {
 	_, err := normalizeCodexImportEntry(codexImportEntry{Index: 1, Value: expiredToken})
 	if err == nil {
 		t.Fatal("normalizeCodexImportEntry error = nil, want expired token error")
+		return
 	}
 	if !strings.Contains(err.Error(), "已过期") {
 		t.Fatalf("error = %v, want expired token message", err)
@@ -271,6 +272,7 @@ func TestResolveCodexImportExpiryForNoRefreshTokenRequiresExpiry(t *testing.T) {
 	_, _, _, _, err := resolveCodexImportExpiry(CodexSessionImportRequest{}, item)
 	if err == nil {
 		t.Fatal("resolveCodexImportExpiry error = nil, want missing expiry error")
+		return
 	}
 	if !strings.Contains(err.Error(), "无法解析 accessToken 过期时间") {
 		t.Fatalf("error = %v, want missing expiry message", err)

--- a/backend/internal/handler/admin/payment_handler_test.go
+++ b/backend/internal/handler/admin/payment_handler_test.go
@@ -34,6 +34,7 @@ func TestSanitizeAdminPaymentOrderForResponseAddsCurrency(t *testing.T) {
 	got := sanitizeAdminPaymentOrderForResponse(order)
 	if got == nil {
 		t.Fatal("expected sanitized order")
+		return
 	}
 	if got.Currency != "USD" {
 		t.Fatalf("expected currency USD, got %q", got.Currency)

--- a/backend/internal/handler/payment_handler_resume_test.go
+++ b/backend/internal/handler/payment_handler_resume_test.go
@@ -72,6 +72,7 @@ func TestApplyWeChatPaymentResumeClaimsRejectsPaymentTypeMismatch(t *testing.T) 
 	})
 	if err == nil {
 		t.Fatal("applyWeChatPaymentResumeClaims should reject mismatched payment types")
+		return
 	}
 }
 

--- a/backend/internal/payment/crypto_test.go
+++ b/backend/internal/payment/crypto_test.go
@@ -73,6 +73,7 @@ func TestDecryptWithWrongKeyFails(t *testing.T) {
 	_, err = Decrypt(encrypted, key2)
 	if err == nil {
 		t.Fatal("Decrypt with wrong key should fail, but got nil error")
+		return
 	}
 }
 
@@ -90,6 +91,7 @@ func TestEncryptRejectsInvalidKeyLength(t *testing.T) {
 		_, err := Encrypt("test", key)
 		if err == nil {
 			t.Fatalf("Encrypt should reject key of length %d", len(key))
+			return
 		}
 	}
 }
@@ -105,6 +107,7 @@ func TestDecryptRejectsInvalidKeyLength(t *testing.T) {
 		_, err := Decrypt("dummydata:dummydata:dummydata", key)
 		if err == nil {
 			t.Fatalf("Decrypt should reject key of length %d", len(key))
+			return
 		}
 	}
 }
@@ -158,6 +161,7 @@ func TestDecryptInvalidFormat(t *testing.T) {
 		_, err := Decrypt(input, key)
 		if err == nil {
 			t.Fatalf("Decrypt(%q) should fail but got nil error", input)
+			return
 		}
 	}
 }

--- a/backend/internal/payment/provider/alipay_test.go
+++ b/backend/internal/payment/provider/alipay_test.go
@@ -117,6 +117,7 @@ func TestNewAlipay(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+					return
 				}
 				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
 					t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
@@ -128,6 +129,7 @@ func TestNewAlipay(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatal("expected non-nil Alipay instance")
+				return
 			}
 			if got.instanceID != "test-instance" {
 				t.Errorf("instanceID = %q, want %q", got.instanceID, "test-instance")

--- a/backend/internal/payment/provider/easypay_refund_test.go
+++ b/backend/internal/payment/provider/easypay_refund_test.go
@@ -171,6 +171,7 @@ func TestEasyPayRefundResponseErrors(t *testing.T) {
 			})
 			if err == nil {
 				t.Fatal("Refund returned nil error")
+				return
 			}
 			if !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("Refund error = %q, want substring %q", err.Error(), tt.want)

--- a/backend/internal/payment/provider/wxpay_test.go
+++ b/backend/internal/payment/provider/wxpay_test.go
@@ -317,6 +317,7 @@ func TestNewWxpay(t *testing.T) {
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+					return
 				}
 				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
 					t.Errorf("error %q should contain %q", err.Error(), tt.errSubstr)
@@ -328,6 +329,7 @@ func TestNewWxpay(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatal("expected non-nil Wxpay instance")
+				return
 			}
 			if got.instanceID != "test-instance" {
 				t.Errorf("instanceID = %q, want %q", got.instanceID, "test-instance")
@@ -451,6 +453,7 @@ func TestResolveWxpayCreateMode(t *testing.T) {
 			if tt.wantErr != "" {
 				if err == nil {
 					t.Fatal("expected error, got nil")
+					return
 				}
 				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Fatalf("error %q should contain %q", err.Error(), tt.wantErr)
@@ -690,6 +693,7 @@ func TestCreatePaymentMobileH5ReturnsNoAuthErrorWithoutNativeFallback(t *testing
 	})
 	if err == nil {
 		t.Fatal("expected no-auth error, got nil")
+		return
 	}
 	if jsapiCalls != 0 {
 		t.Fatalf("jsapi prepay calls = %d, want 0", jsapiCalls)

--- a/backend/internal/payment/registry_test.go
+++ b/backend/internal/payment/registry_test.go
@@ -65,6 +65,7 @@ func TestRegistryGetProviderNotFound(t *testing.T) {
 	_, err := r.GetProvider("nonexistent")
 	if err == nil {
 		t.Fatal("GetProvider for unregistered type should return error")
+		return
 	}
 }
 
@@ -95,6 +96,7 @@ func TestRegistryGetProviderByKeyNotFound(t *testing.T) {
 	_, err := r.GetProviderByKey("nonexistent")
 	if err == nil {
 		t.Fatal("GetProviderByKey for unknown key should return error")
+		return
 	}
 }
 

--- a/backend/internal/payment/wire_test.go
+++ b/backend/internal/payment/wire_test.go
@@ -58,5 +58,6 @@ func TestProvideEncryptionKeyRejectsConfiguredInvalidLength(t *testing.T) {
 	_, err := ProvideEncryptionKey(cfg)
 	if err == nil {
 		t.Fatal("expected error for invalid key length")
+		return
 	}
 }

--- a/backend/internal/pkg/antigravity/client_test.go
+++ b/backend/internal/pkg/antigravity/client_test.go
@@ -291,6 +291,7 @@ func TestNewClient_无代理(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("NewClient 返回 nil")
+		return
 	}
 	if client.httpClient == nil {
 		t.Fatal("httpClient 为 nil")
@@ -311,6 +312,7 @@ func TestNewClient_有代理(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("NewClient 返回 nil")
+		return
 	}
 	if client.httpClient.Transport == nil {
 		t.Fatal("有代理时 Transport 不应为 nil")
@@ -324,6 +326,7 @@ func TestNewClient_空格代理(t *testing.T) {
 	}
 	if client == nil {
 		t.Fatal("NewClient 返回 nil")
+		return
 	}
 	// 空格代理应等同于无代理
 	if client.httpClient.Transport != nil {
@@ -336,6 +339,7 @@ func TestNewClient_无效代理URL(t *testing.T) {
 	_, err := NewClient("://invalid")
 	if err == nil {
 		t.Fatal("无效代理 URL 应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "invalid proxy URL") {
 		t.Errorf("错误信息应包含 'invalid proxy URL': got %s", err.Error())
@@ -566,6 +570,7 @@ func TestClient_ExchangeCode_无ClientSecret(t *testing.T) {
 	_, err := client.ExchangeCode(context.Background(), "code", "verifier")
 	if err == nil {
 		t.Fatal("缺少 client_secret 时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), AntigravityOAuthClientSecretEnv) {
 		t.Errorf("错误信息应包含环境变量名: got %s", err.Error())
@@ -669,6 +674,7 @@ func TestClient_RefreshToken_无ClientSecret(t *testing.T) {
 	_, err := client.RefreshToken(context.Background(), "refresh-tok")
 	if err == nil {
 		t.Fatal("缺少 client_secret 时应返回错误")
+		return
 	}
 }
 
@@ -951,6 +957,7 @@ func TestClient_ExchangeCode_ServerError_RealCall(t *testing.T) {
 	_, err := client.ExchangeCode(context.Background(), "expired-code", "verifier")
 	if err == nil {
 		t.Fatal("服务器返回 400 时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "token 交换失败") {
 		t.Errorf("错误信息应包含 'token 交换失败': got %s", err.Error())
@@ -979,6 +986,7 @@ func TestClient_ExchangeCode_InvalidJSON_RealCall(t *testing.T) {
 	_, err := client.ExchangeCode(context.Background(), "code", "verifier")
 	if err == nil {
 		t.Fatal("无效 JSON 响应应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "token 解析失败") {
 		t.Errorf("错误信息应包含 'token 解析失败': got %s", err.Error())
@@ -1006,6 +1014,7 @@ func TestClient_ExchangeCode_ContextCanceled_RealCall(t *testing.T) {
 	_, err := client.ExchangeCode(ctx, "code", "verifier")
 	if err == nil {
 		t.Fatal("context 取消时应返回错误")
+		return
 	}
 }
 
@@ -1082,6 +1091,7 @@ func TestClient_RefreshToken_ServerError_RealCall(t *testing.T) {
 	_, err := client.RefreshToken(context.Background(), "revoked-token")
 	if err == nil {
 		t.Fatal("服务器返回 401 时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "token 刷新失败") {
 		t.Errorf("错误信息应包含 'token 刷新失败': got %s", err.Error())
@@ -1107,6 +1117,7 @@ func TestClient_RefreshToken_InvalidJSON_RealCall(t *testing.T) {
 	_, err := client.RefreshToken(context.Background(), "refresh-tok")
 	if err == nil {
 		t.Fatal("无效 JSON 响应应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "token 解析失败") {
 		t.Errorf("错误信息应包含 'token 解析失败': got %s", err.Error())
@@ -1134,6 +1145,7 @@ func TestClient_RefreshToken_ContextCanceled_RealCall(t *testing.T) {
 	_, err := client.RefreshToken(ctx, "refresh-tok")
 	if err == nil {
 		t.Fatal("context 取消时应返回错误")
+		return
 	}
 }
 
@@ -1202,6 +1214,7 @@ func TestClient_GetUserInfo_Unauthorized_RealCall(t *testing.T) {
 	_, err := client.GetUserInfo(context.Background(), "bad-token")
 	if err == nil {
 		t.Fatal("服务器返回 401 时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "获取用户信息失败") {
 		t.Errorf("错误信息应包含 '获取用户信息失败': got %s", err.Error())
@@ -1226,6 +1239,7 @@ func TestClient_GetUserInfo_InvalidJSON_RealCall(t *testing.T) {
 	_, err := client.GetUserInfo(context.Background(), "token")
 	if err == nil {
 		t.Fatal("无效 JSON 响应应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "用户信息解析失败") {
 		t.Errorf("错误信息应包含 '用户信息解析失败': got %s", err.Error())
@@ -1249,6 +1263,7 @@ func TestClient_GetUserInfo_ContextCanceled_RealCall(t *testing.T) {
 	_, err := client.GetUserInfo(ctx, "token")
 	if err == nil {
 		t.Fatal("context 取消时应返回错误")
+		return
 	}
 }
 
@@ -1337,6 +1352,7 @@ func TestClient_LoadCodeAssist_Success_RealCall(t *testing.T) {
 	// 验证原始 JSON map
 	if rawResp == nil {
 		t.Fatal("rawResp 不应为 nil")
+		return
 	}
 	if rawResp["cloudaicompanionProject"] != "test-project-123" {
 		t.Errorf("rawResp cloudaicompanionProject 不匹配: got %v", rawResp["cloudaicompanionProject"])
@@ -1356,6 +1372,7 @@ func TestClient_LoadCodeAssist_HTTPError_RealCall(t *testing.T) {
 	_, _, err := client.LoadCodeAssist(context.Background(), "bad-token")
 	if err == nil {
 		t.Fatal("服务器返回 403 时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "loadCodeAssist 失败") {
 		t.Errorf("错误信息应包含 'loadCodeAssist 失败': got %s", err.Error())
@@ -1379,6 +1396,7 @@ func TestClient_LoadCodeAssist_InvalidJSON_RealCall(t *testing.T) {
 	_, _, err := client.LoadCodeAssist(context.Background(), "token")
 	if err == nil {
 		t.Fatal("无效 JSON 响应应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "响应解析失败") {
 		t.Errorf("错误信息应包含 '响应解析失败': got %s", err.Error())
@@ -1440,6 +1458,7 @@ func TestClient_LoadCodeAssist_AllURLsFail_RealCall(t *testing.T) {
 	_, _, err := client.LoadCodeAssist(context.Background(), "token")
 	if err == nil {
 		t.Fatal("所有 URL 都失败时应返回错误")
+		return
 	}
 }
 
@@ -1459,6 +1478,7 @@ func TestClient_LoadCodeAssist_ContextCanceled_RealCall(t *testing.T) {
 	_, _, err := client.LoadCodeAssist(ctx, "token")
 	if err == nil {
 		t.Fatal("context 取消时应返回错误")
+		return
 	}
 }
 
@@ -1556,6 +1576,7 @@ func TestClient_FetchAvailableModels_Success_RealCall(t *testing.T) {
 	// 验证原始 JSON map
 	if rawResp == nil {
 		t.Fatal("rawResp 不应为 nil")
+		return
 	}
 	if rawResp["models"] == nil {
 		t.Error("rawResp models 不应为 nil")
@@ -1575,6 +1596,7 @@ func TestClient_FetchAvailableModels_HTTPError_RealCall(t *testing.T) {
 	_, _, err := client.FetchAvailableModels(context.Background(), "bad-token", "proj")
 	if err == nil {
 		t.Fatal("服务器返回 403 时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "fetchAvailableModels 失败") {
 		t.Errorf("错误信息应包含 'fetchAvailableModels 失败': got %s", err.Error())
@@ -1595,6 +1617,7 @@ func TestClient_FetchAvailableModels_InvalidJSON_RealCall(t *testing.T) {
 	_, _, err := client.FetchAvailableModels(context.Background(), "token", "proj")
 	if err == nil {
 		t.Fatal("无效 JSON 响应应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "响应解析失败") {
 		t.Errorf("错误信息应包含 '响应解析失败': got %s", err.Error())
@@ -1653,6 +1676,7 @@ func TestClient_FetchAvailableModels_AllURLsFail_RealCall(t *testing.T) {
 	_, _, err := client.FetchAvailableModels(context.Background(), "token", "proj")
 	if err == nil {
 		t.Fatal("所有 URL 都失败时应返回错误")
+		return
 	}
 }
 
@@ -1672,6 +1696,7 @@ func TestClient_FetchAvailableModels_ContextCanceled_RealCall(t *testing.T) {
 	_, _, err := client.FetchAvailableModels(ctx, "token", "proj")
 	if err == nil {
 		t.Fatal("context 取消时应返回错误")
+		return
 	}
 }
 
@@ -1698,6 +1723,7 @@ func TestClient_FetchAvailableModels_EmptyModels_RealCall(t *testing.T) {
 	}
 	if rawResp == nil {
 		t.Fatal("rawResp 不应为 nil")
+		return
 	}
 }
 

--- a/backend/internal/pkg/antigravity/oauth_test.go
+++ b/backend/internal/pkg/antigravity/oauth_test.go
@@ -43,6 +43,7 @@ func TestGetClientSecret_环境变量为空(t *testing.T) {
 	_, err := getClientSecret()
 	if err == nil {
 		t.Fatal("defaultClientSecret 为空时应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), AntigravityOAuthClientSecretEnv) {
 		t.Errorf("错误信息应包含环境变量名: got %s", err.Error())
@@ -57,6 +58,7 @@ func TestGetClientSecret_环境变量未设置(t *testing.T) {
 	_, err := getClientSecret()
 	if err == nil {
 		t.Fatal("defaultClientSecret 为空时应返回错误")
+		return
 	}
 }
 
@@ -68,6 +70,7 @@ func TestGetClientSecret_环境变量含空格(t *testing.T) {
 	_, err := getClientSecret()
 	if err == nil {
 		t.Fatal("defaultClientSecret 仅含空格时应返回错误")
+		return
 	}
 }
 
@@ -135,6 +138,7 @@ func TestNewURLAvailability(t *testing.T) {
 	ua := NewURLAvailability(5 * time.Minute)
 	if ua == nil {
 		t.Fatal("NewURLAvailability 返回 nil")
+		return
 	}
 	if ua.ttl != 5*time.Minute {
 		t.Errorf("TTL 不匹配: got %v, want 5m", ua.ttl)
@@ -301,6 +305,7 @@ func TestNewSessionStore(t *testing.T) {
 
 	if store == nil {
 		t.Fatal("NewSessionStore 返回 nil")
+		return
 	}
 	if store.sessions == nil {
 		t.Error("sessions map 不应为 nil")

--- a/backend/internal/pkg/antigravity/request_transformer_test.go
+++ b/backend/internal/pkg/antigravity/request_transformer_test.go
@@ -354,6 +354,7 @@ func TestBuildGenerationConfig_ThinkingDynamicBudget(t *testing.T) {
 			cfg := buildGenerationConfig(req)
 			if cfg == nil {
 				t.Fatalf("expected non-nil generationConfig")
+				return
 			}
 
 			if tt.wantPresent {

--- a/backend/internal/pkg/httputil/body_test.go
+++ b/backend/internal/pkg/httputil/body_test.go
@@ -103,6 +103,7 @@ func TestReadRequestBodyWithPrealloc_RejectsUnsupportedEncoding(t *testing.T) {
 	_, err := ReadRequestBodyWithPrealloc(req)
 	if err == nil {
 		t.Fatal("expected error for unsupported encoding, got nil")
+		return
 	}
 	if !strings.Contains(err.Error(), "br") {
 		t.Fatalf("error should mention encoding, got %v", err)
@@ -114,6 +115,7 @@ func TestReadRequestBodyWithPrealloc_RejectsCorruptZstd(t *testing.T) {
 	_, err := ReadRequestBodyWithPrealloc(req)
 	if err == nil {
 		t.Fatal("expected error for corrupt zstd body, got nil")
+		return
 	}
 }
 

--- a/backend/internal/pkg/logger/options_test.go
+++ b/backend/internal/pkg/logger/options_test.go
@@ -98,5 +98,6 @@ func TestBuildFileCore_InvalidPathFallback(t *testing.T) {
 	_, _, err := buildFileCore(encoder, zap.NewAtomicLevel(), opts)
 	if err == nil {
 		t.Fatalf("buildFileCore() expected error for invalid path")
+		return
 	}
 }

--- a/backend/internal/pkg/proxyurl/parse_test.go
+++ b/backend/internal/pkg/proxyurl/parse_test.go
@@ -41,6 +41,7 @@ func TestParse_有效HTTP代理(t *testing.T) {
 	}
 	if parsed == nil {
 		t.Fatal("parsed 不应为 nil")
+		return
 	}
 	if parsed.Host != "proxy.example.com:8080" {
 		t.Errorf("Host 不匹配: got %q", parsed.Host)
@@ -75,6 +76,7 @@ func TestParse_无效URL(t *testing.T) {
 	_, _, err := Parse("://invalid")
 	if err == nil {
 		t.Fatal("无效 URL 应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "invalid proxy URL") {
 		t.Errorf("错误信息应包含 'invalid proxy URL': got %s", err.Error())
@@ -85,6 +87,7 @@ func TestParse_缺少Host(t *testing.T) {
 	_, _, err := Parse("http://")
 	if err == nil {
 		t.Fatal("缺少 host 应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "missing host") {
 		t.Errorf("错误信息应包含 'missing host': got %s", err.Error())
@@ -95,6 +98,7 @@ func TestParse_不支持的Scheme(t *testing.T) {
 	_, _, err := Parse("ftp://proxy.example.com:21")
 	if err == nil {
 		t.Fatal("不支持的 scheme 应返回错误")
+		return
 	}
 	if !strings.Contains(err.Error(), "unsupported proxy scheme") {
 		t.Errorf("错误信息应包含 'unsupported proxy scheme': got %s", err.Error())
@@ -124,6 +128,7 @@ func TestParse_含密码URL脱敏(t *testing.T) {
 	_, _, err = Parse("http://user:secret_password@:0/")
 	if err == nil {
 		t.Fatal("缺少 host 应返回错误")
+		return
 	}
 	if strings.Contains(err.Error(), "secret_password") {
 		t.Error("错误信息不应包含明文密码")
@@ -143,6 +148,7 @@ func TestParse_带空白的有效URL(t *testing.T) {
 	}
 	if parsed == nil {
 		t.Fatal("parsed 不应为 nil")
+		return
 	}
 }
 
@@ -211,5 +217,6 @@ func TestParse_无Scheme裸地址(t *testing.T) {
 	_, _, err := Parse("proxy.example.com:8080")
 	if err == nil {
 		t.Fatal("无 scheme 的裸地址应返回错误")
+		return
 	}
 }

--- a/backend/internal/pkg/tlsfingerprint/dialer_test.go
+++ b/backend/internal/pkg/tlsfingerprint/dialer_test.go
@@ -202,6 +202,7 @@ func TestHTTPProxyDialerBasic(t *testing.T) {
 
 	if dialer == nil {
 		t.Fatal("expected dialer to be created")
+		return
 	}
 	if dialer.profile != profile {
 		t.Error("expected profile to be set")
@@ -225,6 +226,7 @@ func TestSOCKS5ProxyDialerBasic(t *testing.T) {
 
 	if dialer == nil {
 		t.Fatal("expected dialer to be created")
+		return
 	}
 	if dialer.profile != profile {
 		t.Error("expected profile to be set")

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -218,6 +218,7 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		progress := buildCodexUsageProgressFromExtra(extra, "5h", now)
 		if progress == nil {
 			t.Fatal("expected non-nil progress")
+			return
 		}
 		if progress.Utilization != 0 {
 			t.Fatalf("expected Utilization=0 for expired window, got %v", progress.Utilization)
@@ -236,6 +237,7 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		progress := buildCodexUsageProgressFromExtra(extra, "5h", now)
 		if progress == nil {
 			t.Fatal("expected non-nil progress")
+			return
 		}
 		if progress.Utilization != 42.0 {
 			t.Fatalf("expected Utilization=42, got %v", progress.Utilization)
@@ -250,6 +252,7 @@ func TestBuildCodexUsageProgressFromExtra_ZerosExpiredWindow(t *testing.T) {
 		progress := buildCodexUsageProgressFromExtra(extra, "7d", now)
 		if progress == nil {
 			t.Fatal("expected non-nil progress")
+			return
 		}
 		if progress.Utilization != 0 {
 			t.Fatalf("expected Utilization=0 for expired 7d window, got %v", progress.Utilization)

--- a/backend/internal/service/auth_service_platform_quota_test.go
+++ b/backend/internal/service/auth_service_platform_quota_test.go
@@ -169,6 +169,7 @@ func TestResolveSignupGrantPlan_GlobalQuotaLoadedBeforeAuthSource(t *testing.T) 
 	q := plan.PlatformQuotas["anthropic"]
 	if q == nil {
 		t.Fatal("expected anthropic quota to be set")
+		return
 	}
 	if q.DailyLimitUSD == nil || *q.DailyLimitUSD != 10 {
 		t.Errorf("expected anthropic daily=10, got %v", q.DailyLimitUSD)

--- a/backend/internal/service/billing_cache_service_user_platform_quota_test.go
+++ b/backend/internal/service/billing_cache_service_user_platform_quota_test.go
@@ -374,6 +374,7 @@ func TestCheckUserPlatformQuotaEligibility_WindowExpiredRefreshesCache(t *testin
 	refreshed := cache.getEntry()
 	if refreshed == nil {
 		t.Fatal("窗口过期后 cache entry 不应为 nil(应被 SetCache 覆盖,而非 Delete)")
+		return
 	}
 	if refreshed.DailyUsageUSD != 0 {
 		t.Errorf("刷新后 DailyUsageUSD = %v, want 0", refreshed.DailyUsageUSD)
@@ -687,6 +688,7 @@ func TestCheckUserPlatformQuotaEligibility_NoRow_WritesSentinel(t *testing.T) {
 	sentinel := cache.getEntry()
 	if sentinel == nil {
 		t.Fatal("expected sentinel entry backfilled")
+		return
 	}
 	if sentinel.DailyLimitUSD != nil || sentinel.WeeklyLimitUSD != nil || sentinel.MonthlyLimitUSD != nil {
 		t.Errorf("sentinel must have all-nil limits")

--- a/backend/internal/service/channel_monitor_runner_test.go
+++ b/backend/internal/service/channel_monitor_runner_test.go
@@ -111,12 +111,14 @@ func TestSchedule_ReplaceCancelsOldTask(t *testing.T) {
 	first := runnerTaskPtr(r, 7)
 	if first == nil {
 		t.Fatal("first schedule did not register task")
+		return
 	}
 
 	r.Schedule(m)
 	second := runnerTaskPtr(r, 7)
 	if second == nil {
 		t.Fatal("second schedule did not register task")
+		return
 	}
 	if first == second {
 		t.Fatal("re-Schedule should create a new scheduledMonitor instance")

--- a/backend/internal/service/channel_monitor_service_grok_test.go
+++ b/backend/internal/service/channel_monitor_service_grok_test.go
@@ -81,5 +81,6 @@ func TestApplyMonitorUpdate_SwitchToGrokRejectsResponsesMode(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Grok responses mode should remain unsupported")
+		return
 	}
 }

--- a/backend/internal/service/crs_sync_helpers_test.go
+++ b/backend/internal/service/crs_sync_helpers_test.go
@@ -55,6 +55,7 @@ func TestBuildSelectedSet(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatalf("buildSelectedSet(%v) = nil, want non-nil map", tt.ids)
+				return
 			}
 			if len(got) != tt.wantSize {
 				t.Errorf("buildSelectedSet(%v) has %d entries, want %d", tt.ids, len(got), tt.wantSize)

--- a/backend/internal/service/gateway_service_bedrock_beta_test.go
+++ b/backend/internal/service/gateway_service_bedrock_beta_test.go
@@ -78,6 +78,7 @@ func TestResolveBedrockBetaTokensForRequest_BlocksOnOriginalAnthropicToken(t *te
 	)
 	if err == nil {
 		t.Fatal("expected raw advanced-tool-use token to be blocked before Bedrock transform")
+		return
 	}
 	if err.Error() != "advanced tool use is blocked" {
 		t.Fatalf("unexpected error: %v", err)
@@ -165,6 +166,7 @@ func TestResolveBedrockBetaTokensForRequest_BlocksBodyAutoInjectedComputerUse(t 
 	)
 	if err == nil {
 		t.Fatal("expected body-injected computer-use to be blocked")
+		return
 	}
 	if err.Error() != "computer use is blocked" {
 		t.Fatalf("unexpected error: %v", err)
@@ -210,6 +212,7 @@ func TestResolveBedrockBetaTokensForRequest_BlocksBodyAutoInjectedToolSearch(t *
 	)
 	if err == nil {
 		t.Fatal("expected body-injected tool-search-tool to be blocked")
+		return
 	}
 	if err.Error() != "tool search is blocked" {
 		t.Fatalf("unexpected error: %v", err)

--- a/backend/internal/service/gateway_service_subscription_billing_test.go
+++ b/backend/internal/service/gateway_service_subscription_billing_test.go
@@ -73,6 +73,7 @@ func TestBuildUsageBillingCommand_SubscriptionAppliesRateMultiplier(t *testing.T
 			cmd := buildUsageBillingCommand("req-1", nil, p)
 			if cmd == nil {
 				t.Fatal("buildUsageBillingCommand returned nil")
+				return
 			}
 			if cmd.SubscriptionCost != tt.wantSub {
 				t.Errorf("SubscriptionCost = %v, want %v", cmd.SubscriptionCost, tt.wantSub)

--- a/backend/internal/service/gemini_messages_compat_service_test.go
+++ b/backend/internal/service/gemini_messages_compat_service_test.go
@@ -320,6 +320,7 @@ func TestConvertClaudeToolsToGeminiTools_CustomType(t *testing.T) {
 
 			if result == nil {
 				t.Fatalf("%s: expected non-nil result", tt.description)
+				return
 			}
 
 			if len(result) != 1 {
@@ -784,6 +785,7 @@ func TestExtractGeminiUsage(t *testing.T) {
 			}
 			if got == nil {
 				t.Fatalf("期望返回非 nil，实际返回 nil")
+				return
 			}
 			if got.InputTokens != tt.wantUsage.InputTokens {
 				t.Errorf("InputTokens: 期望 %d，实际 %d", tt.wantUsage.InputTokens, got.InputTokens)
@@ -924,6 +926,7 @@ func TestParseGeminiRateLimitResetTime(t *testing.T) {
 
 			if got == nil {
 				t.Fatalf("期望返回非 nil，实际返回 nil")
+				return
 			}
 
 			// approxDelta == -1 表示只检查非 nil，不检查具体值（如 daily quota 场景）

--- a/backend/internal/service/gemini_oauth_service_test.go
+++ b/backend/internal/service/gemini_oauth_service_test.go
@@ -106,6 +106,7 @@ func TestGeminiOAuthService_GenerateAuthURL_RedirectURIStrategy(t *testing.T) {
 			if tt.wantErrSubstr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tt.wantErrSubstr)
+					return
 				}
 				if !strings.Contains(err.Error(), tt.wantErrSubstr) {
 					t.Fatalf("expected error containing %q, got: %v", tt.wantErrSubstr, err)
@@ -882,6 +883,7 @@ func TestGeminiOAuthService_RefreshToken_NonRetryableError(t *testing.T) {
 	_, err := svc.RefreshToken(context.Background(), "code_assist", "revoked-token", "")
 	if err == nil {
 		t.Fatal("RefreshToken 应返回错误（不可重试的 invalid_grant）")
+		return
 	}
 	if !strings.Contains(err.Error(), "invalid_grant") {
 		t.Fatalf("错误应包含 invalid_grant: got=%q", err.Error())
@@ -938,6 +940,7 @@ func TestGeminiOAuthService_RefreshAccountToken_NotGeminiOAuth(t *testing.T) {
 	_, err := svc.RefreshAccountToken(context.Background(), account)
 	if err == nil {
 		t.Fatal("应返回错误（非 Gemini OAuth 账号）")
+		return
 	}
 	if !strings.Contains(err.Error(), "not a Gemini OAuth account") {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -962,6 +965,7 @@ func TestGeminiOAuthService_RefreshAccountToken_NoRefreshToken(t *testing.T) {
 	_, err := svc.RefreshAccountToken(context.Background(), account)
 	if err == nil {
 		t.Fatal("应返回错误（无 refresh_token）")
+		return
 	}
 	if !strings.Contains(err.Error(), "no refresh token") {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -1220,6 +1224,7 @@ func TestGeminiOAuthService_RefreshAccountToken_CodeAssist_NoProjectID_FailsEmpt
 	_, err := svc.RefreshAccountToken(context.Background(), account)
 	if err == nil {
 		t.Fatal("应返回错误（无法检测 project_id）")
+		return
 	}
 	if !strings.Contains(err.Error(), "project_id") {
 		t.Fatalf("错误信息应包含 project_id: got=%q", err.Error())
@@ -1381,6 +1386,7 @@ func TestGeminiOAuthService_RefreshAccountToken_UnauthorizedClient_NoFallback(t 
 	_, err := svc.RefreshAccountToken(context.Background(), account)
 	if err == nil {
 		t.Fatal("应返回错误（无 fallback）")
+		return
 	}
 	if !strings.Contains(err.Error(), "OAuth client mismatch") {
 		t.Fatalf("错误应包含 OAuth client mismatch: got=%q", err.Error())
@@ -1404,6 +1410,7 @@ func TestGeminiOAuthService_ExchangeCode_SessionNotFound(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("应返回错误（session 不存在）")
+		return
 	}
 	if !strings.Contains(err.Error(), "session not found") {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -1431,6 +1438,7 @@ func TestGeminiOAuthService_ExchangeCode_InvalidState(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("应返回错误（state 不匹配）")
+		return
 	}
 	if !strings.Contains(err.Error(), "invalid state") {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -1456,6 +1464,7 @@ func TestGeminiOAuthService_ExchangeCode_EmptyState(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("应返回错误（空 state）")
+		return
 	}
 }
 

--- a/backend/internal/service/oauth_service_test.go
+++ b/backend/internal/service/oauth_service_test.go
@@ -123,6 +123,7 @@ func TestNewOAuthService(t *testing.T) {
 
 	if svc == nil {
 		t.Fatal("NewOAuthService 返回 nil")
+		return
 	}
 	if svc.proxyRepo != proxyRepo {
 		t.Fatal("proxyRepo 未正确设置")
@@ -150,6 +151,7 @@ func TestOAuthService_GenerateAuthURL(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("GenerateAuthURL 返回 nil")
+		return
 	}
 	if result.AuthURL == "" {
 		t.Fatal("AuthURL 为空")
@@ -211,6 +213,7 @@ func TestOAuthService_GenerateSetupTokenURL(t *testing.T) {
 	}
 	if result == nil {
 		t.Fatal("GenerateSetupTokenURL 返回 nil")
+		return
 	}
 
 	// 验证 scope 是 inference
@@ -235,6 +238,7 @@ func TestOAuthService_ExchangeCode_SessionNotFound(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("ExchangeCode 应返回错误（session 不存在）")
+		return
 	}
 	if err.Error() != "session not found or expired" {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -376,6 +380,7 @@ func TestOAuthService_ExchangeCode_ClientError(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("ExchangeCode 应返回错误")
+		return
 	}
 	if err.Error() != "upstream error: invalid code" {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -439,6 +444,7 @@ func TestOAuthService_RefreshToken_Error(t *testing.T) {
 	_, err := svc.RefreshToken(context.Background(), "expired-token", "")
 	if err == nil {
 		t.Fatal("RefreshToken 应返回错误")
+		return
 	}
 }
 
@@ -460,6 +466,7 @@ func TestOAuthService_RefreshAccountToken_NoRefreshToken(t *testing.T) {
 	_, err := svc.RefreshAccountToken(context.Background(), account)
 	if err == nil {
 		t.Fatal("RefreshAccountToken 应返回错误（无 refresh_token）")
+		return
 	}
 	if err.Error() != "no refresh token available" {
 		t.Fatalf("错误信息不匹配: got=%q", err.Error())
@@ -484,6 +491,7 @@ func TestOAuthService_RefreshAccountToken_EmptyRefreshToken(t *testing.T) {
 	_, err := svc.RefreshAccountToken(context.Background(), account)
 	if err == nil {
 		t.Fatal("RefreshAccountToken 应返回错误（refresh_token 为空）")
+		return
 	}
 }
 

--- a/backend/internal/service/openai_codex_models_service_test.go
+++ b/backend/internal/service/openai_codex_models_service_test.go
@@ -437,6 +437,7 @@ func TestFetchCodexModelsManifestAPIKeyCustomUpstream(t *testing.T) {
 
 	if gotRequest == nil {
 		t.Fatal("expected request to custom API key upstream")
+		return
 	}
 	if gotRequest.Method != http.MethodGet {
 		t.Errorf("method: got %q", gotRequest.Method)
@@ -655,6 +656,7 @@ func TestFetchCodexModelsManifestRejectsInvalidEnvelope(t *testing.T) {
 			)
 			if err == nil {
 				t.Fatal("expected invalid manifest error, got nil")
+				return
 			}
 			if infraerrors.Reason(err) != "OPENAI_CODEX_MODELS_UPSTREAM_INVALID_MANIFEST" {
 				t.Errorf("error reason: got %q", infraerrors.Reason(err))
@@ -1237,6 +1239,7 @@ func TestFetchCodexModelsManifestAPIKeyRejectsBaseURLFragment(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected invalid upstream base URL error, got nil")
+		return
 	}
 	if infraerrors.Reason(err) != "OPENAI_CODEX_MODELS_API_KEY_UPSTREAM_INVALID" {
 		t.Errorf("error reason: got %q", infraerrors.Reason(err))
@@ -1406,6 +1409,7 @@ func TestFetchCodexModelsManifestAPIKeyUpstreamError(t *testing.T) {
 	)
 	if err == nil {
 		t.Fatal("expected error for upstream 429, got nil")
+		return
 	}
 	if infraerrors.Code(err) != http.StatusBadGateway {
 		t.Errorf("error status: got %d, want %d", infraerrors.Code(err), http.StatusBadGateway)
@@ -1440,6 +1444,7 @@ func TestFetchCodexModelsManifestAPIKeyRejectsOfficialOpenAIBaseURL(t *testing.T
 			)
 			if err == nil {
 				t.Fatal("expected unsupported API key upstream error, got nil")
+				return
 			}
 			if infraerrors.Reason(err) != "OPENAI_CODEX_MODELS_API_KEY_UPSTREAM_UNSUPPORTED" {
 				t.Errorf("error reason: got %q", infraerrors.Reason(err))

--- a/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
+++ b/backend/internal/service/openai_gateway_service_codex_snapshot_test.go
@@ -52,6 +52,7 @@ func TestCodexResetAtRFC3339(t *testing.T) {
 		got := codexResetAtRFC3339(base, &sec)
 		if got == nil {
 			t.Fatal("expected non-nil")
+			return
 		}
 		if *got != "2026-02-16T10:01:30Z" {
 			t.Fatalf("got %s, want %s", *got, "2026-02-16T10:01:30Z")
@@ -63,6 +64,7 @@ func TestCodexResetAtRFC3339(t *testing.T) {
 		got := codexResetAtRFC3339(base, &sec)
 		if got == nil {
 			t.Fatal("expected non-nil")
+			return
 		}
 		if *got != "2026-02-16T10:00:00Z" {
 			t.Fatalf("got %s, want %s", *got, "2026-02-16T10:00:00Z")
@@ -91,6 +93,7 @@ func TestBuildCodexUsageExtraUpdates_UsesSnapshotUpdatedAt(t *testing.T) {
 	updates := buildCodexUsageExtraUpdates(snapshot, time.Date(2026, 2, 20, 8, 0, 0, 0, time.UTC))
 	if updates == nil {
 		t.Fatal("expected non-nil updates")
+		return
 	}
 
 	if got := updates["codex_usage_updated_at"]; got != "2026-02-16T10:00:00Z" {
@@ -127,6 +130,7 @@ func TestBuildCodexUsageExtraUpdates_FreshAccountUsedPercentNotInverted_Issue299
 	updates := buildCodexUsageExtraUpdates(snapshot, time.Date(2026, 2, 16, 10, 0, 0, 0, time.UTC))
 	if updates == nil {
 		t.Fatal("expected non-nil updates")
+		return
 	}
 
 	if got := updates["codex_5h_used_percent"]; got != 1.0 {
@@ -153,6 +157,7 @@ func TestBuildCodexUsageExtraUpdates_FallbackToNowWhenUpdatedAtInvalid(t *testin
 	updates := buildCodexUsageExtraUpdates(snapshot, fallbackNow)
 	if updates == nil {
 		t.Fatal("expected non-nil updates")
+		return
 	}
 
 	if got := updates["codex_usage_updated_at"]; got != "2026-02-20T08:30:00Z" {
@@ -184,6 +189,7 @@ func TestBuildCodexUsageExtraUpdates_ClampNegativeResetSeconds(t *testing.T) {
 	updates := buildCodexUsageExtraUpdates(snapshot, time.Time{})
 	if updates == nil {
 		t.Fatal("expected non-nil updates")
+		return
 	}
 
 	if got := updates["codex_5h_reset_after_seconds"]; got != -15 {
@@ -211,6 +217,7 @@ func TestBuildCodexUsageExtraUpdates_WithoutNormalizedWindowFields(t *testing.T)
 	updates := buildCodexUsageExtraUpdates(snapshot, fallbackNow)
 	if updates == nil {
 		t.Fatal("expected non-nil updates")
+		return
 	}
 
 	if got := updates["codex_usage_updated_at"]; got != "2026-02-20T09:15:00Z" {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -828,6 +828,7 @@ func TestOpenAISelectAccountForModelWithExclusions_NoModelSupport(t *testing.T) 
 	acc, err := svc.SelectAccountForModelWithExclusions(context.Background(), nil, "", "gpt-4", nil)
 	if err == nil {
 		t.Fatalf("expected error for unsupported model")
+		return
 	}
 	if acc != nil {
 		t.Fatalf("expected nil account for unsupported model")
@@ -1066,6 +1067,7 @@ func TestOpenAISelectAccountForModelWithExclusions_NoAccounts(t *testing.T) {
 	acc, err := svc.SelectAccountForModelWithExclusions(context.Background(), nil, "", "", nil)
 	if err == nil {
 		t.Fatalf("expected error for no accounts")
+		return
 	}
 	if acc != nil {
 		t.Fatalf("expected nil account")
@@ -1095,6 +1097,7 @@ func TestOpenAISelectAccountWithLoadAwareness_NoCandidates(t *testing.T) {
 	selection, err := svc.SelectAccountWithLoadAwareness(context.Background(), &groupID, "", "gpt-4", nil)
 	if err == nil {
 		t.Fatalf("expected error for no candidates")
+		return
 	}
 	if selection != nil {
 		t.Fatalf("expected nil selection")
@@ -2484,6 +2487,7 @@ func TestOpenAIInvalidBaseURLWhenAllowlistDisabled(t *testing.T) {
 	_, err := svc.buildUpstreamRequest(c.Request.Context(), c, account, []byte("{}"), "token", false, "", false)
 	if err == nil {
 		t.Fatalf("expected error for invalid base_url when allowlist disabled")
+		return
 	}
 }
 

--- a/backend/internal/service/openai_images_incomplete_test.go
+++ b/backend/internal/service/openai_images_incomplete_test.go
@@ -18,6 +18,7 @@ func TestExtractImagesUpstreamError_IncompleteIsRetryable(t *testing.T) {
 	got := extractOpenAIImagesUpstreamError([]byte(body))
 	if got == nil {
 		t.Fatal("incomplete event should produce an upstream error, got nil")
+		return
 	}
 	if got.StatusCode != http.StatusBadGateway {
 		t.Fatalf("incomplete(max_output_tokens) should be 502 retryable, got %d", got.StatusCode)
@@ -39,6 +40,7 @@ func TestExtractImagesUpstreamError_IncompleteContentFilterNotRetryable(t *testi
 	got := extractOpenAIImagesUpstreamError([]byte(body))
 	if got == nil {
 		t.Fatal("content_filter incomplete should produce error")
+		return
 	}
 	if got.StatusCode != http.StatusBadRequest {
 		t.Fatalf("content_filter should be 400 (non-retryable), got %d", got.StatusCode)
@@ -109,6 +111,7 @@ func TestImagesOAuthNonStreaming_CompletedNoImageTriggersSameAccountRetry(t *tes
 
 	if err == nil {
 		t.Fatal("completed-but-no-image should return an error")
+		return
 	}
 	var failoverErr *UpstreamFailoverError
 	if !errors.As(err, &failoverErr) {
@@ -143,6 +146,7 @@ func TestImagesOAuthNonStreaming_ContentRefusalReturns400NoRetry(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("content refusal should return an error")
+		return
 	}
 	// 应是不可重试的内容策略错误（400），而非 UpstreamFailoverError。
 	var failoverErr *UpstreamFailoverError

--- a/backend/internal/service/ops_log_runtime_test.go
+++ b/backend/internal/service/ops_log_runtime_test.go
@@ -141,6 +141,7 @@ func TestUpdateRuntimeLogConfig_InvalidConfigShouldNotApply(t *testing.T) {
 	}, 1)
 	if err == nil {
 		t.Fatalf("expected validation error")
+		return
 	}
 	if logger.CurrentLevel() != "info" {
 		t.Fatalf("logger level changed unexpectedly: %s", logger.CurrentLevel())
@@ -226,6 +227,7 @@ func TestResetRuntimeLogConfig_InvalidOperator(t *testing.T) {
 	_, err := svc.ResetRuntimeLogConfig(context.Background(), 0)
 	if err == nil {
 		t.Fatalf("expected invalid operator error")
+		return
 	}
 	if err.Error() != "invalid operator id" {
 		t.Fatalf("unexpected error: %v", err)
@@ -321,6 +323,7 @@ func TestUpdateRuntimeLogConfig_PersistFailureRollback(t *testing.T) {
 	}, 5)
 	if err == nil {
 		t.Fatalf("expected persist error")
+		return
 	}
 	// Persist failure should rollback runtime level back to old effective level.
 	if logger.CurrentLevel() != "info" {

--- a/backend/internal/service/ops_service_user_error_test.go
+++ b/backend/internal/service/ops_service_user_error_test.go
@@ -105,6 +105,7 @@ func TestGetUserErrorRequestDetail_OwnershipEnforced(t *testing.T) {
 	got, err := svc.GetUserErrorRequestDetail(context.Background(), callerUID, 42)
 	if err == nil {
 		t.Fatal("expected error for unauthorized access, got nil")
+		return
 	}
 	if got != nil {
 		t.Fatalf("expected nil detail for unauthorized access, got %+v", got)
@@ -121,6 +122,7 @@ func TestGetUserErrorRequestDetail_OwnershipEnforced(t *testing.T) {
 	}
 	if got2 == nil {
 		t.Fatal("expected non-nil detail for legitimate access")
+		return
 	}
 	if got2.ID != 42 {
 		t.Errorf("want ID=42, got %d", got2.ID)
@@ -143,6 +145,7 @@ func TestGetUserErrorRequestDetail_NotFound(t *testing.T) {
 	got, err := svc.GetUserErrorRequestDetail(context.Background(), 1, 999)
 	if err == nil {
 		t.Fatal("expected error for not found, got nil")
+		return
 	}
 	if got != nil {
 		t.Fatalf("expected nil detail, got %+v", got)
@@ -156,9 +159,11 @@ func TestGetUserErrorRequestDetail_InvalidID(t *testing.T) {
 	_, err := svc.GetUserErrorRequestDetail(context.Background(), 1, 0)
 	if err == nil {
 		t.Fatal("expected error for id=0")
+		return
 	}
 	_, err = svc.GetUserErrorRequestDetail(context.Background(), 1, -5)
 	if err == nil {
 		t.Fatal("expected error for id=-5")
+		return
 	}
 }

--- a/backend/internal/service/ops_system_log_service_test.go
+++ b/backend/internal/service/ops_system_log_service_test.go
@@ -35,6 +35,7 @@ func TestOpsServiceListSystemLogs_DefaultClampAndSuccess(t *testing.T) {
 	}
 	if gotFilter == nil {
 		t.Fatalf("expected repository to receive filter")
+		return
 	}
 	if gotFilter.Page != 1 || gotFilter.PageSize != 200 {
 		t.Fatalf("filter normalized unexpectedly: page=%d pageSize=%d", gotFilter.Page, gotFilter.PageSize)
@@ -54,6 +55,7 @@ func TestOpsServiceListSystemLogs_MonitoringDisabled(t *testing.T) {
 	_, err := svc.ListSystemLogs(context.Background(), &OpsSystemLogFilter{})
 	if err == nil {
 		t.Fatalf("expected disabled error")
+		return
 	}
 }
 
@@ -78,6 +80,7 @@ func TestOpsServiceListSystemLogs_RepoErrorMapped(t *testing.T) {
 	_, err := svc.ListSystemLogs(context.Background(), &OpsSystemLogFilter{})
 	if err == nil {
 		t.Fatalf("expected mapped internal error")
+		return
 	}
 	if !strings.Contains(err.Error(), "OPS_SYSTEM_LOG_LIST_FAILED") {
 		t.Fatalf("unexpected error: %v", err)
@@ -119,6 +122,7 @@ func TestOpsServiceCleanupSystemLogs_SuccessAndAudit(t *testing.T) {
 	}
 	if audit == nil {
 		t.Fatalf("expected cleanup audit")
+		return
 	}
 	if !strings.Contains(audit.Conditions, `"host":"api-node-1"`) {
 		t.Fatalf("audit conditions should include host: %s", audit.Conditions)
@@ -156,6 +160,7 @@ func TestOpsServiceCleanupSystemLogs_FilterRequired(t *testing.T) {
 	_, err := svc.CleanupSystemLogs(context.Background(), &OpsSystemLogCleanupFilter{}, 1)
 	if err == nil {
 		t.Fatalf("expected filter required error")
+		return
 	}
 	if !strings.Contains(strings.ToLower(err.Error()), "filter") {
 		t.Fatalf("unexpected error: %v", err)
@@ -173,6 +178,7 @@ func TestOpsServiceCleanupSystemLogs_InvalidRange(t *testing.T) {
 	}, 1)
 	if err == nil {
 		t.Fatalf("expected invalid range error")
+		return
 	}
 }
 

--- a/backend/internal/service/ops_user_error_test.go
+++ b/backend/internal/service/ops_user_error_test.go
@@ -134,6 +134,7 @@ func TestToUserErrorRequestDetail_WhitelistAndRedacts(t *testing.T) {
 	out := ToUserErrorRequestDetail(src)
 	if out == nil {
 		t.Fatal("expected non-nil detail")
+		return
 	}
 
 	// 基础字段正确映射

--- a/backend/internal/service/payment_order_result_test.go
+++ b/backend/internal/service/payment_order_result_test.go
@@ -188,6 +188,7 @@ func TestValidateSelectedCreateOrderAmountCurrencyRejectsFractionalZeroDecimal(t
 	})
 	if err == nil {
 		t.Fatal("expected fractional JPY amount to fail")
+		return
 	}
 	if appErr := infraerrors.FromError(err); appErr.Reason != "INVALID_AMOUNT" {
 		t.Fatalf("reason = %q, want INVALID_AMOUNT", appErr.Reason)
@@ -297,6 +298,7 @@ func TestCalculateCreateOrderPayAmountRejectsFractionalZeroDecimal(t *testing.T)
 	_, _, err := calculateCreateOrderPayAmount(100.5, 0, "JPY")
 	if err == nil {
 		t.Fatal("expected fractional JPY amount to fail")
+		return
 	}
 	if appErr := infraerrors.FromError(err); appErr.Reason != "INVALID_AMOUNT" {
 		t.Fatalf("reason = %q, want INVALID_AMOUNT", appErr.Reason)
@@ -391,6 +393,7 @@ func TestMaybeBuildWeChatOAuthRequiredResponse(t *testing.T) {
 	}
 	if resp == nil {
 		t.Fatal("expected oauth_required response, got nil")
+		return
 	}
 	if resp.ResultType != payment.CreatePaymentResultOAuthRequired {
 		t.Fatalf("result type = %q, want %q", resp.ResultType, payment.CreatePaymentResultOAuthRequired)
@@ -429,6 +432,7 @@ func TestMaybeBuildWeChatOAuthRequiredResponseRequiresMPConfigInWeChat(t *testin
 	}
 	if err == nil {
 		t.Fatal("expected error, got nil")
+		return
 	}
 
 	appErr := infraerrors.FromError(err)
@@ -468,6 +472,7 @@ func TestMaybeBuildWeChatOAuthRequiredResponseRequiresResumeSigningKey(t *testin
 	}
 	if err == nil {
 		t.Fatal("expected error, got nil")
+		return
 	}
 
 	appErr := infraerrors.FromError(err)
@@ -505,6 +510,7 @@ func TestMaybeBuildWeChatOAuthRequiredResponseFallsBackToConfiguredLegacySigning
 	}
 	if resp == nil {
 		t.Fatal("expected oauth-required response, got nil")
+		return
 	}
 	if resp.ResultType != payment.CreatePaymentResultOAuthRequired {
 		t.Fatalf("result type = %q, want %q", resp.ResultType, payment.CreatePaymentResultOAuthRequired)

--- a/backend/internal/service/payment_resume_service_test.go
+++ b/backend/internal/service/payment_resume_service_test.go
@@ -238,6 +238,7 @@ func TestCreateTokenRejectsMissingSigningKey(t *testing.T) {
 	_, err := svc.CreateToken(ResumeTokenClaims{OrderID: 42})
 	if err == nil {
 		t.Fatal("CreateToken should reject missing signing key")
+		return
 	}
 }
 
@@ -249,6 +250,7 @@ func TestParseTokenRejectsFallbackSignedTokenWhenSigningKeyMissing(t *testing.T)
 	_, err := svc.ParseToken(token)
 	if err == nil {
 		t.Fatal("ParseToken should reject tokens when signing key is missing")
+		return
 	}
 }
 
@@ -269,6 +271,7 @@ func TestParseTokenRejectsExpiredToken(t *testing.T) {
 	_, err = svc.ParseToken(token)
 	if err == nil {
 		t.Fatal("ParseToken should reject expired tokens")
+		return
 	}
 }
 
@@ -312,6 +315,7 @@ func TestCreateWeChatPaymentResumeTokenRejectsMissingSigningKey(t *testing.T) {
 	_, err := svc.CreateWeChatPaymentResumeToken(WeChatPaymentResumeClaims{OpenID: "openid-123"})
 	if err == nil {
 		t.Fatal("CreateWeChatPaymentResumeToken should reject missing signing key")
+		return
 	}
 }
 
@@ -327,6 +331,7 @@ func TestParseWeChatPaymentResumeTokenRejectsFallbackSignedTokenWhenSigningKeyMi
 	_, err := svc.ParseWeChatPaymentResumeToken(token)
 	if err == nil {
 		t.Fatal("ParseWeChatPaymentResumeToken should reject tokens when signing key is missing")
+		return
 	}
 }
 
@@ -347,6 +352,7 @@ func TestParseWeChatPaymentResumeTokenRejectsExpiredToken(t *testing.T) {
 	_, err = svc.ParseWeChatPaymentResumeToken(token)
 	if err == nil {
 		t.Fatal("ParseWeChatPaymentResumeToken should reject expired tokens")
+		return
 	}
 }
 
@@ -769,6 +775,7 @@ func TestVisibleMethodLoadBalancerRejectsInvalidSourceWhenMultipleProvidersEnabl
 			_, err = lb.SelectInstance(ctx, "", tt.method, payment.StrategyRoundRobin, 9.9)
 			if err == nil {
 				t.Fatal("SelectInstance should reject invalid visible method source configuration")
+				return
 			}
 			if infraerrors.Reason(err) != "INVALID_PAYMENT_VISIBLE_METHOD_SOURCE" {
 				t.Fatalf("Reason(err) = %q, want %q", infraerrors.Reason(err), "INVALID_PAYMENT_VISIBLE_METHOD_SOURCE")

--- a/backend/internal/service/ratelimit_service_anthropic_test.go
+++ b/backend/internal/service/ratelimit_service_anthropic_test.go
@@ -195,6 +195,7 @@ func TestSelectAnthropicFableWindowLimit_RejectedStatus(t *testing.T) {
 	limit := selectAnthropicFableWindowLimit(headers, now)
 	if limit == nil {
 		t.Fatal("expected non-nil limit")
+		return
 	}
 	if !limit.resetAt.Equal(reset) {
 		t.Errorf("expected resetAt=%v, got %v", reset, limit.resetAt)
@@ -216,6 +217,7 @@ func TestSelectAnthropicFableWindowLimit_UtilizationOnly(t *testing.T) {
 	limit := selectAnthropicFableWindowLimit(headers, now)
 	if limit == nil {
 		t.Fatal("expected non-nil limit")
+		return
 	}
 	if !limit.resetAt.Equal(reset) {
 		t.Errorf("expected resetAt=%v, got %v", reset, limit.resetAt)
@@ -252,6 +254,7 @@ func TestSelectAnthropicFableWindowLimit_FallsBackToAggregateReset(t *testing.T)
 	limit := selectAnthropicFableWindowLimit(headers, now)
 	if limit == nil {
 		t.Fatal("expected non-nil limit via aggregate reset fallback")
+		return
 	}
 	if !limit.resetAt.Equal(reset) {
 		t.Errorf("expected resetAt=%v, got %v", reset, limit.resetAt)

--- a/backend/internal/service/ratelimit_service_openai_test.go
+++ b/backend/internal/service/ratelimit_service_openai_test.go
@@ -31,6 +31,7 @@ func TestCalculateOpenAI429ResetTime_7dExhausted(t *testing.T) {
 
 	if resetAt == nil {
 		t.Fatal("expected non-nil resetAt")
+		return
 	}
 
 	// Should be approximately 384607 seconds from now
@@ -61,6 +62,7 @@ func TestCalculateOpenAI429ResetTime_5hExhausted(t *testing.T) {
 
 	if resetAt == nil {
 		t.Fatal("expected non-nil resetAt")
+		return
 	}
 
 	// Should be approximately 3600 seconds from now
@@ -91,6 +93,7 @@ func TestCalculateOpenAI429ResetTime_NeitherExhausted_UsesMax(t *testing.T) {
 
 	if resetAt == nil {
 		t.Fatal("expected non-nil resetAt")
+		return
 	}
 
 	// Should use the max (100000 seconds from 7d window)
@@ -135,6 +138,7 @@ func TestCalculateOpenAI429ResetTime_ReversedWindowOrder(t *testing.T) {
 
 	if resetAt == nil {
 		t.Fatal("expected non-nil resetAt")
+		return
 	}
 
 	// Should correctly identify that primary is 5h (smaller window) and use its reset time
@@ -278,6 +282,7 @@ func TestNormalizedCodexLimits(t *testing.T) {
 	normalized := snapshot.Normalize()
 	if normalized == nil {
 		t.Fatal("expected non-nil normalized")
+		return
 	}
 
 	// Primary has larger window (10080 > 300), so primary should be 7d
@@ -309,6 +314,7 @@ func TestNormalizedCodexLimits_OnlyPrimaryData(t *testing.T) {
 	normalized := snapshot.Normalize()
 	if normalized == nil {
 		t.Fatal("expected non-nil normalized")
+		return
 	}
 
 	// Legacy assumption: primary=7d, secondary=5h
@@ -388,6 +394,7 @@ func TestNormalizedCodexLimits_OnlySecondaryData(t *testing.T) {
 	normalized := snapshot.Normalize()
 	if normalized == nil {
 		t.Fatal("expected non-nil normalized")
+		return
 	}
 
 	// Legacy assumption: primary=7d, secondary=5h
@@ -422,6 +429,7 @@ func TestNormalizedCodexLimits_BothDataNoWindowMinutes(t *testing.T) {
 	normalized := snapshot.Normalize()
 	if normalized == nil {
 		t.Fatal("expected non-nil normalized")
+		return
 	}
 
 	// Legacy assumption: primary=7d, secondary=5h
@@ -485,6 +493,7 @@ func TestCalculateOpenAI429ResetTime_UserProvidedScenario(t *testing.T) {
 
 	if resetAt == nil {
 		t.Fatal("expected non-nil resetAt for user scenario")
+		return
 	}
 
 	// Should use the 7d reset time (384607 seconds) since 7d limit is exhausted (100%)

--- a/backend/internal/service/scheduler_snapshot_hydration_test.go
+++ b/backend/internal/service/scheduler_snapshot_hydration_test.go
@@ -152,6 +152,7 @@ func TestOpenAINewAcquiredSelectionResult_ReleasesSlotWhenHydrationFails(t *test
 
 	if err == nil {
 		t.Fatalf("expected hydration error")
+		return
 	}
 	if selection != nil {
 		t.Fatalf("expected nil selection on hydration error")

--- a/backend/internal/service/timing_wheel_service_test.go
+++ b/backend/internal/service/timing_wheel_service_test.go
@@ -20,6 +20,7 @@ func TestNewTimingWheelService_InitFail_NoPanicAndReturnError(t *testing.T) {
 	svc, err := NewTimingWheelService()
 	if err == nil {
 		t.Fatalf("期望返回 error，但得到 nil")
+		return
 	}
 	if svc != nil {
 		t.Fatalf("期望返回 nil svc，但得到非空")
@@ -33,6 +34,7 @@ func TestNewTimingWheelService_Success(t *testing.T) {
 	}
 	if svc == nil {
 		t.Fatalf("期望 svc 非空，但得到 nil")
+		return
 	}
 	svc.Stop()
 }
@@ -53,6 +55,7 @@ func TestNewTimingWheelService_ExecuteCallbackRunsFunc(t *testing.T) {
 	}
 	if captured == nil {
 		t.Fatalf("期望 captured 非空，但得到 nil")
+		return
 	}
 
 	called := false

--- a/backend/internal/service/wire_test.go
+++ b/backend/internal/service/wire_test.go
@@ -19,6 +19,7 @@ func TestProvideTimingWheelService_ReturnsError(t *testing.T) {
 	svc, err := ProvideTimingWheelService()
 	if err == nil {
 		t.Fatalf("期望返回 error，但得到 nil")
+		return
 	}
 	if svc != nil {
 		t.Fatalf("期望返回 nil svc，但得到非空")
@@ -32,6 +33,7 @@ func TestProvideTimingWheelService_Success(t *testing.T) {
 	}
 	if svc == nil {
 		t.Fatalf("期望 svc 非空，但得到 nil")
+		return
 	}
 	svc.Stop()
 }


### PR DESCRIPTION
## Summary
- add explicit returns to all test nil guards that call testing.T.Fatal or Fatalf
- prevent SA5011 reports when golangci-lint runs with a cold package cache
- preserve test behavior while making control flow explicit to staticcheck

## Scope
- test files only
- 173 mechanical return statements across 43 files
- no production behavior changes

## Context
- the same three main-branch SA5011 diagnostics reproduce on unrelated deployment PR #4998 and logging PR #5030
- merging this isolated baseline fix lets those PRs rebase without carrying unrelated test edits

## Verification
- `git diff --check`
- repository scan reports no remaining single-line nil/Fatal guards without an explicit return
- full upstream CI passes: shell, Go tests, frontend, golangci-lint, backend/frontend security, and CLA
- refreshed `v0.1.168` rebase: shell, backend unit/integration tests, golangci-lint, frontend, backend/frontend security, and CLA all pass