### PR TITLE
fix(logging): record cleanup success at info level

### DIFF
--- a/backend/internal/service/ops_cleanup_service.go
+++ b/backend/internal/service/ops_cleanup_service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/redis/go-redis/v9"
 	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
 )
 
 const (
@@ -285,7 +286,10 @@ func (s *OpsCleanupService) runScheduled() {
 		return
 	}
 	s.recordHeartbeatSuccess(runAt, time.Since(startedAt), counts)
-	logger.LegacyPrintf("service.ops_cleanup", "[OpsCleanup] cleanup complete: %s", counts)
+	logger.L().Info("[OpsCleanup] cleanup complete",
+		zap.String("component", "service.ops_cleanup"),
+		zap.String("deleted_counts", counts.String()),
+	)
 }
 
 func (s *OpsCleanupService) runCleanupOnce(ctx context.Context) (opsCleanupDeletedCounts, error) {


### PR DESCRIPTION
## Summary

- emit successful ops cleanup completion with an explicit structured `Info` log
- avoid `LegacyPrintf` inferring ERROR from the successful `error_logs=0` count field
- keep cleanup failures on the existing error path

## Impact

This changes logging only. Cleanup scheduling, retention, leader locking, deletion counts, heartbeat recording, and failure handling are unchanged.

## Verification

- reproduced on v0.1.166: `[OpsCleanup] cleanup complete: error_logs=0 ...` was emitted at ERROR
- `git diff --check`
- upstream CI
- refreshed `v0.1.168` rebase: shell, backend unit/integration tests, golangci-lint, frontend, backend/frontend security, and CLA all pass