### PR TITLE
fix(payment): preserve UTF-8 in EasyPay errors

### DIFF
--- a/backend/internal/payment/provider/easypay.go
+++ b/backend/internal/payment/provider/easypay.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 )
@@ -477,7 +478,11 @@ func summarizeEasyPayResponse(body []byte) string {
 		return "<empty>"
 	}
 	if len(summary) > maxEasypayErrorSummary {
-		return summary[:maxEasypayErrorSummary] + "..."
+		truncated := summary[:maxEasypayErrorSummary]
+		for len(truncated) > 0 && !utf8.ValidString(truncated) {
+			truncated = truncated[:len(truncated)-1]
+		}
+		return truncated + "..."
 	}
 	return summary
 }

--- a/backend/internal/payment/provider/easypay_refund_test.go
+++ b/backend/internal/payment/provider/easypay_refund_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/Wei-Shaw/sub2api/internal/payment"
 )
@@ -176,6 +177,18 @@ func TestEasyPayRefundResponseErrors(t *testing.T) {
 				t.Fatalf("Refund error = %q, want substring %q", err.Error(), tt.want)
 			}
 		})
+	}
+}
+
+func TestSummarizeEasyPayResponsePreservesUTF8(t *testing.T) {
+	t.Parallel()
+
+	summary := summarizeEasyPayResponse([]byte(strings.Repeat("错", 171)))
+	if !utf8.ValidString(summary) {
+		t.Fatalf("summarizeEasyPayResponse returned invalid UTF-8: %q", summary)
+	}
+	if !strings.HasSuffix(summary, "...") {
+		t.Fatalf("summarizeEasyPayResponse() = %q, want truncated suffix", summary)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve valid UTF-8 when truncating long EasyPay error responses
- add a regression test for a multibyte character crossing the 512-byte limit

## Root cause
`summary[:maxEasypayErrorSummary]` truncated by bytes and could split a UTF-8 code point. The resulting invalid string is later rendered with replacement characters, corrupting the provider error shown to users.

The fix backs up to the nearest valid UTF-8 boundary while keeping the existing byte limit and `...` suffix.

## Testing
- Before the fix: `go test ./internal/payment/provider -run '^TestSummarizeEasyPayResponsePreservesUTF8$' -count=1 -v` failed with an invalid `\xe9\x94` suffix
- `go test ./internal/payment/provider -run '^TestSummarizeEasyPayResponsePreservesUTF8$' -count=1 -v`
- `go test -tags=unit ./internal/payment/provider -count=1`
- `golangci-lint run --timeout=10m ./...` (`0 issues`)
- `go build ./cmd/server`

The local full unit run reached one unrelated existing failure in `TestContentModerationRuntimeSnapshotRefreshFailureKeepsStaleConfig`; the affected package and all other reported packages passed.

## Related issue
None found after searching open and closed issues and pull requests.