### PR TITLE
fix(release): include pricing fallback resources

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -17,6 +17,7 @@ jobs:
           /bin/bash -n deploy/apple-container.sh
           /bin/bash deploy/tests/apple-container-test.sh
           /bin/sh deploy/tests/docker-compose-security-test.sh
+          /bin/sh deploy/tests/docker-runtime-resources-test.sh
           /bin/sh deploy/test-caddyfile-cache.sh
 
   test:

--- a/.goreleaser.simple.yaml
+++ b/.goreleaser.simple.yaml
@@ -49,6 +49,7 @@ dockers:
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
+      - backend/resources
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.version={{ .Version }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,6 +65,7 @@ dockers:
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
+      - backend/resources
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -80,6 +81,7 @@ dockers:
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
+      - backend/resources
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -95,6 +97,7 @@ dockers:
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
+      - backend/resources
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.version={{ .Version }}"
@@ -110,6 +113,7 @@ dockers:
     use: buildx
     extra_files:
       - deploy/docker-entrypoint.sh
+      - backend/resources
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.version={{ .Version }}"

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -42,8 +42,9 @@ RUN addgroup -g 1000 sub2api && \
 
 WORKDIR /app
 
-# Copy pre-built binary from GoReleaser
+# Copy the pre-built binary and runtime fallback resources from GoReleaser
 COPY sub2api /app/sub2api
+COPY --chown=sub2api:sub2api backend/resources /app/resources
 
 # Create data directory
 RUN mkdir -p /app/data && chown -R sub2api:sub2api /app

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -103,8 +103,9 @@ RUN addgroup -g 1000 sub2api && \
 # Set working directory
 WORKDIR /app
 
-# Copy binary from builder
+# Copy binary and runtime fallback resources from builder
 COPY --from=backend-builder /app/sub2api /app/sub2api
+COPY --from=backend-builder --chown=sub2api:sub2api /app/backend/resources /app/resources
 
 # Create data directory
 RUN mkdir -p /app/data && chown -R sub2api:sub2api /app

--- a/deploy/tests/docker-runtime-resources-test.sh
+++ b/deploy/tests/docker-runtime-resources-test.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$repo_root"
+
+fail() {
+  printf 'docker runtime resources test failed: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_line() {
+  file=$1
+  line=$2
+  grep -Fqx "$line" "$file" || fail "$file is missing: $line"
+}
+
+assert_count() {
+  file=$1
+  line=$2
+  expected=$3
+  actual=$(grep -Fxc "$line" "$file" || true)
+  [ "$actual" -eq "$expected" ] || fail "$file has $actual occurrences of '$line', expected $expected"
+}
+
+test -s backend/resources/model-pricing/model_prices_and_context_window.json || \
+  fail 'fallback pricing data is missing or empty'
+
+assert_line Dockerfile.goreleaser 'COPY --chown=sub2api:sub2api backend/resources /app/resources'
+assert_line deploy/Dockerfile 'COPY --from=backend-builder --chown=sub2api:sub2api /app/backend/resources /app/resources'
+assert_count .goreleaser.yaml '      - backend/resources' 4
+assert_count .goreleaser.simple.yaml '      - backend/resources' 1
+
+printf 'docker runtime resources test passed\n'


### PR DESCRIPTION
## Summary

- include `backend/resources` in every GoReleaser Docker build context
- copy runtime fallback resources into GoReleaser and deploy images
- add a shell contract test covering both release configurations and runtime Dockerfiles

## Problem

The main `Dockerfile` ships `/app/resources`, but `Dockerfile.goreleaser` (used by official releases) and `deploy/Dockerfile` do not. As a result, released containers log `Fallback merge skipped` for the default `pricing.fallback_file`, leaving no bundled pricing fallback when the remote source is unavailable.

## Verification

- `git diff --check`
- local static contract assertions passed for the fallback file, both Dockerfile copy instructions, and all five GoReleaser `extra_files` entries
- GoReleaser documentation confirms directories are supported by `extra_files`
- official production image `0.1.168@sha256:85d29bfc69fa7a314cd2a35420dbe2faa6251ccbb3c3d1d4c56c732270e87479` reproduces the missing fallback warning
- refreshed `v0.1.168` rebase: shell, backend unit/integration tests, golangci-lint, frontend, backend/frontend security, and CLA all pass