### PR TITLE
fix(deploy): prevent application privilege gains

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           /bin/bash -n deploy/apple-container.sh
           /bin/bash deploy/tests/apple-container-test.sh
+          /bin/sh deploy/tests/docker-compose-security-test.sh
           /bin/sh deploy/test-caddyfile-cache.sh
 
   test:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -17,6 +17,8 @@ services:
         NPM_CONFIG_REGISTRY: ${NPM_CONFIG_REGISTRY:-https://registry.npmmirror.com}
     container_name: sub2api-dev
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     ports:
       - "${BIND_HOST:-127.0.0.1}:${SERVER_PORT:-8080}:8080"
     volumes:

--- a/deploy/docker-compose.local.yml
+++ b/deploy/docker-compose.local.yml
@@ -27,6 +27,8 @@ services:
     image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     ulimits:
       nofile:
         soft: 100000

--- a/deploy/docker-compose.standalone.yml
+++ b/deploy/docker-compose.standalone.yml
@@ -15,6 +15,8 @@ services:
     image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     ulimits:
       nofile:
         soft: 100000

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     image: weishaw/sub2api:latest
     container_name: sub2api
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     ulimits:
       nofile:
         soft: 100000

--- a/deploy/tests/docker-compose-security-test.sh
+++ b/deploy/tests/docker-compose-security-test.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+cd "$repo_root"
+
+check_application_security_opt() {
+  file=$1
+  count=$(
+    awk '
+      $0 == "  sub2api:" {
+        in_application = 1
+        next
+      }
+      in_application && $0 ~ /^  [A-Za-z0-9_-]+:$/ {
+        in_application = 0
+      }
+      in_application && $0 == "    security_opt:" {
+        in_security_opt = 1
+        next
+      }
+      in_application && in_security_opt && $0 == "      - no-new-privileges:true" {
+        count++
+      }
+      END { print count + 0 }
+    ' "$file"
+  )
+
+  if [ "$count" -ne 1 ]; then
+    printf '%s must enable no-new-privileges exactly once for the sub2api service\n' "$file" >&2
+    exit 1
+  fi
+}
+
+for compose_file in \
+  deploy/docker-compose.yml \
+  deploy/docker-compose.local.yml \
+  deploy/docker-compose.standalone.yml \
+  deploy/docker-compose.dev.yml
+do
+  check_application_security_opt "$compose_file"
+done
+
+printf 'docker compose security test passed\n'


### PR DESCRIPTION
## Summary

- enable `no-new-privileges` for the Sub2API application in all four Compose variants
- add a shell contract test that keeps the setting scoped to the application service
- run the contract in the existing deployment CI job

## Rationale

The application entrypoint starts as root only to repair `/app/data` ownership and then drops to the `sub2api` user. Without `no-new-privileges`, a compromised application process retains a path to gain privileges through future setuid/file-capability additions in the runtime image.

This change does not alter PostgreSQL or Redis, resource limits, networking, volumes, or application configuration.

## Verification

- current release image `0.1.168` completed an isolated `su-exec sub2api` transition with `no-new-privileges:true`
- production application container was recreated with this setting and verified healthy with PID 1 at UID 1000 and `NoNewPrivs: 1`
- all four Compose files pass `docker compose config --quiet`
- positive shell contract and missing-setting negative fixture pass
- `git diff --check`
- refreshed `v0.1.168` rebase: shell, backend unit/integration tests, golangci-lint, frontend, backend/frontend security, and CLA all pass