### PR TITLE
feat(ops): 支持企业微信群机器人预警通知

### DIFF
--- a/backend/internal/handler/admin/ops_alerts_handler.go
+++ b/backend/internal/handler/admin/ops_alerts_handler.go
@@ -77,13 +77,15 @@ type opsAlertRuleValidatedInput struct {
 
 	Enabled     bool
 	NotifyEmail bool
+	NotifyWeCom bool
 
-	WindowProvided    bool
-	SustainedProvided bool
-	CooldownProvided  bool
-	SeverityProvided  bool
-	EnabledProvided   bool
-	NotifyProvided    bool
+	WindowProvided      bool
+	SustainedProvided   bool
+	CooldownProvided    bool
+	SeverityProvided    bool
+	EnabledProvided     bool
+	NotifyProvided      bool
+	NotifyWeComProvided bool
 }
 
 func isPercentOrRateMetric(metricType string) bool {
@@ -196,6 +198,13 @@ func validateOpsAlertRulePayload(raw map[string]json.RawMessage) (*opsAlertRuleV
 		validated.NotifyEmail = true
 	}
 
+	if v, ok := raw["notify_wecom"]; ok {
+		validated.NotifyWeComProvided = true
+		if err := json.Unmarshal(v, &validated.NotifyWeCom); err != nil {
+			return nil, fmt.Errorf("notify_wecom must be a boolean")
+		}
+	}
+
 	if v, ok := raw["window_minutes"]; ok {
 		validated.WindowProvided = true
 		if err := json.Unmarshal(v, &validated.WindowMinutes); err != nil {
@@ -296,6 +305,7 @@ func (h *OpsHandler) CreateAlertRule(c *gin.Context) {
 	rule.Severity = validated.Severity
 	rule.Enabled = validated.Enabled
 	rule.NotifyEmail = validated.NotifyEmail
+	rule.NotifyWeCom = validated.NotifyWeCom
 
 	created, err := h.opsService.CreateAlertRule(c.Request.Context(), &rule)
 	if err != nil {
@@ -351,6 +361,7 @@ func (h *OpsHandler) UpdateAlertRule(c *gin.Context) {
 	rule.Severity = validated.Severity
 	rule.Enabled = validated.Enabled
 	rule.NotifyEmail = validated.NotifyEmail
+	rule.NotifyWeCom = validated.NotifyWeCom
 
 	updated, err := h.opsService.UpdateAlertRule(c.Request.Context(), &rule)
 	if err != nil {
@@ -551,6 +562,19 @@ func (h *OpsHandler) ListAlertEvents(c *gin.Context) {
 			filter.EmailSent = &b
 		default:
 			response.BadRequest(c, "Invalid email_sent")
+			return
+		}
+	}
+	if v := strings.TrimSpace(c.Query("wecom_sent")); v != "" {
+		switch strings.ToLower(v) {
+		case "true", "1":
+			b := true
+			filter.WeComSent = &b
+		case "false", "0":
+			b := false
+			filter.WeComSent = &b
+		default:
+			response.BadRequest(c, "Invalid wecom_sent")
 			return
 		}
 	}

--- a/backend/internal/handler/admin/ops_settings_handler.go
+++ b/backend/internal/handler/admin/ops_settings_handler.go
@@ -56,6 +56,67 @@ func (h *OpsHandler) UpdateEmailNotificationConfig(c *gin.Context) {
 	response.Success(c, updated)
 }
 
+// GetWeComNotificationConfig returns a masked WeCom bot config.
+// GET /api/v1/admin/ops/wecom-notification/config
+func (h *OpsHandler) GetWeComNotificationConfig(c *gin.Context) {
+	if h.opsService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "Ops service not available")
+		return
+	}
+	if err := h.opsService.RequireMonitoringEnabled(c.Request.Context()); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	cfg, err := h.opsService.GetWeComNotificationConfigView(c.Request.Context())
+	if err != nil {
+		response.Error(c, http.StatusInternalServerError, "Failed to get WeCom notification config")
+		return
+	}
+	response.Success(c, cfg)
+}
+
+// UpdateWeComNotificationConfig updates WeCom bot notification config.
+// PUT /api/v1/admin/ops/wecom-notification/config
+func (h *OpsHandler) UpdateWeComNotificationConfig(c *gin.Context) {
+	if h.opsService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "Ops service not available")
+		return
+	}
+	if err := h.opsService.RequireMonitoringEnabled(c.Request.Context()); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	var req service.OpsWeComNotificationConfigUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		response.BadRequest(c, "Invalid request body")
+		return
+	}
+	updated, err := h.opsService.UpdateWeComNotificationConfig(c.Request.Context(), &req)
+	if err != nil {
+		response.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	response.Success(c, updated)
+}
+
+// TestWeComNotification sends a test message without exposing the webhook.
+// POST /api/v1/admin/ops/wecom-notification/test
+func (h *OpsHandler) TestWeComNotification(c *gin.Context) {
+	if h.opsService == nil {
+		response.Error(c, http.StatusServiceUnavailable, "Ops service not available")
+		return
+	}
+	if err := h.opsService.RequireMonitoringEnabled(c.Request.Context()); err != nil {
+		response.ErrorFrom(c, err)
+		return
+	}
+	if err := h.opsService.TestWeComNotification(c.Request.Context()); err != nil {
+		response.Error(c, http.StatusBadRequest, err.Error())
+		return
+	}
+	response.Success(c, gin.H{"sent": true})
+}
+
 // GetAlertRuntimeSettings returns Ops alert evaluator runtime settings (DB-backed).
 // GET /api/v1/admin/ops/runtime/alert
 func (h *OpsHandler) GetAlertRuntimeSettings(c *gin.Context) {

--- a/backend/internal/repository/ops_repo_alerts.go
+++ b/backend/internal/repository/ops_repo_alerts.go
@@ -30,6 +30,7 @@ SELECT
   sustained_minutes,
   cooldown_minutes,
   COALESCE(notify_email, true),
+  COALESCE(notify_wecom, false),
   filters,
   last_triggered_at,
   created_at,
@@ -61,6 +62,7 @@ ORDER BY id DESC`
 			&rule.SustainedMinutes,
 			&rule.CooldownMinutes,
 			&rule.NotifyEmail,
+			&rule.NotifyWeCom,
 			&filtersRaw,
 			&lastTriggeredAt,
 			&rule.CreatedAt,
@@ -112,11 +114,12 @@ INSERT INTO ops_alert_rules (
   sustained_minutes,
   cooldown_minutes,
   notify_email,
+  notify_wecom,
   filters,
   created_at,
   updated_at
 ) VALUES (
-  $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,NOW(),NOW()
+  $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,NOW(),NOW()
 )
 RETURNING
   id,
@@ -131,6 +134,7 @@ RETURNING
   sustained_minutes,
   cooldown_minutes,
   COALESCE(notify_email, true),
+  COALESCE(notify_wecom, false),
   filters,
   last_triggered_at,
   created_at,
@@ -154,6 +158,7 @@ RETURNING
 		input.SustainedMinutes,
 		input.CooldownMinutes,
 		input.NotifyEmail,
+		input.NotifyWeCom,
 		filtersArg,
 	).Scan(
 		&out.ID,
@@ -168,6 +173,7 @@ RETURNING
 		&out.SustainedMinutes,
 		&out.CooldownMinutes,
 		&out.NotifyEmail,
+		&out.NotifyWeCom,
 		&filtersRaw,
 		&lastTriggeredAt,
 		&out.CreatedAt,
@@ -219,7 +225,8 @@ SET
   sustained_minutes = $10,
   cooldown_minutes = $11,
   notify_email = $12,
-  filters = $13,
+  notify_wecom = $13,
+  filters = $14,
   updated_at = NOW()
 WHERE id = $1
 RETURNING
@@ -235,6 +242,7 @@ RETURNING
   sustained_minutes,
   cooldown_minutes,
   COALESCE(notify_email, true),
+  COALESCE(notify_wecom, false),
   filters,
   last_triggered_at,
   created_at,
@@ -259,6 +267,7 @@ RETURNING
 		input.SustainedMinutes,
 		input.CooldownMinutes,
 		input.NotifyEmail,
+		input.NotifyWeCom,
 		filtersArg,
 	).Scan(
 		&out.ID,
@@ -273,6 +282,7 @@ RETURNING
 		&out.SustainedMinutes,
 		&out.CooldownMinutes,
 		&out.NotifyEmail,
+		&out.NotifyWeCom,
 		&filtersRaw,
 		&lastTriggeredAt,
 		&out.CreatedAt,
@@ -351,6 +361,7 @@ SELECT
   fired_at,
   resolved_at,
   email_sent,
+  COALESCE(wecom_sent, false),
   created_at
 FROM ops_alert_events
 ` + where + `
@@ -383,6 +394,7 @@ LIMIT ` + limitArg
 			&ev.FiredAt,
 			&resolvedAt,
 			&ev.EmailSent,
+			&ev.WeComSent,
 			&ev.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -435,6 +447,7 @@ SELECT
   fired_at,
   resolved_at,
   email_sent,
+  COALESCE(wecom_sent, false),
   created_at
 FROM ops_alert_events
 WHERE id = $1`
@@ -472,6 +485,7 @@ SELECT
   fired_at,
   resolved_at,
   email_sent,
+  COALESCE(wecom_sent, false),
   created_at
 FROM ops_alert_events
 WHERE rule_id = $1 AND status = $2
@@ -511,6 +525,7 @@ SELECT
   fired_at,
   resolved_at,
   email_sent,
+  COALESCE(wecom_sent, false),
   created_at
 FROM ops_alert_events
 WHERE rule_id = $1
@@ -554,9 +569,10 @@ INSERT INTO ops_alert_events (
   fired_at,
   resolved_at,
   email_sent,
+  wecom_sent,
   created_at
 ) VALUES (
-  $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,NOW()
+  $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,NOW()
 )
 RETURNING
   id,
@@ -571,6 +587,7 @@ RETURNING
   fired_at,
   resolved_at,
   email_sent,
+  COALESCE(wecom_sent, false),
   created_at`
 
 	row := r.db.QueryRowContext(
@@ -587,6 +604,7 @@ RETURNING
 		event.FiredAt,
 		opsNullTime(event.ResolvedAt),
 		event.EmailSent,
+		event.WeComSent,
 	)
 	return scanOpsAlertEvent(row)
 }
@@ -621,6 +639,18 @@ func (r *opsRepository) UpdateAlertEventEmailSent(ctx context.Context, eventID i
 	}
 
 	_, err := r.db.ExecContext(ctx, "UPDATE ops_alert_events SET email_sent = $2 WHERE id = $1", eventID, emailSent)
+	return err
+}
+
+func (r *opsRepository) UpdateAlertEventWeComSent(ctx context.Context, eventID int64, weComSent bool) error {
+	if r == nil || r.db == nil {
+		return fmt.Errorf("nil ops repository")
+	}
+	if eventID <= 0 {
+		return fmt.Errorf("invalid event id")
+	}
+
+	_, err := r.db.ExecContext(ctx, "UPDATE ops_alert_events SET wecom_sent = $2 WHERE id = $1", eventID, weComSent)
 	return err
 }
 
@@ -763,6 +793,7 @@ func scanOpsAlertEvent(row opsAlertEventRow) (*service.OpsAlertEvent, error) {
 		&ev.FiredAt,
 		&resolvedAt,
 		&ev.EmailSent,
+		&ev.WeComSent,
 		&ev.CreatedAt,
 	); err != nil {
 		return nil, err
@@ -807,6 +838,10 @@ func buildOpsAlertEventsWhere(filter *service.OpsAlertEventFilter) (string, []an
 	if filter.EmailSent != nil {
 		args = append(args, *filter.EmailSent)
 		clauses = append(clauses, "email_sent = $"+itoa(len(args)))
+	}
+	if filter.WeComSent != nil {
+		args = append(args, *filter.WeComSent)
+		clauses = append(clauses, "wecom_sent = $"+itoa(len(args)))
 	}
 	if filter.StartTime != nil && !filter.StartTime.IsZero() {
 		args = append(args, *filter.StartTime)

--- a/backend/internal/server/routes/admin.go
+++ b/backend/internal/server/routes/admin.go
@@ -199,6 +199,9 @@ func registerOpsRoutes(admin *gin.RouterGroup, h *handler.Handlers) {
 		// Email notification config (DB-backed)
 		ops.GET("/email-notification/config", h.Admin.Ops.GetEmailNotificationConfig)
 		ops.PUT("/email-notification/config", h.Admin.Ops.UpdateEmailNotificationConfig)
+		ops.GET("/wecom-notification/config", h.Admin.Ops.GetWeComNotificationConfig)
+		ops.PUT("/wecom-notification/config", h.Admin.Ops.UpdateWeComNotificationConfig)
+		ops.POST("/wecom-notification/test", h.Admin.Ops.TestWeComNotification)
 
 		// Runtime settings (DB-backed)
 		runtime := ops.Group("/runtime")

--- a/backend/internal/service/audit_log.go
+++ b/backend/internal/service/audit_log.go
@@ -131,8 +131,9 @@ var auditBodySensitiveExactKeys = func() map[string]struct{} {
 		// 字符串值内嵌完整凭证的字段：
 		// proxy_key 为 protocol|host|port|username|password 拼接，
 		// custom_key 为用户自设的平台 API Key 明文，
-		// session 为 Ollama Cloud 用量的浏览器会话 Cookie 明文。
-		"proxy_key", "custom_key", "session",
+		// session 为 Ollama Cloud 用量的浏览器会话 Cookie 明文，
+		// webhook_url 为企业微信群机器人的完整访问凭据。
+		"proxy_key", "custom_key", "session", "webhook_url",
 	}
 	set := make(map[string]struct{}, len(builtin)+len(SensitiveCredentialKeys)+16)
 	for _, k := range builtin {

--- a/backend/internal/service/audit_log_test.go
+++ b/backend/internal/service/audit_log_test.go
@@ -76,6 +76,14 @@ func TestRedactAuditBody_BareSessionKeyRedacted(t *testing.T) {
 	}
 }
 
+func TestRedactAuditBody_RedactsWebhookURL(t *testing.T) {
+	const secret = "wecom-secret-value"
+	out := RedactAuditBody([]byte(`{"enabled":true,"webhook_url":"https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=`+secret+`"}`), "application/json")
+	if strings.Contains(out, secret) || !strings.Contains(out, `"webhook_url":"***"`) {
+		t.Fatalf("webhook_url was not redacted: %s", out)
+	}
+}
+
 // TestRedactAuditBody_AuthoritativeTablesSynced 覆盖曾经漏网的凭证字段：
 // 账号 credentials 敏感子键、支付渠道无分隔符密钥、字符串值内嵌凭证的 proxy_key / custom_key，
 // 以及 camelCase 等命名变体（归一化比对）。

--- a/backend/internal/service/domain_constants.go
+++ b/backend/internal/service/domain_constants.go
@@ -356,6 +356,9 @@ const (
 	// SettingKeyOpsEmailNotificationConfig stores JSON config for ops email notifications.
 	SettingKeyOpsEmailNotificationConfig = "ops_email_notification_config"
 
+	// SettingKeyOpsWeComNotificationConfig stores JSON config for ops WeCom bot notifications.
+	SettingKeyOpsWeComNotificationConfig = "ops_wecom_notification_config"
+
 	// SettingKeyOpsAlertRuntimeSettings stores JSON config for ops alert evaluator runtime settings.
 	SettingKeyOpsAlertRuntimeSettings = "ops_alert_runtime_settings"
 

--- a/backend/internal/service/ops_alert_evaluator_service.go
+++ b/backend/internal/service/ops_alert_evaluator_service.go
@@ -50,6 +50,7 @@ type OpsAlertEvaluatorService struct {
 	ruleStates map[int64]*opsAlertRuleState
 
 	emailLimiter *slidingWindowLimiter
+	weComLimiter *slidingWindowLimiter
 
 	skipLogMu sync.Mutex
 	skipLogAt time.Time
@@ -80,6 +81,7 @@ func NewOpsAlertEvaluatorService(
 		instanceID:   uuid.NewString(),
 		ruleStates:   map[int64]*opsAlertRuleState{},
 		emailLimiter: newSlidingWindowLimiter(0, time.Hour),
+		weComLimiter: newSlidingWindowLimiter(0, time.Hour),
 	}
 }
 
@@ -199,6 +201,7 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 	eventsCreated := 0
 	eventsResolved := 0
 	emailsSent := 0
+	weComSent := 0
 
 	now := time.Now().UTC()
 	safeEnd := now.Truncate(time.Minute)
@@ -295,6 +298,9 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 				if s.maybeSendAlertEmail(ctx, runtimeCfg, rule, created) {
 					emailsSent++
 				}
+				if s.maybeSendAlertWeCom(ctx, runtimeCfg, rule, created) {
+					weComSent++
+				}
 			}
 			continue
 		}
@@ -306,11 +312,16 @@ func (s *OpsAlertEvaluatorService) evaluateOnce(interval time.Duration) {
 				logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] resolve event failed (event=%d): %v", activeEvent.ID, err)
 			} else {
 				eventsResolved++
+				activeEvent.Status = OpsAlertStatusResolved
+				activeEvent.ResolvedAt = &resolvedAt
+				if s.maybeSendAlertWeCom(ctx, runtimeCfg, rule, activeEvent) {
+					weComSent++
+				}
 			}
 		}
 	}
 
-	result := truncateString(fmt.Sprintf("rules=%d enabled=%d evaluated=%d created=%d resolved=%d emails_sent=%d", rulesTotal, rulesEnabled, rulesEvaluated, eventsCreated, eventsResolved, emailsSent), 2048)
+	result := truncateString(fmt.Sprintf("rules=%d enabled=%d evaluated=%d created=%d resolved=%d emails_sent=%d wecom_sent=%d", rulesTotal, rulesEnabled, rulesEvaluated, eventsCreated, eventsResolved, emailsSent, weComSent), 2048)
 	s.recordHeartbeatSuccess(runAt, time.Since(startedAt), result)
 }
 
@@ -745,6 +756,82 @@ func (s *OpsAlertEvaluatorService) maybeSendAlertEmail(ctx context.Context, runt
 		_ = s.opsRepo.UpdateAlertEventEmailSent(context.Background(), event.ID, true)
 	}
 	return anySent
+}
+
+func (s *OpsAlertEvaluatorService) maybeSendAlertWeCom(ctx context.Context, runtimeCfg *OpsAlertRuntimeSettings, rule *OpsAlertRule, event *OpsAlertEvent) bool {
+	if s == nil || s.opsService == nil || s.opsService.weComNotifier == nil || s.opsRepo == nil || event == nil || rule == nil {
+		return false
+	}
+	isResolved := event.Status == OpsAlertStatusResolved || event.Status == OpsAlertStatusManualResolved
+	if !isResolved && event.WeComSent {
+		return false
+	}
+	if !rule.NotifyWeCom {
+		return false
+	}
+	cfg, err := s.opsService.GetWeComNotificationConfig(ctx)
+	if err != nil || cfg == nil || !cfg.Enabled || strings.TrimSpace(cfg.WebhookURL) == "" {
+		return false
+	}
+	if isResolved && !cfg.IncludeResolvedAlerts {
+		return false
+	}
+	if !shouldSendOpsAlertWeComByMinSeverity(cfg.MinSeverity, rule.Severity) {
+		return false
+	}
+	if runtimeCfg != nil && runtimeCfg.Silencing.Enabled && isOpsAlertSilenced(time.Now().UTC(), rule, event, runtimeCfg.Silencing) {
+		return false
+	}
+	s.weComLimiter.SetLimit(cfg.RateLimitPerHour)
+	if !s.weComLimiter.Allow(time.Now().UTC()) {
+		return false
+	}
+	if err := s.opsService.weComNotifier.SendMarkdown(ctx, cfg.WebhookURL, buildOpsAlertWeComMarkdown(rule, event)); err != nil {
+		logger.LegacyPrintf("service.ops_alert_evaluator", "[OpsAlertEvaluator] send WeCom notification failed (event=%d): %v", event.ID, err)
+		return false
+	}
+	event.WeComSent = true
+	if updater, ok := s.opsRepo.(interface {
+		UpdateAlertEventWeComSent(context.Context, int64, bool) error
+	}); ok {
+		_ = updater.UpdateAlertEventWeComSent(context.Background(), event.ID, true)
+	}
+	return true
+}
+
+func shouldSendOpsAlertWeComByMinSeverity(minSeverity, severity string) bool {
+	minSeverity = strings.ToUpper(strings.TrimSpace(minSeverity))
+	severity = strings.ToUpper(strings.TrimSpace(severity))
+	if minSeverity == "" {
+		return true
+	}
+	rank := map[string]int{"P0": 0, "P1": 1, "P2": 2, "P3": 3}
+	minRank, minOK := rank[minSeverity]
+	severityRank, severityOK := rank[severity]
+	return minOK && severityOK && severityRank <= minRank
+}
+
+func buildOpsAlertWeComMarkdown(rule *OpsAlertRule, event *OpsAlertEvent) string {
+	status := "触发"
+	if event != nil && (event.Status == OpsAlertStatusResolved || event.Status == OpsAlertStatusManualResolved) {
+		status = "恢复"
+	}
+	name, severity, description := "-", "-", "-"
+	if rule != nil {
+		name = strings.TrimSpace(rule.Name)
+		severity = strings.TrimSpace(rule.Severity)
+	}
+	if event != nil && strings.TrimSpace(event.Description) != "" {
+		description = strings.TrimSpace(event.Description)
+	}
+	content := fmt.Sprintf("## Sub2API 运维预警%s\n> 级别：**%s**\n> 规则：%s\n> 详情：%s", status, severity, name, description)
+	if event != nil && !event.FiredAt.IsZero() {
+		content += "\n> 触发时间：" + event.FiredAt.UTC().Format(time.RFC3339)
+	}
+	if event != nil && event.ResolvedAt != nil {
+		content += "\n> 恢复时间：" + event.ResolvedAt.UTC().Format(time.RFC3339)
+	}
+	return content
 }
 
 func opsAlertEmailVariables(rule *OpsAlertRule, event *OpsAlertEvent) map[string]string {

--- a/backend/internal/service/ops_alert_models.go
+++ b/backend/internal/service/ops_alert_models.go
@@ -30,6 +30,7 @@ type OpsAlertRule struct {
 	CooldownMinutes  int `json:"cooldown_minutes"`
 
 	NotifyEmail bool `json:"notify_email"`
+	NotifyWeCom bool `json:"notify_wecom"`
 
 	Filters map[string]any `json:"filters,omitempty"`
 
@@ -56,6 +57,7 @@ type OpsAlertEvent struct {
 	ResolvedAt *time.Time `json:"resolved_at,omitempty"`
 
 	EmailSent bool      `json:"email_sent"`
+	WeComSent bool      `json:"wecom_sent"`
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -85,6 +87,7 @@ type OpsAlertEventFilter struct {
 	Status    string
 	Severity  string
 	EmailSent *bool
+	WeComSent *bool
 
 	StartTime *time.Time
 	EndTime   *time.Time

--- a/backend/internal/service/ops_service.go
+++ b/backend/internal/service/ops_service.go
@@ -62,6 +62,7 @@ type OpsService struct {
 	ingressRejectAggregator     *OpsIngressRejectAggregator
 	authCacheInvalidationWorker *AuthCacheInvalidationWorker
 	apiKeyService               *APIKeyService
+	weComNotifier               OpsWeComNotifier
 
 	// cleanupReloader 由 wire 在 OpsCleanupService 构造完成后通过 SetCleanupReloader 注入。
 	// 解耦避免 OpsService -> OpsCleanupService 的硬依赖（cleanup 也读 settings，会循环）。
@@ -137,10 +138,18 @@ func NewOpsService(
 		geminiCompatService:       geminiCompatService,
 		antigravityGatewayService: antigravityGatewayService,
 		systemLogSink:             systemLogSink,
+		weComNotifier:             newOpsWeComHTTPNotifier(),
 	}
 	svc.initRuntimeSettings(context.Background())
 	svc.applyRuntimeLogConfigOnStartup(context.Background())
 	return svc
+}
+
+// SetWeComNotifier replaces the notifier for tests and alternate transports.
+func (s *OpsService) SetWeComNotifier(notifier OpsWeComNotifier) {
+	if s != nil {
+		s.weComNotifier = notifier
+	}
 }
 
 func (s *OpsService) RequireMonitoringEnabled(ctx context.Context) error {

--- a/backend/internal/service/ops_settings_models.go
+++ b/backend/internal/service/ops_settings_models.go
@@ -38,6 +38,34 @@ type OpsEmailNotificationConfigUpdateRequest struct {
 	Report *OpsEmailReportConfig `json:"report"`
 }
 
+// OpsWeComNotificationConfig is stored internally. WebhookURL must never be
+// returned by an admin API or written to logs.
+type OpsWeComNotificationConfig struct {
+	Enabled               bool   `json:"enabled"`
+	WebhookURL            string `json:"webhook_url"`
+	MinSeverity           string `json:"min_severity"`
+	RateLimitPerHour      int    `json:"rate_limit_per_hour"`
+	IncludeResolvedAlerts bool   `json:"include_resolved_alerts"`
+}
+
+type OpsWeComNotificationConfigView struct {
+	Enabled               bool   `json:"enabled"`
+	WebhookConfigured     bool   `json:"webhook_configured"`
+	WebhookURLMasked      string `json:"webhook_url_masked,omitempty"`
+	MinSeverity           string `json:"min_severity"`
+	RateLimitPerHour      int    `json:"rate_limit_per_hour"`
+	IncludeResolvedAlerts bool   `json:"include_resolved_alerts"`
+}
+
+type OpsWeComNotificationConfigUpdateRequest struct {
+	Enabled               bool    `json:"enabled"`
+	WebhookURL            *string `json:"webhook_url,omitempty"`
+	ClearWebhook          bool    `json:"clear_webhook,omitempty"`
+	MinSeverity           string  `json:"min_severity"`
+	RateLimitPerHour      int     `json:"rate_limit_per_hour"`
+	IncludeResolvedAlerts bool    `json:"include_resolved_alerts"`
+}
+
 type OpsDistributedLockSettings struct {
 	Enabled    bool   `json:"enabled"`
 	Key        string `json:"key"`

--- a/backend/internal/service/ops_wecom_notification.go
+++ b/backend/internal/service/ops_wecom_notification.go
@@ -1,0 +1,252 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	opsWeComWebhookHost = "qyapi.weixin.qq.com"
+	opsWeComWebhookPath = "/cgi-bin/webhook/send"
+)
+
+type OpsWeComNotifier interface {
+	SendMarkdown(ctx context.Context, webhookURL, content string) error
+}
+
+type opsWeComHTTPNotifier struct {
+	client *http.Client
+}
+
+func newOpsWeComHTTPNotifier() OpsWeComNotifier {
+	return &opsWeComHTTPNotifier{
+		client: &http.Client{
+			Timeout: 8 * time.Second,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+}
+
+func (n *opsWeComHTTPNotifier) SendMarkdown(ctx context.Context, webhookURL, content string) error {
+	if err := validateOpsWeComWebhookURL(webhookURL); err != nil {
+		return err
+	}
+	if n == nil || n.client == nil {
+		return errors.New("wecom notifier not initialized")
+	}
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return errors.New("wecom message is empty")
+	}
+	if len(content) > 4000 {
+		content = content[:4000]
+	}
+	payload, err := json.Marshal(map[string]any{
+		"msgtype": "markdown",
+		"markdown": map[string]string{
+			"content": content,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return errors.New("failed to build wecom request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		return errors.New("failed to send wecom notification")
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return errors.New("failed to read wecom response")
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("wecom returned HTTP %d", resp.StatusCode)
+	}
+	var result struct {
+		ErrCode int    `json:"errcode"`
+		ErrMsg  string `json:"errmsg"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return errors.New("invalid wecom response")
+	}
+	if result.ErrCode != 0 {
+		return fmt.Errorf("wecom returned error code %d", result.ErrCode)
+	}
+	return nil
+}
+
+func (s *OpsService) GetWeComNotificationConfig(ctx context.Context) (*OpsWeComNotificationConfig, error) {
+	defaultCfg := defaultOpsWeComNotificationConfig()
+	if s == nil || s.settingRepo == nil {
+		return defaultCfg, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	raw, err := s.settingRepo.GetValue(ctx, SettingKeyOpsWeComNotificationConfig)
+	if err != nil {
+		if errors.Is(err, ErrSettingNotFound) {
+			return defaultCfg, nil
+		}
+		return nil, err
+	}
+	cfg := &OpsWeComNotificationConfig{}
+	if err := json.Unmarshal([]byte(raw), cfg); err != nil {
+		return defaultCfg, nil
+	}
+	normalizeOpsWeComNotificationConfig(cfg)
+	return cfg, nil
+}
+
+func (s *OpsService) GetWeComNotificationConfigView(ctx context.Context) (*OpsWeComNotificationConfigView, error) {
+	cfg, err := s.GetWeComNotificationConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return opsWeComNotificationConfigView(cfg), nil
+}
+
+func (s *OpsService) UpdateWeComNotificationConfig(ctx context.Context, req *OpsWeComNotificationConfigUpdateRequest) (*OpsWeComNotificationConfigView, error) {
+	if s == nil || s.settingRepo == nil {
+		return nil, errors.New("setting repository not initialized")
+	}
+	if req == nil {
+		return nil, errors.New("invalid request")
+	}
+	cfg, err := s.GetWeComNotificationConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Enabled = req.Enabled
+	cfg.MinSeverity = strings.ToUpper(strings.TrimSpace(req.MinSeverity))
+	cfg.RateLimitPerHour = req.RateLimitPerHour
+	cfg.IncludeResolvedAlerts = req.IncludeResolvedAlerts
+	if req.ClearWebhook {
+		cfg.WebhookURL = ""
+	} else if req.WebhookURL != nil {
+		cfg.WebhookURL = strings.TrimSpace(*req.WebhookURL)
+	}
+	if err := validateOpsWeComNotificationConfig(cfg); err != nil {
+		return nil, err
+	}
+	encoded, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.settingRepo.Set(ctx, SettingKeyOpsWeComNotificationConfig, string(encoded)); err != nil {
+		return nil, err
+	}
+	return opsWeComNotificationConfigView(cfg), nil
+}
+
+func (s *OpsService) TestWeComNotification(ctx context.Context) error {
+	if s == nil || s.weComNotifier == nil {
+		return errors.New("wecom notifier not initialized")
+	}
+	cfg, err := s.GetWeComNotificationConfig(ctx)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(cfg.WebhookURL) == "" {
+		return errors.New("wecom webhook is not configured")
+	}
+	content := fmt.Sprintf("## Sub2API 企业微信通知测试\n> 配置验证成功\n> 时间：%s", time.Now().UTC().Format(time.RFC3339))
+	return s.weComNotifier.SendMarkdown(ctx, cfg.WebhookURL, content)
+}
+
+func defaultOpsWeComNotificationConfig() *OpsWeComNotificationConfig {
+	return &OpsWeComNotificationConfig{
+		Enabled:               false,
+		MinSeverity:           "",
+		RateLimitPerHour:      0,
+		IncludeResolvedAlerts: true,
+	}
+}
+
+func normalizeOpsWeComNotificationConfig(cfg *OpsWeComNotificationConfig) {
+	if cfg == nil {
+		return
+	}
+	cfg.WebhookURL = strings.TrimSpace(cfg.WebhookURL)
+	cfg.MinSeverity = strings.ToUpper(strings.TrimSpace(cfg.MinSeverity))
+}
+
+func validateOpsWeComNotificationConfig(cfg *OpsWeComNotificationConfig) error {
+	if cfg == nil {
+		return errors.New("invalid config")
+	}
+	if cfg.RateLimitPerHour < 0 {
+		return errors.New("rate_limit_per_hour must be >= 0")
+	}
+	switch cfg.MinSeverity {
+	case "", "P0", "P1", "P2", "P3":
+	default:
+		return errors.New("min_severity must be one of: P0, P1, P2, P3")
+	}
+	if cfg.WebhookURL != "" {
+		if err := validateOpsWeComWebhookURL(cfg.WebhookURL); err != nil {
+			return err
+		}
+	}
+	if cfg.Enabled && cfg.WebhookURL == "" {
+		return errors.New("webhook_url is required when enabled")
+	}
+	return nil
+}
+
+func validateOpsWeComWebhookURL(raw string) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return errors.New("invalid wecom webhook URL")
+	}
+	if parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), opsWeComWebhookHost) || parsed.Port() != "" {
+		return errors.New("webhook_url must use the official WeCom HTTPS host")
+	}
+	if parsed.Path != opsWeComWebhookPath || parsed.User != nil || parsed.Fragment != "" || strings.TrimSpace(parsed.Query().Get("key")) == "" {
+		return errors.New("invalid wecom webhook URL")
+	}
+	return nil
+}
+
+func opsWeComNotificationConfigView(cfg *OpsWeComNotificationConfig) *OpsWeComNotificationConfigView {
+	if cfg == nil {
+		cfg = defaultOpsWeComNotificationConfig()
+	}
+	return &OpsWeComNotificationConfigView{
+		Enabled:               cfg.Enabled,
+		WebhookConfigured:     strings.TrimSpace(cfg.WebhookURL) != "",
+		WebhookURLMasked:      maskOpsWeComWebhookURL(cfg.WebhookURL),
+		MinSeverity:           cfg.MinSeverity,
+		RateLimitPerHour:      cfg.RateLimitPerHour,
+		IncludeResolvedAlerts: cfg.IncludeResolvedAlerts,
+	}
+}
+
+func maskOpsWeComWebhookURL(raw string) string {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || parsed.Query().Get("key") == "" {
+		return ""
+	}
+	key := parsed.Query().Get("key")
+	suffix := key
+	if len(suffix) > 4 {
+		suffix = suffix[len(suffix)-4:]
+	}
+	return "https://" + opsWeComWebhookHost + opsWeComWebhookPath + "?key=****" + suffix
+}

--- a/backend/internal/service/ops_wecom_notification_test.go
+++ b/backend/internal/service/ops_wecom_notification_test.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type opsWeComNotifierStub struct {
+	content string
+	url     string
+	err     error
+}
+
+func (s *opsWeComNotifierStub) SendMarkdown(_ context.Context, webhookURL, content string) error {
+	s.url = webhookURL
+	s.content = content
+	return s.err
+}
+
+func TestValidateOpsWeComWebhookURL(t *testing.T) {
+	valid := "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=1234567890abcdef"
+	if err := validateOpsWeComWebhookURL(valid); err != nil {
+		t.Fatalf("valid URL rejected: %v", err)
+	}
+	for _, raw := range []string{
+		"http://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=x",
+		"https://example.com/cgi-bin/webhook/send?key=x",
+		"https://qyapi.weixin.qq.com/cgi-bin/webhook/send",
+		"https://qyapi.weixin.qq.com.evil.test/cgi-bin/webhook/send?key=x",
+	} {
+		if err := validateOpsWeComWebhookURL(raw); err == nil {
+			t.Fatalf("unsafe URL accepted: %s", raw)
+		}
+	}
+}
+
+func TestOpsWeComConfigMasksWebhookAndPreservesSecret(t *testing.T) {
+	repo := newRuntimeSettingRepoStub()
+	svc := &OpsService{settingRepo: repo}
+	webhook := "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=1234567890abcdef"
+
+	view, err := svc.UpdateWeComNotificationConfig(context.Background(), &OpsWeComNotificationConfigUpdateRequest{
+		Enabled:          true,
+		WebhookURL:       &webhook,
+		MinSeverity:      "P1",
+		RateLimitPerHour: 20,
+	})
+	if err != nil {
+		t.Fatalf("UpdateWeComNotificationConfig() error = %v", err)
+	}
+	if !view.WebhookConfigured || strings.Contains(view.WebhookURLMasked, "1234567890abcdef") {
+		t.Fatalf("webhook was not masked: %#v", view)
+	}
+	if strings.Contains(view.WebhookURLMasked, "webhook/send?key=1234") {
+		t.Fatalf("webhook prefix leaked: %s", view.WebhookURLMasked)
+	}
+
+	loaded, err := svc.GetWeComNotificationConfig(context.Background())
+	if err != nil {
+		t.Fatalf("GetWeComNotificationConfig() error = %v", err)
+	}
+	if loaded.WebhookURL != webhook {
+		t.Fatalf("stored webhook changed: %q", loaded.WebhookURL)
+	}
+
+	view, err = svc.UpdateWeComNotificationConfig(context.Background(), &OpsWeComNotificationConfigUpdateRequest{
+		Enabled:          true,
+		MinSeverity:      "P2",
+		RateLimitPerHour: 10,
+	})
+	if err != nil {
+		t.Fatalf("partial update error = %v", err)
+	}
+	if !view.WebhookConfigured {
+		t.Fatal("partial update cleared webhook")
+	}
+}
+
+func TestOpsWeComTestMessageUsesStoredWebhook(t *testing.T) {
+	repo := newRuntimeSettingRepoStub()
+	webhook := "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=1234567890abcdef"
+	notifier := &opsWeComNotifierStub{}
+	svc := &OpsService{settingRepo: repo, weComNotifier: notifier}
+	if _, err := svc.UpdateWeComNotificationConfig(context.Background(), &OpsWeComNotificationConfigUpdateRequest{
+		WebhookURL: &webhook,
+	}); err != nil {
+		t.Fatalf("store config: %v", err)
+	}
+	if err := svc.TestWeComNotification(context.Background()); err != nil {
+		t.Fatalf("TestWeComNotification() error = %v", err)
+	}
+	if notifier.url != webhook || !strings.Contains(notifier.content, "通知测试") {
+		t.Fatalf("unexpected test delivery: %#v", notifier)
+	}
+}
+
+func TestShouldSendOpsAlertWeComByMinSeverity(t *testing.T) {
+	if !shouldSendOpsAlertWeComByMinSeverity("P1", "P0") {
+		t.Fatal("P0 should pass a P1 threshold")
+	}
+	if shouldSendOpsAlertWeComByMinSeverity("P1", "P2") {
+		t.Fatal("P2 should not pass a P1 threshold")
+	}
+	if !shouldSendOpsAlertWeComByMinSeverity("", "P3") {
+		t.Fatal("empty threshold should allow all severities")
+	}
+}

--- a/backend/internal/util/logredact/redact.go
+++ b/backend/internal/util/logredact/redact.go
@@ -20,6 +20,7 @@ var defaultSensitiveKeys = map[string]struct{}{
 	"id_token":           {},
 	"client_secret":      {},
 	"password":           {},
+	"webhook_url":        {},
 }
 
 var defaultSensitiveKeyList = []string{
@@ -31,6 +32,7 @@ var defaultSensitiveKeyList = []string{
 	"id_token",
 	"client_secret",
 	"password",
+	"webhook_url",
 }
 
 type textRedactPatterns struct {

--- a/backend/internal/util/logredact/redact_test.go
+++ b/backend/internal/util/logredact/redact_test.go
@@ -67,6 +67,14 @@ func TestRedactText_DefaultPathDoesNotUseExtraCache(t *testing.T) {
 	}
 }
 
+func TestRedactJSON_WebhookURLIsSensitiveByDefault(t *testing.T) {
+	const secret = "secret-value"
+	out := RedactJSON([]byte(`{"webhook_url":"https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=` + secret + `"}`))
+	if strings.Contains(out, secret) || !strings.Contains(out, `"webhook_url":"***"`) {
+		t.Fatalf("expected webhook_url redacted, got %q", out)
+	}
+}
+
 func clearExtraTextPatternCache() {
 	extraTextPatternCache.Range(func(key, value any) bool {
 		extraTextPatternCache.Delete(key)

--- a/backend/migrations/192_ops_wecom_alert_notification.sql
+++ b/backend/migrations/192_ops_wecom_alert_notification.sql
@@ -1,0 +1,8 @@
+ALTER TABLE ops_alert_rules
+    ADD COLUMN IF NOT EXISTS notify_wecom BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE ops_alert_events
+    ADD COLUMN IF NOT EXISTS wecom_sent BOOLEAN NOT NULL DEFAULT FALSE;
+
+COMMENT ON COLUMN ops_alert_rules.notify_wecom IS 'Whether this rule sends WeCom bot notifications';
+COMMENT ON COLUMN ops_alert_events.wecom_sent IS 'Whether a WeCom bot notification was sent for this event';

--- a/frontend/src/api/admin/ops.ts
+++ b/frontend/src/api/admin/ops.ts
@@ -703,6 +703,7 @@ export interface AlertRule {
   severity: OpsSeverity
   cooldown_minutes: number
   notify_email: boolean
+  notify_wecom: boolean
   filters?: Record<string, any>
   created_at?: string
   updated_at?: string
@@ -722,6 +723,7 @@ export interface AlertEvent {
   fired_at: string
   resolved_at?: string | null
   email_sent: boolean
+  wecom_sent: boolean
   created_at: string
 }
 
@@ -748,6 +750,24 @@ export interface EmailNotificationConfig {
     account_health_schedule: string
     account_health_error_rate_threshold: number
   }
+}
+
+export interface WeComNotificationConfig {
+  enabled: boolean
+  webhook_configured: boolean
+  webhook_url_masked?: string
+  min_severity: '' | 'P0' | 'P1' | 'P2' | 'P3'
+  rate_limit_per_hour: number
+  include_resolved_alerts: boolean
+}
+
+export interface WeComNotificationConfigUpdate {
+  enabled: boolean
+  webhook_url?: string
+  clear_webhook?: boolean
+  min_severity: '' | 'P0' | 'P1' | 'P2' | 'P3'
+  rate_limit_per_hour: number
+  include_resolved_alerts: boolean
 }
 
 export interface OpsMetricThresholds {
@@ -1197,6 +1217,7 @@ export interface AlertEventsQuery {
   status?: string
   severity?: string
   email_sent?: boolean
+  wecom_sent?: boolean
   time_range?: string
   start_time?: string
   end_time?: string
@@ -1240,6 +1261,20 @@ export async function getEmailNotificationConfig(): Promise<EmailNotificationCon
 export async function updateEmailNotificationConfig(config: EmailNotificationConfig): Promise<EmailNotificationConfig> {
   const { data } = await apiClient.put<EmailNotificationConfig>('/admin/ops/email-notification/config', config)
   return data
+}
+
+export async function getWeComNotificationConfig(): Promise<WeComNotificationConfig> {
+  const { data } = await apiClient.get<WeComNotificationConfig>('/admin/ops/wecom-notification/config')
+  return data
+}
+
+export async function updateWeComNotificationConfig(config: WeComNotificationConfigUpdate): Promise<WeComNotificationConfig> {
+  const { data } = await apiClient.put<WeComNotificationConfig>('/admin/ops/wecom-notification/config', config)
+  return data
+}
+
+export async function testWeComNotification(): Promise<void> {
+  await apiClient.post('/admin/ops/wecom-notification/test')
 }
 
 // Runtime settings (DB-backed)
@@ -1344,6 +1379,9 @@ export const opsAPI = {
   createAlertSilence,
   getEmailNotificationConfig,
   updateEmailNotificationConfig,
+  getWeComNotificationConfig,
+  updateWeComNotificationConfig,
+  testWeComNotification,
   getAlertRuntimeSettings,
   updateAlertRuntimeSettings,
   getRuntimeLogConfig,

--- a/frontend/src/i18n/locales/en/admin/ops.ts
+++ b/frontend/src/i18n/locales/en/admin/ops.ts
@@ -456,13 +456,17 @@ export default {
           metric: 'Metric / Threshold',
           dimensions: 'Dimensions',
           email: 'Email Sent',
+          wecom: 'WeCom',
+          delivery: 'Delivery',
+          sent: 'Sent',
+          ignored: 'Not sent',
           emailSent: 'Sent',
           emailIgnored: 'Ignored'
         }
       },
       alertRules: {
         title: 'Alert Rules',
-        description: 'Create and manage threshold-based system alerts (email-only)',
+        description: 'Create and manage threshold alerts with email and WeCom bot notifications',
         loading: 'Loading...',
         empty: 'No alert rules',
         loadFailed: 'Failed to load alert rules',
@@ -543,7 +547,8 @@ export default {
           sustained: 'Sustained (samples)',
           cooldown: 'Cooldown (minutes)',
           enabled: 'Enabled',
-          notifyEmail: 'Send email notifications'
+          notifyEmail: 'Send email notifications',
+          notifyWeCom: 'Send WeCom bot notifications'
         },
         validation: {
           title: 'Please fix the following issues',
@@ -672,6 +677,24 @@ export default {
         emailPlaceholder: 'Enter email address',
         recipientsHint: 'If empty, the system will use the first admin email as default recipient',
         minSeverity: 'Minimum Severity',
+        wecom: {
+          title: 'WeCom Group Bot',
+          enabled: 'Enable WeCom bot alerts',
+          enabledHint: 'Only rules with WeCom notifications enabled will send messages',
+          webhook: 'Bot Webhook',
+          webhookPlaceholder: 'Paste the WeCom group bot webhook',
+          webhookHint: 'The URL is returned masked; only the official WeCom bot endpoint is allowed',
+          minSeverity: 'Minimum Alert Severity',
+          allSeverities: 'All severities',
+          rateLimit: 'Hourly Send Limit (0 = unlimited)',
+          includeResolved: 'Notify when resolved',
+          test: 'Send Test Message',
+          testing: 'Testing...',
+          testSuccess: 'WeCom bot test message sent',
+          testFailed: 'Failed to send WeCom bot test message',
+          webhookRequired: 'A webhook is required when WeCom bot alerts are enabled',
+          rateLimitInvalid: 'The WeCom hourly send limit must be at least 0'
+        },
         reportConfig: 'Report Configuration',
         enableReport: 'Enable Reports',
         reportRecipients: 'Report Recipient Emails',

--- a/frontend/src/i18n/locales/zh/admin/ops.ts
+++ b/frontend/src/i18n/locales/zh/admin/ops.ts
@@ -456,13 +456,17 @@ export default {
           metric: '指标 / 阈值',
           dimensions: '维度',
           email: '邮件已发送',
+          wecom: '企微',
+          delivery: '通知状态',
+          sent: '已发送',
+          ignored: '未发送',
           emailSent: '已发送',
           emailIgnored: '已忽略'
         }
       },
       alertRules: {
         title: '告警规则',
-        description: '创建与管理系统阈值告警（仅邮件通知）',
+        description: '创建与管理系统阈值告警，支持邮件和企业微信群机器人通知',
         loading: '加载中...',
         empty: '暂无告警规则',
         loadFailed: '加载告警规则失败',
@@ -543,7 +547,8 @@ export default {
           sustained: '连续样本数（每分钟）',
           cooldown: '冷却期（分钟）',
           enabled: '启用',
-          notifyEmail: '发送邮件通知'
+          notifyEmail: '发送邮件通知',
+          notifyWeCom: '发送企业微信群机器人通知'
         },
         validation: {
           title: '请先修正以下问题',
@@ -672,6 +677,24 @@ export default {
         emailPlaceholder: '输入邮箱地址',
         recipientsHint: '若为空，系统将使用第一个管理员邮箱作为默认收件人',
         minSeverity: '最低级别',
+        wecom: {
+          title: '企业微信群机器人',
+          enabled: '启用企微机器人预警',
+          enabledHint: '启用后，仅对规则中勾选企微通知的告警发送消息',
+          webhook: '机器人 Webhook',
+          webhookPlaceholder: '粘贴企业微信群机器人 Webhook',
+          webhookHint: '地址只会脱敏展示；仅允许企业微信官方机器人地址',
+          minSeverity: '最低告警级别',
+          allSeverities: '全部级别',
+          rateLimit: '每小时发送上限（0 表示不限）',
+          includeResolved: '恢复时发送通知',
+          test: '发送测试消息',
+          testing: '正在测试...',
+          testSuccess: '企微机器人测试消息发送成功',
+          testFailed: '企微机器人测试消息发送失败',
+          webhookRequired: '启用企微机器人预警时必须配置 Webhook',
+          rateLimitInvalid: '企微机器人每小时发送上限必须大于等于 0'
+        },
         reportConfig: '评估报告配置',
         enableReport: '开启评估报告',
         reportRecipients: '评估报告接收邮箱',

--- a/frontend/src/views/admin/ops/components/OpsAlertEventsCard.vue
+++ b/frontend/src/views/admin/ops/components/OpsAlertEventsCard.vue
@@ -437,6 +437,10 @@ const empty = computed(() => events.value.length === 0 && !loading.value)
                 />
                 {{ row.email_sent ? t('admin.ops.alertEvents.table.emailSent') : t('admin.ops.alertEvents.table.emailIgnored') }}
               </span>
+              <span class="inline-flex items-center gap-1">
+                <Icon :name="row.wecom_sent ? 'checkCircle' : 'ban'" size="xs" :class="row.wecom_sent ? 'text-green-600 dark:text-green-400' : 'text-gray-400 dark:text-gray-500'" />
+                {{ t('admin.ops.alertEvents.table.wecom') }} {{ row.wecom_sent ? t('admin.ops.alertEvents.table.sent') : t('admin.ops.alertEvents.table.ignored') }}
+              </span>
             </div>
             <div class="text-[11px] text-gray-400 dark:text-gray-500">{{ formatDimensionsSummary(row) }}</div>
           </div>
@@ -466,7 +470,7 @@ const empty = computed(() => events.value.length === 0 && !loading.value)
                 {{ t('admin.ops.alertEvents.table.dimensions') }}
               </th>
               <th class="px-4 py-3 text-right text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                {{ t('admin.ops.alertEvents.table.email') }}
+                {{ t('admin.ops.alertEvents.table.delivery') }}
               </th>
             </tr>
           </thead>
@@ -510,26 +514,14 @@ const empty = computed(() => events.value.length === 0 && !loading.value)
                 {{ formatDimensionsSummary(row) }}
               </td>
               <td class="whitespace-nowrap px-4 py-3 text-right text-xs">
-                <span
-                  class="inline-flex items-center justify-end gap-1.5"
-                  :title="row.email_sent ? t('admin.ops.alertEvents.table.emailSent') : t('admin.ops.alertEvents.table.emailIgnored')"
-                >
-                  <Icon
-                    v-if="row.email_sent"
-                    name="checkCircle"
-                    size="sm"
-                    class="text-green-600 dark:text-green-400"
-                  />
-                  <Icon
-                    v-else
-                    name="ban"
-                    size="sm"
-                    class="text-gray-400 dark:text-gray-500"
-                  />
+                <div class="flex flex-col items-end gap-1">
                   <span class="text-[11px] font-bold text-gray-600 dark:text-gray-300">
-                    {{ row.email_sent ? t('admin.ops.alertEvents.table.emailSent') : t('admin.ops.alertEvents.table.emailIgnored') }}
+                    {{ t('admin.ops.alertEvents.table.email') }}：{{ row.email_sent ? t('admin.ops.alertEvents.table.sent') : t('admin.ops.alertEvents.table.ignored') }}
                   </span>
-                </span>
+                  <span class="text-[11px] font-bold text-gray-600 dark:text-gray-300">
+                    {{ t('admin.ops.alertEvents.table.wecom') }}：{{ row.wecom_sent ? t('admin.ops.alertEvents.table.sent') : t('admin.ops.alertEvents.table.ignored') }}
+                  </span>
+                </div>
               </td>
             </tr>
           </tbody>
@@ -692,4 +684,3 @@ const empty = computed(() => events.value.length === 0 && !loading.value)
     </BaseDialog>
   </div>
 </template>
-

--- a/frontend/src/views/admin/ops/components/OpsAlertRulesCard.vue
+++ b/frontend/src/views/admin/ops/components/OpsAlertRulesCard.vue
@@ -296,7 +296,8 @@ function newRuleDraft(): AlertRule {
     sustained_minutes: 2,
     severity: 'P1',
     cooldown_minutes: 10,
-    notify_email: true
+    notify_email: true,
+    notify_wecom: false
   }
 }
 
@@ -604,6 +605,11 @@ function cancelDelete() {
           <div class="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3 dark:bg-dark-800/50 md:col-span-2">
             <span class="text-xs font-bold text-gray-700 dark:text-gray-200">{{ t('admin.ops.alertRules.form.notifyEmail') }}</span>
             <input v-model="draft!.notify_email" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
+          </div>
+
+          <div class="flex items-center justify-between rounded-xl bg-gray-50 px-4 py-3 dark:bg-dark-800/50 md:col-span-2">
+            <span class="text-xs font-bold text-gray-700 dark:text-gray-200">{{ t('admin.ops.alertRules.form.notifyWeCom') }}</span>
+            <input v-model="draft!.notify_wecom" type="checkbox" class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
           </div>
         </div>
       </div>

--- a/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
+++ b/frontend/src/views/admin/ops/components/OpsSettingsDialog.vue
@@ -6,7 +6,7 @@ import { opsAPI } from '@/api/admin/ops'
 import BaseDialog from '@/components/common/BaseDialog.vue'
 import Select from '@/components/common/Select.vue'
 import Toggle from '@/components/common/Toggle.vue'
-import type { OpsAlertRuntimeSettings, EmailNotificationConfig, AlertSeverity, OpsAdvancedSettings, OpsMetricThresholds } from '../types'
+import type { OpsAlertRuntimeSettings, EmailNotificationConfig, AlertSeverity, WeComNotificationConfig, WeComNotificationConfigUpdate, OpsAdvancedSettings, OpsMetricThresholds } from '../types'
 
 const { t } = useI18n()
 const appStore = useAppStore()
@@ -27,6 +27,9 @@ const saving = ref(false)
 const runtimeSettings = ref<OpsAlertRuntimeSettings | null>(null)
 // 邮件通知配置
 const emailConfig = ref<EmailNotificationConfig | null>(null)
+const weComConfig = ref<WeComNotificationConfig | null>(null)
+const weComWebhookInput = ref('')
+const testingWeCom = ref(false)
 // 高级设置
 const advancedSettings = ref<OpsAdvancedSettings | null>(null)
 // 指标阈值配置
@@ -41,14 +44,17 @@ const metricThresholds = ref<OpsMetricThresholds>({
 async function loadAllSettings() {
   loading.value = true
   try {
-    const [runtime, email, advanced, thresholds] = await Promise.all([
+    const [runtime, email, weCom, advanced, thresholds] = await Promise.all([
       opsAPI.getAlertRuntimeSettings(),
       opsAPI.getEmailNotificationConfig(),
+      opsAPI.getWeComNotificationConfig(),
       opsAPI.getAdvancedSettings(),
       opsAPI.getMetricThresholds()
     ])
     runtimeSettings.value = runtime
     emailConfig.value = email
+    weComConfig.value = weCom
+    weComWebhookInput.value = ''
     advancedSettings.value = advanced
     // 兼容旧 payload：后端未返回该字段时补默认值，保证表单可绑定
     if (advancedSettings.value && !advancedSettings.value.openai_account_quota_auto_pause) {
@@ -89,6 +95,42 @@ const severityOptions: Array<{ value: AlertSeverity | ''; label: string }> = [
   { value: 'warning', label: t('common.warning') },
   { value: 'info', label: t('common.info') }
 ]
+const weComSeverityOptions = [
+  { value: '', label: t('admin.ops.settings.wecom.allSeverities') },
+  { value: 'P0', label: 'P0' },
+  { value: 'P1', label: 'P1' },
+  { value: 'P2', label: 'P2' },
+  { value: 'P3', label: 'P3' }
+]
+
+function buildWeComUpdate(): WeComNotificationConfigUpdate | null {
+  if (!weComConfig.value) return null
+  const payload: WeComNotificationConfigUpdate = {
+    enabled: weComConfig.value.enabled,
+    min_severity: weComConfig.value.min_severity,
+    rate_limit_per_hour: weComConfig.value.rate_limit_per_hour,
+    include_resolved_alerts: weComConfig.value.include_resolved_alerts
+  }
+  const webhook = weComWebhookInput.value.trim()
+  if (webhook) payload.webhook_url = webhook
+  return payload
+}
+
+async function testWeComNotification() {
+  const payload = buildWeComUpdate()
+  if (!payload) return
+  testingWeCom.value = true
+  try {
+    weComConfig.value = await opsAPI.updateWeComNotificationConfig(payload)
+    weComWebhookInput.value = ''
+    await opsAPI.testWeComNotification()
+    appStore.showSuccess(t('admin.ops.settings.wecom.testSuccess'))
+  } catch (err: any) {
+    appStore.showError(err?.response?.data?.message || err?.response?.data?.detail || t('admin.ops.settings.wecom.testFailed'))
+  } finally {
+    testingWeCom.value = false
+  }
+}
 
 // 验证邮箱
 function isValidEmailAddress(email: string): boolean {
@@ -158,6 +200,14 @@ const validation = computed(() => {
   }
 
   // 邮件配置: 启用但无收件人时不阻断保存, 保存时会自动禁用
+  if (weComConfig.value) {
+    if (weComConfig.value.enabled && !weComConfig.value.webhook_configured && !weComWebhookInput.value.trim()) {
+      errors.push(t('admin.ops.settings.wecom.webhookRequired'))
+    }
+    if (!Number.isFinite(weComConfig.value.rate_limit_per_hour) || weComConfig.value.rate_limit_per_hour < 0) {
+      errors.push(t('admin.ops.settings.wecom.rateLimitInvalid'))
+    }
+  }
 
   // 验证高级设置
   if (advancedSettings.value) {
@@ -216,6 +266,7 @@ async function saveAllSettings() {
     await Promise.all([
       runtimeSettings.value ? opsAPI.updateAlertRuntimeSettings(runtimeSettings.value) : Promise.resolve(),
       emailConfig.value ? opsAPI.updateEmailNotificationConfig(emailConfig.value) : Promise.resolve(),
+      buildWeComUpdate() ? opsAPI.updateWeComNotificationConfig(buildWeComUpdate()!) : Promise.resolve(),
       advancedSettings.value ? opsAPI.updateAdvancedSettings(advancedSettings.value) : Promise.resolve(),
       opsAPI.updateMetricThresholds(metricThresholds.value)
     ])
@@ -237,7 +288,7 @@ async function saveAllSettings() {
       {{ t('common.loading') }}
     </div>
 
-    <div v-else-if="runtimeSettings && emailConfig && advancedSettings" class="space-y-6">
+    <div v-else-if="runtimeSettings && emailConfig && weComConfig && advancedSettings" class="space-y-6">
       <!-- 验证错误 -->
       <div v-if="!validation.valid" class="rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-200">
         <div class="font-bold">{{ t('admin.ops.settings.validation.title') }}</div>
@@ -307,6 +358,48 @@ async function saveAllSettings() {
             <label class="input-label">{{ t('admin.ops.settings.minSeverity') }}</label>
             <Select v-model="emailConfig.alert.min_severity" :options="severityOptions" />
           </div>
+        </div>
+      </div>
+
+      <!-- 企业微信群机器人 -->
+      <div class="rounded-2xl bg-gray-50 p-4 dark:bg-dark-700/50">
+        <h4 class="mb-3 text-sm font-semibold text-gray-900 dark:text-white">{{ t('admin.ops.settings.wecom.title') }}</h4>
+        <div class="space-y-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <label class="font-medium text-gray-900 dark:text-white">{{ t('admin.ops.settings.wecom.enabled') }}</label>
+              <p class="mt-1 text-xs text-gray-500">{{ t('admin.ops.settings.wecom.enabledHint') }}</p>
+            </div>
+            <Toggle v-model="weComConfig.enabled" />
+          </div>
+          <div>
+            <label class="input-label">{{ t('admin.ops.settings.wecom.webhook') }}</label>
+            <input
+              v-model="weComWebhookInput"
+              type="password"
+              class="input"
+              autocomplete="new-password"
+              :placeholder="weComConfig.webhook_configured ? weComConfig.webhook_url_masked : t('admin.ops.settings.wecom.webhookPlaceholder')"
+            />
+            <p class="mt-1 text-xs text-gray-500">{{ t('admin.ops.settings.wecom.webhookHint') }}</p>
+          </div>
+          <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label class="input-label">{{ t('admin.ops.settings.wecom.minSeverity') }}</label>
+              <Select v-model="weComConfig.min_severity" :options="weComSeverityOptions" />
+            </div>
+            <div>
+              <label class="input-label">{{ t('admin.ops.settings.wecom.rateLimit') }}</label>
+              <input v-model.number="weComConfig.rate_limit_per_hour" type="number" min="0" class="input" />
+            </div>
+          </div>
+          <div class="flex items-center justify-between">
+            <label class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ t('admin.ops.settings.wecom.includeResolved') }}</label>
+            <Toggle v-model="weComConfig.include_resolved_alerts" />
+          </div>
+          <button type="button" class="btn btn-secondary" :disabled="testingWeCom || (!weComConfig.webhook_configured && !weComWebhookInput.trim())" @click="testWeComNotification">
+            {{ testingWeCom ? t('admin.ops.settings.wecom.testing') : t('admin.ops.settings.wecom.test') }}
+          </button>
         </div>
       </div>
 

--- a/frontend/src/views/admin/ops/types.ts
+++ b/frontend/src/views/admin/ops/types.ts
@@ -12,6 +12,8 @@ export type {
   MetricType,
   Operator,
   EmailNotificationConfig,
+  WeComNotificationConfig,
+  WeComNotificationConfigUpdate,
   OpsDistributedLockSettings,
   OpsAlertRuntimeSettings,
   OpsMetricThresholds,


### PR DESCRIPTION
## 背景

当前运维预警主要通过邮件发送。在团队值班和故障响应场景中，告警直接进入企业微信群可以缩短发现与协作链路。

Closes #5036

## 主要变更

- 新增企业微信群机器人通知配置：启用状态、Webhook、最低告警级别、每小时发送上限和恢复通知。
- 新增测试消息接口，管理员可以在设置页直接验证机器人配置。
- 告警规则支持单独开启或关闭企微通知，已有规则默认关闭。
- 告警触发和自动恢复时发送 Markdown 消息，并记录企微投递状态。
- 告警事件列表分别展示邮件和企微的投递结果。
- 新增数据库迁移，为告警规则和事件补充 notify_wecom、wecom_sent 字段。

## 安全处理

- 仅允许 qyapi.weixin.qq.com 官方 HTTPS Webhook。
- 禁止 HTTP 重定向并设置请求超时。
- 配置查询接口只返回脱敏后的 Webhook。
- 通用日志脱敏和管理审计请求体均擦除 webhook_url。
- 发送失败日志不包含 Webhook 地址或 key。

## 兼容性

- 企微通知全局默认关闭。
- 已有规则的 notify_wecom 默认为 false。
- 不改变现有邮件通知配置和发送链路。

## 验证

- go test ./internal/service ./internal/handler/admin ./internal/repository ./internal/util/logredact
- 企微 Webhook 白名单、脱敏、配置更新、测试消息和级别过滤单元测试
- pnpm typecheck
- pnpm exec eslint（本次涉及的前端文件）
- pnpm build
- git diff --check

前端生产构建通过；仅保留项目已有的动态导入与大 chunk 提示。