### PR TITLE
fix(grok): bump pinned Grok CLI version to 0.2.114

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,7 @@ The Grok OAuth flow uses PKCE and does not require committing private secrets. T
 | `XAI_OAUTH_AUTHORIZE_URL` | `https://auth.x.ai/oauth2/authorize` |
 | `XAI_OAUTH_TOKEN_URL` | `https://auth.x.ai/oauth2/token` |
 | `XAI_BASE_URL` | `https://api.x.ai/v1`; runtime-diagnostics override (account `base_url` controls request forwarding) |
-| `XAI_GROK_CLI_VERSION` | `0.2.93`; optional override for the client identity sent to `cli-chat-proxy.grok.com` |
+| `XAI_GROK_CLI_VERSION` | `0.2.114`; optional override for the client identity sent to `cli-chat-proxy.grok.com`. The pinned value is also the floor: an override below it is dropped |
 
 Administrators can create Grok OAuth or API-key accounts from the dashboard. OAuth authorization and reauthorization are also available through the admin API:
 

--- a/backend/internal/pkg/xai/billing.go
+++ b/backend/internal/pkg/xai/billing.go
@@ -15,8 +15,11 @@ const (
 	CLITokenAuthHeader     = "x-xai-token-auth"
 	CLITokenAuthValue      = "xai-grok-cli"
 	CLIClientVersionHeader = "x-grok-client-version"
+	// CLIClientVersion is the one place the pinned Grok CLI version lives. The
+	// repository and service layers build their own client identity from it, so
+	// one bump here covers OAuth traffic and billing probes together.
 	// Keep in sync with https://x.ai/cli/stable.
-	CLIClientVersion = "0.2.93"
+	CLIClientVersion = "0.2.114"
 	CLIUserAgent     = "grok-pager/" + CLIClientVersion + " grok-shell/" + CLIClientVersion + " (macos; aarch64)"
 
 	BillingWeeklyPath  = "/billing?format=credits"

--- a/backend/internal/repository/http_upstream.go
+++ b/backend/internal/repository/http_upstream.go
@@ -30,6 +30,7 @@ import (
 	"github.com/Wei-Shaw/sub2api/internal/pkg/proxyutil"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/servertiming"
 	"github.com/Wei-Shaw/sub2api/internal/pkg/tlsfingerprint"
+	"github.com/Wei-Shaw/sub2api/internal/pkg/xai"
 	"github.com/Wei-Shaw/sub2api/internal/service"
 	"github.com/Wei-Shaw/sub2api/internal/util/urlvalidator"
 	"golang.org/x/mod/semver"
@@ -76,7 +77,7 @@ const (
 	// allowing operators to bump it without waiting for a Sub2API release.
 	grokCLIProxyHost       = "cli-chat-proxy.grok.com"
 	grokOfficialAPIHost    = "api.x.ai"
-	grokCLIStableVersion   = "0.2.93"
+	grokCLIStableVersion   = xai.CLIClientVersion
 	grokCLIVersionOverride = "XAI_GROK_CLI_VERSION"
 	grokFallbackBodyLimit  = 64 << 10
 )

--- a/backend/internal/repository/http_upstream_test.go
+++ b/backend/internal/repository/http_upstream_test.go
@@ -235,9 +235,9 @@ func TestHTTPUpstreamDoAppliesGrokCLIIdentityBeforeOAuthRoundTrip(t *testing.T) 
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 			require.NoError(t, resp.Body.Close())
 
-			require.Equal(t, "0.2.93", capturedHeaders.Get("x-grok-client-version"))
+			require.Equal(t, "0.2.114", capturedHeaders.Get("x-grok-client-version"))
 			require.Equal(t, "xai-grok-cli", capturedHeaders.Get("X-XAI-Token-Auth"))
-			require.Equal(t, "xai-grok-workspace/0.2.93", capturedHeaders.Get("User-Agent"))
+			require.Equal(t, "xai-grok-workspace/0.2.114", capturedHeaders.Get("User-Agent"))
 		})
 	}
 }
@@ -458,61 +458,63 @@ func TestApplyGrokCLIProxyHeaders(t *testing.T) {
 
 		applyGrokCLIProxyHeaders(req)
 
-		require.Equal(t, "0.2.93", req.Header.Get("x-grok-client-version"))
+		require.Equal(t, "0.2.114", req.Header.Get("x-grok-client-version"))
 		require.Equal(t, "xai-grok-cli", req.Header.Get("X-XAI-Token-Auth"))
-		require.Equal(t, "xai-grok-workspace/0.2.93", req.Header.Get("User-Agent"))
+		require.Equal(t, "xai-grok-workspace/0.2.114", req.Header.Get("User-Agent"))
 	})
 
 	t.Run("accepts a valid operator override", func(t *testing.T) {
-		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.95-alpha.1")
+		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.115-alpha.1")
 		req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/chat/completions", nil)
 		require.NoError(t, err)
 
 		applyGrokCLIProxyHeaders(req)
 
-		require.Equal(t, "0.2.95-alpha.1", req.Header.Get("x-grok-client-version"))
-		require.Equal(t, "xai-grok-workspace/0.2.95-alpha.1", req.Header.Get("User-Agent"))
+		require.Equal(t, "0.2.115-alpha.1", req.Header.Get("x-grok-client-version"))
+		require.Equal(t, "xai-grok-workspace/0.2.115-alpha.1", req.Header.Get("User-Agent"))
 	})
 
 	t.Run("rejects an unsafe override", func(t *testing.T) {
-		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.95\r\nX-Injected: true")
+		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.115\r\nX-Injected: true")
 		req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", nil)
 		require.NoError(t, err)
 
 		applyGrokCLIProxyHeaders(req)
 
-		require.Equal(t, "0.2.93", req.Header.Get("x-grok-client-version"))
+		require.Equal(t, "0.2.114", req.Header.Get("x-grok-client-version"))
 		require.Empty(t, req.Header.Get("X-Injected"))
 	})
 
 	t.Run("rejects an override below the supported minimum", func(t *testing.T) {
-		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.92")
+		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.113")
 		req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", nil)
 		require.NoError(t, err)
 
 		applyGrokCLIProxyHeaders(req)
 
-		require.Equal(t, "0.2.93", req.Header.Get("x-grok-client-version"))
-		require.Equal(t, "xai-grok-workspace/0.2.93", req.Header.Get("User-Agent"))
+		require.Equal(t, "0.2.114", req.Header.Get("x-grok-client-version"))
+		require.Equal(t, "xai-grok-workspace/0.2.114", req.Header.Get("User-Agent"))
 	})
 
 	t.Run("rejects a prerelease override at the minimum version", func(t *testing.T) {
-		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.93-beta.1")
+		t.Setenv("XAI_GROK_CLI_VERSION", "0.2.114-beta.1")
 		req, err := http.NewRequest(http.MethodPost, "https://cli-chat-proxy.grok.com/v1/responses", nil)
 		require.NoError(t, err)
 
 		applyGrokCLIProxyHeaders(req)
 
-		require.Equal(t, "0.2.93", req.Header.Get("x-grok-client-version"))
-		require.Equal(t, "xai-grok-workspace/0.2.93", req.Header.Get("User-Agent"))
+		require.Equal(t, "0.2.114", req.Header.Get("x-grok-client-version"))
+		require.Equal(t, "xai-grok-workspace/0.2.114", req.Header.Get("User-Agent"))
 	})
 
+	// Every entry sits above the pinned minimum, so a rejection here can only be
+	// caused by the malformed semver and never by the version being too old.
 	for _, version := range []string{
-		"0.2.093",
-		"0.2.94-alpha..1",
+		"0.2.0115",
+		"0.2.115-alpha..1",
 		"0.3",
 		"1",
-		"0.2.95+build.1",
+		"0.2.115+build.1",
 	} {
 		t.Run("rejects invalid semver "+version, func(t *testing.T) {
 			t.Setenv("XAI_GROK_CLI_VERSION", version)
@@ -521,8 +523,8 @@ func TestApplyGrokCLIProxyHeaders(t *testing.T) {
 
 			applyGrokCLIProxyHeaders(req)
 
-			require.Equal(t, "0.2.93", req.Header.Get("x-grok-client-version"))
-			require.Equal(t, "xai-grok-workspace/0.2.93", req.Header.Get("User-Agent"))
+			require.Equal(t, "0.2.114", req.Header.Get("x-grok-client-version"))
+			require.Equal(t, "xai-grok-workspace/0.2.114", req.Header.Get("User-Agent"))
 		})
 	}
 

--- a/backend/internal/service/openai_gateway_grok.go
+++ b/backend/internal/service/openai_gateway_grok.go
@@ -23,7 +23,7 @@ const (
 	grokComposerImageBridgeVisionModel     = "grok-build-0.1"
 	grokComposerImageBridgeMaxOutputTokens = 512
 	grokUpstreamUserAgent                  = "sub2api-grok/1.0"
-	grokCLIVersion                         = "0.2.93"
+	grokCLIVersion                         = xai.CLIClientVersion
 	grokDefaultResponsesModel              = "grok-4.5"
 	grokRateLimitFallbackCooldown          = 2 * time.Minute
 	grokRateLimitRepeatCooldown            = 10 * time.Minute


### PR DESCRIPTION
## What

Bumps the pinned Grok CLI version from `0.2.93` to `0.2.114`.

`cli-chat-proxy.grok.com` turns away requests that do not name a supported client version — the failure mode #3952 was opened for. The pin has sat at `0.2.93` since 2026-07-17 (`8bc0a277f`), while both sources report `0.2.114` (checked 2026-07-29):

```
$ curl -s https://x.ai/cli/stable
0.2.114
$ npm view @xai-official/grok version
0.2.114
```

## One constant instead of three

The version was written out in **three** places, which is how they came to drift:

| File | Constant | Used for |
|---|---|---|
| `repository/http_upstream.go` | `grokCLIStableVersion` | OAuth traffic through the CLI proxy |
| `pkg/xai/billing.go` | `CLIClientVersion` | billing and quota probes |
| `service/openai_gateway_grok.go` | `grokCLIVersion` | gateway request headers |

`xai.CLIClientVersion` is now the single source and the other two build their client identity from it, so the next bump is a one-line change. `internal/pkg/xai` is a leaf package that both layers already import, so this adds no import cycle. `CLIUserAgent` derives from the same constant and needed no edit.

This overlaps with part of what #4974 raises about the hardcoded `0.2.93` appearing under two different client identities. It does not resolve that RFC — it only removes the drift between the copies.

## Checked against the real client

Rather than trust the version feed alone, I unpacked the actual `0.2.114` binary (`@xai-official/grok-darwin-arm64`). The `x-grok-client-version` header name, the `xai-grok-cli` token-auth value, and the version string all match what the CLI sends. The `(macos; aarch64)` user-agent is assembled at runtime and has no literal in the binary, so that format is left as-is; only the version part moves.

## Test fixtures that carried a meaning

The pinned value is also the **floor** an operator override must clear (`isSupportedGrokCLIVersion`). Several fixtures encoded a relationship to that floor rather than a fixed number, so they were moved rather than search-and-replaced:

- **"accepts a valid operator override"** now uses `0.2.115-alpha.1`. Left at `0.2.95-alpha.1` it would fall below the new floor, be dropped, and the case would silently stop testing acceptance.
- **"rejects a prerelease override at the minimum version"** tracks the pin to `0.2.114-beta.1`, or it collapses into a duplicate of the below-minimum case.
- **Three of the five malformed-semver entries** sat below the new floor, so they would have been rejected for being *old* rather than *malformed* — the right result for the wrong reason. They now sit above it, so only the bad syntax can cause the rejection.

I ran the suite **before** correcting the fixtures and confirmed it failed with `expected: "0.2.93", actual: "0.2.114"`, which is the evidence these assertions really do guard the pin.

Worth noting for future bumps: `http_upstream_test.go` is the only place that asserts the version as a literal. The `pkg/xai` and `service` tests reference the constants symbolically, so they check the plumbing but cannot catch a wrong pin.

## Checks

```
go build ./...                                          # clean
go vet -tags unit ./internal/{repository,service,pkg/xai}  # clean
go test -tags unit ./internal/repository/ ./internal/pkg/xai/ ./internal/service/  # ok
gofmt -l <changed files>                                # clean
```

Operators who need to move ahead of a release still have the `XAI_GROK_CLI_VERSION` escape hatch; the pin is the floor it must clear.
