### PR TITLE
feat(accounts): prefer live upstream models for connection tests

### DIFF
--- a/backend/internal/handler/admin/account_handler.go
+++ b/backend/internal/handler/admin/account_handler.go
@@ -1010,6 +1010,7 @@ func (h *AccountHandler) Update(c *gin.Context) {
 	if len(req.Credentials) > 0 {
 		h.scheduleOpenAIResponsesProbe(account)
 	}
+	invalidateLiveAccountModels(accountID)
 
 	response.Success(c, h.buildAccountResponseWithRuntime(c.Request.Context(), account))
 }
@@ -2370,6 +2371,15 @@ func (h *AccountHandler) GetAvailableModels(c *gin.Context) {
 	account, err := h.adminService.GetAccount(c.Request.Context(), accountID)
 	if err != nil {
 		response.NotFound(c, "Account not found")
+		return
+	}
+
+	// Prefer the account's real upstream model list so the connection-test
+	// dialog offers models that this account can actually serve. Preserve the
+	// existing static list as a fallback when live discovery is unsupported or
+	// temporarily unavailable.
+	if models, ok := h.tryLiveAccountModels(c.Request.Context(), account, c.Query("refresh") == "1"); ok {
+		response.Success(c, models)
 		return
 	}
 

--- a/backend/internal/handler/admin/account_handler_available_models_test.go
+++ b/backend/internal/handler/admin/account_handler_available_models_test.go
@@ -30,9 +30,26 @@ func (s *availableModelsAdminService) GetAccount(_ context.Context, id int64) (*
 }
 
 func setupAvailableModelsRouter(adminSvc service.AdminService) *gin.Engine {
+	return setupAvailableModelsRouterWithUpstream(adminSvc, nil)
+}
+
+func setupAvailableModelsRouterWithUpstream(adminSvc service.AdminService, upstream service.HTTPUpstream) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
-	handler := NewAccountHandler(adminSvc, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+	var accountTestSvc *service.AccountTestService
+	if upstream != nil {
+		accountTestSvc = service.NewAccountTestService(
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			upstream,
+			&config.Config{Security: config.SecurityConfig{URLAllowlist: config.URLAllowlistConfig{Enabled: false}}},
+			nil,
+		)
+	}
+	handler := NewAccountHandler(adminSvc, nil, nil, nil, nil, nil, nil, nil, accountTestSvc, nil, nil, nil, nil, nil)
 	router.GET("/api/v1/admin/accounts/:id/models", handler.GetAvailableModels)
 	return router
 }
@@ -103,6 +120,97 @@ func TestAccountHandlerGetAvailableModels_GrokUsesXAIModels(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
 	require.Len(t, resp.Data, 1)
 	require.Equal(t, "grok-4.3", resp.Data[0].ID)
+}
+
+func TestAccountHandlerGetAvailableModels_PrefersLiveUpstreamModels(t *testing.T) {
+	const accountID int64 = 46
+	invalidateLiveAccountModels(accountID)
+	t.Cleanup(func() { invalidateLiveAccountModels(accountID) })
+
+	svc := &availableModelsAdminService{
+		stubAdminService: newStubAdminService(),
+		account: service.Account{
+			ID:       accountID,
+			Name:     "compatible-upstream",
+			Platform: service.PlatformOpenAI,
+			Type:     service.AccountTypeAPIKey,
+			Status:   service.StatusActive,
+			Credentials: map[string]any{
+				"api_key":  "test-key",
+				"base_url": "https://example.com/v1",
+			},
+		},
+	}
+	upstream := &syncUpstreamHTTPUpstream{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(
+			`{"data":[{"id":"provider-model-b"},{"id":"provider-model-a"}]}`,
+		)),
+	}}
+	router := setupAvailableModelsRouterWithUpstream(svc, upstream)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/46/models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []struct {
+			ID          string `json:"id"`
+			DisplayName string `json:"display_name"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Equal(t, []struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"display_name"`
+	}{
+		{ID: "provider-model-a", DisplayName: "provider-model-a"},
+		{ID: "provider-model-b", DisplayName: "provider-model-b"},
+	}, resp.Data)
+}
+
+func TestAccountHandlerGetAvailableModels_FallsBackWhenLiveDiscoveryFails(t *testing.T) {
+	const accountID int64 = 47
+	invalidateLiveAccountModels(accountID)
+	t.Cleanup(func() { invalidateLiveAccountModels(accountID) })
+
+	svc := &availableModelsAdminService{
+		stubAdminService: newStubAdminService(),
+		account: service.Account{
+			ID:       accountID,
+			Name:     "compatible-upstream",
+			Platform: service.PlatformOpenAI,
+			Type:     service.AccountTypeAPIKey,
+			Status:   service.StatusActive,
+			Credentials: map[string]any{
+				"api_key":  "test-key",
+				"base_url": "https://example.com/v1",
+				"model_mapping": map[string]any{
+					"fallback-model": "fallback-model",
+				},
+			},
+		},
+	}
+	upstream := &syncUpstreamHTTPUpstream{resp: &http.Response{
+		StatusCode: http.StatusBadGateway,
+		Body:       io.NopCloser(strings.NewReader(`{"error":"temporarily unavailable"}`)),
+	}}
+	router := setupAvailableModelsRouterWithUpstream(svc, upstream)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/admin/accounts/47/models", nil)
+	router.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.Len(t, resp.Data, 1)
+	require.Equal(t, "fallback-model", resp.Data[0].ID)
 }
 
 func TestAccountHandlerGetAvailableModels_GrokDefaultsToXAIModelsWithoutMapping(t *testing.T) {

--- a/backend/internal/handler/admin/account_models_live.go
+++ b/backend/internal/handler/admin/account_models_live.go
@@ -1,0 +1,112 @@
+package admin
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Wei-Shaw/sub2api/internal/service"
+)
+
+// liveAccountModel is the common response shape consumed by the account test
+// dialog, regardless of the account's upstream platform.
+type liveAccountModel struct {
+	ID          string `json:"id"`
+	Object      string `json:"object,omitempty"`
+	Type        string `json:"type,omitempty"`
+	OwnedBy     string `json:"owned_by,omitempty"`
+	DisplayName string `json:"display_name"`
+	CreatedAt   string `json:"created_at,omitempty"`
+}
+
+const (
+	liveAccountModelsTTL     = 5 * time.Minute
+	liveAccountModelsTimeout = 5 * time.Second
+)
+
+type liveAccountModelsEntry struct {
+	models    []liveAccountModel
+	fetchedAt time.Time
+	// key distinguishes snapshots taken against different upstreams, so
+	// changing an account's base URL invalidates the cached list immediately.
+	key string
+}
+
+// Opening the test dialog repeatedly should not hammer the account's upstream.
+var liveAccountModelsCache sync.Map // accountID -> liveAccountModelsEntry
+
+// tryLiveAccountModels returns the account's real upstream model list. It
+// reports ok=false when live discovery is unavailable so the caller can retain
+// the existing static per-platform fallback.
+func (h *AccountHandler) tryLiveAccountModels(ctx context.Context, account *service.Account, refresh bool) ([]liveAccountModel, bool) {
+	if h == nil || h.accountTestService == nil || account == nil {
+		return nil, false
+	}
+
+	cacheKey := liveAccountModelsCacheKey(account)
+	if !refresh {
+		if cached, ok := liveAccountModelsCache.Load(account.ID); ok {
+			if entry, ok := cached.(liveAccountModelsEntry); ok &&
+				entry.key == cacheKey &&
+				time.Since(entry.fetchedAt) < liveAccountModelsTTL &&
+				len(entry.models) > 0 {
+				return entry.models, true
+			}
+		}
+	}
+
+	fetchCtx, cancel := context.WithTimeout(ctx, liveAccountModelsTimeout)
+	defer cancel()
+
+	modelIDs, err := h.accountTestService.FetchUpstreamSupportedModels(fetchCtx, account)
+	if err != nil || len(modelIDs) == 0 {
+		return nil, false
+	}
+
+	models := make([]liveAccountModel, 0, len(modelIDs))
+	for _, id := range modelIDs {
+		if id == "" {
+			continue
+		}
+		models = append(models, liveAccountModel{
+			ID:          id,
+			Object:      "model",
+			Type:        "model",
+			DisplayName: id,
+		})
+	}
+	if len(models) == 0 {
+		return nil, false
+	}
+
+	liveAccountModelsCache.Store(account.ID, liveAccountModelsEntry{
+		models:    models,
+		fetchedAt: time.Now(),
+		key:       cacheKey,
+	})
+	return models, true
+}
+
+func liveAccountModelsCacheKey(account *service.Account) string {
+	if account == nil {
+		return ""
+	}
+	return account.Platform + "\x00" + account.Type + "\x00" + accountUpstreamBaseURL(account)
+}
+
+func accountUpstreamBaseURL(account *service.Account) string {
+	switch {
+	case account.IsOpenAI():
+		return account.GetOpenAIBaseURL()
+	case account.IsGemini():
+		return account.GetGeminiBaseURL("")
+	case account.IsGrok():
+		return account.GetGrokBaseURL()
+	default:
+		return account.GetBaseURL()
+	}
+}
+
+func invalidateLiveAccountModels(accountID int64) {
+	liveAccountModelsCache.Delete(accountID)
+}


### PR DESCRIPTION
## What changed

- Prefer an account's live upstream model list in the admin connection-test model picker.
- Cache successful model discovery for five minutes to avoid repeated upstream requests.
- Invalidate the cached list when the account is updated.
- Preserve the existing static platform/model-mapping list when discovery is unsupported or fails.

## Why

OpenAI-compatible accounts can point to third-party upstreams whose supported
models differ from Sub2API's built-in OpenAI defaults. The connection-test
dialog could therefore offer models the selected account cannot serve even
though Sub2API already has a safe upstream model discovery implementation.

## Impact

Administrators see the models actually exposed by an account when opening the
connection-test dialog. A slow or unavailable model-list endpoint does not
break the dialog: discovery is bounded to five seconds and falls back to the
existing behavior.

## Validation

- `go test ./internal/handler/admin`
- `go test ./...`
