### PR TITLE
fix: clarify passkey deployment guidance

### DIFF
--- a/frontend/src/i18n/locales/en/admin/settings.ts
+++ b/frontend/src/i18n/locales/en/admin/settings.ts
@@ -144,6 +144,7 @@ export default {
         passkeyRPID: 'RP ID',
         passkeyOrigins: 'Allowed HTTPS origins',
         passkeyValueNotConfigured: 'Not configured',
+        passkeyDeploymentHint: 'Ask the server operator to set webauthn.enabled to true, configure webauthn.rp_id (domain only) and webauthn.rp_origins (full HTTPS origins), then restart the service.',
         stepUp: 'Step-up 2FA for Sensitive Operations',
         stepUpHint: 'When enabled, sensitive operations (account/proxy export, backup creation and download, S3 config changes, promoting admins) require a recent TOTP verification (valid for 15 minutes). Your own account must have 2FA enabled before turning this on; turning it off also requires step-up verification.',
         stepUpEnableRequiresTotp: 'Enable 2FA (TOTP) for your own account in Profile before turning on step-up verification.',

--- a/frontend/src/i18n/locales/zh/admin/settings.ts
+++ b/frontend/src/i18n/locales/zh/admin/settings.ts
@@ -144,6 +144,7 @@ export default {
         passkeyRPID: 'RP ID',
         passkeyOrigins: '允许的 HTTPS 来源',
         passkeyValueNotConfigured: '未配置',
+        passkeyDeploymentHint: '请由服务器运维在部署配置中将 webauthn.enabled 设为 true，填写 webauthn.rp_id（仅域名）与 webauthn.rp_origins（完整 HTTPS 来源），然后重启服务。',
         stepUp: '敏感操作二次验证 (step-up 2FA)',
         stepUpHint: '开启后，账号/代理导出、备份创建与下载、S3 配置修改、提升管理员等敏感操作需要先完成 TOTP 二次验证（15 分钟内有效）。开启前需本人已启用 2FA；关闭该开关本身也需要二次验证。',
         stepUpEnableRequiresTotp: '开启敏感操作二次验证前，请先在个人资料中为当前账号启用 2FA (TOTP)。',

--- a/frontend/src/views/admin/SettingsView.vue
+++ b/frontend/src/views/admin/SettingsView.vue
@@ -1631,6 +1631,9 @@
                           )
                     }}
                   </p>
+                  <p v-if="!form.passkey_configured" class="mt-2">
+                    {{ t("admin.settings.security.passkeyDeploymentHint") }}
+                  </p>
                 </div>
               </div>
 

--- a/frontend/src/views/admin/__tests__/SettingsView.spec.ts
+++ b/frontend/src/views/admin/__tests__/SettingsView.spec.ts
@@ -225,6 +225,8 @@ vi.mock("vue-i18n", async () => {
     "admin.settings.upstreamBillingProbe.intervalHint": "范围 5–1440 分钟。",
     "admin.settings.upstreamBillingProbe.saved": "上游倍率自动探测设置已保存",
     "admin.settings.upstreamBillingProbe.saveFailed": "保存上游倍率自动探测设置失败",
+    "admin.settings.security.passkeyDeploymentHint":
+      "请由服务器运维在部署配置中将 webauthn.enabled 设为 true，填写 webauthn.rp_id（仅域名）与 webauthn.rp_origins（完整 HTTPS 来源），然后重启服务。",
     "admin.settings.site.uploadImage": "上传图片",
     "admin.settings.site.remove": "移除",
     "admin.settings.platformQuota.platform": "平台",
@@ -737,6 +739,7 @@ describe("admin SettingsView payment visible method controls", () => {
     expect(toggle.attributes("disabled")).toBeUndefined();
     expect(settings.text()).toContain("sub3.nebula-spaces.com");
     expect(settings.text()).toContain("https://sub3.nebula-spaces.com");
+    expect(settings.text()).not.toContain("webauthn.enabled");
 
     await toggle.setValue(false);
     await wrapper.find("form").trigger("submit.prevent");
@@ -762,9 +765,14 @@ describe("admin SettingsView payment visible method controls", () => {
 
     const settings = wrapper.get('[data-testid="passkey-settings"]');
     expect(settings.get('[data-testid="passkey-toggle"]').attributes("disabled")).toBeDefined();
-    expect(settings.get('[data-testid="passkey-config-status"]').text()).toContain(
+    const status = settings.get('[data-testid="passkey-config-status"]');
+    expect(status.text()).toContain(
       "admin.settings.security.passkeyNotConfigured",
     );
+    expect(status.text()).toContain("webauthn.enabled");
+    expect(status.text()).toContain("webauthn.rp_id");
+    expect(status.text()).toContain("webauthn.rp_origins");
+    expect(status.text()).toContain("然后重启服务");
   });
 
   it("loads, edits, validates, and saves forwarded client-IP headers", async () => {


### PR DESCRIPTION
## Summary

- show the exact `webauthn.enabled`, `webauthn.rp_id`, and `webauthn.rp_origins` deployment keys when passkey RP configuration is unavailable
- keep the guidance hidden once the RP configuration is valid
- add focused coverage for both configured and unconfigured states

Follow-up to #4920. This only closes the admin UX gap; it does not weaken WebAuthn validation or add parallel configuration state.

## Verification

Executed from the immutable commit archive on the authoritative Oracle OCI ARM64 host:

- `SettingsView.spec.ts`: 28/28 passed
- frontend typecheck: passed
- ESLint on the four changed files: passed
- existing isolated `sub3` and production `sub2` containers remained healthy; both public `/health` endpoints returned HTTP 200

No secrets, runtime configuration, or deployment artifacts are included.